### PR TITLE
[router][server] Reduce the granularity of latency histogram percentiles and disable key value profiling for single gets

### DIFF
--- a/internal/venice-client-common/src/main/java/com/linkedin/venice/stats/TehutiUtils.java
+++ b/internal/venice-client-common/src/main/java/com/linkedin/venice/stats/TehutiUtils.java
@@ -23,7 +23,7 @@ public class TehutiUtils {
   // metrics. It's likely to degrade critical path performance
   private static final double[] FINE_GRAINED_HISTOGRAM_PERCENTILES =
       new double[] { 0.01, 0.1, 1, 2, 3, 4, 5, 10, 20, 30, 40, 50, 60, 70, 80, 90, 95, 99, 99.9 };
-  private static final double[] HISTOGRAM_PERCENTILES_FOR_NETWORK_LATENCY = new double[] { 50, 77, 90, 95, 99, 99.9 };
+  private static final double[] HISTOGRAM_PERCENTILES_FOR_NETWORK_LATENCY = new double[] { 50, 95, 99, 99.9 };
   private static final String ROUND_NUMBER_SUFFIX = ".0";
 
   /**

--- a/services/venice-server/src/main/java/com/linkedin/venice/stats/ServerHttpRequestStats.java
+++ b/services/venice-server/src/main/java/com/linkedin/venice/stats/ServerHttpRequestStats.java
@@ -295,8 +295,8 @@ public class ServerHttpRequestStats extends AbstractVeniceHttpStats {
         () -> totalStats.earlyTerminatedEarlyRequestCountSensor,
         new OccurrenceRate());
 
-    if (isKeyValueProfilingEnabled || requestType == RequestType.SINGLE_GET) {
-      // size profiling is only expensive for requests with lots of keys, but we keep it always on for single gets...
+    if (isKeyValueProfilingEnabled) {
+      // size profiling is expensive
       String requestValueSizeSensorName = "request_value_size";
       requestValueSizeSensor = registerPerStoreAndTotal(
           requestValueSizeSensorName,


### PR DESCRIPTION
<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## Reduce the granularity of latency histogram percentiles and disable key value profiling for single gets
<!--
Describe
- What changes to make and why you are making these changes.
- How are you going to achieve your goal.
- Describe what testings you have done, for example, performance testing etc.

If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->
Currently, we record fine-grained percentiles for key and value of all single get requests. This bloats up the metrics significantly. This commit restricts key and value profiling only for cases where this config is enabled.

In addition to this, removed P77 and P90 metrics from latency metrics. We still have p50, p95, p99 and p99.9.

## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
GH CI

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [X] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.