### PR TITLE
[router] Do not classify REQUEST_ENTITY_TOO_LARGE as unhealthy

### DIFF
--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/router/TestRead.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/router/TestRead.java
@@ -450,6 +450,9 @@ public abstract class TestRead {
         storeClient.batchGet(keySet).get();
         fail("Should receive exception since the batch request key count exceeds cluster-level threshold");
       } catch (Exception e) {
+        double throttledRequestLatencyForBatchGet =
+            getAggregateRouterMetricValue(".total--multiget_unhealthy_request.Count");
+        Assert.assertEquals(throttledRequestLatencyForBatchGet, 0.0, "There should not be any unhealthy requests!");
         LOGGER.info(e);
       }
       // Bump up store-level max key count in batch-get request

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/router/TestRead.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/router/TestRead.java
@@ -450,9 +450,8 @@ public abstract class TestRead {
         storeClient.batchGet(keySet).get();
         fail("Should receive exception since the batch request key count exceeds cluster-level threshold");
       } catch (Exception e) {
-        double throttledRequestLatencyForBatchGet =
-            getAggregateRouterMetricValue(".total--multiget_unhealthy_request.Count");
-        Assert.assertEquals(throttledRequestLatencyForBatchGet, 0.0, "There should not be any unhealthy requests!");
+        double unhealthyRequestCount = getAggregateRouterMetricValue(".total--multiget_unhealthy_request.Count");
+        Assert.assertEquals(unhealthyRequestCount, 0.0, "There should not be any unhealthy requests!");
         LOGGER.info(e);
       }
       // Bump up store-level max key count in batch-get request

--- a/services/venice-router/src/main/java/com/linkedin/venice/router/api/RouterExceptionAndTrackingUtils.java
+++ b/services/venice-router/src/main/java/com/linkedin/venice/router/api/RouterExceptionAndTrackingUtils.java
@@ -153,7 +153,7 @@ public class RouterExceptionAndTrackingUtils {
         ROUTER_STATS.getStatsByType(requestType.isPresent() ? requestType.get() : RequestType.SINGLE_GET);
     // If we don't know the actual store name, this error will only be aggregated in server level, but not
     // in store level
-    if (responseStatus.equals(BAD_REQUEST)) {
+    if (responseStatus.equals(BAD_REQUEST) || responseStatus.equals(REQUEST_ENTITY_TOO_LARGE)) {
       stats.recordBadRequest(storeName.orElse(null));
     } else if (responseStatus.equals(TOO_MANY_REQUESTS)) {
       if (storeName.isPresent()) {


### PR DESCRIPTION
<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## Do not classify REQUEST_ENTITY_TOO_LARGE as unhealthy
<!--
Describe
- What changes to make and why you are making these changes.
- How are you going to achieve your goal.
- Describe what testings you have done, for example, performance testing etc.

If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

Fix large batch get error getting classified as unhealthy request.
## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
GHCI
## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.