### PR TITLE
[controller] Refresh OfflinePushStatus after change listener subscription during loadAllPushes() call

### DIFF
--- a/clients/venice-admin-tool/src/test/java/com/linkedin/venice/TestKafkaTopicDumper.java
+++ b/clients/venice-admin-tool/src/test/java/com/linkedin/venice/TestKafkaTopicDumper.java
@@ -30,7 +30,6 @@ import java.util.Optional;
 import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericData;
 import org.apache.avro.generic.GenericRecord;
-import org.apache.logging.log4j.LogManager;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
@@ -205,7 +204,6 @@ public class TestKafkaTopicDumper {
     GenericRecord updateRecord = new UpdateBuilderImpl(updateSchema).setNewFieldValue("firstName", "f2").build();
 
     // Test PUT with and without RMD
-    LogManager.getLogger(TestKafkaTopicDumper.class).info("DEBUGGING: {} {}", rmdRecord, rmdSchema);
     byte[] serializedValue = valueSerializer.serialize(valueRecord);
     byte[] serializedRmd = rmdSerializer.serialize(rmdRecord);
     byte[] serializedUpdate = updateSerializer.serialize(updateRecord);

--- a/internal/venice-common/src/main/java/com/linkedin/venice/pushmonitor/OfflinePushStatus.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/pushmonitor/OfflinePushStatus.java
@@ -53,7 +53,7 @@ public class OfflinePushStatus {
   private List<StatusSnapshot> statusHistory;
   private String incrementalPushVersion = "";
   // Key is Partition Id (0 to n-1); value is the corresponding partition status.
-  private Map<Integer, PartitionStatus> partitionIdToStatus;
+  private final Map<Integer, PartitionStatus> partitionIdToStatus;
 
   private Map<String, String> pushProperties;
 

--- a/services/venice-controller/src/main/java/com/linkedin/venice/pushmonitor/AbstractPushMonitor.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/pushmonitor/AbstractPushMonitor.java
@@ -309,9 +309,12 @@ public abstract class AbstractPushMonitor
 
   protected void updateOfflinePush(String topic) {
     String store = Version.parseStoreFromKafkaTopicName(topic);
+    OfflinePushStatus offlinePushStatus;
     try (AutoCloseableLock ignored = clusterLockManager.createStoreWriteLock(store)) {
-      OfflinePushStatus offlinePushStatus = getOfflinePushAccessor().getOfflinePushStatusAndItsPartitionStatuses(topic);
+      offlinePushStatus = getOfflinePushAccessor().getOfflinePushStatusAndItsPartitionStatuses(topic);
       topicToPushMap.put(topic, offlinePushStatus);
+    }
+    if (offlinePushStatus != null) {
       LOGGER.info(
           "Update offline push status from ZK for topic: {}, current status: {}",
           topic,

--- a/services/venice-controller/src/main/java/com/linkedin/venice/pushmonitor/AbstractPushMonitor.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/pushmonitor/AbstractPushMonitor.java
@@ -124,8 +124,8 @@ public abstract class AbstractPushMonitor
     this.pushStatusCollector = new PushStatusCollector(
         metadataRepository,
         pushStatusStoreReader,
-        this::handleCompletedPush,
-        this::handleErrorPush,
+        (topic) -> handleCompletedPush(topic),
+        (topic, details) -> handleErrorPush(topic, details),
         controllerConfig.isDaVinciPushStatusScanEnabled(),
         controllerConfig.getDaVinciPushStatusScanIntervalInSeconds(),
         controllerConfig.getDaVinciPushStatusScanThreadNumber(),
@@ -773,7 +773,9 @@ public abstract class AbstractPushMonitor
   @Override
   public void onPartitionStatusChange(String topic, ReadOnlyPartitionStatus partitionStatus) {
     String storeName = Version.parseStoreFromKafkaTopicName(topic);
+    LOGGER.info("DEBUGGING 123");
     try (AutoCloseableLock ignore = clusterLockManager.createStoreWriteLock(storeName)) {
+      LOGGER.info("DEBUGGING 456");
       OfflinePushStatus pushStatus = getOfflinePush(topic);
       if (pushStatus == null) {
         LOGGER.error("Can not find Offline push for topic:{}, ignore the partition status change notification.", topic);

--- a/services/venice-controller/src/main/java/com/linkedin/venice/pushmonitor/AbstractPushMonitor.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/pushmonitor/AbstractPushMonitor.java
@@ -773,9 +773,7 @@ public abstract class AbstractPushMonitor
   @Override
   public void onPartitionStatusChange(String topic, ReadOnlyPartitionStatus partitionStatus) {
     String storeName = Version.parseStoreFromKafkaTopicName(topic);
-    LOGGER.info("DEBUGGING 123");
     try (AutoCloseableLock ignore = clusterLockManager.createStoreWriteLock(storeName)) {
-      LOGGER.info("DEBUGGING 456");
       OfflinePushStatus pushStatus = getOfflinePush(topic);
       if (pushStatus == null) {
         LOGGER.error("Can not find Offline push for topic:{}, ignore the partition status change notification.", topic);

--- a/services/venice-controller/src/main/java/com/linkedin/venice/pushmonitor/AbstractPushMonitor.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/pushmonitor/AbstractPushMonitor.java
@@ -151,7 +151,7 @@ public abstract class AbstractPushMonitor
       LOGGER.info("Load all pushes started for cluster {}'s {}", clusterName, getClass().getSimpleName());
       for (OfflinePushStatus offlinePushStatus: offlinePushStatusList) {
         try {
-          // topicToPushMap.put(offlinePushStatus.getKafkaTopic(), offlinePushStatus);
+          topicToPushMap.put(offlinePushStatus.getKafkaTopic(), offlinePushStatus);
           routingDataRepository.subscribeRoutingDataChange(offlinePushStatus.getKafkaTopic(), this);
           getOfflinePushAccessor().subscribePartitionStatusChange(offlinePushStatus, this);
           /**

--- a/services/venice-controller/src/main/java/com/linkedin/venice/pushmonitor/PartitionStatusBasedPushMonitor.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/pushmonitor/PartitionStatusBasedPushMonitor.java
@@ -82,7 +82,6 @@ public class PartitionStatusBasedPushMonitor extends AbstractPushMonitor {
         offlinePushStatus,
         partitionAssignment,
         getDisableReplicaCallback(partitionAssignment.getTopic()));
-    LOGGER.info("DEBUGGING NEW DETAIL: {}", statusWithDetails.getStatus());
     if (statusWithDetails.getStatus().isTerminal()) {
       LOGGER.info(
           "Found a offline pushes could be terminated: {}, status: {}",

--- a/services/venice-controller/src/main/java/com/linkedin/venice/pushmonitor/PartitionStatusBasedPushMonitor.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/pushmonitor/PartitionStatusBasedPushMonitor.java
@@ -82,6 +82,7 @@ public class PartitionStatusBasedPushMonitor extends AbstractPushMonitor {
         offlinePushStatus,
         partitionAssignment,
         getDisableReplicaCallback(partitionAssignment.getTopic()));
+    LOGGER.info("DEBUGGING NEW DETAIL: {}", statusWithDetails.getStatus());
     if (statusWithDetails.getStatus().isTerminal()) {
       LOGGER.info(
           "Found a offline pushes could be terminated: {}, status: {}",


### PR DESCRIPTION
## [controller] Refresh OfflinePushStatus after change listener subscription during loadAllPushes() call
The issue:
We observed such race condition in controller deployment/restart. When it restarts, it will call loadAllPushes() which load all OfflinePushStatus snapshot for all topics from ZK, it will then iterate the list and try to subscribe to the changes. If there is any change in between, it will be missed and push job can hang forever.

This PR adds a refresh offline pushes call after listener subscription. It is using the same store level lock, so it should not cause any race condition or deadlock with change listener callback.



## How was this PR tested?
Add an unit test
## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.