### PR TITLE
Further split services unit tests into Routers/Servers/Controllers

### DIFF
--- a/.github/workflows/UnitTests-core.yml
+++ b/.github/workflows/UnitTests-core.yml
@@ -54,7 +54,7 @@ jobs:
         env:
           NODE_OPTIONS: "--max_old_space_size=8192"
         uses: mikepenz/action-junit-report@v3
-        if: failure() #  run  only if the previous step fails
+        if: always() 
         with:
          check_name: ${{ inputs.artifact_suffix }}-jdk${{ matrix.jdk }} Report
          report_paths: '**/build/test-results/test/TEST-*.xml'

--- a/.github/workflows/UnitTests-core.yml
+++ b/.github/workflows/UnitTests-core.yml
@@ -50,6 +50,7 @@ jobs:
           rsync -R --files-from=artifacts.list . ${{ inputs.artifact_suffix }}-artifacts
           tar -zcvf ${{ inputs.artifact_suffix }}-jdk${{ matrix.jdk }}-logs.tar.gz ${{ inputs.artifact_suffix }}-artifacts
       - name: Publish Test Report
+        continue-on-error: true
         env:
           NODE_OPTIONS: "--max_old_space_size=8192"
         uses: mikepenz/action-junit-report@v3

--- a/.github/workflows/UnitTests-core.yml
+++ b/.github/workflows/UnitTests-core.yml
@@ -54,9 +54,10 @@ jobs:
         env:
           NODE_OPTIONS: "--max_old_space_size=8192"
         uses: mikepenz/action-junit-report@v3
-        if: always() # always run even if the previous step fails
+        if: failure() #  run  only if the previous step fails
         with:
-          report_paths: '**/build/test-results/test/TEST-*.xml'
+         check_name: ${{ inputs.artifact_suffix }}-jdk${{ matrix.jdk }} Report
+         report_paths: '**/build/test-results/test/TEST-*.xml'
       - name: Upload Build Artifacts
         if: success() || failure()
         uses: actions/upload-artifact@v4

--- a/.github/workflows/VeniceCI-StaticAnalysisAndUnitTests.yml
+++ b/.github/workflows/VeniceCI-StaticAnalysisAndUnitTests.yml
@@ -87,24 +87,24 @@ jobs:
   Controller:
    uses: ./.github/workflows/UnitTests-core.yml
    with:
-    artifact_suffix: services
+    artifact_suffix: controller
     arg: :services:venice-controller:jacocoTestCoverageVerification :services:venice-controller:diffCoverage --continue
   Server:
    uses: ./.github/workflows/UnitTests-core.yml
    with:
-    artifact_suffix: services
+    artifact_suffix: server
     arg: :services:venice-server:jacocoTestCoverageVerification :services:venice-server:diffCoverage --continue
   Router:
    uses: ./.github/workflows/UnitTests-core.yml
    with:
-    artifact_suffix: services
+    artifact_suffix: router
     arg: :services:venice-router:jacocoTestCoverageVerification :services:venice-router:diffCoverage --continue
 
   StaticAnalysisAndUnitTestsCompletionCheck:
     strategy:
       fail-fast: false
     runs-on: ubuntu-latest
-    needs: [ValidateGradleWrapper, StaticAnalysis, Clients, Internal, Services]
+    needs: [ValidateGradleWrapper, StaticAnalysis, Clients, Internal, Controller, Server, Router]
     timeout-minutes: 120
     if: success() || failure()  # Always run this job, regardless of previous job status
     steps:

--- a/.github/workflows/VeniceCI-StaticAnalysisAndUnitTests.yml
+++ b/.github/workflows/VeniceCI-StaticAnalysisAndUnitTests.yml
@@ -126,7 +126,15 @@ jobs:
            echo "Internal module unit tests failed."
            exit 1
          fi
-         if [ "${{ needs.Services.result }}" != "success" ]; then
+         if [ "${{ needs.Controller.result }}" != "success" ]; then
+           echo "Services module unit tests failed."
+           exit 1
+         fi
+         if [ "${{ needs.Server.result }}" != "success" ]; then
+           echo "Services module unit tests failed."
+           exit 1
+         fi
+         if [ "${{ needs.Router.result }}" != "success" ]; then
            echo "Services module unit tests failed."
            exit 1
          fi

--- a/.github/workflows/VeniceCI-StaticAnalysisAndUnitTests.yml
+++ b/.github/workflows/VeniceCI-StaticAnalysisAndUnitTests.yml
@@ -65,8 +65,7 @@ jobs:
    uses: ./.github/workflows/UnitTests-core.yml
    with:
     artifact_suffix: clients
-    arg: :clients:da-vinci-client:jacocoTestCoverageVerification :clients:da-vinci-client:diffCoverage
-      :clients:venice-admin-tool:jacocoTestCoverageVerification :clients:venice-admin-tool:diffCoverage
+    arg: :clients:venice-admin-tool:jacocoTestCoverageVerification :clients:venice-admin-tool:diffCoverage
       :clients:venice-producer:jacocoTestCoverageVerification :clients:venice-producer:diffCoverage
       :integrations:venice-pulsar:jacocoTestCoverageVerification :integrations:venice-pulsar:diffCoverage
       :clients:venice-client:jacocoTestCoverageVerification :clients:venice-client:diffCoverage
@@ -93,7 +92,8 @@ jobs:
    uses: ./.github/workflows/UnitTests-core.yml
    with:
     artifact_suffix: server
-    arg: :services:venice-server:jacocoTestCoverageVerification :services:venice-server:diffCoverage --continue
+    arg: :clients:da-vinci-client:jacocoTestCoverageVerification :clients:da-vinci-client:diffCoverage
+     :services:venice-server:jacocoTestCoverageVerification :services:venice-server:diffCoverage --continue
   Router:
    uses: ./.github/workflows/UnitTests-core.yml
    with:

--- a/.github/workflows/VeniceCI-StaticAnalysisAndUnitTests.yml
+++ b/.github/workflows/VeniceCI-StaticAnalysisAndUnitTests.yml
@@ -87,17 +87,17 @@ jobs:
   Controller:
    uses: ./.github/workflows/UnitTests-core.yml
    with:
-    artifact_suffix: controller
+    artifact_suffix: services
     arg: :services:venice-controller:jacocoTestCoverageVerification :services:venice-controller:diffCoverage --continue
   Server:
    uses: ./.github/workflows/UnitTests-core.yml
    with:
-    artifact_suffix: server
+    artifact_suffix: services
     arg: :services:venice-server:jacocoTestCoverageVerification :services:venice-server:diffCoverage --continue
   Router:
    uses: ./.github/workflows/UnitTests-core.yml
    with:
-    artifact_suffix: router
+    artifact_suffix: services
     arg: :services:venice-router:jacocoTestCoverageVerification :services:venice-router:diffCoverage --continue
 
   StaticAnalysisAndUnitTestsCompletionCheck:

--- a/.github/workflows/VeniceCI-StaticAnalysisAndUnitTests.yml
+++ b/.github/workflows/VeniceCI-StaticAnalysisAndUnitTests.yml
@@ -127,15 +127,15 @@ jobs:
            exit 1
          fi
          if [ "${{ needs.Controller.result }}" != "success" ]; then
-           echo "Services module unit tests failed."
+           echo "Controller module unit tests failed."
            exit 1
          fi
          if [ "${{ needs.Server.result }}" != "success" ]; then
-           echo "Services module unit tests failed."
+           echo "Server module unit tests failed."
            exit 1
          fi
          if [ "${{ needs.Router.result }}" != "success" ]; then
-           echo "Services module unit tests failed."
+           echo "Router module unit tests failed."
            exit 1
          fi
       # If all previous jobs were successful, proceed

--- a/.github/workflows/VeniceCI-StaticAnalysisAndUnitTests.yml
+++ b/.github/workflows/VeniceCI-StaticAnalysisAndUnitTests.yml
@@ -84,13 +84,21 @@ jobs:
      :internal:venice-test-common:jacocoTestCoverageVerification :internal:venice-test-common:diffCoverage --continue
 
 
-  Services:
-    uses: ./.github/workflows/UnitTests-core.yml
-    with:
-      artifact_suffix: services
-      arg: :services:venice-controller:jacocoTestCoverageVerification :services:venice-controller:diffCoverage
-       :services:venice-router:jacocoTestCoverageVerification :services:venice-router:diffCoverage
-       :services:venice-server:jacocoTestCoverageVerification :services:venice-server:diffCoverage --continue
+  Controller:
+   uses: ./.github/workflows/UnitTests-core.yml
+   with:
+    artifact_suffix: controller
+    arg: :services:venice-controller:jacocoTestCoverageVerification :services:venice-controller:diffCoverage --continue
+  Server:
+   uses: ./.github/workflows/UnitTests-core.yml
+   with:
+    artifact_suffix: server
+    arg: :services:venice-server:jacocoTestCoverageVerification :services:venice-server:diffCoverage --continue
+  Router:
+   uses: ./.github/workflows/UnitTests-core.yml
+   with:
+    artifact_suffix: router
+    arg: :services:venice-router:jacocoTestCoverageVerification :services:venice-router:diffCoverage --continue
 
   StaticAnalysisAndUnitTestsCompletionCheck:
     strategy:

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTaskTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTaskTest.java
@@ -2323,6 +2323,7 @@ public abstract class StoreIngestionTaskTest {
         });
 
     StoreIngestionTaskTestConfig config = new StoreIngestionTaskTestConfig(relevantPartitions, () -> {
+      Utils.sleep(1000);
       // Verify that all partitions reported success.
       maxOffsetPerPartition.entrySet()
           .stream()


### PR DESCRIPTION
<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## Further split services unit tests into Routers/Servers/Controllers
<!--
Describe
- What changes to make and why you are making these changes.
- How are you going to achieve your goal.
- Describe what testings you have done, for example, performance testing etc.

If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

The client module contains da-vinci-client which contains most of the server code. This PR splits the unit tests into more categories based on the venice components like router/server/controller etc which should improve total UT CI runtime further from 28 mins to 12mins. Also fixed the some flakiness in SIT tests for jdk8.

<img width="824" alt="image" src="https://github.com/user-attachments/assets/8f30bc26-9a1b-4283-a980-9998e79667f8" />

## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
CI
## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.