### PR TITLE
[client-common][router] minor cleanup and some tests for otel

### DIFF
--- a/internal/venice-client-common/src/main/java/com/linkedin/venice/stats/VeniceMetricsConfig.java
+++ b/internal/venice-client-common/src/main/java/com/linkedin/venice/stats/VeniceMetricsConfig.java
@@ -111,6 +111,10 @@ public class VeniceMetricsConfig {
 
   private final String serviceName;
   private final String metricPrefix;
+  /**
+   * List of all the metrics emitted by the service: Currently used to set Exponential Histogram view
+   * for instruments of type {@link com.linkedin.venice.stats.metrics.MetricType#HISTOGRAM}
+   */
   private final Collection<MetricEntity> metricEntities;
   /** reusing tehuti's MetricConfig */
   private final MetricConfig tehutiMetricConfig;
@@ -266,6 +270,11 @@ public class VeniceMetricsConfig {
       String configValue;
       if ((configValue = configs.get(OTEL_VENICE_METRICS_ENABLED)) != null) {
         setEmitOtelMetrics(Boolean.parseBoolean(configValue));
+      }
+
+      if (!emitOtelMetrics) {
+        // Early return if OpenTelemetry metrics are disabled
+        return this;
       }
 
       if ((configValue = configs.get(OTEL_VENICE_METRICS_PREFIX)) != null) {

--- a/internal/venice-client-common/src/main/java/com/linkedin/venice/stats/VeniceMetricsRepository.java
+++ b/internal/venice-client-common/src/main/java/com/linkedin/venice/stats/VeniceMetricsRepository.java
@@ -22,11 +22,14 @@ public class VeniceMetricsRepository extends MetricsRepository implements Closea
   public VeniceMetricsRepository() {
     super();
     this.veniceMetricsConfig = new VeniceMetricsConfig.Builder().build();
-    this.openTelemetryMetricsRepository = new VeniceOpenTelemetryMetricsRepository(veniceMetricsConfig);
+    this.openTelemetryMetricsRepository =
+        (veniceMetricsConfig.emitOtelMetrics() ? new VeniceOpenTelemetryMetricsRepository(veniceMetricsConfig) : null);
   }
 
   public VeniceMetricsRepository(VeniceMetricsConfig veniceMetricsConfig) {
-    this(veniceMetricsConfig, new VeniceOpenTelemetryMetricsRepository(veniceMetricsConfig));
+    this(
+        veniceMetricsConfig,
+        veniceMetricsConfig.emitOtelMetrics() ? new VeniceOpenTelemetryMetricsRepository(veniceMetricsConfig) : null);
   }
 
   public VeniceMetricsRepository(

--- a/internal/venice-client-common/src/main/java/com/linkedin/venice/stats/VeniceOpenTelemetryMetricNamingFormat.java
+++ b/internal/venice-client-common/src/main/java/com/linkedin/venice/stats/VeniceOpenTelemetryMetricNamingFormat.java
@@ -90,4 +90,8 @@ public enum VeniceOpenTelemetryMetricNamingFormat implements VeniceEnumValue {
     }
     return Character.toUpperCase(word.charAt(0)) + word.substring(1);
   }
+
+  public static VeniceOpenTelemetryMetricNamingFormat getDefaultFormat() {
+    return SNAKE_CASE;
+  }
 }

--- a/internal/venice-client-common/src/main/java/com/linkedin/venice/utils/metrics/MetricsRepositoryUtils.java
+++ b/internal/venice-client-common/src/main/java/com/linkedin/venice/utils/metrics/MetricsRepositoryUtils.java
@@ -2,6 +2,7 @@ package com.linkedin.venice.utils.metrics;
 
 import com.linkedin.venice.stats.VeniceMetricsConfig;
 import com.linkedin.venice.stats.VeniceMetricsRepository;
+import com.linkedin.venice.stats.VeniceOpenTelemetryMetricNamingFormat;
 import io.tehuti.metrics.MetricConfig;
 import io.tehuti.metrics.MetricsRepository;
 import io.tehuti.metrics.stats.AsyncGauge;
@@ -23,7 +24,17 @@ public class MetricsRepositoryUtils {
   }
 
   public static MetricsRepository createSingleThreadedVeniceMetricsRepository() {
-    return createSingleThreadedVeniceMetricsRepository(TimeUnit.MINUTES.toMillis(1), 100);
+    return createSingleThreadedVeniceMetricsRepository(
+        TimeUnit.MINUTES.toMillis(1),
+        100,
+        false,
+        VeniceOpenTelemetryMetricNamingFormat.getDefaultFormat());
+  }
+
+  public static MetricsRepository createSingleThreadedVeniceMetricsRepository(
+      boolean isOtelEnabled,
+      VeniceOpenTelemetryMetricNamingFormat otelFormat) {
+    return createSingleThreadedVeniceMetricsRepository(TimeUnit.MINUTES.toMillis(1), 100, isOtelEnabled, otelFormat);
   }
 
   public static MetricConfig getMetricConfig(
@@ -45,9 +56,12 @@ public class MetricsRepositoryUtils {
 
   public static MetricsRepository createSingleThreadedVeniceMetricsRepository(
       long maxMetricsMeasurementTimeoutMs,
-      long initialMetricsMeasurementTimeoutMs) {
+      long initialMetricsMeasurementTimeoutMs,
+      boolean isOtelEnabled,
+      VeniceOpenTelemetryMetricNamingFormat otelFormat) {
     return new VeniceMetricsRepository(
-        new VeniceMetricsConfig.Builder()
+        new VeniceMetricsConfig.Builder().setEmitOtelMetrics(isOtelEnabled)
+            .setMetricNamingFormat(otelFormat)
             .setTehutiMetricConfig(getMetricConfig(maxMetricsMeasurementTimeoutMs, initialMetricsMeasurementTimeoutMs))
             .build());
   }

--- a/internal/venice-client-common/src/main/java/com/linkedin/venice/utils/metrics/MetricsRepositoryUtils.java
+++ b/internal/venice-client-common/src/main/java/com/linkedin/venice/utils/metrics/MetricsRepositoryUtils.java
@@ -3,9 +3,14 @@ package com.linkedin.venice.utils.metrics;
 import com.linkedin.venice.stats.VeniceMetricsConfig;
 import com.linkedin.venice.stats.VeniceMetricsRepository;
 import com.linkedin.venice.stats.VeniceOpenTelemetryMetricNamingFormat;
+import com.linkedin.venice.stats.metrics.MetricEntity;
+import com.linkedin.venice.stats.metrics.MetricType;
+import com.linkedin.venice.stats.metrics.MetricUnit;
 import io.tehuti.metrics.MetricConfig;
 import io.tehuti.metrics.MetricsRepository;
 import io.tehuti.metrics.stats.AsyncGauge;
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.concurrent.TimeUnit;
 
 
@@ -59,8 +64,13 @@ public class MetricsRepositoryUtils {
       long initialMetricsMeasurementTimeoutMs,
       boolean isOtelEnabled,
       VeniceOpenTelemetryMetricNamingFormat otelFormat) {
+    Collection<MetricEntity> metricEntities = new ArrayList<>();
+    metricEntities
+        .add(new MetricEntity("test_metric", MetricType.HISTOGRAM, MetricUnit.MILLISECOND, "Test description"));
+
     return new VeniceMetricsRepository(
         new VeniceMetricsConfig.Builder().setEmitOtelMetrics(isOtelEnabled)
+            .setMetricEntities(metricEntities)
             .setMetricNamingFormat(otelFormat)
             .setTehutiMetricConfig(getMetricConfig(maxMetricsMeasurementTimeoutMs, initialMetricsMeasurementTimeoutMs))
             .build());

--- a/internal/venice-client-common/src/test/java/com/linkedin/venice/stats/VeniceMetricsConfigTest.java
+++ b/internal/venice-client-common/src/test/java/com/linkedin/venice/stats/VeniceMetricsConfigTest.java
@@ -84,9 +84,10 @@ public class VeniceMetricsConfigTest {
         .build();
   }
 
-  @Test(expectedExceptions = IllegalArgumentException.class)
+  @Test(expectedExceptions = IllegalArgumentException.class, expectedExceptionsMessageRegExp = "No enum constant com.linkedin.venice.stats.VeniceOpenTelemetryMetricNamingFormat.INVALID_FORMAT")
   public void testOtelConfigWithInvalidMetricFormat() {
     Map<String, String> otelConfigs = new HashMap<>();
+    otelConfigs.put(OTEL_VENICE_METRICS_ENABLED, "true");
     otelConfigs.put(OTEL_VENICE_METRICS_NAMING_FORMAT, "INVALID_FORMAT");
 
     new Builder().extractAndSetOtelConfigs(otelConfigs).build();

--- a/internal/venice-client-common/src/test/java/com/linkedin/venice/stats/VeniceMetricsConfigTest.java
+++ b/internal/venice-client-common/src/test/java/com/linkedin/venice/stats/VeniceMetricsConfigTest.java
@@ -11,6 +11,7 @@ import static com.linkedin.venice.stats.VeniceMetricsConfig.OTEL_VENICE_METRICS_
 import static com.linkedin.venice.stats.VeniceMetricsConfig.OTEL_VENICE_METRICS_EXPORT_TO_ENDPOINT;
 import static com.linkedin.venice.stats.VeniceMetricsConfig.OTEL_VENICE_METRICS_EXPORT_TO_LOG;
 import static com.linkedin.venice.stats.VeniceMetricsConfig.OTEL_VENICE_METRICS_NAMING_FORMAT;
+import static com.linkedin.venice.stats.VeniceOpenTelemetryMetricNamingFormat.SNAKE_CASE;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNotNull;
@@ -42,7 +43,7 @@ public class VeniceMetricsConfigTest {
     assertEquals(config.getOtelEndpoint(), null);
     assertTrue(config.getOtelHeaders().isEmpty());
     assertFalse(config.exportOtelMetricsToLog());
-    assertEquals(config.getMetricNamingFormat(), VeniceOpenTelemetryMetricNamingFormat.SNAKE_CASE);
+    assertEquals(config.getMetricNamingFormat(), SNAKE_CASE);
     assertEquals(config.getOtelAggregationTemporalitySelector(), AggregationTemporalitySelector.deltaPreferred());
     assertEquals(config.useOtelExponentialHistogram(), true);
     assertEquals(config.getOtelExponentialHistogramMaxScale(), 3);

--- a/internal/venice-client-common/src/test/java/com/linkedin/venice/stats/VeniceMetricsRepositoryTest.java
+++ b/internal/venice-client-common/src/test/java/com/linkedin/venice/stats/VeniceMetricsRepositoryTest.java
@@ -6,7 +6,12 @@ import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertTrue;
 
+import com.linkedin.venice.stats.metrics.MetricEntity;
+import com.linkedin.venice.stats.metrics.MetricType;
+import com.linkedin.venice.stats.metrics.MetricUnit;
 import io.tehuti.metrics.MetricConfig;
+import java.util.ArrayList;
+import java.util.Collection;
 import org.mockito.Mockito;
 import org.testng.annotations.Test;
 
@@ -41,7 +46,11 @@ public class VeniceMetricsRepositoryTest {
 
   @Test
   public void testConstructorWithMetricConfigAndOtelEnabled() {
-    VeniceMetricsConfig metricsConfig = new VeniceMetricsConfig.Builder().setEmitOtelMetrics(true).build();
+    Collection<MetricEntity> metricEntities = new ArrayList<>();
+    metricEntities
+        .add(new MetricEntity("test_metric", MetricType.HISTOGRAM, MetricUnit.MILLISECOND, "Test description"));
+    VeniceMetricsConfig metricsConfig =
+        new VeniceMetricsConfig.Builder().setEmitOtelMetrics(true).setMetricEntities(metricEntities).build();
     VeniceMetricsRepository repository = new VeniceMetricsRepository(metricsConfig);
 
     assertEquals(

--- a/internal/venice-client-common/src/test/java/com/linkedin/venice/stats/VeniceMetricsRepositoryTest.java
+++ b/internal/venice-client-common/src/test/java/com/linkedin/venice/stats/VeniceMetricsRepositoryTest.java
@@ -1,7 +1,10 @@
 package com.linkedin.venice.stats;
 
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertTrue;
 
 import io.tehuti.metrics.MetricConfig;
 import org.mockito.Mockito;
@@ -10,10 +13,45 @@ import org.testng.annotations.Test;
 
 public class VeniceMetricsRepositoryTest {
   @Test
-  public void testDefaultConstructor() throws Exception {
+  public void testDefaultConstructor() {
     VeniceMetricsRepository repository = new VeniceMetricsRepository();
     assertNotNull(repository.getVeniceMetricsConfig(), "VeniceMetricsConfig should not be null.");
-    assertNotNull(repository.getOpenTelemetryMetricsRepository(), "OpenTelemetryMetricsRepository should not be null.");
+    assertFalse(repository.getVeniceMetricsConfig().emitOtelMetrics());
+    assertNull(
+        repository.getOpenTelemetryMetricsRepository(),
+        "OpenTelemetryMetricsRepository should be null if not enabled explicitly");
+    repository.close();
+  }
+
+  @Test
+  public void testConstructorWithMetricConfig() {
+    VeniceMetricsConfig metricsConfig = new VeniceMetricsConfig.Builder().build();
+    VeniceMetricsRepository repository = new VeniceMetricsRepository(metricsConfig);
+    assertFalse(metricsConfig.emitOtelMetrics());
+
+    assertEquals(
+        repository.getVeniceMetricsConfig(),
+        metricsConfig,
+        "VeniceMetricsConfig should match the provided config.");
+    assertNull(
+        repository.getOpenTelemetryMetricsRepository(),
+        "OpenTelemetryMetricsRepository should be null if not enabled explicitly");
+    repository.close();
+  }
+
+  @Test
+  public void testConstructorWithMetricConfigAndOtelEnabled() {
+    VeniceMetricsConfig metricsConfig = new VeniceMetricsConfig.Builder().setEmitOtelMetrics(true).build();
+    VeniceMetricsRepository repository = new VeniceMetricsRepository(metricsConfig);
+
+    assertEquals(
+        repository.getVeniceMetricsConfig(),
+        metricsConfig,
+        "VeniceMetricsConfig should match the provided config.");
+    assertTrue(metricsConfig.emitOtelMetrics());
+    assertNotNull(
+        repository.getOpenTelemetryMetricsRepository(),
+        "OpenTelemetryMetricsRepository should not be null if enabled explicitly");
     repository.close();
   }
 

--- a/internal/venice-client-common/src/test/java/com/linkedin/venice/stats/VeniceOpenTelemetryMetricsRepositoryTest.java
+++ b/internal/venice-client-common/src/test/java/com/linkedin/venice/stats/VeniceOpenTelemetryMetricsRepositoryTest.java
@@ -1,18 +1,23 @@
 package com.linkedin.venice.stats;
 
+import static com.linkedin.venice.stats.VeniceOpenTelemetryMetricNamingFormat.SNAKE_CASE;
 import static com.linkedin.venice.stats.VeniceOpenTelemetryMetricNamingFormat.transformMetricName;
 import static com.linkedin.venice.stats.VeniceOpenTelemetryMetricNamingFormat.validateMetricName;
+import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertSame;
+import static org.testng.Assert.fail;
 
+import com.linkedin.venice.exceptions.VeniceException;
 import com.linkedin.venice.stats.metrics.MetricEntity;
 import com.linkedin.venice.stats.metrics.MetricType;
 import com.linkedin.venice.stats.metrics.MetricUnit;
 import io.opentelemetry.api.metrics.DoubleHistogram;
 import io.opentelemetry.api.metrics.LongCounter;
 import io.opentelemetry.sdk.metrics.export.MetricExporter;
+import java.util.ArrayList;
 import org.mockito.Mockito;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
@@ -27,13 +32,12 @@ public class VeniceOpenTelemetryMetricsRepositoryTest {
   @BeforeMethod
   public void setUp() {
     mockMetricsConfig = Mockito.mock(VeniceMetricsConfig.class);
-    Mockito.when(mockMetricsConfig.emitOtelMetrics()).thenReturn(true);
-    Mockito.when(mockMetricsConfig.getMetricNamingFormat())
-        .thenReturn(VeniceOpenTelemetryMetricNamingFormat.SNAKE_CASE);
-    Mockito.when(mockMetricsConfig.getMetricPrefix()).thenReturn("test_prefix");
-    Mockito.when(mockMetricsConfig.getServiceName()).thenReturn("test_service");
-    Mockito.when(mockMetricsConfig.exportOtelMetricsToEndpoint()).thenReturn(true);
-    Mockito.when(mockMetricsConfig.getOtelEndpoint()).thenReturn("http://localhost:4318");
+    when(mockMetricsConfig.emitOtelMetrics()).thenReturn(true);
+    when(mockMetricsConfig.getMetricNamingFormat()).thenReturn(SNAKE_CASE);
+    when(mockMetricsConfig.getMetricPrefix()).thenReturn("test_prefix");
+    when(mockMetricsConfig.getServiceName()).thenReturn("test_service");
+    when(mockMetricsConfig.exportOtelMetricsToEndpoint()).thenReturn(true);
+    when(mockMetricsConfig.getOtelEndpoint()).thenReturn("http://localhost:4318");
 
     metricsRepository = new VeniceOpenTelemetryMetricsRepository(mockMetricsConfig);
   }
@@ -52,7 +56,7 @@ public class VeniceOpenTelemetryMetricsRepositoryTest {
 
   @Test
   public void testConstructorWithEmitDisabled() {
-    Mockito.when(mockMetricsConfig.emitOtelMetrics()).thenReturn(false);
+    when(mockMetricsConfig.emitOtelMetrics()).thenReturn(false);
     VeniceOpenTelemetryMetricsRepository metricsRepository =
         new VeniceOpenTelemetryMetricsRepository(mockMetricsConfig);
 
@@ -90,8 +94,7 @@ public class VeniceOpenTelemetryMetricsRepositoryTest {
 
   @Test
   public void testTransformMetricName() {
-    Mockito.when(mockMetricsConfig.getMetricNamingFormat())
-        .thenReturn(VeniceOpenTelemetryMetricNamingFormat.SNAKE_CASE);
+    when(mockMetricsConfig.getMetricNamingFormat()).thenReturn(SNAKE_CASE);
     assertEquals(metricsRepository.getFullMetricName("prefix", "metric_name"), "prefix.metric_name");
 
     String transformedName =
@@ -122,5 +125,34 @@ public class VeniceOpenTelemetryMetricsRepositoryTest {
 
     assertNotNull(counter1);
     assertSame(counter1, counter2, "Should return the same instance for the same counter name.");
+  }
+
+  @Test
+  public void testRepositoryCreationWithoutSetMetricEntities() {
+    when(mockMetricsConfig.useOtelExponentialHistogram()).thenReturn(true);
+    when(mockMetricsConfig.getMetricEntities()).thenReturn(null);
+    try {
+      new VeniceOpenTelemetryMetricsRepository(mockMetricsConfig);
+      fail();
+    } catch (VeniceException e) {
+      // Verify that the exception message is correct
+      assertEquals(
+          e.getCause().getMessage(),
+          "metricEntities cannot be empty if exponential Histogram is enabled, List all the metrics used in this service using setMetricEntities method");
+    }
+
+    when(mockMetricsConfig.getMetricEntities()).thenReturn(new ArrayList<>());
+    try {
+      new VeniceOpenTelemetryMetricsRepository(mockMetricsConfig);
+      fail();
+    } catch (VeniceException e) {
+      // Verify that the exception message is correct
+      assertEquals(
+          e.getCause().getMessage(),
+          "metricEntities cannot be empty if exponential Histogram is enabled, List all the metrics used in this service using setMetricEntities method");
+    }
+
+    when(mockMetricsConfig.useOtelExponentialHistogram()).thenReturn(false);
+    new VeniceOpenTelemetryMetricsRepository(mockMetricsConfig);
   }
 }

--- a/internal/venice-client-common/src/test/java/com/linkedin/venice/stats/dimensions/VeniceMetricsDimensionsTest.java
+++ b/internal/venice-client-common/src/test/java/com/linkedin/venice/stats/dimensions/VeniceMetricsDimensionsTest.java
@@ -1,5 +1,6 @@
 package com.linkedin.venice.stats.dimensions;
 
+import static com.linkedin.venice.stats.VeniceOpenTelemetryMetricNamingFormat.SNAKE_CASE;
 import static org.testng.Assert.assertEquals;
 
 import com.linkedin.venice.stats.VeniceOpenTelemetryMetricNamingFormat;
@@ -9,7 +10,7 @@ import org.testng.annotations.Test;
 public class VeniceMetricsDimensionsTest {
   @Test
   public void testGetDimensionNameInSnakeCase() {
-    VeniceOpenTelemetryMetricNamingFormat format = VeniceOpenTelemetryMetricNamingFormat.SNAKE_CASE;
+    VeniceOpenTelemetryMetricNamingFormat format = SNAKE_CASE;
     for (VeniceMetricsDimensions dimension: VeniceMetricsDimensions.values()) {
       switch (dimension) {
         case VENICE_STORE_NAME:

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/integration/utils/VeniceRouterWrapper.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/integration/utils/VeniceRouterWrapper.java
@@ -29,7 +29,6 @@ import static com.linkedin.venice.stats.VeniceMetricsConfig.OTEL_EXPORTER_OTLP_M
 import static com.linkedin.venice.stats.VeniceMetricsConfig.OTEL_EXPORTER_OTLP_METRICS_PROTOCOL;
 import static com.linkedin.venice.stats.VeniceMetricsConfig.OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE;
 import static com.linkedin.venice.stats.VeniceMetricsConfig.OTEL_VENICE_METRICS_ENABLED;
-import static com.linkedin.venice.stats.VeniceMetricsConfig.OTEL_VENICE_METRICS_EXPORT_TO_LOG;
 
 import com.linkedin.venice.client.store.ClientConfig;
 import com.linkedin.venice.helix.HelixBaseRoutingRepository;
@@ -163,7 +162,6 @@ public class VeniceRouterWrapper extends ProcessWrapper implements MetricsAware 
           .put(ROUTER_STORAGE_NODE_CLIENT_TYPE, StorageNodeClientType.APACHE_HTTP_ASYNC_CLIENT.name())
           // OpenTelemetry configs
           .put(OTEL_VENICE_METRICS_ENABLED, Boolean.TRUE.toString())
-          .put(OTEL_VENICE_METRICS_EXPORT_TO_LOG, Boolean.TRUE.toString())
           .put(OTEL_EXPORTER_OTLP_METRICS_PROTOCOL, "http/protobuf")
           .put(OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE, "delta")
           .put(OTEL_EXPORTER_OTLP_METRICS_DEFAULT_HISTOGRAM_AGGREGATION, "base2_exponential_bucket_histogram")

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/integration/utils/VeniceRouterWrapper.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/integration/utils/VeniceRouterWrapper.java
@@ -26,11 +26,9 @@ import static com.linkedin.venice.router.RouterServer.ROUTER_SERVICE_METRIC_ENTI
 import static com.linkedin.venice.stats.VeniceMetricsConfig.OTEL_EXPORTER_OTLP_METRICS_DEFAULT_HISTOGRAM_AGGREGATION;
 import static com.linkedin.venice.stats.VeniceMetricsConfig.OTEL_EXPORTER_OTLP_METRICS_DEFAULT_HISTOGRAM_AGGREGATION_MAX_BUCKETS;
 import static com.linkedin.venice.stats.VeniceMetricsConfig.OTEL_EXPORTER_OTLP_METRICS_DEFAULT_HISTOGRAM_AGGREGATION_MAX_SCALE;
-import static com.linkedin.venice.stats.VeniceMetricsConfig.OTEL_EXPORTER_OTLP_METRICS_ENDPOINT;
 import static com.linkedin.venice.stats.VeniceMetricsConfig.OTEL_EXPORTER_OTLP_METRICS_PROTOCOL;
 import static com.linkedin.venice.stats.VeniceMetricsConfig.OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE;
 import static com.linkedin.venice.stats.VeniceMetricsConfig.OTEL_VENICE_METRICS_ENABLED;
-import static com.linkedin.venice.stats.VeniceMetricsConfig.OTEL_VENICE_METRICS_EXPORT_TO_ENDPOINT;
 import static com.linkedin.venice.stats.VeniceMetricsConfig.OTEL_VENICE_METRICS_EXPORT_TO_LOG;
 
 import com.linkedin.venice.client.store.ClientConfig;
@@ -166,9 +164,7 @@ public class VeniceRouterWrapper extends ProcessWrapper implements MetricsAware 
           // OpenTelemetry configs
           .put(OTEL_VENICE_METRICS_ENABLED, Boolean.TRUE.toString())
           .put(OTEL_VENICE_METRICS_EXPORT_TO_LOG, Boolean.TRUE.toString())
-          .put(OTEL_VENICE_METRICS_EXPORT_TO_ENDPOINT, Boolean.TRUE.toString())
           .put(OTEL_EXPORTER_OTLP_METRICS_PROTOCOL, "http/protobuf")
-          .put(OTEL_EXPORTER_OTLP_METRICS_ENDPOINT, "http://localhost:4318/v1/metrics")
           .put(OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE, "delta")
           .put(OTEL_EXPORTER_OTLP_METRICS_DEFAULT_HISTOGRAM_AGGREGATION, "base2_exponential_bucket_histogram")
           .put(OTEL_EXPORTER_OTLP_METRICS_DEFAULT_HISTOGRAM_AGGREGATION_MAX_SCALE, 3)

--- a/services/venice-router/src/main/java/com/linkedin/venice/router/stats/RouterHttpRequestStats.java
+++ b/services/venice-router/src/main/java/com/linkedin/venice/router/stats/RouterHttpRequestStats.java
@@ -129,10 +129,9 @@ public class RouterHttpRequestStats extends AbstractVeniceHttpStats {
   private final Sensor errorRetryAttemptTriggeredByPendingRequestCheckSensor;
 
   private final String systemStoreName;
-  private Attributes commonMetricDimensions = null;
-  private boolean emitOpenTelemetryMetrics = false;
-  private VeniceOpenTelemetryMetricNamingFormat openTelemetryMetricFormat =
-      VeniceOpenTelemetryMetricNamingFormat.getDefaultFormat();
+  private final Attributes commonMetricDimensions;
+  private final boolean emitOpenTelemetryMetrics;
+  private final VeniceOpenTelemetryMetricNamingFormat openTelemetryMetricFormat;
 
   // QPS metrics
   public RouterHttpRequestStats(
@@ -160,7 +159,13 @@ public class RouterHttpRequestStats extends AbstractVeniceHttpStats {
           attributesBuilder.put(entry.getKey(), entry.getValue());
         }
         commonMetricDimensions = attributesBuilder.build();
+      } else {
+        commonMetricDimensions = null;
       }
+    } else {
+      emitOpenTelemetryMetrics = false;
+      openTelemetryMetricFormat = VeniceOpenTelemetryMetricNamingFormat.getDefaultFormat();
+      commonMetricDimensions = null;
     }
 
     this.systemStoreName = VeniceSystemStoreUtils.extractSystemStoreType(storeName);

--- a/services/venice-router/src/main/java/com/linkedin/venice/router/stats/RouterMetricEntity.java
+++ b/services/venice-router/src/main/java/com/linkedin/venice/router/stats/RouterMetricEntity.java
@@ -23,11 +23,11 @@ import java.util.Set;
  */
 public enum RouterMetricEntity {
   INCOMING_CALL_COUNT(
-      "incoming_call_count", MetricType.COUNTER, MetricUnit.NUMBER, "Count of all incoming requests",
+      MetricType.COUNTER, MetricUnit.NUMBER, "Count of all incoming requests",
       setOf(VENICE_STORE_NAME, VENICE_CLUSTER_NAME, VENICE_REQUEST_METHOD)
   ),
   CALL_COUNT(
-      "call_count", MetricType.COUNTER, MetricUnit.NUMBER, "Count of all requests with response details",
+      MetricType.COUNTER, MetricUnit.NUMBER, "Count of all requests with response details",
       setOf(
           VENICE_STORE_NAME,
           VENICE_CLUSTER_NAME,
@@ -37,7 +37,7 @@ public enum RouterMetricEntity {
           VENICE_RESPONSE_STATUS_CODE_CATEGORY)
   ),
   CALL_TIME(
-      "call_time", MetricType.HISTOGRAM, MetricUnit.MILLISECOND, "Latency based on all responses",
+      MetricType.HISTOGRAM, MetricUnit.MILLISECOND, "Latency based on all responses",
       setOf(
           VENICE_STORE_NAME,
           VENICE_CLUSTER_NAME,
@@ -46,40 +46,38 @@ public enum RouterMetricEntity {
           VENICE_RESPONSE_STATUS_CODE_CATEGORY)
   ),
   CALL_KEY_COUNT(
-      "call_key_count", MetricType.MIN_MAX_COUNT_SUM_AGGREGATIONS, MetricUnit.NUMBER,
-      "Count of keys in multi key requests",
+      MetricType.MIN_MAX_COUNT_SUM_AGGREGATIONS, MetricUnit.NUMBER, "Count of keys in multi key requests",
       setOf(VENICE_STORE_NAME, VENICE_CLUSTER_NAME, VENICE_REQUEST_METHOD, VENICE_REQUEST_VALIDATION_OUTCOME)
   ),
   RETRY_COUNT(
-      "retry_count", MetricType.COUNTER, MetricUnit.NUMBER, "Count of retries triggered",
+      MetricType.COUNTER, MetricUnit.NUMBER, "Count of retries triggered",
       setOf(VENICE_STORE_NAME, VENICE_CLUSTER_NAME, VENICE_REQUEST_METHOD, VENICE_REQUEST_RETRY_TYPE)
   ),
   ALLOWED_RETRY_COUNT(
-      "allowed_retry_count", MetricType.COUNTER, MetricUnit.NUMBER, "Count of allowed retry requests",
+      MetricType.COUNTER, MetricUnit.NUMBER, "Count of allowed retry requests",
       setOf(VENICE_STORE_NAME, VENICE_CLUSTER_NAME, VENICE_REQUEST_METHOD)
   ),
   DISALLOWED_RETRY_COUNT(
-      "disallowed_retry_count", MetricType.COUNTER, MetricUnit.NUMBER, "Count of disallowed retry requests",
+      MetricType.COUNTER, MetricUnit.NUMBER, "Count of disallowed retry requests",
       setOf(VENICE_STORE_NAME, VENICE_CLUSTER_NAME, VENICE_REQUEST_METHOD)
   ),
   RETRY_DELAY(
-      "retry_delay", MetricType.MIN_MAX_COUNT_SUM_AGGREGATIONS, MetricUnit.MILLISECOND, "Retry delay time",
+      MetricType.MIN_MAX_COUNT_SUM_AGGREGATIONS, MetricUnit.MILLISECOND, "Retry delay time",
       setOf(VENICE_STORE_NAME, VENICE_CLUSTER_NAME, VENICE_REQUEST_METHOD)
   ),
   ABORTED_RETRY_COUNT(
-      "aborted_retry_count", MetricType.COUNTER, MetricUnit.NUMBER, "Count of aborted retry requests",
+      MetricType.COUNTER, MetricUnit.NUMBER, "Count of aborted retry requests",
       setOf(VENICE_STORE_NAME, VENICE_CLUSTER_NAME, VENICE_REQUEST_METHOD, VENICE_REQUEST_RETRY_ABORT_REASON)
   );
 
   private final MetricEntity metricEntity;
 
   RouterMetricEntity(
-      String metricName,
       MetricType metricType,
       MetricUnit unit,
       String description,
       Set<VeniceMetricsDimensions> dimensionsList) {
-    this.metricEntity = new MetricEntity(metricName, metricType, unit, description, dimensionsList);
+    this.metricEntity = new MetricEntity(this.name().toLowerCase(), metricType, unit, description, dimensionsList);
   }
 
   public MetricEntity getMetricEntity() {

--- a/services/venice-router/src/test/java/com/linkedin/venice/router/stats/AggRouterHttpRequestStatsTest.java
+++ b/services/venice-router/src/test/java/com/linkedin/venice/router/stats/AggRouterHttpRequestStatsTest.java
@@ -1,10 +1,9 @@
-package com.linkedin.venice.router;
+package com.linkedin.venice.router.stats;
 
 import static io.netty.handler.codec.http.HttpResponseStatus.TOO_MANY_REQUESTS;
 
 import com.linkedin.venice.meta.ReadOnlyStoreRepository;
 import com.linkedin.venice.read.RequestType;
-import com.linkedin.venice.router.stats.AggRouterHttpRequestStats;
 import com.linkedin.venice.stats.VeniceMetricsRepository;
 import com.linkedin.venice.tehuti.MockTehutiReporter;
 import com.linkedin.venice.utils.Utils;

--- a/services/venice-router/src/test/java/com/linkedin/venice/router/stats/RouterHttpRequestStatsTest.java
+++ b/services/venice-router/src/test/java/com/linkedin/venice/router/stats/RouterHttpRequestStatsTest.java
@@ -15,12 +15,17 @@ import static org.testng.Assert.assertTrue;
 import com.linkedin.alpini.router.monitoring.ScatterGatherStats;
 import com.linkedin.venice.read.RequestType;
 import com.linkedin.venice.stats.VeniceOpenTelemetryMetricNamingFormat;
+import com.linkedin.venice.stats.metrics.MetricEntity;
+import com.linkedin.venice.stats.metrics.MetricType;
+import com.linkedin.venice.stats.metrics.MetricUnit;
 import com.linkedin.venice.tehuti.MockTehutiReporter;
 import com.linkedin.venice.utils.DataProviderUtils;
 import com.linkedin.venice.utils.metrics.MetricsRepositoryUtils;
 import io.netty.handler.codec.http.HttpResponseStatus;
 import io.opentelemetry.api.common.Attributes;
 import io.tehuti.metrics.MetricsRepository;
+import java.util.ArrayList;
+import java.util.Collection;
 import org.testng.annotations.Test;
 
 
@@ -31,9 +36,13 @@ public class RouterHttpRequestStatsTest {
     String clusterName = "test-cluster";
     MetricsRepository metricsRepository;
     if (useVeniceMetricRepository) {
+      Collection<MetricEntity> metricEntities = new ArrayList<>();
+      metricEntities
+          .add(new MetricEntity("test_metric", MetricType.HISTOGRAM, MetricUnit.MILLISECOND, "Test description"));
       metricsRepository = MetricsRepositoryUtils.createSingleThreadedVeniceMetricsRepository(
           isOtelEnabled,
-          isOtelEnabled ? PASCAL_CASE : VeniceOpenTelemetryMetricNamingFormat.getDefaultFormat());
+          isOtelEnabled ? PASCAL_CASE : VeniceOpenTelemetryMetricNamingFormat.getDefaultFormat(),
+          metricEntities);
     } else {
       metricsRepository = MetricsRepositoryUtils.createSingleThreadedMetricsRepository();
     }

--- a/services/venice-router/src/test/java/com/linkedin/venice/router/stats/RouterHttpRequestStatsTest.java
+++ b/services/venice-router/src/test/java/com/linkedin/venice/router/stats/RouterHttpRequestStatsTest.java
@@ -1,0 +1,77 @@
+package com.linkedin.venice.router.stats;
+
+import static com.linkedin.venice.router.stats.RouterHttpRequestStats.RouterTehutiMetricNameEnum.HEALTHY_REQUEST;
+import static com.linkedin.venice.stats.VeniceOpenTelemetryMetricNamingFormat.PASCAL_CASE;
+import static com.linkedin.venice.stats.dimensions.VeniceMetricsDimensions.VENICE_CLUSTER_NAME;
+import static com.linkedin.venice.stats.dimensions.VeniceMetricsDimensions.VENICE_REQUEST_METHOD;
+import static com.linkedin.venice.stats.dimensions.VeniceMetricsDimensions.VENICE_STORE_NAME;
+import static org.mockito.Mockito.mock;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertTrue;
+
+import com.linkedin.alpini.router.monitoring.ScatterGatherStats;
+import com.linkedin.venice.read.RequestType;
+import com.linkedin.venice.stats.VeniceOpenTelemetryMetricNamingFormat;
+import com.linkedin.venice.tehuti.MockTehutiReporter;
+import com.linkedin.venice.utils.DataProviderUtils;
+import com.linkedin.venice.utils.metrics.MetricsRepositoryUtils;
+import io.netty.handler.codec.http.HttpResponseStatus;
+import io.opentelemetry.api.common.Attributes;
+import io.tehuti.metrics.MetricsRepository;
+import org.testng.annotations.Test;
+
+
+public class RouterHttpRequestStatsTest {
+  @Test(dataProvider = "Two-True-and-False", dataProviderClass = DataProviderUtils.class)
+  public void routerMetricsTest(boolean useVeniceMetricRepository, boolean isOtelEnabled) {
+    String storeName = "test-store";
+    String clusterName = "test-cluster";
+    MetricsRepository metricsRepository;
+    if (useVeniceMetricRepository) {
+      metricsRepository = MetricsRepositoryUtils.createSingleThreadedVeniceMetricsRepository(
+          isOtelEnabled,
+          isOtelEnabled ? PASCAL_CASE : VeniceOpenTelemetryMetricNamingFormat.getDefaultFormat());
+    } else {
+      metricsRepository = MetricsRepositoryUtils.createSingleThreadedMetricsRepository();
+    }
+    metricsRepository.addReporter(new MockTehutiReporter());
+
+    RouterHttpRequestStats routerHttpRequestStats = new RouterHttpRequestStats(
+        metricsRepository,
+        storeName,
+        clusterName,
+        RequestType.SINGLE_GET,
+        mock(ScatterGatherStats.class),
+        false);
+
+    if (useVeniceMetricRepository && isOtelEnabled) {
+      assertTrue(routerHttpRequestStats.emitOpenTelemetryMetrics(), "Otel should be enabled");
+      assertEquals(routerHttpRequestStats.getOpenTelemetryMetricsFormat(), PASCAL_CASE);
+      Attributes attributes = routerHttpRequestStats.getCommonMetricDimensions();
+      assertNotNull(attributes);
+      attributes.forEach((key, value) -> {
+        if (key.getKey().equals(VENICE_STORE_NAME.getDimensionName(PASCAL_CASE))) {
+          assertEquals(value, storeName);
+        } else if (key.getKey().equals(VENICE_REQUEST_METHOD.getDimensionName(PASCAL_CASE))) {
+          assertEquals(value, RequestType.SINGLE_GET.name().toLowerCase());
+        } else if (key.getKey().equals(VENICE_CLUSTER_NAME.getDimensionName(PASCAL_CASE))) {
+          assertEquals(value, clusterName);
+        }
+      });
+    } else {
+      assertFalse(routerHttpRequestStats.emitOpenTelemetryMetrics(), "Otel should not be enabled");
+      assertEquals(
+          routerHttpRequestStats.getOpenTelemetryMetricsFormat(),
+          VeniceOpenTelemetryMetricNamingFormat.getDefaultFormat());
+      assertNull(routerHttpRequestStats.getCommonMetricDimensions());
+    }
+
+    routerHttpRequestStats.recordHealthyRequest(1.0, HttpResponseStatus.OK);
+    assertEquals(
+        metricsRepository.getMetric("." + storeName + "--" + HEALTHY_REQUEST.getMetricName() + ".Count").value(),
+        1.0);
+  }
+}


### PR DESCRIPTION
## Summary
some minor cleanups and tests including
1. Not initializing `VeniceOpenTelemetryMetricsRepository` when otel is not configured
2. if `setMetricEntities` is not configured in VeniceMetricsConfig and if exponential bucket histogram is enabled (which is enabled by default), builder will fail fast.
3. Disabling OTel exporting to endpoint in routers for integration tests
4. Removing the explicit names passed in `RouterMetricEntity` and use the enum name itself to be less error prone
5. some tests around these changes

## How was this PR tested?
GH CI

## Does this PR introduce any user-facing changes?
- [x] No. You can skip the rest of this section.
- [] Yes. Make sure to explain your proposed changes and call out the behavior change.