### PR TITLE
[server] swap map for list fields when examining idealstate for disk cleanup

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/storage/StorageService.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/storage/StorageService.java
@@ -395,7 +395,8 @@ public class StorageService extends AbstractVeniceService {
             continue;
           }
           String partitionDbName = storeName + "_" + partitionId;
-          if (!listFields.containsKey(partitionDbName) || !listFields.get(partitionDbName).contains(instanceHostName)) {
+          List<String> hostNames = listFields.get(partitionDbName);
+          if (hostNames != null || !listFields.get(partitionDbName).contains(instanceHostName)) {
             LOGGER.info(
                 "the following partition is not assigned to the current host {} and is being dropped from storage engine {}: {}",
                 instanceHostName,

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/storage/StorageService.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/storage/StorageService.java
@@ -387,7 +387,13 @@ public class StorageService extends AbstractVeniceService {
           new PropertyKey.Builder(configLoader.getVeniceClusterConfig().getClusterName());
       SafeHelixDataAccessor helixDataAccessor = manager.getHelixDataAccessor();
       IdealState idealState = helixDataAccessor.getProperty(propertyKeyBuilder.idealStates(storeName));
-
+      /**
+       * In a helix ideal state, helix maintains information in listfields and mapfields.  The mapfields inform which
+       * messages needs to be sent based on the current LIVEINSTANCES, and will therefore be reflective of what
+       * nodes are available to receive messages.  The listfields however will contain the assignment, and will only
+       * change if a rebalance is calculated.  For this clean up code, we rely on entries in the listfield based
+       * on which state transitions we're anticipating to receive.
+       */
       if (idealState != null) {
         Map<String, List<String>> listFields = idealState.getRecord().getListFields();
         for (Integer partitionId: storageEnginePartitionIds) {

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/storage/StorageService.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/storage/StorageService.java
@@ -389,13 +389,13 @@ public class StorageService extends AbstractVeniceService {
       IdealState idealState = helixDataAccessor.getProperty(propertyKeyBuilder.idealStates(storeName));
 
       if (idealState != null) {
-        Map<String, List<String>> mapFields = idealState.getRecord().getListFields();
+        Map<String, List<String>> listFields = idealState.getRecord().getListFields();
         for (Integer partitionId: storageEnginePartitionIds) {
           if (storageEngine.isMetadataPartition(partitionId)) {
             continue;
           }
           String partitionDbName = storeName + "_" + partitionId;
-          if (!mapFields.containsKey(partitionDbName) || !mapFields.get(partitionDbName).contains(instanceHostName)) {
+          if (!listFields.containsKey(partitionDbName) || !listFields.get(partitionDbName).contains(instanceHostName)) {
             LOGGER.info(
                 "the following partition is not assigned to the current host {} and is being dropped from storage engine {}: {}",
                 instanceHostName,

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/storage/StorageService.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/storage/StorageService.java
@@ -389,14 +389,13 @@ public class StorageService extends AbstractVeniceService {
       IdealState idealState = helixDataAccessor.getProperty(propertyKeyBuilder.idealStates(storeName));
 
       if (idealState != null) {
-        Map<String, Map<String, String>> mapFields = idealState.getRecord().getMapFields();
+        Map<String, List<String>> mapFields = idealState.getRecord().getListFields();
         for (Integer partitionId: storageEnginePartitionIds) {
           if (storageEngine.isMetadataPartition(partitionId)) {
             continue;
           }
           String partitionDbName = storeName + "_" + partitionId;
-          if (!mapFields.containsKey(partitionDbName)
-              || !mapFields.get(partitionDbName).containsKey(instanceHostName)) {
+          if (!mapFields.containsKey(partitionDbName) || !mapFields.get(partitionDbName).contains(instanceHostName)) {
             LOGGER.info(
                 "the following partition is not assigned to the current host {} and is being dropped from storage engine {}: {}",
                 instanceHostName,

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/storage/StorageService.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/storage/StorageService.java
@@ -402,7 +402,7 @@ public class StorageService extends AbstractVeniceService {
           }
           String partitionDbName = storeName + "_" + partitionId;
           List<String> hostNames = listFields.get(partitionDbName);
-          if (hostNames != null || !listFields.get(partitionDbName).contains(instanceHostName)) {
+          if (hostNames == null || !hostNames.contains(instanceHostName)) {
             LOGGER.info(
                 "the following partition is not assigned to the current host {} and is being dropped from storage engine {}: {}",
                 instanceHostName,

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/storage/StorageServiceTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/storage/StorageServiceTest.java
@@ -177,6 +177,20 @@ public class StorageServiceTest {
     mapFields.put("test_store_v1_0", testPartitionZero);
     mapFields.put("test_store_v1_1", testPartitionOne);
     record.setMapFields(mapFields);
+
+    Map<String, List<String>> listFields = new HashMap<>();
+    List<String> testPartitionZeroHostList = new ArrayList<>();
+    testPartitionZeroHostList.add("host_1430");
+    testPartitionZeroHostList.add("host_1435");
+    testPartitionZeroHostList.add("host_1440");
+    List<String> testPartitionOneHostList = new ArrayList<>();
+    testPartitionOneHostList.add("host_1520");
+    testPartitionOneHostList.add("host_1525");
+    testPartitionOneHostList.add("host_1530");
+    listFields.put("test_store_v1_0", testPartitionZeroHostList);
+    listFields.put("test_store_v1_1", testPartitionOneHostList);
+    record.setListFields(listFields);
+
     when(idealState.getRecord()).thenReturn(record);
     when(manager.getInstanceName()).thenReturn("host_1520");
 

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/storage/StorageServiceTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/storage/StorageServiceTest.java
@@ -146,7 +146,6 @@ public class StorageServiceTest {
     mockStorageEngineRepository.addLocalStorageEngine(abstractStorageEngine);
 
     String resourceName = "test_store_v1";
-    String storeName = "test_store";
 
     when(abstractStorageEngine.getStoreVersionName()).thenReturn(resourceName);
     abstractStorageEngine.addStoragePartition(0);

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/server/VeniceServerTest.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/server/VeniceServerTest.java
@@ -222,8 +222,11 @@ public class VeniceServerTest {
       cluster.addVeniceServer(featureProperties, new Properties());
       cluster.addVeniceServer(featureProperties, new Properties());
 
+      cluster.getLeaderVeniceController()
+          .getVeniceHelixAdmin()
+          .getHelixAdminClient()
+          .manuallyEnableMaintenanceMode(cluster.getClusterName(), true, "Prevent nodes from re-joining", null);
       cluster.restartVeniceServer(server.getPort());
-
       TestUtils.waitForNonDeterministicAssertion(
           30,
           TimeUnit.SECONDS,


### PR DESCRIPTION
## [server] swap map for list fields when examining idealstate for disk cleanup

In a helix ideal state, helix maintains information in listfields and mapfields.  The mapfields inform which messages needs to be sent based on the current LIVEINSTANCES, and will therefore be reflective of what nodes are available to receive messages.  The listfields however will contain the assignment, and will only change if a rebalance is calculated.  For this clean up code, we rely on entries in the listfield based on which state transitions we're anticipating to receive.

Resolves #XXX

## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [ ] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.