### PR TITLE
[changelog] Make changes for venice view consumption

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/consumer/ChangelogClientConfig.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/consumer/ChangelogClientConfig.java
@@ -229,7 +229,7 @@ public class ChangelogClientConfig<T extends SpecificRecord> {
     return isBeforeImageView;
   }
 
-  protected ChangelogClientConfig setIsBeforeImageView(Boolean beforeImageView) {
+  public ChangelogClientConfig setIsBeforeImageView(Boolean beforeImageView) {
     isBeforeImageView = beforeImageView;
     return this;
   }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/consumer/ChangelogClientConfig.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/consumer/ChangelogClientConfig.java
@@ -12,6 +12,7 @@ public class ChangelogClientConfig<T extends SpecificRecord> {
   private Properties consumerProperties;
   private SchemaReader schemaReader;
   private String viewName;
+  private Boolean isBeforeImageView = false;
 
   private String consumerName = "";
 
@@ -219,7 +220,17 @@ public class ChangelogClientConfig<T extends SpecificRecord> {
         .setRocksDBBlockCacheSizeInBytes(config.getRocksDBBlockCacheSizeInBytes())
         .setConsumerName(config.consumerName)
         .setDatabaseSyncBytesInterval(config.getDatabaseSyncBytesInterval())
-        .setShouldCompactMessages(config.shouldCompactMessages());
+        .setShouldCompactMessages(config.shouldCompactMessages())
+        .setIsBeforeImageView(config.isBeforeImageView());
     return newConfig;
+  }
+
+  protected Boolean isBeforeImageView() {
+    return isBeforeImageView;
+  }
+
+  protected ChangelogClientConfig setIsBeforeImageView(Boolean beforeImageView) {
+    isBeforeImageView = beforeImageView;
+    return this;
   }
 }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/consumer/InternalLocalBootstrappingVeniceChangelogConsumer.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/consumer/InternalLocalBootstrappingVeniceChangelogConsumer.java
@@ -94,7 +94,8 @@ class InternalLocalBootstrappingVeniceChangelogConsumer<K, V> extends VeniceAfte
     bootstrapStateMap = new VeniceConcurrentHashMap<>();
     syncBytesInterval = changelogClientConfig.getDatabaseSyncBytesInterval();
     metricsRepository = changelogClientConfig.getInnerClientConfig().getMetricsRepository();
-    String localStateTopicNameTemp = changelogClientConfig.getStoreName() + LOCAL_STATE_TOPIC_SUFFIX;
+    String viewNamePath = changelogClientConfig.getViewName() == null ? "" : "- " + changelogClientConfig.getViewName();
+    String localStateTopicNameTemp = changelogClientConfig.getStoreName() + viewNamePath + LOCAL_STATE_TOPIC_SUFFIX;
     String bootstrapFileSystemPath = changelogClientConfig.getBootstrapFileSystemPath();
     if (StringUtils.isNotEmpty(consumerId)) {
       localStateTopicNameTemp += "-" + consumerId;

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/consumer/InternalLocalBootstrappingVeniceChangelogConsumer.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/consumer/InternalLocalBootstrappingVeniceChangelogConsumer.java
@@ -94,7 +94,7 @@ class InternalLocalBootstrappingVeniceChangelogConsumer<K, V> extends VeniceAfte
     bootstrapStateMap = new VeniceConcurrentHashMap<>();
     syncBytesInterval = changelogClientConfig.getDatabaseSyncBytesInterval();
     metricsRepository = changelogClientConfig.getInnerClientConfig().getMetricsRepository();
-    String viewNamePath = changelogClientConfig.getViewName() == null ? "" : "- " + changelogClientConfig.getViewName();
+    String viewNamePath = changelogClientConfig.getViewName() == null ? "" : "-" + changelogClientConfig.getViewName();
     String localStateTopicNameTemp = changelogClientConfig.getStoreName() + viewNamePath + LOCAL_STATE_TOPIC_SUFFIX;
     String bootstrapFileSystemPath = changelogClientConfig.getBootstrapFileSystemPath();
     if (StringUtils.isNotEmpty(consumerId)) {

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/consumer/InternalLocalBootstrappingVeniceChangelogConsumer.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/consumer/InternalLocalBootstrappingVeniceChangelogConsumer.java
@@ -508,10 +508,9 @@ class InternalLocalBootstrappingVeniceChangelogConsumer<K, V> extends VeniceAfte
 
     storageService.start();
     try {
-      // storeRepository.start();
       storeRepository.subscribe(storeName);
     } catch (InterruptedException e) {
-      throw new RuntimeException(e);
+      throw new VeniceException("Failed to start bootstrapping changelog consumer with error:", e);
     }
 
     return seekWithBootStrap(partitions);

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/consumer/InternalLocalBootstrappingVeniceChangelogConsumer.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/consumer/InternalLocalBootstrappingVeniceChangelogConsumer.java
@@ -183,7 +183,8 @@ class InternalLocalBootstrappingVeniceChangelogConsumer<K, V> extends VeniceAfte
   protected boolean handleVersionSwapControlMessage(
       ControlMessage controlMessage,
       PubSubTopicPartition pubSubTopicPartition,
-      String topicSuffix) {
+      String topicSuffix,
+      Integer upstreamPartition) {
     ControlMessageType controlMessageType = ControlMessageType.valueOf(controlMessage);
     if (controlMessageType.equals(ControlMessageType.VERSION_SWAP)) {
       VersionSwap versionSwap = (VersionSwap) controlMessage.controlMessageUnion;
@@ -506,7 +507,7 @@ class InternalLocalBootstrappingVeniceChangelogConsumer<K, V> extends VeniceAfte
 
     storageService.start();
     try {
-      storeRepository.start();
+      // storeRepository.start();
       storeRepository.subscribe(storeName);
     } catch (InterruptedException e) {
       throw new RuntimeException(e);

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/consumer/InternalLocalBootstrappingVeniceChangelogConsumer.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/consumer/InternalLocalBootstrappingVeniceChangelogConsumer.java
@@ -525,7 +525,7 @@ class InternalLocalBootstrappingVeniceChangelogConsumer<K, V> extends VeniceAfte
       throw new VeniceException("Failed to start bootstrapping changelog consumer with error:", e);
     }
     Store store = storeRepository.getStore(storeName);
-    for (int partition = 0; partition < store.getPartitionCount(); partition++) {
+    for (int partition = 0; partition < store.getVersion(store.getCurrentVersion()).getPartitionCount(); partition++) {
       allPartitions.add(partition);
     }
     return this.start(allPartitions);

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/consumer/InternalLocalBootstrappingVeniceChangelogConsumer.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/consumer/InternalLocalBootstrappingVeniceChangelogConsumer.java
@@ -520,6 +520,11 @@ class InternalLocalBootstrappingVeniceChangelogConsumer<K, V> extends VeniceAfte
   @Override
   public CompletableFuture<Void> start() {
     Set<Integer> allPartitions = new HashSet<>();
+    try {
+      storeRepository.subscribe(storeName);
+    } catch (InterruptedException e) {
+      throw new VeniceException("Failed to start bootstrapping changelog consumer with error:", e);
+    }
     Store store = storeRepository.getStore(storeName);
     for (int partition = 0; partition < store.getPartitionCount(); partition++) {
       allPartitions.add(partition);

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/consumer/InternalLocalBootstrappingVeniceChangelogConsumer.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/consumer/InternalLocalBootstrappingVeniceChangelogConsumer.java
@@ -31,6 +31,7 @@ import com.linkedin.venice.kafka.protocol.enums.ControlMessageType;
 import com.linkedin.venice.kafka.protocol.state.PartitionState;
 import com.linkedin.venice.kafka.protocol.state.StoreVersionState;
 import com.linkedin.venice.meta.PersistenceType;
+import com.linkedin.venice.meta.Store;
 import com.linkedin.venice.offsets.OffsetRecord;
 import com.linkedin.venice.pubsub.adapter.kafka.ApacheKafkaOffsetPosition;
 import com.linkedin.venice.pubsub.api.PubSubConsumerAdapter;
@@ -519,7 +520,8 @@ class InternalLocalBootstrappingVeniceChangelogConsumer<K, V> extends VeniceAfte
   @Override
   public CompletableFuture<Void> start() {
     Set<Integer> allPartitions = new HashSet<>();
-    for (int partition = 0; partition < partitionCount; partition++) {
+    Store store = storeRepository.getStore(storeName);
+    for (int partition = 0; partition < store.getPartitionCount(); partition++) {
       allPartitions.add(partition);
     }
     return this.start(allPartitions);

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/consumer/VeniceAfterImageConsumerImpl.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/consumer/VeniceAfterImageConsumerImpl.java
@@ -93,6 +93,11 @@ public class VeniceAfterImageConsumerImpl<K, V> extends VeniceChangelogConsumerI
     if (partitions.isEmpty()) {
       return CompletableFuture.completedFuture(null);
     }
+    try {
+      storeRepository.subscribe(storeName);
+    } catch (InterruptedException e) {
+      throw new VeniceException("Failed to start bootstrapping changelog consumer with error:", e);
+    }
     if (!versionSwapThreadScheduled.get()) {
       // schedule the version swap thread and set up the callback listener
       this.storeRepository.registerStoreDataChangedListener(versionSwapListener);

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/consumer/VeniceAfterImageConsumerImpl.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/consumer/VeniceAfterImageConsumerImpl.java
@@ -2,6 +2,7 @@ package com.linkedin.davinci.consumer;
 
 import com.linkedin.alpini.base.concurrency.Executors;
 import com.linkedin.alpini.base.concurrency.ScheduledExecutorService;
+import com.linkedin.davinci.repository.NativeMetadataRepositoryViewAdapter;
 import com.linkedin.venice.exceptions.VeniceException;
 import com.linkedin.venice.kafka.protocol.ControlMessage;
 import com.linkedin.venice.kafka.protocol.KafkaMessageEnvelope;
@@ -207,5 +208,11 @@ public class VeniceAfterImageConsumerImpl<K, V> extends VeniceChangelogConsumerI
       // repository change.
       versionSwapListener.handleStoreChanged(null);
     }
+  }
+
+  @Override
+  public void setStoreRepository(NativeMetadataRepositoryViewAdapter repository) {
+    super.setStoreRepository(repository);
+    versionSwapListener.setStoreRepository(repository);
   }
 }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/consumer/VeniceChangelogConsumerClientFactory.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/consumer/VeniceChangelogConsumerClientFactory.java
@@ -78,7 +78,7 @@ public class VeniceChangelogConsumerClientFactory {
       String viewClass = getViewClass(newStoreChangelogClientConfig, storeName);
       String consumerName = suffixConsumerIdToStore(storeName + "-" + viewClass.getClass().getSimpleName(), consumerId);
       if (viewClass.equals(ChangeCaptureView.class.getCanonicalName())) {
-        // TODO: This is a little bit of a back. This is to deal with the an issue where the before image change
+        // TODO: This is a little bit of a hack. This is to deal with the an issue where the before image change
         // capture topic doesn't follow the same naming convention as view topics.
         newStoreChangelogClientConfig.setIsBeforeImageView(true);
         return new VeniceChangelogConsumerImpl(

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/consumer/VeniceChangelogConsumerClientFactory.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/consumer/VeniceChangelogConsumerClientFactory.java
@@ -78,6 +78,9 @@ public class VeniceChangelogConsumerClientFactory {
       String viewClass = getViewClass(newStoreChangelogClientConfig, storeName);
       String consumerName = suffixConsumerIdToStore(storeName + "-" + viewClass.getClass().getSimpleName(), consumerId);
       if (viewClass.equals(ChangeCaptureView.class.getCanonicalName())) {
+        // TODO: This is a little bit of a back. This is to deal with the an issue where the before image change
+        // capture topic doesn't follow the same naming convention as view topics.
+        newStoreChangelogClientConfig.setIsBeforeImageView(true);
         return new VeniceChangelogConsumerImpl(
             newStoreChangelogClientConfig,
             consumer != null

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/consumer/VeniceChangelogConsumerImpl.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/consumer/VeniceChangelogConsumerImpl.java
@@ -803,20 +803,6 @@ public class VeniceChangelogConsumerImpl<K, V> implements VeniceChangelogConsume
         compressor = compressorMap.get(pubSubTopicPartition.getPartitionNumber());
       }
 
-      // if (pubSubTopicPartition.getPubSubTopic().isVersionTopic()) {
-      // deserializerProvider = Lazy.of(() -> storeDeserializerCache.getDeserializer(put.schemaId, put.schemaId));
-      // readerSchemaId = put.schemaId;
-      // } else {
-      // deserializerProvider = Lazy.of(() -> recordChangeDeserializer);
-      // readerSchemaId = this.schemaReader.getLatestValueSchemaId();
-      // }
-      //
-      // if (pubSubTopicPartition.getPubSubTopic().isVersionTopic()) {
-      // compressor = compressorMap.get(pubSubTopicPartition.getPartitionNumber());
-      // } else {
-      // compressor = NO_OP_COMPRESSOR;
-      // }
-
       assembledObject = chunkAssembler.bufferAndAssembleRecord(
           pubSubTopicPartition,
           put.getSchemaId(),

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/consumer/VeniceChangelogConsumerImpl.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/consumer/VeniceChangelogConsumerImpl.java
@@ -200,7 +200,7 @@ public class VeniceChangelogConsumerImpl<K, V> implements VeniceChangelogConsume
   @Override
   public int getPartitionCount() {
     Store store = getStore();
-    return store.getPartitionCount();
+    return store.getVersion(store.getCurrentVersion()).getPartitionCount();
   }
 
   @Override
@@ -453,8 +453,7 @@ public class VeniceChangelogConsumerImpl<K, V> implements VeniceChangelogConsume
 
   @Override
   public CompletableFuture<Void> subscribeAll() {
-    Store store = getStore();
-    return this.subscribe(IntStream.range(0, store.getPartitionCount()).boxed().collect(Collectors.toSet()));
+    return this.subscribe(IntStream.range(0, getPartitionCount()).boxed().collect(Collectors.toSet()));
   }
 
   @Override
@@ -579,8 +578,7 @@ public class VeniceChangelogConsumerImpl<K, V> implements VeniceChangelogConsume
   @Override
   public void unsubscribeAll() {
     Set<Integer> allPartitions = new HashSet<>();
-    Store store = getStore();
-    for (int partition = 0; partition < store.getPartitionCount(); partition++) {
+    for (int partition = 0; partition < getPartitionCount(); partition++) {
       allPartitions.add(partition);
     }
     this.unsubscribe(allPartitions);

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/consumer/VersionSwapDataChangeListener.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/consumer/VersionSwapDataChangeListener.java
@@ -1,5 +1,6 @@
 package com.linkedin.davinci.consumer;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.linkedin.davinci.repository.NativeMetadataRepositoryViewAdapter;
 import com.linkedin.venice.meta.Store;
 import com.linkedin.venice.meta.StoreDataChangedListener;
@@ -14,7 +15,7 @@ import org.apache.logging.log4j.Logger;
 class VersionSwapDataChangeListener<K, V> implements StoreDataChangedListener {
   private static final Logger LOGGER = LogManager.getLogger(VersionSwapDataChangeListener.class);
   private final VeniceAfterImageConsumerImpl<K, V> consumer;
-  private final NativeMetadataRepositoryViewAdapter storeRepository;
+  private NativeMetadataRepositoryViewAdapter storeRepository;
   private final String storeName;
   private final String consumerName;
 
@@ -70,5 +71,10 @@ class VersionSwapDataChangeListener<K, V> implements StoreDataChangedListener {
             e);
       }
     }
+  }
+
+  @VisibleForTesting
+  void setStoreRepository(NativeMetadataRepositoryViewAdapter storeRepository) {
+    this.storeRepository = storeRepository;
   }
 }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/consumer/VersionSwapDataChangeListener.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/consumer/VersionSwapDataChangeListener.java
@@ -32,12 +32,12 @@ class VersionSwapDataChangeListener<K, V> implements StoreDataChangedListener {
 
   @Override
   public void handleStoreChanged(Store store) {
-    // store may be null as this is called by other repair tasks
-    if (!consumer.subscribed()) {
-      // skip this for now as the consumer hasn't even been set up yet
-      return;
-    }
     synchronized (this) {
+      // store may be null as this is called by other repair tasks
+      if (!consumer.subscribed()) {
+        // skip this for now as the consumer hasn't even been set up yet
+        return;
+      }
       Set<Integer> partitions = new HashSet<>();
       try {
         // Check the current version of the server
@@ -75,6 +75,9 @@ class VersionSwapDataChangeListener<K, V> implements StoreDataChangedListener {
 
   @VisibleForTesting
   void setStoreRepository(NativeMetadataRepositoryViewAdapter storeRepository) {
-    this.storeRepository = storeRepository;
+    // This is chiefly to make static analysis happy
+    synchronized (this) {
+      this.storeRepository = storeRepository;
+    }
   }
 }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/consumer/VersionSwapDataChangeListener.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/consumer/VersionSwapDataChangeListener.java
@@ -6,6 +6,7 @@ import com.linkedin.venice.meta.Store;
 import com.linkedin.venice.meta.StoreDataChangedListener;
 import com.linkedin.venice.meta.Version;
 import com.linkedin.venice.pubsub.api.PubSubTopicPartition;
+import com.linkedin.venice.views.VeniceView;
 import java.util.HashSet;
 import java.util.Set;
 import org.apache.logging.log4j.LogManager;
@@ -51,7 +52,12 @@ class VersionSwapDataChangeListener<K, V> implements StoreDataChangedListener {
 
         // for all partition subscriptions that are not subscribed to the current version, resubscribe them
         for (PubSubTopicPartition topicPartition: subscriptions) {
-          int version = Version.parseVersionFromVersionTopicName(topicPartition.getPubSubTopic().getName());
+          int version;
+          if (topicPartition.getPubSubTopic().isViewTopic()) {
+            version = VeniceView.parseVersionFromViewTopic(topicPartition.getPubSubTopic().getName());
+          } else {
+            version = Version.parseVersionFromVersionTopicName(topicPartition.getPubSubTopic().getName());
+          }
           if (version != currentVersion) {
             partitions.add(topicPartition.getPartitionNumber());
           }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/consumer/VersionSwapDataChangeListener.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/consumer/VersionSwapDataChangeListener.java
@@ -1,6 +1,6 @@
 package com.linkedin.davinci.consumer;
 
-import com.linkedin.davinci.repository.ThinClientMetaStoreBasedRepository;
+import com.linkedin.davinci.repository.NativeMetadataRepositoryViewAdapter;
 import com.linkedin.venice.meta.Store;
 import com.linkedin.venice.meta.StoreDataChangedListener;
 import com.linkedin.venice.meta.Version;
@@ -14,13 +14,13 @@ import org.apache.logging.log4j.Logger;
 class VersionSwapDataChangeListener<K, V> implements StoreDataChangedListener {
   private static final Logger LOGGER = LogManager.getLogger(VersionSwapDataChangeListener.class);
   private final VeniceAfterImageConsumerImpl<K, V> consumer;
-  private final ThinClientMetaStoreBasedRepository storeRepository;
+  private final NativeMetadataRepositoryViewAdapter storeRepository;
   private final String storeName;
   private final String consumerName;
 
   VersionSwapDataChangeListener(
       VeniceAfterImageConsumerImpl<K, V> consumer,
-      ThinClientMetaStoreBasedRepository storeRepository,
+      NativeMetadataRepositoryViewAdapter storeRepository,
       String storeName,
       String consumerName) {
     this.consumer = consumer;

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/store/view/ChangeCaptureViewWriter.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/store/view/ChangeCaptureViewWriter.java
@@ -152,6 +152,11 @@ public class ChangeCaptureViewWriter extends VeniceViewWriter {
   }
 
   @Override
+  public String composeTopicName(int version) {
+    return internalView.composeTopicName(version);
+  }
+
+  @Override
   public String getWriterClassName() {
     return internalView.getWriterClassName();
   }

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/consumer/InternalLocalBootstrappingVeniceChangelogConsumerTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/consumer/InternalLocalBootstrappingVeniceChangelogConsumerTest.java
@@ -189,11 +189,13 @@ public class InternalLocalBootstrappingVeniceChangelogConsumerTest {
     metadataRepository = mock(NativeMetadataRepositoryViewAdapter.class);
     Store store = mock(Store.class);
     Version mockVersion = new VersionImpl(storeName, 1, "foo");
+    mockVersion.setPartitionCount(2);
     when(store.getCurrentVersion()).thenReturn(1);
     when(store.getCompressionStrategy()).thenReturn(CompressionStrategy.NO_OP);
     when(store.getPartitionCount()).thenReturn(2);
     when(metadataRepository.getStore(anyString())).thenReturn(store);
     when(store.getVersionOrThrow(Mockito.anyInt())).thenReturn(mockVersion);
+    when(store.getVersion(Mockito.anyInt())).thenReturn(mockVersion);
     when(metadataRepository.getValueSchema(storeName, TEST_SCHEMA_ID))
         .thenReturn(new SchemaEntry(TEST_SCHEMA_ID, valueSchema));
     bootstrappingVeniceChangelogConsumer.setStoreRepository(metadataRepository);

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/consumer/InternalLocalBootstrappingVeniceChangelogConsumerTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/consumer/InternalLocalBootstrappingVeniceChangelogConsumerTest.java
@@ -180,7 +180,8 @@ public class InternalLocalBootstrappingVeniceChangelogConsumerTest {
             .setConsumerProperties(consumerProperties)
             .setLocalD2ZkHosts(TEST_ZOOKEEPER_ADDRESS)
             .setRocksDBBlockCacheSizeInBytes(TEST_ROCKSDB_BLOCK_CACHE_SIZE_IN_BYTES)
-            .setDatabaseSyncBytesInterval(TEST_DB_SYNC_BYTES_INTERVAL);
+            .setDatabaseSyncBytesInterval(TEST_DB_SYNC_BYTES_INTERVAL)
+            .setIsBeforeImageView(true);
     changelogClientConfig.getInnerClientConfig().setMetricsRepository(new MetricsRepository());
     bootstrappingVeniceChangelogConsumer =
         new InternalLocalBootstrappingVeniceChangelogConsumer<>(changelogClientConfig, pubSubConsumer, null);
@@ -190,6 +191,7 @@ public class InternalLocalBootstrappingVeniceChangelogConsumerTest {
     Version mockVersion = new VersionImpl(storeName, 1, "foo");
     when(store.getCurrentVersion()).thenReturn(1);
     when(store.getCompressionStrategy()).thenReturn(CompressionStrategy.NO_OP);
+    when(store.getPartitionCount()).thenReturn(2);
     when(metadataRepository.getStore(anyString())).thenReturn(store);
     when(store.getVersionOrThrow(Mockito.anyInt())).thenReturn(mockVersion);
     when(metadataRepository.getValueSchema(storeName, TEST_SCHEMA_ID))
@@ -230,7 +232,7 @@ public class InternalLocalBootstrappingVeniceChangelogConsumerTest {
     verify(mockStorageService, times(1)).start();
     verify(mockStorageService, times(1)).openStoreForNewPartition(any(), eq(0), any());
     verify(mockStorageService, times(1)).openStoreForNewPartition(any(), eq(1), any());
-    verify(metadataRepository, times(1)).subscribe(storeName);
+    verify(metadataRepository, times(2)).subscribe(storeName);
     verify(pubSubConsumer, times(1)).subscribe(topicPartition_0, LOWEST_OFFSET);
     verify(pubSubConsumer, times(1)).subscribe(topicPartition_1, LOWEST_OFFSET);
     verify(pubSubConsumer, times(1)).subscribe(topicPartition_0, 0L);

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/consumer/InternalLocalBootstrappingVeniceChangelogConsumerTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/consumer/InternalLocalBootstrappingVeniceChangelogConsumerTest.java
@@ -129,7 +129,7 @@ public class InternalLocalBootstrappingVeniceChangelogConsumerTest {
   @BeforeMethod
   public void setUp() {
     storeName = Utils.getUniqueString();
-    localStateTopicName = storeName + "_Bootstrap_v1";
+    localStateTopicName = storeName + "-changeCaptureView" + "_Bootstrap_v1";
     schemaReader = mock(SchemaReader.class);
     Schema keySchema = AvroCompatibilityHelper.parse("\"string\"");
     doReturn(keySchema).when(schemaReader).getKeySchema();

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/consumer/InternalLocalBootstrappingVeniceChangelogConsumerTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/consumer/InternalLocalBootstrappingVeniceChangelogConsumerTest.java
@@ -18,7 +18,7 @@ import static org.mockito.Mockito.when;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.linkedin.avroutil1.compatibility.AvroCompatibilityHelper;
-import com.linkedin.davinci.repository.ThinClientMetaStoreBasedRepository;
+import com.linkedin.davinci.repository.NativeMetadataRepositoryViewAdapter;
 import com.linkedin.davinci.storage.StorageEngineMetadataService;
 import com.linkedin.davinci.storage.StorageEngineRepository;
 import com.linkedin.davinci.storage.StorageMetadataService;
@@ -113,7 +113,7 @@ public class InternalLocalBootstrappingVeniceChangelogConsumerTest {
   private RecordSerializer<String> keySerializer;
   private RecordSerializer<String> valueSerializer;
   private PubSubConsumerAdapter pubSubConsumer;
-  private ThinClientMetaStoreBasedRepository metadataRepository;
+  private NativeMetadataRepositoryViewAdapter metadataRepository;
   private PubSubTopic changeCaptureTopic;
   private SchemaReader schemaReader;
   private Schema valueSchema;
@@ -185,7 +185,7 @@ public class InternalLocalBootstrappingVeniceChangelogConsumerTest {
     bootstrappingVeniceChangelogConsumer =
         new InternalLocalBootstrappingVeniceChangelogConsumer<>(changelogClientConfig, pubSubConsumer, null);
 
-    metadataRepository = mock(ThinClientMetaStoreBasedRepository.class);
+    metadataRepository = mock(NativeMetadataRepositoryViewAdapter.class);
     Store store = mock(Store.class);
     Version mockVersion = new VersionImpl(storeName, 1, "foo");
     when(store.getCurrentVersion()).thenReturn(1);
@@ -230,7 +230,6 @@ public class InternalLocalBootstrappingVeniceChangelogConsumerTest {
     verify(mockStorageService, times(1)).start();
     verify(mockStorageService, times(1)).openStoreForNewPartition(any(), eq(0), any());
     verify(mockStorageService, times(1)).openStoreForNewPartition(any(), eq(1), any());
-    verify(metadataRepository, times(1)).start();
     verify(metadataRepository, times(1)).subscribe(storeName);
     verify(pubSubConsumer, times(1)).subscribe(topicPartition_0, LOWEST_OFFSET);
     verify(pubSubConsumer, times(1)).subscribe(topicPartition_1, LOWEST_OFFSET);

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/consumer/VeniceChangelogConsumerClientFactoryTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/consumer/VeniceChangelogConsumerClientFactoryTest.java
@@ -270,9 +270,11 @@ public class VeniceChangelogConsumerClientFactoryTest {
     NativeMetadataRepositoryViewAdapter mockRepository = mock(NativeMetadataRepositoryViewAdapter.class);
     Store store = mock(Store.class);
     Version mockVersion = new VersionImpl(STORE_NAME, 1, "foo");
+    mockVersion.setPartitionCount(2);
     Mockito.when(store.getCurrentVersion()).thenReturn(1);
     Mockito.when(store.getCompressionStrategy()).thenReturn(CompressionStrategy.NO_OP);
     Mockito.when(store.getPartitionCount()).thenReturn(2);
+    Mockito.when(store.getVersion(anyInt())).thenReturn(mockVersion);
     Mockito.when(mockRepository.getStore(anyString())).thenReturn(store);
     Mockito.when(store.getVersionOrThrow(Mockito.anyInt())).thenReturn(mockVersion);
 

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/consumer/VeniceChangelogConsumerClientFactoryTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/consumer/VeniceChangelogConsumerClientFactoryTest.java
@@ -3,18 +3,24 @@ package com.linkedin.davinci.consumer;
 import static com.linkedin.venice.ConfigKeys.CLUSTER_NAME;
 import static com.linkedin.venice.ConfigKeys.KAFKA_BOOTSTRAP_SERVERS;
 import static com.linkedin.venice.ConfigKeys.ZOOKEEPER_ADDRESS;
+import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.linkedin.d2.balancer.D2Client;
 import com.linkedin.data.ByteString;
+import com.linkedin.davinci.repository.NativeMetadataRepositoryViewAdapter;
 import com.linkedin.r2.message.rest.RestResponse;
 import com.linkedin.venice.client.store.schemas.TestKeyRecord;
+import com.linkedin.venice.compression.CompressionStrategy;
 import com.linkedin.venice.controllerapi.D2ControllerClient;
 import com.linkedin.venice.controllerapi.D2ServiceDiscoveryResponse;
 import com.linkedin.venice.controllerapi.StoreResponse;
+import com.linkedin.venice.meta.Store;
 import com.linkedin.venice.meta.StoreInfo;
+import com.linkedin.venice.meta.Version;
+import com.linkedin.venice.meta.VersionImpl;
 import com.linkedin.venice.meta.ViewConfig;
 import com.linkedin.venice.meta.ViewConfigImpl;
 import com.linkedin.venice.pubsub.api.PubSubConsumerAdapter;
@@ -234,7 +240,8 @@ public class VeniceChangelogConsumerClientFactoryTest {
         new ChangelogClientConfig().setConsumerProperties(consumerProperties)
             .setSchemaReader(mockSchemaReader)
             .setBootstrapFileSystemPath(TEST_BOOTSTRAP_FILE_SYSTEM_PATH)
-            .setLocalD2ZkHosts(TEST_ZOOKEEPER_ADDRESS);
+            .setLocalD2ZkHosts(TEST_ZOOKEEPER_ADDRESS)
+            .setIsBeforeImageView(true);
     VeniceChangelogConsumerClientFactory veniceChangelogConsumerClientFactory =
         new VeniceChangelogConsumerClientFactory(globalChangelogClientConfig, new MetricsRepository());
     D2ControllerClient mockControllerClient = Mockito.mock(D2ControllerClient.class);
@@ -259,6 +266,18 @@ public class VeniceChangelogConsumerClientFactoryTest {
     Assert.assertTrue(consumer instanceof LocalBootstrappingVeniceChangelogConsumer);
 
     globalChangelogClientConfig.setViewName(VIEW_NAME);
+
+    NativeMetadataRepositoryViewAdapter mockRepository = mock(NativeMetadataRepositoryViewAdapter.class);
+    Store store = mock(Store.class);
+    Version mockVersion = new VersionImpl(STORE_NAME, 1, "foo");
+    Mockito.when(store.getCurrentVersion()).thenReturn(1);
+    Mockito.when(store.getCompressionStrategy()).thenReturn(CompressionStrategy.NO_OP);
+    Mockito.when(store.getPartitionCount()).thenReturn(2);
+    Mockito.when(mockRepository.getStore(anyString())).thenReturn(store);
+    Mockito.when(store.getVersionOrThrow(Mockito.anyInt())).thenReturn(mockVersion);
+
+    ((LocalBootstrappingVeniceChangelogConsumer) consumer).setStoreRepository(mockRepository);
+
     consumer = veniceChangelogConsumerClientFactory.getBootstrappingChangelogConsumer(STORE_NAME);
     Assert.assertTrue(consumer instanceof LocalBootstrappingVeniceChangelogConsumer);
 

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/consumer/VeniceChangelogConsumerImplTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/consumer/VeniceChangelogConsumerImplTest.java
@@ -363,7 +363,6 @@ public class VeniceChangelogConsumerImplTest {
 
     PubSubConsumerAdapter mockPubSubConsumer = mock(PubSubConsumerAdapter.class);
     PubSubTopic oldVersionTopic = pubSubTopicRepository.getTopic(Version.composeKafkaTopic(storeName, 1));
-    PubSubTopic oldChangeCaptureTopic = pubSubTopicRepository.getTopic(oldVersionTopic.getName());
 
     prepareVersionTopicRecordsToBePolled(0L, 5L, mockPubSubConsumer, oldVersionTopic, 0, true);
     ChangelogClientConfig changelogClientConfig =

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/consumer/VeniceChangelogConsumerImplTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/consumer/VeniceChangelogConsumerImplTest.java
@@ -137,12 +137,14 @@ public class VeniceChangelogConsumerImplTest {
     NativeMetadataRepositoryViewAdapter mockRepository = mock(NativeMetadataRepositoryViewAdapter.class);
     Store store = mock(Store.class);
     Version mockVersion = new VersionImpl(storeName, 1, "foo");
+    mockVersion.setPartitionCount(2);
     Mockito.when(store.getCurrentVersion()).thenReturn(1);
     Mockito.when(store.getCompressionStrategy()).thenReturn(CompressionStrategy.NO_OP);
     Mockito.when(mockRepository.getStore(anyString())).thenReturn(store);
     Mockito.when(store.getVersionOrThrow(Mockito.anyInt())).thenReturn(mockVersion);
     Mockito.when(mockRepository.getValueSchema(storeName, 1)).thenReturn(new SchemaEntry(1, valueSchema));
     Mockito.when(store.getPartitionCount()).thenReturn(2);
+    Mockito.when(store.getVersion(Mockito.anyInt())).thenReturn(mockVersion);
     veniceChangelogConsumer.setStoreRepository(mockRepository);
 
     Assert.assertEquals(veniceChangelogConsumer.getPartitionCount(), 2);
@@ -221,10 +223,12 @@ public class VeniceChangelogConsumerImplTest {
     NativeMetadataRepositoryViewAdapter mockRepository = mock(NativeMetadataRepositoryViewAdapter.class);
     Store store = mock(Store.class);
     Version mockVersion = new VersionImpl(storeName, 1, "foo");
+    mockVersion.setPartitionCount(2);
     Mockito.when(store.getCurrentVersion()).thenReturn(1);
     Mockito.when(store.getCompressionStrategy()).thenReturn(CompressionStrategy.NO_OP);
     Mockito.when(store.getPartitionCount()).thenReturn(2);
     Mockito.when(mockRepository.getStore(anyString())).thenReturn(store);
+    Mockito.when(store.getVersion(Mockito.anyInt())).thenReturn(mockVersion);
     veniceChangelogConsumer.setStoreRepository(mockRepository);
 
     Assert.assertEquals(veniceChangelogConsumer.getPartitionCount(), 2);
@@ -304,12 +308,14 @@ public class VeniceChangelogConsumerImplTest {
     NativeMetadataRepositoryViewAdapter mockRepository = mock(NativeMetadataRepositoryViewAdapter.class);
     Store store = mock(Store.class);
     Version mockVersion = new VersionImpl(storeName, 1, "foo");
+    mockVersion.setPartitionCount(2);
     Mockito.when(store.getCurrentVersion()).thenReturn(1);
     Mockito.when(store.getCompressionStrategy()).thenReturn(CompressionStrategy.NO_OP);
     Mockito.when(store.getPartitionCount()).thenReturn(2);
     Mockito.when(mockRepository.getStore(anyString())).thenReturn(store);
     Mockito.when(mockRepository.getValueSchema(storeName, 1)).thenReturn(new SchemaEntry(1, valueSchema));
     Mockito.when(store.getVersionOrThrow(Mockito.anyInt())).thenReturn(mockVersion);
+    Mockito.when(store.getVersion(Mockito.anyInt())).thenReturn(mockVersion);
     veniceChangelogConsumer.setStoreRepository(mockRepository);
 
     Assert.assertEquals(veniceChangelogConsumer.getPartitionCount(), 2);
@@ -385,12 +391,14 @@ public class VeniceChangelogConsumerImplTest {
     NativeMetadataRepositoryViewAdapter mockRepository = mock(NativeMetadataRepositoryViewAdapter.class);
     Store store = mock(Store.class);
     Version mockVersion = new VersionImpl(storeName, 1, "foo");
+    mockVersion.setPartitionCount(2);
     Mockito.when(store.getCurrentVersion()).thenReturn(1);
     Mockito.when(store.getCompressionStrategy()).thenReturn(CompressionStrategy.NO_OP);
     Mockito.when(store.getPartitionCount()).thenReturn(2);
     Mockito.when(mockRepository.getStore(anyString())).thenReturn(store);
     Mockito.when(mockRepository.getValueSchema(storeName, 1)).thenReturn(new SchemaEntry(1, valueSchema));
     Mockito.when(store.getVersionOrThrow(Mockito.anyInt())).thenReturn(mockVersion);
+    Mockito.when(store.getVersion(Mockito.anyInt())).thenReturn(mockVersion);
     veniceChangelogConsumer.setStoreRepository(mockRepository);
 
     Assert.assertEquals(veniceChangelogConsumer.getPartitionCount(), 2);
@@ -483,12 +491,14 @@ public class VeniceChangelogConsumerImplTest {
     NativeMetadataRepositoryViewAdapter mockRepository = mock(NativeMetadataRepositoryViewAdapter.class);
     Store store = mock(Store.class);
     Version mockVersion = new VersionImpl(storeName, 1, "foo");
+    mockVersion.setPartitionCount(2);
     Mockito.when(store.getCurrentVersion()).thenReturn(1);
     Mockito.when(store.getCompressionStrategy()).thenReturn(CompressionStrategy.NO_OP);
     Mockito.when(store.getPartitionCount()).thenReturn(2);
     Mockito.when(mockRepository.getStore(anyString())).thenReturn(store);
     Mockito.when(mockRepository.getValueSchema(storeName, 1)).thenReturn(new SchemaEntry(1, valueSchema));
     Mockito.when(store.getVersionOrThrow(Mockito.anyInt())).thenReturn(mockVersion);
+    Mockito.when(store.getVersion(Mockito.anyInt())).thenReturn(mockVersion);
     veniceChangelogConsumer.setStoreRepository(mockRepository);
 
     Assert.assertEquals(veniceChangelogConsumer.getPartitionCount(), 2);

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/consumer/VeniceChangelogConsumerImplTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/consumer/VeniceChangelogConsumerImplTest.java
@@ -12,7 +12,7 @@ import static org.mockito.Mockito.verify;
 import com.linkedin.avroutil1.compatibility.AvroCompatibilityHelper;
 import com.linkedin.davinci.consumer.stats.BasicConsumerStats;
 import com.linkedin.davinci.kafka.consumer.TestPubSubTopic;
-import com.linkedin.davinci.repository.ThinClientMetaStoreBasedRepository;
+import com.linkedin.davinci.repository.NativeMetadataRepositoryViewAdapter;
 import com.linkedin.venice.client.change.capture.protocol.RecordChangeEvent;
 import com.linkedin.venice.client.change.capture.protocol.ValueBytes;
 import com.linkedin.venice.compression.CompressionStrategy;
@@ -134,7 +134,7 @@ public class VeniceChangelogConsumerImplTest {
         new VeniceChangelogConsumerImpl<>(changelogClientConfig, mockPubSubConsumer);
     Assert.assertEquals(veniceChangelogConsumer.getPartitionCount(), 2);
 
-    ThinClientMetaStoreBasedRepository mockRepository = mock(ThinClientMetaStoreBasedRepository.class);
+    NativeMetadataRepositoryViewAdapter mockRepository = mock(NativeMetadataRepositoryViewAdapter.class);
     Store store = mock(Store.class);
     Version mockVersion = new VersionImpl(storeName, 1, "foo");
     Mockito.when(store.getCurrentVersion()).thenReturn(1);
@@ -217,7 +217,7 @@ public class VeniceChangelogConsumerImplTest {
     veniceChangelogConsumer.versionSwapDetectionIntervalTimeInMs = 1;
     Assert.assertEquals(veniceChangelogConsumer.getPartitionCount(), 2);
 
-    ThinClientMetaStoreBasedRepository mockRepository = mock(ThinClientMetaStoreBasedRepository.class);
+    NativeMetadataRepositoryViewAdapter mockRepository = mock(NativeMetadataRepositoryViewAdapter.class);
     Store store = mock(Store.class);
     Version mockVersion = new VersionImpl(storeName, 1, "foo");
     Mockito.when(store.getCurrentVersion()).thenReturn(1);
@@ -297,7 +297,7 @@ public class VeniceChangelogConsumerImplTest {
         new VeniceAfterImageConsumerImpl<>(changelogClientConfig, mockPubSubConsumer);
     Assert.assertEquals(veniceChangelogConsumer.getPartitionCount(), 2);
 
-    ThinClientMetaStoreBasedRepository mockRepository = mock(ThinClientMetaStoreBasedRepository.class);
+    NativeMetadataRepositoryViewAdapter mockRepository = mock(NativeMetadataRepositoryViewAdapter.class);
     Store store = mock(Store.class);
     Version mockVersion = new VersionImpl(storeName, 1, "foo");
     Mockito.when(store.getCurrentVersion()).thenReturn(1);
@@ -376,7 +376,7 @@ public class VeniceChangelogConsumerImplTest {
         new VeniceAfterImageConsumerImpl<>(changelogClientConfig, mockPubSubConsumer);
     Assert.assertEquals(veniceChangelogConsumer.getPartitionCount(), 2);
 
-    ThinClientMetaStoreBasedRepository mockRepository = mock(ThinClientMetaStoreBasedRepository.class);
+    NativeMetadataRepositoryViewAdapter mockRepository = mock(NativeMetadataRepositoryViewAdapter.class);
     Store store = mock(Store.class);
     Version mockVersion = new VersionImpl(storeName, 1, "foo");
     Mockito.when(store.getCurrentVersion()).thenReturn(1);
@@ -434,7 +434,7 @@ public class VeniceChangelogConsumerImplTest {
 
     String storeName = "Leppalúði_store";
 
-    ThinClientMetaStoreBasedRepository mockRepository = Mockito.mock(ThinClientMetaStoreBasedRepository.class);
+    NativeMetadataRepositoryViewAdapter mockRepository = Mockito.mock(NativeMetadataRepositoryViewAdapter.class);
     Store mockStore = Mockito.mock(Store.class);
     Mockito.when(mockStore.getCurrentVersion()).thenReturn(5);
     Mockito.when(mockRepository.getStore(storeName)).thenReturn(mockStore);

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/consumer/VeniceChangelogConsumerImplTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/consumer/VeniceChangelogConsumerImplTest.java
@@ -129,10 +129,9 @@ public class VeniceChangelogConsumerImplTest {
         false,
         false);
     ChangelogClientConfig changelogClientConfig =
-        getChangelogClientConfig(d2ControllerClient).setViewName("changeCaptureView");
+        getChangelogClientConfig(d2ControllerClient).setViewName("changeCaptureView").setIsBeforeImageView(true);
     VeniceChangelogConsumerImpl<String, Utf8> veniceChangelogConsumer =
         new VeniceChangelogConsumerImpl<>(changelogClientConfig, mockPubSubConsumer);
-    Assert.assertEquals(veniceChangelogConsumer.getPartitionCount(), 2);
 
     NativeMetadataRepositoryViewAdapter mockRepository = mock(NativeMetadataRepositoryViewAdapter.class);
     Store store = mock(Store.class);
@@ -142,8 +141,11 @@ public class VeniceChangelogConsumerImplTest {
     Mockito.when(mockRepository.getStore(anyString())).thenReturn(store);
     Mockito.when(store.getVersionOrThrow(Mockito.anyInt())).thenReturn(mockVersion);
     Mockito.when(mockRepository.getValueSchema(storeName, 1)).thenReturn(new SchemaEntry(1, valueSchema));
-
+    Mockito.when(store.getPartitionCount()).thenReturn(2);
     veniceChangelogConsumer.setStoreRepository(mockRepository);
+
+    Assert.assertEquals(veniceChangelogConsumer.getPartitionCount(), 2);
+
     veniceChangelogConsumer.subscribe(new HashSet<>(Arrays.asList(0))).get();
     veniceChangelogConsumer.seekToTimestamp(System.currentTimeMillis() - 10000L);
     PubSubTopicPartition oldVersionTopicPartition = new PubSubTopicPartitionImpl(oldVersionTopic, 0);
@@ -215,16 +217,18 @@ public class VeniceChangelogConsumerImplTest {
         mockPubSubConsumer,
         Lazy.of(() -> mockInternalSeekConsumer));
     veniceChangelogConsumer.versionSwapDetectionIntervalTimeInMs = 1;
-    Assert.assertEquals(veniceChangelogConsumer.getPartitionCount(), 2);
-
     NativeMetadataRepositoryViewAdapter mockRepository = mock(NativeMetadataRepositoryViewAdapter.class);
     Store store = mock(Store.class);
     Version mockVersion = new VersionImpl(storeName, 1, "foo");
     Mockito.when(store.getCurrentVersion()).thenReturn(1);
     Mockito.when(store.getCompressionStrategy()).thenReturn(CompressionStrategy.NO_OP);
+    Mockito.when(store.getPartitionCount()).thenReturn(2);
     Mockito.when(mockRepository.getStore(anyString())).thenReturn(store);
-    Mockito.when(store.getVersionOrThrow(Mockito.anyInt())).thenReturn(mockVersion);
     veniceChangelogConsumer.setStoreRepository(mockRepository);
+
+    Assert.assertEquals(veniceChangelogConsumer.getPartitionCount(), 2);
+
+    Mockito.when(store.getVersionOrThrow(Mockito.anyInt())).thenReturn(mockVersion);
     veniceChangelogConsumer.subscribe(new HashSet<>(Arrays.asList(0))).get();
 
     Set<Integer> partitionSet = new HashSet<>();
@@ -295,17 +299,19 @@ public class VeniceChangelogConsumerImplTest {
     ChangelogClientConfig changelogClientConfig = getChangelogClientConfig(d2ControllerClient).setViewName("");
     VeniceChangelogConsumerImpl<String, Utf8> veniceChangelogConsumer =
         new VeniceAfterImageConsumerImpl<>(changelogClientConfig, mockPubSubConsumer);
-    Assert.assertEquals(veniceChangelogConsumer.getPartitionCount(), 2);
 
     NativeMetadataRepositoryViewAdapter mockRepository = mock(NativeMetadataRepositoryViewAdapter.class);
     Store store = mock(Store.class);
     Version mockVersion = new VersionImpl(storeName, 1, "foo");
     Mockito.when(store.getCurrentVersion()).thenReturn(1);
     Mockito.when(store.getCompressionStrategy()).thenReturn(CompressionStrategy.NO_OP);
+    Mockito.when(store.getPartitionCount()).thenReturn(2);
     Mockito.when(mockRepository.getStore(anyString())).thenReturn(store);
     Mockito.when(mockRepository.getValueSchema(storeName, 1)).thenReturn(new SchemaEntry(1, valueSchema));
     Mockito.when(store.getVersionOrThrow(Mockito.anyInt())).thenReturn(mockVersion);
     veniceChangelogConsumer.setStoreRepository(mockRepository);
+
+    Assert.assertEquals(veniceChangelogConsumer.getPartitionCount(), 2);
     veniceChangelogConsumer.subscribe(new HashSet<>(Arrays.asList(0))).get();
     verify(mockPubSubConsumer).subscribe(new PubSubTopicPartitionImpl(oldVersionTopic, 0), OffsetRecord.LOWEST_OFFSET);
 
@@ -317,8 +323,8 @@ public class VeniceChangelogConsumerImplTest {
       Assert.assertEquals(messageStr.toString(), "newValue" + i);
     }
     prepareChangeCaptureRecordsToBePolled(
-        0L,
-        10L,
+        5L,
+        15L,
         mockPubSubConsumer,
         oldChangeCaptureTopic,
         0,
@@ -330,8 +336,8 @@ public class VeniceChangelogConsumerImplTest {
         (List<PubSubMessage<String, ChangeEvent<Utf8>, VeniceChangeCoordinate>>) veniceChangelogConsumer.poll(100);
     Assert.assertFalse(pubSubMessages.isEmpty());
     Assert.assertEquals(pubSubMessages.size(), 10);
-    for (int i = 0; i < 10; i++) {
-      PubSubMessage<String, ChangeEvent<Utf8>, VeniceChangeCoordinate> pubSubMessage = pubSubMessages.get(i);
+    for (int i = 5; i < 15; i++) {
+      PubSubMessage<String, ChangeEvent<Utf8>, VeniceChangeCoordinate> pubSubMessage = pubSubMessages.get(i - 5);
       Utf8 pubSubMessageValue = pubSubMessage.getValue().getCurrentValue();
       Assert.assertEquals(pubSubMessageValue.toString(), "newValue" + i);
     }
@@ -374,17 +380,20 @@ public class VeniceChangelogConsumerImplTest {
     changelogClientConfig.getInnerClientConfig().setMetricsRepository(new MetricsRepository());
     VeniceChangelogConsumerImpl<String, Utf8> veniceChangelogConsumer =
         new VeniceAfterImageConsumerImpl<>(changelogClientConfig, mockPubSubConsumer);
-    Assert.assertEquals(veniceChangelogConsumer.getPartitionCount(), 2);
 
     NativeMetadataRepositoryViewAdapter mockRepository = mock(NativeMetadataRepositoryViewAdapter.class);
     Store store = mock(Store.class);
     Version mockVersion = new VersionImpl(storeName, 1, "foo");
     Mockito.when(store.getCurrentVersion()).thenReturn(1);
     Mockito.when(store.getCompressionStrategy()).thenReturn(CompressionStrategy.NO_OP);
+    Mockito.when(store.getPartitionCount()).thenReturn(2);
     Mockito.when(mockRepository.getStore(anyString())).thenReturn(store);
     Mockito.when(mockRepository.getValueSchema(storeName, 1)).thenReturn(new SchemaEntry(1, valueSchema));
     Mockito.when(store.getVersionOrThrow(Mockito.anyInt())).thenReturn(mockVersion);
     veniceChangelogConsumer.setStoreRepository(mockRepository);
+
+    Assert.assertEquals(veniceChangelogConsumer.getPartitionCount(), 2);
+
     veniceChangelogConsumer.subscribe(new HashSet<>(Arrays.asList(0))).get();
     verify(mockPubSubConsumer).subscribe(new PubSubTopicPartitionImpl(oldVersionTopic, 0), OffsetRecord.LOWEST_OFFSET);
 
@@ -396,8 +405,8 @@ public class VeniceChangelogConsumerImplTest {
       Assert.assertEquals(messageStr.toString(), "newValue" + i);
     }
     prepareChangeCaptureRecordsToBePolled(
-        0L,
-        10L,
+        5L,
+        15L,
         mockPubSubConsumer,
         oldChangeCaptureTopic,
         0,
@@ -408,8 +417,8 @@ public class VeniceChangelogConsumerImplTest {
     pubSubMessages = new ArrayList<>(veniceChangelogConsumer.poll(100));
     Assert.assertFalse(pubSubMessages.isEmpty());
     Assert.assertEquals(pubSubMessages.size(), 10);
-    for (int i = 0; i < 10; i++) {
-      PubSubMessage<String, ChangeEvent<Utf8>, VeniceChangeCoordinate> pubSubMessage = pubSubMessages.get(i);
+    for (int i = 5; i < 15; i++) {
+      PubSubMessage<String, ChangeEvent<Utf8>, VeniceChangeCoordinate> pubSubMessage = pubSubMessages.get(i - 5);
       Utf8 pubSubMessageValue = pubSubMessage.getValue().getCurrentValue();
       Assert.assertEquals(pubSubMessageValue.toString(), "newValue" + i);
     }
@@ -469,6 +478,18 @@ public class VeniceChangelogConsumerImplTest {
     ChangelogClientConfig changelogClientConfig = getChangelogClientConfig(d2ControllerClient).setViewName("");
     VeniceChangelogConsumerImpl<String, Utf8> veniceChangelogConsumer =
         new VeniceAfterImageConsumerImpl<>(changelogClientConfig, mockPubSubConsumer);
+
+    NativeMetadataRepositoryViewAdapter mockRepository = mock(NativeMetadataRepositoryViewAdapter.class);
+    Store store = mock(Store.class);
+    Version mockVersion = new VersionImpl(storeName, 1, "foo");
+    Mockito.when(store.getCurrentVersion()).thenReturn(1);
+    Mockito.when(store.getCompressionStrategy()).thenReturn(CompressionStrategy.NO_OP);
+    Mockito.when(store.getPartitionCount()).thenReturn(2);
+    Mockito.when(mockRepository.getStore(anyString())).thenReturn(store);
+    Mockito.when(mockRepository.getValueSchema(storeName, 1)).thenReturn(new SchemaEntry(1, valueSchema));
+    Mockito.when(store.getVersionOrThrow(Mockito.anyInt())).thenReturn(mockVersion);
+    veniceChangelogConsumer.setStoreRepository(mockRepository);
+
     Assert.assertEquals(veniceChangelogConsumer.getPartitionCount(), 2);
 
     VeniceChangelogConsumerImpl.HeartbeatReporterThread reporterThread =

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/consumer/VeniceChangelogConsumerImplTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/consumer/VeniceChangelogConsumerImplTest.java
@@ -64,6 +64,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import org.apache.avro.Schema;
@@ -495,7 +496,7 @@ public class VeniceChangelogConsumerImplTest {
     VeniceChangelogConsumerImpl.HeartbeatReporterThread reporterThread =
         veniceChangelogConsumer.getHeartbeatReporterThread();
 
-    Map<Integer, Long> lastHeartbeat = new HashMap<>();
+    ConcurrentHashMap<Integer, Long> lastHeartbeat = new VeniceConcurrentHashMap<>();
     BasicConsumerStats consumerStats = Mockito.mock(BasicConsumerStats.class);
     Set<PubSubTopicPartition> topicPartitionSet = new HashSet<>();
     topicPartitionSet.add(new PubSubTopicPartitionImpl(oldVersionTopic, 1));

--- a/internal/venice-client-common/src/main/java/com/linkedin/venice/schema/rmd/RmdUtils.java
+++ b/internal/venice-client-common/src/main/java/com/linkedin/venice/schema/rmd/RmdUtils.java
@@ -3,6 +3,7 @@ package com.linkedin.venice.schema.rmd;
 import static com.linkedin.venice.schema.rmd.RmdConstants.REPLICATION_CHECKPOINT_VECTOR_FIELD_POS;
 import static com.linkedin.venice.schema.rmd.RmdConstants.TIMESTAMP_FIELD_POS;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import org.antlr.v4.runtime.misc.NotNull;
@@ -99,5 +100,30 @@ public class RmdUtils {
       }
     }
     return true;
+  }
+
+  static public List<Long> mergeOffsetVectors(@NotNull List<Long> baseOffset, @NotNull List<Long> advancedOffset) {
+    List<Long> shortVector;
+    List<Long> longVector;
+
+    if (baseOffset.size() > advancedOffset.size()) {
+      shortVector = advancedOffset;
+      longVector = baseOffset;
+    } else {
+      shortVector = baseOffset;
+      longVector = advancedOffset;
+    }
+
+    List<Long> mergedVector = new ArrayList<>(longVector.size());
+
+    for (int i = 0; i < shortVector.size(); i++) {
+      mergedVector.add(Math.max(shortVector.get(i), longVector.get(i)));
+    }
+
+    if (longVector.size() != shortVector.size()) {
+      mergedVector.addAll(longVector.subList(shortVector.size(), longVector.size()));
+    }
+
+    return mergedVector;
   }
 }

--- a/internal/venice-client-common/src/test/java/com/linkedin/venice/schema/rmd/TestRmdUtils.java
+++ b/internal/venice-client-common/src/test/java/com/linkedin/venice/schema/rmd/TestRmdUtils.java
@@ -70,10 +70,36 @@ public class TestRmdUtils {
     list2.add(1L);
     list2.add(9L);
 
+    List<Long> list3 = new ArrayList<>();
+    list3.add(10L);
+
+    List<Long> list4 = new ArrayList<>();
+    list4.add(-1L);
+
     Assert.assertFalse(RmdUtils.hasOffsetAdvanced(list1, list2));
     Assert.assertFalse(RmdUtils.hasOffsetAdvanced(list1, Collections.emptyList()));
     Assert.assertTrue(RmdUtils.hasOffsetAdvanced(list2, list1));
     Assert.assertTrue(RmdUtils.hasOffsetAdvanced(Collections.emptyList(), list2));
+
+    List<Long> mergedList = RmdUtils.mergeOffsetVectors(list2, list1);
+    Assert.assertEquals(mergedList.get(0), list2.get(0));
+    Assert.assertEquals(mergedList.get(1), list1.get(1));
+
+    mergedList = RmdUtils.mergeOffsetVectors(list2, Collections.EMPTY_LIST);
+    Assert.assertEquals(mergedList.get(0), list2.get(0));
+    Assert.assertEquals(mergedList.get(1), list2.get(1));
+
+    mergedList = RmdUtils.mergeOffsetVectors(Collections.EMPTY_LIST, list2);
+    Assert.assertEquals(mergedList.get(0), list2.get(0));
+    Assert.assertEquals(mergedList.get(1), list2.get(1));
+
+    mergedList = RmdUtils.mergeOffsetVectors(list1, list3);
+    Assert.assertEquals(mergedList.get(0), list3.get(0));
+    Assert.assertEquals(mergedList.get(1), list1.get(1));
+
+    mergedList = RmdUtils.mergeOffsetVectors(list3, list1);
+    Assert.assertEquals(mergedList.get(0), list3.get(0));
+    Assert.assertEquals(mergedList.get(1), list1.get(1));
   }
 
   @Test(expectedExceptions = IllegalStateException.class)

--- a/internal/venice-common/src/main/java/com/linkedin/venice/views/ChangeCaptureView.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/views/ChangeCaptureView.java
@@ -54,6 +54,11 @@ public class ChangeCaptureView extends VeniceView {
   }
 
   @Override
+  public String composeTopicName(int version) {
+    return Version.composeKafkaTopic(storeName, version) + CHANGE_CAPTURE_TOPIC_SUFFIX;
+  }
+
+  @Override
   public String getWriterClassName() {
     return CHANGE_CAPTURE_VIEW_WRITER_CLASS_NAME;
   }

--- a/internal/venice-common/src/main/java/com/linkedin/venice/views/MaterializedView.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/views/MaterializedView.java
@@ -66,6 +66,12 @@ public class MaterializedView extends VeniceView {
         properties);
   }
 
+  @Override
+  public String composeTopicName(int version) {
+    return Version.composeKafkaTopic(storeName, version) + VIEW_NAME_SEPARATOR + viewName
+        + MATERIALIZED_VIEW_TOPIC_SUFFIX;
+  }
+
   /**
    * {@link MaterializedViewParameters#MATERIALIZED_VIEW_PARTITION_COUNT} is required to configure a new re-partition view.
    * {@link MaterializedViewParameters#MATERIALIZED_VIEW_PARTITIONER} is optional. The re-partition view will use the store level

--- a/internal/venice-common/src/main/java/com/linkedin/venice/views/VeniceView.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/views/VeniceView.java
@@ -59,6 +59,10 @@ public abstract class VeniceView {
     return Collections.emptyMap();
   }
 
+  public String composeTopicName(int version) {
+    return Version.composeKafkaTopic(storeName, version);
+  }
+
   /**
    * Implementations should return the fully specified class name for the component VeniceViewWriter
    * implementation.

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/consumer/TestChangelogConsumer.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/consumer/TestChangelogConsumer.java
@@ -172,7 +172,7 @@ public class TestChangelogConsumer {
     TestView.resetCounters();
   }
 
-  @Test(timeOut = TEST_TIMEOUT, priority = 3)
+  @Test(timeOut = TEST_TIMEOUT * 2, priority = 3)
   public void testAAIngestionWithStoreView() throws Exception {
     // Set up the store
     Long timestamp = System.currentTimeMillis();
@@ -545,7 +545,7 @@ public class TestChangelogConsumer {
     veniceChangelogConsumer.seekToBeginningOfPush().join();
     TestUtils.waitForNonDeterministicAssertion(5, TimeUnit.SECONDS, () -> {
       pollChangeEventsFromChangeCaptureConsumer(polledChangeEvents, veniceChangelogConsumer);
-      Assert.assertEquals(polledChangeEvents.size(), 30);
+      Assert.assertEquals(polledChangeEvents.size(), 10);
     });
 
     // Save a checkpoint and clear the map
@@ -571,7 +571,7 @@ public class TestChangelogConsumer {
     TestUtils.waitForNonDeterministicAssertion(5, TimeUnit.SECONDS, () -> {
       pollChangeEventsFromChangeCaptureConsumer(polledChangeEvents, veniceChangelogConsumer);
       // Repush with TTL will include delete events in the topic
-      Assert.assertEquals(polledChangeEvents.size(), 16);
+      Assert.assertEquals(polledChangeEvents.size(), 5);
     });
     allChangeEvents.putAll(polledChangeEvents);
     polledChangeEvents.clear();
@@ -619,7 +619,7 @@ public class TestChangelogConsumer {
       pollAfterImageEventsFromChangeCaptureConsumer(versionTopicEvents, versionTopicConsumer);
       // Reconsuming the events from the version topic, which at this point should just contain the same 16
       // events we consumed with the before/after image consumer earlier.
-      Assert.assertEquals(versionTopicEvents.size(), 30);
+      Assert.assertEquals(versionTopicEvents.size(), 10);
     });
 
     // Verify version swap count matches with version count - 1 (since we don't transmit from version 0 to version 1).

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/consumer/TestChangelogConsumer.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/consumer/TestChangelogConsumer.java
@@ -102,7 +102,7 @@ import org.testng.annotations.Test;
 
 
 public class TestChangelogConsumer {
-  private static final int TEST_TIMEOUT = 2 * Time.MS_PER_MINUTE;
+  private static final int TEST_TIMEOUT = 3 * Time.MS_PER_MINUTE;
   private static final String[] CLUSTER_NAMES =
       IntStream.range(0, 1).mapToObj(i -> "venice-cluster" + i).toArray(String[]::new);
 
@@ -254,7 +254,8 @@ public class TestChangelogConsumer {
         .setControllerD2ServiceName(D2_SERVICE_NAME)
         .setD2ServiceName(VeniceRouterWrapper.CLUSTER_DISCOVERY_D2_SERVICE_NAME)
         .setLocalD2ZkHosts(localZkServer.getAddress())
-        .setControllerRequestRetryCount(3);
+        .setControllerRequestRetryCount(3)
+        .setIsBeforeImageView(true);
     VeniceChangelogConsumerClientFactory veniceChangelogConsumerClientFactory =
         new VeniceChangelogConsumerClientFactory(globalChangelogClientConfig, metricsRepository);
 

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/consumer/TestChangelogConsumer.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/consumer/TestChangelogConsumer.java
@@ -172,7 +172,7 @@ public class TestChangelogConsumer {
     TestView.resetCounters();
   }
 
-  @Test(timeOut = TEST_TIMEOUT * 2, priority = 3)
+  @Test(timeOut = TEST_TIMEOUT, priority = 3)
   public void testAAIngestionWithStoreView() throws Exception {
     // Set up the store
     Long timestamp = System.currentTimeMillis();


### PR DESCRIPTION
[tests incoming]

These changes make it so that the venice after image consumer is able to now consume view topics. View topics internally very much resemble version topics, which the after image consumer understands today.  So the logic is largely the same.  The only difference we add here is that we now have to consult store repositories which are view aware, and we have to chnage how we maintain local highwatermark information.  Highwatermarks are meant to be compared on RT partitions, and new view types map 1:N and N:N RT partitions to view partitions.  This means we need to add an additional dimensionality to highwatermark filtering where instead of keeping a single map of topic partitions to offsets, but a map of topic partitions to maps of RT partitions to highwatermarks.

There's still some pending work here, we need to figure out chunk assembly (as the current implementation of chunk assembly doesn't account for interleaving writes) and we need to put a bow on how we articulate to the consumers what the upstream RT partition is (right now we're just hardcoding the 1:1 pairing).

<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## Summary, imperative, start upper case, don't end with a period
<!--
Describe
- What changes to make and why you are making these changes.
- How are you going to achieve your goal.
- Describe what testings you have done, for example, performance testing etc.

If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

Resolves #XXX

## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [ ] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.