### PR TITLE
[controller] Fix regression in ACL handling for non-secure admin server

### DIFF
--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceController.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceController.java
@@ -206,7 +206,7 @@ public class VeniceController {
         secure || multiClusterConfigs.isControllerEnforceSSLOnly(),
         secure ? multiClusterConfigs.getSslConfig() : Optional.empty(),
         secure && multiClusterConfigs.adminCheckReadMethodForKafka(),
-        accessController,
+        secure ? accessController : Optional.empty(),
         multiClusterConfigs.getDisabledRoutes(),
         multiClusterConfigs.getCommonConfig().getJettyConfigOverrides(),
         multiClusterConfigs.getCommonConfig().isDisableParentRequestTopicForStreamPushes(),

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/server/AbstractRoute.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/server/AbstractRoute.java
@@ -6,6 +6,7 @@ import static com.linkedin.venice.controllerapi.ControllerApiConstants.NAME;
 
 import com.linkedin.venice.acl.AclException;
 import com.linkedin.venice.acl.DynamicAccessController;
+import com.linkedin.venice.acl.NoOpDynamicAccessController;
 import com.linkedin.venice.exceptions.VeniceException;
 import java.security.cert.X509Certificate;
 import java.util.Optional;
@@ -164,7 +165,7 @@ public class AbstractRoute {
     /**
      * {@link accessController} will be empty if ACL is not enabled.
      */
-    return accessController.isPresent();
+    return accessController.isPresent() && !(accessController.get() instanceof NoOpDynamicAccessController);
   }
 
   /**


### PR DESCRIPTION
## Do not pass DynamicAccessController when using non-secure channel


VeniceController refactoring, where the DynamicAccessController (DAC) was inadvertently passed to the  
Admin Server even when SSL was disabled. The presence of a DAC was incorrectly interpreted as ACL  
checks being enabled, causing the Admin Server to enforce ACLs on both secure and non-secure  
channels. This happened because a valid DAC was applied universally to both secure and non-secure  
admin servers.  

The fix ensures that the DynamicAccessController is no longer passed to the Admin Server when using  
a non-secure channel. Additionally, when the NoOpDynamicAccessController is set, it is now explicitly  
treated as a signal that ACL checks are disabled for HTTP requests in the controller. These changes  
restore the expected behavior.  


## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
CI

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.