### PR TITLE
[duckdb] Composite primary key support

### DIFF
--- a/integrations/venice-duckdb/build.gradle
+++ b/integrations/venice-duckdb/build.gradle
@@ -4,6 +4,8 @@ dependencies {
   implementation libraries.duckdbJdbc
 
   implementation project(':internal:venice-client-common')
+
+  testImplementation project(':internal:venice-common')
 }
 
 checkerFramework {


### PR DESCRIPTION
By leveraging a different CREATE TABLE syntax, we can support composite primary keys, which previously did not work. This also simplifies the upsert syntax by letting us use CREATE OR REPLACE INTO, rather than the more verbose ON CONFLICT DO UPDATE SET x = EXCLUDED.x syntax.

Also simplified the upsertStatement and upsertProcessor APIs to have one fewer param each.

## How was this PR tested?
New unit tests.

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.