### PR TITLE
[Server] Fixed the connection tracking

### DIFF
--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/fastclient/FastClientIndividualFeatureConfigurationTest.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/fastclient/FastClientIndividualFeatureConfigurationTest.java
@@ -26,6 +26,7 @@ import com.linkedin.venice.serialization.avro.VeniceAvroKafkaSerializer;
 import com.linkedin.venice.utils.ExceptionUtils;
 import com.linkedin.venice.utils.IntegrationTestPushUtils;
 import com.linkedin.venice.utils.TestUtils;
+import com.linkedin.venice.utils.Utils;
 import com.linkedin.venice.writer.VeniceWriter;
 import com.linkedin.venice.writer.VeniceWriterOptions;
 import io.tehuti.metrics.MetricsRepository;
@@ -121,8 +122,9 @@ public class FastClientIndividualFeatureConfigurationTest extends AbstractClient
     });
     int quotaRequestedQPSSum = 0;
     int quotaRequestedKPSSum = 0;
-    int clientConnectionCountRateSum = 0;
-    int routerConnectionCountRateSum = 0;
+    double clientConnectionCountRateSum = 0;
+    double routerConnectionCountRateSum = 0;
+    Utils.sleep(3000); // sleep 3s as the connection tracking metrics are updated every 1s
     for (MetricsRepository serverMetric: serverMetrics) {
       quotaRequestedQPSSum += serverMetric.getMetric(readQuotaRequestedQPSString).value();
       quotaRequestedKPSSum += serverMetric.getMetric(readQuotaRequestedKPSString).value();
@@ -135,7 +137,7 @@ public class FastClientIndividualFeatureConfigurationTest extends AbstractClient
     assertTrue(quotaRequestedQPSSum >= 0, "Quota request sum: " + quotaRequestedQPSSum);
     assertTrue(quotaRequestedKPSSum >= 0, "Quota request key count sum: " + quotaRequestedKPSSum);
     assertTrue(clientConnectionCountRateSum > 0, "Servers should have more than 0 client connections");
-    assertEquals(routerConnectionCountRateSum, 0, "Servers should have 0 router connections");
+    assertEquals(routerConnectionCountRateSum, 0.0d, "Servers should have 0 router connections");
     // At least one server's usage ratio should eventually be a positive decimal
     TestUtils.waitForNonDeterministicAssertion(5, TimeUnit.SECONDS, () -> {
       double usageRatio = 0;

--- a/services/venice-server/src/main/java/com/linkedin/venice/listener/HttpChannelInitializer.java
+++ b/services/venice-server/src/main/java/com/linkedin/venice/listener/HttpChannelInitializer.java
@@ -58,7 +58,7 @@ public class HttpChannelInitializer extends ChannelInitializer<SocketChannel> {
   private final VeniceServerConfig serverConfig;
   private final ReadQuotaEnforcementHandler quotaEnforcer;
   private final VeniceHttp2PipelineInitializerBuilder http2PipelineInitializerBuilder;
-  private final ServerConnectionStats serverConnectionStats;
+  private final ServerConnectionStatsHandler serverConnectionStatsHandler;
   private AggServerQuotaUsageStats quotaUsageStats;
   List<ServerInterceptor> aclInterceptors;
   private final IdentityParser identityParser;
@@ -152,7 +152,14 @@ public class HttpChannelInitializer extends ChannelInitializer<SocketChannel> {
     }
     this.http2PipelineInitializerBuilder = new VeniceHttp2PipelineInitializerBuilder(serverConfig);
 
-    serverConnectionStats = new ServerConnectionStats(metricsRepository, "server_connection_stats");
+    if (sslFactory.isPresent()) {
+      this.serverConnectionStatsHandler = new ServerConnectionStatsHandler(
+          this.identityParser,
+          new ServerConnectionStats(metricsRepository, "server_connection_stats"),
+          serverConfig.getRouterPrincipalName());
+    } else {
+      this.serverConnectionStatsHandler = null;
+    }
   }
 
   /*
@@ -175,11 +182,10 @@ public class HttpChannelInitializer extends ChannelInitializer<SocketChannel> {
       }
       sslInitializer.setIdentityParser(identityParser::parseIdentityFromCert);
       ch.pipeline().addLast(sslInitializer);
+      ch.pipeline().addLast(serverConnectionStatsHandler);
     }
+
     ChannelPipelineConsumer httpPipelineInitializer = (pipeline, whetherNeedServerCodec) -> {
-      ServerConnectionStatsHandler serverConnectionStatsHandler =
-          new ServerConnectionStatsHandler(serverConnectionStats, serverConfig.getRouterPrincipalName());
-      pipeline.addLast(serverConnectionStatsHandler);
       StatsHandler statsHandler = new StatsHandler(singleGetStats, multiGetStats, computeStats);
       pipeline.addLast(statsHandler);
       if (whetherNeedServerCodec) {

--- a/services/venice-server/src/main/java/com/linkedin/venice/listener/ServerConnectionStatsHandler.java
+++ b/services/venice-server/src/main/java/com/linkedin/venice/listener/ServerConnectionStatsHandler.java
@@ -1,74 +1,147 @@
 package com.linkedin.venice.listener;
 
+import com.linkedin.venice.authorization.IdentityParser;
 import com.linkedin.venice.stats.ServerConnectionStats;
-import com.linkedin.venice.utils.SslUtils;
+import com.linkedin.venice.utils.DaemonThreadFactory;
+import io.netty.channel.ChannelHandler;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandlerAdapter;
 import io.netty.handler.ssl.SslHandler;
 import io.netty.util.Attribute;
 import io.netty.util.AttributeKey;
+import java.security.cert.Certificate;
 import java.security.cert.X509Certificate;
-import javax.net.ssl.SSLPeerUnverifiedException;
+import java.util.Comparator;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.concurrent.ConcurrentSkipListSet;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import javax.net.ssl.SSLSession;
+import javax.security.auth.x500.X500Principal;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 
+@ChannelHandler.Sharable
 public class ServerConnectionStatsHandler extends ChannelInboundHandlerAdapter {
+  private static final Logger LOGGER = LogManager.getLogger(ServerConnectionStatsHandler.class);
   public static final AttributeKey<Boolean> CHANNEL_ACTIVATED = AttributeKey.valueOf("channelActivated");
+  private final IdentityParser identityParser;
   private final ServerConnectionStats serverConnectionStats;
   private final String routerPrincipalName;
 
-  public ServerConnectionStatsHandler(ServerConnectionStats serverConnectionStats, String routerPrincipalName) {
+  private final Set<ChannelHandlerContext> newConnections =
+      new ConcurrentSkipListSet<>(Comparator.comparingInt(Object::hashCode));
+  private final Set<ChannelHandlerContext> trackedConnections =
+      new ConcurrentSkipListSet<>(Comparator.comparingInt(Object::hashCode));
+
+  private final ScheduledExecutorService connectionScanner =
+      Executors.newSingleThreadScheduledExecutor(new DaemonThreadFactory("ServerConnectionStatsHandler-Scanner"));
+
+  public ServerConnectionStatsHandler(
+      IdentityParser identityParser,
+      ServerConnectionStats serverConnectionStats,
+      String routerPrincipalName) {
+    this.identityParser = identityParser;
     this.serverConnectionStats = serverConnectionStats;
     this.routerPrincipalName = routerPrincipalName;
+
+    connectionScanner.scheduleAtFixedRate(() -> {
+      try {
+        if (newConnections.isEmpty()) {
+          return;
+        }
+        Set<ChannelHandlerContext> newConnectionsCopy = new HashSet<>(newConnections);
+        for (ChannelHandlerContext ctx: newConnectionsCopy) {
+          SslHandler sslHandler = extractSslHandler(ctx);
+          if (sslHandler == null) {
+            /**
+             * ssl handler is not available yet, which means the ssl handshake is still in progress, so
+             * we will track it in next iteration.
+             */
+            continue;
+          }
+          String principalName = getPrincipal(sslHandler);
+          if (principalName == null) {
+            /**
+             * principal name is not available yet, which means the ssl handshake is still in progress, so
+             * we will track it in next iteration.
+             */
+            continue;
+          }
+          if (principalName.contains(routerPrincipalName)) {
+            serverConnectionStats.incrementRouterConnectionCount();
+          } else {
+            serverConnectionStats.incrementClientConnectionCount();
+          }
+          trackedConnections.add(ctx);
+          newConnections.remove(ctx);
+          Attribute<Boolean> activated = ctx.channel().attr(CHANNEL_ACTIVATED);
+          activated.set(true);
+        }
+      } catch (Exception e) {
+        LOGGER.error("Got exception when scanning new connections", e);
+      }
+    }, 0, 1, java.util.concurrent.TimeUnit.SECONDS);
   }
 
   @Override
   public void channelActive(ChannelHandlerContext ctx) throws Exception {
-    Attribute<Boolean> activated = ctx.channel().attr(CHANNEL_ACTIVATED);
-    if (activated.get() != null && activated.get()) {
-      return;
-    }
-    activated.set(true);
-    SslHandler sslHandler = extractSslHandler(ctx);
-    if (sslHandler == null) {
-      // No ssl enabled, record all connections as client connections
-      serverConnectionStats.incrementClientConnectionCount();
-      return;
-    }
-    String principalName = getPrincipal(sslHandler);
-    if (principalName != null && principalName.contains(routerPrincipalName)) {
-      serverConnectionStats.incrementRouterConnectionCount();
-    } else {
-      serverConnectionStats.incrementClientConnectionCount();
-    }
+    newConnections.add(ctx);
+    super.channelActive(ctx);
   }
 
   @Override
   public void channelInactive(ChannelHandlerContext ctx) throws Exception {
     Attribute<Boolean> activated = ctx.channel().attr(CHANNEL_ACTIVATED);
-    if (activated.get() == null || !activated.get()) {
-      return;
+    if (activated.get() != null && activated.get()) {
+      activated.set(false);
+      SslHandler sslHandler = extractSslHandler(ctx);
+      if (sslHandler == null) {
+        LOGGER.error("Failed to extract ssl handler in function: channelInactive");
+      } else {
+        String principalName = getPrincipal(sslHandler);
+        if (principalName == null) {
+          LOGGER.error("Failed to extract principal name from ssl handler in function: channelInactive");
+        } else if (principalName.contains(routerPrincipalName)) {
+          serverConnectionStats.decrementRouterConnectionCount();
+        } else {
+          serverConnectionStats.decrementClientConnectionCount();
+        }
+      }
     }
-    activated.set(false);
-    SslHandler sslHandler = extractSslHandler(ctx);
-    if (sslHandler == null) {
-      // No ssl enabled, record all connections as client connections
-      serverConnectionStats.decrementClientConnectionCount();
-      return;
-    }
-    String principalName = getPrincipal(sslHandler);
-    if (principalName != null && principalName.contains(routerPrincipalName)) {
-      serverConnectionStats.decrementRouterConnectionCount();
-    } else {
-      serverConnectionStats.decrementClientConnectionCount();
-    }
+
+    newConnections.remove(ctx);
+    trackedConnections.remove(ctx);
+    super.channelInactive(ctx);
   }
 
   protected SslHandler extractSslHandler(ChannelHandlerContext ctx) {
     return ServerHandlerUtils.extractSslHandler(ctx);
   }
 
-  private String getPrincipal(SslHandler sslHandler) throws SSLPeerUnverifiedException {
-    X509Certificate clientCert = SslUtils.getX509Certificate(sslHandler.engine().getSession().getPeerCertificates()[0]);
-    return clientCert.getSubjectX500Principal().getName();
+  private String getPrincipal(SslHandler sslHandler) {
+    try {
+      SSLSession session = sslHandler.engine().getSession();
+      String remoteCN = null;
+      for (Certificate cert: session.getPeerCertificates()) {
+        if (cert instanceof X509Certificate) {
+          if (identityParser != null) {
+            remoteCN = identityParser.parseIdentityFromCert((X509Certificate) cert);
+            break;
+          } else {
+            X500Principal cn = ((X509Certificate) cert).getSubjectX500Principal();
+            if (cn != null) {
+              remoteCN = cn.getName();
+              break;
+            }
+          }
+        }
+      }
+      return remoteCN;
+    } catch (Exception e) {
+      return null;
+    }
   }
 }

--- a/services/venice-server/src/main/java/com/linkedin/venice/listener/ServerConnectionStatsHandler.java
+++ b/services/venice-server/src/main/java/com/linkedin/venice/listener/ServerConnectionStatsHandler.java
@@ -89,6 +89,11 @@ public class ServerConnectionStatsHandler extends ChannelInboundHandlerAdapter {
   @Override
   public void channelActive(ChannelHandlerContext ctx) throws Exception {
     newConnections.add(ctx);
+    /**
+     * The reason to record connection request here is that we want to record all the connection requests,
+     * regardless of whether Server is able to extract a valid cert or not later on.
+     */
+    serverConnectionStats.newConnectionRequest();
     super.channelActive(ctx);
   }
 

--- a/services/venice-server/src/main/java/com/linkedin/venice/stats/ServerConnectionStats.java
+++ b/services/venice-server/src/main/java/com/linkedin/venice/stats/ServerConnectionStats.java
@@ -15,6 +15,7 @@ public class ServerConnectionStats extends AbstractVeniceStats {
 
   private final Sensor routerConnectionRequestSensor;
   private final Sensor clientConnectionRequestSensor;
+  private final Sensor connectionRequestSensor;
 
   private final AtomicLong routerConnectionCount = new AtomicLong();
   private final AtomicLong clientConnectionCount = new AtomicLong();
@@ -27,6 +28,7 @@ public class ServerConnectionStats extends AbstractVeniceStats {
     registerSensorIfAbsent(
         new AsyncGauge((ignored, ignored2) -> clientConnectionCount.get(), CLIENT_CONNECTION_COUNT_GAUGE));
     clientConnectionRequestSensor = registerSensorIfAbsent(CLIENT_CONNECTION_REQUEST, new OccurrenceRate());
+    connectionRequestSensor = registerSensorIfAbsent("connection_request", new OccurrenceRate());
   }
 
   public void incrementRouterConnectionCount() {
@@ -45,5 +47,9 @@ public class ServerConnectionStats extends AbstractVeniceStats {
 
   public void decrementClientConnectionCount() {
     clientConnectionCount.decrementAndGet();
+  }
+
+  public void newConnectionRequest() {
+    connectionRequestSensor.record();
   }
 }

--- a/services/venice-server/src/test/java/com/linkedin/venice/listener/ServerConnectionStatsHandlerTest.java
+++ b/services/venice-server/src/test/java/com/linkedin/venice/listener/ServerConnectionStatsHandlerTest.java
@@ -55,6 +55,7 @@ public class ServerConnectionStatsHandlerTest {
     verify(serverConnectionStats, never()).decrementClientConnectionCount();
     verify(serverConnectionStats, never()).incrementRouterConnectionCount();
     verify(serverConnectionStats, never()).decrementRouterConnectionCount();
+    verify(serverConnectionStats, times(1)).newConnectionRequest();
   }
 
   @Test
@@ -94,5 +95,6 @@ public class ServerConnectionStatsHandlerTest {
     verify(serverConnectionStats, timeout(3000).times(1)).incrementRouterConnectionCount();
     verify(serverConnectionStats, times(1)).decrementRouterConnectionCount();
     verify(serverConnectionStats, times(1)).decrementClientConnectionCount();
+    verify(serverConnectionStats, times(2)).newConnectionRequest();
   }
 }


### PR DESCRIPTION
The previous connection tracking is not working properly because of two reasons:
1. `ServerConnectionStatsHandler` is being executed in the sub-channel, which is measuring the QPS rather than the new connection rate.
2. The way to extract the identity from cert is not right, so router connectin count is always 0.

To fix the above issues, this PR:
1. Move `ServerConnectionStatsHandler` up to be executed in the parent channel.
2. Use the correct identity parser to extract the application name from the cert, so that it can differentiate Router connections from Fast Client.
3. In function: `channelActive`, we can't extract `SslHandler` as SSL hasn't kicked in yet when the connection is established, so this PR introduces an async way to track new connections util the SSL handshake is fully done.

This PR also adds a new metric: `connection_request` to track the new connection rate in case the above async tracking would miss some connections, such as connection doesn't have a valid cert.
<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->


<!--
Describe
- What changes to make and why you are making these changes.
- How are you going to achieve your goal.
- Describe what testings you have done, for example, performance testing etc.

If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->



## How was this PR tested?
CI
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.