### PR TITLE
[da-vinci] DVC batch incremental push status across all partitions on the same node

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/DaVinciBackend.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/DaVinciBackend.java
@@ -625,10 +625,10 @@ public class DaVinciBackend implements Closeable {
     VersionBackend versionBackend = versionByTopicMap.get(kafkaTopic);
     if (versionBackend != null && versionBackend.isReportingPushStatus()) {
       Version version = versionBackend.getVersion();
-      if (writeBatchingPushStatus && !incrementalPushVersion.isPresent()) {
-        // Batching the push statuses from all partitions for batch pushes;
+      if (writeBatchingPushStatus) {
+        // Batching the push statuses from all partitions;
         // VersionBackend will handle the push status update to Venice backend
-        versionBackend.updatePartitionStatus(partition, status);
+        versionBackend.updatePartitionStatus(partition, status, incrementalPushVersion);
       } else {
         pushStatusStoreWriter
             .writePushStatus(version.getStoreName(), version.getNumber(), partition, status, incrementalPushVersion);

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/VersionBackend.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/VersionBackend.java
@@ -523,9 +523,9 @@ public class VersionBackend {
         .collect(Collectors.toList());
   }
 
-  public void updatePartitionStatus(int partition, ExecutionStatus status) {
+  public void updatePartitionStatus(int partition, ExecutionStatus status, Optional<String> incrementalPushVersion) {
     if (daVinciPushStatusUpdateTask != null) {
-      daVinciPushStatusUpdateTask.updatePartitionStatus(partition, status);
+      daVinciPushStatusUpdateTask.updatePartitionStatus(partition, status, incrementalPushVersion);
     }
   }
 }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/notifier/DaVinciPushStatusUpdateTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/notifier/DaVinciPushStatusUpdateTask.java
@@ -206,5 +206,12 @@ public class DaVinciPushStatusUpdateTask {
       this.startSignalSent = false;
       this.endSignalSent = false;
     }
+
+    @Override
+    public String toString() {
+      return "IncrementalPushStatus{" + "incrementalPushVersion='" + incrementalPushVersion + '\''
+          + ", startSignalSent=" + startSignalSent + ", endSignalSent=" + endSignalSent + ", partitionStatus="
+          + partitionStatus + '}';
+    }
   }
 }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/notifier/DaVinciPushStatusUpdateTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/notifier/DaVinciPushStatusUpdateTask.java
@@ -143,7 +143,7 @@ public class DaVinciPushStatusUpdateTask {
   public Set<Integer> getTrackedPartitions(Optional<String> incrementalPushVersion) {
     if (incrementalPushVersion.isPresent()) {
       IncrementalPushStatus incrementalPushStatus = incrementalPushVersionToStatus.get(incrementalPushVersion.get());
-      return (incrementalPushStatus == null) ? Collections.EMPTY_SET : incrementalPushStatus.partitionStatus.keySet();
+      return (incrementalPushStatus == null) ? Collections.emptySet() : incrementalPushStatus.partitionStatus.keySet();
     } else {
       return batchPushPartitionStatus.keySet();
     }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/notifier/DaVinciPushStatusUpdateTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/notifier/DaVinciPushStatusUpdateTask.java
@@ -5,26 +5,32 @@ import com.linkedin.venice.pushmonitor.ExecutionStatus;
 import com.linkedin.venice.pushstatushelper.PushStatusStoreWriter;
 import com.linkedin.venice.utils.DaemonThreadFactory;
 import com.linkedin.venice.utils.concurrent.VeniceConcurrentHashMap;
+import java.util.Collections;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 
 /**
  * This is a scheduler for sending batching push status in DaVinci.
  */
 public class DaVinciPushStatusUpdateTask {
+  private static final Logger LOGGER = LogManager.getLogger(DaVinciPushStatusUpdateTask.class);
   private final Version version;
   private final PushStatusStoreWriter pushStatusStoreWriter;
   private boolean batchPushStartSignalSent;
   private boolean batchPushEndSignalSent;
   private final long daVinciPushStatusCheckIntervalInMs;
   private final Supplier<Boolean> areAllPartitionFuturesCompletedSuccessfully;
-  private final Map<Integer, ExecutionStatus> partitionStatus = new VeniceConcurrentHashMap<>();
-  // Executor for scheduling tasks
+  private final Map<Integer, ExecutionStatus> batchPushPartitionStatus = new VeniceConcurrentHashMap<>();
+  private final Map<String, IncrementalPushStatus> incrementalPushVersionToStatus = new VeniceConcurrentHashMap<>();
   private final ScheduledExecutorService scheduler =
       Executors.newScheduledThreadPool(1, new DaemonThreadFactory("davinci-push-status-update-task-scheduler"));
 
@@ -57,75 +63,148 @@ public class DaVinciPushStatusUpdateTask {
     this.batchPushEndSignalSent = true;
   }
 
-  public void updatePartitionStatus(int partition, ExecutionStatus status) {
-    partitionStatus.put(partition, status);
+  public void updatePartitionStatus(int partition, ExecutionStatus status, Optional<String> incrementalPushVersion) {
+    if (incrementalPushVersion.isPresent()) {
+      updateIncrementalPushStatus(incrementalPushVersion.get(), partition, status);
+    } else {
+      batchPushPartitionStatus.put(partition, status);
+    }
+  }
+
+  private void updateIncrementalPushStatus(String incrementalPushVersion, int partition, ExecutionStatus status) {
+    IncrementalPushStatus incrementalPushStatus = incrementalPushVersionToStatus
+        .computeIfAbsent(incrementalPushVersion, k -> new IncrementalPushStatus(incrementalPushVersion));
+
+    if (incrementalPushStatus.endSignalSent) {
+      LOGGER.warn(
+          "Received status update for store version {} partition {} with status {} for incremental push version {} after terminal signal is sent; ignoring it",
+          version.kafkaTopicName(),
+          partition,
+          status,
+          incrementalPushVersion);
+      return;
+    }
+    incrementalPushStatus.partitionStatus.put(partition, status);
   }
 
   private void maybeSendBatchingStatus() {
-    // First, check if the batch push start signal has been sent, if not, send out STARTED status for this version
-    // immediately, regardless if there is any partition subscription happened (this is also needed for delayed version
-    // swap for DaVinci during target colo pushes)
-    // If STARTED is sent, and if COMPLETED is not sent, check if all partitions are in COMPLETED status. If so, send
-    // the COMPLETED status.
+    handleBatchPushStatus();
+    handleIncrementalPushStatus();
+  }
+
+  private void handleBatchPushStatus() {
     if (!isBatchPushStartSignalSent()) {
-      pushStatusStoreWriter.writeVersionLevelPushStatus(
-          version.getStoreName(),
-          version.getNumber(),
-          ExecutionStatus.STARTED,
-          getTrackedPartitions());
+      sendPushStatus(ExecutionStatus.STARTED, Optional.empty());
       batchPushStartSignalSent();
-    } else if (!isBatchPushEndSignalSent() && areAllPartitionsOnSameTerminalStatus(ExecutionStatus.COMPLETED)
+    } else if (!isBatchPushEndSignalSent()
+        && areAllPartitionsOnSameTerminalStatus(ExecutionStatus.COMPLETED, Optional.empty())
         && areAllPartitionFuturesCompletedSuccessfully.get()) {
-      pushStatusStoreWriter.writeVersionLevelPushStatus(
-          version.getStoreName(),
-          version.getNumber(),
-          ExecutionStatus.COMPLETED,
-          getTrackedPartitions());
+      sendPushStatus(ExecutionStatus.COMPLETED, Optional.empty());
       batchPushEndSignalSent();
-      // Shutdown the scheduler after sending the final status
-      shutdown();
-    } else if (!isBatchPushEndSignalSent() && isAnyPartitionOnErrorStatus()) {
-      pushStatusStoreWriter.writeVersionLevelPushStatus(
-          version.getStoreName(),
-          version.getNumber(),
-          ExecutionStatus.ERROR,
-          getTrackedPartitions());
+      batchPushPartitionStatus.clear();
+    } else if (!isBatchPushEndSignalSent() && isAnyPartitionOnErrorStatus(Optional.empty())) {
+      sendPushStatus(ExecutionStatus.ERROR, Optional.empty());
       batchPushEndSignalSent();
-      // Shutdown the scheduler after sending the final status
-      shutdown();
+      batchPushPartitionStatus.clear();
     }
   }
 
-  /**
-   * Get the partition id set that is being tracked
-   */
-  public Set<Integer> getTrackedPartitions() {
-    return partitionStatus.keySet();
+  private void handleIncrementalPushStatus() {
+    incrementalPushVersionToStatus.forEach((incrementalPushVersion, incrementalPushStatus) -> {
+      if (!incrementalPushStatus.startSignalSent) {
+        sendPushStatus(ExecutionStatus.START_OF_INCREMENTAL_PUSH_RECEIVED, Optional.of(incrementalPushVersion));
+        incrementalPushStatus.startSignalSent = true;
+      } else if (!incrementalPushStatus.endSignalSent && areAllPartitionsOnSameTerminalStatus(
+          ExecutionStatus.END_OF_INCREMENTAL_PUSH_RECEIVED,
+          Optional.of(incrementalPushVersion))) {
+        sendPushStatus(ExecutionStatus.END_OF_INCREMENTAL_PUSH_RECEIVED, Optional.of(incrementalPushVersion));
+        incrementalPushStatus.endSignalSent = true;
+        // Clean up the status map for incremental push versions in case there are too many of them and cause OOM
+        incrementalPushStatus.partitionStatus.clear();
+      } else if (!incrementalPushStatus.endSignalSent
+          && isAnyPartitionOnErrorStatus(Optional.of(incrementalPushVersion))) {
+        sendPushStatus(ExecutionStatus.ERROR, Optional.of(incrementalPushVersion));
+        incrementalPushStatus.endSignalSent = true;
+        // Clean up the status map for incremental push versions in case there are too many of them and cause OOM
+        incrementalPushStatus.partitionStatus.clear();
+      }
+    });
   }
 
-  public boolean areAllPartitionsOnSameTerminalStatus(ExecutionStatus status) {
+  private void sendPushStatus(ExecutionStatus status, Optional<String> incrementalPushVersion) {
+    pushStatusStoreWriter.writeVersionLevelPushStatus(
+        version.getStoreName(),
+        version.getNumber(),
+        status,
+        getTrackedPartitions(incrementalPushVersion),
+        incrementalPushVersion);
+  }
+
+  public Set<Integer> getTrackedPartitions(Optional<String> incrementalPushVersion) {
+    if (incrementalPushVersion.isPresent()) {
+      IncrementalPushStatus incrementalPushStatus = incrementalPushVersionToStatus.get(incrementalPushVersion.get());
+      return (incrementalPushStatus == null) ? Collections.EMPTY_SET : incrementalPushStatus.partitionStatus.keySet();
+    } else {
+      return batchPushPartitionStatus.keySet();
+    }
+  }
+
+  public boolean areAllPartitionsOnSameTerminalStatus(ExecutionStatus status, Optional<String> incrementalPushVersion) {
+    return arePartitionsOnTargetStatus(status, incrementalPushVersion, true);
+  }
+
+  public boolean isAnyPartitionOnErrorStatus(Optional<String> incrementalPushVersion) {
+    return arePartitionsOnTargetStatus(ExecutionStatus.ERROR, incrementalPushVersion, false);
+  }
+
+  private boolean arePartitionsOnTargetStatus(
+      ExecutionStatus status,
+      Optional<String> incrementalPushVersion,
+      boolean allMatch) {
+    Map<Integer, ExecutionStatus> partitionStatus = getPartitionStatus(incrementalPushVersion);
     if (partitionStatus.isEmpty()) {
       return false;
     }
-    return partitionStatus.values().stream().allMatch(status::equals);
+    return allMatch
+        ? partitionStatus.values().stream().allMatch(status::equals)
+        : partitionStatus.values().stream().anyMatch(status::equals);
   }
 
-  public boolean isAnyPartitionOnErrorStatus() {
-    if (partitionStatus.isEmpty()) {
-      return false;
+  private Map<Integer, ExecutionStatus> getPartitionStatus(Optional<String> incrementalPushVersion) {
+    if (incrementalPushVersion.isPresent()) {
+      IncrementalPushStatus incrementalPushStatus = incrementalPushVersionToStatus.get(incrementalPushVersion.get());
+      if (incrementalPushStatus == null) {
+        return Collections.EMPTY_MAP;
+      }
+      return incrementalPushStatus.partitionStatus;
+    } else {
+      return batchPushPartitionStatus;
     }
-    return partitionStatus.values().stream().anyMatch(ExecutionStatus.ERROR::equals);
   }
 
   public void start() {
-    // Schedule a task to check current status of all hosted partitions periodically
-    scheduler.scheduleAtFixedRate(() -> {
-      maybeSendBatchingStatus();
-    }, 0, daVinciPushStatusCheckIntervalInMs, TimeUnit.MILLISECONDS);
+    scheduler.scheduleAtFixedRate(
+        this::maybeSendBatchingStatus,
+        0,
+        daVinciPushStatusCheckIntervalInMs,
+        TimeUnit.MILLISECONDS);
   }
 
-  // Shutdown the scheduler gracefully
   public void shutdown() {
     scheduler.shutdown();
+  }
+
+  private static class IncrementalPushStatus {
+    private final String incrementalPushVersion;
+    private boolean startSignalSent;
+    private boolean endSignalSent;
+    private Map<Integer, ExecutionStatus> partitionStatus;
+
+    public IncrementalPushStatus(String incrementalPushVersion) {
+      this.incrementalPushVersion = incrementalPushVersion;
+      this.partitionStatus = new ConcurrentHashMap<>();
+      this.startSignalSent = false;
+      this.endSignalSent = false;
+    }
   }
 }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/notifier/DaVinciPushStatusUpdateTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/notifier/DaVinciPushStatusUpdateTask.java
@@ -121,12 +121,6 @@ public class DaVinciPushStatusUpdateTask {
         incrementalPushStatus.endSignalSent = true;
         // Clean up the status map for incremental push versions in case there are too many of them and cause OOM
         incrementalPushStatus.partitionStatus.clear();
-      } else if (!incrementalPushStatus.endSignalSent
-          && isAnyPartitionOnErrorStatus(Optional.of(incrementalPushVersion))) {
-        sendPushStatus(ExecutionStatus.ERROR, Optional.of(incrementalPushVersion));
-        incrementalPushStatus.endSignalSent = true;
-        // Clean up the status map for incremental push versions in case there are too many of them and cause OOM
-        incrementalPushStatus.partitionStatus.clear();
       }
     });
   }

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/notifier/TestDaVinciPushStatusUpdateTask.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/notifier/TestDaVinciPushStatusUpdateTask.java
@@ -55,29 +55,143 @@ public class TestDaVinciPushStatusUpdateTask {
     // Start the task
     task.start();
     TestUtils.waitForNonDeterministicAssertion(5, TimeUnit.SECONDS, () -> {
-      verify(pushStatusStoreWriter, times(1)).writeVersionLevelPushStatus(
-          eq(storeName),
-          eq(versionNumber),
-          eq(ExecutionStatus.STARTED),
-          any(),
-          Optional.empty());
+      verify(pushStatusStoreWriter, times(1))
+          .writeVersionLevelPushStatus(eq(storeName), eq(versionNumber), eq(ExecutionStatus.STARTED), any(), any());
       // However, COMPLETED status should never be sent
-      verify(pushStatusStoreWriter, never()).writeVersionLevelPushStatus(
-          eq(storeName),
-          eq(versionNumber),
-          eq(ExecutionStatus.COMPLETED),
-          any(),
-          Optional.empty());
+      verify(pushStatusStoreWriter, never())
+          .writeVersionLevelPushStatus(eq(storeName), eq(versionNumber), eq(ExecutionStatus.COMPLETED), any(), any());
     });
     // Update the push status of partition 4 to COMPLETED too
     task.updatePartitionStatus(4, ExecutionStatus.COMPLETED, Optional.empty());
     TestUtils.waitForNonDeterministicAssertion(5, TimeUnit.SECONDS, () -> {
+      verify(pushStatusStoreWriter, times(1))
+          .writeVersionLevelPushStatus(eq(storeName), eq(versionNumber), eq(ExecutionStatus.COMPLETED), any(), any());
+    });
+    task.shutdown();
+  }
+
+  @Test
+  public void testUpdateTaskForIncrementalPush() {
+    String storeName = Utils.getUniqueString("test-store");
+    int versionNumber = 1;
+    Version version = mock(Version.class);
+    doReturn(storeName).when(version).getStoreName();
+    doReturn(versionNumber).when(version).getNumber();
+    PushStatusStoreWriter pushStatusStoreWriter = mock(PushStatusStoreWriter.class);
+    // Always return true for this supplier since there is no VersionBackend
+    Supplier<Boolean> areAllPartitionFuturesCompletedSuccessfully = () -> true;
+    DaVinciPushStatusUpdateTask task = new DaVinciPushStatusUpdateTask(
+        version,
+        100,
+        pushStatusStoreWriter,
+        areAllPartitionFuturesCompletedSuccessfully);
+
+    // Two incremental pushes running at the same time
+    String incrementalPushVersion1 = "incremental-push-1";
+    String incrementalPushVersion2 = "incremental-push-2";
+    task.updatePartitionStatus(
+        1,
+        ExecutionStatus.END_OF_INCREMENTAL_PUSH_RECEIVED,
+        Optional.of(incrementalPushVersion1));
+    task.updatePartitionStatus(
+        2,
+        ExecutionStatus.END_OF_INCREMENTAL_PUSH_RECEIVED,
+        Optional.of(incrementalPushVersion1));
+    task.updatePartitionStatus(
+        3,
+        ExecutionStatus.END_OF_INCREMENTAL_PUSH_RECEIVED,
+        Optional.of(incrementalPushVersion1));
+    task.updatePartitionStatus(
+        1,
+        ExecutionStatus.START_OF_INCREMENTAL_PUSH_RECEIVED,
+        Optional.of(incrementalPushVersion2));
+    task.updatePartitionStatus(
+        2,
+        ExecutionStatus.END_OF_INCREMENTAL_PUSH_RECEIVED,
+        Optional.of(incrementalPushVersion2));
+    task.updatePartitionStatus(
+        3,
+        ExecutionStatus.END_OF_INCREMENTAL_PUSH_RECEIVED,
+        Optional.of(incrementalPushVersion2));
+    // Verify that the status is consistent across all partitions
+    assertTrue(
+        task.areAllPartitionsOnSameTerminalStatus(
+            ExecutionStatus.END_OF_INCREMENTAL_PUSH_RECEIVED,
+            Optional.of(incrementalPushVersion1)));
+    assertFalse(
+        task.areAllPartitionsOnSameTerminalStatus(
+            ExecutionStatus.END_OF_INCREMENTAL_PUSH_RECEIVED,
+            Optional.of(incrementalPushVersion2)));
+
+    // Set partition 4 to ERROR
+    task.updatePartitionStatus(4, ExecutionStatus.ERROR, Optional.of(incrementalPushVersion1));
+    assertFalse(
+        task.areAllPartitionsOnSameTerminalStatus(
+            ExecutionStatus.END_OF_INCREMENTAL_PUSH_RECEIVED,
+            Optional.of(incrementalPushVersion1)));
+    assertTrue(task.isAnyPartitionOnErrorStatus(Optional.of(incrementalPushVersion1)));
+
+    // Set the status of partition 4 back to STARTED
+    task.updatePartitionStatus(4, ExecutionStatus.STARTED, Optional.of(incrementalPushVersion1));
+    assertFalse(
+        task.areAllPartitionsOnSameTerminalStatus(
+            ExecutionStatus.END_OF_INCREMENTAL_PUSH_RECEIVED,
+            Optional.of(incrementalPushVersion1)));
+
+    // Start the task
+    task.start();
+    TestUtils.waitForNonDeterministicAssertion(5, TimeUnit.SECONDS, () -> {
       verify(pushStatusStoreWriter, times(1)).writeVersionLevelPushStatus(
           eq(storeName),
           eq(versionNumber),
-          eq(ExecutionStatus.COMPLETED),
+          eq(ExecutionStatus.START_OF_INCREMENTAL_PUSH_RECEIVED),
           any(),
-          Optional.empty());
+          eq(Optional.of(incrementalPushVersion1)));
+      verify(pushStatusStoreWriter, times(1)).writeVersionLevelPushStatus(
+          eq(storeName),
+          eq(versionNumber),
+          eq(ExecutionStatus.START_OF_INCREMENTAL_PUSH_RECEIVED),
+          any(),
+          eq(Optional.of(incrementalPushVersion2)));
+      // However, COMPLETED status should never be sent
+      verify(pushStatusStoreWriter, never()).writeVersionLevelPushStatus(
+          eq(storeName),
+          eq(versionNumber),
+          eq(ExecutionStatus.END_OF_INCREMENTAL_PUSH_RECEIVED),
+          any(),
+          eq(Optional.of(incrementalPushVersion1)));
+      verify(pushStatusStoreWriter, never()).writeVersionLevelPushStatus(
+          eq(storeName),
+          eq(versionNumber),
+          eq(ExecutionStatus.END_OF_INCREMENTAL_PUSH_RECEIVED),
+          any(),
+          eq(Optional.of(incrementalPushVersion2)));
+    });
+    // Update the push status of partition 4 of incremental version 1 to END_OF_INCREMENTAL_PUSH_RECEIVED too
+    // also update the push status of partition 1 of incremental version 2 to END_OF_INCREMENTAL_PUSH_RECEIVED
+    task.updatePartitionStatus(
+        4,
+        ExecutionStatus.END_OF_INCREMENTAL_PUSH_RECEIVED,
+        Optional.of(incrementalPushVersion1));
+    task.updatePartitionStatus(
+        1,
+        ExecutionStatus.END_OF_INCREMENTAL_PUSH_RECEIVED,
+        Optional.of(incrementalPushVersion2));
+    TestUtils.waitForNonDeterministicAssertion(5, TimeUnit.SECONDS, () -> {
+      verify(pushStatusStoreWriter, times(1)).writeVersionLevelPushStatus(
+          eq(storeName),
+          eq(versionNumber),
+          eq(ExecutionStatus.END_OF_INCREMENTAL_PUSH_RECEIVED),
+          any(),
+          eq(Optional.of(incrementalPushVersion1)));
+    });
+    TestUtils.waitForNonDeterministicAssertion(5, TimeUnit.SECONDS, () -> {
+      verify(pushStatusStoreWriter, times(1)).writeVersionLevelPushStatus(
+          eq(storeName),
+          eq(versionNumber),
+          eq(ExecutionStatus.END_OF_INCREMENTAL_PUSH_RECEIVED),
+          any(),
+          eq(Optional.of(incrementalPushVersion2)));
     });
     task.shutdown();
   }

--- a/internal/venice-common/src/main/java/com/linkedin/venice/pushstatushelper/PushStatusStoreWriter.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/pushstatushelper/PushStatusStoreWriter.java
@@ -2,6 +2,7 @@ package com.linkedin.venice.pushstatushelper;
 
 import com.linkedin.venice.common.PushStatusStoreUtils;
 import com.linkedin.venice.pubsub.api.PubSubProduceResult;
+import com.linkedin.venice.pubsub.api.PubSubProducerCallback;
 import com.linkedin.venice.pushmonitor.ExecutionStatus;
 import com.linkedin.venice.pushstatus.PushStatusKey;
 import com.linkedin.venice.schema.SchemaEntry;
@@ -33,6 +34,20 @@ public class PushStatusStoreWriter implements AutoCloseable {
   private final int valueSchemaId;
   private final int derivedSchemaId;
   private final Schema updateSchema;
+
+  private static final PubSubProducerCallback PUSH_STATUS_UPDATE_LOGGER_CALLBACK = new PubSubProducerCallback() {
+    @Override
+    public void onCompletion(PubSubProduceResult produceResult, Exception exception) {
+      if (exception != null) {
+        LOGGER.error("Failed to update push status. Error: ", exception);
+      } else {
+        LOGGER.info(
+            "Updated push status into topic {} at offset {}.",
+            produceResult.getTopic(),
+            produceResult.getOffset());
+      }
+    }
+  };
 
   public PushStatusStoreWriter(
       VeniceWriterFactory writerFactory,
@@ -145,7 +160,12 @@ public class PushStatusStoreWriter implements AutoCloseable {
         storeName,
         version,
         partitionIds);
-    writer.update(pushStatusKey, updateBuilder.build(), valueSchemaId, derivedSchemaId, null);
+    writer.update(
+        pushStatusKey,
+        updateBuilder.build(),
+        valueSchemaId,
+        derivedSchemaId,
+        PUSH_STATUS_UPDATE_LOGGER_CALLBACK);
   }
 
   // For storing ongoing incremental push versions, we are (re)using 'instances' field of the PushStatusValue record.

--- a/internal/venice-common/src/main/java/com/linkedin/venice/pushstatushelper/PushStatusStoreWriter.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/pushstatushelper/PushStatusStoreWriter.java
@@ -132,9 +132,10 @@ public class PushStatusStoreWriter implements AutoCloseable {
       String storeName,
       int version,
       ExecutionStatus status,
-      Set<Integer> partitionIds) {
+      Set<Integer> partitionIds,
+      Optional<String> incrementalPushVersion) {
     VeniceWriter writer = veniceWriterCache.prepareVeniceWriter(storeName);
-    PushStatusKey pushStatusKey = PushStatusStoreUtils.getPushKey(version);
+    PushStatusKey pushStatusKey = PushStatusStoreUtils.getPushKey(version, incrementalPushVersion);
     UpdateBuilder updateBuilder = new UpdateBuilderImpl(updateSchema);
     updateBuilder.setEntriesToAddToMapField("instances", Collections.singletonMap(instanceName, status.getValue()));
     LOGGER.info(

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/DaVinciClientTest.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/DaVinciClientTest.java
@@ -62,6 +62,7 @@ import com.linkedin.venice.D2.D2ClientUtils;
 import com.linkedin.venice.compression.CompressionStrategy;
 import com.linkedin.venice.controllerapi.ControllerClient;
 import com.linkedin.venice.controllerapi.ControllerResponse;
+import com.linkedin.venice.controllerapi.JobStatusQueryResponse;
 import com.linkedin.venice.controllerapi.NewStoreResponse;
 import com.linkedin.venice.controllerapi.UpdateStoreQueryParams;
 import com.linkedin.venice.controllerapi.VersionCreationResponse;
@@ -79,6 +80,7 @@ import com.linkedin.venice.meta.Version;
 import com.linkedin.venice.offsets.OffsetRecord;
 import com.linkedin.venice.partitioner.ConstantVenicePartitioner;
 import com.linkedin.venice.pubsub.PubSubProducerAdapterFactory;
+import com.linkedin.venice.pushmonitor.ExecutionStatus;
 import com.linkedin.venice.serialization.VeniceKafkaSerializer;
 import com.linkedin.venice.serialization.avro.AvroProtocolDefinition;
 import com.linkedin.venice.serialization.avro.VeniceAvroKafkaSerializer;
@@ -705,6 +707,68 @@ public class DaVinciClientTest {
       // client3 is expected to be removed by the factory during bootstrap
       TestUtils.waitForNonDeterministicAssertion(60, TimeUnit.SECONDS, true, () -> {
         assertEquals(FileUtils.sizeOfDirectory(new File(baseDataPath)), 0);
+      });
+    }
+  }
+
+  @Test(timeOut = TEST_TIMEOUT, dataProviderClass = DataProviderUtils.class, dataProvider = "True-and-False")
+  public void testIncrementalPushStatusBatching(boolean isIngestionIsolated) throws Exception {
+    final int partition = 0;
+    final int partitionCount = 1;
+    String storeName = Utils.getUniqueString("store");
+    Consumer<UpdateStoreQueryParams> paramsConsumer =
+        params -> params.setPartitionerClass(ConstantVenicePartitioner.class.getName())
+            .setPartitionCount(partitionCount)
+            .setPartitionerParams(
+                Collections.singletonMap(ConstantVenicePartitioner.CONSTANT_PARTITION, String.valueOf(partition)));
+    // Create an empty hybrid store first
+    setupHybridStore(storeName, paramsConsumer, 0);
+
+    String incrementalPushVersion = System.currentTimeMillis() + "_test_1";
+    runIncrementalPush(storeName, incrementalPushVersion, 100);
+
+    // Build the da-vinci client
+    VeniceProperties backendConfig = new PropertyBuilder().put(CLIENT_USE_SYSTEM_STORE_REPOSITORY, true)
+        .put(CLIENT_SYSTEM_STORE_REPOSITORY_REFRESH_INTERVAL_SECONDS, 1)
+        .put(DATA_BASE_PATH, Utils.getTempDataDirectory().getAbsolutePath())
+        .put(PERSISTENCE_TYPE, ROCKS_DB)
+        .put(PUSH_STATUS_STORE_ENABLED, true)
+        .put(DAVINCI_PUSH_STATUS_CHECK_INTERVAL_IN_MS, 1000)
+        .build();
+
+    MetricsRepository metricsRepository = new MetricsRepository();
+    try (CachingDaVinciClientFactory factory = new CachingDaVinciClientFactory(
+        d2Client,
+        VeniceRouterWrapper.CLUSTER_DISCOVERY_D2_SERVICE_NAME,
+        metricsRepository,
+        backendConfig)) {
+      DaVinciConfig daVinciConfig = new DaVinciConfig().setIsolated(isIngestionIsolated);
+      DaVinciClient<Integer, Integer> client = factory.getAndStartGenericAvroClient(storeName, daVinciConfig);
+
+      client.subscribe(Collections.singleton(partition)).get();
+      TestUtils.waitForNonDeterministicAssertion(TEST_TIMEOUT, TimeUnit.MILLISECONDS, () -> {
+        Map<Integer, Integer> keyValueMap = new HashMap<>();
+        for (Integer i = 0; i < 100; i++) {
+          assertEquals(client.get(i).get(), i);
+          keyValueMap.put(i, i);
+        }
+
+        Map<Integer, Integer> batchGetResult = client.batchGet(keyValueMap.keySet()).get();
+        assertNotNull(batchGetResult);
+        assertEquals(batchGetResult, keyValueMap);
+      });
+
+      // Verify the incremental push status is END_OF_INCREMENTAL_PUSH_RECEIVED
+      cluster.useControllerClient(controllerClient -> {
+        String versionTopic = Version.composeKafkaTopic(storeName, 1);
+        JobStatusQueryResponse statusQueryResponse =
+            controllerClient.queryJobStatus(versionTopic, Optional.of(incrementalPushVersion));
+        if (statusQueryResponse.isError()) {
+          throw new VeniceException(statusQueryResponse.getError());
+        }
+        assertEquals(
+            ExecutionStatus.valueOf(statusQueryResponse.getStatus()),
+            ExecutionStatus.END_OF_INCREMENTAL_PUSH_RECEIVED);
       });
     }
   }
@@ -1549,25 +1613,28 @@ public class DaVinciClientTest {
 
   private void setupHybridStore(String storeName, Consumer<UpdateStoreQueryParams> paramsConsumer, int keyCount)
       throws Exception {
-    UpdateStoreQueryParams params =
-        new UpdateStoreQueryParams().setHybridRewindSeconds(10).setHybridOffsetLagThreshold(10);
+    UpdateStoreQueryParams params = new UpdateStoreQueryParams().setHybridRewindSeconds(10)
+        .setHybridOffsetLagThreshold(10)
+        .setIncrementalPushEnabled(true);
     paramsConsumer.accept(params);
     cluster.useControllerClient(client -> {
       client.createNewStore(storeName, "owner", DEFAULT_KEY_SCHEMA, DEFAULT_VALUE_SCHEMA);
       cluster.createMetaSystemStore(storeName);
       client.updateStore(storeName, params);
       cluster.createVersion(storeName, DEFAULT_KEY_SCHEMA, DEFAULT_VALUE_SCHEMA, Stream.of());
-      SystemProducer producer = IntegrationTestPushUtils.getSamzaProducer(
-          cluster,
-          storeName,
-          Version.PushType.STREAM,
-          Pair.create(VENICE_PARTITIONERS, ConstantVenicePartitioner.class.getName()));
-      try {
-        for (int i = 0; i < keyCount; i++) {
-          IntegrationTestPushUtils.sendStreamingRecord(producer, storeName, i, i);
+      if (keyCount > 0) {
+        SystemProducer producer = IntegrationTestPushUtils.getSamzaProducer(
+            cluster,
+            storeName,
+            Version.PushType.STREAM,
+            Pair.create(VENICE_PARTITIONERS, ConstantVenicePartitioner.class.getName()));
+        try {
+          for (int i = 0; i < keyCount; i++) {
+            IntegrationTestPushUtils.sendStreamingRecord(producer, storeName, i, i);
+          }
+        } finally {
+          producer.stop();
         }
-      } finally {
-        producer.stop();
       }
     });
   }
@@ -1585,6 +1652,32 @@ public class DaVinciClientTest {
     } finally {
       producer.stop();
     }
+  }
+
+  private void runIncrementalPush(String storeName, String incrementalPushVersion, int keyCount) throws Exception {
+    String realTimeTopicName = Version.composeRealTimeTopic(storeName);
+    VeniceWriterFactory vwFactory =
+        IntegrationTestPushUtils.getVeniceWriterFactory(cluster.getPubSubBrokerWrapper(), pubSubProducerAdapterFactory);
+    VeniceKafkaSerializer keySerializer = new VeniceAvroKafkaSerializer(DEFAULT_KEY_SCHEMA);
+    VeniceKafkaSerializer valueSerializer = new VeniceAvroKafkaSerializer(DEFAULT_VALUE_SCHEMA);
+    int valueSchemaId = HelixReadOnlySchemaRepository.VALUE_SCHEMA_STARTING_ID;
+
+    try (VeniceWriter<Object, Object, byte[]> batchProducer = vwFactory.createVeniceWriter(
+        new VeniceWriterOptions.Builder(realTimeTopicName).setKeySerializer(keySerializer)
+            .setValueSerializer(valueSerializer)
+            .build())) {
+      batchProducer.broadcastStartOfIncrementalPush(incrementalPushVersion, new HashMap<>());
+
+      Future[] writerFutures = new Future[keyCount];
+      for (int i = 0; i < keyCount; i++) {
+        writerFutures[i] = batchProducer.put(i, i, valueSchemaId);
+      }
+      for (int i = 0; i < keyCount; i++) {
+        writerFutures[i].get();
+      }
+      batchProducer.broadcastEndOfIncrementalPush(incrementalPushVersion, Collections.emptyMap());
+    }
+
   }
 
   /*

--- a/internal/venice-test-common/src/main/java/com/linkedin/venice/logger/TestLogAppender.java
+++ b/internal/venice-test-common/src/main/java/com/linkedin/venice/logger/TestLogAppender.java
@@ -1,0 +1,31 @@
+package com.linkedin.venice.logger;
+
+import java.io.Serializable;
+import org.apache.logging.log4j.core.Layout;
+import org.apache.logging.log4j.core.LogEvent;
+import org.apache.logging.log4j.core.appender.AbstractAppender;
+
+
+/**
+ * A test log appender that can be used to verify log messages in unit tests.
+ */
+public class TestLogAppender extends AbstractAppender {
+  // in-memory log to track log messages
+  private StringBuilder log = new StringBuilder();
+
+  public TestLogAppender(String name, Layout<? extends Serializable> layout) {
+    super(name, null, layout, false, null);
+  }
+
+  @Override
+  public void append(LogEvent event) {
+    log.append(event.getMessage().getFormattedMessage()).append("\n");
+  }
+
+  /**
+   * Use this api to verify log messages; once it's called, the log will be cleared.
+   */
+  public String getLog() {
+    return log.toString();
+  }
+}


### PR DESCRIPTION
## Summary
This feature is controlled by config:
davinci.push.status.check.interval.in.ms

When the config value is non-negative (default value is -1, disabled), the feature is enabled, and DVC would batch both batch push status and incremental push status across all partitions hosted on the node.

For each incremental push version on a DVC node, there would be at most two status event messages:
START_OF_INCREMENTAL_PUSH_RECEIVED - at least one partition on the DVC
                                     node starts ingesting data for this
                                     incremental push version;
END_OF_INCREMENTAL_PUSH_RECEIVED   - all hosted partitions on the DVC node
                                     finish ingesting data for this
                                     incremental push version.

The batching feature for incremental pushes reuse the "DaVinciPushStatusUpdateTask" for batch push status; "DaVinciPushStatusUpdateTask" is a bachground task which wakes up regularly based on the above config value, and check what status events it should send; besides, it would not shutdown itself anymore after batch push completes, since incremental pushes could happen anytime.

New version level key for incremental push status: version + incremental_push_version.

## How was this PR tested?
new unit test;
new integration test

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [] No. You can skip the rest of this section.
- [x] Yes. Make sure to explain your proposed changes and call out the behavior change.
DVC will change the way it reports push status once the feature is enabled, which requires venice-backend to be deployed to the supported version.