### PR TITLE
[duckdb] Operation Foie Gras

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/client/BlockingDaVinciRecordTransformer.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/client/BlockingDaVinciRecordTransformer.java
@@ -2,6 +2,7 @@ package com.linkedin.davinci.client;
 
 import com.linkedin.venice.annotation.Experimental;
 import com.linkedin.venice.utils.lazy.Lazy;
+import java.io.IOException;
 import java.util.concurrent.CountDownLatch;
 import org.apache.avro.Schema;
 
@@ -55,5 +56,10 @@ public class BlockingDaVinciRecordTransformer<K, V, O> extends DaVinciRecordTran
 
   public void onEndVersionIngestion(int currentVersion) {
     this.recordTransformer.onEndVersionIngestion(currentVersion);
+  }
+
+  @Override
+  public void close() throws IOException {
+    this.recordTransformer.close();
   }
 }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/client/DaVinciRecordTransformer.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/client/DaVinciRecordTransformer.java
@@ -5,6 +5,7 @@ import com.linkedin.venice.annotation.Experimental;
 import com.linkedin.venice.compression.VeniceCompressor;
 import com.linkedin.venice.exceptions.VeniceException;
 import com.linkedin.venice.utils.lazy.Lazy;
+import java.io.Closeable;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.ByteBuffer;
@@ -29,7 +30,7 @@ import org.objectweb.asm.ClassReader;
  * @param <O> the type of the output value
  */
 @Experimental
-public abstract class DaVinciRecordTransformer<K, V, O> {
+public abstract class DaVinciRecordTransformer<K, V, O> implements Closeable {
   /**
    * Version of the store of when the transformer is initialized.
    */
@@ -128,6 +129,10 @@ public abstract class DaVinciRecordTransformer<K, V, O> {
    */
   public void onEndVersionIngestion(int currentVersion) {
     return;
+  }
+
+  public boolean useUniformInputValueSchema() {
+    return false;
   }
 
   // Final methods below

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/config/DaVinciConfigTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/config/DaVinciConfigTest.java
@@ -10,6 +10,7 @@ import com.linkedin.davinci.client.DaVinciRecordTransformer;
 import com.linkedin.davinci.client.DaVinciRecordTransformerConfig;
 import com.linkedin.davinci.client.DaVinciRecordTransformerResult;
 import com.linkedin.venice.utils.lazy.Lazy;
+import java.io.IOException;
 import org.apache.avro.Schema;
 import org.testng.annotations.Test;
 
@@ -33,6 +34,11 @@ public class DaVinciConfigTest {
     @Override
     public void processPut(Lazy<Integer> key, Lazy<Integer> value) {
       return;
+    }
+
+    @Override
+    public void close() throws IOException {
+
     }
   }
 

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/transformer/TestStringRecordTransformer.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/transformer/TestStringRecordTransformer.java
@@ -3,6 +3,7 @@ package com.linkedin.davinci.transformer;
 import com.linkedin.davinci.client.DaVinciRecordTransformer;
 import com.linkedin.davinci.client.DaVinciRecordTransformerResult;
 import com.linkedin.venice.utils.lazy.Lazy;
+import java.io.IOException;
 import org.apache.avro.Schema;
 import org.apache.avro.util.Utf8;
 
@@ -36,5 +37,10 @@ public class TestStringRecordTransformer extends DaVinciRecordTransformer<Intege
   @Override
   public void processPut(Lazy<Integer> key, Lazy<String> value) {
     return;
+  }
+
+  @Override
+  public void close() throws IOException {
+
   }
 }

--- a/integrations/venice-duckdb/src/main/java/com/linkedin/venice/duckdb/DuckDBDaVinciRecordTransformer.java
+++ b/integrations/venice-duckdb/src/main/java/com/linkedin/venice/duckdb/DuckDBDaVinciRecordTransformer.java
@@ -1,6 +1,6 @@
 package com.linkedin.venice.duckdb;
 
-import static com.linkedin.venice.sql.AvroToSQL.UnsupportedTypeHandling.FAIL;
+import static com.linkedin.venice.sql.AvroToSQL.UnsupportedTypeHandling.SKIP;
 
 import com.linkedin.davinci.client.DaVinciRecordTransformer;
 import com.linkedin.davinci.client.DaVinciRecordTransformerResult;
@@ -9,7 +9,9 @@ import com.linkedin.venice.sql.AvroToSQL;
 import com.linkedin.venice.sql.InsertProcessor;
 import com.linkedin.venice.sql.SQLUtils;
 import com.linkedin.venice.sql.TableDefinition;
+import com.linkedin.venice.utils.concurrent.CloseableThreadLocal;
 import com.linkedin.venice.utils.lazy.Lazy;
+import java.io.IOException;
 import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.PreparedStatement;
@@ -34,6 +36,10 @@ public class DuckDBDaVinciRecordTransformer
   private final String versionTableName;
   private final String duckDBUrl;
   private final Set<String> columnsToProject;
+  private final CloseableThreadLocal<Connection> connection;
+  private final CloseableThreadLocal<PreparedStatement> deletePreparedStatement;
+  private final CloseableThreadLocal<PreparedStatement> upsertPreparedStatement;
+  private final InsertProcessor upsertProcessor;
 
   public DuckDBDaVinciRecordTransformer(
       int storeVersion,
@@ -49,6 +55,31 @@ public class DuckDBDaVinciRecordTransformer
     this.versionTableName = buildStoreNameWithVersion(storeVersion);
     this.duckDBUrl = "jdbc:duckdb:" + baseDir + "/" + duckDBFilePath;
     this.columnsToProject = columnsToProject;
+    String deleteStatement = String.format(deleteStatementTemplate, versionTableName, "key"); // TODO: Fix this, it is
+                                                                                              // broken
+    String upsertStatement = AvroToSQL.upsertStatement(versionTableName, keySchema, inputValueSchema, columnsToProject);
+    this.connection = CloseableThreadLocal.withInitial(() -> {
+      try {
+        return DriverManager.getConnection(duckDBUrl);
+      } catch (SQLException e) {
+        throw new VeniceException("Failed to connect to DB!", e);
+      }
+    });
+    this.deletePreparedStatement = CloseableThreadLocal.withInitial(() -> {
+      try {
+        return this.connection.get().prepareStatement(deleteStatement);
+      } catch (SQLException e) {
+        throw new VeniceException("Failed to create PreparedStatement!", e);
+      }
+    });
+    this.upsertPreparedStatement = CloseableThreadLocal.withInitial(() -> {
+      try {
+        return this.connection.get().prepareStatement(upsertStatement);
+      } catch (SQLException e) {
+        throw new VeniceException("Failed to create PreparedStatement!", e);
+      }
+    });
+    this.upsertProcessor = AvroToSQL.upsertProcessor(keySchema, inputValueSchema, columnsToProject);
   }
 
   @Override
@@ -60,38 +91,18 @@ public class DuckDBDaVinciRecordTransformer
 
   @Override
   public void processPut(Lazy<GenericRecord> key, Lazy<GenericRecord> value) {
-    // TODO: Pre-allocate the upsert statement and everything that goes into it, as much as possible.
-    Schema keySchema = key.get().getSchema();
-    Schema valueSchema = value.get().getSchema();
-    String upsertStatement = AvroToSQL.upsertStatement(versionTableName, keySchema, valueSchema, this.columnsToProject);
-
-    // ToDo: Instead of creating a connection on every call, have a long-term connection. Maybe a connection pool?
-    try (Connection connection = DriverManager.getConnection(duckDBUrl)) {
-      // TODO: Pre-allocate the upsert processor as well
-      InsertProcessor upsertProcessor = AvroToSQL.upsertProcessor(keySchema, valueSchema, this.columnsToProject);
-
-      // TODO: Pre-allocate the prepared statement (consider thread-local if it's not thread safe)
-      try (PreparedStatement preparedStatement = connection.prepareStatement(upsertStatement)) {
-        upsertProcessor.process(key.get(), value.get(), preparedStatement);
-      }
-    } catch (SQLException e) {
-      throw new RuntimeException(e);
-    }
+    this.upsertProcessor.process(key.get(), value.get(), this.upsertPreparedStatement.get());
   }
 
   @Override
   public void processDelete(Lazy<GenericRecord> key) {
-    // Unable to convert to prepared statement as table and column names can't be parameterized
-    // ToDo make delete non-hardcoded on primaryKey
-    String deleteStatement = String.format(deleteStatementTemplate, versionTableName, "key");
-
-    // ToDo: Instead of creating a connection on every call, have a long-term connection. Maybe a connection pool?
-    try (Connection connection = DriverManager.getConnection(duckDBUrl);
-        PreparedStatement stmt = connection.prepareStatement(deleteStatement)) {
+    try {
+      PreparedStatement stmt = this.deletePreparedStatement.get();
+      // TODO: Fix this, it is broken.
       stmt.setString(1, key.get().get("key").toString());
       stmt.execute();
     } catch (SQLException e) {
-      throw new RuntimeException(e);
+      throw new VeniceException("Failed to execute delete!");
     }
   }
 
@@ -104,7 +115,7 @@ public class DuckDBDaVinciRecordTransformer
           getKeySchema(),
           getOutputValueSchema(),
           this.columnsToProject,
-          FAIL,
+          SKIP,
           true);
       TableDefinition existingTableDefinition = SQLUtils.getTableDefinition(this.versionTableName, connection);
       if (existingTableDefinition == null) {
@@ -151,11 +162,22 @@ public class DuckDBDaVinciRecordTransformer
     }
   }
 
+  public boolean useUniformInputValueSchema() {
+    return true;
+  }
+
   public String getDuckDBUrl() {
     return duckDBUrl;
   }
 
   public String buildStoreNameWithVersion(int version) {
     return storeNameWithoutVersionInfo + "_v" + version;
+  }
+
+  @Override
+  public void close() throws IOException {
+    this.deletePreparedStatement.close();
+    this.upsertPreparedStatement.close();
+    this.connection.close();
   }
 }

--- a/internal/venice-client-common/src/main/java/com/linkedin/venice/utils/concurrent/CloseableThreadLocal.java
+++ b/internal/venice-client-common/src/main/java/com/linkedin/venice/utils/concurrent/CloseableThreadLocal.java
@@ -20,6 +20,10 @@ public class CloseableThreadLocal<T extends AutoCloseable> implements AutoClosea
   private final Set<T> valueSet = new ConcurrentSkipListSet<>(new HashCodeComparator<>());
   private final ThreadLocal<T> threadLocal;
 
+  public static <T> CloseableThreadLocal withInitial(Supplier<T> initialValue) {
+    return new CloseableThreadLocal(initialValue);
+  }
+
   /**
    * Creates a closeable thread local. The initial value of the
    * variable is determined by invoking the {@code get} method

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestIntToStringRecordTransformer.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestIntToStringRecordTransformer.java
@@ -3,6 +3,7 @@ package com.linkedin.venice.endToEnd;
 import com.linkedin.davinci.client.DaVinciRecordTransformer;
 import com.linkedin.davinci.client.DaVinciRecordTransformerResult;
 import com.linkedin.venice.utils.lazy.Lazy;
+import java.io.IOException;
 import org.apache.avro.Schema;
 
 
@@ -29,5 +30,10 @@ public class TestIntToStringRecordTransformer extends DaVinciRecordTransformer<I
   @Override
   public void processPut(Lazy<Integer> key, Lazy<String> value) {
     return;
+  }
+
+  @Override
+  public void close() throws IOException {
+
   }
 }

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestSkipResultRecordTransformer.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestSkipResultRecordTransformer.java
@@ -3,6 +3,7 @@ package com.linkedin.venice.endToEnd;
 import com.linkedin.davinci.client.DaVinciRecordTransformer;
 import com.linkedin.davinci.client.DaVinciRecordTransformerResult;
 import com.linkedin.venice.utils.lazy.Lazy;
+import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 import org.apache.avro.Schema;
@@ -55,4 +56,8 @@ public class TestSkipResultRecordTransformer extends DaVinciRecordTransformer<In
     inMemoryDB.put(key, value);
   }
 
+  @Override
+  public void close() throws IOException {
+
+  }
 }

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestStringRecordTransformer.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestStringRecordTransformer.java
@@ -3,6 +3,7 @@ package com.linkedin.venice.endToEnd;
 import com.linkedin.davinci.client.DaVinciRecordTransformer;
 import com.linkedin.davinci.client.DaVinciRecordTransformerResult;
 import com.linkedin.venice.utils.lazy.Lazy;
+import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 import org.apache.avro.Schema;
@@ -61,4 +62,8 @@ public class TestStringRecordTransformer extends DaVinciRecordTransformer<Intege
     inMemoryDB.put(key, value);
   }
 
+  @Override
+  public void close() throws IOException {
+
+  }
 }

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestUnchangedResultRecordTransformer.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestUnchangedResultRecordTransformer.java
@@ -3,6 +3,7 @@ package com.linkedin.venice.endToEnd;
 import com.linkedin.davinci.client.DaVinciRecordTransformer;
 import com.linkedin.davinci.client.DaVinciRecordTransformerResult;
 import com.linkedin.venice.utils.lazy.Lazy;
+import java.io.IOException;
 import org.apache.avro.Schema;
 
 
@@ -27,4 +28,8 @@ public class TestUnchangedResultRecordTransformer extends DaVinciRecordTransform
     return;
   }
 
+  @Override
+  public void close() throws IOException {
+
+  }
 }


### PR DESCRIPTION
Time to force-feed the duck. Pre-allocated all Avro deserializers, connection, prepared statement as well as the InsertProcessor, so that the hot path has as little to do as possible.

Miscellaneous:

- Changed the unhandled type policy from FAIL to SKIP.

- Made DVRT implement Closeable.

- Added a new useUniformInputValueSchema() API to DVRT:

  - If false (default), SIT will give whatever incoming record in the schema it comes in.

  - If true (which the DuckDB DVRT does), SIT will use Avro schema evolution to decode the incoming records into the same schema which it passed into the DVRT constructor.

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.