### PR TITLE
[da-vinci][server] Fixed the race condition during BlobDB rolling out/back (#1500)

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/ingestion/main/MainIngestionStorageMetadataService.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/ingestion/main/MainIngestionStorageMetadataService.java
@@ -76,9 +76,10 @@ public class MainIngestionStorageMetadataService extends AbstractVeniceService i
   }
 
   @Override
-  public void computeStoreVersionState(String topicName, Function<StoreVersionState, StoreVersionState> mapFunction)
-      throws VeniceException {
-    topicStoreVersionStateMap.compute(topicName, (key, previousStoreVersionState) -> {
+  public StoreVersionState computeStoreVersionState(
+      String topicName,
+      Function<StoreVersionState, StoreVersionState> mapFunction) throws VeniceException {
+    return topicStoreVersionStateMap.compute(topicName, (key, previousStoreVersionState) -> {
       StoreVersionState newStoreVersionState = mapFunction.apply(previousStoreVersionState);
       storeVersionStateSyncer.accept(topicName, newStoreVersionState);
 

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
@@ -2935,47 +2935,72 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
     } else {
       sorted = startOfPush.sorted;
     }
-    beginBatchWrite(partition, sorted, partitionConsumptionState);
-    partitionConsumptionState.setStartOfPushTimestamp(startOfPushKME.producerMetadata.messageTimestamp);
+
+    StoreVersionState persistedStoreVersionState =
+        storageMetadataService.computeStoreVersionState(kafkaVersionTopic, previousStoreVersionState -> {
+          if (previousStoreVersionState == null) {
+            // No other partition of the same topic has started yet, let's initialize the StoreVersionState
+            StoreVersionState newStoreVersionState = new StoreVersionState();
+            newStoreVersionState.sorted = sorted;
+            newStoreVersionState.chunked = startOfPush.chunked;
+            newStoreVersionState.compressionStrategy = startOfPush.compressionStrategy;
+            newStoreVersionState.compressionDictionary = startOfPush.compressionDictionary;
+            if (startOfPush.compressionStrategy == CompressionStrategy.ZSTD_WITH_DICT.getValue()) {
+              if (startOfPush.compressionDictionary == null) {
+                throw new VeniceException(
+                    "compression Dictionary should not be empty if CompressionStrategy is ZSTD_WITH_DICT");
+              }
+            }
+            newStoreVersionState.batchConflictResolutionPolicy = startOfPush.timestampPolicy;
+            newStoreVersionState.startOfPushTimestamp = startOfPushKME.producerMetadata.messageTimestamp;
+
+            LOGGER.info(
+                "Persisted {} for the first time following a SOP for topic {} with sorted: {}.",
+                StoreVersionState.class.getSimpleName(),
+                kafkaVersionTopic,
+                newStoreVersionState.sorted);
+            return newStoreVersionState;
+          } else if (previousStoreVersionState.chunked != startOfPush.chunked) {
+            // Something very wrong is going on ): ...
+            throw new VeniceException(
+                "Unexpected: received multiple " + ControlMessageType.START_OF_PUSH.name()
+                    + " control messages with inconsistent 'chunked' fields within the same topic!");
+          } else if (previousStoreVersionState.sorted != sorted) {
+            if (!isHybridMode()) {
+              // Something very wrong is going on ): ...
+              throw new VeniceException(
+                  "Unexpected: received multiple " + ControlMessageType.START_OF_PUSH.name()
+                      + " control messages with inconsistent 'sorted' fields within the same topic!"
+                      + " And persisted sorted value: " + previousStoreVersionState.sorted
+                      + " is different from the current one: " + sorted);
+            }
+            /**
+             * Because of the blob-db integration, `SIT` will forcibly set `sorted` to `false` for hybrid stores (check the
+             * above javadoc) and inconsistent `sorted` can happen during the rolling out/rolling back blob-db features.
+             * Here is one case how it can happen during the rolling out of blob-db:
+             * 1. P1 processes `SOP` with `sorted=true` and persist it in `StoreVersionState`.
+             * 2. P2 hasn't started processing `SOP` yet.
+             * 3. Restart the cluster and roll out blob-db feature.
+             * 4. when P2 processes `SOP` with `sorted=true`, it will forcibly set `sorted=false`, and it will be different
+             *    from the previously persisted `StoreVersionState`.
+             * 5. This is fine as long as we just follow the previously persisted `StoreVersionState`.
+             * 6. Here are the reasons why step 5 is true:
+             *    a. If the input for a given partition is truly sorted, it can always be ingested as unsorted data.
+             *    b. If the input for a given partition is not sorted, the underlying `SSTFileWriter` will throw exception
+             *       when we try to ingest it as sorted data.
+             */
+            LOGGER.warn(
+                "Store version state for topic {} has already been initialized with a different value of 'sorted': {}",
+                kafkaVersionTopic,
+                previousStoreVersionState.sorted);
+          }
+          // No need to mutate it, so we return it as is
+          return previousStoreVersionState;
+        });
 
     ingestionNotificationDispatcher.reportStarted(partitionConsumptionState);
-    storageMetadataService.computeStoreVersionState(kafkaVersionTopic, previousStoreVersionState -> {
-      if (previousStoreVersionState == null) {
-        // No other partition of the same topic has started yet, let's initialize the StoreVersionState
-        StoreVersionState newStoreVersionState = new StoreVersionState();
-        newStoreVersionState.sorted = sorted;
-        newStoreVersionState.chunked = startOfPush.chunked;
-        newStoreVersionState.compressionStrategy = startOfPush.compressionStrategy;
-        newStoreVersionState.compressionDictionary = startOfPush.compressionDictionary;
-        if (startOfPush.compressionStrategy == CompressionStrategy.ZSTD_WITH_DICT.getValue()) {
-          if (startOfPush.compressionDictionary == null) {
-            throw new VeniceException(
-                "compression Dictionary should not be empty if CompressionStrategy is ZSTD_WITH_DICT");
-          }
-        }
-        newStoreVersionState.batchConflictResolutionPolicy = startOfPush.timestampPolicy;
-        newStoreVersionState.startOfPushTimestamp = startOfPushKME.producerMetadata.messageTimestamp;
-
-        LOGGER.info(
-            "Persisted {} for the first time following a SOP for topic {}.",
-            StoreVersionState.class.getSimpleName(),
-            kafkaVersionTopic);
-        return newStoreVersionState;
-      } else if (previousStoreVersionState.sorted != sorted) {
-        // Something very wrong is going on ): ...
-        throw new VeniceException(
-            "Unexpected: received multiple " + ControlMessageType.START_OF_PUSH.name()
-                + " control messages with inconsistent 'sorted' fields within the same topic!");
-      } else if (previousStoreVersionState.chunked != startOfPush.chunked) {
-        // Something very wrong is going on ): ...
-        throw new VeniceException(
-            "Unexpected: received multiple " + ControlMessageType.START_OF_PUSH.name()
-                + " control messages with inconsistent 'chunked' fields within the same topic!");
-      } else {
-        // No need to mutate it, so we return it as is
-        return previousStoreVersionState;
-      }
-    });
+    beginBatchWrite(partition, persistedStoreVersionState.sorted, partitionConsumptionState);
+    partitionConsumptionState.setStartOfPushTimestamp(startOfPushKME.producerMetadata.messageTimestamp);
   }
 
   protected void processEndOfPush(

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/storage/StorageEngineMetadataService.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/storage/StorageEngineMetadataService.java
@@ -62,13 +62,15 @@ public class StorageEngineMetadataService extends AbstractVeniceService implemen
   }
 
   @Override
-  public void computeStoreVersionState(String topicName, Function<StoreVersionState, StoreVersionState> mapFunction)
-      throws VeniceException {
+  public StoreVersionState computeStoreVersionState(
+      String topicName,
+      Function<StoreVersionState, StoreVersionState> mapFunction) throws VeniceException {
     AbstractStorageEngine engine = getStorageEngineOrThrow(topicName);
     synchronized (engine) {
       StoreVersionState previousSVS = engine.getStoreVersionState();
       StoreVersionState newSVS = mapFunction.apply(previousSVS);
       engine.putStoreVersionState(newSVS);
+      return newSVS;
     }
   }
 

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/storage/StorageMetadataService.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/storage/StorageMetadataService.java
@@ -11,8 +11,9 @@ import java.util.function.Function;
  * This is a superset of the OffsetManager APIs, which also provide functions for storing store-version level state.
  */
 public interface StorageMetadataService extends OffsetManager {
-  void computeStoreVersionState(String topicName, Function<StoreVersionState, StoreVersionState> mapFunction)
-      throws VeniceException;
+  StoreVersionState computeStoreVersionState(
+      String topicName,
+      Function<StoreVersionState, StoreVersionState> mapFunction) throws VeniceException;
 
   /**
    * This will clear all metadata, including store-version state and partition states, tied to {@param topicName}.

--- a/internal/venice-test-common/src/main/java/com/linkedin/venice/offsets/DeepCopyStorageMetadataService.java
+++ b/internal/venice-test-common/src/main/java/com/linkedin/venice/offsets/DeepCopyStorageMetadataService.java
@@ -28,9 +28,10 @@ public class DeepCopyStorageMetadataService extends DeepCopyOffsetManager implem
   }
 
   @Override
-  public void computeStoreVersionState(String topicName, Function<StoreVersionState, StoreVersionState> mapFunction)
-      throws VeniceException {
-    delegateStorageMetadataService.computeStoreVersionState(topicName, previousStoreVersionState -> {
+  public StoreVersionState computeStoreVersionState(
+      String topicName,
+      Function<StoreVersionState, StoreVersionState> mapFunction) throws VeniceException {
+    return delegateStorageMetadataService.computeStoreVersionState(topicName, previousStoreVersionState -> {
       StoreVersionState newSVS = mapFunction.apply(
           previousStoreVersionState == null
               ? null

--- a/internal/venice-test-common/src/main/java/com/linkedin/venice/offsets/InMemoryStorageMetadataService.java
+++ b/internal/venice-test-common/src/main/java/com/linkedin/venice/offsets/InMemoryStorageMetadataService.java
@@ -19,10 +19,12 @@ public class InMemoryStorageMetadataService extends InMemoryOffsetManager implem
   private final ConcurrentMap<String, StoreVersionState> topicToStoreVersionStateMap = new ConcurrentHashMap<>();
 
   @Override
-  public void computeStoreVersionState(String topicName, Function<StoreVersionState, StoreVersionState> mapFunction)
-      throws VeniceException {
+  public StoreVersionState computeStoreVersionState(
+      String topicName,
+      Function<StoreVersionState, StoreVersionState> mapFunction) throws VeniceException {
     LOGGER.info("InMemoryStorageMetadataService.compute(StoreVersionState) called for topicName: {}", topicName);
-    topicToStoreVersionStateMap.compute(topicName, (s, storeVersionState) -> mapFunction.apply(storeVersionState));
+    return topicToStoreVersionStateMap
+        .compute(topicName, (s, storeVersionState) -> mapFunction.apply(storeVersionState));
   }
 
   @Override

--- a/internal/venice-test-common/src/main/java/com/linkedin/venice/utils/DataProviderUtils.java
+++ b/internal/venice-test-common/src/main/java/com/linkedin/venice/utils/DataProviderUtils.java
@@ -25,6 +25,7 @@ import org.testng.collections.Lists;
 public class DataProviderUtils {
   public static final Object[] BOOLEAN = { false, true };
   public static final Object[] BOOLEAN_FALSE = { false };
+  public static final Object[] OPTIONAL_BOOLEAN = { false, true, null };
   public static final Object[] COMPRESSION_STRATEGIES = { NO_OP, GZIP, ZSTD_WITH_DICT };
   public static final Object[] PARTITION_COUNTS = { 1, 2, 3, 4, 8, 10, 16, 19, 92, 128 };
 
@@ -47,6 +48,11 @@ public class DataProviderUtils {
   @DataProvider(name = "Two-True-and-False")
   public static Object[][] twoBoolean() {
     return allPermutationGenerator(BOOLEAN, BOOLEAN);
+  }
+
+  @DataProvider(name = "Boolean-and-Optional-Boolean")
+  public static Object[][] booleanAndOptionalBoolean() {
+    return allPermutationGenerator(BOOLEAN, OPTIONAL_BOOLEAN);
   }
 
   @DataProvider(name = "Three-True-and-False")


### PR DESCRIPTION
* [da-vinci][server] Fixed the race condition during BlobDB rolling out/back

Because of the blob-db integration, `SIT` will forcibly set `sorted` to `false` for hybrid stores and inconsistent `sorted` can happen during the rolling out/rolling back blob-db features. Here is one case how it can happen during the rolling out of blob-db:
1. P1 processes `SOP` with `sorted=true` and persist it in `StoreVersionState`.
2. P2 hasn't started processing `SOP` yet.
3. Restart the cluster and roll out blob-db feature.
4. when P2 processes `SOP` with `sorted=true`, it will forcibly set `sorted=false`, and it will be different from the previously persisted `StoreVersionState`.
5. This is fine as long as we just follow the previously persisted `StoreVersionState`.
6. Here are the reasons why step 5 is true: a. If the input for a given partition is truly sorted, it can always be ingested as unsorted data. b. If the input for a given partition is not sorted, the underlying `SSTFileWriter` will throw exception when we try to ingest it as sorted data.


<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat], [protocol]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

<!--
Describe
- What changes to make and why you are making these changes.
- How are you going to achieve your goal.
- Describe what testings you have done, for example, performance testing etc.

If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->


## How was this PR tested?
CI
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.