### PR TITLE
[router] Added more debugging details to compression inconsistency issue

### DIFF
--- a/services/venice-router/src/main/java/com/linkedin/venice/router/api/VeniceResponseAggregator.java
+++ b/services/venice-router/src/main/java/com/linkedin/venice/router/api/VeniceResponseAggregator.java
@@ -343,11 +343,12 @@ public class VeniceResponseAggregator implements ResponseAggregatorFactory<Basic
       return responseCompression;
     } else {
       String errorMsg = String.format(
-          "Inconsistent compression strategy returned. Store: %s; Version: %d, ExpectedCompression: %d, ResponseCompression: %d",
+          "Inconsistent compression strategy returned. Store: %s; Version: %d, ExpectedCompression: %d, ResponseCompression: %d, All headers: %s",
           storeName,
           version,
           compressionStrategy.getValue(),
-          responseCompression.getValue());
+          responseCompression.getValue(),
+          response.headers().toString());
       throw RouterExceptionAndTrackingUtils.newVeniceExceptionAndTracking(
           Optional.of(storeName),
           Optional.of(RequestType.MULTI_GET),


### PR DESCRIPTION
The router expects to get the same compression scheme from all server responses when performing a batch get, but it seems that this is not always the case. This change will log the response headers in case this happens, in the hope that it gives more clues about what went wrong.

## How was this PR tested?
GHCI.

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.