### PR TITLE
[duckdb] Fixed multi-store bug

### DIFF
--- a/all-modules/build.gradle
+++ b/all-modules/build.gradle
@@ -3,7 +3,7 @@
 dependencies {
   rootProject.subprojects.each { subproject ->
     // Excluding venice-duckdb as it's experimental and causes build issues
-    if (subproject.path != project.path && subproject.subprojects.isEmpty() && subproject.path != ':venice-duckdb') {
+    if (subproject.path != project.path && subproject.subprojects.isEmpty() && subproject.path != ':integrations:venice-duckdb') {
       implementation (project(subproject.path)) {
         exclude group: 'org.duckdb'
         exclude module: 'venice-duckdb'

--- a/build.gradle
+++ b/build.gradle
@@ -82,7 +82,7 @@ ext.libraries = [
     commonsLang: 'commons-lang:commons-lang:2.6',
     conscrypt: 'org.conscrypt:conscrypt-openjdk-uber:2.5.2',
     d2: "com.linkedin.pegasus:d2:${pegasusVersion}",
-    duckdbJdbc: "org.duckdb:duckdb_jdbc:1.2.0-20250117.012118-121", // TODO: Remove SNAPSHOT when the real release is published!
+    duckdbJdbc: "org.duckdb:duckdb_jdbc:1.2.0-20250121.012246-127", // TODO: Remove SNAPSHOT when the real release is published!
     failsafe: 'net.jodah:failsafe:2.4.0',
     fastUtil: 'it.unimi.dsi:fastutil:8.3.0',
     grpcNettyShaded: "io.grpc:grpc-netty-shaded:${grpcVersion}",

--- a/gradle/spotbugs/exclude.xml
+++ b/gradle/spotbugs/exclude.xml
@@ -504,6 +504,8 @@
       <Class name="com.linkedin.venice.duckdb.DuckDBHelloWorldTest"/>
       <Class name="com.linkedin.venice.duckdb.DuckDBAvroToSQLTest"/>
       <Class name="com.linkedin.venice.duckdb.DuckDBDaVinciRecordTransformer"/>
+      <Class name="com.linkedin.venice.duckdb.DuckDBDaVinciRecordTransformerTest"/>
+      <Class name="com.linkedin.venice.endToEnd.DuckDBDaVinciRecordTransformerIntegrationTest"/>
       <Class name="com.linkedin.venice.sql.SQLHelloWorldTest"/>
       <Class name="com.linkedin.venice.sql.SQLUtilsTest"/>
       <Class name="com.linkedin.venice.sql.SQLUtils"/>

--- a/integrations/venice-duckdb/src/integrationTest/java/com/linkedin/venice/endToEnd/DuckDBDaVinciRecordTransformerIntegrationTest.java
+++ b/integrations/venice-duckdb/src/integrationTest/java/com/linkedin/venice/endToEnd/DuckDBDaVinciRecordTransformerIntegrationTest.java
@@ -158,18 +158,18 @@ public class DuckDBDaVinciRecordTransformerIntegrationTest {
 
       clientWithRecordTransformer.subscribeAll().get();
 
-      assertRowCount(duckDBUrl, "subscribeAll() finishes!");
+      assertRowCount(duckDBUrl, storeName, "subscribeAll() finishes!");
 
       clientWithRecordTransformer.unsubscribeAll();
     }
 
-    assertRowCount(duckDBUrl, "DVC gets closed!");
+    assertRowCount(duckDBUrl, storeName, "DVC gets closed!");
   }
 
-  private void assertRowCount(String duckDBUrl, String assertionErrorMsg) throws SQLException {
+  private void assertRowCount(String duckDBUrl, String storeName, String assertionErrorMsg) throws SQLException {
     try (Connection connection = DriverManager.getConnection(duckDBUrl);
         Statement statement = connection.createStatement();
-        ResultSet rs = statement.executeQuery("SELECT count(*) FROM current_version")) {
+        ResultSet rs = statement.executeQuery("SELECT count(*) FROM " + storeName)) {
       assertTrue(rs.next());
       int rowCount = rs.getInt(1);
       assertEquals(

--- a/integrations/venice-duckdb/src/main/java/com/linkedin/venice/duckdb/DuckDBDaVinciRecordTransformer.java
+++ b/integrations/venice-duckdb/src/main/java/com/linkedin/venice/duckdb/DuckDBDaVinciRecordTransformer.java
@@ -29,8 +29,7 @@ public class DuckDBDaVinciRecordTransformer
   private static final Logger LOGGER = LogManager.getLogger(DuckDBDaVinciRecordTransformer.class);
   private static final String duckDBFilePath = "my_database.duckdb";
   private static final String deleteStatementTemplate = "DELETE FROM %s WHERE %s = ?;";
-  private static final String createViewStatementTemplate =
-      "CREATE OR REPLACE VIEW current_version AS SELECT * FROM %s;";
+  private static final String createViewStatementTemplate = "CREATE OR REPLACE VIEW %s AS SELECT * FROM %s;";
   private static final String dropTableStatementTemplate = "DROP TABLE %s;";
   private final String storeNameWithoutVersionInfo;
   private final String versionTableName;
@@ -132,7 +131,8 @@ public class DuckDBDaVinciRecordTransformer
 
       if (isCurrentVersion) {
         // Unable to convert to prepared statement as table and column names can't be parameterized
-        String createViewStatement = String.format(createViewStatementTemplate, versionTableName);
+        String createViewStatement =
+            String.format(createViewStatementTemplate, storeNameWithoutVersionInfo, versionTableName);
         stmt.execute(createViewStatement);
       }
     } catch (SQLException e) {
@@ -146,7 +146,8 @@ public class DuckDBDaVinciRecordTransformer
         Statement stmt = connection.createStatement()) {
       // Swap to current version
       String currentVersionTableName = buildStoreNameWithVersion(currentVersion);
-      String createViewStatement = String.format(createViewStatementTemplate, currentVersionTableName);
+      String createViewStatement =
+          String.format(createViewStatementTemplate, storeNameWithoutVersionInfo, currentVersionTableName);
       stmt.execute(createViewStatement);
 
       if (currentVersion != getStoreVersion()) {

--- a/integrations/venice-duckdb/src/test/java/com/linkedin/venice/duckdb/DuckDBDaVinciRecordTransformerTest.java
+++ b/integrations/venice-duckdb/src/test/java/com/linkedin/venice/duckdb/DuckDBDaVinciRecordTransformerTest.java
@@ -1,6 +1,8 @@
 package com.linkedin.venice.duckdb;
 
-import static com.linkedin.venice.utils.TestWriteUtils.*;
+import static com.linkedin.venice.utils.TestWriteUtils.NAME_RECORD_V1_SCHEMA;
+import static com.linkedin.venice.utils.TestWriteUtils.SIMPLE_USER_WITH_DEFAULT_SCHEMA;
+import static com.linkedin.venice.utils.TestWriteUtils.SINGLE_FIELD_RECORD_SCHEMA;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNull;
@@ -202,6 +204,7 @@ public class DuckDBDaVinciRecordTransformerTest {
         Statement stmt = connection.createStatement()) {
       try (ResultSet rs = stmt.executeQuery("SELECT * FROM " + store1)) {
         assertTrue(rs.next(), "There should be a first row!");
+        assertEquals(rs.getString("key"), "key");
         assertEquals(rs.getString("firstName"), "Duck");
         assertEquals(rs.getString("lastName"), "Goose");
         assertFalse(rs.next(), "There should be only one row!");
@@ -225,6 +228,7 @@ public class DuckDBDaVinciRecordTransformerTest {
         Statement stmt = connection.createStatement()) {
       try (ResultSet rs = stmt.executeQuery("SELECT * FROM " + store1)) {
         assertTrue(rs.next(), "There should be a first row!");
+        assertEquals(rs.getString("key"), "key");
         assertEquals(rs.getString("firstName"), "Duck");
         assertEquals(rs.getString("lastName"), "Goose");
         assertFalse(rs.next(), "There should be only one row!");
@@ -232,8 +236,25 @@ public class DuckDBDaVinciRecordTransformerTest {
 
       try (ResultSet rs = stmt.executeQuery("SELECT * FROM " + store2)) {
         assertTrue(rs.next(), "There should be a first row!");
+        assertEquals(rs.getString("key"), "key");
+        assertEquals(rs.getString("value"), "value");
         assertEquals(rs.getString("firstName"), "Duck2");
         assertEquals(rs.getString("lastName"), "Goose2");
+        assertFalse(rs.next(), "There should be only one row!");
+      }
+
+      try (ResultSet rs = stmt.executeQuery(
+          "SELECT s1.key AS s1key, s1.firstName AS s1FirstName, s1.lastName AS s1LastName, "
+              + "s2.key AS s2key, s2.value AS s2value, s2.firstName AS s2FirstName, s2.lastName AS s2LastName "
+              + "FROM " + store1 + " s1 JOIN " + store2 + " s2 ON s1.key = s2.key")) {
+        assertTrue(rs.next(), "There should be a first row!");
+        assertEquals(rs.getString("s1key"), "key");
+        assertEquals(rs.getString("s1FirstName"), "Duck");
+        assertEquals(rs.getString("s1LastName"), "Goose");
+        assertEquals(rs.getString("s2key"), "key");
+        assertEquals(rs.getString("s2value"), "value");
+        assertEquals(rs.getString("s2FirstName"), "Duck2");
+        assertEquals(rs.getString("s2LastName"), "Goose2");
         assertFalse(rs.next(), "There should be only one row!");
       }
     }


### PR DESCRIPTION
The view created by DuckDBDVRT was called current_version, so it could not work with multiple stores. Changed it so that the view inherits the store name instead.

Miscellaneous build changes:

- Fixed the duckdb exclusion rule in all-modules.
- Bumped up the duckdb snapshot dep to the current latest one.

## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
New unit test.

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.