### PR TITLE
[chanelog] Clean up consumer state on changelog client

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/consumer/VeniceAfterImageConsumerImpl.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/consumer/VeniceAfterImageConsumerImpl.java
@@ -81,11 +81,17 @@ public class VeniceAfterImageConsumerImpl<K, V> extends VeniceChangelogConsumerI
 
   @Override
   public CompletableFuture<Void> seekToTimestamps(Map<Integer, Long> timestamps) {
+    if (timestamps.isEmpty()) {
+      return null;
+    }
     return internalSeekToTimestamps(timestamps, "");
   }
 
   @Override
   public CompletableFuture<Void> subscribe(Set<Integer> partitions) {
+    if (partitions.isEmpty()) {
+      return null;
+    }
     if (!versionSwapThreadScheduled.get()) {
       // schedule the version swap thread and set up the callback listener
       this.storeRepository.registerStoreDataChangedListener(versionSwapListener);
@@ -101,11 +107,17 @@ public class VeniceAfterImageConsumerImpl<K, V> extends VeniceChangelogConsumerI
 
   @Override
   public CompletableFuture<Void> seekToTail(Set<Integer> partitions) {
+    if (partitions.isEmpty()) {
+      return null;
+    }
     return internalSeekToTail(partitions, "");
   }
 
   @Override
   public CompletableFuture<Void> seekToEndOfPush(Set<Integer> partitions) {
+    if (partitions.isEmpty()) {
+      return null;
+    }
     return CompletableFuture.supplyAsync(() -> {
       synchronized (internalSeekConsumer) {
         try {
@@ -113,6 +125,7 @@ public class VeniceAfterImageConsumerImpl<K, V> extends VeniceChangelogConsumerI
           // approach
           // we'd like to do is instead add the offset of the EOP message in the VT, and then just seek to that offset.
           // We'll do that in a future patch.
+          internalSeekConsumer.get().unsubscribeAll();
           internalSeekConsumer.get().subscribe(partitions).get();
 
           // We need to get the internal consumer as we have to intercept the control messages that we would normally

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/consumer/VeniceChangelogConsumerImpl.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/consumer/VeniceChangelogConsumerImpl.java
@@ -239,7 +239,7 @@ public class VeniceChangelogConsumerImpl<K, V> implements VeniceChangelogConsume
 
       synchronized (pubSubConsumer) {
         Set<PubSubTopicPartition> topicPartitionSet = getTopicAssignment();
-        for (PubSubTopicPartition topicPartition: pubSubConsumer.getAssignment()) {
+        for (PubSubTopicPartition topicPartition: topicPartitionSet) {
           if (partitions.contains(topicPartition.getPartitionNumber())) {
             pubSubConsumer.unSubscribe(topicPartition);
           }
@@ -549,6 +549,9 @@ public class VeniceChangelogConsumerImpl<K, V> implements VeniceChangelogConsume
 
   @Override
   public void unsubscribe(Set<Integer> partitions) {
+    if (partitions.isEmpty()) {
+      return;
+    }
     synchronized (pubSubConsumer) {
       Set<PubSubTopicPartition> topicPartitionSet = getTopicAssignment();
       Set<PubSubTopicPartition> topicPartitionsToUnsub = new HashSet<>();

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/consumer/VersionSwapDataChangeListener.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/consumer/VersionSwapDataChangeListener.java
@@ -56,6 +56,10 @@ class VersionSwapDataChangeListener<K, V> implements StoreDataChangedListener {
           }
         }
 
+        if (partitions.isEmpty()) {
+          return;
+        }
+
         LOGGER.info(
             "New Version detected!  Seeking consumer to version: " + currentVersion + " in consumer: " + consumerName);
         this.consumer.seekToEndOfPush(partitions).get();


### PR DESCRIPTION
## [chanelog] Clean up consumer state on changelog client

And other protections like subscribing to an empty set of partitions.

Resolves #XXX

## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [ ] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.