### PR TITLE
[server] Fix NPE when key value size profiling is not enabled

### DIFF
--- a/services/venice-server/src/main/java/com/linkedin/venice/stats/ServerHttpRequestStats.java
+++ b/services/venice-server/src/main/java/com/linkedin/venice/stats/ServerHttpRequestStats.java
@@ -445,11 +445,15 @@ public class ServerHttpRequestStats extends AbstractVeniceHttpStats {
   }
 
   public void recordKeySizeInByte(int keySize) {
-    requestKeySizeSensor.record(keySize);
+    if (requestKeySizeSensor != null) {
+      requestKeySizeSensor.record(keySize);
+    }
   }
 
   public void recordValueSizeInByte(int valueSize) {
-    requestValueSizeSensor.record(valueSize);
+    if (requestValueSizeSensor != null) {
+      requestValueSizeSensor.record(valueSize);
+    }
   }
 
   public void recordMisroutedStoreVersionRequest() {


### PR DESCRIPTION
<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## Fix NPE when key value size profiling is not enabled

This commit addresses a NullPointerException in `ServerHttpRequestStats` when attempting to record key or value sizes while the corresponding profiling sensors (`requestKeySizeSensor` or `requestValueSizeSensor`) are null. 


## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
UT

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.