### PR TITLE
[admin-tool][server] Add two admin tool commands for dumping consumer ingestion states and heartbeat states; Add logging for stale heartbeat replicas

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/AbstractKafkaConsumerService.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/AbstractKafkaConsumerService.java
@@ -40,8 +40,10 @@ public abstract class AbstractKafkaConsumerService extends AbstractVeniceService
       PubSubTopic versionTopic,
       PubSubTopicPartition pubSubTopicPartition);
 
-  public abstract Map<PubSubTopicPartition, TopicPartitionIngestionInfo> getIngestionInfoFromConsumer(
+  public abstract Map<String, TopicPartitionIngestionInfo> getIngestionInfoFromConsumer(
       PubSubTopic versionTopic,
       PubSubTopicPartition pubSubTopicPartition);
+
+  public abstract Map<String, ConsumerServiceIngestionInfo> getIngestionInfoFromConsumerServices();
 
 }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/ConsumerIngestionInfo.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/ConsumerIngestionInfo.java
@@ -1,0 +1,74 @@
+package com.linkedin.davinci.kafka.consumer;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.Map;
+
+
+public class ConsumerIngestionInfo {
+  private String consumerName;
+  private Map<String, TopicPartitionIngestionInfo> consumerIngestionInfo;
+
+  @JsonCreator
+  public ConsumerIngestionInfo(
+      @JsonProperty("consumerName") String consumerName,
+      @JsonProperty("consumerIngestionInfo") Map<String, TopicPartitionIngestionInfo> consumerIngestionInfo) {
+    this.consumerIngestionInfo = consumerIngestionInfo;
+    this.consumerName = consumerName;
+  }
+
+  public String getConsumerName() {
+    return consumerName;
+  }
+
+  public void setConsumerName(String consumerName) {
+    this.consumerName = consumerName;
+  }
+
+  public Map<String, TopicPartitionIngestionInfo> getConsumerIngestionInfo() {
+    return consumerIngestionInfo;
+  }
+
+  public void setConsumerIngestionInfo(Map<String, TopicPartitionIngestionInfo> consumerIngestionInfo) {
+    this.consumerIngestionInfo = consumerIngestionInfo;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+
+    ConsumerIngestionInfo consumerIngestionInfo = (ConsumerIngestionInfo) o;
+    return this.consumerName.equals(consumerIngestionInfo.getConsumerName())
+        && this.consumerIngestionInfo.equals(consumerIngestionInfo.getConsumerIngestionInfo());
+  }
+
+  @Override
+  public int hashCode() {
+    int result = consumerName.hashCode();
+    result = 31 * result + consumerIngestionInfo.hashCode();
+    return result;
+  }
+
+  @Override
+  public String toString() {
+    StringBuilder sb = new StringBuilder();
+    sb.append("{");
+
+    for (Map.Entry<String, TopicPartitionIngestionInfo> entry: consumerIngestionInfo.entrySet()) {
+      sb.append("\"").append(entry.getKey()).append("\"").append("=").append(entry.getValue().toString()).append(", ");
+    }
+
+    // Remove trailing comma and space, if any
+    if (!consumerIngestionInfo.isEmpty()) {
+      sb.setLength(sb.length() - 2);
+    }
+
+    sb.append("}");
+    return sb.toString();
+  }
+}

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/ConsumerServiceIngestionInfo.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/ConsumerServiceIngestionInfo.java
@@ -1,0 +1,74 @@
+package com.linkedin.davinci.kafka.consumer;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.Map;
+
+
+public class ConsumerServiceIngestionInfo {
+  private String consumerServiceName;
+  private Map<String, ConsumerIngestionInfo> consumerServiceIngestionInfo;
+
+  @JsonCreator
+  public ConsumerServiceIngestionInfo(
+      @JsonProperty("consumerServiceName") String consumerServiceName,
+      @JsonProperty("consumerServiceIngestionInfo") Map<String, ConsumerIngestionInfo> consumerServiceIngestionInfo) {
+    this.consumerServiceIngestionInfo = consumerServiceIngestionInfo;
+    this.consumerServiceName = consumerServiceName;
+  }
+
+  public void setConsumerServiceName(String consumerServiceName) {
+    this.consumerServiceName = consumerServiceName;
+  }
+
+  public String getConsumerServiceName() {
+    return consumerServiceName;
+  }
+
+  public void setConsumerServiceIngestionInfo(Map<String, ConsumerIngestionInfo> consumerServiceIngestionInfo) {
+    this.consumerServiceIngestionInfo = consumerServiceIngestionInfo;
+  }
+
+  public Map<String, ConsumerIngestionInfo> getConsumerServiceIngestionInfo() {
+    return consumerServiceIngestionInfo;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+
+    ConsumerServiceIngestionInfo consumerServiceIngestionInfo = (ConsumerServiceIngestionInfo) o;
+    return this.consumerServiceName.equals(consumerServiceIngestionInfo.getConsumerServiceName())
+        && this.consumerServiceIngestionInfo.equals(consumerServiceIngestionInfo.getConsumerServiceIngestionInfo());
+  }
+
+  @Override
+  public int hashCode() {
+    int result = consumerServiceName.hashCode();
+    result = 31 * result + consumerServiceIngestionInfo.hashCode();
+    return result;
+  }
+
+  @Override
+  public String toString() {
+    StringBuilder sb = new StringBuilder();
+    sb.append("{");
+
+    for (Map.Entry<String, ConsumerIngestionInfo> entry: consumerServiceIngestionInfo.entrySet()) {
+      sb.append("\"").append(entry.getKey()).append("\"").append("=").append(entry.getValue().toString()).append(", ");
+    }
+
+    // Remove trailing comma and space, if any
+    if (!consumerServiceIngestionInfo.isEmpty()) {
+      sb.setLength(sb.length() - 2);
+    }
+
+    sb.append("}");
+    return sb.toString();
+  }
+}

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/KafkaConsumerServiceDelegator.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/KafkaConsumerServiceDelegator.java
@@ -219,7 +219,7 @@ public class KafkaConsumerServiceDelegator extends AbstractKafkaConsumerService 
   }
 
   @Override
-  public Map<PubSubTopicPartition, TopicPartitionIngestionInfo> getIngestionInfoFromConsumer(
+  public Map<String, TopicPartitionIngestionInfo> getIngestionInfoFromConsumer(
       PubSubTopic versionTopic,
       PubSubTopicPartition pubSubTopicPartition) {
     KafkaConsumerService kafkaConsumerService = getKafkaConsumerService(versionTopic, pubSubTopicPartition);
@@ -233,6 +233,17 @@ public class KafkaConsumerServiceDelegator extends AbstractKafkaConsumerService 
           pubSubTopicPartition);
       return Collections.emptyMap();
     }
+  }
+
+  @Override
+  public Map<String, ConsumerServiceIngestionInfo> getIngestionInfoFromConsumerServices() {
+    Map<String, ConsumerServiceIngestionInfo> aggregateResult = new VeniceConcurrentHashMap<>();
+    for (KafkaConsumerService kafkaConsumerService: consumerServices) {
+      Map<String, ConsumerServiceIngestionInfo> consumerServiceResult =
+          kafkaConsumerService.getIngestionInfoFromConsumerServices();
+      aggregateResult.putAll(consumerServiceResult);
+    }
+    return aggregateResult;
   }
 
   @Override

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/KafkaStoreIngestionService.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/KafkaStoreIngestionService.java
@@ -1148,7 +1148,6 @@ public class KafkaStoreIngestionService extends AbstractVeniceService implements
     return kafkaConsumerProperties;
   }
 
-  @Override
   public ByteBuffer getStoreVersionCompressionDictionary(String topicName) {
     return storageMetadataService.getStoreVersionCompressionDictionary(topicName);
   }
@@ -1157,7 +1156,6 @@ public class KafkaStoreIngestionService extends AbstractVeniceService implements
     return topicNameToIngestionTaskMap.get(topicName);
   }
 
-  @Override
   public AdminResponse getConsumptionSnapshots(String topicName, ComplementSet<Integer> partitions) {
     AdminResponse response = new AdminResponse();
     StoreIngestionTask ingestionTask = getStoreIngestionTask(topicName);
@@ -1193,6 +1191,19 @@ public class KafkaStoreIngestionService extends AbstractVeniceService implements
           e);
     }
     return topicPartitionIngestionContextResponse;
+  }
+
+  public TopicPartitionIngestionContextResponse getIngestionContext() {
+    TopicPartitionIngestionContextResponse response = new TopicPartitionIngestionContextResponse();
+    try {
+      byte[] topicPartitionInfo = aggKafkaConsumerService.getIngestionInfoForConsumerServices();
+      response.setTopicPartitionIngestionContext(topicPartitionInfo);
+    } catch (Exception e) {
+      response.setError(true);
+      response.setMessage(e.getMessage());
+      LOGGER.error("Error on get topic partition ingestion context for all consumers", e);
+    }
+    return response;
   }
 
   /**

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionService.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionService.java
@@ -5,7 +5,6 @@ import com.linkedin.davinci.config.VeniceStoreVersionConfig;
 import com.linkedin.davinci.helix.LeaderFollowerPartitionStateModel;
 import com.linkedin.davinci.notifier.VeniceNotifier;
 import com.linkedin.davinci.stats.AggVersionedIngestionStats;
-import com.linkedin.davinci.storage.IngestionMetadataRetriever;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 
@@ -13,7 +12,7 @@ import java.util.concurrent.CompletableFuture;
 /**
  * An interface for Store Ingestion Service for Venice.
  */
-public interface StoreIngestionService extends IngestionMetadataRetriever {
+public interface StoreIngestionService {
   /**
    * Starts consuming messages from Kafka Partition corresponding to Venice Partition.
    * @param veniceStore Venice Store for the partition.

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/TopicPartitionIngestionInfo.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/TopicPartitionIngestionInfo.java
@@ -113,4 +113,12 @@ public class TopicPartitionIngestionInfo {
     result = 31 * result + versionTopicName.hashCode();
     return result;
   }
+
+  @Override
+  public String toString() {
+    return "{" + "\"latestOffset\"=" + latestOffset + ", \"offsetLag\"=" + offsetLag + ", \"msgRate\"=" + msgRate
+        + ", \"byteRate\"=" + byteRate + ", \"consumerIdStr\"='" + consumerIdStr + '\''
+        + ", \"elapsedTimeSinceLastPollInMs\"=" + elapsedTimeSinceLastPollInMs + ", \"versionTopicName\"=\""
+        + versionTopicName + "\"" + '}';
+  }
 }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/ingestion/heartbeat/HeartbeatMonitoringService.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/ingestion/heartbeat/HeartbeatMonitoringService.java
@@ -1,8 +1,10 @@
 package com.linkedin.davinci.stats.ingestion.heartbeat;
 
+import com.linkedin.davinci.kafka.consumer.LeaderFollowerStateType;
 import com.linkedin.venice.meta.ReadOnlyStoreRepository;
 import com.linkedin.venice.meta.Version;
 import com.linkedin.venice.service.AbstractVeniceService;
+import com.linkedin.venice.utils.Utils;
 import com.linkedin.venice.utils.concurrent.VeniceConcurrentHashMap;
 import io.tehuti.metrics.MetricConfig;
 import io.tehuti.metrics.MetricsRepository;
@@ -36,13 +38,15 @@ import org.apache.logging.log4j.Logger;
  */
 public class HeartbeatMonitoringService extends AbstractVeniceService {
   private final Thread reportingThread;
+  private final Thread lagLoggingThread;
   private static final Logger LOGGER = LogManager.getLogger(HeartbeatMonitoringService.class);
   public static final int DEFAULT_REPORTER_THREAD_SLEEP_INTERVAL_SECONDS = 60;
-
+  public static final int DEFAULT_LAG_LOGGING_THREAD_SLEEP_INTERVAL_SECONDS = 60;
+  public static final int DEFAULT_STALE_HEARTBEAT_LOG_THRESHOLD = 600;
   private final Set<String> regionNames;
   private final String localRegionName;
 
-  // store -> version -> partition -> region -> timestamp
+  // store -> version -> partition -> region -> (timestamp, RTS)
   private final Map<String, Map<Integer, Map<Integer, Map<String, Pair<Long, Boolean>>>>> followerHeartbeatTimeStamps;
   private final Map<String, Map<Integer, Map<Integer, Map<String, Pair<Long, Boolean>>>>> leaderHeartbeatTimeStamps;
   HeartbeatVersionedStats versionStatsReporter;
@@ -55,6 +59,7 @@ public class HeartbeatMonitoringService extends AbstractVeniceService {
     this.regionNames = regionNames;
     this.localRegionName = localRegionName;
     this.reportingThread = new HeartbeatReporterThread();
+    this.lagLoggingThread = new HeartbeatLagLoggingThread();
     followerHeartbeatTimeStamps = new VeniceConcurrentHashMap<>();
     leaderHeartbeatTimeStamps = new VeniceConcurrentHashMap<>();
     versionStatsReporter = new HeartbeatVersionedStats(
@@ -81,9 +86,17 @@ public class HeartbeatMonitoringService extends AbstractVeniceService {
           Map<String, Pair<Long, Boolean>> regionTimestamps = new VeniceConcurrentHashMap<>();
           if (version.isActiveActiveReplicationEnabled() && !isFollower) {
             for (String region: regionNames) {
+              LOGGER.info(
+                  "DEBUGGING PUTTING AA REGION: {}, topic: {}",
+                  region,
+                  Version.composeKafkaTopic(version.getStoreName(), version.getNumber()));
               regionTimestamps.put(region, new MutablePair<>(System.currentTimeMillis(), false));
             }
           } else {
+            LOGGER.info(
+                "DEBUGGING PUTTING LOCAL REGION: {}, topic: {}",
+                localRegionName,
+                Version.composeKafkaTopic(version.getStoreName(), version.getNumber()));
             regionTimestamps.put(localRegionName, new MutablePair<>(System.currentTimeMillis(), false));
           }
           return regionTimestamps;
@@ -138,15 +151,86 @@ public class HeartbeatMonitoringService extends AbstractVeniceService {
     removeEntry(followerHeartbeatTimeStamps, version, partition);
   }
 
+  public Map<String, ReplicaHeartbeatInfo> getHeartbeatInfo(
+      String topicFilter,
+      int partitionFilter,
+      boolean filterLagReplica) {
+    Map<String, ReplicaHeartbeatInfo> aggregateResult = new VeniceConcurrentHashMap<>();
+    long currentTimestamp = System.currentTimeMillis();
+    aggregateResult.putAll(
+        getHeartbeatInfoFromMap(
+            leaderHeartbeatTimeStamps,
+            LeaderFollowerStateType.LEADER.name(),
+            currentTimestamp,
+            topicFilter,
+            partitionFilter,
+            filterLagReplica));
+    aggregateResult.putAll(
+        getHeartbeatInfoFromMap(
+            followerHeartbeatTimeStamps,
+            LeaderFollowerStateType.STANDBY.name(),
+            currentTimestamp,
+            topicFilter,
+            partitionFilter,
+            filterLagReplica));
+    return aggregateResult;
+  }
+
+  Map<String, ReplicaHeartbeatInfo> getHeartbeatInfoFromMap(
+      Map<String, Map<Integer, Map<Integer, Map<String, Pair<Long, Boolean>>>>> heartbeatTimestampMap,
+      String leaderState,
+      long currentTimestamp,
+      String topicFilter,
+      int partitionFilter,
+      boolean filterLagReplica) {
+    Map<String, ReplicaHeartbeatInfo> result = new VeniceConcurrentHashMap<>();
+    for (Map.Entry<String, Map<Integer, Map<Integer, Map<String, Pair<Long, Boolean>>>>> storeName: heartbeatTimestampMap
+        .entrySet()) {
+      for (Map.Entry<Integer, Map<Integer, Map<String, Pair<Long, Boolean>>>> version: storeName.getValue()
+          .entrySet()) {
+        for (Map.Entry<Integer, Map<String, Pair<Long, Boolean>>> partition: version.getValue().entrySet()) {
+          for (Map.Entry<String, Pair<Long, Boolean>> region: partition.getValue().entrySet()) {
+            String topicName = Version.composeKafkaTopic(storeName.getKey(), version.getKey());
+            long heartbeatTs = region.getValue().getLeft();
+            long lag = currentTimestamp - heartbeatTs;
+            if ((!"".equals(topicFilter) && !topicFilter.equals(topicName))) {
+              continue;
+            }
+            // Partition filter will only be valid if topicFilter is in place.
+            if (!topicFilter.isEmpty() && partitionFilter >= 0 && partitionFilter != partition.getKey()) {
+              continue;
+            }
+            if (filterLagReplica && lag < DEFAULT_STALE_HEARTBEAT_LOG_THRESHOLD * 1000) {
+              continue;
+            }
+            String replicaId =
+                Utils.getReplicaId(Version.composeKafkaTopic(storeName.getKey(), version.getKey()), partition.getKey());
+            ReplicaHeartbeatInfo replicaHeartbeatInfo = new ReplicaHeartbeatInfo(
+                replicaId,
+                region.getKey(),
+                leaderState,
+                region.getValue().getRight(),
+                heartbeatTs,
+                lag);
+            result.put(replicaId + "-" + region.getKey(), replicaHeartbeatInfo);
+          }
+        }
+      }
+    }
+    return result;
+  }
+
   @Override
   public boolean startInner() throws Exception {
     reportingThread.start();
+    lagLoggingThread.start();
     return true;
   }
 
   @Override
   public void stopInner() throws Exception {
     reportingThread.interrupt();
+    lagLoggingThread.interrupt();
   }
 
   /**
@@ -251,6 +335,39 @@ public class HeartbeatMonitoringService extends AbstractVeniceService {
             .recordFollowerLag(storeName, version, region, heartbeatTs, isReadyToServe)));
   }
 
+  protected void checkAndMaybeLogHeartbeatDelayMap(
+      Map<String, Map<Integer, Map<Integer, Map<String, Pair<Long, Boolean>>>>> heartbeatTimestamps) {
+    long currentTimestamp = System.currentTimeMillis();
+    for (Map.Entry<String, Map<Integer, Map<Integer, Map<String, Pair<Long, Boolean>>>>> storeName: heartbeatTimestamps
+        .entrySet()) {
+      for (Map.Entry<Integer, Map<Integer, Map<String, Pair<Long, Boolean>>>> version: storeName.getValue()
+          .entrySet()) {
+        for (Map.Entry<Integer, Map<String, Pair<Long, Boolean>>> partition: version.getValue().entrySet()) {
+          for (Map.Entry<String, Pair<Long, Boolean>> region: partition.getValue().entrySet()) {
+            long heartbeatTs = region.getValue().getLeft();
+            long lag = currentTimestamp - heartbeatTs;
+            if (lag > DEFAULT_STALE_HEARTBEAT_LOG_THRESHOLD && region.getValue().getRight()) {
+              String replicaId = Utils
+                  .getReplicaId(Version.composeKafkaTopic(storeName.getKey(), version.getKey()), partition.getKey());
+              LOGGER.warn(
+                  "Replica: {}, region: {} is having heartbeat lag: {}, latest heartbeat: {}, current timestamp: {}",
+                  replicaId,
+                  region.getKey(),
+                  lag,
+                  heartbeatTs,
+                  currentTimestamp);
+            }
+          }
+        }
+      }
+    }
+  }
+
+  protected void checkAndMaybeLogHeartbeatDelay() {
+    checkAndMaybeLogHeartbeatDelayMap(leaderHeartbeatTimeStamps);
+    checkAndMaybeLogHeartbeatDelayMap(followerHeartbeatTimeStamps);
+  }
+
   @FunctionalInterface
   interface ReportLagFunction {
     void apply(String storeName, int version, String region, long lag, boolean isReadyToServe);
@@ -272,7 +389,27 @@ public class HeartbeatMonitoringService extends AbstractVeniceService {
           break;
         }
       }
-      LOGGER.info("RemoteIngestionRepairService thread interrupted!  Shutting down...");
+      LOGGER.info("Heartbeat lag metric reporting thread interrupted!  Shutting down...");
+    }
+  }
+
+  private class HeartbeatLagLoggingThread extends Thread {
+    HeartbeatLagLoggingThread() {
+      super("Ingestion-Heartbeat-Lag-Logging-Service-Thread");
+    }
+
+    @Override
+    public void run() {
+      while (!Thread.interrupted()) {
+        checkAndMaybeLogHeartbeatDelay();
+        try {
+          TimeUnit.SECONDS.sleep(DEFAULT_LAG_LOGGING_THREAD_SLEEP_INTERVAL_SECONDS);
+        } catch (InterruptedException e) {
+          // We've received an interrupt which is to be expected, so we'll just leave the loop and log
+          break;
+        }
+      }
+      LOGGER.info("Heartbeat lag logging thread interrupted!  Shutting down...");
     }
   }
 }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/ingestion/heartbeat/HeartbeatVersionedStats.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/ingestion/heartbeat/HeartbeatVersionedStats.java
@@ -37,7 +37,7 @@ public class HeartbeatVersionedStats extends AbstractVeniceAggVersionedStats<Hea
       long heartbeatTs,
       boolean isReadyToServe) {
     // If the partition is ready to serve, report it's lage to the main lag metric. Otherwise, report it
-    // to the catch up metric.
+    // to the catch-up metric.
     // The metric which isn't updated is squelched by reporting the currentTime (so as to appear caught up and mute
     // alerts)
     if (isReadyToServe) {

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/ingestion/heartbeat/ReplicaHeartbeatInfo.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/ingestion/heartbeat/ReplicaHeartbeatInfo.java
@@ -1,0 +1,112 @@
+package com.linkedin.davinci.stats.ingestion.heartbeat;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+
+public class ReplicaHeartbeatInfo {
+  private String replicaId;
+  private String region;
+  private String leaderState;
+  private boolean readyToServe;
+  private long heartbeat;
+  private long lag;
+
+  @JsonCreator
+  public ReplicaHeartbeatInfo(
+      @JsonProperty("replicaId") String replicaId,
+      @JsonProperty("region") String region,
+      @JsonProperty("leaderState") String leaderState,
+      @JsonProperty("readyToServe") boolean readyToServe,
+      @JsonProperty("heartbeat") long heartbeat,
+      @JsonProperty("lag") long lag) {
+    this.leaderState = leaderState;
+    this.replicaId = replicaId;
+    this.region = region;
+    this.readyToServe = readyToServe;
+    this.heartbeat = heartbeat;
+    this.lag = lag;
+  }
+
+  public long getHeartbeat() {
+    return heartbeat;
+  }
+
+  public void setHeartbeat(long heartbeat) {
+    this.heartbeat = heartbeat;
+  }
+
+  public String getLeaderState() {
+    return leaderState;
+  }
+
+  public void setLeaderState(String leaderState) {
+    this.leaderState = leaderState;
+  }
+
+  public String getReplicaId() {
+    return replicaId;
+  }
+
+  public void setReplicaId(String replicaId) {
+    this.replicaId = replicaId;
+  }
+
+  public String getRegion() {
+    return region;
+  }
+
+  public void setRegion(String region) {
+    this.region = region;
+  }
+
+  public long getLag() {
+    return lag;
+  }
+
+  public void setLag(long lag) {
+    this.lag = lag;
+  }
+
+  public boolean isReadyToServe() {
+    return readyToServe;
+  }
+
+  public void setReadyToServe(boolean readyToServe) {
+    this.readyToServe = readyToServe;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+
+    ReplicaHeartbeatInfo replicaHeartbeatInfo = (ReplicaHeartbeatInfo) o;
+    return this.replicaId.equals(replicaHeartbeatInfo.getReplicaId())
+        && this.heartbeat == replicaHeartbeatInfo.getHeartbeat() && this.region.equals(replicaHeartbeatInfo.getRegion())
+        && this.readyToServe == replicaHeartbeatInfo.isReadyToServe() && this.lag == replicaHeartbeatInfo.getLag()
+        && this.leaderState.equals(replicaHeartbeatInfo.leaderState);
+  }
+
+  @Override
+  public int hashCode() {
+    int result = replicaId.hashCode();
+    result = 31 * result + region.hashCode();
+    result = 31 * result + leaderState.hashCode();
+    result = 31 * result + Boolean.hashCode(readyToServe);
+    result = 31 * result + Long.hashCode(heartbeat);
+    result = 31 * result + Long.hashCode(lag);
+    return result;
+  }
+
+  @Override
+  public String toString() {
+    return "{" + "\"replica\"='" + replicaId + '\'' + ", \"region\"='" + region + '\'' + ", \"leaderState\"='"
+        + leaderState + '\'' + ", \"readyToServe\"='" + readyToServe + '\'' + ", \"heartbeat\"=" + heartbeat
+        + ", \"lag\"=" + lag + '}';
+  }
+}

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/storage/IngestionMetadataRetriever.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/storage/IngestionMetadataRetriever.java
@@ -16,4 +16,10 @@ public interface IngestionMetadataRetriever {
       String topicName,
       int partitionNum);
 
+  TopicPartitionIngestionContextResponse getIngestionContext();
+
+  TopicPartitionIngestionContextResponse getHeartbeatLag(
+      String topicFilter,
+      int partitionFilter,
+      boolean filterLagReplica);
 }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/storage/IngestionMetadataRetrieverDelegator.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/storage/IngestionMetadataRetrieverDelegator.java
@@ -1,0 +1,73 @@
+package com.linkedin.davinci.storage;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.linkedin.davinci.kafka.consumer.KafkaStoreIngestionService;
+import com.linkedin.davinci.listener.response.AdminResponse;
+import com.linkedin.davinci.listener.response.TopicPartitionIngestionContextResponse;
+import com.linkedin.davinci.stats.ingestion.heartbeat.HeartbeatMonitoringService;
+import com.linkedin.davinci.stats.ingestion.heartbeat.ReplicaHeartbeatInfo;
+import com.linkedin.venice.helix.VeniceJsonSerializer;
+import com.linkedin.venice.utils.ComplementSet;
+import java.nio.ByteBuffer;
+import java.util.Map;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+
+public class IngestionMetadataRetrieverDelegator implements IngestionMetadataRetriever {
+  private static final Logger LOGGER = LogManager.getLogger(IngestionMetadataRetrieverDelegator.class);
+  private final KafkaStoreIngestionService kafkaStoreIngestionService;
+  private final HeartbeatMonitoringService heartbeatMonitoringService;
+
+  private final VeniceJsonSerializer<Map<String, ReplicaHeartbeatInfo>> replicaInfoJsonSerializer =
+      new VeniceJsonSerializer<>(new TypeReference<Map<String, ReplicaHeartbeatInfo>>() {
+      });
+
+  public IngestionMetadataRetrieverDelegator(
+      KafkaStoreIngestionService kafkaStoreIngestionService,
+      HeartbeatMonitoringService heartbeatMonitoringService) {
+    this.kafkaStoreIngestionService = kafkaStoreIngestionService;
+    this.heartbeatMonitoringService = heartbeatMonitoringService;
+  }
+
+  @Override
+  public ByteBuffer getStoreVersionCompressionDictionary(String topicName) {
+    return kafkaStoreIngestionService.getStoreVersionCompressionDictionary(topicName);
+  }
+
+  @Override
+  public AdminResponse getConsumptionSnapshots(String topicName, ComplementSet<Integer> partitions) {
+    return kafkaStoreIngestionService.getConsumptionSnapshots(topicName, partitions);
+  }
+
+  @Override
+  public TopicPartitionIngestionContextResponse getTopicPartitionIngestionContext(
+      String versionTopic,
+      String topicName,
+      int partitionNum) {
+    return kafkaStoreIngestionService.getTopicPartitionIngestionContext(versionTopic, topicName, partitionNum);
+  }
+
+  @Override
+  public TopicPartitionIngestionContextResponse getIngestionContext() {
+    return kafkaStoreIngestionService.getIngestionContext();
+  }
+
+  @Override
+  public TopicPartitionIngestionContextResponse getHeartbeatLag(
+      String topicFilter,
+      int partitionFilter,
+      boolean filterLagReplica) {
+    TopicPartitionIngestionContextResponse response = new TopicPartitionIngestionContextResponse();
+    try {
+      byte[] topicPartitionInfo = replicaInfoJsonSerializer
+          .serialize(heartbeatMonitoringService.getHeartbeatInfo(topicFilter, partitionFilter, filterLagReplica), "");
+      response.setTopicPartitionIngestionContext(topicPartitionInfo);
+    } catch (Exception e) {
+      response.setError(true);
+      response.setMessage(e.getMessage());
+      LOGGER.error("Error on get topic partition ingestion context for all consumers", e);
+    }
+    return response;
+  }
+}

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/KafkaConsumerServiceTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/KafkaConsumerServiceTest.java
@@ -89,7 +89,7 @@ public class KafkaConsumerServiceTest {
         ConsumerPoolType.REGULAR_POOL,
         factory,
         properties,
-        1000l,
+        1000L,
         2,
         mock(IngestionThrottler.class),
         mock(KafkaClusterBasedRecordThrottler.class),
@@ -199,16 +199,17 @@ public class KafkaConsumerServiceTest {
 
     TestUtils.waitForNonDeterministicAssertion(1, TimeUnit.SECONDS, true, true, () -> {
       verify(consumer1, atLeastOnce()).poll(anyLong());
-      Map<PubSubTopicPartition, TopicPartitionIngestionInfo> topicPartitionIngestionInfoMap =
+      Map<String, TopicPartitionIngestionInfo> topicPartitionIngestionInfoMap =
           consumerService.getIngestionInfoFromConsumer(versionTopic, topicPartition);
       Assert.assertEquals(topicPartitionIngestionInfoMap.size(), 1);
-      Assert.assertTrue(topicPartitionIngestionInfoMap.containsKey(topicPartition));
-      Assert.assertTrue(topicPartitionIngestionInfoMap.get(topicPartition).getConsumerIdStr().contains("0"));
-      Assert.assertTrue(topicPartitionIngestionInfoMap.get(topicPartition).getConsumerIdStr().contains(testKafkaUrl));
-      Assert.assertTrue(topicPartitionIngestionInfoMap.get(topicPartition).getMsgRate() > 0);
-      Assert.assertTrue(topicPartitionIngestionInfoMap.get(topicPartition).getByteRate() > 0);
+      Assert.assertTrue(topicPartitionIngestionInfoMap.containsKey(topicPartition.toString()));
+      Assert.assertTrue(topicPartitionIngestionInfoMap.get(topicPartition.toString()).getConsumerIdStr().contains("0"));
+      Assert.assertTrue(
+          topicPartitionIngestionInfoMap.get(topicPartition.toString()).getConsumerIdStr().contains(testKafkaUrl));
+      Assert.assertTrue(topicPartitionIngestionInfoMap.get(topicPartition.toString()).getMsgRate() > 0);
+      Assert.assertTrue(topicPartitionIngestionInfoMap.get(topicPartition.toString()).getByteRate() > 0);
       Assert.assertEquals(
-          topicPartitionIngestionInfoMap.get(topicPartition).getVersionTopicName(),
+          topicPartitionIngestionInfoMap.get(topicPartition.toString()).getVersionTopicName(),
           topicForStoreName3.getName());
       verify(mockIngestionThrottler, atLeastOnce()).maybeThrottleBandwidth(anyInt());
       verify(mockIngestionThrottler, atLeastOnce())
@@ -227,7 +228,7 @@ public class KafkaConsumerServiceTest {
         poolType,
         factory,
         properties,
-        1000l,
+        1000L,
         1,
         mockIngestionThrottler,
         mock(KafkaClusterBasedRecordThrottler.class),
@@ -381,7 +382,7 @@ public class KafkaConsumerServiceTest {
         ConsumerPoolType.REGULAR_POOL,
         factory,
         properties,
-        1000l,
+        1000L,
         2,
         mock(IngestionThrottler.class),
         mock(KafkaClusterBasedRecordThrottler.class),

--- a/clients/venice-admin-tool/src/main/java/com/linkedin/venice/Arg.java
+++ b/clients/venice-admin-tool/src/main/java/com/linkedin/venice/Arg.java
@@ -275,6 +275,7 @@ public enum Arg {
   ), RECOVER_CLUSTER("recover-cluster", "rc", true, "Cluster to recover from"),
   BACKUP_FOLDER("backup-folder", "bf", true, "Backup folder path"),
   DEBUG("debug", "d", false, "Print debugging messages for execute-data-recovery"),
+  LAG_FILTER_ENABLED("lag-filter-enabled", "lfe", true, "Enable heartbeat lag filter for a heartbeat request"),
   BLOB_TRANSFER_ENABLED("blob-transfer-enabled", "bt", true, "Flag to indicate if the blob transfer is allowed or not");
 
   private final String argName;

--- a/clients/venice-admin-tool/src/main/java/com/linkedin/venice/Command.java
+++ b/clients/venice-admin-tool/src/main/java/com/linkedin/venice/Command.java
@@ -62,6 +62,7 @@ import static com.linkedin.venice.Arg.KAFKA_TOPIC_PARTITION;
 import static com.linkedin.venice.Arg.KAFKA_TOPIC_RETENTION_IN_MS;
 import static com.linkedin.venice.Arg.KEY;
 import static com.linkedin.venice.Arg.KEY_SCHEMA;
+import static com.linkedin.venice.Arg.LAG_FILTER_ENABLED;
 import static com.linkedin.venice.Arg.LARGEST_USED_VERSION_NUMBER;
 import static com.linkedin.venice.Arg.LATEST_SUPERSET_SCHEMA_ID;
 import static com.linkedin.venice.Arg.MAX_COMPACTION_LAG_SECONDS;
@@ -518,6 +519,15 @@ public enum Command {
       "dump-topic-partition-ingestion-context",
       "Dump the topic partition ingestion context belong to a certain store version in a certain storage node",
       new Arg[] { SERVER_URL, STORE, VERSION, KAFKA_TOPIC_NAME, KAFKA_TOPIC_PARTITION }
+  ),
+  DUMP_HOST_INGESTION_CONTEXT(
+      "dump-host-ingestion-context", "Dump all topic partition ingestion context belong to a certain storage node",
+      new Arg[] { SERVER_URL }
+  ),
+  DUMP_HOST_HEARTBEAT(
+      "dump-host-heartbeat",
+      "Dump all heartbeat belong to a certain storage node. You can use topic/partition to filter specific resource, and you can choose to filter resources that are lagging.",
+      new Arg[] { SERVER_URL }, new Arg[] { KAFKA_TOPIC_NAME, PARTITION, LAG_FILTER_ENABLED }
   ),
   CONFIGURE_STORE_VIEW(
       "configure-store-view", "Configure store view of a certain store", new Arg[] { URL, STORE, VIEW_NAME },

--- a/internal/venice-common/src/main/java/com/linkedin/venice/meta/QueryAction.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/meta/QueryAction.java
@@ -26,5 +26,7 @@ public enum QueryAction {
   CURRENT_VERSION,
 
   // TOPIC_PARTITION_INGESTION_CONTEXT is a GET request to /version topic/topic/partition from server admin tool
-  TOPIC_PARTITION_INGESTION_CONTEXT
+  TOPIC_PARTITION_INGESTION_CONTEXT,
+
+  HOST_INGESTION_CONTEXT, HOST_HEARTBEAT_LAG
 }

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestDumpIngestionContext.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestDumpIngestionContext.java
@@ -1,0 +1,183 @@
+package com.linkedin.venice.endToEnd;
+
+import static com.linkedin.venice.utils.TestUtils.assertCommand;
+import static com.linkedin.venice.utils.TestWriteUtils.loadFileAsString;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.linkedin.avroutil1.compatibility.AvroCompatibilityHelper;
+import com.linkedin.davinci.kafka.consumer.ConsumerServiceIngestionInfo;
+import com.linkedin.davinci.kafka.consumer.KafkaConsumerServiceDelegator;
+import com.linkedin.davinci.kafka.consumer.KafkaStoreIngestionService;
+import com.linkedin.davinci.listener.response.TopicPartitionIngestionContextResponse;
+import com.linkedin.davinci.stats.ingestion.heartbeat.ReplicaHeartbeatInfo;
+import com.linkedin.venice.AdminTool;
+import com.linkedin.venice.ConfigKeys;
+import com.linkedin.venice.compression.CompressionStrategy;
+import com.linkedin.venice.controllerapi.ControllerClient;
+import com.linkedin.venice.controllerapi.ControllerResponse;
+import com.linkedin.venice.controllerapi.UpdateStoreQueryParams;
+import com.linkedin.venice.controllerapi.VersionCreationResponse;
+import com.linkedin.venice.exceptions.VeniceException;
+import com.linkedin.venice.helix.VeniceJsonSerializer;
+import com.linkedin.venice.integration.utils.ServiceFactory;
+import com.linkedin.venice.integration.utils.VeniceClusterWrapper;
+import com.linkedin.venice.integration.utils.VeniceControllerWrapper;
+import com.linkedin.venice.integration.utils.VeniceMultiClusterWrapper;
+import com.linkedin.venice.integration.utils.VeniceServerWrapper;
+import com.linkedin.venice.integration.utils.VeniceTwoLayerMultiRegionMultiClusterWrapper;
+import com.linkedin.venice.meta.Store;
+import com.linkedin.venice.meta.Version;
+import com.linkedin.venice.utils.TestUtils;
+import com.linkedin.venice.utils.Utils;
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Properties;
+import java.util.concurrent.TimeUnit;
+import org.apache.avro.Schema;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.testng.Assert;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+
+public class TestDumpIngestionContext {
+  private static final Logger LOGGER = LogManager.getLogger(TestDumpIngestionContext.class);
+  private static final int NUMBER_OF_CHILD_DATACENTERS = 2;
+  private static final int NUMBER_OF_CLUSTERS = 1;
+  private static final int TEST_TIMEOUT_MS = 180_000;
+
+  private static final int REPLICATION_FACTOR = 2;
+  private static final String CLUSTER_NAME = "venice-cluster0";
+
+  private static VeniceJsonSerializer<Map<String, Map<String, ConsumerServiceIngestionInfo>>> VENICE_JSON_SERIALIZER =
+      new VeniceJsonSerializer<>(new TypeReference<Map<String, Map<String, ConsumerServiceIngestionInfo>>>() {
+      });
+
+  private VeniceTwoLayerMultiRegionMultiClusterWrapper multiRegionMultiClusterWrapper;
+  private VeniceControllerWrapper parentController;
+  private List<VeniceMultiClusterWrapper> childDatacenters;
+
+  @BeforeClass(alwaysRun = true)
+  public void setUp() {
+    Properties serverProperties = new Properties();
+    serverProperties.put(ConfigKeys.SERVER_RESUBSCRIPTION_TRIGGERED_BY_VERSION_INGESTION_CONTEXT_CHANGE_ENABLED, true);
+    serverProperties.put(
+        ConfigKeys.SERVER_CONSUMER_POOL_ALLOCATION_STRATEGY,
+        KafkaConsumerServiceDelegator.ConsumerPoolStrategyType.CURRENT_VERSION_PRIORITIZATION.name());
+    Properties controllerProps = new Properties();
+    controllerProps.put(ConfigKeys.CONTROLLER_AUTO_MATERIALIZE_META_SYSTEM_STORE, false);
+    this.multiRegionMultiClusterWrapper = ServiceFactory.getVeniceTwoLayerMultiRegionMultiClusterWrapper(
+        NUMBER_OF_CHILD_DATACENTERS,
+        NUMBER_OF_CLUSTERS,
+        1,
+        1,
+        2,
+        1,
+        REPLICATION_FACTOR,
+        Optional.of(controllerProps),
+        Optional.of(controllerProps),
+        Optional.of(serverProperties),
+        false);
+    this.childDatacenters = multiRegionMultiClusterWrapper.getChildRegions();
+    List<VeniceControllerWrapper> parentControllers = multiRegionMultiClusterWrapper.getParentControllers();
+    this.parentController = parentControllers.get(0);
+  }
+
+  @Test(timeOut = TEST_TIMEOUT_MS)
+  public void testDumpIngestionContext() {
+    final String storeName = Utils.getUniqueString("dumpInfo");
+    String parentControllerUrl = parentController.getControllerUrl();
+    Schema keySchema = AvroCompatibilityHelper.parse(loadFileAsString("UserKey.avsc"));
+    Schema valueSchema = AvroCompatibilityHelper.parse(loadFileAsString("UserValue.avsc"));
+
+    try (ControllerClient parentControllerClient = new ControllerClient(CLUSTER_NAME, parentControllerUrl)) {
+      assertCommand(
+          parentControllerClient.createNewStore(storeName, "test_owner", keySchema.toString(), valueSchema.toString()));
+      UpdateStoreQueryParams updateStoreParams =
+          new UpdateStoreQueryParams().setStorageQuotaInByte(Store.UNLIMITED_STORAGE_QUOTA)
+              .setCompressionStrategy(CompressionStrategy.NO_OP)
+              .setActiveActiveReplicationEnabled(true)
+              .setWriteComputationEnabled(true)
+              .setHybridRewindSeconds(86400L)
+              .setHybridOffsetLagThreshold(10L);
+      ControllerResponse updateStoreResponse =
+          parentControllerClient.retryableRequest(5, c -> c.updateStore(storeName, updateStoreParams));
+      assertFalse(updateStoreResponse.isError(), "Update store got error: " + updateStoreResponse.getError());
+
+      VersionCreationResponse response = parentControllerClient.emptyPush(storeName, "test_push_id", 1000);
+      assertEquals(response.getVersion(), 1);
+      assertFalse(response.isError(), "Empty push to parent colo should succeed");
+      TestUtils.waitForNonDeterministicPushCompletion(
+          Version.composeKafkaTopic(storeName, 1),
+          parentControllerClient,
+          30,
+          TimeUnit.SECONDS);
+
+      VeniceClusterWrapper veniceCluster = childDatacenters.get(0).getClusters().get(CLUSTER_NAME);
+      VeniceServerWrapper serverWrapper = veniceCluster.getVeniceServers().get(0);
+      KafkaStoreIngestionService kafkaStoreIngestionService =
+          serverWrapper.getVeniceServer().getKafkaStoreIngestionService();
+
+      Map<String, ReplicaHeartbeatInfo> heartbeatInfoMap =
+          serverWrapper.getVeniceServer().getHeartbeatMonitoringService().getHeartbeatInfo("", -1, false);
+      LOGGER.info("Heartbeat Info:\n" + heartbeatInfoMap);
+      int totalReplicaCount = heartbeatInfoMap.size();
+
+      heartbeatInfoMap = serverWrapper.getVeniceServer()
+          .getHeartbeatMonitoringService()
+          .getHeartbeatInfo(Version.composeKafkaTopic(storeName, 1), -1, false);
+      LOGGER.info("Heartbeat Info with topic filtering:\n" + heartbeatInfoMap);
+      Assert.assertEquals(heartbeatInfoMap.keySet().stream().filter(x -> x.endsWith("dc-0")).count(), 3);
+      Assert.assertEquals(
+          heartbeatInfoMap.keySet().stream().filter(x -> x.endsWith("dc-1")).count() * 2,
+          heartbeatInfoMap.values().stream().filter(x -> x.getLeaderState().equals("LEADER")).count());
+
+      heartbeatInfoMap = serverWrapper.getVeniceServer()
+          .getHeartbeatMonitoringService()
+          .getHeartbeatInfo(Version.composeKafkaTopic(storeName, 1), 2, false);
+      LOGGER.info("Heartbeat Info with topic/partition filtering:\n" + heartbeatInfoMap);
+      Assert.assertTrue(
+          heartbeatInfoMap.keySet()
+              .stream()
+              .allMatch(x -> x.startsWith(Version.composeKafkaTopic(storeName, 1) + "-2")));
+
+      heartbeatInfoMap = serverWrapper.getVeniceServer().getHeartbeatMonitoringService().getHeartbeatInfo("", 2, false);
+      LOGGER.info("Heartbeat Info with only partition filtering should be invalid:\n" + heartbeatInfoMap);
+      Assert.assertEquals(heartbeatInfoMap.size(), totalReplicaCount);
+
+      heartbeatInfoMap = serverWrapper.getVeniceServer().getHeartbeatMonitoringService().getHeartbeatInfo("", -1, true);
+      LOGGER.info("Heartbeat Info with lag filtering:\n" + heartbeatInfoMap);
+      Assert.assertTrue(heartbeatInfoMap.isEmpty());
+
+      // Test dump all consumer context.
+      TopicPartitionIngestionContextResponse ingestionContextResponse =
+          kafkaStoreIngestionService.getIngestionContext();
+      try {
+        Map<String, Map<String, ConsumerServiceIngestionInfo>> topicPartitionIngestionContexts =
+            VENICE_JSON_SERIALIZER.deserialize(ingestionContextResponse.getTopicPartitionIngestionContext(), "");
+        LOGGER.info(topicPartitionIngestionContexts);
+      } catch (IOException e) {
+        throw new VeniceException("Got IO Exception during consumer pool check.", e);
+      }
+      // Print out for display only.
+      String serverUrl = "http://" + serverWrapper.getHost() + ":" + serverWrapper.getPort();
+      String[] args = { "--dump-host-ingestion-context", "--server-url", serverUrl };
+      try {
+        AdminTool.main(args);
+      } catch (Exception e) {
+        throw new VeniceException(e);
+      }
+      String[] args2 = { "--dump-host-heartbeat", "--server-url", serverUrl };
+      try {
+        AdminTool.main(args2);
+      } catch (Exception e) {
+        throw new VeniceException(e);
+      }
+    }
+  }
+}

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/integration/utils/VeniceServerWrapper.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/integration/utils/VeniceServerWrapper.java
@@ -14,6 +14,7 @@ import static com.linkedin.venice.ConfigKeys.KAFKA_SECURITY_PROTOCOL;
 import static com.linkedin.venice.ConfigKeys.LISTENER_PORT;
 import static com.linkedin.venice.ConfigKeys.LOCAL_CONTROLLER_D2_SERVICE_NAME;
 import static com.linkedin.venice.ConfigKeys.LOCAL_D2_ZK_HOST;
+import static com.linkedin.venice.ConfigKeys.LOCAL_REGION_NAME;
 import static com.linkedin.venice.ConfigKeys.MAX_ONLINE_OFFLINE_STATE_TRANSITION_THREAD_NUMBER;
 import static com.linkedin.venice.ConfigKeys.PARTICIPANT_MESSAGE_CONSUMPTION_DELAY_MS;
 import static com.linkedin.venice.ConfigKeys.PERSISTENCE_TYPE;
@@ -224,6 +225,7 @@ public class VeniceServerWrapper extends ProcessWrapper implements MetricsAware 
       PropertyBuilder serverPropsBuilder = new PropertyBuilder().put(LISTENER_PORT, listenPort)
           .put(ADMIN_PORT, TestUtils.getFreePort())
           .put(DATA_BASE_PATH, dataDirectory.getAbsolutePath())
+          .put(LOCAL_REGION_NAME, regionName)
           .put(ENABLE_SERVER_ALLOW_LIST, enableServerAllowlist)
           .put(SERVER_REST_SERVICE_STORAGE_THREAD_NUM, 4)
           .put(MAX_ONLINE_OFFLINE_STATE_TRANSITION_THREAD_NUMBER, 100)

--- a/services/venice-server/src/main/java/com/linkedin/venice/listener/RouterRequestHttpHandler.java
+++ b/services/venice-server/src/main/java/com/linkedin/venice/listener/RouterRequestHttpHandler.java
@@ -7,6 +7,8 @@ import com.linkedin.venice.listener.request.CurrentVersionRequest;
 import com.linkedin.venice.listener.request.DictionaryFetchRequest;
 import com.linkedin.venice.listener.request.GetRouterRequest;
 import com.linkedin.venice.listener.request.HealthCheckRequest;
+import com.linkedin.venice.listener.request.HeartbeatRequest;
+import com.linkedin.venice.listener.request.IngestionContextRequest;
 import com.linkedin.venice.listener.request.MetadataFetchRequest;
 import com.linkedin.venice.listener.request.MultiGetRouterRequestWrapper;
 import com.linkedin.venice.listener.request.RouterRequest;
@@ -137,6 +139,17 @@ public class RouterRequestHttpHandler extends SimpleChannelInboundHandler<FullHt
           statsHandler.setStoreName(currentVersionRequest.getStoreName());
           ctx.fireChannelRead(currentVersionRequest);
           break;
+        case HOST_INGESTION_CONTEXT:
+          statsHandler.setMetadataRequest(true);
+          IngestionContextRequest ingestionContextRequest =
+              IngestionContextRequest.parseGetHttpRequest(uri.getPath(), requestParts);
+          ctx.fireChannelRead(ingestionContextRequest);
+
+        case HOST_HEARTBEAT_LAG:
+          statsHandler.setMetadataRequest(true);
+          HeartbeatRequest heartbeatRequest = HeartbeatRequest.parseGetHttpRequest(uri.getPath(), requestParts);
+          ctx.fireChannelRead(heartbeatRequest);
+
         case TOPIC_PARTITION_INGESTION_CONTEXT:
           TopicPartitionIngestionContextRequest topicPartitionIngestionContextRequest =
               TopicPartitionIngestionContextRequest.parseGetHttpRequest(uri.getPath(), requestParts);

--- a/services/venice-server/src/main/java/com/linkedin/venice/listener/StorageReadRequestHandler.java
+++ b/services/venice-server/src/main/java/com/linkedin/venice/listener/StorageReadRequestHandler.java
@@ -36,6 +36,8 @@ import com.linkedin.venice.listener.request.CurrentVersionRequest;
 import com.linkedin.venice.listener.request.DictionaryFetchRequest;
 import com.linkedin.venice.listener.request.GetRouterRequest;
 import com.linkedin.venice.listener.request.HealthCheckRequest;
+import com.linkedin.venice.listener.request.HeartbeatRequest;
+import com.linkedin.venice.listener.request.IngestionContextRequest;
 import com.linkedin.venice.listener.request.MetadataFetchRequest;
 import com.linkedin.venice.listener.request.MultiGetRouterRequestWrapper;
 import com.linkedin.venice.listener.request.MultiKeyRouterRequestWrapper;
@@ -373,6 +375,13 @@ public class StorageReadRequestHandler extends ChannelInboundHandlerAdapter {
     } else if (message instanceof TopicPartitionIngestionContextRequest) {
       TopicPartitionIngestionContextResponse response =
           handleTopicPartitionIngestionContextRequest((TopicPartitionIngestionContextRequest) message);
+      context.writeAndFlush(response);
+    } else if (message instanceof IngestionContextRequest) {
+      TopicPartitionIngestionContextResponse response =
+          handleIngestionContextRequest((IngestionContextRequest) message);
+      context.writeAndFlush(response);
+    } else if (message instanceof HeartbeatRequest) {
+      TopicPartitionIngestionContextResponse response = handleHeartbeatRequest((HeartbeatRequest) message);
       context.writeAndFlush(response);
     } else {
       context.writeAndFlush(
@@ -851,4 +860,18 @@ public class StorageReadRequestHandler extends ChannelInboundHandlerAdapter {
     String topicName = topicPartitionIngestionContextRequest.getTopic();
     return ingestionMetadataRetriever.getTopicPartitionIngestionContext(versionTopic, topicName, partition);
   }
+
+  private TopicPartitionIngestionContextResponse handleIngestionContextRequest(
+      IngestionContextRequest ingestionContextRequest) {
+    // TODO: Add conditional filter;
+    return ingestionMetadataRetriever.getIngestionContext();
+  }
+
+  private TopicPartitionIngestionContextResponse handleHeartbeatRequest(HeartbeatRequest heartbeatRequest) {
+    return ingestionMetadataRetriever.getHeartbeatLag(
+        heartbeatRequest.getTopic(),
+        heartbeatRequest.getPartition(),
+        heartbeatRequest.isFilterLagReplica());
+  }
+
 }

--- a/services/venice-server/src/main/java/com/linkedin/venice/listener/request/HeartbeatRequest.java
+++ b/services/venice-server/src/main/java/com/linkedin/venice/listener/request/HeartbeatRequest.java
@@ -1,0 +1,45 @@
+package com.linkedin.venice.listener.request;
+
+import com.linkedin.venice.exceptions.VeniceException;
+
+
+public class HeartbeatRequest {
+  private final String topic;
+  private final int partition;
+  private final boolean filterLagReplica;
+
+  private HeartbeatRequest(String topic, int partition, boolean filterLagReplica) {
+    this.topic = topic;
+    this.partition = partition;
+    this.filterLagReplica = filterLagReplica;
+  }
+
+  public String getTopic() {
+    return topic;
+  }
+
+  public int getPartition() {
+    return partition;
+  }
+
+  public boolean isFilterLagReplica() {
+    return filterLagReplica;
+  }
+
+  public static HeartbeatRequest parseGetHttpRequest(String uri, String[] requestParts) {
+    if (requestParts.length == 5) {
+      // [0]""/[1]"action"/[2]"topic"/[3]"partition"/[4]"filter lagging flag"
+      try {
+        String topic = requestParts[2];
+        int partition = Integer.parseInt(requestParts[3]);
+        boolean filterLagReplica = Boolean.getBoolean(requestParts[4]);
+        return new HeartbeatRequest(topic, partition, filterLagReplica);
+      } catch (Exception e) {
+        throw new VeniceException("Unable to parse request for a HeartbeatRequest action: " + uri);
+      }
+    } else {
+      throw new VeniceException("not a valid request for a HeartbeatRequest action: " + uri);
+    }
+  }
+
+}

--- a/services/venice-server/src/main/java/com/linkedin/venice/listener/request/IngestionContextRequest.java
+++ b/services/venice-server/src/main/java/com/linkedin/venice/listener/request/IngestionContextRequest.java
@@ -1,0 +1,18 @@
+package com.linkedin.venice.listener.request;
+
+import com.linkedin.venice.exceptions.VeniceException;
+
+
+public class IngestionContextRequest {
+  private IngestionContextRequest() {
+  }
+
+  public static IngestionContextRequest parseGetHttpRequest(String uri, String[] requestParts) {
+    if (requestParts.length == 2) {
+      return new IngestionContextRequest();
+    } else {
+      throw new VeniceException("not a valid request for a TopicPartitionIngestionContext action: " + uri);
+    }
+  }
+
+}

--- a/services/venice-server/src/main/java/com/linkedin/venice/server/VeniceServer.java
+++ b/services/venice-server/src/main/java/com/linkedin/venice/server/VeniceServer.java
@@ -16,6 +16,7 @@ import com.linkedin.davinci.stats.RocksDBMemoryStats;
 import com.linkedin.davinci.stats.ingestion.heartbeat.HeartbeatMonitoringService;
 import com.linkedin.davinci.storage.DiskHealthCheckService;
 import com.linkedin.davinci.storage.IngestionMetadataRetriever;
+import com.linkedin.davinci.storage.IngestionMetadataRetrieverDelegator;
 import com.linkedin.davinci.storage.ReadMetadataRetriever;
 import com.linkedin.davinci.storage.StorageEngineMetadataService;
 import com.linkedin.davinci.storage.StorageEngineRepository;
@@ -432,7 +433,7 @@ public class VeniceServer {
         metadataRepo,
         storeValueSchemasCacheService,
         customizedViewFuture,
-        kafkaStoreIngestionService,
+        new IngestionMetadataRetrieverDelegator(kafkaStoreIngestionService, heartbeatMonitoringService),
         serverReadMetadataRepository,
         serverConfig,
         metricsRepository,
@@ -537,6 +538,15 @@ public class VeniceServer {
     } else {
       throw new VeniceException("Cannot get kafka store ingestion service if server is not started");
     }
+  }
+
+  public HeartbeatMonitoringService getHeartbeatMonitoringService() {
+    if (isStarted()) {
+      return heartbeatMonitoringService;
+    } else {
+      throw new VeniceException("Cannot get heartbeat monitoring service if server is not started");
+    }
+
   }
 
   // This is for testing purpose.


### PR DESCRIPTION

<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## [admin-tool][server] Add two admin tool commands for dumping consumer ingestion states and heartbeat states; Add logging for stale heartbeat replicas

We already have a admin-tool command to dump ingestion context for a specific topic partition's ingestion context on a specific server host. However, we found it is not very easy to detect which partition replica is actually lagging, when there are multiple partitions assigned to the host. We can iterate over all of them via Helix UI, but it is going to be time consuming.

This PR added 3 things to improve the usability.
1. Add a heartbeat scan thread to periodically run and log lagging resources (every minute by default, this should be good enough not to spam logging). This can be further collected by other logging collecting system and we can easily detect on which host, what replica is lagging by how much.
2. Add a command to dump heartbeat status from a host. It has 3 optional filter: topic filter, partition filter and lag filter. You can choose to see only specific topic / topic-partition or you can choose to only see resources that are lagging. This serves as the manual helper when (1) might be missing stuff.
3. Add a command to dump all consumer service. Filters are not added yet, if you think this is important, I can also add it. I think this will be very useful to see overall distribution and consumption rate for each: region / consumer services / consumer levels.

My long term hope is these commands can be further extended to run periodically when you choose to "attach" to a specific host, and it can collect data for certain time and generate local visualization to help us understand ingestion performance and fairness (because we don't emit too many low level metrics so as to avoid metric explosion), but we need these endpoints to get started. 


## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
Added an integration test to tests two admin tool commands.

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.