### PR TITLE
[controller] use `Utils::getRealTimeTopicName` in tests

### DIFF
--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/ActiveActiveStoreIngestionTaskTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/ActiveActiveStoreIngestionTaskTest.java
@@ -227,8 +227,6 @@ public class ActiveActiveStoreIngestionTaskTest {
         100L,
         DataReplicationPolicy.NON_AGGREGATE,
         BufferReplayPolicy.REWIND_FROM_EOP);
-    Version mockVersion = new VersionImpl(STORE_NAME, 1, PUSH_JOB_ID);
-    mockVersion.setHybridStoreConfig(hybridStoreConfig);
 
     StorageService storageService = mock(StorageService.class);
     Store store = new ZKStore(
@@ -241,6 +239,8 @@ public class ActiveActiveStoreIngestionTaskTest {
         OfflinePushStrategy.WAIT_ALL_REPLICAS,
         1);
     store.setHybridStoreConfig(hybridStoreConfig);
+    Version mockVersion = new VersionImpl(STORE_NAME, 1, PUSH_JOB_ID);
+    mockVersion.setHybridStoreConfig(hybridStoreConfig);
     store.setVersions(Collections.singletonList(mockVersion));
 
     Properties kafkaConsumerProperties = new Properties();

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/KafkaConsumerServiceDelegatorTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/KafkaConsumerServiceDelegatorTest.java
@@ -556,7 +556,7 @@ public class KafkaConsumerServiceDelegatorTest {
     KafkaConsumerServiceDelegator delegator =
         new KafkaConsumerServiceDelegator(mockConfig, consumerServiceBuilder, isAAWCStoreFunc);
     PubSubTopicPartition realTimeTopicPartition =
-        new PubSubTopicPartitionImpl(TOPIC_REPOSITORY.getTopic(Version.composeRealTimeTopic(storeName)), 0);
+        new PubSubTopicPartitionImpl(TOPIC_REPOSITORY.getTopic(storeName + Version.REAL_TIME_TOPIC_SUFFIX), 0);
 
     CountDownLatch countDownLatch = new CountDownLatch(1);
     List<Thread> infiniteSubUnSubThreads = new ArrayList<>();

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/KafkaConsumerServiceDelegatorTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/KafkaConsumerServiceDelegatorTest.java
@@ -556,7 +556,7 @@ public class KafkaConsumerServiceDelegatorTest {
     KafkaConsumerServiceDelegator delegator =
         new KafkaConsumerServiceDelegator(mockConfig, consumerServiceBuilder, isAAWCStoreFunc);
     PubSubTopicPartition realTimeTopicPartition =
-        new PubSubTopicPartitionImpl(TOPIC_REPOSITORY.getTopic(storeName + Version.REAL_TIME_TOPIC_SUFFIX), 0);
+        new PubSubTopicPartitionImpl(TOPIC_REPOSITORY.getTopic(Utils.composeRealTimeTopic(storeName)), 0);
 
     CountDownLatch countDownLatch = new CountDownLatch(1);
     List<Thread> infiniteSubUnSubThreads = new ArrayList<>();

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/PushTimeoutTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/PushTimeoutTest.java
@@ -134,7 +134,7 @@ public class PushTimeoutTest {
      * {@link StoreIngestionTask#reportIfCatchUpVersionTopicOffset(PartitionConsumptionState)}
      */
     doReturn(true).when(mockOffsetRecord).isEndOfPushReceived();
-    doReturn(Version.composeRealTimeTopic(storeName)).when(mockOffsetRecord).getLeaderTopic();
+    doReturn(Utils.getRealTimeTopicName(mockStore)).when(mockOffsetRecord).getLeaderTopic();
     /**
      * Return 0 as the max offset for VT and 1 as the overall consume progress, so reportIfCatchUpVersionTopicOffset()
      * will determine that base topic is caught up.

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTaskTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTaskTest.java
@@ -503,7 +503,7 @@ public abstract class StoreIngestionTaskTest {
     mockStorageEngineRepository = mock(StorageEngineRepository.class);
     storeInfo = mock(StoreInfo.class, RETURNS_DEEP_STUBS);
     when(storeInfo.getHybridStoreConfig().getRealTimeTopicName())
-        .thenReturn(storeNameWithoutVersionInfo + Version.REAL_TIME_TOPIC_SUFFIX);
+        .thenReturn(Utils.composeRealTimeTopic(storeNameWithoutVersionInfo));
 
     mockLogNotifier = mock(LogNotifier.class);
     mockNotifierProgress = new ArrayList<>();
@@ -3984,7 +3984,7 @@ public abstract class StoreIngestionTaskTest {
 
   @Test
   public void testResubscribeAfterRoleChange() throws Exception {
-    String realTimeTopicName = storeNameWithoutVersionInfo + Version.REAL_TIME_TOPIC_SUFFIX;
+    String realTimeTopicName = Utils.composeRealTimeTopic(storeNameWithoutVersionInfo);
     PubSubTopic realTimeTopic = pubSubTopicRepository.getTopic(realTimeTopicName);
     // Prepare both local and remote real-time topics
     inMemoryLocalKafkaBroker.createTopic(realTimeTopicName, PARTITION_COUNT);

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/TopicExistenceCheckerTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/TopicExistenceCheckerTest.java
@@ -7,6 +7,7 @@ import static org.mockito.Mockito.mock;
 import com.linkedin.venice.exceptions.VeniceNoStoreException;
 import com.linkedin.venice.meta.ReadOnlyStoreRepository;
 import com.linkedin.venice.meta.Store;
+import com.linkedin.venice.meta.Version;
 import com.linkedin.venice.meta.VersionImpl;
 import org.testng.Assert;
 import org.testng.annotations.Test;
@@ -24,7 +25,8 @@ public class TopicExistenceCheckerTest {
 
     ReadOnlyStoreRepository repository = mock(ReadOnlyStoreRepository.class);
     Store store = mock(Store.class);
-    doReturn(new VersionImpl("existingTopic", 123)).when(store).getVersion(123);
+    doReturn(new VersionImpl("existingTopic", 123, "existingTopic" + Version.REAL_TIME_TOPIC_SUFFIX)).when(store)
+        .getVersion(123);
     doReturn(store).when(repository).getStoreOrThrow("existingTopic");
     doThrow(new VeniceNoStoreException(nontExitingTopic1)).when(repository).getStoreOrThrow("non-existingTopic");
     doReturn(true).when(store).isHybrid();

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/TopicExistenceCheckerTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/TopicExistenceCheckerTest.java
@@ -7,7 +7,6 @@ import static org.mockito.Mockito.mock;
 import com.linkedin.venice.exceptions.VeniceNoStoreException;
 import com.linkedin.venice.meta.ReadOnlyStoreRepository;
 import com.linkedin.venice.meta.Store;
-import com.linkedin.venice.meta.Version;
 import com.linkedin.venice.meta.VersionImpl;
 import org.testng.Assert;
 import org.testng.annotations.Test;
@@ -25,8 +24,7 @@ public class TopicExistenceCheckerTest {
 
     ReadOnlyStoreRepository repository = mock(ReadOnlyStoreRepository.class);
     Store store = mock(Store.class);
-    doReturn(new VersionImpl("existingTopic", 123, "existingTopic" + Version.REAL_TIME_TOPIC_SUFFIX)).when(store)
-        .getVersion(123);
+    doReturn(new VersionImpl("existingTopic", 123)).when(store).getVersion(123);
     doReturn(store).when(repository).getStoreOrThrow("existingTopic");
     doThrow(new VeniceNoStoreException(nontExitingTopic1)).when(repository).getStoreOrThrow("non-existingTopic");
     doReturn(true).when(store).isHybrid();

--- a/clients/venice-admin-tool/src/test/java/com/linkedin/venice/TestAdminToolConsumption.java
+++ b/clients/venice-admin-tool/src/test/java/com/linkedin/venice/TestAdminToolConsumption.java
@@ -2,6 +2,7 @@ package com.linkedin.venice;
 
 import static com.linkedin.venice.kafka.protocol.enums.MessageType.PUT;
 import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -32,6 +33,7 @@ import com.linkedin.venice.pubsub.PubSubTopicRepository;
 import com.linkedin.venice.pubsub.adapter.kafka.consumer.ApacheKafkaConsumerAdapter;
 import com.linkedin.venice.pubsub.api.PubSubMessage;
 import com.linkedin.venice.pubsub.api.PubSubTopicPartition;
+import com.linkedin.venice.utils.Utils;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -50,7 +52,7 @@ public class TestAdminToolConsumption {
   @Test
   void testAdminToolAdminMessageConsumption() {
     int assignedPartition = 0;
-    String topic = Version.composeRealTimeTopic(STORE_NAME);
+    String topic = Utils.composeRealTimeTopic(STORE_NAME);
     PubSubTopicPartition pubSubTopicPartition =
         new PubSubTopicPartitionImpl(pubSubTopicRepository.getTopic(topic), assignedPartition);
     int adminMessageNum = 10;
@@ -112,16 +114,18 @@ public class TestAdminToolConsumption {
 
   @Test
   public void testAdminToolConsumption() {
-    String topic = Version.composeRealTimeTopic(STORE_NAME);
     ControllerClient controllerClient = mock(ControllerClient.class);
     SchemaResponse schemaResponse = mock(SchemaResponse.class);
     when(schemaResponse.getSchemaStr()).thenReturn(SCHEMA_STRING);
     when(controllerClient.getKeySchema(STORE_NAME)).thenReturn(schemaResponse);
     StoreResponse storeResponse = mock(StoreResponse.class);
-    StoreInfo storeInfo = mock(StoreInfo.class);
+    StoreInfo storeInfo = mock(StoreInfo.class, RETURNS_DEEP_STUBS);
     when(storeInfo.getPartitionCount()).thenReturn(2);
     when(controllerClient.getStore(STORE_NAME)).thenReturn(storeResponse);
     when(storeResponse.getStore()).thenReturn(storeInfo);
+    when(storeInfo.getHybridStoreConfig().getRealTimeTopicName())
+        .thenReturn(STORE_NAME + Version.REAL_TIME_TOPIC_SUFFIX);
+    String topic = storeInfo.getHybridStoreConfig().getRealTimeTopicName();
 
     int assignedPartition = 0;
     long startOffset = 0;

--- a/clients/venice-admin-tool/src/test/java/com/linkedin/venice/TestAdminToolConsumption.java
+++ b/clients/venice-admin-tool/src/test/java/com/linkedin/venice/TestAdminToolConsumption.java
@@ -26,7 +26,6 @@ import com.linkedin.venice.kafka.protocol.enums.ControlMessageType;
 import com.linkedin.venice.kafka.protocol.enums.MessageType;
 import com.linkedin.venice.message.KafkaKey;
 import com.linkedin.venice.meta.StoreInfo;
-import com.linkedin.venice.meta.Version;
 import com.linkedin.venice.pubsub.ImmutablePubSubMessage;
 import com.linkedin.venice.pubsub.PubSubTopicPartitionImpl;
 import com.linkedin.venice.pubsub.PubSubTopicRepository;
@@ -123,8 +122,7 @@ public class TestAdminToolConsumption {
     when(storeInfo.getPartitionCount()).thenReturn(2);
     when(controllerClient.getStore(STORE_NAME)).thenReturn(storeResponse);
     when(storeResponse.getStore()).thenReturn(storeInfo);
-    when(storeInfo.getHybridStoreConfig().getRealTimeTopicName())
-        .thenReturn(STORE_NAME + Version.REAL_TIME_TOPIC_SUFFIX);
+    when(storeInfo.getHybridStoreConfig().getRealTimeTopicName()).thenReturn(Utils.composeRealTimeTopic(STORE_NAME));
     String topic = storeInfo.getHybridStoreConfig().getRealTimeTopicName();
 
     int assignedPartition = 0;

--- a/clients/venice-producer/src/test/java/com/linkedin/venice/producer/online/OnlineVeniceProducerTest.java
+++ b/clients/venice-producer/src/test/java/com/linkedin/venice/producer/online/OnlineVeniceProducerTest.java
@@ -909,7 +909,7 @@ public class OnlineVeniceProducerTest {
         versionCreationResponse.setPartitionerClass(partitionerConfig.getPartitionerClass());
         versionCreationResponse.setPartitionerParams(partitionerConfig.getPartitionerParams());
         versionCreationResponse.setKafkaBootstrapServers("localhost:9092");
-        versionCreationResponse.setKafkaTopic(Version.composeRealTimeTopic(storeName));
+        versionCreationResponse.setKafkaTopic(Utils.getRealTimeTopicName(store));
         versionCreationResponse.setEnableSSL(false);
 
         return getTransportClientFuture(MAPPER.writeValueAsBytes(versionCreationResponse), delayInResponseMs);

--- a/clients/venice-push-job/src/test/java/com/linkedin/venice/heartbeat/TestPushJobHeartbeatSender.java
+++ b/clients/venice-push-job/src/test/java/com/linkedin/venice/heartbeat/TestPushJobHeartbeatSender.java
@@ -9,10 +9,10 @@ import com.linkedin.venice.controllerapi.StoreResponse;
 import com.linkedin.venice.meta.PartitionerConfig;
 import com.linkedin.venice.meta.PartitionerConfigImpl;
 import com.linkedin.venice.meta.StoreInfo;
-import com.linkedin.venice.meta.Version;
 import com.linkedin.venice.serialization.avro.AvroProtocolDefinition;
 import com.linkedin.venice.status.protocol.BatchJobHeartbeatKey;
 import com.linkedin.venice.status.protocol.BatchJobHeartbeatValue;
+import com.linkedin.venice.utils.Utils;
 import com.linkedin.venice.utils.VeniceProperties;
 import java.util.Optional;
 import java.util.Properties;
@@ -32,8 +32,10 @@ public class TestPushJobHeartbeatSender {
     // Prepare controller client.
     ControllerClient controllerClient = mock(ControllerClient.class);
     StoreResponse storeResponse = mock(StoreResponse.class);
-    StoreInfo storeInfo = mock(StoreInfo.class);
+    StoreInfo storeInfo = mock(StoreInfo.class, RETURNS_DEEP_STUBS);
     PartitionerConfig partitionerConfig = new PartitionerConfigImpl();
+    when(storeInfo.getHybridStoreConfig().getRealTimeTopicName())
+        .thenReturn(Utils.composeRealTimeTopic(heartbeatStoreName));
     doReturn(1).when(storeInfo).getPartitionCount();
     doReturn(partitionerConfig).when(storeInfo).getPartitionerConfig();
     doReturn(storeInfo).when(storeResponse).getStore();
@@ -60,6 +62,6 @@ public class TestPushJobHeartbeatSender {
         (DefaultPushJobHeartbeatSender) pushJobHeartbeatSender;
     Assert.assertEquals(
         defaultPushJobHeartbeatSender.getVeniceWriter().getTopicName(),
-        Version.composeRealTimeTopic(heartbeatStoreName));
+        Utils.composeRealTimeTopic(heartbeatStoreName));
   }
 }

--- a/clients/venice-thin-client/src/test/java/com/linkedin/venice/client/schema/RouterBackedSchemaReaderTest.java
+++ b/clients/venice-thin-client/src/test/java/com/linkedin/venice/client/schema/RouterBackedSchemaReaderTest.java
@@ -530,7 +530,7 @@ public class RouterBackedSchemaReaderTest {
     versionCreationResponse.setPartitionerClass(partitionerConfig.getPartitionerClass());
     versionCreationResponse.setPartitionerParams(partitionerConfig.getPartitionerParams());
     versionCreationResponse.setKafkaBootstrapServers("localhost:9092");
-    versionCreationResponse.setKafkaTopic(Version.composeRealTimeTopic(storeName));
+    versionCreationResponse.setKafkaTopic(Utils.getRealTimeTopicName(store));
     versionCreationResponse.setEnableSSL(false);
 
     CompletableFuture<byte[]> requestTopicFuture = mock(CompletableFuture.class);

--- a/internal/venice-common/src/test/java/com/linkedin/venice/meta/TestVersion.java
+++ b/internal/venice-common/src/test/java/com/linkedin/venice/meta/TestVersion.java
@@ -39,7 +39,7 @@ public class TestVersion {
   public void serializes() throws IOException {
     String storeName = Utils.getUniqueString("store");
     int versionNumber = 17;
-    Version version = new VersionImpl(storeName, versionNumber);
+    Version version = new VersionImpl(storeName, versionNumber, storeName + Version.REAL_TIME_TOPIC_SUFFIX);
     String serialized = OBJECT_MAPPER.writeValueAsString(version);
     Assert.assertTrue(serialized.contains(storeName));
   }

--- a/internal/venice-common/src/test/java/com/linkedin/venice/meta/TestVersion.java
+++ b/internal/venice-common/src/test/java/com/linkedin/venice/meta/TestVersion.java
@@ -39,7 +39,7 @@ public class TestVersion {
   public void serializes() throws IOException {
     String storeName = Utils.getUniqueString("store");
     int versionNumber = 17;
-    Version version = new VersionImpl(storeName, versionNumber, storeName + Version.REAL_TIME_TOPIC_SUFFIX);
+    Version version = new VersionImpl(storeName, versionNumber);
     String serialized = OBJECT_MAPPER.writeValueAsString(version);
     Assert.assertTrue(serialized.contains(storeName));
   }

--- a/internal/venice-common/src/test/java/com/linkedin/venice/store/StoreStateReaderTest.java
+++ b/internal/venice-common/src/test/java/com/linkedin/venice/store/StoreStateReaderTest.java
@@ -67,8 +67,6 @@ public class StoreStateReaderTest {
   private ZKStore getStore() {
     int partitionCount = 10;
     PartitionerConfig partitionerConfig = new PartitionerConfigImpl();
-    Version version = new VersionImpl(storeName, 1, "test-job-id");
-    version.setPartitionCount(partitionCount);
 
     HybridStoreConfig hybridStoreConfig = new HybridStoreConfigImpl(
         1000,
@@ -92,6 +90,8 @@ public class StoreStateReaderTest {
         partitionerConfig,
         3);
     store.setPartitionCount(partitionCount);
+    Version version = new VersionImpl(storeName, 1, "test-job-id");
+    version.setPartitionCount(partitionCount);
     store.setVersions(Collections.singletonList(version));
 
     return store;

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/consumer/ConsumerIntegrationTest.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/consumer/ConsumerIntegrationTest.java
@@ -11,7 +11,6 @@ import com.linkedin.venice.exceptions.VeniceMessageException;
 import com.linkedin.venice.integration.utils.ServiceFactory;
 import com.linkedin.venice.integration.utils.VeniceClusterWrapper;
 import com.linkedin.venice.kafka.protocol.KafkaMessageEnvelope;
-import com.linkedin.venice.meta.Version;
 import com.linkedin.venice.partitioner.DefaultVenicePartitioner;
 import com.linkedin.venice.partitioner.VenicePartitioner;
 import com.linkedin.venice.pubsub.adapter.kafka.producer.ApacheKafkaProducerAdapter;
@@ -118,7 +117,6 @@ public abstract class ConsumerIntegrationTest {
   public void testSetUp() {
     store = Utils.getUniqueString("consumer_integ_test");
     version = 1;
-    topicName = Version.composeRealTimeTopic(store);
     cluster.getNewStore(store);
     long streamingRewindSeconds = 25L;
     long streamingMessageLag = 2L;
@@ -126,6 +124,8 @@ public abstract class ConsumerIntegrationTest {
         store,
         new UpdateStoreQueryParams().setHybridRewindSeconds(streamingRewindSeconds)
             .setHybridOffsetLagThreshold(streamingMessageLag));
+    topicName = Utils.getRealTimeTopicName(
+        cluster.getLeaderVeniceController().getVeniceAdmin().getStore(cluster.getClusterName(), store));
     controllerClient.emptyPush(store, "test_push", 1);
     TestUtils.waitForNonDeterministicAssertion(15, TimeUnit.SECONDS, () -> {
       StoreResponse freshStoreResponse = controllerClient.getStore(store);

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/controller/AbstractTestVeniceHelixAdmin.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/controller/AbstractTestVeniceHelixAdmin.java
@@ -29,7 +29,6 @@ import com.linkedin.venice.integration.utils.PubSubBrokerWrapper;
 import com.linkedin.venice.integration.utils.ServiceFactory;
 import com.linkedin.venice.integration.utils.ZkServerWrapper;
 import com.linkedin.venice.meta.Store;
-import com.linkedin.venice.meta.Version;
 import com.linkedin.venice.pubsub.PubSubTopicRepository;
 import com.linkedin.venice.stats.HelixMessageChannelStats;
 import com.linkedin.venice.utils.HelixUtils;
@@ -271,6 +270,6 @@ class AbstractTestVeniceHelixAdmin {
         TimeUnit.SECONDS,
         () -> Assert.assertEquals(
             veniceAdmin.getRealTimeTopic(clusterName, participantStoreName),
-            Version.composeRealTimeTopic(participantStoreName)));
+            Utils.composeRealTimeTopic(participantStoreName)));
   }
 }

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/controller/TestIncrementalPush.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/controller/TestIncrementalPush.java
@@ -35,6 +35,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Properties;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
 import org.apache.helix.zookeeper.impl.client.ZkClient;
 import org.testng.Assert;
 import org.testng.annotations.AfterClass;
@@ -69,6 +70,10 @@ public class TestIncrementalPush {
   public void testIncrementalPushStatusNotUpdateReplicaCurrentStatus() throws IOException {
     String storeName = Utils.getUniqueString("testIncPushStore");
     cluster.getNewStore(storeName);
+    AtomicReference<StoreInfo> storeInfo = new AtomicReference<>();
+    cluster.useControllerClient(controllerClient -> {
+      storeInfo.set(controllerClient.getStore(storeName).getStore());
+    });
     UpdateStoreQueryParams params = new UpdateStoreQueryParams();
     params.setIncrementalPushEnabled(true)
         .setStorageQuotaInByte(Store.UNLIMITED_STORAGE_QUOTA)
@@ -85,7 +90,7 @@ public class TestIncrementalPush {
     String incPushTopic = "TEST_INC_PUSH";
 
     VeniceWriter<String, String, byte[]> veniceWriterRt =
-        cluster.getVeniceWriter(Version.composeRealTimeTopic(storeName));
+        cluster.getVeniceWriter(Utils.getRealTimeTopicName(storeInfo.get()));
     veniceWriterRt.broadcastStartOfIncrementalPush(incPushTopic, new HashMap<>());
 
     TestUtils.waitForNonDeterministicCompletion(

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/controller/TestIncrementalPush.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/controller/TestIncrementalPush.java
@@ -72,7 +72,8 @@ public class TestIncrementalPush {
     cluster.getNewStore(storeName);
     AtomicReference<StoreInfo> storeInfo = new AtomicReference<>();
     cluster.useControllerClient(controllerClient -> {
-      storeInfo.set(controllerClient.getStore(storeName).getStore());
+      StoreResponse storeResponse = TestUtils.assertCommand(controllerClient.getStore(storeName));
+      storeInfo.set(storeResponse.getStore());
     });
     UpdateStoreQueryParams params = new UpdateStoreQueryParams();
     params.setIncrementalPushEnabled(true)

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/controller/TestParentControllerWithMultiDataCenter.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/controller/TestParentControllerWithMultiDataCenter.java
@@ -123,9 +123,9 @@ public class TestParentControllerWithMultiDataCenter {
         newStoreResponse.isError(),
         "The NewStoreResponse returned an error: " + newStoreResponse.getError());
 
-    StoreInfo store = parentControllerClient.getStore(storeName).getStore();
+    StoreInfo store = TestUtils.assertCommand(parentControllerClient.getStore(storeName)).getStore();
     String rtTopicName = Utils.getRealTimeTopicName(store);
-    PubSubTopic rtPubSubTopic = new PubSubTopicRepository().getTopic(rtTopicName);
+    PubSubTopic rtPubSubTopic = pubSubTopicRepository.getTopic(rtTopicName);
 
     UpdateStoreQueryParams updateStoreParams = new UpdateStoreQueryParams();
     updateStoreParams.setIncrementalPushEnabled(true)

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/controller/TestTopicRequestOnHybridDelete.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/controller/TestTopicRequestOnHybridDelete.java
@@ -67,7 +67,7 @@ public class TestTopicRequestOnHybridDelete {
 
       String storeName = Utils.getUniqueString("hybrid-store");
       venice.getNewStore(storeName);
-      StoreInfo storeInfo = finalControllerClient.getStore(storeName).getStore();
+      StoreInfo storeInfo = TestUtils.assertCommand(finalControllerClient.getStore(storeName)).getStore();
       makeStoreHybrid(venice, storeName, 100L, 5L);
       controllerClient.emptyPush(storeName, Utils.getUniqueString("push-id"), 1L);
 

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/controller/TestTopicRequestOnHybridDelete.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/controller/TestTopicRequestOnHybridDelete.java
@@ -1,6 +1,5 @@
 package com.linkedin.venice.controller;
 
-import static com.linkedin.venice.meta.Version.composeRealTimeTopic;
 import static com.linkedin.venice.pubsub.PubSubConstants.PUBSUB_OPERATION_TIMEOUT_MS_DEFAULT_VALUE;
 import static com.linkedin.venice.utils.IntegrationTestPushUtils.getSamzaProducer;
 import static com.linkedin.venice.utils.IntegrationTestPushUtils.makeStoreHybrid;
@@ -19,6 +18,7 @@ import com.linkedin.venice.controllerapi.VersionCreationResponse;
 import com.linkedin.venice.exceptions.VeniceException;
 import com.linkedin.venice.integration.utils.ServiceFactory;
 import com.linkedin.venice.integration.utils.VeniceClusterWrapper;
+import com.linkedin.venice.meta.StoreInfo;
 import com.linkedin.venice.meta.Version;
 import com.linkedin.venice.meta.VersionStatus;
 import com.linkedin.venice.pubsub.PubSubTopicRepository;
@@ -67,6 +67,7 @@ public class TestTopicRequestOnHybridDelete {
 
       String storeName = Utils.getUniqueString("hybrid-store");
       venice.getNewStore(storeName);
+      StoreInfo storeInfo = finalControllerClient.getStore(storeName).getStore();
       makeStoreHybrid(venice, storeName, 100L, 5L);
       controllerClient.emptyPush(storeName, Utils.getUniqueString("push-id"), 1L);
 
@@ -113,7 +114,8 @@ public class TestTopicRequestOnHybridDelete {
 
       TopicManager topicManager = venice.getLeaderVeniceController().getVeniceAdmin().getTopicManager();
       try {
-        topicManager.ensureTopicIsDeletedAndBlock(pubSubTopicRepository.getTopic(composeRealTimeTopic(storeName)));
+        topicManager
+            .ensureTopicIsDeletedAndBlock(pubSubTopicRepository.getTopic(Utils.getRealTimeTopicName(storeInfo)));
       } catch (VeniceException e) {
         fail("Exception during topic deletion " + e);
       }

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/controller/TestVeniceHelixAdminWithSharedEnvironment.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/controller/TestVeniceHelixAdminWithSharedEnvironment.java
@@ -648,6 +648,7 @@ public class TestVeniceHelixAdminWithSharedEnvironment extends AbstractTestVenic
     Assert.assertThrows(VeniceNoStoreException.class, () -> veniceAdmin.getRealTimeTopic(clusterName, storeName));
 
     veniceAdmin.createStore(clusterName, storeName, "owner", KEY_SCHEMA, VALUE_SCHEMA);
+    Store store = veniceAdmin.getStore(clusterName, storeName);
     veniceAdmin.updateStore(
         clusterName,
         storeName,
@@ -667,7 +668,7 @@ public class TestVeniceHelixAdminWithSharedEnvironment extends AbstractTestVenic
     veniceAdmin.incrementVersionIdempotent(clusterName, storeName, Version.guidBasedDummyPushId(), partitions, 1);
 
     String rtTopic = veniceAdmin.getRealTimeTopic(clusterName, storeName);
-    Assert.assertEquals(rtTopic, Version.composeRealTimeTopic(storeName));
+    Assert.assertEquals(rtTopic, Utils.getRealTimeTopicName(store));
   }
 
   @Test(timeOut = TOTAL_TIMEOUT_FOR_LONG_TEST_MS)
@@ -859,7 +860,7 @@ public class TestVeniceHelixAdminWithSharedEnvironment extends AbstractTestVenic
   @Test(timeOut = TOTAL_TIMEOUT_FOR_LONG_TEST_MS)
   public void testKillOfflinePush() throws Exception {
     PubSubTopic participantStoreRTTopic = pubSubTopicRepository
-        .getTopic(Version.composeRealTimeTopic(VeniceSystemStoreUtils.getParticipantStoreNameForCluster(clusterName)));
+        .getTopic(Utils.composeRealTimeTopic(VeniceSystemStoreUtils.getParticipantStoreNameForCluster(clusterName)));
     String newNodeId = Utils.getHelixNodeIdentifier(Utils.getHostName(), 9786);
     // Ensure original participant store would hang on bootstrap state.
     delayParticipantJobCompletion(true);
@@ -1671,6 +1672,7 @@ public class TestVeniceHelixAdminWithSharedEnvironment extends AbstractTestVenic
   public void testGetIncrementalPushVersion() {
     String incrementalAndHybridEnabledStoreName = Utils.getUniqueString("testHybridStore");
     veniceAdmin.createStore(clusterName, incrementalAndHybridEnabledStoreName, storeOwner, "\"string\"", "\"string\"");
+    veniceAdmin.getStore(clusterName, incrementalAndHybridEnabledStoreName);
     veniceAdmin.updateStore(
         clusterName,
         incrementalAndHybridEnabledStoreName,

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/controller/TestVeniceHelixAdminWithSharedEnvironment.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/controller/TestVeniceHelixAdminWithSharedEnvironment.java
@@ -1672,7 +1672,6 @@ public class TestVeniceHelixAdminWithSharedEnvironment extends AbstractTestVenic
   public void testGetIncrementalPushVersion() {
     String incrementalAndHybridEnabledStoreName = Utils.getUniqueString("testHybridStore");
     veniceAdmin.createStore(clusterName, incrementalAndHybridEnabledStoreName, storeOwner, "\"string\"", "\"string\"");
-    veniceAdmin.getStore(clusterName, incrementalAndHybridEnabledStoreName);
     veniceAdmin.updateStore(
         clusterName,
         incrementalAndHybridEnabledStoreName,

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/controller/server/TestAdminSparkServer.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/controller/server/TestAdminSparkServer.java
@@ -1063,7 +1063,7 @@ public class TestAdminSparkServer extends AbstractTestAdminSparkServer {
         Assert.assertFalse(
             childMultiStoreTopicResponse.getTopics().contains(Version.composeKafkaTopic(metaSystemStoreName, 1)));
         Assert.assertFalse(
-            childMultiStoreTopicResponse.getTopics().contains(Version.composeRealTimeTopic(metaSystemStoreName)));
+            childMultiStoreTopicResponse.getTopics().contains(Utils.composeRealTimeTopic(metaSystemStoreName)));
       });
     } finally {
       deleteStore(storeName);

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/controller/server/TestAdminSparkWithMocks.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/controller/server/TestAdminSparkWithMocks.java
@@ -1,6 +1,7 @@
 package com.linkedin.venice.controller.server;
 
 import static com.linkedin.venice.meta.Store.NON_EXISTING_VERSION;
+import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.anyBoolean;
 import static org.mockito.Mockito.anyString;
 import static org.mockito.Mockito.doReturn;
@@ -77,7 +78,7 @@ public class TestAdminSparkWithMocks {
     doReturn(1).when(admin).calculateNumberOfPartitions(anyString(), anyString());
     doReturn("kafka-bootstrap").when(admin).getKafkaBootstrapServers(anyBoolean());
     doReturn("store_rt").when(admin).getRealTimeTopic(anyString(), anyString());
-    doReturn("store_rt").when(admin).getRealTimeTopic(anyString(), Mockito.<Store>any());
+    doReturn("store_rt").when(admin).getRealTimeTopic(anyString(), any(Store.class));
     // Add a banned route not relevant to the test just to make sure theres coverage for unbanned routes still be
     // accessible
     AdminSparkServer server =
@@ -139,7 +140,7 @@ public class TestAdminSparkWithMocks {
     doReturn(1).when(admin).calculateNumberOfPartitions(anyString(), anyString());
     doReturn("kafka-bootstrap").when(admin).getKafkaBootstrapServers(anyBoolean());
     doReturn("store_rt").when(admin).getRealTimeTopic(anyString(), anyString());
-    doReturn("store_rt").when(admin).getRealTimeTopic(anyString(), Mockito.<Store>any());
+    doReturn("store_rt").when(admin).getRealTimeTopic(anyString(), any(Store.class));
     AdminSparkServer server =
         ServiceFactory.getMockAdminSparkServer(admin, "clustername", Arrays.asList(ControllerRoute.REQUEST_TOPIC));
     int port = server.getPort();
@@ -217,7 +218,7 @@ public class TestAdminSparkWithMocks {
     doReturn(true).when(admin).whetherEnableBatchPushFromAdmin(anyString());
     doReturn(true).when(admin).isActiveActiveReplicationEnabledInAllRegion(clusterName, storeName, false);
     doReturn(Utils.getRealTimeTopicName(mockStore)).when(admin).getRealTimeTopic(anyString(), anyString());
-    doReturn(Utils.getRealTimeTopicName(mockStore)).when(admin).getRealTimeTopic(anyString(), Mockito.<Store>any());
+    doReturn(Utils.getRealTimeTopicName(mockStore)).when(admin).getRealTimeTopic(anyString(), any(Store.class));
     doReturn(corpRegionKafka).when(admin).getNativeReplicationKafkaBootstrapServerAddress(corpRegion);
     doReturn(emergencySourceRegionKafka).when(admin)
         .getNativeReplicationKafkaBootstrapServerAddress(emergencySourceRegion);
@@ -335,7 +336,7 @@ public class TestAdminSparkWithMocks {
     doReturn(1).when(admin).calculateNumberOfPartitions(anyString(), anyString());
     doReturn("kafka-bootstrap").when(admin).getKafkaBootstrapServers(anyBoolean());
     doReturn("store_rt").when(admin).getRealTimeTopic(anyString(), anyString());
-    doReturn("store_rt").when(admin).getRealTimeTopic(anyString(), Mockito.<Store>any());
+    doReturn("store_rt").when(admin).getRealTimeTopic(anyString(), any(Store.class));
     doReturn(samzaPolicy).when(admin).isParent();
     doReturn(ParentControllerRegionState.ACTIVE).when(admin).getParentControllerRegionState();
     doReturn(aaEnabled).when(admin).isActiveActiveReplicationEnabledInAllRegion(anyString(), anyString(), eq(true));

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/controller/server/TestAdminSparkWithMocks.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/controller/server/TestAdminSparkWithMocks.java
@@ -27,6 +27,7 @@ import com.linkedin.venice.meta.ZKStore;
 import com.linkedin.venice.utils.DataProviderUtils;
 import com.linkedin.venice.utils.ObjectMapperFactory;
 import com.linkedin.venice.utils.SslUtils;
+import com.linkedin.venice.utils.Utils;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -76,6 +77,7 @@ public class TestAdminSparkWithMocks {
     doReturn(1).when(admin).calculateNumberOfPartitions(anyString(), anyString());
     doReturn("kafka-bootstrap").when(admin).getKafkaBootstrapServers(anyBoolean());
     doReturn("store_rt").when(admin).getRealTimeTopic(anyString(), anyString());
+    doReturn("store_rt").when(admin).getRealTimeTopic(anyString(), Mockito.<Store>any());
     // Add a banned route not relevant to the test just to make sure theres coverage for unbanned routes still be
     // accessible
     AdminSparkServer server =
@@ -137,6 +139,7 @@ public class TestAdminSparkWithMocks {
     doReturn(1).when(admin).calculateNumberOfPartitions(anyString(), anyString());
     doReturn("kafka-bootstrap").when(admin).getKafkaBootstrapServers(anyBoolean());
     doReturn("store_rt").when(admin).getRealTimeTopic(anyString(), anyString());
+    doReturn("store_rt").when(admin).getRealTimeTopic(anyString(), Mockito.<Store>any());
     AdminSparkServer server =
         ServiceFactory.getMockAdminSparkServer(admin, "clustername", Arrays.asList(ControllerRoute.REQUEST_TOPIC));
     int port = server.getPort();
@@ -213,7 +216,8 @@ public class TestAdminSparkWithMocks {
     doReturn(corpRegionKafka).when(admin).getKafkaBootstrapServers(anyBoolean());
     doReturn(true).when(admin).whetherEnableBatchPushFromAdmin(anyString());
     doReturn(true).when(admin).isActiveActiveReplicationEnabledInAllRegion(clusterName, storeName, false);
-    doReturn(Version.composeRealTimeTopic(storeName)).when(admin).getRealTimeTopic(anyString(), anyString());
+    doReturn(Utils.getRealTimeTopicName(mockStore)).when(admin).getRealTimeTopic(anyString(), anyString());
+    doReturn(Utils.getRealTimeTopicName(mockStore)).when(admin).getRealTimeTopic(anyString(), Mockito.<Store>any());
     doReturn(corpRegionKafka).when(admin).getNativeReplicationKafkaBootstrapServerAddress(corpRegion);
     doReturn(emergencySourceRegionKafka).when(admin)
         .getNativeReplicationKafkaBootstrapServerAddress(emergencySourceRegion);
@@ -331,6 +335,7 @@ public class TestAdminSparkWithMocks {
     doReturn(1).when(admin).calculateNumberOfPartitions(anyString(), anyString());
     doReturn("kafka-bootstrap").when(admin).getKafkaBootstrapServers(anyBoolean());
     doReturn("store_rt").when(admin).getRealTimeTopic(anyString(), anyString());
+    doReturn("store_rt").when(admin).getRealTimeTopic(anyString(), Mockito.<Store>any());
     doReturn(samzaPolicy).when(admin).isParent();
     doReturn(ParentControllerRegionState.ACTIVE).when(admin).getParentControllerRegionState();
     doReturn(aaEnabled).when(admin).isActiveActiveReplicationEnabledInAllRegion(anyString(), anyString(), eq(true));

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/DaVinciLiveUpdateSuppressionTest.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/DaVinciLiveUpdateSuppressionTest.java
@@ -98,7 +98,7 @@ public class DaVinciLiveUpdateSuppressionTest {
     cluster.useControllerClient(client -> {
       TestUtils.assertCommand(
           client.createNewStore(storeName, getClass().getName(), DEFAULT_KEY_SCHEMA, DEFAULT_VALUE_SCHEMA));
-      storeInfo.set(client.getStore(storeName).getStore());
+      storeInfo.set(TestUtils.assertCommand(client.getStore(storeName)).getStore());
       cluster.createMetaSystemStore(storeName);
       client.updateStore(
           storeName,

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/DaVinciLiveUpdateSuppressionTest.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/DaVinciLiveUpdateSuppressionTest.java
@@ -22,7 +22,7 @@ import com.linkedin.venice.integration.utils.DaVinciTestContext;
 import com.linkedin.venice.integration.utils.ServiceFactory;
 import com.linkedin.venice.integration.utils.VeniceClusterWrapper;
 import com.linkedin.venice.meta.IngestionMode;
-import com.linkedin.venice.meta.Version;
+import com.linkedin.venice.meta.StoreInfo;
 import com.linkedin.venice.pubsub.PubSubProducerAdapterFactory;
 import com.linkedin.venice.serialization.VeniceKafkaSerializer;
 import com.linkedin.venice.serialization.avro.VeniceAvroKafkaSerializer;
@@ -42,6 +42,7 @@ import java.util.Optional;
 import java.util.Properties;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.testng.annotations.AfterClass;
@@ -93,9 +94,11 @@ public class DaVinciLiveUpdateSuppressionTest {
   @Test(dataProvider = "Isolated-Ingestion", dataProviderClass = DataProviderUtils.class, timeOut = TEST_TIMEOUT * 2)
   public void testLiveUpdateSuppression(IngestionMode ingestionMode) throws Exception {
     final String storeName = Utils.getUniqueString("store");
+    AtomicReference<StoreInfo> storeInfo = new AtomicReference<>();
     cluster.useControllerClient(client -> {
       TestUtils.assertCommand(
           client.createNewStore(storeName, getClass().getName(), DEFAULT_KEY_SCHEMA, DEFAULT_VALUE_SCHEMA));
+      storeInfo.set(client.getStore(storeName).getStore());
       cluster.createMetaSystemStore(storeName);
       client.updateStore(
           storeName,
@@ -146,7 +149,7 @@ public class DaVinciLiveUpdateSuppressionTest {
     try (CachingDaVinciClientFactory ignored = daVinciTestContext.getDaVinciClientFactory();
         DaVinciClient<Integer, Integer> client = daVinciTestContext.getDaVinciClient();
         VeniceWriter<Object, Object, byte[]> realTimeProducer = vwFactory.createVeniceWriter(
-            new VeniceWriterOptions.Builder(Version.composeRealTimeTopic(storeName)).setKeySerializer(keySerializer)
+            new VeniceWriterOptions.Builder(Utils.getRealTimeTopicName(storeInfo.get())).setKeySerializer(keySerializer)
                 .setValueSerializer(valueSerializer)
                 .build())) {
       client.subscribe(Collections.singleton(0)).get();

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/PartialUpdateTest.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/PartialUpdateTest.java
@@ -1202,7 +1202,7 @@ public class PartialUpdateTest {
       assertCommand(
           parentControllerClient
               .createNewStore(storeName, "test_owner", STRING_SCHEMA.toString(), valueSchema.toString()));
-      StoreInfo storeInfo = parentControllerClient.getStore(storeName).getStore();
+      StoreInfo storeInfo = TestUtils.assertCommand(parentControllerClient.getStore(storeName)).getStore();
       String realTimeTopicName = Utils.getRealTimeTopicName(storeInfo);
       PubSubTopic realTimeTopic = PUB_SUB_TOPIC_REPOSITORY.getTopic(realTimeTopicName);
       realTimeTopicPartition = new PubSubTopicPartitionImpl(realTimeTopic, 0);

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/PushStatusStoreTest.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/PushStatusStoreTest.java
@@ -342,7 +342,7 @@ public class PushStatusStoreTest {
     runVPJ(getVPJProperties(storeName2), 1, cluster);
 
     String pushStatusStoreRT =
-        Version.composeRealTimeTopic(VeniceSystemStoreUtils.getDaVinciPushStatusStoreName(storeName));
+        Utils.composeRealTimeTopic(VeniceSystemStoreUtils.getDaVinciPushStatusStoreName(storeName));
     admin.getTopicManager().ensureTopicIsDeletedAndBlock(pubSubTopicRepository.getTopic(pushStatusStoreRT));
     TestUtils.waitForNonDeterministicAssertion(
         30,

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestActiveActiveReplicationForIncPush.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestActiveActiveReplicationForIncPush.java
@@ -167,6 +167,8 @@ public class TestActiveActiveReplicationForIncPush {
 
       TestUtils.assertCommand(parentControllerClient.createNewStore(storeName, "owner", keySchemaStr, valueSchemaStr));
 
+      StoreInfo storeInfo = parentControllerClient.getStore(storeName).getStore();
+
       verifyHybridAndIncPushConfig(
           storeName,
           false,
@@ -218,7 +220,7 @@ public class TestActiveActiveReplicationForIncPush {
         Assert.assertEquals(job.getKafkaUrl(), childDatacenters.get(2).getKafkaBrokerWrapper().getAddress());
       }
       if (isSeparateRealTimeTopicEnabled) {
-        verifyForSeparateIncrementalPushTopic(storeName, propsInc1, 2);
+        verifyForSeparateIncrementalPushTopic(storeName, propsInc1, 2, storeInfo);
       } else {
         verifyForRealTimeIncrementalPushTopic(storeName, propsInc1, propsInc2);
       }
@@ -228,7 +230,8 @@ public class TestActiveActiveReplicationForIncPush {
   private void verifyForSeparateIncrementalPushTopic(
       String storeName,
       Properties propsInc1,
-      int dcIndexForSourceRegion) {
+      int dcIndexForSourceRegion,
+      StoreInfo storeInfo) {
     // Prepare TopicManagers
     List<TopicManager> topicManagers = new ArrayList<>();
     for (VeniceMultiClusterWrapper childDataCenter: childDatacenters) {
@@ -249,7 +252,7 @@ public class TestActiveActiveReplicationForIncPush {
         PUB_SUB_TOPIC_REPOSITORY.getTopic(Version.composeSeparateRealTimeTopic(storeName)),
         0);
     PubSubTopicPartition realTimeTopicPartition =
-        new PubSubTopicPartitionImpl(PUB_SUB_TOPIC_REPOSITORY.getTopic(Version.composeRealTimeTopic(storeName)), 0);
+        new PubSubTopicPartitionImpl(PUB_SUB_TOPIC_REPOSITORY.getTopic(Utils.getRealTimeTopicName(storeInfo)), 0);
     try (VenicePushJob job = new VenicePushJob("Test push job incremental with NR + A/A from dc-2", propsInc1)) {
       // TODO: Once server part separate topic ingestion logic is ready, we should avoid runAsync here and add extra
       // check

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestActiveActiveReplicationForIncPush.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestActiveActiveReplicationForIncPush.java
@@ -167,7 +167,7 @@ public class TestActiveActiveReplicationForIncPush {
 
       TestUtils.assertCommand(parentControllerClient.createNewStore(storeName, "owner", keySchemaStr, valueSchemaStr));
 
-      StoreInfo storeInfo = parentControllerClient.getStore(storeName).getStore();
+      StoreInfo storeInfo = TestUtils.assertCommand(parentControllerClient.getStore(storeName)).getStore();
 
       verifyHybridAndIncPushConfig(
           storeName,

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestEmptyPush.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestEmptyPush.java
@@ -28,6 +28,7 @@ import com.linkedin.venice.integration.utils.ServiceFactory;
 import com.linkedin.venice.integration.utils.VeniceClusterCreateOptions;
 import com.linkedin.venice.integration.utils.VeniceClusterWrapper;
 import com.linkedin.venice.meta.Store;
+import com.linkedin.venice.meta.StoreInfo;
 import com.linkedin.venice.meta.Version;
 import com.linkedin.venice.pubsub.api.PubSubTopic;
 import com.linkedin.venice.pubsub.manager.TopicManager;
@@ -116,6 +117,7 @@ public class TestEmptyPush {
                     venice.getPubSubTopicRepository())
                 .getTopicManager(venice.getPubSubBrokerWrapper().getAddress())) {
       controllerClient.createNewStore(storeName, "owner", STRING_SCHEMA.toString(), STRING_SCHEMA.toString());
+      StoreInfo storeInfo = controllerClient.getStore(storeName).getStore();
       controllerClient.updateStore(
           storeName,
           new UpdateStoreQueryParams().setStorageQuotaInByte(Store.UNLIMITED_STORAGE_QUOTA)
@@ -135,7 +137,7 @@ public class TestEmptyPush {
           dictForVersion1,
           "Dict shouldn't be null for the empty push to a hybrid store without any records in RT");
       PubSubTopic storeRealTimeTopic =
-          venice.getPubSubTopicRepository().getTopic(Version.composeRealTimeTopic(storeName));
+          venice.getPubSubTopicRepository().getTopic(Utils.getRealTimeTopicName(storeInfo));
       assertTrue(topicManager.containsTopicAndAllPartitionsAreOnline(storeRealTimeTopic));
       // One time refresh of router metadata.
       venice.refreshAllRouterMetaData();

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestEmptyPush.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestEmptyPush.java
@@ -117,7 +117,7 @@ public class TestEmptyPush {
                     venice.getPubSubTopicRepository())
                 .getTopicManager(venice.getPubSubBrokerWrapper().getAddress())) {
       controllerClient.createNewStore(storeName, "owner", STRING_SCHEMA.toString(), STRING_SCHEMA.toString());
-      StoreInfo storeInfo = controllerClient.getStore(storeName).getStore();
+      StoreInfo storeInfo = TestUtils.assertCommand(controllerClient.getStore(storeName)).getStore();
       controllerClient.updateStore(
           storeName,
           new UpdateStoreQueryParams().setStorageQuotaInByte(Store.UNLIMITED_STORAGE_QUOTA)

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestHybrid.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestHybrid.java
@@ -804,7 +804,7 @@ public class TestHybrid {
         Assert.assertEquals(store.getStore().getCurrentVersion(), 1);
       });
 
-      StoreInfo storeInfo = controllerClient.getStore(storeName).getStore();
+      StoreInfo storeInfo = TestUtils.assertCommand(controllerClient.getStore(storeName)).getStore();
 
       /**
        * Verify that all messages from {@link tmpTopic2} are in store and no message from {@link tmpTopic1} is in store.
@@ -1164,7 +1164,7 @@ public class TestHybrid {
 
       try (
           ControllerClient controllerClient = createStoreForJob(venice.getClusterName(), recordSchema, vpjProperties)) {
-        StoreInfo storeInfo = controllerClient.getStore(storeName).getStore();
+        StoreInfo storeInfo = TestUtils.assertCommand(controllerClient.getStore(storeName)).getStore();
         // Have 1 partition only, so that all keys are produced to the same partition
         ControllerResponse response = controllerClient.updateStore(
             storeName,
@@ -1427,7 +1427,7 @@ public class TestHybrid {
     try (ControllerClient controllerClient = createStoreForJob(venice.getClusterName(), recordSchema, vpjProperties);
         AvroGenericStoreClient client = ClientFactory.getAndStartGenericAvroClient(
             ClientConfig.defaultGenericClientConfig(storeName).setVeniceURL(venice.getRandomRouterURL()))) {
-      StoreInfo storeInfo = controllerClient.getStore(storeName).getStore();
+      StoreInfo storeInfo = TestUtils.assertCommand(controllerClient.getStore(storeName)).getStore();
       // Have 1 partition only, so that all keys are produced to the same partition
       ControllerResponse response = controllerClient.updateStore(
           storeName,

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestHybrid.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestHybrid.java
@@ -71,6 +71,7 @@ import com.linkedin.venice.meta.InstanceStatus;
 import com.linkedin.venice.meta.PersistenceType;
 import com.linkedin.venice.meta.QueryAction;
 import com.linkedin.venice.meta.Store;
+import com.linkedin.venice.meta.StoreInfo;
 import com.linkedin.venice.meta.StoreStatus;
 import com.linkedin.venice.meta.Version;
 import com.linkedin.venice.producer.VeniceProducer;
@@ -803,15 +804,17 @@ public class TestHybrid {
         Assert.assertEquals(store.getStore().getCurrentVersion(), 1);
       });
 
+      StoreInfo storeInfo = controllerClient.getStore(storeName).getStore();
+
       /**
        * Verify that all messages from {@link tmpTopic2} are in store and no message from {@link tmpTopic1} is in store.
        */
       try (
           AvroGenericStoreClient<String, Utf8> client = ClientFactory.getAndStartGenericAvroClient(
               ClientConfig.defaultGenericClientConfig(storeName).setVeniceURL(venice.getRandomRouterURL()));
-          VeniceWriter<byte[], byte[], byte[]> realTimeTopicWriter = TestUtils
-              .getVeniceWriterFactory(veniceWriterProperties, pubSubProducerAdapterFactory)
-              .createVeniceWriter(new VeniceWriterOptions.Builder(Version.composeRealTimeTopic(storeName)).build());) {
+          VeniceWriter<byte[], byte[], byte[]> realTimeTopicWriter =
+              TestUtils.getVeniceWriterFactory(veniceWriterProperties, pubSubProducerAdapterFactory)
+                  .createVeniceWriter(new VeniceWriterOptions.Builder(Utils.getRealTimeTopicName(storeInfo)).build())) {
         // Build a producer to produce 2 TS messages into RT
         realTimeTopicWriter.broadcastTopicSwitch(
             Collections.singletonList(venice.getPubSubBrokerWrapper().getAddress()),
@@ -1161,6 +1164,7 @@ public class TestHybrid {
 
       try (
           ControllerClient controllerClient = createStoreForJob(venice.getClusterName(), recordSchema, vpjProperties)) {
+        StoreInfo storeInfo = controllerClient.getStore(storeName).getStore();
         // Have 1 partition only, so that all keys are produced to the same partition
         ControllerResponse response = controllerClient.updateStore(
             storeName,
@@ -1193,7 +1197,7 @@ public class TestHybrid {
             new AvroGenericDeserializer<>(STRING_SCHEMA, STRING_SCHEMA);
         try (VeniceWriter<byte[], byte[], byte[]> realTimeTopicWriter =
             TestUtils.getVeniceWriterFactory(veniceWriterProperties, pubSubProducerAdapterFactory)
-                .createVeniceWriter(new VeniceWriterOptions.Builder(Version.composeRealTimeTopic(storeName)).build())) {
+                .createVeniceWriter(new VeniceWriterOptions.Builder(Utils.getRealTimeTopicName(storeInfo)).build())) {
           // Send <key1, value1, seq: 1>
           Pair<KafkaKey, KafkaMessageEnvelope> record = getKafkaKeyAndValueEnvelope(
               stringSerializer.serialize(key1),
@@ -1348,6 +1352,7 @@ public class TestHybrid {
     try (ControllerClient controllerClient = createStoreForJob(venice.getClusterName(), recordSchema, vpjProperties);
         AvroGenericStoreClient client = ClientFactory.getAndStartGenericAvroClient(
             ClientConfig.defaultGenericClientConfig(storeName).setVeniceURL(venice.getRandomRouterURL()))) {
+      StoreInfo storeInfo = controllerClient.getStore(storeName).getStore();
       // Have 1 partition only, so that all keys are produced to the same partition
       ControllerResponse response = controllerClient.updateStore(
           storeName,
@@ -1377,7 +1382,7 @@ public class TestHybrid {
       for (int i = 0; i < 2; i++) {
         try (VeniceWriter<byte[], byte[], byte[]> realTimeTopicWriter =
             TestUtils.getVeniceWriterFactory(veniceWriterProperties, pubSubProducerAdapterFactory)
-                .createVeniceWriter(new VeniceWriterOptions.Builder(Version.composeRealTimeTopic(storeName)).build())) {
+                .createVeniceWriter(new VeniceWriterOptions.Builder(Utils.getRealTimeTopicName(storeInfo)).build())) {
           for (int j = i * 50 + 1; j <= i * 50 + 50; j++) {
             realTimeTopicWriter
                 .put(stringSerializer.serialize(String.valueOf(j)), stringSerializer.serialize(prefix + j), 1);
@@ -1422,6 +1427,7 @@ public class TestHybrid {
     try (ControllerClient controllerClient = createStoreForJob(venice.getClusterName(), recordSchema, vpjProperties);
         AvroGenericStoreClient client = ClientFactory.getAndStartGenericAvroClient(
             ClientConfig.defaultGenericClientConfig(storeName).setVeniceURL(venice.getRandomRouterURL()))) {
+      StoreInfo storeInfo = controllerClient.getStore(storeName).getStore();
       // Have 1 partition only, so that all keys are produced to the same partition
       ControllerResponse response = controllerClient.updateStore(
           storeName,
@@ -1450,7 +1456,7 @@ public class TestHybrid {
       for (int i = 0; i < 2; i++) {
         try (VeniceWriter<byte[], byte[], byte[]> realTimeTopicWriter =
             TestUtils.getVeniceWriterFactory(veniceWriterProperties, pubSubProducerAdapterFactory)
-                .createVeniceWriter(new VeniceWriterOptions.Builder(Version.composeRealTimeTopic(storeName)).build())) {
+                .createVeniceWriter(new VeniceWriterOptions.Builder(Utils.getRealTimeTopicName(storeInfo)).build())) {
           for (int j = i * 50 + 1; j <= i * 50 + 50; j++) {
             realTimeTopicWriter
                 .put(stringSerializer.serialize(String.valueOf(j)), stringSerializer.serialize(prefix + j), 1);

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestHybridMultiRegion.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestHybridMultiRegion.java
@@ -34,6 +34,7 @@ import com.linkedin.venice.meta.HybridStoreConfig;
 import com.linkedin.venice.meta.HybridStoreConfigImpl;
 import com.linkedin.venice.meta.PersistenceType;
 import com.linkedin.venice.meta.Store;
+import com.linkedin.venice.meta.StoreInfo;
 import com.linkedin.venice.meta.Version;
 import com.linkedin.venice.meta.ZKStore;
 import com.linkedin.venice.pubsub.PubSubProducerAdapterFactory;
@@ -107,6 +108,8 @@ public class TestHybridMultiRegion {
 
       // Create store at parent, make it a hybrid store
       controllerClient.createNewStore(storeName, "owner", STRING_SCHEMA.toString(), STRING_SCHEMA.toString());
+      StoreInfo storeInfo = controllerClient.getStore(storeName).getStore();
+      String realTimeTopicName = Utils.getRealTimeTopicName(storeInfo);
       controllerClient.updateStore(
           storeName,
           new UpdateStoreQueryParams().setStorageQuotaInByte(Store.UNLIMITED_STORAGE_QUOTA)
@@ -142,7 +145,7 @@ public class TestHybridMultiRegion {
       // And real-time topic should exist now.
       assertTrue(
           topicManager.containsTopicAndAllPartitionsAreOnline(
-              sharedVeniceClusterWrapper.getPubSubTopicRepository().getTopic(Version.composeRealTimeTopic(storeName))));
+              sharedVeniceClusterWrapper.getPubSubTopicRepository().getTopic(realTimeTopicName)));
       // Creating a store object with default values since we're not updating bootstrap to online timeout
       StoreProperties storeProperties = AvroRecordUtils.prefillAvroRecordWithDefaultValue(new StoreProperties());
       storeProperties.name = storeName;
@@ -150,8 +153,8 @@ public class TestHybridMultiRegion {
       storeProperties.createdTime = System.currentTimeMillis();
       Store store = new ZKStore(storeProperties);
       assertEquals(
-          topicManager.getTopicRetention(
-              sharedVeniceClusterWrapper.getPubSubTopicRepository().getTopic(Version.composeRealTimeTopic(storeName))),
+          topicManager
+              .getTopicRetention(sharedVeniceClusterWrapper.getPubSubTopicRepository().getTopic(realTimeTopicName)),
           StoreUtils.getExpectedRetentionTimeInMs(store, hybridStoreConfig),
           "RT retention not configured properly");
       // Make sure RT retention is updated when the rewind time is updated
@@ -160,8 +163,8 @@ public class TestHybridMultiRegion {
       controllerClient
           .updateStore(storeName, new UpdateStoreQueryParams().setHybridRewindSeconds(newStreamingRewindSeconds));
       assertEquals(
-          topicManager.getTopicRetention(
-              sharedVeniceClusterWrapper.getPubSubTopicRepository().getTopic(Version.composeRealTimeTopic(storeName))),
+          topicManager
+              .getTopicRetention(sharedVeniceClusterWrapper.getPubSubTopicRepository().getTopic(realTimeTopicName)),
           StoreUtils.getExpectedRetentionTimeInMs(store, hybridStoreConfig),
           "RT retention not updated properly");
     }

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestHybridMultiRegion.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestHybridMultiRegion.java
@@ -108,7 +108,7 @@ public class TestHybridMultiRegion {
 
       // Create store at parent, make it a hybrid store
       controllerClient.createNewStore(storeName, "owner", STRING_SCHEMA.toString(), STRING_SCHEMA.toString());
-      StoreInfo storeInfo = controllerClient.getStore(storeName).getStore();
+      StoreInfo storeInfo = TestUtils.assertCommand(controllerClient.getStore(storeName)).getStore();
       String realTimeTopicName = Utils.getRealTimeTopicName(storeInfo);
       controllerClient.updateStore(
           storeName,

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestHybridStoreDeletion.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestHybridStoreDeletion.java
@@ -111,6 +111,7 @@ public class TestHybridStoreDeletion {
     final String storeNameFirst = Utils.getUniqueString("hybrid-store-test-first");
     final String storeNameSecond = Utils.getUniqueString("hybrid-store-test-second");
     final String[] storeNames = new String[] { storeNameFirst, storeNameSecond };
+    String[] realTimeTopicNames = new String[storeNames.length];
 
     try (TopicManager topicManager =
         IntegrationTestPushUtils
@@ -124,9 +125,13 @@ public class TestHybridStoreDeletion {
 
       createStoresAndVersions(storeNames, streamingRewindSeconds, streamingMessageLag);
 
+      veniceCluster.useControllerClient(controllerClient -> {
+        realTimeTopicNames[0] = Utils.getRealTimeTopicName(controllerClient.getStore(storeNameFirst).getStore());
+        realTimeTopicNames[1] = Utils.getRealTimeTopicName(controllerClient.getStore(storeNameSecond).getStore());
+      });
+
       // Wait until the rt topic of the first store is fully deleted.
-      PubSubTopic rtTopicFirst1 =
-          veniceCluster.getPubSubTopicRepository().getTopic(Version.composeRealTimeTopic(storeNameFirst));
+      PubSubTopic rtTopicFirst1 = veniceCluster.getPubSubTopicRepository().getTopic(realTimeTopicNames[0]);
       TestUtils.waitForNonDeterministicAssertion(10, TimeUnit.SECONDS, true, true, () -> {
         Assert.assertTrue(topicManager.containsTopic(rtTopicFirst1));
       });
@@ -135,12 +140,11 @@ public class TestHybridStoreDeletion {
       produceToStoreRTTopic(storeNameFirst, 200);
 
       // Delete the rt topic of the first store.
-      topicManager.ensureTopicIsDeletedAndBlock(
-          veniceCluster.getPubSubTopicRepository().getTopic(Version.composeRealTimeTopic(storeNameFirst)));
+      topicManager
+          .ensureTopicIsDeletedAndBlock(veniceCluster.getPubSubTopicRepository().getTopic(realTimeTopicNames[0]));
 
       // Wait until the rt topic of the first store is fully deleted.
-      PubSubTopic rtTopicFirst =
-          veniceCluster.getPubSubTopicRepository().getTopic(Version.composeRealTimeTopic(storeNameFirst));
+      PubSubTopic rtTopicFirst = veniceCluster.getPubSubTopicRepository().getTopic(realTimeTopicNames[0]);
       TestUtils.waitForNonDeterministicAssertion(10, TimeUnit.SECONDS, true, true, () -> {
         Assert.assertFalse(topicManager.containsTopic(rtTopicFirst));
       });
@@ -162,7 +166,6 @@ public class TestHybridStoreDeletion {
           }
         });
       }
-
     }
   }
 

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestHybridStoreDeletion.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestHybridStoreDeletion.java
@@ -126,8 +126,10 @@ public class TestHybridStoreDeletion {
       createStoresAndVersions(storeNames, streamingRewindSeconds, streamingMessageLag);
 
       veniceCluster.useControllerClient(controllerClient -> {
-        realTimeTopicNames[0] = Utils.getRealTimeTopicName(controllerClient.getStore(storeNameFirst).getStore());
-        realTimeTopicNames[1] = Utils.getRealTimeTopicName(controllerClient.getStore(storeNameSecond).getStore());
+        realTimeTopicNames[0] =
+            Utils.getRealTimeTopicName(TestUtils.assertCommand(controllerClient.getStore(storeNameFirst)).getStore());
+        realTimeTopicNames[1] =
+            Utils.getRealTimeTopicName(TestUtils.assertCommand(controllerClient.getStore(storeNameSecond)).getStore());
       });
 
       // Wait until the rt topic of the first store is fully deleted.

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/ingestionHeartbeat/IngestionHeartBeatTest.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/ingestionHeartbeat/IngestionHeartBeatTest.java
@@ -148,7 +148,7 @@ public class IngestionHeartBeatTest {
       assertCommand(
           parentControllerClient
               .createNewStore(storeName, "test_owner", keySchemaStr, NAME_RECORD_V1_SCHEMA.toString()));
-      StoreInfo storeInfo = parentControllerClient.getStore(storeName).getStore();
+      StoreInfo storeInfo = TestUtils.assertCommand(parentControllerClient.getStore(storeName)).getStore();
       UpdateStoreQueryParams updateStoreParams =
           new UpdateStoreQueryParams().setStorageQuotaInByte(Store.UNLIMITED_STORAGE_QUOTA)
               .setCompressionStrategy(CompressionStrategy.NO_OP)

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/ingestionHeartbeat/IngestionHeartBeatTest.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/ingestionHeartbeat/IngestionHeartBeatTest.java
@@ -36,6 +36,7 @@ import com.linkedin.venice.kafka.protocol.KafkaMessageEnvelope;
 import com.linkedin.venice.message.KafkaKey;
 import com.linkedin.venice.meta.DataReplicationPolicy;
 import com.linkedin.venice.meta.Store;
+import com.linkedin.venice.meta.StoreInfo;
 import com.linkedin.venice.meta.Version;
 import com.linkedin.venice.pubsub.PubSubTopicPartitionImpl;
 import com.linkedin.venice.pubsub.PubSubTopicRepository;
@@ -147,6 +148,7 @@ public class IngestionHeartBeatTest {
       assertCommand(
           parentControllerClient
               .createNewStore(storeName, "test_owner", keySchemaStr, NAME_RECORD_V1_SCHEMA.toString()));
+      StoreInfo storeInfo = parentControllerClient.getStore(storeName).getStore();
       UpdateStoreQueryParams updateStoreParams =
           new UpdateStoreQueryParams().setStorageQuotaInByte(Store.UNLIMITED_STORAGE_QUOTA)
               .setCompressionStrategy(CompressionStrategy.NO_OP)
@@ -215,7 +217,7 @@ public class IngestionHeartBeatTest {
             // RT: verify HB is received
             verifyHBinKafkaTopic(
                 pubSubConsumer,
-                storeName,
+                storeInfo,
                 partition,
                 isActiveActiveEnabled,
                 isIncrementalPushEnabled,
@@ -226,7 +228,7 @@ public class IngestionHeartBeatTest {
             // header to all VT.
             verifyHBinKafkaTopic(
                 pubSubConsumer,
-                storeName,
+                storeInfo,
                 partition,
                 isActiveActiveEnabled,
                 isIncrementalPushEnabled,
@@ -240,14 +242,14 @@ public class IngestionHeartBeatTest {
 
   private void verifyHBinKafkaTopic(
       PubSubConsumerAdapter pubSubConsumer,
-      String storeName,
+      StoreInfo storeInfo,
       int partition,
       boolean isActiveActiveEnabled,
       boolean isIncrementalPushEnabled,
       DataReplicationPolicy dataReplicationPolicy,
       boolean isRealTime) throws InterruptedException {
     String topicToSubscribeTo = isRealTime
-        ? Version.composeRealTimeTopic(storeName)
+        ? Utils.getRealTimeTopicName(storeInfo)
         : Version.composeKafkaTopic(storeName, isIncrementalPushEnabled ? 1 : 2);
     pubSubConsumer.subscribe(
         new PubSubTopicPartitionImpl(new PubSubTopicRepository().getTopic(topicToSubscribeTo), partition),

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/restart/TestRestartServerDuringIngestion.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/restart/TestRestartServerDuringIngestion.java
@@ -122,7 +122,7 @@ public abstract class TestRestartServerDuringIngestion {
               Optional.empty(),
               false,
               -1));
-      storeInfo = controllerClient.getStore(storeName).getStore();
+      storeInfo = TestUtils.assertCommand(controllerClient.getStore(storeName)).getStore();
     }
 
     String topic = versionCreationResponse.getKafkaTopic();

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/restart/TestRestartServerDuringIngestion.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/restart/TestRestartServerDuringIngestion.java
@@ -19,6 +19,7 @@ import com.linkedin.venice.integration.utils.VeniceRouterWrapper;
 import com.linkedin.venice.integration.utils.VeniceServerWrapper;
 import com.linkedin.venice.meta.PersistenceType;
 import com.linkedin.venice.meta.RoutingDataRepository;
+import com.linkedin.venice.meta.StoreInfo;
 import com.linkedin.venice.meta.Version;
 import com.linkedin.venice.pubsub.PubSubProducerAdapterFactory;
 import com.linkedin.venice.pushmonitor.ExecutionStatus;
@@ -90,6 +91,7 @@ public abstract class TestRestartServerDuringIngestion {
   public void testIngestionRecovery() throws ExecutionException, InterruptedException {
     // Create a store
     String stringSchemaStr = "\"string\"";
+    StoreInfo storeInfo;
     AvroSerializer serializer = new AvroSerializer(AvroCompatibilityHelper.parse(stringSchemaStr));
     AvroGenericDeserializer deserializer =
         new AvroGenericDeserializer(Schema.parse(stringSchemaStr), Schema.parse(stringSchemaStr));
@@ -120,11 +122,14 @@ public abstract class TestRestartServerDuringIngestion {
               Optional.empty(),
               false,
               -1));
+      storeInfo = controllerClient.getStore(storeName).getStore();
     }
+
     String topic = versionCreationResponse.getKafkaTopic();
     PubSubBrokerWrapper pubSubBrokerWrapper = cluster.getPubSubBrokerWrapper();
     VeniceWriterFactory veniceWriterFactory =
         IntegrationTestPushUtils.getVeniceWriterFactory(pubSubBrokerWrapper, pubSubProducerAdapterFactory);
+
     try (VeniceWriter<byte[], byte[], byte[]> veniceWriter =
         veniceWriterFactory.createVeniceWriter(new VeniceWriterOptions.Builder(topic).build())) {
       veniceWriter.broadcastStartOfPush(true, Collections.emptyMap());
@@ -195,7 +200,7 @@ public abstract class TestRestartServerDuringIngestion {
         cur = 0;
 
         try (VeniceWriter<byte[], byte[], byte[]> streamingWriter = veniceWriterFactory
-            .createVeniceWriter(new VeniceWriterOptions.Builder(Version.composeRealTimeTopic(storeName)).build())) {
+            .createVeniceWriter(new VeniceWriterOptions.Builder(Utils.getRealTimeTopicName(storeInfo)).build())) {
           for (Map.Entry<byte[], byte[]> entry: unsortedInputRecords.entrySet()) {
             if (restartPointSetForUnsortedInput.contains(++cur)) {
               // Restart server

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/Admin.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/Admin.java
@@ -9,6 +9,7 @@ import com.linkedin.venice.controllerapi.StoreComparisonInfo;
 import com.linkedin.venice.controllerapi.UpdateClusterConfigQueryParams;
 import com.linkedin.venice.controllerapi.UpdateStoragePersonaQueryParams;
 import com.linkedin.venice.controllerapi.UpdateStoreQueryParams;
+import com.linkedin.venice.exceptions.VeniceNoStoreException;
 import com.linkedin.venice.helix.HelixReadOnlyStoreConfigRepository;
 import com.linkedin.venice.helix.HelixReadOnlyZKSharedSchemaRepository;
 import com.linkedin.venice.helix.HelixReadOnlyZKSharedSystemStoreRepository;
@@ -288,7 +289,15 @@ public interface Admin extends AutoCloseable, Closeable {
       String targetedRegions,
       int repushSourceVersion);
 
-  String getRealTimeTopic(String clusterName, String storeName);
+  String getRealTimeTopic(String clusterName, Store store);
+
+  default String getRealTimeTopic(String clusterName, String storeName) {
+    Store store = getStore(clusterName, storeName);
+    if (store == null) {
+      throw new VeniceNoStoreException(storeName, clusterName);
+    }
+    return getRealTimeTopic(clusterName, store);
+  }
 
   String getSeparateRealTimeTopic(String clusterName, String storeName);
 

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceHelixAdmin.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceHelixAdmin.java
@@ -3142,6 +3142,21 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
     return realTimeTopic.getName();
   }
 
+  /**
+   * Get the real time topic name for a given store. If the topic is not created in Kafka, it creates the
+   * real time topic and returns the topic name.
+   * @param clusterName name of the Venice cluster.
+   * @param store store.
+   * @return name of the store's real time topic name.
+   */
+  @Override
+  public String getRealTimeTopic(String clusterName, Store store) {
+    checkControllerLeadershipFor(clusterName);
+    PubSubTopic realTimeTopic = pubSubTopicRepository.getTopic(Utils.getRealTimeTopicName(store));
+    ensureRealTimeTopicIsReady(clusterName, realTimeTopic);
+    return realTimeTopic.getName();
+  }
+
   @Override
   public String getSeparateRealTimeTopic(String clusterName, String storeName) {
     checkControllerLeadershipFor(clusterName);

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceParentHelixAdmin.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceParentHelixAdmin.java
@@ -1717,6 +1717,14 @@ public class VeniceParentHelixAdmin implements Admin {
     return getVeniceHelixAdmin().getRealTimeTopic(clusterName, storeName);
   }
 
+  /**
+   * @see VeniceHelixAdmin#getRealTimeTopic(String, Store)
+   */
+  @Override
+  public String getRealTimeTopic(String clusterName, Store store) {
+    return getVeniceHelixAdmin().getRealTimeTopic(clusterName, store);
+  }
+
   @Override
   public String getSeparateRealTimeTopic(String clusterName, String storeName) {
     return getVeniceHelixAdmin().getSeparateRealTimeTopic(clusterName, storeName);

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/server/CreateVersion.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/server/CreateVersion.java
@@ -86,7 +86,6 @@ public class CreateVersion extends AbstractRoute {
             && (!hasWriteAccessToTopic(request) || (this.checkReadMethodForKafka && !hasReadAccessToTopic(request)))) {
           response.status(HttpStatus.SC_FORBIDDEN);
           String userId = getPrincipalId(request);
-          String storeName = request.queryParams(NAME);
 
           /**
            * When partners have ACL issues for their push, we should provide an accurate and informative messages that

--- a/services/venice-controller/src/test/java/com/linkedin/venice/controller/AbstractTestVeniceParentHelixAdmin.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/controller/AbstractTestVeniceParentHelixAdmin.java
@@ -1,6 +1,7 @@
 package com.linkedin.venice.controller;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
 import static org.mockito.Mockito.anyString;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
@@ -111,9 +112,10 @@ public class AbstractTestVeniceParentHelixAdmin {
 
     personaRepository = mock(StoragePersonaRepository.class);
 
-    store = mock(Store.class);
+    store = mock(Store.class, RETURNS_DEEP_STUBS);
     doReturn(OfflinePushStrategy.WAIT_N_MINUS_ONE_REPLCIA_PER_PARTITION).when(store).getOffLinePushStrategy();
     doReturn(false).when(store).isMigrating();
+    when(store.getHybridStoreConfig().getRealTimeTopicName()).thenReturn("test_real_time_topic_rt");
     doReturn(store).when(internalAdmin).checkPreConditionForAclOp(any(), any());
 
     HelixReadWriteStoreRepository storeRepository = mock(HelixReadWriteStoreRepository.class);

--- a/services/venice-controller/src/test/java/com/linkedin/venice/controller/ParticipantStoreClientsManagerTest.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/controller/ParticipantStoreClientsManagerTest.java
@@ -14,13 +14,13 @@ import com.linkedin.d2.balancer.D2Client;
 import com.linkedin.venice.client.store.AvroSpecificStoreClient;
 import com.linkedin.venice.common.VeniceSystemStoreUtils;
 import com.linkedin.venice.exceptions.VeniceException;
-import com.linkedin.venice.meta.Version;
 import com.linkedin.venice.participant.protocol.ParticipantMessageKey;
 import com.linkedin.venice.participant.protocol.ParticipantMessageValue;
 import com.linkedin.venice.pubsub.PubSubTopicRepository;
 import com.linkedin.venice.pubsub.api.PubSubTopic;
 import com.linkedin.venice.pubsub.manager.TopicManager;
 import com.linkedin.venice.pubsub.manager.TopicManagerRepository;
+import com.linkedin.venice.utils.Utils;
 import com.linkedin.venice.writer.VeniceWriter;
 import com.linkedin.venice.writer.VeniceWriterFactory;
 import com.linkedin.venice.writer.VeniceWriterOptions;
@@ -95,7 +95,7 @@ public class ParticipantStoreClientsManagerTest {
 
   @Test
   public void testGetWriter() {
-    String participantStoreRT = Version.composeRealTimeTopic(PARTICIPANT_STORE_NAME);
+    String participantStoreRT = Utils.composeRealTimeTopic(PARTICIPANT_STORE_NAME);
     PubSubTopic participantStoreTopic = pubSubTopicRepository.getTopic(participantStoreRT);
     TopicManager localTopicManager = mock(TopicManager.class);
     when(topicManagerRepository.getLocalTopicManager()).thenReturn(localTopicManager);
@@ -122,7 +122,7 @@ public class ParticipantStoreClientsManagerTest {
 
   @Test
   public void testGetWriterTopicNotFound() {
-    String participantStoreRT = Version.composeRealTimeTopic(PARTICIPANT_STORE_NAME);
+    String participantStoreRT = Utils.composeRealTimeTopic(PARTICIPANT_STORE_NAME);
     PubSubTopic participantStoreTopic = pubSubTopicRepository.getTopic(participantStoreRT);
     TopicManager localTopicManager = mock(TopicManager.class);
     when(topicManagerRepository.getLocalTopicManager()).thenReturn(localTopicManager);

--- a/services/venice-controller/src/test/java/com/linkedin/venice/controller/TestVeniceHelixAdminWithoutCluster.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/controller/TestVeniceHelixAdminWithoutCluster.java
@@ -151,7 +151,7 @@ public class TestVeniceHelixAdminWithoutCluster {
     String clusterName = "cluster1";
     String storeName = Utils.getUniqueString("test_store_recreation");
     Set<PubSubTopic> topics = new HashSet<>();
-    topics.add(pubSubTopicRepository.getTopic(storeName + Version.REAL_TIME_TOPIC_SUFFIX));
+    topics.add(pubSubTopicRepository.getTopic(Utils.composeRealTimeTopic(storeName)));
     topics.add(pubSubTopicRepository.getTopic("unknown_store_v1"));
     testCheckResourceCleanupBeforeStoreCreationWithParams(
         clusterName,

--- a/services/venice-controller/src/test/java/com/linkedin/venice/controller/TestVeniceHelixAdminWithoutCluster.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/controller/TestVeniceHelixAdminWithoutCluster.java
@@ -151,7 +151,7 @@ public class TestVeniceHelixAdminWithoutCluster {
     String clusterName = "cluster1";
     String storeName = Utils.getUniqueString("test_store_recreation");
     Set<PubSubTopic> topics = new HashSet<>();
-    topics.add(pubSubTopicRepository.getTopic(Version.composeRealTimeTopic(storeName)));
+    topics.add(pubSubTopicRepository.getTopic(storeName + Version.REAL_TIME_TOPIC_SUFFIX));
     topics.add(pubSubTopicRepository.getTopic("unknown_store_v1"));
     testCheckResourceCleanupBeforeStoreCreationWithParams(
         clusterName,
@@ -170,7 +170,7 @@ public class TestVeniceHelixAdminWithoutCluster {
     Set<PubSubTopic> topics = new HashSet<>();
     topics.add(
         pubSubTopicRepository
-            .getTopic(Version.composeRealTimeTopic(VeniceSystemStoreType.META_STORE.getSystemStoreName(storeName))));
+            .getTopic(Utils.composeRealTimeTopic(VeniceSystemStoreType.META_STORE.getSystemStoreName(storeName))));
     topics.add(pubSubTopicRepository.getTopic("unknown_store_v1"));
     testCheckResourceCleanupBeforeStoreCreationWithParams(
         clusterName,
@@ -237,6 +237,7 @@ public class TestVeniceHelixAdminWithoutCluster {
     TopicManager topicManager = mock(TopicManager.class);
     doReturn(topics).when(topicManager).listTopics();
     doReturn(topicManager).when(admin).getTopicManager();
+    doReturn(store.orElse(null)).when(admin).getStore(clusterName, storeName);
 
     doReturn(helixResources).when(admin).getAllLiveHelixResources(clusterName);
 

--- a/services/venice-controller/src/test/java/com/linkedin/venice/controller/TestVeniceParentHelixAdmin.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/controller/TestVeniceParentHelixAdmin.java
@@ -1539,7 +1539,7 @@ public class TestVeniceParentHelixAdmin extends AbstractTestVeniceParentHelixAdm
     } catch (VeniceException e) {
     }
 
-    doReturn(false).when(internalAdmin).isTopicTruncated(anyString());
+    doReturn(false).when(internalAdmin).isTopicTruncated(eq(Utils.composeRealTimeTopic(storeName)));
     assertEquals(
         parentAdmin.getIncrementalPushVersion(incrementalPushVersion, ExecutionStatus.COMPLETED),
         incrementalPushVersion);

--- a/services/venice-controller/src/test/java/com/linkedin/venice/controller/TestVeniceParentHelixAdmin.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/controller/TestVeniceParentHelixAdmin.java
@@ -1521,7 +1521,8 @@ public class TestVeniceParentHelixAdmin extends AbstractTestVeniceParentHelixAdm
   @Test
   public void testGetIncrementalPushVersion() {
     String storeName = "testStore";
-    Version incrementalPushVersion = new VersionImpl(storeName, 1);
+    parentAdmin.getStore(storeName, clusterName);
+    Version incrementalPushVersion = new VersionImpl(storeName, 1, storeName + Version.REAL_TIME_TOPIC_SUFFIX);
     assertEquals(
         parentAdmin.getIncrementalPushVersion(incrementalPushVersion, ExecutionStatus.COMPLETED),
         incrementalPushVersion);
@@ -1538,12 +1539,12 @@ public class TestVeniceParentHelixAdmin extends AbstractTestVeniceParentHelixAdm
     } catch (VeniceException e) {
     }
 
-    doReturn(false).when(internalAdmin).isTopicTruncated(Version.composeRealTimeTopic(storeName));
+    doReturn(false).when(internalAdmin).isTopicTruncated(anyString());
     assertEquals(
         parentAdmin.getIncrementalPushVersion(incrementalPushVersion, ExecutionStatus.COMPLETED),
         incrementalPushVersion);
 
-    doReturn(true).when(internalAdmin).isTopicTruncated(Version.composeRealTimeTopic(storeName));
+    doReturn(true).when(internalAdmin).isTopicTruncated(anyString());
     assertThrows(
         VeniceException.class,
         () -> parentAdmin.getIncrementalPushVersion(incrementalPushVersion, ExecutionStatus.COMPLETED));

--- a/services/venice-controller/src/test/java/com/linkedin/venice/controller/TestVeniceParentHelixAdmin.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/controller/TestVeniceParentHelixAdmin.java
@@ -1522,7 +1522,7 @@ public class TestVeniceParentHelixAdmin extends AbstractTestVeniceParentHelixAdm
   public void testGetIncrementalPushVersion() {
     String storeName = "testStore";
     parentAdmin.getStore(storeName, clusterName);
-    Version incrementalPushVersion = new VersionImpl(storeName, 1, storeName + Version.REAL_TIME_TOPIC_SUFFIX);
+    Version incrementalPushVersion = new VersionImpl(storeName, 1);
     assertEquals(
         parentAdmin.getIncrementalPushVersion(incrementalPushVersion, ExecutionStatus.COMPLETED),
         incrementalPushVersion);

--- a/services/venice-controller/src/test/java/com/linkedin/venice/controller/kafka/TestTopicCleanupService.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/controller/kafka/TestTopicCleanupService.java
@@ -106,7 +106,7 @@ public class TestTopicCleanupService {
       String requestedStoreName = invocation.getArgument(1); // Capture the storeName argument
       Store mockStore = mock(Store.class, RETURNS_DEEP_STUBS);
       when(mockStore.getHybridStoreConfig().getRealTimeTopicName())
-          .thenReturn(requestedStoreName + Version.REAL_TIME_TOPIC_SUFFIX);
+          .thenReturn(Utils.composeRealTimeTopic(requestedStoreName));
       return mockStore;
     });
   }
@@ -473,9 +473,8 @@ public class TestTopicCleanupService {
   @Test
   public void testExtractVersionTopicsToCleanupIgnoresInputWithNonVersionTopics() {
     String storeName = Utils.getUniqueString("test_store");
-    String realTimeTopicName = storeName + Version.REAL_TIME_TOPIC_SUFFIX;
     Map<PubSubTopic, Long> topicRetentions = new HashMap<>();
-    topicRetentions.put(pubSubTopicRepository.getTopic(realTimeTopicName), Long.MAX_VALUE);
+    topicRetentions.put(pubSubTopicRepository.getTopic(Utils.composeRealTimeTopic(storeName)), Long.MAX_VALUE);
     topicRetentions
         .put(pubSubTopicRepository.getTopic(Version.composeStreamReprocessingTopic(storeName, 1)), Long.MAX_VALUE);
     topicRetentions.put(pubSubTopicRepository.getTopic(Version.composeKafkaTopic(storeName, 1)), 1000L);

--- a/services/venice-controller/src/test/java/com/linkedin/venice/controller/kafka/TestTopicCleanupService.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/controller/kafka/TestTopicCleanupService.java
@@ -1,5 +1,6 @@
 package com.linkedin.venice.controller.kafka;
 
+import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.anyString;
 import static org.mockito.Mockito.atLeast;
@@ -100,6 +101,14 @@ public class TestTopicCleanupService {
         pubSubTopicRepository,
         topicCleanupServiceStats,
         pubSubClientsFactory);
+
+    when(admin.getStore(any(), anyString())).thenAnswer(invocation -> {
+      String requestedStoreName = invocation.getArgument(1); // Capture the storeName argument
+      Store mockStore = mock(Store.class, RETURNS_DEEP_STUBS);
+      when(mockStore.getHybridStoreConfig().getRealTimeTopicName())
+          .thenReturn(requestedStoreName + Version.REAL_TIME_TOPIC_SUFFIX);
+      return mockStore;
+    });
   }
 
   @AfterMethod
@@ -464,8 +473,9 @@ public class TestTopicCleanupService {
   @Test
   public void testExtractVersionTopicsToCleanupIgnoresInputWithNonVersionTopics() {
     String storeName = Utils.getUniqueString("test_store");
+    String realTimeTopicName = storeName + Version.REAL_TIME_TOPIC_SUFFIX;
     Map<PubSubTopic, Long> topicRetentions = new HashMap<>();
-    topicRetentions.put(pubSubTopicRepository.getTopic(Version.composeRealTimeTopic(storeName)), Long.MAX_VALUE);
+    topicRetentions.put(pubSubTopicRepository.getTopic(realTimeTopicName), Long.MAX_VALUE);
     topicRetentions
         .put(pubSubTopicRepository.getTopic(Version.composeStreamReprocessingTopic(storeName, 1)), Long.MAX_VALUE);
     topicRetentions.put(pubSubTopicRepository.getTopic(Version.composeKafkaTopic(storeName, 1)), 1000L);

--- a/services/venice-controller/src/test/java/com/linkedin/venice/controller/server/CreateVersionTest.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/controller/server/CreateVersionTest.java
@@ -45,6 +45,7 @@ import com.linkedin.venice.meta.VersionImpl;
 import com.linkedin.venice.meta.ZKStore;
 import com.linkedin.venice.utils.DataProviderUtils;
 import com.linkedin.venice.utils.ObjectMapperFactory;
+import com.linkedin.venice.utils.Utils;
 import java.security.cert.X509Certificate;
 import java.util.HashMap;
 import java.util.Map;
@@ -190,7 +191,7 @@ public class CreateVersionTest {
     if (isSeparateTopicEnabled) {
       assertEquals(versionCreateResponse.getKafkaTopic(), Version.composeSeparateRealTimeTopic(STORE_NAME));
     } else {
-      assertEquals(versionCreateResponse.getKafkaTopic(), Version.composeRealTimeTopic(STORE_NAME));
+      assertEquals(versionCreateResponse.getKafkaTopic(), Utils.getRealTimeTopicName(store));
     }
   }
 

--- a/services/venice-controller/src/test/java/com/linkedin/venice/ingestion/control/RealTimeTopicSwitcherTest.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/ingestion/control/RealTimeTopicSwitcherTest.java
@@ -25,6 +25,7 @@ import com.linkedin.venice.meta.ViewConfigImpl;
 import com.linkedin.venice.pubsub.PubSubTopicRepository;
 import com.linkedin.venice.pubsub.api.PubSubTopic;
 import com.linkedin.venice.pubsub.manager.TopicManager;
+import com.linkedin.venice.utils.Utils;
 import com.linkedin.venice.utils.VeniceProperties;
 import com.linkedin.venice.writer.VeniceWriter;
 import com.linkedin.venice.writer.VeniceWriterFactory;
@@ -136,15 +137,15 @@ public class RealTimeTopicSwitcherTest {
     Map<String, ViewConfig> viewConfigs = new HashMap<>();
     viewConfigs.put("testView", new ViewConfigImpl("testClass", Collections.emptyMap()));
 
+    Store mockStore = mock(Store.class);
+    when(mockStore.getName()).thenReturn(storeName);
     Version version1 = new VersionImpl(storeName, 1, "push1");
     Version version2 = new VersionImpl(storeName, 2, "push2");
     version2.setViewConfigs(viewConfigs);
     Version version3 = new VersionImpl(storeName, 3, "push3");
     version3.setViewConfigs(viewConfigs);
+    PubSubTopic realTimeTopic = pubSubTopicRepository.getTopic(Utils.getRealTimeTopicName(version1));
 
-    PubSubTopic realTimeTopic = pubSubTopicRepository.getTopic(Version.composeRealTimeTopic(storeName));
-    Store mockStore = mock(Store.class);
-    when(mockStore.getName()).thenReturn(storeName);
     when(mockStore.getVersion(1)).thenReturn(version1);
     when(mockStore.getVersion(2)).thenReturn(version2);
     when(mockStore.getVersion(3)).thenReturn(version3);

--- a/services/venice-controller/src/test/java/com/linkedin/venice/pushmonitor/AbstractPushMonitorTest.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/pushmonitor/AbstractPushMonitorTest.java
@@ -772,7 +772,7 @@ public abstract class AbstractPushMonitorTest {
     replicaStatuses.get(0).updateStatus(ExecutionStatus.END_OF_PUSH_RECEIVED);
     monitor.onPartitionStatusChange(topic, partitionStatus);
     verify(realTimeTopicSwitcher, times(1)).switchToRealTimeTopic(
-        eq(Version.composeRealTimeTopic(store.getName())),
+        eq(Utils.getRealTimeTopicName(store)),
         eq(topic),
         eq(store),
         eq(aggregateRealTimeSourceKafkaUrl),
@@ -841,7 +841,7 @@ public abstract class AbstractPushMonitorTest {
     }
     // Only send one SOBR
     verify(realTimeTopicSwitcher, only()).switchToRealTimeTopic(
-        eq(Version.composeRealTimeTopic(store.getName())),
+        eq(Utils.getRealTimeTopicName(store)),
         eq(topic),
         eq(store),
         eq(aggregateRealTimeSourceKafkaUrl),

--- a/services/venice-router/src/test/java/com/linkedin/venice/router/TestMetaDataHandler.java
+++ b/services/venice-router/src/test/java/com/linkedin/venice/router/TestMetaDataHandler.java
@@ -68,6 +68,7 @@ import com.linkedin.venice.serialization.avro.AvroProtocolDefinition;
 import com.linkedin.venice.utils.ObjectMapperFactory;
 import com.linkedin.venice.utils.TestUtils;
 import com.linkedin.venice.utils.Time;
+import com.linkedin.venice.utils.Utils;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.handler.codec.http.EmptyHttpHeaders;
 import io.netty.handler.codec.http.FullHttpRequest;
@@ -1276,6 +1277,7 @@ public class TestMetaDataHandler {
 
     Mockito.doReturn(1).when(store).getCurrentVersion();
     Mockito.doReturn(currentVersion).when(store).getVersion(1);
+    Mockito.doReturn(storeName).when(store).getName();
 
     Mockito.doReturn(store).when(storeRepository).getStore(storeName);
     FullHttpResponse response = passRequestToMetadataHandler(
@@ -1291,7 +1293,7 @@ public class TestMetaDataHandler {
         OBJECT_MAPPER.readValue(response.content().array(), VersionCreationResponse.class);
     Assert.assertEquals(versionCreationResponse.getName(), storeName);
     Assert.assertEquals(versionCreationResponse.getCluster(), clusterName);
-    Assert.assertEquals(versionCreationResponse.getKafkaTopic(), Version.composeRealTimeTopic(storeName));
+    Assert.assertEquals(versionCreationResponse.getKafkaTopic(), Utils.getRealTimeTopicName(store));
     Assert.assertEquals(versionCreationResponse.getKafkaBootstrapServers(), KAFKA_BOOTSTRAP_SERVERS);
     Assert.assertEquals(versionCreationResponse.getAmplificationFactor(), 1);
     Assert.assertEquals(versionCreationResponse.getPartitions(), 10);
@@ -1329,6 +1331,7 @@ public class TestMetaDataHandler {
 
     Mockito.doReturn(1).when(store).getCurrentVersion();
     Mockito.doReturn(currentVersion).when(store).getVersion(1);
+    Mockito.doReturn(storeName).when(store).getName();
 
     Mockito.doReturn(store).when(storeRepository).getStore(storeName);
     FullHttpResponse response = passRequestToMetadataHandler(
@@ -1344,7 +1347,7 @@ public class TestMetaDataHandler {
         OBJECT_MAPPER.readValue(response.content().array(), VersionCreationResponse.class);
     Assert.assertEquals(versionCreationResponse.getName(), storeName);
     Assert.assertEquals(versionCreationResponse.getCluster(), clusterName);
-    Assert.assertEquals(versionCreationResponse.getKafkaTopic(), Version.composeRealTimeTopic(storeName));
+    Assert.assertEquals(versionCreationResponse.getKafkaTopic(), Utils.getRealTimeTopicName(store));
     Assert.assertEquals(versionCreationResponse.getKafkaBootstrapServers(), KAFKA_BOOTSTRAP_SERVERS);
     Assert.assertEquals(versionCreationResponse.getAmplificationFactor(), 1);
     Assert.assertEquals(versionCreationResponse.getPartitions(), 10);
@@ -1384,6 +1387,7 @@ public class TestMetaDataHandler {
 
     Mockito.doReturn(1).when(store).getCurrentVersion();
     Mockito.doReturn(currentVersion).when(store).getVersion(1);
+    Mockito.doReturn(storeName).when(store).getName();
 
     Mockito.doReturn(store).when(storeRepository).getStore(storeName);
     FullHttpResponse response = passRequestToMetadataHandler(
@@ -1400,7 +1404,7 @@ public class TestMetaDataHandler {
         OBJECT_MAPPER.readValue(response.content().array(), VersionCreationResponse.class);
     Assert.assertEquals(versionCreationResponse.getName(), storeName);
     Assert.assertEquals(versionCreationResponse.getCluster(), clusterName);
-    Assert.assertEquals(versionCreationResponse.getKafkaTopic(), Version.composeRealTimeTopic(storeName));
+    Assert.assertEquals(versionCreationResponse.getKafkaTopic(), Utils.getRealTimeTopicName(store));
     Assert.assertEquals(versionCreationResponse.getKafkaBootstrapServers(), KAFKA_BOOTSTRAP_SERVERS);
     Assert.assertEquals(versionCreationResponse.getAmplificationFactor(), 1);
     Assert.assertEquals(versionCreationResponse.getPartitions(), 10);

--- a/services/venice-server/src/test/java/com/linkedin/venice/stats/AggVersionedIngestionStatsTest.java
+++ b/services/venice-server/src/test/java/com/linkedin/venice/stats/AggVersionedIngestionStatsTest.java
@@ -64,7 +64,6 @@ public class AggVersionedIngestionStatsTest {
     storeList.add(mockStore);
 
     doReturn(mockStore).when(mockMetaRepository).getStoreOrThrow(any());
-
     doReturn(storeList).when(mockMetaRepository).getAllStores();
 
     // No metrics initially.
@@ -139,7 +138,6 @@ public class AggVersionedIngestionStatsTest {
     storeList.add(mockStore);
 
     doReturn(mockStore).when(mockMetaRepository).getStoreOrThrow(any());
-
     doReturn(storeList).when(mockMetaRepository).getAllStores();
 
     stats.loadAllStats();


### PR DESCRIPTION

<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## Change references for `Version::composeRealTimeTopic` to `Utils::getRealTimeTopicName`
<!--
Describe


If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->
This is the continuation work of https://github.com/linkedin/venice/pull/1345 
Changing references for `Version::composeRealTimeTopic` to `Utils::getRealTimeTopicName`. Because there are too many references to review easily, only references in test files are changed in this PR.

Resolves #XXX

## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.