### PR TITLE
[duckdb] Utility to compare table schemas

### DIFF
--- a/gradle/spotbugs/exclude.xml
+++ b/gradle/spotbugs/exclude.xml
@@ -77,6 +77,7 @@
       <Class name="com.linkedin.davinci.StoreBackendTest"/>
       <Class name="com.linkedin.venice.memory.ClassSizeEstimatorTest"/>
       <Class name="com.linkedin.venice.controller.server.VeniceControllerAccessManagerTest"/>
+      <Class name="com.linkedin.venice.sql.SQLUtilsTest"/>
     </Or>
   </Match>
   <Match>
@@ -500,9 +501,12 @@
   <Match>
     <Bug pattern="SQL_NONCONSTANT_STRING_PASSED_TO_EXECUTE"/>
     <Or>
-      <Class name="com.linkedin.venice.duckdb.HelloWorldTest"/>
+      <Class name="com.linkedin.venice.duckdb.DuckDBHelloWorldTest"/>
       <Class name="com.linkedin.venice.duckdb.DuckDBAvroToSQLTest"/>
       <Class name="com.linkedin.venice.duckdb.DuckDBDaVinciRecordTransformer"/>
+      <Class name="com.linkedin.venice.sql.SQLHelloWorldTest"/>
+      <Class name="com.linkedin.venice.sql.SQLUtilsTest"/>
+      <Class name="com.linkedin.venice.sql.SQLUtils"/>
     </Or>
   </Match>
   <Match>

--- a/integrations/venice-duckdb/build.gradle
+++ b/integrations/venice-duckdb/build.gradle
@@ -2,6 +2,7 @@ dependencies {
   implementation libraries.avro
   implementation libraries.avroUtilCompatHelper
   implementation libraries.duckdbJdbc
+  api libraries.log4j2api
 
   implementation project(':clients:da-vinci-client')
   implementation project(':internal:venice-client-common')

--- a/integrations/venice-duckdb/src/main/java/com/linkedin/venice/duckdb/DuckDBDaVinciRecordTransformer.java
+++ b/integrations/venice-duckdb/src/main/java/com/linkedin/venice/duckdb/DuckDBDaVinciRecordTransformer.java
@@ -31,7 +31,6 @@ public class DuckDBDaVinciRecordTransformer
   private static final String duckDBFilePath = "my_database.duckdb";
   // ToDo: Don't hardcode the table name. Get it from the storeName
   private static final String baseVersionTableName = "my_table_v";
-  private static final Set<String> primaryKeys = Collections.singleton("firstName");
   private static final String deleteStatementTemplate = "DELETE FROM %s WHERE %s = ?;";
   private static final String createViewStatementTemplate =
       "CREATE OR REPLACE VIEW current_version AS SELECT * FROM %s;";
@@ -135,7 +134,7 @@ public class DuckDBDaVinciRecordTransformer
         String createTableStatement = SQLUtils.createTableStatement(desiredTableDefinition);
         stmt.execute(createTableStatement);
       } else if (existingTableDefinition.equals(desiredTableDefinition)) {
-        LOGGER.info("Table '{}' found on disk and its schema is compatible. Will reuse.");
+        LOGGER.info("Table '{}' found on disk and its schema is compatible. Will reuse.", this.versionTableName);
       } else {
         // TODO: Handle the wiping and re-bootstrap automatically.
         throw new VeniceException(

--- a/integrations/venice-duckdb/src/main/java/com/linkedin/venice/sql/ColumnDefinition.java
+++ b/integrations/venice-duckdb/src/main/java/com/linkedin/venice/sql/ColumnDefinition.java
@@ -1,0 +1,109 @@
+package com.linkedin.venice.sql;
+
+import java.sql.JDBCType;
+import java.util.Objects;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+
+public class ColumnDefinition {
+  @Nonnull
+  private final String name;
+  @Nonnull
+  private final JDBCType type;
+  private final boolean nullable;
+  @Nullable
+  private final IndexType indexType;
+  @Nullable
+  private final String defaultValue;
+  @Nullable
+  private final String extra;
+  private final int jdbcIndex;
+
+  public ColumnDefinition(@Nonnull String name, @Nonnull JDBCType type, int jdbcIndex) {
+    this(name, type, true, null, jdbcIndex);
+  }
+
+  public ColumnDefinition(
+      @Nonnull String name,
+      @Nonnull JDBCType type,
+      boolean nullable,
+      @Nullable IndexType indexType,
+      int jdbcIndex) {
+    this(name, type, nullable, indexType, null, null, jdbcIndex);
+  }
+
+  public ColumnDefinition(
+      @Nonnull String name,
+      @Nonnull JDBCType type,
+      boolean nullable,
+      @Nullable IndexType indexType,
+      @Nullable String defaultValue,
+      @Nullable String extra,
+      int jdbcIndex) {
+    this.name = Objects.requireNonNull(name);
+    this.type = Objects.requireNonNull(type);
+    this.nullable = nullable;
+    this.indexType = indexType;
+    this.defaultValue = defaultValue;
+    this.extra = extra;
+    this.jdbcIndex = jdbcIndex;
+    if (this.jdbcIndex < 1) {
+      throw new IllegalArgumentException("The jdbcIndex must be at least 1");
+    }
+  }
+
+  @Nonnull
+  public String getName() {
+    return name;
+  }
+
+  @Nonnull
+  public JDBCType getType() {
+    return type;
+  }
+
+  public boolean isNullable() {
+    return nullable;
+  }
+
+  @Nullable
+  public IndexType getIndexType() {
+    return indexType;
+  }
+
+  @Nullable
+  public String getDefaultValue() {
+    return defaultValue;
+  }
+
+  @Nullable
+  public String getExtra() {
+    return extra;
+  }
+
+  public int getJdbcIndex() {
+    return jdbcIndex;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+
+    ColumnDefinition that = (ColumnDefinition) o;
+
+    return this.nullable == that.nullable && this.jdbcIndex == that.jdbcIndex && this.name.equals(that.name)
+        && this.type == that.type && this.indexType == that.indexType && Objects.equals(defaultValue, that.defaultValue)
+        && Objects.equals(extra, that.extra);
+  }
+
+  @Override
+  public int hashCode() {
+    return this.name.hashCode();
+  }
+}

--- a/integrations/venice-duckdb/src/main/java/com/linkedin/venice/sql/IndexType.java
+++ b/integrations/venice-duckdb/src/main/java/com/linkedin/venice/sql/IndexType.java
@@ -1,0 +1,5 @@
+package com.linkedin.venice.sql;
+
+public enum IndexType {
+  PRIMARY_KEY, UNIQUE;
+}

--- a/integrations/venice-duckdb/src/main/java/com/linkedin/venice/sql/SQLUtils.java
+++ b/integrations/venice-duckdb/src/main/java/com/linkedin/venice/sql/SQLUtils.java
@@ -1,0 +1,130 @@
+package com.linkedin.venice.sql;
+
+import java.sql.Connection;
+import java.sql.JDBCType;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+
+public class SQLUtils {
+  private static final String SHOW_TABLE_COLUMN_NAME = "column_name";
+  private static final String SHOW_TABLE_TYPE = "column_type";
+  private static final String SHOW_TABLE_NULLABLE = "null";
+  private static final String SHOW_TABLE_INDEX_TYPE = "key";
+  private static final String SHOW_TABLE_DEFAULT = "default";
+  private static final String SHOW_TABLE_EXTRA = "extra";
+
+  private SQLUtils() {
+    /**
+     * Static utils.
+     *
+     * If we wish to specialize the behavior of this class for different DB vendors, then we can change it to
+     * an abstract class and have instantiable subclasses for each vendor.
+     */
+  }
+
+  @Nullable
+  public static TableDefinition getTableDefinition(@Nonnull String tableName, Connection connection)
+      throws SQLException {
+    try (PreparedStatement preparedStatement =
+        connection.prepareStatement("SELECT * FROM (SHOW TABLES) WHERE name = ?;")) {
+      preparedStatement.setString(1, cleanTableName(tableName));
+      try (ResultSet resultSet = preparedStatement.executeQuery()) {
+        if (!resultSet.next()) {
+          return null;
+        }
+      }
+    }
+    try (Statement statement = connection.createStatement();
+        ResultSet resultSet = statement.executeQuery("SHOW " + cleanTableName(tableName))) {
+      int jdbcIndex = 1;
+      List<ColumnDefinition> columns = new ArrayList<>();
+      while (resultSet.next()) {
+        columns.add(convertToColumnDefinition(resultSet, jdbcIndex++));
+      }
+      return new TableDefinition(tableName, columns);
+    }
+  }
+
+  @Nonnull
+  public static String createTableStatement(TableDefinition tableDefinition) {
+    StringBuffer stringBuffer = new StringBuffer();
+    stringBuffer.append("CREATE TABLE " + cleanTableName(tableDefinition.getName()) + "(");
+    boolean firstColumn = true;
+
+    for (ColumnDefinition columnDefinition: tableDefinition.getColumns()) {
+      if (firstColumn) {
+        firstColumn = false;
+      } else {
+        stringBuffer.append(", ");
+      }
+
+      stringBuffer.append(cleanColumnName(columnDefinition.getName()) + " " + columnDefinition.getType().name());
+    }
+
+    firstColumn = true;
+    if (!tableDefinition.getPrimaryKeyColumns().isEmpty()) {
+      stringBuffer.append(", PRIMARY KEY(");
+      for (ColumnDefinition columnDefinition: tableDefinition.getPrimaryKeyColumns()) {
+        if (firstColumn) {
+          firstColumn = false;
+        } else {
+          stringBuffer.append(", ");
+        }
+        stringBuffer.append(cleanColumnName(columnDefinition.getName()));
+      }
+      stringBuffer.append(")");
+    }
+    stringBuffer.append(");");
+
+    return stringBuffer.toString();
+  }
+
+  /**
+   * This function should encapsulate the handling of any illegal characters (by either failing or converting them).
+   */
+  @Nonnull
+  static String cleanTableName(@Nonnull String avroRecordName) {
+    return Objects.requireNonNull(avroRecordName);
+  }
+
+  /**
+   * This function should encapsulate the handling of any illegal characters (by either failing or converting them).
+   */
+  @Nonnull
+  static String cleanColumnName(@Nonnull String avroFieldName) {
+    return Objects.requireNonNull(avroFieldName);
+  }
+
+  /**
+   * {@link ResultSet#next()} should have already been called upstream. This function will not call it.
+   */
+  private static ColumnDefinition convertToColumnDefinition(ResultSet resultSet, int jdbcIndex) throws SQLException {
+    return new ColumnDefinition(
+        resultSet.getString(SHOW_TABLE_COLUMN_NAME),
+        JDBCType.valueOf(resultSet.getString(SHOW_TABLE_TYPE)),
+        resultSet.getString(SHOW_TABLE_NULLABLE).equals("YES"),
+        convertIndexType(resultSet.getString(SHOW_TABLE_INDEX_TYPE)),
+        resultSet.getString(SHOW_TABLE_DEFAULT),
+        resultSet.getString(SHOW_TABLE_EXTRA),
+        jdbcIndex);
+  }
+
+  private static IndexType convertIndexType(String indexType) {
+    if (indexType == null) {
+      return null;
+    } else if (indexType.equals("PRI")) {
+      return IndexType.PRIMARY_KEY;
+    } else if (indexType.equals("UNI")) {
+      return IndexType.UNIQUE;
+    }
+    throw new IllegalArgumentException("Unsupported index type: " + indexType);
+  }
+}

--- a/integrations/venice-duckdb/src/main/java/com/linkedin/venice/sql/TableDefinition.java
+++ b/integrations/venice-duckdb/src/main/java/com/linkedin/venice/sql/TableDefinition.java
@@ -1,0 +1,102 @@
+package com.linkedin.venice.sql;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+
+public class TableDefinition {
+  @Nonnull
+  private final String name;
+  @Nonnull
+  private final List<ColumnDefinition> columns;
+  @Nonnull
+  private final List<ColumnDefinition> primaryKeyColumns;
+
+  public TableDefinition(@Nonnull String name, @Nonnull List<ColumnDefinition> columns) {
+    this.name = Objects.requireNonNull(name);
+    this.columns = Collections.unmodifiableList(columns);
+    if (this.columns.isEmpty()) {
+      throw new IllegalArgumentException("columns cannot be empty!");
+    }
+    for (int i = 0; i < this.columns.size(); i++) {
+      ColumnDefinition columnDefinition = this.columns.get(i);
+      if (columnDefinition == null) {
+        throw new IllegalArgumentException(
+            "The columns list must be densely populated, but found a null entry at index: " + i);
+      }
+      int expectedJdbcIndex = i + 1;
+      if (columnDefinition.getJdbcIndex() != expectedJdbcIndex) {
+        throw new IllegalArgumentException(
+            "The columns list must be populated in the correct order, column '" + columnDefinition.getName()
+                + "' found at index " + i + " but its JDBC index is " + columnDefinition.getJdbcIndex() + " (expected "
+                + expectedJdbcIndex + ").");
+      }
+    }
+    List<ColumnDefinition> pkColumns = new ArrayList<>();
+    for (ColumnDefinition columnDefinition: this.columns) {
+      if (columnDefinition.getIndexType() == IndexType.PRIMARY_KEY) {
+        pkColumns.add(columnDefinition);
+      }
+    }
+    this.primaryKeyColumns = pkColumns.isEmpty() ? Collections.emptyList() : Collections.unmodifiableList(pkColumns);
+  }
+
+  @Nonnull
+  public String getName() {
+    return name;
+  }
+
+  @Nonnull
+  public List<ColumnDefinition> getColumns() {
+    return columns;
+  }
+
+  @Nonnull
+  ColumnDefinition getColumnByJdbcIndex(int index) {
+    if (index < 1 || index > this.columns.size()) {
+      throw new IndexOutOfBoundsException("Invalid index. The valid range is: 1.." + this.columns.size());
+    }
+    return this.columns.get(index - 1);
+  }
+
+  @Nullable
+  ColumnDefinition getColumnByName(@Nonnull String columnName) {
+    Objects.requireNonNull(columnName);
+    for (int i = 0; i < this.columns.size(); i++) {
+      ColumnDefinition columnDefinition = this.columns.get(i);
+      if (columnDefinition.getName().equals(columnName)) {
+        return columnDefinition;
+      }
+    }
+    return null;
+  }
+
+  @Nonnull
+  public List<ColumnDefinition> getPrimaryKeyColumns() {
+    return primaryKeyColumns;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+
+    TableDefinition that = (TableDefinition) o;
+
+    return this.name.equals(that.name) && this.columns.equals(that.columns)
+        && this.primaryKeyColumns.equals(that.primaryKeyColumns);
+  }
+
+  @Override
+  public int hashCode() {
+    return this.name.hashCode();
+  }
+}

--- a/integrations/venice-duckdb/src/test/java/com/linkedin/venice/duckdb/DuckDBAvroToSQLTest.java
+++ b/integrations/venice-duckdb/src/test/java/com/linkedin/venice/duckdb/DuckDBAvroToSQLTest.java
@@ -9,6 +9,7 @@ import static org.testng.Assert.assertTrue;
 import com.linkedin.venice.sql.AvroToSQL;
 import com.linkedin.venice.sql.AvroToSQLTest;
 import com.linkedin.venice.sql.InsertProcessor;
+import com.linkedin.venice.sql.SQLUtils;
 import com.linkedin.venice.utils.ByteUtils;
 import java.io.IOException;
 import java.nio.ByteBuffer;
@@ -67,8 +68,8 @@ public class DuckDBAvroToSQLTest {
         Statement stmt = connection.createStatement()) {
       // create a table
       String tableName = "MyRecord_v1";
-      String createTableStatement =
-          AvroToSQL.createTableStatement(tableName, keySchema, valueSchema, Collections.emptySet(), SKIP, true);
+      String createTableStatement = SQLUtils.createTableStatement(
+          AvroToSQL.getTableDefinition(tableName, keySchema, valueSchema, Collections.emptySet(), SKIP, true));
       System.out.println(createTableStatement);
       stmt.execute(createTableStatement);
 

--- a/integrations/venice-duckdb/src/test/java/com/linkedin/venice/duckdb/DuckDBHelloWorldTest.java
+++ b/integrations/venice-duckdb/src/test/java/com/linkedin/venice/duckdb/DuckDBHelloWorldTest.java
@@ -1,0 +1,59 @@
+package com.linkedin.venice.duckdb;
+
+import com.linkedin.venice.sql.SQLHelloWorldTest;
+import com.linkedin.venice.utils.Utils;
+import java.io.File;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import org.duckdb.DuckDBAppender;
+import org.duckdb.DuckDBConnection;
+import org.testng.annotations.Test;
+
+
+/**
+ * The aim of this class is just to test DuckDB itself, without any Venice-ism involved.
+ */
+public class DuckDBHelloWorldTest extends SQLHelloWorldTest {
+  public static final String DUCKDB_CONN_PREFIX = "jdbc:duckdb:";
+
+  @Override
+  protected Connection getConnection() throws SQLException {
+    return DriverManager.getConnection(DUCKDB_CONN_PREFIX);
+  }
+
+  @Override
+  protected String getConnectionStringToPersistentDB() {
+    File tmpDir = Utils.getTempDataDirectory();
+    return DUCKDB_CONN_PREFIX + tmpDir.getAbsolutePath() + "/foo.duckdb";
+  }
+
+  @Test
+  public void testAppender() throws SQLException {
+    try (DuckDBConnection connection = (DuckDBConnection) getConnection();
+        Statement stmt = connection.createStatement()) {
+      // create a table
+      stmt.execute(createTableStatement("items", true));
+      // insert two items into the table
+      try (DuckDBAppender appender = connection.createAppender(DuckDBConnection.DEFAULT_SCHEMA, "items")) {
+        appender.beginRow();
+        appender.append("jeans");
+        appender.append(20.0);
+        appender.append(1);
+        appender.endRow();
+
+        appender.beginRow();
+        appender.append("hammer");
+        appender.append(42.2);
+        appender.append(2);
+        appender.endRow();
+      }
+
+      try (ResultSet rs = stmt.executeQuery("SELECT * FROM items")) {
+        assertValidityOfResultSet1(rs);
+      }
+    }
+  }
+}

--- a/integrations/venice-duckdb/src/test/java/com/linkedin/venice/duckdb/DuckDBSQLUtilsTest.java
+++ b/integrations/venice-duckdb/src/test/java/com/linkedin/venice/duckdb/DuckDBSQLUtilsTest.java
@@ -1,0 +1,16 @@
+package com.linkedin.venice.duckdb;
+
+import com.linkedin.venice.sql.SQLUtilsTest;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.SQLException;
+import org.testng.annotations.Test;
+
+
+@Test
+public class DuckDBSQLUtilsTest extends SQLUtilsTest {
+  @Override
+  protected Connection getConnection() throws SQLException {
+    return DriverManager.getConnection(DuckDBHelloWorldTest.DUCKDB_CONN_PREFIX);
+  }
+}

--- a/integrations/venice-duckdb/src/test/java/com/linkedin/venice/sql/SQLUtilsTest.java
+++ b/integrations/venice-duckdb/src/test/java/com/linkedin/venice/sql/SQLUtilsTest.java
@@ -1,0 +1,183 @@
+package com.linkedin.venice.sql;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNotEquals;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertNotSame;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertThrows;
+import static org.testng.Assert.assertTrue;
+
+import java.sql.Connection;
+import java.sql.JDBCType;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import org.testng.annotations.Test;
+
+
+public abstract class SQLUtilsTest {
+  private static final String TABLE_NAME = "items";
+  private static final String KEY1_NAME = "key1";
+  private static final String KEY2_NAME = "key2";
+  private static final String VAL1_NAME = "val1";
+  private static final String VAL2_NAME = "val2";
+
+  protected abstract Connection getConnection() throws SQLException;
+
+  @Test
+  public void pojoTesting() {
+    // Basics
+    TableDefinition tableDefinition = getTableDefinition();
+    assertEquals(tableDefinition.getName(), TABLE_NAME);
+    assertEquals(tableDefinition.getColumns().size(), 4);
+    assertEquals(tableDefinition.getPrimaryKeyColumns().size(), 2);
+
+    int expectedJdbcIndex = 1;
+    ColumnDefinition key1 = tableDefinition.getColumnByJdbcIndex(expectedJdbcIndex);
+    assertNotNull(key1);
+    assertEquals(key1.getName(), KEY1_NAME);
+    assertEquals(key1.getType(), JDBCType.INTEGER);
+    assertFalse(key1.isNullable());
+    assertEquals(key1.getIndexType(), IndexType.PRIMARY_KEY);
+    assertNull(key1.getDefaultValue());
+    assertNull(key1.getExtra());
+    assertEquals(key1.getJdbcIndex(), expectedJdbcIndex++);
+
+    ColumnDefinition key2 = tableDefinition.getColumnByJdbcIndex(expectedJdbcIndex);
+    assertNotNull(key2);
+    assertEquals(key2.getName(), KEY2_NAME);
+    assertEquals(key2.getType(), JDBCType.BIGINT);
+    assertFalse(key2.isNullable());
+    assertEquals(key2.getIndexType(), IndexType.PRIMARY_KEY);
+    assertNull(key2.getDefaultValue());
+    assertNull(key2.getExtra());
+    assertEquals(key2.getJdbcIndex(), expectedJdbcIndex++);
+
+    ColumnDefinition val1 = tableDefinition.getColumnByJdbcIndex(expectedJdbcIndex);
+    assertNotNull(val1);
+    assertEquals(val1.getName(), VAL1_NAME);
+    assertEquals(val1.getType(), JDBCType.VARCHAR);
+    assertTrue(val1.isNullable());
+    assertNull(val1.getIndexType());
+    assertNull(val1.getDefaultValue());
+    assertNull(val1.getExtra());
+    assertEquals(val1.getJdbcIndex(), expectedJdbcIndex++);
+
+    ColumnDefinition val2 = tableDefinition.getColumnByJdbcIndex(expectedJdbcIndex);
+    assertNotNull(val2);
+    assertEquals(val2.getName(), VAL2_NAME);
+    assertEquals(val2.getType(), JDBCType.DOUBLE);
+    assertTrue(val2.isNullable());
+    assertNull(val2.getIndexType());
+    assertNull(val2.getDefaultValue());
+    assertNull(val2.getExtra());
+    assertEquals(val2.getJdbcIndex(), expectedJdbcIndex++);
+
+    // Equality checks
+    TableDefinition otherTableDefinition = getTableDefinition();
+    assertNotSame(tableDefinition, otherTableDefinition);
+    assertEquals(tableDefinition, otherTableDefinition);
+    assertEquals(tableDefinition, tableDefinition);
+
+    TableDefinition differentTableDefinition = new TableDefinition(TABLE_NAME, Collections.singletonList(key1));
+    assertNotEquals(tableDefinition, differentTableDefinition);
+
+    assertNotEquals(tableDefinition, null);
+    assertNotEquals(null, tableDefinition);
+    assertNotEquals(tableDefinition, "");
+    assertNotEquals("", tableDefinition);
+
+    ColumnDefinition otherKey1 = otherTableDefinition.getColumnByName(KEY1_NAME);
+    assertNotSame(key1, otherKey1);
+    assertEquals(key1, otherKey1);
+    assertEquals(key1, key1);
+
+    ColumnDefinition otherKey2 = otherTableDefinition.getColumnByName(KEY2_NAME);
+    assertNotSame(key2, otherKey2);
+    assertEquals(key2, otherKey2);
+
+    ColumnDefinition otherVal1 = otherTableDefinition.getColumnByName(VAL1_NAME);
+    assertNotSame(val1, otherVal1);
+    assertEquals(val1, otherVal1);
+
+    ColumnDefinition otherVal2 = otherTableDefinition.getColumnByName(VAL2_NAME);
+    assertNotSame(val2, otherVal2);
+    assertEquals(val2, otherVal2);
+
+    assertNull(otherTableDefinition.getColumnByName("bogus"));
+
+    assertNotEquals(key1, null);
+    assertNotEquals(null, key1);
+    assertNotEquals(key1, "");
+    assertNotEquals("", key1);
+
+    // Invalid inputs
+    assertThrows(NullPointerException.class, () -> new TableDefinition(null, Collections.emptyList()));
+    assertThrows(IllegalArgumentException.class, () -> new TableDefinition(TABLE_NAME, Collections.emptyList()));
+
+    assertThrows(IllegalArgumentException.class, () -> new ColumnDefinition(KEY1_NAME, JDBCType.INTEGER, 0));
+    assertThrows(IllegalArgumentException.class, () -> new ColumnDefinition(VAL1_NAME, JDBCType.VARCHAR, 0));
+
+    List<ColumnDefinition> outOfOrderColumns = new ArrayList<>();
+    outOfOrderColumns.add(key2);
+    outOfOrderColumns.add(key1);
+    assertThrows(IllegalArgumentException.class, () -> new TableDefinition(TABLE_NAME, outOfOrderColumns));
+
+    List<ColumnDefinition> sparseColumns = new ArrayList<>();
+    sparseColumns.add(key1);
+    sparseColumns.add(key2);
+    sparseColumns.add(1, null);
+    assertThrows(IllegalArgumentException.class, () -> new TableDefinition(TABLE_NAME, sparseColumns));
+
+    assertThrows(IndexOutOfBoundsException.class, () -> tableDefinition.getColumnByJdbcIndex(0));
+    assertThrows(IndexOutOfBoundsException.class, () -> tableDefinition.getColumnByJdbcIndex(5));
+  }
+
+  @Test
+  public void testGetTableDefinition() throws SQLException {
+    try (Connection connection = getConnection(); Statement statement = connection.createStatement()) {
+      // Starting point: empty
+      assertNull(SQLUtils.getTableDefinition(TABLE_NAME, connection));
+
+      String differentTable = "not_the_table_we_want";
+      statement.execute(
+          "CREATE TABLE " + differentTable + " (" + KEY1_NAME + " INTEGER, " + KEY2_NAME + " BIGINT, " + VAL1_NAME
+              + " VARCHAR UNIQUE, " + VAL2_NAME + " DOUBLE, PRIMARY KEY (key1, key2));");
+
+      assertNull(SQLUtils.getTableDefinition(TABLE_NAME, connection));
+
+      statement.execute(
+          "CREATE TABLE " + TABLE_NAME + " (" + KEY1_NAME + " INTEGER, " + KEY2_NAME + " BIGINT, " + VAL1_NAME
+              + " VARCHAR, " + VAL2_NAME + " DOUBLE, PRIMARY KEY (key1, key2));");
+
+      TableDefinition tableDefinition = SQLUtils.getTableDefinition(TABLE_NAME, connection);
+      assertNotNull(tableDefinition);
+
+      TableDefinition expectedTableDefinition = getTableDefinition();
+      assertEquals(tableDefinition, expectedTableDefinition);
+
+      TableDefinition differentTableDefinition = SQLUtils.getTableDefinition(differentTable, connection);
+      assertNotNull(differentTableDefinition);
+      assertNotEquals(tableDefinition, differentTableDefinition);
+    }
+  }
+
+  private TableDefinition getTableDefinition() {
+    int jdbcIndex = 1;
+    ColumnDefinition key1 =
+        new ColumnDefinition(KEY1_NAME, JDBCType.INTEGER, false, IndexType.PRIMARY_KEY, jdbcIndex++);
+    ColumnDefinition key2 = new ColumnDefinition(KEY2_NAME, JDBCType.BIGINT, false, IndexType.PRIMARY_KEY, jdbcIndex++);
+    ColumnDefinition val1 = new ColumnDefinition(VAL1_NAME, JDBCType.VARCHAR, jdbcIndex++);
+    ColumnDefinition val2 = new ColumnDefinition(VAL2_NAME, JDBCType.DOUBLE, jdbcIndex++);
+    List<ColumnDefinition> columns = new ArrayList<>();
+    columns.add(key1);
+    columns.add(key2);
+    columns.add(val1);
+    columns.add(val2);
+    return new TableDefinition(TABLE_NAME, columns);
+  }
+}


### PR DESCRIPTION
This is used to check whether a pre-existing table on disk has a schema equal to the one we want.

Did this by introducing various utility classes, including:

- ColumnDefinition
- TableDefinition
- IndexType
- SQLUtils

Also refactored unit tests to decouple from DuckDB, so that it's easier to test other engines in the future (e.g., SQLite).

## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
New unit tests.

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.