### PR TITLE
[server] AAWC delete operation should auto-convert value-level RMD record

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/replication/merge/MergeConflictResolver.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/replication/merge/MergeConflictResolver.java
@@ -210,7 +210,7 @@ public class MergeConflictResolver {
     if (useFieldLevelTimestamp || RmdUtils.getRmdTimestampType(oldTimestampObject).equals(PER_FIELD_TIMESTAMP)) {
       return mergeDeleteWithFieldLevelTimestamp(
           oldValueBytesProvider,
-          (GenericRecord) oldTimestampObject,
+          oldTimestampObject,
           oldValueSchemaID,
           oldRmdRecord,
           deleteOperationColoID,
@@ -382,15 +382,19 @@ public class MergeConflictResolver {
 
   private MergeConflictResult mergeDeleteWithFieldLevelTimestamp(
       Lazy<ByteBuffer> oldValueBytesProvider,
-      GenericRecord oldValueFieldTimestampsRecord,
+      Object oldTimestampObject,
       int oldValueSchemaID,
       GenericRecord oldRmdRecord,
       int deleteOperationColoID,
       long deleteOperationTimestamp,
       long deleteOperationSourceOffset,
       int deleteOperationSourceBrokerID) {
-    if (ignoreNewDelete(oldValueFieldTimestampsRecord, deleteOperationTimestamp)) {
-      return MergeConflictResult.getIgnoredResult();
+
+    if (oldTimestampObject instanceof GenericRecord) {
+      final GenericRecord oldValueFieldTimestampsRecord = (GenericRecord) oldTimestampObject;
+      if (ignoreNewDelete(oldValueFieldTimestampsRecord, deleteOperationTimestamp)) {
+        return MergeConflictResult.getIgnoredResult();
+      }
     }
     // In this case, the writer and reader schemas are the same because deletion does not introduce any new schema.
     final Schema oldValueSchema = getValueSchema(oldValueSchemaID);


### PR DESCRIPTION
## [server] AAWC delete operation should auto-convert value-level RMD record
When we enabled partial update as store config, existing SIT will pick up this config after a server restart and becomes AAWC SIT and requires to work on field level TS.
We solved the similar issue in PUT operation in #1081 , where we will make no assumption on existing RMD record and optionally convert it from value-level to field-level. This PR completes the fix by adding the same logic to DELETE operation.

## How was this PR tested?
Add a new unit test and new integration test.
## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.