### PR TITLE
[server] System store current version should also place latch when becoming from offline to standby

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/helix/LeaderFollowerPartitionStateModel.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/helix/LeaderFollowerPartitionStateModel.java
@@ -5,7 +5,6 @@ import com.linkedin.davinci.ingestion.IngestionBackend;
 import com.linkedin.davinci.kafka.consumer.LeaderFollowerStoreIngestionTask;
 import com.linkedin.davinci.stats.ParticipantStateTransitionStats;
 import com.linkedin.davinci.stats.ingestion.heartbeat.HeartbeatMonitoringService;
-import com.linkedin.venice.common.VeniceSystemStoreUtils;
 import com.linkedin.venice.exceptions.VeniceException;
 import com.linkedin.venice.exceptions.VeniceNoStoreException;
 import com.linkedin.venice.helix.HelixPartitionStatusAccessor;
@@ -94,8 +93,7 @@ public class LeaderFollowerPartitionStateModel extends AbstractPartitionStateMod
       String storeName = Version.parseStoreFromKafkaTopicName(resourceName);
       int version = Version.parseVersionFromKafkaTopicName(resourceName);
       Store store = getStoreRepo().getStoreOrThrow(storeName);
-      boolean isRegularStoreCurrentVersion =
-          store.getCurrentVersion() == version && !VeniceSystemStoreUtils.isSystemStore(storeName);
+      boolean isRegularStoreCurrentVersion = store.getCurrentVersion() == version;
 
       /**
        * For regular store current version, firstly create a latch, then start ingestion and wait for ingestion

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/helix/VeniceLeaderFollowerStateModelTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/helix/VeniceLeaderFollowerStateModelTest.java
@@ -62,6 +62,23 @@ public class VeniceLeaderFollowerStateModelTest extends
         Store.BOOTSTRAP_TO_ONLINE_TIMEOUT_IN_HOURS,
         mockStoreIngestionService);
 
+    when(mockSystemStore.getCurrentVersion()).thenReturn(2);
+    testStateModel.onBecomeStandbyFromOffline(mockSystemStoreMessage, mockContext);
+    verify(mockNotifier, never()).waitConsumptionCompleted(
+        mockSystemStoreMessage.getResourceName(),
+        testPartition,
+        Store.BOOTSTRAP_TO_ONLINE_TIMEOUT_IN_HOURS,
+        mockStoreIngestionService);
+
+    // When serving current version system store, it should have latch in place.
+    when(mockSystemStore.getCurrentVersion()).thenReturn(1);
+    testStateModel.onBecomeStandbyFromOffline(mockSystemStoreMessage, mockContext);
+    verify(mockNotifier, times(1)).waitConsumptionCompleted(
+        mockSystemStoreMessage.getResourceName(),
+        testPartition,
+        Store.BOOTSTRAP_TO_ONLINE_TIMEOUT_IN_HOURS,
+        mockStoreIngestionService);
+
     when(mockStore.getCurrentVersion()).thenReturn(1);
     testStateModel.onBecomeStandbyFromOffline(mockMessage, mockContext);
     verify(mockNotifier).startConsumption(mockMessage.getResourceName(), testPartition);


### PR DESCRIPTION
## [server] System store current version should also place latch when becoming from offline to standby
If not, system store can be come standby/leader prematurely for current version and serve stale data.

## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
Add unit test
## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.