### PR TITLE
[controller] Update parent version status to account for child version status

### DIFF
--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestPushJobWithNativeReplication.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestPushJobWithNativeReplication.java
@@ -30,7 +30,15 @@ import static com.linkedin.venice.utils.IntegrationTestPushUtils.sendStreamingRe
 import static com.linkedin.venice.utils.TestUtils.assertCommand;
 import static com.linkedin.venice.utils.TestUtils.waitForNonDeterministicAssertion;
 import static com.linkedin.venice.utils.TestWriteUtils.getTempDataDirectory;
-import static com.linkedin.venice.vpj.VenicePushJobConstants.*;
+import static com.linkedin.venice.vpj.VenicePushJobConstants.DEFAULT_KEY_FIELD_PROP;
+import static com.linkedin.venice.vpj.VenicePushJobConstants.DEFAULT_VALUE_FIELD_PROP;
+import static com.linkedin.venice.vpj.VenicePushJobConstants.DEFER_VERSION_SWAP;
+import static com.linkedin.venice.vpj.VenicePushJobConstants.INCREMENTAL_PUSH;
+import static com.linkedin.venice.vpj.VenicePushJobConstants.INPUT_PATH_PROP;
+import static com.linkedin.venice.vpj.VenicePushJobConstants.PUSH_JOB_STATUS_UPLOAD_ENABLE;
+import static com.linkedin.venice.vpj.VenicePushJobConstants.SEND_CONTROL_MESSAGES_DIRECTLY;
+import static com.linkedin.venice.vpj.VenicePushJobConstants.TARGETED_REGION_PUSH_ENABLED;
+import static com.linkedin.venice.vpj.VenicePushJobConstants.TARGETED_REGION_PUSH_WITH_DEFERRED_SWAP;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNotNull;
 

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceParentHelixAdmin.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceParentHelixAdmin.java
@@ -3663,7 +3663,7 @@ public class VeniceParentHelixAdmin implements Admin {
         boolean isDeferredSwap = version != null && version.isVersionSwapDeferred();
         // targetedRegions is non-empty for target region push of batch store
         boolean isTargetRegionPush = !StringUtils.isEmpty(targetedRegions);
-        if (!isDeferredSwap || isDeferredSwap && isTargetRegionPush) {
+        if (!isDeferredSwap || isTargetRegionPush) {
           Version storeVersion = parentStore.getVersion(versionNum);
           boolean isVersionPushed = storeVersion != null && storeVersion.getStatus().equals(PUSHED);
           boolean isHybridStore = storeVersion != null && storeVersion.getHybridStoreConfig() != null;
@@ -3692,8 +3692,8 @@ public class VeniceParentHelixAdmin implements Admin {
           Map<String, Integer> currentVersionsToColo = getCurrentVersionsForMultiColos(clusterName, storeName);
           int latestVersionNum = parentStore.getLargestUsedVersionNumber();
           boolean isLatestVersionOnlineInAllRegions = true;
-          for (String region: currentVersionsToColo.keySet()) {
-            if (currentVersionsToColo.get(region) != latestVersionNum) {
+          for (Map.Entry<String, Integer> entry: currentVersionsToColo.entrySet()) {
+            if (currentVersionsToColo.get(entry.getKey()) != latestVersionNum) {
               isLatestVersionOnlineInAllRegions = false;
             }
           }


### PR DESCRIPTION
<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## Summary, imperative, start upper case, don't end with a period
<!--
Describe
- What changes to make and why you are making these changes.
- How are you going to achieve your goal.
- Describe what testings you have done, for example, performance testing etc.

If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

Previously the parent version status is updated to `PUSHED` for a target region push if the version is not null and not already set to `PUSHED`. And in the next poll, it is set to `ONLINE` because the above conditions are no longer met. This, however, is inaccurate because it doesn't check if the child region is serving the new version already before changing the status to `ONLINE`. This change modifies the logic to check if all child regions are on the latest version before marking the parent version status as `ONLINE`

## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
Updated integration tests

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.