### PR TITLE
[venice-thin-client] Avoid using common thread pool for store client warming up.

### DIFF
--- a/clients/venice-thin-client/src/main/java/com/linkedin/venice/client/store/AbstractAvroStoreClient.java
+++ b/clients/venice-thin-client/src/main/java/com/linkedin/venice/client/store/AbstractAvroStoreClient.java
@@ -75,8 +75,7 @@ public abstract class AbstractAvroStoreClient<K, V> extends InternalAvroStoreCli
   private RecordDeserializer<StreamingFooterRecordV1> streamingFooterRecordDeserializer;
   private TransportClient transportClient;
   private final Executor deserializationExecutor;
-  private final Executor veniceClientWarmUpExecutor =
-      Executors.newFixedThreadPool(1, new DaemonThreadFactory("Venice-Client-Warmup"));
+  private final Executor veniceClientWarmUpExecutor;
   private final CompressorFactory compressorFactory;
   private final String storageRequestPath;
   private final String computeRequestPath;
@@ -134,6 +133,8 @@ public abstract class AbstractAvroStoreClient<K, V> extends InternalAvroStoreCli
     this.compressorFactory = new CompressorFactory();
     this.storageRequestPath = TYPE_STORAGE + "/" + clientConfig.getStoreName();
     this.computeRequestPath = TYPE_COMPUTE + "/" + clientConfig.getStoreName();
+    this.veniceClientWarmUpExecutor = Executors
+        .newFixedThreadPool(1, new DaemonThreadFactory("Venice-Client-Warmup-For-" + clientConfig.getStoreName()));
   }
 
   @Override

--- a/clients/venice-thin-client/src/main/java/com/linkedin/venice/client/store/AbstractAvroStoreClient.java
+++ b/clients/venice-thin-client/src/main/java/com/linkedin/venice/client/store/AbstractAvroStoreClient.java
@@ -75,6 +75,8 @@ public abstract class AbstractAvroStoreClient<K, V> extends InternalAvroStoreCli
   private RecordDeserializer<StreamingFooterRecordV1> streamingFooterRecordDeserializer;
   private TransportClient transportClient;
   private final Executor deserializationExecutor;
+  private final Executor veniceClientWarmUpExecutor =
+      Executors.newFixedThreadPool(1, new DaemonThreadFactory("Venice-Client-Warmup"));
   private final CompressorFactory compressorFactory;
   private final String storageRequestPath;
   private final String computeRequestPath;
@@ -714,7 +716,7 @@ public abstract class AbstractAvroStoreClient<K, V> extends InternalAvroStoreCli
          * If the D2 client isn't retry in the async warm-up phase, it will be delayed to the first query.
          * Essentially, this is a best-effort.
          */
-        CompletableFuture.runAsync(this::getKeySerializerWithRetryWithLongInterval);
+        CompletableFuture.runAsync(this::getKeySerializerWithRetryWithLongInterval, veniceClientWarmUpExecutor);
       }
     }
   }


### PR DESCRIPTION
<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## Summary, imperative, start upper case, don't end with a period
<!--
Describe
- What changes to make and why you are making these changes.
- How are you going to achieve your goal.
- Describe what testings you have done, for example, performance testing etc.

If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

The `venice-thin-client` utilizes the ForkJoinPool common pool, which can cause spurious timeouts during application startup, potentially resulting in startup failures. The recommended solution is to use a different thread pool to mitigate contention issues. Here we adopt a single thread pool for warm-up logic. 

## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [ ] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.