### PR TITLE
[admin-tool] Add support for dumping topic switch message details

### DIFF
--- a/clients/venice-admin-tool/src/main/java/com/linkedin/venice/AdminTool.java
+++ b/clients/venice-admin-tool/src/main/java/com/linkedin/venice/AdminTool.java
@@ -1661,6 +1661,7 @@ public class AdminTool {
     boolean logMetadata = cmd.hasOption(Arg.LOG_METADATA.toString());
     boolean logDataRecord = cmd.hasOption(Arg.LOG_DATA_RECORD.toString());
     boolean logRmdRecord = cmd.hasOption(Arg.LOG_RMD_RECORD.toString());
+    boolean logTsRecord = cmd.hasOption(Arg.LOG_TS_RECORD.toString());
     try (PubSubConsumerAdapter consumer = getConsumer(consumerProps, pubSubClientsFactory)) {
       try (KafkaTopicDumper ktd = new KafkaTopicDumper(
           controllerClient,
@@ -1673,7 +1674,8 @@ public class AdminTool {
           maxConsumeAttempts,
           logMetadata,
           logDataRecord,
-          logRmdRecord)) {
+          logRmdRecord,
+          logTsRecord)) {
         ktd.fetchAndProcess();
       } catch (Exception e) {
         System.err.println("Something went wrong during topic dump");

--- a/clients/venice-admin-tool/src/main/java/com/linkedin/venice/Arg.java
+++ b/clients/venice-admin-tool/src/main/java/com/linkedin/venice/Arg.java
@@ -181,6 +181,7 @@ public enum Arg {
   LOG_METADATA("log-metadata", "lm", false, "Log the metadata for each kafka message on console"),
   LOG_DATA_RECORD("log-data-record", "ldr", false, "Log the data record for each kafka message on console"),
   LOG_RMD_RECORD("log-rmd-record", "lrr", false, "Log the RMD record for each kafka message on console"),
+  LOG_TS_RECORD("log-ts-record", "lts", false, "Log the topic switch message on console"),
   NATIVE_REPLICATION_SOURCE_FABRIC(
       "native-replication-source-fabric", "nrsf", true,
       "The source fabric name to be used in native replication. Remote consumption will happen from kafka in this fabric."

--- a/clients/venice-admin-tool/src/test/java/com/linkedin/venice/TestAdminToolConsumption.java
+++ b/clients/venice-admin-tool/src/test/java/com/linkedin/venice/TestAdminToolConsumption.java
@@ -218,6 +218,7 @@ public class TestAdminToolConsumption {
         3,
         true,
         false,
+        false,
         false);
     Assert.assertEquals(kafkaTopicDumper.fetchAndProcess(), consumedMessageCount);
   }


### PR DESCRIPTION
## Add support for dumping TopicSwitch message details

Add support to dump details of TopicSwitch messages via the admin tool.  
This will help in debugging and root cause analysis of ingestion issues.


## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
UT and local experiments

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.