### PR TITLE
[server][dvc] Increase graceful shutdown time for Da Vinci to reduce timeout exception

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/KafkaStoreIngestionService.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/KafkaStoreIngestionService.java
@@ -676,7 +676,7 @@ public class KafkaStoreIngestionService extends AbstractVeniceService implements
     try (AutoCloseableLock ignore = topicLockManager.getLockForResource(topicName)) {
       StoreIngestionTask storeIngestionTask = topicNameToIngestionTaskMap.remove(topicName);
       if (storeIngestionTask != null) {
-        storeIngestionTask.shutdown(30);
+        storeIngestionTask.shutdownAndWait(30);
         LOGGER.info("Successfully shut down ingestion task for {}", topicName);
       } else {
         LOGGER.info("Ignoring close request for not-existing consumption task {}", topicName);

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/KafkaStoreIngestionService.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/KafkaStoreIngestionService.java
@@ -674,9 +674,9 @@ public class KafkaStoreIngestionService extends AbstractVeniceService implements
    */
   public void shutdownStoreIngestionTask(String topicName) {
     try (AutoCloseableLock ignore = topicLockManager.getLockForResource(topicName)) {
-      if (topicNameToIngestionTaskMap.containsKey(topicName)) {
-        StoreIngestionTask storeIngestionTask = topicNameToIngestionTaskMap.remove(topicName);
-        storeIngestionTask.shutdown(10000);
+      StoreIngestionTask storeIngestionTask = topicNameToIngestionTaskMap.remove(topicName);
+      if (storeIngestionTask != null) {
+        storeIngestionTask.shutdown(30);
         LOGGER.info("Successfully shut down ingestion task for {}", topicName);
       } else {
         LOGGER.info("Ignoring close request for not-existing consumption task {}", topicName);

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
@@ -3917,7 +3917,7 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
    * This method is a blocking call to wait for {@link StoreIngestionTask} for fully shutdown in the given time.
    * @param waitTime Maximum wait time for the shutdown operation.
    */
-  public synchronized void shutdown(int waitTime) {
+  public void shutdownAndWait(int waitTime) {
     long startTimeInMs = System.currentTimeMillis();
     close();
     try {

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
@@ -1608,8 +1608,9 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
          * to avoid infinite wait in case there is some regression.
          */
         CompletableFuture.allOf(shutdownFutures.toArray(new CompletableFuture[0])).get(60, SECONDS);
-        getGracefulShutdownLatch().countDown();
       }
+      // Release the latch after all the shutdown completes in DVC/Server.
+      getGracefulShutdownLatch().countDown();
     } catch (VeniceIngestionTaskKilledException e) {
       LOGGER.info("{} has been killed.", ingestionTaskName);
       ingestionNotificationDispatcher.reportKilled(partitionConsumptionStateMap.values(), e);

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
@@ -4392,7 +4392,7 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
     return true;
   }
 
-  public CountDownLatch getGracefulShutdownLatch() {
+  CountDownLatch getGracefulShutdownLatch() {
     return gracefulShutdownLatch;
   }
 

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
@@ -3922,7 +3922,7 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
     close();
     try {
       if (!getGracefulShutdownLatch().await(waitTime, SECONDS)) {
-        LOGGER.info(
+        LOGGER.warn(
             "Unable to shutdown ingestion task of topic: {} gracefully in {}ms",
             kafkaVersionTopic,
             SECONDS.toMillis(waitTime));

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestTopicWiseSharedConsumerPoolResilience.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestTopicWiseSharedConsumerPoolResilience.java
@@ -102,7 +102,7 @@ public class TestTopicWiseSharedConsumerPoolResilience {
           // resource when participant store task is not working.
           String resourceNameForBackupVersion = Version.composeKafkaTopic(storeName, (cur - 2));
           TestUtils.waitForNonDeterministicCompletion(
-              10,
+              30,
               TimeUnit.SECONDS,
               () -> !admin.isResourceStillAlive(resourceNameForBackupVersion));
         }

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestTopicWiseSharedConsumerPoolResilience.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestTopicWiseSharedConsumerPoolResilience.java
@@ -102,7 +102,7 @@ public class TestTopicWiseSharedConsumerPoolResilience {
           // resource when participant store task is not working.
           String resourceNameForBackupVersion = Version.composeKafkaTopic(storeName, (cur - 2));
           TestUtils.waitForNonDeterministicCompletion(
-              30,
+              10,
               TimeUnit.SECONDS,
               () -> !admin.isResourceStillAlive(resourceNameForBackupVersion));
         }


### PR DESCRIPTION
## [server][dvc] Increase graceful shutdown time for Da Vinci to reduce timeout exception
For Da Vinci, when we close / retire a version, it will call shutdownIngestionTask API, which will try to unsubscribe and sync offset for graceful shutdown. Today the timeout is 10 seconds and it could timeout for topic with many partition assignment.
This will result in two kinds of exceptions:
1. When it is doing graceful shutdown and syncing offset, it may fail after the wait timeout as it will also remove storage engine
2. It may also failed to persist certain lingering data in drainer after timeout. 

This PR tries to do minimal changes to reduce the noises in application that runs DVC by increasing the total timeout for per SIT shutdown wait. 

## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
N/A
## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.