### PR TITLE
[duckdb] Refactored AvroToSQL to make key schemas first-class

### DIFF
--- a/integrations/venice-duckdb/src/main/java/com/linkedin/venice/sql/InsertProcessor.java
+++ b/integrations/venice-duckdb/src/main/java/com/linkedin/venice/sql/InsertProcessor.java
@@ -1,0 +1,200 @@
+package com.linkedin.venice.sql;
+
+import com.linkedin.venice.utils.ByteUtils;
+import java.nio.ByteBuffer;
+import java.sql.JDBCType;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+import javax.annotation.Nonnull;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericRecord;
+
+
+public class InsertProcessor {
+  private final int[] keyFieldIndexToJdbcIndexMapping;
+  private final int[] valueFieldIndexToJdbcIndexMapping;
+  private final int[] keyFieldIndexToUnionBranchIndex;
+  private final int[] valueFieldIndexToUnionBranchIndex;
+  private final JDBCType[] keyFieldIndexToCorrespondingType;
+  private final JDBCType[] valueFieldIndexToCorrespondingType;
+
+  InsertProcessor(@Nonnull Schema keySchema, @Nonnull Schema valueSchema, @Nonnull Set<String> columnsToProject) {
+    Objects.requireNonNull(keySchema);
+    Objects.requireNonNull(valueSchema);
+    Objects.requireNonNull(columnsToProject);
+
+    int keyFieldCount = keySchema.getFields().size();
+    this.keyFieldIndexToJdbcIndexMapping = new int[keyFieldCount];
+    this.keyFieldIndexToUnionBranchIndex = new int[keyFieldCount];
+    this.keyFieldIndexToCorrespondingType = new JDBCType[keyFieldCount];
+
+    int valueFieldCount = valueSchema.getFields().size();
+    this.valueFieldIndexToJdbcIndexMapping = new int[valueFieldCount];
+    this.valueFieldIndexToUnionBranchIndex = new int[valueFieldCount];
+    this.valueFieldIndexToCorrespondingType = new JDBCType[valueFieldCount];
+
+    // N.B.: JDBC indices start at 1, not at 0.
+    int index = 1;
+    index = populateArrays(
+        index,
+        keySchema,
+        this.keyFieldIndexToJdbcIndexMapping,
+        this.keyFieldIndexToUnionBranchIndex,
+        this.keyFieldIndexToCorrespondingType,
+        Collections.emptySet()); // N.B.: All key columns must be projected.
+    populateArrays(
+        index, // N.B.: The same index value needs to carry over from key to value columns.
+        valueSchema,
+        this.valueFieldIndexToJdbcIndexMapping,
+        this.valueFieldIndexToUnionBranchIndex,
+        this.valueFieldIndexToCorrespondingType,
+        columnsToProject);
+  }
+
+  public void process(GenericRecord key, GenericRecord value, PreparedStatement preparedStatement) {
+    try {
+      processRecord(
+          key,
+          preparedStatement,
+          this.keyFieldIndexToJdbcIndexMapping,
+          this.keyFieldIndexToUnionBranchIndex,
+          this.keyFieldIndexToCorrespondingType);
+
+      processRecord(
+          value,
+          preparedStatement,
+          this.valueFieldIndexToJdbcIndexMapping,
+          this.valueFieldIndexToUnionBranchIndex,
+          this.valueFieldIndexToCorrespondingType);
+
+      preparedStatement.execute();
+    } catch (SQLException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  private int populateArrays(
+      int index,
+      @Nonnull Schema schema,
+      @Nonnull int[] avroFieldIndexToJdbcIndexMapping,
+      @Nonnull int[] avroFieldIndexToUnionBranchIndex,
+      @Nonnull JDBCType[] avroFieldIndexToCorrespondingType,
+      @Nonnull Set<String> columnsToProject) {
+    for (Schema.Field field: schema.getFields()) {
+      JDBCType correspondingType = AvroToSQL.getCorrespondingType(field);
+      if (correspondingType == null) {
+        // Skipped field.
+        continue;
+      }
+      if (!columnsToProject.isEmpty() && !columnsToProject.contains(field.name())) {
+        // Column is not projected.
+        continue;
+      }
+      avroFieldIndexToJdbcIndexMapping[field.pos()] = index++;
+      avroFieldIndexToCorrespondingType[field.pos()] = correspondingType;
+      if (field.schema().getType() == Schema.Type.UNION) {
+        Schema fieldSchema = field.schema();
+        List<Schema> unionBranches = fieldSchema.getTypes();
+        if (unionBranches.get(0).getType() == Schema.Type.NULL) {
+          avroFieldIndexToUnionBranchIndex[field.pos()] = 1;
+        } else if (unionBranches.get(1).getType() == Schema.Type.NULL) {
+          avroFieldIndexToUnionBranchIndex[field.pos()] = 0;
+        } else {
+          throw new IllegalStateException("Should have skipped unsupported union: " + fieldSchema);
+        }
+      }
+    }
+    return index;
+  }
+
+  private void processRecord(
+      GenericRecord record,
+      PreparedStatement preparedStatement,
+      int[] avroFieldIndexToJdbcIndexMapping,
+      int[] avroFieldIndexToUnionBranchIndex,
+      JDBCType[] avroFieldIndexToCorrespondingType) throws SQLException {
+    int jdbcIndex;
+    JDBCType jdbcType;
+    Object fieldValue;
+    Schema.Type fieldType;
+    for (Schema.Field field: record.getSchema().getFields()) {
+      jdbcIndex = avroFieldIndexToJdbcIndexMapping[field.pos()];
+      if (jdbcIndex == 0) {
+        // Skipped field.
+        continue;
+      }
+      fieldValue = record.get(field.pos());
+      if (fieldValue == null) {
+        jdbcType = avroFieldIndexToCorrespondingType[field.pos()];
+        preparedStatement.setNull(jdbcIndex, jdbcType.getVendorTypeNumber());
+        continue;
+      }
+      fieldType = field.schema().getType();
+      if (fieldType == Schema.Type.UNION) {
+        // Unions are handled via unpacking
+        fieldType = field.schema().getTypes().get(avroFieldIndexToUnionBranchIndex[field.pos()]).getType();
+      }
+      try {
+        processField(jdbcIndex, fieldType, fieldValue, preparedStatement, field.name());
+      } catch (Exception e) {
+        throw new RuntimeException(
+            "Failed to process field. Name: '" + field.name() + "; jdbcIndex: " + jdbcIndex + "; type: " + fieldType
+                + "; value: " + fieldValue,
+            e);
+      }
+    }
+  }
+
+  private void processField(
+      int jdbcIndex,
+      @Nonnull Schema.Type fieldType,
+      @Nonnull Object fieldValue,
+      @Nonnull PreparedStatement preparedStatement,
+      @Nonnull String fieldName) throws SQLException {
+    switch (fieldType) {
+      case FIXED:
+      case BYTES:
+        preparedStatement.setBytes(jdbcIndex, ByteUtils.extractByteArray((ByteBuffer) fieldValue));
+        break;
+      case STRING:
+        preparedStatement.setString(jdbcIndex, fieldValue.toString());
+        break;
+      case INT:
+        preparedStatement.setInt(jdbcIndex, (int) fieldValue);
+        break;
+      case LONG:
+        preparedStatement.setLong(jdbcIndex, (long) fieldValue);
+        break;
+      case FLOAT:
+        preparedStatement.setFloat(jdbcIndex, (float) fieldValue);
+        break;
+      case DOUBLE:
+        preparedStatement.setDouble(jdbcIndex, (double) fieldValue);
+        break;
+      case BOOLEAN:
+        preparedStatement.setBoolean(jdbcIndex, (boolean) fieldValue);
+        break;
+      case NULL:
+        // Weird case... probably never comes into play?
+        preparedStatement.setNull(jdbcIndex, JDBCType.NULL.getVendorTypeNumber());
+        break;
+
+      case UNION:
+        // Defensive code. Unreachable.
+        throw new IllegalArgumentException(
+            "Unions should be unpacked by the calling function, but union field '" + fieldName + "' was passed in!");
+
+      // These types could be supported eventually, but for now aren't.
+      case RECORD:
+      case ENUM:
+      case ARRAY:
+      case MAP:
+      default:
+        throw new IllegalStateException("Should have skipped field '" + fieldName + "' but somehow didn't!");
+    }
+  }
+}

--- a/integrations/venice-duckdb/src/test/java/com/linkedin/venice/duckdb/DuckDBAvroToSQLTest.java
+++ b/integrations/venice-duckdb/src/test/java/com/linkedin/venice/duckdb/DuckDBAvroToSQLTest.java
@@ -1,6 +1,6 @@
 package com.linkedin.venice.duckdb;
 
-import static com.linkedin.avroutil1.compatibility.AvroCompatibilityHelper.*;
+import static com.linkedin.avroutil1.compatibility.AvroCompatibilityHelper.createSchemaField;
 import static com.linkedin.venice.sql.AvroToSQL.UnsupportedTypeHandling.SKIP;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;

--- a/integrations/venice-duckdb/src/test/java/com/linkedin/venice/sql/AvroToSQLTest.java
+++ b/integrations/venice-duckdb/src/test/java/com/linkedin/venice/sql/AvroToSQLTest.java
@@ -1,8 +1,10 @@
 package com.linkedin.venice.sql;
 
-import static com.linkedin.avroutil1.compatibility.AvroCompatibilityHelper.*;
-import static com.linkedin.venice.sql.AvroToSQL.UnsupportedTypeHandling.*;
-import static org.testng.Assert.*;
+import static com.linkedin.avroutil1.compatibility.AvroCompatibilityHelper.createSchemaField;
+import static com.linkedin.venice.sql.AvroToSQL.UnsupportedTypeHandling.FAIL;
+import static com.linkedin.venice.sql.AvroToSQL.UnsupportedTypeHandling.SKIP;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertThrows;
 
 import java.util.ArrayList;
 import java.util.Collections;

--- a/internal/venice-test-common/build.gradle
+++ b/internal/venice-test-common/build.gradle
@@ -266,9 +266,6 @@ task integrationTests_9999(type: Test) {
         excludeTestsMatching pattern
       }
     }
-
-    // There's an issue where it passes locally but not on the CI
-    excludeTestsMatching 'com.linkedin.venice.endToEnd.DuckDBDaVinciRecordTransformerTest'
   }
   beforeSuite { descriptor ->
     suiteStartTime = System.currentTimeMillis()

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/DuckDBDaVinciRecordTransformerIntegrationTest.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/DuckDBDaVinciRecordTransformerIntegrationTest.java
@@ -12,8 +12,14 @@ import static com.linkedin.venice.ConfigKeys.SERVER_PROMOTION_TO_LEADER_REPLICA_
 import static com.linkedin.venice.meta.PersistenceType.ROCKS_DB;
 import static com.linkedin.venice.utils.IntegrationTestPushUtils.createStoreForJob;
 import static com.linkedin.venice.utils.IntegrationTestPushUtils.defaultVPJProps;
-import static com.linkedin.venice.utils.TestWriteUtils.*;
-import static com.linkedin.venice.vpj.VenicePushJobConstants.*;
+import static com.linkedin.venice.utils.TestWriteUtils.DEFAULT_USER_DATA_RECORD_COUNT;
+import static com.linkedin.venice.utils.TestWriteUtils.NAME_RECORD_V1_SCHEMA;
+import static com.linkedin.venice.utils.TestWriteUtils.SINGLE_FIELD_RECORD_SCHEMA;
+import static com.linkedin.venice.utils.TestWriteUtils.getTempDataDirectory;
+import static com.linkedin.venice.utils.TestWriteUtils.writeSimpleAvroFile;
+import static com.linkedin.venice.vpj.VenicePushJobConstants.DEFAULT_KEY_FIELD_PROP;
+import static com.linkedin.venice.vpj.VenicePushJobConstants.DEFAULT_VALUE_FIELD_PROP;
+import static com.linkedin.venice.vpj.VenicePushJobConstants.VENICE_STORE_NAME_PROP;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertTrue;

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/DuckDBDaVinciRecordTransformerIntegrationTest.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/DuckDBDaVinciRecordTransformerIntegrationTest.java
@@ -12,12 +12,8 @@ import static com.linkedin.venice.ConfigKeys.SERVER_PROMOTION_TO_LEADER_REPLICA_
 import static com.linkedin.venice.meta.PersistenceType.ROCKS_DB;
 import static com.linkedin.venice.utils.IntegrationTestPushUtils.createStoreForJob;
 import static com.linkedin.venice.utils.IntegrationTestPushUtils.defaultVPJProps;
-import static com.linkedin.venice.utils.TestWriteUtils.DEFAULT_USER_DATA_RECORD_COUNT;
-import static com.linkedin.venice.utils.TestWriteUtils.NAME_RECORD_V1_SCHEMA;
-import static com.linkedin.venice.utils.TestWriteUtils.getTempDataDirectory;
-import static com.linkedin.venice.utils.TestWriteUtils.writeSimpleAvroFileWithStringToNameRecordV1Schema;
-import static com.linkedin.venice.vpj.VenicePushJobConstants.DEFAULT_KEY_FIELD_PROP;
-import static com.linkedin.venice.vpj.VenicePushJobConstants.VENICE_STORE_NAME_PROP;
+import static com.linkedin.venice.utils.TestWriteUtils.*;
+import static com.linkedin.venice.vpj.VenicePushJobConstants.*;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertTrue;
@@ -37,8 +33,8 @@ import com.linkedin.venice.integration.utils.ServiceFactory;
 import com.linkedin.venice.integration.utils.VeniceClusterWrapper;
 import com.linkedin.venice.integration.utils.VeniceRouterWrapper;
 import com.linkedin.venice.sql.DuckDBDaVinciRecordTransformer;
-import com.linkedin.venice.utils.DataProviderUtils;
 import com.linkedin.venice.utils.PropertyBuilder;
+import com.linkedin.venice.utils.PushInputSchemaBuilder;
 import com.linkedin.venice.utils.TestUtils;
 import com.linkedin.venice.utils.TestWriteUtils;
 import com.linkedin.venice.utils.Utils;
@@ -54,6 +50,7 @@ import java.util.Properties;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
 import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericData;
 import org.apache.avro.generic.GenericRecord;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -63,7 +60,7 @@ import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 
-public class DuckDBDaVinciRecordTransformerTest {
+public class DuckDBDaVinciRecordTransformerIntegrationTest {
   private static final Logger LOGGER = LogManager.getLogger(DaVinciClientRecordTransformerTest.class);
   private static final int TEST_TIMEOUT = 120_000;
   private VeniceClusterWrapper cluster;
@@ -102,8 +99,17 @@ public class DuckDBDaVinciRecordTransformerTest {
     }
   }
 
-  @Test(timeOut = TEST_TIMEOUT, dataProvider = "dv-client-config-provider", dataProviderClass = DataProviderUtils.class)
-  public void testRecordTransformer(DaVinciConfig clientConfig) throws Exception {
+  /**
+   * This test works on mac but fails on the CI, likely due to: https://github.com/duckdb/duckdb-java/issues/14
+   *
+   * There is a fix merged for this, but it has not been released yet.
+   *
+   * TODO: Re-enable once we can depend on a clean release.
+   */
+  @Test(timeOut = TEST_TIMEOUT, enabled = false)
+  public void testRecordTransformer() throws Exception {
+    DaVinciConfig clientConfig = new DaVinciConfig();
+
     File tmpDir = Utils.getTempDataDirectory();
     String storeName = Utils.getUniqueString("test-store");
     boolean pushStatusStoreEnabled = false;
@@ -157,7 +163,22 @@ public class DuckDBDaVinciRecordTransformerTest {
     File inputDir = getTempDataDirectory();
     Consumer<UpdateStoreQueryParams> paramsConsumer = params -> {};
     Consumer<Properties> propertiesConsumer = properties -> {};
-    Schema valueSchema = writeSimpleAvroFileWithStringToNameRecordV1Schema(inputDir);
+    Schema pushRecordSchema = new PushInputSchemaBuilder().setKeySchema(SINGLE_FIELD_RECORD_SCHEMA)
+        .setValueSchema(NAME_RECORD_V1_SCHEMA)
+        .build();
+    String firstName = "first_name_";
+    String lastName = "last_name_";
+    Schema valueSchema = writeSimpleAvroFile(inputDir, pushRecordSchema, i -> {
+      GenericRecord keyValueRecord = new GenericData.Record(pushRecordSchema);
+      GenericRecord key = new GenericData.Record(SINGLE_FIELD_RECORD_SCHEMA);
+      key.put("key", i.toString());
+      keyValueRecord.put(DEFAULT_KEY_FIELD_PROP, key);
+      GenericRecord valueRecord = new GenericData.Record(NAME_RECORD_V1_SCHEMA);
+      valueRecord.put("firstName", firstName + i);
+      valueRecord.put("lastName", lastName + i);
+      keyValueRecord.put(DEFAULT_VALUE_FIELD_PROP, valueRecord); // Value
+      return keyValueRecord;
+    });
     String keySchemaStr = valueSchema.getField(DEFAULT_KEY_FIELD_PROP).schema().toString();
 
     // Setup VPJ job properties.

--- a/internal/venice-test-common/src/main/resources/valueSchema/SingleFieldRecord.avsc
+++ b/internal/venice-test-common/src/main/resources/valueSchema/SingleFieldRecord.avsc
@@ -1,0 +1,10 @@
+{
+  "type" : "record",
+  "name" : "SingleFieldRecord",
+  "namespace" : "example.avro",
+  "fields" : [ {
+    "name" : "key",
+    "type" : "string",
+    "default" : ""
+  } ]
+}


### PR DESCRIPTION
This refactoring lets the calling code pass the two kinds of schemas, for keys and values, as separate params. Previously, the calling code would have had to assemble a new schema equivalent to the SQL row, which was unwieldy.

Also added support for projecting columns (unused for now).

## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
Unit tests.

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.