### PR TITLE
[server] Fix stats handling for SINGLE_GET requests

### DIFF
--- a/services/venice-server/src/test/java/com/linkedin/venice/stats/AggServerHttpRequestStatsTest.java
+++ b/services/venice-server/src/test/java/com/linkedin/venice/stats/AggServerHttpRequestStatsTest.java
@@ -13,8 +13,10 @@ import org.testng.annotations.Test;
 
 
 public class AggServerHttpRequestStatsTest {
-  private MetricsRepository metricsRepository, metricsRepositoryForKVProfiling;
-  private MockTehutiReporter reporter, reporterForKVProfiling;
+  private MetricsRepository metricsRepository;
+  private MockTehutiReporter reporter;
+  private MetricsRepository metricsRepositoryForKVProfiling;
+  private MockTehutiReporter reporterForKVProfiling;
   private AggServerHttpRequestStats singleGetStats;
   private AggServerHttpRequestStats singleGetStatsWithKVProfiling;
   private AggServerHttpRequestStats batchGetStats;

--- a/services/venice-server/src/test/java/com/linkedin/venice/stats/AggServerHttpRequestStatsTest.java
+++ b/services/venice-server/src/test/java/com/linkedin/venice/stats/AggServerHttpRequestStatsTest.java
@@ -13,10 +13,11 @@ import org.testng.annotations.Test;
 
 
 public class AggServerHttpRequestStatsTest {
-  protected MetricsRepository metricsRepository;
-  protected MockTehutiReporter reporter;
-  protected AggServerHttpRequestStats singleGetStats;
-  protected AggServerHttpRequestStats batchGetStats;
+  private MetricsRepository metricsRepository, metricsRepositoryForKVProfiling;
+  private MockTehutiReporter reporter, reporterForKVProfiling;
+  private AggServerHttpRequestStats singleGetStats;
+  private AggServerHttpRequestStats singleGetStatsWithKVProfiling;
+  private AggServerHttpRequestStats batchGetStats;
 
   private static final String STORE_FOO = "store_foo";
   private static final String STORE_BAR = "store_bar";
@@ -26,14 +27,21 @@ public class AggServerHttpRequestStatsTest {
   @BeforeTest
   public void setUp() {
     this.metricsRepository = new MetricsRepository();
-    Assert.assertEquals(metricsRepository.metrics().size(), 0);
     this.reporter = new MockTehutiReporter();
     this.metricsRepository.addReporter(reporter);
+
+    this.metricsRepositoryForKVProfiling = new MetricsRepository();
+    this.reporterForKVProfiling = new MockTehutiReporter();
+    this.metricsRepositoryForKVProfiling.addReporter(reporterForKVProfiling);
+
+    Assert.assertEquals(metricsRepository.metrics().size(), 0);
+    Assert.assertEquals(metricsRepositoryForKVProfiling.metrics().size(), 0);
+
     this.singleGetStats = new AggServerHttpRequestStats(
         "test_cluster",
         metricsRepository,
         RequestType.SINGLE_GET,
-        true,
+        false,
         Mockito.mock(ReadOnlyStoreRepository.class),
         true,
         false);
@@ -45,18 +53,31 @@ public class AggServerHttpRequestStatsTest {
         Mockito.mock(ReadOnlyStoreRepository.class),
         true,
         false);
+
+    this.singleGetStatsWithKVProfiling = new AggServerHttpRequestStats(
+        "test_cluster",
+        metricsRepositoryForKVProfiling,
+        RequestType.SINGLE_GET,
+        true,
+        Mockito.mock(ReadOnlyStoreRepository.class),
+        true,
+        false);
   }
 
   @AfterTest
   public void cleanUp() {
     metricsRepository.close();
+    metricsRepositoryForKVProfiling.close();
     reporter.close();
+    reporterForKVProfiling.close();
   }
 
   @Test
   public void testMetrics() {
     ServerHttpRequestStats singleGetServerStatsFoo = singleGetStats.getStoreStats(STORE_FOO);
     ServerHttpRequestStats singleGetServerStatsBar = singleGetStats.getStoreStats(STORE_BAR);
+    ServerHttpRequestStats singleGetServerStatsWithKvProfilingFoo =
+        singleGetStatsWithKVProfiling.getStoreStats(STORE_FOO);
 
     singleGetServerStatsFoo.recordSuccessRequest();
     singleGetServerStatsFoo.recordSuccessRequest();
@@ -65,6 +86,9 @@ public class AggServerHttpRequestStatsTest {
 
     singleGetServerStatsFoo.recordKeySizeInByte(100);
     singleGetServerStatsFoo.recordValueSizeInByte(1000);
+
+    singleGetServerStatsWithKvProfilingFoo.recordKeySizeInByte(100);
+    singleGetServerStatsWithKvProfilingFoo.recordValueSizeInByte(1000);
 
     Assert.assertTrue(
         reporter.query("." + STORE_FOO + "--success_request.OccurrenceRate").value() > 0,
@@ -75,15 +99,34 @@ public class AggServerHttpRequestStatsTest {
     Assert.assertTrue(
         reporter.query(".total--success_request_ratio.RatioStat").value() > 0,
         "success_request_ratio should be positive");
+    Assert.assertTrue(
+        reporter.query(".store_foo--request_key_size.Avg").value() > 0,
+        "Avg value for request key size should always be recorded");
+    Assert.assertTrue(
+        reporter.query(".store_foo--request_key_size.Max").value() > 0,
+        "Max value for request key size should always be recorded");
 
-    String[] percentileStrings = new String[] { "0_01", "0_01", "0_1", "1", "2", "3", "4", "5", "10", "20", "30", "40",
-        "50", "60", "70", "80", "90", "95", "99", "99_9" };
+    Assert.assertTrue(
+        reporterForKVProfiling.query(".store_foo--request_key_size.Avg").value() > 0,
+        "Avg value for request key size should always be recorded");
+    Assert.assertTrue(
+        reporterForKVProfiling.query(".store_foo--request_key_size.Max").value() > 0,
+        "Max value for request key size should always be recorded");
 
-    for (int i = 0; i < percentileStrings.length; i++) {
+    String[] fineGrainedPercentiles = new String[] { "0_01", "0_01", "0_1", "1", "2", "3", "4", "5", "10", "20", "30",
+        "40", "50", "60", "70", "80", "90", "95", "99", "99_9" };
+    for (String fineGrainedPercentile: fineGrainedPercentiles) {
+      Assert.assertNull(
+          metricsRepository.getMetric(".store_foo--request_key_size." + fineGrainedPercentile + "thPercentile"));
+      Assert.assertNull(
+          metricsRepository.getMetric(".store_foo--request_value_size." + fineGrainedPercentile + "thPercentile"));
+
       Assert.assertTrue(
-          reporter.query(".store_foo--request_key_size." + percentileStrings[i] + "thPercentile").value() > 0);
+          reporterForKVProfiling.query(".store_foo--request_key_size." + fineGrainedPercentile + "thPercentile")
+              .value() > 0);
       Assert.assertTrue(
-          reporter.query(".store_foo--request_value_size." + percentileStrings[i] + "thPercentile").value() > 0);
+          reporterForKVProfiling.query(".store_foo--request_value_size." + fineGrainedPercentile + "thPercentile")
+              .value() > 0);
     }
 
     singleGetStats.handleStoreDeleted(STORE_FOO);


### PR DESCRIPTION
<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## Fix stats handling for `SINGLE_GET` requests
<!--
Describe
- What changes to make and why you are making these changes.
- How are you going to achieve your goal.
- Describe what testings you have done, for example, performance testing etc.

If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->
In a previous commit (#1377), when removing some metrics, we ended up removing some key metrics about key and value size values for single_get requests as well. That change also led to NPEs as the caller expected the K/V stats to always be recorded for Single-get requests. This commit adds `Avg` and `Max` stats by default for key and value sizes in single get requests.

## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
Added unit tests

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [X] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.