### PR TITLE
[server] Incremental push status should not update replica current status

### DIFF
--- a/internal/venice-common/src/main/java/com/linkedin/venice/pushmonitor/PartitionStatus.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/pushmonitor/PartitionStatus.java
@@ -68,8 +68,7 @@ public class PartitionStatus implements Comparable<PartitionStatus> {
       boolean enableStatusHistory) {
     ReplicaStatus replicaStatus =
         replicaStatusMap.compute(instanceId, (k, v) -> v == null ? new ReplicaStatus(k, enableStatusHistory) : v);
-    replicaStatus.setIncrementalPushVersion(incrementalPushVersion);
-    replicaStatus.updateStatus(newStatus);
+    replicaStatus.updateStatus(newStatus, incrementalPushVersion);
     return replicaStatus;
   }
 

--- a/internal/venice-common/src/main/java/com/linkedin/venice/pushmonitor/ReplicaStatus.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/pushmonitor/ReplicaStatus.java
@@ -47,14 +47,16 @@ public class ReplicaStatus {
     this.statusHistory = enableStatusHistory ? new LinkedList<>() : null;
   }
 
-  public void updateStatus(ExecutionStatus newStatus) {
-    currentStatus = newStatus;
+  public void updateStatus(ExecutionStatus newStatus, String incrementalPushVersion) {
+    setIncrementalPushVersion(incrementalPushVersion);
+    if (!isIncrementalPushStatus(newStatus)) {
+      setCurrentStatus(newStatus);
+    }
     addHistoricStatus(newStatus);
   }
 
-  public void updateStatus(ExecutionStatus newStatus, String incrementalPushVersion) {
-    setIncrementalPushVersion(incrementalPushVersion);
-    updateStatus(newStatus);
+  void updateStatus(ExecutionStatus newStatus) {
+    updateStatus(newStatus, "");
   }
 
   public String getInstanceId() {

--- a/internal/venice-common/src/main/java/com/linkedin/venice/pushmonitor/ReplicaStatus.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/pushmonitor/ReplicaStatus.java
@@ -51,7 +51,7 @@ public class ReplicaStatus {
     if (!isIncrementalPushStatus(newStatus)) {
       setCurrentStatus(newStatus);
     }
-    addHistoricStatus(newStatus);
+    addHistoricStatus(newStatus, incrementalPushVersion);
   }
 
   void updateStatus(ExecutionStatus newStatus) {
@@ -98,7 +98,7 @@ public class ReplicaStatus {
     this.statusHistory = statusHistory;
   }
 
-  private void addHistoricStatus(ExecutionStatus status) {
+  private void addHistoricStatus(ExecutionStatus status, String incrementalPushVersion) {
     if (statusHistory == null) {
       // Status history is disabled
       return;
@@ -122,7 +122,7 @@ public class ReplicaStatus {
 
     StatusSnapshot snapshot = new StatusSnapshot(status, LocalDateTime.now().toString());
     if (isIncrementalPushStatus(status)) {
-      snapshot.setIncrementalPushVersion(status.toString());
+      snapshot.setIncrementalPushVersion(incrementalPushVersion);
     }
     statusHistory.add(snapshot);
   }

--- a/internal/venice-common/src/main/java/com/linkedin/venice/pushmonitor/ReplicaStatus.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/pushmonitor/ReplicaStatus.java
@@ -16,7 +16,6 @@ import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Objects;
-import org.apache.commons.lang.StringUtils;
 
 
 /**
@@ -122,8 +121,8 @@ public class ReplicaStatus {
     removeOldStatuses();
 
     StatusSnapshot snapshot = new StatusSnapshot(status, LocalDateTime.now().toString());
-    if (!StringUtils.isEmpty(incrementalPushVersion)) {
-      snapshot.setIncrementalPushVersion(incrementalPushVersion);
+    if (isIncrementalPushStatus(status)) {
+      snapshot.setIncrementalPushVersion(status.toString());
     }
     statusHistory.add(snapshot);
   }

--- a/internal/venice-common/src/test/java/com/linkedin/venice/pushmonitor/PartitionStatusTest.java
+++ b/internal/venice-common/src/test/java/com/linkedin/venice/pushmonitor/PartitionStatusTest.java
@@ -10,11 +10,11 @@ import org.testng.annotations.Test;
 
 
 public class PartitionStatusTest {
-  private int partitionId = 0;
+  private static final int PARTITION_ID = 0;
 
   @Test
   public void testUpdateReplicaStatus() {
-    PartitionStatus partitionStatus = new PartitionStatus(partitionId);
+    PartitionStatus partitionStatus = new PartitionStatus(PARTITION_ID);
     String instanceId = "testInstance";
     Assert.assertEquals(partitionStatus.getReplicaStatus(instanceId), ExecutionStatus.NOT_CREATED);
     partitionStatus.updateReplicaStatus(instanceId, ExecutionStatus.PROGRESS);
@@ -26,7 +26,7 @@ public class PartitionStatusTest {
   @Test
   public void testReadonlyPartitionStatus() {
     String instanceId = "testInstance";
-    PartitionStatus partitionStatus = new PartitionStatus(partitionId);
+    PartitionStatus partitionStatus = new PartitionStatus(PARTITION_ID);
     partitionStatus.updateReplicaStatus(instanceId, ExecutionStatus.PROGRESS);
     PartitionStatus readonlyPartitionStatus = ReadOnlyPartitionStatus.fromPartitionStatus(partitionStatus);
     assertThrows(
@@ -42,7 +42,7 @@ public class PartitionStatusTest {
 
   @Test
   public void testHasFatalDataValidationError() {
-    PartitionStatus partitionStatus = new PartitionStatus(partitionId);
+    PartitionStatus partitionStatus = new PartitionStatus(PARTITION_ID);
     Assert.assertFalse(partitionStatus.hasFatalDataValidationError());
 
     partitionStatus.updateReplicaStatus("testInstance1", ExecutionStatus.COMPLETED);
@@ -61,14 +61,12 @@ public class PartitionStatusTest {
 
   @Test
   public void testValidateBatchUpdateEOIP() {
-    PartitionStatus partitionStatus = new PartitionStatus(partitionId);
+    PartitionStatus partitionStatus = new PartitionStatus(PARTITION_ID);
     Assert.assertFalse(partitionStatus.hasFatalDataValidationError());
 
     partitionStatus.batchUpdateReplicaIncPushStatus("testInstance1", Arrays.asList("a", "b", "c"), 100L);
     Assert.assertFalse(partitionStatus.hasFatalDataValidationError());
-    Assert.assertEquals(
-        partitionStatus.getReplicaStatus("testInstance1"),
-        ExecutionStatus.END_OF_INCREMENTAL_PUSH_RECEIVED);
+    Assert.assertEquals(partitionStatus.getReplicaStatus("testInstance1"), ExecutionStatus.STARTED);
     ReplicaStatus replicaStatus = partitionStatus.getReplicaStatuses().iterator().next();
     Assert.assertEquals(replicaStatus.getCurrentProgress(), 100L);
     Assert.assertEquals(replicaStatus.getStatusHistory().get(0).getIncrementalPushVersion(), "a");

--- a/internal/venice-common/src/test/java/com/linkedin/venice/pushmonitor/ReplicaStatusTest.java
+++ b/internal/venice-common/src/test/java/com/linkedin/venice/pushmonitor/ReplicaStatusTest.java
@@ -16,19 +16,19 @@ import org.testng.annotations.Test;
 
 
 public class ReplicaStatusTest {
-  private final String instanceId = "testInstance";
+  private static final String INSTANCE_ID = "testInstance";
 
   @Test
   public void testCreateReplicaStatus() {
-    ReplicaStatus replicaStatus = new ReplicaStatus(instanceId);
-    Assert.assertEquals(replicaStatus.getInstanceId(), instanceId);
+    ReplicaStatus replicaStatus = new ReplicaStatus(INSTANCE_ID);
+    Assert.assertEquals(replicaStatus.getInstanceId(), INSTANCE_ID);
     Assert.assertEquals(replicaStatus.getCurrentStatus(), STARTED);
     Assert.assertEquals(replicaStatus.getCurrentProgress(), 0);
   }
 
   private void testStatusesUpdate(ExecutionStatus from, ExecutionStatus... statuses) {
     for (ExecutionStatus status: statuses) {
-      ReplicaStatus replicaStatus = new ReplicaStatus(instanceId);
+      ReplicaStatus replicaStatus = new ReplicaStatus(INSTANCE_ID);
       replicaStatus.setCurrentStatus(from);
       replicaStatus.updateStatus(status);
       if (isIncrementalPushStatus(status)) {
@@ -80,7 +80,7 @@ public class ReplicaStatusTest {
 
   @Test
   public void testStatusHistory() {
-    ReplicaStatus replicaStatus = new ReplicaStatus(instanceId);
+    ReplicaStatus replicaStatus = new ReplicaStatus(INSTANCE_ID);
     replicaStatus.updateStatus(STARTED);
     replicaStatus.updateStatus(PROGRESS);
     replicaStatus.updateStatus(COMPLETED);
@@ -94,7 +94,7 @@ public class ReplicaStatusTest {
 
   @Test
   public void testStatusHistoryTooLong() {
-    ReplicaStatus replicaStatus = new ReplicaStatus(instanceId);
+    ReplicaStatus replicaStatus = new ReplicaStatus(INSTANCE_ID);
     for (int i = 0; i < ReplicaStatus.MAX_HISTORY_LENGTH * 2; i++) {
       replicaStatus.updateStatus(STARTED);
     }
@@ -103,7 +103,7 @@ public class ReplicaStatusTest {
 
   @Test
   public void testStatusHistorySaveLastValidStatus() {
-    ReplicaStatus replicaStatus = new ReplicaStatus(instanceId);
+    ReplicaStatus replicaStatus = new ReplicaStatus(INSTANCE_ID);
     replicaStatus.updateStatus(COMPLETED);
     replicaStatus.updateStatus(START_OF_INCREMENTAL_PUSH_RECEIVED);
     for (int i = 0; i <= ReplicaStatus.MAX_HISTORY_LENGTH + 1; i++) {
@@ -124,7 +124,7 @@ public class ReplicaStatusTest {
 
   @Test
   public void testIncrementalPushStatesGotRemovedFirst() {
-    ReplicaStatus replicaStatus = new ReplicaStatus(instanceId);
+    ReplicaStatus replicaStatus = new ReplicaStatus(INSTANCE_ID);
     replicaStatus.updateStatus(STARTED);
     replicaStatus.updateStatus(END_OF_PUSH_RECEIVED);
     replicaStatus.updateStatus(COMPLETED);
@@ -160,7 +160,7 @@ public class ReplicaStatusTest {
 
   @Test
   public void testCurrentIncPushVersionStatusGotSaved() {
-    ReplicaStatus replicaStatus = new ReplicaStatus(instanceId);
+    ReplicaStatus replicaStatus = new ReplicaStatus(INSTANCE_ID);
     // update (max length + 1) statuses to the replica status history
     replicaStatus.updateStatus(STARTED);
     for (int i = 0; i < ReplicaStatus.MAX_HISTORY_LENGTH; i++) {
@@ -174,7 +174,7 @@ public class ReplicaStatusTest {
 
   @Test
   public void testStatusHistoryWithLotsOfProgressStatus() {
-    ReplicaStatus replicaStatus = new ReplicaStatus(instanceId);
+    ReplicaStatus replicaStatus = new ReplicaStatus(INSTANCE_ID);
     replicaStatus.updateStatus(STARTED);
     for (int i = 0; i < ReplicaStatus.MAX_HISTORY_LENGTH * 2; i++) {
       replicaStatus.updateStatus(PROGRESS);

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/controller/TestIncrementalPush.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/controller/TestIncrementalPush.java
@@ -1,32 +1,44 @@
 package com.linkedin.venice.controller;
 
+import static com.linkedin.venice.utils.IntegrationTestPushUtils.runVPJ;
 import static com.linkedin.venice.utils.TestUtils.assertCommand;
+import static com.linkedin.venice.utils.TestWriteUtils.getTempDataDirectory;
 import static java.util.Objects.requireNonNull;
 import static org.testng.Assert.assertEquals;
 
+import com.linkedin.venice.controllerapi.ControllerClient;
 import com.linkedin.venice.controllerapi.StoreResponse;
 import com.linkedin.venice.controllerapi.UpdateStoreQueryParams;
 import com.linkedin.venice.controllerapi.VersionCreationResponse;
+import com.linkedin.venice.helix.HelixAdapterSerializer;
+import com.linkedin.venice.helix.VeniceOfflinePushMonitorAccessor;
+import com.linkedin.venice.helix.ZkClientFactory;
 import com.linkedin.venice.integration.utils.ServiceFactory;
 import com.linkedin.venice.integration.utils.VeniceClusterCreateOptions;
 import com.linkedin.venice.integration.utils.VeniceClusterWrapper;
 import com.linkedin.venice.meta.BackupStrategy;
+import com.linkedin.venice.meta.Store;
 import com.linkedin.venice.meta.StoreInfo;
 import com.linkedin.venice.meta.Version;
 import com.linkedin.venice.pushmonitor.ExecutionStatus;
+import com.linkedin.venice.pushmonitor.OfflinePushStatus;
+import com.linkedin.venice.utils.IntegrationTestPushUtils;
 import com.linkedin.venice.utils.TestUtils;
+import com.linkedin.venice.utils.TestWriteUtils;
 import com.linkedin.venice.utils.Time;
 import com.linkedin.venice.utils.Utils;
 import com.linkedin.venice.writer.VeniceWriter;
+import java.io.File;
+import java.io.IOException;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Optional;
+import java.util.Properties;
 import java.util.concurrent.TimeUnit;
+import org.apache.helix.zookeeper.impl.client.ZkClient;
 import org.testng.Assert;
 import org.testng.annotations.AfterClass;
-import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeClass;
-import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 
@@ -35,7 +47,6 @@ import org.testng.annotations.Test;
  */
 public class TestIncrementalPush {
   private VeniceClusterWrapper cluster;
-  private String storeName;
   private static final int PARTITION_SIZE = 1000;
 
   @BeforeClass(alwaysRun = true)
@@ -46,6 +57,7 @@ public class TestIncrementalPush {
             .replicationFactor(3)
             .partitionSize(PARTITION_SIZE)
             .build());
+
   }
 
   @AfterClass(alwaysRun = true)
@@ -53,9 +65,65 @@ public class TestIncrementalPush {
     cluster.close();
   }
 
-  @BeforeMethod(alwaysRun = true)
-  public void setUp() {
-    storeName = Utils.getUniqueString("testIncPushStore");
+  @Test(timeOut = 2 * Time.MS_PER_MINUTE)
+  public void testIncrementalPushStatusNotUpdateReplicaCurrentStatus() throws IOException {
+    String storeName = Utils.getUniqueString("testIncPushStore");
+    cluster.getNewStore(storeName);
+    UpdateStoreQueryParams params = new UpdateStoreQueryParams();
+    params.setIncrementalPushEnabled(true)
+        .setStorageQuotaInByte(Store.UNLIMITED_STORAGE_QUOTA)
+        .setHybridRewindSeconds(1000)
+        .setHybridOffsetLagThreshold(1000);
+    cluster.updateStore(storeName, params);
+
+    File inputDirBatch = getTempDataDirectory();
+    String inputDirPathBatch = "file:" + inputDirBatch.getAbsolutePath();
+    Properties propsBatch = IntegrationTestPushUtils.defaultVPJProps(cluster, inputDirPathBatch, storeName);
+    TestWriteUtils.writeSimpleAvroFileWithStringToStringSchema(inputDirBatch);
+    ControllerClient controllerClient = new ControllerClient(cluster.getClusterName(), cluster.getAllControllersURLs());
+    runVPJ(propsBatch, 1, controllerClient);
+    String incPushTopic = "TEST_INC_PUSH";
+
+    VeniceWriter<String, String, byte[]> veniceWriterRt =
+        cluster.getVeniceWriter(Version.composeRealTimeTopic(storeName));
+    veniceWriterRt.broadcastStartOfIncrementalPush(incPushTopic, new HashMap<>());
+
+    TestUtils.waitForNonDeterministicCompletion(
+        30,
+        TimeUnit.SECONDS,
+        () -> cluster.getLeaderVeniceController()
+            .getVeniceAdmin()
+            .getOffLinePushStatus(
+                cluster.getClusterName(),
+                Version.composeKafkaTopic(storeName, 1),
+                Optional.of(incPushTopic),
+                null,
+                null)
+            .getExecutionStatus()
+            .equals(ExecutionStatus.START_OF_INCREMENTAL_PUSH_RECEIVED));
+
+    ZkClient zkClient = ZkClientFactory.newZkClient(cluster.getZk().getAddress());
+    VeniceOfflinePushMonitorAccessor accessor =
+        new VeniceOfflinePushMonitorAccessor(cluster.getClusterName(), zkClient, new HelixAdapterSerializer(), 1, 0);
+
+    // Even after consuming SOIP, we should see replica current status not flipped to non-terminal status
+    TestUtils.waitForNonDeterministicAssertion(30, TimeUnit.SECONDS, () -> {
+      OfflinePushStatus offlinePushStatus =
+          accessor.getOfflinePushStatusAndItsPartitionStatuses(Version.composeKafkaTopic(storeName, 1));
+      Assert.assertTrue(
+          offlinePushStatus.getPartitionStatuses()
+              .stream()
+              .allMatch(
+                  partition -> partition.getReplicaStatuses()
+                      .stream()
+                      .allMatch(replica -> replica.getCurrentStatus().equals(ExecutionStatus.COMPLETED))));
+    });
+  }
+
+  @Test(timeOut = 2 * Time.MS_PER_MINUTE)
+  public void testGetOfflineStatusIncrementalPush() {
+
+    String storeName = Utils.getUniqueString("testIncPushStore");
     cluster.getNewStore(storeName);
     long storageQuota = 2L * PARTITION_SIZE;
     UpdateStoreQueryParams params = new UpdateStoreQueryParams();
@@ -66,15 +134,7 @@ public class TestIncrementalPush {
         .setBackupStrategy(BackupStrategy.KEEP_MIN_VERSIONS)
         .setNumVersionsToPreserve(3);
     cluster.updateStore(storeName, params);
-  }
 
-  @AfterMethod(alwaysRun = true)
-  public void cleanUp() {
-    cluster.useControllerClient(controllerClient -> controllerClient.deleteStore(storeName));
-  }
-
-  @Test(timeOut = 2 * Time.MS_PER_MINUTE)
-  public void testGetOfflineStatusIncrementalPush() {
     // store version 1
     VersionCreationResponse v1Response = cluster.getNewVersion(storeName);
     Assert.assertFalse(v1Response.isError());

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestActiveActiveReplicationForIncPush.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestActiveActiveReplicationForIncPush.java
@@ -127,7 +127,7 @@ public class TestActiveActiveReplicationForIncPush {
    * regions. And also incremental push can push to the closes kafka cluster from the grid using the SOURCE_GRID_CONFIG.
    */
   @Test(timeOut = TEST_TIMEOUT, dataProvider = "True-and-False", dataProviderClass = DataProviderUtils.class)
-  public void testAAReplicationForIncrementalPushToRT(Boolean isSeparateRealTimeTopicEnabled) throws Exception {
+  public void testAAReplicationForIncrementalPushToRT(boolean isSeparateRealTimeTopicEnabled) throws Exception {
     File inputDirBatch = getTempDataDirectory();
     File inputDirInc1 = getTempDataDirectory();
     File inputDirInc2 = getTempDataDirectory();
@@ -239,7 +239,7 @@ public class TestActiveActiveReplicationForIncPush {
               .getTopicManagerRepo(
                   PUBSUB_OPERATION_TIMEOUT_MS_DEFAULT_VALUE,
                   100,
-                  0l,
+                  0L,
                   childDataCenter.getKafkaBrokerWrapper(),
                   pubSubTopicRepository)
               .getLocalTopicManager());


### PR DESCRIPTION

<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## [server] Incremental push status should not update replica current status
Offline push job polling checks replica's current status to determine if replicas are ready, if status is not terminal, it will also check if it is ready to start buffer rewind.
Incremental push will also update the replica's current status, so it is possible that it will flip the current status from terminal (COMPLETED) -> non terminal (SOIP)
If there are concurrent / consecutive incremental push, it could potentially result in offline push job polling could not complete forever (especially when there are other factors - slow nodes and such). 

This PR changes the behavior so that SOIP/EOIP won't affect replica current status polling.
Also, it should stop logging tons of "not ready to start buffer replay" due to certain partition status flipped to non-terminal status and which is not EOIP

## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
Add new integration test to validate the behavior and adjust unit test.
## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.