### PR TITLE
[server] fix flaky test in blob transfer integration test

### DIFF
--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/BlobP2PTransferAmongServersTest.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/BlobP2PTransferAmongServersTest.java
@@ -66,7 +66,7 @@ public class BlobP2PTransferAmongServersTest {
     }
   }
 
-  @Test(singleThreaded = true)
+  @Test(singleThreaded = true, timeOut = 180000)
   public void testBlobP2PTransferAmongServersForBatchStore() throws Exception {
     String storeName = "test-store";
     Consumer<UpdateStoreQueryParams> paramsConsumer = params -> params.setBlobTransferEnabled(true);
@@ -139,7 +139,7 @@ public class BlobP2PTransferAmongServersTest {
    * If there are no snapshots available for the store on server2, the blob transfer should throw an exception and return a 404 error.
    * When server1 restarts and receives the 404 error from server2, it will switch to using Kafka to ingest the data.
    */
-  @Test(singleThreaded = true)
+  @Test(singleThreaded = true, timeOut = 180000)
   public void testBlobTransferThrowExceptionIfSnapshotNotExisted() throws Exception {
     String storeName = "test-store-snapshot-not-existed";
     Consumer<UpdateStoreQueryParams> paramsConsumer = params -> params.setBlobTransferEnabled(true);
@@ -286,7 +286,7 @@ public class BlobP2PTransferAmongServersTest {
     LOGGER.info("**TIME** VPJ" + expectedVersionNumber + " takes " + (System.currentTimeMillis() - vpjStart));
   }
 
-  @Test(singleThreaded = true)
+  @Test(singleThreaded = true, timeOut = 180000)
   public void testBlobP2PTransferAmongServersForHybridStore() throws Exception {
     ControllerClient controllerClient = new ControllerClient(cluster.getClusterName(), cluster.getAllControllersURLs());
     // prepare hybrid store.

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/BlobP2PTransferAmongServersTest.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/BlobP2PTransferAmongServersTest.java
@@ -306,13 +306,15 @@ public class BlobP2PTransferAmongServersTest {
     VeniceServerWrapper server2 = cluster.getVeniceServers().get(1);
 
     // offset record should be same after the empty push
-    for (int partitionId = 0; partitionId < PARTITION_COUNT; partitionId++) {
-      OffsetRecord offsetRecord1 =
-          server1.getVeniceServer().getStorageMetadataService().getLastOffset(storeName + "_v1", partitionId);
-      OffsetRecord offsetRecord2 =
-          server2.getVeniceServer().getStorageMetadataService().getLastOffset(storeName + "_v1", partitionId);
-      Assert.assertEquals(offsetRecord2.getLocalVersionTopicOffset(), offsetRecord1.getLocalVersionTopicOffset());
-    }
+    TestUtils.waitForNonDeterministicAssertion(2, TimeUnit.MINUTES, () -> {
+      for (int partitionId = 0; partitionId < PARTITION_COUNT; partitionId++) {
+        OffsetRecord offsetRecord1 =
+            server1.getVeniceServer().getStorageMetadataService().getLastOffset(storeName + "_v1", partitionId);
+        OffsetRecord offsetRecord2 =
+            server2.getVeniceServer().getStorageMetadataService().getLastOffset(storeName + "_v1", partitionId);
+        Assert.assertEquals(offsetRecord2.getLocalVersionTopicOffset(), offsetRecord1.getLocalVersionTopicOffset());
+      }
+    });
 
     // cleanup and stop server 1
     cluster.stopVeniceServer(server1.getPort());


### PR DESCRIPTION
<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## [server] fix flaky test in blob transfer integration test
Fix the flaky integration test in blob transfer. The offset records of server1 and server2 could differ because the ingestion speed may vary.
<!--
Describe
- What changes to make and why you are making these changes.
- How are you going to achieve your goal.
- Describe what testings you have done, for example, performance testing etc.

If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->



## How was this PR tested?
Integration test.
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.