### PR TITLE
[protocol] Add KafkaMessageEnvelope schema v12 to replace long offsets with PubSubPosition

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -4,7 +4,7 @@ Add a list of affected components in the PR title in the following format:
 
 Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
 [vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
-[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat]
+[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat], [protocol]
 
 Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine
 

--- a/build.gradle
+++ b/build.gradle
@@ -314,7 +314,8 @@ subprojects {
     doFirst {
       def versionOverrides = [
 //        project(':internal:venice-common').file('src/main/resources/avro/StoreVersionState/v5', PathValidation.DIRECTORY)
-        project(':internal:venice-common').file('src/main/resources/avro/PartitionState/v15', PathValidation.DIRECTORY)
+        project(':internal:venice-common').file('src/main/resources/avro/PartitionState/v15', PathValidation.DIRECTORY),
+        project(':internal:venice-common').file('src/main/resources/avro/KafkaMessageEnvelope/v11', PathValidation.DIRECTORY)
       ]
 
       def schemaDirs = [sourceDir]

--- a/docs/dev_guide/how_to/recommended_development_workflow.md
+++ b/docs/dev_guide/how_to/recommended_development_workflow.md
@@ -33,7 +33,7 @@ The GitHub issue should contain the detailed problem statement.
 6. The PR title should usually be of the form `[component1]...[componentN]: Concise commit message`.
    * Valid tags are: `[da-vinci]` (or `[dvc]`), `[server]`, `[controller]`, `[router]`, `[samza]`,
       `[vpj]`, `[fast-client]` (or `[fc]`), `[thin-client]` (or `[tc]`), `[changelog]` (or `[cc]`),
-      `[producer]`, `[admin-tool]`, `[test]`, `[build]`, `[doc]`, `[script]`, `[compat]`
+      `[producer]`, `[admin-tool]`, `[test]`, `[build]`, `[doc]`, `[script]`, `[compat]`, `[protocol]`
    * `[compat]` tag means there are compatibility related changes in this PR, including upgrading protocol version, upgrading system store value schemas, etc. When there is a compatibility related change, it usually requires a specific deployment order, like upgrading controller before upgrading server. In this case, please explicitly call out the required deployment order in the commit message.
 7. If the pull request is still a work in progress, and so is not ready to be merged, but needs to be pushed to GitHub to facilitate review,
     then create the PR as a [draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests#draft-pull-requests) PR

--- a/internal/venice-common/src/main/resources/avro/KafkaMessageEnvelope/v12/KafkaMessageEnvelope.avsc
+++ b/internal/venice-common/src/main/resources/avro/KafkaMessageEnvelope/v12/KafkaMessageEnvelope.avsc
@@ -1,0 +1,371 @@
+{
+  "name": "KafkaMessageEnvelope",
+  "namespace": "com.linkedin.venice.kafka.protocol",
+  "type": "record",
+  "fields": [
+    {
+      "name": "messageType",
+      "doc": "Using int because Avro Enums are not evolvable. Readers should always handle the 'unknown' value edge case, to account for future evolutions of this protocol. The mapping is the following: 0 => Put, 1 => Delete, 2 => ControlMessage, 3 => Update.",
+      "type": "int"
+    }, {
+      "name": "producerMetadata",
+      "doc": "ProducerMetadata contains information that the consumer can use to identify an upstream producer. This is common for all MessageType.",
+      "type": {
+        "name": "ProducerMetadata",
+        "type": "record",
+        "fields": [
+          {
+            "name": "producerGUID",
+            "doc": "A unique identifier for this producer.",
+            "type": {
+              "name": "GUID",
+              "type": "fixed",
+              "size": 16
+            }
+          }, {
+            "name": "segmentNumber",
+            "doc": "A number used to disambiguate between sequential segments sent into a given partition by a given producer. An incremented SegmentNumber should only be sent following an EndOfSegment control message. For finite streams (such as those bulk-loaded from Hadoop), it can be acceptable to have a single SegmentNumber per producer/partition combination, though that is not something that the downstream consumer should assume. For infinite streams, segments should be terminated and begun anew periodically. This number begins at 0.",
+            "type": "int"
+          }, {
+            "name": "messageSequenceNumber",
+            "doc": "A monotonically increasing number with no gaps used to distinguish unique messages produced in this segment (i.e.: by this producer into a given partition). This number begins at 0 (with a StartOfSegment ControlMessage) and subsequent messages (such as Put) will have a SequenceNumber of 1 and so forth.",
+            "type": "int"
+          }, {
+            "name": "messageTimestamp",
+            "doc": "The time of the producer's local system clock, at the time the message was submitted for production. This is the number of milliseconds from the unix epoch, 1 January 1970 00:00:00.000 UTC.",
+            "type": "long"
+          }, {
+            "name": "logicalTimestamp",
+            "doc": "This timestamp may be specified by the user. Sentinel value of -1 => apps are not using latest lib, -2 => apps have not specified the time. In case of negative values messageTimestamp field will be used for replication metadata.",
+            "type": "long",
+            "default": -1
+          }
+        ]
+      }
+    }, {
+      "name": "payloadUnion",
+      "doc": "This contains the main payload of the message. Which branch of the union is present is based on the previously-defined MessageType field.",
+      "type": [
+        {
+          "name": "Put",
+          "doc": "Put payloads contain a record value, and information on how to deserialize it.",
+          "type": "record",
+          "fields": [
+            {
+              "name": "putValue",
+              "doc": "The record's value to be persisted in the storage engine.",
+              "type": "bytes"
+            }, {
+              "name": "schemaId",
+              "doc": "An identifier used to determine how the PutValue can be deserialized. Also used, in conjunction with the replicationMetadataVersionId, to deserialize the replicationMetadataPayload.",
+              "type": "int"
+            }, {
+              "name": "replicationMetadataVersionId",
+              "doc": "The A/A replication metadata schema version ID that will be used to deserialize replicationMetadataPayload.",
+              "type": "int",
+              "default": -1
+            }, {
+              "name": "replicationMetadataPayload",
+              "doc": "The serialized value of the replication metadata schema.",
+              "type": "bytes",
+              "default": ""
+            }
+          ]
+        }, {
+          "name": "Update",
+          "doc": "Partial update operation, which merges the update value with the existing value.",
+          "type": "record",
+          "fields": [
+            {
+              "name": "schemaId",
+              "doc": "The original schema ID.",
+              "type": "int"
+            }, {
+              "name": "updateSchemaId",
+              "doc": "The derived schema ID that will be used to deserialize updateValue.",
+              "type": "int"
+            }, {
+              "name": "updateValue",
+              "doc": "New value(s) for parts of the record that need to be updated.",
+              "type": "bytes"
+            }
+          ]
+        }, {
+          "name": "Delete",
+          "doc": "Delete payloads contain fields related to replication metadata of the record.",
+          "type": "record",
+          "fields": [
+            {
+              "name": "schemaId",
+              "doc": "An identifier used, in conjunction with the replicationMetadataVersionId, to deserialize the replicationMetadataPayload.",
+              "type": "int",
+              "default": -1
+            }, {
+              "name": "replicationMetadataVersionId",
+              "doc": "The A/A replication metadata schema version ID that will be used to deserialize replicationMetadataPayload.",
+              "type": "int",
+              "default": -1
+            }, {
+              "name": "replicationMetadataPayload",
+              "doc": "The serialized value of the replication metadata schema.",
+              "type": "bytes",
+              "default": ""
+            }
+          ]
+        }, {
+          "name": "ControlMessage",
+          "doc": "ControlMessage payloads contain metadata about the stream of data, for validation and debuggability purposes.",
+          "type": "record",
+          "fields": [
+            {
+              "name": "controlMessageType",
+              "doc": "Using int because Avro Enums are not evolvable. Readers should always handle the 'unknown' value edge case, to account for future evolutions of this protocol. The mapping is the following: 0 => StartOfPush, 1 => EndOfPush, 2 => StartOfSegment, 3 => EndOfSegment, 4 => StartOfBufferReplay (Deprecated), 5 => StartOfIncrementalPush, 6 => EndOfIncrementalPush, 7 => TopicSwitch, 8 => VersionSwap",
+              "type": "int"
+            }, {
+              "name": "debugInfo",
+              "doc": "This metadata is for logging and traceability purposes. It can be used to propagate information about the producer, the environment it runs in, or the source of data being produced into Venice. There should be no assumptions that any of this data will be used (or even looked at) by the downstream consumer in any particular way.",
+              "type": {
+                "type": "map",
+                "values": "string"
+              }
+            }, {
+              "name": "controlMessageUnion",
+              "doc": "This contains the ControlMessage data which is specific to each type of ControlMessage. Which branch of the union is present is based on the previously-defined MessageType field.",
+              "type": [
+                {
+                  "name": "StartOfPush",
+                  "doc": "This ControlMessage is sent once per partition, at the beginning of a bulk load, before any of the data producers come online. This does not contain any data beyond the one which is common to all ControlMessageType.",
+                  "type": "record",
+                  "fields": [
+                    {
+                      "name": "sorted",
+                      "doc": "Whether the messages inside current topic partition between 'StartOfPush' control message and 'EndOfPush' control message is lexicographically sorted by key bytes",
+                      "type": "boolean",
+                      "default": false
+                    }, {
+                      "name": "chunked",
+                      "doc": "Whether the messages inside the current push are encoded with chunking support. If true, this means keys will be prefixed with ChunkId, and values may contain a ChunkedValueManifest (if schema is defined as -20).",
+                      "type": "boolean",
+                      "default": false
+                    }, {
+                      "name": "compressionStrategy",
+                      "doc": "What type of compression strategy the current push uses. Using int because Avro Enums are not evolvable. The mapping is the following: 0 => NO_OP, 1 => GZIP, 2 => ZSTD, 3 => ZSTD_WITH_DICT",
+                      "type": "int",
+                      "default": 0
+                    }, {
+                      "name": "compressionDictionary",
+                      "doc": "The raw bytes of dictionary used to compress/decompress records.",
+                      "type": ["null", "bytes"],
+                      "default": null
+                    }, {
+                      "name": "timestampPolicy",
+                      "doc": "The policy to determine timestamps of batch push records. 0 => no per record replication metadata is stored, hybrid writes always win over batch, 1 => no per record timestamp metadata is stored, Start-Of-Push Control message's logicalTimestamp is treated as last update timestamp for all batch record, and hybrid writes wins only when their own logicalTimestamp are higher, 2 => per record timestamp metadata is provided by the push job and stored for each key, enabling full conflict resolution granularity on a per field basis, just like when merging concurrent update operations.",
+                      "type": "int",
+                      "default": 0
+                    }
+                  ]
+                }, {
+                  "name": "EndOfPush",
+                  "doc": "This ControlMessage is sent once per partition, at the end of a bulk load, after all of the data producers come online. This does not contain any data beyond the one which is common to all ControlMessageType.",
+                  "type": "record",
+                  "fields": []
+                }, {
+                  "name": "StartOfSegment",
+                  "doc": "This ControlMessage is sent at least once per partition per producer. It may be sent more than once per partition/producer, but only after the producer has sent an EndOfSegment into that partition to terminate the previously started segment.",
+                  "type": "record",
+                  "fields": [
+                    {
+                      "name": "checksumType",
+                      "doc": "Using int because Avro Enums are not evolvable. Readers should always handle the 'unknown' value edge case, to account for future evolutions of this protocol. The downstream consumer is expected to compute this checksum and use it to validate the incoming stream of data. The current mapping is the following: 0 => None, 1 => MD5, 2 => Adler32, 3 => CRC32.",
+                      "type": "int"
+                    }, {
+                      "name": "upcomingAggregates",
+                      "doc": "An array of names of aggregate computation strategies for which there will be a value percolated in the corresponding EndOfSegment ControlMessage. The downstream consumer may choose to compute these aggregates on its own and use them as additional validation safeguards, or it may choose to merely log them, or even ignore them altogether.",
+                      "type": {
+                        "type": "array",
+                        "items": "string"
+                      }
+                    }
+                  ]
+                }, {
+                  "name": "EndOfSegment",
+                  "doc": "This ControlMessage is sent at least once per partition per producer. It may be sent more than once per partition/producer, but only after the producer has sent a StartOfSegment into that partition. There should be an equal number of StartOfSegment and EndOfSegment messages in each producer/partition pair.",
+                  "type": "record",
+                  "fields": [
+                    {
+                      "name": "checksumValue",
+                      "doc": "The value of the checksum computed since the last StartOfSegment ControlMessage.",
+                      "type": "bytes"
+                    }, {
+                      "name": "computedAggregates",
+                      "doc": "A map containing the results of the aggregate computation strategies that were promised in the previous StartOfSegment ControlMessage. The downstream consumer may choose to compare the value of these aggregates against those that it computed on its own ir oder to use them as additional validation safeguards, or it may choose to merely log them, or even ignore them altogether.",
+                      "type": {
+                        "type": "array",
+                        "items": "long"
+                      }
+                    }, {
+                      "name": "finalSegment",
+                      "doc": "This field is set to true when the producer knows that there is no more data coming from its data source after this EndOfSegment. This happens at the time the producer is closed.",
+                      "type": "boolean"
+                    }
+                  ]
+                }, {
+                  "name": "StartOfBufferReplay",
+                  "doc": "[Deprecated] This ControlMessage is sent by the Controller, once per partition, after the EndOfPush ControlMessage, in Hybrid Stores that ingest from both offline and nearline sources. It contains information about the the offsets from which the Buffer Replay Service started replaying data from the real-time buffer topic onto the store-version topic. This can be used as a synchronization marker between the real-time buffer topic and the store-version topic, akin to how a clapperboard is used to synchronize sound and image in filmmaking. This synchronization marker can in turn be used by the consumer to compute an offset lag.",
+                  "type": "record",
+                  "fields": [
+                    {
+                      "name": "sourceOffsets",
+                      "doc": "Array of offsets from the real-time buffer topic at which the Buffer Replay Service started replaying data. The index position of the array corresponds to the partition number in the real-time buffer.",
+                      "type": {
+                        "type": "array",
+                        "items": "long"
+                      }
+                    }, {
+                      "name": "sourceKafkaCluster",
+                      "doc": "Kafka bootstrap servers URL of the cluster where the source buffer exists.",
+                      "type": "string"
+                    }, {
+                      "name": "sourceTopicName",
+                      "doc": "Name of the source buffer topic.",
+                      "type": "string"
+                    }
+                  ]
+                }, {
+                  "name": "StartOfIncrementalPush",
+                  "doc": "This ControlMessage is sent per partition by each offline incremental push job, once per partition, at the beginning of a incremental push.",
+                  "type": "record",
+                  "fields": [
+                    {
+                      "name": "version",
+                      "doc": "The version of current incremental push. Each incremental push is associated with a version. Both 'StartOfIncrementalPush' control message and 'EndOfIncrementalPush' contain version info so they can be paired to each other.",
+                      "type": "string"
+                    }
+                  ]
+                }, {
+                  "name": "EndOfIncrementalPush",
+                  "doc": "This ControlMessage is sent per partition by each offline incremental push job, once per partition, at the end of a incremental push",
+                  "type": "record",
+                  "fields": [
+                    {
+                      "name": "version",
+                      "doc": "The version of current incremental push. Each incremental push is associated with a version. Both 'StartOfIncrementalPush' control message and 'EndOfIncrementalPush' contain version info so they can be paired to each other.",
+                      "type": "string"
+                    }
+                  ]
+                }, {
+                  "name": "TopicSwitch",
+                  "doc": "This ControlMessage is sent by the Controller, once per partition; it will only be used in leader/follower state transition model; this control message will indicate the leader to switch to a new source topic and start consuming from offset with a specific timestamp.",
+                  "type": "record",
+                  "fields": [
+                    {
+                      "name": "sourceKafkaServers",
+                      "doc": "A list of Kafka bootstrap servers URLs where the new source topic exists; currently there will be only one URL in the list, but the list opens up the possibility for leader to consume from different fabrics in active-active replication mode.",
+                      "type": {
+                        "type": "array",
+                        "items": "string"
+                      }
+                    }, {
+                      "name": "sourceTopicName",
+                      "doc": "Name of new the source topic.",
+                      "type": "string"
+                    }, {
+                      "name": "rewindStartTimestamp",
+                      "doc": "The creation time of this control message in parent controller minus the rewind time of the corresponding store; leaders in different fabrics will get the offset of the source topic by the same start timestamp and start consuming from there; if timestamp is 0, leader will start consuming from the beginning of the source topic.",
+                      "type": "long"
+                    }
+                  ]
+                }, {
+                  "name": "VersionSwap",
+                  "doc": "This controlMessage is written to the real-time topic by the controller or to the store-version topic by the current version's leader server. It can be used to let current version and future version synchronize on a specific point for all regions' real-time topics, to guarantee there is only one store version producing to change capture topic all the time. It can also be used by the consumer client to switch to another store-version topic and filter messages that have a lower watermark than the one dictated by the leader.",
+                  "type": "record",
+                  "fields": [
+                    {
+                      "name": "oldServingVersionTopic",
+                      "doc": "Name of the old source topic we are switching from.",
+                      "type": "string"
+                    }, {
+                      "name": "newServingVersionTopic",
+                      "doc": "Name of the new source topic we are switching to.",
+                      "type": "string"
+                    }, {
+                      "name": "localHighWatermarks",
+                      "doc": "The latest offsets of all real-time topic has been consumed up until now.",
+                      "type": [
+                        "null",
+                        {
+                          "type": "array",
+                          "items": "long"
+                        }
+                      ],
+                      "default": null
+                    }, {
+                      "name": "localHighWatermarkPubSubPositions",
+                      "doc": "The latest pubsub positions of all real-time topic has been consumed up until now.",
+                      "type": [
+                        "null",
+                        {
+                          "type": "array",
+                          "items": "bytes"
+                        }
+                      ],
+                      "default": null
+                    }, {
+                      "name": "isRepush",
+                      "doc": "Flag to indicate this version swap is triggered by repush or not.",
+                      "type": "boolean",
+                      "default": false
+                    }, {
+                      "name": "isLastVersionSwapMessageFromRealTimeTopic",
+                      "doc": "Flag to indicate this version swap message in version topic is triggered by the last version swap in real time topic the leader server has received. With this flag, new leader will be able to recover the full state during leadership handover, when we rely on real-time topics for all regions to achieve version swap synchronization.",
+                      "type": "boolean",
+                      "default": false
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }, {
+      "name": "leaderMetadataFooter",
+      "doc": "A optional footer that leader SN can use to give extra L/F related mete data",
+      "type": [
+        "null",
+        {
+          "name": "LeaderMetadata",
+          "type": "record",
+          "fields": [
+            {
+              "name": "hostName",
+              "doc": "The identifier of the host which sends the message.This helps detect the 'split brain' scenario in leader SN. Notice that it is different from GUID. GUID represents the one who produces the message. In 'pass-through' mode, the relaying producer will reuse the same GUID from the upstream message.",
+              "type": "string"
+            }, {
+              "name": "upstreamOffset",
+              "doc": "Where this message is located in RT/GF/remote VT topic. This value will be determined and modified by leader SN at runtime.",
+              "type": "long",
+              "default": -1
+            }, {
+              "name": "upstreamKafkaClusterId",
+              "doc": "Kafka bootstrap server URL of the cluster where RT/GF/remote VT topic exists, represented by an integer to reduce the overhead. This value will be determined and modified by leader SN at runtime.",
+              "type": "int",
+              "default": -1
+            }, {
+              "name": "upstreamPubSubPosition",
+              "doc": "The position of the message in the upstream pubsub system (usually real-time topic).",
+              "type": ["null", "bytes"],
+              "default": null
+            }, {
+              "name": "termId",
+              "doc": "TermId is a unique identifier (usually a Helix message timestamp) for the term in which the message is produced.",
+              "type": "long",
+              "default": -1
+            }
+          ]
+        }
+      ],
+      "default": null
+    }
+  ]
+}

--- a/internal/venice-common/src/main/resources/avro/KafkaMessageEnvelope/v12/KafkaMessageEnvelope.avsc
+++ b/internal/venice-common/src/main/resources/avro/KafkaMessageEnvelope/v12/KafkaMessageEnvelope.avsc
@@ -301,15 +301,12 @@
                       "default": null
                     }, {
                       "name": "localHighWatermarkPubSubPositions",
-                      "doc": "The latest pubsub positions of all real-time topic has been consumed up until now.",
-                      "type": [
-                        "null",
-                        {
-                          "type": "array",
-                          "items": "bytes"
-                        }
-                      ],
-                      "default": null
+                      "doc": "The latest pubsub positions of all real-time topics consumed up until now.",
+                      "type": {
+                        "type": "array",
+                        "items": "bytes"
+                      },
+                      "default": []
                     }, {
                       "name": "isRepush",
                       "doc": "Flag to indicate this version swap is triggered by repush or not.",
@@ -354,8 +351,8 @@
             }, {
               "name": "upstreamPubSubPosition",
               "doc": "The position of the message in the upstream pubsub system (usually real-time topic).",
-              "type": ["null", "bytes"],
-              "default": null
+              "type": "bytes",
+              "default": ""
             }, {
               "name": "termId",
               "doc": "TermId is a unique identifier (usually a Helix message timestamp) for the term in which the message is produced.",


### PR DESCRIPTION
## Add PubSubPosition fields in KafkaMessageEnvelope to replace long offsets

This update introduces a new schema version: `v12` for `KafkaMessageEnvelope` to add fields aimed  
at eventually replacing long-based offsets with `PubSubPosition`. Specifically:
- **`localHighWatermarkPubSubPositions`** is introduced to eventually replace
  `localHighWatermarks`, which stores the latest consumed positions for all real-time topics.
- **`upstreamPubSubPosition`** is introduced to eventually replace `upstreamOffset`, which
  stores the message position in the upstream pubsub system.
  
Misc Addition:
- **`termId`** is introduced to track the unique term in which the message was produced,
  typically using a Helix message timestamp of the leader state transition.

  `termId` is intended to uniquely represent a leader session or term in the replication log.
  In scenarios like split-brain, where multiple writers may exist simultaneously, `termId` will
  help establish a partial order (happens-before relationship) on records. Each replica will
  maintain a `termId` and update it upon becoming the leader, marking the start of a new
  leadership term. The leader will then attach this `termId` to every record it writes to the
  version topic, allowing followers to distinguish between records from the legitimate leader
  and those from outdated or conflicting writers. This mechanism is expected to ensure that
  replicas correctly identify and process only valid records.

```bash
sumane@sumane-mn3406 venice % export VAR1=v11 VAR2=v12
diff internal/venice-common/src/main/resources/avro/KafkaMessageEnvelope/$VAR1/KafkaMessageEnvelope.avsc \
     internal/venice-common/src/main/resources/avro/KafkaMessageEnvelope/$VAR2/KafkaMessageEnvelope.avsc
302a303,310
>                       "name": "localHighWatermarkPubSubPositions",
>                       "doc": "The latest pubsub positions of all real-time topics consumed up until now.",
>                       "type": {
>                         "type": "array",
>                         "items": "bytes"
>                       },
>                       "default": []
>                     }, {
341a350,359
>               "default": -1
>             }, {
>               "name": "upstreamPubSubPosition",
>               "doc": "The position of the message in the upstream pubsub system (usually real-time topic).",
>               "type": "bytes",
>               "default": ""
>             }, {
>               "name": "termId",
>               "doc": "TermId is a unique identifier (usually a Helix message timestamp) for the term in which the message is produced.",
>               "type": "long",

```

## How was this PR tested?
CI

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.