### PR TITLE
[controller] Fix node removable check with locked instances

### DIFF
--- a/internal/venice-common/src/main/java/com/linkedin/venice/controllerapi/ControllerApiConstants.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/controllerapi/ControllerApiConstants.java
@@ -31,7 +31,6 @@ public class ControllerApiConstants {
   public static final String INSTANCES = "instances";
   public static final String TO_BE_STOPPED_INSTANCES = "to_be_stopped_instances";
 
-  public static final String INSTANCE_VIEW = "instance_view";
   public static final String KEY_SCHEMA = "key_schema";
   public static final String VALUE_SCHEMA = "value_schema";
   public static final String DERIVED_SCHEMA = "derived_schema";
@@ -205,8 +204,6 @@ public class ControllerApiConstants {
    * source fabric is included in the request body as byte array or not.
    */
   public static final String SOURCE_FABRIC_VERSION_INCLUDED = "source.fabric.version.included";
-
-  public static final String LOCKED_NODE_ID_LIST_SEPARATOR = ",";
 
   public static final String KAFKA_TOPIC_LOG_COMPACTION_ENABLED = "kafka.topic.log.compaction.enabled";
   public static final String KAFKA_TOPIC_RETENTION_IN_MS = "kafka.topic.retention.in.ms";

--- a/internal/venice-common/src/main/java/com/linkedin/venice/controllerapi/ControllerClient.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/controllerapi/ControllerClient.java
@@ -26,7 +26,6 @@ import static com.linkedin.venice.controllerapi.ControllerApiConstants.KAFKA_TOP
 import static com.linkedin.venice.controllerapi.ControllerApiConstants.KAFKA_TOPIC_MIN_IN_SYNC_REPLICA;
 import static com.linkedin.venice.controllerapi.ControllerApiConstants.KAFKA_TOPIC_RETENTION_IN_MS;
 import static com.linkedin.venice.controllerapi.ControllerApiConstants.KEY_SCHEMA;
-import static com.linkedin.venice.controllerapi.ControllerApiConstants.LOCKED_NODE_ID_LIST_SEPARATOR;
 import static com.linkedin.venice.controllerapi.ControllerApiConstants.NAME;
 import static com.linkedin.venice.controllerapi.ControllerApiConstants.OFFSET;
 import static com.linkedin.venice.controllerapi.ControllerApiConstants.OPERATION;
@@ -893,8 +892,8 @@ public class ControllerClient implements Closeable {
   }
 
   public NodeStatusResponse isNodeRemovable(String instanceId, List<String> lockedNodeIds) {
-    QueryParams params = newParams().add(STORAGE_NODE_ID, instanceId)
-        .add(TO_BE_STOPPED_INSTANCES, String.join(LOCKED_NODE_ID_LIST_SEPARATOR, lockedNodeIds));
+    QueryParams params =
+        newParams().add(STORAGE_NODE_ID, instanceId).add(TO_BE_STOPPED_INSTANCES, String.join(",", lockedNodeIds));
     return request(ControllerRoute.NODE_REMOVABLE, params, NodeStatusResponse.class);
   }
 

--- a/internal/venice-common/src/main/java/com/linkedin/venice/controllerapi/ControllerRoute.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/controllerapi/ControllerRoute.java
@@ -34,7 +34,6 @@ import static com.linkedin.venice.controllerapi.ControllerApiConstants.HYBRID_ST
 import static com.linkedin.venice.controllerapi.ControllerApiConstants.HYBRID_STORE_OVERHEAD_BYPASS;
 import static com.linkedin.venice.controllerapi.ControllerApiConstants.INCLUDE_SYSTEM_STORES;
 import static com.linkedin.venice.controllerapi.ControllerApiConstants.INCREMENTAL_PUSH_ENABLED;
-import static com.linkedin.venice.controllerapi.ControllerApiConstants.INSTANCE_VIEW;
 import static com.linkedin.venice.controllerapi.ControllerApiConstants.IS_SYSTEM_STORE;
 import static com.linkedin.venice.controllerapi.ControllerApiConstants.KAFKA_TOPIC_LOG_COMPACTION_ENABLED;
 import static com.linkedin.venice.controllerapi.ControllerApiConstants.KAFKA_TOPIC_MIN_IN_SYNC_REPLICA;
@@ -157,8 +156,7 @@ public enum ControllerRoute {
   ), LIST_REPLICAS("/list_replicas", HttpMethod.GET, Arrays.asList(NAME, VERSION)),
   NODE_REPLICAS("/storage_node_replicas", HttpMethod.GET, Collections.singletonList(STORAGE_NODE_ID)),
   NODE_REMOVABLE(
-      "/node_removable", HttpMethod.GET, Collections.singletonList(STORAGE_NODE_ID), INSTANCE_VIEW,
-      TO_BE_STOPPED_INSTANCES
+      "/node_removable", HttpMethod.GET, Collections.singletonList(STORAGE_NODE_ID), TO_BE_STOPPED_INSTANCES
   ), NODE_REPLICAS_READINESS("/node_replicas_readiness", HttpMethod.GET, Collections.singletonList(STORAGE_NODE_ID)),
   ALLOW_LIST_ADD_NODE("/allow_list_add_node", HttpMethod.POST, Collections.singletonList(STORAGE_NODE_ID)),
   ALLOW_LIST_REMOVE_NODE("/allow_list_remove_node", HttpMethod.POST, Collections.singletonList(STORAGE_NODE_ID)),

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/controller/TestInstanceRemovable.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/controller/TestInstanceRemovable.java
@@ -326,7 +326,7 @@ public class TestInstanceRemovable {
             .equals(ExecutionStatus.COMPLETED));
     int serverPort1 = cluster.getVeniceServers().get(0).getPort();
     String nodeID = Utils.getHelixNodeIdentifier(Utils.getHostName(), serverPort1);
-    Assert.assertFalse(veniceAdmin.isInstanceRemovable(clusterName, nodeID, new ArrayList<>(), false).isRemovable());
+    Assert.assertFalse(veniceAdmin.isInstanceRemovable(clusterName, nodeID, new ArrayList<>()).isRemovable());
     // Add a new node and increase the replica count to 2.
     cluster.addVeniceServer(new Properties(), new Properties());
     TestUtils.waitForNonDeterministicCompletion(
@@ -357,7 +357,7 @@ public class TestInstanceRemovable {
             .getExecutionStatus()
             .equals(ExecutionStatus.COMPLETED));
     // The old instance should now be removable because its replica is no longer the current version.
-    Assert.assertTrue(veniceAdmin.isInstanceRemovable(clusterName, nodeID, new ArrayList<>(), false).isRemovable());
+    Assert.assertTrue(veniceAdmin.isInstanceRemovable(clusterName, nodeID, new ArrayList<>()).isRemovable());
   }
 
   @Test
@@ -407,10 +407,8 @@ public class TestInstanceRemovable {
     storeRepository.updateStore(store);
 
     // Enough number of replicas, any of instance is able to moved out.
-    Assert.assertTrue(
-        veniceAdmin.isInstanceRemovable(clusterName, nodeId1, Collections.emptyList(), false).isRemovable());
-    Assert.assertTrue(
-        veniceAdmin.isInstanceRemovable(clusterName, nodeId2, Collections.emptyList(), false).isRemovable());
+    Assert.assertTrue(veniceAdmin.isInstanceRemovable(clusterName, nodeId1, Collections.emptyList()).isRemovable());
+    Assert.assertTrue(veniceAdmin.isInstanceRemovable(clusterName, nodeId2, Collections.emptyList()).isRemovable());
 
     // Shutdown one instance
     cluster.stopVeniceServer(serverPort1);
@@ -424,9 +422,9 @@ public class TestInstanceRemovable {
     });
 
     Assert.assertTrue(
-        veniceAdmin.isInstanceRemovable(clusterName, nodeId1, new ArrayList<>(), false).isRemovable(),
+        veniceAdmin.isInstanceRemovable(clusterName, nodeId1, new ArrayList<>()).isRemovable(),
         "Instance is shutdown.");
-    NodeRemovableResult result = veniceAdmin.isInstanceRemovable(clusterName, nodeId2, new ArrayList<>(), false);
+    NodeRemovableResult result = veniceAdmin.isInstanceRemovable(clusterName, nodeId2, new ArrayList<>());
     Assert.assertFalse(result.isRemovable(), "Only one instance is alive, can not be moved out.");
     Assert.assertEquals(result.getBlockingReason(), NodeRemovableResult.BlockingRemoveReason.WILL_LOSE_DATA.toString());
   }

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/helixrebalance/TestRebalanceByDefaultStrategy.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/helixrebalance/TestRebalanceByDefaultStrategy.java
@@ -94,7 +94,7 @@ public class TestRebalanceByDefaultStrategy {
         try {
           if (cluster.getLeaderVeniceController()
               .getVeniceAdmin()
-              .isInstanceRemovable(clusterName, instanceId, Collections.emptyList(), false)
+              .isInstanceRemovable(clusterName, instanceId, Collections.emptyList())
               .isRemovable()) {
             cluster.stopVeniceServer(port);
             Thread.sleep(UPGRADE_TIME_MS);

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/Admin.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/Admin.java
@@ -571,18 +571,11 @@ public interface Admin extends AutoCloseable, Closeable {
    * This instance should not be removed out of cluster, otherwise Venice will lose data.
    * For detail criteria please refer to {@link InstanceStatusDecider}
    *
+   * @param clusterName The cluster were the hosts belong.
    * @param helixNodeId nodeId of helix participant. HOST_PORT.
    * @param lockedNodes A list of helix nodeIds whose resources are assumed to be unusable (stopped).
-   * @param isFromInstanceView If the value is true, it means we will only check the partitions this instance hold.
-   *                           E.g. if all replicas of a partition are error, but this instance does not hold any
-   *                           replica in this partition, we will skip this partition in the checking.
-   *                           If the value is false, we will check all partitions of resources this instance hold.
    */
-  NodeRemovableResult isInstanceRemovable(
-      String clusterName,
-      String helixNodeId,
-      List<String> lockedNodes,
-      boolean isFromInstanceView);
+  NodeRemovableResult isInstanceRemovable(String clusterName, String helixNodeId, List<String> lockedNodes);
 
   /**
    * Get instance of leader controller. If there is no leader controller for the given cluster, throw a

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceHelixAdmin.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceHelixAdmin.java
@@ -6685,21 +6685,13 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
   }
 
   /**
-   * @see Admin#isInstanceRemovable(String, String, List, boolean)
+   * @see Admin#isInstanceRemovable(String, String, List)
    */
   @Override
-  public NodeRemovableResult isInstanceRemovable(
-      String clusterName,
-      String helixNodeId,
-      List<String> lockedNodes,
-      boolean isFromInstanceView) {
+  public NodeRemovableResult isInstanceRemovable(String clusterName, String helixNodeId, List<String> lockedNodes) {
     checkControllerLeadershipFor(clusterName);
-    return InstanceStatusDecider.isRemovable(
-        getHelixVeniceClusterResources(clusterName),
-        clusterName,
-        helixNodeId,
-        lockedNodes,
-        isFromInstanceView);
+    return InstanceStatusDecider
+        .isRemovable(getHelixVeniceClusterResources(clusterName), clusterName, helixNodeId, lockedNodes);
   }
 
   /**

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceParentHelixAdmin.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceParentHelixAdmin.java
@@ -3903,11 +3903,7 @@ public class VeniceParentHelixAdmin implements Admin {
    * Unsupported operation in the parent controller.
    */
   @Override
-  public NodeRemovableResult isInstanceRemovable(
-      String clusterName,
-      String instanceId,
-      List<String> lockedNodes,
-      boolean isFromInstanceView) {
+  public NodeRemovableResult isInstanceRemovable(String clusterName, String instanceId, List<String> lockedNodes) {
     throw new VeniceException("isInstanceRemovable is not supported!");
   }
 

--- a/services/venice-controller/src/test/java/com/linkedin/venice/controller/TestInstanceStatusDecider.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/controller/TestInstanceStatusDecider.java
@@ -70,14 +70,26 @@ public class TestInstanceStatusDecider {
     doReturn(mockMonitor).when(resources).getPushMonitor();
     doReturn(manager).when(resources).getHelixManager();
     doReturn(accessor).when(manager).getHelixDataAccessor();
-    doReturn(new LiveInstance("test")).when(accessor).getProperty(any(PropertyKey.class));
+    doReturn(new LiveInstance("test_1")).when(accessor).getProperty(any(PropertyKey.class));
   }
 
   @Test
   public void testIsRemovableNonLiveInstance() {
+    String liveInstanceId = "localhost_1";
+    String nonLiveInstanceId = "test_1";
+    List<Instance> instances = new ArrayList<>();
+    instances.add(Instance.fromNodeId(liveInstanceId));
+
+    EnumMap<HelixState, List<Instance>> helixStateToInstancesMap = new EnumMap<>(HelixState.class);
+    helixStateToInstancesMap.put(HelixState.LEADER, instances);
+    EnumMap<ExecutionStatus, List<Instance>> executionStatusToInstancesMap = new EnumMap<>(ExecutionStatus.class);
+    executionStatusToInstancesMap.put(ExecutionStatus.STARTED, instances);
+    PartitionAssignment partitionAssignment = prepareAssignments(resourceName);
+    partitionAssignment.addPartition(new Partition(0, helixStateToInstancesMap, executionStatusToInstancesMap));
+
     doReturn(null).when(accessor).getProperty(any(PropertyKey.class));
     Assert.assertTrue(
-        InstanceStatusDecider.isRemovable(resources, clusterName, "test").isRemovable(),
+        InstanceStatusDecider.isRemovable(resources, clusterName, nonLiveInstanceId).isRemovable(),
         "A non-alive instance should be removable from cluster");
   }
 
@@ -87,45 +99,10 @@ public class TestInstanceStatusDecider {
    */
   @Test
   public void testIsRemovableLossData() {
-    String onlineInstanceId = "localhost_1";
-    String bootstrapInstanceId = "localhost_2";
-    PartitionAssignment partitionAssignment = prepareAssignments(resourceName);
-    List<Instance> onlineInstances = new ArrayList<>();
-    onlineInstances.add(Instance.fromNodeId(onlineInstanceId));
-    List<Instance> bootstrapInstances = new ArrayList<>();
-    bootstrapInstances.add(Instance.fromNodeId(bootstrapInstanceId));
-
-    EnumMap<HelixState, List<Instance>> helixStateToInstancesMap = new EnumMap<>(HelixState.class);
-    helixStateToInstancesMap.put(HelixState.LEADER, onlineInstances);
-    helixStateToInstancesMap.put(HelixState.STANDBY, bootstrapInstances);
-
-    EnumMap<ExecutionStatus, List<Instance>> executionStatusToInstancesMap = new EnumMap<>(ExecutionStatus.class);
-    executionStatusToInstancesMap.put(ExecutionStatus.COMPLETED, onlineInstances);
-    executionStatusToInstancesMap.put(ExecutionStatus.STARTED, bootstrapInstances);
-    partitionAssignment.addPartition(new Partition(0, helixStateToInstancesMap, executionStatusToInstancesMap));
-
-    // Test the completed push.
-    prepareStoreAndVersion(storeName, version, VersionStatus.ONLINE, true, 2);
-    NodeRemovableResult bootstrapInstanceIsRemovable =
-        InstanceStatusDecider.isRemovable(resources, clusterName, bootstrapInstanceId);
-    Assert.assertTrue(
-        bootstrapInstanceIsRemovable.isRemovable(),
-        bootstrapInstanceId + " could be removed because it's not the last online copy: "
-            + bootstrapInstanceIsRemovable.getDetails());
-    NodeRemovableResult onlineInstanceIsRemovable =
-        InstanceStatusDecider.isRemovable(resources, clusterName, onlineInstanceId);
-    Assert.assertFalse(
-        onlineInstanceIsRemovable.isRemovable(),
-        onlineInstanceId + " could NOT be removed because it the last online copy: "
-            + onlineInstanceIsRemovable.getDetails());
-
-  }
-
-  @Test
-  public void testIsRemovableLossDataInstanceView() {
     int partitionCount = 2;
     String instance1Name = "localhost_1";
     String instance2Name = "localhost_2";
+    String instance3Name = "localhost_3";
     Instance instance1 = Instance.fromNodeId(instance1Name);
     Instance instance2 = Instance.fromNodeId(instance2Name);
 
@@ -151,17 +128,31 @@ public class TestInstanceStatusDecider {
     // Test the completed push.
     prepareStoreAndVersion(storeName, version, VersionStatus.ONLINE, true, 2);
     Assert.assertTrue(
-        InstanceStatusDecider.isRemovable(resources, clusterName, instance1Name, Collections.emptyList(), true)
-            .isRemovable(),
-        instance1Name + "could be removed because it's not the last online copy in the instance's point of view.");
+        InstanceStatusDecider.isRemovable(resources, clusterName, instance1Name, Collections.emptyList()).isRemovable(),
+        instance1Name + " could be removed because it's not the last online copy.");
     Assert.assertFalse(
-        InstanceStatusDecider.isRemovable(resources, clusterName, instance2Name, Collections.emptyList(), true)
+        InstanceStatusDecider.isRemovable(resources, clusterName, instance2Name, Collections.emptyList()).isRemovable(),
+        instance2Name + " could NOT be removed because it the last online copy for partition 1.");
+
+    // Locked node check when locked instance doesn't share any replica with the instance being removed
+    Assert.assertTrue(
+        InstanceStatusDecider
+            .isRemovable(resources, clusterName, instance1Name, Collections.singletonList(instance3Name))
             .isRemovable(),
-        instance2Name + "could NOT be removed because it the last online copy in the instance's point of view.");
+        instance1Name + " could be removed because it's not the last online copy.");
     Assert.assertFalse(
-        InstanceStatusDecider.isRemovable(resources, clusterName, instance1Name).isRemovable(),
-        instance1Name
-            + "could NOT be removed because in the cluster's point of view, partition 1 does not have any online replica alive.");
+        InstanceStatusDecider
+            .isRemovable(resources, clusterName, instance2Name, Collections.singletonList(instance3Name))
+            .isRemovable(),
+        instance2Name + " could NOT be removed because it the last online copy for partition 1.");
+
+    // Locked node check when locked instance shares replicas with the instance being removed
+    Assert.assertFalse(
+        InstanceStatusDecider
+            .isRemovable(resources, clusterName, instance1Name, Collections.singletonList(instance2Name))
+            .isRemovable(),
+        instance1Name + " could NOT be removed because it will be the last online copy after " + instance2Name
+            + " is removed.");
   }
 
   /**
@@ -194,83 +185,65 @@ public class TestInstanceStatusDecider {
    */
   @Test
   public void testIsRemovableTriggerRebalance() {
-    int replicationFactor = 3;
-    List<Instance> instances = new ArrayList<>();
-    for (int i = 1; i <= replicationFactor; i++) {
-      instances.add(Instance.fromNodeId("localhost_" + i));
-    }
-
-    PartitionAssignment partitionAssignment = prepareAssignments(resourceName);
-    EnumMap<HelixState, List<Instance>> helixStateToInstancesMapForP0 = new EnumMap<>(HelixState.class);
-    helixStateToInstancesMapForP0.put(HelixState.LEADER, Arrays.asList(instances.get(0)));
-    helixStateToInstancesMapForP0.put(HelixState.STANDBY, Arrays.asList(instances.get(1), instances.get(2)));
-    EnumMap<ExecutionStatus, List<Instance>> executionStatusToInstancesMapForP0 = new EnumMap<>(ExecutionStatus.class);
-    executionStatusToInstancesMapForP0.put(ExecutionStatus.COMPLETED, instances);
-    partitionAssignment
-        .addPartition(new Partition(0, helixStateToInstancesMapForP0, executionStatusToInstancesMapForP0));
-
-    prepareStoreAndVersion(storeName, version, VersionStatus.ONLINE, true, 3);
-    Assert.assertTrue(
-        InstanceStatusDecider.isRemovable(resources, clusterName, "localhost_1").isRemovable(),
-        "Instance should be removable because after removing one instance, there are still 2 active replicas, it will not trigger re-balance.");
-
-    // Remove one instance
-    helixStateToInstancesMapForP0 = new EnumMap<>(HelixState.class);
-    helixStateToInstancesMapForP0.put(HelixState.LEADER, Arrays.asList(instances.get(0)));
-    helixStateToInstancesMapForP0.put(HelixState.STANDBY, Arrays.asList(instances.get(1)));
-    executionStatusToInstancesMapForP0 = new EnumMap<>(ExecutionStatus.class);
-    executionStatusToInstancesMapForP0
-        .put(ExecutionStatus.COMPLETED, Arrays.asList(instances.get(0), instances.get(1)));
-    partitionAssignment
-        .addPartition(new Partition(0, helixStateToInstancesMapForP0, executionStatusToInstancesMapForP0));
-
-    prepareStoreAndVersion(storeName, version, VersionStatus.ONLINE, true, 3);
-    NodeRemovableResult result = InstanceStatusDecider.isRemovable(resources, clusterName, "localhost_1");
-    Assert.assertFalse(
-        result.isRemovable(),
-        "Instance should NOT be removable because after removing one instance, there are only 1 active replica, it will not trigger re-balance.");
-    Assert.assertEquals(
-        result.getBlockingReason(),
-        NodeRemovableResult.BlockingRemoveReason.WILL_TRIGGER_LOAD_REBALANCE.toString(),
-        "Instance should NOT be removable because after removing one instance, there are only 1 active replica, it will not trigger re-balance.");
-
-  }
-
-  @Test
-  public void testIsRemovableTriggerRebalanceInstanceView() {
     int partitionCount = 2;
-    int replicationFactor = 3;
+    String instance1Name = "localhost_1";
+    Instance instance1 = Instance.fromNodeId(instance1Name);
+
+    String instance2Name = "localhost_2";
+    Instance instance2 = Instance.fromNodeId(instance2Name);
+
+    String instance3Name = "localhost_3";
+    Instance instance3 = Instance.fromNodeId(instance3Name);
+
+    String instance4Name = "localhost_4";
+    Instance instance4 = Instance.fromNodeId(instance4Name);
+
+    String instance5Name = "localhost_5";
+
     PartitionAssignment partitionAssignment = prepareMultiPartitionAssignments(resourceName, partitionCount);
 
-    List<Instance> instances = new ArrayList<>();
-    for (int i = 1; i <= replicationFactor; i++) {
-      instances.add(Instance.fromNodeId("localhost_" + i));
-    }
-
     EnumMap<HelixState, List<Instance>> helixStateToInstancesMapForP0 = new EnumMap<>(HelixState.class);
-    helixStateToInstancesMapForP0.put(HelixState.LEADER, Arrays.asList(instances.get(0)));
-    helixStateToInstancesMapForP0.put(HelixState.STANDBY, Arrays.asList(instances.get(1), instances.get(2)));
+    helixStateToInstancesMapForP0.put(HelixState.LEADER, Arrays.asList(instance1));
+    helixStateToInstancesMapForP0.put(HelixState.STANDBY, Arrays.asList(instance2, instance3));
     EnumMap<ExecutionStatus, List<Instance>> executionStatusToInstancesMapForP0 = new EnumMap<>(ExecutionStatus.class);
-    executionStatusToInstancesMapForP0.put(ExecutionStatus.COMPLETED, instances);
+    executionStatusToInstancesMapForP0.put(ExecutionStatus.COMPLETED, Arrays.asList(instance1, instance2, instance3));
     partitionAssignment
         .addPartition(new Partition(0, helixStateToInstancesMapForP0, executionStatusToInstancesMapForP0));
 
     EnumMap<HelixState, List<Instance>> helixStateToInstancesMapForP1 = new EnumMap<>(HelixState.class);
-    helixStateToInstancesMapForP1.put(HelixState.LEADER, Arrays.asList(instances.get(0)));
+    helixStateToInstancesMapForP1.put(HelixState.LEADER, Arrays.asList(instance1, instance4));
     EnumMap<ExecutionStatus, List<Instance>> executionStatusToInstancesMapForP1 = new EnumMap<>(ExecutionStatus.class);
-    executionStatusToInstancesMapForP1.put(ExecutionStatus.COMPLETED, Arrays.asList(instances.get(0)));
+    executionStatusToInstancesMapForP1.put(ExecutionStatus.COMPLETED, Arrays.asList(instance1, instance4));
     partitionAssignment
         .addPartition(new Partition(1, helixStateToInstancesMapForP1, executionStatusToInstancesMapForP1));
 
     prepareStoreAndVersion(storeName, version, VersionStatus.ONLINE, true, 3);
     Assert.assertTrue(
-        InstanceStatusDecider.isRemovable(resources, clusterName, "localhost_3", Collections.emptyList(), true)
-            .isRemovable(),
-        "Instance should be removable because after removing one instance, there are 2 active replicas in partition 0 in instance's point of view, it will not trigger re-balance.");
+        InstanceStatusDecider.isRemovable(resources, clusterName, instance3Name, Collections.emptyList()).isRemovable(),
+        "Instance should be removable because after removing one instance, there are 2 active replicas in partition 0, it will not trigger re-balance.");
     Assert.assertFalse(
-        InstanceStatusDecider.isRemovable(resources, clusterName, "localhost_3").isRemovable(),
-        "Instance should NOT be removable because after removing one instance, there are only 1 active replicas in partition 1 in cluster's point of view, it will trigger re-balance.");
+        InstanceStatusDecider.isRemovable(resources, clusterName, instance1Name, Collections.emptyList()).isRemovable(),
+        "Instance should NOT be removable because after removing one instance, there are 1 active replicas in partition 1, it will trigger re-balance.");
 
+    // Locked node check when locked instance doesn't share any replica with the instance being removed
+    Assert.assertTrue(
+        InstanceStatusDecider
+            .isRemovable(resources, clusterName, instance3Name, Collections.singletonList(instance5Name))
+            .isRemovable(),
+        "Instance should be removable because after removing one instance, there are 2 active replicas in partition 0, it will not trigger re-balance.");
+    Assert.assertFalse(
+        InstanceStatusDecider
+            .isRemovable(resources, clusterName, instance1Name, Collections.singletonList(instance5Name))
+            .isRemovable(),
+        "Instance should NOT be removable because after removing one instance, there are 1 active replicas in partition 1, it will trigger re-balance.");
+
+    // Locked node check when locked instance shares replicas with the instance being removed
+    Assert.assertFalse(
+        InstanceStatusDecider
+            .isRemovable(resources, clusterName, instance2Name, Collections.singletonList(instance3Name))
+            .isRemovable(),
+        instance2Name + " could NOT be removed because it will trigger rebalance after " + instance3Name
+            + " is removed.");
   }
 
   private PartitionAssignment prepareAssignments(String resourceName) {


### PR DESCRIPTION
<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## Fix node removable check with locked instances
<!--
Describe
- What changes to make and why you are making these changes.
- How are you going to achieve your goal.
- Describe what testings you have done, for example, performance testing etc.

If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->
Currently, there is a bug where even if an instance is non-removable, if it doesn't share any partition with some locked instance, it returns a removable result for the instance.

This commit also depracates the cluster view in the `node_removable` check and removes the `instance_view` API param.

## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
Added extra checks in unit tests

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [ ] No. You can skip the rest of this section.
- [X] Yes. Make sure to explain your proposed changes and call out the behavior change.
    - Before this change, invoking `/node_removable` endpoint on controllers would check if the cluster view is healthy after removal of the specified instance. However, this is not desirable because it would block the removal of the instance even if it doesn't cause any change to the cluster's healthiness. This mode has been deprecated in favor of the `instance_view` mode that was previously available by specifying an API param. Specifying the API param is now a no-op, so, it is still a backwards compatible change