### PR TITLE
[protocol] Add adminOperationProtocolVersion into proto schema AdminTopicMetadata

### DIFF
--- a/internal/venice-common/src/main/proto/controller/ClusterAdminOpsGrpcService.proto
+++ b/internal/venice-common/src/main/proto/controller/ClusterAdminOpsGrpcService.proto
@@ -63,4 +63,5 @@ message AdminTopicGrpcMetadata {
   optional string storeName = 3;
   optional int64 offset = 4;
   optional int64 upstreamOffset = 5;
+  optional int64 adminOperationProtocolVersion = 6;
 }


### PR DESCRIPTION
## Summary, imperative, start upper case, don't end with a period
[protocol] Add adminOperationProtocolVersion into proto schema AdminTopicMetadata

This is the preparation for PR: #1418 

## Why?
Since we are introducing a new field in AdminTopicMetadata, we will need to update the API `getAdminTopicMetadata` to return the full metadata map on remote. To do that, we need to add this key into the response object. 

## How was this PR tested?
Only schema changed

## Does this PR introduce any user-facing changes?
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.