### PR TITLE
[controller] Skip checking RT for deleted stores

### DIFF
--- a/internal/venice-client-common/src/main/java/com/linkedin/venice/exceptions/VeniceNoStoreException.java
+++ b/internal/venice-client-common/src/main/java/com/linkedin/venice/exceptions/VeniceNoStoreException.java
@@ -9,6 +9,7 @@ import org.apache.http.HttpStatus;
 public class VeniceNoStoreException extends VeniceException {
   private final String storeName;
   private final String clusterName;
+  public static final String DOES_NOT_EXISTS = " does not exist";
 
   public VeniceNoStoreException(String storeName, String clusterName) {
     super(getErrorMessage(storeName, clusterName, null), ErrorType.STORE_NOT_FOUND);
@@ -54,7 +55,7 @@ public class VeniceNoStoreException extends VeniceException {
   }
 
   private static String getErrorMessage(String storeName, String clusterName, String additionalMessage) {
-    StringBuilder errorBuilder = new StringBuilder().append("Store: ").append(storeName).append(" does not exist");
+    StringBuilder errorBuilder = new StringBuilder().append("Store: ").append(storeName).append(DOES_NOT_EXISTS);
     if (clusterName != null) {
       errorBuilder.append(" in cluster ").append(clusterName);
     } else {

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceHelixAdmin.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceHelixAdmin.java
@@ -3912,8 +3912,9 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
         if (storeResponse.isError()) {
           if (storeResponse.getError().contains(DOES_NOT_EXISTS)) {
             LOGGER.warn(
-                "Store {} does not exist in fabric {}, probably deleted already, skipping RT check",
+                "Store {} does not exist in cluster {} in fabric {}, probably deleted already, skipping RT check",
                 storeName,
+                clusterName,
                 controllerClientEntry.getKey());
             continue;
           }
@@ -3927,8 +3928,9 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
         }
       } catch (VeniceNoStoreException e) {
         LOGGER.warn(
-            "Store {} does not exist in fabric {}, probably deleted already, skipping RT check",
+            "Store {} does not exist in cluster {} in fabric {}, probably deleted already, skipping RT check",
             storeName,
+            clusterName,
             controllerClientEntry.getKey());
         continue;
       }

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceHelixAdmin.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceHelixAdmin.java
@@ -3896,6 +3896,13 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
     for (Map.Entry<String, ControllerClient> controllerClientEntry: controllerClientMap.entrySet()) {
       StoreResponse storeResponse = controllerClientEntry.getValue().getStore(storeName);
       if (storeResponse.isError()) {
+        if (storeResponse.getError().contains("does not exist")) {
+          LOGGER.warn(
+              "Store {} does not exist in fabric {}, probably deleted already, skipping RT check",
+              storeName,
+              controllerClientEntry.getKey());
+          continue;
+        }
         LOGGER.warn(
             "Skipping RT cleanup check for store: {} in cluster: {} due to unable to get store from fabric: {} Error: {}",
             storeName,

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceHelixAdmin.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceHelixAdmin.java
@@ -7,6 +7,7 @@ import static com.linkedin.venice.ConfigKeys.KAFKA_REPLICATION_FACTOR;
 import static com.linkedin.venice.ConfigKeys.SSL_KAFKA_BOOTSTRAP_SERVERS;
 import static com.linkedin.venice.ConfigKeys.SSL_TO_KAFKA_LEGACY;
 import static com.linkedin.venice.controller.UserSystemStoreLifeCycleHelper.AUTO_META_SYSTEM_STORE_PUSH_ID_PREFIX;
+import static com.linkedin.venice.exceptions.VeniceNoStoreException.DOES_NOT_EXISTS;
 import static com.linkedin.venice.meta.HybridStoreConfigImpl.DEFAULT_HYBRID_OFFSET_LAG_THRESHOLD;
 import static com.linkedin.venice.meta.HybridStoreConfigImpl.DEFAULT_HYBRID_TIME_LAG_THRESHOLD;
 import static com.linkedin.venice.meta.HybridStoreConfigImpl.DEFAULT_REAL_TIME_TOPIC_NAME;
@@ -3894,9 +3895,20 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
     String rtTopicName = Utils.composeRealTimeTopic(storeName);
     Map<String, ControllerClient> controllerClientMap = getControllerClientMap(clusterName);
     for (Map.Entry<String, ControllerClient> controllerClientEntry: controllerClientMap.entrySet()) {
-      StoreResponse storeResponse = controllerClientEntry.getValue().getStore(storeName);
+      StoreResponse storeResponse = RetryUtils.executeWithMaxAttemptAndExponentialBackoff(() -> {
+        StoreResponse response = controllerClientEntry.getValue().getStore(storeName);
+        if (response.isError() && response.getError().contains(DOES_NOT_EXISTS)) {
+          throw new VeniceException("Store does not exist " + storeName);
+        }
+        return response;
+      },
+          5,
+          Duration.ofMillis(10),
+          Duration.ofMillis(500),
+          Duration.ofSeconds(5),
+          Collections.singletonList(VeniceException.class));
       if (storeResponse.isError()) {
-        if (storeResponse.getError().contains("does not exist")) {
+        if (storeResponse.getError().contains(DOES_NOT_EXISTS)) {
           LOGGER.warn(
               "Store {} does not exist in fabric {}, probably deleted already, skipping RT check",
               storeName,


### PR DESCRIPTION
<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat], [protocol]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## Skip checking RT for deleted stores
<!--
Describe
- What changes to make and why you are making these changes.
- How are you going to achieve your goal.
- Describe what testings you have done, for example, performance testing etc.

If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

When deleting stores, we check for hybridness in child colos, if one of the colo has already deleted the store, the check returns false, which can block RT deletion forever.
This PR fixes such cases.

## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
GHCI
## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.