### PR TITLE
[controller] Allow configuring cloud information processor package in Helix CloudConfig

### DIFF
--- a/internal/venice-common/src/main/java/com/linkedin/venice/ConfigKeys.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/ConfigKeys.java
@@ -336,7 +336,7 @@ public class ConfigKeys {
       "controller.storage.cluster.helix.cloud.enabled";
 
   /**
-   * What cloud environment the controller is in. Maps to {@link org.apache.helix.cloud.constants.CloudProvider} Default is empty string.
+   * What cloud environment the controller is in. Maps to {@link org.apache.helix.cloud.constants.CloudProvider}. Default is empty string.
    */
   public static final String CONTROLLER_HELIX_CLOUD_PROVIDER = "controller.helix.cloud.provider";
 
@@ -351,7 +351,13 @@ public class ConfigKeys {
   public static final String CONTROLLER_HELIX_CLOUD_INFO_SOURCES = "controller.helix.cloud.info.sources";
 
   /**
-   * Name of the function that processes the fetching and parsing of cloud information. Default is empty string.
+   * Package name of the class that processes the fetching and parsing of cloud information. Default is empty string.
+   */
+  public static final String CONTROLLER_HELIX_CLOUD_INFO_PROCESSOR_PACKAGE =
+      "controller.helix.cloud.info.processor.package";
+
+  /**
+   * Name of the class that processes the fetching and parsing of cloud information. Default is empty string.
    */
   public static final String CONTROLLER_HELIX_CLOUD_INFO_PROCESSOR_NAME = "controller.helix.cloud.info.processor.name";
 

--- a/internal/venice-common/src/main/java/com/linkedin/venice/utils/HelixUtils.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/utils/HelixUtils.java
@@ -389,6 +389,7 @@ public class HelixUtils {
       CloudProvider cloudProvider,
       String cloudId,
       List<String> cloudInfoSources,
+      String cloudInfoProcessorPackage,
       String cloudInfoProcessorName) {
     CloudConfig.Builder cloudConfigBuilder =
         new CloudConfig.Builder().setCloudEnabled(true).setCloudProvider(cloudProvider);
@@ -399,6 +400,10 @@ public class HelixUtils {
 
     if (cloudInfoSources != null && !cloudInfoSources.isEmpty()) {
       cloudConfigBuilder.setCloudInfoSources(cloudInfoSources);
+    }
+
+    if (!StringUtils.isEmpty(cloudInfoProcessorPackage)) {
+      cloudConfigBuilder.setCloudInfoProcessorPackageName(cloudInfoProcessorPackage);
     }
 
     if (!StringUtils.isEmpty(cloudInfoProcessorName)) {

--- a/internal/venice-common/src/test/java/com/linkedin/venice/utils/TestHelixUtils.java
+++ b/internal/venice-common/src/test/java/com/linkedin/venice/utils/TestHelixUtils.java
@@ -32,14 +32,19 @@ public class TestHelixUtils {
     List<String> cloudInfoSources = new ArrayList<>();
     cloudInfoSources.add("TestSource");
 
-    CloudConfig cloudConfig =
-        HelixUtils.getCloudConfig(CloudProvider.CUSTOMIZED, "NA", cloudInfoSources, "TestProcessor");
+    CloudConfig cloudConfig = HelixUtils.getCloudConfig(
+        CloudProvider.CUSTOMIZED,
+        "NA",
+        cloudInfoSources,
+        "com.linkedin.venice.controller.helix",
+        "TestProcessor");
 
     assertTrue(cloudConfig.isCloudEnabled());
     assertEquals(cloudConfig.getCloudProvider(), "CUSTOMIZED");
     assertEquals(cloudConfig.getCloudID(), "NA");
     assertEquals(cloudConfig.getCloudInfoSources().size(), 1);
     assertEquals(cloudConfig.getCloudInfoSources().get(0), "TestSource");
+    assertEquals(cloudConfig.getCloudInfoProcessorPackage(), "com.linkedin.venice.controller.helix");
     assertEquals(cloudConfig.getCloudInfoProcessorName(), "TestProcessor");
   }
 
@@ -47,7 +52,12 @@ public class TestHelixUtils {
   public void testGetCloudConfigWhenControllerCloudInfoSourcesNotSet() {
     assertThrows(
         HelixException.class,
-        () -> HelixUtils.getCloudConfig(CloudProvider.CUSTOMIZED, "NA", Collections.emptyList(), "TestProcessor"));
+        () -> HelixUtils.getCloudConfig(
+            CloudProvider.CUSTOMIZED,
+            "NA",
+            Collections.emptyList(),
+            "com.linkedin.venice.controller.helix",
+            "TestProcessor"));
   }
 
   @Test
@@ -57,6 +67,11 @@ public class TestHelixUtils {
 
     assertThrows(
         HelixException.class,
-        () -> HelixUtils.getCloudConfig(CloudProvider.CUSTOMIZED, "NA", cloudInfoSources, ""));
+        () -> HelixUtils.getCloudConfig(
+            CloudProvider.CUSTOMIZED,
+            "NA",
+            cloudInfoSources,
+            "com.linkedin.venice.controller.helix",
+            ""));
   }
 }

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/controller/TestHAASController.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/controller/TestHAASController.java
@@ -338,8 +338,12 @@ public class TestHAASController {
 
       when(commonConfig.isControllerClusterHelixCloudEnabled()).thenReturn(true);
       when(commonConfig.isStorageClusterHelixCloudEnabled()).thenReturn(true);
-      CloudConfig cloudConfig =
-          HelixUtils.getCloudConfig(CloudProvider.CUSTOMIZED, "NA", cloudInfoSources, "TestProcessor");
+      CloudConfig cloudConfig = HelixUtils.getCloudConfig(
+          CloudProvider.CUSTOMIZED,
+          "NA",
+          cloudInfoSources,
+          "com.linkedin.venice.controller.helix",
+          "TestProcessor");
       when(commonConfig.getHelixCloudConfig()).thenReturn(cloudConfig);
 
       doReturn(helixAsAServiceWrapper.getZkAddress()).when(controllerMultiClusterConfig).getZkAddress();

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceControllerClusterConfig.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceControllerClusterConfig.java
@@ -50,6 +50,7 @@ import static com.linkedin.venice.ConfigKeys.CONTROLLER_ENFORCE_SSL;
 import static com.linkedin.venice.ConfigKeys.CONTROLLER_HAAS_SUPER_CLUSTER_NAME;
 import static com.linkedin.venice.ConfigKeys.CONTROLLER_HELIX_CLOUD_ID;
 import static com.linkedin.venice.ConfigKeys.CONTROLLER_HELIX_CLOUD_INFO_PROCESSOR_NAME;
+import static com.linkedin.venice.ConfigKeys.CONTROLLER_HELIX_CLOUD_INFO_PROCESSOR_PACKAGE;
 import static com.linkedin.venice.ConfigKeys.CONTROLLER_HELIX_CLOUD_INFO_SOURCES;
 import static com.linkedin.venice.ConfigKeys.CONTROLLER_HELIX_CLOUD_PROVIDER;
 import static com.linkedin.venice.ConfigKeys.CONTROLLER_HELIX_REST_CUSTOMIZED_HEALTH_URL;
@@ -918,6 +919,7 @@ public class VeniceControllerClusterConfig {
       }
 
       String helixCloudId = props.getString(CONTROLLER_HELIX_CLOUD_ID, "");
+      String helixCloudInfoProcessorPackage = props.getString(CONTROLLER_HELIX_CLOUD_INFO_PROCESSOR_PACKAGE, "");
       String helixCloudInfoProcessorName = props.getString(CONTROLLER_HELIX_CLOUD_INFO_PROCESSOR_NAME, "");
 
       List<String> helixCloudInfoSources;
@@ -927,8 +929,12 @@ public class VeniceControllerClusterConfig {
         helixCloudInfoSources = props.getList(CONTROLLER_HELIX_CLOUD_INFO_SOURCES);
       }
 
-      helixCloudConfig = HelixUtils
-          .getCloudConfig(helixCloudProvider, helixCloudId, helixCloudInfoSources, helixCloudInfoProcessorName);
+      helixCloudConfig = HelixUtils.getCloudConfig(
+          helixCloudProvider,
+          helixCloudId,
+          helixCloudInfoSources,
+          helixCloudInfoProcessorPackage,
+          helixCloudInfoProcessorName);
     } else {
       helixCloudConfig = null;
     }


### PR DESCRIPTION
<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## Allow configuring cloud information processor package in Helix CloudConfig
<!--
Describe
- What changes to make and why you are making these changes.
- How are you going to achieve your goal.
- Describe what testings you have done, for example, performance testing etc.

If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->
Helix allows configuring `CloudConfigs` that can be used to populate instance `DOMAIN` fields on participant startup. In these configs, we can specify a class name and a package name. If a package name is not specified, Helix uses a default value of `org.apache.helix.cloud.<CLOUD_PROVIDER>`. This might not be desirable for all usecases, so, this commit allows overriding the package name.

## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
Modified UTs

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [X] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.