### PR TITLE
[controller][server][da-vinci-client] Mark a helix replica to error state during ingestion error

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/DaVinciBackend.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/DaVinciBackend.java
@@ -277,6 +277,7 @@ public class DaVinciBackend implements Closeable {
           pubSubClientsFactory,
           Optional.empty(),
           // TODO: It would be good to monitor heartbeats like this from davinci, but needs some work
+          null,
           null);
 
       ingestionService.start();

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/config/VeniceServerConfig.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/config/VeniceServerConfig.java
@@ -136,6 +136,7 @@ import static com.linkedin.venice.ConfigKeys.SERVER_QUOTA_ENFORCEMENT_INTERVAL_I
 import static com.linkedin.venice.ConfigKeys.SERVER_RECORD_LEVEL_METRICS_WHEN_BOOTSTRAPPING_CURRENT_VERSION_ENABLED;
 import static com.linkedin.venice.ConfigKeys.SERVER_REMOTE_CONSUMER_CONFIG_PREFIX;
 import static com.linkedin.venice.ConfigKeys.SERVER_REMOTE_INGESTION_REPAIR_SLEEP_INTERVAL_SECONDS;
+import static com.linkedin.venice.ConfigKeys.SERVER_RESET_ERROR_REPLICA_ENABLED;
 import static com.linkedin.venice.ConfigKeys.SERVER_REST_SERVICE_EPOLL_ENABLED;
 import static com.linkedin.venice.ConfigKeys.SERVER_REST_SERVICE_STORAGE_THREAD_NUM;
 import static com.linkedin.venice.ConfigKeys.SERVER_RESUBSCRIPTION_TRIGGERED_BY_VERSION_INGESTION_CONTEXT_CHANGE_ENABLED;
@@ -490,7 +491,8 @@ public class VeniceServerConfig extends VeniceClusterConfig {
   private final long optimizeDatabaseForBackupVersionNoReadThresholdMS;
   private final long optimizeDatabaseServiceScheduleIntervalSeconds;
   private final boolean unregisterMetricForDeletedStoreEnabled;
-  private final boolean readOnlyForBatchOnlyStoreEnabled; // TODO: remove this config as its never used in prod
+  protected final boolean readOnlyForBatchOnlyStoreEnabled; // TODO: remove this config as its never used in prod
+  private final boolean resetErrorReplicaEnabled;
   private final int fastAvroFieldLimitPerMethod;
 
   /**
@@ -648,9 +650,9 @@ public class VeniceServerConfig extends VeniceClusterConfig {
     remoteIngestionRepairSleepInterval = serverProperties.getInt(
         SERVER_REMOTE_INGESTION_REPAIR_SLEEP_INTERVAL_SECONDS,
         RemoteIngestionRepairService.DEFAULT_REPAIR_THREAD_SLEEP_INTERVAL_SECONDS);
-
     readOnlyForBatchOnlyStoreEnabled =
         serverProperties.getBoolean(SERVER_DB_READ_ONLY_FOR_BATCH_ONLY_STORE_ENABLED, true);
+    resetErrorReplicaEnabled = serverProperties.getBoolean(SERVER_RESET_ERROR_REPLICA_ENABLED, false);
     databaseSyncBytesIntervalForTransactionalMode =
         serverProperties.getSizeInBytes(SERVER_DATABASE_SYNC_BYTES_INTERNAL_FOR_TRANSACTIONAL_MODE, 32 * 1024 * 1024);
     databaseSyncBytesIntervalForDeferredWriteMode =
@@ -1471,6 +1473,10 @@ public class VeniceServerConfig extends VeniceClusterConfig {
 
   public boolean isReadOnlyForBatchOnlyStoreEnabled() {
     return readOnlyForBatchOnlyStoreEnabled;
+  }
+
+  public boolean isResetErrorReplicaEnabled() {
+    return resetErrorReplicaEnabled;
   }
 
   public int getFastAvroFieldLimitPerMethod() {

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/helix/HelixParticipationService.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/helix/HelixParticipationService.java
@@ -79,7 +79,7 @@ public class HelixParticipationService extends AbstractVeniceService
   private final String clusterName;
   private final String participantName;
   private final String zkAddress;
-  private StoreIngestionService ingestionService = null;
+  private final StoreIngestionService ingestionService;
   private final StorageService storageService;
   private final VeniceConfigLoader veniceConfigLoader;
   private final ReadOnlyStoreRepository helixReadOnlyStoreRepository;

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/helix/HelixParticipationService.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/helix/HelixParticipationService.java
@@ -79,7 +79,7 @@ public class HelixParticipationService extends AbstractVeniceService
   private final String clusterName;
   private final String participantName;
   private final String zkAddress;
-  private final StoreIngestionService ingestionService;
+  private StoreIngestionService ingestionService = null;
   private final StorageService storageService;
   private final VeniceConfigLoader veniceConfigLoader;
   private final ReadOnlyStoreRepository helixReadOnlyStoreRepository;
@@ -478,5 +478,9 @@ public class HelixParticipationService extends AbstractVeniceService
     } else {
       LOGGER.info("Ignore the kill message for topic: {}", message.getKafkaTopic());
     }
+  }
+
+  public KafkaStoreIngestionService getKafkaStoreIngestionService() {
+    return (KafkaStoreIngestionService) ingestionService;
   }
 }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/ingestion/isolated/IsolatedIngestionServer.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/ingestion/isolated/IsolatedIngestionServer.java
@@ -716,6 +716,7 @@ public class IsolatedIngestionServer extends AbstractVeniceService {
         repairService,
         pubSubClientsFactory,
         sslFactory,
+        null,
         null);
     storeIngestionService.start();
     storeIngestionService.addIngestionNotifier(new IsolatedIngestionNotifier(this));

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/ActiveActiveStoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/ActiveActiveStoreIngestionTask.java
@@ -114,7 +114,9 @@ public class ActiveActiveStoreIngestionTask extends LeaderFollowerStoreIngestion
       int errorPartitionId,
       boolean isIsolatedIngestion,
       Optional<ObjectCacheBackend> cacheBackend,
-      DaVinciRecordTransformerFunctionalInterface recordTransformerFunction) {
+      DaVinciRecordTransformerFunctionalInterface recordTransformerFunction,
+      String zkAddress,
+      int port) {
     super(
         storageService,
         builder,
@@ -126,7 +128,9 @@ public class ActiveActiveStoreIngestionTask extends LeaderFollowerStoreIngestion
         errorPartitionId,
         isIsolatedIngestion,
         cacheBackend,
-        recordTransformerFunction);
+        recordTransformerFunction,
+        zkAddress,
+        port);
 
     this.rmdProtocolVersionId = version.getRmdVersionId();
 

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/ActiveActiveStoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/ActiveActiveStoreIngestionTask.java
@@ -116,8 +116,7 @@ public class ActiveActiveStoreIngestionTask extends LeaderFollowerStoreIngestion
       boolean isIsolatedIngestion,
       Optional<ObjectCacheBackend> cacheBackend,
       DaVinciRecordTransformerFunctionalInterface recordTransformerFunction,
-      Lazy<ZKHelixAdmin> zkHelixAdmin,
-      int port) {
+      Lazy<ZKHelixAdmin> zkHelixAdmin) {
     super(
         storageService,
         builder,
@@ -130,8 +129,7 @@ public class ActiveActiveStoreIngestionTask extends LeaderFollowerStoreIngestion
         isIsolatedIngestion,
         cacheBackend,
         recordTransformerFunction,
-        zkHelixAdmin,
-        port);
+        zkHelixAdmin);
 
     this.rmdProtocolVersionId = version.getRmdVersionId();
 

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/ActiveActiveStoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/ActiveActiveStoreIngestionTask.java
@@ -75,6 +75,7 @@ import java.util.function.BiConsumer;
 import java.util.function.BooleanSupplier;
 import org.apache.avro.generic.GenericRecord;
 import org.apache.avro.io.BinaryDecoder;
+import org.apache.helix.manager.zk.ZKHelixAdmin;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -115,7 +116,7 @@ public class ActiveActiveStoreIngestionTask extends LeaderFollowerStoreIngestion
       boolean isIsolatedIngestion,
       Optional<ObjectCacheBackend> cacheBackend,
       DaVinciRecordTransformerFunctionalInterface recordTransformerFunction,
-      String zkAddress,
+      Lazy<ZKHelixAdmin> zkHelixAdmin,
       int port) {
     super(
         storageService,
@@ -129,7 +130,7 @@ public class ActiveActiveStoreIngestionTask extends LeaderFollowerStoreIngestion
         isIsolatedIngestion,
         cacheBackend,
         recordTransformerFunction,
-        zkAddress,
+        zkHelixAdmin,
         port);
 
     this.rmdProtocolVersionId = version.getRmdVersionId();

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/KafkaStoreIngestionService.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/KafkaStoreIngestionService.java
@@ -536,8 +536,7 @@ public class KafkaStoreIngestionService extends AbstractVeniceService implements
         isIsolatedIngestion,
         cacheBackend,
         recordTransformerFunction,
-        zkHelixAdmin,
-        serverConfig.getListenerPort());
+        zkHelixAdmin);
   }
 
   private static void shutdownExecutorService(ExecutorService executor, String name, boolean force) {

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTask.java
@@ -215,7 +215,9 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
       int errorPartitionId,
       boolean isIsolatedIngestion,
       Optional<ObjectCacheBackend> cacheBackend,
-      DaVinciRecordTransformerFunctionalInterface recordTransformerFunction) {
+      DaVinciRecordTransformerFunctionalInterface recordTransformerFunction,
+      String zkAddress,
+      int port) {
     super(
         storageService,
         builder,
@@ -228,7 +230,9 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
         isIsolatedIngestion,
         cacheBackend,
         recordTransformerFunction,
-        builder.getLeaderFollowerNotifiers());
+        builder.getLeaderFollowerNotifiers(),
+        zkAddress,
+        port);
     this.version = version;
     this.heartbeatMonitoringService = builder.getHeartbeatMonitoringService();
     /**

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTask.java
@@ -112,6 +112,7 @@ import java.util.function.LongPredicate;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
 import org.apache.avro.generic.GenericRecord;
+import org.apache.helix.manager.zk.ZKHelixAdmin;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -216,7 +217,7 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
       boolean isIsolatedIngestion,
       Optional<ObjectCacheBackend> cacheBackend,
       DaVinciRecordTransformerFunctionalInterface recordTransformerFunction,
-      String zkAddress,
+      Lazy<ZKHelixAdmin> zkHelixAdmin,
       int port) {
     super(
         storageService,
@@ -231,7 +232,7 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
         cacheBackend,
         recordTransformerFunction,
         builder.getLeaderFollowerNotifiers(),
-        zkAddress,
+        zkHelixAdmin,
         port);
     this.version = version;
     this.heartbeatMonitoringService = builder.getHeartbeatMonitoringService();

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTask.java
@@ -217,8 +217,7 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
       boolean isIsolatedIngestion,
       Optional<ObjectCacheBackend> cacheBackend,
       DaVinciRecordTransformerFunctionalInterface recordTransformerFunction,
-      Lazy<ZKHelixAdmin> zkHelixAdmin,
-      int port) {
+      Lazy<ZKHelixAdmin> zkHelixAdmin) {
     super(
         storageService,
         builder,
@@ -232,8 +231,7 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
         cacheBackend,
         recordTransformerFunction,
         builder.getLeaderFollowerNotifiers(),
-        zkHelixAdmin,
-        port);
+        zkHelixAdmin);
     this.version = version;
     this.heartbeatMonitoringService = builder.getHeartbeatMonitoringService();
     /**

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
@@ -354,6 +354,8 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
   protected Lazy<ZKHelixAdmin> zkHelixAdmin;
   protected final String hostName;
 
+  private Lazy<ZKHelixAdmin> zkHelixAdmin;
+
   public StoreIngestionTask(
       StorageService storageService,
       StoreIngestionTaskFactory.Builder builder,
@@ -367,7 +369,7 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
       Optional<ObjectCacheBackend> cacheBackend,
       DaVinciRecordTransformerFunctionalInterface recordTransformerFunction,
       Queue<VeniceNotifier> notifiers,
-      String zkAddress,
+      Lazy<ZKHelixAdmin> zkHelixAdmin,
       int port) {
     this.storeConfig = storeConfig;
     this.readCycleDelayMs = storeConfig.getKafkaReadCycleDelayMs();
@@ -535,14 +537,8 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
     }
     this.batchReportIncPushStatusEnabled = !isDaVinciClient && serverConfig.getBatchReportEOIPEnabled();
     this.parallelProcessingThreadPool = builder.getAAWCWorkLoadProcessingThreadPool();
-    this.zkHelixAdmin = Lazy.of(() -> new ZKHelixAdmin(zkAddress));
     this.hostName = Utils.getHostName() + "_" + port;
-  }
-
-  // TEST ONLY
-
-  public void setZkHelixAdmin(ZKHelixAdmin zkHelixAdmin) {
-    this.zkHelixAdmin = Lazy.of(() -> zkHelixAdmin);
+    this.zkHelixAdmin = zkHelixAdmin;
   }
 
   /** Package-private on purpose, only intended for tests. Do not use for production use cases. */

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
@@ -351,7 +351,7 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
   protected final ExecutorService parallelProcessingThreadPool;
 
   protected final CountDownLatch gracefulShutdownLatch = new CountDownLatch(1);
-  protected final Lazy<ZKHelixAdmin> zkHelixAdmin;
+  protected Lazy<ZKHelixAdmin> zkHelixAdmin;
   protected final String hostName;
 
   public StoreIngestionTask(
@@ -537,6 +537,12 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
     this.parallelProcessingThreadPool = builder.getAAWCWorkLoadProcessingThreadPool();
     this.zkHelixAdmin = Lazy.of(() -> new ZKHelixAdmin(zkAddress));
     this.hostName = Utils.getHostName() + "_" + port;
+  }
+
+  // TEST ONLY
+
+  public void setZkHelixAdmin(ZKHelixAdmin zkHelixAdmin) {
+    this.zkHelixAdmin = Lazy.of(() -> zkHelixAdmin);
   }
 
   /** Package-private on purpose, only intended for tests. Do not use for production use cases. */

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
@@ -4179,16 +4179,12 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
     ingestionNotificationDispatcher.reportError(pcsList, message, e);
     // Set the replica state to ERROR so that the controller can attempt to reset the partition.
     if (!isDaVinciClient) {
-      try {
-        zkHelixAdmin.get()
-            .setPartitionsToError(
-                serverConfig.getClusterName(),
-                hostName,
-                kafkaVersionTopic,
-                Collections.singletonList(HelixUtils.getPartitionName(kafkaVersionTopic, userPartition)));
-      } catch (Exception ex) {
-        LOGGER.warn("aa", ex);
-      }
+      zkHelixAdmin.get()
+          .setPartitionsToError(
+              serverConfig.getClusterName(),
+              hostName,
+              kafkaVersionTopic,
+              Collections.singletonList(HelixUtils.getPartitionName(kafkaVersionTopic, userPartition)));
     }
   }
 

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
@@ -4178,12 +4178,18 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
     }
     ingestionNotificationDispatcher.reportError(pcsList, message, e);
     // Set the replica state to ERROR so that the controller can attempt to reset the partition.
-    zkHelixAdmin.get()
-        .setPartitionsToError(
-            serverConfig.getClusterName(),
-            hostName,
-            storeName,
-            Collections.singletonList(HelixUtils.getPartitionName(storeName, userPartition)));
+    if (!isDaVinciClient) {
+      try {
+        zkHelixAdmin.get()
+            .setPartitionsToError(
+                serverConfig.getClusterName(),
+                hostName,
+                kafkaVersionTopic,
+                Collections.singletonList(HelixUtils.getPartitionName(kafkaVersionTopic, userPartition)));
+      } catch (Exception ex) {
+        LOGGER.warn("aa", ex);
+      }
+    }
   }
 
   public boolean isActiveActiveReplicationEnabled() {

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
@@ -354,8 +354,6 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
   protected Lazy<ZKHelixAdmin> zkHelixAdmin;
   protected final String hostName;
 
-  private Lazy<ZKHelixAdmin> zkHelixAdmin;
-
   public StoreIngestionTask(
       StorageService storageService,
       StoreIngestionTaskFactory.Builder builder,

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTaskFactory.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTaskFactory.java
@@ -24,12 +24,14 @@ import com.linkedin.venice.pubsub.manager.TopicManagerRepository;
 import com.linkedin.venice.serialization.avro.InternalAvroSpecificSerializer;
 import com.linkedin.venice.system.store.MetaStoreWriter;
 import com.linkedin.venice.utils.DiskUsage;
+import com.linkedin.venice.utils.lazy.Lazy;
 import com.linkedin.venice.writer.VeniceWriterFactory;
 import java.util.Optional;
 import java.util.Properties;
 import java.util.Queue;
 import java.util.concurrent.ExecutorService;
 import java.util.function.BooleanSupplier;
+import org.apache.helix.manager.zk.ZKHelixAdmin;
 
 
 public class StoreIngestionTaskFactory {
@@ -54,7 +56,7 @@ public class StoreIngestionTaskFactory {
       boolean isIsolatedIngestion,
       Optional<ObjectCacheBackend> cacheBackend,
       DaVinciRecordTransformerFunctionalInterface recordTransformerFunction,
-      String zkAddress,
+      Lazy<ZKHelixAdmin> zkHelixAdmin,
       int portNum) {
     if (version.isActiveActiveReplicationEnabled()) {
       return new ActiveActiveStoreIngestionTask(
@@ -69,7 +71,7 @@ public class StoreIngestionTaskFactory {
           isIsolatedIngestion,
           cacheBackend,
           recordTransformerFunction,
-          zkAddress,
+          zkHelixAdmin,
           portNum);
     }
     return new LeaderFollowerStoreIngestionTask(
@@ -84,7 +86,7 @@ public class StoreIngestionTaskFactory {
         isIsolatedIngestion,
         cacheBackend,
         recordTransformerFunction,
-        zkAddress,
+        zkHelixAdmin,
         portNum);
   }
 

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTaskFactory.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTaskFactory.java
@@ -53,7 +53,9 @@ public class StoreIngestionTaskFactory {
       int partitionId,
       boolean isIsolatedIngestion,
       Optional<ObjectCacheBackend> cacheBackend,
-      DaVinciRecordTransformerFunctionalInterface recordTransformerFunction) {
+      DaVinciRecordTransformerFunctionalInterface recordTransformerFunction,
+      String zkAddress,
+      int portNum) {
     if (version.isActiveActiveReplicationEnabled()) {
       return new ActiveActiveStoreIngestionTask(
           storageService,
@@ -66,7 +68,9 @@ public class StoreIngestionTaskFactory {
           partitionId,
           isIsolatedIngestion,
           cacheBackend,
-          recordTransformerFunction);
+          recordTransformerFunction,
+          zkAddress,
+          portNum);
     }
     return new LeaderFollowerStoreIngestionTask(
         storageService,
@@ -79,7 +83,9 @@ public class StoreIngestionTaskFactory {
         partitionId,
         isIsolatedIngestion,
         cacheBackend,
-        recordTransformerFunction);
+        recordTransformerFunction,
+        zkAddress,
+        portNum);
   }
 
   /**

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTaskFactory.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTaskFactory.java
@@ -56,8 +56,7 @@ public class StoreIngestionTaskFactory {
       boolean isIsolatedIngestion,
       Optional<ObjectCacheBackend> cacheBackend,
       DaVinciRecordTransformerFunctionalInterface recordTransformerFunction,
-      Lazy<ZKHelixAdmin> zkHelixAdmin,
-      int portNum) {
+      Lazy<ZKHelixAdmin> zkHelixAdmin) {
     if (version.isActiveActiveReplicationEnabled()) {
       return new ActiveActiveStoreIngestionTask(
           storageService,
@@ -71,8 +70,7 @@ public class StoreIngestionTaskFactory {
           isIsolatedIngestion,
           cacheBackend,
           recordTransformerFunction,
-          zkHelixAdmin,
-          portNum);
+          zkHelixAdmin);
     }
     return new LeaderFollowerStoreIngestionTask(
         storageService,
@@ -86,8 +84,7 @@ public class StoreIngestionTaskFactory {
         isIsolatedIngestion,
         cacheBackend,
         recordTransformerFunction,
-        zkHelixAdmin,
-        portNum);
+        zkHelixAdmin);
   }
 
   /**

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/ActiveActiveStoreIngestionTaskTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/ActiveActiveStoreIngestionTaskTest.java
@@ -262,8 +262,7 @@ public class ActiveActiveStoreIngestionTaskTest {
         false,
         Optional.empty(),
         null,
-        null,
-        port);
+        null);
 
     PartitionConsumptionState badPartitionConsumptionState = mock(PartitionConsumptionState.class);
     when(badPartitionConsumptionState.hasLagCaughtUp()).thenReturn(true);

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/ActiveActiveStoreIngestionTaskTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/ActiveActiveStoreIngestionTaskTest.java
@@ -260,7 +260,9 @@ public class ActiveActiveStoreIngestionTaskTest {
         1,
         false,
         Optional.empty(),
-        null);
+        null,
+        null,
+        anyInt());
 
     PartitionConsumptionState badPartitionConsumptionState = mock(PartitionConsumptionState.class);
     when(badPartitionConsumptionState.hasLagCaughtUp()).thenReturn(true);

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/ActiveActiveStoreIngestionTaskTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/ActiveActiveStoreIngestionTaskTest.java
@@ -249,6 +249,7 @@ public class ActiveActiveStoreIngestionTaskTest {
     kafkaConsumerProperties.put(ZOOKEEPER_ADDRESS, BOOTSTRAP_SERVER);
     VeniceStoreVersionConfig storeVersionConfig =
         new VeniceStoreVersionConfig(STORE_NAME + "_v1", new VeniceProperties(kafkaConsumerProperties));
+    int port = 123;
     ActiveActiveStoreIngestionTask ingestionTask = new ActiveActiveStoreIngestionTask(
         storageService,
         builder,
@@ -262,7 +263,7 @@ public class ActiveActiveStoreIngestionTaskTest {
         Optional.empty(),
         null,
         null,
-        anyInt());
+        port);
 
     PartitionConsumptionState badPartitionConsumptionState = mock(PartitionConsumptionState.class);
     when(badPartitionConsumptionState.hasLagCaughtUp()).thenReturn(true);

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/KafkaStoreIngestionServiceTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/KafkaStoreIngestionServiceTest.java
@@ -180,6 +180,7 @@ public abstract class KafkaStoreIngestionServiceTest {
         null,
         mockPubSubClientsFactory,
         Optional.empty(),
+        null,
         null);
 
     String mockStoreName = "test";
@@ -264,6 +265,7 @@ public abstract class KafkaStoreIngestionServiceTest {
         null,
         mockPubSubClientsFactory,
         Optional.empty(),
+        null,
         null);
     String topic1 = "test-store_v1";
     String topic2 = "test-store_v2";
@@ -352,6 +354,7 @@ public abstract class KafkaStoreIngestionServiceTest {
         null,
         mockPubSubClientsFactory,
         Optional.empty(),
+        null,
         null);
     String topicName = "test-store_v1";
     String storeName = Version.parseStoreFromKafkaTopicName(topicName);
@@ -417,6 +420,7 @@ public abstract class KafkaStoreIngestionServiceTest {
         null,
         mockPubSubClientsFactory,
         Optional.empty(),
+        null,
         null);
     String topicName = "test-store_v1";
     String storeName = Version.parseStoreFromKafkaTopicName(topicName);

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTaskTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTaskTest.java
@@ -176,7 +176,7 @@ public class LeaderFollowerStoreIngestionTaskTest {
         false,
         Optional.empty(),
         null,
-        ZOOKEEPER_ADDRESS,
+        null,
         123);
 
     leaderFollowerStoreIngestionTask.addPartitionConsumptionState(0, mockPartitionConsumptionState);

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTaskTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTaskTest.java
@@ -174,7 +174,7 @@ public class LeaderFollowerStoreIngestionTaskTest {
         0,
         false,
         Optional.empty(),
-        null);
+        null, null, 123);
     leaderFollowerStoreIngestionTask.addPartitionConsumptionState(0, mockPartitionConsumptionState);
   }
 

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTaskTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTaskTest.java
@@ -1,6 +1,5 @@
 package com.linkedin.davinci.kafka.consumer;
 
-import static com.linkedin.venice.ConfigKeys.*;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -176,8 +175,7 @@ public class LeaderFollowerStoreIngestionTaskTest {
         false,
         Optional.empty(),
         null,
-        null,
-        123);
+        null);
 
     leaderFollowerStoreIngestionTask.addPartitionConsumptionState(0, mockPartitionConsumptionState);
   }

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTaskTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTaskTest.java
@@ -1,5 +1,6 @@
 package com.linkedin.davinci.kafka.consumer;
 
+import static com.linkedin.venice.ConfigKeys.*;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -174,7 +175,10 @@ public class LeaderFollowerStoreIngestionTaskTest {
         0,
         false,
         Optional.empty(),
-        null, null, 123);
+        null,
+        ZOOKEEPER_ADDRESS,
+        123);
+
     leaderFollowerStoreIngestionTask.addPartitionConsumptionState(0, mockPartitionConsumptionState);
   }
 

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/PushTimeoutTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/PushTimeoutTest.java
@@ -1,6 +1,7 @@
 package com.linkedin.davinci.kafka.consumer;
 
 import static com.linkedin.venice.ConfigKeys.KAFKA_BOOTSTRAP_SERVERS;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.Mockito.anyString;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.eq;
@@ -78,7 +79,9 @@ public class PushTimeoutTest {
         0,
         false,
         Optional.empty(),
-        null);
+        null,
+        null,
+        anyInt());
 
     leaderFollowerStoreIngestionTask
         .subscribePartition(new PubSubTopicPartitionImpl(pubSubTopicRepository.getTopic(versionTopic), 0));
@@ -153,7 +156,9 @@ public class PushTimeoutTest {
         0,
         false,
         Optional.empty(),
-        null);
+        null,
+        null,
+        anyInt());
 
     leaderFollowerStoreIngestionTask
         .subscribePartition(new PubSubTopicPartitionImpl(pubSubTopicRepository.getTopic(versionTopic), 0));

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/PushTimeoutTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/PushTimeoutTest.java
@@ -1,7 +1,6 @@
 package com.linkedin.davinci.kafka.consumer;
 
-import static com.linkedin.venice.ConfigKeys.KAFKA_BOOTSTRAP_SERVERS;
-import static org.mockito.ArgumentMatchers.anyInt;
+import static com.linkedin.venice.ConfigKeys.*;
 import static org.mockito.Mockito.anyString;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.eq;
@@ -80,8 +79,8 @@ public class PushTimeoutTest {
         false,
         Optional.empty(),
         null,
-        null,
-        anyInt());
+        ZOOKEEPER_ADDRESS,
+        122);
 
     leaderFollowerStoreIngestionTask
         .subscribePartition(new PubSubTopicPartitionImpl(pubSubTopicRepository.getTopic(versionTopic), 0));
@@ -157,8 +156,8 @@ public class PushTimeoutTest {
         false,
         Optional.empty(),
         null,
-        null,
-        anyInt());
+        ZOOKEEPER_ADDRESS,
+        123);
 
     leaderFollowerStoreIngestionTask
         .subscribePartition(new PubSubTopicPartitionImpl(pubSubTopicRepository.getTopic(versionTopic), 0));

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/PushTimeoutTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/PushTimeoutTest.java
@@ -1,6 +1,6 @@
 package com.linkedin.davinci.kafka.consumer;
 
-import static com.linkedin.venice.ConfigKeys.*;
+import static com.linkedin.venice.ConfigKeys.KAFKA_BOOTSTRAP_SERVERS;
 import static org.mockito.Mockito.anyString;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.eq;
@@ -79,8 +79,7 @@ public class PushTimeoutTest {
         false,
         Optional.empty(),
         null,
-        null,
-        122);
+        null);
 
     leaderFollowerStoreIngestionTask
         .subscribePartition(new PubSubTopicPartitionImpl(pubSubTopicRepository.getTopic(versionTopic), 0));
@@ -156,8 +155,7 @@ public class PushTimeoutTest {
         false,
         Optional.empty(),
         null,
-        null,
-        123);
+        null);
 
     leaderFollowerStoreIngestionTask
         .subscribePartition(new PubSubTopicPartitionImpl(pubSubTopicRepository.getTopic(versionTopic), 0));

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/PushTimeoutTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/PushTimeoutTest.java
@@ -79,7 +79,7 @@ public class PushTimeoutTest {
         false,
         Optional.empty(),
         null,
-        ZOOKEEPER_ADDRESS,
+        null,
         122);
 
     leaderFollowerStoreIngestionTask
@@ -156,7 +156,7 @@ public class PushTimeoutTest {
         false,
         Optional.empty(),
         null,
-        ZOOKEEPER_ADDRESS,
+        null,
         123);
 
     leaderFollowerStoreIngestionTask

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTaskTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTaskTest.java
@@ -862,7 +862,10 @@ public abstract class StoreIngestionTaskTest {
             PARTITION_FOO,
             false,
             Optional.empty(),
-            recordTransformerFunction));
+            recordTransformerFunction,
+            null,
+            anyInt()));
+
     Future testSubscribeTaskFuture = null;
     try {
       for (int partition: partitions) {
@@ -2728,7 +2731,7 @@ public abstract class StoreIngestionTaskTest {
             PARTITION_FOO,
             false,
             Optional.empty(),
-            null));
+            null, null, 123));
 
     Schema schema1 = Schema.parse(
         "{" + "\"fields\": ["
@@ -2936,7 +2939,9 @@ public abstract class StoreIngestionTaskTest {
         PARTITION_FOO,
         false,
         Optional.empty(),
-        null);
+        null,
+        null,
+        anyInt());
 
     AtomicLong remoteKafkaQuota = new AtomicLong(10);
 
@@ -3087,7 +3092,9 @@ public abstract class StoreIngestionTaskTest {
         PARTITION_FOO,
         false,
         Optional.empty(),
-        null);
+        null,
+        null,
+        anyInt());
     String rtTopicName = Version.composeRealTimeTopic(mockStore.getName());
     PubSubTopic rtTopic = pubSubTopicRepository.getTopic(rtTopicName);
     TopicSwitch topicSwitchWithSourceRealTimeTopic = new TopicSwitch();
@@ -3306,7 +3313,9 @@ public abstract class StoreIngestionTaskTest {
         PARTITION_FOO,
         false,
         Optional.empty(),
-        null);
+        null,
+        null,
+        anyInt());
 
     if (hybridConfig.equals(HYBRID) && nodeType.equals(LEADER) && isAaWCParallelProcessingEnabled()) {
       assertTrue(storeIngestionTaskUnderTest instanceof ActiveActiveStoreIngestionTask);
@@ -3454,7 +3463,9 @@ public abstract class StoreIngestionTaskTest {
         PARTITION_FOO,
         false,
         Optional.empty(),
-        null);
+        null,
+        null,
+        anyInt());
 
     PartitionConsumptionState mockPartitionConsumptionState = mock(PartitionConsumptionState.class);
     doCallRealMethod().when(mockPartitionConsumptionState).isLeaderCompleted();
@@ -3609,7 +3620,9 @@ public abstract class StoreIngestionTaskTest {
             PARTITION_FOO,
             false,
             Optional.empty(),
-            null);
+            null,
+            null,
+            anyInt());
 
     OffsetRecord mockOffsetRecord = mock(OffsetRecord.class);
     PartitionConsumptionState partitionConsumptionState =
@@ -3707,7 +3720,9 @@ public abstract class StoreIngestionTaskTest {
         PARTITION_FOO,
         false,
         Optional.empty(),
-        null);
+        null,
+        null,
+        anyInt());
     TopicManager mockTopicManagerRemoteKafka = mock(TopicManager.class);
     doReturn(mockTopicManagerRemoteKafka).when(mockTopicManagerRepository)
         .getTopicManager(inMemoryRemoteKafkaBroker.getKafkaBootstrapServer());
@@ -3781,7 +3796,9 @@ public abstract class StoreIngestionTaskTest {
             0,
             false,
             Optional.empty(),
-            null);
+            null,
+            null,
+            anyInt());
 
     TopicSwitch topicSwitch = new TopicSwitch();
     topicSwitch.sourceKafkaServers = Collections.singletonList("localhost");
@@ -3897,7 +3914,9 @@ public abstract class StoreIngestionTaskTest {
             -1,
             false,
             Optional.empty(),
-            null));
+            null,
+            null,
+            anyInt()));
 
     OffsetRecord offsetRecord = mock(OffsetRecord.class);
     doReturn(pubSubTopicRepository.getTopic(versionTopicName)).when(offsetRecord).getLeaderTopic(any());
@@ -4431,7 +4450,9 @@ public abstract class StoreIngestionTaskTest {
         1,
         false,
         Optional.empty(),
-        null);
+        null,
+        null,
+        anyInt());
     OffsetRecord offsetRecord = mock(OffsetRecord.class);
     doReturn(pubSubTopic).when(offsetRecord).getLeaderTopic(any());
     PartitionConsumptionState partitionConsumptionState =
@@ -4548,7 +4569,9 @@ public abstract class StoreIngestionTaskTest {
             0,
             false,
             Optional.empty(),
-            null);
+            null,
+            null,
+            anyInt());
 
     ingestionTask.setPartitionConsumptionState(0, pcs);
     ingestionTask.maybeSendIngestionHeartbeat();
@@ -4637,7 +4660,9 @@ public abstract class StoreIngestionTaskTest {
             0,
             false,
             Optional.empty(),
-            null);
+            null,
+            null,
+            anyInt());
 
     ingestionTask.setPartitionConsumptionState(0, pcs0);
     ingestionTask.setPartitionConsumptionState(1, pcs1);

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTaskTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTaskTest.java
@@ -864,10 +864,8 @@ public abstract class StoreIngestionTaskTest {
             false,
             Optional.empty(),
             recordTransformerFunction,
-            "localhost",
+            Lazy.of(() -> mock(ZKHelixAdmin.class)),
             123));
-
-    storeIngestionTaskUnderTest.setZkHelixAdmin(mock(ZKHelixAdmin.class));
 
     Future testSubscribeTaskFuture = null;
     try {
@@ -2943,7 +2941,7 @@ public abstract class StoreIngestionTaskTest {
         false,
         Optional.empty(),
         null,
-        ZOOKEEPER_ADDRESS,
+        null,
         123);
 
     AtomicLong remoteKafkaQuota = new AtomicLong(10);
@@ -3096,7 +3094,7 @@ public abstract class StoreIngestionTaskTest {
         false,
         Optional.empty(),
         null,
-        ZOOKEEPER_ADDRESS,
+        null,
         123);
     String rtTopicName = Version.composeRealTimeTopic(mockStore.getName());
     PubSubTopic rtTopic = pubSubTopicRepository.getTopic(rtTopicName);
@@ -3317,7 +3315,7 @@ public abstract class StoreIngestionTaskTest {
         false,
         Optional.empty(),
         null,
-        ZOOKEEPER_ADDRESS,
+        null,
         123);
 
     if (hybridConfig.equals(HYBRID) && nodeType.equals(LEADER) && isAaWCParallelProcessingEnabled()) {
@@ -3467,7 +3465,7 @@ public abstract class StoreIngestionTaskTest {
         false,
         Optional.empty(),
         null,
-        ZOOKEEPER_ADDRESS,
+        null,
         123);
 
     PartitionConsumptionState mockPartitionConsumptionState = mock(PartitionConsumptionState.class);
@@ -3624,7 +3622,7 @@ public abstract class StoreIngestionTaskTest {
             false,
             Optional.empty(),
             null,
-            ZOOKEEPER_ADDRESS,
+            null,
             123);
 
     OffsetRecord mockOffsetRecord = mock(OffsetRecord.class);
@@ -3724,7 +3722,7 @@ public abstract class StoreIngestionTaskTest {
         false,
         Optional.empty(),
         null,
-        ZOOKEEPER_ADDRESS,
+        null,
         123);
     TopicManager mockTopicManagerRemoteKafka = mock(TopicManager.class);
     doReturn(mockTopicManagerRemoteKafka).when(mockTopicManagerRepository)
@@ -3800,7 +3798,7 @@ public abstract class StoreIngestionTaskTest {
             false,
             Optional.empty(),
             null,
-            ZOOKEEPER_ADDRESS,
+            null,
             123);
 
     TopicSwitch topicSwitch = new TopicSwitch();
@@ -3918,7 +3916,7 @@ public abstract class StoreIngestionTaskTest {
             false,
             Optional.empty(),
             null,
-            ZOOKEEPER_ADDRESS,
+            null,
             123));
 
     OffsetRecord offsetRecord = mock(OffsetRecord.class);
@@ -4454,7 +4452,7 @@ public abstract class StoreIngestionTaskTest {
         false,
         Optional.empty(),
         null,
-        ZOOKEEPER_ADDRESS,
+        null,
         123);
     OffsetRecord offsetRecord = mock(OffsetRecord.class);
     doReturn(pubSubTopic).when(offsetRecord).getLeaderTopic(any());
@@ -4573,7 +4571,7 @@ public abstract class StoreIngestionTaskTest {
             false,
             Optional.empty(),
             null,
-            ZOOKEEPER_ADDRESS,
+            null,
             123);
 
     ingestionTask.setPartitionConsumptionState(0, pcs);
@@ -4664,7 +4662,7 @@ public abstract class StoreIngestionTaskTest {
             false,
             Optional.empty(),
             null,
-            ZOOKEEPER_ADDRESS,
+            null,
             123);
 
     ingestionTask.setPartitionConsumptionState(0, pcs0);

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTaskTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTaskTest.java
@@ -248,6 +248,7 @@ import java.util.stream.Collectors;
 import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericData;
 import org.apache.avro.generic.GenericRecord;
+import org.apache.helix.manager.zk.ZKHelixAdmin;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.mockito.ArgumentCaptor;
@@ -863,8 +864,10 @@ public abstract class StoreIngestionTaskTest {
             false,
             Optional.empty(),
             recordTransformerFunction,
-            ZOOKEEPER_ADDRESS,
+            "localhost",
             123));
+
+    storeIngestionTaskUnderTest.setZkHelixAdmin(mock(ZKHelixAdmin.class));
 
     Future testSubscribeTaskFuture = null;
     try {

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTaskTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTaskTest.java
@@ -2943,8 +2943,8 @@ public abstract class StoreIngestionTaskTest {
         false,
         Optional.empty(),
         null,
-        null,
-        anyInt());
+        ZOOKEEPER_ADDRESS,
+        123);
 
     AtomicLong remoteKafkaQuota = new AtomicLong(10);
 
@@ -3724,8 +3724,8 @@ public abstract class StoreIngestionTaskTest {
         false,
         Optional.empty(),
         null,
-        null,
-        anyInt());
+        ZOOKEEPER_ADDRESS,
+        123);
     TopicManager mockTopicManagerRemoteKafka = mock(TopicManager.class);
     doReturn(mockTopicManagerRemoteKafka).when(mockTopicManagerRepository)
         .getTopicManager(inMemoryRemoteKafkaBroker.getKafkaBootstrapServer());
@@ -3800,8 +3800,8 @@ public abstract class StoreIngestionTaskTest {
             false,
             Optional.empty(),
             null,
-            null,
-            anyInt());
+            ZOOKEEPER_ADDRESS,
+            123);
 
     TopicSwitch topicSwitch = new TopicSwitch();
     topicSwitch.sourceKafkaServers = Collections.singletonList("localhost");
@@ -3918,8 +3918,8 @@ public abstract class StoreIngestionTaskTest {
             false,
             Optional.empty(),
             null,
-            null,
-            anyInt()));
+            ZOOKEEPER_ADDRESS,
+            123));
 
     OffsetRecord offsetRecord = mock(OffsetRecord.class);
     doReturn(pubSubTopicRepository.getTopic(versionTopicName)).when(offsetRecord).getLeaderTopic(any());

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTaskTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTaskTest.java
@@ -863,8 +863,8 @@ public abstract class StoreIngestionTaskTest {
             false,
             Optional.empty(),
             recordTransformerFunction,
-            null,
-            anyInt()));
+            ZOOKEEPER_ADDRESS,
+            123));
 
     Future testSubscribeTaskFuture = null;
     try {
@@ -3093,8 +3093,8 @@ public abstract class StoreIngestionTaskTest {
         false,
         Optional.empty(),
         null,
-        null,
-        anyInt());
+        ZOOKEEPER_ADDRESS,
+        123);
     String rtTopicName = Version.composeRealTimeTopic(mockStore.getName());
     PubSubTopic rtTopic = pubSubTopicRepository.getTopic(rtTopicName);
     TopicSwitch topicSwitchWithSourceRealTimeTopic = new TopicSwitch();
@@ -3314,8 +3314,8 @@ public abstract class StoreIngestionTaskTest {
         false,
         Optional.empty(),
         null,
-        null,
-        anyInt());
+        ZOOKEEPER_ADDRESS,
+        123);
 
     if (hybridConfig.equals(HYBRID) && nodeType.equals(LEADER) && isAaWCParallelProcessingEnabled()) {
       assertTrue(storeIngestionTaskUnderTest instanceof ActiveActiveStoreIngestionTask);
@@ -3464,8 +3464,8 @@ public abstract class StoreIngestionTaskTest {
         false,
         Optional.empty(),
         null,
-        null,
-        anyInt());
+        ZOOKEEPER_ADDRESS,
+        123);
 
     PartitionConsumptionState mockPartitionConsumptionState = mock(PartitionConsumptionState.class);
     doCallRealMethod().when(mockPartitionConsumptionState).isLeaderCompleted();
@@ -3621,8 +3621,8 @@ public abstract class StoreIngestionTaskTest {
             false,
             Optional.empty(),
             null,
-            null,
-            anyInt());
+            ZOOKEEPER_ADDRESS,
+            123);
 
     OffsetRecord mockOffsetRecord = mock(OffsetRecord.class);
     PartitionConsumptionState partitionConsumptionState =
@@ -4451,8 +4451,8 @@ public abstract class StoreIngestionTaskTest {
         false,
         Optional.empty(),
         null,
-        null,
-        anyInt());
+        ZOOKEEPER_ADDRESS,
+        123);
     OffsetRecord offsetRecord = mock(OffsetRecord.class);
     doReturn(pubSubTopic).when(offsetRecord).getLeaderTopic(any());
     PartitionConsumptionState partitionConsumptionState =
@@ -4570,8 +4570,8 @@ public abstract class StoreIngestionTaskTest {
             false,
             Optional.empty(),
             null,
-            null,
-            anyInt());
+            ZOOKEEPER_ADDRESS,
+            123);
 
     ingestionTask.setPartitionConsumptionState(0, pcs);
     ingestionTask.maybeSendIngestionHeartbeat();
@@ -4661,8 +4661,8 @@ public abstract class StoreIngestionTaskTest {
             false,
             Optional.empty(),
             null,
-            null,
-            anyInt());
+            ZOOKEEPER_ADDRESS,
+            123);
 
     ingestionTask.setPartitionConsumptionState(0, pcs0);
     ingestionTask.setPartitionConsumptionState(1, pcs1);

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTaskTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTaskTest.java
@@ -864,8 +864,7 @@ public abstract class StoreIngestionTaskTest {
             false,
             Optional.empty(),
             recordTransformerFunction,
-            Lazy.of(() -> mock(ZKHelixAdmin.class)),
-            123));
+            Lazy.of(() -> mock(ZKHelixAdmin.class))));
 
     Future testSubscribeTaskFuture = null;
     try {
@@ -2733,8 +2732,7 @@ public abstract class StoreIngestionTaskTest {
             false,
             Optional.empty(),
             null,
-            null,
-            123));
+            null));
 
     Schema schema1 = Schema.parse(
         "{" + "\"fields\": ["
@@ -2943,8 +2941,7 @@ public abstract class StoreIngestionTaskTest {
         false,
         Optional.empty(),
         null,
-        null,
-        123);
+        null);
 
     AtomicLong remoteKafkaQuota = new AtomicLong(10);
 
@@ -3096,8 +3093,7 @@ public abstract class StoreIngestionTaskTest {
         false,
         Optional.empty(),
         null,
-        null,
-        123);
+        null);
     String rtTopicName = Version.composeRealTimeTopic(mockStore.getName());
     PubSubTopic rtTopic = pubSubTopicRepository.getTopic(rtTopicName);
     TopicSwitch topicSwitchWithSourceRealTimeTopic = new TopicSwitch();
@@ -3317,8 +3313,7 @@ public abstract class StoreIngestionTaskTest {
         false,
         Optional.empty(),
         null,
-        null,
-        123);
+        null);
 
     if (hybridConfig.equals(HYBRID) && nodeType.equals(LEADER) && isAaWCParallelProcessingEnabled()) {
       assertTrue(storeIngestionTaskUnderTest instanceof ActiveActiveStoreIngestionTask);
@@ -3467,8 +3462,7 @@ public abstract class StoreIngestionTaskTest {
         false,
         Optional.empty(),
         null,
-        null,
-        123);
+        null);
 
     PartitionConsumptionState mockPartitionConsumptionState = mock(PartitionConsumptionState.class);
     doCallRealMethod().when(mockPartitionConsumptionState).isLeaderCompleted();
@@ -3624,8 +3618,7 @@ public abstract class StoreIngestionTaskTest {
             false,
             Optional.empty(),
             null,
-            null,
-            123);
+            null);
 
     OffsetRecord mockOffsetRecord = mock(OffsetRecord.class);
     PartitionConsumptionState partitionConsumptionState =
@@ -3724,8 +3717,7 @@ public abstract class StoreIngestionTaskTest {
         false,
         Optional.empty(),
         null,
-        null,
-        123);
+        null);
     TopicManager mockTopicManagerRemoteKafka = mock(TopicManager.class);
     doReturn(mockTopicManagerRemoteKafka).when(mockTopicManagerRepository)
         .getTopicManager(inMemoryRemoteKafkaBroker.getKafkaBootstrapServer());
@@ -3800,8 +3792,7 @@ public abstract class StoreIngestionTaskTest {
             false,
             Optional.empty(),
             null,
-            null,
-            123);
+            null);
 
     TopicSwitch topicSwitch = new TopicSwitch();
     topicSwitch.sourceKafkaServers = Collections.singletonList("localhost");
@@ -3918,8 +3909,7 @@ public abstract class StoreIngestionTaskTest {
             false,
             Optional.empty(),
             null,
-            null,
-            123));
+            null));
 
     OffsetRecord offsetRecord = mock(OffsetRecord.class);
     doReturn(pubSubTopicRepository.getTopic(versionTopicName)).when(offsetRecord).getLeaderTopic(any());
@@ -4454,8 +4444,7 @@ public abstract class StoreIngestionTaskTest {
         false,
         Optional.empty(),
         null,
-        null,
-        123);
+        null);
     OffsetRecord offsetRecord = mock(OffsetRecord.class);
     doReturn(pubSubTopic).when(offsetRecord).getLeaderTopic(any());
     PartitionConsumptionState partitionConsumptionState =
@@ -4573,8 +4562,7 @@ public abstract class StoreIngestionTaskTest {
             false,
             Optional.empty(),
             null,
-            null,
-            123);
+            null);
 
     ingestionTask.setPartitionConsumptionState(0, pcs);
     ingestionTask.maybeSendIngestionHeartbeat();
@@ -4664,8 +4652,7 @@ public abstract class StoreIngestionTaskTest {
             false,
             Optional.empty(),
             null,
-            null,
-            123);
+            null);
 
     ingestionTask.setPartitionConsumptionState(0, pcs0);
     ingestionTask.setPartitionConsumptionState(1, pcs1);

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTaskTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTaskTest.java
@@ -2732,7 +2732,9 @@ public abstract class StoreIngestionTaskTest {
             PARTITION_FOO,
             false,
             Optional.empty(),
-            null, null, 123));
+            null,
+            null,
+            123));
 
     Schema schema1 = Schema.parse(
         "{" + "\"fields\": ["

--- a/internal/venice-common/src/main/java/com/linkedin/venice/ConfigKeys.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/ConfigKeys.java
@@ -758,6 +758,7 @@ public class ConfigKeys {
 
   public static final String SERVER_DB_READ_ONLY_FOR_BATCH_ONLY_STORE_ENABLED =
       "server.db.read.only.for.batch.only.store.enabled";
+  public static final String SERVER_RESET_ERROR_REPLICA_ENABLED = "server.reset.error.replica.enabled";
   /**
    * A list of fully-qualified class names of all stats classes that needs to be initialized in isolated ingestion process,
    * separated by comma. This config will help isolated ingestion process to register extra stats needed for monitoring,

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestLeaderReplicaFailover.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestLeaderReplicaFailover.java
@@ -3,6 +3,7 @@ package com.linkedin.venice.endToEnd;
 import static com.linkedin.davinci.store.rocksdb.RocksDBServerConfig.ROCKSDB_PLAIN_TABLE_FORMAT_ENABLED;
 import static com.linkedin.venice.ConfigKeys.DEFAULT_OFFLINE_PUSH_STRATEGY;
 import static com.linkedin.venice.ConfigKeys.DEFAULT_PARTITION_SIZE;
+import static com.linkedin.venice.ConfigKeys.SERVER_RESET_ERROR_REPLICA_ENABLED;
 import static com.linkedin.venice.utils.IntegrationTestPushUtils.createStoreForJob;
 import static com.linkedin.venice.utils.IntegrationTestPushUtils.defaultVPJProps;
 import static com.linkedin.venice.utils.TestWriteUtils.getTempDataDirectory;
@@ -82,6 +83,7 @@ public class TestLeaderReplicaFailover {
     Properties serverProperties = new Properties();
     serverProperties.setProperty(ConfigKeys.SERVER_PROMOTION_TO_LEADER_REPLICA_DELAY_SECONDS, Long.toString(1));
     serverProperties.put(ROCKSDB_PLAIN_TABLE_FORMAT_ENABLED, false);
+    serverProperties.put(SERVER_RESET_ERROR_REPLICA_ENABLED, true);
     serverProperties.put(DEFAULT_OFFLINE_PUSH_STRATEGY, OfflinePushStrategy.WAIT_N_MINUS_ONE_REPLCIA_PER_PARTITION);
 
     Properties parent = new Properties();

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/ErrorPartitionResetTask.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/ErrorPartitionResetTask.java
@@ -91,10 +91,7 @@ public class ErrorPartitionResetTask implements Runnable, Closeable {
         long startTime = System.currentTimeMillis();
         // Copy the previous iteration's reset tracker resources and remove them from the set if they are still relevant
         irrelevantResources.addAll(errorPartitionResetTracker.keySet());
-        readOnlyStoreRepository.getAllStores()
-            .stream()
-            .filter(s -> !s.isSystemStore())
-            .forEach(this::resetApplicableErrorPartitions);
+        readOnlyStoreRepository.getAllStores().forEach(this::resetApplicableErrorPartitions);
 
         // Remove all the irrelevant entries from the error partition reset tracker
         for (String irrelevantResource: irrelevantResources) {

--- a/services/venice-server/src/main/java/com/linkedin/venice/server/VeniceServer.java
+++ b/services/venice-server/src/main/java/com/linkedin/venice/server/VeniceServer.java
@@ -73,6 +73,7 @@ import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
+import org.apache.helix.manager.zk.ZKHelixAdmin;
 import org.apache.helix.zookeeper.impl.client.ZkClient;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -120,6 +121,7 @@ public class VeniceServer {
   private ServerReadMetadataRepository serverReadMetadataRepository;
   private BlobTransferManager<Void> blobTransferManager;
   private AggVersionedBlobTransferStats aggVersionedBlobTransferStats;
+  private Lazy<ZKHelixAdmin> zkHelixAdmin;
 
   /**
    * @deprecated Use {@link VeniceServer#VeniceServer(VeniceServerContext)} instead.
@@ -371,6 +373,7 @@ public class VeniceServer {
         serverConfig.getRegionName());
     services.add(heartbeatMonitoringService);
 
+    this.zkHelixAdmin = Lazy.of(() -> new ZKHelixAdmin(serverConfig.getZookeeperAddress()));
     // create and add KafkaSimpleConsumerService
     this.kafkaStoreIngestionService = new KafkaStoreIngestionService(
         storageService,
@@ -394,7 +397,8 @@ public class VeniceServer {
         remoteIngestionRepairService,
         pubSubClientsFactory,
         sslFactory,
-        heartbeatMonitoringService);
+        heartbeatMonitoringService,
+        zkHelixAdmin);
 
     this.diskHealthCheckService = new DiskHealthCheckService(
         serverConfig.isDiskHealthCheckServiceEnabled(),


### PR DESCRIPTION
<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## Mark a helix replica to error state during ingestion error
<!--
Describe
- What changes to make and why you are making these changes.
- How are you going to achieve your goal.
- Describe what testings you have done, for example, performance testing etc.

If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

If ingestion task encounters any error, it just marks the CV to error state which never remediates. This PR makes user of a new [API](https://github.com/apache/helix/pull/2792) helix added to annotate a replica to ERROR state. This will later be picked by the error replica reset task `ErrorPartitionResetTask`  which will attempt to recover those replicas. 
Also added system stores to the controller error replica reset task.

## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
GHCI
## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.