### PR TITLE
[controller][server] Remove SIT ready-to-serve check for A/A and non-AGG store during L/F transition

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/config/VeniceClusterConfig.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/config/VeniceClusterConfig.java
@@ -96,7 +96,6 @@ public class VeniceClusterConfig {
 
   public VeniceClusterConfig(VeniceProperties clusterProps, Map<String, Map<String, String>> kafkaClusterMap)
       throws ConfigurationException {
-    LOGGER.info("Input Kafka Cluster Map: {}", kafkaClusterMap);
     this.clusterName = clusterProps.getString(CLUSTER_NAME);
     this.zookeeperAddress = clusterProps.getString(ZOOKEEPER_ADDRESS);
 

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/config/VeniceClusterConfig.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/config/VeniceClusterConfig.java
@@ -96,6 +96,7 @@ public class VeniceClusterConfig {
 
   public VeniceClusterConfig(VeniceProperties clusterProps, Map<String, Map<String, String>> kafkaClusterMap)
       throws ConfigurationException {
+    LOGGER.info("Input Kafka Cluster Map: {}", kafkaClusterMap);
     this.clusterName = clusterProps.getString(CLUSTER_NAME);
     this.zookeeperAddress = clusterProps.getString(ZOOKEEPER_ADDRESS);
 

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/ActiveActiveStoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/ActiveActiveStoreIngestionTask.java
@@ -1151,8 +1151,6 @@ public class ActiveActiveStoreIngestionTask extends LeaderFollowerStoreIngestion
     syncTopicSwitchToIngestionMetadataService(topicSwitch, partitionConsumptionState);
     if (!isLeader(partitionConsumptionState)) {
       partitionConsumptionState.getOffsetRecord().setLeaderTopic(newSourceTopic);
-      // TODO: Remove this check totally once Aggregate mode is fully deprecated.
-      return isHybridAggregateMode();
     }
     return false;
   }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/ActiveActiveStoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/ActiveActiveStoreIngestionTask.java
@@ -1533,7 +1533,6 @@ public class ActiveActiveStoreIngestionTask extends LeaderFollowerStoreIngestion
     Set<String> leaderSourceKafkaURLs = getConsumptionSourceKafkaAddress(partitionConsumptionState);
     Map<String, Long> leaderOffsetByKafkaURL = new HashMap<>(leaderSourceKafkaURLs.size());
     List<CharSequence> unreachableBrokerList = new ArrayList<>();
-
     // TODO: Potentially this logic can be merged into below branch.
     if (calculateUpstreamOffsetFromTopicSwitch) {
       leaderOffsetByKafkaURL =
@@ -1555,7 +1554,6 @@ public class ActiveActiveStoreIngestionTask extends LeaderFollowerStoreIngestion
           "Failed to reach broker urls {}, will schedule retry to compute upstream offset and resubscribe!",
           unreachableBrokerList.toString());
     }
-
     // subscribe to the new upstream
     leaderOffsetByKafkaURL.forEach((kafkaURL, leaderStartOffset) -> {
       consumerSubscribe(leaderTopic, partitionConsumptionState, leaderStartOffset, kafkaURL);

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/ActiveActiveStoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/ActiveActiveStoreIngestionTask.java
@@ -1127,10 +1127,6 @@ public class ActiveActiveStoreIngestionTask extends LeaderFollowerStoreIngestion
     partitionConsumptionState.getOffsetRecord().setLeaderTopic(newSourceTopic);
     // Calculate leader offset and start consumption
     prepareLeaderOffsetCheckpointAndStartConsumptionAsLeader(newSourceTopic, partitionConsumptionState, true);
-
-    // In case new topic is empty and leader can never become online
-    // TODO: Remove this check after AGG mode is deprecated.
-    defaultReadyToServeChecker.apply(partitionConsumptionState);
   }
 
   /**
@@ -1155,7 +1151,8 @@ public class ActiveActiveStoreIngestionTask extends LeaderFollowerStoreIngestion
     syncTopicSwitchToIngestionMetadataService(topicSwitch, partitionConsumptionState);
     if (!isLeader(partitionConsumptionState)) {
       partitionConsumptionState.getOffsetRecord().setLeaderTopic(newSourceTopic);
-      return true;
+      // TODO: Remove this check totally once Aggregate mode is fully deprecated.
+      return isHybridAggregateMode();
     }
     return false;
   }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTask.java
@@ -669,10 +669,7 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
              * In extreme case, if there is no message in real-time topic, there will be no new message after leader switch
              * to the real-time topic, so `isReadyToServe()` check will never be invoked.
              */
-            if (isHybridAggregateMode()) {
-              defaultReadyToServeChecker.apply(partitionConsumptionState);
-            }
-
+            maybeApplyReadyToServeCheck(partitionConsumptionState);
           }
           break;
 
@@ -1067,9 +1064,7 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
         upstreamStartOffset);
 
     // In case new topic is empty and leader can never become online
-    if (isHybridAggregateMode()) {
-      defaultReadyToServeChecker.apply(partitionConsumptionState);
-    }
+    maybeApplyReadyToServeCheck(partitionConsumptionState);
   }
 
   protected void syncConsumedUpstreamRTOffsetMapIfNeeded(

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTask.java
@@ -669,7 +669,10 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
              * In extreme case, if there is no message in real-time topic, there will be no new message after leader switch
              * to the real-time topic, so `isReadyToServe()` check will never be invoked.
              */
-            defaultReadyToServeChecker.apply(partitionConsumptionState);
+            if (isHybridAggregateMode()) {
+              defaultReadyToServeChecker.apply(partitionConsumptionState);
+            }
+
           }
           break;
 
@@ -1064,7 +1067,9 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
         upstreamStartOffset);
 
     // In case new topic is empty and leader can never become online
-    defaultReadyToServeChecker.apply(partitionConsumptionState);
+    if (isHybridAggregateMode()) {
+      defaultReadyToServeChecker.apply(partitionConsumptionState);
+    }
   }
 
   protected void syncConsumedUpstreamRTOffsetMapIfNeeded(
@@ -1326,7 +1331,7 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
        * Real time topic for that partition is empty or the rewind start offset is very closed to the end, followers
        * calculate the lag of the leader and decides the lag is small enough.
        */
-      return true;
+      return isHybridAggregateMode();
     }
     return false;
   }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
@@ -4577,13 +4577,13 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
         && hybridStoreConfig.get().getDataReplicationPolicy().equals(DataReplicationPolicy.AGGREGATE);
   }
 
-  ReadyToServeCheck getReadyToServerChecker() {
+  ReadyToServeCheck getReadyToServeChecker() {
     return defaultReadyToServeChecker;
   }
 
   void maybeApplyReadyToServeCheck(PartitionConsumptionState partitionConsumptionState) {
     if (isHybridAggregateMode()) {
-      getReadyToServerChecker().apply(partitionConsumptionState);
+      getReadyToServeChecker().apply(partitionConsumptionState);
     }
   }
 }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
@@ -77,6 +77,7 @@ import com.linkedin.venice.kafka.protocol.enums.MessageType;
 import com.linkedin.venice.kafka.protocol.state.PartitionState;
 import com.linkedin.venice.kafka.protocol.state.StoreVersionState;
 import com.linkedin.venice.message.KafkaKey;
+import com.linkedin.venice.meta.DataReplicationPolicy;
 import com.linkedin.venice.meta.HybridStoreConfig;
 import com.linkedin.venice.meta.ReadOnlySchemaRepository;
 import com.linkedin.venice.meta.ReadOnlyStoreRepository;
@@ -2071,6 +2072,7 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
           }
         }
       }
+      // This ready-to-serve check is acceptable in SIT thread as it happens before subscription.
       if (!isCompletedReport) {
         defaultReadyToServeChecker.apply(newPartitionConsumptionState);
       }
@@ -4566,7 +4568,12 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
     this.versionRole = versionRole;
   }
 
-  protected boolean isDaVinciClient() {
+  boolean isDaVinciClient() {
     return isDaVinciClient;
+  }
+
+  boolean isHybridAggregateMode() {
+    return hybridStoreConfig.isPresent()
+        && hybridStoreConfig.get().getDataReplicationPolicy().equals(DataReplicationPolicy.AGGREGATE);
   }
 }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
@@ -4576,4 +4576,14 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
     return hybridStoreConfig.isPresent()
         && hybridStoreConfig.get().getDataReplicationPolicy().equals(DataReplicationPolicy.AGGREGATE);
   }
+
+  ReadyToServeCheck getReadyToServerChecker() {
+    return defaultReadyToServeChecker;
+  }
+
+  void maybeApplyReadyToServeCheck(PartitionConsumptionState partitionConsumptionState) {
+    if (isHybridAggregateMode()) {
+      getReadyToServerChecker().apply(partitionConsumptionState);
+    }
+  }
 }

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/StoreBackendTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/StoreBackendTest.java
@@ -403,6 +403,8 @@ public class StoreBackendTest {
       try (ReferenceCounted<VersionBackend> versionRef = storeBackend.getDaVinciCurrentVersion()) {
         assertEquals(versionRef.get().getVersion().getNumber(), version1.getNumber());
       }
+      // Bootstrap checker thread can also modify the versionMap, adding wait-assert here to avoid NPE.
+      assertNotNull(versionMap.get(version2.kafkaTopicName()));
     });
     versionMap.get(version2.kafkaTopicName()).completePartition(partition);
 

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTaskTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTaskTest.java
@@ -3683,16 +3683,20 @@ public abstract class StoreIngestionTaskTest {
 
   @DataProvider
   public static Object[][] testProcessTopicSwitchProvider() {
-    return new Object[][] { { LEADER }, { DA_VINCI } };
+    return DataProviderUtils.allPermutationGenerator(new NodeType[] { DA_VINCI, LEADER }, DataProviderUtils.BOOLEAN);
   }
 
   @Test(dataProvider = "testProcessTopicSwitchProvider")
-  public void testProcessTopicSwitch(NodeType nodeType) {
+  public void testProcessTopicSwitch(NodeType nodeType, boolean isAggregateMode) {
     VenicePartitioner partitioner = getVenicePartitioner();
     PartitionerConfig partitionerConfig = new PartitionerConfigImpl();
     partitionerConfig.setPartitionerClass(partitioner.getClass().getName());
-    HybridStoreConfig hybridStoreConfig =
-        new HybridStoreConfigImpl(100, 100, 100, DataReplicationPolicy.AGGREGATE, BufferReplayPolicy.REWIND_FROM_EOP);
+    HybridStoreConfig hybridStoreConfig = new HybridStoreConfigImpl(
+        100,
+        100,
+        100,
+        isAggregateMode ? DataReplicationPolicy.AGGREGATE : DataReplicationPolicy.NON_AGGREGATE,
+        BufferReplayPolicy.REWIND_FROM_EOP);
     MockStoreVersionConfigs storeAndVersionConfigs =
         setupStoreAndVersionMocks(2, partitionerConfig, Optional.of(hybridStoreConfig), false, true, AA_OFF);
     StorageService storageService = mock(StorageService.class);
@@ -3740,7 +3744,8 @@ public abstract class StoreIngestionTaskTest {
     doReturn(mockOffsetRecord).when(mockPcs).getOffsetRecord();
     doReturn(PARTITION_FOO).when(mockPcs).getPartition();
     doReturn(PARTITION_FOO).when(mockPcs).getPartition();
-    storeIngestionTaskUnderTest.processTopicSwitch(controlMessage, PARTITION_FOO, 10, mockPcs);
+    boolean result = storeIngestionTaskUnderTest.processTopicSwitch(controlMessage, PARTITION_FOO, 10, mockPcs);
+    Assert.assertEquals(isAggregateMode, result);
     verify(mockTopicManagerRemoteKafka, never()).getOffsetByTime(any(), anyLong());
     verify(mockOffsetRecord, never()).setLeaderUpstreamOffset(anyString(), anyLong());
   }

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/controller/TestClusterLevelConfigForNativeReplication.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/controller/TestClusterLevelConfigForNativeReplication.java
@@ -97,6 +97,7 @@ public class TestClusterLevelConfigForNativeReplication {
         parentControllerClient.updateStore(
             storeName,
             new UpdateStoreQueryParams().setIncrementalPushEnabled(true)
+                .setActiveActiveReplicationEnabled(true)
                 .setHybridRewindSeconds(1L)
                 .setHybridOffsetLagThreshold(10)));
     TestUtils.waitForNonDeterministicAssertion(TEST_TIMEOUT, TimeUnit.MILLISECONDS, () -> {

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/controller/TestParentControllerWithMultiDataCenter.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/controller/TestParentControllerWithMultiDataCenter.java
@@ -3,6 +3,7 @@ package com.linkedin.venice.controller;
 import static com.linkedin.venice.ConfigKeys.DEFAULT_MAX_NUMBER_OF_PARTITIONS;
 import static com.linkedin.venice.ConfigKeys.DEFAULT_NUMBER_OF_PARTITION_FOR_HYBRID;
 import static com.linkedin.venice.ConfigKeys.DEFAULT_PARTITION_SIZE;
+import static com.linkedin.venice.ConfigKeys.ENABLE_ACTIVE_ACTIVE_REPLICATION_AS_DEFAULT_FOR_HYBRID_STORE;
 import static com.linkedin.venice.utils.IntegrationTestPushUtils.createStoreForJob;
 import static com.linkedin.venice.utils.TestWriteUtils.getTempDataDirectory;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.DEFER_VERSION_SWAP;
@@ -78,6 +79,7 @@ public class TestParentControllerWithMultiDataCenter {
     controllerProps.put(DEFAULT_NUMBER_OF_PARTITION_FOR_HYBRID, 2);
     controllerProps.put(DEFAULT_MAX_NUMBER_OF_PARTITIONS, 3);
     controllerProps.put(DEFAULT_PARTITION_SIZE, 1024);
+    controllerProps.put(ENABLE_ACTIVE_ACTIVE_REPLICATION_AS_DEFAULT_FOR_HYBRID_STORE, true);
     multiRegionMultiClusterWrapper = ServiceFactory.getVeniceTwoLayerMultiRegionMultiClusterWrapper(
         NUMBER_OF_CHILD_DATACENTERS,
         NUMBER_OF_CLUSTERS,

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/controller/TestParentControllerWithMultiDataCenter.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/controller/TestParentControllerWithMultiDataCenter.java
@@ -326,6 +326,10 @@ public class TestParentControllerWithMultiDataCenter {
           incPushStoreName,
           parentControllerClient,
           new UpdateStoreQueryParams().setStorageQuotaInByte(Store.UNLIMITED_STORAGE_QUOTA)
+              .setHybridRewindSeconds(expectedHybridRewindSeconds)
+              .setHybridOffsetLagThreshold(expectedHybridOffsetLagThreshold)
+              .setHybridBufferReplayPolicy(expectedHybridBufferReplayPolicy)
+              .setActiveActiveReplicationEnabled(true)
               .setIncrementalPushEnabled(true));
       TestUtils.waitForNonDeterministicAssertion(30, TimeUnit.SECONDS, false, true, () -> {
         for (ControllerClient controllerClient: controllerClients) {

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/controller/TestParentControllerWithMultiDataCenter.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/controller/TestParentControllerWithMultiDataCenter.java
@@ -3,7 +3,6 @@ package com.linkedin.venice.controller;
 import static com.linkedin.venice.ConfigKeys.DEFAULT_MAX_NUMBER_OF_PARTITIONS;
 import static com.linkedin.venice.ConfigKeys.DEFAULT_NUMBER_OF_PARTITION_FOR_HYBRID;
 import static com.linkedin.venice.ConfigKeys.DEFAULT_PARTITION_SIZE;
-import static com.linkedin.venice.ConfigKeys.ENABLE_ACTIVE_ACTIVE_REPLICATION_AS_DEFAULT_FOR_HYBRID_STORE;
 import static com.linkedin.venice.utils.IntegrationTestPushUtils.createStoreForJob;
 import static com.linkedin.venice.utils.TestWriteUtils.getTempDataDirectory;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.DEFER_VERSION_SWAP;
@@ -11,6 +10,7 @@ import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 import static org.testng.AssertJUnit.fail;
 
+import com.linkedin.venice.common.VeniceSystemStoreType;
 import com.linkedin.venice.common.VeniceSystemStoreUtils;
 import com.linkedin.venice.controllerapi.ControllerClient;
 import com.linkedin.venice.controllerapi.ControllerResponse;
@@ -79,18 +79,19 @@ public class TestParentControllerWithMultiDataCenter {
     controllerProps.put(DEFAULT_NUMBER_OF_PARTITION_FOR_HYBRID, 2);
     controllerProps.put(DEFAULT_MAX_NUMBER_OF_PARTITIONS, 3);
     controllerProps.put(DEFAULT_PARTITION_SIZE, 1024);
-    controllerProps.put(ENABLE_ACTIVE_ACTIVE_REPLICATION_AS_DEFAULT_FOR_HYBRID_STORE, true);
+    Properties serverProps = new Properties();
     multiRegionMultiClusterWrapper = ServiceFactory.getVeniceTwoLayerMultiRegionMultiClusterWrapper(
         NUMBER_OF_CHILD_DATACENTERS,
         NUMBER_OF_CLUSTERS,
         1,
         1,
+        2,
         1,
-        1,
-        1,
+        2,
         Optional.of(controllerProps),
         Optional.of(controllerProps),
-        Optional.empty());
+        Optional.of(serverProps),
+        false);
 
     childDatacenters = multiRegionMultiClusterWrapper.getChildRegions();
   }
@@ -113,12 +114,6 @@ public class TestParentControllerWithMultiDataCenter {
           new ControllerClient(clusterName, childDatacenters.get(i).getControllerConnectString());
     }
 
-    List<TopicManager> topicManagers = new ArrayList<>(2);
-    topicManagers
-        .add(childDatacenters.get(0).getControllers().values().iterator().next().getVeniceAdmin().getTopicManager());
-    topicManagers
-        .add(childDatacenters.get(1).getControllers().values().iterator().next().getVeniceAdmin().getTopicManager());
-
     NewStoreResponse newStoreResponse =
         parentControllerClient.retryableRequest(5, c -> c.createNewStore(storeName, "", "\"string\"", "\"string\""));
     Assert.assertFalse(
@@ -126,11 +121,15 @@ public class TestParentControllerWithMultiDataCenter {
         "The NewStoreResponse returned an error: " + newStoreResponse.getError());
 
     StoreInfo store = TestUtils.assertCommand(parentControllerClient.getStore(storeName)).getStore();
-    String rtTopicName = Utils.getRealTimeTopicName(store);
-    PubSubTopic rtPubSubTopic = pubSubTopicRepository.getTopic(rtTopicName);
+
+    String metaSystemStoreTopic =
+        Version.composeKafkaTopic(VeniceSystemStoreType.META_STORE.getSystemStoreName(storeName), 1);
+    TestUtils.waitForNonDeterministicPushCompletion(metaSystemStoreTopic, parentControllerClient, 30, TimeUnit.SECONDS);
 
     UpdateStoreQueryParams updateStoreParams = new UpdateStoreQueryParams();
     updateStoreParams.setBackupStrategy(BackupStrategy.KEEP_MIN_VERSIONS)
+        .setActiveActiveReplicationEnabled(true)
+        .setIncrementalPushEnabled(true)
         .setNumVersionsToPreserve(2)
         .setHybridRewindSeconds(1000)
         .setHybridOffsetLagThreshold(1000);
@@ -141,6 +140,14 @@ public class TestParentControllerWithMultiDataCenter {
         .sendEmptyPushAndWait(storeName, Utils.getUniqueString("empty-push"), 1L, 60L * Time.MS_PER_SECOND);
     PubSubTopic versionPubsubTopic = getVersionPubsubTopic(storeName, response);
 
+    List<TopicManager> topicManagers = new ArrayList<>(2);
+    topicManagers
+        .add(childDatacenters.get(0).getControllers().values().iterator().next().getVeniceAdmin().getTopicManager());
+    topicManagers
+        .add(childDatacenters.get(1).getControllers().values().iterator().next().getVeniceAdmin().getTopicManager());
+
+    String rtTopicName = Utils.getRealTimeTopicName(store);
+    PubSubTopic rtPubSubTopic = pubSubTopicRepository.getTopic(rtTopicName);
     for (TopicManager topicManager: topicManagers) {
       Assert.assertTrue(topicManager.containsTopic(versionPubsubTopic));
       Assert.assertTrue(topicManager.containsTopic(rtPubSubTopic));

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/controller/TestParentControllerWithMultiDataCenter.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/controller/TestParentControllerWithMultiDataCenter.java
@@ -128,8 +128,7 @@ public class TestParentControllerWithMultiDataCenter {
     PubSubTopic rtPubSubTopic = pubSubTopicRepository.getTopic(rtTopicName);
 
     UpdateStoreQueryParams updateStoreParams = new UpdateStoreQueryParams();
-    updateStoreParams.setIncrementalPushEnabled(true)
-        .setBackupStrategy(BackupStrategy.KEEP_MIN_VERSIONS)
+    updateStoreParams.setBackupStrategy(BackupStrategy.KEEP_MIN_VERSIONS)
         .setNumVersionsToPreserve(2)
         .setHybridRewindSeconds(1000)
         .setHybridOffsetLagThreshold(1000);

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/ActiveActiveReplicationForHybridTest.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/ActiveActiveReplicationForHybridTest.java
@@ -188,12 +188,10 @@ public class ActiveActiveReplicationForHybridTest {
     String storeName1 = Utils.getUniqueString("test-batch-store");
     String storeName2 = Utils.getUniqueString("test-hybrid-agg-store");
     String storeName3 = Utils.getUniqueString("test-hybrid-non-agg-store");
-    String storeName4 = Utils.getUniqueString("test-incremental-push-store");
     try {
       createAndVerifyStoreInAllRegions(storeName1, parentControllerClient, dcControllerClientList);
       createAndVerifyStoreInAllRegions(storeName2, parentControllerClient, dcControllerClientList);
       createAndVerifyStoreInAllRegions(storeName3, parentControllerClient, dcControllerClientList);
-      createAndVerifyStoreInAllRegions(storeName4, parentControllerClient, dcControllerClientList);
 
       assertCommand(
           parentControllerClient.updateStore(
@@ -206,9 +204,6 @@ public class ActiveActiveReplicationForHybridTest {
           parentControllerClient.updateStore(
               storeName3,
               new UpdateStoreQueryParams().setHybridRewindSeconds(10).setHybridOffsetLagThreshold(2)));
-
-      assertCommand(
-          parentControllerClient.updateStore(storeName4, new UpdateStoreQueryParams().setIncrementalPushEnabled(true)));
 
       // Test batch
       assertCommand(
@@ -249,18 +244,8 @@ public class ActiveActiveReplicationForHybridTest {
       verifyDCConfigAARepl(parentControllerClient, storeName3, true, true, false);
       verifyDCConfigAARepl(dc0Client, storeName3, true, true, false);
       verifyDCConfigAARepl(dc1Client, storeName3, true, true, false);
-
-      // Test incremental
-      assertCommand(
-          parentControllerClient.configureActiveActiveReplicationForCluster(
-              true,
-              VeniceUserStoreType.INCREMENTAL_PUSH.toString(),
-              Optional.empty()));
-      verifyDCConfigAARepl(parentControllerClient, storeName4, false, false, true);
-      verifyDCConfigAARepl(dc0Client, storeName4, false, false, true);
-      verifyDCConfigAARepl(dc1Client, storeName4, false, false, true);
     } finally {
-      deleteStores(storeName1, storeName2, storeName3, storeName4);
+      deleteStores(storeName1, storeName2, storeName3);
     }
   }
 

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/PartialUpdateTest.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/PartialUpdateTest.java
@@ -406,6 +406,7 @@ public class PartialUpdateTest {
       UpdateStoreQueryParams updateStoreParams =
           new UpdateStoreQueryParams().setStorageQuotaInByte(Store.UNLIMITED_STORAGE_QUOTA)
               .setCompressionStrategy(CompressionStrategy.NO_OP)
+              .setActiveActiveReplicationEnabled(true)
               .setWriteComputationEnabled(true)
               .setChunkingEnabled(true)
               .setIncrementalPushEnabled(true)

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/PartialUpdateTest.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/PartialUpdateTest.java
@@ -1490,12 +1490,10 @@ public class PartialUpdateTest {
         newStoreResponse.isError(),
         "The NewStoreResponse returned an error: " + newStoreResponse.getError());
 
-    StoreInfo store = TestUtils.assertCommand(parentControllerClient.getStore(storeName)).getStore();
-
     UpdateStoreQueryParams updateStoreParams = new UpdateStoreQueryParams();
     updateStoreParams.setBackupStrategy(BackupStrategy.KEEP_MIN_VERSIONS)
         .setActiveActiveReplicationEnabled(true)
-        // .setIncrementalPushEnabled(true)
+        .setIncrementalPushEnabled(true)
         .setNumVersionsToPreserve(2)
         .setHybridRewindSeconds(1000)
         .setHybridOffsetLagThreshold(1000);

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/PartialUpdateTest.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/PartialUpdateTest.java
@@ -1,6 +1,7 @@
 package com.linkedin.venice.endToEnd;
 
 import static com.linkedin.davinci.stats.HostLevelIngestionStats.ASSEMBLED_RMD_SIZE_IN_BYTES;
+import static com.linkedin.venice.endToEnd.TestBatch.TEST_TIMEOUT;
 import static com.linkedin.venice.integration.utils.VeniceControllerWrapper.PARENT_D2_SERVICE_NAME;
 import static com.linkedin.venice.samza.VeniceSystemFactory.DEPLOYMENT_ID;
 import static com.linkedin.venice.samza.VeniceSystemFactory.VENICE_AGGREGATE;
@@ -63,6 +64,7 @@ import com.linkedin.venice.client.store.ClientFactory;
 import com.linkedin.venice.compression.CompressionStrategy;
 import com.linkedin.venice.controllerapi.ControllerClient;
 import com.linkedin.venice.controllerapi.ControllerResponse;
+import com.linkedin.venice.controllerapi.NewStoreResponse;
 import com.linkedin.venice.controllerapi.SchemaResponse;
 import com.linkedin.venice.controllerapi.UpdateStoreQueryParams;
 import com.linkedin.venice.controllerapi.VersionCreationResponse;
@@ -74,6 +76,7 @@ import com.linkedin.venice.integration.utils.VeniceControllerWrapper;
 import com.linkedin.venice.integration.utils.VeniceMultiClusterWrapper;
 import com.linkedin.venice.integration.utils.VeniceServerWrapper;
 import com.linkedin.venice.integration.utils.VeniceTwoLayerMultiRegionMultiClusterWrapper;
+import com.linkedin.venice.meta.BackupStrategy;
 import com.linkedin.venice.meta.ReadOnlySchemaRepository;
 import com.linkedin.venice.meta.Store;
 import com.linkedin.venice.meta.StoreInfo;
@@ -1466,6 +1469,46 @@ public class PartialUpdateTest {
         });
       }
     }
+  }
+
+  @Test(timeOut = TEST_TIMEOUT)
+  public void testRTTopicDeletionWithHybridAndIncrementalVersions() {
+    String storeName = Utils.getUniqueString("testRTTopicDeletion");
+    String clusterName = CLUSTER_NAME;
+    String parentControllerURLs = multiRegionMultiClusterWrapper.getControllerConnectString();
+    ControllerClient parentControllerClient =
+        ControllerClient.constructClusterControllerClient(clusterName, parentControllerURLs);
+    ControllerClient[] childControllerClients = new ControllerClient[childDatacenters.size()];
+    for (int i = 0; i < childDatacenters.size(); i++) {
+      childControllerClients[i] =
+          new ControllerClient(clusterName, childDatacenters.get(i).getControllerConnectString());
+    }
+
+    NewStoreResponse newStoreResponse =
+        parentControllerClient.retryableRequest(5, c -> c.createNewStore(storeName, "", "\"string\"", "\"string\""));
+    Assert.assertFalse(
+        newStoreResponse.isError(),
+        "The NewStoreResponse returned an error: " + newStoreResponse.getError());
+
+    StoreInfo store = TestUtils.assertCommand(parentControllerClient.getStore(storeName)).getStore();
+
+    UpdateStoreQueryParams updateStoreParams = new UpdateStoreQueryParams();
+    updateStoreParams.setBackupStrategy(BackupStrategy.KEEP_MIN_VERSIONS)
+        .setActiveActiveReplicationEnabled(true)
+        // .setIncrementalPushEnabled(true)
+        .setNumVersionsToPreserve(2)
+        .setHybridRewindSeconds(1000)
+        .setHybridOffsetLagThreshold(1000);
+    TestWriteUtils.updateStore(storeName, parentControllerClient, updateStoreParams);
+
+    VersionCreationResponse response = parentControllerClient.emptyPush(storeName, "test_push_id", 1000);
+    assertEquals(response.getVersion(), 1);
+    assertFalse(response.isError(), "Empty push to parent colo should succeed");
+    TestUtils.waitForNonDeterministicPushCompletion(
+        Version.composeKafkaTopic(storeName, 1),
+        parentControllerClient,
+        60,
+        TimeUnit.SECONDS);
   }
 
   @Test(timeOut = TEST_TIMEOUT_MS)

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/PartialUpdateTest.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/PartialUpdateTest.java
@@ -1474,15 +1474,9 @@ public class PartialUpdateTest {
   @Test(timeOut = TEST_TIMEOUT)
   public void testRTTopicDeletionWithHybridAndIncrementalVersions() {
     String storeName = Utils.getUniqueString("testRTTopicDeletion");
-    String clusterName = CLUSTER_NAME;
     String parentControllerURLs = multiRegionMultiClusterWrapper.getControllerConnectString();
     ControllerClient parentControllerClient =
-        ControllerClient.constructClusterControllerClient(clusterName, parentControllerURLs);
-    ControllerClient[] childControllerClients = new ControllerClient[childDatacenters.size()];
-    for (int i = 0; i < childDatacenters.size(); i++) {
-      childControllerClients[i] =
-          new ControllerClient(clusterName, childDatacenters.get(i).getControllerConnectString());
-    }
+        ControllerClient.constructClusterControllerClient(CLUSTER_NAME, parentControllerURLs);
 
     NewStoreResponse newStoreResponse =
         parentControllerClient.retryableRequest(5, c -> c.createNewStore(storeName, "", "\"string\"", "\"string\""));

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/PushJobDetailsTest.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/PushJobDetailsTest.java
@@ -338,7 +338,12 @@ public class PushJobDetailsTest {
       // because hadoop job client cannot fetch counters properly.
       parentControllerClient.updateStore(
           testStoreName,
-          new UpdateStoreQueryParams().setStorageQuotaInByte(-1).setPartitionCount(2).setIncrementalPushEnabled(true));
+          new UpdateStoreQueryParams().setStorageQuotaInByte(-1)
+              .setPartitionCount(2)
+              .setHybridOffsetLagThreshold(10)
+              .setHybridRewindSeconds(10)
+              .setActiveActiveReplicationEnabled(true)
+              .setIncrementalPushEnabled(true));
       Properties pushJobProps = defaultVPJProps(multiRegionMultiClusterWrapper, inputDirPathForFullPush, testStoreName);
       pushJobProps.setProperty(PUSH_JOB_STATUS_UPLOAD_ENABLE, String.valueOf(true));
       try (VenicePushJob testPushJob = new VenicePushJob("test-push-job-details-job", pushJobProps)) {

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/PushStatusStoreMultiColoTest.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/PushStatusStoreMultiColoTest.java
@@ -121,6 +121,7 @@ public class PushStatusStoreMultiColoTest {
             storeName,
             new UpdateStoreQueryParams().setStorageQuotaInByte(Store.UNLIMITED_STORAGE_QUOTA)
                 .setPartitionCount(PARTITION_COUNT)
+                .setActiveActiveReplicationEnabled(true)
                 .setIncrementalPushEnabled(true)));
     String daVinciPushStatusSystemStoreName =
         VeniceSystemStoreType.DAVINCI_PUSH_STATUS_STORE.getSystemStoreName(storeName);

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestBatchReportIncrementalPush.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestBatchReportIncrementalPush.java
@@ -121,6 +121,7 @@ public class TestBatchReportIncrementalPush {
               .setCompressionStrategy(CompressionStrategy.NO_OP)
               .setWriteComputationEnabled(true)
               .setChunkingEnabled(true)
+              .setActiveActiveReplicationEnabled(true)
               .setIncrementalPushEnabled(true)
               .setHybridRewindSeconds(1000L)
               .setHybridOffsetLagThreshold(2L);

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestPushJobWithNativeReplication.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestPushJobWithNativeReplication.java
@@ -32,16 +32,11 @@ import static com.linkedin.venice.utils.TestUtils.waitForNonDeterministicAsserti
 import static com.linkedin.venice.utils.TestWriteUtils.STRING_SCHEMA;
 import static com.linkedin.venice.utils.TestWriteUtils.getTempDataDirectory;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.DEFAULT_KEY_FIELD_PROP;
-import static com.linkedin.venice.vpj.VenicePushJobConstants.DEFAULT_RE_PUSH_REWIND_IN_SECONDS_OVERRIDE;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.DEFAULT_VALUE_FIELD_PROP;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.INCREMENTAL_PUSH;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.INPUT_PATH_PROP;
-import static com.linkedin.venice.vpj.VenicePushJobConstants.KAFKA_INPUT_BROKER_URL;
-import static com.linkedin.venice.vpj.VenicePushJobConstants.KAFKA_INPUT_MAX_RECORDS_PER_MAPPER;
-import static com.linkedin.venice.vpj.VenicePushJobConstants.KAFKA_INPUT_TOPIC;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.PUSH_JOB_STATUS_UPLOAD_ENABLE;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.SEND_CONTROL_MESSAGES_DIRECTLY;
-import static com.linkedin.venice.vpj.VenicePushJobConstants.SOURCE_KAFKA;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.TARGETED_REGION_PUSH_ENABLED;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.TARGETED_REGION_PUSH_WITH_DEFERRED_SWAP;
 import static org.testng.Assert.assertFalse;
@@ -119,7 +114,6 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Properties;
 import java.util.Set;
-import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
@@ -573,94 +567,6 @@ public class TestPushJobWithNativeReplication {
               }
             }
           });
-        });
-  }
-
-  @Test(timeOut = TEST_TIMEOUT)
-  public void testMultiDataCenterRePushWithIncrementalPush() throws Exception {
-    motherOfAllTests(
-        "testMultiDataCenterRePushWithIncrementalPush",
-        updateStoreQueryParams -> updateStoreQueryParams.setPartitionCount(1),
-        100,
-        (parentControllerClient, clusterName, storeName, props, inputDir) -> {
-          try (VenicePushJob job = new VenicePushJob("Test push job", props)) {
-            job.run();
-
-            // Verify the kafka URL being returned to the push job is the same as dc-0 kafka url.
-            Assert.assertEquals(job.getKafkaUrl(), childDatacenters.get(0).getKafkaBrokerWrapper().getAddress());
-          }
-          VeniceWriter<String, String, byte[]> incPushToRTWriter = null;
-          try {
-            assertFalse(
-                parentControllerClient
-                    .updateStore(
-                        storeName,
-                        new UpdateStoreQueryParams().setActiveActiveReplicationEnabled(true)
-                            .setIncrementalPushEnabled(true)
-                            .setHybridOffsetLagThreshold(1)
-                            .setHybridRewindSeconds(Time.SECONDS_PER_DAY))
-                    .isError());
-
-            // Update the store to L/F hybrid and enable INCREMENTAL_PUSH_SAME_AS_REAL_TIME.
-            props.setProperty(SOURCE_KAFKA, "true");
-            props.setProperty(
-                KAFKA_INPUT_BROKER_URL,
-                multiRegionMultiClusterWrapper.getParentKafkaBrokerWrapper().getAddress());
-            props.setProperty(KAFKA_INPUT_MAX_RECORDS_PER_MAPPER, "5");
-            props.setProperty(VeniceWriter.ENABLE_CHUNKING, "false");
-            props.setProperty(KAFKA_INPUT_TOPIC, Version.composeKafkaTopic(storeName, 1));
-
-            try (VenicePushJob rePushJob = new VenicePushJob("Test re-push job re-push", props)) {
-              rePushJob.run();
-            }
-            String incPushToRTVersion = System.currentTimeMillis() + "_test_inc_push_to_rt";
-            VeniceControllerWrapper parentController =
-                parentControllers.stream().filter(c -> c.isLeaderController(clusterName)).findAny().get();
-            incPushToRTWriter = startIncrementalPush(
-                parentControllerClient,
-                storeName,
-                parentController.getVeniceAdmin().getVeniceWriterFactory(),
-                incPushToRTVersion);
-            final String newVersionTopic = Version.composeKafkaTopic(
-                storeName,
-                parentControllerClient.getStore(storeName).getStore().getLargestUsedVersionNumber());
-            // Incremental push shouldn't be blocked and we will complete it once the new re-push is started.
-            String incValuePrefix = "inc_test_";
-            int newRePushVersion = Version.parseVersionFromKafkaTopicName(newVersionTopic) + 1;
-            VeniceWriter<String, String, byte[]> finalIncPushToRTWriter = incPushToRTWriter;
-            CompletableFuture.runAsync(() -> {
-              TestUtils.waitForNonDeterministicAssertion(30, TimeUnit.SECONDS, true, () -> {
-                Assert.assertEquals(
-                    parentControllerClient.getStore(storeName).getStore().getLargestUsedVersionNumber(),
-                    newRePushVersion);
-              });
-              for (int i = 1; i <= 10; i++) {
-                finalIncPushToRTWriter.put(Integer.toString(i), incValuePrefix + i, 1);
-              }
-              finalIncPushToRTWriter.broadcastEndOfIncrementalPush(incPushToRTVersion, new HashMap<>());
-            });
-            // The re-push should complete and contain all the incremental push to RT data.
-            props.setProperty(KAFKA_INPUT_TOPIC, newVersionTopic);
-            try (VenicePushJob rePushJob = new VenicePushJob("Test re-push job re-push", props)) {
-              rePushJob.run();
-            }
-            // Rewind should be overwritten.
-            Optional<Version> latestVersion =
-                parentControllerClient.getStore(storeName).getStore().getVersion(newRePushVersion);
-            Assert.assertTrue(latestVersion.isPresent());
-            Assert.assertEquals(
-                latestVersion.get().getHybridStoreConfig().getRewindTimeInSeconds(),
-                DEFAULT_RE_PUSH_REWIND_IN_SECONDS_OVERRIDE);
-            for (int dataCenterIndex = 0; dataCenterIndex < NUMBER_OF_CHILD_DATACENTERS; dataCenterIndex++) {
-              String routerUrl =
-                  childDatacenters.get(dataCenterIndex).getClusters().get(clusterName).getRandomRouterURL();
-              verifyVeniceStoreData(storeName, routerUrl, incValuePrefix, 10);
-            }
-          } finally {
-            if (incPushToRTWriter != null) {
-              incPushToRTWriter.close();
-            }
-          }
         });
   }
 

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestPushJobWithNativeReplication.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestPushJobWithNativeReplication.java
@@ -482,6 +482,7 @@ public class TestPushJobWithNativeReplication {
         updateStoreQueryParams -> updateStoreQueryParams.setPartitionCount(1)
             .setHybridOffsetLagThreshold(TEST_TIMEOUT)
             .setHybridRewindSeconds(2L)
+            .setActiveActiveReplicationEnabled(true)
             .setIncrementalPushEnabled(true),
         100,
         (parentControllerClient, clusterName, storeName, props, inputDir) -> {
@@ -509,8 +510,7 @@ public class TestPushJobWithNativeReplication {
     int partitionCount = 2;
     motherOfAllTests(
         "testActiveActiveForHeartbeatSystemStores",
-        updateStoreQueryParams -> updateStoreQueryParams.setPartitionCount(partitionCount)
-            .setIncrementalPushEnabled(true),
+        updateStoreQueryParams -> updateStoreQueryParams.setPartitionCount(partitionCount),
         recordCount,
         (parentControllerClient, clusterName, storeName, props, inputDir) -> {
           try (
@@ -595,7 +595,8 @@ public class TestPushJobWithNativeReplication {
                 parentControllerClient
                     .updateStore(
                         storeName,
-                        new UpdateStoreQueryParams().setIncrementalPushEnabled(true)
+                        new UpdateStoreQueryParams().setActiveActiveReplicationEnabled(true)
+                            .setIncrementalPushEnabled(true)
                             .setHybridOffsetLagThreshold(1)
                             .setHybridRewindSeconds(Time.SECONDS_PER_DAY))
                     .isError());

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/ingestionHeartbeat/IngestionHeartBeatTest.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/ingestionHeartbeat/IngestionHeartBeatTest.java
@@ -164,6 +164,11 @@ public class IngestionHeartBeatTest {
       ControllerResponse updateStoreResponse =
           parentControllerClient.retryableRequest(5, c -> c.updateStore(storeName, updateStoreParams));
 
+      // If config combination for incremental push is wrong, update store should fail loudly.
+      if (!isActiveActiveEnabled && isIncrementalPushEnabled) {
+        assertTrue(updateStoreResponse.isError(), "Update store does not error on invalid config combination.");
+        return;
+      }
       assertFalse(updateStoreResponse.isError(), "Update store got error: " + updateStoreResponse.getError());
 
       VersionCreationResponse response = parentControllerClient.emptyPush(storeName, "test_push_id", 1000);

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/integration/utils/VeniceTwoLayerMultiRegionMultiClusterWrapper.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/integration/utils/VeniceTwoLayerMultiRegionMultiClusterWrapper.java
@@ -24,7 +24,6 @@ import com.linkedin.venice.utils.Utils;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -256,44 +255,43 @@ public class VeniceTwoLayerMultiRegionMultiClusterWrapper extends ProcessWrapper
       Optional<Properties> serverProperties,
       List<String> regionNames,
       List<PubSubBrokerWrapper> kafkaBrokers) {
-    if (serverProperties.isPresent()) {
-      PubSubSecurityProtocol baseSecurityProtocol = PubSubSecurityProtocol.valueOf(
-          serverProperties.get().getProperty(KAFKA_SECURITY_PROTOCOL, PubSubSecurityProtocol.PLAINTEXT.name()));
-      Map<String, Map<String, String>> kafkaClusterMap = new HashMap<>();
-      Map<String, String> mapping;
-      for (int i = 1; i <= regionNames.size(); i++) {
-        int clusterId = i - 1;
-        String regionName = regionNames.get(clusterId);
-        PubSubSecurityProtocol securityProtocol = baseSecurityProtocol;
-        if (clusterId > 0) {
-          // Testing mixed security on any 2-layer setup with 2 or more DCs.
-          securityProtocol = PubSubSecurityProtocol.SSL;
-        }
-        PubSubBrokerWrapper pubSubBrokerWrapper = kafkaBrokers.get(i);
-        mapping = prepareKafkaClusterMappingInfo(regionName, pubSubBrokerWrapper, securityProtocol, "");
-        kafkaClusterMap.put(String.valueOf(clusterId), mapping);
+    PubSubSecurityProtocol baseSecurityProtocol = serverProperties
+        .map(
+            properties -> PubSubSecurityProtocol
+                .valueOf(properties.getProperty(KAFKA_SECURITY_PROTOCOL, PubSubSecurityProtocol.PLAINTEXT.name())))
+        .orElse(PubSubSecurityProtocol.PLAINTEXT);
+    Map<String, Map<String, String>> kafkaClusterMap = new HashMap<>();
+    Map<String, String> mapping;
+    for (int i = 1; i <= regionNames.size(); i++) {
+      int clusterId = i - 1;
+      String regionName = regionNames.get(clusterId);
+      PubSubSecurityProtocol securityProtocol = baseSecurityProtocol;
+      if (clusterId > 0) {
+        // Testing mixed security on any 2-layer setup with 2 or more DCs.
+        securityProtocol = PubSubSecurityProtocol.SSL;
       }
-
-      for (int i = 1 + regionNames.size(); i <= 2 * regionNames.size(); i++) {
-        int clusterId = i - 1;
-        String regionName = regionNames.get(clusterId - regionNames.size());
-        PubSubBrokerWrapper pubSubBrokerWrapper = kafkaBrokers.get(i - regionNames.size());
-        mapping = prepareKafkaClusterMappingInfo(
-            regionName,
-            pubSubBrokerWrapper,
-            baseSecurityProtocol,
-            Utils.SEPARATE_TOPIC_SUFFIX);
-        kafkaClusterMap.put(String.valueOf(clusterId), mapping);
-      }
-
-      LOGGER.info(
-          "addKafkaClusterIDMappingToServerConfigs \n\treceived broker list: \n\t\t{} \n\tand generated cluster map: \n\t\t{}",
-          kafkaBrokers.stream().map(PubSubBrokerWrapper::toString).collect(Collectors.joining("\n\t\t")),
-          kafkaClusterMap.entrySet().stream().map(Objects::toString).collect(Collectors.joining("\n\t\t")));
-      return kafkaClusterMap;
-    } else {
-      return Collections.emptyMap();
+      PubSubBrokerWrapper pubSubBrokerWrapper = kafkaBrokers.get(i);
+      mapping = prepareKafkaClusterMappingInfo(regionName, pubSubBrokerWrapper, securityProtocol, "");
+      kafkaClusterMap.put(String.valueOf(clusterId), mapping);
     }
+
+    for (int i = 1 + regionNames.size(); i <= 2 * regionNames.size(); i++) {
+      int clusterId = i - 1;
+      String regionName = regionNames.get(clusterId - regionNames.size());
+      PubSubBrokerWrapper pubSubBrokerWrapper = kafkaBrokers.get(i - regionNames.size());
+      mapping = prepareKafkaClusterMappingInfo(
+          regionName,
+          pubSubBrokerWrapper,
+          baseSecurityProtocol,
+          Utils.SEPARATE_TOPIC_SUFFIX);
+      kafkaClusterMap.put(String.valueOf(clusterId), mapping);
+    }
+
+    LOGGER.info(
+        "addKafkaClusterIDMappingToServerConfigs \n\treceived broker list: \n\t\t{} \n\tand generated cluster map: \n\t\t{}",
+        kafkaBrokers.stream().map(PubSubBrokerWrapper::toString).collect(Collectors.joining("\n\t\t")),
+        kafkaClusterMap.entrySet().stream().map(Objects::toString).collect(Collectors.joining("\n\t\t")));
+    return kafkaClusterMap;
   }
 
   static Map<String, String> prepareKafkaClusterMappingInfo(

--- a/internal/venice-test-common/src/main/java/com/linkedin/venice/utils/TestUtils.java
+++ b/internal/venice-test-common/src/main/java/com/linkedin/venice/utils/TestUtils.java
@@ -467,7 +467,7 @@ public class TestUtils {
       ControllerClient controllerClient,
       long timeout,
       TimeUnit timeoutUnit) {
-    waitForNonDeterministicAssertion(timeout, timeoutUnit, () -> {
+    waitForNonDeterministicAssertion(timeout, timeoutUnit, true, () -> {
       JobStatusQueryResponse jobStatusQueryResponse =
           assertCommand(controllerClient.queryJobStatus(topicName, Optional.empty()));
       ExecutionStatus executionStatus = ExecutionStatus.valueOf(jobStatusQueryResponse.getStatus());

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceParentHelixAdmin.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceParentHelixAdmin.java
@@ -2769,6 +2769,18 @@ public class VeniceParentHelixAdmin implements Admin {
       }
 
       /**
+       * Pre-flight check for incremental push config update. We only allow incremental push config to be turned on
+       * when store is A/A. Otherwise, we should fail store update.
+       */
+      if (setStore.hybridStoreConfig != null && setStore.incrementalPushEnabled
+          && !setStore.activeActiveReplicationEnabled) {
+        throw new VeniceHttpException(
+            HttpStatus.SC_BAD_REQUEST,
+            "Hybrid store config invalid. Cannot have incremental push enabled while A/A not enabled",
+            ErrorType.BAD_REQUEST);
+      }
+
+      /**
        * By default, parent controllers will not try to replicate the unchanged store configs to child controllers;
        * an updatedConfigsList will be used to represent which configs are updated by users.
        */

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceParentHelixAdmin.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceParentHelixAdmin.java
@@ -2518,7 +2518,7 @@ public class VeniceParentHelixAdmin implements Admin {
           && !veniceHelixAdmin.isHybrid(currStore.getHybridStoreConfig())
           && !veniceHelixAdmin.isHybrid(updatedHybridStoreConfig)) {
         LOGGER.info(
-            "Enabling incremental push for a batch store:{}. Converting it to a hybrid store with default configs.",
+            "Enabling incremental push for a batch store:{}. Converting it to Active/Active hybrid store with default configs.",
             storeName);
         HybridStoreConfigRecord hybridStoreConfigRecord = new HybridStoreConfigRecord();
         hybridStoreConfigRecord.rewindTimeInSeconds = DEFAULT_REWIND_TIME_IN_SECONDS;
@@ -2533,6 +2533,10 @@ public class VeniceParentHelixAdmin implements Admin {
         updatedConfigsList.add(BUFFER_REPLAY_POLICY);
         hybridStoreConfigRecord.realTimeTopicName = DEFAULT_REAL_TIME_TOPIC_NAME;
         setStore.hybridStoreConfig = hybridStoreConfigRecord;
+        if (!currStore.isSystemStore() && controllerConfig.isActiveActiveReplicationEnabledAsDefaultForHybrid()) {
+          setStore.activeActiveReplicationEnabled = true;
+          updatedConfigsList.add(ACTIVE_ACTIVE_REPLICATION_ENABLED);
+        }
       }
 
       /**

--- a/services/venice-controller/src/test/java/com/linkedin/venice/controller/TestVeniceParentHelixAdmin.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/controller/TestVeniceParentHelixAdmin.java
@@ -1750,8 +1750,7 @@ public class TestVeniceParentHelixAdmin extends AbstractTestVeniceParentHelixAdm
     when(zkClient.readData(zkMetadataNodePath, null)).thenReturn(null)
         .thenReturn(AdminTopicMetadataAccessor.generateMetadataMap(1, -1, 1));
 
-    UpdateStoreQueryParams storeQueryParams1 =
-        new UpdateStoreQueryParams().setIncrementalPushEnabled(true).setBlobTransferEnabled(true);
+    UpdateStoreQueryParams storeQueryParams1 = new UpdateStoreQueryParams().setBlobTransferEnabled(true);
     parentAdmin.initStorageCluster(clusterName);
     parentAdmin.updateStore(clusterName, storeName, storeQueryParams1);
 
@@ -1771,7 +1770,6 @@ public class TestVeniceParentHelixAdmin extends AbstractTestVeniceParentHelixAdm
     assertEquals(adminMessage.operationType, AdminMessageType.UPDATE_STORE.getValue());
 
     UpdateStore updateStore = (UpdateStore) adminMessage.payloadUnion;
-    assertEquals(updateStore.incrementalPushEnabled, true);
     Assert.assertTrue(updateStore.blobTransferEnabled);
 
     long readQuota = 100L;

--- a/services/venice-controller/src/test/java/com/linkedin/venice/controller/TestVeniceParentHelixAdmin.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/controller/TestVeniceParentHelixAdmin.java
@@ -2663,8 +2663,8 @@ public class TestVeniceParentHelixAdmin extends AbstractTestVeniceParentHelixAdm
         () -> parentAdmin.deleteAclForStore(clusterName, storeName));
   }
 
-  @Test
-  public void testHybridAndIncrementalUpdateStoreCommands() {
+  @Test(dataProvider = "True-and-False", dataProviderClass = DataProviderUtils.class)
+  public void testHybridAndIncrementalUpdateStoreCommands(boolean aaEnabled) {
     String storeName = Utils.getUniqueString("testUpdateStore");
     Store store = TestUtils.createTestStore(storeName, "test", System.currentTimeMillis());
     doReturn(store).when(internalAdmin).getStore(clusterName, storeName);
@@ -2701,6 +2701,7 @@ public class TestVeniceParentHelixAdmin extends AbstractTestVeniceParentHelixAdm
     assertEquals(updateStore.hybridStoreConfig.offsetLagThresholdToGoOnline, 20000);
     assertEquals(updateStore.hybridStoreConfig.rewindTimeInSeconds, 60);
 
+    store.setActiveActiveReplicationEnabled(aaEnabled);
     store.setHybridStoreConfig(
         new HybridStoreConfigImpl(
             60,
@@ -2709,10 +2710,15 @@ public class TestVeniceParentHelixAdmin extends AbstractTestVeniceParentHelixAdm
             DataReplicationPolicy.NON_AGGREGATE,
             BufferReplayPolicy.REWIND_FROM_EOP));
     // Incremental push can be enabled on a hybrid store, default inc push policy is inc push to RT now
-    parentAdmin.updateStore(clusterName, storeName, new UpdateStoreQueryParams().setIncrementalPushEnabled(true));
-
-    // veniceWriter.put will be called again for the second update store command
-    verify(veniceWriter, times(2)).put(keyCaptor.capture(), valueCaptor.capture(), schemaCaptor.capture());
+    if (aaEnabled) {
+      parentAdmin.updateStore(clusterName, storeName, new UpdateStoreQueryParams().setIncrementalPushEnabled(true));
+      // veniceWriter.put will be called again for the second update store command
+      verify(veniceWriter, times(2)).put(keyCaptor.capture(), valueCaptor.capture(), schemaCaptor.capture());
+    } else {
+      assertThrows(
+          () -> parentAdmin
+              .updateStore(clusterName, storeName, new UpdateStoreQueryParams().setIncrementalPushEnabled(true)));
+    }
   }
 
   @Test


### PR DESCRIPTION
<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## [server] Remove SIT ready-to-serve check for A/A and non-AGG store during L/F transition
<!--
Describe
- What changes to make and why you are making these changes.
- How are you going to achieve your goal.
- Describe what testings you have done, for example, performance testing etc.

If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->
Ready-to-serve check happens in two threads today:
(1) Drainer: which is reasonable
(2) SIT thread: there are two sub-cases:
- During L/F transition: It is only for empty RT topic, and today we have HB for non-agg and A/A already, so it only applies to the lingering AGG system store. In this PR, it is checked against store data replication type, if it is AGG we will still have it. We will completely remove it once AGG mode is removed.
- Before subscribe, it has a pre-check for short circuit to complete, and this is fine, as it is before the subscribe.

Also, I noticed that there are a bunch of integration tests which **enables incremental push on NON-AA store**. This is totally invalid setup and after removing the additional RTS check, these tests start to fail/very flaky. 
To make sure we don't do this in test and prod, this PR added a new check in update store command in parent controller, which will fail loudly if the new update request is to set incremental push to be true on a non-A/A store. 
I have another thinking about enabling all the configs that are enabled in production to be enabled in the test suite, but I'd like to do it in another separate PR, so it is easier for reviewers. 

Beyonds that, fixed a flaky unit test that can throw NPE.
## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
Add a sinlge unit test.

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.