### PR TITLE
[admin-tool] Add support for dumping messages within a specified time range

### DIFF
--- a/clients/venice-admin-tool/src/main/java/com/linkedin/venice/AdminTool.java
+++ b/clients/venice-admin-tool/src/main/java/com/linkedin/venice/AdminTool.java
@@ -1669,6 +1669,10 @@ public class AdminTool {
     String startDatetime = getOptionalArgument(cmd, Arg.START_DATE);
     long startTimestamp =
         startDatetime == null ? -1 : Utils.parseDateTimeToEpoch(startDatetime, DEFAULT_DATE_FORMAT, PST_TIME_ZONE);
+    if (startTimestamp != -1 && startingOffset != -1) {
+      throw new VeniceException("Only one of start date and starting offset can be specified");
+    }
+
     String endDatetime = getOptionalArgument(cmd, Arg.END_DATE);
     long endTimestamp =
         endDatetime == null ? -1 : Utils.parseDateTimeToEpoch(endDatetime, DEFAULT_DATE_FORMAT, PST_TIME_ZONE);

--- a/clients/venice-admin-tool/src/main/java/com/linkedin/venice/AdminTool.java
+++ b/clients/venice-admin-tool/src/main/java/com/linkedin/venice/AdminTool.java
@@ -1650,6 +1650,9 @@ public class AdminTool {
     long startingOffset = (getOptionalArgument(cmd, Arg.STARTING_OFFSET) == null)
         ? -1
         : Long.parseLong(getOptionalArgument(cmd, Arg.STARTING_OFFSET));
+    long startingTimestamp = (getOptionalArgument(cmd, Arg.STARTING_TIMESTAMP) == null)
+        ? -1
+        : Long.parseLong(getOptionalArgument(cmd, Arg.STARTING_TIMESTAMP));
     int messageCount = (getOptionalArgument(cmd, Arg.MESSAGE_COUNT) == null)
         ? -1
         : Integer.parseInt(getOptionalArgument(cmd, Arg.MESSAGE_COUNT));
@@ -1673,6 +1676,7 @@ public class AdminTool {
           kafkaTopic,
           partitionNumber,
           startingOffset,
+          startingTimestamp,
           messageCount,
           parentDir,
           maxConsumeAttempts,

--- a/clients/venice-admin-tool/src/main/java/com/linkedin/venice/AdminTool.java
+++ b/clients/venice-admin-tool/src/main/java/com/linkedin/venice/AdminTool.java
@@ -89,9 +89,11 @@ import com.linkedin.venice.meta.Version;
 import com.linkedin.venice.meta.VersionStatus;
 import com.linkedin.venice.metadata.response.MetadataResponseRecord;
 import com.linkedin.venice.pubsub.PubSubClientsFactory;
+import com.linkedin.venice.pubsub.PubSubTopicPartitionImpl;
 import com.linkedin.venice.pubsub.PubSubTopicRepository;
 import com.linkedin.venice.pubsub.api.PubSubConsumerAdapter;
 import com.linkedin.venice.pubsub.api.PubSubMessageDeserializer;
+import com.linkedin.venice.pubsub.api.PubSubTopicPartition;
 import com.linkedin.venice.pubsub.api.exceptions.PubSubOpTimeoutException;
 import com.linkedin.venice.pubsub.manager.TopicManager;
 import com.linkedin.venice.pubsub.manager.TopicManagerContext;
@@ -123,7 +125,6 @@ import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Paths;
-import java.text.SimpleDateFormat;
 import java.time.Duration;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
@@ -141,7 +142,6 @@ import java.util.Optional;
 import java.util.Properties;
 import java.util.Set;
 import java.util.StringJoiner;
-import java.util.TimeZone;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
 import java.util.function.Function;
@@ -160,15 +160,18 @@ import org.apache.commons.cli.Options;
 import org.apache.commons.cli.ParseException;
 import org.apache.commons.lang.StringUtils;
 import org.apache.helix.zookeeper.impl.client.ZkClient;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 
 public class AdminTool {
+  private static final Logger LOGGER = LogManager.getLogger(AdminTool.class);
   private static ObjectWriter jsonWriter = ObjectMapperFactory.getInstance().writerWithDefaultPrettyPrinter();
   private static final String STATUS = "status";
   private static final String ERROR = "error";
   private static final String SUCCESS = "success";
 
-  private static final PubSubTopicRepository PUB_SUB_TOPIC_REPOSITORY = new PubSubTopicRepository();
+  private static final PubSubTopicRepository TOPIC_REPOSITORY = new PubSubTopicRepository();
 
   private static final ObjectMapper OBJECT_MAPPER = ObjectMapperFactory.getInstance();
 
@@ -185,6 +188,8 @@ public class AdminTool {
       "zookeeper.ssl.trustStore.location",
       "zookeeper.ssl.trustStore.password",
       "zookeeper.ssl.trustStore.type");
+  private static final String DEFAULT_DATE_FORMAT = "yyyy-MM-dd hh:mm:ss";
+  private static final String PST_TIME_ZONE = "America/Los_Angeles";
 
   public static void main(String[] args) throws Exception {
     // Generate PubSubClientsFactory from java system properties, apache kafka adapter is the default one.
@@ -1539,7 +1544,6 @@ public class AdminTool {
     Properties properties = loadProperties(cmd, Arg.KAFKA_CONSUMER_CONFIG_FILE);
     properties.put(KAFKA_BOOTSTRAP_SERVERS, kafkaBootstrapServer);
     VeniceProperties veniceProperties = new VeniceProperties(properties);
-    PubSubTopicRepository pubSubTopicRepository = new PubSubTopicRepository();
     int kafkaTimeOut = 30 * Time.MS_PER_SECOND;
     int topicDeletionStatusPollingInterval = 2 * Time.MS_PER_SECOND;
     if (cmd.hasOption(Arg.KAFKA_OPERATION_TIMEOUT.toString())) {
@@ -1553,7 +1557,7 @@ public class AdminTool {
             .setTopicMinLogCompactionLagMs(0L)
             .setPubSubConsumerAdapterFactory(pubSubClientsFactory.getConsumerAdapterFactory())
             .setPubSubAdminAdapterFactory(pubSubClientsFactory.getAdminAdapterFactory())
-            .setPubSubTopicRepository(pubSubTopicRepository)
+            .setPubSubTopicRepository(TOPIC_REPOSITORY)
             .setTopicMetadataFetcherConsumerPoolSize(1)
             .setTopicMetadataFetcherThreadPoolSize(1)
             .build();
@@ -1562,7 +1566,7 @@ public class AdminTool {
         new TopicManagerRepository(topicManagerContext, kafkaBootstrapServer).getLocalTopicManager()) {
       String topicName = getRequiredArgument(cmd, Arg.KAFKA_TOPIC_NAME);
       try {
-        topicManager.ensureTopicIsDeletedAndBlock(PUB_SUB_TOPIC_REPOSITORY.getTopic(topicName));
+        topicManager.ensureTopicIsDeletedAndBlock(TOPIC_REPOSITORY.getTopic(topicName));
         long runTime = System.currentTimeMillis() - startTime;
         printObject("Topic '" + topicName + "' is deleted. Run time: " + runTime + " ms.");
       } catch (PubSubOpTimeoutException e) {
@@ -1620,21 +1624,22 @@ public class AdminTool {
     String progressInterval = getOptionalArgument(cmd, Arg.PROGRESS_INTERVAL);
     String keyString = getRequiredArgument(cmd, Arg.KEY);
 
-    SimpleDateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd hh:mm:ss");
-    dateFormat.setTimeZone(TimeZone.getTimeZone("America/Los_Angeles"));
     try (PubSubConsumerAdapter consumer = getConsumer(consumerProps, pubSubClientsFactory)) {
       TopicMessageFinder.find(
           controllerClient,
           consumer,
           kafkaTopic,
           keyString,
-          dateFormat.parse(startDateInPST).getTime(),
-          endDateInPST == null ? Long.MAX_VALUE : dateFormat.parse(endDateInPST).getTime(),
+          Utils.parseDateTimeToEpoch(startDateInPST, DEFAULT_DATE_FORMAT, PST_TIME_ZONE),
+          endDateInPST == null
+              ? Long.MAX_VALUE
+              : Utils.parseDateTimeToEpoch(endDateInPST, DEFAULT_DATE_FORMAT, PST_TIME_ZONE),
           progressInterval == null ? 1000000 : Long.parseLong(progressInterval));
     }
   }
 
-  private static void dumpKafkaTopic(CommandLine cmd, PubSubClientsFactory pubSubClientsFactory) {
+  private static void dumpKafkaTopic(CommandLine cmd, PubSubClientsFactory pubSubClientsFactory)
+      throws java.text.ParseException {
     Properties consumerProps = loadProperties(cmd, Arg.KAFKA_CONSUMER_CONFIG_FILE);
     String kafkaUrl = getRequiredArgument(cmd, Arg.KAFKA_BOOTSTRAP_SERVERS);
 
@@ -1650,9 +1655,6 @@ public class AdminTool {
     long startingOffset = (getOptionalArgument(cmd, Arg.STARTING_OFFSET) == null)
         ? -1
         : Long.parseLong(getOptionalArgument(cmd, Arg.STARTING_OFFSET));
-    long startingTimestamp = (getOptionalArgument(cmd, Arg.STARTING_TIMESTAMP) == null)
-        ? -1
-        : Long.parseLong(getOptionalArgument(cmd, Arg.STARTING_TIMESTAMP));
     int messageCount = (getOptionalArgument(cmd, Arg.MESSAGE_COUNT) == null)
         ? -1
         : Integer.parseInt(getOptionalArgument(cmd, Arg.MESSAGE_COUNT));
@@ -1664,27 +1666,43 @@ public class AdminTool {
     if (getOptionalArgument(cmd, Arg.MAX_POLL_ATTEMPTS) != null) {
       maxConsumeAttempts = Integer.parseInt(getOptionalArgument(cmd, Arg.MAX_POLL_ATTEMPTS));
     }
+    String startDatetime = getOptionalArgument(cmd, Arg.START_DATE);
+    long startTimestamp =
+        startDatetime == null ? -1 : Utils.parseDateTimeToEpoch(startDatetime, DEFAULT_DATE_FORMAT, PST_TIME_ZONE);
+    String endDatetime = getOptionalArgument(cmd, Arg.END_DATE);
+    long endTimestamp =
+        endDatetime == null ? -1 : Utils.parseDateTimeToEpoch(endDatetime, DEFAULT_DATE_FORMAT, PST_TIME_ZONE);
 
     boolean logMetadata = cmd.hasOption(Arg.LOG_METADATA.toString());
     boolean logDataRecord = cmd.hasOption(Arg.LOG_DATA_RECORD.toString());
     boolean logRmdRecord = cmd.hasOption(Arg.LOG_RMD_RECORD.toString());
     boolean logTsRecord = cmd.hasOption(Arg.LOG_TS_RECORD.toString());
     try (PubSubConsumerAdapter consumer = getConsumer(consumerProps, pubSubClientsFactory)) {
+      PubSubTopicPartition topicPartition =
+          new PubSubTopicPartitionImpl(TOPIC_REPOSITORY.getTopic(kafkaTopic), partitionNumber);
+      long startOffset =
+          KafkaTopicDumper.calculateStartingOffset(consumer, topicPartition, startingOffset, startTimestamp);
+      long endOffset = KafkaTopicDumper.calculateEndingOffset(consumer, topicPartition, endTimestamp);
+      if (messageCount <= 0) {
+        messageCount = (int) (endOffset - startOffset);
+      }
+      LOGGER.info(
+          "TopicPartition: {} Start offset: {}, End offset: {}, Message count: {}",
+          topicPartition,
+          startOffset,
+          endOffset,
+          messageCount);
       try (KafkaTopicDumper ktd = new KafkaTopicDumper(
           controllerClient,
           consumer,
-          kafkaTopic,
-          partitionNumber,
-          startingOffset,
-          startingTimestamp,
-          messageCount,
+          topicPartition,
           parentDir,
           maxConsumeAttempts,
           logMetadata,
           logDataRecord,
           logRmdRecord,
           logTsRecord)) {
-        ktd.fetchAndProcess();
+        ktd.fetchAndProcess(startOffset, endOffset, messageCount);
       } catch (Exception e) {
         System.err.println("Something went wrong during topic dump");
         e.printStackTrace();

--- a/clients/venice-admin-tool/src/main/java/com/linkedin/venice/Arg.java
+++ b/clients/venice-admin-tool/src/main/java/com/linkedin/venice/Arg.java
@@ -118,7 +118,10 @@ public enum Arg {
   VENICE_CLIENT_SSL_CONFIG_FILE(
       "venice-client-ssl-config-file", "vcsc", true, "Configuration file for querying key in Venice client through SSL."
   ), STARTING_OFFSET("starting_offset", "so", true, "Starting offset when dumping admin messages, inclusive"),
-  MESSAGE_COUNT("message_count", "mc", true, "Max message count when dumping admin messages"),
+  STARTING_TIMESTAMP(
+      "starting_timestamp", "sts", true,
+      "Dump messages from a topic with a timestamp (in long epoch format) greater than the specified value."
+  ), MESSAGE_COUNT("message_count", "mc", true, "Max message count when dumping admin messages"),
   PARENT_DIRECTORY(
       "parent_output_directory", "pod", true,
       "A directory where output can be dumped to.  If dumping a kafka topic, the output will be dumped under this directory."

--- a/clients/venice-admin-tool/src/main/java/com/linkedin/venice/Arg.java
+++ b/clients/venice-admin-tool/src/main/java/com/linkedin/venice/Arg.java
@@ -118,10 +118,7 @@ public enum Arg {
   VENICE_CLIENT_SSL_CONFIG_FILE(
       "venice-client-ssl-config-file", "vcsc", true, "Configuration file for querying key in Venice client through SSL."
   ), STARTING_OFFSET("starting_offset", "so", true, "Starting offset when dumping admin messages, inclusive"),
-  STARTING_TIMESTAMP(
-      "starting_timestamp", "sts", true,
-      "Dump messages from a topic with a timestamp (in long epoch format) greater than the specified value."
-  ), MESSAGE_COUNT("message_count", "mc", true, "Max message count when dumping admin messages"),
+  MESSAGE_COUNT("message_count", "mc", true, "Max message count when dumping admin messages"),
   PARENT_DIRECTORY(
       "parent_output_directory", "pod", true,
       "A directory where output can be dumped to.  If dumping a kafka topic, the output will be dumped under this directory."

--- a/clients/venice-admin-tool/src/main/java/com/linkedin/venice/KafkaTopicDumper.java
+++ b/clients/venice-admin-tool/src/main/java/com/linkedin/venice/KafkaTopicDumper.java
@@ -31,7 +31,6 @@ import com.linkedin.venice.kafka.protocol.enums.MessageType;
 import com.linkedin.venice.message.KafkaKey;
 import com.linkedin.venice.meta.StoreInfo;
 import com.linkedin.venice.meta.Version;
-import com.linkedin.venice.pubsub.PubSubTopicPartitionImpl;
 import com.linkedin.venice.pubsub.PubSubTopicRepository;
 import com.linkedin.venice.pubsub.api.PubSubConsumerAdapter;
 import com.linkedin.venice.pubsub.api.PubSubMessage;
@@ -81,6 +80,7 @@ import org.apache.logging.log4j.Logger;
  */
 public class KafkaTopicDumper implements AutoCloseable {
   private static final Logger LOGGER = LogManager.getLogger(KafkaTopicDumper.class);
+  private static final PubSubTopicRepository TOPIC_REPOSITORY = new PubSubTopicRepository();
   private static final String VENICE_ETL_KEY_FIELD = "key";
   private static final String VENICE_ETL_VALUE_FIELD = "value";
   private static final String VENICE_ETL_OFFSET_FIELD = "offset";
@@ -93,8 +93,6 @@ public class KafkaTopicDumper implements AutoCloseable {
   private static final String REGULAR_REC = "REG";
   private static final String CONTROL_REC = "CTRL";
 
-  private final String topicName;
-  private final int partition;
   private final String keySchemaStr;
   private final Schema keySchema;
   private final String latestValueSchemaStr;
@@ -105,8 +103,6 @@ public class KafkaTopicDumper implements AutoCloseable {
   private final VeniceCompressor compressor;
   private final String parentDirectory;
   private final PubSubConsumerAdapter consumer;
-  private final long messageCount;
-  private final long endOffset;
   private final int maxConsumeAttempts;
   private final boolean logMetadata;
   private final boolean logDataRecord;
@@ -123,27 +119,23 @@ public class KafkaTopicDumper implements AutoCloseable {
   private GenericDatumReader<Object>[] valueReaders;
   private DecoderFactory decoderFactory = new DecoderFactory();
   private Schema outputSchema;
+  private PubSubTopicPartition topicPartition;
 
   public KafkaTopicDumper(
       ControllerClient controllerClient,
       PubSubConsumerAdapter consumer,
-      String topic,
-      int partitionNumber,
-      long startingOffset,
-      long startingTimestamp,
-      int messageCount,
+      PubSubTopicPartition topicPartition,
       String parentDir,
       int maxConsumeAttempts,
       boolean logMetadata,
       boolean logDataRecord,
       boolean logRmdRecord,
       boolean logTsRecord) {
+    this.topicPartition = topicPartition;
     this.consumer = consumer;
     this.maxConsumeAttempts = maxConsumeAttempts;
 
-    PubSubTopicRepository pubSubTopicRepository = new PubSubTopicRepository();
-
-    String storeName = Version.parseStoreFromKafkaTopicName(topic);
+    String storeName = Version.parseStoreFromKafkaTopicName(topicPartition.getTopicName());
     StoreResponse storeResponse = controllerClient.getStore(storeName);
     if (storeResponse.isError()) {
       throw new VeniceException(
@@ -152,8 +144,8 @@ public class KafkaTopicDumper implements AutoCloseable {
 
     StoreInfo storeInfo = storeResponse.getStore();
     this.compressorFactory = new CompressorFactory();
-    if (Version.isATopicThatIsVersioned(topic)) {
-      int version = Version.parseVersionFromKafkaTopicName(topic);
+    if (Version.isATopicThatIsVersioned(topicPartition.getTopicName())) {
+      int version = Version.parseVersionFromKafkaTopicName(topicPartition.getTopicName());
       Optional<Version> optionalVersion = storeInfo.getVersion(version);
       if (!optionalVersion.isPresent()) {
         throw new VeniceException("Version: " + version + " does not exist for store: " + storeName);
@@ -161,7 +153,8 @@ public class KafkaTopicDumper implements AutoCloseable {
       this.isChunkingEnabled = optionalVersion.get().isChunkingEnabled();
       CompressionStrategy compressionStrategy = optionalVersion.get().getCompressionStrategy();
       if (compressionStrategy == CompressionStrategy.ZSTD_WITH_DICT) {
-        ByteBuffer dictionary = DictionaryUtils.readDictionaryFromKafka(topic, consumer, pubSubTopicRepository);
+        ByteBuffer dictionary =
+            DictionaryUtils.readDictionaryFromKafka(topicPartition.getTopicName(), consumer, TOPIC_REPOSITORY);
         compressor = compressorFactory
             .createCompressorWithDictionary(ByteUtils.extractByteArray(dictionary), Zstd.maxCompressionLevel());
       } else {
@@ -184,9 +177,6 @@ public class KafkaTopicDumper implements AutoCloseable {
       chunkedKeySuffixDeserializer = null;
       manifestSerializer = null;
     }
-
-    this.topicName = topic;
-    this.partition = partitionNumber;
     this.parentDirectory = parentDir;
     this.logMetadata = logMetadata;
     this.logDataRecord = logDataRecord;
@@ -196,7 +186,7 @@ public class KafkaTopicDumper implements AutoCloseable {
     if (logMetadata && !logDataRecord) {
       this.latestValueSchemaStr = null;
       this.allValueSchemas = null;
-    } else if (topicName.contains(ChangeCaptureView.CHANGE_CAPTURE_TOPIC_SUFFIX)) {
+    } else if (topicPartition.getTopicName().contains(ChangeCaptureView.CHANGE_CAPTURE_TOPIC_SUFFIX)) {
       // For now dump data record to console mode does not support change capture topic.
       this.latestValueSchemaStr = RecordChangeEvent.getClassSchema().toString();
       this.allValueSchemas = new Schema[1];
@@ -236,42 +226,70 @@ public class KafkaTopicDumper implements AutoCloseable {
         }
       }
     }
-
-    PubSubTopicPartition partition =
-        new PubSubTopicPartitionImpl(pubSubTopicRepository.getTopic(topicName), partitionNumber);
-    this.endOffset = consumer.endOffset(partition);
-    LOGGER.info("End offset for partition {} is {}", partition, this.endOffset);
-    if (messageCount < 0) {
-      this.messageCount = this.endOffset;
-    } else {
-      this.messageCount = messageCount;
-    }
-    long computedStartingOffset = getOffsetToConsumerFrom(consumer, partition, startingOffset, startingTimestamp);
-    consumer.subscribe(partition, computedStartingOffset - 1);
     if (!(logMetadata || logDataRecord)) {
       setupDumpFile();
     }
   }
 
-  static long getOffsetToConsumerFrom(
+  // Constructor for testing purpose only
+  KafkaTopicDumper(PubSubConsumerAdapter consumer, PubSubTopicPartition topicPartition, int maxConsumeAttempts) {
+    this.topicPartition = topicPartition;
+    this.consumer = consumer;
+    this.maxConsumeAttempts = maxConsumeAttempts;
+    this.keySchemaStr = null;
+    this.keySchema = null;
+    this.keyReader = null;
+    this.latestValueSchemaStr = null;
+    this.allValueSchemas = null;
+    this.parentDirectory = null;
+    this.logMetadata = false;
+    this.logDataRecord = false;
+    this.logRmdRecord = false;
+    this.logTsRecord = false;
+    this.isChunkingEnabled = false;
+    this.compressorFactory = new CompressorFactory();
+    this.compressor = compressorFactory.getCompressor(CompressionStrategy.NO_OP);
+    this.chunkKeyValueTransformer = null;
+    this.chunkedKeySuffixDeserializer = null;
+    this.manifestSerializer = null;
+  }
+
+  /**
+   * Calculates the starting offset for consuming messages from a PubSub topic partition.
+   *
+   * <p>This method determines the appropriate starting offset based on the provided starting
+   * offset or timestamp. If a specific {@code startingTimestamp} is provided, it attempts to find
+   * the offset corresponding to that timestamp. If no offset is found for the timestamp, it throws
+   * a {@link PubSubClientException}. The calculated starting offset will always be greater than
+   * or equal to the partition's beginning offset to ensure it is within the valid range.
+   *
+   * @param consumer the {@link PubSubConsumerAdapter} used to fetch offsets
+   * @param partition the {@link PubSubTopicPartition} identifying the topic and partition
+   * @param startingOffset the default starting offset to use if no timestamp is provided
+   * @param startingTimestamp the starting timestamp (epoch in milliseconds) to locate an offset.
+   *                          If set to -1, the method uses the provided {@code startingOffset}.
+   * @return the calculated starting offset for the partition
+   * @throws PubSubClientException if no offset is found for the provided timestamp
+   */
+  static long calculateStartingOffset(
       PubSubConsumerAdapter consumer,
       PubSubTopicPartition partition,
       long startingOffset,
       long startingTimestamp) {
     if (startingTimestamp != -1) {
-      LOGGER.info(
-          "Requested to dump topic-partition: {} with starting timestamp: {}. Will try to find the offset for the timestamp.",
-          partition,
-          startingTimestamp);
+      LOGGER.info("Searching for offset for timestamp: {} in topic-partition: {}", partition, startingTimestamp);
       Long offsetForTime = consumer.offsetForTime(partition, startingTimestamp);
       if (offsetForTime == null) {
         LOGGER.error(
-            "No offset found for timestamp: {} in topic-partition: {}. There might be no message in the topic-partition "
-                + " with timestamp greater than or equal to the requested timestamp.",
+            "No offset found for the requested timestamp: {} in topic-partition: {}. "
+                + "This indicates that there are no messages in the topic-partition with a timestamp "
+                + "greater than or equal to the provided timestamp. Verify if the topic-partition has data "
+                + "in the specified time range.",
             startingTimestamp,
             partition);
         throw new PubSubClientException(
-            "No offset found for timestamp: " + startingTimestamp + " in topic-partition: " + partition);
+            "Failed to find an offset for the requested timestamp: " + startingTimestamp + " in topic-partition: "
+                + partition + ". Ensure that messages exist in the specified time range.");
       }
       LOGGER.info(
           "Found offset: {} for timestamp: {} in topic-partition: {}",
@@ -280,55 +298,128 @@ public class KafkaTopicDumper implements AutoCloseable {
           partition);
       startingOffset = offsetForTime;
     }
-
     Long partitionBeginningOffset =
         consumer.beginningOffset(partition, getPubsubOffsetApiTimeoutDurationDefaultValue());
-    long computedStartingOffset = Math.max(partitionBeginningOffset, startingOffset);
-    LOGGER.info(
-        "Consumer will start consuming from offset: {} in topic-partition: {}",
-        computedStartingOffset,
-        partition);
-    return computedStartingOffset;
+    return Math.max(partitionBeginningOffset, startingOffset);
   }
 
   /**
-   * 1. Fetch up to {@link KafkaTopicDumper#messageCount} messages in this partition.
-   * 2. Discard non-control messages.
+   * Calculates the ending offset for consuming messages from a PubSub topic partition.
+   *
+   * <p>This method determines the appropriate ending offset based on the provided timestamp.
+   * If the {@code endTimestamp} is -1, it directly returns the end offset of the partition.
+   * If a specific {@code endTimestamp} is provided, it attempts to find the offset corresponding
+   * to the timestamp. If no offset is found for the given timestamp, it falls back to the partition's
+   * end offset and logs a warning.
+   *
+   * @param consumer the {@link PubSubConsumerAdapter} used to fetch offsets
+   * @param partition the {@link PubSubTopicPartition} identifying the topic and partition
+   * @param endTimestamp the ending timestamp (epoch in milliseconds). If set to -1, the method uses the end offset.
+   * @return the calculated ending offset for the partition
    */
-  public int fetchAndProcess() {
-    int countdownBeforeStop = maxConsumeAttempts;
-    int currentMessageCount = 0;
+  static long calculateEndingOffset(PubSubConsumerAdapter consumer, PubSubTopicPartition partition, long endTimestamp) {
+    long endOffset = consumer.endOffset(partition) - 1;
+    if (endTimestamp == -1) {
+      return endOffset;
+    }
+    Long offsetForTime = consumer.offsetForTime(partition, endTimestamp);
+    if (offsetForTime != null) {
+      return offsetForTime;
+    }
+    // if offsetForTime returns null, it means there is no message with timestamp >= endTimestamp;
+    // In this case we will use the endOffset
+    LOGGER.warn(
+        "No offset found for the requested timestamp: {} in topic-partition: {}. "
+            + "This indicates that there are no messages in the topic-partition with a timestamp "
+            + "greater than or equal to the provided timestamp. Returning the end offset: {}",
+        endTimestamp,
+        partition,
+        endOffset);
+    return endOffset;
+  }
 
-    int lastReportedConsumedCount = 0;
-    PubSubMessage<KafkaKey, KafkaMessageEnvelope, Long> lastProcessRecord = null;
-    do {
-      Map<PubSubTopicPartition, List<PubSubMessage<KafkaKey, KafkaMessageEnvelope, Long>>> records =
-          consumer.poll(5000); // up to 5 seconds
-      Iterator<PubSubMessage<KafkaKey, KafkaMessageEnvelope, Long>> recordsIterator =
-          Utils.iterateOnMapOfLists(records);
-      while (recordsIterator.hasNext() && currentMessageCount < messageCount) {
-        currentMessageCount++;
-        PubSubMessage<KafkaKey, KafkaMessageEnvelope, Long> record = recordsIterator.next();
-        lastProcessRecord = record;
-        processRecord(record);
+  /**
+   * Fetches and processes messages from a given PubSub topic partition between specified offsets.
+   *
+   * <p>The method polls messages from the specified `startOffset` to `endOffset` and processes up to
+   * `messageCount` messages. It uses the consumer to fetch records in batches, processes them via
+   * {@code processRecord}, and stops under the following conditions:
+   * <ul>
+   *   <li>The number of processed messages reaches {@code messageCount}.</li>
+   *   <li>The offset of the last processed message is greater than or equal to {@code endOffset}.</li>
+   *   <li>No new records are fetched within the allowed number of attempts.</li>
+   * </ul>
+   *
+   * @param startOffset the starting offset (inclusive) to begin processing messages
+   * @param endOffset the ending offset (exclusive) to stop processing messages
+   * @param messageCount the maximum number of messages to process
+   * @return the total number of messages processed
+   * @throws IllegalArgumentException if {@code messageCount} is less than or equal to zero, or if
+   *                                  {@code startOffset} is greater than {@code endOffset}
+   */
+  public int fetchAndProcess(long startOffset, long endOffset, int messageCount) {
+    if (messageCount <= 0) {
+      throw new IllegalArgumentException("Invalid message count: " + messageCount);
+    }
+    if (startOffset > endOffset) {
+      throw new IllegalArgumentException("Invalid offset range: [" + startOffset + ", " + endOffset + ")");
+    }
+
+    int remainingAttempts = maxConsumeAttempts;
+    int processedMessageCount = 0;
+    int lastReportedCount = 0;
+
+    consumer.subscribe(topicPartition, startOffset - 1);
+
+    try {
+      PubSubMessage<KafkaKey, KafkaMessageEnvelope, Long> lastProcessedRecord = null;
+      while (remainingAttempts > 0 && processedMessageCount < messageCount) {
+        // Poll for records
+        Map<PubSubTopicPartition, List<PubSubMessage<KafkaKey, KafkaMessageEnvelope, Long>>> records =
+            consumer.poll(5000); // Poll for up to 5 seconds
+        Iterator<PubSubMessage<KafkaKey, KafkaMessageEnvelope, Long>> recordIterator =
+            Utils.iterateOnMapOfLists(records);
+        boolean hasProcessedRecords = false;
+        while (recordIterator.hasNext() && processedMessageCount < messageCount) {
+          PubSubMessage<KafkaKey, KafkaMessageEnvelope, Long> record = recordIterator.next();
+          processedMessageCount++;
+          lastProcessedRecord = record;
+          hasProcessedRecords = true;
+          processRecord(record);
+          // Exit early if endOffset is reached
+          if (record.getOffset() >= endOffset) {
+            LOGGER.info("Reached endOffset. Total messages processed: {}", processedMessageCount);
+            return processedMessageCount;
+          }
+        }
+
+        // Log progress if sufficient messages have been processed since the last report
+        if (processedMessageCount - lastReportedCount >= 1000) {
+          LOGGER.info(
+              "Consumed {} messages; last consumed message offset: {}",
+              processedMessageCount,
+              lastProcessedRecord.getOffset());
+          lastReportedCount = processedMessageCount;
+        }
+
+        // Adjust remaining attempts if no records were processed
+        remainingAttempts = hasProcessedRecords ? maxConsumeAttempts : remainingAttempts - 1;
       }
 
-      if (currentMessageCount - lastReportedConsumedCount > 1000) {
-        LOGGER.info(
-            "Consumed {} messages; last consumed message offset:{}",
-            currentMessageCount,
-            lastProcessRecord.getOffset());
-        lastReportedConsumedCount = currentMessageCount;
-      }
-      countdownBeforeStop = records.isEmpty() ? countdownBeforeStop - 1 : maxConsumeAttempts;
-    } while ((lastProcessRecord != null && lastProcessRecord.getOffset() < (this.endOffset - 2))
-        && currentMessageCount < messageCount && countdownBeforeStop > 0);
-    return currentMessageCount;
+      // Return the total number of processed messages
+      return processedMessageCount;
+
+    } finally {
+      // Ensure unsubscription to free resources
+      consumer.unSubscribe(topicPartition);
+    }
   }
 
   private void setupDumpFile() {
     // build file
-    File dataFile = new File(this.parentDirectory + this.topicName + "_" + this.partition + ".avro");
+    File dataFile = new File(
+        this.parentDirectory + this.topicPartition.getTopicName() + "_" + this.topicPartition.getPartitionNumber()
+            + ".avro");
     List<Schema.Field> outputSchemaFields = new ArrayList<>();
     for (Schema.Field field: VeniceKafkaDecodedRecord.SCHEMA$.getFields()) {
       if (field.name().equals(VENICE_ETL_KEY_FIELD)) {
@@ -492,7 +583,7 @@ public class KafkaTopicDumper implements AutoCloseable {
         : String.format("Key: %s; Value: %s; Schema: %s", keyRecord, valueRecord, valuePayloadSchemaId);
   }
 
-  private void processRecord(PubSubMessage<KafkaKey, KafkaMessageEnvelope, Long> record) {
+  void processRecord(PubSubMessage<KafkaKey, KafkaMessageEnvelope, Long> record) {
     if (logTsRecord) {
       logIfTopicSwitchMessage(record);
     } else if (logDataRecord) {

--- a/clients/venice-admin-tool/src/main/java/com/linkedin/venice/KafkaTopicDumper.java
+++ b/clients/venice-admin-tool/src/main/java/com/linkedin/venice/KafkaTopicDumper.java
@@ -382,15 +382,15 @@ public class KafkaTopicDumper implements AutoCloseable {
         boolean hasProcessedRecords = false;
         while (recordIterator.hasNext() && processedMessageCount < messageCount) {
           PubSubMessage<KafkaKey, KafkaMessageEnvelope, Long> record = recordIterator.next();
+          // Exit early if endOffset is reached
+          if (record.getOffset() > endOffset) {
+            LOGGER.info("Reached endOffset: {}. Total messages processed: {}", endOffset, processedMessageCount);
+            return processedMessageCount;
+          }
           processedMessageCount++;
           lastProcessedRecord = record;
           hasProcessedRecords = true;
           processRecord(record);
-          // Exit early if endOffset is reached
-          if (record.getOffset() >= endOffset) {
-            LOGGER.info("Reached endOffset. Total messages processed: {}", processedMessageCount);
-            return processedMessageCount;
-          }
         }
 
         // Log progress if sufficient messages have been processed since the last report

--- a/clients/venice-admin-tool/src/main/java/com/linkedin/venice/KafkaTopicDumper.java
+++ b/clients/venice-admin-tool/src/main/java/com/linkedin/venice/KafkaTopicDumper.java
@@ -264,14 +264,7 @@ public class KafkaTopicDumper implements AutoCloseable {
           partition,
           startingTimestamp);
       Long offsetForTime = consumer.offsetForTime(partition, startingTimestamp);
-      if (offsetForTime != null) {
-        LOGGER.info(
-            "Found offset: {} for timestamp: {} in topic-partition: {}",
-            offsetForTime,
-            startingTimestamp,
-            partition);
-        startingOffset = offsetForTime;
-      } else {
+      if (offsetForTime == null) {
         LOGGER.error(
             "No offset found for timestamp: {} in topic-partition: {}. There might be no message in the topic-partition "
                 + " with timestamp greater than or equal to the requested timestamp.",
@@ -280,6 +273,12 @@ public class KafkaTopicDumper implements AutoCloseable {
         throw new PubSubClientException(
             "No offset found for timestamp: " + startingTimestamp + " in topic-partition: " + partition);
       }
+      LOGGER.info(
+          "Found offset: {} for timestamp: {} in topic-partition: {}",
+          offsetForTime,
+          startingTimestamp,
+          partition);
+      startingOffset = offsetForTime;
     }
 
     Long partitionBeginningOffset =

--- a/clients/venice-admin-tool/src/test/java/com/linkedin/venice/TestAdminToolConsumption.java
+++ b/clients/venice-admin-tool/src/test/java/com/linkedin/venice/TestAdminToolConsumption.java
@@ -210,17 +210,13 @@ public class TestAdminToolConsumption {
     KafkaTopicDumper kafkaTopicDumper = new KafkaTopicDumper(
         controllerClient,
         apacheKafkaConsumer,
-        topic,
-        assignedPartition,
-        0,
-        -1,
-        2,
+        pubSubTopicPartition,
         "",
         3,
         true,
         false,
         false,
         false);
-    Assert.assertEquals(kafkaTopicDumper.fetchAndProcess(), consumedMessageCount);
+    Assert.assertEquals(kafkaTopicDumper.fetchAndProcess(0, 1, 2), consumedMessageCount);
   }
 }

--- a/clients/venice-admin-tool/src/test/java/com/linkedin/venice/TestAdminToolConsumption.java
+++ b/clients/venice-admin-tool/src/test/java/com/linkedin/venice/TestAdminToolConsumption.java
@@ -213,6 +213,7 @@ public class TestAdminToolConsumption {
         topic,
         assignedPartition,
         0,
+        -1,
         2,
         "",
         3,

--- a/clients/venice-admin-tool/src/test/java/com/linkedin/venice/TestKafkaTopicDumper.java
+++ b/clients/venice-admin-tool/src/test/java/com/linkedin/venice/TestKafkaTopicDumper.java
@@ -417,11 +417,11 @@ public class TestKafkaTopicDumper {
     assertEquals(processedCount, 0, "Should process no messages when poll returns empty");
 
     // Case 5: endOffset is reached before messageCount is reached
-    mockMessages = createMockMessages(3, 0);
+    mockMessages = createMockMessages(4, 0);
     mockPollResult.put(topicPartition, mockMessages);
     when(mockConsumer.poll(5000L)).thenReturn(mockPollResult);
     processedCount = spyDumper.fetchAndProcess(0, 2, 5);
-    assertEquals(processedCount, 3, "Should stop processing when endOffset is reached and tailing is disabled");
+    assertEquals(processedCount, 3, "Should stop processing when endOffset is reached");
 
     // Verify unsubscription
     verify(mockConsumer, atLeastOnce()).unSubscribe(topicPartition);

--- a/internal/venice-common/src/main/java/com/linkedin/venice/utils/Utils.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/utils/Utils.java
@@ -39,6 +39,8 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.text.DecimalFormat;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -53,6 +55,7 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.Properties;
 import java.util.Set;
+import java.util.TimeZone;
 import java.util.TreeMap;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -1033,5 +1036,19 @@ public class Utils {
       return kafkaUrl.substring(0, kafkaUrl.length() - SEPARATE_TOPIC_SUFFIX.length());
     }
     return kafkaUrl;
+  }
+
+  /**
+   * Parses a date-time string to epoch milliseconds using the default format and time zone.
+   *
+   * @param dateTime the date-time string in the format "yyyy-MM-dd hh:mm:ss"
+   * @return the epoch time in milliseconds
+   * @throws ParseException if the date-time string cannot be parsed
+   */
+  public static long parseDateTimeToEpoch(String dateTime, String dateTimeFormat, String timeZone)
+      throws ParseException {
+    SimpleDateFormat dateFormat = new SimpleDateFormat(dateTimeFormat);
+    dateFormat.setTimeZone(TimeZone.getTimeZone(timeZone));
+    return dateFormat.parse(dateTime).getTime();
   }
 }

--- a/internal/venice-common/src/test/java/com/linkedin/venice/utils/UtilsTest.java
+++ b/internal/venice-common/src/test/java/com/linkedin/venice/utils/UtilsTest.java
@@ -3,6 +3,7 @@ package com.linkedin.venice.utils;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertThrows;
 import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.expectThrows;
 import static org.testng.Assert.fail;
@@ -15,6 +16,7 @@ import com.linkedin.venice.meta.Version;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.text.ParseException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -190,7 +192,7 @@ public class UtilsTest {
 
   @Test
   public void testSanitizingStringForLogger() {
-    Assert.assertEquals(Utils.getSanitizedStringForLogger(".abc.123."), "_abc_123_");
+    assertEquals(Utils.getSanitizedStringForLogger(".abc.123."), "_abc_123_");
   }
 
   @Test
@@ -199,13 +201,13 @@ public class UtilsTest {
     Assert.assertTrue(Utils.parseCommaSeparatedStringToSet("").isEmpty());
 
     Set<String> set = Utils.parseCommaSeparatedStringToSet("a,b,c");
-    Assert.assertEquals(set.size(), 3);
+    assertEquals(set.size(), 3);
     Assert.assertTrue(set.contains("a"));
     Assert.assertTrue(set.contains("b"));
     Assert.assertTrue(set.contains("c"));
 
     Set<String> setWithSpaces = Utils.parseCommaSeparatedStringToSet("a, b, c");
-    Assert.assertEquals(setWithSpaces.size(), 3);
+    assertEquals(setWithSpaces.size(), 3);
     Assert.assertTrue(setWithSpaces.contains("a"));
     Assert.assertTrue(setWithSpaces.contains("b"));
     Assert.assertTrue(setWithSpaces.contains("c"));
@@ -217,25 +219,25 @@ public class UtilsTest {
     Assert.assertTrue(Utils.parseCommaSeparatedStringToList("").isEmpty());
 
     List<String> list = Utils.parseCommaSeparatedStringToList("a,b,c");
-    Assert.assertEquals(list.size(), 3);
-    Assert.assertEquals(list.get(0), "a");
-    Assert.assertEquals(list.get(1), "b");
-    Assert.assertEquals(list.get(2), "c");
+    assertEquals(list.size(), 3);
+    assertEquals(list.get(0), "a");
+    assertEquals(list.get(1), "b");
+    assertEquals(list.get(2), "c");
 
     List<String> stringList = Utils.parseCommaSeparatedStringToList("a, b, c");
-    Assert.assertEquals(stringList.size(), 3);
-    Assert.assertEquals(list.get(0), "a");
-    Assert.assertEquals(list.get(1), "b");
-    Assert.assertEquals(list.get(2), "c");
+    assertEquals(stringList.size(), 3);
+    assertEquals(list.get(0), "a");
+    assertEquals(list.get(1), "b");
+    assertEquals(list.get(2), "c");
   }
 
   @Test
   public void testResolveKafkaUrlForSepTopic() {
     String originalKafkaUrl = "localhost:12345";
     String originalKafkaUrlForSep = "localhost:12345_sep";
-    Assert.assertEquals(Utils.resolveKafkaUrlForSepTopic(""), "");
-    Assert.assertEquals(Utils.resolveKafkaUrlForSepTopic(originalKafkaUrlForSep), originalKafkaUrl);
-    Assert.assertEquals(Utils.resolveKafkaUrlForSepTopic(originalKafkaUrl), originalKafkaUrl);
+    assertEquals(Utils.resolveKafkaUrlForSepTopic(""), "");
+    assertEquals(Utils.resolveKafkaUrlForSepTopic(originalKafkaUrlForSep), originalKafkaUrl);
+    assertEquals(Utils.resolveKafkaUrlForSepTopic(originalKafkaUrl), originalKafkaUrl);
   }
 
   @Test
@@ -344,4 +346,30 @@ public class UtilsTest {
     String result = Utils.getRealTimeTopicName(mockVersion);
     assertEquals("TestStore" + Version.REAL_TIME_TOPIC_SUFFIX, result);
   }
+
+  @Test
+  public void testParseDateTimeToEpoch() throws Exception {
+    // Case 1: Valid Input
+    String dateTimePst = "2024-12-02 15:30:00";
+    String dateTimeUtc = "2024-12-02 23:30:00";
+    String format = "yyyy-MM-dd HH:mm:ss";
+    String timeZone = "America/Los_Angeles";
+    long expectedEpoch = 1733182200000L;
+
+    long epochTime = Utils.parseDateTimeToEpoch(dateTimePst, format, timeZone);
+    assertEquals(epochTime, expectedEpoch, "The epoch time does not match the expected value.");
+
+    // Case 2: Invalid Date Format
+    assertThrows(ParseException.class, () -> Utils.parseDateTimeToEpoch("2024-12-02T15:30:00", format, timeZone));
+
+    // Case 3: Invalid Time Zone; fallback to GMT
+    long gmtEpochTime = Utils.parseDateTimeToEpoch(dateTimeUtc, format, "InvalidTimeZone");
+    assertEquals(gmtEpochTime, expectedEpoch, "The epoch time does not match the expected value for GMT.");
+
+    // Case 4: Different Time Zone
+    String utcTimeZone = "UTC";
+    long utcEpochTime = Utils.parseDateTimeToEpoch(dateTimeUtc, format, utcTimeZone);
+    assertEquals(utcEpochTime, expectedEpoch, "The epoch time does not match the expected value for UTC.");
+  }
+
 }

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/controller/VeniceParentHelixAdminTest.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/controller/VeniceParentHelixAdminTest.java
@@ -158,7 +158,7 @@ public class VeniceParentHelixAdminTest {
                 false,
                 Optional.empty(),
                 Optional.empty(),
-                Optional.of("dc-1"),
+                Optional.of("dc-0"),
                 false,
                 -1));
         // Check version-level rewind time config


### PR DESCRIPTION
## [admin-tool] Add support for dumping messages within a specified time range
This commit adds support to the admin tool for dumping messages from a PubSub topic within a specified time range, using start and end date-time in the format "yyyy-MM-dd HH:mm:ss" (PST). Previously, the admin tool could not consume messages based on time ranges. This code change allows targeted message dumping to streamline troubleshooting.


## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
CI and PROD 

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.