### PR TITLE
[controller] Ensure real-time topic partition count matches hybrid version partition count

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -12,7 +12,7 @@ plugins {
   id 'com.dorongold.task-tree' version '2.1.0'
   id 'com.github.johnrengelman.shadow' version '6.1.0' apply false
   id 'com.github.spotbugs' version '4.8.0' apply false
-  id 'org.gradle.test-retry' version '1.5.0' apply false
+  id 'org.gradle.test-retry' version '1.6.0' apply false
   id 'com.form.diff-coverage' version '0.9.5' apply false
   id 'me.champeau.jmh' version '0.6.7' apply false
   id 'io.github.lhotari.gradle-nar-plugin' version '0.5.1' apply false

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTask.java
@@ -846,6 +846,7 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
   private boolean isLocalVersionTopicPartitionFullyConsumed(PartitionConsumptionState pcs) {
     long localVTOff = pcs.getLatestProcessedLocalVersionTopicOffset();
     long localVTEndOffset = getTopicPartitionEndOffSet(localKafkaServer, versionTopic, pcs.getPartition());
+
     if (localVTEndOffset == StatsErrorCode.LAG_MEASUREMENT_FAILURE.code) {
       return false;
     }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
@@ -12,6 +12,7 @@ import static com.linkedin.davinci.validation.KafkaDataIntegrityValidator.DISABL
 import static com.linkedin.venice.ConfigKeys.KAFKA_BOOTSTRAP_SERVERS;
 import static com.linkedin.venice.LogMessages.KILLED_JOB_MESSAGE;
 import static com.linkedin.venice.kafka.protocol.enums.ControlMessageType.START_OF_SEGMENT;
+import static com.linkedin.venice.pubsub.PubSubConstants.UNKNOWN_LATEST_OFFSET;
 import static com.linkedin.venice.utils.Utils.FATAL_DATA_VALIDATION_ERROR;
 import static com.linkedin.venice.utils.Utils.getReplicaId;
 import static java.util.Comparator.comparingInt;
@@ -2346,16 +2347,17 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
    * written to, the end offset is 0.
    */
   protected long getTopicPartitionEndOffSet(String kafkaUrl, PubSubTopic pubSubTopic, int partition) {
-    long offsetFromConsumer = aggKafkaConsumerService
-        .getLatestOffsetBasedOnMetrics(kafkaUrl, versionTopic, new PubSubTopicPartitionImpl(pubSubTopic, partition));
+    PubSubTopicPartition topicPartition = new PubSubTopicPartitionImpl(pubSubTopic, partition);
+    long offsetFromConsumer =
+        aggKafkaConsumerService.getLatestOffsetBasedOnMetrics(kafkaUrl, versionTopic, topicPartition);
     if (offsetFromConsumer >= 0) {
       return offsetFromConsumer;
     }
     try {
       return RetryUtils.executeWithMaxAttemptAndExponentialBackoff(() -> {
         long offset = getTopicManager(kafkaUrl).getLatestOffsetCachedNonBlocking(pubSubTopic, partition);
-        if (offset == -1) {
-          throw new VeniceException("Found latest offset -1");
+        if (offset == UNKNOWN_LATEST_OFFSET) {
+          throw new VeniceException("Latest offset is unknown. Check if the topic: " + topicPartition + " exists.");
         }
         return offset;
       },
@@ -3103,6 +3105,13 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
         processEndOfIncrementalPush(controlMessage, partitionConsumptionState);
         break;
       case TOPIC_SWITCH:
+        TopicSwitch topicSwitch = (TopicSwitch) controlMessage.controlMessageUnion;
+        LOGGER.info(
+            "Received {} control message. Replica: {}, Offset: {} NewSource: {}",
+            type.name(),
+            partitionConsumptionState.getReplicaId(),
+            offset,
+            topicSwitch.getSourceKafkaServers());
         checkReadyToServeAfterProcess =
             processTopicSwitch(controlMessage, partition, offset, partitionConsumptionState);
         break;

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/consumer/VeniceChangelogConsumerClientFactoryTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/consumer/VeniceChangelogConsumerClientFactoryTest.java
@@ -3,7 +3,8 @@ package com.linkedin.davinci.consumer;
 import static com.linkedin.venice.ConfigKeys.CLUSTER_NAME;
 import static com.linkedin.venice.ConfigKeys.KAFKA_BOOTSTRAP_SERVERS;
 import static com.linkedin.venice.ConfigKeys.ZOOKEEPER_ADDRESS;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.linkedin.d2.balancer.D2Client;

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/stats/DIVStatsReporterTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/stats/DIVStatsReporterTest.java
@@ -1,8 +1,9 @@
 package com.linkedin.davinci.stats;
 
 import static com.linkedin.venice.stats.StatsErrorCode.NULL_DIV_STATS;
-import static org.mockito.Mockito.*;
-import static org.testng.Assert.*;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.testng.Assert.assertEquals;
 
 import com.linkedin.venice.tehuti.MockTehutiReporter;
 import com.linkedin.venice.utils.Utils;

--- a/clients/venice-client/src/test/java/com/linkedin/venice/fastclient/transport/GrpcTransportClientTest.java
+++ b/clients/venice-client/src/test/java/com/linkedin/venice/fastclient/transport/GrpcTransportClientTest.java
@@ -1,7 +1,17 @@
 package com.linkedin.venice.fastclient.transport;
 
-import static org.mockito.Mockito.*;
-import static org.testng.Assert.*;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.anyBoolean;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
 
 import com.google.common.collect.ImmutableMap;
 import com.linkedin.r2.transport.common.Client;

--- a/clients/venice-push-job/src/test/java/com/linkedin/venice/heartbeat/TestPushJobHeartbeatSender.java
+++ b/clients/venice-push-job/src/test/java/com/linkedin/venice/heartbeat/TestPushJobHeartbeatSender.java
@@ -1,6 +1,9 @@
 package com.linkedin.venice.heartbeat;
 
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import com.linkedin.venice.controllerapi.ControllerClient;
 import com.linkedin.venice.controllerapi.MultiSchemaResponse;

--- a/integrations/venice-samza/src/test/java/com/linkedin/venice/samza/VeniceSystemProducerTest.java
+++ b/integrations/venice-samza/src/test/java/com/linkedin/venice/samza/VeniceSystemProducerTest.java
@@ -2,7 +2,16 @@ package com.linkedin.venice.samza;
 
 import static com.linkedin.venice.ConfigKeys.KAFKA_BOOTSTRAP_SERVERS;
 import static com.linkedin.venice.pubsub.adapter.kafka.producer.ApacheKafkaProducerConfig.KAFKA_BUFFER_MEMORY;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.anyBoolean;
+import static org.mockito.Mockito.anyLong;
+import static org.mockito.Mockito.anyString;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertNull;

--- a/internal/venice-common/src/main/java/com/linkedin/venice/controllerapi/RequestTopicForPushRequest.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/controllerapi/RequestTopicForPushRequest.java
@@ -49,15 +49,6 @@ public class RequestTopicForPushRequest {
     this.pushJobId = pushJobId;
   }
 
-  public static PushType extractPushType(String pushTypeString) {
-    try {
-      return PushType.valueOf(pushTypeString);
-    } catch (IllegalArgumentException e) {
-      throw new IllegalArgumentException(
-          pushTypeString + " is an invalid push type. Valid push types are: " + Arrays.toString(PushType.values()));
-    }
-  }
-
   public String getClusterName() {
     return clusterName;
   }

--- a/internal/venice-common/src/main/java/com/linkedin/venice/controllerapi/RequestTopicForPushRequest.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/controllerapi/RequestTopicForPushRequest.java
@@ -1,0 +1,187 @@
+package com.linkedin.venice.controllerapi;
+
+import com.linkedin.venice.meta.Version.PushType;
+import java.security.cert.X509Certificate;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+
+
+public class RequestTopicForPushRequest {
+  private final String clusterName;
+  private final String storeName;
+  private final PushType pushType;
+  private final String pushJobId;
+
+  private boolean sendStartOfPush = false;
+  private boolean sorted = false; // an inefficient but safe default
+  private boolean isWriteComputeEnabled = false;
+  private boolean separateRealTimeTopicEnabled = false;
+  private long rewindTimeInSecondsOverride = -1L;
+  private boolean deferVersionSwap = false;
+  private String targetedRegions = null;
+  private int repushSourceVersion = -1;
+  private Set<String> partitioners = Collections.emptySet();
+  private String compressionDictionary = null;
+  private X509Certificate certificateInRequest = null;
+  private String sourceGridFabric = null;
+  private String emergencySourceRegion = null;
+
+  public RequestTopicForPushRequest(String clusterName, String storeName, PushType pushType, String pushJobId) {
+    if (clusterName == null || clusterName.isEmpty()) {
+      throw new IllegalArgumentException("clusterName is required");
+    }
+    if (storeName == null || storeName.isEmpty()) {
+      throw new IllegalArgumentException("storeName is required");
+    }
+    if (pushType == null) {
+      throw new IllegalArgumentException("pushType is required");
+    }
+
+    if (pushJobId == null || pushJobId.isEmpty()) {
+      throw new IllegalArgumentException("pushJobId is required");
+    }
+
+    this.clusterName = clusterName;
+    this.storeName = storeName;
+    this.pushType = pushType;
+    this.pushJobId = pushJobId;
+  }
+
+  public static PushType extractPushType(String pushTypeString) {
+    try {
+      return PushType.valueOf(pushTypeString);
+    } catch (IllegalArgumentException e) {
+      throw new IllegalArgumentException(
+          pushTypeString + " is an invalid push type. Valid push types are: " + Arrays.toString(PushType.values()));
+    }
+  }
+
+  public String getClusterName() {
+    return clusterName;
+  }
+
+  public String getStoreName() {
+    return storeName;
+  }
+
+  public PushType getPushType() {
+    return pushType;
+  }
+
+  public String getPushJobId() {
+    return pushJobId;
+  }
+
+  public boolean isSendStartOfPush() {
+    return sendStartOfPush;
+  }
+
+  public boolean isSorted() {
+    return sorted;
+  }
+
+  public boolean isWriteComputeEnabled() {
+    return isWriteComputeEnabled;
+  }
+
+  public String getSourceGridFabric() {
+    return sourceGridFabric;
+  }
+
+  public long getRewindTimeInSecondsOverride() {
+    return rewindTimeInSecondsOverride;
+  }
+
+  public boolean isDeferVersionSwap() {
+    return deferVersionSwap;
+  }
+
+  public String getTargetedRegions() {
+    return targetedRegions;
+  }
+
+  public int getRepushSourceVersion() {
+    return repushSourceVersion;
+  }
+
+  public Set<String> getPartitioners() {
+    return partitioners;
+  }
+
+  public String getCompressionDictionary() {
+    return compressionDictionary;
+  }
+
+  public X509Certificate getCertificateInRequest() {
+    return certificateInRequest;
+  }
+
+  public String getEmergencySourceRegion() {
+    return emergencySourceRegion;
+  }
+
+  public void setSendStartOfPush(boolean sendStartOfPush) {
+    this.sendStartOfPush = sendStartOfPush;
+  }
+
+  public void setSorted(boolean sorted) {
+    this.sorted = sorted;
+  }
+
+  public void setWriteComputeEnabled(boolean writeComputeEnabled) {
+    isWriteComputeEnabled = writeComputeEnabled;
+  }
+
+  public void setSourceGridFabric(String sourceGridFabric) {
+    this.sourceGridFabric = sourceGridFabric;
+  }
+
+  public void setRewindTimeInSecondsOverride(long rewindTimeInSecondsOverride) {
+    this.rewindTimeInSecondsOverride = rewindTimeInSecondsOverride;
+  }
+
+  public void setDeferVersionSwap(boolean deferVersionSwap) {
+    this.deferVersionSwap = deferVersionSwap;
+  }
+
+  public void setTargetedRegions(String targetedRegions) {
+    this.targetedRegions = targetedRegions;
+  }
+
+  public void setRepushSourceVersion(int repushSourceVersion) {
+    this.repushSourceVersion = repushSourceVersion;
+  }
+
+  public void setPartitioners(String commaSeparatedPartitioners) {
+    if (commaSeparatedPartitioners == null || commaSeparatedPartitioners.isEmpty()) {
+      return;
+    }
+    setPartitioners(new HashSet<>(Arrays.asList(commaSeparatedPartitioners.split(","))));
+  }
+
+  public void setPartitioners(Set<String> partitioners) {
+    this.partitioners = partitioners;
+  }
+
+  public void setCompressionDictionary(String compressionDictionary) {
+    this.compressionDictionary = compressionDictionary;
+  }
+
+  public void setCertificateInRequest(X509Certificate certificateInRequest) {
+    this.certificateInRequest = certificateInRequest;
+  }
+
+  public void setEmergencySourceRegion(String emergencySourceRegion) {
+    this.emergencySourceRegion = emergencySourceRegion;
+  }
+
+  public boolean isSeparateRealTimeTopicEnabled() {
+    return separateRealTimeTopicEnabled;
+  }
+
+  public void setSeparateRealTimeTopicEnabled(boolean separateRealTimeTopicEnabled) {
+    this.separateRealTimeTopicEnabled = separateRealTimeTopicEnabled;
+  }
+}

--- a/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/PubSubConstants.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/PubSubConstants.java
@@ -65,7 +65,7 @@ public class PubSubConstants {
    * Default value of sleep interval for polling topic deletion status from ZK.
    */
   public static final int PUBSUB_TOPIC_DELETION_STATUS_POLL_INTERVAL_MS_DEFAULT_VALUE = 2 * Time.MS_PER_SECOND;
-  public static final long UNKNOWN_LATEST_OFFSET = -12345;
+  public static final long UNKNOWN_LATEST_OFFSET = -404L;
 
   private static final Duration PUBSUB_OFFSET_API_TIMEOUT_DURATION_DEFAULT_VALUE_DEFAULT = Duration.ofMinutes(1);
   private static Duration PUBSUB_OFFSET_API_TIMEOUT_DURATION_DEFAULT_VALUE =

--- a/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/PubSubConstants.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/PubSubConstants.java
@@ -65,6 +65,7 @@ public class PubSubConstants {
    * Default value of sleep interval for polling topic deletion status from ZK.
    */
   public static final int PUBSUB_TOPIC_DELETION_STATUS_POLL_INTERVAL_MS_DEFAULT_VALUE = 2 * Time.MS_PER_SECOND;
+  public static final long UNKNOWN_LATEST_OFFSET = -12345;
 
   private static final Duration PUBSUB_OFFSET_API_TIMEOUT_DURATION_DEFAULT_VALUE_DEFAULT = Duration.ofMinutes(1);
   private static Duration PUBSUB_OFFSET_API_TIMEOUT_DURATION_DEFAULT_VALUE =

--- a/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/PubSubConstants.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/PubSubConstants.java
@@ -2,6 +2,7 @@ package com.linkedin.venice.pubsub;
 
 import com.linkedin.venice.pubsub.api.exceptions.PubSubClientRetriableException;
 import com.linkedin.venice.pubsub.api.exceptions.PubSubOpTimeoutException;
+import com.linkedin.venice.pubsub.api.exceptions.PubSubTopicDoesNotExistException;
 import com.linkedin.venice.utils.Time;
 import java.time.Duration;
 import java.util.Arrays;
@@ -61,11 +62,18 @@ public class PubSubConstants {
   public static final List<Class<? extends Throwable>> CREATE_TOPIC_RETRIABLE_EXCEPTIONS =
       Collections.unmodifiableList(Arrays.asList(PubSubOpTimeoutException.class, PubSubClientRetriableException.class));
 
+  public static final List<Class<? extends Throwable>> TOPIC_METADATA_OP_RETRIABLE_EXCEPTIONS =
+      Collections.unmodifiableList(
+          Arrays.asList(
+              PubSubTopicDoesNotExistException.class,
+              PubSubOpTimeoutException.class,
+              PubSubClientRetriableException.class));
+
   /**
    * Default value of sleep interval for polling topic deletion status from ZK.
    */
   public static final int PUBSUB_TOPIC_DELETION_STATUS_POLL_INTERVAL_MS_DEFAULT_VALUE = 2 * Time.MS_PER_SECOND;
-  public static final long UNKNOWN_LATEST_OFFSET = -404L;
+  public static final long UNKNOWN_LATEST_OFFSET = -1L;
 
   private static final Duration PUBSUB_OFFSET_API_TIMEOUT_DURATION_DEFAULT_VALUE_DEFAULT = Duration.ofMinutes(1);
   private static Duration PUBSUB_OFFSET_API_TIMEOUT_DURATION_DEFAULT_VALUE =

--- a/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/PubSubTopicConfiguration.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/PubSubTopicConfiguration.java
@@ -6,7 +6,7 @@ import java.util.Optional;
 /**
  * Represents a {@link com.linkedin.venice.pubsub.api.PubSubTopic} configuration.
  */
-public class PubSubTopicConfiguration {
+public class PubSubTopicConfiguration implements Cloneable {
   Optional<Long> retentionInMs;
   boolean isLogCompacted;
   Long minLogCompactionLagMs;
@@ -102,5 +102,10 @@ public class PubSubTopicConfiguration {
         minInSyncReplicas.isPresent() ? minInSyncReplicas.get() : "not set",
         minLogCompactionLagMs,
         maxLogCompactionLagMs.isPresent() ? maxLogCompactionLagMs.get() : " not set");
+  }
+
+  @Override
+  public PubSubTopicConfiguration clone() throws CloneNotSupportedException {
+    return (PubSubTopicConfiguration) super.clone();
   }
 }

--- a/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/manager/TopicManager.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/manager/TopicManager.java
@@ -272,6 +272,17 @@ public class TopicManager implements Closeable {
     return false;
   }
 
+  public boolean updateTopicRetentionWithRetries(PubSubTopic topicName, long expectedRetentionInMs) {
+    PubSubTopicConfiguration topicConfiguration = getCachedTopicConfig(topicName);
+    return RetryUtils.executeWithMaxAttemptAndExponentialBackoff(
+        () -> updateTopicRetention(topicName, expectedRetentionInMs, topicConfiguration),
+        5,
+        Duration.ofMillis(200),
+        Duration.ofSeconds(1),
+        Duration.ofMillis(2 * topicManagerContext.getPubSubOperationTimeoutMs()),
+        CREATE_TOPIC_RETRIABLE_EXCEPTIONS);
+  }
+
   public void updateTopicCompactionPolicy(PubSubTopic topic, boolean expectedLogCompacted) {
     updateTopicCompactionPolicy(topic, expectedLogCompacted, -1, Optional.empty());
   }

--- a/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/manager/TopicMetadataFetcher.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/manager/TopicMetadataFetcher.java
@@ -392,7 +392,7 @@ class TopicMetadataFetcher implements Closeable {
     if (cachedValue == null) {
       cachedValue = latestOffsetCache.get(pubSubTopicPartition);
       if (cachedValue == null) {
-        return -1;
+        return PubSubConstants.UNKNOWN_LATEST_OFFSET;
       }
     }
     return cachedValue.getValue();

--- a/internal/venice-common/src/main/java/com/linkedin/venice/utils/Utils.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/utils/Utils.java
@@ -308,6 +308,12 @@ public class Utils {
    * any string that are not equal to 'true', We validate the string by our own.
    */
   public static boolean parseBooleanFromString(String value, String fieldName) {
+    if (value == null) {
+      throw new VeniceHttpException(
+          HttpStatus.SC_BAD_REQUEST,
+          fieldName + " must be a boolean, but value is null",
+          ErrorType.BAD_REQUEST);
+    }
     if (value.equalsIgnoreCase("true") || value.equalsIgnoreCase("false")) {
       return Boolean.parseBoolean(value);
     } else {

--- a/internal/venice-common/src/test/java/com/linkedin/venice/controllerapi/RequestTopicForPushRequestTest.java
+++ b/internal/venice-common/src/test/java/com/linkedin/venice/controllerapi/RequestTopicForPushRequestTest.java
@@ -1,0 +1,114 @@
+package com.linkedin.venice.controllerapi;
+
+import static com.linkedin.venice.meta.Version.PushType.BATCH;
+import static com.linkedin.venice.meta.Version.PushType.STREAM;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import org.testng.Assert;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+
+public class RequestTopicForPushRequestTest {
+  private RequestTopicForPushRequest request;
+
+  @BeforeMethod
+  public void setUp() {
+    request = new RequestTopicForPushRequest("clusterA", "storeA", BATCH, "job123");
+  }
+
+  @Test
+  public void testRequestTopicForPushRequestConstructorArgs() {
+    assertEquals(request.getClusterName(), "clusterA");
+    assertEquals(request.getStoreName(), "storeA");
+    assertEquals(request.getPushType(), BATCH);
+    assertEquals(request.getPushJobId(), "job123");
+
+    // Invalid clusterName
+    IllegalArgumentException ex1 = Assert.expectThrows(
+        IllegalArgumentException.class,
+        () -> new RequestTopicForPushRequest("", "storeA", BATCH, "job123"));
+    assertEquals(ex1.getMessage(), "clusterName is required");
+
+    // Invalid storeName
+    IllegalArgumentException ex2 = Assert.expectThrows(
+        IllegalArgumentException.class,
+        () -> new RequestTopicForPushRequest("clusterA", "", BATCH, "job123"));
+    assertEquals(ex2.getMessage(), "storeName is required");
+
+    // Null pushType
+    IllegalArgumentException ex3 = Assert.expectThrows(
+        IllegalArgumentException.class,
+        () -> new RequestTopicForPushRequest("clusterA", "storeA", null, "job123"));
+    assertEquals(ex3.getMessage(), "pushType is required");
+
+    // Invalid pushJobId
+    IllegalArgumentException ex4 = Assert.expectThrows(
+        IllegalArgumentException.class,
+        () -> new RequestTopicForPushRequest("clusterA", "storeA", BATCH, ""));
+    assertEquals(ex4.getMessage(), "pushJobId is required");
+  }
+
+  @Test
+  public void testExtractPushTypeValidAndInvalidValues() {
+    // Valid cases
+    assertEquals(RequestTopicForPushRequest.extractPushType("BATCH"), BATCH);
+    assertEquals(RequestTopicForPushRequest.extractPushType("STREAM"), STREAM);
+
+    // Invalid case
+    IllegalArgumentException ex = Assert
+        .expectThrows(IllegalArgumentException.class, () -> RequestTopicForPushRequest.extractPushType("INVALID"));
+    assertTrue(ex.getMessage().contains("INVALID is an invalid push type"));
+  }
+
+  @Test
+  public void testRequestTopicForPushRequestSettersAndGetters() {
+    request.setSendStartOfPush(true);
+    request.setSorted(true);
+    request.setWriteComputeEnabled(true);
+    request.setSourceGridFabric("fabricA");
+    request.setRewindTimeInSecondsOverride(3600);
+    request.setDeferVersionSwap(true);
+    request.setTargetedRegions("regionA,regionB");
+    request.setRepushSourceVersion(42);
+    request.setPartitioners("partitioner1,partitioner2");
+    request.setCompressionDictionary("compressionDict");
+    request.setEmergencySourceRegion("regionX");
+
+    assertTrue(request.isSendStartOfPush());
+    assertTrue(request.isSorted());
+    assertTrue(request.isWriteComputeEnabled());
+    assertEquals(request.getSourceGridFabric(), "fabricA");
+    assertEquals(request.getRewindTimeInSecondsOverride(), 3600);
+    assertTrue(request.isDeferVersionSwap());
+    assertEquals(request.getTargetedRegions(), "regionA,regionB");
+    assertEquals(request.getRepushSourceVersion(), 42);
+    assertEquals(request.getPartitioners(), new HashSet<>(Arrays.asList("partitioner1", "partitioner2")));
+    assertEquals(request.getCompressionDictionary(), "compressionDict");
+    assertEquals(request.getEmergencySourceRegion(), "regionX");
+  }
+
+  @Test
+  public void testSetPartitionersValidAndEmptyCases() {
+    // Valid partitioners
+    request.setPartitioners("partitioner1");
+    assertEquals(request.getPartitioners(), new HashSet<>(Collections.singletonList("partitioner1")));
+    request.setPartitioners("partitioner1,partitioner2");
+    assertEquals(request.getPartitioners(), new HashSet<>(Arrays.asList("partitioner1", "partitioner2")));
+
+    // Empty set
+    request.setPartitioners(Collections.emptySet());
+    assertEquals(request.getPartitioners(), Collections.emptySet());
+
+    // Null and empty string
+    request.setPartitioners((String) null);
+    assertEquals(request.getPartitioners(), Collections.emptySet());
+
+    request.setPartitioners("");
+    assertEquals(request.getPartitioners(), Collections.emptySet());
+  }
+}

--- a/internal/venice-common/src/test/java/com/linkedin/venice/controllerapi/RequestTopicForPushRequestTest.java
+++ b/internal/venice-common/src/test/java/com/linkedin/venice/controllerapi/RequestTopicForPushRequestTest.java
@@ -1,7 +1,6 @@
 package com.linkedin.venice.controllerapi;
 
 import static com.linkedin.venice.meta.Version.PushType.BATCH;
-import static com.linkedin.venice.meta.Version.PushType.STREAM;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
 
@@ -51,18 +50,6 @@ public class RequestTopicForPushRequestTest {
         IllegalArgumentException.class,
         () -> new RequestTopicForPushRequest("clusterA", "storeA", BATCH, ""));
     assertEquals(ex4.getMessage(), "pushJobId is required");
-  }
-
-  @Test
-  public void testExtractPushTypeValidAndInvalidValues() {
-    // Valid cases
-    assertEquals(RequestTopicForPushRequest.extractPushType("BATCH"), BATCH);
-    assertEquals(RequestTopicForPushRequest.extractPushType("STREAM"), STREAM);
-
-    // Invalid case
-    IllegalArgumentException ex = Assert
-        .expectThrows(IllegalArgumentException.class, () -> RequestTopicForPushRequest.extractPushType("INVALID"));
-    assertTrue(ex.getMessage().contains("INVALID is an invalid push type"));
   }
 
   @Test

--- a/internal/venice-common/src/test/java/com/linkedin/venice/controllerapi/RequestTopicForPushRequestTest.java
+++ b/internal/venice-common/src/test/java/com/linkedin/venice/controllerapi/RequestTopicForPushRequestTest.java
@@ -1,9 +1,11 @@
 package com.linkedin.venice.controllerapi;
 
 import static com.linkedin.venice.meta.Version.PushType.BATCH;
+import static org.mockito.Mockito.*;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
 
+import java.security.cert.X509Certificate;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
@@ -65,6 +67,10 @@ public class RequestTopicForPushRequestTest {
     request.setPartitioners("partitioner1,partitioner2");
     request.setCompressionDictionary("compressionDict");
     request.setEmergencySourceRegion("regionX");
+    request.setSeparateRealTimeTopicEnabled(true);
+
+    X509Certificate x509Certificate = mock(X509Certificate.class);
+    request.setCertificateInRequest(x509Certificate);
 
     assertTrue(request.isSendStartOfPush());
     assertTrue(request.isSorted());
@@ -77,6 +83,8 @@ public class RequestTopicForPushRequestTest {
     assertEquals(request.getPartitioners(), new HashSet<>(Arrays.asList("partitioner1", "partitioner2")));
     assertEquals(request.getCompressionDictionary(), "compressionDict");
     assertEquals(request.getEmergencySourceRegion(), "regionX");
+    assertTrue(request.isSeparateRealTimeTopicEnabled());
+    assertEquals(request.getCertificateInRequest(), x509Certificate);
   }
 
   @Test

--- a/internal/venice-common/src/test/java/com/linkedin/venice/controllerapi/RequestTopicForPushRequestTest.java
+++ b/internal/venice-common/src/test/java/com/linkedin/venice/controllerapi/RequestTopicForPushRequestTest.java
@@ -1,7 +1,7 @@
 package com.linkedin.venice.controllerapi;
 
 import static com.linkedin.venice.meta.Version.PushType.BATCH;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.mock;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
 

--- a/internal/venice-common/src/test/java/com/linkedin/venice/helix/HelixCustomizedViewOfflinePushRepositoryTest.java
+++ b/internal/venice-common/src/test/java/com/linkedin/venice/helix/HelixCustomizedViewOfflinePushRepositoryTest.java
@@ -1,7 +1,12 @@
 package com.linkedin.venice.helix;
 
-import static org.mockito.ArgumentMatchers.*;
-import static org.mockito.Mockito.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import com.linkedin.venice.meta.ReadOnlyStoreRepository;
 import com.linkedin.venice.meta.Store;

--- a/internal/venice-common/src/test/java/com/linkedin/venice/helix/TestHelixLiveInstanceMonitor.java
+++ b/internal/venice-common/src/test/java/com/linkedin/venice/helix/TestHelixLiveInstanceMonitor.java
@@ -1,7 +1,9 @@
 package com.linkedin.venice.helix;
 
-import static org.mockito.ArgumentMatchers.*;
-import static org.mockito.Mockito.*;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 
 import org.apache.helix.zookeeper.impl.client.ZkClient;
 import org.mockito.Mockito;

--- a/internal/venice-common/src/test/java/com/linkedin/venice/meta/RetryManagerTest.java
+++ b/internal/venice-common/src/test/java/com/linkedin/venice/meta/RetryManagerTest.java
@@ -1,6 +1,7 @@
 package com.linkedin.venice.meta;
 
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
 
 import com.linkedin.venice.utils.TestUtils;
 import io.tehuti.metrics.MetricsRepository;

--- a/internal/venice-common/src/test/java/com/linkedin/venice/meta/TestVersion.java
+++ b/internal/venice-common/src/test/java/com/linkedin/venice/meta/TestVersion.java
@@ -1,9 +1,14 @@
 package com.linkedin.venice.meta;
 
 import static com.linkedin.venice.meta.Version.VENICE_TTL_RE_PUSH_PUSH_ID_PREFIX;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.expectThrows;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.linkedin.venice.exceptions.VeniceException;
+import com.linkedin.venice.meta.Version.PushType;
 import com.linkedin.venice.utils.ObjectMapperFactory;
 import com.linkedin.venice.utils.Utils;
 import java.io.IOException;
@@ -27,7 +32,7 @@ public class TestVersion {
   @Test
   public void identifiesValidTopicNames() {
     String goodTopic = "my_very_good_store_v4";
-    Assert.assertTrue(
+    assertTrue(
         Version.isVersionTopicOrStreamReprocessingTopic(goodTopic),
         goodTopic + " should parse as a valid store-version topic");
 
@@ -43,7 +48,7 @@ public class TestVersion {
     int versionNumber = 17;
     Version version = new VersionImpl(storeName, versionNumber);
     String serialized = OBJECT_MAPPER.writeValueAsString(version);
-    Assert.assertTrue(serialized.contains(storeName));
+    assertTrue(serialized.contains(storeName));
   }
 
   /**
@@ -54,21 +59,21 @@ public class TestVersion {
   @Test
   public void deserializeWithWrongFields() throws IOException {
     Version oldParsedVersion = OBJECT_MAPPER.readValue(OLD_SERIALIZED, Version.class);
-    Assert.assertEquals(oldParsedVersion.getStoreName(), "store-1492637190910-78714331");
+    assertEquals(oldParsedVersion.getStoreName(), "store-1492637190910-78714331");
 
     Version newParsedVersion = OBJECT_MAPPER.readValue(EXTRA_FIELD_SERIALIZED, Version.class);
-    Assert.assertEquals(newParsedVersion.getStoreName(), "store-1492637190910-12345678");
+    assertEquals(newParsedVersion.getStoreName(), "store-1492637190910-12345678");
 
     Version legacyParsedVersion = OBJECT_MAPPER.readValue(MISSING_FIELD_SERIALIZED, Version.class);
-    Assert.assertEquals(legacyParsedVersion.getStoreName(), "store-missing");
-    Assert.assertNotNull(legacyParsedVersion.getPushJobId()); // missing final field can still deserialize, just gets
-                                                              // arbitrary value from constructor
+    assertEquals(legacyParsedVersion.getStoreName(), "store-missing");
+    assertNotNull(legacyParsedVersion.getPushJobId()); // missing final field can still deserialize, just gets
+                                                       // arbitrary value from constructor
   }
 
   @Test
   public void testParseStoreFromRealTimeTopic() {
     String validRealTimeTopic = "abc_rt";
-    Assert.assertEquals(Version.parseStoreFromRealTimeTopic(validRealTimeTopic), "abc");
+    assertEquals(Version.parseStoreFromRealTimeTopic(validRealTimeTopic), "abc");
     String invalidRealTimeTopic = "abc";
     try {
       Version.parseStoreFromRealTimeTopic(invalidRealTimeTopic);
@@ -82,19 +87,19 @@ public class TestVersion {
   public void testIsTopic() {
     String topic = "abc_rt";
     Assert.assertFalse(Version.isVersionTopic(topic));
-    Assert.assertTrue(Version.isRealTimeTopic(topic));
+    assertTrue(Version.isRealTimeTopic(topic));
     topic = "abc";
     Assert.assertFalse(Version.isVersionTopic(topic));
     topic = "abc_v12df";
     Assert.assertFalse(Version.isVersionTopic(topic));
     topic = "abc_v123";
-    Assert.assertTrue(Version.isVersionTopic(topic));
+    assertTrue(Version.isVersionTopic(topic));
     Assert.assertFalse(Version.isRealTimeTopic(topic));
-    Assert.assertTrue(Version.isVersionTopicOrStreamReprocessingTopic(topic));
+    assertTrue(Version.isVersionTopicOrStreamReprocessingTopic(topic));
     topic = "abc_v123_sr";
     Assert.assertFalse(Version.isVersionTopic(topic));
-    Assert.assertTrue(Version.isStreamReprocessingTopic(topic));
-    Assert.assertTrue(Version.isVersionTopicOrStreamReprocessingTopic(topic));
+    assertTrue(Version.isStreamReprocessingTopic(topic));
+    assertTrue(Version.isVersionTopicOrStreamReprocessingTopic(topic));
     topic = "abc_v12ab3_sr";
     Assert.assertFalse(Version.isVersionTopic(topic));
     Assert.assertFalse(Version.isStreamReprocessingTopic(topic));
@@ -110,43 +115,101 @@ public class TestVersion {
     String topic = "abc_rt";
     Assert.assertFalse(Version.isATopicThatIsVersioned(topic));
     topic = "abc_v1_sr";
-    Assert.assertTrue(Version.isATopicThatIsVersioned(topic));
+    assertTrue(Version.isATopicThatIsVersioned(topic));
     topic = "abc_v1";
-    Assert.assertTrue(Version.isATopicThatIsVersioned(topic));
+    assertTrue(Version.isATopicThatIsVersioned(topic));
     topic = "abc_v1_cc";
-    Assert.assertTrue(Version.isATopicThatIsVersioned(topic));
+    assertTrue(Version.isATopicThatIsVersioned(topic));
     String pushId = VENICE_TTL_RE_PUSH_PUSH_ID_PREFIX + System.currentTimeMillis();
-    Assert.assertTrue(Version.isPushIdTTLRePush(pushId));
+    assertTrue(Version.isPushIdTTLRePush(pushId));
   }
 
   @Test
   public void testParseStoreFromKafkaTopicName() {
     String storeName = "abc";
     String topic = "abc_rt";
-    Assert.assertEquals(Version.parseStoreFromKafkaTopicName(topic), storeName);
+    assertEquals(Version.parseStoreFromKafkaTopicName(topic), storeName);
     topic = "abc_v1";
-    Assert.assertEquals(Version.parseStoreFromKafkaTopicName(topic), storeName);
+    assertEquals(Version.parseStoreFromKafkaTopicName(topic), storeName);
     topic = "abc_v1_cc";
-    Assert.assertEquals(Version.parseStoreFromKafkaTopicName(topic), storeName);
+    assertEquals(Version.parseStoreFromKafkaTopicName(topic), storeName);
   }
 
   @Test
   public void testParseVersionFromKafkaTopicName() {
     int version = 1;
     String topic = "abc_v1";
-    Assert.assertEquals(Version.parseVersionFromVersionTopicName(topic), version);
+    assertEquals(Version.parseVersionFromVersionTopicName(topic), version);
     topic = "abc_v1_cc";
-    Assert.assertEquals(Version.parseVersionFromKafkaTopicName(topic), version);
+    assertEquals(Version.parseVersionFromKafkaTopicName(topic), version);
   }
 
   @Test
   void testVersionStatus() {
     for (VersionStatus status: VersionStatus.values()) {
       if (status == VersionStatus.KILLED) {
-        Assert.assertTrue(VersionStatus.isVersionKilled(status));
+        assertTrue(VersionStatus.isVersionKilled(status));
       } else {
         Assert.assertFalse(VersionStatus.isVersionKilled(status));
       }
     }
+  }
+
+  @Test
+  public void testExtractPushType() {
+    // Case 1: Valid push types
+    assertEquals(PushType.extractPushType("BATCH"), PushType.BATCH);
+    assertEquals(PushType.extractPushType("STREAM_REPROCESSING"), PushType.STREAM_REPROCESSING);
+    assertEquals(PushType.extractPushType("STREAM"), PushType.STREAM);
+    assertEquals(PushType.extractPushType("INCREMENTAL"), PushType.INCREMENTAL);
+
+    // Case 2: Invalid push type
+    String invalidType = "INVALID_TYPE";
+    IllegalArgumentException invalidException =
+        expectThrows(IllegalArgumentException.class, () -> PushType.extractPushType(invalidType));
+    assertTrue(invalidException.getMessage().contains(invalidType));
+    assertTrue(invalidException.getMessage().contains("Valid push types are"));
+
+    // Case 3: Case sensitivity
+    String lowerCaseType = "batch";
+    IllegalArgumentException caseException =
+        expectThrows(IllegalArgumentException.class, () -> PushType.extractPushType(lowerCaseType));
+    assertTrue(caseException.getMessage().contains(lowerCaseType));
+
+    // Case 4: Empty string
+    String emptyInput = "";
+    IllegalArgumentException emptyException =
+        expectThrows(IllegalArgumentException.class, () -> PushType.extractPushType(emptyInput));
+    assertTrue(emptyException.getMessage().contains(emptyInput));
+
+    // Case 5: Null input
+    IllegalArgumentException exception =
+        expectThrows(IllegalArgumentException.class, () -> PushType.extractPushType(null));
+    assertNotNull(exception);
+  }
+
+  @Test
+  public void testValueOfIntReturnsPushType() {
+    // Case 1: Valid integer values
+    assertEquals(PushType.valueOf(0), PushType.BATCH);
+    assertEquals(PushType.valueOf(1), PushType.STREAM_REPROCESSING);
+    assertEquals(PushType.valueOf(2), PushType.STREAM);
+    assertEquals(PushType.valueOf(3), PushType.INCREMENTAL);
+
+    // Case 2: Invalid integer value (negative)
+    int invalidNegative = -1;
+    VeniceException negativeException = expectThrows(VeniceException.class, () -> PushType.valueOf(invalidNegative));
+    assertTrue(negativeException.getMessage().contains("Invalid push type with int value: " + invalidNegative));
+
+    // Case 3: Invalid integer value (positive out of range)
+    int invalidPositive = 999;
+    VeniceException positiveException = expectThrows(VeniceException.class, () -> PushType.valueOf(invalidPositive));
+    assertTrue(positiveException.getMessage().contains("Invalid push type with int value: " + invalidPositive));
+
+    // Case 4: Edge case - Valid minimum value
+    assertEquals(PushType.valueOf(0), PushType.BATCH);
+
+    // Case 5: Edge case - Valid maximum value
+    assertEquals(PushType.valueOf(3), PushType.INCREMENTAL);
   }
 }

--- a/internal/venice-common/src/test/java/com/linkedin/venice/pubsub/PubSubTopicConfigurationTest.java
+++ b/internal/venice-common/src/test/java/com/linkedin/venice/pubsub/PubSubTopicConfigurationTest.java
@@ -1,0 +1,121 @@
+package com.linkedin.venice.pubsub;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNotEquals;
+import static org.testng.Assert.assertNotSame;
+import static org.testng.Assert.assertNull;
+
+import java.util.Optional;
+import org.testng.annotations.Test;
+
+
+public class PubSubTopicConfigurationTest {
+  @Test
+  public void testPubSubTopicConfiguration() throws CloneNotSupportedException {
+    // Case 1: Verify construction and getters
+    Optional<Long> retentionInMs = Optional.of(3600000L);
+    boolean isLogCompacted = true;
+    Optional<Integer> minInSyncReplicas = Optional.of(2);
+    Long minLogCompactionLagMs = 60000L;
+    Optional<Long> maxLogCompactionLagMs = Optional.of(120000L);
+
+    PubSubTopicConfiguration config = new PubSubTopicConfiguration(
+        retentionInMs,
+        isLogCompacted,
+        minInSyncReplicas,
+        minLogCompactionLagMs,
+        maxLogCompactionLagMs);
+
+    assertEquals(config.retentionInMs(), retentionInMs, "Retention in ms should match the provided value.");
+    assertEquals(config.isLogCompacted(), isLogCompacted, "Log compaction flag should match the provided value.");
+    assertEquals(
+        config.minInSyncReplicas(),
+        minInSyncReplicas,
+        "Min in-sync replicas should match the provided value.");
+    assertEquals(
+        config.minLogCompactionLagMs(),
+        minLogCompactionLagMs,
+        "Min log compaction lag ms should match the provided value.");
+    assertEquals(
+        config.getMaxLogCompactionLagMs(),
+        maxLogCompactionLagMs,
+        "Max log compaction lag ms should match the provided value.");
+
+    // Case 2: Verify setters
+    config.setLogCompacted(false);
+    config.setRetentionInMs(Optional.of(7200000L));
+    config.setMinInSyncReplicas(Optional.of(3));
+    config.setMinLogCompactionLagMs(120000L);
+    config.setMaxLogCompactionLagMs(Optional.of(180000L));
+
+    assertFalse(config.isLogCompacted(), "Log compaction flag should be updated.");
+    assertEquals(config.retentionInMs(), Optional.of(7200000L), "Retention in ms should be updated.");
+    assertEquals(config.minInSyncReplicas(), Optional.of(3), "Min in-sync replicas should be updated.");
+    assertEquals(config.minLogCompactionLagMs(), Long.valueOf(120000L), "Min log compaction lag ms should be updated.");
+    assertEquals(
+        config.getMaxLogCompactionLagMs(),
+        Optional.of(180000L),
+        "Max log compaction lag ms should be updated.");
+
+    // Case 3: Verify cloning
+    PubSubTopicConfiguration clonedConfig = config.clone();
+
+    assertNotSame(clonedConfig, config, "Cloned object should not be the same as the original.");
+    assertEquals(
+        clonedConfig.retentionInMs(),
+        config.retentionInMs(),
+        "Retention in ms should be identical in the cloned object.");
+    assertEquals(
+        clonedConfig.isLogCompacted(),
+        config.isLogCompacted(),
+        "Log compaction flag should be identical in the cloned object.");
+    assertEquals(
+        clonedConfig.minInSyncReplicas(),
+        config.minInSyncReplicas(),
+        "Min in-sync replicas should be identical in the cloned object.");
+    assertEquals(
+        clonedConfig.minLogCompactionLagMs(),
+        config.minLogCompactionLagMs(),
+        "Min log compaction lag ms should be identical in the cloned object.");
+    assertEquals(
+        clonedConfig.getMaxLogCompactionLagMs(),
+        config.getMaxLogCompactionLagMs(),
+        "Max log compaction lag ms should be identical in the cloned object.");
+
+    clonedConfig.setLogCompacted(true);
+    clonedConfig.setRetentionInMs(Optional.of(14400000L));
+    clonedConfig.setMinInSyncReplicas(Optional.of(4));
+    clonedConfig.setMinLogCompactionLagMs(180000L);
+
+    assertNotEquals(
+        config.isLogCompacted(),
+        clonedConfig.isLogCompacted(),
+        "Log compaction flag should be different in the cloned object.");
+    assertNotEquals(
+        config.retentionInMs(),
+        clonedConfig.retentionInMs(),
+        "Retention in ms should be different in the cloned object.");
+    assertNotEquals(
+        config.minInSyncReplicas(),
+        clonedConfig.minInSyncReplicas(),
+        "Min in-sync replicas should be different in the cloned object.");
+    assertNotEquals(
+        config.minLogCompactionLagMs(),
+        clonedConfig.minLogCompactionLagMs(),
+        "Min log compaction lag ms should be different in the cloned object.");
+    assertEquals(
+        config.getMaxLogCompactionLagMs(),
+        clonedConfig.getMaxLogCompactionLagMs(),
+        "Max log compaction lag ms should be identical in the cloned object.");
+
+    // Case 4: Verify edge cases
+    PubSubTopicConfiguration emptyConfig =
+        new PubSubTopicConfiguration(Optional.empty(), false, Optional.empty(), null, Optional.empty());
+
+    assertFalse(emptyConfig.retentionInMs().isPresent(), "Retention in ms should be empty.");
+    assertFalse(emptyConfig.minInSyncReplicas().isPresent(), "Min in-sync replicas should be empty.");
+    assertNull(emptyConfig.minLogCompactionLagMs(), "Min log compaction lag ms should be null.");
+    assertFalse(emptyConfig.getMaxLogCompactionLagMs().isPresent(), "Max log compaction lag ms should be empty.");
+  }
+}

--- a/internal/venice-common/src/test/java/com/linkedin/venice/pubsub/adapter/kafka/admin/ApacheKafkaAdminConfigTest.java
+++ b/internal/venice-common/src/test/java/com/linkedin/venice/pubsub/adapter/kafka/admin/ApacheKafkaAdminConfigTest.java
@@ -1,6 +1,6 @@
 package com.linkedin.venice.pubsub.adapter.kafka.admin;
 
-import static org.testng.Assert.*;
+import static org.testng.Assert.assertEquals;
 
 import com.linkedin.venice.pubsub.api.PubSubSecurityProtocol;
 import com.linkedin.venice.utils.VeniceProperties;

--- a/internal/venice-common/src/test/java/com/linkedin/venice/pubsub/manager/TopicMetadataFetcherTest.java
+++ b/internal/venice-common/src/test/java/com/linkedin/venice/pubsub/manager/TopicMetadataFetcherTest.java
@@ -29,6 +29,7 @@ import com.linkedin.venice.kafka.protocol.KafkaMessageEnvelope;
 import com.linkedin.venice.kafka.protocol.ProducerMetadata;
 import com.linkedin.venice.message.KafkaKey;
 import com.linkedin.venice.pubsub.ImmutablePubSubMessage;
+import com.linkedin.venice.pubsub.PubSubConstants;
 import com.linkedin.venice.pubsub.PubSubTopicPartitionImpl;
 import com.linkedin.venice.pubsub.PubSubTopicPartitionInfo;
 import com.linkedin.venice.pubsub.PubSubTopicRepository;
@@ -262,7 +263,7 @@ public class TopicMetadataFetcherTest {
     assertEquals(res.get(1), 222L);
     assertEquals(
         topicMetadataFetcher.getLatestOffsetCachedNonBlocking(new PubSubTopicPartitionImpl(pubSubTopic, 0)),
-        -1);
+        PubSubConstants.UNKNOWN_LATEST_OFFSET);
 
     verify(consumerMock, times(3)).partitionsFor(pubSubTopic);
     verify(consumerMock, times(1)).endOffsets(eq(offsetsMap.keySet()), any(Duration.class));

--- a/internal/venice-common/src/test/java/com/linkedin/venice/pushstatushelper/PushStatusStoreReaderTest.java
+++ b/internal/venice-common/src/test/java/com/linkedin/venice/pushstatushelper/PushStatusStoreReaderTest.java
@@ -3,7 +3,7 @@ package com.linkedin.venice.pushstatushelper;
 import static com.linkedin.venice.common.PushStatusStoreUtils.SERVER_INCREMENTAL_PUSH_PREFIX;
 import static com.linkedin.venice.common.PushStatusStoreUtils.getServerIncrementalPushKey;
 import static com.linkedin.venice.pushmonitor.ExecutionStatus.END_OF_INCREMENTAL_PUSH_RECEIVED;
-import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.anySet;
 import static org.mockito.Mockito.doCallRealMethod;

--- a/internal/venice-common/src/test/java/com/linkedin/venice/serialization/avro/AvroSpecificStoreDeserializerCacheTest.java
+++ b/internal/venice-common/src/test/java/com/linkedin/venice/serialization/avro/AvroSpecificStoreDeserializerCacheTest.java
@@ -1,6 +1,11 @@
 package com.linkedin.venice.serialization.avro;
 
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.anyInt;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertSame;
 

--- a/internal/venice-common/src/test/java/com/linkedin/venice/utils/KafkaSSLUtilsTest.java
+++ b/internal/venice-common/src/test/java/com/linkedin/venice/utils/KafkaSSLUtilsTest.java
@@ -1,6 +1,7 @@
 package com.linkedin.venice.utils;
 
-import static org.testng.Assert.*;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
 
 import com.linkedin.venice.pubsub.api.PubSubSecurityProtocol;
 import org.testng.annotations.Test;

--- a/internal/venice-common/src/test/java/com/linkedin/venice/utils/UtilsTest.java
+++ b/internal/venice-common/src/test/java/com/linkedin/venice/utils/UtilsTest.java
@@ -10,6 +10,7 @@ import static org.testng.Assert.expectThrows;
 import static org.testng.Assert.fail;
 
 import com.linkedin.venice.exceptions.VeniceException;
+import com.linkedin.venice.exceptions.VeniceHttpException;
 import com.linkedin.venice.meta.HybridStoreConfig;
 import com.linkedin.venice.meta.Store;
 import com.linkedin.venice.meta.StoreInfo;
@@ -29,7 +30,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.TreeMap;
+import org.apache.http.HttpStatus;
 import org.testng.Assert;
+import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 import org.testng.collections.Lists;
 
@@ -499,5 +502,35 @@ public class UtilsTest {
   void testInvalidOldNameWithNonNumericVersion() {
     String oldName = "storeName_vX_rt";
     assertThrows(NumberFormatException.class, () -> Utils.createNewRealTimeTopicName(oldName));
+  }
+
+  @DataProvider(name = "booleanParsingData")
+  public Object[][] booleanParsingData() {
+    return new Object[][] {
+        // Valid cases
+        { "true", "testField", true }, // Valid "true"
+        { "false", "testField", false }, // Valid "false"
+        { "TRUE", "testField", true }, // Valid case-insensitive "TRUE"
+        { "FALSE", "testField", false }, // Valid case-insensitive "FALSE"
+
+        // Invalid cases
+        { "notABoolean", "testField", null }, // Invalid string
+        { "123", "testField", null }, // Non-boolean numeric string
+        { "", "testField", null }, // Empty string
+        { null, "testField", null }, // Null input
+    };
+  }
+
+  @Test(dataProvider = "booleanParsingData")
+  public void testParseBooleanFromString(String value, String fieldName, Boolean expectedResult) {
+    if (expectedResult != null) {
+      // For valid cases
+      boolean result = Utils.parseBooleanFromString(value, fieldName);
+      assertEquals((boolean) expectedResult, result, "Parsed boolean value does not match expected value.");
+      return;
+    }
+    VeniceHttpException e =
+        expectThrows(VeniceHttpException.class, () -> Utils.parseBooleanFromString(value, fieldName));
+    assertEquals(e.getHttpStatusCode(), HttpStatus.SC_BAD_REQUEST, "Invalid status code.");
   }
 }

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/consumer/TestChangelogConsumer.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/consumer/TestChangelogConsumer.java
@@ -112,7 +112,6 @@ public class TestChangelogConsumer {
   private String clusterName;
   private VeniceClusterWrapper clusterWrapper;
   private ControllerClient parentControllerClient;
-
   private static final List<Schema> SCHEMA_HISTORY = Arrays.asList(
       NAME_RECORD_V1_SCHEMA,
       NAME_RECORD_V2_SCHEMA,

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/controller/TestInstanceRemovable.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/controller/TestInstanceRemovable.java
@@ -1,10 +1,12 @@
 package com.linkedin.venice.controller;
 
+import com.linkedin.venice.ConfigKeys;
 import com.linkedin.venice.controllerapi.ControllerClient;
 import com.linkedin.venice.controllerapi.StoppableNodeStatusResponse;
 import com.linkedin.venice.controllerapi.UpdateStoreQueryParams;
 import com.linkedin.venice.controllerapi.VersionCreationResponse;
 import com.linkedin.venice.integration.utils.ServiceFactory;
+import com.linkedin.venice.integration.utils.VeniceClusterCreateOptions;
 import com.linkedin.venice.integration.utils.VeniceClusterWrapper;
 import com.linkedin.venice.integration.utils.VeniceServerWrapper;
 import com.linkedin.venice.meta.PartitionAssignment;
@@ -34,17 +36,16 @@ public class TestInstanceRemovable {
   int replicaFactor = 3;
 
   private void setupCluster(int numberOfServer) {
-    int numberOfController = 1;
-    int numberOfRouter = 1;
-
+    Properties properties = new Properties();
+    properties.setProperty(ConfigKeys.PARTICIPANT_MESSAGE_STORE_ENABLED, "false");
     cluster = ServiceFactory.getVeniceCluster(
-        numberOfController,
-        numberOfServer,
-        numberOfRouter,
-        replicaFactor,
-        partitionSize,
-        false,
-        false);
+        new VeniceClusterCreateOptions.Builder().numberOfControllers(1)
+            .numberOfServers(numberOfServer)
+            .numberOfRouters(1)
+            .replicationFactor(replicaFactor)
+            .partitionSize(partitionSize)
+            .extraProperties(properties)
+            .build());
   }
 
   @AfterMethod
@@ -169,7 +170,7 @@ public class TestInstanceRemovable {
 
     // Wait push completed.
     TestUtils.waitForNonDeterministicCompletion(
-        3,
+        30,
         TimeUnit.SECONDS,
         () -> cluster.getLeaderVeniceController()
             .getVeniceAdmin()

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/controller/TestVeniceHelixAdminWithSharedEnvironment.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/controller/TestVeniceHelixAdminWithSharedEnvironment.java
@@ -11,9 +11,12 @@ import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.reset;
+import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertThrows;
+import static org.testng.Assert.assertTrue;
 
 import com.linkedin.venice.ConfigKeys;
+import com.linkedin.venice.common.VeniceSystemStoreType;
 import com.linkedin.venice.common.VeniceSystemStoreUtils;
 import com.linkedin.venice.compression.CompressionStrategy;
 import com.linkedin.venice.controller.exception.HelixClusterMaintenanceModeException;
@@ -71,6 +74,7 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Properties;
 import java.util.concurrent.CompletableFuture;
@@ -641,34 +645,46 @@ public class TestVeniceHelixAdminWithSharedEnvironment extends AbstractTestVenic
   }
 
   @Test(timeOut = TOTAL_TIMEOUT_FOR_LONG_TEST_MS)
-  public void testGetRealTimeTopic() {
+  public void testEnsureRealTimeTopicExistsForUserSystemStores() {
     String storeName = Utils.getUniqueString("store");
+    String metaStoreName = VeniceSystemStoreType.META_STORE.getSystemStoreName(storeName);
 
-    // Must not be able to get a real time topic until the store is created
-    Assert.assertThrows(VeniceNoStoreException.class, () -> veniceAdmin.getRealTimeTopic(clusterName, storeName, null));
+    Exception notSystemStoreException = Assert.expectThrows(
+        VeniceNoStoreException.class,
+        () -> veniceAdmin.ensureRealTimeTopicExistsForUserSystemStores(clusterName, metaStoreName));
+    assertTrue(
+        notSystemStoreException.getMessage().contains("does not exist in"),
+        "Got unexpected error message: " + notSystemStoreException.getMessage());
 
     veniceAdmin.createStore(clusterName, storeName, "owner", KEY_SCHEMA, VALUE_SCHEMA);
-    Store store = veniceAdmin.getStore(clusterName, storeName);
+    Store userStore = veniceAdmin.getStore(clusterName, storeName);
+    assertNotNull(userStore, "User store should be created and not null");
     veniceAdmin.updateStore(
         clusterName,
         storeName,
-        new UpdateStoreQueryParams().setHybridRewindSeconds(25L).setHybridOffsetLagThreshold(100L)); // make store
-                                                                                                     // hybrid
+        new UpdateStoreQueryParams().setHybridRewindSeconds(25L).setHybridOffsetLagThreshold(100L));
 
-    try {
-      veniceAdmin.getRealTimeTopic(clusterName, storeName, null);
-      Assert.fail("Must not be able to get a real time topic until the store is initialized with a version");
-    } catch (VeniceException e) {
-      Assert.assertTrue(
-          e.getMessage().contains("is not initialized with a version"),
-          "Got unexpected error message: " + e.getMessage());
-    }
+    Exception exception = Assert.expectThrows(
+        VeniceException.class,
+        () -> veniceAdmin.ensureRealTimeTopicExistsForUserSystemStores(clusterName, storeName));
+    assertTrue(
+        exception.getMessage().contains("not a user system store"),
+        "Got unexpected error message: " + notSystemStoreException.getMessage());
 
-    int partitions = 2; // TODO verify partition count for RT topic.
-    veniceAdmin.incrementVersionIdempotent(clusterName, storeName, Version.guidBasedDummyPushId(), partitions, 1);
+    String pushStatusStoreName = VeniceSystemStoreType.DAVINCI_PUSH_STATUS_STORE.getSystemStoreName(storeName);
+    Store pushStatusStore = veniceAdmin.getStore(clusterName, pushStatusStoreName);
+    PubSubTopic pushStatusRealTimeTopic = pubSubTopicRepository.getTopic(Utils.getRealTimeTopicName(pushStatusStore));
+    assertNotNull(pushStatusStore, "Push status store should not be created yet");
+    TestUtils.waitForNonDeterministicCompletion(
+        30,
+        TimeUnit.SECONDS,
+        () -> !veniceAdmin.getTopicManager().containsTopic(pushStatusRealTimeTopic));
 
-    String rtTopic = veniceAdmin.getRealTimeTopic(clusterName, storeName, partitions);
-    Assert.assertEquals(rtTopic, Utils.getRealTimeTopicName(store));
+    veniceAdmin.ensureRealTimeTopicExistsForUserSystemStores(clusterName, pushStatusStoreName);
+    TestUtils.waitForNonDeterministicCompletion(
+        30,
+        TimeUnit.SECONDS,
+        () -> veniceAdmin.getTopicManager().containsTopic(pushStatusRealTimeTopic));
   }
 
   @Test(timeOut = TOTAL_TIMEOUT_FOR_LONG_TEST_MS)
@@ -1679,17 +1695,21 @@ public class TestVeniceHelixAdminWithSharedEnvironment extends AbstractTestVenic
         new UpdateStoreQueryParams().setHybridOffsetLagThreshold(1)
             .setHybridRewindSeconds(0)
             .setIncrementalPushEnabled(true));
-    veniceAdmin.incrementVersionIdempotent(
+    Version version = veniceAdmin.incrementVersionIdempotent(
         clusterName,
         incrementalAndHybridEnabledStoreName,
         Version.guidBasedDummyPushId(),
         1,
         1);
-    String rtTopic = veniceAdmin.getRealTimeTopic(clusterName, incrementalAndHybridEnabledStoreName, 1);
     TestUtils.waitForNonDeterministicCompletion(
         TOTAL_TIMEOUT_FOR_SHORT_TEST_MS,
         TimeUnit.MILLISECONDS,
         () -> veniceAdmin.getCurrentVersion(clusterName, incrementalAndHybridEnabledStoreName) == 1);
+    PubSubTopic rtTopic = pubSubTopicRepository.getTopic(Utils.getRealTimeTopicName(version));
+    TestUtils.waitForNonDeterministicCompletion(
+        TOTAL_TIMEOUT_FOR_LONG_TEST_MS,
+        TimeUnit.MILLISECONDS,
+        () -> veniceAdmin.getTopicManager().containsTopic(rtTopic));
 
     // For incremental push policy INCREMENTAL_PUSH_SAME_AS_REAL_TIME, incremental push should succeed even if version
     // topic is truncated
@@ -1698,7 +1718,7 @@ public class TestVeniceHelixAdminWithSharedEnvironment extends AbstractTestVenic
 
     // For incremental push policy INCREMENTAL_PUSH_SAME_AS_REAL_TIME, incremental push should fail if rt topic is
     // truncated
-    veniceAdmin.truncateKafkaTopic(rtTopic);
+    veniceAdmin.truncateKafkaTopic(rtTopic.getName());
     Assert.assertThrows(
         VeniceException.class,
         () -> veniceAdmin.getIncrementalPushVersion(clusterName, incrementalAndHybridEnabledStoreName, "test-job-1"));
@@ -1863,8 +1883,21 @@ public class TestVeniceHelixAdminWithSharedEnvironment extends AbstractTestVenic
     Assert.assertTrue(veniceAdmin.getStore(clusterName, storeName).isSeparateRealTimeTopicEnabled());
     Assert.assertTrue(veniceAdmin.getStore(clusterName, storeName).getVersion(1).isSeparateRealTimeTopicEnabled());
 
-    String rtTopic = veniceAdmin.getRealTimeTopic(clusterName, storeName, 1);
-    String incrementalPushRealTimeTopic = veniceAdmin.getSeparateRealTimeTopic(clusterName, storeName, 1);
+    Store store = Objects.requireNonNull(veniceAdmin.getStore(clusterName, storeName), "Store should not be null");
+
+    String rtTopic = Utils.getRealTimeTopicName(store);
+    PubSubTopic rtPubSubTopic = pubSubTopicRepository.getTopic(rtTopic);
+    String incrementalPushRealTimeTopic = Version.composeSeparateRealTimeTopic(storeName);
+    PubSubTopic incrementalPushRealTimePubSubTopic = pubSubTopicRepository.getTopic(incrementalPushRealTimeTopic);
+    TestUtils.waitForNonDeterministicCompletion(
+        TOTAL_TIMEOUT_FOR_SHORT_TEST_MS,
+        TimeUnit.MILLISECONDS,
+        () -> veniceAdmin.getTopicManager().containsTopic(rtPubSubTopic));
+    TestUtils.waitForNonDeterministicCompletion(
+        TOTAL_TIMEOUT_FOR_SHORT_TEST_MS,
+        TimeUnit.MILLISECONDS,
+        () -> veniceAdmin.getTopicManager().containsTopic(incrementalPushRealTimePubSubTopic));
+
     Assert.assertFalse(veniceAdmin.isTopicTruncated(rtTopic));
     Assert.assertFalse(veniceAdmin.isTopicTruncated(incrementalPushRealTimeTopic));
     veniceAdmin.updateStore(

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/controller/VeniceParentHelixAdminTest.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/controller/VeniceParentHelixAdminTest.java
@@ -309,8 +309,9 @@ public class VeniceParentHelixAdminTest {
 
       PubSubBrokerWrapper parentPubSub = twoLayerMultiRegionMultiClusterWrapper.getParentKafkaBrokerWrapper();
       PubSubTopicRepository pubSubTopicRepository = new PubSubTopicRepository();
-      // Manually create an RT topic in the parent region to simulate its existence,
-      // as RT topics are no longer created for regional system stores like meta and ps3.
+      // Manually create an RT topic in the parent region to simulate its presence for lingering system store resources.
+      // This is necessary because RT topics are no longer automatically created for regional system stores such as meta
+      // and ps3.
       try (TopicManagerRepository topicManagerRepo = IntegrationTestPushUtils
           .getTopicManagerRepo(PUBSUB_OPERATION_TIMEOUT_MS_DEFAULT_VALUE, 100, 0l, parentPubSub, pubSubTopicRepository);
           TopicManager topicManager = topicManagerRepo.getLocalTopicManager()) {

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/controller/server/TestAdminSparkServerWithMultiServers.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/controller/server/TestAdminSparkServerWithMultiServers.java
@@ -254,7 +254,9 @@ public class TestAdminSparkServerWithMultiServers {
         controllerClient.updateStore(
             storeName,
             new UpdateStoreQueryParams().setHybridRewindSeconds(1000).setHybridOffsetLagThreshold(1000));
-        controllerClient.emptyPush(storeName, Utils.getUniqueString("emptyPushId"), 10000);
+        TestUtils.assertCommand(
+            controllerClient
+                .sendEmptyPushAndWait(storeName, Utils.getUniqueString("emptyPushId"), 10000, TEST_TIMEOUT));
       }
 
       // Both

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/controller/server/TestAdminSparkWithMocks.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/controller/server/TestAdminSparkWithMocks.java
@@ -149,7 +149,6 @@ public class TestAdminSparkWithMocks {
     doReturn(1).when(admin).getReplicationFactor(anyString(), anyString());
     doReturn(1).when(admin).calculateNumberOfPartitions(anyString(), anyString());
     doReturn("kafka-bootstrap").when(admin).getKafkaBootstrapServers(anyBoolean());
-    doReturn("store_rt").when(admin).getRealTimeTopic(anyString(), anyString(), any());
     AdminSparkServer server =
         ServiceFactory.getMockAdminSparkServer(admin, "clustername", Arrays.asList(ControllerRoute.REQUEST_TOPIC));
     int port = server.getPort();
@@ -226,7 +225,6 @@ public class TestAdminSparkWithMocks {
     doReturn(corpRegionKafka).when(admin).getKafkaBootstrapServers(anyBoolean());
     doReturn(true).when(admin).whetherEnableBatchPushFromAdmin(anyString());
     doReturn(true).when(admin).isActiveActiveReplicationEnabledInAllRegion(clusterName, storeName, false);
-    doReturn(Version.composeRealTimeTopic(storeName)).when(admin).getRealTimeTopic(anyString(), anyString(), any());
     doReturn(corpRegionKafka).when(admin).getNativeReplicationKafkaBootstrapServerAddress(corpRegion);
     doReturn(emergencySourceRegionKafka).when(admin)
         .getNativeReplicationKafkaBootstrapServerAddress(emergencySourceRegion);

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/BlobP2PTransferAmongServersTest.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/BlobP2PTransferAmongServersTest.java
@@ -342,9 +342,9 @@ public class BlobP2PTransferAmongServersTest {
       veniceProducer.stop();
     }
 
+    cluster.restartVeniceServer(server1.getPort());
     // restart server 1
     TestUtils.waitForNonDeterministicAssertion(2, TimeUnit.MINUTES, () -> {
-      cluster.restartVeniceServer(server1.getPort());
       Assert.assertTrue(server1.isRunning());
     });
 

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/PartialUpdateTest.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/PartialUpdateTest.java
@@ -174,6 +174,7 @@ public class PartialUpdateTest {
         Boolean.toString(isAAWCParallelProcessingEnabled()));
     Properties controllerProps = new Properties();
     controllerProps.put(ConfigKeys.CONTROLLER_AUTO_MATERIALIZE_META_SYSTEM_STORE, false);
+    controllerProps.put(ConfigKeys.PARTICIPANT_MESSAGE_STORE_ENABLED, false);
     this.multiRegionMultiClusterWrapper = ServiceFactory.getVeniceTwoLayerMultiRegionMultiClusterWrapper(
         NUMBER_OF_CHILD_DATACENTERS,
         NUMBER_OF_CLUSTERS,

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestActiveActiveReplicationForIncPush.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestActiveActiveReplicationForIncPush.java
@@ -21,6 +21,7 @@ import static com.linkedin.venice.vpj.VenicePushJobConstants.SOURCE_GRID_FABRIC;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertTrue;
 
 import com.linkedin.venice.controllerapi.ControllerClient;
 import com.linkedin.venice.controllerapi.StoreResponse;
@@ -37,8 +38,11 @@ import com.linkedin.venice.meta.StoreInfo;
 import com.linkedin.venice.meta.Version;
 import com.linkedin.venice.pubsub.PubSubTopicPartitionImpl;
 import com.linkedin.venice.pubsub.PubSubTopicRepository;
+import com.linkedin.venice.pubsub.api.PubSubTopic;
 import com.linkedin.venice.pubsub.api.PubSubTopicPartition;
 import com.linkedin.venice.pubsub.manager.TopicManager;
+import com.linkedin.venice.samza.VeniceSystemFactory;
+import com.linkedin.venice.samza.VeniceSystemProducer;
 import com.linkedin.venice.utils.IntegrationTestPushUtils;
 import com.linkedin.venice.utils.TestUtils;
 import com.linkedin.venice.utils.TestWriteUtils;
@@ -47,6 +51,7 @@ import com.linkedin.venice.utils.Utils;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Properties;
 import java.util.concurrent.CompletableFuture;
@@ -55,6 +60,7 @@ import java.util.function.Function;
 import org.apache.avro.Schema;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.apache.samza.config.MapConfig;
 import org.testng.Assert;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
@@ -132,6 +138,135 @@ public class TestActiveActiveReplicationForIncPush {
   public void testAAReplicationForIncPush() throws Exception {
     // TODO: Remove this hack if we solve the test-retry plugin's flakiness with DataProviders
     testAAReplicationForIncPush(false);
+  }
+
+  /**
+   * This test reproduces an issue where the real-time topic partition count did not match the hybrid version
+   * partition count under the following scenario:
+   *
+   * 1. Create a store with 1 partition.
+   * 2. Perform a batch push, resulting in a batch version with 1 partition.
+   * 3. Update the store to have 3 partitions and convert it into a hybrid store.
+   * 4. Start real-time writes using push type {@link com.linkedin.venice.meta.Version.PushType#STREAM}.
+   * 5. Perform a full push, which creates a hybrid version with 3 partitions. This push results in an error
+   *    because, after the topic switch to real-time consumers, partitions 1 and 2 of the real-time topic cannot
+   *    be found, as it has only 1 partition (partition: 0).
+   *
+   * The root cause of the issue lies in step 4, where the real-time topic was created if it did not already exist.
+   * The partition count for the real-time topic was derived from the largest existing version, which in this case
+   * was the batch version with 1 partition. This caused the real-time topic to have incorrect partition count (1
+   * instead of 3).
+   *
+   * To resolve this issue:
+   * - STREAM push type is no longer allowed if there is no online hybrid version.
+   * - If there is an online hybrid version, it is safe to assume that the real-time topic partition count matches
+   *   the hybrid version partition count.
+   * - The real-time topic is no longer created if it does not exist as part of the `requestTopicForPushing` method.
+   */
+  @Test(timeOut = TEST_TIMEOUT)
+  public void testRealTimeTopicPartitionCountMatchesHybridVersion() throws Exception {
+    File inputDirBatch = getTempDataDirectory();
+    String parentControllerUrls = multiRegionMultiClusterWrapper.getControllerConnectString();
+    String inputDirPathBatch = "file:" + inputDirBatch.getAbsolutePath();
+    try (ControllerClient parentControllerClient = new ControllerClient(clusterName, parentControllerUrls)) {
+      String storeName = Utils.getUniqueString("store");
+      Properties propsBatch =
+          IntegrationTestPushUtils.defaultVPJProps(multiRegionMultiClusterWrapper, inputDirPathBatch, storeName);
+      propsBatch.put(SEND_CONTROL_MESSAGES_DIRECTLY, true);
+      Schema recordSchema = TestWriteUtils.writeSimpleAvroFileWithStringToStringSchema(inputDirBatch);
+      String keySchemaStr = recordSchema.getField(DEFAULT_KEY_FIELD_PROP).schema().toString();
+      String valueSchemaStr = recordSchema.getField(DEFAULT_VALUE_FIELD_PROP).schema().toString();
+
+      TestUtils.assertCommand(parentControllerClient.createNewStore(storeName, "owner", keySchemaStr, valueSchemaStr));
+      UpdateStoreQueryParams updateStoreParams1 =
+          new UpdateStoreQueryParams().setStorageQuotaInByte(Store.UNLIMITED_STORAGE_QUOTA).setPartitionCount(1);
+      TestUtils.assertCommand(parentControllerClient.updateStore(storeName, updateStoreParams1));
+
+      // Run a batch push first to create a batch version with 1 partition
+      try (VenicePushJob job = new VenicePushJob("Test push job batch with NR + A/A all fabrics", propsBatch)) {
+        job.run();
+      }
+
+      // wait until version is created and verify the partition count
+      TestUtils.waitForNonDeterministicAssertion(1, TimeUnit.MINUTES, () -> {
+        StoreResponse storeResponse = assertCommand(parentControllerClient.getStore(storeName));
+        StoreInfo storeInfo = storeResponse.getStore();
+        assertNotNull(storeInfo, "Store info is null.");
+        assertNull(storeInfo.getHybridStoreConfig(), "Hybrid store config is not null.");
+        assertNotNull(storeInfo.getVersion(1), "Version 1 is not present.");
+        Optional<Version> version = storeInfo.getVersion(1);
+        assertTrue(version.isPresent(), "Version 1 is not present.");
+        assertNull(version.get().getHybridStoreConfig(), "Version level hybrid store config is not null.");
+        assertEquals(version.get().getPartitionCount(), 1, "Partition count is not 1.");
+      });
+
+      // Update the store to have 3 partitions and convert it into a hybrid store
+      UpdateStoreQueryParams updateStoreParams =
+          new UpdateStoreQueryParams().setStorageQuotaInByte(Store.UNLIMITED_STORAGE_QUOTA)
+              .setPartitionCount(3)
+              .setHybridOffsetLagThreshold(TEST_TIMEOUT / 2)
+              .setHybridRewindSeconds(2L);
+      TestUtils.assertCommand(parentControllerClient.updateStore(storeName, updateStoreParams));
+
+      TestUtils.waitForNonDeterministicAssertion(1, TimeUnit.MINUTES, () -> {
+        StoreResponse storeResponse = assertCommand(parentControllerClient.getStore(storeName));
+        StoreInfo storeInfo = storeResponse.getStore();
+        assertNotNull(storeInfo, "Store info is null.");
+        assertNotNull(storeInfo.getHybridStoreConfig(), "Hybrid store config is null.");
+        // verify that there is just one version and it is batch version
+        assertEquals(storeInfo.getVersions().size(), 1, "Version count is not 1.");
+        Optional<Version> version = storeInfo.getVersion(1);
+        assertTrue(version.isPresent(), "Version 1 is not present.");
+        assertNull(version.get().getHybridStoreConfig(), "Version level hybrid store config is not null.");
+        assertEquals(version.get().getPartitionCount(), 1, "Partition count is not 1.");
+      });
+
+      // Push job step was disabled to reproduce the issue
+      // Run a full push to create a hybrid version with 3 partitions
+      try (VenicePushJob job = new VenicePushJob("push_job_to_create_hybrid_version", propsBatch)) {
+        job.run();
+      }
+
+      // wait until hybrid version is created and verify the partition count
+      TestUtils.waitForNonDeterministicAssertion(1, TimeUnit.MINUTES, () -> {
+        StoreResponse storeResponse = assertCommand(parentControllerClient.getStore(storeName));
+        StoreInfo storeInfo = storeResponse.getStore();
+        assertNotNull(storeInfo, "Store info is null.");
+        assertNotNull(storeInfo.getHybridStoreConfig(), "Hybrid store config is null.");
+        assertNotNull(storeInfo.getVersion(2), "Version 2 is not present.");
+        Optional<Version> version = storeInfo.getVersion(2);
+        assertTrue(version.isPresent(), "Version 2 is not present.");
+        assertNotNull(version.get().getHybridStoreConfig(), "Version level hybrid store config is null.");
+        assertEquals(version.get().getPartitionCount(), 3, "Partition count is not 3.");
+      });
+
+      VeniceSystemFactory factory = new VeniceSystemFactory();
+      Map<String, String> samzaConfig = IntegrationTestPushUtils.getSamzaProducerConfig(childDatacenters, 1, storeName);
+      VeniceSystemProducer veniceProducer = factory.getClosableProducer("venice", new MapConfig(samzaConfig), null);
+      veniceProducer.start();
+
+      PubSubTopicRepository pubSubTopicRepository =
+          childDatacenters.get(1).getClusters().get(clusterName).getPubSubTopicRepository();
+      PubSubTopic realTimeTopic = pubSubTopicRepository.getTopic(Version.composeRealTimeTopic(storeName));
+
+      // wait for 120 secs and check producer getTopicName
+      TestUtils.waitForNonDeterministicAssertion(2, TimeUnit.MINUTES, () -> {
+        Assert.assertEquals(veniceProducer.getTopicName(), realTimeTopic.getName());
+      });
+
+      try (TopicManager topicManager =
+          IntegrationTestPushUtils
+              .getTopicManagerRepo(
+                  PUBSUB_OPERATION_TIMEOUT_MS_DEFAULT_VALUE,
+                  100,
+                  0l,
+                  childDatacenters.get(1).getClusters().get(clusterName).getPubSubBrokerWrapper(),
+                  pubSubTopicRepository)
+              .getLocalTopicManager()) {
+        int partitionCount = topicManager.getPartitionCount(realTimeTopic);
+        assertEquals(partitionCount, 3, "Partition count is not 3.");
+      }
+    }
   }
 
   /**

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/router/TestRead.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/router/TestRead.java
@@ -156,6 +156,7 @@ public abstract class TestRead {
     extraProperties.put(ConfigKeys.ROUTER_HTTP2_INBOUND_ENABLED, isRouterHttp2Enabled());
     extraProperties.put(ConfigKeys.SERVER_HTTP2_INBOUND_ENABLED, true);
     extraProperties.put(ConfigKeys.ROUTER_PER_STORE_ROUTER_QUOTA_BUFFER, 0.0);
+    extraProperties.put(ConfigKeys.PARTICIPANT_MESSAGE_STORE_ENABLED, false);
 
     veniceCluster = ServiceFactory.getVeniceCluster(1, 1, 1, 2, 100, true, false, extraProperties);
     routerAddr = veniceCluster.getRandomRouterSslURL();

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/router/TestRetryQuotaRejection.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/router/TestRetryQuotaRejection.java
@@ -1,7 +1,6 @@
 package com.linkedin.venice.router;
 
-import static com.linkedin.venice.ConfigKeys.ROUTER_ENABLE_READ_THROTTLING;
-import static com.linkedin.venice.ConfigKeys.SERVER_QUOTA_ENFORCEMENT_ENABLED;
+import static com.linkedin.venice.ConfigKeys.*;
 import static org.testng.Assert.assertEquals;
 
 import com.linkedin.d2.balancer.D2Client;
@@ -16,6 +15,7 @@ import com.linkedin.venice.controllerapi.VersionCreationResponse;
 import com.linkedin.venice.helix.HelixReadOnlySchemaRepository;
 import com.linkedin.venice.integration.utils.D2TestUtils;
 import com.linkedin.venice.integration.utils.ServiceFactory;
+import com.linkedin.venice.integration.utils.VeniceClusterCreateOptions;
 import com.linkedin.venice.integration.utils.VeniceClusterWrapper;
 import com.linkedin.venice.integration.utils.VeniceRouterWrapper;
 import com.linkedin.venice.integration.utils.VeniceServerWrapper;
@@ -83,8 +83,17 @@ public class TestRetryQuotaRejection {
     extraProperties.put(ConfigKeys.ROUTER_STORAGE_NODE_CLIENT_TYPE, StorageNodeClientType.APACHE_HTTP_ASYNC_CLIENT);
     extraProperties.put(ROUTER_ENABLE_READ_THROTTLING, false);
     extraProperties.put(SERVER_QUOTA_ENFORCEMENT_ENABLED, "true");
+    extraProperties.put(PARTICIPANT_MESSAGE_STORE_ENABLED, "false");
 
-    veniceCluster = ServiceFactory.getVeniceCluster(1, 1, 2, 2, 100, true, false, extraProperties);
+    veniceCluster = ServiceFactory.getVeniceCluster(
+        new VeniceClusterCreateOptions.Builder().numberOfControllers(1)
+            .numberOfServers(1)
+            .numberOfRouters(2)
+            .replicationFactor(2)
+            .partitionSize(100)
+            .sslToStorageNodes(true)
+            .extraProperties(extraProperties)
+            .build());
     Properties serverProperties = new Properties();
     Properties serverFeatureProperties = new Properties();
     serverFeatureProperties.put(VeniceServerWrapper.SERVER_ENABLE_SSL, "true");

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/Admin.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/Admin.java
@@ -9,7 +9,6 @@ import com.linkedin.venice.controllerapi.StoreComparisonInfo;
 import com.linkedin.venice.controllerapi.UpdateClusterConfigQueryParams;
 import com.linkedin.venice.controllerapi.UpdateStoragePersonaQueryParams;
 import com.linkedin.venice.controllerapi.UpdateStoreQueryParams;
-import com.linkedin.venice.exceptions.VeniceNoStoreException;
 import com.linkedin.venice.helix.HelixReadOnlyStoreConfigRepository;
 import com.linkedin.venice.helix.HelixReadOnlyZKSharedSchemaRepository;
 import com.linkedin.venice.helix.HelixReadOnlyZKSharedSystemStoreRepository;
@@ -289,26 +288,9 @@ public interface Admin extends AutoCloseable, Closeable {
       String targetedRegions,
       int repushSourceVersion);
 
-  String getRealTimeTopic(String clusterName, Store store);
+  Version getIncrementalPushVersion(String clusterName, String storeName, String pushJobId);
 
-  default String getRealTimeTopic(String clusterName, String storeName) {
-    Store store = getStore(clusterName, storeName);
-    if (store == null) {
-      throw new VeniceNoStoreException(storeName, clusterName);
-    }
-    return getRealTimeTopic(clusterName, store);
-  }
-
-  String getSeparateRealTimeTopic(String clusterName, String storeName);
-
-  /**
-   * Right now, it will return the latest version recorded in parent controller. There are a couple of edge cases.
-   * 1. If a push fails in some colos, the version will be inconsistent among colos
-   * 2. If rollback happens, latest version will not be the current version.
-   *
-   * TODO: figure out how we'd like to cover these edge cases
-   */
-  Version getIncrementalPushVersion(String clusterName, String storeName);
+  Version getReferenceVersionForStreamingWrites(String clusterName, String storeName, String pushJobId);
 
   int getCurrentVersion(String clusterName, String storeName);
 

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceControllerClusterConfig.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceControllerClusterConfig.java
@@ -828,7 +828,7 @@ public class VeniceControllerClusterConfig {
     this.parentControllerMaxErroredTopicNumToKeep = props.getInt(PARENT_CONTROLLER_MAX_ERRORED_TOPIC_NUM_TO_KEEP, 0);
 
     this.pushJobStatusStoreClusterName = props.getString(PUSH_JOB_STATUS_STORE_CLUSTER_NAME, "");
-    this.participantMessageStoreEnabled = props.getBoolean(PARTICIPANT_MESSAGE_STORE_ENABLED, false);
+    this.participantMessageStoreEnabled = props.getBoolean(PARTICIPANT_MESSAGE_STORE_ENABLED, true);
     this.adminHelixMessagingChannelEnabled = props.getBoolean(ADMIN_HELIX_MESSAGING_CHANNEL_ENABLED, true);
     if (!adminHelixMessagingChannelEnabled && !participantMessageStoreEnabled) {
       throw new VeniceException(

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceControllerClusterConfig.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceControllerClusterConfig.java
@@ -828,7 +828,7 @@ public class VeniceControllerClusterConfig {
     this.parentControllerMaxErroredTopicNumToKeep = props.getInt(PARENT_CONTROLLER_MAX_ERRORED_TOPIC_NUM_TO_KEEP, 0);
 
     this.pushJobStatusStoreClusterName = props.getString(PUSH_JOB_STATUS_STORE_CLUSTER_NAME, "");
-    this.participantMessageStoreEnabled = props.getBoolean(PARTICIPANT_MESSAGE_STORE_ENABLED, true);
+    this.participantMessageStoreEnabled = props.getBoolean(PARTICIPANT_MESSAGE_STORE_ENABLED, false);
     this.adminHelixMessagingChannelEnabled = props.getBoolean(ADMIN_HELIX_MESSAGING_CHANNEL_ENABLED, true);
     if (!adminHelixMessagingChannelEnabled && !participantMessageStoreEnabled) {
       throw new VeniceException(

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceHelixAdmin.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceHelixAdmin.java
@@ -14,6 +14,7 @@ import static com.linkedin.venice.meta.HybridStoreConfigImpl.DEFAULT_REWIND_TIME
 import static com.linkedin.venice.meta.Store.NON_EXISTING_VERSION;
 import static com.linkedin.venice.meta.Version.PushType;
 import static com.linkedin.venice.meta.VersionStatus.ERROR;
+import static com.linkedin.venice.meta.VersionStatus.KILLED;
 import static com.linkedin.venice.meta.VersionStatus.NOT_CREATED;
 import static com.linkedin.venice.meta.VersionStatus.ONLINE;
 import static com.linkedin.venice.meta.VersionStatus.PUSHED;
@@ -3034,7 +3035,7 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
         clusterName);
     String storeName = store.getName();
     // Create real-time topic if it doesn't exist; otherwise, update the retention time if necessary
-    PubSubTopic realTimeTopic = pubSubTopicRepository.getTopic(Utils.getRealTimeTopicName(version));
+    PubSubTopic realTimeTopic = getPubSubTopicRepository().getTopic(Utils.getRealTimeTopicName(version));
     createOrUpdateRealTimeTopic(clusterName, store, version, realTimeTopic);
 
     // Create separate real-time topic if it doesn't exist; otherwise, update the retention time if necessary
@@ -3044,7 +3045,7 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
           clusterName,
           store,
           version,
-          pubSubTopicRepository.getTopic(Version.composeSeparateRealTimeTopic(storeName)));
+          getPubSubTopicRepository().getTopic(Version.composeSeparateRealTimeTopic(storeName)));
     }
   }
 
@@ -3069,9 +3070,9 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
     int expectedNumOfPartitions = version.getPartitionCount();
     TopicManager topicManager = getTopicManager();
     if (topicManager.containsTopic(realTimeTopic)) {
-      validateAndUpdateTopic(realTimeTopic, store, version, expectedNumOfPartitions, getTopicManager());
+      validateAndUpdateTopic(realTimeTopic, store, version, expectedNumOfPartitions, topicManager);
     } else {
-      VeniceControllerClusterConfig clusterConfig = multiClusterConfigs.getControllerConfig(clusterName);
+      VeniceControllerClusterConfig clusterConfig = getControllerConfig(clusterName);
       topicManager.createTopic(
           realTimeTopic,
           expectedNumOfPartitions,
@@ -3104,7 +3105,7 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
    * @param topicManager the {@link TopicManager} used for topic management operations
    * @throws VeniceException if the partition count of the topic does not match the expected partition count
    */
-  private void validateAndUpdateTopic(
+  void validateAndUpdateTopic(
       PubSubTopic realTimeTopic,
       Store store,
       Version version,
@@ -3298,115 +3299,67 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
   }
 
   /**
-   * Get the real time topic name for a given store. If the topic is not created in Kafka, it creates the
-   * real time topic and returns the topic name.
-   * @param clusterName name of the Venice cluster.
-   * @param store name of the store.
-   * @return name of the store's real time topic name.
+   * Ensures that a real-time topic exists for the given user system store.
+   * If the topic does not already exist in PubSub, it creates the real-time topic
+   * and returns the topic name. This method is specific to user system stores,
+   * where real-time topics are eagerly created by the controller to prevent
+   * blocking of threads that produce data to these stores.
+   *
+   * @param clusterName the name of the Venice cluster.
+   * @param storeName the name of the store.
+   * @return the name of the store's real-time topic.
+   * @throws VeniceNoStoreException if the store does not exist in the specified cluster.
+   * @throws VeniceException if the store is not a user system store or if the partition count is invalid.
    */
-  public String getRealTimeTopic(String clusterName, Store store, Integer expectedPartitionCount) {
-    PubSubTopic realTimeTopic = pubSubTopicRepository.getTopic(Utils.getRealTimeTopicName(store));
-    ensureRealTimeTopicIsReady(clusterName, realTimeTopic, expectedPartitionCount);
-    return realTimeTopic.getName();
-  }
-
-  public String getRealTimeTopic(String clusterName, String storeName, Integer expectedPartitionCount) {
+  void ensureRealTimeTopicExistsForUserSystemStores(String clusterName, String storeName) {
+    checkControllerLeadershipFor(clusterName);
     Store store = getStore(clusterName, storeName);
     if (store == null) {
       throw new VeniceNoStoreException(storeName, clusterName);
     }
-    return getRealTimeTopic(clusterName, store, expectedPartitionCount);
-  }
-
-  public String getSeparateRealTimeTopic(String clusterName, String storeName, Integer expectedPartitionCount) {
-    PubSubTopic incrementalPushRealTimeTopic =
-        pubSubTopicRepository.getTopic(Version.composeSeparateRealTimeTopic(storeName));
-    ensureRealTimeTopicIsReady(clusterName, incrementalPushRealTimeTopic, expectedPartitionCount);
-    return incrementalPushRealTimeTopic.getName();
-  }
-
-  private void ensureRealTimeTopicIsReady(
-      String clusterName,
-      PubSubTopic realTimeTopic,
-      Integer expectedPartitionCount) {
-    checkControllerLeadershipFor(clusterName);
+    VeniceSystemStoreType systemStoreType = VeniceSystemStoreType.getSystemStoreType(storeName);
+    if (VeniceSystemStoreType.META_STORE != systemStoreType
+        && VeniceSystemStoreType.DAVINCI_PUSH_STATUS_STORE != systemStoreType) {
+      LOGGER.error("Failed to create real time topic for store: {} because it is not a user system store.", storeName);
+      throw new VeniceException(
+          "Failed to create real time topic for store: " + storeName + " because it is not a user system store.");
+    }
+    PubSubTopic realTimeTopic = getPubSubTopicRepository().getTopic(Utils.getRealTimeTopicName(store));
     TopicManager topicManager = getTopicManager();
-    String storeName = realTimeTopic.getStoreName();
-    if (!topicManager.containsTopic(realTimeTopic)) {
-      HelixVeniceClusterResources resources = getHelixVeniceClusterResources(clusterName);
-      try (AutoCloseableLock ignore = resources.getClusterLockManager().createStoreWriteLock(storeName)) {
-        boolean isRealTimeTopicCreated = topicManager.containsTopic(realTimeTopic);
-        if (isRealTimeTopicCreated && expectedPartitionCount != null) {
-          int actualPartitionCount = topicManager.getPartitionCount(realTimeTopic);
-          if (actualPartitionCount == expectedPartitionCount) {
-            // Topic is already created with the expected partition count
-            return;
-          }
+    if (topicManager.containsTopic(realTimeTopic)) {
+      return;
+    }
 
-          LOGGER.error(
-              "Real time topic: {} has partition count: {} but expected partition count is: {}",
-              realTimeTopic.getName(),
-              actualPartitionCount,
-              expectedPartitionCount);
-          throw new VeniceException(
-              "Real time topic " + realTimeTopic.getName() + " has partition count " + actualPartitionCount
-                  + " but expected partition count is " + expectedPartitionCount);
-        } else if (isRealTimeTopicCreated) {
-          // real-time topic exists but
-          return;
-        }
-
-        ReadWriteStoreRepository repository = resources.getStoreMetadataRepository();
-        Store store = repository.getStore(storeName);
-        if (store == null) {
-          throwStoreDoesNotExist(clusterName, storeName);
-        }
-        if (!store.isHybrid() && !store.isWriteComputationEnabled() && !store.isSystemStore()) {
-          logAndThrow("Store " + storeName + " is not hybrid, refusing to return a realtime topic");
-        }
-        Version version = store.getVersion(store.getLargestUsedVersionNumber());
-        int partitionCount = version != null ? version.getPartitionCount() : 0;
-        // during transition to version based partition count, some old stores may have partition count on the store
-        // config only.
-        if (partitionCount == 0) {
-          // Now store-level partition count is set when a store is converted to hybrid
-          partitionCount = store.getPartitionCount();
-          if (partitionCount == 0) {
-            if (version == null) {
-              throw new VeniceException("Store: " + storeName + " is not initialized with a version yet");
-            } else {
-              throw new VeniceException("Store: " + storeName + " has partition count set to 0");
-            }
-          }
-        }
-
-        if (expectedPartitionCount != null && partitionCount != expectedPartitionCount) {
-          LOGGER.error(
-              "Version partition count: {} does not match expected partition count: {} "
-                  + "for store: {}. Will use expected partition count to create real time topic",
-              partitionCount,
-              expectedPartitionCount,
-              storeName);
-          partitionCount = expectedPartitionCount;
-        }
-
-        VeniceControllerClusterConfig clusterConfig = getHelixVeniceClusterResources(clusterName).getConfig();
-        getTopicManager().createTopic(
-            realTimeTopic,
-            partitionCount,
-            clusterConfig.getKafkaReplicationFactorRTTopics(),
-            store.getRetentionTime(),
-            false,
-            // Note: do not enable RT compaction! Might make jobs in Online/Offline model stuck
-            clusterConfig.getMinInSyncReplicasRealTimeTopics(),
-            false);
-        // TODO: if there is an online version from a batch push before this store was hybrid then we won't start
-        // replicating to it. A new version must be created.
-        LOGGER.warn(
-            "Creating real time topic per topic request for store: {}. "
-                + "Buffer replay won't start for any existing versions",
-            storeName);
+    HelixVeniceClusterResources resources = getHelixVeniceClusterResources(clusterName);
+    try (AutoCloseableLock ignore = resources.getClusterLockManager().createStoreWriteLock(storeName)) {
+      // check again that the real-time topic does not exist
+      if (topicManager.containsTopic(realTimeTopic)) {
+        return;
       }
+      Version version = store.getVersion(store.getLargestUsedVersionNumber());
+      int partitionCount = version != null ? version.getPartitionCount() : store.getPartitionCount();
+      if (partitionCount == 0) {
+        LOGGER.error(
+            "Failed to create real time topic for user system store: {} because both store and version have partition count set to 0.",
+            storeName);
+        throw new VeniceException(
+            "Failed to create real time topic for user system store: " + storeName
+                + " because both store and version have partition count set to 0.");
+      }
+      VeniceControllerClusterConfig clusterConfig = getControllerConfig(clusterName);
+      LOGGER.info(
+          "Creating real time topic for user system store: {} with partition count: {}",
+          storeName,
+          partitionCount);
+      getTopicManager().createTopic(
+          realTimeTopic,
+          partitionCount,
+          clusterConfig.getKafkaReplicationFactorRTTopics(),
+          store.getRetentionTime(),
+          false,
+          // Note: do not enable RT compaction! Might make jobs in Online/Offline model stuck
+          clusterConfig.getMinInSyncReplicasRealTimeTopics(),
+          false);
     }
   }
 
@@ -3429,182 +3382,148 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
     }
   }
 
-  /**
-   * @see Admin#getIncrementalPushVersion(String, String, String)
-   */
   @Override
-  public Version getIncrementalPushVersion(String clusterName, String storeName, String pushJobId) {
+  public Version getReferenceVersionForStreamingWrites(String clusterName, String storeName, String pushJobId) {
     checkControllerLeadershipFor(clusterName);
     HelixVeniceClusterResources resources = getHelixVeniceClusterResources(clusterName);
     try (AutoCloseableLock ignore = resources.getClusterLockManager().createStoreReadLock(storeName)) {
+      validateStoreSetupForRTWrites(clusterName, storeName, pushJobId, PushType.STREAM);
       Store store = resources.getStoreMetadataRepository().getStore(storeName);
-      if (store == null) {
-        LOGGER.error(
-            "Unable to locate version for incremental push: {}. Store: {} does not exist in cluster: {}",
-            pushJobId,
-            storeName,
-            clusterName);
-        throwStoreDoesNotExist(clusterName, storeName);
-      }
-
-      if (!store.isIncrementalPushEnabled()) {
-        throw new VeniceException("Incremental push is not enabled for store: " + storeName);
-      }
-
-      List<Version> versions = new ArrayList<>(store.getVersions());
-      if (versions.isEmpty()) {
-        throw new VeniceException("Store: " + storeName + " is not initialized with a version yet");
-      }
-
-      Version hybridVersion = null;
-      versions.sort(Comparator.comparingInt(Version::getNumber).reversed());
-      for (Version version: versions) {
-        if (version.getHybridStoreConfig() != null && version.getStatus() == ONLINE) {
-          hybridVersion = version;
-          break;
-        }
-      }
-
-      if (hybridVersion == null) {
-        LOGGER.error(
-            "Could not find an online hybrid store version for incremental push: {} on store: {} in cluster: {}",
-            pushJobId,
-            storeName,
-            clusterName);
-        throw new VeniceException(
-            "No ONLINE hybrid store version found for store: " + storeName + " in cluster: " + clusterName);
-      }
-      LOGGER.info(
-          "Found hybrid version: {} for store: {} in cluster: {}. Will use it as a reference for incremental push: {}",
-          hybridVersion.getNumber(),
-          storeName,
-          clusterName,
-          pushJobId);
-
-      // If real-time topic is not required, no need to check for its presence
-      if (!isRealTimeTopicRequired(store, hybridVersion)) {
-        return hybridVersion;
-      }
-
-      PubSubTopic rtTopic = pubSubTopicRepository.getTopic(Utils.getRealTimeTopicName(store));
-      if (!getTopicManager().containsTopicAndAllPartitionsAreOnline(rtTopic) || isTopicTruncated(rtTopic.getName())) {
-        LOGGER.error(
-            "Incremental push: {} cannot be started for store: {} in cluster: {} because the topic: {} is either absent or being truncated",
-            pushJobId,
-            storeName,
-            clusterName,
-            rtTopic);
-        resources.getVeniceAdminStats().recordUnexpectedTopicAbsenceCount();
-        throw new VeniceException(
-            "Incremental push cannot be started for store: " + storeName + " in cluster: " + clusterName
-                + " because the topic: " + rtTopic + " is either absent or being truncated");
-      }
-
-      if (hybridVersion.isSeparateRealTimeTopicEnabled()) {
-        PubSubTopic separateRtTopic = pubSubTopicRepository.getTopic(Version.composeSeparateRealTimeTopic(storeName));
-        if (!getTopicManager().containsTopicAndAllPartitionsAreOnline(separateRtTopic)
-            || isTopicTruncated(separateRtTopic.getName())) {
-          LOGGER.error(
-              "Incremental push: {} cannot be started for store: {} in cluster: {} because the topic: {} is either absent or being truncated",
-              pushJobId,
-              storeName,
-              clusterName,
-              separateRtTopic);
-          resources.getVeniceAdminStats().recordUnexpectedTopicAbsenceCount();
-          throw new VeniceException(
-              "Incremental push cannot be started for store: " + storeName + " in cluster: " + clusterName
-                  + " because the topic: " + separateRtTopic + " is either absent or being truncated");
-        }
+      Version hybridVersion = getReferenceHybridVersionForRealTimeWrites(clusterName, store, pushJobId);
+      if (!isParent()) {
+        PubSubTopic rtTopic = getPubSubTopicRepository().getTopic(Utils.getRealTimeTopicName(hybridVersion));
+        int partitionCount = hybridVersion.getPartitionCount();
+        validateTopicPresenceAndState(clusterName, storeName, pushJobId, PushType.STREAM, rtTopic, partitionCount);
       }
       return hybridVersion;
     }
   }
 
   @Override
-  public Version getReferenceVersionForStreamingWrites(String clusterName, String storeName, String pushJobId) {
-    boolean requiresVersionToBeOnline = true;
+  public Version getIncrementalPushVersion(String clusterName, String storeName, String pushJobId) {
     checkControllerLeadershipFor(clusterName);
     HelixVeniceClusterResources resources = getHelixVeniceClusterResources(clusterName);
     try (AutoCloseableLock ignore = resources.getClusterLockManager().createStoreReadLock(storeName)) {
+      validateStoreSetupForRTWrites(clusterName, storeName, pushJobId, PushType.INCREMENTAL);
       Store store = resources.getStoreMetadataRepository().getStore(storeName);
-      if (store == null) {
-        throwStoreDoesNotExist(clusterName, storeName);
-      }
-      if (!store.isHybrid()) {
-        LOGGER.warn(
-            "Rejecting request for streaming writes with pushJobId: {} for store: {} in cluster: {} because it is not a hybrid store",
-            pushJobId,
-            storeName,
-            clusterName);
-        throw new VeniceException(
-            "Store: " + storeName + " is not a hybrid store and cannot be used for streaming writes");
-      }
-      List<Version> versions = new ArrayList<>(store.getVersions());
-      if (versions.isEmpty()) {
-        LOGGER.warn(
-            "Rejecting request for streaming writes with pushJobId: {} for store: {} in cluster: {} because it is not initialized with a version yet",
-            pushJobId,
-            storeName,
-            clusterName);
-        throw new VeniceException(
-            "Streaming writes cannot be started for store: " + storeName
-                + " because it is not initialized with a version yet");
-      }
-
-      Version hybridVersion = null;
-
-      versions.sort(Comparator.comparingInt(Version::getNumber).reversed());
-      for (Version version: versions) {
-        if (version.getHybridStoreConfig() != null && (!requiresVersionToBeOnline || version.getStatus() == ONLINE)) {
-          hybridVersion = version;
-          break;
-        }
-      }
-      if (hybridVersion == null) {
-        String logMessage = String.format(
-            "Could not find %s hybrid store version for streaming writes with pushJobId: %s on store: %s in cluster: %s",
-            requiresVersionToBeOnline ? "an ONLINE" : "a",
-            pushJobId,
-            storeName,
-            clusterName);
-        LOGGER.error(logMessage);
-        throw new VeniceException(logMessage);
-      }
-
-      LOGGER.info(
-          "Found {} hybrid version: {} for store: {} in cluster: {}. Will use it as a reference for streaming writes with pushJobId: {}",
-          requiresVersionToBeOnline ? "an ONLINE" : "a",
-          hybridVersion.getNumber(),
-          storeName,
-          clusterName,
-          pushJobId);
-
-      int partitionCount = hybridVersion.getPartitionCount();
-      if (isParent()) {
-        /**
-         * Create RT topic here in parent region. For child regions, RT should always be created as part of
-         * {@link RealTimeTopicSwitcher#ensurePreconditions(PubSubTopic, PubSubTopic, Store, Optional)}
-         */
-        // getRealTimeTopic(clusterName, storeName, partitionCount);
-        System.out.println("getRealTimeTopic");
-      }
-      PubSubTopic rtTopic = pubSubTopicRepository.getTopic(Version.composeRealTimeTopic(storeName));
-      if (!getTopicManager().containsTopicAndAllPartitionsAreOnline(rtTopic, partitionCount)
-          || isTopicTruncated(rtTopic.getName())) {
-        LOGGER.error(
-            "Streaming writes: {} cannot be started for store: {} in cluster: {} because the topic: {} is "
-                + "either absent or being truncated or has different partition count than hybrid version partition count",
-            pushJobId,
-            storeName,
-            clusterName,
-            rtTopic);
-        resources.getVeniceAdminStats().recordUnexpectedTopicAbsenceCount();
-        throw new VeniceException(
-            "Streaming writes cannot be started for store: " + storeName + " in cluster: " + clusterName
-                + " because the topic: " + rtTopic + " is either absent or being truncated");
+      Version hybridVersion = getReferenceHybridVersionForRealTimeWrites(clusterName, store, pushJobId);
+      // If real-time topic is required, validate that it exists and is in a good state
+      if (isRealTimeTopicRequired(store, hybridVersion)) {
+        validateTopicForIncrementalPush(clusterName, store, hybridVersion, pushJobId);
       }
       return hybridVersion;
     }
+  }
+
+  void validateStoreSetupForRTWrites(String clusterName, String storeName, String pushJobId, PushType pushType) {
+    Store store = getHelixVeniceClusterResources(clusterName).getStoreMetadataRepository().getStore(storeName);
+    if (store == null) {
+      throwStoreDoesNotExist(clusterName, storeName);
+    }
+    if (!store.isHybrid()) {
+      LOGGER.error(
+          "{} push writes with pushJobId: {} on store: {} in cluster: {} are not allowed because it is not a hybrid store",
+          pushType,
+          pushJobId,
+          storeName,
+          clusterName);
+      throw new VeniceException(
+          "Store: " + storeName + " is not a hybrid store and cannot be used for " + pushType + " writes");
+    }
+    if (pushType == PushType.INCREMENTAL && !store.isIncrementalPushEnabled()) {
+      LOGGER.error(
+          "Incremental push with pushJobId: {} on store: {} in cluster: {} is not allowed because incremental push is not enabled",
+          pushJobId,
+          storeName,
+          clusterName);
+      throw new VeniceException("Store: " + storeName + " is not an incremental push store");
+    }
+  }
+
+  void validateTopicForIncrementalPush(
+      String clusterName,
+      Store store,
+      Version referenceHybridVersion,
+      String pushJobId) {
+    PubSubTopicRepository topicRepository = getPubSubTopicRepository();
+    if (referenceHybridVersion.isSeparateRealTimeTopicEnabled()) {
+      PubSubTopic separateRtTopic = topicRepository.getTopic(Version.composeSeparateRealTimeTopic(store.getName()));
+      validateTopicPresenceAndState(
+          clusterName,
+          store.getName(),
+          pushJobId,
+          PushType.INCREMENTAL,
+          separateRtTopic,
+          referenceHybridVersion.getPartitionCount());
+      // We can consider short-circuiting here if the separate real-time topic is enabled and
+      // the topic is in a good state
+    }
+
+    PubSubTopic rtTopic = topicRepository.getTopic(Utils.getRealTimeTopicName(referenceHybridVersion));
+    validateTopicPresenceAndState(
+        clusterName,
+        store.getName(),
+        pushJobId,
+        PushType.INCREMENTAL,
+        rtTopic,
+        referenceHybridVersion.getPartitionCount());
+  }
+
+  void validateTopicPresenceAndState(
+      String clusterName,
+      String storeName,
+      String pushJobId,
+      PushType pushType,
+      PubSubTopic topic,
+      int partitionCount) {
+    if (getTopicManager().containsTopicAndAllPartitionsAreOnline(topic, partitionCount)
+        && !isTopicTruncated(topic.getName())) {
+      return;
+    }
+    LOGGER.error(
+        "{} push writes from pushJobId: {} cannot be accepted on store: {} in cluster: {} because the topic: {} is either absent or being truncated",
+        pushType,
+        pushJobId,
+        storeName,
+        clusterName,
+        topic);
+    getHelixVeniceClusterResources(clusterName).getVeniceAdminStats().recordUnexpectedTopicAbsenceCount();
+    throw new VeniceException(
+        pushType + " push writes cannot be accepted on store: " + storeName + " in cluster: " + clusterName
+            + " because the topic: " + topic + " is either absent or being truncated");
+  }
+
+  Version getReferenceHybridVersionForRealTimeWrites(String clusterName, Store store, String pushJobId) {
+    List<Version> versions = new ArrayList<>(store.getVersions());
+    if (versions.isEmpty()) {
+      LOGGER.error(
+          "Store: {} in cluster: {} is not initialized with a version yet. Rejecting request for writes with pushJobId: {}",
+          store.getName(),
+          clusterName,
+          pushJobId);
+      throw new VeniceException("Store: " + store.getName() + " is not initialized with a version yet.");
+    }
+
+    versions.sort(Comparator.comparingInt(Version::getNumber).reversed());
+    for (Version version: versions) {
+      if (version.getHybridStoreConfig() != null && version.getStatus() != ERROR && version.getStatus() != KILLED) {
+        LOGGER.info(
+            "Found hybrid version: {} for store: {} in cluster: {}. Will use it as a reference for pushJobId: {}",
+            version.getNumber(),
+            version,
+            clusterName,
+            pushJobId);
+        return version;
+      }
+    }
+
+    String logMessage = String.format(
+        "No valid hybrid store version (non-errored) found in store: %s in cluster: %s for pushJobId: %s.",
+        store.getName(),
+        clusterName,
+        pushJobId);
+    LOGGER.error(logMessage);
+    throw new VeniceException(logMessage);
   }
 
   /**
@@ -4578,7 +4497,8 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
       preCheckStorePartitionCountUpdate(clusterName, store, partitionCount);
       // Do not update the partitionCount on the store.version as version config is immutable. The
       // version.getPartitionCount()
-      // is read only in getRealTimeTopic and createInternalStore creation, so modifying currentVersion should not have
+      // is read only in ensureRealTimeTopicExistsForUserSystemStores and createInternalStore creation, so modifying
+      // currentVersion should not have
       // any effect.
       if (store.isHybrid()
           && multiClusterConfigs.getControllerConfig(clusterName).isHybridStorePartitionCountUpdateEnabled()) {
@@ -8355,7 +8275,7 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
 
     if (!isParent()) {
       // We do not materialize PS3 for parent region. Hence, skip RT topic creation.
-      getRealTimeTopic(clusterName, daVinciPushStatusStoreName, null);
+      ensureRealTimeTopicExistsForUserSystemStores(clusterName, daVinciPushStatusStoreName);
     }
     if (!store.isDaVinciPushStatusStoreEnabled()) {
       storeMetadataUpdate(clusterName, storeName, (s) -> {
@@ -8378,11 +8298,12 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
       throwStoreDoesNotExist(clusterName, regularStoreName);
     }
 
-    // Make sure RT topic exists before producing. There's no write to parent region meta store RT, but we still create
-    // the RT topic to be consistent in case it was not auto-materialized
+    // Make sure RT topic exists before producing.
     if (!isParent()) {
-      // We do not materialize PS3 for parent region. Hence, skip RT topic creation.
-      getRealTimeTopic(clusterName, VeniceSystemStoreType.META_STORE.getSystemStoreName(regularStoreName), null);
+      // We do not materialize meta store for parent region. Hence, skip RT topic creation.
+      ensureRealTimeTopicExistsForUserSystemStores(
+          clusterName,
+          VeniceSystemStoreType.META_STORE.getSystemStoreName(regularStoreName));
     }
 
     // Update the store flag to enable meta system store.
@@ -8806,6 +8727,10 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
   // Visible for testing
   VeniceControllerMultiClusterConfig getMultiClusterConfigs() {
     return multiClusterConfigs;
+  }
+
+  VeniceControllerClusterConfig getControllerConfig(String clusterName) {
+    return multiClusterConfigs.getControllerConfig(clusterName);
   }
 
   // Only for testing

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceParentHelixAdmin.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceParentHelixAdmin.java
@@ -1532,7 +1532,7 @@ public class VeniceParentHelixAdmin implements Admin {
 
     Version newVersion;
     if (pushType.isIncremental()) {
-      newVersion = getVeniceHelixAdmin().getIncrementalPushVersion(clusterName, storeName);
+      newVersion = getVeniceHelixAdmin().getIncrementalPushVersion(clusterName, storeName, pushJobId);
     } else {
       validateTargetedRegions(targetedRegions, clusterName);
 
@@ -1710,19 +1710,6 @@ public class VeniceParentHelixAdmin implements Admin {
   }
 
   /**
-   * @see VeniceHelixAdmin#getRealTimeTopic(String, Store)
-   */
-  @Override
-  public String getRealTimeTopic(String clusterName, Store store) {
-    return getVeniceHelixAdmin().getRealTimeTopic(clusterName, store);
-  }
-
-  @Override
-  public String getSeparateRealTimeTopic(String clusterName, String storeName) {
-    return getVeniceHelixAdmin().getSeparateRealTimeTopic(clusterName, storeName);
-  }
-
-  /**
    * A couple of extra checks are needed in parent controller
    * 1. check batch job statuses across child controllers. (We cannot only check the version status
    * in parent controller since they are marked as STARTED)
@@ -1730,12 +1717,17 @@ public class VeniceParentHelixAdmin implements Admin {
    * preserve incremental push topic in parent Kafka anymore
    */
   @Override
-  public Version getIncrementalPushVersion(String clusterName, String storeName) {
-    Version incrementalPushVersion = getVeniceHelixAdmin().getIncrementalPushVersion(clusterName, storeName);
+  public Version getIncrementalPushVersion(String clusterName, String storeName, String pushJobId) {
+    Version incrementalPushVersion = getVeniceHelixAdmin().getIncrementalPushVersion(clusterName, storeName, pushJobId);
     String incrementalPushTopic = incrementalPushVersion.kafkaTopicName();
     ExecutionStatus status = getOffLinePushStatus(clusterName, incrementalPushTopic).getExecutionStatus();
 
     return getIncrementalPushVersion(incrementalPushVersion, status);
+  }
+
+  @Override
+  public Version getReferenceVersionForStreamingWrites(String clusterName, String storeName, String pushJobId) {
+    return getVeniceHelixAdmin().getReferenceVersionForStreamingWrites(clusterName, storeName, pushJobId);
   }
 
   // This method is only for internal / test use case

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/init/SystemStoreInitializationHelper.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/init/SystemStoreInitializationHelper.java
@@ -64,6 +64,7 @@ public final class SystemStoreInitializationHelper {
       UpdateStoreQueryParams updateStoreQueryParams,
       Admin admin,
       VeniceControllerMultiClusterConfig multiClusterConfigs) {
+    LOGGER.info("Setting up system store: {} in cluster: {}", systemStoreName, clusterName);
     Map<Integer, Schema> protocolSchemaMap = Utils.getAllSchemasFromResources(protocolDefinition);
     Store store = admin.getStore(clusterName, systemStoreName);
     String keySchemaString = keySchema != null ? keySchema.toString() : DEFAULT_KEY_SCHEMA_STR;
@@ -86,7 +87,7 @@ public final class SystemStoreInitializationHelper {
         throw new VeniceException("Unable to create or fetch store " + systemStoreName);
       }
     } else {
-      LOGGER.info("Internal store {} already exists in cluster {}", systemStoreName, clusterName);
+      LOGGER.info("Internal store: {} already exists in cluster: {}", systemStoreName, clusterName);
       if (keySchema != null) {
         /**
          * Only verify the key schema if it is explicitly specified by the caller, and we don't care
@@ -203,6 +204,8 @@ public final class SystemStoreInitializationHelper {
 
       LOGGER.info("Created a version for internal store {} in cluster {}", systemStoreName, clusterName);
     }
+
+    LOGGER.info("System store: {} in cluster: {} is set up", systemStoreName, clusterName);
   }
 
   // Visible for testing

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/server/CreateVersion.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/server/CreateVersion.java
@@ -474,7 +474,7 @@ public class CreateVersion extends AbstractRoute {
         RequestTopicForPushRequest requestTopicForPushRequest = new RequestTopicForPushRequest(
             request.queryParams(CLUSTER),
             request.queryParams(NAME),
-            RequestTopicForPushRequest.extractPushType(request.queryParams(PUSH_TYPE)),
+            PushType.extractPushType(request.queryParams(PUSH_TYPE)),
             request.queryParams(PUSH_JOB_ID));
 
         // populate the request object with optional parameters

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/server/CreateVersion.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/server/CreateVersion.java
@@ -283,7 +283,6 @@ public class CreateVersion extends AbstractRoute {
           request.getPushType().name(),
           "Please push data to Venice Parent Colo instead");
     }
-    response.setPartitions(admin.calculateNumberOfPartitions(clusterName, storeName));
     int computedPartitionCount = admin.calculateNumberOfPartitions(clusterName, storeName);
     final Version version = admin.incrementVersionIdempotent(
         clusterName,

--- a/services/venice-controller/src/test/java/com/linkedin/venice/controller/TestVeniceHelixAdmin.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/controller/TestVeniceHelixAdmin.java
@@ -75,7 +75,7 @@ public class TestVeniceHelixAdmin {
   @Test
   public void enforceRealTimeTopicCreationBeforeWriting() {
     VeniceHelixAdmin veniceHelixAdmin = mock(VeniceHelixAdmin.class);
-    doReturn("test_rt").when(veniceHelixAdmin).getRealTimeTopic(anyString(), anyString());
+    doReturn("test_rt").when(veniceHelixAdmin).getRealTimeTopic(anyString(), anyString(), any());
     doCallRealMethod().when(veniceHelixAdmin).setUpMetaStoreAndMayProduceSnapshot(anyString(), anyString());
 
     InOrder inorder = inOrder(veniceHelixAdmin);
@@ -92,7 +92,7 @@ public class TestVeniceHelixAdmin {
     veniceHelixAdmin.setUpMetaStoreAndMayProduceSnapshot(anyString(), anyString());
 
     // Enforce that getRealTimeTopic happens before storeMetadataUpdate. See the above comments for the reasons.
-    inorder.verify(veniceHelixAdmin).getRealTimeTopic(anyString(), anyString());
+    inorder.verify(veniceHelixAdmin).getRealTimeTopic(anyString(), anyString(), any());
     inorder.verify(veniceHelixAdmin).storeMetadataUpdate(anyString(), anyString(), any());
   }
 

--- a/services/venice-controller/src/test/java/com/linkedin/venice/controller/TestVeniceHelixAdmin.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/controller/TestVeniceHelixAdmin.java
@@ -1,32 +1,65 @@
 package com.linkedin.venice.controller;
 
+import static com.linkedin.venice.meta.Version.PushType.*;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.doCallRealMethod;
+import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.expectThrows;
 
+import com.linkedin.venice.common.VeniceSystemStoreType;
 import com.linkedin.venice.controller.stats.DisabledPartitionStats;
+import com.linkedin.venice.controller.stats.VeniceAdminStats;
+import com.linkedin.venice.exceptions.VeniceException;
 import com.linkedin.venice.helix.HelixExternalViewRepository;
+import com.linkedin.venice.meta.DataReplicationPolicy;
+import com.linkedin.venice.meta.HybridStoreConfig;
 import com.linkedin.venice.meta.PartitionAssignment;
 import com.linkedin.venice.meta.ReadWriteStoreRepository;
 import com.linkedin.venice.meta.Store;
 import com.linkedin.venice.meta.Version;
+import com.linkedin.venice.meta.Version.PushType;
+import com.linkedin.venice.meta.VersionStatus;
+import com.linkedin.venice.pubsub.PubSubTopicRepository;
+import com.linkedin.venice.pubsub.api.PubSubTopic;
+import com.linkedin.venice.pubsub.manager.TopicManager;
 import com.linkedin.venice.pushmonitor.ExecutionStatus;
 import com.linkedin.venice.utils.HelixUtils;
+import com.linkedin.venice.utils.Utils;
+import com.linkedin.venice.utils.locks.ClusterLockManager;
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InOrder;
 import org.testng.annotations.Test;
 
 
 public class TestVeniceHelixAdmin {
+  private static final PubSubTopicRepository PUB_SUB_TOPIC_REPOSITORY = new PubSubTopicRepository();
+
   @Test
   public void testDropResources() {
     VeniceHelixAdmin veniceHelixAdmin = mock(VeniceHelixAdmin.class);
@@ -58,14 +91,13 @@ public class TestVeniceHelixAdmin {
 
     veniceHelixAdmin.deleteHelixResource(clusterName, kafkaTopic);
     verify(veniceHelixAdmin, times(1)).enableDisabledPartition(clusterName, kafkaTopic, false);
-
   }
 
   /**
    * This test verify that in function {@link VeniceHelixAdmin#setUpMetaStoreAndMayProduceSnapshot},
    * meta store RT topic creation has to happen before any writings to meta store's rt topic.
    * As of today, topic creation and checks to make sure that RT exists are handled in function
-   * {@link VeniceHelixAdmin#getRealTimeTopic}. On the other hand, as {@link VeniceHelixAdmin#storeMetadataUpdate}
+   * {@link VeniceHelixAdmin#ensureRealTimeTopicExistsForUserSystemStores}. On the other hand, as {@link VeniceHelixAdmin#storeMetadataUpdate}
    * writes to the same RT topic, it should happen after the above function. The following test enforces
    * such order at the statement level.
    *
@@ -73,9 +105,9 @@ public class TestVeniceHelixAdmin {
    * it is okay to relax on the ordering enforcement or delete the unit test if necessary.
    */
   @Test
-  public void enforceRealTimeTopicCreationBeforeWriting() {
+  public void enforceRealTimeTopicCreationBeforeWritingToMetaSystemStore() {
     VeniceHelixAdmin veniceHelixAdmin = mock(VeniceHelixAdmin.class);
-    doReturn("test_rt").when(veniceHelixAdmin).getRealTimeTopic(anyString(), anyString(), any());
+    doNothing().when(veniceHelixAdmin).ensureRealTimeTopicExistsForUserSystemStores(anyString(), anyString());
     doCallRealMethod().when(veniceHelixAdmin).setUpMetaStoreAndMayProduceSnapshot(anyString(), anyString());
 
     InOrder inorder = inOrder(veniceHelixAdmin);
@@ -91,8 +123,9 @@ public class TestVeniceHelixAdmin {
 
     veniceHelixAdmin.setUpMetaStoreAndMayProduceSnapshot(anyString(), anyString());
 
-    // Enforce that getRealTimeTopic happens before storeMetadataUpdate. See the above comments for the reasons.
-    inorder.verify(veniceHelixAdmin).getRealTimeTopic(anyString(), anyString(), any());
+    // Enforce that ensureRealTimeTopicExistsForUserSystemStores happens before storeMetadataUpdate. See the above
+    // comments for the reasons.
+    inorder.verify(veniceHelixAdmin).ensureRealTimeTopicExistsForUserSystemStores(anyString(), anyString());
     inorder.verify(veniceHelixAdmin).storeMetadataUpdate(anyString(), anyString(), any());
   }
 
@@ -123,5 +156,735 @@ public class TestVeniceHelixAdmin {
     daVinciStatus = ExecutionStatus.DVC_INGESTION_ERROR_DISK_FULL;
     overallStatus = VeniceHelixAdmin.getOverallPushStatus(veniceStatus, daVinciStatus);
     assertEquals(overallStatus, ExecutionStatus.DVC_INGESTION_ERROR_DISK_FULL);
+  }
+
+  @Test
+  public void testIsRealTimeTopicRequired() {
+    VeniceHelixAdmin veniceHelixAdmin = mock(VeniceHelixAdmin.class);
+    Store store = mock(Store.class, RETURNS_DEEP_STUBS);
+    Version version = mock(Version.class);
+    doCallRealMethod().when(veniceHelixAdmin).isRealTimeTopicRequired(store, version);
+
+    // Case 1: Store is not hybrid
+    doReturn(false).when(store).isHybrid();
+    assertFalse(veniceHelixAdmin.isRealTimeTopicRequired(store, version));
+
+    // Case 2: Store is hybrid and version is not hybrid
+    doReturn(true).when(store).isHybrid();
+    doReturn(false).when(version).isHybrid();
+
+    // Case 3: Both store and version are hybrid && controller is child
+    doReturn(true).when(store).isHybrid();
+    doReturn(true).when(version).isHybrid();
+    assertTrue(veniceHelixAdmin.isRealTimeTopicRequired(store, version));
+    doReturn(false).when(veniceHelixAdmin).isParent();
+    assertTrue(veniceHelixAdmin.isRealTimeTopicRequired(store, version));
+
+    // Case 4: Both store and version are hybrid && controller is parent && AA is enabled
+    doReturn(true).when(veniceHelixAdmin).isParent();
+    doReturn(true).when(store).isActiveActiveReplicationEnabled();
+    assertFalse(veniceHelixAdmin.isRealTimeTopicRequired(store, version));
+
+    // Case 5: Both store and version are hybrid && controller is parent && AA is disabled and IncPush is enabled
+    doReturn(false).when(store).isActiveActiveReplicationEnabled();
+    doReturn(true).when(store).isIncrementalPushEnabled();
+    when(store.getHybridStoreConfig().getDataReplicationPolicy()).thenReturn(DataReplicationPolicy.NON_AGGREGATE);
+    assertTrue(veniceHelixAdmin.isRealTimeTopicRequired(store, version));
+
+    // Case 6: Both store and version are hybrid && controller is parent && AA is disabled and IncPush is disabled but
+    // DRP is AGGREGATE
+    doReturn(false).when(store).isIncrementalPushEnabled();
+    when(store.getHybridStoreConfig().getDataReplicationPolicy()).thenReturn(DataReplicationPolicy.AGGREGATE);
+    assertTrue(veniceHelixAdmin.isRealTimeTopicRequired(store, version));
+  }
+
+  @Test
+  public void testCreateOrUpdateRealTimeTopics() {
+    String clusterName = "testCluster";
+    String storeName = "testStore";
+    Store store = mock(Store.class, RETURNS_DEEP_STUBS);
+    when(store.getName()).thenReturn(storeName);
+    Version version = mock(Version.class);
+    when(version.getStoreName()).thenReturn(storeName);
+
+    // Case 1: Only one real-time topic is required
+    VeniceHelixAdmin veniceHelixAdmin = mock(VeniceHelixAdmin.class);
+    doCallRealMethod().when(veniceHelixAdmin).createOrUpdateRealTimeTopics(eq(clusterName), eq(store), eq(version));
+    when(veniceHelixAdmin.getPubSubTopicRepository()).thenReturn(PUB_SUB_TOPIC_REPOSITORY);
+    doNothing().when(veniceHelixAdmin)
+        .createOrUpdateRealTimeTopic(eq(clusterName), eq(store), eq(version), any(PubSubTopic.class));
+    veniceHelixAdmin.createOrUpdateRealTimeTopics(clusterName, store, version);
+    // verify and capture the arguments passed to createOrUpdateRealTimeTopic
+    ArgumentCaptor<PubSubTopic> pubSubTopicArgumentCaptor = ArgumentCaptor.forClass(PubSubTopic.class);
+    verify(veniceHelixAdmin, times(1))
+        .createOrUpdateRealTimeTopic(eq(clusterName), eq(store), eq(version), pubSubTopicArgumentCaptor.capture());
+    assertEquals(pubSubTopicArgumentCaptor.getValue().getName(), "testStore_rt");
+
+    // Case 2: Both regular and separate real-time topics are required
+    when(version.isSeparateRealTimeTopicEnabled()).thenReturn(true);
+    veniceHelixAdmin.createOrUpdateRealTimeTopics(clusterName, store, version);
+    pubSubTopicArgumentCaptor = ArgumentCaptor.forClass(PubSubTopic.class);
+    // verify and capture the arguments passed to createOrUpdateRealTimeTopic
+    verify(veniceHelixAdmin, times(3))
+        .createOrUpdateRealTimeTopic(eq(clusterName), eq(store), eq(version), pubSubTopicArgumentCaptor.capture());
+    Set<PubSubTopic> pubSubTopics = new HashSet<>(pubSubTopicArgumentCaptor.getAllValues());
+    PubSubTopic separateRealTimeTopic = PUB_SUB_TOPIC_REPOSITORY.getTopic(storeName + "_rt_sep");
+    assertTrue(pubSubTopics.contains(separateRealTimeTopic));
+  }
+
+  @Test
+  public void testCreateOrUpdateRealTimeTopic() {
+    String clusterName = "testCluster";
+    String storeName = "testStore";
+    int partitionCount = 10;
+    Store store = mock(Store.class, RETURNS_DEEP_STUBS);
+    when(store.getName()).thenReturn(storeName);
+    Version version = mock(Version.class);
+    when(version.getStoreName()).thenReturn(storeName);
+    when(version.getPartitionCount()).thenReturn(partitionCount);
+    PubSubTopicRepository pubSubTopicRepository = new PubSubTopicRepository();
+    PubSubTopic pubSubTopic = pubSubTopicRepository.getTopic(storeName + "_rt");
+    TopicManager topicManager = mock(TopicManager.class);
+    VeniceHelixAdmin veniceHelixAdmin = mock(VeniceHelixAdmin.class);
+    when(veniceHelixAdmin.getTopicManager()).thenReturn(topicManager);
+
+    // Case 1: Real-time topic already exists
+    doCallRealMethod().when(veniceHelixAdmin)
+        .createOrUpdateRealTimeTopic(eq(clusterName), eq(store), eq(version), any(PubSubTopic.class));
+    when(veniceHelixAdmin.getPubSubTopicRepository()).thenReturn(pubSubTopicRepository);
+    when(topicManager.containsTopic(pubSubTopic)).thenReturn(true);
+    doNothing().when(veniceHelixAdmin)
+        .validateAndUpdateTopic(eq(pubSubTopic), eq(store), eq(version), eq(partitionCount), eq(topicManager));
+    veniceHelixAdmin.createOrUpdateRealTimeTopic(clusterName, store, version, pubSubTopic);
+    verify(veniceHelixAdmin, times(1))
+        .validateAndUpdateTopic(eq(pubSubTopic), eq(store), eq(version), eq(partitionCount), eq(topicManager));
+    verify(topicManager, never()).createTopic(
+        any(PubSubTopic.class),
+        anyInt(),
+        anyInt(),
+        anyLong(),
+        anyBoolean(),
+        any(Optional.class),
+        anyBoolean());
+
+    // Case 2: Real-time topic does not exist
+    VeniceControllerClusterConfig clusterConfig = mock(VeniceControllerClusterConfig.class);
+    when(veniceHelixAdmin.getControllerConfig(clusterName)).thenReturn(clusterConfig);
+    when(topicManager.containsTopic(pubSubTopic)).thenReturn(false);
+    veniceHelixAdmin.createOrUpdateRealTimeTopic(clusterName, store, version, pubSubTopic);
+    verify(topicManager, times(1)).createTopic(
+        eq(pubSubTopic),
+        eq(partitionCount),
+        anyInt(),
+        anyLong(),
+        anyBoolean(),
+        any(Optional.class),
+        anyBoolean());
+  }
+
+  @Test
+  public void testValidateAndUpdateTopic() {
+    PubSubTopic realTimeTopic = PUB_SUB_TOPIC_REPOSITORY.getTopic("testStore_rt");
+    Store store = mock(Store.class, RETURNS_DEEP_STUBS);
+    when(store.getName()).thenReturn("testStore");
+    Version version = mock(Version.class);
+    int expectedNumOfPartitions = 10;
+    TopicManager topicManager = mock(TopicManager.class);
+
+    // Case 1: Actual partition count is not equal to expected partition count
+    VeniceHelixAdmin veniceHelixAdmin = mock(VeniceHelixAdmin.class);
+    doCallRealMethod().when(veniceHelixAdmin)
+        .validateAndUpdateTopic(
+            any(PubSubTopic.class),
+            any(Store.class),
+            any(Version.class),
+            anyInt(),
+            any(TopicManager.class));
+    when(version.getPartitionCount()).thenReturn(expectedNumOfPartitions);
+    when(topicManager.getPartitionCount(realTimeTopic)).thenReturn(expectedNumOfPartitions - 1);
+    Exception exception = expectThrows(
+        VeniceException.class,
+        () -> veniceHelixAdmin
+            .validateAndUpdateTopic(realTimeTopic, store, version, expectedNumOfPartitions, topicManager));
+    assertTrue(exception.getMessage().contains("has different partition count"));
+
+    // Case 2: Actual partition count is equal to expected partition count
+    when(topicManager.getPartitionCount(realTimeTopic)).thenReturn(expectedNumOfPartitions);
+    when(topicManager.updateTopicRetentionWithRetries(eq(realTimeTopic), anyLong())).thenReturn(true);
+    veniceHelixAdmin.validateAndUpdateTopic(realTimeTopic, store, version, expectedNumOfPartitions, topicManager);
+    verify(topicManager, times(1)).updateTopicRetentionWithRetries(eq(realTimeTopic), anyLong());
+  }
+
+  @Test
+  public void testEnsureRealTimeTopicExistsForUserSystemStores() {
+    String clusterName = "testCluster";
+    String storeName = "testStore";
+    String systemStoreName = VeniceSystemStoreType.DAVINCI_PUSH_STATUS_STORE.getSystemStoreName(storeName);
+    int partitionCount = 10;
+    Store userStore = mock(Store.class, RETURNS_DEEP_STUBS);
+    when(userStore.getName()).thenReturn(storeName);
+    Version version = mock(Version.class);
+    when(version.getStoreName()).thenReturn(storeName);
+    when(version.getPartitionCount()).thenReturn(partitionCount);
+    when(userStore.getPartitionCount()).thenReturn(partitionCount);
+    TopicManager topicManager = mock(TopicManager.class);
+    PubSubTopicRepository pubSubTopicRepository = new PubSubTopicRepository();
+    VeniceHelixAdmin veniceHelixAdmin = mock(VeniceHelixAdmin.class);
+    doReturn(topicManager).when(veniceHelixAdmin).getTopicManager();
+    doReturn(pubSubTopicRepository).when(veniceHelixAdmin).getPubSubTopicRepository();
+
+    // Case 1: Store does not exist
+    doReturn(null).when(veniceHelixAdmin).getStore(clusterName, storeName);
+    doNothing().when(veniceHelixAdmin).checkControllerLeadershipFor(clusterName);
+    doCallRealMethod().when(veniceHelixAdmin).ensureRealTimeTopicExistsForUserSystemStores(anyString(), anyString());
+    Exception notFoundException = expectThrows(
+        VeniceException.class,
+        () -> veniceHelixAdmin.ensureRealTimeTopicExistsForUserSystemStores(clusterName, storeName));
+    assertTrue(
+        notFoundException.getMessage().contains("does not exist in"),
+        "Actual message: " + notFoundException.getMessage());
+
+    // Case 2: Store exists, but it's not user system store
+    doReturn(userStore).when(veniceHelixAdmin).getStore(clusterName, storeName);
+    Exception notUserSystemStoreException = expectThrows(
+        VeniceException.class,
+        () -> veniceHelixAdmin.ensureRealTimeTopicExistsForUserSystemStores(clusterName, storeName));
+    assertTrue(
+        notUserSystemStoreException.getMessage().contains("is not a user system store"),
+        "Actual message: " + notUserSystemStoreException.getMessage());
+
+    // Case 3: Store exists, it's a user system store, but real-time topic already exists
+    Store systemStore = mock(Store.class, RETURNS_DEEP_STUBS);
+    doReturn(systemStoreName).when(systemStore).getName();
+    doReturn(Collections.emptyList()).when(systemStore).getVersions();
+    doReturn(systemStore).when(veniceHelixAdmin).getStore(clusterName, systemStoreName);
+    doReturn(true).when(topicManager).containsTopic(any(PubSubTopic.class));
+    veniceHelixAdmin.ensureRealTimeTopicExistsForUserSystemStores(clusterName, systemStoreName);
+    verify(topicManager, times(1)).containsTopic(any(PubSubTopic.class));
+
+    HelixVeniceClusterResources veniceClusterResources = mock(HelixVeniceClusterResources.class);
+    doReturn(veniceClusterResources).when(veniceHelixAdmin).getHelixVeniceClusterResources(clusterName);
+    ClusterLockManager clusterLockManager = mock(ClusterLockManager.class);
+    when(veniceClusterResources.getClusterLockManager()).thenReturn(clusterLockManager);
+
+    // Case 4: Store exists, it's a user system store, first check if real-time topic exists returns false but
+    // later RT topic was created
+    topicManager = mock(TopicManager.class);
+    doReturn(topicManager).when(veniceHelixAdmin).getTopicManager();
+    doReturn(false).doReturn(true).when(topicManager).containsTopic(any(PubSubTopic.class));
+    veniceHelixAdmin.ensureRealTimeTopicExistsForUserSystemStores(clusterName, systemStoreName);
+    verify(topicManager, times(2)).containsTopic(any(PubSubTopic.class));
+    verify(topicManager, never()).createTopic(
+        any(PubSubTopic.class),
+        anyInt(),
+        anyInt(),
+        anyLong(),
+        anyBoolean(),
+        any(Optional.class),
+        anyBoolean());
+
+    // Case 5: Store exists, it's a user system store, but real-time topic does not exist and there are no versions
+    // and store partition count is zero
+    doReturn(0).when(systemStore).getPartitionCount();
+    doReturn(false).when(topicManager).containsTopic(any(PubSubTopic.class));
+    Exception zeroPartitionCountException = expectThrows(
+        VeniceException.class,
+        () -> veniceHelixAdmin.ensureRealTimeTopicExistsForUserSystemStores(clusterName, systemStoreName));
+    assertTrue(
+        zeroPartitionCountException.getMessage().contains("partition count set to 0"),
+        "Actual message: " + zeroPartitionCountException.getMessage());
+
+    // Case 6: Store exists, it's a user system store, but real-time topic does not exist and there are no versions
+    // hence create a new real-time topic should use store's partition count
+
+    doReturn(false).when(topicManager).containsTopic(any(PubSubTopic.class));
+    doReturn(null).when(systemStore).getVersion(anyInt());
+    doReturn(5).when(systemStore).getPartitionCount();
+    VeniceControllerClusterConfig clusterConfig = mock(VeniceControllerClusterConfig.class);
+    when(veniceHelixAdmin.getControllerConfig(clusterName)).thenReturn(clusterConfig);
+    veniceHelixAdmin.ensureRealTimeTopicExistsForUserSystemStores(clusterName, systemStoreName);
+    ArgumentCaptor<Integer> partitionCountArgumentCaptor = ArgumentCaptor.forClass(Integer.class);
+    verify(topicManager, times(1)).createTopic(
+        any(PubSubTopic.class),
+        partitionCountArgumentCaptor.capture(),
+        anyInt(),
+        anyLong(),
+        anyBoolean(),
+        any(Optional.class),
+        anyBoolean());
+    assertEquals(partitionCountArgumentCaptor.getValue().intValue(), 5);
+
+    // Case 7: Store exists, it's a user system store, but real-time topic does not exist and there are versions
+    version = mock(Version.class);
+    topicManager = mock(TopicManager.class);
+    doReturn(topicManager).when(veniceHelixAdmin).getTopicManager();
+    doReturn(false).when(topicManager).containsTopic(any(PubSubTopic.class));
+    doReturn(version).when(systemStore).getVersion(anyInt());
+    doReturn(10).when(version).getPartitionCount();
+    veniceHelixAdmin.ensureRealTimeTopicExistsForUserSystemStores(clusterName, systemStoreName);
+    partitionCountArgumentCaptor = ArgumentCaptor.forClass(Integer.class);
+    verify(topicManager, times(1)).createTopic(
+        any(PubSubTopic.class),
+        partitionCountArgumentCaptor.capture(),
+        anyInt(),
+        anyLong(),
+        anyBoolean(),
+        any(Optional.class),
+        anyBoolean());
+    assertEquals(partitionCountArgumentCaptor.getValue().intValue(), 10);
+  }
+
+  @Test
+  public void testValidateStoreSetupForRTWrites() {
+    String clusterName = "testCluster";
+    String storeName = "testStore";
+    String pushJobId = "pushJob123";
+    VeniceHelixAdmin veniceHelixAdmin = mock(VeniceHelixAdmin.class);
+    Store store = mock(Store.class, RETURNS_DEEP_STUBS);
+    HelixVeniceClusterResources helixVeniceClusterResources = mock(HelixVeniceClusterResources.class);
+    ReadWriteStoreRepository storeMetadataRepository = mock(ReadWriteStoreRepository.class);
+
+    // Mock the method chain
+    doReturn(helixVeniceClusterResources).when(veniceHelixAdmin).getHelixVeniceClusterResources(clusterName);
+    doReturn(storeMetadataRepository).when(helixVeniceClusterResources).getStoreMetadataRepository();
+    doReturn(store).when(storeMetadataRepository).getStore(storeName);
+
+    doCallRealMethod().when(veniceHelixAdmin)
+        .validateStoreSetupForRTWrites(anyString(), anyString(), anyString(), any(PushType.class));
+
+    // Case 1: Store does not exist
+    doReturn(null).when(storeMetadataRepository).getStore(storeName);
+    Exception storeNotFoundException = expectThrows(
+        VeniceException.class,
+        () -> veniceHelixAdmin.validateStoreSetupForRTWrites(clusterName, storeName, pushJobId, STREAM));
+    assertTrue(
+        storeNotFoundException.getMessage().contains("does not exist"),
+        "Actual message: " + storeNotFoundException.getMessage());
+
+    // Case 2: Store exists but is not hybrid
+    doReturn(store).when(storeMetadataRepository).getStore(storeName);
+    doReturn(false).when(store).isHybrid();
+    Exception nonHybridStoreException = expectThrows(
+        VeniceException.class,
+        () -> veniceHelixAdmin.validateStoreSetupForRTWrites(clusterName, storeName, pushJobId, STREAM));
+    assertTrue(
+        nonHybridStoreException.getMessage().contains("is not a hybrid store"),
+        "Actual message: " + nonHybridStoreException.getMessage());
+
+    // Case 3: Store is hybrid but pushType is INCREMENTAL and incremental push is not enabled
+    doReturn(true).when(store).isHybrid();
+    doReturn(false).when(store).isIncrementalPushEnabled();
+    Exception incrementalPushNotEnabledException = expectThrows(
+        VeniceException.class,
+        () -> veniceHelixAdmin.validateStoreSetupForRTWrites(clusterName, storeName, pushJobId, INCREMENTAL));
+    assertTrue(
+        incrementalPushNotEnabledException.getMessage().contains("is not an incremental push store"),
+        "Actual message: " + incrementalPushNotEnabledException.getMessage());
+    verify(store, times(1)).isIncrementalPushEnabled();
+
+    // Case 4: Store is hybrid and pushType is INCREMENTAL with incremental push enabled
+    doReturn(true).when(store).isIncrementalPushEnabled();
+    veniceHelixAdmin.validateStoreSetupForRTWrites(clusterName, storeName, pushJobId, INCREMENTAL);
+    verify(store, times(2)).isIncrementalPushEnabled();
+  }
+
+  @Test
+  public void testValidateTopicPresenceAndState() {
+    String clusterName = "testCluster";
+    String storeName = "testStore";
+    String pushJobId = "pushJob123";
+    PubSubTopic topic = mock(PubSubTopic.class);
+    int partitionCount = 10;
+    VeniceHelixAdmin veniceHelixAdmin = mock(VeniceHelixAdmin.class);
+
+    TopicManager topicManager = mock(TopicManager.class);
+    HelixVeniceClusterResources helixVeniceClusterResources = mock(HelixVeniceClusterResources.class);
+    VeniceAdminStats veniceAdminStats = mock(VeniceAdminStats.class);
+
+    doReturn(topicManager).when(veniceHelixAdmin).getTopicManager();
+    doReturn(helixVeniceClusterResources).when(veniceHelixAdmin).getHelixVeniceClusterResources(clusterName);
+    doReturn(veniceAdminStats).when(helixVeniceClusterResources).getVeniceAdminStats();
+
+    doCallRealMethod().when(veniceHelixAdmin)
+        .validateTopicPresenceAndState(
+            anyString(),
+            anyString(),
+            anyString(),
+            any(PushType.class),
+            any(PubSubTopic.class),
+            anyInt());
+
+    // Case 1: Topic exists, all partitions are online, and topic is not truncated
+    when(topicManager.containsTopicAndAllPartitionsAreOnline(topic, partitionCount)).thenReturn(true);
+    when(veniceHelixAdmin.isTopicTruncated(topic.getName())).thenReturn(false);
+    veniceHelixAdmin
+        .validateTopicPresenceAndState(clusterName, storeName, pushJobId, PushType.BATCH, topic, partitionCount);
+    verify(topicManager, times(1)).containsTopicAndAllPartitionsAreOnline(topic, partitionCount);
+    verify(veniceHelixAdmin, times(1)).isTopicTruncated(topic.getName());
+
+    // Case 2: Topic does not exist or not all partitions are online
+    doReturn(false).when(topicManager).containsTopicAndAllPartitionsAreOnline(topic, partitionCount);
+    Exception topicAbsentException = expectThrows(
+        VeniceException.class,
+        () -> veniceHelixAdmin
+            .validateTopicPresenceAndState(clusterName, storeName, pushJobId, PushType.BATCH, topic, partitionCount));
+    assertTrue(
+        topicAbsentException.getMessage().contains("is either absent or being truncated"),
+        "Actual message: " + topicAbsentException.getMessage());
+    verify(veniceAdminStats, times(1)).recordUnexpectedTopicAbsenceCount();
+
+    // Case 3: Topic exists, all partitions are online, but topic is truncated
+    when(topicManager.containsTopicAndAllPartitionsAreOnline(topic, partitionCount)).thenReturn(true);
+    when(veniceHelixAdmin.isTopicTruncated(topic.getName())).thenReturn(true);
+    Exception topicTruncatedException = expectThrows(
+        VeniceException.class,
+        () -> veniceHelixAdmin
+            .validateTopicPresenceAndState(clusterName, storeName, pushJobId, INCREMENTAL, topic, partitionCount));
+    assertTrue(
+        topicTruncatedException.getMessage().contains("is either absent or being truncated"),
+        "Actual message: " + topicTruncatedException.getMessage());
+    verify(veniceAdminStats, times(2)).recordUnexpectedTopicAbsenceCount();
+
+    // Case 4: Validate behavior with different PushType (e.g., INCREMENTAL)
+    when(topicManager.containsTopicAndAllPartitionsAreOnline(topic, partitionCount)).thenReturn(true);
+    when(veniceHelixAdmin.isTopicTruncated(topic.getName())).thenReturn(false);
+    veniceHelixAdmin
+        .validateTopicPresenceAndState(clusterName, storeName, pushJobId, INCREMENTAL, topic, partitionCount);
+    verify(topicManager, times(4)).containsTopicAndAllPartitionsAreOnline(topic, partitionCount);
+    verify(veniceHelixAdmin, times(3)).isTopicTruncated(topic.getName());
+  }
+
+  @Test
+  public void testValidateTopicForIncrementalPush() {
+    String clusterName = "testCluster";
+    String storeName = "testStore";
+    String pushJobId = "pushJob123";
+    int partitionCount = 10;
+    Store store = mock(Store.class);
+    Version referenceHybridVersion = mock(Version.class, RETURNS_DEEP_STUBS);
+    PubSubTopicRepository topicRepository = new PubSubTopicRepository();
+
+    doReturn(storeName).when(store).getName();
+    doReturn(storeName).when(referenceHybridVersion).getStoreName();
+    doReturn(partitionCount).when(referenceHybridVersion).getPartitionCount();
+    PubSubTopic separateRtTopic = topicRepository.getTopic(Version.composeSeparateRealTimeTopic(storeName));
+    PubSubTopic rtTopic = topicRepository.getTopic(Utils.getRealTimeTopicName(referenceHybridVersion));
+
+    VeniceHelixAdmin veniceHelixAdmin0 = mock(VeniceHelixAdmin.class);
+    doReturn(topicRepository).when(veniceHelixAdmin0).getPubSubTopicRepository();
+    doCallRealMethod().when(veniceHelixAdmin0)
+        .validateTopicForIncrementalPush(anyString(), any(Store.class), any(Version.class), anyString());
+    doNothing().when(veniceHelixAdmin0)
+        .validateTopicPresenceAndState(
+            anyString(),
+            anyString(),
+            anyString(),
+            any(PushType.class),
+            any(PubSubTopic.class),
+            anyInt());
+
+    // Case 1: Separate real-time topic is enabled, and both topics are valid
+    doReturn(true).when(referenceHybridVersion).isSeparateRealTimeTopicEnabled();
+
+    veniceHelixAdmin0.validateTopicForIncrementalPush(clusterName, store, referenceHybridVersion, pushJobId);
+
+    verify(veniceHelixAdmin0, times(1))
+        .validateTopicPresenceAndState(clusterName, storeName, pushJobId, INCREMENTAL, separateRtTopic, partitionCount);
+    verify(veniceHelixAdmin0, times(1))
+        .validateTopicPresenceAndState(clusterName, storeName, pushJobId, INCREMENTAL, rtTopic, partitionCount);
+
+    // Case 2: Separate real-time topic is disabled, only real-time topic is validated
+    VeniceHelixAdmin veniceHelixAdmin1 = mock(VeniceHelixAdmin.class);
+    doReturn(topicRepository).when(veniceHelixAdmin1).getPubSubTopicRepository();
+    doCallRealMethod().when(veniceHelixAdmin1)
+        .validateTopicForIncrementalPush(anyString(), any(Store.class), any(Version.class), anyString());
+    doNothing().when(veniceHelixAdmin1)
+        .validateTopicPresenceAndState(
+            anyString(),
+            anyString(),
+            anyString(),
+            any(PushType.class),
+            any(PubSubTopic.class),
+            anyInt());
+
+    doReturn(false).when(referenceHybridVersion).isSeparateRealTimeTopicEnabled();
+    veniceHelixAdmin1.validateTopicForIncrementalPush(clusterName, store, referenceHybridVersion, pushJobId);
+    verify(veniceHelixAdmin1, never())
+        .validateTopicPresenceAndState(clusterName, storeName, pushJobId, INCREMENTAL, separateRtTopic, partitionCount);
+    verify(veniceHelixAdmin1, times(1))
+        .validateTopicPresenceAndState(clusterName, storeName, pushJobId, INCREMENTAL, rtTopic, partitionCount);
+
+    // Case 3: Exception is thrown during validation of separate real-time topic
+    doReturn(true).when(referenceHybridVersion).isSeparateRealTimeTopicEnabled();
+    doThrow(new VeniceException("Separate real-time topic validation failed")).when(veniceHelixAdmin1)
+        .validateTopicPresenceAndState(
+            anyString(),
+            anyString(),
+            anyString(),
+            any(PushType.class),
+            eq(separateRtTopic),
+            anyInt());
+
+    Exception separateRtTopicException = expectThrows(
+        VeniceException.class,
+        () -> veniceHelixAdmin1.validateTopicForIncrementalPush(clusterName, store, referenceHybridVersion, pushJobId));
+    assertTrue(
+        separateRtTopicException.getMessage().contains("Separate real-time topic validation failed"),
+        "Actual message: " + separateRtTopicException.getMessage());
+
+    // Case 4: Exception is thrown during validation of real-time topic
+    doNothing().when(veniceHelixAdmin1)
+        .validateTopicPresenceAndState(
+            anyString(),
+            anyString(),
+            anyString(),
+            any(PushType.class),
+            eq(separateRtTopic),
+            anyInt());
+    doThrow(new VeniceException("Real-time topic validation failed")).when(veniceHelixAdmin1)
+        .validateTopicPresenceAndState(
+            anyString(),
+            anyString(),
+            anyString(),
+            any(PushType.class),
+            eq(rtTopic),
+            anyInt());
+
+    Exception rtTopicException = expectThrows(
+        VeniceException.class,
+        () -> veniceHelixAdmin1.validateTopicForIncrementalPush(clusterName, store, referenceHybridVersion, pushJobId));
+    assertTrue(
+        rtTopicException.getMessage().contains("Real-time topic validation failed"),
+        "Actual message: " + rtTopicException.getMessage());
+  }
+
+  @Test
+  public void testGetReferenceHybridVersionForRealTimeWrites() {
+    String clusterName = "testCluster";
+    String storeName = "testStore";
+    String pushJobId = "pushJob123";
+    Store store = mock(Store.class, RETURNS_DEEP_STUBS);
+    VeniceHelixAdmin veniceHelixAdmin = mock(VeniceHelixAdmin.class);
+
+    // Mock method calls
+    doReturn(storeName).when(store).getName();
+    doCallRealMethod().when(veniceHelixAdmin)
+        .getReferenceHybridVersionForRealTimeWrites(anyString(), any(Store.class), anyString());
+
+    // Case 1: Store has no versions
+    doReturn(Collections.emptyList()).when(store).getVersions();
+    Exception noVersionsException = expectThrows(
+        VeniceException.class,
+        () -> veniceHelixAdmin.getReferenceHybridVersionForRealTimeWrites(clusterName, store, pushJobId));
+    assertTrue(
+        noVersionsException.getMessage().contains("is not initialized with a version yet."),
+        "Actual message: " + noVersionsException.getMessage());
+
+    // Case 2: Store has versions, but none are valid hybrid versions
+    Version version1 = mock(Version.class);
+    Version version2 = mock(Version.class);
+    doReturn(Arrays.asList(version1, version2)).when(store).getVersions();
+    doReturn(null).when(version1).getHybridStoreConfig();
+    doReturn(null).when(version2).getHybridStoreConfig();
+
+    Exception noValidHybridException = expectThrows(
+        VeniceException.class,
+        () -> veniceHelixAdmin.getReferenceHybridVersionForRealTimeWrites(clusterName, store, pushJobId));
+    assertTrue(
+        noValidHybridException.getMessage().contains("No valid hybrid store version"),
+        "Actual message: " + noValidHybridException.getMessage());
+
+    // Case 3: Store has valid hybrid versions, selects the highest version number
+    Version validVersion1 = mock(Version.class, RETURNS_DEEP_STUBS);
+    Version validVersion2 = mock(Version.class, RETURNS_DEEP_STUBS);
+
+    doReturn(10).when(validVersion1).getNumber();
+    doReturn(20).when(validVersion2).getNumber();
+    doReturn(VersionStatus.ONLINE).when(validVersion1).getStatus();
+    doReturn(VersionStatus.ONLINE).when(validVersion2).getStatus();
+    HybridStoreConfig hybridStoreConfig = mock(HybridStoreConfig.class);
+    doReturn(hybridStoreConfig).when(validVersion1).getHybridStoreConfig();
+    doReturn(hybridStoreConfig).when(validVersion2).getHybridStoreConfig();
+    doReturn(Arrays.asList(validVersion1, validVersion2)).when(store).getVersions();
+
+    Version referenceVersion =
+        veniceHelixAdmin.getReferenceHybridVersionForRealTimeWrites(clusterName, store, pushJobId);
+    assertEquals(
+        referenceVersion,
+        validVersion2,
+        "Expected the version with the highest version number to be selected.");
+
+    // Case 4: Store has valid hybrid versions, but they are ERROR or KILLED
+    doReturn(VersionStatus.ERROR).when(validVersion1).getStatus();
+    doReturn(VersionStatus.KILLED).when(validVersion2).getStatus();
+    Exception invalidHybridVersionException = expectThrows(
+        VeniceException.class,
+        () -> veniceHelixAdmin.getReferenceHybridVersionForRealTimeWrites(clusterName, store, pushJobId));
+    assertTrue(
+        invalidHybridVersionException.getMessage().contains("No valid hybrid store version"),
+        "Actual message: " + invalidHybridVersionException.getMessage());
+  }
+
+  @Test
+  public void testGetIncrementalPushVersion() {
+    String clusterName = "testCluster";
+    String storeName = "testStore";
+    String pushJobId = "pushJob123";
+
+    VeniceHelixAdmin veniceHelixAdmin = mock(VeniceHelixAdmin.class);
+    HelixVeniceClusterResources resources = mock(HelixVeniceClusterResources.class, RETURNS_DEEP_STUBS);
+    ClusterLockManager lockManager = new ClusterLockManager(clusterName);
+    Store store = mock(Store.class);
+    Version hybridVersion = mock(Version.class);
+
+    doReturn(resources).when(veniceHelixAdmin).getHelixVeniceClusterResources(clusterName);
+    doReturn(lockManager).when(resources).getClusterLockManager();
+    doReturn(hybridVersion).when(veniceHelixAdmin)
+        .getReferenceHybridVersionForRealTimeWrites(clusterName, store, pushJobId);
+
+    when(resources.getStoreMetadataRepository().getStore(storeName)).thenReturn(store);
+
+    doCallRealMethod().when(veniceHelixAdmin).getIncrementalPushVersion(anyString(), anyString(), anyString());
+
+    // Case 1: All validations pass, and the real-time topic is not required
+    doNothing().when(veniceHelixAdmin).checkControllerLeadershipFor(clusterName);
+    doNothing().when(veniceHelixAdmin)
+        .validateStoreSetupForRTWrites(eq(clusterName), eq(storeName), eq(pushJobId), eq(INCREMENTAL));
+    doReturn(false).when(veniceHelixAdmin).isRealTimeTopicRequired(store, hybridVersion);
+    Version result = veniceHelixAdmin.getIncrementalPushVersion(clusterName, storeName, pushJobId);
+    assertEquals(result, hybridVersion, "Expected the hybrid version to be returned.");
+
+    // Case 2: Real-time topic is required, and validation succeeds
+    doReturn(true).when(veniceHelixAdmin).isRealTimeTopicRequired(store, hybridVersion);
+    doNothing().when(veniceHelixAdmin).validateTopicForIncrementalPush(clusterName, store, hybridVersion, pushJobId);
+    result = veniceHelixAdmin.getIncrementalPushVersion(clusterName, storeName, pushJobId);
+    assertEquals(result, hybridVersion, "Expected the hybrid version to be returned after topic validation.");
+    verify(veniceHelixAdmin, times(1)).validateTopicForIncrementalPush(clusterName, store, hybridVersion, pushJobId);
+
+    // Case 3: Real-time topic validation fails
+    doThrow(new VeniceException("Real-time topic validation failed")).when(veniceHelixAdmin)
+        .validateTopicForIncrementalPush(clusterName, store, hybridVersion, pushJobId);
+    Exception rtTopicValidationException = expectThrows(
+        VeniceException.class,
+        () -> veniceHelixAdmin.getIncrementalPushVersion(clusterName, storeName, pushJobId));
+    assertTrue(
+        rtTopicValidationException.getMessage().contains("Real-time topic validation failed"),
+        "Actual message: " + rtTopicValidationException.getMessage());
+
+    // Case 4: Reference hybrid version retrieval fails
+    doThrow(new VeniceException("No valid hybrid version found")).when(veniceHelixAdmin)
+        .getReferenceHybridVersionForRealTimeWrites(clusterName, store, pushJobId);
+    Exception hybridVersionException = expectThrows(
+        VeniceException.class,
+        () -> veniceHelixAdmin.getIncrementalPushVersion(clusterName, storeName, pushJobId));
+    assertTrue(
+        hybridVersionException.getMessage().contains("No valid hybrid version found"),
+        "Actual message: " + hybridVersionException.getMessage());
+
+    // Case 5: Store setup validation fails
+    doThrow(new VeniceException("Store setup validation failed")).when(veniceHelixAdmin)
+        .validateStoreSetupForRTWrites(eq(clusterName), eq(storeName), eq(pushJobId), eq(INCREMENTAL));
+
+    Exception storeSetupValidationException = expectThrows(
+        VeniceException.class,
+        () -> veniceHelixAdmin.getIncrementalPushVersion(clusterName, storeName, pushJobId));
+    assertTrue(
+        storeSetupValidationException.getMessage().contains("Store setup validation failed"),
+        "Actual message: " + storeSetupValidationException.getMessage());
+  }
+
+  @Test
+  public void testGetReferenceVersionForStreamingWrites() {
+    String clusterName = "testCluster";
+    String storeName = "testStore";
+    String pushJobId = "pushJob123";
+    int partitionCount = 10;
+
+    VeniceHelixAdmin veniceHelixAdmin = mock(VeniceHelixAdmin.class);
+    HelixVeniceClusterResources resources = mock(HelixVeniceClusterResources.class, RETURNS_DEEP_STUBS);
+    ClusterLockManager lockManager = new ClusterLockManager(clusterName);
+    Store store = mock(Store.class);
+    Version hybridVersion = mock(Version.class);
+    PubSubTopicRepository topicRepository = new PubSubTopicRepository();
+    PubSubTopic rtTopic = topicRepository.getTopic("testStore_rt");
+
+    doReturn(storeName).when(store).getName();
+    doReturn(storeName).when(hybridVersion).getStoreName();
+    doReturn(resources).when(veniceHelixAdmin).getHelixVeniceClusterResources(clusterName);
+    doReturn(lockManager).when(resources).getClusterLockManager();
+    doReturn(hybridVersion).when(veniceHelixAdmin)
+        .getReferenceHybridVersionForRealTimeWrites(clusterName, store, pushJobId);
+    doReturn(topicRepository).when(veniceHelixAdmin).getPubSubTopicRepository();
+    doReturn(partitionCount).when(hybridVersion).getPartitionCount();
+
+    when(resources.getStoreMetadataRepository().getStore(storeName)).thenReturn(store);
+
+    doCallRealMethod().when(veniceHelixAdmin)
+        .getReferenceVersionForStreamingWrites(anyString(), anyString(), anyString());
+
+    // Case 1: All validations pass, and the controller is parent
+    doNothing().when(veniceHelixAdmin).checkControllerLeadershipFor(clusterName);
+    doNothing().when(veniceHelixAdmin)
+        .validateStoreSetupForRTWrites(eq(clusterName), eq(storeName), eq(pushJobId), eq(PushType.STREAM));
+    doReturn(true).when(veniceHelixAdmin).isParent();
+
+    Version result = veniceHelixAdmin.getReferenceVersionForStreamingWrites(clusterName, storeName, pushJobId);
+    assertEquals(result, hybridVersion, "Expected the hybrid version to be returned.");
+
+    // Case 2: All validations pass, and the controller is not parent
+    doReturn(false).when(veniceHelixAdmin).isParent();
+    doNothing().when(veniceHelixAdmin)
+        .validateTopicPresenceAndState(
+            eq(clusterName),
+            eq(storeName),
+            eq(pushJobId),
+            eq(PushType.STREAM),
+            eq(rtTopic),
+            eq(partitionCount));
+    result = veniceHelixAdmin.getReferenceVersionForStreamingWrites(clusterName, storeName, pushJobId);
+    assertEquals(result, hybridVersion, "Expected the hybrid version to be returned after topic validation.");
+    verify(veniceHelixAdmin, times(1)).validateTopicPresenceAndState(
+        eq(clusterName),
+        eq(storeName),
+        eq(pushJobId),
+        eq(PushType.STREAM),
+        eq(rtTopic),
+        eq(partitionCount));
+
+    // Case 3: Topic validation fails when the controller is not parent
+    doThrow(new VeniceException("Real-time topic validation failed")).when(veniceHelixAdmin)
+        .validateTopicPresenceAndState(
+            eq(clusterName),
+            eq(storeName),
+            eq(pushJobId),
+            eq(PushType.STREAM),
+            eq(rtTopic),
+            eq(partitionCount));
+    Exception rtTopicValidationException = expectThrows(
+        VeniceException.class,
+        () -> veniceHelixAdmin.getReferenceVersionForStreamingWrites(clusterName, storeName, pushJobId));
+    assertTrue(
+        rtTopicValidationException.getMessage().contains("Real-time topic validation failed"),
+        "Actual message: " + rtTopicValidationException.getMessage());
+
+    // Case 4: Reference hybrid version retrieval fails
+    doThrow(new VeniceException("No valid hybrid version found")).when(veniceHelixAdmin)
+        .getReferenceHybridVersionForRealTimeWrites(clusterName, store, pushJobId);
+    Exception hybridVersionException = expectThrows(
+        VeniceException.class,
+        () -> veniceHelixAdmin.getReferenceVersionForStreamingWrites(clusterName, storeName, pushJobId));
+    assertTrue(
+        hybridVersionException.getMessage().contains("No valid hybrid version found"),
+        "Actual message: " + hybridVersionException.getMessage());
+
+    // Case 5: Store setup validation fails
+    doThrow(new VeniceException("Store setup validation failed")).when(veniceHelixAdmin)
+        .validateStoreSetupForRTWrites(eq(clusterName), eq(storeName), eq(pushJobId), eq(PushType.STREAM));
+    Exception storeSetupValidationException = expectThrows(
+        VeniceException.class,
+        () -> veniceHelixAdmin.getReferenceVersionForStreamingWrites(clusterName, storeName, pushJobId));
+    assertTrue(
+        storeSetupValidationException.getMessage().contains("Store setup validation failed"),
+        "Actual message: " + storeSetupValidationException.getMessage());
   }
 }

--- a/services/venice-controller/src/test/java/com/linkedin/venice/controller/server/CreateVersionTest.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/controller/server/CreateVersionTest.java
@@ -4,55 +4,82 @@ import static com.linkedin.venice.HttpConstants.HTTP_GET;
 import static com.linkedin.venice.VeniceConstants.CONTROLLER_SSL_CERTIFICATE_ATTRIBUTE_NAME;
 import static com.linkedin.venice.controller.server.CreateVersion.overrideSourceRegionAddressForIncrementalPushJob;
 import static com.linkedin.venice.controllerapi.ControllerApiConstants.CLUSTER;
+import static com.linkedin.venice.controllerapi.ControllerApiConstants.COMPRESSION_DICTIONARY;
+import static com.linkedin.venice.controllerapi.ControllerApiConstants.DEFER_VERSION_SWAP;
 import static com.linkedin.venice.controllerapi.ControllerApiConstants.HOSTNAME;
+import static com.linkedin.venice.controllerapi.ControllerApiConstants.IS_WRITE_COMPUTE_ENABLED;
 import static com.linkedin.venice.controllerapi.ControllerApiConstants.NAME;
+import static com.linkedin.venice.controllerapi.ControllerApiConstants.PARTITIONERS;
+import static com.linkedin.venice.controllerapi.ControllerApiConstants.PUSH_IN_SORTED_ORDER;
 import static com.linkedin.venice.controllerapi.ControllerApiConstants.PUSH_JOB_ID;
 import static com.linkedin.venice.controllerapi.ControllerApiConstants.PUSH_TYPE;
 import static com.linkedin.venice.controllerapi.ControllerApiConstants.REPUSH_SOURCE_VERSION;
+import static com.linkedin.venice.controllerapi.ControllerApiConstants.REWIND_TIME_IN_SECONDS_OVERRIDE;
+import static com.linkedin.venice.controllerapi.ControllerApiConstants.SEND_START_OF_PUSH;
 import static com.linkedin.venice.controllerapi.ControllerApiConstants.SEPARATE_REAL_TIME_TOPIC_ENABLED;
+import static com.linkedin.venice.controllerapi.ControllerApiConstants.SOURCE_GRID_FABRIC;
 import static com.linkedin.venice.controllerapi.ControllerApiConstants.STORE_SIZE;
+import static com.linkedin.venice.controllerapi.ControllerApiConstants.TARGETED_REGIONS;
 import static com.linkedin.venice.controllerapi.ControllerRoute.REQUEST_TOPIC;
 import static com.linkedin.venice.meta.BufferReplayPolicy.REWIND_FROM_EOP;
 import static com.linkedin.venice.meta.DataReplicationPolicy.ACTIVE_ACTIVE;
 import static com.linkedin.venice.meta.DataReplicationPolicy.AGGREGATE;
 import static com.linkedin.venice.meta.DataReplicationPolicy.NONE;
 import static com.linkedin.venice.meta.DataReplicationPolicy.NON_AGGREGATE;
+import static com.linkedin.venice.meta.Version.PushType.*;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
-import static org.mockito.Mockito.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doCallRealMethod;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.expectThrows;
+import static org.testng.Assert.fail;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.linkedin.venice.acl.DynamicAccessController;
+import com.linkedin.venice.compression.CompressionStrategy;
 import com.linkedin.venice.controller.Admin;
+import com.linkedin.venice.controllerapi.RequestTopicForPushRequest;
 import com.linkedin.venice.controllerapi.VersionCreationResponse;
 import com.linkedin.venice.exceptions.VeniceException;
+import com.linkedin.venice.exceptions.VeniceHttpException;
+import com.linkedin.venice.meta.DataReplicationPolicy;
+import com.linkedin.venice.meta.HybridStoreConfig;
 import com.linkedin.venice.meta.HybridStoreConfigImpl;
 import com.linkedin.venice.meta.OfflinePushStrategy;
+import com.linkedin.venice.meta.PartitionerConfig;
 import com.linkedin.venice.meta.PersistenceType;
 import com.linkedin.venice.meta.ReadStrategy;
 import com.linkedin.venice.meta.RoutingStrategy;
 import com.linkedin.venice.meta.Store;
 import com.linkedin.venice.meta.Version;
-import com.linkedin.venice.meta.Version.PushType;
 import com.linkedin.venice.meta.VersionImpl;
 import com.linkedin.venice.meta.ZKStore;
 import com.linkedin.venice.utils.DataProviderUtils;
 import com.linkedin.venice.utils.ObjectMapperFactory;
 import com.linkedin.venice.utils.Utils;
+import com.linkedin.venice.utils.lazy.Lazy;
 import java.security.cert.X509Certificate;
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import javax.security.auth.x500.X500Principal;
 import javax.servlet.http.HttpServletRequest;
+import org.apache.http.HttpStatus;
 import org.testng.Assert;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
@@ -95,7 +122,7 @@ public class CreateVersionTest {
     queryMap.put(NAME, new String[] { STORE_NAME });
     queryMap.put(STORE_SIZE, new String[] { "0" });
     queryMap.put(REPUSH_SOURCE_VERSION, new String[] { "0" });
-    queryMap.put(PUSH_TYPE, new String[] { PushType.INCREMENTAL.name() });
+    queryMap.put(PUSH_TYPE, new String[] { INCREMENTAL.name() });
     queryMap.put(PUSH_JOB_ID, new String[] { JOB_ID });
     queryMap.put(HOSTNAME, new String[] { "localhost" });
 
@@ -168,7 +195,7 @@ public class CreateVersionTest {
             JOB_ID,
             0,
             0,
-            PushType.INCREMENTAL,
+            INCREMENTAL,
             false,
             false,
             null,
@@ -227,7 +254,7 @@ public class CreateVersionTest {
             JOB_ID,
             0,
             0,
-            PushType.INCREMENTAL,
+            INCREMENTAL,
             false,
             false,
             null,
@@ -253,7 +280,7 @@ public class CreateVersionTest {
         OBJECT_MAPPER.readValue(result.toString(), VersionCreationResponse.class);
     assertTrue(versionCreateResponse.isError());
     assertTrue(versionCreateResponse.getError().contains("which does not have hybrid mode enabled"));
-    Assert.assertNull(versionCreateResponse.getKafkaTopic());
+    assertNull(versionCreateResponse.getKafkaTopic());
   }
 
   @Test
@@ -281,7 +308,7 @@ public class CreateVersionTest {
             JOB_ID,
             0,
             0,
-            PushType.INCREMENTAL,
+            INCREMENTAL,
             false,
             false,
             null,
@@ -336,39 +363,87 @@ public class CreateVersionTest {
     creationResponse = new VersionCreationResponse();
     creationResponse.setKafkaBootstrapServers("default.src.region.com");
     doReturn(Optional.empty()).when(admin).getAggregateRealTimeTopicSource(CLUSTER_NAME);
-    overrideSourceRegionAddressForIncrementalPushJob(admin, creationResponse, CLUSTER_NAME, null, null, false, true);
+    overrideSourceRegionAddressForIncrementalPushJob(
+        admin,
+        creationResponse,
+        CLUSTER_NAME,
+        STORE_NAME,
+        null,
+        null,
+        false,
+        true);
     assertEquals(creationResponse.getKafkaBootstrapServers(), "default.src.region.com");
 
     // AA-all-region is disabled & NR is enabled * AGG RT address is set
     creationResponse = new VersionCreationResponse();
     creationResponse.setKafkaBootstrapServers("default.src.region.com");
     doReturn(Optional.of("agg.rt.region.com")).when(admin).getAggregateRealTimeTopicSource(CLUSTER_NAME);
-    overrideSourceRegionAddressForIncrementalPushJob(admin, creationResponse, CLUSTER_NAME, null, null, false, true);
+    overrideSourceRegionAddressForIncrementalPushJob(
+        admin,
+        creationResponse,
+        CLUSTER_NAME,
+        STORE_NAME,
+        null,
+        null,
+        false,
+        true);
     assertEquals(creationResponse.getKafkaBootstrapServers(), "agg.rt.region.com");
 
     // AA-all-region and NR are disabled
     creationResponse = new VersionCreationResponse();
     creationResponse.setKafkaBootstrapServers("default.src.region.com");
-    overrideSourceRegionAddressForIncrementalPushJob(admin, creationResponse, CLUSTER_NAME, null, null, false, false);
+    overrideSourceRegionAddressForIncrementalPushJob(
+        admin,
+        creationResponse,
+        CLUSTER_NAME,
+        STORE_NAME,
+        null,
+        null,
+        false,
+        false);
     assertEquals(creationResponse.getKafkaBootstrapServers(), "default.src.region.com");
 
     // AA-all-region is enabled and NR is disabled
     creationResponse = new VersionCreationResponse();
     creationResponse.setKafkaBootstrapServers("default.src.region.com");
-    overrideSourceRegionAddressForIncrementalPushJob(admin, creationResponse, CLUSTER_NAME, null, null, true, false);
+    overrideSourceRegionAddressForIncrementalPushJob(
+        admin,
+        creationResponse,
+        CLUSTER_NAME,
+        STORE_NAME,
+        null,
+        null,
+        true,
+        false);
     assertEquals(creationResponse.getKafkaBootstrapServers(), "default.src.region.com");
 
     // AA-all-region and NR are enabled AND emergencySourceRegion and pushJobSourceGridFabric are null
     creationResponse = new VersionCreationResponse();
     creationResponse.setKafkaBootstrapServers("default.src.region.com");
-    overrideSourceRegionAddressForIncrementalPushJob(admin, creationResponse, CLUSTER_NAME, null, null, true, true);
+    overrideSourceRegionAddressForIncrementalPushJob(
+        admin,
+        creationResponse,
+        CLUSTER_NAME,
+        STORE_NAME,
+        null,
+        null,
+        true,
+        true);
     assertEquals(creationResponse.getKafkaBootstrapServers(), "default.src.region.com");
 
     // AA-all-region and NR are enabled AND emergencySourceRegion is not set but pushJobSourceGridFabric is provided
     creationResponse = new VersionCreationResponse();
     creationResponse.setKafkaBootstrapServers("default.src.region.com");
     doReturn("vpj.src.region.com").when(admin).getNativeReplicationKafkaBootstrapServerAddress("dc-vpj");
-    overrideSourceRegionAddressForIncrementalPushJob(admin, creationResponse, CLUSTER_NAME, null, "dc-vpj", true, true);
+    overrideSourceRegionAddressForIncrementalPushJob(
+        admin,
+        creationResponse,
+        CLUSTER_NAME,
+        STORE_NAME,
+        null,
+        "dc-vpj",
+        true,
+        true);
     assertEquals(creationResponse.getKafkaBootstrapServers(), "vpj.src.region.com");
 
     // AA-all-region and NR are enabled AND emergencySourceRegion is set and pushJobSourceGridFabric is provided
@@ -379,6 +454,7 @@ public class CreateVersionTest {
         admin,
         creationResponse,
         CLUSTER_NAME,
+        STORE_NAME,
         "dc-e",
         "dc-vpj",
         true,
@@ -389,7 +465,15 @@ public class CreateVersionTest {
     creationResponse = new VersionCreationResponse();
     creationResponse.setKafkaBootstrapServers("emergency.src.region.com");
     doReturn("emergency.src.region.com").when(admin).getNativeReplicationKafkaBootstrapServerAddress("dc-e");
-    overrideSourceRegionAddressForIncrementalPushJob(admin, creationResponse, CLUSTER_NAME, "dc-e", null, true, true);
+    overrideSourceRegionAddressForIncrementalPushJob(
+        admin,
+        creationResponse,
+        CLUSTER_NAME,
+        STORE_NAME,
+        "dc-e",
+        null,
+        true,
+        true);
     assertEquals(creationResponse.getKafkaBootstrapServers(), "emergency.src.region.com");
   }
 
@@ -398,7 +482,15 @@ public class CreateVersionTest {
     VersionCreationResponse creationResponse = new VersionCreationResponse();
     creationResponse.setKafkaBootstrapServers("default.src.region.com");
     doReturn(null).when(admin).getNativeReplicationKafkaBootstrapServerAddress("dc1");
-    overrideSourceRegionAddressForIncrementalPushJob(admin, creationResponse, CLUSTER_NAME, "dc1", null, true, true);
+    overrideSourceRegionAddressForIncrementalPushJob(
+        admin,
+        creationResponse,
+        CLUSTER_NAME,
+        STORE_NAME,
+        "dc1",
+        null,
+        true,
+        true);
   }
 
   @Test
@@ -408,35 +500,35 @@ public class CreateVersionTest {
     // push type is STREAM and store is not hybrid
     Store store1 = mock(Store.class);
     when(store1.isHybrid()).thenReturn(false);
-    Exception e = expectThrows(VeniceException.class, () -> createVersion.validatePushType(PushType.STREAM, store1));
+    Exception e = expectThrows(VeniceException.class, () -> createVersion.validatePushType(STREAM, store1));
     assertTrue(e.getMessage().contains("which is not configured to be a hybrid store"));
 
     // push type is STREAM and store is AA enabled hybrid
     Store store2 = mock(Store.class);
     when(store2.isHybrid()).thenReturn(true);
     when(store2.isActiveActiveReplicationEnabled()).thenReturn(true);
-    createVersion.validatePushType(PushType.STREAM, store2);
+    createVersion.validatePushType(STREAM, store2);
 
     // push type is STREAM and store is not AA enabled hybrid but has NON_AGGREGATE replication policy
     Store store3 = mock(Store.class);
     when(store3.isHybrid()).thenReturn(true);
     when(store3.isActiveActiveReplicationEnabled()).thenReturn(false);
     when(store3.getHybridStoreConfig()).thenReturn(new HybridStoreConfigImpl(0, 1, 0, NON_AGGREGATE, REWIND_FROM_EOP));
-    createVersion.validatePushType(PushType.STREAM, store3);
+    createVersion.validatePushType(STREAM, store3);
 
     // push type is STREAM and store is not AA enabled hybrid but has AGGREGATE replication policy
     Store store4 = mock(Store.class);
     when(store4.isHybrid()).thenReturn(true);
     when(store4.isActiveActiveReplicationEnabled()).thenReturn(false);
     when(store4.getHybridStoreConfig()).thenReturn(new HybridStoreConfigImpl(0, 1, 0, AGGREGATE, REWIND_FROM_EOP));
-    createVersion.validatePushType(PushType.STREAM, store4);
+    createVersion.validatePushType(STREAM, store4);
 
     // push type is STREAM and store is not AA enabled hybrid but has NONE replication policy
     Store store5 = mock(Store.class);
     when(store5.isHybrid()).thenReturn(true);
     when(store5.isActiveActiveReplicationEnabled()).thenReturn(false);
     when(store5.getHybridStoreConfig()).thenReturn(new HybridStoreConfigImpl(0, 1, 0, NONE, REWIND_FROM_EOP));
-    Exception e5 = expectThrows(VeniceException.class, () -> createVersion.validatePushType(PushType.STREAM, store5));
+    Exception e5 = expectThrows(VeniceException.class, () -> createVersion.validatePushType(STREAM, store5));
     assertTrue(e5.getMessage().contains("which is configured to have a hybrid data replication policy"));
 
     // push type is STREAM and store is not AA enabled hybrid but has ACTIVE_ACTIVE replication policy
@@ -444,7 +536,7 @@ public class CreateVersionTest {
     when(store6.isHybrid()).thenReturn(true);
     when(store6.isActiveActiveReplicationEnabled()).thenReturn(false);
     when(store6.getHybridStoreConfig()).thenReturn(new HybridStoreConfigImpl(0, 1, 0, ACTIVE_ACTIVE, REWIND_FROM_EOP));
-    Exception e6 = expectThrows(VeniceException.class, () -> createVersion.validatePushType(PushType.STREAM, store6));
+    Exception e6 = expectThrows(VeniceException.class, () -> createVersion.validatePushType(STREAM, store6));
     assertTrue(e6.getMessage().contains("which is configured to have a hybrid data replication policy"));
   }
 
@@ -455,16 +547,391 @@ public class CreateVersionTest {
     // push type is INCREMENTAL and store is not hybrid
     Store store1 = mock(Store.class);
     when(store1.isHybrid()).thenReturn(false);
-    Exception e =
-        expectThrows(VeniceException.class, () -> createVersion.validatePushType(PushType.INCREMENTAL, store1));
+    Exception e = expectThrows(VeniceException.class, () -> createVersion.validatePushType(INCREMENTAL, store1));
     assertTrue(e.getMessage().contains("which does not have hybrid mode enabled"));
 
     // push type is INCREMENTAL and store is hybrid but incremental push is not enabled
     Store store2 = mock(Store.class);
     when(store2.isHybrid()).thenReturn(true);
     when(store2.isIncrementalPushEnabled()).thenReturn(false);
-    Exception e2 =
-        expectThrows(VeniceException.class, () -> createVersion.validatePushType(PushType.INCREMENTAL, store2));
+    Exception e2 = expectThrows(VeniceException.class, () -> createVersion.validatePushType(INCREMENTAL, store2));
     assertTrue(e2.getMessage().contains("which does not have incremental push enabled"));
+  }
+
+  @Test
+  public void testExtractOptionalParamsFromRequestTopicForPushingRequest() {
+    // Test case 1: Default values
+    Request mockRequest = mock(Request.class);
+    doCallRealMethod().when(mockRequest).queryParamOrDefault(anyString(), anyString());
+    doReturn(null).when(mockRequest).queryParams(any());
+
+    RequestTopicForPushRequest requestDetails = new RequestTopicForPushRequest(CLUSTER_NAME, STORE_NAME, BATCH, JOB_ID);
+
+    CreateVersion.extractOptionalParamsFromRequestTopicRequest(mockRequest, requestDetails, false);
+
+    assertNotNull(requestDetails.getPartitioners(), "Default partitioners should not be null");
+    assertTrue(requestDetails.getPartitioners().isEmpty(), "Default partitioners should be empty");
+    assertFalse(requestDetails.isSendStartOfPush(), "Default sendStartOfPush should be false");
+    assertFalse(requestDetails.isSorted(), "Default sorted should be false");
+    assertFalse(requestDetails.isWriteComputeEnabled(), "Default writeComputeEnabled should be false");
+    assertEquals(
+        requestDetails.getRewindTimeInSecondsOverride(),
+        -1L,
+        "Default rewindTimeInSecondsOverride should be -1");
+    assertFalse(requestDetails.isDeferVersionSwap(), "Default deferVersionSwap should be false");
+    assertNull(requestDetails.getTargetedRegions(), "Default targetedRegions should be null");
+    assertEquals(requestDetails.getRepushSourceVersion(), -1, "Default repushSourceVersion should be -1");
+    assertNull(requestDetails.getSourceGridFabric(), "Default sourceGridFabric should be null");
+    assertNull(requestDetails.getCompressionDictionary(), "Default compressionDictionary should be null");
+    assertNull(requestDetails.getCertificateInRequest(), "Default certificateInRequest should be null");
+
+    // Test case 2: All optional parameters are set
+    mockRequest = mock(Request.class);
+    doCallRealMethod().when(mockRequest).queryParamOrDefault(any(), any());
+    String customPartitioners = "f.q.c.n.P1,f.q.c.n.P2";
+    Set<String> expectedPartitioners = new HashSet<>(Arrays.asList("f.q.c.n.P1", "f.q.c.n.P2"));
+
+    when(mockRequest.queryParams(eq(PARTITIONERS))).thenReturn(customPartitioners);
+    when(mockRequest.queryParams(SEND_START_OF_PUSH)).thenReturn("true");
+    when(mockRequest.queryParams(PUSH_IN_SORTED_ORDER)).thenReturn("true");
+    when(mockRequest.queryParams(IS_WRITE_COMPUTE_ENABLED)).thenReturn("true");
+    when(mockRequest.queryParams(REWIND_TIME_IN_SECONDS_OVERRIDE)).thenReturn("120");
+    when(mockRequest.queryParams(DEFER_VERSION_SWAP)).thenReturn("true");
+    when(mockRequest.queryParams(TARGETED_REGIONS)).thenReturn("region-1");
+    when(mockRequest.queryParams(REPUSH_SOURCE_VERSION)).thenReturn("5");
+    when(mockRequest.queryParams(SOURCE_GRID_FABRIC)).thenReturn("grid-fabric");
+    when(mockRequest.queryParams(COMPRESSION_DICTIONARY)).thenReturn("XYZ");
+
+    requestDetails = new RequestTopicForPushRequest(CLUSTER_NAME, STORE_NAME, BATCH, JOB_ID);
+
+    CreateVersion.extractOptionalParamsFromRequestTopicRequest(mockRequest, requestDetails, false);
+
+    assertEquals(requestDetails.getPartitioners(), expectedPartitioners);
+    assertTrue(requestDetails.isSendStartOfPush());
+    assertTrue(requestDetails.isSorted());
+    assertTrue(requestDetails.isWriteComputeEnabled());
+    assertEquals(requestDetails.getRewindTimeInSecondsOverride(), 120L);
+    assertTrue(requestDetails.isDeferVersionSwap());
+    assertEquals(requestDetails.getTargetedRegions(), "region-1");
+    assertEquals(requestDetails.getRepushSourceVersion(), 5);
+    assertEquals(requestDetails.getSourceGridFabric(), "grid-fabric");
+    assertEquals(requestDetails.getCompressionDictionary(), "XYZ");
+
+    // Test case 3: check that the certificate is set in the request details when access control is enabled
+    HttpServletRequest mockHttpServletRequest = mock(HttpServletRequest.class);
+    X509Certificate[] mockCertificates = { mock(X509Certificate.class) };
+    when(mockHttpServletRequest.getAttribute(CONTROLLER_SSL_CERTIFICATE_ATTRIBUTE_NAME)).thenReturn(mockCertificates);
+    when(mockRequest.raw()).thenReturn(mockHttpServletRequest);
+    CreateVersion.extractOptionalParamsFromRequestTopicRequest(mockRequest, requestDetails, true);
+    assertEquals(requestDetails.getCertificateInRequest(), mockCertificates[0]);
+
+    // Test case 4: Invalid values for optional parameters
+    when(mockRequest.queryParams(SEND_START_OF_PUSH)).thenReturn("notBoolean");
+    when(mockRequest.queryParams(REWIND_TIME_IN_SECONDS_OVERRIDE)).thenReturn("invalidLong");
+
+    requestDetails = new RequestTopicForPushRequest(CLUSTER_NAME, STORE_NAME, BATCH, JOB_ID);
+    Request finalMockRequest = mockRequest;
+    RequestTopicForPushRequest finalRequestDetails = requestDetails;
+    VeniceHttpException e = expectThrows(
+        VeniceHttpException.class,
+        () -> CreateVersion.extractOptionalParamsFromRequestTopicRequest(finalMockRequest, finalRequestDetails, false));
+    assertEquals(e.getHttpStatusCode(), HttpStatus.SC_BAD_REQUEST);
+  }
+
+  @Test
+  public void testVerifyAndConfigurePartitionerSettings() {
+    VersionCreationResponse response = new VersionCreationResponse();
+    PartitionerConfig storePartitionerConfig = mock(PartitionerConfig.class);
+    when(storePartitionerConfig.getPartitionerClass()).thenReturn("f.q.c.n.DefaultPartitioner");
+
+    // Test Case 1: Null partitionersFromRequest (should pass)
+    try {
+      CreateVersion.verifyAndConfigurePartitionerSettings(storePartitionerConfig, null, response);
+    } catch (Exception e) {
+      fail("Null partitionersFromRequest should not throw an exception.");
+    }
+    assertEquals(response.getPartitionerClass(), "f.q.c.n.DefaultPartitioner");
+
+    // Test Case 2: Empty partitionersFromRequest (should pass)
+    response = new VersionCreationResponse();
+    Set<String> partitionersFromRequest = Collections.emptySet();
+    try {
+      CreateVersion.verifyAndConfigurePartitionerSettings(storePartitionerConfig, partitionersFromRequest, response);
+    } catch (Exception e) {
+      fail("Empty partitionersFromRequest should not throw an exception.");
+    }
+    assertEquals(response.getPartitionerClass(), "f.q.c.n.DefaultPartitioner");
+
+    // Test Case 3: Matching partitioner in partitionersFromRequest (should pass)
+    response = new VersionCreationResponse();
+    partitionersFromRequest = new HashSet<>(Arrays.asList("f.q.c.n.DefaultPartitioner", "f.q.c.n.CustomPartitioner"));
+    try {
+      CreateVersion.verifyAndConfigurePartitionerSettings(storePartitionerConfig, partitionersFromRequest, response);
+    } catch (Exception e) {
+      fail("Matching partitioner should not throw an exception.");
+    }
+    assertEquals(response.getPartitionerClass(), "f.q.c.n.DefaultPartitioner");
+
+    // Test Case 4: Non-matching partitioner in partitionersFromRequest (should throw exception)
+    final VersionCreationResponse finalResponse = new VersionCreationResponse();
+    partitionersFromRequest = new HashSet<>(Collections.singletonList("f.q.c.n.CustomPartitioner"));
+    Set<String> finalPartitionersFromRequest = partitionersFromRequest;
+    Exception e = expectThrows(
+        VeniceException.class,
+        () -> CreateVersion.verifyAndConfigurePartitionerSettings(
+            storePartitionerConfig,
+            finalPartitionersFromRequest,
+            finalResponse));
+    assertTrue(e.getMessage().contains("cannot be found"));
+  }
+
+  @Test
+  public void testDetermineResponseTopic() {
+    String storeName = "test_store";
+    String vtName = Version.composeKafkaTopic(storeName, 1);
+    String rtName = Version.composeRealTimeTopic(storeName);
+    String srTopicName = Version.composeStreamReprocessingTopic(storeName, 1);
+    String separateRtName = Version.composeSeparateRealTimeTopic(storeName);
+
+    RequestTopicForPushRequest request = new RequestTopicForPushRequest("v0", storeName, INCREMENTAL, "JOB_ID");
+
+    // Test Case: PushType.INCREMENTAL with separate real-time topic enabled
+    Version mockVersion1 = mock(Version.class);
+    when(mockVersion1.kafkaTopicName()).thenReturn(vtName);
+    when(mockVersion1.isSeparateRealTimeTopicEnabled()).thenReturn(true);
+    request.setSeparateRealTimeTopicEnabled(true);
+    String result1 = CreateVersion.determineResponseTopic(storeName, mockVersion1, request);
+    assertEquals(result1, separateRtName);
+
+    // Test Case: PushType.INCREMENTAL with separate real-time topic enabled, but the request does not have the separate
+    // real-time topic flag
+    mockVersion1 = mock(Version.class);
+    when(mockVersion1.kafkaTopicName()).thenReturn(vtName);
+    when(mockVersion1.isSeparateRealTimeTopicEnabled()).thenReturn(true);
+    request.setSeparateRealTimeTopicEnabled(false);
+    result1 = CreateVersion.determineResponseTopic(storeName, mockVersion1, request);
+    assertEquals(result1, rtName);
+
+    // Test Case: PushType.INCREMENTAL without separate real-time topic enabled
+    Version mockVersion2 = mock(Version.class);
+    when(mockVersion2.kafkaTopicName()).thenReturn(vtName);
+    when(mockVersion2.isSeparateRealTimeTopicEnabled()).thenReturn(true);
+    request = new RequestTopicForPushRequest("v0", storeName, INCREMENTAL, "JOB_ID");
+    String result2 = CreateVersion.determineResponseTopic(storeName, mockVersion2, request);
+    assertEquals(result2, rtName);
+
+    // Test Case: PushType.STREAM
+    Version mockVersion3 = mock(Version.class);
+    when(mockVersion3.kafkaTopicName()).thenReturn(vtName);
+    request = new RequestTopicForPushRequest("v0", storeName, STREAM, "JOB_ID");
+    String result3 = CreateVersion.determineResponseTopic(storeName, mockVersion3, request);
+    assertEquals(result3, rtName);
+
+    // Test Case: PushType.STREAM_REPROCESSING
+    Version mockVersion4 = mock(Version.class);
+    when(mockVersion4.kafkaTopicName()).thenReturn(vtName);
+    when(mockVersion4.getNumber()).thenReturn(1);
+    request = new RequestTopicForPushRequest("v0", storeName, STREAM_REPROCESSING, "JOB_ID");
+    String result4 = CreateVersion.determineResponseTopic(storeName, mockVersion4, request);
+    assertEquals(result4, srTopicName);
+
+    // Test Case: Default case with a Kafka topic
+    Version mockVersion5 = mock(Version.class);
+    when(mockVersion5.kafkaTopicName()).thenReturn(vtName);
+    request = new RequestTopicForPushRequest("v0", storeName, BATCH, "JOB_ID");
+    String result5 = CreateVersion.determineResponseTopic(storeName, mockVersion5, request);
+    assertEquals(result5, vtName);
+  }
+
+  @Test
+  public void testGetCompressionStrategy() {
+    // Test Case 1: Real-time topic returns NO_OP
+    Version mockVersion1 = mock(Version.class);
+    String responseTopic1 = Version.composeRealTimeTopic("test_store");
+    CompressionStrategy result1 = CreateVersion.getCompressionStrategy(mockVersion1, responseTopic1);
+    assertEquals(result1, CompressionStrategy.NO_OP);
+
+    // Test Case 2: Non-real-time topic returns version's compression strategy
+    Version mockVersion2 = mock(Version.class);
+    String responseTopic2 = Version.composeKafkaTopic("test_store", 1);
+    when(mockVersion2.getCompressionStrategy()).thenReturn(CompressionStrategy.GZIP);
+    CompressionStrategy result2 = CreateVersion.getCompressionStrategy(mockVersion2, responseTopic2);
+    assertEquals(result2, CompressionStrategy.GZIP);
+  }
+
+  @Test
+  public void testConfigureSourceFabric() {
+    // Test Case 1: Native replication enabled and non-incremental push type
+    Admin mockAdmin1 = mock(Admin.class);
+    Version mockVersion1 = mock(Version.class);
+    Lazy<Boolean> mockLazy1 = mock(Lazy.class);
+    RequestTopicForPushRequest mockRequest1 = mock(RequestTopicForPushRequest.class);
+    VersionCreationResponse mockResponse1 = new VersionCreationResponse();
+
+    when(mockVersion1.isNativeReplicationEnabled()).thenReturn(true);
+    when(mockVersion1.getPushStreamSourceAddress()).thenReturn("bootstrapServer1");
+    when(mockVersion1.getNativeReplicationSourceFabric()).thenReturn("sourceFabric1");
+    when(mockRequest1.getPushType()).thenReturn(BATCH);
+
+    CreateVersion.configureSourceFabric(mockAdmin1, mockVersion1, mockLazy1, mockRequest1, mockResponse1);
+
+    assertEquals(mockResponse1.getKafkaBootstrapServers(), "bootstrapServer1");
+    assertEquals(mockResponse1.getKafkaSourceRegion(), "sourceFabric1");
+
+    // Test Case 2: Native replication enabled with null PushStreamSourceAddress
+    Admin mockAdmin2 = mock(Admin.class);
+    Version mockVersion2 = mock(Version.class);
+    Lazy<Boolean> mockLazy2 = mock(Lazy.class);
+    RequestTopicForPushRequest mockRequest2 = mock(RequestTopicForPushRequest.class);
+    VersionCreationResponse mockResponse2 = new VersionCreationResponse();
+
+    when(mockVersion2.isNativeReplicationEnabled()).thenReturn(true);
+    when(mockVersion2.getPushStreamSourceAddress()).thenReturn(null);
+    when(mockVersion2.getNativeReplicationSourceFabric()).thenReturn("sourceFabric2");
+    when(mockRequest2.getPushType()).thenReturn(BATCH);
+
+    CreateVersion.configureSourceFabric(mockAdmin2, mockVersion2, mockLazy2, mockRequest2, mockResponse2);
+
+    assertNull(mockResponse2.getKafkaBootstrapServers());
+    assertEquals(mockResponse2.getKafkaSourceRegion(), "sourceFabric2");
+
+    // Test Case 3: Incremental push with parent admin and override source region
+    Admin mockAdmin3 = mock(Admin.class);
+    Version mockVersion3 = mock(Version.class);
+    Lazy<Boolean> mockLazy3 = mock(Lazy.class);
+    RequestTopicForPushRequest mockRequest3 = mock(RequestTopicForPushRequest.class);
+    VersionCreationResponse mockResponse3 = new VersionCreationResponse();
+
+    when(mockAdmin3.isParent()).thenReturn(true);
+    when(mockVersion3.isNativeReplicationEnabled()).thenReturn(true);
+    when(mockRequest3.getPushType()).thenReturn(INCREMENTAL);
+    when(mockRequest3.getClusterName()).thenReturn("testCluster");
+    when(mockRequest3.getStoreName()).thenReturn("testStore");
+    when(mockRequest3.getEmergencySourceRegion()).thenReturn("emergencyRegion");
+    when(mockRequest3.getSourceGridFabric()).thenReturn("gridFabric");
+    when(mockLazy3.get()).thenReturn(true);
+
+    when(mockAdmin3.getNativeReplicationKafkaBootstrapServerAddress("emergencyRegion"))
+        .thenReturn("emergencyRegionAddress");
+
+    CreateVersion.configureSourceFabric(mockAdmin3, mockVersion3, mockLazy3, mockRequest3, mockResponse3);
+
+    assertEquals(mockResponse3.getKafkaBootstrapServers(), "emergencyRegionAddress");
+
+    // No specific assertions here since `overrideSourceRegionAddressForIncrementalPushJob` is mocked,
+    // but we can verify if the mock was called with appropriate parameters.
+    verify(mockAdmin3, times(1)).isParent();
+  }
+
+  @Test
+  public void testHandleStreamPushTypeInParentController() {
+    Admin admin = mock(Admin.class);
+    Store store = mock(Store.class);
+    when(store.getName()).thenReturn(STORE_NAME);
+    HybridStoreConfig hybridStoreConfig = mock(HybridStoreConfig.class);
+    when(store.getHybridStoreConfig()).thenReturn(hybridStoreConfig);
+    RequestTopicForPushRequest request = new RequestTopicForPushRequest("CLUSTER_NAME", STORE_NAME, STREAM, "JOB_ID");
+    VersionCreationResponse response = new VersionCreationResponse();
+
+    // Case 1: Parent region; With stream pushes disabled
+    when(admin.isParent()).thenReturn(true);
+    CreateVersion createVersionNotOk = new CreateVersion(true, Optional.of(accessClient), false, true);
+    VeniceException ex1 = expectThrows(
+        VeniceException.class,
+        () -> createVersionNotOk.handleStreamPushType(admin, store, request, response, Lazy.of(() -> false)));
+    assertTrue(
+        ex1.getMessage().contains("Write operations to the parent region are not permitted with push type: STREAM"));
+
+    CreateVersion createVersionOk = new CreateVersion(true, Optional.of(accessClient), false, false);
+
+    // Case 2: Parent region; Non-aggregate mode in parent with no AA replication
+    when(admin.isParent()).thenReturn(true);
+    when(store.getHybridStoreConfig().getDataReplicationPolicy()).thenReturn(NON_AGGREGATE);
+    VeniceException ex2 = expectThrows(
+        VeniceException.class,
+        () -> createVersionOk.handleStreamPushType(admin, store, request, response, Lazy.of(() -> false)));
+    assertTrue(ex2.getMessage().contains("Store is not in aggregate mode!"));
+
+    // Case 3: Parent region; Non-aggregate mode but AA replication enabled and no hybrid version
+    when(admin.isParent()).thenReturn(true);
+    when(store.getHybridStoreConfig().getDataReplicationPolicy()).thenReturn(NON_AGGREGATE);
+    when(store.isActiveActiveReplicationEnabled()).thenReturn(true);
+    when(admin.getReferenceVersionForStreamingWrites(anyString(), anyString(), anyString())).thenReturn(null);
+    VeniceException ex3 = expectThrows(
+        VeniceException.class,
+        () -> createVersionOk.handleStreamPushType(admin, store, request, response, Lazy.of(() -> true)));
+    assertTrue(ex3.getMessage().contains("No hybrid version found for store"), "Got: " + ex3.getMessage());
+
+    // Case 4: Parent region; Aggregate mode but no hybrid version
+    when(admin.isParent()).thenReturn(true);
+    when(store.getHybridStoreConfig().getDataReplicationPolicy()).thenReturn(AGGREGATE);
+    when(store.isActiveActiveReplicationEnabled()).thenReturn(false);
+    when(admin.getReferenceVersionForStreamingWrites(anyString(), anyString(), anyString())).thenReturn(null);
+    VeniceException ex4 = expectThrows(
+        VeniceException.class,
+        () -> createVersionOk.handleStreamPushType(admin, store, request, response, Lazy.of(() -> true)));
+    assertTrue(ex4.getMessage().contains("No hybrid version found for store"), "Got: " + ex4.getMessage());
+
+    // Case 5: Parent region; Aggregate mode and there is a hybrid version
+    Version mockVersion = mock(Version.class);
+    when(mockVersion.getPartitionCount()).thenReturn(42);
+    when(admin.isParent()).thenReturn(true);
+    when(store.getHybridStoreConfig().getDataReplicationPolicy()).thenReturn(AGGREGATE);
+    when(admin.getReferenceVersionForStreamingWrites(anyString(), anyString(), anyString())).thenReturn(mockVersion);
+    createVersionOk.handleStreamPushType(admin, store, request, response, Lazy.of(() -> true));
+    assertEquals(response.getPartitions(), 42);
+    assertEquals(response.getCompressionStrategy(), CompressionStrategy.NO_OP);
+    assertEquals(response.getKafkaTopic(), Version.composeRealTimeTopic(STORE_NAME));
+  }
+
+  @Test
+  public void testHandleStreamPushTypeInChildController() {
+    Admin admin = mock(Admin.class);
+    Store store = mock(Store.class);
+    when(store.getName()).thenReturn(STORE_NAME);
+    HybridStoreConfig hybridStoreConfig = mock(HybridStoreConfig.class);
+    when(store.getHybridStoreConfig()).thenReturn(hybridStoreConfig);
+    RequestTopicForPushRequest request = new RequestTopicForPushRequest("CLUSTER_NAME", STORE_NAME, STREAM, "JOB_ID");
+    VersionCreationResponse response = new VersionCreationResponse();
+    CreateVersion createVersionOk = new CreateVersion(true, Optional.of(accessClient), false, false);
+
+    // Case 1: Child region; Aggregate mode in child and AA not enabled
+    when(admin.isParent()).thenReturn(false);
+    when(store.getHybridStoreConfig().getDataReplicationPolicy()).thenReturn(DataReplicationPolicy.AGGREGATE);
+    when(store.isActiveActiveReplicationEnabled()).thenReturn(false);
+    VeniceException ex5 = expectThrows(
+        VeniceException.class,
+        () -> createVersionOk.handleStreamPushType(admin, store, request, response, Lazy.of(() -> false)));
+    assertTrue(ex5.getMessage().contains("Store is in aggregate mode and AA is not enabled"));
+
+    // Case 2: Child region; Aggregate mode but AA is enabled in all regions but no hybrid version
+    when(admin.isParent()).thenReturn(false);
+    when(store.isActiveActiveReplicationEnabled()).thenReturn(true);
+    when(store.getHybridStoreConfig().getDataReplicationPolicy()).thenReturn(DataReplicationPolicy.AGGREGATE);
+    when(admin.getReferenceVersionForStreamingWrites(anyString(), anyString(), anyString())).thenReturn(null);
+    VeniceException ex6 = expectThrows(
+        VeniceException.class,
+        () -> createVersionOk.handleStreamPushType(admin, store, request, response, Lazy.of(() -> true)));
+    assertTrue(ex6.getMessage().contains("No hybrid version found"), "Got: " + ex6.getMessage());
+
+    // Case 3: Child region; Non-aggregate mode but no hybrid version
+    when(admin.isParent()).thenReturn(false);
+    when(store.getHybridStoreConfig().getDataReplicationPolicy()).thenReturn(DataReplicationPolicy.NON_AGGREGATE);
+    when(admin.getReferenceVersionForStreamingWrites(anyString(), anyString(), anyString())).thenReturn(null);
+    VeniceException ex7 = expectThrows(
+        VeniceException.class,
+        () -> createVersionOk.handleStreamPushType(admin, store, request, response, Lazy.of(() -> true)));
+    assertTrue(ex7.getMessage().contains("No hybrid version found"), "Got: " + ex7.getMessage());
+
+    // Case 4: Child region; Non-aggregate mode and there is a hybrid version
+    Version mockVersion = mock(Version.class);
+    when(mockVersion.getPartitionCount()).thenReturn(42);
+    when(admin.isParent()).thenReturn(false);
+    when(store.getHybridStoreConfig().getDataReplicationPolicy()).thenReturn(DataReplicationPolicy.NON_AGGREGATE);
+    when(admin.getReferenceVersionForStreamingWrites(anyString(), anyString(), anyString())).thenReturn(mockVersion);
+    createVersionOk.handleStreamPushType(admin, store, request, response, Lazy.of(() -> true));
+    assertEquals(response.getPartitions(), 42);
+    assertEquals(response.getCompressionStrategy(), CompressionStrategy.NO_OP);
+    assertEquals(response.getKafkaTopic(), Version.composeRealTimeTopic(STORE_NAME));
   }
 }

--- a/services/venice-router/src/test/java/com/linkedin/venice/router/api/path/TestVeniceComputePath.java
+++ b/services/venice-router/src/test/java/com/linkedin/venice/router/api/path/TestVeniceComputePath.java
@@ -1,7 +1,7 @@
 package com.linkedin.venice.router.api.path;
 
 import static com.linkedin.venice.compute.ComputeRequestWrapper.LATEST_SCHEMA_VERSION_FOR_COMPUTE_REQUEST;
-import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.anyInt;
 import static org.mockito.Mockito.mock;

--- a/services/venice-router/src/test/java/com/linkedin/venice/router/stats/AdminOperationsStatsTest.java
+++ b/services/venice-router/src/test/java/com/linkedin/venice/router/stats/AdminOperationsStatsTest.java
@@ -1,6 +1,7 @@
 package com.linkedin.venice.router.stats;
 
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import com.linkedin.venice.router.VeniceRouterConfig;
 import com.linkedin.venice.tehuti.MockTehutiReporter;


### PR DESCRIPTION
##  Ensure real-time topic partition count matches hybrid version partition count

This fix addresses an issue where the real-time topic partition count did not align 
with the hybrid version partition count, which caused ingestion failures in hybrid 
stores.

### Problem Description

The issue occurs in the following scenario:
1. Create a store with 1 partition.
2. Perform a batch push, creating a batch version with 1 partition.
3. Update the store to 3 partitions and convert it to a hybrid store.
4. Start real-time writes using push type `STREAM`.
5. Perform a full push to create a hybrid version with 3 partitions. This push fails 
   because, after the topic switch, real-time consumers cannot find partitions 2 and 3 
   due to the real-time topic having only 1 partition.

### Root Cause
- In step 4, if the real-time topic did not exist, it gets created with a partition 
  count derived from the largest existing version (batch version with 1 partition), 
  which led to a mismatch.

### Solution

- Stream and incremental push types are now disallowed if there is no online hybrid 
  version.
- If an online hybrid version exists, the real-time topic partition count is now 
  validated to match the hybrid version partition count.
- The `requestTopicForPushing` method no longer creates a real-time topic if it does 
  not already exist, except during new hybrid version creation.
- For new hybrid versions, the real-time topic is created at version creation time 
  instead of during a topic switch. The logic for real-time topic creation during a 
  topic switch is retained for backward compatibility and will be removed once the 
  release with these changes is fully rolled out.

### Miscellaneous Changes

- Refactored `CreateVersion::requestTopicForPushing` to improve unit testability.
- Added similar validation checks for incremental push job types.
- Stopped creating real-time topics for regional system stores like meta and PS3 in 
  the parent region.
- Improved logging around topic switches to make it easier to debug and search.


## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
UTs and E2E in CI

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.