### PR TITLE
[thin-client] Added a retry executor to avoid deadlock issues

### DIFF
--- a/clients/venice-thin-client/src/main/java/com/linkedin/venice/client/store/AbstractAvroStoreClient.java
+++ b/clients/venice-thin-client/src/main/java/com/linkedin/venice/client/store/AbstractAvroStoreClient.java
@@ -100,7 +100,7 @@ public abstract class AbstractAvroStoreClient<K, V> extends InternalAvroStoreCli
    * Also, we don't want to use the default thread pool: CompletableFuture#useCommonPool since it is being shared,
    * and the deserialization could be blocked by the logic not belonging to Venice Client.
    **/
-  private static Executor DESERIALIZATION_EXECUTOR;
+  static Executor DESERIALIZATION_EXECUTOR;
 
   private volatile boolean whetherStoreInitTriggeredByRequestFail = false;
 

--- a/clients/venice-thin-client/src/main/java/com/linkedin/venice/client/store/ClientConfig.java
+++ b/clients/venice-thin-client/src/main/java/com/linkedin/venice/client/store/ClientConfig.java
@@ -50,6 +50,7 @@ public class ClientConfig<T extends SpecificRecord> {
   private boolean retryOnAllErrors = false;
   private int retryCount = 1;
   private long retryBackOffInMs = 0;
+  private Executor retryExecutor = null;
   private boolean useBlackHoleDeserializer = false;
   private boolean forceClusterDiscoveryAtStartTime = false;
   private boolean projectionFieldValidation = true;
@@ -111,6 +112,7 @@ public class ClientConfig<T extends SpecificRecord> {
         .setRetryOnAllErrors(config.isRetryOnAllErrorsEnabled())
         .setRetryCount(config.getRetryCount())
         .setRetryBackOffInMs(config.getRetryBackOffInMs())
+        .setRetryExecutor(config.getRetryExecutor())
         .setUseBlackHoleDeserializer(config.isUseBlackHoleDeserializer())
         // Security settings
         .setHttps(config.isHttps())
@@ -415,6 +417,15 @@ public class ClientConfig<T extends SpecificRecord> {
 
   public long getRetryBackOffInMs() {
     return retryBackOffInMs;
+  }
+
+  public Executor getRetryExecutor() {
+    return retryExecutor;
+  }
+
+  public ClientConfig<T> setRetryExecutor(Executor retryExecutor) {
+    this.retryExecutor = retryExecutor;
+    return this;
   }
 
   public boolean isUseBlackHoleDeserializer() {

--- a/clients/venice-thin-client/src/main/java/com/linkedin/venice/client/store/RetriableStoreClient.java
+++ b/clients/venice-thin-client/src/main/java/com/linkedin/venice/client/store/RetriableStoreClient.java
@@ -3,11 +3,14 @@ package com.linkedin.venice.client.store;
 import com.linkedin.venice.client.exceptions.VeniceClientException;
 import com.linkedin.venice.client.exceptions.VeniceClientHttpException;
 import com.linkedin.venice.read.RequestType;
+import com.linkedin.venice.utils.DaemonThreadFactory;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Executor;
+import java.util.concurrent.Executors;
 import java.util.function.Supplier;
 import org.apache.commons.httpclient.HttpStatus;
 
@@ -16,17 +19,45 @@ import org.apache.commons.httpclient.HttpStatus;
  * TODO: make retry work for compute request.
  */
 public class RetriableStoreClient<K, V> extends DelegatingStoreClient<K, V> {
+  /**
+   * We need to execute the retry in a different thread pool than the one being used by the response callback.
+   * If we don't use another thread pool, the de-serialization thread pool will be used to initiate
+   * the retry request, which needs to submit the deserialization request for the retry response to the same thread
+   * pool, which can cause a deadlock issue.
+   * This issue is similar to the one around {@link AbstractAvroStoreClient#DESERIALIZATION_EXECUTOR}.
+   */
+  private static Executor RETRY_EXECUTOR;
+
   private final StatTrackingStoreClient statStoreclient;
   private final boolean retryOnAllErrors;
   private final long retryBackOffInMs;
   private final int retryCount;
+  private final Executor retryExecutor;
+
+  public static synchronized Executor getDefaultRetryExecutor() {
+    if (RETRY_EXECUTOR == null) {
+      // Half of process number of threads should be good enough, minimum 2
+      int threadNum = Math.max(Runtime.getRuntime().availableProcessors() / 2, 2);
+
+      RETRY_EXECUTOR = Executors.newFixedThreadPool(threadNum, new DaemonThreadFactory("Venice-Request-Retry"));
+    }
+
+    return RETRY_EXECUTOR;
+  }
 
   public RetriableStoreClient(StatTrackingStoreClient<K, V> innerStoreClient, ClientConfig clientConfig) {
     super(innerStoreClient);
     this.statStoreclient = innerStoreClient;
-    retryOnAllErrors = clientConfig.isRetryOnAllErrorsEnabled();
-    retryBackOffInMs = clientConfig.getRetryBackOffInMs();
-    retryCount = clientConfig.getRetryCount();
+    this.retryOnAllErrors = clientConfig.isRetryOnAllErrorsEnabled();
+    this.retryBackOffInMs = clientConfig.getRetryBackOffInMs();
+    this.retryCount = clientConfig.getRetryCount();
+    Executor configuredRetryExecutor = clientConfig.getRetryExecutor();
+    if (clientConfig.getDeserializationExecutor() != null && configuredRetryExecutor != null
+        && clientConfig.getDeserializationExecutor() == configuredRetryExecutor) {
+      throw new VeniceClientException(
+          "RetryExecutor needs to be different from DeserializationExecutor to avoid deadlock issues");
+    }
+    this.retryExecutor = configuredRetryExecutor != null ? configuredRetryExecutor : getDefaultRetryExecutor();
   }
 
   /**
@@ -60,7 +91,8 @@ public class RetriableStoreClient<K, V> extends DelegatingStoreClient<K, V> {
 
   private <T> CompletableFuture<T> executeWithRetry(Supplier<CompletableFuture<T>> supplier, RequestType requestType) {
     CompletableFuture<T> retryFuture = new CompletableFuture<>();
-    supplier.get().whenComplete((T val, Throwable throwable) -> {
+
+    supplier.get().whenCompleteAsync((T val, Throwable throwable) -> {
       if (throwable != null) {
         int attempt = 0;
         Throwable retryThrowable = throwable;
@@ -90,7 +122,7 @@ public class RetriableStoreClient<K, V> extends DelegatingStoreClient<K, V> {
       } else {
         retryFuture.complete(val);
       }
-    });
+    }, this.retryExecutor);
     return retryFuture;
   }
 


### PR DESCRIPTION


<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## Summary, imperative, start upper case, don't end with a period
We need to execute the retry in a different thread pool than the one being used by the response callback. If we don't use another thread pool, the de-serialization thread pool will be used to initiate the retry request, which needs to submit the deserialization request for the retry response
 to the same thread pool, which can cause a deadlock issue.
This issue is similar to the one around {@link AbstractAvroStoreClient#DESERIALIZATION_EXECUTOR}.
<!--
Describe
- What changes to make and why you are making these changes.
- How are you going to achieve your goal.
- Describe what testings you have done, for example, performance testing etc.

If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->


## How was this PR tested?
CI
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.