### PR TITLE
[server] Add option to disable incremental push status update writes to Zookeeper or PS3 (push status system store)

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/helix/HelixParticipationService.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/helix/HelixParticipationService.java
@@ -381,7 +381,8 @@ public class HelixParticipationService extends AbstractVeniceService
           partitionPushStatusAccessor,
           statusStoreWriter,
           helixReadOnlyStoreRepository,
-          instance.getNodeId());
+          instance.getNodeId(),
+          veniceServerConfig.getIncrementalPushStatusWriteMode());
 
       ingestionBackend.getStoreIngestionService().addIngestionNotifier(pushStatusNotifier);
 

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/notifier/PushStatusNotifier.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/notifier/PushStatusNotifier.java
@@ -151,15 +151,21 @@ public class PushStatusNotifier implements VeniceNotifier {
       long offset,
       List<String> pendingReportIncPushVersionList) {
 
-    offLinePushAccessor
-        .batchUpdateReplicaIncPushStatus(topic, partitionId, instanceId, offset, pendingReportIncPushVersionList);
-    // We don't need to report redundant SOIP for these stale inc push versions as they've all received EOIP.
-    for (String incPushVersion: pendingReportIncPushVersionList) {
-      updateIncrementalPushStatusToPushStatusStore(
-          topic,
-          incPushVersion,
-          partitionId,
-          END_OF_INCREMENTAL_PUSH_RECEIVED);
+    if (incrementalPushStatusWriteMode == IncrementalPushStatusWriteMode.ZOOKEEPER_ONLY
+        || incrementalPushStatusWriteMode == IncrementalPushStatusWriteMode.DUAL) {
+      offLinePushAccessor
+          .batchUpdateReplicaIncPushStatus(topic, partitionId, instanceId, offset, pendingReportIncPushVersionList);
+    }
+    if (incrementalPushStatusWriteMode == IncrementalPushStatusWriteMode.PUSH_STATUS_SYSTEM_STORE_ONLY
+        || incrementalPushStatusWriteMode == IncrementalPushStatusWriteMode.DUAL) {
+      // We don't need to report redundant SOIP for these stale inc push versions as they've all received EOIP.
+      for (String incPushVersion: pendingReportIncPushVersionList) {
+        updateIncrementalPushStatusToPushStatusStore(
+            topic,
+            incPushVersion,
+            partitionId,
+            END_OF_INCREMENTAL_PUSH_RECEIVED);
+      }
     }
   }
 

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/notifier/TestPushStatusNotifier.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/notifier/TestPushStatusNotifier.java
@@ -1,10 +1,24 @@
 package com.linkedin.davinci.notifier;
 
+import static com.linkedin.davinci.config.VeniceServerConfig.IncrementalPushStatusWriteMode.DUAL;
+import static com.linkedin.davinci.config.VeniceServerConfig.IncrementalPushStatusWriteMode.PUSH_STATUS_SYSTEM_STORE_ONLY;
+import static com.linkedin.davinci.config.VeniceServerConfig.IncrementalPushStatusWriteMode.ZOOKEEPER_ONLY;
+import static com.linkedin.venice.pushmonitor.ExecutionStatus.END_OF_INCREMENTAL_PUSH_RECEIVED;
+import static com.linkedin.venice.pushmonitor.ExecutionStatus.START_OF_INCREMENTAL_PUSH_RECEIVED;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.anyLong;
+import static org.mockito.Mockito.anyString;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
+import com.linkedin.davinci.config.VeniceServerConfig.IncrementalPushStatusWriteMode;
 import com.linkedin.venice.helix.HelixPartitionStatusAccessor;
 import com.linkedin.venice.meta.ReadOnlyStoreRepository;
 import com.linkedin.venice.meta.Store;
@@ -12,15 +26,38 @@ import com.linkedin.venice.pushmonitor.ExecutionStatus;
 import com.linkedin.venice.pushmonitor.OfflinePushAccessor;
 import com.linkedin.venice.pushstatushelper.PushStatusStoreWriter;
 import org.apache.helix.HelixException;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 
 public class TestPushStatusNotifier {
+  public static final String INSTANCE_ID = "instance1";
+  private OfflinePushAccessor offlinePushAccessor;
+  private HelixPartitionStatusAccessor helixPartitionStatusAccessor;
+  private PushStatusStoreWriter pushStatusStoreWriter;
+  private ReadOnlyStoreRepository storeRepository;
+  private PushStatusNotifier notifier;
+  private static final String STORE_NAME = "test_store";
+  private static final int STORE_VERSION = 1;
+  private static final String TOPIC = "test_store_v1";
+  private static final int PARTITION_ID = 1;
+  private static final long OFFSET = 12345L;
+  private static final String MESSAGE = "Test Message";
+
+  @BeforeMethod
+  public void setUp() {
+    offlinePushAccessor = mock(OfflinePushAccessor.class);
+    helixPartitionStatusAccessor = mock(HelixPartitionStatusAccessor.class);
+    pushStatusStoreWriter = mock(PushStatusStoreWriter.class);
+    storeRepository = mock(ReadOnlyStoreRepository.class);
+    Store store = mock(Store.class);
+    when(store.isDaVinciPushStatusStoreEnabled()).thenReturn(true);
+    when(storeRepository.getStoreOrThrow(any())).thenReturn(store);
+  }
+
   @Test
   public void testCompleteCVUpdate() {
-    OfflinePushAccessor offlinePushAccessor = mock(OfflinePushAccessor.class);
-    HelixPartitionStatusAccessor helixPartitionStatusAccessor = mock(HelixPartitionStatusAccessor.class);
-    PushStatusStoreWriter pushStatusStoreWriter = mock(PushStatusStoreWriter.class);
     ReadOnlyStoreRepository storeRepository = mock(ReadOnlyStoreRepository.class);
     String topic = "abc_v1";
     String host = "localhost";
@@ -30,7 +67,8 @@ public class TestPushStatusNotifier {
         helixPartitionStatusAccessor,
         pushStatusStoreWriter,
         storeRepository,
-        host);
+        host,
+        DUAL);
     statusNotifier.completed(topic, 1, 1, "");
     verify(offlinePushAccessor, times(1)).updateReplicaStatus(topic, 1, host, ExecutionStatus.COMPLETED, 1, "");
 
@@ -49,5 +87,93 @@ public class TestPushStatusNotifier {
     statusNotifier.started(topic, 1, "");
     statusNotifier.endOfPushReceived(topic, 1, 1, "");
     statusNotifier.progress(topic, 1, 1, "");
+  }
+
+  @DataProvider(name = "startOfIncrementalPushCases")
+  public Object[][] startOfIncrementalPushCases() {
+    return new Object[][] { { ZOOKEEPER_ONLY, true, false }, { PUSH_STATUS_SYSTEM_STORE_ONLY, false, true },
+        { DUAL, true, true } };
+  }
+
+  @Test(dataProvider = "startOfIncrementalPushCases")
+  public void testStartOfIncrementalPushReceived(
+      IncrementalPushStatusWriteMode mode,
+      boolean expectZookeeper,
+      boolean expectPushStatusStore) {
+
+    notifier = new PushStatusNotifier(
+        offlinePushAccessor,
+        helixPartitionStatusAccessor,
+        pushStatusStoreWriter,
+        storeRepository,
+        "instance1",
+        mode);
+
+    notifier.startOfIncrementalPushReceived(TOPIC, PARTITION_ID, OFFSET, MESSAGE);
+
+    if (expectZookeeper) {
+      verify(offlinePushAccessor, times(1))
+          .updateReplicaStatus(TOPIC, PARTITION_ID, INSTANCE_ID, START_OF_INCREMENTAL_PUSH_RECEIVED, OFFSET, MESSAGE);
+    } else {
+      verify(offlinePushAccessor, never())
+          .updateReplicaStatus(anyString(), anyInt(), anyString(), any(ExecutionStatus.class), anyLong(), anyString());
+    }
+
+    if (expectPushStatusStore) {
+      verify(pushStatusStoreWriter, times(1)).writePushStatus(
+          eq(STORE_NAME),
+          eq(STORE_VERSION),
+          eq(PARTITION_ID),
+          eq(START_OF_INCREMENTAL_PUSH_RECEIVED),
+          any(),
+          any());
+    } else {
+      verify(pushStatusStoreWriter, never())
+          .writePushStatus(anyString(), anyInt(), anyInt(), any(ExecutionStatus.class), any());
+    }
+  }
+
+  @DataProvider(name = "endOfIncrementalPushCases")
+  public Object[][] endOfIncrementalPushCases() {
+    return new Object[][] { { ZOOKEEPER_ONLY, true, false }, { PUSH_STATUS_SYSTEM_STORE_ONLY, false, true },
+        { DUAL, true, true } };
+  }
+
+  @Test(dataProvider = "endOfIncrementalPushCases")
+  public void testEndOfIncrementalPushReceived(
+      IncrementalPushStatusWriteMode mode,
+      boolean expectZookeeper,
+      boolean expectPushStatusStore) {
+
+    notifier = new PushStatusNotifier(
+        offlinePushAccessor,
+        helixPartitionStatusAccessor,
+        pushStatusStoreWriter,
+        storeRepository,
+        INSTANCE_ID,
+        mode);
+
+    notifier.endOfIncrementalPushReceived(TOPIC, PARTITION_ID, OFFSET, MESSAGE);
+
+    if (expectZookeeper) {
+      verify(offlinePushAccessor, times(1))
+          .updateReplicaStatus(TOPIC, PARTITION_ID, INSTANCE_ID, END_OF_INCREMENTAL_PUSH_RECEIVED, OFFSET, MESSAGE);
+    } else {
+      verify(offlinePushAccessor, never())
+          .updateReplicaStatus(anyString(), anyInt(), anyString(), any(ExecutionStatus.class), anyLong(), anyString());
+    }
+
+    if (expectPushStatusStore) {
+      verify(pushStatusStoreWriter, times(1)).writePushStatus(
+          eq(STORE_NAME),
+          eq(STORE_VERSION),
+          eq(PARTITION_ID),
+          eq(END_OF_INCREMENTAL_PUSH_RECEIVED),
+          any(),
+          any());
+    } else {
+      verify(pushStatusStoreWriter, never())
+          .writePushStatus(anyString(), anyInt(), anyInt(), any(ExecutionStatus.class), any());
+    }
   }
 }

--- a/internal/venice-common/src/main/java/com/linkedin/venice/ConfigKeys.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/ConfigKeys.java
@@ -779,6 +779,11 @@ public class ConfigKeys {
       "server.batch.report.end.of.incremental.push.status.enabled";
 
   /**
+   * This config dictates where the server should write the end of incremental push status.
+   */
+  public static final String SERVER_INCREMENTAL_PUSH_STATUS_WRITE_MODE = "server.incremental.push.status.write.mode";
+
+  /**
    * whether to enable checksum verification in the ingestion path from kafka to database persistency. If enabled it will
    * keep a running checksum for all and only PUT kafka data message received in the ingestion task and periodically
    * verify it against the key/values saved in the database persistency layer.

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/davinci/notifier/LeaderErrorNotifier.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/davinci/notifier/LeaderErrorNotifier.java
@@ -3,6 +3,7 @@ package com.linkedin.davinci.notifier;
 import static com.linkedin.venice.common.VeniceSystemStoreUtils.*;
 import static com.linkedin.venice.pushmonitor.ExecutionStatus.*;
 
+import com.linkedin.davinci.config.VeniceServerConfig;
 import com.linkedin.venice.helix.HelixPartitionStatusAccessor;
 import com.linkedin.venice.meta.ReadOnlyStoreRepository;
 import com.linkedin.venice.pushmonitor.OfflinePushAccessor;
@@ -23,7 +24,13 @@ public class LeaderErrorNotifier extends PushStatusNotifier {
       PushStatusStoreWriter writer,
       ReadOnlyStoreRepository repository,
       String instanceId) {
-    super(accessor, helixPartitionStatusAccessor, writer, repository, instanceId);
+    super(
+        accessor,
+        helixPartitionStatusAccessor,
+        writer,
+        repository,
+        instanceId,
+        VeniceServerConfig.IncrementalPushStatusWriteMode.DUAL);
     this.accessor = accessor;
     this.instanceId = instanceId;
   }

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/PushStatusStoreTest.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/PushStatusStoreTest.java
@@ -5,6 +5,7 @@ import static com.linkedin.venice.ConfigKeys.CLIENT_USE_SYSTEM_STORE_REPOSITORY;
 import static com.linkedin.venice.ConfigKeys.DAVINCI_PUSH_STATUS_SCAN_INTERVAL_IN_SECONDS;
 import static com.linkedin.venice.ConfigKeys.PUSH_STATUS_INSTANCE_NAME_SUFFIX;
 import static com.linkedin.venice.ConfigKeys.PUSH_STATUS_STORE_ENABLED;
+import static com.linkedin.venice.ConfigKeys.SERVER_INCREMENTAL_PUSH_STATUS_WRITE_MODE;
 import static com.linkedin.venice.ConfigKeys.SERVER_PROMOTION_TO_LEADER_REPLICA_DELAY_SECONDS;
 import static com.linkedin.venice.ConfigKeys.USE_PUSH_STATUS_STORE_FOR_INCREMENTAL_PUSH;
 import static com.linkedin.venice.common.PushStatusStoreUtils.SERVER_INCREMENTAL_PUSH_PREFIX;
@@ -22,6 +23,7 @@ import static org.testng.Assert.assertTrue;
 import com.linkedin.d2.balancer.D2Client;
 import com.linkedin.davinci.client.DaVinciClient;
 import com.linkedin.davinci.client.DaVinciConfig;
+import com.linkedin.davinci.config.VeniceServerConfig.IncrementalPushStatusWriteMode;
 import com.linkedin.venice.D2.D2ClientUtils;
 import com.linkedin.venice.client.store.AvroGenericStoreClient;
 import com.linkedin.venice.client.store.ClientConfig;
@@ -37,6 +39,7 @@ import com.linkedin.venice.hadoop.VenicePushJob;
 import com.linkedin.venice.integration.utils.D2TestUtils;
 import com.linkedin.venice.integration.utils.DaVinciTestContext;
 import com.linkedin.venice.integration.utils.ServiceFactory;
+import com.linkedin.venice.integration.utils.VeniceClusterCreateOptions;
 import com.linkedin.venice.integration.utils.VeniceClusterWrapper;
 import com.linkedin.venice.integration.utils.VeniceRouterWrapper;
 import com.linkedin.venice.meta.Store;
@@ -93,10 +96,17 @@ public class PushStatusStoreTest {
     extraProperties.setProperty(SERVER_PROMOTION_TO_LEADER_REPLICA_DELAY_SECONDS, Long.toString(1L));
     // all tests in this class will be reading incremental push status from push status store
     extraProperties.setProperty(USE_PUSH_STATUS_STORE_FOR_INCREMENTAL_PUSH, String.valueOf(true));
+    extraProperties.setProperty(
+        SERVER_INCREMENTAL_PUSH_STATUS_WRITE_MODE,
+        IncrementalPushStatusWriteMode.PUSH_STATUS_SYSTEM_STORE_ONLY.toString());
 
     Utils.thisIsLocalhost();
-    cluster = ServiceFactory
-        .getVeniceCluster(1, NUMBER_OF_SERVERS, 1, REPLICATION_FACTOR, 10000, false, false, extraProperties);
+    cluster = ServiceFactory.getVeniceCluster(
+        new VeniceClusterCreateOptions.Builder().numberOfServers(NUMBER_OF_SERVERS)
+            .replicationFactor(REPLICATION_FACTOR)
+            .partitionSize(10000)
+            .extraProperties(extraProperties)
+            .build());
     controllerClient = cluster.getControllerClient();
     d2Client = D2TestUtils.getAndStartD2Client(cluster.getZk().getAddress());
     reader = new PushStatusStoreReader(

--- a/services/venice-controller/src/main/java/com/linkedin/venice/pushmonitor/AbstractPushMonitor.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/pushmonitor/AbstractPushMonitor.java
@@ -375,6 +375,10 @@ public abstract class AbstractPushMonitor
       PushStatusStoreReader pushStatusStoreReader,
       int numberOfPartitions,
       int replicationFactor) {
+    LOGGER.debug(
+        "Querying incremental push status from PS3 for storeVersion: {}, incrementalPushVersion: {}",
+        kafkaTopic,
+        incrementalPushVersion);
     String storeName = Version.parseStoreFromKafkaTopicName(kafkaTopic);
     int storeVersion = Version.parseVersionFromVersionTopicName(kafkaTopic);
     Map<Integer, Map<CharSequence, Integer>> pushStatusMap =


### PR DESCRIPTION
## Add option to disable incremental push status update writes to Zookeeper or PS3 
Currently, incremental push status updates are written to both Zookeeper and
PS3. As part of a phased approach to eventually discontinue Zookeeper updates,
this PR introduces a configuration option allowing selective control over where
these updates are written, enabling flexibility to disable updates to either
Zookeeper, PS3, or both.


## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->

E2ETest and UTs

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.