### PR TITLE
[da-vinci][server] Added flag to enable RocksDB blob file for blocked based format

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/RocksDBMemoryStats.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/RocksDBMemoryStats.java
@@ -55,7 +55,11 @@ public class RocksDBMemoryStats extends AbstractVeniceStats {
       "rocksdb.actual-delayed-write-rate",
       "rocksdb.block-cache-capacity",
       "rocksdb.block-cache-pinned-usage",
-      "rocksdb.block-cache-usage");
+      "rocksdb.block-cache-usage",
+      "rocksdb.num-blob-files",
+      "rocksdb.total-blob-file-size",
+      "rocksdb.live-blob-file-size",
+      "rocksdb.live-blob-file-garbage-size");
 
   // metrics emitted on a per instance basis need only be collected once, not aggregated
   private static final Set<String> INSTANCE_METRIC_DOMAINS = Collections.unmodifiableSet(

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/store/rocksdb/RocksDBServerConfig.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/store/rocksdb/RocksDBServerConfig.java
@@ -3,11 +3,14 @@ package com.linkedin.davinci.store.rocksdb;
 import com.linkedin.venice.exceptions.VeniceException;
 import com.linkedin.venice.utils.VeniceProperties;
 import java.util.Arrays;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.rocksdb.CompactionStyle;
 import org.rocksdb.CompressionType;
 
 
 public class RocksDBServerConfig {
+  private static final Logger LOGGER = LogManager.getLogger(RocksDBServerConfig.class);
   /**
    * Ability to use direct IO for disk reads, might yield better performance on Azure disks.
    * Also makes caching behavior more consistent, by limiting the caching to only RocksDB.
@@ -219,6 +222,17 @@ public class RocksDBServerConfig {
   public static final String ROCKSDB_MAX_LOG_FILE_SIZE = "rocksdb.max.log.file.size";
   public static final String RECORD_TRANSFORMER_VALUE_SCHEMA = "record.transformer.value.schema";
 
+  /**
+   * Check this page to find more details:
+   * https://github.com/facebook/rocksdb/wiki/BlobDB
+   */
+  public static final String ROCKSDB_BLOB_FILES_ENABLED = "rocksdb.blob.files.enabled";
+  public static final String ROCKSDB_MIN_BLOB_SIZE_IN_BYTES = "rocksdb.min.blob.size.in.bytes";
+  public static final String ROCKSDB_BLOB_FILE_SIZE_IN_BYTES = "rocksdb.blob.file.size.in.bytes";
+  public static final String ROCKSDB_BLOB_GARBAGE_COLLECTION_AGE_CUTOFF = "rocksdb.blob.garbage.collection.age.cutoff";
+  public static final String ROCKSDB_BLOB_GARBAGE_COLLECTION_FORCE_THRESHOLD =
+      "rocksdb.blob.garbage.collection.force.threshold";
+
   private final boolean rocksDBUseDirectReads;
 
   private final int rocksDBEnvFlushPoolSize;
@@ -285,6 +299,12 @@ public class RocksDBServerConfig {
   private final int maxLogFileNum;
   private final long maxLogFileSize;
   private final String transformerValueSchema;
+
+  private final boolean blobFilesEnabled;
+  private final long minBlobSizeInBytes;
+  private final long blobFileSizeInBytes;
+  private final double blobGarbageCollectionAgeCutOff;
+  private final double blobGarbageCollectionForceThreshold;
 
   public RocksDBServerConfig(VeniceProperties props) {
     // Do not use Direct IO for reads by default
@@ -407,6 +427,20 @@ public class RocksDBServerConfig {
     this.maxLogFileNum = props.getInt(ROCKSDB_MAX_LOG_FILE_NUM, 3);
     this.maxLogFileSize = props.getSizeInBytes(ROCKSDB_MAX_LOG_FILE_SIZE, 10 * 1024 * 1024); // 10MB;
     this.transformerValueSchema = props.getString(RECORD_TRANSFORMER_VALUE_SCHEMA, "null");
+
+    /**
+     *  Check this page to find more details:
+     *  https://github.com/facebook/rocksdb/wiki/BlobDB
+     */
+    this.blobFilesEnabled = props.getBoolean(ROCKSDB_BLOB_FILES_ENABLED, false);
+    if (this.blobFilesEnabled) {
+      LOGGER.info("RocksDB Blob files feature is enabled");
+    }
+    this.minBlobSizeInBytes = props.getSizeInBytes(ROCKSDB_MIN_BLOB_SIZE_IN_BYTES, 4 * 1024); // default: 4KB
+    this.blobFileSizeInBytes = props.getSizeInBytes(ROCKSDB_BLOB_FILE_SIZE_IN_BYTES, 256 * 1024 * 1024); // default:
+                                                                                                         // 256MB
+    this.blobGarbageCollectionAgeCutOff = props.getDouble(ROCKSDB_BLOB_GARBAGE_COLLECTION_AGE_CUTOFF, 0.25);
+    this.blobGarbageCollectionForceThreshold = props.getDouble(ROCKSDB_BLOB_GARBAGE_COLLECTION_FORCE_THRESHOLD, 0.8);
   }
 
   public int getLevel0FileNumCompactionTriggerWriteOnlyVersion() {
@@ -616,4 +650,23 @@ public class RocksDBServerConfig {
     return transformerValueSchema;
   }
 
+  public boolean isBlobFilesEnabled() {
+    return blobFilesEnabled;
+  }
+
+  public long getMinBlobSizeInBytes() {
+    return minBlobSizeInBytes;
+  }
+
+  public long getBlobFileSizeInBytes() {
+    return blobFileSizeInBytes;
+  }
+
+  public double getBlobGarbageCollectionAgeCutOff() {
+    return blobGarbageCollectionAgeCutOff;
+  }
+
+  public double getBlobGarbageCollectionForceThreshold() {
+    return blobGarbageCollectionForceThreshold;
+  }
 }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/store/rocksdb/RocksDBServerConfig.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/store/rocksdb/RocksDBServerConfig.java
@@ -232,6 +232,7 @@ public class RocksDBServerConfig {
   public static final String ROCKSDB_BLOB_GARBAGE_COLLECTION_AGE_CUTOFF = "rocksdb.blob.garbage.collection.age.cutoff";
   public static final String ROCKSDB_BLOB_GARBAGE_COLLECTION_FORCE_THRESHOLD =
       "rocksdb.blob.garbage.collection.force.threshold";
+  public static final String ROCKSDB_BLOB_FILE_STARTING_LEVEL = "rocksdb.blob.file.starting.level";
 
   private final boolean rocksDBUseDirectReads;
 
@@ -305,6 +306,7 @@ public class RocksDBServerConfig {
   private final long blobFileSizeInBytes;
   private final double blobGarbageCollectionAgeCutOff;
   private final double blobGarbageCollectionForceThreshold;
+  private final int blobFileStartingLevel;
 
   public RocksDBServerConfig(VeniceProperties props) {
     // Do not use Direct IO for reads by default
@@ -441,6 +443,7 @@ public class RocksDBServerConfig {
                                                                                                          // 256MB
     this.blobGarbageCollectionAgeCutOff = props.getDouble(ROCKSDB_BLOB_GARBAGE_COLLECTION_AGE_CUTOFF, 0.25);
     this.blobGarbageCollectionForceThreshold = props.getDouble(ROCKSDB_BLOB_GARBAGE_COLLECTION_FORCE_THRESHOLD, 0.8);
+    this.blobFileStartingLevel = props.getInt(ROCKSDB_BLOB_FILE_STARTING_LEVEL, 0);
   }
 
   public int getLevel0FileNumCompactionTriggerWriteOnlyVersion() {
@@ -668,5 +671,9 @@ public class RocksDBServerConfig {
 
   public double getBlobGarbageCollectionForceThreshold() {
     return blobGarbageCollectionForceThreshold;
+  }
+
+  public int getBlobFileStartingLevel() {
+    return blobFileStartingLevel;
   }
 }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/store/rocksdb/RocksDBStoragePartition.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/store/rocksdb/RocksDBStoragePartition.java
@@ -412,6 +412,7 @@ public class RocksDBStoragePartition extends AbstractStoragePartition {
         options.setBlobFileSize(rocksDBServerConfig.getBlobFileSizeInBytes());
         options.setBlobGarbageCollectionAgeCutoff(rocksDBServerConfig.getBlobGarbageCollectionAgeCutOff());
         options.setBlobGarbageCollectionForceThreshold(rocksDBServerConfig.getBlobGarbageCollectionForceThreshold());
+        options.setBlobFileStartingLevel(rocksDBServerConfig.getBlobFileStartingLevel());
       }
     }
 

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/store/rocksdb/RocksDBStoragePartition.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/store/rocksdb/RocksDBStoragePartition.java
@@ -401,6 +401,18 @@ public class RocksDBStoragePartition extends AbstractStoragePartition {
       tableConfig.setCacheIndexAndFilterBlocks(rocksDBServerConfig.isRocksDBSetCacheIndexAndFilterBlocks());
       tableConfig.setFormatVersion(rocksDBServerConfig.getBlockBaseFormatVersion());
       options.setTableFormatConfig(tableConfig);
+
+      /**
+       * Only enable blob files for block-based format.
+       */
+      if (rocksDBServerConfig.isBlobFilesEnabled()) {
+        options.setEnableBlobFiles(true);
+        options.setEnableBlobGarbageCollection(true);
+        options.setMinBlobSize(rocksDBServerConfig.getMinBlobSizeInBytes());
+        options.setBlobFileSize(rocksDBServerConfig.getBlobFileSizeInBytes());
+        options.setBlobGarbageCollectionAgeCutoff(rocksDBServerConfig.getBlobGarbageCollectionAgeCutOff());
+        options.setBlobGarbageCollectionForceThreshold(rocksDBServerConfig.getBlobGarbageCollectionForceThreshold());
+      }
     }
 
     if (storagePartitionConfig.isWriteOnlyConfig()) {

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestHybrid.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestHybrid.java
@@ -1,5 +1,6 @@
 package com.linkedin.venice.endToEnd;
 
+import static com.linkedin.davinci.store.rocksdb.RocksDBServerConfig.ROCKSDB_BLOB_FILES_ENABLED;
 import static com.linkedin.davinci.store.rocksdb.RocksDBServerConfig.ROCKSDB_PLAIN_TABLE_FORMAT_ENABLED;
 import static com.linkedin.venice.ConfigKeys.DEFAULT_MAX_NUMBER_OF_PARTITIONS;
 import static com.linkedin.venice.ConfigKeys.KAFKA_BOOTSTRAP_SERVERS;
@@ -1716,6 +1717,8 @@ public class TestHybrid {
           KafkaConsumerService.ConsumerAssignmentStrategy.PARTITION_WISE_SHARED_CONSUMER_ASSIGNMENT_STRATEGY.name());
     }
     cluster.addVeniceServer(new Properties(), serverProperties);
+    // Enable blob files in one server
+    serverProperties.setProperty(ROCKSDB_BLOB_FILES_ENABLED, "true");
     cluster.addVeniceServer(new Properties(), serverProperties);
 
     return cluster;


### PR DESCRIPTION
<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## Summary, imperative, start upper case, don't end with a period
This PR adds options to enable BlobDB feature in RocksDB to reduce write amplification for large value stores.
Currently, these options are only valid for block-based format.

New configs:
rocksdb.blob.files.enabled : default false
rocksdb.min.blob.size.in.bytes : default 4KB
rocksdb.blob.file.size.in.bytes : default 256MB
rocksdb.blob.garbage.collection.age.cutoff : default 0.25
rocksdb.blob.garbage.collection.force.threshold : default 0.8
rocksdb.blob.file.starting.level: default 0

This feature is not perfect, as the main goal is to reduce the write amplification, but space amplification will increase and we can tune the above params to find the right balance.

<!--
Describe
- What changes to make and why you are making these changes.
- How are you going to achieve your goal.
- Describe what testings you have done, for example, performance testing etc.

If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->


## How was this PR tested?
CI
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.