### PR TITLE
[server] SN read quota versioned stats not initialized after restart

### DIFF
--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/fastclient/FastClientIndividualFeatureConfigurationTest.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/fastclient/FastClientIndividualFeatureConfigurationTest.java
@@ -186,6 +186,10 @@ public class FastClientIndividualFeatureConfigurationTest extends AbstractClient
       LOGGER.info("RESTARTING servers");
       veniceCluster.stopAndRestartVeniceServer(veniceServerWrapper.getPort());
     }
+    serverMetrics.clear();
+    for (int i = 0; i < veniceCluster.getVeniceServers().size(); i++) {
+      serverMetrics.add(veniceCluster.getVeniceServers().get(i).getMetricsRepository());
+    }
     for (int j = 0; j < 5; j++) {
       for (int i = 0; i < recordCnt; i++) {
         String key = keyPrefix + i;
@@ -198,7 +202,7 @@ public class FastClientIndividualFeatureConfigurationTest extends AbstractClient
       quotaRequestedQPSSum += serverMetric.getMetric(readQuotaRequestedQPSString).value();
       assertEquals(serverMetric.getMetric(readQuotaAllowedUnintentionally).value(), 0d);
     }
-    assertTrue(quotaRequestedQPSSum >= 0, "Quota request sum: " + quotaRequestedQPSSum);
+    assertTrue(quotaRequestedQPSSum > 0, "Quota request sum: " + quotaRequestedQPSSum);
   }
 
   @Test(timeOut = TIME_OUT)

--- a/services/venice-server/src/main/java/com/linkedin/venice/listener/ReadQuotaEnforcementHandler.java
+++ b/services/venice-server/src/main/java/com/linkedin/venice/listener/ReadQuotaEnforcementHandler.java
@@ -173,6 +173,8 @@ public class ReadQuotaEnforcementHandler extends SimpleChannelInboundHandler<Rou
       for (Version version: versions) {
         customizedViewRepository.subscribeRoutingDataChange(version.kafkaTopicName(), this);
       }
+      // also invoke handle store change to ensure corresponding token bucket and stats are initialized.
+      handleStoreChanged(store);
     }
     this.initializedVolatile = true;
   }

--- a/services/venice-server/src/main/java/com/linkedin/venice/stats/ServerReadQuotaUsageStats.java
+++ b/services/venice-server/src/main/java/com/linkedin/venice/stats/ServerReadQuotaUsageStats.java
@@ -79,6 +79,14 @@ public class ServerReadQuotaUsageStats extends AbstractVeniceStats {
     }
   }
 
+  public int getCurrentVersion() {
+    return currentVersion.get();
+  }
+
+  public int getBackupVersion() {
+    return backupVersion.get();
+  }
+
   public void removeVersion(int version) {
     versionedStats.remove(version);
   }


### PR DESCRIPTION
## [server] SN read quota versioned stats not initialized after restart

The currentVersion and backupVersion of ServerReadQuotaUsageStats are not set after server restart because handleStoreChanged is invoked for all stores when the store repo undergoing refresh before we initialize and register store change listener in ReadQuotaEnforcementHandler (part of the ListenerService). As a result metrics that depend on current and backup versions will not show up properly until store is updated.

The fix is to during initialization of ReadQuotaEnforcementHandler we will invoke handleStoreChanged for all stores after we register store change listener.

The bug is actually reproducible in existing integration test. However, it was not caught because the test was broken/misconfigured...

## How was this PR tested?
Existing unit and integration tests

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [ ] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.