### PR TITLE
[controller] Set default for `is_abort_migration_cleanup` to false when null

### DIFF
--- a/clients/venice-admin-tool/src/main/java/com/linkedin/venice/AdminTool.java
+++ b/clients/venice-admin-tool/src/main/java/com/linkedin/venice/AdminTool.java
@@ -841,8 +841,7 @@ public class AdminTool {
     String valueSchemaFile = getRequiredArgument(cmd, Arg.VALUE_SCHEMA, Command.NEW_STORE);
     String valueSchema = readFile(valueSchemaFile);
     String owner = getOptionalArgument(cmd, Arg.OWNER, "");
-    boolean isVsonStore =
-        Utils.parseBooleanFromString(getOptionalArgument(cmd, Arg.VSON_STORE, "false"), "isVsonStore");
+    boolean isVsonStore = Utils.parseBooleanOrThrow(getOptionalArgument(cmd, Arg.VSON_STORE, "false"), "isVsonStore");
     if (isVsonStore) {
       keySchema = VsonAvroSchemaAdapter.parse(keySchema).toString();
       valueSchema = VsonAvroSchemaAdapter.parse(valueSchema).toString();
@@ -1126,7 +1125,7 @@ public class AdminTool {
   }
 
   private static void booleanParam(CommandLine cmd, Arg param, Consumer<Boolean> setter, Set<Arg> argSet) {
-    genericParam(cmd, param, s -> Utils.parseBooleanFromString(s, param.toString()), setter, argSet);
+    genericParam(cmd, param, s -> Utils.parseBooleanOrThrow(s, param.toString()), setter, argSet);
   }
 
   private static void stringMapParam(
@@ -2536,8 +2535,7 @@ public class AdminTool {
     String valueSchema = readFile(valueSchemaFile);
     String aclPerms = getRequiredArgument(cmd, Arg.ACL_PERMS, Command.NEW_STORE);
     String owner = getOptionalArgument(cmd, Arg.OWNER, "");
-    boolean isVsonStore =
-        Utils.parseBooleanFromString(getOptionalArgument(cmd, Arg.VSON_STORE, "false"), "isVsonStore");
+    boolean isVsonStore = Utils.parseBooleanOrThrow(getOptionalArgument(cmd, Arg.VSON_STORE, "false"), "isVsonStore");
     if (isVsonStore) {
       keySchema = VsonAvroSchemaAdapter.parse(keySchema).toString();
       valueSchema = VsonAvroSchemaAdapter.parse(valueSchema).toString();

--- a/internal/venice-common/src/main/java/com/linkedin/venice/utils/Utils.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/utils/Utils.java
@@ -304,27 +304,6 @@ public class Utils {
   }
 
   /**
-   * Since {@link Boolean#parseBoolean(String)} does not throw exception and will always return 'false' for
-   * any string that are not equal to 'true', We validate the string by our own.
-   */
-  public static boolean parseBooleanFromString(String value, String fieldName) {
-    if (value == null) {
-      throw new VeniceHttpException(
-          HttpStatus.SC_BAD_REQUEST,
-          fieldName + " must be a boolean, but value is null",
-          ErrorType.BAD_REQUEST);
-    }
-    if (value.equalsIgnoreCase("true") || value.equalsIgnoreCase("false")) {
-      return Boolean.parseBoolean(value);
-    } else {
-      throw new VeniceHttpException(
-          HttpStatus.SC_BAD_REQUEST,
-          fieldName + " must be a boolean, but value: " + value,
-          ErrorType.BAD_REQUEST);
-    }
-  }
-
-  /**
    * Parses a boolean from a string, ensuring that only valid boolean values ("true" or "false")
    * are accepted. Throws an exception if the value is null or invalid.
    *

--- a/internal/venice-common/src/main/java/com/linkedin/venice/utils/Utils.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/utils/Utils.java
@@ -325,6 +325,52 @@ public class Utils {
   }
 
   /**
+   * Parses a boolean from a string, ensuring that only valid boolean values ("true" or "false")
+   * are accepted. Throws an exception if the value is null or invalid.
+   *
+   * @param value the string to parse
+   * @param fieldName the name of the field being validated
+   * @return the parsed boolean value
+   * @throws VeniceHttpException if the value is null or not "true" or "false"
+   */
+  public static boolean parseBooleanOrThrow(String value, String fieldName) {
+    if (value == null) {
+      throw new VeniceHttpException(
+          HttpStatus.SC_BAD_REQUEST,
+          fieldName + " must be a boolean, but value is null.",
+          ErrorType.BAD_REQUEST);
+    }
+    return parseBoolean(value, fieldName);
+  }
+
+  /**
+   * Parses a boolean from a string, ensuring that only null and valid boolean values ("true" or "false")
+   * are accepted. Returns false if the value is null.
+   *
+   * @param value the string to parse
+   * @param fieldName the name of the field being validated
+   * @return the parsed boolean value, or false if the input is null
+   * @throws VeniceHttpException if the value is not "true" or "false"
+   */
+  public static boolean parseBooleanOrFalse(String value, String fieldName) {
+    return value != null && parseBoolean(value, fieldName);
+  }
+
+  /**
+   * Validates the boolean string, allowing only "true" or "false".
+   * Throws an exception if the value is invalid.
+   */
+  private static boolean parseBoolean(String value, String fieldName) {
+    if (!"true".equalsIgnoreCase(value) && !"false".equalsIgnoreCase(value)) {
+      throw new VeniceHttpException(
+          HttpStatus.SC_BAD_REQUEST,
+          fieldName + " must be a boolean, but value: " + value + " is invalid.",
+          ErrorType.BAD_REQUEST);
+    }
+    return Boolean.parseBoolean(value);
+  }
+
+  /**
    * For String-String key-value map config, we expect the command-line interface users to use JSON
    * format to represent it. This method deserialize it to String-String map.
    */

--- a/internal/venice-common/src/test/java/com/linkedin/venice/utils/UtilsTest.java
+++ b/internal/venice-common/src/test/java/com/linkedin/venice/utils/UtilsTest.java
@@ -541,19 +541,6 @@ public class UtilsTest {
   }
 
   @Test(dataProvider = "booleanParsingData")
-  public void testParseBooleanFromString(String value, String fieldName, Boolean expectedResult) {
-    if (expectedResult != null) {
-      // For valid cases
-      boolean result = Utils.parseBooleanFromString(value, fieldName);
-      assertEquals(result, (boolean) expectedResult, "Parsed boolean value does not match expected value.");
-      return;
-    }
-    VeniceHttpException e =
-        expectThrows(VeniceHttpException.class, () -> Utils.parseBooleanFromString(value, fieldName));
-    assertEquals(e.getHttpStatusCode(), HttpStatus.SC_BAD_REQUEST, "Invalid status code.");
-  }
-
-  @Test(dataProvider = "booleanParsingData")
   public void testParseBooleanOrThrow(String value, String fieldName, Boolean expectedResult) {
     if (expectedResult != null) {
       // For valid cases

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/server/ControllerRoutes.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/server/ControllerRoutes.java
@@ -121,7 +121,7 @@ public class ControllerRoutes extends AbstractRoute {
     return updateKafkaTopicConfig(admin, adminRequest -> {
       AdminSparkServer.validateParams(adminRequest, UPDATE_KAFKA_TOPIC_LOG_COMPACTION.getParams(), admin);
       PubSubTopic topicName = pubSubTopicRepository.getTopic(adminRequest.queryParams(TOPIC));
-      boolean kafkaTopicLogCompactionEnabled = Utils.parseBooleanFromString(
+      boolean kafkaTopicLogCompactionEnabled = Utils.parseBooleanOrThrow(
           adminRequest.queryParams(KAFKA_TOPIC_LOG_COMPACTION_ENABLED),
           KAFKA_TOPIC_LOG_COMPACTION_ENABLED);
 

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/server/CreateVersion.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/server/CreateVersion.java
@@ -82,20 +82,19 @@ public class CreateVersion extends AbstractRoute {
     request.setPartitioners(httpRequest.queryParamOrDefault(PARTITIONERS, null));
 
     request.setSendStartOfPush(
-        Utils.parseBooleanFromString(httpRequest.queryParamOrDefault(SEND_START_OF_PUSH, "false"), SEND_START_OF_PUSH));
+        Utils.parseBooleanOrThrow(httpRequest.queryParamOrDefault(SEND_START_OF_PUSH, "false"), SEND_START_OF_PUSH));
 
     request.setSorted(
-        Utils.parseBooleanFromString(
-            httpRequest.queryParamOrDefault(PUSH_IN_SORTED_ORDER, "false"),
-            PUSH_IN_SORTED_ORDER));
+        Utils
+            .parseBooleanOrThrow(httpRequest.queryParamOrDefault(PUSH_IN_SORTED_ORDER, "false"), PUSH_IN_SORTED_ORDER));
 
     request.setWriteComputeEnabled(
-        Utils.parseBooleanFromString(
+        Utils.parseBooleanOrThrow(
             httpRequest.queryParamOrDefault(IS_WRITE_COMPUTE_ENABLED, "false"),
             IS_WRITE_COMPUTE_ENABLED));
 
     request.setSeparateRealTimeTopicEnabled(
-        Utils.parseBooleanFromString(
+        Utils.parseBooleanOrThrow(
             httpRequest.queryParamOrDefault(SEPARATE_REAL_TIME_TOPIC_ENABLED, "false"),
             SEPARATE_REAL_TIME_TOPIC_ENABLED));
 
@@ -109,7 +108,7 @@ public class CreateVersion extends AbstractRoute {
      * Version level override to defer marking this new version to the serving version post push completion.
      */
     request.setDeferVersionSwap(
-        Utils.parseBooleanFromString(httpRequest.queryParamOrDefault(DEFER_VERSION_SWAP, "false"), DEFER_VERSION_SWAP));
+        Utils.parseBooleanOrThrow(httpRequest.queryParamOrDefault(DEFER_VERSION_SWAP, "false"), DEFER_VERSION_SWAP));
 
     request.setTargetedRegions(httpRequest.queryParamOrDefault(TARGETED_REGIONS, null));
 

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/server/DataRecoveryRoutes.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/server/DataRecoveryRoutes.java
@@ -48,12 +48,11 @@ public class DataRecoveryRoutes extends AbstractRoute {
         int version = Utils.parseIntFromString(request.queryParams(VERSION), VERSION);
         String sourceFabric = request.queryParams(SOURCE_FABRIC);
         String destinationFabric = request.queryParams(FABRIC);
-        boolean copyAllVersionConfigs = Utils.parseBooleanFromString(
+        boolean copyAllVersionConfigs = Utils.parseBooleanOrThrow(
             request.queryParams(DATA_RECOVERY_COPY_ALL_VERSION_CONFIGS),
             DATA_RECOVERY_COPY_ALL_VERSION_CONFIGS);
-        boolean sourceVersionIncluded = Utils.parseBooleanFromString(
-            request.queryParams(SOURCE_FABRIC_VERSION_INCLUDED),
-            SOURCE_FABRIC_VERSION_INCLUDED);
+        boolean sourceVersionIncluded = Utils
+            .parseBooleanOrThrow(request.queryParams(SOURCE_FABRIC_VERSION_INCLUDED), SOURCE_FABRIC_VERSION_INCLUDED);
         Optional<Version> sourceVersion;
         if (sourceVersionIncluded) {
           Version sourceVersionObject = null;

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/server/RoutersClusterConfigRoutes.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/server/RoutersClusterConfigRoutes.java
@@ -37,7 +37,7 @@ public class RoutersClusterConfigRoutes extends AbstractRoute {
         AdminSparkServer.validateParams(request, ENABLE_THROTTLING.getParams(), admin);
         String clusterName = request.queryParams(CLUSTER);
         veniceResponse.setCluster(clusterName);
-        boolean status = Utils.parseBooleanFromString(request.queryParams(STATUS), "enableThrottling");
+        boolean status = Utils.parseBooleanOrThrow(request.queryParams(STATUS), "enableThrottling");
         admin.updateRoutersClusterConfig(
             clusterName,
             Optional.of(status),
@@ -62,7 +62,7 @@ public class RoutersClusterConfigRoutes extends AbstractRoute {
         AdminSparkServer.validateParams(request, ENABLE_MAX_CAPACITY_PROTECTION.getParams(), admin);
         String clusterName = request.queryParams(CLUSTER);
         veniceResponse.setCluster(clusterName);
-        boolean status = Utils.parseBooleanFromString(request.queryParams(STATUS), "enableMaxCapacityProtection");
+        boolean status = Utils.parseBooleanOrThrow(request.queryParams(STATUS), "enableMaxCapacityProtection");
         admin.updateRoutersClusterConfig(
             clusterName,
             Optional.empty(),
@@ -87,7 +87,7 @@ public class RoutersClusterConfigRoutes extends AbstractRoute {
         AdminSparkServer.validateParams(request, ENABLE_QUOTA_REBALANCED.getParams(), admin);
         String clusterName = request.queryParams(CLUSTER);
         veniceResponse.setCluster(clusterName);
-        boolean status = Utils.parseBooleanFromString(request.queryParams(STATUS), "enableQuotaRebalance");
+        boolean status = Utils.parseBooleanOrThrow(request.queryParams(STATUS), "enableQuotaRebalance");
         int expectedRouterCount =
             Utils.parseIntFromString(request.queryParams(EXPECTED_ROUTER_COUNT), "expectedRouterCount");
         admin.updateRoutersClusterConfig(

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/server/SkipAdminRoute.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/server/SkipAdminRoute.java
@@ -39,7 +39,7 @@ public class SkipAdminRoute extends AbstractRoute {
         AdminSparkServer.validateParams(request, SKIP_ADMIN.getParams(), admin);
         responseObject.setCluster(request.queryParams(CLUSTER));
         long offset = Utils.parseLongFromString(request.queryParams(OFFSET), OFFSET);
-        boolean skipDIV = Utils.parseBooleanFromString(request.queryParams(SKIP_DIV), SKIP_DIV);
+        boolean skipDIV = Utils.parseBooleanOrThrow(request.queryParams(SKIP_DIV), SKIP_DIV);
         admin.skipAdminMessage(responseObject.getCluster(), offset, skipDIV);
       } catch (Throwable e) {
         responseObject.setError(e);

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/server/StoresRoutes.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/server/StoresRoutes.java
@@ -520,7 +520,7 @@ public class StoresRoutes extends AbstractRoute {
           String clusterName = request.queryParams(CLUSTER);
           String storeName = request.queryParams(NAME);
           boolean abortMigratingStore =
-              Utils.parseBooleanFromString(request.queryParams(IS_ABORT_MIGRATION_CLEANUP), IS_ABORT_MIGRATION_CLEANUP);
+              Utils.parseBooleanOrFalse(request.queryParams(IS_ABORT_MIGRATION_CLEANUP), IS_ABORT_MIGRATION_CLEANUP);
           veniceResponse.setCluster(clusterName);
           veniceResponse.setName(storeName);
 

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/server/StoresRoutes.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/server/StoresRoutes.java
@@ -696,7 +696,7 @@ public class StoresRoutes extends AbstractRoute {
         String cluster = request.queryParams(CLUSTER);
         String storeName = request.queryParams(NAME);
         String operation = request.queryParams(OPERATION);
-        boolean status = Utils.parseBooleanFromString(request.queryParams(STATUS), "storeAccessStatus");
+        boolean status = Utils.parseBooleanOrThrow(request.queryParams(STATUS), "storeAccessStatus");
 
         veniceResponse.setCluster(cluster);
         veniceResponse.setName(storeName);
@@ -812,7 +812,7 @@ public class StoresRoutes extends AbstractRoute {
 
         String cluster = request.queryParams(CLUSTER);
         boolean enableActiveActiveReplicationForCluster =
-            Utils.parseBooleanFromString(request.queryParams(STATUS), STATUS);
+            Utils.parseBooleanOrThrow(request.queryParams(STATUS), STATUS);
         String regionsFilterParams = request.queryParamOrDefault(REGIONS_FILTER, null);
 
         admin.configureActiveActiveReplication(

--- a/services/venice-controller/src/test/java/com/linkedin/venice/controller/server/StoreRoutesTest.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/controller/server/StoreRoutesTest.java
@@ -101,7 +101,6 @@ public class StoreRoutesTest {
     Request request = mock(Request.class);
     doReturn(TEST_CLUSTER).when(request).queryParams(eq(ControllerApiConstants.CLUSTER));
     doReturn(TEST_STORE_NAME).when(request).queryParams(eq(ControllerApiConstants.NAME));
-    doReturn("true").when(request).queryParams(eq(ControllerApiConstants.IS_ABORT_MIGRATION_CLEANUP));
 
     Route deleteStoreRoute = new StoresRoutes(false, Optional.empty(), pubSubTopicRepository).deleteStore(mockAdmin);
     TrackableControllerResponse trackableControllerResponse = ObjectMapperFactory.getInstance()
@@ -112,6 +111,7 @@ public class StoreRoutesTest {
     Assert.assertEquals(trackableControllerResponse.getCluster(), TEST_CLUSTER);
     Assert.assertEquals(trackableControllerResponse.getName(), TEST_STORE_NAME);
 
+    doReturn("true").when(request).queryParams(eq(ControllerApiConstants.IS_ABORT_MIGRATION_CLEANUP));
     String errMessage = "Store " + TEST_STORE_NAME + "'s migrating flag is false. Not safe to delete a store "
         + "that is assumed to be migrating without the migrating flag setup as true.";
     doThrow(new VeniceException(errMessage, INVALID_CONFIG)).when(mockAdmin)


### PR DESCRIPTION
<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## [controller] Set default for `is_abort_migration_cleanup` to false when null
<!--
Describe
- What changes to make and why you are making these changes.
- How are you going to achieve your goal.
- Describe what testings you have done, for example, performance testing etc.

If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

Handle cases where `is_abort_migration_cleanup` is null by setting it to false. This ensures that the system remains backward compatible even when the value is not explicitly provided.

## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
Tested by adding comprehensive unit tests that cover the new functionality and ensure its correctness.
## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.