### PR TITLE
[CI] Remove checks for test reports to avoid CI failures

### DIFF
--- a/.github/rawWorkflows/gh-ci-parameterized-flow.txt
+++ b/.github/rawWorkflows/gh-ci-parameterized-flow.txt
@@ -47,6 +47,7 @@
           rsync -R --files-from=artifacts.list . ${{ github.job }}-artifacts
           tar -zcvf ${{ github.job }}-jdk${{ matrix.jdk }}-logs.tar.gz ${{ github.job }}-artifacts
       - name: Publish Test Report
+        continue-on-error: true
         env:
           NODE_OPTIONS: "--max_old_space_size=8192"
         uses: mikepenz/action-junit-report@v5

--- a/.github/rawWorkflows/gh-ci-parameterized-flow.txt
+++ b/.github/rawWorkflows/gh-ci-parameterized-flow.txt
@@ -9,6 +9,7 @@
      id-token: write
      contents: read
      checks: write
+     pull-requests: write
     needs: $Dependency
     if: $Conditional
     timeout-minutes: $TimeOut
@@ -45,20 +46,19 @@
           find . -path "**/build/reports/*" -or -path "**/build/test-results/*" > artifacts.list
           rsync -R --files-from=artifacts.list . ${{ github.job }}-artifacts
           tar -zcvf ${{ github.job }}-jdk${{ matrix.jdk }}-logs.tar.gz ${{ github.job }}-artifacts
-      - name: Generate Fork Repo Test Reports
-        if: ${{ (github.repository_owner != 'linkedin') && (success() || failure()) }}
-        uses: dorny/test-reporter@v1.9.1
+      - name: Publish Test Report
         env:
-         NODE_OPTIONS: --max-old-space-size=9182
+          NODE_OPTIONS: "--max_old_space_size=8192"
+        uses: mikepenz/action-junit-report@v5
+        if: always()
         with:
-         token: ${{ secrets.GITHUB_TOKEN }}
-         name: ${{ github.job }} Test Reports       # Name where it report the test results
-         path: '**/TEST-*.xml'
-         fail-on-error: 'false'
-         max-annotations: '10'
-         list-tests: 'all'
-         list-suites: 'all'
-         reporter: java-junit
+         check_name: ${{ inputs.artifact_suffix }}-jdk${{ matrix.jdk }} Report
+         comment: true
+         annotate_only: true
+         flaky_summary: true
+         commit: ${{github.event.workflow_run.head_sha}}
+         detailed_summary: true
+         report_paths: '**/build/test-results/test/TEST-*.xml'
       - name: Upload Build Artifacts
         if: success() || failure()
         uses: actions/upload-artifact@v4

--- a/.github/rawWorkflows/gh-ci-parameterized-flow.txt
+++ b/.github/rawWorkflows/gh-ci-parameterized-flow.txt
@@ -56,7 +56,7 @@
         uses: mikepenz/action-junit-report@v5
         if: always()
         with:
-         check_name: ${{ inputs.artifact_suffix }}-jdk${{ matrix.jdk }} Report
+         check_name: ${{ github.job }}-jdk${{ matrix.jdk }} Report
          comment: false
          annotate_only: true
          flaky_summary: true
@@ -71,7 +71,7 @@
           path: ${{ github.job }}-jdk${{ matrix.jdk }}-logs.tar.gz
           retention-days: 30
       - name: Upload test results to BuildPulse for flaky test detection
-        if: '!cancelled()' # Run this step even when the tests fail. Skip if the workflow is cancelled.
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main' && !cancelled()
         uses: buildpulse/buildpulse-action@main
         with:
           account: 100582612927

--- a/.github/rawWorkflows/gh-ci-parameterized-flow.txt
+++ b/.github/rawWorkflows/gh-ci-parameterized-flow.txt
@@ -49,6 +49,20 @@
           find . -path "**/build/reports/*" -or -path "**/build/test-results/*" > artifacts.list
           rsync -R --files-from=artifacts.list . ${{ github.job }}-artifacts
           tar -zcvf ${{ github.job }}-jdk${{ matrix.jdk }}-logs.tar.gz ${{ github.job }}-artifacts
+      - name: Generate Fork Repo Test Reports
+        if: ${{ (github.repository_owner != 'linkedin') && (success() || failure()) }}
+        uses: dorny/test-reporter@v1.9.1
+        env:
+         NODE_OPTIONS: --max-old-space-size=9182
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          name: ${{ github.job }} Test Reports       # Name where it report the test results
+          path: '**/TEST-*.xml'
+          fail-on-error: 'false'
+          max-annotations: '10'
+          list-tests: 'all'
+          list-suites: 'all'
+          reporter: java-junit
       - name: Publish Test Report
         continue-on-error: true
         env:
@@ -56,13 +70,13 @@
         uses: mikepenz/action-junit-report@v5
         if: always()
         with:
-         check_name: ${{ github.job }}-jdk${{ matrix.jdk }} Report
-         comment: false
-         annotate_only: true
-         flaky_summary: true
-         commit: ${{github.event.workflow_run.head_sha}}
-         detailed_summary: true
-         report_paths: '**/build/test-results/test/TEST-*.xml'
+          check_name: ${{ github.job }}-jdk${{ matrix.jdk }} Report
+          comment: false
+          annotate_only: true
+          flaky_summary: true
+          commit: ${{github.event.workflow_run.head_sha}}
+          detailed_summary: true
+          report_paths: '**/build/test-results/test/TEST-*.xml'
       - name: Upload Build Artifacts
         if: success() || failure()
         uses: actions/upload-artifact@v4

--- a/.github/rawWorkflows/gh-ci-parameterized-flow.txt
+++ b/.github/rawWorkflows/gh-ci-parameterized-flow.txt
@@ -54,7 +54,7 @@
         if: always()
         with:
          check_name: ${{ inputs.artifact_suffix }}-jdk${{ matrix.jdk }} Report
-         comment: true
+         comment: false
          annotate_only: true
          flaky_summary: true
          commit: ${{github.event.workflow_run.head_sha}}

--- a/.github/rawWorkflows/gh-ci-parameterized-flow.txt
+++ b/.github/rawWorkflows/gh-ci-parameterized-flow.txt
@@ -10,6 +10,7 @@
      contents: read
      checks: write
      pull-requests: write
+     issues: write
     needs: $Dependency
     if: $Conditional
     timeout-minutes: $TimeOut

--- a/.github/rawWorkflows/gh-ci-parameterized-flow.txt
+++ b/.github/rawWorkflows/gh-ci-parameterized-flow.txt
@@ -34,6 +34,8 @@
           git fetch upstream
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4
+        with:
+          add-job-summary: never
       - name: Run Integration Tests
         run: ./gradlew $GradleArguments
       - name: Package Build Artifacts

--- a/.github/workflows/UnitTests-core.yml
+++ b/.github/workflows/UnitTests-core.yml
@@ -34,6 +34,7 @@ jobs:
           java-version: ${{ matrix.jdk }}
           distribution: 'temurin'
           cache: 'gradle'
+          add-job-summary: never
       - shell: bash
         run: |
           git remote set-head origin --auto

--- a/.github/workflows/UnitTests-core.yml
+++ b/.github/workflows/UnitTests-core.yml
@@ -42,6 +42,8 @@ jobs:
           git fetch upstream
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4
+        with:
+          add-job-summary: never
       - name: Run Unit Tests with Code Coverage
         run: ./gradlew  -x :internal:venice-avro-compatibility-test:test  ${{ inputs.arg }}
       - name: Package Build Artifacts

--- a/.github/workflows/UnitTests-core.yml
+++ b/.github/workflows/UnitTests-core.yml
@@ -58,7 +58,7 @@ jobs:
         if: always()
         with:
          check_name: ${{ inputs.artifact_suffix }}-jdk${{ matrix.jdk }} Report
-         comment: true
+         comment: false
          annotate_only: true
          flaky_summary: true
          commit: ${{github.event.workflow_run.head_sha}}

--- a/.github/workflows/UnitTests-core.yml
+++ b/.github/workflows/UnitTests-core.yml
@@ -23,6 +23,7 @@ jobs:
       checks: write
       id-token: write
       pull-requests: write
+      issues: write
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/UnitTests-core.yml
+++ b/.github/workflows/UnitTests-core.yml
@@ -22,6 +22,7 @@ jobs:
       contents: read
       checks: write
       id-token: write
+      pull-requests: write
     steps:
       - uses: actions/checkout@v4
         with:
@@ -50,13 +51,17 @@ jobs:
           rsync -R --files-from=artifacts.list . ${{ inputs.artifact_suffix }}-artifacts
           tar -zcvf ${{ inputs.artifact_suffix }}-jdk${{ matrix.jdk }}-logs.tar.gz ${{ inputs.artifact_suffix }}-artifacts
       - name: Publish Test Report
-        continue-on-error: true
         env:
           NODE_OPTIONS: "--max_old_space_size=8192"
-        uses: mikepenz/action-junit-report@v3
-        if: always() 
+        uses: mikepenz/action-junit-report@v5
+        if: always()
         with:
          check_name: ${{ inputs.artifact_suffix }}-jdk${{ matrix.jdk }} Report
+         comment: true
+         annotate_only: true
+         flaky_summary: true
+         commit: ${{github.event.workflow_run.head_sha}}
+         detailed_summary: true
          report_paths: '**/build/test-results/test/TEST-*.xml'
       - name: Upload Build Artifacts
         if: success() || failure()

--- a/.github/workflows/UnitTests-core.yml
+++ b/.github/workflows/UnitTests-core.yml
@@ -51,6 +51,7 @@ jobs:
           rsync -R --files-from=artifacts.list . ${{ inputs.artifact_suffix }}-artifacts
           tar -zcvf ${{ inputs.artifact_suffix }}-jdk${{ matrix.jdk }}-logs.tar.gz ${{ inputs.artifact_suffix }}-artifacts
       - name: Publish Test Report
+        continue-on-error: true
         env:
           NODE_OPTIONS: "--max_old_space_size=8192"
         uses: mikepenz/action-junit-report@v5

--- a/.github/workflows/UnitTests-core.yml
+++ b/.github/workflows/UnitTests-core.yml
@@ -34,7 +34,6 @@ jobs:
           java-version: ${{ matrix.jdk }}
           distribution: 'temurin'
           cache: 'gradle'
-          add-job-summary: never
       - shell: bash
         run: |
           git remote set-head origin --auto

--- a/.github/workflows/VeniceCI-CompatibilityTests.yml
+++ b/.github/workflows/VeniceCI-CompatibilityTests.yml
@@ -30,6 +30,8 @@ jobs:
           git fetch upstream
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4
+        with:
+          add-job-summary: never
       - name: Run Avro Compatibility Tests
         run: ./gradlew -DmaxParallelForks=2 --parallel :internal:venice-avro-compatibility-test:test --continue
       - name: Package Build Artifacts

--- a/.github/workflows/VeniceCI-CompatibilityTests.yml
+++ b/.github/workflows/VeniceCI-CompatibilityTests.yml
@@ -89,6 +89,8 @@ jobs:
           git fetch upstream
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4
+        with:
+          add-job-summary: never
       - name: Run alpini unit tests
         run: ./gradlew --continue --no-daemon -DmaxParallelForks=1 alpiniUnitTest
       - name: Package Build Artifacts
@@ -131,6 +133,8 @@ jobs:
           git fetch upstream
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4
+        with:
+          add-job-summary: never
       - name: Build with gradle
         run: ./gradlew assemble --continue --no-daemon -DforkEvery=1 -DmaxParallelForks=1
 

--- a/.github/workflows/VeniceCI-E2ETests.yml
+++ b/.github/workflows/VeniceCI-E2ETests.yml
@@ -24,6 +24,7 @@ jobs:
      id-token: write
      contents: read
      checks: write
+     pull-requests: write
     timeout-minutes: 120
     concurrency:
      group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-jdk${{ matrix.jdk }}-IntegrationTests_1000
@@ -58,20 +59,19 @@ jobs:
           find . -path "**/build/reports/*" -or -path "**/build/test-results/*" > artifacts.list
           rsync -R --files-from=artifacts.list . ${{ github.job }}-artifacts
           tar -zcvf ${{ github.job }}-jdk${{ matrix.jdk }}-logs.tar.gz ${{ github.job }}-artifacts
-      - name: Generate Fork Repo Test Reports
-        if: ${{ (github.repository_owner != 'linkedin') && (success() || failure()) }}
-        uses: dorny/test-reporter@v1.9.1
+      - name: Publish Test Report
         env:
-         NODE_OPTIONS: --max-old-space-size=9182
+          NODE_OPTIONS: "--max_old_space_size=8192"
+        uses: mikepenz/action-junit-report@v5
+        if: always()
         with:
-         token: ${{ secrets.GITHUB_TOKEN }}
-         name: ${{ github.job }} Test Reports       # Name where it report the test results
-         path: '**/TEST-*.xml'
-         fail-on-error: 'false'
-         max-annotations: '10'
-         list-tests: 'all'
-         list-suites: 'all'
-         reporter: java-junit
+         check_name: ${{ inputs.artifact_suffix }}-jdk${{ matrix.jdk }} Report
+         comment: true
+         annotate_only: true
+         flaky_summary: true
+         commit: ${{github.event.workflow_run.head_sha}}
+         detailed_summary: true
+         report_paths: '**/build/test-results/test/TEST-*.xml'
       - name: Upload Build Artifacts
         if: success() || failure()
         uses: actions/upload-artifact@v4
@@ -101,6 +101,7 @@ jobs:
      id-token: write
      contents: read
      checks: write
+     pull-requests: write
     timeout-minutes: 120
     concurrency:
      group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-jdk${{ matrix.jdk }}-IntegrationTests_1010
@@ -135,20 +136,19 @@ jobs:
           find . -path "**/build/reports/*" -or -path "**/build/test-results/*" > artifacts.list
           rsync -R --files-from=artifacts.list . ${{ github.job }}-artifacts
           tar -zcvf ${{ github.job }}-jdk${{ matrix.jdk }}-logs.tar.gz ${{ github.job }}-artifacts
-      - name: Generate Fork Repo Test Reports
-        if: ${{ (github.repository_owner != 'linkedin') && (success() || failure()) }}
-        uses: dorny/test-reporter@v1.9.1
+      - name: Publish Test Report
         env:
-         NODE_OPTIONS: --max-old-space-size=9182
+          NODE_OPTIONS: "--max_old_space_size=8192"
+        uses: mikepenz/action-junit-report@v5
+        if: always()
         with:
-         token: ${{ secrets.GITHUB_TOKEN }}
-         name: ${{ github.job }} Test Reports       # Name where it report the test results
-         path: '**/TEST-*.xml'
-         fail-on-error: 'false'
-         max-annotations: '10'
-         list-tests: 'all'
-         list-suites: 'all'
-         reporter: java-junit
+         check_name: ${{ inputs.artifact_suffix }}-jdk${{ matrix.jdk }} Report
+         comment: true
+         annotate_only: true
+         flaky_summary: true
+         commit: ${{github.event.workflow_run.head_sha}}
+         detailed_summary: true
+         report_paths: '**/build/test-results/test/TEST-*.xml'
       - name: Upload Build Artifacts
         if: success() || failure()
         uses: actions/upload-artifact@v4
@@ -178,6 +178,7 @@ jobs:
      id-token: write
      contents: read
      checks: write
+     pull-requests: write
     timeout-minutes: 120
     concurrency:
      group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-jdk${{ matrix.jdk }}-IntegrationTests_1020
@@ -212,20 +213,19 @@ jobs:
           find . -path "**/build/reports/*" -or -path "**/build/test-results/*" > artifacts.list
           rsync -R --files-from=artifacts.list . ${{ github.job }}-artifacts
           tar -zcvf ${{ github.job }}-jdk${{ matrix.jdk }}-logs.tar.gz ${{ github.job }}-artifacts
-      - name: Generate Fork Repo Test Reports
-        if: ${{ (github.repository_owner != 'linkedin') && (success() || failure()) }}
-        uses: dorny/test-reporter@v1.9.1
+      - name: Publish Test Report
         env:
-         NODE_OPTIONS: --max-old-space-size=9182
+          NODE_OPTIONS: "--max_old_space_size=8192"
+        uses: mikepenz/action-junit-report@v5
+        if: always()
         with:
-         token: ${{ secrets.GITHUB_TOKEN }}
-         name: ${{ github.job }} Test Reports       # Name where it report the test results
-         path: '**/TEST-*.xml'
-         fail-on-error: 'false'
-         max-annotations: '10'
-         list-tests: 'all'
-         list-suites: 'all'
-         reporter: java-junit
+         check_name: ${{ inputs.artifact_suffix }}-jdk${{ matrix.jdk }} Report
+         comment: true
+         annotate_only: true
+         flaky_summary: true
+         commit: ${{github.event.workflow_run.head_sha}}
+         detailed_summary: true
+         report_paths: '**/build/test-results/test/TEST-*.xml'
       - name: Upload Build Artifacts
         if: success() || failure()
         uses: actions/upload-artifact@v4
@@ -255,6 +255,7 @@ jobs:
      id-token: write
      contents: read
      checks: write
+     pull-requests: write
     timeout-minutes: 120
     concurrency:
      group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-jdk${{ matrix.jdk }}-IntegrationTests_1030
@@ -289,20 +290,19 @@ jobs:
           find . -path "**/build/reports/*" -or -path "**/build/test-results/*" > artifacts.list
           rsync -R --files-from=artifacts.list . ${{ github.job }}-artifacts
           tar -zcvf ${{ github.job }}-jdk${{ matrix.jdk }}-logs.tar.gz ${{ github.job }}-artifacts
-      - name: Generate Fork Repo Test Reports
-        if: ${{ (github.repository_owner != 'linkedin') && (success() || failure()) }}
-        uses: dorny/test-reporter@v1.9.1
+      - name: Publish Test Report
         env:
-         NODE_OPTIONS: --max-old-space-size=9182
+          NODE_OPTIONS: "--max_old_space_size=8192"
+        uses: mikepenz/action-junit-report@v5
+        if: always()
         with:
-         token: ${{ secrets.GITHUB_TOKEN }}
-         name: ${{ github.job }} Test Reports       # Name where it report the test results
-         path: '**/TEST-*.xml'
-         fail-on-error: 'false'
-         max-annotations: '10'
-         list-tests: 'all'
-         list-suites: 'all'
-         reporter: java-junit
+         check_name: ${{ inputs.artifact_suffix }}-jdk${{ matrix.jdk }} Report
+         comment: true
+         annotate_only: true
+         flaky_summary: true
+         commit: ${{github.event.workflow_run.head_sha}}
+         detailed_summary: true
+         report_paths: '**/build/test-results/test/TEST-*.xml'
       - name: Upload Build Artifacts
         if: success() || failure()
         uses: actions/upload-artifact@v4
@@ -332,6 +332,7 @@ jobs:
      id-token: write
      contents: read
      checks: write
+     pull-requests: write
     timeout-minutes: 120
     concurrency:
      group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-jdk${{ matrix.jdk }}-IntegrationTests_1040
@@ -366,20 +367,19 @@ jobs:
           find . -path "**/build/reports/*" -or -path "**/build/test-results/*" > artifacts.list
           rsync -R --files-from=artifacts.list . ${{ github.job }}-artifacts
           tar -zcvf ${{ github.job }}-jdk${{ matrix.jdk }}-logs.tar.gz ${{ github.job }}-artifacts
-      - name: Generate Fork Repo Test Reports
-        if: ${{ (github.repository_owner != 'linkedin') && (success() || failure()) }}
-        uses: dorny/test-reporter@v1.9.1
+      - name: Publish Test Report
         env:
-         NODE_OPTIONS: --max-old-space-size=9182
+          NODE_OPTIONS: "--max_old_space_size=8192"
+        uses: mikepenz/action-junit-report@v5
+        if: always()
         with:
-         token: ${{ secrets.GITHUB_TOKEN }}
-         name: ${{ github.job }} Test Reports       # Name where it report the test results
-         path: '**/TEST-*.xml'
-         fail-on-error: 'false'
-         max-annotations: '10'
-         list-tests: 'all'
-         list-suites: 'all'
-         reporter: java-junit
+         check_name: ${{ inputs.artifact_suffix }}-jdk${{ matrix.jdk }} Report
+         comment: true
+         annotate_only: true
+         flaky_summary: true
+         commit: ${{github.event.workflow_run.head_sha}}
+         detailed_summary: true
+         report_paths: '**/build/test-results/test/TEST-*.xml'
       - name: Upload Build Artifacts
         if: success() || failure()
         uses: actions/upload-artifact@v4
@@ -409,6 +409,7 @@ jobs:
      id-token: write
      contents: read
      checks: write
+     pull-requests: write
     timeout-minutes: 120
     concurrency:
      group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-jdk${{ matrix.jdk }}-IntegrationTests_1050
@@ -443,20 +444,19 @@ jobs:
           find . -path "**/build/reports/*" -or -path "**/build/test-results/*" > artifacts.list
           rsync -R --files-from=artifacts.list . ${{ github.job }}-artifacts
           tar -zcvf ${{ github.job }}-jdk${{ matrix.jdk }}-logs.tar.gz ${{ github.job }}-artifacts
-      - name: Generate Fork Repo Test Reports
-        if: ${{ (github.repository_owner != 'linkedin') && (success() || failure()) }}
-        uses: dorny/test-reporter@v1.9.1
+      - name: Publish Test Report
         env:
-         NODE_OPTIONS: --max-old-space-size=9182
+          NODE_OPTIONS: "--max_old_space_size=8192"
+        uses: mikepenz/action-junit-report@v5
+        if: always()
         with:
-         token: ${{ secrets.GITHUB_TOKEN }}
-         name: ${{ github.job }} Test Reports       # Name where it report the test results
-         path: '**/TEST-*.xml'
-         fail-on-error: 'false'
-         max-annotations: '10'
-         list-tests: 'all'
-         list-suites: 'all'
-         reporter: java-junit
+         check_name: ${{ inputs.artifact_suffix }}-jdk${{ matrix.jdk }} Report
+         comment: true
+         annotate_only: true
+         flaky_summary: true
+         commit: ${{github.event.workflow_run.head_sha}}
+         detailed_summary: true
+         report_paths: '**/build/test-results/test/TEST-*.xml'
       - name: Upload Build Artifacts
         if: success() || failure()
         uses: actions/upload-artifact@v4
@@ -486,6 +486,7 @@ jobs:
      id-token: write
      contents: read
      checks: write
+     pull-requests: write
     timeout-minutes: 120
     concurrency:
      group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-jdk${{ matrix.jdk }}-IntegrationTests_1060
@@ -520,20 +521,19 @@ jobs:
           find . -path "**/build/reports/*" -or -path "**/build/test-results/*" > artifacts.list
           rsync -R --files-from=artifacts.list . ${{ github.job }}-artifacts
           tar -zcvf ${{ github.job }}-jdk${{ matrix.jdk }}-logs.tar.gz ${{ github.job }}-artifacts
-      - name: Generate Fork Repo Test Reports
-        if: ${{ (github.repository_owner != 'linkedin') && (success() || failure()) }}
-        uses: dorny/test-reporter@v1.9.1
+      - name: Publish Test Report
         env:
-         NODE_OPTIONS: --max-old-space-size=9182
+          NODE_OPTIONS: "--max_old_space_size=8192"
+        uses: mikepenz/action-junit-report@v5
+        if: always()
         with:
-         token: ${{ secrets.GITHUB_TOKEN }}
-         name: ${{ github.job }} Test Reports       # Name where it report the test results
-         path: '**/TEST-*.xml'
-         fail-on-error: 'false'
-         max-annotations: '10'
-         list-tests: 'all'
-         list-suites: 'all'
-         reporter: java-junit
+         check_name: ${{ inputs.artifact_suffix }}-jdk${{ matrix.jdk }} Report
+         comment: true
+         annotate_only: true
+         flaky_summary: true
+         commit: ${{github.event.workflow_run.head_sha}}
+         detailed_summary: true
+         report_paths: '**/build/test-results/test/TEST-*.xml'
       - name: Upload Build Artifacts
         if: success() || failure()
         uses: actions/upload-artifact@v4
@@ -563,6 +563,7 @@ jobs:
      id-token: write
      contents: read
      checks: write
+     pull-requests: write
     timeout-minutes: 120
     concurrency:
      group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-jdk${{ matrix.jdk }}-IntegrationTests_1070
@@ -597,20 +598,19 @@ jobs:
           find . -path "**/build/reports/*" -or -path "**/build/test-results/*" > artifacts.list
           rsync -R --files-from=artifacts.list . ${{ github.job }}-artifacts
           tar -zcvf ${{ github.job }}-jdk${{ matrix.jdk }}-logs.tar.gz ${{ github.job }}-artifacts
-      - name: Generate Fork Repo Test Reports
-        if: ${{ (github.repository_owner != 'linkedin') && (success() || failure()) }}
-        uses: dorny/test-reporter@v1.9.1
+      - name: Publish Test Report
         env:
-         NODE_OPTIONS: --max-old-space-size=9182
+          NODE_OPTIONS: "--max_old_space_size=8192"
+        uses: mikepenz/action-junit-report@v5
+        if: always()
         with:
-         token: ${{ secrets.GITHUB_TOKEN }}
-         name: ${{ github.job }} Test Reports       # Name where it report the test results
-         path: '**/TEST-*.xml'
-         fail-on-error: 'false'
-         max-annotations: '10'
-         list-tests: 'all'
-         list-suites: 'all'
-         reporter: java-junit
+         check_name: ${{ inputs.artifact_suffix }}-jdk${{ matrix.jdk }} Report
+         comment: true
+         annotate_only: true
+         flaky_summary: true
+         commit: ${{github.event.workflow_run.head_sha}}
+         detailed_summary: true
+         report_paths: '**/build/test-results/test/TEST-*.xml'
       - name: Upload Build Artifacts
         if: success() || failure()
         uses: actions/upload-artifact@v4
@@ -640,6 +640,7 @@ jobs:
      id-token: write
      contents: read
      checks: write
+     pull-requests: write
     timeout-minutes: 120
     concurrency:
      group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-jdk${{ matrix.jdk }}-IntegrationTests_1080
@@ -674,20 +675,19 @@ jobs:
           find . -path "**/build/reports/*" -or -path "**/build/test-results/*" > artifacts.list
           rsync -R --files-from=artifacts.list . ${{ github.job }}-artifacts
           tar -zcvf ${{ github.job }}-jdk${{ matrix.jdk }}-logs.tar.gz ${{ github.job }}-artifacts
-      - name: Generate Fork Repo Test Reports
-        if: ${{ (github.repository_owner != 'linkedin') && (success() || failure()) }}
-        uses: dorny/test-reporter@v1.9.1
+      - name: Publish Test Report
         env:
-         NODE_OPTIONS: --max-old-space-size=9182
+          NODE_OPTIONS: "--max_old_space_size=8192"
+        uses: mikepenz/action-junit-report@v5
+        if: always()
         with:
-         token: ${{ secrets.GITHUB_TOKEN }}
-         name: ${{ github.job }} Test Reports       # Name where it report the test results
-         path: '**/TEST-*.xml'
-         fail-on-error: 'false'
-         max-annotations: '10'
-         list-tests: 'all'
-         list-suites: 'all'
-         reporter: java-junit
+         check_name: ${{ inputs.artifact_suffix }}-jdk${{ matrix.jdk }} Report
+         comment: true
+         annotate_only: true
+         flaky_summary: true
+         commit: ${{github.event.workflow_run.head_sha}}
+         detailed_summary: true
+         report_paths: '**/build/test-results/test/TEST-*.xml'
       - name: Upload Build Artifacts
         if: success() || failure()
         uses: actions/upload-artifact@v4
@@ -717,6 +717,7 @@ jobs:
      id-token: write
      contents: read
      checks: write
+     pull-requests: write
     timeout-minutes: 120
     concurrency:
      group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-jdk${{ matrix.jdk }}-IntegrationTests_1090
@@ -751,20 +752,19 @@ jobs:
           find . -path "**/build/reports/*" -or -path "**/build/test-results/*" > artifacts.list
           rsync -R --files-from=artifacts.list . ${{ github.job }}-artifacts
           tar -zcvf ${{ github.job }}-jdk${{ matrix.jdk }}-logs.tar.gz ${{ github.job }}-artifacts
-      - name: Generate Fork Repo Test Reports
-        if: ${{ (github.repository_owner != 'linkedin') && (success() || failure()) }}
-        uses: dorny/test-reporter@v1.9.1
+      - name: Publish Test Report
         env:
-         NODE_OPTIONS: --max-old-space-size=9182
+          NODE_OPTIONS: "--max_old_space_size=8192"
+        uses: mikepenz/action-junit-report@v5
+        if: always()
         with:
-         token: ${{ secrets.GITHUB_TOKEN }}
-         name: ${{ github.job }} Test Reports       # Name where it report the test results
-         path: '**/TEST-*.xml'
-         fail-on-error: 'false'
-         max-annotations: '10'
-         list-tests: 'all'
-         list-suites: 'all'
-         reporter: java-junit
+         check_name: ${{ inputs.artifact_suffix }}-jdk${{ matrix.jdk }} Report
+         comment: true
+         annotate_only: true
+         flaky_summary: true
+         commit: ${{github.event.workflow_run.head_sha}}
+         detailed_summary: true
+         report_paths: '**/build/test-results/test/TEST-*.xml'
       - name: Upload Build Artifacts
         if: success() || failure()
         uses: actions/upload-artifact@v4
@@ -794,6 +794,7 @@ jobs:
      id-token: write
      contents: read
      checks: write
+     pull-requests: write
     timeout-minutes: 120
     concurrency:
      group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-jdk${{ matrix.jdk }}-IntegrationTests_1100
@@ -828,20 +829,19 @@ jobs:
           find . -path "**/build/reports/*" -or -path "**/build/test-results/*" > artifacts.list
           rsync -R --files-from=artifacts.list . ${{ github.job }}-artifacts
           tar -zcvf ${{ github.job }}-jdk${{ matrix.jdk }}-logs.tar.gz ${{ github.job }}-artifacts
-      - name: Generate Fork Repo Test Reports
-        if: ${{ (github.repository_owner != 'linkedin') && (success() || failure()) }}
-        uses: dorny/test-reporter@v1.9.1
+      - name: Publish Test Report
         env:
-         NODE_OPTIONS: --max-old-space-size=9182
+          NODE_OPTIONS: "--max_old_space_size=8192"
+        uses: mikepenz/action-junit-report@v5
+        if: always()
         with:
-         token: ${{ secrets.GITHUB_TOKEN }}
-         name: ${{ github.job }} Test Reports       # Name where it report the test results
-         path: '**/TEST-*.xml'
-         fail-on-error: 'false'
-         max-annotations: '10'
-         list-tests: 'all'
-         list-suites: 'all'
-         reporter: java-junit
+         check_name: ${{ inputs.artifact_suffix }}-jdk${{ matrix.jdk }} Report
+         comment: true
+         annotate_only: true
+         flaky_summary: true
+         commit: ${{github.event.workflow_run.head_sha}}
+         detailed_summary: true
+         report_paths: '**/build/test-results/test/TEST-*.xml'
       - name: Upload Build Artifacts
         if: success() || failure()
         uses: actions/upload-artifact@v4
@@ -871,6 +871,7 @@ jobs:
      id-token: write
      contents: read
      checks: write
+     pull-requests: write
     timeout-minutes: 120
     concurrency:
      group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-jdk${{ matrix.jdk }}-IntegrationTests_1110
@@ -905,20 +906,19 @@ jobs:
           find . -path "**/build/reports/*" -or -path "**/build/test-results/*" > artifacts.list
           rsync -R --files-from=artifacts.list . ${{ github.job }}-artifacts
           tar -zcvf ${{ github.job }}-jdk${{ matrix.jdk }}-logs.tar.gz ${{ github.job }}-artifacts
-      - name: Generate Fork Repo Test Reports
-        if: ${{ (github.repository_owner != 'linkedin') && (success() || failure()) }}
-        uses: dorny/test-reporter@v1.9.1
+      - name: Publish Test Report
         env:
-         NODE_OPTIONS: --max-old-space-size=9182
+          NODE_OPTIONS: "--max_old_space_size=8192"
+        uses: mikepenz/action-junit-report@v5
+        if: always()
         with:
-         token: ${{ secrets.GITHUB_TOKEN }}
-         name: ${{ github.job }} Test Reports       # Name where it report the test results
-         path: '**/TEST-*.xml'
-         fail-on-error: 'false'
-         max-annotations: '10'
-         list-tests: 'all'
-         list-suites: 'all'
-         reporter: java-junit
+         check_name: ${{ inputs.artifact_suffix }}-jdk${{ matrix.jdk }} Report
+         comment: true
+         annotate_only: true
+         flaky_summary: true
+         commit: ${{github.event.workflow_run.head_sha}}
+         detailed_summary: true
+         report_paths: '**/build/test-results/test/TEST-*.xml'
       - name: Upload Build Artifacts
         if: success() || failure()
         uses: actions/upload-artifact@v4
@@ -948,6 +948,7 @@ jobs:
      id-token: write
      contents: read
      checks: write
+     pull-requests: write
     timeout-minutes: 120
     concurrency:
      group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-jdk${{ matrix.jdk }}-IntegrationTests_1120
@@ -982,20 +983,19 @@ jobs:
           find . -path "**/build/reports/*" -or -path "**/build/test-results/*" > artifacts.list
           rsync -R --files-from=artifacts.list . ${{ github.job }}-artifacts
           tar -zcvf ${{ github.job }}-jdk${{ matrix.jdk }}-logs.tar.gz ${{ github.job }}-artifacts
-      - name: Generate Fork Repo Test Reports
-        if: ${{ (github.repository_owner != 'linkedin') && (success() || failure()) }}
-        uses: dorny/test-reporter@v1.9.1
+      - name: Publish Test Report
         env:
-         NODE_OPTIONS: --max-old-space-size=9182
+          NODE_OPTIONS: "--max_old_space_size=8192"
+        uses: mikepenz/action-junit-report@v5
+        if: always()
         with:
-         token: ${{ secrets.GITHUB_TOKEN }}
-         name: ${{ github.job }} Test Reports       # Name where it report the test results
-         path: '**/TEST-*.xml'
-         fail-on-error: 'false'
-         max-annotations: '10'
-         list-tests: 'all'
-         list-suites: 'all'
-         reporter: java-junit
+         check_name: ${{ inputs.artifact_suffix }}-jdk${{ matrix.jdk }} Report
+         comment: true
+         annotate_only: true
+         flaky_summary: true
+         commit: ${{github.event.workflow_run.head_sha}}
+         detailed_summary: true
+         report_paths: '**/build/test-results/test/TEST-*.xml'
       - name: Upload Build Artifacts
         if: success() || failure()
         uses: actions/upload-artifact@v4
@@ -1025,6 +1025,7 @@ jobs:
      id-token: write
      contents: read
      checks: write
+     pull-requests: write
     timeout-minutes: 120
     concurrency:
      group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-jdk${{ matrix.jdk }}-IntegrationTests_1130
@@ -1059,20 +1060,19 @@ jobs:
           find . -path "**/build/reports/*" -or -path "**/build/test-results/*" > artifacts.list
           rsync -R --files-from=artifacts.list . ${{ github.job }}-artifacts
           tar -zcvf ${{ github.job }}-jdk${{ matrix.jdk }}-logs.tar.gz ${{ github.job }}-artifacts
-      - name: Generate Fork Repo Test Reports
-        if: ${{ (github.repository_owner != 'linkedin') && (success() || failure()) }}
-        uses: dorny/test-reporter@v1.9.1
+      - name: Publish Test Report
         env:
-         NODE_OPTIONS: --max-old-space-size=9182
+          NODE_OPTIONS: "--max_old_space_size=8192"
+        uses: mikepenz/action-junit-report@v5
+        if: always()
         with:
-         token: ${{ secrets.GITHUB_TOKEN }}
-         name: ${{ github.job }} Test Reports       # Name where it report the test results
-         path: '**/TEST-*.xml'
-         fail-on-error: 'false'
-         max-annotations: '10'
-         list-tests: 'all'
-         list-suites: 'all'
-         reporter: java-junit
+         check_name: ${{ inputs.artifact_suffix }}-jdk${{ matrix.jdk }} Report
+         comment: true
+         annotate_only: true
+         flaky_summary: true
+         commit: ${{github.event.workflow_run.head_sha}}
+         detailed_summary: true
+         report_paths: '**/build/test-results/test/TEST-*.xml'
       - name: Upload Build Artifacts
         if: success() || failure()
         uses: actions/upload-artifact@v4
@@ -1102,6 +1102,7 @@ jobs:
      id-token: write
      contents: read
      checks: write
+     pull-requests: write
     timeout-minutes: 120
     concurrency:
      group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-jdk${{ matrix.jdk }}-IntegrationTests_1200
@@ -1136,20 +1137,19 @@ jobs:
           find . -path "**/build/reports/*" -or -path "**/build/test-results/*" > artifacts.list
           rsync -R --files-from=artifacts.list . ${{ github.job }}-artifacts
           tar -zcvf ${{ github.job }}-jdk${{ matrix.jdk }}-logs.tar.gz ${{ github.job }}-artifacts
-      - name: Generate Fork Repo Test Reports
-        if: ${{ (github.repository_owner != 'linkedin') && (success() || failure()) }}
-        uses: dorny/test-reporter@v1.9.1
+      - name: Publish Test Report
         env:
-         NODE_OPTIONS: --max-old-space-size=9182
+          NODE_OPTIONS: "--max_old_space_size=8192"
+        uses: mikepenz/action-junit-report@v5
+        if: always()
         with:
-         token: ${{ secrets.GITHUB_TOKEN }}
-         name: ${{ github.job }} Test Reports       # Name where it report the test results
-         path: '**/TEST-*.xml'
-         fail-on-error: 'false'
-         max-annotations: '10'
-         list-tests: 'all'
-         list-suites: 'all'
-         reporter: java-junit
+         check_name: ${{ inputs.artifact_suffix }}-jdk${{ matrix.jdk }} Report
+         comment: true
+         annotate_only: true
+         flaky_summary: true
+         commit: ${{github.event.workflow_run.head_sha}}
+         detailed_summary: true
+         report_paths: '**/build/test-results/test/TEST-*.xml'
       - name: Upload Build Artifacts
         if: success() || failure()
         uses: actions/upload-artifact@v4
@@ -1179,6 +1179,7 @@ jobs:
      id-token: write
      contents: read
      checks: write
+     pull-requests: write
     timeout-minutes: 120
     concurrency:
      group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-jdk${{ matrix.jdk }}-IntegrationTests_1210
@@ -1213,20 +1214,19 @@ jobs:
           find . -path "**/build/reports/*" -or -path "**/build/test-results/*" > artifacts.list
           rsync -R --files-from=artifacts.list . ${{ github.job }}-artifacts
           tar -zcvf ${{ github.job }}-jdk${{ matrix.jdk }}-logs.tar.gz ${{ github.job }}-artifacts
-      - name: Generate Fork Repo Test Reports
-        if: ${{ (github.repository_owner != 'linkedin') && (success() || failure()) }}
-        uses: dorny/test-reporter@v1.9.1
+      - name: Publish Test Report
         env:
-         NODE_OPTIONS: --max-old-space-size=9182
+          NODE_OPTIONS: "--max_old_space_size=8192"
+        uses: mikepenz/action-junit-report@v5
+        if: always()
         with:
-         token: ${{ secrets.GITHUB_TOKEN }}
-         name: ${{ github.job }} Test Reports       # Name where it report the test results
-         path: '**/TEST-*.xml'
-         fail-on-error: 'false'
-         max-annotations: '10'
-         list-tests: 'all'
-         list-suites: 'all'
-         reporter: java-junit
+         check_name: ${{ inputs.artifact_suffix }}-jdk${{ matrix.jdk }} Report
+         comment: true
+         annotate_only: true
+         flaky_summary: true
+         commit: ${{github.event.workflow_run.head_sha}}
+         detailed_summary: true
+         report_paths: '**/build/test-results/test/TEST-*.xml'
       - name: Upload Build Artifacts
         if: success() || failure()
         uses: actions/upload-artifact@v4
@@ -1256,6 +1256,7 @@ jobs:
      id-token: write
      contents: read
      checks: write
+     pull-requests: write
     timeout-minutes: 120
     concurrency:
      group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-jdk${{ matrix.jdk }}-IntegrationTests_1220
@@ -1290,20 +1291,19 @@ jobs:
           find . -path "**/build/reports/*" -or -path "**/build/test-results/*" > artifacts.list
           rsync -R --files-from=artifacts.list . ${{ github.job }}-artifacts
           tar -zcvf ${{ github.job }}-jdk${{ matrix.jdk }}-logs.tar.gz ${{ github.job }}-artifacts
-      - name: Generate Fork Repo Test Reports
-        if: ${{ (github.repository_owner != 'linkedin') && (success() || failure()) }}
-        uses: dorny/test-reporter@v1.9.1
+      - name: Publish Test Report
         env:
-         NODE_OPTIONS: --max-old-space-size=9182
+          NODE_OPTIONS: "--max_old_space_size=8192"
+        uses: mikepenz/action-junit-report@v5
+        if: always()
         with:
-         token: ${{ secrets.GITHUB_TOKEN }}
-         name: ${{ github.job }} Test Reports       # Name where it report the test results
-         path: '**/TEST-*.xml'
-         fail-on-error: 'false'
-         max-annotations: '10'
-         list-tests: 'all'
-         list-suites: 'all'
-         reporter: java-junit
+         check_name: ${{ inputs.artifact_suffix }}-jdk${{ matrix.jdk }} Report
+         comment: true
+         annotate_only: true
+         flaky_summary: true
+         commit: ${{github.event.workflow_run.head_sha}}
+         detailed_summary: true
+         report_paths: '**/build/test-results/test/TEST-*.xml'
       - name: Upload Build Artifacts
         if: success() || failure()
         uses: actions/upload-artifact@v4
@@ -1333,6 +1333,7 @@ jobs:
      id-token: write
      contents: read
      checks: write
+     pull-requests: write
     timeout-minutes: 120
     concurrency:
      group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-jdk${{ matrix.jdk }}-IntegrationTests_1230
@@ -1367,20 +1368,19 @@ jobs:
           find . -path "**/build/reports/*" -or -path "**/build/test-results/*" > artifacts.list
           rsync -R --files-from=artifacts.list . ${{ github.job }}-artifacts
           tar -zcvf ${{ github.job }}-jdk${{ matrix.jdk }}-logs.tar.gz ${{ github.job }}-artifacts
-      - name: Generate Fork Repo Test Reports
-        if: ${{ (github.repository_owner != 'linkedin') && (success() || failure()) }}
-        uses: dorny/test-reporter@v1.9.1
+      - name: Publish Test Report
         env:
-         NODE_OPTIONS: --max-old-space-size=9182
+          NODE_OPTIONS: "--max_old_space_size=8192"
+        uses: mikepenz/action-junit-report@v5
+        if: always()
         with:
-         token: ${{ secrets.GITHUB_TOKEN }}
-         name: ${{ github.job }} Test Reports       # Name where it report the test results
-         path: '**/TEST-*.xml'
-         fail-on-error: 'false'
-         max-annotations: '10'
-         list-tests: 'all'
-         list-suites: 'all'
-         reporter: java-junit
+         check_name: ${{ inputs.artifact_suffix }}-jdk${{ matrix.jdk }} Report
+         comment: true
+         annotate_only: true
+         flaky_summary: true
+         commit: ${{github.event.workflow_run.head_sha}}
+         detailed_summary: true
+         report_paths: '**/build/test-results/test/TEST-*.xml'
       - name: Upload Build Artifacts
         if: success() || failure()
         uses: actions/upload-artifact@v4
@@ -1410,6 +1410,7 @@ jobs:
      id-token: write
      contents: read
      checks: write
+     pull-requests: write
     timeout-minutes: 120
     concurrency:
      group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-jdk${{ matrix.jdk }}-IntegrationTests_1240
@@ -1444,20 +1445,19 @@ jobs:
           find . -path "**/build/reports/*" -or -path "**/build/test-results/*" > artifacts.list
           rsync -R --files-from=artifacts.list . ${{ github.job }}-artifacts
           tar -zcvf ${{ github.job }}-jdk${{ matrix.jdk }}-logs.tar.gz ${{ github.job }}-artifacts
-      - name: Generate Fork Repo Test Reports
-        if: ${{ (github.repository_owner != 'linkedin') && (success() || failure()) }}
-        uses: dorny/test-reporter@v1.9.1
+      - name: Publish Test Report
         env:
-         NODE_OPTIONS: --max-old-space-size=9182
+          NODE_OPTIONS: "--max_old_space_size=8192"
+        uses: mikepenz/action-junit-report@v5
+        if: always()
         with:
-         token: ${{ secrets.GITHUB_TOKEN }}
-         name: ${{ github.job }} Test Reports       # Name where it report the test results
-         path: '**/TEST-*.xml'
-         fail-on-error: 'false'
-         max-annotations: '10'
-         list-tests: 'all'
-         list-suites: 'all'
-         reporter: java-junit
+         check_name: ${{ inputs.artifact_suffix }}-jdk${{ matrix.jdk }} Report
+         comment: true
+         annotate_only: true
+         flaky_summary: true
+         commit: ${{github.event.workflow_run.head_sha}}
+         detailed_summary: true
+         report_paths: '**/build/test-results/test/TEST-*.xml'
       - name: Upload Build Artifacts
         if: success() || failure()
         uses: actions/upload-artifact@v4
@@ -1487,6 +1487,7 @@ jobs:
      id-token: write
      contents: read
      checks: write
+     pull-requests: write
     timeout-minutes: 120
     concurrency:
      group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-jdk${{ matrix.jdk }}-IntegrationTests_1250
@@ -1521,20 +1522,19 @@ jobs:
           find . -path "**/build/reports/*" -or -path "**/build/test-results/*" > artifacts.list
           rsync -R --files-from=artifacts.list . ${{ github.job }}-artifacts
           tar -zcvf ${{ github.job }}-jdk${{ matrix.jdk }}-logs.tar.gz ${{ github.job }}-artifacts
-      - name: Generate Fork Repo Test Reports
-        if: ${{ (github.repository_owner != 'linkedin') && (success() || failure()) }}
-        uses: dorny/test-reporter@v1.9.1
+      - name: Publish Test Report
         env:
-         NODE_OPTIONS: --max-old-space-size=9182
+          NODE_OPTIONS: "--max_old_space_size=8192"
+        uses: mikepenz/action-junit-report@v5
+        if: always()
         with:
-         token: ${{ secrets.GITHUB_TOKEN }}
-         name: ${{ github.job }} Test Reports       # Name where it report the test results
-         path: '**/TEST-*.xml'
-         fail-on-error: 'false'
-         max-annotations: '10'
-         list-tests: 'all'
-         list-suites: 'all'
-         reporter: java-junit
+         check_name: ${{ inputs.artifact_suffix }}-jdk${{ matrix.jdk }} Report
+         comment: true
+         annotate_only: true
+         flaky_summary: true
+         commit: ${{github.event.workflow_run.head_sha}}
+         detailed_summary: true
+         report_paths: '**/build/test-results/test/TEST-*.xml'
       - name: Upload Build Artifacts
         if: success() || failure()
         uses: actions/upload-artifact@v4
@@ -1564,6 +1564,7 @@ jobs:
      id-token: write
      contents: read
      checks: write
+     pull-requests: write
     timeout-minutes: 120
     concurrency:
      group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-jdk${{ matrix.jdk }}-IntegrationTests_1260
@@ -1598,20 +1599,19 @@ jobs:
           find . -path "**/build/reports/*" -or -path "**/build/test-results/*" > artifacts.list
           rsync -R --files-from=artifacts.list . ${{ github.job }}-artifacts
           tar -zcvf ${{ github.job }}-jdk${{ matrix.jdk }}-logs.tar.gz ${{ github.job }}-artifacts
-      - name: Generate Fork Repo Test Reports
-        if: ${{ (github.repository_owner != 'linkedin') && (success() || failure()) }}
-        uses: dorny/test-reporter@v1.9.1
+      - name: Publish Test Report
         env:
-         NODE_OPTIONS: --max-old-space-size=9182
+          NODE_OPTIONS: "--max_old_space_size=8192"
+        uses: mikepenz/action-junit-report@v5
+        if: always()
         with:
-         token: ${{ secrets.GITHUB_TOKEN }}
-         name: ${{ github.job }} Test Reports       # Name where it report the test results
-         path: '**/TEST-*.xml'
-         fail-on-error: 'false'
-         max-annotations: '10'
-         list-tests: 'all'
-         list-suites: 'all'
-         reporter: java-junit
+         check_name: ${{ inputs.artifact_suffix }}-jdk${{ matrix.jdk }} Report
+         comment: true
+         annotate_only: true
+         flaky_summary: true
+         commit: ${{github.event.workflow_run.head_sha}}
+         detailed_summary: true
+         report_paths: '**/build/test-results/test/TEST-*.xml'
       - name: Upload Build Artifacts
         if: success() || failure()
         uses: actions/upload-artifact@v4
@@ -1641,6 +1641,7 @@ jobs:
      id-token: write
      contents: read
      checks: write
+     pull-requests: write
     timeout-minutes: 120
     concurrency:
      group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-jdk${{ matrix.jdk }}-IntegrationTests_1270
@@ -1675,20 +1676,19 @@ jobs:
           find . -path "**/build/reports/*" -or -path "**/build/test-results/*" > artifacts.list
           rsync -R --files-from=artifacts.list . ${{ github.job }}-artifacts
           tar -zcvf ${{ github.job }}-jdk${{ matrix.jdk }}-logs.tar.gz ${{ github.job }}-artifacts
-      - name: Generate Fork Repo Test Reports
-        if: ${{ (github.repository_owner != 'linkedin') && (success() || failure()) }}
-        uses: dorny/test-reporter@v1.9.1
+      - name: Publish Test Report
         env:
-         NODE_OPTIONS: --max-old-space-size=9182
+          NODE_OPTIONS: "--max_old_space_size=8192"
+        uses: mikepenz/action-junit-report@v5
+        if: always()
         with:
-         token: ${{ secrets.GITHUB_TOKEN }}
-         name: ${{ github.job }} Test Reports       # Name where it report the test results
-         path: '**/TEST-*.xml'
-         fail-on-error: 'false'
-         max-annotations: '10'
-         list-tests: 'all'
-         list-suites: 'all'
-         reporter: java-junit
+         check_name: ${{ inputs.artifact_suffix }}-jdk${{ matrix.jdk }} Report
+         comment: true
+         annotate_only: true
+         flaky_summary: true
+         commit: ${{github.event.workflow_run.head_sha}}
+         detailed_summary: true
+         report_paths: '**/build/test-results/test/TEST-*.xml'
       - name: Upload Build Artifacts
         if: success() || failure()
         uses: actions/upload-artifact@v4
@@ -1718,6 +1718,7 @@ jobs:
      id-token: write
      contents: read
      checks: write
+     pull-requests: write
     timeout-minutes: 120
     concurrency:
      group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-jdk${{ matrix.jdk }}-IntegrationTests_1280
@@ -1752,20 +1753,19 @@ jobs:
           find . -path "**/build/reports/*" -or -path "**/build/test-results/*" > artifacts.list
           rsync -R --files-from=artifacts.list . ${{ github.job }}-artifacts
           tar -zcvf ${{ github.job }}-jdk${{ matrix.jdk }}-logs.tar.gz ${{ github.job }}-artifacts
-      - name: Generate Fork Repo Test Reports
-        if: ${{ (github.repository_owner != 'linkedin') && (success() || failure()) }}
-        uses: dorny/test-reporter@v1.9.1
+      - name: Publish Test Report
         env:
-         NODE_OPTIONS: --max-old-space-size=9182
+          NODE_OPTIONS: "--max_old_space_size=8192"
+        uses: mikepenz/action-junit-report@v5
+        if: always()
         with:
-         token: ${{ secrets.GITHUB_TOKEN }}
-         name: ${{ github.job }} Test Reports       # Name where it report the test results
-         path: '**/TEST-*.xml'
-         fail-on-error: 'false'
-         max-annotations: '10'
-         list-tests: 'all'
-         list-suites: 'all'
-         reporter: java-junit
+         check_name: ${{ inputs.artifact_suffix }}-jdk${{ matrix.jdk }} Report
+         comment: true
+         annotate_only: true
+         flaky_summary: true
+         commit: ${{github.event.workflow_run.head_sha}}
+         detailed_summary: true
+         report_paths: '**/build/test-results/test/TEST-*.xml'
       - name: Upload Build Artifacts
         if: success() || failure()
         uses: actions/upload-artifact@v4
@@ -1795,6 +1795,7 @@ jobs:
      id-token: write
      contents: read
      checks: write
+     pull-requests: write
     timeout-minutes: 120
     concurrency:
      group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-jdk${{ matrix.jdk }}-IntegrationTests_1400
@@ -1829,20 +1830,19 @@ jobs:
           find . -path "**/build/reports/*" -or -path "**/build/test-results/*" > artifacts.list
           rsync -R --files-from=artifacts.list . ${{ github.job }}-artifacts
           tar -zcvf ${{ github.job }}-jdk${{ matrix.jdk }}-logs.tar.gz ${{ github.job }}-artifacts
-      - name: Generate Fork Repo Test Reports
-        if: ${{ (github.repository_owner != 'linkedin') && (success() || failure()) }}
-        uses: dorny/test-reporter@v1.9.1
+      - name: Publish Test Report
         env:
-         NODE_OPTIONS: --max-old-space-size=9182
+          NODE_OPTIONS: "--max_old_space_size=8192"
+        uses: mikepenz/action-junit-report@v5
+        if: always()
         with:
-         token: ${{ secrets.GITHUB_TOKEN }}
-         name: ${{ github.job }} Test Reports       # Name where it report the test results
-         path: '**/TEST-*.xml'
-         fail-on-error: 'false'
-         max-annotations: '10'
-         list-tests: 'all'
-         list-suites: 'all'
-         reporter: java-junit
+         check_name: ${{ inputs.artifact_suffix }}-jdk${{ matrix.jdk }} Report
+         comment: true
+         annotate_only: true
+         flaky_summary: true
+         commit: ${{github.event.workflow_run.head_sha}}
+         detailed_summary: true
+         report_paths: '**/build/test-results/test/TEST-*.xml'
       - name: Upload Build Artifacts
         if: success() || failure()
         uses: actions/upload-artifact@v4
@@ -1872,6 +1872,7 @@ jobs:
      id-token: write
      contents: read
      checks: write
+     pull-requests: write
     timeout-minutes: 120
     concurrency:
      group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-jdk${{ matrix.jdk }}-IntegrationTests_1410
@@ -1906,20 +1907,19 @@ jobs:
           find . -path "**/build/reports/*" -or -path "**/build/test-results/*" > artifacts.list
           rsync -R --files-from=artifacts.list . ${{ github.job }}-artifacts
           tar -zcvf ${{ github.job }}-jdk${{ matrix.jdk }}-logs.tar.gz ${{ github.job }}-artifacts
-      - name: Generate Fork Repo Test Reports
-        if: ${{ (github.repository_owner != 'linkedin') && (success() || failure()) }}
-        uses: dorny/test-reporter@v1.9.1
+      - name: Publish Test Report
         env:
-         NODE_OPTIONS: --max-old-space-size=9182
+          NODE_OPTIONS: "--max_old_space_size=8192"
+        uses: mikepenz/action-junit-report@v5
+        if: always()
         with:
-         token: ${{ secrets.GITHUB_TOKEN }}
-         name: ${{ github.job }} Test Reports       # Name where it report the test results
-         path: '**/TEST-*.xml'
-         fail-on-error: 'false'
-         max-annotations: '10'
-         list-tests: 'all'
-         list-suites: 'all'
-         reporter: java-junit
+         check_name: ${{ inputs.artifact_suffix }}-jdk${{ matrix.jdk }} Report
+         comment: true
+         annotate_only: true
+         flaky_summary: true
+         commit: ${{github.event.workflow_run.head_sha}}
+         detailed_summary: true
+         report_paths: '**/build/test-results/test/TEST-*.xml'
       - name: Upload Build Artifacts
         if: success() || failure()
         uses: actions/upload-artifact@v4
@@ -1949,6 +1949,7 @@ jobs:
      id-token: write
      contents: read
      checks: write
+     pull-requests: write
     timeout-minutes: 120
     concurrency:
      group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-jdk${{ matrix.jdk }}-IntegrationTests_1420
@@ -1983,20 +1984,19 @@ jobs:
           find . -path "**/build/reports/*" -or -path "**/build/test-results/*" > artifacts.list
           rsync -R --files-from=artifacts.list . ${{ github.job }}-artifacts
           tar -zcvf ${{ github.job }}-jdk${{ matrix.jdk }}-logs.tar.gz ${{ github.job }}-artifacts
-      - name: Generate Fork Repo Test Reports
-        if: ${{ (github.repository_owner != 'linkedin') && (success() || failure()) }}
-        uses: dorny/test-reporter@v1.9.1
+      - name: Publish Test Report
         env:
-         NODE_OPTIONS: --max-old-space-size=9182
+          NODE_OPTIONS: "--max_old_space_size=8192"
+        uses: mikepenz/action-junit-report@v5
+        if: always()
         with:
-         token: ${{ secrets.GITHUB_TOKEN }}
-         name: ${{ github.job }} Test Reports       # Name where it report the test results
-         path: '**/TEST-*.xml'
-         fail-on-error: 'false'
-         max-annotations: '10'
-         list-tests: 'all'
-         list-suites: 'all'
-         reporter: java-junit
+         check_name: ${{ inputs.artifact_suffix }}-jdk${{ matrix.jdk }} Report
+         comment: true
+         annotate_only: true
+         flaky_summary: true
+         commit: ${{github.event.workflow_run.head_sha}}
+         detailed_summary: true
+         report_paths: '**/build/test-results/test/TEST-*.xml'
       - name: Upload Build Artifacts
         if: success() || failure()
         uses: actions/upload-artifact@v4
@@ -2026,6 +2026,7 @@ jobs:
      id-token: write
      contents: read
      checks: write
+     pull-requests: write
     timeout-minutes: 120
     concurrency:
      group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-jdk${{ matrix.jdk }}-IntegrationTests_1430
@@ -2060,20 +2061,19 @@ jobs:
           find . -path "**/build/reports/*" -or -path "**/build/test-results/*" > artifacts.list
           rsync -R --files-from=artifacts.list . ${{ github.job }}-artifacts
           tar -zcvf ${{ github.job }}-jdk${{ matrix.jdk }}-logs.tar.gz ${{ github.job }}-artifacts
-      - name: Generate Fork Repo Test Reports
-        if: ${{ (github.repository_owner != 'linkedin') && (success() || failure()) }}
-        uses: dorny/test-reporter@v1.9.1
+      - name: Publish Test Report
         env:
-         NODE_OPTIONS: --max-old-space-size=9182
+          NODE_OPTIONS: "--max_old_space_size=8192"
+        uses: mikepenz/action-junit-report@v5
+        if: always()
         with:
-         token: ${{ secrets.GITHUB_TOKEN }}
-         name: ${{ github.job }} Test Reports       # Name where it report the test results
-         path: '**/TEST-*.xml'
-         fail-on-error: 'false'
-         max-annotations: '10'
-         list-tests: 'all'
-         list-suites: 'all'
-         reporter: java-junit
+         check_name: ${{ inputs.artifact_suffix }}-jdk${{ matrix.jdk }} Report
+         comment: true
+         annotate_only: true
+         flaky_summary: true
+         commit: ${{github.event.workflow_run.head_sha}}
+         detailed_summary: true
+         report_paths: '**/build/test-results/test/TEST-*.xml'
       - name: Upload Build Artifacts
         if: success() || failure()
         uses: actions/upload-artifact@v4
@@ -2103,6 +2103,7 @@ jobs:
      id-token: write
      contents: read
      checks: write
+     pull-requests: write
     timeout-minutes: 120
     concurrency:
      group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-jdk${{ matrix.jdk }}-IntegrationTests_1440
@@ -2137,20 +2138,19 @@ jobs:
           find . -path "**/build/reports/*" -or -path "**/build/test-results/*" > artifacts.list
           rsync -R --files-from=artifacts.list . ${{ github.job }}-artifacts
           tar -zcvf ${{ github.job }}-jdk${{ matrix.jdk }}-logs.tar.gz ${{ github.job }}-artifacts
-      - name: Generate Fork Repo Test Reports
-        if: ${{ (github.repository_owner != 'linkedin') && (success() || failure()) }}
-        uses: dorny/test-reporter@v1.9.1
+      - name: Publish Test Report
         env:
-         NODE_OPTIONS: --max-old-space-size=9182
+          NODE_OPTIONS: "--max_old_space_size=8192"
+        uses: mikepenz/action-junit-report@v5
+        if: always()
         with:
-         token: ${{ secrets.GITHUB_TOKEN }}
-         name: ${{ github.job }} Test Reports       # Name where it report the test results
-         path: '**/TEST-*.xml'
-         fail-on-error: 'false'
-         max-annotations: '10'
-         list-tests: 'all'
-         list-suites: 'all'
-         reporter: java-junit
+         check_name: ${{ inputs.artifact_suffix }}-jdk${{ matrix.jdk }} Report
+         comment: true
+         annotate_only: true
+         flaky_summary: true
+         commit: ${{github.event.workflow_run.head_sha}}
+         detailed_summary: true
+         report_paths: '**/build/test-results/test/TEST-*.xml'
       - name: Upload Build Artifacts
         if: success() || failure()
         uses: actions/upload-artifact@v4
@@ -2180,6 +2180,7 @@ jobs:
      id-token: write
      contents: read
      checks: write
+     pull-requests: write
     timeout-minutes: 120
     concurrency:
      group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-jdk${{ matrix.jdk }}-IntegrationTests_1500
@@ -2214,20 +2215,19 @@ jobs:
           find . -path "**/build/reports/*" -or -path "**/build/test-results/*" > artifacts.list
           rsync -R --files-from=artifacts.list . ${{ github.job }}-artifacts
           tar -zcvf ${{ github.job }}-jdk${{ matrix.jdk }}-logs.tar.gz ${{ github.job }}-artifacts
-      - name: Generate Fork Repo Test Reports
-        if: ${{ (github.repository_owner != 'linkedin') && (success() || failure()) }}
-        uses: dorny/test-reporter@v1.9.1
+      - name: Publish Test Report
         env:
-         NODE_OPTIONS: --max-old-space-size=9182
+          NODE_OPTIONS: "--max_old_space_size=8192"
+        uses: mikepenz/action-junit-report@v5
+        if: always()
         with:
-         token: ${{ secrets.GITHUB_TOKEN }}
-         name: ${{ github.job }} Test Reports       # Name where it report the test results
-         path: '**/TEST-*.xml'
-         fail-on-error: 'false'
-         max-annotations: '10'
-         list-tests: 'all'
-         list-suites: 'all'
-         reporter: java-junit
+         check_name: ${{ inputs.artifact_suffix }}-jdk${{ matrix.jdk }} Report
+         comment: true
+         annotate_only: true
+         flaky_summary: true
+         commit: ${{github.event.workflow_run.head_sha}}
+         detailed_summary: true
+         report_paths: '**/build/test-results/test/TEST-*.xml'
       - name: Upload Build Artifacts
         if: success() || failure()
         uses: actions/upload-artifact@v4
@@ -2257,6 +2257,7 @@ jobs:
      id-token: write
      contents: read
      checks: write
+     pull-requests: write
     timeout-minutes: 120
     concurrency:
      group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-jdk${{ matrix.jdk }}-IntegrationTests_1550
@@ -2291,20 +2292,19 @@ jobs:
           find . -path "**/build/reports/*" -or -path "**/build/test-results/*" > artifacts.list
           rsync -R --files-from=artifacts.list . ${{ github.job }}-artifacts
           tar -zcvf ${{ github.job }}-jdk${{ matrix.jdk }}-logs.tar.gz ${{ github.job }}-artifacts
-      - name: Generate Fork Repo Test Reports
-        if: ${{ (github.repository_owner != 'linkedin') && (success() || failure()) }}
-        uses: dorny/test-reporter@v1.9.1
+      - name: Publish Test Report
         env:
-         NODE_OPTIONS: --max-old-space-size=9182
+          NODE_OPTIONS: "--max_old_space_size=8192"
+        uses: mikepenz/action-junit-report@v5
+        if: always()
         with:
-         token: ${{ secrets.GITHUB_TOKEN }}
-         name: ${{ github.job }} Test Reports       # Name where it report the test results
-         path: '**/TEST-*.xml'
-         fail-on-error: 'false'
-         max-annotations: '10'
-         list-tests: 'all'
-         list-suites: 'all'
-         reporter: java-junit
+         check_name: ${{ inputs.artifact_suffix }}-jdk${{ matrix.jdk }} Report
+         comment: true
+         annotate_only: true
+         flaky_summary: true
+         commit: ${{github.event.workflow_run.head_sha}}
+         detailed_summary: true
+         report_paths: '**/build/test-results/test/TEST-*.xml'
       - name: Upload Build Artifacts
         if: success() || failure()
         uses: actions/upload-artifact@v4
@@ -2334,6 +2334,7 @@ jobs:
      id-token: write
      contents: read
      checks: write
+     pull-requests: write
     timeout-minutes: 120
     concurrency:
      group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-jdk${{ matrix.jdk }}-IntegrationTests_9999
@@ -2368,20 +2369,19 @@ jobs:
           find . -path "**/build/reports/*" -or -path "**/build/test-results/*" > artifacts.list
           rsync -R --files-from=artifacts.list . ${{ github.job }}-artifacts
           tar -zcvf ${{ github.job }}-jdk${{ matrix.jdk }}-logs.tar.gz ${{ github.job }}-artifacts
-      - name: Generate Fork Repo Test Reports
-        if: ${{ (github.repository_owner != 'linkedin') && (success() || failure()) }}
-        uses: dorny/test-reporter@v1.9.1
+      - name: Publish Test Report
         env:
-         NODE_OPTIONS: --max-old-space-size=9182
+          NODE_OPTIONS: "--max_old_space_size=8192"
+        uses: mikepenz/action-junit-report@v5
+        if: always()
         with:
-         token: ${{ secrets.GITHUB_TOKEN }}
-         name: ${{ github.job }} Test Reports       # Name where it report the test results
-         path: '**/TEST-*.xml'
-         fail-on-error: 'false'
-         max-annotations: '10'
-         list-tests: 'all'
-         list-suites: 'all'
-         reporter: java-junit
+         check_name: ${{ inputs.artifact_suffix }}-jdk${{ matrix.jdk }} Report
+         comment: true
+         annotate_only: true
+         flaky_summary: true
+         commit: ${{github.event.workflow_run.head_sha}}
+         detailed_summary: true
+         report_paths: '**/build/test-results/test/TEST-*.xml'
       - name: Upload Build Artifacts
         if: success() || failure()
         uses: actions/upload-artifact@v4

--- a/.github/workflows/VeniceCI-E2ETests.yml
+++ b/.github/workflows/VeniceCI-E2ETests.yml
@@ -62,6 +62,20 @@ jobs:
           find . -path "**/build/reports/*" -or -path "**/build/test-results/*" > artifacts.list
           rsync -R --files-from=artifacts.list . ${{ github.job }}-artifacts
           tar -zcvf ${{ github.job }}-jdk${{ matrix.jdk }}-logs.tar.gz ${{ github.job }}-artifacts
+      - name: Generate Fork Repo Test Reports
+        if: ${{ (github.repository_owner != 'linkedin') && (success() || failure()) }}
+        uses: dorny/test-reporter@v1.9.1
+        env:
+         NODE_OPTIONS: --max-old-space-size=9182
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          name: ${{ github.job }} Test Reports       # Name where it report the test results
+          path: '**/TEST-*.xml'
+          fail-on-error: 'false'
+          max-annotations: '10'
+          list-tests: 'all'
+          list-suites: 'all'
+          reporter: java-junit
       - name: Publish Test Report
         continue-on-error: true
         env:
@@ -69,13 +83,13 @@ jobs:
         uses: mikepenz/action-junit-report@v5
         if: always()
         with:
-         check_name: ${{ github.job }}-jdk${{ matrix.jdk }} Report
-         comment: false
-         annotate_only: true
-         flaky_summary: true
-         commit: ${{github.event.workflow_run.head_sha}}
-         detailed_summary: true
-         report_paths: '**/build/test-results/test/TEST-*.xml'
+          check_name: ${{ github.job }}-jdk${{ matrix.jdk }} Report
+          comment: false
+          annotate_only: true
+          flaky_summary: true
+          commit: ${{github.event.workflow_run.head_sha}}
+          detailed_summary: true
+          report_paths: '**/build/test-results/test/TEST-*.xml'
       - name: Upload Build Artifacts
         if: success() || failure()
         uses: actions/upload-artifact@v4
@@ -143,6 +157,20 @@ jobs:
           find . -path "**/build/reports/*" -or -path "**/build/test-results/*" > artifacts.list
           rsync -R --files-from=artifacts.list . ${{ github.job }}-artifacts
           tar -zcvf ${{ github.job }}-jdk${{ matrix.jdk }}-logs.tar.gz ${{ github.job }}-artifacts
+      - name: Generate Fork Repo Test Reports
+        if: ${{ (github.repository_owner != 'linkedin') && (success() || failure()) }}
+        uses: dorny/test-reporter@v1.9.1
+        env:
+         NODE_OPTIONS: --max-old-space-size=9182
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          name: ${{ github.job }} Test Reports       # Name where it report the test results
+          path: '**/TEST-*.xml'
+          fail-on-error: 'false'
+          max-annotations: '10'
+          list-tests: 'all'
+          list-suites: 'all'
+          reporter: java-junit
       - name: Publish Test Report
         continue-on-error: true
         env:
@@ -150,13 +178,13 @@ jobs:
         uses: mikepenz/action-junit-report@v5
         if: always()
         with:
-         check_name: ${{ github.job }}-jdk${{ matrix.jdk }} Report
-         comment: false
-         annotate_only: true
-         flaky_summary: true
-         commit: ${{github.event.workflow_run.head_sha}}
-         detailed_summary: true
-         report_paths: '**/build/test-results/test/TEST-*.xml'
+          check_name: ${{ github.job }}-jdk${{ matrix.jdk }} Report
+          comment: false
+          annotate_only: true
+          flaky_summary: true
+          commit: ${{github.event.workflow_run.head_sha}}
+          detailed_summary: true
+          report_paths: '**/build/test-results/test/TEST-*.xml'
       - name: Upload Build Artifacts
         if: success() || failure()
         uses: actions/upload-artifact@v4
@@ -224,6 +252,20 @@ jobs:
           find . -path "**/build/reports/*" -or -path "**/build/test-results/*" > artifacts.list
           rsync -R --files-from=artifacts.list . ${{ github.job }}-artifacts
           tar -zcvf ${{ github.job }}-jdk${{ matrix.jdk }}-logs.tar.gz ${{ github.job }}-artifacts
+      - name: Generate Fork Repo Test Reports
+        if: ${{ (github.repository_owner != 'linkedin') && (success() || failure()) }}
+        uses: dorny/test-reporter@v1.9.1
+        env:
+         NODE_OPTIONS: --max-old-space-size=9182
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          name: ${{ github.job }} Test Reports       # Name where it report the test results
+          path: '**/TEST-*.xml'
+          fail-on-error: 'false'
+          max-annotations: '10'
+          list-tests: 'all'
+          list-suites: 'all'
+          reporter: java-junit
       - name: Publish Test Report
         continue-on-error: true
         env:
@@ -231,13 +273,13 @@ jobs:
         uses: mikepenz/action-junit-report@v5
         if: always()
         with:
-         check_name: ${{ github.job }}-jdk${{ matrix.jdk }} Report
-         comment: false
-         annotate_only: true
-         flaky_summary: true
-         commit: ${{github.event.workflow_run.head_sha}}
-         detailed_summary: true
-         report_paths: '**/build/test-results/test/TEST-*.xml'
+          check_name: ${{ github.job }}-jdk${{ matrix.jdk }} Report
+          comment: false
+          annotate_only: true
+          flaky_summary: true
+          commit: ${{github.event.workflow_run.head_sha}}
+          detailed_summary: true
+          report_paths: '**/build/test-results/test/TEST-*.xml'
       - name: Upload Build Artifacts
         if: success() || failure()
         uses: actions/upload-artifact@v4
@@ -305,6 +347,20 @@ jobs:
           find . -path "**/build/reports/*" -or -path "**/build/test-results/*" > artifacts.list
           rsync -R --files-from=artifacts.list . ${{ github.job }}-artifacts
           tar -zcvf ${{ github.job }}-jdk${{ matrix.jdk }}-logs.tar.gz ${{ github.job }}-artifacts
+      - name: Generate Fork Repo Test Reports
+        if: ${{ (github.repository_owner != 'linkedin') && (success() || failure()) }}
+        uses: dorny/test-reporter@v1.9.1
+        env:
+         NODE_OPTIONS: --max-old-space-size=9182
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          name: ${{ github.job }} Test Reports       # Name where it report the test results
+          path: '**/TEST-*.xml'
+          fail-on-error: 'false'
+          max-annotations: '10'
+          list-tests: 'all'
+          list-suites: 'all'
+          reporter: java-junit
       - name: Publish Test Report
         continue-on-error: true
         env:
@@ -312,13 +368,13 @@ jobs:
         uses: mikepenz/action-junit-report@v5
         if: always()
         with:
-         check_name: ${{ github.job }}-jdk${{ matrix.jdk }} Report
-         comment: false
-         annotate_only: true
-         flaky_summary: true
-         commit: ${{github.event.workflow_run.head_sha}}
-         detailed_summary: true
-         report_paths: '**/build/test-results/test/TEST-*.xml'
+          check_name: ${{ github.job }}-jdk${{ matrix.jdk }} Report
+          comment: false
+          annotate_only: true
+          flaky_summary: true
+          commit: ${{github.event.workflow_run.head_sha}}
+          detailed_summary: true
+          report_paths: '**/build/test-results/test/TEST-*.xml'
       - name: Upload Build Artifacts
         if: success() || failure()
         uses: actions/upload-artifact@v4
@@ -386,6 +442,20 @@ jobs:
           find . -path "**/build/reports/*" -or -path "**/build/test-results/*" > artifacts.list
           rsync -R --files-from=artifacts.list . ${{ github.job }}-artifacts
           tar -zcvf ${{ github.job }}-jdk${{ matrix.jdk }}-logs.tar.gz ${{ github.job }}-artifacts
+      - name: Generate Fork Repo Test Reports
+        if: ${{ (github.repository_owner != 'linkedin') && (success() || failure()) }}
+        uses: dorny/test-reporter@v1.9.1
+        env:
+         NODE_OPTIONS: --max-old-space-size=9182
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          name: ${{ github.job }} Test Reports       # Name where it report the test results
+          path: '**/TEST-*.xml'
+          fail-on-error: 'false'
+          max-annotations: '10'
+          list-tests: 'all'
+          list-suites: 'all'
+          reporter: java-junit
       - name: Publish Test Report
         continue-on-error: true
         env:
@@ -393,13 +463,13 @@ jobs:
         uses: mikepenz/action-junit-report@v5
         if: always()
         with:
-         check_name: ${{ github.job }}-jdk${{ matrix.jdk }} Report
-         comment: false
-         annotate_only: true
-         flaky_summary: true
-         commit: ${{github.event.workflow_run.head_sha}}
-         detailed_summary: true
-         report_paths: '**/build/test-results/test/TEST-*.xml'
+          check_name: ${{ github.job }}-jdk${{ matrix.jdk }} Report
+          comment: false
+          annotate_only: true
+          flaky_summary: true
+          commit: ${{github.event.workflow_run.head_sha}}
+          detailed_summary: true
+          report_paths: '**/build/test-results/test/TEST-*.xml'
       - name: Upload Build Artifacts
         if: success() || failure()
         uses: actions/upload-artifact@v4
@@ -467,6 +537,20 @@ jobs:
           find . -path "**/build/reports/*" -or -path "**/build/test-results/*" > artifacts.list
           rsync -R --files-from=artifacts.list . ${{ github.job }}-artifacts
           tar -zcvf ${{ github.job }}-jdk${{ matrix.jdk }}-logs.tar.gz ${{ github.job }}-artifacts
+      - name: Generate Fork Repo Test Reports
+        if: ${{ (github.repository_owner != 'linkedin') && (success() || failure()) }}
+        uses: dorny/test-reporter@v1.9.1
+        env:
+         NODE_OPTIONS: --max-old-space-size=9182
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          name: ${{ github.job }} Test Reports       # Name where it report the test results
+          path: '**/TEST-*.xml'
+          fail-on-error: 'false'
+          max-annotations: '10'
+          list-tests: 'all'
+          list-suites: 'all'
+          reporter: java-junit
       - name: Publish Test Report
         continue-on-error: true
         env:
@@ -474,13 +558,13 @@ jobs:
         uses: mikepenz/action-junit-report@v5
         if: always()
         with:
-         check_name: ${{ github.job }}-jdk${{ matrix.jdk }} Report
-         comment: false
-         annotate_only: true
-         flaky_summary: true
-         commit: ${{github.event.workflow_run.head_sha}}
-         detailed_summary: true
-         report_paths: '**/build/test-results/test/TEST-*.xml'
+          check_name: ${{ github.job }}-jdk${{ matrix.jdk }} Report
+          comment: false
+          annotate_only: true
+          flaky_summary: true
+          commit: ${{github.event.workflow_run.head_sha}}
+          detailed_summary: true
+          report_paths: '**/build/test-results/test/TEST-*.xml'
       - name: Upload Build Artifacts
         if: success() || failure()
         uses: actions/upload-artifact@v4
@@ -548,6 +632,20 @@ jobs:
           find . -path "**/build/reports/*" -or -path "**/build/test-results/*" > artifacts.list
           rsync -R --files-from=artifacts.list . ${{ github.job }}-artifacts
           tar -zcvf ${{ github.job }}-jdk${{ matrix.jdk }}-logs.tar.gz ${{ github.job }}-artifacts
+      - name: Generate Fork Repo Test Reports
+        if: ${{ (github.repository_owner != 'linkedin') && (success() || failure()) }}
+        uses: dorny/test-reporter@v1.9.1
+        env:
+         NODE_OPTIONS: --max-old-space-size=9182
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          name: ${{ github.job }} Test Reports       # Name where it report the test results
+          path: '**/TEST-*.xml'
+          fail-on-error: 'false'
+          max-annotations: '10'
+          list-tests: 'all'
+          list-suites: 'all'
+          reporter: java-junit
       - name: Publish Test Report
         continue-on-error: true
         env:
@@ -555,13 +653,13 @@ jobs:
         uses: mikepenz/action-junit-report@v5
         if: always()
         with:
-         check_name: ${{ github.job }}-jdk${{ matrix.jdk }} Report
-         comment: false
-         annotate_only: true
-         flaky_summary: true
-         commit: ${{github.event.workflow_run.head_sha}}
-         detailed_summary: true
-         report_paths: '**/build/test-results/test/TEST-*.xml'
+          check_name: ${{ github.job }}-jdk${{ matrix.jdk }} Report
+          comment: false
+          annotate_only: true
+          flaky_summary: true
+          commit: ${{github.event.workflow_run.head_sha}}
+          detailed_summary: true
+          report_paths: '**/build/test-results/test/TEST-*.xml'
       - name: Upload Build Artifacts
         if: success() || failure()
         uses: actions/upload-artifact@v4
@@ -629,6 +727,20 @@ jobs:
           find . -path "**/build/reports/*" -or -path "**/build/test-results/*" > artifacts.list
           rsync -R --files-from=artifacts.list . ${{ github.job }}-artifacts
           tar -zcvf ${{ github.job }}-jdk${{ matrix.jdk }}-logs.tar.gz ${{ github.job }}-artifacts
+      - name: Generate Fork Repo Test Reports
+        if: ${{ (github.repository_owner != 'linkedin') && (success() || failure()) }}
+        uses: dorny/test-reporter@v1.9.1
+        env:
+         NODE_OPTIONS: --max-old-space-size=9182
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          name: ${{ github.job }} Test Reports       # Name where it report the test results
+          path: '**/TEST-*.xml'
+          fail-on-error: 'false'
+          max-annotations: '10'
+          list-tests: 'all'
+          list-suites: 'all'
+          reporter: java-junit
       - name: Publish Test Report
         continue-on-error: true
         env:
@@ -636,13 +748,13 @@ jobs:
         uses: mikepenz/action-junit-report@v5
         if: always()
         with:
-         check_name: ${{ github.job }}-jdk${{ matrix.jdk }} Report
-         comment: false
-         annotate_only: true
-         flaky_summary: true
-         commit: ${{github.event.workflow_run.head_sha}}
-         detailed_summary: true
-         report_paths: '**/build/test-results/test/TEST-*.xml'
+          check_name: ${{ github.job }}-jdk${{ matrix.jdk }} Report
+          comment: false
+          annotate_only: true
+          flaky_summary: true
+          commit: ${{github.event.workflow_run.head_sha}}
+          detailed_summary: true
+          report_paths: '**/build/test-results/test/TEST-*.xml'
       - name: Upload Build Artifacts
         if: success() || failure()
         uses: actions/upload-artifact@v4
@@ -710,6 +822,20 @@ jobs:
           find . -path "**/build/reports/*" -or -path "**/build/test-results/*" > artifacts.list
           rsync -R --files-from=artifacts.list . ${{ github.job }}-artifacts
           tar -zcvf ${{ github.job }}-jdk${{ matrix.jdk }}-logs.tar.gz ${{ github.job }}-artifacts
+      - name: Generate Fork Repo Test Reports
+        if: ${{ (github.repository_owner != 'linkedin') && (success() || failure()) }}
+        uses: dorny/test-reporter@v1.9.1
+        env:
+         NODE_OPTIONS: --max-old-space-size=9182
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          name: ${{ github.job }} Test Reports       # Name where it report the test results
+          path: '**/TEST-*.xml'
+          fail-on-error: 'false'
+          max-annotations: '10'
+          list-tests: 'all'
+          list-suites: 'all'
+          reporter: java-junit
       - name: Publish Test Report
         continue-on-error: true
         env:
@@ -717,13 +843,13 @@ jobs:
         uses: mikepenz/action-junit-report@v5
         if: always()
         with:
-         check_name: ${{ github.job }}-jdk${{ matrix.jdk }} Report
-         comment: false
-         annotate_only: true
-         flaky_summary: true
-         commit: ${{github.event.workflow_run.head_sha}}
-         detailed_summary: true
-         report_paths: '**/build/test-results/test/TEST-*.xml'
+          check_name: ${{ github.job }}-jdk${{ matrix.jdk }} Report
+          comment: false
+          annotate_only: true
+          flaky_summary: true
+          commit: ${{github.event.workflow_run.head_sha}}
+          detailed_summary: true
+          report_paths: '**/build/test-results/test/TEST-*.xml'
       - name: Upload Build Artifacts
         if: success() || failure()
         uses: actions/upload-artifact@v4
@@ -791,6 +917,20 @@ jobs:
           find . -path "**/build/reports/*" -or -path "**/build/test-results/*" > artifacts.list
           rsync -R --files-from=artifacts.list . ${{ github.job }}-artifacts
           tar -zcvf ${{ github.job }}-jdk${{ matrix.jdk }}-logs.tar.gz ${{ github.job }}-artifacts
+      - name: Generate Fork Repo Test Reports
+        if: ${{ (github.repository_owner != 'linkedin') && (success() || failure()) }}
+        uses: dorny/test-reporter@v1.9.1
+        env:
+         NODE_OPTIONS: --max-old-space-size=9182
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          name: ${{ github.job }} Test Reports       # Name where it report the test results
+          path: '**/TEST-*.xml'
+          fail-on-error: 'false'
+          max-annotations: '10'
+          list-tests: 'all'
+          list-suites: 'all'
+          reporter: java-junit
       - name: Publish Test Report
         continue-on-error: true
         env:
@@ -798,13 +938,13 @@ jobs:
         uses: mikepenz/action-junit-report@v5
         if: always()
         with:
-         check_name: ${{ github.job }}-jdk${{ matrix.jdk }} Report
-         comment: false
-         annotate_only: true
-         flaky_summary: true
-         commit: ${{github.event.workflow_run.head_sha}}
-         detailed_summary: true
-         report_paths: '**/build/test-results/test/TEST-*.xml'
+          check_name: ${{ github.job }}-jdk${{ matrix.jdk }} Report
+          comment: false
+          annotate_only: true
+          flaky_summary: true
+          commit: ${{github.event.workflow_run.head_sha}}
+          detailed_summary: true
+          report_paths: '**/build/test-results/test/TEST-*.xml'
       - name: Upload Build Artifacts
         if: success() || failure()
         uses: actions/upload-artifact@v4
@@ -872,6 +1012,20 @@ jobs:
           find . -path "**/build/reports/*" -or -path "**/build/test-results/*" > artifacts.list
           rsync -R --files-from=artifacts.list . ${{ github.job }}-artifacts
           tar -zcvf ${{ github.job }}-jdk${{ matrix.jdk }}-logs.tar.gz ${{ github.job }}-artifacts
+      - name: Generate Fork Repo Test Reports
+        if: ${{ (github.repository_owner != 'linkedin') && (success() || failure()) }}
+        uses: dorny/test-reporter@v1.9.1
+        env:
+         NODE_OPTIONS: --max-old-space-size=9182
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          name: ${{ github.job }} Test Reports       # Name where it report the test results
+          path: '**/TEST-*.xml'
+          fail-on-error: 'false'
+          max-annotations: '10'
+          list-tests: 'all'
+          list-suites: 'all'
+          reporter: java-junit
       - name: Publish Test Report
         continue-on-error: true
         env:
@@ -879,13 +1033,13 @@ jobs:
         uses: mikepenz/action-junit-report@v5
         if: always()
         with:
-         check_name: ${{ github.job }}-jdk${{ matrix.jdk }} Report
-         comment: false
-         annotate_only: true
-         flaky_summary: true
-         commit: ${{github.event.workflow_run.head_sha}}
-         detailed_summary: true
-         report_paths: '**/build/test-results/test/TEST-*.xml'
+          check_name: ${{ github.job }}-jdk${{ matrix.jdk }} Report
+          comment: false
+          annotate_only: true
+          flaky_summary: true
+          commit: ${{github.event.workflow_run.head_sha}}
+          detailed_summary: true
+          report_paths: '**/build/test-results/test/TEST-*.xml'
       - name: Upload Build Artifacts
         if: success() || failure()
         uses: actions/upload-artifact@v4
@@ -953,6 +1107,20 @@ jobs:
           find . -path "**/build/reports/*" -or -path "**/build/test-results/*" > artifacts.list
           rsync -R --files-from=artifacts.list . ${{ github.job }}-artifacts
           tar -zcvf ${{ github.job }}-jdk${{ matrix.jdk }}-logs.tar.gz ${{ github.job }}-artifacts
+      - name: Generate Fork Repo Test Reports
+        if: ${{ (github.repository_owner != 'linkedin') && (success() || failure()) }}
+        uses: dorny/test-reporter@v1.9.1
+        env:
+         NODE_OPTIONS: --max-old-space-size=9182
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          name: ${{ github.job }} Test Reports       # Name where it report the test results
+          path: '**/TEST-*.xml'
+          fail-on-error: 'false'
+          max-annotations: '10'
+          list-tests: 'all'
+          list-suites: 'all'
+          reporter: java-junit
       - name: Publish Test Report
         continue-on-error: true
         env:
@@ -960,13 +1128,13 @@ jobs:
         uses: mikepenz/action-junit-report@v5
         if: always()
         with:
-         check_name: ${{ github.job }}-jdk${{ matrix.jdk }} Report
-         comment: false
-         annotate_only: true
-         flaky_summary: true
-         commit: ${{github.event.workflow_run.head_sha}}
-         detailed_summary: true
-         report_paths: '**/build/test-results/test/TEST-*.xml'
+          check_name: ${{ github.job }}-jdk${{ matrix.jdk }} Report
+          comment: false
+          annotate_only: true
+          flaky_summary: true
+          commit: ${{github.event.workflow_run.head_sha}}
+          detailed_summary: true
+          report_paths: '**/build/test-results/test/TEST-*.xml'
       - name: Upload Build Artifacts
         if: success() || failure()
         uses: actions/upload-artifact@v4
@@ -1034,6 +1202,20 @@ jobs:
           find . -path "**/build/reports/*" -or -path "**/build/test-results/*" > artifacts.list
           rsync -R --files-from=artifacts.list . ${{ github.job }}-artifacts
           tar -zcvf ${{ github.job }}-jdk${{ matrix.jdk }}-logs.tar.gz ${{ github.job }}-artifacts
+      - name: Generate Fork Repo Test Reports
+        if: ${{ (github.repository_owner != 'linkedin') && (success() || failure()) }}
+        uses: dorny/test-reporter@v1.9.1
+        env:
+         NODE_OPTIONS: --max-old-space-size=9182
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          name: ${{ github.job }} Test Reports       # Name where it report the test results
+          path: '**/TEST-*.xml'
+          fail-on-error: 'false'
+          max-annotations: '10'
+          list-tests: 'all'
+          list-suites: 'all'
+          reporter: java-junit
       - name: Publish Test Report
         continue-on-error: true
         env:
@@ -1041,13 +1223,13 @@ jobs:
         uses: mikepenz/action-junit-report@v5
         if: always()
         with:
-         check_name: ${{ github.job }}-jdk${{ matrix.jdk }} Report
-         comment: false
-         annotate_only: true
-         flaky_summary: true
-         commit: ${{github.event.workflow_run.head_sha}}
-         detailed_summary: true
-         report_paths: '**/build/test-results/test/TEST-*.xml'
+          check_name: ${{ github.job }}-jdk${{ matrix.jdk }} Report
+          comment: false
+          annotate_only: true
+          flaky_summary: true
+          commit: ${{github.event.workflow_run.head_sha}}
+          detailed_summary: true
+          report_paths: '**/build/test-results/test/TEST-*.xml'
       - name: Upload Build Artifacts
         if: success() || failure()
         uses: actions/upload-artifact@v4
@@ -1115,6 +1297,20 @@ jobs:
           find . -path "**/build/reports/*" -or -path "**/build/test-results/*" > artifacts.list
           rsync -R --files-from=artifacts.list . ${{ github.job }}-artifacts
           tar -zcvf ${{ github.job }}-jdk${{ matrix.jdk }}-logs.tar.gz ${{ github.job }}-artifacts
+      - name: Generate Fork Repo Test Reports
+        if: ${{ (github.repository_owner != 'linkedin') && (success() || failure()) }}
+        uses: dorny/test-reporter@v1.9.1
+        env:
+         NODE_OPTIONS: --max-old-space-size=9182
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          name: ${{ github.job }} Test Reports       # Name where it report the test results
+          path: '**/TEST-*.xml'
+          fail-on-error: 'false'
+          max-annotations: '10'
+          list-tests: 'all'
+          list-suites: 'all'
+          reporter: java-junit
       - name: Publish Test Report
         continue-on-error: true
         env:
@@ -1122,13 +1318,13 @@ jobs:
         uses: mikepenz/action-junit-report@v5
         if: always()
         with:
-         check_name: ${{ github.job }}-jdk${{ matrix.jdk }} Report
-         comment: false
-         annotate_only: true
-         flaky_summary: true
-         commit: ${{github.event.workflow_run.head_sha}}
-         detailed_summary: true
-         report_paths: '**/build/test-results/test/TEST-*.xml'
+          check_name: ${{ github.job }}-jdk${{ matrix.jdk }} Report
+          comment: false
+          annotate_only: true
+          flaky_summary: true
+          commit: ${{github.event.workflow_run.head_sha}}
+          detailed_summary: true
+          report_paths: '**/build/test-results/test/TEST-*.xml'
       - name: Upload Build Artifacts
         if: success() || failure()
         uses: actions/upload-artifact@v4
@@ -1196,6 +1392,20 @@ jobs:
           find . -path "**/build/reports/*" -or -path "**/build/test-results/*" > artifacts.list
           rsync -R --files-from=artifacts.list . ${{ github.job }}-artifacts
           tar -zcvf ${{ github.job }}-jdk${{ matrix.jdk }}-logs.tar.gz ${{ github.job }}-artifacts
+      - name: Generate Fork Repo Test Reports
+        if: ${{ (github.repository_owner != 'linkedin') && (success() || failure()) }}
+        uses: dorny/test-reporter@v1.9.1
+        env:
+         NODE_OPTIONS: --max-old-space-size=9182
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          name: ${{ github.job }} Test Reports       # Name where it report the test results
+          path: '**/TEST-*.xml'
+          fail-on-error: 'false'
+          max-annotations: '10'
+          list-tests: 'all'
+          list-suites: 'all'
+          reporter: java-junit
       - name: Publish Test Report
         continue-on-error: true
         env:
@@ -1203,13 +1413,13 @@ jobs:
         uses: mikepenz/action-junit-report@v5
         if: always()
         with:
-         check_name: ${{ github.job }}-jdk${{ matrix.jdk }} Report
-         comment: false
-         annotate_only: true
-         flaky_summary: true
-         commit: ${{github.event.workflow_run.head_sha}}
-         detailed_summary: true
-         report_paths: '**/build/test-results/test/TEST-*.xml'
+          check_name: ${{ github.job }}-jdk${{ matrix.jdk }} Report
+          comment: false
+          annotate_only: true
+          flaky_summary: true
+          commit: ${{github.event.workflow_run.head_sha}}
+          detailed_summary: true
+          report_paths: '**/build/test-results/test/TEST-*.xml'
       - name: Upload Build Artifacts
         if: success() || failure()
         uses: actions/upload-artifact@v4
@@ -1277,6 +1487,20 @@ jobs:
           find . -path "**/build/reports/*" -or -path "**/build/test-results/*" > artifacts.list
           rsync -R --files-from=artifacts.list . ${{ github.job }}-artifacts
           tar -zcvf ${{ github.job }}-jdk${{ matrix.jdk }}-logs.tar.gz ${{ github.job }}-artifacts
+      - name: Generate Fork Repo Test Reports
+        if: ${{ (github.repository_owner != 'linkedin') && (success() || failure()) }}
+        uses: dorny/test-reporter@v1.9.1
+        env:
+         NODE_OPTIONS: --max-old-space-size=9182
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          name: ${{ github.job }} Test Reports       # Name where it report the test results
+          path: '**/TEST-*.xml'
+          fail-on-error: 'false'
+          max-annotations: '10'
+          list-tests: 'all'
+          list-suites: 'all'
+          reporter: java-junit
       - name: Publish Test Report
         continue-on-error: true
         env:
@@ -1284,13 +1508,13 @@ jobs:
         uses: mikepenz/action-junit-report@v5
         if: always()
         with:
-         check_name: ${{ github.job }}-jdk${{ matrix.jdk }} Report
-         comment: false
-         annotate_only: true
-         flaky_summary: true
-         commit: ${{github.event.workflow_run.head_sha}}
-         detailed_summary: true
-         report_paths: '**/build/test-results/test/TEST-*.xml'
+          check_name: ${{ github.job }}-jdk${{ matrix.jdk }} Report
+          comment: false
+          annotate_only: true
+          flaky_summary: true
+          commit: ${{github.event.workflow_run.head_sha}}
+          detailed_summary: true
+          report_paths: '**/build/test-results/test/TEST-*.xml'
       - name: Upload Build Artifacts
         if: success() || failure()
         uses: actions/upload-artifact@v4
@@ -1358,6 +1582,20 @@ jobs:
           find . -path "**/build/reports/*" -or -path "**/build/test-results/*" > artifacts.list
           rsync -R --files-from=artifacts.list . ${{ github.job }}-artifacts
           tar -zcvf ${{ github.job }}-jdk${{ matrix.jdk }}-logs.tar.gz ${{ github.job }}-artifacts
+      - name: Generate Fork Repo Test Reports
+        if: ${{ (github.repository_owner != 'linkedin') && (success() || failure()) }}
+        uses: dorny/test-reporter@v1.9.1
+        env:
+         NODE_OPTIONS: --max-old-space-size=9182
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          name: ${{ github.job }} Test Reports       # Name where it report the test results
+          path: '**/TEST-*.xml'
+          fail-on-error: 'false'
+          max-annotations: '10'
+          list-tests: 'all'
+          list-suites: 'all'
+          reporter: java-junit
       - name: Publish Test Report
         continue-on-error: true
         env:
@@ -1365,13 +1603,13 @@ jobs:
         uses: mikepenz/action-junit-report@v5
         if: always()
         with:
-         check_name: ${{ github.job }}-jdk${{ matrix.jdk }} Report
-         comment: false
-         annotate_only: true
-         flaky_summary: true
-         commit: ${{github.event.workflow_run.head_sha}}
-         detailed_summary: true
-         report_paths: '**/build/test-results/test/TEST-*.xml'
+          check_name: ${{ github.job }}-jdk${{ matrix.jdk }} Report
+          comment: false
+          annotate_only: true
+          flaky_summary: true
+          commit: ${{github.event.workflow_run.head_sha}}
+          detailed_summary: true
+          report_paths: '**/build/test-results/test/TEST-*.xml'
       - name: Upload Build Artifacts
         if: success() || failure()
         uses: actions/upload-artifact@v4
@@ -1439,6 +1677,20 @@ jobs:
           find . -path "**/build/reports/*" -or -path "**/build/test-results/*" > artifacts.list
           rsync -R --files-from=artifacts.list . ${{ github.job }}-artifacts
           tar -zcvf ${{ github.job }}-jdk${{ matrix.jdk }}-logs.tar.gz ${{ github.job }}-artifacts
+      - name: Generate Fork Repo Test Reports
+        if: ${{ (github.repository_owner != 'linkedin') && (success() || failure()) }}
+        uses: dorny/test-reporter@v1.9.1
+        env:
+         NODE_OPTIONS: --max-old-space-size=9182
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          name: ${{ github.job }} Test Reports       # Name where it report the test results
+          path: '**/TEST-*.xml'
+          fail-on-error: 'false'
+          max-annotations: '10'
+          list-tests: 'all'
+          list-suites: 'all'
+          reporter: java-junit
       - name: Publish Test Report
         continue-on-error: true
         env:
@@ -1446,13 +1698,13 @@ jobs:
         uses: mikepenz/action-junit-report@v5
         if: always()
         with:
-         check_name: ${{ github.job }}-jdk${{ matrix.jdk }} Report
-         comment: false
-         annotate_only: true
-         flaky_summary: true
-         commit: ${{github.event.workflow_run.head_sha}}
-         detailed_summary: true
-         report_paths: '**/build/test-results/test/TEST-*.xml'
+          check_name: ${{ github.job }}-jdk${{ matrix.jdk }} Report
+          comment: false
+          annotate_only: true
+          flaky_summary: true
+          commit: ${{github.event.workflow_run.head_sha}}
+          detailed_summary: true
+          report_paths: '**/build/test-results/test/TEST-*.xml'
       - name: Upload Build Artifacts
         if: success() || failure()
         uses: actions/upload-artifact@v4
@@ -1520,6 +1772,20 @@ jobs:
           find . -path "**/build/reports/*" -or -path "**/build/test-results/*" > artifacts.list
           rsync -R --files-from=artifacts.list . ${{ github.job }}-artifacts
           tar -zcvf ${{ github.job }}-jdk${{ matrix.jdk }}-logs.tar.gz ${{ github.job }}-artifacts
+      - name: Generate Fork Repo Test Reports
+        if: ${{ (github.repository_owner != 'linkedin') && (success() || failure()) }}
+        uses: dorny/test-reporter@v1.9.1
+        env:
+         NODE_OPTIONS: --max-old-space-size=9182
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          name: ${{ github.job }} Test Reports       # Name where it report the test results
+          path: '**/TEST-*.xml'
+          fail-on-error: 'false'
+          max-annotations: '10'
+          list-tests: 'all'
+          list-suites: 'all'
+          reporter: java-junit
       - name: Publish Test Report
         continue-on-error: true
         env:
@@ -1527,13 +1793,13 @@ jobs:
         uses: mikepenz/action-junit-report@v5
         if: always()
         with:
-         check_name: ${{ github.job }}-jdk${{ matrix.jdk }} Report
-         comment: false
-         annotate_only: true
-         flaky_summary: true
-         commit: ${{github.event.workflow_run.head_sha}}
-         detailed_summary: true
-         report_paths: '**/build/test-results/test/TEST-*.xml'
+          check_name: ${{ github.job }}-jdk${{ matrix.jdk }} Report
+          comment: false
+          annotate_only: true
+          flaky_summary: true
+          commit: ${{github.event.workflow_run.head_sha}}
+          detailed_summary: true
+          report_paths: '**/build/test-results/test/TEST-*.xml'
       - name: Upload Build Artifacts
         if: success() || failure()
         uses: actions/upload-artifact@v4
@@ -1601,6 +1867,20 @@ jobs:
           find . -path "**/build/reports/*" -or -path "**/build/test-results/*" > artifacts.list
           rsync -R --files-from=artifacts.list . ${{ github.job }}-artifacts
           tar -zcvf ${{ github.job }}-jdk${{ matrix.jdk }}-logs.tar.gz ${{ github.job }}-artifacts
+      - name: Generate Fork Repo Test Reports
+        if: ${{ (github.repository_owner != 'linkedin') && (success() || failure()) }}
+        uses: dorny/test-reporter@v1.9.1
+        env:
+         NODE_OPTIONS: --max-old-space-size=9182
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          name: ${{ github.job }} Test Reports       # Name where it report the test results
+          path: '**/TEST-*.xml'
+          fail-on-error: 'false'
+          max-annotations: '10'
+          list-tests: 'all'
+          list-suites: 'all'
+          reporter: java-junit
       - name: Publish Test Report
         continue-on-error: true
         env:
@@ -1608,13 +1888,13 @@ jobs:
         uses: mikepenz/action-junit-report@v5
         if: always()
         with:
-         check_name: ${{ github.job }}-jdk${{ matrix.jdk }} Report
-         comment: false
-         annotate_only: true
-         flaky_summary: true
-         commit: ${{github.event.workflow_run.head_sha}}
-         detailed_summary: true
-         report_paths: '**/build/test-results/test/TEST-*.xml'
+          check_name: ${{ github.job }}-jdk${{ matrix.jdk }} Report
+          comment: false
+          annotate_only: true
+          flaky_summary: true
+          commit: ${{github.event.workflow_run.head_sha}}
+          detailed_summary: true
+          report_paths: '**/build/test-results/test/TEST-*.xml'
       - name: Upload Build Artifacts
         if: success() || failure()
         uses: actions/upload-artifact@v4
@@ -1682,6 +1962,20 @@ jobs:
           find . -path "**/build/reports/*" -or -path "**/build/test-results/*" > artifacts.list
           rsync -R --files-from=artifacts.list . ${{ github.job }}-artifacts
           tar -zcvf ${{ github.job }}-jdk${{ matrix.jdk }}-logs.tar.gz ${{ github.job }}-artifacts
+      - name: Generate Fork Repo Test Reports
+        if: ${{ (github.repository_owner != 'linkedin') && (success() || failure()) }}
+        uses: dorny/test-reporter@v1.9.1
+        env:
+         NODE_OPTIONS: --max-old-space-size=9182
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          name: ${{ github.job }} Test Reports       # Name where it report the test results
+          path: '**/TEST-*.xml'
+          fail-on-error: 'false'
+          max-annotations: '10'
+          list-tests: 'all'
+          list-suites: 'all'
+          reporter: java-junit
       - name: Publish Test Report
         continue-on-error: true
         env:
@@ -1689,13 +1983,13 @@ jobs:
         uses: mikepenz/action-junit-report@v5
         if: always()
         with:
-         check_name: ${{ github.job }}-jdk${{ matrix.jdk }} Report
-         comment: false
-         annotate_only: true
-         flaky_summary: true
-         commit: ${{github.event.workflow_run.head_sha}}
-         detailed_summary: true
-         report_paths: '**/build/test-results/test/TEST-*.xml'
+          check_name: ${{ github.job }}-jdk${{ matrix.jdk }} Report
+          comment: false
+          annotate_only: true
+          flaky_summary: true
+          commit: ${{github.event.workflow_run.head_sha}}
+          detailed_summary: true
+          report_paths: '**/build/test-results/test/TEST-*.xml'
       - name: Upload Build Artifacts
         if: success() || failure()
         uses: actions/upload-artifact@v4
@@ -1763,6 +2057,20 @@ jobs:
           find . -path "**/build/reports/*" -or -path "**/build/test-results/*" > artifacts.list
           rsync -R --files-from=artifacts.list . ${{ github.job }}-artifacts
           tar -zcvf ${{ github.job }}-jdk${{ matrix.jdk }}-logs.tar.gz ${{ github.job }}-artifacts
+      - name: Generate Fork Repo Test Reports
+        if: ${{ (github.repository_owner != 'linkedin') && (success() || failure()) }}
+        uses: dorny/test-reporter@v1.9.1
+        env:
+         NODE_OPTIONS: --max-old-space-size=9182
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          name: ${{ github.job }} Test Reports       # Name where it report the test results
+          path: '**/TEST-*.xml'
+          fail-on-error: 'false'
+          max-annotations: '10'
+          list-tests: 'all'
+          list-suites: 'all'
+          reporter: java-junit
       - name: Publish Test Report
         continue-on-error: true
         env:
@@ -1770,13 +2078,13 @@ jobs:
         uses: mikepenz/action-junit-report@v5
         if: always()
         with:
-         check_name: ${{ github.job }}-jdk${{ matrix.jdk }} Report
-         comment: false
-         annotate_only: true
-         flaky_summary: true
-         commit: ${{github.event.workflow_run.head_sha}}
-         detailed_summary: true
-         report_paths: '**/build/test-results/test/TEST-*.xml'
+          check_name: ${{ github.job }}-jdk${{ matrix.jdk }} Report
+          comment: false
+          annotate_only: true
+          flaky_summary: true
+          commit: ${{github.event.workflow_run.head_sha}}
+          detailed_summary: true
+          report_paths: '**/build/test-results/test/TEST-*.xml'
       - name: Upload Build Artifacts
         if: success() || failure()
         uses: actions/upload-artifact@v4
@@ -1844,6 +2152,20 @@ jobs:
           find . -path "**/build/reports/*" -or -path "**/build/test-results/*" > artifacts.list
           rsync -R --files-from=artifacts.list . ${{ github.job }}-artifacts
           tar -zcvf ${{ github.job }}-jdk${{ matrix.jdk }}-logs.tar.gz ${{ github.job }}-artifacts
+      - name: Generate Fork Repo Test Reports
+        if: ${{ (github.repository_owner != 'linkedin') && (success() || failure()) }}
+        uses: dorny/test-reporter@v1.9.1
+        env:
+         NODE_OPTIONS: --max-old-space-size=9182
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          name: ${{ github.job }} Test Reports       # Name where it report the test results
+          path: '**/TEST-*.xml'
+          fail-on-error: 'false'
+          max-annotations: '10'
+          list-tests: 'all'
+          list-suites: 'all'
+          reporter: java-junit
       - name: Publish Test Report
         continue-on-error: true
         env:
@@ -1851,13 +2173,13 @@ jobs:
         uses: mikepenz/action-junit-report@v5
         if: always()
         with:
-         check_name: ${{ github.job }}-jdk${{ matrix.jdk }} Report
-         comment: false
-         annotate_only: true
-         flaky_summary: true
-         commit: ${{github.event.workflow_run.head_sha}}
-         detailed_summary: true
-         report_paths: '**/build/test-results/test/TEST-*.xml'
+          check_name: ${{ github.job }}-jdk${{ matrix.jdk }} Report
+          comment: false
+          annotate_only: true
+          flaky_summary: true
+          commit: ${{github.event.workflow_run.head_sha}}
+          detailed_summary: true
+          report_paths: '**/build/test-results/test/TEST-*.xml'
       - name: Upload Build Artifacts
         if: success() || failure()
         uses: actions/upload-artifact@v4
@@ -1925,6 +2247,20 @@ jobs:
           find . -path "**/build/reports/*" -or -path "**/build/test-results/*" > artifacts.list
           rsync -R --files-from=artifacts.list . ${{ github.job }}-artifacts
           tar -zcvf ${{ github.job }}-jdk${{ matrix.jdk }}-logs.tar.gz ${{ github.job }}-artifacts
+      - name: Generate Fork Repo Test Reports
+        if: ${{ (github.repository_owner != 'linkedin') && (success() || failure()) }}
+        uses: dorny/test-reporter@v1.9.1
+        env:
+         NODE_OPTIONS: --max-old-space-size=9182
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          name: ${{ github.job }} Test Reports       # Name where it report the test results
+          path: '**/TEST-*.xml'
+          fail-on-error: 'false'
+          max-annotations: '10'
+          list-tests: 'all'
+          list-suites: 'all'
+          reporter: java-junit
       - name: Publish Test Report
         continue-on-error: true
         env:
@@ -1932,13 +2268,13 @@ jobs:
         uses: mikepenz/action-junit-report@v5
         if: always()
         with:
-         check_name: ${{ github.job }}-jdk${{ matrix.jdk }} Report
-         comment: false
-         annotate_only: true
-         flaky_summary: true
-         commit: ${{github.event.workflow_run.head_sha}}
-         detailed_summary: true
-         report_paths: '**/build/test-results/test/TEST-*.xml'
+          check_name: ${{ github.job }}-jdk${{ matrix.jdk }} Report
+          comment: false
+          annotate_only: true
+          flaky_summary: true
+          commit: ${{github.event.workflow_run.head_sha}}
+          detailed_summary: true
+          report_paths: '**/build/test-results/test/TEST-*.xml'
       - name: Upload Build Artifacts
         if: success() || failure()
         uses: actions/upload-artifact@v4
@@ -2006,6 +2342,20 @@ jobs:
           find . -path "**/build/reports/*" -or -path "**/build/test-results/*" > artifacts.list
           rsync -R --files-from=artifacts.list . ${{ github.job }}-artifacts
           tar -zcvf ${{ github.job }}-jdk${{ matrix.jdk }}-logs.tar.gz ${{ github.job }}-artifacts
+      - name: Generate Fork Repo Test Reports
+        if: ${{ (github.repository_owner != 'linkedin') && (success() || failure()) }}
+        uses: dorny/test-reporter@v1.9.1
+        env:
+         NODE_OPTIONS: --max-old-space-size=9182
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          name: ${{ github.job }} Test Reports       # Name where it report the test results
+          path: '**/TEST-*.xml'
+          fail-on-error: 'false'
+          max-annotations: '10'
+          list-tests: 'all'
+          list-suites: 'all'
+          reporter: java-junit
       - name: Publish Test Report
         continue-on-error: true
         env:
@@ -2013,13 +2363,13 @@ jobs:
         uses: mikepenz/action-junit-report@v5
         if: always()
         with:
-         check_name: ${{ github.job }}-jdk${{ matrix.jdk }} Report
-         comment: false
-         annotate_only: true
-         flaky_summary: true
-         commit: ${{github.event.workflow_run.head_sha}}
-         detailed_summary: true
-         report_paths: '**/build/test-results/test/TEST-*.xml'
+          check_name: ${{ github.job }}-jdk${{ matrix.jdk }} Report
+          comment: false
+          annotate_only: true
+          flaky_summary: true
+          commit: ${{github.event.workflow_run.head_sha}}
+          detailed_summary: true
+          report_paths: '**/build/test-results/test/TEST-*.xml'
       - name: Upload Build Artifacts
         if: success() || failure()
         uses: actions/upload-artifact@v4
@@ -2087,6 +2437,20 @@ jobs:
           find . -path "**/build/reports/*" -or -path "**/build/test-results/*" > artifacts.list
           rsync -R --files-from=artifacts.list . ${{ github.job }}-artifacts
           tar -zcvf ${{ github.job }}-jdk${{ matrix.jdk }}-logs.tar.gz ${{ github.job }}-artifacts
+      - name: Generate Fork Repo Test Reports
+        if: ${{ (github.repository_owner != 'linkedin') && (success() || failure()) }}
+        uses: dorny/test-reporter@v1.9.1
+        env:
+         NODE_OPTIONS: --max-old-space-size=9182
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          name: ${{ github.job }} Test Reports       # Name where it report the test results
+          path: '**/TEST-*.xml'
+          fail-on-error: 'false'
+          max-annotations: '10'
+          list-tests: 'all'
+          list-suites: 'all'
+          reporter: java-junit
       - name: Publish Test Report
         continue-on-error: true
         env:
@@ -2094,13 +2458,13 @@ jobs:
         uses: mikepenz/action-junit-report@v5
         if: always()
         with:
-         check_name: ${{ github.job }}-jdk${{ matrix.jdk }} Report
-         comment: false
-         annotate_only: true
-         flaky_summary: true
-         commit: ${{github.event.workflow_run.head_sha}}
-         detailed_summary: true
-         report_paths: '**/build/test-results/test/TEST-*.xml'
+          check_name: ${{ github.job }}-jdk${{ matrix.jdk }} Report
+          comment: false
+          annotate_only: true
+          flaky_summary: true
+          commit: ${{github.event.workflow_run.head_sha}}
+          detailed_summary: true
+          report_paths: '**/build/test-results/test/TEST-*.xml'
       - name: Upload Build Artifacts
         if: success() || failure()
         uses: actions/upload-artifact@v4
@@ -2168,6 +2532,20 @@ jobs:
           find . -path "**/build/reports/*" -or -path "**/build/test-results/*" > artifacts.list
           rsync -R --files-from=artifacts.list . ${{ github.job }}-artifacts
           tar -zcvf ${{ github.job }}-jdk${{ matrix.jdk }}-logs.tar.gz ${{ github.job }}-artifacts
+      - name: Generate Fork Repo Test Reports
+        if: ${{ (github.repository_owner != 'linkedin') && (success() || failure()) }}
+        uses: dorny/test-reporter@v1.9.1
+        env:
+         NODE_OPTIONS: --max-old-space-size=9182
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          name: ${{ github.job }} Test Reports       # Name where it report the test results
+          path: '**/TEST-*.xml'
+          fail-on-error: 'false'
+          max-annotations: '10'
+          list-tests: 'all'
+          list-suites: 'all'
+          reporter: java-junit
       - name: Publish Test Report
         continue-on-error: true
         env:
@@ -2175,13 +2553,13 @@ jobs:
         uses: mikepenz/action-junit-report@v5
         if: always()
         with:
-         check_name: ${{ github.job }}-jdk${{ matrix.jdk }} Report
-         comment: false
-         annotate_only: true
-         flaky_summary: true
-         commit: ${{github.event.workflow_run.head_sha}}
-         detailed_summary: true
-         report_paths: '**/build/test-results/test/TEST-*.xml'
+          check_name: ${{ github.job }}-jdk${{ matrix.jdk }} Report
+          comment: false
+          annotate_only: true
+          flaky_summary: true
+          commit: ${{github.event.workflow_run.head_sha}}
+          detailed_summary: true
+          report_paths: '**/build/test-results/test/TEST-*.xml'
       - name: Upload Build Artifacts
         if: success() || failure()
         uses: actions/upload-artifact@v4
@@ -2249,6 +2627,20 @@ jobs:
           find . -path "**/build/reports/*" -or -path "**/build/test-results/*" > artifacts.list
           rsync -R --files-from=artifacts.list . ${{ github.job }}-artifacts
           tar -zcvf ${{ github.job }}-jdk${{ matrix.jdk }}-logs.tar.gz ${{ github.job }}-artifacts
+      - name: Generate Fork Repo Test Reports
+        if: ${{ (github.repository_owner != 'linkedin') && (success() || failure()) }}
+        uses: dorny/test-reporter@v1.9.1
+        env:
+         NODE_OPTIONS: --max-old-space-size=9182
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          name: ${{ github.job }} Test Reports       # Name where it report the test results
+          path: '**/TEST-*.xml'
+          fail-on-error: 'false'
+          max-annotations: '10'
+          list-tests: 'all'
+          list-suites: 'all'
+          reporter: java-junit
       - name: Publish Test Report
         continue-on-error: true
         env:
@@ -2256,13 +2648,13 @@ jobs:
         uses: mikepenz/action-junit-report@v5
         if: always()
         with:
-         check_name: ${{ github.job }}-jdk${{ matrix.jdk }} Report
-         comment: false
-         annotate_only: true
-         flaky_summary: true
-         commit: ${{github.event.workflow_run.head_sha}}
-         detailed_summary: true
-         report_paths: '**/build/test-results/test/TEST-*.xml'
+          check_name: ${{ github.job }}-jdk${{ matrix.jdk }} Report
+          comment: false
+          annotate_only: true
+          flaky_summary: true
+          commit: ${{github.event.workflow_run.head_sha}}
+          detailed_summary: true
+          report_paths: '**/build/test-results/test/TEST-*.xml'
       - name: Upload Build Artifacts
         if: success() || failure()
         uses: actions/upload-artifact@v4
@@ -2330,6 +2722,20 @@ jobs:
           find . -path "**/build/reports/*" -or -path "**/build/test-results/*" > artifacts.list
           rsync -R --files-from=artifacts.list . ${{ github.job }}-artifacts
           tar -zcvf ${{ github.job }}-jdk${{ matrix.jdk }}-logs.tar.gz ${{ github.job }}-artifacts
+      - name: Generate Fork Repo Test Reports
+        if: ${{ (github.repository_owner != 'linkedin') && (success() || failure()) }}
+        uses: dorny/test-reporter@v1.9.1
+        env:
+         NODE_OPTIONS: --max-old-space-size=9182
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          name: ${{ github.job }} Test Reports       # Name where it report the test results
+          path: '**/TEST-*.xml'
+          fail-on-error: 'false'
+          max-annotations: '10'
+          list-tests: 'all'
+          list-suites: 'all'
+          reporter: java-junit
       - name: Publish Test Report
         continue-on-error: true
         env:
@@ -2337,13 +2743,13 @@ jobs:
         uses: mikepenz/action-junit-report@v5
         if: always()
         with:
-         check_name: ${{ github.job }}-jdk${{ matrix.jdk }} Report
-         comment: false
-         annotate_only: true
-         flaky_summary: true
-         commit: ${{github.event.workflow_run.head_sha}}
-         detailed_summary: true
-         report_paths: '**/build/test-results/test/TEST-*.xml'
+          check_name: ${{ github.job }}-jdk${{ matrix.jdk }} Report
+          comment: false
+          annotate_only: true
+          flaky_summary: true
+          commit: ${{github.event.workflow_run.head_sha}}
+          detailed_summary: true
+          report_paths: '**/build/test-results/test/TEST-*.xml'
       - name: Upload Build Artifacts
         if: success() || failure()
         uses: actions/upload-artifact@v4
@@ -2411,6 +2817,20 @@ jobs:
           find . -path "**/build/reports/*" -or -path "**/build/test-results/*" > artifacts.list
           rsync -R --files-from=artifacts.list . ${{ github.job }}-artifacts
           tar -zcvf ${{ github.job }}-jdk${{ matrix.jdk }}-logs.tar.gz ${{ github.job }}-artifacts
+      - name: Generate Fork Repo Test Reports
+        if: ${{ (github.repository_owner != 'linkedin') && (success() || failure()) }}
+        uses: dorny/test-reporter@v1.9.1
+        env:
+         NODE_OPTIONS: --max-old-space-size=9182
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          name: ${{ github.job }} Test Reports       # Name where it report the test results
+          path: '**/TEST-*.xml'
+          fail-on-error: 'false'
+          max-annotations: '10'
+          list-tests: 'all'
+          list-suites: 'all'
+          reporter: java-junit
       - name: Publish Test Report
         continue-on-error: true
         env:
@@ -2418,13 +2838,13 @@ jobs:
         uses: mikepenz/action-junit-report@v5
         if: always()
         with:
-         check_name: ${{ github.job }}-jdk${{ matrix.jdk }} Report
-         comment: false
-         annotate_only: true
-         flaky_summary: true
-         commit: ${{github.event.workflow_run.head_sha}}
-         detailed_summary: true
-         report_paths: '**/build/test-results/test/TEST-*.xml'
+          check_name: ${{ github.job }}-jdk${{ matrix.jdk }} Report
+          comment: false
+          annotate_only: true
+          flaky_summary: true
+          commit: ${{github.event.workflow_run.head_sha}}
+          detailed_summary: true
+          report_paths: '**/build/test-results/test/TEST-*.xml'
       - name: Upload Build Artifacts
         if: success() || failure()
         uses: actions/upload-artifact@v4
@@ -2492,6 +2912,20 @@ jobs:
           find . -path "**/build/reports/*" -or -path "**/build/test-results/*" > artifacts.list
           rsync -R --files-from=artifacts.list . ${{ github.job }}-artifacts
           tar -zcvf ${{ github.job }}-jdk${{ matrix.jdk }}-logs.tar.gz ${{ github.job }}-artifacts
+      - name: Generate Fork Repo Test Reports
+        if: ${{ (github.repository_owner != 'linkedin') && (success() || failure()) }}
+        uses: dorny/test-reporter@v1.9.1
+        env:
+         NODE_OPTIONS: --max-old-space-size=9182
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          name: ${{ github.job }} Test Reports       # Name where it report the test results
+          path: '**/TEST-*.xml'
+          fail-on-error: 'false'
+          max-annotations: '10'
+          list-tests: 'all'
+          list-suites: 'all'
+          reporter: java-junit
       - name: Publish Test Report
         continue-on-error: true
         env:
@@ -2499,13 +2933,13 @@ jobs:
         uses: mikepenz/action-junit-report@v5
         if: always()
         with:
-         check_name: ${{ github.job }}-jdk${{ matrix.jdk }} Report
-         comment: false
-         annotate_only: true
-         flaky_summary: true
-         commit: ${{github.event.workflow_run.head_sha}}
-         detailed_summary: true
-         report_paths: '**/build/test-results/test/TEST-*.xml'
+          check_name: ${{ github.job }}-jdk${{ matrix.jdk }} Report
+          comment: false
+          annotate_only: true
+          flaky_summary: true
+          commit: ${{github.event.workflow_run.head_sha}}
+          detailed_summary: true
+          report_paths: '**/build/test-results/test/TEST-*.xml'
       - name: Upload Build Artifacts
         if: success() || failure()
         uses: actions/upload-artifact@v4

--- a/.github/workflows/VeniceCI-E2ETests.yml
+++ b/.github/workflows/VeniceCI-E2ETests.yml
@@ -25,6 +25,7 @@ jobs:
      contents: read
      checks: write
      pull-requests: write
+     issues: write
     timeout-minutes: 120
     concurrency:
      group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-jdk${{ matrix.jdk }}-IntegrationTests_1000
@@ -60,13 +61,14 @@ jobs:
           rsync -R --files-from=artifacts.list . ${{ github.job }}-artifacts
           tar -zcvf ${{ github.job }}-jdk${{ matrix.jdk }}-logs.tar.gz ${{ github.job }}-artifacts
       - name: Publish Test Report
+        continue-on-error: true
         env:
           NODE_OPTIONS: "--max_old_space_size=8192"
         uses: mikepenz/action-junit-report@v5
         if: always()
         with:
          check_name: ${{ inputs.artifact_suffix }}-jdk${{ matrix.jdk }} Report
-         comment: true
+         comment: false
          annotate_only: true
          flaky_summary: true
          commit: ${{github.event.workflow_run.head_sha}}
@@ -102,6 +104,7 @@ jobs:
      contents: read
      checks: write
      pull-requests: write
+     issues: write
     timeout-minutes: 120
     concurrency:
      group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-jdk${{ matrix.jdk }}-IntegrationTests_1010
@@ -137,13 +140,14 @@ jobs:
           rsync -R --files-from=artifacts.list . ${{ github.job }}-artifacts
           tar -zcvf ${{ github.job }}-jdk${{ matrix.jdk }}-logs.tar.gz ${{ github.job }}-artifacts
       - name: Publish Test Report
+        continue-on-error: true
         env:
           NODE_OPTIONS: "--max_old_space_size=8192"
         uses: mikepenz/action-junit-report@v5
         if: always()
         with:
          check_name: ${{ inputs.artifact_suffix }}-jdk${{ matrix.jdk }} Report
-         comment: true
+         comment: false
          annotate_only: true
          flaky_summary: true
          commit: ${{github.event.workflow_run.head_sha}}
@@ -179,6 +183,7 @@ jobs:
      contents: read
      checks: write
      pull-requests: write
+     issues: write
     timeout-minutes: 120
     concurrency:
      group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-jdk${{ matrix.jdk }}-IntegrationTests_1020
@@ -214,13 +219,14 @@ jobs:
           rsync -R --files-from=artifacts.list . ${{ github.job }}-artifacts
           tar -zcvf ${{ github.job }}-jdk${{ matrix.jdk }}-logs.tar.gz ${{ github.job }}-artifacts
       - name: Publish Test Report
+        continue-on-error: true
         env:
           NODE_OPTIONS: "--max_old_space_size=8192"
         uses: mikepenz/action-junit-report@v5
         if: always()
         with:
          check_name: ${{ inputs.artifact_suffix }}-jdk${{ matrix.jdk }} Report
-         comment: true
+         comment: false
          annotate_only: true
          flaky_summary: true
          commit: ${{github.event.workflow_run.head_sha}}
@@ -256,6 +262,7 @@ jobs:
      contents: read
      checks: write
      pull-requests: write
+     issues: write
     timeout-minutes: 120
     concurrency:
      group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-jdk${{ matrix.jdk }}-IntegrationTests_1030
@@ -291,13 +298,14 @@ jobs:
           rsync -R --files-from=artifacts.list . ${{ github.job }}-artifacts
           tar -zcvf ${{ github.job }}-jdk${{ matrix.jdk }}-logs.tar.gz ${{ github.job }}-artifacts
       - name: Publish Test Report
+        continue-on-error: true
         env:
           NODE_OPTIONS: "--max_old_space_size=8192"
         uses: mikepenz/action-junit-report@v5
         if: always()
         with:
          check_name: ${{ inputs.artifact_suffix }}-jdk${{ matrix.jdk }} Report
-         comment: true
+         comment: false
          annotate_only: true
          flaky_summary: true
          commit: ${{github.event.workflow_run.head_sha}}
@@ -333,6 +341,7 @@ jobs:
      contents: read
      checks: write
      pull-requests: write
+     issues: write
     timeout-minutes: 120
     concurrency:
      group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-jdk${{ matrix.jdk }}-IntegrationTests_1040
@@ -368,13 +377,14 @@ jobs:
           rsync -R --files-from=artifacts.list . ${{ github.job }}-artifacts
           tar -zcvf ${{ github.job }}-jdk${{ matrix.jdk }}-logs.tar.gz ${{ github.job }}-artifacts
       - name: Publish Test Report
+        continue-on-error: true
         env:
           NODE_OPTIONS: "--max_old_space_size=8192"
         uses: mikepenz/action-junit-report@v5
         if: always()
         with:
          check_name: ${{ inputs.artifact_suffix }}-jdk${{ matrix.jdk }} Report
-         comment: true
+         comment: false
          annotate_only: true
          flaky_summary: true
          commit: ${{github.event.workflow_run.head_sha}}
@@ -410,6 +420,7 @@ jobs:
      contents: read
      checks: write
      pull-requests: write
+     issues: write
     timeout-minutes: 120
     concurrency:
      group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-jdk${{ matrix.jdk }}-IntegrationTests_1050
@@ -445,13 +456,14 @@ jobs:
           rsync -R --files-from=artifacts.list . ${{ github.job }}-artifacts
           tar -zcvf ${{ github.job }}-jdk${{ matrix.jdk }}-logs.tar.gz ${{ github.job }}-artifacts
       - name: Publish Test Report
+        continue-on-error: true
         env:
           NODE_OPTIONS: "--max_old_space_size=8192"
         uses: mikepenz/action-junit-report@v5
         if: always()
         with:
          check_name: ${{ inputs.artifact_suffix }}-jdk${{ matrix.jdk }} Report
-         comment: true
+         comment: false
          annotate_only: true
          flaky_summary: true
          commit: ${{github.event.workflow_run.head_sha}}
@@ -487,6 +499,7 @@ jobs:
      contents: read
      checks: write
      pull-requests: write
+     issues: write
     timeout-minutes: 120
     concurrency:
      group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-jdk${{ matrix.jdk }}-IntegrationTests_1060
@@ -522,13 +535,14 @@ jobs:
           rsync -R --files-from=artifacts.list . ${{ github.job }}-artifacts
           tar -zcvf ${{ github.job }}-jdk${{ matrix.jdk }}-logs.tar.gz ${{ github.job }}-artifacts
       - name: Publish Test Report
+        continue-on-error: true
         env:
           NODE_OPTIONS: "--max_old_space_size=8192"
         uses: mikepenz/action-junit-report@v5
         if: always()
         with:
          check_name: ${{ inputs.artifact_suffix }}-jdk${{ matrix.jdk }} Report
-         comment: true
+         comment: false
          annotate_only: true
          flaky_summary: true
          commit: ${{github.event.workflow_run.head_sha}}
@@ -564,6 +578,7 @@ jobs:
      contents: read
      checks: write
      pull-requests: write
+     issues: write
     timeout-minutes: 120
     concurrency:
      group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-jdk${{ matrix.jdk }}-IntegrationTests_1070
@@ -599,13 +614,14 @@ jobs:
           rsync -R --files-from=artifacts.list . ${{ github.job }}-artifacts
           tar -zcvf ${{ github.job }}-jdk${{ matrix.jdk }}-logs.tar.gz ${{ github.job }}-artifacts
       - name: Publish Test Report
+        continue-on-error: true
         env:
           NODE_OPTIONS: "--max_old_space_size=8192"
         uses: mikepenz/action-junit-report@v5
         if: always()
         with:
          check_name: ${{ inputs.artifact_suffix }}-jdk${{ matrix.jdk }} Report
-         comment: true
+         comment: false
          annotate_only: true
          flaky_summary: true
          commit: ${{github.event.workflow_run.head_sha}}
@@ -641,6 +657,7 @@ jobs:
      contents: read
      checks: write
      pull-requests: write
+     issues: write
     timeout-minutes: 120
     concurrency:
      group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-jdk${{ matrix.jdk }}-IntegrationTests_1080
@@ -676,13 +693,14 @@ jobs:
           rsync -R --files-from=artifacts.list . ${{ github.job }}-artifacts
           tar -zcvf ${{ github.job }}-jdk${{ matrix.jdk }}-logs.tar.gz ${{ github.job }}-artifacts
       - name: Publish Test Report
+        continue-on-error: true
         env:
           NODE_OPTIONS: "--max_old_space_size=8192"
         uses: mikepenz/action-junit-report@v5
         if: always()
         with:
          check_name: ${{ inputs.artifact_suffix }}-jdk${{ matrix.jdk }} Report
-         comment: true
+         comment: false
          annotate_only: true
          flaky_summary: true
          commit: ${{github.event.workflow_run.head_sha}}
@@ -718,6 +736,7 @@ jobs:
      contents: read
      checks: write
      pull-requests: write
+     issues: write
     timeout-minutes: 120
     concurrency:
      group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-jdk${{ matrix.jdk }}-IntegrationTests_1090
@@ -753,13 +772,14 @@ jobs:
           rsync -R --files-from=artifacts.list . ${{ github.job }}-artifacts
           tar -zcvf ${{ github.job }}-jdk${{ matrix.jdk }}-logs.tar.gz ${{ github.job }}-artifacts
       - name: Publish Test Report
+        continue-on-error: true
         env:
           NODE_OPTIONS: "--max_old_space_size=8192"
         uses: mikepenz/action-junit-report@v5
         if: always()
         with:
          check_name: ${{ inputs.artifact_suffix }}-jdk${{ matrix.jdk }} Report
-         comment: true
+         comment: false
          annotate_only: true
          flaky_summary: true
          commit: ${{github.event.workflow_run.head_sha}}
@@ -795,6 +815,7 @@ jobs:
      contents: read
      checks: write
      pull-requests: write
+     issues: write
     timeout-minutes: 120
     concurrency:
      group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-jdk${{ matrix.jdk }}-IntegrationTests_1100
@@ -830,13 +851,14 @@ jobs:
           rsync -R --files-from=artifacts.list . ${{ github.job }}-artifacts
           tar -zcvf ${{ github.job }}-jdk${{ matrix.jdk }}-logs.tar.gz ${{ github.job }}-artifacts
       - name: Publish Test Report
+        continue-on-error: true
         env:
           NODE_OPTIONS: "--max_old_space_size=8192"
         uses: mikepenz/action-junit-report@v5
         if: always()
         with:
          check_name: ${{ inputs.artifact_suffix }}-jdk${{ matrix.jdk }} Report
-         comment: true
+         comment: false
          annotate_only: true
          flaky_summary: true
          commit: ${{github.event.workflow_run.head_sha}}
@@ -872,6 +894,7 @@ jobs:
      contents: read
      checks: write
      pull-requests: write
+     issues: write
     timeout-minutes: 120
     concurrency:
      group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-jdk${{ matrix.jdk }}-IntegrationTests_1110
@@ -907,13 +930,14 @@ jobs:
           rsync -R --files-from=artifacts.list . ${{ github.job }}-artifacts
           tar -zcvf ${{ github.job }}-jdk${{ matrix.jdk }}-logs.tar.gz ${{ github.job }}-artifacts
       - name: Publish Test Report
+        continue-on-error: true
         env:
           NODE_OPTIONS: "--max_old_space_size=8192"
         uses: mikepenz/action-junit-report@v5
         if: always()
         with:
          check_name: ${{ inputs.artifact_suffix }}-jdk${{ matrix.jdk }} Report
-         comment: true
+         comment: false
          annotate_only: true
          flaky_summary: true
          commit: ${{github.event.workflow_run.head_sha}}
@@ -949,6 +973,7 @@ jobs:
      contents: read
      checks: write
      pull-requests: write
+     issues: write
     timeout-minutes: 120
     concurrency:
      group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-jdk${{ matrix.jdk }}-IntegrationTests_1120
@@ -984,13 +1009,14 @@ jobs:
           rsync -R --files-from=artifacts.list . ${{ github.job }}-artifacts
           tar -zcvf ${{ github.job }}-jdk${{ matrix.jdk }}-logs.tar.gz ${{ github.job }}-artifacts
       - name: Publish Test Report
+        continue-on-error: true
         env:
           NODE_OPTIONS: "--max_old_space_size=8192"
         uses: mikepenz/action-junit-report@v5
         if: always()
         with:
          check_name: ${{ inputs.artifact_suffix }}-jdk${{ matrix.jdk }} Report
-         comment: true
+         comment: false
          annotate_only: true
          flaky_summary: true
          commit: ${{github.event.workflow_run.head_sha}}
@@ -1026,6 +1052,7 @@ jobs:
      contents: read
      checks: write
      pull-requests: write
+     issues: write
     timeout-minutes: 120
     concurrency:
      group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-jdk${{ matrix.jdk }}-IntegrationTests_1130
@@ -1061,13 +1088,14 @@ jobs:
           rsync -R --files-from=artifacts.list . ${{ github.job }}-artifacts
           tar -zcvf ${{ github.job }}-jdk${{ matrix.jdk }}-logs.tar.gz ${{ github.job }}-artifacts
       - name: Publish Test Report
+        continue-on-error: true
         env:
           NODE_OPTIONS: "--max_old_space_size=8192"
         uses: mikepenz/action-junit-report@v5
         if: always()
         with:
          check_name: ${{ inputs.artifact_suffix }}-jdk${{ matrix.jdk }} Report
-         comment: true
+         comment: false
          annotate_only: true
          flaky_summary: true
          commit: ${{github.event.workflow_run.head_sha}}
@@ -1103,6 +1131,7 @@ jobs:
      contents: read
      checks: write
      pull-requests: write
+     issues: write
     timeout-minutes: 120
     concurrency:
      group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-jdk${{ matrix.jdk }}-IntegrationTests_1200
@@ -1138,13 +1167,14 @@ jobs:
           rsync -R --files-from=artifacts.list . ${{ github.job }}-artifacts
           tar -zcvf ${{ github.job }}-jdk${{ matrix.jdk }}-logs.tar.gz ${{ github.job }}-artifacts
       - name: Publish Test Report
+        continue-on-error: true
         env:
           NODE_OPTIONS: "--max_old_space_size=8192"
         uses: mikepenz/action-junit-report@v5
         if: always()
         with:
          check_name: ${{ inputs.artifact_suffix }}-jdk${{ matrix.jdk }} Report
-         comment: true
+         comment: false
          annotate_only: true
          flaky_summary: true
          commit: ${{github.event.workflow_run.head_sha}}
@@ -1180,6 +1210,7 @@ jobs:
      contents: read
      checks: write
      pull-requests: write
+     issues: write
     timeout-minutes: 120
     concurrency:
      group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-jdk${{ matrix.jdk }}-IntegrationTests_1210
@@ -1215,13 +1246,14 @@ jobs:
           rsync -R --files-from=artifacts.list . ${{ github.job }}-artifacts
           tar -zcvf ${{ github.job }}-jdk${{ matrix.jdk }}-logs.tar.gz ${{ github.job }}-artifacts
       - name: Publish Test Report
+        continue-on-error: true
         env:
           NODE_OPTIONS: "--max_old_space_size=8192"
         uses: mikepenz/action-junit-report@v5
         if: always()
         with:
          check_name: ${{ inputs.artifact_suffix }}-jdk${{ matrix.jdk }} Report
-         comment: true
+         comment: false
          annotate_only: true
          flaky_summary: true
          commit: ${{github.event.workflow_run.head_sha}}
@@ -1257,6 +1289,7 @@ jobs:
      contents: read
      checks: write
      pull-requests: write
+     issues: write
     timeout-minutes: 120
     concurrency:
      group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-jdk${{ matrix.jdk }}-IntegrationTests_1220
@@ -1292,13 +1325,14 @@ jobs:
           rsync -R --files-from=artifacts.list . ${{ github.job }}-artifacts
           tar -zcvf ${{ github.job }}-jdk${{ matrix.jdk }}-logs.tar.gz ${{ github.job }}-artifacts
       - name: Publish Test Report
+        continue-on-error: true
         env:
           NODE_OPTIONS: "--max_old_space_size=8192"
         uses: mikepenz/action-junit-report@v5
         if: always()
         with:
          check_name: ${{ inputs.artifact_suffix }}-jdk${{ matrix.jdk }} Report
-         comment: true
+         comment: false
          annotate_only: true
          flaky_summary: true
          commit: ${{github.event.workflow_run.head_sha}}
@@ -1334,6 +1368,7 @@ jobs:
      contents: read
      checks: write
      pull-requests: write
+     issues: write
     timeout-minutes: 120
     concurrency:
      group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-jdk${{ matrix.jdk }}-IntegrationTests_1230
@@ -1369,13 +1404,14 @@ jobs:
           rsync -R --files-from=artifacts.list . ${{ github.job }}-artifacts
           tar -zcvf ${{ github.job }}-jdk${{ matrix.jdk }}-logs.tar.gz ${{ github.job }}-artifacts
       - name: Publish Test Report
+        continue-on-error: true
         env:
           NODE_OPTIONS: "--max_old_space_size=8192"
         uses: mikepenz/action-junit-report@v5
         if: always()
         with:
          check_name: ${{ inputs.artifact_suffix }}-jdk${{ matrix.jdk }} Report
-         comment: true
+         comment: false
          annotate_only: true
          flaky_summary: true
          commit: ${{github.event.workflow_run.head_sha}}
@@ -1411,6 +1447,7 @@ jobs:
      contents: read
      checks: write
      pull-requests: write
+     issues: write
     timeout-minutes: 120
     concurrency:
      group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-jdk${{ matrix.jdk }}-IntegrationTests_1240
@@ -1446,13 +1483,14 @@ jobs:
           rsync -R --files-from=artifacts.list . ${{ github.job }}-artifacts
           tar -zcvf ${{ github.job }}-jdk${{ matrix.jdk }}-logs.tar.gz ${{ github.job }}-artifacts
       - name: Publish Test Report
+        continue-on-error: true
         env:
           NODE_OPTIONS: "--max_old_space_size=8192"
         uses: mikepenz/action-junit-report@v5
         if: always()
         with:
          check_name: ${{ inputs.artifact_suffix }}-jdk${{ matrix.jdk }} Report
-         comment: true
+         comment: false
          annotate_only: true
          flaky_summary: true
          commit: ${{github.event.workflow_run.head_sha}}
@@ -1488,6 +1526,7 @@ jobs:
      contents: read
      checks: write
      pull-requests: write
+     issues: write
     timeout-minutes: 120
     concurrency:
      group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-jdk${{ matrix.jdk }}-IntegrationTests_1250
@@ -1523,13 +1562,14 @@ jobs:
           rsync -R --files-from=artifacts.list . ${{ github.job }}-artifacts
           tar -zcvf ${{ github.job }}-jdk${{ matrix.jdk }}-logs.tar.gz ${{ github.job }}-artifacts
       - name: Publish Test Report
+        continue-on-error: true
         env:
           NODE_OPTIONS: "--max_old_space_size=8192"
         uses: mikepenz/action-junit-report@v5
         if: always()
         with:
          check_name: ${{ inputs.artifact_suffix }}-jdk${{ matrix.jdk }} Report
-         comment: true
+         comment: false
          annotate_only: true
          flaky_summary: true
          commit: ${{github.event.workflow_run.head_sha}}
@@ -1565,6 +1605,7 @@ jobs:
      contents: read
      checks: write
      pull-requests: write
+     issues: write
     timeout-minutes: 120
     concurrency:
      group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-jdk${{ matrix.jdk }}-IntegrationTests_1260
@@ -1600,13 +1641,14 @@ jobs:
           rsync -R --files-from=artifacts.list . ${{ github.job }}-artifacts
           tar -zcvf ${{ github.job }}-jdk${{ matrix.jdk }}-logs.tar.gz ${{ github.job }}-artifacts
       - name: Publish Test Report
+        continue-on-error: true
         env:
           NODE_OPTIONS: "--max_old_space_size=8192"
         uses: mikepenz/action-junit-report@v5
         if: always()
         with:
          check_name: ${{ inputs.artifact_suffix }}-jdk${{ matrix.jdk }} Report
-         comment: true
+         comment: false
          annotate_only: true
          flaky_summary: true
          commit: ${{github.event.workflow_run.head_sha}}
@@ -1642,6 +1684,7 @@ jobs:
      contents: read
      checks: write
      pull-requests: write
+     issues: write
     timeout-minutes: 120
     concurrency:
      group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-jdk${{ matrix.jdk }}-IntegrationTests_1270
@@ -1677,13 +1720,14 @@ jobs:
           rsync -R --files-from=artifacts.list . ${{ github.job }}-artifacts
           tar -zcvf ${{ github.job }}-jdk${{ matrix.jdk }}-logs.tar.gz ${{ github.job }}-artifacts
       - name: Publish Test Report
+        continue-on-error: true
         env:
           NODE_OPTIONS: "--max_old_space_size=8192"
         uses: mikepenz/action-junit-report@v5
         if: always()
         with:
          check_name: ${{ inputs.artifact_suffix }}-jdk${{ matrix.jdk }} Report
-         comment: true
+         comment: false
          annotate_only: true
          flaky_summary: true
          commit: ${{github.event.workflow_run.head_sha}}
@@ -1719,6 +1763,7 @@ jobs:
      contents: read
      checks: write
      pull-requests: write
+     issues: write
     timeout-minutes: 120
     concurrency:
      group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-jdk${{ matrix.jdk }}-IntegrationTests_1280
@@ -1754,13 +1799,14 @@ jobs:
           rsync -R --files-from=artifacts.list . ${{ github.job }}-artifacts
           tar -zcvf ${{ github.job }}-jdk${{ matrix.jdk }}-logs.tar.gz ${{ github.job }}-artifacts
       - name: Publish Test Report
+        continue-on-error: true
         env:
           NODE_OPTIONS: "--max_old_space_size=8192"
         uses: mikepenz/action-junit-report@v5
         if: always()
         with:
          check_name: ${{ inputs.artifact_suffix }}-jdk${{ matrix.jdk }} Report
-         comment: true
+         comment: false
          annotate_only: true
          flaky_summary: true
          commit: ${{github.event.workflow_run.head_sha}}
@@ -1796,6 +1842,7 @@ jobs:
      contents: read
      checks: write
      pull-requests: write
+     issues: write
     timeout-minutes: 120
     concurrency:
      group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-jdk${{ matrix.jdk }}-IntegrationTests_1400
@@ -1831,13 +1878,14 @@ jobs:
           rsync -R --files-from=artifacts.list . ${{ github.job }}-artifacts
           tar -zcvf ${{ github.job }}-jdk${{ matrix.jdk }}-logs.tar.gz ${{ github.job }}-artifacts
       - name: Publish Test Report
+        continue-on-error: true
         env:
           NODE_OPTIONS: "--max_old_space_size=8192"
         uses: mikepenz/action-junit-report@v5
         if: always()
         with:
          check_name: ${{ inputs.artifact_suffix }}-jdk${{ matrix.jdk }} Report
-         comment: true
+         comment: false
          annotate_only: true
          flaky_summary: true
          commit: ${{github.event.workflow_run.head_sha}}
@@ -1873,6 +1921,7 @@ jobs:
      contents: read
      checks: write
      pull-requests: write
+     issues: write
     timeout-minutes: 120
     concurrency:
      group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-jdk${{ matrix.jdk }}-IntegrationTests_1410
@@ -1908,13 +1957,14 @@ jobs:
           rsync -R --files-from=artifacts.list . ${{ github.job }}-artifacts
           tar -zcvf ${{ github.job }}-jdk${{ matrix.jdk }}-logs.tar.gz ${{ github.job }}-artifacts
       - name: Publish Test Report
+        continue-on-error: true
         env:
           NODE_OPTIONS: "--max_old_space_size=8192"
         uses: mikepenz/action-junit-report@v5
         if: always()
         with:
          check_name: ${{ inputs.artifact_suffix }}-jdk${{ matrix.jdk }} Report
-         comment: true
+         comment: false
          annotate_only: true
          flaky_summary: true
          commit: ${{github.event.workflow_run.head_sha}}
@@ -1950,6 +2000,7 @@ jobs:
      contents: read
      checks: write
      pull-requests: write
+     issues: write
     timeout-minutes: 120
     concurrency:
      group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-jdk${{ matrix.jdk }}-IntegrationTests_1420
@@ -1985,13 +2036,14 @@ jobs:
           rsync -R --files-from=artifacts.list . ${{ github.job }}-artifacts
           tar -zcvf ${{ github.job }}-jdk${{ matrix.jdk }}-logs.tar.gz ${{ github.job }}-artifacts
       - name: Publish Test Report
+        continue-on-error: true
         env:
           NODE_OPTIONS: "--max_old_space_size=8192"
         uses: mikepenz/action-junit-report@v5
         if: always()
         with:
          check_name: ${{ inputs.artifact_suffix }}-jdk${{ matrix.jdk }} Report
-         comment: true
+         comment: false
          annotate_only: true
          flaky_summary: true
          commit: ${{github.event.workflow_run.head_sha}}
@@ -2027,6 +2079,7 @@ jobs:
      contents: read
      checks: write
      pull-requests: write
+     issues: write
     timeout-minutes: 120
     concurrency:
      group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-jdk${{ matrix.jdk }}-IntegrationTests_1430
@@ -2062,13 +2115,14 @@ jobs:
           rsync -R --files-from=artifacts.list . ${{ github.job }}-artifacts
           tar -zcvf ${{ github.job }}-jdk${{ matrix.jdk }}-logs.tar.gz ${{ github.job }}-artifacts
       - name: Publish Test Report
+        continue-on-error: true
         env:
           NODE_OPTIONS: "--max_old_space_size=8192"
         uses: mikepenz/action-junit-report@v5
         if: always()
         with:
          check_name: ${{ inputs.artifact_suffix }}-jdk${{ matrix.jdk }} Report
-         comment: true
+         comment: false
          annotate_only: true
          flaky_summary: true
          commit: ${{github.event.workflow_run.head_sha}}
@@ -2104,6 +2158,7 @@ jobs:
      contents: read
      checks: write
      pull-requests: write
+     issues: write
     timeout-minutes: 120
     concurrency:
      group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-jdk${{ matrix.jdk }}-IntegrationTests_1440
@@ -2139,13 +2194,14 @@ jobs:
           rsync -R --files-from=artifacts.list . ${{ github.job }}-artifacts
           tar -zcvf ${{ github.job }}-jdk${{ matrix.jdk }}-logs.tar.gz ${{ github.job }}-artifacts
       - name: Publish Test Report
+        continue-on-error: true
         env:
           NODE_OPTIONS: "--max_old_space_size=8192"
         uses: mikepenz/action-junit-report@v5
         if: always()
         with:
          check_name: ${{ inputs.artifact_suffix }}-jdk${{ matrix.jdk }} Report
-         comment: true
+         comment: false
          annotate_only: true
          flaky_summary: true
          commit: ${{github.event.workflow_run.head_sha}}
@@ -2181,6 +2237,7 @@ jobs:
      contents: read
      checks: write
      pull-requests: write
+     issues: write
     timeout-minutes: 120
     concurrency:
      group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-jdk${{ matrix.jdk }}-IntegrationTests_1500
@@ -2216,13 +2273,14 @@ jobs:
           rsync -R --files-from=artifacts.list . ${{ github.job }}-artifacts
           tar -zcvf ${{ github.job }}-jdk${{ matrix.jdk }}-logs.tar.gz ${{ github.job }}-artifacts
       - name: Publish Test Report
+        continue-on-error: true
         env:
           NODE_OPTIONS: "--max_old_space_size=8192"
         uses: mikepenz/action-junit-report@v5
         if: always()
         with:
          check_name: ${{ inputs.artifact_suffix }}-jdk${{ matrix.jdk }} Report
-         comment: true
+         comment: false
          annotate_only: true
          flaky_summary: true
          commit: ${{github.event.workflow_run.head_sha}}
@@ -2258,6 +2316,7 @@ jobs:
      contents: read
      checks: write
      pull-requests: write
+     issues: write
     timeout-minutes: 120
     concurrency:
      group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-jdk${{ matrix.jdk }}-IntegrationTests_1550
@@ -2293,13 +2352,14 @@ jobs:
           rsync -R --files-from=artifacts.list . ${{ github.job }}-artifacts
           tar -zcvf ${{ github.job }}-jdk${{ matrix.jdk }}-logs.tar.gz ${{ github.job }}-artifacts
       - name: Publish Test Report
+        continue-on-error: true
         env:
           NODE_OPTIONS: "--max_old_space_size=8192"
         uses: mikepenz/action-junit-report@v5
         if: always()
         with:
          check_name: ${{ inputs.artifact_suffix }}-jdk${{ matrix.jdk }} Report
-         comment: true
+         comment: false
          annotate_only: true
          flaky_summary: true
          commit: ${{github.event.workflow_run.head_sha}}
@@ -2335,6 +2395,7 @@ jobs:
      contents: read
      checks: write
      pull-requests: write
+     issues: write
     timeout-minutes: 120
     concurrency:
      group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-jdk${{ matrix.jdk }}-IntegrationTests_9999
@@ -2370,13 +2431,14 @@ jobs:
           rsync -R --files-from=artifacts.list . ${{ github.job }}-artifacts
           tar -zcvf ${{ github.job }}-jdk${{ matrix.jdk }}-logs.tar.gz ${{ github.job }}-artifacts
       - name: Publish Test Report
+        continue-on-error: true
         env:
           NODE_OPTIONS: "--max_old_space_size=8192"
         uses: mikepenz/action-junit-report@v5
         if: always()
         with:
          check_name: ${{ inputs.artifact_suffix }}-jdk${{ matrix.jdk }} Report
-         comment: true
+         comment: false
          annotate_only: true
          flaky_summary: true
          commit: ${{github.event.workflow_run.head_sha}}

--- a/.github/workflows/VeniceCI-E2ETests.yml
+++ b/.github/workflows/VeniceCI-E2ETests.yml
@@ -69,7 +69,7 @@ jobs:
         uses: mikepenz/action-junit-report@v5
         if: always()
         with:
-         check_name: ${{ inputs.artifact_suffix }}-jdk${{ matrix.jdk }} Report
+         check_name: ${{ github.job }}-jdk${{ matrix.jdk }} Report
          comment: false
          annotate_only: true
          flaky_summary: true
@@ -84,7 +84,7 @@ jobs:
           path: ${{ github.job }}-jdk${{ matrix.jdk }}-logs.tar.gz
           retention-days: 30
       - name: Upload test results to BuildPulse for flaky test detection
-        if: '!cancelled()' # Run this step even when the tests fail. Skip if the workflow is cancelled.
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main' && !cancelled()
         uses: buildpulse/buildpulse-action@main
         with:
           account: 100582612927
@@ -150,7 +150,7 @@ jobs:
         uses: mikepenz/action-junit-report@v5
         if: always()
         with:
-         check_name: ${{ inputs.artifact_suffix }}-jdk${{ matrix.jdk }} Report
+         check_name: ${{ github.job }}-jdk${{ matrix.jdk }} Report
          comment: false
          annotate_only: true
          flaky_summary: true
@@ -165,7 +165,7 @@ jobs:
           path: ${{ github.job }}-jdk${{ matrix.jdk }}-logs.tar.gz
           retention-days: 30
       - name: Upload test results to BuildPulse for flaky test detection
-        if: '!cancelled()' # Run this step even when the tests fail. Skip if the workflow is cancelled.
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main' && !cancelled()
         uses: buildpulse/buildpulse-action@main
         with:
           account: 100582612927
@@ -231,7 +231,7 @@ jobs:
         uses: mikepenz/action-junit-report@v5
         if: always()
         with:
-         check_name: ${{ inputs.artifact_suffix }}-jdk${{ matrix.jdk }} Report
+         check_name: ${{ github.job }}-jdk${{ matrix.jdk }} Report
          comment: false
          annotate_only: true
          flaky_summary: true
@@ -246,7 +246,7 @@ jobs:
           path: ${{ github.job }}-jdk${{ matrix.jdk }}-logs.tar.gz
           retention-days: 30
       - name: Upload test results to BuildPulse for flaky test detection
-        if: '!cancelled()' # Run this step even when the tests fail. Skip if the workflow is cancelled.
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main' && !cancelled()
         uses: buildpulse/buildpulse-action@main
         with:
           account: 100582612927
@@ -312,7 +312,7 @@ jobs:
         uses: mikepenz/action-junit-report@v5
         if: always()
         with:
-         check_name: ${{ inputs.artifact_suffix }}-jdk${{ matrix.jdk }} Report
+         check_name: ${{ github.job }}-jdk${{ matrix.jdk }} Report
          comment: false
          annotate_only: true
          flaky_summary: true
@@ -327,7 +327,7 @@ jobs:
           path: ${{ github.job }}-jdk${{ matrix.jdk }}-logs.tar.gz
           retention-days: 30
       - name: Upload test results to BuildPulse for flaky test detection
-        if: '!cancelled()' # Run this step even when the tests fail. Skip if the workflow is cancelled.
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main' && !cancelled()
         uses: buildpulse/buildpulse-action@main
         with:
           account: 100582612927
@@ -393,7 +393,7 @@ jobs:
         uses: mikepenz/action-junit-report@v5
         if: always()
         with:
-         check_name: ${{ inputs.artifact_suffix }}-jdk${{ matrix.jdk }} Report
+         check_name: ${{ github.job }}-jdk${{ matrix.jdk }} Report
          comment: false
          annotate_only: true
          flaky_summary: true
@@ -408,7 +408,7 @@ jobs:
           path: ${{ github.job }}-jdk${{ matrix.jdk }}-logs.tar.gz
           retention-days: 30
       - name: Upload test results to BuildPulse for flaky test detection
-        if: '!cancelled()' # Run this step even when the tests fail. Skip if the workflow is cancelled.
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main' && !cancelled()
         uses: buildpulse/buildpulse-action@main
         with:
           account: 100582612927
@@ -474,7 +474,7 @@ jobs:
         uses: mikepenz/action-junit-report@v5
         if: always()
         with:
-         check_name: ${{ inputs.artifact_suffix }}-jdk${{ matrix.jdk }} Report
+         check_name: ${{ github.job }}-jdk${{ matrix.jdk }} Report
          comment: false
          annotate_only: true
          flaky_summary: true
@@ -489,7 +489,7 @@ jobs:
           path: ${{ github.job }}-jdk${{ matrix.jdk }}-logs.tar.gz
           retention-days: 30
       - name: Upload test results to BuildPulse for flaky test detection
-        if: '!cancelled()' # Run this step even when the tests fail. Skip if the workflow is cancelled.
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main' && !cancelled()
         uses: buildpulse/buildpulse-action@main
         with:
           account: 100582612927
@@ -555,7 +555,7 @@ jobs:
         uses: mikepenz/action-junit-report@v5
         if: always()
         with:
-         check_name: ${{ inputs.artifact_suffix }}-jdk${{ matrix.jdk }} Report
+         check_name: ${{ github.job }}-jdk${{ matrix.jdk }} Report
          comment: false
          annotate_only: true
          flaky_summary: true
@@ -570,7 +570,7 @@ jobs:
           path: ${{ github.job }}-jdk${{ matrix.jdk }}-logs.tar.gz
           retention-days: 30
       - name: Upload test results to BuildPulse for flaky test detection
-        if: '!cancelled()' # Run this step even when the tests fail. Skip if the workflow is cancelled.
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main' && !cancelled()
         uses: buildpulse/buildpulse-action@main
         with:
           account: 100582612927
@@ -636,7 +636,7 @@ jobs:
         uses: mikepenz/action-junit-report@v5
         if: always()
         with:
-         check_name: ${{ inputs.artifact_suffix }}-jdk${{ matrix.jdk }} Report
+         check_name: ${{ github.job }}-jdk${{ matrix.jdk }} Report
          comment: false
          annotate_only: true
          flaky_summary: true
@@ -651,7 +651,7 @@ jobs:
           path: ${{ github.job }}-jdk${{ matrix.jdk }}-logs.tar.gz
           retention-days: 30
       - name: Upload test results to BuildPulse for flaky test detection
-        if: '!cancelled()' # Run this step even when the tests fail. Skip if the workflow is cancelled.
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main' && !cancelled()
         uses: buildpulse/buildpulse-action@main
         with:
           account: 100582612927
@@ -717,7 +717,7 @@ jobs:
         uses: mikepenz/action-junit-report@v5
         if: always()
         with:
-         check_name: ${{ inputs.artifact_suffix }}-jdk${{ matrix.jdk }} Report
+         check_name: ${{ github.job }}-jdk${{ matrix.jdk }} Report
          comment: false
          annotate_only: true
          flaky_summary: true
@@ -732,7 +732,7 @@ jobs:
           path: ${{ github.job }}-jdk${{ matrix.jdk }}-logs.tar.gz
           retention-days: 30
       - name: Upload test results to BuildPulse for flaky test detection
-        if: '!cancelled()' # Run this step even when the tests fail. Skip if the workflow is cancelled.
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main' && !cancelled()
         uses: buildpulse/buildpulse-action@main
         with:
           account: 100582612927
@@ -798,7 +798,7 @@ jobs:
         uses: mikepenz/action-junit-report@v5
         if: always()
         with:
-         check_name: ${{ inputs.artifact_suffix }}-jdk${{ matrix.jdk }} Report
+         check_name: ${{ github.job }}-jdk${{ matrix.jdk }} Report
          comment: false
          annotate_only: true
          flaky_summary: true
@@ -813,7 +813,7 @@ jobs:
           path: ${{ github.job }}-jdk${{ matrix.jdk }}-logs.tar.gz
           retention-days: 30
       - name: Upload test results to BuildPulse for flaky test detection
-        if: '!cancelled()' # Run this step even when the tests fail. Skip if the workflow is cancelled.
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main' && !cancelled()
         uses: buildpulse/buildpulse-action@main
         with:
           account: 100582612927
@@ -879,7 +879,7 @@ jobs:
         uses: mikepenz/action-junit-report@v5
         if: always()
         with:
-         check_name: ${{ inputs.artifact_suffix }}-jdk${{ matrix.jdk }} Report
+         check_name: ${{ github.job }}-jdk${{ matrix.jdk }} Report
          comment: false
          annotate_only: true
          flaky_summary: true
@@ -894,7 +894,7 @@ jobs:
           path: ${{ github.job }}-jdk${{ matrix.jdk }}-logs.tar.gz
           retention-days: 30
       - name: Upload test results to BuildPulse for flaky test detection
-        if: '!cancelled()' # Run this step even when the tests fail. Skip if the workflow is cancelled.
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main' && !cancelled()
         uses: buildpulse/buildpulse-action@main
         with:
           account: 100582612927
@@ -960,7 +960,7 @@ jobs:
         uses: mikepenz/action-junit-report@v5
         if: always()
         with:
-         check_name: ${{ inputs.artifact_suffix }}-jdk${{ matrix.jdk }} Report
+         check_name: ${{ github.job }}-jdk${{ matrix.jdk }} Report
          comment: false
          annotate_only: true
          flaky_summary: true
@@ -975,7 +975,7 @@ jobs:
           path: ${{ github.job }}-jdk${{ matrix.jdk }}-logs.tar.gz
           retention-days: 30
       - name: Upload test results to BuildPulse for flaky test detection
-        if: '!cancelled()' # Run this step even when the tests fail. Skip if the workflow is cancelled.
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main' && !cancelled()
         uses: buildpulse/buildpulse-action@main
         with:
           account: 100582612927
@@ -1041,7 +1041,7 @@ jobs:
         uses: mikepenz/action-junit-report@v5
         if: always()
         with:
-         check_name: ${{ inputs.artifact_suffix }}-jdk${{ matrix.jdk }} Report
+         check_name: ${{ github.job }}-jdk${{ matrix.jdk }} Report
          comment: false
          annotate_only: true
          flaky_summary: true
@@ -1056,7 +1056,7 @@ jobs:
           path: ${{ github.job }}-jdk${{ matrix.jdk }}-logs.tar.gz
           retention-days: 30
       - name: Upload test results to BuildPulse for flaky test detection
-        if: '!cancelled()' # Run this step even when the tests fail. Skip if the workflow is cancelled.
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main' && !cancelled()
         uses: buildpulse/buildpulse-action@main
         with:
           account: 100582612927
@@ -1122,7 +1122,7 @@ jobs:
         uses: mikepenz/action-junit-report@v5
         if: always()
         with:
-         check_name: ${{ inputs.artifact_suffix }}-jdk${{ matrix.jdk }} Report
+         check_name: ${{ github.job }}-jdk${{ matrix.jdk }} Report
          comment: false
          annotate_only: true
          flaky_summary: true
@@ -1137,7 +1137,7 @@ jobs:
           path: ${{ github.job }}-jdk${{ matrix.jdk }}-logs.tar.gz
           retention-days: 30
       - name: Upload test results to BuildPulse for flaky test detection
-        if: '!cancelled()' # Run this step even when the tests fail. Skip if the workflow is cancelled.
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main' && !cancelled()
         uses: buildpulse/buildpulse-action@main
         with:
           account: 100582612927
@@ -1203,7 +1203,7 @@ jobs:
         uses: mikepenz/action-junit-report@v5
         if: always()
         with:
-         check_name: ${{ inputs.artifact_suffix }}-jdk${{ matrix.jdk }} Report
+         check_name: ${{ github.job }}-jdk${{ matrix.jdk }} Report
          comment: false
          annotate_only: true
          flaky_summary: true
@@ -1218,7 +1218,7 @@ jobs:
           path: ${{ github.job }}-jdk${{ matrix.jdk }}-logs.tar.gz
           retention-days: 30
       - name: Upload test results to BuildPulse for flaky test detection
-        if: '!cancelled()' # Run this step even when the tests fail. Skip if the workflow is cancelled.
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main' && !cancelled()
         uses: buildpulse/buildpulse-action@main
         with:
           account: 100582612927
@@ -1284,7 +1284,7 @@ jobs:
         uses: mikepenz/action-junit-report@v5
         if: always()
         with:
-         check_name: ${{ inputs.artifact_suffix }}-jdk${{ matrix.jdk }} Report
+         check_name: ${{ github.job }}-jdk${{ matrix.jdk }} Report
          comment: false
          annotate_only: true
          flaky_summary: true
@@ -1299,7 +1299,7 @@ jobs:
           path: ${{ github.job }}-jdk${{ matrix.jdk }}-logs.tar.gz
           retention-days: 30
       - name: Upload test results to BuildPulse for flaky test detection
-        if: '!cancelled()' # Run this step even when the tests fail. Skip if the workflow is cancelled.
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main' && !cancelled()
         uses: buildpulse/buildpulse-action@main
         with:
           account: 100582612927
@@ -1365,7 +1365,7 @@ jobs:
         uses: mikepenz/action-junit-report@v5
         if: always()
         with:
-         check_name: ${{ inputs.artifact_suffix }}-jdk${{ matrix.jdk }} Report
+         check_name: ${{ github.job }}-jdk${{ matrix.jdk }} Report
          comment: false
          annotate_only: true
          flaky_summary: true
@@ -1380,7 +1380,7 @@ jobs:
           path: ${{ github.job }}-jdk${{ matrix.jdk }}-logs.tar.gz
           retention-days: 30
       - name: Upload test results to BuildPulse for flaky test detection
-        if: '!cancelled()' # Run this step even when the tests fail. Skip if the workflow is cancelled.
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main' && !cancelled()
         uses: buildpulse/buildpulse-action@main
         with:
           account: 100582612927
@@ -1446,7 +1446,7 @@ jobs:
         uses: mikepenz/action-junit-report@v5
         if: always()
         with:
-         check_name: ${{ inputs.artifact_suffix }}-jdk${{ matrix.jdk }} Report
+         check_name: ${{ github.job }}-jdk${{ matrix.jdk }} Report
          comment: false
          annotate_only: true
          flaky_summary: true
@@ -1461,7 +1461,7 @@ jobs:
           path: ${{ github.job }}-jdk${{ matrix.jdk }}-logs.tar.gz
           retention-days: 30
       - name: Upload test results to BuildPulse for flaky test detection
-        if: '!cancelled()' # Run this step even when the tests fail. Skip if the workflow is cancelled.
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main' && !cancelled()
         uses: buildpulse/buildpulse-action@main
         with:
           account: 100582612927
@@ -1527,7 +1527,7 @@ jobs:
         uses: mikepenz/action-junit-report@v5
         if: always()
         with:
-         check_name: ${{ inputs.artifact_suffix }}-jdk${{ matrix.jdk }} Report
+         check_name: ${{ github.job }}-jdk${{ matrix.jdk }} Report
          comment: false
          annotate_only: true
          flaky_summary: true
@@ -1542,7 +1542,7 @@ jobs:
           path: ${{ github.job }}-jdk${{ matrix.jdk }}-logs.tar.gz
           retention-days: 30
       - name: Upload test results to BuildPulse for flaky test detection
-        if: '!cancelled()' # Run this step even when the tests fail. Skip if the workflow is cancelled.
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main' && !cancelled()
         uses: buildpulse/buildpulse-action@main
         with:
           account: 100582612927
@@ -1608,7 +1608,7 @@ jobs:
         uses: mikepenz/action-junit-report@v5
         if: always()
         with:
-         check_name: ${{ inputs.artifact_suffix }}-jdk${{ matrix.jdk }} Report
+         check_name: ${{ github.job }}-jdk${{ matrix.jdk }} Report
          comment: false
          annotate_only: true
          flaky_summary: true
@@ -1623,7 +1623,7 @@ jobs:
           path: ${{ github.job }}-jdk${{ matrix.jdk }}-logs.tar.gz
           retention-days: 30
       - name: Upload test results to BuildPulse for flaky test detection
-        if: '!cancelled()' # Run this step even when the tests fail. Skip if the workflow is cancelled.
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main' && !cancelled()
         uses: buildpulse/buildpulse-action@main
         with:
           account: 100582612927
@@ -1689,7 +1689,7 @@ jobs:
         uses: mikepenz/action-junit-report@v5
         if: always()
         with:
-         check_name: ${{ inputs.artifact_suffix }}-jdk${{ matrix.jdk }} Report
+         check_name: ${{ github.job }}-jdk${{ matrix.jdk }} Report
          comment: false
          annotate_only: true
          flaky_summary: true
@@ -1704,7 +1704,7 @@ jobs:
           path: ${{ github.job }}-jdk${{ matrix.jdk }}-logs.tar.gz
           retention-days: 30
       - name: Upload test results to BuildPulse for flaky test detection
-        if: '!cancelled()' # Run this step even when the tests fail. Skip if the workflow is cancelled.
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main' && !cancelled()
         uses: buildpulse/buildpulse-action@main
         with:
           account: 100582612927
@@ -1770,7 +1770,7 @@ jobs:
         uses: mikepenz/action-junit-report@v5
         if: always()
         with:
-         check_name: ${{ inputs.artifact_suffix }}-jdk${{ matrix.jdk }} Report
+         check_name: ${{ github.job }}-jdk${{ matrix.jdk }} Report
          comment: false
          annotate_only: true
          flaky_summary: true
@@ -1785,7 +1785,7 @@ jobs:
           path: ${{ github.job }}-jdk${{ matrix.jdk }}-logs.tar.gz
           retention-days: 30
       - name: Upload test results to BuildPulse for flaky test detection
-        if: '!cancelled()' # Run this step even when the tests fail. Skip if the workflow is cancelled.
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main' && !cancelled()
         uses: buildpulse/buildpulse-action@main
         with:
           account: 100582612927
@@ -1851,7 +1851,7 @@ jobs:
         uses: mikepenz/action-junit-report@v5
         if: always()
         with:
-         check_name: ${{ inputs.artifact_suffix }}-jdk${{ matrix.jdk }} Report
+         check_name: ${{ github.job }}-jdk${{ matrix.jdk }} Report
          comment: false
          annotate_only: true
          flaky_summary: true
@@ -1866,7 +1866,7 @@ jobs:
           path: ${{ github.job }}-jdk${{ matrix.jdk }}-logs.tar.gz
           retention-days: 30
       - name: Upload test results to BuildPulse for flaky test detection
-        if: '!cancelled()' # Run this step even when the tests fail. Skip if the workflow is cancelled.
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main' && !cancelled()
         uses: buildpulse/buildpulse-action@main
         with:
           account: 100582612927
@@ -1932,7 +1932,7 @@ jobs:
         uses: mikepenz/action-junit-report@v5
         if: always()
         with:
-         check_name: ${{ inputs.artifact_suffix }}-jdk${{ matrix.jdk }} Report
+         check_name: ${{ github.job }}-jdk${{ matrix.jdk }} Report
          comment: false
          annotate_only: true
          flaky_summary: true
@@ -1947,7 +1947,7 @@ jobs:
           path: ${{ github.job }}-jdk${{ matrix.jdk }}-logs.tar.gz
           retention-days: 30
       - name: Upload test results to BuildPulse for flaky test detection
-        if: '!cancelled()' # Run this step even when the tests fail. Skip if the workflow is cancelled.
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main' && !cancelled()
         uses: buildpulse/buildpulse-action@main
         with:
           account: 100582612927
@@ -2013,7 +2013,7 @@ jobs:
         uses: mikepenz/action-junit-report@v5
         if: always()
         with:
-         check_name: ${{ inputs.artifact_suffix }}-jdk${{ matrix.jdk }} Report
+         check_name: ${{ github.job }}-jdk${{ matrix.jdk }} Report
          comment: false
          annotate_only: true
          flaky_summary: true
@@ -2028,7 +2028,7 @@ jobs:
           path: ${{ github.job }}-jdk${{ matrix.jdk }}-logs.tar.gz
           retention-days: 30
       - name: Upload test results to BuildPulse for flaky test detection
-        if: '!cancelled()' # Run this step even when the tests fail. Skip if the workflow is cancelled.
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main' && !cancelled()
         uses: buildpulse/buildpulse-action@main
         with:
           account: 100582612927
@@ -2094,7 +2094,7 @@ jobs:
         uses: mikepenz/action-junit-report@v5
         if: always()
         with:
-         check_name: ${{ inputs.artifact_suffix }}-jdk${{ matrix.jdk }} Report
+         check_name: ${{ github.job }}-jdk${{ matrix.jdk }} Report
          comment: false
          annotate_only: true
          flaky_summary: true
@@ -2109,7 +2109,7 @@ jobs:
           path: ${{ github.job }}-jdk${{ matrix.jdk }}-logs.tar.gz
           retention-days: 30
       - name: Upload test results to BuildPulse for flaky test detection
-        if: '!cancelled()' # Run this step even when the tests fail. Skip if the workflow is cancelled.
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main' && !cancelled()
         uses: buildpulse/buildpulse-action@main
         with:
           account: 100582612927
@@ -2175,7 +2175,7 @@ jobs:
         uses: mikepenz/action-junit-report@v5
         if: always()
         with:
-         check_name: ${{ inputs.artifact_suffix }}-jdk${{ matrix.jdk }} Report
+         check_name: ${{ github.job }}-jdk${{ matrix.jdk }} Report
          comment: false
          annotate_only: true
          flaky_summary: true
@@ -2190,7 +2190,7 @@ jobs:
           path: ${{ github.job }}-jdk${{ matrix.jdk }}-logs.tar.gz
           retention-days: 30
       - name: Upload test results to BuildPulse for flaky test detection
-        if: '!cancelled()' # Run this step even when the tests fail. Skip if the workflow is cancelled.
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main' && !cancelled()
         uses: buildpulse/buildpulse-action@main
         with:
           account: 100582612927
@@ -2256,7 +2256,7 @@ jobs:
         uses: mikepenz/action-junit-report@v5
         if: always()
         with:
-         check_name: ${{ inputs.artifact_suffix }}-jdk${{ matrix.jdk }} Report
+         check_name: ${{ github.job }}-jdk${{ matrix.jdk }} Report
          comment: false
          annotate_only: true
          flaky_summary: true
@@ -2271,7 +2271,7 @@ jobs:
           path: ${{ github.job }}-jdk${{ matrix.jdk }}-logs.tar.gz
           retention-days: 30
       - name: Upload test results to BuildPulse for flaky test detection
-        if: '!cancelled()' # Run this step even when the tests fail. Skip if the workflow is cancelled.
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main' && !cancelled()
         uses: buildpulse/buildpulse-action@main
         with:
           account: 100582612927
@@ -2337,7 +2337,7 @@ jobs:
         uses: mikepenz/action-junit-report@v5
         if: always()
         with:
-         check_name: ${{ inputs.artifact_suffix }}-jdk${{ matrix.jdk }} Report
+         check_name: ${{ github.job }}-jdk${{ matrix.jdk }} Report
          comment: false
          annotate_only: true
          flaky_summary: true
@@ -2352,7 +2352,7 @@ jobs:
           path: ${{ github.job }}-jdk${{ matrix.jdk }}-logs.tar.gz
           retention-days: 30
       - name: Upload test results to BuildPulse for flaky test detection
-        if: '!cancelled()' # Run this step even when the tests fail. Skip if the workflow is cancelled.
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main' && !cancelled()
         uses: buildpulse/buildpulse-action@main
         with:
           account: 100582612927
@@ -2418,7 +2418,7 @@ jobs:
         uses: mikepenz/action-junit-report@v5
         if: always()
         with:
-         check_name: ${{ inputs.artifact_suffix }}-jdk${{ matrix.jdk }} Report
+         check_name: ${{ github.job }}-jdk${{ matrix.jdk }} Report
          comment: false
          annotate_only: true
          flaky_summary: true
@@ -2433,7 +2433,7 @@ jobs:
           path: ${{ github.job }}-jdk${{ matrix.jdk }}-logs.tar.gz
           retention-days: 30
       - name: Upload test results to BuildPulse for flaky test detection
-        if: '!cancelled()' # Run this step even when the tests fail. Skip if the workflow is cancelled.
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main' && !cancelled()
         uses: buildpulse/buildpulse-action@main
         with:
           account: 100582612927
@@ -2499,7 +2499,7 @@ jobs:
         uses: mikepenz/action-junit-report@v5
         if: always()
         with:
-         check_name: ${{ inputs.artifact_suffix }}-jdk${{ matrix.jdk }} Report
+         check_name: ${{ github.job }}-jdk${{ matrix.jdk }} Report
          comment: false
          annotate_only: true
          flaky_summary: true
@@ -2514,7 +2514,7 @@ jobs:
           path: ${{ github.job }}-jdk${{ matrix.jdk }}-logs.tar.gz
           retention-days: 30
       - name: Upload test results to BuildPulse for flaky test detection
-        if: '!cancelled()' # Run this step even when the tests fail. Skip if the workflow is cancelled.
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main' && !cancelled()
         uses: buildpulse/buildpulse-action@main
         with:
           account: 100582612927

--- a/.github/workflows/VeniceCI-E2ETests.yml
+++ b/.github/workflows/VeniceCI-E2ETests.yml
@@ -47,6 +47,8 @@ jobs:
           git fetch upstream
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4
+        with:
+          add-job-summary: never
       - name: Run Integration Tests
         run: ./gradlew --continue --no-daemon -DforkEvery=1 -DmaxParallelForks=1 integrationTests_1000
       - name: Package Build Artifacts
@@ -126,6 +128,8 @@ jobs:
           git fetch upstream
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4
+        with:
+          add-job-summary: never
       - name: Run Integration Tests
         run: ./gradlew --continue --no-daemon -DforkEvery=1 -DmaxParallelForks=1 integrationTests_1010
       - name: Package Build Artifacts
@@ -205,6 +209,8 @@ jobs:
           git fetch upstream
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4
+        with:
+          add-job-summary: never
       - name: Run Integration Tests
         run: ./gradlew --continue --no-daemon -DforkEvery=1 -DmaxParallelForks=1 integrationTests_1020
       - name: Package Build Artifacts
@@ -284,6 +290,8 @@ jobs:
           git fetch upstream
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4
+        with:
+          add-job-summary: never
       - name: Run Integration Tests
         run: ./gradlew --continue --no-daemon -DforkEvery=1 -DmaxParallelForks=1 integrationTests_1030
       - name: Package Build Artifacts
@@ -363,6 +371,8 @@ jobs:
           git fetch upstream
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4
+        with:
+          add-job-summary: never
       - name: Run Integration Tests
         run: ./gradlew --continue --no-daemon -DforkEvery=1 -DmaxParallelForks=1 integrationTests_1040
       - name: Package Build Artifacts
@@ -442,6 +452,8 @@ jobs:
           git fetch upstream
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4
+        with:
+          add-job-summary: never
       - name: Run Integration Tests
         run: ./gradlew --continue --no-daemon -DforkEvery=1 -DmaxParallelForks=1 integrationTests_1050
       - name: Package Build Artifacts
@@ -521,6 +533,8 @@ jobs:
           git fetch upstream
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4
+        with:
+          add-job-summary: never
       - name: Run Integration Tests
         run: ./gradlew --continue --no-daemon -DforkEvery=1 -DmaxParallelForks=1 integrationTests_1060
       - name: Package Build Artifacts
@@ -600,6 +614,8 @@ jobs:
           git fetch upstream
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4
+        with:
+          add-job-summary: never
       - name: Run Integration Tests
         run: ./gradlew --continue --no-daemon -DforkEvery=1 -DmaxParallelForks=1 integrationTests_1070
       - name: Package Build Artifacts
@@ -679,6 +695,8 @@ jobs:
           git fetch upstream
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4
+        with:
+          add-job-summary: never
       - name: Run Integration Tests
         run: ./gradlew --continue --no-daemon -DforkEvery=1 -DmaxParallelForks=1 integrationTests_1080
       - name: Package Build Artifacts
@@ -758,6 +776,8 @@ jobs:
           git fetch upstream
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4
+        with:
+          add-job-summary: never
       - name: Run Integration Tests
         run: ./gradlew --continue --no-daemon -DforkEvery=1 -DmaxParallelForks=1 integrationTests_1090
       - name: Package Build Artifacts
@@ -837,6 +857,8 @@ jobs:
           git fetch upstream
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4
+        with:
+          add-job-summary: never
       - name: Run Integration Tests
         run: ./gradlew --continue --no-daemon -DforkEvery=1 -DmaxParallelForks=1 integrationTests_1100
       - name: Package Build Artifacts
@@ -916,6 +938,8 @@ jobs:
           git fetch upstream
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4
+        with:
+          add-job-summary: never
       - name: Run Integration Tests
         run: ./gradlew --continue --no-daemon -DforkEvery=1 -DmaxParallelForks=1 integrationTests_1110
       - name: Package Build Artifacts
@@ -995,6 +1019,8 @@ jobs:
           git fetch upstream
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4
+        with:
+          add-job-summary: never
       - name: Run Integration Tests
         run: ./gradlew --continue --no-daemon -DforkEvery=1 -DmaxParallelForks=1 integrationTests_1120
       - name: Package Build Artifacts
@@ -1074,6 +1100,8 @@ jobs:
           git fetch upstream
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4
+        with:
+          add-job-summary: never
       - name: Run Integration Tests
         run: ./gradlew --continue --no-daemon -DforkEvery=1 -DmaxParallelForks=1 integrationTests_1130
       - name: Package Build Artifacts
@@ -1153,6 +1181,8 @@ jobs:
           git fetch upstream
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4
+        with:
+          add-job-summary: never
       - name: Run Integration Tests
         run: ./gradlew --continue --no-daemon -DforkEvery=1 -DmaxParallelForks=1 integrationTests_1200
       - name: Package Build Artifacts
@@ -1232,6 +1262,8 @@ jobs:
           git fetch upstream
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4
+        with:
+          add-job-summary: never
       - name: Run Integration Tests
         run: ./gradlew --continue --no-daemon -DforkEvery=1 -DmaxParallelForks=1 integrationTests_1210
       - name: Package Build Artifacts
@@ -1311,6 +1343,8 @@ jobs:
           git fetch upstream
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4
+        with:
+          add-job-summary: never
       - name: Run Integration Tests
         run: ./gradlew --continue --no-daemon -DforkEvery=1 -DmaxParallelForks=1 integrationTests_1220
       - name: Package Build Artifacts
@@ -1390,6 +1424,8 @@ jobs:
           git fetch upstream
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4
+        with:
+          add-job-summary: never
       - name: Run Integration Tests
         run: ./gradlew --continue --no-daemon -DforkEvery=1 -DmaxParallelForks=1 integrationTests_1230
       - name: Package Build Artifacts
@@ -1469,6 +1505,8 @@ jobs:
           git fetch upstream
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4
+        with:
+          add-job-summary: never
       - name: Run Integration Tests
         run: ./gradlew --continue --no-daemon -DforkEvery=1 -DmaxParallelForks=1 integrationTests_1240
       - name: Package Build Artifacts
@@ -1548,6 +1586,8 @@ jobs:
           git fetch upstream
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4
+        with:
+          add-job-summary: never
       - name: Run Integration Tests
         run: ./gradlew --continue --no-daemon -DforkEvery=1 -DmaxParallelForks=1 integrationTests_1250
       - name: Package Build Artifacts
@@ -1627,6 +1667,8 @@ jobs:
           git fetch upstream
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4
+        with:
+          add-job-summary: never
       - name: Run Integration Tests
         run: ./gradlew --continue --no-daemon -DforkEvery=1 -DmaxParallelForks=1 integrationTests_1260
       - name: Package Build Artifacts
@@ -1706,6 +1748,8 @@ jobs:
           git fetch upstream
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4
+        with:
+          add-job-summary: never
       - name: Run Integration Tests
         run: ./gradlew --continue --no-daemon -DforkEvery=1 -DmaxParallelForks=1 integrationTests_1270
       - name: Package Build Artifacts
@@ -1785,6 +1829,8 @@ jobs:
           git fetch upstream
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4
+        with:
+          add-job-summary: never
       - name: Run Integration Tests
         run: ./gradlew --continue --no-daemon -DforkEvery=1 -DmaxParallelForks=1 integrationTests_1280
       - name: Package Build Artifacts
@@ -1864,6 +1910,8 @@ jobs:
           git fetch upstream
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4
+        with:
+          add-job-summary: never
       - name: Run Integration Tests
         run: ./gradlew --continue --no-daemon -DforkEvery=1 -DmaxParallelForks=1 integrationTests_1400
       - name: Package Build Artifacts
@@ -1943,6 +1991,8 @@ jobs:
           git fetch upstream
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4
+        with:
+          add-job-summary: never
       - name: Run Integration Tests
         run: ./gradlew --continue --no-daemon -DforkEvery=1 -DmaxParallelForks=1 integrationTests_1410
       - name: Package Build Artifacts
@@ -2022,6 +2072,8 @@ jobs:
           git fetch upstream
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4
+        with:
+          add-job-summary: never
       - name: Run Integration Tests
         run: ./gradlew --continue --no-daemon -DforkEvery=1 -DmaxParallelForks=1 integrationTests_1420
       - name: Package Build Artifacts
@@ -2101,6 +2153,8 @@ jobs:
           git fetch upstream
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4
+        with:
+          add-job-summary: never
       - name: Run Integration Tests
         run: ./gradlew --continue --no-daemon -DforkEvery=1 -DmaxParallelForks=1 integrationTests_1430
       - name: Package Build Artifacts
@@ -2180,6 +2234,8 @@ jobs:
           git fetch upstream
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4
+        with:
+          add-job-summary: never
       - name: Run Integration Tests
         run: ./gradlew --continue --no-daemon -DforkEvery=1 -DmaxParallelForks=1 integrationTests_1440
       - name: Package Build Artifacts
@@ -2259,6 +2315,8 @@ jobs:
           git fetch upstream
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4
+        with:
+          add-job-summary: never
       - name: Run Integration Tests
         run: ./gradlew --continue --no-daemon -DforkEvery=1 -DmaxParallelForks=1 integrationTests_1500
       - name: Package Build Artifacts
@@ -2338,6 +2396,8 @@ jobs:
           git fetch upstream
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4
+        with:
+          add-job-summary: never
       - name: Run Integration Tests
         run: ./gradlew --continue --no-daemon -DforkEvery=1 -DmaxParallelForks=1 integrationTests_1550
       - name: Package Build Artifacts
@@ -2417,6 +2477,8 @@ jobs:
           git fetch upstream
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4
+        with:
+          add-job-summary: never
       - name: Run Integration Tests
         run: ./gradlew --continue --no-daemon -DforkEvery=1 -DmaxParallelForks=1 integrationTests_9999
       - name: Package Build Artifacts

--- a/.github/workflows/VeniceCI-StaticAnalysisAndUnitTests.yml
+++ b/.github/workflows/VeniceCI-StaticAnalysisAndUnitTests.yml
@@ -36,7 +36,6 @@ jobs:
           java-version: ${{ matrix.jdk }}
           distribution: 'temurin'
           cache: 'gradle'
-          add-job-summary: never
       - shell: bash
         run: |
           git remote set-head origin --auto
@@ -44,6 +43,8 @@ jobs:
           git fetch upstream
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4
+        with:
+          add-job-summary: never
       - name: Run Static Analysis
         run: ./gradlew --continue --no-daemon clean check --parallel -Pspotallbugs -x test -x integrationTest -x jacocoTestCoverageVerification
       - name: Package Build Artifacts

--- a/.github/workflows/VeniceCI-StaticAnalysisAndUnitTests.yml
+++ b/.github/workflows/VeniceCI-StaticAnalysisAndUnitTests.yml
@@ -36,6 +36,7 @@ jobs:
           java-version: ${{ matrix.jdk }}
           distribution: 'temurin'
           cache: 'gradle'
+          add-job-summary: never
       - shell: bash
         run: |
           git remote set-head origin --auto

--- a/clients/venice-client/src/test/java/com/linkedin/venice/fastclient/BatchGetAvroStoreClientUnitTest.java
+++ b/clients/venice-client/src/test/java/com/linkedin/venice/fastclient/BatchGetAvroStoreClientUnitTest.java
@@ -40,7 +40,7 @@ import org.testng.annotations.Test;
  */
 
 public class BatchGetAvroStoreClientUnitTest {
-  private static final int TEST_TIMEOUT = 5 * Time.MS_PER_SECOND;
+  private static final int TEST_TIMEOUT = 30 * Time.MS_PER_SECOND;
   private static final Logger LOGGER = LogManager.getLogger(BatchGetAvroStoreClientUnitTest.class);
   private static final long CLIENT_TIME_OUT_IN_SECONDS = 10;
   private static final int RETRY_THRESHOLD_IN_MS = 50;


### PR DESCRIPTION
<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## Remove checks for test reports to avoid CI failures
- Replaced test reporter checks with annotation-only execution.
- Failed and flaky tests will now appear under the “Summary” tab and in the “Files Changed” tab (at the end for tests in unchanged files).
- Removed Gradle summary reporting.
 
 
![image](https://github.com/user-attachments/assets/b9ae392f-0e8e-4d5d-bea6-919b7eaf0628)

 
![image](https://github.com/user-attachments/assets/aef10277-5b72-4023-af90-5b4be95b935a)


## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.