### PR TITLE
[server][da-vinci] Instantiate the gracefulShutdownLatch lazily

### DIFF
--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/KafkaStoreIngestionServiceTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/KafkaStoreIngestionServiceTest.java
@@ -394,6 +394,14 @@ public abstract class KafkaStoreIngestionServiceTest {
     Assert.assertNotNull(newStoreIngestionTask);
     Assert.assertNotEquals(storeIngestionTask, newStoreIngestionTask);
     assertEquals(newStoreIngestionTask.getStorageEngine(), storageEngine2);
+
+    // Mimic a graceful shutdown timeout
+    kafkaStoreIngestionService.startConsumption(new VeniceStoreVersionConfig(topicName, veniceProperties), 0);
+    StoreIngestionTask shutdownTimeoutTask = kafkaStoreIngestionService.getStoreIngestionTask(topicName);
+    // Initialize the latch forcefully to mimic task is running
+    shutdownTimeoutTask.getGracefulShutdownLatch().get();
+    // Graceful shutdown wait should time out
+    Assert.assertFalse(shutdownTimeoutTask.shutdownAndWait(1));
   }
 
   @Test(dataProvider = "True-and-False", dataProviderClass = DataProviderUtils.class)


### PR DESCRIPTION
## [server][da-vinci] Instantiate the gracefulShutdownLatch lazily

Instantiate the gracefulShutdownLatch lazily to avoid waiting for the latch when shutting down an ingestion task that was just initialized. This is more of an issue in unit tests where we mock out certain parts and the run() method of SIT never get to execute so waiting on the latch that was originally initialized during instance instantiation will timeout.

## How was this PR tested?
Existing unit and integration tests.

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.