### PR TITLE
[test] Add test logic for verifying thread pool metric emitted before server shutdown during integration test.

### DIFF
--- a/internal/venice-test-common/src/main/java/com/linkedin/venice/tehuti/MockTehutiReporter.java
+++ b/internal/venice-test-common/src/main/java/com/linkedin/venice/tehuti/MockTehutiReporter.java
@@ -18,6 +18,10 @@ public class MockTehutiReporter implements MetricsReporter {
 
   @Override
   public void init(List<TehutiMetric> metrics) {
+    // Ensure lately added reporter has all metrics.
+    for (TehutiMetric metric: metrics) {
+      this.metrics.put(metric.name(), metric);
+    }
   }
 
   @Override


### PR DESCRIPTION
<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat], [protocol]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## Summary, imperative, start upper case, don't end with a period
<!--
Describe
- What changes to make and why you are making these changes.
- How are you going to achieve your goal.
- Describe what testings you have done, for example, performance testing etc.

If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

In production, we previously observed no state transition metrics emitted, here we add test logic to verify these metrics will be emitted for every Venice server instances. 

## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
ci
## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [ ] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.