### PR TITLE
[admin-tool] Add gRPC endpoint for updateAdminOperationProtocolVersion

### DIFF
--- a/clients/venice-admin-tool/src/main/java/com/linkedin/venice/AdminTool.java
+++ b/clients/venice-admin-tool/src/main/java/com/linkedin/venice/AdminTool.java
@@ -3279,7 +3279,8 @@ public class AdminTool {
         getRequiredArgument(cmd, Arg.ADMIN_OPERATION_PROTOCOL_VERSION, Command.UPDATE_ADMIN_OPERATION_PROTOCOL_VERSION);
     long protocolVersion =
         Utils.parseLongFromString(protocolVersionInString, Arg.ADMIN_OPERATION_PROTOCOL_VERSION.name());
-    ControllerResponse response = controllerClient.updateAdminOperationProtocolVersion(clusterName, protocolVersion);
+    AdminTopicMetadataResponse response =
+        controllerClient.updateAdminOperationProtocolVersion(clusterName, protocolVersion);
     printObject(response);
   }
 

--- a/internal/venice-common/src/main/java/com/linkedin/venice/controllerapi/ControllerClient.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/controllerapi/ControllerClient.java
@@ -1351,7 +1351,7 @@ public class ControllerClient implements Closeable {
     return request(ControllerRoute.GET_ADMIN_TOPIC_METADATA, params, AdminTopicMetadataResponse.class);
   }
 
-  public ControllerResponse updateAdminTopicMetadata(
+  public AdminTopicMetadataResponse updateAdminTopicMetadata(
       long executionId,
       Optional<String> storeName,
       Optional<Long> offset,
@@ -1360,15 +1360,15 @@ public class ControllerClient implements Closeable {
         .add(NAME, storeName)
         .add(OFFSET, offset)
         .add(UPSTREAM_OFFSET, upstreamOffset);
-    return request(ControllerRoute.UPDATE_ADMIN_TOPIC_METADATA, params, ControllerResponse.class);
+    return request(ControllerRoute.UPDATE_ADMIN_TOPIC_METADATA, params, AdminTopicMetadataResponse.class);
   }
 
-  public ControllerResponse updateAdminOperationProtocolVersion(
+  public AdminTopicMetadataResponse updateAdminOperationProtocolVersion(
       String clusterName,
       Long adminOperationProtocolVersion) {
     QueryParams params =
         newParams().add(CLUSTER, clusterName).add(ADMIN_OPERATION_PROTOCOL_VERSION, adminOperationProtocolVersion);
-    return request(ControllerRoute.UPDATE_ADMIN_OPERATION_PROTOCOL_VERSION, params, ControllerResponse.class);
+    return request(ControllerRoute.UPDATE_ADMIN_OPERATION_PROTOCOL_VERSION, params, AdminTopicMetadataResponse.class);
   }
 
   public ControllerResponse deleteKafkaTopic(String topicName) {

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/grpc/server/ClusterAdminOpsGrpcServiceImpl.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/grpc/server/ClusterAdminOpsGrpcServiceImpl.java
@@ -15,6 +15,7 @@ import com.linkedin.venice.protocols.controller.AdminTopicMetadataGrpcResponse;
 import com.linkedin.venice.protocols.controller.ClusterAdminOpsGrpcServiceGrpc;
 import com.linkedin.venice.protocols.controller.LastSuccessfulAdminCommandExecutionGrpcRequest;
 import com.linkedin.venice.protocols.controller.LastSuccessfulAdminCommandExecutionGrpcResponse;
+import com.linkedin.venice.protocols.controller.UpdateAdminOperationProtocolVersionGrpcRequest;
 import com.linkedin.venice.protocols.controller.UpdateAdminTopicMetadataGrpcRequest;
 import io.grpc.Context;
 import io.grpc.stub.StreamObserver;
@@ -87,5 +88,18 @@ public class ClusterAdminOpsGrpcServiceImpl extends ClusterAdminOpsGrpcServiceIm
       }
       return requestHandler.updateAdminTopicMetadata(request);
     }, responseObserver, metadata.getClusterName(), metadata.hasStoreName() ? metadata.getStoreName() : null);
+  }
+
+  @Override
+  public void updateAdminOperationProtocolVersion(
+      UpdateAdminOperationProtocolVersionGrpcRequest request,
+      StreamObserver<AdminTopicMetadataGrpcResponse> responseObserver) {
+    LOGGER.debug("Received updateAdminOperationProtocolVersion request: {}", request);
+    ControllerGrpcServerUtils.handleRequest(
+        ClusterAdminOpsGrpcServiceGrpc.getUpdateAdminOperationProtocolVersionMethod(),
+        () -> requestHandler.updateAdminOperationProtocolVersion(request),
+        responseObserver,
+        request.getClusterName(),
+        null);
   }
 }

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/server/AdminSparkServer.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/server/AdminSparkServer.java
@@ -641,7 +641,8 @@ public class AdminSparkServer extends AbstractVeniceService {
         UPDATE_ADMIN_OPERATION_PROTOCOL_VERSION.getPath(),
         new VeniceParentControllerRegionStateHandler(
             admin,
-            adminTopicMetadataRoutes.updateAdminOperationProtocolVersion(admin)));
+            adminTopicMetadataRoutes
+                .updateAdminOperationProtocolVersion(admin, requestHandler.getClusterAdminOpsRequestHandler())));
     httpService.post(
         DELETE_KAFKA_TOPIC.getPath(),
         new VeniceParentControllerRegionStateHandler(admin, storesRoutes.deleteKafkaTopic(admin)));

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/server/ClusterAdminOpsRequestHandler.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/server/ClusterAdminOpsRequestHandler.java
@@ -153,15 +153,9 @@ public class ClusterAdminOpsRequestHandler {
   public AdminTopicMetadataGrpcResponse updateAdminOperationProtocolVersion(
       UpdateAdminOperationProtocolVersionGrpcRequest request) {
     String clusterName = request.getClusterName();
-    if (StringUtils.isBlank(clusterName)) {
-      throw new IllegalArgumentException("Cluster name is required for updating admin operation protocol version");
-    }
-
     long adminOperationProtocolVersion = request.getAdminOperationProtocolVersion();
-    if (adminOperationProtocolVersion == 0 || adminOperationProtocolVersion < -1) {
-      throw new IllegalArgumentException(
-          "Admin operation protocol version is required and must be -1 or greater than 0");
-    }
+    ControllerRequestParamValidator
+        .validateAdminOperationProtocolVersionRequest(clusterName, adminOperationProtocolVersion);
 
     LOGGER.info(
         "Updating admin operation protocol version for cluster: {} to version: {}",

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/server/ClusterAdminOpsRequestHandler.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/server/ClusterAdminOpsRequestHandler.java
@@ -14,6 +14,7 @@ import com.linkedin.venice.protocols.controller.AdminTopicMetadataGrpcRequest;
 import com.linkedin.venice.protocols.controller.AdminTopicMetadataGrpcResponse;
 import com.linkedin.venice.protocols.controller.LastSuccessfulAdminCommandExecutionGrpcRequest;
 import com.linkedin.venice.protocols.controller.LastSuccessfulAdminCommandExecutionGrpcResponse;
+import com.linkedin.venice.protocols.controller.UpdateAdminOperationProtocolVersionGrpcRequest;
 import com.linkedin.venice.protocols.controller.UpdateAdminTopicMetadataGrpcRequest;
 import com.linkedin.venice.utils.Pair;
 import java.util.Map;
@@ -147,5 +148,28 @@ public class ClusterAdminOpsRequestHandler {
     AdminTopicMetadataGrpcResponse.Builder responseBuilder =
         AdminTopicMetadataGrpcResponse.newBuilder().setMetadata(adminTopicGrpcMetadataBuilder.build());
     return responseBuilder.build();
+  }
+
+  public AdminTopicMetadataGrpcResponse updateAdminOperationProtocolVersion(
+      UpdateAdminOperationProtocolVersionGrpcRequest request) {
+    String clusterName = request.getClusterName();
+    if (StringUtils.isBlank(clusterName)) {
+      throw new IllegalArgumentException("Cluster name is required for updating admin operation protocol version");
+    }
+
+    long adminOperationProtocolVersion = request.getAdminOperationProtocolVersion();
+
+    LOGGER.info(
+        "Updating admin operation protocol version for cluster: {} to version: {}",
+        clusterName,
+        adminOperationProtocolVersion);
+
+    // TODO: Call the actual method to update the admin operation protocol version (#1418)
+    // admin.updateAdminOperationProtocolVersion(clusterName, adminOperationProtocolVersion);
+
+    AdminTopicGrpcMetadata.Builder adminMetadataBuilder = AdminTopicGrpcMetadata.newBuilder()
+        .setClusterName(clusterName)
+        .setAdminOperationProtocolVersion(adminOperationProtocolVersion);
+    return AdminTopicMetadataGrpcResponse.newBuilder().setMetadata(adminMetadataBuilder.build()).build();
   }
 }

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/server/ClusterAdminOpsRequestHandler.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/server/ClusterAdminOpsRequestHandler.java
@@ -164,8 +164,7 @@ public class ClusterAdminOpsRequestHandler {
         clusterName,
         adminOperationProtocolVersion);
 
-    // TODO: Call the actual method to update the admin operation protocol version (#1418)
-    // admin.updateAdminOperationProtocolVersion(clusterName, adminOperationProtocolVersion);
+    admin.updateAdminOperationProtocolVersion(clusterName, adminOperationProtocolVersion);
 
     AdminTopicGrpcMetadata.Builder adminMetadataBuilder = AdminTopicGrpcMetadata.newBuilder()
         .setClusterName(clusterName)

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/server/ClusterAdminOpsRequestHandler.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/server/ClusterAdminOpsRequestHandler.java
@@ -158,6 +158,10 @@ public class ClusterAdminOpsRequestHandler {
     }
 
     long adminOperationProtocolVersion = request.getAdminOperationProtocolVersion();
+    if (adminOperationProtocolVersion == 0 || adminOperationProtocolVersion < -1) {
+      throw new IllegalArgumentException(
+          "Admin operation protocol version is required and must be -1 or greater than 0");
+    }
 
     LOGGER.info(
         "Updating admin operation protocol version for cluster: {} to version: {}",

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/server/ControllerRequestParamValidator.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/server/ControllerRequestParamValidator.java
@@ -45,4 +45,14 @@ public class ControllerRequestParamValidator {
       throw new IllegalArgumentException("Admin command execution id with positive value is required");
     }
   }
+
+  public static void validateAdminOperationProtocolVersionRequest(String clusterName, long protocolVersion) {
+    if (StringUtils.isBlank(clusterName)) {
+      throw new IllegalArgumentException("Cluster name is required for updating admin operation protocol version");
+    }
+    if (protocolVersion == 0 || protocolVersion < -1) {
+      throw new IllegalArgumentException(
+          "Admin operation protocol version is required and must be -1 or greater than 0");
+    }
+  }
 }

--- a/services/venice-controller/src/test/java/com/linkedin/venice/controller/grpc/server/ClusterAdminOpsGrpcServiceImplTest.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/controller/grpc/server/ClusterAdminOpsGrpcServiceImplTest.java
@@ -25,6 +25,7 @@ import com.linkedin.venice.protocols.controller.ClusterAdminOpsGrpcServiceGrpc;
 import com.linkedin.venice.protocols.controller.ClusterAdminOpsGrpcServiceGrpc.ClusterAdminOpsGrpcServiceBlockingStub;
 import com.linkedin.venice.protocols.controller.LastSuccessfulAdminCommandExecutionGrpcRequest;
 import com.linkedin.venice.protocols.controller.LastSuccessfulAdminCommandExecutionGrpcResponse;
+import com.linkedin.venice.protocols.controller.UpdateAdminOperationProtocolVersionGrpcRequest;
 import com.linkedin.venice.protocols.controller.UpdateAdminTopicMetadataGrpcRequest;
 import com.linkedin.venice.protocols.controller.VeniceControllerGrpcErrorInfo;
 import io.grpc.ManagedChannel;
@@ -190,5 +191,26 @@ public class ClusterAdminOpsGrpcServiceImplTest {
     assertTrue(
         errorInfo.getErrorMessage().contains(ACL_CHECK_FAILURE_WARN_MESSAGE_PREFIX),
         "Actual error message: " + errorInfo.getErrorMessage());
+  }
+
+  @Test
+  public void testUpdateAdminOperationProtocolVersionSuccess() {
+    AdminTopicGrpcMetadata.Builder adminTopicGrpcMetadataBuilder =
+        AdminTopicGrpcMetadata.newBuilder().setClusterName(TEST_CLUSTER).setAdminOperationProtocolVersion(1L);
+    AdminTopicMetadataGrpcResponse response =
+        AdminTopicMetadataGrpcResponse.newBuilder().setMetadata(adminTopicGrpcMetadataBuilder.build()).build();
+    doReturn(response).when(requestHandler)
+        .updateAdminOperationProtocolVersion(any(UpdateAdminOperationProtocolVersionGrpcRequest.class));
+    doReturn(true).when(accessManager).isAllowListUser(anyString(), any());
+
+    UpdateAdminOperationProtocolVersionGrpcRequest request = UpdateAdminOperationProtocolVersionGrpcRequest.newBuilder()
+        .setClusterName(TEST_CLUSTER)
+        .setAdminOperationProtocolVersion(1L)
+        .build();
+
+    AdminTopicMetadataGrpcResponse actualResponse = blockingStub.updateAdminOperationProtocolVersion(request);
+    assertNotNull(actualResponse);
+    assertEquals(actualResponse.getMetadata().getClusterName(), TEST_CLUSTER);
+    assertEquals(actualResponse.getMetadata().getAdminOperationProtocolVersion(), 1L);
   }
 }

--- a/services/venice-controller/src/test/java/com/linkedin/venice/controller/server/ClusterAdminOpsRequestHandlerTest.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/controller/server/ClusterAdminOpsRequestHandlerTest.java
@@ -23,6 +23,7 @@ import com.linkedin.venice.protocols.controller.AdminTopicMetadataGrpcRequest;
 import com.linkedin.venice.protocols.controller.AdminTopicMetadataGrpcResponse;
 import com.linkedin.venice.protocols.controller.LastSuccessfulAdminCommandExecutionGrpcRequest;
 import com.linkedin.venice.protocols.controller.LastSuccessfulAdminCommandExecutionGrpcResponse;
+import com.linkedin.venice.protocols.controller.UpdateAdminOperationProtocolVersionGrpcRequest;
 import com.linkedin.venice.protocols.controller.UpdateAdminTopicMetadataGrpcRequest;
 import java.util.Collections;
 import java.util.HashMap;
@@ -264,5 +265,49 @@ public class ClusterAdminOpsRequestHandlerTest {
     assertTrue(
         exception.getMessage().contains("Updating offsets is not allowed for store-level admin topic metadata"),
         "Actual message: " + exception.getMessage());
+  }
+
+  @Test
+  public void testUpdateAdminOperationProtocolVersionSuccess() {
+    String clusterName = "test-cluster";
+    long version = 12345L;
+    UpdateAdminOperationProtocolVersionGrpcRequest request = UpdateAdminOperationProtocolVersionGrpcRequest.newBuilder()
+        .setClusterName(clusterName)
+        .setAdminOperationProtocolVersion(version)
+        .build();
+    AdminTopicMetadataGrpcResponse response = handler.updateAdminOperationProtocolVersion(request);
+
+    assertNotNull(response);
+    assertEquals(response.getMetadata().getClusterName(), clusterName);
+    assertEquals(response.getMetadata().getAdminOperationProtocolVersion(), version);
+  }
+
+  @Test
+  public void testUpdateAdminOperationProtocolVersionInvalidInputs() {
+    String clusterName = "test-cluster";
+    long version = 12345L;
+
+    // No cluster name
+    UpdateAdminOperationProtocolVersionGrpcRequest request1 =
+        UpdateAdminOperationProtocolVersionGrpcRequest.newBuilder()
+            .setClusterName("")
+            .setAdminOperationProtocolVersion(version)
+            .build();
+    Exception exception =
+        expectThrows(IllegalArgumentException.class, () -> handler.updateAdminOperationProtocolVersion(request1));
+    assertTrue(
+        exception.getMessage().contains("Cluster name is required for updating admin operation protocol version"));
+
+    // Invalid version
+    UpdateAdminOperationProtocolVersionGrpcRequest request2 =
+        UpdateAdminOperationProtocolVersionGrpcRequest.newBuilder()
+            .setClusterName(clusterName)
+            .setAdminOperationProtocolVersion(0)
+            .build();
+    exception =
+        expectThrows(IllegalArgumentException.class, () -> handler.updateAdminOperationProtocolVersion(request2));
+    assertTrue(
+        exception.getMessage()
+            .contains("Admin operation protocol version is required and must be -1 or greater than 0"));
   }
 }


### PR DESCRIPTION
## [admin-tool] Add gRPC endpoint for updateAdminOperationProtocolVersion
Within #1418, we have added the HTTP endpoint for --update-admin-operation-protocol-version in admin-tool to update admin operation protocol version, and we would do the same for gRPC endpoint.

## How was this PR tested?
CI
## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.