### PR TITLE
[controller] Dual write push job details to both parent and child region

### DIFF
--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/PushJobDetailsTest.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/PushJobDetailsTest.java
@@ -321,7 +321,7 @@ public class PushJobDetailsTest {
     }
   }
 
-  @Test(dataProvider = "Two-True-and-False", dataProviderClass = DataProviderUtils.class, timeOut = 300
+  @Test(dataProvider = "Two-True-and-False", dataProviderClass = DataProviderUtils.class, timeOut = 180
       * Time.MS_PER_SECOND)
   public void testPushJobDetails(boolean useCustomCheckpoints, boolean migratePushStatusStoreToAA) throws IOException {
     try {

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceHelixAdmin.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceHelixAdmin.java
@@ -180,6 +180,7 @@ import com.linkedin.venice.schema.rmd.RmdSchemaEntry;
 import com.linkedin.venice.schema.writecompute.DerivedSchemaEntry;
 import com.linkedin.venice.security.SSLFactory;
 import com.linkedin.venice.serialization.avro.AvroProtocolDefinition;
+import com.linkedin.venice.serialization.avro.InternalAvroSpecificSerializer;
 import com.linkedin.venice.serialization.avro.VeniceAvroKafkaSerializer;
 import com.linkedin.venice.serializer.AvroSerializer;
 import com.linkedin.venice.serializer.RecordDeserializer;
@@ -346,6 +347,8 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
   protected static final long INTERNAL_STORE_RTT_RETRY_BACKOFF_MS = TimeUnit.SECONDS.toMillis(5);
   private static final int PARTICIPANT_MESSAGE_STORE_SCHEMA_ID = 1;
   private static final long PUSH_STATUS_STORE_WRITER_TIMEOUT_MS = TimeUnit.SECONDS.toMillis(30);
+  private final InternalAvroSpecificSerializer<PushJobDetails> pushJobDetailsSerializer =
+      AvroProtocolDefinition.PUSH_JOB_DETAILS.getSerializer();
 
   static final int VERSION_ID_UNSET = -1;
 
@@ -1292,10 +1295,40 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
    */
   @Override
   public void sendPushJobDetails(PushJobStatusRecordKey key, PushJobDetails value) {
+    sendPushJobDetailsToLocalRT(key, value);
+    if (isParent()) {
+      String lastDualWriteError = "";
+      for (Map.Entry<String, ControllerClient> entry: getControllerClientMap(getPushJobStatusStoreClusterName())
+          .entrySet()) {
+        LOGGER.info("Sending push job details: {} to region: {} for: {}", value, entry.getKey(), key);
+        ControllerResponse response = entry.getValue()
+            .sendPushJobDetails(
+                key.storeName.toString(),
+                key.versionNumber,
+                getPushJobDetailsSerializer().serialize(null, value));
+        if (response.isError()) {
+          LOGGER.error(
+              "Unable to send push job details to region: {}, for key: {}, value: {} for error: {}",
+              entry.getKey(),
+              key,
+              value,
+              response.getError());
+          lastDualWriteError = response.getError();
+        } else {
+          // When A/A is enabled, we only need to write to one child region and it will be replicated to all regions.
+          return;
+        }
+      }
+      throw new VeniceException(
+          "Unable to dual write push job details to any child region with last error:" + lastDualWriteError);
+    }
+  }
+
+  void sendPushJobDetailsToLocalRT(PushJobStatusRecordKey key, PushJobDetails value) {
     // Emit push job status metrics
     emitPushJobStatusMetrics(pushJobStatusStatsMap, key, value, pushJobUserErrorCheckpoints);
     // Send push job details to the push job status system store
-    if (pushJobStatusStoreClusterName.isEmpty()) {
+    if (getPushJobStatusStoreClusterName().isEmpty()) {
       throw new VeniceException(
           ("Unable to send the push job details because " + ConfigKeys.PUSH_JOB_STATUS_STORE_CLUSTER_NAME)
               + " is not configured");
@@ -8776,5 +8809,13 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
   @Override
   public PubSubTopicRepository getPubSubTopicRepository() {
     return pubSubTopicRepository;
+  }
+
+  String getPushJobStatusStoreClusterName() {
+    return pushJobStatusStoreClusterName;
+  }
+
+  InternalAvroSpecificSerializer<PushJobDetails> getPushJobDetailsSerializer() {
+    return pushJobDetailsSerializer;
   }
 }

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceParentHelixAdmin.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceParentHelixAdmin.java
@@ -494,7 +494,6 @@ public class VeniceParentHelixAdmin implements Admin {
     boolean initializePushJobDetailsStore = !StringUtils.isEmpty(pushJobDetailsStoreClusterName);
     if (initRoutineForPushJobDetailsSystemStore != null) {
       if (initializePushJobDetailsStore) {
-        // TODO: When we plan to enable active-active push details store in future, we need to enable it by default.
         UpdateStoreQueryParams updateStoreQueryParamsForPushJobDetails =
             new UpdateStoreQueryParams().setHybridDataReplicationPolicy(DataReplicationPolicy.AGGREGATE);
         initRoutineForPushJobDetailsSystemStore.setDelegate(

--- a/services/venice-controller/src/test/java/com/linkedin/venice/controller/TestVeniceParentHelixAdmin.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/controller/TestVeniceParentHelixAdmin.java
@@ -8,6 +8,7 @@ import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.anyBoolean;
 import static org.mockito.Mockito.anyInt;
 import static org.mockito.Mockito.anyString;
+import static org.mockito.Mockito.atLeast;
 import static org.mockito.Mockito.doCallRealMethod;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;
@@ -84,6 +85,9 @@ import com.linkedin.venice.pushmonitor.StatusSnapshot;
 import com.linkedin.venice.schema.GeneratedSchemaID;
 import com.linkedin.venice.schema.avro.DirectionalSchemaCompatibilityType;
 import com.linkedin.venice.serialization.avro.AvroProtocolDefinition;
+import com.linkedin.venice.serialization.avro.InternalAvroSpecificSerializer;
+import com.linkedin.venice.status.protocol.PushJobDetails;
+import com.linkedin.venice.status.protocol.PushJobStatusRecordKey;
 import com.linkedin.venice.utils.DataProviderUtils;
 import com.linkedin.venice.utils.Pair;
 import com.linkedin.venice.utils.SystemTime;
@@ -130,6 +134,36 @@ public class TestVeniceParentHelixAdmin extends AbstractTestVeniceParentHelixAdm
   @AfterMethod
   public void cleanupTestCase() {
     super.cleanupTestCase();
+  }
+
+  @Test
+  public void testDualWriteSendPushJobDetails() {
+    parentAdmin.initStorageCluster(clusterName);
+    PushJobStatusRecordKey key = new PushJobStatusRecordKey();
+    key.versionNumber = 1;
+    key.storeName = "abc";
+    PushJobDetails value = new PushJobDetails();
+    doCallRealMethod().when(internalAdmin).sendPushJobDetails(any(), any());
+    ControllerClient controllerClient = mock(ControllerClient.class);
+    ControllerResponse controllerResponse = mock(ControllerResponse.class);
+    when(controllerResponse.isError()).thenReturn(false);
+    doReturn(controllerResponse).when(controllerClient).sendPushJobDetails(anyString(), anyInt(), any(byte[].class));
+    Assert.assertNotNull(controllerClient.sendPushJobDetails("abc", 1, "abc".getBytes()));
+    Map<String, ControllerClient> controllerClientMap = new HashMap<>();
+    controllerClientMap.put("test-region", controllerClient);
+    doReturn(controllerClientMap).when(internalAdmin).getControllerClientMap(anyString());
+    doReturn(true).when(internalAdmin).isParent();
+    InternalAvroSpecificSerializer<PushJobDetails> pushJobDetailsInternalAvroSpecificSerializer =
+        mock(InternalAvroSpecificSerializer.class);
+    doReturn("abc".getBytes()).when(pushJobDetailsInternalAvroSpecificSerializer).serialize(any(), any());
+    doReturn(pushJobDetailsInternalAvroSpecificSerializer).when(internalAdmin).getPushJobDetailsSerializer();
+    doReturn("test-cluster").when(internalAdmin).getPushJobStatusStoreClusterName();
+    parentAdmin.sendPushJobDetails(key, value);
+    verify(internalAdmin, atLeast(1)).sendPushJobDetails(key, value);
+    verify(internalAdmin, atLeast(1)).sendPushJobDetailsToLocalRT(any(), any());
+    verify(controllerClient, atLeast(1)).sendPushJobDetails(anyString(), anyInt(), any());
+    doReturn(controllerClients).when(internalAdmin).getControllerClientMap(any());
+
   }
 
   @Test


### PR DESCRIPTION
<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## [controller] Dual write push job details to both parent and child region
Add a dual write to child region for push job details, so when the system store is converted to A/A it will still be able to consume the updates.

The hard-coding of AGG mode in system store initialization routine will not be changed, as it will only kick in if no such store is found. We will update this after second phase when we remove the parent RT write.
## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
Added new unit test and new integration test
## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.