### PR TITLE
[WIP][vpj] Add a way to run DataWriter jobs in an isolated environment

### DIFF
--- a/clients/venice-push-job/build.gradle
+++ b/clients/venice-push-job/build.gradle
@@ -91,6 +91,7 @@ dependencies {
   implementation project(':clients:venice-thin-client') // Needed by the KME SchemaReader
 
   implementation libraries.commonsIo
+  implementation libraries.commonsCli
   implementation libraries.fastUtil
   implementation libraries.jacksonCore
   implementation libraries.jdom

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/mapreduce/counter/MRJobCounterHelper.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/mapreduce/counter/MRJobCounterHelper.java
@@ -178,6 +178,10 @@ public class MRJobCounterHelper {
     incrAmountWithGroupCounterName(reporter, TOTAL_PUT_OR_DELETE_COUNT_GROUP_COUNTER_NAME, amount);
   }
 
+  public static long getEmptyRecordCount(Reporter reporter) {
+    return getCountWithGroupCounterName(reporter, EMPTY_RECORD_COUNTER_NAME);
+  }
+
   public static long getWriteAclAuthorizationFailureCount(Reporter reporter) {
     return getCountWithGroupCounterName(reporter, WRITE_ACL_FAILURE_GROUP_COUNTER_NAME);
   }
@@ -214,8 +218,16 @@ public class MRJobCounterHelper {
     return getCountFromCounters(counters, OUTPUT_RECORD_COUNT_GROUP_COUNTER_NAME);
   }
 
+  public static long getEmptyRecordCount(Counters counters) {
+    return getCountFromCounters(counters, EMPTY_RECORD_COUNTER_NAME);
+  }
+
   public static long getWriteAclAuthorizationFailureCount(Counters counters) {
     return getCountFromCounters(counters, WRITE_ACL_FAILURE_GROUP_COUNTER_NAME);
+  }
+
+  public static long getDuplicateKeyWithIdenticalCount(Counters counters) {
+    return getCountFromCounters(counters, DUP_KEY_WITH_IDENTICAL_VALUE_GROUP_COUNTER_NAME);
   }
 
   public static long getDuplicateKeyWithDistinctCount(Counters counters) {

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/mapreduce/datawriter/jobs/DataWriterMRJob.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/mapreduce/datawriter/jobs/DataWriterMRJob.java
@@ -348,6 +348,11 @@ public class DataWriterMRJob extends DataWriterComputeJob {
   }
 
   @Override
+  public VeniceProperties getJobProperties() {
+    return vpjProperties;
+  }
+
+  @Override
   public PushJobSetting getPushJobSetting() {
     return pushJobSetting;
   }

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/mapreduce/datawriter/task/CounterBackedMapReduceDataWriterTaskTracker.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/mapreduce/datawriter/task/CounterBackedMapReduceDataWriterTaskTracker.java
@@ -21,6 +21,11 @@ public class CounterBackedMapReduceDataWriterTaskTracker implements DataWriterTa
   }
 
   @Override
+  public long getEmptyRecordCount() {
+    return MRJobCounterHelper.getEmptyRecordCount(counters);
+  }
+
+  @Override
   public long getTotalKeySize() {
     return MRJobCounterHelper.getTotalKeySize(counters);
   }
@@ -53,6 +58,11 @@ public class CounterBackedMapReduceDataWriterTaskTracker implements DataWriterTa
   @Override
   public long getWriteAclAuthorizationFailureCount() {
     return MRJobCounterHelper.getWriteAclAuthorizationFailureCount(counters);
+  }
+
+  @Override
+  public long getDuplicateKeyWithIdenticalValueCount() {
+    return MRJobCounterHelper.getDuplicateKeyWithIdenticalCount(counters);
   }
 
   @Override

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/task/datawriter/DataWriterTaskTracker.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/task/datawriter/DataWriterTaskTracker.java
@@ -56,6 +56,10 @@ public interface DataWriterTaskTracker extends TaskTracker {
     return 0;
   }
 
+  default long getEmptyRecordCount() {
+    return 0;
+  }
+
   default long getTotalKeySize() {
     return 0;
   }
@@ -81,6 +85,10 @@ public interface DataWriterTaskTracker extends TaskTracker {
   }
 
   default long getWriteAclAuthorizationFailureCount() {
+    return 0;
+  }
+
+  default long getDuplicateKeyWithIdenticalValueCount() {
     return 0;
   }
 

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/jobs/ComputeJob.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/jobs/ComputeJob.java
@@ -42,6 +42,11 @@ public interface ComputeJob extends Closeable {
 
   Throwable getFailureReason();
 
+  /**
+   * Return the job properties that were used to configure the job in {@link #configure(VeniceProperties)}
+   */
+  VeniceProperties getJobProperties();
+
   default void kill() {
   }
 

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/jobs/DataWriterComputeJob.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/jobs/DataWriterComputeJob.java
@@ -114,7 +114,7 @@ public abstract class DataWriterComputeJob implements ComputeJob {
   protected abstract void runComputeJob();
 
   @Override
-  public void configure(VeniceProperties properties) {
+  public final void configure(VeniceProperties properties) {
     LOGGER.warn("Data writer compute job needs additional configs to be configured.");
   }
 

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/proxyjob/datawriter/jobs/AbstractDataWriterProxyJob.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/proxyjob/datawriter/jobs/AbstractDataWriterProxyJob.java
@@ -1,0 +1,99 @@
+package com.linkedin.venice.proxyjob.datawriter.jobs;
+
+import static com.linkedin.venice.vpj.VenicePushJobConstants.PERMISSION_700;
+
+import com.linkedin.venice.hadoop.PushJobSetting;
+import com.linkedin.venice.hadoop.task.datawriter.DataWriterTaskTracker;
+import com.linkedin.venice.hadoop.utils.HadoopUtils;
+import com.linkedin.venice.jobs.DataWriterComputeJob;
+import com.linkedin.venice.proxyjob.datawriter.task.DelegatingReadOnlyDataWriterTaskTracker;
+import com.linkedin.venice.proxyjob.datawriter.utils.ProxyJobCliUtils;
+import com.linkedin.venice.proxyjob.datawriter.utils.ProxyJobStatus;
+import com.linkedin.venice.proxyjob.datawriter.utils.ProxyJobUtils;
+import com.linkedin.venice.utils.Utils;
+import com.linkedin.venice.utils.VeniceProperties;
+import java.io.IOException;
+import java.util.List;
+import org.apache.hadoop.fs.Path;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+
+/**
+ * This will be the proxy job for the data writer job. It will launch the data writer job in an isolated environment,
+ * like a new process, or a remote execution environment. It will act as a proxy between the data writer job and the VPJ
+ * driver.
+ */
+public abstract class AbstractDataWriterProxyJob extends DataWriterComputeJob {
+  private static final Logger LOGGER = LogManager.getLogger(AbstractDataWriterProxyJob.class);
+  private VeniceProperties props;
+  private PushJobSetting pushJobSetting;
+  private DelegatingReadOnlyDataWriterTaskTracker taskTracker;
+
+  @Override
+  public DataWriterTaskTracker getTaskTracker() {
+    return taskTracker;
+  }
+
+  protected abstract void runProxyJob(List<String> args);
+
+  @Override
+  protected final void runComputeJob() {
+    String proxyJobStateDir = Utils.escapeFilePathComponent(Utils.getUniqueString("data_writer_proxy_job"));
+    Path proxyJobStateDirPath = new Path(pushJobSetting.jobTmpDir, proxyJobStateDir);
+    try {
+      HadoopUtils.createDirectoryWithPermission(proxyJobStateDirPath, PERMISSION_700);
+      List<String> args =
+          ProxyJobCliUtils.toCliArgs(props.toProperties(), pushJobSetting, proxyJobStateDirPath.toUri().toString());
+      runProxyJob(args);
+
+      ProxyJobStatus jobStatus = ProxyJobUtils.getJobStatus(proxyJobStateDirPath);
+      if (jobStatus == null) {
+        throw new RuntimeException("Failed to get job status from proxy job state directory: " + proxyJobStateDirPath);
+      }
+
+      taskTracker.setDelegate(jobStatus.getTaskTracker());
+      logJobMetrics(jobStatus.getTaskTracker());
+      if (jobStatus.getFailureReason() != null) {
+        throw new RuntimeException(jobStatus.getFailureReason());
+      }
+    } catch (IOException e) {
+      throw new RuntimeException("Failed to create proxy job state directory: " + proxyJobStateDirPath, e);
+    }
+  }
+
+  private void logJobMetrics(DataWriterTaskTracker taskTracker) {
+    LOGGER.info("Job metrics for data writer job:");
+    LOGGER.info("  Total Output Records: {}", taskTracker.getOutputRecordsCount());
+    LOGGER.info("  Empty Records: {}", taskTracker.getEmptyRecordCount());
+    LOGGER.info("  Total Key Size: {}", taskTracker.getTotalKeySize());
+    LOGGER.info("  Total Uncompressed Value Size: {}", taskTracker.getTotalUncompressedValueSize());
+    LOGGER.info("  Total Compressed Value Size: {}", taskTracker.getTotalValueSize());
+    LOGGER.info("  Total Gzip Compressed Value Size: {}", taskTracker.getTotalGzipCompressedValueSize());
+    LOGGER.info("  Total Zstd Compressed Value Size: {}", taskTracker.getTotalZstdCompressedValueSize());
+    LOGGER.info("  Spray All Partitions Triggered: {}", taskTracker.getSprayAllPartitionsCount());
+    LOGGER.info("  Partition Writers Closed: {}", taskTracker.getPartitionWriterCloseCount());
+    LOGGER.info("  Repush TTL Filtered Records: {}", taskTracker.getRepushTtlFilterCount());
+    LOGGER.info("  ACL Authorization Failures: {}", taskTracker.getWriteAclAuthorizationFailureCount());
+    LOGGER.info("  Record Too Large Failures: {}", taskTracker.getRecordTooLargeFailureCount());
+    LOGGER.info("  Duplicate Key With Identical Value: {}", taskTracker.getDuplicateKeyWithIdenticalValueCount());
+    LOGGER.info("  Duplicate Key With Distinct Value: {}", taskTracker.getDuplicateKeyWithDistinctValueCount());
+  }
+
+  @Override
+  public VeniceProperties getJobProperties() {
+    return props;
+  }
+
+  @Override
+  protected PushJobSetting getPushJobSetting() {
+    return pushJobSetting;
+  }
+
+  @Override
+  public void configure(VeniceProperties props, PushJobSetting pushJobSetting) {
+    this.props = props;
+    this.pushJobSetting = pushJobSetting;
+    this.taskTracker = new DelegatingReadOnlyDataWriterTaskTracker();
+  }
+}

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/proxyjob/datawriter/jobs/DataWriterProxyDriver.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/proxyjob/datawriter/jobs/DataWriterProxyDriver.java
@@ -1,0 +1,74 @@
+package com.linkedin.venice.proxyjob.datawriter.jobs;
+
+import static com.linkedin.venice.vpj.VenicePushJobConstants.DATA_WRITER_PROXY_COMPUTE_JOB_CLASS;
+
+import com.linkedin.venice.hadoop.PushJobSetting;
+import com.linkedin.venice.jobs.DataWriterComputeJob;
+import com.linkedin.venice.proxyjob.datawriter.utils.ProxyJobCliUtils;
+import com.linkedin.venice.proxyjob.datawriter.utils.ProxyJobStatus;
+import com.linkedin.venice.proxyjob.datawriter.utils.ProxyJobUtils;
+import com.linkedin.venice.utils.ReflectUtils;
+import com.linkedin.venice.utils.Utils;
+import com.linkedin.venice.utils.VeniceProperties;
+import java.util.Properties;
+import org.apache.commons.cli.CommandLine;
+import org.apache.commons.lang3.Validate;
+import org.apache.hadoop.fs.Path;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+
+public class DataWriterProxyDriver {
+  private static final Logger LOGGER = LogManager.getLogger(DataWriterProxyDriver.class);
+
+  public static void main(String[] args) throws Exception {
+    runDataWriterJob(args, true);
+  }
+
+  public static void runDataWriterJob(String[] args, boolean killFromShutdownHook) throws Exception {
+    CommandLine commandLine = ProxyJobCliUtils.parseArgs(args);
+    Properties properties = ProxyJobCliUtils.getPropertiesFromCliArgs(commandLine);
+    VeniceProperties props = new VeniceProperties(properties);
+
+    PushJobSetting pushJobSetting = ProxyJobCliUtils.getPushJobSettingFromCliArgs(commandLine);
+
+    String outputPathStr = ProxyJobCliUtils.getOutputDirFromCliArgs(commandLine);
+    Path outputPath = new Path(outputPathStr);
+
+    String computeJobClassName = props.getString(DATA_WRITER_PROXY_COMPUTE_JOB_CLASS);
+
+    Class objectClass = ReflectUtils.loadClass(computeJobClassName);
+    Validate.isAssignableFrom(DataWriterComputeJob.class, objectClass);
+    Class<? extends DataWriterComputeJob> computeJobClass = (Class<? extends DataWriterComputeJob>) objectClass;
+    DataWriterComputeJob computeJob = ReflectUtils.callConstructor(computeJobClass, new Class[0], new Object[0]);
+
+    computeJob.configure(props, pushJobSetting);
+
+    // A shutdown hook is needed to kill the compute job to handle the case where the job is killed by the environment.
+    Thread computeJobKiller = new Thread(() -> {
+      LOGGER.info("Killing compute job from shutdown hook");
+      try {
+        computeJob.kill();
+      } catch (Exception e) {
+        throw new RuntimeException(e);
+      }
+    });
+
+    if (killFromShutdownHook) {
+      Runtime.getRuntime().addShutdownHook(computeJobKiller);
+    }
+
+    computeJob.runJob();
+
+    if (killFromShutdownHook) {
+      // Job completed, remove the shutdown hook
+      Runtime.getRuntime().removeShutdownHook(computeJobKiller);
+    }
+
+    ProxyJobStatus status =
+        new ProxyJobStatus(computeJob.getTaskTracker(), computeJob.getStatus(), computeJob.getFailureReason());
+    ProxyJobUtils.writeJobStatus(outputPath, status);
+
+    Utils.closeQuietlyWithErrorLogged(computeJob);
+  }
+}

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/proxyjob/datawriter/jobs/ForkedProcessProxyJob.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/proxyjob/datawriter/jobs/ForkedProcessProxyJob.java
@@ -1,0 +1,19 @@
+package com.linkedin.venice.proxyjob.datawriter.jobs;
+
+import com.linkedin.venice.utils.ForkedJavaProcess;
+import java.util.Collections;
+import java.util.List;
+
+
+public class ForkedProcessProxyJob extends AbstractDataWriterProxyJob {
+  @Override
+  protected void runProxyJob(List<String> args) {
+    try {
+      ForkedJavaProcess javaProcess =
+          ForkedJavaProcess.exec(DataWriterProxyDriver.class, args, Collections.emptyList());
+      javaProcess.waitFor();
+    } catch (Exception e) {
+      throw new RuntimeException("Failed to run data writer job", e);
+    }
+  }
+}

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/proxyjob/datawriter/task/DelegatingReadOnlyDataWriterTaskTracker.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/proxyjob/datawriter/task/DelegatingReadOnlyDataWriterTaskTracker.java
@@ -1,0 +1,135 @@
+package com.linkedin.venice.proxyjob.datawriter.task;
+
+import com.linkedin.venice.hadoop.task.datawriter.DataWriterTaskTracker;
+
+
+public class DelegatingReadOnlyDataWriterTaskTracker implements DataWriterTaskTracker {
+  private DataWriterTaskTracker delegate;
+
+  public DelegatingReadOnlyDataWriterTaskTracker() {
+  }
+
+  public void setDelegate(DataWriterTaskTracker delegate) {
+    this.delegate = delegate;
+  }
+
+  @Override
+  public long getSprayAllPartitionsCount() {
+    if (delegate == null) {
+      return DataWriterTaskTracker.super.getSprayAllPartitionsCount();
+    }
+    return delegate.getSprayAllPartitionsCount();
+  }
+
+  @Override
+  public long getEmptyRecordCount() {
+    if (delegate == null) {
+      return DataWriterTaskTracker.super.getEmptyRecordCount();
+    }
+    return delegate.getEmptyRecordCount();
+  }
+
+  @Override
+  public long getTotalKeySize() {
+    if (delegate == null) {
+      return DataWriterTaskTracker.super.getTotalKeySize();
+    }
+    return delegate.getTotalKeySize();
+  }
+
+  @Override
+  public long getTotalValueSize() {
+    if (delegate == null) {
+      return DataWriterTaskTracker.super.getTotalValueSize();
+    }
+    return delegate.getTotalValueSize();
+  }
+
+  @Override
+  public long getTotalUncompressedValueSize() {
+    if (delegate == null) {
+      return DataWriterTaskTracker.super.getTotalUncompressedValueSize();
+    }
+    return delegate.getTotalUncompressedValueSize();
+  }
+
+  @Override
+  public long getTotalGzipCompressedValueSize() {
+    if (delegate == null) {
+      return DataWriterTaskTracker.super.getTotalGzipCompressedValueSize();
+    }
+    return delegate.getTotalGzipCompressedValueSize();
+  }
+
+  @Override
+  public long getTotalZstdCompressedValueSize() {
+    if (delegate == null) {
+      return DataWriterTaskTracker.super.getTotalZstdCompressedValueSize();
+    }
+    return delegate.getTotalZstdCompressedValueSize();
+  }
+
+  @Override
+  public long getRecordTooLargeFailureCount() {
+    if (delegate == null) {
+      return DataWriterTaskTracker.super.getRecordTooLargeFailureCount();
+    }
+    return delegate.getRecordTooLargeFailureCount();
+  }
+
+  @Override
+  public long getWriteAclAuthorizationFailureCount() {
+    if (delegate == null) {
+      return DataWriterTaskTracker.super.getWriteAclAuthorizationFailureCount();
+    }
+    return delegate.getWriteAclAuthorizationFailureCount();
+  }
+
+  @Override
+  public long getDuplicateKeyWithIdenticalValueCount() {
+    if (delegate == null) {
+      return DataWriterTaskTracker.super.getDuplicateKeyWithIdenticalValueCount();
+    }
+    return delegate.getDuplicateKeyWithIdenticalValueCount();
+  }
+
+  @Override
+  public long getDuplicateKeyWithDistinctValueCount() {
+    if (delegate == null) {
+      return DataWriterTaskTracker.super.getDuplicateKeyWithDistinctValueCount();
+    }
+    return delegate.getDuplicateKeyWithDistinctValueCount();
+  }
+
+  @Override
+  public long getOutputRecordsCount() {
+    if (delegate == null) {
+      return DataWriterTaskTracker.super.getOutputRecordsCount();
+    }
+    return delegate.getOutputRecordsCount();
+  }
+
+  @Override
+  public long getPartitionWriterCloseCount() {
+    if (delegate == null) {
+      return DataWriterTaskTracker.super.getPartitionWriterCloseCount();
+    }
+    return delegate.getPartitionWriterCloseCount();
+  }
+
+  @Override
+  public long getRepushTtlFilterCount() {
+    if (delegate == null) {
+      return DataWriterTaskTracker.super.getRepushTtlFilterCount();
+    }
+    return delegate.getRepushTtlFilterCount();
+  }
+
+  @Override
+  public long getTotalPutOrDeleteRecordsCount() {
+    if (delegate == null) {
+      return DataWriterTaskTracker.super.getTotalPutOrDeleteRecordsCount();
+    }
+    return delegate.getTotalPutOrDeleteRecordsCount();
+  }
+}

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/proxyjob/datawriter/task/SerializingDataWriterTaskTracker.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/proxyjob/datawriter/task/SerializingDataWriterTaskTracker.java
@@ -1,0 +1,178 @@
+package com.linkedin.venice.proxyjob.datawriter.task;
+
+import com.linkedin.venice.hadoop.task.datawriter.DataWriterTaskTracker;
+import java.io.Serializable;
+
+
+public class SerializingDataWriterTaskTracker implements DataWriterTaskTracker, Serializable {
+  private long sprayAllPartitionsCount = 0;
+  private long emptyRecordCount = 0;
+  private long totalKeySize = 0;
+  private long totalValueSize = 0;
+  private long totalUncompressedValueSize = 0;
+  private long totalGzipCompressedValueSize = 0;
+  private long totalZstdCompressedValueSize = 0;
+  private long recordTooLargeFailureCount = 0;
+  private long writeAclAuthorizationFailureCount = 0;
+  private long duplicateKeyWithIdenticalValueCount = 0;
+  private long duplicateKeyWithDistinctValueCount = 0;
+  private long outputRecordsCount = 0;
+  private long partitionWriterCloseCount = 0;
+  private long repushTtlFilterCount = 0;
+  private long totalPutOrDeleteRecordsCount = 0;
+
+  public static SerializingDataWriterTaskTracker fromDataWriterTaskTracker(DataWriterTaskTracker delegate) {
+    SerializingDataWriterTaskTracker taskTracker = new SerializingDataWriterTaskTracker();
+    taskTracker.setSprayAllPartitionsCount(delegate.getSprayAllPartitionsCount());
+    taskTracker.setEmptyRecordCount(delegate.getEmptyRecordCount());
+    taskTracker.setTotalKeySize(delegate.getTotalKeySize());
+    taskTracker.setTotalValueSize(delegate.getTotalValueSize());
+    taskTracker.setTotalUncompressedValueSize(delegate.getTotalUncompressedValueSize());
+    taskTracker.setTotalGzipCompressedValueSize(delegate.getTotalGzipCompressedValueSize());
+    taskTracker.setTotalZstdCompressedValueSize(delegate.getTotalZstdCompressedValueSize());
+    taskTracker.setRecordTooLargeFailureCount(delegate.getRecordTooLargeFailureCount());
+    taskTracker.setWriteAclAuthorizationFailureCount(delegate.getWriteAclAuthorizationFailureCount());
+    taskTracker.setDuplicateKeyWithIdenticalValueCount(delegate.getDuplicateKeyWithIdenticalValueCount());
+    taskTracker.setDuplicateKeyWithDistinctValueCount(delegate.getDuplicateKeyWithDistinctValueCount());
+    taskTracker.setOutputRecordsCount(delegate.getOutputRecordsCount());
+    taskTracker.setPartitionWriterCloseCount(delegate.getPartitionWriterCloseCount());
+    taskTracker.setRepushTtlFilterCount(delegate.getRepushTtlFilterCount());
+    taskTracker.setTotalPutOrDeleteRecordsCount(delegate.getTotalPutOrDeleteRecordsCount());
+    return taskTracker;
+  }
+
+  @Override
+  public long getSprayAllPartitionsCount() {
+    return sprayAllPartitionsCount;
+  }
+
+  public void setSprayAllPartitionsCount(long sprayAllPartitionsCount) {
+    this.sprayAllPartitionsCount = sprayAllPartitionsCount;
+  }
+
+  @Override
+  public long getEmptyRecordCount() {
+    return emptyRecordCount;
+  }
+
+  public void setEmptyRecordCount(long emptyRecordCount) {
+    this.emptyRecordCount = emptyRecordCount;
+  }
+
+  @Override
+  public long getTotalKeySize() {
+    return totalKeySize;
+  }
+
+  public void setTotalKeySize(long totalKeySize) {
+    this.totalKeySize = totalKeySize;
+  }
+
+  @Override
+  public long getTotalValueSize() {
+    return totalValueSize;
+  }
+
+  public void setTotalValueSize(long totalValueSize) {
+    this.totalValueSize = totalValueSize;
+  }
+
+  @Override
+  public long getTotalUncompressedValueSize() {
+    return totalUncompressedValueSize;
+  }
+
+  public void setTotalUncompressedValueSize(long totalUncompressedValueSize) {
+    this.totalUncompressedValueSize = totalUncompressedValueSize;
+  }
+
+  @Override
+  public long getTotalGzipCompressedValueSize() {
+    return totalGzipCompressedValueSize;
+  }
+
+  public void setTotalGzipCompressedValueSize(long totalGzipCompressedValueSize) {
+    this.totalGzipCompressedValueSize = totalGzipCompressedValueSize;
+  }
+
+  @Override
+  public long getTotalZstdCompressedValueSize() {
+    return totalZstdCompressedValueSize;
+  }
+
+  public void setTotalZstdCompressedValueSize(long totalZstdCompressedValueSize) {
+    this.totalZstdCompressedValueSize = totalZstdCompressedValueSize;
+  }
+
+  @Override
+  public long getRecordTooLargeFailureCount() {
+    return recordTooLargeFailureCount;
+  }
+
+  public void setRecordTooLargeFailureCount(long recordTooLargeFailureCount) {
+    this.recordTooLargeFailureCount = recordTooLargeFailureCount;
+  }
+
+  @Override
+  public long getWriteAclAuthorizationFailureCount() {
+    return writeAclAuthorizationFailureCount;
+  }
+
+  public void setWriteAclAuthorizationFailureCount(long writeAclAuthorizationFailureCount) {
+    this.writeAclAuthorizationFailureCount = writeAclAuthorizationFailureCount;
+  }
+
+  @Override
+  public long getDuplicateKeyWithIdenticalValueCount() {
+    return duplicateKeyWithIdenticalValueCount;
+  }
+
+  public void setDuplicateKeyWithIdenticalValueCount(long duplicateKeyWithIdenticalValueCount) {
+    this.duplicateKeyWithIdenticalValueCount = duplicateKeyWithIdenticalValueCount;
+  }
+
+  @Override
+  public long getDuplicateKeyWithDistinctValueCount() {
+    return duplicateKeyWithDistinctValueCount;
+  }
+
+  public void setDuplicateKeyWithDistinctValueCount(long duplicateKeyWithDistinctValueCount) {
+    this.duplicateKeyWithDistinctValueCount = duplicateKeyWithDistinctValueCount;
+  }
+
+  @Override
+  public long getOutputRecordsCount() {
+    return outputRecordsCount;
+  }
+
+  public void setOutputRecordsCount(long outputRecordsCount) {
+    this.outputRecordsCount = outputRecordsCount;
+  }
+
+  @Override
+  public long getPartitionWriterCloseCount() {
+    return partitionWriterCloseCount;
+  }
+
+  public void setPartitionWriterCloseCount(long partitionWriterCloseCount) {
+    this.partitionWriterCloseCount = partitionWriterCloseCount;
+  }
+
+  @Override
+  public long getRepushTtlFilterCount() {
+    return repushTtlFilterCount;
+  }
+
+  public void setRepushTtlFilterCount(long repushTtlFilterCount) {
+    this.repushTtlFilterCount = repushTtlFilterCount;
+  }
+
+  @Override
+  public long getTotalPutOrDeleteRecordsCount() {
+    return totalPutOrDeleteRecordsCount;
+  }
+
+  public void setTotalPutOrDeleteRecordsCount(long totalPutOrDeleteRecordsCount) {
+    this.totalPutOrDeleteRecordsCount = totalPutOrDeleteRecordsCount;
+  }
+}

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/proxyjob/datawriter/utils/ProxyJobCliUtils.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/proxyjob/datawriter/utils/ProxyJobCliUtils.java
@@ -1,0 +1,114 @@
+package com.linkedin.venice.proxyjob.datawriter.utils;
+
+import com.linkedin.venice.compression.GzipCompressor;
+import com.linkedin.venice.exceptions.VeniceException;
+import com.linkedin.venice.hadoop.PushJobSetting;
+import com.linkedin.venice.utils.ByteUtils;
+import com.linkedin.venice.utils.EncodingUtils;
+import java.io.IOException;
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Properties;
+import org.apache.commons.cli.CommandLine;
+import org.apache.commons.cli.CommandLineParser;
+import org.apache.commons.cli.DefaultParser;
+import org.apache.commons.cli.Option;
+import org.apache.commons.cli.Options;
+import org.apache.commons.cli.ParseException;
+import org.apache.commons.lang3.SerializationUtils;
+
+
+public final class ProxyJobCliUtils {
+  private ProxyJobCliUtils() {
+  }
+
+  private enum Arg {
+    PROPS("props", "p", true, "Serialized job properties"),
+    PUSH_JOB_SETTINGS("push-job-settings", "s", true, "Serialized push job settings"),
+    OUTPUT_DIR("output-dir", "o", true, "Path of the directory where the job should output it's final state");
+
+    private final Option option;
+
+    Arg(String longOpt, String shortOpt, boolean parameterized, String helpText) {
+      this.option =
+          Option.builder(shortOpt).longOpt(longOpt).argName(longOpt).hasArg(parameterized).desc(helpText).build();
+    }
+
+    public Option getOption() {
+      return this.option;
+    }
+
+    public String getShortOpt() {
+      return this.option.getOpt();
+    }
+
+    public String getName() {
+      return this.option.getArgName();
+    }
+
+    public String toString() {
+      return this.getName();
+    }
+  }
+
+  public static List<String> toCliArgs(Properties properties, PushJobSetting pushJobSetting, String outputDir) {
+    List<String> cliArgs = new ArrayList<>();
+    addComplexCliArgs(cliArgs, Arg.PROPS, properties);
+    addComplexCliArgs(cliArgs, Arg.PUSH_JOB_SETTINGS, pushJobSetting);
+    addCliArg(cliArgs, Arg.OUTPUT_DIR, outputDir);
+    return cliArgs;
+  }
+
+  private static void addComplexCliArgs(List<String> cliArgs, Arg arg, Serializable serializableObj) {
+    try (GzipCompressor compressor = new GzipCompressor()) {
+      byte[] data = compressor.compress(SerializationUtils.serialize(serializableObj));
+      String dataB64 = EncodingUtils.base64EncodeToString(data);
+      addCliArg(cliArgs, arg, dataB64);
+    } catch (IOException e) {
+      throw new VeniceException(e);
+    }
+  }
+
+  private static void addCliArg(List<String> cliArgs, Arg key, String value) {
+    if (value == null) {
+      return;
+    }
+
+    cliArgs.add("-" + key.getOption().getOpt());
+    cliArgs.add(value);
+  }
+
+  public static CommandLine parseArgs(String[] args) throws ParseException {
+    Options options = new Options();
+    for (Arg option: Arg.values()) {
+      options.addOption(option.getOption());
+    }
+
+    CommandLineParser parser = new DefaultParser(false);
+    return parser.parse(options, args);
+  }
+
+  private static <T extends Serializable> T getComplexObjectFromCliArgs(CommandLine commandLine, Arg arg) {
+    String dataStr = commandLine.getOptionValue(arg.getShortOpt());
+    try (GzipCompressor compressor = new GzipCompressor()) {
+      byte[] compressed = EncodingUtils.base64DecodeFromString(dataStr);
+      byte[] data = ByteUtils.extractByteArray(compressor.decompress(compressed, 0, compressed.length));
+      return (T) SerializationUtils.deserialize(data);
+    } catch (IOException e) {
+      throw new VeniceException(e);
+    }
+  }
+
+  public static Properties getPropertiesFromCliArgs(CommandLine commandLine) {
+    return getComplexObjectFromCliArgs(commandLine, Arg.PROPS);
+  }
+
+  public static PushJobSetting getPushJobSettingFromCliArgs(CommandLine commandLine) {
+    return getComplexObjectFromCliArgs(commandLine, Arg.PUSH_JOB_SETTINGS);
+  }
+
+  public static String getOutputDirFromCliArgs(CommandLine commandLine) {
+    return commandLine.getOptionValue(Arg.OUTPUT_DIR.getShortOpt());
+  }
+}

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/proxyjob/datawriter/utils/ProxyJobStatus.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/proxyjob/datawriter/utils/ProxyJobStatus.java
@@ -1,0 +1,31 @@
+package com.linkedin.venice.proxyjob.datawriter.utils;
+
+import com.linkedin.venice.hadoop.task.datawriter.DataWriterTaskTracker;
+import com.linkedin.venice.jobs.ComputeJob;
+import com.linkedin.venice.proxyjob.datawriter.task.SerializingDataWriterTaskTracker;
+import java.io.Serializable;
+
+
+public class ProxyJobStatus implements Serializable {
+  private final SerializingDataWriterTaskTracker taskTracker;
+  private final ComputeJob.Status status;
+  private final Throwable failureReason;
+
+  public ProxyJobStatus(DataWriterTaskTracker taskTracker, ComputeJob.Status status, Throwable failureReason) {
+    this.taskTracker = SerializingDataWriterTaskTracker.fromDataWriterTaskTracker(taskTracker);
+    this.status = status;
+    this.failureReason = failureReason;
+  }
+
+  public DataWriterTaskTracker getTaskTracker() {
+    return taskTracker;
+  }
+
+  public ComputeJob.Status getStatus() {
+    return status;
+  }
+
+  public Throwable getFailureReason() {
+    return failureReason;
+  }
+}

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/proxyjob/datawriter/utils/ProxyJobUtils.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/proxyjob/datawriter/utils/ProxyJobUtils.java
@@ -1,0 +1,40 @@
+package com.linkedin.venice.proxyjob.datawriter.utils;
+
+import java.io.IOException;
+import org.apache.commons.io.IOUtils;
+import org.apache.commons.lang3.SerializationUtils;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FSDataInputStream;
+import org.apache.hadoop.fs.FSDataOutputStream;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+
+
+public final class ProxyJobUtils {
+  private static final String FILE_NAME = "jobStatus";
+
+  private ProxyJobUtils() {
+  }
+
+  public static void writeJobStatus(Path proxyJobStateDirPath, ProxyJobStatus status) throws IOException {
+    FileSystem fs = proxyJobStateDirPath.getFileSystem(new Configuration());
+    FSDataOutputStream out = fs.create(new Path(proxyJobStateDirPath, FILE_NAME));
+
+    byte[] serializedStatus = SerializationUtils.serialize(status);
+
+    out.write(serializedStatus);
+    out.flush();
+    out.close();
+  }
+
+  public static ProxyJobStatus getJobStatus(Path proxyJobStateDirPath) throws IOException {
+    FileSystem fs = proxyJobStateDirPath.getFileSystem(new Configuration());
+    Path filePath = new Path(proxyJobStateDirPath, FILE_NAME);
+    if (!fs.exists(filePath)) {
+      return null;
+    }
+    FSDataInputStream inputStream = fs.open(filePath);
+    byte[] serializedStatus = IOUtils.toByteArray(inputStream);
+    return SerializationUtils.deserialize(serializedStatus);
+  }
+}

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/spark/datawriter/jobs/AbstractDataWriterSparkJob.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/spark/datawriter/jobs/AbstractDataWriterSparkJob.java
@@ -354,9 +354,8 @@ public abstract class AbstractDataWriterSparkJob extends DataWriterComputeJob {
     return taskTracker;
   }
 
-  // This is a part of the public API. Do not remove.
-  @SuppressWarnings("unused")
-  protected VeniceProperties getJobProperties() {
+  @Override
+  public VeniceProperties getJobProperties() {
     return props;
   }
 

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/spark/datawriter/task/SparkDataWriterTaskTracker.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/spark/datawriter/task/SparkDataWriterTaskTracker.java
@@ -86,6 +86,11 @@ public class SparkDataWriterTaskTracker implements DataWriterTaskTracker {
   }
 
   @Override
+  public long getEmptyRecordCount() {
+    return accumulators.emptyRecordCounter.value();
+  }
+
+  @Override
   public long getTotalKeySize() {
     return accumulators.totalKeySizeCounter.value();
   }
@@ -118,6 +123,11 @@ public class SparkDataWriterTaskTracker implements DataWriterTaskTracker {
   @Override
   public long getWriteAclAuthorizationFailureCount() {
     return accumulators.writeAclAuthorizationFailureCounter.value();
+  }
+
+  @Override
+  public long getDuplicateKeyWithIdenticalValueCount() {
+    return accumulators.duplicateKeyWithIdenticalValueCounter.value();
   }
 
   @Override

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/vpj/VenicePushJobConstants.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/vpj/VenicePushJobConstants.java
@@ -355,4 +355,9 @@ public final class VenicePushJobConstants {
    * The class must extend {@link DataWriterComputeJob} and have a zero-arg constructor.
    */
   public static final String DATA_WRITER_COMPUTE_JOB_CLASS = "data.writer.compute.job.class";
+
+  /**
+   *
+   */
+  public static final String DATA_WRITER_PROXY_COMPUTE_JOB_CLASS = "data.writer.proxy.compute.job.class";
 }

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestBatch.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestBatch.java
@@ -37,6 +37,7 @@ import static com.linkedin.venice.utils.TestWriteUtils.writeSimpleAvroFileWithSt
 import static com.linkedin.venice.vpj.VenicePushJobConstants.ALLOW_DUPLICATE_KEY;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.COMPRESSION_METRIC_COLLECTION_ENABLED;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.DATA_WRITER_COMPUTE_JOB_CLASS;
+import static com.linkedin.venice.vpj.VenicePushJobConstants.DATA_WRITER_PROXY_COMPUTE_JOB_CLASS;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.DEFAULT_KEY_FIELD_PROP;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.DEFAULT_VALUE_FIELD_PROP;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.INCREMENTAL_PUSH;
@@ -66,6 +67,7 @@ import com.linkedin.venice.exceptions.VeniceException;
 import com.linkedin.venice.integration.utils.VeniceClusterWrapper;
 import com.linkedin.venice.meta.BackupStrategy;
 import com.linkedin.venice.meta.Version;
+import com.linkedin.venice.proxyjob.datawriter.jobs.ForkedProcessProxyJob;
 import com.linkedin.venice.read.RequestType;
 import com.linkedin.venice.spark.datawriter.jobs.DataWriterSparkJob;
 import com.linkedin.venice.stats.AbstractVeniceStats;
@@ -895,7 +897,8 @@ public abstract class TestBatch {
 
     String inputDirPath = "file://" + inputDir.getAbsolutePath();
     Properties props = defaultVPJProps(veniceCluster, inputDirPath, storeName);
-    props.setProperty(DATA_WRITER_COMPUTE_JOB_CLASS, DataWriterSparkJob.class.getCanonicalName());
+    props.setProperty(DATA_WRITER_COMPUTE_JOB_CLASS, ForkedProcessProxyJob.class.getCanonicalName());
+    props.setProperty(DATA_WRITER_PROXY_COMPUTE_JOB_CLASS, DataWriterSparkJob.class.getCanonicalName());
     props.setProperty(SPARK_NATIVE_INPUT_FORMAT_ENABLED, String.valueOf(true));
     extraProps.accept(props);
 


### PR DESCRIPTION
<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## Add a way to run DataWriter jobs in an isolated environment
<!--
Describe
- What changes to make and why you are making these changes.
- How are you going to achieve your goal.
- Describe what testings you have done, for example, performance testing etc.

If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->
Currently, VPJ is written in a way where it launches the compute tasks from it's local environment. If an environment only allows running Spark jobs via `spark-submit`, the entire VPJ logic needs to run on the Spark driver, making the driver non-idempotent.

With this change, we can separate the VPJ driver logic from Spark compute environment, and launch only the compute tasks on Spark. The driver on Spark is a very thin wrapper that only parses CLI args and launches the compute jobs. This makes the Spark compute job idempotent as well, and can improve the resiliency.

Another benefit of this change is that this improves the debugging experience as the logs can now be viewed in the environment where the user's job was triggered, and they don't have to check the logs on the Spark driver.

## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
Tested manually, and in integration tests. More testing is in progress.

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [X] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.