### PR TITLE
[server] Use thread safe map for versioned stats in SN read quota

### DIFF
--- a/services/venice-server/src/main/java/com/linkedin/venice/stats/ServerReadQuotaUsageStats.java
+++ b/services/venice-server/src/main/java/com/linkedin/venice/stats/ServerReadQuotaUsageStats.java
@@ -2,13 +2,13 @@ package com.linkedin.venice.stats;
 
 import com.linkedin.venice.utils.SystemTime;
 import com.linkedin.venice.utils.Time;
+import com.linkedin.venice.utils.concurrent.VeniceConcurrentHashMap;
 import io.tehuti.metrics.MetricConfig;
 import io.tehuti.metrics.MetricsRepository;
 import io.tehuti.metrics.Sensor;
 import io.tehuti.metrics.stats.AsyncGauge;
 import io.tehuti.metrics.stats.Count;
 import io.tehuti.metrics.stats.Rate;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 
@@ -30,7 +30,8 @@ public class ServerReadQuotaUsageStats extends AbstractVeniceStats {
   private final Sensor rejectedKPS; // rejected key per second
   private final Sensor allowedUnintentionallyKPS; // allowed KPS unintentionally due to error or insufficient info
   private final Sensor usageRatioSensor; // requested kps divided by nodes quota responsibility
-  private final ConcurrentHashMap<Integer, ServerReadQuotaVersionedStats> versionedStats = new ConcurrentHashMap<>();
+  private final VeniceConcurrentHashMap<Integer, ServerReadQuotaVersionedStats> versionedStats =
+      new VeniceConcurrentHashMap<>();
   private final AtomicInteger currentVersion = new AtomicInteger(0);
   private final AtomicInteger backupVersion = new AtomicInteger(0);
   private final Time time;

--- a/services/venice-server/src/main/java/com/linkedin/venice/stats/ServerReadQuotaUsageStats.java
+++ b/services/venice-server/src/main/java/com/linkedin/venice/stats/ServerReadQuotaUsageStats.java
@@ -8,8 +8,7 @@ import io.tehuti.metrics.Sensor;
 import io.tehuti.metrics.stats.AsyncGauge;
 import io.tehuti.metrics.stats.Count;
 import io.tehuti.metrics.stats.Rate;
-import it.unimi.dsi.fastutil.ints.Int2ObjectMap;
-import it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 
@@ -31,7 +30,7 @@ public class ServerReadQuotaUsageStats extends AbstractVeniceStats {
   private final Sensor rejectedKPS; // rejected key per second
   private final Sensor allowedUnintentionallyKPS; // allowed KPS unintentionally due to error or insufficient info
   private final Sensor usageRatioSensor; // requested kps divided by nodes quota responsibility
-  private final Int2ObjectMap<ServerReadQuotaVersionedStats> versionedStats = new Int2ObjectOpenHashMap<>();
+  private final ConcurrentHashMap<Integer, ServerReadQuotaVersionedStats> versionedStats = new ConcurrentHashMap<>();
   private final AtomicInteger currentVersion = new AtomicInteger(0);
   private final AtomicInteger backupVersion = new AtomicInteger(0);
   private final Time time;
@@ -144,10 +143,10 @@ public class ServerReadQuotaUsageStats extends AbstractVeniceStats {
    */
   final Double getReadQuotaUsageRatio() {
     int version = currentVersion.get();
-    if (version < 1 || !versionedStats.containsKey(version)) {
+    ServerReadQuotaVersionedStats stats = versionedStats.get(version);
+    if (version < 1 || stats == null) {
       return Double.NaN;
     }
-    ServerReadQuotaVersionedStats stats = versionedStats.get(version);
     long nodeKpsResponsibility = stats.getNodeKpsResponsibility();
     if (nodeKpsResponsibility < 1) {
       return Double.NaN;


### PR DESCRIPTION
## [server] Use thread safe map for versioned stats in SN read quota

`Int2ObjectOpenHashMap` is not thread safe and using it for `ServerReadQuotaUsageStats` could result in unexpected behaviors during race conditions since the map is accessed and modified by multiple triggers and threads:

1. Read traffic
2. CV/routing change events
3. Version creation and deletion events

Added a test and confirmed that it will hang/timeout with `Int2ObjectOpenHashMap` but succeed with a thread safe map like `VeniceConcurrentHashMap`

Also minor defensive code change in `getReadQuotaUsageRatio` to avoid NPE since the map could change in between check and access.

## How was this PR tested?
New unit test and existing integration tests

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.