### PR TITLE
[controller] Refactor HelixAdminClient APIs to accept strongly typed Helix objects

### DIFF
--- a/internal/venice-common/src/main/java/com/linkedin/venice/utils/HelixUtils.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/utils/HelixUtils.java
@@ -12,6 +12,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
+import org.apache.commons.lang.StringUtils;
 import org.apache.helix.AccessOption;
 import org.apache.helix.HelixAdmin;
 import org.apache.helix.PropertyKey;
@@ -392,15 +393,15 @@ public class HelixUtils {
     CloudConfig.Builder cloudConfigBuilder =
         new CloudConfig.Builder().setCloudEnabled(true).setCloudProvider(cloudProvider);
 
-    if (!cloudId.isEmpty()) {
+    if (!StringUtils.isEmpty(cloudId)) {
       cloudConfigBuilder.setCloudID(cloudId);
     }
 
-    if (!cloudInfoSources.isEmpty()) {
+    if (cloudInfoSources != null && !cloudInfoSources.isEmpty()) {
       cloudConfigBuilder.setCloudInfoSources(cloudInfoSources);
     }
 
-    if (!cloudInfoProcessorName.isEmpty()) {
+    if (!StringUtils.isEmpty(cloudInfoProcessorName)) {
       cloudConfigBuilder.setCloudInfoProcessorName(cloudInfoProcessorName);
     }
 

--- a/internal/venice-common/src/main/java/com/linkedin/venice/utils/HelixUtils.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/utils/HelixUtils.java
@@ -15,8 +15,10 @@ import java.util.concurrent.TimeUnit;
 import org.apache.helix.AccessOption;
 import org.apache.helix.HelixAdmin;
 import org.apache.helix.PropertyKey;
+import org.apache.helix.cloud.constants.CloudProvider;
 import org.apache.helix.manager.zk.ZKHelixAdmin;
 import org.apache.helix.manager.zk.ZkBaseDataAccessor;
+import org.apache.helix.model.CloudConfig;
 import org.apache.helix.model.CustomizedStateConfig;
 import org.apache.helix.model.HelixConfigScope;
 import org.apache.helix.model.InstanceConfig;
@@ -380,5 +382,28 @@ public class HelixUtils {
    */
   public static String instanceIdToUrl(String instanceId) {
     return "https://" + instanceId.replace("_", ":");
+  }
+
+  public static CloudConfig getCloudConfig(
+      CloudProvider cloudProvider,
+      String cloudId,
+      List<String> cloudInfoSources,
+      String cloudInfoProcessorName) {
+    CloudConfig.Builder cloudConfigBuilder =
+        new CloudConfig.Builder().setCloudEnabled(true).setCloudProvider(cloudProvider);
+
+    if (!cloudId.isEmpty()) {
+      cloudConfigBuilder.setCloudID(cloudId);
+    }
+
+    if (!cloudInfoSources.isEmpty()) {
+      cloudConfigBuilder.setCloudInfoSources(cloudInfoSources);
+    }
+
+    if (!cloudInfoProcessorName.isEmpty()) {
+      cloudConfigBuilder.setCloudInfoProcessorName(cloudInfoProcessorName);
+    }
+
+    return cloudConfigBuilder.build();
   }
 }

--- a/internal/venice-common/src/test/java/com/linkedin/venice/utils/TestHelixUtils.java
+++ b/internal/venice-common/src/test/java/com/linkedin/venice/utils/TestHelixUtils.java
@@ -1,6 +1,16 @@
 package com.linkedin.venice.utils;
 
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertThrows;
+import static org.testng.Assert.assertTrue;
+
 import com.linkedin.venice.meta.Instance;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import org.apache.helix.HelixException;
+import org.apache.helix.cloud.constants.CloudProvider;
+import org.apache.helix.model.CloudConfig;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
@@ -15,5 +25,38 @@ public class TestHelixUtils {
     Instance instance2 = HelixUtils.getInstanceFromHelixInstanceName("host_name_5678");
     Assert.assertEquals(instance2.getHost(), "host_name");
     Assert.assertEquals(instance2.getPort(), 5678);
+  }
+
+  @Test
+  public void testGetCloudConfig() {
+    List<String> cloudInfoSources = new ArrayList<>();
+    cloudInfoSources.add("TestSource");
+
+    CloudConfig cloudConfig =
+        HelixUtils.getCloudConfig(CloudProvider.CUSTOMIZED, "NA", cloudInfoSources, "TestProcessor");
+
+    assertTrue(cloudConfig.isCloudEnabled());
+    assertEquals(cloudConfig.getCloudProvider(), "CUSTOMIZED");
+    assertEquals(cloudConfig.getCloudID(), "NA");
+    assertEquals(cloudConfig.getCloudInfoSources().size(), 1);
+    assertEquals(cloudConfig.getCloudInfoSources().get(0), "TestSource");
+    assertEquals(cloudConfig.getCloudInfoProcessorName(), "TestProcessor");
+  }
+
+  @Test
+  public void testGetCloudConfigWhenControllerCloudInfoSourcesNotSet() {
+    assertThrows(
+        HelixException.class,
+        () -> HelixUtils.getCloudConfig(CloudProvider.CUSTOMIZED, "NA", Collections.emptyList(), "TestProcessor"));
+  }
+
+  @Test
+  public void testGetCloudConfigWhenControllerCloudInfoProcessorNameNotSet() {
+    List<String> cloudInfoSources = new ArrayList<>();
+    cloudInfoSources.add("TestSource");
+
+    assertThrows(
+        HelixException.class,
+        () -> HelixUtils.getCloudConfig(CloudProvider.CUSTOMIZED, "NA", cloudInfoSources, ""));
   }
 }

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/HelixAdminClient.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/HelixAdminClient.java
@@ -2,6 +2,7 @@ package com.linkedin.venice.controller;
 
 import java.util.List;
 import java.util.Map;
+import org.apache.helix.model.ClusterConfig;
 
 
 /**
@@ -29,9 +30,9 @@ public interface HelixAdminClient {
   /**
    * Create and configure the Venice storage cluster.
    * @param clusterName of the Venice storage cluster.
-   * @param helixClusterProperties to be applied to the new cluster.
+   * @param clusterConfig {@link ClusterConfig} for the new cluster.
    */
-  void createVeniceStorageCluster(String clusterName, Map<String, String> helixClusterProperties);
+  void createVeniceStorageCluster(String clusterName, ClusterConfig clusterConfig);
 
   /**
    * Check if the given Venice storage cluster's cluster resource is in the Venice controller cluster.
@@ -62,9 +63,9 @@ public interface HelixAdminClient {
   /**
    * Update some Helix cluster properties for the given cluster.
    * @param clusterName of the cluster to be updated.
-   * @param helixClusterProperties to be applied to the given cluster.
+   * @param clusterConfig {@link ClusterConfig} for the new cluster.
    */
-  void updateClusterConfigs(String clusterName, Map<String, String> helixClusterProperties);
+  void updateClusterConfigs(String clusterName, ClusterConfig clusterConfig);
 
   /**
    * Disable or enable a list of partitions on an instance.

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceControllerClusterConfig.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceControllerClusterConfig.java
@@ -145,7 +145,6 @@ import static com.linkedin.venice.ConfigKeys.PUBSUB_TOPIC_MANAGER_METADATA_FETCH
 import static com.linkedin.venice.ConfigKeys.PUBSUB_TOPIC_MANAGER_METADATA_FETCHER_THREAD_POOL_SIZE;
 import static com.linkedin.venice.ConfigKeys.PUSH_JOB_FAILURE_CHECKPOINTS_TO_DEFINE_USER_ERROR;
 import static com.linkedin.venice.ConfigKeys.PUSH_JOB_STATUS_STORE_CLUSTER_NAME;
-import static com.linkedin.venice.ConfigKeys.PUSH_MONITOR_TYPE;
 import static com.linkedin.venice.ConfigKeys.PUSH_SSL_ALLOWLIST;
 import static com.linkedin.venice.ConfigKeys.PUSH_SSL_WHITELIST;
 import static com.linkedin.venice.ConfigKeys.PUSH_STATUS_STORE_ENABLED;
@@ -190,8 +189,8 @@ import com.linkedin.venice.meta.RoutingStrategy;
 import com.linkedin.venice.pubsub.PubSubAdminAdapterFactory;
 import com.linkedin.venice.pubsub.PubSubClientsFactory;
 import com.linkedin.venice.pushmonitor.LeakedPushStatusCleanUpService;
-import com.linkedin.venice.pushmonitor.PushMonitorType;
 import com.linkedin.venice.status.BatchJobHeartbeatConfigs;
+import com.linkedin.venice.utils.HelixUtils;
 import com.linkedin.venice.utils.KafkaSSLUtils;
 import com.linkedin.venice.utils.RegionUtils;
 import com.linkedin.venice.utils.Time;
@@ -212,6 +211,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import org.apache.helix.cloud.constants.CloudProvider;
 import org.apache.helix.controller.rebalancer.strategy.CrushRebalanceStrategy;
+import org.apache.helix.model.CloudConfig;
 import org.apache.kafka.common.protocol.SecurityProtocol;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -366,10 +366,7 @@ public class VeniceControllerClusterConfig {
 
   private final boolean controllerClusterHelixCloudEnabled;
   private final boolean storageClusterHelixCloudEnabled;
-  private final CloudProvider helixCloudProvider;
-  private final String helixCloudId;
-  private final List<String> helixCloudInfoSources;
-  private final String helixCloudInfoProcessorName;
+  private final CloudConfig helixCloudConfig;
 
   private final boolean usePushStatusStoreForIncrementalPushStatusReads;
 
@@ -430,7 +427,6 @@ public class VeniceControllerClusterConfig {
   private final boolean sslToKafka;
   private final int helixSendMessageTimeoutMilliseconds;
   private final int adminTopicReplicationFactor;
-  private final PushMonitorType pushMonitorType;
 
   private final String kafkaSecurityProtocol;
   // SSL related config
@@ -629,8 +625,6 @@ public class VeniceControllerClusterConfig {
     this.pushSSLAllowlist = props.getListWithAlternative(PUSH_SSL_ALLOWLIST, PUSH_SSL_WHITELIST, new ArrayList<>());
     this.helixRebalanceAlg = props.getString(HELIX_REBALANCE_ALG, CrushRebalanceStrategy.class.getName());
     this.adminTopicReplicationFactor = props.getInt(ADMIN_TOPIC_REPLICATION_FACTOR, 3);
-    this.pushMonitorType =
-        PushMonitorType.valueOf(props.getString(PUSH_MONITOR_TYPE, PushMonitorType.WRITE_COMPUTE_STORE.name()));
     if (adminTopicReplicationFactor < 1) {
       throw new ConfigurationException(ADMIN_TOPIC_REPLICATION_FACTOR + " cannot be less than 1.");
     }
@@ -910,25 +904,30 @@ public class VeniceControllerClusterConfig {
     this.storageClusterHelixCloudEnabled = props.getBoolean(CONTROLLER_STORAGE_CLUSTER_HELIX_CLOUD_ENABLED, false);
 
     if (controllerClusterHelixCloudEnabled || storageClusterHelixCloudEnabled) {
+      CloudProvider helixCloudProvider;
       String controllerCloudProvider = props.getString(CONTROLLER_HELIX_CLOUD_PROVIDER).toUpperCase();
       try {
-        this.helixCloudProvider = CloudProvider.valueOf(controllerCloudProvider);
+        helixCloudProvider = CloudProvider.valueOf(controllerCloudProvider);
       } catch (IllegalArgumentException e) {
         throw new VeniceException(
             "Invalid Helix cloud provider: " + controllerCloudProvider + ". Must be one of: "
                 + Arrays.toString(CloudProvider.values()));
       }
-    } else {
-      this.helixCloudProvider = null;
-    }
 
-    this.helixCloudId = props.getString(CONTROLLER_HELIX_CLOUD_ID, "");
-    this.helixCloudInfoProcessorName = props.getString(CONTROLLER_HELIX_CLOUD_INFO_PROCESSOR_NAME, "");
+      String helixCloudId = props.getString(CONTROLLER_HELIX_CLOUD_ID, "");
+      String helixCloudInfoProcessorName = props.getString(CONTROLLER_HELIX_CLOUD_INFO_PROCESSOR_NAME, "");
 
-    if (props.getString(CONTROLLER_HELIX_CLOUD_INFO_SOURCES, "").isEmpty()) {
-      this.helixCloudInfoSources = Collections.emptyList();
+      List<String> helixCloudInfoSources;
+      if (props.getString(CONTROLLER_HELIX_CLOUD_INFO_SOURCES, "").isEmpty()) {
+        helixCloudInfoSources = Collections.emptyList();
+      } else {
+        helixCloudInfoSources = props.getList(CONTROLLER_HELIX_CLOUD_INFO_SOURCES);
+      }
+
+      helixCloudConfig = HelixUtils
+          .getCloudConfig(helixCloudProvider, helixCloudId, helixCloudInfoSources, helixCloudInfoProcessorName);
     } else {
-      this.helixCloudInfoSources = props.getList(CONTROLLER_HELIX_CLOUD_INFO_SOURCES);
+      helixCloudConfig = null;
     }
 
     this.unregisterMetricForDeletedStoreEnabled = props.getBoolean(UNREGISTER_METRIC_FOR_DELETED_STORE_ENABLED, false);
@@ -1577,20 +1576,8 @@ public class VeniceControllerClusterConfig {
     return storageClusterHelixCloudEnabled;
   }
 
-  public CloudProvider getHelixCloudProvider() {
-    return helixCloudProvider;
-  }
-
-  public String getHelixCloudId() {
-    return helixCloudId;
-  }
-
-  public List<String> getHelixCloudInfoSources() {
-    return helixCloudInfoSources;
-  }
-
-  public String getHelixCloudInfoProcessorName() {
-    return helixCloudInfoProcessorName;
+  public CloudConfig getHelixCloudConfig() {
+    return helixCloudConfig;
   }
 
   public boolean usePushStatusStoreForIncrementalPush() {

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/ZkHelixAdminClient.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/ZkHelixAdminClient.java
@@ -19,7 +19,6 @@ import org.apache.helix.controller.rebalancer.waged.WagedRebalancer;
 import org.apache.helix.manager.zk.ZKHelixAdmin;
 import org.apache.helix.manager.zk.ZKHelixManager;
 import org.apache.helix.manager.zk.ZNRecordSerializer;
-import org.apache.helix.model.CloudConfig;
 import org.apache.helix.model.ClusterConfig;
 import org.apache.helix.model.HelixConfigScope;
 import org.apache.helix.model.IdealState;
@@ -92,18 +91,17 @@ public class ZkHelixAdminClient implements HelixAdminClient {
         if (!helixAdmin.addCluster(controllerClusterName, false)) {
           throw new VeniceRetriableException("Failed to create Helix cluster, will retry");
         }
-        Map<String, String> helixClusterProperties = new HashMap<>();
-        helixClusterProperties.put(ZKHelixManager.ALLOW_PARTICIPANT_AUTO_JOIN, String.valueOf(true));
+        ClusterConfig clusterConfig = new ClusterConfig(controllerClusterName);
+        clusterConfig.getRecord().setBooleanField(ZKHelixManager.ALLOW_PARTICIPANT_AUTO_JOIN, true);
         // Topology and fault zone type fields are used by CRUSH alg. Helix would apply the constrains on CRUSH alg to
         // choose proper instance to hold the replica.
-        helixClusterProperties
-            .put(ClusterConfig.ClusterConfigProperty.TOPOLOGY_AWARE_ENABLED.name(), String.valueOf(false));
+        clusterConfig.setTopologyAwareEnabled(false);
 
-        updateClusterConfigs(controllerClusterName, helixClusterProperties);
+        updateClusterConfigs(controllerClusterName, clusterConfig);
         helixAdmin.addStateModelDef(controllerClusterName, LeaderStandbySMD.name, LeaderStandbySMD.build());
 
         if (commonConfig.isControllerClusterHelixCloudEnabled()) {
-          setCloudConfig(controllerClusterName, commonConfig);
+          helixAdmin.addCloudConfig(controllerClusterName, commonConfig.getHelixCloudConfig());
         }
       }
       return true;
@@ -116,21 +114,21 @@ public class ZkHelixAdminClient implements HelixAdminClient {
   }
 
   /**
-   * @see HelixAdminClient#createVeniceStorageCluster(String, Map)
+   * @see HelixAdminClient#createVeniceStorageCluster(String, ClusterConfig)
    */
   @Override
-  public void createVeniceStorageCluster(String clusterName, Map<String, String> helixClusterProperties) {
+  public void createVeniceStorageCluster(String clusterName, ClusterConfig helixClusterConfig) {
     boolean success = RetryUtils.executeWithMaxAttempt(() -> {
       if (!isVeniceStorageClusterCreated(clusterName)) {
         if (!helixAdmin.addCluster(clusterName, false)) {
           throw new VeniceRetriableException("Failed to create Helix cluster, will retry");
         }
-        updateClusterConfigs(clusterName, helixClusterProperties);
+        updateClusterConfigs(clusterName, helixClusterConfig);
         helixAdmin.addStateModelDef(clusterName, LeaderStandbySMD.name, LeaderStandbySMD.build());
 
-        VeniceControllerClusterConfig config = multiClusterConfigs.getControllerConfig(clusterName);
-        if (config.isStorageClusterHelixCloudEnabled()) {
-          setCloudConfig(clusterName, config);
+        VeniceControllerClusterConfig clusterConfig = multiClusterConfigs.getControllerConfig(clusterName);
+        if (clusterConfig.isStorageClusterHelixCloudEnabled()) {
+          helixAdmin.addCloudConfig(clusterName, clusterConfig.getHelixCloudConfig());
         }
       }
       return true;
@@ -207,12 +205,13 @@ public class ZkHelixAdminClient implements HelixAdminClient {
   }
 
   /**
-   * @see HelixAdminClient#updateClusterConfigs(String, Map)
+   * @see HelixAdminClient#updateClusterConfigs(String, ClusterConfig)
    */
   @Override
-  public void updateClusterConfigs(String clusterName, Map<String, String> helixClusterProperties) {
+  public void updateClusterConfigs(String clusterName, ClusterConfig clusterConfig) {
     HelixConfigScope configScope =
         new HelixConfigScopeBuilder(HelixConfigScope.ConfigScopeProperty.CLUSTER).forCluster(clusterName).build();
+    Map<String, String> helixClusterProperties = new HashMap<>(clusterConfig.getRecord().getSimpleFields());
     helixAdmin.setConfig(configScope, helixClusterProperties);
   }
 
@@ -317,26 +316,5 @@ public class ZkHelixAdminClient implements HelixAdminClient {
   @Override
   public void close() {
     helixAdmin.close();
-  }
-
-  public void setCloudConfig(String clusterName, VeniceControllerClusterConfig config) {
-    String cloudId = config.getHelixCloudId();
-    List<String> cloudInfoSources = config.getHelixCloudInfoSources();
-    String cloudInfoProcessorName = config.getHelixCloudInfoProcessorName();
-    CloudConfig.Builder cloudConfigBuilder =
-        new CloudConfig.Builder().setCloudEnabled(true).setCloudProvider(config.getHelixCloudProvider());
-
-    if (!cloudId.isEmpty()) {
-      cloudConfigBuilder.setCloudID(cloudId);
-    }
-
-    if (!cloudInfoSources.isEmpty()) {
-      cloudConfigBuilder.setCloudInfoSources(cloudInfoSources);
-    }
-
-    if (!cloudInfoProcessorName.isEmpty()) {
-      cloudConfigBuilder.setCloudInfoProcessorName(cloudInfoProcessorName);
-    }
-    helixAdmin.addCloudConfig(clusterName, cloudConfigBuilder.build());
   }
 }

--- a/services/venice-controller/src/test/java/com/linkedin/venice/controller/TestVeniceControllerClusterConfig.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/controller/TestVeniceControllerClusterConfig.java
@@ -10,8 +10,13 @@ import static com.linkedin.venice.ConfigKeys.CLUSTER_TO_D2;
 import static com.linkedin.venice.ConfigKeys.CLUSTER_TO_SERVER_D2;
 import static com.linkedin.venice.ConfigKeys.CONTROLLER_ADD_VERSION_VIA_ADMIN_PROTOCOL;
 import static com.linkedin.venice.ConfigKeys.CONTROLLER_DISABLED_ROUTES;
+import static com.linkedin.venice.ConfigKeys.CONTROLLER_HELIX_CLOUD_ID;
+import static com.linkedin.venice.ConfigKeys.CONTROLLER_HELIX_CLOUD_INFO_PROCESSOR_NAME;
+import static com.linkedin.venice.ConfigKeys.CONTROLLER_HELIX_CLOUD_INFO_SOURCES;
+import static com.linkedin.venice.ConfigKeys.CONTROLLER_HELIX_CLOUD_PROVIDER;
 import static com.linkedin.venice.ConfigKeys.CONTROLLER_PARENT_MODE;
 import static com.linkedin.venice.ConfigKeys.CONTROLLER_SSL_ENABLED;
+import static com.linkedin.venice.ConfigKeys.CONTROLLER_STORAGE_CLUSTER_HELIX_CLOUD_ENABLED;
 import static com.linkedin.venice.ConfigKeys.CONTROLLER_SYSTEM_SCHEMA_CLUSTER_NAME;
 import static com.linkedin.venice.ConfigKeys.DEFAULT_MAX_NUMBER_OF_PARTITIONS;
 import static com.linkedin.venice.ConfigKeys.DEFAULT_PARTITION_SIZE;
@@ -29,9 +34,12 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertThrows;
+import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.expectThrows;
 
 import com.linkedin.venice.PushJobCheckpoints;
 import com.linkedin.venice.controllerapi.ControllerRoute;
+import com.linkedin.venice.exceptions.UndefinedPropertyException;
 import com.linkedin.venice.exceptions.VeniceException;
 import com.linkedin.venice.status.protocol.PushJobDetails;
 import com.linkedin.venice.utils.DataProviderUtils;
@@ -47,6 +55,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
+import org.apache.commons.lang.StringUtils;
+import org.apache.helix.cloud.constants.CloudProvider;
+import org.apache.helix.model.CloudConfig;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
@@ -224,5 +235,52 @@ public class TestVeniceControllerClusterConfig {
       VeniceProperties controllerPropsInvalid = new VeniceProperties(properties);
       assertThrows(IllegalArgumentException.class, () -> parsePushJobUserErrorCheckpoints(controllerPropsInvalid));
     }
+  }
+
+  @Test
+  public void testHelixCloudConfig() {
+    Properties baseProps = getBaseSingleRegionProperties(false);
+    baseProps.setProperty(CONTROLLER_STORAGE_CLUSTER_HELIX_CLOUD_ENABLED, "true");
+
+    UndefinedPropertyException e1 = expectThrows(
+        UndefinedPropertyException.class,
+        () -> new VeniceControllerClusterConfig(new VeniceProperties(baseProps)));
+    assertTrue(e1.getMessage().contains("Missing required property '" + CONTROLLER_HELIX_CLOUD_PROVIDER + "'"));
+
+    baseProps.setProperty(CONTROLLER_HELIX_CLOUD_PROVIDER, "invalidProvider");
+    VeniceException e2 =
+        expectThrows(VeniceException.class, () -> new VeniceControllerClusterConfig(new VeniceProperties(baseProps)));
+    assertTrue(e2.getMessage().contains("Invalid Helix cloud provider"));
+
+    baseProps.setProperty(CONTROLLER_HELIX_CLOUD_PROVIDER, CloudProvider.AZURE.name());
+    VeniceControllerClusterConfig clusterConfig1 = new VeniceControllerClusterConfig(new VeniceProperties(baseProps));
+    validateCloudConfig(clusterConfig1, CloudProvider.AZURE, null, null, null);
+
+    CloudProvider cloudProvider = CloudProvider.CUSTOMIZED;
+    String cloudId = "ABC";
+    String processorName = "testProcessor";
+    List<String> cloudInfoSources = Arrays.asList("source1", "source2");
+
+    baseProps.setProperty(CONTROLLER_HELIX_CLOUD_PROVIDER, cloudProvider.name());
+    baseProps.setProperty(CONTROLLER_HELIX_CLOUD_ID, cloudId);
+    baseProps.setProperty(CONTROLLER_HELIX_CLOUD_INFO_PROCESSOR_NAME, processorName);
+    baseProps.setProperty(CONTROLLER_HELIX_CLOUD_INFO_SOURCES, StringUtils.join(cloudInfoSources, ","));
+
+    VeniceControllerClusterConfig clusterConfig2 = new VeniceControllerClusterConfig(new VeniceProperties(baseProps));
+    validateCloudConfig(clusterConfig2, CloudProvider.CUSTOMIZED, cloudId, processorName, cloudInfoSources);
+  }
+
+  private void validateCloudConfig(
+      VeniceControllerClusterConfig clusterConfig,
+      CloudProvider cloudProvider,
+      String cloudId,
+      String processorName,
+      List<String> cloudInfoSources) {
+    CloudConfig cloudConfig = clusterConfig.getHelixCloudConfig();
+    assertTrue(cloudConfig.isCloudEnabled());
+    assertEquals(cloudConfig.getCloudProvider(), cloudProvider.name());
+    assertEquals(cloudConfig.getCloudID(), cloudId);
+    assertEquals(cloudConfig.getCloudInfoProcessorName(), processorName);
+    assertEquals(cloudConfig.getCloudInfoSources(), cloudInfoSources);
   }
 }

--- a/services/venice-controller/src/test/java/com/linkedin/venice/controller/TestZkHelixAdminClient.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/controller/TestZkHelixAdminClient.java
@@ -1,22 +1,30 @@
 package com.linkedin.venice.controller;
 
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.anyString;
+import static org.mockito.Mockito.clearInvocations;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doCallRealMethod;
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-import static org.testng.Assert.assertThrows;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
 
+import com.linkedin.venice.utils.HelixUtils;
 import java.lang.reflect.Field;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
+import java.util.Map;
 import org.apache.helix.HelixAdmin;
-import org.apache.helix.HelixException;
-import org.apache.helix.cloud.constants.CloudProvider;
+import org.apache.helix.manager.zk.ZKHelixManager;
+import org.apache.helix.model.CloudConfig;
+import org.apache.helix.model.ClusterConfig;
+import org.apache.helix.model.HelixConfigScope;
 import org.apache.helix.model.IdealState;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
@@ -26,16 +34,15 @@ public class TestZkHelixAdminClient {
   private ZkHelixAdminClient zkHelixAdminClient;
   private HelixAdmin mockHelixAdmin;
   private VeniceControllerMultiClusterConfig mockMultiClusterConfigs;
-  private VeniceControllerClusterConfig mockClusterConfig;
-
-  private static final String controllerClusterName = "venice-controllers";
+  private VeniceControllerClusterConfig mockCommonConfig;
+  private static final String VENICE_CONTROLLER_CLUSTER = "venice-controller-cluster";
 
   @BeforeMethod
   public void setUp() throws NoSuchFieldException, IllegalAccessException {
     zkHelixAdminClient = mock(ZkHelixAdminClient.class);
     mockHelixAdmin = mock(HelixAdmin.class);
     mockMultiClusterConfigs = mock(VeniceControllerMultiClusterConfig.class);
-    mockClusterConfig = mock(VeniceControllerClusterConfig.class);
+    mockCommonConfig = mock(VeniceControllerClusterConfig.class);
 
     AccessController.doPrivileged((PrivilegedAction<Void>) () -> {
       try {
@@ -46,74 +53,134 @@ public class TestZkHelixAdminClient {
         Field multiClusterConfigsField = ZkHelixAdminClient.class.getDeclaredField("multiClusterConfigs");
         multiClusterConfigsField.setAccessible(true);
         multiClusterConfigsField.set(zkHelixAdminClient, mockMultiClusterConfigs);
+
+        Field commonConfigsField = ZkHelixAdminClient.class.getDeclaredField("commonConfig");
+        commonConfigsField.setAccessible(true);
+        commonConfigsField.set(zkHelixAdminClient, mockCommonConfig);
+
+        Field controllerClusterNameField = ZkHelixAdminClient.class.getDeclaredField("controllerClusterName");
+        controllerClusterNameField.setAccessible(true);
+        controllerClusterNameField.set(zkHelixAdminClient, VENICE_CONTROLLER_CLUSTER);
       } catch (NoSuchFieldException | IllegalAccessException e) {
         throw new RuntimeException(e);
       }
       return null;
     });
+
+    doReturn(mockCommonConfig).when(mockMultiClusterConfigs).getCommonConfig();
   }
 
   @Test
   public void testInstanceGroupTag() {
+    String clusterName = "test-cluster";
     IdealState mockIdealState = mock(IdealState.class);
+    VeniceControllerClusterConfig mockClusterConfig = mock(VeniceControllerClusterConfig.class);
 
     when(mockClusterConfig.getControllerResourceInstanceGroupTag()).thenReturn("GENERAL");
-    when(mockMultiClusterConfigs.getControllerConfig(anyString())).thenReturn(mockClusterConfig);
+    when(mockMultiClusterConfigs.getControllerConfig(clusterName)).thenReturn(mockClusterConfig);
     when(mockHelixAdmin.getResourceIdealState(any(), any())).thenReturn(mockIdealState);
 
     doCallRealMethod().when(zkHelixAdminClient).addVeniceStorageClusterToControllerCluster(anyString());
 
-    String clusterName = "test-cluster";
     zkHelixAdminClient.addVeniceStorageClusterToControllerCluster(clusterName);
 
     verify(mockIdealState).setInstanceGroupTag("GENERAL");
   }
 
   @Test
-  public void testSetCloudConfig() {
-    CloudProvider cloudProvider = CloudProvider.CUSTOMIZED;
-    List<String> cloudInfoSources = new ArrayList<>();
-    cloudInfoSources.add("TestSource");
+  public void testCreateVeniceControllerCluster() {
+    doReturn(true).when(mockHelixAdmin).addCluster(VENICE_CONTROLLER_CLUSTER, false);
+    doReturn(true).when(mockCommonConfig).isControllerClusterHelixCloudEnabled();
 
-    when(mockClusterConfig.getHelixCloudProvider()).thenReturn(cloudProvider);
-    when(mockClusterConfig.getHelixCloudId()).thenReturn("NA");
-    when(mockClusterConfig.getHelixCloudInfoSources()).thenReturn(cloudInfoSources);
-    when(mockClusterConfig.getHelixCloudInfoProcessorName()).thenReturn("TestProcessor");
+    CloudConfig cloudConfig = mock(CloudConfig.class);
+    doReturn(cloudConfig).when(mockCommonConfig).getHelixCloudConfig();
 
-    doCallRealMethod().when(zkHelixAdminClient).setCloudConfig(controllerClusterName, mockClusterConfig);
-    zkHelixAdminClient.setCloudConfig(controllerClusterName, mockClusterConfig);
+    doCallRealMethod().when(zkHelixAdminClient).createVeniceControllerCluster();
 
-    verify(mockHelixAdmin).addCloudConfig(any(), any());
+    doAnswer(invocation -> {
+      ClusterConfig clusterConfig = invocation.getArgument(1);
+
+      assertEquals(clusterConfig.getClusterName(), VENICE_CONTROLLER_CLUSTER);
+      assertTrue(clusterConfig.getRecord().getBooleanField(ZKHelixManager.ALLOW_PARTICIPANT_AUTO_JOIN, false));
+      assertFalse(clusterConfig.isTopologyAwareEnabled());
+
+      return null;
+    }).when(zkHelixAdminClient).updateClusterConfigs(eq(VENICE_CONTROLLER_CLUSTER), any(ClusterConfig.class));
+
+    zkHelixAdminClient.createVeniceControllerCluster();
+
+    verify(mockHelixAdmin).addCloudConfig(VENICE_CONTROLLER_CLUSTER, cloudConfig);
   }
 
   @Test
-  public void testControllerCloudInfoSourcesNotSet() {
-    CloudProvider cloudProvider = CloudProvider.CUSTOMIZED;
-    when(mockClusterConfig.getHelixCloudProvider()).thenReturn(cloudProvider);
-    when(mockClusterConfig.getHelixCloudId()).thenReturn("NA");
-    when(mockClusterConfig.getHelixCloudInfoSources()).thenReturn(Collections.emptyList());
-    when(mockClusterConfig.getHelixCloudInfoProcessorName()).thenReturn("TestProcessor");
+  public void testCreateVeniceStorageCluster() {
+    String clusterName = "testCluster";
 
-    doCallRealMethod().when(zkHelixAdminClient).setCloudConfig(controllerClusterName, mockClusterConfig);
-    assertThrows(
-        HelixException.class,
-        () -> zkHelixAdminClient.setCloudConfig(controllerClusterName, mockClusterConfig));
+    VeniceControllerClusterConfig mockClusterConfig = mock(VeniceControllerClusterConfig.class);
+    when(mockMultiClusterConfigs.getControllerConfig(clusterName)).thenReturn(mockClusterConfig);
+
+    doReturn(true).when(mockHelixAdmin).addCluster(clusterName, false);
+    doCallRealMethod().when(zkHelixAdminClient).createVeniceStorageCluster(any(), any());
+
+    // When the cluster is not Helix cloud enabled
+    ClusterConfig helixClusterConfig = mock(ClusterConfig.class);
+    zkHelixAdminClient.createVeniceStorageCluster(clusterName, helixClusterConfig);
+
+    verify(zkHelixAdminClient).updateClusterConfigs(clusterName, helixClusterConfig);
+    verify(mockHelixAdmin, never()).addCloudConfig(any(), any());
+
+    clearInvocations(zkHelixAdminClient);
+
+    // When the cluster is Helix cloud enabled
+    doReturn(true).when(mockClusterConfig).isStorageClusterHelixCloudEnabled();
+    CloudConfig cloudConfig = mock(CloudConfig.class);
+    doReturn(cloudConfig).when(mockClusterConfig).getHelixCloudConfig();
+    zkHelixAdminClient.createVeniceStorageCluster(clusterName, helixClusterConfig);
+
+    verify(zkHelixAdminClient).updateClusterConfigs(clusterName, helixClusterConfig);
+    verify(mockHelixAdmin).addCloudConfig(clusterName, cloudConfig);
   }
 
   @Test
-  public void testControllerCloudInfoProcessorNameNotSet() {
-    CloudProvider cloudProvider = CloudProvider.CUSTOMIZED;
-    List<String> cloudInfoSources = new ArrayList<>();
-    cloudInfoSources.add("TestSource");
+  public void testUpdateClusterConfigs() {
+    doCallRealMethod().when(zkHelixAdminClient).updateClusterConfigs(anyString(), any());
 
-    when(mockClusterConfig.getHelixCloudProvider()).thenReturn(cloudProvider);
-    when(mockClusterConfig.getHelixCloudId()).thenReturn("NA");
-    when(mockClusterConfig.getHelixCloudInfoSources()).thenReturn(cloudInfoSources);
-    when(mockClusterConfig.getHelixCloudInfoProcessorName()).thenReturn("");
+    String clusterName = "testCluster";
+    ClusterConfig clusterConfig = new ClusterConfig(clusterName);
 
-    doCallRealMethod().when(zkHelixAdminClient).setCloudConfig(controllerClusterName, mockClusterConfig);
-    assertThrows(
-        HelixException.class,
-        () -> zkHelixAdminClient.setCloudConfig(controllerClusterName, mockClusterConfig));
+    clusterConfig.getRecord().setBooleanField(ZKHelixManager.ALLOW_PARTICIPANT_AUTO_JOIN, true);
+    clusterConfig.setRebalanceDelayTime(1000);
+    clusterConfig.setDelayRebalaceEnabled(true);
+
+    clusterConfig.setPersistBestPossibleAssignment(true);
+    // Topology and fault zone type fields are used by CRUSH alg. Helix would apply the constrains on CRUSH alg to
+    // choose proper instance to hold the replica.
+    clusterConfig.setTopology("/" + HelixUtils.TOPOLOGY_CONSTRAINT);
+    clusterConfig.setFaultZoneType(HelixUtils.TOPOLOGY_CONSTRAINT);
+
+    doAnswer(invocation -> {
+      HelixConfigScope scope = invocation.getArgument(0);
+      Map<String, String> clusterProps = invocation.getArgument(1);
+
+      assertEquals(scope.getType(), HelixConfigScope.ConfigScopeProperty.CLUSTER);
+      assertEquals(scope.getClusterName(), clusterName);
+      assertEquals(clusterProps.size(), 6);
+      assertEquals(clusterProps.get(ZKHelixManager.ALLOW_PARTICIPANT_AUTO_JOIN), "true");
+      assertEquals(clusterProps.get(ClusterConfig.ClusterConfigProperty.DELAY_REBALANCE_ENABLED.name()), "true");
+      assertEquals(clusterProps.get(ClusterConfig.ClusterConfigProperty.DELAY_REBALANCE_TIME.name()), "1000");
+      assertEquals(
+          clusterProps.get(ClusterConfig.ClusterConfigProperty.PERSIST_BEST_POSSIBLE_ASSIGNMENT.name()),
+          "true");
+      assertEquals(
+          clusterProps.get(ClusterConfig.ClusterConfigProperty.TOPOLOGY.name()),
+          "/" + HelixUtils.TOPOLOGY_CONSTRAINT);
+      assertEquals(
+          clusterProps.get(ClusterConfig.ClusterConfigProperty.FAULT_ZONE_TYPE.name()),
+          HelixUtils.TOPOLOGY_CONSTRAINT);
+
+      return null;
+    }).when(mockHelixAdmin).setConfig(any(), any());
+
+    zkHelixAdminClient.updateClusterConfigs(clusterName, clusterConfig);
   }
 }


### PR DESCRIPTION
<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## Refactor `HelixAdminClient` APIs to accept strongly typed Helix objects
<!--
Describe
- What changes to make and why you are making these changes.
- How are you going to achieve your goal.
- Describe what testings you have done, for example, performance testing etc.

If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->
Currently, HelixAdminClient APIs accept a String-to-String map to set on the cluster configs. Changed to use strongly typed Helix `ClusterConfig` object instead.

Also, moved the `CloudConfig` creation at time of parsing configs, and reusing the created object instead of creating it at time of cluster creation.

## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
Added unit tests. GH CI for regression testing

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [X] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.