### PR TITLE
[server][common] Fixed bug in AA/WC parallel processing support

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/ActiveActiveStoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/ActiveActiveStoreIngestionTask.java
@@ -153,11 +153,10 @@ public class ActiveActiveStoreIngestionTask extends LeaderFollowerStoreIngestion
     this.remoteIngestionRepairService = builder.getRemoteIngestionRepairService();
     this.ingestionBatchProcessorLazy = Lazy.of(() -> {
       if (!serverConfig.isAAWCWorkloadParallelProcessingEnabled()) {
-        LOGGER
-            .info("AA/WC workload parallel processing enabled is false for store version: {}", getKafkaVersionTopic());
+        LOGGER.info("AA/WC workload parallel processing is disabled for store version: {}", getKafkaVersionTopic());
         return null;
       }
-      LOGGER.info("AA/WC workload parallel processing enabled is true for store version: {}", getKafkaVersionTopic());
+      LOGGER.info("AA/WC workload parallel processing is enabled for store version: {}", getKafkaVersionTopic());
       return new IngestionBatchProcessor(
           kafkaVersionTopic,
           parallelProcessingThreadPool,

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/ActiveActiveStoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/ActiveActiveStoreIngestionTask.java
@@ -153,14 +153,15 @@ public class ActiveActiveStoreIngestionTask extends LeaderFollowerStoreIngestion
     this.remoteIngestionRepairService = builder.getRemoteIngestionRepairService();
     this.ingestionBatchProcessorLazy = Lazy.of(() -> {
       if (!serverConfig.isAAWCWorkloadParallelProcessingEnabled()) {
-        LOGGER.info("AA/WC workload parallel processing enabled is false");
+        LOGGER
+            .info("AA/WC workload parallel processing enabled is false for store version: {}", getKafkaVersionTopic());
         return null;
       }
-      LOGGER.info("AA/WC workload parallel processing enabled is true");
+      LOGGER.info("AA/WC workload parallel processing enabled is true for store version: {}", getKafkaVersionTopic());
       return new IngestionBatchProcessor(
           kafkaVersionTopic,
           parallelProcessingThreadPool,
-          null,
+          keyLevelLocksManager.get(),
           this::processActiveActiveMessage,
           isWriteComputationEnabled,
           isActiveActiveReplicationEnabled(),

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/IngestionBatchProcessor.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/IngestionBatchProcessor.java
@@ -28,7 +28,7 @@ import java.util.concurrent.locks.ReentrantLock;
  * resources to speed up the leader ingestion.
  */
 public class IngestionBatchProcessor {
-  public static final TreeMap EMPTY_TREE_MAP = new TreeMap();
+  private static final TreeMap EMPTY_TREE_MAP = new TreeMap();
 
   interface ProcessingFunction {
     PubSubMessageProcessedResult apply(

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTask.java
@@ -340,10 +340,10 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
         serverConfig.isComputeFastAvroEnabled());
     this.ingestionBatchProcessingLazy = Lazy.of(() -> {
       if (!serverConfig.isAAWCWorkloadParallelProcessingEnabled()) {
-        LOGGER.info("AA/WC workload parallel processing enabled is false");
+        LOGGER.info("AA/WC workload parallel processing is disabled for store version: {}", getKafkaVersionTopic());
         return null;
       }
-      LOGGER.info("AA/WC workload parallel processing enabled is true");
+      LOGGER.info("AA/WC workload parallel processing is enabled for store version: {}", getKafkaVersionTopic());
       return new IngestionBatchProcessor(
           kafkaVersionTopic,
           parallelProcessingThreadPool,

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/PubSubMessageProcessedResultWrapper.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/PubSubMessageProcessedResultWrapper.java
@@ -19,7 +19,7 @@ public class PubSubMessageProcessedResultWrapper<K, V, OFFSET> {
     return processedResult;
   }
 
-  public void setProcessedResult(PubSubMessageProcessedResult transformedResult) {
-    this.processedResult = transformedResult;
+  public void setProcessedResult(PubSubMessageProcessedResult processedResult) {
+    this.processedResult = processedResult;
   }
 }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
@@ -38,6 +38,7 @@ import com.linkedin.davinci.store.AbstractStorageEngine;
 import com.linkedin.davinci.store.StoragePartitionConfig;
 import com.linkedin.davinci.store.cache.backend.ObjectCacheBackend;
 import com.linkedin.davinci.store.record.ValueRecord;
+import com.linkedin.davinci.utils.ByteArrayKey;
 import com.linkedin.davinci.utils.ChunkAssembler;
 import com.linkedin.davinci.validation.KafkaDataIntegrityValidator;
 import com.linkedin.davinci.validation.PartitionTracker;
@@ -1262,7 +1263,7 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
      * Process records batch by batch.
      */
     for (List<PubSubMessage<KafkaKey, KafkaMessageEnvelope, Long>> batch: batches) {
-      List<ReentrantLock> locks = ingestionBatchProcessor.lockKeys(batch);
+      Map<ByteArrayKey, ReentrantLock> keyLockMap = ingestionBatchProcessor.lockKeys(batch);
       try {
         long beforeProcessingPerRecordTimestampNs = System.nanoTime();
         List<PubSubMessageProcessedResultWrapper<KafkaKey, KafkaMessageEnvelope, Long>> processedResults =
@@ -1288,7 +1289,7 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
               elapsedTimeForPuttingIntoQueue);
         }
       } finally {
-        ingestionBatchProcessor.unlockKeys(batch, locks);
+        ingestionBatchProcessor.unlockKeys(keyLockMap);
       }
     }
 

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
@@ -126,12 +126,12 @@ import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.NavigableMap;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Properties;
 import java.util.Queue;
 import java.util.Set;
-import java.util.TreeMap;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.ConcurrentSkipListSet;
@@ -1264,7 +1264,7 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
      * Process records batch by batch.
      */
     for (List<PubSubMessage<KafkaKey, KafkaMessageEnvelope, Long>> batch: batches) {
-      TreeMap<ByteArrayKey, ReentrantLock> keyLockMap = ingestionBatchProcessor.lockKeys(batch);
+      NavigableMap<ByteArrayKey, ReentrantLock> keyLockMap = ingestionBatchProcessor.lockKeys(batch);
       try {
         long beforeProcessingPerRecordTimestampNs = System.nanoTime();
         List<PubSubMessageProcessedResultWrapper<KafkaKey, KafkaMessageEnvelope, Long>> processedResults =

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
@@ -131,6 +131,7 @@ import java.util.Optional;
 import java.util.Properties;
 import java.util.Queue;
 import java.util.Set;
+import java.util.TreeMap;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.ConcurrentSkipListSet;
@@ -1263,7 +1264,7 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
      * Process records batch by batch.
      */
     for (List<PubSubMessage<KafkaKey, KafkaMessageEnvelope, Long>> batch: batches) {
-      Map<ByteArrayKey, ReentrantLock> keyLockMap = ingestionBatchProcessor.lockKeys(batch);
+      TreeMap<ByteArrayKey, ReentrantLock> keyLockMap = ingestionBatchProcessor.lockKeys(batch);
       try {
         long beforeProcessingPerRecordTimestampNs = System.nanoTime();
         List<PubSubMessageProcessedResultWrapper<KafkaKey, KafkaMessageEnvelope, Long>> processedResults =

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/utils/ByteArrayKey.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/utils/ByteArrayKey.java
@@ -31,6 +31,10 @@ public class ByteArrayKey {
     return Arrays.equals(content, that.content);
   }
 
+  public byte[] getContent() {
+    return this.content;
+  }
+
   @Override
   public int hashCode() {
     return this.hashCode;

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/utils/ByteArrayKey.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/utils/ByteArrayKey.java
@@ -1,12 +1,13 @@
 package com.linkedin.davinci.utils;
 
+import com.linkedin.venice.utils.ByteUtils;
 import java.util.Arrays;
 
 
 /**
  * A low overhead immutable container of byte[] suitable for use as a map key.
  */
-public class ByteArrayKey {
+public class ByteArrayKey implements Comparable<ByteArrayKey> {
   private final byte[] content;
   private final int hashCode;
 
@@ -42,5 +43,10 @@ public class ByteArrayKey {
 
   public static ByteArrayKey wrap(byte[] content) {
     return new ByteArrayKey(content);
+  }
+
+  @Override
+  public int compareTo(ByteArrayKey o) {
+    return ByteUtils.compare(content, o.content);
   }
 }

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/IngestionBatchProcessorTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/IngestionBatchProcessorTest.java
@@ -116,11 +116,15 @@ public class IngestionBatchProcessorTest {
         true,
         mock(AggVersionedIngestionStats.class),
         mock(HostLevelIngestionStats.class));
-    List<ReentrantLock> locks = batchProcessor.lockKeys(Arrays.asList(rtMessage1, rtMessage2));
+    /**
+     * Switch the input order to make sure the `lockKeys` function would sort them when locking.
+     */
+    List<ReentrantLock> locks = batchProcessor.lockKeys(Arrays.asList(rtMessage2, rtMessage1));
     verify(mockKeyLevelLocksManager).acquireLockByKey(ByteArrayKey.wrap(key1));
     verify(mockKeyLevelLocksManager).acquireLockByKey(ByteArrayKey.wrap(key2));
     verify(lockForKey1).lock();
     verify(lockForKey2).lock();
+    // Verify the order
     assertEquals(locks.get(0), lockForKey1);
     assertEquals(locks.get(1), lockForKey2);
 

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/IngestionBatchProcessorTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/IngestionBatchProcessorTest.java
@@ -4,6 +4,7 @@ import static org.mockito.ArgumentMatchers.anyDouble;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertEquals;
@@ -31,6 +32,7 @@ import com.linkedin.venice.utils.DaemonThreadFactory;
 import java.nio.ByteBuffer;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.locks.ReentrantLock;
 import org.testng.annotations.Test;
 
@@ -119,22 +121,34 @@ public class IngestionBatchProcessorTest {
     /**
      * Switch the input order to make sure the `lockKeys` function would sort them when locking.
      */
-    List<ReentrantLock> locks = batchProcessor.lockKeys(Arrays.asList(rtMessage2, rtMessage1));
+    Map<ByteArrayKey, ReentrantLock> keyLockMap = batchProcessor.lockKeys(Arrays.asList(rtMessage2, rtMessage1));
     verify(mockKeyLevelLocksManager).acquireLockByKey(ByteArrayKey.wrap(key1));
     verify(mockKeyLevelLocksManager).acquireLockByKey(ByteArrayKey.wrap(key2));
     verify(lockForKey1).lock();
     verify(lockForKey2).lock();
     // Verify the order
-    assertEquals(locks.get(0), lockForKey1);
-    assertEquals(locks.get(1), lockForKey2);
+    ReentrantLock[] locks = keyLockMap.values().toArray(new ReentrantLock[0]);
+    assertEquals(locks[0], lockForKey1);
+    assertEquals(locks[1], lockForKey2);
 
     // unlock test
-    batchProcessor.unlockKeys(Arrays.asList(rtMessage1, rtMessage2), locks);
+    batchProcessor.unlockKeys(keyLockMap);
 
     verify(lockForKey1).unlock();
     verify(lockForKey2).unlock();
     verify(mockKeyLevelLocksManager).releaseLock(ByteArrayKey.wrap(key1));
     verify(mockKeyLevelLocksManager).releaseLock(ByteArrayKey.wrap(key2));
+
+    // Duplicate messages in the batch
+    keyLockMap = batchProcessor.lockKeys(Arrays.asList(rtMessage1, rtMessage2, rtMessage1));
+    verify(mockKeyLevelLocksManager, times(2)).acquireLockByKey(ByteArrayKey.wrap(key1));
+    verify(mockKeyLevelLocksManager, times(2)).acquireLockByKey(ByteArrayKey.wrap(key2));
+    verify(lockForKey1, times(2)).lock();
+    verify(lockForKey2, times(2)).lock();
+    // Verify the order
+    locks = keyLockMap.values().toArray(new ReentrantLock[0]);
+    assertEquals(locks[0], lockForKey1);
+    assertEquals(locks[1], lockForKey2);
   }
 
   @Test

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/IngestionBatchProcessorTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/IngestionBatchProcessorTest.java
@@ -32,7 +32,7 @@ import com.linkedin.venice.utils.DaemonThreadFactory;
 import java.nio.ByteBuffer;
 import java.util.Arrays;
 import java.util.List;
-import java.util.TreeMap;
+import java.util.NavigableMap;
 import java.util.concurrent.locks.ReentrantLock;
 import org.testng.annotations.Test;
 
@@ -121,7 +121,8 @@ public class IngestionBatchProcessorTest {
     /**
      * Switch the input order to make sure the `lockKeys` function would sort them when locking.
      */
-    TreeMap<ByteArrayKey, ReentrantLock> keyLockMap = batchProcessor.lockKeys(Arrays.asList(rtMessage2, rtMessage1));
+    NavigableMap<ByteArrayKey, ReentrantLock> keyLockMap =
+        batchProcessor.lockKeys(Arrays.asList(rtMessage2, rtMessage1));
     verify(mockKeyLevelLocksManager).acquireLockByKey(ByteArrayKey.wrap(key1));
     verify(mockKeyLevelLocksManager).acquireLockByKey(ByteArrayKey.wrap(key2));
     verify(lockForKey1).lock();

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/IngestionBatchProcessorTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/IngestionBatchProcessorTest.java
@@ -32,7 +32,7 @@ import com.linkedin.venice.utils.DaemonThreadFactory;
 import java.nio.ByteBuffer;
 import java.util.Arrays;
 import java.util.List;
-import java.util.Map;
+import java.util.TreeMap;
 import java.util.concurrent.locks.ReentrantLock;
 import org.testng.annotations.Test;
 
@@ -121,7 +121,7 @@ public class IngestionBatchProcessorTest {
     /**
      * Switch the input order to make sure the `lockKeys` function would sort them when locking.
      */
-    Map<ByteArrayKey, ReentrantLock> keyLockMap = batchProcessor.lockKeys(Arrays.asList(rtMessage2, rtMessage1));
+    TreeMap<ByteArrayKey, ReentrantLock> keyLockMap = batchProcessor.lockKeys(Arrays.asList(rtMessage2, rtMessage1));
     verify(mockKeyLevelLocksManager).acquireLockByKey(ByteArrayKey.wrap(key1));
     verify(mockKeyLevelLocksManager).acquireLockByKey(ByteArrayKey.wrap(key2));
     verify(lockForKey1).lock();

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTaskTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTaskTest.java
@@ -3152,6 +3152,14 @@ public abstract class StoreIngestionTaskTest {
         Optional.empty(),
         null);
 
+    if (hybridConfig.equals(HYBRID) && nodeType.equals(LEADER) && isAaWCParallelProcessingEnabled()) {
+      assertTrue(storeIngestionTaskUnderTest instanceof ActiveActiveStoreIngestionTask);
+      ActiveActiveStoreIngestionTask activeActiveStoreIngestionTask =
+          (ActiveActiveStoreIngestionTask) storeIngestionTaskUnderTest;
+      assertNotNull(activeActiveStoreIngestionTask.getIngestionBatchProcessor());
+      assertNotNull(activeActiveStoreIngestionTask.getIngestionBatchProcessor().getLockManager());
+    }
+
     String rtTopicName = Version.composeRealTimeTopic(mockStore.getName());
     PubSubTopic rtTopic = pubSubTopicRepository.getTopic(rtTopicName);
     TopicSwitch topicSwitchWithMultipleSourceKafkaServers = new TopicSwitch();

--- a/internal/venice-client-common/src/main/java/com/linkedin/venice/utils/SparseConcurrentList.java
+++ b/internal/venice-client-common/src/main/java/com/linkedin/venice/utils/SparseConcurrentList.java
@@ -250,6 +250,12 @@ public class SparseConcurrentList<E> extends CopyOnWriteArrayList<E> {
         if (element == null) {
           element = mappingFunction.apply(index);
           /**
+           * Don't update the list if the computed result is `null`.
+           */
+          if (element == null) {
+            return null;
+          }
+          /**
            * It's important NOT to call {@link #handleSizeDuringMutation(Object, Object)} since {@link #set(int, Object)}
            * already calls it.
            */

--- a/internal/venice-client-common/src/test/java/com/linkedin/venice/utils/SparseConcurrentListTest.java
+++ b/internal/venice-client-common/src/test/java/com/linkedin/venice/utils/SparseConcurrentListTest.java
@@ -86,6 +86,10 @@ public class SparseConcurrentListTest {
     assertEquals(scl.values().size(), scl.nonNullSize());
     assertFalse(scl.isEmpty());
 
+    // Compute if absent for an unpopulated index with computed result as `null`.
+    scl.computeIfAbsent(40, k -> null);
+    assertEquals(scl.size(), 8);
+
     // Go back to the initial state...
     scl.clear();
     assertEquals(scl.size(), 0);


### PR DESCRIPTION


<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## Summary, imperative, start upper case, don't end with a period
This PR fixed the following issues:
1. AASIT should pass non-null `KeyLevelLocksManager` to `IngestionBatchProcessor`, otherwise, race condition will happen.
2. Fixed the locking order in `IngestionBatchProcessor` to avoid deadlock.
3. Updated `SparseConcurrentList#computeIfAbsent` to skip adjust list size if the computed result is `null`.
<!--
Describe
- What changes to make and why you are making these changes.
- How are you going to achieve your goal.
- Describe what testings you have done, for example, performance testing etc.

If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->


## How was this PR tested?
CI
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.