### PR TITLE
[server] A few changes for separate RT ingestion

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/config/VeniceServerConfig.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/config/VeniceServerConfig.java
@@ -84,6 +84,7 @@ import static com.linkedin.venice.ConfigKeys.SERVER_DB_READ_ONLY_FOR_BATCH_ONLY_
 import static com.linkedin.venice.ConfigKeys.SERVER_DEBUG_LOGGING_ENABLED;
 import static com.linkedin.venice.ConfigKeys.SERVER_DEDICATED_CONSUMER_POOL_FOR_AA_WC_LEADER_ENABLED;
 import static com.linkedin.venice.ConfigKeys.SERVER_DEDICATED_CONSUMER_POOL_SIZE_FOR_AA_WC_LEADER;
+import static com.linkedin.venice.ConfigKeys.SERVER_DEDICATED_CONSUMER_POOL_SIZE_FOR_SEP_RT_LEADER;
 import static com.linkedin.venice.ConfigKeys.SERVER_DEDICATED_DRAINER_FOR_SORTED_INPUT_ENABLED;
 import static com.linkedin.venice.ConfigKeys.SERVER_DELETE_UNASSIGNED_PARTITIONS_ON_STARTUP;
 import static com.linkedin.venice.ConfigKeys.SERVER_DISK_FULL_THRESHOLD;
@@ -150,6 +151,7 @@ import static com.linkedin.venice.ConfigKeys.SERVER_ROCKSDB_STORAGE_CONFIG_CHECK
 import static com.linkedin.venice.ConfigKeys.SERVER_ROUTER_CONNECTION_WARMING_DELAY_MS;
 import static com.linkedin.venice.ConfigKeys.SERVER_SCHEMA_FAST_CLASS_WARMUP_TIMEOUT;
 import static com.linkedin.venice.ConfigKeys.SERVER_SCHEMA_PRESENCE_CHECK_ENABLED;
+import static com.linkedin.venice.ConfigKeys.SERVER_SEP_RT_LEADER_QUOTA_RECORDS_PER_SECOND;
 import static com.linkedin.venice.ConfigKeys.SERVER_SHARED_CONSUMER_ASSIGNMENT_STRATEGY;
 import static com.linkedin.venice.ConfigKeys.SERVER_SHARED_CONSUMER_NON_EXISTING_TOPIC_CLEANUP_DELAY_MS;
 import static com.linkedin.venice.ConfigKeys.SERVER_SHUTDOWN_DISK_UNHEALTHY_TIME_MS;
@@ -550,6 +552,7 @@ public class VeniceServerConfig extends VeniceClusterConfig {
   private final int consumerPoolSizeForNonCurrentVersionNonAAWCLeader;
 
   private final int dedicatedConsumerPoolSizeForAAWCLeader;
+  private final int dedicatedConsumerPoolSizeForSepRTLeader;
   private final boolean useDaVinciSpecificExecutionStatusForError;
   private final long daVinciPushStatusCheckIntervalInMs;
   private final boolean recordLevelMetricWhenBootstrappingCurrentVersionEnabled;
@@ -567,6 +570,7 @@ public class VeniceServerConfig extends VeniceClusterConfig {
   private final boolean resubscriptionTriggeredByVersionIngestionContextChangeEnabled;
   private final int defaultMaxRecordSizeBytes;
   private final int aaWCLeaderQuotaRecordsPerSecond;
+  private final int sepRTLeaderQuotaRecordsPerSecond;
   private final int currentVersionAAWCLeaderQuotaRecordsPerSecond;
   private final int currentVersionSepRTLeaderQuotaRecordsPerSecond;
   private final int currentVersionNonAAWCLeaderQuotaRecordsPerSecond;
@@ -919,6 +923,9 @@ public class VeniceServerConfig extends VeniceClusterConfig {
         serverProperties.getInt(SERVER_CONSUMER_POOL_SIZE_FOR_NON_CURRENT_VERSION_NON_AA_WC_LEADER, 10);
     dedicatedConsumerPoolSizeForAAWCLeader =
         serverProperties.getInt(SERVER_DEDICATED_CONSUMER_POOL_SIZE_FOR_AA_WC_LEADER, 5);
+    dedicatedConsumerPoolSizeForSepRTLeader =
+        serverProperties.getInt(SERVER_DEDICATED_CONSUMER_POOL_SIZE_FOR_SEP_RT_LEADER, 3);
+
     useDaVinciSpecificExecutionStatusForError =
         serverProperties.getBoolean(USE_DA_VINCI_SPECIFIC_EXECUTION_STATUS_FOR_ERROR, false);
     daVinciPushStatusCheckIntervalInMs = serverProperties.getLong(DAVINCI_PUSH_STATUS_CHECK_INTERVAL_IN_MS, -1L);
@@ -941,6 +948,8 @@ public class VeniceServerConfig extends VeniceClusterConfig {
               + generateHumanReadableByteCountString(BYTES_PER_MB));
     }
     aaWCLeaderQuotaRecordsPerSecond = serverProperties.getInt(SERVER_AA_WC_LEADER_QUOTA_RECORDS_PER_SECOND, -1);
+    sepRTLeaderQuotaRecordsPerSecond = serverProperties.getInt(SERVER_SEP_RT_LEADER_QUOTA_RECORDS_PER_SECOND, -1);
+
     currentVersionAAWCLeaderQuotaRecordsPerSecond =
         serverProperties.getInt(SERVER_CURRENT_VERSION_AA_WC_LEADER_QUOTA_RECORDS_PER_SECOND, -1);
     currentVersionSepRTLeaderQuotaRecordsPerSecond =
@@ -1641,6 +1650,10 @@ public class VeniceServerConfig extends VeniceClusterConfig {
     return dedicatedConsumerPoolSizeForAAWCLeader;
   }
 
+  public int getDedicatedConsumerPoolSizeForSepRTLeader() {
+    return dedicatedConsumerPoolSizeForSepRTLeader;
+  }
+
   public KafkaConsumerServiceDelegator.ConsumerPoolStrategyType getConsumerPoolStrategyType() {
     return consumerPoolStrategyType;
   }
@@ -1715,6 +1728,10 @@ public class VeniceServerConfig extends VeniceClusterConfig {
 
   public int getAaWCLeaderQuotaRecordsPerSecond() {
     return aaWCLeaderQuotaRecordsPerSecond;
+  }
+
+  public int getSepRTLeaderQuotaRecordsPerSecond() {
+    return sepRTLeaderQuotaRecordsPerSecond;
   }
 
   public int getCurrentVersionAAWCLeaderQuotaRecordsPerSecond() {

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/ActiveActiveStoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/ActiveActiveStoreIngestionTask.java
@@ -175,7 +175,8 @@ public class ActiveActiveStoreIngestionTask extends LeaderFollowerStoreIngestion
   public static int getKeyLevelLockMaxPoolSizeBasedOnServerConfig(VeniceServerConfig serverConfig, int partitionCount) {
     int consumerPoolSizeForLeaderConsumption = 0;
     if (serverConfig.isDedicatedConsumerPoolForAAWCLeaderEnabled()) {
-      consumerPoolSizeForLeaderConsumption = serverConfig.getDedicatedConsumerPoolSizeForAAWCLeader();
+      consumerPoolSizeForLeaderConsumption = serverConfig.getDedicatedConsumerPoolSizeForAAWCLeader()
+          + serverConfig.getDedicatedConsumerPoolSizeForSepRTLeader();
     } else if (serverConfig.getConsumerPoolStrategyType()
         .equals(KafkaConsumerServiceDelegator.ConsumerPoolStrategyType.CURRENT_VERSION_PRIORITIZATION)) {
       consumerPoolSizeForLeaderConsumption = serverConfig.getConsumerPoolSizeForCurrentVersionAAWCLeader()

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/ConsumerPoolType.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/ConsumerPoolType.java
@@ -5,6 +5,7 @@ public enum ConsumerPoolType {
    * The following pool types are being used when the dedicated AA/WC leader consumer pool feature is enabled.
    */
   AA_WC_LEADER_POOL("_for_aa_wc_leader"), // For AA/WC leader
+  SEP_RT_LEADER_POOL("_for_sep_rt_leader"), // For Separate RT leader
   REGULAR_POOL(""), // For other kinds of workload except AA/WC leader, and this pool type is also being used when using
                     // a single consumer pool.
 

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/IngestionThrottler.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/IngestionThrottler.java
@@ -111,6 +111,14 @@ public class IngestionThrottler implements Closeable {
             false,
             EventThrottler.BLOCK_STRATEGY));
     this.poolTypeRecordThrottlerMap.put(
+        ConsumerPoolType.SEP_RT_LEADER_POOL,
+        new EventThrottler(
+            serverConfig.getSepRTLeaderQuotaRecordsPerSecond(),
+            serverConfig.getKafkaFetchQuotaTimeWindow(),
+            "sep_rt_leader_records_count",
+            false,
+            EventThrottler.BLOCK_STRATEGY));
+    this.poolTypeRecordThrottlerMap.put(
         ConsumerPoolType.CURRENT_VERSION_AA_WC_LEADER_POOL,
         new EventThrottler(
             serverConfig.getCurrentVersionAAWCLeaderQuotaRecordsPerSecond(),

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTask.java
@@ -2458,9 +2458,7 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
 
       if (consumerRecord.getTopicPartition().getPubSubTopic().isRealTime()) {
         recordRegionHybridConsumptionStats(
-            // convert the cluster id back to the original cluster id for monitoring purpose
-            serverConfig.getEquivalentKafkaClusterIdForSepTopic(
-                serverConfig.getEquivalentKafkaClusterIdForSepTopic(kafkaClusterId)),
+            kafkaClusterId,
             consumerRecord.getPayloadSize(),
             consumerRecord.getOffset(),
             beforeProcessingBatchRecordsTimestampMs);

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/ActiveActiveStoreIngestionTaskTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/ActiveActiveStoreIngestionTaskTest.java
@@ -723,9 +723,14 @@ public class ActiveActiveStoreIngestionTaskTest {
         .thenReturn(KafkaConsumerServiceDelegator.ConsumerPoolStrategyType.DEFAULT);
     when(serverConfig.getConsumerPoolSizePerKafkaCluster()).thenReturn(100);
     when(serverConfig.getKafkaClusterIdToUrlMap()).thenReturn(clusterIdToUrlMap);
+    when(serverConfig.getDedicatedConsumerPoolSizeForSepRTLeader()).thenReturn(3);
+    when(serverConfig.getDedicatedConsumerPoolSizeForAAWCLeader()).thenReturn(5);
     assertEquals(ActiveActiveStoreIngestionTask.getKeyLevelLockMaxPoolSizeBasedOnServerConfig(serverConfig, 10), 31);
-
+    when(serverConfig.isDedicatedConsumerPoolForAAWCLeaderEnabled()).thenReturn(true);
+    assertEquals(ActiveActiveStoreIngestionTask.getKeyLevelLockMaxPoolSizeBasedOnServerConfig(serverConfig, 10), 25);
+    assertEquals(ActiveActiveStoreIngestionTask.getKeyLevelLockMaxPoolSizeBasedOnServerConfig(serverConfig, 1), 4);
     // Test when current version prioritization strategy is enabled.
+    when(serverConfig.isDedicatedConsumerPoolForAAWCLeaderEnabled()).thenReturn(false);
     when(serverConfig.getConsumerPoolStrategyType())
         .thenReturn(KafkaConsumerServiceDelegator.ConsumerPoolStrategyType.CURRENT_VERSION_PRIORITIZATION);
     when(serverConfig.getConsumerPoolSizeForCurrentVersionAAWCLeader()).thenReturn(10);

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/KafkaConsumerServiceDelegatorTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/KafkaConsumerServiceDelegatorTest.java
@@ -151,16 +151,22 @@ public class KafkaConsumerServiceDelegatorTest {
   public void unsubscribeAllTest() {
     KafkaConsumerService mockDefaultConsumerService = mock(KafkaConsumerService.class);
     KafkaConsumerService mockDedicatedConsumerService = mock(KafkaConsumerService.class);
+    KafkaConsumerService mockDedicatedConsumerServiceForSepRT = mock(KafkaConsumerService.class);
     VeniceServerConfig mockConfig = mock(VeniceServerConfig.class);
     doReturn(true).when(mockConfig).isDedicatedConsumerPoolForAAWCLeaderEnabled();
     doReturn(KafkaConsumerServiceDelegator.ConsumerPoolStrategyType.AA_OR_WC_LEADER_DEDICATED).when(mockConfig)
         .getConsumerPoolStrategyType();
 
     Function<String, Boolean> isAAWCStoreFunc = vt -> true;
-    KafkaConsumerServiceDelegator.KafkaConsumerServiceBuilder consumerServiceBuilder =
-        (ignored, poolType) -> poolType.equals(ConsumerPoolType.REGULAR_POOL)
-            ? mockDefaultConsumerService
-            : mockDedicatedConsumerService;
+    KafkaConsumerServiceDelegator.KafkaConsumerServiceBuilder consumerServiceBuilder = (ignored, poolType) -> {
+      if (poolType.equals(ConsumerPoolType.AA_WC_LEADER_POOL)) {
+        return mockDedicatedConsumerService;
+      } else if (poolType.equals(ConsumerPoolType.SEP_RT_LEADER_POOL)) {
+        return mockDedicatedConsumerServiceForSepRT;
+      } else {
+        return mockDefaultConsumerService;
+      }
+    };
 
     KafkaConsumerServiceDelegator delegator =
         new KafkaConsumerServiceDelegator(mockConfig, consumerServiceBuilder, isAAWCStoreFunc);
@@ -168,6 +174,7 @@ public class KafkaConsumerServiceDelegatorTest {
     delegator.unsubscribeAll(versionTopic);
     verify(mockDefaultConsumerService).unsubscribeAll(versionTopic);
     verify(mockDedicatedConsumerService).unsubscribeAll(versionTopic);
+    verify(mockDedicatedConsumerServiceForSepRT).unsubscribeAll(versionTopic);
   }
 
   @Test
@@ -175,16 +182,22 @@ public class KafkaConsumerServiceDelegatorTest {
       throws Exception {
     KafkaConsumerService mockDefaultConsumerService = mock(KafkaConsumerService.class);
     KafkaConsumerService mockDedicatedConsumerService = mock(KafkaConsumerService.class);
+    KafkaConsumerService mockDedicatedConsumerServiceForSepRT = mock(KafkaConsumerService.class);
     VeniceServerConfig mockConfig = mock(VeniceServerConfig.class);
     doReturn(true).when(mockConfig).isDedicatedConsumerPoolForAAWCLeaderEnabled();
     doReturn(KafkaConsumerServiceDelegator.ConsumerPoolStrategyType.AA_OR_WC_LEADER_DEDICATED).when(mockConfig)
         .getConsumerPoolStrategyType();
 
     Function<String, Boolean> isAAWCStoreFunc = vt -> true;
-    KafkaConsumerServiceDelegator.KafkaConsumerServiceBuilder consumerServiceBuilder =
-        (ignored, poolType) -> poolType.equals(ConsumerPoolType.REGULAR_POOL)
-            ? mockDefaultConsumerService
-            : mockDedicatedConsumerService;
+    KafkaConsumerServiceDelegator.KafkaConsumerServiceBuilder consumerServiceBuilder = (ignored, poolType) -> {
+      if (poolType.equals(ConsumerPoolType.AA_WC_LEADER_POOL)) {
+        return mockDedicatedConsumerService;
+      } else if (poolType.equals(ConsumerPoolType.SEP_RT_LEADER_POOL)) {
+        return mockDedicatedConsumerServiceForSepRT;
+      } else {
+        return mockDefaultConsumerService;
+      }
+    };
 
     KafkaConsumerServiceDelegator delegator =
         new KafkaConsumerServiceDelegator(mockConfig, consumerServiceBuilder, isAAWCStoreFunc);

--- a/internal/venice-common/src/main/java/com/linkedin/venice/ConfigKeys.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/ConfigKeys.java
@@ -2217,8 +2217,12 @@ public class ConfigKeys {
    */
   public static final String SERVER_DEDICATED_CONSUMER_POOL_FOR_AA_WC_LEADER_ENABLED =
       "server.dedicated.consumer.pool.for.aa.wc.leader.enabled";
+
   public static final String SERVER_DEDICATED_CONSUMER_POOL_SIZE_FOR_AA_WC_LEADER =
       "server.dedicated.consumer.pool.size.for.aa.wc.leader";
+
+  public static final String SERVER_DEDICATED_CONSUMER_POOL_SIZE_FOR_SEP_RT_LEADER =
+      "server.dedicated.consumer.pool.size.for.sep.rt.leader";
 
   /**
    * Consumer Pool allocation strategy to rely on pool size to prioritize specific traffic. There will be 3 different
@@ -2339,6 +2343,12 @@ public class ConfigKeys {
    */
   public static final String SERVER_AA_WC_LEADER_QUOTA_RECORDS_PER_SECOND =
       "server.aa.wc.leader.quota.records.per.second";
+  /**
+   * Quota for separate realtime topic leader replica as we know separate realtime topic messages are not prioritized
+   * compared to realtime topic messages, so we would like to use the following throttler to limit the resource usage.
+   */
+  public static final String SERVER_SEP_RT_LEADER_QUOTA_RECORDS_PER_SECOND =
+      "server.sep.rt.leader.quota.records.per.second";
 
   /**
    * The following finer quota enforcement will be used when {@literal ConsumerPoolStrategyType.CURRENT_VERSION_PRIORITIZATION}


### PR DESCRIPTION
<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## [server] A few changes for separate RT ingestion
Fixed two issues found in tests:
(1) region level metrics should not be resolved to non-sep region, it will cause confusion as we can't tell whether it is coming from RT or sepRT.
(2) Add separate pool and throttler for sep RT in dedicated AAWC leader consumer pool mode. This is addition to original implementation in current version prioritization mode separate pool, as not all clusters have rolled out this feature.

## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
Updated unit test.
## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.