### PR TITLE
[server] Add store-aware partition-wise shared consumer assignment strategy

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/KafkaConsumerService.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/KafkaConsumerService.java
@@ -173,7 +173,10 @@ public abstract class KafkaConsumerService extends AbstractKafkaConsumerService 
   }
 
   /** May be overridden to clean up state in sub-classes */
-  void handleUnsubscription(SharedKafkaConsumer consumer, PubSubTopicPartition topicPartition) {
+  void handleUnsubscription(
+      SharedKafkaConsumer consumer,
+      PubSubTopic versionTopic,
+      PubSubTopicPartition topicPartition) {
   }
 
   private String getUniqueClientId(String kafkaUrl, int suffix) {

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/KafkaConsumerService.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/KafkaConsumerService.java
@@ -557,4 +557,8 @@ public abstract class KafkaConsumerService extends AbstractKafkaConsumerService 
   public void setThreadFactory(RandomAccessDaemonThreadFactory threadFactory) {
     this.threadFactory = threadFactory;
   }
+
+  IndexedMap<SharedKafkaConsumer, ConsumptionTask> getConsumerToConsumptionTask() {
+    return consumerToConsumptionTask;
+  }
 }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/KafkaConsumerService.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/KafkaConsumerService.java
@@ -540,7 +540,8 @@ public abstract class KafkaConsumerService extends AbstractKafkaConsumerService 
    */
   public enum ConsumerAssignmentStrategy {
     TOPIC_WISE_SHARED_CONSUMER_ASSIGNMENT_STRATEGY(TopicWiseKafkaConsumerService::new),
-    PARTITION_WISE_SHARED_CONSUMER_ASSIGNMENT_STRATEGY(PartitionWiseKafkaConsumerService::new);
+    PARTITION_WISE_SHARED_CONSUMER_ASSIGNMENT_STRATEGY(PartitionWiseKafkaConsumerService::new),
+    STORE_AWARE_PARTITION_WISE_SHARED_CONSUMER_ASSIGNMENT_STRATEGY(StoreAwarePartitionWiseKafkaConsumerService::new);
 
     final KCSConstructor constructor;
 

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/PartitionWiseKafkaConsumerService.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/PartitionWiseKafkaConsumerService.java
@@ -145,7 +145,10 @@ public class PartitionWiseKafkaConsumerService extends KafkaConsumerService {
   }
 
   @Override
-  void handleUnsubscription(SharedKafkaConsumer consumer, PubSubTopicPartition pubSubTopicPartition) {
+  void handleUnsubscription(
+      SharedKafkaConsumer consumer,
+      PubSubTopic versionTopic,
+      PubSubTopicPartition pubSubTopicPartition) {
     if (pubSubTopicPartition.getPubSubTopic().isRealTime()) {
       Set<PubSubConsumerAdapter> rtTopicConsumers = rtTopicPartitionToConsumerMap.get(pubSubTopicPartition);
       if (rtTopicConsumers != null) {

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/PartitionWiseKafkaConsumerService.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/PartitionWiseKafkaConsumerService.java
@@ -32,10 +32,10 @@ public class PartitionWiseKafkaConsumerService extends KafkaConsumerService {
    * have same real-time topics, we should avoid same real-time topic partition from different version topics sharing
    * the same consumer from consumer pool.
    */
-  private final Map<PubSubTopicPartition, Set<PubSubConsumerAdapter>> rtTopicPartitionToConsumerMap =
+  protected final Map<PubSubTopicPartition, Set<PubSubConsumerAdapter>> rtTopicPartitionToConsumerMap =
       new VeniceConcurrentHashMap<>();
 
-  private final Logger LOGGER;
+  protected Logger LOGGER;
 
   private int shareConsumerIndex = 0;
 
@@ -137,7 +137,7 @@ public class PartitionWiseKafkaConsumerService extends KafkaConsumerService {
     return consumer;
   }
 
-  private boolean alreadySubscribedRealtimeTopicPartition(
+  protected boolean alreadySubscribedRealtimeTopicPartition(
       SharedKafkaConsumer consumer,
       PubSubTopicPartition topicPartition) {
     Set<PubSubConsumerAdapter> consumers = rtTopicPartitionToConsumerMap.get(topicPartition);

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/PartitionWiseKafkaConsumerService.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/PartitionWiseKafkaConsumerService.java
@@ -58,6 +58,48 @@ public class PartitionWiseKafkaConsumerService extends KafkaConsumerService {
       final boolean isKafkaConsumerOffsetCollectionEnabled,
       final ReadOnlyStoreRepository metadataRepository,
       final boolean isUnregisterMetricForDeletedStoreEnabled) {
+    this(
+        poolType,
+        consumerFactory,
+        consumerProperties,
+        readCycleDelayMs,
+        numOfConsumersPerKafkaCluster,
+        ingestionThrottler,
+        kafkaClusterBasedRecordThrottler,
+        metricsRepository,
+        kafkaClusterAlias,
+        sharedConsumerNonExistingTopicCleanupDelayMS,
+        topicExistenceChecker,
+        liveConfigBasedKafkaThrottlingEnabled,
+        pubSubDeserializer,
+        time,
+        stats,
+        isKafkaConsumerOffsetCollectionEnabled,
+        metadataRepository,
+        isUnregisterMetricForDeletedStoreEnabled,
+        PartitionWiseKafkaConsumerService.class.toString());
+  }
+
+  PartitionWiseKafkaConsumerService(
+      final ConsumerPoolType poolType,
+      final PubSubConsumerAdapterFactory consumerFactory,
+      final Properties consumerProperties,
+      final long readCycleDelayMs,
+      final int numOfConsumersPerKafkaCluster,
+      final IngestionThrottler ingestionThrottler,
+      final KafkaClusterBasedRecordThrottler kafkaClusterBasedRecordThrottler,
+      final MetricsRepository metricsRepository,
+      final String kafkaClusterAlias,
+      final long sharedConsumerNonExistingTopicCleanupDelayMS,
+      final TopicExistenceChecker topicExistenceChecker,
+      final boolean liveConfigBasedKafkaThrottlingEnabled,
+      final PubSubMessageDeserializer pubSubDeserializer,
+      final Time time,
+      final AggKafkaConsumerServiceStats stats,
+      final boolean isKafkaConsumerOffsetCollectionEnabled,
+      final ReadOnlyStoreRepository metadataRepository,
+      final boolean isUnregisterMetricForDeletedStoreEnabled,
+      final String loggerNamePrefix) {
     super(
         poolType,
         consumerFactory,
@@ -77,7 +119,7 @@ public class PartitionWiseKafkaConsumerService extends KafkaConsumerService {
         isKafkaConsumerOffsetCollectionEnabled,
         metadataRepository,
         isUnregisterMetricForDeletedStoreEnabled);
-    this.LOGGER = LogManager.getLogger(PartitionWiseKafkaConsumerService.class + " [" + kafkaUrlForLogger + "]");
+    this.LOGGER = LogManager.getLogger(loggerNamePrefix + " [" + kafkaUrlForLogger + "]");
   }
 
   @Override

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/PartitionWiseKafkaConsumerService.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/PartitionWiseKafkaConsumerService.java
@@ -140,7 +140,7 @@ public class PartitionWiseKafkaConsumerService extends KafkaConsumerService {
   protected boolean alreadySubscribedRealtimeTopicPartition(
       SharedKafkaConsumer consumer,
       PubSubTopicPartition topicPartition) {
-    Set<PubSubConsumerAdapter> consumers = rtTopicPartitionToConsumerMap.get(topicPartition);
+    Set<PubSubConsumerAdapter> consumers = getRtTopicPartitionToConsumerMap().get(topicPartition);
     return consumers != null && consumers.contains(consumer);
   }
 
@@ -155,5 +155,13 @@ public class PartitionWiseKafkaConsumerService extends KafkaConsumerService {
         rtTopicConsumers.remove(consumer);
       }
     }
+  }
+
+  Map<PubSubTopicPartition, Set<PubSubConsumerAdapter>> getRtTopicPartitionToConsumerMap() {
+    return rtTopicPartitionToConsumerMap;
+  }
+
+  Logger getLOGGER() {
+    return LOGGER;
   }
 }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/PartitionWiseKafkaConsumerService.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/PartitionWiseKafkaConsumerService.java
@@ -35,7 +35,7 @@ public class PartitionWiseKafkaConsumerService extends KafkaConsumerService {
   protected final Map<PubSubTopicPartition, Set<PubSubConsumerAdapter>> rtTopicPartitionToConsumerMap =
       new VeniceConcurrentHashMap<>();
 
-  protected Logger LOGGER;
+  private final Logger LOGGER;
 
   private int shareConsumerIndex = 0;
 

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/SharedKafkaConsumer.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/SharedKafkaConsumer.java
@@ -109,7 +109,7 @@ class SharedKafkaConsumer implements PubSubConsumerAdapter {
    * Listeners may use this callback to clean up lingering state they may be holding about a consumer.
    */
   interface UnsubscriptionListener {
-    void call(SharedKafkaConsumer consumer, PubSubTopicPartition pubSubTopicPartition);
+    void call(SharedKafkaConsumer consumer, PubSubTopic versionTopic, PubSubTopicPartition pubSubTopicPartition);
   }
 
   protected synchronized void updateCurrentAssignment(Set<PubSubTopicPartition> newAssignment) {
@@ -155,8 +155,8 @@ class SharedKafkaConsumer implements PubSubConsumerAdapter {
   public synchronized void unSubscribe(PubSubTopicPartition pubSubTopicPartition) {
     unSubscribeAction(() -> {
       this.delegate.unSubscribe(pubSubTopicPartition);
-      subscribedTopicPartitionToVersionTopic.remove(pubSubTopicPartition);
-      unsubscriptionListener.call(this, pubSubTopicPartition);
+      PubSubTopic versionTopic = subscribedTopicPartitionToVersionTopic.remove(pubSubTopicPartition);
+      unsubscriptionListener.call(this, versionTopic, pubSubTopicPartition);
       return Collections.singleton(pubSubTopicPartition);
     });
   }
@@ -166,8 +166,8 @@ class SharedKafkaConsumer implements PubSubConsumerAdapter {
     unSubscribeAction(() -> {
       this.delegate.batchUnsubscribe(pubSubTopicPartitionSet);
       for (PubSubTopicPartition pubSubTopicPartition: pubSubTopicPartitionSet) {
-        subscribedTopicPartitionToVersionTopic.remove(pubSubTopicPartition);
-        unsubscriptionListener.call(this, pubSubTopicPartition);
+        PubSubTopic versionTopic = subscribedTopicPartitionToVersionTopic.remove(pubSubTopicPartition);
+        unsubscriptionListener.call(this, versionTopic, pubSubTopicPartition);
       }
       return pubSubTopicPartitionSet;
     });

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreAwarePartitionWiseKafkaConsumerService.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreAwarePartitionWiseKafkaConsumerService.java
@@ -2,19 +2,14 @@ package com.linkedin.davinci.kafka.consumer;
 
 import com.linkedin.davinci.stats.AggKafkaConsumerServiceStats;
 import com.linkedin.venice.meta.ReadOnlyStoreRepository;
-import com.linkedin.venice.meta.Store;
 import com.linkedin.venice.meta.Version;
 import com.linkedin.venice.pubsub.PubSubConsumerAdapterFactory;
-import com.linkedin.venice.pubsub.api.PubSubConsumerAdapter;
 import com.linkedin.venice.pubsub.api.PubSubMessageDeserializer;
 import com.linkedin.venice.pubsub.api.PubSubTopic;
 import com.linkedin.venice.pubsub.api.PubSubTopicPartition;
 import com.linkedin.venice.utils.Time;
-import com.linkedin.venice.utils.concurrent.VeniceConcurrentHashMap;
 import io.tehuti.metrics.MetricsRepository;
-import java.util.Collections;
 import java.util.HashSet;
-import java.util.Map;
 import java.util.Properties;
 
 
@@ -24,21 +19,13 @@ import java.util.Properties;
  * This is store-aware version of topic-wise shared consumer service. The topic partition assignment in this service has
  * a heuristic that we should distribute the all the subscriptions related to a same store / version as even as possible.
  * The load calculation for each consumer will be:
- * Hybrid store: Consumer assignment size + IMPOSSIBLE_MAX_PARTITION_COUNT_PER_CONSUMER * subscription count for the same store;
- * Batch only store: Consumer assignment size + IMPOSSIBLE_MAX_PARTITION_COUNT_PER_CONSUMER * subscription count for the same store version;
- * and we will pick the least loaded consumer for a new topic partition request.
+ * Consumer assignment size + IMPOSSIBLE_MAX_PARTITION_COUNT_PER_CONSUMER * subscription count for the same store;
+ * and we will pick the least loaded consumer for a new topic partition request. If there is no eligible consumer, it
+ * will throw {@link IllegalStateException}
  */
 public class StoreAwarePartitionWiseKafkaConsumerService extends PartitionWiseKafkaConsumerService {
-  // This constant makes sure the store / store version count will always be prioritized over consumer assignment count.
+  // This constant makes sure the store subscription count will always be prioritized over consumer assignment count.
   private static final int IMPOSSIBLE_MAX_PARTITION_COUNT_PER_CONSUMER = 10000;
-  /**
-   * Resource identifier to Consumer Count Map. Resource identifier is the token that determines replica distribution
-   * for different consumer. For batch only store, resource identifier is topic name. For hybrid store, resource
-   * identifier is the store name.
-   */
-  private final Map<String, Map<PubSubConsumerAdapter, Integer>> resourceIdentifierToConsumerMap =
-      new VeniceConcurrentHashMap<>();
-  private final ReadOnlyStoreRepository storeRepository;
 
   StoreAwarePartitionWiseKafkaConsumerService(
       final ConsumerPoolType poolType,
@@ -79,17 +66,15 @@ public class StoreAwarePartitionWiseKafkaConsumerService extends PartitionWiseKa
         metadataRepository,
         isUnregisterMetricForDeletedStoreEnabled,
         StoreAwarePartitionWiseKafkaConsumerService.class.toString());
-    this.storeRepository = metadataRepository;
   }
 
   @Override
   protected synchronized SharedKafkaConsumer pickConsumerForPartition(
       PubSubTopic versionTopic,
       PubSubTopicPartition topicPartition) {
-    String resourceIdentifier = getResourceIdentifier(versionTopic);
-    int minLoad = Integer.MAX_VALUE;
+    String storeName = versionTopic.getStoreName();
+    long minLoad = Long.MAX_VALUE;
     SharedKafkaConsumer minLoadConsumer = null;
-    Map<Integer, Integer> consumerToLoadMap = new VeniceConcurrentHashMap<>();
     for (SharedKafkaConsumer consumer: getConsumerToConsumptionTask().keySet()) {
       int index = getConsumerToConsumptionTask().indexOf(consumer);
       if (topicPartition.getPubSubTopic().isRealTime()
@@ -100,26 +85,15 @@ public class StoreAwarePartitionWiseKafkaConsumerService extends PartitionWiseKa
             topicPartition);
         continue;
       }
-      int baseAssignmentCount = consumer.getAssignmentSize();
-      int storeSubscriptionCount =
-          getResourceIdentifierToConsumerMap().getOrDefault(resourceIdentifier, Collections.emptyMap())
-              .getOrDefault(consumer, 0);
-      int overallLoad = storeSubscriptionCount * IMPOSSIBLE_MAX_PARTITION_COUNT_PER_CONSUMER + baseAssignmentCount;
+      long overallLoad = getConsumerStoreLoad(consumer, storeName);
       if (overallLoad < minLoad) {
         minLoadConsumer = consumer;
         minLoad = overallLoad;
       }
-      consumerToLoadMap.put(index, overallLoad);
     }
-    if (minLoad == Integer.MAX_VALUE) {
-      throw new IllegalStateException(
-          "Unable to find least loaded consumer entry. Current load map: " + consumerToLoadMap);
+    if (minLoad == Long.MAX_VALUE) {
+      throw new IllegalStateException("Unable to find least loaded consumer entry.");
     }
-    // Update resource identifier to consumer load map.
-    Map<PubSubConsumerAdapter, Integer> consumerMap = getResourceIdentifierToConsumerMap()
-        .computeIfAbsent(resourceIdentifier, key -> new VeniceConcurrentHashMap<>());
-    int existCount = consumerMap.getOrDefault(minLoadConsumer, 0);
-    consumerMap.put(minLoadConsumer, existCount + 1);
 
     // Update RT topic partition consumer map.
     if (topicPartition.getPubSubTopic().isRealTime()) {
@@ -136,61 +110,12 @@ public class StoreAwarePartitionWiseKafkaConsumerService extends PartitionWiseKa
     return minLoadConsumer;
   }
 
-  @Override
-  void handleUnsubscription(
-      SharedKafkaConsumer consumer,
-      PubSubTopic versionTopic,
-      PubSubTopicPartition pubSubTopicPartition) {
-    super.handleUnsubscription(consumer, versionTopic, pubSubTopicPartition);
-    // Update resource identifier to consumer assignment map.
-    String resourceIdentifier = getResourceIdentifier(versionTopic);
-    decreaseResourceIdentifierToConsumerCount(resourceIdentifier, consumer);
-  }
-
-  synchronized void decreaseResourceIdentifierToConsumerCount(String resourceIdentifier, SharedKafkaConsumer consumer) {
-    getResourceIdentifierToConsumerMap().compute(resourceIdentifier, (key, consumerCountMap) -> {
-      if (consumerCountMap == null) {
-        throw new IllegalStateException(
-            "Resource identifier consumer map does not contain expected resource identifier: " + resourceIdentifier);
-      }
-      consumerCountMap.compute(consumer, (k, count) -> {
-        if (count == null || count <= 0) {
-          throw new IllegalStateException(
-              "Consumer assignment count map does not contain matching consumer: " + consumer);
-        }
-        return count == 1 ? null : count - 1;
-      });
-      return consumerCountMap.isEmpty() ? null : consumerCountMap;
-    });
-  }
-
-  String getResourceIdentifier(PubSubTopic topic) {
-    String storeName = topic.getStoreName();
-    Store store = getStoreRepository().getStore(storeName);
-    if (store == null) {
-      getLOGGER().warn("Unable to locate store: {}, will default to use store name as resource identifier.", storeName);
-      return storeName;
-    }
-    int versionNumber = Version.parseVersionFromVersionTopicName(topic.getName());
-    Version version = store.getVersion(versionNumber);
-    if (version == null) {
-      getLOGGER().warn(
-          "Unable to locate version: {} for store name: {}, will rely on store's hybrid config to decide resource identifier.",
-          versionNumber,
-          storeName);
-      return store.isHybrid() ? storeName : topic.getName();
-    }
-    if (version.getHybridStoreConfig() == null) {
-      return topic.getName();
-    }
-    return storeName;
-  }
-
-  Map<String, Map<PubSubConsumerAdapter, Integer>> getResourceIdentifierToConsumerMap() {
-    return resourceIdentifierToConsumerMap;
-  }
-
-  ReadOnlyStoreRepository getStoreRepository() {
-    return storeRepository;
+  long getConsumerStoreLoad(SharedKafkaConsumer consumer, String storeName) {
+    long baseAssignmentCount = consumer.getAssignmentSize();
+    long storeSubscriptionCount = consumer.getAssignment()
+        .stream()
+        .filter(x -> Version.parseStoreFromKafkaTopicName(x.getTopicName()).equals(storeName))
+        .count();
+    return storeSubscriptionCount * IMPOSSIBLE_MAX_PARTITION_COUNT_PER_CONSUMER + baseAssignmentCount;
   }
 }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreAwarePartitionWiseKafkaConsumerService.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreAwarePartitionWiseKafkaConsumerService.java
@@ -1,0 +1,157 @@
+package com.linkedin.davinci.kafka.consumer;
+
+import com.linkedin.davinci.stats.AggKafkaConsumerServiceStats;
+import com.linkedin.venice.meta.ReadOnlyStoreRepository;
+import com.linkedin.venice.meta.Version;
+import com.linkedin.venice.pubsub.PubSubConsumerAdapterFactory;
+import com.linkedin.venice.pubsub.api.PubSubConsumerAdapter;
+import com.linkedin.venice.pubsub.api.PubSubMessageDeserializer;
+import com.linkedin.venice.pubsub.api.PubSubTopic;
+import com.linkedin.venice.pubsub.api.PubSubTopicPartition;
+import com.linkedin.venice.utils.Time;
+import com.linkedin.venice.utils.concurrent.VeniceConcurrentHashMap;
+import io.tehuti.metrics.MetricsRepository;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Properties;
+import org.apache.logging.log4j.LogManager;
+
+
+/**
+ * {@link StoreAwarePartitionWiseKafkaConsumerService} is used to allocate share consumer from consumer pool at partition granularity.
+ * One shared consumer may have multiple topics, and each topic may have multiple consumers.
+ * This is store-aware version of topic-wise shared consumer service. The topic partition assignment in this service has
+ * a heuristic that we should distribute the all the subscriptions related to a same store as even as possible.
+ * The load calculation for each consumer will be consumer assignment size + STORE_SUBSCRIPTION_LOAD * subscription count
+ * that belongs to the same store, and we will pick the least loaded consumer for a new topic partition request.
+ */
+public class StoreAwarePartitionWiseKafkaConsumerService extends PartitionWiseKafkaConsumerService {
+  private static final long DEFAULT_STORE_SUBSCRIPTION_LOAD = 100;
+  private final Map<String, Map<PubSubConsumerAdapter, Integer>> storeToConsumerMap = new VeniceConcurrentHashMap<>();
+
+  StoreAwarePartitionWiseKafkaConsumerService(
+      final ConsumerPoolType poolType,
+      final PubSubConsumerAdapterFactory consumerFactory,
+      final Properties consumerProperties,
+      final long readCycleDelayMs,
+      final int numOfConsumersPerKafkaCluster,
+      final IngestionThrottler ingestionThrottler,
+      final KafkaClusterBasedRecordThrottler kafkaClusterBasedRecordThrottler,
+      final MetricsRepository metricsRepository,
+      final String kafkaClusterAlias,
+      final long sharedConsumerNonExistingTopicCleanupDelayMS,
+      final TopicExistenceChecker topicExistenceChecker,
+      final boolean liveConfigBasedKafkaThrottlingEnabled,
+      final PubSubMessageDeserializer pubSubDeserializer,
+      final Time time,
+      final AggKafkaConsumerServiceStats stats,
+      final boolean isKafkaConsumerOffsetCollectionEnabled,
+      final ReadOnlyStoreRepository metadataRepository,
+      final boolean isUnregisterMetricForDeletedStoreEnabled) {
+    super(
+        poolType,
+        consumerFactory,
+        consumerProperties,
+        readCycleDelayMs,
+        numOfConsumersPerKafkaCluster,
+        ingestionThrottler,
+        kafkaClusterBasedRecordThrottler,
+        metricsRepository,
+        kafkaClusterAlias,
+        sharedConsumerNonExistingTopicCleanupDelayMS,
+        topicExistenceChecker,
+        liveConfigBasedKafkaThrottlingEnabled,
+        pubSubDeserializer,
+        time,
+        stats,
+        isKafkaConsumerOffsetCollectionEnabled,
+        metadataRepository,
+        isUnregisterMetricForDeletedStoreEnabled);
+    this.LOGGER =
+        LogManager.getLogger(StoreAwarePartitionWiseKafkaConsumerService.class + " [" + kafkaUrlForLogger + "]");
+  }
+
+  @Override
+  protected synchronized SharedKafkaConsumer pickConsumerForPartition(
+      PubSubTopic versionTopic,
+      PubSubTopicPartition topicPartition) {
+    Map<Integer, Long> consumerToLoadMap = new VeniceConcurrentHashMap<>();
+    for (int i = 0; i < consumerToConsumptionTask.size(); i++) {
+      SharedKafkaConsumer consumer = consumerToConsumptionTask.getByIndex(i).getKey();
+      if (topicPartition.getPubSubTopic().isRealTime()
+          && alreadySubscribedRealtimeTopicPartition(consumer, topicPartition)) {
+        LOGGER.info(
+            "Consumer ID: {} has already subscribed the same real time topic-partition: {}, will assign MAX load to avoid being picked.",
+            i,
+            topicPartition);
+        consumerToLoadMap.put(i, Long.MAX_VALUE);
+        continue;
+      }
+      long baseAssignmentCount = consumer.getAssignmentSize();
+      long storeSubscriptionCount = storeToConsumerMap.getOrDefault(versionTopic.getStoreName(), Collections.emptyMap())
+          .getOrDefault(consumer, 0);
+      long overallLoad = storeSubscriptionCount * DEFAULT_STORE_SUBSCRIPTION_LOAD + baseAssignmentCount;
+      consumerToLoadMap.put(i, overallLoad);
+    }
+
+    // Sort consumer by computed load.
+    Optional<Map.Entry<Integer, Long>> leastLoadedEntry =
+        consumerToLoadMap.entrySet().stream().min(Map.Entry.comparingByValue());
+    if (!leastLoadedEntry.isPresent()) {
+      throw new IllegalStateException(
+          "Unable to find least loaded consumer entry. Current load map: " + consumerToLoadMap);
+    }
+
+    int index = leastLoadedEntry.get().getKey();
+    long load = leastLoadedEntry.get().getValue();
+
+    if (load == Long.MAX_VALUE) {
+      throw new IllegalStateException("Did not find a suitable consumer with valid load.");
+    }
+
+    SharedKafkaConsumer consumer = consumerToConsumptionTask.getByIndex(index).getKey();
+    // Update store to consumer load map.
+    String storeName = versionTopic.getStoreName();
+    Map<PubSubConsumerAdapter, Integer> consumerMap =
+        storeToConsumerMap.computeIfAbsent(storeName, key -> new VeniceConcurrentHashMap<>());
+    int existCount = consumerMap.getOrDefault(consumer, 0);
+    consumerMap.put(consumer, existCount + 1);
+
+    // Update RT topic partition consumer map.
+    if (topicPartition.getPubSubTopic().isRealTime()) {
+      rtTopicPartitionToConsumerMap.computeIfAbsent(topicPartition, key -> new HashSet<>()).add(consumer);
+    }
+
+    LOGGER.info(
+        "Picked consumer id: {}, assignment size: {}, computed load: {} for topic partition: {}, version topic: {}",
+        index,
+        consumer.getAssignmentSize(),
+        load,
+        topicPartition,
+        versionTopic);
+    return consumer;
+  }
+
+  @Override
+  void handleUnsubscription(SharedKafkaConsumer consumer, PubSubTopicPartition pubSubTopicPartition) {
+    super.handleUnsubscription(consumer, pubSubTopicPartition);
+
+    // Update Store to Consumer-Assignment map counting.
+    String storeName = Version.parseStoreFromKafkaTopicName(pubSubTopicPartition.getTopicName());
+    if (!storeToConsumerMap.containsKey(storeName)) {
+      throw new IllegalStateException("Store consumer map does not contain correct store name: " + storeName);
+    }
+
+    int count = storeToConsumerMap.get(storeName).getOrDefault(consumer, 0);
+    if (count <= 0) {
+      throw new IllegalStateException("Consumer assignment count map does not contain matching consumer: " + consumer);
+    }
+    if (count == 1) {
+      storeToConsumerMap.get(storeName).remove(consumer);
+    } else {
+      storeToConsumerMap.get(storeName).put(consumer, count - 1);
+    }
+  }
+}

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreAwarePartitionWiseKafkaConsumerService.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreAwarePartitionWiseKafkaConsumerService.java
@@ -95,7 +95,7 @@ public class StoreAwarePartitionWiseKafkaConsumerService extends PartitionWiseKa
       if (topicPartition.getPubSubTopic().isRealTime()
           && alreadySubscribedRealtimeTopicPartition(consumer, topicPartition)) {
         getLOGGER().info(
-            "Consumer id: {} has already subscribed the same real time topic-partition: {}, will assign MAX load to avoid being picked.",
+            "Consumer id: {} has already subscribed the same real time topic-partition: {} and thus cannot be picked",
             index,
             topicPartition);
         continue;

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/KafkaStoreIngestionServiceWithStoreAwarePartitionWiseTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/KafkaStoreIngestionServiceWithStoreAwarePartitionWiseTest.java
@@ -1,0 +1,7 @@
+package com.linkedin.davinci.kafka.consumer;
+
+public class KafkaStoreIngestionServiceWithStoreAwarePartitionWiseTest extends KafkaStoreIngestionServiceTest {
+  protected KafkaConsumerService.ConsumerAssignmentStrategy getConsumerAssignmentStrategy() {
+    return KafkaConsumerService.ConsumerAssignmentStrategy.STORE_AWARE_PARTITION_WISE_SHARED_CONSUMER_ASSIGNMENT_STRATEGY;
+  }
+}

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/SharedKafkaConsumerTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/SharedKafkaConsumerTest.java
@@ -48,7 +48,7 @@ public class SharedKafkaConsumerTest {
   public void testSubscriptionEmptyPoll() {
     PubSubTopic nonExistingTopic1 = pubSubTopicRepository.getTopic("nonExistingTopic1_v3");
 
-    SharedKafkaConsumer sharedConsumer = new SharedKafkaConsumer(consumer, stats, () -> {}, (c, tp) -> {});
+    SharedKafkaConsumer sharedConsumer = new SharedKafkaConsumer(consumer, stats, () -> {}, (c, vt, tp) -> {});
 
     Set<PubSubTopicPartition> assignmentReturnedConsumer = new HashSet<>();
     PubSubTopicPartition nonExistentPubSubTopicPartition = new PubSubTopicPartitionImpl(nonExistingTopic1, 1);


### PR DESCRIPTION
## [server] Add store-aware partition-wise shared consumer assignment strategy

Add a new version of partition wise shared consumer assignment strategy.
We have been seeing subscriptions to the same topic / store be assigned to the same consumer, and for a particular store push's view (can be inc push / full push) it can be competing with each other and becomes the long-tail partition and slow down the overall progress. 
Assuming the store/topic itself does not have data-skew, then we should try to assign these subscriptions to different consumers as even as possible. Especially for RT topics, backup / current / future version will share the same input volume, so we should not treat them differently within the same pool, but we can further optimize that in different level (Pool assignment strategy) 
This PR adds the new strategy so when a new topic partition is looking for assignment, it will compute and sort all the consumer's load based on general load and the store-specific load. It will assign the new topic partition to the least loaded consumer based on the computed load.

## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
Add a new unit test, will add integration test as well.
## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.