### PR TITLE
[changelog] Add resiliency to version swap in change capture client

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/consumer/VeniceAfterImageConsumerImpl.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/consumer/VeniceAfterImageConsumerImpl.java
@@ -175,6 +175,10 @@ public class VeniceAfterImageConsumerImpl<K, V> extends VeniceChangelogConsumerI
     });
   }
 
+  public boolean subscribed() {
+    return isSubscribed.get();
+  }
+
   @Override
   protected CompletableFuture<Void> internalSeek(
       Set<Integer> partitions,

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/consumer/VeniceAfterImageConsumerImpl.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/consumer/VeniceAfterImageConsumerImpl.java
@@ -87,8 +87,11 @@ public class VeniceAfterImageConsumerImpl<K, V> extends VeniceChangelogConsumerI
     if (!versionSwapThreadScheduled.get()) {
       // schedule the version swap thread and set up the callback listener
       this.storeRepository.registerStoreDataChangedListener(versionSwapListener);
-      versionSwapExecutorService
-          .schedule(new VersionSwapDetectionThread(), versionSwapDetectionIntervalTimeInMs, TimeUnit.MILLISECONDS);
+      versionSwapExecutorService.scheduleAtFixedRate(
+          new VersionSwapDetectionThread(),
+          versionSwapDetectionIntervalTimeInMs,
+          versionSwapDetectionIntervalTimeInMs,
+          TimeUnit.MILLISECONDS);
       versionSwapThreadScheduled.set(true);
     }
     return super.subscribe(partitions);

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/consumer/VeniceAfterImageConsumerImpl.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/consumer/VeniceAfterImageConsumerImpl.java
@@ -7,6 +7,8 @@ import com.linkedin.venice.kafka.protocol.ControlMessage;
 import com.linkedin.venice.kafka.protocol.KafkaMessageEnvelope;
 import com.linkedin.venice.kafka.protocol.enums.ControlMessageType;
 import com.linkedin.venice.message.KafkaKey;
+import com.linkedin.venice.meta.Store;
+import com.linkedin.venice.meta.StoreDataChangedListener;
 import com.linkedin.venice.meta.Version;
 import com.linkedin.venice.pubsub.adapter.kafka.ApacheKafkaOffsetPosition;
 import com.linkedin.venice.pubsub.api.PubSubConsumerAdapter;
@@ -24,6 +26,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
+import org.apache.kafka.common.errors.UnknownTopicOrPartitionException;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -39,6 +42,7 @@ public class VeniceAfterImageConsumerImpl<K, V> extends VeniceChangelogConsumerI
   final private Lazy<VeniceChangelogConsumerImpl<K, V>> internalSeekConsumer;
   private final ScheduledExecutorService versionSwapExecutorService = Executors.newSingleThreadScheduledExecutor();
   AtomicBoolean versionSwapThreadScheduled = new AtomicBoolean(false);
+  private final VersionSwapDataChangeListener versionSwapListener = new VersionSwapDataChangeListener();
 
   public VeniceAfterImageConsumerImpl(ChangelogClientConfig changelogClientConfig, PubSubConsumerAdapter consumer) {
     this(
@@ -63,7 +67,14 @@ public class VeniceAfterImageConsumerImpl<K, V> extends VeniceChangelogConsumerI
 
   @Override
   public Collection<PubSubMessage<K, ChangeEvent<V>, VeniceChangeCoordinate>> poll(long timeoutInMs) {
-    return internalPoll(timeoutInMs, "");
+    try {
+      return internalPoll(timeoutInMs, "");
+    } catch (UnknownTopicOrPartitionException ex) {
+      LOGGER.error("Caught unknown Topic exception, will attempt repair and retry: ", ex);
+      storeRepository.refresh();
+      versionSwapListener.handleStoreChanged(null);
+      return internalPoll(timeoutInMs, "");
+    }
   }
 
   @Override
@@ -74,7 +85,8 @@ public class VeniceAfterImageConsumerImpl<K, V> extends VeniceChangelogConsumerI
   @Override
   public CompletableFuture<Void> subscribe(Set<Integer> partitions) {
     if (!versionSwapThreadScheduled.get()) {
-      // schedule the version swap thread
+      // schedule the version swap thread and set up the callback listener
+      this.storeRepository.registerStoreDataChangedListener(versionSwapListener);
       versionSwapExecutorService
           .schedule(new VersionSwapDetectionThread(), versionSwapDetectionIntervalTimeInMs, TimeUnit.MILLISECONDS);
       versionSwapThreadScheduled.set(true);
@@ -166,47 +178,58 @@ public class VeniceAfterImageConsumerImpl<K, V> extends VeniceChangelogConsumerI
     return super.internalSeek(partitions, targetTopic, seekAction);
   }
 
+  private class VersionSwapDataChangeListener implements StoreDataChangedListener {
+    @Override
+    public void handleStoreChanged(Store store) {
+      synchronized (this) {
+        Set<Integer> partitions = new HashSet<>();
+        try {
+          // Check the current version of the server
+          int currentVersion = storeRepository.getStore(storeName).getCurrentVersion();
+
+          // Check the current ingested version
+          Set<PubSubTopicPartition> subscriptions = getTopicAssignment();
+          synchronized (subscriptions) {
+            if (subscriptions.isEmpty()) {
+              return;
+            }
+            int maxVersion = -1;
+            for (PubSubTopicPartition topicPartition: subscriptions) {
+              int version = Version.parseVersionFromVersionTopicName(topicPartition.getPubSubTopic().getName());
+              if (version >= maxVersion) {
+                maxVersion = version;
+              }
+            }
+
+            // Seek to end of push
+            if (currentVersion != maxVersion) {
+              // get current subscriptions and seek to endOfPush
+              for (PubSubTopicPartition partitionSubscription: subscriptions) {
+                partitions.add(partitionSubscription.getPartitionNumber());
+              }
+            }
+
+            LOGGER.info(
+                "New Version detected!  Seeking consumer to version: " + currentVersion + " in consumer: "
+                    + changelogClientConfig.getConsumerName());
+            seekToEndOfPush(partitions).get();
+          }
+        } catch (Exception e) {
+          LOGGER.error(
+              "Seek to End of Push Failed for store: " + storeName + " partitions: " + partitions + " on consumer: "
+                  + changelogClientConfig.getConsumerName() + "will retry...",
+              e);
+        }
+      }
+    }
+  }
+
   private class VersionSwapDetectionThread implements Runnable {
     @Override
     public void run() {
-      Set<Integer> partitions = new HashSet<>();
-      try {
-        // Check the current version of the server
-        int currentVersion = storeRepository.getStore(storeName).getCurrentVersion();
-
-        // Check the current ingested version
-        Set<PubSubTopicPartition> subscriptions = getTopicAssignment();
-        synchronized (subscriptions) {
-          if (subscriptions.isEmpty()) {
-            return;
-          }
-          int maxVersion = -1;
-          for (PubSubTopicPartition topicPartition: subscriptions) {
-            int version = Version.parseVersionFromVersionTopicName(topicPartition.getPubSubTopic().getName());
-            if (version >= maxVersion) {
-              maxVersion = version;
-            }
-          }
-
-          // Seek to end of push
-          if (currentVersion != maxVersion) {
-            // get current subscriptions and seek to endOfPush
-            for (PubSubTopicPartition partitionSubscription: subscriptions) {
-              partitions.add(partitionSubscription.getPartitionNumber());
-            }
-          }
-
-          LOGGER.info(
-              "New Version detected!  Seeking consumer to version: " + currentVersion + " in consumer: "
-                  + changelogClientConfig.getConsumerName());
-          seekToEndOfPush(partitions).get();
-        }
-      } catch (Exception e) {
-        LOGGER.error(
-            "Seek to End of Push Failed for store: " + storeName + " partitions: " + partitions + " on consumer: "
-                + changelogClientConfig.getConsumerName() + "will retry...",
-            e);
-      }
+      // the purpose of this thread is to just keep polling just in case something goes wrong at time of the store
+      // repository change.
+      versionSwapListener.handleStoreChanged(null);
     }
   }
 }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/consumer/VeniceChangelogConsumerImpl.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/consumer/VeniceChangelogConsumerImpl.java
@@ -68,6 +68,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
@@ -105,6 +106,8 @@ public class VeniceChangelogConsumerImpl<K, V> implements VeniceChangelogConsume
   protected final Map<Integer, AtomicLong> partitionToDeleteMessageCount = new VeniceConcurrentHashMap<>();
   protected final Map<Integer, Boolean> partitionToBootstrapState = new VeniceConcurrentHashMap<>();
   protected final long startTimestamp;
+
+  protected final AtomicBoolean isSubscribed = new AtomicBoolean(false);
 
   protected final RecordDeserializer<K> keyDeserializer;
   private final D2ControllerClient d2ControllerClient;
@@ -260,8 +263,9 @@ public class VeniceChangelogConsumerImpl<K, V> implements VeniceChangelogConsume
           pubSubConsumer.subscribe(topicPartition, OffsetRecord.LOWEST_OFFSET);
           currentVersionLastHeartbeat.put(topicPartition.getPartitionNumber(), System.currentTimeMillis());
         }
-        return null;
       }
+      isSubscribed.set(true);
+      return null;
     });
   }
 

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/consumer/VersionSwapDataChangeListener.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/consumer/VersionSwapDataChangeListener.java
@@ -32,6 +32,10 @@ class VersionSwapDataChangeListener<K, V> implements StoreDataChangedListener {
   @Override
   public void handleStoreChanged(Store store) {
     // store may be null as this is called by other repair tasks
+    if (!consumer.subscribed()) {
+      // skip this for now as the consumer hasn't even been set up yet
+      return;
+    }
     synchronized (this) {
       Set<Integer> partitions = new HashSet<>();
       try {

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/consumer/VersionSwapDataChangeListener.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/consumer/VersionSwapDataChangeListener.java
@@ -1,0 +1,66 @@
+package com.linkedin.davinci.consumer;
+
+import com.linkedin.davinci.repository.ThinClientMetaStoreBasedRepository;
+import com.linkedin.venice.meta.Store;
+import com.linkedin.venice.meta.StoreDataChangedListener;
+import com.linkedin.venice.meta.Version;
+import com.linkedin.venice.pubsub.api.PubSubTopicPartition;
+import java.util.HashSet;
+import java.util.Set;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+
+class VersionSwapDataChangeListener<K, V> implements StoreDataChangedListener {
+  private static final Logger LOGGER = LogManager.getLogger(VersionSwapDataChangeListener.class);
+  private final VeniceAfterImageConsumerImpl<K, V> consumer;
+  private final ThinClientMetaStoreBasedRepository storeRepository;
+  private final String storeName;
+  private final String consumerName;
+
+  VersionSwapDataChangeListener(
+      VeniceAfterImageConsumerImpl<K, V> consumer,
+      ThinClientMetaStoreBasedRepository storeRepository,
+      String storeName,
+      String consumerName) {
+    this.consumer = consumer;
+    this.storeRepository = storeRepository;
+    this.storeName = storeName;
+    this.consumerName = consumerName;
+  }
+
+  @Override
+  public void handleStoreChanged(Store store) {
+    // store may be null as this is called by other repair tasks
+    synchronized (this) {
+      Set<Integer> partitions = new HashSet<>();
+      try {
+        // Check the current version of the server
+        int currentVersion = this.storeRepository.getStore(this.storeName).getCurrentVersion();
+
+        // Check the current ingested version
+        Set<PubSubTopicPartition> subscriptions = this.consumer.getTopicAssignment();
+        if (subscriptions.isEmpty()) {
+          return;
+        }
+
+        // for all partition subscriptions that are not subscribed to the current version, resubscribe them
+        for (PubSubTopicPartition topicPartition: subscriptions) {
+          int version = Version.parseVersionFromVersionTopicName(topicPartition.getPubSubTopic().getName());
+          if (version != currentVersion) {
+            partitions.add(topicPartition.getPartitionNumber());
+          }
+        }
+
+        LOGGER.info(
+            "New Version detected!  Seeking consumer to version: " + currentVersion + " in consumer: " + consumerName);
+        this.consumer.seekToEndOfPush(partitions).get();
+      } catch (Exception e) {
+        LOGGER.error(
+            "Seek to End of Push Failed for store: " + this.storeName + " partitions: " + partitions + " on consumer: "
+                + consumerName + "will retry...",
+            e);
+      }
+    }
+  }
+}

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/consumer/VeniceChangelogConsumerImplTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/consumer/VeniceChangelogConsumerImplTest.java
@@ -416,10 +416,8 @@ public class VeniceChangelogConsumerImplTest {
 
   @Test
   public void testVersionSwapDataChangeListener() {
-    // consumer.getTopicAssignment();
-    // this.consumer.seekToEndOfPush(partitions).get();
     VeniceAfterImageConsumerImpl mockConsumer = Mockito.mock(VeniceAfterImageConsumerImpl.class);
-    // Set<PubSubTopicPartition> getTopicAssignment()
+    Mockito.when(mockConsumer.subscribed()).thenReturn(true);
     PubSubTopicPartition topicPartition = new PubSubTopicPartitionImpl(
         new TestPubSubTopic(storeName + "_v1", storeName, PubSubTopicType.VERSION_TOPIC),
         1);

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/consumer/VeniceChangelogConsumerImplTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/consumer/VeniceChangelogConsumerImplTest.java
@@ -11,6 +11,7 @@ import static org.mockito.Mockito.verify;
 
 import com.linkedin.avroutil1.compatibility.AvroCompatibilityHelper;
 import com.linkedin.davinci.consumer.stats.BasicConsumerStats;
+import com.linkedin.davinci.kafka.consumer.TestPubSubTopic;
 import com.linkedin.davinci.repository.ThinClientMetaStoreBasedRepository;
 import com.linkedin.venice.client.change.capture.protocol.RecordChangeEvent;
 import com.linkedin.venice.client.change.capture.protocol.ValueBytes;
@@ -40,6 +41,7 @@ import com.linkedin.venice.pubsub.api.PubSubConsumerAdapter;
 import com.linkedin.venice.pubsub.api.PubSubMessage;
 import com.linkedin.venice.pubsub.api.PubSubTopic;
 import com.linkedin.venice.pubsub.api.PubSubTopicPartition;
+import com.linkedin.venice.pubsub.api.PubSubTopicType;
 import com.linkedin.venice.schema.SchemaEntry;
 import com.linkedin.venice.schema.SchemaReader;
 import com.linkedin.venice.schema.rmd.RmdConstants;
@@ -410,6 +412,35 @@ public class VeniceChangelogConsumerImplTest {
     veniceChangelogConsumer.close();
     verify(mockPubSubConsumer, times(2)).batchUnsubscribe(any());
     verify(mockPubSubConsumer).close();
+  }
+
+  @Test
+  public void testVersionSwapDataChangeListener() {
+    // consumer.getTopicAssignment();
+    // this.consumer.seekToEndOfPush(partitions).get();
+    VeniceAfterImageConsumerImpl mockConsumer = Mockito.mock(VeniceAfterImageConsumerImpl.class);
+    // Set<PubSubTopicPartition> getTopicAssignment()
+    PubSubTopicPartition topicPartition = new PubSubTopicPartitionImpl(
+        new TestPubSubTopic(storeName + "_v1", storeName, PubSubTopicType.VERSION_TOPIC),
+        1);
+
+    Set<PubSubTopicPartition> topicPartitionSet = new HashSet<>();
+    topicPartitionSet.add(topicPartition);
+    Mockito.when(mockConsumer.getTopicAssignment()).thenReturn(topicPartitionSet);
+    Mockito.when(mockConsumer.seekToEndOfPush(Mockito.anySet())).thenReturn(CompletableFuture.completedFuture(null));
+
+    String storeName = "Leppalúði_store";
+
+    ThinClientMetaStoreBasedRepository mockRepository = Mockito.mock(ThinClientMetaStoreBasedRepository.class);
+    Store mockStore = Mockito.mock(Store.class);
+    Mockito.when(mockStore.getCurrentVersion()).thenReturn(5);
+    Mockito.when(mockRepository.getStore(storeName)).thenReturn(mockStore);
+
+    VersionSwapDataChangeListener changeListener =
+        new VersionSwapDataChangeListener(mockConsumer, mockRepository, storeName, "");
+    changeListener.handleStoreChanged(null);
+    Mockito.verify(mockConsumer).seekToEndOfPush(Mockito.anySet());
+
   }
 
   @Test

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/consumer/TestChangelogConsumer.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/consumer/TestChangelogConsumer.java
@@ -266,8 +266,7 @@ public class TestChangelogConsumer {
           .setControllerD2ServiceName(D2_SERVICE_NAME)
           .setD2ServiceName(VeniceRouterWrapper.CLUSTER_DISCOVERY_D2_SERVICE_NAME)
           .setLocalD2ZkHosts(localZkServer.getAddress())
-          .setControllerRequestRetryCount(3)
-          .setVersionSwapDetectionIntervalTimeInMs(10L);
+          .setControllerRequestRetryCount(3);
       VeniceChangelogConsumerClientFactory veniceChangelogConsumerClientFactory =
           new VeniceChangelogConsumerClientFactory(globalChangelogClientConfig, metricsRepository);
 


### PR DESCRIPTION
## [changelog] Add resiliency to version swap in change capture client

This improves resiliency in a layered approach.  It:

- Makes the metadata update a change listener on the store repository 
- Makes the original detection thread a last ditch effort should something go wrong when reacting to that call back 
- Makes the unknown topic or partition exception a signal to try and force a refresh of metadata and fix the subscription
- Actually uses the correct executor task method so that the refresh is properly scheduled (as opposed to the original one which only did it once).

Resolves #XXX

## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [ ] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.