### PR TITLE
[router] Improve HAR routing in Router

### DIFF
--- a/internal/venice-client-common/src/main/java/com/linkedin/venice/stats/AbstractVeniceStats.java
+++ b/internal/venice-client-common/src/main/java/com/linkedin/venice/stats/AbstractVeniceStats.java
@@ -136,7 +136,7 @@ public class AbstractVeniceStats {
               }
             }
           } else {
-            String metricName = sensorFullName + "." + metricNameSuffix(stat);
+            String metricName = getMetricFullName(sensor, stat);
             if (metricsRepository.getMetric(metricName) == null) {
               sensor.add(metricName, stat, config);
             }
@@ -145,6 +145,10 @@ public class AbstractVeniceStats {
       }
       return sensor;
     });
+  }
+
+  protected String getMetricFullName(Sensor sensor, MeasurableStat stat) {
+    return sensor.name() + "." + metricNameSuffix(stat);
   }
 
   /**

--- a/services/venice-router/src/main/java/com/linkedin/venice/router/api/VeniceDelegateMode.java
+++ b/services/venice-router/src/main/java/com/linkedin/venice/router/api/VeniceDelegateMode.java
@@ -512,6 +512,8 @@ public class VeniceDelegateMode extends ScatterGatherMode {
       Map<Instance, KeyPartitionSet<Instance, RouterKey>> hostMap = new HashMap<>();
       int helixGroupNum = getHelixGroupNum();
       int assignedHelixGroupId = getAssignedHelixGroupId(venicePath);
+      // This is used to record the request start time for the whole Router request.
+      venicePath.recordOriginalRequestStartTimestamp();
       currentPartition = 0;
       try {
         for (; currentPartition < partitionCount; currentPartition++) {

--- a/services/venice-router/src/main/java/com/linkedin/venice/router/api/VeniceResponseAggregator.java
+++ b/services/venice-router/src/main/java/com/linkedin/venice/router/api/VeniceResponseAggregator.java
@@ -181,7 +181,10 @@ public class VeniceResponseAggregator implements ResponseAggregatorFactory<Basic
      * 3. HelixGroupId is valid since Helix-assisted routing is only enabled for multi-key request.
       */
     if (!venicePath.isRetryRequest() && helixGroupSelector != null && venicePath.getHelixGroupId() >= 0) {
-      helixGroupSelector.finishRequest(venicePath.getRequestId(), venicePath.getHelixGroupId());
+      helixGroupSelector.finishRequest(
+          venicePath.getRequestId(),
+          venicePath.getHelixGroupId(),
+          LatencyUtils.getElapsedTimeFromMsToMs(venicePath.getOriginalRequestStartTs()));
     }
     RequestType requestType = venicePath.getRequestType();
     AggRouterHttpRequestStats stats = routerStats.getStatsByType(requestType);

--- a/services/venice-router/src/main/java/com/linkedin/venice/router/api/routing/helix/HelixGroupRoundRobinStrategy.java
+++ b/services/venice-router/src/main/java/com/linkedin/venice/router/api/routing/helix/HelixGroupRoundRobinStrategy.java
@@ -14,25 +14,8 @@ public class HelixGroupRoundRobinStrategy implements HelixGroupSelectionStrategy
   }
 
   @Override
-  public void finishRequest(long requestId, int groupId) {
+  public void finishRequest(long requestId, int groupId, double latency) {
     // do nothing
   }
 
-  @Override
-  public int getMaxGroupPendingRequest() {
-    // Not supported
-    return -1;
-  }
-
-  @Override
-  public int getMinGroupPendingRequest() {
-    // Not supported
-    return -1;
-  }
-
-  @Override
-  public int getAvgGroupPendingRequest() {
-    // Not supported
-    return -1;
-  }
 }

--- a/services/venice-router/src/main/java/com/linkedin/venice/router/api/routing/helix/HelixGroupSelectionStrategy.java
+++ b/services/venice-router/src/main/java/com/linkedin/venice/router/api/routing/helix/HelixGroupSelectionStrategy.java
@@ -10,20 +10,6 @@ public interface HelixGroupSelectionStrategy {
    * Notify the corresponding Helix Group that the request is completed, and the implementation will decide whether
    * any cleanup is required or not.
    */
-  void finishRequest(long requestId, int groupId);
+  void finishRequest(long requestId, int groupId, double latency);
 
-  /**
-   * Get the maximum of the pending requests among all the groups
-   */
-  int getMaxGroupPendingRequest();
-
-  /**
-   * Get the minimum of the pending requests among all the groups
-   */
-  int getMinGroupPendingRequest();
-
-  /**
-   * Get the average of the pending requests among all the groups
-   */
-  int getAvgGroupPendingRequest();
 }

--- a/services/venice-router/src/test/java/com/linkedin/venice/router/api/routing/helix/TestHelixGroupLeastLoadedStrategy.java
+++ b/services/venice-router/src/test/java/com/linkedin/venice/router/api/routing/helix/TestHelixGroupLeastLoadedStrategy.java
@@ -6,6 +6,8 @@ import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 
 import com.linkedin.alpini.base.concurrency.TimeoutProcessor;
+import com.linkedin.venice.router.stats.HelixGroupStats;
+import io.tehuti.metrics.MetricsRepository;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
@@ -15,24 +17,39 @@ public class TestHelixGroupLeastLoadedStrategy {
   public void testSelectGroup() {
     TimeoutProcessor timeoutProcessor = mock(TimeoutProcessor.class);
     doReturn(mock(TimeoutProcessor.TimeoutFuture.class)).when(timeoutProcessor).schedule(any(), anyLong(), any());
-    HelixGroupLeastLoadedStrategy strategy = new HelixGroupLeastLoadedStrategy(timeoutProcessor, 10000);
+    HelixGroupLeastLoadedStrategy strategy =
+        new HelixGroupLeastLoadedStrategy(timeoutProcessor, 10000, mock(HelixGroupStats.class));
     int groupNum = 3;
     // Group 0 is slow.
     Assert.assertEquals(strategy.selectGroup(0, groupNum), 0);
     Assert.assertEquals(strategy.selectGroup(1, groupNum), 1);
     Assert.assertEquals(strategy.selectGroup(2, groupNum), 2);
-    Assert.assertEquals(strategy.getMaxGroupPendingRequest(), 1);
-    Assert.assertEquals(strategy.getMinGroupPendingRequest(), 1);
-    Assert.assertEquals(strategy.getAvgGroupPendingRequest(), 1);
-    strategy.finishRequest(1, 1);
-    strategy.finishRequest(2, 2);
+    strategy.finishRequest(1, 1, 1);
+    strategy.finishRequest(2, 2, 1);
     Assert.assertEquals(strategy.selectGroup(3, groupNum), 1);
     Assert.assertEquals(strategy.selectGroup(4, groupNum), 2);
-    strategy.finishRequest(0, 0);
-    strategy.finishRequest(3, 1);
-    strategy.finishRequest(4, 2);
+    strategy.finishRequest(0, 0, 1);
+    strategy.finishRequest(3, 1, 1);
+    strategy.finishRequest(4, 2, 1);
     // Group 0 is recovered
     Assert.assertEquals(strategy.selectGroup(5, groupNum), 2);
     Assert.assertEquals(strategy.selectGroup(6, groupNum), 0);
+  }
+
+  @Test
+  public void testLatencyBasedGroupSelection() {
+    TimeoutProcessor timeoutProcessor = mock(TimeoutProcessor.class);
+    doReturn(mock(TimeoutProcessor.TimeoutFuture.class)).when(timeoutProcessor).schedule(any(), anyLong(), any());
+    HelixGroupStats stats = new HelixGroupStats(new MetricsRepository());
+    HelixGroupLeastLoadedStrategy strategy = new HelixGroupLeastLoadedStrategy(timeoutProcessor, 10000, stats);
+    int groupNum = 3;
+    Assert.assertEquals(strategy.selectGroup(0, groupNum), 0);
+    Assert.assertEquals(strategy.selectGroup(1, groupNum), 1);
+    Assert.assertEquals(strategy.selectGroup(2, groupNum), 2);
+    // Group 2 is the fastest one
+    strategy.finishRequest(0, 0, 2);
+    strategy.finishRequest(1, 1, 3);
+    strategy.finishRequest(2, 2, 1);
+    Assert.assertEquals(strategy.selectGroup(3, groupNum), 2);
   }
 }

--- a/services/venice-router/src/test/java/com/linkedin/venice/router/api/routing/helix/TestHelixGroupRoundRobinStrategy.java
+++ b/services/venice-router/src/test/java/com/linkedin/venice/router/api/routing/helix/TestHelixGroupRoundRobinStrategy.java
@@ -10,16 +10,16 @@ public class TestHelixGroupRoundRobinStrategy {
     HelixGroupRoundRobinStrategy strategy = new HelixGroupRoundRobinStrategy();
     int groupNum = 3;
     Assert.assertEquals(strategy.selectGroup(0, groupNum), 0);
-    strategy.finishRequest(0, 0);
+    strategy.finishRequest(0, 0, 1);
     Assert.assertEquals(strategy.selectGroup(1, groupNum), 1);
-    strategy.finishRequest(1, 1);
+    strategy.finishRequest(1, 1, 1);
     Assert.assertEquals(strategy.selectGroup(2, groupNum), 2);
-    strategy.finishRequest(2, 2);
+    strategy.finishRequest(2, 2, 1);
     Assert.assertEquals(strategy.selectGroup(3, groupNum), 0);
-    strategy.finishRequest(3, 0);
+    strategy.finishRequest(3, 0, 1);
     Assert.assertEquals(strategy.selectGroup(4, groupNum), 1);
-    strategy.finishRequest(4, 1);
+    strategy.finishRequest(4, 1, 1);
     Assert.assertEquals(strategy.selectGroup(5, groupNum), 2);
-    strategy.finishRequest(5, 2);
+    strategy.finishRequest(5, 2, 1);
   }
 }


### PR DESCRIPTION
Update Venice Router HAR least-loaded algo to take group latency into account and here
are the reasons:
a. When the total qps is relatively low, the pending request count based load rebalancing
      algo doesn't work well as most of the time, the pending count is 0. One example: let us
      say, the avg latency of one group is 10ms, and if the group qps is 10, that means very likely
      only 10-20% of the time, there are some pending requests and even another group latency is
      much lower: 1-2ms, the faster group won't be selected, and the latency-based LB algo will kick
      in when the above case happens to prefer the faster group if the pending count is equal among all
      the groups.
b. Completely getting rid of pending request count based LB will result in another issue as the relatively
      slower group will get almost zero request.
c. A combination of pending request and latency will select the faster groups when all groups are busy or idle,
      and it will still send some amount of requests to the slower groups in case it is too idle and it will help
      bring back the slower group into the rotation when it is recovered from the slowness.

<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

<!--
Describe
- What changes to make and why you are making these changes.
- How are you going to achieve your goal.
- Describe what testings you have done, for example, performance testing etc.

If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->


## How was this PR tested?
CI
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.