### PR TITLE
[router] Fix invalid tehuti sensor name passed in for latencies

### DIFF
--- a/internal/venice-client-common/src/main/java/com/linkedin/venice/stats/metrics/MetricEntityState.java
+++ b/internal/venice-client-common/src/main/java/com/linkedin/venice/stats/metrics/MetricEntityState.java
@@ -111,9 +111,9 @@ public class MetricEntityState {
       if (sensor != null) {
         sensor.record(value);
       } else {
-        // Log using Redundant log filters to catch any bad name passed in
+        // Log using Redundant log filters to catch any bad tehutiMetricNameEnum is passed in
         String errorLog = "Tehuti Sensor with name '" + tehutiMetricNameEnum + "' not found.";
-        if (REDUNDANT_LOG_FILTER.isRedundantLog(errorLog)) {
+        if (!REDUNDANT_LOG_FILTER.isRedundantLog(errorLog)) {
           LOGGER.error(errorLog);
         }
       }

--- a/services/venice-router/src/main/java/com/linkedin/venice/router/stats/RouterHttpRequestStats.java
+++ b/services/venice-router/src/main/java/com/linkedin/venice/router/stats/RouterHttpRequestStats.java
@@ -363,11 +363,14 @@ public class RouterHttpRequestStats extends AbstractVeniceHttpStats {
   }
 
   public void recordHealthyRequest(Double latency, HttpResponseStatus responseStatus) {
-    TehutiMetricNameEnum tehutiMetricNameEnum = RouterTehutiMetricNameEnum.HEALTHY_REQUEST;
     VeniceResponseStatusCategory veniceResponseStatusCategory = VeniceResponseStatusCategory.HEALTHY;
-    recordRequestMetric(tehutiMetricNameEnum, responseStatus, veniceResponseStatusCategory);
+    recordRequestMetric(RouterTehutiMetricNameEnum.HEALTHY_REQUEST, responseStatus, veniceResponseStatusCategory);
     if (latency != null) {
-      recordLatencyMetric(tehutiMetricNameEnum, latency, responseStatus, veniceResponseStatusCategory);
+      recordLatencyMetric(
+          RouterTehutiMetricNameEnum.HEALTHY_REQUEST_LATENCY,
+          latency,
+          responseStatus,
+          veniceResponseStatusCategory);
     }
   }
 
@@ -400,10 +403,13 @@ public class RouterHttpRequestStats extends AbstractVeniceHttpStats {
   }
 
   public void recordTardyRequest(double latency, HttpResponseStatus responseStatus) {
-    TehutiMetricNameEnum tehutiMetricNameEnum = RouterTehutiMetricNameEnum.TARDY_REQUEST;
     VeniceResponseStatusCategory veniceResponseStatusCategory = VeniceResponseStatusCategory.TARDY;
-    recordRequestMetric(tehutiMetricNameEnum, responseStatus, veniceResponseStatusCategory);
-    recordLatencyMetric(tehutiMetricNameEnum, latency, responseStatus, veniceResponseStatusCategory);
+    recordRequestMetric(RouterTehutiMetricNameEnum.TARDY_REQUEST, responseStatus, veniceResponseStatusCategory);
+    recordLatencyMetric(
+        RouterTehutiMetricNameEnum.TARDY_REQUEST_LATENCY,
+        latency,
+        responseStatus,
+        veniceResponseStatusCategory);
   }
 
   public void recordThrottledRequest(double latency, HttpResponseStatus responseStatus) {
@@ -465,7 +471,10 @@ public class RouterHttpRequestStats extends AbstractVeniceHttpStats {
   }
 
   public void recordBadRequestKeyCount(int keyCount) {
-    recordKeyCountMetric(keyCount, RequestValidationOutcome.INVALID_KEY_COUNT_LIMIT_EXCEEDED);
+    recordKeyCountMetric(
+        RouterTehutiMetricNameEnum.BAD_REQUEST_KEY_COUNT,
+        keyCount,
+        RequestValidationOutcome.INVALID_KEY_COUNT_LIMIT_EXCEEDED);
   }
 
   public void recordRequestThrottledByRouterCapacity() {
@@ -548,10 +557,13 @@ public class RouterHttpRequestStats extends AbstractVeniceHttpStats {
   }
 
   public void recordKeyNum(int keyNum) {
-    recordKeyCountMetric(keyNum, RequestValidationOutcome.VALID);
+    recordKeyCountMetric(RouterTehutiMetricNameEnum.KEY_NUM, keyNum, RequestValidationOutcome.VALID);
   }
 
-  public void recordKeyCountMetric(int keyNum, RequestValidationOutcome outcome) {
+  public void recordKeyCountMetric(
+      TehutiMetricNameEnum tehutiMetricNameEnum,
+      int keyNum,
+      RequestValidationOutcome outcome) {
     Attributes dimensions = null;
     if (emitOpenTelemetryMetrics) {
       dimensions = Attributes.builder()
@@ -559,7 +571,7 @@ public class RouterHttpRequestStats extends AbstractVeniceHttpStats {
           .put(getDimensionName(VENICE_REQUEST_VALIDATION_OUTCOME), outcome.getOutcome())
           .build();
     }
-    keyCountMetric.record(RouterTehutiMetricNameEnum.KEY_NUM, keyNum, dimensions);
+    keyCountMetric.record(tehutiMetricNameEnum, keyNum, dimensions);
   }
 
   public void recordRequestUsage(int usage) {


### PR DESCRIPTION
## Summary
If an invalid `TehutiMetricNameEnum` that was not registered with `MetricEntityState` is passed in, it will be skipped during record() and will be silently ignored. Found this issue for `healthy_request_latency` and this PR fixes this issue and adds logging with redundant logging filter to log such issues. Not throwing an exception as we will be moving a lot of the existing metrics to Otel and tracking this log will help find and fix the issue during the migration and not affect the rollout process.

## How was this PR tested?
unit test

## Does this PR introduce any user-facing changes?
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.