### PR TITLE
[controller] Add interceptor to enforce SSL/TLS and propagate client attributes in gRPC controller server

### DIFF
--- a/gradle/spotbugs/exclude.xml
+++ b/gradle/spotbugs/exclude.xml
@@ -76,6 +76,7 @@
       <Class name="com.linkedin.venice.router.api.TestHostFinder"/>
       <Class name="com.linkedin.davinci.StoreBackendTest"/>
       <Class name="com.linkedin.venice.memory.ClassSizeEstimatorTest"/>
+      <Class name="com.linkedin.venice.controller.server.VeniceControllerAccessManagerTest"/>
     </Or>
   </Match>
   <Match>

--- a/internal/venice-common/src/main/java/com/linkedin/venice/acl/NoOpDynamicAccessController.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/acl/NoOpDynamicAccessController.java
@@ -1,0 +1,68 @@
+package com.linkedin.venice.acl;
+
+import java.security.cert.X509Certificate;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+
+
+public class NoOpDynamicAccessController implements DynamicAccessController {
+  public static final String USER_UNKNOWN = "USER_UNKNOWN";
+
+  @Override
+  public DynamicAccessController init(List<String> resources) {
+    return this;
+  }
+
+  @Override
+  public boolean hasAccess(X509Certificate clientCert, String resource, String method) throws AclException {
+    return true;
+  }
+
+  @Override
+  public boolean hasAccessToTopic(X509Certificate clientCert, String resource, String method) throws AclException {
+    return true;
+  }
+
+  @Override
+  public boolean hasAccessToAdminOperation(X509Certificate clientCert, String operation) throws AclException {
+    return true;
+  }
+
+  @Override
+  public boolean isAllowlistUsers(X509Certificate clientCert, String resource, String method) {
+    return true;
+  }
+
+  @Override
+  public String getPrincipalId(X509Certificate clientCert) {
+    if (clientCert != null && clientCert.getSubjectX500Principal() != null) {
+      return clientCert.getSubjectX500Principal().getName();
+    }
+    return USER_UNKNOWN;
+  }
+
+  @Override
+  public boolean hasAcl(String resource) throws AclException {
+    return true;
+  }
+
+  @Override
+  public void addAcl(String resource) throws AclException {
+  }
+
+  @Override
+  public void removeAcl(String resource) throws AclException {
+
+  }
+
+  @Override
+  public Set<String> getAccessControlledResources() {
+    return Collections.emptySet();
+  }
+
+  @Override
+  public boolean isFailOpen() {
+    return false;
+  }
+}

--- a/internal/venice-common/src/main/java/com/linkedin/venice/acl/NoOpDynamicAccessController.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/acl/NoOpDynamicAccessController.java
@@ -6,8 +6,16 @@ import java.util.List;
 import java.util.Set;
 
 
+/**
+ * A no-op implementation of {@link DynamicAccessController}.
+ */
 public class NoOpDynamicAccessController implements DynamicAccessController {
   public static final String USER_UNKNOWN = "USER_UNKNOWN";
+
+  public static final NoOpDynamicAccessController INSTANCE = new NoOpDynamicAccessController();
+
+  private NoOpDynamicAccessController() {
+  }
 
   @Override
   public DynamicAccessController init(List<String> resources) {

--- a/internal/venice-common/src/test/java/com/linkedin/venice/acl/NoOpDynamicAccessControllerTest.java
+++ b/internal/venice-common/src/test/java/com/linkedin/venice/acl/NoOpDynamicAccessControllerTest.java
@@ -20,7 +20,7 @@ public class NoOpDynamicAccessControllerTest {
 
   @BeforeMethod
   public void setUp() {
-    accessController = new NoOpDynamicAccessController();
+    accessController = NoOpDynamicAccessController.INSTANCE;
   }
 
   @Test

--- a/internal/venice-common/src/test/java/com/linkedin/venice/acl/NoOpDynamicAccessControllerTest.java
+++ b/internal/venice-common/src/test/java/com/linkedin/venice/acl/NoOpDynamicAccessControllerTest.java
@@ -1,0 +1,67 @@
+package com.linkedin.venice.acl;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertSame;
+import static org.testng.Assert.assertTrue;
+
+import java.security.cert.X509Certificate;
+import java.util.Collections;
+import java.util.Set;
+import javax.security.auth.x500.X500Principal;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+
+public class NoOpDynamicAccessControllerTest {
+  private NoOpDynamicAccessController accessController;
+
+  @BeforeMethod
+  public void setUp() {
+    accessController = new NoOpDynamicAccessController();
+  }
+
+  @Test
+  public void testAlwaysTrueMethods() throws AclException {
+    // Test all methods that always return true
+    assertTrue(accessController.hasAccess(null, "resource", "GET"), "Expected hasAccess to return true.");
+    assertTrue(accessController.hasAccessToTopic(null, "topic", "READ"), "Expected hasAccessToTopic to return true.");
+    assertTrue(
+        accessController.hasAccessToAdminOperation(null, "operation"),
+        "Expected hasAccessToAdminOperation to return true.");
+    assertTrue(accessController.isAllowlistUsers(null, "resource", "GET"), "Expected isAllowlistUsers to return true.");
+    assertTrue(accessController.hasAcl("resource"), "Expected hasAcl to return true.");
+  }
+
+  @Test
+  public void testInitReturnsSameInstance() {
+    DynamicAccessController initializedController = accessController.init(Collections.emptyList());
+    assertSame(initializedController, accessController, "Expected the same instance after init.");
+  }
+
+  @Test
+  public void testGetPrincipalId() {
+    String expectedId = "CN=Test User,OU=Engineering,O=LinkedIn,C=US";
+    X509Certificate mockCertificate = mock(X509Certificate.class);
+    when(mockCertificate.getSubjectX500Principal()).thenReturn(new X500Principal(expectedId));
+
+    assertEquals(accessController.getPrincipalId(mockCertificate), expectedId, "Expected the correct principal ID.");
+    assertEquals(
+        accessController.getPrincipalId(null),
+        NoOpDynamicAccessController.USER_UNKNOWN,
+        "Expected USER_UNKNOWN for null certificate.");
+  }
+
+  @Test
+  public void testGetAccessControlledResources() {
+    Set<String> resources = accessController.getAccessControlledResources();
+    assertTrue(resources.isEmpty(), "Expected access-controlled resources to be empty.");
+  }
+
+  @Test
+  public void testIsFailOpen() {
+    assertFalse(accessController.isFailOpen(), "Expected isFailOpen to return false.");
+  }
+}

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/controller/TestControllerSecureGrpcServer.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/controller/TestControllerSecureGrpcServer.java
@@ -1,0 +1,81 @@
+package com.linkedin.venice.controller;
+
+import static com.linkedin.venice.controller.server.grpc.ControllerGrpcSslSessionInterceptor.CLIENT_CERTIFICATE_CONTEXT_KEY;
+import static org.testng.Assert.assertEquals;
+
+import com.linkedin.venice.controller.server.grpc.ControllerGrpcSslSessionInterceptor;
+import com.linkedin.venice.grpc.GrpcUtils;
+import com.linkedin.venice.grpc.VeniceGrpcServer;
+import com.linkedin.venice.grpc.VeniceGrpcServerConfig;
+import com.linkedin.venice.protocols.controller.DiscoverClusterGrpcRequest;
+import com.linkedin.venice.protocols.controller.DiscoverClusterGrpcResponse;
+import com.linkedin.venice.protocols.controller.VeniceControllerGrpcServiceGrpc;
+import com.linkedin.venice.protocols.controller.VeniceControllerGrpcServiceGrpc.VeniceControllerGrpcServiceBlockingStub;
+import com.linkedin.venice.security.SSLFactory;
+import com.linkedin.venice.utils.SslUtils;
+import com.linkedin.venice.utils.TestUtils;
+import io.grpc.ChannelCredentials;
+import io.grpc.Context;
+import io.grpc.Grpc;
+import io.grpc.ManagedChannel;
+import java.security.cert.X509Certificate;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+
+public class TestControllerSecureGrpcServer {
+  private VeniceGrpcServer grpcSecureServer;
+  private int grpcSecureServerPort;
+  private SSLFactory sslFactory;
+
+  @BeforeClass(alwaysRun = true)
+  public void setUpClass() {
+    sslFactory = SslUtils.getVeniceLocalSslFactory();
+    grpcSecureServerPort = TestUtils.getFreePort();
+    VeniceGrpcServerConfig grpcSecureServerConfig =
+        new VeniceGrpcServerConfig.Builder().setService(new VeniceControllerGrpcSecureServiceTestImpl())
+            .setPort(grpcSecureServerPort)
+            .setNumThreads(2)
+            .setSslFactory(sslFactory)
+            .setInterceptor(new ControllerGrpcSslSessionInterceptor())
+            .build();
+    grpcSecureServer = new VeniceGrpcServer(grpcSecureServerConfig);
+    grpcSecureServer.start();
+  }
+
+  @AfterClass
+  public void tearDownClass() {
+    if (grpcSecureServer != null) {
+      grpcSecureServer.stop();
+    }
+  }
+
+  public static class VeniceControllerGrpcSecureServiceTestImpl
+      extends VeniceControllerGrpcServiceGrpc.VeniceControllerGrpcServiceImplBase {
+    @Override
+    public void discoverClusterForStore(
+        DiscoverClusterGrpcRequest request,
+        io.grpc.stub.StreamObserver<DiscoverClusterGrpcResponse> responseObserver) {
+      X509Certificate clientCert = CLIENT_CERTIFICATE_CONTEXT_KEY.get(Context.current());
+      if (clientCert == null) {
+        throw new RuntimeException("Client cert is null");
+      }
+      DiscoverClusterGrpcResponse discoverClusterGrpcResponse =
+          DiscoverClusterGrpcResponse.newBuilder().setClusterName("test-cluster").build();
+      responseObserver.onNext(discoverClusterGrpcResponse);
+      responseObserver.onCompleted();
+    }
+  }
+
+  @Test
+  public void testSslCertificatePropagationByGrpcInterceptor() {
+    String serverAddress = String.format("localhost:%d", grpcSecureServerPort);
+    ChannelCredentials credentials = GrpcUtils.buildChannelCredentials(sslFactory);
+    ManagedChannel channel = Grpc.newChannelBuilder(serverAddress, credentials).build();
+    VeniceControllerGrpcServiceBlockingStub blockingStub = VeniceControllerGrpcServiceGrpc.newBlockingStub(channel);
+    DiscoverClusterGrpcRequest request = DiscoverClusterGrpcRequest.newBuilder().setStoreName("test-store").build();
+    DiscoverClusterGrpcResponse response = blockingStub.discoverClusterForStore(request);
+    assertEquals(response.getClusterName(), "test-cluster");
+  }
+}

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceController.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceController.java
@@ -13,6 +13,7 @@ import com.linkedin.venice.controller.kafka.TopicCleanupServiceForParentControll
 import com.linkedin.venice.controller.server.AdminSparkServer;
 import com.linkedin.venice.controller.server.VeniceControllerGrpcServiceImpl;
 import com.linkedin.venice.controller.server.VeniceControllerRequestHandler;
+import com.linkedin.venice.controller.server.grpc.ControllerGrpcSslSessionInterceptor;
 import com.linkedin.venice.controller.server.grpc.ParentControllerRegionValidationInterceptor;
 import com.linkedin.venice.controller.stats.TopicCleanupServiceStats;
 import com.linkedin.venice.controller.supersetschema.SupersetSchemaGenerator;
@@ -296,6 +297,7 @@ public class VeniceController {
             .build());
 
     if (sslEnabled) {
+      interceptors.add(new ControllerGrpcSslSessionInterceptor());
       SSLFactory sslFactory = SslUtils.getSSLFactory(
           multiClusterConfigs.getSslConfig().get().getSslProperties(),
           multiClusterConfigs.getSslFactoryClassName());

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/server/VeniceControllerAccessManager.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/server/VeniceControllerAccessManager.java
@@ -1,0 +1,134 @@
+package com.linkedin.venice.controller.server;
+
+import static java.util.Objects.requireNonNull;
+
+import com.linkedin.venice.acl.AclException;
+import com.linkedin.venice.acl.DynamicAccessController;
+import com.linkedin.venice.acl.NoOpDynamicAccessController;
+import com.linkedin.venice.authorization.Method;
+import java.security.cert.X509Certificate;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+
+public class VeniceControllerAccessManager {
+  private static final Logger LOGGER = LogManager.getLogger(VeniceControllerAccessManager.class);
+
+  protected static final String UNKNOWN_USER = "USER_UNKNOWN";
+  private static final String UNKNOWN_STORE = "STORE_UNKNOWN";
+  private static final String UNKNOWN_PRINCIPAL = "PRINCIPAL_UNKNOWN";
+  private final DynamicAccessController accessController;
+
+  public VeniceControllerAccessManager(DynamicAccessController accessController) {
+    this.accessController = requireNonNull(accessController, "DynamicAccessController is required to enforce ACL");
+  }
+
+  /**
+   * Checks whether the user certificate in the request grants access of the specified {@link Method}
+   * type to the given resource.
+   *
+   * @param resourceName The name of the resource to access.
+   * @param x509Certificate The user's X.509 certificate (nullable).
+   * @param accessMethod The method of access (e.g., GET, POST).
+   * @param requesterHostname The hostname of the requester (optional).
+   * @param requesterIp The IP address of the requester (optional).
+   * @return true if access is granted; false otherwise.
+   */
+  protected boolean hasAccess(
+      @Nonnull String resourceName,
+      @Nullable X509Certificate x509Certificate,
+      @Nonnull Method accessMethod,
+      @Nullable String requesterHostname,
+      @Nullable String requesterIp) {
+
+    resourceName = requireNonNull(resourceName, "Resource name is required to enforce ACL");
+    accessMethod = requireNonNull(accessMethod, "Access method is required to enforce ACL");
+
+    try {
+      if (accessController.hasAccess(x509Certificate, resourceName, accessMethod.name())) {
+        return true;
+      }
+      // Access denied
+      LOGGER.warn(
+          "Client with principal: {} hostName: {} ipAddr: {} doesn't have access to the store: {}",
+          getSubjectX500Principal(x509Certificate),
+          requesterHostname,
+          requesterIp,
+          resourceName);
+    } catch (AclException e) {
+      LOGGER.error(
+          "Error when checking access for client with principal: {} hostName: {} ipAddr: {} to store: {}",
+          getSubjectX500Principal(x509Certificate),
+          requesterHostname,
+          requesterIp,
+          resourceName,
+          e);
+    }
+    return false;
+  }
+
+  private String getSubjectX500Principal(X509Certificate x509Certificate) {
+    if (x509Certificate != null && x509Certificate.getSubjectX500Principal() != null) {
+      return x509Certificate.getSubjectX500Principal().toString();
+    }
+    return UNKNOWN_PRINCIPAL;
+  }
+
+  public boolean hasWriteAccessToPubSubTopic(
+      String resourceName,
+      X509Certificate x509Certificate,
+      String requesterHostname,
+      String requesterIp) {
+    return hasAccess(resourceName, x509Certificate, Method.Write, requesterHostname, requesterIp);
+  }
+
+  public boolean hasReadAccessToPubSubTopic(
+      String resourceName,
+      X509Certificate x509Certificate,
+      String requesterHostname,
+      String requesterIp) {
+    return hasAccess(resourceName, x509Certificate, Method.Read, requesterHostname, requesterIp);
+  }
+
+  public boolean hasAccessToStore(
+      String resourceName,
+      X509Certificate x509Certificate,
+      String requesterHostname,
+      String requesterIp) {
+    return hasAccess(resourceName, x509Certificate, Method.GET, requesterHostname, requesterIp);
+  }
+
+  /**
+   * Check whether the user is within the admin users allowlist.
+   */
+  public boolean isAllowListUser(String resourceName, X509Certificate x509Certificate) {
+    if (resourceName == null) {
+      resourceName = UNKNOWN_STORE;
+    }
+    return accessController.isAllowlistUsers(x509Certificate, resourceName, Method.GET.name());
+  }
+
+  public String getPrincipalId(X509Certificate x509Certificate) {
+    try {
+      if (x509Certificate != null) {
+        return accessController.getPrincipalId(x509Certificate);
+      }
+      LOGGER.warn("Client certificate is null. Unable to extract principal Id. Returning USER_UNKNOWN");
+    } catch (Exception e) {
+      LOGGER.error("Error when retrieving principal Id from request", e);
+    }
+    return UNKNOWN_USER;
+  }
+
+  /**
+   * @return whether ACL check is enabled.
+   */
+  protected boolean isAclEnabled() {
+    /**
+     * {@link accessController} will be of type {@link NoOpDynamicAccessController} if ACL is disabled.
+     */
+    return !(accessController instanceof NoOpDynamicAccessController);
+  }
+}

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/server/VeniceControllerGrpcServiceImpl.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/server/VeniceControllerGrpcServiceImpl.java
@@ -22,9 +22,11 @@ public class VeniceControllerGrpcServiceImpl extends VeniceControllerGrpcService
   private static final Logger LOGGER = LogManager.getLogger(VeniceControllerGrpcServiceImpl.class);
 
   private final VeniceControllerRequestHandler requestHandler;
+  private final VeniceControllerAccessManager accessManager;
 
   public VeniceControllerGrpcServiceImpl(VeniceControllerRequestHandler requestHandler) {
     this.requestHandler = requestHandler;
+    this.accessManager = requestHandler.getControllerAccessManager();
   }
 
   @Override

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/server/VeniceControllerRequestHandler.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/server/VeniceControllerRequestHandler.java
@@ -27,10 +27,12 @@ public class VeniceControllerRequestHandler {
   public static final String DEFAULT_STORE_OWNER = "";
   private final Admin admin;
   private final boolean sslEnabled;
+  private final VeniceControllerAccessManager accessManager;
 
   public VeniceControllerRequestHandler(ControllerRequestHandlerDependencies dependencies) {
     this.admin = dependencies.getAdmin();
     this.sslEnabled = dependencies.isSslEnabled();
+    this.accessManager = dependencies.getControllerAccessManager();
   }
 
   // visibility: package-private
@@ -130,5 +132,9 @@ public class VeniceControllerRequestHandler {
 
     LOGGER.info("Successfully created store: {} in cluster: {}", storeName, clusterName);
     return responseBuilder.build();
+  }
+
+  public VeniceControllerAccessManager getControllerAccessManager() {
+    return accessManager;
   }
 }

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/server/grpc/ControllerGrpcSslSessionInterceptor.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/server/grpc/ControllerGrpcSslSessionInterceptor.java
@@ -1,0 +1,164 @@
+package com.linkedin.venice.controller.server.grpc;
+
+import com.linkedin.venice.grpc.GrpcUtils;
+import com.linkedin.venice.protocols.controller.ControllerGrpcErrorType;
+import com.linkedin.venice.protocols.controller.VeniceControllerGrpcErrorInfo;
+import io.grpc.Context;
+import io.grpc.Contexts;
+import io.grpc.Grpc;
+import io.grpc.Metadata;
+import io.grpc.ServerCall;
+import io.grpc.ServerCallHandler;
+import io.grpc.ServerInterceptor;
+import io.grpc.Status;
+import io.grpc.StatusRuntimeException;
+import io.grpc.protobuf.StatusProto;
+import java.net.SocketAddress;
+import java.security.cert.X509Certificate;
+import javax.net.ssl.SSLSession;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+
+/**
+ * Intercepts gRPC calls to enforce SSL/TLS requirements and propagate client certificate
+ * and remote address details into the gRPC {@link Context}.
+ *
+ * <p>If the gRPC connection does not have an SSL session, the interceptor rejects the call
+ * with an UNAUTHENTICATED status. Otherwise, it extracts the client certificate and remote
+ * address, injecting them into the gRPC context for downstream processing.</p>
+ *
+ * <p>The following attributes are injected into the {@link Context}:
+ * <ul>
+ *   <li>{@code CLIENT_CERTIFICATE_CONTEXT_KEY}: The client's X.509 certificate.</li>
+ *   <li>{@code CLIENT_ADDRESS_CONTEXT_KEY}: The client's remote address as a string.</li>
+ * </ul>
+ *
+ * <p>Errors are logged if the SSL session is missing or if certificate extraction fails.</p>
+ */
+public class ControllerGrpcSslSessionInterceptor implements ServerInterceptor {
+  private static final Logger LOGGER = LogManager.getLogger(ControllerGrpcSslSessionInterceptor.class);
+  protected static final String UNKNOWN_REMOTE_ADDRESS = "unknown";
+
+  public static final Context.Key<X509Certificate> CLIENT_CERTIFICATE_CONTEXT_KEY =
+      Context.key("controller-client-certificate");
+  public static final Context.Key<String> CLIENT_ADDRESS_CONTEXT_KEY = Context.key("controller-client-address");
+
+  protected static final VeniceControllerGrpcErrorInfo NON_SSL_ERROR_INFO = VeniceControllerGrpcErrorInfo.newBuilder()
+      .setStatusCode(Status.UNAUTHENTICATED.getCode().value())
+      .setErrorType(ControllerGrpcErrorType.CONNECTION_ERROR)
+      .setErrorMessage("SSL connection required")
+      .build();
+
+  protected static final StatusRuntimeException NON_SSL_CONNECTION_ERROR = StatusProto.toStatusRuntimeException(
+      com.google.rpc.Status.newBuilder()
+          .setCode(Status.UNAUTHENTICATED.getCode().value())
+          .addDetails(com.google.protobuf.Any.pack(NON_SSL_ERROR_INFO))
+          .build());
+
+  /**
+   * Intercepts a gRPC call to enforce SSL/TLS requirements and propagate SSL-related attributes
+   * into the gRPC {@link Context}. This ensures that only secure connections with valid client
+   * certificates proceed further in the call chain.
+   *
+   * <p>The method performs the following steps:
+   * <ul>
+   *   <li>Extracts the remote address from the server call attributes.</li>
+   *   <li>Validates the presence of an SSL session. If absent, the call is closed with an
+   *       {@code UNAUTHENTICATED} status.</li>
+   *   <li>Attempts to extract the client certificate from the SSL session. If extraction fails,
+   *       the call is closed with an {@code UNAUTHENTICATED} status.</li>
+   *   <li>Creates a new {@link Context} containing the client certificate and remote address,
+   *       and passes it to the downstream handlers.</li>
+   * </ul>
+   *
+   * @param serverCall The gRPC server call being intercepted.
+   * @param metadata The metadata associated with the call, containing headers and other request data.
+   * @param serverCallHandler The downstream handler that processes the call if validation passes.
+   * @param <ReqT> The request type of the gRPC method.
+   * @param <RespT> The response type of the gRPC method.
+   * @return A {@link ServerCall.Listener} for handling the intercepted call, or a no-op listener
+   *         if the call is terminated early due to validation failure.
+   */
+  @Override
+  public <ReqT, RespT> io.grpc.ServerCall.Listener<ReqT> interceptCall(
+      ServerCall<ReqT, RespT> serverCall,
+      Metadata metadata,
+      ServerCallHandler<ReqT, RespT> serverCallHandler) {
+
+    // Extract remote address
+    String remoteAddressStr = getRemoteAddress(serverCall);
+
+    // Validate SSL session
+    SSLSession sslSession = serverCall.getAttributes().get(Grpc.TRANSPORT_ATTR_SSL_SESSION);
+    if (sslSession == null) {
+      return closeWithSslError(serverCall);
+    }
+
+    // Extract client certificate
+    X509Certificate clientCert = extractClientCertificate(serverCall);
+    if (clientCert == null) {
+      return closeWithSslError(serverCall);
+    }
+
+    // Create a new context with SSL-related attributes
+    Context context = updateAndGetContext(clientCert, remoteAddressStr);
+
+    // Proceed with the call
+    return Contexts.interceptCall(context, serverCall, metadata, serverCallHandler);
+  }
+
+  /**
+   * Retrieves the remote address from the server call attributes.
+   *
+   * @param serverCall The gRPC server call.
+   * @return The remote address as a string, or "unknown" if not available.
+   */
+  private String getRemoteAddress(ServerCall<?, ?> serverCall) {
+    SocketAddress remoteAddress = serverCall.getAttributes().get(Grpc.TRANSPORT_ATTR_REMOTE_ADDR);
+    return remoteAddress != null ? remoteAddress.toString() : UNKNOWN_REMOTE_ADDRESS;
+  }
+
+  /**
+   * Closes the server call with an SSL error status.
+   *
+   * @param serverCall The gRPC server call to close.
+   * @param <ReqT> The request type.
+   * @param <RespT> The response type.
+   * @return A no-op listener to terminate the call.
+   */
+  private <ReqT, RespT> ServerCall.Listener<ReqT> closeWithSslError(ServerCall<ReqT, RespT> serverCall) {
+    LOGGER.debug("SSL not enabled or client certificate extraction failed");
+    serverCall.close(NON_SSL_CONNECTION_ERROR.getStatus(), NON_SSL_CONNECTION_ERROR.getTrailers());
+    return new ServerCall.Listener<ReqT>() {
+    };
+  }
+
+  /**
+   * Extracts the client certificate from the gRPC server call.
+   *
+   * @param serverCall The gRPC server call.
+   * @return The client certificate, or null if extraction fails.
+   */
+  private X509Certificate extractClientCertificate(ServerCall<?, ?> serverCall) {
+    try {
+      return GrpcUtils.extractGrpcClientCert(serverCall);
+    } catch (Exception e) {
+      LOGGER.error("Failed to extract client certificate", e);
+      return null;
+    }
+  }
+
+  /**
+   * Updates the gRPC context of the current scope by adding SSL-related attributes.
+   *
+   * @param clientCert The client certificate.
+   * @param remoteAddressStr The remote address as a string.
+   * @return The new context.
+   */
+  private Context updateAndGetContext(X509Certificate clientCert, String remoteAddressStr) {
+    return Context.current()
+        .withValue(CLIENT_CERTIFICATE_CONTEXT_KEY, clientCert)
+        .withValue(CLIENT_ADDRESS_CONTEXT_KEY, remoteAddressStr);
+  }
+}

--- a/services/venice-controller/src/test/java/com/linkedin/venice/controller/ControllerRequestHandlerDependenciesTest.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/controller/ControllerRequestHandlerDependenciesTest.java
@@ -10,6 +10,7 @@ import static org.testng.Assert.expectThrows;
 
 import com.linkedin.venice.SSLConfig;
 import com.linkedin.venice.acl.DynamicAccessController;
+import com.linkedin.venice.acl.NoOpDynamicAccessController;
 import com.linkedin.venice.controllerapi.ControllerRoute;
 import com.linkedin.venice.pubsub.PubSubTopicRepository;
 import com.linkedin.venice.utils.VeniceProperties;
@@ -94,7 +95,8 @@ public class ControllerRequestHandlerDependenciesTest {
     assertFalse(dependencies.isSslEnabled());
     assertFalse(dependencies.isCheckReadMethodForKafka());
     assertNull(dependencies.getSslConfig());
-    assertNull(dependencies.getAccessController());
+    assertNotNull(dependencies.getAccessController());
+    assertTrue(dependencies.getAccessController() instanceof NoOpDynamicAccessController);
     assertTrue(dependencies.getDisabledRoutes().isEmpty());
     assertFalse(dependencies.isDisableParentRequestTopicForStreamPushes());
     assertNull(dependencies.getMetricsRepository());

--- a/services/venice-controller/src/test/java/com/linkedin/venice/controller/server/VeniceControllerAccessManagerTest.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/controller/server/VeniceControllerAccessManagerTest.java
@@ -1,0 +1,133 @@
+package com.linkedin.venice.controller.server;
+
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.expectThrows;
+
+import com.linkedin.venice.acl.AclException;
+import com.linkedin.venice.acl.DynamicAccessController;
+import com.linkedin.venice.acl.NoOpDynamicAccessController;
+import com.linkedin.venice.authorization.Method;
+import java.security.cert.X509Certificate;
+import javax.security.auth.x500.X500Principal;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+
+public class VeniceControllerAccessManagerTest {
+  private DynamicAccessController mockedAccessController;
+  private VeniceControllerAccessManager controllerAccessManager;
+
+  @BeforeMethod
+  public void setUp() {
+    mockedAccessController = mock(DynamicAccessController.class);
+    controllerAccessManager = new VeniceControllerAccessManager(mockedAccessController);
+  }
+
+  @Test
+  public void testHasWriteAccessToPubSubTopicGranted() throws AclException {
+    String resourceName = "test-topic";
+    X509Certificate mockCert = mock(X509Certificate.class);
+
+    when(mockedAccessController.hasAccess(mockCert, resourceName, Method.Write.name())).thenReturn(true);
+
+    assertTrue(controllerAccessManager.hasWriteAccessToPubSubTopic(resourceName, mockCert, "host", "127.0.0.1"));
+    verify(mockedAccessController, times(1)).hasAccess(mockCert, resourceName, Method.Write.name());
+  }
+
+  @Test
+  public void testHasWriteAccessToPubSubTopicDenied() throws AclException {
+    String resourceName = "test-topic";
+    X509Certificate mockCert = mock(X509Certificate.class);
+
+    when(mockedAccessController.hasAccess(mockCert, resourceName, Method.Write.name())).thenReturn(false);
+
+    assertFalse(controllerAccessManager.hasWriteAccessToPubSubTopic(resourceName, mockCert, "host", "127.0.0.1"));
+    verify(mockedAccessController, times(1)).hasAccess(mockCert, resourceName, Method.Write.name());
+  }
+
+  @Test
+  public void testHasAccessHandlesNullCertificate() throws AclException {
+    String resourceName = "test-topic";
+
+    when(mockedAccessController.hasAccess(null, resourceName, Method.Read.name())).thenReturn(true);
+
+    assertTrue(controllerAccessManager.hasReadAccessToPubSubTopic(resourceName, null, "host", "127.0.0.1"));
+    verify(mockedAccessController, times(1)).hasAccess(null, resourceName, Method.Read.name());
+  }
+
+  @Test
+  public void testHasAccessHandlesNullResource() {
+    String resourceName = null;
+    X509Certificate mockCert = mock(X509Certificate.class);
+
+    Exception e = expectThrows(
+        NullPointerException.class,
+        () -> controllerAccessManager.hasAccess(resourceName, mockCert, Method.Write, "host", ""));
+    assertTrue(e.getMessage().contains("Resource name is required to enforce ACL"));
+  }
+
+  @Test
+  public void testHasAccessHandlesNullMethod() {
+    String resourceName = "test-topic";
+    X509Certificate mockCert = mock(X509Certificate.class);
+
+    Exception e = expectThrows(
+        NullPointerException.class,
+        () -> controllerAccessManager.hasAccess(resourceName, mockCert, null, "host", "127.0.0.1"));
+    assertTrue(e.getMessage().contains("Access method is required to enforce ACL"));
+  }
+
+  @Test
+  public void testHasAccessWhenAccessControllerThrowsException() throws AclException {
+    String resourceName = "test-topic";
+    X509Certificate mockCert = mock(X509Certificate.class);
+
+    when(mockedAccessController.hasAccess(mockCert, resourceName, Method.Write.name()))
+        .thenThrow(new AclException("Test exception"));
+
+    assertFalse(controllerAccessManager.hasAccess(resourceName, mockCert, Method.Write, "host", ""));
+    verify(mockedAccessController, times(1)).hasAccess(mockCert, resourceName, Method.Write.name());
+  }
+
+  @Test
+  public void testHasAccessWhenAccessControllerIsNull() {
+    Exception e = expectThrows(NullPointerException.class, () -> new VeniceControllerAccessManager(null));
+    assertTrue(e.getMessage().contains("is required to enforce ACL"));
+  }
+
+  @Test
+  public void testAccessManagerWithNoOpDynamicAccessController() {
+    String resourceName = "test-topic";
+    String hostname = "host";
+    String remoteAddr = "127.0.0.1";
+
+    // Case 1: Non-null certificate
+    X509Certificate mockCert = mock(X509Certificate.class);
+    X500Principal principal = new X500Principal("CN=Test User");
+    doReturn(principal).when(mockCert).getSubjectX500Principal();
+
+    VeniceControllerAccessManager accessManager =
+        new VeniceControllerAccessManager(NoOpDynamicAccessController.INSTANCE);
+    assertTrue(accessManager.hasAccessToStore(resourceName, mockCert, hostname, remoteAddr));
+    assertTrue(accessManager.hasReadAccessToPubSubTopic(resourceName, mockCert, hostname, remoteAddr));
+    assertTrue(accessManager.hasWriteAccessToPubSubTopic(resourceName, mockCert, hostname, remoteAddr));
+    assertTrue(accessManager.isAllowListUser(resourceName, mockCert));
+    assertFalse(accessManager.isAclEnabled());
+    assertEquals(accessManager.getPrincipalId(mockCert), "CN=Test User");
+
+    // Case 2: Null certificate
+    assertTrue(accessManager.hasAccessToStore(resourceName, null, hostname, remoteAddr));
+    assertTrue(accessManager.hasReadAccessToPubSubTopic(resourceName, null, hostname, remoteAddr));
+    assertTrue(accessManager.hasWriteAccessToPubSubTopic(resourceName, null, hostname, remoteAddr));
+    assertTrue(accessManager.isAllowListUser(resourceName, null));
+    assertFalse(accessManager.isAclEnabled());
+    assertEquals(accessManager.getPrincipalId(null), VeniceControllerAccessManager.UNKNOWN_USER);
+  }
+}

--- a/services/venice-controller/src/test/java/com/linkedin/venice/controller/server/VeniceControllerAccessManagerTest.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/controller/server/VeniceControllerAccessManagerTest.java
@@ -64,12 +64,11 @@ public class VeniceControllerAccessManagerTest {
 
   @Test
   public void testHasAccessHandlesNullResource() {
-    String resourceName = null;
     X509Certificate mockCert = mock(X509Certificate.class);
 
     Exception e = expectThrows(
         NullPointerException.class,
-        () -> controllerAccessManager.hasAccess(resourceName, mockCert, Method.Write, "host", ""));
+        () -> controllerAccessManager.hasAccess(null, mockCert, Method.Write, "host", ""));
     assertTrue(e.getMessage().contains("Resource name is required to enforce ACL"));
   }
 

--- a/services/venice-controller/src/test/java/com/linkedin/venice/controller/server/grpc/ControllerGrpcSslSessionInterceptorTest.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/controller/server/grpc/ControllerGrpcSslSessionInterceptorTest.java
@@ -1,0 +1,108 @@
+package com.linkedin.venice.controller.server.grpc;
+
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.grpc.Attributes;
+import io.grpc.Grpc;
+import io.grpc.Metadata;
+import io.grpc.ServerCall;
+import io.grpc.ServerCallHandler;
+import java.net.SocketAddress;
+import java.security.cert.Certificate;
+import java.security.cert.X509Certificate;
+import javax.net.ssl.SSLPeerUnverifiedException;
+import javax.net.ssl.SSLSession;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+
+public class ControllerGrpcSslSessionInterceptorTest {
+  private ControllerGrpcSslSessionInterceptor interceptor;
+  private ServerCall<Object, Object> serverCall;
+  private Metadata metadata;
+  private ServerCallHandler<Object, Object> serverCallHandler;
+
+  @BeforeMethod
+  public void setUp() {
+    interceptor = new ControllerGrpcSslSessionInterceptor();
+    serverCall = mock(ServerCall.class);
+    metadata = new Metadata();
+    serverCallHandler = mock(ServerCallHandler.class);
+  }
+
+  @Test
+  public void testSslSessionNotEnabled() {
+    Attributes attributes = Attributes.newBuilder().build();
+    when(serverCall.getAttributes()).thenReturn(attributes);
+    interceptor.interceptCall(serverCall, metadata, serverCallHandler);
+    verify(serverCall, times(1)).close(
+        eq(ControllerGrpcSslSessionInterceptor.NON_SSL_CONNECTION_ERROR.getStatus()),
+        eq(ControllerGrpcSslSessionInterceptor.NON_SSL_CONNECTION_ERROR.getTrailers()));
+    verify(serverCallHandler, never()).startCall(any(), any());
+  }
+
+  @Test
+  public void testSslSessionEnabledWithValidCertificate() throws SSLPeerUnverifiedException {
+    SSLSession sslSession = mock(SSLSession.class);
+    SocketAddress remoteAddress = mock(SocketAddress.class);
+    X509Certificate clientCertificate = mock(X509Certificate.class);
+
+    Attributes attributes = Attributes.newBuilder()
+        .set(Grpc.TRANSPORT_ATTR_SSL_SESSION, sslSession)
+        .set(Grpc.TRANSPORT_ATTR_REMOTE_ADDR, remoteAddress)
+        .build();
+
+    when(serverCall.getAttributes()).thenReturn(attributes);
+    when(remoteAddress.toString()).thenReturn("remote-address");
+    Certificate[] peerCertificates = new Certificate[] { clientCertificate };
+    when(sslSession.getPeerCertificates()).thenReturn(peerCertificates);
+
+    interceptor.interceptCall(serverCall, metadata, serverCallHandler);
+
+    verify(serverCallHandler, times(1)).startCall(serverCall, metadata);
+  }
+
+  @Test
+  public void testCertificateExtractionFails() throws SSLPeerUnverifiedException {
+    SSLSession sslSession = mock(SSLSession.class);
+    SocketAddress remoteAddress = mock(SocketAddress.class);
+
+    Attributes attributes = Attributes.newBuilder()
+        .set(Grpc.TRANSPORT_ATTR_SSL_SESSION, sslSession)
+        .set(Grpc.TRANSPORT_ATTR_REMOTE_ADDR, remoteAddress)
+        .build();
+
+    when(serverCall.getAttributes()).thenReturn(attributes);
+    doThrow(new RuntimeException("Failed to extract certificate")).when(sslSession).getPeerCertificates();
+
+    interceptor.interceptCall(serverCall, metadata, serverCallHandler);
+
+    verify(serverCall, times(1)).close(
+        eq(ControllerGrpcSslSessionInterceptor.NON_SSL_CONNECTION_ERROR.getStatus()),
+        eq(ControllerGrpcSslSessionInterceptor.NON_SSL_CONNECTION_ERROR.getTrailers()));
+    verify(serverCallHandler, never()).startCall(any(), any());
+  }
+
+  @Test
+  public void testRemoteAddressUnknown() throws SSLPeerUnverifiedException {
+    SSLSession sslSession = mock(SSLSession.class);
+    X509Certificate clientCertificate = mock(X509Certificate.class);
+
+    Attributes attributes = Attributes.newBuilder().set(Grpc.TRANSPORT_ATTR_SSL_SESSION, sslSession).build();
+
+    when(serverCall.getAttributes()).thenReturn(attributes);
+    Certificate[] peerCertificates = new Certificate[] { clientCertificate };
+    when(sslSession.getPeerCertificates()).thenReturn(peerCertificates);
+
+    interceptor.interceptCall(serverCall, metadata, serverCallHandler);
+
+    verify(serverCallHandler, times(1)).startCall(serverCall, metadata);
+  }
+}


### PR DESCRIPTION
<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## [controller] Add interceptor to enforce SSL/TLS and propagate client attributes in gRPC controller server
This commit introduces a gRPC interceptor that ensures all incoming connections use SSL/TLS 
and extracts client SSL attributes for downstream processing.

Key features:
- Validates the presence of an SSL session for each gRPC call.
- Extracts client certificate and remote address details.
- Injects extracted attributes into the gRPC context for downstream access.
- Rejects calls without SSL/TLS with an UNAUTHENTICATED status.


## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [ ] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.