### PR TITLE
Cancel previous workflow run on new push

### DIFF
--- a/.github/rawWorkflows/gh-ci-parameterized-flow.txt
+++ b/.github/rawWorkflows/gh-ci-parameterized-flow.txt
@@ -11,6 +11,9 @@
     needs: $Dependency
     if: $Conditional
     timeout-minutes: $TimeOut
+    concurrency:
+     group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+     cancel-in-progress: true
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/rawWorkflows/gh-ci-parameterized-flow.txt
+++ b/.github/rawWorkflows/gh-ci-parameterized-flow.txt
@@ -1,4 +1,5 @@
   $FlowName:
+    name: $FlowName
     strategy:
       fail-fast: false
       matrix:
@@ -12,7 +13,7 @@
     if: $Conditional
     timeout-minutes: $TimeOut
     concurrency:
-     group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-${{ github.job }}-jdk${{ matrix.jdk }}
+     group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-jdk${{ matrix.jdk }}-$FlowName
      cancel-in-progress: true
     steps:
       - uses: actions/checkout@v4

--- a/.github/rawWorkflows/gh-ci-parameterized-flow.txt
+++ b/.github/rawWorkflows/gh-ci-parameterized-flow.txt
@@ -12,7 +12,7 @@
     if: $Conditional
     timeout-minutes: $TimeOut
     concurrency:
-     group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+     group: ${{ github.workflow }}-${{ github.event.pull_request.number }}-${{ github.job }}-jdk${{ matrix.jdk }}
      cancel-in-progress: true
     steps:
       - uses: actions/checkout@v4

--- a/.github/rawWorkflows/gh-ci-parameterized-flow.txt
+++ b/.github/rawWorkflows/gh-ci-parameterized-flow.txt
@@ -12,7 +12,7 @@
     if: $Conditional
     timeout-minutes: $TimeOut
     concurrency:
-     group: ${{ github.workflow }}-${{ github.event.pull_request.number }}-${{ github.job }}-jdk${{ matrix.jdk }}
+     group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-${{ github.job }}-jdk${{ matrix.jdk }}
      cancel-in-progress: true
     steps:
       - uses: actions/checkout@v4

--- a/.github/rawWorkflows/gh-ci-parameterized-flow.txt
+++ b/.github/rawWorkflows/gh-ci-parameterized-flow.txt
@@ -14,7 +14,7 @@
     timeout-minutes: $TimeOut
     concurrency:
      group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-jdk${{ matrix.jdk }}-$FlowName
-     cancel-in-progress: true
+     cancel-in-progress: ${{ github.event_name == 'pull_request' }}
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/VeniceCI-E2ETests.yml
+++ b/.github/workflows/VeniceCI-E2ETests.yml
@@ -25,7 +25,7 @@ jobs:
      checks: write
     timeout-minutes: 120
     concurrency:
-     group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+     group: ${{ github.workflow }}-${{ github.event.pull_request.number }}-${{ github.job }}-jdk${{ matrix.jdk }}
      cancel-in-progress: true
     steps:
       - uses: actions/checkout@v4
@@ -91,7 +91,7 @@ jobs:
      checks: write
     timeout-minutes: 120
     concurrency:
-     group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+     group: ${{ github.workflow }}-${{ github.event.pull_request.number }}-${{ github.job }}-jdk${{ matrix.jdk }}
      cancel-in-progress: true
     steps:
       - uses: actions/checkout@v4
@@ -157,7 +157,7 @@ jobs:
      checks: write
     timeout-minutes: 120
     concurrency:
-     group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+     group: ${{ github.workflow }}-${{ github.event.pull_request.number }}-${{ github.job }}-jdk${{ matrix.jdk }}
      cancel-in-progress: true
     steps:
       - uses: actions/checkout@v4
@@ -223,7 +223,7 @@ jobs:
      checks: write
     timeout-minutes: 120
     concurrency:
-     group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+     group: ${{ github.workflow }}-${{ github.event.pull_request.number }}-${{ github.job }}-jdk${{ matrix.jdk }}
      cancel-in-progress: true
     steps:
       - uses: actions/checkout@v4
@@ -289,7 +289,7 @@ jobs:
      checks: write
     timeout-minutes: 120
     concurrency:
-     group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+     group: ${{ github.workflow }}-${{ github.event.pull_request.number }}-${{ github.job }}-jdk${{ matrix.jdk }}
      cancel-in-progress: true
     steps:
       - uses: actions/checkout@v4
@@ -355,7 +355,7 @@ jobs:
      checks: write
     timeout-minutes: 120
     concurrency:
-     group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+     group: ${{ github.workflow }}-${{ github.event.pull_request.number }}-${{ github.job }}-jdk${{ matrix.jdk }}
      cancel-in-progress: true
     steps:
       - uses: actions/checkout@v4
@@ -421,7 +421,7 @@ jobs:
      checks: write
     timeout-minutes: 120
     concurrency:
-     group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+     group: ${{ github.workflow }}-${{ github.event.pull_request.number }}-${{ github.job }}-jdk${{ matrix.jdk }}
      cancel-in-progress: true
     steps:
       - uses: actions/checkout@v4
@@ -487,7 +487,7 @@ jobs:
      checks: write
     timeout-minutes: 120
     concurrency:
-     group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+     group: ${{ github.workflow }}-${{ github.event.pull_request.number }}-${{ github.job }}-jdk${{ matrix.jdk }}
      cancel-in-progress: true
     steps:
       - uses: actions/checkout@v4
@@ -553,7 +553,7 @@ jobs:
      checks: write
     timeout-minutes: 120
     concurrency:
-     group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+     group: ${{ github.workflow }}-${{ github.event.pull_request.number }}-${{ github.job }}-jdk${{ matrix.jdk }}
      cancel-in-progress: true
     steps:
       - uses: actions/checkout@v4
@@ -619,7 +619,7 @@ jobs:
      checks: write
     timeout-minutes: 120
     concurrency:
-     group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+     group: ${{ github.workflow }}-${{ github.event.pull_request.number }}-${{ github.job }}-jdk${{ matrix.jdk }}
      cancel-in-progress: true
     steps:
       - uses: actions/checkout@v4
@@ -685,7 +685,7 @@ jobs:
      checks: write
     timeout-minutes: 120
     concurrency:
-     group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+     group: ${{ github.workflow }}-${{ github.event.pull_request.number }}-${{ github.job }}-jdk${{ matrix.jdk }}
      cancel-in-progress: true
     steps:
       - uses: actions/checkout@v4
@@ -751,7 +751,7 @@ jobs:
      checks: write
     timeout-minutes: 120
     concurrency:
-     group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+     group: ${{ github.workflow }}-${{ github.event.pull_request.number }}-${{ github.job }}-jdk${{ matrix.jdk }}
      cancel-in-progress: true
     steps:
       - uses: actions/checkout@v4
@@ -817,7 +817,7 @@ jobs:
      checks: write
     timeout-minutes: 120
     concurrency:
-     group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+     group: ${{ github.workflow }}-${{ github.event.pull_request.number }}-${{ github.job }}-jdk${{ matrix.jdk }}
      cancel-in-progress: true
     steps:
       - uses: actions/checkout@v4
@@ -883,7 +883,7 @@ jobs:
      checks: write
     timeout-minutes: 120
     concurrency:
-     group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+     group: ${{ github.workflow }}-${{ github.event.pull_request.number }}-${{ github.job }}-jdk${{ matrix.jdk }}
      cancel-in-progress: true
     steps:
       - uses: actions/checkout@v4
@@ -949,7 +949,7 @@ jobs:
      checks: write
     timeout-minutes: 120
     concurrency:
-     group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+     group: ${{ github.workflow }}-${{ github.event.pull_request.number }}-${{ github.job }}-jdk${{ matrix.jdk }}
      cancel-in-progress: true
     steps:
       - uses: actions/checkout@v4
@@ -1015,7 +1015,7 @@ jobs:
      checks: write
     timeout-minutes: 120
     concurrency:
-     group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+     group: ${{ github.workflow }}-${{ github.event.pull_request.number }}-${{ github.job }}-jdk${{ matrix.jdk }}
      cancel-in-progress: true
     steps:
       - uses: actions/checkout@v4
@@ -1081,7 +1081,7 @@ jobs:
      checks: write
     timeout-minutes: 120
     concurrency:
-     group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+     group: ${{ github.workflow }}-${{ github.event.pull_request.number }}-${{ github.job }}-jdk${{ matrix.jdk }}
      cancel-in-progress: true
     steps:
       - uses: actions/checkout@v4
@@ -1147,7 +1147,7 @@ jobs:
      checks: write
     timeout-minutes: 120
     concurrency:
-     group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+     group: ${{ github.workflow }}-${{ github.event.pull_request.number }}-${{ github.job }}-jdk${{ matrix.jdk }}
      cancel-in-progress: true
     steps:
       - uses: actions/checkout@v4
@@ -1213,7 +1213,7 @@ jobs:
      checks: write
     timeout-minutes: 120
     concurrency:
-     group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+     group: ${{ github.workflow }}-${{ github.event.pull_request.number }}-${{ github.job }}-jdk${{ matrix.jdk }}
      cancel-in-progress: true
     steps:
       - uses: actions/checkout@v4
@@ -1279,7 +1279,7 @@ jobs:
      checks: write
     timeout-minutes: 120
     concurrency:
-     group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+     group: ${{ github.workflow }}-${{ github.event.pull_request.number }}-${{ github.job }}-jdk${{ matrix.jdk }}
      cancel-in-progress: true
     steps:
       - uses: actions/checkout@v4
@@ -1345,7 +1345,7 @@ jobs:
      checks: write
     timeout-minutes: 120
     concurrency:
-     group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+     group: ${{ github.workflow }}-${{ github.event.pull_request.number }}-${{ github.job }}-jdk${{ matrix.jdk }}
      cancel-in-progress: true
     steps:
       - uses: actions/checkout@v4
@@ -1411,7 +1411,7 @@ jobs:
      checks: write
     timeout-minutes: 120
     concurrency:
-     group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+     group: ${{ github.workflow }}-${{ github.event.pull_request.number }}-${{ github.job }}-jdk${{ matrix.jdk }}
      cancel-in-progress: true
     steps:
       - uses: actions/checkout@v4
@@ -1477,7 +1477,7 @@ jobs:
      checks: write
     timeout-minutes: 120
     concurrency:
-     group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+     group: ${{ github.workflow }}-${{ github.event.pull_request.number }}-${{ github.job }}-jdk${{ matrix.jdk }}
      cancel-in-progress: true
     steps:
       - uses: actions/checkout@v4
@@ -1543,7 +1543,7 @@ jobs:
      checks: write
     timeout-minutes: 120
     concurrency:
-     group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+     group: ${{ github.workflow }}-${{ github.event.pull_request.number }}-${{ github.job }}-jdk${{ matrix.jdk }}
      cancel-in-progress: true
     steps:
       - uses: actions/checkout@v4
@@ -1609,7 +1609,7 @@ jobs:
      checks: write
     timeout-minutes: 120
     concurrency:
-     group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+     group: ${{ github.workflow }}-${{ github.event.pull_request.number }}-${{ github.job }}-jdk${{ matrix.jdk }}
      cancel-in-progress: true
     steps:
       - uses: actions/checkout@v4
@@ -1675,7 +1675,7 @@ jobs:
      checks: write
     timeout-minutes: 120
     concurrency:
-     group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+     group: ${{ github.workflow }}-${{ github.event.pull_request.number }}-${{ github.job }}-jdk${{ matrix.jdk }}
      cancel-in-progress: true
     steps:
       - uses: actions/checkout@v4
@@ -1741,7 +1741,7 @@ jobs:
      checks: write
     timeout-minutes: 120
     concurrency:
-     group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+     group: ${{ github.workflow }}-${{ github.event.pull_request.number }}-${{ github.job }}-jdk${{ matrix.jdk }}
      cancel-in-progress: true
     steps:
       - uses: actions/checkout@v4
@@ -1807,7 +1807,7 @@ jobs:
      checks: write
     timeout-minutes: 120
     concurrency:
-     group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+     group: ${{ github.workflow }}-${{ github.event.pull_request.number }}-${{ github.job }}-jdk${{ matrix.jdk }}
      cancel-in-progress: true
     steps:
       - uses: actions/checkout@v4
@@ -1873,7 +1873,7 @@ jobs:
      checks: write
     timeout-minutes: 120
     concurrency:
-     group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+     group: ${{ github.workflow }}-${{ github.event.pull_request.number }}-${{ github.job }}-jdk${{ matrix.jdk }}
      cancel-in-progress: true
     steps:
       - uses: actions/checkout@v4
@@ -1939,7 +1939,7 @@ jobs:
      checks: write
     timeout-minutes: 120
     concurrency:
-     group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+     group: ${{ github.workflow }}-${{ github.event.pull_request.number }}-${{ github.job }}-jdk${{ matrix.jdk }}
      cancel-in-progress: true
     steps:
       - uses: actions/checkout@v4
@@ -2005,7 +2005,7 @@ jobs:
      checks: write
     timeout-minutes: 120
     concurrency:
-     group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+     group: ${{ github.workflow }}-${{ github.event.pull_request.number }}-${{ github.job }}-jdk${{ matrix.jdk }}
      cancel-in-progress: true
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/VeniceCI-E2ETests.yml
+++ b/.github/workflows/VeniceCI-E2ETests.yml
@@ -25,7 +25,7 @@ jobs:
      checks: write
     timeout-minutes: 120
     concurrency:
-     group: ${{ github.workflow }}-${{ github.event.pull_request.number }}-${{ github.job }}-jdk${{ matrix.jdk }}
+     group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-${{ github.job }}-jdk${{ matrix.jdk }}
      cancel-in-progress: true
     steps:
       - uses: actions/checkout@v4
@@ -91,7 +91,7 @@ jobs:
      checks: write
     timeout-minutes: 120
     concurrency:
-     group: ${{ github.workflow }}-${{ github.event.pull_request.number }}-${{ github.job }}-jdk${{ matrix.jdk }}
+     group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-${{ github.job }}-jdk${{ matrix.jdk }}
      cancel-in-progress: true
     steps:
       - uses: actions/checkout@v4
@@ -157,7 +157,7 @@ jobs:
      checks: write
     timeout-minutes: 120
     concurrency:
-     group: ${{ github.workflow }}-${{ github.event.pull_request.number }}-${{ github.job }}-jdk${{ matrix.jdk }}
+     group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-${{ github.job }}-jdk${{ matrix.jdk }}
      cancel-in-progress: true
     steps:
       - uses: actions/checkout@v4
@@ -223,7 +223,7 @@ jobs:
      checks: write
     timeout-minutes: 120
     concurrency:
-     group: ${{ github.workflow }}-${{ github.event.pull_request.number }}-${{ github.job }}-jdk${{ matrix.jdk }}
+     group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-${{ github.job }}-jdk${{ matrix.jdk }}
      cancel-in-progress: true
     steps:
       - uses: actions/checkout@v4
@@ -289,7 +289,7 @@ jobs:
      checks: write
     timeout-minutes: 120
     concurrency:
-     group: ${{ github.workflow }}-${{ github.event.pull_request.number }}-${{ github.job }}-jdk${{ matrix.jdk }}
+     group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-${{ github.job }}-jdk${{ matrix.jdk }}
      cancel-in-progress: true
     steps:
       - uses: actions/checkout@v4
@@ -355,7 +355,7 @@ jobs:
      checks: write
     timeout-minutes: 120
     concurrency:
-     group: ${{ github.workflow }}-${{ github.event.pull_request.number }}-${{ github.job }}-jdk${{ matrix.jdk }}
+     group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-${{ github.job }}-jdk${{ matrix.jdk }}
      cancel-in-progress: true
     steps:
       - uses: actions/checkout@v4
@@ -421,7 +421,7 @@ jobs:
      checks: write
     timeout-minutes: 120
     concurrency:
-     group: ${{ github.workflow }}-${{ github.event.pull_request.number }}-${{ github.job }}-jdk${{ matrix.jdk }}
+     group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-${{ github.job }}-jdk${{ matrix.jdk }}
      cancel-in-progress: true
     steps:
       - uses: actions/checkout@v4
@@ -487,7 +487,7 @@ jobs:
      checks: write
     timeout-minutes: 120
     concurrency:
-     group: ${{ github.workflow }}-${{ github.event.pull_request.number }}-${{ github.job }}-jdk${{ matrix.jdk }}
+     group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-${{ github.job }}-jdk${{ matrix.jdk }}
      cancel-in-progress: true
     steps:
       - uses: actions/checkout@v4
@@ -553,7 +553,7 @@ jobs:
      checks: write
     timeout-minutes: 120
     concurrency:
-     group: ${{ github.workflow }}-${{ github.event.pull_request.number }}-${{ github.job }}-jdk${{ matrix.jdk }}
+     group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-${{ github.job }}-jdk${{ matrix.jdk }}
      cancel-in-progress: true
     steps:
       - uses: actions/checkout@v4
@@ -619,7 +619,7 @@ jobs:
      checks: write
     timeout-minutes: 120
     concurrency:
-     group: ${{ github.workflow }}-${{ github.event.pull_request.number }}-${{ github.job }}-jdk${{ matrix.jdk }}
+     group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-${{ github.job }}-jdk${{ matrix.jdk }}
      cancel-in-progress: true
     steps:
       - uses: actions/checkout@v4
@@ -685,7 +685,7 @@ jobs:
      checks: write
     timeout-minutes: 120
     concurrency:
-     group: ${{ github.workflow }}-${{ github.event.pull_request.number }}-${{ github.job }}-jdk${{ matrix.jdk }}
+     group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-${{ github.job }}-jdk${{ matrix.jdk }}
      cancel-in-progress: true
     steps:
       - uses: actions/checkout@v4
@@ -751,7 +751,7 @@ jobs:
      checks: write
     timeout-minutes: 120
     concurrency:
-     group: ${{ github.workflow }}-${{ github.event.pull_request.number }}-${{ github.job }}-jdk${{ matrix.jdk }}
+     group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-${{ github.job }}-jdk${{ matrix.jdk }}
      cancel-in-progress: true
     steps:
       - uses: actions/checkout@v4
@@ -817,7 +817,7 @@ jobs:
      checks: write
     timeout-minutes: 120
     concurrency:
-     group: ${{ github.workflow }}-${{ github.event.pull_request.number }}-${{ github.job }}-jdk${{ matrix.jdk }}
+     group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-${{ github.job }}-jdk${{ matrix.jdk }}
      cancel-in-progress: true
     steps:
       - uses: actions/checkout@v4
@@ -883,7 +883,7 @@ jobs:
      checks: write
     timeout-minutes: 120
     concurrency:
-     group: ${{ github.workflow }}-${{ github.event.pull_request.number }}-${{ github.job }}-jdk${{ matrix.jdk }}
+     group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-${{ github.job }}-jdk${{ matrix.jdk }}
      cancel-in-progress: true
     steps:
       - uses: actions/checkout@v4
@@ -949,7 +949,7 @@ jobs:
      checks: write
     timeout-minutes: 120
     concurrency:
-     group: ${{ github.workflow }}-${{ github.event.pull_request.number }}-${{ github.job }}-jdk${{ matrix.jdk }}
+     group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-${{ github.job }}-jdk${{ matrix.jdk }}
      cancel-in-progress: true
     steps:
       - uses: actions/checkout@v4
@@ -1015,7 +1015,7 @@ jobs:
      checks: write
     timeout-minutes: 120
     concurrency:
-     group: ${{ github.workflow }}-${{ github.event.pull_request.number }}-${{ github.job }}-jdk${{ matrix.jdk }}
+     group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-${{ github.job }}-jdk${{ matrix.jdk }}
      cancel-in-progress: true
     steps:
       - uses: actions/checkout@v4
@@ -1081,7 +1081,7 @@ jobs:
      checks: write
     timeout-minutes: 120
     concurrency:
-     group: ${{ github.workflow }}-${{ github.event.pull_request.number }}-${{ github.job }}-jdk${{ matrix.jdk }}
+     group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-${{ github.job }}-jdk${{ matrix.jdk }}
      cancel-in-progress: true
     steps:
       - uses: actions/checkout@v4
@@ -1147,7 +1147,7 @@ jobs:
      checks: write
     timeout-minutes: 120
     concurrency:
-     group: ${{ github.workflow }}-${{ github.event.pull_request.number }}-${{ github.job }}-jdk${{ matrix.jdk }}
+     group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-${{ github.job }}-jdk${{ matrix.jdk }}
      cancel-in-progress: true
     steps:
       - uses: actions/checkout@v4
@@ -1213,7 +1213,7 @@ jobs:
      checks: write
     timeout-minutes: 120
     concurrency:
-     group: ${{ github.workflow }}-${{ github.event.pull_request.number }}-${{ github.job }}-jdk${{ matrix.jdk }}
+     group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-${{ github.job }}-jdk${{ matrix.jdk }}
      cancel-in-progress: true
     steps:
       - uses: actions/checkout@v4
@@ -1279,7 +1279,7 @@ jobs:
      checks: write
     timeout-minutes: 120
     concurrency:
-     group: ${{ github.workflow }}-${{ github.event.pull_request.number }}-${{ github.job }}-jdk${{ matrix.jdk }}
+     group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-${{ github.job }}-jdk${{ matrix.jdk }}
      cancel-in-progress: true
     steps:
       - uses: actions/checkout@v4
@@ -1345,7 +1345,7 @@ jobs:
      checks: write
     timeout-minutes: 120
     concurrency:
-     group: ${{ github.workflow }}-${{ github.event.pull_request.number }}-${{ github.job }}-jdk${{ matrix.jdk }}
+     group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-${{ github.job }}-jdk${{ matrix.jdk }}
      cancel-in-progress: true
     steps:
       - uses: actions/checkout@v4
@@ -1411,7 +1411,7 @@ jobs:
      checks: write
     timeout-minutes: 120
     concurrency:
-     group: ${{ github.workflow }}-${{ github.event.pull_request.number }}-${{ github.job }}-jdk${{ matrix.jdk }}
+     group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-${{ github.job }}-jdk${{ matrix.jdk }}
      cancel-in-progress: true
     steps:
       - uses: actions/checkout@v4
@@ -1477,7 +1477,7 @@ jobs:
      checks: write
     timeout-minutes: 120
     concurrency:
-     group: ${{ github.workflow }}-${{ github.event.pull_request.number }}-${{ github.job }}-jdk${{ matrix.jdk }}
+     group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-${{ github.job }}-jdk${{ matrix.jdk }}
      cancel-in-progress: true
     steps:
       - uses: actions/checkout@v4
@@ -1543,7 +1543,7 @@ jobs:
      checks: write
     timeout-minutes: 120
     concurrency:
-     group: ${{ github.workflow }}-${{ github.event.pull_request.number }}-${{ github.job }}-jdk${{ matrix.jdk }}
+     group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-${{ github.job }}-jdk${{ matrix.jdk }}
      cancel-in-progress: true
     steps:
       - uses: actions/checkout@v4
@@ -1609,7 +1609,7 @@ jobs:
      checks: write
     timeout-minutes: 120
     concurrency:
-     group: ${{ github.workflow }}-${{ github.event.pull_request.number }}-${{ github.job }}-jdk${{ matrix.jdk }}
+     group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-${{ github.job }}-jdk${{ matrix.jdk }}
      cancel-in-progress: true
     steps:
       - uses: actions/checkout@v4
@@ -1675,7 +1675,7 @@ jobs:
      checks: write
     timeout-minutes: 120
     concurrency:
-     group: ${{ github.workflow }}-${{ github.event.pull_request.number }}-${{ github.job }}-jdk${{ matrix.jdk }}
+     group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-${{ github.job }}-jdk${{ matrix.jdk }}
      cancel-in-progress: true
     steps:
       - uses: actions/checkout@v4
@@ -1741,7 +1741,7 @@ jobs:
      checks: write
     timeout-minutes: 120
     concurrency:
-     group: ${{ github.workflow }}-${{ github.event.pull_request.number }}-${{ github.job }}-jdk${{ matrix.jdk }}
+     group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-${{ github.job }}-jdk${{ matrix.jdk }}
      cancel-in-progress: true
     steps:
       - uses: actions/checkout@v4
@@ -1807,7 +1807,7 @@ jobs:
      checks: write
     timeout-minutes: 120
     concurrency:
-     group: ${{ github.workflow }}-${{ github.event.pull_request.number }}-${{ github.job }}-jdk${{ matrix.jdk }}
+     group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-${{ github.job }}-jdk${{ matrix.jdk }}
      cancel-in-progress: true
     steps:
       - uses: actions/checkout@v4
@@ -1873,7 +1873,7 @@ jobs:
      checks: write
     timeout-minutes: 120
     concurrency:
-     group: ${{ github.workflow }}-${{ github.event.pull_request.number }}-${{ github.job }}-jdk${{ matrix.jdk }}
+     group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-${{ github.job }}-jdk${{ matrix.jdk }}
      cancel-in-progress: true
     steps:
       - uses: actions/checkout@v4
@@ -1939,7 +1939,7 @@ jobs:
      checks: write
     timeout-minutes: 120
     concurrency:
-     group: ${{ github.workflow }}-${{ github.event.pull_request.number }}-${{ github.job }}-jdk${{ matrix.jdk }}
+     group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-${{ github.job }}-jdk${{ matrix.jdk }}
      cancel-in-progress: true
     steps:
       - uses: actions/checkout@v4
@@ -2005,7 +2005,7 @@ jobs:
      checks: write
     timeout-minutes: 120
     concurrency:
-     group: ${{ github.workflow }}-${{ github.event.pull_request.number }}-${{ github.job }}-jdk${{ matrix.jdk }}
+     group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-${{ github.job }}-jdk${{ matrix.jdk }}
      cancel-in-progress: true
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/VeniceCI-E2ETests.yml
+++ b/.github/workflows/VeniceCI-E2ETests.yml
@@ -27,7 +27,7 @@ jobs:
     timeout-minutes: 120
     concurrency:
      group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-jdk${{ matrix.jdk }}-IntegrationTests_1000
-     cancel-in-progress: true
+     cancel-in-progress: ${{ github.event_name == 'pull_request' }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -94,7 +94,7 @@ jobs:
     timeout-minutes: 120
     concurrency:
      group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-jdk${{ matrix.jdk }}-IntegrationTests_1010
-     cancel-in-progress: true
+     cancel-in-progress: ${{ github.event_name == 'pull_request' }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -161,7 +161,7 @@ jobs:
     timeout-minutes: 120
     concurrency:
      group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-jdk${{ matrix.jdk }}-IntegrationTests_1020
-     cancel-in-progress: true
+     cancel-in-progress: ${{ github.event_name == 'pull_request' }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -228,7 +228,7 @@ jobs:
     timeout-minutes: 120
     concurrency:
      group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-jdk${{ matrix.jdk }}-IntegrationTests_1030
-     cancel-in-progress: true
+     cancel-in-progress: ${{ github.event_name == 'pull_request' }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -295,7 +295,7 @@ jobs:
     timeout-minutes: 120
     concurrency:
      group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-jdk${{ matrix.jdk }}-IntegrationTests_1040
-     cancel-in-progress: true
+     cancel-in-progress: ${{ github.event_name == 'pull_request' }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -362,7 +362,7 @@ jobs:
     timeout-minutes: 120
     concurrency:
      group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-jdk${{ matrix.jdk }}-IntegrationTests_1050
-     cancel-in-progress: true
+     cancel-in-progress: ${{ github.event_name == 'pull_request' }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -429,7 +429,7 @@ jobs:
     timeout-minutes: 120
     concurrency:
      group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-jdk${{ matrix.jdk }}-IntegrationTests_1060
-     cancel-in-progress: true
+     cancel-in-progress: ${{ github.event_name == 'pull_request' }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -496,7 +496,7 @@ jobs:
     timeout-minutes: 120
     concurrency:
      group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-jdk${{ matrix.jdk }}-IntegrationTests_1070
-     cancel-in-progress: true
+     cancel-in-progress: ${{ github.event_name == 'pull_request' }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -563,7 +563,7 @@ jobs:
     timeout-minutes: 120
     concurrency:
      group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-jdk${{ matrix.jdk }}-IntegrationTests_1080
-     cancel-in-progress: true
+     cancel-in-progress: ${{ github.event_name == 'pull_request' }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -630,7 +630,7 @@ jobs:
     timeout-minutes: 120
     concurrency:
      group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-jdk${{ matrix.jdk }}-IntegrationTests_1090
-     cancel-in-progress: true
+     cancel-in-progress: ${{ github.event_name == 'pull_request' }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -697,7 +697,7 @@ jobs:
     timeout-minutes: 120
     concurrency:
      group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-jdk${{ matrix.jdk }}-IntegrationTests_1100
-     cancel-in-progress: true
+     cancel-in-progress: ${{ github.event_name == 'pull_request' }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -764,7 +764,7 @@ jobs:
     timeout-minutes: 120
     concurrency:
      group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-jdk${{ matrix.jdk }}-IntegrationTests_1110
-     cancel-in-progress: true
+     cancel-in-progress: ${{ github.event_name == 'pull_request' }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -831,7 +831,7 @@ jobs:
     timeout-minutes: 120
     concurrency:
      group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-jdk${{ matrix.jdk }}-IntegrationTests_1120
-     cancel-in-progress: true
+     cancel-in-progress: ${{ github.event_name == 'pull_request' }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -898,7 +898,7 @@ jobs:
     timeout-minutes: 120
     concurrency:
      group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-jdk${{ matrix.jdk }}-IntegrationTests_1130
-     cancel-in-progress: true
+     cancel-in-progress: ${{ github.event_name == 'pull_request' }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -965,7 +965,7 @@ jobs:
     timeout-minutes: 120
     concurrency:
      group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-jdk${{ matrix.jdk }}-IntegrationTests_1200
-     cancel-in-progress: true
+     cancel-in-progress: ${{ github.event_name == 'pull_request' }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -1032,7 +1032,7 @@ jobs:
     timeout-minutes: 120
     concurrency:
      group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-jdk${{ matrix.jdk }}-IntegrationTests_1210
-     cancel-in-progress: true
+     cancel-in-progress: ${{ github.event_name == 'pull_request' }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -1099,7 +1099,7 @@ jobs:
     timeout-minutes: 120
     concurrency:
      group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-jdk${{ matrix.jdk }}-IntegrationTests_1220
-     cancel-in-progress: true
+     cancel-in-progress: ${{ github.event_name == 'pull_request' }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -1166,7 +1166,7 @@ jobs:
     timeout-minutes: 120
     concurrency:
      group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-jdk${{ matrix.jdk }}-IntegrationTests_1230
-     cancel-in-progress: true
+     cancel-in-progress: ${{ github.event_name == 'pull_request' }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -1233,7 +1233,7 @@ jobs:
     timeout-minutes: 120
     concurrency:
      group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-jdk${{ matrix.jdk }}-IntegrationTests_1240
-     cancel-in-progress: true
+     cancel-in-progress: ${{ github.event_name == 'pull_request' }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -1300,7 +1300,7 @@ jobs:
     timeout-minutes: 120
     concurrency:
      group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-jdk${{ matrix.jdk }}-IntegrationTests_1250
-     cancel-in-progress: true
+     cancel-in-progress: ${{ github.event_name == 'pull_request' }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -1367,7 +1367,7 @@ jobs:
     timeout-minutes: 120
     concurrency:
      group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-jdk${{ matrix.jdk }}-IntegrationTests_1260
-     cancel-in-progress: true
+     cancel-in-progress: ${{ github.event_name == 'pull_request' }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -1434,7 +1434,7 @@ jobs:
     timeout-minutes: 120
     concurrency:
      group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-jdk${{ matrix.jdk }}-IntegrationTests_1270
-     cancel-in-progress: true
+     cancel-in-progress: ${{ github.event_name == 'pull_request' }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -1501,7 +1501,7 @@ jobs:
     timeout-minutes: 120
     concurrency:
      group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-jdk${{ matrix.jdk }}-IntegrationTests_1280
-     cancel-in-progress: true
+     cancel-in-progress: ${{ github.event_name == 'pull_request' }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -1568,7 +1568,7 @@ jobs:
     timeout-minutes: 120
     concurrency:
      group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-jdk${{ matrix.jdk }}-IntegrationTests_1400
-     cancel-in-progress: true
+     cancel-in-progress: ${{ github.event_name == 'pull_request' }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -1635,7 +1635,7 @@ jobs:
     timeout-minutes: 120
     concurrency:
      group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-jdk${{ matrix.jdk }}-IntegrationTests_1410
-     cancel-in-progress: true
+     cancel-in-progress: ${{ github.event_name == 'pull_request' }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -1702,7 +1702,7 @@ jobs:
     timeout-minutes: 120
     concurrency:
      group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-jdk${{ matrix.jdk }}-IntegrationTests_1420
-     cancel-in-progress: true
+     cancel-in-progress: ${{ github.event_name == 'pull_request' }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -1769,7 +1769,7 @@ jobs:
     timeout-minutes: 120
     concurrency:
      group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-jdk${{ matrix.jdk }}-IntegrationTests_1430
-     cancel-in-progress: true
+     cancel-in-progress: ${{ github.event_name == 'pull_request' }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -1836,7 +1836,7 @@ jobs:
     timeout-minutes: 120
     concurrency:
      group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-jdk${{ matrix.jdk }}-IntegrationTests_1440
-     cancel-in-progress: true
+     cancel-in-progress: ${{ github.event_name == 'pull_request' }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -1903,7 +1903,7 @@ jobs:
     timeout-minutes: 120
     concurrency:
      group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-jdk${{ matrix.jdk }}-IntegrationTests_1500
-     cancel-in-progress: true
+     cancel-in-progress: ${{ github.event_name == 'pull_request' }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -1970,7 +1970,7 @@ jobs:
     timeout-minutes: 120
     concurrency:
      group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-jdk${{ matrix.jdk }}-IntegrationTests_1550
-     cancel-in-progress: true
+     cancel-in-progress: ${{ github.event_name == 'pull_request' }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -2037,7 +2037,7 @@ jobs:
     timeout-minutes: 120
     concurrency:
      group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-jdk${{ matrix.jdk }}-IntegrationTests_9999
-     cancel-in-progress: true
+     cancel-in-progress: ${{ github.event_name == 'pull_request' }}
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/VeniceCI-E2ETests.yml
+++ b/.github/workflows/VeniceCI-E2ETests.yml
@@ -24,6 +24,9 @@ jobs:
      contents: read
      checks: write
     timeout-minutes: 120
+    concurrency:
+     group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+     cancel-in-progress: true
     steps:
       - uses: actions/checkout@v4
         with:
@@ -87,6 +90,9 @@ jobs:
      contents: read
      checks: write
     timeout-minutes: 120
+    concurrency:
+     group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+     cancel-in-progress: true
     steps:
       - uses: actions/checkout@v4
         with:
@@ -150,6 +156,9 @@ jobs:
      contents: read
      checks: write
     timeout-minutes: 120
+    concurrency:
+     group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+     cancel-in-progress: true
     steps:
       - uses: actions/checkout@v4
         with:
@@ -213,6 +222,9 @@ jobs:
      contents: read
      checks: write
     timeout-minutes: 120
+    concurrency:
+     group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+     cancel-in-progress: true
     steps:
       - uses: actions/checkout@v4
         with:
@@ -276,6 +288,9 @@ jobs:
      contents: read
      checks: write
     timeout-minutes: 120
+    concurrency:
+     group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+     cancel-in-progress: true
     steps:
       - uses: actions/checkout@v4
         with:
@@ -339,6 +354,9 @@ jobs:
      contents: read
      checks: write
     timeout-minutes: 120
+    concurrency:
+     group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+     cancel-in-progress: true
     steps:
       - uses: actions/checkout@v4
         with:
@@ -402,6 +420,9 @@ jobs:
      contents: read
      checks: write
     timeout-minutes: 120
+    concurrency:
+     group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+     cancel-in-progress: true
     steps:
       - uses: actions/checkout@v4
         with:
@@ -465,6 +486,9 @@ jobs:
      contents: read
      checks: write
     timeout-minutes: 120
+    concurrency:
+     group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+     cancel-in-progress: true
     steps:
       - uses: actions/checkout@v4
         with:
@@ -528,6 +552,9 @@ jobs:
      contents: read
      checks: write
     timeout-minutes: 120
+    concurrency:
+     group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+     cancel-in-progress: true
     steps:
       - uses: actions/checkout@v4
         with:
@@ -591,6 +618,9 @@ jobs:
      contents: read
      checks: write
     timeout-minutes: 120
+    concurrency:
+     group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+     cancel-in-progress: true
     steps:
       - uses: actions/checkout@v4
         with:
@@ -654,6 +684,9 @@ jobs:
      contents: read
      checks: write
     timeout-minutes: 120
+    concurrency:
+     group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+     cancel-in-progress: true
     steps:
       - uses: actions/checkout@v4
         with:
@@ -717,6 +750,9 @@ jobs:
      contents: read
      checks: write
     timeout-minutes: 120
+    concurrency:
+     group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+     cancel-in-progress: true
     steps:
       - uses: actions/checkout@v4
         with:
@@ -780,6 +816,9 @@ jobs:
      contents: read
      checks: write
     timeout-minutes: 120
+    concurrency:
+     group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+     cancel-in-progress: true
     steps:
       - uses: actions/checkout@v4
         with:
@@ -843,6 +882,9 @@ jobs:
      contents: read
      checks: write
     timeout-minutes: 120
+    concurrency:
+     group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+     cancel-in-progress: true
     steps:
       - uses: actions/checkout@v4
         with:
@@ -906,6 +948,9 @@ jobs:
      contents: read
      checks: write
     timeout-minutes: 120
+    concurrency:
+     group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+     cancel-in-progress: true
     steps:
       - uses: actions/checkout@v4
         with:
@@ -969,6 +1014,9 @@ jobs:
      contents: read
      checks: write
     timeout-minutes: 120
+    concurrency:
+     group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+     cancel-in-progress: true
     steps:
       - uses: actions/checkout@v4
         with:
@@ -1032,6 +1080,9 @@ jobs:
      contents: read
      checks: write
     timeout-minutes: 120
+    concurrency:
+     group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+     cancel-in-progress: true
     steps:
       - uses: actions/checkout@v4
         with:
@@ -1095,6 +1146,9 @@ jobs:
      contents: read
      checks: write
     timeout-minutes: 120
+    concurrency:
+     group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+     cancel-in-progress: true
     steps:
       - uses: actions/checkout@v4
         with:
@@ -1158,6 +1212,9 @@ jobs:
      contents: read
      checks: write
     timeout-minutes: 120
+    concurrency:
+     group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+     cancel-in-progress: true
     steps:
       - uses: actions/checkout@v4
         with:
@@ -1221,6 +1278,9 @@ jobs:
      contents: read
      checks: write
     timeout-minutes: 120
+    concurrency:
+     group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+     cancel-in-progress: true
     steps:
       - uses: actions/checkout@v4
         with:
@@ -1284,6 +1344,9 @@ jobs:
      contents: read
      checks: write
     timeout-minutes: 120
+    concurrency:
+     group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+     cancel-in-progress: true
     steps:
       - uses: actions/checkout@v4
         with:
@@ -1347,6 +1410,9 @@ jobs:
      contents: read
      checks: write
     timeout-minutes: 120
+    concurrency:
+     group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+     cancel-in-progress: true
     steps:
       - uses: actions/checkout@v4
         with:
@@ -1410,6 +1476,9 @@ jobs:
      contents: read
      checks: write
     timeout-minutes: 120
+    concurrency:
+     group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+     cancel-in-progress: true
     steps:
       - uses: actions/checkout@v4
         with:
@@ -1473,6 +1542,9 @@ jobs:
      contents: read
      checks: write
     timeout-minutes: 120
+    concurrency:
+     group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+     cancel-in-progress: true
     steps:
       - uses: actions/checkout@v4
         with:
@@ -1536,6 +1608,9 @@ jobs:
      contents: read
      checks: write
     timeout-minutes: 120
+    concurrency:
+     group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+     cancel-in-progress: true
     steps:
       - uses: actions/checkout@v4
         with:
@@ -1599,6 +1674,9 @@ jobs:
      contents: read
      checks: write
     timeout-minutes: 120
+    concurrency:
+     group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+     cancel-in-progress: true
     steps:
       - uses: actions/checkout@v4
         with:
@@ -1662,6 +1740,9 @@ jobs:
      contents: read
      checks: write
     timeout-minutes: 120
+    concurrency:
+     group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+     cancel-in-progress: true
     steps:
       - uses: actions/checkout@v4
         with:
@@ -1725,6 +1806,9 @@ jobs:
      contents: read
      checks: write
     timeout-minutes: 120
+    concurrency:
+     group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+     cancel-in-progress: true
     steps:
       - uses: actions/checkout@v4
         with:
@@ -1788,6 +1872,9 @@ jobs:
      contents: read
      checks: write
     timeout-minutes: 120
+    concurrency:
+     group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+     cancel-in-progress: true
     steps:
       - uses: actions/checkout@v4
         with:
@@ -1851,6 +1938,9 @@ jobs:
      contents: read
      checks: write
     timeout-minutes: 120
+    concurrency:
+     group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+     cancel-in-progress: true
     steps:
       - uses: actions/checkout@v4
         with:
@@ -1914,6 +2004,9 @@ jobs:
      contents: read
      checks: write
     timeout-minutes: 120
+    concurrency:
+     group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+     cancel-in-progress: true
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/VeniceCI-E2ETests.yml
+++ b/.github/workflows/VeniceCI-E2ETests.yml
@@ -14,6 +14,7 @@ on: [push, pull_request, workflow_dispatch]
 
 jobs:
   IntegrationTests_1000:
+    name: IntegrationTests_1000
     strategy:
       fail-fast: false
       matrix:
@@ -25,7 +26,7 @@ jobs:
      checks: write
     timeout-minutes: 120
     concurrency:
-     group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-${{ github.job }}-jdk${{ matrix.jdk }}
+     group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-jdk${{ matrix.jdk }}-IntegrationTests_1000
      cancel-in-progress: true
     steps:
       - uses: actions/checkout@v4
@@ -80,6 +81,7 @@ jobs:
           retention-days: 30
 
   IntegrationTests_1010:
+    name: IntegrationTests_1010
     strategy:
       fail-fast: false
       matrix:
@@ -91,7 +93,7 @@ jobs:
      checks: write
     timeout-minutes: 120
     concurrency:
-     group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-${{ github.job }}-jdk${{ matrix.jdk }}
+     group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-jdk${{ matrix.jdk }}-IntegrationTests_1010
      cancel-in-progress: true
     steps:
       - uses: actions/checkout@v4
@@ -146,6 +148,7 @@ jobs:
           retention-days: 30
 
   IntegrationTests_1020:
+    name: IntegrationTests_1020
     strategy:
       fail-fast: false
       matrix:
@@ -157,7 +160,7 @@ jobs:
      checks: write
     timeout-minutes: 120
     concurrency:
-     group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-${{ github.job }}-jdk${{ matrix.jdk }}
+     group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-jdk${{ matrix.jdk }}-IntegrationTests_1020
      cancel-in-progress: true
     steps:
       - uses: actions/checkout@v4
@@ -212,6 +215,7 @@ jobs:
           retention-days: 30
 
   IntegrationTests_1030:
+    name: IntegrationTests_1030
     strategy:
       fail-fast: false
       matrix:
@@ -223,7 +227,7 @@ jobs:
      checks: write
     timeout-minutes: 120
     concurrency:
-     group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-${{ github.job }}-jdk${{ matrix.jdk }}
+     group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-jdk${{ matrix.jdk }}-IntegrationTests_1030
      cancel-in-progress: true
     steps:
       - uses: actions/checkout@v4
@@ -278,6 +282,7 @@ jobs:
           retention-days: 30
 
   IntegrationTests_1040:
+    name: IntegrationTests_1040
     strategy:
       fail-fast: false
       matrix:
@@ -289,7 +294,7 @@ jobs:
      checks: write
     timeout-minutes: 120
     concurrency:
-     group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-${{ github.job }}-jdk${{ matrix.jdk }}
+     group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-jdk${{ matrix.jdk }}-IntegrationTests_1040
      cancel-in-progress: true
     steps:
       - uses: actions/checkout@v4
@@ -344,6 +349,7 @@ jobs:
           retention-days: 30
 
   IntegrationTests_1050:
+    name: IntegrationTests_1050
     strategy:
       fail-fast: false
       matrix:
@@ -355,7 +361,7 @@ jobs:
      checks: write
     timeout-minutes: 120
     concurrency:
-     group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-${{ github.job }}-jdk${{ matrix.jdk }}
+     group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-jdk${{ matrix.jdk }}-IntegrationTests_1050
      cancel-in-progress: true
     steps:
       - uses: actions/checkout@v4
@@ -410,6 +416,7 @@ jobs:
           retention-days: 30
 
   IntegrationTests_1060:
+    name: IntegrationTests_1060
     strategy:
       fail-fast: false
       matrix:
@@ -421,7 +428,7 @@ jobs:
      checks: write
     timeout-minutes: 120
     concurrency:
-     group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-${{ github.job }}-jdk${{ matrix.jdk }}
+     group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-jdk${{ matrix.jdk }}-IntegrationTests_1060
      cancel-in-progress: true
     steps:
       - uses: actions/checkout@v4
@@ -476,6 +483,7 @@ jobs:
           retention-days: 30
 
   IntegrationTests_1070:
+    name: IntegrationTests_1070
     strategy:
       fail-fast: false
       matrix:
@@ -487,7 +495,7 @@ jobs:
      checks: write
     timeout-minutes: 120
     concurrency:
-     group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-${{ github.job }}-jdk${{ matrix.jdk }}
+     group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-jdk${{ matrix.jdk }}-IntegrationTests_1070
      cancel-in-progress: true
     steps:
       - uses: actions/checkout@v4
@@ -542,6 +550,7 @@ jobs:
           retention-days: 30
 
   IntegrationTests_1080:
+    name: IntegrationTests_1080
     strategy:
       fail-fast: false
       matrix:
@@ -553,7 +562,7 @@ jobs:
      checks: write
     timeout-minutes: 120
     concurrency:
-     group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-${{ github.job }}-jdk${{ matrix.jdk }}
+     group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-jdk${{ matrix.jdk }}-IntegrationTests_1080
      cancel-in-progress: true
     steps:
       - uses: actions/checkout@v4
@@ -608,6 +617,7 @@ jobs:
           retention-days: 30
 
   IntegrationTests_1090:
+    name: IntegrationTests_1090
     strategy:
       fail-fast: false
       matrix:
@@ -619,7 +629,7 @@ jobs:
      checks: write
     timeout-minutes: 120
     concurrency:
-     group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-${{ github.job }}-jdk${{ matrix.jdk }}
+     group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-jdk${{ matrix.jdk }}-IntegrationTests_1090
      cancel-in-progress: true
     steps:
       - uses: actions/checkout@v4
@@ -674,6 +684,7 @@ jobs:
           retention-days: 30
 
   IntegrationTests_1100:
+    name: IntegrationTests_1100
     strategy:
       fail-fast: false
       matrix:
@@ -685,7 +696,7 @@ jobs:
      checks: write
     timeout-minutes: 120
     concurrency:
-     group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-${{ github.job }}-jdk${{ matrix.jdk }}
+     group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-jdk${{ matrix.jdk }}-IntegrationTests_1100
      cancel-in-progress: true
     steps:
       - uses: actions/checkout@v4
@@ -740,6 +751,7 @@ jobs:
           retention-days: 30
 
   IntegrationTests_1110:
+    name: IntegrationTests_1110
     strategy:
       fail-fast: false
       matrix:
@@ -751,7 +763,7 @@ jobs:
      checks: write
     timeout-minutes: 120
     concurrency:
-     group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-${{ github.job }}-jdk${{ matrix.jdk }}
+     group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-jdk${{ matrix.jdk }}-IntegrationTests_1110
      cancel-in-progress: true
     steps:
       - uses: actions/checkout@v4
@@ -806,6 +818,7 @@ jobs:
           retention-days: 30
 
   IntegrationTests_1120:
+    name: IntegrationTests_1120
     strategy:
       fail-fast: false
       matrix:
@@ -817,7 +830,7 @@ jobs:
      checks: write
     timeout-minutes: 120
     concurrency:
-     group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-${{ github.job }}-jdk${{ matrix.jdk }}
+     group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-jdk${{ matrix.jdk }}-IntegrationTests_1120
      cancel-in-progress: true
     steps:
       - uses: actions/checkout@v4
@@ -872,6 +885,7 @@ jobs:
           retention-days: 30
 
   IntegrationTests_1130:
+    name: IntegrationTests_1130
     strategy:
       fail-fast: false
       matrix:
@@ -883,7 +897,7 @@ jobs:
      checks: write
     timeout-minutes: 120
     concurrency:
-     group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-${{ github.job }}-jdk${{ matrix.jdk }}
+     group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-jdk${{ matrix.jdk }}-IntegrationTests_1130
      cancel-in-progress: true
     steps:
       - uses: actions/checkout@v4
@@ -938,6 +952,7 @@ jobs:
           retention-days: 30
 
   IntegrationTests_1200:
+    name: IntegrationTests_1200
     strategy:
       fail-fast: false
       matrix:
@@ -949,7 +964,7 @@ jobs:
      checks: write
     timeout-minutes: 120
     concurrency:
-     group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-${{ github.job }}-jdk${{ matrix.jdk }}
+     group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-jdk${{ matrix.jdk }}-IntegrationTests_1200
      cancel-in-progress: true
     steps:
       - uses: actions/checkout@v4
@@ -1004,6 +1019,7 @@ jobs:
           retention-days: 30
 
   IntegrationTests_1210:
+    name: IntegrationTests_1210
     strategy:
       fail-fast: false
       matrix:
@@ -1015,7 +1031,7 @@ jobs:
      checks: write
     timeout-minutes: 120
     concurrency:
-     group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-${{ github.job }}-jdk${{ matrix.jdk }}
+     group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-jdk${{ matrix.jdk }}-IntegrationTests_1210
      cancel-in-progress: true
     steps:
       - uses: actions/checkout@v4
@@ -1070,6 +1086,7 @@ jobs:
           retention-days: 30
 
   IntegrationTests_1220:
+    name: IntegrationTests_1220
     strategy:
       fail-fast: false
       matrix:
@@ -1081,7 +1098,7 @@ jobs:
      checks: write
     timeout-minutes: 120
     concurrency:
-     group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-${{ github.job }}-jdk${{ matrix.jdk }}
+     group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-jdk${{ matrix.jdk }}-IntegrationTests_1220
      cancel-in-progress: true
     steps:
       - uses: actions/checkout@v4
@@ -1136,6 +1153,7 @@ jobs:
           retention-days: 30
 
   IntegrationTests_1230:
+    name: IntegrationTests_1230
     strategy:
       fail-fast: false
       matrix:
@@ -1147,7 +1165,7 @@ jobs:
      checks: write
     timeout-minutes: 120
     concurrency:
-     group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-${{ github.job }}-jdk${{ matrix.jdk }}
+     group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-jdk${{ matrix.jdk }}-IntegrationTests_1230
      cancel-in-progress: true
     steps:
       - uses: actions/checkout@v4
@@ -1202,6 +1220,7 @@ jobs:
           retention-days: 30
 
   IntegrationTests_1240:
+    name: IntegrationTests_1240
     strategy:
       fail-fast: false
       matrix:
@@ -1213,7 +1232,7 @@ jobs:
      checks: write
     timeout-minutes: 120
     concurrency:
-     group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-${{ github.job }}-jdk${{ matrix.jdk }}
+     group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-jdk${{ matrix.jdk }}-IntegrationTests_1240
      cancel-in-progress: true
     steps:
       - uses: actions/checkout@v4
@@ -1268,6 +1287,7 @@ jobs:
           retention-days: 30
 
   IntegrationTests_1250:
+    name: IntegrationTests_1250
     strategy:
       fail-fast: false
       matrix:
@@ -1279,7 +1299,7 @@ jobs:
      checks: write
     timeout-minutes: 120
     concurrency:
-     group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-${{ github.job }}-jdk${{ matrix.jdk }}
+     group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-jdk${{ matrix.jdk }}-IntegrationTests_1250
      cancel-in-progress: true
     steps:
       - uses: actions/checkout@v4
@@ -1334,6 +1354,7 @@ jobs:
           retention-days: 30
 
   IntegrationTests_1260:
+    name: IntegrationTests_1260
     strategy:
       fail-fast: false
       matrix:
@@ -1345,7 +1366,7 @@ jobs:
      checks: write
     timeout-minutes: 120
     concurrency:
-     group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-${{ github.job }}-jdk${{ matrix.jdk }}
+     group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-jdk${{ matrix.jdk }}-IntegrationTests_1260
      cancel-in-progress: true
     steps:
       - uses: actions/checkout@v4
@@ -1400,6 +1421,7 @@ jobs:
           retention-days: 30
 
   IntegrationTests_1270:
+    name: IntegrationTests_1270
     strategy:
       fail-fast: false
       matrix:
@@ -1411,7 +1433,7 @@ jobs:
      checks: write
     timeout-minutes: 120
     concurrency:
-     group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-${{ github.job }}-jdk${{ matrix.jdk }}
+     group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-jdk${{ matrix.jdk }}-IntegrationTests_1270
      cancel-in-progress: true
     steps:
       - uses: actions/checkout@v4
@@ -1466,6 +1488,7 @@ jobs:
           retention-days: 30
 
   IntegrationTests_1280:
+    name: IntegrationTests_1280
     strategy:
       fail-fast: false
       matrix:
@@ -1477,7 +1500,7 @@ jobs:
      checks: write
     timeout-minutes: 120
     concurrency:
-     group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-${{ github.job }}-jdk${{ matrix.jdk }}
+     group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-jdk${{ matrix.jdk }}-IntegrationTests_1280
      cancel-in-progress: true
     steps:
       - uses: actions/checkout@v4
@@ -1532,6 +1555,7 @@ jobs:
           retention-days: 30
 
   IntegrationTests_1400:
+    name: IntegrationTests_1400
     strategy:
       fail-fast: false
       matrix:
@@ -1543,7 +1567,7 @@ jobs:
      checks: write
     timeout-minutes: 120
     concurrency:
-     group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-${{ github.job }}-jdk${{ matrix.jdk }}
+     group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-jdk${{ matrix.jdk }}-IntegrationTests_1400
      cancel-in-progress: true
     steps:
       - uses: actions/checkout@v4
@@ -1598,6 +1622,7 @@ jobs:
           retention-days: 30
 
   IntegrationTests_1410:
+    name: IntegrationTests_1410
     strategy:
       fail-fast: false
       matrix:
@@ -1609,7 +1634,7 @@ jobs:
      checks: write
     timeout-minutes: 120
     concurrency:
-     group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-${{ github.job }}-jdk${{ matrix.jdk }}
+     group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-jdk${{ matrix.jdk }}-IntegrationTests_1410
      cancel-in-progress: true
     steps:
       - uses: actions/checkout@v4
@@ -1664,6 +1689,7 @@ jobs:
           retention-days: 30
 
   IntegrationTests_1420:
+    name: IntegrationTests_1420
     strategy:
       fail-fast: false
       matrix:
@@ -1675,7 +1701,7 @@ jobs:
      checks: write
     timeout-minutes: 120
     concurrency:
-     group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-${{ github.job }}-jdk${{ matrix.jdk }}
+     group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-jdk${{ matrix.jdk }}-IntegrationTests_1420
      cancel-in-progress: true
     steps:
       - uses: actions/checkout@v4
@@ -1730,6 +1756,7 @@ jobs:
           retention-days: 30
 
   IntegrationTests_1430:
+    name: IntegrationTests_1430
     strategy:
       fail-fast: false
       matrix:
@@ -1741,7 +1768,7 @@ jobs:
      checks: write
     timeout-minutes: 120
     concurrency:
-     group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-${{ github.job }}-jdk${{ matrix.jdk }}
+     group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-jdk${{ matrix.jdk }}-IntegrationTests_1430
      cancel-in-progress: true
     steps:
       - uses: actions/checkout@v4
@@ -1796,6 +1823,7 @@ jobs:
           retention-days: 30
 
   IntegrationTests_1440:
+    name: IntegrationTests_1440
     strategy:
       fail-fast: false
       matrix:
@@ -1807,7 +1835,7 @@ jobs:
      checks: write
     timeout-minutes: 120
     concurrency:
-     group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-${{ github.job }}-jdk${{ matrix.jdk }}
+     group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-jdk${{ matrix.jdk }}-IntegrationTests_1440
      cancel-in-progress: true
     steps:
       - uses: actions/checkout@v4
@@ -1862,6 +1890,7 @@ jobs:
           retention-days: 30
 
   IntegrationTests_1500:
+    name: IntegrationTests_1500
     strategy:
       fail-fast: false
       matrix:
@@ -1873,7 +1902,7 @@ jobs:
      checks: write
     timeout-minutes: 120
     concurrency:
-     group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-${{ github.job }}-jdk${{ matrix.jdk }}
+     group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-jdk${{ matrix.jdk }}-IntegrationTests_1500
      cancel-in-progress: true
     steps:
       - uses: actions/checkout@v4
@@ -1928,6 +1957,7 @@ jobs:
           retention-days: 30
 
   IntegrationTests_1550:
+    name: IntegrationTests_1550
     strategy:
       fail-fast: false
       matrix:
@@ -1939,7 +1969,7 @@ jobs:
      checks: write
     timeout-minutes: 120
     concurrency:
-     group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-${{ github.job }}-jdk${{ matrix.jdk }}
+     group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-jdk${{ matrix.jdk }}-IntegrationTests_1550
      cancel-in-progress: true
     steps:
       - uses: actions/checkout@v4
@@ -1994,6 +2024,7 @@ jobs:
           retention-days: 30
 
   IntegrationTests_9999:
+    name: IntegrationTests_9999
     strategy:
       fail-fast: false
       matrix:
@@ -2005,7 +2036,7 @@ jobs:
      checks: write
     timeout-minutes: 120
     concurrency:
-     group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-${{ github.job }}-jdk${{ matrix.jdk }}
+     group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-jdk${{ matrix.jdk }}-IntegrationTests_9999
      cancel-in-progress: true
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/VeniceCI-StaticAnalysisAndUnitTests.yml
+++ b/.github/workflows/VeniceCI-StaticAnalysisAndUnitTests.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     concurrency:
-     group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+     group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
      cancel-in-progress: true
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/VeniceCI-StaticAnalysisAndUnitTests.yml
+++ b/.github/workflows/VeniceCI-StaticAnalysisAndUnitTests.yml
@@ -9,6 +9,9 @@ jobs:
       fail-fast: false
     runs-on: ubuntu-latest
     timeout-minutes: 5
+    concurrency:
+     group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+     cancel-in-progress: true
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/VeniceCI-StaticAnalysisAndUnitTests.yml
+++ b/.github/workflows/VeniceCI-StaticAnalysisAndUnitTests.yml
@@ -11,7 +11,7 @@ jobs:
     timeout-minutes: 5
     concurrency:
      group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-     cancel-in-progress: true
+     cancel-in-progress: ${{ github.event_name == 'pull_request' }}
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## Cancel previous workflow check-run on new push
<!--
Describe
- What changes to make and why you are making these changes.
- How are you going to achieve your goal.
- Describe what testings you have done, for example, performance testing etc.

If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

Often times developers push new commits to the same PR which kicks off new check runs, while the previous runs still running which causes longer wait times for the new workflow to start. This change will cancel the previous workflow runs on every new push leading to quicker check runs results for the new change.

## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
GHCI
## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.