### PR TITLE
[da-vinci][controller] Filter out status reporting from the nodes, where the DaVinci app is still bootstrapping

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/DaVinciBackend.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/DaVinciBackend.java
@@ -447,7 +447,8 @@ public class DaVinciBackend implements Closeable {
             storageMetadataService,
             ingestionService,
             storageService,
-            blobTransferManager)
+            blobTransferManager,
+            this::getVeniceCurrentVersionNumber)
         : new DefaultIngestionBackend(
             storageMetadataService,
             ingestionService,
@@ -657,6 +658,11 @@ public class DaVinciBackend implements Closeable {
     }
   }
 
+  int getVeniceCurrentVersionNumber(String storeName) {
+    Version currentVersion = getVeniceCurrentVersion(storeName);
+    return currentVersion == null ? -1 : currentVersion.getNumber();
+  }
+
   private Version getVeniceLatestNonFaultyVersion(Store store, Set<Integer> faultyVersions) {
     Version latestNonFaultyVersion = null;
     for (Version version: store.getVersions()) {
@@ -821,7 +827,7 @@ public class DaVinciBackend implements Closeable {
   }
 
   public boolean hasCurrentVersionBootstrapping() {
-    return ingestionService.hasCurrentVersionBootstrapping();
+    return ingestionBackend.hasCurrentVersionBootstrapping();
   }
 
   static class BootstrappingAwareCompletableFuture {

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/DaVinciBackend.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/DaVinciBackend.java
@@ -604,21 +604,6 @@ public class DaVinciBackend implements Closeable {
       ExecutionStatus status,
       Optional<String> incrementalPushVersion) {
     VersionBackend versionBackend = versionByTopicMap.get(kafkaTopic);
-    if (hasCurrentVersionBootstrapping()
-        /**
-         * It is fine to report the status for Venice current version as the push job for current version is completed already.
-         * Another benefit is to support blob discovery for current version.
-         */
-        && getVeniceCurrentVersionNumber(Version.parseStoreFromKafkaTopicName(kafkaTopic)) != Version
-            .parseVersionFromVersionTopicName(kafkaTopic)) {
-      LOGGER.info(
-          "DaVinci is still bootstrapping, so skip the status report for store version: {}, partition: {}, status: {}{}",
-          kafkaTopic,
-          partition,
-          status,
-          (incrementalPushVersion.isPresent() ? ", inc push version: " + incrementalPushVersion.get() : ""));
-      return;
-    }
     if (versionBackend != null && versionBackend.isReportingPushStatus()) {
       Version version = versionBackend.getVersion();
       if (writeBatchingPushStatus && !incrementalPushVersion.isPresent()) {
@@ -670,11 +655,6 @@ public class DaVinciBackend implements Closeable {
     } catch (VeniceNoStoreException e) {
       return null;
     }
-  }
-
-  int getVeniceCurrentVersionNumber(String storeName) {
-    Version currentVersion = getVeniceCurrentVersion(storeName);
-    return currentVersion == null ? -1 : currentVersion.getNumber();
   }
 
   private Version getVeniceLatestNonFaultyVersion(Store store, Set<Integer> faultyVersions) {

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/DaVinciBackend.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/DaVinciBackend.java
@@ -602,6 +602,13 @@ public class DaVinciBackend implements Closeable {
       int partition,
       ExecutionStatus status,
       Optional<String> incrementalPushVersion) {
+    if (hasCurrentVersionBootstrapping()) {
+      LOGGER.info(
+          "DaVinci is still bootstrapping, so skip the status report for store version: " + kafkaTopic + ", partition: "
+              + partition + ", status: " + status
+              + (incrementalPushVersion.isPresent() ? ", inc push version: " + incrementalPushVersion.get() : ""));
+      return;
+    }
     VersionBackend versionBackend = versionByTopicMap.get(kafkaTopic);
     if (versionBackend != null && versionBackend.isReportingPushStatus()) {
       Version version = versionBackend.getVersion();
@@ -817,5 +824,9 @@ public class DaVinciBackend implements Closeable {
       status = ExecutionStatus.ERROR;
     }
     return status;
+  }
+
+  public boolean hasCurrentVersionBootstrapping() {
+    return ingestionService.hasCurrentVersionBootstrapping();
   }
 }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/VersionBackend.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/VersionBackend.java
@@ -204,8 +204,8 @@ public class VersionBackend {
   protected static void sendOutHeartbeat(DaVinciBackend backend, Version version) {
     if (backend.hasCurrentVersionBootstrapping()) {
       LOGGER.info(
-          "DaVinci still is still bootstrapping, so it will send heart-beat deletion message "
-              + "for store: {} to avoid delaying the new push job",
+          "DaVinci still is still bootstrapping, so it will send heart-beat message with a special timestamp"
+              + " for store: {} to avoid delaying the new push job",
           version.getStoreName());
       /**
        * Tell backend that the report from the bootstrapping instance doesn't count to avoid

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/VersionBackend.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/VersionBackend.java
@@ -193,11 +193,22 @@ public class VersionBackend {
     if (isReportingPushStatus() && heartbeat == null) {
       heartbeat = backend.getExecutor().scheduleAtFixedRate(() -> {
         try {
-          backend.getPushStatusStoreWriter().writeHeartbeat(version.getStoreName());
+          sendOutHeartbeat(backend, version);
         } catch (Throwable t) {
           LOGGER.error("Unable to send heartbeat for {}", this);
         }
       }, 0, heartbeatInterval, TimeUnit.SECONDS);
+    }
+  }
+
+  protected static void sendOutHeartbeat(DaVinciBackend backend, Version version) {
+    if (backend.hasCurrentVersionBootstrapping()) {
+      LOGGER.info(
+          "DaVinci still is still bootstrapping, so it will skip heart-beat message "
+              + "for store: {} to avoid delaying the new push job",
+          version.getStoreName());
+    } else {
+      backend.getPushStatusStoreWriter().writeHeartbeat(version.getStoreName());
     }
   }
 

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/VersionBackend.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/VersionBackend.java
@@ -208,13 +208,10 @@ public class VersionBackend {
               + "for store: {} to avoid delaying the new push job",
           version.getStoreName());
       /**
-       * Delete the heartbeat for the current instance if it is still bootstrapping.
-       * The reason to have such logic is that the bootstrapping of current version of
-       * some other store can happen later than the current store.
-       * We need to delete heartbeat for current instance to make sure Controller
-       * doesn't accidentally treat this node as crashed, then fail the push job.
+       * Tell backend that the report from the bootstrapping instance doesn't count to avoid
+       * delaying new pushes.
        */
-      backend.getPushStatusStoreWriter().deleteHeartbeat(version.getStoreName());
+      backend.getPushStatusStoreWriter().writeHeartbeatForBootstrappingInstance(version.getStoreName());
     } else {
       backend.getPushStatusStoreWriter().writeHeartbeat(version.getStoreName());
     }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/ingestion/DefaultIngestionBackend.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/ingestion/DefaultIngestionBackend.java
@@ -189,6 +189,11 @@ public class DefaultIngestionBackend implements IngestionBackend {
   }
 
   @Override
+  public boolean hasCurrentVersionBootstrapping() {
+    return getStoreIngestionService().hasCurrentVersionBootstrapping();
+  }
+
+  @Override
   public KafkaStoreIngestionService getStoreIngestionService() {
     return storeIngestionService;
   }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/ingestion/IngestionBackend.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/ingestion/IngestionBackend.java
@@ -54,4 +54,9 @@ public interface IngestionBackend extends Closeable {
 
   // setStorageEngineReference is used by Da Vinci exclusively to speed up storage engine retrieval for read path.
   void setStorageEngineReference(String topicName, AtomicReference<AbstractStorageEngine> storageEngineReference);
+
+  /**
+   * Check whether there are any current version bootstrapping or not.
+   */
+  boolean hasCurrentVersionBootstrapping();
 }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/ingestion/IsolatedIngestionBackend.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/ingestion/IsolatedIngestionBackend.java
@@ -11,6 +11,7 @@ import com.linkedin.davinci.ingestion.main.MainIngestionMonitorService;
 import com.linkedin.davinci.ingestion.main.MainIngestionRequestClient;
 import com.linkedin.davinci.ingestion.main.MainIngestionStorageMetadataService;
 import com.linkedin.davinci.ingestion.main.MainPartitionIngestionStatus;
+import com.linkedin.davinci.ingestion.main.MainTopicIngestionStatus;
 import com.linkedin.davinci.kafka.consumer.KafkaStoreIngestionService;
 import com.linkedin.davinci.notifier.RelayNotifier;
 import com.linkedin.davinci.notifier.VeniceNotifier;
@@ -19,12 +20,15 @@ import com.linkedin.davinci.storage.StorageService;
 import com.linkedin.venice.exceptions.VeniceException;
 import com.linkedin.venice.ingestion.protocol.enums.IngestionCommandType;
 import com.linkedin.venice.ingestion.protocol.enums.IngestionComponentType;
+import com.linkedin.venice.meta.Version;
 import com.linkedin.venice.utils.Time;
 import com.linkedin.venice.utils.Utils;
 import io.tehuti.metrics.MetricsRepository;
+import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.function.Function;
 import java.util.function.Supplier;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -50,6 +54,7 @@ public class IsolatedIngestionBackend extends DefaultIngestionBackend implements
   private final MainIngestionMonitorService mainIngestionMonitorService;
   private final VeniceConfigLoader configLoader;
   private final ExecutorService completionReportHandlingExecutor = Executors.newFixedThreadPool(10);
+  private final Function<String, Integer> currentVersionSupplier;
   private Process isolatedIngestionServiceProcess;
 
   public IsolatedIngestionBackend(
@@ -58,7 +63,8 @@ public class IsolatedIngestionBackend extends DefaultIngestionBackend implements
       StorageMetadataService storageMetadataService,
       KafkaStoreIngestionService storeIngestionService,
       StorageService storageService,
-      BlobTransferManager blobTransferManager) {
+      BlobTransferManager blobTransferManager,
+      Function<String, Integer> currentVersionSupplier) {
     super(
         storageMetadataService,
         storeIngestionService,
@@ -68,6 +74,7 @@ public class IsolatedIngestionBackend extends DefaultIngestionBackend implements
     int servicePort = configLoader.getVeniceServerConfig().getIngestionServicePort();
     int listenerPort = configLoader.getVeniceServerConfig().getIngestionApplicationPort();
     this.configLoader = configLoader;
+    this.currentVersionSupplier = currentVersionSupplier;
     // Create the ingestion request client.
     mainIngestionRequestClient = new MainIngestionRequestClient(configLoader);
     // Create the forked isolated ingestion process.
@@ -192,6 +199,10 @@ public class IsolatedIngestionBackend extends DefaultIngestionBackend implements
     return mainIngestionMonitorService;
   }
 
+  Function<String, Integer> getCurrentVersionSupplier() {
+    return currentVersionSupplier;
+  }
+
   public MainIngestionRequestClient getMainIngestionRequestClient() {
     return mainIngestionRequestClient;
   }
@@ -216,6 +227,31 @@ public class IsolatedIngestionBackend extends DefaultIngestionBackend implements
     } catch (Exception e) {
       LOGGER.info("Unable to close {}", getClass().getSimpleName(), e);
     }
+  }
+
+  public boolean hasCurrentVersionBootstrapping() {
+    if (super.hasCurrentVersionBootstrapping()) {
+      return true;
+    }
+
+    Map<String, MainTopicIngestionStatus> topicIngestionStatusMap =
+        getMainIngestionMonitorService().getTopicIngestionStatusMap();
+    for (Map.Entry<String, MainTopicIngestionStatus> entry: topicIngestionStatusMap.entrySet()) {
+      String topicName = entry.getKey();
+      MainTopicIngestionStatus ingestionStatus = entry.getValue();
+      String storeName = Version.parseStoreFromKafkaTopicName(topicName);
+      int version = Version.parseVersionFromKafkaTopicName(topicName);
+      /**
+       * If the current version is still being ingested by isolated process, it means the bootstrapping hasn't finished
+       * yet as the ingestion task should be handled over to main process if all partitions complete ingestion.
+       */
+      if (getCurrentVersionSupplier().apply(storeName) == version
+          && ingestionStatus.hasPartitionIngestingInIsolatedProcess()) {
+        return true;
+      }
+    }
+
+    return false;
   }
 
   boolean isTopicPartitionHostedInMainProcess(String topicName, int partition) {

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/ingestion/main/MainTopicIngestionStatus.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/ingestion/main/MainTopicIngestionStatus.java
@@ -43,4 +43,13 @@ public class MainTopicIngestionStatus {
   public String getTopicName() {
     return topicName;
   }
+
+  public boolean hasPartitionIngestingInIsolatedProcess() {
+    for (Map.Entry<Integer, MainPartitionIngestionStatus> entry: ingestionStatusMap.entrySet()) {
+      if (entry.getValue().equals(MainPartitionIngestionStatus.ISOLATED)) {
+        return true;
+      }
+    }
+    return false;
+  }
 }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/KafkaStoreIngestionService.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/KafkaStoreIngestionService.java
@@ -557,6 +557,20 @@ public class KafkaStoreIngestionService extends AbstractVeniceService implements
     }
   }
 
+  public boolean hasCurrentVersionBootstrapping() {
+    return hasCurrentVersionBootstrapping(topicNameToIngestionTaskMap);
+  }
+
+  public static boolean hasCurrentVersionBootstrapping(Map<String, StoreIngestionTask> ingestionTaskMap) {
+    for (Map.Entry<String, StoreIngestionTask> entry: ingestionTaskMap.entrySet()) {
+      StoreIngestionTask task = entry.getValue();
+      if (task.isCurrentVersion() && !task.hasAllPartitionReportedCompleted()) {
+        return true;
+      }
+    }
+    return false;
+  }
+
   /**
    * Stops all the Kafka consumption tasks.
    * Closes all the Kafka clients.

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/DaVinciBackendTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/DaVinciBackendTest.java
@@ -4,6 +4,10 @@ import static com.linkedin.venice.pushmonitor.ExecutionStatus.DVC_INGESTION_ERRO
 import static com.linkedin.venice.pushmonitor.ExecutionStatus.ERROR;
 import static com.linkedin.venice.utils.DataProviderUtils.BOOLEAN;
 import static com.linkedin.venice.utils.DataProviderUtils.allPermutationGenerator;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.fail;
 
@@ -11,6 +15,9 @@ import com.linkedin.venice.exceptions.DiskLimitExhaustedException;
 import com.linkedin.venice.exceptions.MemoryLimitExhaustedException;
 import com.linkedin.venice.exceptions.VeniceException;
 import com.linkedin.venice.pushmonitor.ExecutionStatus;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
@@ -117,6 +124,19 @@ public class DaVinciBackendTest {
           DaVinciBackend.getDaVinciErrorStatus(veniceException, useDaVinciSpecificExecutionStatusForError),
           ERROR);
     }
+  }
+
+  @Test
+  public void testBootstrappingAwareCompletableFuture()
+      throws ExecutionException, InterruptedException, TimeoutException {
+    DaVinciBackend backend = mock(DaVinciBackend.class);
+
+    when(backend.hasCurrentVersionBootstrapping()).thenReturn(true).thenReturn(false);
+
+    DaVinciBackend.BootstrappingAwareCompletableFuture future =
+        new DaVinciBackend.BootstrappingAwareCompletableFuture(backend);
+    future.getBootstrappingFuture().get(10, TimeUnit.SECONDS);
+    verify(backend, times(2)).hasCurrentVersionBootstrapping();
   }
 
 }

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/VersionBackendTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/VersionBackendTest.java
@@ -110,6 +110,8 @@ public class VersionBackendTest {
     VersionBackend.sendOutHeartbeat(backend, currentVersion);
     VersionBackend.sendOutHeartbeat(backend, futureVersion);
 
+    verify(mockWriter, times(2)).deleteHeartbeat(storeName);
+
     verify(mockWriter, never()).writeHeartbeat(storeName);
 
     doReturn(false).when(backend).hasCurrentVersionBootstrapping();

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/VersionBackendTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/VersionBackendTest.java
@@ -110,8 +110,7 @@ public class VersionBackendTest {
     VersionBackend.sendOutHeartbeat(backend, currentVersion);
     VersionBackend.sendOutHeartbeat(backend, futureVersion);
 
-    verify(mockWriter, times(2)).deleteHeartbeat(storeName);
-
+    verify(mockWriter, times(2)).writeHeartbeatForBootstrappingInstance(storeName);
     verify(mockWriter, never()).writeHeartbeat(storeName);
 
     doReturn(false).when(backend).hasCurrentVersionBootstrapping();

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/ingestion/DefaultIngestionBackendTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/ingestion/DefaultIngestionBackendTest.java
@@ -4,10 +4,14 @@ import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
 
 import com.linkedin.davinci.blobtransfer.BlobTransferManager;
 import com.linkedin.davinci.config.VeniceServerConfig;
@@ -26,7 +30,6 @@ import java.time.Duration;
 import java.util.concurrent.CompletableFuture;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
-import org.testng.Assert;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
@@ -108,6 +111,18 @@ public class DefaultIngestionBackendTest {
 
     CompletableFuture<Void> future =
         ingestionBackend.bootstrapFromBlobs(store, VERSION_NUMBER, PARTITION).toCompletableFuture();
-    Assert.assertTrue(future.isDone());
+    assertTrue(future.isDone());
+  }
+
+  @Test
+  public void testHasCurrentVersionBootstrapping() {
+    KafkaStoreIngestionService mockIngestionService = mock(KafkaStoreIngestionService.class);
+    DefaultIngestionBackend ingestionBackend =
+        new DefaultIngestionBackend(null, mockIngestionService, null, null, null);
+    doReturn(true).when(mockIngestionService).hasCurrentVersionBootstrapping();
+    assertTrue(ingestionBackend.hasCurrentVersionBootstrapping());
+
+    doReturn(false).when(mockIngestionService).hasCurrentVersionBootstrapping();
+    assertFalse(ingestionBackend.hasCurrentVersionBootstrapping());
   }
 }

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/ingestion/main/MainTopicIngestionStatusTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/ingestion/main/MainTopicIngestionStatusTest.java
@@ -1,0 +1,24 @@
+package com.linkedin.davinci.ingestion.main;
+
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+
+import org.testng.annotations.Test;
+
+
+public class MainTopicIngestionStatusTest {
+  @Test
+  public void testHasPartitionIngestingInIsolatedProcess() {
+    String topicName = "test_store_v1";
+    MainTopicIngestionStatus ingestionStatus = new MainTopicIngestionStatus(topicName);
+    ingestionStatus.setPartitionIngestionStatusToLocalIngestion(1);
+    ingestionStatus.setPartitionIngestionStatusToLocalIngestion(2);
+    assertFalse(ingestionStatus.hasPartitionIngestingInIsolatedProcess());
+
+    ingestionStatus.setPartitionIngestionStatusToIsolatedIngestion(3);
+    assertTrue(ingestionStatus.hasPartitionIngestingInIsolatedProcess());
+
+    ingestionStatus.removePartitionIngestionStatus(3);
+    assertFalse(ingestionStatus.hasPartitionIngestingInIsolatedProcess());
+  }
+}

--- a/internal/venice-common/src/main/java/com/linkedin/venice/pushstatushelper/PushStatusStoreReader.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/pushstatushelper/PushStatusStoreReader.java
@@ -230,7 +230,10 @@ public class PushStatusStoreReader implements Closeable {
   }
 
   public boolean isInstanceAlive(String storeName, String instanceName) {
-    long lastReportTimeStamp = getHeartbeat(storeName, instanceName);
+    return isInstanceAlive(getHeartbeat(storeName, instanceName));
+  }
+
+  boolean isInstanceAlive(long lastReportTimeStamp) {
     return System.currentTimeMillis() - lastReportTimeStamp <= TimeUnit.SECONDS
         .toMillis(heartbeatExpirationTimeInSeconds);
   }
@@ -240,11 +243,8 @@ public class PushStatusStoreReader implements Closeable {
     if (lastReportTimeStamp < 0) {
       return InstanceStatus.BOOTSTRAPPING;
     }
-    if (System.currentTimeMillis() - lastReportTimeStamp <= TimeUnit.SECONDS
-        .toMillis(heartbeatExpirationTimeInSeconds)) {
-      return InstanceStatus.ALIVE;
-    }
-    return InstanceStatus.DEAD;
+
+    return isInstanceAlive(lastReportTimeStamp) ? InstanceStatus.ALIVE : InstanceStatus.DEAD;
   }
 
   public Map<CharSequence, Integer> getSupposedlyOngoingIncrementalPushVersions(String storeName, int storeVersion) {

--- a/internal/venice-common/src/main/java/com/linkedin/venice/pushstatushelper/PushStatusStoreWriter.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/pushstatushelper/PushStatusStoreWriter.java
@@ -76,6 +76,12 @@ public class PushStatusStoreWriter implements AutoCloseable {
     writer.update(pushStatusKey, updateBuilder.build(), valueSchemaId, derivedSchemaId, null);
   }
 
+  public void deleteHeartbeat(String storeName) {
+    VeniceWriter writer = veniceWriterCache.prepareVeniceWriter(storeName);
+    PushStatusKey pushStatusKey = PushStatusStoreUtils.getHeartbeatKey(instanceName);
+    writer.delete(pushStatusKey, null);
+  }
+
   public void writePushStatus(
       String storeName,
       int version,

--- a/internal/venice-common/src/main/java/com/linkedin/venice/pushstatushelper/PushStatusStoreWriter.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/pushstatushelper/PushStatusStoreWriter.java
@@ -67,6 +67,15 @@ public class PushStatusStoreWriter implements AutoCloseable {
     writeHeartbeat(storeName, System.currentTimeMillis());
   }
 
+  /**
+   * This function will write `-1` to indicate the node is bootstrapping and Controller
+   * should ignore all the reports from this instance.
+   * @param storeName
+   */
+  public void writeHeartbeatForBootstrappingInstance(String storeName) {
+    writeHeartbeat(storeName, -1);
+  }
+
   public void writeHeartbeat(String storeName, long heartbeat) {
     VeniceWriter writer = veniceWriterCache.prepareVeniceWriter(storeName);
     PushStatusKey pushStatusKey = PushStatusStoreUtils.getHeartbeatKey(instanceName);
@@ -74,12 +83,6 @@ public class PushStatusStoreWriter implements AutoCloseable {
     updateBuilder.setNewFieldValue("reportTimestamp", heartbeat);
     LOGGER.info("Sending heartbeat of {}", instanceName);
     writer.update(pushStatusKey, updateBuilder.build(), valueSchemaId, derivedSchemaId, null);
-  }
-
-  public void deleteHeartbeat(String storeName) {
-    VeniceWriter writer = veniceWriterCache.prepareVeniceWriter(storeName);
-    PushStatusKey pushStatusKey = PushStatusStoreUtils.getHeartbeatKey(instanceName);
-    writer.delete(pushStatusKey, null);
   }
 
   public void writePushStatus(

--- a/internal/venice-common/src/test/java/com/linkedin/venice/pushstatushelper/PushStatusStoreReaderTest.java
+++ b/internal/venice-common/src/test/java/com/linkedin/venice/pushstatushelper/PushStatusStoreReaderTest.java
@@ -6,6 +6,7 @@ import static com.linkedin.venice.pushmonitor.ExecutionStatus.END_OF_INCREMENTAL
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.anySet;
+import static org.mockito.Mockito.doCallRealMethod;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.mock;
@@ -13,6 +14,7 @@ import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertEqualsDeep;
 import static org.testng.Assert.assertNotEquals;
 
@@ -364,5 +366,23 @@ public class PushStatusStoreReaderTest {
 
     // Test that push status store reader will also return null instead of empty map in this case
     Assert.assertNull(storeReaderSpy.getVersionStatus(storeName, storeVersion));
+  }
+
+  @Test
+  public void testGetInstanceStatus() {
+    PushStatusStoreReader mockReader = mock(PushStatusStoreReader.class);
+    doCallRealMethod().when(mockReader).getInstanceStatus(any(), any());
+
+    doReturn(-1l).when(mockReader).getHeartbeat("store_1", "instance_1");
+    assertEquals(
+        mockReader.getInstanceStatus("store_1", "instance_1"),
+        PushStatusStoreReader.InstanceStatus.BOOTSTRAPPING);
+
+    doReturn(1000l).when(mockReader).getHeartbeat("store_1", "instance_1");
+    doReturn(true).when(mockReader).isInstanceAlive(anyLong());
+    assertEquals(mockReader.getInstanceStatus("store_1", "instance_1"), PushStatusStoreReader.InstanceStatus.ALIVE);
+
+    doReturn(false).when(mockReader).isInstanceAlive(anyLong());
+    assertEquals(mockReader.getInstanceStatus("store_1", "instance_1"), PushStatusStoreReader.InstanceStatus.DEAD);
   }
 }

--- a/internal/venice-common/src/test/java/com/linkedin/venice/pushstatushelper/PushStatusStoreWriterTest.java
+++ b/internal/venice-common/src/test/java/com/linkedin/venice/pushstatushelper/PushStatusStoreWriterTest.java
@@ -144,4 +144,13 @@ public class PushStatusStoreWriterTest {
     verify(veniceWriterMock)
         .update(eq(statusKey), eq(getHeartbeatRecord(heartbeat)), eq(valueSchemaId), eq(derivedSchemaId), eq(null));
   }
+
+  @Test
+  public void testWriteHeartbeatForBootstrappingInstance() {
+    PushStatusKey statusKey = PushStatusStoreUtils.getHeartbeatKey(instanceName);
+    pushStatusStoreWriter.writeHeartbeatForBootstrappingInstance(storeName);
+    verify(veniceWriterCacheMock).prepareVeniceWriter(storeName);
+    verify(veniceWriterMock)
+        .update(eq(statusKey), eq(getHeartbeatRecord(-1)), eq(valueSchemaId), eq(derivedSchemaId), eq(null));
+  }
 }

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/DaVinciClientTest.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/DaVinciClientTest.java
@@ -775,7 +775,7 @@ public class DaVinciClientTest {
         // Isolated clients should not be able to unsubscribe partitions of other clients.
         client3.unsubscribeAll();
 
-        client3.subscribe(Collections.singleton(partition)).get(0, TimeUnit.SECONDS);
+        client3.subscribe(Collections.singleton(partition)).get(10, TimeUnit.SECONDS);
         for (int i = 0; i < KEY_COUNT; i++) {
           final int key = i;
           // Both client2 & client4 are not subscribed to any partition. But client2 is not-isolated so it can

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/DaVinciClientTest.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/DaVinciClientTest.java
@@ -11,8 +11,10 @@ import static com.linkedin.venice.ConfigKeys.DAVINCI_P2P_BLOB_TRANSFER_SERVER_PO
 import static com.linkedin.venice.ConfigKeys.DAVINCI_PUSH_STATUS_CHECK_INTERVAL_IN_MS;
 import static com.linkedin.venice.ConfigKeys.DAVINCI_PUSH_STATUS_SCAN_INTERVAL_IN_SECONDS;
 import static com.linkedin.venice.ConfigKeys.DA_VINCI_CURRENT_VERSION_BOOTSTRAPPING_SPEEDUP_ENABLED;
+import static com.linkedin.venice.ConfigKeys.KAFKA_FETCH_QUOTA_RECORDS_PER_SECOND;
 import static com.linkedin.venice.ConfigKeys.PERSISTENCE_TYPE;
 import static com.linkedin.venice.ConfigKeys.PUSH_STATUS_STORE_ENABLED;
+import static com.linkedin.venice.ConfigKeys.PUSH_STATUS_STORE_HEARTBEAT_INTERVAL_IN_SECONDS;
 import static com.linkedin.venice.ConfigKeys.SERVER_CONSUMER_POOL_SIZE_PER_KAFKA_CLUSTER;
 import static com.linkedin.venice.ConfigKeys.SERVER_DATABASE_CHECKSUM_VERIFICATION_ENABLED;
 import static com.linkedin.venice.ConfigKeys.SERVER_DATABASE_SYNC_BYTES_INTERNAL_FOR_DEFERRED_WRITE_MODE;
@@ -70,6 +72,7 @@ import com.linkedin.venice.integration.utils.ServiceFactory;
 import com.linkedin.venice.integration.utils.VeniceClusterWrapper;
 import com.linkedin.venice.integration.utils.VeniceRouterWrapper;
 import com.linkedin.venice.meta.IngestionMetadataUpdateType;
+import com.linkedin.venice.meta.IngestionMode;
 import com.linkedin.venice.meta.Version;
 import com.linkedin.venice.offsets.OffsetRecord;
 import com.linkedin.venice.partitioner.ConstantVenicePartitioner;
@@ -148,6 +151,8 @@ public class DaVinciClientTest {
     inputDirPath = "file://" + inputDir.getAbsolutePath();
     Properties clusterConfig = new Properties();
     clusterConfig.put(SERVER_PROMOTION_TO_LEADER_REPLICA_DELAY_SECONDS, 1L);
+    clusterConfig.put(PUSH_STATUS_STORE_ENABLED, true);
+    clusterConfig.put(DAVINCI_PUSH_STATUS_SCAN_INTERVAL_IN_SECONDS, 3);
     cluster = ServiceFactory.getVeniceCluster(1, 2, 1, 2, 100, false, false, clusterConfig);
     d2Client = new D2ClientBuilder().setZkHosts(cluster.getZk().getAddress())
         .setZkSessionTimeout(3, TimeUnit.SECONDS)
@@ -785,6 +790,58 @@ public class DaVinciClientTest {
           assertThrows(NonLocalAccessException.class, () -> client4.get(key).get());
         }
       }
+    }
+  }
+
+  @Test(timeOut = TEST_TIMEOUT, dataProvider = "Isolated-Ingestion", dataProviderClass = DataProviderUtils.class)
+  public void testStatusReportDuringBoostrap(IngestionMode ingestionMode) throws Exception {
+    int keyCnt = 1000;
+    String storeName = createStoreWithMetaSystemStoreAndPushStatusSystemStore(keyCnt);
+    String baseDataPath = Utils.getTempDataDirectory().getAbsolutePath();
+    Map<String, Object> extraBackendProp = new HashMap<>();
+    extraBackendProp.put(DATA_BASE_PATH, baseDataPath);
+    extraBackendProp.put(PUSH_STATUS_STORE_HEARTBEAT_INTERVAL_IN_SECONDS, "5");
+    extraBackendProp.put(KAFKA_FETCH_QUOTA_RECORDS_PER_SECOND, "5");
+    extraBackendProp.put(PUSH_STATUS_STORE_ENABLED, "true");
+    DaVinciTestContext<Integer, Object> daVinciTestContext =
+        ServiceFactory.getGenericAvroDaVinciFactoryAndClientWithRetries(
+            d2Client,
+            new MetricsRepository(),
+            Optional.empty(),
+            cluster.getZk().getAddress(),
+            storeName,
+            new DaVinciConfig().setIsolated(ingestionMode.equals(IngestionMode.ISOLATED)),
+            extraBackendProp);
+    try (DaVinciClient<Integer, Object> client = daVinciTestContext.getDaVinciClient()) {
+      CompletableFuture<Void> subscribeFuture = client.subscribeAll();
+
+      /**
+       * Create a new version while bootstrapping.
+       */
+      VersionCreationResponse newVersion = cluster.getNewVersion(storeName);
+      String topic = newVersion.getKafkaTopic();
+      VeniceWriterFactory vwFactory = IntegrationTestPushUtils
+          .getVeniceWriterFactory(cluster.getPubSubBrokerWrapper(), pubSubProducerAdapterFactory);
+      VeniceKafkaSerializer keySerializer = new VeniceAvroKafkaSerializer(DEFAULT_KEY_SCHEMA);
+      VeniceKafkaSerializer valueSerializer = new VeniceAvroKafkaSerializer(DEFAULT_VALUE_SCHEMA);
+      int valueSchemaId = HelixReadOnlySchemaRepository.VALUE_SCHEMA_STARTING_ID;
+
+      try (VeniceWriter<Object, Object, byte[]> batchProducer = vwFactory.createVeniceWriter(
+          new VeniceWriterOptions.Builder(topic).setKeySerializer(keySerializer)
+              .setValueSerializer(valueSerializer)
+              .build())) {
+        batchProducer.broadcastStartOfPush(Collections.emptyMap());
+        int keyCntForSecondVersion = 100;
+        Future[] writerFutures = new Future[keyCntForSecondVersion];
+        for (int i = 0; i < keyCntForSecondVersion; i++) {
+          writerFutures[i] = batchProducer.put(i, i, valueSchemaId);
+        }
+        for (int i = 0; i < keyCntForSecondVersion; i++) {
+          writerFutures[i].get();
+        }
+        batchProducer.broadcastEndOfPush(Collections.emptyMap());
+      }
+      subscribeFuture.get();
     }
   }
 

--- a/services/venice-controller/src/main/java/com/linkedin/venice/pushmonitor/PushMonitorUtils.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/pushmonitor/PushMonitorUtils.java
@@ -105,7 +105,7 @@ public class PushMonitorUtils {
           }
           continue;
         }
-        if (!instanceStatus.equals(PushStatusStoreReader.InstanceStatus.DEAD)) {
+        if (instanceStatus.equals(PushStatusStoreReader.InstanceStatus.DEAD)) {
           offlineInstanceCount++;
           // Keep at most 5 offline instances for logging purpose.
           if (offlineInstanceList.size() < 5) {

--- a/services/venice-controller/src/main/java/com/linkedin/venice/pushmonitor/PushMonitorUtils.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/pushmonitor/PushMonitorUtils.java
@@ -89,13 +89,6 @@ public class PushMonitorUtils {
       Set<String> incompleteInstanceList = new HashSet<>();
       ExecutionStatus errorStatus = ExecutionStatus.ERROR;
       for (Map.Entry<CharSequence, Integer> entry: instances.entrySet()) {
-        ExecutionStatus status = ExecutionStatus.valueOf(entry.getValue());
-        // We will skip completed instances, as they have stopped emitting heartbeats and will not be counted as live
-        // instances.
-        if (status == completeStatus) {
-          completedInstanceCount++;
-          continue;
-        }
         PushStatusStoreReader.InstanceStatus instanceStatus =
             reader.getInstanceStatus(storeName, entry.getKey().toString());
         if (instanceStatus.equals(PushStatusStoreReader.InstanceStatus.BOOTSTRAPPING)) {
@@ -103,6 +96,13 @@ public class PushMonitorUtils {
               "Skipping ingestion status report from bootstrapping instance: {} for topic: {}",
               entry.getKey().toString(),
               topicName);
+          continue;
+        }
+        ExecutionStatus status = ExecutionStatus.valueOf(entry.getValue());
+        // We will skip completed instances, as they have stopped emitting heartbeats and will not be counted as live
+        // instances.
+        if (status == completeStatus) {
+          completedInstanceCount++;
           continue;
         }
         if (instanceStatus.equals(PushStatusStoreReader.InstanceStatus.DEAD)) {
@@ -249,13 +249,6 @@ public class PushMonitorUtils {
       boolean allInstancesCompleted = true;
       totalReplicaCount += instances.size();
       for (Map.Entry<CharSequence, Integer> entry: instances.entrySet()) {
-        ExecutionStatus status = ExecutionStatus.valueOf(entry.getValue());
-        // We will skip completed replicas, as they have stopped emitting heartbeats and will not be counted as live
-        // replicas.
-        if (status == completeStatus) {
-          completedReplicaCount++;
-          continue;
-        }
         String instanceName = entry.getKey().toString();
         PushStatusStoreReader.InstanceStatus instanceStatus = instanceLivenessCache
             .computeIfAbsent(instanceName, ignored -> reader.getInstanceStatus(storeName, instanceName));
@@ -267,6 +260,14 @@ public class PushMonitorUtils {
               entry.getKey().toString(),
               topicName,
               partitionId);
+          continue;
+        }
+
+        ExecutionStatus status = ExecutionStatus.valueOf(entry.getValue());
+        // We will skip completed replicas, as they have stopped emitting heartbeats and will not be counted as live
+        // replicas.
+        if (status == completeStatus) {
+          completedReplicaCount++;
           continue;
         }
         if (instanceStatus.equals(PushStatusStoreReader.InstanceStatus.DEAD)) {

--- a/services/venice-controller/src/test/java/com/linkedin/venice/pushmonitor/PushMonitorUtilsTest.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/pushmonitor/PushMonitorUtilsTest.java
@@ -21,22 +21,32 @@ public class PushMonitorUtilsTest {
   @Test
   public void testCompleteStatusCanBeReportedWithOfflineInstancesBelowFailFastThreshold() {
     PushMonitorUtils.setDaVinciErrorInstanceWaitTime(0);
+    PushMonitorUtils.setDVCDeadInstanceTime("store_v1", System.currentTimeMillis());
     PushStatusStoreReader reader = mock(PushStatusStoreReader.class);
     /**
       * Instance a is offline and its push status is not completed.
       * Instance b,c,d are online and their push status is completed.
       * In this case, the overall DaVinci push status can be COMPLETED as long as 1 is below the fail fast threshold.
       */
-    doReturn(false).when(reader).isInstanceAlive(eq("store"), eq("a"));
-    doReturn(true).when(reader).isInstanceAlive(eq("store"), eq("b"));
-    doReturn(true).when(reader).isInstanceAlive(eq("store"), eq("c"));
-    doReturn(true).when(reader).isInstanceAlive(eq("store"), eq("d"));
+    doReturn(PushStatusStoreReader.InstanceStatus.DEAD).when(reader).getInstanceStatus(eq("store"), eq("a"));
+    doReturn(PushStatusStoreReader.InstanceStatus.ALIVE).when(reader).getInstanceStatus(eq("store"), eq("b"));
+    doReturn(PushStatusStoreReader.InstanceStatus.ALIVE).when(reader).getInstanceStatus(eq("store"), eq("c"));
+    doReturn(PushStatusStoreReader.InstanceStatus.ALIVE).when(reader).getInstanceStatus(eq("store"), eq("d"));
+    // Bootstrapping nodes should be ignored
+    doReturn(PushStatusStoreReader.InstanceStatus.BOOTSTRAPPING).when(reader).getInstanceStatus(eq("store"), eq("e"));
+    doReturn(PushStatusStoreReader.InstanceStatus.BOOTSTRAPPING).when(reader).getInstanceStatus(eq("store"), eq("f"));
+    doReturn(PushStatusStoreReader.InstanceStatus.BOOTSTRAPPING).when(reader).getInstanceStatus(eq("store"), eq("g"));
+    doReturn(PushStatusStoreReader.InstanceStatus.BOOTSTRAPPING).when(reader).getInstanceStatus(eq("store"), eq("h"));
 
     Map<CharSequence, Integer> map = new HashMap<>();
     map.put("a", 2);
     map.put("b", 10);
     map.put("c", 10);
     map.put("d", 10);
+    map.put("e", 2);
+    map.put("f", 2);
+    map.put("g", 2);
+    map.put("h", 2);
 
     // Test partition level key first
     doReturn(null).when(reader).getVersionStatus("store", 1);
@@ -56,10 +66,10 @@ public class PushMonitorUtilsTest {
   public void testDaVinciPushStatusScan(boolean useDaVinciSpecificExecutionStatusForError) {
     PushMonitorUtils.setDaVinciErrorInstanceWaitTime(0);
     PushStatusStoreReader reader = mock(PushStatusStoreReader.class);
-    doReturn(true).when(reader).isInstanceAlive(eq("store"), eq("a"));
-    doReturn(false).when(reader).isInstanceAlive(eq("store"), eq("b"));
-    doReturn(false).when(reader).isInstanceAlive(eq("store"), eq("c"));
-    doReturn(false).when(reader).isInstanceAlive(eq("store"), eq("d"));
+    doReturn(PushStatusStoreReader.InstanceStatus.ALIVE).when(reader).getInstanceStatus(eq("store"), eq("a"));
+    doReturn(PushStatusStoreReader.InstanceStatus.DEAD).when(reader).getInstanceStatus(eq("store"), eq("b"));
+    doReturn(PushStatusStoreReader.InstanceStatus.DEAD).when(reader).getInstanceStatus(eq("store"), eq("c"));
+    doReturn(PushStatusStoreReader.InstanceStatus.DEAD).when(reader).getInstanceStatus(eq("store"), eq("d"));
 
     Map<CharSequence, Integer> map = new HashMap<>();
     map.put("a", 3);

--- a/services/venice-controller/src/test/java/com/linkedin/venice/pushmonitor/PushStatusCollectorTest.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/pushmonitor/PushStatusCollectorTest.java
@@ -109,7 +109,8 @@ public class PushStatusCollectorTest {
         .thenReturn(startedInstancePushStatus, dvcTooManyDeadInstancesErrorInstancePushStatus);
     when(pushStatusStoreReader.getPartitionStatus(daVinciStoreName, 11, 0, Optional.empty()))
         .thenReturn(startedInstancePushStatus, dvcOtherErrorInstancePushStatus);
-    when(pushStatusStoreReader.isInstanceAlive(daVinciStoreName, "instance")).thenReturn(true);
+    when(pushStatusStoreReader.getInstanceStatus(daVinciStoreName, "instance"))
+        .thenReturn(PushStatusStoreReader.InstanceStatus.ALIVE);
     pushStatusCollector.subscribeTopic(daVinciStoreTopicV1, 1);
     Assert.assertFalse(pushStatusCollector.getTopicToPushStatusMap().containsKey(daVinciStoreTopicV1));
 
@@ -241,7 +242,8 @@ public class PushStatusCollectorTest {
         .thenReturn(Collections.emptyMap(), startedInstancePushStatus, dvcTooManyDeadInstancesErrorInstancePushStatus);
     when(pushStatusStoreReader.getPartitionStatus(daVinciStoreName, 6, 0, Optional.empty()))
         .thenReturn(Collections.emptyMap(), startedInstancePushStatus, dvcOtherErrorInstancePushStatus);
-    when(pushStatusStoreReader.isInstanceAlive(daVinciStoreName, "instance")).thenReturn(true);
+    when(pushStatusStoreReader.getInstanceStatus(daVinciStoreName, "instance"))
+        .thenReturn(PushStatusStoreReader.InstanceStatus.ALIVE);
     pushStatusCollector.subscribeTopic(daVinciStoreTopicV1, 1);
     Assert.assertFalse(pushStatusCollector.getTopicToPushStatusMap().containsKey(daVinciStoreTopicV1));
 
@@ -330,7 +332,8 @@ public class PushStatusCollectorTest {
 
     when(pushStatusStoreReader.getPartitionStatus(daVinciStoreName, 2, 0, Optional.empty()))
         .thenReturn(Collections.emptyMap());
-    when(pushStatusStoreReader.isInstanceAlive(daVinciStoreName, "instance")).thenReturn(true);
+    when(pushStatusStoreReader.getInstanceStatus(daVinciStoreName, "instance"))
+        .thenReturn(PushStatusStoreReader.InstanceStatus.ALIVE);
     pushStatusCollector.subscribeTopic(daVinciStoreTopicV1, 1);
     Assert.assertFalse(pushStatusCollector.getTopicToPushStatusMap().containsKey(daVinciStoreTopicV1));
 


### PR DESCRIPTION
## Summary
In Prod, we are seeing the bootstrapping nodes are blocking the new push, and this PR will let Controller ignore the status report from the nodes, which are still bootstrapping.
This feature is especially important for DaVinci apps, which are using multiple large stores and bootstrapping from an empty state can take a long time and it can delay the new push significantly.

<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

<!--
Describe
- What changes to make and why you are making these changes.
- How are you going to achieve your goal.
- Describe what testings you have done, for example, performance testing etc.

If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->


## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.