### PR TITLE
[controller] Enforce ACL checks on gRPC createStore API

### DIFF
--- a/internal/venice-common/src/main/java/com/linkedin/venice/acl/NoOpDynamicAccessController.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/acl/NoOpDynamicAccessController.java
@@ -14,7 +14,7 @@ public class NoOpDynamicAccessController implements DynamicAccessController {
 
   public static final NoOpDynamicAccessController INSTANCE = new NoOpDynamicAccessController();
 
-  private NoOpDynamicAccessController() {
+  protected NoOpDynamicAccessController() {
   }
 
   @Override

--- a/internal/venice-common/src/main/java/com/linkedin/venice/controllerapi/transport/GrpcRequestResponseConverter.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/controllerapi/transport/GrpcRequestResponseConverter.java
@@ -33,7 +33,7 @@ public class GrpcRequestResponseConverter {
    *
    * @param code            The gRPC status code representing the error (e.g., {@link io.grpc.Status.Code}).
    * @param errorType       The specific controller error type represented by {@link ControllerGrpcErrorType}.
-   * @param e               The exception containing the error message.
+   * @param errorMessage    The error message to be included in the response.
    * @param clusterName     The name of the cluster associated with the error (can be null).
    * @param storeName       The name of the store associated with the error (can be null).
    * @param responseObserver The {@link StreamObserver} to send the error response back to the client.
@@ -62,14 +62,14 @@ public class GrpcRequestResponseConverter {
   public static void sendErrorResponse(
       Code code,
       ControllerGrpcErrorType errorType,
-      Exception e,
+      String errorMessage,
       String clusterName,
       String storeName,
       StreamObserver<?> responseObserver) {
     VeniceControllerGrpcErrorInfo.Builder errorInfoBuilder =
         VeniceControllerGrpcErrorInfo.newBuilder().setStatusCode(code.value()).setErrorType(errorType);
-    if (e.getMessage() != null) {
-      errorInfoBuilder.setErrorMessage(e.getMessage());
+    if (errorMessage != null) {
+      errorInfoBuilder.setErrorMessage(errorMessage);
     }
     if (clusterName != null) {
       errorInfoBuilder.setClusterName(clusterName);
@@ -83,6 +83,22 @@ public class GrpcRequestResponseConverter {
 
     // Send the error response
     responseObserver.onError(StatusProto.toStatusRuntimeException(status));
+  }
+
+  public static void sendErrorResponse(
+      Code code,
+      ControllerGrpcErrorType errorType,
+      Exception exception,
+      String clusterName,
+      String storeName,
+      StreamObserver<?> responseObserver) {
+    sendErrorResponse(
+        code,
+        errorType,
+        exception != null ? exception.getMessage() : "",
+        clusterName,
+        storeName,
+        responseObserver);
   }
 
   /**

--- a/internal/venice-common/src/main/proto/VeniceControllerGrpcService.proto
+++ b/internal/venice-common/src/main/proto/VeniceControllerGrpcService.proto
@@ -62,6 +62,7 @@ enum ControllerGrpcErrorType {
   BAD_REQUEST = 8;
   CONCURRENT_BATCH_PUSH = 9;
   RESOURCE_STILL_EXISTS = 10;
+  UNAUTHORIZED = 11;
 }
 
 message VeniceControllerGrpcErrorInfo {

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/controller/TestControllerSecureGrpcServer.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/controller/TestControllerSecureGrpcServer.java
@@ -1,9 +1,10 @@
 package com.linkedin.venice.controller;
 
-import static com.linkedin.venice.controller.server.grpc.ControllerGrpcSslSessionInterceptor.CLIENT_CERTIFICATE_CONTEXT_KEY;
+import static com.linkedin.venice.controller.server.grpc.ControllerGrpcSslSessionInterceptor.GRPC_CONTROLLER_CLIENT_DETAILS;
 import static org.testng.Assert.assertEquals;
 
 import com.linkedin.venice.controller.server.grpc.ControllerGrpcSslSessionInterceptor;
+import com.linkedin.venice.controller.server.grpc.GrpcControllerClientDetails;
 import com.linkedin.venice.grpc.GrpcUtils;
 import com.linkedin.venice.grpc.VeniceGrpcServer;
 import com.linkedin.venice.grpc.VeniceGrpcServerConfig;
@@ -18,7 +19,6 @@ import io.grpc.ChannelCredentials;
 import io.grpc.Context;
 import io.grpc.Grpc;
 import io.grpc.ManagedChannel;
-import java.security.cert.X509Certificate;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
@@ -57,9 +57,12 @@ public class TestControllerSecureGrpcServer {
     public void discoverClusterForStore(
         DiscoverClusterGrpcRequest request,
         io.grpc.stub.StreamObserver<DiscoverClusterGrpcResponse> responseObserver) {
-      X509Certificate clientCert = CLIENT_CERTIFICATE_CONTEXT_KEY.get(Context.current());
-      if (clientCert == null) {
+      GrpcControllerClientDetails clientDetails = GRPC_CONTROLLER_CLIENT_DETAILS.get(Context.current());
+      if (clientDetails.getClientCertificate() == null) {
         throw new RuntimeException("Client cert is null");
+      }
+      if (clientDetails.getClientAddress() == null) {
+        throw new RuntimeException("Client address is null");
       }
       DiscoverClusterGrpcResponse discoverClusterGrpcResponse =
           DiscoverClusterGrpcResponse.newBuilder().setClusterName("test-cluster").build();

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/integration/utils/VeniceClusterCreateOptions.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/integration/utils/VeniceClusterCreateOptions.java
@@ -12,6 +12,7 @@ import static com.linkedin.venice.integration.utils.VeniceClusterWrapperConstant
 import static com.linkedin.venice.integration.utils.VeniceClusterWrapperConstants.DEFAULT_SSL_TO_STORAGE_NODES;
 import static com.linkedin.venice.integration.utils.VeniceClusterWrapperConstants.STANDALONE_REGION_NAME;
 
+import com.linkedin.venice.acl.DynamicAccessController;
 import com.linkedin.venice.utils.Utils;
 import java.util.Collections;
 import java.util.Map;
@@ -44,6 +45,7 @@ public class VeniceClusterCreateOptions {
   private final ZkServerWrapper zkServerWrapper;
   private final String veniceZkBasePath;
   private final PubSubBrokerWrapper pubSubBrokerWrapper;
+  private final DynamicAccessController accessController;
 
   private VeniceClusterCreateOptions(Builder builder) {
     this.clusterName = builder.clusterName;
@@ -71,6 +73,7 @@ public class VeniceClusterCreateOptions {
     this.zkServerWrapper = builder.zkServerWrapper;
     this.veniceZkBasePath = builder.veniceZkBasePath;
     this.pubSubBrokerWrapper = builder.pubSubBrokerWrapper;
+    this.accessController = builder.accessController;
   }
 
   public String getClusterName() {
@@ -171,6 +174,10 @@ public class VeniceClusterCreateOptions {
 
   public PubSubBrokerWrapper getKafkaBrokerWrapper() {
     return pubSubBrokerWrapper;
+  }
+
+  public DynamicAccessController getAccessController() {
+    return accessController;
   }
 
   @Override
@@ -279,6 +286,7 @@ public class VeniceClusterCreateOptions {
     private ZkServerWrapper zkServerWrapper;
     private String veniceZkBasePath = "/";
     private PubSubBrokerWrapper pubSubBrokerWrapper;
+    private DynamicAccessController accessController;
 
     public Builder clusterName(String clusterName) {
       this.clusterName = clusterName;
@@ -406,6 +414,11 @@ public class VeniceClusterCreateOptions {
 
     public Builder kafkaBrokerWrapper(PubSubBrokerWrapper pubSubBrokerWrapper) {
       this.pubSubBrokerWrapper = pubSubBrokerWrapper;
+      return this;
+    }
+
+    public Builder accessController(DynamicAccessController accessController) {
+      this.accessController = accessController;
       return this;
     }
 

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/integration/utils/VeniceClusterWrapper.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/integration/utils/VeniceClusterWrapper.java
@@ -236,6 +236,7 @@ public class VeniceClusterWrapper extends ProcessWrapper {
                 .d2Enabled(true)
                 .regionName(options.getRegionName())
                 .extraProperties(options.getExtraProperties())
+                .dynamicAccessController(options.getAccessController())
                 .build());
         LOGGER.info(
             "[{}][{}] Created child controller on port {}",

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/integration/utils/VeniceControllerCreateOptions.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/integration/utils/VeniceControllerCreateOptions.java
@@ -10,6 +10,7 @@ import static com.linkedin.venice.integration.utils.VeniceClusterWrapperConstant
 import static com.linkedin.venice.integration.utils.VeniceClusterWrapperConstants.DEFAULT_PARTITION_SIZE_BYTES;
 import static com.linkedin.venice.integration.utils.VeniceClusterWrapperConstants.DEFAULT_REPLICATION_FACTOR;
 
+import com.linkedin.venice.acl.DynamicAccessController;
 import com.linkedin.venice.authorization.AuthorizerService;
 import java.util.Arrays;
 import java.util.Map;
@@ -38,6 +39,7 @@ public class VeniceControllerCreateOptions {
   private final Properties extraProperties;
   private final AuthorizerService authorizerService;
   private final String regionName;
+  private final DynamicAccessController dynamicAccessController;
 
   private VeniceControllerCreateOptions(Builder builder) {
     multiRegion = builder.multiRegion;
@@ -59,6 +61,7 @@ public class VeniceControllerCreateOptions {
     authorizerService = builder.authorizerService;
     isParent = builder.childControllers != null && builder.childControllers.length != 0;
     regionName = builder.regionName;
+    dynamicAccessController = builder.dynamicAccessController;
   }
 
   @Override
@@ -201,6 +204,10 @@ public class VeniceControllerCreateOptions {
     return authorizerService;
   }
 
+  public DynamicAccessController getDynamicAccessController() {
+    return dynamicAccessController;
+  }
+
   public String getRegionName() {
     return regionName;
   }
@@ -224,6 +231,7 @@ public class VeniceControllerCreateOptions {
     private Properties extraProperties = new Properties();
     private AuthorizerService authorizerService;
     private String regionName;
+    private DynamicAccessController dynamicAccessController;
 
     public Builder(String[] clusterNames, ZkServerWrapper zkServer, PubSubBrokerWrapper kafkaBroker) {
       this.clusterNames = Objects.requireNonNull(clusterNames, "clusterNames cannot be null when creating controller");
@@ -312,6 +320,11 @@ public class VeniceControllerCreateOptions {
 
     public Builder regionName(String regionName) {
       this.regionName = regionName;
+      return this;
+    }
+
+    public Builder dynamicAccessController(DynamicAccessController dynamicAccessController) {
+      this.dynamicAccessController = dynamicAccessController;
       return this;
     }
 

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/integration/utils/VeniceControllerWrapper.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/integration/utils/VeniceControllerWrapper.java
@@ -378,6 +378,7 @@ public class VeniceControllerWrapper extends ProcessWrapper {
           .setD2Client(d2Client)
           .setRouterClientConfig(consumerClientConfig.orElse(null))
           .setExternalSupersetSchemaGenerator(supersetSchemaGenerator.orElse(null))
+          .setAccessController(options.getDynamicAccessController())
           .build();
       VeniceController veniceController = new VeniceController(ctx);
       return new VeniceControllerWrapper(

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/server/grpc/GrpcControllerClientDetails.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/server/grpc/GrpcControllerClientDetails.java
@@ -1,0 +1,37 @@
+package com.linkedin.venice.controller.server.grpc;
+
+import java.security.cert.X509Certificate;
+
+
+/**
+ * Represents the details of a gRPC controller client, including the client's certificate and
+ * address. This class is immutable and provides methods to access the client's X.509
+ * certificate and address.
+ *
+ * <p>The primary purpose of this class is to encapsulate client-specific details passed
+ * in a gRPC context, which can be utilized for authorization, auditing, or debugging.</p>
+ */
+public class GrpcControllerClientDetails {
+  public static final GrpcControllerClientDetails UNDEFINED_CLIENT_DETAILS = new GrpcControllerClientDetails();
+
+  private final String clientAddress;
+  private final X509Certificate clientCertificate;
+
+  private GrpcControllerClientDetails() {
+    this.clientAddress = null;
+    this.clientCertificate = null;
+  }
+
+  public GrpcControllerClientDetails(X509Certificate clientCertificate, String clientAddress) {
+    this.clientAddress = clientAddress;
+    this.clientCertificate = clientCertificate;
+  }
+
+  public String getClientAddress() {
+    return clientAddress;
+  }
+
+  public X509Certificate getClientCertificate() {
+    return clientCertificate;
+  }
+}

--- a/services/venice-controller/src/test/java/com/linkedin/venice/controller/server/grpc/GrpcControllerClientDetailsTest.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/controller/server/grpc/GrpcControllerClientDetailsTest.java
@@ -1,0 +1,21 @@
+package com.linkedin.venice.controller.server.grpc;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNull;
+
+import org.testng.annotations.Test;
+
+
+public class GrpcControllerClientDetailsTest {
+  @Test
+  public void testGetClientAddress() {
+    String clientAddress = "localhost";
+    GrpcControllerClientDetails grpcControllerClientDetails = new GrpcControllerClientDetails(null, clientAddress);
+    assertEquals(grpcControllerClientDetails.getClientAddress(), clientAddress);
+    assertNull(grpcControllerClientDetails.getClientCertificate(), "Client certificate should be null");
+
+    grpcControllerClientDetails = new GrpcControllerClientDetails(null, null);
+    assertNull(grpcControllerClientDetails.getClientAddress());
+    assertNull(grpcControllerClientDetails.getClientCertificate());
+  }
+}


### PR DESCRIPTION
<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## Enforce ACL checks on VeniceControllerGrpcServiceImpl::createStore API

- Use access controller manager to enforce ACL checks in gRPC createStore API.
- Add support for running E2E tests with a custom access controller.
- Introduce `GrpcControllerClientDetails` to encapsulate gRPC session details for 
  authorization checks.

## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.