### PR TITLE
[server][dvc] support hybrid store in blob transfer with recreating snapshots

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/DaVinciBackend.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/DaVinciBackend.java
@@ -295,7 +295,9 @@ public class DaVinciBackend implements Closeable {
             configLoader.getVeniceServerConfig().getDvcP2pBlobTransferClientPort(),
             configLoader.getVeniceServerConfig().getRocksDBPath(),
             clientConfig,
-            storageMetadataService);
+            storageMetadataService,
+            readOnlyStoreRepository,
+            storageService.getStorageEngineRepository());
       } else {
         blobTransferManager = null;
       }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/DaVinciBackend.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/DaVinciBackend.java
@@ -297,7 +297,9 @@ public class DaVinciBackend implements Closeable {
             clientConfig,
             storageMetadataService,
             readOnlyStoreRepository,
-            storageService.getStorageEngineRepository());
+            storageService.getStorageEngineRepository(),
+            backendConfig.getMaxConcurrentSnapshotUser(),
+            backendConfig.getSnapshotRetentionTimeInMin());
       } else {
         blobTransferManager = null;
       }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/blobtransfer/BlobSnapshotManager.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/blobtransfer/BlobSnapshotManager.java
@@ -119,10 +119,9 @@ public class BlobSnapshotManager {
 
     // check if the concurrent user count exceeds the limit
     checkIfConcurrentUserExceedsLimit(topicName, partitionId);
-    concurrentSnapshotUsers.putIfAbsent(topicName, new VeniceConcurrentHashMap<>());
-    concurrentSnapshotUsers.get(topicName).putIfAbsent(partitionId, new AtomicLong(0));
-
-    concurrentSnapshotUsers.get(topicName).get(partitionId).incrementAndGet();
+    concurrentSnapshotUsers.computeIfAbsent(topicName, k -> new VeniceConcurrentHashMap<>())
+        .computeIfAbsent(partitionId, k -> new AtomicLong(0))
+        .incrementAndGet();
 
     boolean isHybrid = isStoreHybrid(payload.getStoreName());
     if (!isHybrid) {

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/blobtransfer/BlobSnapshotManager.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/blobtransfer/BlobSnapshotManager.java
@@ -12,6 +12,7 @@ import java.io.File;
 import java.io.IOException;
 import java.util.Map;
 import java.util.Objects;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
@@ -24,19 +25,31 @@ import org.rocksdb.RocksDBException;
 
 
 /**
- * This class will take and return a snapshot of a hybrid store, if someone is using a snapshot then it will return
- * the snapshot that person is using, otherwise, it will return the last snapshot taken if it is not stale
- * If the snapshot is stale and no one is using it, it will update the snapshot and return the new one
+ * This class will manage the snapshot creation, for batch store and hybrid store.
  */
 
 public class BlobSnapshotManager {
-  // A map to keep track of the number of hosts using a snapshot for a particular topic and partition
-  private final Map<String, Map<Integer, AtomicLong>> concurrentSnapshotUsers;
+  private static final Logger LOGGER = LogManager.getLogger(BlobSnapshotManager.class);
+  private final static long SNAPSHOT_RETENTION_TIME_IN_HOUR = 1;
+  private final long SNAPSHOT_RETENTION_TIME_IN_MILLIS = TimeUnit.HOURS.toMillis(SNAPSHOT_RETENTION_TIME_IN_HOUR);
+  public final static int MAX_CONCURRENT_USERS = 5;
+
+  // A map to keep track of the number of hosts using a snapshot for a particular topic and partition, use to restrict
+  // concurrent user count
+  // Example: <topicName, <partitionId, concurrentUsersAmount>>
+  private Map<String, Map<Integer, AtomicLong>> concurrentSnapshotUsers;
+  // A map to keep track of the snapshot timestamps for a particular topic and partition, use to track snapshot
+  // staleness
+  // Example: <topicName, <partitionId, timestamp>>
+  private Map<String, Map<Integer, Long>> snapshotTimestamps;
+  // A map to keep track the snapshot respective offset record for a particular topic and partition, use to keep
+  // snapshot/offset consistency
+  // Example: <topicName, <partitionId, offset>>
+  private Map<String, Map<Integer, BlobTransferPartitionMetadata>> snapshotMetadataRecords;
 
   private final ReadOnlyStoreRepository readOnlyStoreRepository;
   private final StorageEngineRepository storageEngineRepository;
   private final Lock lock = new ReentrantLock();
-  private static final Logger LOGGER = LogManager.getLogger(BlobSnapshotManager.class);
 
   /**
    * Constructor for the BlobSnapshotManager
@@ -48,42 +61,101 @@ public class BlobSnapshotManager {
     this.storageEngineRepository = storageEngineRepository;
 
     this.concurrentSnapshotUsers = new VeniceConcurrentHashMap<>();
+    this.snapshotTimestamps = new VeniceConcurrentHashMap<>();
+    this.snapshotMetadataRecords = new VeniceConcurrentHashMap<>();
   }
 
   /**
    * Recreate a snapshot for a hybrid store and return true if the snapshot is successfully created
    * If the snapshot is being used by some other host, throw an exception
+   * @param payload the blob transfer payload which carries the topic name, store name and partition id
+   * @param blobTransferPartitionMetadata the blob transfer partition metadata which carries the snapshot offset
    */
-  public boolean recreateSnapshotForHybrid(BlobTransferPayload payload) {
+  public void recreateSnapshotForHybrid(
+      BlobTransferPayload payload,
+      BlobTransferPartitionMetadata blobTransferPartitionMetadata) throws VeniceException {
     String topicName = payload.getTopicName();
-    String storeName = payload.getStoreName();
     int partitionId = payload.getPartition();
 
-    if (!isStoreHybrid(storeName)) {
-      LOGGER.info("Store {} is not hybrid, skipping snapshot re-create", storeName);
-      return false;
-    }
-
+    snapshotTimestamps.putIfAbsent(topicName, new VeniceConcurrentHashMap<>());
+    snapshotMetadataRecords.putIfAbsent(topicName, new VeniceConcurrentHashMap<>());
     concurrentSnapshotUsers.putIfAbsent(topicName, new VeniceConcurrentHashMap<>());
     concurrentSnapshotUsers.get(topicName).putIfAbsent(partitionId, new AtomicLong(0));
 
     try (AutoCloseableLock ignored = AutoCloseableLock.of(lock)) {
-      if (concurrentSnapshotUsers.get(topicName).get(partitionId) == null
-          || concurrentSnapshotUsers.get(topicName).get(partitionId).get() == 0) {
+      // check if the concurrent user count exceeds the limit
+      checkIfConcurrentUserExceedsLimit(topicName, partitionId);
+      // check if the snapshot is stale and need to be recreated
+      checkIfSnapshotIsStaleAndRecreate(topicName, partitionId, blobTransferPartitionMetadata);
+    }
+  }
+
+  /**
+   * Check if the snapshot is stale and recreate it if necessary
+   * @param topicName the topic name
+   * @param partitionId the partition id
+   * @param blobTransferPartitionMetadata the blob transfer partition metadata
+   */
+  private void checkIfSnapshotIsStaleAndRecreate(
+      String topicName,
+      int partitionId,
+      BlobTransferPartitionMetadata blobTransferPartitionMetadata) {
+    boolean snapshotStale = isSnapshotStale(topicName, partitionId);
+    if (snapshotStale) {
+      try {
         createSnapshot(topicName, partitionId);
-      } else {
-        // the snapshot is being used, cannot generate a new snapshot at the same time
-        String errorMessage = String.format(
-            "Snapshot is being used by some hosts, cannot recreate new snapshot for topic %s partition %d",
-            topicName,
-            partitionId);
-        LOGGER.error(errorMessage);
+        // update the snapshot timestamp to reflect the latest snapshot creation time
+        snapshotTimestamps.get(topicName).put(partitionId, System.currentTimeMillis());
+        // update the snapshot offset record to reflect the latest snapshot offset
+        snapshotMetadataRecords.get(topicName).put(partitionId, blobTransferPartitionMetadata);
+        LOGGER.info("Successfully created snapshot for topic {} partition {}", topicName, partitionId);
+      } catch (Exception e) {
+        String errorMessage =
+            String.format("Failed to create snapshot for topic %s partition %d", topicName, partitionId);
+        LOGGER.error(errorMessage, e);
         throw new VeniceException(errorMessage);
       }
+    } else {
+      LOGGER.info(
+          "Snapshot for topic {} partition {} is not stale, skip creating new snapshot. ",
+          topicName,
+          partitionId);
     }
 
     concurrentSnapshotUsers.get(topicName).get(partitionId).incrementAndGet();
-    return true;
+  }
+
+  /**
+   * Check if the concurrent user count exceeds the limit
+   * @param topicName the topic name
+   * @param partitionId the partition id
+   * @throws VeniceException if the concurrent user count exceeds the limit
+   */
+  private void checkIfConcurrentUserExceedsLimit(String topicName, int partitionId) throws VeniceException {
+    boolean exceededMaxConcurrentUsers = getConcurrentSnapshotUsers(topicName, partitionId) >= MAX_CONCURRENT_USERS;
+    if (exceededMaxConcurrentUsers) {
+      String errorMessage = String.format(
+          "Exceeded the maximum number of concurrent users %d for topic %s partition %d",
+          MAX_CONCURRENT_USERS,
+          topicName,
+          partitionId);
+      LOGGER.error(errorMessage);
+      throw new VeniceException(errorMessage);
+    }
+  }
+
+  /**
+   * Check if the snapshot is stale
+   * @param topicName the topic name
+   * @param partitionId the partition id
+   * @return true if the snapshot is stale, false otherwise
+   */
+  private boolean isSnapshotStale(String topicName, int partitionId) {
+    if (!snapshotTimestamps.containsKey(topicName) || !snapshotTimestamps.get(topicName).containsKey(partitionId)) {
+      return true;
+    }
+    return System.currentTimeMillis()
+        - snapshotTimestamps.get(topicName).get(partitionId) > SNAPSHOT_RETENTION_TIME_IN_MILLIS;
   }
 
   /**
@@ -122,7 +194,7 @@ public class BlobSnapshotManager {
    * @param storeName the name of the store
    * @return true if the store is hybrid, false otherwise
    */
-  protected boolean isStoreHybrid(String storeName) {
+  public boolean isStoreHybrid(String storeName) {
     Store store = readOnlyStoreRepository.getStore(storeName);
     if (store != null) {
       return store.isHybrid();
@@ -172,5 +244,37 @@ public class BlobSnapshotManager {
         Objects.requireNonNull(storageEngineRepository.getLocalStorageEngine(kafkaVersionTopic));
     AbstractStoragePartition partition = storageEngine.getPartitionOrThrow(partitionId);
     partition.createSnapshot();
+  }
+
+  /**
+   * Decrease the user count for the snapshot to allow other hosts can use it.
+   * @param isHybridStore the snapshot is generated for hybrid mode
+   * @param blobTransferRequest the blob transfer request
+   */
+  public void removeConcurrentUserRestriction(boolean isHybridStore, BlobTransferPayload blobTransferRequest) {
+    if (!isHybridStore) {
+      LOGGER.info(
+          "Snapshot for topic {} partition {} is not new hybrid, skip reset user count",
+          blobTransferRequest.getTopicName(),
+          blobTransferRequest.getPartition());
+      return;
+    }
+
+    // decrease the user count for allowing other hosts can use it
+    decreaseConcurrentUserCount(blobTransferRequest.getTopicName(), blobTransferRequest.getPartition());
+    LOGGER.info(
+        "Decreased user count for snapshot of topic {} partition {}",
+        blobTransferRequest.getTopicName(),
+        blobTransferRequest.getPartition());
+  }
+
+  /**
+   * Get the snapshot metadata for a particular topic and partition
+   * @param topicName the topic name
+   * @param partitionId the partition id
+   * @return the snapshot metadata
+   */
+  public BlobTransferPartitionMetadata getTransferredSnapshotMetadata(String topicName, int partitionId) {
+    return snapshotMetadataRecords.get(topicName).get(partitionId);
   }
 }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/blobtransfer/BlobSnapshotManager.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/blobtransfer/BlobSnapshotManager.java
@@ -40,8 +40,6 @@ public class BlobSnapshotManager {
   private static final InternalAvroSpecificSerializer<StoreVersionState> storeVersionStateSerializer =
       AvroProtocolDefinition.STORE_VERSION_STATE.getSerializer();
   private final static int DEFAULT_SNAPSHOT_RETENTION_TIME_IN_MIN = 30;
-  private final long SNAPSHOT_RETENTION_TIME_IN_MILLIS =
-      TimeUnit.MINUTES.toMillis(DEFAULT_SNAPSHOT_RETENTION_TIME_IN_MIN);
   public final static int DEFAULT_MAX_CONCURRENT_USERS = 5;
 
   // A map to keep track of the number of hosts using a snapshot for a particular topic and partition, use to restrict

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/blobtransfer/BlobTransferPayload.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/blobtransfer/BlobTransferPayload.java
@@ -13,9 +13,11 @@ public class BlobTransferPayload {
   private final int partition;
   private final String topicName;
   private final String partitionDir;
+  private final String storeName;
 
   public BlobTransferPayload(String baseDir, String storeName, int version, int partition) {
     this.partition = partition;
+    this.storeName = storeName;
     this.topicName = storeName + "_v" + version;
     this.partitionDir = composePartitionDbDir(baseDir, topicName, partition);
   }
@@ -38,5 +40,9 @@ public class BlobTransferPayload {
 
   public int getPartition() {
     return partition;
+  }
+
+  public String getStoreName() {
+    return storeName;
   }
 }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/blobtransfer/BlobTransferUtil.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/blobtransfer/BlobTransferUtil.java
@@ -4,6 +4,7 @@ import static com.linkedin.venice.client.store.ClientFactory.getTransportClient;
 
 import com.linkedin.davinci.blobtransfer.client.NettyFileTransferClient;
 import com.linkedin.davinci.blobtransfer.server.P2PBlobTransferService;
+import com.linkedin.davinci.storage.StorageEngineRepository;
 import com.linkedin.davinci.storage.StorageMetadataService;
 import com.linkedin.venice.blobtransfer.DaVinciBlobFinder;
 import com.linkedin.venice.blobtransfer.ServerBlobFinder;
@@ -11,6 +12,7 @@ import com.linkedin.venice.client.store.AbstractAvroStoreClient;
 import com.linkedin.venice.client.store.AvroGenericStoreClientImpl;
 import com.linkedin.venice.client.store.ClientConfig;
 import com.linkedin.venice.helix.HelixCustomizedViewOfflinePushRepository;
+import com.linkedin.venice.meta.ReadOnlyStoreRepository;
 import java.util.concurrent.CompletableFuture;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -32,13 +34,17 @@ public class BlobTransferUtil {
       int p2pTransferPort,
       String baseDir,
       ClientConfig clientConfig,
-      StorageMetadataService storageMetadataService) {
+      StorageMetadataService storageMetadataService,
+      ReadOnlyStoreRepository readOnlyStoreRepository,
+      StorageEngineRepository storageEngineRepository) {
     return getP2PBlobTransferManagerForDVCAndStart(
         p2pTransferPort,
         p2pTransferPort,
         baseDir,
         clientConfig,
-        storageMetadataService);
+        storageMetadataService,
+        readOnlyStoreRepository,
+        storageEngineRepository);
   }
 
   public static BlobTransferManager<Void> getP2PBlobTransferManagerForDVCAndStart(
@@ -46,12 +52,16 @@ public class BlobTransferUtil {
       int p2pTransferClientPort,
       String baseDir,
       ClientConfig clientConfig,
-      StorageMetadataService storageMetadataService) {
+      StorageMetadataService storageMetadataService,
+      ReadOnlyStoreRepository readOnlyStoreRepository,
+      StorageEngineRepository storageEngineRepository) {
     try {
+      BlobSnapshotManager blobSnapshotManager =
+          new BlobSnapshotManager(readOnlyStoreRepository, storageEngineRepository);
       AbstractAvroStoreClient storeClient =
           new AvroGenericStoreClientImpl<>(getTransportClient(clientConfig), false, clientConfig);
       BlobTransferManager<Void> manager = new NettyP2PBlobTransferManager(
-          new P2PBlobTransferService(p2pTransferServerPort, baseDir, storageMetadataService),
+          new P2PBlobTransferService(p2pTransferServerPort, baseDir, storageMetadataService, blobSnapshotManager),
           new NettyFileTransferClient(p2pTransferClientPort, baseDir, storageMetadataService),
           new DaVinciBlobFinder(storeClient));
       manager.start();
@@ -76,10 +86,14 @@ public class BlobTransferUtil {
       int p2pTransferClientPort,
       String baseDir,
       CompletableFuture<HelixCustomizedViewOfflinePushRepository> customizedViewFuture,
-      StorageMetadataService storageMetadataService) {
+      StorageMetadataService storageMetadataService,
+      ReadOnlyStoreRepository readOnlyStoreRepository,
+      StorageEngineRepository storageEngineRepository) {
     try {
+      BlobSnapshotManager blobSnapshotManager =
+          new BlobSnapshotManager(readOnlyStoreRepository, storageEngineRepository);
       BlobTransferManager<Void> manager = new NettyP2PBlobTransferManager(
-          new P2PBlobTransferService(p2pTransferServerPort, baseDir, storageMetadataService),
+          new P2PBlobTransferService(p2pTransferServerPort, baseDir, storageMetadataService, blobSnapshotManager),
           new NettyFileTransferClient(p2pTransferClientPort, baseDir, storageMetadataService),
           new ServerBlobFinder(customizedViewFuture));
       manager.start();

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/blobtransfer/BlobTransferUtil.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/blobtransfer/BlobTransferUtil.java
@@ -36,7 +36,9 @@ public class BlobTransferUtil {
       ClientConfig clientConfig,
       StorageMetadataService storageMetadataService,
       ReadOnlyStoreRepository readOnlyStoreRepository,
-      StorageEngineRepository storageEngineRepository) {
+      StorageEngineRepository storageEngineRepository,
+      int maxConcurrentSnapshotUser,
+      int snapshotRetentionTimeInMin) {
     return getP2PBlobTransferManagerForDVCAndStart(
         p2pTransferPort,
         p2pTransferPort,
@@ -44,7 +46,9 @@ public class BlobTransferUtil {
         clientConfig,
         storageMetadataService,
         readOnlyStoreRepository,
-        storageEngineRepository);
+        storageEngineRepository,
+        maxConcurrentSnapshotUser,
+        snapshotRetentionTimeInMin);
   }
 
   public static BlobTransferManager<Void> getP2PBlobTransferManagerForDVCAndStart(
@@ -54,14 +58,20 @@ public class BlobTransferUtil {
       ClientConfig clientConfig,
       StorageMetadataService storageMetadataService,
       ReadOnlyStoreRepository readOnlyStoreRepository,
-      StorageEngineRepository storageEngineRepository) {
+      StorageEngineRepository storageEngineRepository,
+      int maxConcurrentSnapshotUser,
+      int snapshotRetentionTimeInMin) {
     try {
-      BlobSnapshotManager blobSnapshotManager =
-          new BlobSnapshotManager(readOnlyStoreRepository, storageEngineRepository);
+      BlobSnapshotManager blobSnapshotManager = new BlobSnapshotManager(
+          readOnlyStoreRepository,
+          storageEngineRepository,
+          storageMetadataService,
+          maxConcurrentSnapshotUser,
+          snapshotRetentionTimeInMin);
       AbstractAvroStoreClient storeClient =
           new AvroGenericStoreClientImpl<>(getTransportClient(clientConfig), false, clientConfig);
       BlobTransferManager<Void> manager = new NettyP2PBlobTransferManager(
-          new P2PBlobTransferService(p2pTransferServerPort, baseDir, storageMetadataService, blobSnapshotManager),
+          new P2PBlobTransferService(p2pTransferServerPort, baseDir, blobSnapshotManager),
           new NettyFileTransferClient(p2pTransferClientPort, baseDir, storageMetadataService),
           new DaVinciBlobFinder(storeClient));
       manager.start();
@@ -88,12 +98,18 @@ public class BlobTransferUtil {
       CompletableFuture<HelixCustomizedViewOfflinePushRepository> customizedViewFuture,
       StorageMetadataService storageMetadataService,
       ReadOnlyStoreRepository readOnlyStoreRepository,
-      StorageEngineRepository storageEngineRepository) {
+      StorageEngineRepository storageEngineRepository,
+      int maxConcurrentSnapshotUser,
+      int snapshotRetentionTimeInMin) {
     try {
-      BlobSnapshotManager blobSnapshotManager =
-          new BlobSnapshotManager(readOnlyStoreRepository, storageEngineRepository);
+      BlobSnapshotManager blobSnapshotManager = new BlobSnapshotManager(
+          readOnlyStoreRepository,
+          storageEngineRepository,
+          storageMetadataService,
+          maxConcurrentSnapshotUser,
+          snapshotRetentionTimeInMin);
       BlobTransferManager<Void> manager = new NettyP2PBlobTransferManager(
-          new P2PBlobTransferService(p2pTransferServerPort, baseDir, storageMetadataService, blobSnapshotManager),
+          new P2PBlobTransferService(p2pTransferServerPort, baseDir, blobSnapshotManager),
           new NettyFileTransferClient(p2pTransferClientPort, baseDir, storageMetadataService),
           new ServerBlobFinder(customizedViewFuture));
       manager.start();

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/blobtransfer/client/P2PFileTransferClientHandler.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/blobtransfer/client/P2PFileTransferClientHandler.java
@@ -101,7 +101,14 @@ public class P2PFileTransferClientHandler extends SimpleChannelInboundHandler<Ht
       Files.createDirectories(partitionDir);
 
       // Prepare the file, remove it if it exists
-      Files.deleteIfExists(partitionDir.resolve(fileName));
+      if (Files.deleteIfExists(partitionDir.resolve(fileName))) {
+        LOGGER.info(
+            "File {} already exists for topic {} partition {}. Overwriting it.",
+            fileName,
+            payload.getTopicName(),
+            payload.getPartition());
+      }
+
       Path file = Files.createFile(partitionDir.resolve(fileName));
 
       outputFileChannel = FileChannel.open(file, StandardOpenOption.WRITE, StandardOpenOption.APPEND);

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/blobtransfer/client/P2PFileTransferClientHandler.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/blobtransfer/client/P2PFileTransferClientHandler.java
@@ -100,8 +100,10 @@ public class P2PFileTransferClientHandler extends SimpleChannelInboundHandler<Ht
       Path partitionDir = Paths.get(payload.getPartitionDir());
       Files.createDirectories(partitionDir);
 
-      // Prepare the file
+      // Prepare the file, remove it if it exists
+      Files.deleteIfExists(partitionDir.resolve(fileName));
       Path file = Files.createFile(partitionDir.resolve(fileName));
+
       outputFileChannel = FileChannel.open(file, StandardOpenOption.WRITE, StandardOpenOption.APPEND);
 
     } else if (msg instanceof HttpContent) {

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/blobtransfer/client/P2PFileTransferClientHandler.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/blobtransfer/client/P2PFileTransferClientHandler.java
@@ -102,7 +102,7 @@ public class P2PFileTransferClientHandler extends SimpleChannelInboundHandler<Ht
 
       // Prepare the file, remove it if it exists
       if (Files.deleteIfExists(partitionDir.resolve(fileName))) {
-        LOGGER.info(
+        LOGGER.debug(
             "File {} already exists for topic {} partition {}. Overwriting it.",
             fileName,
             payload.getTopicName(),

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/blobtransfer/server/BlobTransferNettyChannelInitializer.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/blobtransfer/server/BlobTransferNettyChannelInitializer.java
@@ -1,7 +1,6 @@
 package com.linkedin.davinci.blobtransfer.server;
 
 import com.linkedin.davinci.blobtransfer.BlobSnapshotManager;
-import com.linkedin.davinci.storage.StorageMetadataService;
 import io.netty.channel.ChannelInitializer;
 import io.netty.channel.ChannelPipeline;
 import io.netty.channel.socket.SocketChannel;
@@ -13,15 +12,10 @@ import io.netty.handler.timeout.IdleStateHandler;
 
 public class BlobTransferNettyChannelInitializer extends ChannelInitializer<SocketChannel> {
   private final String baseDir;
-  private StorageMetadataService storageMetadataService;
   private BlobSnapshotManager blobSnapshotManager;
 
-  public BlobTransferNettyChannelInitializer(
-      String baseDir,
-      StorageMetadataService storageMetadataService,
-      BlobSnapshotManager blobSnapshotManager) {
+  public BlobTransferNettyChannelInitializer(String baseDir, BlobSnapshotManager blobSnapshotManager) {
     this.baseDir = baseDir;
-    this.storageMetadataService = storageMetadataService;
     this.blobSnapshotManager = blobSnapshotManager;
   }
 
@@ -38,8 +32,6 @@ public class BlobTransferNettyChannelInitializer extends ChannelInitializer<Sock
         // for safe writing of chunks for responses
         .addLast("chunker", new ChunkedWriteHandler())
         // for handling p2p file transfer
-        .addLast(
-            "p2pFileTransferHandler",
-            new P2PFileTransferServerHandler(baseDir, storageMetadataService, blobSnapshotManager));
+        .addLast("p2pFileTransferHandler", new P2PFileTransferServerHandler(baseDir, blobSnapshotManager));
   }
 }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/blobtransfer/server/BlobTransferNettyChannelInitializer.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/blobtransfer/server/BlobTransferNettyChannelInitializer.java
@@ -1,5 +1,6 @@
 package com.linkedin.davinci.blobtransfer.server;
 
+import com.linkedin.davinci.blobtransfer.BlobSnapshotManager;
 import com.linkedin.davinci.storage.StorageMetadataService;
 import io.netty.channel.ChannelInitializer;
 import io.netty.channel.ChannelPipeline;
@@ -13,10 +14,15 @@ import io.netty.handler.timeout.IdleStateHandler;
 public class BlobTransferNettyChannelInitializer extends ChannelInitializer<SocketChannel> {
   private final String baseDir;
   private StorageMetadataService storageMetadataService;
+  private BlobSnapshotManager blobSnapshotManager;
 
-  public BlobTransferNettyChannelInitializer(String baseDir, StorageMetadataService storageMetadataService) {
+  public BlobTransferNettyChannelInitializer(
+      String baseDir,
+      StorageMetadataService storageMetadataService,
+      BlobSnapshotManager blobSnapshotManager) {
     this.baseDir = baseDir;
     this.storageMetadataService = storageMetadataService;
+    this.blobSnapshotManager = blobSnapshotManager;
   }
 
   @Override
@@ -32,6 +38,8 @@ public class BlobTransferNettyChannelInitializer extends ChannelInitializer<Sock
         // for safe writing of chunks for responses
         .addLast("chunker", new ChunkedWriteHandler())
         // for handling p2p file transfer
-        .addLast("p2pFileTransferHandler", new P2PFileTransferServerHandler(baseDir, storageMetadataService));
+        .addLast(
+            "p2pFileTransferHandler",
+            new P2PFileTransferServerHandler(baseDir, storageMetadataService, blobSnapshotManager));
   }
 }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/blobtransfer/server/P2PBlobTransferService.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/blobtransfer/server/P2PBlobTransferService.java
@@ -1,5 +1,6 @@
 package com.linkedin.davinci.blobtransfer.server;
 
+import com.linkedin.davinci.blobtransfer.BlobSnapshotManager;
 import com.linkedin.davinci.storage.StorageMetadataService;
 import com.linkedin.venice.service.AbstractVeniceService;
 import io.netty.bootstrap.ServerBootstrap;
@@ -31,7 +32,11 @@ public class P2PBlobTransferService extends AbstractVeniceService {
   // TODO 5: add compression support
   // TODO 6: consider either increasing worker threads or have a dedicated thread pool to handle requests.
 
-  public P2PBlobTransferService(int port, String baseDir, StorageMetadataService storageMetadataService) {
+  public P2PBlobTransferService(
+      int port,
+      String baseDir,
+      StorageMetadataService storageMetadataService,
+      BlobSnapshotManager blobSnapshotManager) {
     this.port = port;
     this.serverBootstrap = new ServerBootstrap();
 
@@ -48,7 +53,7 @@ public class P2PBlobTransferService extends AbstractVeniceService {
 
     serverBootstrap.group(bossGroup, workerGroup)
         .channel(socketChannelClass)
-        .childHandler(new BlobTransferNettyChannelInitializer(baseDir, storageMetadataService))
+        .childHandler(new BlobTransferNettyChannelInitializer(baseDir, storageMetadataService, blobSnapshotManager))
         .option(ChannelOption.SO_BACKLOG, 1000)
         .option(ChannelOption.SO_REUSEADDR, true)
         .childOption(ChannelOption.SO_KEEPALIVE, true)

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/blobtransfer/server/P2PBlobTransferService.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/blobtransfer/server/P2PBlobTransferService.java
@@ -1,7 +1,6 @@
 package com.linkedin.davinci.blobtransfer.server;
 
 import com.linkedin.davinci.blobtransfer.BlobSnapshotManager;
-import com.linkedin.davinci.storage.StorageMetadataService;
 import com.linkedin.venice.service.AbstractVeniceService;
 import io.netty.bootstrap.ServerBootstrap;
 import io.netty.channel.ChannelFuture;
@@ -32,11 +31,7 @@ public class P2PBlobTransferService extends AbstractVeniceService {
   // TODO 5: add compression support
   // TODO 6: consider either increasing worker threads or have a dedicated thread pool to handle requests.
 
-  public P2PBlobTransferService(
-      int port,
-      String baseDir,
-      StorageMetadataService storageMetadataService,
-      BlobSnapshotManager blobSnapshotManager) {
+  public P2PBlobTransferService(int port, String baseDir, BlobSnapshotManager blobSnapshotManager) {
     this.port = port;
     this.serverBootstrap = new ServerBootstrap();
 
@@ -53,7 +48,7 @@ public class P2PBlobTransferService extends AbstractVeniceService {
 
     serverBootstrap.group(bossGroup, workerGroup)
         .channel(socketChannelClass)
-        .childHandler(new BlobTransferNettyChannelInitializer(baseDir, storageMetadataService, blobSnapshotManager))
+        .childHandler(new BlobTransferNettyChannelInitializer(baseDir, blobSnapshotManager))
         .option(ChannelOption.SO_BACKLOG, 1000)
         .option(ChannelOption.SO_REUSEADDR, true)
         .childOption(ChannelOption.SO_KEEPALIVE, true)

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/config/VeniceServerConfig.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/config/VeniceServerConfig.java
@@ -5,6 +5,8 @@ import static com.linkedin.davinci.store.rocksdb.RocksDBServerConfig.ROCKSDB_TOT
 import static com.linkedin.venice.ConfigConstants.DEFAULT_MAX_RECORD_SIZE_BYTES_BACKFILL;
 import static com.linkedin.venice.ConfigKeys.AUTOCREATE_DATA_PATH;
 import static com.linkedin.venice.ConfigKeys.BLOB_TRANSFER_MANAGER_ENABLED;
+import static com.linkedin.venice.ConfigKeys.BLOB_TRANSFER_MAX_CONCURRENT_SNAPSHOT_USER;
+import static com.linkedin.venice.ConfigKeys.BLOB_TRANSFER_SNAPSHOT_RETENTION_TIME_IN_MIN;
 import static com.linkedin.venice.ConfigKeys.DATA_BASE_PATH;
 import static com.linkedin.venice.ConfigKeys.DAVINCI_P2P_BLOB_TRANSFER_CLIENT_PORT;
 import static com.linkedin.venice.ConfigKeys.DAVINCI_P2P_BLOB_TRANSFER_SERVER_PORT;
@@ -530,6 +532,8 @@ public class VeniceServerConfig extends VeniceClusterConfig {
   private final boolean recordLevelMetricWhenBootstrappingCurrentVersionEnabled;
   private final String identityParserClassName;
   private final boolean blobTransferManagerEnabled;
+  private final int snapshotRetentionTimeInMin;
+  private final int maxConcurrentSnapshotUser;
   private final int dvcP2pBlobTransferServerPort;
   private final int dvcP2pBlobTransferClientPort;
   private final boolean daVinciCurrentVersionBootstrappingSpeedupEnabled;
@@ -569,6 +573,8 @@ public class VeniceServerConfig extends VeniceClusterConfig {
         serverProperties.getInt(MAX_LEADER_FOLLOWER_STATE_TRANSITION_THREAD_NUMBER, 20);
 
     blobTransferManagerEnabled = serverProperties.getBoolean(BLOB_TRANSFER_MANAGER_ENABLED, false);
+    snapshotRetentionTimeInMin = serverProperties.getInt(BLOB_TRANSFER_SNAPSHOT_RETENTION_TIME_IN_MIN, 30);
+    maxConcurrentSnapshotUser = serverProperties.getInt(BLOB_TRANSFER_MAX_CONCURRENT_SNAPSHOT_USER, 5);
     dvcP2pBlobTransferServerPort = serverProperties.getInt(DAVINCI_P2P_BLOB_TRANSFER_SERVER_PORT, -1);
     dvcP2pBlobTransferClientPort =
         serverProperties.getInt(DAVINCI_P2P_BLOB_TRANSFER_CLIENT_PORT, dvcP2pBlobTransferServerPort);
@@ -1022,6 +1028,14 @@ public class VeniceServerConfig extends VeniceClusterConfig {
 
   public boolean isBlobTransferManagerEnabled() {
     return blobTransferManagerEnabled;
+  }
+
+  public int getMaxConcurrentSnapshotUser() {
+    return maxConcurrentSnapshotUser;
+  }
+
+  public int getSnapshotRetentionTimeInMin() {
+    return snapshotRetentionTimeInMin;
   }
 
   /**

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/ingestion/DefaultIngestionBackend.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/ingestion/DefaultIngestionBackend.java
@@ -96,10 +96,7 @@ public class DefaultIngestionBackend implements IngestionBackend {
    * Blob transfer should be enabled to boostrap from blobs, and it currently only supports batch-stores.
    */
   CompletionStage<Void> bootstrapFromBlobs(Store store, int versionNumber, int partitionId) {
-    // TODO: need to differentiate that's DVC or server. Right now, it doesn't tell so both components can create,
-    // though
-    // Only DVC would create blobTransferManager.
-    if (!store.isBlobTransferEnabled() || store.isHybrid() || blobTransferManager == null) {
+    if (!store.isBlobTransferEnabled() || blobTransferManager == null) {
       return CompletableFuture.completedFuture(null);
     }
 

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/ingestion/DefaultIngestionBackend.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/ingestion/DefaultIngestionBackend.java
@@ -78,9 +78,7 @@ public class DefaultIngestionBackend implements IngestionBackend {
           storeVersion,
           partition);
     };
-    // TODO: remove hybrid check after blob transfer in hybrid mode is fully supported
-    if (!storeAndVersion.getFirst().isBlobTransferEnabled() || storeAndVersion.getFirst().isHybrid()
-        || blobTransferManager == null) {
+    if (!storeAndVersion.getFirst().isBlobTransferEnabled() || blobTransferManager == null) {
       runnable.run();
     } else {
       CompletionStage<Void> bootstrapFuture =

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/store/rocksdb/RocksDBStoragePartition.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/store/rocksdb/RocksDBStoragePartition.java
@@ -489,7 +489,7 @@ public class RocksDBStoragePartition extends AbstractStoragePartition {
   @Override
   public synchronized void createSnapshot() {
     if (blobTransferEnabled) {
-      BlobSnapshotManager.createSnapshotForBatch(rocksDB, fullPathForPartitionDBSnapshot);
+      BlobSnapshotManager.createSnapshot(rocksDB, fullPathForPartitionDBSnapshot);
     }
   }
 

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/blobtransfer/BlobSnapshotManagerTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/blobtransfer/BlobSnapshotManagerTest.java
@@ -1,6 +1,15 @@
 package com.linkedin.davinci.blobtransfer;
 
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import com.linkedin.davinci.storage.StorageEngineRepository;
 import com.linkedin.davinci.storage.StorageMetadataService;
@@ -196,7 +205,7 @@ public class BlobSnapshotManagerTest {
         asyncExecutor.submit(() -> {
           BlobTransferPartitionMetadata actualBlobTransferPartitionMetadata =
               blobSnapshotManager.getTransferMetadata(blobTransferPayload);
-          blobSnapshotManager.decreaseConcurrentUserCount(blobTransferPayload.getTopicName(), PARTITION_ID);
+          blobSnapshotManager.decreaseConcurrentUserCount(blobTransferPayload);
           Assert.assertEquals(actualBlobTransferPartitionMetadata, blobTransferPartitionMetadata);
           latch.countDown();
         });

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/blobtransfer/TestNettyP2PBlobTransferManager.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/blobtransfer/TestNettyP2PBlobTransferManager.java
@@ -7,6 +7,7 @@ import static org.mockito.Mockito.mock;
 
 import com.linkedin.davinci.blobtransfer.client.NettyFileTransferClient;
 import com.linkedin.davinci.blobtransfer.server.P2PBlobTransferService;
+import com.linkedin.davinci.storage.StorageEngineRepository;
 import com.linkedin.davinci.storage.StorageMetadataService;
 import com.linkedin.venice.blobtransfer.BlobFinder;
 import com.linkedin.venice.blobtransfer.BlobPeersDiscoveryResponse;
@@ -14,6 +15,7 @@ import com.linkedin.venice.exceptions.VenicePeersConnectionException;
 import com.linkedin.venice.exceptions.VenicePeersNotFoundException;
 import com.linkedin.venice.kafka.protocol.state.PartitionState;
 import com.linkedin.venice.kafka.protocol.state.StoreVersionState;
+import com.linkedin.venice.meta.ReadOnlyStoreRepository;
 import com.linkedin.venice.offsets.OffsetRecord;
 import com.linkedin.venice.serialization.avro.AvroProtocolDefinition;
 import com.linkedin.venice.serialization.avro.InternalAvroSpecificSerializer;
@@ -45,6 +47,7 @@ public class TestNettyP2PBlobTransferManager {
   NettyFileTransferClient client;
   NettyP2PBlobTransferManager manager;
   StorageMetadataService storageMetadataService;
+  BlobSnapshotManager blobSnapshotManager;
   Path tmpSnapshotDir;
   Path tmpPartitionDir;
   String TEST_STORE = "test_store";
@@ -60,7 +63,12 @@ public class TestNettyP2PBlobTransferManager {
     tmpPartitionDir = Files.createTempDirectory(TMP_PARTITION_DIR);
     // intentionally use different directories for snapshot and partition so that we can verify the file transfer
     storageMetadataService = mock(StorageMetadataService.class);
-    server = new P2PBlobTransferService(port, tmpSnapshotDir.toString(), storageMetadataService);
+
+    ReadOnlyStoreRepository readOnlyStoreRepository = mock(ReadOnlyStoreRepository.class);
+    StorageEngineRepository storageEngineRepository = mock(StorageEngineRepository.class);
+    blobSnapshotManager = Mockito.spy(new BlobSnapshotManager(readOnlyStoreRepository, storageEngineRepository));
+
+    server = new P2PBlobTransferService(port, tmpSnapshotDir.toString(), storageMetadataService, blobSnapshotManager);
     client = Mockito.spy(new NettyFileTransferClient(port, tmpPartitionDir.toString(), storageMetadataService));
     finder = mock(BlobFinder.class);
 
@@ -130,7 +138,10 @@ public class TestNettyP2PBlobTransferManager {
   }
 
   @Test
-  public void testLocalFileTransfer() throws IOException, ExecutionException, InterruptedException, TimeoutException {
+  public void testLocalFileTransferInBatchStore()
+      throws IOException, ExecutionException, InterruptedException, TimeoutException {
+    Mockito.doReturn(false).when(blobSnapshotManager).isStoreHybrid(anyString());
+
     BlobPeersDiscoveryResponse response = new BlobPeersDiscoveryResponse();
     response.setDiscoveryResult(Collections.singletonList("localhost"));
     doReturn(response).when(finder).discoverBlobPeers(anyString(), anyInt(), anyInt());
@@ -189,10 +200,10 @@ public class TestNettyP2PBlobTransferManager {
     Assert.assertTrue(Arrays.equals(Files.readAllBytes(file2), Files.readAllBytes(destFile2)));
     Assert.assertTrue(Arrays.equals(Files.readAllBytes(file3), Files.readAllBytes(destFile3)));
 
-    // Verify the metadata is retrieved
-    Mockito.verify(storageMetadataService, Mockito.times(1))
+    // Verify the metadata is retrieved twice
+    Mockito.verify(storageMetadataService, Mockito.times(2))
         .getLastOffset(TEST_STORE + "_v" + TEST_VERSION, TEST_PARTITION);
-    Mockito.verify(storageMetadataService, Mockito.times(1)).getStoreVersionState(TEST_STORE + "_v" + TEST_VERSION);
+    Mockito.verify(storageMetadataService, Mockito.times(2)).getStoreVersionState(TEST_STORE + "_v" + TEST_VERSION);
 
     // Verify the record is updated
     Mockito.verify(storageMetadataService, Mockito.times(1))
@@ -272,7 +283,93 @@ public class TestNettyP2PBlobTransferManager {
     Assert.assertTrue(Arrays.equals(Files.readAllBytes(file2), Files.readAllBytes(destFile2)));
     Assert.assertTrue(Arrays.equals(Files.readAllBytes(file3), Files.readAllBytes(destFile3)));
 
-    // Verify the metadata is retrieved
+    // Verify the metadata is retrieved twice
+    Mockito.verify(storageMetadataService, Mockito.times(2))
+        .getLastOffset(TEST_STORE + "_v" + TEST_VERSION, TEST_PARTITION);
+    Mockito.verify(storageMetadataService, Mockito.times(2)).getStoreVersionState(TEST_STORE + "_v" + TEST_VERSION);
+
+    // Verify the record is updated
+    Mockito.verify(storageMetadataService, Mockito.times(1))
+        .put(TEST_STORE + "_v" + TEST_VERSION, TEST_PARTITION, expectOffsetRecord);
+
+    // Verify the store version state is updated
+    Mockito.verify(storageMetadataService, Mockito.times(1))
+        .computeStoreVersionState(Mockito.anyString(), Mockito.any());
+  }
+
+  @Test
+  public void testLocalFileTransferInHybridStore()
+      throws IOException, ExecutionException, InterruptedException, TimeoutException {
+    Mockito.doReturn(true).when(blobSnapshotManager).isStoreHybrid(anyString());
+    Mockito.doNothing().when(blobSnapshotManager).createSnapshot(anyString(), anyInt());
+
+    BlobPeersDiscoveryResponse response = new BlobPeersDiscoveryResponse();
+    response.setDiscoveryResult(Collections.singletonList("localhost"));
+    doReturn(response).when(finder).discoverBlobPeers(anyString(), anyInt(), anyInt());
+
+    StoreVersionState storeVersionState = new StoreVersionState();
+    Mockito.doReturn(storeVersionState).when(storageMetadataService).getStoreVersionState(Mockito.any());
+
+    InternalAvroSpecificSerializer<PartitionState> partitionStateSerializer =
+        AvroProtocolDefinition.PARTITION_STATE.getSerializer();
+    OffsetRecord expectOffsetRecord = new OffsetRecord(partitionStateSerializer);
+    expectOffsetRecord.setOffsetLag(1000L);
+    Mockito.doReturn(expectOffsetRecord).when(storageMetadataService).getLastOffset(Mockito.any(), Mockito.anyInt());
+
+    // Prepare files in the snapshot directory
+    Path snapshotDir = Paths.get(
+        RocksDBUtils.composeSnapshotDir(tmpSnapshotDir.toString(), TEST_STORE + "_v" + TEST_VERSION, TEST_PARTITION));
+    Path partitionDir = Paths.get(
+        RocksDBUtils
+            .composePartitionDbDir(tmpPartitionDir.toString(), TEST_STORE + "_v" + TEST_VERSION, TEST_PARTITION));
+    Files.createDirectories(snapshotDir);
+    Path file1 = snapshotDir.resolve("file1.txt");
+    Path file2 = snapshotDir.resolve("file2.txt");
+    Path file3 = snapshotDir.resolve("file3.txt");
+    Path destFile1 = partitionDir.resolve("file1.txt");
+    Path destFile2 = partitionDir.resolve("file2.txt");
+    Path destFile3 = partitionDir.resolve("file3.txt");
+    // small file
+    Files.write(file1.toAbsolutePath(), "helloworld".getBytes());
+    Files.write(file3.toAbsolutePath(), "helloworldtwice".getBytes());
+    // large file
+    long size = 10 * 1024 * 1024;
+    // Create an array of dummy bytes
+    byte[] dummyData = new byte[1024]; // 1KB of dummy data
+    Arrays.fill(dummyData, (byte) 0); // Fill with zeros or any dummy value
+
+    // Write data to the file in chunks
+    for (long written = 0; written < size; written += dummyData.length) {
+      Files.write(file2.toAbsolutePath(), dummyData, StandardOpenOption.CREATE, StandardOpenOption.APPEND);
+    }
+    // file2 content
+    byte[] file2Content = Files.readAllBytes(file2);
+
+    // both files don't exist in the partition directory
+    Assert.assertTrue(Files.notExists(destFile1));
+    Assert.assertTrue(Files.notExists(destFile2));
+    Assert.assertTrue(Files.notExists(destFile3));
+
+    // Manager should be able to fetch the file and download it to another directory
+    CompletionStage<InputStream> future = manager.get(TEST_STORE, TEST_VERSION, TEST_PARTITION);
+    future.toCompletableFuture().get(1, TimeUnit.MINUTES);
+
+    // Verify files are all written to the partition directory
+    Assert.assertTrue(Files.exists(destFile1));
+    Assert.assertTrue(Files.exists(destFile2));
+    Assert.assertTrue(Files.exists(destFile3));
+    // the server snapshot should be deleted
+    Assert.assertTrue(Files.notExists(file1));
+    Assert.assertTrue(Files.notExists(file2));
+    Assert.assertTrue(Files.notExists(file3));
+
+    // same content
+    Assert.assertTrue(Arrays.equals(Files.readAllBytes(destFile1), "helloworld".getBytes()));
+    Assert.assertTrue(Arrays.equals(Files.readAllBytes(destFile2), file2Content));
+    Assert.assertTrue(Arrays.equals(Files.readAllBytes(destFile3), "helloworldtwice".getBytes()));
+
+    // Verify the metadata is retrieved one time,
+    // which is the first time preparing the snapshot before new snapshot is created.
     Mockito.verify(storageMetadataService, Mockito.times(1))
         .getLastOffset(TEST_STORE + "_v" + TEST_VERSION, TEST_PARTITION);
     Mockito.verify(storageMetadataService, Mockito.times(1)).getStoreVersionState(TEST_STORE + "_v" + TEST_VERSION);
@@ -284,5 +381,14 @@ public class TestNettyP2PBlobTransferManager {
     // Verify the store version state is updated
     Mockito.verify(storageMetadataService, Mockito.times(1))
         .computeStoreVersionState(Mockito.anyString(), Mockito.any());
+
+    // Verify the createSnapshot is called
+    Mockito.verify(blobSnapshotManager, Mockito.times(1)).recreateSnapshotForHybrid(Mockito.any());
+    Mockito.verify(blobSnapshotManager, Mockito.times(1)).createSnapshot(TEST_STORE + "_v" + TEST_VERSION, 0);
+
+    // Verify the concurrent user of this partition is 0 as it should firstly be 1 and after the file is sent,
+    // it should decrease to 0
+    long concurrentUser = blobSnapshotManager.getConcurrentSnapshotUsers(TEST_STORE + "_v" + TEST_VERSION, 0);
+    Assert.assertEquals(concurrentUser, 0);
   }
 }

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/blobtransfer/TestP2PFileTransferServerHandler.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/blobtransfer/TestP2PFileTransferServerHandler.java
@@ -110,6 +110,7 @@ public class TestP2PFileTransferServerHandler {
     ch.writeInbound(request);
     FullHttpResponse response = ch.readOutbound();
     Assert.assertEquals(response.status().code(), 404);
+    Assert.assertEquals(blobSnapshotManager.getConcurrentSnapshotUsers("myStore_v1", 10), 0L);
   }
 
   @Test
@@ -131,6 +132,7 @@ public class TestP2PFileTransferServerHandler {
     ch.writeInbound(request);
     FullHttpResponse response = ch.readOutbound();
     Assert.assertEquals(response.status().code(), 500);
+    Assert.assertEquals(blobSnapshotManager.getConcurrentSnapshotUsers("myStore_v1", 10), 0L);
   }
 
   @Test
@@ -191,6 +193,8 @@ public class TestP2PFileTransferServerHandler {
     DefaultHttpResponse endOfTransfer = (DefaultHttpResponse) response;
     Assert.assertEquals(endOfTransfer.headers().get(BLOB_TRANSFER_STATUS), BLOB_TRANSFER_COMPLETED);
     // end of STATUS response
+
+    Assert.assertEquals(blobSnapshotManager.getConcurrentSnapshotUsers("myStore_v1", 10), 0L);
   }
 
   @Test
@@ -267,6 +271,8 @@ public class TestP2PFileTransferServerHandler {
     DefaultHttpResponse endOfTransfer = (DefaultHttpResponse) response;
     Assert.assertEquals(endOfTransfer.headers().get(BLOB_TRANSFER_STATUS), BLOB_TRANSFER_COMPLETED);
     // end of STATUS response
+
+    Assert.assertEquals(blobSnapshotManager.getConcurrentSnapshotUsers("myStore_v1", 10), 0L);
   }
 
   /**
@@ -288,5 +294,7 @@ public class TestP2PFileTransferServerHandler {
     Object response = ch.readOutbound();
     Assert.assertTrue(response instanceof DefaultHttpResponse);
     Assert.assertEquals(((DefaultHttpResponse) response).status(), HttpResponseStatus.NOT_FOUND);
+
+    Assert.assertEquals(blobSnapshotManager.getConcurrentSnapshotUsers("myStore_v1", 10), 0L);
   }
 }

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/blobtransfer/TestP2PFileTransferServerHandler.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/blobtransfer/TestP2PFileTransferServerHandler.java
@@ -7,9 +7,11 @@ import static com.linkedin.davinci.blobtransfer.BlobTransferUtils.BlobTransferTy
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.linkedin.davinci.blobtransfer.server.P2PFileTransferServerHandler;
+import com.linkedin.davinci.storage.StorageEngineRepository;
 import com.linkedin.davinci.storage.StorageMetadataService;
 import com.linkedin.venice.kafka.protocol.state.PartitionState;
 import com.linkedin.venice.kafka.protocol.state.StoreVersionState;
+import com.linkedin.venice.meta.ReadOnlyStoreRepository;
 import com.linkedin.venice.offsets.OffsetRecord;
 import com.linkedin.venice.serialization.avro.AvroProtocolDefinition;
 import com.linkedin.venice.serialization.avro.InternalAvroSpecificSerializer;
@@ -23,7 +25,6 @@ import io.netty.handler.codec.http.FullHttpRequest;
 import io.netty.handler.codec.http.FullHttpResponse;
 import io.netty.handler.codec.http.HttpHeaderNames;
 import io.netty.handler.codec.http.HttpMethod;
-import io.netty.handler.codec.http.HttpResponseStatus;
 import io.netty.handler.codec.http.HttpVersion;
 import io.netty.handler.codec.http.LastHttpContent;
 import io.netty.handler.timeout.IdleStateEvent;
@@ -48,12 +49,19 @@ public class TestP2PFileTransferServerHandler {
   Path baseDir;
   StorageMetadataService storageMetadataService;
   P2PFileTransferServerHandler serverHandler;
+  BlobSnapshotManager blobSnapshotManager;
+  ReadOnlyStoreRepository readOnlyStoreRepository;
+  StorageEngineRepository storageEngineRepository;
 
   @BeforeMethod
   public void setUp() throws IOException {
     baseDir = Files.createTempDirectory("tmp");
     storageMetadataService = Mockito.mock(StorageMetadataService.class);
-    serverHandler = new P2PFileTransferServerHandler(baseDir.toString(), storageMetadataService);
+    readOnlyStoreRepository = Mockito.mock(ReadOnlyStoreRepository.class);
+    storageEngineRepository = Mockito.mock(StorageEngineRepository.class);
+
+    blobSnapshotManager = new BlobSnapshotManager(readOnlyStoreRepository, storageEngineRepository);
+    serverHandler = new P2PFileTransferServerHandler(baseDir.toString(), storageMetadataService, blobSnapshotManager);
     ch = new EmbeddedChannel(serverHandler);
   }
 
@@ -87,6 +95,15 @@ public class TestP2PFileTransferServerHandler {
 
   @Test
   public void testRejectNonExistPath() {
+    // prepare response from metadata service for the metadata preparation
+    StoreVersionState storeVersionState = new StoreVersionState();
+    Mockito.doReturn(storeVersionState).when(storageMetadataService).getStoreVersionState(Mockito.any());
+    InternalAvroSpecificSerializer<PartitionState> partitionStateSerializer =
+        AvroProtocolDefinition.PARTITION_STATE.getSerializer();
+    OffsetRecord offsetRecord = new OffsetRecord(partitionStateSerializer);
+    offsetRecord.setOffsetLag(1000L);
+    Mockito.doReturn(offsetRecord).when(storageMetadataService).getLastOffset(Mockito.any(), Mockito.anyInt());
+
     FullHttpRequest request = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, "/myStore/1/10");
     ch.writeInbound(request);
     FullHttpResponse response = ch.readOutbound();
@@ -94,7 +111,27 @@ public class TestP2PFileTransferServerHandler {
   }
 
   @Test
+  public void testWhenMetadataCreateError() {
+    // prepare the file request
+    FullHttpRequest request = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, "/myStore/1/10");
+
+    ch.writeInbound(request);
+
+    FullHttpResponse response = ch.readOutbound();
+    Assert.assertEquals(response.status().code(), 500);
+  }
+
+  @Test
   public void testFailOnAccessPath() throws IOException {
+    // prepare response from metadata service for the metadata preparation
+    StoreVersionState storeVersionState = new StoreVersionState();
+    Mockito.doReturn(storeVersionState).when(storageMetadataService).getStoreVersionState(Mockito.any());
+    InternalAvroSpecificSerializer<PartitionState> partitionStateSerializer =
+        AvroProtocolDefinition.PARTITION_STATE.getSerializer();
+    OffsetRecord offsetRecord = new OffsetRecord(partitionStateSerializer);
+    offsetRecord.setOffsetLag(1000L);
+    Mockito.doReturn(offsetRecord).when(storageMetadataService).getLastOffset(Mockito.any(), Mockito.anyInt());
+
     // create an empty snapshot dir
     Path snapshotDir = Paths.get(RocksDBUtils.composeSnapshotDir(baseDir.toString(), "myStore_v1", 10));
     Files.createDirectories(snapshotDir);
@@ -114,7 +151,7 @@ public class TestP2PFileTransferServerHandler {
   }
 
   @Test
-  public void testTransferSingleFileAndSingleMetadata() throws IOException {
+  public void testTransferSingleFileAndSingleMetadataForBatchStore() throws IOException {
     // prepare response from metadata service
     StoreVersionState storeVersionState = new StoreVersionState();
     Mockito.doReturn(storeVersionState).when(storageMetadataService).getStoreVersionState(Mockito.any());
@@ -239,38 +276,5 @@ public class TestP2PFileTransferServerHandler {
     DefaultHttpResponse endOfTransfer = (DefaultHttpResponse) response;
     Assert.assertEquals(endOfTransfer.headers().get(BLOB_TRANSFER_STATUS), BLOB_TRANSFER_COMPLETED);
     // end of STATUS response
-  }
-
-  @Test
-  public void testWhenMetadataCreateError() throws IOException {
-    // prepare the file request
-    Path snapshotDir = Paths.get(RocksDBUtils.composeSnapshotDir(baseDir.toString(), "myStore_v1", 10));
-    Files.createDirectories(snapshotDir);
-    Path file1 = snapshotDir.resolve("file1");
-    Files.write(file1.toAbsolutePath(), "hello".getBytes());
-    FullHttpRequest request = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, "/myStore/1/10");
-
-    ch.writeInbound(request);
-
-    // start of file1
-    Object response = ch.readOutbound();
-    Assert.assertTrue(response instanceof DefaultHttpResponse);
-    DefaultHttpResponse httpResponse = (DefaultHttpResponse) response;
-    Assert.assertEquals(
-        httpResponse.headers().get(HttpHeaderNames.CONTENT_DISPOSITION),
-        "attachment; filename=\"file1\"");
-    Assert.assertEquals(httpResponse.headers().get(BLOB_TRANSFER_TYPE), BlobTransferType.FILE.toString());
-    // send the content in one chunk
-    response = ch.readOutbound();
-    Assert.assertTrue(response instanceof DefaultFileRegion);
-    // the last empty response for file1
-    response = ch.readOutbound();
-    Assert.assertTrue(response instanceof LastHttpContent);
-    // end of file1
-
-    // metadata in server side has error
-    response = ch.readOutbound();
-    Assert.assertTrue(response instanceof DefaultHttpResponse);
-    Assert.assertEquals(((DefaultHttpResponse) response).status(), HttpResponseStatus.INTERNAL_SERVER_ERROR);
   }
 }

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/store/rocksdb/RocksDBStoragePartitionTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/store/rocksdb/RocksDBStoragePartitionTest.java
@@ -932,17 +932,17 @@ public class RocksDBStoragePartitionTest {
         storeConfig);
 
     try (MockedStatic<BlobSnapshotManager> mockedBlobSnapshotManager = Mockito.mockStatic(BlobSnapshotManager.class)) {
-      mockedBlobSnapshotManager.when(() -> BlobSnapshotManager.createSnapshotForBatch(Mockito.any(), Mockito.any()))
+      mockedBlobSnapshotManager.when(() -> BlobSnapshotManager.createSnapshot(Mockito.any(), Mockito.any()))
           .thenAnswer(invocation -> {
             return null;
           });
       storagePartition.createSnapshot();
       if (blobTransferEnabled) {
         mockedBlobSnapshotManager
-            .verify(() -> BlobSnapshotManager.createSnapshotForBatch(Mockito.any(), Mockito.any()), Mockito.times(1));
+            .verify(() -> BlobSnapshotManager.createSnapshot(Mockito.any(), Mockito.any()), Mockito.times(1));
       } else {
         mockedBlobSnapshotManager
-            .verify(() -> BlobSnapshotManager.createSnapshotForBatch(Mockito.any(), Mockito.any()), Mockito.never());
+            .verify(() -> BlobSnapshotManager.createSnapshot(Mockito.any(), Mockito.any()), Mockito.never());
       }
     }
 

--- a/internal/venice-common/src/main/java/com/linkedin/venice/ConfigKeys.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/ConfigKeys.java
@@ -1757,6 +1757,10 @@ public class ConfigKeys {
       "davinci.push.status.scan.max.offline.instance.ratio";
   // this is a host-level config to decide whether bootstrap a blob transfer manager for the host
   public static final String BLOB_TRANSFER_MANAGER_ENABLED = "blob.transfer.manager.enabled";
+  public static final String BLOB_TRANSFER_SNAPSHOT_RETENTION_TIME_IN_MIN =
+      "blob.transfer.snapshot.retention.time.in.min";
+  public static final String BLOB_TRANSFER_MAX_CONCURRENT_SNAPSHOT_USER = "blob.transfer.max.concurrent.snapshot.user";
+
   // Port used by peer-to-peer transfer service. It should be used by both server and client
   public static final String DAVINCI_P2P_BLOB_TRANSFER_SERVER_PORT = "davinci.p2p.blob.transfer.server.port";
   // Ideally this config should NOT be used but for testing purpose on a single host, we need to separate the ports.

--- a/services/venice-server/src/main/java/com/linkedin/venice/server/VeniceServer.java
+++ b/services/venice-server/src/main/java/com/linkedin/venice/server/VeniceServer.java
@@ -455,7 +455,9 @@ public class VeniceServer {
           customizedViewFuture,
           storageMetadataService,
           metadataRepo,
-          storageService.getStorageEngineRepository());
+          storageService.getStorageEngineRepository(),
+          serverConfig.getMaxConcurrentSnapshotUser(),
+          serverConfig.getSnapshotRetentionTimeInMin());
     } else {
       blobTransferManager = null;
     }

--- a/services/venice-server/src/main/java/com/linkedin/venice/server/VeniceServer.java
+++ b/services/venice-server/src/main/java/com/linkedin/venice/server/VeniceServer.java
@@ -453,7 +453,9 @@ public class VeniceServer {
           serverConfig.getDvcP2pBlobTransferClientPort(),
           serverConfig.getRocksDBPath(),
           customizedViewFuture,
-          storageMetadataService);
+          storageMetadataService,
+          metadataRepo,
+          storageService.getStorageEngineRepository());
     } else {
       blobTransferManager = null;
     }


### PR DESCRIPTION
<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## [server][dvc] support hybrid store in blob transfer with recreating snapshots
<!--
Describe
- What changes to make and why you are making these changes.
- How are you going to achieve your goal.
- Describe what testings you have done, for example, performance testing etc.

If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

Blob transfer currently does not support hybrid stores because snapshot generation occurs only after Kafka ingestion is complete in batch store, which can result in outdated snapshots for hybrid stores.

To resolve this issue, this PR will:

1. Regenerate a new snapshot if snapshot is staled when a client sends a GET request.
2. Ensure that the transferred offset record accurately reflects the one immediately preceding the snapshot's recreation. If the snapshot manager generates the snapshot first and uses the current offset record for the client, the most recent/largest offset record may be excluded from the snapshot.
3. Throttle concurrent users. The blob snapshot manager will maintain a concurrentSnapshotUsers map to limit the number of hosts that can initiate a snapshot simultaneously for each topic and partition. If too many hosts attempt to request a snapshot for the same topic and partition, the server will respond with a 404 error. The maximum number of allowed concurrent users will be controlled by config.
4. Manage snapshot timestamps by implementing a config-controlled snapshot retention time to ensure the freshness of hybrid snapshots.

## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
unit test.
[WIP] integration test
## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.