### PR TITLE
[test] Make StoreIngestionTask::testStartServerAndShutdownWithPartitionAssignmentVerification & testCheckBeforeJoinCluster less flaky

### DIFF
--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/server/VeniceServerTest.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/server/VeniceServerTest.java
@@ -209,7 +209,7 @@ public class VeniceServerTest {
       cluster.restartVeniceServer(server.getPort());
 
       TestUtils.waitForNonDeterministicAssertion(
-          3,
+          30,
           TimeUnit.SECONDS,
           () -> Assert.assertEquals(storageService.getStorageEngine(storeName).getPartitionIds().size(), 0));
     }

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/server/VeniceServerTest.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/server/VeniceServerTest.java
@@ -153,6 +153,7 @@ public class VeniceServerTest {
       }
 
       cluster.restartVeniceServer(server.getPort());
+      TestUtils.waitForNonDeterministicAssertion(10, TimeUnit.SECONDS, () -> Assert.assertTrue(server.isRunning()));
 
       TestUtils.waitForNonDeterministicAssertion(
           30,

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/server/VeniceServerTest.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/server/VeniceServerTest.java
@@ -207,13 +207,11 @@ public class VeniceServerTest {
       cluster.addVeniceServer(featureProperties, new Properties());
 
       cluster.restartVeniceServer(server.getPort());
-      StorageEngineRepository storageEngineRepository =
-          server.getVeniceServer().getStorageService().getStorageEngineRepository();
 
       TestUtils.waitForNonDeterministicAssertion(
           3,
           TimeUnit.SECONDS,
-          () -> Assert.assertEquals(storageEngineRepository.getAllLocalStorageEngines().size(), 0));
+          () -> Assert.assertEquals(storageService.getStorageEngine(storeName).getPartitionIds().size(), 0));
     }
   }
 

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/server/VeniceServerTest.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/server/VeniceServerTest.java
@@ -153,7 +153,7 @@ public class VeniceServerTest {
       cluster.getLeaderVeniceController()
           .getVeniceHelixAdmin()
           .getHelixAdminClient()
-          .manuallyEnableMaintenanceMode(cluster.getClusterName(), false, "Prevent nodes from re-joining", null);
+          .manuallyEnableMaintenanceMode(cluster.getClusterName(), true, "Prevent nodes from re-joining", null);
 
       cluster.restartVeniceServer(server.getPort());
       TestUtils.waitForNonDeterministicAssertion(10, TimeUnit.SECONDS, () -> Assert.assertTrue(server.isRunning()));

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/server/VeniceServerTest.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/server/VeniceServerTest.java
@@ -145,6 +145,9 @@ public class VeniceServerTest {
       }
 
       cluster.restartVeniceServer(server.getPort());
+
+      TestUtils.waitForNonDeterministicAssertion(10, TimeUnit.SECONDS, () -> Assert.assertTrue(server.isRunning()));
+
       Assert.assertTrue(
           server.getVeniceServer()
               .getStorageService()

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/HelixAdminClient.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/HelixAdminClient.java
@@ -133,4 +133,14 @@ public interface HelixAdminClient {
    * Release resources.
    */
   void close();
+
+  /**
+   * Manually enable maintenance mode. To be called by the REST client that accepts KV mappings as
+   * the payload.
+   */
+  void manuallyEnableMaintenanceMode(
+      String clusterName,
+      boolean enabled,
+      String reason,
+      Map<String, String> customFields);
 }

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/ZkHelixAdminClient.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/ZkHelixAdminClient.java
@@ -333,4 +333,15 @@ public class ZkHelixAdminClient implements HelixAdminClient {
   public void close() {
     helixAdmin.close();
   }
+
+  /**
+   * @see HelixAdminClient#manuallyEnableMaintenanceMode(String, boolean, String, Map<String, String>)
+   */
+  public void manuallyEnableMaintenanceMode(
+      String clusterName,
+      boolean enabled,
+      String reason,
+      Map<String, String> customFields) {
+    helixAdmin.manuallyEnableMaintenanceMode(clusterName, enabled, reason, customFields);
+  }
 }


### PR DESCRIPTION
<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## Summary, imperative, start upper case, don't end with a period
<!--
Describe
- What changes to make and why you are making these changes.
- How are you going to achieve your goal.
- Describe what testings you have done, for example, performance testing etc.

If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->
Make `StoreIngestionTask::testStartServerAndShutdownWithPartitionAssignmentVerification` less flaky by checking that the number of partitions is 0 instead of storageEngines is 0. This is because after the node comes online, Helix tries to re-assign partitions to it immediately, which re-creates the storageEngine.

Also made `StoreIngestionTask::testCheckBeforeJoinCluster` less flaky by turning on maintenance mode on the Helix cluster after removing the node from the cluster.

## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
CI

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [X] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.