### PR TITLE
[duckdb] Avro to SQL converter

### DIFF
--- a/integrations/venice-duckdb/build.gradle
+++ b/integrations/venice-duckdb/build.gradle
@@ -1,5 +1,6 @@
 dependencies {
   implementation libraries.avro
+  implementation libraries.avroUtilCompatHelper
   implementation libraries.duckdbJdbc
 }
 

--- a/integrations/venice-duckdb/build.gradle
+++ b/integrations/venice-duckdb/build.gradle
@@ -1,4 +1,5 @@
 dependencies {
+  implementation libraries.avro
   implementation libraries.duckdbJdbc
 }
 

--- a/integrations/venice-duckdb/src/main/java/com/linkedin/venice/sql/AvroToSQL.java
+++ b/integrations/venice-duckdb/src/main/java/com/linkedin/venice/sql/AvroToSQL.java
@@ -1,0 +1,139 @@
+package com.linkedin.venice.sql;
+
+import java.sql.JDBCType;
+import java.util.Collections;
+import java.util.EnumMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.apache.avro.Schema;
+
+
+/**
+ * Utility intended to convert Avro -> SQL, including DDL and DML statements.
+ *
+ * Initially, this implementation may have a DuckDB slant, though in the long-run it should ideally be vendor-neutral.
+ */
+public class AvroToSQL {
+  public enum UnsupportedTypeHandling {
+    FAIL, SKIP;
+  }
+
+  private static final Map<Schema.Type, JDBCType> AVRO_TO_JDBC_TYPE_MAPPING;
+
+  /** Not sure if the reverse mapping will be needed. TODO: Decide whether to keep or remove. */
+  private static final Map<JDBCType, Schema.Type> JDBC_TO_AVRO_TYPE_MAPPING;
+
+  static {
+    Map<Schema.Type, JDBCType> avroToJdbc = new EnumMap(Schema.Type.class);
+    Map<JDBCType, Schema.Type> jdbcToAvro = new EnumMap(JDBCType.class);
+
+    // avroToJdbc.put(Schema.Type.UNION, JDBCType.?); // Unions need special handling, see below
+    avroToJdbc.put(Schema.Type.FIXED, JDBCType.BINARY);
+    avroToJdbc.put(Schema.Type.STRING, JDBCType.VARCHAR);
+    avroToJdbc.put(Schema.Type.BYTES, JDBCType.VARBINARY);
+    avroToJdbc.put(Schema.Type.INT, JDBCType.INTEGER);
+    avroToJdbc.put(Schema.Type.LONG, JDBCType.BIGINT);
+    avroToJdbc.put(Schema.Type.FLOAT, JDBCType.FLOAT);
+    avroToJdbc.put(Schema.Type.DOUBLE, JDBCType.DOUBLE);
+    avroToJdbc.put(Schema.Type.BOOLEAN, JDBCType.BOOLEAN);
+    avroToJdbc.put(Schema.Type.NULL, JDBCType.NULL);
+
+    // Unsupported for now, but eventually might be:
+    // avroToJdbc.put(Schema.Type.RECORD, JDBCType.STRUCT);
+    // avroToJdbc.put(Schema.Type.ENUM, JDBCType.?);
+    // avroToJdbc.put(Schema.Type.ARRAY, JDBCType.ARRAY);
+    // avroToJdbc.put(Schema.Type.MAP, JDBCType.?);
+
+    for (Map.Entry<Schema.Type, JDBCType> entry: avroToJdbc.entrySet()) {
+      if (jdbcToAvro.put(entry.getValue(), entry.getKey()) != null) {
+        // There is already a mapping!
+        throw new IllegalStateException("There cannot be two mappings for: " + entry.getValue());
+      }
+    }
+
+    AVRO_TO_JDBC_TYPE_MAPPING = Collections.unmodifiableMap(avroToJdbc);
+    JDBC_TO_AVRO_TYPE_MAPPING = Collections.unmodifiableMap(jdbcToAvro);
+  }
+
+  private AvroToSQL() {
+    // Static util
+  }
+
+  public static String createTableStatement(
+      Schema avroSchema,
+      Set<String> primaryKeyColumns,
+      UnsupportedTypeHandling unsupportedTypeHandling) {
+    if (avroSchema.getType() != Schema.Type.RECORD) {
+      throw new IllegalArgumentException("Only Avro records can have a corresponding CREATE TABLE statement.");
+    }
+    String createTable = "CREATE TABLE " + cleanTableName(avroSchema.getName()) + "(";
+    boolean firstColumn = true;
+
+    for (Schema.Field field: avroSchema.getFields()) {
+      Schema fieldSchema = field.schema();
+      Schema.Type fieldType = fieldSchema.getType();
+
+      // Unpack unions
+      if (fieldType == Schema.Type.UNION) {
+        List<Schema> unionBranches = fieldSchema.getTypes();
+        boolean unsupported = false;
+        if (unionBranches.size() != 2) {
+          unsupported = true;
+        } else if (unionBranches.get(0).getType() == Schema.Type.NULL) {
+          fieldType = unionBranches.get(1).getType();
+        } else if (unionBranches.get(1).getType() == Schema.Type.NULL) {
+          fieldType = unionBranches.get(0).getType();
+        } else {
+          unsupported = true;
+        }
+        if (unsupported) {
+          switch (unsupportedTypeHandling) {
+            case SKIP:
+              continue;
+            case FAIL:
+              throw new IllegalArgumentException(
+                  "Avro unions are only supported if they have two branches and one of them is null. Provided union: "
+                      + field.schema());
+          }
+        }
+      }
+
+      JDBCType correspondingType = AVRO_TO_JDBC_TYPE_MAPPING.get(fieldType);
+      if (correspondingType == null) {
+        switch (unsupportedTypeHandling) {
+          case SKIP:
+            continue;
+          case FAIL:
+            throw new IllegalArgumentException(fieldType + " is not supported!");
+        }
+      }
+
+      if (firstColumn) {
+        firstColumn = false;
+      } else {
+        createTable += ", ";
+      }
+
+      createTable += cleanColumnName(field.name()) + " " + correspondingType.name();
+
+      if (primaryKeyColumns.contains(field.name())) {
+        createTable += " PRIMARY KEY";
+      }
+    }
+    createTable += ");";
+
+    return createTable;
+  }
+
+  /**
+   * This function should encapsulate the handling of any illegal characters (by either failing or converting them).
+   */
+  private static String cleanTableName(String avroRecordName) {
+    return avroRecordName;
+  }
+
+  private static String cleanColumnName(String avroFieldName) {
+    return avroFieldName;
+  }
+}

--- a/integrations/venice-duckdb/src/test/java/com/linkedin/venice/duckdb/HelloWorldTest.java
+++ b/integrations/venice-duckdb/src/test/java/com/linkedin/venice/duckdb/HelloWorldTest.java
@@ -2,6 +2,7 @@ package com.linkedin.venice.duckdb;
 
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertThrows;
 import static org.testng.Assert.assertTrue;
 
 import java.sql.Connection;
@@ -17,7 +18,7 @@ import org.testng.annotations.Test;
  */
 public class HelloWorldTest {
   /**
-   * Lightly adapted from: https://duckdb.org/docs/api/java.html#querying
+   * Adapted from: https://duckdb.org/docs/api/java.html#querying
    */
   @Test
   public void test() throws SQLException {
@@ -121,6 +122,23 @@ public class HelloWorldTest {
       try (ResultSet rs = stmt.executeQuery("SELECT * FROM my_table_current_version")) {
         assertValidityOfResultSet2(rs);
       }
+    }
+  }
+
+  @Test
+  public void testPrimaryKey() throws SQLException {
+    try (Connection connection = DriverManager.getConnection("jdbc:duckdb:");
+        Statement stmt = connection.createStatement()) {
+      // create a table
+      stmt.execute("CREATE TABLE items (item VARCHAR PRIMARY KEY, value DECIMAL(10, 2), count INTEGER)");
+      // insert two items into the table
+      stmt.execute(insertDataset1Statement("items"));
+
+      try (ResultSet rs = stmt.executeQuery("SELECT * FROM items")) {
+        assertValidityOfResultSet1(rs);
+      }
+
+      assertThrows(SQLException.class, () -> stmt.execute(insertDataset2Statement("items")));
     }
   }
 

--- a/integrations/venice-duckdb/src/test/java/com/linkedin/venice/sql/AvroToSQLTest.java
+++ b/integrations/venice-duckdb/src/test/java/com/linkedin/venice/sql/AvroToSQLTest.java
@@ -1,0 +1,153 @@
+package com.linkedin.venice.sql;
+
+import static com.linkedin.venice.sql.AvroToSQL.UnsupportedTypeHandling.FAIL;
+import static com.linkedin.venice.sql.AvroToSQL.UnsupportedTypeHandling.SKIP;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertThrows;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import org.apache.avro.Schema;
+import org.testng.annotations.Test;
+
+
+public class AvroToSQLTest {
+  private static final String EXPECTED_CREATE_TABLE_STATEMENT_WITH_ALL_TYPES = "CREATE TABLE MyRecord(" //
+      + "fixedField BINARY, " //
+      + "stringField VARCHAR, " //
+      + "bytesField VARBINARY, "//
+      + "intField INTEGER, " //
+      + "longField BIGINT, " //
+      + "floatField FLOAT, " //
+      + "doubleField DOUBLE, " //
+      + "booleanField BOOLEAN, " //
+      + "nullField NULL, " //
+      + "fixedFieldUnion1 BINARY, " //
+      + "fixedFieldUnion2 BINARY, " //
+      + "stringFieldUnion1 VARCHAR, " //
+      + "stringFieldUnion2 VARCHAR, " //
+      + "bytesFieldUnion1 VARBINARY, " //
+      + "bytesFieldUnion2 VARBINARY, " //
+      + "intFieldUnion1 INTEGER, " //
+      + "intFieldUnion2 INTEGER, " //
+      + "longFieldUnion1 BIGINT, " //
+      + "longFieldUnion2 BIGINT, " //
+      + "floatFieldUnion1 FLOAT, " //
+      + "floatFieldUnion2 FLOAT, " //
+      + "doubleFieldUnion1 DOUBLE, " //
+      + "doubleFieldUnion2 DOUBLE, " //
+      + "booleanFieldUnion1 BOOLEAN, " //
+      + "booleanFieldUnion2 BOOLEAN);";
+
+  @Test
+  public void testValidCreateTable() {
+    List<Schema.Field> allFields = getAllValidFields();
+    Schema schemaWithAllSupportedFieldTypes = Schema.createRecord("MyRecord", "", "", false, allFields);
+
+    String createTableStatementForAllFields =
+        AvroToSQL.createTableStatement(schemaWithAllSupportedFieldTypes, Collections.emptySet(), FAIL);
+    assertEquals(createTableStatementForAllFields, EXPECTED_CREATE_TABLE_STATEMENT_WITH_ALL_TYPES);
+
+    // Primary keys
+    Set<String> primaryKeys = new HashSet<>();
+    primaryKeys.add("stringField");
+    String createTableWithPrimaryKey =
+        AvroToSQL.createTableStatement(schemaWithAllSupportedFieldTypes, primaryKeys, FAIL);
+    String expectedCreateTable = EXPECTED_CREATE_TABLE_STATEMENT_WITH_ALL_TYPES
+        .replace("stringField VARCHAR", "stringField VARCHAR PRIMARY KEY");
+    assertEquals(createTableWithPrimaryKey, expectedCreateTable);
+  }
+
+  @Test
+  public void testInvalidCreateTable() {
+    // Types that will for sure not be supported.
+
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> AvroToSQL.createTableStatement(Schema.create(Schema.Type.INT), Collections.emptySet(), FAIL));
+
+    testSchemaWithInvalidType(
+        new Schema.Field(
+            "TripleUnionWithNull",
+            Schema.createUnion(
+                Schema.create(Schema.Type.NULL),
+                Schema.create(Schema.Type.INT),
+                Schema.create(Schema.Type.STRING))));
+
+    testSchemaWithInvalidType(
+        new Schema.Field(
+            "TripleUnionWithoutNull",
+            Schema.createUnion(
+                Schema.create(Schema.Type.BOOLEAN),
+                Schema.create(Schema.Type.INT),
+                Schema.create(Schema.Type.STRING))));
+
+    testSchemaWithInvalidType(
+        new Schema.Field(
+            "DoubleUnionWithoutNull",
+            Schema.createUnion(Schema.create(Schema.Type.INT), Schema.create(Schema.Type.STRING))));
+
+    // Types that could eventually become supported...
+
+    testSchemaWithInvalidType(new Schema.Field("StringArray", Schema.createArray(Schema.create(Schema.Type.STRING))));
+
+    testSchemaWithInvalidType(new Schema.Field("StringStringMap", Schema.createMap(Schema.create(Schema.Type.STRING))));
+
+    testSchemaWithInvalidType(
+        new Schema.Field("Record", Schema.createRecord("NestedRecord", "", "", false, Collections.emptyList())));
+  }
+
+  private List<Schema.Field> getAllValidFields() {
+    List<Schema.Field> allFields = new ArrayList<>();
+
+    // Basic types
+    allFields.add(new Schema.Field("fixedField", Schema.createFixed("MyFixed", "", "", 1)));
+    allFields.add(new Schema.Field("stringField", Schema.create(Schema.Type.STRING)));
+    allFields.add(new Schema.Field("bytesField", Schema.create(Schema.Type.BYTES)));
+    allFields.add(new Schema.Field("intField", Schema.create(Schema.Type.INT)));
+    allFields.add(new Schema.Field("longField", Schema.create(Schema.Type.LONG)));
+    allFields.add(new Schema.Field("floatField", Schema.create(Schema.Type.FLOAT)));
+    allFields.add(new Schema.Field("doubleField", Schema.create(Schema.Type.DOUBLE)));
+    allFields.add(new Schema.Field("booleanField", Schema.create(Schema.Type.BOOLEAN)));
+    allFields.add(new Schema.Field("nullField", Schema.create(Schema.Type.NULL)));
+
+    // Unions with null
+    List<Schema.Field> allOptionalFields = new ArrayList<>();
+    for (Schema.Field field: allFields) {
+      if (field.schema().getType() == Schema.Type.NULL) {
+        // Madness? THIS -- IS -- SPARTAAAAAAAAAAAAAAAAAA!!!!!!!!!
+        continue;
+      }
+
+      // Include both union branch orders
+      allOptionalFields.add(
+          new Schema.Field(
+              field.name() + "Union1",
+              Schema.createUnion(Schema.create(Schema.Type.NULL), field.schema())));
+      allOptionalFields.add(
+          new Schema.Field(
+              field.name() + "Union2",
+              Schema.createUnion(field.schema(), Schema.create(Schema.Type.NULL))));
+    }
+    allFields.addAll(allOptionalFields);
+
+    return allFields;
+  }
+
+  private void testSchemaWithInvalidType(Schema.Field invalidField) {
+    List<Schema.Field> allFields = getAllValidFields();
+    allFields.add(invalidField);
+
+    Schema schema = Schema.createRecord("MyRecord", "", "", false, allFields);
+
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> AvroToSQL.createTableStatement(schema, Collections.emptySet(), FAIL));
+
+    String createTableStatement = AvroToSQL.createTableStatement(schema, Collections.emptySet(), SKIP);
+    assertEquals(createTableStatement, EXPECTED_CREATE_TABLE_STATEMENT_WITH_ALL_TYPES);
+  }
+}


### PR DESCRIPTION
Currently supports converting an Avro schema into a CREATE TABLE statement.

Does not yet support  Map/Array/Enum/Struct types.

## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
New unit tests.

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.