### PR TITLE
[server] Fix stats handling handling for early exiting requests in servers

### DIFF
--- a/services/venice-server/src/test/java/com/linkedin/venice/listener/OutboundHttpWrapperHandlerTest.java
+++ b/services/venice-server/src/test/java/com/linkedin/venice/listener/OutboundHttpWrapperHandlerTest.java
@@ -150,19 +150,18 @@ public class OutboundHttpWrapperHandlerTest {
 
   @Test
   public void testWriteDefaultFullHttpResponse() {
-    FullHttpResponse msg = new DefaultFullHttpResponse(HTTP_1_1, HttpResponseStatus.OK);
+    FullHttpResponse msg = new DefaultFullHttpResponse(HTTP_1_1, HttpResponseStatus.NOT_FOUND);
     StatsHandler statsHandler = mock(StatsHandler.class);
     ChannelHandlerContext mockCtx = mock(ChannelHandlerContext.class);
-
-    FullHttpResponse response = new DefaultFullHttpResponse(HTTP_1_1, HttpResponseStatus.OK);
 
     OutboundHttpWrapperHandler outboundHttpWrapperHandler = new OutboundHttpWrapperHandler(statsHandler);
 
     when(mockCtx.writeAndFlush(any())).then(i -> {
       FullHttpResponse actualResponse = (DefaultFullHttpResponse) i.getArguments()[0];
-      Assert.assertEquals(actualResponse.content(), response.content());
-      Assert.assertTrue(actualResponse.headers().equals(response.headers()));
-      Assert.assertTrue(actualResponse.equals(response));
+      Assert.assertEquals(actualResponse.content(), msg.content());
+      Assert.assertEquals(actualResponse.headers(), msg.headers());
+      Assert.assertEquals(actualResponse, msg);
+      verify(statsHandler).setResponseStatus(HttpResponseStatus.NOT_FOUND);
       return null;
     });
 


### PR DESCRIPTION
<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## Fix stats handling handling for early exiting requests in servers
<!--
Describe
- What changes to make and why you are making these changes.
- How are you going to achieve your goal.
- Describe what testings you have done, for example, performance testing etc.

If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->
In servers, when handling stats, we refer to a cached value of status code. However, in case of early exiting responses like `FORBIDDEN`, `UNAUTHORIZED`, etc. we missed updating the cached value, and that triggered incorrect code execution leading to excessive logging.

## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
Added unit tests

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [X] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.