### PR TITLE
[server] Add ability to configure Helix InstanceOperation to UNKNOWN

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/config/VeniceServerConfig.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/config/VeniceServerConfig.java
@@ -1104,7 +1104,7 @@ public class VeniceServerConfig extends VeniceClusterConfig {
     return nettyWorkerThreadCount;
   }
 
-  public boolean getHelixJoinAsUnknown() {
+  public boolean isHelixJoinAsUnknownEnabled() {
     return helixJoinAsUnknown;
   }
 

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/config/VeniceServerConfig.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/config/VeniceServerConfig.java
@@ -84,6 +84,7 @@ import static com.linkedin.venice.ConfigKeys.SERVER_ENABLE_LIVE_CONFIG_BASED_KAF
 import static com.linkedin.venice.ConfigKeys.SERVER_ENABLE_PARALLEL_BATCH_GET;
 import static com.linkedin.venice.ConfigKeys.SERVER_FORKED_PROCESS_JVM_ARGUMENT_LIST;
 import static com.linkedin.venice.ConfigKeys.SERVER_GLOBAL_RT_DIV_ENABLED;
+import static com.linkedin.venice.ConfigKeys.SERVER_HELIX_JOIN_AS_UNKNOWN;
 import static com.linkedin.venice.ConfigKeys.SERVER_HTTP2_HEADER_TABLE_SIZE;
 import static com.linkedin.venice.ConfigKeys.SERVER_HTTP2_INBOUND_ENABLED;
 import static com.linkedin.venice.ConfigKeys.SERVER_HTTP2_INITIAL_WINDOW_SIZE;
@@ -338,6 +339,7 @@ public class VeniceServerConfig extends VeniceClusterConfig {
    * number of worker threads for the netty listener.  If not specified, netty uses twice cpu count.
    */
   private final int nettyWorkerThreadCount;
+  private final boolean helixJoinAsUnknown;
   private final int grpcWorkerThreadCount;
 
   private final long databaseSyncBytesIntervalForTransactionalMode;
@@ -618,6 +620,7 @@ public class VeniceServerConfig extends VeniceClusterConfig {
         .getInt(PUBSUB_TOPIC_MANAGER_METADATA_FETCHER_THREAD_POOL_SIZE, topicManagerMetadataFetcherConsumerPoolSize);
     nettyGracefulShutdownPeriodSeconds = serverProperties.getInt(SERVER_NETTY_GRACEFUL_SHUTDOWN_PERIOD_SECONDS, 30);
     nettyWorkerThreadCount = serverProperties.getInt(SERVER_NETTY_WORKER_THREADS, 0);
+    helixJoinAsUnknown = serverProperties.getBoolean(SERVER_HELIX_JOIN_AS_UNKNOWN, false);
     grpcWorkerThreadCount =
         serverProperties.getInt(GRPC_SERVER_WORKER_THREAD_COUNT, Runtime.getRuntime().availableProcessors());
 
@@ -1099,6 +1102,10 @@ public class VeniceServerConfig extends VeniceClusterConfig {
 
   public int getNettyWorkerThreadCount() {
     return nettyWorkerThreadCount;
+  }
+
+  public boolean getHelixJoinAsUnknown() {
+    return helixJoinAsUnknown;
   }
 
   public int getGrpcWorkerThreadCount() {

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/helix/HelixParticipationService.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/helix/HelixParticipationService.java
@@ -162,15 +162,13 @@ public class HelixParticipationService extends AbstractVeniceService
   }
 
   public HelixManagerProperty buildHelixManagerProperty(VeniceServerConfig config) {
-    InstanceConstants.InstanceOperation instanceOperation;
-    if (config.getHelixJoinAsUnknown()) {
-      instanceOperation = InstanceConstants.InstanceOperation.UNKNOWN;
-    } else {
-      instanceOperation = InstanceConstants.InstanceOperation.ENABLE;
-    }
     InstanceConfig.Builder defaultInstanceConfigBuilder =
-        new InstanceConfig.Builder().setInstanceOperation(instanceOperation)
-            .setPort(Integer.toString(config.getListenerPort()));
+        new InstanceConfig.Builder().setPort(Integer.toString(config.getListenerPort()));
+
+    if (config.getHelixJoinAsUnknown()) {
+      defaultInstanceConfigBuilder.setInstanceOperation(InstanceConstants.InstanceOperation.UNKNOWN);
+    }
+
     return new HelixManagerProperty.Builder().setDefaultInstanceConfigBuilder(defaultInstanceConfigBuilder).build();
   }
 

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/helix/HelixParticipationService.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/helix/HelixParticipationService.java
@@ -161,10 +161,7 @@ public class HelixParticipationService extends AbstractVeniceService
     return helixStateTransitionThreadPool;
   }
 
-  @Override
-  public boolean startInner() {
-    LOGGER.info("Attempting to start HelixParticipation service");
-    VeniceServerConfig config = veniceConfigLoader.getVeniceServerConfig();
+  public HelixManagerProperty buildHelixManagerProperty(VeniceServerConfig config) {
     InstanceConstants.InstanceOperation instanceOperation;
     if (config.getHelixJoinAsUnknown()) {
       instanceOperation = InstanceConstants.InstanceOperation.UNKNOWN;
@@ -174,8 +171,14 @@ public class HelixParticipationService extends AbstractVeniceService
     InstanceConfig.Builder defaultInstanceConfigBuilder =
         new InstanceConfig.Builder().setInstanceOperation(instanceOperation)
             .setPort(Integer.toString(config.getListenerPort()));
-    HelixManagerProperty helixManagerProperty =
-        new HelixManagerProperty.Builder().setDefaultInstanceConfigBuilder(defaultInstanceConfigBuilder).build();
+    return new HelixManagerProperty.Builder().setDefaultInstanceConfigBuilder(defaultInstanceConfigBuilder).build();
+  }
+
+  @Override
+  public boolean startInner() {
+    LOGGER.info("Attempting to start HelixParticipation service");
+    VeniceServerConfig config = veniceConfigLoader.getVeniceServerConfig();
+    HelixManagerProperty helixManagerProperty = buildHelixManagerProperty(config);
     helixManager = new SafeHelixManager(
         new ZKHelixManager(
             clusterName,

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/helix/HelixParticipationService.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/helix/HelixParticipationService.java
@@ -165,6 +165,9 @@ public class HelixParticipationService extends AbstractVeniceService
     InstanceConfig.Builder defaultInstanceConfigBuilder =
         new InstanceConfig.Builder().setPort(Integer.toString(config.getListenerPort()));
 
+    // For a participant to auto-register with Helix without causing a rebalance everytime a new participant joins
+    // the cluster (i.e. during deployment), we need to set the instance operation to UNKNOWN. Then these participants
+    // would be ENABLED in a batch, so it only rebalances once.
     if (config.getHelixJoinAsUnknown()) {
       defaultInstanceConfigBuilder.setInstanceOperation(InstanceConstants.InstanceOperation.UNKNOWN);
     }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/helix/HelixParticipationService.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/helix/HelixParticipationService.java
@@ -168,7 +168,7 @@ public class HelixParticipationService extends AbstractVeniceService
     // For a participant to auto-register with Helix without causing a rebalance everytime a new participant joins
     // the cluster (i.e. during deployment), we need to set the instance operation to UNKNOWN. Then these participants
     // would be ENABLED in a batch, so it only rebalances once.
-    if (config.getHelixJoinAsUnknown()) {
+    if (config.isHelixJoinAsUnknownEnabled()) {
       defaultInstanceConfigBuilder.setInstanceOperation(InstanceConstants.InstanceOperation.UNKNOWN);
     }
 

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/helix/HelixParticipationServiceTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/helix/HelixParticipationServiceTest.java
@@ -1,9 +1,12 @@
 package com.linkedin.davinci.helix;
 
+import static org.mockito.Mockito.doCallRealMethod;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
+import com.linkedin.davinci.config.VeniceServerConfig;
 import com.linkedin.davinci.storage.StorageService;
 import com.linkedin.venice.helix.HelixPartitionStatusAccessor;
 import java.util.Arrays;
@@ -39,5 +42,16 @@ public class HelixParticipationServiceTest {
     verify(mockAccessor).deleteReplicaStatus(resourceV2, 1);
     verify(mockAccessor).deleteReplicaStatus(resourceV2, 2);
     verify(mockAccessor).deleteReplicaStatus(resourceV2, 3);
+  }
+
+  @Test
+  public void testUnknownHelixInstanceOperation() {
+    HelixParticipationService mockHelixParticipationService = mock(HelixParticipationService.class);
+    VeniceServerConfig mockServerConfig = mock(VeniceServerConfig.class);
+
+    when(mockServerConfig.getHelixJoinAsUnknown()).thenReturn(true);
+
+    doCallRealMethod().when(mockHelixParticipationService).buildHelixManagerProperty(mockServerConfig);
+    mockHelixParticipationService.buildHelixManagerProperty(mockServerConfig);
   }
 }

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/helix/HelixParticipationServiceTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/helix/HelixParticipationServiceTest.java
@@ -49,7 +49,7 @@ public class HelixParticipationServiceTest {
     HelixParticipationService mockHelixParticipationService = mock(HelixParticipationService.class);
     VeniceServerConfig mockServerConfig = mock(VeniceServerConfig.class);
 
-    when(mockServerConfig.getHelixJoinAsUnknown()).thenReturn(true);
+    when(mockServerConfig.isHelixJoinAsUnknownEnabled()).thenReturn(true);
 
     doCallRealMethod().when(mockHelixParticipationService).buildHelixManagerProperty(mockServerConfig);
     mockHelixParticipationService.buildHelixManagerProperty(mockServerConfig);

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/helix/HelixParticipationServiceTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/helix/HelixParticipationServiceTest.java
@@ -1,8 +1,9 @@
 package com.linkedin.davinci.helix;
 
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 
-import com.linkedin.davinci.config.VeniceServerConfig;
 import com.linkedin.davinci.storage.StorageService;
 import com.linkedin.venice.helix.HelixPartitionStatusAccessor;
 import java.util.Arrays;
@@ -38,16 +39,5 @@ public class HelixParticipationServiceTest {
     verify(mockAccessor).deleteReplicaStatus(resourceV2, 1);
     verify(mockAccessor).deleteReplicaStatus(resourceV2, 2);
     verify(mockAccessor).deleteReplicaStatus(resourceV2, 3);
-  }
-
-  @Test
-  public void testUnknownHelixInstanceOperation() {
-    HelixParticipationService mockHelixParticipationService = mock(HelixParticipationService.class);
-    VeniceServerConfig mockServerConfig = mock(VeniceServerConfig.class);
-
-    when(mockServerConfig.getHelixJoinAsUnknown()).thenReturn(true);
-
-    doCallRealMethod().when(mockHelixParticipationService).buildHelixManagerProperty(mockServerConfig);
-    mockHelixParticipationService.buildHelixManagerProperty(mockServerConfig);
   }
 }

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/helix/HelixParticipationServiceTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/helix/HelixParticipationServiceTest.java
@@ -1,9 +1,8 @@
 package com.linkedin.davinci.helix;
 
-import static org.mockito.Mockito.doReturn;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.*;
 
+import com.linkedin.davinci.config.VeniceServerConfig;
 import com.linkedin.davinci.storage.StorageService;
 import com.linkedin.venice.helix.HelixPartitionStatusAccessor;
 import java.util.Arrays;
@@ -39,5 +38,16 @@ public class HelixParticipationServiceTest {
     verify(mockAccessor).deleteReplicaStatus(resourceV2, 1);
     verify(mockAccessor).deleteReplicaStatus(resourceV2, 2);
     verify(mockAccessor).deleteReplicaStatus(resourceV2, 3);
+  }
+
+  @Test
+  public void testUnknownHelixInstanceOperation() {
+    HelixParticipationService mockHelixParticipationService = mock(HelixParticipationService.class);
+    VeniceServerConfig mockServerConfig = mock(VeniceServerConfig.class);
+
+    when(mockServerConfig.getHelixJoinAsUnknown()).thenReturn(true);
+
+    doCallRealMethod().when(mockHelixParticipationService).buildHelixManagerProperty(mockServerConfig);
+    mockHelixParticipationService.buildHelixManagerProperty(mockServerConfig);
   }
 }

--- a/internal/venice-common/src/main/java/com/linkedin/venice/ConfigKeys.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/ConfigKeys.java
@@ -452,6 +452,10 @@ public class ConfigKeys {
   public static final String SERVER_NETTY_GRACEFUL_SHUTDOWN_PERIOD_SECONDS =
       "server.netty.graceful.shutdown.period.seconds";
   public static final String SERVER_NETTY_WORKER_THREADS = "server.netty.worker.threads";
+  /**
+   * Whether to join a Helix cluster in an UNKNOWN state
+   */
+  public static final String SERVER_HELIX_JOIN_AS_UNKNOWN = "server.helix.join.as.unknown";
 
   /**
    * This config key is a misspelling. It is now considered deprecated.

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/server/VeniceServerTest.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/server/VeniceServerTest.java
@@ -1,6 +1,7 @@
 package com.linkedin.venice.server;
 
 import static com.linkedin.venice.ConfigKeys.CONTROLLER_ZK_SHARED_META_SYSTEM_SCHEMA_STORE_AUTO_CREATION_ENABLED;
+import static com.linkedin.venice.ConfigKeys.SERVER_HELIX_JOIN_AS_UNKNOWN;
 import static com.linkedin.venice.integration.utils.VeniceServerWrapper.SERVER_ENABLE_SERVER_ALLOW_LIST;
 import static com.linkedin.venice.integration.utils.VeniceServerWrapper.SERVER_IS_AUTO_JOIN;
 
@@ -336,6 +337,15 @@ public class VeniceServerTest {
         Assert.assertNotNull(schemaResponse.getSchemas());
         Assert.assertEquals(schemaResponse.getSchemas().length, currentProtocolVersion * 2);
       });
+    }
+  }
+
+  @Test
+  public void testHelixUnknownInstanceOperation() {
+    try (VeniceClusterWrapper cluster = ServiceFactory.getVeniceCluster(1, 0, 0)) {
+      Properties properties = new Properties();
+      properties.put(SERVER_HELIX_JOIN_AS_UNKNOWN, true);
+      cluster.addVeniceServer(new Properties(), properties);
     }
   }
 }

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/server/VeniceServerTest.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/server/VeniceServerTest.java
@@ -1,7 +1,6 @@
 package com.linkedin.venice.server;
 
 import static com.linkedin.venice.ConfigKeys.CONTROLLER_ZK_SHARED_META_SYSTEM_SCHEMA_STORE_AUTO_CREATION_ENABLED;
-import static com.linkedin.venice.ConfigKeys.SERVER_HELIX_JOIN_AS_UNKNOWN;
 import static com.linkedin.venice.integration.utils.VeniceServerWrapper.SERVER_ENABLE_SERVER_ALLOW_LIST;
 import static com.linkedin.venice.integration.utils.VeniceServerWrapper.SERVER_IS_AUTO_JOIN;
 
@@ -337,15 +336,6 @@ public class VeniceServerTest {
         Assert.assertNotNull(schemaResponse.getSchemas());
         Assert.assertEquals(schemaResponse.getSchemas().length, currentProtocolVersion * 2);
       });
-    }
-  }
-
-  @Test
-  public void testHelixUnknownInstanceOperation() {
-    try (VeniceClusterWrapper cluster = ServiceFactory.getVeniceCluster(1, 0, 0)) {
-      Properties properties = new Properties();
-      properties.put(SERVER_HELIX_JOIN_AS_UNKNOWN, true);
-      cluster.addVeniceServer(new Properties(), properties);
     }
   }
 }


### PR DESCRIPTION
<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## Summary, imperative, start upper case, don't end with a period
<!--
Describe
- What changes to make and why you are making these changes.
- How are you going to achieve your goal.
- Describe what testings you have done, for example, performance testing etc.

If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->
For a participant to auto-register with Helix without causing a rebalance every time a new participant joins the cluster (i.e. during deployment), we need to set the instance operation to UNKNOWN. Then these participants would be ENABLED in a batch, so it only rebalances once.

## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
Added unit and integration tests.

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [X] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.