### PR TITLE
[server] Fix NPE in StoreAwarePartitionWiseKafkaConsumerService#handleUnsubscription

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/SharedKafkaConsumer.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/SharedKafkaConsumer.java
@@ -192,6 +192,8 @@ class SharedKafkaConsumer implements PubSubConsumerAdapter {
     long currentPollTimes = pollTimes;
     long startTime = System.currentTimeMillis();
     Set<PubSubTopicPartition> topicPartitions = supplier.get();
+    updateCurrentAssignment(delegate.getAssignment());
+    waitAfterUnsubscribe(currentPollTimes, topicPartitions, timeoutMs);
     long elapsedTime = System.currentTimeMillis() - startTime;
     LOGGER.info(
         "Shared consumer {} unsubscribed {} partition(s): ({}) in {} ms",
@@ -199,8 +201,6 @@ class SharedKafkaConsumer implements PubSubConsumerAdapter {
         topicPartitions.size(),
         topicPartitions,
         elapsedTime);
-    updateCurrentAssignment(delegate.getAssignment());
-    waitAfterUnsubscribe(currentPollTimes, topicPartitions, timeoutMs);
   }
 
   protected void waitAfterUnsubscribe(

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/SharedKafkaConsumer.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/SharedKafkaConsumer.java
@@ -190,8 +190,8 @@ class SharedKafkaConsumer implements PubSubConsumerAdapter {
    */
   protected synchronized void unSubscribeAction(Supplier<Set<PubSubTopicPartition>> supplier, long timeoutMs) {
     long currentPollTimes = pollTimes;
-    Set<PubSubTopicPartition> topicPartitions = supplier.get();
     long startTime = System.currentTimeMillis();
+    Set<PubSubTopicPartition> topicPartitions = supplier.get();
     long elapsedTime = System.currentTimeMillis() - startTime;
     LOGGER.info(
         "Shared consumer {} unsubscribed {} partition(s): ({}) in {} ms",

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreAwarePartitionWiseKafkaConsumerService.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreAwarePartitionWiseKafkaConsumerService.java
@@ -122,7 +122,7 @@ public class StoreAwarePartitionWiseKafkaConsumerService extends PartitionWiseKa
       PubSubTopic versionTopic,
       PubSubTopicPartition pubSubTopicPartition) {
     super.handleUnsubscription(consumer, versionTopic, pubSubTopicPartition);
-    decreaseConsumerStoreLoad(consumer, versionTopic.getStoreName());
+    decreaseConsumerStoreLoad(consumer, versionTopic);
   }
 
   int getConsumerStoreLoad(SharedKafkaConsumer consumer, String storeName) {
@@ -138,7 +138,12 @@ public class StoreAwarePartitionWiseKafkaConsumerService extends PartitionWiseKa
         .compute(storeName, (k, v) -> (v == null) ? 1 : v + 1);
   }
 
-  void decreaseConsumerStoreLoad(SharedKafkaConsumer consumer, String storeName) {
+  void decreaseConsumerStoreLoad(SharedKafkaConsumer consumer, PubSubTopic versionTopic) {
+    if (versionTopic == null) {
+      getLOGGER().warn("Incoming versionTopic is null, will skip decreasing store load for consumer: {}", consumer);
+      return;
+    }
+    String storeName = versionTopic.getStoreName();
     if (!getConsumerToBaseLoadCount().containsKey(consumer)) {
       throw new IllegalStateException("Consumer to base load count map does not contain consumer: " + consumer);
     }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreAwarePartitionWiseKafkaConsumerService.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreAwarePartitionWiseKafkaConsumerService.java
@@ -139,8 +139,16 @@ public class StoreAwarePartitionWiseKafkaConsumerService extends PartitionWiseKa
   }
 
   void decreaseConsumerStoreLoad(SharedKafkaConsumer consumer, PubSubTopic versionTopic) {
+    /**
+     * When versionTopic is null, it means a specific Topic-Partition has been unsubscribed for more than 1 time. This
+     * can happen during version deprecation, where {@link ParticipantStoreConsumptionTask} is also trying to unsubscribe
+     * every partitions
+     */
     if (versionTopic == null) {
-      getLOGGER().warn("Incoming versionTopic is null, will skip decreasing store load for consumer: {}", consumer);
+      getLOGGER().warn(
+          "Incoming versionTopic is null, will skip decreasing store load for consumer: {} with index: {}",
+          consumer,
+          getConsumerToConsumptionTask().indexOf(consumer));
       return;
     }
     String storeName = versionTopic.getStoreName();

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/KafkaConsumerServiceTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/KafkaConsumerServiceTest.java
@@ -232,7 +232,7 @@ public class KafkaConsumerServiceTest {
         poolType,
         factory,
         properties,
-        1000l,
+        1000L,
         1,
         mockIngestionThrottler,
         mock(KafkaClusterBasedRecordThrottler.class),
@@ -436,6 +436,8 @@ public class KafkaConsumerServiceTest {
     PubSubTopic pubSubTopicForStoreName3 = pubSubTopicRepository.getTopic(topicForStoreName3);
 
     String storeName4 = Utils.getUniqueString("test_consumer_service4");
+    String topicForStoreName4 = Version.composeKafkaTopic(storeName4, 1);
+    PubSubTopic pubSubTopicForStoreName4 = pubSubTopicRepository.getTopic(topicForStoreName4);
 
     SharedKafkaConsumer consumer1 = mock(SharedKafkaConsumer.class);
     SharedKafkaConsumer consumer2 = mock(SharedKafkaConsumer.class);
@@ -461,9 +463,9 @@ public class KafkaConsumerServiceTest {
     when(consumerService.getLOGGER())
         .thenReturn(LogManager.getLogger(StoreAwarePartitionWiseKafkaConsumerService.class));
     doCallRealMethod().when(consumerService).pickConsumerForPartition(any(), any());
-    doCallRealMethod().when(consumerService).getConsumerStoreLoad(any(), anyString());
-    doCallRealMethod().when(consumerService).increaseConsumerStoreLoad(any(), anyString());
-    doCallRealMethod().when(consumerService).decreaseConsumerStoreLoad(any(), anyString());
+    doCallRealMethod().when(consumerService).getConsumerStoreLoad(any(), any());
+    doCallRealMethod().when(consumerService).increaseConsumerStoreLoad(any(), any());
+    doCallRealMethod().when(consumerService).decreaseConsumerStoreLoad(any(), any());
 
     consumerToBasicLoadMap.put(consumer1, 1);
     Map<String, Integer> innerMap1 = new VeniceConcurrentHashMap<>();
@@ -508,25 +510,28 @@ public class KafkaConsumerServiceTest {
     Assert.assertEquals(consumerService.getConsumerStoreLoad(consumer1, storeName3), 10003);
 
     // Validate decrease consumer entry
-    Assert.assertThrows(() -> consumerService.decreaseConsumerStoreLoad(consumer1, storeName4));
+    Assert.assertThrows(() -> consumerService.decreaseConsumerStoreLoad(consumer1, pubSubTopicForStoreName4));
 
-    consumerService.decreaseConsumerStoreLoad(consumer1, storeName1);
+    consumerService.decreaseConsumerStoreLoad(consumer1, pubSubTopicForStoreName1);
     Assert.assertEquals(consumerToBasicLoadMap.get(consumer1).intValue(), 2);
     Assert.assertNull(consumerToStoreLoadMap.get(consumer1).get(storeName1));
     Assert.assertEquals(consumerService.getConsumerStoreLoad(consumer1, storeName1), 2);
-    Assert.assertThrows(() -> consumerService.decreaseConsumerStoreLoad(consumer1, storeName1));
+    Assert.assertThrows(() -> consumerService.decreaseConsumerStoreLoad(consumer1, pubSubTopicForStoreName1));
 
-    consumerService.decreaseConsumerStoreLoad(consumer1, storeName2);
+    consumerService.decreaseConsumerStoreLoad(consumer1, pubSubTopicForStoreName2);
     Assert.assertEquals(consumerToBasicLoadMap.get(consumer1).intValue(), 1);
     Assert.assertNull(consumerToStoreLoadMap.get(consumer1).get(storeName2));
     Assert.assertEquals(consumerService.getConsumerStoreLoad(consumer1, storeName2), 1);
-    Assert.assertThrows(() -> consumerService.decreaseConsumerStoreLoad(consumer1, storeName2));
+    Assert.assertThrows(() -> consumerService.decreaseConsumerStoreLoad(consumer1, pubSubTopicForStoreName2));
 
-    consumerService.decreaseConsumerStoreLoad(consumer1, storeName3);
+    consumerService.decreaseConsumerStoreLoad(consumer1, pubSubTopicForStoreName3);
     Assert.assertNull(consumerToBasicLoadMap.get(consumer1));
     Assert.assertNull(consumerToStoreLoadMap.get(consumer1));
     Assert.assertEquals(consumerService.getConsumerStoreLoad(consumer1, storeName3), 0);
-    Assert.assertThrows(() -> consumerService.decreaseConsumerStoreLoad(consumer1, storeName3));
+    Assert.assertThrows(() -> consumerService.decreaseConsumerStoreLoad(consumer1, pubSubTopicForStoreName3));
+
+    // Make sure invalid versionTopic won't throw NPE.
+    consumerService.decreaseConsumerStoreLoad(consumer1, null);
 
     // Validate increase consumer entry
     consumerService.increaseConsumerStoreLoad(consumer1, storeName1);


### PR DESCRIPTION


<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## [server] Fix NPE in StoreAwarePartitionWiseKafkaConsumerService#handleUnsubscription
This PR only fixes NPE exception in StoreAwarePartitionWiseKafkaConsumerService#handleUnsubscription. 2nd call to the same TP unsubscription will be ignored, as expected, as it should be decrease twice.

There is still race condition in upstream call where unsubscribe and unsubscribeAll from SIT/Participant thread can dual unsubscribe on the same TP, due to race condition in certain map bookkeeping operation. This PR does not fix that, due to other unclear performance concern. It is harmless for now, as 2nd call to the same TP will be ignored by consumer.


## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
Adjust unit test to cover the case.
## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.