### PR TITLE
Revert "[compat] [controller] add rt topic name in store config (#1345)"

### DIFF
--- a/internal/venice-common/src/main/java/com/linkedin/venice/controllerapi/ControllerApiConstants.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/controllerapi/ControllerApiConstants.java
@@ -55,7 +55,6 @@ public class ControllerApiConstants {
   public static final String TIME_LAG_TO_GO_ONLINE = "time_lag_to_go_online";
   public static final String DATA_REPLICATION_POLICY = "data_replication_policy";
   public static final String BUFFER_REPLAY_POLICY = "buffer_replay_policy";
-  public static final String REAL_TIME_TOPIC_NAME = "real_time_topic_name";
   public static final String COMPRESSION_STRATEGY = "compression_strategy";
   public static final String CLIENT_DECOMPRESSION_ENABLED = "client_decompression_enabled";
   public static final String CHUNKING_ENABLED = "chunking_enabled";

--- a/internal/venice-common/src/main/java/com/linkedin/venice/controllerapi/UpdateStoreQueryParams.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/controllerapi/UpdateStoreQueryParams.java
@@ -46,7 +46,6 @@ import static com.linkedin.venice.controllerapi.ControllerApiConstants.PERSONA_N
 import static com.linkedin.venice.controllerapi.ControllerApiConstants.PUSH_STREAM_SOURCE_ADDRESS;
 import static com.linkedin.venice.controllerapi.ControllerApiConstants.READ_COMPUTATION_ENABLED;
 import static com.linkedin.venice.controllerapi.ControllerApiConstants.READ_QUOTA_IN_CU;
-import static com.linkedin.venice.controllerapi.ControllerApiConstants.REAL_TIME_TOPIC_NAME;
 import static com.linkedin.venice.controllerapi.ControllerApiConstants.REGIONS_FILTER;
 import static com.linkedin.venice.controllerapi.ControllerApiConstants.REGULAR_VERSION_ETL_ENABLED;
 import static com.linkedin.venice.controllerapi.ControllerApiConstants.REPLICATE_ALL_CONFIGS;
@@ -363,14 +362,6 @@ public class UpdateStoreQueryParams extends QueryParams {
 
   public Optional<BufferReplayPolicy> getHybridBufferReplayPolicy() {
     return Optional.ofNullable(params.get(BUFFER_REPLAY_POLICY)).map(BufferReplayPolicy::valueOf);
-  }
-
-  public UpdateStoreQueryParams setRealTimeTopicName(String realTimeTopicName) {
-    return putString(REAL_TIME_TOPIC_NAME, realTimeTopicName);
-  }
-
-  public Optional<String> getRealTimeTopicName() {
-    return getString(REAL_TIME_TOPIC_NAME);
   }
 
   public UpdateStoreQueryParams setAccessControlled(boolean accessControlled) {

--- a/internal/venice-common/src/main/java/com/linkedin/venice/meta/HybridStoreConfig.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/meta/HybridStoreConfig.java
@@ -26,9 +26,5 @@ public interface HybridStoreConfig extends DataModelBackedStructure<StoreHybridC
 
   BufferReplayPolicy getBufferReplayPolicy();
 
-  String getRealTimeTopicName();
-
-  void setRealTimeTopicName(String realTimeTopicName);
-
   HybridStoreConfig clone();
 }

--- a/internal/venice-common/src/main/java/com/linkedin/venice/meta/HybridStoreConfigImpl.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/meta/HybridStoreConfigImpl.java
@@ -1,6 +1,5 @@
 package com.linkedin.venice.meta;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -18,33 +17,15 @@ public class HybridStoreConfigImpl implements HybridStoreConfig {
   public static final long DEFAULT_REWIND_TIME_IN_SECONDS = Time.SECONDS_PER_DAY;
   public static final long DEFAULT_HYBRID_TIME_LAG_THRESHOLD = -1L;
   public static final long DEFAULT_HYBRID_OFFSET_LAG_THRESHOLD = 1000L;
-  public static final String DEFAULT_REAL_TIME_TOPIC_NAME = "";
 
   private final StoreHybridConfig hybridConfig;
 
-  public HybridStoreConfigImpl(
-      long rewindTimeInSeconds,
-      long offsetLagThresholdToGoOnline,
-      long producerTimestampLagThresholdToGoOnlineInSeconds,
-      DataReplicationPolicy dataReplicationPolicy,
-      BufferReplayPolicy bufferReplayPolicy) {
-    this(
-        rewindTimeInSeconds,
-        offsetLagThresholdToGoOnline,
-        producerTimestampLagThresholdToGoOnlineInSeconds,
-        dataReplicationPolicy,
-        bufferReplayPolicy,
-        DEFAULT_REAL_TIME_TOPIC_NAME);
-  }
-
-  @JsonCreator
   public HybridStoreConfigImpl(
       @JsonProperty("rewindTimeInSeconds") long rewindTimeInSeconds,
       @JsonProperty("offsetLagThresholdToGoOnline") long offsetLagThresholdToGoOnline,
       @JsonProperty("producerTimestampLagThresholdToGoOnlineInSeconds") long producerTimestampLagThresholdToGoOnlineInSeconds,
       @JsonProperty("dataReplicationPolicy") DataReplicationPolicy dataReplicationPolicy,
-      @JsonProperty("bufferReplayPolicy") BufferReplayPolicy bufferReplayPolicy,
-      @JsonProperty("realTimeTopicName") String realTimeTopicName) {
+      @JsonProperty("bufferReplayPolicy") BufferReplayPolicy bufferReplayPolicy) {
     this.hybridConfig = new StoreHybridConfig();
     this.hybridConfig.rewindTimeInSeconds = rewindTimeInSeconds;
     this.hybridConfig.offsetLagThresholdToGoOnline = offsetLagThresholdToGoOnline;
@@ -56,7 +37,6 @@ public class HybridStoreConfigImpl implements HybridStoreConfig {
         : dataReplicationPolicy.getValue();
     this.hybridConfig.bufferReplayPolicy =
         bufferReplayPolicy == null ? BufferReplayPolicy.REWIND_FROM_EOP.getValue() : bufferReplayPolicy.getValue();
-    this.hybridConfig.realTimeTopicName = realTimeTopicName;
   }
 
   HybridStoreConfigImpl(StoreHybridConfig config) {
@@ -104,16 +84,6 @@ public class HybridStoreConfigImpl implements HybridStoreConfig {
   }
 
   @Override
-  public String getRealTimeTopicName() {
-    return this.hybridConfig.realTimeTopicName.toString();
-  }
-
-  @Override
-  public void setRealTimeTopicName(String realTimeTopicName) {
-    this.hybridConfig.realTimeTopicName = realTimeTopicName;
-  }
-
-  @Override
   public StoreHybridConfig dataModel() {
     return this.hybridConfig;
   }
@@ -142,7 +112,6 @@ public class HybridStoreConfigImpl implements HybridStoreConfig {
         getOffsetLagThresholdToGoOnline(),
         getProducerTimestampLagThresholdToGoOnlineInSeconds(),
         getDataReplicationPolicy(),
-        getBufferReplayPolicy(),
-        getRealTimeTopicName());
+        getBufferReplayPolicy());
   }
 }

--- a/internal/venice-common/src/main/java/com/linkedin/venice/meta/ReadOnlyStore.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/meta/ReadOnlyStore.java
@@ -143,16 +143,6 @@ public class ReadOnlyStore implements Store {
     }
 
     @Override
-    public String getRealTimeTopicName() {
-      return this.delegate.getRealTimeTopicName();
-    }
-
-    @Override
-    public void setRealTimeTopicName(String realTimeTopicName) {
-      throw new UnsupportedOperationException();
-    }
-
-    @Override
     public HybridStoreConfig clone() {
       return this.delegate.clone();
     }
@@ -521,11 +511,6 @@ public class ReadOnlyStore implements Store {
     @Override
     public void setUseVersionLevelIncrementalPushEnabled(boolean versionLevelIncrementalPushEnabled) {
       throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public boolean isHybrid() {
-      return this.delegate.isHybrid();
     }
 
     @Override

--- a/internal/venice-common/src/main/java/com/linkedin/venice/meta/Version.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/meta/Version.java
@@ -174,8 +174,6 @@ public interface Version extends Comparable<Version>, DataModelBackedStructure<S
 
   void setUseVersionLevelIncrementalPushEnabled(boolean versionLevelIncrementalPushEnabled);
 
-  boolean isHybrid();
-
   HybridStoreConfig getHybridStoreConfig();
 
   void setHybridStoreConfig(HybridStoreConfig hybridConfig);

--- a/internal/venice-common/src/main/java/com/linkedin/venice/meta/VersionImpl.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/meta/VersionImpl.java
@@ -299,11 +299,6 @@ public class VersionImpl implements Version {
   }
 
   @Override
-  public boolean isHybrid() {
-    return getHybridStoreConfig() != null;
-  }
-
-  @Override
   public HybridStoreConfig getHybridStoreConfig() {
     if (this.storeVersion.hybridConfig == null) {
       return null;

--- a/internal/venice-common/src/test/java/com/linkedin/venice/utils/UtilsTest.java
+++ b/internal/venice-common/src/test/java/com/linkedin/venice/utils/UtilsTest.java
@@ -1,23 +1,16 @@
 package com.linkedin.venice.utils;
 
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.expectThrows;
 import static org.testng.Assert.fail;
 
 import com.linkedin.venice.exceptions.VeniceException;
-import com.linkedin.venice.meta.HybridStoreConfig;
-import com.linkedin.venice.meta.Store;
-import com.linkedin.venice.meta.StoreInfo;
-import com.linkedin.venice.meta.Version;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
@@ -26,7 +19,6 @@ import java.util.Set;
 import java.util.TreeMap;
 import org.testng.Assert;
 import org.testng.annotations.Test;
-import org.testng.collections.Lists;
 
 
 /**
@@ -236,112 +228,5 @@ public class UtilsTest {
     Assert.assertEquals(Utils.resolveKafkaUrlForSepTopic(""), "");
     Assert.assertEquals(Utils.resolveKafkaUrlForSepTopic(originalKafkaUrlForSep), originalKafkaUrl);
     Assert.assertEquals(Utils.resolveKafkaUrlForSepTopic(originalKafkaUrl), originalKafkaUrl);
-  }
-
-  @Test
-  void testGetRealTimeTopicNameWithStore() {
-    Store mockStore = mock(Store.class);
-    List<Version> mockVersions = Collections.singletonList(mock(Version.class));
-    HybridStoreConfig mockHybridConfig = mock(HybridStoreConfig.class);
-
-    when(mockStore.getName()).thenReturn("TestStore");
-    when(mockStore.getVersions()).thenReturn(mockVersions);
-    when(mockStore.getCurrentVersion()).thenReturn(1);
-    when(mockStore.getHybridStoreConfig()).thenReturn(mockHybridConfig);
-
-    when(mockHybridConfig.getRealTimeTopicName()).thenReturn("RealTimeTopic");
-
-    String result = Utils.getRealTimeTopicName(mockStore);
-    assertEquals("RealTimeTopic", result);
-  }
-
-  @Test
-  void testGetRealTimeTopicNameWithStoreInfo() {
-    StoreInfo mockStoreInfo = mock(StoreInfo.class);
-    List<Version> mockVersions = Collections.singletonList(mock(Version.class));
-    HybridStoreConfig mockHybridConfig = mock(HybridStoreConfig.class);
-
-    when(mockStoreInfo.getName()).thenReturn("TestStore");
-    when(mockStoreInfo.getVersions()).thenReturn(mockVersions);
-    when(mockStoreInfo.getCurrentVersion()).thenReturn(1);
-    when(mockStoreInfo.getHybridStoreConfig()).thenReturn(mockHybridConfig);
-
-    when(mockHybridConfig.getRealTimeTopicName()).thenReturn("RealTimeTopic");
-
-    String result = Utils.getRealTimeTopicName(mockStoreInfo);
-    assertEquals("RealTimeTopic", result);
-  }
-
-  @Test
-  void testGetRealTimeTopicNameWithHybridConfig() {
-    HybridStoreConfig mockHybridConfig = mock(HybridStoreConfig.class);
-
-    when(mockHybridConfig.getRealTimeTopicName()).thenReturn("RealTimeTopic");
-    String result = Utils.getRealTimeTopicName("TestStore", Collections.EMPTY_LIST, 1, mockHybridConfig);
-
-    assertEquals("RealTimeTopic", result);
-  }
-
-  @Test
-  void testGetRealTimeTopicNameWithoutHybridConfig() {
-    String result = Utils.getRealTimeTopicName("TestStore", Collections.EMPTY_LIST, 0, null);
-    assertEquals("TestStore" + Version.REAL_TIME_TOPIC_SUFFIX, result);
-  }
-
-  @Test
-  void testGetRealTimeTopicNameWithConflictingVersions() {
-    Version mockVersion1 = mock(Version.class);
-    Version mockVersion2 = mock(Version.class);
-    HybridStoreConfig mockConfig1 = mock(HybridStoreConfig.class);
-    HybridStoreConfig mockConfig2 = mock(HybridStoreConfig.class);
-
-    when(mockVersion1.isHybrid()).thenReturn(true);
-    when(mockVersion2.isHybrid()).thenReturn(true);
-    when(mockVersion1.getHybridStoreConfig()).thenReturn(mockConfig1);
-    when(mockVersion2.getHybridStoreConfig()).thenReturn(mockConfig2);
-    when(mockConfig1.getRealTimeTopicName()).thenReturn("RealTimeTopic1");
-    when(mockConfig2.getRealTimeTopicName()).thenReturn("RealTimeTopic2");
-
-    String result = Utils.getRealTimeTopicName("TestStore", Lists.newArrayList(mockVersion1, mockVersion2), 1, null);
-    assertTrue(result.equals("RealTimeTopic1") || result.equals("RealTimeTopic2"));
-  }
-
-  @Test
-  void testGetRealTimeTopicNameWithExceptionHandling() {
-    Version mockVersion1 = mock(Version.class);
-    Version mockVersion2 = mock(Version.class);
-
-    when(mockVersion1.isHybrid()).thenReturn(true);
-    when(mockVersion1.getHybridStoreConfig()).thenThrow(new VeniceException("Test Exception"));
-
-    when(mockVersion2.isHybrid()).thenReturn(false);
-
-    String result = Utils.getRealTimeTopicName("TestStore", Lists.newArrayList(mockVersion1, mockVersion2), 1, null);
-    assertEquals("TestStore" + Version.REAL_TIME_TOPIC_SUFFIX, result);
-  }
-
-  @Test
-  void testGetRealTimeTopicNameWithVersion() {
-    Version mockVersion = mock(Version.class);
-    HybridStoreConfig mockHybridConfig = mock(HybridStoreConfig.class);
-
-    when(mockVersion.getHybridStoreConfig()).thenReturn(mockHybridConfig);
-    when(mockVersion.getStoreName()).thenReturn("TestStore");
-    when(mockHybridConfig.getRealTimeTopicName()).thenReturn("RealTimeTopic");
-
-    String result = Utils.getRealTimeTopicName(mockVersion);
-    assertEquals("RealTimeTopic", result);
-  }
-
-  @Test
-  void testGetRealTimeTopicNameWithNonHybridVersion() {
-    // Mocking the Version object
-    Version mockVersion = mock(Version.class);
-
-    // Mock setup to trigger the exception path
-    when(mockVersion.getHybridStoreConfig()).thenReturn(null);
-    when(mockVersion.getStoreName()).thenReturn("TestStore");
-    String result = Utils.getRealTimeTopicName(mockVersion);
-    assertEquals("TestStore" + Version.REAL_TIME_TOPIC_SUFFIX, result);
   }
 }

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceHelixAdmin.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceHelixAdmin.java
@@ -9,7 +9,6 @@ import static com.linkedin.venice.ConfigKeys.SSL_TO_KAFKA_LEGACY;
 import static com.linkedin.venice.controller.UserSystemStoreLifeCycleHelper.AUTO_META_SYSTEM_STORE_PUSH_ID_PREFIX;
 import static com.linkedin.venice.meta.HybridStoreConfigImpl.DEFAULT_HYBRID_OFFSET_LAG_THRESHOLD;
 import static com.linkedin.venice.meta.HybridStoreConfigImpl.DEFAULT_HYBRID_TIME_LAG_THRESHOLD;
-import static com.linkedin.venice.meta.HybridStoreConfigImpl.DEFAULT_REAL_TIME_TOPIC_NAME;
 import static com.linkedin.venice.meta.HybridStoreConfigImpl.DEFAULT_REWIND_TIME_IN_SECONDS;
 import static com.linkedin.venice.meta.Store.NON_EXISTING_VERSION;
 import static com.linkedin.venice.meta.Version.PushType;
@@ -4780,7 +4779,6 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
     Optional<Long> hybridTimeLagThreshold = params.getHybridTimeLagThreshold();
     Optional<DataReplicationPolicy> hybridDataReplicationPolicy = params.getHybridDataReplicationPolicy();
     Optional<BufferReplayPolicy> hybridBufferReplayPolicy = params.getHybridBufferReplayPolicy();
-    Optional<String> realTimeTopicName = params.getRealTimeTopicName();
     Optional<Boolean> accessControlled = params.getAccessControlled();
     Optional<CompressionStrategy> compressionStrategy = params.getCompressionStrategy();
     Optional<Boolean> clientDecompressionEnabled = params.getClientDecompressionEnabled();
@@ -4833,8 +4831,7 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
           hybridOffsetLagThreshold,
           hybridTimeLagThreshold,
           hybridDataReplicationPolicy,
-          hybridBufferReplayPolicy,
-          realTimeTopicName);
+          hybridBufferReplayPolicy);
       newHybridStoreConfig = Optional.ofNullable(hybridConfig);
     } else {
       newHybridStoreConfig = Optional.empty();
@@ -5181,8 +5178,7 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
                 hybridStoreConfig.getOffsetLagThresholdToGoOnline(),
                 hybridStoreConfig.getProducerTimestampLagThresholdToGoOnlineInSeconds(),
                 DataReplicationPolicy.NON_AGGREGATE,
-                hybridStoreConfig.getBufferReplayPolicy(),
-                hybridStoreConfig.getRealTimeTopicName()));
+                hybridStoreConfig.getBufferReplayPolicy()));
       }
       return store;
     });
@@ -5244,8 +5240,7 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
       Optional<Long> hybridOffsetLagThreshold,
       Optional<Long> hybridTimeLagThreshold,
       Optional<DataReplicationPolicy> hybridDataReplicationPolicy,
-      Optional<BufferReplayPolicy> bufferReplayPolicy,
-      Optional<String> realTimeTopicName) {
+      Optional<BufferReplayPolicy> bufferReplayPolicy) {
     if (!hybridRewindSeconds.isPresent() && !hybridOffsetLagThreshold.isPresent() && !oldStore.isHybrid()) {
       return null; // For the nullable union in the avro record
     }
@@ -5263,8 +5258,7 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
           hybridDataReplicationPolicy.isPresent()
               ? hybridDataReplicationPolicy.get()
               : oldHybridConfig.getDataReplicationPolicy(),
-          bufferReplayPolicy.isPresent() ? bufferReplayPolicy.get() : oldHybridConfig.getBufferReplayPolicy(),
-          realTimeTopicName.orElseGet(oldHybridConfig::getRealTimeTopicName));
+          bufferReplayPolicy.isPresent() ? bufferReplayPolicy.get() : oldHybridConfig.getBufferReplayPolicy());
     } else {
       // switching a non-hybrid store to hybrid; must specify:
       // 1. rewind time
@@ -5282,8 +5276,7 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
           hybridOffsetLagThreshold.orElse(DEFAULT_HYBRID_OFFSET_LAG_THRESHOLD),
           hybridTimeLagThreshold.orElse(DEFAULT_HYBRID_TIME_LAG_THRESHOLD),
           hybridDataReplicationPolicy.orElse(DataReplicationPolicy.NON_AGGREGATE),
-          bufferReplayPolicy.orElse(BufferReplayPolicy.REWIND_FROM_EOP),
-          realTimeTopicName.orElse(DEFAULT_REAL_TIME_TOPIC_NAME));
+          bufferReplayPolicy.orElse(BufferReplayPolicy.REWIND_FROM_EOP));
     }
     if (mergedHybridStoreConfig.getRewindTimeInSeconds() > 0
         && mergedHybridStoreConfig.getOffsetLagThresholdToGoOnline() < 0
@@ -7850,8 +7843,7 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
           hybridStoreConfigRecord.offsetLagThresholdToGoOnline,
           hybridStoreConfigRecord.producerTimestampLagThresholdToGoOnlineInSeconds,
           DataReplicationPolicy.valueOf(hybridStoreConfigRecord.dataReplicationPolicy),
-          BufferReplayPolicy.valueOf(hybridStoreConfigRecord.bufferReplayPolicy),
-          hybridStoreConfigRecord.realTimeTopicName.toString());
+          BufferReplayPolicy.valueOf(hybridStoreConfigRecord.bufferReplayPolicy));
     }
     return isHybrid(hybridStoreConfig);
   }

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceParentHelixAdmin.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceParentHelixAdmin.java
@@ -47,7 +47,6 @@ import static com.linkedin.venice.controllerapi.ControllerApiConstants.PERSONA_N
 import static com.linkedin.venice.controllerapi.ControllerApiConstants.PUSH_STREAM_SOURCE_ADDRESS;
 import static com.linkedin.venice.controllerapi.ControllerApiConstants.READ_COMPUTATION_ENABLED;
 import static com.linkedin.venice.controllerapi.ControllerApiConstants.READ_QUOTA_IN_CU;
-import static com.linkedin.venice.controllerapi.ControllerApiConstants.REAL_TIME_TOPIC_NAME;
 import static com.linkedin.venice.controllerapi.ControllerApiConstants.REGULAR_VERSION_ETL_ENABLED;
 import static com.linkedin.venice.controllerapi.ControllerApiConstants.REPLICATION_FACTOR;
 import static com.linkedin.venice.controllerapi.ControllerApiConstants.REPLICATION_METADATA_PROTOCOL_VERSION_ID;
@@ -66,7 +65,6 @@ import static com.linkedin.venice.controllerapi.ControllerApiConstants.VERSION;
 import static com.linkedin.venice.controllerapi.ControllerApiConstants.WRITE_COMPUTATION_ENABLED;
 import static com.linkedin.venice.meta.HybridStoreConfigImpl.DEFAULT_HYBRID_OFFSET_LAG_THRESHOLD;
 import static com.linkedin.venice.meta.HybridStoreConfigImpl.DEFAULT_HYBRID_TIME_LAG_THRESHOLD;
-import static com.linkedin.venice.meta.HybridStoreConfigImpl.DEFAULT_REAL_TIME_TOPIC_NAME;
 import static com.linkedin.venice.meta.HybridStoreConfigImpl.DEFAULT_REWIND_TIME_IN_SECONDS;
 import static com.linkedin.venice.meta.Version.VERSION_SEPARATOR;
 import static com.linkedin.venice.meta.VersionStatus.ONLINE;
@@ -2238,7 +2236,6 @@ public class VeniceParentHelixAdmin implements Admin {
       Optional<Long> hybridTimeLagThreshold = params.getHybridTimeLagThreshold();
       Optional<DataReplicationPolicy> hybridDataReplicationPolicy = params.getHybridDataReplicationPolicy();
       Optional<BufferReplayPolicy> hybridBufferReplayPolicy = params.getHybridBufferReplayPolicy();
-      Optional<String> realTimeTopicName = params.getRealTimeTopicName();
       Optional<Boolean> accessControlled = params.getAccessControlled();
       Optional<CompressionStrategy> compressionStrategy = params.getCompressionStrategy();
       Optional<Boolean> clientDecompressionEnabled = params.getClientDecompressionEnabled();
@@ -2424,15 +2421,13 @@ public class VeniceParentHelixAdmin implements Admin {
       hybridTimeLagThreshold.map(addToUpdatedConfigList(updatedConfigsList, TIME_LAG_TO_GO_ONLINE));
       hybridDataReplicationPolicy.map(addToUpdatedConfigList(updatedConfigsList, DATA_REPLICATION_POLICY));
       hybridBufferReplayPolicy.map(addToUpdatedConfigList(updatedConfigsList, BUFFER_REPLAY_POLICY));
-      realTimeTopicName.map(addToUpdatedConfigList(updatedConfigsList, REAL_TIME_TOPIC_NAME));
       HybridStoreConfig updatedHybridStoreConfig = VeniceHelixAdmin.mergeNewSettingsIntoOldHybridStoreConfig(
           currStore,
           hybridRewindSeconds,
           hybridOffsetLagThreshold,
           hybridTimeLagThreshold,
           hybridDataReplicationPolicy,
-          hybridBufferReplayPolicy,
-          realTimeTopicName);
+          hybridBufferReplayPolicy);
 
       // Get VeniceControllerClusterConfig for the cluster
       VeniceControllerClusterConfig controllerConfig =
@@ -2507,7 +2502,6 @@ public class VeniceParentHelixAdmin implements Admin {
             updatedHybridStoreConfig.getProducerTimestampLagThresholdToGoOnlineInSeconds();
         hybridStoreConfigRecord.dataReplicationPolicy = updatedHybridStoreConfig.getDataReplicationPolicy().getValue();
         hybridStoreConfigRecord.bufferReplayPolicy = updatedHybridStoreConfig.getBufferReplayPolicy().getValue();
-        hybridStoreConfigRecord.realTimeTopicName = updatedHybridStoreConfig.getRealTimeTopicName();
         setStore.hybridStoreConfig = hybridStoreConfigRecord;
       }
 
@@ -2528,7 +2522,6 @@ public class VeniceParentHelixAdmin implements Admin {
         updatedConfigsList.add(DATA_REPLICATION_POLICY);
         hybridStoreConfigRecord.bufferReplayPolicy = BufferReplayPolicy.REWIND_FROM_EOP.getValue();
         updatedConfigsList.add(BUFFER_REPLAY_POLICY);
-        hybridStoreConfigRecord.realTimeTopicName = DEFAULT_REAL_TIME_TOPIC_NAME;
         setStore.hybridStoreConfig = hybridStoreConfigRecord;
       }
 

--- a/services/venice-controller/src/test/java/com/linkedin/venice/controller/TestVeniceHelixAdminWithoutCluster.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/controller/TestVeniceHelixAdminWithoutCluster.java
@@ -48,10 +48,8 @@ public class TestVeniceHelixAdminWithoutCluster {
     Optional<Long> timeLag = Optional.of(300L);
     Optional<DataReplicationPolicy> dataReplicationPolicy = Optional.of(DataReplicationPolicy.AGGREGATE);
     Optional<BufferReplayPolicy> bufferReplayPolicy = Optional.of(BufferReplayPolicy.REWIND_FROM_EOP);
-    Optional<String> realTimeTopicName = Optional.of("storeName_rt");
     HybridStoreConfig hybridStoreConfig = VeniceHelixAdmin.mergeNewSettingsIntoOldHybridStoreConfig(
         store,
-        Optional.empty(),
         Optional.empty(),
         Optional.empty(),
         Optional.empty(),
@@ -67,8 +65,7 @@ public class TestVeniceHelixAdminWithoutCluster {
         lagOffset,
         timeLag,
         dataReplicationPolicy,
-        bufferReplayPolicy,
-        realTimeTopicName);
+        bufferReplayPolicy);
     Assert.assertNotNull(hybridStoreConfig, "specifying rewind and lagOffset should generate a valid hybrid config");
     Assert.assertEquals(hybridStoreConfig.getRewindTimeInSeconds(), 123L);
     Assert.assertEquals(hybridStoreConfig.getOffsetLagThresholdToGoOnline(), 1500L);
@@ -80,7 +77,6 @@ public class TestVeniceHelixAdminWithoutCluster {
         store,
         rewind,
         lagOffset,
-        Optional.empty(),
         Optional.empty(),
         Optional.empty(),
         Optional.empty());

--- a/services/venice-controller/src/test/java/com/linkedin/venice/controller/kafka/consumer/AdminConsumptionTaskTest.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/controller/kafka/consumer/AdminConsumptionTaskTest.java
@@ -18,7 +18,6 @@ import static com.linkedin.venice.controllerapi.ControllerApiConstants.STORE_MIG
 import static com.linkedin.venice.controllerapi.ControllerApiConstants.TIME_LAG_TO_GO_ONLINE;
 import static com.linkedin.venice.controllerapi.ControllerApiConstants.VERSION;
 import static com.linkedin.venice.controllerapi.ControllerApiConstants.WRITE_COMPUTATION_ENABLED;
-import static com.linkedin.venice.meta.HybridStoreConfigImpl.DEFAULT_REAL_TIME_TOPIC_NAME;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.anyBoolean;
 import static org.mockito.Mockito.anyDouble;
@@ -932,7 +931,6 @@ public class AdminConsumptionTaskTest {
     hybridConfig.offsetLagThresholdToGoOnline = 1000L;
     hybridConfig.producerTimestampLagThresholdToGoOnlineInSeconds = 300L;
     hybridConfig.dataReplicationPolicy = DataReplicationPolicy.AGGREGATE.getValue();
-    hybridConfig.realTimeTopicName = DEFAULT_REAL_TIME_TOPIC_NAME;
     setStore.hybridStoreConfig = hybridConfig;
 
     ETLStoreConfigRecord etlStoreConfig = new ETLStoreConfigRecord();


### PR DESCRIPTION


<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## Reverts a commit that throws NPE
<!--
Describe
- What changes to make and why you are making these changes.
- How are you going to achieve your goal.
- Describe what testings you have done, for example, performance testing etc.

If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

This reverts commit cc6e3db6f898a0c5efd1aa18847511b113525ab5.  PR https://github.com/linkedin/venice/pull/1345 
because that commits throws NPE 

`Caused by: java.lang.NullPointerException: Cannot invoke "java.lang.CharSequence.toString()" because "this.hybridConfig.realTimeTopicName" is null
        at com.linkedin.venice.meta.HybridStoreConfigImpl.getRealTimeTopicName(HybridStoreConfigImpl.java:108) ~[com.linkedin.venice.venice-common-0.4.368.jar:?]
        at com.linkedin.venice.meta.HybridStoreConfigImpl.clone(HybridStoreConfigImpl.java:146) ~[com.linkedin.venice.venice-common-0.4.368.jar:?]
        at com.linkedin.venice.meta.ZKStore.<init>(ZKStore.java:186) ~[com.linkedin.venice.venice-common-0.4.368.jar:?]
        at com.linkedin.venice.meta.ZKStore.cloneStore(ZKStore.java:969) ~[com.linkedin.venice.venice-common-0.4.368.jar:?]
        at com.linkedin.venice.helix.HelixReadWriteStoreRepository.lambda$getAllStores$0(HelixReadWriteStoreRepository.java:96) ~[com.linkedin.venice.venice-common-0.4.368.jar:?]
        at java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:197) ~[?:?]
        at java.util.concurrent.ConcurrentHashMap$ValueSpliterator.forEachRemaining(ConcurrentHashMap.java:3612) ~[?:?]
        at java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:509) ~[?:?]
        at java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:499) ~[?:?]
        at java.util.stream.ReduceOps$ReduceOp.evaluateSequential(ReduceOps.java:921) ~[?:?]
        at java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234) ~[?:?]
        at java.util.stream.ReferencePipeline.collect(ReferencePipeline.java:682) ~[?:?]
        at com.linkedin.venice.helix.HelixReadWriteStoreRepository.getAllStores(HelixReadWriteStoreRepository.java:96) ~[com.linkedin.venice.venice-common-0.4.368.jar:?]
        at com.linkedin.venice.helix.HelixReadOnlyStoreRepositoryAdapter.getAllStores(HelixReadOnlyStoreRepositoryAdapter.java:127) ~[com.linkedin.venice.venice-common-0.4.368.jar:?]
        at com.linkedin.venice.controller.HelixVeniceClusterResources.repairStoreReplicationFactor(HelixVeniceClusterResources.java:215) ~[com.linkedin.venice.venice-controller-0.4.368.jar:?]
        at com.linkedin.venice.controller.HelixVeniceClusterResources.refresh(HelixVeniceClusterResources.java:244) ~[com.linkedin.venice.venice-controller-0.4.368.jar:?]
        at com.linkedin.venice.controller.VeniceControllerStateModel.initClusterResources(VeniceControllerStateModel.java:195) ~[com.linkedin.venice.venice-controller-0.4.368.jar:?]
        at com.linkedin.venice.controller.VeniceControllerStateModel.lambda$onBecomeLeaderFromStandby$0(VeniceControllerStateModel.java:150) ~[com.linkedin.venice.venice-controller-0.4.368.jar:?]
        at com.linkedin.venice.controller.VeniceControllerStateModel.executeStateTransition(VeniceControllerStateModel.java:111) ~[com.linkedin.venice.venice-controller-0.4.368.jar:?]
        at com.linkedin.venice.controller.VeniceControllerStateModel.onBecomeLeaderFromStandby(VeniceControllerStateModel.java:129) ~[com.linkedin.venice.venice-controller-0.4.368.jar:?]
        ... 12 more`

Resolves #XXX

## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.