### PR TITLE
[test] Make sure meta store ready before DVC memory limiter test

### DIFF
--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/DaVinciClientMemoryLimitTest.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/DaVinciClientMemoryLimitTest.java
@@ -47,7 +47,6 @@ import com.linkedin.venice.controllerapi.ControllerResponse;
 import com.linkedin.venice.controllerapi.NewStoreResponse;
 import com.linkedin.venice.controllerapi.StoreResponse;
 import com.linkedin.venice.controllerapi.UpdateStoreQueryParams;
-import com.linkedin.venice.controllerapi.VersionCreationResponse;
 import com.linkedin.venice.exceptions.VeniceException;
 import com.linkedin.venice.integration.utils.ServiceFactory;
 import com.linkedin.venice.integration.utils.VeniceClusterWrapper;
@@ -591,14 +590,8 @@ public class DaVinciClientMemoryLimitTest {
   private void prepareMetaSystemStore(String storeName) throws Exception {
     final String metaSystemStoreName = VeniceSystemStoreType.META_STORE.getSystemStoreName(storeName);
     veniceCluster.useControllerClient(controllerClient -> {
-      VersionCreationResponse metaSystemStoreVersionCreationResponse =
-          controllerClient.emptyPush(metaSystemStoreName, "test_bootstrap_meta_system_store", 10000);
-      assertFalse(
-          metaSystemStoreVersionCreationResponse.isError(),
-          "New version creation for meta system store failed with error: "
-              + metaSystemStoreVersionCreationResponse.getError());
       TestUtils.waitForNonDeterministicPushCompletion(
-          metaSystemStoreVersionCreationResponse.getKafkaTopic(),
+          Version.composeKafkaTopic(metaSystemStoreName, 1),
           controllerClient,
           30,
           TimeUnit.SECONDS);

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/DaVinciClientMemoryLimitTest.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/DaVinciClientMemoryLimitTest.java
@@ -142,7 +142,7 @@ public class DaVinciClientMemoryLimitTest {
     return venicePropertyBuilder.build();
   }
 
-  @Test(timeOut = TEST_TIMEOUT, dataProviderClass = DataProviderUtils.class, dataProvider = "Two-True-and-False")
+  @Test(timeOut = TEST_TIMEOUT, invocationCount = 20, dataProviderClass = DataProviderUtils.class, dataProvider = "Two-True-and-False")
   public void testDaVinciMemoryLimitShouldFailLargeDataPush(
       boolean ingestionIsolationEnabledInDaVinci,
       boolean useDaVinciSpecificExecutionStatusForError) throws Exception {
@@ -587,7 +587,7 @@ public class DaVinciClientMemoryLimitTest {
     }
   }
 
-  private void prepareMetaSystemStore(String storeName) throws Exception {
+  private void prepareMetaSystemStore(String storeName) {
     final String metaSystemStoreName = VeniceSystemStoreType.META_STORE.getSystemStoreName(storeName);
     veniceCluster.useControllerClient(controllerClient -> {
       TestUtils.waitForNonDeterministicPushCompletion(

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/DaVinciClientMemoryLimitTest.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/DaVinciClientMemoryLimitTest.java
@@ -41,11 +41,13 @@ import com.linkedin.venice.D2.D2ClientUtils;
 import com.linkedin.venice.client.store.AvroGenericStoreClient;
 import com.linkedin.venice.client.store.ClientConfig;
 import com.linkedin.venice.client.store.ClientFactory;
+import com.linkedin.venice.common.VeniceSystemStoreType;
 import com.linkedin.venice.controllerapi.ControllerClient;
 import com.linkedin.venice.controllerapi.ControllerResponse;
 import com.linkedin.venice.controllerapi.NewStoreResponse;
 import com.linkedin.venice.controllerapi.StoreResponse;
 import com.linkedin.venice.controllerapi.UpdateStoreQueryParams;
+import com.linkedin.venice.controllerapi.VersionCreationResponse;
 import com.linkedin.venice.exceptions.VeniceException;
 import com.linkedin.venice.integration.utils.ServiceFactory;
 import com.linkedin.venice.integration.utils.VeniceClusterWrapper;
@@ -76,7 +78,7 @@ import org.testng.annotations.Test;
 
 public class DaVinciClientMemoryLimitTest {
   private static final int TEST_TIMEOUT = 180_000;
-  private VeniceClusterWrapper venice;
+  private VeniceClusterWrapper veniceCluster;
   private D2Client d2Client;
 
   @BeforeClass
@@ -86,8 +88,8 @@ public class DaVinciClientMemoryLimitTest {
     clusterConfig.put(SERVER_PROMOTION_TO_LEADER_REPLICA_DELAY_SECONDS, 10L);
     // To allow more times for DaVinci clients to report status
     clusterConfig.put(DAVINCI_PUSH_STATUS_SCAN_NO_REPORT_RETRY_MAX_ATTEMPTS, 15);
-    venice = ServiceFactory.getVeniceCluster(1, 2, 1, 1, 100, false, false, clusterConfig);
-    d2Client = new D2ClientBuilder().setZkHosts(venice.getZk().getAddress())
+    veniceCluster = ServiceFactory.getVeniceCluster(1, 2, 1, 1, 100, false, false, clusterConfig);
+    d2Client = new D2ClientBuilder().setZkHosts(veniceCluster.getZk().getAddress())
         .setZkSessionTimeout(3, TimeUnit.SECONDS)
         .setZkStartupTimeout(3, TimeUnit.SECONDS)
         .build();
@@ -99,7 +101,7 @@ public class DaVinciClientMemoryLimitTest {
     if (d2Client != null) {
       D2ClientUtils.shutdownClient(d2Client);
     }
-    Utils.closeQuietlyWithErrorLogged(venice);
+    Utils.closeQuietlyWithErrorLogged(veniceCluster);
   }
 
   private VeniceProperties getDaVinciBackendConfig(
@@ -122,7 +124,7 @@ public class DaVinciClientMemoryLimitTest {
         .put(DATA_BASE_PATH, baseDataPath)
         .put(PERSISTENCE_TYPE, ROCKS_DB)
         .put(PUSH_STATUS_STORE_ENABLED, true)
-        .put(D2_ZK_HOSTS_ADDRESS, venice.getZk().getAddress())
+        .put(D2_ZK_HOSTS_ADDRESS, veniceCluster.getZk().getAddress())
         .put(CLUSTER_DISCOVERY_D2_SERVICE, VeniceRouterWrapper.CLUSTER_DISCOVERY_D2_SERVICE_NAME)
         .put(ROCKSDB_MEMTABLE_SIZE_IN_BYTES, "2MB")
         .put(ROCKSDB_TOTAL_MEMTABLE_USAGE_CAP_IN_BYTES, "10MB")
@@ -150,21 +152,23 @@ public class DaVinciClientMemoryLimitTest {
     File inputDir = getTempDataDirectory();
     String inputDirPath = "file://" + inputDir.getAbsolutePath();
     Schema recordSchema = TestWriteUtils.writeSimpleAvroFileWithStringToStringSchema(inputDir, 100, 100);
-    Properties vpjProperties = defaultVPJProps(venice, inputDirPath, storeName);
+    Properties vpjProperties = defaultVPJProps(veniceCluster, inputDirPath, storeName);
 
     String storeNameWithoutMemoryEnforcement = Utils.getUniqueString("store_without_memory_enforcement");
 
-    try (ControllerClient controllerClient = createStoreForJob(venice.getClusterName(), recordSchema, vpjProperties);
+    try (
+        ControllerClient controllerClient =
+            createStoreForJob(veniceCluster.getClusterName(), recordSchema, vpjProperties);
         AvroGenericStoreClient client = ClientFactory.getAndStartGenericAvroClient(
-            ClientConfig.defaultGenericClientConfig(storeName).setVeniceURL(venice.getRandomRouterURL()))) {
-      venice.createMetaSystemStore(storeName);
-      venice.createPushStatusSystemStore(storeName);
+            ClientConfig.defaultGenericClientConfig(storeName).setVeniceURL(veniceCluster.getRandomRouterURL()))) {
+      veniceCluster.createMetaSystemStore(storeName);
+      veniceCluster.createPushStatusSystemStore(storeName);
 
       // Make sure DaVinci push status system store is enabled
       StoreResponse storeResponse = controllerClient.getStore(storeName);
       assertFalse(storeResponse.isError(), "Store response receives an error: " + storeResponse.getError());
       assertTrue(storeResponse.getStore().isDaVinciPushStatusStoreEnabled());
-
+      prepareMetaSystemStore(storeName);
       // Do an VPJ push
       runVPJ(vpjProperties, 1, controllerClient);
 
@@ -210,7 +214,7 @@ public class DaVinciClientMemoryLimitTest {
         inputDir = getTempDataDirectory();
         inputDirPath = "file://" + inputDir.getAbsolutePath();
         TestWriteUtils.writeSimpleAvroFileWithStringToStringSchema(inputDir, 1000, 100000);
-        final Properties vpjPropertiesForV2 = defaultVPJProps(venice, inputDirPath, storeName);
+        final Properties vpjPropertiesForV2 = defaultVPJProps(veniceCluster, inputDirPath, storeName);
 
         VeniceException exception =
             expectThrows(VeniceException.class, () -> runVPJ(vpjPropertiesForV2, 2, controllerClient));
@@ -227,11 +231,11 @@ public class DaVinciClientMemoryLimitTest {
                         + (useDaVinciSpecificExecutionStatusForError ? " due to memory limit reached" : "")));
 
         // Run a bigger push against a non-enforced store should succeed
-        vpjProperties = defaultVPJProps(venice, inputDirPath, storeNameWithoutMemoryEnforcement);
+        vpjProperties = defaultVPJProps(veniceCluster, inputDirPath, storeNameWithoutMemoryEnforcement);
         try (ControllerClient controllerClient1 =
-            createStoreForJob(venice.getClusterName(), recordSchema, vpjProperties)) {
-          venice.createMetaSystemStore(storeNameWithoutMemoryEnforcement);
-          venice.createPushStatusSystemStore(storeNameWithoutMemoryEnforcement);
+            createStoreForJob(veniceCluster.getClusterName(), recordSchema, vpjProperties)) {
+          veniceCluster.createMetaSystemStore(storeNameWithoutMemoryEnforcement);
+          veniceCluster.createPushStatusSystemStore(storeNameWithoutMemoryEnforcement);
 
           // Make sure DaVinci push status system store is enabled
           storeResponse = controllerClient1.getStore(storeNameWithoutMemoryEnforcement);
@@ -257,6 +261,7 @@ public class DaVinciClientMemoryLimitTest {
     }
   }
 
+  @Test(enabled = false)
   public void testDaVinciMemoryLimitShouldFailLargeDataPushAndResumeHybridStore(
       boolean ingestionIsolationEnabledInDaVinci,
       boolean useDaVinciSpecificExecutionStatusForError) throws Exception {
@@ -265,13 +270,16 @@ public class DaVinciClientMemoryLimitTest {
     File inputDir = getTempDataDirectory();
     String inputDirPath = "file://" + inputDir.getAbsolutePath();
     Schema recordSchema = TestWriteUtils.writeSimpleAvroFileWithStringToStringSchema(inputDir, 100, 100);
-    Properties vpjProperties = defaultVPJProps(venice, inputDirPath, batchOnlyStoreName);
+    Properties vpjProperties = defaultVPJProps(veniceCluster, inputDirPath, batchOnlyStoreName);
 
-    try (ControllerClient controllerClient = createStoreForJob(venice.getClusterName(), recordSchema, vpjProperties);
+    try (
+        ControllerClient controllerClient =
+            createStoreForJob(veniceCluster.getClusterName(), recordSchema, vpjProperties);
         AvroGenericStoreClient client = ClientFactory.getAndStartGenericAvroClient(
-            ClientConfig.defaultGenericClientConfig(batchOnlyStoreName).setVeniceURL(venice.getRandomRouterURL()))) {
-      venice.createMetaSystemStore(batchOnlyStoreName);
-      venice.createPushStatusSystemStore(batchOnlyStoreName);
+            ClientConfig.defaultGenericClientConfig(batchOnlyStoreName)
+                .setVeniceURL(veniceCluster.getRandomRouterURL()))) {
+      veniceCluster.createMetaSystemStore(batchOnlyStoreName);
+      veniceCluster.createPushStatusSystemStore(batchOnlyStoreName);
 
       // Make sure DaVinci push status system store is enabled
       StoreResponse storeResponseForBatchOnlyStore = controllerClient.getStore(batchOnlyStoreName);
@@ -296,8 +304,8 @@ public class DaVinciClientMemoryLimitTest {
       assertFalse(
           updateStoreResponseForHybridStore.isError(),
           "Received error when converting a hybrid store: " + updateStoreResponseForHybridStore.getError());
-      venice.createMetaSystemStore(hybridStoreName);
-      venice.createPushStatusSystemStore(hybridStoreName);
+      veniceCluster.createMetaSystemStore(hybridStoreName);
+      veniceCluster.createPushStatusSystemStore(hybridStoreName);
 
       ControllerResponse emptyPushForHybridStore =
           controllerClient.sendEmptyPushAndWait(hybridStoreName, "test_hybrid_push_v1", 1024 * 1024 * 100l, 30 * 1000);
@@ -351,7 +359,7 @@ public class DaVinciClientMemoryLimitTest {
         daVinciClientForHybridStore.subscribeAll().get(30, TimeUnit.SECONDS);
 
         // Write some records and verify
-        SystemProducer veniceProducer = getSamzaProducer(venice, hybridStoreName, Version.PushType.STREAM);
+        SystemProducer veniceProducer = getSamzaProducer(veniceCluster, hybridStoreName, Version.PushType.STREAM);
 
         int hybridStoreKeyId = 0;
         for (; hybridStoreKeyId <= 100; ++hybridStoreKeyId) {
@@ -374,7 +382,7 @@ public class DaVinciClientMemoryLimitTest {
         inputDir = getTempDataDirectory();
         inputDirPath = "file://" + inputDir.getAbsolutePath();
         TestWriteUtils.writeSimpleAvroFileWithStringToStringSchema(inputDir, 1000, 100000);
-        final Properties vpjPropertiesForV2 = defaultVPJProps(venice, inputDirPath, batchOnlyStoreName);
+        final Properties vpjPropertiesForV2 = defaultVPJProps(veniceCluster, inputDirPath, batchOnlyStoreName);
 
         VeniceException exception =
             expectThrows(VeniceException.class, () -> runVPJ(vpjPropertiesForV2, 2, controllerClient));
@@ -429,13 +437,16 @@ public class DaVinciClientMemoryLimitTest {
     File inputDir = getTempDataDirectory();
     String inputDirPath = "file://" + inputDir.getAbsolutePath();
     Schema recordSchema = TestWriteUtils.writeSimpleAvroFileWithStringToStringSchema(inputDir, 190, 100000); // ~19MB
-    Properties vpjProperties = defaultVPJProps(venice, inputDirPath, batchOnlyStoreName);
+    Properties vpjProperties = defaultVPJProps(veniceCluster, inputDirPath, batchOnlyStoreName);
 
-    try (ControllerClient controllerClient = createStoreForJob(venice.getClusterName(), recordSchema, vpjProperties);
+    try (
+        ControllerClient controllerClient =
+            createStoreForJob(veniceCluster.getClusterName(), recordSchema, vpjProperties);
         AvroGenericStoreClient client = ClientFactory.getAndStartGenericAvroClient(
-            ClientConfig.defaultGenericClientConfig(batchOnlyStoreName).setVeniceURL(venice.getRandomRouterURL()))) {
-      venice.createMetaSystemStore(batchOnlyStoreName);
-      venice.createPushStatusSystemStore(batchOnlyStoreName);
+            ClientConfig.defaultGenericClientConfig(batchOnlyStoreName)
+                .setVeniceURL(veniceCluster.getRandomRouterURL()))) {
+      veniceCluster.createMetaSystemStore(batchOnlyStoreName);
+      veniceCluster.createPushStatusSystemStore(batchOnlyStoreName);
 
       // Make sure DaVinci push status system store is enabled
       StoreResponse storeResponseForBatchOnlyStore = controllerClient.getStore(batchOnlyStoreName);
@@ -460,8 +471,8 @@ public class DaVinciClientMemoryLimitTest {
       assertFalse(
           updateStoreResponseForHybridStore.isError(),
           "Received error when converting a hybrid store: " + updateStoreResponseForHybridStore.getError());
-      venice.createMetaSystemStore(hybridStoreName);
-      venice.createPushStatusSystemStore(hybridStoreName);
+      veniceCluster.createMetaSystemStore(hybridStoreName);
+      veniceCluster.createPushStatusSystemStore(hybridStoreName);
 
       ControllerResponse emptyPushForHybridStore =
           controllerClient.sendEmptyPushAndWait(hybridStoreName, "test_hybrid_push_v1", 1024 * 1024 * 100l, 30 * 1000);
@@ -514,7 +525,7 @@ public class DaVinciClientMemoryLimitTest {
         daVinciClientForHybridStore.subscribeAll().get(30, TimeUnit.SECONDS);
 
         // Write some large records and verify
-        SystemProducer veniceProducer = getSamzaProducer(venice, hybridStoreName, Version.PushType.STREAM);
+        SystemProducer veniceProducer = getSamzaProducer(veniceCluster, hybridStoreName, Version.PushType.STREAM);
 
         int hybridStoreKeyId = 0;
         for (; hybridStoreKeyId < 100; ++hybridStoreKeyId) {
@@ -575,5 +586,22 @@ public class DaVinciClientMemoryLimitTest {
         controllerClient.disableAndDeleteStore(hybridStoreName);
       }
     }
+  }
+
+  private void prepareMetaSystemStore(String storeName) throws Exception {
+    final String metaSystemStoreName = VeniceSystemStoreType.META_STORE.getSystemStoreName(storeName);
+    veniceCluster.useControllerClient(controllerClient -> {
+      VersionCreationResponse metaSystemStoreVersionCreationResponse =
+          controllerClient.emptyPush(metaSystemStoreName, "test_bootstrap_meta_system_store", 10000);
+      assertFalse(
+          metaSystemStoreVersionCreationResponse.isError(),
+          "New version creation for meta system store failed with error: "
+              + metaSystemStoreVersionCreationResponse.getError());
+      TestUtils.waitForNonDeterministicPushCompletion(
+          metaSystemStoreVersionCreationResponse.getKafkaTopic(),
+          controllerClient,
+          30,
+          TimeUnit.SECONDS);
+    });
   }
 }

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/DaVinciClientMemoryLimitTest.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/DaVinciClientMemoryLimitTest.java
@@ -142,7 +142,7 @@ public class DaVinciClientMemoryLimitTest {
     return venicePropertyBuilder.build();
   }
 
-  @Test(timeOut = TEST_TIMEOUT, invocationCount = 20, dataProviderClass = DataProviderUtils.class, dataProvider = "Two-True-and-False")
+  @Test(timeOut = TEST_TIMEOUT, dataProviderClass = DataProviderUtils.class, dataProvider = "Two-True-and-False")
   public void testDaVinciMemoryLimitShouldFailLargeDataPush(
       boolean ingestionIsolationEnabledInDaVinci,
       boolean useDaVinciSpecificExecutionStatusForError) throws Exception {


### PR DESCRIPTION
<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

##  Make sure meta store ready before DVC memory limiter test
<!--
Describe
- What changes to make and why you are making these changes.
- How are you going to achieve your goal.
- Describe what testings you have done, for example, performance testing etc.

If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

Trying to deflake `testDaVinciMemoryLimitShouldFailLargeDataPush` 
## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.