### PR TITLE
[router] More efficient handling of batch get key count limit breach

### DIFF
--- a/internal/venice-client-common/src/main/java/com/linkedin/venice/D2/D2ClientUtils.java
+++ b/internal/venice-client-common/src/main/java/com/linkedin/venice/D2/D2ClientUtils.java
@@ -62,6 +62,9 @@ public class D2ClientUtils {
   }
 
   public static void shutdownClient(D2Client client, long timeoutInMs) {
+    if (client == null) {
+      return;
+    }
     long startTime = System.currentTimeMillis();
     CompletableFuture<Void> future = new CompletableFuture<>();
 

--- a/internal/venice-client-common/src/main/java/com/linkedin/venice/exceptions/VeniceException.java
+++ b/internal/venice-client-common/src/main/java/com/linkedin/venice/exceptions/VeniceException.java
@@ -18,6 +18,10 @@ public class VeniceException extends RuntimeException {
     super(s);
   }
 
+  public VeniceException(String s, boolean fillInStacktrace) {
+    super(s, null, true, fillInStacktrace);
+  }
+
   public VeniceException(String s, ErrorType errorType) {
     super(s);
     this.errorType = errorType;

--- a/internal/venice-client-common/src/test/java/com/linkedin/venice/D2/D2ClientUtilsTest.java
+++ b/internal/venice-client-common/src/test/java/com/linkedin/venice/D2/D2ClientUtilsTest.java
@@ -1,0 +1,12 @@
+package com.linkedin.venice.D2;
+
+import org.testng.annotations.Test;
+
+
+public class D2ClientUtilsTest {
+  @Test
+  public void testClose() {
+    // Should not throw
+    D2ClientUtils.shutdownClient(null);
+  }
+}

--- a/internal/venice-test-common/build.gradle
+++ b/internal/venice-test-common/build.gradle
@@ -241,12 +241,12 @@ integrationTestBuckets.each { name, patterns ->
       excludeGroups 'flaky'
       listeners = ['com.linkedin.venice.testng.VeniceSuiteListener', 'com.linkedin.venice.testng.VeniceTestListener']
     }
-    doFirst {
+    beforeSuite { descriptor ->
       suiteStartTime = System.currentTimeMillis()
     }
     afterSuite { descriptor, result ->
       if (descriptor.name.startsWith("com.linkedin")) {
-        println "Test Suite ${descriptor.name} completed in ${(System.currentTimeMillis() - suiteStartTime )/1000} s"
+        println "Test Suite ${descriptor.name} completed (${result.getResultType()}) in ${(System.currentTimeMillis() - suiteStartTime )/1000} s"
       }
     }
   }
@@ -263,7 +263,7 @@ task integrationTests_9999(type: Test) {
       }
     }
   }
-  doFirst {
+  beforeSuite { descriptor ->
     suiteStartTime = System.currentTimeMillis()
   }
   configure integrationTestConfigs
@@ -273,7 +273,7 @@ task integrationTests_9999(type: Test) {
   }
   afterSuite { descriptor, result ->
     if (descriptor.name.startsWith("com.linkedin")) {
-      println "Test Suite ${descriptor.name} completed in ${(System.currentTimeMillis() - suiteStartTime )/1000} s"
+      println "Test Suite ${descriptor.name} completed (${result.getResultType()}) in ${(System.currentTimeMillis() - suiteStartTime )/1000} s"
     }
   }
 }

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/controller/TestHAASController.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/controller/TestHAASController.java
@@ -324,7 +324,7 @@ public class TestHAASController {
     }
   }
 
-  @Test
+  @Test(timeOut = 90 * Time.MS_PER_SECOND)
   public void testCloudConfig() {
     try (ZkServerWrapper zk = ServiceFactory.getZkServer();
         HelixAsAServiceWrapper helixAsAServiceWrapper = startAndWaitForHAASToBeAvailable(zk.getAddress())) {
@@ -356,7 +356,7 @@ public class TestHAASController {
     }
   }
 
-  @Test
+  @Test(timeOut = 90 * Time.MS_PER_SECOND)
   public void testHelixUnknownInstanceOperation() {
     try (VeniceClusterWrapper venice = ServiceFactory.getVeniceCluster(0, 0, 0, 1);
         HelixAsAServiceWrapper helixAsAServiceWrapper = startAndWaitForHAASToBeAvailable(venice.getZk().getAddress())) {

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/router/TestBlobDiscovery.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/router/TestBlobDiscovery.java
@@ -8,7 +8,7 @@ import static com.linkedin.venice.ConfigKeys.OFFLINE_JOB_START_TIMEOUT_MS;
 import static com.linkedin.venice.ConfigKeys.PERSISTENCE_TYPE;
 import static com.linkedin.venice.ConfigKeys.PUSH_STATUS_STORE_ENABLED;
 import static com.linkedin.venice.client.store.ClientFactory.getTransportClient;
-import static org.testng.Assert.assertFalse;
+import static com.linkedin.venice.utils.TestUtils.assertCommand;
 
 import com.linkedin.d2.balancer.D2Client;
 import com.linkedin.davinci.client.DaVinciClient;
@@ -113,8 +113,7 @@ public class TestBlobDiscovery {
         PubSubBrokerWrapper.getBrokerDetailsForClients(pubSubBrokerWrappers);
 
     try (ControllerClient parentControllerClient = new ControllerClient(clusterName, parentControllerURLs)) {
-      assertFalse(
-          parentControllerClient.createNewStore(storeName, "venice-test", INT_KEY_SCHEMA, INT_VALUE_SCHEMA).isError());
+      assertCommand(parentControllerClient.createNewStore(storeName, "venice-test", INT_KEY_SCHEMA, INT_VALUE_SCHEMA));
 
       PubSubProducerAdapterFactory pubSubProducerAdapterFactory = multiClusterVenice.getClusters()
           .get(clusterName)

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/router/TestRead.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/router/TestRead.java
@@ -465,8 +465,7 @@ public abstract class TestRead {
       });
 
       // Single get quota test
-      int throttledRequestsForSingleGet =
-          (int) getAggregateRouterMetricValue(".total--multiget_throttled_request.Count");
+      int throttledRequestsForSingleGet = (int) getAggregateRouterMetricValue(".total--throttled_request.Count");
       Assert.assertEquals(
           throttledRequestsForSingleGet,
           0,

--- a/services/venice-router/src/main/java/com/linkedin/venice/router/api/RouterExceptionAndTrackingUtils.java
+++ b/services/venice-router/src/main/java/com/linkedin/venice/router/api/RouterExceptionAndTrackingUtils.java
@@ -37,9 +37,6 @@ public class RouterExceptionAndTrackingUtils {
 
   private static final Logger LOGGER = LogManager.getLogger(RouterExceptionAndTrackingUtils.class);
 
-  /** We do not fill in the stacktrace at all for "expected exceptions" (quota, etc) */
-  private static final boolean DO_NOT_FILL_IN_STACKTRACE = false;
-
   private static final RedundantExceptionFilter EXCEPTION_FILTER =
       RedundantExceptionFilter.getRedundantExceptionFilter();
 
@@ -63,7 +60,8 @@ public class RouterExceptionAndTrackingUtils {
             false,
             null,
             true,
-            DO_NOT_FILL_IN_STACKTRACE)
+            /** We do not fill in the stacktrace at all for "expected exceptions" (quota, etc) */
+            false)
         : new RouterException(HttpResponseStatus.class, responseStatus, responseStatus.code(), msg, false);
     String name = storeName.isPresent() ? storeName.get() : "";
     if (!EXCEPTION_FILTER.isRedundantException(name, String.valueOf(e.code()))) {
@@ -119,7 +117,7 @@ public class RouterExceptionAndTrackingUtils {
     String name = storeName.isPresent() ? storeName.get() : "";
     VeniceException e = isExpected(responseStatus, failureType)
         // Do not dump stack-trace for Quota exceed exception as it might blow up memory on high load
-        ? new VeniceException(msg, DO_NOT_FILL_IN_STACKTRACE)
+        ? new VeniceException(msg, false)
         : new VeniceException(msg);
 
     if (!EXCEPTION_FILTER.isRedundantException(name, e)) {

--- a/services/venice-router/src/main/java/com/linkedin/venice/router/api/RouterExceptionAndTrackingUtils.java
+++ b/services/venice-router/src/main/java/com/linkedin/venice/router/api/RouterExceptionAndTrackingUtils.java
@@ -1,6 +1,7 @@
 package com.linkedin.venice.router.api;
 
 import static io.netty.handler.codec.http.HttpResponseStatus.BAD_REQUEST;
+import static io.netty.handler.codec.http.HttpResponseStatus.REQUEST_ENTITY_TOO_LARGE;
 import static io.netty.handler.codec.http.HttpResponseStatus.SERVICE_UNAVAILABLE;
 import static io.netty.handler.codec.http.HttpResponseStatus.TOO_MANY_REQUESTS;
 
@@ -22,6 +23,8 @@ import org.apache.logging.log4j.Logger;
  *
  * TODO: If later on DDS router could support a better way to register a handler to handle the exceptional cases,
  * we should update the logic here.
+ *
+ * TODO: Remove all {@link Optional} from this class.
  */
 
 public class RouterExceptionAndTrackingUtils {
@@ -30,11 +33,12 @@ public class RouterExceptionAndTrackingUtils {
     SMART_RETRY_ABORTED_BY_MAX_RETRY_ROUTE_LIMIT, RESOURCE_NOT_FOUND, RETRY_ABORTED_BY_NO_AVAILABLE_REPLICA
   }
 
-  private static final StackTraceElement[] emptyStackTrace = new StackTraceElement[0];
-
   private static RouterStats<AggRouterHttpRequestStats> ROUTER_STATS;
 
   private static final Logger LOGGER = LogManager.getLogger(RouterExceptionAndTrackingUtils.class);
+
+  /** We do not fill in the stacktrace at all for "expected exceptions" (quota, etc) */
+  private static final boolean DO_NOT_FILL_IN_STACKTRACE = false;
 
   private static final RedundantExceptionFilter EXCEPTION_FILTER =
       RedundantExceptionFilter.getRedundantExceptionFilter();
@@ -50,13 +54,17 @@ public class RouterExceptionAndTrackingUtils {
       String msg,
       FailureType failureType) {
     metricTracking(storeName, requestType, responseStatus, failureType);
-    RouterException e =
-        new RouterException(HttpResponseStatus.class, responseStatus, responseStatus.code(), msg, false);
-    // Do not dump stack-trace for Quota exceed exception as it might blow up memory on high load
-    if (responseStatus.equals(TOO_MANY_REQUESTS) || responseStatus.equals(SERVICE_UNAVAILABLE)
-        || failureType == FailureType.RESOURCE_NOT_FOUND) {
-      e.setStackTrace(emptyStackTrace);
-    }
+    RouterException e = isExpected(responseStatus, failureType)
+        ? new RouterException(
+            HttpResponseStatus.class,
+            responseStatus,
+            responseStatus.code(),
+            msg,
+            false,
+            null,
+            true,
+            DO_NOT_FILL_IN_STACKTRACE)
+        : new RouterException(HttpResponseStatus.class, responseStatus, responseStatus.code(), msg, false);
     String name = storeName.isPresent() ? storeName.get() : "";
     if (!EXCEPTION_FILTER.isRedundantException(name, String.valueOf(e.code()))) {
       if (responseStatus == BAD_REQUEST) {
@@ -71,6 +79,17 @@ public class RouterExceptionAndTrackingUtils {
       }
     }
     return e;
+  }
+
+  /**
+   * Some error conditions are "expected". They are common, and we would like to treat them as efficiently as possible,
+   * e.g. by not logging or even filling in the stacktrace.
+   *
+   * This includes user errors, and hardware failures. It does NOT include anything that would be related to a "bug".
+   */
+  private static boolean isExpected(HttpResponseStatus responseStatus, FailureType failureType) {
+    return responseStatus.equals(TOO_MANY_REQUESTS) || responseStatus.equals(SERVICE_UNAVAILABLE)
+        || responseStatus.equals(REQUEST_ENTITY_TOO_LARGE) || failureType == FailureType.RESOURCE_NOT_FOUND;
   }
 
   public static RouterException newRouterExceptionAndTracking(
@@ -98,12 +117,11 @@ public class RouterExceptionAndTrackingUtils {
       FailureType failureType) {
     metricTracking(storeName, requestType, responseStatus, failureType);
     String name = storeName.isPresent() ? storeName.get() : "";
-    VeniceException e = new VeniceException(msg);
+    VeniceException e = isExpected(responseStatus, failureType)
+        // Do not dump stack-trace for Quota exceed exception as it might blow up memory on high load
+        ? new VeniceException(msg, DO_NOT_FILL_IN_STACKTRACE)
+        : new VeniceException(msg);
 
-    // Do not dump stack-trace for Quota exceed exception as it might blow up memory on high load
-    if (responseStatus.equals(TOO_MANY_REQUESTS) || responseStatus.equals(SERVICE_UNAVAILABLE)) {
-      e.setStackTrace(emptyStackTrace);
-    }
     if (!EXCEPTION_FILTER.isRedundantException(name, e)) {
       LOGGER.warn("Got an exception for store: {}", name, e);
     }

--- a/services/venice-router/src/main/java/com/linkedin/venice/router/api/path/VeniceComputePath.java
+++ b/services/venice-router/src/main/java/com/linkedin/venice/router/api/path/VeniceComputePath.java
@@ -25,6 +25,7 @@ import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.function.BiConsumer;
@@ -139,7 +140,7 @@ public class VeniceComputePath extends VeniceMultiKeyPath<ComputeRouterRequestKe
     }
 
     // deserialize the second part of the request content using the same decoder
-    Iterable<ByteBuffer> keys = COMPUTE_REQUEST_CLIENT_KEY_V1_DESERIALIZER.deserializeObjects(decoder);
+    List<ByteBuffer> keys = COMPUTE_REQUEST_CLIENT_KEY_V1_DESERIALIZER.deserializeObjects(decoder);
 
     initialize(storeName, resourceName, keys, partitionFinder, maxKeyCount, null);
   }

--- a/services/venice-router/src/main/java/com/linkedin/venice/router/api/path/VeniceMultiGetPath.java
+++ b/services/venice-router/src/main/java/com/linkedin/venice/router/api/path/VeniceMultiGetPath.java
@@ -21,6 +21,7 @@ import com.linkedin.venice.serializer.FastSerializerDeserializerFactory;
 import com.linkedin.venice.serializer.RecordDeserializer;
 import com.linkedin.venice.serializer.RecordSerializer;
 import java.nio.ByteBuffer;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import javax.annotation.Nonnull;
@@ -71,7 +72,7 @@ public class VeniceMultiGetPath extends VeniceMultiKeyPath<MultiGetRouterRequest
           "Expected api version: " + EXPECTED_PROTOCOL.getProtocolVersion() + ", but received: " + apiVersion);
     }
 
-    Iterable<ByteBuffer> keys;
+    List<ByteBuffer> keys;
     byte[] content;
 
     if (request.hasAttr(RouterThrottleHandler.THROTTLE_HANDLER_BYTE_ATTRIBUTE_KEY)) {
@@ -157,7 +158,7 @@ public class VeniceMultiGetPath extends VeniceMultiKeyPath<MultiGetRouterRequest
     return MULTI_GET_ROUTER_REQUEST_KEY_V1_SERIALIZER.serializeObjects(routerKeyMap.values());
   }
 
-  private static Iterable<ByteBuffer> deserialize(byte[] content) {
+  private static List<ByteBuffer> deserialize(byte[] content) {
     return EXPECTED_PROTOCOL_DESERIALIZER.deserializeObjects(
         OptimizedBinaryDecoderFactory.defaultFactory().createOptimizedBinaryDecoder(content, 0, content.length));
   }


### PR DESCRIPTION
- In VeniceMultiKeyPath::initialize, we check the key count sooner, which is possible thanks to an earlier refactoring to the Avro deserialization code which now returns a List rather than an Iterable.

- In VenicePathParser::parseResourceUri, when the batch get key count is exceeded, we mark it as a 413, and then treat it as an "expected exception" in RouterExceptionAndTrackingUtils, which suppresses the stacktrace from the logs.

- In RouterExceptionAndTrackingUtils, we further improve the handling of "expected exceptions" so that not only we avoid logging the stacktrace, but we also skip filling it in in the first place. Previously, the stacktrace would be filled in and then suppressed, and filling in stacktraces can be expensive. This change should help not only batch get key count limit breaches but also other forms of quota breaches, store not found, etc.

Miscellaneous:

- Tweaked the logging of the build which had a bookkeeping error in the time taken to run each test class.

- Added a null check in D2ClientUtils::shutdownClient since it caused some integration tests to fail during their tear down.

## How was this PR tested?
GHCI.

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [ ] No. You can skip the rest of this section.
- [x] Yes. Make sure to explain your proposed changes and call out the behavior change.

Clients will receive the 413 status code now instead of 400 if they breach the batch get key count limit.