### PR TITLE
[admin-tool] Add support for toggling Store::isMigrating config via Admin-Tool

### DIFF
--- a/clients/venice-admin-tool/src/main/java/com/linkedin/venice/AdminTool.java
+++ b/clients/venice-admin-tool/src/main/java/com/linkedin/venice/AdminTool.java
@@ -1125,6 +1125,7 @@ public class AdminTool {
     booleanParam(cmd, Arg.SEPARATE_REALTIME_TOPIC_ENABLED, p -> params.setSeparateRealTimeTopicEnabled(p), argSet);
     booleanParam(cmd, Arg.WRITE_COMPUTATION_ENABLED, p -> params.setWriteComputationEnabled(p), argSet);
     booleanParam(cmd, Arg.READ_COMPUTATION_ENABLED, p -> params.setReadComputationEnabled(p), argSet);
+    booleanParam(cmd, Arg.STORE_MIGRATION, p -> params.setStoreMigration(p), argSet);
     integerParam(
         cmd,
         Arg.BOOTSTRAP_TO_ONLINE_TIMEOUT_IN_HOUR,

--- a/clients/venice-admin-tool/src/main/java/com/linkedin/venice/AdminTool.java
+++ b/clients/venice-admin-tool/src/main/java/com/linkedin/venice/AdminTool.java
@@ -1125,7 +1125,7 @@ public class AdminTool {
     booleanParam(cmd, Arg.SEPARATE_REALTIME_TOPIC_ENABLED, p -> params.setSeparateRealTimeTopicEnabled(p), argSet);
     booleanParam(cmd, Arg.WRITE_COMPUTATION_ENABLED, p -> params.setWriteComputationEnabled(p), argSet);
     booleanParam(cmd, Arg.READ_COMPUTATION_ENABLED, p -> params.setReadComputationEnabled(p), argSet);
-    booleanParam(cmd, Arg.STORE_MIGRATION, p -> params.setStoreMigration(p), argSet);
+    booleanParam(cmd, Arg.ENABLE_STORE_MIGRATION, p -> params.setStoreMigration(p), argSet);
     integerParam(
         cmd,
         Arg.BOOTSTRAP_TO_ONLINE_TIMEOUT_IN_HOUR,

--- a/clients/venice-admin-tool/src/main/java/com/linkedin/venice/Arg.java
+++ b/clients/venice-admin-tool/src/main/java/com/linkedin/venice/Arg.java
@@ -294,7 +294,7 @@ public enum Arg {
   ),
   DAVINCI_HEARTBEAT_REPORTED(
       "dvc-heartbeat-reported", "dvchb", true, "Flag to indicate whether DVC is bootstrapping and sending heartbeats"
-  );
+  ), STORE_MIGRATION("store-migration", "sm", true, "Enable store migration store config");
 
   private final String argName;
   private final String first;

--- a/clients/venice-admin-tool/src/main/java/com/linkedin/venice/Arg.java
+++ b/clients/venice-admin-tool/src/main/java/com/linkedin/venice/Arg.java
@@ -294,7 +294,7 @@ public enum Arg {
   ),
   DAVINCI_HEARTBEAT_REPORTED(
       "dvc-heartbeat-reported", "dvchb", true, "Flag to indicate whether DVC is bootstrapping and sending heartbeats"
-  ), STORE_MIGRATION("store-migration", "sm", true, "Enable store migration store config");
+  ), ENABLE_STORE_MIGRATION("enable-store-migration", "esm", true, "Toggle store migration store config");
 
   private final String argName;
   private final String first;

--- a/clients/venice-admin-tool/src/main/java/com/linkedin/venice/Command.java
+++ b/clients/venice-admin-tool/src/main/java/com/linkedin/venice/Command.java
@@ -120,6 +120,7 @@ import static com.linkedin.venice.Arg.STORAGE_PERSONA;
 import static com.linkedin.venice.Arg.STORAGE_QUOTA;
 import static com.linkedin.venice.Arg.STORE;
 import static com.linkedin.venice.Arg.STORES;
+import static com.linkedin.venice.Arg.STORE_MIGRATION;
 import static com.linkedin.venice.Arg.STORE_SIZE;
 import static com.linkedin.venice.Arg.STORE_TYPE;
 import static com.linkedin.venice.Arg.STORE_VIEW_CONFIGS;
@@ -278,7 +279,7 @@ public enum Command {
           MAX_COMPACTION_LAG_SECONDS, MAX_RECORD_SIZE_BYTES, MAX_NEARLINE_RECORD_SIZE_BYTES,
           UNUSED_SCHEMA_DELETION_ENABLED, BLOB_TRANSFER_ENABLED, SEPARATE_REALTIME_TOPIC_ENABLED,
           NEARLINE_PRODUCER_COMPRESSION_ENABLED, NEARLINE_PRODUCER_COUNT_PER_WRITER, TARGET_SWAP_REGION,
-          TARGET_SWAP_REGION_WAIT_TIME, DAVINCI_HEARTBEAT_REPORTED }
+          TARGET_SWAP_REGION_WAIT_TIME, DAVINCI_HEARTBEAT_REPORTED, STORE_MIGRATION }
   ),
   UPDATE_CLUSTER_CONFIG(
       "update-cluster-config", "Update live cluster configs", new Arg[] { URL, CLUSTER },

--- a/clients/venice-admin-tool/src/main/java/com/linkedin/venice/Command.java
+++ b/clients/venice-admin-tool/src/main/java/com/linkedin/venice/Command.java
@@ -31,6 +31,7 @@ import static com.linkedin.venice.Arg.DEST_ZOOKEEPER_URL;
 import static com.linkedin.venice.Arg.DISABLE_DAVINCI_PUSH_STATUS_STORE;
 import static com.linkedin.venice.Arg.DISABLE_META_STORE;
 import static com.linkedin.venice.Arg.ENABLE_DISABLED_REPLICA;
+import static com.linkedin.venice.Arg.ENABLE_STORE_MIGRATION;
 import static com.linkedin.venice.Arg.END_DATE;
 import static com.linkedin.venice.Arg.ETLED_PROXY_USER_ACCOUNT;
 import static com.linkedin.venice.Arg.EXECUTION;
@@ -120,7 +121,6 @@ import static com.linkedin.venice.Arg.STORAGE_PERSONA;
 import static com.linkedin.venice.Arg.STORAGE_QUOTA;
 import static com.linkedin.venice.Arg.STORE;
 import static com.linkedin.venice.Arg.STORES;
-import static com.linkedin.venice.Arg.STORE_MIGRATION;
 import static com.linkedin.venice.Arg.STORE_SIZE;
 import static com.linkedin.venice.Arg.STORE_TYPE;
 import static com.linkedin.venice.Arg.STORE_VIEW_CONFIGS;
@@ -279,7 +279,7 @@ public enum Command {
           MAX_COMPACTION_LAG_SECONDS, MAX_RECORD_SIZE_BYTES, MAX_NEARLINE_RECORD_SIZE_BYTES,
           UNUSED_SCHEMA_DELETION_ENABLED, BLOB_TRANSFER_ENABLED, SEPARATE_REALTIME_TOPIC_ENABLED,
           NEARLINE_PRODUCER_COMPRESSION_ENABLED, NEARLINE_PRODUCER_COUNT_PER_WRITER, TARGET_SWAP_REGION,
-          TARGET_SWAP_REGION_WAIT_TIME, DAVINCI_HEARTBEAT_REPORTED, STORE_MIGRATION }
+          TARGET_SWAP_REGION_WAIT_TIME, DAVINCI_HEARTBEAT_REPORTED, ENABLE_STORE_MIGRATION }
   ),
   UPDATE_CLUSTER_CONFIG(
       "update-cluster-config", "Update live cluster configs", new Arg[] { URL, CLUSTER },

--- a/internal/venice-common/src/main/java/com/linkedin/venice/controllerapi/ControllerApiConstants.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/controllerapi/ControllerApiConstants.java
@@ -83,7 +83,17 @@ public class ControllerApiConstants {
   public static final String PUSH_STRATEGY = "push_strategy";
 
   public static final String ACCESS_CONTROLLED = "access_controlled";
+  /**
+   * @deprecated Use {@link #ENABLE_STORE_MIGRATION} instead. This constant is kept for backward compatibility
+   * and will be removed in a future release.
+   */
+  @Deprecated
   public static final String STORE_MIGRATION = "store_migration";
+
+  /**
+   * Constant for enabling store migration. Replaces the deprecated {@link #STORE_MIGRATION}.
+   */
+  public static final String ENABLE_STORE_MIGRATION = "enable_store_migration";
 
   public static final String PUSH_JOB_STATUS = "push_job_status";
   public static final String PUSH_JOB_DURATION = "push_job_duration";

--- a/internal/venice-common/src/main/java/com/linkedin/venice/controllerapi/ControllerRoute.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/controllerapi/ControllerRoute.java
@@ -79,6 +79,7 @@ import static com.linkedin.venice.controllerapi.ControllerApiConstants.SOURCE_FA
 import static com.linkedin.venice.controllerapi.ControllerApiConstants.STATUS;
 import static com.linkedin.venice.controllerapi.ControllerApiConstants.STORAGE_NODE_ID;
 import static com.linkedin.venice.controllerapi.ControllerApiConstants.STORAGE_QUOTA_IN_BYTE;
+import static com.linkedin.venice.controllerapi.ControllerApiConstants.STORE_MIGRATION;
 import static com.linkedin.venice.controllerapi.ControllerApiConstants.STORE_TYPE;
 import static com.linkedin.venice.controllerapi.ControllerApiConstants.TOPIC;
 import static com.linkedin.venice.controllerapi.ControllerApiConstants.TOPIC_COMPACTION_POLICY;
@@ -128,7 +129,7 @@ public enum ControllerRoute {
       READ_COMPUTATION_ENABLED, BACKUP_STRATEGY, AUTO_SCHEMA_REGISTER_FOR_PUSHJOB_ENABLED, INCREMENTAL_PUSH_ENABLED,
       BOOTSTRAP_TO_ONLINE_TIMEOUT_IN_HOURS, HYBRID_STORE_DISK_QUOTA_ENABLED, REGULAR_VERSION_ETL_ENABLED,
       FUTURE_VERSION_ETL_ENABLED, ETLED_PROXY_USER_ACCOUNT, DISABLE_META_STORE, DISABLE_DAVINCI_PUSH_STATUS_STORE,
-      PERSONA_NAME, MAX_RECORD_SIZE_BYTES, MAX_NEARLINE_RECORD_SIZE_BYTES
+      PERSONA_NAME, MAX_RECORD_SIZE_BYTES, MAX_NEARLINE_RECORD_SIZE_BYTES, STORE_MIGRATION
   ), SET_VERSION("/set_version", HttpMethod.POST, Arrays.asList(NAME, VERSION)),
   ROLLBACK_TO_BACKUP_VERSION(
       "/rollback_to_backup_version", HttpMethod.POST, Collections.singletonList(NAME), REGIONS_FILTER

--- a/internal/venice-common/src/main/java/com/linkedin/venice/controllerapi/ControllerRoute.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/controllerapi/ControllerRoute.java
@@ -21,6 +21,7 @@ import static com.linkedin.venice.controllerapi.ControllerApiConstants.DISABLE_D
 import static com.linkedin.venice.controllerapi.ControllerApiConstants.DISABLE_META_STORE;
 import static com.linkedin.venice.controllerapi.ControllerApiConstants.ENABLE_DISABLED_REPLICAS;
 import static com.linkedin.venice.controllerapi.ControllerApiConstants.ENABLE_READS;
+import static com.linkedin.venice.controllerapi.ControllerApiConstants.ENABLE_STORE_MIGRATION;
 import static com.linkedin.venice.controllerapi.ControllerApiConstants.ENABLE_WRITES;
 import static com.linkedin.venice.controllerapi.ControllerApiConstants.ETLED_PROXY_USER_ACCOUNT;
 import static com.linkedin.venice.controllerapi.ControllerApiConstants.EXECUTION_ID;
@@ -129,7 +130,7 @@ public enum ControllerRoute {
       READ_COMPUTATION_ENABLED, BACKUP_STRATEGY, AUTO_SCHEMA_REGISTER_FOR_PUSHJOB_ENABLED, INCREMENTAL_PUSH_ENABLED,
       BOOTSTRAP_TO_ONLINE_TIMEOUT_IN_HOURS, HYBRID_STORE_DISK_QUOTA_ENABLED, REGULAR_VERSION_ETL_ENABLED,
       FUTURE_VERSION_ETL_ENABLED, ETLED_PROXY_USER_ACCOUNT, DISABLE_META_STORE, DISABLE_DAVINCI_PUSH_STATUS_STORE,
-      PERSONA_NAME, MAX_RECORD_SIZE_BYTES, MAX_NEARLINE_RECORD_SIZE_BYTES, STORE_MIGRATION
+      PERSONA_NAME, MAX_RECORD_SIZE_BYTES, MAX_NEARLINE_RECORD_SIZE_BYTES, STORE_MIGRATION, ENABLE_STORE_MIGRATION
   ), SET_VERSION("/set_version", HttpMethod.POST, Arrays.asList(NAME, VERSION)),
   ROLLBACK_TO_BACKUP_VERSION(
       "/rollback_to_backup_version", HttpMethod.POST, Collections.singletonList(NAME), REGIONS_FILTER

--- a/internal/venice-common/src/main/java/com/linkedin/venice/controllerapi/UpdateStoreQueryParams.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/controllerapi/UpdateStoreQueryParams.java
@@ -18,6 +18,7 @@ import static com.linkedin.venice.controllerapi.ControllerApiConstants.DISABLE_D
 import static com.linkedin.venice.controllerapi.ControllerApiConstants.DISABLE_META_STORE;
 import static com.linkedin.venice.controllerapi.ControllerApiConstants.DISABLE_STORE_VIEW;
 import static com.linkedin.venice.controllerapi.ControllerApiConstants.ENABLE_READS;
+import static com.linkedin.venice.controllerapi.ControllerApiConstants.ENABLE_STORE_MIGRATION;
 import static com.linkedin.venice.controllerapi.ControllerApiConstants.ENABLE_WRITES;
 import static com.linkedin.venice.controllerapi.ControllerApiConstants.ETLED_PROXY_USER_ACCOUNT;
 import static com.linkedin.venice.controllerapi.ControllerApiConstants.FUTURE_VERSION_ETL_ENABLED;
@@ -448,10 +449,14 @@ public class UpdateStoreQueryParams extends QueryParams {
   }
 
   public UpdateStoreQueryParams setStoreMigration(boolean migrating) {
-    return putBoolean(STORE_MIGRATION, migrating);
+    return putBoolean(STORE_MIGRATION, migrating).putBoolean(ENABLE_STORE_MIGRATION, migrating);
   }
 
   public Optional<Boolean> getStoreMigration() {
+    Optional<Boolean> storeMigration = getBoolean(ENABLE_STORE_MIGRATION);
+    if (storeMigration.isPresent()) {
+      return storeMigration;
+    }
     return getBoolean(STORE_MIGRATION);
   }
 

--- a/internal/venice-common/src/test/java/com/linkedin/venice/controllerapi/UpdateStoreQueryParamsTest.java
+++ b/internal/venice-common/src/test/java/com/linkedin/venice/controllerapi/UpdateStoreQueryParamsTest.java
@@ -1,0 +1,26 @@
+package com.linkedin.venice.controllerapi;
+
+import static com.linkedin.venice.controllerapi.ControllerApiConstants.ENABLE_STORE_MIGRATION;
+import static com.linkedin.venice.controllerapi.ControllerApiConstants.STORE_MIGRATION;
+import static org.testng.Assert.assertEquals;
+
+import java.util.Optional;
+import org.testng.annotations.Test;
+
+
+public class UpdateStoreQueryParamsTest {
+  @Test
+  public void testSetStoreMigrationSetsBothKeys() {
+    UpdateStoreQueryParams params = new UpdateStoreQueryParams();
+    params.setStoreMigration(true);
+    assertEquals(params.getStoreMigration(), Optional.of(Boolean.TRUE));
+    assertEquals(params.getString(STORE_MIGRATION).orElse(null), "true");
+    assertEquals(params.getString(ENABLE_STORE_MIGRATION).orElse(null), "true");
+
+    params = new UpdateStoreQueryParams();
+    params.setStoreMigration(false);
+    assertEquals(params.getStoreMigration(), Optional.of(Boolean.FALSE));
+    assertEquals(params.getString(STORE_MIGRATION).orElse(null), "false");
+    assertEquals(params.getString(ENABLE_STORE_MIGRATION).orElse(null), "false");
+  }
+}

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/controller/AdminToolE2ETest.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/controller/AdminToolE2ETest.java
@@ -285,14 +285,14 @@ public class AdminToolE2ETest {
 
       // Update store migration status to true
       String[] adminToolArgs = new String[] { "--url", parentControllerClient.getLeaderControllerUrl(), "--cluster",
-          clusterName, "--store", storeName, "--update-store", "--store-migration", "true" };
+          clusterName, "--store", storeName, "--update-store", "--enable-store-migration", "true" };
       AdminTool.main(adminToolArgs);
       validateStoreMigrationStatus(parentControllerClient, storeName, true, "parentController");
       validateStoreMigrationStatusAcrossChildRegions(storeName, clusterName, true);
 
       // Set back status to false and validate
       adminToolArgs = new String[] { "--url", parentControllerClient.getLeaderControllerUrl(), "--cluster", clusterName,
-          "--store", storeName, "--update-store", "--store-migration", "false" };
+          "--store", storeName, "--update-store", "--enable-store-migration", "false" };
       AdminTool.main(adminToolArgs);
       validateStoreMigrationStatus(parentControllerClient, storeName, false, "parentController");
       validateStoreMigrationStatusAcrossChildRegions(storeName, clusterName, false);

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/controller/AdminToolE2ETest.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/controller/AdminToolE2ETest.java
@@ -12,24 +12,29 @@ import com.linkedin.venice.controllerapi.ControllerClient;
 import com.linkedin.venice.controllerapi.MultiStoreResponse;
 import com.linkedin.venice.controllerapi.NewStoreResponse;
 import com.linkedin.venice.controllerapi.StoreResponse;
+import com.linkedin.venice.controllerapi.UpdateStoreQueryParams;
 import com.linkedin.venice.integration.utils.ServiceFactory;
+import com.linkedin.venice.integration.utils.VeniceControllerWrapper;
 import com.linkedin.venice.integration.utils.VeniceMultiClusterWrapper;
 import com.linkedin.venice.integration.utils.VeniceTwoLayerMultiRegionMultiClusterWrapper;
+import com.linkedin.venice.meta.StoreInfo;
 import com.linkedin.venice.utils.TestUtils;
 import com.linkedin.venice.utils.Utils;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Properties;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 
-public class AdminToolBackfillTest {
+public class AdminToolE2ETest {
   private static final int TEST_TIMEOUT = 300_000; // empty push on push status store takes a long time to finish
 
   private static final int NUMBER_OF_CHILD_DATACENTERS = 2; // DO NOT CHANGE
@@ -260,5 +265,53 @@ public class AdminToolBackfillTest {
     assertTrue(
         allStores.contains(pushStatusStoreName),
         pushStatusStoreName + " is not present in list store response with " + clientName);
+  }
+
+  @Test(timeOut = TEST_TIMEOUT)
+  public void testUpdateStoreMigrationStatus() throws Exception {
+    String storeName = Utils.getUniqueString("testUpdateStoreMigrationStatus");
+    List<VeniceControllerWrapper> parentControllers = multiRegionMultiClusterWrapper.getParentControllers();
+    String clusterName = clusterNames[0];
+    String parentControllerURLs =
+        parentControllers.stream().map(VeniceControllerWrapper::getControllerUrl).collect(Collectors.joining(","));
+
+    try (ControllerClient parentControllerClient = new ControllerClient(clusterName, parentControllerURLs);) {
+      TestUtils.assertCommand(
+          parentControllerClient
+              .retryableRequest(5, c -> c.createNewStore(storeName, "test", "\"string\"", "\"string\"")));
+
+      StoreResponse storeResponse = TestUtils.assertCommand(parentControllerClient.getStore(storeName));
+      StoreInfo storeInfo = Objects.requireNonNull(storeResponse.getStore(), "Store not found");
+      assertFalse(storeInfo.isMigrating(), "Store::isMigrating should be false");
+      // Update store migration status
+      parentControllerClient.updateStore(storeName, new UpdateStoreQueryParams().setStoreMigration(true));
+
+      String[] adminToolArgs = new String[] { "--url", parentControllerClient.getLeaderControllerUrl(), "--cluster",
+          clusterName, "--store", storeName, "--update-store", "--store-migration", "true" };
+      AdminTool.main(adminToolArgs);
+
+      TestUtils.waitForNonDeterministicAssertion(30, TimeUnit.SECONDS, () -> {
+        StoreResponse updatedStoreResponse = parentControllerClient.getStore(storeName);
+        StoreInfo updatedStoreInfo =
+            Objects.requireNonNull(updatedStoreResponse.getStore(), "Store not found in parent controller");
+        assertTrue(updatedStoreInfo.isMigrating(), "Store::isMigrating should be true in parent controller");
+      });
+
+      for (VeniceMultiClusterWrapper childRegion: childDatacenters) {
+        try (ControllerClient childControllerClient =
+            new ControllerClient(clusterName, childRegion.getControllerConnectString())) {
+          TestUtils.waitForNonDeterministicAssertion(30, TimeUnit.SECONDS, () -> {
+            StoreResponse updatedStoreResponse = childControllerClient.getStore(storeName);
+            StoreInfo updatedStoreInfo = Objects.requireNonNull(
+                updatedStoreResponse.getStore(),
+                "Store not found in child controller: " + childRegion.getRegionName());
+            assertTrue(
+                updatedStoreInfo.isMigrating(),
+                "Store::isMigrating should be true in child controller: " + childRegion.getRegionName());
+          });
+        }
+      }
+
+    }
   }
 }

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceParentHelixAdmin.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceParentHelixAdmin.java
@@ -20,6 +20,7 @@ import static com.linkedin.venice.controllerapi.ControllerApiConstants.DATA_REPL
 import static com.linkedin.venice.controllerapi.ControllerApiConstants.DISABLE_DAVINCI_PUSH_STATUS_STORE;
 import static com.linkedin.venice.controllerapi.ControllerApiConstants.DISABLE_META_STORE;
 import static com.linkedin.venice.controllerapi.ControllerApiConstants.ENABLE_READS;
+import static com.linkedin.venice.controllerapi.ControllerApiConstants.ENABLE_STORE_MIGRATION;
 import static com.linkedin.venice.controllerapi.ControllerApiConstants.ENABLE_WRITES;
 import static com.linkedin.venice.controllerapi.ControllerApiConstants.ETLED_PROXY_USER_ACCOUNT;
 import static com.linkedin.venice.controllerapi.ControllerApiConstants.FUTURE_VERSION_ETL_ENABLED;
@@ -2557,8 +2558,10 @@ public class VeniceParentHelixAdmin implements Admin {
       setStore.numVersionsToPreserve =
           numVersionsToPreserve.map(addToUpdatedConfigList(updatedConfigsList, NUM_VERSIONS_TO_PRESERVE))
               .orElseGet(currStore::getNumVersionsToPreserve);
-      setStore.isMigrating = storeMigration.map(addToUpdatedConfigList(updatedConfigsList, STORE_MIGRATION))
-          .orElseGet(currStore::isMigrating);
+      setStore.isMigrating =
+          storeMigration.map(addToUpdatedConfigList(updatedConfigsList, STORE_MIGRATION, ENABLE_STORE_MIGRATION))
+
+              .orElseGet(currStore::isMigrating);
       setStore.replicationMetadataVersionID = replicationMetadataVersionID
           .map(addToUpdatedConfigList(updatedConfigsList, REPLICATION_METADATA_PROTOCOL_VERSION_ID))
           .orElse(currStore.getRmdVersion());
@@ -5077,6 +5080,17 @@ public class VeniceParentHelixAdmin implements Admin {
   private <T> Function<T, T> addToUpdatedConfigList(List<CharSequence> updatedConfigList, String config) {
     return (configValue) -> {
       updatedConfigList.add(config);
+      return configValue;
+    };
+  }
+
+  static private <T> Function<T, T> addToUpdatedConfigList(
+      List<CharSequence> updatedConfigList,
+      String config,
+      String legacyConfigName) {
+    return (configValue) -> {
+      updatedConfigList.add(config);
+      updatedConfigList.add(legacyConfigName);
       return configValue;
     };
   }

--- a/services/venice-controller/src/test/java/com/linkedin/venice/controller/kafka/consumer/AdminConsumptionTaskTest.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/controller/kafka/consumer/AdminConsumptionTaskTest.java
@@ -4,6 +4,7 @@ import static com.linkedin.venice.controllerapi.ControllerApiConstants.ACCESS_CO
 import static com.linkedin.venice.controllerapi.ControllerApiConstants.AMPLIFICATION_FACTOR;
 import static com.linkedin.venice.controllerapi.ControllerApiConstants.BOOTSTRAP_TO_ONLINE_TIMEOUT_IN_HOURS;
 import static com.linkedin.venice.controllerapi.ControllerApiConstants.ENABLE_READS;
+import static com.linkedin.venice.controllerapi.ControllerApiConstants.ENABLE_STORE_MIGRATION;
 import static com.linkedin.venice.controllerapi.ControllerApiConstants.ENABLE_WRITES;
 import static com.linkedin.venice.controllerapi.ControllerApiConstants.ETLED_PROXY_USER_ACCOUNT;
 import static com.linkedin.venice.controllerapi.ControllerApiConstants.INCREMENTAL_PUSH_ENABLED;
@@ -14,7 +15,6 @@ import static com.linkedin.venice.controllerapi.ControllerApiConstants.PARTITION
 import static com.linkedin.venice.controllerapi.ControllerApiConstants.PARTITION_COUNT;
 import static com.linkedin.venice.controllerapi.ControllerApiConstants.READ_COMPUTATION_ENABLED;
 import static com.linkedin.venice.controllerapi.ControllerApiConstants.REWIND_TIME_IN_SECONDS;
-import static com.linkedin.venice.controllerapi.ControllerApiConstants.STORE_MIGRATION;
 import static com.linkedin.venice.controllerapi.ControllerApiConstants.TIME_LAG_TO_GO_ONLINE;
 import static com.linkedin.venice.controllerapi.ControllerApiConstants.VERSION;
 import static com.linkedin.venice.controllerapi.ControllerApiConstants.WRITE_COMPUTATION_ENABLED;
@@ -957,7 +957,7 @@ public class AdminConsumptionTaskTest {
       setStore.updatedConfigsList.add(ENABLE_WRITES);
       setStore.updatedConfigsList.add(ACCESS_CONTROLLED);
       setStore.updatedConfigsList.add(INCREMENTAL_PUSH_ENABLED);
-      setStore.updatedConfigsList.add(STORE_MIGRATION);
+      setStore.updatedConfigsList.add(ENABLE_STORE_MIGRATION);
       setStore.updatedConfigsList.add(WRITE_COMPUTATION_ENABLED);
       setStore.updatedConfigsList.add(READ_COMPUTATION_ENABLED);
       setStore.updatedConfigsList.add(BOOTSTRAP_TO_ONLINE_TIMEOUT_IN_HOURS);


### PR DESCRIPTION

## Add support for toggling Store::isMigrating config via Admin-Tool

In certain scenarios, toggling the Store::isMigrating flag is necessary to safely clean up
lingering states in destination cluster during abort migration. However, the admin tool
currently lacks the capability to update this configuration.

This PR introduces support for enabling or disabling the Store::isMigrating config through
the admin tool.
## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
E2E test

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.