### PR TITLE
[dvc][duckdb] API change proposal to support DVRT checkpointing

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -82,7 +82,7 @@ ext.libraries = [
     commonsLang: 'commons-lang:commons-lang:2.6',
     conscrypt: 'org.conscrypt:conscrypt-openjdk-uber:2.5.2',
     d2: "com.linkedin.pegasus:d2:${pegasusVersion}",
-    duckdbJdbc: "org.duckdb:duckdb_jdbc:1.2.0-20250124.011319-133", // TODO: Remove SNAPSHOT when the real release is published!
+    duckdbJdbc: "org.duckdb:duckdb_jdbc:1.2.0-20250127.011437-139", // TODO: Remove SNAPSHOT when the real release is published!
     failsafe: 'net.jodah:failsafe:2.4.0',
     fastUtil: 'it.unimi.dsi:fastutil:8.3.0',
     grpcNettyShaded: "io.grpc:grpc-netty-shaded:${grpcVersion}",

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/DaVinciBackend.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/DaVinciBackend.java
@@ -246,7 +246,9 @@ public class DaVinciBackend implements Closeable {
               new MetadataUpdateStats(metricsRepository),
               configLoader,
               storageService.getStoreVersionStateSyncer())
-          : new StorageEngineMetadataService(storageService.getStorageEngineRepository(), partitionStateSerializer);
+          : new StorageEngineMetadataService(
+              storageService.getStorageEngineRepository()::getCheckpointStorageEngine,
+              partitionStateSerializer);
       // Start storage metadata service
       ((AbstractVeniceService) storageMetadataService).start();
       compressorFactory = new StorageEngineBackedCompressorFactory(storageMetadataService);

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/client/BlockingDaVinciRecordTransformer.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/client/BlockingDaVinciRecordTransformer.java
@@ -1,5 +1,6 @@
 package com.linkedin.davinci.client;
 
+import com.linkedin.davinci.storage.StorageMetadataService;
 import com.linkedin.venice.annotation.Experimental;
 import com.linkedin.venice.utils.lazy.Lazy;
 import java.io.IOException;
@@ -56,6 +57,16 @@ public class BlockingDaVinciRecordTransformer<K, V, O> extends DaVinciRecordTran
 
   public void onEndVersionIngestion(int currentVersion) {
     this.recordTransformer.onEndVersionIngestion(currentVersion);
+  }
+
+  @Override
+  public boolean useUniformInputValueSchema() {
+    return this.recordTransformer.useUniformInputValueSchema();
+  }
+
+  @Override
+  public StorageMetadataService getStorageMetadataService() {
+    return this.recordTransformer.getStorageMetadataService();
   }
 
   @Override

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/client/DaVinciRecordTransformer.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/client/DaVinciRecordTransformer.java
@@ -1,5 +1,6 @@
 package com.linkedin.davinci.client;
 
+import com.linkedin.davinci.storage.StorageMetadataService;
 import com.linkedin.davinci.store.AbstractStorageEngine;
 import com.linkedin.venice.annotation.Experimental;
 import com.linkedin.venice.compression.VeniceCompressor;
@@ -133,6 +134,11 @@ public abstract class DaVinciRecordTransformer<K, V, O> implements Closeable {
 
   public boolean useUniformInputValueSchema() {
     return false;
+  }
+
+  /** A subclass can return a concrete implementation of {@link StorageMetadataService} to control checkpointing. */
+  public StorageMetadataService getStorageMetadataService() {
+    return null;
   }
 
   // Final methods below

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/consumer/InternalLocalBootstrappingVeniceChangelogConsumer.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/consumer/InternalLocalBootstrappingVeniceChangelogConsumer.java
@@ -131,8 +131,9 @@ class InternalLocalBootstrappingVeniceChangelogConsumer<K, V> extends VeniceAfte
         true,
         true,
         functionToCheckWhetherStorageEngineShouldBeKeptOrNot());
-    storageMetadataService =
-        new StorageEngineMetadataService(storageService.getStorageEngineRepository(), partitionStateSerializer);
+    storageMetadataService = new StorageEngineMetadataService(
+        storageService.getStorageEngineRepository()::getCheckpointStorageEngine,
+        partitionStateSerializer);
   }
 
   private Function<String, Boolean> functionToCheckWhetherStorageEngineShouldBeKeptOrNot() {

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/ingestion/isolated/IsolatedIngestionServer.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/ingestion/isolated/IsolatedIngestionServer.java
@@ -685,8 +685,9 @@ public class IsolatedIngestionServer extends AbstractVeniceService {
             .setStoreName(AvroProtocolDefinition.KAFKA_MESSAGE_ENVELOPE.getSystemStoreName()),
         null);
 
-    storageMetadataService =
-        new StorageEngineMetadataService(storageService.getStorageEngineRepository(), partitionStateSerializer);
+    storageMetadataService = new StorageEngineMetadataService(
+        storageService.getStorageEngineRepository()::getCheckpointStorageEngine,
+        partitionStateSerializer);
 
     StorageEngineBackedCompressorFactory compressorFactory =
         new StorageEngineBackedCompressorFactory(storageMetadataService);

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/storage/StorageEngineRepository.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/storage/StorageEngineRepository.java
@@ -1,6 +1,7 @@
 package com.linkedin.davinci.storage;
 
 import com.linkedin.davinci.store.AbstractStorageEngine;
+import com.linkedin.davinci.store.CheckpointStorageEngine;
 import com.linkedin.venice.exceptions.VeniceException;
 import java.util.ArrayList;
 import java.util.List;
@@ -23,6 +24,10 @@ public class StorageEngineRepository {
 
   public AbstractStorageEngine getLocalStorageEngine(String storeName) {
     return localStorageEngines.get(storeName);
+  }
+
+  public CheckpointStorageEngine getCheckpointStorageEngine(String storeName) {
+    return getLocalStorageEngine(storeName);
   }
 
   public AbstractStorageEngine removeLocalStorageEngine(String storeName) {

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/store/CheckpointStorageEngine.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/store/CheckpointStorageEngine.java
@@ -1,0 +1,25 @@
+package com.linkedin.davinci.store;
+
+import com.linkedin.venice.kafka.protocol.state.StoreVersionState;
+import com.linkedin.venice.offsets.OffsetRecord;
+
+
+/**
+ * Interface to read and write the metadata needed for checkpointing, including:
+ *
+ * - {@link com.linkedin.venice.offsets.OffsetRecord}
+ * - {@link com.linkedin.venice.kafka.protocol.state.StoreVersionState}
+ */
+public interface CheckpointStorageEngine {
+  void putPartitionOffset(int partitionId, OffsetRecord offsetRecord);
+
+  OffsetRecord getPartitionOffset(int partitionId);
+
+  void clearPartitionOffset(int partitionId);
+
+  void putStoreVersionState(StoreVersionState versionState);
+
+  StoreVersionState getStoreVersionState();
+
+  void clearStoreVersionState();
+}

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/store/rocksdb/RocksDBStorageEngineTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/store/rocksdb/RocksDBStorageEngineTest.java
@@ -3,6 +3,7 @@ package com.linkedin.davinci.store.rocksdb;
 import static com.linkedin.davinci.store.AbstractStorageEngine.METADATA_PARTITION_ID;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertNull;
 
 import com.linkedin.davinci.config.VeniceStoreVersionConfig;
 import com.linkedin.davinci.stats.AggVersionedStorageEngineStats;
@@ -132,13 +133,13 @@ public class RocksDBStorageEngineTest extends AbstractStorageEngineTest {
     offsetRecord.setRealtimeTopicProducerState(kafkaUrl, guid, ppState);
     offsetRecord.setCheckpointLocalVersionTopicOffset(666L);
     rocksDBStorageEngine.putPartitionOffset(PARTITION_ID, offsetRecord);
-    Assert.assertEquals(rocksDBStorageEngine.getPartitionOffset(PARTITION_ID).get().getLocalVersionTopicOffset(), 666L);
+    Assert.assertEquals(rocksDBStorageEngine.getPartitionOffset(PARTITION_ID).getLocalVersionTopicOffset(), 666L);
     ProducerPartitionState ppStateFromRocksDB =
-        rocksDBStorageEngine.getPartitionOffset(PARTITION_ID).get().getRealTimeProducerState(kafkaUrl, guid);
+        rocksDBStorageEngine.getPartitionOffset(PARTITION_ID).getRealTimeProducerState(kafkaUrl, guid);
     Assert.assertEquals(ppStateFromRocksDB.getSegmentNumber(), segment);
     Assert.assertEquals(ppStateFromRocksDB.getMessageSequenceNumber(), sequence);
     rocksDBStorageEngine.clearPartitionOffset(PARTITION_ID);
-    Assert.assertEquals(rocksDBStorageEngine.getPartitionOffset(PARTITION_ID).isPresent(), false);
+    assertNull(rocksDBStorageEngine.getPartitionOffset(PARTITION_ID));
   }
 
   private ProducerPartitionState createProducerPartitionState(int segment, int sequence) {

--- a/services/venice-server/src/main/java/com/linkedin/venice/server/VeniceServer.java
+++ b/services/venice-server/src/main/java/com/linkedin/venice/server/VeniceServer.java
@@ -327,8 +327,9 @@ public class VeniceServer {
         storeVersionStateSerializer,
         partitionStateSerializer,
         metadataRepo);
-    storageEngineMetadataService =
-        new StorageEngineMetadataService(storageService.getStorageEngineRepository(), partitionStateSerializer);
+    storageEngineMetadataService = new StorageEngineMetadataService(
+        storageService.getStorageEngineRepository()::getCheckpointStorageEngine,
+        partitionStateSerializer);
     services.add(storageEngineMetadataService);
     storageMetadataService = storageEngineMetadataService;
     services.add(storageService);


### PR DESCRIPTION
This PR simply adds a getStorageMetadataService API to DVRT, with a default implementation returning null. If the SIT gets null from DVRT, then nothing changes compared to today. If it gets a non-null instance, then read/write operations for OffsetRecord and StoreVersionState will go through the DVRT SMS instance, rather than the regular one.

This will allow DVRT to implement checkpointing. In the case of DuckDB, it means that the DuckDB file will be able to contain the checkpointing, and the RocksDB metadata partition will be empty.


## How was this PR tested?
N/A
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.