### PR TITLE
[controller] fix topic priority determination in TopicCleanupService

### DIFF
--- a/internal/venice-common/src/test/java/com/linkedin/venice/pubsub/PubSubTopicPartitionInfoTest.java
+++ b/internal/venice-common/src/test/java/com/linkedin/venice/pubsub/PubSubTopicPartitionInfoTest.java
@@ -3,7 +3,12 @@ package com.linkedin.venice.pubsub;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 
+import com.linkedin.venice.controller.kafka.TopicCleanupService;
+import com.linkedin.venice.meta.Version;
 import com.linkedin.venice.pubsub.api.PubSubTopic;
+import java.util.PriorityQueue;
+import java.util.Random;
+import org.testng.Assert;
 import org.testng.annotations.Test;
 
 
@@ -11,6 +16,8 @@ import org.testng.annotations.Test;
  * Unit tests for {@link PubSubTopicPartitionInfo}.
  */
 public class PubSubTopicPartitionInfoTest {
+  Random rand = new Random();
+
   @Test
   public void testTopic() {
     PubSubTopic pubSubTopic = new PubSubTopicImpl("testTopic");
@@ -35,5 +42,30 @@ public class PubSubTopicPartitionInfoTest {
   public void testToString() {
     PubSubTopicPartitionInfo partitionInfo = new PubSubTopicPartitionInfo(new PubSubTopicImpl("testTopic"), 0, true);
     assertEquals(partitionInfo.toString(), "Partition(topic = testTopic, partition=0, hasInSyncReplica = true)");
+  }
+
+  @Test
+  public void testTopicDeletionPriority() {
+    PriorityQueue<PubSubTopic> allTopics = new PriorityQueue<>(TopicCleanupService.topicPriorityComparator);
+    int numberOfRTTopicsInTest = 0;
+
+    for (int i = 0; i < 100; i++) {
+      int randomNum = rand.nextInt(2);
+      if (randomNum == 0) {
+        allTopics.add(new PubSubTopicImpl("topic" + i + Version.REAL_TIME_TOPIC_SUFFIX));
+        numberOfRTTopicsInTest++;
+      } else {
+        allTopics.add(new PubSubTopicImpl("topic" + i));
+      }
+    }
+
+    int i = 0;
+    while (!allTopics.isEmpty()) {
+      if (i++ < numberOfRTTopicsInTest) {
+        Assert.assertTrue(allTopics.poll().isRealTime());
+      } else {
+        Assert.assertFalse(allTopics.poll().isRealTime());
+      }
+    }
   }
 }

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/kafka/TopicCleanupService.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/kafka/TopicCleanupService.java
@@ -21,6 +21,7 @@ import com.linkedin.venice.utils.Time;
 import com.linkedin.venice.utils.VeniceProperties;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -90,6 +91,8 @@ public class TopicCleanupService extends AbstractVeniceService {
   private final Map<PubSubTopic, Integer> danglingTopicOccurrenceCounter;
   private final int danglingTopicOccurrenceThresholdForCleanup;
   private final long danglingTopicCleanupIntervalMs;
+  public final static Comparator<PubSubTopic> topicPriorityComparator =
+      Comparator.comparingInt(topic -> (topic.isRealTime() ? -1 : 1));
 
   public TopicCleanupService(
       Admin admin,
@@ -232,7 +235,7 @@ public class TopicCleanupService extends AbstractVeniceService {
    * If version topic deletion takes more than certain time it refreshes the entire topic list and start deleting from RT topics again.
     */
   void cleanupVeniceTopics() {
-    PriorityQueue<PubSubTopic> allTopics = new PriorityQueue<>((s1, s2) -> s1.isRealTime() ? -1 : 0);
+    PriorityQueue<PubSubTopic> allTopics = new PriorityQueue<>(topicPriorityComparator);
     populateDeprecatedTopicQueue(allTopics);
     topicCleanupServiceStats.recordDeletableTopicsCount(allTopics.size());
     long refreshTime = System.currentTimeMillis();


### PR DESCRIPTION
<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## Summary, imperative, start upper case, don't end with a period
<!--
Describe
- What changes to make and why you are making these changes.
- How are you going to achieve your goal.
- Describe what testings you have done, for example, performance testing etc.

If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->
The comparator used in TopicCleanupService to assign higher priority to RT topics over non RT topics `(s1, s2) -> s1.isRealTime() ? -1 : 0` is incorrect. It does not assign two RT topics (or two non RT topics) as equal priority, which violates the fundamental contract of sorting algorithms.
In some cases, this results in RT topic being assigned lower priority than a non RT topic. This PR fixes the comparator and uses both the topics in determining the relative priority.

Resolves #XXX

## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
added a unit test in PubSubTopicPartitionInfoTest, which fails without the fix.

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.