### PR TITLE
[controller] do not delay RT topic deletion if the store is no longer hybrid

### DIFF
--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/controller/AbstractTestVeniceHelixAdmin.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/controller/AbstractTestVeniceHelixAdmin.java
@@ -13,10 +13,13 @@ import static com.linkedin.venice.ConfigKeys.DEFAULT_PARTITION_SIZE;
 import static com.linkedin.venice.ConfigKeys.KAFKA_BOOTSTRAP_SERVERS;
 import static com.linkedin.venice.ConfigKeys.KAFKA_REPLICATION_FACTOR;
 import static com.linkedin.venice.ConfigKeys.PARTICIPANT_MESSAGE_STORE_ENABLED;
+import static com.linkedin.venice.ConfigKeys.TOPIC_CLEANUP_SLEEP_INTERVAL_BETWEEN_TOPIC_LIST_FETCH_MS;
 import static com.linkedin.venice.ConfigKeys.UNREGISTER_METRIC_FOR_DELETED_STORE_ENABLED;
 import static com.linkedin.venice.ConfigKeys.ZOOKEEPER_ADDRESS;
 
 import com.linkedin.venice.common.VeniceSystemStoreUtils;
+import com.linkedin.venice.controller.kafka.TopicCleanupService;
+import com.linkedin.venice.controller.stats.TopicCleanupServiceStats;
 import com.linkedin.venice.exceptions.VeniceException;
 import com.linkedin.venice.helix.HelixAdapterSerializer;
 import com.linkedin.venice.helix.SafeHelixManager;
@@ -94,6 +97,7 @@ class AbstractTestVeniceHelixAdmin {
     }
     properties.put(UNREGISTER_METRIC_FOR_DELETED_STORE_ENABLED, true);
     properties.put(CONTROLLER_INSTANCE_TAG_LIST, "GENERAL,TEST");
+    properties.put(TOPIC_CLEANUP_SLEEP_INTERVAL_BETWEEN_TOPIC_LIST_FETCH_MS, 100);
     controllerProps = new VeniceProperties(properties);
     helixMessageChannelStats = new HelixMessageChannelStats(new MetricsRepository(), clusterName);
     controllerConfig = new VeniceControllerClusterConfig(controllerProps);
@@ -105,6 +109,13 @@ class AbstractTestVeniceHelixAdmin {
         pubSubTopicRepository,
         pubSubBrokerWrapper.getPubSubClientsFactory());
     veniceAdmin.initStorageCluster(clusterName);
+    TopicCleanupService topicCleanupService = new TopicCleanupService(
+        veniceAdmin,
+        multiClusterConfig,
+        pubSubTopicRepository,
+        new TopicCleanupServiceStats(metricsRepository),
+        pubSubBrokerWrapper.getPubSubClientsFactory());
+    topicCleanupService.start();
     startParticipant();
     waitUntilIsLeader(veniceAdmin, clusterName, LEADER_CHANGE_TIMEOUT_MS);
 

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/controller/TestParentControllerWithMultiDataCenter.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/controller/TestParentControllerWithMultiDataCenter.java
@@ -7,11 +7,13 @@ import static com.linkedin.venice.utils.IntegrationTestPushUtils.createStoreForJ
 import static com.linkedin.venice.utils.TestWriteUtils.getTempDataDirectory;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.DEFER_VERSION_SWAP;
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
 import static org.testng.AssertJUnit.fail;
 
 import com.linkedin.venice.common.VeniceSystemStoreUtils;
 import com.linkedin.venice.controllerapi.ControllerClient;
 import com.linkedin.venice.controllerapi.ControllerResponse;
+import com.linkedin.venice.controllerapi.JobStatusQueryResponse;
 import com.linkedin.venice.controllerapi.NewStoreResponse;
 import com.linkedin.venice.controllerapi.SchemaResponse;
 import com.linkedin.venice.controllerapi.StoreResponse;
@@ -20,17 +22,20 @@ import com.linkedin.venice.controllerapi.VersionCreationResponse;
 import com.linkedin.venice.integration.utils.ServiceFactory;
 import com.linkedin.venice.integration.utils.VeniceMultiClusterWrapper;
 import com.linkedin.venice.integration.utils.VeniceTwoLayerMultiRegionMultiClusterWrapper;
+import com.linkedin.venice.meta.BackupStrategy;
 import com.linkedin.venice.meta.BufferReplayPolicy;
 import com.linkedin.venice.meta.Store;
 import com.linkedin.venice.meta.StoreInfo;
 import com.linkedin.venice.meta.Version;
 import com.linkedin.venice.pubsub.PubSubTopicRepository;
+import com.linkedin.venice.pubsub.api.PubSubTopic;
 import com.linkedin.venice.pubsub.manager.TopicManager;
 import com.linkedin.venice.schema.rmd.RmdSchemaEntry;
 import com.linkedin.venice.schema.rmd.RmdSchemaGenerator;
 import com.linkedin.venice.utils.IntegrationTestPushUtils;
 import com.linkedin.venice.utils.TestUtils;
 import com.linkedin.venice.utils.TestWriteUtils;
+import com.linkedin.venice.utils.Time;
 import com.linkedin.venice.utils.Utils;
 import java.io.File;
 import java.io.IOException;
@@ -91,6 +96,123 @@ public class TestParentControllerWithMultiDataCenter {
   @AfterClass(alwaysRun = true)
   public void cleanUp() {
     Utils.closeQuietlyWithErrorLogged(multiRegionMultiClusterWrapper);
+  }
+
+  @Test(timeOut = TEST_TIMEOUT)
+  public void testRTTopicDeletionWithHybridAndIncrementalVersions() {
+    String storeName = Utils.getUniqueString("testRTTopicDeletion");
+    String clusterName = CLUSTER_NAMES[0];
+    String rtTopicName = Version.composeRealTimeTopic(storeName);
+    PubSubTopic rtPubSubTopic = new PubSubTopicRepository().getTopic(rtTopicName);
+    String parentControllerURLs = multiRegionMultiClusterWrapper.getControllerConnectString();
+    ControllerClient parentControllerClient =
+        ControllerClient.constructClusterControllerClient(clusterName, parentControllerURLs);
+    ControllerClient[] childControllerClients = new ControllerClient[childDatacenters.size()];
+    for (int i = 0; i < childDatacenters.size(); i++) {
+      childControllerClients[i] =
+          new ControllerClient(clusterName, childDatacenters.get(i).getControllerConnectString());
+    }
+
+    List<TopicManager> topicManagers = new ArrayList<>(2);
+    topicManagers
+        .add(childDatacenters.get(0).getControllers().values().iterator().next().getVeniceAdmin().getTopicManager());
+    topicManagers
+        .add(childDatacenters.get(1).getControllers().values().iterator().next().getVeniceAdmin().getTopicManager());
+
+    NewStoreResponse newStoreResponse =
+        parentControllerClient.retryableRequest(5, c -> c.createNewStore(storeName, "", "\"string\"", "\"string\""));
+    Assert.assertFalse(
+        newStoreResponse.isError(),
+        "The NewStoreResponse returned an error: " + newStoreResponse.getError());
+
+    UpdateStoreQueryParams updateStoreParams = new UpdateStoreQueryParams();
+    updateStoreParams.setIncrementalPushEnabled(true)
+        .setBackupStrategy(BackupStrategy.KEEP_MIN_VERSIONS)
+        .setNumVersionsToPreserve(2)
+        .setHybridRewindSeconds(1000)
+        .setHybridOffsetLagThreshold(1000);
+    TestWriteUtils.updateStore(storeName, parentControllerClient, updateStoreParams);
+
+    // create new version by doing an empty push
+    ControllerResponse response = parentControllerClient
+        .sendEmptyPushAndWait(storeName, Utils.getUniqueString("empty-push"), 1L, 60L * Time.MS_PER_SECOND);
+    PubSubTopic versionPubsubTopic = getVersionPubsubTopic(storeName, response);
+
+    for (TopicManager topicManager: topicManagers) {
+      Assert.assertTrue(topicManager.containsTopic(versionPubsubTopic));
+      Assert.assertTrue(topicManager.containsTopic(rtPubSubTopic));
+    }
+    for (ControllerClient controllerClient: childControllerClients) {
+      Assert.assertEquals(controllerClient.getStore(storeName).getStore().getCurrentVersion(), 1);
+    }
+
+    // create new version by doing an empty push
+    response = parentControllerClient
+        .sendEmptyPushAndWait(storeName, Utils.getUniqueString("empty-push"), 1L, 60L * Time.MS_PER_SECOND);
+    versionPubsubTopic = getVersionPubsubTopic(storeName, response);
+
+    for (TopicManager topicManager: topicManagers) {
+      Assert.assertTrue(topicManager.containsTopic(versionPubsubTopic));
+      Assert.assertTrue(topicManager.containsTopic(rtPubSubTopic));
+    }
+    for (ControllerClient controllerClient: childControllerClients) {
+      Assert.assertEquals(controllerClient.getStore(storeName).getStore().getCurrentVersion(), 2);
+    }
+
+    // change store from hybrid to batch-only
+    UpdateStoreQueryParams params = new UpdateStoreQueryParams();
+    params.setHybridRewindSeconds(-1).setHybridTimeLagThreshold(-1).setHybridOffsetLagThreshold(-1);
+    TestWriteUtils.updateStore(storeName, parentControllerClient, params);
+
+    // create new version by doing an empty push
+    response = parentControllerClient
+        .sendEmptyPushAndWait(storeName, Utils.getUniqueString("empty-push"), 1L, 60L * Time.MS_PER_SECOND);
+
+    // at this point, the current version should be batch-only, but the older version should be hybrid, so rt topic
+    // should not get deleted
+    versionPubsubTopic = getVersionPubsubTopic(storeName, response);
+
+    for (ControllerClient controllerClient: childControllerClients) {
+      StoreInfo storeInfo = controllerClient.getStore(storeName).getStore();
+      int currentVersion = storeInfo.getCurrentVersion();
+      Assert.assertEquals(currentVersion, 3);
+      Assert.assertNull(storeInfo.getVersion(currentVersion).get().getHybridStoreConfig());
+      Assert.assertNotNull(storeInfo.getVersion(currentVersion - 1).get().getHybridStoreConfig());
+    }
+
+    for (TopicManager topicManager: topicManagers) {
+      Assert.assertTrue(topicManager.containsTopic(versionPubsubTopic));
+      Assert.assertTrue(topicManager.containsTopic(rtPubSubTopic));
+    }
+
+    // create new version by doing an empty push
+    response = parentControllerClient
+        .sendEmptyPushAndWait(storeName, Utils.getUniqueString("empty-push"), 1L, 60L * Time.MS_PER_SECOND);
+    versionPubsubTopic = getVersionPubsubTopic(storeName, response);
+    for (ControllerClient controllerClient: childControllerClients) {
+      Assert.assertEquals(controllerClient.getStore(storeName).getStore().getCurrentVersion(), 4);
+    }
+
+    // now both the versions should be batch-only, so rt topic should get deleted by TopicCleanupService
+    for (TopicManager topicManager: topicManagers) {
+      Assert.assertTrue(topicManager.containsTopic(versionPubsubTopic));
+      TestUtils.waitForNonDeterministicAssertion(
+          30,
+          TimeUnit.SECONDS,
+          true,
+          true,
+          () -> Assert.assertFalse(topicManager.containsTopic(rtPubSubTopic)));
+    }
+
+    /*
+     todo - RT topics are not used in parent controller in the current architecture, so we can ignore any RT topics in parent
+     controller that exist because they are still on old architecture.
+    
+      TestUtils.waitForNonDeterministicAssertion(60, TimeUnit.SECONDS, true,  true, () -> {
+        Assert.assertFalse(parentTopicManager.containsTopic(rtPubSubTopic));
+      }
+     );
+    */
   }
 
   @Test(timeOut = TEST_TIMEOUT)
@@ -564,5 +686,16 @@ public class TestParentControllerWithMultiDataCenter {
         assertEquals(storeInfo.getCurrentVersion(), expectedVersion);
       });
     }
+  }
+
+  static PubSubTopic getVersionPubsubTopic(String storeName, ControllerResponse response) {
+    assertFalse(response.isError(), "Failed to perform empty push on test store");
+    String versionTopic = null;
+    if (response instanceof VersionCreationResponse) {
+      versionTopic = ((VersionCreationResponse) response).getKafkaTopic();
+    } else if (response instanceof JobStatusQueryResponse) {
+      versionTopic = Version.composeKafkaTopic(storeName, ((JobStatusQueryResponse) response).getVersion());
+    }
+    return new PubSubTopicRepository().getTopic(versionTopic);
   }
 }

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/Admin.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/Admin.java
@@ -538,6 +538,8 @@ public interface Admin extends AutoCloseable, Closeable {
       List<String> toBeStoppedInstances,
       boolean isSSLEnabled);
 
+  boolean isRTTopicDeletionPermittedByAllControllers(String clusterName, Store store);
+
   /**
    * Check if this controller itself is the leader controller for a given cluster or not. Note that the controller can be
    * either a parent controller or a child controller since a cluster must have a leader child controller and a leader

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/Admin.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/Admin.java
@@ -538,7 +538,7 @@ public interface Admin extends AutoCloseable, Closeable {
       List<String> toBeStoppedInstances,
       boolean isSSLEnabled);
 
-  boolean isRTTopicDeletionPermittedByAllControllers(String clusterName, Store store);
+  boolean isRTTopicDeletionPermittedByAllControllers(String clusterName, String storeName);
 
   /**
    * Check if this controller itself is the leader controller for a given cluster or not. Note that the controller can be

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceHelixAdmin.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceHelixAdmin.java
@@ -3517,7 +3517,7 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
       PubSubTopic rtTopic = pubSubTopicRepository.getTopic(Version.composeRealTimeTopic(storeName));
       if (!store.isHybrid() && getTopicManager().containsTopic(rtTopic)) {
         store = resources.getStoreMetadataRepository().getStore(storeName);
-        safeDeleteRTTopic(clusterName, storeName, store);
+        safeDeleteRTTopic(clusterName, store);
       }
     }
   }
@@ -3532,17 +3532,29 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
     }
   }
 
-  private void safeDeleteRTTopic(String clusterName, String storeName, Store store) {
+  private void safeDeleteRTTopic(String clusterName, Store store) {
+    if (isRTTopicDeletionPermittedByAllControllers(clusterName, store)) {
+      deleteRTTopic(clusterName, store.getName());
+    }
+  }
+
+  public boolean isRTTopicDeletionPermittedByAllControllers(String clusterName, Store store) {
     // Perform RT cleanup checks for batch only store that used to be hybrid. Check the local versions first
     // to see if any version is still using RT and then also check other fabrics before deleting the RT. Since
     // we perform this check everytime when a store version is deleted we can afford to do best effort
     // approach if some fabrics are unavailable or out of sync (temporarily).
-    boolean canDeleteRT = !Version.containsHybridVersion(store.getVersions());
+    String storeName = store.getName();
+    String rtTopicName = Version.composeRealTimeTopic(storeName);
+    if (Version.containsHybridVersion(store.getVersions())) {
+      LOGGER.warn(
+          "Topic {} cannot be deleted yet because the store {} has at least one hybrid version",
+          rtTopicName,
+          storeName);
+      return false;
+    }
+
     Map<String, ControllerClient> controllerClientMap = getControllerClientMap(clusterName);
     for (Map.Entry<String, ControllerClient> controllerClientEntry: controllerClientMap.entrySet()) {
-      if (!canDeleteRT) {
-        return;
-      }
       StoreResponse storeResponse = controllerClientEntry.getValue().getStore(storeName);
       if (storeResponse.isError()) {
         LOGGER.warn(
@@ -3551,24 +3563,37 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
             clusterName,
             controllerClientEntry.getKey(),
             storeResponse.getError());
-        return;
+        return false;
       }
-      canDeleteRT = !Version.containsHybridVersion(storeResponse.getStore().getVersions());
+      if (Version.containsHybridVersion(storeResponse.getStore().getVersions())) {
+        LOGGER.warn(
+            "Topic {} cannot be deleted yet because the store {} has at least one hybrid version",
+            rtTopicName,
+            storeName);
+        return false;
+      }
     }
-    if (canDeleteRT) {
-      String rtTopicToDelete = Version.composeRealTimeTopic(storeName);
-      truncateKafkaTopic(rtTopicToDelete);
-      for (ControllerClient controllerClient: controllerClientMap.values()) {
-        controllerClient.deleteKafkaTopic(rtTopicToDelete);
-      }
-      // Check if there is incremental push topic exist. If yes, delete it and send out to let other controller to
-      // delete it.
-      String incrementalPushRTTopicToDelete = Version.composeSeparateRealTimeTopic(storeName);
-      if (getTopicManager().containsTopic(pubSubTopicRepository.getTopic(incrementalPushRTTopicToDelete))) {
-        truncateKafkaTopic(incrementalPushRTTopicToDelete);
-        for (ControllerClient controllerClient: controllerClientMap.values()) {
-          controllerClient.deleteKafkaTopic(incrementalPushRTTopicToDelete);
-        }
+    return true;
+  }
+
+  private void deleteRTTopic(String clusterName, String storeName) {
+    Map<String, ControllerClient> controllerClientMap = getControllerClientMap(clusterName);
+    String rtTopicToDelete = Version.composeRealTimeTopic(storeName);
+    deleteRTTopicFromAllFabrics(rtTopicToDelete, controllerClientMap);
+    // Check if there is incremental push topic exist. If yes, delete it and send out to let other controller to
+    // delete it.
+    String incrementalPushRTTopicToDelete = Version.composeSeparateRealTimeTopic(storeName);
+    if (getTopicManager().containsTopic(pubSubTopicRepository.getTopic(incrementalPushRTTopicToDelete))) {
+      deleteRTTopicFromAllFabrics(incrementalPushRTTopicToDelete, controllerClientMap);
+    }
+  }
+
+  private void deleteRTTopicFromAllFabrics(String topic, Map<String, ControllerClient> controllerClientMap) {
+    truncateKafkaTopic(topic);
+    for (ControllerClient controllerClient: controllerClientMap.values()) {
+      ControllerResponse deleteResponse = controllerClient.deleteKafkaTopic(topic);
+      if (deleteResponse.isError()) {
+        LOGGER.error("Deleting real time topic " + topic + " encountered error " + deleteResponse.getError());
       }
     }
   }
@@ -7440,7 +7465,7 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
     if (storeName.isPresent()) {
       /**
        * Legacy stores venice_system_store_davinci_push_status_store_<cluster_name> still exist.
-       * But {@link com.linkedin.venice.helix.HelixReadOnlyStoreRepositoryAdapter#getStore(String)} cannot find
+       * But {@link HelixReadOnlyStoreRepositoryAdapter#getStore(String)} cannot find
        * them by store names. Skip davinci push status stores until legacy znodes are cleaned up.
        */
       VeniceSystemStoreType systemStoreType = VeniceSystemStoreType.getSystemStoreType(storeName.get());

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceHelixAdmin.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceHelixAdmin.java
@@ -3532,15 +3532,16 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
   }
 
   private void safeDeleteRTTopic(String clusterName, String storeName) {
-    if (isRTTopicDeletionPermittedByAllControllers(clusterName, storeName)) {
+    boolean rtDeletionPermitted = isRTTopicDeletionPermittedByAllControllers(clusterName, storeName);
+    if (rtDeletionPermitted) {
       String rtTopicToDelete = Version.composeRealTimeTopic(storeName);
       deleteRTTopicFromAllFabrics(rtTopicToDelete, clusterName);
-    }
-    // Check if there is incremental push topic exist. If yes, delete it and send out to let other controller to
-    // delete it.
-    String incrementalPushRTTopicToDelete = Version.composeSeparateRealTimeTopic(storeName);
-    if (getTopicManager().containsTopic(pubSubTopicRepository.getTopic(incrementalPushRTTopicToDelete))) {
-      deleteRTTopicFromAllFabrics(incrementalPushRTTopicToDelete, clusterName);
+      // Check if there is incremental push topic exist. If yes, delete it and send out to let other controller to
+      // delete it.
+      String incrementalPushRTTopicToDelete = Version.composeSeparateRealTimeTopic(storeName);
+      if (getTopicManager().containsTopic(pubSubTopicRepository.getTopic(incrementalPushRTTopicToDelete))) {
+        deleteRTTopicFromAllFabrics(incrementalPushRTTopicToDelete, clusterName);
+      }
     }
   }
 

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceParentHelixAdmin.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceParentHelixAdmin.java
@@ -3868,6 +3868,11 @@ public class VeniceParentHelixAdmin implements Admin {
     throw new VeniceUnsupportedOperationException("getAggregatedHealthStatus");
   }
 
+  @Override
+  public boolean isRTTopicDeletionPermittedByAllControllers(String clusterName, Store store) {
+    return false;
+  }
+
   /**
    * @see VeniceHelixAdmin#isLeaderControllerFor(String)
    */

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceParentHelixAdmin.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceParentHelixAdmin.java
@@ -3869,7 +3869,7 @@ public class VeniceParentHelixAdmin implements Admin {
   }
 
   @Override
-  public boolean isRTTopicDeletionPermittedByAllControllers(String clusterName, Store store) {
+  public boolean isRTTopicDeletionPermittedByAllControllers(String clusterName, String storeName) {
     return false;
   }
 

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/kafka/TopicCleanupService.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/kafka/TopicCleanupService.java
@@ -76,12 +76,8 @@ public class TopicCleanupService extends AbstractVeniceService {
   private final int minNumberOfUnusedKafkaTopicsToPreserve;
   private final AtomicBoolean stop = new AtomicBoolean(false);
   private final AtomicBoolean stopped = new AtomicBoolean(false);
-  private final Set<String> childRegions;
-  private final Map<String, Map<String, Integer>> multiDataCenterStoreToVersionTopicCount;
   private final PubSubTopicRepository pubSubTopicRepository;
   private final TopicCleanupServiceStats topicCleanupServiceStats;
-  private String localDatacenter;
-  private boolean isRTTopicDeletionBlocked = false;
   private boolean isLeaderControllerOfControllerCluster = false;
   private long refreshQueueCycle = Time.MS_PER_MINUTE;
 
@@ -109,23 +105,13 @@ public class TopicCleanupService extends AbstractVeniceService {
     this.multiClusterConfigs = multiClusterConfigs;
     this.pubSubTopicRepository = pubSubTopicRepository;
     this.topicCleanupServiceStats = topicCleanupServiceStats;
-    this.childRegions = multiClusterConfigs.getCommonConfig().getChildDatacenters();
-    if (!admin.isParent()) {
-      // Only perform cross fabric VT check for RT deletion in child fabrics.
-      this.multiDataCenterStoreToVersionTopicCount = new HashMap<>(childRegions.size());
-      for (String datacenter: childRegions) {
-        multiDataCenterStoreToVersionTopicCount.put(datacenter, new HashMap<>());
-      }
-    } else {
-      this.multiDataCenterStoreToVersionTopicCount = Collections.emptyMap();
-    }
 
     this.danglingTopicCleanupIntervalMs =
         Time.MS_PER_SECOND * multiClusterConfigs.getDanglingTopicCleanupIntervalSeconds();
 
-    PubSubAdminAdapterFactory sourceOfTruthAdminAdapterFactory =
+    PubSubAdminAdapterFactory<?> sourceOfTruthAdminAdapterFactory =
         multiClusterConfigs.getSourceOfTruthAdminAdapterFactory();
-    PubSubAdminAdapterFactory pubSubAdminAdapterFactory = pubSubClientsFactory.getAdminAdapterFactory();
+    PubSubAdminAdapterFactory<?> pubSubAdminAdapterFactory = pubSubClientsFactory.getAdminAdapterFactory();
     this.danglingTopicOccurrenceCounter = new HashMap<>();
     this.danglingTopicOccurrenceThresholdForCleanup =
         multiClusterConfigs.getDanglingTopicOccurrenceThresholdForCleanup();
@@ -138,7 +124,7 @@ public class TopicCleanupService extends AbstractVeniceService {
   }
 
   private PubSubAdminAdapter constructSourceOfTruthPubSubAdminAdapter(
-      PubSubAdminAdapterFactory sourceOfTruthAdminAdapterFactory) {
+      PubSubAdminAdapterFactory<?> sourceOfTruthAdminAdapterFactory) {
     VeniceProperties veniceProperties = admin.getPubSubSSLProperties(getTopicManager().getPubSubClusterAddress());
     return sourceOfTruthAdminAdapterFactory.create(veniceProperties, pubSubTopicRepository);
   }
@@ -180,7 +166,7 @@ public class TopicCleanupService extends AbstractVeniceService {
     return this.stopped.get();
   }
 
-  TopicManager getTopicManager() {
+  final TopicManager getTopicManager() {
     return admin.getTopicManager();
   }
 
@@ -239,45 +225,35 @@ public class TopicCleanupService extends AbstractVeniceService {
     populateDeprecatedTopicQueue(allTopics);
     topicCleanupServiceStats.recordDeletableTopicsCount(allTopics.size());
     long refreshTime = System.currentTimeMillis();
+
     while (!allTopics.isEmpty()) {
       PubSubTopic topic = allTopics.poll();
+      String storeName = topic.getStoreName();
+      String clusterDiscovered;
+      Store store;
       try {
-        if (topic.isRealTime() && !multiDataCenterStoreToVersionTopicCount.isEmpty()) {
-          // Only delete realtime topic in child fabrics if all version topics are deleted in all child fabrics.
-          if (isRTTopicDeletionBlocked) {
-            LOGGER.warn(
-                "Topic deletion for topic: {} is blocked due to unable to fetch version topic info",
-                topic.getName());
-            topicCleanupServiceStats.recordTopicDeletionError();
-            continue;
-          }
-          boolean canDelete = true;
-          for (Map.Entry<String, Map<String, Integer>> mapEntry: multiDataCenterStoreToVersionTopicCount.entrySet()) {
-            if (mapEntry.getValue().containsKey(topic.getStoreName())) {
-              canDelete = false;
-              LOGGER.info(
-                  "Topic deletion for topic: {} is delayed due to {} version topics found in datacenter {}",
-                  topic.getName(),
-                  mapEntry.getValue().get(topic.getStoreName()),
-                  mapEntry.getKey());
-              break;
-            }
-          }
-          if (!canDelete) {
-            continue;
-          }
-        }
-        getTopicManager().ensureTopicIsDeletedAndBlockWithRetry(topic);
-        topicCleanupServiceStats.recordTopicDeleted();
-      } catch (VeniceException e) {
-        LOGGER.warn("Caught exception when trying to delete topic: {} - {}", topic.getName(), e.toString());
-        topicCleanupServiceStats.recordTopicDeletionError();
-        // No op, will try again in the next cleanup cycle.
+        clusterDiscovered = admin.discoverCluster(storeName).getFirst();
+        store = admin.getStore(clusterDiscovered, storeName);
+      } catch (VeniceNoStoreException e) {
+        LOGGER.warn(
+            "Store {} not found. Exception when trying to delete topic: {} - {}",
+            storeName,
+            topic.getName(),
+            e.toString());
+        deleteTopic(topic);
+        continue;
+      }
+
+      if (!topic.isRealTime() || admin.isRTTopicDeletionPermittedByAllControllers(clusterDiscovered, store)) {
+        // delete if it is a VT topic or an RT topic eligible for deletion by the above condition
+        deleteTopic(topic);
+      } else {
+        LOGGER.warn("Topic deletion for topic: {} is delayed.", topic.getName());
       }
 
       if (!topic.isRealTime()) {
         // If Version topic deletion took long time, skip further VT deletion and check if we have new RT topic to
-        // delete
+        // delete. Some new RT topics might have become eligible for deletion in this period.
         if (System.currentTimeMillis() - refreshTime > refreshQueueCycle) {
           allTopics.clear();
           populateDeprecatedTopicQueue(allTopics);
@@ -290,10 +266,20 @@ public class TopicCleanupService extends AbstractVeniceService {
     }
   }
 
+  private void deleteTopic(PubSubTopic topic) {
+    try {
+      getTopicManager().ensureTopicIsDeletedAndBlockWithRetry(topic);
+      topicCleanupServiceStats.recordTopicDeleted();
+    } catch (VeniceException e) {
+      LOGGER.warn("Caught exception when trying to delete topic: {} - {}", topic.getName(), e.toString());
+      topicCleanupServiceStats.recordTopicDeletionError();
+      // No op, will try again in the next cleanup cycle.
+    }
+  }
+
   private void populateDeprecatedTopicQueue(PriorityQueue<PubSubTopic> topics) {
     Map<PubSubTopic, Long> topicsWithRetention = getTopicManager().getAllTopicRetentions();
     Map<String, Map<PubSubTopic, Long>> allStoreTopics = getAllVeniceStoreTopicsRetentions(topicsWithRetention);
-    AtomicBoolean realTimeTopicDeletionNeeded = new AtomicBoolean(false);
     allStoreTopics.forEach((storeName, topicRetentions) -> {
       int minNumOfUnusedVersionTopicsOverride = minNumberOfUnusedKafkaTopicsToPreserve;
       PubSubTopic realTimeTopic = pubSubTopicRepository.getTopic(Version.composeRealTimeTopic(storeName));
@@ -301,7 +287,6 @@ public class TopicCleanupService extends AbstractVeniceService {
         if (admin.isTopicTruncatedBasedOnRetention(topicRetentions.get(realTimeTopic))) {
           topics.offer(realTimeTopic);
           minNumOfUnusedVersionTopicsOverride = 0;
-          realTimeTopicDeletionNeeded.set(true);
         }
         topicRetentions.remove(realTimeTopic);
       }
@@ -311,9 +296,6 @@ public class TopicCleanupService extends AbstractVeniceService {
         topics.addAll(oldTopicsToDelete);
       }
     });
-    if (realTimeTopicDeletionNeeded.get() && !multiDataCenterStoreToVersionTopicCount.isEmpty()) {
-      refreshMultiDataCenterStoreToVersionTopicCountMap(topicsWithRetention.keySet());
-    }
 
     // Check if there are dangling topics to be deleted.
     if (sourceOfTruthPubSubAdminAdapter != null
@@ -324,60 +306,6 @@ public class TopicCleanupService extends AbstractVeniceService {
       }
       recentDanglingTopicCleanupTime = System.currentTimeMillis();
       topics.addAll(pubSubTopics);
-    }
-  }
-
-  private void refreshMultiDataCenterStoreToVersionTopicCountMap(Set<PubSubTopic> localTopics) {
-    if (localDatacenter == null) {
-      String localPubSubBootstrapServer = getTopicManager().getPubSubClusterAddress();
-      for (String childFabric: childRegions) {
-        if (localPubSubBootstrapServer.equals(multiClusterConfigs.getChildDataCenterKafkaUrlMap().get(childFabric))) {
-          localDatacenter = childFabric;
-          break;
-        }
-      }
-      if (localDatacenter == null) {
-        String childFabrics = String.join(",", childRegions);
-        LOGGER.error(
-            "Blocking RT topic deletion. Cannot find local datacenter in child datacenter list: {}",
-            childFabrics);
-        isRTTopicDeletionBlocked = true;
-        return;
-      }
-    }
-    clearAndPopulateStoreToVersionTopicCountMap(
-        localTopics,
-        multiDataCenterStoreToVersionTopicCount.get(localDatacenter));
-    if (childRegions.size() > 1) {
-      for (String childFabric: childRegions) {
-        try {
-          if (childFabric.equals(localDatacenter)) {
-            continue;
-          }
-          String pubSubBootstrapServer = multiClusterConfigs.getChildDataCenterKafkaUrlMap().get(childFabric);
-          Set<PubSubTopic> remoteTopics = getTopicManager(pubSubBootstrapServer).listTopics();
-          clearAndPopulateStoreToVersionTopicCountMap(
-              remoteTopics,
-              multiDataCenterStoreToVersionTopicCount.get(childFabric));
-        } catch (Exception e) {
-          LOGGER.error("Failed to refresh store to version topic count map for fabric {}", childFabric, e);
-          isRTTopicDeletionBlocked = true;
-          return;
-        }
-      }
-    }
-    isRTTopicDeletionBlocked = false;
-  }
-
-  private static void clearAndPopulateStoreToVersionTopicCountMap(
-      Set<PubSubTopic> topics,
-      Map<String, Integer> storeToVersionTopicCountMap) {
-    storeToVersionTopicCountMap.clear();
-    for (PubSubTopic topic: topics) {
-      String storeName = topic.getStoreName();
-      if (!storeName.isEmpty() && topic.isVersionTopic()) {
-        storeToVersionTopicCountMap.merge(storeName, 1, Integer::sum);
-      }
     }
   }
 
@@ -452,11 +380,18 @@ public class TopicCleanupService extends AbstractVeniceService {
         /** Consider only truncated topics */
         .filter(t -> admin.isTopicTruncatedBasedOnRetention(t.getName(), topicRetentions.get(t)))
         /** Always preserve the last {@link #minNumberOfUnusedKafkaTopicsToPreserve} topics, whether they are healthy or not */
-        .filter(t -> Version.parseVersionFromKafkaTopicName(t.getName()) <= maxVersionNumberToDelete)
+        .filter(t -> {
+          try {
+            return Version.parseVersionFromKafkaTopicName(t.getName()) <= maxVersionNumberToDelete;
+          } catch (Exception e) {
+            LOGGER.error("Could not parse version from kafka topic " + t.getName());
+            return false;
+          }
+        })
         /**
          * Filter out resources, which haven't been fully removed in child fabrics yet. This is only performed in the
          * child fabric because parent fabric don't have storage node helix resources.
-         *
+         * <p>
          * The reason to filter out still-alive resource is to avoid triggering the non-existing topic issue
          * of Kafka consumer happening in Storage Node.
          */

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/kafka/TopicCleanupService.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/kafka/TopicCleanupService.java
@@ -230,10 +230,8 @@ public class TopicCleanupService extends AbstractVeniceService {
       PubSubTopic topic = allTopics.poll();
       String storeName = topic.getStoreName();
       String clusterDiscovered;
-      Store store;
       try {
         clusterDiscovered = admin.discoverCluster(storeName).getFirst();
-        store = admin.getStore(clusterDiscovered, storeName);
       } catch (VeniceNoStoreException e) {
         LOGGER.warn(
             "Store {} not found. Exception when trying to delete topic: {} - {}",
@@ -244,7 +242,7 @@ public class TopicCleanupService extends AbstractVeniceService {
         continue;
       }
 
-      if (!topic.isRealTime() || admin.isRTTopicDeletionPermittedByAllControllers(clusterDiscovered, store)) {
+      if (!topic.isRealTime() || admin.isRTTopicDeletionPermittedByAllControllers(clusterDiscovered, storeName)) {
         // delete if it is a VT topic or an RT topic eligible for deletion by the above condition
         deleteTopic(topic);
       } else {

--- a/services/venice-controller/src/test/java/com/linkedin/venice/controller/kafka/TestTopicCleanupService.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/controller/kafka/TestTopicCleanupService.java
@@ -1,5 +1,6 @@
 package com.linkedin.venice.controller.kafka;
 
+import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.anyString;
 import static org.mockito.Mockito.atLeast;
@@ -19,9 +20,9 @@ import com.linkedin.venice.controller.Admin;
 import com.linkedin.venice.controller.VeniceControllerClusterConfig;
 import com.linkedin.venice.controller.VeniceControllerMultiClusterConfig;
 import com.linkedin.venice.controller.stats.TopicCleanupServiceStats;
-import com.linkedin.venice.exceptions.VeniceException;
 import com.linkedin.venice.exceptions.VeniceNoStoreException;
 import com.linkedin.venice.helix.HelixReadOnlyStoreConfigRepository;
+import com.linkedin.venice.meta.HybridStoreConfig;
 import com.linkedin.venice.meta.Store;
 import com.linkedin.venice.meta.StoreConfig;
 import com.linkedin.venice.meta.Version;
@@ -43,7 +44,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
-import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
@@ -190,12 +190,15 @@ public class TestTopicCleanupService {
   }
 
   @Test
-  public void testCleanupVeniceTopics() throws ExecutionException {
+  public void testCleanupVeniceTopics() {
+    String clusterName = "clusterName";
     String storeName1 = Utils.getUniqueString("store1");
     String storeName2 = Utils.getUniqueString("store2");
     String storeName3 = Utils.getUniqueString("store3");
     String storeName4 = Utils.getUniqueString("store4");
     String storeName5 = Utils.getUniqueString("store5");
+    String storeName6 = Utils.getUniqueString("store6");
+
     Map<PubSubTopic, Long> storeTopics = new HashMap<>();
     storeTopics.put(getPubSubTopic(storeName1, "_v1"), 1000L);
     storeTopics.put(getPubSubTopic(storeName1, "_v2"), 1000L);
@@ -208,6 +211,9 @@ public class TestTopicCleanupService {
     storeTopics.put(getPubSubTopic(storeName3, "_v100"), Long.MAX_VALUE);
     storeTopics.put(getPubSubTopic(storeName4, "_rt"), Long.MAX_VALUE);
     storeTopics.put(getPubSubTopic(storeName5, "_v1"), Long.MAX_VALUE);
+    storeTopics.put(getPubSubTopic(storeName6, "_rt"), 1000L);
+    storeTopics.put(getPubSubTopic(storeName6, "_v1"), Long.MAX_VALUE);
+    storeTopics.put(getPubSubTopic(storeName6, "_v2"), Long.MAX_VALUE);
     storeTopics.put(getPubSubTopic(PubSubTopicType.ADMIN_TOPIC_PREFIX, "_cluster"), Long.MAX_VALUE);
 
     Map<PubSubTopic, Long> storeTopics2 = new HashMap<>();
@@ -231,6 +237,8 @@ public class TestTopicCleanupService {
     doReturn(true).when(admin).isTopicTruncatedBasedOnRetention(1000L);
     doReturn(false).when(admin).isTopicTruncatedBasedOnRetention(any(), eq(Long.MAX_VALUE));
     doReturn(true).when(admin).isTopicTruncatedBasedOnRetention(any(), eq(1000L));
+    doReturn(Pair.create(clusterName, null)).when(admin).discoverCluster(anyString());
+    doReturn(true).when(admin).isRTTopicDeletionPermittedByAllControllers(anyString(), any());
     doReturn(Optional.of(new StoreConfig(storeName1))).when(storeConfigRepository).getStoreConfig(storeName1);
 
     Set<PubSubTopic> pubSubTopicSet = new HashSet<>();
@@ -245,23 +253,68 @@ public class TestTopicCleanupService {
     doReturn(apacheKafkaAdminAdapter).when(apacheKafkaAdminAdapterFactory).create(any(), eq(pubSubTopicRepository));
 
     topicCleanupService.setSourceOfTruthPubSubAdminAdapter(apacheKafkaAdminAdapter);
-    String clusterName = "clusterName";
     Pair<String, String> pair = new Pair<>(clusterName, "");
-    doReturn(pair).when(admin).discoverCluster(storeName3);
-    doReturn(pair).when(admin).discoverCluster(storeName4);
+    doReturn(pair).when(admin).discoverCluster(anyString());
     doThrow(new VeniceNoStoreException(storeName5)).when(admin).discoverCluster(storeName5);
 
+    Store store2 = mock(Store.class);
+    doReturn(storeName2).when(store2).getName();
+
     Store store3 = mock(Store.class);
+    doReturn(storeName3).when(store3).getName();
+
     doReturn(false).when(store3).containsVersion(100);
 
     Store store4 = mock(Store.class);
+    doReturn(storeName4).when(store4).getName();
     doReturn(false).when(store4).isHybrid();
-    Version version = mock(Version.class);
-    doReturn(null).when(version).getHybridStoreConfig();
 
+    Store store5 = mock(Store.class);
+
+    Store store6 = mock(Store.class);
+    doReturn(storeName6).when(store6).getName();
+
+    Version batchVersion = mock(Version.class);
+    doReturn(null).when(batchVersion).getHybridStoreConfig();
+
+    doReturn(store2).when(admin).getStore(clusterName, storeName2);
     doReturn(store3).when(admin).getStore(clusterName, storeName3);
     doReturn(store4).when(admin).getStore(clusterName, storeName4);
+    doReturn(store5).when(admin).getStore(clusterName, storeName5);
+    doReturn(store6).when(admin).getStore(clusterName, storeName6);
     doReturn(pubSubTopicSet).when(apacheKafkaAdminAdapter).listAllTopics();
+
+    Version hybridVersion = mock(Version.class);
+    doReturn(mock(HybridStoreConfig.class)).when(hybridVersion).getHybridStoreConfig();
+
+    doReturn(Collections.singletonList(hybridVersion)).when(store2).getVersions();
+    doReturn(Collections.singletonList(hybridVersion)).when(store3).getVersions();
+    doReturn(Collections.singletonList(batchVersion)).when(store6).getVersions();
+    // simulating blocked delete
+    doReturn(false).when(admin)
+        .isRTTopicDeletionPermittedByAllControllers(
+            anyString(),
+            argThat(arg -> (arg != null && storeName1.equals(arg.getName()))));
+    doReturn(false).when(admin)
+        .isRTTopicDeletionPermittedByAllControllers(
+            anyString(),
+            argThat(arg -> (arg != null && storeName2.equals(arg.getName()))));
+    doReturn(false).when(admin)
+        .isRTTopicDeletionPermittedByAllControllers(
+            anyString(),
+            argThat(arg -> (arg != null && storeName3.equals(arg.getName()))));
+    doReturn(true).when(admin)
+        .isRTTopicDeletionPermittedByAllControllers(
+            anyString(),
+            argThat(arg -> (arg != null && storeName4.equals(arg.getName()))));
+    doReturn(true).when(admin)
+        .isRTTopicDeletionPermittedByAllControllers(
+            anyString(),
+            argThat(arg -> (arg != null && storeName5.equals(arg.getName()))));
+    doReturn(true).when(admin)
+        .isRTTopicDeletionPermittedByAllControllers(
+            anyString(),
+            argThat(arg -> (arg != null && storeName6.equals(arg.getName()))));
 
     topicCleanupService.cleanupVeniceTopics();
 
@@ -271,17 +324,27 @@ public class TestTopicCleanupService {
     verify(topicManager, never()).ensureTopicIsDeletedAndBlockWithRetry(getPubSubTopic(storeName1, "_v3"));
     verify(topicManager, never()).ensureTopicIsDeletedAndBlockWithRetry(getPubSubTopic(storeName1, "_v4"));
     verify(topicManager, atLeastOnce()).ensureTopicIsDeletedAndBlockWithRetry(getPubSubTopic(storeName2, "_v1"));
+    verify(topicManager, atLeastOnce()).ensureTopicIsDeletedAndBlockWithRetry(getPubSubTopic(storeName6, "_rt"));
     // Delete should be blocked by local VT
     verify(topicManager, never()).ensureTopicIsDeletedAndBlockWithRetry(getPubSubTopic(storeName2, "_rt"));
     // Delete should be blocked by remote VT
     verify(topicManager, never()).ensureTopicIsDeletedAndBlockWithRetry(getPubSubTopic(storeName3, "_rt"));
-    verify(topicCleanupServiceStats, atLeastOnce()).recordDeletableTopicsCount(8);
+    verify(topicCleanupServiceStats, atLeastOnce()).recordDeletableTopicsCount(9);
     verify(topicCleanupServiceStats, never()).recordTopicDeletionError();
     verify(topicCleanupServiceStats, atLeastOnce()).recordTopicDeleted();
 
     verify(topicManager, atLeastOnce()).ensureTopicIsDeletedAndBlockWithRetry(getPubSubTopic(storeName3, "_v100"));
     verify(topicManager, atLeastOnce()).ensureTopicIsDeletedAndBlockWithRetry(getPubSubTopic(storeName4, "_rt"));
     verify(topicManager, atLeastOnce()).ensureTopicIsDeletedAndBlockWithRetry(getPubSubTopic(storeName5, "_v1"));
+
+    doReturn(true).when(admin)
+        .isRTTopicDeletionPermittedByAllControllers(
+            anyString(),
+            argThat(arg -> (arg != null && arg.getName().equals(storeName2))));
+    doReturn(true).when(admin)
+        .isRTTopicDeletionPermittedByAllControllers(
+            anyString(),
+            argThat(arg -> (arg != null && arg.getName().equals(storeName3))));
     topicCleanupService.cleanupVeniceTopics();
 
     verify(topicManager, never()).ensureTopicIsDeletedAndBlockWithRetry(getPubSubTopic(storeName1, "_v3"));
@@ -297,7 +360,7 @@ public class TestTopicCleanupService {
   }
 
   @Test
-  public void testRun() throws Exception {
+  public void testRun() {
     String storeName1 = Utils.getUniqueString("store1");
     String storeName2 = Utils.getUniqueString("store2");
     String storeName3 = Utils.getUniqueString("store3");
@@ -330,6 +393,7 @@ public class TestTopicCleanupService {
     doReturn(false).when(admin).isTopicTruncatedBasedOnRetention(any(), eq(Long.MAX_VALUE));
     doReturn(true).when(admin).isTopicTruncatedBasedOnRetention(any(), eq(1000L));
     doReturn(true).when(admin).isLeaderControllerOfControllerCluster();
+    doReturn(Pair.create("cluster0", null)).when(admin).discoverCluster(any());
     // Resource is still alive
     doReturn(true).when(admin).isResourceStillAlive(storeName2 + "_v2");
 
@@ -355,7 +419,7 @@ public class TestTopicCleanupService {
   }
 
   @Test
-  public void testRunWhenCurrentControllerChangeFromLeaderToFollower() throws Exception {
+  public void testRunWhenCurrentControllerChangeFromLeaderToFollower() {
     String storeName1 = Utils.getUniqueString("store1");
     doReturn(Optional.of(new StoreConfig(storeName1))).when(storeConfigRepository).getStoreConfig(storeName1);
     Map<PubSubTopic, Long> storeTopics1 = new HashMap<>();
@@ -387,9 +451,10 @@ public class TestTopicCleanupService {
   }
 
   @Test
-  public void testRunWhenCurrentControllerChangeFromFollowerToLeader() throws Exception {
+  public void testRunWhenCurrentControllerChangeFromFollowerToLeader() {
     String storeName1 = Utils.getUniqueString("store1");
     doReturn(Optional.of(new StoreConfig(storeName1))).when(storeConfigRepository).getStoreConfig(storeName1);
+    doReturn(new Pair<>("clusterName", "")).when(admin).discoverCluster(anyString());
     Map<PubSubTopic, Long> storeTopics1 = new HashMap<>();
     storeTopics1.put(getPubSubTopic(storeName1, "_v1"), 1000L);
     storeTopics1.put(getPubSubTopic(storeName1, "_v2"), 1000L);
@@ -442,56 +507,26 @@ public class TestTopicCleanupService {
   }
 
   @Test
-  public void testCleanVeniceTopicsBlockRTTopicDeletionWhenMisconfigured() {
-    // RT topic deletion should be blocked when controller is misconfigured
-    // Mis-configured where local data center is not in the child data centers list
-    VeniceControllerClusterConfig controllerConfig = mock(VeniceControllerClusterConfig.class);
-    doReturn(controllerConfig).when(veniceControllerMultiClusterConfig).getCommonConfig();
-    doReturn(Collections.singleton("remote")).when(controllerConfig).getChildDatacenters();
-    TopicCleanupService blockedTopicCleanupService = new TopicCleanupService(
-        admin,
-        veniceControllerMultiClusterConfig,
-        pubSubTopicRepository,
-        topicCleanupServiceStats,
-        pubSubClientsFactory);
-    String storeName = Utils.getUniqueString("testStore");
-    Map<PubSubTopic, Long> storeTopics = new HashMap<>();
-    storeTopics.put(getPubSubTopic(storeName, "_rt"), 1000L);
-    doReturn(false).when(admin).isTopicTruncatedBasedOnRetention(Long.MAX_VALUE);
-    doReturn(true).when(admin).isTopicTruncatedBasedOnRetention(1000L);
-    doReturn(false).when(admin).isTopicTruncatedBasedOnRetention(any(), eq(Long.MAX_VALUE));
-    doReturn(true).when(admin).isTopicTruncatedBasedOnRetention(any(), eq(1000L));
-    doReturn(storeTopics).when(topicManager).getAllTopicRetentions();
-    doReturn(storeTopics).when(remoteTopicManager).getAllTopicRetentions();
-    doReturn(Optional.of(new StoreConfig(storeName))).when(storeConfigRepository).getStoreConfig(storeName);
-    blockedTopicCleanupService.cleanupVeniceTopics();
-    verify(topicManager, atLeastOnce()).getPubSubClusterAddress();
-    verify(topicManager, never()).ensureTopicIsDeletedAndBlockWithRetry(getPubSubTopic(storeName, "_rt"));
-    verify(topicCleanupServiceStats, atLeastOnce()).recordDeletableTopicsCount(1);
-    verify(topicCleanupServiceStats, atLeastOnce()).recordTopicDeletionError();
-  }
-
-  @Test
   public void testCleanVeniceTopicRTTopicDeletionWithErrorFetchingVT() {
     // RT topic deletion should be blocked when version topic cannot be fetched due to error
     String storeName = Utils.getUniqueString("testStore");
     Map<PubSubTopic, Long> storeTopics = new HashMap<>();
     storeTopics.put(getPubSubTopic(storeName, "_rt"), 1000L);
+    doReturn(Pair.create("cluster0", null)).when(admin).discoverCluster(any());
     doReturn(false).when(admin).isTopicTruncatedBasedOnRetention(Long.MAX_VALUE);
     doReturn(true).when(admin).isTopicTruncatedBasedOnRetention(1000L);
     doReturn(false).when(admin).isTopicTruncatedBasedOnRetention(any(), eq(Long.MAX_VALUE));
     doReturn(true).when(admin).isTopicTruncatedBasedOnRetention(any(), eq(1000L));
     doReturn(storeTopics).when(topicManager).getAllTopicRetentions();
+    doReturn(false).when(admin).isRTTopicDeletionPermittedByAllControllers(anyString(), any());
     doReturn(Optional.of(new StoreConfig(storeName))).when(storeConfigRepository).getStoreConfig(storeName);
-    when(remoteTopicManager.listTopics()).thenThrow(new VeniceException("test")).thenReturn(storeTopics.keySet());
 
     topicCleanupService.cleanupVeniceTopics();
 
     verify(topicManager, never()).ensureTopicIsDeletedAndBlockWithRetry(getPubSubTopic(storeName, "_rt"));
-    verify(remoteTopicManager, atLeastOnce()).listTopics();
     verify(topicCleanupServiceStats, atLeastOnce()).recordDeletableTopicsCount(1);
-    verify(topicCleanupServiceStats, atLeastOnce()).recordTopicDeletionError();
 
+    doReturn(true).when(admin).isRTTopicDeletionPermittedByAllControllers(anyString(), any());
     topicCleanupService.cleanupVeniceTopics();
 
     verify(topicManager, atLeastOnce()).ensureTopicIsDeletedAndBlockWithRetry(getPubSubTopic(storeName, "_rt"));
@@ -511,6 +546,8 @@ public class TestTopicCleanupService {
     doReturn(true).when(admin).isTopicTruncatedBasedOnRetention(1000L);
     doReturn(false).when(admin).isTopicTruncatedBasedOnRetention(any(), eq(Long.MAX_VALUE));
     doReturn(true).when(admin).isTopicTruncatedBasedOnRetention(any(), eq(1000L));
+    doReturn(Pair.create("cluster0", null)).when(admin).discoverCluster(any());
+    doReturn(true).when(admin).isRTTopicDeletionPermittedByAllControllers(anyString(), any());
     when(topicManager.getAllTopicRetentions()).thenReturn(storeTopics1).thenReturn(storeTopics2);
     doReturn(storeTopics2).when(remoteTopicManager).getAllTopicRetentions();
 
@@ -519,8 +556,6 @@ public class TestTopicCleanupService {
     verify(remoteTopicManager, never()).getAllTopicRetentions();
 
     topicCleanupService.cleanupVeniceTopics();
-
-    verify(remoteTopicManager, atLeastOnce()).listTopics();
   }
 
   @Test

--- a/services/venice-controller/src/test/java/com/linkedin/venice/controller/kafka/TestTopicCleanupService.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/controller/kafka/TestTopicCleanupService.java
@@ -1,6 +1,5 @@
 package com.linkedin.venice.controller.kafka;
 
-import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.anyString;
 import static org.mockito.Mockito.atLeast;
@@ -291,30 +290,12 @@ public class TestTopicCleanupService {
     doReturn(Collections.singletonList(hybridVersion)).when(store3).getVersions();
     doReturn(Collections.singletonList(batchVersion)).when(store6).getVersions();
     // simulating blocked delete
-    doReturn(false).when(admin)
-        .isRTTopicDeletionPermittedByAllControllers(
-            anyString(),
-            argThat(arg -> (arg != null && storeName1.equals(arg.getName()))));
-    doReturn(false).when(admin)
-        .isRTTopicDeletionPermittedByAllControllers(
-            anyString(),
-            argThat(arg -> (arg != null && storeName2.equals(arg.getName()))));
-    doReturn(false).when(admin)
-        .isRTTopicDeletionPermittedByAllControllers(
-            anyString(),
-            argThat(arg -> (arg != null && storeName3.equals(arg.getName()))));
-    doReturn(true).when(admin)
-        .isRTTopicDeletionPermittedByAllControllers(
-            anyString(),
-            argThat(arg -> (arg != null && storeName4.equals(arg.getName()))));
-    doReturn(true).when(admin)
-        .isRTTopicDeletionPermittedByAllControllers(
-            anyString(),
-            argThat(arg -> (arg != null && storeName5.equals(arg.getName()))));
-    doReturn(true).when(admin)
-        .isRTTopicDeletionPermittedByAllControllers(
-            anyString(),
-            argThat(arg -> (arg != null && storeName6.equals(arg.getName()))));
+    doReturn(false).when(admin).isRTTopicDeletionPermittedByAllControllers(anyString(), eq(storeName1));
+    doReturn(false).when(admin).isRTTopicDeletionPermittedByAllControllers(anyString(), eq(storeName2));
+    doReturn(false).when(admin).isRTTopicDeletionPermittedByAllControllers(anyString(), eq(storeName3));
+    doReturn(true).when(admin).isRTTopicDeletionPermittedByAllControllers(anyString(), eq(storeName4));
+    doReturn(true).when(admin).isRTTopicDeletionPermittedByAllControllers(anyString(), eq(storeName5));
+    doReturn(true).when(admin).isRTTopicDeletionPermittedByAllControllers(anyString(), eq(storeName6));
 
     topicCleanupService.cleanupVeniceTopics();
 
@@ -337,14 +318,8 @@ public class TestTopicCleanupService {
     verify(topicManager, atLeastOnce()).ensureTopicIsDeletedAndBlockWithRetry(getPubSubTopic(storeName4, "_rt"));
     verify(topicManager, atLeastOnce()).ensureTopicIsDeletedAndBlockWithRetry(getPubSubTopic(storeName5, "_v1"));
 
-    doReturn(true).when(admin)
-        .isRTTopicDeletionPermittedByAllControllers(
-            anyString(),
-            argThat(arg -> (arg != null && arg.getName().equals(storeName2))));
-    doReturn(true).when(admin)
-        .isRTTopicDeletionPermittedByAllControllers(
-            anyString(),
-            argThat(arg -> (arg != null && arg.getName().equals(storeName3))));
+    doReturn(true).when(admin).isRTTopicDeletionPermittedByAllControllers(anyString(), eq(storeName2));
+    doReturn(true).when(admin).isRTTopicDeletionPermittedByAllControllers(anyString(), eq(storeName3));
     topicCleanupService.cleanupVeniceTopics();
 
     verify(topicManager, never()).ensureTopicIsDeletedAndBlockWithRetry(getPubSubTopic(storeName1, "_v3"));

--- a/services/venice-controller/src/test/java/com/linkedin/venice/controller/kafka/TestTopicCleanupServiceForMultiKafkaClusters.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/controller/kafka/TestTopicCleanupServiceForMultiKafkaClusters.java
@@ -59,6 +59,7 @@ public class TestTopicCleanupServiceForMultiKafkaClusters {
     doReturn(kafkaUrlMap).when(config).getChildDataCenterKafkaUrlMap();
 
     admin = mock(Admin.class);
+    doReturn(true).when(admin).isParent();
     topicManager1 = mock(TopicManager.class);
     doReturn(kafkaClusterServerUrl1).when(topicManager1).getPubSubClusterAddress();
     doReturn(topicManager1).when(admin).getTopicManager(kafkaClusterServerUrl1);

--- a/services/venice-controller/src/test/java/com/linkedin/venice/controller/kafka/TestTopicCleanupServiceForParentController.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/controller/kafka/TestTopicCleanupServiceForParentController.java
@@ -32,6 +32,7 @@ public class TestTopicCleanupServiceForParentController {
   @BeforeTest
   public void setUp() {
     admin = mock(Admin.class);
+    doReturn(true).when(admin).isParent();
     topicManager = mock(TopicManager.class);
     doReturn(topicManager).when(admin).getTopicManager();
     VeniceControllerMultiClusterConfig config = mock(VeniceControllerMultiClusterConfig.class);


### PR DESCRIPTION
<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## Avoid `getStore` from the controller which is not the leader of cluster this store is a part of 

<!--
Describe
- What changes to make and why you are making these changes.
- How are you going to achieve your goal.
- Describe what testings you have done, for example, performance testing etc.

If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->
When TopicCleanupService tries to delete RT topics, it does not have to wait for all the corresponding VT topics to get deleted if all the versions of the store has changed from hybrid to batch. If all the versions are batch, it can be safely assumed that no VT topic is consuming from that RT topic.
This was already done in https://github.com/linkedin/venice/pull/1234 but that commit was reverted in https://github.com/linkedin/venice/pull/1355
It was reverted because TCS was trying to get `Store` for which it was not the leader controller. Only leader controller caches and stores the information for all the stores in the cluster it is leader of. 

So this time, `isRTTopicDeletionPermittedByAllControllers` will not take `Store` object, it will use the ControllerClientMap to get Store information for all the stores. 

Resolves #XXX

## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.