### PR TITLE
[controller] Set Helix instance tags automatically only when registering new participants

### DIFF
--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/HelixAdminClient.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/HelixAdminClient.java
@@ -123,9 +123,4 @@ public interface HelixAdminClient {
    * Release resources.
    */
   void close();
-
-  /**
-   * Adds a tag to an instance
-   */
-  void addInstanceTag(String clusterName, String instanceName, String tag);
 }

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceHelixAdmin.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceHelixAdmin.java
@@ -257,7 +257,6 @@ import org.apache.helix.AccessOption;
 import org.apache.helix.HelixAdmin;
 import org.apache.helix.HelixException;
 import org.apache.helix.HelixManagerProperty;
-import org.apache.helix.HelixPropertyFactory;
 import org.apache.helix.InstanceType;
 import org.apache.helix.PropertyKey;
 import org.apache.helix.controller.rebalancer.DelayedAutoRebalancer;
@@ -271,6 +270,7 @@ import org.apache.helix.model.ClusterConfig;
 import org.apache.helix.model.ExternalView;
 import org.apache.helix.model.HelixConfigScope;
 import org.apache.helix.model.IdealState;
+import org.apache.helix.model.InstanceConfig;
 import org.apache.helix.model.LeaderStandbySMD;
 import org.apache.helix.model.LiveInstance;
 import org.apache.helix.model.MaintenanceSignal;
@@ -784,8 +784,18 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
     InstanceType instanceType =
         isControllerClusterHAAS ? InstanceType.PARTICIPANT : InstanceType.CONTROLLER_PARTICIPANT;
     String zkAddress = multiClusterConfigs.getControllerClusterZkAddress();
+
+    InstanceConfig.Builder defaultInstanceConfigBuilder =
+        new InstanceConfig.Builder().setPort(Integer.toString(multiClusterConfigs.getAdminPort()));
+
+    List<String> instanceTagList = multiClusterConfigs.getControllerInstanceTagList();
+    for (String instanceTag: instanceTagList) {
+      defaultInstanceConfigBuilder.addTag(instanceTag);
+    }
+
     HelixManagerProperty helixManagerProperty =
-        HelixPropertyFactory.getInstance().getHelixManagerProperty(zkAddress, controllerClusterName);
+        new HelixManagerProperty.Builder().setDefaultInstanceConfigBuilder(defaultInstanceConfigBuilder).build();
+
     SafeHelixManager tempManager = new SafeHelixManager(
         new ZKHelixManager(controllerClusterName, controllerName, instanceType, zkAddress, null, helixManagerProperty));
     StateMachineEngine stateMachine = tempManager.getStateMachineEngine();
@@ -800,13 +810,7 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
     }
     controllerClusterKeyBuilder = new PropertyKey.Builder(tempManager.getClusterName());
     helixManager = tempManager;
-
-    List<String> instanceTagList = multiClusterConfigs.getControllerInstanceTagList();
-    for (String instanceTag: instanceTagList) {
-      helixAdminClient.addInstanceTag(controllerClusterName, helixManager.getInstanceName(), instanceTag);
-    }
     LOGGER.info("Connected to controller cluster {} with controller {}", controllerClusterName, controllerName);
-
   }
 
   public ZkClient getZkClient() {

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/ZkHelixAdminClient.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/ZkHelixAdminClient.java
@@ -319,14 +319,6 @@ public class ZkHelixAdminClient implements HelixAdminClient {
     helixAdmin.close();
   }
 
-  /**
-   * @see HelixAdminClient#addInstanceTag(String, String, String)()
-   */
-  @Override
-  public void addInstanceTag(String clusterName, String instanceName, String tag) {
-    helixAdmin.addInstanceTag(clusterName, instanceName, tag);
-  }
-
   public void setCloudConfig(String clusterName, VeniceControllerClusterConfig config) {
     String cloudId = config.getHelixCloudId();
     List<String> cloudInfoSources = config.getHelixCloudInfoSources();


### PR DESCRIPTION
<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## Set Helix instance tags automatically only when registering new participants
<!--
Describe
- What changes to make and why you are making these changes.
- How are you going to achieve your goal.
- Describe what testings you have done, for example, performance testing etc.

If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->
Helix's doesn't have an API for setting `InstanceTags` for instances atomically. They can only be added and removed one-by-one. Also, each tag modification could lead to rebalances of resources.

There are a couple of other issues with our current implementation:
1. Currently, we only add instance tags, but didn't purge ones that are no longer valid
2. We register a participant in Helix first, and then add the tags one by one. This will lead to multiple rounds of rebalances

This PR sets the tags in the instance config at the time new instances are being registered. We can edit the tags for existing instances operationally as a one-time effort.

## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
GH CI

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [X] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.