### PR TITLE
[venice-router] Add store discovery metric

### DIFF
--- a/services/venice-router/src/main/java/com/linkedin/venice/router/MetaDataHandler.java
+++ b/services/venice-router/src/main/java/com/linkedin/venice/router/MetaDataHandler.java
@@ -158,7 +158,6 @@ public class MetaDataHandler extends SimpleChannelInboundHandler<HttpRequest> {
   static final String REQUEST_BLOB_DISCOVERY_ERROR_PUSH_STORE =
       "Blob Discovery: failed to get the live node hostNames for store:%s version:%s partition:%s";
   private final VeniceVersionFinder veniceVersionFinder;
-
   private final MetricsRepository metricsRepository;
 
   public MetaDataHandler(
@@ -485,8 +484,9 @@ public class MetaDataHandler extends SimpleChannelInboundHandler<HttpRequest> {
     }
 
     // Only create metrics for valid stores
-    Sensor d2DiscoverySensor = metricsRepository.sensor(String.format("venice.router.d2_discovery.%s", storeName));
-    d2DiscoverySensor.add(String.format("venice.router.d2_discovery.%s.request.count", storeName), new Count());
+    String d2DiscoveryMetricName = "venice.router.d2_discovery." + storeName;
+    Sensor d2DiscoverySensor = metricsRepository.sensor(d2DiscoveryMetricName);
+    d2DiscoverySensor.add(d2DiscoveryMetricName + ".request.count", new Count());
     d2DiscoverySensor.record();
 
     String clusterName = config.get().getCluster();

--- a/services/venice-router/src/main/java/com/linkedin/venice/router/RouterServer.java
+++ b/services/venice-router/src/main/java/com/linkedin/venice/router/RouterServer.java
@@ -594,7 +594,8 @@ public class RouterServer extends AbstractVeniceService {
         config.getKafkaBootstrapServers(),
         config.isSslToKafka(),
         versionFinder,
-        pushStatusStoreReader);
+        pushStatusStoreReader,
+        metricsRepository);
 
     // Setup stat tracking for exceptional case
     RouterExceptionAndTrackingUtils.setRouterStats(routerStats);


### PR DESCRIPTION
<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->


<!--
## Summary, imperative, start upper case, don't end with a period
Describe
- What changes to make and why you are making these changes.
- How are you going to achieve your goal.
- Describe what testings you have done, for example, performance testing etc.

If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->
This pull request introduces changes to the `MetaDataHandler` class in the `venice-router` service to integrate metrics tracking using the `MetricsRepository`. Additionally, it updates the corresponding test class to mock and verify the new metrics functionality.

### Integration of Metrics Tracking:

* [`services/venice-router/src/main/java/com/linkedin/venice/router/MetaDataHandler.java`]Added `MetricsRepository` and `Sensor` imports, and integrated metrics tracking by adding `metricsRepository` as a class member and initializing it in the constructor. Created and recorded a metric in the `handleD2ServiceLookup` method. 
### Updates to Router Server:

* [`services/venice-router/src/main/java/com/linkedin/venice/router/RouterServer.java`]
* Passed `metricsRepository` to the `MetaDataHandler` constructor to ensure metrics tracking is initialized.

### Test Class Adjustments:

* [`services/venice-router/src/test/java/com/linkedin/venice/router/TestMetaDataHandler.java`] Added `MetricsRepository` and `Sensor` imports, and set up a mock `MetricsRepository` in the `setUp` method. Updated tests to include `metricsRepository` when instantiating `MetaDataHandler`.


Resolves #1407

## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
Successfully ran these test locally:
```
> gradlew clean -DmaxParallelForks=2  --parallel -x :internal:venice-avro-compatibility-test:test jacocoTestCoverageVerification diffCoverage --continue
> gradlew --continue --no-daemon -DmaxParallelForks=2 --parallel -Pspotallbugs check -x spotlessCheck -x test -x integrationTest -x jacocoTestCoverageVerification
```

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [X] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.