### PR TITLE
[dvc][server] verifying discovered host connectivity before initiating blob transfer request

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/DaVinciBackend.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/DaVinciBackend.java
@@ -320,7 +320,8 @@ public class DaVinciBackend implements Closeable {
             aggVersionedBlobTransferStats,
             backendConfig.getRocksDBServerConfig().isRocksDBPlainTableFormatEnabled()
                 ? BlobTransferTableFormat.PLAIN_TABLE
-                : BlobTransferTableFormat.BLOCK_BASED_TABLE);
+                : BlobTransferTableFormat.BLOCK_BASED_TABLE,
+            backendConfig.getBlobTransferPeersConnectivityFreshnessInSeconds());
       } else {
         aggVersionedBlobTransferStats = null;
         blobTransferManager = null;

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/blobtransfer/BlobSnapshotManager.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/blobtransfer/BlobSnapshotManager.java
@@ -351,6 +351,16 @@ public class BlobSnapshotManager {
    * @return the metadata for the blob transfer request
    */
   public BlobTransferPartitionMetadata prepareMetadata(BlobTransferPayload blobTransferRequest) {
+    if (storageMetadataService == null || storeVersionStateSerializer == null) {
+      throw new VeniceException("StorageMetadataService or storeVersionStateSerializer is not initialized");
+    }
+
+    if (storageMetadataService.getStoreVersionState(blobTransferRequest.getTopicName()) == null
+        || storageMetadataService
+            .getLastOffset(blobTransferRequest.getTopicName(), blobTransferRequest.getPartition()) == null) {
+      throw new VeniceException("Cannot get store version state or offset record from storage metadata service.");
+    }
+
     // prepare metadata
     StoreVersionState storeVersionState =
         storageMetadataService.getStoreVersionState(blobTransferRequest.getTopicName());

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/blobtransfer/BlobTransferUtil.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/blobtransfer/BlobTransferUtil.java
@@ -40,7 +40,8 @@ public class BlobTransferUtil {
       int snapshotRetentionTimeInMin,
       int blobTransferMaxTimeoutInMin,
       AggVersionedBlobTransferStats aggVersionedBlobTransferStats,
-      BlobTransferUtils.BlobTransferTableFormat transferSnapshotTableFormat) {
+      BlobTransferUtils.BlobTransferTableFormat transferSnapshotTableFormat,
+      int peersConnectivityFreshnessInSeconds) {
     try {
       BlobSnapshotManager blobSnapshotManager = new BlobSnapshotManager(
           readOnlyStoreRepository,
@@ -51,7 +52,11 @@ public class BlobTransferUtil {
           transferSnapshotTableFormat);
       BlobTransferManager<Void> manager = new NettyP2PBlobTransferManager(
           new P2PBlobTransferService(p2pTransferServerPort, baseDir, blobTransferMaxTimeoutInMin, blobSnapshotManager),
-          new NettyFileTransferClient(p2pTransferClientPort, baseDir, storageMetadataService),
+          new NettyFileTransferClient(
+              p2pTransferClientPort,
+              baseDir,
+              storageMetadataService,
+              peersConnectivityFreshnessInSeconds),
           new DaVinciBlobFinder(clientConfig),
           baseDir,
           aggVersionedBlobTransferStats);
@@ -84,7 +89,8 @@ public class BlobTransferUtil {
       int snapshotRetentionTimeInMin,
       int blobTransferMaxTimeoutInMin,
       AggVersionedBlobTransferStats aggVersionedBlobTransferStats,
-      BlobTransferUtils.BlobTransferTableFormat transferSnapshotTableFormat) {
+      BlobTransferUtils.BlobTransferTableFormat transferSnapshotTableFormat,
+      int peersConnectivityFreshnessInSeconds) {
     try {
       BlobSnapshotManager blobSnapshotManager = new BlobSnapshotManager(
           readOnlyStoreRepository,
@@ -95,7 +101,11 @@ public class BlobTransferUtil {
           transferSnapshotTableFormat);
       BlobTransferManager<Void> manager = new NettyP2PBlobTransferManager(
           new P2PBlobTransferService(p2pTransferServerPort, baseDir, blobTransferMaxTimeoutInMin, blobSnapshotManager),
-          new NettyFileTransferClient(p2pTransferClientPort, baseDir, storageMetadataService),
+          new NettyFileTransferClient(
+              p2pTransferClientPort,
+              baseDir,
+              storageMetadataService,
+              peersConnectivityFreshnessInSeconds),
           new ServerBlobFinder(customizedViewFuture),
           baseDir,
           aggVersionedBlobTransferStats);

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/blobtransfer/NettyP2PBlobTransferManager.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/blobtransfer/NettyP2PBlobTransferManager.java
@@ -95,10 +95,10 @@ public class NettyP2PBlobTransferManager implements P2PBlobTransferManager<Void>
     }
 
     List<String> discoverPeers = response.getDiscoveryResult();
-    Set<String> uniqueConnectablePeers = getUniqueConnectableHosts(discoverPeers, storeName, version, partition);
+    Set<String> connectablePeers = getConnectableHosts(discoverPeers, storeName, version, partition);
 
     // 2: Process peers sequentially to fetch the blob
-    processPeersSequentially(uniqueConnectablePeers, storeName, version, partition, tableFormat, resultFuture);
+    processPeersSequentially(connectablePeers, storeName, version, partition, tableFormat, resultFuture);
 
     return resultFuture;
   }
@@ -252,18 +252,14 @@ public class NettyP2PBlobTransferManager implements P2PBlobTransferManager<Void>
   }
 
   /**
-   * Get the unique connectable hosts for the given storeName, version, and partition
+   * Get the connectable hosts for the given storeName, version, and partition
    * @param discoverPeers the list of discovered peers
    * @param storeName the name of the store
    * @param version the version of the store
    * @param partition the partition of the store
    * @return the set of unique connectable hosts
    */
-  private Set<String> getUniqueConnectableHosts(
-      List<String> discoverPeers,
-      String storeName,
-      int version,
-      int partition) {
+  private Set<String> getConnectableHosts(List<String> discoverPeers, String storeName, int version, int partition) {
     // Extract unique hosts from the discovered peers
     Set<String> uniquePeers = discoverPeers.stream().map(peer -> peer.split("_")[0]).collect(Collectors.toSet());
 
@@ -278,10 +274,6 @@ public class NettyP2PBlobTransferManager implements P2PBlobTransferManager<Void>
     // Get the connectable hosts for this store, version, and partition
     Set<String> connectablePeers =
         nettyClient.getConnectableHosts((HashSet<String>) uniquePeers, storeName, version, partition);
-
-    // Exclude the current host
-    String currentHost = Utils.getHostName();
-    connectablePeers.remove(currentHost);
 
     LOGGER.info(
         "Total {} unique connectable peers for store {} version {} partition {}, peers are {}",

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/blobtransfer/NettyP2PBlobTransferManager.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/blobtransfer/NettyP2PBlobTransferManager.java
@@ -17,9 +17,12 @@ import com.linkedin.venice.utils.Utils;
 import java.io.InputStream;
 import java.time.Duration;
 import java.time.Instant;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
+import java.util.stream.Collectors;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -92,11 +95,10 @@ public class NettyP2PBlobTransferManager implements P2PBlobTransferManager<Void>
     }
 
     List<String> discoverPeers = response.getDiscoveryResult();
-    LOGGER
-        .info("Discovered peers {} for store {} version {} partition {}", discoverPeers, storeName, version, partition);
+    Set<String> uniqueConnectablePeers = getUniqueConnectableHosts(discoverPeers, storeName, version, partition);
 
     // 2: Process peers sequentially to fetch the blob
-    processPeersSequentially(discoverPeers, storeName, version, partition, tableFormat, resultFuture);
+    processPeersSequentially(uniqueConnectablePeers, storeName, version, partition, tableFormat, resultFuture);
 
     return resultFuture;
   }
@@ -121,7 +123,7 @@ public class NettyP2PBlobTransferManager implements P2PBlobTransferManager<Void>
    *  - Success case:
    *  1. If the blob is successfully fetched from a peer, an InputStream of the blob is returned.
    *
-   * @param peers the list of peers to process
+   * @param uniqueConnectablePeers the set of peers to process
    * @param storeName the name of the store
    * @param version the version of the store
    * @param partition the partition of the store
@@ -129,7 +131,7 @@ public class NettyP2PBlobTransferManager implements P2PBlobTransferManager<Void>
    * @param resultFuture the future to complete with the InputStream of the blob
    */
   private void processPeersSequentially(
-      List<String> peers,
+      Set<String> uniqueConnectablePeers,
       String storeName,
       int version,
       int partition,
@@ -142,11 +144,9 @@ public class NettyP2PBlobTransferManager implements P2PBlobTransferManager<Void>
     CompletableFuture<Void> chainOfPeersFuture = CompletableFuture.completedFuture(null);
 
     // Iterate through each peer and chain the futures
-    for (int currentPeerIndex = 0; currentPeerIndex < peers.size(); currentPeerIndex++) {
-      final int peerIndex = currentPeerIndex;
+    for (String chosenHost: uniqueConnectablePeers) {
       // Chain the next operation to the previous future
       chainOfPeersFuture = chainOfPeersFuture.thenCompose(v -> {
-        String chosenHost = peers.get(peerIndex).split("_")[0];
 
         if (resultFuture.isDone()) {
           // If the result future is already completed, skip the current peer
@@ -154,7 +154,13 @@ public class NettyP2PBlobTransferManager implements P2PBlobTransferManager<Void>
         }
 
         // Attempt to fetch the blob from the current peer asynchronously
-        LOGGER.info("Attempting to connect to host: {}", chosenHost);
+        LOGGER.info(
+            "Attempting to connect to host: {} for store {} version {} partition {} table format {}",
+            chosenHost,
+            storeName,
+            version,
+            partition,
+            tableFormat);
 
         return nettyClient.get(chosenHost, storeName, version, partition, tableFormat)
             .toCompletableFuture()
@@ -243,5 +249,47 @@ public class NettyP2PBlobTransferManager implements P2PBlobTransferManager<Void>
           partition,
           e);
     }
+  }
+
+  /**
+   * Get the unique connectable hosts for the given storeName, version, and partition
+   * @param discoverPeers the list of discovered peers
+   * @param storeName the name of the store
+   * @param version the version of the store
+   * @param partition the partition of the store
+   * @return the set of unique connectable hosts
+   */
+  private Set<String> getUniqueConnectableHosts(
+      List<String> discoverPeers,
+      String storeName,
+      int version,
+      int partition) {
+    // Extract unique hosts from the discovered peers
+    Set<String> uniquePeers = discoverPeers.stream().map(peer -> peer.split("_")[0]).collect(Collectors.toSet());
+
+    LOGGER.info(
+        "Discovered {} unique peers store {} version {} partition {}, peers are {}",
+        uniquePeers.size(),
+        storeName,
+        version,
+        partition,
+        uniquePeers);
+
+    // Get the connectable hosts for this store, version, and partition
+    Set<String> connectablePeers =
+        nettyClient.getConnectableHosts((HashSet<String>) uniquePeers, storeName, version, partition);
+
+    // Exclude the current host
+    String currentHost = Utils.getHostName();
+    connectablePeers.remove(currentHost);
+
+    LOGGER.info(
+        "Total {} unique connectable peers for store {} version {} partition {}, peers are {}",
+        connectablePeers.size(),
+        storeName,
+        version,
+        partition,
+        connectablePeers);
+    return connectablePeers;
   }
 }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/blobtransfer/client/NettyFileTransferClient.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/blobtransfer/client/NettyFileTransferClient.java
@@ -203,6 +203,7 @@ public class NettyFileTransferClient {
   public void close() {
     workerGroup.shutdownGracefully();
     executorService.shutdown();
+    scheduledExecutorService.shutdown();
     unconnectableHosts.clear();
     connectedHosts.clear();
   }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/blobtransfer/client/NettyFileTransferClient.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/blobtransfer/client/NettyFileTransferClient.java
@@ -131,10 +131,23 @@ public class NettyFileTransferClient {
             channel.close(); // this is only for checking connectivity no need to open it.
             return host;
           } else {
+            LOGGER.warn(
+                "Failed to connect to host: {} for store {} version {} partition {}",
+                host,
+                storeName,
+                version,
+                partition);
             unconnectableHostsToTimestamp.put(host, System.currentTimeMillis());
             return null;
           }
         } catch (Exception e) {
+          LOGGER.warn(
+              "Failed to connect to host: {} for store {} version {} partition {}",
+              host,
+              storeName,
+              version,
+              partition,
+              e);
           unconnectableHostsToTimestamp.put(host, System.currentTimeMillis());
           return null;
         }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/blobtransfer/client/NettyFileTransferClient.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/blobtransfer/client/NettyFileTransferClient.java
@@ -113,7 +113,7 @@ public class NettyFileTransferClient {
     Iterator<String> discoveredHostsIterator = discoveredHosts.iterator();
     while (discoveredHostsIterator.hasNext()) {
       String host = discoveredHostsIterator.next();
-      if (connectedHostsToTimestamp.contains(host)) {
+      if (connectedHostsToTimestamp.containsKey(host)) {
         connectableHostsResult.add(host);
         discoveredHostsIterator.remove();
       }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/config/VeniceServerConfig.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/config/VeniceServerConfig.java
@@ -9,6 +9,7 @@ import static com.linkedin.venice.ConfigKeys.BLOB_TRANSFER_DISABLED_OFFSET_LAG_T
 import static com.linkedin.venice.ConfigKeys.BLOB_TRANSFER_MANAGER_ENABLED;
 import static com.linkedin.venice.ConfigKeys.BLOB_TRANSFER_MAX_CONCURRENT_SNAPSHOT_USER;
 import static com.linkedin.venice.ConfigKeys.BLOB_TRANSFER_MAX_TIMEOUT_IN_MIN;
+import static com.linkedin.venice.ConfigKeys.BLOB_TRANSFER_PEERS_CONNECTIVITY_FRESHNESS_IN_SECONDS;
 import static com.linkedin.venice.ConfigKeys.BLOB_TRANSFER_SNAPSHOT_RETENTION_TIME_IN_MIN;
 import static com.linkedin.venice.ConfigKeys.DATA_BASE_PATH;
 import static com.linkedin.venice.ConfigKeys.DAVINCI_P2P_BLOB_TRANSFER_CLIENT_PORT;
@@ -556,6 +557,7 @@ public class VeniceServerConfig extends VeniceClusterConfig {
   private final int snapshotRetentionTimeInMin;
   private final int maxConcurrentSnapshotUser;
   private final int blobTransferMaxTimeoutInMin;
+  private final int blobTransferPeersConnectivityFreshnessInSeconds;
   private final long blobTransferDisabledOffsetLagThreshold;
   private final int dvcP2pBlobTransferServerPort;
   private final int dvcP2pBlobTransferClientPort;
@@ -608,6 +610,8 @@ public class VeniceServerConfig extends VeniceClusterConfig {
     snapshotRetentionTimeInMin = serverProperties.getInt(BLOB_TRANSFER_SNAPSHOT_RETENTION_TIME_IN_MIN, 60);
     maxConcurrentSnapshotUser = serverProperties.getInt(BLOB_TRANSFER_MAX_CONCURRENT_SNAPSHOT_USER, 5);
     blobTransferMaxTimeoutInMin = serverProperties.getInt(BLOB_TRANSFER_MAX_TIMEOUT_IN_MIN, 60);
+    blobTransferPeersConnectivityFreshnessInSeconds =
+        serverProperties.getInt(BLOB_TRANSFER_PEERS_CONNECTIVITY_FRESHNESS_IN_SECONDS, 30);
     blobTransferDisabledOffsetLagThreshold =
         serverProperties.getLong(BLOB_TRANSFER_DISABLED_OFFSET_LAG_THRESHOLD, 100000L);
     dvcP2pBlobTransferServerPort = serverProperties.getInt(DAVINCI_P2P_BLOB_TRANSFER_SERVER_PORT, -1);
@@ -1105,6 +1109,10 @@ public class VeniceServerConfig extends VeniceClusterConfig {
 
   public int getBlobTransferMaxTimeoutInMin() {
     return blobTransferMaxTimeoutInMin;
+  }
+
+  public int getBlobTransferPeersConnectivityFreshnessInSeconds() {
+    return blobTransferPeersConnectivityFreshnessInSeconds;
   }
 
   public long getBlobTransferDisabledOffsetLagThreshold() {

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/blobtransfer/TestNettyP2PBlobTransferManager.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/blobtransfer/TestNettyP2PBlobTransferManager.java
@@ -84,7 +84,7 @@ public class TestNettyP2PBlobTransferManager {
 
     server =
         new P2PBlobTransferService(port, tmpSnapshotDir.toString(), blobTransferMaxTimeoutInMin, blobSnapshotManager);
-    client = Mockito.spy(new NettyFileTransferClient(port, tmpPartitionDir.toString(), storageMetadataService));
+    client = Mockito.spy(new NettyFileTransferClient(port, tmpPartitionDir.toString(), storageMetadataService, 30));
     finder = mock(BlobFinder.class);
 
     manager = new NettyP2PBlobTransferManager(server, client, finder, tmpPartitionDir.toString(), blobTransferStats);

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/blobtransfer/TestNettyP2PBlobTransferManager.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/blobtransfer/TestNettyP2PBlobTransferManager.java
@@ -273,12 +273,12 @@ public class TestNettyP2PBlobTransferManager {
     });
 
     // Verification:
-    // Verify that even has bad hosts in the list, it still finally uses good host to transfer the file
     Mockito.verify(client, Mockito.times(1))
         .get("localhost", TEST_STORE, TEST_VERSION, TEST_PARTITION, BlobTransferTableFormat.BLOCK_BASED_TABLE);
-    Mockito.verify(client, Mockito.times(1))
+    // Verify that bad hosts are not called to fetch the file as they are no longer connectable
+    Mockito.verify(client, Mockito.never())
         .get("badhost1", TEST_STORE, TEST_VERSION, TEST_PARTITION, BlobTransferTableFormat.BLOCK_BASED_TABLE);
-    Mockito.verify(client, Mockito.times(1))
+    Mockito.verify(client, Mockito.never())
         .get("badhost2", TEST_STORE, TEST_VERSION, TEST_PARTITION, BlobTransferTableFormat.BLOCK_BASED_TABLE);
 
     verifyFileTransferSuccess(expectOffsetRecord);
@@ -425,9 +425,9 @@ public class TestNettyP2PBlobTransferManager {
     Assert.assertTrue(Arrays.equals(Files.readAllBytes(file3), Files.readAllBytes(destFile3)));
 
     // Verify the metadata is retrieved
-    Mockito.verify(storageMetadataService, Mockito.times(1))
+    Mockito.verify(storageMetadataService, Mockito.times(2))
         .getLastOffset(TEST_STORE + "_v" + TEST_VERSION, TEST_PARTITION);
-    Mockito.verify(storageMetadataService, Mockito.times(1)).getStoreVersionState(TEST_STORE + "_v" + TEST_VERSION);
+    Mockito.verify(storageMetadataService, Mockito.times(2)).getStoreVersionState(TEST_STORE + "_v" + TEST_VERSION);
 
     // Verify the record is updated
     Mockito.verify(storageMetadataService, Mockito.times(1))

--- a/internal/venice-common/src/main/java/com/linkedin/venice/ConfigKeys.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/ConfigKeys.java
@@ -1827,6 +1827,10 @@ public class ConfigKeys {
   // this is a config to decide the max allowed offset lag to use kafka, even if the blob transfer is enable.
   public static final String BLOB_TRANSFER_DISABLED_OFFSET_LAG_THRESHOLD =
       "blob.transfer.disabled.offset.lag.threshold";
+  // This is a freshness in sec to measure the connectivity between the peers,
+  // if the connectivity is not fresh, then retry the connection.
+  public static final String BLOB_TRANSFER_PEERS_CONNECTIVITY_FRESHNESS_IN_SECONDS =
+      "blob.transfer.peers.connectivity.freshness.in.seconds";
 
   // Port used by peer-to-peer transfer service. It should be used by both server and client
   public static final String DAVINCI_P2P_BLOB_TRANSFER_SERVER_PORT = "davinci.p2p.blob.transfer.server.port";

--- a/services/venice-server/src/main/java/com/linkedin/venice/server/VeniceServer.java
+++ b/services/venice-server/src/main/java/com/linkedin/venice/server/VeniceServer.java
@@ -491,7 +491,8 @@ public class VeniceServer {
           aggVersionedBlobTransferStats,
           serverConfig.getRocksDBServerConfig().isRocksDBPlainTableFormatEnabled()
               ? BlobTransferTableFormat.PLAIN_TABLE
-              : BlobTransferTableFormat.BLOCK_BASED_TABLE);
+              : BlobTransferTableFormat.BLOCK_BASED_TABLE,
+          serverConfig.getBlobTransferPeersConnectivityFreshnessInSeconds());
     } else {
       aggVersionedBlobTransferStats = null;
       blobTransferManager = null;


### PR DESCRIPTION
## [dvc][server] verifying discovered host connectivity before initiating blob transfer request

During testing on the dark hosts, we observed a few issues:

1. Previously, the per-partition bootstrap process worked as follows: it finds peers (e.g., 1500+ peers) and attempts to connect to each one. If the connection is successful, it sends the bootstrap request; if the connection fails, it moves on to the next candidate host. 
When there are many partitions, such as 200, this results in 200 * 1500 connection attempts. This process is unnecessarily time-consuming (waiting time = reject response time * 200 * 1500). Some partitions share the same peer-finding results, leading to redundant connection attempts to unreachable hosts. To address this, this PR introduces two map (a connectable host map and an unconnectable host map) to avoid redundant reconnections. The connectivity status need to be within certain preset config, if exceed the freshness, Netty client will retry to check the connectivity. 

2. During testing, we encountered a case where a partition bootstrap thread stalled after sending the connection request. It was found that the sender had already sent a reject response for the connection, but the receiver did not receive this response at all. As a result, the thread continued waiting for a response, and the partition was never successfully bootstrapped, whether via blob transfer or Kafka ingestion. To resolve this, this PR introduces a timeout to ensure that if the blob transfer or host connection is not completed, the process will fall back to Kafka ingestion instead of waiting indefinitely.


## How was this PR tested?
Tested on dark hosts.

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [ ] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.