### PR TITLE
[vpj][admin-tool] Remove subscription from consumer after dictionary download in DictionaryUtils::readDictionaryFromKafka

### DIFF
--- a/internal/venice-common/src/test/java/com/linkedin/venice/utils/DictionaryUtilsTest.java
+++ b/internal/venice-common/src/test/java/com/linkedin/venice/utils/DictionaryUtilsTest.java
@@ -1,6 +1,7 @@
 package com.linkedin.venice.utils;
 
 import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
@@ -65,6 +66,8 @@ public class DictionaryUtilsTest {
     ByteBuffer dictionaryFromKafka =
         DictionaryUtils.readDictionaryFromKafka(topic.getName(), pubSubConsumer, pubSubTopicRepository);
     Assert.assertEquals(dictionaryFromKafka.array(), dictionaryToSend);
+    verify(pubSubConsumer, times(1)).subscribe(eq(topicPartition), anyLong());
+    verify(pubSubConsumer, times(1)).unSubscribe(topicPartition);
     verify(pubSubConsumer, times(1)).poll(anyLong());
   }
 
@@ -94,6 +97,8 @@ public class DictionaryUtilsTest {
     ByteBuffer dictionaryFromKafka =
         DictionaryUtils.readDictionaryFromKafka(topic.getName(), pubSubConsumer, pubSubTopicRepository);
     Assert.assertNull(dictionaryFromKafka);
+    verify(pubSubConsumer, times(1)).subscribe(eq(topicPartition), anyLong());
+    verify(pubSubConsumer, times(1)).unSubscribe(topicPartition);
     verify(pubSubConsumer, times(1)).poll(anyLong());
   }
 
@@ -121,6 +126,8 @@ public class DictionaryUtilsTest {
     ByteBuffer dictionaryFromKafka =
         DictionaryUtils.readDictionaryFromKafka(topic.getName(), pubSubConsumer, pubSubTopicRepository);
     Assert.assertNull(dictionaryFromKafka);
+    verify(pubSubConsumer, times(1)).subscribe(eq(topicPartition), anyLong());
+    verify(pubSubConsumer, times(1)).unSubscribe(topicPartition);
     verify(pubSubConsumer, times(1)).poll(anyLong());
   }
 
@@ -154,6 +161,8 @@ public class DictionaryUtilsTest {
     ByteBuffer dictionaryFromKafka =
         DictionaryUtils.readDictionaryFromKafka(topic.getName(), pubSubConsumer, pubSubTopicRepository);
     Assert.assertEquals(dictionaryFromKafka.array(), dictionaryToSend);
+    verify(pubSubConsumer, times(1)).subscribe(eq(topicPartition), anyLong());
+    verify(pubSubConsumer, times(1)).unSubscribe(topicPartition);
     verify(pubSubConsumer, times(2)).poll(anyLong());
   }
 }


### PR DESCRIPTION
## Remove subscription from consumer after dictionary download in DictionaryUtils::readDictionaryFromKafka

This change ensures that the subscription is cleaned up from the PubSub consumer once the
dictionary is downloaded in DictionaryUtils::readDictionaryFromKafka. Without this
cleanup, subsequent attempts to resubscribe to the same topic partition are ignored which
can have side effects.

This issue particularly impacts the admin tool, as it uses the same consumer for
dictionary downloads and then tries to subscribe to the same partition for dumping
messages. The resubscription request is rejected because the consumer already has an
active subscription from the dictionary fetch operation. Consequently, the dumper cannot
seek to the provided offset if the partition being dumped is 0 (the same partition used
during dictionary download).

By removing the subscription after the dictionary is fetched, this fix ensures that
subsequent operations, such as seek and subscribe for message dumping, work as expected.

## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
UT and CI

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.