### PR TITLE
[controller] Stop writing writing ready-to-serve instances info in meta system store

### DIFF
--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/fastclient/utils/AbstractClientEndToEndSetup.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/fastclient/utils/AbstractClientEndToEndSetup.java
@@ -6,10 +6,6 @@ import static com.linkedin.venice.fastclient.meta.StoreMetadataFetchMode.SERVER_
 import static com.linkedin.venice.fastclient.utils.ClientTestUtils.FASTCLIENT_HTTP_VARIANTS;
 import static com.linkedin.venice.fastclient.utils.ClientTestUtils.REQUEST_TYPES_SMALL;
 import static com.linkedin.venice.fastclient.utils.ClientTestUtils.STORE_METADATA_FETCH_MODES;
-import static com.linkedin.venice.system.store.MetaStoreWriter.KEY_STRING_CLUSTER_NAME;
-import static com.linkedin.venice.system.store.MetaStoreWriter.KEY_STRING_PARTITION_ID;
-import static com.linkedin.venice.system.store.MetaStoreWriter.KEY_STRING_STORE_NAME;
-import static com.linkedin.venice.system.store.MetaStoreWriter.KEY_STRING_VERSION_NUMBER;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNotNull;
@@ -44,9 +40,6 @@ import com.linkedin.venice.read.RequestType;
 import com.linkedin.venice.serialization.VeniceKafkaSerializer;
 import com.linkedin.venice.serialization.avro.AvroProtocolDefinition;
 import com.linkedin.venice.serialization.avro.VeniceAvroKafkaSerializer;
-import com.linkedin.venice.system.store.MetaStoreDataType;
-import com.linkedin.venice.systemstore.schemas.StoreMetaKey;
-import com.linkedin.venice.systemstore.schemas.StoreMetaValue;
 import com.linkedin.venice.utils.DataProviderUtils;
 import com.linkedin.venice.utils.IntegrationTestPushUtils;
 import com.linkedin.venice.utils.SslUtils;
@@ -281,31 +274,6 @@ public abstract class AbstractClientEndToEndSetup {
           30,
           TimeUnit.SECONDS);
     });
-
-    // Verify meta system store received the snapshot writes.
-    try (AvroSpecificStoreClient<StoreMetaKey, StoreMetaValue> metaClient =
-        com.linkedin.venice.client.store.ClientFactory.getAndStartSpecificAvroClient(
-            com.linkedin.venice.client.store.ClientConfig
-                .defaultSpecificClientConfig(metaSystemStoreName, StoreMetaValue.class)
-                .setVeniceURL(veniceCluster.getRandomRouterURL())
-                .setSslFactory(SslUtils.getVeniceLocalSslFactory()))) {
-      StoreMetaKey replicaStatusKey =
-          MetaStoreDataType.STORE_REPLICA_STATUSES.getStoreMetaKey(new HashMap<String, String>() {
-            {
-              put(KEY_STRING_STORE_NAME, storeName);
-              put(KEY_STRING_CLUSTER_NAME, veniceCluster.getClusterName());
-              put(
-                  KEY_STRING_VERSION_NUMBER,
-                  Integer.toString(Version.parseVersionFromVersionTopicName(storeVersionName)));
-              put(KEY_STRING_PARTITION_ID, "0");
-            }
-          });
-      TestUtils.waitForNonDeterministicAssertion(
-          30,
-          TimeUnit.SECONDS,
-          true,
-          () -> assertNotNull(metaClient.get(replicaStatusKey).get()));
-    }
   }
 
   private void waitForRouterD2() {

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceHelixAdmin.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceHelixAdmin.java
@@ -7964,6 +7964,9 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
       return;
     }
     for (Version version: versions) {
+      if (version.getStatus() == ERROR) {
+        continue;
+      }
       int versionNumber = version.getNumber();
       String topic = Version.composeKafkaTopic(regularStoreName, versionNumber);
       int partitionCount = version.getPartitionCount();

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceHelixAdmin.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceHelixAdmin.java
@@ -7958,44 +7958,6 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
         "Wrote value schemas to meta system store for venice store: {} in cluster: {}",
         regularStoreName,
         clusterName);
-    // replica status for all the available versions
-    List<Version> versions = store.getVersions();
-    if (versions.isEmpty()) {
-      return;
-    }
-    for (Version version: versions) {
-      if (version.getStatus() == ERROR) {
-        continue;
-      }
-      int versionNumber = version.getNumber();
-      String topic = Version.composeKafkaTopic(regularStoreName, versionNumber);
-      int partitionCount = version.getPartitionCount();
-      HelixCustomizedViewOfflinePushRepository customizedViewOfflinePushRepository =
-          getHelixVeniceClusterResources(clusterName).getCustomizedViewRepository();
-      for (int curPartitionId = 0; curPartitionId < partitionCount; ++curPartitionId) {
-        List<Instance> readyToServeInstances =
-            customizedViewOfflinePushRepository.getReadyToServeInstances(topic, curPartitionId);
-        metaStoreWriter.get()
-            .writeReadyToServerStoreReplicas(
-                clusterName,
-                regularStoreName,
-                versionNumber,
-                curPartitionId,
-                readyToServeInstances);
-        LOGGER.info(
-            "Wrote the following ready-to-serve instance: {} for store: {}, version: {}, partition id: {} in cluster: {}",
-            readyToServeInstances.toString(),
-            regularStoreName,
-            versionNumber,
-            curPartitionId,
-            clusterName);
-      }
-      LOGGER.info(
-          "Wrote replica status snapshot for version: {} to meta system store for venice store: {} in cluster: {}",
-          versionNumber,
-          regularStoreName,
-          clusterName);
-    }
   }
 
   private boolean isAmplificationFactorUpdateOnly(


### PR DESCRIPTION
##  Stop writing writing ready-to-serve instances info in meta system store

When materializing the meta store, we produce a snapshot of
readyToServeInstances for all user store versions. If a version is in an ERROR
state, its Helix resources may not exist. Attempting to check these resources
can throw exceptions, potentially causing the addVersion process to fail. 

The info about RTS instances in meta store was required in the past but it is no  
longer used by any clients so it's safe to stop writing this into meta system store.


## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.