### PR TITLE
[server][controller][vpj] Add PubSubConsumerAdapter::subscribe with PubSubPosition parameter

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/SharedKafkaConsumer.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/SharedKafkaConsumer.java
@@ -3,6 +3,7 @@ package com.linkedin.davinci.kafka.consumer;
 import static com.linkedin.venice.utils.LatencyUtils.getElapsedTimeFromMsToMs;
 
 import com.linkedin.davinci.stats.AggKafkaConsumerServiceStats;
+import com.linkedin.venice.annotation.UnderDevelopment;
 import com.linkedin.venice.exceptions.VeniceException;
 import com.linkedin.venice.kafka.protocol.KafkaMessageEnvelope;
 import com.linkedin.venice.message.KafkaKey;
@@ -128,6 +129,7 @@ class SharedKafkaConsumer implements PubSubConsumerAdapter {
     stats.recordTotalUpdateCurrentAssignmentLatency(getElapsedTimeFromMsToMs(updateCurrentAssignmentStartTime));
   }
 
+  @UnderDevelopment(value = "This API may not be implemented in all PubSubConsumerAdapter implementations.")
   @Override
   public synchronized void subscribe(PubSubTopicPartition pubSubTopicPartition, long lastReadOffset) {
     throw new VeniceException(

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/SharedKafkaConsumer.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/SharedKafkaConsumer.java
@@ -129,15 +129,15 @@ class SharedKafkaConsumer implements PubSubConsumerAdapter {
     stats.recordTotalUpdateCurrentAssignmentLatency(getElapsedTimeFromMsToMs(updateCurrentAssignmentStartTime));
   }
 
-  @UnderDevelopment(value = "This API may not be implemented in all PubSubConsumerAdapter implementations.")
   @Override
   public synchronized void subscribe(PubSubTopicPartition pubSubTopicPartition, long lastReadOffset) {
     throw new VeniceException(
         this.getClass().getSimpleName() + " does not support subscribe without specifying a version-topic.");
   }
 
+  @UnderDevelopment(value = "This API may not be implemented in all PubSubConsumerAdapter implementations.")
   @Override
-  public synchronized void subscribe(PubSubTopicPartition pubSubTopicPartition, PubSubPosition lastReadOffset) {
+  public synchronized void subscribe(PubSubTopicPartition pubSubTopicPartition, PubSubPosition lastReadPubSubPosition) {
     throw new VeniceException(
         this.getClass().getSimpleName() + " does not support subscribe without specifying a version-topic.");
   }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/SharedKafkaConsumer.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/SharedKafkaConsumer.java
@@ -9,6 +9,7 @@ import com.linkedin.venice.message.KafkaKey;
 import com.linkedin.venice.pubsub.PubSubTopicPartitionInfo;
 import com.linkedin.venice.pubsub.api.PubSubConsumerAdapter;
 import com.linkedin.venice.pubsub.api.PubSubMessage;
+import com.linkedin.venice.pubsub.api.PubSubPosition;
 import com.linkedin.venice.pubsub.api.PubSubTopic;
 import com.linkedin.venice.pubsub.api.PubSubTopicPartition;
 import com.linkedin.venice.pubsub.api.exceptions.PubSubUnsubscribedTopicPartitionException;
@@ -129,6 +130,12 @@ class SharedKafkaConsumer implements PubSubConsumerAdapter {
 
   @Override
   public synchronized void subscribe(PubSubTopicPartition pubSubTopicPartition, long lastReadOffset) {
+    throw new VeniceException(
+        this.getClass().getSimpleName() + " does not support subscribe without specifying a version-topic.");
+  }
+
+  @Override
+  public synchronized void subscribe(PubSubTopicPartition pubSubTopicPartition, PubSubPosition lastReadOffset) {
     throw new VeniceException(
         this.getClass().getSimpleName() + " does not support subscribe without specifying a version-topic.");
   }
@@ -344,8 +351,18 @@ class SharedKafkaConsumer implements PubSubConsumerAdapter {
   }
 
   @Override
+  public PubSubPosition getLatestPosition(PubSubTopicPartition pubSubTopicPartition) {
+    return delegate.getLatestPosition(pubSubTopicPartition);
+  }
+
+  @Override
   public Long offsetForTime(PubSubTopicPartition pubSubTopicPartition, long timestamp, Duration timeout) {
     throw new UnsupportedOperationException("offsetForTime is not supported in SharedKafkaConsumer");
+  }
+
+  @Override
+  public PubSubPosition positionForTime(PubSubTopicPartition pubSubTopicPartition, long timestamp, Duration timeout) {
+    throw new UnsupportedOperationException("positionForTime is not supported in SharedKafkaConsumer");
   }
 
   @Override
@@ -354,8 +371,18 @@ class SharedKafkaConsumer implements PubSubConsumerAdapter {
   }
 
   @Override
+  public PubSubPosition positionForTime(PubSubTopicPartition pubSubTopicPartition, long timestamp) {
+    throw new UnsupportedOperationException("positionForTime is not supported in SharedKafkaConsumer");
+  }
+
+  @Override
   public Long beginningOffset(PubSubTopicPartition partition, Duration timeout) {
     throw new UnsupportedOperationException("beginningOffset is not supported in SharedKafkaConsumer");
+  }
+
+  @Override
+  public PubSubPosition beginningPosition(PubSubTopicPartition pubSubTopicPartition, Duration timeout) {
+    throw new UnsupportedOperationException("beginningPosition is not supported in SharedKafkaConsumer");
   }
 
   @Override
@@ -364,8 +391,20 @@ class SharedKafkaConsumer implements PubSubConsumerAdapter {
   }
 
   @Override
+  public Map<PubSubTopicPartition, PubSubPosition> endPositions(
+      Collection<PubSubTopicPartition> partitions,
+      Duration timeout) {
+    throw new UnsupportedOperationException("endPositions is not supported in SharedKafkaConsumer");
+  }
+
+  @Override
   public Long endOffset(PubSubTopicPartition pubSubTopicPartition) {
     throw new UnsupportedOperationException("endOffset is not supported in SharedKafkaConsumer");
+  }
+
+  @Override
+  public PubSubPosition endPosition(PubSubTopicPartition pubSubTopicPartition) {
+    throw new UnsupportedOperationException("endPosition is not supported in SharedKafkaConsumer");
   }
 
   @Override

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/SharedKafkaConsumer.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/SharedKafkaConsumer.java
@@ -351,18 +351,8 @@ class SharedKafkaConsumer implements PubSubConsumerAdapter {
   }
 
   @Override
-  public PubSubPosition getLatestPosition(PubSubTopicPartition pubSubTopicPartition) {
-    return delegate.getLatestPosition(pubSubTopicPartition);
-  }
-
-  @Override
   public Long offsetForTime(PubSubTopicPartition pubSubTopicPartition, long timestamp, Duration timeout) {
     throw new UnsupportedOperationException("offsetForTime is not supported in SharedKafkaConsumer");
-  }
-
-  @Override
-  public PubSubPosition positionForTime(PubSubTopicPartition pubSubTopicPartition, long timestamp, Duration timeout) {
-    throw new UnsupportedOperationException("positionForTime is not supported in SharedKafkaConsumer");
   }
 
   @Override
@@ -371,18 +361,8 @@ class SharedKafkaConsumer implements PubSubConsumerAdapter {
   }
 
   @Override
-  public PubSubPosition positionForTime(PubSubTopicPartition pubSubTopicPartition, long timestamp) {
-    throw new UnsupportedOperationException("positionForTime is not supported in SharedKafkaConsumer");
-  }
-
-  @Override
   public Long beginningOffset(PubSubTopicPartition partition, Duration timeout) {
     throw new UnsupportedOperationException("beginningOffset is not supported in SharedKafkaConsumer");
-  }
-
-  @Override
-  public PubSubPosition beginningPosition(PubSubTopicPartition pubSubTopicPartition, Duration timeout) {
-    throw new UnsupportedOperationException("beginningPosition is not supported in SharedKafkaConsumer");
   }
 
   @Override
@@ -391,20 +371,8 @@ class SharedKafkaConsumer implements PubSubConsumerAdapter {
   }
 
   @Override
-  public Map<PubSubTopicPartition, PubSubPosition> endPositions(
-      Collection<PubSubTopicPartition> partitions,
-      Duration timeout) {
-    throw new UnsupportedOperationException("endPositions is not supported in SharedKafkaConsumer");
-  }
-
-  @Override
   public Long endOffset(PubSubTopicPartition pubSubTopicPartition) {
     throw new UnsupportedOperationException("endOffset is not supported in SharedKafkaConsumer");
-  }
-
-  @Override
-  public PubSubPosition endPosition(PubSubTopicPartition pubSubTopicPartition) {
-    throw new UnsupportedOperationException("endPosition is not supported in SharedKafkaConsumer");
   }
 
   @Override

--- a/gradle/spotbugs/exclude.xml
+++ b/gradle/spotbugs/exclude.xml
@@ -78,6 +78,7 @@
       <Class name="com.linkedin.venice.memory.ClassSizeEstimatorTest"/>
       <Class name="com.linkedin.venice.controller.server.VeniceControllerAccessManagerTest"/>
       <Class name="com.linkedin.venice.sql.SQLUtilsTest"/>
+      <Class name="com.linkedin.venice.pubsub.adapter.kafka.consumer.ApacheKafkaConsumerAdapterTest"/>
     </Or>
   </Match>
   <Match>

--- a/internal/venice-common/src/main/java/com/linkedin/venice/annotation/UnderDevelopment.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/annotation/UnderDevelopment.java
@@ -1,0 +1,20 @@
+package com.linkedin.venice.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+
+/**
+ * Indicates that an API (class, method, or field) is under development and is not yet stable.
+ * This annotation warns users that the annotated element may change or be removed in future versions.
+ */
+@Retention(RetentionPolicy.CLASS) // Retained in class files but not available at runtime.
+@Target({ ElementType.METHOD, ElementType.CONSTRUCTOR, ElementType.TYPE, ElementType.FIELD })
+public @interface UnderDevelopment {
+  /**
+   * An optional message providing additional details about the development status.
+   */
+  String value() default "";
+}

--- a/internal/venice-common/src/main/java/com/linkedin/venice/annotation/VisibleForTesting.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/annotation/VisibleForTesting.java
@@ -1,0 +1,18 @@
+package com.linkedin.venice.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+
+/**
+ * Indicates that a method, class, or field is more visible than otherwise necessary
+ * for the purpose of testing. This is useful for documenting code and communicating
+ * that a specific visibility level (e.g., `public` or `protected`) is intentional
+ * for testing purposes.
+ */
+@Retention(RetentionPolicy.CLASS) // Retained in class files but not available at runtime.
+@Target({ ElementType.METHOD, ElementType.CONSTRUCTOR, ElementType.TYPE, ElementType.FIELD })
+public @interface VisibleForTesting {
+}

--- a/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/adapter/kafka/consumer/ApacheKafkaConsumerAdapter.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/adapter/kafka/consumer/ApacheKafkaConsumerAdapter.java
@@ -419,22 +419,6 @@ public class ApacheKafkaConsumerAdapter implements PubSubConsumerAdapter {
   }
 
   /**
-   * Returns the latest position for the given topic-partition. The latest offsets are derived from the lag metric
-   * and may be outdated or imprecise.
-   *
-   * @param pubSubTopicPartition the topic-partition for which the latest position is requested
-   * @return the latest position as a {@link PubSubPosition}, or {@link PubSubPosition#LATEST} if tracking is unavailable
-   */
-  @Override
-  public PubSubPosition getLatestPosition(PubSubTopicPartition pubSubTopicPartition) {
-    return topicPartitionsOffsetsTracker != null
-        ? new ApacheKafkaOffsetPosition(
-            topicPartitionsOffsetsTracker
-                .getEndOffset(pubSubTopicPartition.getTopicName(), pubSubTopicPartition.getPartitionNumber()))
-        : PubSubPosition.LATEST;
-  }
-
-  /**
    * @return get the offset of the first message with timestamp greater than or equal to the target timestamp.
    *          {@code null} will be returned for the partition if there is no such message.
    */
@@ -467,11 +451,6 @@ public class ApacheKafkaConsumerAdapter implements PubSubConsumerAdapter {
   }
 
   @Override
-  public PubSubPosition positionForTime(PubSubTopicPartition pubSubTopicPartition, long timestamp, Duration timeout) {
-    throw new UnsupportedOperationException("positionForTime is not supported in Apache Kafka consumer");
-  }
-
-  @Override
   public Long offsetForTime(PubSubTopicPartition pubSubTopicPartition, long timestamp) {
     try {
       TopicPartition topicPartition = new TopicPartition(
@@ -499,11 +478,6 @@ public class ApacheKafkaConsumerAdapter implements PubSubConsumerAdapter {
   }
 
   @Override
-  public PubSubPosition positionForTime(PubSubTopicPartition pubSubTopicPartition, long timestamp) {
-    return null;
-  }
-
-  @Override
   public Long beginningOffset(PubSubTopicPartition pubSubTopicPartition, Duration timeout) {
     TopicPartition kafkaTp =
         new TopicPartition(pubSubTopicPartition.getPubSubTopic().getName(), pubSubTopicPartition.getPartitionNumber());
@@ -514,11 +488,6 @@ public class ApacheKafkaConsumerAdapter implements PubSubConsumerAdapter {
     } catch (Exception e) {
       throw new PubSubClientException("Exception while getting beginning offset for " + kafkaTp, e);
     }
-  }
-
-  @Override
-  public PubSubPosition beginningPosition(PubSubTopicPartition pubSubTopicPartition, Duration timeout) {
-    return null;
   }
 
   @Override
@@ -547,13 +516,6 @@ public class ApacheKafkaConsumerAdapter implements PubSubConsumerAdapter {
   }
 
   @Override
-  public Map<PubSubTopicPartition, PubSubPosition> endPositions(
-      Collection<PubSubTopicPartition> partitions,
-      Duration timeout) {
-    throw new UnsupportedOperationException("endPositions is not supported in Apache Kafka consumer");
-  }
-
-  @Override
   public Long endOffset(PubSubTopicPartition pubSubTopicPartition) {
     try {
       TopicPartition topicPartition = new TopicPartition(
@@ -571,11 +533,6 @@ public class ApacheKafkaConsumerAdapter implements PubSubConsumerAdapter {
     } catch (Exception e) {
       throw new PubSubClientException("Failed to fetch end offset for " + pubSubTopicPartition, e);
     }
-  }
-
-  @Override
-  public PubSubPosition endPosition(PubSubTopicPartition pubSubTopicPartition) {
-    return null;
   }
 
   /**

--- a/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/adapter/kafka/consumer/ApacheKafkaConsumerAdapter.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/adapter/kafka/consumer/ApacheKafkaConsumerAdapter.java
@@ -174,9 +174,6 @@ public class ApacheKafkaConsumerAdapter implements PubSubConsumerAdapter {
     }
     assignments.put(topicPartition, pubSubTopicPartition);
     LOGGER.info("Subscribed to topic-partition: {} from position: {}", pubSubTopicPartition, logMessage);
-
-    assignments.put(topicPartition, pubSubTopicPartition);
-    LOGGER.info("Subscribed to topic-partition: {} from position: {}", pubSubTopicPartition, lastReadPubSubPosition);
   }
 
   private TopicPartition toKafkaTopicPartition(PubSubTopicPartition topicPartition) {

--- a/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/adapter/kafka/consumer/ApacheKafkaConsumerAdapter.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/adapter/kafka/consumer/ApacheKafkaConsumerAdapter.java
@@ -5,11 +5,13 @@ import com.linkedin.venice.kafka.protocol.KafkaMessageEnvelope;
 import com.linkedin.venice.message.KafkaKey;
 import com.linkedin.venice.offsets.OffsetRecord;
 import com.linkedin.venice.pubsub.PubSubTopicPartitionInfo;
+import com.linkedin.venice.pubsub.adapter.kafka.ApacheKafkaOffsetPosition;
 import com.linkedin.venice.pubsub.adapter.kafka.TopicPartitionsOffsetsTracker;
 import com.linkedin.venice.pubsub.api.PubSubConsumerAdapter;
 import com.linkedin.venice.pubsub.api.PubSubMessage;
 import com.linkedin.venice.pubsub.api.PubSubMessageDeserializer;
 import com.linkedin.venice.pubsub.api.PubSubMessageHeaders;
+import com.linkedin.venice.pubsub.api.PubSubPosition;
 import com.linkedin.venice.pubsub.api.PubSubTopic;
 import com.linkedin.venice.pubsub.api.PubSubTopicPartition;
 import com.linkedin.venice.pubsub.api.exceptions.PubSubClientException;
@@ -29,6 +31,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
+import javax.annotation.Nonnull;
 import org.apache.kafka.clients.consumer.Consumer;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.consumer.ConsumerRecords;
@@ -88,8 +91,9 @@ public class ApacheKafkaConsumerAdapter implements PubSubConsumerAdapter {
   }
 
   /**
-   * Subscribe to a topic-partition if not already subscribed. If the topic-partition is already subscribed, this
-   * method is a no-op. This method requires the topic-partition to exist.
+   * Subscribes to a topic-partition if not already subscribed. If the topic-partition is already subscribed,
+   * this method is a no-op.
+   *
    * @param pubSubTopicPartition the topic-partition to subscribe to
    * @param lastReadOffset the last read offset for the topic-partition
    * @throws IllegalArgumentException if the topic-partition is null or the partition number is negative
@@ -97,45 +101,88 @@ public class ApacheKafkaConsumerAdapter implements PubSubConsumerAdapter {
    */
   @Override
   public void subscribe(PubSubTopicPartition pubSubTopicPartition, long lastReadOffset) {
-    String topic = pubSubTopicPartition.getPubSubTopic().getName();
-    int partition = pubSubTopicPartition.getPartitionNumber();
-    TopicPartition topicPartition = new TopicPartition(topic, partition);
-    Set<TopicPartition> topicPartitionSet = kafkaConsumer.assignment();
-    if (topicPartitionSet.contains(topicPartition)) {
-      LOGGER.warn("Already subscribed to topic-partition:{}, ignoring subscription request", pubSubTopicPartition);
+    subscribe(
+        pubSubTopicPartition,
+        (lastReadOffset <= OffsetRecord.LOWEST_OFFSET)
+            ? PubSubPosition.EARLIEST
+            : new ApacheKafkaOffsetPosition(lastReadOffset));
+  }
+
+  /**
+   * Subscribes to a topic-partition if not already subscribed. If the topic-partition is already subscribed,
+   * this method is a no-op.
+   *
+   * @param pubSubTopicPartition the topic-partition to subscribe to
+   * @param lastReadPubSubPosition the last known position for the topic-partition
+   * @throws IllegalArgumentException if lastReadPubSubPosition is invalid
+   * @throws PubSubTopicDoesNotExistException if the topic does not exist
+   */
+  @Override
+  public void subscribe(
+      @Nonnull PubSubTopicPartition pubSubTopicPartition,
+      @Nonnull PubSubPosition lastReadPubSubPosition) {
+    if (lastReadPubSubPosition == null) {
+      LOGGER
+          .error("Failed to subscribe to topic-partition: {} because last read position is null", pubSubTopicPartition);
+      throw new IllegalArgumentException("Last read position cannot be null");
+    }
+    if (lastReadPubSubPosition != PubSubPosition.EARLIEST && lastReadPubSubPosition != PubSubPosition.LATEST
+        && !(lastReadPubSubPosition instanceof ApacheKafkaOffsetPosition)) {
+      LOGGER.error(
+          "Failed to subscribe to topic-partition: {} because last read position type: {} is not supported with consumer type: {}",
+          pubSubTopicPartition,
+          lastReadPubSubPosition.getClass().getName(),
+          ApacheKafkaConsumerAdapter.class.getName());
+      throw new IllegalArgumentException(
+          "Last read position must be an instance of " + ApacheKafkaOffsetPosition.class.getName() + " as consumer is "
+              + ApacheKafkaConsumerAdapter.class.getName() + " but it is "
+              + lastReadPubSubPosition.getClass().getName());
+    }
+
+    TopicPartition topicPartition = toKafkaTopicPartition(pubSubTopicPartition);
+    if (kafkaConsumer.assignment().contains(topicPartition)) {
+      LOGGER.warn(
+          "Already subscribed to topic-partition:{}, ignoring subscription request with position: {}",
+          pubSubTopicPartition,
+          lastReadPubSubPosition);
       return;
     }
 
-    // Check if the topic-partition exists
+    validateTopicExistence(pubSubTopicPartition);
+
+    List<TopicPartition> topicPartitionList = new ArrayList<>(kafkaConsumer.assignment());
+    topicPartitionList.add(topicPartition);
+    kafkaConsumer.assign(topicPartitionList);
+
+    String logMessage;
+    if (lastReadPubSubPosition == PubSubPosition.EARLIEST) {
+      kafkaConsumer.seekToBeginning(Collections.singletonList(topicPartition));
+      logMessage = PubSubPosition.EARLIEST.toString();
+    } else if (lastReadPubSubPosition == PubSubPosition.LATEST) {
+      kafkaConsumer.seekToEnd(Collections.singletonList(topicPartition));
+      logMessage = PubSubPosition.LATEST.toString();
+    } else {
+      ApacheKafkaOffsetPosition kafkaOffsetPosition = (ApacheKafkaOffsetPosition) lastReadPubSubPosition;
+      long consumptionStartOffset = kafkaOffsetPosition.getOffset() + 1;
+      kafkaConsumer.seek(topicPartition, consumptionStartOffset);
+      logMessage = "" + consumptionStartOffset;
+    }
+    assignments.put(topicPartition, pubSubTopicPartition);
+    LOGGER.info("Subscribed to topic-partition: {} from position: {}", pubSubTopicPartition, logMessage);
+
+    assignments.put(topicPartition, pubSubTopicPartition);
+    LOGGER.info("Subscribed to topic-partition: {} from position: {}", pubSubTopicPartition, lastReadPubSubPosition);
+  }
+
+  private TopicPartition toKafkaTopicPartition(PubSubTopicPartition topicPartition) {
+    return new TopicPartition(topicPartition.getPubSubTopic().getName(), topicPartition.getPartitionNumber());
+  }
+
+  private void validateTopicExistence(PubSubTopicPartition pubSubTopicPartition) {
     if (config.shouldCheckTopicExistenceBeforeConsuming() && !isValidTopicPartition(pubSubTopicPartition)) {
       LOGGER.error("Cannot subscribe to topic-partition: {} because it does not exist", pubSubTopicPartition);
       throw new PubSubTopicDoesNotExistException(pubSubTopicPartition.getPubSubTopic());
     }
-
-    List<TopicPartition> topicPartitionList = new ArrayList<>(topicPartitionSet);
-    topicPartitionList.add(topicPartition);
-    kafkaConsumer.assign(topicPartitionList); // add the topic-partition to the subscription
-    // Use the last read offset to seek to the next offset to read.
-    long consumptionStartOffset = lastReadOffset <= OffsetRecord.LOWEST_OFFSET ? 0 : lastReadOffset + 1;
-    if (lastReadOffset <= OffsetRecord.LOWEST_OFFSET) {
-      if (lastReadOffset < OffsetRecord.LOWEST_OFFSET) {
-        LOGGER.warn(
-            "Last read offset: {} for topic-partition: {} is less than the lowest offset: {}, seeking to beginning."
-                + " This may indicate an off-by-one error.",
-            lastReadOffset,
-            pubSubTopicPartition,
-            OffsetRecord.LOWEST_OFFSET);
-      }
-      kafkaConsumer.seekToBeginning(Collections.singletonList(topicPartition));
-    } else {
-      kafkaConsumer.seek(topicPartition, consumptionStartOffset);
-    }
-    assignments.put(topicPartition, pubSubTopicPartition);
-    LOGGER.info(
-        "Subscribed to topic-partition: {} at offset: {} and last read offset was: {}",
-        pubSubTopicPartition,
-        consumptionStartOffset,
-        lastReadOffset);
   }
 
   // visible for testing
@@ -357,11 +404,34 @@ public class ApacheKafkaConsumerAdapter implements PubSubConsumerAdapter {
     return topicPartitionsOffsetsTracker != null ? topicPartitionsOffsetsTracker.getOffsetLag(topic, partition) : -1;
   }
 
+  /**
+   * Returns the latest offset for the given topic-partition. The latest offsets are derived from the lag metric
+   * and may be outdated or imprecise.
+   *
+   * @param pubSubTopicPartition the topic-partition for which the latest offset is requested
+   * @return the latest offset, or -1 if tracking is unavailable
+   */
   @Override
   public long getLatestOffset(PubSubTopicPartition pubSubTopicPartition) {
     String topic = pubSubTopicPartition.getPubSubTopic().getName();
     int partition = pubSubTopicPartition.getPartitionNumber();
     return topicPartitionsOffsetsTracker != null ? topicPartitionsOffsetsTracker.getEndOffset(topic, partition) : -1;
+  }
+
+  /**
+   * Returns the latest position for the given topic-partition. The latest offsets are derived from the lag metric
+   * and may be outdated or imprecise.
+   *
+   * @param pubSubTopicPartition the topic-partition for which the latest position is requested
+   * @return the latest position as a {@link PubSubPosition}, or {@link PubSubPosition#LATEST} if tracking is unavailable
+   */
+  @Override
+  public PubSubPosition getLatestPosition(PubSubTopicPartition pubSubTopicPartition) {
+    return topicPartitionsOffsetsTracker != null
+        ? new ApacheKafkaOffsetPosition(
+            topicPartitionsOffsetsTracker
+                .getEndOffset(pubSubTopicPartition.getTopicName(), pubSubTopicPartition.getPartitionNumber()))
+        : PubSubPosition.LATEST;
   }
 
   /**
@@ -397,6 +467,11 @@ public class ApacheKafkaConsumerAdapter implements PubSubConsumerAdapter {
   }
 
   @Override
+  public PubSubPosition positionForTime(PubSubTopicPartition pubSubTopicPartition, long timestamp, Duration timeout) {
+    throw new UnsupportedOperationException("positionForTime is not supported in Apache Kafka consumer");
+  }
+
+  @Override
   public Long offsetForTime(PubSubTopicPartition pubSubTopicPartition, long timestamp) {
     try {
       TopicPartition topicPartition = new TopicPartition(
@@ -424,6 +499,11 @@ public class ApacheKafkaConsumerAdapter implements PubSubConsumerAdapter {
   }
 
   @Override
+  public PubSubPosition positionForTime(PubSubTopicPartition pubSubTopicPartition, long timestamp) {
+    return null;
+  }
+
+  @Override
   public Long beginningOffset(PubSubTopicPartition pubSubTopicPartition, Duration timeout) {
     TopicPartition kafkaTp =
         new TopicPartition(pubSubTopicPartition.getPubSubTopic().getName(), pubSubTopicPartition.getPartitionNumber());
@@ -434,6 +514,11 @@ public class ApacheKafkaConsumerAdapter implements PubSubConsumerAdapter {
     } catch (Exception e) {
       throw new PubSubClientException("Exception while getting beginning offset for " + kafkaTp, e);
     }
+  }
+
+  @Override
+  public PubSubPosition beginningPosition(PubSubTopicPartition pubSubTopicPartition, Duration timeout) {
+    return null;
   }
 
   @Override
@@ -462,6 +547,13 @@ public class ApacheKafkaConsumerAdapter implements PubSubConsumerAdapter {
   }
 
   @Override
+  public Map<PubSubTopicPartition, PubSubPosition> endPositions(
+      Collection<PubSubTopicPartition> partitions,
+      Duration timeout) {
+    throw new UnsupportedOperationException("endPositions is not supported in Apache Kafka consumer");
+  }
+
+  @Override
   public Long endOffset(PubSubTopicPartition pubSubTopicPartition) {
     try {
       TopicPartition topicPartition = new TopicPartition(
@@ -479,6 +571,11 @@ public class ApacheKafkaConsumerAdapter implements PubSubConsumerAdapter {
     } catch (Exception e) {
       throw new PubSubClientException("Failed to fetch end offset for " + pubSubTopicPartition, e);
     }
+  }
+
+  @Override
+  public PubSubPosition endPosition(PubSubTopicPartition pubSubTopicPartition) {
+    return null;
   }
 
   /**

--- a/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/adapter/kafka/consumer/ApacheKafkaConsumerAdapter.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/adapter/kafka/consumer/ApacheKafkaConsumerAdapter.java
@@ -109,13 +109,18 @@ public class ApacheKafkaConsumerAdapter implements PubSubConsumerAdapter {
   }
 
   /**
-   * Subscribes to a topic-partition if not already subscribed. If the topic-partition is already subscribed,
-   * this method is a no-op.
+   * Subscribes to a specified topic-partition if it is not already subscribed. If the topic-partition is already
+   * subscribed, this method performs no action.
+   *
+   * The subscription uses the provided {@link PubSubPosition} to determine the starting offset for consumption.
+   * If the position is {@link PubSubPosition#EARLIEST}, the consumer will seek to the earliest available message.
+   * If it is {@link PubSubPosition#LATEST}, the consumer will seek to the latest offset. If an instance of
+   * {@link ApacheKafkaOffsetPosition} is provided, the consumer will seek to the specified offset plus one.
    *
    * @param pubSubTopicPartition the topic-partition to subscribe to
    * @param lastReadPubSubPosition the last known position for the topic-partition
-   * @throws IllegalArgumentException if lastReadPubSubPosition is invalid
-   * @throws PubSubTopicDoesNotExistException if the topic does not exist
+   * @throws IllegalArgumentException if lastReadPubSubPosition is null or not an instance of {@link ApacheKafkaOffsetPosition}
+   * @throws PubSubTopicDoesNotExistException if the specified topic does not exist
    */
   @Override
   public void subscribe(

--- a/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/api/PubSubConsumerAdapter.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/api/PubSubConsumerAdapter.java
@@ -16,6 +16,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import javax.annotation.Nonnull;
 
 
 /**
@@ -39,8 +40,27 @@ public interface PubSubConsumerAdapter extends AutoCloseable, Closeable {
    */
   void subscribe(PubSubTopicPartition pubSubTopicPartition, long lastReadOffset);
 
+  /**
+   * Subscribes to a specified topic-partition if it is not already subscribed. If the topic-partition is
+   * already subscribed, this method performs no action.
+   *
+   * The subscription uses the provided {@link PubSubPosition} to determine the starting offset for
+   * consumption. If the position is {@link PubSubPosition#EARLIEST}, the consumer will seek to the earliest
+   * available message. If it is {@link PubSubPosition#LATEST}, the consumer will seek to the latest available
+   * message. If a custom position is provided, implementations should resolve it to the corresponding offset
+   * or position in the underlying pub-sub system.
+   *
+   * Implementations of this interface should ensure proper validation of the topic-partition existence and
+   * manage consumer assignments. This method does not guarantee immediate subscription state changes and may
+   * defer them based on implementation details.
+   *
+   * @param pubSubTopicPartition the topic-partition to subscribe to
+   * @param lastReadPubSubPosition the last known position for the topic-partition
+   * @throws IllegalArgumentException if lastReadPubSubPosition is null or of an unsupported type
+   * @throws PubSubTopicDoesNotExistException if the specified topic does not exist
+   */
   @UnderDevelopment("This method is under development and may be subject to change.")
-  void subscribe(PubSubTopicPartition pubSubTopicPartition, PubSubPosition lastReadPubSubPosition);
+  void subscribe(@Nonnull PubSubTopicPartition pubSubTopicPartition, @Nonnull PubSubPosition lastReadPubSubPosition);
 
   /**
    * Unsubscribes the consumer from a specified topic-partition.

--- a/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/api/PubSubConsumerAdapter.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/api/PubSubConsumerAdapter.java
@@ -39,7 +39,7 @@ public interface PubSubConsumerAdapter extends AutoCloseable, Closeable {
    */
   void subscribe(PubSubTopicPartition pubSubTopicPartition, long lastReadOffset);
 
-  @UnderDevelopment
+  @UnderDevelopment("This method is under development and may be subject to change.")
   void subscribe(PubSubTopicPartition pubSubTopicPartition, PubSubPosition lastReadPubSubPosition);
 
   /**
@@ -143,11 +143,6 @@ public interface PubSubConsumerAdapter extends AutoCloseable, Closeable {
     return -1;
   }
 
-  @UnderDevelopment
-  default PubSubPosition getLatestPosition(PubSubTopicPartition pubSubTopicPartition) {
-    return PubSubPosition.LATEST;
-  }
-
   /**
    * Retrieves the offset of the first message with a timestamp greater than or equal to the target
    * timestamp for the specified PubSub topic-partition. If no such message is found, {@code null}
@@ -163,8 +158,6 @@ public interface PubSubConsumerAdapter extends AutoCloseable, Closeable {
    */
   Long offsetForTime(PubSubTopicPartition pubSubTopicPartition, long timestamp, Duration timeout);
 
-  PubSubPosition positionForTime(PubSubTopicPartition pubSubTopicPartition, long timestamp, Duration timeout);
-
   /**
    * Retrieves the offset of the first message with a timestamp greater than or equal to the target
    * timestamp for the specified PubSub topic-partition. If no such message is found, {@code null}
@@ -179,9 +172,6 @@ public interface PubSubConsumerAdapter extends AutoCloseable, Closeable {
    */
   Long offsetForTime(PubSubTopicPartition pubSubTopicPartition, long timestamp);
 
-  @UnderDevelopment
-  PubSubPosition positionForTime(PubSubTopicPartition pubSubTopicPartition, long timestamp);
-
   /**
    * Retrieves the beginning offset for the specified PubSub topic-partition.
    *
@@ -193,9 +183,6 @@ public interface PubSubConsumerAdapter extends AutoCloseable, Closeable {
    * @throws PubSubClientException If there is an error while attempting to fetch the beginning offset.
    */
   Long beginningOffset(PubSubTopicPartition pubSubTopicPartition, Duration timeout);
-
-  @UnderDevelopment
-  PubSubPosition beginningPosition(PubSubTopicPartition pubSubTopicPartition, Duration timeout);
 
   /**
    * Retrieves the end offsets for a collection of PubSub topic-partitions. The end offset represents
@@ -211,9 +198,6 @@ public interface PubSubConsumerAdapter extends AutoCloseable, Closeable {
    */
   Map<PubSubTopicPartition, Long> endOffsets(Collection<PubSubTopicPartition> partitions, Duration timeout);
 
-  @UnderDevelopment
-  Map<PubSubTopicPartition, PubSubPosition> endPositions(Collection<PubSubTopicPartition> partitions, Duration timeout);
-
   /**
    * Retrieves the end offset for the specified PubSub topic-partition. The end offset represents
    * the highest offset available in each specified partition, i.e., offset of the last message + 1.
@@ -225,9 +209,6 @@ public interface PubSubConsumerAdapter extends AutoCloseable, Closeable {
    * @throws PubSubClientException If there is an error while attempting to fetch the end offset.
    */
   Long endOffset(PubSubTopicPartition pubSubTopicPartition);
-
-  @UnderDevelopment
-  PubSubPosition endPosition(PubSubTopicPartition pubSubTopicPartition);
 
   /**
    * Retrieves the list of partitions associated with a given Pub-Sub topic.

--- a/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/api/PubSubConsumerAdapter.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/api/PubSubConsumerAdapter.java
@@ -1,5 +1,6 @@
 package com.linkedin.venice.pubsub.api;
 
+import com.linkedin.venice.annotation.UnderDevelopment;
 import com.linkedin.venice.kafka.protocol.KafkaMessageEnvelope;
 import com.linkedin.venice.message.KafkaKey;
 import com.linkedin.venice.pubsub.PubSubConstants;
@@ -37,6 +38,9 @@ public interface PubSubConsumerAdapter extends AutoCloseable, Closeable {
    * @throws PubSubTopicDoesNotExistException If the topic does not exist.
    */
   void subscribe(PubSubTopicPartition pubSubTopicPartition, long lastReadOffset);
+
+  @UnderDevelopment
+  void subscribe(PubSubTopicPartition pubSubTopicPartition, PubSubPosition lastReadPubSubPosition);
 
   /**
    * Unsubscribes the consumer from a specified topic-partition.
@@ -139,6 +143,11 @@ public interface PubSubConsumerAdapter extends AutoCloseable, Closeable {
     return -1;
   }
 
+  @UnderDevelopment
+  default PubSubPosition getLatestPosition(PubSubTopicPartition pubSubTopicPartition) {
+    return PubSubPosition.LATEST;
+  }
+
   /**
    * Retrieves the offset of the first message with a timestamp greater than or equal to the target
    * timestamp for the specified PubSub topic-partition. If no such message is found, {@code null}
@@ -154,6 +163,8 @@ public interface PubSubConsumerAdapter extends AutoCloseable, Closeable {
    */
   Long offsetForTime(PubSubTopicPartition pubSubTopicPartition, long timestamp, Duration timeout);
 
+  PubSubPosition positionForTime(PubSubTopicPartition pubSubTopicPartition, long timestamp, Duration timeout);
+
   /**
    * Retrieves the offset of the first message with a timestamp greater than or equal to the target
    * timestamp for the specified PubSub topic-partition. If no such message is found, {@code null}
@@ -168,6 +179,9 @@ public interface PubSubConsumerAdapter extends AutoCloseable, Closeable {
    */
   Long offsetForTime(PubSubTopicPartition pubSubTopicPartition, long timestamp);
 
+  @UnderDevelopment
+  PubSubPosition positionForTime(PubSubTopicPartition pubSubTopicPartition, long timestamp);
+
   /**
    * Retrieves the beginning offset for the specified PubSub topic-partition.
    *
@@ -179,6 +193,9 @@ public interface PubSubConsumerAdapter extends AutoCloseable, Closeable {
    * @throws PubSubClientException If there is an error while attempting to fetch the beginning offset.
    */
   Long beginningOffset(PubSubTopicPartition pubSubTopicPartition, Duration timeout);
+
+  @UnderDevelopment
+  PubSubPosition beginningPosition(PubSubTopicPartition pubSubTopicPartition, Duration timeout);
 
   /**
    * Retrieves the end offsets for a collection of PubSub topic-partitions. The end offset represents
@@ -194,6 +211,9 @@ public interface PubSubConsumerAdapter extends AutoCloseable, Closeable {
    */
   Map<PubSubTopicPartition, Long> endOffsets(Collection<PubSubTopicPartition> partitions, Duration timeout);
 
+  @UnderDevelopment
+  Map<PubSubTopicPartition, PubSubPosition> endPositions(Collection<PubSubTopicPartition> partitions, Duration timeout);
+
   /**
    * Retrieves the end offset for the specified PubSub topic-partition. The end offset represents
    * the highest offset available in each specified partition, i.e., offset of the last message + 1.
@@ -205,6 +225,9 @@ public interface PubSubConsumerAdapter extends AutoCloseable, Closeable {
    * @throws PubSubClientException If there is an error while attempting to fetch the end offset.
    */
   Long endOffset(PubSubTopicPartition pubSubTopicPartition);
+
+  @UnderDevelopment
+  PubSubPosition endPosition(PubSubTopicPartition pubSubTopicPartition);
 
   /**
    * Retrieves the list of partitions associated with a given Pub-Sub topic.

--- a/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/api/PubSubPosition.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/api/PubSubPosition.java
@@ -8,6 +8,82 @@ import com.linkedin.venice.pubsub.PubSubPositionFactory;
  */
 public interface PubSubPosition {
   /**
+   * A special position representing the earliest available message in a partition. All pub-sub adapters must support
+   * this position, and all pub-sub client implementations should interpret it as the earliest retrievable message in
+   * the partition. Implementations must map this position to the corresponding earliest offset or equivalent marker
+   * in the underlying pub-sub system.
+   */
+  PubSubPosition EARLIEST = new PubSubPosition() {
+    @Override
+    public int comparePosition(PubSubPosition other) {
+      throw new IllegalStateException("Cannot compare EARLIEST position");
+    }
+
+    @Override
+    public long diff(PubSubPosition other) {
+      throw new IllegalStateException("Cannot diff EARLIEST position");
+    }
+
+    @Override
+    public PubSubPositionWireFormat getPositionWireFormat() {
+      throw new IllegalStateException("Cannot serialize EARLIEST position");
+    }
+
+    @Override
+    public String toString() {
+      return "EARLIEST";
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+      return obj == this;
+    }
+
+    @Override
+    public int hashCode() {
+      return 1;
+    }
+  };
+
+  /**
+   * A special position representing the latest available message in a partition. All pub-sub adapters must support
+   * this position, and all pub-sub client implementations should interpret it as the most recent retrievable message
+   * in the partition. Implementations must map this position to the corresponding latest offset or equivalent marker
+   * in the underlying pub-sub system.
+   */
+  PubSubPosition LATEST = new PubSubPosition() {
+    @Override
+    public int comparePosition(PubSubPosition other) {
+      throw new IllegalStateException("Cannot compare LATEST position");
+    }
+
+    @Override
+    public long diff(PubSubPosition other) {
+      throw new IllegalStateException("Cannot diff LATEST position");
+    }
+
+    @Override
+    public PubSubPositionWireFormat getPositionWireFormat() {
+      throw new IllegalStateException("Cannot serialize LATEST position");
+    }
+
+    @Override
+    public String toString() {
+      return "LATEST";
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+      return obj == this;
+    }
+
+    @Override
+    public int hashCode() {
+      return 2;
+    }
+  };
+
+  /**
    * @param other the other position to compare to
    * @return returns 0 if the positions are equal,
    *          -1 if this position is less than the other position,

--- a/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/api/PubSubPosition.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/api/PubSubPosition.java
@@ -41,7 +41,7 @@ public interface PubSubPosition {
 
     @Override
     public int hashCode() {
-      return 1;
+      return -1;
     }
   };
 
@@ -79,7 +79,7 @@ public interface PubSubPosition {
 
     @Override
     public int hashCode() {
-      return 2;
+      return -2;
     }
   };
 

--- a/internal/venice-common/src/test/java/com/linkedin/venice/pubsub/adapter/kafka/consumer/ApacheKafkaConsumerAdapterTest.java
+++ b/internal/venice-common/src/test/java/com/linkedin/venice/pubsub/adapter/kafka/consumer/ApacheKafkaConsumerAdapterTest.java
@@ -1,11 +1,14 @@
 package com.linkedin.venice.pubsub.adapter.kafka.consumer;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -27,9 +30,11 @@ import com.linkedin.venice.offsets.OffsetRecord;
 import com.linkedin.venice.pubsub.PubSubTopicPartitionImpl;
 import com.linkedin.venice.pubsub.PubSubTopicPartitionInfo;
 import com.linkedin.venice.pubsub.PubSubTopicRepository;
+import com.linkedin.venice.pubsub.adapter.kafka.ApacheKafkaOffsetPosition;
 import com.linkedin.venice.pubsub.adapter.kafka.TopicPartitionsOffsetsTracker;
 import com.linkedin.venice.pubsub.api.PubSubMessage;
 import com.linkedin.venice.pubsub.api.PubSubMessageDeserializer;
+import com.linkedin.venice.pubsub.api.PubSubPosition;
 import com.linkedin.venice.pubsub.api.PubSubTopic;
 import com.linkedin.venice.pubsub.api.PubSubTopicPartition;
 import com.linkedin.venice.pubsub.api.exceptions.PubSubClientException;
@@ -94,6 +99,106 @@ public class ApacheKafkaConsumerAdapterTest {
   @AfterMethod(alwaysRun = true)
   public void cleanUp() {
     pubSubMessageDeserializer.close();
+  }
+
+  @Test
+  public void testSubscribeWithValidOffset() {
+    PubSubTopicPartition pubSubTopicPartition = new PubSubTopicPartitionImpl(pubSubTopicRepository.getTopic("test"), 0);
+    TopicPartition topicPartition = new TopicPartition("test", 0);
+
+    when(internalKafkaConsumer.assignment()).thenReturn(Collections.emptySet());
+    doNothing().when(internalKafkaConsumer).assign(any());
+
+    kafkaConsumerAdapter.subscribe(pubSubTopicPartition, 100);
+    verify(internalKafkaConsumer).assign(any(List.class));
+    verify(internalKafkaConsumer).seek(topicPartition, 101); // Should seek to offset + 1
+
+    kafkaConsumerAdapter.subscribe(pubSubTopicPartition, 200);
+    verify(internalKafkaConsumer, times(2)).assign(any(List.class));
+    verify(internalKafkaConsumer).seek(topicPartition, 201); // Should seek to offset + 1
+  }
+
+  @Test
+  public void testSubscribeWithEarliestOffset() {
+    PubSubTopicPartition pubSubTopicPartition = new PubSubTopicPartitionImpl(pubSubTopicRepository.getTopic("test"), 0);
+    TopicPartition topicPartition = new TopicPartition("test", 0);
+
+    when(internalKafkaConsumer.assignment()).thenReturn(Collections.emptySet());
+    doNothing().when(internalKafkaConsumer).assign(any());
+
+    kafkaConsumerAdapter.subscribe(pubSubTopicPartition, PubSubPosition.EARLIEST);
+    verify(internalKafkaConsumer).assign(any(List.class));
+    verify(internalKafkaConsumer).seekToBeginning(Collections.singletonList(topicPartition));
+
+    kafkaConsumerAdapter.subscribe(pubSubTopicPartition, -1);
+    verify(internalKafkaConsumer, times(2)).assign(any(List.class));
+    verify(internalKafkaConsumer, times(2)).seekToBeginning(Collections.singletonList(topicPartition));
+  }
+
+  @Test
+  public void testSubscribeAlreadySubscribed() {
+    PubSubTopicPartition pubSubTopicPartition = new PubSubTopicPartitionImpl(pubSubTopicRepository.getTopic("test"), 0);
+    TopicPartition topicPartition = new TopicPartition("test", 0);
+
+    when(internalKafkaConsumer.assignment()).thenReturn(Collections.singleton(topicPartition));
+
+    kafkaConsumerAdapter.subscribe(pubSubTopicPartition, 100);
+
+    verify(internalKafkaConsumer, never()).assign(any());
+    verify(internalKafkaConsumer, never()).seek(any(), anyLong());
+  }
+
+  @Test
+  public void testSubscribeWithLatestPubSubPosition() {
+    PubSubTopicPartition pubSubTopicPartition = new PubSubTopicPartitionImpl(pubSubTopicRepository.getTopic("test"), 0);
+    TopicPartition topicPartition = new TopicPartition("test", 0);
+
+    when(internalKafkaConsumer.assignment()).thenReturn(Collections.emptySet());
+
+    kafkaConsumerAdapter.subscribe(pubSubTopicPartition, PubSubPosition.LATEST);
+
+    verify(internalKafkaConsumer).assign(any(List.class));
+    verify(internalKafkaConsumer).seekToEnd(Collections.singletonList(topicPartition));
+  }
+
+  @Test(expectedExceptions = IllegalArgumentException.class)
+  public void testSubscribeWithNullPubSubPosition() {
+    PubSubTopicPartition pubSubTopicPartition = new PubSubTopicPartitionImpl(pubSubTopicRepository.getTopic("test"), 0);
+    kafkaConsumerAdapter.subscribe(pubSubTopicPartition, null);
+  }
+
+  @Test(expectedExceptions = IllegalArgumentException.class)
+  public void testSubscribeWithInvalidPubSubPositionType() {
+    PubSubTopicPartition pubSubTopicPartition = new PubSubTopicPartitionImpl(pubSubTopicRepository.getTopic("test"), 0);
+    kafkaConsumerAdapter.subscribe(pubSubTopicPartition, mock(PubSubPosition.class));
+  }
+
+  @Test
+  public void testSubscribeWithApacheKafkaOffsetPosition() {
+    PubSubTopicPartition pubSubTopicPartition = new PubSubTopicPartitionImpl(pubSubTopicRepository.getTopic("test"), 0);
+    TopicPartition topicPartition = new TopicPartition("test", 0);
+    ApacheKafkaOffsetPosition offsetPosition = new ApacheKafkaOffsetPosition(50);
+
+    when(internalKafkaConsumer.assignment()).thenReturn(Collections.emptySet());
+
+    kafkaConsumerAdapter.subscribe(pubSubTopicPartition, offsetPosition);
+
+    verify(internalKafkaConsumer).assign(any(List.class));
+    verify(internalKafkaConsumer).seek(topicPartition, 51);
+  }
+
+  @Test
+  public void testSubscribeTwiceWithSamePartition() {
+    PubSubTopicPartition pubSubTopicPartition = new PubSubTopicPartitionImpl(pubSubTopicRepository.getTopic("test"), 0);
+    TopicPartition topicPartition = new TopicPartition("test", 0);
+
+    when(internalKafkaConsumer.assignment()).thenReturn(Collections.emptySet())
+        .thenReturn(Collections.singleton(topicPartition));
+
+    kafkaConsumerAdapter.subscribe(pubSubTopicPartition, 100);
+    kafkaConsumerAdapter.subscribe(pubSubTopicPartition, 200);
+
+    verify(internalKafkaConsumer, times(1)).assign(any());
   }
 
   @Test

--- a/internal/venice-common/src/test/java/com/linkedin/venice/pubsub/adapter/kafka/consumer/ApacheKafkaConsumerAdapterTest.java
+++ b/internal/venice-common/src/test/java/com/linkedin/venice/pubsub/adapter/kafka/consumer/ApacheKafkaConsumerAdapterTest.java
@@ -110,6 +110,7 @@ public class ApacheKafkaConsumerAdapterTest {
     doNothing().when(internalKafkaConsumer).assign(any());
 
     kafkaConsumerAdapter.subscribe(pubSubTopicPartition, 100);
+    assertTrue(kafkaConsumerAdapter.getAssignment().contains(pubSubTopicPartition));
     verify(internalKafkaConsumer).assign(any(List.class));
     verify(internalKafkaConsumer).seek(topicPartition, 101); // Should seek to offset + 1
 
@@ -127,6 +128,7 @@ public class ApacheKafkaConsumerAdapterTest {
     doNothing().when(internalKafkaConsumer).assign(any());
 
     kafkaConsumerAdapter.subscribe(pubSubTopicPartition, PubSubPosition.EARLIEST);
+    assertTrue(kafkaConsumerAdapter.getAssignment().contains(pubSubTopicPartition));
     verify(internalKafkaConsumer).assign(any(List.class));
     verify(internalKafkaConsumer).seekToBeginning(Collections.singletonList(topicPartition));
 
@@ -157,6 +159,7 @@ public class ApacheKafkaConsumerAdapterTest {
 
     kafkaConsumerAdapter.subscribe(pubSubTopicPartition, PubSubPosition.LATEST);
 
+    assertTrue(kafkaConsumerAdapter.getAssignment().contains(pubSubTopicPartition));
     verify(internalKafkaConsumer).assign(any(List.class));
     verify(internalKafkaConsumer).seekToEnd(Collections.singletonList(topicPartition));
   }
@@ -182,7 +185,7 @@ public class ApacheKafkaConsumerAdapterTest {
     when(internalKafkaConsumer.assignment()).thenReturn(Collections.emptySet());
 
     kafkaConsumerAdapter.subscribe(pubSubTopicPartition, offsetPosition);
-
+    assertTrue(kafkaConsumerAdapter.getAssignment().contains(pubSubTopicPartition));
     verify(internalKafkaConsumer).assign(any(List.class));
     verify(internalKafkaConsumer).seek(topicPartition, 51);
   }
@@ -196,8 +199,8 @@ public class ApacheKafkaConsumerAdapterTest {
         .thenReturn(Collections.singleton(topicPartition));
 
     kafkaConsumerAdapter.subscribe(pubSubTopicPartition, 100);
+    assertTrue(kafkaConsumerAdapter.getAssignment().contains(pubSubTopicPartition));
     kafkaConsumerAdapter.subscribe(pubSubTopicPartition, 200);
-
     verify(internalKafkaConsumer, times(1)).assign(any());
   }
 

--- a/internal/venice-test-common/src/main/java/com/linkedin/venice/unit/kafka/consumer/MockInMemoryConsumer.java
+++ b/internal/venice-test-common/src/main/java/com/linkedin/venice/unit/kafka/consumer/MockInMemoryConsumer.java
@@ -6,6 +6,7 @@ import com.linkedin.venice.offsets.OffsetRecord;
 import com.linkedin.venice.pubsub.PubSubTopicPartitionInfo;
 import com.linkedin.venice.pubsub.api.PubSubConsumerAdapter;
 import com.linkedin.venice.pubsub.api.PubSubMessage;
+import com.linkedin.venice.pubsub.api.PubSubPosition;
 import com.linkedin.venice.pubsub.api.PubSubTopic;
 import com.linkedin.venice.pubsub.api.PubSubTopicPartition;
 import com.linkedin.venice.pubsub.api.exceptions.PubSubUnsubscribedTopicPartitionException;
@@ -59,6 +60,11 @@ public class MockInMemoryConsumer implements PubSubConsumerAdapter {
     pausedTopicPartitions.remove(pubSubTopicPartition);
     delegate.subscribe(pubSubTopicPartition, lastReadOffset);
     offsets.put(pubSubTopicPartition, lastReadOffset);
+  }
+
+  @Override
+  public void subscribe(PubSubTopicPartition pubSubTopicPartition, PubSubPosition lastReadPubSubPosition) {
+    throw new UnsupportedOperationException("Not implemented");
   }
 
   @Override
@@ -159,7 +165,12 @@ public class MockInMemoryConsumer implements PubSubConsumerAdapter {
 
   @Override
   public Long offsetForTime(PubSubTopicPartition pubSubTopicPartition, long timestamp, Duration timeout) {
-    return null;
+    throw new UnsupportedOperationException("Not implemented");
+  }
+
+  @Override
+  public PubSubPosition positionForTime(PubSubTopicPartition pubSubTopicPartition, long timestamp, Duration timeout) {
+    throw new UnsupportedOperationException("Not implemented");
   }
 
   @Override
@@ -168,8 +179,18 @@ public class MockInMemoryConsumer implements PubSubConsumerAdapter {
   }
 
   @Override
+  public PubSubPosition positionForTime(PubSubTopicPartition pubSubTopicPartition, long timestamp) {
+    throw new UnsupportedOperationException("Not implemented");
+  }
+
+  @Override
   public Long beginningOffset(PubSubTopicPartition partition, Duration timeout) {
     return 0L;
+  }
+
+  @Override
+  public PubSubPosition beginningPosition(PubSubTopicPartition pubSubTopicPartition, Duration timeout) {
+    throw new UnsupportedOperationException("Not implemented");
   }
 
   @Override
@@ -182,9 +203,21 @@ public class MockInMemoryConsumer implements PubSubConsumerAdapter {
   }
 
   @Override
+  public Map<PubSubTopicPartition, PubSubPosition> endPositions(
+      Collection<PubSubTopicPartition> partitions,
+      Duration timeout) {
+    throw new UnsupportedOperationException("Not implemented");
+  }
+
+  @Override
   public Long endOffset(PubSubTopicPartition pubSubTopicPartition) {
     return broker
         .endOffsets(pubSubTopicPartition.getPubSubTopic().getName(), pubSubTopicPartition.getPartitionNumber());
+  }
+
+  @Override
+  public PubSubPosition endPosition(PubSubTopicPartition pubSubTopicPartition) {
+    throw new UnsupportedOperationException("Not implemented");
   }
 
   @Override

--- a/internal/venice-test-common/src/main/java/com/linkedin/venice/unit/kafka/consumer/MockInMemoryConsumer.java
+++ b/internal/venice-test-common/src/main/java/com/linkedin/venice/unit/kafka/consumer/MockInMemoryConsumer.java
@@ -169,28 +169,13 @@ public class MockInMemoryConsumer implements PubSubConsumerAdapter {
   }
 
   @Override
-  public PubSubPosition positionForTime(PubSubTopicPartition pubSubTopicPartition, long timestamp, Duration timeout) {
-    throw new UnsupportedOperationException("Not implemented");
-  }
-
-  @Override
   public Long offsetForTime(PubSubTopicPartition pubSubTopicPartition, long timestamp) {
     return null;
   }
 
   @Override
-  public PubSubPosition positionForTime(PubSubTopicPartition pubSubTopicPartition, long timestamp) {
-    throw new UnsupportedOperationException("Not implemented");
-  }
-
-  @Override
   public Long beginningOffset(PubSubTopicPartition partition, Duration timeout) {
     return 0L;
-  }
-
-  @Override
-  public PubSubPosition beginningPosition(PubSubTopicPartition pubSubTopicPartition, Duration timeout) {
-    throw new UnsupportedOperationException("Not implemented");
   }
 
   @Override
@@ -203,21 +188,9 @@ public class MockInMemoryConsumer implements PubSubConsumerAdapter {
   }
 
   @Override
-  public Map<PubSubTopicPartition, PubSubPosition> endPositions(
-      Collection<PubSubTopicPartition> partitions,
-      Duration timeout) {
-    throw new UnsupportedOperationException("Not implemented");
-  }
-
-  @Override
   public Long endOffset(PubSubTopicPartition pubSubTopicPartition) {
     return broker
         .endOffsets(pubSubTopicPartition.getPubSubTopic().getName(), pubSubTopicPartition.getPartitionNumber());
-  }
-
-  @Override
-  public PubSubPosition endPosition(PubSubTopicPartition pubSubTopicPartition) {
-    throw new UnsupportedOperationException("Not implemented");
   }
 
   @Override

--- a/internal/venice-test-common/src/main/java/com/linkedin/venice/unit/kafka/consumer/MockInMemoryConsumer.java
+++ b/internal/venice-test-common/src/main/java/com/linkedin/venice/unit/kafka/consumer/MockInMemoryConsumer.java
@@ -165,7 +165,7 @@ public class MockInMemoryConsumer implements PubSubConsumerAdapter {
 
   @Override
   public Long offsetForTime(PubSubTopicPartition pubSubTopicPartition, long timestamp, Duration timeout) {
-    throw new UnsupportedOperationException("Not implemented");
+    return null;
   }
 
   @Override


### PR DESCRIPTION
## Add PubSubConsumerAdapter::subscribe with PubSubPosition parameter


Introduce a new overload of `subscribe` in `PubSubConsumerAdapter` that accepts a  
`PubSubPosition`. This change is aimed at supporting non-numeric offsets. This allows  
consumers to specify positions such as `EARLIEST`, `LATEST`, or an implementation-specific  
position type. Implementors must map this `PubSubPosition` to the appropriate offset in  
the underlying pub-sub system.

### Enhancements to PubSub Consumer Functionality:

- **PubSubConsumerAdapter:**  
  Added a new `subscribe` method that uses `PubSubPosition` to determine the starting  
  offset for consumption. This method is marked with the `UnderDevelopment` annotation.  
  (`PubSubConsumerAdapter.java`)

- **PubSubPosition Updates:**  
  Added `EARLIEST` and `LATEST` positions to the `PubSubPosition` interface.  
  (`PubSubPosition.java`)


- **ApacheKafkaConsumerAdapter Implementation:**  
  Implemented the new `subscribe` method to handle `PubSubPosition`. 


### New Annotations:

- **UnderDevelopment:**  
  Added a new annotation to indicate that an API is under development and not yet stable.  
  (`UnderDevelopment.java`)
  
- **VisibleForTesting:**  
  Added a new annotation to indicate that a method, class, or field is more visible than  
  necessary for testing purposes. (`VisibleForTesting.java`)



## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
UT and E2ETest

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.