### PR TITLE
[controller][grpc] Add ClusterAdminOpsGrpcService with handler and tests

### DIFF
--- a/internal/venice-common/src/main/proto/controller/ClusterAdminOpsGrpcService.proto
+++ b/internal/venice-common/src/main/proto/controller/ClusterAdminOpsGrpcService.proto
@@ -1,0 +1,66 @@
+syntax = 'proto3';
+package com.linkedin.venice.protocols.controller;
+
+
+import "controller/ControllerGrpcRequestContext.proto";
+
+option java_multiple_files = true;
+
+service ClusterAdminOpsGrpcService {
+  // AdminCommandExecution
+  rpc getAdminCommandExecutionStatus(AdminCommandExecutionStatusGrpcRequest) returns (AdminCommandExecutionStatusGrpcResponse) {}
+  rpc getLastSuccessfulAdminCommandExecutionId(LastSuccessfulAdminCommandExecutionGrpcRequest) returns (LastSuccessfulAdminCommandExecutionGrpcResponse) {}
+
+  // AdminTopicMetadata
+  rpc getAdminTopicMetadata(AdminTopicMetadataGrpcRequest) returns (AdminTopicMetadataGrpcResponse) {}
+  rpc updateAdminTopicMetadata(UpdateAdminTopicMetadataGrpcRequest) returns (UpdateAdminTopicMetadataGrpcResponse) {}
+}
+
+
+message AdminCommandExecutionStatusGrpcRequest {
+  string clusterName = 1;
+  int64 adminCommandExecutionId = 2;
+}
+
+message AdminCommandExecutionStatusGrpcResponse {
+  string clusterName = 1;
+  int64 adminCommandExecutionId = 2;
+  string operation = 3;
+  string startTime = 4;
+  map<string, string> fabricToExecutionStatusMap = 5;
+}
+
+message LastSuccessfulAdminCommandExecutionGrpcRequest {
+  string clusterName = 1;
+}
+
+message LastSuccessfulAdminCommandExecutionGrpcResponse {
+  string clusterName = 1;
+  int64 lastSuccessfulAdminCommandExecutionId = 2;
+}
+
+message AdminTopicMetadataGrpcRequest {
+  string clusterName = 1;
+  optional string storeName = 2;
+}
+
+message AdminTopicMetadataGrpcResponse {
+  AdminTopicGrpcMetadata metadata = 1;
+}
+
+message UpdateAdminTopicMetadataGrpcResponse {
+  string clusterName = 1;
+  optional string storeName = 2;
+}
+
+message UpdateAdminTopicMetadataGrpcRequest {
+  AdminTopicGrpcMetadata metadata = 1;
+}
+
+message AdminTopicGrpcMetadata {
+  string clusterName = 1;
+  int64 executionId = 2;
+  optional string storeName = 3;
+  optional int64 offset = 4;
+  optional int64 upstreamOffset = 5;
+}

--- a/internal/venice-common/src/test/java/com/linkedin/venice/controllerapi/transport/GrpcRequestResponseConverterTest.java
+++ b/internal/venice-common/src/test/java/com/linkedin/venice/controllerapi/transport/GrpcRequestResponseConverterTest.java
@@ -7,6 +7,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertThrows;
 import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.expectThrows;
 
@@ -15,6 +16,7 @@ import com.google.rpc.Code;
 import com.google.rpc.Status;
 import com.linkedin.venice.client.exceptions.VeniceClientException;
 import com.linkedin.venice.controller.grpc.GrpcRequestResponseConverter;
+import com.linkedin.venice.controllerapi.AdminCommandExecutionStatus;
 import com.linkedin.venice.controllerapi.ControllerResponse;
 import com.linkedin.venice.protocols.controller.ClusterStoreGrpcInfo;
 import com.linkedin.venice.protocols.controller.ControllerGrpcErrorType;
@@ -22,6 +24,10 @@ import com.linkedin.venice.protocols.controller.VeniceControllerGrpcErrorInfo;
 import io.grpc.StatusRuntimeException;
 import io.grpc.protobuf.StatusProto;
 import io.grpc.stub.StreamObserver;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 import org.testng.annotations.Test;
 
 
@@ -144,5 +150,64 @@ public class GrpcRequestResponseConverterTest {
     });
 
     assertTrue(thrownException.getMessage().contains("Failed to unpack error details"));
+  }
+
+  @Test
+  public void testToExecutionStatusMapSuccess() {
+    Map<String, String> grpcMap = new HashMap<>();
+    grpcMap.put("fabric1", "COMPLETED");
+    grpcMap.put("fabric2", "PROCESSING");
+    grpcMap.put("fabric3", "ERROR");
+
+    ConcurrentHashMap<String, AdminCommandExecutionStatus> executionStatusMap =
+        GrpcRequestResponseConverter.toExecutionStatusMap(grpcMap);
+
+    assertNotNull(executionStatusMap);
+    assertEquals(executionStatusMap.size(), grpcMap.size());
+    assertEquals(executionStatusMap.get("fabric1"), AdminCommandExecutionStatus.COMPLETED);
+    assertEquals(executionStatusMap.get("fabric2"), AdminCommandExecutionStatus.PROCESSING);
+    assertEquals(executionStatusMap.get("fabric3"), AdminCommandExecutionStatus.ERROR);
+  }
+
+  @Test
+  public void testToExecutionStatusMapWithEmptyInput() {
+    Map<String, String> grpcMap = Collections.emptyMap();
+    ConcurrentHashMap<String, AdminCommandExecutionStatus> executionStatusMap =
+        GrpcRequestResponseConverter.toExecutionStatusMap(grpcMap);
+
+    assertNotNull(executionStatusMap);
+    assertEquals(executionStatusMap.size(), 0);
+  }
+
+  @Test
+  public void testToExecutionStatusMapWithInvalidStatus() {
+    Map<String, String> grpcMap = new HashMap<>();
+    grpcMap.put("fabric1", "INVALID_STATUS");
+    assertThrows(IllegalArgumentException.class, () -> GrpcRequestResponseConverter.toExecutionStatusMap(grpcMap));
+  }
+
+  @Test
+  public void testToGrpcExecutionStatusMapSuccess() {
+    ConcurrentHashMap<String, AdminCommandExecutionStatus> executionStatusMap = new ConcurrentHashMap<>();
+    executionStatusMap.put("fabric1", AdminCommandExecutionStatus.COMPLETED);
+    executionStatusMap.put("fabric2", AdminCommandExecutionStatus.PROCESSING);
+    executionStatusMap.put("fabric3", AdminCommandExecutionStatus.ERROR);
+
+    Map<String, String> grpcMap = GrpcRequestResponseConverter.toGrpcExecutionStatusMap(executionStatusMap);
+
+    assertNotNull(grpcMap);
+    assertEquals(grpcMap.size(), executionStatusMap.size());
+    assertEquals(grpcMap.get("fabric1"), "COMPLETED");
+    assertEquals(grpcMap.get("fabric2"), "PROCESSING");
+    assertEquals(grpcMap.get("fabric3"), "ERROR");
+  }
+
+  @Test
+  public void testToGrpcExecutionStatusMapWithEmptyInput() {
+    ConcurrentHashMap<String, AdminCommandExecutionStatus> executionStatusMap = new ConcurrentHashMap<>();
+    Map<String, String> grpcMap = GrpcRequestResponseConverter.toGrpcExecutionStatusMap(executionStatusMap);
+
+    assertNotNull(grpcMap);
+    assertEquals(grpcMap.size(), 0);
   }
 }

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/grpc/GrpcRequestResponseConverter.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/grpc/GrpcRequestResponseConverter.java
@@ -2,6 +2,7 @@ package com.linkedin.venice.controller.grpc;
 
 import com.google.protobuf.Any;
 import com.linkedin.venice.client.exceptions.VeniceClientException;
+import com.linkedin.venice.controllerapi.AdminCommandExecutionStatus;
 import com.linkedin.venice.controllerapi.ControllerResponse;
 import com.linkedin.venice.protocols.controller.ClusterStoreGrpcInfo;
 import com.linkedin.venice.protocols.controller.ControllerGrpcErrorType;
@@ -10,6 +11,8 @@ import io.grpc.Status.Code;
 import io.grpc.StatusRuntimeException;
 import io.grpc.protobuf.StatusProto;
 import io.grpc.stub.StreamObserver;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 
 public class GrpcRequestResponseConverter {
@@ -140,4 +143,35 @@ public class GrpcRequestResponseConverter {
     }
     throw new VeniceClientException("An unknown gRPC error occurred. Error code: " + Code.UNKNOWN.name());
   }
+
+  /**
+   * Converts a gRPC map with string statuses to a ConcurrentHashMap with AdminCommandExecutionStatus.
+   *
+   * @param grpcMap Map with keys as fabric names and values as string statuses.
+   * @return A ConcurrentHashMap with keys as fabric names and values as AdminCommandExecutionStatus.
+   */
+  public static ConcurrentHashMap<String, AdminCommandExecutionStatus> toExecutionStatusMap(
+      Map<String, String> grpcMap) {
+    ConcurrentHashMap<String, AdminCommandExecutionStatus> executionStatusMap = new ConcurrentHashMap<>(grpcMap.size());
+    for (Map.Entry<String, String> entry: grpcMap.entrySet()) {
+      executionStatusMap.put(entry.getKey(), AdminCommandExecutionStatus.valueOf(entry.getValue()));
+    }
+    return executionStatusMap;
+  }
+
+  /**
+   * Converts a ConcurrentHashMap with AdminCommandExecutionStatus to a map with string statuses.
+   *
+   * @param executionStatusMap ConcurrentHashMap with keys as fabric names and values as AdminCommandExecutionStatus.
+   * @return A Map with keys as fabric names and values as string statuses.
+   */
+  public static Map<String, String> toGrpcExecutionStatusMap(
+      Map<String, AdminCommandExecutionStatus> executionStatusMap) {
+    ConcurrentHashMap<String, String> grpcMap = new ConcurrentHashMap<>(executionStatusMap.size());
+    for (Map.Entry<String, AdminCommandExecutionStatus> entry: executionStatusMap.entrySet()) {
+      grpcMap.put(entry.getKey(), entry.getValue().name());
+    }
+    return grpcMap;
+  }
+
 }

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/grpc/server/ClusterAdminOpsGrpcServiceImpl.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/grpc/server/ClusterAdminOpsGrpcServiceImpl.java
@@ -1,0 +1,92 @@
+package com.linkedin.venice.controller.grpc.server;
+
+import static com.linkedin.venice.controller.grpc.server.ControllerGrpcServerUtils.isAllowListUser;
+import static com.linkedin.venice.controller.server.VeniceRouteHandler.ACL_CHECK_FAILURE_WARN_MESSAGE_PREFIX;
+import static com.linkedin.venice.protocols.controller.ClusterAdminOpsGrpcServiceGrpc.*;
+
+import com.linkedin.venice.controller.server.ClusterAdminOpsRequestHandler;
+import com.linkedin.venice.controller.server.VeniceControllerAccessManager;
+import com.linkedin.venice.exceptions.VeniceUnauthorizedAccessException;
+import com.linkedin.venice.protocols.controller.AdminCommandExecutionStatusGrpcRequest;
+import com.linkedin.venice.protocols.controller.AdminCommandExecutionStatusGrpcResponse;
+import com.linkedin.venice.protocols.controller.AdminTopicGrpcMetadata;
+import com.linkedin.venice.protocols.controller.AdminTopicMetadataGrpcRequest;
+import com.linkedin.venice.protocols.controller.AdminTopicMetadataGrpcResponse;
+import com.linkedin.venice.protocols.controller.ClusterAdminOpsGrpcServiceGrpc;
+import com.linkedin.venice.protocols.controller.LastSuccessfulAdminCommandExecutionGrpcRequest;
+import com.linkedin.venice.protocols.controller.LastSuccessfulAdminCommandExecutionGrpcResponse;
+import com.linkedin.venice.protocols.controller.UpdateAdminTopicMetadataGrpcRequest;
+import com.linkedin.venice.protocols.controller.UpdateAdminTopicMetadataGrpcResponse;
+import io.grpc.Context;
+import io.grpc.stub.StreamObserver;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+
+public class ClusterAdminOpsGrpcServiceImpl extends ClusterAdminOpsGrpcServiceImplBase {
+  private static final Logger LOGGER = LogManager.getLogger(ClusterAdminOpsGrpcServiceImpl.class);
+  private final ClusterAdminOpsRequestHandler requestHandler;
+  private final VeniceControllerAccessManager accessManager;
+
+  public ClusterAdminOpsGrpcServiceImpl(
+      ClusterAdminOpsRequestHandler requestHandler,
+      VeniceControllerAccessManager accessManager) {
+    this.requestHandler = requestHandler;
+    this.accessManager = accessManager;
+  }
+
+  @Override
+  public void getAdminCommandExecutionStatus(
+      AdminCommandExecutionStatusGrpcRequest request,
+      StreamObserver<AdminCommandExecutionStatusGrpcResponse> responseObserver) {
+    LOGGER.debug("Received getAdminCommandExecutionStatus request: {}", request);
+    ControllerGrpcServerUtils.handleRequest(
+        ClusterAdminOpsGrpcServiceGrpc.getGetAdminCommandExecutionStatusMethod(),
+        () -> requestHandler.getAdminCommandExecutionStatus(request),
+        responseObserver,
+        request.getClusterName(),
+        null);
+  }
+
+  @Override
+  public void getLastSuccessfulAdminCommandExecutionId(
+      LastSuccessfulAdminCommandExecutionGrpcRequest request,
+      StreamObserver<LastSuccessfulAdminCommandExecutionGrpcResponse> responseObserver) {
+    LOGGER.debug("Received getLastSuccessfulAdminCommandExecutionId request: {}", request);
+    ControllerGrpcServerUtils.handleRequest(
+        ClusterAdminOpsGrpcServiceGrpc.getGetLastSuccessfulAdminCommandExecutionIdMethod(),
+        () -> requestHandler.getLastSucceedExecutionId(request),
+        responseObserver,
+        request.getClusterName(),
+        null);
+  }
+
+  @Override
+  public void getAdminTopicMetadata(
+      AdminTopicMetadataGrpcRequest request,
+      StreamObserver<AdminTopicMetadataGrpcResponse> responseObserver) {
+    LOGGER.debug("Received getAdminTopicMetadata request: {}", request);
+    ControllerGrpcServerUtils.handleRequest(
+        ClusterAdminOpsGrpcServiceGrpc.getGetAdminTopicMetadataMethod(),
+        () -> requestHandler.getAdminTopicMetadata(request),
+        responseObserver,
+        request.getClusterName(),
+        request.hasStoreName() ? request.getStoreName() : null);
+  }
+
+  @Override
+  public void updateAdminTopicMetadata(
+      UpdateAdminTopicMetadataGrpcRequest request,
+      StreamObserver<UpdateAdminTopicMetadataGrpcResponse> responseObserver) {
+    LOGGER.debug("Received updateAdminTopicMetadata request: {}", request);
+    AdminTopicGrpcMetadata metadata = request.getMetadata();
+    ControllerGrpcServerUtils.handleRequest(ClusterAdminOpsGrpcServiceGrpc.getUpdateAdminTopicMetadataMethod(), () -> {
+      if (!isAllowListUser(accessManager, request.getMetadata().getStoreName(), Context.current())) {
+        throw new VeniceUnauthorizedAccessException(
+            ACL_CHECK_FAILURE_WARN_MESSAGE_PREFIX
+                + ClusterAdminOpsGrpcServiceGrpc.getUpdateAdminTopicMetadataMethod().getFullMethodName());
+      }
+      return requestHandler.updateAdminTopicMetadata(request);
+    }, responseObserver, metadata.getClusterName(), metadata.hasStoreName() ? metadata.getStoreName() : null);
+  }
+}

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/grpc/server/ClusterAdminOpsGrpcServiceImpl.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/grpc/server/ClusterAdminOpsGrpcServiceImpl.java
@@ -2,7 +2,7 @@ package com.linkedin.venice.controller.grpc.server;
 
 import static com.linkedin.venice.controller.grpc.server.ControllerGrpcServerUtils.isAllowListUser;
 import static com.linkedin.venice.controller.server.VeniceRouteHandler.ACL_CHECK_FAILURE_WARN_MESSAGE_PREFIX;
-import static com.linkedin.venice.protocols.controller.ClusterAdminOpsGrpcServiceGrpc.*;
+import static com.linkedin.venice.protocols.controller.ClusterAdminOpsGrpcServiceGrpc.ClusterAdminOpsGrpcServiceImplBase;
 
 import com.linkedin.venice.controller.server.ClusterAdminOpsRequestHandler;
 import com.linkedin.venice.controller.server.VeniceControllerAccessManager;

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/server/AdminCommandExecutionRoutes.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/server/AdminCommandExecutionRoutes.java
@@ -9,10 +9,17 @@ import com.linkedin.venice.HttpConstants;
 import com.linkedin.venice.LastSucceedExecutionIdResponse;
 import com.linkedin.venice.acl.DynamicAccessController;
 import com.linkedin.venice.controller.Admin;
-import com.linkedin.venice.controller.AdminCommandExecutionTracker;
+import com.linkedin.venice.controller.grpc.GrpcRequestResponseConverter;
 import com.linkedin.venice.controllerapi.AdminCommandExecution;
+import com.linkedin.venice.controllerapi.AdminCommandExecutionStatus;
 import com.linkedin.venice.controllerapi.routes.AdminCommandExecutionResponse;
+import com.linkedin.venice.protocols.controller.AdminCommandExecutionStatusGrpcRequest;
+import com.linkedin.venice.protocols.controller.AdminCommandExecutionStatusGrpcResponse;
+import com.linkedin.venice.protocols.controller.LastSuccessfulAdminCommandExecutionGrpcRequest;
+import com.linkedin.venice.protocols.controller.LastSuccessfulAdminCommandExecutionGrpcResponse;
+import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
 import spark.Route;
 
 
@@ -25,29 +32,35 @@ public class AdminCommandExecutionRoutes extends AbstractRoute {
    * No ACL check; any user is allowed to check admin command execution status.
    * @see Admin#getAdminCommandExecutionTracker(String)
    */
-  public Route getExecution(Admin admin) {
+  public Route getExecution(Admin admin, ClusterAdminOpsRequestHandler requestHandler) {
     return (request, response) -> {
       AdminCommandExecutionResponse responseObject = new AdminCommandExecutionResponse();
       response.type(HttpConstants.JSON);
-      // This request should only hit the parent controller. If a PROD controller get this kind of request, a empty
-      // response would be return.
-      AdminSparkServer.validateParams(request, EXECUTION.getParams(), admin);
-      String cluster = request.queryParams(CLUSTER);
-      long executionId = Long.parseLong(request.queryParams(EXECUTION_ID));
-      responseObject.setCluster(cluster);
-      Optional<AdminCommandExecutionTracker> adminCommandExecutionTracker =
-          admin.getAdminCommandExecutionTracker(cluster);
-      if (adminCommandExecutionTracker.isPresent()) {
-        AdminCommandExecution execution = adminCommandExecutionTracker.get().checkExecutionStatus(executionId);
-        if (execution == null) {
-          responseObject
-              .setError("Could not find the execution by given id: " + executionId + " in cluster: " + cluster);
-        } else {
-          responseObject.setExecution(execution);
-        }
-      } else {
-        responseObject.setError(
-            "Could not track execution in this controller. Make sure you send the command to a correct parent controller.");
+      try {
+        // This request should only hit the parent controller. If a PROD controller get this kind of request, a empty
+        // response would be return.
+        AdminSparkServer.validateParams(request, EXECUTION.getParams(), admin);
+        String cluster = request.queryParams(CLUSTER);
+        long executionId = Long.parseLong(request.queryParams(EXECUTION_ID));
+        AdminCommandExecutionStatusGrpcRequest.Builder requestBuilder =
+            AdminCommandExecutionStatusGrpcRequest.newBuilder();
+        requestBuilder.setClusterName(cluster).setAdminCommandExecutionId(executionId);
+        AdminCommandExecutionStatusGrpcResponse grpcResponse =
+            requestHandler.getAdminCommandExecutionStatus(requestBuilder.build());
+        responseObject.setCluster(cluster);
+        AdminCommandExecution execution = new AdminCommandExecution();
+        execution.setExecutionId(executionId);
+        execution.setOperation(grpcResponse.getOperation());
+        execution.setClusterName(grpcResponse.getClusterName());
+        execution.setStartTime(grpcResponse.getStartTime());
+        Map<String, String> fabricToExecutionStatusMap = grpcResponse.getFabricToExecutionStatusMapMap();
+        ConcurrentHashMap<String, AdminCommandExecutionStatus> executionStatusMap =
+            GrpcRequestResponseConverter.toExecutionStatusMap(fabricToExecutionStatusMap);
+        execution.setFabricToExecutionStatusMap(executionStatusMap);
+        responseObject.setExecution(execution);
+      } catch (Throwable e) {
+        responseObject.setError(e.getMessage());
+        AdminSparkServer.handleError(e, request, response);
       }
       return AdminSparkServer.OBJECT_MAPPER.writeValueAsString(responseObject);
     };
@@ -57,15 +70,17 @@ public class AdminCommandExecutionRoutes extends AbstractRoute {
    * No ACL check; any user is allowed to check last succeeded execution Id.
    * @see Admin#getLastSucceedExecutionId(String)
    */
-  public Route getLastSucceedExecutionId(Admin admin) {
+  public Route getLastSucceedExecutionId(Admin admin, ClusterAdminOpsRequestHandler requestHandler) {
     return (request, response) -> {
       LastSucceedExecutionIdResponse responseObject = new LastSucceedExecutionIdResponse();
       response.type(HttpConstants.JSON);
-      AdminSparkServer.validateParams(request, LAST_SUCCEED_EXECUTION_ID.getParams(), admin);
-      String cluster = request.queryParams(CLUSTER);
-      responseObject.setCluster(cluster);
       try {
-        responseObject.setLastSucceedExecutionId(admin.getLastSucceedExecutionId(cluster));
+        AdminSparkServer.validateParams(request, LAST_SUCCEED_EXECUTION_ID.getParams(), admin);
+        String cluster = request.queryParams(CLUSTER);
+        responseObject.setCluster(cluster);
+        LastSuccessfulAdminCommandExecutionGrpcResponse grpcResponse = requestHandler.getLastSucceedExecutionId(
+            LastSuccessfulAdminCommandExecutionGrpcRequest.newBuilder().setClusterName(cluster).build());
+        responseObject.setLastSucceedExecutionId(grpcResponse.getLastSuccessfulAdminCommandExecutionId());
       } catch (Throwable e) {
         responseObject.setError(e);
         AdminSparkServer.handleError(e, request, response);

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/server/AdminCommandExecutionRoutes.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/server/AdminCommandExecutionRoutes.java
@@ -43,8 +43,9 @@ public class AdminCommandExecutionRoutes extends AbstractRoute {
         String cluster = request.queryParams(CLUSTER);
         long executionId = Long.parseLong(request.queryParams(EXECUTION_ID));
         AdminCommandExecutionStatusGrpcRequest.Builder requestBuilder =
-            AdminCommandExecutionStatusGrpcRequest.newBuilder();
-        requestBuilder.setClusterName(cluster).setAdminCommandExecutionId(executionId);
+            AdminCommandExecutionStatusGrpcRequest.newBuilder()
+                .setClusterName(cluster)
+                .setAdminCommandExecutionId(executionId);
         AdminCommandExecutionStatusGrpcResponse grpcResponse =
             requestHandler.getAdminCommandExecutionStatus(requestBuilder.build());
         responseObject.setCluster(cluster);

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/server/AdminSparkServer.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/server/AdminSparkServer.java
@@ -499,12 +499,15 @@ public class AdminSparkServer extends AbstractVeniceService {
 
     httpService.get(
         EXECUTION.getPath(),
-        new VeniceParentControllerRegionStateHandler(admin, adminCommandExecutionRoutes.getExecution(admin)));
+        new VeniceParentControllerRegionStateHandler(
+            admin,
+            adminCommandExecutionRoutes.getExecution(admin, requestHandler.getClusterAdminOpsRequestHandler())));
     httpService.get(
         LAST_SUCCEED_EXECUTION_ID.getPath(),
         new VeniceParentControllerRegionStateHandler(
             admin,
-            adminCommandExecutionRoutes.getLastSucceedExecutionId(admin)));
+            adminCommandExecutionRoutes
+                .getLastSucceedExecutionId(admin, requestHandler.getClusterAdminOpsRequestHandler())));
 
     httpService.get(
         STORAGE_ENGINE_OVERHEAD_RATIO.getPath(),
@@ -624,10 +627,15 @@ public class AdminSparkServer extends AbstractVeniceService {
 
     httpService.get(
         GET_ADMIN_TOPIC_METADATA.getPath(),
-        new VeniceParentControllerRegionStateHandler(admin, adminTopicMetadataRoutes.getAdminTopicMetadata(admin)));
+        new VeniceParentControllerRegionStateHandler(
+            admin,
+            adminTopicMetadataRoutes.getAdminTopicMetadata(admin, requestHandler.getClusterAdminOpsRequestHandler())));
     httpService.post(
         UPDATE_ADMIN_TOPIC_METADATA.getPath(),
-        new VeniceParentControllerRegionStateHandler(admin, adminTopicMetadataRoutes.updateAdminTopicMetadata(admin)));
+        new VeniceParentControllerRegionStateHandler(
+            admin,
+            adminTopicMetadataRoutes
+                .updateAdminTopicMetadata(admin, requestHandler.getClusterAdminOpsRequestHandler())));
 
     httpService.post(
         DELETE_KAFKA_TOPIC.getPath(),

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/server/AdminTopicMetadataRoutes.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/server/AdminTopicMetadataRoutes.java
@@ -85,9 +85,8 @@ public class AdminTopicMetadataRoutes extends AbstractRoute {
         Optional<Long> offset = Optional.ofNullable(request.queryParams(OFFSET)).map(Long::parseLong);
         Optional<Long> upstreamOffset = Optional.ofNullable(request.queryParams(UPSTREAM_OFFSET)).map(Long::parseLong);
 
-        AdminTopicGrpcMetadata.Builder adminMetadataBuilder = AdminTopicGrpcMetadata.newBuilder();
-        adminMetadataBuilder.setClusterName(clusterName);
-        adminMetadataBuilder.setExecutionId(executionId);
+        AdminTopicGrpcMetadata.Builder adminMetadataBuilder =
+            AdminTopicGrpcMetadata.newBuilder().setClusterName(clusterName).setExecutionId(executionId);
         storeName.ifPresent(adminMetadataBuilder::setStoreName);
         offset.ifPresent(adminMetadataBuilder::setOffset);
         upstreamOffset.ifPresent(adminMetadataBuilder::setUpstreamOffset);

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/server/AdminTopicMetadataRoutes.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/server/AdminTopicMetadataRoutes.java
@@ -11,13 +11,15 @@ import static com.linkedin.venice.controllerapi.ControllerRoute.UPDATE_ADMIN_TOP
 import com.linkedin.venice.HttpConstants;
 import com.linkedin.venice.acl.DynamicAccessController;
 import com.linkedin.venice.controller.Admin;
-import com.linkedin.venice.controller.AdminTopicMetadataAccessor;
 import com.linkedin.venice.controllerapi.AdminTopicMetadataResponse;
 import com.linkedin.venice.controllerapi.ControllerResponse;
 import com.linkedin.venice.exceptions.ErrorType;
 import com.linkedin.venice.exceptions.VeniceException;
-import com.linkedin.venice.utils.Pair;
-import java.util.Map;
+import com.linkedin.venice.protocols.controller.AdminTopicGrpcMetadata;
+import com.linkedin.venice.protocols.controller.AdminTopicMetadataGrpcRequest;
+import com.linkedin.venice.protocols.controller.AdminTopicMetadataGrpcResponse;
+import com.linkedin.venice.protocols.controller.UpdateAdminTopicMetadataGrpcRequest;
+import com.linkedin.venice.protocols.controller.UpdateAdminTopicMetadataGrpcResponse;
 import java.util.Optional;
 import org.apache.http.HttpStatus;
 import spark.Route;
@@ -31,7 +33,7 @@ public class AdminTopicMetadataRoutes extends AbstractRoute {
   /**
    * @see Admin#getAdminTopicMetadata(String, Optional)
    */
-  public Route getAdminTopicMetadata(Admin admin) {
+  public Route getAdminTopicMetadata(Admin admin, ClusterAdminOpsRequestHandler requestHandler) {
     return (request, response) -> {
       AdminTopicMetadataResponse responseObject = new AdminTopicMetadataResponse();
       response.type(HttpConstants.JSON);
@@ -41,16 +43,17 @@ public class AdminTopicMetadataRoutes extends AbstractRoute {
         String clusterName = request.queryParams(CLUSTER);
         Optional<String> storeName = Optional.ofNullable(request.queryParams(NAME));
 
+        AdminTopicMetadataGrpcRequest.Builder requestBuilder = AdminTopicMetadataGrpcRequest.newBuilder();
+        requestBuilder.setClusterName(clusterName);
+        storeName.ifPresent(requestBuilder::setStoreName);
+        AdminTopicMetadataGrpcResponse internalResponse = requestHandler.getAdminTopicMetadata(requestBuilder.build());
+        AdminTopicGrpcMetadata adminTopicMetadata = internalResponse.getMetadata();
         responseObject.setCluster(clusterName);
         storeName.ifPresent(responseObject::setName);
-
-        Map<String, Long> metadata = admin.getAdminTopicMetadata(clusterName, storeName);
-
-        responseObject.setExecutionId(AdminTopicMetadataAccessor.getExecutionId(metadata));
+        responseObject.setExecutionId(adminTopicMetadata.getExecutionId());
         if (!storeName.isPresent()) {
-          Pair<Long, Long> offsets = AdminTopicMetadataAccessor.getOffsets(metadata);
-          responseObject.setOffset(offsets.getFirst());
-          responseObject.setUpstreamOffset(offsets.getSecond());
+          responseObject.setOffset(adminTopicMetadata.getOffset());
+          responseObject.setUpstreamOffset(adminTopicMetadata.getUpstreamOffset());
         }
       } catch (Throwable e) {
         responseObject.setError(e);
@@ -63,7 +66,7 @@ public class AdminTopicMetadataRoutes extends AbstractRoute {
   /**
    * @see Admin#updateAdminTopicMetadata(String, long, Optional, Optional, Optional)
    */
-  public Route updateAdminTopicMetadata(Admin admin) {
+  public Route updateAdminTopicMetadata(Admin admin, ClusterAdminOpsRequestHandler requestHandler) {
     return (request, response) -> {
       ControllerResponse responseObject = new ControllerResponse();
       response.type(HttpConstants.JSON);
@@ -82,20 +85,16 @@ public class AdminTopicMetadataRoutes extends AbstractRoute {
         Optional<Long> offset = Optional.ofNullable(request.queryParams(OFFSET)).map(Long::parseLong);
         Optional<Long> upstreamOffset = Optional.ofNullable(request.queryParams(UPSTREAM_OFFSET)).map(Long::parseLong);
 
-        if (storeName.isPresent()) {
-          if (offset.isPresent() || upstreamOffset.isPresent()) {
-            throw new VeniceException("There is no store-level offsets to be updated");
-          }
-        } else {
-          if (!offset.isPresent() || !upstreamOffset.isPresent()) {
-            throw new VeniceException("Offsets must be provided to update cluster-level admin topic metadata");
-          }
-        }
-
-        responseObject.setCluster(clusterName);
-        storeName.ifPresent(responseObject::setName);
-
-        admin.updateAdminTopicMetadata(clusterName, executionId, storeName, offset, upstreamOffset);
+        AdminTopicGrpcMetadata.Builder adminMetadataBuilder = AdminTopicGrpcMetadata.newBuilder();
+        adminMetadataBuilder.setClusterName(clusterName);
+        adminMetadataBuilder.setExecutionId(executionId);
+        storeName.ifPresent(adminMetadataBuilder::setStoreName);
+        offset.ifPresent(adminMetadataBuilder::setOffset);
+        upstreamOffset.ifPresent(adminMetadataBuilder::setUpstreamOffset);
+        UpdateAdminTopicMetadataGrpcResponse internalResponse = requestHandler.updateAdminTopicMetadata(
+            UpdateAdminTopicMetadataGrpcRequest.newBuilder().setMetadata(adminMetadataBuilder).build());
+        responseObject.setCluster(internalResponse.getClusterName());
+        responseObject.setName(internalResponse.hasStoreName() ? internalResponse.getStoreName() : null);
       } catch (Throwable e) {
         responseObject.setError(e);
         AdminSparkServer.handleError(new VeniceException(e), request, response);

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/server/ClusterAdminOpsRequestHandler.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/server/ClusterAdminOpsRequestHandler.java
@@ -1,0 +1,143 @@
+package com.linkedin.venice.controller.server;
+
+import com.linkedin.venice.controller.Admin;
+import com.linkedin.venice.controller.AdminCommandExecutionTracker;
+import com.linkedin.venice.controller.AdminTopicMetadataAccessor;
+import com.linkedin.venice.controller.ControllerRequestHandlerDependencies;
+import com.linkedin.venice.controller.grpc.GrpcRequestResponseConverter;
+import com.linkedin.venice.controllerapi.AdminCommandExecution;
+import com.linkedin.venice.exceptions.VeniceException;
+import com.linkedin.venice.protocols.controller.AdminCommandExecutionStatusGrpcRequest;
+import com.linkedin.venice.protocols.controller.AdminCommandExecutionStatusGrpcResponse;
+import com.linkedin.venice.protocols.controller.AdminTopicGrpcMetadata;
+import com.linkedin.venice.protocols.controller.AdminTopicMetadataGrpcRequest;
+import com.linkedin.venice.protocols.controller.AdminTopicMetadataGrpcResponse;
+import com.linkedin.venice.protocols.controller.LastSuccessfulAdminCommandExecutionGrpcRequest;
+import com.linkedin.venice.protocols.controller.LastSuccessfulAdminCommandExecutionGrpcResponse;
+import com.linkedin.venice.protocols.controller.UpdateAdminTopicMetadataGrpcRequest;
+import com.linkedin.venice.protocols.controller.UpdateAdminTopicMetadataGrpcResponse;
+import com.linkedin.venice.utils.Pair;
+import java.util.Map;
+import java.util.Optional;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+
+public class ClusterAdminOpsRequestHandler {
+  Logger LOGGER = LogManager.getLogger(ClusterAdminOpsRequestHandler.class);
+
+  private final Admin admin;
+
+  public ClusterAdminOpsRequestHandler(ControllerRequestHandlerDependencies dependencies) {
+    this.admin = dependencies.getAdmin();
+  }
+
+  public AdminCommandExecutionStatusGrpcResponse getAdminCommandExecutionStatus(
+      AdminCommandExecutionStatusGrpcRequest request) {
+    String clusterName = request.getClusterName();
+    long executionId = request.getAdminCommandExecutionId();
+    ControllerRequestParamValidator.validateAdminCommandExecutionRequest(clusterName, executionId);
+    LOGGER
+        .info("Getting admin command execution status for cluster: {} and execution id: {}", clusterName, executionId);
+    Optional<AdminCommandExecutionTracker> adminCommandExecutionTracker =
+        admin.getAdminCommandExecutionTracker(clusterName);
+    if (!adminCommandExecutionTracker.isPresent()) {
+      throw new VeniceException(
+          "Could not track execution in this controller. Make sure you send the command to a correct parent controller.");
+    }
+    AdminCommandExecutionTracker tracker = adminCommandExecutionTracker.get();
+    AdminCommandExecution execution = tracker.checkExecutionStatus(executionId);
+    if (execution == null) {
+      throw new VeniceException(
+          "Could not find the execution by given id: " + executionId + " in cluster: " + clusterName);
+    }
+
+    AdminCommandExecutionStatusGrpcResponse.Builder responseBuilder =
+        AdminCommandExecutionStatusGrpcResponse.newBuilder();
+    responseBuilder.setClusterName(clusterName).setAdminCommandExecutionId(execution.getExecutionId());
+    if (execution.getOperation() != null) {
+      responseBuilder.setOperation(execution.getOperation());
+    }
+    if (execution.getStartTime() != null) {
+      responseBuilder.setStartTime(execution.getStartTime());
+    }
+    Map<String, String> fabricToExecutionStatusMap =
+        GrpcRequestResponseConverter.toGrpcExecutionStatusMap(execution.getFabricToExecutionStatusMap());
+    responseBuilder.putAllFabricToExecutionStatusMap(fabricToExecutionStatusMap);
+    return responseBuilder.build();
+  }
+
+  public LastSuccessfulAdminCommandExecutionGrpcResponse getLastSucceedExecutionId(
+      LastSuccessfulAdminCommandExecutionGrpcRequest request) {
+    String clusterName = request.getClusterName();
+    if (StringUtils.isBlank(clusterName)) {
+      throw new IllegalArgumentException("Cluster name is required for getting last succeeded execution id");
+    }
+    LOGGER.info("Getting last succeeded execution id in cluster: {}", clusterName);
+    long lastSucceedExecutionId = admin.getLastSucceedExecutionId(clusterName);
+    return LastSuccessfulAdminCommandExecutionGrpcResponse.newBuilder()
+        .setClusterName(clusterName)
+        .setLastSuccessfulAdminCommandExecutionId(lastSucceedExecutionId)
+        .build();
+  }
+
+  public AdminTopicMetadataGrpcResponse getAdminTopicMetadata(AdminTopicMetadataGrpcRequest request) {
+    String clusterName = request.getClusterName();
+    if (StringUtils.isBlank(clusterName)) {
+      throw new IllegalArgumentException("Cluster name is required for getting admin topic metadata");
+    }
+    String storeName = request.hasStoreName() ? request.getStoreName() : null;
+    LOGGER.info(
+        "Getting admin topic metadata for cluster: {}{}",
+        clusterName,
+        storeName != null ? " and store: " + storeName : "");
+
+    AdminTopicGrpcMetadata.Builder adminMetadataBuilder = AdminTopicGrpcMetadata.newBuilder();
+    Map<String, Long> metadata = admin.getAdminTopicMetadata(clusterName, Optional.ofNullable(storeName));
+    adminMetadataBuilder.setExecutionId(AdminTopicMetadataAccessor.getExecutionId(metadata));
+    if (storeName == null) {
+      Pair<Long, Long> offsets = AdminTopicMetadataAccessor.getOffsets(metadata);
+      adminMetadataBuilder.setOffset(offsets.getFirst());
+      adminMetadataBuilder.setUpstreamOffset(offsets.getSecond());
+    }
+
+    adminMetadataBuilder.setClusterName(clusterName);
+    if (storeName != null) {
+      adminMetadataBuilder.setStoreName(storeName);
+    }
+    return AdminTopicMetadataGrpcResponse.newBuilder().setMetadata(adminMetadataBuilder.build()).build();
+  }
+
+  public UpdateAdminTopicMetadataGrpcResponse updateAdminTopicMetadata(UpdateAdminTopicMetadataGrpcRequest request) {
+    AdminTopicGrpcMetadata metadata = request.getMetadata();
+    String clusterName = metadata.getClusterName();
+    long executionId = metadata.getExecutionId();
+    ControllerRequestParamValidator.validateAdminCommandExecutionRequest(clusterName, executionId);
+    String storeName = metadata.hasStoreName() ? metadata.getStoreName() : null;
+    Long offset = metadata.hasOffset() ? metadata.getOffset() : null;
+    Long upstreamOffset = metadata.hasUpstreamOffset() ? metadata.getUpstreamOffset() : null;
+    LOGGER.info(
+        "Updating admin topic metadata for cluster: {}{} with execution id: {}",
+        clusterName,
+        storeName != null ? " and store: " + storeName : "",
+        executionId);
+    if (storeName != null && (offset != null || upstreamOffset != null)) {
+      throw new VeniceException("Updating offsets is not allowed for store-level admin topic metadata");
+    } else if (storeName == null && (offset == null || upstreamOffset == null)) {
+      throw new VeniceException("Offsets must be provided to update cluster-level admin topic metadata");
+    }
+    admin.updateAdminTopicMetadata(
+        clusterName,
+        executionId,
+        Optional.ofNullable(storeName),
+        Optional.ofNullable(offset),
+        Optional.ofNullable(upstreamOffset));
+    UpdateAdminTopicMetadataGrpcResponse.Builder responseBuilder =
+        UpdateAdminTopicMetadataGrpcResponse.newBuilder().setClusterName(clusterName);
+    if (storeName != null) {
+      responseBuilder.setStoreName(storeName);
+    }
+    return responseBuilder.build();
+  }
+}

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/server/ControllerRequestParamValidator.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/server/ControllerRequestParamValidator.java
@@ -36,4 +36,13 @@ public class ControllerRequestParamValidator {
       throw new IllegalArgumentException("Store name is mandatory parameter");
     }
   }
+
+  public static void validateAdminCommandExecutionRequest(String clusterName, long executionId) {
+    if (StringUtils.isBlank(clusterName)) {
+      throw new IllegalArgumentException("Cluster name is required for getting admin command execution status");
+    }
+    if (executionId <= 0) {
+      throw new IllegalArgumentException("Admin command execution id with positive value is required");
+    }
+  }
 }

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/server/VeniceControllerRequestHandler.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/server/VeniceControllerRequestHandler.java
@@ -24,12 +24,14 @@ public class VeniceControllerRequestHandler {
   private final boolean sslEnabled;
   private final VeniceControllerAccessManager accessManager;
   private final StoreRequestHandler storeRequestHandler;
+  private final ClusterAdminOpsRequestHandler clusterAdminOpsRequestHandler;
 
   public VeniceControllerRequestHandler(ControllerRequestHandlerDependencies dependencies) {
     this.admin = dependencies.getAdmin();
     this.sslEnabled = dependencies.isSslEnabled();
     this.accessManager = dependencies.getControllerAccessManager();
     this.storeRequestHandler = new StoreRequestHandler(dependencies);
+    this.clusterAdminOpsRequestHandler = new ClusterAdminOpsRequestHandler(dependencies);
   }
 
   // visibility: package-private
@@ -43,6 +45,10 @@ public class VeniceControllerRequestHandler {
 
   public StoreRequestHandler getStoreRequestHandler() {
     return storeRequestHandler;
+  }
+
+  public ClusterAdminOpsRequestHandler getClusterAdminOpsRequestHandler() {
+    return clusterAdminOpsRequestHandler;
   }
 
   /**

--- a/services/venice-controller/src/test/java/com/linkedin/venice/controller/grpc/server/ClusterAdminOpsGrpcServiceImplTest.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/controller/grpc/server/ClusterAdminOpsGrpcServiceImplTest.java
@@ -1,0 +1,179 @@
+package com.linkedin.venice.controller.grpc.server;
+
+import static com.linkedin.venice.controller.server.VeniceRouteHandler.ACL_CHECK_FAILURE_WARN_MESSAGE_PREFIX;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.expectThrows;
+
+import com.linkedin.venice.controller.grpc.GrpcRequestResponseConverter;
+import com.linkedin.venice.controller.server.ClusterAdminOpsRequestHandler;
+import com.linkedin.venice.controller.server.VeniceControllerAccessManager;
+import com.linkedin.venice.exceptions.VeniceException;
+import com.linkedin.venice.protocols.controller.AdminCommandExecutionStatusGrpcRequest;
+import com.linkedin.venice.protocols.controller.AdminCommandExecutionStatusGrpcResponse;
+import com.linkedin.venice.protocols.controller.AdminTopicGrpcMetadata;
+import com.linkedin.venice.protocols.controller.AdminTopicMetadataGrpcRequest;
+import com.linkedin.venice.protocols.controller.AdminTopicMetadataGrpcResponse;
+import com.linkedin.venice.protocols.controller.ClusterAdminOpsGrpcServiceGrpc;
+import com.linkedin.venice.protocols.controller.ClusterAdminOpsGrpcServiceGrpc.ClusterAdminOpsGrpcServiceBlockingStub;
+import com.linkedin.venice.protocols.controller.LastSuccessfulAdminCommandExecutionGrpcRequest;
+import com.linkedin.venice.protocols.controller.LastSuccessfulAdminCommandExecutionGrpcResponse;
+import com.linkedin.venice.protocols.controller.UpdateAdminTopicMetadataGrpcRequest;
+import com.linkedin.venice.protocols.controller.UpdateAdminTopicMetadataGrpcResponse;
+import com.linkedin.venice.protocols.controller.VeniceControllerGrpcErrorInfo;
+import io.grpc.ManagedChannel;
+import io.grpc.Server;
+import io.grpc.Status;
+import io.grpc.StatusRuntimeException;
+import io.grpc.inprocess.InProcessChannelBuilder;
+import io.grpc.inprocess.InProcessServerBuilder;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+
+public class ClusterAdminOpsGrpcServiceImplTest {
+  private static final String TEST_CLUSTER = "test-cluster";
+  private static final String TEST_STORE = "test-store";
+  private static final long EXECUTION_ID = 12345L;
+
+  private Server grpcServer;
+  private ManagedChannel grpcChannel;
+  private ClusterAdminOpsRequestHandler requestHandler;
+  private ClusterAdminOpsGrpcServiceBlockingStub blockingStub;
+  private VeniceControllerAccessManager accessManager;
+
+  @BeforeMethod
+  public void setUp() throws Exception {
+    accessManager = mock(VeniceControllerAccessManager.class);
+    requestHandler = mock(ClusterAdminOpsRequestHandler.class);
+
+    String serverName = InProcessServerBuilder.generateName();
+    grpcServer = InProcessServerBuilder.forName(serverName)
+        .directExecutor()
+        .addService(new ClusterAdminOpsGrpcServiceImpl(requestHandler, accessManager))
+        .build()
+        .start();
+
+    grpcChannel = InProcessChannelBuilder.forName(serverName).directExecutor().build();
+    blockingStub = ClusterAdminOpsGrpcServiceGrpc.newBlockingStub(grpcChannel);
+  }
+
+  @AfterMethod
+  public void tearDown() throws Exception {
+    if (grpcServer != null) {
+      grpcServer.shutdown();
+    }
+    if (grpcChannel != null) {
+      grpcChannel.shutdown();
+    }
+  }
+
+  @Test
+  public void testGetAdminCommandExecutionStatusSuccess() {
+    AdminCommandExecutionStatusGrpcResponse response = AdminCommandExecutionStatusGrpcResponse.newBuilder()
+        .setClusterName(TEST_CLUSTER)
+        .setAdminCommandExecutionId(EXECUTION_ID)
+        .build();
+    doReturn(response).when(requestHandler)
+        .getAdminCommandExecutionStatus(any(AdminCommandExecutionStatusGrpcRequest.class));
+
+    AdminCommandExecutionStatusGrpcRequest request = AdminCommandExecutionStatusGrpcRequest.newBuilder()
+        .setClusterName(TEST_CLUSTER)
+        .setAdminCommandExecutionId(EXECUTION_ID)
+        .build();
+
+    AdminCommandExecutionStatusGrpcResponse actualResponse = blockingStub.getAdminCommandExecutionStatus(request);
+    assertNotNull(actualResponse);
+    assertEquals(actualResponse.getClusterName(), TEST_CLUSTER);
+    assertEquals(actualResponse.getAdminCommandExecutionId(), EXECUTION_ID);
+  }
+
+  @Test
+  public void testGetAdminCommandExecutionStatusError() {
+    AdminCommandExecutionStatusGrpcRequest request = AdminCommandExecutionStatusGrpcRequest.newBuilder()
+        .setClusterName(TEST_CLUSTER)
+        .setAdminCommandExecutionId(EXECUTION_ID)
+        .build();
+
+    doThrow(new VeniceException("Error")).when(requestHandler)
+        .getAdminCommandExecutionStatus(any(AdminCommandExecutionStatusGrpcRequest.class));
+
+    StatusRuntimeException e =
+        expectThrows(StatusRuntimeException.class, () -> blockingStub.getAdminCommandExecutionStatus(request));
+    assertEquals(e.getStatus().getCode(), Status.INTERNAL.getCode());
+  }
+
+  @Test
+  public void testGetLastSuccessfulAdminCommandExecutionIdSuccess() {
+    LastSuccessfulAdminCommandExecutionGrpcResponse response =
+        LastSuccessfulAdminCommandExecutionGrpcResponse.newBuilder()
+            .setClusterName(TEST_CLUSTER)
+            .setLastSuccessfulAdminCommandExecutionId(EXECUTION_ID)
+            .build();
+    doReturn(response).when(requestHandler)
+        .getLastSucceedExecutionId(any(LastSuccessfulAdminCommandExecutionGrpcRequest.class));
+
+    LastSuccessfulAdminCommandExecutionGrpcRequest request =
+        LastSuccessfulAdminCommandExecutionGrpcRequest.newBuilder().setClusterName(TEST_CLUSTER).build();
+
+    LastSuccessfulAdminCommandExecutionGrpcResponse actualResponse =
+        blockingStub.getLastSuccessfulAdminCommandExecutionId(request);
+    assertNotNull(actualResponse);
+    assertEquals(actualResponse.getClusterName(), TEST_CLUSTER);
+    assertEquals(actualResponse.getLastSuccessfulAdminCommandExecutionId(), EXECUTION_ID);
+  }
+
+  @Test
+  public void testGetAdminTopicMetadataSuccess() {
+    AdminTopicGrpcMetadata metadata =
+        AdminTopicGrpcMetadata.newBuilder().setClusterName(TEST_CLUSTER).setExecutionId(EXECUTION_ID).build();
+    AdminTopicMetadataGrpcResponse response = AdminTopicMetadataGrpcResponse.newBuilder().setMetadata(metadata).build();
+    doReturn(response).when(requestHandler).getAdminTopicMetadata(any(AdminTopicMetadataGrpcRequest.class));
+
+    AdminTopicMetadataGrpcRequest request =
+        AdminTopicMetadataGrpcRequest.newBuilder().setClusterName(TEST_CLUSTER).setStoreName(TEST_STORE).build();
+
+    AdminTopicMetadataGrpcResponse actualResponse = blockingStub.getAdminTopicMetadata(request);
+    assertNotNull(actualResponse);
+    assertEquals(actualResponse.getMetadata().getClusterName(), TEST_CLUSTER);
+    assertEquals(actualResponse.getMetadata().getExecutionId(), EXECUTION_ID);
+  }
+
+  @Test
+  public void testUpdateAdminTopicMetadataSuccess() {
+    UpdateAdminTopicMetadataGrpcResponse response =
+        UpdateAdminTopicMetadataGrpcResponse.newBuilder().setClusterName(TEST_CLUSTER).build();
+    doReturn(response).when(requestHandler).updateAdminTopicMetadata(any(UpdateAdminTopicMetadataGrpcRequest.class));
+    doReturn(true).when(accessManager).isAllowListUser(anyString(), any());
+
+    UpdateAdminTopicMetadataGrpcRequest request = UpdateAdminTopicMetadataGrpcRequest.newBuilder()
+        .setMetadata(AdminTopicGrpcMetadata.newBuilder().setClusterName(TEST_CLUSTER).setExecutionId(EXECUTION_ID))
+        .build();
+
+    UpdateAdminTopicMetadataGrpcResponse actualResponse = blockingStub.updateAdminTopicMetadata(request);
+    assertNotNull(actualResponse);
+    assertEquals(actualResponse.getClusterName(), TEST_CLUSTER);
+  }
+
+  @Test
+  public void testUpdateAdminTopicMetadataUnauthorized() {
+    UpdateAdminTopicMetadataGrpcRequest request = UpdateAdminTopicMetadataGrpcRequest.newBuilder()
+        .setMetadata(AdminTopicGrpcMetadata.newBuilder().setClusterName(TEST_CLUSTER).setExecutionId(EXECUTION_ID))
+        .build();
+    doReturn(false).when(accessManager).isAllowListUser(anyString(), any());
+    StatusRuntimeException e =
+        expectThrows(StatusRuntimeException.class, () -> blockingStub.updateAdminTopicMetadata(request));
+    assertEquals(e.getStatus().getCode(), Status.PERMISSION_DENIED.getCode());
+    VeniceControllerGrpcErrorInfo errorInfo = GrpcRequestResponseConverter.parseControllerGrpcError(e);
+    assertTrue(
+        errorInfo.getErrorMessage().contains(ACL_CHECK_FAILURE_WARN_MESSAGE_PREFIX),
+        "Actual error message: " + errorInfo.getErrorMessage());
+  }
+}

--- a/services/venice-controller/src/test/java/com/linkedin/venice/controller/server/AdminCommandExecutionRoutesTest.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/controller/server/AdminCommandExecutionRoutesTest.java
@@ -1,0 +1,178 @@
+package com.linkedin.venice.controller.server;
+
+import static com.linkedin.venice.controllerapi.ControllerApiConstants.CLUSTER;
+import static com.linkedin.venice.controllerapi.ControllerApiConstants.EXECUTION_ID;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertTrue;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.linkedin.venice.LastSucceedExecutionIdResponse;
+import com.linkedin.venice.controller.Admin;
+import com.linkedin.venice.controllerapi.AdminCommandExecutionStatus;
+import com.linkedin.venice.controllerapi.routes.AdminCommandExecutionResponse;
+import com.linkedin.venice.protocols.controller.AdminCommandExecutionStatusGrpcRequest;
+import com.linkedin.venice.protocols.controller.AdminCommandExecutionStatusGrpcResponse;
+import com.linkedin.venice.protocols.controller.LastSuccessfulAdminCommandExecutionGrpcRequest;
+import com.linkedin.venice.protocols.controller.LastSuccessfulAdminCommandExecutionGrpcResponse;
+import com.linkedin.venice.utils.ObjectMapperFactory;
+import java.util.HashMap;
+import java.util.Optional;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+import spark.QueryParamsMap;
+import spark.Request;
+import spark.Response;
+import spark.Route;
+
+
+public class AdminCommandExecutionRoutesTest {
+  private static final ObjectMapper OBJECT_MAPPER = ObjectMapperFactory.getInstance();
+  private static final String TEST_CLUSTER = "test-cluster";
+  private static final long TEST_EXECUTION_ID = 12345L;
+
+  private Admin mockAdmin;
+  private ClusterAdminOpsRequestHandler requestHandler;
+  private Request request;
+  private Response response;
+
+  @BeforeMethod
+  public void setUp() {
+    request = mock(Request.class);
+    response = mock(Response.class);
+    mockAdmin = mock(Admin.class);
+    doReturn(true).when(mockAdmin).isLeaderControllerFor(TEST_CLUSTER);
+    requestHandler = mock(ClusterAdminOpsRequestHandler.class);
+  }
+
+  @Test
+  public void testGetExecutionSuccess() throws Exception {
+    QueryParamsMap paramsMap = mock(QueryParamsMap.class);
+    doReturn(new HashMap<>()).when(paramsMap).toMap();
+    doReturn(paramsMap).when(request).queryMap();
+
+    when(request.queryParams(CLUSTER)).thenReturn(TEST_CLUSTER);
+    when(request.queryParams(EXECUTION_ID)).thenReturn(String.valueOf(TEST_EXECUTION_ID));
+
+    AdminCommandExecutionStatusGrpcResponse grpcResponse = AdminCommandExecutionStatusGrpcResponse.newBuilder()
+        .setClusterName(TEST_CLUSTER)
+        .setAdminCommandExecutionId(TEST_EXECUTION_ID)
+        .setOperation("test-operation")
+        .putFabricToExecutionStatusMap("fabric1", AdminCommandExecutionStatus.COMPLETED.name())
+        .putFabricToExecutionStatusMap("fabric2", AdminCommandExecutionStatus.PROCESSING.name())
+        .setStartTime(String.valueOf(123456789L))
+        .build();
+
+    when(requestHandler.getAdminCommandExecutionStatus(any(AdminCommandExecutionStatusGrpcRequest.class)))
+        .thenReturn(grpcResponse);
+
+    Route route = new AdminCommandExecutionRoutes(false, Optional.empty()).getExecution(mockAdmin, requestHandler);
+    AdminCommandExecutionResponse responseObject =
+        OBJECT_MAPPER.readValue(route.handle(request, response).toString(), AdminCommandExecutionResponse.class);
+
+    verify(requestHandler, times(1)).getAdminCommandExecutionStatus(any(AdminCommandExecutionStatusGrpcRequest.class));
+    assertEquals(responseObject.getCluster(), TEST_CLUSTER);
+    assertEquals(responseObject.getExecution().getExecutionId(), TEST_EXECUTION_ID);
+    assertEquals(responseObject.getExecution().getOperation(), "test-operation");
+    assertEquals(
+        responseObject.getExecution().getFabricToExecutionStatusMap().get("fabric1"),
+        AdminCommandExecutionStatus.COMPLETED);
+  }
+
+  @Test
+  public void testGetExecutionMissingParameters() throws Exception {
+    QueryParamsMap paramsMap = mock(QueryParamsMap.class);
+    doReturn(new HashMap<>()).when(paramsMap).toMap();
+    doReturn(paramsMap).when(request).queryMap();
+
+    when(request.queryParams(CLUSTER)).thenReturn(null); // Missing cluster
+    when(request.queryParams(EXECUTION_ID)).thenReturn(String.valueOf(TEST_EXECUTION_ID));
+
+    Route route = new AdminCommandExecutionRoutes(false, Optional.empty()).getExecution(mockAdmin, requestHandler);
+    AdminCommandExecutionResponse responseObject =
+        OBJECT_MAPPER.readValue(route.handle(request, response).toString(), AdminCommandExecutionResponse.class);
+
+    verify(requestHandler, never()).getAdminCommandExecutionStatus(any());
+    assertNotNull(responseObject.getError());
+    assertTrue(responseObject.getError().contains("cluster_name is a required parameter"));
+  }
+
+  @Test
+  public void testGetExecutionHandlesException() throws Exception {
+    QueryParamsMap paramsMap = mock(QueryParamsMap.class);
+    doReturn(new HashMap<>()).when(paramsMap).toMap();
+    doReturn(paramsMap).when(request).queryMap();
+
+    when(request.queryParams(CLUSTER)).thenReturn(TEST_CLUSTER);
+    when(request.queryParams(EXECUTION_ID)).thenReturn(String.valueOf(TEST_EXECUTION_ID));
+
+    when(requestHandler.getAdminCommandExecutionStatus(any(AdminCommandExecutionStatusGrpcRequest.class)))
+        .thenThrow(new RuntimeException("Internal error"));
+
+    Route route = new AdminCommandExecutionRoutes(false, Optional.empty()).getExecution(mockAdmin, requestHandler);
+    AdminCommandExecutionResponse responseObject =
+        OBJECT_MAPPER.readValue(route.handle(request, response).toString(), AdminCommandExecutionResponse.class);
+
+    verify(requestHandler, times(1)).getAdminCommandExecutionStatus(any(AdminCommandExecutionStatusGrpcRequest.class));
+    assertNotNull(responseObject.getError());
+    assertTrue(responseObject.getError().contains("Internal error"));
+  }
+
+  @Test
+  public void testGetLastSucceedExecutionIdSuccess() throws Exception {
+    QueryParamsMap paramsMap = mock(QueryParamsMap.class);
+    doReturn(new HashMap<>()).when(paramsMap).toMap();
+    doReturn(paramsMap).when(request).queryMap();
+
+    when(request.queryParams(CLUSTER)).thenReturn(TEST_CLUSTER);
+
+    LastSuccessfulAdminCommandExecutionGrpcResponse grpcResponse =
+        LastSuccessfulAdminCommandExecutionGrpcResponse.newBuilder()
+            .setLastSuccessfulAdminCommandExecutionId(TEST_EXECUTION_ID)
+            .build();
+
+    when(requestHandler.getLastSucceedExecutionId(any(LastSuccessfulAdminCommandExecutionGrpcRequest.class)))
+        .thenReturn(grpcResponse);
+
+    Route route =
+        new AdminCommandExecutionRoutes(false, Optional.empty()).getLastSucceedExecutionId(mockAdmin, requestHandler);
+    LastSucceedExecutionIdResponse responseObject =
+        OBJECT_MAPPER.readValue(route.handle(request, response).toString(), LastSucceedExecutionIdResponse.class);
+
+    verify(requestHandler, times(1))
+        .getLastSucceedExecutionId(any(LastSuccessfulAdminCommandExecutionGrpcRequest.class));
+    assertEquals(responseObject.getCluster(), TEST_CLUSTER);
+    assertEquals(responseObject.getLastSucceedExecutionId(), TEST_EXECUTION_ID);
+    assertNull(responseObject.getError());
+  }
+
+  @Test
+  public void testGetLastSucceedExecutionIdHandlesException() throws Exception {
+    QueryParamsMap paramsMap = mock(QueryParamsMap.class);
+    doReturn(new HashMap<>()).when(paramsMap).toMap();
+    doReturn(paramsMap).when(request).queryMap();
+
+    when(request.queryParams(CLUSTER)).thenReturn(TEST_CLUSTER);
+
+    when(requestHandler.getLastSucceedExecutionId(any(LastSuccessfulAdminCommandExecutionGrpcRequest.class)))
+        .thenThrow(new RuntimeException("Internal error"));
+
+    Route route =
+        new AdminCommandExecutionRoutes(false, Optional.empty()).getLastSucceedExecutionId(mockAdmin, requestHandler);
+    LastSucceedExecutionIdResponse responseObject =
+        OBJECT_MAPPER.readValue(route.handle(request, response).toString(), LastSucceedExecutionIdResponse.class);
+
+    verify(requestHandler, times(1))
+        .getLastSucceedExecutionId(any(LastSuccessfulAdminCommandExecutionGrpcRequest.class));
+    assertNotNull(responseObject.getError());
+    assertTrue(responseObject.getError().contains("Internal error"));
+  }
+}

--- a/services/venice-controller/src/test/java/com/linkedin/venice/controller/server/AdminTopicMetadataRoutesTest.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/controller/server/AdminTopicMetadataRoutesTest.java
@@ -1,0 +1,218 @@
+package com.linkedin.venice.controller.server;
+
+import static com.linkedin.venice.VeniceConstants.CONTROLLER_SSL_CERTIFICATE_ATTRIBUTE_NAME;
+import static com.linkedin.venice.controllerapi.ControllerApiConstants.CLUSTER;
+import static com.linkedin.venice.controllerapi.ControllerApiConstants.EXECUTION_ID;
+import static com.linkedin.venice.controllerapi.ControllerApiConstants.STORE_NAME;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertTrue;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.linkedin.venice.acl.DynamicAccessController;
+import com.linkedin.venice.controller.Admin;
+import com.linkedin.venice.controllerapi.AdminTopicMetadataResponse;
+import com.linkedin.venice.controllerapi.ControllerResponse;
+import com.linkedin.venice.protocols.controller.AdminTopicGrpcMetadata;
+import com.linkedin.venice.protocols.controller.AdminTopicMetadataGrpcRequest;
+import com.linkedin.venice.protocols.controller.AdminTopicMetadataGrpcResponse;
+import com.linkedin.venice.protocols.controller.UpdateAdminTopicMetadataGrpcRequest;
+import com.linkedin.venice.protocols.controller.UpdateAdminTopicMetadataGrpcResponse;
+import com.linkedin.venice.utils.ObjectMapperFactory;
+import java.security.cert.X509Certificate;
+import java.util.HashMap;
+import java.util.Optional;
+import javax.security.auth.x500.X500Principal;
+import javax.servlet.http.HttpServletRequest;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+import spark.QueryParamsMap;
+import spark.Request;
+import spark.Response;
+import spark.Route;
+
+
+public class AdminTopicMetadataRoutesTest {
+  private static final ObjectMapper OBJECT_MAPPER = ObjectMapperFactory.getInstance();
+  private static final String TEST_CLUSTER = "test-cluster";
+  private static final String TEST_STORE = "test-store";
+  private static final long TEST_EXECUTION_ID = 12345L;
+
+  private Admin mockAdmin;
+  private ClusterAdminOpsRequestHandler requestHandler;
+  private Request request;
+  private Response response;
+
+  @BeforeMethod
+  public void setUp() {
+    request = mock(Request.class);
+    response = mock(Response.class);
+    mockAdmin = mock(Admin.class);
+    doReturn(true).when(mockAdmin).isLeaderControllerFor(TEST_CLUSTER);
+    requestHandler = mock(ClusterAdminOpsRequestHandler.class);
+  }
+
+  @Test
+  public void testGetAdminTopicMetadataSuccess() throws Exception {
+    QueryParamsMap paramsMap = mock(QueryParamsMap.class);
+    doReturn(new HashMap<>()).when(paramsMap).toMap();
+    doReturn(paramsMap).when(request).queryMap();
+
+    when(request.queryParams(CLUSTER)).thenReturn(TEST_CLUSTER);
+    when(request.queryParams(STORE_NAME)).thenReturn(null);
+
+    AdminTopicMetadataGrpcResponse grpcResponse = AdminTopicMetadataGrpcResponse.newBuilder()
+        .setMetadata(
+            AdminTopicGrpcMetadata.newBuilder()
+                .setClusterName(TEST_CLUSTER)
+                .setExecutionId(TEST_EXECUTION_ID)
+                .setOffset(100)
+                .setUpstreamOffset(200))
+        .build();
+
+    when(requestHandler.getAdminTopicMetadata(any(AdminTopicMetadataGrpcRequest.class))).thenReturn(grpcResponse);
+
+    Route route =
+        new AdminTopicMetadataRoutes(false, Optional.empty()).getAdminTopicMetadata(mockAdmin, requestHandler);
+    AdminTopicMetadataResponse responseObject =
+        OBJECT_MAPPER.readValue(route.handle(request, response).toString(), AdminTopicMetadataResponse.class);
+
+    verify(requestHandler, times(1)).getAdminTopicMetadata(any(AdminTopicMetadataGrpcRequest.class));
+    assertEquals(responseObject.getCluster(), TEST_CLUSTER);
+    assertEquals(responseObject.getExecutionId(), TEST_EXECUTION_ID);
+    assertEquals(responseObject.getOffset(), 100L);
+    assertEquals(responseObject.getUpstreamOffset(), 200L);
+    assertNull(responseObject.getError());
+
+    // non-null store name
+    when(request.queryParams(STORE_NAME)).thenReturn(TEST_STORE);
+    grpcResponse = AdminTopicMetadataGrpcResponse.newBuilder()
+        .setMetadata(
+            AdminTopicGrpcMetadata.newBuilder()
+                .setClusterName(TEST_CLUSTER)
+                .setStoreName(TEST_STORE)
+                .setExecutionId(TEST_EXECUTION_ID)
+                .setOffset(100)
+                .setUpstreamOffset(200))
+        .build();
+
+    when(requestHandler.getAdminTopicMetadata(any(AdminTopicMetadataGrpcRequest.class))).thenReturn(grpcResponse);
+
+    responseObject =
+        OBJECT_MAPPER.readValue(route.handle(request, response).toString(), AdminTopicMetadataResponse.class);
+
+    verify(requestHandler, times(2)).getAdminTopicMetadata(any(AdminTopicMetadataGrpcRequest.class));
+    assertEquals(responseObject.getCluster(), TEST_CLUSTER);
+    assertEquals(responseObject.getName(), TEST_STORE);
+    assertEquals(responseObject.getExecutionId(), TEST_EXECUTION_ID);
+    assertEquals(responseObject.getOffset(), -1L);
+    assertEquals(responseObject.getUpstreamOffset(), -1L);
+    assertNull(responseObject.getError());
+  }
+
+  @Test
+  public void testGetAdminTopicMetadataHandlesMissingParams() throws Exception {
+    QueryParamsMap paramsMap = mock(QueryParamsMap.class);
+    doReturn(new HashMap<>()).when(paramsMap).toMap();
+    doReturn(paramsMap).when(request).queryMap();
+
+    when(request.queryParams(CLUSTER)).thenReturn(null); // Missing cluster parameter
+
+    Route route =
+        new AdminTopicMetadataRoutes(false, Optional.empty()).getAdminTopicMetadata(mockAdmin, requestHandler);
+    AdminTopicMetadataResponse responseObject =
+        OBJECT_MAPPER.readValue(route.handle(request, response).toString(), AdminTopicMetadataResponse.class);
+
+    verify(requestHandler, never()).getAdminTopicMetadata(any());
+    assertNotNull(responseObject.getError());
+    assertTrue(responseObject.getError().contains("cluster_name is a required parameter"));
+  }
+
+  @Test
+  public void testUpdateAdminTopicMetadataSuccess() throws Exception {
+    QueryParamsMap paramsMap = mock(QueryParamsMap.class);
+    doReturn(new HashMap<>()).when(paramsMap).toMap();
+    doReturn(paramsMap).when(request).queryMap();
+
+    when(request.queryParams(CLUSTER)).thenReturn(TEST_CLUSTER);
+    when(request.queryParams(EXECUTION_ID)).thenReturn(String.valueOf(TEST_EXECUTION_ID));
+    when(request.queryParams(STORE_NAME)).thenReturn(TEST_STORE);
+
+    UpdateAdminTopicMetadataGrpcResponse grpcResponse =
+        UpdateAdminTopicMetadataGrpcResponse.newBuilder().setClusterName(TEST_CLUSTER).setStoreName(TEST_STORE).build();
+
+    when(requestHandler.updateAdminTopicMetadata(any(UpdateAdminTopicMetadataGrpcRequest.class)))
+        .thenReturn(grpcResponse);
+
+    Route route =
+        new AdminTopicMetadataRoutes(false, Optional.empty()).updateAdminTopicMetadata(mockAdmin, requestHandler);
+    ControllerResponse responseObject =
+        OBJECT_MAPPER.readValue(route.handle(request, response).toString(), ControllerResponse.class);
+
+    verify(requestHandler, times(1)).updateAdminTopicMetadata(any(UpdateAdminTopicMetadataGrpcRequest.class));
+    assertEquals(responseObject.getCluster(), TEST_CLUSTER);
+    assertEquals(responseObject.getName(), TEST_STORE);
+    assertNull(responseObject.getError());
+  }
+
+  @Test
+  public void testUpdateAdminTopicMetadataHandlesUnauthorizedAccess() throws Exception {
+    QueryParamsMap paramsMap = mock(QueryParamsMap.class);
+    doReturn(new HashMap<>()).when(paramsMap).toMap();
+    doReturn(paramsMap).when(request).queryMap();
+
+    DynamicAccessController accessController = mock(DynamicAccessController.class);
+    when(accessController.isAllowlistUsers(any(), any(), any())).thenReturn(false);
+    HttpServletRequest httpServletRequest = mock(HttpServletRequest.class);
+    when(request.raw()).thenReturn(httpServletRequest);
+    X509Certificate certificate = mock(X509Certificate.class);
+    X500Principal principal = new X500Principal("CN=foo");
+    X509Certificate[] certificates = new X509Certificate[] { mock(X509Certificate.class) };
+    when(httpServletRequest.getAttribute(CONTROLLER_SSL_CERTIFICATE_ATTRIBUTE_NAME)).thenReturn(certificates);
+    doReturn(principal).when(certificate).getSubjectX500Principal();
+    doReturn(httpServletRequest).when(request).raw();
+
+    when(request.queryParams(CLUSTER)).thenReturn(TEST_CLUSTER);
+    when(request.queryParams(EXECUTION_ID)).thenReturn(String.valueOf(TEST_EXECUTION_ID));
+    when(request.queryParams(STORE_NAME)).thenReturn(TEST_STORE);
+    Route route = new AdminTopicMetadataRoutes(false, Optional.of(accessController))
+        .updateAdminTopicMetadata(mockAdmin, requestHandler);
+    ControllerResponse responseObject =
+        OBJECT_MAPPER.readValue(route.handle(request, response).toString(), ControllerResponse.class);
+
+    verify(requestHandler, never()).updateAdminTopicMetadata(any(UpdateAdminTopicMetadataGrpcRequest.class));
+    assertNotNull(responseObject.getError());
+    assertTrue(responseObject.getError().contains("Only admin users are allowed"));
+  }
+
+  @Test
+  public void testUpdateAdminTopicMetadataHandlesException() throws Exception {
+    QueryParamsMap paramsMap = mock(QueryParamsMap.class);
+    doReturn(new HashMap<>()).when(paramsMap).toMap();
+    doReturn(paramsMap).when(request).queryMap();
+
+    when(request.queryParams(CLUSTER)).thenReturn(TEST_CLUSTER);
+    when(request.queryParams(EXECUTION_ID)).thenReturn(String.valueOf(TEST_EXECUTION_ID));
+    when(request.queryParams(STORE_NAME)).thenReturn(TEST_STORE);
+
+    when(requestHandler.updateAdminTopicMetadata(any(UpdateAdminTopicMetadataGrpcRequest.class)))
+        .thenThrow(new RuntimeException("Internal error"));
+
+    Route route =
+        new AdminTopicMetadataRoutes(false, Optional.empty()).updateAdminTopicMetadata(mockAdmin, requestHandler);
+    ControllerResponse responseObject =
+        OBJECT_MAPPER.readValue(route.handle(request, response).toString(), ControllerResponse.class);
+
+    verify(requestHandler, times(1)).updateAdminTopicMetadata(any(UpdateAdminTopicMetadataGrpcRequest.class));
+    assertNotNull(responseObject.getError());
+    assertTrue(responseObject.getError().contains("Internal error"));
+  }
+}

--- a/services/venice-controller/src/test/java/com/linkedin/venice/controller/server/ClusterAdminOpsRequestHandlerTest.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/controller/server/ClusterAdminOpsRequestHandlerTest.java
@@ -1,0 +1,260 @@
+package com.linkedin.venice.controller.server;
+
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.expectThrows;
+
+import com.linkedin.venice.controller.Admin;
+import com.linkedin.venice.controller.AdminCommandExecutionTracker;
+import com.linkedin.venice.controller.ControllerRequestHandlerDependencies;
+import com.linkedin.venice.controllerapi.AdminCommandExecution;
+import com.linkedin.venice.controllerapi.AdminCommandExecutionStatus;
+import com.linkedin.venice.exceptions.VeniceException;
+import com.linkedin.venice.protocols.controller.AdminCommandExecutionStatusGrpcRequest;
+import com.linkedin.venice.protocols.controller.AdminCommandExecutionStatusGrpcResponse;
+import com.linkedin.venice.protocols.controller.AdminTopicGrpcMetadata;
+import com.linkedin.venice.protocols.controller.AdminTopicMetadataGrpcRequest;
+import com.linkedin.venice.protocols.controller.AdminTopicMetadataGrpcResponse;
+import com.linkedin.venice.protocols.controller.LastSuccessfulAdminCommandExecutionGrpcRequest;
+import com.linkedin.venice.protocols.controller.LastSuccessfulAdminCommandExecutionGrpcResponse;
+import com.linkedin.venice.protocols.controller.UpdateAdminTopicMetadataGrpcRequest;
+import com.linkedin.venice.protocols.controller.UpdateAdminTopicMetadataGrpcResponse;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+
+public class ClusterAdminOpsRequestHandlerTest {
+  private ClusterAdminOpsRequestHandler handler;
+  private Admin mockAdmin;
+  private AdminCommandExecutionTracker mockTracker;
+
+  @BeforeMethod
+  public void setUp() {
+    mockAdmin = mock(Admin.class);
+    ControllerRequestHandlerDependencies dependencies = mock(ControllerRequestHandlerDependencies.class);
+    when(dependencies.getAdmin()).thenReturn(mockAdmin);
+    handler = new ClusterAdminOpsRequestHandler(dependencies);
+    mockTracker = mock(AdminCommandExecutionTracker.class);
+  }
+
+  @Test
+  public void testGetAdminCommandExecutionStatusSuccess() {
+    String clusterName = "test-cluster";
+    long executionId = 12345L;
+
+    AdminCommandExecution mockExecution = new AdminCommandExecution();
+    mockExecution.setExecutionId(executionId);
+    mockExecution.setOperation("test-operation");
+    mockExecution.setStartTime(String.valueOf(123456789L));
+    mockExecution.setFabricToExecutionStatusMap(
+        new ConcurrentHashMap<>(Collections.singletonMap("fabric1", AdminCommandExecutionStatus.COMPLETED)));
+
+    when(mockAdmin.getAdminCommandExecutionTracker(clusterName)).thenReturn(Optional.of(mockTracker));
+    when(mockTracker.checkExecutionStatus(executionId)).thenReturn(mockExecution);
+
+    AdminCommandExecutionStatusGrpcRequest request = AdminCommandExecutionStatusGrpcRequest.newBuilder()
+        .setClusterName(clusterName)
+        .setAdminCommandExecutionId(executionId)
+        .build();
+
+    AdminCommandExecutionStatusGrpcResponse response = handler.getAdminCommandExecutionStatus(request);
+
+    assertNotNull(response);
+    assertEquals(response.getClusterName(), clusterName);
+    assertEquals(response.getAdminCommandExecutionId(), executionId);
+    assertEquals(response.getOperation(), "test-operation");
+    assertEquals(response.getStartTime(), String.valueOf(123456789L));
+    assertEquals(
+        response.getFabricToExecutionStatusMapMap().get("fabric1"),
+        AdminCommandExecutionStatus.COMPLETED.name());
+  }
+
+  @Test
+  public void testGetAdminCommandExecutionStatusTrackerNotPresent() {
+    String clusterName = "test-cluster";
+    long executionId = 12345L;
+
+    when(mockAdmin.getAdminCommandExecutionTracker(clusterName)).thenReturn(Optional.empty());
+
+    AdminCommandExecutionStatusGrpcRequest request = AdminCommandExecutionStatusGrpcRequest.newBuilder()
+        .setClusterName(clusterName)
+        .setAdminCommandExecutionId(executionId)
+        .build();
+
+    Exception e = expectThrows(VeniceException.class, () -> handler.getAdminCommandExecutionStatus(request));
+    assertEquals(
+        e.getMessage(),
+        "Could not track execution in this controller. Make sure you send the command to a correct parent controller.");
+  }
+
+  @Test
+  public void testGetAdminCommandExecutionStatusExecutionNotFound() {
+    String clusterName = "test-cluster";
+    long executionId = 12345L;
+
+    when(mockAdmin.getAdminCommandExecutionTracker(clusterName)).thenReturn(Optional.of(mockTracker));
+    when(mockTracker.checkExecutionStatus(executionId)).thenReturn(null);
+
+    AdminCommandExecutionStatusGrpcRequest request = AdminCommandExecutionStatusGrpcRequest.newBuilder()
+        .setClusterName(clusterName)
+        .setAdminCommandExecutionId(executionId)
+        .build();
+
+    Exception e = expectThrows(VeniceException.class, () -> handler.getAdminCommandExecutionStatus(request));
+    assertEquals(e.getMessage(), "Could not find the execution by given id: 12345 in cluster: test-cluster");
+  }
+
+  @Test
+  public void testGetLastSucceedExecutionIdSuccess() {
+    String clusterName = "test-cluster";
+    long lastExecutionId = 54321L;
+
+    when(mockAdmin.getLastSucceedExecutionId(clusterName)).thenReturn(lastExecutionId);
+
+    LastSuccessfulAdminCommandExecutionGrpcRequest request =
+        LastSuccessfulAdminCommandExecutionGrpcRequest.newBuilder().setClusterName(clusterName).build();
+
+    LastSuccessfulAdminCommandExecutionGrpcResponse response = handler.getLastSucceedExecutionId(request);
+
+    assertNotNull(response);
+    assertEquals(response.getClusterName(), clusterName);
+    assertEquals(response.getLastSuccessfulAdminCommandExecutionId(), lastExecutionId);
+  }
+
+  @Test
+  public void testGetLastSucceedExecutionIdInvalidCluster() {
+    LastSuccessfulAdminCommandExecutionGrpcRequest request =
+        LastSuccessfulAdminCommandExecutionGrpcRequest.newBuilder().setClusterName("").build();
+
+    Exception e = expectThrows(IllegalArgumentException.class, () -> handler.getLastSucceedExecutionId(request));
+    assertEquals(e.getMessage(), "Cluster name is required for getting last succeeded execution id");
+  }
+
+  @Test
+  public void testGetAdminTopicMetadataSuccess() {
+    String clusterName = "test-cluster";
+    long executionId = 123L;
+    long offset = 456L;
+    long upstreamOffset = 789L;
+
+    Map<String, Long> metadata = new HashMap<>();
+    metadata.put("offset", offset);
+    metadata.put("upstreamOffset", upstreamOffset);
+    metadata.put("executionId", executionId);
+
+    when(mockAdmin.getAdminTopicMetadata(eq(clusterName), any())).thenReturn(metadata);
+
+    AdminTopicMetadataGrpcRequest request =
+        AdminTopicMetadataGrpcRequest.newBuilder().setClusterName(clusterName).build();
+
+    AdminTopicMetadataGrpcResponse response = handler.getAdminTopicMetadata(request);
+
+    assertNotNull(response);
+    AdminTopicGrpcMetadata adminTopicGrpcMetadata = response.getMetadata();
+    assertEquals(adminTopicGrpcMetadata.getExecutionId(), executionId);
+    assertEquals(adminTopicGrpcMetadata.getOffset(), offset);
+    assertEquals(adminTopicGrpcMetadata.getUpstreamOffset(), upstreamOffset);
+
+    // non null store name
+    request = AdminTopicMetadataGrpcRequest.newBuilder().setClusterName(clusterName).setStoreName("test-store").build();
+    response = handler.getAdminTopicMetadata(request);
+
+    assertNotNull(response);
+    adminTopicGrpcMetadata = response.getMetadata();
+    assertEquals(adminTopicGrpcMetadata.getExecutionId(), executionId);
+    assertEquals(adminTopicGrpcMetadata.getOffset(), 0);
+    assertEquals(adminTopicGrpcMetadata.getUpstreamOffset(), 0);
+  }
+
+  @Test
+  public void testGetAdminTopicMetadataInvalidCluster() {
+    AdminTopicMetadataGrpcRequest request = AdminTopicMetadataGrpcRequest.newBuilder().setClusterName("").build();
+
+    Exception exception = expectThrows(IllegalArgumentException.class, () -> handler.getAdminTopicMetadata(request));
+    assertTrue(exception.getMessage().contains("Cluster name is required for getting admin topic metadata"));
+  }
+
+  @Test
+  public void testUpdateAdminTopicMetadataSuccess() {
+    String clusterName = "test-cluster";
+    long executionId = 12345L;
+    AdminTopicGrpcMetadata metadata = AdminTopicGrpcMetadata.newBuilder()
+        .setClusterName(clusterName)
+        .setExecutionId(executionId)
+        .setOffset(123L)
+        .setUpstreamOffset(456L)
+        .build();
+    UpdateAdminTopicMetadataGrpcRequest request =
+        UpdateAdminTopicMetadataGrpcRequest.newBuilder().setMetadata(metadata).build();
+    UpdateAdminTopicMetadataGrpcResponse response = handler.updateAdminTopicMetadata(request);
+    assertNotNull(response);
+    assertEquals(response.getClusterName(), clusterName);
+    assertFalse(response.hasStoreName());
+
+    // Store name is provided
+    metadata = AdminTopicGrpcMetadata.newBuilder()
+        .setClusterName(clusterName)
+        .setExecutionId(executionId)
+        .setStoreName("test-store")
+        .build();
+    request = UpdateAdminTopicMetadataGrpcRequest.newBuilder().setMetadata(metadata).build();
+    response = handler.updateAdminTopicMetadata(request);
+    assertNotNull(response);
+    assertEquals(response.getClusterName(), clusterName);
+  }
+
+  @Test
+  public void testUpdateAdminTopicMetadataInvalidOffsets() {
+    String clusterName = "test-cluster";
+    long executionId = 12345L;
+
+    AdminTopicGrpcMetadata metadata = AdminTopicGrpcMetadata.newBuilder()
+        .setClusterName(clusterName)
+        .setExecutionId(executionId)
+        .setOffset(123L)
+        .build();
+    UpdateAdminTopicMetadataGrpcRequest request =
+        UpdateAdminTopicMetadataGrpcRequest.newBuilder().setMetadata(metadata).build();
+    Exception exception = expectThrows(VeniceException.class, () -> handler.updateAdminTopicMetadata(request));
+    assertTrue(
+        exception.getMessage().contains("Offsets must be provided to update cluster-level admin topic metadata"),
+        "Actual message: " + exception.getMessage());
+
+    metadata = AdminTopicGrpcMetadata.newBuilder()
+        .setClusterName(clusterName)
+        .setExecutionId(executionId)
+        .setUpstreamOffset(123L)
+        .build();
+    UpdateAdminTopicMetadataGrpcRequest request2 =
+        UpdateAdminTopicMetadataGrpcRequest.newBuilder().setMetadata(metadata).build();
+    exception = expectThrows(VeniceException.class, () -> handler.updateAdminTopicMetadata(request2));
+    assertTrue(
+        exception.getMessage().contains("Offsets must be provided to update cluster-level admin topic metadata"),
+        "Actual message: " + exception.getMessage());
+
+    // both offsets and store name are provided
+    metadata = AdminTopicGrpcMetadata.newBuilder()
+        .setClusterName(clusterName)
+        .setExecutionId(executionId)
+        .setOffset(123L)
+        .setStoreName("test-store")
+        .build();
+    UpdateAdminTopicMetadataGrpcRequest request3 =
+        UpdateAdminTopicMetadataGrpcRequest.newBuilder().setMetadata(metadata).build();
+    exception = expectThrows(VeniceException.class, () -> handler.updateAdminTopicMetadata(request3));
+    assertTrue(
+        exception.getMessage().contains("Updating offsets is not allowed for store-level admin topic metadata"),
+        "Actual message: " + exception.getMessage());
+  }
+}

--- a/services/venice-controller/src/test/java/com/linkedin/venice/controller/server/ClusterAdminOpsRequestHandlerTest.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/controller/server/ClusterAdminOpsRequestHandlerTest.java
@@ -95,7 +95,8 @@ public class ClusterAdminOpsRequestHandlerTest {
     Exception e = expectThrows(VeniceException.class, () -> handler.getAdminCommandExecutionStatus(request));
     assertEquals(
         e.getMessage(),
-        "Could not track execution in this controller. Make sure you send the command to a correct parent controller.");
+        "Could not track execution in this controller for the cluster: test-cluster. Make sure you send the command to a correct parent controller.",
+        "Actual message: " + e.getMessage());
   }
 
   @Test


### PR DESCRIPTION


##  Add ClusterAdminOpsGrpcService with handler and tests

- Added `ClusterAdminOpsGrpcServiceImpl` to support gRPC-based cluster admin operations.
- Implemented methods for admin command status, metadata, and execution ID retrieval.
- Introduced `ClusterAdminOpsRequestHandler` for handling gRPC service requests.
- Added unit tests for the service and request handler to validate functionality.

## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
UT

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.