### PR TITLE
[server] Block OFFLINE->DROPPED ST to wait for drop partition action

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/helix/LeaderFollowerPartitionStateModel.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/helix/LeaderFollowerPartitionStateModel.java
@@ -210,6 +210,9 @@ public class LeaderFollowerPartitionStateModel extends AbstractPartitionStateMod
       } catch (InterruptedException e) {
         throw new VeniceException("Got interrupted while waiting for drop partition future to complete", e);
       } catch (Exception e) {
+        logger.error(
+            "Exception while waiting for drop partition future during the transition from OFFLINE to DROPPED",
+            e);
         throw new VeniceException("Got exception while waiting for drop partition future to complete", e);
       } finally {
         if (waitForDropPartition) {

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/helix/LeaderFollowerPartitionStateModel.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/helix/LeaderFollowerPartitionStateModel.java
@@ -195,12 +195,27 @@ public class LeaderFollowerPartitionStateModel extends AbstractPartitionStateMod
           // Gracefully drop partition to drain the requests to this partition
           Thread.sleep(TimeUnit.SECONDS.toMillis(getStoreAndServerConfigs().getPartitionGracefulDropDelaySeconds()));
         } catch (InterruptedException e) {
-          throw new VeniceException("Got interrupted during state transition: 'OFFLINE' -> 'DROPPED'", e);
+          throw new VeniceException("Got interrupted while waiting for graceful drop delay of serving version", e);
         } finally {
           this.threadPoolStats.decrementThreadBlockedOnOfflineToDroppedTransitionCount();
         }
       }
-      removePartitionFromStoreGracefully();
+      CompletableFuture<Void> dropPartitionFuture = removePartitionFromStoreGracefully();
+      boolean waitForDropPartition = !dropPartitionFuture.isDone();
+      try {
+        if (waitForDropPartition) {
+          this.threadPoolStats.incrementThreadBlockedOnOfflineToDroppedTransitionCount();
+        }
+        dropPartitionFuture.get(WAIT_DROP_PARTITION_TIME_OUT_MS, TimeUnit.MILLISECONDS);
+      } catch (InterruptedException e) {
+        throw new VeniceException("Got interrupted while waiting for drop partition future to complete", e);
+      } catch (Exception e) {
+        throw new VeniceException("Got exception while waiting for drop partition future to complete", e);
+      } finally {
+        if (waitForDropPartition) {
+          this.threadPoolStats.decrementThreadBlockedOnOfflineToDroppedTransitionCount();
+        }
+      }
     });
   }
 

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/ingestion/DefaultIngestionBackend.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/ingestion/DefaultIngestionBackend.java
@@ -201,7 +201,7 @@ public class DefaultIngestionBackend implements IngestionBackend {
   }
 
   @Override
-  public void dropStoragePartitionGracefully(
+  public CompletableFuture<Void> dropStoragePartitionGracefully(
       VeniceStoreVersionConfig storeConfig,
       int partition,
       int timeoutInSeconds,
@@ -210,7 +210,7 @@ public class DefaultIngestionBackend implements IngestionBackend {
     final int waitIntervalInSecond = 1;
     final int maxRetry = timeoutInSeconds / waitIntervalInSecond;
     getStoreIngestionService().stopConsumptionAndWait(storeConfig, partition, waitIntervalInSecond, maxRetry, true);
-    getStoreIngestionService().dropStoragePartitionGracefully(storeConfig, partition);
+    return getStoreIngestionService().dropStoragePartitionGracefully(storeConfig, partition);
   }
 
   @Override

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/ingestion/IngestionBackend.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/ingestion/IngestionBackend.java
@@ -26,12 +26,13 @@ public interface IngestionBackend extends Closeable {
    * @param storeConfig Store version config
    * @param partition Partition number to be dropped in the store version.
    * @param timeoutInSeconds Number of seconds to wait before timeout.
+   * @return a future for the drop partition action.
    */
-  default void dropStoragePartitionGracefully(
+  default CompletableFuture<Void> dropStoragePartitionGracefully(
       VeniceStoreVersionConfig storeConfig,
       int partition,
       int timeoutInSeconds) {
-    dropStoragePartitionGracefully(storeConfig, partition, timeoutInSeconds, true);
+    return dropStoragePartitionGracefully(storeConfig, partition, timeoutInSeconds, true);
   }
 
   /**
@@ -40,8 +41,9 @@ public interface IngestionBackend extends Closeable {
    * @param partition Partition number to be dropped in the store version.
    * @param timeoutInSeconds Number of seconds to wait before timeout.
    * @param removeEmptyStorageEngine Whether to drop storage engine when dropping the last partition.
+   * @return a future for the drop partition action.
    */
-  void dropStoragePartitionGracefully(
+  CompletableFuture<Void> dropStoragePartitionGracefully(
       VeniceStoreVersionConfig storeConfig,
       int partition,
       int timeoutInSeconds,

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/ingestion/IsolatedIngestionBackend.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/ingestion/IsolatedIngestionBackend.java
@@ -131,7 +131,7 @@ public class IsolatedIngestionBackend extends DefaultIngestionBackend implements
   }
 
   @Override
-  public void dropStoragePartitionGracefully(
+  public CompletableFuture<Void> dropStoragePartitionGracefully(
       VeniceStoreVersionConfig storeConfig,
       int partition,
       int timeoutInSeconds,
@@ -156,6 +156,7 @@ public class IsolatedIngestionBackend extends DefaultIngestionBackend implements
       getMainIngestionMonitorService().cleanupTopicState(topicName);
       getMainIngestionRequestClient().removeStorageEngine(topicName);
     }
+    return CompletableFuture.completedFuture(null);
   }
 
   @Override

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
@@ -660,7 +660,7 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
    * Drops a storage partition gracefully.
    * This is always a Helix triggered action.
    */
-  public void dropStoragePartitionGracefully(PubSubTopicPartition topicPartition) {
+  public CompletableFuture<Void> dropStoragePartitionGracefully(PubSubTopicPartition topicPartition) {
     int partitionId = topicPartition.getPartitionNumber();
     synchronized (this) {
       if (isRunning()) {
@@ -670,7 +670,7 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
             partitionId);
         ConsumerAction consumerAction = new ConsumerAction(DROP_PARTITION, topicPartition, nextSeqNum(), true);
         consumerActionsQueue.add(consumerAction);
-        return;
+        return consumerAction.getFuture();
       }
     }
 
@@ -679,6 +679,7 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
         topicPartition.getTopicName(),
         partitionId);
     dropPartitionSynchronously(topicPartition);
+    return CompletableFuture.completedFuture(null);
   }
 
   /**

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/helix/AbstractVenicePartitionStateModelTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/helix/AbstractVenicePartitionStateModelTest.java
@@ -12,6 +12,7 @@ import com.linkedin.venice.meta.ReadOnlyStoreRepository;
 import com.linkedin.venice.meta.Store;
 import com.linkedin.venice.meta.Version;
 import com.linkedin.venice.utils.Utils;
+import java.util.concurrent.CompletableFuture;
 import org.apache.helix.HelixManager;
 import org.apache.helix.NotificationContext;
 import org.apache.helix.customizedstate.CustomizedStateProvider;
@@ -62,6 +63,8 @@ public abstract class AbstractVenicePartitionStateModelTest<MODEL_TYPE extends A
     mockStoreIngestionService = Mockito.mock(KafkaStoreIngestionService.class);
     mockIngestionBackend = Mockito.mock(IngestionBackend.class);
     Mockito.when(mockIngestionBackend.getStoreIngestionService()).thenReturn(mockStoreIngestionService);
+    Mockito.when(mockIngestionBackend.dropStoragePartitionGracefully(Mockito.any(), Mockito.anyInt(), Mockito.anyInt()))
+        .thenReturn(CompletableFuture.completedFuture(null));
     mockStoreConfig = Mockito.mock(VeniceStoreVersionConfig.class);
     Mockito.when(mockStoreConfig.getPartitionGracefulDropDelaySeconds()).thenReturn(1); // 1 second.
     Mockito.when(mockStoreConfig.getStoreVersionName()).thenReturn(resourceName);

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/helix/VeniceLeaderFollowerStateModelTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/helix/VeniceLeaderFollowerStateModelTest.java
@@ -6,6 +6,7 @@ import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -144,11 +145,12 @@ public class VeniceLeaderFollowerStateModelTest extends
     verify(mockParticipantStateTransitionStats, times(1)).incrementThreadBlockedOnOfflineToDroppedTransitionCount();
     verify(mockParticipantStateTransitionStats, times(1)).decrementThreadBlockedOnOfflineToDroppedTransitionCount();
 
+    reset(mockParticipantStateTransitionStats);
     // if the resource is the current serving version, state transition thread will be blocked. And it will be blocked
     // again for drop partition action if it's done asynchronously via SIT
     when(mockStore.getCurrentVersion()).thenReturn(1);
     testStateModel.onBecomeDroppedFromOffline(mockMessage, mockContext);
-    verify(mockParticipantStateTransitionStats, times(3)).incrementThreadBlockedOnOfflineToDroppedTransitionCount();
-    verify(mockParticipantStateTransitionStats, times(3)).decrementThreadBlockedOnOfflineToDroppedTransitionCount();
+    verify(mockParticipantStateTransitionStats, times(2)).incrementThreadBlockedOnOfflineToDroppedTransitionCount();
+    verify(mockParticipantStateTransitionStats, times(2)).decrementThreadBlockedOnOfflineToDroppedTransitionCount();
   }
 }

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/helix/VeniceLeaderFollowerStateModelTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/helix/VeniceLeaderFollowerStateModelTest.java
@@ -1,6 +1,7 @@
 package com.linkedin.davinci.helix;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
@@ -128,5 +129,26 @@ public class VeniceLeaderFollowerStateModelTest extends
         .thenReturn(Pair.create(mockStore, null));
     testStateModel.onBecomeOfflineFromStandby(mockMessage, mockContext);
     verify(spyHeartbeatMonitoringService).removeLagMonitor(any(), eq(testPartition));
+  }
+
+  @Test
+  public void testTransitionToDropIsBlockedOnDropPartitionAction() {
+    // if the resource is not the current serving version, state transition thread will not be blocked. However, we
+    // still block it once to wait for drop partition action if it's done asynchronously via SIT
+    CompletableFuture mockDropPartitionFuture = mock(CompletableFuture.class);
+    when(mockDropPartitionFuture.isDone()).thenReturn(false);
+    when(mockIngestionBackend.dropStoragePartitionGracefully(any(), anyInt(), anyInt()))
+        .thenReturn(mockDropPartitionFuture);
+    when(mockStore.getCurrentVersion()).thenReturn(2);
+    testStateModel.onBecomeDroppedFromOffline(mockMessage, mockContext);
+    verify(mockParticipantStateTransitionStats, times(1)).incrementThreadBlockedOnOfflineToDroppedTransitionCount();
+    verify(mockParticipantStateTransitionStats, times(1)).decrementThreadBlockedOnOfflineToDroppedTransitionCount();
+
+    // if the resource is the current serving version, state transition thread will be blocked. And it will be blocked
+    // again for drop partition action if it's done asynchronously via SIT
+    when(mockStore.getCurrentVersion()).thenReturn(1);
+    testStateModel.onBecomeDroppedFromOffline(mockMessage, mockContext);
+    verify(mockParticipantStateTransitionStats, times(3)).incrementThreadBlockedOnOfflineToDroppedTransitionCount();
+    verify(mockParticipantStateTransitionStats, times(3)).decrementThreadBlockedOnOfflineToDroppedTransitionCount();
   }
 }


### PR DESCRIPTION
## [server] Block OFFLINE->DROPPED ST to wait for drop partition action

Drop partition is performed asynchronously through consumer action in SIT. This behavior allowed a race to occur when we have OFFLINE->DROPPED followed by OFFLINE->STANDBY for the same partition on the same host. This is because we initialize the partition synchronously in OFFLINE->STANDBY and there is a chance the previously queued drop partition consumer action is executed after OFFLINE->STANDBY and that will cause ingestion to fail.

The fix is to block and wait on the drop partition consumer action future in the OFFLINE->DROPPED state transition. This way when the host is picked again for OFFLINE->STANDBY for the same partition, it can do so with a clean state without any lingering async actions.

## How was this PR tested?
Existing and new unit tests

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.