### PR TITLE
[server] Enhance the producer timestamp fetch logic to include both data and heartbeat messages.

### DIFF
--- a/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/manager/TopicMetadataFetcher.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/manager/TopicMetadataFetcher.java
@@ -504,7 +504,8 @@ class TopicMetadataFetcher implements Closeable {
       // iterate in reverse order to find the first data message (not control message) from the end
       for (int i = lastConsumedRecords.size() - 1; i >= 0; i--) {
         PubSubMessage<KafkaKey, KafkaMessageEnvelope, Long> record = lastConsumedRecords.get(i);
-        if (!record.getKey().isControlMessage()) {
+        if (!record.getKey().isControlMessage()
+            || Arrays.equals(record.getKey().getKey(), KafkaKey.HEART_BEAT.getKey())) {
           stats.recordLatency(GET_PRODUCER_TIMESTAMP_OF_LAST_DATA_MESSAGE, startTime);
           // note that the timestamp is the producer timestamp and not the pubsub message (broker) timestamp
           return record.getValue().getProducerMetadata().getMessageTimestamp();

--- a/internal/venice-common/src/test/java/com/linkedin/venice/pubsub/manager/TopicMetadataFetcherTest.java
+++ b/internal/venice-common/src/test/java/com/linkedin/venice/pubsub/manager/TopicMetadataFetcherTest.java
@@ -382,6 +382,15 @@ public class TopicMetadataFetcherTest {
     verify(consumerMock, times(2)).unSubscribe(eq(topicPartition));
   }
 
+  private PubSubMessage getHeartBeatPubSubMessage(PubSubTopicPartition topicPartition, long offset) {
+    KafkaKey key = KafkaKey.HEART_BEAT;
+    KafkaMessageEnvelope val = mock(KafkaMessageEnvelope.class);
+    ProducerMetadata producerMetadata = new ProducerMetadata();
+    producerMetadata.setMessageTimestamp(System.nanoTime());
+    when(val.getProducerMetadata()).thenReturn(producerMetadata);
+    return new ImmutablePubSubMessage(key, val, topicPartition, offset, System.currentTimeMillis(), 512);
+  }
+
   private PubSubMessage getPubSubMessage(PubSubTopicPartition topicPartition, boolean isControlMessage, long offset) {
     KafkaKey key = mock(KafkaKey.class);
     when(key.isControlMessage()).thenReturn(isControlMessage);
@@ -402,13 +411,19 @@ public class TopicMetadataFetcherTest {
     assertEquals(timestamp, PUBSUB_NO_PRODUCER_TIME_IN_EMPTY_TOPIC_PARTITION);
     verify(metadataFetcherSpy, times(1)).consumeLatestRecords(eq(topicPartition), anyInt());
 
-    // test when there are no data messages to consume
+    // test when there are no data messages and heartbeat messages to consume
     PubSubMessage<KafkaKey, KafkaMessageEnvelope, Long> cm = getPubSubMessage(topicPartition, true, 5);
     doReturn(Collections.singletonList(cm)).when(metadataFetcherSpy).consumeLatestRecords(eq(topicPartition), anyInt());
     Throwable t = expectThrows(
         VeniceException.class,
         () -> metadataFetcherSpy.getProducerTimestampOfLastDataMessage(topicPartition));
     assertTrue(t.getMessage().contains("No data message found in topic-partition"));
+
+    // test when there are heartbeat messages but no data messages to consume
+    PubSubMessage<KafkaKey, KafkaMessageEnvelope, Long> hm = getHeartBeatPubSubMessage(topicPartition, 6);
+    doReturn(Collections.singletonList(hm)).when(metadataFetcherSpy).consumeLatestRecords(eq(topicPartition), anyInt());
+    timestamp = metadataFetcherSpy.getProducerTimestampOfLastDataMessage(topicPartition);
+    assertEquals(timestamp, hm.getValue().getProducerMetadata().getMessageTimestamp());
 
     // test when there are data messages to consume
     PubSubMessage<KafkaKey, KafkaMessageEnvelope, Long> dm0 = getPubSubMessage(topicPartition, false, 4);


### PR DESCRIPTION
<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## Summary, imperative, start upper case, don't end with a period
<!--
Describe
- What changes to make and why you are making these changes.
- How are you going to achieve your goal.
- Describe what testings you have done, for example, performance testing etc.

If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->
Update the topic metadata producer timestamp fetch logic to include heartbeat messages. Previously, the getProducerTimestampOfLastDataMessage function only considered data messages when retrieving the producer timestamp from the most recent messages. However, for real-time topics without data ingestion, the last messages could be heartbeat control messages, causing endless searching during the ready-to-serve check due to the continuous arrival of new heartbeat messages.

## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [ ] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.