### PR TITLE
[all] Bumped up the tehuti dep to the latest 0.12.3

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -126,7 +126,7 @@ ext.libraries = [
     snappy: 'org.iq80.snappy:snappy:0.4',
     spark: 'com.sparkjava:spark-core:2.9.4', // Spark-Java Rest framework
     spotbugs: 'com.github.spotbugs:spotbugs:4.5.2',
-    tehuti: 'io.tehuti:tehuti:0.12.2',
+    tehuti: 'io.tehuti:tehuti:0.12.3',
     testcontainers: 'org.testcontainers:testcontainers:1.18.0',
     testng: 'org.testng:testng:6.14.3',
     tomcatAnnotations: 'org.apache.tomcat:annotations-api:6.0.53',


### PR DESCRIPTION
## Summary
Bumped up the tehuti dep to the latest 0.12.3 which has the [fix](https://github.com/tehuti-io/tehuti/pull/34) to a deadlock issue involving lock in `MetricRepository` and `Sensor`.

## How was this PR tested?
GH CI

## Does this PR introduce any user-facing changes?
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.