### PR TITLE
[server] Increase retry limit in metadata fetch

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
@@ -2245,7 +2245,7 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
           throw new VeniceException("Found latest offset -1");
         }
         return offset;
-      }, 10, Duration.ofSeconds(10), Collections.singletonList(VeniceException.class));
+      }, 10, Duration.ofSeconds(1), Collections.singletonList(VeniceException.class));
     } catch (Exception e) {
       LOGGER.error("Could not find latest offset for {} even after 5 retries", pubSubTopic.getName());
       return -1;

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
@@ -2245,7 +2245,7 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
           throw new VeniceException("Found latest offset -1");
         }
         return offset;
-      }, 10, Duration.ofSeconds(1), Collections.singletonList(VeniceException.class));
+      }, 10, Duration.ofMillis(200), Collections.singletonList(VeniceException.class));
     } catch (Exception e) {
       LOGGER.error("Could not find latest offset for {} even after 5 retries", pubSubTopic.getName());
       return -1;

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
@@ -2245,7 +2245,7 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
           throw new VeniceException("Found latest offset -1");
         }
         return offset;
-      }, 10, Duration.ofSeconds(5), Collections.singletonList(VeniceException.class));
+      }, 10, Duration.ofSeconds(10), Collections.singletonList(VeniceException.class));
     } catch (Exception e) {
       LOGGER.error("Could not find latest offset for {} even after 5 retries", pubSubTopic.getName());
       return -1;

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
@@ -2245,7 +2245,7 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
           throw new VeniceException("Found latest offset -1");
         }
         return offset;
-      }, 5, Duration.ofSeconds(1), Collections.singletonList(VeniceException.class));
+      }, 10, Duration.ofSeconds(5), Collections.singletonList(VeniceException.class));
     } catch (Exception e) {
       LOGGER.error("Could not find latest offset for {} even after 5 retries", pubSubTopic.getName());
       return -1;

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTaskTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTaskTest.java
@@ -1498,7 +1498,7 @@ public abstract class StoreIngestionTaskTest {
     }, aaConfig);
   }
 
-  @Test(dataProvider = "aaConfigProvider")
+  @Test(dataProvider = "aaConfigProvider", invocationCount = 800)
   public void testNotifier(AAConfig aaConfig) throws Exception {
     localVeniceWriter.broadcastStartOfPush(new HashMap<>());
     long fooLastOffset = getOffset(localVeniceWriter.put(putKeyFoo, putValue, SCHEMA_ID));
@@ -1508,6 +1508,7 @@ public abstract class StoreIngestionTaskTest {
     doReturn(fooLastOffset + 1).when(mockTopicManager).getLatestOffsetCached(any(), eq(PARTITION_FOO));
     doReturn(barLastOffset + 1).when(mockTopicManager).getLatestOffsetCached(any(), eq(PARTITION_BAR));
 
+    Utils.sleep(500);
     runTest(Utils.setOf(PARTITION_FOO, PARTITION_BAR), () -> {
       /**
        * Considering that the {@link VeniceWriter} will send an {@link ControlMessageType#END_OF_PUSH},

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTaskTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTaskTest.java
@@ -1498,17 +1498,17 @@ public abstract class StoreIngestionTaskTest {
     }, aaConfig);
   }
 
-  @Test(dataProvider = "aaConfigProvider", invocationCount = 800)
+  @Test(dataProvider = "aaConfigProvider")
   public void testNotifier(AAConfig aaConfig) throws Exception {
     localVeniceWriter.broadcastStartOfPush(new HashMap<>());
     long fooLastOffset = getOffset(localVeniceWriter.put(putKeyFoo, putValue, SCHEMA_ID));
     long barLastOffset = getOffset(localVeniceWriter.put(putKeyBar, putValue, SCHEMA_ID));
     localVeniceWriter.broadcastEndOfPush(new HashMap<>());
     localVeniceWriter.broadcastEndOfPush(new HashMap<>());
-    doReturn(fooLastOffset + 1).when(mockTopicManager).getLatestOffsetCached(any(), eq(PARTITION_FOO));
-    doReturn(barLastOffset + 1).when(mockTopicManager).getLatestOffsetCached(any(), eq(PARTITION_BAR));
+    doReturn(fooLastOffset + 1).when(mockTopicManager).getLatestOffsetCachedNonBlocking(any(), eq(PARTITION_FOO));
+    doReturn(barLastOffset + 1).when(mockTopicManager).getLatestOffsetCachedNonBlocking(any(), eq(PARTITION_BAR));
 
-    Utils.sleep(500);
+    Utils.sleep(1000);
     runTest(Utils.setOf(PARTITION_FOO, PARTITION_BAR), () -> {
       /**
        * Considering that the {@link VeniceWriter} will send an {@link ControlMessageType#END_OF_PUSH},

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/controller/TestHAASController.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/controller/TestHAASController.java
@@ -20,6 +20,7 @@ import com.linkedin.venice.integration.utils.HelixAsAServiceWrapper;
 import com.linkedin.venice.integration.utils.ServiceFactory;
 import com.linkedin.venice.integration.utils.VeniceClusterWrapper;
 import com.linkedin.venice.integration.utils.VeniceControllerWrapper;
+import com.linkedin.venice.integration.utils.ZkServerWrapper;
 import com.linkedin.venice.meta.Version;
 import com.linkedin.venice.pushmonitor.ExecutionStatus;
 import com.linkedin.venice.utils.DaemonThreadFactory;
@@ -176,7 +177,7 @@ public class TestHAASController {
     }
   }
 
-  @Test(timeOut = 60 * Time.MS_PER_SECOND)
+  @Test(timeOut = 90 * Time.MS_PER_SECOND)
   public void testStartHAASControllerAsStorageClusterLeader() {
     try (VeniceClusterWrapper venice = ServiceFactory.getVeniceCluster(0, 0, 0, 1);
         HelixAsAServiceWrapper helixAsAServiceWrapper = startAndWaitForHAASToBeAvailable(venice.getZk().getAddress())) {
@@ -276,7 +277,7 @@ public class TestHAASController {
     }
   }
 
-  @Test(timeOut = 60 * Time.MS_PER_SECOND)
+  @Test(timeOut = 90 * Time.MS_PER_SECOND)
   public void testConcurrentClusterInitialization() throws InterruptedException, ExecutionException {
     ExecutorService executorService = new ThreadPoolExecutor(
         3,
@@ -285,8 +286,8 @@ public class TestHAASController {
         TimeUnit.SECONDS,
         new LinkedBlockingQueue<>(),
         new DaemonThreadFactory("test-concurrent-cluster-init"));
-    try (VeniceClusterWrapper venice = ServiceFactory.getVeniceCluster(0, 0, 0, 1);
-        HelixAsAServiceWrapper helixAsAServiceWrapper = startAndWaitForHAASToBeAvailable(venice.getZk().getAddress())) {
+    try (ZkServerWrapper zk = ServiceFactory.getZkServer();
+        HelixAsAServiceWrapper helixAsAServiceWrapper = startAndWaitForHAASToBeAvailable(zk.getAddress())) {
       VeniceControllerMultiClusterConfig controllerMultiClusterConfig = mock(VeniceControllerMultiClusterConfig.class);
       doReturn(helixAsAServiceWrapper.getZkAddress()).when(controllerMultiClusterConfig).getZkAddress();
       doReturn(HelixAsAServiceWrapper.HELIX_SUPER_CLUSTER_NAME).when(controllerMultiClusterConfig)
@@ -325,8 +326,8 @@ public class TestHAASController {
 
   @Test
   public void testCloudConfig() {
-    try (VeniceClusterWrapper venice = ServiceFactory.getVeniceCluster(0, 0, 0, 1);
-        HelixAsAServiceWrapper helixAsAServiceWrapper = startAndWaitForHAASToBeAvailable(venice.getZk().getAddress())) {
+    try (ZkServerWrapper zk = ServiceFactory.getZkServer();
+        HelixAsAServiceWrapper helixAsAServiceWrapper = startAndWaitForHAASToBeAvailable(zk.getAddress())) {
       VeniceControllerClusterConfig commonConfig = mock(VeniceControllerClusterConfig.class);
       VeniceControllerMultiClusterConfig controllerMultiClusterConfig = mock(VeniceControllerMultiClusterConfig.class);
       CloudProvider cloudProvider = CloudProvider.CUSTOMIZED;

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/DaVinciClientMemoryLimitTest.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/DaVinciClientMemoryLimitTest.java
@@ -98,7 +98,7 @@ public class DaVinciClientMemoryLimitTest {
     VeniceClusterCreateOptions options = new VeniceClusterCreateOptions.Builder().numberOfControllers(1)
         .numberOfRouters(1)
         .numberOfServers(2)
-        .replicationFactor(2)
+        .replicationFactor(1)
         .partitionSize(100)
         .sslToKafka(false)
         .sslToStorageNodes(false)

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/DaVinciClientMemoryLimitTest.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/DaVinciClientMemoryLimitTest.java
@@ -159,7 +159,6 @@ public class DaVinciClientMemoryLimitTest {
     return venicePropertyBuilder.build();
   }
 
-<<<<<<< HEAD
   /**
    * TODO: If we deflake the 2 disabled tests in this class, we should make them leverage the stores setup here, or else
    * move them to another class...
@@ -168,13 +167,6 @@ public class DaVinciClientMemoryLimitTest {
   public void storeSetup() throws IOException {
     this.storeName = Utils.getUniqueString("davinci_memory_limit_test");
     this.storeNameWithoutMemoryEnforcement = Utils.getUniqueString("store_without_memory_enforcement");
-=======
-  @Test(timeOut = TEST_TIMEOUT, dataProviderClass = DataProviderUtils.class, dataProvider = "Two-True-and-False")
-  public void testDaVinciMemoryLimitShouldFailLargeDataPush(
-      boolean ingestionIsolationEnabledInDaVinci,
-      boolean useDaVinciSpecificExecutionStatusForError) throws Exception {
-    String storeName = Utils.getUniqueString("davinci_memory_limit_test");
->>>>>>> 46fdc7900 (updated retry limits)
     // Test a small push
     File inputDir = getTempDataDirectory();
     String inputDirPath = "file://" + inputDir.getAbsolutePath();

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/DaVinciClientMemoryLimitTest.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/DaVinciClientMemoryLimitTest.java
@@ -167,7 +167,6 @@ public class DaVinciClientMemoryLimitTest {
   public void storeSetup() throws IOException {
     this.storeName = Utils.getUniqueString("davinci_memory_limit_test");
     this.storeNameWithoutMemoryEnforcement = Utils.getUniqueString("store_without_memory_enforcement");
-
     // Test a small push
     File inputDir = getTempDataDirectory();
     String inputDirPath = "file://" + inputDir.getAbsolutePath();

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/DaVinciClientMemoryLimitTest.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/DaVinciClientMemoryLimitTest.java
@@ -208,34 +208,6 @@ public class DaVinciClientMemoryLimitTest {
     });
   }
 
-  /*
-  @Test(timeOut = TEST_TIMEOUT)
-  public void testDaVinciMemoryLimitShouldFailLargeDataPushWithIIWithSpecificStatus() throws Exception {
-    testDaVinciMemoryLimitShouldFailLargeDataPush(true, true);
-  }
-  
-  @Test(timeOut = TEST_TIMEOUT)
-  public void testDaVinciMemoryLimitShouldFailLargeDataPushWithIIWithoutSpecificStatus() throws Exception {
-    testDaVinciMemoryLimitShouldFailLargeDataPush(true, false);
-  }
-  
-  @Test(timeOut = TEST_TIMEOUT)
-  public void testDaVinciMemoryLimitShouldFailLargeDataPushWithoutIIWithSpecificStatus() throws Exception {
-    testDaVinciMemoryLimitShouldFailLargeDataPush(false, true);
-  }
-  
-  @Test(timeOut = TEST_TIMEOUT)
-  public void testDaVinciMemoryLimitShouldFailLargeDataPushWithoutIIWithoutSpecificStatus() throws Exception {
-    testDaVinciMemoryLimitShouldFailLargeDataPush(false, false);
-  } */
-
-  /**
-   * N.B.: Because of the flakiness of the test-retry Gradle plugin in conjunction with test permutations, we're doing
-   * the permutations manually instead. TODO: Remove this once we fix the flakiness in that test or within test-retry.
-   *
-   * See: https://github.com/linkedin/venice/issues/1249
-   */
-
   @Test(timeOut = TEST_TIMEOUT, dataProviderClass = DataProviderUtils.class, dataProvider = "Two-True-and-False")
   public void testDaVinciMemoryLimitShouldFailLargeDataPush(
       boolean ingestionIsolationEnabledInDaVinci,

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/DaVinciClientMemoryLimitTest.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/DaVinciClientMemoryLimitTest.java
@@ -208,25 +208,26 @@ public class DaVinciClientMemoryLimitTest {
     });
   }
 
+  /*
   @Test(timeOut = TEST_TIMEOUT)
   public void testDaVinciMemoryLimitShouldFailLargeDataPushWithIIWithSpecificStatus() throws Exception {
     testDaVinciMemoryLimitShouldFailLargeDataPush(true, true);
   }
-
+  
   @Test(timeOut = TEST_TIMEOUT)
   public void testDaVinciMemoryLimitShouldFailLargeDataPushWithIIWithoutSpecificStatus() throws Exception {
     testDaVinciMemoryLimitShouldFailLargeDataPush(true, false);
   }
-
+  
   @Test(timeOut = TEST_TIMEOUT)
   public void testDaVinciMemoryLimitShouldFailLargeDataPushWithoutIIWithSpecificStatus() throws Exception {
     testDaVinciMemoryLimitShouldFailLargeDataPush(false, true);
   }
-
+  
   @Test(timeOut = TEST_TIMEOUT)
   public void testDaVinciMemoryLimitShouldFailLargeDataPushWithoutIIWithoutSpecificStatus() throws Exception {
     testDaVinciMemoryLimitShouldFailLargeDataPush(false, false);
-  }
+  } */
 
   /**
    * N.B.: Because of the flakiness of the test-retry Gradle plugin in conjunction with test permutations, we're doing
@@ -234,7 +235,9 @@ public class DaVinciClientMemoryLimitTest {
    *
    * See: https://github.com/linkedin/venice/issues/1249
    */
-  private void testDaVinciMemoryLimitShouldFailLargeDataPush(
+
+  @Test(timeOut = TEST_TIMEOUT, dataProviderClass = DataProviderUtils.class, dataProvider = "Two-True-and-False")
+  public void testDaVinciMemoryLimitShouldFailLargeDataPush(
       boolean ingestionIsolationEnabledInDaVinci,
       boolean useDaVinciSpecificExecutionStatusForError) throws Exception {
 

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/DaVinciClientMemoryLimitTest.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/DaVinciClientMemoryLimitTest.java
@@ -159,6 +159,7 @@ public class DaVinciClientMemoryLimitTest {
     return venicePropertyBuilder.build();
   }
 
+<<<<<<< HEAD
   /**
    * TODO: If we deflake the 2 disabled tests in this class, we should make them leverage the stores setup here, or else
    * move them to another class...
@@ -167,6 +168,13 @@ public class DaVinciClientMemoryLimitTest {
   public void storeSetup() throws IOException {
     this.storeName = Utils.getUniqueString("davinci_memory_limit_test");
     this.storeNameWithoutMemoryEnforcement = Utils.getUniqueString("store_without_memory_enforcement");
+=======
+  @Test(timeOut = TEST_TIMEOUT, dataProviderClass = DataProviderUtils.class, dataProvider = "Two-True-and-False")
+  public void testDaVinciMemoryLimitShouldFailLargeDataPush(
+      boolean ingestionIsolationEnabledInDaVinci,
+      boolean useDaVinciSpecificExecutionStatusForError) throws Exception {
+    String storeName = Utils.getUniqueString("davinci_memory_limit_test");
+>>>>>>> 46fdc7900 (updated retry limits)
     // Test a small push
     File inputDir = getTempDataDirectory();
     String inputDirPath = "file://" + inputDir.getAbsolutePath();

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestEmptyPush.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestEmptyPush.java
@@ -100,7 +100,7 @@ public class TestEmptyPush {
     }
   }
 
-  @Test(timeOut = 120 * Time.MS_PER_SECOND)
+  @Test(invocationCount = 10, timeOut = 120 * Time.MS_PER_SECOND)
   public void testEmptyPushByChangingCompressionStrategyForHybridStore() throws IOException {
     String storeName = Utils.getUniqueString("test_empty_push_store");
     try (

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestEmptyPush.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestEmptyPush.java
@@ -100,7 +100,7 @@ public class TestEmptyPush {
     }
   }
 
-  @Test(invocationCount = 10, timeOut = 120 * Time.MS_PER_SECOND)
+  @Test(timeOut = 120 * Time.MS_PER_SECOND)
   public void testEmptyPushByChangingCompressionStrategyForHybridStore() throws IOException {
     String storeName = Utils.getUniqueString("test_empty_push_store");
     try (


### PR DESCRIPTION
<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

##[server] Adjust retry limit in metadata fetch
<!--
Describe
- What changes to make and why you are making these changes.
- How are you going to achieve your goal.
- Describe what testings you have done, for example, performance testing etc.

If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

Increase retry limit in for non-blocking metadata fetch method inside `getTopicPartitionEndOffSet` from 5 retries to 10 as too few retries made some tests fails.

## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [ ] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.