### PR TITLE
[Fix-a-thon] [Not-For-Review] Client bindings and request flows for controller APIs createStore, getStoresInCluster and QueryJobStatus

### DIFF
--- a/internal/venice-common/src/main/java/com/linkedin/venice/grpc/ControllerGrpcTransport.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/grpc/ControllerGrpcTransport.java
@@ -1,0 +1,157 @@
+package com.linkedin.venice.grpc;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Preconditions;
+import com.linkedin.venice.client.exceptions.VeniceClientException;
+import com.linkedin.venice.controllerapi.QueryParams;
+import com.linkedin.venice.exceptions.VeniceException;
+import com.linkedin.venice.protocols.CreateStoreGrpcRequest;
+import com.linkedin.venice.protocols.GetStoresInClusterGrpcRequest;
+import com.linkedin.venice.protocols.QueryJobStatusGrpcRequest;
+import com.linkedin.venice.protocols.VeniceControllerGrpcServiceGrpc;
+import com.linkedin.venice.security.SSLFactory;
+import com.linkedin.venice.utils.concurrent.VeniceConcurrentHashMap;
+import io.grpc.ChannelCredentials;
+import io.grpc.Grpc;
+import io.grpc.InsecureChannelCredentials;
+import io.grpc.ManagedChannel;
+import io.grpc.TlsChannelCredentials;
+import io.grpc.stub.StreamObserver;
+import java.io.IOException;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+
+
+public class ControllerGrpcTransport implements AutoCloseable {
+  private static final int PORT = 1234;
+  private static final String GRPC_ADDRESS_FORMAT = "%s:%s";
+  private final VeniceConcurrentHashMap<String, ManagedChannel> serverGrpcChannels;
+  private final ChannelCredentials channelCredentials;
+  private final VeniceConcurrentHashMap<ManagedChannel, VeniceControllerGrpcServiceGrpc.VeniceControllerGrpcServiceStub> stubCache;
+
+  public ControllerGrpcTransport(Optional<SSLFactory> sslFactory) {
+    this.stubCache = new VeniceConcurrentHashMap<>();
+    this.serverGrpcChannels = new VeniceConcurrentHashMap<>();
+    this.channelCredentials = buildChannelCredentials(sslFactory);
+  }
+
+  public <ResT> CompletionStage<ResT> request(
+      String serverUrl,
+      QueryParams params,
+      Class<ResT> responseType,
+      GrpcControllerRoute route) {
+
+    VeniceControllerGrpcServiceGrpc.VeniceControllerGrpcServiceStub stub = getOrCreateStub(serverUrl);
+    CompletableFuture<ResT> valueFuture = new CompletableFuture<>();
+
+    if (GrpcControllerRoute.CREATE_STORE.equals(route)) {
+      stub.createStore(
+          (CreateStoreGrpcRequest) GrpcConverters.getRequestConverter(route.getRequestType()).convert(params),
+          buildStreamObserver(valueFuture, responseType, route));
+    } else if (GrpcControllerRoute.GET_STORES_IN_CLUSTER.equals(route)) {
+      stub.getStoresInCluster(
+          (GetStoresInClusterGrpcRequest) GrpcConverters.getRequestConverter(route.getRequestType()).convert(params),
+          buildStreamObserver(valueFuture, responseType, route));
+    } else if (GrpcControllerRoute.QUERY_JOB_STATUS.equals(route)) {
+      stub.getJobStatus(
+          (QueryJobStatusGrpcRequest) GrpcConverters.getRequestConverter(route.getRequestType()).convert(params),
+          buildStreamObserver(valueFuture, responseType, route));
+    } else {
+      throw new VeniceException("Unknown gRPC route; Failing the request");
+    }
+
+    return valueFuture;
+  }
+
+  @VisibleForTesting
+  <T, ResT> ControllerGrpcObserver<T, ResT> buildStreamObserver(
+      CompletableFuture<ResT> future,
+      Class<ResT> httpResponseType,
+      GrpcControllerRoute route) {
+    return new ControllerGrpcObserver<>(future, httpResponseType, route);
+  }
+
+  @Override
+  public void close() throws IOException {
+    for (Map.Entry<String, ManagedChannel> entry: serverGrpcChannels.entrySet()) {
+      entry.getValue().shutdown();
+    }
+  }
+
+  @VisibleForTesting
+  ChannelCredentials buildChannelCredentials(Optional<SSLFactory> sslFactory) {
+    SSLFactory factory = sslFactory.orElse(null);
+
+    if (factory == null) {
+      return InsecureChannelCredentials.create();
+    }
+
+    try {
+      TlsChannelCredentials.Builder tlsBuilder = TlsChannelCredentials.newBuilder()
+          .keyManager(GrpcUtils.getKeyManagers(factory))
+          .trustManager(GrpcUtils.getTrustManagers(factory));
+      return tlsBuilder.build();
+    } catch (Exception e) {
+      throw new VeniceClientException(
+          "Failed to initialize SSL channel credentials for Venice gRPC Transport Client",
+          e);
+    }
+  }
+
+  VeniceControllerGrpcServiceGrpc.VeniceControllerGrpcServiceStub getOrCreateStub(String serverAddress) {
+    String grpcAddress = getGrpcAddressFromServerAddress(serverAddress);
+
+    ManagedChannel channel = serverGrpcChannels
+        .computeIfAbsent(serverAddress, k -> Grpc.newChannelBuilder(grpcAddress, channelCredentials).build());
+
+    return stubCache.computeIfAbsent(channel, VeniceControllerGrpcServiceGrpc::newStub);
+  }
+
+  @VisibleForTesting
+  String getGrpcAddressFromServerAddress(String serverAddress) {
+    String[] serverAddressParts = serverAddress.split(":");
+    Preconditions.checkState(serverAddressParts.length == 2, "Invalid server address");
+
+    return String.format(GRPC_ADDRESS_FORMAT, serverAddressParts[0], PORT);
+  }
+
+  static class ControllerGrpcObserver<ResT, HttpResT> implements StreamObserver<ResT> {
+    private final CompletableFuture<HttpResT> responseFuture;
+    private final Class<HttpResT> httpResponseType;
+
+    private final GrpcControllerRoute route;
+
+    public ControllerGrpcObserver(
+        CompletableFuture<HttpResT> future,
+        Class<HttpResT> httpResponseType,
+        GrpcControllerRoute route) {
+      this.httpResponseType = httpResponseType;
+      this.responseFuture = future;
+      this.route = route;
+    }
+
+    @Override
+    public void onNext(ResT value) {
+      if (!responseFuture.isDone()) {
+
+        @SuppressWarnings("Unchecked")
+        HttpResT result = ((GrpcToHttpResponseConverter<ResT, HttpResT>) GrpcConverters
+            .getResponseConverter(route.getResponseType(), httpResponseType)).convert(value);
+
+        responseFuture.complete(result);
+      }
+    }
+
+    @Override
+    public void onError(Throwable t) {
+      responseFuture.completeExceptionally(t);
+    }
+
+    @Override
+    public void onCompleted() {
+      // do nothing
+    }
+  }
+}

--- a/internal/venice-common/src/main/java/com/linkedin/venice/grpc/GrpcControllerRoute.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/grpc/GrpcControllerRoute.java
@@ -1,0 +1,32 @@
+package com.linkedin.venice.grpc;
+
+import com.google.protobuf.GeneratedMessageV3;
+import com.linkedin.venice.protocols.CreateStoreGrpcRequest;
+import com.linkedin.venice.protocols.CreateStoreGrpcResponse;
+import com.linkedin.venice.protocols.GetStoresInClusterGrpcRequest;
+import com.linkedin.venice.protocols.GetStoresInClusterGrpcResponse;
+import com.linkedin.venice.protocols.QueryJobStatusGrpcRequest;
+import com.linkedin.venice.protocols.QueryJobStatusGrpcResponse;
+
+
+public enum GrpcControllerRoute {
+  CREATE_STORE(CreateStoreGrpcRequest.class, CreateStoreGrpcResponse.class),
+  GET_STORES_IN_CLUSTER(GetStoresInClusterGrpcRequest.class, GetStoresInClusterGrpcResponse.class),
+  QUERY_JOB_STATUS(QueryJobStatusGrpcRequest.class, QueryJobStatusGrpcResponse.class);
+
+  private final Class<? extends GeneratedMessageV3> requestType;
+  private final Class<? extends GeneratedMessageV3> responseType;
+
+  GrpcControllerRoute(Class<? extends GeneratedMessageV3> reqT, Class<? extends GeneratedMessageV3> resT) {
+    this.requestType = reqT;
+    this.responseType = resT;
+  }
+
+  public Class<? extends GeneratedMessageV3> getRequestType() {
+    return this.requestType;
+  }
+
+  public Class<? extends GeneratedMessageV3> getResponseType() {
+    return this.responseType;
+  }
+}

--- a/internal/venice-common/src/main/java/com/linkedin/venice/grpc/GrpcConverters.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/grpc/GrpcConverters.java
@@ -1,0 +1,195 @@
+package com.linkedin.venice.grpc;
+
+import static com.linkedin.venice.controllerapi.ControllerApiConstants.*;
+
+import com.linkedin.venice.controllerapi.ControllerRoute;
+import com.linkedin.venice.controllerapi.JobStatusQueryResponse;
+import com.linkedin.venice.controllerapi.MultiStoreInfoResponse;
+import com.linkedin.venice.controllerapi.NewStoreResponse;
+import com.linkedin.venice.controllerapi.QueryParams;
+import com.linkedin.venice.meta.StoreInfo;
+import com.linkedin.venice.meta.UncompletedPartition;
+import com.linkedin.venice.meta.UncompletedReplica;
+import com.linkedin.venice.protocols.CreateStoreGrpcRequest;
+import com.linkedin.venice.protocols.CreateStoreGrpcResponse;
+import com.linkedin.venice.protocols.GetStoresInClusterGrpcRequest;
+import com.linkedin.venice.protocols.GetStoresInClusterGrpcResponse;
+import com.linkedin.venice.protocols.QueryJobStatusGrpcRequest;
+import com.linkedin.venice.protocols.QueryJobStatusGrpcResponse;
+import com.linkedin.venice.pushmonitor.ExecutionStatus;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+
+public class GrpcConverters {
+  static {
+    ResponseConverterRegistry.registerConverter(
+        CreateStoreGrpcResponse.class,
+        NewStoreResponse.class,
+        GrpcConverters::convertCreateStoreResponse);
+    ResponseConverterRegistry.registerConverter(
+        GetStoresInClusterGrpcResponse.class,
+        MultiStoreInfoResponse.class,
+        GrpcConverters::convertGetStoresInClusterResponse);
+    ResponseConverterRegistry.registerConverter(
+        QueryJobStatusGrpcResponse.class,
+        JobStatusQueryResponse.class,
+        GrpcConverters::convertQueryJobStatusResponse);
+
+    RequestConverterRegistry.registerConverter(CreateStoreGrpcRequest.class, GrpcConverters::convertCreateStoreRequest);
+    RequestConverterRegistry
+        .registerConverter(GetStoresInClusterGrpcRequest.class, GrpcConverters::convertGetClusterStoreRequest);
+    RequestConverterRegistry
+        .registerConverter(QueryJobStatusGrpcRequest.class, GrpcConverters::convertQueryJobStatusRequest);
+  }
+
+  public static GrpcControllerRoute mapControllerRouteToGrpcControllerRoute(ControllerRoute route) {
+    if (ControllerRoute.NEW_STORE.equals(route)) {
+      return GrpcControllerRoute.CREATE_STORE;
+    } else if (ControllerRoute.GET_STORES_IN_CLUSTER.equals(route)) {
+      return GrpcControllerRoute.GET_STORES_IN_CLUSTER;
+    } else if (ControllerRoute.JOB.equals(route)) {
+      return GrpcControllerRoute.QUERY_JOB_STATUS;
+    } else {
+      throw new RuntimeException("Converter for route is not implemented");
+    }
+  }
+
+  public static <T> HttpToGrpcRequestConverter<T> getRequestConverter(Class<T> requestType) {
+    return RequestConverterRegistry.getConverter(requestType);
+  }
+
+  public static <S, D> GrpcToHttpResponseConverter<S, D> getResponseConverter(
+      Class<S> grpcResponseType,
+      Class<D> responseType) {
+    return ResponseConverterRegistry.getConverter(grpcResponseType, responseType);
+  }
+
+  private static NewStoreResponse convertCreateStoreResponse(CreateStoreGrpcResponse grpcResponse) {
+    NewStoreResponse response = new NewStoreResponse();
+    response.setOwner(grpcResponse.getOwner());
+    return response;
+  }
+
+  private static MultiStoreInfoResponse convertGetStoresInClusterResponse(GetStoresInClusterGrpcResponse grpcResponse) {
+    ArrayList<StoreInfo> storeInfoList = grpcResponse.getStoresList().stream().map(s -> {
+      StoreInfo info = new StoreInfo();
+      info.setName(s.getName());
+      info.setOwner(s.getOwner());
+      info.setCurrentVersion(s.getCurrentVersion());
+      info.setColoToCurrentVersions(s.getColoToCurrentVersionMap());
+      info.setEnableStoreReads(s.getEnableReads());
+      info.setEnableStoreWrites(s.getEnableWrites());
+      info.setPartitionCount(s.getPartitionCount());
+
+      return info;
+
+    }).collect(ArrayList::new, ArrayList::add, ArrayList::addAll);
+
+    MultiStoreInfoResponse response = new MultiStoreInfoResponse();
+    response.setStoreInfoList(storeInfoList);
+
+    return response;
+  }
+
+  private static JobStatusQueryResponse convertQueryJobStatusResponse(QueryJobStatusGrpcResponse grpcResponse) {
+    JobStatusQueryResponse response = new JobStatusQueryResponse();
+    response.setVersion(grpcResponse.getVersion());
+    response.setStatus(grpcResponse.getStatus());
+    response.setStatusDetails(grpcResponse.getStatusDetails());
+    response.setStatusUpdateTimestamp(grpcResponse.getStatusUpdateTimeStamp());
+    response.setUncompletedPartitions(map(grpcResponse.getUncompletedPartitionsList()));
+    return response;
+  }
+
+  private static List<UncompletedPartition> map(List<QueryJobStatusGrpcResponse.UnCompletedPartition> partitions) {
+    List<UncompletedPartition> output = new ArrayList<>();
+
+    partitions.forEach(partition -> {
+      UncompletedPartition uncompletedPartition = new UncompletedPartition();
+      uncompletedPartition.setPartitionId(partition.getPartition());
+      List<UncompletedReplica> mappedUCRs = partition.getUncompletedReplicasList().stream().map(ucr -> {
+        UncompletedReplica replica = new UncompletedReplica();
+        replica.setStatus(ExecutionStatus.valueOf(ucr.getExecutionStatus()));
+        replica.setStatusDetails(ucr.getStatusDetails());
+        replica.setCurrentOffset(ucr.getCurrentOffset());
+        replica.setInstanceId(ucr.getInstanceId());
+
+        return replica;
+      }).collect(Collectors.toList());
+
+      uncompletedPartition.setUncompletedReplicas(mappedUCRs);
+
+      output.add(uncompletedPartition);
+    });
+
+    return output;
+  }
+
+  // Request converters
+  private static CreateStoreGrpcRequest convertCreateStoreRequest(QueryParams params) {
+    CreateStoreGrpcRequest.Builder requestBuilder = CreateStoreGrpcRequest.newBuilder()
+        .setStoreName(unwrapRequiredOptional(params.getString(NAME)))
+        .setKeySchema(unwrapRequiredOptional(params.getString(KEY_SCHEMA)))
+        .setValueSchema(unwrapRequiredOptional(params.getString(VALUE_SCHEMA)));
+
+    // set optional fields
+    params.getString(OWNER).ifPresent(requestBuilder::setOwner);
+
+    return requestBuilder.build();
+  }
+
+  private static GetStoresInClusterGrpcRequest convertGetClusterStoreRequest(QueryParams params) {
+    return GetStoresInClusterGrpcRequest.newBuilder()
+        .setClusterName(unwrapRequiredOptional(params.getString(CLUSTER)))
+        .build();
+  }
+
+  private static QueryJobStatusGrpcRequest convertQueryJobStatusRequest(QueryParams params) {
+    QueryJobStatusGrpcRequest.Builder requestBuilder = QueryJobStatusGrpcRequest.newBuilder()
+        .setName(unwrapRequiredOptional(params.getString(NAME)))
+        .setVersion(Integer.parseInt(unwrapRequiredOptional(params.getString(VERSION))));
+
+    params.getString(INCREMENTAL_PUSH_VERSION).ifPresent(requestBuilder::setIncrementalPushVersion);
+    params.getString(TARGETED_REGIONS).ifPresent(requestBuilder::setTargetedRegions);
+
+    return requestBuilder.build();
+  }
+
+  private static String unwrapRequiredOptional(Optional<String> value) {
+    return value.orElseThrow(RuntimeException::new);
+  }
+
+  private static class ResponseConverterRegistry {
+    private static final Map<Class<?>, Map<Class<?>, GrpcToHttpResponseConverter<?, ?>>> registry = new HashMap<>();
+
+    public static <S, T> void registerConverter(
+        Class<S> sourceType,
+        Class<T> targetType,
+        GrpcToHttpResponseConverter<S, T> converter) {
+      registry.computeIfAbsent(sourceType, k -> new HashMap<>()).put(targetType, converter);
+    }
+
+    @SuppressWarnings("unchecked")
+    public static <S, T> GrpcToHttpResponseConverter<S, T> getConverter(Class<S> sourceType, Class<T> targetType) {
+      return (GrpcToHttpResponseConverter<S, T>) registry.getOrDefault(sourceType, new HashMap<>()).get(targetType);
+    }
+  }
+
+  private static class RequestConverterRegistry {
+    private static final Map<Class<?>, HttpToGrpcRequestConverter<?>> registry = new HashMap<>();
+
+    public static <T> void registerConverter(Class<T> requestType, HttpToGrpcRequestConverter<T> converter) {
+      registry.computeIfAbsent(requestType, k -> converter);
+    }
+
+    @SuppressWarnings("unchecked")
+    public static <T> HttpToGrpcRequestConverter<T> getConverter(Class<T> requestType) {
+      return (HttpToGrpcRequestConverter<T>) registry.get(requestType);
+    }
+  }
+}

--- a/internal/venice-common/src/main/java/com/linkedin/venice/grpc/GrpcToHttpResponseConverter.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/grpc/GrpcToHttpResponseConverter.java
@@ -1,0 +1,6 @@
+package com.linkedin.venice.grpc;
+
+@FunctionalInterface
+public interface GrpcToHttpResponseConverter<S, D> {
+  D convert(S grpcResponse);
+}

--- a/internal/venice-common/src/main/java/com/linkedin/venice/grpc/HttpToGrpcRequestConverter.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/grpc/HttpToGrpcRequestConverter.java
@@ -1,0 +1,9 @@
+package com.linkedin.venice.grpc;
+
+import com.linkedin.venice.controllerapi.QueryParams;
+
+
+@FunctionalInterface
+public interface HttpToGrpcRequestConverter<D> {
+  D convert(QueryParams requestParams);
+}

--- a/internal/venice-common/src/main/proto/VeniceControllerGrpcService.proto
+++ b/internal/venice-common/src/main/proto/VeniceControllerGrpcService.proto
@@ -1,0 +1,68 @@
+syntax = 'proto3';
+package com.linkedin.venice.protocols;
+
+option java_multiple_files = true;
+
+service VeniceControllerGrpcService {
+  rpc getStoresInCluster (GetStoresInClusterGrpcRequest) returns (GetStoresInClusterGrpcResponse) {}
+  rpc createStore(CreateStoreGrpcRequest) returns (CreateStoreGrpcResponse) {}
+  rpc getJobStatus(QueryJobStatusGrpcRequest) returns (QueryJobStatusGrpcResponse) {}
+}
+
+message GetStoresInClusterGrpcRequest {
+  string clusterName = 1;
+}
+
+message GetStoresInClusterGrpcResponse {
+  message StoreInfo {
+    string name = 1;
+    optional string owner = 2;
+    int32 currentVersion = 3;
+    int32 partitionCount = 4;
+    map<string, int32> coloToCurrentVersion = 5;
+    int32 reservedVersion = 6;
+    bool enableWrites = 7;
+    bool enableReads = 8;
+  }
+
+  repeated StoreInfo stores = 1;
+}
+
+message CreateStoreGrpcRequest {
+  string storeName = 1;
+  string keySchema = 2;
+  string valueSchema = 3;
+  optional string owner = 4;
+}
+
+message CreateStoreGrpcResponse {
+  string owner = 1;
+}
+
+message QueryJobStatusGrpcRequest {
+  string name = 1;
+  int32 version = 2;
+  string targetedRegions = 3;
+  optional string incrementalPushVersion = 4;
+}
+
+message QueryJobStatusGrpcResponse {
+  int32 version = 1;
+  string status = 2;
+  string statusDetails = 3;
+  int64 statusUpdateTimeStamp = 4;
+
+  // intentionally ignore extra information related fields and details
+
+  message UnCompletedPartition {
+    int32 partition = 1;
+    message UnCompletedReplicas {
+      string instanceId = 1;
+      string executionStatus = 2;
+      int64 currentOffset = 3;
+      string statusDetails = 4;
+    }
+    repeated UnCompletedReplicas uncompletedReplicas = 2;
+  }
+  repeated UnCompletedPartition uncompletedPartitions = 5;
+}

--- a/internal/venice-common/src/test/java/com/linkedin/venice/grpc/ControllerGrpcTransportTest.java
+++ b/internal/venice-common/src/test/java/com/linkedin/venice/grpc/ControllerGrpcTransportTest.java
@@ -1,0 +1,148 @@
+package com.linkedin.venice.grpc;
+
+import static com.linkedin.venice.controllerapi.ControllerApiConstants.*;
+import static org.mockito.Mockito.*;
+import static org.testng.Assert.*;
+
+import com.linkedin.venice.controllerapi.MultiStoreInfoResponse;
+import com.linkedin.venice.controllerapi.NewStoreResponse;
+import com.linkedin.venice.controllerapi.QueryParams;
+import com.linkedin.venice.meta.StoreInfo;
+import com.linkedin.venice.protocols.CreateStoreGrpcRequest;
+import com.linkedin.venice.protocols.CreateStoreGrpcResponse;
+import com.linkedin.venice.protocols.GetStoresInClusterGrpcRequest;
+import com.linkedin.venice.protocols.GetStoresInClusterGrpcResponse;
+import com.linkedin.venice.protocols.VeniceControllerGrpcServiceGrpc;
+import java.util.Collections;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import org.mockito.ArgumentMatcher;
+import org.mockito.Mock;
+import org.testng.annotations.Test;
+
+
+public class ControllerGrpcTransportTest {
+  private static final String STORE_CLUSTER_NAME = "test-cluster";
+  private static final String SERVER_URL = "localhost:9000";
+  private static final String STORE_NAME = "test-store";
+  private static final String STORE_KEY_SCHEMA = "test-key-schema";
+  private static final String STORE_VALUE_SCHEMA = "test-value-schema";
+  private static final String STORE_OWNER = "test-owner";
+  private static final int STORE_PARTITION_COUNT = 10;
+  private static final boolean STORE_ENABLE_READS = true;
+  private static final boolean STORE_ENABLE_WRITES = false;
+  private static final int STORE_CURRENT_VERSION = 1;
+  @Mock
+  private ControllerGrpcTransport controllerGrpcTransport;
+
+  @Test
+  public void testCreateStoreRequestSend() {
+    VeniceControllerGrpcServiceGrpc.VeniceControllerGrpcServiceStub mockClientStub =
+        mock(VeniceControllerGrpcServiceGrpc.VeniceControllerGrpcServiceStub.class);
+
+    controllerGrpcTransport = spy(new ControllerGrpcTransport(Optional.empty()));
+
+    doReturn(mockClientStub).when(controllerGrpcTransport).getOrCreateStub(any());
+    QueryParams params = new QueryParams();
+    params.add(NAME, STORE_NAME)
+        .add(KEY_SCHEMA, STORE_KEY_SCHEMA)
+        .add(VALUE_SCHEMA, STORE_VALUE_SCHEMA)
+        .add(OWNER, STORE_OWNER);
+
+    controllerGrpcTransport.request(SERVER_URL, params, NewStoreResponse.class, GrpcControllerRoute.CREATE_STORE);
+    verify(mockClientStub).createStore(argThat(expectedCreateStoreRequest()), any());
+  }
+
+  @Test
+  public void testCreateStoreResponseReceived() {
+    CreateStoreGrpcResponse mockResponse = mock(CreateStoreGrpcResponse.class);
+    CompletableFuture<NewStoreResponse> responseFuture = new CompletableFuture<>();
+
+    when(mockResponse.getOwner()).thenReturn(STORE_OWNER);
+
+    ControllerGrpcTransport.ControllerGrpcObserver<CreateStoreGrpcResponse, NewStoreResponse> observer =
+        new ControllerGrpcTransport.ControllerGrpcObserver<>(
+            responseFuture,
+            NewStoreResponse.class,
+            GrpcControllerRoute.CREATE_STORE);
+
+    observer.onNext(mockResponse);
+
+    assertTrue(responseFuture.isDone());
+    try {
+      NewStoreResponse actualResponse = responseFuture.get();
+      assertEquals(actualResponse.getOwner(), STORE_OWNER);
+    } catch (Exception e) {
+      fail();
+    }
+  }
+
+  @Test
+  public void testGetStoresInClusterRequestSend() {
+    VeniceControllerGrpcServiceGrpc.VeniceControllerGrpcServiceStub mockClientStub =
+        mock(VeniceControllerGrpcServiceGrpc.VeniceControllerGrpcServiceStub.class);
+
+    controllerGrpcTransport = spy(new ControllerGrpcTransport(Optional.empty()));
+
+    doReturn(mockClientStub).when(controllerGrpcTransport).getOrCreateStub(any());
+    QueryParams params = new QueryParams();
+    params.add(CLUSTER, STORE_CLUSTER_NAME);
+
+    controllerGrpcTransport
+        .request(SERVER_URL, params, MultiStoreInfoResponse.class, GrpcControllerRoute.GET_STORES_IN_CLUSTER);
+    verify(mockClientStub).getStoresInCluster(argThat(expectedGetStoreInClusterRequest()), any());
+  }
+
+  @Test
+  public void testGetStoresInClusterResponseReceived() {
+    GetStoresInClusterGrpcResponse mockResponse = mock(GetStoresInClusterGrpcResponse.class);
+    CompletableFuture<MultiStoreInfoResponse> responseFuture = new CompletableFuture<>();
+
+    GetStoresInClusterGrpcResponse.StoreInfo mockStoreInfo = GetStoresInClusterGrpcResponse.StoreInfo.newBuilder()
+        .setName(STORE_NAME)
+        .setOwner(STORE_OWNER)
+        .setPartitionCount(STORE_PARTITION_COUNT)
+        .setEnableReads(STORE_ENABLE_READS)
+        .setEnableWrites(STORE_ENABLE_WRITES)
+        .setCurrentVersion(STORE_CURRENT_VERSION)
+        .build();
+
+    when(mockResponse.getStoresList()).thenReturn(Collections.singletonList(mockStoreInfo));
+
+    ControllerGrpcTransport.ControllerGrpcObserver<GetStoresInClusterGrpcResponse, MultiStoreInfoResponse> observer =
+        new ControllerGrpcTransport.ControllerGrpcObserver<>(
+            responseFuture,
+            MultiStoreInfoResponse.class,
+            GrpcControllerRoute.GET_STORES_IN_CLUSTER);
+
+    observer.onNext(mockResponse);
+
+    assertTrue(responseFuture.isDone());
+    try {
+      MultiStoreInfoResponse actualResponse = responseFuture.get();
+      assertNotNull(actualResponse);
+      assertEquals(actualResponse.getStoreInfoList().size(), 1);
+      StoreInfo info = actualResponse.getStoreInfoList().get(0);
+
+      assertEquals(info.getOwner(), STORE_OWNER);
+      assertEquals(info.getName(), STORE_NAME);
+      assertEquals(info.getPartitionCount(), STORE_PARTITION_COUNT);
+      assertEquals(info.getCurrentVersion(), STORE_CURRENT_VERSION);
+      assertEquals(info.isEnableStoreReads(), STORE_ENABLE_READS);
+      assertEquals(info.isEnableStoreWrites(), STORE_ENABLE_WRITES);
+    } catch (Exception e) {
+      fail();
+    }
+  }
+
+  ArgumentMatcher<CreateStoreGrpcRequest> expectedCreateStoreRequest() {
+    return argument -> STORE_OWNER.equalsIgnoreCase(argument.getOwner())
+        && STORE_NAME.equalsIgnoreCase(argument.getStoreName())
+        && STORE_KEY_SCHEMA.equalsIgnoreCase(argument.getKeySchema())
+        && STORE_VALUE_SCHEMA.equalsIgnoreCase(argument.getValueSchema());
+  }
+
+  ArgumentMatcher<GetStoresInClusterGrpcRequest> expectedGetStoreInClusterRequest() {
+    return argument -> STORE_CLUSTER_NAME.equalsIgnoreCase(argument.getClusterName());
+  }
+}


### PR DESCRIPTION
## Summary, imperative, start upper case, don't end with a period
Client side bindings and GRPC changes to handle following controller APIs
- createStore
- getStoresInCluster
- QueryJobStatus

**Pending**: 
- Wire in the appropriate GRPC port
- Wire the config to enable the GRPC flow for controller route


## How was this PR tested?
Unit test
