### PR TITLE
[vpj] Replace org.apache.kafka.common.TopicPartition with PubSubTopicPartition in VPJ

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
@@ -159,7 +159,6 @@ import java.util.function.Supplier;
 import org.apache.avro.AvroRuntimeException;
 import org.apache.avro.Schema;
 import org.apache.helix.manager.zk.ZKHelixAdmin;
-import org.apache.kafka.clients.CommonClientConfigs;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -4173,7 +4172,7 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
   }
 
   /**
-   * Override the {@link CommonClientConfigs#BOOTSTRAP_SERVERS_CONFIG} config with a remote Kafka bootstrap url.
+   * Override the {@link com.linkedin.venice.ConfigKeys#KAFKA_BOOTSTRAP_SERVERS} config with a remote Kafka bootstrap url.
    */
   protected Properties createKafkaConsumerProperties(
       Properties localConsumerProps,

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/input/kafka/KafkaInputDictTrainer.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/input/kafka/KafkaInputDictTrainer.java
@@ -182,7 +182,7 @@ public class KafkaInputDictTrainer {
     // Get one split per partition
     KafkaInputSplit[] splits = (KafkaInputSplit[]) kafkaInputFormat.getSplitsByRecordsPerSplit(jobConf, Long.MAX_VALUE);
     // The following sort is trying to get a deterministic dict with the same input.
-    Arrays.sort(splits, Comparator.comparingInt(o -> o.getTopicPartition().partition()));
+    Arrays.sort(splits, Comparator.comparingInt(o -> o.getTopicPartition().getPartitionNumber()));
     // Try to gather some records from each partition
     PushJobZstdConfig zstdConfig = new PushJobZstdConfig(props, splits.length);
     ZstdDictTrainer trainer = trainerSupplier.orElseGet(zstdConfig::getZstdDictTrainer);

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/input/kafka/KafkaInputFormat.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/input/kafka/KafkaInputFormat.java
@@ -105,7 +105,7 @@ public class KafkaInputFormat implements InputFormat<KafkaInputMapperKey, KafkaI
       long splitStart = 0;
       while (splitStart < end) {
         long splitEnd = Math.min(splitStart + maxRecordsPerSplit, end);
-        splits.add(new KafkaInputSplit(topicPartition, splitStart, splitEnd));
+        splits.add(new KafkaInputSplit(pubSubTopicRepository, topicPartition, splitStart, splitEnd));
         splitStart = splitEnd;
       }
     });

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/input/kafka/KafkaInputFormat.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/input/kafka/KafkaInputFormat.java
@@ -105,7 +105,7 @@ public class KafkaInputFormat implements InputFormat<KafkaInputMapperKey, KafkaI
       long splitStart = 0;
       while (splitStart < end) {
         long splitEnd = Math.min(splitStart + maxRecordsPerSplit, end);
-        splits.add(new KafkaInputSplit(pubSubTopicRepository, topicPartition, splitStart, splitEnd));
+        splits.add(new KafkaInputSplit(topicPartition, splitStart, splitEnd));
         splitStart = splitEnd;
       }
     });

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/input/kafka/KafkaInputSplit.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/input/kafka/KafkaInputSplit.java
@@ -20,7 +20,7 @@ public class KafkaInputSplit implements InputSplit {
   private long startingOffset;
   private long endingOffset;
   private PubSubTopicPartition topicPartition;
-  private PubSubTopicRepository topicRepository;
+  private final PubSubTopicRepository topicRepository = new PubSubTopicRepository();
 
   /**
    * Nullary Constructor for creating the instance inside the Mapper instance.
@@ -29,19 +29,14 @@ public class KafkaInputSplit implements InputSplit {
   }
 
   /**
-   * Constructs an input split for the provided {@param topic} and {@param partition} restricting data to be between
-   * the {@param startingOffset} and {@param endingOffset}
+   * Constructs an input split for the provided {@param topic} and {@param partition} restricting data to be between the
+   * {@param startingOffset} and {@param endingOffset}
    *
-   * @param topicPartition  the topic-partition for the split
+   * @param topicPartition the topic-partition for the split
    * @param startingOffset the start of the split
    * @param endingOffset   the end of the split
    */
-  public KafkaInputSplit(
-      PubSubTopicRepository topicRepository,
-      PubSubTopicPartition topicPartition,
-      long startingOffset,
-      long endingOffset) {
-    this.topicRepository = topicRepository;
+  public KafkaInputSplit(PubSubTopicPartition topicPartition, long startingOffset, long endingOffset) {
     this.startingOffset = startingOffset;
     this.endingOffset = endingOffset;
     this.topicPartition = topicPartition;

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/input/kafka/KafkaInputSplit.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/input/kafka/KafkaInputSplit.java
@@ -20,12 +20,13 @@ public class KafkaInputSplit implements InputSplit {
   private long startingOffset;
   private long endingOffset;
   private PubSubTopicPartition topicPartition;
-  private PubSubTopicRepository topicRepository;
+  private final PubSubTopicRepository topicRepository;
 
   /**
    * Nullary Constructor for creating the instance inside the Mapper instance.
    */
   public KafkaInputSplit() {
+    topicRepository = new PubSubTopicRepository();
   }
 
   /**

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/input/kafka/KafkaInputSplit.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/input/kafka/KafkaInputSplit.java
@@ -1,23 +1,26 @@
 package com.linkedin.venice.hadoop.input.kafka;
 
+import com.linkedin.venice.pubsub.PubSubTopicPartitionImpl;
+import com.linkedin.venice.pubsub.PubSubTopicRepository;
+import com.linkedin.venice.pubsub.api.PubSubTopicPartition;
 import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
 import org.apache.hadoop.mapred.InputSplit;
-import org.apache.kafka.common.TopicPartition;
 
 
 /**
  * We borrowed some idea from the open-sourced attic-crunch lib:
  * https://github.com/apache/attic-crunch/blob/master/crunch-kafka/src/main/java/org/apache/crunch/kafka/record/KafkaInputSplit.java
  *
- * InputSplit that represent retrieving data from a single {@link TopicPartition} between the specified start
+ * InputSplit that represent retrieving data from a single {@link PubSubTopicPartition} between the specified start
  * and end offsets.
  */
 public class KafkaInputSplit implements InputSplit {
   private long startingOffset;
   private long endingOffset;
-  private TopicPartition topicPartition;
+  private PubSubTopicPartition topicPartition;
+  private PubSubTopicRepository topicRepository;
 
   /**
    * Nullary Constructor for creating the instance inside the Mapper instance.
@@ -29,15 +32,19 @@ public class KafkaInputSplit implements InputSplit {
    * Constructs an input split for the provided {@param topic} and {@param partition} restricting data to be between
    * the {@param startingOffset} and {@param endingOffset}
    *
-   * @param topic          the topic for the split
-   * @param partition      the partition for the topic
+   * @param topicPartition  the topic-partition for the split
    * @param startingOffset the start of the split
    * @param endingOffset   the end of the split
    */
-  public KafkaInputSplit(String topic, int partition, long startingOffset, long endingOffset) {
+  public KafkaInputSplit(
+      PubSubTopicRepository topicRepository,
+      PubSubTopicPartition topicPartition,
+      long startingOffset,
+      long endingOffset) {
+    this.topicRepository = topicRepository;
     this.startingOffset = startingOffset;
     this.endingOffset = endingOffset;
-    topicPartition = new TopicPartition(topic, partition);
+    this.topicPartition = topicPartition;
   }
 
   @Override
@@ -57,7 +64,7 @@ public class KafkaInputSplit implements InputSplit {
    *
    * @return the topic and partition for the split
    */
-  public TopicPartition getTopicPartition() {
+  public PubSubTopicPartition getTopicPartition() {
     return topicPartition;
   }
 
@@ -81,8 +88,8 @@ public class KafkaInputSplit implements InputSplit {
 
   @Override
   public void write(DataOutput dataOutput) throws IOException {
-    dataOutput.writeUTF(topicPartition.topic());
-    dataOutput.writeInt(topicPartition.partition());
+    dataOutput.writeUTF(topicPartition.getTopicName());
+    dataOutput.writeInt(topicPartition.getPartitionNumber());
     dataOutput.writeLong(startingOffset);
     dataOutput.writeLong(endingOffset);
   }
@@ -94,7 +101,7 @@ public class KafkaInputSplit implements InputSplit {
     startingOffset = dataInput.readLong();
     endingOffset = dataInput.readLong();
 
-    topicPartition = new TopicPartition(topic, partition);
+    topicPartition = new PubSubTopicPartitionImpl(topicRepository.getTopic(topic), partition);
   }
 
   @Override

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/input/kafka/KafkaInputSplit.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/input/kafka/KafkaInputSplit.java
@@ -20,7 +20,7 @@ public class KafkaInputSplit implements InputSplit {
   private long startingOffset;
   private long endingOffset;
   private PubSubTopicPartition topicPartition;
-  private final PubSubTopicRepository topicRepository = new PubSubTopicRepository();
+  private PubSubTopicRepository topicRepository;
 
   /**
    * Nullary Constructor for creating the instance inside the Mapper instance.
@@ -29,14 +29,19 @@ public class KafkaInputSplit implements InputSplit {
   }
 
   /**
-   * Constructs an input split for the provided {@param topic} and {@param partition} restricting data to be between the
-   * {@param startingOffset} and {@param endingOffset}
+   * Constructs an input split for the provided {@param topic} and {@param partition} restricting data to be between
+   * the {@param startingOffset} and {@param endingOffset}
    *
-   * @param topicPartition the topic-partition for the split
+   * @param topicPartition  the topic-partition for the split
    * @param startingOffset the start of the split
    * @param endingOffset   the end of the split
    */
-  public KafkaInputSplit(PubSubTopicPartition topicPartition, long startingOffset, long endingOffset) {
+  public KafkaInputSplit(
+      PubSubTopicRepository topicRepository,
+      PubSubTopicPartition topicPartition,
+      long startingOffset,
+      long endingOffset) {
+    this.topicRepository = topicRepository;
     this.startingOffset = startingOffset;
     this.endingOffset = endingOffset;
     this.topicPartition = topicPartition;

--- a/clients/venice-push-job/src/test/java/com/linkedin/venice/hadoop/input/kafka/KafkaInputRecordReaderTest.java
+++ b/clients/venice-push-job/src/test/java/com/linkedin/venice/hadoop/input/kafka/KafkaInputRecordReaderTest.java
@@ -81,7 +81,7 @@ public class KafkaInputRecordReaderTest {
     recordsMap.put(pubSubTopicPartition, consumerRecordList);
     when(consumer.poll(anyLong())).thenReturn(recordsMap, new HashMap<>());
     PubSubTopicPartition topicPartition = new PubSubTopicPartitionImpl(pubSubTopicRepository.getTopic(topic), 0);
-    KafkaInputSplit split = new KafkaInputSplit(pubSubTopicRepository, topicPartition, 0, 102);
+    KafkaInputSplit split = new KafkaInputSplit(topicPartition, 0, 102);
     DataWriterTaskTracker taskTracker = new ReporterBackedMapReduceDataWriterTaskTracker(Reporter.NULL);
     try (KafkaInputRecordReader reader =
         new KafkaInputRecordReader(split, conf, taskTracker, consumer, pubSubTopicRepository)) {

--- a/clients/venice-push-job/src/test/java/com/linkedin/venice/hadoop/input/kafka/KafkaInputRecordReaderTest.java
+++ b/clients/venice-push-job/src/test/java/com/linkedin/venice/hadoop/input/kafka/KafkaInputRecordReaderTest.java
@@ -80,8 +80,8 @@ public class KafkaInputRecordReaderTest {
     Map<PubSubTopicPartition, List<PubSubMessage<KafkaKey, KafkaMessageEnvelope, Long>>> recordsMap = new HashMap<>();
     recordsMap.put(pubSubTopicPartition, consumerRecordList);
     when(consumer.poll(anyLong())).thenReturn(recordsMap, new HashMap<>());
-
-    KafkaInputSplit split = new KafkaInputSplit(topic, 0, 0, 102);
+    PubSubTopicPartition topicPartition = new PubSubTopicPartitionImpl(pubSubTopicRepository.getTopic(topic), 0);
+    KafkaInputSplit split = new KafkaInputSplit(pubSubTopicRepository, topicPartition, 0, 102);
     DataWriterTaskTracker taskTracker = new ReporterBackedMapReduceDataWriterTaskTracker(Reporter.NULL);
     try (KafkaInputRecordReader reader =
         new KafkaInputRecordReader(split, conf, taskTracker, consumer, pubSubTopicRepository)) {

--- a/clients/venice-push-job/src/test/java/com/linkedin/venice/hadoop/input/kafka/KafkaInputRecordReaderTest.java
+++ b/clients/venice-push-job/src/test/java/com/linkedin/venice/hadoop/input/kafka/KafkaInputRecordReaderTest.java
@@ -81,7 +81,7 @@ public class KafkaInputRecordReaderTest {
     recordsMap.put(pubSubTopicPartition, consumerRecordList);
     when(consumer.poll(anyLong())).thenReturn(recordsMap, new HashMap<>());
     PubSubTopicPartition topicPartition = new PubSubTopicPartitionImpl(pubSubTopicRepository.getTopic(topic), 0);
-    KafkaInputSplit split = new KafkaInputSplit(topicPartition, 0, 102);
+    KafkaInputSplit split = new KafkaInputSplit(pubSubTopicRepository, topicPartition, 0, 102);
     DataWriterTaskTracker taskTracker = new ReporterBackedMapReduceDataWriterTaskTracker(Reporter.NULL);
     try (KafkaInputRecordReader reader =
         new KafkaInputRecordReader(split, conf, taskTracker, consumer, pubSubTopicRepository)) {

--- a/clients/venice-push-job/src/test/java/com/linkedin/venice/hadoop/input/kafka/TestKafkaInputDictTrainer.java
+++ b/clients/venice-push-job/src/test/java/com/linkedin/venice/hadoop/input/kafka/TestKafkaInputDictTrainer.java
@@ -59,7 +59,7 @@ public class TestKafkaInputDictTrainer {
     KafkaInputFormat mockFormat = mock(KafkaInputFormat.class);
     PubSubTopicPartition topicPartition =
         new PubSubTopicPartitionImpl(PUB_SUB_TOPIC_REPOSITORY.getTopic("test_topic"), 0);
-    InputSplit[] splits = new KafkaInputSplit[] { new KafkaInputSplit(PUB_SUB_TOPIC_REPOSITORY, topicPartition, 0, 0) };
+    InputSplit[] splits = new KafkaInputSplit[] { new KafkaInputSplit(topicPartition, 0, 0) };
     doReturn(splits).when(mockFormat).getSplitsByRecordsPerSplit(any(), anyLong());
     RecordReader<KafkaInputMapperKey, KafkaInputMapperValue> mockRecordReader = mock(RecordReader.class);
     doReturn(false).when(mockRecordReader).next(any(), any());
@@ -152,8 +152,8 @@ public class TestKafkaInputDictTrainer {
     KafkaInputFormat mockFormat = mock(KafkaInputFormat.class);
     PubSubTopicPartition topicPartition =
         new PubSubTopicPartitionImpl(PUB_SUB_TOPIC_REPOSITORY.getTopic("test_topic"), 0);
-    InputSplit[] splits = new KafkaInputSplit[] { new KafkaInputSplit(PUB_SUB_TOPIC_REPOSITORY, topicPartition, 0, 2),
-        new KafkaInputSplit(PUB_SUB_TOPIC_REPOSITORY, topicPartition, 0, 2) };
+    InputSplit[] splits =
+        new KafkaInputSplit[] { new KafkaInputSplit(topicPartition, 0, 2), new KafkaInputSplit(topicPartition, 0, 2) };
     doReturn(splits).when(mockFormat).getSplitsByRecordsPerSplit(any(), anyLong());
 
     // Return 3 records
@@ -205,8 +205,8 @@ public class TestKafkaInputDictTrainer {
     KafkaInputFormat mockFormat = mock(KafkaInputFormat.class);
     PubSubTopicPartition topicPartition =
         new PubSubTopicPartitionImpl(PUB_SUB_TOPIC_REPOSITORY.getTopic("test_topic"), 0);
-    InputSplit[] splits = new KafkaInputSplit[] { new KafkaInputSplit(PUB_SUB_TOPIC_REPOSITORY, topicPartition, 0, 2),
-        new KafkaInputSplit(PUB_SUB_TOPIC_REPOSITORY, topicPartition, 0, 2) };
+    InputSplit[] splits =
+        new KafkaInputSplit[] { new KafkaInputSplit(topicPartition, 0, 2), new KafkaInputSplit(topicPartition, 0, 2) };
     doReturn(splits).when(mockFormat).getSplitsByRecordsPerSplit(any(), anyLong());
 
     // Return 3 records
@@ -257,8 +257,8 @@ public class TestKafkaInputDictTrainer {
     KafkaInputFormat mockFormat = mock(KafkaInputFormat.class);
     PubSubTopicPartition topicPartition =
         new PubSubTopicPartitionImpl(PUB_SUB_TOPIC_REPOSITORY.getTopic("test_topic"), 0);
-    InputSplit[] splits = new KafkaInputSplit[] { new KafkaInputSplit(PUB_SUB_TOPIC_REPOSITORY, topicPartition, 0, 2),
-        new KafkaInputSplit(PUB_SUB_TOPIC_REPOSITORY, topicPartition, 0, 2) };
+    InputSplit[] splits =
+        new KafkaInputSplit[] { new KafkaInputSplit(topicPartition, 0, 2), new KafkaInputSplit(topicPartition, 0, 2) };
     doReturn(splits).when(mockFormat).getSplitsByRecordsPerSplit(any(), anyLong());
 
     // Return 3 records

--- a/clients/venice-push-job/src/test/java/com/linkedin/venice/hadoop/input/kafka/TestKafkaInputDictTrainer.java
+++ b/clients/venice-push-job/src/test/java/com/linkedin/venice/hadoop/input/kafka/TestKafkaInputDictTrainer.java
@@ -59,7 +59,7 @@ public class TestKafkaInputDictTrainer {
     KafkaInputFormat mockFormat = mock(KafkaInputFormat.class);
     PubSubTopicPartition topicPartition =
         new PubSubTopicPartitionImpl(PUB_SUB_TOPIC_REPOSITORY.getTopic("test_topic"), 0);
-    InputSplit[] splits = new KafkaInputSplit[] { new KafkaInputSplit(topicPartition, 0, 0) };
+    InputSplit[] splits = new KafkaInputSplit[] { new KafkaInputSplit(PUB_SUB_TOPIC_REPOSITORY, topicPartition, 0, 0) };
     doReturn(splits).when(mockFormat).getSplitsByRecordsPerSplit(any(), anyLong());
     RecordReader<KafkaInputMapperKey, KafkaInputMapperValue> mockRecordReader = mock(RecordReader.class);
     doReturn(false).when(mockRecordReader).next(any(), any());
@@ -152,8 +152,8 @@ public class TestKafkaInputDictTrainer {
     KafkaInputFormat mockFormat = mock(KafkaInputFormat.class);
     PubSubTopicPartition topicPartition =
         new PubSubTopicPartitionImpl(PUB_SUB_TOPIC_REPOSITORY.getTopic("test_topic"), 0);
-    InputSplit[] splits =
-        new KafkaInputSplit[] { new KafkaInputSplit(topicPartition, 0, 2), new KafkaInputSplit(topicPartition, 0, 2) };
+    InputSplit[] splits = new KafkaInputSplit[] { new KafkaInputSplit(PUB_SUB_TOPIC_REPOSITORY, topicPartition, 0, 2),
+        new KafkaInputSplit(PUB_SUB_TOPIC_REPOSITORY, topicPartition, 0, 2) };
     doReturn(splits).when(mockFormat).getSplitsByRecordsPerSplit(any(), anyLong());
 
     // Return 3 records
@@ -205,8 +205,8 @@ public class TestKafkaInputDictTrainer {
     KafkaInputFormat mockFormat = mock(KafkaInputFormat.class);
     PubSubTopicPartition topicPartition =
         new PubSubTopicPartitionImpl(PUB_SUB_TOPIC_REPOSITORY.getTopic("test_topic"), 0);
-    InputSplit[] splits =
-        new KafkaInputSplit[] { new KafkaInputSplit(topicPartition, 0, 2), new KafkaInputSplit(topicPartition, 0, 2) };
+    InputSplit[] splits = new KafkaInputSplit[] { new KafkaInputSplit(PUB_SUB_TOPIC_REPOSITORY, topicPartition, 0, 2),
+        new KafkaInputSplit(PUB_SUB_TOPIC_REPOSITORY, topicPartition, 0, 2) };
     doReturn(splits).when(mockFormat).getSplitsByRecordsPerSplit(any(), anyLong());
 
     // Return 3 records
@@ -257,8 +257,8 @@ public class TestKafkaInputDictTrainer {
     KafkaInputFormat mockFormat = mock(KafkaInputFormat.class);
     PubSubTopicPartition topicPartition =
         new PubSubTopicPartitionImpl(PUB_SUB_TOPIC_REPOSITORY.getTopic("test_topic"), 0);
-    InputSplit[] splits =
-        new KafkaInputSplit[] { new KafkaInputSplit(topicPartition, 0, 2), new KafkaInputSplit(topicPartition, 0, 2) };
+    InputSplit[] splits = new KafkaInputSplit[] { new KafkaInputSplit(PUB_SUB_TOPIC_REPOSITORY, topicPartition, 0, 2),
+        new KafkaInputSplit(PUB_SUB_TOPIC_REPOSITORY, topicPartition, 0, 2) };
     doReturn(splits).when(mockFormat).getSplitsByRecordsPerSplit(any(), anyLong());
 
     // Return 3 records

--- a/clients/venice-push-job/src/test/java/com/linkedin/venice/hadoop/input/kafka/TestKafkaInputDictTrainer.java
+++ b/clients/venice-push-job/src/test/java/com/linkedin/venice/hadoop/input/kafka/TestKafkaInputDictTrainer.java
@@ -16,7 +16,10 @@ import com.linkedin.venice.compression.VeniceCompressor;
 import com.linkedin.venice.exceptions.VeniceException;
 import com.linkedin.venice.hadoop.input.kafka.avro.KafkaInputMapperKey;
 import com.linkedin.venice.hadoop.input.kafka.avro.KafkaInputMapperValue;
+import com.linkedin.venice.pubsub.PubSubTopicPartitionImpl;
+import com.linkedin.venice.pubsub.PubSubTopicRepository;
 import com.linkedin.venice.pubsub.api.PubSubConsumerAdapter;
+import com.linkedin.venice.pubsub.api.PubSubTopicPartition;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
@@ -30,6 +33,8 @@ import org.testng.annotations.Test;
 
 
 public class TestKafkaInputDictTrainer {
+  private final static PubSubTopicRepository PUB_SUB_TOPIC_REPOSITORY = new PubSubTopicRepository();
+
   private KafkaInputDictTrainer.CompressorBuilder getCompressorBuilder(VeniceCompressor mockCompressor) {
     return (compressorFactory, compressionStrategy, kafkaUrl, topic, props) -> mockCompressor;
   }
@@ -52,7 +57,9 @@ public class TestKafkaInputDictTrainer {
   @Test(expectedExceptions = VeniceException.class, expectedExceptionsMessageRegExp = "No record.*")
   public void testEmptyTopic() throws IOException {
     KafkaInputFormat mockFormat = mock(KafkaInputFormat.class);
-    InputSplit[] splits = new KafkaInputSplit[] { new KafkaInputSplit("test_topic", 0, 0, 0) };
+    PubSubTopicPartition topicPartition =
+        new PubSubTopicPartitionImpl(PUB_SUB_TOPIC_REPOSITORY.getTopic("test_topic"), 0);
+    InputSplit[] splits = new KafkaInputSplit[] { new KafkaInputSplit(PUB_SUB_TOPIC_REPOSITORY, topicPartition, 0, 0) };
     doReturn(splits).when(mockFormat).getSplitsByRecordsPerSplit(any(), anyLong());
     RecordReader<KafkaInputMapperKey, KafkaInputMapperValue> mockRecordReader = mock(RecordReader.class);
     doReturn(false).when(mockRecordReader).next(any(), any());
@@ -143,8 +150,10 @@ public class TestKafkaInputDictTrainer {
   @Test
   public void testSamplingFromMultiplePartitions() throws IOException {
     KafkaInputFormat mockFormat = mock(KafkaInputFormat.class);
-    InputSplit[] splits = new KafkaInputSplit[] { new KafkaInputSplit("test_topic", 0, 0, 2),
-        new KafkaInputSplit("test_topic", 0, 0, 2) };
+    PubSubTopicPartition topicPartition =
+        new PubSubTopicPartitionImpl(PUB_SUB_TOPIC_REPOSITORY.getTopic("test_topic"), 0);
+    InputSplit[] splits = new KafkaInputSplit[] { new KafkaInputSplit(PUB_SUB_TOPIC_REPOSITORY, topicPartition, 0, 2),
+        new KafkaInputSplit(PUB_SUB_TOPIC_REPOSITORY, topicPartition, 0, 2) };
     doReturn(splits).when(mockFormat).getSplitsByRecordsPerSplit(any(), anyLong());
 
     // Return 3 records
@@ -194,8 +203,10 @@ public class TestKafkaInputDictTrainer {
   @Test
   public void testSamplingFromMultiplePartitionsWithSourceVersionCompressionEnabled() throws IOException {
     KafkaInputFormat mockFormat = mock(KafkaInputFormat.class);
-    InputSplit[] splits = new KafkaInputSplit[] { new KafkaInputSplit("test_topic", 0, 0, 2),
-        new KafkaInputSplit("test_topic", 0, 0, 2) };
+    PubSubTopicPartition topicPartition =
+        new PubSubTopicPartitionImpl(PUB_SUB_TOPIC_REPOSITORY.getTopic("test_topic"), 0);
+    InputSplit[] splits = new KafkaInputSplit[] { new KafkaInputSplit(PUB_SUB_TOPIC_REPOSITORY, topicPartition, 0, 2),
+        new KafkaInputSplit(PUB_SUB_TOPIC_REPOSITORY, topicPartition, 0, 2) };
     doReturn(splits).when(mockFormat).getSplitsByRecordsPerSplit(any(), anyLong());
 
     // Return 3 records
@@ -244,8 +255,10 @@ public class TestKafkaInputDictTrainer {
   @Test
   public void testSamplingFromMultiplePartitionsWithSourceVersionCompressionEnabledWithChunking() throws IOException {
     KafkaInputFormat mockFormat = mock(KafkaInputFormat.class);
-    InputSplit[] splits = new KafkaInputSplit[] { new KafkaInputSplit("test_topic", 0, 0, 2),
-        new KafkaInputSplit("test_topic", 0, 0, 2) };
+    PubSubTopicPartition topicPartition =
+        new PubSubTopicPartitionImpl(PUB_SUB_TOPIC_REPOSITORY.getTopic("test_topic"), 0);
+    InputSplit[] splits = new KafkaInputSplit[] { new KafkaInputSplit(PUB_SUB_TOPIC_REPOSITORY, topicPartition, 0, 2),
+        new KafkaInputSplit(PUB_SUB_TOPIC_REPOSITORY, topicPartition, 0, 2) };
     doReturn(splits).when(mockFormat).getSplitsByRecordsPerSplit(any(), anyLong());
 
     // Return 3 records

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/hadoop/input/kafka/TestKafkaInputRecordReader.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/hadoop/input/kafka/TestKafkaInputRecordReader.java
@@ -93,7 +93,7 @@ public class TestKafkaInputRecordReader {
     conf.set(KAFKA_INPUT_TOPIC, topic);
 
     try (KafkaInputRecordReader reader =
-        new KafkaInputRecordReader(new KafkaInputSplit(pubSubTopicRepository, topicPartition, 0, 102), conf, null)) {
+        new KafkaInputRecordReader(new KafkaInputSplit(topicPartition, 0, 102), conf, null)) {
       for (int i = 0; i < 100; ++i) {
         KafkaInputMapperKey key = new KafkaInputMapperKey();
         KafkaInputMapperValue value = new KafkaInputMapperValue();
@@ -116,7 +116,7 @@ public class TestKafkaInputRecordReader {
     conf.set(KAFKA_INPUT_TOPIC, topic);
     conf.set(KAFKA_SOURCE_KEY_SCHEMA_STRING_PROP, ChunkedKeySuffix.SCHEMA$.toString());
     try (KafkaInputRecordReader reader =
-        new KafkaInputRecordReader(new KafkaInputSplit(pubSubTopicRepository, topicPartition, 0, 102), conf, null)) {
+        new KafkaInputRecordReader(new KafkaInputSplit(topicPartition, 0, 102), conf, null)) {
       for (int i = 0; i < 100; ++i) {
         KafkaInputMapperKey key = new KafkaInputMapperKey();
         KafkaInputMapperValue value = new KafkaInputMapperValue();
@@ -145,7 +145,7 @@ public class TestKafkaInputRecordReader {
     conf.set(KAFKA_INPUT_TOPIC, topic);
     conf.set(KAFKA_SOURCE_KEY_SCHEMA_STRING_PROP, ChunkedKeySuffix.SCHEMA$.toString());
     try (KafkaInputRecordReader reader =
-        new KafkaInputRecordReader(new KafkaInputSplit(pubSubTopicRepository, topicPartition, 0, 102), conf, null)) {
+        new KafkaInputRecordReader(new KafkaInputSplit(topicPartition, 0, 102), conf, null)) {
       for (int i = 0; i < 100; ++i) {
         KafkaInputMapperKey key = new KafkaInputMapperKey();
         KafkaInputMapperValue value = new KafkaInputMapperValue();

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/hadoop/input/kafka/TestKafkaInputRecordReader.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/hadoop/input/kafka/TestKafkaInputRecordReader.java
@@ -93,7 +93,7 @@ public class TestKafkaInputRecordReader {
     conf.set(KAFKA_INPUT_TOPIC, topic);
 
     try (KafkaInputRecordReader reader =
-        new KafkaInputRecordReader(new KafkaInputSplit(topicPartition, 0, 102), conf, null)) {
+        new KafkaInputRecordReader(new KafkaInputSplit(pubSubTopicRepository, topicPartition, 0, 102), conf, null)) {
       for (int i = 0; i < 100; ++i) {
         KafkaInputMapperKey key = new KafkaInputMapperKey();
         KafkaInputMapperValue value = new KafkaInputMapperValue();
@@ -116,7 +116,7 @@ public class TestKafkaInputRecordReader {
     conf.set(KAFKA_INPUT_TOPIC, topic);
     conf.set(KAFKA_SOURCE_KEY_SCHEMA_STRING_PROP, ChunkedKeySuffix.SCHEMA$.toString());
     try (KafkaInputRecordReader reader =
-        new KafkaInputRecordReader(new KafkaInputSplit(topicPartition, 0, 102), conf, null)) {
+        new KafkaInputRecordReader(new KafkaInputSplit(pubSubTopicRepository, topicPartition, 0, 102), conf, null)) {
       for (int i = 0; i < 100; ++i) {
         KafkaInputMapperKey key = new KafkaInputMapperKey();
         KafkaInputMapperValue value = new KafkaInputMapperValue();
@@ -145,7 +145,7 @@ public class TestKafkaInputRecordReader {
     conf.set(KAFKA_INPUT_TOPIC, topic);
     conf.set(KAFKA_SOURCE_KEY_SCHEMA_STRING_PROP, ChunkedKeySuffix.SCHEMA$.toString());
     try (KafkaInputRecordReader reader =
-        new KafkaInputRecordReader(new KafkaInputSplit(topicPartition, 0, 102), conf, null)) {
+        new KafkaInputRecordReader(new KafkaInputSplit(pubSubTopicRepository, topicPartition, 0, 102), conf, null)) {
       for (int i = 0; i < 100; ++i) {
         KafkaInputMapperKey key = new KafkaInputMapperKey();
         KafkaInputMapperValue value = new KafkaInputMapperValue();

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/hadoop/input/kafka/TestKafkaInputRecordReader.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/hadoop/input/kafka/TestKafkaInputRecordReader.java
@@ -10,7 +10,9 @@ import com.linkedin.venice.hadoop.input.kafka.avro.KafkaInputMapperValue;
 import com.linkedin.venice.hadoop.input.kafka.avro.MapperValueType;
 import com.linkedin.venice.integration.utils.PubSubBrokerWrapper;
 import com.linkedin.venice.integration.utils.ServiceFactory;
+import com.linkedin.venice.pubsub.PubSubTopicPartitionImpl;
 import com.linkedin.venice.pubsub.PubSubTopicRepository;
+import com.linkedin.venice.pubsub.api.PubSubTopicPartition;
 import com.linkedin.venice.pubsub.manager.TopicManager;
 import com.linkedin.venice.storage.protocol.ChunkedKeySuffix;
 import com.linkedin.venice.utils.ByteUtils;
@@ -35,7 +37,7 @@ public class TestKafkaInputRecordReader {
 
   private PubSubBrokerWrapper pubSubBrokerWrapper;
   private TopicManager manager;
-  private PubSubTopicRepository pubSubTopicRepository = new PubSubTopicRepository();
+  private final PubSubTopicRepository pubSubTopicRepository = new PubSubTopicRepository();
 
   @BeforeClass
   public void setUp() {
@@ -87,10 +89,11 @@ public class TestKafkaInputRecordReader {
     conf.set(KAFKA_INPUT_BROKER_URL, pubSubBrokerWrapper.getAddress());
     conf.set(KAFKA_SOURCE_KEY_SCHEMA_STRING_PROP, ChunkedKeySuffix.SCHEMA$.toString());
     String topic = getTopic(100, new Pair<>(-1, -1), new Pair<>(-1, -1));
+    PubSubTopicPartition topicPartition = new PubSubTopicPartitionImpl(pubSubTopicRepository.getTopic(topic), 0);
     conf.set(KAFKA_INPUT_TOPIC, topic);
 
-    try (
-        KafkaInputRecordReader reader = new KafkaInputRecordReader(new KafkaInputSplit(topic, 0, 0, 102), conf, null)) {
+    try (KafkaInputRecordReader reader =
+        new KafkaInputRecordReader(new KafkaInputSplit(pubSubTopicRepository, topicPartition, 0, 102), conf, null)) {
       for (int i = 0; i < 100; ++i) {
         KafkaInputMapperKey key = new KafkaInputMapperKey();
         KafkaInputMapperValue value = new KafkaInputMapperValue();
@@ -109,10 +112,11 @@ public class TestKafkaInputRecordReader {
     JobConf conf = new JobConf();
     conf.set(KAFKA_INPUT_BROKER_URL, pubSubBrokerWrapper.getAddress());
     String topic = getTopic(100, new Pair<>(-1, -1), new Pair<>(0, 10));
+    PubSubTopicPartition topicPartition = new PubSubTopicPartitionImpl(pubSubTopicRepository.getTopic(topic), 0);
     conf.set(KAFKA_INPUT_TOPIC, topic);
     conf.set(KAFKA_SOURCE_KEY_SCHEMA_STRING_PROP, ChunkedKeySuffix.SCHEMA$.toString());
-    try (
-        KafkaInputRecordReader reader = new KafkaInputRecordReader(new KafkaInputSplit(topic, 0, 0, 102), conf, null)) {
+    try (KafkaInputRecordReader reader =
+        new KafkaInputRecordReader(new KafkaInputSplit(pubSubTopicRepository, topicPartition, 0, 102), conf, null)) {
       for (int i = 0; i < 100; ++i) {
         KafkaInputMapperKey key = new KafkaInputMapperKey();
         KafkaInputMapperValue value = new KafkaInputMapperValue();
@@ -137,10 +141,11 @@ public class TestKafkaInputRecordReader {
     JobConf conf = new JobConf();
     conf.set(KAFKA_INPUT_BROKER_URL, pubSubBrokerWrapper.getAddress());
     String topic = getTopic(100, new Pair<>(21, 30), new Pair<>(11, 20));
+    PubSubTopicPartition topicPartition = new PubSubTopicPartitionImpl(pubSubTopicRepository.getTopic(topic), 0);
     conf.set(KAFKA_INPUT_TOPIC, topic);
     conf.set(KAFKA_SOURCE_KEY_SCHEMA_STRING_PROP, ChunkedKeySuffix.SCHEMA$.toString());
-    try (
-        KafkaInputRecordReader reader = new KafkaInputRecordReader(new KafkaInputSplit(topic, 0, 0, 102), conf, null)) {
+    try (KafkaInputRecordReader reader =
+        new KafkaInputRecordReader(new KafkaInputSplit(pubSubTopicRepository, topicPartition, 0, 102), conf, null)) {
       for (int i = 0; i < 100; ++i) {
         KafkaInputMapperKey key = new KafkaInputMapperKey();
         KafkaInputMapperValue value = new KafkaInputMapperValue();


### PR DESCRIPTION
## Replace org.apache.kafka.common.TopicPartition with PubSubTopicPartition in VPJ
Replace the usage of Kafka TopicPartition with Venice PubSubOffset instances to enable support for non-Kafka   
pub-sub clients. This change is part of the broader effort to decouple Venice from Kafka-specific classes and  
ensure compatibility with other pub-sub systems.  

## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.