### PR TITLE
[server] Up-Convert PUT message schema in AAWC

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/replication/merge/MergeConflictResolver.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/replication/merge/MergeConflictResolver.java
@@ -333,7 +333,8 @@ public class MergeConflictResolver {
      * {@link mergeResultValueSchema}.
      */
     GenericRecord newValueRecord =
-        deserializerCacheForFullValue.get(newValueSchemaID, newValueSchemaID).deserialize(newValueBytes);
+        deserializerCacheForFullValue.get(newValueSchemaID, mergeResultValueSchemaEntry.getId())
+            .deserialize(newValueBytes);
     ValueAndRmd<GenericRecord> oldValueAndRmd = createOldValueAndRmd(
         mergeResultValueSchemaEntry.getSchema(),
         mergeResultValueSchemaEntry.getId(),

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/replication/merge/MergeConflictResolver.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/replication/merge/MergeConflictResolver.java
@@ -328,9 +328,10 @@ public class MergeConflictResolver {
     final SchemaEntry mergeResultValueSchemaEntry =
         mergeResultValueSchemaResolver.getMergeResultValueSchema(oldValueSchemaID, newValueSchemaID);
     /**
-     * Note that it is important that the new value record should NOT use {@link mergeResultValueSchema}.
-     * {@link newValueWriterSchema} is either the same as {@link mergeResultValueSchema} or it is a subset of
-     * {@link mergeResultValueSchema}.
+     * New value record should use {@link mergeResultValueSchemaEntry} as reader schema for potential schema up-convert.
+     * {@link mergeResultValueSchemaEntry} is either the same as new value schema, if old value schema is the same as
+     * the new value schema, or it will be the superset schema. In the latter case, new value should be up-converted, so
+     * that it contains all the fields and updated value can be properly serialized.
      */
     GenericRecord newValueRecord =
         deserializerCacheForFullValue.get(newValueSchemaID, mergeResultValueSchemaEntry.getId())

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/replication/merge/TestMergeConflictResolver.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/replication/merge/TestMergeConflictResolver.java
@@ -36,7 +36,6 @@ public class TestMergeConflictResolver {
   protected ReadOnlySchemaRepository schemaRepository;
   protected Schema nestedRecordSchemaV1;
   protected Schema nestedRecordSchemaV2;
-  protected Schema nestedRecordRmdSchemaV1;
   protected Schema nestedRecordRmdSchemaV2;
 
   protected Schema userSchemaV1;
@@ -64,7 +63,6 @@ public class TestMergeConflictResolver {
     ValueAndDerivedSchemas personV3Schema = new ValueAndDerivedSchemas(storeName, -1, "avro/PersonV3.avsc");
     this.nestedRecordSchemaV1 = nestedV1Schema.getValueSchema();
     this.nestedRecordSchemaV2 = nestedV2Schema.getValueSchema();
-    this.nestedRecordRmdSchemaV1 = nestedV1Schema.getRmdSchema();
     this.nestedRecordRmdSchemaV2 = nestedV2Schema.getRmdSchema();
 
     this.userSchemaV1 = userV1Schema.getValueSchema();

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/replication/merge/TestMergeConflictResolver.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/replication/merge/TestMergeConflictResolver.java
@@ -34,6 +34,11 @@ public class TestMergeConflictResolver {
 
   protected String storeName;
   protected ReadOnlySchemaRepository schemaRepository;
+  protected Schema nestedRecordSchemaV1;
+  protected Schema nestedRecordSchemaV2;
+  protected Schema nestedRecordRmdSchemaV1;
+  protected Schema nestedRecordRmdSchemaV2;
+
   protected Schema userSchemaV1;
   protected Schema userRmdSchemaV1;
   protected Schema userSchemaV2;
@@ -52,9 +57,16 @@ public class TestMergeConflictResolver {
     this.schemaRepository = mock(ReadOnlySchemaRepository.class);
     ValueAndDerivedSchemas userV1Schema = new ValueAndDerivedSchemas(storeName, -1, "avro/UserV1.avsc");
     ValueAndDerivedSchemas userV2Schema = new ValueAndDerivedSchemas(storeName, -1, "avro/UserV2.avsc");
+    ValueAndDerivedSchemas nestedV1Schema = new ValueAndDerivedSchemas(storeName, -1, "avro/NestedRecordV1.avsc");
+    ValueAndDerivedSchemas nestedV2Schema = new ValueAndDerivedSchemas(storeName, -1, "avro/NestedRecordV2.avsc");
     ValueAndDerivedSchemas personV1Schema = new ValueAndDerivedSchemas(storeName, -1, "avro/PersonV1.avsc");
     ValueAndDerivedSchemas personV2Schema = new ValueAndDerivedSchemas(storeName, -1, "avro/PersonV2.avsc");
     ValueAndDerivedSchemas personV3Schema = new ValueAndDerivedSchemas(storeName, -1, "avro/PersonV3.avsc");
+    this.nestedRecordSchemaV1 = nestedV1Schema.getValueSchema();
+    this.nestedRecordSchemaV2 = nestedV2Schema.getValueSchema();
+    this.nestedRecordRmdSchemaV1 = nestedV1Schema.getRmdSchema();
+    this.nestedRecordRmdSchemaV2 = nestedV2Schema.getRmdSchema();
+
     this.userSchemaV1 = userV1Schema.getValueSchema();
     this.userRmdSchemaV1 = userV1Schema.getRmdSchema();
     this.userSchemaV2 = userV2Schema.getValueSchema();

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/replication/merge/TestMergePutWithFieldLevelTimestamp.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/replication/merge/TestMergePutWithFieldLevelTimestamp.java
@@ -3,6 +3,7 @@ package com.linkedin.davinci.replication.merge;
 import static com.linkedin.venice.schema.rmd.RmdConstants.TIMESTAMP_FIELD_NAME;
 import static com.linkedin.venice.schema.rmd.RmdConstants.TIMESTAMP_FIELD_POS;
 import static com.linkedin.venice.schema.rmd.RmdUtils.getRmdTimestampType;
+import static com.linkedin.venice.schema.rmd.v1.CollectionRmdTimestamp.TOP_LEVEL_TS_FIELD_NAME;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 
@@ -15,7 +16,9 @@ import com.linkedin.venice.schema.rmd.RmdTimestampType;
 import com.linkedin.venice.utils.AvroSupersetSchemaUtils;
 import com.linkedin.venice.utils.lazy.Lazy;
 import java.nio.ByteBuffer;
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericData;
@@ -99,6 +102,53 @@ public class TestMergePutWithFieldLevelTimestamp extends TestMergeConflictResolv
     Assert.assertEquals(((GenericRecord) timestampObject).get("id"), 11L);
     Assert.assertEquals(((GenericRecord) timestampObject).get("name"), 11L);
     Assert.assertEquals(((GenericRecord) timestampObject).get("age"), 11L);
+  }
+
+  @Test
+  public void testNewPutWithOldSchema() {
+    ReadOnlySchemaRepository schemaRepository = mock(ReadOnlySchemaRepository.class);
+    doReturn(new SchemaEntry(1, nestedRecordSchemaV1)).when(schemaRepository).getValueSchema(storeName, 1);
+    doReturn(new SchemaEntry(2, nestedRecordSchemaV2)).when(schemaRepository).getValueSchema(storeName, 2);
+    StringAnnotatedStoreSchemaCache stringAnnotatedStoreSchemaCache =
+        new StringAnnotatedStoreSchemaCache(storeName, schemaRepository);
+
+    MergeConflictResolver mergeConflictResolver = MergeConflictResolverFactory.getInstance()
+        .createMergeConflictResolver(
+            stringAnnotatedStoreSchemaCache,
+            new RmdSerDe(stringAnnotatedStoreSchemaCache, RMD_VERSION_ID),
+            storeName,
+            true,
+            true);
+
+    GenericRecord rmdRecord = createRmdWithValueLevelTimestamp(nestedRecordRmdSchemaV2, 10L);
+    final int oldValueSchemaID = 2;
+
+    GenericRecord newValueRecord = new GenericData.Record(nestedRecordSchemaV1);
+    newValueRecord.put("id", "default_id");
+    Schema arrayItemSchemaInSchemaV1 = nestedRecordSchemaV1.getField("itemList").schema().getElementType();
+    GenericRecord itemRecord = new GenericData.Record(arrayItemSchemaInSchemaV1);
+    itemRecord.put("memberId", 100L);
+    List<GenericRecord> testArray = new ArrayList<>();
+    testArray.add(itemRecord);
+    newValueRecord.put("itemList", testArray);
+    ByteBuffer newValueBytes = ByteBuffer.wrap(getSerializer(nestedRecordSchemaV1).serialize(newValueRecord));
+
+    MergeConflictResult mergeResult = mergeConflictResolver.put(
+        Lazy.of(() -> null),
+        new RmdWithValueSchemaId(oldValueSchemaID, RMD_VERSION_ID, rmdRecord),
+        newValueBytes,
+        11L,
+        1, // Different from the old value schema ID.
+        1L,
+        0,
+        0);
+    Assert.assertFalse(mergeResult.isUpdateIgnored());
+    Object timestampObject = mergeResult.getRmdRecord().get(TIMESTAMP_FIELD_POS);
+    RmdTimestampType rmdTimestampType = getRmdTimestampType(timestampObject);
+    Assert.assertEquals(rmdTimestampType, RmdTimestampType.PER_FIELD_TIMESTAMP);
+    Assert.assertEquals(((GenericRecord) timestampObject).get("id"), 11L);
+    GenericRecord itemListTsObject = (GenericRecord) ((GenericRecord) timestampObject).get("itemList");
+    Assert.assertEquals(itemListTsObject.get(TOP_LEVEL_TS_FIELD_NAME), 11L);
   }
 
   @Test

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/replication/merge/TestMergePutWithFieldLevelTimestamp.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/replication/merge/TestMergePutWithFieldLevelTimestamp.java
@@ -300,14 +300,14 @@ public class TestMergePutWithFieldLevelTimestamp extends TestMergeConflictResolv
     Assert.assertFalse(result.isUpdateIgnored());
     GenericRecord updatedRmd = result.getRmdRecord();
     GenericRecord updatedPerFieldTimestampRecord = (GenericRecord) updatedRmd.get(TIMESTAMP_FIELD_NAME);
-    Assert.assertEquals(updatedPerFieldTimestampRecord.get("id"), 10L); // Not updated
+    Assert.assertEquals(updatedPerFieldTimestampRecord.get("id"), 15L); // Updated due to schema up-convert
     Assert.assertEquals(updatedPerFieldTimestampRecord.get("name"), 20L); // Not updated
     Assert.assertEquals(updatedPerFieldTimestampRecord.get("weight"), 15L); // Not updated and it is a new field.
 
     ByteBuffer newValueOptional = result.getNewValue();
     Assert.assertNotNull(newValueOptional);
     newValueRecord = getDeserializer(userSchemaV5, userSchemaV5).deserialize(newValueOptional);
-    Assert.assertEquals(newValueRecord.get("id").toString(), "123"); // Not updated
+    Assert.assertEquals(newValueRecord.get("id").toString(), "id"); // Updated to default due to schema up-convert
     Assert.assertEquals(newValueRecord.get("name").toString(), "James"); // Not updated
     Assert.assertEquals(newValueRecord.get("weight").toString(), "250.0"); // Updated and it is a new field.
   }
@@ -408,14 +408,14 @@ public class TestMergePutWithFieldLevelTimestamp extends TestMergeConflictResolv
     Assert.assertFalse(result.isUpdateIgnored());
     GenericRecord updatedRmd = result.getRmdRecord();
     GenericRecord updatedPerFieldTimestampRecord = (GenericRecord) updatedRmd.get(TIMESTAMP_FIELD_NAME);
-    Assert.assertEquals(updatedPerFieldTimestampRecord.get("id"), 10L); // Not updated
+    Assert.assertEquals(updatedPerFieldTimestampRecord.get("id"), 25L); // Updated timestamp due to schema up-convert
     Assert.assertEquals(updatedPerFieldTimestampRecord.get("name"), 25L); // Updated
     Assert.assertEquals(updatedPerFieldTimestampRecord.get("weight"), 30L); // Not updated
 
     ByteBuffer newValueOptional = result.getNewValue();
     Assert.assertNotNull(newValueOptional);
     newValueRecord = getDeserializer(userSchemaV5, userSchemaV5).deserialize(newValueOptional);
-    Assert.assertEquals(newValueRecord.get("id").toString(), "123"); // Not updated
+    Assert.assertEquals(newValueRecord.get("id").toString(), "id"); // Updated to default due to schema up-convert
     Assert.assertEquals(newValueRecord.get("name").toString(), "Lebron"); // Updated
     Assert.assertEquals(newValueRecord.get("weight").toString(), "250.1"); // Updated and it is a new field.
   }

--- a/clients/da-vinci-client/src/test/resources/avro/NestedRecordV1.avsc
+++ b/clients/da-vinci-client/src/test/resources/avro/NestedRecordV1.avsc
@@ -1,0 +1,29 @@
+{
+  "type": "record",
+  "name": "NestedRecord",
+  "namespace": "example.avro",
+  "fields": [
+    {
+      "name": "id",
+      "type": "string",
+      "default": "default_id"
+    },
+    {
+      "name": "itemList",
+      "type": {
+        "type": "array",
+        "items": {
+          "type": "record",
+          "name": "ItemRecord",
+          "fields": [
+            {
+              "name": "memberId",
+              "type": "long"
+            }
+          ]
+        }
+      },
+      "default": []
+    }
+  ]
+}

--- a/clients/da-vinci-client/src/test/resources/avro/NestedRecordV2.avsc
+++ b/clients/da-vinci-client/src/test/resources/avro/NestedRecordV2.avsc
@@ -1,0 +1,34 @@
+{
+  "type": "record",
+  "name": "NestedRecord",
+  "namespace": "example.avro",
+  "fields": [
+    {
+      "name": "id",
+      "type": "string",
+      "default": "default_id"
+    },
+    {
+      "name": "itemList",
+      "type": {
+        "type": "array",
+        "items": {
+          "type": "record",
+          "name": "ItemRecord",
+          "fields": [
+            {
+              "name": "memberId",
+              "type": "long"
+            },
+            {
+              "name": "dummyField",
+              "type": "long",
+              "default": 100
+            }
+          ]
+        }
+      },
+      "default": []
+    }
+  ]
+}


### PR DESCRIPTION
<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat], [protocol]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## [server] Up-Convert PUT message schema in AAWC
Today, in AAWC DCR code, we always use incoming schema as both reader/writer schema to deserialize the incoming PUT.
The problem is, if we update the complex record in schema evolution by adding new nested field, and incoming PUT is using old schema, then after merge, the updated value record will be missing the newly added nested fields and unable to be serialized back by superset schema.

The fix is simple, just also use resolved schema as reader schema to up-convert the incoming PUT.
The resolved schema is defined as: If old value schema and incoming value schema is the same, then it is the old value schema. Otherwise, use superset schema of them.

**Behavior Change:**
This PR has certain behavior change: Due to PUT potentially being up-converted to superset schema, it may contain fields filled with default value that is not in the original PUT message. And it may override the existing field value.
For example:
Old Value is {"id": 1, "name": "abc"}, and the new PUT value is {"id": 100}, and assuming new PUT TS is larger than all old value field TS.
Existing behavior will result in {"id": 100, "name": "abc"} and new behavior will result in {"id": 100, "name": <default_name>}

## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
Added a new unit test to catch this issue.

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [ ] No. You can skip the rest of this section.
- [x] Yes. Make sure to explain your proposed changes and call out the behavior change.