### PR TITLE
[server] Fix NPE in read compute store schema warm-up code

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
@@ -1386,9 +1386,9 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
         /**
          * Special handling for current version when encountering {@link MemoryLimitExhaustedException}.
          */
-        if (partitionException instanceof MemoryLimitExhaustedException
-            || partitionException.getCause() instanceof MemoryLimitExhaustedException
-                && isCurrentVersion.getAsBoolean()) {
+        if ((partitionException instanceof MemoryLimitExhaustedException
+            || partitionException.getCause() instanceof MemoryLimitExhaustedException)
+            && !isCurrentVersion.getAsBoolean()) {
           LOGGER.warn(
               "Encountered MemoryLimitExhaustedException, and ingestion task will try to reopen the database and"
                   + " resume the consumption after killing ingestion tasks for non current versions");

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
@@ -14,7 +14,7 @@ import static com.linkedin.venice.LogMessages.KILLED_JOB_MESSAGE;
 import static com.linkedin.venice.kafka.protocol.enums.ControlMessageType.START_OF_SEGMENT;
 import static com.linkedin.venice.utils.Utils.FATAL_DATA_VALIDATION_ERROR;
 import static com.linkedin.venice.utils.Utils.getReplicaId;
-import static java.util.Comparator.*;
+import static java.util.Comparator.comparingInt;
 import static java.util.concurrent.TimeUnit.HOURS;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.concurrent.TimeUnit.MINUTES;

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
@@ -4109,11 +4109,16 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
     LOGGER.info("Replica: {} is ready to serve", partitionConsumptionState.getReplicaId());
   }
 
+  // test only
+  void setValueSchemaId(int id) {
+    this.valueSchemaId = id;
+  }
+
   /**
    * Try to warm-up the schema repo cache before reporting completion as new value schema could cause latency degradation
    * while trying to compile it in the read-path.
    */
-  private void warmupSchemaCache(Store store) {
+  void warmupSchemaCache(Store store) {
     if (!store.isReadComputationEnabled()) {
       return;
     }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
@@ -1386,8 +1386,7 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
         /**
          * Special handling for current version when encountering {@link MemoryLimitExhaustedException}.
          */
-        if ((partitionException instanceof MemoryLimitExhaustedException
-            || partitionException.getCause() instanceof MemoryLimitExhaustedException)
+        if (ExceptionUtils.recursiveClassEquals(partitionException, MemoryLimitExhaustedException.class)
             && isCurrentVersion.getAsBoolean()) {
           LOGGER.warn(
               "Encountered MemoryLimitExhaustedException, and ingestion task will try to reopen the database and"
@@ -4360,8 +4359,7 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
         continue;
       }
       Exception partitionIngestionException = ex.getException();
-      if (partitionIngestionException instanceof MemoryLimitExhaustedException
-          || partitionIngestionException.getCause() instanceof MemoryLimitExhaustedException) {
+      if (ExceptionUtils.recursiveClassEquals(partitionIngestionException, MemoryLimitExhaustedException.class)) {
         return true;
       }
     }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
@@ -4137,15 +4137,15 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
     List<SchemaEntry> schemaEntries = new ArrayList<>(schemaRepository.getValueSchemas(storeName));
     schemaEntries.sort(comparingInt(SchemaEntry::getId).reversed());
     // Try to warm the schema cache by generating last `getNumSchemaFastClassWarmup` schemas.
-    int schemaGenerated = 0;
+    Set<Integer> schemaGenerated = new HashSet<>();
     for (SchemaEntry schemaEntry: schemaEntries) {
-      if (schemaGenerated > numSchemaToGenerate) {
+      schemaGenerated.add(schemaEntry.getId());
+      if (schemaGenerated.size() > numSchemaToGenerate) {
         break;
       }
-      schemaGenerated++;
       cacheFastAvroGenericDeserializer(writerSchema, schemaEntry.getSchema(), warmUpTimeLimit);
     }
-    LOGGER.info("Warmed up cache of {} schemas of store {}", schemaGenerated, storeName);
+    LOGGER.info("Warmed up cache of value schema with ids {} of store {}", schemaGenerated, storeName);
   }
 
   void cacheFastAvroGenericDeserializer(Schema writerSchema, Schema readerSchema, long warmUpTimeLimit) {

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
@@ -4143,10 +4143,13 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
         break;
       }
       schemaGenerated++;
-      FastSerializerDeserializerFactory
-          .cacheFastAvroGenericDeserializer(writerSchema, schemaEntry.getSchema(), warmUpTimeLimit);
+      cacheFastAvroGenericDeserializer(writerSchema, schemaEntry.getSchema(), warmUpTimeLimit);
     }
     LOGGER.info("Warmed up cache of {} schemas of store {}", schemaGenerated, storeName);
+  }
+
+  void cacheFastAvroGenericDeserializer(Schema writerSchema, Schema readerSchema, long warmUpTimeLimit) {
+    FastSerializerDeserializerFactory.cacheFastAvroGenericDeserializer(writerSchema, readerSchema, warmUpTimeLimit);
   }
 
   public void reportError(String message, int userPartition, Exception e) {

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
@@ -4147,6 +4147,7 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
       FastSerializerDeserializerFactory
           .cacheFastAvroGenericDeserializer(writerSchema, schemaEntry.getSchema(), warmUpTimeLimit);
     }
+    LOGGER.info("Warmed up cache of {} schemas of store {}", schemaGenerated, storeName);
   }
 
   public void reportError(String message, int userPartition, Exception e) {

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
@@ -1388,7 +1388,7 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
          */
         if ((partitionException instanceof MemoryLimitExhaustedException
             || partitionException.getCause() instanceof MemoryLimitExhaustedException)
-            && !isCurrentVersion.getAsBoolean()) {
+            && isCurrentVersion.getAsBoolean()) {
           LOGGER.warn(
               "Encountered MemoryLimitExhaustedException, and ingestion task will try to reopen the database and"
                   + " resume the consumption after killing ingestion tasks for non current versions");

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTaskTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTaskTest.java
@@ -3717,7 +3717,7 @@ public abstract class StoreIngestionTaskTest {
     doReturn(true).when(mockStore).isReadComputationEnabled();
     doReturn(true).when(mockSchemaRepo).hasValueSchema(anyString(), anyInt());
     SchemaEntry schemaEntry1 = new SchemaEntry(1, schema1);
-    SchemaEntry schemaEntry2 = new SchemaEntry(2, schema1);
+    SchemaEntry schemaEntry2 = new SchemaEntry(2, schema2);
     doReturn(schemaEntry1).when(mockSchemaRepo).getValueSchema(anyString(), anyInt());
     doReturn(Arrays.asList(schemaEntry1, schemaEntry2)).when(mockSchemaRepo).getValueSchemas(anyString());
     storeIngestionTaskUnderTest.setValueSchemaId(2);

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTaskTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTaskTest.java
@@ -3703,6 +3703,25 @@ public abstract class StoreIngestionTaskTest {
     storeIngestionTaskUnderTest.processTopicSwitch(controlMessage, PARTITION_FOO, 10, mockPcs);
     verify(mockTopicManagerRemoteKafka, never()).getOffsetByTime(any(), anyLong());
     verify(mockOffsetRecord, never()).setLeaderUpstreamOffset(anyString(), anyLong());
+
+    Schema schema1 = Schema.parse(
+        "{" + "\"fields\": ["
+            + "   {\"default\": \"\", \"doc\": \"test field\", \"name\": \"testField1\", \"type\": \"string\"},"
+            + "   {\"default\": 0, \"doc\": \"test field two\", \"name\": \"testField2\", \"type\": \"float\"}"
+            + "   ]," + " \"name\": \"testObject\", \"type\": \"record\"" + "}");
+    Schema schema2 = Schema.parse(
+        "{" + "\"fields\": ["
+            + "   {\"default\": \"\", \"doc\": \"test field\", \"name\": \"testField1\", \"type\": \"string\"},"
+            + "   {\"default\": -1, \"doc\": \"test field two\", \"name\": \"testField2\", \"type\": \"float\"}"
+            + "   ]," + " \"name\": \"testObject\", \"type\": \"record\"" + "}");
+    doReturn(true).when(mockStore).isReadComputationEnabled();
+    doReturn(true).when(mockSchemaRepo).hasValueSchema(anyString(), anyInt());
+    SchemaEntry schemaEntry1 = new SchemaEntry(1, schema1);
+    SchemaEntry schemaEntry2 = new SchemaEntry(2, schema1);
+    doReturn(schemaEntry1).when(mockSchemaRepo).getValueSchema(anyString(), anyInt());
+    doReturn(Arrays.asList(schemaEntry1, schemaEntry2)).when(mockSchemaRepo).getValueSchemas(anyString());
+    storeIngestionTaskUnderTest.setValueSchemaId(2);
+    storeIngestionTaskUnderTest.warmupSchemaCache(mockStore);
   }
 
   @Test(dataProvider = "aaConfigProvider")

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/helix/TestHelixReadOnlySchemaRepository.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/helix/TestHelixReadOnlySchemaRepository.java
@@ -1,7 +1,6 @@
 package com.linkedin.venice.helix;
 
 import static com.linkedin.venice.zk.VeniceZkPaths.STORES;
-import static java.util.Comparator.*;
 
 import com.linkedin.venice.exceptions.VeniceNoStoreException;
 import com.linkedin.venice.integration.utils.ServiceFactory;

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/helix/TestHelixReadOnlySchemaRepository.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/helix/TestHelixReadOnlySchemaRepository.java
@@ -1,6 +1,7 @@
 package com.linkedin.venice.helix;
 
 import static com.linkedin.venice.zk.VeniceZkPaths.STORES;
+import static java.util.Comparator.*;
 
 import com.linkedin.venice.exceptions.VeniceNoStoreException;
 import com.linkedin.venice.integration.utils.ServiceFactory;
@@ -15,7 +16,9 @@ import com.linkedin.venice.schema.SchemaData;
 import com.linkedin.venice.schema.SchemaEntry;
 import com.linkedin.venice.utils.TestUtils;
 import com.linkedin.venice.utils.locks.ClusterLockManager;
+import java.util.ArrayList;
 import java.util.Collection;
+import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 import org.apache.avro.Schema;
@@ -150,6 +153,15 @@ public class TestHelixReadOnlySchemaRepository {
         3,
         TimeUnit.SECONDS,
         () -> schemaRORepo.getValueSchemas(storeName).size() == 2);
+
+    List<SchemaEntry> schemaEntries = new ArrayList<>(schemaRORepo.getValueSchemas(storeName));
+
+    schemaEntries.sort(comparingInt(SchemaEntry::getId));
+    for (SchemaEntry entry: schemaEntries) {
+      if (entry.getId() > 3) {
+        break;
+      }
+    }
     SchemaEntry valueSchema1 = schemaRORepo.getValueSchema(storeName, 1);
     Assert.assertNotNull(valueSchema1);
     Assert.assertEquals(valueSchema1.getSchema().toString(), Schema.parse(valueSchemaStr1).toString());

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/helix/TestHelixReadOnlySchemaRepository.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/helix/TestHelixReadOnlySchemaRepository.java
@@ -16,9 +16,7 @@ import com.linkedin.venice.schema.SchemaData;
 import com.linkedin.venice.schema.SchemaEntry;
 import com.linkedin.venice.utils.TestUtils;
 import com.linkedin.venice.utils.locks.ClusterLockManager;
-import java.util.ArrayList;
 import java.util.Collection;
-import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 import org.apache.avro.Schema;
@@ -154,14 +152,6 @@ public class TestHelixReadOnlySchemaRepository {
         TimeUnit.SECONDS,
         () -> schemaRORepo.getValueSchemas(storeName).size() == 2);
 
-    List<SchemaEntry> schemaEntries = new ArrayList<>(schemaRORepo.getValueSchemas(storeName));
-
-    schemaEntries.sort(comparingInt(SchemaEntry::getId));
-    for (SchemaEntry entry: schemaEntries) {
-      if (entry.getId() > 3) {
-        break;
-      }
-    }
     SchemaEntry valueSchema1 = schemaRORepo.getValueSchema(storeName, 1);
     Assert.assertNotNull(valueSchema1);
     Assert.assertEquals(valueSchema1.getSchema().toString(), Schema.parse(valueSchemaStr1).toString());


### PR DESCRIPTION
<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

##  Fix NPE in read compute store schema warm-up code
<!--
Describe
- What changes to make and why you are making these changes.
- How are you going to achieve your goal.
- Describe what testings you have done, for example, performance testing etc.

If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

For read compute store Venice warms the schema cache by generating the deserializers. But if we have schema deletion enabled and there is a gap in schema ID in schema repo, existing code could hit NPE. This PR fixes that. 

## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
CI
## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.