### PR TITLE
[server] Increased Wait After Unsubscribe Timeout Fix

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/KafkaConsumerService.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/KafkaConsumerService.java
@@ -262,7 +262,7 @@ public abstract class KafkaConsumerService extends AbstractKafkaConsumerService 
        * setting data receiver and unsubscribing concurrently for the same topic partition on a shared consumer.
        */
       try (AutoCloseableLock ignored = AutoCloseableLock.of(consumerToLocks.get(consumer))) {
-        consumer.unSubscribe(pubSubTopicPartition);
+        consumer.unSubscribe(pubSubTopicPartition, timeoutMs);
         removeTopicPartitionFromConsumptionTask(consumer, pubSubTopicPartition);
       }
       versionTopicToTopicPartitionToConsumer.compute(versionTopic, (k, topicPartitionToConsumerMap) -> {


### PR DESCRIPTION
## Summary

1. Continuation of #1213 and #1339.
2. `SharedKafkaConsumer.unSubscribe()` was missing the `timeoutMs` parameter, which was overwritten as a merge conflict in #1308.

## Does this PR introduce any user-facing changes?
- [X] No. You can skip the rest of this section.