### PR TITLE
[da-vinci] Bug fix for peer discovery in DVC with multi-stores

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/blobtransfer/BlobTransferUtil.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/blobtransfer/BlobTransferUtil.java
@@ -20,40 +20,14 @@ public class BlobTransferUtil {
 
   /**
    * Get a P2P blob transfer manager for DaVinci Client and start it.
-   * @param p2pTransferPort, the port used by the P2P transfer server and client
+   * @param p2pTransferServerPort, the port used by the P2P transfer server
+   * @param p2pTransferClientPort, the port used by the P2P transfer client
    * @param baseDir, the base directory of the underlying storage
    * @param clientConfig, the client config to start up a transport client
    * @param storageMetadataService, the storage metadata service
    * @return the blob transfer manager
    * @throws Exception
    */
-  public static BlobTransferManager<Void> getP2PBlobTransferManagerForDVCAndStart(
-      int p2pTransferPort,
-      String baseDir,
-      ClientConfig clientConfig,
-      StorageMetadataService storageMetadataService,
-      ReadOnlyStoreRepository readOnlyStoreRepository,
-      StorageEngineRepository storageEngineRepository,
-      int maxConcurrentSnapshotUser,
-      int snapshotRetentionTimeInMin,
-      int blobTransferMaxTimeoutInMin,
-      AggVersionedBlobTransferStats aggVersionedBlobTransferStats,
-      BlobTransferUtils.BlobTransferTableFormat transferSnapshotTableFormat) {
-    return getP2PBlobTransferManagerForDVCAndStart(
-        p2pTransferPort,
-        p2pTransferPort,
-        baseDir,
-        clientConfig,
-        storageMetadataService,
-        readOnlyStoreRepository,
-        storageEngineRepository,
-        maxConcurrentSnapshotUser,
-        snapshotRetentionTimeInMin,
-        blobTransferMaxTimeoutInMin,
-        aggVersionedBlobTransferStats,
-        transferSnapshotTableFormat);
-  }
-
   public static BlobTransferManager<Void> getP2PBlobTransferManagerForDVCAndStart(
       int p2pTransferServerPort,
       int p2pTransferClientPort,

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/blobtransfer/BlobTransferUtil.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/blobtransfer/BlobTransferUtil.java
@@ -1,7 +1,5 @@
 package com.linkedin.davinci.blobtransfer;
 
-import static com.linkedin.venice.client.store.ClientFactory.getTransportClient;
-
 import com.linkedin.davinci.blobtransfer.client.NettyFileTransferClient;
 import com.linkedin.davinci.blobtransfer.server.P2PBlobTransferService;
 import com.linkedin.davinci.stats.AggVersionedBlobTransferStats;
@@ -9,8 +7,6 @@ import com.linkedin.davinci.storage.StorageEngineRepository;
 import com.linkedin.davinci.storage.StorageMetadataService;
 import com.linkedin.venice.blobtransfer.DaVinciBlobFinder;
 import com.linkedin.venice.blobtransfer.ServerBlobFinder;
-import com.linkedin.venice.client.store.AbstractAvroStoreClient;
-import com.linkedin.venice.client.store.AvroGenericStoreClientImpl;
 import com.linkedin.venice.client.store.ClientConfig;
 import com.linkedin.venice.helix.HelixCustomizedViewOfflinePushRepository;
 import com.linkedin.venice.meta.ReadOnlyStoreRepository;
@@ -79,12 +75,10 @@ public class BlobTransferUtil {
           maxConcurrentSnapshotUser,
           snapshotRetentionTimeInMin,
           transferSnapshotTableFormat);
-      AbstractAvroStoreClient storeClient =
-          new AvroGenericStoreClientImpl<>(getTransportClient(clientConfig), false, clientConfig);
       BlobTransferManager<Void> manager = new NettyP2PBlobTransferManager(
           new P2PBlobTransferService(p2pTransferServerPort, baseDir, blobTransferMaxTimeoutInMin, blobSnapshotManager),
           new NettyFileTransferClient(p2pTransferClientPort, baseDir, storageMetadataService),
-          new DaVinciBlobFinder(storeClient),
+          new DaVinciBlobFinder(clientConfig),
           baseDir,
           aggVersionedBlobTransferStats);
       manager.start();

--- a/clients/venice-thin-client/src/main/java/com/linkedin/venice/client/store/ClientFactory.java
+++ b/clients/venice-thin-client/src/main/java/com/linkedin/venice/client/store/ClientFactory.java
@@ -22,7 +22,7 @@ public class ClientFactory {
   private static Function<ClientConfig, TransportClient> configToTransportClientProviderForTests = null;
 
   // Visible for testing
-  static void setUnitTestMode() {
+  public static void setUnitTestMode() {
     unitTestMode = true;
   }
 
@@ -33,7 +33,7 @@ public class ClientFactory {
 
   // Allow for overriding with mock D2Client for unit tests. The caller must release the object to prevent side-effects
   // VisibleForTesting
-  static void setTransportClientProvider(Function<ClientConfig, TransportClient> transportClientProvider) {
+  public static void setTransportClientProvider(Function<ClientConfig, TransportClient> transportClientProvider) {
     if (!unitTestMode) {
       throw new VeniceUnsupportedOperationException("setTransportClientProvider in non-unit-test-mode");
     }

--- a/internal/venice-common/src/main/java/com/linkedin/venice/blobtransfer/DaVinciBlobFinder.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/blobtransfer/DaVinciBlobFinder.java
@@ -48,15 +48,14 @@ public class DaVinciBlobFinder implements BlobFinder {
    * @return the store client
    */
   AbstractAvroStoreClient getStoreClient(String storeName) {
-    if (!storeToClientMap.containsKey(storeName)) {
+    return storeToClientMap.computeIfAbsent(storeName, k -> {
       // update the config with respective store name
       ClientConfig storeClientConfig = ClientConfig.cloneConfig(clientConfig).setStoreName(storeName);
       AbstractAvroStoreClient storeLevelClient =
           new AvroGenericStoreClientImpl<>(getTransportClient(storeClientConfig), false, storeClientConfig);
-      storeToClientMap.put(storeName, storeLevelClient);
       LOGGER.info("Created store client for store: {}", storeName);
-    }
-    return storeToClientMap.get(storeName);
+      return storeLevelClient;
+    });
   }
 
   @Override

--- a/internal/venice-common/src/main/java/com/linkedin/venice/blobtransfer/DaVinciBlobFinder.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/blobtransfer/DaVinciBlobFinder.java
@@ -52,6 +52,7 @@ public class DaVinciBlobFinder implements BlobFinder {
       ClientConfig storeClientConfig = ClientConfig.cloneConfig(clientConfig).setStoreName(storeName);
       AbstractAvroStoreClient storeLevelClient =
           new AvroGenericStoreClientImpl<>(getTransportClient(storeClientConfig), false, storeClientConfig);
+      storeLevelClient.start();
       LOGGER.info("Started store client for store: {}", storeName);
       return storeLevelClient;
     });

--- a/internal/venice-common/src/main/java/com/linkedin/venice/blobtransfer/DaVinciBlobFinder.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/blobtransfer/DaVinciBlobFinder.java
@@ -46,7 +46,7 @@ public class DaVinciBlobFinder implements BlobFinder {
    * @param storeName
    * @return the store client
    */
-  AbstractAvroStoreClient startStoreClient(String storeName) {
+  AbstractAvroStoreClient getStoreClient(String storeName) {
     return storeToClientMap.computeIfAbsent(storeName, k -> {
       // update the config with respective store name
       ClientConfig storeClientConfig = ClientConfig.cloneConfig(clientConfig).setStoreName(storeName);
@@ -60,7 +60,7 @@ public class DaVinciBlobFinder implements BlobFinder {
 
   @Override
   public BlobPeersDiscoveryResponse discoverBlobPeers(String storeName, int version, int partition) {
-    AbstractAvroStoreClient storeClient = startStoreClient(storeName);
+    AbstractAvroStoreClient storeClient = getStoreClient(storeName);
 
     String uri = buildUriForBlobDiscovery(storeName, version, partition);
     CompletableFuture<BlobPeersDiscoveryResponse> futureResponse = CompletableFuture.supplyAsync(() -> {

--- a/internal/venice-common/src/test/java/com/linkedin/venice/blobtransfer/DaVinciBlobFinderTest.java
+++ b/internal/venice-common/src/test/java/com/linkedin/venice/blobtransfer/DaVinciBlobFinderTest.java
@@ -50,7 +50,7 @@ public class DaVinciBlobFinderTest {
 
   @Test
   public void testDiscoverBlobPeers_Success() {
-    Mockito.doReturn(storeClient).when(daVinciBlobFinder).getStoreClient(storeName);
+    Mockito.doReturn(storeClient).when(daVinciBlobFinder).startStoreClient(storeName);
 
     String responseBodyJson =
         "{\"error\":false,\"errorMessage\":\"\",\"discoveryResult\":[\"host1\",\"host2\",\"host3\"]}";
@@ -68,7 +68,7 @@ public class DaVinciBlobFinderTest {
 
   @Test
   public void testDiscoverBlobPeers_CallsTransportClientWithCorrectURI() {
-    Mockito.doReturn(storeClient).when(daVinciBlobFinder).getStoreClient(storeName);
+    Mockito.doReturn(storeClient).when(daVinciBlobFinder).startStoreClient(storeName);
     String responseBodyJson =
         "{\"error\":false,\"errorMessage\":\"\",\"discoveryResult\":[\"host1\",\"host2\",\"host3\"]}";
     byte[] responseBody = responseBodyJson.getBytes(StandardCharsets.UTF_8);
@@ -90,7 +90,7 @@ public class DaVinciBlobFinderTest {
 
   @Test
   public void testDiscoverBlobPeers_ContentDeserializationError() throws Exception {
-    Mockito.doReturn(storeClient).when(daVinciBlobFinder).getStoreClient(storeName);
+    Mockito.doReturn(storeClient).when(daVinciBlobFinder).startStoreClient(storeName);
 
     String responseBodyJson = "{\"error\":true,\"errorMessage\":\"some error\",\"discoveryResult\":[]}";
     byte[] responseBody = responseBodyJson.getBytes(StandardCharsets.UTF_8);
@@ -112,7 +112,7 @@ public class DaVinciBlobFinderTest {
 
   @Test
   public void testDiscoverBlobPeers_ClientWithIncorrectUri() {
-    Mockito.doReturn(storeClient).when(daVinciBlobFinder).getStoreClient(storeName);
+    Mockito.doReturn(storeClient).when(daVinciBlobFinder).startStoreClient(storeName);
 
     CompletableFuture<byte[]> futureResponse = new CompletableFuture<>();
     futureResponse.completeExceptionally(new RuntimeException("Test Exception"));
@@ -145,13 +145,13 @@ public class DaVinciBlobFinderTest {
     ClientFactory.setTransportClientProvider(clientConfigTransportClientFunction);
 
     // ClientConfig is initialized with storeName
-    AbstractAvroStoreClient storeClient = daVinciBlobFinder.getStoreClient(storeName);
+    AbstractAvroStoreClient storeClient = daVinciBlobFinder.startStoreClient(storeName);
     Assert.assertNotNull(storeClient);
     Assert.assertEquals(storeClient.getStoreName(), storeName);
 
     // Even if the daVinciBlobFinder is initialized at the beginning with "storeName", the getStoreClient
     // method should be able to return a store client for "storeName2"
-    AbstractAvroStoreClient storeClient2 = daVinciBlobFinder.getStoreClient("storeName2");
+    AbstractAvroStoreClient storeClient2 = daVinciBlobFinder.startStoreClient("storeName2");
     Assert.assertNotNull(storeClient2);
     Assert.assertEquals(storeClient2.getStoreName(), "storeName2");
 

--- a/internal/venice-common/src/test/java/com/linkedin/venice/blobtransfer/DaVinciBlobFinderTest.java
+++ b/internal/venice-common/src/test/java/com/linkedin/venice/blobtransfer/DaVinciBlobFinderTest.java
@@ -11,6 +11,7 @@ import static org.testng.Assert.assertTrue;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.linkedin.venice.client.store.AbstractAvroStoreClient;
+import com.linkedin.venice.client.store.ClientConfig;
 import com.linkedin.venice.client.store.transport.TransportClientResponse;
 import com.linkedin.venice.utils.ObjectMapperFactory;
 import java.io.IOException;
@@ -20,6 +21,7 @@ import java.util.concurrent.CompletableFuture;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
 import org.testng.Assert;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
@@ -35,8 +37,12 @@ public class DaVinciBlobFinderTest {
 
   @BeforeMethod
   public void setUp() {
+    ClientConfig clientConfig = ClientConfig.defaultGenericClientConfig(storeName);
+
     storeClient = mock(AbstractAvroStoreClient.class);
-    daVinciBlobFinder = new DaVinciBlobFinder(storeClient);
+    daVinciBlobFinder = spy(new DaVinciBlobFinder(clientConfig));
+
+    Mockito.doReturn(storeClient).when(daVinciBlobFinder).getStoreClient(storeName);
   }
 
   @Test

--- a/internal/venice-common/src/test/java/com/linkedin/venice/blobtransfer/DaVinciBlobFinderTest.java
+++ b/internal/venice-common/src/test/java/com/linkedin/venice/blobtransfer/DaVinciBlobFinderTest.java
@@ -127,7 +127,7 @@ public class DaVinciBlobFinderTest {
   }
 
   @Test
-  public void testGetStoreClient() {
+  public void testGetStoreClient() throws IOException {
     // set up the transport client provider used to initialize the store client
     TransportClient transportClient1 = mock(TransportClient.class);
     TransportClient transportClient2 = mock(TransportClient.class);
@@ -154,5 +154,10 @@ public class DaVinciBlobFinderTest {
     AbstractAvroStoreClient storeClient2 = daVinciBlobFinder.getStoreClient("storeName2");
     Assert.assertNotNull(storeClient2);
     Assert.assertEquals(storeClient2.getStoreName(), "storeName2");
+
+    daVinciBlobFinder.close();
+    // verify that the store client is closed
+    verify(transportClient1).close();
+    verify(transportClient2).close();
   }
 }

--- a/internal/venice-common/src/test/java/com/linkedin/venice/blobtransfer/DaVinciBlobFinderTest.java
+++ b/internal/venice-common/src/test/java/com/linkedin/venice/blobtransfer/DaVinciBlobFinderTest.java
@@ -50,7 +50,7 @@ public class DaVinciBlobFinderTest {
 
   @Test
   public void testDiscoverBlobPeers_Success() {
-    Mockito.doReturn(storeClient).when(daVinciBlobFinder).startStoreClient(storeName);
+    Mockito.doReturn(storeClient).when(daVinciBlobFinder).getStoreClient(storeName);
 
     String responseBodyJson =
         "{\"error\":false,\"errorMessage\":\"\",\"discoveryResult\":[\"host1\",\"host2\",\"host3\"]}";
@@ -68,7 +68,7 @@ public class DaVinciBlobFinderTest {
 
   @Test
   public void testDiscoverBlobPeers_CallsTransportClientWithCorrectURI() {
-    Mockito.doReturn(storeClient).when(daVinciBlobFinder).startStoreClient(storeName);
+    Mockito.doReturn(storeClient).when(daVinciBlobFinder).getStoreClient(storeName);
     String responseBodyJson =
         "{\"error\":false,\"errorMessage\":\"\",\"discoveryResult\":[\"host1\",\"host2\",\"host3\"]}";
     byte[] responseBody = responseBodyJson.getBytes(StandardCharsets.UTF_8);
@@ -90,7 +90,7 @@ public class DaVinciBlobFinderTest {
 
   @Test
   public void testDiscoverBlobPeers_ContentDeserializationError() throws Exception {
-    Mockito.doReturn(storeClient).when(daVinciBlobFinder).startStoreClient(storeName);
+    Mockito.doReturn(storeClient).when(daVinciBlobFinder).getStoreClient(storeName);
 
     String responseBodyJson = "{\"error\":true,\"errorMessage\":\"some error\",\"discoveryResult\":[]}";
     byte[] responseBody = responseBodyJson.getBytes(StandardCharsets.UTF_8);
@@ -112,7 +112,7 @@ public class DaVinciBlobFinderTest {
 
   @Test
   public void testDiscoverBlobPeers_ClientWithIncorrectUri() {
-    Mockito.doReturn(storeClient).when(daVinciBlobFinder).startStoreClient(storeName);
+    Mockito.doReturn(storeClient).when(daVinciBlobFinder).getStoreClient(storeName);
 
     CompletableFuture<byte[]> futureResponse = new CompletableFuture<>();
     futureResponse.completeExceptionally(new RuntimeException("Test Exception"));
@@ -145,13 +145,13 @@ public class DaVinciBlobFinderTest {
     ClientFactory.setTransportClientProvider(clientConfigTransportClientFunction);
 
     // ClientConfig is initialized with storeName
-    AbstractAvroStoreClient storeClient = daVinciBlobFinder.startStoreClient(storeName);
+    AbstractAvroStoreClient storeClient = daVinciBlobFinder.getStoreClient(storeName);
     Assert.assertNotNull(storeClient);
     Assert.assertEquals(storeClient.getStoreName(), storeName);
 
     // Even if the daVinciBlobFinder is initialized at the beginning with "storeName", the getStoreClient
     // method should be able to return a store client for "storeName2"
-    AbstractAvroStoreClient storeClient2 = daVinciBlobFinder.startStoreClient("storeName2");
+    AbstractAvroStoreClient storeClient2 = daVinciBlobFinder.getStoreClient("storeName2");
     Assert.assertNotNull(storeClient2);
     Assert.assertEquals(storeClient2.getStoreName(), "storeName2");
 

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/DaVinciClientTest.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/DaVinciClientTest.java
@@ -1209,6 +1209,13 @@ public class DaVinciClientTest {
         String snapshotPath = RocksDBUtils.composeSnapshotDir(dvcPath1 + "/rocksdb", storeName + "_v1", i);
         Assert.assertTrue(Files.exists(Paths.get(snapshotPath)));
       }
+
+      for (int i = 0; i < 3; i++) {
+        String partitionPath2 = RocksDBUtils.composePartitionDbDir(dvcPath2 + "/rocksdb", storeName + "_v1", i);
+        Assert.assertTrue(Files.exists(Paths.get(partitionPath2)));
+        String snapshotPath2 = RocksDBUtils.composeSnapshotDir(dvcPath2 + "/rocksdb", storeName + "_v1", i);
+        Assert.assertFalse(Files.exists(Paths.get(snapshotPath2)));
+      }
     }
   }
 


### PR DESCRIPTION
<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat], [protocol]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## [da-vinci] Bug fix for peer discovery in DVC with multi-stores

When testing blob transfer on DVC hosts with multiple stores, it was found that some stores encountered errors while finding peers. The error message is as follows:
`2025/01/30 18:41:32.990 ERROR [DaVinciBlobFinder] [ForkJoinPool.commonPool-worker-58] [flip-war] [] Error finding DVC peers for blob transfer in store: FeedEngagementCounts4dByRootObjectUrn, version: 191, partition: 198
java.lang.IllegalArgumentException: argument "src" is null
	at com.fasterxml.jackson.databind.ObjectMapper._assertNotNull(ObjectMapper.java:5072) ~[com.fasterxml.jackson.core.jackson-databind-2.18.0.jar:2.18.0]
	at com.fasterxml.jackson.databind.ObjectMapper.readValue(ObjectMapper.java:3920) ~[com.fasterxml.jackson.core.jackson-databind-2.18.0.jar:2.18.0]
	at com.linkedin.venice.blobtransfer.DaVinciBlobFinder.lambda$discoverBlobPeers$0(DaVinciBlobFinder.java:45)`
	
The root cause was traced to the peerFinder using the **clientConfig** from the **daVinciBackend** during initialization. However, when **daVinciBackend** is initialized, it only occurs for the **first** store, and subsequent stores reuse the existing daVinciBackend (refer: [AvroGenericDaVinciClient.java](https://github.com/linkedin/venice/blob/main/clients/da-vinci-client/src/main/java/com/linkedin/davinci/client/AvroGenericDaVinciClient.java#L737 )). As a result, only the clientConfig from the first store is passed to the peerFinder, causing the peerFinder to send requests to the first store's router to retrieve peer information.


This PR updates the logic to pass the clientConfig to the peerFinder and creates a separate store client for each store.

<!--
Describe
- What changes to make and why you are making these changes.
- How are you going to achieve your goal.
- Describe what testings you have done, for example, performance testing etc.

If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->



## How was this PR tested?
integration test. 
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [ ] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.