### PR TITLE
[controller] Enable configuring a customized health check URL for storage clusters

### DIFF
--- a/internal/venice-common/src/main/java/com/linkedin/venice/ConfigKeys.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/ConfigKeys.java
@@ -351,6 +351,12 @@ public class ConfigKeys {
   public static final String CONTROLLER_HELIX_CLOUD_INFO_PROCESSOR_NAME = "controller.helix.cloud.info.processor.name";
 
   /**
+   * Base URL for customized health checks triggered by Helix. Default is empty string.
+   */
+  public static final String CONTROLLER_HELIX_REST_CUSTOMIZED_HEALTH_URL =
+      "controller.helix.rest.customized.health.url";
+
+  /**
    * Whether to enable graveyard cleanup for batch-only store at cluster level. Default is false.
    */
   public static final String CONTROLLER_STORE_GRAVEYARD_CLEANUP_ENABLED = "controller.store.graveyard.cleanup.enabled";

--- a/internal/venice-common/src/main/java/com/linkedin/venice/controllerapi/AggregatedHealthStatusRequest.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/controllerapi/AggregatedHealthStatusRequest.java
@@ -1,5 +1,9 @@
 package com.linkedin.venice.controllerapi;
 
+import static com.linkedin.venice.controllerapi.ControllerApiConstants.CLUSTER_ID;
+import static com.linkedin.venice.controllerapi.ControllerApiConstants.INSTANCES;
+import static com.linkedin.venice.controllerapi.ControllerApiConstants.TO_BE_STOPPED_INSTANCES;
+
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.Collections;
@@ -13,16 +17,16 @@ public class AggregatedHealthStatusRequest {
 
   @JsonCreator
   public AggregatedHealthStatusRequest(
-      @JsonProperty("cluster_id") String cluster_id,
-      @JsonProperty("instances") List<String> instances,
-      @JsonProperty("to_be_stopped_instances") List<String> to_be_stopped_instances) {
+      @JsonProperty(CLUSTER_ID) String cluster_id,
+      @JsonProperty(INSTANCES) List<String> instances,
+      @JsonProperty(TO_BE_STOPPED_INSTANCES) List<String> to_be_stopped_instances) {
     if (cluster_id == null) {
-      throw new IllegalArgumentException("'cluster_id' is required");
+      throw new IllegalArgumentException("'" + CLUSTER_ID + "' is required");
     }
     this.cluster_id = cluster_id;
 
     if (instances == null) {
-      throw new IllegalArgumentException("'instances' is required");
+      throw new IllegalArgumentException("'" + INSTANCES + "' is required");
     }
     this.instances = instances;
 
@@ -33,17 +37,17 @@ public class AggregatedHealthStatusRequest {
     }
   }
 
-  @JsonProperty("cluster_id")
+  @JsonProperty(CLUSTER_ID)
   public String getClusterId() {
     return cluster_id;
   }
 
-  @JsonProperty("instances")
+  @JsonProperty(INSTANCES)
   public List<String> getInstances() {
     return instances;
   }
 
-  @JsonProperty("to_be_stopped_instances")
+  @JsonProperty(TO_BE_STOPPED_INSTANCES)
   public List<String> getToBeStoppedInstances() {
     return to_be_stopped_instances;
   }

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/controller/TestHAASController.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/controller/TestHAASController.java
@@ -272,7 +272,7 @@ public class TestHAASController {
       client.addClusterToGrandCluster("venice-controllers");
       for (int i = 0; i < 10; i++) {
         String clusterName = "cluster-" + i;
-        client.createVeniceStorageCluster(clusterName, new ClusterConfig(clusterName));
+        client.createVeniceStorageCluster(clusterName, new ClusterConfig(clusterName), null);
         client.addClusterToGrandCluster(clusterName);
         client.addVeniceStorageClusterToControllerCluster(clusterName);
       }

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/HelixAdminClient.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/HelixAdminClient.java
@@ -3,6 +3,7 @@ package com.linkedin.venice.controller;
 import java.util.List;
 import java.util.Map;
 import org.apache.helix.model.ClusterConfig;
+import org.apache.helix.model.RESTConfig;
 
 
 /**
@@ -31,8 +32,9 @@ public interface HelixAdminClient {
    * Create and configure the Venice storage cluster.
    * @param clusterName of the Venice storage cluster.
    * @param clusterConfig {@link ClusterConfig} for the new cluster.
+   * @param restConfig {@link RESTConfig} for the new cluster.
    */
-  void createVeniceStorageCluster(String clusterName, ClusterConfig clusterConfig);
+  void createVeniceStorageCluster(String clusterName, ClusterConfig clusterConfig, RESTConfig restConfig);
 
   /**
    * Check if the given Venice storage cluster's cluster resource is in the Venice controller cluster.
@@ -66,6 +68,13 @@ public interface HelixAdminClient {
    * @param clusterConfig {@link ClusterConfig} for the new cluster.
    */
   void updateClusterConfigs(String clusterName, ClusterConfig clusterConfig);
+
+  /**
+   * Update some Helix cluster properties for the given cluster.
+   * @param clusterName of the cluster to be updated.
+   * @param restConfig {@link RESTConfig} for the new cluster.
+   */
+  void updateRESTConfigs(String clusterName, RESTConfig restConfig);
 
   /**
    * Disable or enable a list of partitions on an instance.

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceControllerClusterConfig.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceControllerClusterConfig.java
@@ -52,6 +52,7 @@ import static com.linkedin.venice.ConfigKeys.CONTROLLER_HELIX_CLOUD_ID;
 import static com.linkedin.venice.ConfigKeys.CONTROLLER_HELIX_CLOUD_INFO_PROCESSOR_NAME;
 import static com.linkedin.venice.ConfigKeys.CONTROLLER_HELIX_CLOUD_INFO_SOURCES;
 import static com.linkedin.venice.ConfigKeys.CONTROLLER_HELIX_CLOUD_PROVIDER;
+import static com.linkedin.venice.ConfigKeys.CONTROLLER_HELIX_REST_CUSTOMIZED_HEALTH_URL;
 import static com.linkedin.venice.ConfigKeys.CONTROLLER_INSTANCE_TAG_LIST;
 import static com.linkedin.venice.ConfigKeys.CONTROLLER_JETTY_CONFIG_OVERRIDE_PREFIX;
 import static com.linkedin.venice.ConfigKeys.CONTROLLER_MIN_SCHEMA_COUNT_TO_KEEP;
@@ -367,6 +368,8 @@ public class VeniceControllerClusterConfig {
   private final boolean controllerClusterHelixCloudEnabled;
   private final boolean storageClusterHelixCloudEnabled;
   private final CloudConfig helixCloudConfig;
+
+  private final String helixRestCustomizedHealthUrl;
 
   private final boolean usePushStatusStoreForIncrementalPushStatusReads;
 
@@ -929,6 +932,8 @@ public class VeniceControllerClusterConfig {
     } else {
       helixCloudConfig = null;
     }
+
+    this.helixRestCustomizedHealthUrl = props.getString(CONTROLLER_HELIX_REST_CUSTOMIZED_HEALTH_URL, "");
 
     this.unregisterMetricForDeletedStoreEnabled = props.getBoolean(UNREGISTER_METRIC_FOR_DELETED_STORE_ENABLED, false);
     this.identityParserClassName = props.getString(IDENTITY_PARSER_CLASS, DefaultIdentityParser.class.getName());
@@ -1578,6 +1583,10 @@ public class VeniceControllerClusterConfig {
 
   public CloudConfig getHelixCloudConfig() {
     return helixCloudConfig;
+  }
+
+  public String getHelixRestCustomizedHealthUrl() {
+    return helixRestCustomizedHealthUrl;
   }
 
   public boolean usePushStatusStoreForIncrementalPush() {

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceHelixAdmin.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceHelixAdmin.java
@@ -274,6 +274,7 @@ import org.apache.helix.model.InstanceConfig;
 import org.apache.helix.model.LeaderStandbySMD;
 import org.apache.helix.model.LiveInstance;
 import org.apache.helix.model.MaintenanceSignal;
+import org.apache.helix.model.RESTConfig;
 import org.apache.helix.model.builder.HelixConfigScopeBuilder;
 import org.apache.helix.participant.StateMachineEngine;
 import org.apache.helix.zookeeper.datamodel.ZNRecord;
@@ -6298,7 +6299,13 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
       helixClusterConfig.setTopology("/" + HelixUtils.TOPOLOGY_CONSTRAINT);
       helixClusterConfig.setFaultZoneType(HelixUtils.TOPOLOGY_CONSTRAINT);
 
-      helixAdminClient.createVeniceStorageCluster(clusterName, helixClusterConfig);
+      RESTConfig restConfig = null;
+      if (!StringUtils.isEmpty(clusterConfigs.getHelixRestCustomizedHealthUrl())) {
+        restConfig = new RESTConfig(clusterName);
+        restConfig.set(RESTConfig.SimpleFields.CUSTOMIZED_HEALTH_URL, clusterConfigs.getHelixRestCustomizedHealthUrl());
+      }
+
+      helixAdminClient.createVeniceStorageCluster(clusterName, helixClusterConfig, restConfig);
     }
     if (!helixAdminClient.isClusterInGrandCluster(clusterName)) {
       helixAdminClient.addClusterToGrandCluster(clusterName);

--- a/services/venice-controller/src/test/java/com/linkedin/venice/controller/TestVeniceControllerClusterConfig.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/controller/TestVeniceControllerClusterConfig.java
@@ -14,6 +14,7 @@ import static com.linkedin.venice.ConfigKeys.CONTROLLER_HELIX_CLOUD_ID;
 import static com.linkedin.venice.ConfigKeys.CONTROLLER_HELIX_CLOUD_INFO_PROCESSOR_NAME;
 import static com.linkedin.venice.ConfigKeys.CONTROLLER_HELIX_CLOUD_INFO_SOURCES;
 import static com.linkedin.venice.ConfigKeys.CONTROLLER_HELIX_CLOUD_PROVIDER;
+import static com.linkedin.venice.ConfigKeys.CONTROLLER_HELIX_REST_CUSTOMIZED_HEALTH_URL;
 import static com.linkedin.venice.ConfigKeys.CONTROLLER_PARENT_MODE;
 import static com.linkedin.venice.ConfigKeys.CONTROLLER_SSL_ENABLED;
 import static com.linkedin.venice.ConfigKeys.CONTROLLER_STORAGE_CLUSTER_HELIX_CLOUD_ENABLED;
@@ -282,5 +283,16 @@ public class TestVeniceControllerClusterConfig {
     assertEquals(cloudConfig.getCloudID(), cloudId);
     assertEquals(cloudConfig.getCloudInfoProcessorName(), processorName);
     assertEquals(cloudConfig.getCloudInfoSources(), cloudInfoSources);
+  }
+
+  @Test
+  public void testHelixRestCustomizedHealthUrl() {
+    Properties baseProps = getBaseSingleRegionProperties(false);
+
+    String healthUrl = "http://localhost:8080/health";
+    baseProps.setProperty(CONTROLLER_HELIX_REST_CUSTOMIZED_HEALTH_URL, healthUrl);
+
+    VeniceControllerClusterConfig clusterConfig = new VeniceControllerClusterConfig(new VeniceProperties(baseProps));
+    assertEquals(clusterConfig.getHelixRestCustomizedHealthUrl(), healthUrl);
   }
 }


### PR DESCRIPTION
<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## Enable configuring a customized health check URL for storage clusters
<!--
Describe
- What changes to make and why you are making these changes.
- How are you going to achieve your goal.
- Describe what testings you have done, for example, performance testing etc.

If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

Helix has added a new functionality that allows configuring a customized health check endpoint that Helix will invoke to decide on the health of the cluster. This URL can be configured by setting the controller config `controller.helix.rest.customized.health.url`.

## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
Added unit tests. GH CI for regression testing

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [X] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.