### PR TITLE
[controller] add a new config that, when set, will update real time topic during partition count update

### DIFF
--- a/internal/venice-common/src/main/java/com/linkedin/venice/ConfigKeys.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/ConfigKeys.java
@@ -2356,4 +2356,6 @@ public class ConfigKeys {
 
   public static final String SERVER_DELETE_UNASSIGNED_PARTITIONS_ON_STARTUP =
       "server.delete.unassigned.partitions.on.startup";
+
+  public static final String UPDATE_REAL_TIME_TOPIC = "update.real.time.topic";
 }

--- a/internal/venice-common/src/main/java/com/linkedin/venice/utils/Utils.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/utils/Utils.java
@@ -632,6 +632,29 @@ public class Utils {
     return Strings.isBlank(realTimeTopicName) ? composeRealTimeTopic(storeName) : realTimeTopicName;
   }
 
+  public static String createNewRealTimeTopicName(String oldRealTimeTopicName) {
+    if (oldRealTimeTopicName == null || !oldRealTimeTopicName.endsWith(Version.REAL_TIME_TOPIC_SUFFIX)) {
+      throw new IllegalArgumentException("Invalid old name format");
+    }
+
+    // Extract the base name and current version
+    String base =
+        oldRealTimeTopicName.substring(0, oldRealTimeTopicName.length() - Version.REAL_TIME_TOPIC_SUFFIX.length());
+    String[] parts = base.split("_v");
+
+    String newBase;
+    if (parts.length == 2) {
+      // Increment the version
+      int version = Integer.parseInt(parts[1]) + 1;
+      newBase = parts[0] + "_v" + version;
+    } else {
+      // Start with version 2
+      newBase = base + "_v2";
+    }
+
+    return newBase + Version.REAL_TIME_TOPIC_SUFFIX;
+  }
+
   private static class TimeUnitInfo {
     String suffix;
     int multiplier;

--- a/internal/venice-common/src/test/java/com/linkedin/venice/utils/UtilsTest.java
+++ b/internal/venice-common/src/test/java/com/linkedin/venice/utils/UtilsTest.java
@@ -393,4 +393,47 @@ public class UtilsTest {
         Utils.resolveLeaderTopicFromPubSubTopic(pubSubTopicRepository, separateRealTimeTopic),
         realTimeTopic);
   }
+
+  @Test
+  void testValidOldNameWithVersionIncrement() {
+    String oldName = "storeName_v1_rt";
+    String expectedNewName = "storeName_v2_rt";
+
+    String result = Utils.createNewRealTimeTopicName(oldName);
+
+    assertEquals(expectedNewName, result);
+  }
+
+  @Test
+  void testValidOldNameStartingNewVersion() {
+    String oldName = "storeName_rt";
+    String expectedNewName = "storeName_v2_rt";
+
+    String result = Utils.createNewRealTimeTopicName(oldName);
+
+    assertEquals(expectedNewName, result);
+  }
+
+  @Test
+  void testInvalidOldNameNull() {
+    assertThrows(IllegalArgumentException.class, () -> Utils.createNewRealTimeTopicName(null));
+  }
+
+  @Test
+  void testInvalidOldNameWithoutSuffix() {
+    String oldName = "storeName_v1";
+    assertThrows(IllegalArgumentException.class, () -> Utils.createNewRealTimeTopicName(oldName));
+  }
+
+  @Test
+  void testInvalidOldNameIncorrectFormat() {
+    String oldName = "storeName_v1_rt_extra";
+    assertThrows(IllegalArgumentException.class, () -> Utils.createNewRealTimeTopicName(oldName));
+  }
+
+  @Test
+  void testInvalidOldNameWithNonNumericVersion() {
+    String oldName = "storeName_vX_rt";
+    assertThrows(NumberFormatException.class, () -> Utils.createNewRealTimeTopicName(oldName));
+  }
 }

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/controller/AdminToolE2ETest.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/controller/AdminToolE2ETest.java
@@ -2,6 +2,7 @@ package com.linkedin.venice.controller;
 
 import static com.linkedin.venice.ConfigKeys.CONTROLLER_AUTO_MATERIALIZE_DAVINCI_PUSH_STATUS_SYSTEM_STORE;
 import static com.linkedin.venice.ConfigKeys.CONTROLLER_AUTO_MATERIALIZE_META_SYSTEM_STORE;
+import static com.linkedin.venice.ConfigKeys.UPDATE_REAL_TIME_TOPIC;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertTrue;
@@ -12,11 +13,14 @@ import com.linkedin.venice.controllerapi.ControllerClient;
 import com.linkedin.venice.controllerapi.MultiStoreResponse;
 import com.linkedin.venice.controllerapi.NewStoreResponse;
 import com.linkedin.venice.controllerapi.StoreResponse;
+import com.linkedin.venice.controllerapi.UpdateStoreQueryParams;
 import com.linkedin.venice.integration.utils.ServiceFactory;
 import com.linkedin.venice.integration.utils.VeniceControllerWrapper;
 import com.linkedin.venice.integration.utils.VeniceMultiClusterWrapper;
 import com.linkedin.venice.integration.utils.VeniceTwoLayerMultiRegionMultiClusterWrapper;
+import com.linkedin.venice.meta.BackupStrategy;
 import com.linkedin.venice.meta.StoreInfo;
+import com.linkedin.venice.meta.Version;
 import com.linkedin.venice.utils.TestUtils;
 import com.linkedin.venice.utils.Utils;
 import java.util.Arrays;
@@ -28,6 +32,7 @@ import java.util.Properties;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
+import org.testng.Assert;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
@@ -50,6 +55,7 @@ public class AdminToolE2ETest {
     Properties parentControllerProperties = new Properties();
     parentControllerProperties.setProperty(CONTROLLER_AUTO_MATERIALIZE_META_SYSTEM_STORE, "false");
     parentControllerProperties.setProperty(CONTROLLER_AUTO_MATERIALIZE_DAVINCI_PUSH_STATUS_SYSTEM_STORE, "false");
+    parentControllerProperties.setProperty(UPDATE_REAL_TIME_TOPIC, "true");
 
     multiRegionMultiClusterWrapper = ServiceFactory.getVeniceTwoLayerMultiRegionMultiClusterWrapper(
         NUMBER_OF_CHILD_DATACENTERS,
@@ -325,5 +331,60 @@ public class AdminToolE2ETest {
         assertFalse(storeInfo.isMigrating(), "Store::isMigrating should be false in " + region);
       }
     });
+  }
+
+  @Test(timeOut = TEST_TIMEOUT)
+  public void testUpdateStoreRealTimeTopicName() throws Exception {
+    String storeName = Utils.getUniqueString("testUpdateStoreRealTimeTopicName");
+    List<VeniceControllerWrapper> parentControllers = multiRegionMultiClusterWrapper.getParentControllers();
+    String clusterName = clusterNames[0];
+    String parentControllerURLs =
+        parentControllers.stream().map(VeniceControllerWrapper::getControllerUrl).collect(Collectors.joining(","));
+    UpdateStoreQueryParams updateStoreParams = new UpdateStoreQueryParams();
+    updateStoreParams.setIncrementalPushEnabled(true)
+        .setBackupStrategy(BackupStrategy.KEEP_MIN_VERSIONS)
+        .setNumVersionsToPreserve(2)
+        .setHybridRewindSeconds(1000)
+        .setHybridOffsetLagThreshold(1000);
+
+    try (ControllerClient parentControllerClient = new ControllerClient(clusterName, parentControllerURLs)) {
+      TestUtils.assertCommand(
+          parentControllerClient
+              .retryableRequest(5, c -> c.createNewStore(storeName, "test", "\"string\"", "\"string\"")));
+
+      TestUtils
+          .assertCommand(parentControllerClient.retryableRequest(5, c -> c.updateStore(storeName, updateStoreParams)));
+
+      multiRegionMultiClusterWrapper.getLeaderParentControllerWithRetries(clusterName)
+          .getVeniceAdmin()
+          .incrementVersionIdempotent(clusterName, storeName, Version.guidBasedDummyPushId(), 1, 1);
+
+      // Update update-real-time-topic to true
+      String[] adminToolArgs = new String[] { "--url", parentControllerClient.getLeaderControllerUrl(), "--cluster",
+          clusterName, "--store", storeName, "--update-store", "--partition-count", "2" };
+      AdminTool.main(adminToolArgs);
+      validateRealTimeTopic(parentControllerClient, storeName);
+      validateRealTimeTopicAcrossChildRegions(storeName, clusterName);
+    }
+  }
+
+  private void validateRealTimeTopic(ControllerClient controllerClient, String storeName) {
+    TestUtils.waitForNonDeterministicAssertion(30, TimeUnit.SECONDS, () -> {
+      StoreInfo storeInfo = controllerClient.getStore(storeName).getStore();
+      String realTimeTopicNameInVersion = Utils.getRealTimeTopicName(storeInfo);
+      String expectedRealTimeTopicNameInStoreConfig = Utils.createNewRealTimeTopicName(realTimeTopicNameInVersion);
+      String actualRealTimeTopicNameInStoreConfig = storeInfo.getHybridStoreConfig().getRealTimeTopicName();
+      Assert.assertNotEquals(expectedRealTimeTopicNameInStoreConfig, realTimeTopicNameInVersion);
+      Assert.assertEquals(expectedRealTimeTopicNameInStoreConfig, actualRealTimeTopicNameInStoreConfig);
+    });
+  }
+
+  private void validateRealTimeTopicAcrossChildRegions(String storeName, String clusterName) {
+    for (VeniceMultiClusterWrapper childRegion: childDatacenters) {
+      try (ControllerClient childControllerClient =
+          new ControllerClient(clusterName, childRegion.getControllerConnectString())) {
+        validateRealTimeTopic(childControllerClient, storeName);
+      }
+    }
   }
 }

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceControllerClusterConfig.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceControllerClusterConfig.java
@@ -163,6 +163,7 @@ import static com.linkedin.venice.ConfigKeys.TERMINAL_STATE_TOPIC_CHECK_DELAY_MS
 import static com.linkedin.venice.ConfigKeys.TOPIC_CLEANUP_DELAY_FACTOR;
 import static com.linkedin.venice.ConfigKeys.TOPIC_CLEANUP_SLEEP_INTERVAL_BETWEEN_TOPIC_LIST_FETCH_MS;
 import static com.linkedin.venice.ConfigKeys.UNREGISTER_METRIC_FOR_DELETED_STORE_ENABLED;
+import static com.linkedin.venice.ConfigKeys.UPDATE_REAL_TIME_TOPIC;
 import static com.linkedin.venice.ConfigKeys.USE_DA_VINCI_SPECIFIC_EXECUTION_STATUS_FOR_ERROR;
 import static com.linkedin.venice.ConfigKeys.USE_PUSH_STATUS_STORE_FOR_INCREMENTAL_PUSH;
 import static com.linkedin.venice.ConfigKeys.VENICE_STORAGE_CLUSTER_LEADER_HAAS;
@@ -534,6 +535,7 @@ public class VeniceControllerClusterConfig {
   private final long serviceDiscoveryRegistrationRetryMS;
 
   private Set<PushJobCheckpoints> pushJobUserErrorCheckpoints;
+  private boolean updateRealTimeTopic;
 
   public VeniceControllerClusterConfig(VeniceProperties props) {
     this.props = props;
@@ -978,6 +980,7 @@ public class VeniceControllerClusterConfig {
     this.serviceDiscoveryRegistrationRetryMS =
         props.getLong(SERVICE_DISCOVERY_REGISTRATION_RETRY_MS, 30L * Time.MS_PER_SECOND);
     this.pushJobUserErrorCheckpoints = parsePushJobUserErrorCheckpoints(props);
+    this.updateRealTimeTopic = props.getBoolean(UPDATE_REAL_TIME_TOPIC, false);
   }
 
   public VeniceProperties getProps() {
@@ -1765,6 +1768,10 @@ public class VeniceControllerClusterConfig {
 
   public int getDanglingTopicOccurrenceThresholdForCleanup() {
     return danglingTopicOccurrenceThresholdForCleanup;
+  }
+
+  public boolean getUpdateRealTimeTopic() {
+    return updateRealTimeTopic;
   }
 
   /**

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceControllerMultiClusterConfig.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceControllerMultiClusterConfig.java
@@ -286,4 +286,8 @@ public class VeniceControllerMultiClusterConfig {
   public List<String> getControllerInstanceTagList() {
     return getCommonConfig().getControllerInstanceTagList();
   }
+
+  public boolean getUpdateRealTimeTopic() {
+    return getCommonConfig().getUpdateRealTimeTopic();
+  }
 }


### PR DESCRIPTION
<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## update real time topic name, if needed during partition count update, when config `update.real.time.topic` is set
<!--
Describe
- What changes to make and why you are making these changes.
- How are you going to achieve your goal.
- Describe what testings you have done, for example, performance testing etc.

If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

With this PR, during partition count update, we will set the real time topic name if the partition count update is needed.
This is a part of the bigger project to achieve re-partitioning in real time topic and because there is a lot of work remaining, we will control this behavior through a config `update.real.time.topic`; the default value of this config will be `false`

Resolves #XXX

## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.