### PR TITLE
[changelog][dvc] Disable TC internal retry in ThinClientMetaStoreBasedRepository

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/repository/ThinClientMetaStoreBasedRepository.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/repository/ThinClientMetaStoreBasedRepository.java
@@ -112,10 +112,9 @@ public class ThinClientMetaStoreBasedRepository extends NativeMetadataRepository
       ClientConfig<StoreMetaValue> clonedClientConfig = ClientConfig.cloneConfig(clientConfig)
           .setStoreName(VeniceSystemStoreType.META_STORE.getSystemStoreName(storeName))
           .setSpecificValueClass(StoreMetaValue.class)
-          .setRetryOnAllErrors(true)
-          .setRetryCount(THIN_CLIENT_RETRY_COUNT)
-          .setForceClusterDiscoveryAtStartTime(true)
-          .setRetryBackOffInMs(THIN_CLIENT_RETRY_BACKOFF_MS);
+          .setRetryOnRouterError(false)
+          .setRetryOnAllErrors(false)
+          .setForceClusterDiscoveryAtStartTime(true);
       return ClientFactory.getAndStartSpecificAvroClient(clonedClientConfig);
     });
   }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/repository/VeniceMetadataRepositoryBuilder.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/repository/VeniceMetadataRepositoryBuilder.java
@@ -59,6 +59,9 @@ public class VeniceMetadataRepositoryBuilder {
       boolean isIngestionIsolation) {
     this.configLoader = configLoader;
     this.clientConfig = clientConfig;
+    if (clientConfig != null) {
+      clientConfig.setMetricsRepository(metricsRepository);
+    }
     this.metricsRepository = metricsRepository;
     this.isIngestionIsolation = isIngestionIsolation;
     this.icProvider = icProvider;

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/NativeMetadataRepositoryStats.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/NativeMetadataRepositoryStats.java
@@ -1,0 +1,42 @@
+package com.linkedin.davinci.stats;
+
+import com.linkedin.venice.stats.AbstractVeniceStats;
+import com.linkedin.venice.utils.concurrent.VeniceConcurrentHashMap;
+import io.tehuti.metrics.MetricsRepository;
+import io.tehuti.metrics.Sensor;
+import io.tehuti.metrics.stats.AsyncGauge;
+import java.time.Clock;
+import java.util.Iterator;
+import java.util.Map;
+
+
+public class NativeMetadataRepositoryStats extends AbstractVeniceStats {
+  private final Sensor storeMetadataStalenessSensor;
+  private final Map<String, Long> metadataCacheTimestampMapInMs = new VeniceConcurrentHashMap<>();
+  private final Clock clock;
+
+  public NativeMetadataRepositoryStats(MetricsRepository metricsRepository, String name, Clock clock) {
+    super(metricsRepository, name);
+    this.clock = clock;
+    this.storeMetadataStalenessSensor = registerSensor(new AsyncGauge((ignored1, ignored2) -> {
+      if (this.metadataCacheTimestampMapInMs.isEmpty()) {
+        return Double.NaN;
+      } else {
+        Iterator<Long> iterator = metadataCacheTimestampMapInMs.values().iterator();
+        long oldest = iterator.next();
+        while (iterator.hasNext()) {
+          oldest = Math.min(oldest, iterator.next());
+        }
+        return clock.millis() - oldest;
+      }
+    }, "store_metadata_staleness_high_watermark_ms"));
+  }
+
+  public void updateCacheTimestamp(String storeName, long cacheTimeStampInMs) {
+    metadataCacheTimestampMapInMs.put(storeName, cacheTimeStampInMs);
+  }
+
+  public void removeCacheTimestamp(String storeName) {
+    metadataCacheTimestampMapInMs.remove(storeName);
+  }
+}

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/consumer/InternalLocalBootstrappingVeniceChangelogConsumerTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/consumer/InternalLocalBootstrappingVeniceChangelogConsumerTest.java
@@ -9,9 +9,7 @@ import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.doReturn;
-import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -64,6 +62,7 @@ import com.linkedin.venice.service.AbstractVeniceService;
 import com.linkedin.venice.utils.Utils;
 import com.linkedin.venice.utils.concurrent.VeniceConcurrentHashMap;
 import com.linkedin.venice.views.ChangeCaptureView;
+import io.tehuti.metrics.MetricsRepository;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
@@ -182,6 +181,7 @@ public class InternalLocalBootstrappingVeniceChangelogConsumerTest {
             .setLocalD2ZkHosts(TEST_ZOOKEEPER_ADDRESS)
             .setRocksDBBlockCacheSizeInBytes(TEST_ROCKSDB_BLOCK_CACHE_SIZE_IN_BYTES)
             .setDatabaseSyncBytesInterval(TEST_DB_SYNC_BYTES_INTERVAL);
+    changelogClientConfig.getInnerClientConfig().setMetricsRepository(new MetricsRepository());
     bootstrappingVeniceChangelogConsumer =
         new InternalLocalBootstrappingVeniceChangelogConsumer<>(changelogClientConfig, pubSubConsumer, null);
 

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/consumer/VeniceChangelogConsumerImplTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/consumer/VeniceChangelogConsumerImplTest.java
@@ -51,6 +51,7 @@ import com.linkedin.venice.utils.Utils;
 import com.linkedin.venice.utils.concurrent.VeniceConcurrentHashMap;
 import com.linkedin.venice.utils.lazy.Lazy;
 import com.linkedin.venice.views.ChangeCaptureView;
+import io.tehuti.metrics.MetricsRepository;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -125,10 +126,7 @@ public class VeniceChangelogConsumerImplTest {
         newVersionTopic,
         false);
     ChangelogClientConfig changelogClientConfig =
-        new ChangelogClientConfig<>().setD2ControllerClient(d2ControllerClient)
-            .setSchemaReader(schemaReader)
-            .setStoreName(storeName)
-            .setViewName("changeCaptureView");
+        getChangelogClientConfig(d2ControllerClient).setViewName("changeCaptureView");
     VeniceChangelogConsumerImpl<String, Utf8> veniceChangelogConsumer =
         new VeniceChangelogConsumerImpl<>(changelogClientConfig, mockPubSubConsumer);
     Assert.assertEquals(veniceChangelogConsumer.getPartitionCount(), 2);
@@ -194,11 +192,7 @@ public class VeniceChangelogConsumerImplTest {
     PubSubTopic oldVersionTopic = pubSubTopicRepository.getTopic(Version.composeKafkaTopic(storeName, 1));
 
     prepareVersionTopicRecordsToBePolled(0L, 5L, mockPubSubConsumer, oldVersionTopic, 0, true);
-    ChangelogClientConfig changelogClientConfig =
-        new ChangelogClientConfig<>().setD2ControllerClient(d2ControllerClient)
-            .setSchemaReader(schemaReader)
-            .setStoreName(storeName)
-            .setViewName("");
+    ChangelogClientConfig changelogClientConfig = getChangelogClientConfig(d2ControllerClient).setViewName("");
 
     VeniceChangelogConsumerImpl mockInternalSeekConsumer = Mockito.mock(VeniceChangelogConsumerImpl.class);
     Mockito.when(mockInternalSeekConsumer.subscribe(any())).thenReturn(CompletableFuture.completedFuture(null));
@@ -279,11 +273,7 @@ public class VeniceChangelogConsumerImplTest {
         pubSubTopicRepository.getTopic(oldVersionTopic + ChangeCaptureView.CHANGE_CAPTURE_TOPIC_SUFFIX);
 
     prepareVersionTopicRecordsToBePolled(0L, 5L, mockPubSubConsumer, oldVersionTopic, 0, true);
-    ChangelogClientConfig changelogClientConfig =
-        new ChangelogClientConfig<>().setD2ControllerClient(d2ControllerClient)
-            .setSchemaReader(schemaReader)
-            .setStoreName(storeName)
-            .setViewName("");
+    ChangelogClientConfig changelogClientConfig = getChangelogClientConfig(d2ControllerClient).setViewName("");
     VeniceChangelogConsumerImpl<String, Utf8> veniceChangelogConsumer =
         new VeniceAfterImageConsumerImpl<>(changelogClientConfig, mockPubSubConsumer);
     Assert.assertEquals(veniceChangelogConsumer.getPartitionCount(), 2);
@@ -351,11 +341,7 @@ public class VeniceChangelogConsumerImplTest {
     PubSubTopic oldVersionTopic = pubSubTopicRepository.getTopic(Version.composeKafkaTopic(storeName, 1));
 
     prepareVersionTopicRecordsToBePolled(0L, 5L, mockPubSubConsumer, oldVersionTopic, 0, true);
-    ChangelogClientConfig changelogClientConfig =
-        new ChangelogClientConfig<>().setD2ControllerClient(d2ControllerClient)
-            .setSchemaReader(schemaReader)
-            .setStoreName(storeName)
-            .setViewName("");
+    ChangelogClientConfig changelogClientConfig = getChangelogClientConfig(d2ControllerClient).setViewName("");
     VeniceChangelogConsumerImpl<String, Utf8> veniceChangelogConsumer =
         new VeniceAfterImageConsumerImpl<>(changelogClientConfig, mockPubSubConsumer);
     Assert.assertEquals(veniceChangelogConsumer.getPartitionCount(), 2);
@@ -559,5 +545,14 @@ public class VeniceChangelogConsumerImplTest {
     kafkaMessageEnvelope.payloadUnion = controlMessage;
     PubSubTopicPartition pubSubTopicPartition = new PubSubTopicPartitionImpl(versionTopic, partition);
     return new ImmutablePubSubMessage<>(kafkaKey, kafkaMessageEnvelope, pubSubTopicPartition, 0, 0, 0);
+  }
+
+  private ChangelogClientConfig getChangelogClientConfig(D2ControllerClient d2ControllerClient) {
+    ChangelogClientConfig changelogClientConfig =
+        new ChangelogClientConfig<>().setD2ControllerClient(d2ControllerClient)
+            .setSchemaReader(schemaReader)
+            .setStoreName(storeName);
+    changelogClientConfig.getInnerClientConfig().setMetricsRepository(new MetricsRepository());
+    return changelogClientConfig;
   }
 }

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/stats/NativeMetadataRepositoryStatsTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/stats/NativeMetadataRepositoryStatsTest.java
@@ -1,0 +1,33 @@
+package com.linkedin.davinci.stats;
+
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+
+import io.tehuti.metrics.MetricsRepository;
+import java.time.Clock;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+
+public class NativeMetadataRepositoryStatsTest {
+  @Test
+  public void testStats() {
+    Clock mockClock = mock(Clock.class);
+    doReturn(1000L).when(mockClock).millis();
+    String store1 = "testStore1";
+    String store2 = "testStore2";
+    NativeMetadataRepositoryStats stats = new NativeMetadataRepositoryStats(new MetricsRepository(), "test", mockClock);
+    Assert.assertEquals(stats.getMetadataStalenessHighWatermarkMs(), Double.NaN);
+    stats.updateCacheTimestamp(store1, 0);
+    Assert.assertEquals(stats.getMetadataStalenessHighWatermarkMs(), 1000d);
+    stats.updateCacheTimestamp(store2, 1000);
+    Assert.assertEquals(stats.getMetadataStalenessHighWatermarkMs(), 1000d);
+    doReturn(1500L).when(mockClock).millis();
+    stats.updateCacheTimestamp(store1, 1100);
+    Assert.assertEquals(stats.getMetadataStalenessHighWatermarkMs(), 500d);
+    stats.removeCacheTimestamp(store2);
+    Assert.assertEquals(stats.getMetadataStalenessHighWatermarkMs(), 400d);
+    stats.removeCacheTimestamp(store1);
+    Assert.assertEquals(stats.getMetadataStalenessHighWatermarkMs(), Double.NaN);
+  }
+}

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/MetaSystemStoreTest.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/MetaSystemStoreTest.java
@@ -50,6 +50,7 @@ import com.linkedin.venice.utils.TestUtils;
 import com.linkedin.venice.utils.Time;
 import com.linkedin.venice.utils.Utils;
 import com.linkedin.venice.utils.VeniceProperties;
+import io.tehuti.metrics.MetricsRepository;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
@@ -383,7 +384,8 @@ public class MetaSystemStoreTest {
     return ClientConfig.defaultSpecificClientConfig(storeName, StoreMetaValue.class)
         .setD2ServiceName(VeniceRouterWrapper.CLUSTER_DISCOVERY_D2_SERVICE_NAME)
         .setD2Client(d2Client)
-        .setVeniceURL(veniceLocalCluster.getZk().getAddress());
+        .setVeniceURL(veniceLocalCluster.getZk().getAddress())
+        .setMetricsRepository(new MetricsRepository());
   }
 
   private void verifyRepository(NativeMetadataRepository nativeMetadataRepository, String regularVeniceStoreName)


### PR DESCRIPTION
## [changelog][dvc] Disable TC internal retry in ThinClientMetaStoreBasedRepository

1. The existing TC internal retry implemented in RetriableStoreClient is vulnerable to a dead lock issue due to deserialization thread performing and waiting on the retry. Once the thread pool is exhausted all deserialization threads will be waiting forever because there won't be any threads left to handle the transport response. We will fix this internal retry in another commit.

2. Disable the TC internal retry in ThinClientMetaStoreBasedRepository because we recently added external retry with RetryUtils.executeWithMaxAttempt and timeout. Remove hardcoded retry configs from NativeMetadataRepository since it's no longer needed and it was leaking implementation details.

3. Added staleness metric in NativeMetadataRepository that should help us detect any issue causing the local metadata to be stale (including the dead lock issue mentioned above) for both DVC and change log use cases.

## How was this PR tested?
New and existing tests

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.