### PR TITLE
[server] Fix resubscription race condition caused by consumer object level lock.

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/KafkaConsumerService.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/KafkaConsumerService.java
@@ -25,6 +25,7 @@ import com.linkedin.venice.utils.Time;
 import com.linkedin.venice.utils.Utils;
 import com.linkedin.venice.utils.VeniceProperties;
 import com.linkedin.venice.utils.concurrent.VeniceConcurrentHashMap;
+import com.linkedin.venice.utils.locks.AutoCloseableLock;
 import io.tehuti.metrics.MetricsRepository;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -35,6 +36,7 @@ import java.util.Set;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.locks.ReentrantLock;
 import java.util.function.IntConsumer;
 import java.util.function.LongSupplier;
 import java.util.function.Supplier;
@@ -76,6 +78,12 @@ public abstract class KafkaConsumerService extends AbstractKafkaConsumerService 
   protected final Map<PubSubTopic, Map<PubSubTopicPartition, SharedKafkaConsumer>> versionTopicToTopicPartitionToConsumer =
       new VeniceConcurrentHashMap<>();
 
+  /**
+    * This read-only per consumer lock is for protecting the partition unsubscription and data receiver setting operations.
+    * Using consumer intrinsic lock may cause race condition, refer https://github.com/linkedin/venice/pull/1308
+   */
+  protected final Map<SharedKafkaConsumer, ReentrantLock> consumerToLocks = new HashMap<>();
+
   private RandomAccessDaemonThreadFactory threadFactory;
   private final Logger LOGGER;
   private final ExecutorService consumerExecutor;
@@ -107,7 +115,8 @@ public abstract class KafkaConsumerService extends AbstractKafkaConsumerService 
       final boolean isUnregisterMetricForDeletedStoreEnabled) {
     this.kafkaUrl = consumerProperties.getProperty(KAFKA_BOOTSTRAP_SERVERS);
     this.kafkaUrlForLogger = Utils.getSanitizedStringForLogger(kafkaUrl);
-    this.LOGGER = LogManager.getLogger(KafkaConsumerService.class.getSimpleName() + " [" + kafkaUrlForLogger + "]");
+    this.LOGGER = LogManager.getLogger(
+        KafkaConsumerService.class.getSimpleName() + " [" + kafkaUrlForLogger + "-" + poolType.getStatSuffix() + "]");
     this.poolType = poolType;
 
     // Initialize consumers and consumerExecutor
@@ -167,6 +176,7 @@ public abstract class KafkaConsumerService extends AbstractKafkaConsumerService 
           this.aggStats,
           cleaner);
       consumerToConsumptionTask.putByIndex(pubSubConsumer, consumptionTask, i);
+      consumerToLocks.put(pubSubConsumer, new ReentrantLock());
     }
 
     LOGGER.info("KafkaConsumerService was initialized with {} consumers.", numOfConsumersPerKafkaCluster);
@@ -229,7 +239,7 @@ public abstract class KafkaConsumerService extends AbstractKafkaConsumerService 
            * Refer {@link KafkaConsumerService#startConsumptionIntoDataReceiver} for avoiding race condition caused by
            * setting data receiver and unsubscribing concurrently for the same topic partition on a shared consumer.
            */
-          synchronized (sharedConsumer) {
+          try (AutoCloseableLock ignored = AutoCloseableLock.of(consumerToLocks.get(sharedConsumer))) {
             sharedConsumer.unSubscribe(topicPartition);
             removeTopicPartitionFromConsumptionTask(sharedConsumer, topicPartition);
           }
@@ -250,8 +260,8 @@ public abstract class KafkaConsumerService extends AbstractKafkaConsumerService 
        * Refer {@link KafkaConsumerService#startConsumptionIntoDataReceiver} for avoiding race condition caused by
        * setting data receiver and unsubscribing concurrently for the same topic partition on a shared consumer.
        */
-      synchronized (consumer) {
-        consumer.unSubscribe(pubSubTopicPartition, timeoutMs);
+      try (AutoCloseableLock ignored = AutoCloseableLock.of(consumerToLocks.get(consumer))) {
+        consumer.unSubscribe(pubSubTopicPartition);
         removeTopicPartitionFromConsumptionTask(consumer, pubSubTopicPartition);
       }
       versionTopicToTopicPartitionToConsumer.compute(versionTopic, (k, topicPartitionToConsumerMap) -> {
@@ -267,8 +277,8 @@ public abstract class KafkaConsumerService extends AbstractKafkaConsumerService 
 
   @Override
   public void batchUnsubscribe(PubSubTopic versionTopic, Set<PubSubTopicPartition> topicPartitionsToUnSub) {
-    Map<PubSubConsumerAdapter, Set<PubSubTopicPartition>> consumerUnSubTopicPartitionSet = new HashMap<>();
-    PubSubConsumerAdapter consumer;
+    Map<SharedKafkaConsumer, Set<PubSubTopicPartition>> consumerUnSubTopicPartitionSet = new HashMap<>();
+    SharedKafkaConsumer consumer;
     for (PubSubTopicPartition topicPartition: topicPartitionsToUnSub) {
       consumer = getConsumerAssignedToVersionTopicPartition(versionTopic, topicPartition);
       if (consumer != null) {
@@ -286,7 +296,7 @@ public abstract class KafkaConsumerService extends AbstractKafkaConsumerService 
        * Refer {@link KafkaConsumerService#startConsumptionIntoDataReceiver} for avoiding race condition caused by
        * setting data receiver and unsubscribing concurrently for the same topic partition on a shared consumer.
        */
-      synchronized (sharedConsumer) {
+      try (AutoCloseableLock ignored = AutoCloseableLock.of(consumerToLocks.get(sharedConsumer))) {
         sharedConsumer.batchUnsubscribe(tpSet);
         tpSet.forEach(task::removeDataReceiver);
       }
@@ -418,7 +428,7 @@ public abstract class KafkaConsumerService extends AbstractKafkaConsumerService 
      * topic partition before subscription. As {@link ConsumptionTask} does not allow 2 different data receivers for
      * the same topic partition, it will throw exception.
      */
-    synchronized (consumer) {
+    try (AutoCloseableLock ignored = AutoCloseableLock.of(consumerToLocks.get(consumer))) {
       ConsumptionTask consumptionTask = consumerToConsumptionTask.get(consumer);
       if (consumptionTask == null) {
         // Defensive coding. Should never happen except in case of a regression.

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/KafkaConsumerServiceDelegatorTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/KafkaConsumerServiceDelegatorTest.java
@@ -529,7 +529,7 @@ public class KafkaConsumerServiceDelegatorTest {
         factory,
         properties,
         1000l,
-        versionNum * 2, // To simulate real production cases: consumers # >> version # per store.
+        versionNum + 2, // To simulate real production cases: consumers # >> version # per store.
         mock(IngestionThrottler.class),
         mock(KafkaClusterBasedRecordThrottler.class),
         mockMetricsRepository,
@@ -625,8 +625,8 @@ public class KafkaConsumerServiceDelegatorTest {
           }
           consumerServiceDelegator
               .startConsumptionIntoDataReceiver(partitionReplicaIngestionContext, 0, consumedDataReceiver);
-          // Avoid wait time here to increase the chance for race condition.
-          consumerServiceDelegator.assignConsumerFor(versionTopic, pubSubTopicPartition).setTimeoutMsOverride(0L);
+          // Use low wait time to trigger unsubscribe and poll lock handoff.
+          consumerServiceDelegator.assignConsumerFor(versionTopic, pubSubTopicPartition).setTimeoutMsOverride(1L);
           int versionNum =
               Version.parseVersionFromKafkaTopicName(partitionReplicaIngestionContext.getVersionTopic().getName());
           if (versionNum % 3 == 0) {


### PR DESCRIPTION
<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## Summary, imperative, start upper case, don't end with a period
<!--
Describe
- What changes to make and why you are making these changes.
- How are you going to achieve your goal.
- Describe what testings you have done, for example, performance testing etc.

If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

This PR addresses a race condition caused by the `wait()` and `notifyAll()` mechanism between the `StoreIngestionTask` thread's call to `SharedKafkaConsumer#unSubscribeAction` and the `ConsumptionTask` thread's call to `SharedKafkaConsumer`#poll. This mechanism ensures that the next poll only occurs after the unsubscription has completed. The wait() inside `SharedKafkaConsumer#unSubscribeAction` releases the object-level lock on the `SharedKafkaConsumer`.

However, the changes introduced in [PR #1263](https://github.com/linkedin/venice/pull/1263) added a consumer intrinsic lock in `KafkaConsumerService` to protect unsubscription operations (inside `unSubscribe`, `unSubscribeAll`, and `batchUnsubscribe`) and data receiver settings (inside `assignConsumerFor`). These changes required the entire lifecycle of unsubscription to be synchronized under the lock, as multiple `StoreIngestionTask` threads could perform re-subscription (unsubscribe followed by resubscribe) concurrently. The `wait()` in `SharedKafkaConsumer#unSubscribeAction` violated this locking assumption, leading to race conditions.

Since the intrinsic `SharedKafkaConsumer` lock cannot be used for both unsubscription/data receiver settings and for coordination between unsubscribe and poll, the solution is to introduce a dedicated lock for each consumer. This ensures proper synchronization while resolving the race condition.

## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
CI
## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [*] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.