### PR TITLE
[router] Replace unhealthy/tardy requests metrics from percentile to regular bucket

### DIFF
--- a/services/venice-router/src/main/java/com/linkedin/venice/router/stats/RouterHttpRequestStats.java
+++ b/services/venice-router/src/main/java/com/linkedin/venice/router/stats/RouterHttpRequestStats.java
@@ -110,11 +110,9 @@ public class RouterHttpRequestStats extends AbstractVeniceHttpStats {
     latencySensor = registerSensorWithDetailedPercentiles("latency", new Avg(), new Max(0));
     healthyRequestLatencySensor =
         registerSensorWithDetailedPercentiles("healthy_request_latency", new Avg(), new Max(0));
-    unhealthyRequestLatencySensor =
-        registerSensorWithDetailedPercentiles("unhealthy_request_latency", new Avg(), new Max(0));
-    tardyRequestLatencySensor = registerSensorWithDetailedPercentiles("tardy_request_latency", new Avg(), new Max(0));
-    throttledRequestLatencySensor =
-        registerSensorWithDetailedPercentiles("throttled_request_latency", new Avg(), new Max(0));
+    unhealthyRequestLatencySensor = registerSensor("unhealthy_request_latency", new Avg(), new Max(0));
+    tardyRequestLatencySensor = registerSensor("tardy_request_latency", new Avg(), new Max(0));
+    throttledRequestLatencySensor = registerSensor("throttled_request_latency", new Avg(), new Max(0));
     routerResponseWaitingTimeSensor = registerSensor(
         "response_waiting_time",
         TehutiUtils.getPercentileStat(getName(), getFullMetricName("response_waiting_time")));


### PR DESCRIPTION


<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## Replace unhealthy/tardy requests metrics from percentile to regular bucket

<!--
Describe
- What changes to make and why you are making these changes.
- How are you going to achieve your goal.
- Describe what testings you have done, for example, performance testing etc.

If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->
We do not need to detailed percentile metrics of the negative events in route.

## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
GHCI
## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.