### PR TITLE
[server] Validate PubSub address against cluster map in AASIT::consumerSubscribe

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
@@ -4442,4 +4442,8 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
   void setVersionRole(PartitionReplicaIngestionContext.VersionRole versionRole) {
     this.versionRole = versionRole;
   }
+
+  protected boolean isDaVinciClient() {
+    return isDaVinciClient;
+  }
 }

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTaskTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTaskTest.java
@@ -3734,8 +3734,8 @@ public abstract class StoreIngestionTaskTest {
     VeniceProperties mockVeniceProperties = mock(VeniceProperties.class);
     doReturn(true).when(mockVeniceProperties).isEmpty();
     doReturn(mockVeniceProperties).when(mockVeniceServerConfig).getKafkaConsumerConfigsForLocalConsumption();
-    doReturn(Object2IntMaps.emptyMap()).when(mockVeniceServerConfig).getKafkaClusterUrlToIdMap();
-    doReturn(Int2ObjectMaps.emptyMap()).when(mockVeniceServerConfig).getKafkaClusterIdToUrlMap();
+    doReturn(Object2IntMaps.singleton("localhost", 0)).when(mockVeniceServerConfig).getKafkaClusterUrlToIdMap();
+    doReturn(Int2ObjectMaps.singleton(0, "localhost")).when(mockVeniceServerConfig).getKafkaClusterIdToUrlMap();
 
     StoreIngestionTaskFactory ingestionTaskFactory = TestUtils.getStoreIngestionTaskBuilder(storeName)
         .setTopicManagerRepository(mockTopicManagerRepository)

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/integration/utils/VeniceClusterWrapper.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/integration/utils/VeniceClusterWrapper.java
@@ -287,6 +287,7 @@ public class VeniceClusterWrapper extends ProcessWrapper {
         if (!options.getRegionName().isEmpty() && !options.getClusterName().isEmpty()) {
           serverName = options.getRegionName() + ":" + options.getClusterName() + ":sn-" + i;
         }
+
         VeniceServerWrapper veniceServerWrapper = ServiceFactory.getVeniceServer(
             options.getRegionName(),
             options.getClusterName(),
@@ -655,6 +656,7 @@ public class VeniceClusterWrapper extends ProcessWrapper {
   public VeniceServerWrapper addVeniceServer(Properties featureProperties, Properties configProperties) {
     Properties mergedProperties = options.getExtraProperties();
     mergedProperties.putAll(configProperties);
+
     VeniceServerWrapper veniceServerWrapper = ServiceFactory.getVeniceServer(
         options.getRegionName(),
         getClusterName(),

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/integration/utils/VeniceTwoLayerMultiRegionMultiClusterWrapper.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/integration/utils/VeniceTwoLayerMultiRegionMultiClusterWrapper.java
@@ -252,7 +252,7 @@ public class VeniceTwoLayerMultiRegionMultiClusterWrapper extends ProcessWrapper
     }
   }
 
-  private static Map<String, Map<String, String>> addKafkaClusterIDMappingToServerConfigs(
+  public static Map<String, Map<String, String>> addKafkaClusterIDMappingToServerConfigs(
       Optional<Properties> serverProperties,
       List<String> regionNames,
       List<PubSubBrokerWrapper> kafkaBrokers) {


### PR DESCRIPTION
## Validate PubSub address against cluster map in AASIT::consumerSubscribe
Ensure the PubSub URL is present in the PubSub cluster map before  
subscribing to a topic. This prevents issues caused by attempting to  
subscribe to unknown PubSub URLs during message consumption.  

Example case:
If the cluster map contains entries like `[a: 0, b: 1]` and the TopicSwitch (TS) message references address c, the subscription check ensures c is present in the cluster map. If `c` is not found, the subscription fails, and ingestion errors out. This prevents consuming any records from address `c`, and hence no records with a` -1` upstream offset are produced to VT.


## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
CI, UT, and local runs

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.