### PR TITLE
[server][dvc] add table format info in the blob transfer

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/DaVinciBackend.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/DaVinciBackend.java
@@ -9,6 +9,7 @@ import static java.lang.Thread.currentThread;
 
 import com.linkedin.davinci.blobtransfer.BlobTransferManager;
 import com.linkedin.davinci.blobtransfer.BlobTransferUtil;
+import com.linkedin.davinci.blobtransfer.BlobTransferUtils.BlobTransferTableFormat;
 import com.linkedin.davinci.client.DaVinciRecordTransformerFunctionalInterface;
 import com.linkedin.davinci.compression.StorageEngineBackedCompressorFactory;
 import com.linkedin.davinci.config.StoreBackendConfig;
@@ -311,7 +312,10 @@ public class DaVinciBackend implements Closeable {
             backendConfig.getMaxConcurrentSnapshotUser(),
             backendConfig.getSnapshotRetentionTimeInMin(),
             backendConfig.getBlobTransferMaxTimeoutInMin(),
-            aggVersionedBlobTransferStats);
+            aggVersionedBlobTransferStats,
+            backendConfig.getRocksDBServerConfig().isRocksDBPlainTableFormatEnabled()
+                ? BlobTransferTableFormat.PLAIN_TABLE
+                : BlobTransferTableFormat.BLOCK_BASED_TABLE);
       } else {
         aggVersionedBlobTransferStats = null;
         blobTransferManager = null;

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/blobtransfer/BlobSnapshotManager.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/blobtransfer/BlobSnapshotManager.java
@@ -63,6 +63,7 @@ public class BlobSnapshotManager {
   private final StorageMetadataService storageMetadataService;
   private final int maxConcurrentUsers;
   private final long snapshotRetentionTimeInMillis;
+  private final BlobTransferUtils.BlobTransferTableFormat blobTransferTableFormat;
   private final Lock lock = new ReentrantLock();
 
   /**
@@ -73,13 +74,14 @@ public class BlobSnapshotManager {
       StorageEngineRepository storageEngineRepository,
       StorageMetadataService storageMetadataService,
       int maxConcurrentUsers,
-      int snapshotRetentionTimeInMin) {
+      int snapshotRetentionTimeInMin,
+      BlobTransferUtils.BlobTransferTableFormat transferTableFormat) {
     this.readOnlyStoreRepository = readOnlyStoreRepository;
     this.storageEngineRepository = storageEngineRepository;
     this.storageMetadataService = storageMetadataService;
     this.maxConcurrentUsers = maxConcurrentUsers;
     this.snapshotRetentionTimeInMillis = TimeUnit.MINUTES.toMillis(snapshotRetentionTimeInMin);
-
+    this.blobTransferTableFormat = transferTableFormat;
     this.concurrentSnapshotUsers = new VeniceConcurrentHashMap<>();
     this.snapshotTimestamps = new VeniceConcurrentHashMap<>();
     this.snapshotMetadataRecords = new VeniceConcurrentHashMap<>();
@@ -99,7 +101,8 @@ public class BlobSnapshotManager {
         storageEngineRepository,
         storageMetadataService,
         DEFAULT_MAX_CONCURRENT_USERS,
-        DEFAULT_SNAPSHOT_RETENTION_TIME_IN_MIN);
+        DEFAULT_SNAPSHOT_RETENTION_TIME_IN_MIN,
+        BlobTransferUtils.BlobTransferTableFormat.BLOCK_BASED_TABLE);
   }
 
   /**
@@ -363,5 +366,13 @@ public class BlobSnapshotManager {
         blobTransferRequest.getPartition(),
         offsetRecordByte,
         storeVersionStateByte);
+  }
+
+  /**
+   * Get the current snapshot format, which is a config value.
+   * @return the transfer table format, BLOCK_BASED_TABLE or PLAIN_TABLE.
+   */
+  public BlobTransferUtils.BlobTransferTableFormat getBlobTransferTableFormat() {
+    return this.blobTransferTableFormat;
   }
 }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/blobtransfer/BlobTransferManager.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/blobtransfer/BlobTransferManager.java
@@ -1,5 +1,6 @@
 package com.linkedin.davinci.blobtransfer;
 
+import com.linkedin.davinci.blobtransfer.BlobTransferUtils.BlobTransferTableFormat;
 import com.linkedin.davinci.stats.AggVersionedBlobTransferStats;
 import com.linkedin.venice.annotation.Experimental;
 import com.linkedin.venice.exceptions.VenicePeersNotFoundException;
@@ -26,13 +27,17 @@ public interface BlobTransferManager<T> extends AutoCloseable {
    * @param storeName
    * @param version
    * @param partition
+   * @param requestTableFormat the table format defined in config (PLAIN_TABLE or BLOCK_BASED_TABLE).
    * @return the InputStream of the blob. The return type is experimental and may change in the future.
    * @throws VenicePeersNotFoundException when the peers are not found for the requested blob. Other exceptions may be
    * thrown, but it's wrapped inside the CompletionStage.
    */
   @Experimental
-  CompletionStage<? extends InputStream> get(String storeName, int version, int partition)
-      throws VenicePeersNotFoundException;
+  CompletionStage<? extends InputStream> get(
+      String storeName,
+      int version,
+      int partition,
+      BlobTransferTableFormat requestTableFormat) throws VenicePeersNotFoundException;
 
   /**
    * Put the blob for the given storeName and partition

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/blobtransfer/BlobTransferPayload.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/blobtransfer/BlobTransferPayload.java
@@ -3,6 +3,7 @@ package com.linkedin.davinci.blobtransfer;
 import static com.linkedin.venice.store.rocksdb.RocksDBUtils.composePartitionDbDir;
 import static com.linkedin.venice.store.rocksdb.RocksDBUtils.composeSnapshotDir;
 
+import com.linkedin.davinci.blobtransfer.BlobTransferUtils.BlobTransferTableFormat;
 import com.linkedin.venice.utils.Utils;
 
 
@@ -14,12 +15,19 @@ public class BlobTransferPayload {
   private final String topicName;
   private final String partitionDir;
   private final String storeName;
+  private final BlobTransferTableFormat requestTableFormat;
 
-  public BlobTransferPayload(String baseDir, String storeName, int version, int partition) {
+  public BlobTransferPayload(
+      String baseDir,
+      String storeName,
+      int version,
+      int partition,
+      BlobTransferTableFormat requestTableFormat) {
     this.partition = partition;
     this.storeName = storeName;
     this.topicName = storeName + "_v" + version;
     this.partitionDir = composePartitionDbDir(baseDir, topicName, partition);
+    this.requestTableFormat = requestTableFormat;
   }
 
   public String getPartitionDir() {
@@ -44,5 +52,9 @@ public class BlobTransferPayload {
 
   public String getStoreName() {
     return storeName;
+  }
+
+  public BlobTransferTableFormat getRequestTableFormat() {
+    return requestTableFormat;
   }
 }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/blobtransfer/BlobTransferUtil.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/blobtransfer/BlobTransferUtil.java
@@ -41,7 +41,8 @@ public class BlobTransferUtil {
       int maxConcurrentSnapshotUser,
       int snapshotRetentionTimeInMin,
       int blobTransferMaxTimeoutInMin,
-      AggVersionedBlobTransferStats aggVersionedBlobTransferStats) {
+      AggVersionedBlobTransferStats aggVersionedBlobTransferStats,
+      BlobTransferUtils.BlobTransferTableFormat transferSnapshotTableFormat) {
     return getP2PBlobTransferManagerForDVCAndStart(
         p2pTransferPort,
         p2pTransferPort,
@@ -53,7 +54,8 @@ public class BlobTransferUtil {
         maxConcurrentSnapshotUser,
         snapshotRetentionTimeInMin,
         blobTransferMaxTimeoutInMin,
-        aggVersionedBlobTransferStats);
+        aggVersionedBlobTransferStats,
+        transferSnapshotTableFormat);
   }
 
   public static BlobTransferManager<Void> getP2PBlobTransferManagerForDVCAndStart(
@@ -67,14 +69,16 @@ public class BlobTransferUtil {
       int maxConcurrentSnapshotUser,
       int snapshotRetentionTimeInMin,
       int blobTransferMaxTimeoutInMin,
-      AggVersionedBlobTransferStats aggVersionedBlobTransferStats) {
+      AggVersionedBlobTransferStats aggVersionedBlobTransferStats,
+      BlobTransferUtils.BlobTransferTableFormat transferSnapshotTableFormat) {
     try {
       BlobSnapshotManager blobSnapshotManager = new BlobSnapshotManager(
           readOnlyStoreRepository,
           storageEngineRepository,
           storageMetadataService,
           maxConcurrentSnapshotUser,
-          snapshotRetentionTimeInMin);
+          snapshotRetentionTimeInMin,
+          transferSnapshotTableFormat);
       AbstractAvroStoreClient storeClient =
           new AvroGenericStoreClientImpl<>(getTransportClient(clientConfig), false, clientConfig);
       BlobTransferManager<Void> manager = new NettyP2PBlobTransferManager(
@@ -111,14 +115,16 @@ public class BlobTransferUtil {
       int maxConcurrentSnapshotUser,
       int snapshotRetentionTimeInMin,
       int blobTransferMaxTimeoutInMin,
-      AggVersionedBlobTransferStats aggVersionedBlobTransferStats) {
+      AggVersionedBlobTransferStats aggVersionedBlobTransferStats,
+      BlobTransferUtils.BlobTransferTableFormat transferSnapshotTableFormat) {
     try {
       BlobSnapshotManager blobSnapshotManager = new BlobSnapshotManager(
           readOnlyStoreRepository,
           storageEngineRepository,
           storageMetadataService,
           maxConcurrentSnapshotUser,
-          snapshotRetentionTimeInMin);
+          snapshotRetentionTimeInMin,
+          transferSnapshotTableFormat);
       BlobTransferManager<Void> manager = new NettyP2PBlobTransferManager(
           new P2PBlobTransferService(p2pTransferServerPort, baseDir, blobTransferMaxTimeoutInMin, blobSnapshotManager),
           new NettyFileTransferClient(p2pTransferClientPort, baseDir, storageMetadataService),

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/blobtransfer/BlobTransferUtils.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/blobtransfer/BlobTransferUtils.java
@@ -22,6 +22,10 @@ public class BlobTransferUtils {
     FILE, METADATA
   }
 
+  public enum BlobTransferTableFormat {
+    PLAIN_TABLE, BLOCK_BASED_TABLE
+  }
+
   /**
    * Check if the HttpResponse message is for metadata.
    * @param msg the HttpResponse message

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/blobtransfer/client/P2PFileTransferClientHandler.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/blobtransfer/client/P2PFileTransferClientHandler.java
@@ -56,9 +56,10 @@ public class P2PFileTransferClientHandler extends SimpleChannelInboundHandler<Ht
       CompletionStage<InputStream> inputStreamFuture,
       String storeName,
       int version,
-      int partition) {
+      int partition,
+      BlobTransferUtils.BlobTransferTableFormat tableFormat) {
     this.inputStreamFuture = inputStreamFuture;
-    this.payload = new BlobTransferPayload(baseDir, storeName, version, partition);
+    this.payload = new BlobTransferPayload(baseDir, storeName, version, partition, tableFormat);
   }
 
   @Override

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/blobtransfer/client/P2PMetadataTransferHandler.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/blobtransfer/client/P2PMetadataTransferHandler.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.annotations.VisibleForTesting;
 import com.linkedin.davinci.blobtransfer.BlobTransferPartitionMetadata;
 import com.linkedin.davinci.blobtransfer.BlobTransferPayload;
+import com.linkedin.davinci.blobtransfer.BlobTransferUtils.BlobTransferTableFormat;
 import com.linkedin.davinci.storage.StorageMetadataService;
 import com.linkedin.venice.exceptions.VeniceException;
 import com.linkedin.venice.kafka.protocol.state.PartitionState;
@@ -41,9 +42,10 @@ public class P2PMetadataTransferHandler extends SimpleChannelInboundHandler<Full
       String baseDir,
       String storeName,
       int version,
-      int partition) {
+      int partition,
+      BlobTransferTableFormat tableFormat) {
     this.storageMetadataService = storageMetadataService;
-    this.payload = new BlobTransferPayload(baseDir, storeName, version, partition);
+    this.payload = new BlobTransferPayload(baseDir, storeName, version, partition, tableFormat);
   }
 
   @Override

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/blobtransfer/server/P2PFileTransferServerHandler.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/blobtransfer/server/P2PFileTransferServerHandler.java
@@ -3,6 +3,7 @@ package com.linkedin.davinci.blobtransfer.server;
 import static com.linkedin.davinci.blobtransfer.BlobTransferUtils.BLOB_TRANSFER_COMPLETED;
 import static com.linkedin.davinci.blobtransfer.BlobTransferUtils.BLOB_TRANSFER_STATUS;
 import static com.linkedin.davinci.blobtransfer.BlobTransferUtils.BLOB_TRANSFER_TYPE;
+import static com.linkedin.davinci.blobtransfer.BlobTransferUtils.BlobTransferTableFormat;
 import static com.linkedin.davinci.blobtransfer.BlobTransferUtils.BlobTransferType;
 import static com.linkedin.venice.utils.NettyUtils.setupResponseAndFlush;
 import static io.netty.handler.codec.http.HttpHeaderValues.APPLICATION_JSON;
@@ -118,6 +119,16 @@ public class P2PFileTransferServerHandler extends SimpleChannelInboundHandler<Fu
 
         if (!snapshotDir.exists() || !snapshotDir.isDirectory()) {
           byte[] errBody = ("Snapshot for " + blobTransferRequest.getFullResourceName() + " doesn't exist").getBytes();
+          setupResponseAndFlush(HttpResponseStatus.NOT_FOUND, errBody, false, ctx);
+          return;
+        }
+
+        // Check the snapshot table format
+        BlobTransferTableFormat currentSnapshotTableFormat = blobSnapshotManager.getBlobTransferTableFormat();
+        if (!blobTransferRequest.getRequestTableFormat().name().equals(currentSnapshotTableFormat.name())) {
+          byte[] errBody = ("Table format mismatch for " + blobTransferRequest.getFullResourceName()
+              + ", current snapshot format is " + currentSnapshotTableFormat.name() + ", requested format is "
+              + blobTransferRequest.getRequestTableFormat().name()).getBytes();
           setupResponseAndFlush(HttpResponseStatus.NOT_FOUND, errBody, false, ctx);
           return;
         }
@@ -278,13 +289,24 @@ public class P2PFileTransferServerHandler extends SimpleChannelInboundHandler<Fu
   private BlobTransferPayload parseBlobTransferPayload(URI uri) throws IllegalArgumentException {
     // Parse the request uri to obtain the storeName and partition
     String[] requestParts = RequestHelper.getRequestParts(uri);
-    if (requestParts.length == 4) {
-      // [0]""/[1]"store"/[2]"version"/[3]"partition"
+
+    // Ensure table format is valid
+    BlobTransferTableFormat requestTableFormat;
+    try {
+      requestTableFormat = BlobTransferTableFormat.valueOf(requestParts[4]);
+    } catch (IllegalArgumentException e) {
+      throw new IllegalArgumentException(
+          "Invalid table format: " + requestParts[4] + " for fetching blob at " + uri.getPath());
+    }
+
+    if (requestParts.length == 5) {
+      // [0]""/[1]"store"/[2]"version"/[3]"partition/[4]"table format"
       return new BlobTransferPayload(
           baseDir,
           requestParts[1],
           Integer.parseInt(requestParts[2]),
-          Integer.parseInt(requestParts[3]));
+          Integer.parseInt(requestParts[3]),
+          requestTableFormat);
     } else {
       throw new IllegalArgumentException("Invalid request for fetching blob at " + uri.getPath());
     }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/blobtransfer/server/P2PFileTransferServerHandler.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/blobtransfer/server/P2PFileTransferServerHandler.java
@@ -125,7 +125,7 @@ public class P2PFileTransferServerHandler extends SimpleChannelInboundHandler<Fu
 
         // Check the snapshot table format
         BlobTransferTableFormat currentSnapshotTableFormat = blobSnapshotManager.getBlobTransferTableFormat();
-        if (!blobTransferRequest.getRequestTableFormat().name().equals(currentSnapshotTableFormat.name())) {
+        if (blobTransferRequest.getRequestTableFormat() != currentSnapshotTableFormat) {
           byte[] errBody = ("Table format mismatch for " + blobTransferRequest.getFullResourceName()
               + ", current snapshot format is " + currentSnapshotTableFormat.name() + ", requested format is "
               + blobTransferRequest.getRequestTableFormat().name()).getBytes();

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/blobtransfer/BlobSnapshotManagerTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/blobtransfer/BlobSnapshotManagerTest.java
@@ -1,5 +1,6 @@
 package com.linkedin.davinci.blobtransfer;
 
+import static com.linkedin.davinci.blobtransfer.BlobTransferUtils.BlobTransferTableFormat;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doReturn;
@@ -54,8 +55,12 @@ public class BlobSnapshotManagerTest {
       new BlobTransferPartitionMetadata();
   private static final String DB_DIR = BASE_PATH + "/" + STORE_NAME + "_v" + VERSION_ID + "/"
       + RocksDBUtils.getPartitionDbName(STORE_NAME + "_v" + VERSION_ID, PARTITION_ID);
-  private static final BlobTransferPayload blobTransferPayload =
-      new BlobTransferPayload(BASE_PATH, STORE_NAME, VERSION_ID, PARTITION_ID);
+  private static final BlobTransferPayload blobTransferPayload = new BlobTransferPayload(
+      BASE_PATH,
+      STORE_NAME,
+      VERSION_ID,
+      PARTITION_ID,
+      BlobTransferTableFormat.BLOCK_BASED_TABLE);
 
   @Test(timeOut = TIMEOUT)
   public void testHybridSnapshot() {

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/blobtransfer/TestP2PFileTransferClientHandler.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/blobtransfer/TestP2PFileTransferClientHandler.java
@@ -72,7 +72,8 @@ public class TestP2PFileTransferClientHandler {
             inputStreamFuture,
             TEST_STORE,
             TEST_VERSION,
-            TEST_PARTITION));
+            TEST_PARTITION,
+            BlobTransferUtils.BlobTransferTableFormat.BLOCK_BASED_TABLE));
 
     clientMetadataHandler = Mockito.spy(
         new P2PMetadataTransferHandler(
@@ -80,7 +81,8 @@ public class TestP2PFileTransferClientHandler {
             baseDir.toString(),
             TEST_STORE,
             TEST_VERSION,
-            TEST_PARTITION));
+            TEST_PARTITION,
+            BlobTransferUtils.BlobTransferTableFormat.BLOCK_BASED_TABLE));
 
     Mockito.doNothing().when(clientMetadataHandler).updateStorePartitionMetadata(Mockito.any(), Mockito.any());
 
@@ -216,7 +218,12 @@ public class TestP2PFileTransferClientHandler {
     inputStreamFuture.toCompletableFuture().get(1, TimeUnit.MINUTES);
 
     // verify the content is written to the disk
-    BlobTransferPayload payload = new BlobTransferPayload(baseDir.toString(), TEST_STORE, TEST_VERSION, TEST_PARTITION);
+    BlobTransferPayload payload = new BlobTransferPayload(
+        baseDir.toString(),
+        TEST_STORE,
+        TEST_VERSION,
+        TEST_PARTITION,
+        BlobTransferUtils.BlobTransferTableFormat.BLOCK_BASED_TABLE);
     Path dest = Paths.get(payload.getPartitionDir());
     Assert.assertTrue(Files.exists(dest));
     Assert.assertTrue(Files.isDirectory(dest));
@@ -259,7 +266,12 @@ public class TestP2PFileTransferClientHandler {
     inputStreamFuture.toCompletableFuture().get(1, TimeUnit.MINUTES);
 
     // verify the content is written to the disk
-    BlobTransferPayload payload = new BlobTransferPayload(baseDir.toString(), TEST_STORE, TEST_VERSION, TEST_PARTITION);
+    BlobTransferPayload payload = new BlobTransferPayload(
+        baseDir.toString(),
+        TEST_STORE,
+        TEST_VERSION,
+        TEST_PARTITION,
+        BlobTransferUtils.BlobTransferTableFormat.BLOCK_BASED_TABLE);
     Path dest = Paths.get(payload.getPartitionDir());
     Assert.assertTrue(Files.exists(dest));
     Assert.assertTrue(Files.isDirectory(dest));
@@ -381,7 +393,12 @@ public class TestP2PFileTransferClientHandler {
     inputStreamFuture.toCompletableFuture().get(1, TimeUnit.MINUTES);
 
     // Verify the files are written to disk
-    BlobTransferPayload payload = new BlobTransferPayload(baseDir.toString(), TEST_STORE, TEST_VERSION, TEST_PARTITION);
+    BlobTransferPayload payload = new BlobTransferPayload(
+        baseDir.toString(),
+        TEST_STORE,
+        TEST_VERSION,
+        TEST_PARTITION,
+        BlobTransferUtils.BlobTransferTableFormat.BLOCK_BASED_TABLE);
     Path dest = Paths.get(payload.getPartitionDir());
     Assert.assertTrue(Files.exists(dest));
     Assert.assertTrue(Files.isDirectory(dest));

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/BlobP2PTransferAmongServersTest.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/BlobP2PTransferAmongServersTest.java
@@ -37,7 +37,6 @@ import org.apache.logging.log4j.Logger;
 import org.apache.samza.system.SystemProducer;
 import org.testng.Assert;
 import org.testng.annotations.AfterMethod;
-import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 
@@ -47,12 +46,9 @@ public class BlobP2PTransferAmongServersTest {
   private static final int STREAMING_RECORD_SIZE = 1024;
   private String path1;
   private String path2;
+  private int server1Port;
+  private int server2Port;
   private VeniceClusterWrapper cluster;
-
-  @BeforeMethod(alwaysRun = true)
-  public void setUp() {
-    cluster = initializeVeniceCluster();
-  }
 
   @AfterMethod(alwaysRun = true)
   public void tearDown() {
@@ -68,12 +64,14 @@ public class BlobP2PTransferAmongServersTest {
 
   @Test(singleThreaded = true, timeOut = 180000)
   public void testBlobP2PTransferAmongServersForBatchStore() throws Exception {
+    cluster = initializeVeniceCluster();
+
     String storeName = "test-store";
     Consumer<UpdateStoreQueryParams> paramsConsumer = params -> params.setBlobTransferEnabled(true);
     setUpBatchStore(cluster, storeName, paramsConsumer, properties -> {}, true);
 
-    VeniceServerWrapper server1 = cluster.getVeniceServers().get(0);
-    VeniceServerWrapper server2 = cluster.getVeniceServers().get(1);
+    VeniceServerWrapper server1 = cluster.getVeniceServerByPort(server1Port);
+    VeniceServerWrapper server2 = cluster.getVeniceServerByPort(server2Port);
 
     // verify the snapshot is generated for both servers after the job is done
     for (int partitionId = 0; partitionId < PARTITION_COUNT; partitionId++) {
@@ -97,7 +95,7 @@ public class BlobP2PTransferAmongServersTest {
           Files.exists(Paths.get(RocksDBUtils.composeSnapshotDir(path1 + "/rocksdb", storeName + "_v1", partitionId))));
     }
 
-    cluster.stopAndRestartVeniceServer(server1.getPort());
+    cluster.stopAndRestartVeniceServer(server1Port);
     TestUtils.waitForNonDeterministicAssertion(2, TimeUnit.MINUTES, () -> {
       Assert.assertTrue(server1.isRunning());
     });
@@ -121,6 +119,11 @@ public class BlobP2PTransferAmongServersTest {
         File file = new File(RocksDBUtils.composePartitionDbDir(path1 + "/rocksdb", storeName + "_v1", partitionId));
         Boolean fileExisted = Files.exists(file.toPath());
         Assert.assertTrue(fileExisted);
+        // ensure the snapshot file is not generated
+        File snapshotFile =
+            new File(RocksDBUtils.composeSnapshotDir(path1 + "/rocksdb", storeName + "_v1", partitionId));
+        Boolean snapshotFileExisted = Files.exists(snapshotFile.toPath());
+        Assert.assertFalse(snapshotFileExisted);
       }
     });
 
@@ -141,12 +144,12 @@ public class BlobP2PTransferAmongServersTest {
    */
   @Test(singleThreaded = true, timeOut = 180000)
   public void testBlobTransferThrowExceptionIfSnapshotNotExisted() throws Exception {
+    cluster = initializeVeniceCluster();
     String storeName = "test-store-snapshot-not-existed";
     Consumer<UpdateStoreQueryParams> paramsConsumer = params -> params.setBlobTransferEnabled(true);
     setUpBatchStore(cluster, storeName, paramsConsumer, properties -> {}, true);
 
-    VeniceServerWrapper server1 = cluster.getVeniceServers().get(0);
-
+    VeniceServerWrapper server1 = cluster.getVeniceServerByPort(server1Port);
     // verify the snapshot is generated for both servers after the job is done
     for (int i = 0; i < PARTITION_COUNT; i++) {
       String snapshotPath1 = RocksDBUtils.composeSnapshotDir(path1 + "/rocksdb", storeName + "_v1", i);
@@ -176,7 +179,7 @@ public class BlobP2PTransferAmongServersTest {
       }
     }
 
-    cluster.stopAndRestartVeniceServer(server1.getPort());
+    cluster.stopAndRestartVeniceServer(server1Port);
     TestUtils.waitForNonDeterministicAssertion(2, TimeUnit.MINUTES, () -> {
       Assert.assertTrue(server1.isRunning());
     });
@@ -207,7 +210,81 @@ public class BlobP2PTransferAmongServersTest {
     });
   }
 
+  /**
+   * Test when the format of the rocksdb is different between two servers,
+   * the blob transfer should throw an exception and return a 404 error.
+   */
+  @Test(singleThreaded = true, timeOut = 180000)
+  public void testBlobTransferThrowExceptionIfTableFormatNotMatch() throws Exception {
+    cluster = initializeVeniceCluster(false);
+
+    String storeName = "test-store-format-not-match";
+    Consumer<UpdateStoreQueryParams> paramsConsumer = params -> params.setBlobTransferEnabled(true);
+    setUpBatchStore(cluster, storeName, paramsConsumer, properties -> {}, true);
+
+    VeniceServerWrapper server1 = cluster.getVeniceServerByPort(server1Port);
+
+    // verify the snapshot is generated for both servers after the job is done
+    for (int partitionId = 0; partitionId < PARTITION_COUNT; partitionId++) {
+      String snapshotPath1 = RocksDBUtils.composeSnapshotDir(path1 + "/rocksdb", storeName + "_v1", partitionId);
+      Assert.assertTrue(Files.exists(Paths.get(snapshotPath1)));
+      String snapshotPath2 = RocksDBUtils.composeSnapshotDir(path2 + "/rocksdb", storeName + "_v1", partitionId);
+      Assert.assertTrue(Files.exists(Paths.get(snapshotPath2)));
+    }
+
+    // cleanup and restart server 1
+    FileUtils.deleteDirectory(
+        new File(RocksDBUtils.composePartitionDbDir(path1 + "/rocksdb", storeName + "_v1", METADATA_PARTITION_ID)));
+    for (int partitionId = 0; partitionId < PARTITION_COUNT; partitionId++) {
+      FileUtils.deleteDirectory(
+          new File(RocksDBUtils.composePartitionDbDir(path1 + "/rocksdb", storeName + "_v1", partitionId)));
+      // both partition db and snapshot should be deleted
+      Assert.assertFalse(
+          Files.exists(
+              Paths.get(RocksDBUtils.composePartitionDbDir(path1 + "/rocksdb", storeName + "_v1", partitionId))));
+      Assert.assertFalse(
+          Files.exists(Paths.get(RocksDBUtils.composeSnapshotDir(path1 + "/rocksdb", storeName + "_v1", partitionId))));
+    }
+
+    cluster.stopAndRestartVeniceServer(server1Port);
+    TestUtils.waitForNonDeterministicAssertion(2, TimeUnit.MINUTES, () -> {
+      Assert.assertTrue(server1.isRunning());
+    });
+
+    // wait for server 1
+    cluster.getVeniceControllers().forEach(controller -> {
+      TestUtils.waitForNonDeterministicAssertion(2, TimeUnit.MINUTES, () -> {
+        Assert.assertEquals(
+            controller.getController()
+                .getVeniceControllerService()
+                .getVeniceHelixAdmin()
+                .getAllStoreStatuses(cluster.getClusterName())
+                .get(storeName),
+            FULLLY_REPLICATED.toString());
+      });
+    });
+
+    TestUtils.waitForNonDeterministicAssertion(2, TimeUnit.MINUTES, () -> {
+      for (int partitionId = 0; partitionId < PARTITION_COUNT; partitionId++) {
+        File file = new File(RocksDBUtils.composePartitionDbDir(path1 + "/rocksdb", storeName + "_v1", partitionId));
+        Boolean fileExisted = Files.exists(file.toPath());
+        Assert.assertTrue(fileExisted);
+        // ensure that the snapshot file is generated as it is re-ingested, not from server2 file transfer
+        File snapshotFile =
+            new File(RocksDBUtils.composeSnapshotDir(path1 + "/rocksdb", storeName + "_v1", partitionId));
+        Boolean snapshotFileExisted = Files.exists(snapshotFile.toPath());
+        Assert.assertTrue(snapshotFileExisted);
+      }
+    });
+  }
+
   public VeniceClusterWrapper initializeVeniceCluster() {
+    return initializeVeniceCluster(true);
+  }
+
+  public VeniceClusterWrapper initializeVeniceCluster(boolean sameRocksDBFormat) {
+    server1Port = -1;
+    server2Port = -1;
     path1 = Utils.getTempDataDirectory().getAbsolutePath();
     path2 = Utils.getTempDataDirectory().getAbsolutePath();
 
@@ -231,6 +308,8 @@ public class BlobP2PTransferAmongServersTest {
     serverProperties.setProperty(ConfigKeys.DAVINCI_P2P_BLOB_TRANSFER_CLIENT_PORT, String.valueOf(port2));
     serverProperties.setProperty(ConfigKeys.BLOB_TRANSFER_MANAGER_ENABLED, "true");
     veniceClusterWrapper.addVeniceServer(new Properties(), serverProperties);
+    // get the first port id for finding first server.
+    server1Port = veniceClusterWrapper.getVeniceServers().get(0).getPort();
 
     // add second server
     serverProperties.setProperty(ConfigKeys.DATA_BASE_PATH, path2);
@@ -238,7 +317,20 @@ public class BlobP2PTransferAmongServersTest {
     serverProperties.setProperty(ConfigKeys.BLOB_TRANSFER_MANAGER_ENABLED, "true");
     serverProperties.setProperty(ConfigKeys.DAVINCI_P2P_BLOB_TRANSFER_SERVER_PORT, String.valueOf(port2));
     serverProperties.setProperty(ConfigKeys.DAVINCI_P2P_BLOB_TRANSFER_CLIENT_PORT, String.valueOf(port1));
+
+    if (!sameRocksDBFormat) {
+      // the second server use PLAIN_TABLE_FORMAT
+      serverProperties.setProperty(ROCKSDB_PLAIN_TABLE_FORMAT_ENABLED, "true");
+    }
+
     veniceClusterWrapper.addVeniceServer(new Properties(), serverProperties);
+    // get the second port num for finding second server,
+    // because the order of servers is not guaranteed, need to exclude the first server.
+    for (VeniceServerWrapper server: veniceClusterWrapper.getVeniceServers()) {
+      if (server.getPort() != server1Port) {
+        server2Port = server.getPort();
+      }
+    }
 
     Properties routerProperties = new Properties();
     routerProperties.put(ConfigKeys.ROUTER_CLIENT_DECOMPRESSION_ENABLED, "true");
@@ -288,6 +380,8 @@ public class BlobP2PTransferAmongServersTest {
 
   @Test(singleThreaded = true, timeOut = 180000)
   public void testBlobP2PTransferAmongServersForHybridStore() throws Exception {
+    cluster = initializeVeniceCluster();
+
     ControllerClient controllerClient = new ControllerClient(cluster.getClusterName(), cluster.getAllControllersURLs());
     // prepare hybrid store.
     String storeName = "test-store-hybrid";
@@ -303,8 +397,8 @@ public class BlobP2PTransferAmongServersTest {
 
     TestUtils.assertCommand(
         controllerClient.sendEmptyPushAndWait(storeName, Utils.getUniqueString("empty-hybrid-push"), 1L, 120000));
-    VeniceServerWrapper server1 = cluster.getVeniceServers().get(0);
-    VeniceServerWrapper server2 = cluster.getVeniceServers().get(1);
+    VeniceServerWrapper server1 = cluster.getVeniceServerByPort(server1Port);
+    VeniceServerWrapper server2 = cluster.getVeniceServerByPort(server2Port);
 
     // offset record should be same after the empty push
     TestUtils.waitForNonDeterministicAssertion(2, TimeUnit.MINUTES, () -> {
@@ -318,7 +412,7 @@ public class BlobP2PTransferAmongServersTest {
     });
 
     // cleanup and stop server 1
-    cluster.stopVeniceServer(server1.getPort());
+    cluster.stopVeniceServer(server1Port);
     FileUtils.deleteDirectory(
         new File(RocksDBUtils.composePartitionDbDir(path1 + "/rocksdb", storeName + "_v1", METADATA_PARTITION_ID)));
     for (int partitionId = 0; partitionId < PARTITION_COUNT; partitionId++) {
@@ -366,6 +460,11 @@ public class BlobP2PTransferAmongServersTest {
         File file = new File(RocksDBUtils.composePartitionDbDir(path1 + "/rocksdb", storeName + "_v1", partitionId));
         Boolean fileExisted = Files.exists(file.toPath());
         Assert.assertTrue(fileExisted);
+        // ensure that the snapshot is not generated.
+        File snapshotFile =
+            new File(RocksDBUtils.composeSnapshotDir(path1 + "/rocksdb", storeName + "_v1", partitionId));
+        Boolean snapshotFileExisted = Files.exists(snapshotFile.toPath());
+        Assert.assertFalse(snapshotFileExisted);
       }
     });
 

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/integration/utils/VeniceClusterWrapper.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/integration/utils/VeniceClusterWrapper.java
@@ -493,6 +493,10 @@ public class VeniceClusterWrapper extends ProcessWrapper {
     return new ArrayList<>(veniceServerWrappers.values());
   }
 
+  public synchronized VeniceServerWrapper getVeniceServerByPort(int port) {
+    return veniceServerWrappers.get(port);
+  }
+
   public synchronized Map<String, String> getNettyServerToGrpcAddress() {
     return nettyServerToGrpcAddress;
   }

--- a/services/venice-server/src/main/java/com/linkedin/venice/server/VeniceServer.java
+++ b/services/venice-server/src/main/java/com/linkedin/venice/server/VeniceServer.java
@@ -3,6 +3,7 @@ package com.linkedin.venice.server;
 import com.linkedin.avro.fastserde.FastDeserializerGeneratorAccessor;
 import com.linkedin.davinci.blobtransfer.BlobTransferManager;
 import com.linkedin.davinci.blobtransfer.BlobTransferUtil;
+import com.linkedin.davinci.blobtransfer.BlobTransferUtils.BlobTransferTableFormat;
 import com.linkedin.davinci.compression.StorageEngineBackedCompressorFactory;
 import com.linkedin.davinci.config.VeniceClusterConfig;
 import com.linkedin.davinci.config.VeniceConfigLoader;
@@ -473,7 +474,10 @@ public class VeniceServer {
           serverConfig.getMaxConcurrentSnapshotUser(),
           serverConfig.getSnapshotRetentionTimeInMin(),
           serverConfig.getBlobTransferMaxTimeoutInMin(),
-          aggVersionedBlobTransferStats);
+          aggVersionedBlobTransferStats,
+          serverConfig.getRocksDBServerConfig().isRocksDBPlainTableFormatEnabled()
+              ? BlobTransferTableFormat.PLAIN_TABLE
+              : BlobTransferTableFormat.BLOCK_BASED_TABLE);
     } else {
       aggVersionedBlobTransferStats = null;
       blobTransferManager = null;


### PR DESCRIPTION
<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## [server][dvc] add table format info in the blob transfer
<!--
Describe
- What changes to make and why you are making these changes.
- How are you going to achieve your goal.
- Describe what testings you have done, for example, performance testing etc.

If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

There is an edge case where multiple file formats may coexist within a single cluster. For instance, DVC1 might use a plain-table format while DVC2 uses a block-based format. If DVC2 requests data from DVC1 during bootstrap, it could end up with a plain-table store in DVC2, leading to read issues.

This PR addresses the issue by:

- Receiver side: Including the table format in the bootstrap request URI. An example URI: `[0]""/[1]"store"/[2]"version"/[3]"partition/[4]"table format"`.

- Sender side: Storing the current snapshot format in the snapshot manager. When a bootstrap request arrives, the snapshot manager compares the existing snapshot format with the requested table format. If they do not match, it returns a 404 error to reject the blob transfer request.

## How was this PR tested?
Integration test "testBlobTransferThrowExceptionIfTableFormatNotMatch".
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.