### PR TITLE
[build] Add checker framework for nullness type-checking

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,6 +17,7 @@ plugins {
   id 'me.champeau.jmh' version '0.6.7' apply false
   id 'io.github.lhotari.gradle-nar-plugin' version '0.5.1' apply false
   id 'com.google.protobuf' version '0.9.3' apply false
+  id 'org.checkerframework' version '0.6.47' // Checker Framework pluggable type-checking
 }
 
 apply from: "$rootDir/gradle/helper/git.gradle"
@@ -192,6 +193,7 @@ subprojects {
     plugin 'java-library'
     plugin 'com.github.spotbugs'
     plugin 'org.gradle.test-retry'
+    plugin 'org.checkerframework'
   }
 
   if (isLeafSubModule) {
@@ -818,4 +820,13 @@ task verifyJdkVersion {
 gradle.taskGraph.whenReady {
   // Ensure the JDK version is verified before any other tasks
   verifyJdkVersion
+}
+
+task listSubprojects {
+  doLast {
+    println "Subprojects:"
+    subprojects.each { subproject ->
+      println "${subproject.name}"
+    }
+  }
 }

--- a/clients/da-vinci-client/build.gradle
+++ b/clients/da-vinci-client/build.gradle
@@ -49,3 +49,10 @@ dependencies {
 ext {
   jacocoCoverageThreshold = 0.40
 }
+
+checkerFramework {
+  extraJavacArgs = ['-Xmaxerrs', '256']
+  checkers = ['org.checkerframework.checker.nullness.NullnessChecker']
+  skipCheckerFramework = true
+  excludeTests = true
+}

--- a/clients/venice-admin-tool/build.gradle
+++ b/clients/venice-admin-tool/build.gradle
@@ -47,3 +47,10 @@ jar {
 ext {
   jacocoCoverageThreshold = 0.00
 }
+
+checkerFramework {
+  extraJavacArgs = ['-Xmaxerrs', '256']
+  checkers = ['org.checkerframework.checker.nullness.NullnessChecker']
+  skipCheckerFramework = true
+  excludeTests = true
+}

--- a/clients/venice-client/build.gradle
+++ b/clients/venice-client/build.gradle
@@ -37,3 +37,10 @@ dependencies {
 ext {
   jacocoCoverageThreshold = 0.53
 }
+
+checkerFramework {
+  extraJavacArgs = ['-Xmaxerrs', '256']
+  checkers = ['org.checkerframework.checker.nullness.NullnessChecker']
+  skipCheckerFramework = true
+  excludeTests = true
+}

--- a/clients/venice-producer/build.gradle
+++ b/clients/venice-producer/build.gradle
@@ -20,3 +20,10 @@ jar {
 ext {
     jacocoCoverageThreshold = 0.5
 }
+
+checkerFramework {
+    extraJavacArgs = ['-Xmaxerrs', '256']
+    checkers = ['org.checkerframework.checker.nullness.NullnessChecker']
+    skipCheckerFramework = true
+    excludeTests = true
+}

--- a/clients/venice-push-job/build.gradle
+++ b/clients/venice-push-job/build.gradle
@@ -121,3 +121,10 @@ jar {
 ext {
   jacocoCoverageThreshold = 0.39
 }
+
+checkerFramework {
+  extraJavacArgs = ['-Xmaxerrs', '256']
+  checkers = ['org.checkerframework.checker.nullness.NullnessChecker']
+  skipCheckerFramework = true
+  excludeTests = true
+}

--- a/clients/venice-thin-client/build.gradle
+++ b/clients/venice-thin-client/build.gradle
@@ -47,3 +47,10 @@ jar {
 ext {
   jacocoCoverageThreshold = 0.44
 }
+
+checkerFramework {
+  extraJavacArgs = ['-Xmaxerrs', '256']
+  checkers = ['org.checkerframework.checker.nullness.NullnessChecker']
+  skipCheckerFramework = true
+  excludeTests = true
+}

--- a/integrations/venice-beam/build.gradle
+++ b/integrations/venice-beam/build.gradle
@@ -18,3 +18,10 @@ ext {
   // to be tested in integration test
   jacocoCoverageThreshold = 0.00
 }
+
+checkerFramework {
+  extraJavacArgs = ['-Xmaxerrs', '256']
+  checkers = ['org.checkerframework.checker.nullness.NullnessChecker']
+  skipCheckerFramework = true
+  excludeTests = true
+}

--- a/integrations/venice-pulsar/build.gradle
+++ b/integrations/venice-pulsar/build.gradle
@@ -52,3 +52,10 @@ ext {
   // tested in integration test
   jacocoCoverageThreshold = 0.00
 }
+
+checkerFramework {
+  extraJavacArgs = ['-Xmaxerrs', '256']
+  checkers = ['org.checkerframework.checker.nullness.NullnessChecker']
+  skipCheckerFramework = true
+  excludeTests = true
+}

--- a/integrations/venice-samza/build.gradle
+++ b/integrations/venice-samza/build.gradle
@@ -23,3 +23,10 @@ dependencies {
 ext {
   jacocoCoverageThreshold = 0.01
 }
+
+checkerFramework {
+  extraJavacArgs = ['-Xmaxerrs', '256']
+  checkers = ['org.checkerframework.checker.nullness.NullnessChecker']
+  skipCheckerFramework = true
+  excludeTests = true
+}

--- a/internal/venice-client-common/build.gradle
+++ b/internal/venice-client-common/build.gradle
@@ -53,3 +53,10 @@ dependencies {
 ext {
   jacocoCoverageThreshold = 0.36
 }
+
+checkerFramework {
+  extraJavacArgs = ['-Xmaxerrs', '256']
+  checkers = ['org.checkerframework.checker.nullness.NullnessChecker']
+  skipCheckerFramework = true
+  excludeTests = true
+}

--- a/internal/venice-common/build.gradle
+++ b/internal/venice-common/build.gradle
@@ -72,3 +72,10 @@ sourceSets.main.resources.srcDir(generateSslCertificate)
 ext {
   jacocoCoverageThreshold = 0.33
 }
+
+checkerFramework {
+  extraJavacArgs = ['-Xmaxerrs', '256']
+  checkers = ['org.checkerframework.checker.nullness.NullnessChecker']
+  skipCheckerFramework = true
+  excludeTests = true
+}

--- a/services/venice-controller/build.gradle
+++ b/services/venice-controller/build.gradle
@@ -63,3 +63,10 @@ jar {
 ext {
   jacocoCoverageThreshold = 0.21
 }
+
+checkerFramework {
+  extraJavacArgs = ['-Xmaxerrs', '256']
+  checkers = ['org.checkerframework.checker.nullness.NullnessChecker']
+  skipCheckerFramework = true
+  excludeTests = true
+}

--- a/services/venice-router/build.gradle
+++ b/services/venice-router/build.gradle
@@ -84,3 +84,10 @@ jar {
 ext {
   jacocoCoverageThreshold = 0.40
 }
+
+checkerFramework {
+  extraJavacArgs = ['-Xmaxerrs', '256']
+  checkers = ['org.checkerframework.checker.nullness.NullnessChecker']
+  skipCheckerFramework = true
+  excludeTests = true
+}

--- a/services/venice-server/build.gradle
+++ b/services/venice-server/build.gradle
@@ -78,3 +78,10 @@ jar {
 ext {
   jacocoCoverageThreshold = 0.38
 }
+
+checkerFramework {
+  extraJavacArgs = ['-Xmaxerrs', '256']
+  checkers = ['org.checkerframework.checker.nullness.NullnessChecker']
+  skipCheckerFramework = true
+  excludeTests = true
+}

--- a/services/venice-standalone/build.gradle
+++ b/services/venice-standalone/build.gradle
@@ -37,3 +37,9 @@ ext {
   jacocoCoverageThreshold = 0.23
 }
 
+checkerFramework {
+  extraJavacArgs = ['-Xmaxerrs', '256']
+  checkers = ['org.checkerframework.checker.nullness.NullnessChecker']
+  skipCheckerFramework = true
+  excludeTests = true
+}


### PR DESCRIPTION
<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## Add checker framework for nullness type-checking
We've been running into a lot of NPEs lately, so we decided to bring in the Checker Framework for nullness type-checking to help catch and prevent these issues. The checker is off by default and will be turned on gradually for each module. To enable it, pass the `-PskipCheckerFramework=false` flag when running Gradle.

Example:
```bash
./gradlew -PskipCheckerFramework=false compileJava
```

For more info about checker framework, see [Checker Framework](https://checkerframework.org)

## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.