### PR TITLE
[server] Fix IndexOutOfBoundsException in memory usage in SBS

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreBufferService.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreBufferService.java
@@ -65,6 +65,8 @@ public class StoreBufferService extends AbstractStoreBufferService {
 
   private final boolean isSorted;
 
+  private boolean isStarted = false;
+
   public StoreBufferService(
       int drainerNum,
       long bufferCapacityPerDrainer,
@@ -308,6 +310,7 @@ public class StoreBufferService extends AbstractStoreBufferService {
       drainerList.add(drainer);
     }
     this.executorService.shutdown();
+    isStarted = true;
     return true;
   }
 
@@ -319,6 +322,7 @@ public class StoreBufferService extends AbstractStoreBufferService {
       this.executorService.shutdownNow();
       this.executorService.awaitTermination(10, TimeUnit.SECONDS);
     }
+    isStarted = false;
   }
 
   @Override
@@ -343,6 +347,10 @@ public class StoreBufferService extends AbstractStoreBufferService {
   public long getMaxMemoryUsagePerDrainer() {
     long maxUsage = 0;
     boolean slowDrainerExists = false;
+
+    if (!isStarted) {
+      return maxUsage;
+    }
 
     for (MemoryBoundBlockingQueue<QueueNode> queue: blockingQueueArr) {
       maxUsage = Math.max(maxUsage, queue.getMemoryUsage());

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreBufferService.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreBufferService.java
@@ -65,7 +65,7 @@ public class StoreBufferService extends AbstractStoreBufferService {
 
   private final boolean isSorted;
 
-  private boolean isStarted = false;
+  private volatile boolean isStarted = false;
 
   public StoreBufferService(
       int drainerNum,

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreBufferService.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreBufferService.java
@@ -317,12 +317,12 @@ public class StoreBufferService extends AbstractStoreBufferService {
   @Override
   public void stopInner() throws Exception {
     // Graceful shutdown
+    isStarted = false;
     drainerList.forEach(drainer -> drainer.stop());
     if (this.executorService != null) {
       this.executorService.shutdownNow();
       this.executorService.awaitTermination(10, TimeUnit.SECONDS);
     }
-    isStarted = false;
   }
 
   @Override


### PR DESCRIPTION
<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## Fix IndexOutOfBoundsException in memory usage in SBS
<!--
Describe
- What changes to make and why you are making these changes.
- How are you going to achieve your goal.
- Describe what testings you have done, for example, performance testing etc.

If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

Since the `drainerList` is allocated during startInner, initial metric calls to `StoreBufferServiceStats` would return `IndexOutOfBoundsException` in the code. This PR fixes that.

## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->

GHCI
## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.