### PR TITLE
[vpj] Make Spark job exceptions be thrown during execution instead of configuration

### DIFF
--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/VenicePushJob.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/VenicePushJob.java
@@ -97,6 +97,7 @@ import com.linkedin.venice.etl.ETLValueSchemaTransformation;
 import com.linkedin.venice.exceptions.ErrorType;
 import com.linkedin.venice.exceptions.VeniceException;
 import com.linkedin.venice.exceptions.VeniceResourceAccessException;
+import com.linkedin.venice.hadoop.exceptions.VeniceInvalidInputException;
 import com.linkedin.venice.hadoop.input.kafka.KafkaInputDictTrainer;
 import com.linkedin.venice.hadoop.mapreduce.datawriter.jobs.DataWriterMRJob;
 import com.linkedin.venice.hadoop.mapreduce.engine.DefaultJobClientWrapper;
@@ -1054,6 +1055,10 @@ public class VenicePushJob implements AutoCloseable {
           throw new VeniceException(
               "Data writer job failed unexpectedly with status: " + dataWriterComputeJob.getStatus());
         } else {
+          if (t instanceof VeniceInvalidInputException) {
+            updatePushJobDetailsWithCheckpoint(PushJobCheckpoints.INVALID_INPUT_FILE);
+          }
+
           throwVeniceException(t);
         }
       } else {
@@ -1069,19 +1074,12 @@ public class VenicePushJob implements AutoCloseable {
   }
 
   private void checkLastModificationTimeAndLog() throws IOException {
-    checkLastModificationTimeAndLog(false);
-  }
-
-  private void checkLastModificationTimeAndLog(boolean throwExceptionOnDataSetChange) throws IOException {
     long lastModificationTime = getInputDataInfoProvider().getInputLastModificationTime(pushJobSetting.inputURI);
     if (lastModificationTime > inputDataInfo.getInputModificationTime()) {
       updatePushJobDetailsWithCheckpoint(PushJobCheckpoints.DATASET_CHANGED);
-      String error = "Dataset changed during the push job. Please check above logs to see if the change "
-          + "caused the MapReduce failure and rerun the job without dataset change.";
+      String error = "Dataset changed during the push job. Please investigate if the change caused the failure and "
+          + "rerun the job without changing the dataset while the job is running.";
       LOGGER.error(error);
-      if (throwExceptionOnDataSetChange) {
-        throw new VeniceException(error);
-      }
     }
   }
 

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/VenicePushJob.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/VenicePushJob.java
@@ -1077,9 +1077,9 @@ public class VenicePushJob implements AutoCloseable {
     long lastModificationTime = getInputDataInfoProvider().getInputLastModificationTime(pushJobSetting.inputURI);
     if (lastModificationTime > inputDataInfo.getInputModificationTime()) {
       updatePushJobDetailsWithCheckpoint(PushJobCheckpoints.DATASET_CHANGED);
-      String error = "Dataset changed during the push job. Please investigate if the change caused the failure and "
-          + "rerun the job without changing the dataset while the job is running.";
-      LOGGER.error(error);
+      LOGGER.error(
+          "Dataset changed during the push job. Please investigate if the change caused the failure and "
+              + "rerun the job without changing the dataset while the job is running.");
     }
   }
 

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/exceptions/VeniceInvalidInputException.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/exceptions/VeniceInvalidInputException.java
@@ -1,0 +1,14 @@
+package com.linkedin.venice.hadoop.exceptions;
+
+import com.linkedin.venice.exceptions.VeniceException;
+
+
+public class VeniceInvalidInputException extends VeniceException {
+  public VeniceInvalidInputException(String message) {
+    super(message);
+  }
+
+  public VeniceInvalidInputException(String message, Throwable throwable) {
+    super(message, throwable);
+  }
+}

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/spark/datawriter/jobs/AbstractDataWriterSparkJob.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/spark/datawriter/jobs/AbstractDataWriterSparkJob.java
@@ -52,9 +52,9 @@ import static com.linkedin.venice.vpj.VenicePushJobConstants.ZSTD_DICTIONARY_CRE
 
 import com.github.luben.zstd.Zstd;
 import com.linkedin.venice.compression.CompressionStrategy;
-import com.linkedin.venice.exceptions.VeniceException;
 import com.linkedin.venice.exceptions.VeniceUnsupportedOperationException;
 import com.linkedin.venice.hadoop.PushJobSetting;
+import com.linkedin.venice.hadoop.exceptions.VeniceInvalidInputException;
 import com.linkedin.venice.hadoop.input.kafka.ttl.TTLResolutionPolicy;
 import com.linkedin.venice.hadoop.ssl.TempFileSSLConfigurator;
 import com.linkedin.venice.hadoop.task.datawriter.DataWriterTaskTracker;
@@ -70,7 +70,6 @@ import com.linkedin.venice.spark.utils.SparkScalaUtils;
 import com.linkedin.venice.utils.VeniceProperties;
 import com.linkedin.venice.writer.VeniceWriter;
 import java.io.IOException;
-import java.util.Objects;
 import java.util.Properties;
 import java.util.UUID;
 import org.apache.kafka.clients.CommonClientConfigs;
@@ -88,6 +87,7 @@ import org.apache.spark.sql.SparkSession;
 import org.apache.spark.sql.catalyst.encoders.ExpressionEncoder;
 import org.apache.spark.sql.catalyst.encoders.RowEncoder;
 import org.apache.spark.sql.functions;
+import org.apache.spark.sql.types.DataType;
 import org.apache.spark.sql.types.DataTypes;
 import org.apache.spark.sql.types.StructField;
 import org.apache.spark.sql.types.StructType;
@@ -105,7 +105,6 @@ public abstract class AbstractDataWriterSparkJob extends DataWriterComputeJob {
 
   private String jobGroupId;
   private SparkSession sparkSession;
-  private Dataset<Row> dataFrame;
   private DataWriterAccumulators accumulatorsForDataWriterJob;
   private SparkDataWriterTaskTracker taskTracker;
 
@@ -115,18 +114,8 @@ public abstract class AbstractDataWriterSparkJob extends DataWriterComputeJob {
     this.pushJobSetting = pushJobSetting;
     setupDefaultSparkSessionForDataWriterJob(pushJobSetting, props);
 
-    // Load data from input path
-    this.dataFrame = getInputDataFrame();
-    Objects.requireNonNull(this.dataFrame, "The input data frame cannot be null");
-    validateDataFrameSchema(this.dataFrame);
-
     Properties jobProps = new Properties();
     sparkSession.conf().getAll().foreach(entry -> jobProps.setProperty(entry._1, entry._2));
-    if (pushJobSetting.materializedViewConfigFlatMap != null) {
-      jobProps.put(PUSH_JOB_VIEW_CONFIGS, pushJobSetting.materializedViewConfigFlatMap);
-      jobProps.put(VALUE_SCHEMA_DIR, pushJobSetting.valueSchemaDir);
-      jobProps.put(RMD_SCHEMA_DIR, pushJobSetting.rmdSchemaDir);
-    }
     accumulatorsForDataWriterJob = new DataWriterAccumulators(sparkSession);
     taskTracker = new SparkDataWriterTaskTracker(accumulatorsForDataWriterJob);
   }
@@ -187,7 +176,7 @@ public abstract class AbstractDataWriterSparkJob extends DataWriterComputeJob {
     jobConf.set(PARTITIONER_CLASS, pushJobSetting.partitionerClass);
     // flatten partitionerParams since RuntimeConfig class does not support set an object
     if (pushJobSetting.partitionerParams != null) {
-      pushJobSetting.partitionerParams.forEach((key, value) -> jobConf.set(key, value));
+      pushJobSetting.partitionerParams.forEach(jobConf::set);
     }
     jobConf.set(PARTITION_COUNT, pushJobSetting.partitionCount);
     if (pushJobSetting.sslToKafka) {
@@ -267,6 +256,12 @@ public abstract class AbstractDataWriterSparkJob extends DataWriterComputeJob {
     jobConf.set(PUSH_JOB_GUID_MOST_SIGNIFICANT_BITS, producerGuid.getMostSignificantBits());
     jobConf.set(PUSH_JOB_GUID_LEAST_SIGNIFICANT_BITS, producerGuid.getLeastSignificantBits());
 
+    if (pushJobSetting.materializedViewConfigFlatMap != null) {
+      jobConf.set(PUSH_JOB_VIEW_CONFIGS, pushJobSetting.materializedViewConfigFlatMap);
+      jobConf.set(VALUE_SCHEMA_DIR, pushJobSetting.valueSchemaDir);
+      jobConf.set(RMD_SCHEMA_DIR, pushJobSetting.rmdSchemaDir);
+    }
+
     /**
      * Override the configs following the rules:
      * <ul>
@@ -301,7 +296,7 @@ public abstract class AbstractDataWriterSparkJob extends DataWriterComputeJob {
    *   <li>Must not contain fields with names beginning with "_". These are reserved for internal use.</li>
    *   <li>Can contain fields that do not violate the above constraints</li>
    * </ul>
-   * @see {@link #validateDataFrameSchema(StructType)}
+   * @see {@link #validateDataFrame(Dataset)}
    *
    * @return The data frame based on the user's input data
    */
@@ -340,6 +335,10 @@ public abstract class AbstractDataWriterSparkJob extends DataWriterComputeJob {
 
   @Override
   protected void runComputeJob() {
+    // Load data from input path
+    Dataset<Row> dataFrame = getInputDataFrame();
+    validateDataFrame(dataFrame);
+
     ExpressionEncoder<Row> rowEncoder = RowEncoder.apply(DEFAULT_SCHEMA);
     ExpressionEncoder<Row> rowEncoderWithPartition = RowEncoder.apply(DEFAULT_SCHEMA_WITH_PARTITION);
     int numOutputPartitions = pushJobSetting.partitionCount;
@@ -422,54 +421,62 @@ public abstract class AbstractDataWriterSparkJob extends DataWriterComputeJob {
     LOGGER.info("  {}: {}", accumulator.name().get(), accumulator.value());
   }
 
-  private void validateDataFrameSchema(Dataset<Row> dataFrameForDataWriterJob) {
-    StructType dataSchema = dataFrameForDataWriterJob.schema();
-    if (!validateDataFrameSchema(dataSchema)) {
-      String errorMessage =
-          String.format("The provided input data schema is not supported. Provided schema: %s.", dataSchema);
-      throw new VeniceException(errorMessage);
+  private void validateDataFrame(Dataset<Row> dataFrameForDataWriterJob) {
+    if (dataFrameForDataWriterJob == null) {
+      throw new VeniceInvalidInputException("The input data frame cannot be null");
     }
-  }
 
-  private boolean validateDataFrameSchema(StructType dataSchema) {
+    StructType dataSchema = dataFrameForDataWriterJob.schema();
     StructField[] fields = dataSchema.fields();
 
     if (fields.length < 2) {
-      LOGGER.error("The provided input data schema does not have enough fields");
-      return false;
+      String errorMessage =
+          String.format("The provided input data does not have enough fields. Provided schema: %s.", dataSchema);
+      throw new VeniceInvalidInputException(errorMessage);
     }
 
     int keyFieldIndex = SparkScalaUtils.getFieldIndex(dataSchema, KEY_COLUMN_NAME);
 
     if (keyFieldIndex == -1) {
-      LOGGER.error("The provided input data schema does not have a {} field", KEY_COLUMN_NAME);
-      return false;
+      String errorMessage = String.format(
+          "The provided input data frame does not have a %s field. Provided schema: %s.",
+          KEY_COLUMN_NAME,
+          dataSchema);
+      throw new VeniceInvalidInputException(errorMessage);
     }
 
-    if (!fields[keyFieldIndex].dataType().equals(DataTypes.BinaryType)) {
-      LOGGER.error("The provided input key field's schema must be {}", DataTypes.BinaryType);
-      return false;
+    StructField keyField = fields[keyFieldIndex];
+    DataType keyType = keyField.dataType();
+    if (!keyType.equals(DataTypes.BinaryType)) {
+      String errorMessage =
+          String.format("The provided input key field's schema must be %s. Got: %s.", DataTypes.BinaryType, keyType);
+      throw new VeniceInvalidInputException(errorMessage);
     }
 
     int valueFieldIndex = SparkScalaUtils.getFieldIndex(dataSchema, VALUE_COLUMN_NAME);
 
     if (valueFieldIndex == -1) {
-      LOGGER.error("The provided input data schema does not have a {} field", VALUE_COLUMN_NAME);
-      return false;
+      String errorMessage = String.format(
+          "The provided input data frame does not have a %s field. Provided schema: %s.",
+          VALUE_COLUMN_NAME,
+          dataSchema);
+      throw new VeniceInvalidInputException(errorMessage);
     }
 
+    StructField valueField = fields[valueFieldIndex];
+    DataType valueType = valueField.dataType();
     if (!fields[valueFieldIndex].dataType().equals(DataTypes.BinaryType)) {
-      LOGGER.error("The provided input value field's schema must be {}", DataTypes.BinaryType);
-      return false;
+      String errorMessage = String
+          .format("The provided input value field's schema must be %s. Got: %s.", DataTypes.BinaryType, valueType);
+      throw new VeniceInvalidInputException(errorMessage);
     }
 
     for (StructField field: fields) {
       if (field.name().startsWith("_")) {
-        LOGGER.error("The provided input must not have fields that start with an underscore");
-        return false;
+        String errorMessage = String
+            .format("The provided input must not have fields that start with an underscore. Got: %s", field.name());
+        throw new VeniceInvalidInputException(errorMessage);
       }
     }
-
-    return true;
   }
 }

--- a/clients/venice-push-job/src/test/java/com/linkedin/venice/spark/datawriter/jobs/AbstractDataWriterSparkJobTest.java
+++ b/clients/venice-push-job/src/test/java/com/linkedin/venice/spark/datawriter/jobs/AbstractDataWriterSparkJobTest.java
@@ -14,8 +14,9 @@ import static org.apache.spark.sql.types.DataTypes.StringType;
 
 import com.linkedin.venice.compression.CompressionStrategy;
 import com.linkedin.venice.etl.ETLValueSchemaTransformation;
-import com.linkedin.venice.exceptions.VeniceException;
 import com.linkedin.venice.hadoop.PushJobSetting;
+import com.linkedin.venice.hadoop.exceptions.VeniceInvalidInputException;
+import com.linkedin.venice.jobs.ComputeJob;
 import com.linkedin.venice.jobs.DataWriterComputeJob;
 import com.linkedin.venice.meta.Version;
 import com.linkedin.venice.partitioner.DefaultVenicePartitioner;
@@ -84,27 +85,51 @@ public class AbstractDataWriterSparkJobTest {
     PushJobSetting setting = getDefaultPushJobSetting(inputDir, dataSchema);
     Properties properties = new Properties();
     try (DataWriterComputeJob computeJob = new InvalidKeySchemaDataWriterSparkJob()) {
-      Assert.assertThrows(VeniceException.class, () -> computeJob.configure(new VeniceProperties(properties), setting));
+      computeJob.configure(new VeniceProperties(properties), setting);
+      computeJob.runJob();
+      Assert.assertEquals(computeJob.getStatus(), ComputeJob.Status.FAILED);
+      Assert.assertNotNull(computeJob.getFailureReason());
+      Assert.assertTrue(computeJob.getFailureReason() instanceof VeniceInvalidInputException);
     }
 
     try (DataWriterComputeJob computeJob = new InvalidValueSchemaDataWriterSparkJob()) {
-      Assert.assertThrows(VeniceException.class, () -> computeJob.configure(new VeniceProperties(properties), setting));
+      computeJob.configure(new VeniceProperties(properties), setting);
+      computeJob.runJob();
+      Assert.assertEquals(computeJob.getStatus(), ComputeJob.Status.FAILED);
+      Assert.assertNotNull(computeJob.getFailureReason());
+      Assert.assertTrue(computeJob.getFailureReason() instanceof VeniceInvalidInputException);
     }
 
     try (DataWriterComputeJob computeJob = new IncompleteFieldDataWriterSparkJob()) {
-      Assert.assertThrows(VeniceException.class, () -> computeJob.configure(new VeniceProperties(properties), setting));
+      computeJob.configure(new VeniceProperties(properties), setting);
+      computeJob.runJob();
+      Assert.assertEquals(computeJob.getStatus(), ComputeJob.Status.FAILED);
+      Assert.assertNotNull(computeJob.getFailureReason());
+      Assert.assertTrue(computeJob.getFailureReason() instanceof VeniceInvalidInputException);
     }
 
     try (DataWriterComputeJob computeJob = new MissingKeyFieldDataWriterSparkJob()) {
-      Assert.assertThrows(VeniceException.class, () -> computeJob.configure(new VeniceProperties(properties), setting));
+      computeJob.configure(new VeniceProperties(properties), setting);
+      computeJob.runJob();
+      Assert.assertEquals(computeJob.getStatus(), ComputeJob.Status.FAILED);
+      Assert.assertNotNull(computeJob.getFailureReason());
+      Assert.assertTrue(computeJob.getFailureReason() instanceof VeniceInvalidInputException);
     }
 
     try (DataWriterComputeJob computeJob = new MissingValueFieldDataWriterSparkJob()) {
-      Assert.assertThrows(VeniceException.class, () -> computeJob.configure(new VeniceProperties(properties), setting));
+      computeJob.configure(new VeniceProperties(properties), setting);
+      computeJob.runJob();
+      Assert.assertEquals(computeJob.getStatus(), ComputeJob.Status.FAILED);
+      Assert.assertNotNull(computeJob.getFailureReason());
+      Assert.assertTrue(computeJob.getFailureReason() instanceof VeniceInvalidInputException);
     }
 
     try (DataWriterComputeJob computeJob = new SchemaWithRestrictedFieldDataWriterSparkJob()) {
-      Assert.assertThrows(VeniceException.class, () -> computeJob.configure(new VeniceProperties(properties), setting));
+      computeJob.configure(new VeniceProperties(properties), setting);
+      computeJob.runJob();
+      Assert.assertEquals(computeJob.getStatus(), ComputeJob.Status.FAILED);
+      Assert.assertNotNull(computeJob.getFailureReason());
+      Assert.assertTrue(computeJob.getFailureReason() instanceof VeniceInvalidInputException);
     }
   }
 


### PR DESCRIPTION
<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## Make Spark job exceptions be thrown during execution instead of configuration
<!--
Describe
- What changes to make and why you are making these changes.
- How are you going to achieve your goal.
- Describe what testings you have done, for example, performance testing etc.

If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->
In Spark ComputeJob, some cases of `DATASET_CHANGED` were not getting tracked correctly, and were instead getting tracked as `START_DATA_WRITER_JOB`.

This was because of an incorrect assumption that Spark jobs would get executed only when the final action stage is encountered. But in practice, the spark stages were starting to get executed when the `repartitionAndSortWithinPartitions` call was getting invoked. This was previously done in the `configure` phase, and exceptions thrown in this stage are not handled as errors during the execution of the compute job.

This commit moves all Spark execution logic inside the `runComputeJob` method instead.

In addition to this, this commit also moves all other input validation inside the same function too so that they can be reported with valid status.

## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
GH CI. Added new tests

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [X] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.