### PR TITLE
[admin-tool][controller] Add new config into ZK and allow admin-tool to update the config

### DIFF
--- a/clients/venice-admin-tool/src/main/java/com/linkedin/venice/AdminTool.java
+++ b/clients/venice-admin-tool/src/main/java/com/linkedin/venice/AdminTool.java
@@ -597,6 +597,9 @@ public class AdminTool {
         case CLUSTER_BATCH_TASK:
           clusterBatchTask(cmd);
           break;
+        case UPDATE_ADMIN_OPERATION_PROTOCOL_VERSION:
+          updateAdminOperationProtocolVersion(cmd);
+          break;
         default:
           StringJoiner availableCommands = new StringJoiner(", ");
           for (Command c: Command.values()) {
@@ -3268,6 +3271,16 @@ public class AdminTool {
     } finally {
       Utils.closeQuietlyWithErrorLogged(transportClient);
     }
+  }
+
+  private static void updateAdminOperationProtocolVersion(CommandLine cmd) throws Exception {
+    String clusterName = getRequiredArgument(cmd, Arg.CLUSTER, Command.UPDATE_ADMIN_OPERATION_PROTOCOL_VERSION);
+    String protocolVersionInString =
+        getRequiredArgument(cmd, Arg.ADMIN_OPERATION_PROTOCOL_VERSION, Command.UPDATE_ADMIN_OPERATION_PROTOCOL_VERSION);
+    long protocolVersion =
+        Utils.parseLongFromString(protocolVersionInString, Arg.ADMIN_OPERATION_PROTOCOL_VERSION.name());
+    ControllerResponse response = controllerClient.updateAdminOperationProtocolVersion(clusterName, protocolVersion);
+    printObject(response);
   }
 
   private static void migrateVeniceZKPaths(CommandLine cmd) throws Exception {

--- a/clients/venice-admin-tool/src/main/java/com/linkedin/venice/Arg.java
+++ b/clients/venice-admin-tool/src/main/java/com/linkedin/venice/Arg.java
@@ -297,7 +297,10 @@ public enum Arg {
   ),
   DAVINCI_HEARTBEAT_REPORTED(
       "dvc-heartbeat-reported", "dvchb", true, "Flag to indicate whether DVC is bootstrapping and sending heartbeats"
-  ), ENABLE_STORE_MIGRATION("enable-store-migration", "esm", true, "Toggle store migration store config");
+  ), ENABLE_STORE_MIGRATION("enable-store-migration", "esm", true, "Toggle store migration store config"),
+  ADMIN_OPERATION_PROTOCOL_VERSION(
+      "admin-operation-protocol-version", "aopv", true, "Admin operation protocol version"
+  );
 
   private final String argName;
   private final String first;

--- a/clients/venice-admin-tool/src/main/java/com/linkedin/venice/Command.java
+++ b/clients/venice-admin-tool/src/main/java/com/linkedin/venice/Command.java
@@ -3,6 +3,7 @@ package com.linkedin.venice;
 import static com.linkedin.venice.Arg.ACCESS_CONTROL;
 import static com.linkedin.venice.Arg.ACL_PERMS;
 import static com.linkedin.venice.Arg.ACTIVE_ACTIVE_REPLICATION_ENABLED;
+import static com.linkedin.venice.Arg.ADMIN_OPERATION_PROTOCOL_VERSION;
 import static com.linkedin.venice.Arg.ALLOW_STORE_MIGRATION;
 import static com.linkedin.venice.Arg.AUTO_SCHEMA_REGISTER_FOR_PUSHJOB_ENABLED;
 import static com.linkedin.venice.Arg.BACKUP_FOLDER;
@@ -582,6 +583,10 @@ public enum Command {
       "dump-host-heartbeat",
       "Dump all heartbeat belong to a certain storage node. You can use topic/partition to filter specific resource, and you can choose to filter resources that are lagging.",
       new Arg[] { SERVER_URL, KAFKA_TOPIC_NAME }, new Arg[] { PARTITION, LAG_FILTER_ENABLED }
+  ),
+  UPDATE_ADMIN_OPERATION_PROTOCOL_VERSION(
+      "update-admin-operation-protocol-version", "Update the admin operation protocol version",
+      new Arg[] { URL, CLUSTER, ADMIN_OPERATION_PROTOCOL_VERSION }
   );
 
   private final String commandName;

--- a/clients/venice-admin-tool/src/test/java/com/linkedin/venice/TestAdminTool.java
+++ b/clients/venice-admin-tool/src/test/java/com/linkedin/venice/TestAdminTool.java
@@ -414,14 +414,9 @@ public class TestAdminTool {
   }
 
   @Test
-  public void testUpdateAdminOperationProtocolVersion() throws ParseException, IOException {
+  public void testUpdateAdminOperationProtocolVersionWithInvalidInput() {
     String[] args = { "--update-admin-operation-protocol-version", "--url", "http://localhost:7036", "--cluster",
-        "test-cluster", "--admin-operation-protocol-version", "1" };
-
-    try {
-      AdminTool.main(args);
-    } catch (Exception e) {
-      Assert.fail("AdminTool should allow admin topic metadata to be updated admin operation version", e);
-    }
+        "test-cluster", "--admin-operation-protocol-version", "many" };
+    Assert.assertThrows(VeniceException.class, () -> AdminTool.main(args));
   }
 }

--- a/clients/venice-admin-tool/src/test/java/com/linkedin/venice/TestAdminTool.java
+++ b/clients/venice-admin-tool/src/test/java/com/linkedin/venice/TestAdminTool.java
@@ -416,7 +416,7 @@ public class TestAdminTool {
   @Test
   public void testUpdateAdminOperationProtocolVersionWithInvalidInput() {
     String[] args = { "--update-admin-operation-protocol-version", "--url", "http://localhost:7036", "--cluster",
-        "test-cluster", "--admin-operation-protocol-version", "many" };
+        "test-cluster", "--admin-operation-protocol-version", "thisShouldBeLongValue" };
     Assert.assertThrows(VeniceException.class, () -> AdminTool.main(args));
   }
 }

--- a/clients/venice-admin-tool/src/test/java/com/linkedin/venice/TestAdminTool.java
+++ b/clients/venice-admin-tool/src/test/java/com/linkedin/venice/TestAdminTool.java
@@ -412,4 +412,16 @@ public class TestAdminTool {
     CommandLine finalCommandLine = commandLine;
     Assert.assertThrows(() -> AdminTool.getConfigureStoreViewQueryParams(finalCommandLine));
   }
+
+  @Test
+  public void testUpdateAdminOperationProtocolVersion() throws ParseException, IOException {
+    String[] args = { "--update-admin-operation-protocol-version", "--url", "http://localhost:7036", "--cluster",
+        "test-cluster", "--admin-operation-protocol-version", "1" };
+
+    try {
+      AdminTool.main(args);
+    } catch (Exception e) {
+      Assert.fail("AdminTool should allow admin topic metadata to be updated admin operation version", e);
+    }
+  }
 }

--- a/internal/venice-common/src/main/java/com/linkedin/venice/controllerapi/AdminTopicMetadataResponse.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/controllerapi/AdminTopicMetadataResponse.java
@@ -18,6 +18,11 @@ public class AdminTopicMetadataResponse extends ControllerResponse {
    */
   private long upstreamOffset = -1;
 
+  /**
+   * The current admin operation protocol version, which is cluster-level and be SOT for serialize/deserialize admin operation message
+   */
+  private long adminOperationProtocolVersion = -1;
+
   public long getExecutionId() {
     return executionId;
   }
@@ -40,5 +45,13 @@ public class AdminTopicMetadataResponse extends ControllerResponse {
 
   public void setUpstreamOffset(long upstreamOffset) {
     this.upstreamOffset = upstreamOffset;
+  }
+
+  public void setAdminOperationProtocolVersion(long adminOperationProtocolVersion) {
+    this.adminOperationProtocolVersion = adminOperationProtocolVersion;
+  }
+
+  public Long getAdminOperationProtocolVersion() {
+    return adminOperationProtocolVersion;
   }
 }

--- a/internal/venice-common/src/main/java/com/linkedin/venice/controllerapi/AdminTopicMetadataResponse.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/controllerapi/AdminTopicMetadataResponse.java
@@ -51,7 +51,7 @@ public class AdminTopicMetadataResponse extends ControllerResponse {
     this.adminOperationProtocolVersion = adminOperationProtocolVersion;
   }
 
-  public Long getAdminOperationProtocolVersion() {
+  public long getAdminOperationProtocolVersion() {
     return adminOperationProtocolVersion;
   }
 }

--- a/internal/venice-common/src/main/java/com/linkedin/venice/controllerapi/ControllerApiConstants.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/controllerapi/ControllerApiConstants.java
@@ -225,6 +225,7 @@ public class ControllerApiConstants {
   public static final String KAFKA_TOPIC_RETENTION_IN_MS = "kafka.topic.retention.in.ms";
   public static final String KAFKA_TOPIC_MIN_IN_SYNC_REPLICA = "kafka.topic.min.in.sync.replica";
   public static final String UPSTREAM_OFFSET = "upstream_offset";
+  public static final String ADMIN_OPERATION_PROTOCOL_VERSION = "admin_operation_protocol_version";
 
   public static final String PERSONA_NAME = "persona_name";
   public static final String PERSONA_OWNERS = "persona_owners";

--- a/internal/venice-common/src/main/java/com/linkedin/venice/controllerapi/ControllerClient.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/controllerapi/ControllerClient.java
@@ -1,6 +1,7 @@
 package com.linkedin.venice.controllerapi;
 
 import static com.linkedin.venice.controllerapi.ControllerApiConstants.ACCESS_PERMISSION;
+import static com.linkedin.venice.controllerapi.ControllerApiConstants.ADMIN_OPERATION_PROTOCOL_VERSION;
 import static com.linkedin.venice.controllerapi.ControllerApiConstants.AMPLIFICATION_FACTOR;
 import static com.linkedin.venice.controllerapi.ControllerApiConstants.BATCH_JOB_HEARTBEAT_ENABLED;
 import static com.linkedin.venice.controllerapi.ControllerApiConstants.CLUSTER;
@@ -1360,6 +1361,14 @@ public class ControllerClient implements Closeable {
         .add(OFFSET, offset)
         .add(UPSTREAM_OFFSET, upstreamOffset);
     return request(ControllerRoute.UPDATE_ADMIN_TOPIC_METADATA, params, ControllerResponse.class);
+  }
+
+  public ControllerResponse updateAdminOperationProtocolVersion(
+      String clusterName,
+      Long adminOperationProtocolVersion) {
+    QueryParams params =
+        newParams().add(CLUSTER, clusterName).add(ADMIN_OPERATION_PROTOCOL_VERSION, adminOperationProtocolVersion);
+    return request(ControllerRoute.UPDATE_ADMIN_OPERATION_PROTOCOL_VERSION, params, ControllerResponse.class);
   }
 
   public ControllerResponse deleteKafkaTopic(String topicName) {

--- a/internal/venice-common/src/main/java/com/linkedin/venice/controllerapi/ControllerRoute.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/controllerapi/ControllerRoute.java
@@ -2,6 +2,7 @@ package com.linkedin.venice.controllerapi;
 
 import static com.linkedin.venice.controllerapi.ControllerApiConstants.ACCESS_CONTROLLED;
 import static com.linkedin.venice.controllerapi.ControllerApiConstants.ACCESS_PERMISSION;
+import static com.linkedin.venice.controllerapi.ControllerApiConstants.ADMIN_OPERATION_PROTOCOL_VERSION;
 import static com.linkedin.venice.controllerapi.ControllerApiConstants.AMPLIFICATION_FACTOR;
 import static com.linkedin.venice.controllerapi.ControllerApiConstants.AUTO_SCHEMA_REGISTER_FOR_PUSHJOB_ENABLED;
 import static com.linkedin.venice.controllerapi.ControllerApiConstants.BACKUP_STRATEGY;
@@ -284,6 +285,10 @@ public enum ControllerRoute {
   UPDATE_ADMIN_TOPIC_METADATA(
       "/update_admin_topic_metadata", HttpMethod.POST, Arrays.asList(CLUSTER, EXECUTION_ID), NAME, OFFSET,
       UPSTREAM_OFFSET
+  ),
+  UPDATE_ADMIN_OPERATION_PROTOCOL_VERSION(
+      "/update_admin_operation_protocol_version", HttpMethod.POST,
+      Arrays.asList(CLUSTER, ADMIN_OPERATION_PROTOCOL_VERSION)
   ), DELETE_KAFKA_TOPIC("/delete_kafka_topic", HttpMethod.POST, Arrays.asList(CLUSTER, TOPIC)),
 
   CREATE_STORAGE_PERSONA(

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/controller/TestAdminToolEndToEnd.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/controller/TestAdminToolEndToEnd.java
@@ -9,9 +9,11 @@ import com.linkedin.venice.AdminTool;
 import com.linkedin.venice.Arg;
 import com.linkedin.venice.controllerapi.AdminTopicMetadataResponse;
 import com.linkedin.venice.controllerapi.ControllerClient;
+import com.linkedin.venice.controllerapi.ControllerResponse;
 import com.linkedin.venice.controllerapi.MultiStoreResponse;
 import com.linkedin.venice.controllerapi.NewStoreResponse;
 import com.linkedin.venice.controllerapi.StoreResponse;
+import com.linkedin.venice.controllerapi.UpdateStoreQueryParams;
 import com.linkedin.venice.controllerapi.VersionCreationResponse;
 import com.linkedin.venice.exceptions.VeniceException;
 import com.linkedin.venice.helix.HelixAdapterSerializer;
@@ -194,8 +196,9 @@ public class TestAdminToolEndToEnd {
 
   @Test(timeOut = 4 * TEST_TIMEOUT)
   public void testUpdateAdminOperationVersion() throws Exception {
-    Long currentVersion = -1L;
+    Long defaultVersion = -1L;
     Long newVersion = 80L;
+    String storeName = Utils.getUniqueString("test-store");
     try (VeniceTwoLayerMultiRegionMultiClusterWrapper venice =
         ServiceFactory.getVeniceTwoLayerMultiRegionMultiClusterWrapper(
             new VeniceMultiRegionClusterCreateOptions.Builder().numberOfRegions(1)
@@ -209,24 +212,57 @@ public class TestAdminToolEndToEnd {
       String clusterName = venice.getClusterNames()[0];
 
       // Get the parent con†roller
-      VeniceControllerWrapper controller = venice.getParentControllers().get(0);
-      ControllerClient controllerClient = new ControllerClient(clusterName, controller.getControllerUrl());
+      VeniceControllerWrapper parentController = venice.getParentControllers().get(0);
+      ControllerClient parentControllerClient = new ControllerClient(clusterName, parentController.getControllerUrl());
 
-      // Setup the original metadata
-      AdminTopicMetadataResponse originalMetadata = controllerClient.getAdminTopicMetadata(Optional.empty());
-      Assert.assertEquals(originalMetadata.getAdminOperationProtocolVersion(), (long) currentVersion);
+      // Verify the original metadata - default value
+      AdminTopicMetadataResponse originalMetadata = parentControllerClient.getAdminTopicMetadata(Optional.empty());
+      Assert.assertEquals(originalMetadata.getAdminOperationProtocolVersion(), (long) defaultVersion);
+      Assert.assertEquals(originalMetadata.getExecutionId(), (long) defaultVersion);
+      Assert.assertEquals(originalMetadata.getOffset(), (long) defaultVersion);
+      Assert.assertEquals(originalMetadata.getUpstreamOffset(), (long) defaultVersion);
+
+      // Create store
+      NewStoreResponse newStoreResponse =
+          parentControllerClient.createNewStore(storeName, "test", "\"string\"", "\"string\"");
+      Assert.assertFalse(newStoreResponse.isError());
+      VersionCreationResponse versionCreationResponse =
+          parentControllerClient.emptyPush(storeName, Utils.getUniqueString("empty-push-1"), 1L);
+      Assert.assertFalse(versionCreationResponse.isError());
+
+      // Update store config
+      ControllerResponse updateStore =
+          parentControllerClient.updateStore(storeName, new UpdateStoreQueryParams().setBatchGetLimit(100));
+      Assert.assertFalse(updateStore.isError());
+
+      // Check the baseline metadata
+      AdminTopicMetadataResponse metdataAfterStoreCreation =
+          parentControllerClient.getAdminTopicMetadata(Optional.empty());
+      long baselineExecutionId = metdataAfterStoreCreation.getExecutionId();
+      long baselineOffset = metdataAfterStoreCreation.getOffset();
+      long baselineUpstreamOffset = metdataAfterStoreCreation.getUpstreamOffset();
+      long baselineAdminVersion = metdataAfterStoreCreation.getAdminOperationProtocolVersion();
+
+      // Execution id and offset should be positive now since we have created a store and updated the store config
+      Assert.assertEquals(baselineAdminVersion, (long) defaultVersion);
+      Assert.assertTrue(baselineExecutionId > 0);
+      Assert.assertTrue(baselineOffset > 0);
+      Assert.assertEquals(baselineUpstreamOffset, (long) defaultVersion);
 
       // Update the admin operation version to newVersion - 80
       String[] updateAdminOperationVersionArgs =
-          { "--update-admin-operation-protocol-version", "--url", controller.getControllerUrl(), "--cluster",
+          { "--update-admin-operation-protocol-version", "--url", parentController.getControllerUrl(), "--cluster",
               clusterName, "--admin-operation-protocol-version", newVersion.toString() };
 
       AdminTool.main(updateAdminOperationVersionArgs);
 
-      // Verify the admin operation metadata version is updated
+      // Verify the admin operation metadata version is updated and the remaining data is unchanged
       TestUtils.waitForNonDeterministicAssertion(30, TimeUnit.SECONDS, () -> {
-        AdminTopicMetadataResponse updatedMetadata = controllerClient.getAdminTopicMetadata(Optional.empty());
+        AdminTopicMetadataResponse updatedMetadata = parentControllerClient.getAdminTopicMetadata(Optional.empty());
         Assert.assertEquals(updatedMetadata.getAdminOperationProtocolVersion(), (long) newVersion);
+        Assert.assertEquals(updatedMetadata.getExecutionId(), baselineExecutionId);
+        Assert.assertEquals(updatedMetadata.getOffset(), baselineOffset);
+        Assert.assertEquals(updatedMetadata.getUpstreamOffset(), baselineUpstreamOffset);
       });
     }
   }

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/controller/TestAdminToolEndToEnd.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/controller/TestAdminToolEndToEnd.java
@@ -214,7 +214,7 @@ public class TestAdminToolEndToEnd {
 
       // Setup the original metadata
       AdminTopicMetadataResponse originalMetadata = controllerClient.getAdminTopicMetadata(Optional.empty());
-      Assert.assertEquals(originalMetadata.getAdminOperationProtocolVersion(), currentVersion);
+      Assert.assertEquals(originalMetadata.getAdminOperationProtocolVersion(), (long) currentVersion);
 
       // Update the admin operation version to newVersion - 80
       String[] updateAdminOperationVersionArgs =
@@ -226,7 +226,7 @@ public class TestAdminToolEndToEnd {
       // Verify the admin operation metadata version is updated
       TestUtils.waitForNonDeterministicAssertion(30, TimeUnit.SECONDS, () -> {
         AdminTopicMetadataResponse updatedMetadata = controllerClient.getAdminTopicMetadata(Optional.empty());
-        Assert.assertEquals(updatedMetadata.getAdminOperationProtocolVersion(), newVersion);
+        Assert.assertEquals(updatedMetadata.getAdminOperationProtocolVersion(), (long) newVersion);
       });
     }
   }

--- a/internal/venice-test-common/src/main/java/com/linkedin/venice/admin/InMemoryAdminTopicMetadataAccessor.java
+++ b/internal/venice-test-common/src/main/java/com/linkedin/venice/admin/InMemoryAdminTopicMetadataAccessor.java
@@ -16,7 +16,7 @@ public class InMemoryAdminTopicMetadataAccessor extends AdminTopicMetadataAccess
 
   @Override
   public void updateMetadata(String clusterName, Map<String, Long> metadata) {
-    inMemoryMetadata = metadata;
+    inMemoryMetadata.putAll(metadata);
     LOGGER.info("Persisted admin topic metadata map for cluster: {}, map: {}", clusterName, metadata);
   }
 

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/Admin.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/Admin.java
@@ -953,6 +953,8 @@ public interface Admin extends AutoCloseable, Closeable {
       Optional<Long> offset,
       Optional<Long> upstreamOffset);
 
+  void updateAdminOperationProtocolVersion(String clusterName, Long adminOperationProtocolVersion);
+
   void createStoragePersona(
       String clusterName,
       String name,

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/AdminTopicMetadataAccessor.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/AdminTopicMetadataAccessor.java
@@ -36,26 +36,6 @@ public abstract class AdminTopicMetadataAccessor {
     return metadata;
   }
 
-  public static Map<String, Long> generateMetadataMap(long localOffset, long upstreamOffset, long executionId) {
-    return generateMetadataMap(
-        Optional.of(localOffset),
-        Optional.of(upstreamOffset),
-        Optional.of(executionId),
-        Optional.empty());
-  }
-
-  public static Map<String, Long> generateMetadataMap(
-      long localOffset,
-      long upstreamOffset,
-      long executionId,
-      long adminOperationProtocolVersion) {
-    return generateMetadataMap(
-        Optional.of(localOffset),
-        Optional.of(upstreamOffset),
-        Optional.of(executionId),
-        Optional.of(adminOperationProtocolVersion));
-  }
-
   /**
    * @return a pair of values to which the specified keys are mapped to {@linkplain AdminTopicMetadataAccessor#OFFSET_KEY}
    * and {@linkplain AdminTopicMetadataAccessor#UPSTREAM_OFFSET_KEY}.

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/AdminTopicMetadataAccessor.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/AdminTopicMetadataAccessor.java
@@ -20,7 +20,8 @@ public abstract class AdminTopicMetadataAccessor {
 
   /**
    * @return a map with {@linkplain AdminTopicMetadataAccessor#OFFSET_KEY}, {@linkplain AdminTopicMetadataAccessor#UPSTREAM_OFFSET_KEY},
-   *         {@linkplain AdminTopicMetadataAccessor#EXECUTION_ID_KEY}, {@linkplain AdminTopicMetadataAccessor#ADMIN_OPERATION_PROTOCOL_VERSION_KEY} specified to input values.
+   *         {@linkplain AdminTopicMetadataAccessor#EXECUTION_ID_KEY}, {@linkplain AdminTopicMetadataAccessor#ADMIN_OPERATION_PROTOCOL_VERSION_KEY}
+   *         specified to input values.
    */
   public static Map<String, Long> generateMetadataMap(
       Optional<Long> localOffset,
@@ -72,12 +73,15 @@ public abstract class AdminTopicMetadataAccessor {
     return metadata.getOrDefault(EXECUTION_ID_KEY, UNDEFINED_VALUE);
   }
 
+  /**
+   * @return the value to which the specified key is mapped to {@linkplain AdminTopicMetadataAccessor#ADMIN_OPERATION_PROTOCOL_VERSION_KEY}.
+   */
   public static long getAdminOperationProtocolVersion(Map<String, Long> metadata) {
     return metadata.getOrDefault(ADMIN_OPERATION_PROTOCOL_VERSION_KEY, UNDEFINED_VALUE);
   }
 
   /**
-   * Update all relevant metadata for a given cluster in a single transaction.
+   * Update all relevant metadata for a given cluster in a single transaction with information provided in metadata.
    * @param clusterName of the cluster at interest.
    * @param metadata map containing relevant information.
    */

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/AdminTopicMetadataAccessor.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/AdminTopicMetadataAccessor.java
@@ -81,7 +81,7 @@ public abstract class AdminTopicMetadataAccessor {
   }
 
   /**
-   * Update all relevant metadata for a given cluster in a single transaction with information provided in metadata.
+   * Update specific metadata for a given cluster in a single transaction with information provided in metadata.
    * @param clusterName of the cluster at interest.
    * @param metadata map containing relevant information.
    */

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/AdminTopicMetadataAccessor.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/AdminTopicMetadataAccessor.java
@@ -3,6 +3,7 @@ package com.linkedin.venice.controller;
 import com.linkedin.venice.utils.Pair;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Optional;
 
 
 public abstract class AdminTopicMetadataAccessor {
@@ -14,18 +15,44 @@ public abstract class AdminTopicMetadataAccessor {
    */
   private static final String UPSTREAM_OFFSET_KEY = "upstreamOffset";
   private static final String EXECUTION_ID_KEY = "executionId";
+  private static final String ADMIN_OPERATION_PROTOCOL_VERSION_KEY = "adminOperationProtocolVersion";
   private static final long UNDEFINED_VALUE = -1;
 
   /**
    * @return a map with {@linkplain AdminTopicMetadataAccessor#OFFSET_KEY}, {@linkplain AdminTopicMetadataAccessor#UPSTREAM_OFFSET_KEY},
-   *         {@linkplain AdminTopicMetadataAccessor#EXECUTION_ID_KEY} specified to input values.
+   *         {@linkplain AdminTopicMetadataAccessor#EXECUTION_ID_KEY}, {@linkplain AdminTopicMetadataAccessor#ADMIN_OPERATION_PROTOCOL_VERSION_KEY} specified to input values.
    */
-  public static Map<String, Long> generateMetadataMap(long localOffset, long upstreamOffset, long executionId) {
+  public static Map<String, Long> generateMetadataMap(
+      Optional<Long> localOffset,
+      Optional<Long> upstreamOffset,
+      Optional<Long> executionId,
+      Optional<Long> adminOperationProtocolVersion) {
     Map<String, Long> metadata = new HashMap<>();
-    metadata.put(OFFSET_KEY, localOffset);
-    metadata.put(UPSTREAM_OFFSET_KEY, upstreamOffset);
-    metadata.put(EXECUTION_ID_KEY, executionId);
+    localOffset.ifPresent(offset -> metadata.put(OFFSET_KEY, offset));
+    upstreamOffset.ifPresent(offset -> metadata.put(UPSTREAM_OFFSET_KEY, offset));
+    executionId.ifPresent(id -> metadata.put(EXECUTION_ID_KEY, id));
+    adminOperationProtocolVersion.ifPresent(version -> metadata.put(ADMIN_OPERATION_PROTOCOL_VERSION_KEY, version));
     return metadata;
+  }
+
+  public static Map<String, Long> generateMetadataMap(long localOffset, long upstreamOffset, long executionId) {
+    return generateMetadataMap(
+        Optional.of(localOffset),
+        Optional.of(upstreamOffset),
+        Optional.of(executionId),
+        Optional.empty());
+  }
+
+  public static Map<String, Long> generateMetadataMap(
+      long localOffset,
+      long upstreamOffset,
+      long executionId,
+      long adminOperationProtocolVersion) {
+    return generateMetadataMap(
+        Optional.of(localOffset),
+        Optional.of(upstreamOffset),
+        Optional.of(executionId),
+        Optional.of(adminOperationProtocolVersion));
   }
 
   /**
@@ -43,6 +70,10 @@ public abstract class AdminTopicMetadataAccessor {
    */
   public static long getExecutionId(Map<String, Long> metadata) {
     return metadata.getOrDefault(EXECUTION_ID_KEY, UNDEFINED_VALUE);
+  }
+
+  public static long getAdminOperationProtocolVersion(Map<String, Long> metadata) {
+    return metadata.getOrDefault(ADMIN_OPERATION_PROTOCOL_VERSION_KEY, UNDEFINED_VALUE);
   }
 
   /**

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceHelixAdmin.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceHelixAdmin.java
@@ -7498,7 +7498,8 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
   }
 
   /**
-   * @return cluster-level execution id, offset and upstream offset. If store name is specified, it returns store-level execution id.
+   * @return cluster-level execution id, offset, upstream offset, and admin operation protocol version.
+   *        If store name is specified, it returns store-level execution id.
    */
   public Map<String, Long> getAdminTopicMetadata(String clusterName, Optional<String> storeName) {
     Map<String, Long> metadata = getAdminConsumerService(clusterName).getAdminTopicMetadata(clusterName);

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceHelixAdmin.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceHelixAdmin.java
@@ -7502,20 +7502,14 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
    *        If store name is specified, it returns store-level execution id.
    */
   public Map<String, Long> getAdminTopicMetadata(String clusterName, Optional<String> storeName) {
-    Map<String, Long> metadata = getAdminConsumerService(clusterName).getAdminTopicMetadata(clusterName);
-
     if (storeName.isPresent()) {
       Long executionId = getExecutionIdAccessor().getLastSucceededExecutionIdMap(clusterName).get(storeName.get());
-      Long adminOperationProtocolVersion = AdminTopicMetadataAccessor.getAdminOperationProtocolVersion(metadata);
       return executionId == null
           ? Collections.emptyMap()
-          : AdminTopicMetadataAccessor.generateMetadataMap(
-              Optional.of(-1L),
-              Optional.of(-1L),
-              Optional.of(executionId),
-              Optional.of(adminOperationProtocolVersion));
+          : AdminTopicMetadataAccessor
+              .generateMetadataMap(Optional.of(-1L), Optional.of(-1L), Optional.of(executionId), Optional.of(-1L));
     }
-    return metadata;
+    return getAdminConsumerService(clusterName).getAdminTopicMetadata(clusterName);
   }
 
   /**

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceHelixAdmin.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceHelixAdmin.java
@@ -7509,7 +7509,11 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
       Long adminOperationProtocolVersion = AdminTopicMetadataAccessor.getAdminOperationProtocolVersion(metadata);
       return executionId == null
           ? Collections.emptyMap()
-          : AdminTopicMetadataAccessor.generateMetadataMap(-1, -1, executionId, adminOperationProtocolVersion);
+          : AdminTopicMetadataAccessor.generateMetadataMap(
+              Optional.of(-1L),
+              Optional.of(-1L),
+              Optional.of(executionId),
+              Optional.of(adminOperationProtocolVersion));
     }
     return metadata;
   }

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceHelixAdmin.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceHelixAdmin.java
@@ -7681,6 +7681,7 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
     return this.getPubSubSSLPropertiesFromControllerConfig(pubSubBrokerAddress);
   }
 
+  // public for testing purpose
   public AdminConsumerService getAdminConsumerService(String clusterName) {
     return adminConsumerServices.get(clusterName);
   }

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceParentHelixAdmin.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceParentHelixAdmin.java
@@ -4268,11 +4268,11 @@ public class VeniceParentHelixAdmin implements Admin {
   }
 
   /**
-   * Unsupported operation in the parent controller.
+   * Get AdminTopicMetadata from parent controller
    */
   @Override
   public Map<String, Long> getAdminTopicMetadata(String clusterName, Optional<String> storeName) {
-    throw new VeniceUnsupportedOperationException("getAdminTopicMetadata");
+    return getVeniceHelixAdmin().getAdminTopicMetadata(clusterName, storeName);
   }
 
   /**
@@ -4286,6 +4286,14 @@ public class VeniceParentHelixAdmin implements Admin {
       Optional<Long> offset,
       Optional<Long> upstreamOffset) {
     throw new VeniceUnsupportedOperationException("updateAdminTopicMetadata");
+  }
+
+  /**
+   * Update AdminOperationProtocolVersion in metadata
+   */
+  @Override
+  public void updateAdminOperationProtocolVersion(String clusterName, Long adminOperationProtocolVersion) {
+    getVeniceHelixAdmin().updateAdminOperationProtocolVersion(clusterName, adminOperationProtocolVersion);
   }
 
   /**

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/ZkAdminTopicMetadataAccessor.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/ZkAdminTopicMetadataAccessor.java
@@ -42,6 +42,9 @@ public class ZkAdminTopicMetadataAccessor extends AdminTopicMetadataAccessor {
   public void updateMetadata(String clusterName, Map<String, Long> newMetadata) {
     String path = getAdminTopicMetadataNodePath(clusterName);
     HelixUtils.compareAndUpdate(zkMapAccessor, path, ZK_UPDATE_RETRY, currentMetadataMap -> {
+      if (currentMetadataMap == null) {
+        currentMetadataMap = new HashMap<>();
+      }
       currentMetadataMap.putAll(newMetadata);
       return currentMetadataMap;
     });

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/ZkAdminTopicMetadataAccessor.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/ZkAdminTopicMetadataAccessor.java
@@ -36,21 +36,25 @@ public class ZkAdminTopicMetadataAccessor extends AdminTopicMetadataAccessor {
   }
 
   /**
-   * Update the upstream metadata map for the given cluster with specific information provided in newMetadata
+   * Update the upstream metadata map for the given cluster with specific information provided in metadataDelta
    *
    * @see AdminTopicMetadataAccessor#updateMetadata(String, Map)
    */
   @Override
-  public void updateMetadata(String clusterName, Map<String, Long> newMetadata) {
+  public void updateMetadata(String clusterName, Map<String, Long> metadataDelta) {
     String path = getAdminTopicMetadataNodePath(clusterName);
     HelixUtils.compareAndUpdate(zkMapAccessor, path, ZK_UPDATE_RETRY, currentMetadataMap -> {
       if (currentMetadataMap == null) {
         currentMetadataMap = new HashMap<>();
       }
-      currentMetadataMap.putAll(newMetadata);
+      LOGGER.info(
+          "Updating AdminTopicMetadata map for cluster: {}. Current metadata: {}. New delta metadata: {}",
+          clusterName,
+          currentMetadataMap,
+          metadataDelta);
+      currentMetadataMap.putAll(metadataDelta);
       return currentMetadataMap;
     });
-    LOGGER.info("Persisted admin topic metadata map for cluster: {}, map: {}", clusterName, newMetadata);
   }
 
   /**

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/ZkAdminTopicMetadataAccessor.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/ZkAdminTopicMetadataAccessor.java
@@ -37,6 +37,8 @@ public class ZkAdminTopicMetadataAccessor extends AdminTopicMetadataAccessor {
 
   /**
    * Update the upstream metadata map for the given cluster with specific information provided in newMetadata
+   *
+   * @see AdminTopicMetadataAccessor#updateMetadata(String, Map)
    */
   @Override
   public void updateMetadata(String clusterName, Map<String, Long> newMetadata) {

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/kafka/consumer/AdminConsumerService.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/kafka/consumer/AdminConsumerService.java
@@ -188,11 +188,29 @@ public class AdminConsumerService extends AbstractVeniceService {
   public void updateAdminTopicMetadata(String clusterName, long executionId, long offset, long upstreamOffset) {
     if (clusterName.equals(config.getClusterName())) {
       Map<String, Long> metadata = AdminTopicMetadataAccessor.generateMetadataMap(offset, upstreamOffset, executionId);
-      adminTopicMetadataAccessor.updateMetadata(clusterName, metadata);
+      adminTopicMetadataAccessor.partialUpdateMetadata(clusterName, metadata);
     } else {
       throw new VeniceException(
           "This AdminConsumptionService is for cluster: " + config.getClusterName()
               + ".  Cannot get the last succeed execution Id for cluster: " + clusterName);
+    }
+  }
+
+  /**
+   * Update the admin operation protocol version for the given cluster.
+   */
+  public void updateAdminOperationProtocolVersion(String clusterName, long adminOperationProtocolVersion) {
+    if (clusterName.equals(config.getClusterName())) {
+      Map<String, Long> metadata = AdminTopicMetadataAccessor.generateMetadataMap(
+          Optional.empty(),
+          Optional.empty(),
+          Optional.empty(),
+          Optional.of(adminOperationProtocolVersion));
+      adminTopicMetadataAccessor.partialUpdateMetadata(clusterName, metadata);
+    } else {
+      throw new VeniceException(
+          "This AdminConsumptionService is for cluster: " + config.getClusterName()
+              + ".  Cannot update the version for cluster: " + clusterName);
     }
   }
 

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/kafka/consumer/AdminConsumerService.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/kafka/consumer/AdminConsumerService.java
@@ -190,8 +190,11 @@ public class AdminConsumerService extends AbstractVeniceService {
     if (clusterName.equals(config.getClusterName())) {
       try (AutoCloseableLock ignore =
           admin.getHelixVeniceClusterResources(clusterName).getClusterLockManager().createClusterWriteLock()) {
-        Map<String, Long> metadata =
-            AdminTopicMetadataAccessor.generateMetadataMap(offset, upstreamOffset, executionId);
+        Map<String, Long> metadata = AdminTopicMetadataAccessor.generateMetadataMap(
+            Optional.of(offset),
+            Optional.of(upstreamOffset),
+            Optional.of(executionId),
+            Optional.empty());
         adminTopicMetadataAccessor.updateMetadata(clusterName, metadata);
       }
     } else {

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/kafka/consumer/AdminConsumptionTask.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/kafka/consumer/AdminConsumptionTask.java
@@ -34,6 +34,7 @@ import com.linkedin.venice.utils.LatencyUtils;
 import com.linkedin.venice.utils.Pair;
 import com.linkedin.venice.utils.Time;
 import com.linkedin.venice.utils.Utils;
+import com.linkedin.venice.utils.locks.AutoCloseableLock;
 import java.io.Closeable;
 import java.io.IOException;
 import java.util.ArrayList;
@@ -896,16 +897,19 @@ public class AdminConsumptionTask implements Runnable, Closeable {
       // Skip since there are no new admin messages processed.
       return;
     }
-    Map<String, Long> metadata = remoteConsumptionEnabled
-        ? AdminTopicMetadataAccessor
-            .generateMetadataMap(localOffsetCheckpointAtStartTime, lastOffset, lastDelegatedExecutionId)
-        : AdminTopicMetadataAccessor
-            .generateMetadataMap(lastOffset, upstreamOffsetCheckpointAtStartTime, lastDelegatedExecutionId);
-    adminTopicMetadataAccessor.updateMetadata(clusterName, metadata);
-    lastPersistedOffset = lastOffset;
-    lastPersistedExecutionId = lastDelegatedExecutionId;
-    LOGGER.info("Updated lastPersistedOffset to {}", lastPersistedOffset);
-    stats.setAdminConsumptionCheckpointOffset(lastPersistedOffset);
+    try (AutoCloseableLock ignore =
+        admin.getHelixVeniceClusterResources(clusterName).getClusterLockManager().createClusterWriteLock()) {
+      Map<String, Long> metadata = remoteConsumptionEnabled
+          ? AdminTopicMetadataAccessor
+              .generateMetadataMap(localOffsetCheckpointAtStartTime, lastOffset, lastDelegatedExecutionId)
+          : AdminTopicMetadataAccessor
+              .generateMetadataMap(lastOffset, upstreamOffsetCheckpointAtStartTime, lastDelegatedExecutionId);
+      adminTopicMetadataAccessor.updateMetadata(clusterName, metadata);
+      lastPersistedOffset = lastOffset;
+      lastPersistedExecutionId = lastDelegatedExecutionId;
+      LOGGER.info("Updated lastPersistedOffset to {}", lastPersistedOffset);
+      stats.setAdminConsumptionCheckpointOffset(lastPersistedOffset);
+    }
   }
 
   void skipMessageWithOffset(long offset) {

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/kafka/consumer/AdminConsumptionTask.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/kafka/consumer/AdminConsumptionTask.java
@@ -900,10 +900,16 @@ public class AdminConsumptionTask implements Runnable, Closeable {
     try (AutoCloseableLock ignore =
         admin.getHelixVeniceClusterResources(clusterName).getClusterLockManager().createClusterWriteLock()) {
       Map<String, Long> metadata = remoteConsumptionEnabled
-          ? AdminTopicMetadataAccessor
-              .generateMetadataMap(localOffsetCheckpointAtStartTime, lastOffset, lastDelegatedExecutionId)
-          : AdminTopicMetadataAccessor
-              .generateMetadataMap(lastOffset, upstreamOffsetCheckpointAtStartTime, lastDelegatedExecutionId);
+          ? AdminTopicMetadataAccessor.generateMetadataMap(
+              Optional.of(localOffsetCheckpointAtStartTime),
+              Optional.of(lastOffset),
+              Optional.of(lastDelegatedExecutionId),
+              Optional.empty())
+          : AdminTopicMetadataAccessor.generateMetadataMap(
+              Optional.of(lastOffset),
+              Optional.of(upstreamOffsetCheckpointAtStartTime),
+              Optional.of(lastDelegatedExecutionId),
+              Optional.empty());
       adminTopicMetadataAccessor.updateMetadata(clusterName, metadata);
       lastPersistedOffset = lastOffset;
       lastPersistedExecutionId = lastDelegatedExecutionId;

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/server/AdminSparkServer.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/server/AdminSparkServer.java
@@ -95,6 +95,7 @@ import static com.linkedin.venice.controllerapi.ControllerRoute.STORAGE_ENGINE_O
 import static com.linkedin.venice.controllerapi.ControllerRoute.STORE;
 import static com.linkedin.venice.controllerapi.ControllerRoute.STORE_MIGRATION_ALLOWED;
 import static com.linkedin.venice.controllerapi.ControllerRoute.UPDATE_ACL;
+import static com.linkedin.venice.controllerapi.ControllerRoute.UPDATE_ADMIN_OPERATION_PROTOCOL_VERSION;
 import static com.linkedin.venice.controllerapi.ControllerRoute.UPDATE_ADMIN_TOPIC_METADATA;
 import static com.linkedin.venice.controllerapi.ControllerRoute.UPDATE_CLUSTER_CONFIG;
 import static com.linkedin.venice.controllerapi.ControllerRoute.UPDATE_KAFKA_TOPIC_LOG_COMPACTION;
@@ -636,7 +637,11 @@ public class AdminSparkServer extends AbstractVeniceService {
             admin,
             adminTopicMetadataRoutes
                 .updateAdminTopicMetadata(admin, requestHandler.getClusterAdminOpsRequestHandler())));
-
+    httpService.post(
+        UPDATE_ADMIN_OPERATION_PROTOCOL_VERSION.getPath(),
+        new VeniceParentControllerRegionStateHandler(
+            admin,
+            adminTopicMetadataRoutes.updateAdminOperationProtocolVersion(admin)));
     httpService.post(
         DELETE_KAFKA_TOPIC.getPath(),
         new VeniceParentControllerRegionStateHandler(admin, storesRoutes.deleteKafkaTopic(admin)));

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/server/AdminTopicMetadataRoutes.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/server/AdminTopicMetadataRoutes.java
@@ -53,10 +53,10 @@ public class AdminTopicMetadataRoutes extends AbstractRoute {
         responseObject.setCluster(clusterName);
         storeName.ifPresent(responseObject::setName);
         responseObject.setExecutionId(adminTopicMetadata.getExecutionId());
-        responseObject.setAdminOperationProtocolVersion(adminTopicMetadata.getAdminOperationProtocolVersion());
         if (!storeName.isPresent()) {
           responseObject.setOffset(adminTopicMetadata.getOffset());
           responseObject.setUpstreamOffset(adminTopicMetadata.getUpstreamOffset());
+          responseObject.setAdminOperationProtocolVersion(adminTopicMetadata.getAdminOperationProtocolVersion());
         }
       } catch (Throwable e) {
         responseObject.setError(e);

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/server/AdminTopicMetadataRoutes.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/server/AdminTopicMetadataRoutes.java
@@ -97,7 +97,6 @@ public class AdminTopicMetadataRoutes extends AbstractRoute {
             UpdateAdminTopicMetadataGrpcRequest.newBuilder().setMetadata(adminMetadataBuilder).build());
         responseObject.setCluster(internalResponse.getClusterName());
         responseObject.setName(internalResponse.hasStoreName() ? internalResponse.getStoreName() : null);
-        admin.updateAdminTopicMetadata(clusterName, executionId, storeName, offset, upstreamOffset);
       } catch (Throwable e) {
         responseObject.setError(e);
         AdminSparkServer.handleError(new VeniceException(e), request, response);

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/server/AdminTopicMetadataRoutes.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/server/AdminTopicMetadataRoutes.java
@@ -97,19 +97,6 @@ public class AdminTopicMetadataRoutes extends AbstractRoute {
             UpdateAdminTopicMetadataGrpcRequest.newBuilder().setMetadata(adminMetadataBuilder).build());
         responseObject.setCluster(internalResponse.getClusterName());
         responseObject.setName(internalResponse.hasStoreName() ? internalResponse.getStoreName() : null);
-        if (storeName.isPresent()) {
-          if (offset.isPresent() || upstreamOffset.isPresent()) {
-            throw new VeniceException("There is no store-level offsets to be updated");
-          }
-        } else {
-          if (!offset.isPresent() || !upstreamOffset.isPresent()) {
-            throw new VeniceException("Offsets must be provided to update cluster-level admin topic metadata");
-          }
-        }
-
-        responseObject.setCluster(clusterName);
-        storeName.ifPresent(responseObject::setName);
-
         admin.updateAdminTopicMetadata(clusterName, executionId, storeName, offset, upstreamOffset);
       } catch (Throwable e) {
         responseObject.setError(e);
@@ -121,7 +108,7 @@ public class AdminTopicMetadataRoutes extends AbstractRoute {
 
   public Route updateAdminOperationProtocolVersion(Admin admin) {
     return (request, response) -> {
-      ControllerResponse responseObject = new ControllerResponse();
+      AdminTopicMetadataResponse responseObject = new AdminTopicMetadataResponse();
       response.type(HttpConstants.JSON);
       try {
         if (!isAllowListUser(request)) {
@@ -136,9 +123,9 @@ public class AdminTopicMetadataRoutes extends AbstractRoute {
         Long adminOperationProtocolVersion = Long.parseLong(request.queryParams(ADMIN_OPERATION_PROTOCOL_VERSION));
 
         responseObject.setCluster(clusterName);
+        responseObject.setAdminOperationProtocolVersion(adminOperationProtocolVersion);
 
         admin.updateAdminOperationProtocolVersion(clusterName, adminOperationProtocolVersion);
-
       } catch (Throwable e) {
         responseObject.setError(e);
         AdminSparkServer.handleError(new VeniceException(e), request, response);

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/server/ClusterAdminOpsRequestHandler.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/server/ClusterAdminOpsRequestHandler.java
@@ -102,11 +102,11 @@ public class ClusterAdminOpsRequestHandler {
       Pair<Long, Long> offsets = AdminTopicMetadataAccessor.getOffsets(metadata);
       adminMetadataBuilder.setOffset(offsets.getFirst());
       adminMetadataBuilder.setUpstreamOffset(offsets.getSecond());
+      adminMetadataBuilder
+          .setAdminOperationProtocolVersion(AdminTopicMetadataAccessor.getAdminOperationProtocolVersion(metadata));
     } else {
       adminMetadataBuilder.setStoreName(storeName);
     }
-    adminMetadataBuilder
-        .setAdminOperationProtocolVersion(AdminTopicMetadataAccessor.getAdminOperationProtocolVersion(metadata));
     return AdminTopicMetadataGrpcResponse.newBuilder().setMetadata(adminMetadataBuilder.build()).build();
   }
 

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/server/ClusterAdminOpsRequestHandler.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/server/ClusterAdminOpsRequestHandler.java
@@ -105,6 +105,8 @@ public class ClusterAdminOpsRequestHandler {
     } else {
       adminMetadataBuilder.setStoreName(storeName);
     }
+    adminMetadataBuilder
+        .setAdminOperationProtocolVersion(AdminTopicMetadataAccessor.getAdminOperationProtocolVersion(metadata));
     return AdminTopicMetadataGrpcResponse.newBuilder().setMetadata(adminMetadataBuilder.build()).build();
   }
 

--- a/services/venice-controller/src/test/java/com/linkedin/venice/controller/TestVeniceHelixAdmin.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/controller/TestVeniceHelixAdmin.java
@@ -985,7 +985,7 @@ public class TestVeniceHelixAdmin {
     when(adminConsumerService.getAdminTopicMetadata(anyString())).thenReturn(remoteMetadata);
 
     Map<String, Long> expectedMetadata = AdminTopicMetadataAccessor
-        .generateMetadataMap(Optional.of(-1L), Optional.of(-1L), Optional.of(10L), Optional.of(1L));
+        .generateMetadataMap(Optional.of(-1L), Optional.of(-1L), Optional.of(10L), Optional.of(-1L));
     Map<String, Long> metadataForStore = veniceHelixAdmin.getAdminTopicMetadata(clusterName, Optional.of(storeName));
     assertEquals(metadataForStore, expectedMetadata);
   }

--- a/services/venice-controller/src/test/java/com/linkedin/venice/controller/TestVeniceHelixAdmin.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/controller/TestVeniceHelixAdmin.java
@@ -25,6 +25,7 @@ import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.expectThrows;
 
 import com.linkedin.venice.common.VeniceSystemStoreType;
+import com.linkedin.venice.controller.kafka.consumer.AdminConsumerService;
 import com.linkedin.venice.controller.stats.DisabledPartitionStats;
 import com.linkedin.venice.controller.stats.VeniceAdminStats;
 import com.linkedin.venice.exceptions.VeniceException;
@@ -954,5 +955,88 @@ public class TestVeniceHelixAdmin {
     for (int i = 0; i < pubSubTopics.size(); i++) {
       assertEquals(pubSubTopics.get(i).getName(), expectedUpdateCompactionTopics.get(i));
     }
+  }
+
+  @Test
+  public void testGetAdminTopicMetadata() {
+    String clusterName = "test-cluster";
+    String storeName = "test-store";
+    VeniceHelixAdmin veniceHelixAdmin = mock(VeniceHelixAdmin.class);
+    doCallRealMethod().when(veniceHelixAdmin).getAdminTopicMetadata(clusterName, Optional.of(storeName));
+    doCallRealMethod().when(veniceHelixAdmin).getAdminTopicMetadata(clusterName, Optional.empty());
+
+    // Case 1: Not store name provided
+    Map<String, Long> remoteMetadata = AdminTopicMetadataAccessor.generateMetadataMap(10, -1, 1, 1);
+    AdminConsumerService adminConsumerService = mock(AdminConsumerService.class);
+    when(veniceHelixAdmin.getAdminConsumerService(clusterName)).thenReturn(adminConsumerService);
+    when(adminConsumerService.getAdminTopicMetadata(anyString())).thenReturn(remoteMetadata);
+
+    Map<String, Long> metadata = veniceHelixAdmin.getAdminTopicMetadata(clusterName, Optional.empty());
+    assertEquals(metadata, remoteMetadata);
+
+    // Case 2: Store name is provided
+    ExecutionIdAccessor executionIdAccessor = mock(ExecutionIdAccessor.class);
+    Map<String, Long> executionIdMap = new HashMap<>();
+    executionIdMap.put(storeName, 10L);
+    when(veniceHelixAdmin.getExecutionIdAccessor()).thenReturn(executionIdAccessor);
+    when(executionIdAccessor.getLastSucceededExecutionIdMap(anyString())).thenReturn(executionIdMap);
+    when(veniceHelixAdmin.getExecutionIdAccessor()).thenReturn(executionIdAccessor);
+    when(adminConsumerService.getAdminTopicMetadata(anyString())).thenReturn(remoteMetadata);
+
+    Map<String, Long> expectedMetadata = AdminTopicMetadataAccessor.generateMetadataMap(-1, -1, 10, 1);
+    Map<String, Long> metadataForStore = veniceHelixAdmin.getAdminTopicMetadata(clusterName, Optional.of(storeName));
+    assertEquals(metadataForStore, expectedMetadata);
+  }
+
+  @Test
+  public void testUpdateAdminTopicMetadata() {
+    String clusterName = "test-cluster";
+    String storeName = "test-store";
+    long executionId = 10L;
+    Long offset = 10L;
+    Long upstreamOffset = 1L;
+    VeniceHelixAdmin veniceHelixAdmin = mock(VeniceHelixAdmin.class);
+    doCallRealMethod().when(veniceHelixAdmin)
+        .updateAdminTopicMetadata(clusterName, executionId, Optional.of(storeName), Optional.empty(), Optional.empty());
+    doCallRealMethod().when(veniceHelixAdmin)
+        .updateAdminTopicMetadata(
+            clusterName,
+            executionId,
+            Optional.empty(),
+            Optional.of(offset),
+            Optional.of(upstreamOffset));
+
+    // Case 1: Store name is provided
+    ExecutionIdAccessor executionIdAccessor = mock(ExecutionIdAccessor.class);
+    when(veniceHelixAdmin.getExecutionIdAccessor()).thenReturn(executionIdAccessor);
+
+    veniceHelixAdmin
+        .updateAdminTopicMetadata(clusterName, executionId, Optional.of(storeName), Optional.empty(), Optional.empty());
+    verify(executionIdAccessor, times(1)).updateLastSucceededExecutionIdMap(clusterName, storeName, executionId);
+
+    // Case 2: Store name is not provided
+    AdminConsumerService adminConsumerService = mock(AdminConsumerService.class);
+    when(veniceHelixAdmin.getAdminConsumerService(clusterName)).thenReturn(adminConsumerService);
+    veniceHelixAdmin.updateAdminTopicMetadata(
+        clusterName,
+        executionId,
+        Optional.empty(),
+        Optional.of(offset),
+        Optional.of(upstreamOffset));
+    verify(executionIdAccessor, never()).updateLastSucceededExecutionId(anyString(), anyLong());
+    verify(adminConsumerService, times(1)).updateAdminTopicMetadata(clusterName, executionId, offset, upstreamOffset);
+  }
+
+  @Test
+  public void testUpdateAdminOperationProtocolVersion() {
+    String clusterName = "test-cluster";
+    Long adminProtocolVersion = 10L;
+    VeniceHelixAdmin veniceHelixAdmin = mock(VeniceHelixAdmin.class);
+    doCallRealMethod().when(veniceHelixAdmin).updateAdminOperationProtocolVersion(clusterName, adminProtocolVersion);
+    AdminConsumerService adminConsumerService = mock(AdminConsumerService.class);
+    when(veniceHelixAdmin.getAdminConsumerService(clusterName)).thenReturn(adminConsumerService);
+
+    veniceHelixAdmin.updateAdminOperationProtocolVersion(clusterName, adminProtocolVersion);
+    verify(adminConsumerService, times(1)).updateAdminOperationProtocolVersion(clusterName, adminProtocolVersion);
   }
 }

--- a/services/venice-controller/src/test/java/com/linkedin/venice/controller/TestVeniceHelixAdmin.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/controller/TestVeniceHelixAdmin.java
@@ -966,7 +966,8 @@ public class TestVeniceHelixAdmin {
     doCallRealMethod().when(veniceHelixAdmin).getAdminTopicMetadata(clusterName, Optional.empty());
 
     // Case 1: Not store name provided
-    Map<String, Long> remoteMetadata = AdminTopicMetadataAccessor.generateMetadataMap(10, -1, 1, 1);
+    Map<String, Long> remoteMetadata = AdminTopicMetadataAccessor
+        .generateMetadataMap(Optional.of(10L), Optional.of(-1L), Optional.of(1L), Optional.of(1L));
     AdminConsumerService adminConsumerService = mock(AdminConsumerService.class);
     when(veniceHelixAdmin.getAdminConsumerService(clusterName)).thenReturn(adminConsumerService);
     when(adminConsumerService.getAdminTopicMetadata(anyString())).thenReturn(remoteMetadata);
@@ -983,7 +984,8 @@ public class TestVeniceHelixAdmin {
     when(veniceHelixAdmin.getExecutionIdAccessor()).thenReturn(executionIdAccessor);
     when(adminConsumerService.getAdminTopicMetadata(anyString())).thenReturn(remoteMetadata);
 
-    Map<String, Long> expectedMetadata = AdminTopicMetadataAccessor.generateMetadataMap(-1, -1, 10, 1);
+    Map<String, Long> expectedMetadata = AdminTopicMetadataAccessor
+        .generateMetadataMap(Optional.of(-1L), Optional.of(-1L), Optional.of(10L), Optional.of(1L));
     Map<String, Long> metadataForStore = veniceHelixAdmin.getAdminTopicMetadata(clusterName, Optional.of(storeName));
     assertEquals(metadataForStore, expectedMetadata);
   }

--- a/services/venice-controller/src/test/java/com/linkedin/venice/controller/TestVeniceParentHelixAdmin.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/controller/TestVeniceParentHelixAdmin.java
@@ -299,7 +299,9 @@ public class TestVeniceParentHelixAdmin extends AbstractTestVeniceParentHelixAdm
         .when(veniceWriter)
         .put(any(), any(), anyInt());
     when(zkClient.readData(zkMetadataNodePath, null)).thenReturn(null)
-        .thenReturn(AdminTopicMetadataAccessor.generateMetadataMap(1, -1, 1));
+        .thenReturn(
+            AdminTopicMetadataAccessor
+                .generateMetadataMap(Optional.of(1L), Optional.of(-1L), Optional.of(1L), Optional.empty()));
 
     parentAdmin.initStorageCluster(clusterName);
 
@@ -378,8 +380,9 @@ public class TestVeniceParentHelixAdmin extends AbstractTestVeniceParentHelixAdm
       String valueSchemaStr = "\"string\"";
       when(veniceWriter.put(any(), any(), anyInt())).then(invocation -> {
         // Once we send message to topic through venice writer, return offset 1
-        when(zkClient.readData(metadataPath, null))
-            .thenReturn(AdminTopicMetadataAccessor.generateMetadataMap(1, -1, 1));
+        when(zkClient.readData(metadataPath, null)).thenReturn(
+            AdminTopicMetadataAccessor
+                .generateMetadataMap(Optional.of(1L), Optional.of(-1L), Optional.of(1L), Optional.empty()));
         CompletableFuture future = mock(CompletableFuture.class);
         doReturn(new SimplePubSubProduceResultImpl(adminTopic, partitionId, 1, -1)).when(future).get();
         return future;
@@ -491,7 +494,9 @@ public class TestVeniceParentHelixAdmin extends AbstractTestVeniceParentHelixAdm
         .put(any(), any(), anyInt());
 
     when(zkClient.readData(zkMetadataNodePath, null)).thenReturn(null)
-        .thenReturn(AdminTopicMetadataAccessor.generateMetadataMap(1, -1, 1));
+        .thenReturn(
+            AdminTopicMetadataAccessor
+                .generateMetadataMap(Optional.of(1L), Optional.of(-1L), Optional.of(1L), Optional.empty()));
 
     parentAdmin.initStorageCluster(clusterName);
     parentAdmin.addValueSchema(clusterName, storeName, valueSchemaStr, DirectionalSchemaCompatibilityType.FULL);
@@ -543,7 +548,9 @@ public class TestVeniceParentHelixAdmin extends AbstractTestVeniceParentHelixAdm
         .put(any(), any(), anyInt());
 
     when(zkClient.readData(zkMetadataNodePath, null)).thenReturn(null)
-        .thenReturn(AdminTopicMetadataAccessor.generateMetadataMap(1, -1, 1));
+        .thenReturn(
+            AdminTopicMetadataAccessor
+                .generateMetadataMap(Optional.of(1L), Optional.of(-1L), Optional.of(1L), Optional.empty()));
 
     parentAdmin.initStorageCluster(clusterName);
     parentAdmin.addDerivedSchema(clusterName, storeName, valueSchemaId, derivedSchemaStr);
@@ -570,7 +577,9 @@ public class TestVeniceParentHelixAdmin extends AbstractTestVeniceParentHelixAdm
         .put(any(), any(), anyInt());
 
     when(zkClient.readData(zkMetadataNodePath, null)).thenReturn(null)
-        .thenReturn(AdminTopicMetadataAccessor.generateMetadataMap(1, -1, 1));
+        .thenReturn(
+            AdminTopicMetadataAccessor
+                .generateMetadataMap(Optional.of(1L), Optional.of(-1L), Optional.of(1L), Optional.empty()));
 
     String storeName = "test-store";
     parentAdmin.initStorageCluster(clusterName);
@@ -606,7 +615,9 @@ public class TestVeniceParentHelixAdmin extends AbstractTestVeniceParentHelixAdm
         .put(any(), any(), anyInt());
 
     when(zkClient.readData(zkMetadataNodePath, null)).thenReturn(null)
-        .thenReturn(AdminTopicMetadataAccessor.generateMetadataMap(1, -1, 1));
+        .thenReturn(
+            AdminTopicMetadataAccessor
+                .generateMetadataMap(Optional.of(1L), Optional.of(-1L), Optional.of(1L), Optional.empty()));
 
     String storeName = "test-store";
     parentAdmin.initStorageCluster(clusterName);
@@ -647,7 +658,9 @@ public class TestVeniceParentHelixAdmin extends AbstractTestVeniceParentHelixAdm
 
     when(zkClient.readData(zkMetadataNodePath, null))
         .thenReturn(new OffsetRecord(AvroProtocolDefinition.PARTITION_STATE.getSerializer()))
-        .thenReturn(AdminTopicMetadataAccessor.generateMetadataMap(1, -1, 1));
+        .thenReturn(
+            AdminTopicMetadataAccessor
+                .generateMetadataMap(Optional.of(1L), Optional.of(-1L), Optional.of(1L), Optional.empty()));
 
     parentAdmin.initStorageCluster(clusterName);
     assertThrows(VeniceNoStoreException.class, () -> parentAdmin.setStoreWriteability(clusterName, storeName, false));
@@ -660,7 +673,9 @@ public class TestVeniceParentHelixAdmin extends AbstractTestVeniceParentHelixAdm
         .put(any(), any(), anyInt());
 
     when(zkClient.readData(zkMetadataNodePath, null)).thenReturn(null)
-        .thenReturn(AdminTopicMetadataAccessor.generateMetadataMap(1, -1, 1));
+        .thenReturn(
+            AdminTopicMetadataAccessor
+                .generateMetadataMap(Optional.of(1L), Optional.of(-1L), Optional.of(1L), Optional.empty()));
 
     String storeName = "test-store";
     parentAdmin.initStorageCluster(clusterName);
@@ -696,7 +711,9 @@ public class TestVeniceParentHelixAdmin extends AbstractTestVeniceParentHelixAdm
         .put(any(), any(), anyInt());
 
     when(zkClient.readData(zkMetadataNodePath, null)).thenReturn(null)
-        .thenReturn(AdminTopicMetadataAccessor.generateMetadataMap(1, -1, 1));
+        .thenReturn(
+            AdminTopicMetadataAccessor
+                .generateMetadataMap(Optional.of(1L), Optional.of(-1L), Optional.of(1L), Optional.empty()));
 
     String storeName = "test-store";
     parentAdmin.initStorageCluster(clusterName);
@@ -735,7 +752,9 @@ public class TestVeniceParentHelixAdmin extends AbstractTestVeniceParentHelixAdm
         .put(any(), any(), anyInt());
 
     when(zkClient.readData(zkMetadataNodePath, null)).thenReturn(null)
-        .thenReturn(AdminTopicMetadataAccessor.generateMetadataMap(1, -1, 1));
+        .thenReturn(
+            AdminTopicMetadataAccessor
+                .generateMetadataMap(Optional.of(1L), Optional.of(-1L), Optional.of(1L), Optional.empty()));
     Store store = mock(Store.class);
     doReturn(store).when(internalAdmin).getStore(clusterName, pubSubTopic.getStoreName());
 
@@ -798,7 +817,9 @@ public class TestVeniceParentHelixAdmin extends AbstractTestVeniceParentHelixAdm
           .when(veniceWriter)
           .put(any(), any(), anyInt());
       when(zkClient.readData(zkMetadataNodePath, null)).thenReturn(null)
-          .thenReturn(AdminTopicMetadataAccessor.generateMetadataMap(1, -1, 1));
+          .thenReturn(
+              AdminTopicMetadataAccessor
+                  .generateMetadataMap(Optional.of(1L), Optional.of(-1L), Optional.of(1L), Optional.empty()));
       partialMockParentAdmin.incrementVersionIdempotent(clusterName, storeName, pushJobId, 1, 1);
       verify(internalAdmin).addVersionAndTopicOnly(
           clusterName,
@@ -929,7 +950,9 @@ public class TestVeniceParentHelixAdmin extends AbstractTestVeniceParentHelixAdm
           .when(veniceWriter)
           .put(any(), any(), anyInt());
       when(zkClient.readData(zkMetadataNodePath, null)).thenReturn(null)
-          .thenReturn(AdminTopicMetadataAccessor.generateMetadataMap(1, -1, 1));
+          .thenReturn(
+              AdminTopicMetadataAccessor
+                  .generateMetadataMap(Optional.of(1L), Optional.of(-1L), Optional.of(1L), Optional.empty()));
       Version newVersion = partialMockParentAdmin.incrementVersionIdempotent(
           clusterName,
           storeName,
@@ -1019,7 +1042,9 @@ public class TestVeniceParentHelixAdmin extends AbstractTestVeniceParentHelixAdm
           .when(veniceWriter)
           .put(any(), any(), anyInt());
       when(zkClient.readData(zkMetadataNodePath, null)).thenReturn(null)
-          .thenReturn(AdminTopicMetadataAccessor.generateMetadataMap(1, -1, 1));
+          .thenReturn(
+              AdminTopicMetadataAccessor
+                  .generateMetadataMap(Optional.of(1L), Optional.of(-1L), Optional.of(1L), Optional.empty()));
       partialMockParentAdmin.incrementVersionIdempotent(
           clusterName,
           storeName,
@@ -1783,7 +1808,9 @@ public class TestVeniceParentHelixAdmin extends AbstractTestVeniceParentHelixAdm
         .put(any(), any(), anyInt());
 
     when(zkClient.readData(zkMetadataNodePath, null)).thenReturn(null)
-        .thenReturn(AdminTopicMetadataAccessor.generateMetadataMap(1, -1, 1));
+        .thenReturn(
+            AdminTopicMetadataAccessor
+                .generateMetadataMap(Optional.of(1L), Optional.of(-1L), Optional.of(1L), Optional.empty()));
 
     UpdateStoreQueryParams storeQueryParams1 = new UpdateStoreQueryParams().setBlobTransferEnabled(true);
     parentAdmin.initStorageCluster(clusterName);
@@ -1913,7 +1940,9 @@ public class TestVeniceParentHelixAdmin extends AbstractTestVeniceParentHelixAdm
         .put(any(), any(), anyInt());
 
     when(zkClient.readData(zkMetadataNodePath, null)).thenReturn(null)
-        .thenReturn(AdminTopicMetadataAccessor.generateMetadataMap(1, -1, 1));
+        .thenReturn(
+            AdminTopicMetadataAccessor
+                .generateMetadataMap(Optional.of(1L), Optional.of(-1L), Optional.of(1L), Optional.empty()));
 
     parentAdmin.initStorageCluster(clusterName);
     parentAdmin
@@ -1938,7 +1967,9 @@ public class TestVeniceParentHelixAdmin extends AbstractTestVeniceParentHelixAdm
         .put(any(), any(), anyInt());
 
     when(zkClient.readData(zkMetadataNodePath, null)).thenReturn(null)
-        .thenReturn(AdminTopicMetadataAccessor.generateMetadataMap(1, -1, 1));
+        .thenReturn(
+            AdminTopicMetadataAccessor
+                .generateMetadataMap(Optional.of(1L), Optional.of(-1L), Optional.of(1L), Optional.empty()));
 
     UpdateStoreQueryParams updateStoreQueryParams = new UpdateStoreQueryParams().setTargetRegionSwap("prod")
         .setTargetRegionSwapWaitTime(100)
@@ -1976,7 +2007,9 @@ public class TestVeniceParentHelixAdmin extends AbstractTestVeniceParentHelixAdm
         .put(any(), any(), anyInt());
 
     when(zkClient.readData(zkMetadataNodePath, null)).thenReturn(null)
-        .thenReturn(AdminTopicMetadataAccessor.generateMetadataMap(1, -1, 1));
+        .thenReturn(
+            AdminTopicMetadataAccessor
+                .generateMetadataMap(Optional.of(1L), Optional.of(-1L), Optional.of(1L), Optional.empty()));
 
     parentAdmin.initStorageCluster(clusterName);
     // When user disable hybrid but also try to manually turn on A/A or Incremental Push, update operation should fail
@@ -2147,7 +2180,9 @@ public class TestVeniceParentHelixAdmin extends AbstractTestVeniceParentHelixAdm
         .put(any(), any(), anyInt());
 
     when(zkClient.readData(zkMetadataNodePath, null)).thenReturn(null)
-        .thenReturn(AdminTopicMetadataAccessor.generateMetadataMap(1, -1, 1));
+        .thenReturn(
+            AdminTopicMetadataAccessor
+                .generateMetadataMap(Optional.of(1L), Optional.of(-1L), Optional.of(1L), Optional.empty()));
 
     parentAdmin.initStorageCluster(clusterName);
     parentAdmin.updateStore(
@@ -2178,7 +2213,9 @@ public class TestVeniceParentHelixAdmin extends AbstractTestVeniceParentHelixAdm
         .put(any(), any(), anyInt());
 
     when(zkClient.readData(zkMetadataNodePath, null)).thenReturn(null)
-        .thenReturn(AdminTopicMetadataAccessor.generateMetadataMap(1, -1, 1));
+        .thenReturn(
+            AdminTopicMetadataAccessor
+                .generateMetadataMap(Optional.of(1L), Optional.of(-1L), Optional.of(1L), Optional.empty()));
     parentAdmin.initStorageCluster(clusterName);
 
     assertThrows(
@@ -2230,7 +2267,9 @@ public class TestVeniceParentHelixAdmin extends AbstractTestVeniceParentHelixAdm
         .put(any(), any(), anyInt());
 
     when(zkClient.readData(zkMetadataNodePath, null)).thenReturn(null)
-        .thenReturn(AdminTopicMetadataAccessor.generateMetadataMap(1, -1, 1));
+        .thenReturn(
+            AdminTopicMetadataAccessor
+                .generateMetadataMap(Optional.of(1L), Optional.of(-1L), Optional.of(1L), Optional.empty()));
 
     parentAdmin.initStorageCluster(clusterName);
     parentAdmin.deleteStore(clusterName, storeName, false, 0, true);
@@ -2569,7 +2608,9 @@ public class TestVeniceParentHelixAdmin extends AbstractTestVeniceParentHelixAdm
           .put(any(), any(), anyInt());
       mockControllerClients(storeName);
       when(zkClient.readData(zkMetadataNodePath, null)).thenReturn(null)
-          .thenReturn(AdminTopicMetadataAccessor.generateMetadataMap(1, -1, 1));
+          .thenReturn(
+              AdminTopicMetadataAccessor
+                  .generateMetadataMap(Optional.of(1L), Optional.of(-1L), Optional.of(1L), Optional.empty()));
 
       if (isIncrementalPush) {
         /**
@@ -2727,7 +2768,9 @@ public class TestVeniceParentHelixAdmin extends AbstractTestVeniceParentHelixAdm
         .put(any(), any(), anyInt());
 
     when(zkClient.readData(zkMetadataNodePath, null)).thenReturn(null)
-        .thenReturn(AdminTopicMetadataAccessor.generateMetadataMap(1, -1, 1));
+        .thenReturn(
+            AdminTopicMetadataAccessor
+                .generateMetadataMap(Optional.of(1L), Optional.of(-1L), Optional.of(1L), Optional.empty()));
 
     parentAdmin.initStorageCluster(clusterName);
     parentAdmin.updateStore(
@@ -2792,7 +2835,9 @@ public class TestVeniceParentHelixAdmin extends AbstractTestVeniceParentHelixAdm
         .when(veniceWriter)
         .put(any(), any(), anyInt());
     when(zkClient.readData(zkMetadataNodePath, null)).thenReturn(null)
-        .thenReturn(AdminTopicMetadataAccessor.generateMetadataMap(1, -1, 1));
+        .thenReturn(
+            AdminTopicMetadataAccessor
+                .generateMetadataMap(Optional.of(1L), Optional.of(-1L), Optional.of(1L), Optional.empty()));
     parentAdmin.initStorageCluster(clusterName);
     String storeName = "test-store";
     String owner = "test-owner";
@@ -2967,7 +3012,9 @@ public class TestVeniceParentHelixAdmin extends AbstractTestVeniceParentHelixAdm
         .put(any(), any(), anyInt());
 
     when(zkClient.readData(zkMetadataNodePath, null)).thenReturn(null)
-        .thenReturn(AdminTopicMetadataAccessor.generateMetadataMap(1, -1, 1));
+        .thenReturn(
+            AdminTopicMetadataAccessor
+                .generateMetadataMap(Optional.of(1L), Optional.of(-1L), Optional.of(1L), Optional.empty()));
 
     parentAdmin.initStorageCluster(clusterName);
     return store;

--- a/services/venice-controller/src/test/java/com/linkedin/venice/controller/TestVeniceParentHelixAdminWithAcl.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/controller/TestVeniceParentHelixAdminWithAcl.java
@@ -126,7 +126,9 @@ public class TestVeniceParentHelixAdminWithAcl extends AbstractTestVeniceParentH
         .put(any(), any(), anyInt());
 
     when(zkClient.readData(zkMetadataNodePath, null)).thenReturn(null)
-        .thenReturn(AdminTopicMetadataAccessor.generateMetadataMap(1, -1, 1));
+        .thenReturn(
+            AdminTopicMetadataAccessor
+                .generateMetadataMap(Optional.of(1L), Optional.of(-1L), Optional.of(1L), Optional.empty()));
     initializeParentAdmin(Optional.of(authorizerService));
     parentAdmin.initStorageCluster(clusterName);
     parentAdmin.deleteStore(clusterName, storeName, false, 0, true);
@@ -175,7 +177,9 @@ public class TestVeniceParentHelixAdminWithAcl extends AbstractTestVeniceParentH
         .checkPreConditionForAclOp(clusterName, storeName);
 
     when(zkClient.readData(zkMetadataNodePath, null)).thenReturn(new OffsetRecord(partitionStateSerializer))
-        .thenReturn(AdminTopicMetadataAccessor.generateMetadataMap(1, -1, 1));
+        .thenReturn(
+            AdminTopicMetadataAccessor
+                .generateMetadataMap(Optional.of(1L), Optional.of(-1L), Optional.of(1L), Optional.empty()));
     initializeParentAdmin(Optional.of(authorizerService));
     Assert.assertThrows(
         VeniceNoStoreException.class,
@@ -193,7 +197,9 @@ public class TestVeniceParentHelixAdminWithAcl extends AbstractTestVeniceParentH
         .checkPreConditionForAclOp(clusterName, storeName);
 
     when(zkClient.readData(zkMetadataNodePath, null)).thenReturn(new OffsetRecord(partitionStateSerializer))
-        .thenReturn(AdminTopicMetadataAccessor.generateMetadataMap(1, -1, 1));
+        .thenReturn(
+            AdminTopicMetadataAccessor
+                .generateMetadataMap(Optional.of(1L), Optional.of(-1L), Optional.of(1L), Optional.empty()));
     initializeParentAdmin(Optional.of(authorizerService));
     Assert.assertThrows(VeniceNoStoreException.class, () -> parentAdmin.getAclForStore(clusterName, storeName));
   }
@@ -208,7 +214,9 @@ public class TestVeniceParentHelixAdminWithAcl extends AbstractTestVeniceParentH
         .checkPreConditionForAclOp(clusterName, storeName);
 
     when(zkClient.readData(zkMetadataNodePath, null)).thenReturn(new OffsetRecord(partitionStateSerializer))
-        .thenReturn(AdminTopicMetadataAccessor.generateMetadataMap(1, -1, 1));
+        .thenReturn(
+            AdminTopicMetadataAccessor
+                .generateMetadataMap(Optional.of(1L), Optional.of(-1L), Optional.of(1L), Optional.empty()));
     initializeParentAdmin(Optional.of(authorizerService));
     Assert.assertThrows(VeniceNoStoreException.class, () -> parentAdmin.deleteAclForStore(clusterName, storeName));
     Assert.assertEquals(0, authorizerService.clearAclCounter);

--- a/services/venice-controller/src/test/java/com/linkedin/venice/controller/TestZkAdminTopicMetadataAccessor.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/controller/TestZkAdminTopicMetadataAccessor.java
@@ -10,6 +10,7 @@ import static org.testng.Assert.assertEquals;
 import com.linkedin.venice.helix.HelixAdapterSerializer;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Optional;
 import org.apache.helix.zookeeper.impl.client.ZkClient;
 import org.apache.zookeeper.data.Stat;
 import org.apache.zookeeper.server.DataTree;
@@ -36,14 +37,16 @@ public class TestZkAdminTopicMetadataAccessor {
     String clusterName = "test-cluster";
 
     // Original metadata
-    Map<String, Long> currentMetadata = AdminTopicMetadataAccessor.generateMetadataMap(1, -1, 1, 18);
+    Map<String, Long> currentMetadata = AdminTopicMetadataAccessor
+        .generateMetadataMap(Optional.of(1L), Optional.of(-1L), Optional.of(1L), Optional.of(18L));
 
     // New metadata
     Map<String, Long> newMetadata = new HashMap<>();
     newMetadata.put("offset", 100L);
 
     // Updated metadata with new metadata
-    Map<String, Long> updatedMetadata = AdminTopicMetadataAccessor.generateMetadataMap(100, -1, 1, 18);
+    Map<String, Long> updatedMetadata = AdminTopicMetadataAccessor
+        .generateMetadataMap(Optional.of(100L), Optional.of(-1L), Optional.of(1L), Optional.of(18L));
 
     String metadataPath = ZkAdminTopicMetadataAccessor.getAdminTopicMetadataNodePath(clusterName);
     try (MockedStatic<DataTree> dataTreeMockedStatic = Mockito.mockStatic(DataTree.class)) {
@@ -69,7 +72,8 @@ public class TestZkAdminTopicMetadataAccessor {
   @Test
   public void testGetMetadata() {
     String clusterName = "test-cluster";
-    Map<String, Long> currentMetadata = AdminTopicMetadataAccessor.generateMetadataMap(1, -1, 1, 18);
+    Map<String, Long> currentMetadata = AdminTopicMetadataAccessor
+        .generateMetadataMap(Optional.of(1L), Optional.of(-1L), Optional.of(1L), Optional.of(18L));
     String metadataPath = ZkAdminTopicMetadataAccessor.getAdminTopicMetadataNodePath(clusterName);
 
     when(zkClient.readData(metadataPath, null)).thenReturn(null).thenReturn(currentMetadata);

--- a/services/venice-controller/src/test/java/com/linkedin/venice/controller/TestZkAdminTopicMetadataAccessor.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/controller/TestZkAdminTopicMetadataAccessor.java
@@ -1,8 +1,11 @@
 package com.linkedin.venice.controller;
 
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.*;
-import static org.testng.Assert.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertEquals;
 
 import com.linkedin.venice.helix.HelixAdapterSerializer;
 import java.util.HashMap;
@@ -43,7 +46,7 @@ public class TestZkAdminTopicMetadataAccessor {
     Map<String, Long> updatedMetadata = AdminTopicMetadataAccessor.generateMetadataMap(100, -1, 1, 18);
 
     String metadataPath = ZkAdminTopicMetadataAccessor.getAdminTopicMetadataNodePath(clusterName);
-    try (MockedStatic<DataTree> dataTreeMockedStatic = Mockito.mockStatic(DataTree.class, RETURNS_SMART_NULLS)) {
+    try (MockedStatic<DataTree> dataTreeMockedStatic = Mockito.mockStatic(DataTree.class)) {
       dataTreeMockedStatic.when(() -> DataTree.copyStat(any(), any())).thenAnswer(invocation -> null);
       Stat readStat = new Stat();
 

--- a/services/venice-controller/src/test/java/com/linkedin/venice/controller/TestZkAdminTopicMetadataAccessor.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/controller/TestZkAdminTopicMetadataAccessor.java
@@ -63,14 +63,16 @@ public class TestZkAdminTopicMetadataAccessor {
   @Test
   public void testUpdateMetadataWithFullMetadata() {
     String clusterName = "test-cluster";
+    Long originalOffset = 1L;
+    Long newOffset = 100L;
 
     // Original metadata
     Map<String, Long> currentMetadata = AdminTopicMetadataAccessor
-        .generateMetadataMap(Optional.of(1L), Optional.of(-1L), Optional.of(1L), Optional.of(18L));
+        .generateMetadataMap(Optional.of(originalOffset), Optional.of(-1L), Optional.of(1L), Optional.of(18L));
 
     // metadata that we are trying to update
     Map<String, Long> metadataDelta = new HashMap<>();
-    metadataDelta.put("offset", 100L);
+    metadataDelta.put("offset", newOffset);
 
     String metadataPath = ZkAdminTopicMetadataAccessor.getAdminTopicMetadataNodePath(clusterName);
     try (MockedStatic<DataTree> dataTreeMockedStatic = Mockito.mockStatic(DataTree.class)) {
@@ -84,9 +86,9 @@ public class TestZkAdminTopicMetadataAccessor {
 
       // The updated metadata should be the original metadata with the offset updated
       Map<String, Long> updatedMetadata = AdminTopicMetadataAccessor
-          .generateMetadataMap(Optional.of(100L), Optional.of(-1L), Optional.of(1L), Optional.of(18L));
+          .generateMetadataMap(Optional.of(newOffset), Optional.of(-1L), Optional.of(1L), Optional.of(18L));
 
-      // Verify that the metadata path got read 2 times
+      // Verify that the metadata path got read 1 times
       verify(zkClient, times(1)).readData(metadataPath, readStat);
 
       // Verify that the metadata path got written with the correct updated metadata

--- a/services/venice-controller/src/test/java/com/linkedin/venice/controller/TestZkAdminTopicMetadataAccessor.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/controller/TestZkAdminTopicMetadataAccessor.java
@@ -1,0 +1,82 @@
+package com.linkedin.venice.controller;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+import static org.testng.Assert.*;
+
+import com.linkedin.venice.helix.HelixAdapterSerializer;
+import java.util.HashMap;
+import java.util.Map;
+import org.apache.helix.zookeeper.impl.client.ZkClient;
+import org.apache.zookeeper.data.Stat;
+import org.apache.zookeeper.server.DataTree;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+
+public class TestZkAdminTopicMetadataAccessor {
+  private ZkClient zkClient;
+  private HelixAdapterSerializer adapterSerializer;
+  private ZkAdminTopicMetadataAccessor zkAdminTopicMetadataAccessor;
+
+  @BeforeMethod
+  public void setUp() {
+    zkClient = mock(ZkClient.class);
+    adapterSerializer = mock(HelixAdapterSerializer.class);
+    zkAdminTopicMetadataAccessor = new ZkAdminTopicMetadataAccessor(zkClient, adapterSerializer);
+  }
+
+  @Test
+  public void testUpdateMetadata() {
+    String clusterName = "test-cluster";
+
+    // Original metadata
+    Map<String, Long> currentMetadata = AdminTopicMetadataAccessor.generateMetadataMap(1, -1, 1, 18);
+
+    // New metadata
+    Map<String, Long> newMetadata = new HashMap<>();
+    newMetadata.put("offset", 100L);
+
+    // Updated metadata with new metadata
+    Map<String, Long> updatedMetadata = AdminTopicMetadataAccessor.generateMetadataMap(100, -1, 1, 18);
+
+    String metadataPath = ZkAdminTopicMetadataAccessor.getAdminTopicMetadataNodePath(clusterName);
+    try (MockedStatic<DataTree> dataTreeMockedStatic = Mockito.mockStatic(DataTree.class, RETURNS_SMART_NULLS)) {
+      dataTreeMockedStatic.when(() -> DataTree.copyStat(any(), any())).thenAnswer(invocation -> null);
+      Stat readStat = new Stat();
+
+      when(zkClient.readData(metadataPath, readStat)).thenReturn(null) // Case 1: when there is no metadata
+          .thenReturn(currentMetadata); // Case 2: the metadata is not null
+
+      // Case 1: when there is no metadata - null
+      zkAdminTopicMetadataAccessor.updateMetadata(clusterName, newMetadata);
+      verify(zkClient, times(1)).writeDataGetStat(metadataPath, newMetadata, 0);
+
+      // Case 2: the metadata is not null
+      zkAdminTopicMetadataAccessor.updateMetadata(clusterName, newMetadata);
+      verify(zkClient, times(1)).writeDataGetStat(metadataPath, updatedMetadata, 0);
+
+      // Verify that the metadata path got read 2 times
+      verify(zkClient, times(2)).readData(metadataPath, readStat);
+    }
+  }
+
+  @Test
+  public void testGetMetadata() {
+    String clusterName = "test-cluster";
+    Map<String, Long> currentMetadata = AdminTopicMetadataAccessor.generateMetadataMap(1, -1, 1, 18);
+    String metadataPath = ZkAdminTopicMetadataAccessor.getAdminTopicMetadataNodePath(clusterName);
+
+    when(zkClient.readData(metadataPath, null)).thenReturn(null).thenReturn(currentMetadata);
+
+    // Case 1: when there is no metadata
+    Map<String, Long> metadata = zkAdminTopicMetadataAccessor.getMetadata(clusterName);
+    assertEquals(metadata, new HashMap<>());
+
+    // Case 2: the metadata is not null
+    metadata = zkAdminTopicMetadataAccessor.getMetadata(clusterName);
+    assertEquals(metadata, currentMetadata);
+  }
+}

--- a/services/venice-controller/src/test/java/com/linkedin/venice/controller/kafka/consumer/AdminConsumptionTaskTest.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/controller/kafka/consumer/AdminConsumptionTaskTest.java
@@ -744,7 +744,11 @@ public class AdminConsumptionTaskTest {
         AdminOperationSerializer.LATEST_SCHEMA_ID_FOR_ADMIN_OPERATION);
     adminTopicMetadataAccessor.updateMetadata(
         clusterName,
-        AdminTopicMetadataAccessor.generateMetadataMap(metadataForStoreName0Future.get().getOffset(), -1, 1));
+        AdminTopicMetadataAccessor.generateMetadataMap(
+            Optional.of(metadataForStoreName0Future.get().getOffset()),
+            Optional.of(-1L),
+            Optional.of(1L),
+            Optional.empty()));
 
     // Write a message with a skipped execution id but a different producer metadata.
     veniceWriter.put(
@@ -830,7 +834,8 @@ public class AdminConsumptionTaskTest {
     // The store doesn't exist
     doReturn(false).when(admin).hasStore(clusterName, storeName1);
     doReturn(false).when(admin).hasStore(clusterName, storeName2);
-    Map<String, Long> newMetadata = AdminTopicMetadataAccessor.generateMetadataMap(1, -1, 1);
+    Map<String, Long> newMetadata = AdminTopicMetadataAccessor
+        .generateMetadataMap(Optional.of(1L), Optional.of(-1L), Optional.of(1L), Optional.empty());
     adminTopicMetadataAccessor.updateMetadata(clusterName, newMetadata);
 
     AdminConsumptionTask task = getAdminConsumptionTask(new RandomPollStrategy(), false);
@@ -1119,7 +1124,8 @@ public class AdminConsumptionTaskTest {
         getKillOfflinePushJobMessage(clusterName, storeTopicName, 4L),
         AdminOperationSerializer.LATEST_SCHEMA_ID_FOR_ADMIN_OPERATION);
     long offset = future.get(TIMEOUT, TimeUnit.MILLISECONDS).getOffset();
-    Map<String, Long> newMetadata = AdminTopicMetadataAccessor.generateMetadataMap(offset, -1, 4L);
+    Map<String, Long> newMetadata = AdminTopicMetadataAccessor
+        .generateMetadataMap(Optional.of(offset), Optional.of(-1L), Optional.of(4L), Optional.empty());
     adminTopicMetadataAccessor.updateMetadata(clusterName, newMetadata);
     executionIdAccessor.updateLastSucceededExecutionIdMap(clusterName, storeName, 4L);
     // Resubscribe to the admin topic and make sure it can still process new admin messages

--- a/services/venice-controller/src/test/java/com/linkedin/venice/controller/kafka/consumer/AdminConsumptionTaskTest.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/controller/kafka/consumer/AdminConsumptionTaskTest.java
@@ -19,7 +19,25 @@ import static com.linkedin.venice.controllerapi.ControllerApiConstants.TIME_LAG_
 import static com.linkedin.venice.controllerapi.ControllerApiConstants.VERSION;
 import static com.linkedin.venice.controllerapi.ControllerApiConstants.WRITE_COMPUTATION_ENABLED;
 import static com.linkedin.venice.meta.HybridStoreConfigImpl.DEFAULT_REAL_TIME_TOPIC_NAME;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.anyBoolean;
+import static org.mockito.Mockito.anyDouble;
+import static org.mockito.Mockito.anyInt;
+import static org.mockito.Mockito.anyLong;
+import static org.mockito.Mockito.argThat;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doCallRealMethod;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.timeout;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import com.linkedin.venice.admin.InMemoryAdminTopicMetadataAccessor;
 import com.linkedin.venice.admin.InMemoryExecutionIdAccessor;

--- a/services/venice-controller/src/test/java/com/linkedin/venice/controller/kafka/consumer/AdminConsumptionTaskTest.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/controller/kafka/consumer/AdminConsumptionTaskTest.java
@@ -19,29 +19,14 @@ import static com.linkedin.venice.controllerapi.ControllerApiConstants.TIME_LAG_
 import static com.linkedin.venice.controllerapi.ControllerApiConstants.VERSION;
 import static com.linkedin.venice.controllerapi.ControllerApiConstants.WRITE_COMPUTATION_ENABLED;
 import static com.linkedin.venice.meta.HybridStoreConfigImpl.DEFAULT_REAL_TIME_TOPIC_NAME;
-import static org.mockito.Mockito.any;
-import static org.mockito.Mockito.anyBoolean;
-import static org.mockito.Mockito.anyDouble;
-import static org.mockito.Mockito.anyInt;
-import static org.mockito.Mockito.anyLong;
-import static org.mockito.Mockito.argThat;
-import static org.mockito.Mockito.atLeastOnce;
-import static org.mockito.Mockito.doAnswer;
-import static org.mockito.Mockito.doReturn;
-import static org.mockito.Mockito.doThrow;
-import static org.mockito.Mockito.eq;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.timeout;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 import com.linkedin.venice.admin.InMemoryAdminTopicMetadataAccessor;
 import com.linkedin.venice.admin.InMemoryExecutionIdAccessor;
 import com.linkedin.venice.common.VeniceSystemStoreType;
 import com.linkedin.venice.controller.AdminTopicMetadataAccessor;
 import com.linkedin.venice.controller.ExecutionIdAccessor;
+import com.linkedin.venice.controller.HelixVeniceClusterResources;
 import com.linkedin.venice.controller.VeniceHelixAdmin;
 import com.linkedin.venice.controller.kafka.AdminTopicUtils;
 import com.linkedin.venice.controller.kafka.protocol.admin.AddVersion;
@@ -97,6 +82,7 @@ import com.linkedin.venice.utils.TestUtils;
 import com.linkedin.venice.utils.Utils;
 import com.linkedin.venice.utils.VeniceProperties;
 import com.linkedin.venice.utils.concurrent.VeniceConcurrentHashMap;
+import com.linkedin.venice.utils.locks.ClusterLockManager;
 import com.linkedin.venice.writer.VeniceWriter;
 import com.linkedin.venice.writer.VeniceWriterOptions;
 import java.io.IOException;
@@ -189,6 +175,12 @@ public class AdminConsumptionTaskTest {
     doReturn(new HashSet<>(Arrays.asList(pubSubTopic))).when(topicManager).listTopics();
     doReturn(topicManager).when(admin).getTopicManager();
     doReturn(true).when(topicManager).containsTopicAndAllPartitionsAreOnline(pubSubTopic);
+
+    HelixVeniceClusterResources resources = mock(HelixVeniceClusterResources.class, RETURNS_DEEP_STUBS);
+    ClusterLockManager lockManager = new ClusterLockManager(clusterName);
+    doReturn(resources).when(admin).getHelixVeniceClusterResources(clusterName);
+    doReturn(lockManager).when(resources).getClusterLockManager();
+    doCallRealMethod().when(resources).getStoreMetadataRepository();
   }
 
   @AfterMethod

--- a/services/venice-controller/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
+++ b/services/venice-controller/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
@@ -1,0 +1,1 @@
+mock-maker-inline


### PR DESCRIPTION
## Summary
- Add admin operation version into ZK as a config and allow admin-tool to update the version. 
We will introduce a new field in adminTopicMetadata in ZK at cluster-level to store the admin operation version to serialize/deserialize the message.
- Add HTTP API for admin-tool to set the version.

## Why?
Please take a look at the design doc [here](https://docs.google.com/document/d/1JrLeuRzgW3VrYzWf844P8geD1vC1CZol6QCWDrD2pX0/edit?tab=t.0#heading=h.fut1ik6kdppl). This PR is the first step to remove protocol upgrade deployment order. The expectation is that, with the remote protocol version at cluster-level, the deserializer will use the version, which the writer used to serialize AdminOperation, to deserialize the message. We will fail fast if necessary if the schema versions mismatch.

## How was this PR tested?
added UTs and integration tests

## What's next?
Update the serializer to fetch the version in ZK before serialize the message, and pass over this version for deserializer to deserialize.

## Does this PR introduce any user-facing changes?
-  [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.