### PR TITLE
[dvc][doc] Refactor DaVinciRecordTransformerConfig to use Builder pattern and update DVRT docs

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/client/AvroGenericDaVinciClient.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/client/AvroGenericDaVinciClient.java
@@ -700,6 +700,12 @@ public class AvroGenericDaVinciClient<K, V> implements DaVinciClient<K, V>, Avro
       kafkaBootstrapServers = backendConfig.getString(KAFKA_BOOTSTRAP_SERVERS);
     }
 
+    String recordTransformerOutputValueSchema = "null";
+
+    if (daVinciConfig.isRecordTransformerEnabled() && recordTransformerConfig.getOutputValueSchema() != null) {
+      recordTransformerOutputValueSchema = recordTransformerConfig.getOutputValueSchema().toString();
+    }
+
     VeniceProperties config = new PropertyBuilder().put(KAFKA_ADMIN_CLASS, ApacheKafkaAdminAdapter.class.getName())
         .put(ROCKSDB_LEVEL0_FILE_NUM_COMPACTION_TRIGGER, 4) // RocksDB default config
         .put(ROCKSDB_LEVEL0_SLOWDOWN_WRITES_TRIGGER, 20) // RocksDB default config
@@ -712,11 +718,7 @@ public class AvroGenericDaVinciClient<K, V> implements DaVinciClient<K, V>, Avro
         .put(KAFKA_BOOTSTRAP_SERVERS, kafkaBootstrapServers)
         .put(ROCKSDB_PLAIN_TABLE_FORMAT_ENABLED, daVinciConfig.getStorageClass() == StorageClass.MEMORY_BACKED_BY_DISK)
         .put(INGESTION_USE_DA_VINCI_CLIENT, true)
-        .put(
-            RECORD_TRANSFORMER_VALUE_SCHEMA,
-            daVinciConfig.isRecordTransformerEnabled()
-                ? recordTransformerConfig.getOutputValueSchema().toString()
-                : "null")
+        .put(RECORD_TRANSFORMER_VALUE_SCHEMA, recordTransformerOutputValueSchema)
         .put(INGESTION_ISOLATION_CONFIG_PREFIX + "." + INGESTION_MEMORY_LIMIT, -1) // Explicitly disable memory limiter
                                                                                    // in Isolated Process
         .put(backendConfig.toProperties())

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/client/AvroGenericDaVinciClient.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/client/AvroGenericDaVinciClient.java
@@ -701,9 +701,10 @@ public class AvroGenericDaVinciClient<K, V> implements DaVinciClient<K, V>, Avro
       kafkaBootstrapServers = backendConfig.getString(KAFKA_BOOTSTRAP_SERVERS);
     }
 
-    String recordTransformerOutputValueSchema = daVinciConfig.isRecordTransformerEnabled()
-        ? Objects.toString(recordTransformerConfig.getOutputValueSchema(), "null")
-        : "null";
+    String recordTransformerOutputValueSchema = "null";
+    if (daVinciConfig.isRecordTransformerEnabled()) {
+      recordTransformerOutputValueSchema = Objects.toString(recordTransformerConfig.getOutputValueSchema(), "null");
+    }
 
     VeniceProperties config = new PropertyBuilder().put(KAFKA_ADMIN_CLASS, ApacheKafkaAdminAdapter.class.getName())
         .put(ROCKSDB_LEVEL0_FILE_NUM_COMPACTION_TRIGGER, 4) // RocksDB default config

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/client/AvroGenericDaVinciClient.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/client/AvroGenericDaVinciClient.java
@@ -69,6 +69,7 @@ import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
@@ -700,10 +701,9 @@ public class AvroGenericDaVinciClient<K, V> implements DaVinciClient<K, V>, Avro
       kafkaBootstrapServers = backendConfig.getString(KAFKA_BOOTSTRAP_SERVERS);
     }
 
-    String recordTransformerOutputValueSchema = "null";
-    if (daVinciConfig.isRecordTransformerEnabled() && recordTransformerConfig.getOutputValueSchema() != null) {
-      recordTransformerOutputValueSchema = recordTransformerConfig.getOutputValueSchema().toString();
-    }
+    String recordTransformerOutputValueSchema = daVinciConfig.isRecordTransformerEnabled()
+        ? Objects.toString(recordTransformerConfig.getOutputValueSchema(), "null")
+        : "null";
 
     VeniceProperties config = new PropertyBuilder().put(KAFKA_ADMIN_CLASS, ApacheKafkaAdminAdapter.class.getName())
         .put(ROCKSDB_LEVEL0_FILE_NUM_COMPACTION_TRIGGER, 4) // RocksDB default config

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/client/AvroGenericDaVinciClient.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/client/AvroGenericDaVinciClient.java
@@ -701,7 +701,6 @@ public class AvroGenericDaVinciClient<K, V> implements DaVinciClient<K, V>, Avro
     }
 
     String recordTransformerOutputValueSchema = "null";
-
     if (daVinciConfig.isRecordTransformerEnabled() && recordTransformerConfig.getOutputValueSchema() != null) {
       recordTransformerOutputValueSchema = recordTransformerConfig.getOutputValueSchema().toString();
     }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/client/BlockingDaVinciRecordTransformer.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/client/BlockingDaVinciRecordTransformer.java
@@ -29,8 +29,8 @@ public class BlockingDaVinciRecordTransformer<K, V, O> extends DaVinciRecordTran
       Schema keySchema,
       Schema inputValueSchema,
       Schema outputValueSchema,
-      boolean storeRecordsInDaVinci) {
-    super(recordTransformer.getStoreVersion(), keySchema, inputValueSchema, outputValueSchema, storeRecordsInDaVinci);
+      DaVinciRecordTransformerConfig recordTransformerConfig) {
+    super(recordTransformer.getStoreVersion(), keySchema, inputValueSchema, outputValueSchema, recordTransformerConfig);
     this.recordTransformer = recordTransformer;
   }
 

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/client/DaVinciRecordTransformer.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/client/DaVinciRecordTransformer.java
@@ -44,6 +44,11 @@ public abstract class DaVinciRecordTransformer<K, V, O> implements Closeable {
   private final boolean storeRecordsInDaVinci;
 
   /**
+   * Boolean to determine if we should always bootstrap from Version Topic.
+   */
+  private final boolean alwaysBootstrapFromVersionTopic;
+
+  /**
    * The key schema, which is immutable inside DaVinciClient. Users can modify the key if they are storing records in an external storage engine, but this must be managed by the user.
    */
   private final Schema keySchema;
@@ -65,17 +70,17 @@ public abstract class DaVinciRecordTransformer<K, V, O> implements Closeable {
    * @param keySchema the key schema, which is immutable inside DaVinciClient. Users can modify the key if they are storing records in an external storage engine, but this must be managed by the user
    * @param inputValueSchema the value schema before transformation
    * @param outputValueSchema the value schema after transformation
-   * @param storeRecordsInDaVinci set this to false if you intend to store records in a custom storage,
-   *                              and not in the Da Vinci Client
+   * @param recordTransformerConfig
    */
   public DaVinciRecordTransformer(
       int storeVersion,
       Schema keySchema,
       Schema inputValueSchema,
       Schema outputValueSchema,
-      boolean storeRecordsInDaVinci) {
+      DaVinciRecordTransformerConfig recordTransformerConfig) {
     this.storeVersion = storeVersion;
-    this.storeRecordsInDaVinci = storeRecordsInDaVinci;
+    this.storeRecordsInDaVinci = recordTransformerConfig.getStoreRecordsInDaVinci();
+    this.alwaysBootstrapFromVersionTopic = recordTransformerConfig.getAlwaysBootstrapFromVersionTopic();
     this.keySchema = keySchema;
     // ToDo: Make use of inputValueSchema to support reader/writer schemas
     this.inputValueSchema = inputValueSchema;
@@ -225,6 +230,13 @@ public abstract class DaVinciRecordTransformer<K, V, O> implements Closeable {
    */
   public final boolean getStoreRecordsInDaVinci() {
     return storeRecordsInDaVinci;
+  }
+
+  /**
+   * @return {@link #alwaysBootstrapFromVersionTopic}
+   */
+  public final boolean getAlwaysBootstrapFromVersionTopic() {
+    return alwaysBootstrapFromVersionTopic;
   }
 
   /**

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/client/DaVinciRecordTransformer.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/client/DaVinciRecordTransformer.java
@@ -44,7 +44,7 @@ public abstract class DaVinciRecordTransformer<K, V, O> implements Closeable {
   private final boolean storeRecordsInDaVinci;
 
   /**
-   * Boolean to determine if we should always bootstrap from Version Topic.
+   * Boolean to determine if we should always bootstrap from the Version Topic.
    */
   private final boolean alwaysBootstrapFromVersionTopic;
 
@@ -70,7 +70,7 @@ public abstract class DaVinciRecordTransformer<K, V, O> implements Closeable {
    * @param keySchema the key schema, which is immutable inside DaVinciClient. Users can modify the key if they are storing records in an external storage engine, but this must be managed by the user
    * @param inputValueSchema the value schema before transformation
    * @param outputValueSchema the value schema after transformation
-   * @param recordTransformerConfig
+   * @param recordTransformerConfig the config for the record transformer
    */
   public DaVinciRecordTransformer(
       int storeVersion,

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/client/DaVinciRecordTransformerConfig.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/client/DaVinciRecordTransformerConfig.java
@@ -1,5 +1,7 @@
 package com.linkedin.davinci.client;
 
+import com.linkedin.venice.exceptions.VeniceException;
+import java.util.Optional;
 import org.apache.avro.Schema;
 
 
@@ -10,19 +12,22 @@ public class DaVinciRecordTransformerConfig {
   private final DaVinciRecordTransformerFunctionalInterface recordTransformerFunction;
   private final Class outputValueClass;
   private final Schema outputValueSchema;
+  private final boolean storeRecordsInDaVinci;
+  private final boolean alwaysBootstrapFromVersionTopic;
 
-  /**
-   * @param recordTransformerFunction the functional interface for creating a {@link DaVinciRecordTransformer}
-   * @param outputValueClass the class of the output value
-   * @param outputValueSchema the schema of the output value
-   */
-  public DaVinciRecordTransformerConfig(
-      DaVinciRecordTransformerFunctionalInterface recordTransformerFunction,
-      Class outputValueClass,
-      Schema outputValueSchema) {
-    this.recordTransformerFunction = recordTransformerFunction;
-    this.outputValueClass = outputValueClass;
-    this.outputValueSchema = outputValueSchema;
+  public DaVinciRecordTransformerConfig(Builder builder) {
+    this.recordTransformerFunction = Optional.ofNullable(builder.recordTransformerFunction)
+        .orElseThrow(() -> new VeniceException("recordTransformerFunction cannot be null"));
+
+    this.outputValueClass = builder.outputValueClass;
+    this.outputValueSchema = builder.outputValueSchema;
+    if ((this.outputValueClass != null && this.outputValueSchema == null)
+        || (this.outputValueClass == null && this.outputValueSchema != null)) {
+      throw new VeniceException("outputValueClass and outputValueSchema must be defined together");
+    }
+
+    this.storeRecordsInDaVinci = Optional.ofNullable(builder.storeRecordsInDaVinci).orElse(true);
+    this.alwaysBootstrapFromVersionTopic = Optional.ofNullable(builder.alwaysBootstrapFromVersionTopic).orElse(false);
   }
 
   /**
@@ -44,5 +49,75 @@ public class DaVinciRecordTransformerConfig {
    */
   public Schema getOutputValueSchema() {
     return outputValueSchema;
+  }
+
+  /**
+   * @return {@link #storeRecordsInDaVinci}
+   */
+  public boolean getStoreRecordsInDaVinci() {
+    return storeRecordsInDaVinci;
+  }
+
+  /**
+   * @return {@link #alwaysBootstrapFromVersionTopic}
+   */
+  public boolean getAlwaysBootstrapFromVersionTopic() {
+    return alwaysBootstrapFromVersionTopic;
+  }
+
+  public static class Builder {
+    private DaVinciRecordTransformerFunctionalInterface recordTransformerFunction;
+    private Class outputValueClass;
+    private Schema outputValueSchema;
+    private Boolean storeRecordsInDaVinci;
+    private Boolean alwaysBootstrapFromVersionTopic;
+
+    /**
+     * @param recordTransformerFunction the functional interface for creating a {@link DaVinciRecordTransformer}
+     */
+    public Builder setRecordTransformerFunction(DaVinciRecordTransformerFunctionalInterface recordTransformerFunction) {
+      this.recordTransformerFunction = recordTransformerFunction;
+      return this;
+    }
+
+    /**
+     * @param outputValueClass the class of the output value
+     */
+    public Builder setOutputValueClass(Class outputValueClass) {
+      this.outputValueClass = outputValueClass;
+      return this;
+    }
+
+    /**
+     * @param outputValueSchema the schema of the output value
+     */
+    public Builder setOutputValueSchema(Schema outputValueSchema) {
+      this.outputValueSchema = outputValueSchema;
+      return this;
+    }
+
+    /**
+     * @param storeRecordsInDaVinci set this to false if you intend to store records in a custom storage,
+     *                              and not in the Da Vinci Client.
+     *                              Default is true.
+     */
+    public Builder setStoreRecordsInDaVinci(boolean storeRecordsInDaVinci) {
+      this.storeRecordsInDaVinci = storeRecordsInDaVinci;
+      return this;
+    }
+
+    /**
+     * @param alwaysBootstrapFromVersionTopic set this to true if {@link #storeRecordsInDaVinci} is false, and you're
+     *                                        storing records in memory without being backed by disk.
+     *                                        Default is false.
+     */
+    public Builder setAlwaysBootstrapFromVersionTopic(boolean alwaysBootstrapFromVersionTopic) {
+      this.alwaysBootstrapFromVersionTopic = alwaysBootstrapFromVersionTopic;
+      return this;
+    }
+
+    public DaVinciRecordTransformerConfig build() {
+      return new DaVinciRecordTransformerConfig(this);
+    }
   }
 }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/client/DaVinciRecordTransformerConfig.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/client/DaVinciRecordTransformerConfig.java
@@ -81,6 +81,7 @@ public class DaVinciRecordTransformerConfig {
     }
 
     /**
+     * Set this if you modify the schema during transformation. Must be used in conjunction with {@link #setOutputValueSchema(Schema)}
      * @param outputValueClass the class of the output value
      */
     public Builder setOutputValueClass(Class outputValueClass) {
@@ -89,6 +90,7 @@ public class DaVinciRecordTransformerConfig {
     }
 
     /**
+     * Set this if you modify the schema during transformation. Must be used in conjunction with {@link #setOutputValueClass(Class)}
      * @param outputValueSchema the schema of the output value
      */
     public Builder setOutputValueSchema(Schema outputValueSchema) {

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/client/DaVinciRecordTransformerFunctionalInterface.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/client/DaVinciRecordTransformerFunctionalInterface.java
@@ -13,5 +13,6 @@ public interface DaVinciRecordTransformerFunctionalInterface {
       Integer storeVersion,
       Schema keySchema,
       Schema inputValueSchema,
-      Schema outputValueSchema);
+      Schema outputValueSchema,
+      DaVinciRecordTransformerConfig recordTransformerConfig);
 }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/client/DaVinciRecordTransformerUtility.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/client/DaVinciRecordTransformerUtility.java
@@ -110,7 +110,7 @@ public class DaVinciRecordTransformerUtility<K, O> {
 
     boolean transformerLogicChanged = hasTransformerLogicChanged(classHash, offsetRecord);
 
-    if (!recordTransformer.getStoreRecordsInDaVinci() || transformerLogicChanged) {
+    if (recordTransformer.getAlwaysBootstrapFromVersionTopic() || transformerLogicChanged) {
       LOGGER.info("Bootstrapping directly from the VersionTopic for partition {}", partitionId);
 
       // Bootstrap from VT

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
@@ -481,6 +481,11 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
       this.recordTransformerInputValueSchema = schemaRepository.getSupersetOrLatestValueSchema(storeName).getSchema();
       Schema outputValueSchema = recordTransformerConfig.getOutputValueSchema();
 
+      // User doesn't intend on transforming records. Use input value schema instead.
+      if (outputValueSchema == null) {
+        outputValueSchema = this.recordTransformerInputValueSchema;
+      }
+
       DaVinciRecordTransformer clientRecordTransformer = recordTransformerConfig.getRecordTransformerFunction()
           .apply(
               versionNumber,

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
@@ -482,14 +482,19 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
       Schema outputValueSchema = recordTransformerConfig.getOutputValueSchema();
 
       DaVinciRecordTransformer clientRecordTransformer = recordTransformerConfig.getRecordTransformerFunction()
-          .apply(versionNumber, keySchema, this.recordTransformerInputValueSchema, outputValueSchema);
+          .apply(
+              versionNumber,
+              keySchema,
+              this.recordTransformerInputValueSchema,
+              outputValueSchema,
+              recordTransformerConfig);
 
       this.recordTransformer = new BlockingDaVinciRecordTransformer(
           clientRecordTransformer,
           keySchema,
           this.recordTransformerInputValueSchema,
           outputValueSchema,
-          clientRecordTransformer.getStoreRecordsInDaVinci());
+          recordTransformerConfig);
       this.recordTransformerDeserializersByPutSchemaId = new SparseConcurrentList<>();
 
       versionedIngestionStats.registerTransformerLatencySensor(storeName, versionNumber);

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/client/AvroGenericDaVinciClientTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/client/AvroGenericDaVinciClientTest.java
@@ -60,15 +60,11 @@ public class AvroGenericDaVinciClientTest {
       daVinciConfig = new DaVinciConfig();
     }
 
-    DaVinciRecordTransformerConfig recordTransformerConfig = new DaVinciRecordTransformerConfig(
-        (storeVersion, keySchema, inputValueSchema, outputValueSchema) -> new TestStringRecordTransformer(
-            storeVersion,
-            keySchema,
-            inputValueSchema,
-            outputValueSchema,
-            true),
-        String.class,
-        Schema.create(Schema.Type.STRING));
+    DaVinciRecordTransformerConfig recordTransformerConfig =
+        new DaVinciRecordTransformerConfig.Builder().setRecordTransformerFunction(TestStringRecordTransformer::new)
+            .setOutputValueClass(String.class)
+            .setOutputValueSchema(Schema.create(Schema.Type.STRING))
+            .build();
     daVinciConfig.setRecordTransformerConfig(recordTransformerConfig);
 
     VeniceProperties backendConfig = mock(VeniceProperties.class);

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/config/DaVinciConfigTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/config/DaVinciConfigTest.java
@@ -60,10 +60,7 @@ public class DaVinciConfigTest {
             dummyRecordTransformerConfig);
 
     DaVinciRecordTransformerConfig recordTransformerConfig =
-        new DaVinciRecordTransformerConfig.Builder().setRecordTransformerFunction(recordTransformerFunction)
-            .setOutputValueClass(String.class)
-            .setOutputValueSchema(Schema.create(Schema.Type.INT))
-            .build();
+        new DaVinciRecordTransformerConfig.Builder().setRecordTransformerFunction(recordTransformerFunction).build();
     config.setRecordTransformerConfig(recordTransformerConfig);
 
     assertTrue(config.isRecordTransformerEnabled());
@@ -86,10 +83,7 @@ public class DaVinciConfigTest {
             dummyRecordTransformerConfig);
 
     DaVinciRecordTransformerConfig recordTransformerConfig =
-        new DaVinciRecordTransformerConfig.Builder().setRecordTransformerFunction(recordTransformerFunction)
-            .setOutputValueClass(String.class)
-            .setOutputValueSchema(Schema.create(Schema.Type.INT))
-            .build();
+        new DaVinciRecordTransformerConfig.Builder().setRecordTransformerFunction(recordTransformerFunction).build();
     config.setRecordTransformerConfig(recordTransformerConfig);
 
     assertNotNull(config.getRecordTransformerConfig());

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/config/DaVinciConfigTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/config/DaVinciConfigTest.java
@@ -45,14 +45,14 @@ public class DaVinciConfigTest {
 
   @Test
   public void testRecordTransformerEnabled() {
-    DaVinciConfig clientConfig = new DaVinciConfig();
-    assertFalse(clientConfig.isRecordTransformerEnabled());
+    DaVinciConfig config = new DaVinciConfig();
+    assertFalse(config.isRecordTransformerEnabled());
 
     DaVinciRecordTransformerConfig dummyRecordTransformerConfig =
         new DaVinciRecordTransformerConfig.Builder().setRecordTransformerFunction(TestRecordTransformer::new).build();
 
     DaVinciRecordTransformerFunctionalInterface recordTransformerFunction =
-        (storeVersion, keySchema, inputValueSchema, outputValueSchema, config) -> new TestRecordTransformer(
+        (storeVersion, keySchema, inputValueSchema, outputValueSchema, config1) -> new TestRecordTransformer(
             storeVersion,
             keySchema,
             inputValueSchema,
@@ -64,21 +64,21 @@ public class DaVinciConfigTest {
             .setOutputValueClass(String.class)
             .setOutputValueSchema(Schema.create(Schema.Type.INT))
             .build();
-    clientConfig.setRecordTransformerConfig(recordTransformerConfig);
+    config.setRecordTransformerConfig(recordTransformerConfig);
 
-    assertTrue(clientConfig.isRecordTransformerEnabled());
+    assertTrue(config.isRecordTransformerEnabled());
   }
 
   @Test
   public void testGetAndSetRecordTransformer() {
-    DaVinciConfig clientConfig = new DaVinciConfig();
-    assertNull(clientConfig.getRecordTransformerConfig());
+    DaVinciConfig config = new DaVinciConfig();
+    assertNull(config.getRecordTransformerConfig());
 
     DaVinciRecordTransformerConfig dummyRecordTransformerConfig =
         new DaVinciRecordTransformerConfig.Builder().setRecordTransformerFunction(TestRecordTransformer::new).build();
 
     DaVinciRecordTransformerFunctionalInterface recordTransformerFunction =
-        (storeVersion, keySchema, inputValueSchema, outputValueSchema, config) -> new TestRecordTransformer(
+        (storeVersion, keySchema, inputValueSchema, outputValueSchema, config1) -> new TestRecordTransformer(
             storeVersion,
             keySchema,
             inputValueSchema,
@@ -90,9 +90,9 @@ public class DaVinciConfigTest {
             .setOutputValueClass(String.class)
             .setOutputValueSchema(Schema.create(Schema.Type.INT))
             .build();
-    clientConfig.setRecordTransformerConfig(recordTransformerConfig);
+    config.setRecordTransformerConfig(recordTransformerConfig);
 
-    assertNotNull(clientConfig.getRecordTransformerConfig());
+    assertNotNull(config.getRecordTransformerConfig());
   }
 
 }

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/config/DaVinciConfigTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/config/DaVinciConfigTest.java
@@ -8,6 +8,7 @@ import static org.testng.Assert.assertTrue;
 import com.linkedin.davinci.client.DaVinciConfig;
 import com.linkedin.davinci.client.DaVinciRecordTransformer;
 import com.linkedin.davinci.client.DaVinciRecordTransformerConfig;
+import com.linkedin.davinci.client.DaVinciRecordTransformerFunctionalInterface;
 import com.linkedin.davinci.client.DaVinciRecordTransformerResult;
 import com.linkedin.venice.utils.lazy.Lazy;
 import java.io.IOException;
@@ -22,8 +23,8 @@ public class DaVinciConfigTest {
         Schema keySchema,
         Schema inputValueSchema,
         Schema outputValueSchema,
-        boolean storeRecordsInDaVinci) {
-      super(storeVersion, keySchema, inputValueSchema, outputValueSchema, storeRecordsInDaVinci);
+        DaVinciRecordTransformerConfig recordTransformerConfig) {
+      super(storeVersion, keySchema, inputValueSchema, outputValueSchema, recordTransformerConfig);
     }
 
     @Override
@@ -44,38 +45,56 @@ public class DaVinciConfigTest {
 
   @Test
   public void testRecordTransformerEnabled() {
-    DaVinciConfig config = new DaVinciConfig();
-    assertFalse(config.isRecordTransformerEnabled());
+    DaVinciConfig clientConfig = new DaVinciConfig();
+    assertFalse(clientConfig.isRecordTransformerEnabled());
 
-    DaVinciRecordTransformerConfig recordTransformerConfig = new DaVinciRecordTransformerConfig(
-        (storeVersion, keySchema, inputValueSchema, outputValueSchema) -> new TestRecordTransformer(
+    DaVinciRecordTransformerConfig dummyRecordTransformerConfig = new DaVinciRecordTransformerConfig.Builder()
+        .setRecordTransformerFunction((storeVersion, keySchema, inputValueSchema, outputValueSchema, config) -> null)
+        .build();
+
+    DaVinciRecordTransformerFunctionalInterface recordTransformerFunction =
+        (storeVersion, keySchema, inputValueSchema, outputValueSchema, config) -> new TestRecordTransformer(
             storeVersion,
             keySchema,
             inputValueSchema,
             outputValueSchema,
-            true),
-        String.class,
-        Schema.create(Schema.Type.INT));
-    config.setRecordTransformerConfig(recordTransformerConfig);
-    assertTrue(config.isRecordTransformerEnabled());
+            dummyRecordTransformerConfig);
+
+    DaVinciRecordTransformerConfig recordTransformerConfig =
+        new DaVinciRecordTransformerConfig.Builder().setRecordTransformerFunction(recordTransformerFunction)
+            .setOutputValueClass(String.class)
+            .setOutputValueSchema(Schema.create(Schema.Type.INT))
+            .build();
+    clientConfig.setRecordTransformerConfig(recordTransformerConfig);
+
+    assertTrue(clientConfig.isRecordTransformerEnabled());
   }
 
   @Test
   public void testGetAndSetRecordTransformer() {
-    DaVinciConfig config = new DaVinciConfig();
-    assertNull(config.getRecordTransformerConfig());
+    DaVinciConfig clientConfig = new DaVinciConfig();
+    assertNull(clientConfig.getRecordTransformerConfig());
 
-    DaVinciRecordTransformerConfig recordTransformerConfig = new DaVinciRecordTransformerConfig(
-        (storeVersion, keySchema, inputValueSchema, outputValueSchema) -> new TestRecordTransformer(
+    DaVinciRecordTransformerConfig dummyRecordTransformerConfig = new DaVinciRecordTransformerConfig.Builder()
+        .setRecordTransformerFunction((storeVersion, keySchema, inputValueSchema, outputValueSchema, config) -> null)
+        .build();
+
+    DaVinciRecordTransformerFunctionalInterface recordTransformerFunction =
+        (storeVersion, keySchema, inputValueSchema, outputValueSchema, config) -> new TestRecordTransformer(
             storeVersion,
             keySchema,
             inputValueSchema,
             outputValueSchema,
-            true),
-        String.class,
-        Schema.create(Schema.Type.INT));
-    config.setRecordTransformerConfig(recordTransformerConfig);
-    assertNotNull(config.getRecordTransformerConfig());
+            dummyRecordTransformerConfig);
+
+    DaVinciRecordTransformerConfig recordTransformerConfig =
+        new DaVinciRecordTransformerConfig.Builder().setRecordTransformerFunction(recordTransformerFunction)
+            .setOutputValueClass(String.class)
+            .setOutputValueSchema(Schema.create(Schema.Type.INT))
+            .build();
+    clientConfig.setRecordTransformerConfig(recordTransformerConfig);
+
+    assertNotNull(clientConfig.getRecordTransformerConfig());
   }
 
 }

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/config/DaVinciConfigTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/config/DaVinciConfigTest.java
@@ -48,9 +48,8 @@ public class DaVinciConfigTest {
     DaVinciConfig clientConfig = new DaVinciConfig();
     assertFalse(clientConfig.isRecordTransformerEnabled());
 
-    DaVinciRecordTransformerConfig dummyRecordTransformerConfig = new DaVinciRecordTransformerConfig.Builder()
-        .setRecordTransformerFunction((storeVersion, keySchema, inputValueSchema, outputValueSchema, config) -> null)
-        .build();
+    DaVinciRecordTransformerConfig dummyRecordTransformerConfig =
+        new DaVinciRecordTransformerConfig.Builder().setRecordTransformerFunction(TestRecordTransformer::new).build();
 
     DaVinciRecordTransformerFunctionalInterface recordTransformerFunction =
         (storeVersion, keySchema, inputValueSchema, outputValueSchema, config) -> new TestRecordTransformer(
@@ -75,9 +74,8 @@ public class DaVinciConfigTest {
     DaVinciConfig clientConfig = new DaVinciConfig();
     assertNull(clientConfig.getRecordTransformerConfig());
 
-    DaVinciRecordTransformerConfig dummyRecordTransformerConfig = new DaVinciRecordTransformerConfig.Builder()
-        .setRecordTransformerFunction((storeVersion, keySchema, inputValueSchema, outputValueSchema, config) -> null)
-        .build();
+    DaVinciRecordTransformerConfig dummyRecordTransformerConfig =
+        new DaVinciRecordTransformerConfig.Builder().setRecordTransformerFunction(TestRecordTransformer::new).build();
 
     DaVinciRecordTransformerFunctionalInterface recordTransformerFunction =
         (storeVersion, keySchema, inputValueSchema, outputValueSchema, config) -> new TestRecordTransformer(

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTaskTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTaskTest.java
@@ -4838,16 +4838,13 @@ public abstract class StoreIngestionTaskTest {
       }
     }, aaConfig);
 
-    DaVinciRecordTransformerConfig recordTransformerConfig = new DaVinciRecordTransformerConfig(
-        (storeVersion, keySchema, inputValueSchema, outputValueSchema) -> new TestStringRecordTransformer(
-            storeVersion,
-            keySchema,
-            inputValueSchema,
-            outputValueSchema,
-            true),
-        String.class,
-        Schema.create(Schema.Type.STRING));
+    DaVinciRecordTransformerConfig recordTransformerConfig =
+        new DaVinciRecordTransformerConfig.Builder().setRecordTransformerFunction(TestStringRecordTransformer::new)
+            .setOutputValueClass(String.class)
+            .setOutputValueSchema(Schema.create(Schema.Type.STRING))
+            .build();
     config.setRecordTransformerConfig(recordTransformerConfig);
+
     runTest(config);
 
     // Transformer error should never be recorded
@@ -4914,15 +4911,11 @@ public abstract class StoreIngestionTaskTest {
           .recordTransformerError(eq(storeNameWithoutVersionInfo), anyInt(), anyDouble(), anyLong());
     }, aaConfig);
 
-    DaVinciRecordTransformerConfig recordTransformerConfig = new DaVinciRecordTransformerConfig(
-        (storeVersion, keySchema, inputValueSchema, outputValueSchema) -> new TestStringRecordTransformer(
-            storeVersion,
-            keySchema,
-            inputValueSchema,
-            outputValueSchema,
-            true),
-        String.class,
-        Schema.create(Schema.Type.STRING));
+    DaVinciRecordTransformerConfig recordTransformerConfig =
+        new DaVinciRecordTransformerConfig.Builder().setRecordTransformerFunction(TestStringRecordTransformer::new)
+            .setOutputValueClass(String.class)
+            .setOutputValueSchema(Schema.create(Schema.Type.STRING))
+            .build();
     config.setRecordTransformerConfig(recordTransformerConfig);
     runTest(config);
   }

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTaskTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTaskTest.java
@@ -4979,8 +4979,6 @@ public abstract class StoreIngestionTaskTest {
 
     DaVinciRecordTransformerConfig recordTransformerConfig =
         new DaVinciRecordTransformerConfig.Builder().setRecordTransformerFunction(TestStringRecordTransformer::new)
-            .setOutputValueClass(String.class)
-            .setOutputValueSchema(Schema.create(Schema.Type.STRING))
             .build();
     config.setRecordTransformerConfig(recordTransformerConfig);
     runTest(config);

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/transformer/DaVinciRecordTransformerConfigTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/transformer/DaVinciRecordTransformerConfigTest.java
@@ -75,7 +75,7 @@ public class DaVinciRecordTransformerConfigTest {
   }
 
   @Test
-  public void testNotDefiningOutputValueClassAndSchema() {
+  public void testUndefinedOutputValueClassAndSchema() {
     DaVinciRecordTransformerConfig recordTransformerConfig =
         new DaVinciRecordTransformerConfig.Builder().setRecordTransformerFunction(TestStringRecordTransformer::new)
             .build();

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/transformer/DaVinciRecordTransformerConfigTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/transformer/DaVinciRecordTransformerConfigTest.java
@@ -1,0 +1,89 @@
+package com.linkedin.davinci.transformer;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertThrows;
+import static org.testng.Assert.assertTrue;
+
+import com.linkedin.davinci.client.DaVinciRecordTransformerConfig;
+import com.linkedin.venice.exceptions.VeniceException;
+import org.apache.avro.Schema;
+import org.testng.annotations.Test;
+
+
+public class DaVinciRecordTransformerConfigTest {
+  @Test
+  public void testRecordTransformerFunctionRequired() {
+    assertThrows(VeniceException.class, () -> new DaVinciRecordTransformerConfig.Builder().build());
+  }
+
+  @Test
+  public void testOutputValueClassAndSchemaBothRequired() {
+    assertThrows(
+        VeniceException.class,
+        () -> new DaVinciRecordTransformerConfig.Builder()
+            .setRecordTransformerFunction(TestStringRecordTransformer::new)
+            .setOutputValueClass(String.class)
+            .build());
+
+    assertThrows(
+        VeniceException.class,
+        () -> new DaVinciRecordTransformerConfig.Builder()
+            .setRecordTransformerFunction(TestStringRecordTransformer::new)
+            .setOutputValueSchema(Schema.create(Schema.Type.STRING))
+            .build());
+  }
+
+  @Test
+  public void testDefaults() {
+    Class outputValueClass = String.class;
+    Schema outputValueSchema = Schema.create(Schema.Type.STRING);
+
+    DaVinciRecordTransformerConfig recordTransformerConfig =
+        new DaVinciRecordTransformerConfig.Builder().setRecordTransformerFunction(TestStringRecordTransformer::new)
+            .setOutputValueClass(outputValueClass)
+            .setOutputValueSchema(outputValueSchema)
+            .build();
+
+    assertNotNull(recordTransformerConfig.getRecordTransformerFunction());
+    assertEquals(recordTransformerConfig.getOutputValueClass(), outputValueClass);
+    assertEquals(recordTransformerConfig.getOutputValueSchema(), outputValueSchema);
+    assertTrue(recordTransformerConfig.getStoreRecordsInDaVinci());
+    assertFalse(recordTransformerConfig.getAlwaysBootstrapFromVersionTopic());
+  }
+
+  @Test
+  public void testNonDefaults() {
+    Class outputValueClass = String.class;
+    Schema outputValueSchema = Schema.create(Schema.Type.STRING);
+
+    DaVinciRecordTransformerConfig recordTransformerConfig =
+        new DaVinciRecordTransformerConfig.Builder().setRecordTransformerFunction(TestStringRecordTransformer::new)
+            .setOutputValueClass(outputValueClass)
+            .setOutputValueSchema(outputValueSchema)
+            .setStoreRecordsInDaVinci(false)
+            .setAlwaysBootstrapFromVersionTopic(true)
+            .build();
+
+    assertNotNull(recordTransformerConfig.getRecordTransformerFunction());
+    assertEquals(recordTransformerConfig.getOutputValueClass(), outputValueClass);
+    assertEquals(recordTransformerConfig.getOutputValueSchema(), outputValueSchema);
+    assertFalse(recordTransformerConfig.getStoreRecordsInDaVinci());
+    assertTrue(recordTransformerConfig.getAlwaysBootstrapFromVersionTopic());
+  }
+
+  @Test
+  public void testNotDefiningOutputValueClassAndSchema() {
+    DaVinciRecordTransformerConfig recordTransformerConfig =
+        new DaVinciRecordTransformerConfig.Builder().setRecordTransformerFunction(TestStringRecordTransformer::new)
+            .build();
+
+    assertNotNull(recordTransformerConfig.getRecordTransformerFunction());
+    assertNull(recordTransformerConfig.getOutputValueClass());
+    assertNull(recordTransformerConfig.getOutputValueSchema());
+    assertTrue(recordTransformerConfig.getStoreRecordsInDaVinci());
+    assertFalse(recordTransformerConfig.getAlwaysBootstrapFromVersionTopic());
+  }
+}

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/transformer/RecordTransformerTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/transformer/RecordTransformerTest.java
@@ -40,10 +40,10 @@ public class RecordTransformerTest {
     Schema keySchema = Schema.create(Schema.Type.INT);
     Schema valueSchema = Schema.create(Schema.Type.STRING);
 
-    DaVinciRecordTransformerConfig dummyRecordTransformerConfig = new DaVinciRecordTransformerConfig.Builder()
-        .setRecordTransformerFunction((storeVersion, keySchema1, inputValueSchema, outputValueSchema, config) -> null)
-        .setStoreRecordsInDaVinci(false)
-        .build();
+    DaVinciRecordTransformerConfig dummyRecordTransformerConfig =
+        new DaVinciRecordTransformerConfig.Builder().setRecordTransformerFunction(TestStringRecordTransformer::new)
+            .setStoreRecordsInDaVinci(false)
+            .build();
 
     DaVinciRecordTransformer<Integer, String, String> recordTransformer = new TestStringRecordTransformer(
         storeVersion,
@@ -86,9 +86,9 @@ public class RecordTransformerTest {
     Schema keySchema = Schema.create(Schema.Type.INT);
     Schema valueSchema = Schema.create(Schema.Type.STRING);
 
-    DaVinciRecordTransformerConfig dummyRecordTransformerConfig = new DaVinciRecordTransformerConfig.Builder()
-        .setRecordTransformerFunction((storeVersion, keySchema1, inputValueSchema, outputValueSchema, config) -> null)
-        .build();
+    DaVinciRecordTransformerConfig dummyRecordTransformerConfig =
+        new DaVinciRecordTransformerConfig.Builder().setRecordTransformerFunction(TestStringRecordTransformer::new)
+            .build();
 
     DaVinciRecordTransformer<Integer, String, String> recordTransformer = new TestStringRecordTransformer(
         storeVersion,
@@ -137,10 +137,10 @@ public class RecordTransformerTest {
     Schema keySchema = Schema.create(Schema.Type.INT);
     Schema valueSchema = Schema.create(Schema.Type.STRING);
 
-    DaVinciRecordTransformerConfig dummyRecordTransformerConfig = new DaVinciRecordTransformerConfig.Builder()
-        .setRecordTransformerFunction((storeVersion, keySchema1, inputValueSchema, outputValueSchema, config) -> null)
-        .setAlwaysBootstrapFromVersionTopic(true)
-        .build();
+    DaVinciRecordTransformerConfig dummyRecordTransformerConfig =
+        new DaVinciRecordTransformerConfig.Builder().setRecordTransformerFunction(TestStringRecordTransformer::new)
+            .setAlwaysBootstrapFromVersionTopic(true)
+            .build();
 
     DaVinciRecordTransformer<Integer, String, String> recordTransformer = new TestStringRecordTransformer(
         storeVersion,
@@ -189,9 +189,9 @@ public class RecordTransformerTest {
     Schema keySchema = Schema.create(Schema.Type.INT);
     Schema valueSchema = Schema.create(Schema.Type.STRING);
 
-    DaVinciRecordTransformerConfig dummyRecordTransformerConfig = new DaVinciRecordTransformerConfig.Builder()
-        .setRecordTransformerFunction((storeVersion, keySchema1, inputValueSchema, outputValueSchema, config) -> null)
-        .build();
+    DaVinciRecordTransformerConfig dummyRecordTransformerConfig =
+        new DaVinciRecordTransformerConfig.Builder().setRecordTransformerFunction(TestStringRecordTransformer::new)
+            .build();
 
     DaVinciRecordTransformer<Integer, String, String> recordTransformer = new TestStringRecordTransformer(
         storeVersion,

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/transformer/RecordTransformerTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/transformer/RecordTransformerTest.java
@@ -150,11 +150,6 @@ public class RecordTransformerTest {
         dummyRecordTransformerConfig);
     assertEquals(recordTransformer.getStoreVersion(), storeVersion);
 
-    AbstractStorageIterator iterator = mock(AbstractStorageIterator.class);
-    when(iterator.isValid()).thenReturn(true).thenReturn(false);
-    when(iterator.key()).thenReturn("mockKey".getBytes());
-    when(iterator.value()).thenReturn("mockValue".getBytes());
-
     AbstractStorageEngine storageEngine = mock(AbstractStorageEngine.class);
     Lazy<VeniceCompressor> compressor = Lazy.of(() -> mock(VeniceCompressor.class));
 
@@ -170,15 +165,9 @@ public class RecordTransformerTest {
     offsetRecord.setRecordTransformerClassHash(recordTransformer.getClassHash());
     assertEquals((int) offsetRecord.getRecordTransformerClassHash(), recordTransformer.getClassHash());
 
-    // class hash should be the same when the OffsetRecord is serialized then deserialized
-    byte[] offsetRecordBytes = offsetRecord.toBytes();
-    OffsetRecord deserializedOffsetRecord = new OffsetRecord(offsetRecordBytes, partitionStateSerializer);
-    assertEquals((int) deserializedOffsetRecord.getRecordTransformerClassHash(), recordTransformer.getClassHash());
-
     when(storageEngine.getPartitionOffset(partitionId)).thenReturn(Optional.of(offsetRecord));
 
     // Execute the onRecovery method again to test the case where the classHash exists
-    when(storageEngine.getIterator(partitionId)).thenReturn(iterator);
     recordTransformer.onRecovery(storageEngine, partitionId, partitionStateSerializer, compressor);
     verify(storageEngine, times(1)).clearPartitionOffset(partitionId);
     verify(storageEngine, never()).getIterator(partitionId);

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/transformer/TestStringRecordTransformer.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/transformer/TestStringRecordTransformer.java
@@ -1,6 +1,7 @@
 package com.linkedin.davinci.transformer;
 
 import com.linkedin.davinci.client.DaVinciRecordTransformer;
+import com.linkedin.davinci.client.DaVinciRecordTransformerConfig;
 import com.linkedin.davinci.client.DaVinciRecordTransformerResult;
 import com.linkedin.venice.utils.lazy.Lazy;
 import java.io.IOException;
@@ -14,8 +15,8 @@ public class TestStringRecordTransformer extends DaVinciRecordTransformer<Intege
       Schema keySchema,
       Schema inputValueSchema,
       Schema outputValueSchema,
-      boolean storeRecordsInDaVinci) {
-    super(storeVersion, keySchema, inputValueSchema, outputValueSchema, storeRecordsInDaVinci);
+      DaVinciRecordTransformerConfig recordTransformerConfig) {
+    super(storeVersion, keySchema, inputValueSchema, outputValueSchema, recordTransformerConfig);
   }
 
   @Override

--- a/docs/user_guide/read_api/da_vinci_client.md
+++ b/docs/user_guide/read_api/da_vinci_client.md
@@ -12,44 +12,36 @@ cache. Future updates to the data continue to be streamed in and applied to the 
 
 ## Record Transformer
 This feature enables applications to transform records before they're stored in the Da Vinci Client
-or a custom storage of your choice.
+or redirected to a custom storage of your choice.
 It's capable of handling records that are compressed and/or chunked.
 
-### Usage
+### Example Usage
 Steps to use the record transformer:
 1. Implement the 
 [DaVinciRecordTransformer](http://venicedb.org/javadoc/com/linkedin/davinci/client/DaVinciRecordTransformer.html) 
 abstract class.
 2. Create an instance of [DaVinciRecordTransformerConfig](http://venicedb.org/javadoc/com/linkedin/davinci/client/DaVinciRecordTransformerConfig.html).
-3. Pass the instance of the config into [setRecordTransformerConfig()](https://venicedb.org/javadoc/com/linkedin/davinci/client/DaVinciConfig.html#setRecordTransformerConfig(com.linkedin.davinci.client.DaVinciRecordTransformerConfig)). 
-
-When a message is being consumed, the 
-[DaVinciRecordTransformer](http://venicedb.org/javadoc/com/linkedin/davinci/client/DaVinciRecordTransformer.html) will 
-modify the value before it is written to storage.
+3. Pass the instance of the config into [setRecordTransformerConfig()](https://venicedb.org/javadoc/com/linkedin/davinci/client/DaVinciConfig.html#setRecordTransformerConfig(com.linkedin.davinci.client.DaVinciRecordTransformerConfig)).
 
 Here's an example `DaVinciRecordTransformer` implementation:
 ```
-package com.linkedin.davinci.transformer;
-
 import com.linkedin.davinci.client.DaVinciRecordTransformer;
+import com.linkedin.davinci.client.DaVinciRecordTransformerConfig;
+import com.linkedin.davinci.client.DaVinciRecordTransformerResult;
 import com.linkedin.venice.utils.lazy.Lazy;
+import java.io.IOException;
 import org.apache.avro.Schema;
 import org.apache.avro.util.Utf8;
 
 
 public class StringRecordTransformer extends DaVinciRecordTransformer<Integer, String, String> {
-  public TestStringRecordTransformer(int storeVersion, boolean storeRecordsInDaVinci) {
-    super(storeVersion, storeRecordsInDaVinci);
-  }
-
-  @Override
-  public Schema getKeySchema() {
-    return Schema.create(Schema.Type.INT);
-  }
-
-  @Override
-  public Schema getOutputValueSchema() {
-    return Schema.create(Schema.Type.STRING);
+  public StringRecordTransformer(
+      int storeVersion,
+      Schema keySchema,
+      Schema inputValueSchema,
+      Schema outputValueSchema,
+      DaVinciRecordTransformerConfig recordTransformerConfig) {
+    super(storeVersion, keySchema, inputValueSchema, outputValueSchema, recordTransformerConfig);
   }
 
   @Override
@@ -84,8 +76,62 @@ public class StringRecordTransformer extends DaVinciRecordTransformer<Integer, S
 Here's an example `DaVinciRecordTransformerConfig` implementation:
 ```
 DaVinciConfig config = new DaVinciConfig();
-DaVinciRecordTransformerConfig recordTransformerConfig = new DaVinciRecordTransformerConfig(
-    (storeVersion) -> new StringRecordTransformer(storeVersion, true),
-    String.class, Schema.create(Schema.Type.STRING));
-config.setRecordTransformerFunction((storeVersion) -> new StringRecordTransformer(storeVersion, true));
+DaVinciRecordTransformerConfig recordTransformerConfig =
+        new DaVinciRecordTransformerConfig.Builder()
+            .setRecordTransformerFunction(StringRecordTransformer::new)
+            .build();
+config.setRecordTransformerConfig(recordTransformerConfig);
+```
+
+### Schema Modification
+If you want to modify the Value Schema of the record, here's an example `DaVinciRecordTransformer` implementation:
+```
+import com.linkedin.davinci.client.DaVinciRecordTransformer;
+import com.linkedin.davinci.client.DaVinciRecordTransformerConfig;
+import com.linkedin.davinci.client.DaVinciRecordTransformerResult;
+import com.linkedin.venice.utils.lazy.Lazy;
+import java.io.IOException;
+import org.apache.avro.Schema;
+
+
+/**
+ * Transforms int values to strings
+ */
+public class IntToStringRecordTransformer extends DaVinciRecordTransformer<Integer, Integer, String> {
+  public IntToStringRecordTransformer(
+      int storeVersion,
+      Schema keySchema,
+      Schema inputValueSchema,
+      Schema outputValueSchema,
+      DaVinciRecordTransformerConfig recordTransformerConfig) {
+    super(storeVersion, keySchema, inputValueSchema, outputValueSchema, recordTransformerConfig);
+  }
+
+  @Override
+  public DaVinciRecordTransformerResult<String> transform(Lazy<Integer> key, Lazy<Integer> value) {
+    String valueStr = value.get().toString();
+    String transformedValue = valueStr + "Transformed";
+    return new DaVinciRecordTransformerResult<>(DaVinciRecordTransformerResult.Result.TRANSFORMED, transformedValue);
+  }
+
+  @Override
+  public void processPut(Lazy<Integer> key, Lazy<String> value) {
+    return;
+  }
+
+  @Override
+  public void close() throws IOException {
+
+  }
+}
+```
+
+```
+DaVinciRecordTransformerConfig recordTransformerConfig =
+        new DaVinciRecordTransformerConfig.Builder()
+            .setRecordTransformerFunction(IntToStringRecordTransformer::new)
+            .setOutputValueClass(String.class)
+            .setOutputValueSchema(Schema.create(Schema.Type.STRING))
+            .build();
+config.setRecordTransformerConfig(recordTransformerConfig);
 ```

--- a/docs/user_guide/read_api/da_vinci_client.md
+++ b/docs/user_guide/read_api/da_vinci_client.md
@@ -126,6 +126,7 @@ public class IntToStringRecordTransformer extends DaVinciRecordTransformer<Integ
 }
 ```
 
+Here's an example `DaVinciRecordTransformerConfig` implementation:
 ```
 DaVinciRecordTransformerConfig recordTransformerConfig =
         new DaVinciRecordTransformerConfig.Builder()

--- a/integrations/venice-duckdb/src/integrationTest/java/com/linkedin/venice/endToEnd/DuckDBDaVinciRecordTransformerIntegrationTest.java
+++ b/integrations/venice-duckdb/src/integrationTest/java/com/linkedin/venice/endToEnd/DuckDBDaVinciRecordTransformerIntegrationTest.java
@@ -151,8 +151,6 @@ public class DuckDBDaVinciRecordTransformerIntegrationTest {
 
       DaVinciRecordTransformerConfig recordTransformerConfig =
           new DaVinciRecordTransformerConfig.Builder().setRecordTransformerFunction(recordTransformerFunction)
-              .setOutputValueClass(GenericRecord.class)
-              .setOutputValueSchema(NAME_RECORD_V1_SCHEMA)
               .setStoreRecordsInDaVinci(false)
               .build();
       clientConfig.setRecordTransformerConfig(recordTransformerConfig);

--- a/integrations/venice-duckdb/src/main/java/com/linkedin/venice/duckdb/DuckDBDaVinciRecordTransformer.java
+++ b/integrations/venice-duckdb/src/main/java/com/linkedin/venice/duckdb/DuckDBDaVinciRecordTransformer.java
@@ -3,6 +3,7 @@ package com.linkedin.venice.duckdb;
 import static com.linkedin.venice.sql.AvroToSQL.UnsupportedTypeHandling.SKIP;
 
 import com.linkedin.davinci.client.DaVinciRecordTransformer;
+import com.linkedin.davinci.client.DaVinciRecordTransformerConfig;
 import com.linkedin.davinci.client.DaVinciRecordTransformerResult;
 import com.linkedin.venice.exceptions.VeniceException;
 import com.linkedin.venice.sql.AvroToSQL;
@@ -44,11 +45,11 @@ public class DuckDBDaVinciRecordTransformer
       Schema keySchema,
       Schema inputValueSchema,
       Schema outputValueSchema,
-      boolean storeRecordsInDaVinci,
+      DaVinciRecordTransformerConfig recordTransformerConfig,
       String baseDir,
       String storeNameWithoutVersionInfo,
       Set<String> columnsToProject) {
-    super(storeVersion, keySchema, inputValueSchema, outputValueSchema, storeRecordsInDaVinci);
+    super(storeVersion, keySchema, inputValueSchema, outputValueSchema, recordTransformerConfig);
     this.storeNameWithoutVersionInfo = storeNameWithoutVersionInfo;
     this.versionTableName = buildStoreNameWithVersion(storeVersion);
     this.duckDBUrl = "jdbc:duckdb:" + baseDir + "/" + duckDBFilePath;

--- a/integrations/venice-duckdb/src/test/java/com/linkedin/venice/duckdb/DuckDBDaVinciRecordTransformerTest.java
+++ b/integrations/venice-duckdb/src/test/java/com/linkedin/venice/duckdb/DuckDBDaVinciRecordTransformerTest.java
@@ -8,6 +8,7 @@ import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertTrue;
 
+import com.linkedin.davinci.client.DaVinciRecordTransformerConfig;
 import com.linkedin.davinci.client.DaVinciRecordTransformerResult;
 import com.linkedin.davinci.client.DaVinciRecordTransformerUtility;
 import com.linkedin.venice.kafka.protocol.state.PartitionState;
@@ -16,7 +17,6 @@ import com.linkedin.venice.serialization.avro.AvroProtocolDefinition;
 import com.linkedin.venice.serialization.avro.InternalAvroSpecificSerializer;
 import com.linkedin.venice.utils.Utils;
 import com.linkedin.venice.utils.lazy.Lazy;
-import java.io.IOException;
 import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.ResultSet;
@@ -39,15 +39,20 @@ public class DuckDBDaVinciRecordTransformerTest {
   private final Set<String> columnsToProject = Collections.emptySet();
 
   @Test
-  public void testRecordTransformer() throws IOException {
+  public void testRecordTransformer() {
     String tempDir = Utils.getTempDataDirectory().getAbsolutePath();
+
+    DaVinciRecordTransformerConfig dummyRecordTransformerConfig = new DaVinciRecordTransformerConfig.Builder()
+        .setRecordTransformerFunction((storeVersion, keySchema, inputValueSchema, outputValueSchema, config) -> null)
+        .setStoreRecordsInDaVinci(false)
+        .build();
 
     try (DuckDBDaVinciRecordTransformer recordTransformer = new DuckDBDaVinciRecordTransformer(
         storeVersion,
         SINGLE_FIELD_RECORD_SCHEMA,
         NAME_RECORD_V1_SCHEMA,
         NAME_RECORD_V1_SCHEMA,
-        false,
+        dummyRecordTransformerConfig,
         tempDir,
         storeName,
         columnsToProject)) {
@@ -99,12 +104,17 @@ public class DuckDBDaVinciRecordTransformerTest {
   public void testVersionSwap() throws SQLException {
     String tempDir = Utils.getTempDataDirectory().getAbsolutePath();
 
+    DaVinciRecordTransformerConfig dummyRecordTransformerConfig = new DaVinciRecordTransformerConfig.Builder()
+        .setRecordTransformerFunction((storeVersion, keySchema, inputValueSchema, outputValueSchema, config) -> null)
+        .setStoreRecordsInDaVinci(false)
+        .build();
+
     DuckDBDaVinciRecordTransformer recordTransformer_v1 = new DuckDBDaVinciRecordTransformer(
         1,
         SINGLE_FIELD_RECORD_SCHEMA,
         NAME_RECORD_V1_SCHEMA,
         NAME_RECORD_V1_SCHEMA,
-        false,
+        dummyRecordTransformerConfig,
         tempDir,
         storeName,
         columnsToProject);
@@ -113,7 +123,7 @@ public class DuckDBDaVinciRecordTransformerTest {
         SINGLE_FIELD_RECORD_SCHEMA,
         NAME_RECORD_V1_SCHEMA,
         NAME_RECORD_V1_SCHEMA,
-        false,
+        dummyRecordTransformerConfig,
         tempDir,
         storeName,
         columnsToProject);
@@ -162,12 +172,17 @@ public class DuckDBDaVinciRecordTransformerTest {
     String store1 = "store1";
     String store2 = "store2";
 
+    DaVinciRecordTransformerConfig dummyRecordTransformerConfig = new DaVinciRecordTransformerConfig.Builder()
+        .setRecordTransformerFunction((storeVersion, keySchema, inputValueSchema, outputValueSchema, config) -> null)
+        .setStoreRecordsInDaVinci(false)
+        .build();
+
     DuckDBDaVinciRecordTransformer recordTransformerForStore1 = new DuckDBDaVinciRecordTransformer(
         1,
         SINGLE_FIELD_RECORD_SCHEMA,
         NAME_RECORD_V1_SCHEMA,
         NAME_RECORD_V1_SCHEMA,
-        false,
+        dummyRecordTransformerConfig,
         tempDir,
         store1,
         columnsToProject);
@@ -176,7 +191,7 @@ public class DuckDBDaVinciRecordTransformerTest {
         TWO_FIELDS_RECORD_SCHEMA,
         NAME_RECORD_V1_SCHEMA,
         NAME_RECORD_V1_SCHEMA,
-        false,
+        dummyRecordTransformerConfig,
         tempDir,
         store2,
         columnsToProject);

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/davinci/DaVinciUserApp.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/davinci/DaVinciUserApp.java
@@ -73,16 +73,11 @@ public class DaVinciUserApp {
     daVinciConfig.setStorageClass(storageClassEnum);
 
     if (recordTransformerEnabled) {
-      DaVinciRecordTransformerConfig recordTransformerConfig = new DaVinciRecordTransformerConfig(
-          (storeVersion, keySchema, inputValueSchema, outputValueSchema) -> new TestStringRecordTransformer(
-              storeVersion,
-              keySchema,
-              inputValueSchema,
-              outputValueSchema,
-              true),
-          String.class,
-          Schema.create(Schema.Type.STRING));
-
+      DaVinciRecordTransformerConfig recordTransformerConfig =
+          new DaVinciRecordTransformerConfig.Builder().setRecordTransformerFunction(TestStringRecordTransformer::new)
+              .setOutputValueClass(String.class)
+              .setOutputValueSchema(Schema.create(Schema.Type.STRING))
+              .build();
       daVinciConfig.setRecordTransformerConfig(recordTransformerConfig);
     }
 

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/davinci/DaVinciUserApp.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/davinci/DaVinciUserApp.java
@@ -27,7 +27,6 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
-import org.apache.avro.Schema;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -75,8 +74,6 @@ public class DaVinciUserApp {
     if (recordTransformerEnabled) {
       DaVinciRecordTransformerConfig recordTransformerConfig =
           new DaVinciRecordTransformerConfig.Builder().setRecordTransformerFunction(TestStringRecordTransformer::new)
-              .setOutputValueClass(String.class)
-              .setOutputValueSchema(Schema.create(Schema.Type.STRING))
               .build();
       daVinciConfig.setRecordTransformerConfig(recordTransformerConfig);
     }

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/DaVinciClientRecordTransformerTest.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/DaVinciClientRecordTransformerTest.java
@@ -128,8 +128,6 @@ public class DaVinciClientRecordTransformerTest {
 
       DaVinciRecordTransformerConfig recordTransformerConfig =
           new DaVinciRecordTransformerConfig.Builder().setRecordTransformerFunction(TestStringRecordTransformer::new)
-              .setOutputValueClass(String.class)
-              .setOutputValueSchema(Schema.create(Schema.Type.STRING))
               .build();
       clientConfig.setRecordTransformerConfig(recordTransformerConfig);
 
@@ -224,12 +222,11 @@ public class DaVinciClientRecordTransformerTest {
       TestStringRecordTransformer recordTransformer =
           new TestStringRecordTransformer(1, myKeySchema, myValueSchema, myValueSchema, dummyRecordTransformerConfig);
 
-      DaVinciRecordTransformerConfig recordTransformerConfig = new DaVinciRecordTransformerConfig.Builder()
-          .setRecordTransformerFunction(
-              (storeVersion, keySchema, inputValueSchema, outputValueSchema, config) -> recordTransformer)
-          .setOutputValueClass(String.class)
-          .setOutputValueSchema(Schema.create(Schema.Type.STRING))
-          .build();
+      DaVinciRecordTransformerConfig recordTransformerConfig =
+          new DaVinciRecordTransformerConfig.Builder()
+              .setRecordTransformerFunction(
+                  (storeVersion, keySchema, inputValueSchema, outputValueSchema, config) -> recordTransformer)
+              .build();
       clientConfig.setRecordTransformerConfig(recordTransformerConfig);
 
       DaVinciClient<Integer, Object> clientWithRecordTransformer =
@@ -309,12 +306,11 @@ public class DaVinciClientRecordTransformerTest {
       TestStringRecordTransformer recordTransformer =
           new TestStringRecordTransformer(1, myKeySchema, myValueSchema, myValueSchema, dummyRecordTransformerConfig);
 
-      DaVinciRecordTransformerConfig recordTransformerConfig = new DaVinciRecordTransformerConfig.Builder()
-          .setRecordTransformerFunction(
-              (storeVersion, keySchema, inputValueSchema, outputValueSchema, config) -> recordTransformer)
-          .setOutputValueClass(String.class)
-          .setOutputValueSchema(Schema.create(Schema.Type.STRING))
-          .build();
+      DaVinciRecordTransformerConfig recordTransformerConfig =
+          new DaVinciRecordTransformerConfig.Builder()
+              .setRecordTransformerFunction(
+                  (storeVersion, keySchema, inputValueSchema, outputValueSchema, config) -> recordTransformer)
+              .build();
       clientConfig.setRecordTransformerConfig(recordTransformerConfig);
 
       DaVinciClient<Integer, String> clientWithRecordTransformer =
@@ -383,8 +379,6 @@ public class DaVinciClientRecordTransformerTest {
     DaVinciRecordTransformerConfig recordTransformerConfig = new DaVinciRecordTransformerConfig.Builder()
         .setRecordTransformerFunction(
             (storeVersion, keySchema, inputValueSchema, outputValueSchema, config) -> recordTransformer)
-        .setOutputValueClass(String.class)
-        .setOutputValueSchema(Schema.create(Schema.Type.STRING))
         .setStoreRecordsInDaVinci(false)
         .build();
     clientConfig.setRecordTransformerConfig(recordTransformerConfig);
@@ -436,12 +430,11 @@ public class DaVinciClientRecordTransformerTest {
     TestSkipResultRecordTransformer recordTransformer =
         new TestSkipResultRecordTransformer(1, myKeySchema, myValueSchema, myValueSchema, dummyRecordTransformerConfig);
 
-    DaVinciRecordTransformerConfig recordTransformerConfig = new DaVinciRecordTransformerConfig.Builder()
-        .setRecordTransformerFunction(
-            (storeVersion, keySchema, inputValueSchema, outputValueSchema, config) -> recordTransformer)
-        .setOutputValueClass(String.class)
-        .setOutputValueSchema(Schema.create(Schema.Type.STRING))
-        .build();
+    DaVinciRecordTransformerConfig recordTransformerConfig =
+        new DaVinciRecordTransformerConfig.Builder()
+            .setRecordTransformerFunction(
+                (storeVersion, keySchema, inputValueSchema, outputValueSchema, config) -> recordTransformer)
+            .build();
     clientConfig.setRecordTransformerConfig(recordTransformerConfig);
 
     try (CachingDaVinciClientFactory factory = new CachingDaVinciClientFactory(
@@ -483,8 +476,6 @@ public class DaVinciClientRecordTransformerTest {
 
     DaVinciRecordTransformerConfig recordTransformerConfig = new DaVinciRecordTransformerConfig.Builder()
         .setRecordTransformerFunction(TestUnchangedResultRecordTransformer::new)
-        .setOutputValueClass(String.class)
-        .setOutputValueSchema(Schema.create(Schema.Type.STRING))
         .build();
     clientConfig.setRecordTransformerConfig(recordTransformerConfig);
 
@@ -536,12 +527,11 @@ public class DaVinciClientRecordTransformerTest {
     TestStringRecordTransformer recordTransformer =
         new TestStringRecordTransformer(1, myKeySchema, myValueSchema, myValueSchema, dummyRecordTransformerConfig);
 
-    DaVinciRecordTransformerConfig recordTransformerConfig = new DaVinciRecordTransformerConfig.Builder()
-        .setRecordTransformerFunction(
-            (storeVersion, keySchema, inputValueSchema, outputValueSchema, config) -> recordTransformer)
-        .setOutputValueClass(String.class)
-        .setOutputValueSchema(Schema.create(Schema.Type.STRING))
-        .build();
+    DaVinciRecordTransformerConfig recordTransformerConfig =
+        new DaVinciRecordTransformerConfig.Builder()
+            .setRecordTransformerFunction(
+                (storeVersion, keySchema, inputValueSchema, outputValueSchema, config) -> recordTransformer)
+            .build();
     clientConfig.setRecordTransformerConfig(recordTransformerConfig);
 
     setUpStore(storeName, paramsConsumer, properties -> {}, pushStatusStoreEnabled);

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/DaVinciClientRecordTransformerTest.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/DaVinciClientRecordTransformerTest.java
@@ -217,9 +217,9 @@ public class DaVinciClientRecordTransformerTest {
       Schema myKeySchema = Schema.create(Schema.Type.INT);
       Schema myValueSchema = Schema.create(Schema.Type.STRING);
 
-      DaVinciRecordTransformerConfig dummyRecordTransformerConfig = new DaVinciRecordTransformerConfig.Builder()
-          .setRecordTransformerFunction((storeVersion, keySchema, inputValueSchema, outputValueSchema, config) -> null)
-          .build();
+      DaVinciRecordTransformerConfig dummyRecordTransformerConfig =
+          new DaVinciRecordTransformerConfig.Builder().setRecordTransformerFunction(TestStringRecordTransformer::new)
+              .build();
 
       TestStringRecordTransformer recordTransformer =
           new TestStringRecordTransformer(1, myKeySchema, myValueSchema, myValueSchema, dummyRecordTransformerConfig);
@@ -302,9 +302,9 @@ public class DaVinciClientRecordTransformerTest {
       Schema myKeySchema = Schema.create(Schema.Type.INT);
       Schema myValueSchema = Schema.create(Schema.Type.STRING);
 
-      DaVinciRecordTransformerConfig dummyRecordTransformerConfig = new DaVinciRecordTransformerConfig.Builder()
-          .setRecordTransformerFunction((storeVersion, keySchema, inputValueSchema, outputValueSchema, config) -> null)
-          .build();
+      DaVinciRecordTransformerConfig dummyRecordTransformerConfig =
+          new DaVinciRecordTransformerConfig.Builder().setRecordTransformerFunction(TestStringRecordTransformer::new)
+              .build();
 
       TestStringRecordTransformer recordTransformer =
           new TestStringRecordTransformer(1, myKeySchema, myValueSchema, myValueSchema, dummyRecordTransformerConfig);
@@ -372,10 +372,10 @@ public class DaVinciClientRecordTransformerTest {
     Schema myKeySchema = Schema.create(Schema.Type.INT);
     Schema myValueSchema = Schema.create(Schema.Type.STRING);
 
-    DaVinciRecordTransformerConfig dummyRecordTransformerConfig = new DaVinciRecordTransformerConfig.Builder()
-        .setRecordTransformerFunction((storeVersion, keySchema, inputValueSchema, outputValueSchema, config) -> null)
-        .setStoreRecordsInDaVinci(false)
-        .build();
+    DaVinciRecordTransformerConfig dummyRecordTransformerConfig =
+        new DaVinciRecordTransformerConfig.Builder().setRecordTransformerFunction(TestStringRecordTransformer::new)
+            .setStoreRecordsInDaVinci(false)
+            .build();
 
     TestStringRecordTransformer recordTransformer =
         new TestStringRecordTransformer(1, myKeySchema, myValueSchema, myValueSchema, dummyRecordTransformerConfig);
@@ -429,9 +429,9 @@ public class DaVinciClientRecordTransformerTest {
     Schema myKeySchema = Schema.create(Schema.Type.INT);
     Schema myValueSchema = Schema.create(Schema.Type.STRING);
 
-    DaVinciRecordTransformerConfig dummyRecordTransformerConfig = new DaVinciRecordTransformerConfig.Builder()
-        .setRecordTransformerFunction((storeVersion, keySchema, inputValueSchema, outputValueSchema, config) -> null)
-        .build();
+    DaVinciRecordTransformerConfig dummyRecordTransformerConfig =
+        new DaVinciRecordTransformerConfig.Builder().setRecordTransformerFunction(TestSkipResultRecordTransformer::new)
+            .build();
 
     TestSkipResultRecordTransformer recordTransformer =
         new TestSkipResultRecordTransformer(1, myKeySchema, myValueSchema, myValueSchema, dummyRecordTransformerConfig);
@@ -529,9 +529,9 @@ public class DaVinciClientRecordTransformerTest {
     Schema myKeySchema = Schema.create(Schema.Type.INT);
     Schema myValueSchema = Schema.create(Schema.Type.STRING);
 
-    DaVinciRecordTransformerConfig dummyRecordTransformerConfig = new DaVinciRecordTransformerConfig.Builder()
-        .setRecordTransformerFunction((storeVersion, keySchema, inputValueSchema, outputValueSchema, config) -> null)
-        .build();
+    DaVinciRecordTransformerConfig dummyRecordTransformerConfig =
+        new DaVinciRecordTransformerConfig.Builder().setRecordTransformerFunction(TestStringRecordTransformer::new)
+            .build();
 
     TestStringRecordTransformer recordTransformer =
         new TestStringRecordTransformer(1, myKeySchema, myValueSchema, myValueSchema, dummyRecordTransformerConfig);

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/DaVinciClientRecordTransformerTest.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/DaVinciClientRecordTransformerTest.java
@@ -126,15 +126,11 @@ public class DaVinciClientRecordTransformerTest {
         metricsRepository,
         backendConfig)) {
 
-      DaVinciRecordTransformerConfig recordTransformerConfig = new DaVinciRecordTransformerConfig(
-          (storeVersion, keySchema, inputValueSchema, outputValueSchema) -> new TestStringRecordTransformer(
-              storeVersion,
-              keySchema,
-              inputValueSchema,
-              outputValueSchema,
-              true),
-          String.class,
-          Schema.create(Schema.Type.STRING));
+      DaVinciRecordTransformerConfig recordTransformerConfig =
+          new DaVinciRecordTransformerConfig.Builder().setRecordTransformerFunction(TestStringRecordTransformer::new)
+              .setOutputValueClass(String.class)
+              .setOutputValueSchema(Schema.create(Schema.Type.STRING))
+              .build();
       clientConfig.setRecordTransformerConfig(recordTransformerConfig);
 
       DaVinciClient<Integer, Object> clientWithRecordTransformer =
@@ -172,15 +168,12 @@ public class DaVinciClientRecordTransformerTest {
         VeniceRouterWrapper.CLUSTER_DISCOVERY_D2_SERVICE_NAME,
         metricsRepository,
         backendConfig)) {
-      DaVinciRecordTransformerConfig recordTransformerConfig = new DaVinciRecordTransformerConfig(
-          (storeVersion, keySchema, inputValueSchema, outputValueSchema) -> new TestIntToStringRecordTransformer(
-              storeVersion,
-              keySchema,
-              inputValueSchema,
-              outputValueSchema,
-              true),
-          String.class,
-          Schema.create(Schema.Type.STRING));
+
+      DaVinciRecordTransformerConfig recordTransformerConfig = new DaVinciRecordTransformerConfig.Builder()
+          .setRecordTransformerFunction(TestIntToStringRecordTransformer::new)
+          .setOutputValueClass(String.class)
+          .setOutputValueSchema(Schema.create(Schema.Type.STRING))
+          .build();
       clientConfig.setRecordTransformerConfig(recordTransformerConfig);
 
       DaVinciClient<Integer, String> clientWithRecordTransformer =
@@ -224,13 +217,19 @@ public class DaVinciClientRecordTransformerTest {
       Schema myKeySchema = Schema.create(Schema.Type.INT);
       Schema myValueSchema = Schema.create(Schema.Type.STRING);
 
-      TestStringRecordTransformer recordTransformer =
-          new TestStringRecordTransformer(1, myKeySchema, myValueSchema, myValueSchema, true);
+      DaVinciRecordTransformerConfig dummyRecordTransformerConfig = new DaVinciRecordTransformerConfig.Builder()
+          .setRecordTransformerFunction((storeVersion, keySchema, inputValueSchema, outputValueSchema, config) -> null)
+          .build();
 
-      DaVinciRecordTransformerConfig recordTransformerConfig = new DaVinciRecordTransformerConfig(
-          (storeVersion, keySchema, inputValueSchema, outputValueSchema) -> recordTransformer,
-          String.class,
-          Schema.create(Schema.Type.STRING));
+      TestStringRecordTransformer recordTransformer =
+          new TestStringRecordTransformer(1, myKeySchema, myValueSchema, myValueSchema, dummyRecordTransformerConfig);
+
+      DaVinciRecordTransformerConfig recordTransformerConfig = new DaVinciRecordTransformerConfig.Builder()
+          .setRecordTransformerFunction(
+              (storeVersion, keySchema, inputValueSchema, outputValueSchema, config) -> recordTransformer)
+          .setOutputValueClass(String.class)
+          .setOutputValueSchema(Schema.create(Schema.Type.STRING))
+          .build();
       clientConfig.setRecordTransformerConfig(recordTransformerConfig);
 
       DaVinciClient<Integer, Object> clientWithRecordTransformer =
@@ -303,13 +302,19 @@ public class DaVinciClientRecordTransformerTest {
       Schema myKeySchema = Schema.create(Schema.Type.INT);
       Schema myValueSchema = Schema.create(Schema.Type.STRING);
 
-      TestStringRecordTransformer recordTransformer =
-          new TestStringRecordTransformer(1, myKeySchema, myValueSchema, myValueSchema, true);
+      DaVinciRecordTransformerConfig dummyRecordTransformerConfig = new DaVinciRecordTransformerConfig.Builder()
+          .setRecordTransformerFunction((storeVersion, keySchema, inputValueSchema, outputValueSchema, config) -> null)
+          .build();
 
-      DaVinciRecordTransformerConfig recordTransformerConfig = new DaVinciRecordTransformerConfig(
-          (storeVersion, keySchema, inputValueSchema, outputValueSchema) -> recordTransformer,
-          String.class,
-          Schema.create(Schema.Type.STRING));
+      TestStringRecordTransformer recordTransformer =
+          new TestStringRecordTransformer(1, myKeySchema, myValueSchema, myValueSchema, dummyRecordTransformerConfig);
+
+      DaVinciRecordTransformerConfig recordTransformerConfig = new DaVinciRecordTransformerConfig.Builder()
+          .setRecordTransformerFunction(
+              (storeVersion, keySchema, inputValueSchema, outputValueSchema, config) -> recordTransformer)
+          .setOutputValueClass(String.class)
+          .setOutputValueSchema(Schema.create(Schema.Type.STRING))
+          .build();
       clientConfig.setRecordTransformerConfig(recordTransformerConfig);
 
       DaVinciClient<Integer, String> clientWithRecordTransformer =
@@ -367,13 +372,21 @@ public class DaVinciClientRecordTransformerTest {
     Schema myKeySchema = Schema.create(Schema.Type.INT);
     Schema myValueSchema = Schema.create(Schema.Type.STRING);
 
-    TestStringRecordTransformer recordTransformer =
-        new TestStringRecordTransformer(1, myKeySchema, myValueSchema, myValueSchema, false);
+    DaVinciRecordTransformerConfig dummyRecordTransformerConfig = new DaVinciRecordTransformerConfig.Builder()
+        .setRecordTransformerFunction((storeVersion, keySchema, inputValueSchema, outputValueSchema, config) -> null)
+        .setStoreRecordsInDaVinci(false)
+        .build();
 
-    DaVinciRecordTransformerConfig recordTransformerConfig = new DaVinciRecordTransformerConfig(
-        (storeVersion, keySchema, inputValueSchema, outputValueSchema) -> recordTransformer,
-        String.class,
-        Schema.create(Schema.Type.STRING));
+    TestStringRecordTransformer recordTransformer =
+        new TestStringRecordTransformer(1, myKeySchema, myValueSchema, myValueSchema, dummyRecordTransformerConfig);
+
+    DaVinciRecordTransformerConfig recordTransformerConfig = new DaVinciRecordTransformerConfig.Builder()
+        .setRecordTransformerFunction(
+            (storeVersion, keySchema, inputValueSchema, outputValueSchema, config) -> recordTransformer)
+        .setOutputValueClass(String.class)
+        .setOutputValueSchema(Schema.create(Schema.Type.STRING))
+        .setStoreRecordsInDaVinci(false)
+        .build();
     clientConfig.setRecordTransformerConfig(recordTransformerConfig);
 
     try (CachingDaVinciClientFactory factory = new CachingDaVinciClientFactory(
@@ -416,13 +429,19 @@ public class DaVinciClientRecordTransformerTest {
     Schema myKeySchema = Schema.create(Schema.Type.INT);
     Schema myValueSchema = Schema.create(Schema.Type.STRING);
 
-    TestSkipResultRecordTransformer recordTransformer =
-        new TestSkipResultRecordTransformer(1, myKeySchema, myValueSchema, myValueSchema, true);
+    DaVinciRecordTransformerConfig dummyRecordTransformerConfig = new DaVinciRecordTransformerConfig.Builder()
+        .setRecordTransformerFunction((storeVersion, keySchema, inputValueSchema, outputValueSchema, config) -> null)
+        .build();
 
-    DaVinciRecordTransformerConfig recordTransformerConfig = new DaVinciRecordTransformerConfig(
-        (storeVersion, keySchema, inputValueSchema, outputValueSchema) -> recordTransformer,
-        String.class,
-        Schema.create(Schema.Type.STRING));
+    TestSkipResultRecordTransformer recordTransformer =
+        new TestSkipResultRecordTransformer(1, myKeySchema, myValueSchema, myValueSchema, dummyRecordTransformerConfig);
+
+    DaVinciRecordTransformerConfig recordTransformerConfig = new DaVinciRecordTransformerConfig.Builder()
+        .setRecordTransformerFunction(
+            (storeVersion, keySchema, inputValueSchema, outputValueSchema, config) -> recordTransformer)
+        .setOutputValueClass(String.class)
+        .setOutputValueSchema(Schema.create(Schema.Type.STRING))
+        .build();
     clientConfig.setRecordTransformerConfig(recordTransformerConfig);
 
     try (CachingDaVinciClientFactory factory = new CachingDaVinciClientFactory(
@@ -462,15 +481,11 @@ public class DaVinciClientRecordTransformerTest {
     VeniceProperties backendConfig = buildRecordTransformerBackendConfig(pushStatusStoreEnabled);
     MetricsRepository metricsRepository = new MetricsRepository();
 
-    DaVinciRecordTransformerConfig recordTransformerConfig = new DaVinciRecordTransformerConfig(
-        (storeVersion, keySchema, inputValueSchema, outputValueSchema) -> new TestUnchangedResultRecordTransformer(
-            storeVersion,
-            keySchema,
-            inputValueSchema,
-            outputValueSchema,
-            true),
-        String.class,
-        Schema.create(Schema.Type.STRING));
+    DaVinciRecordTransformerConfig recordTransformerConfig = new DaVinciRecordTransformerConfig.Builder()
+        .setRecordTransformerFunction(TestUnchangedResultRecordTransformer::new)
+        .setOutputValueClass(String.class)
+        .setOutputValueSchema(Schema.create(Schema.Type.STRING))
+        .build();
     clientConfig.setRecordTransformerConfig(recordTransformerConfig);
 
     try (CachingDaVinciClientFactory factory = new CachingDaVinciClientFactory(
@@ -514,13 +529,19 @@ public class DaVinciClientRecordTransformerTest {
     Schema myKeySchema = Schema.create(Schema.Type.INT);
     Schema myValueSchema = Schema.create(Schema.Type.STRING);
 
-    TestStringRecordTransformer recordTransformer =
-        new TestStringRecordTransformer(1, myKeySchema, myValueSchema, myValueSchema, true);
+    DaVinciRecordTransformerConfig dummyRecordTransformerConfig = new DaVinciRecordTransformerConfig.Builder()
+        .setRecordTransformerFunction((storeVersion, keySchema, inputValueSchema, outputValueSchema, config) -> null)
+        .build();
 
-    DaVinciRecordTransformerConfig recordTransformerConfig = new DaVinciRecordTransformerConfig(
-        (storeVersion, keySchema, inputValueSchema, outputValueSchema) -> recordTransformer,
-        String.class,
-        Schema.create(Schema.Type.STRING));
+    TestStringRecordTransformer recordTransformer =
+        new TestStringRecordTransformer(1, myKeySchema, myValueSchema, myValueSchema, dummyRecordTransformerConfig);
+
+    DaVinciRecordTransformerConfig recordTransformerConfig = new DaVinciRecordTransformerConfig.Builder()
+        .setRecordTransformerFunction(
+            (storeVersion, keySchema, inputValueSchema, outputValueSchema, config) -> recordTransformer)
+        .setOutputValueClass(String.class)
+        .setOutputValueSchema(Schema.create(Schema.Type.STRING))
+        .build();
     clientConfig.setRecordTransformerConfig(recordTransformerConfig);
 
     setUpStore(storeName, paramsConsumer, properties -> {}, pushStatusStoreEnabled);

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestIntToStringRecordTransformer.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestIntToStringRecordTransformer.java
@@ -1,6 +1,7 @@
 package com.linkedin.venice.endToEnd;
 
 import com.linkedin.davinci.client.DaVinciRecordTransformer;
+import com.linkedin.davinci.client.DaVinciRecordTransformerConfig;
 import com.linkedin.davinci.client.DaVinciRecordTransformerResult;
 import com.linkedin.venice.utils.lazy.Lazy;
 import java.io.IOException;
@@ -16,8 +17,8 @@ public class TestIntToStringRecordTransformer extends DaVinciRecordTransformer<I
       Schema keySchema,
       Schema inputValueSchema,
       Schema outputValueSchema,
-      boolean storeRecordsInDaVinci) {
-    super(storeVersion, keySchema, inputValueSchema, outputValueSchema, storeRecordsInDaVinci);
+      DaVinciRecordTransformerConfig recordTransformerConfig) {
+    super(storeVersion, keySchema, inputValueSchema, outputValueSchema, recordTransformerConfig);
   }
 
   @Override

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestSkipResultRecordTransformer.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestSkipResultRecordTransformer.java
@@ -1,6 +1,7 @@
 package com.linkedin.venice.endToEnd;
 
 import com.linkedin.davinci.client.DaVinciRecordTransformer;
+import com.linkedin.davinci.client.DaVinciRecordTransformerConfig;
 import com.linkedin.davinci.client.DaVinciRecordTransformerResult;
 import com.linkedin.venice.utils.lazy.Lazy;
 import java.io.IOException;
@@ -18,8 +19,8 @@ public class TestSkipResultRecordTransformer extends DaVinciRecordTransformer<In
       Schema keySchema,
       Schema inputValueSchema,
       Schema outputValueSchema,
-      boolean storeRecordsInDaVinci) {
-    super(storeVersion, keySchema, inputValueSchema, outputValueSchema, storeRecordsInDaVinci);
+      DaVinciRecordTransformerConfig recordTransformerConfig) {
+    super(storeVersion, keySchema, inputValueSchema, outputValueSchema, recordTransformerConfig);
   }
 
   @Override

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestStringRecordTransformer.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestStringRecordTransformer.java
@@ -1,6 +1,7 @@
 package com.linkedin.venice.endToEnd;
 
 import com.linkedin.davinci.client.DaVinciRecordTransformer;
+import com.linkedin.davinci.client.DaVinciRecordTransformerConfig;
 import com.linkedin.davinci.client.DaVinciRecordTransformerResult;
 import com.linkedin.venice.utils.lazy.Lazy;
 import java.io.IOException;
@@ -19,8 +20,8 @@ public class TestStringRecordTransformer extends DaVinciRecordTransformer<Intege
       Schema keySchema,
       Schema inputValueSchema,
       Schema outputValueSchema,
-      boolean storeRecordsInDaVinci) {
-    super(storeVersion, keySchema, inputValueSchema, outputValueSchema, storeRecordsInDaVinci);
+      DaVinciRecordTransformerConfig recordTransformerConfig) {
+    super(storeVersion, keySchema, inputValueSchema, outputValueSchema, recordTransformerConfig);
   }
 
   @Override

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestUnchangedResultRecordTransformer.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestUnchangedResultRecordTransformer.java
@@ -1,6 +1,7 @@
 package com.linkedin.venice.endToEnd;
 
 import com.linkedin.davinci.client.DaVinciRecordTransformer;
+import com.linkedin.davinci.client.DaVinciRecordTransformerConfig;
 import com.linkedin.davinci.client.DaVinciRecordTransformerResult;
 import com.linkedin.venice.utils.lazy.Lazy;
 import java.io.IOException;
@@ -14,8 +15,8 @@ public class TestUnchangedResultRecordTransformer extends DaVinciRecordTransform
       Schema keySchema,
       Schema inputValueSchema,
       Schema outputValueSchema,
-      boolean storeRecordsInDaVinci) {
-    super(storeVersion, keySchema, inputValueSchema, outputValueSchema, storeRecordsInDaVinci);
+      DaVinciRecordTransformerConfig recordTransformerConfig) {
+    super(storeVersion, keySchema, inputValueSchema, outputValueSchema, recordTransformerConfig);
   }
 
   @Override


### PR DESCRIPTION
<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat], [protocol]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## [dvc][doc] Refactor DaVinciRecordTransformerConfig to use Builder pattern and update DVRT docs
<!--
Describe
- What changes to make and why you are making these changes.
- How are you going to achieve your goal.
- Describe what testings you have done, for example, performance testing etc.

If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->
1.  Previously, the configs for `DaVinciRecordTransformerConfig` were set by passing in all of the values into its constructor. This means that anytime we wanted to add another config, it would be a breaking change. To resolve this, I refactored `DaVinciRecordTransformerConfig` to use a Builder pattern.
2. Fixed a bug where if a user set `storeRecordsInDaVinci`, it would always bootstrap from VT and ignore the on-disk state. This isn't deseriable behavior. To fix this, I introduced a new config called `alwaysBootstrapFromVersionTopic`. Although most users won't use this, this can serve use-cases where the user is only storing their records in-memory. It is more preferable for users to at least have `storeRecordsInDaVinci` set to true so they can bootstrap from disk and utilize blob transfer.
3. If a user doesn't intend on modifying the schema of their records, the user won't need to pass in`outputValueSchema` and `outputValueClass` to the `DaVinciRecordTransformerConfig` anymore. This can serve use cases where the user just wants to redirect their records to an alternative storage such as DuckDB.
4. Updated the DVRT docs to include the latest changes.

## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
Added unit and integration tests

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [ ] No. You can skip the rest of this section.
- [X] Yes. Make sure to explain your proposed changes and call out the behavior change.

This PR modifies how to instantiate a DVRT, but since this isn't in-use at the moment it doesn't break anyone's changes.
