### PR TITLE
[controller] Log request and response body for aggregated stoppable check

### DIFF
--- a/internal/venice-common/src/main/java/com/linkedin/venice/controllerapi/StoppableNodeStatusResponse.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/controllerapi/StoppableNodeStatusResponse.java
@@ -1,5 +1,6 @@
 package com.linkedin.venice.controllerapi;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
@@ -9,6 +10,10 @@ public class StoppableNodeStatusResponse extends ControllerResponse {
   private Map<String, String> nonStoppableInstancesWithReasons;
 
   public Map<String, String> getNonStoppableInstancesWithReasons() {
+    if (nonStoppableInstancesWithReasons == null) {
+      return Collections.emptyMap();
+    }
+
     return nonStoppableInstancesWithReasons;
   }
 
@@ -17,10 +22,14 @@ public class StoppableNodeStatusResponse extends ControllerResponse {
   }
 
   public List<String> getStoppableInstances() {
+    if (stoppableInstances == null) {
+      return Collections.emptyList();
+    }
+
     return stoppableInstances;
   }
 
-  public void setStoppableInstances(List<String> remoableInstances) {
-    this.stoppableInstances = remoableInstances;
+  public void setStoppableInstances(List<String> removableInstances) {
+    this.stoppableInstances = removableInstances;
   }
 }

--- a/internal/venice-common/src/main/java/com/linkedin/venice/controllerapi/StoppableNodeStatusResponse.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/controllerapi/StoppableNodeStatusResponse.java
@@ -29,7 +29,7 @@ public class StoppableNodeStatusResponse extends ControllerResponse {
     return stoppableInstances;
   }
 
-  public void setStoppableInstances(List<String> removableInstances) {
-    this.stoppableInstances = removableInstances;
+  public void setStoppableInstances(List<String> stoppableInstances) {
+    this.stoppableInstances = stoppableInstances;
   }
 }

--- a/internal/venice-common/src/test/java/com/linkedin/venice/controllerapi/TestStoppableNodeStatusResponse.java
+++ b/internal/venice-common/src/test/java/com/linkedin/venice/controllerapi/TestStoppableNodeStatusResponse.java
@@ -1,41 +1,21 @@
 package com.linkedin.venice.controllerapi;
 
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.linkedin.venice.utils.ObjectMapperFactory;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
 import org.testng.annotations.Test;
 
 
 public class TestStoppableNodeStatusResponse {
   private static final ObjectMapper OBJECT_MAPPER = ObjectMapperFactory.getInstance();
-
-  private static class StoppableNodeStatusResponseForTest {
-    private List<String> stoppableInstances;
-    private Map<String, String> nonStoppableInstancesWithReasons;
-
-    public Map<String, String> getNonStoppableInstancesWithReasons() {
-      return nonStoppableInstancesWithReasons;
-    }
-
-    public void setNonStoppableInstancesWithReason(Map<String, String> nonStoppableInstancesWithReasons) {
-      this.nonStoppableInstancesWithReasons = nonStoppableInstancesWithReasons;
-    }
-
-    public List<String> getStoppableInstances() {
-      return stoppableInstances;
-    }
-
-    public void setStoppableInstances(List<String> removableInstances) {
-      this.stoppableInstances = removableInstances;
-    }
-  }
 
   @Test
   public void testJsonSerialization() throws JsonProcessingException {
@@ -49,11 +29,14 @@ public class TestStoppableNodeStatusResponse {
     });
 
     String serializedResponse = OBJECT_MAPPER.writeValueAsString(response);
-    StoppableNodeStatusResponseForTest deserializedResponse =
-        OBJECT_MAPPER.readValue(serializedResponse, StoppableNodeStatusResponseForTest.class);
+    JsonNode deserializedResponse = OBJECT_MAPPER.readTree(serializedResponse);
 
-    assertEquals(deserializedResponse.stoppableInstances, response.getStoppableInstances());
-    assertEquals(deserializedResponse.nonStoppableInstancesWithReasons, response.getNonStoppableInstancesWithReasons());
+    assertTrue(deserializedResponse.get("stoppableInstances") instanceof ArrayNode);
+    assertEquals(deserializedResponse.get("stoppableInstances").get(0).asText(), "instance1");
+    assertEquals(deserializedResponse.get("stoppableInstances").get(1).asText(), "instance2");
+    assertTrue(deserializedResponse.get("nonStoppableInstancesWithReasons") instanceof ObjectNode);
+    assertEquals(deserializedResponse.get("nonStoppableInstancesWithReasons").get("instance3").asText(), "reason1");
+    assertEquals(deserializedResponse.get("nonStoppableInstancesWithReasons").get("instance4").asText(), "reason2");
   }
 
   @Test
@@ -61,10 +44,9 @@ public class TestStoppableNodeStatusResponse {
     StoppableNodeStatusResponse response = new StoppableNodeStatusResponse();
 
     String serializedResponse = OBJECT_MAPPER.writeValueAsString(response);
-    StoppableNodeStatusResponseForTest deserializedResponse =
-        OBJECT_MAPPER.readValue(serializedResponse, StoppableNodeStatusResponseForTest.class);
+    JsonNode deserializedResponse = OBJECT_MAPPER.readTree(serializedResponse);
 
-    assertEquals(deserializedResponse.stoppableInstances, Collections.emptyList());
-    assertEquals(deserializedResponse.nonStoppableInstancesWithReasons, Collections.emptyMap());
+    assertTrue(deserializedResponse.get("stoppableInstances").isEmpty());
+    assertTrue(deserializedResponse.get("nonStoppableInstancesWithReasons").isEmpty());
   }
 }

--- a/internal/venice-common/src/test/java/com/linkedin/venice/controllerapi/TestStoppableNodeStatusResponse.java
+++ b/internal/venice-common/src/test/java/com/linkedin/venice/controllerapi/TestStoppableNodeStatusResponse.java
@@ -1,0 +1,70 @@
+package com.linkedin.venice.controllerapi;
+
+import static org.testng.Assert.assertEquals;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.linkedin.venice.utils.ObjectMapperFactory;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.testng.annotations.Test;
+
+
+public class TestStoppableNodeStatusResponse {
+  private static final ObjectMapper OBJECT_MAPPER = ObjectMapperFactory.getInstance();
+
+  private static class StoppableNodeStatusResponseForTest {
+    private List<String> stoppableInstances;
+    private Map<String, String> nonStoppableInstancesWithReasons;
+
+    public Map<String, String> getNonStoppableInstancesWithReasons() {
+      return nonStoppableInstancesWithReasons;
+    }
+
+    public void setNonStoppableInstancesWithReason(Map<String, String> nonStoppableInstancesWithReasons) {
+      this.nonStoppableInstancesWithReasons = nonStoppableInstancesWithReasons;
+    }
+
+    public List<String> getStoppableInstances() {
+      return stoppableInstances;
+    }
+
+    public void setStoppableInstances(List<String> removableInstances) {
+      this.stoppableInstances = removableInstances;
+    }
+  }
+
+  @Test
+  public void testJsonSerialization() throws JsonProcessingException {
+    StoppableNodeStatusResponse response = new StoppableNodeStatusResponse();
+    response.setStoppableInstances(Arrays.asList("instance1", "instance2"));
+    response.setNonStoppableInstancesWithReason(new HashMap<String, String>() {
+      {
+        put("instance3", "reason1");
+        put("instance4", "reason2");
+      }
+    });
+
+    String serializedResponse = OBJECT_MAPPER.writeValueAsString(response);
+    StoppableNodeStatusResponseForTest deserializedResponse =
+        OBJECT_MAPPER.readValue(serializedResponse, StoppableNodeStatusResponseForTest.class);
+
+    assertEquals(deserializedResponse.stoppableInstances, response.getStoppableInstances());
+    assertEquals(deserializedResponse.nonStoppableInstancesWithReasons, response.getNonStoppableInstancesWithReasons());
+  }
+
+  @Test
+  public void testJsonSerializationForEmptyContent() throws JsonProcessingException {
+    StoppableNodeStatusResponse response = new StoppableNodeStatusResponse();
+
+    String serializedResponse = OBJECT_MAPPER.writeValueAsString(response);
+    StoppableNodeStatusResponseForTest deserializedResponse =
+        OBJECT_MAPPER.readValue(serializedResponse, StoppableNodeStatusResponseForTest.class);
+
+    assertEquals(deserializedResponse.stoppableInstances, Collections.emptyList());
+    assertEquals(deserializedResponse.nonStoppableInstancesWithReasons, Collections.emptyMap());
+  }
+}

--- a/services/venice-controller/src/test/java/com/linkedin/venice/controller/server/ControllerRoutesTest.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/controller/server/ControllerRoutesTest.java
@@ -4,16 +4,26 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.anyString;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.linkedin.venice.controller.Admin;
+import com.linkedin.venice.controller.InstanceRemovableStatuses;
 import com.linkedin.venice.controller.VeniceParentHelixAdmin;
+import com.linkedin.venice.controllerapi.AggregatedHealthStatusRequest;
 import com.linkedin.venice.controllerapi.ControllerApiConstants;
 import com.linkedin.venice.controllerapi.LeaderControllerResponse;
+import com.linkedin.venice.controllerapi.StoppableNodeStatusResponse;
 import com.linkedin.venice.meta.Instance;
 import com.linkedin.venice.pubsub.PubSubTopicRepository;
 import com.linkedin.venice.utils.ObjectMapperFactory;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import java.util.Optional;
-import org.testng.Assert;
 import org.testng.annotations.Test;
 import spark.Request;
 import spark.Response;
@@ -21,6 +31,7 @@ import spark.Route;
 
 
 public class ControllerRoutesTest {
+  private static final ObjectMapper OBJECT_MAPPER = ObjectMapperFactory.getInstance();
   private static final String TEST_CLUSTER = "test_cluster";
   private static final String TEST_NODE_ID = "l2181";
   private static final String TEST_HOST = "localhost";
@@ -41,34 +52,120 @@ public class ControllerRoutesTest {
 
     Route leaderControllerRoute =
         new ControllerRoutes(false, Optional.empty(), pubSubTopicRepository).getLeaderController(mockAdmin);
-    LeaderControllerResponse leaderControllerResponse = ObjectMapperFactory.getInstance()
-        .readValue(
-            leaderControllerRoute.handle(request, mock(Response.class)).toString(),
-            LeaderControllerResponse.class);
-    Assert.assertEquals(leaderControllerResponse.getCluster(), TEST_CLUSTER);
-    Assert.assertEquals(leaderControllerResponse.getUrl(), "http://" + TEST_HOST + ":" + TEST_PORT);
-    Assert.assertEquals(leaderControllerResponse.getSecureUrl(), "https://" + TEST_HOST + ":" + TEST_SSL_PORT);
+    LeaderControllerResponse leaderControllerResponse = OBJECT_MAPPER.readValue(
+        leaderControllerRoute.handle(request, mock(Response.class)).toString(),
+        LeaderControllerResponse.class);
+    assertEquals(leaderControllerResponse.getCluster(), TEST_CLUSTER);
+    assertEquals(leaderControllerResponse.getUrl(), "http://" + TEST_HOST + ":" + TEST_PORT);
+    assertEquals(leaderControllerResponse.getSecureUrl(), "https://" + TEST_HOST + ":" + TEST_SSL_PORT);
 
     Route leaderControllerSslRoute =
         new ControllerRoutes(true, Optional.empty(), pubSubTopicRepository).getLeaderController(mockAdmin);
-    LeaderControllerResponse leaderControllerResponseSsl = ObjectMapperFactory.getInstance()
-        .readValue(
-            leaderControllerSslRoute.handle(request, mock(Response.class)).toString(),
-            LeaderControllerResponse.class);
-    Assert.assertEquals(leaderControllerResponseSsl.getCluster(), TEST_CLUSTER);
-    Assert.assertEquals(leaderControllerResponseSsl.getUrl(), "https://" + TEST_HOST + ":" + TEST_SSL_PORT);
-    Assert.assertEquals(leaderControllerResponseSsl.getSecureUrl(), "https://" + TEST_HOST + ":" + TEST_SSL_PORT);
+    LeaderControllerResponse leaderControllerResponseSsl = OBJECT_MAPPER.readValue(
+        leaderControllerSslRoute.handle(request, mock(Response.class)).toString(),
+        LeaderControllerResponse.class);
+    assertEquals(leaderControllerResponseSsl.getCluster(), TEST_CLUSTER);
+    assertEquals(leaderControllerResponseSsl.getUrl(), "https://" + TEST_HOST + ":" + TEST_SSL_PORT);
+    assertEquals(leaderControllerResponseSsl.getSecureUrl(), "https://" + TEST_HOST + ":" + TEST_SSL_PORT);
 
     // Controller doesn't support SSL
     Instance leaderNonSslController = new Instance(TEST_NODE_ID, TEST_HOST, TEST_PORT, TEST_PORT);
     doReturn(leaderNonSslController).when(mockAdmin).getLeaderController(anyString());
 
-    LeaderControllerResponse leaderControllerNonSslResponse = ObjectMapperFactory.getInstance()
-        .readValue(
-            leaderControllerRoute.handle(request, mock(Response.class)).toString(),
-            LeaderControllerResponse.class);
-    Assert.assertEquals(leaderControllerNonSslResponse.getCluster(), TEST_CLUSTER);
-    Assert.assertEquals(leaderControllerNonSslResponse.getUrl(), "http://" + TEST_HOST + ":" + TEST_PORT);
-    Assert.assertEquals(leaderControllerNonSslResponse.getSecureUrl(), null);
+    LeaderControllerResponse leaderControllerNonSslResponse = OBJECT_MAPPER.readValue(
+        leaderControllerRoute.handle(request, mock(Response.class)).toString(),
+        LeaderControllerResponse.class);
+    assertEquals(leaderControllerNonSslResponse.getCluster(), TEST_CLUSTER);
+    assertEquals(leaderControllerNonSslResponse.getUrl(), "http://" + TEST_HOST + ":" + TEST_PORT);
+    assertEquals(leaderControllerNonSslResponse.getSecureUrl(), null);
+  }
+
+  @Test
+  public void testGetAggregatedHealthStatus() throws Exception {
+    ControllerRoutes controllerRoutes = new ControllerRoutes(false, Optional.empty(), pubSubTopicRepository);
+    Admin mockAdmin = mock(VeniceParentHelixAdmin.class);
+
+    List<String> instanceList = Arrays.asList("instance1_5000", "instance2_5000");
+    List<String> toBeStoppedInstanceList = Arrays.asList("instance3_5000", "instance4_5000");
+
+    AggregatedHealthStatusRequest requestBody =
+        new AggregatedHealthStatusRequest(TEST_CLUSTER, instanceList, toBeStoppedInstanceList);
+    String body = OBJECT_MAPPER.writeValueAsString(requestBody);
+
+    Request request = mock(Request.class);
+    doReturn(body).when(request).body();
+
+    // Test redirect
+    InstanceRemovableStatuses redirectStatuses = new InstanceRemovableStatuses();
+    redirectStatuses.setRedirectUrl("http://redirect.com");
+    doReturn(redirectStatuses).when(mockAdmin)
+        .getAggregatedHealthStatus(TEST_CLUSTER, instanceList, toBeStoppedInstanceList, false);
+    Response redirectResponse = mock(Response.class);
+    controllerRoutes.getAggregatedHealthStatus(mockAdmin).handle(request, redirectResponse);
+    verify(redirectResponse).redirect("http://redirect.com/aggregatedHealthStatus", 302);
+
+    // Test non-removable instances
+    Map<String, String> nonStoppableInstances = new HashMap() {
+      {
+        put("instance1_5000", "reason1");
+        put("instance2_5000", "reason2");
+      }
+    };
+    InstanceRemovableStatuses nonRemovableStatus = new InstanceRemovableStatuses();
+    nonRemovableStatus.setNonStoppableInstancesWithReasons(nonStoppableInstances);
+
+    doReturn(nonRemovableStatus).when(mockAdmin)
+        .getAggregatedHealthStatus(TEST_CLUSTER, instanceList, toBeStoppedInstanceList, false);
+    Response nonRemovableResponse = mock(Response.class);
+    StoppableNodeStatusResponse nonRemovableStoppableResponse = OBJECT_MAPPER.readValue(
+        controllerRoutes.getAggregatedHealthStatus(mockAdmin).handle(request, nonRemovableResponse).toString(),
+        StoppableNodeStatusResponse.class);
+    assertTrue(nonRemovableStoppableResponse.getStoppableInstances().isEmpty());
+    assertEquals(nonRemovableStoppableResponse.getNonStoppableInstancesWithReasons().size(), 2);
+    assertEquals(nonRemovableStoppableResponse.getNonStoppableInstancesWithReasons().get("instance1_5000"), "reason1");
+    assertEquals(nonRemovableStoppableResponse.getNonStoppableInstancesWithReasons().get("instance2_5000"), "reason2");
+
+    // Test removable instances
+    List<String> stoppableInstances = Arrays.asList("instance1_5000", "instance2_5000");
+    InstanceRemovableStatuses removableStatus = new InstanceRemovableStatuses();
+    removableStatus.setStoppableInstances(stoppableInstances);
+
+    doReturn(removableStatus).when(mockAdmin)
+        .getAggregatedHealthStatus(TEST_CLUSTER, instanceList, toBeStoppedInstanceList, false);
+    Response removableResponse = mock(Response.class);
+    StoppableNodeStatusResponse removableStoppableResponse = OBJECT_MAPPER.readValue(
+        controllerRoutes.getAggregatedHealthStatus(mockAdmin).handle(request, removableResponse).toString(),
+        StoppableNodeStatusResponse.class);
+    assertTrue(removableStoppableResponse.getNonStoppableInstancesWithReasons().isEmpty());
+    assertEquals(removableStoppableResponse.getStoppableInstances().size(), 2);
+    assertEquals(removableStoppableResponse.getStoppableInstances().get(0), "instance1_5000");
+    assertEquals(removableStoppableResponse.getStoppableInstances().get(1), "instance2_5000");
+
+    // Test removable and non removable instances
+    List<String> stoppableInstances1 = Arrays.asList("instance1_5000");
+    Map<String, String> nonStoppableInstances1 = new HashMap() {
+      {
+        put("instance2_5000", "reason2");
+      }
+    };
+
+    InstanceRemovableStatuses removableAndNonRemovableStatus = new InstanceRemovableStatuses();
+    removableAndNonRemovableStatus.setStoppableInstances(stoppableInstances1);
+    removableAndNonRemovableStatus.setNonStoppableInstancesWithReasons(nonStoppableInstances1);
+
+    doReturn(removableAndNonRemovableStatus).when(mockAdmin)
+        .getAggregatedHealthStatus(TEST_CLUSTER, instanceList, toBeStoppedInstanceList, false);
+    Response removableAndNonRemovableResponse = mock(Response.class);
+    StoppableNodeStatusResponse removableAndNonRemovableStoppableResponse = OBJECT_MAPPER.readValue(
+        controllerRoutes.getAggregatedHealthStatus(mockAdmin)
+            .handle(request, removableAndNonRemovableResponse)
+            .toString(),
+        StoppableNodeStatusResponse.class);
+    assertEquals(removableAndNonRemovableStoppableResponse.getNonStoppableInstancesWithReasons().size(), 1);
+    assertEquals(
+        removableAndNonRemovableStoppableResponse.getNonStoppableInstancesWithReasons().get("instance2_5000"),
+        "reason2");
+    assertEquals(removableAndNonRemovableStoppableResponse.getStoppableInstances().size(), 1);
+    assertEquals(removableAndNonRemovableStoppableResponse.getStoppableInstances().get(0), "instance1_5000");
   }
 }


### PR DESCRIPTION
<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## Log request and response body for aggregated stoppable check
<!--
Describe
- What changes to make and why you are making these changes.
- How are you going to achieve your goal.
- Describe what testings you have done, for example, performance testing etc.

If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->
Currently, controller logs audit logs for API requests and responses. These audit logs however, do not log the request body.
In the aggregated stoppable checks API endpoint, the request and response are JSON objects. This PR logs these objects to get visibility into these.

## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
Added unit tests

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [X] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.