### PR TITLE
[fast-client] Added option to enable/disable retry budget

### DIFF
--- a/clients/venice-client/src/main/java/com/linkedin/venice/fastclient/ClientConfig.java
+++ b/clients/venice-client/src/main/java/com/linkedin/venice/fastclient/ClientConfig.java
@@ -87,6 +87,7 @@ public class ClientConfig<K, V, T extends SpecificRecord> {
   private boolean projectionFieldValidation;
   private Set<String> harClusters;
   private final InstanceHealthMonitor instanceHealthMonitor;
+  private final boolean retryBudgetEnabled;
 
   private final MetricsRepository metricsRepository;
 
@@ -121,7 +122,8 @@ public class ClientConfig<K, V, T extends SpecificRecord> {
       boolean projectionFieldValidation,
       long longTailRetryBudgetEnforcementWindowInMs,
       Set<String> harClusters,
-      InstanceHealthMonitor instanceHealthMonitor) {
+      InstanceHealthMonitor instanceHealthMonitor,
+      boolean retryBudgetEnabled) {
     if (storeName == null || storeName.isEmpty()) {
       throw new VeniceClientException("storeName param shouldn't be empty");
     }
@@ -239,6 +241,7 @@ public class ClientConfig<K, V, T extends SpecificRecord> {
     } else {
       this.instanceHealthMonitor = instanceHealthMonitor;
     }
+    this.retryBudgetEnabled = retryBudgetEnabled;
   }
 
   public String getStoreName() {
@@ -375,6 +378,10 @@ public class ClientConfig<K, V, T extends SpecificRecord> {
     return instanceHealthMonitor;
   }
 
+  public boolean isRetryBudgetEnabled() {
+    return retryBudgetEnabled;
+  }
+
   public static class ClientConfigBuilder<K, V, T extends SpecificRecord> {
     private MetricsRepository metricsRepository;
     private String statsPrefix = "";
@@ -418,6 +425,8 @@ public class ClientConfig<K, V, T extends SpecificRecord> {
     private Set<String> harClusters = Collections.EMPTY_SET;
 
     private InstanceHealthMonitor instanceHealthMonitor;
+
+    private boolean retryBudgetEnabled = false;
 
     public ClientConfigBuilder<K, V, T> setStoreName(String storeName) {
       this.storeName = storeName;
@@ -587,6 +596,11 @@ public class ClientConfig<K, V, T extends SpecificRecord> {
       return this;
     }
 
+    public ClientConfigBuilder<K, V, T> setRetryBudgetEnabled(boolean retryBudgetEnabled) {
+      this.retryBudgetEnabled = retryBudgetEnabled;
+      return this;
+    }
+
     public ClientConfigBuilder<K, V, T> clone() {
       return new ClientConfigBuilder().setStoreName(storeName)
           .setR2Client(r2Client)
@@ -619,7 +633,8 @@ public class ClientConfig<K, V, T extends SpecificRecord> {
           .setProjectionFieldValidationEnabled(projectionFieldValidation)
           .setLongTailRetryBudgetEnforcementWindowInMs(longTailRetryBudgetEnforcementWindowInMs)
           .setHARClusters(harClusters)
-          .setInstanceHealthMonitor(instanceHealthMonitor);
+          .setInstanceHealthMonitor(instanceHealthMonitor)
+          .setRetryBudgetEnabled(retryBudgetEnabled);
     }
 
     public ClientConfig<K, V, T> build() {
@@ -654,7 +669,8 @@ public class ClientConfig<K, V, T extends SpecificRecord> {
           projectionFieldValidation,
           longTailRetryBudgetEnforcementWindowInMs,
           harClusters,
-          instanceHealthMonitor);
+          instanceHealthMonitor,
+          retryBudgetEnabled);
     }
   }
 }

--- a/clients/venice-client/src/test/java/com/linkedin/venice/fastclient/RetriableAvroGenericStoreClientRetryBudgetTest.java
+++ b/clients/venice-client/src/test/java/com/linkedin/venice/fastclient/RetriableAvroGenericStoreClientRetryBudgetTest.java
@@ -1,0 +1,9 @@
+package com.linkedin.venice.fastclient;
+
+public class RetriableAvroGenericStoreClientRetryBudgetTest extends RetriableAvroGenericStoreClientTest {
+  @Override
+  protected boolean isRetryBudgetEnabled() {
+    return true;
+  }
+
+}

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/fastclient/FastClientIndividualFeatureConfigurationTest.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/fastclient/FastClientIndividualFeatureConfigurationTest.java
@@ -451,7 +451,8 @@ public class FastClientIndividualFeatureConfigurationTest extends AbstractClient
                     InstanceHealthMonitorConfig.builder()
                         .setClient(r2Client)
                         .setRoutingRequestDefaultTimeoutMS(10000)
-                        .build()));
+                        .build()))
+            .setRetryBudgetEnabled(true);
     String multiKeyLongTailRetryManagerStatsPrefix = ".multi-key-long-tail-retry-manager-" + storeName + "--";
     String singleKeyLongTailRetryManagerStatsPrefix = ".single-key-long-tail-retry-manager-" + storeName + "--";
     MetricsRepository clientMetric = new MetricsRepository();


### PR DESCRIPTION
So far, the retry budget feature doesn't work well with low QPS (retry requests are being rejected),
so this PR introduces a config option to enable/disable this feature and it also disables this feature by default.
We will re-enable it by default once we figure out a way to make it work for all kinds of scenarios.

New client config:
retryBudgetEnabled: default false

<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

<!--
Describe
- What changes to make and why you are making these changes.
- How are you going to achieve your goal.
- Describe what testings you have done, for example, performance testing etc.

If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->


## How was this PR tested?
CI
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [ ] No. You can skip the rest of this section.
- [x] Yes. Make sure to explain your proposed changes and call out the behavior change.