### PR TITLE
[controller] Make to_be_stopped_instances in aggregatedHealthStatus API optional

### DIFF
--- a/internal/venice-common/src/main/java/com/linkedin/venice/controllerapi/AggregatedHealthStatusRequest.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/controllerapi/AggregatedHealthStatusRequest.java
@@ -16,8 +16,16 @@ public class AggregatedHealthStatusRequest {
       @JsonProperty("cluster_id") String cluster_id,
       @JsonProperty("instances") List<String> instances,
       @JsonProperty("to_be_stopped_instances") List<String> to_be_stopped_instances) {
+    if (cluster_id == null) {
+      throw new IllegalArgumentException("'cluster_id' is required");
+    }
     this.cluster_id = cluster_id;
+
+    if (instances == null) {
+      throw new IllegalArgumentException("'instances' is required");
+    }
     this.instances = instances;
+
     if (to_be_stopped_instances == null) {
       this.to_be_stopped_instances = Collections.emptyList();
     } else {

--- a/internal/venice-common/src/main/java/com/linkedin/venice/controllerapi/AggregatedHealthStatusRequest.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/controllerapi/AggregatedHealthStatusRequest.java
@@ -2,27 +2,27 @@ package com.linkedin.venice.controllerapi;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.Collections;
 import java.util.List;
 
 
 public class AggregatedHealthStatusRequest {
-  List<String> instances;
-  List<String> to_be_stopped_instances;
-  String cluster_id;
+  private final String cluster_id;
+  private final List<String> instances;
+  private final List<String> to_be_stopped_instances;
 
   @JsonCreator
   public AggregatedHealthStatusRequest(
+      @JsonProperty("cluster_id") String cluster_id,
       @JsonProperty("instances") List<String> instances,
-      @JsonProperty("to_be_stopped_instances") List<String> to_be_stopped_instances,
-      @JsonProperty("cluster_id") String cluster_id) {
+      @JsonProperty("to_be_stopped_instances") List<String> to_be_stopped_instances) {
+    this.cluster_id = cluster_id;
     this.instances = instances;
-    this.to_be_stopped_instances = to_be_stopped_instances;
-    this.cluster_id = cluster_id;
-  }
-
-  @JsonProperty("cluster_id")
-  public void setClusterId(String cluster_id) {
-    this.cluster_id = cluster_id;
+    if (to_be_stopped_instances == null) {
+      this.to_be_stopped_instances = Collections.emptyList();
+    } else {
+      this.to_be_stopped_instances = to_be_stopped_instances;
+    }
   }
 
   @JsonProperty("cluster_id")
@@ -35,18 +35,8 @@ public class AggregatedHealthStatusRequest {
     return instances;
   }
 
-  @JsonProperty("instances")
-  public void setInstances(List<String> instances) {
-    this.instances = instances;
-  }
-
   @JsonProperty("to_be_stopped_instances")
   public List<String> getToBeStoppedInstances() {
     return to_be_stopped_instances;
-  }
-
-  @JsonProperty("to_be_stopped_instances")
-  public void setToBeStoppedInstances(List<String> to_be_stopped_instances) {
-    this.to_be_stopped_instances = to_be_stopped_instances;
   }
 }

--- a/internal/venice-common/src/main/java/com/linkedin/venice/controllerapi/ControllerApiConstants.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/controllerapi/ControllerApiConstants.java
@@ -244,6 +244,4 @@ public class ControllerApiConstants {
 
   public static final String NEARLINE_PRODUCER_COMPRESSION_ENABLED = "nearline_producer_compression_enabled";
   public static final String NEARLINE_PRODUCER_COUNT_PER_WRITER = "nearline_producer_count_per_writer";
-
-  public static final String AGGR_HEALTH_STATUS_URI = "/aggregatedHealthStatus";
 }

--- a/internal/venice-common/src/main/java/com/linkedin/venice/controllerapi/ControllerClient.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/controllerapi/ControllerClient.java
@@ -923,7 +923,7 @@ public class ControllerClient implements Closeable {
       List<String> toBeStoppedInstances) throws JsonProcessingException {
 
     AggregatedHealthStatusRequest request =
-        new AggregatedHealthStatusRequest(instances, toBeStoppedInstances, clusterName);
+        new AggregatedHealthStatusRequest(clusterName, instances, toBeStoppedInstances);
     String requestString = OBJECT_MAPPER.writeValueAsString(request);
     return request(
         ControllerRoute.AGGREGATED_HEALTH_STATUS,

--- a/internal/venice-common/src/test/java/com/linkedin/venice/controllerapi/TestAggregatedHealthStatusRequest.java
+++ b/internal/venice-common/src/test/java/com/linkedin/venice/controllerapi/TestAggregatedHealthStatusRequest.java
@@ -1,0 +1,60 @@
+package com.linkedin.venice.controllerapi;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.exc.ValueInstantiationException;
+import com.linkedin.venice.utils.ObjectMapperFactory;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+
+public class TestAggregatedHealthStatusRequest {
+  private static final ObjectMapper OBJECT_MAPPER = ObjectMapperFactory.getInstance();
+
+  @Test
+  public void testDeserializationWithAllFields() throws JsonProcessingException {
+    String json =
+        "{\"cluster_id\":\"cluster1\",\"instances\":[\"instance1\",\"instance2\"],\"to_be_stopped_instances\":[\"instance3\",\"instance4\"]}";
+    AggregatedHealthStatusRequest request = OBJECT_MAPPER.readValue(json, AggregatedHealthStatusRequest.class);
+
+    assertEquals(request.getClusterId(), "cluster1");
+    assertEquals(request.getInstances().size(), 2);
+    assertEquals(request.getInstances().get(0), "instance1");
+    assertEquals(request.getInstances().get(1), "instance2");
+    assertEquals(request.getToBeStoppedInstances().size(), 2);
+    assertEquals(request.getToBeStoppedInstances().get(0), "instance3");
+    assertEquals(request.getToBeStoppedInstances().get(1), "instance4");
+  }
+
+  @Test
+  public void testDeserializationWithMandatoryFields() throws JsonProcessingException {
+    String json = "{\"cluster_id\":\"cluster1\",\"instances\":[\"instance1\",\"instance2\"]}";
+    AggregatedHealthStatusRequest request = OBJECT_MAPPER.readValue(json, AggregatedHealthStatusRequest.class);
+
+    assertEquals(request.getClusterId(), "cluster1");
+    assertEquals(request.getInstances().size(), 2);
+    assertEquals(request.getInstances().get(0), "instance1");
+    assertEquals(request.getInstances().get(1), "instance2");
+    assertNotNull(request.getToBeStoppedInstances());
+    assertTrue(request.getToBeStoppedInstances().isEmpty());
+  }
+
+  @Test
+  public void testDeserializationWithMissingMandatoryFields() {
+    String json = "{\"instances\":[\"instance1\",\"instance2\"]}";
+    ValueInstantiationException e = Assert.expectThrows(
+        ValueInstantiationException.class,
+        () -> OBJECT_MAPPER.readValue(json, AggregatedHealthStatusRequest.class));
+    assertTrue(e.getMessage().contains("'cluster_id' is required"), e.getMessage());
+
+    String json2 = "{\"cluster_id\":\"cluster1\"}";
+    ValueInstantiationException e2 = Assert.expectThrows(
+        ValueInstantiationException.class,
+        () -> OBJECT_MAPPER.readValue(json2, AggregatedHealthStatusRequest.class));
+    assertTrue(e2.getMessage().contains("'instances' is required"), e2.getMessage());
+  }
+}

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/server/ControllerRoutes.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/server/ControllerRoutes.java
@@ -1,11 +1,11 @@
 package com.linkedin.venice.controller.server;
 
-import static com.linkedin.venice.controllerapi.ControllerApiConstants.AGGR_HEALTH_STATUS_URI;
 import static com.linkedin.venice.controllerapi.ControllerApiConstants.CLUSTER;
 import static com.linkedin.venice.controllerapi.ControllerApiConstants.KAFKA_TOPIC_LOG_COMPACTION_ENABLED;
 import static com.linkedin.venice.controllerapi.ControllerApiConstants.KAFKA_TOPIC_MIN_IN_SYNC_REPLICA;
 import static com.linkedin.venice.controllerapi.ControllerApiConstants.KAFKA_TOPIC_RETENTION_IN_MS;
 import static com.linkedin.venice.controllerapi.ControllerApiConstants.TOPIC;
+import static com.linkedin.venice.controllerapi.ControllerRoute.AGGREGATED_HEALTH_STATUS;
 import static com.linkedin.venice.controllerapi.ControllerRoute.LEADER_CONTROLLER;
 import static com.linkedin.venice.controllerapi.ControllerRoute.LIST_CHILD_CLUSTERS;
 import static com.linkedin.venice.controllerapi.ControllerRoute.UPDATE_KAFKA_TOPIC_LOG_COMPACTION;
@@ -211,7 +211,9 @@ public class ControllerRoutes extends AbstractRoute {
         InstanceRemovableStatuses statuses =
             admin.getAggregatedHealthStatus(cluster, instanceList, toBeStoppedInstanceList, isSslEnabled());
         if (statuses.getRedirectUrl() != null) {
-          response.redirect(statuses.getRedirectUrl() + AGGR_HEALTH_STATUS_URI, HttpStatus.SC_MOVED_TEMPORARILY);
+          response.redirect(
+              statuses.getRedirectUrl() + AGGREGATED_HEALTH_STATUS.getPath(),
+              HttpStatus.SC_MOVED_TEMPORARILY);
           return null;
         } else {
           responseObject.setNonStoppableInstancesWithReason(statuses.getNonStoppableInstancesWithReasons());


### PR DESCRIPTION
<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## Make to_be_stopped_instances in aggregatedHealthStatus API optional
<!--
Describe
- What changes to make and why you are making these changes.
- How are you going to achieve your goal.
- Describe what testings you have done, for example, performance testing etc.

If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->
In Helix's aggregated stoppable check, the `to_be_stopped_instances` is optional and will be omitted in case there are no instances that have previously been approved. This commit makes our controller handle this.

## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
Added unit test and integration tests. GHCI

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [X] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.