### PR TITLE
[vpj][controller] Add deferred swap for target region push

### DIFF
--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/PushJobSetting.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/PushJobSetting.java
@@ -78,6 +78,7 @@ public class PushJobSetting implements Serializable {
   public boolean d2Routing;
   public String targetedRegions;
   public boolean isTargetedRegionPushEnabled;
+  public boolean isTargetRegionPushWithDeferredSwapEnabled;
   public boolean isSystemSchemaReaderEnabled;
   public String systemSchemaClusterD2ServiceName;
   public String systemSchemaClusterD2ZKHost;

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/VenicePushJob.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/VenicePushJob.java
@@ -400,6 +400,15 @@ public class VenicePushJob implements AutoCloseable {
     if (pushJobSettingToReturn.isIncrementalPush && pushJobSettingToReturn.isTargetedRegionPushEnabled) {
       throw new VeniceException("Incremental push is not supported while using targeted region push mode");
     }
+
+    // If target region push with deferred version swap is enabled, enable deferVersionSwap and
+    // isTargetedRegionPushEnabled
+    if (props.getBoolean(TARGETED_REGION_PUSH_WITH_DEFERRED_SWAP, false)) {
+      pushJobSettingToReturn.deferVersionSwap = true;
+      pushJobSettingToReturn.isTargetedRegionPushEnabled = true;
+      pushJobSettingToReturn.isTargetRegionPushWithDeferredSwapEnabled = true;
+    }
+
     if (props.containsKey(TARGETED_REGION_PUSH_LIST)) {
       if (pushJobSettingToReturn.isTargetedRegionPushEnabled) {
         pushJobSettingToReturn.targetedRegions = props.getString(TARGETED_REGION_PUSH_LIST);
@@ -501,14 +510,6 @@ public class VenicePushJob implements AutoCloseable {
       Class objectClass = ReflectUtils.loadClass(dataWriterComputeJobClass);
       Validate.isAssignableFrom(DataWriterComputeJob.class, objectClass);
       pushJobSettingToReturn.dataWriterComputeJobClass = objectClass;
-    }
-
-    // If target region push with deferred version swap is enabled, enable deferVersionSwap and
-    // isTargetedRegionPushEnabled
-    if (props.getBoolean(TARGETED_REGION_PUSH_WITH_DEFERRED_SWAP, false)) {
-      pushJobSettingToReturn.deferVersionSwap = true;
-      pushJobSettingToReturn.isTargetedRegionPushEnabled = true;
-      pushJobSettingToReturn.isTargetRegionPushWithDeferredSwapEnabled = true;
     }
 
     return pushJobSettingToReturn;

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/VenicePushJob.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/VenicePushJob.java
@@ -410,7 +410,7 @@ public class VenicePushJob implements AutoCloseable {
 
     if (props.containsKey(TARGETED_REGION_PUSH_LIST)) {
       if (pushJobSettingToReturn.isTargetedRegionPushEnabled
-          || pushJobSetting.isTargetRegionPushWithDeferredSwapEnabled) {
+          || pushJobSettingToReturn.isTargetRegionPushWithDeferredSwapEnabled) {
         pushJobSettingToReturn.targetedRegions = props.getString(TARGETED_REGION_PUSH_LIST);
       } else {
         throw new VeniceException("Targeted region push list is only supported when targeted region push is enabled");

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/VenicePushJob.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/VenicePushJob.java
@@ -408,6 +408,13 @@ public class VenicePushJob implements AutoCloseable {
       pushJobSettingToReturn.isTargetRegionPushWithDeferredSwapEnabled = true;
     }
 
+    if (pushJobSettingToReturn.isTargetRegionPushWithDeferredSwapEnabled
+        && pushJobSettingToReturn.isTargetedRegionPushEnabled) {
+      throw new VeniceException(
+          "Target region push and target region push with deferred version swap cannot be enabled"
+              + " at the same time");
+    }
+
     if (props.containsKey(TARGETED_REGION_PUSH_LIST)) {
       if (pushJobSettingToReturn.isTargetedRegionPushEnabled
           || pushJobSettingToReturn.isTargetRegionPushWithDeferredSwapEnabled) {

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/VenicePushJob.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/VenicePushJob.java
@@ -508,6 +508,7 @@ public class VenicePushJob implements AutoCloseable {
     if (props.getBoolean(TARGETED_REGION_PUSH_WITH_DEFERRED_SWAP, false)) {
       pushJobSettingToReturn.deferVersionSwap = true;
       pushJobSettingToReturn.isTargetedRegionPushEnabled = true;
+      pushJobSettingToReturn.isTargetRegionPushWithDeferredSwapEnabled = true;
     }
 
     return pushJobSettingToReturn;
@@ -859,8 +860,7 @@ public class VenicePushJob implements AutoCloseable {
       sendPushJobDetailsToController();
 
       // only kick off the validation and post-validation flow when everything has to be done in a single VPJ
-      if (!pushJobSetting.isTargetedRegionPushEnabled
-          || (pushJobSetting.deferVersionSwap && pushJobSetting.isTargetedRegionPushEnabled)) {
+      if (!pushJobSetting.isTargetedRegionPushEnabled || pushJobSetting.isTargetRegionPushWithDeferredSwapEnabled) {
         return;
       }
 

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/vpj/VenicePushJobConstants.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/vpj/VenicePushJobConstants.java
@@ -327,7 +327,8 @@ public final class VenicePushJobConstants {
   /**
    * Config to enable target region push with deferred version swap
    * In this mode, the VPJ will push data to all regions and only switch to the new version in a single region.
-   * The single region is decided by the store config in {@link StoreInfo#getNativeReplicationSourceFabric()}}.
+   * The single region is decided by the store config in {@link StoreInfo#getNativeReplicationSourceFabric()}} unless
+   * a list of regions is passed in from targeted.region.push.list
    * After a specified wait time (default 1h), the remaining regions will switch to the new version.
    */
   public static final String TARGETED_REGION_PUSH_WITH_DEFERRED_SWAP = "targeted.region.push.with.deferred.swap";

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/vpj/VenicePushJobConstants.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/vpj/VenicePushJobConstants.java
@@ -324,6 +324,14 @@ public final class VenicePushJobConstants {
    */
   public static final String TARGETED_REGION_PUSH_LIST = "targeted.region.push.list";
 
+  /**
+   * Config to enable target region push with deferred version swap
+   * In this mode, the VPJ will push data to all regions and only switch to the new version in a single region.
+   * The single region is decided by the store config in {@link StoreInfo#getNativeReplicationSourceFabric()}}.
+   * After a specified wait time (default 1h), the remaining regions will switch to the new version.
+   */
+  public static final String TARGETED_REGION_PUSH_WITH_DEFERRED_SWAP = "targeted.region.push.with.deferred.swap";
+
   public static final boolean DEFAULT_IS_DUPLICATED_KEY_ALLOWED = false;
 
   /**

--- a/clients/venice-push-job/src/test/java/com/linkedin/venice/hadoop/VenicePushJobTest.java
+++ b/clients/venice-push-job/src/test/java/com/linkedin/venice/hadoop/VenicePushJobTest.java
@@ -936,7 +936,7 @@ public class VenicePushJobTest {
     try (VenicePushJob pushJob = getSpyVenicePushJob(props, getClient())) {
       PushJobSetting pushJobSetting = pushJob.getPushJobSetting();
       Assert.assertEquals(pushJobSetting.deferVersionSwap, true);
-      Assert.assertEquals(pushJobSetting.isTargetedRegionPushEnabled, true);
+      Assert.assertEquals(pushJobSetting.isTargetRegionPushWithDeferredSwapEnabled, true);
       Assert.assertEquals(pushJobSetting.targetedRegions, regions);
     }
   }

--- a/clients/venice-push-job/src/test/java/com/linkedin/venice/hadoop/VenicePushJobTest.java
+++ b/clients/venice-push-job/src/test/java/com/linkedin/venice/hadoop/VenicePushJobTest.java
@@ -27,6 +27,7 @@ import static com.linkedin.venice.vpj.VenicePushJobConstants.SOURCE_KAFKA;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.SYSTEM_SCHEMA_READER_ENABLED;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.TARGETED_REGION_PUSH_ENABLED;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.TARGETED_REGION_PUSH_LIST;
+import static com.linkedin.venice.vpj.VenicePushJobConstants.TARGETED_REGION_PUSH_WITH_DEFERRED_SWAP;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.VALUE_FIELD_PROP;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.VENICE_DISCOVER_URL_PROP;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.VENICE_STORE_NAME_PROP;
@@ -920,6 +921,20 @@ public class VenicePushJobTest {
       final VeniceWriter<KafkaKey, byte[], byte[]> veniceWriter = vpj.getVeniceWriter(pushJobSetting);
       Assert.assertNotNull(veniceWriter, "VeniceWriter should've been constructed and returned");
       Assert.assertEquals(veniceWriter, vpj.getVeniceWriter(pushJobSetting), "Second get() should return same object");
+    }
+  }
+
+  @Test
+  public void testTargetRegionPushWithDeferredSwapSettings() {
+    Properties props = getVpjRequiredProperties();
+    props.put(KEY_FIELD_PROP, "id");
+    props.put(VALUE_FIELD_PROP, "name");
+    props.put(TARGETED_REGION_PUSH_WITH_DEFERRED_SWAP, true);
+
+    try (VenicePushJob pushJob = getSpyVenicePushJob(props, getClient())) {
+      PushJobSetting pushJobSetting = pushJob.getPushJobSetting();
+      Assert.assertEquals(pushJobSetting.deferVersionSwap, true);
+      Assert.assertEquals(pushJobSetting.isTargetedRegionPushEnabled, true);
     }
   }
 

--- a/clients/venice-push-job/src/test/java/com/linkedin/venice/hadoop/VenicePushJobTest.java
+++ b/clients/venice-push-job/src/test/java/com/linkedin/venice/hadoop/VenicePushJobTest.java
@@ -941,7 +941,7 @@ public class VenicePushJobTest {
     }
   }
 
-  @Test
+  @Test(expectedExceptions = VeniceException.class, expectedExceptionsMessageRegExp = ".*cannot be enabled at the same time.*")
   public void testEnableBothTargetRegionConfigs() {
     Properties props = getVpjRequiredProperties();
     String regions = "test1, test2";
@@ -951,14 +951,7 @@ public class VenicePushJobTest {
     props.put(TARGETED_REGION_PUSH_ENABLED, true);
     props.put(TARGETED_REGION_PUSH_LIST, regions);
 
-    try {
-      getSpyVenicePushJob(props, getClient());
-    } catch (Exception e) {
-      assertEquals(
-          e.getMessage(),
-          "Target region push and target region push with deferred version swap cannot be enabled"
-              + " at the same time");
-    }
+    getSpyVenicePushJob(props, getClient());
   }
 
   private JobStatusQueryResponse mockJobStatusQuery() {

--- a/clients/venice-push-job/src/test/java/com/linkedin/venice/hadoop/VenicePushJobTest.java
+++ b/clients/venice-push-job/src/test/java/com/linkedin/venice/hadoop/VenicePushJobTest.java
@@ -927,14 +927,17 @@ public class VenicePushJobTest {
   @Test
   public void testTargetRegionPushWithDeferredSwapSettings() {
     Properties props = getVpjRequiredProperties();
+    String regions = "test1, test2";
     props.put(KEY_FIELD_PROP, "id");
     props.put(VALUE_FIELD_PROP, "name");
     props.put(TARGETED_REGION_PUSH_WITH_DEFERRED_SWAP, true);
+    props.put(TARGETED_REGION_PUSH_LIST, regions);
 
     try (VenicePushJob pushJob = getSpyVenicePushJob(props, getClient())) {
       PushJobSetting pushJobSetting = pushJob.getPushJobSetting();
       Assert.assertEquals(pushJobSetting.deferVersionSwap, true);
       Assert.assertEquals(pushJobSetting.isTargetedRegionPushEnabled, true);
+      Assert.assertEquals(pushJobSetting.targetedRegions, regions);
     }
   }
 

--- a/clients/venice-push-job/src/test/java/com/linkedin/venice/hadoop/VenicePushJobTest.java
+++ b/clients/venice-push-job/src/test/java/com/linkedin/venice/hadoop/VenicePushJobTest.java
@@ -941,6 +941,26 @@ public class VenicePushJobTest {
     }
   }
 
+  @Test
+  public void testEnableBothTargetRegionConfigs() {
+    Properties props = getVpjRequiredProperties();
+    String regions = "test1, test2";
+    props.put(KEY_FIELD_PROP, "id");
+    props.put(VALUE_FIELD_PROP, "name");
+    props.put(TARGETED_REGION_PUSH_WITH_DEFERRED_SWAP, true);
+    props.put(TARGETED_REGION_PUSH_ENABLED, true);
+    props.put(TARGETED_REGION_PUSH_LIST, regions);
+
+    try {
+      getSpyVenicePushJob(props, getClient());
+    } catch (Exception e) {
+      assertEquals(
+          e.getMessage(),
+          "Target region push and target region push with deferred version swap cannot be enabled"
+              + " at the same time");
+    }
+  }
+
   private JobStatusQueryResponse mockJobStatusQuery() {
     JobStatusQueryResponse response = new JobStatusQueryResponse();
     response.setStatus(ExecutionStatus.COMPLETED.toString());

--- a/internal/venice-common/src/main/java/com/linkedin/venice/meta/AbstractStore.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/meta/AbstractStore.java
@@ -351,9 +351,13 @@ public abstract class AbstractStore implements Store {
 
   @Override
   public void updateVersionForDaVinciHeartbeat(int versionNumber, boolean reported) {
-    for (StoreVersion version: storeVersionsSupplier.getForUpdate()) {
+    checkVersionSupplier();
+
+    for (StoreVersion storeVersion: storeVersionsSupplier.getForUpdate()) {
+      Version version = new VersionImpl(storeVersion);
       if (version.getNumber() == versionNumber) {
-        version.setIsDaVinciHeartBeatReported(reported);
+        version.setIsDavinciHeartbeatReported(reported);
+        return;
       }
     }
   }

--- a/internal/venice-common/src/main/java/com/linkedin/venice/meta/AbstractStore.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/meta/AbstractStore.java
@@ -348,4 +348,13 @@ public abstract class AbstractStore implements Store {
       }
     }
   }
+
+  @Override
+  public void updateVersionForDaVinciHeartbeat(int versionNumber, boolean reported) {
+    for (StoreVersion version: storeVersionsSupplier.getForUpdate()) {
+      if (version.getNumber() == versionNumber) {
+        version.setIsDaVinciHeartBeatReported(reported);
+      }
+    }
+  }
 }

--- a/internal/venice-common/src/main/java/com/linkedin/venice/meta/ReadOnlyStore.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/meta/ReadOnlyStore.java
@@ -1498,6 +1498,11 @@ public class ReadOnlyStore implements Store {
   }
 
   @Override
+  public void updateVersionForDaVinciHeartbeat(int versionNumber, boolean reported) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
   public String toString() {
     return this.delegate.toString();
   }

--- a/internal/venice-common/src/main/java/com/linkedin/venice/meta/Store.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/meta/Store.java
@@ -341,4 +341,6 @@ public interface Store {
   void setIsDavinciHeartbeatReported(boolean isReported);
 
   boolean getIsDavinciHeartbeatReported();
+
+  void updateVersionForDaVinciHeartbeat(int versionNumber, boolean reported);
 }

--- a/internal/venice-common/src/main/java/com/linkedin/venice/meta/VersionImpl.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/meta/VersionImpl.java
@@ -507,6 +507,7 @@ public class VersionImpl implements Version {
     clonedVersion.setBlobTransferEnabled(isBlobTransferEnabled());
     clonedVersion.setTargetSwapRegion(getTargetSwapRegion());
     clonedVersion.setTargetSwapRegionWaitTime(getTargetSwapRegionWaitTime());
+    clonedVersion.setIsDavinciHeartbeatReported(getIsDavinciHeartbeatReported());
     return clonedVersion;
   }
 

--- a/internal/venice-common/src/test/java/com/linkedin/venice/meta/TestZKStore.java
+++ b/internal/venice-common/src/test/java/com/linkedin/venice/meta/TestZKStore.java
@@ -436,4 +436,13 @@ public class TestZKStore {
         1);
     Assert.assertTrue(store.isAccessControlled());
   }
+
+  @Test
+  public void testUpdateVersionForDaVinciHeartbeat() {
+    String storeName = "testUpdateVersionForDaVinciHeartbeat";
+    Store store = TestUtils.createTestStore(storeName, "owner", System.currentTimeMillis());
+    store.addVersion(new VersionImpl(storeName, 1, "test"));
+    store.updateVersionForDaVinciHeartbeat(1, true);
+    Assert.assertTrue(store.getVersion(1).getIsDavinciHeartbeatReported());
+  }
 }

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/DaVinciClientTest.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/DaVinciClientTest.java
@@ -75,6 +75,7 @@ import com.linkedin.venice.integration.utils.VeniceClusterWrapper;
 import com.linkedin.venice.integration.utils.VeniceRouterWrapper;
 import com.linkedin.venice.meta.IngestionMetadataUpdateType;
 import com.linkedin.venice.meta.IngestionMode;
+import com.linkedin.venice.meta.StoreInfo;
 import com.linkedin.venice.meta.Version;
 import com.linkedin.venice.offsets.OffsetRecord;
 import com.linkedin.venice.partitioner.ConstantVenicePartitioner;
@@ -1544,6 +1545,32 @@ public class DaVinciClientTest {
     for (int i = 0; i < 3; i++) {
       String snapshotPath = RocksDBUtils.composeSnapshotDir(dvcPath1 + "/rocksdb", storeName + "_v1", i);
       Assert.assertTrue(Files.exists(Paths.get(snapshotPath)));
+    }
+  }
+
+  @Test
+  public void testIsDavinciHeartbeatReported() throws Exception {
+    String storeName = Utils.getUniqueString("testIsDavinviHeartbeatReported");
+    Consumer<UpdateStoreQueryParams> paramsConsumer = params -> params.setTargetRegionSwap("test");
+    setUpStore(storeName, paramsConsumer, properties -> {}, true);
+
+    try (DaVinciClient<Object, Object> client = ServiceFactory.getGenericAvroDaVinciClient(storeName, cluster)) {
+      client.subscribeAll().get();
+    }
+
+    Properties vpjProperties = defaultVPJProps(cluster, inputDirPath, storeName);
+    runVPJ(vpjProperties, 2, cluster);
+
+    try (ControllerClient controllerClient = cluster.getControllerClient()) {
+      StoreInfo store = controllerClient.getStore(storeName).getStore();
+      TestUtils.waitForNonDeterministicAssertion(
+          2,
+          TimeUnit.MILLISECONDS,
+          () -> Assert.assertEquals(store.getIsDavinciHeartbeatReported(), true));
+      TestUtils.waitForNonDeterministicAssertion(
+          2,
+          TimeUnit.MILLISECONDS,
+          () -> Assert.assertEquals(store.getVersion(2).get().getIsDavinciHeartbeatReported(), true));
     }
   }
 

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/DaVinciClientTest.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/DaVinciClientTest.java
@@ -1570,14 +1570,10 @@ public class DaVinciClientTest {
 
     try (ControllerClient controllerClient = cluster.getControllerClient()) {
       StoreInfo store = controllerClient.getStore(storeName).getStore();
-      TestUtils.waitForNonDeterministicAssertion(
-          2,
-          TimeUnit.MILLISECONDS,
-          () -> Assert.assertEquals(store.getIsDavinciHeartbeatReported(), true));
-      TestUtils.waitForNonDeterministicAssertion(
-          2,
-          TimeUnit.MILLISECONDS,
-          () -> Assert.assertEquals(store.getVersion(2).get().getIsDavinciHeartbeatReported(), true));
+      TestUtils.waitForNonDeterministicAssertion(2, TimeUnit.MILLISECONDS, () -> {
+        Assert.assertTrue(store.getIsDavinciHeartbeatReported());
+        Assert.assertTrue(store.getVersion(2).get().getIsDavinciHeartbeatReported());
+      });
     }
   }
 

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/DaVinciClientTest.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/DaVinciClientTest.java
@@ -1548,7 +1548,7 @@ public class DaVinciClientTest {
     }
   }
 
-  @Test
+  @Test(timeOut = TEST_TIMEOUT)
   public void testIsDavinciHeartbeatReported() throws Exception {
     String storeName = Utils.getUniqueString("testIsDavinviHeartbeatReported");
     Consumer<UpdateStoreQueryParams> paramsConsumer = params -> params.setTargetRegionSwap("test");
@@ -1558,7 +1558,14 @@ public class DaVinciClientTest {
       client.subscribeAll().get();
     }
 
-    Properties vpjProperties = defaultVPJProps(cluster, inputDirPath, storeName);
+    File inputDirectory = getTempDataDirectory();
+    String inputDirectoryPath = "file://" + inputDirectory.getAbsolutePath();
+    try {
+      writeSimpleAvroFileWithIntToStringSchema(inputDirectory);
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+    Properties vpjProperties = defaultVPJProps(cluster, inputDirectoryPath, storeName);
     runVPJ(vpjProperties, 2, cluster);
 
     try (ControllerClient controllerClient = cluster.getControllerClient()) {

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceHelixAdmin.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceHelixAdmin.java
@@ -2519,6 +2519,49 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
             useFastKafkaOperationTimeout));
   }
 
+  private Pair<Boolean, Version> addVersion(
+      String clusterName,
+      String storeName,
+      String pushJobId,
+      int versionNumber,
+      int numberOfPartitions,
+      int replicationFactor,
+      boolean startIngestion,
+      boolean sendStartOfPush,
+      boolean sorted,
+      boolean useFastKafkaOperationTimeout,
+      PushType pushType,
+      String compressionDictionary,
+      String remoteKafkaBootstrapServers,
+      Optional<String> sourceGridFabric,
+      long rewindTimeInSecondsOverride,
+      int replicationMetadataVersionId,
+      Optional<String> emergencySourceRegion,
+      boolean versionSwapDeferred,
+      int repushSourceVersion) {
+    return addVersion(
+        clusterName,
+        storeName,
+        pushJobId,
+        versionNumber,
+        numberOfPartitions,
+        replicationFactor,
+        startIngestion,
+        sendStartOfPush,
+        sorted,
+        useFastKafkaOperationTimeout,
+        pushType,
+        compressionDictionary,
+        remoteKafkaBootstrapServers,
+        sourceGridFabric,
+        rewindTimeInSecondsOverride,
+        replicationMetadataVersionId,
+        emergencySourceRegion,
+        versionSwapDeferred,
+        null,
+        repushSourceVersion);
+  }
+
   private Optional<Version> getVersionFromSourceCluster(
       ReadWriteStoreRepository repository,
       String destinationCluster,
@@ -3051,7 +3094,6 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
             replicationMetadataVersionId,
             emergencySourceRegion,
             versionSwapDeferred,
-            null,
             repushSourceVersion).getSecond();
   }
 

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/kafka/consumer/AdminExecutionTask.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/kafka/consumer/AdminExecutionTask.java
@@ -666,7 +666,9 @@ public class AdminExecutionTask implements Callable<Void> {
     } else {
       boolean skipConsumption = message.targetedRegions != null && !message.targetedRegions.isEmpty()
           && message.targetedRegions.stream().map(Object::toString).noneMatch(regionName::equals);
-      if (skipConsumption) {
+      boolean isTargetRegionPushWithDeferredSwap = message.targetedRegions != null && message.versionSwapDeferred;
+      String targetedRegions = message.targetedRegions != null ? String.join(",", message.targetedRegions) : "";
+      if (skipConsumption && isTargetRegionPushWithDeferredSwap) {
         // for targeted region push, only allow specified region to process add version message
         LOGGER.info(
             "Skip the add version message for store {} in region {} since this is targeted region push and "
@@ -687,6 +689,7 @@ public class AdminExecutionTask implements Callable<Void> {
             rewindTimeInSecondsOverride,
             replicationMetadataVersionId,
             message.versionSwapDeferred,
+            targetedRegions,
             repushSourceVersion);
       }
     }

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/kafka/consumer/AdminExecutionTask.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/kafka/consumer/AdminExecutionTask.java
@@ -668,7 +668,7 @@ public class AdminExecutionTask implements Callable<Void> {
           && message.targetedRegions.stream().map(Object::toString).noneMatch(regionName::equals);
       boolean isTargetRegionPushWithDeferredSwap = message.targetedRegions != null && message.versionSwapDeferred;
       String targetedRegions = message.targetedRegions != null ? String.join(",", message.targetedRegions) : "";
-      if (skipConsumption && isTargetRegionPushWithDeferredSwap) {
+      if (skipConsumption && !isTargetRegionPushWithDeferredSwap) {
         // for targeted region push, only allow specified region to process add version message
         LOGGER.info(
             "Skip the add version message for store {} in region {} since this is targeted region push and "

--- a/services/venice-controller/src/main/java/com/linkedin/venice/pushmonitor/AbstractPushMonitor.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/pushmonitor/AbstractPushMonitor.java
@@ -1141,8 +1141,8 @@ public abstract class AbstractPushMonitor
           boolean isDeferredSwap = version.isVersionSwapDeferred() && targetRegions.isEmpty();
           if (isTargetRegionPushWithDeferredSwap || isNormalPush) {
             LOGGER.info(
-                "Swapping to version {} for store {} in region {}. isTargetRegionPushWithDeferredSwap is {} and"
-                    + "isNormalPush is {}",
+                "Swapping to version {} for store {} in region {} during "
+                    + (isNormalPush ? "normal push" : "target region push with deferred version swap"),
                 versionNumber,
                 store.getName(),
                 regionName,

--- a/services/venice-controller/src/main/java/com/linkedin/venice/pushmonitor/AbstractPushMonitor.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/pushmonitor/AbstractPushMonitor.java
@@ -1151,18 +1151,18 @@ public abstract class AbstractPushMonitor
             int previousVersion = store.getCurrentVersion();
             store.setCurrentVersion(versionNumber);
             realTimeTopicSwitcher.transmitVersionSwapMessage(store, previousVersion, versionNumber);
-          } else if (isDeferredSwap) {
-            LOGGER.info(
-                "Version swap is deferred for store {} on version {}. Skipping version swap.",
+          } else {
+            String deferredSwapLog = String.format(
+                "Version swap is deferred for store %s on version %d. Skipping version swap",
                 store.getName(),
                 versionNumber);
-          } else {
-            LOGGER.info(
-                "Version swap is deferred for store {} on version {} in region {} because it is not in the target regions: {}",
+            String targetRegionSwapDeferredLog = String.format(
+                "Version swap is deferred for store %s on version %d in region %s because it is not in the target regions: %s",
                 store.getName(),
                 versionNumber,
                 regionName,
-                targetRegions);
+                version.getTargetSwapRegion());
+            LOGGER.info(isDeferredSwap ? deferredSwapLog : targetRegionSwapDeferredLog);
           }
         } else {
           LOGGER.info(

--- a/services/venice-controller/src/main/java/com/linkedin/venice/pushmonitor/AbstractPushMonitor.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/pushmonitor/AbstractPushMonitor.java
@@ -1135,11 +1135,19 @@ public abstract class AbstractPushMonitor
            *  after targetSwapRegionWaitTime passes)
            */
           Set<String> targetRegions = RegionUtils.parseRegionsFilterList(version.getTargetSwapRegion());
-          boolean isValidTargetRegion = targetRegions.contains(regionName);
-          boolean isTargetRegionPushWithDeferredSwap = version.isVersionSwapDeferred() && isValidTargetRegion;
+          boolean isTargetRegionPushWithDeferredSwap =
+              version.isVersionSwapDeferred() && targetRegions.contains(regionName);
           boolean isNormalPush = !version.isVersionSwapDeferred();
           boolean isDeferredSwap = version.isVersionSwapDeferred() && targetRegions.isEmpty();
           if (isTargetRegionPushWithDeferredSwap || isNormalPush) {
+            LOGGER.debug(
+                "Swapping to version {} for store {} in region {}. isTargetRegionPushWithDeferredSwap is {} and"
+                    + "isNormalPush is {}",
+                versionNumber,
+                store.getName(),
+                regionName,
+                isTargetRegionPushWithDeferredSwap,
+                isNormalPush);
             int previousVersion = store.getCurrentVersion();
             store.setCurrentVersion(versionNumber);
             realTimeTopicSwitcher.transmitVersionSwapMessage(store, previousVersion, versionNumber);

--- a/services/venice-controller/src/main/java/com/linkedin/venice/pushmonitor/AbstractPushMonitor.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/pushmonitor/AbstractPushMonitor.java
@@ -1152,17 +1152,12 @@ public abstract class AbstractPushMonitor
             store.setCurrentVersion(versionNumber);
             realTimeTopicSwitcher.transmitVersionSwapMessage(store, previousVersion, versionNumber);
           } else {
-            String deferredSwapLog = String.format(
-                "Version swap is deferred for store %s on version %d. Skipping version swap",
-                store.getName(),
-                versionNumber);
-            String targetRegionSwapDeferredLog = String.format(
-                "Version swap is deferred for store %s on version %d in region %s because it is not in the target regions: %s",
+            LOGGER.info(
+                "Version swap is deferred for store {} on version {} in region {} because "
+                    + (isDeferredSwap ? "deferred version swap is enabled" : "it is not in the target regions"),
                 store.getName(),
                 versionNumber,
-                regionName,
-                version.getTargetSwapRegion());
-            LOGGER.info(isDeferredSwap ? deferredSwapLog : targetRegionSwapDeferredLog);
+                regionName);
           }
         } else {
           LOGGER.info(

--- a/services/venice-controller/src/main/java/com/linkedin/venice/pushmonitor/AbstractPushMonitor.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/pushmonitor/AbstractPushMonitor.java
@@ -1140,7 +1140,7 @@ public abstract class AbstractPushMonitor
           boolean isNormalPush = !version.isVersionSwapDeferred();
           boolean isDeferredSwap = version.isVersionSwapDeferred() && targetRegions.isEmpty();
           if (isTargetRegionPushWithDeferredSwap || isNormalPush) {
-            LOGGER.debug(
+            LOGGER.info(
                 "Swapping to version {} for store {} in region {}. isTargetRegionPushWithDeferredSwap is {} and"
                     + "isNormalPush is {}",
                 versionNumber,
@@ -1158,10 +1158,11 @@ public abstract class AbstractPushMonitor
                 versionNumber);
           } else {
             LOGGER.info(
-                "Version swap is deferred for store {} on version {} in region {} due to target region push w/ deferred swap",
+                "Version swap is deferred for store {} on version {} in region {} because it is not in the target regions: {}",
                 store.getName(),
                 versionNumber,
-                regionName);
+                regionName,
+                targetRegions);
           }
         } else {
           LOGGER.info(

--- a/services/venice-controller/src/main/java/com/linkedin/venice/pushmonitor/PushStatusCollector.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/pushmonitor/PushStatusCollector.java
@@ -177,8 +177,7 @@ public class PushStatusCollector {
       Store store = storeRepository.getStore(storeName);
       if (!store.getIsDavinciHeartbeatReported() && daVinciStatus.getStatus() != ExecutionStatus.NOT_CREATED) {
         int versionNum = Version.parseVersionFromVersionTopicName(pushStatus.topicName);
-        Version version = store.getVersion(versionNum);
-        version.setIsDavinciHeartbeatReported(true);
+        store.updateVersionForDaVinciHeartbeat(versionNum, true);
         storeRepository.updateStore(store);
       }
 

--- a/services/venice-controller/src/main/java/com/linkedin/venice/pushmonitor/PushStatusCollector.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/pushmonitor/PushStatusCollector.java
@@ -178,6 +178,7 @@ public class PushStatusCollector {
       if (!store.getIsDavinciHeartbeatReported() && daVinciStatus.getStatus() != ExecutionStatus.NOT_CREATED) {
         int versionNum = Version.parseVersionFromVersionTopicName(pushStatus.topicName);
         store.updateVersionForDaVinciHeartbeat(versionNum, true);
+        store.setIsDavinciHeartbeatReported(true);
         storeRepository.updateStore(store);
       }
 

--- a/services/venice-controller/src/main/java/com/linkedin/venice/pushmonitor/PushStatusCollector.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/pushmonitor/PushStatusCollector.java
@@ -171,6 +171,17 @@ public class PushStatusCollector {
       } else {
         topicToNoDaVinciStatusRetryCountMap.remove(pushStatus.topicName);
       }
+
+      // If there is some status for a davinci push, mark that there is a dvc heartbeat reported for the latest version
+      String storeName = Version.parseStoreFromKafkaTopicName(pushStatus.topicName);
+      Store store = storeRepository.getStore(storeName);
+      if (!store.getIsDavinciHeartbeatReported() && daVinciStatus.getStatus() != ExecutionStatus.NOT_CREATED) {
+        int versionNum = Version.parseVersionFromVersionTopicName(pushStatus.topicName);
+        Version version = store.getVersion(versionNum);
+        version.setIsDavinciHeartbeatReported(true);
+        storeRepository.updateStore(store);
+      }
+
       LOGGER.info(
           "Received DaVinci status: {} with details: {} for topic: {}",
           daVinciStatus.getStatus(),

--- a/services/venice-controller/src/test/java/com/linkedin/venice/controller/kafka/consumer/AdminConsumptionTaskTest.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/controller/kafka/consumer/AdminConsumptionTaskTest.java
@@ -1162,6 +1162,7 @@ public class AdminConsumptionTaskTest {
             -1,
             1,
             false,
+            "",
             0);
     // isLeaderController() is called once every consumption cycle (1000ms) and for every message processed in
     // AdminExecutionTask.
@@ -1319,6 +1320,7 @@ public class AdminConsumptionTaskTest {
             -1,
             1,
             false,
+            "",
             0);
     Future<PubSubProduceResult> future = veniceWriter.put(
         emptyKeyBytes,
@@ -1450,6 +1452,7 @@ public class AdminConsumptionTaskTest {
           -1,
           1,
           false,
+          "dc-0",
           0);
     });
 


### PR DESCRIPTION
<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## Summary, imperative, start upper case, don't end with a period
<!--
Describe
- What changes to make and why you are making these changes.
- How are you going to achieve your goal.
- Describe what testings you have done, for example, performance testing etc.

If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

Currently, when target region push is enabled, it only ingests the data & swap to the new version in if the current region matches the target region defined by the target region push list or the native replication source fabric. The ingestion for the remaining regions are kicked off after the first region is able to swap to the new version.

The pr adds in a deferred version swap option to the existing target region push. In this version, data is ingested in all regions, but it will only swap to the new version in the target region. The behavior to swap the version out in the remaining regions will be added in later.

## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
unit & integration tests

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [ ] No. You can skip the rest of this section.
- [x] Yes. Make sure to explain your proposed changes and call out the behavior change.
This will be enabled if `targeted.region.push.with.deferred.swap` is passed in in the job settings