### PR TITLE
[test] Speed up TestControllerClient#testControllerClientWithInvalidUrls

### DIFF
--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/controllerapi/TestControllerClient.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/controllerapi/TestControllerClient.java
@@ -173,7 +173,7 @@ public class TestControllerClient {
       // When only some controllers are missing, the ConnectException should never be bubbled up. Since this behavior is
       // triggered from Java libs, and we randomize the controller list to do some load balancing, the best way to
       // validate is to try multiple invocations
-      IntStream.rangeClosed(1, 100).parallel().forEach(i -> {
+      IntStream.rangeClosed(1, 50).parallel().forEach(i -> {
         D2ServiceDiscoveryResponse discoResponsePartialValidController = ControllerClient
             .discoverCluster(nonExistentControllerUrl1 + "," + validControllerUrl, storeName, Optional.empty(), 1);
         Assert.assertFalse(discoResponsePartialValidController.isError());

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/controllerapi/TestControllerClient.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/controllerapi/TestControllerClient.java
@@ -173,7 +173,7 @@ public class TestControllerClient {
       // When only some controllers are missing, the ConnectException should never be bubbled up. Since this behavior is
       // triggered from Java libs, and we randomize the controller list to do some load balancing, the best way to
       // validate is to try multiple invocations
-      IntStream.rangeClosed(1, 10).parallel().forEach(i -> {
+      IntStream.rangeClosed(1, 100).parallel().forEach(i -> {
         D2ServiceDiscoveryResponse discoResponsePartialValidController = ControllerClient
             .discoverCluster(nonExistentControllerUrl1 + "," + validControllerUrl, storeName, Optional.empty(), 1);
         Assert.assertFalse(discoResponsePartialValidController.isError());

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/controllerapi/TestControllerClient.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/controllerapi/TestControllerClient.java
@@ -22,6 +22,7 @@ import io.netty.handler.codec.http.HttpVersion;
 import java.io.IOException;
 import java.net.ConnectException;
 import java.util.Optional;
+import java.util.stream.IntStream;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
@@ -170,9 +171,9 @@ public class TestControllerClient {
           discoResponseInvalidControllers.getError());
 
       // When only some controllers are missing, the ConnectException should never be bubbled up. Since this behavior is
-      // triggered from Java libs, and we randomise the controller list to do some load balancing, the best way to
+      // triggered from Java libs, and we randomize the controller list to do some load balancing, the best way to
       // validate is to try multiple invocations
-      for (int i = 0; i < 100; i++) {
+      IntStream.rangeClosed(1, 10).parallel().forEach(i -> {
         D2ServiceDiscoveryResponse discoResponsePartialValidController = ControllerClient
             .discoverCluster(nonExistentControllerUrl1 + "," + validControllerUrl, storeName, Optional.empty(), 1);
         Assert.assertFalse(discoResponsePartialValidController.isError());
@@ -217,7 +218,7 @@ public class TestControllerClient {
             1);
         Assert.assertTrue(errorDiscoResponseInvalidAndLegacy.isError());
         Assert.assertEquals(errorDiscoResponseInvalidAndLegacy.getErrorType(), ErrorType.BAD_REQUEST);
-      }
+      });
 
       try (ControllerClient controllerClient =
           ControllerClientFactory.getControllerClient(clusterName, validControllerUrl, Optional.empty())) {


### PR DESCRIPTION
<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## Speed up `TestControllerClient#testControllerClientWithInvalidUrls`
<!--
Describe
- What changes to make and why you are making these changes.
- How are you going to achieve your goal.
- Describe what testings you have done, for example, performance testing etc.

If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

This test is validating that as long as at least one of the hosts in the Controller urls is healthy, the `ControllerClient` won't see a `ConnectException`. However, the `ControllerClient` will randomize the controller order in every request, it is not deterministic that a single run will ever attempt to communicate with the unavailable controller. Our tests setup to retry failing tests multiple times, and if any of them passes, it assumes the test is good. So, regressions in this logic could get missed by our team. To prevent this, the test runs the test for 100 iterations.

However, this leads to a case where the test is running for 13 minutes on CI hosts. To speed up the test, we do two things:
1. Reduce the number of iterations to 50
2. Parallelize the loop to concurrently attempt multiple times

## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
This is a test-only change

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [X] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.