### PR TITLE
[duckdb] Fixed delete bug in DuckDB DVRT.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -82,7 +82,7 @@ ext.libraries = [
     commonsLang: 'commons-lang:commons-lang:2.6',
     conscrypt: 'org.conscrypt:conscrypt-openjdk-uber:2.5.2',
     d2: "com.linkedin.pegasus:d2:${pegasusVersion}",
-    duckdbJdbc: "org.duckdb:duckdb_jdbc:1.2.0-20250121.012246-127", // TODO: Remove SNAPSHOT when the real release is published!
+    duckdbJdbc: "org.duckdb:duckdb_jdbc:1.2.0-20250124.011319-133", // TODO: Remove SNAPSHOT when the real release is published!
     failsafe: 'net.jodah:failsafe:2.4.0',
     fastUtil: 'it.unimi.dsi:fastutil:8.3.0',
     grpcNettyShaded: "io.grpc:grpc-netty-shaded:${grpcVersion}",

--- a/integrations/venice-duckdb/build.gradle
+++ b/integrations/venice-duckdb/build.gradle
@@ -16,6 +16,7 @@ dependencies {
   testImplementation project(':internal:venice-common')
 
   integrationTestImplementation project(path: ':internal:venice-test-common', configuration: 'integrationTestUtils')
+  integrationTestImplementation project(':clients:venice-producer')
   integrationTestImplementation project(':clients:venice-push-job')
   integrationTestImplementation project(':clients:venice-thin-client')
   integrationTestImplementation project(':integrations:venice-duckdb')

--- a/integrations/venice-duckdb/src/main/java/com/linkedin/venice/sql/KeyValuePreparedStatementProcessor.java
+++ b/integrations/venice-duckdb/src/main/java/com/linkedin/venice/sql/KeyValuePreparedStatementProcessor.java
@@ -1,0 +1,59 @@
+package com.linkedin.venice.sql;
+
+import com.linkedin.venice.exceptions.VeniceException;
+import java.sql.JDBCType;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.util.Objects;
+import java.util.Set;
+import javax.annotation.Nonnull;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericRecord;
+
+
+public class KeyValuePreparedStatementProcessor extends KeyOnlyPreparedStatementProcessor {
+  private final int[] valueFieldIndexToJdbcIndexMapping;
+  private final int[] valueFieldIndexToUnionBranchIndex;
+  private final JDBCType[] valueFieldIndexToCorrespondingType;
+
+  KeyValuePreparedStatementProcessor(
+      @Nonnull Schema keySchema,
+      @Nonnull Schema valueSchema,
+      @Nonnull Set<String> columnsToProject) {
+    super(keySchema);
+    Objects.requireNonNull(columnsToProject);
+    Objects.requireNonNull(valueSchema);
+
+    int valueFieldCount = valueSchema.getFields().size();
+    this.valueFieldIndexToJdbcIndexMapping = new int[valueFieldCount];
+    this.valueFieldIndexToUnionBranchIndex = new int[valueFieldCount];
+    this.valueFieldIndexToCorrespondingType = new JDBCType[valueFieldCount];
+
+    int valueStartingIndex = getLastKeyJdbcIndex() + 1;
+    populateArrays(
+        valueStartingIndex,
+        valueSchema,
+        this.valueFieldIndexToJdbcIndexMapping,
+        this.valueFieldIndexToUnionBranchIndex,
+        this.valueFieldIndexToCorrespondingType,
+        columnsToProject);
+  }
+
+  @Override
+  public void process(GenericRecord key, GenericRecord value, PreparedStatement preparedStatement) {
+    try {
+      processKey(key, preparedStatement);
+
+      processRecord(
+          value,
+          preparedStatement,
+          this.valueFieldIndexToJdbcIndexMapping,
+          this.valueFieldIndexToUnionBranchIndex,
+          this.valueFieldIndexToCorrespondingType);
+
+      preparedStatement.execute();
+    } catch (SQLException e) {
+      throw new VeniceException("Failed to execute prepared statement!", e);
+    }
+  }
+}

--- a/integrations/venice-duckdb/src/main/java/com/linkedin/venice/sql/PreparedStatementProcessor.java
+++ b/integrations/venice-duckdb/src/main/java/com/linkedin/venice/sql/PreparedStatementProcessor.java
@@ -1,0 +1,10 @@
+package com.linkedin.venice.sql;
+
+import java.sql.PreparedStatement;
+import org.apache.avro.generic.GenericRecord;
+
+
+/** Populates a {@link PreparedStatement} from Avro key/value records. */
+public interface PreparedStatementProcessor {
+  void process(GenericRecord key, GenericRecord value, PreparedStatement preparedStatement);
+}

--- a/integrations/venice-duckdb/src/test/java/com/linkedin/venice/duckdb/DuckDBAvroToSQLTest.java
+++ b/integrations/venice-duckdb/src/test/java/com/linkedin/venice/duckdb/DuckDBAvroToSQLTest.java
@@ -8,7 +8,7 @@ import static org.testng.Assert.assertTrue;
 
 import com.linkedin.venice.sql.AvroToSQL;
 import com.linkedin.venice.sql.AvroToSQLTest;
-import com.linkedin.venice.sql.InsertProcessor;
+import com.linkedin.venice.sql.PreparedStatementProcessor;
 import com.linkedin.venice.sql.SQLUtils;
 import com.linkedin.venice.utils.ByteUtils;
 import java.io.IOException;
@@ -75,7 +75,8 @@ public class DuckDBAvroToSQLTest {
 
       String upsertStatement = AvroToSQL.upsertStatement(tableName, keySchema, valueSchema, Collections.emptySet());
       System.out.println(upsertStatement);
-      InsertProcessor upsertProcessor = AvroToSQL.upsertProcessor(keySchema, valueSchema, Collections.emptySet());
+      PreparedStatementProcessor upsertProcessor =
+          AvroToSQL.upsertProcessor(keySchema, valueSchema, Collections.emptySet());
       for (int rewriteIteration = 0; rewriteIteration < 3; rewriteIteration++) {
         List<Map.Entry<GenericRecord, GenericRecord>> records = generateRecords(keySchema, valueSchema);
         GenericRecord key, value;

--- a/integrations/venice-duckdb/src/test/java/com/linkedin/venice/duckdb/DuckDBDaVinciRecordTransformerTest.java
+++ b/integrations/venice-duckdb/src/test/java/com/linkedin/venice/duckdb/DuckDBDaVinciRecordTransformerTest.java
@@ -1,8 +1,8 @@
 package com.linkedin.venice.duckdb;
 
 import static com.linkedin.venice.utils.TestWriteUtils.NAME_RECORD_V1_SCHEMA;
-import static com.linkedin.venice.utils.TestWriteUtils.SIMPLE_USER_WITH_DEFAULT_SCHEMA;
 import static com.linkedin.venice.utils.TestWriteUtils.SINGLE_FIELD_RECORD_SCHEMA;
+import static com.linkedin.venice.utils.TestWriteUtils.TWO_FIELDS_RECORD_SCHEMA;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNull;
@@ -141,12 +141,7 @@ public class DuckDBDaVinciRecordTransformerTest {
 
     try (Connection connection = DriverManager.getConnection(duckDBUrl);
         Statement stmt = connection.createStatement()) {
-      try (ResultSet rs = stmt.executeQuery("SELECT * FROM " + storeName)) {
-        assertTrue(rs.next(), "There should be a first row!");
-        assertEquals(rs.getString("firstName"), "Duck");
-        assertEquals(rs.getString("lastName"), "Goose");
-        assertFalse(rs.next(), "There should be only one row!");
-      }
+      assertDataset1(stmt, storeName);
 
       // Swap here
       recordTransformer_v1.onEndVersionIngestion(2);
@@ -178,7 +173,7 @@ public class DuckDBDaVinciRecordTransformerTest {
         columnsToProject);
     DuckDBDaVinciRecordTransformer recordTransformerForStore2 = new DuckDBDaVinciRecordTransformer(
         1,
-        SIMPLE_USER_WITH_DEFAULT_SCHEMA,
+        TWO_FIELDS_RECORD_SCHEMA,
         NAME_RECORD_V1_SCHEMA,
         NAME_RECORD_V1_SCHEMA,
         false,
@@ -192,71 +187,88 @@ public class DuckDBDaVinciRecordTransformerTest {
 
     GenericRecord keyRecord = new GenericData.Record(SINGLE_FIELD_RECORD_SCHEMA);
     keyRecord.put("key", "key");
-    Lazy<GenericRecord> lazyKey = Lazy.of(() -> keyRecord);
+    Lazy<GenericRecord> lazyKeyForStore1 = Lazy.of(() -> keyRecord);
 
     GenericRecord valueRecordForStore1 = new GenericData.Record(NAME_RECORD_V1_SCHEMA);
     valueRecordForStore1.put("firstName", "Duck");
     valueRecordForStore1.put("lastName", "Goose");
-    Lazy<GenericRecord> lazyValue = Lazy.of(() -> valueRecordForStore1);
-    recordTransformerForStore1.processPut(lazyKey, lazyValue);
-
-    try (Connection connection = DriverManager.getConnection(duckDBUrl);
-        Statement stmt = connection.createStatement()) {
-      try (ResultSet rs = stmt.executeQuery("SELECT * FROM " + store1)) {
-        assertTrue(rs.next(), "There should be a first row!");
-        assertEquals(rs.getString("key"), "key");
-        assertEquals(rs.getString("firstName"), "Duck");
-        assertEquals(rs.getString("lastName"), "Goose");
-        assertFalse(rs.next(), "There should be only one row!");
-      }
-    }
+    Lazy<GenericRecord> lazyValueForStore1 = Lazy.of(() -> valueRecordForStore1);
+    recordTransformerForStore1.processPut(lazyKeyForStore1, lazyValueForStore1);
 
     recordTransformerForStore2.onStartVersionIngestion(true);
 
-    GenericRecord keyRecordForStore2 = new GenericData.Record(SIMPLE_USER_WITH_DEFAULT_SCHEMA);
-    keyRecordForStore2.put("key", "key");
-    keyRecordForStore2.put("value", "value");
+    try (Connection connection = DriverManager.getConnection(duckDBUrl);
+        Statement stmt = connection.createStatement()) {
+      assertDataset1(stmt, store1);
+      assertJoin(stmt, store1, store2, false);
+    }
+
+    GenericRecord keyRecordForStore2 = new GenericData.Record(TWO_FIELDS_RECORD_SCHEMA);
+    keyRecordForStore2.put("id1", 1);
+    keyRecordForStore2.put("id2", 2L);
     Lazy<GenericRecord> lazyKeyForStore2 = Lazy.of(() -> keyRecordForStore2);
 
     GenericRecord valueRecordForStore2 = new GenericData.Record(NAME_RECORD_V1_SCHEMA);
-    valueRecordForStore2.put("firstName", "Duck2");
-    valueRecordForStore2.put("lastName", "Goose2");
+    valueRecordForStore2.put("firstName", "Duck");
+    valueRecordForStore2.put("lastName", "Goose");
     Lazy<GenericRecord> lazyValueForStore2 = Lazy.of(() -> valueRecordForStore2);
     recordTransformerForStore2.processPut(lazyKeyForStore2, lazyValueForStore2);
 
     try (Connection connection = DriverManager.getConnection(duckDBUrl);
         Statement stmt = connection.createStatement()) {
-      try (ResultSet rs = stmt.executeQuery("SELECT * FROM " + store1)) {
+      assertDataset1(stmt, store1);
+
+      try (ResultSet rs = stmt.executeQuery("SELECT * FROM " + store2)) {
         assertTrue(rs.next(), "There should be a first row!");
-        assertEquals(rs.getString("key"), "key");
+        assertEquals(rs.getInt("id1"), 1);
+        assertEquals(rs.getLong("id2"), 2L);
         assertEquals(rs.getString("firstName"), "Duck");
         assertEquals(rs.getString("lastName"), "Goose");
         assertFalse(rs.next(), "There should be only one row!");
       }
 
-      try (ResultSet rs = stmt.executeQuery("SELECT * FROM " + store2)) {
-        assertTrue(rs.next(), "There should be a first row!");
-        assertEquals(rs.getString("key"), "key");
-        assertEquals(rs.getString("value"), "value");
-        assertEquals(rs.getString("firstName"), "Duck2");
-        assertEquals(rs.getString("lastName"), "Goose2");
-        assertFalse(rs.next(), "There should be only one row!");
-      }
+      assertJoin(stmt, store1, store2, true);
 
-      try (ResultSet rs = stmt.executeQuery(
-          "SELECT s1.key AS s1key, s1.firstName AS s1FirstName, s1.lastName AS s1LastName, "
-              + "s2.key AS s2key, s2.value AS s2value, s2.firstName AS s2FirstName, s2.lastName AS s2LastName "
-              + "FROM " + store1 + " s1 JOIN " + store2 + " s2 ON s1.key = s2.key")) {
-        assertTrue(rs.next(), "There should be a first row!");
-        assertEquals(rs.getString("s1key"), "key");
-        assertEquals(rs.getString("s1FirstName"), "Duck");
-        assertEquals(rs.getString("s1LastName"), "Goose");
-        assertEquals(rs.getString("s2key"), "key");
-        assertEquals(rs.getString("s2value"), "value");
-        assertEquals(rs.getString("s2FirstName"), "Duck2");
-        assertEquals(rs.getString("s2LastName"), "Goose2");
-        assertFalse(rs.next(), "There should be only one row!");
+      recordTransformerForStore2.processDelete(lazyKeyForStore2);
+
+      assertJoin(stmt, store1, store2, false);
+
+      recordTransformerForStore1.processDelete(lazyKeyForStore1);
+
+      try (ResultSet rs = stmt.executeQuery(getJoinQuery(store1, store2))) {
+        assertFalse(rs.next());
       }
     }
+  }
+
+  private void assertDataset1(Statement statement, String storeName) throws SQLException {
+    try (ResultSet rs = statement.executeQuery("SELECT * FROM " + storeName)) {
+      assertTrue(rs.next(), "There should be a first row!");
+      assertEquals(rs.getString("key"), "key");
+      assertEquals(rs.getString("firstName"), "Duck");
+      assertEquals(rs.getString("lastName"), "Goose");
+      assertFalse(rs.next(), "There should be only one row!");
+    }
+  }
+
+  private void assertJoin(Statement statement, String store1, String store2, boolean includeStore2)
+      throws SQLException {
+    try (ResultSet rs = statement.executeQuery(getJoinQuery(store1, store2))) {
+      assertTrue(rs.next(), "There should be a first row!");
+      assertEquals(rs.getString("s1key"), "key");
+      assertEquals(rs.getString("s1FirstName"), "Duck");
+      assertEquals(rs.getString("s1LastName"), "Goose");
+      assertEquals(rs.getInt("s2id1"), includeStore2 ? 1 : 0);
+      assertEquals(rs.getLong("s2id2"), includeStore2 ? 2L : 0);
+      assertEquals(rs.getString("s2FirstName"), includeStore2 ? "Duck" : null);
+      assertEquals(rs.getString("s2LastName"), includeStore2 ? "Goose" : null);
+      assertFalse(rs.next(), "There should be only one row!");
+    }
+  }
+
+  private String getJoinQuery(String store1, String store2) {
+    return "SELECT s1.key AS s1key, s1.firstName AS s1FirstName, s1.lastName AS s1LastName, "
+        + "s2.id1 AS s2id1, s2.id2 AS s2id2, s2.firstName AS s2FirstName, s2.lastName AS s2LastName FROM " + store1
+        + " s1 LEFT JOIN " + store2 + " s2 ON s1.firstName = s2.firstName AND s1.lastName = s2.lastName";
   }
 }

--- a/internal/venice-client-common/src/main/java/com/linkedin/venice/utils/concurrent/CloseableThreadLocal.java
+++ b/internal/venice-client-common/src/main/java/com/linkedin/venice/utils/concurrent/CloseableThreadLocal.java
@@ -20,8 +20,8 @@ public class CloseableThreadLocal<T extends AutoCloseable> implements AutoClosea
   private final Set<T> valueSet = new ConcurrentSkipListSet<>(new HashCodeComparator<>());
   private final ThreadLocal<T> threadLocal;
 
-  public static <T> CloseableThreadLocal withInitial(Supplier<T> initialValue) {
-    return new CloseableThreadLocal(initialValue);
+  public static <T extends AutoCloseable> CloseableThreadLocal<T> withInitial(Supplier<T> initialValue) {
+    return new CloseableThreadLocal<>(initialValue);
   }
 
   /**

--- a/internal/venice-test-common/src/main/java/com/linkedin/venice/utils/TestWriteUtils.java
+++ b/internal/venice-test-common/src/main/java/com/linkedin/venice/utils/TestWriteUtils.java
@@ -85,6 +85,9 @@ public class TestWriteUtils {
   public static final Schema SINGLE_FIELD_RECORD_SCHEMA =
       AvroCompatibilityHelper.parse(loadSchemaFileFromResource("valueSchema/SingleFieldRecord.avsc"));
 
+  public static final Schema TWO_FIELDS_RECORD_SCHEMA =
+      AvroCompatibilityHelper.parse(loadSchemaFileFromResource("valueSchema/TwoFieldsRecord.avsc"));
+
   public static final Schema SIMPLE_USER_WITH_DEFAULT_SCHEMA =
       AvroCompatibilityHelper.parse(loadSchemaFileFromResource("valueSchema/SimpleUserWithDefault.avsc"));
   public static final Schema USER_WITH_FLOAT_ARRAY_SCHEMA =

--- a/internal/venice-test-common/src/main/resources/valueSchema/TwoFieldsRecord.avsc
+++ b/internal/venice-test-common/src/main/resources/valueSchema/TwoFieldsRecord.avsc
@@ -1,0 +1,14 @@
+{
+  "type" : "record",
+  "name" : "TwoFieldsRecord",
+  "namespace" : "example.avro",
+  "fields" : [ {
+    "name" : "id1",
+    "type" : "int",
+    "default" : ""
+  }, {
+    "name" : "id2",
+    "type" : "long",
+    "default" : ""
+  } ]
+}


### PR DESCRIPTION
Delete used to work only for key schemas that had a single string field named "key". Now it works for any schema.

Miscellaneous:

- Refactored the InsertProcessor code to be more generic.

- Bumped DuckDB snapshot dep to the latest.

## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->

New test.
## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.