### PR TITLE
[admin-tool] Modify the response of updateAdminTopicMetadata

### DIFF
--- a/internal/venice-common/src/main/proto/controller/ClusterAdminOpsGrpcService.proto
+++ b/internal/venice-common/src/main/proto/controller/ClusterAdminOpsGrpcService.proto
@@ -13,7 +13,7 @@ service ClusterAdminOpsGrpcService {
 
   // AdminTopicMetadata
   rpc getAdminTopicMetadata(AdminTopicMetadataGrpcRequest) returns (AdminTopicMetadataGrpcResponse) {}
-  rpc updateAdminTopicMetadata(UpdateAdminTopicMetadataGrpcRequest) returns (UpdateAdminTopicMetadataGrpcResponse) {}
+  rpc updateAdminTopicMetadata(UpdateAdminTopicMetadataGrpcRequest) returns (AdminTopicMetadataGrpcResponse) {}
 }
 
 
@@ -48,18 +48,13 @@ message AdminTopicMetadataGrpcResponse {
   AdminTopicGrpcMetadata metadata = 1;
 }
 
-message UpdateAdminTopicMetadataGrpcResponse {
-  string clusterName = 1;
-  optional string storeName = 2;
-}
-
 message UpdateAdminTopicMetadataGrpcRequest {
   AdminTopicGrpcMetadata metadata = 1;
 }
 
 message AdminTopicGrpcMetadata {
   string clusterName = 1;
-  int64 executionId = 2;
+  optional int64 executionId = 2;
   optional string storeName = 3;
   optional int64 offset = 4;
   optional int64 upstreamOffset = 5;

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/grpc/server/ClusterAdminOpsGrpcServiceImpl.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/grpc/server/ClusterAdminOpsGrpcServiceImpl.java
@@ -16,7 +16,6 @@ import com.linkedin.venice.protocols.controller.ClusterAdminOpsGrpcServiceGrpc;
 import com.linkedin.venice.protocols.controller.LastSuccessfulAdminCommandExecutionGrpcRequest;
 import com.linkedin.venice.protocols.controller.LastSuccessfulAdminCommandExecutionGrpcResponse;
 import com.linkedin.venice.protocols.controller.UpdateAdminTopicMetadataGrpcRequest;
-import com.linkedin.venice.protocols.controller.UpdateAdminTopicMetadataGrpcResponse;
 import io.grpc.Context;
 import io.grpc.stub.StreamObserver;
 import org.apache.logging.log4j.LogManager;
@@ -77,7 +76,7 @@ public class ClusterAdminOpsGrpcServiceImpl extends ClusterAdminOpsGrpcServiceIm
   @Override
   public void updateAdminTopicMetadata(
       UpdateAdminTopicMetadataGrpcRequest request,
-      StreamObserver<UpdateAdminTopicMetadataGrpcResponse> responseObserver) {
+      StreamObserver<AdminTopicMetadataGrpcResponse> responseObserver) {
     LOGGER.debug("Received updateAdminTopicMetadata request: {}", request);
     AdminTopicGrpcMetadata metadata = request.getMetadata();
     ControllerGrpcServerUtils.handleRequest(ClusterAdminOpsGrpcServiceGrpc.getUpdateAdminTopicMetadataMethod(), () -> {

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/server/AdminTopicMetadataRoutes.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/server/AdminTopicMetadataRoutes.java
@@ -19,7 +19,6 @@ import com.linkedin.venice.protocols.controller.AdminTopicGrpcMetadata;
 import com.linkedin.venice.protocols.controller.AdminTopicMetadataGrpcRequest;
 import com.linkedin.venice.protocols.controller.AdminTopicMetadataGrpcResponse;
 import com.linkedin.venice.protocols.controller.UpdateAdminTopicMetadataGrpcRequest;
-import com.linkedin.venice.protocols.controller.UpdateAdminTopicMetadataGrpcResponse;
 import java.util.Optional;
 import org.apache.http.HttpStatus;
 import spark.Route;
@@ -90,10 +89,11 @@ public class AdminTopicMetadataRoutes extends AbstractRoute {
         storeName.ifPresent(adminMetadataBuilder::setStoreName);
         offset.ifPresent(adminMetadataBuilder::setOffset);
         upstreamOffset.ifPresent(adminMetadataBuilder::setUpstreamOffset);
-        UpdateAdminTopicMetadataGrpcResponse internalResponse = requestHandler.updateAdminTopicMetadata(
-            UpdateAdminTopicMetadataGrpcRequest.newBuilder().setMetadata(adminMetadataBuilder).build());
-        responseObject.setCluster(internalResponse.getClusterName());
-        responseObject.setName(internalResponse.hasStoreName() ? internalResponse.getStoreName() : null);
+        AdminTopicMetadataGrpcResponse internalResponse = requestHandler.updateAdminTopicMetadata(
+            UpdateAdminTopicMetadataGrpcRequest.newBuilder().setMetadata(adminMetadataBuilder.build()).build());
+        responseObject.setCluster(internalResponse.getMetadata().getClusterName());
+        responseObject.setName(
+            internalResponse.getMetadata().hasStoreName() ? internalResponse.getMetadata().getStoreName() : null);
       } catch (Throwable e) {
         responseObject.setError(e);
         AdminSparkServer.handleError(new VeniceException(e), request, response);

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/server/ControllerRequestParamValidator.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/server/ControllerRequestParamValidator.java
@@ -45,4 +45,10 @@ public class ControllerRequestParamValidator {
       throw new IllegalArgumentException("Admin command execution id with positive value is required");
     }
   }
+
+  public static void validateAdminTopicMetadataRequest(String clusterName) {
+    if (StringUtils.isBlank(clusterName)) {
+      throw new IllegalArgumentException("Cluster name is required for getting admin command execution status");
+    }
+  }
 }

--- a/services/venice-controller/src/test/java/com/linkedin/venice/controller/grpc/server/ClusterAdminOpsGrpcServiceImplTest.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/controller/grpc/server/ClusterAdminOpsGrpcServiceImplTest.java
@@ -7,6 +7,7 @@ import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.expectThrows;
@@ -25,7 +26,6 @@ import com.linkedin.venice.protocols.controller.ClusterAdminOpsGrpcServiceGrpc.C
 import com.linkedin.venice.protocols.controller.LastSuccessfulAdminCommandExecutionGrpcRequest;
 import com.linkedin.venice.protocols.controller.LastSuccessfulAdminCommandExecutionGrpcResponse;
 import com.linkedin.venice.protocols.controller.UpdateAdminTopicMetadataGrpcRequest;
-import com.linkedin.venice.protocols.controller.UpdateAdminTopicMetadataGrpcResponse;
 import com.linkedin.venice.protocols.controller.VeniceControllerGrpcErrorInfo;
 import io.grpc.ManagedChannel;
 import io.grpc.Server;
@@ -148,18 +148,33 @@ public class ClusterAdminOpsGrpcServiceImplTest {
 
   @Test
   public void testUpdateAdminTopicMetadataSuccess() {
-    UpdateAdminTopicMetadataGrpcResponse response =
-        UpdateAdminTopicMetadataGrpcResponse.newBuilder().setClusterName(TEST_CLUSTER).build();
+    AdminTopicGrpcMetadata.Builder adminTopicGrpcMetadataBuilder = AdminTopicGrpcMetadata.newBuilder()
+        .setClusterName(TEST_CLUSTER)
+        .setExecutionId(EXECUTION_ID)
+        .setOffset(100L)
+        .setUpstreamOffset(-1L);
+    AdminTopicMetadataGrpcResponse response =
+        AdminTopicMetadataGrpcResponse.newBuilder().setMetadata(adminTopicGrpcMetadataBuilder.build()).build();
     doReturn(response).when(requestHandler).updateAdminTopicMetadata(any(UpdateAdminTopicMetadataGrpcRequest.class));
     doReturn(true).when(accessManager).isAllowListUser(anyString(), any());
 
     UpdateAdminTopicMetadataGrpcRequest request = UpdateAdminTopicMetadataGrpcRequest.newBuilder()
-        .setMetadata(AdminTopicGrpcMetadata.newBuilder().setClusterName(TEST_CLUSTER).setExecutionId(EXECUTION_ID))
+        .setMetadata(
+            AdminTopicGrpcMetadata.newBuilder()
+                .setClusterName(TEST_CLUSTER)
+                .setExecutionId(EXECUTION_ID)
+                .setOffset(100L)
+                .setUpstreamOffset(-1L))
         .build();
 
-    UpdateAdminTopicMetadataGrpcResponse actualResponse = blockingStub.updateAdminTopicMetadata(request);
+    AdminTopicMetadataGrpcResponse actualResponse = blockingStub.updateAdminTopicMetadata(request);
     assertNotNull(actualResponse);
-    assertEquals(actualResponse.getClusterName(), TEST_CLUSTER);
+    assertEquals(actualResponse.getMetadata().getClusterName(), TEST_CLUSTER);
+    assertEquals(actualResponse.getMetadata().getExecutionId(), EXECUTION_ID);
+    assertEquals(actualResponse.getMetadata().getOffset(), 100L);
+    assertEquals(actualResponse.getMetadata().getUpstreamOffset(), -1L);
+    // Since store name is not provided in the request, no store name will be returned in the response
+    assertFalse(actualResponse.getMetadata().hasStoreName());
   }
 
   @Test

--- a/services/venice-controller/src/test/java/com/linkedin/venice/controller/server/AdminTopicMetadataRoutesTest.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/controller/server/AdminTopicMetadataRoutesTest.java
@@ -25,7 +25,6 @@ import com.linkedin.venice.protocols.controller.AdminTopicGrpcMetadata;
 import com.linkedin.venice.protocols.controller.AdminTopicMetadataGrpcRequest;
 import com.linkedin.venice.protocols.controller.AdminTopicMetadataGrpcResponse;
 import com.linkedin.venice.protocols.controller.UpdateAdminTopicMetadataGrpcRequest;
-import com.linkedin.venice.protocols.controller.UpdateAdminTopicMetadataGrpcResponse;
 import com.linkedin.venice.utils.ObjectMapperFactory;
 import java.security.cert.X509Certificate;
 import java.util.HashMap;
@@ -146,8 +145,12 @@ public class AdminTopicMetadataRoutesTest {
     when(request.queryParams(EXECUTION_ID)).thenReturn(String.valueOf(TEST_EXECUTION_ID));
     when(request.queryParams(STORE_NAME)).thenReturn(TEST_STORE);
 
-    UpdateAdminTopicMetadataGrpcResponse grpcResponse =
-        UpdateAdminTopicMetadataGrpcResponse.newBuilder().setClusterName(TEST_CLUSTER).setStoreName(TEST_STORE).build();
+    AdminTopicGrpcMetadata.Builder adminTopicGrpcMetadataBuilder = AdminTopicGrpcMetadata.newBuilder()
+        .setClusterName(TEST_CLUSTER)
+        .setStoreName(TEST_STORE)
+        .setExecutionId(TEST_EXECUTION_ID);
+    AdminTopicMetadataGrpcResponse grpcResponse =
+        AdminTopicMetadataGrpcResponse.newBuilder().setMetadata(adminTopicGrpcMetadataBuilder.build()).build();
 
     when(requestHandler.updateAdminTopicMetadata(any(UpdateAdminTopicMetadataGrpcRequest.class)))
         .thenReturn(grpcResponse);

--- a/services/venice-controller/src/test/java/com/linkedin/venice/controller/server/ClusterAdminOpsRequestHandlerTest.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/controller/server/ClusterAdminOpsRequestHandlerTest.java
@@ -24,7 +24,6 @@ import com.linkedin.venice.protocols.controller.AdminTopicMetadataGrpcResponse;
 import com.linkedin.venice.protocols.controller.LastSuccessfulAdminCommandExecutionGrpcRequest;
 import com.linkedin.venice.protocols.controller.LastSuccessfulAdminCommandExecutionGrpcResponse;
 import com.linkedin.venice.protocols.controller.UpdateAdminTopicMetadataGrpcRequest;
-import com.linkedin.venice.protocols.controller.UpdateAdminTopicMetadataGrpcResponse;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -198,10 +197,10 @@ public class ClusterAdminOpsRequestHandlerTest {
         .build();
     UpdateAdminTopicMetadataGrpcRequest request =
         UpdateAdminTopicMetadataGrpcRequest.newBuilder().setMetadata(metadata).build();
-    UpdateAdminTopicMetadataGrpcResponse response = handler.updateAdminTopicMetadata(request);
+    AdminTopicMetadataGrpcResponse response = handler.updateAdminTopicMetadata(request);
     assertNotNull(response);
-    assertEquals(response.getClusterName(), clusterName);
-    assertFalse(response.hasStoreName());
+    assertEquals(response.getMetadata().getClusterName(), clusterName);
+    assertFalse(response.getMetadata().hasStoreName());
 
     // Store name is provided
     metadata = AdminTopicGrpcMetadata.newBuilder()
@@ -212,22 +211,30 @@ public class ClusterAdminOpsRequestHandlerTest {
     request = UpdateAdminTopicMetadataGrpcRequest.newBuilder().setMetadata(metadata).build();
     response = handler.updateAdminTopicMetadata(request);
     assertNotNull(response);
-    assertEquals(response.getClusterName(), clusterName);
+    assertEquals(response.getMetadata().getClusterName(), clusterName);
   }
 
   @Test
-  public void testUpdateAdminTopicMetadataInvalidOffsets() {
+  public void testUpdateAdminTopicMetadataInvalidInputs() {
     String clusterName = "test-cluster";
     long executionId = 12345L;
 
-    AdminTopicGrpcMetadata metadata = AdminTopicGrpcMetadata.newBuilder()
+    // No execution id
+    AdminTopicGrpcMetadata metadata = AdminTopicGrpcMetadata.newBuilder().setClusterName(clusterName).build();
+    UpdateAdminTopicMetadataGrpcRequest request =
+        UpdateAdminTopicMetadataGrpcRequest.newBuilder().setMetadata(metadata).build();
+    Exception exception = expectThrows(VeniceException.class, () -> handler.updateAdminTopicMetadata(request));
+    assertTrue(exception.getMessage().contains("Execution id is required to update admin topic metadata"));
+
+    // Either offset or upstream offset is provided
+    metadata = AdminTopicGrpcMetadata.newBuilder()
         .setClusterName(clusterName)
         .setExecutionId(executionId)
         .setOffset(123L)
         .build();
-    UpdateAdminTopicMetadataGrpcRequest request =
+    UpdateAdminTopicMetadataGrpcRequest request1 =
         UpdateAdminTopicMetadataGrpcRequest.newBuilder().setMetadata(metadata).build();
-    Exception exception = expectThrows(VeniceException.class, () -> handler.updateAdminTopicMetadata(request));
+    exception = expectThrows(VeniceException.class, () -> handler.updateAdminTopicMetadata(request1));
     assertTrue(
         exception.getMessage().contains("Offsets must be provided to update cluster-level admin topic metadata"),
         "Actual message: " + exception.getMessage());


### PR DESCRIPTION
[admin-tool] Modify the response of updateAdminTopicMetadata

## Summary, imperative, start upper case, don't end with a period
Modify the response of updateAdminTopicMetadata to have more meaningful response and unify the response of APIs relating to `AdminTopicMetadata`.

Currently, there are 2 APIs related to `AdminTopicMetadata`: `getAdminTopicMetadata` and `updateAdminTopicMetadata`.
While `getAdminTopicMetadata` is returning metadata itself, `updateAdminTopicMetadata` only returns `clusterName` and `storeName`, even though we actually updating many metadata in this `updateAdminTopicMetadata` request.

To reflect better response, we will now return the metadata that we updating inside the response of `updateAdminTopicMetadata`.

This effort will also align with the upcoming API `updateAdminOperationProtocolVersion` in #1418, where we will return the admin operation version + cluster name inside the response.

In this PR, I make `executionId` as optional since `updateAdminOperationProtocolVersion` will also return `AdminTopicMetadataGrpcResponse` but execution id is not necessary inside the response. 

## How was this PR tested?
UTs

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.