### PR TITLE
[server] Tuned zstd compression level in ingestion

### DIFF
--- a/clients/da-vinci-client/build.gradle
+++ b/clients/da-vinci-client/build.gradle
@@ -39,6 +39,7 @@ dependencies {
   implementation libraries.kafkaClients
   implementation libraries.rocksdbjni
   implementation libraries.zkclient // It's necessary to pull in the most recent version of zkclient explicitly, otherwise Helix won't have it...
+  implementation libraries.zstd
 
   testImplementation project(':internal:venice-test-common')
   testImplementation project(':internal:venice-client-common').sourceSets.test.output

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/VersionBackend.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/VersionBackend.java
@@ -109,7 +109,11 @@ public class VersionBackend {
         backend.getConfigLoader().getCombinedProperties().getInt(SERVER_STOP_CONSUMPTION_TIMEOUT_IN_SECONDS, 60);
     this.storeDeserializerCache = backend.getStoreOrThrow(store.getName()).getStoreDeserializerCache();
     this.compressor = Lazy.of(
-        () -> backend.getCompressorFactory().getCompressor(version.getCompressionStrategy(), version.kafkaTopicName()));
+        () -> backend.getCompressorFactory()
+            .getCompressor(
+                version.getCompressionStrategy(),
+                version.kafkaTopicName(),
+                config.getZstdDictCompressionLevel()));
     backend.getVersionByTopicMap().put(version.kafkaTopicName(), this);
     long daVinciPushStatusCheckIntervalInMs = this.config.getDaVinciPushStatusCheckIntervalInMs();
     if (daVinciPushStatusCheckIntervalInMs >= 0) {

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/compression/StorageEngineBackedCompressorFactory.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/compression/StorageEngineBackedCompressorFactory.java
@@ -8,16 +8,22 @@ import com.linkedin.venice.compression.CompressorFactory;
 import com.linkedin.venice.compression.VeniceCompressor;
 import com.linkedin.venice.utils.ByteUtils;
 import java.nio.ByteBuffer;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 
 public class StorageEngineBackedCompressorFactory extends CompressorFactory {
+  private static final Logger LOGGER = LogManager.getLogger(StorageEngineBackedCompressorFactory.class);
   private final StorageMetadataService metadataService;
 
   public StorageEngineBackedCompressorFactory(StorageMetadataService metadataService) {
     this.metadataService = metadataService;
   }
 
-  public VeniceCompressor getCompressor(CompressionStrategy compressionStrategy, String kafkaTopic) {
+  public VeniceCompressor getCompressor(
+      CompressionStrategy compressionStrategy,
+      String kafkaTopic,
+      int dictCompressionLevel) {
     if (ZSTD_WITH_DICT.equals(compressionStrategy)) {
       VeniceCompressor compressor = getVersionSpecificCompressor(kafkaTopic);
       if (compressor != null) {
@@ -28,10 +34,12 @@ public class StorageEngineBackedCompressorFactory extends CompressorFactory {
       if (dictionary == null) {
         throw new IllegalStateException("Got a null dictionary for: " + kafkaTopic);
       }
+      LOGGER.info("Creating a dict compressor with dict level: {} for topic: {}", dictCompressionLevel, kafkaTopic);
       return super.createVersionSpecificCompressorIfNotExist(
           compressionStrategy,
           kafkaTopic,
-          ByteUtils.extractByteArray(dictionary));
+          ByteUtils.extractByteArray(dictionary),
+          dictCompressionLevel);
     } else {
       return getCompressor(compressionStrategy);
     }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTask.java
@@ -3111,8 +3111,11 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
     }
     if (shouldCompressData(partitionConsumptionState)) {
       try {
+        long startTimeInNS = System.nanoTime();
         // We need to expand the front of the returned bytebuffer to make room for schema header insertion
-        return compressor.get().compress(data, ByteUtils.SIZE_OF_INT);
+        ByteBuffer result = compressor.get().compress(data, ByteUtils.SIZE_OF_INT);
+        hostLevelIngestionStats.recordLeaderCompressLatency(LatencyUtils.getElapsedTimeFromNSToMS(startTimeInNS));
+        return result;
       } catch (IOException e) {
         // throw a loud exception if something goes wrong here
         throw new RuntimeException(

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
@@ -498,7 +498,9 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
     this.localKafkaClusterId = kafkaClusterUrlToIdMap.getOrDefault(localKafkaServer, Integer.MIN_VALUE);
     this.compressionStrategy = version.getCompressionStrategy();
     this.compressorFactory = builder.getCompressorFactory();
-    this.compressor = Lazy.of(() -> compressorFactory.getCompressor(compressionStrategy, kafkaVersionTopic));
+    this.compressor = Lazy.of(
+        () -> compressorFactory
+            .getCompressor(compressionStrategy, kafkaVersionTopic, serverConfig.getZstdDictCompressionLevel()));
     this.isChunked = version.isChunkingEnabled();
     this.isRmdChunked = version.isRmdChunkingEnabled();
     this.manifestSerializer = new ChunkedValueManifestSerializer(true);

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/HostLevelIngestionStats.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/HostLevelIngestionStats.java
@@ -145,6 +145,7 @@ public class HostLevelIngestionStats extends AbstractVeniceStats {
   private final LongAdderRateGauge totalTombstoneCreationDCRRate;
 
   private final Sensor leaderProduceLatencySensor;
+  private final Sensor leaderCompressLatencySensor;
   private final LongAdderRateGauge batchProcessingRequestSensor;
   private final Sensor batchProcessingRequestSizeSensor;
   private final LongAdderRateGauge batchProcessingRequestRecordsSensor;
@@ -454,6 +455,11 @@ public class HostLevelIngestionStats extends AbstractVeniceStats {
         totalStats,
         () -> totalStats.leaderProduceLatencySensor,
         avgAndMax());
+    this.leaderCompressLatencySensor = registerPerStoreAndTotalSensor(
+        "leader_compress_latency",
+        totalStats,
+        () -> totalStats.leaderCompressLatencySensor,
+        avgAndMax());
     this.batchProcessingRequestSensor = registerOnlyTotalRate(
         BATCH_PROCESSING_REQUEST,
         totalStats,
@@ -661,6 +667,10 @@ public class HostLevelIngestionStats extends AbstractVeniceStats {
 
   public void recordLeaderProduceLatency(double latency) {
     leaderProduceLatencySensor.record(latency);
+  }
+
+  public void recordLeaderCompressLatency(double latency) {
+    leaderCompressLatencySensor.record(latency);
   }
 
   public void recordBatchProcessingRequest(int size) {

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/storage/chunking/ChunkingTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/storage/chunking/ChunkingTest.java
@@ -4,6 +4,7 @@ import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.mock;
 
+import com.github.luben.zstd.Zstd;
 import com.linkedin.davinci.compression.StorageEngineBackedCompressorFactory;
 import com.linkedin.davinci.listener.response.NoOpReadResponseStats;
 import com.linkedin.davinci.storage.StorageMetadataService;
@@ -225,8 +226,10 @@ public class ChunkingTest {
     int readerSchemaId = schemaEntry.getId();
     try (StorageEngineBackedCompressorFactory compressorFactory =
         new StorageEngineBackedCompressorFactory(mock(StorageMetadataService.class))) {
-      VeniceCompressor compressor =
-          compressorFactory.getCompressor(CompressionStrategy.NO_OP, storageEngine.getStoreVersionName());
+      VeniceCompressor compressor = compressorFactory.getCompressor(
+          CompressionStrategy.NO_OP,
+          storageEngine.getStoreVersionName(),
+          Zstd.defaultCompressionLevel());
       Object retrievedObject;
       if (getWithSchemaId) {
         retrievedObject = chunkingAdapter.getWithSchemaId(

--- a/internal/venice-common/src/main/java/com/linkedin/venice/ConfigKeys.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/ConfigKeys.java
@@ -2326,4 +2326,6 @@ public class ConfigKeys {
    */
   public static final String SERVER_NEARLINE_WORKLOAD_PRODUCER_THROUGHPUT_OPTIMIZATION_ENABLED =
       "server.nearline.workload.producer.throughput.optimization.enabled";
+
+  public static final String SERVER_ZSTD_DICT_COMPRESSION_LEVEL = "server.zstd.dict.compression.level";
 }

--- a/services/venice-server/src/main/java/com/linkedin/venice/listener/StorageReadRequestHandler.java
+++ b/services/venice-server/src/main/java/com/linkedin/venice/listener/StorageReadRequestHandler.java
@@ -690,8 +690,10 @@ public class StorageReadRequestHandler extends ChannelInboundHandlerAdapter {
       this.valueSchemaEntry = handler.getComputeValueSchema(request);
       this.resultSchema = handler.getComputeResultSchema(request.getComputeRequest(), valueSchemaEntry.getSchema());
       this.resultSerializer = handler.genericSerializerGetter.apply(resultSchema);
-      this.compressor = handler.compressorFactory
-          .getCompressor(storeVersion.storageEngine.getCompressionStrategy(), request.getResourceName());
+      this.compressor = handler.compressorFactory.getCompressor(
+          storeVersion.storageEngine.getCompressionStrategy(),
+          request.getResourceName(),
+          handler.serverConfig.getZstdDictCompressionLevel());
       this.operations = request.getComputeRequest().getOperations();
       this.operationResultFields = ComputeUtils.getOperationResultFields(operations, resultSchema);
     }

--- a/services/venice-server/src/test/java/com/linkedin/venice/listener/StorageReadRequestHandlerTest.java
+++ b/services/venice-server/src/test/java/com/linkedin/venice/listener/StorageReadRequestHandlerTest.java
@@ -202,7 +202,7 @@ public class StorageReadRequestHandlerTest {
     doReturn(partitionerConfig).when(version).getPartitionerConfig();
 
     doReturn(storageEngine).when(storageEngineRepository).getLocalStorageEngine(any());
-    doReturn(new NoopCompressor()).when(compressorFactory).getCompressor(any(), any());
+    doReturn(new NoopCompressor()).when(compressorFactory).getCompressor(any(), any(), anyInt());
 
     RocksDBServerConfig rocksDBServerConfig = mock(RocksDBServerConfig.class);
     doReturn(rocksDBServerConfig).when(serverConfig).getRocksDBServerConfig();


### PR DESCRIPTION


<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## Summary, imperative, start upper case, don't end with a period
Previously, Venice Server is always using the max compression level(22) to compress the payload, which is very slow and this PR will change the compression level to the default level (3) by default, and the compression speedup is roughly 10-20x and it might introduce some more storage overhead, 5-10%, but it should be fine.

This PR doesn't change the compression level in batch push as it is offline, and if we see a need to speed up the map-reduce phase, we can do the same later.

New Server Config:
server.zstd.dict.compression.level: default 3

New metric:
leader_compress_latency
<!--
Describe
- What changes to make and why you are making these changes.
- How are you going to achieve your goal.
- Describe what testings you have done, for example, performance testing etc.

If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->


## How was this PR tested?
CI
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.