### PR TITLE
[fast-client] Fixed retry budget freshness issue

### DIFF
--- a/clients/venice-client/src/main/java/com/linkedin/venice/fastclient/ClientConfig.java
+++ b/clients/venice-client/src/main/java/com/linkedin/venice/fastclient/ClientConfig.java
@@ -426,7 +426,7 @@ public class ClientConfig<K, V, T extends SpecificRecord> {
 
     private InstanceHealthMonitor instanceHealthMonitor;
 
-    private boolean retryBudgetEnabled = false;
+    private boolean retryBudgetEnabled = true;
 
     public ClientConfigBuilder<K, V, T> setStoreName(String storeName) {
       this.storeName = storeName;

--- a/internal/venice-common/src/test/java/com/linkedin/venice/meta/RetryManagerTest.java
+++ b/internal/venice-common/src/test/java/com/linkedin/venice/meta/RetryManagerTest.java
@@ -1,7 +1,9 @@
 package com.linkedin.venice.meta;
 
+import static org.mockito.Mockito.atLeast;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 
 import com.linkedin.venice.utils.TestUtils;
 import io.tehuti.metrics.MetricsRepository;
@@ -69,6 +71,20 @@ public class RetryManagerTest {
     // We should eventually be able to perform retries again
     TestUtils
         .waitForNonDeterministicAssertion(5, TimeUnit.SECONDS, () -> Assert.assertTrue(retryManager.isRetryAllowed()));
+
+    // Make sure the empty request count kicks in
+    doReturn(start + 3001).when(mockClock).millis();
+    TestUtils.waitForNonDeterministicAssertion(5, TimeUnit.SECONDS, () -> {
+      verify(mockClock, atLeast(10)).millis();
+    });
+
+    // Send more traffic
+    doReturn(start + 4001).when(mockClock).millis();
+    retryManager.recordRequests(100);
+    TestUtils.waitForNonDeterministicAssertion(
+        5,
+        TimeUnit.SECONDS,
+        () -> Assert.assertTrue(retryManager.isRetryAllowed(40)));
   }
 
   @Test(timeOut = TEST_TIMEOUT_IN_MS)


### PR DESCRIPTION


<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->
This PR fixed a bug in RetryBudget, and previously, if the request volume becomes 0, the retry budget won't be refreshed any more even there are more traffic later on.

This PR also re-enables retry budget by default.
<!--
Describe
- What changes to make and why you are making these changes.
- How are you going to achieve your goal.
- Describe what testings you have done, for example, performance testing etc.

If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->


## How was this PR tested?
CI
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.