### PR TITLE
[controller] Fix bug where setting the cloud config was only done on the controller cluster, not on storage clusters

### DIFF
--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/ZkHelixAdminClient.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/ZkHelixAdminClient.java
@@ -103,7 +103,7 @@ public class ZkHelixAdminClient implements HelixAdminClient {
         helixAdmin.addStateModelDef(controllerClusterName, LeaderStandbySMD.name, LeaderStandbySMD.build());
 
         if (commonConfig.isControllerClusterHelixCloudEnabled()) {
-          setCloudConfig(commonConfig);
+          setCloudConfig(controllerClusterName, commonConfig);
         }
       }
       return true;
@@ -130,7 +130,7 @@ public class ZkHelixAdminClient implements HelixAdminClient {
 
         VeniceControllerClusterConfig config = multiClusterConfigs.getControllerConfig(clusterName);
         if (config.isStorageClusterHelixCloudEnabled()) {
-          setCloudConfig(config);
+          setCloudConfig(clusterName, config);
         }
       }
       return true;
@@ -327,7 +327,7 @@ public class ZkHelixAdminClient implements HelixAdminClient {
     helixAdmin.addInstanceTag(clusterName, instanceName, tag);
   }
 
-  public void setCloudConfig(VeniceControllerClusterConfig config) {
+  public void setCloudConfig(String clusterName, VeniceControllerClusterConfig config) {
     String cloudId = config.getHelixCloudId();
     List<String> cloudInfoSources = config.getHelixCloudInfoSources();
     String cloudInfoProcessorName = config.getHelixCloudInfoProcessorName();
@@ -345,6 +345,6 @@ public class ZkHelixAdminClient implements HelixAdminClient {
     if (!cloudInfoProcessorName.isEmpty()) {
       cloudConfigBuilder.setCloudInfoProcessorName(cloudInfoProcessorName);
     }
-    helixAdmin.addCloudConfig(controllerClusterName, cloudConfigBuilder.build());
+    helixAdmin.addCloudConfig(clusterName, cloudConfigBuilder.build());
   }
 }

--- a/services/venice-controller/src/test/java/com/linkedin/venice/controller/TestZkHelixAdminClient.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/controller/TestZkHelixAdminClient.java
@@ -28,7 +28,7 @@ public class TestZkHelixAdminClient {
   private VeniceControllerMultiClusterConfig mockMultiClusterConfigs;
   private VeniceControllerClusterConfig mockClusterConfig;
 
-  private final String controllerClusterName = "venice-controllers";
+  private static final String controllerClusterName = "venice-controllers";
 
   @BeforeMethod
   public void setUp() throws NoSuchFieldException, IllegalAccessException {

--- a/services/venice-controller/src/test/java/com/linkedin/venice/controller/TestZkHelixAdminClient.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/controller/TestZkHelixAdminClient.java
@@ -28,6 +28,8 @@ public class TestZkHelixAdminClient {
   private VeniceControllerMultiClusterConfig mockMultiClusterConfigs;
   private VeniceControllerClusterConfig mockClusterConfig;
 
+  private final String controllerClusterName = "venice-controllers";
+
   @BeforeMethod
   public void setUp() throws NoSuchFieldException, IllegalAccessException {
     zkHelixAdminClient = mock(ZkHelixAdminClient.class);
@@ -78,8 +80,8 @@ public class TestZkHelixAdminClient {
     when(mockClusterConfig.getHelixCloudInfoSources()).thenReturn(cloudInfoSources);
     when(mockClusterConfig.getHelixCloudInfoProcessorName()).thenReturn("TestProcessor");
 
-    doCallRealMethod().when(zkHelixAdminClient).setCloudConfig(mockClusterConfig);
-    zkHelixAdminClient.setCloudConfig(mockClusterConfig);
+    doCallRealMethod().when(zkHelixAdminClient).setCloudConfig(controllerClusterName, mockClusterConfig);
+    zkHelixAdminClient.setCloudConfig(controllerClusterName, mockClusterConfig);
 
     verify(mockHelixAdmin).addCloudConfig(any(), any());
   }
@@ -92,8 +94,10 @@ public class TestZkHelixAdminClient {
     when(mockClusterConfig.getHelixCloudInfoSources()).thenReturn(Collections.emptyList());
     when(mockClusterConfig.getHelixCloudInfoProcessorName()).thenReturn("TestProcessor");
 
-    doCallRealMethod().when(zkHelixAdminClient).setCloudConfig(mockClusterConfig);
-    assertThrows(HelixException.class, () -> zkHelixAdminClient.setCloudConfig(mockClusterConfig));
+    doCallRealMethod().when(zkHelixAdminClient).setCloudConfig(controllerClusterName, mockClusterConfig);
+    assertThrows(
+        HelixException.class,
+        () -> zkHelixAdminClient.setCloudConfig(controllerClusterName, mockClusterConfig));
   }
 
   @Test
@@ -107,7 +111,9 @@ public class TestZkHelixAdminClient {
     when(mockClusterConfig.getHelixCloudInfoSources()).thenReturn(cloudInfoSources);
     when(mockClusterConfig.getHelixCloudInfoProcessorName()).thenReturn("");
 
-    doCallRealMethod().when(zkHelixAdminClient).setCloudConfig(mockClusterConfig);
-    assertThrows(HelixException.class, () -> zkHelixAdminClient.setCloudConfig(mockClusterConfig));
+    doCallRealMethod().when(zkHelixAdminClient).setCloudConfig(controllerClusterName, mockClusterConfig);
+    assertThrows(
+        HelixException.class,
+        () -> zkHelixAdminClient.setCloudConfig(controllerClusterName, mockClusterConfig));
   }
 }


### PR DESCRIPTION
<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## Summary, imperative, start upper case, don't end with a period
<!--
Describe
- What changes to make and why you are making these changes.
- How are you going to achieve your goal.
- Describe what testings you have done, for example, performance testing etc.

If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->
Fix bug where setting the cloud config was only done on the controller cluster, not on storage clusters. This was done by adding `clusterName` to the method signature of `setCloudConfig`.


## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
CI

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [X] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.