### PR TITLE
[changelog] Fix metadata refresh deadlock scenario

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/consumer/ChangelogClientConfig.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/consumer/ChangelogClientConfig.java
@@ -9,6 +9,7 @@ import org.apache.avro.specific.SpecificRecord;
 
 
 public class ChangelogClientConfig<T extends SpecificRecord> {
+  private Long metaDataRefreshIntervalInSeconds = 60L;
   private Properties consumerProperties;
   private SchemaReader schemaReader;
   private String viewName;
@@ -166,12 +167,12 @@ public class ChangelogClientConfig<T extends SpecificRecord> {
     return this.bootstrapFileSystemPath;
   }
 
-  public long getVersionSwapDetectionIntervalTimeInMs() {
+  public long getVersionSwapDetectionIntervalTimeInSeconds() {
     return versionSwapDetectionIntervalTimeInMs;
   }
 
-  public ChangelogClientConfig setVersionSwapDetectionIntervalTimeInMs(long intervalTimeInMs) {
-    this.versionSwapDetectionIntervalTimeInMs = intervalTimeInMs;
+  public ChangelogClientConfig setVersionSwapDetectionIntervalTimeInSeconds(long intervalTimeInSeconds) {
+    this.versionSwapDetectionIntervalTimeInMs = intervalTimeInSeconds;
     return this;
   }
 
@@ -216,7 +217,7 @@ public class ChangelogClientConfig<T extends SpecificRecord> {
         .setD2Client(config.getD2Client())
         .setControllerRequestRetryCount(config.getControllerRequestRetryCount())
         .setBootstrapFileSystemPath(config.getBootstrapFileSystemPath())
-        .setVersionSwapDetectionIntervalTimeInMs(config.getVersionSwapDetectionIntervalTimeInMs())
+        .setVersionSwapDetectionIntervalTimeInSeconds(config.getVersionSwapDetectionIntervalTimeInSeconds())
         .setRocksDBBlockCacheSizeInBytes(config.getRocksDBBlockCacheSizeInBytes())
         .setConsumerName(config.consumerName)
         .setDatabaseSyncBytesInterval(config.getDatabaseSyncBytesInterval())

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/consumer/ChangelogClientConfig.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/consumer/ChangelogClientConfig.java
@@ -24,7 +24,7 @@ public class ChangelogClientConfig<T extends SpecificRecord> {
   private int controllerRequestRetryCount;
 
   private String bootstrapFileSystemPath;
-  private long versionSwapDetectionIntervalTimeInMs = 600000L;
+  private long versionSwapDetectionIntervalTimeInSeconds = 60L;
 
   /**
    * This will be used in BootstrappingVeniceChangelogConsumer to determine when to sync updates with the underlying
@@ -167,11 +167,11 @@ public class ChangelogClientConfig<T extends SpecificRecord> {
   }
 
   public long getVersionSwapDetectionIntervalTimeInSeconds() {
-    return versionSwapDetectionIntervalTimeInMs;
+    return versionSwapDetectionIntervalTimeInSeconds;
   }
 
   public ChangelogClientConfig setVersionSwapDetectionIntervalTimeInSeconds(long intervalTimeInSeconds) {
-    this.versionSwapDetectionIntervalTimeInMs = intervalTimeInSeconds;
+    this.versionSwapDetectionIntervalTimeInSeconds = intervalTimeInSeconds;
     return this;
   }
 

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/consumer/ChangelogClientConfig.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/consumer/ChangelogClientConfig.java
@@ -9,7 +9,6 @@ import org.apache.avro.specific.SpecificRecord;
 
 
 public class ChangelogClientConfig<T extends SpecificRecord> {
-  private Long metaDataRefreshIntervalInSeconds = 60L;
   private Properties consumerProperties;
   private SchemaReader schemaReader;
   private String viewName;

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/consumer/VeniceAfterImageConsumerImpl.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/consumer/VeniceAfterImageConsumerImpl.java
@@ -1,7 +1,5 @@
 package com.linkedin.davinci.consumer;
 
-import com.linkedin.alpini.base.concurrency.Executors;
-import com.linkedin.alpini.base.concurrency.ScheduledExecutorService;
 import com.linkedin.davinci.repository.NativeMetadataRepositoryViewAdapter;
 import com.linkedin.venice.exceptions.VeniceException;
 import com.linkedin.venice.kafka.protocol.ControlMessage;
@@ -22,7 +20,6 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
-import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import org.apache.kafka.common.errors.UnknownTopicOrPartitionException;
 import org.apache.logging.log4j.LogManager;
@@ -31,14 +28,11 @@ import org.apache.logging.log4j.Logger;
 
 public class VeniceAfterImageConsumerImpl<K, V> extends VeniceChangelogConsumerImpl<K, V> {
   private static final Logger LOGGER = LogManager.getLogger(VeniceAfterImageConsumerImpl.class);
-  // 10 Minute default
-  protected long versionSwapDetectionIntervalTimeInMs;
   // This consumer is used to find EOP messages without impacting consumption by other subscriptions. It's only used
   // in the context of seeking to EOP in the event of the user calling that seek or a version push.
   // TODO: We shouldn't use this in the long run. Once the EOP position is queryable from venice and version
   // swap is produced to VT, then we should remove this as it's no longer needed.
   final private Lazy<VeniceChangelogConsumerImpl<K, V>> internalSeekConsumer;
-  private final ScheduledExecutorService versionSwapExecutorService = Executors.newSingleThreadScheduledExecutor();
   AtomicBoolean versionSwapThreadScheduled = new AtomicBoolean(false);
   private final VersionSwapDataChangeListener<K, V> versionSwapListener;
 
@@ -60,7 +54,6 @@ public class VeniceAfterImageConsumerImpl<K, V> extends VeniceChangelogConsumerI
       Lazy<VeniceChangelogConsumerImpl<K, V>> seekConsumer) {
     super(changelogClientConfig, consumer);
     internalSeekConsumer = seekConsumer;
-    versionSwapDetectionIntervalTimeInMs = changelogClientConfig.getVersionSwapDetectionIntervalTimeInMs();
     versionSwapListener = new VersionSwapDataChangeListener<K, V>(
         this,
         storeRepository,
@@ -74,8 +67,6 @@ public class VeniceAfterImageConsumerImpl<K, V> extends VeniceChangelogConsumerI
       return internalPoll(timeoutInMs, "");
     } catch (UnknownTopicOrPartitionException ex) {
       LOGGER.error("Caught unknown Topic exception, will attempt repair and retry: ", ex);
-      storeRepository.refresh();
-      versionSwapListener.handleStoreChanged(null);
       return internalPoll(timeoutInMs, "");
     }
   }
@@ -101,11 +92,6 @@ public class VeniceAfterImageConsumerImpl<K, V> extends VeniceChangelogConsumerI
     if (!versionSwapThreadScheduled.get()) {
       // schedule the version swap thread and set up the callback listener
       this.storeRepository.registerStoreDataChangedListener(versionSwapListener);
-      versionSwapExecutorService.scheduleAtFixedRate(
-          new VersionSwapDetectionThread(),
-          versionSwapDetectionIntervalTimeInMs,
-          versionSwapDetectionIntervalTimeInMs,
-          TimeUnit.MILLISECONDS);
       versionSwapThreadScheduled.set(true);
     }
     return super.subscribe(partitions);

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/consumer/VeniceAfterImageConsumerImpl.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/consumer/VeniceAfterImageConsumerImpl.java
@@ -192,15 +192,6 @@ public class VeniceAfterImageConsumerImpl<K, V> extends VeniceChangelogConsumerI
     return super.internalSeek(partitions, targetTopic, seekAction);
   }
 
-  private class VersionSwapDetectionThread implements Runnable {
-    @Override
-    public void run() {
-      // the purpose of this thread is to just keep polling just in case something goes wrong at time of the store
-      // repository change.
-      versionSwapListener.handleStoreChanged(null);
-    }
-  }
-
   @Override
   public void setStoreRepository(NativeMetadataRepositoryViewAdapter repository) {
     super.setStoreRepository(repository);

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/consumer/VeniceChangelogConsumerImpl.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/consumer/VeniceChangelogConsumerImpl.java
@@ -1,6 +1,6 @@
 package com.linkedin.davinci.consumer;
 
-import static com.linkedin.venice.ConfigKeys.*;
+import static com.linkedin.venice.ConfigKeys.CLIENT_SYSTEM_STORE_REPOSITORY_REFRESH_INTERVAL_SECONDS;
 import static com.linkedin.venice.kafka.protocol.enums.ControlMessageType.START_OF_SEGMENT;
 import static com.linkedin.venice.schema.rmd.RmdConstants.REPLICATION_CHECKPOINT_VECTOR_FIELD_POS;
 

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/consumer/VeniceChangelogConsumerImplTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/consumer/VeniceChangelogConsumerImplTest.java
@@ -219,7 +219,6 @@ public class VeniceChangelogConsumerImplTest {
         changelogClientConfig,
         mockPubSubConsumer,
         Lazy.of(() -> mockInternalSeekConsumer));
-    veniceChangelogConsumer.versionSwapDetectionIntervalTimeInMs = 1;
     NativeMetadataRepositoryViewAdapter mockRepository = mock(NativeMetadataRepositoryViewAdapter.class);
     Store store = mock(Store.class);
     Version mockVersion = new VersionImpl(storeName, 1, "foo");

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/consumer/TestChangelogConsumer.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/consumer/TestChangelogConsumer.java
@@ -558,26 +558,6 @@ public class TestChangelogConsumer {
       });
     }
 
-    // // Validate changed events for version 2.
-    // allChangeEvents.putAll(polledChangeEvents);
-    // polledChangeEvents.clear();
-    // // As records keys from VPJ start from 1, real-time produced records' key starts from 0, the message with key as
-    // 0
-    // // is new message.
-    // TestUtils.waitForNonDeterministicAssertion(10, TimeUnit.SECONDS, true, () -> {
-    // // poll enough to get through the empty push and the topic jump to RT.
-    // pollChangeEventsFromChangeCaptureConsumer(polledChangeEvents, veniceChangelogConsumer);
-    // pollChangeEventsFromChangeCaptureConsumer(polledChangeEvents, veniceChangelogConsumer);
-    // pollChangeEventsFromChangeCaptureConsumer(polledChangeEvents, veniceChangelogConsumer);
-    // String deleteWithRmdKey = Integer.toString(deleteWithRmdKeyIndex);
-    // String persistWithRmdKey = Integer.toString(deleteWithRmdKeyIndex + 1);
-    // Assert.assertNull(polledChangeEvents.get(deleteWithRmdKey));
-    // Assert.assertNotNull(polledChangeEvents.get(persistWithRmdKey));
-    // Assert.assertEquals(
-    // polledChangeEvents.get(persistWithRmdKey).getValue().getCurrentValue().toString(),
-    // "stream_" + persistWithRmdKey);
-    // });
-
     /**
      * Now we have store version v3.
      */
@@ -616,42 +596,6 @@ public class TestChangelogConsumer {
       runSamzaStreamJob(veniceProducer, storeName, mockTime, 10, 10, 20);
     }
 
-    // Validate changed events for version 3.
-
-    // TestUtils.waitForNonDeterministicAssertion(60, TimeUnit.SECONDS, true, () -> {
-    // pollChangeEventsFromChangeCaptureConsumer(polledChangeEvents, veniceChangelogConsumer);
-    // // Filter previous 21 messages.
-    // Assert.assertEquals(polledChangeEvents.size(), 1);
-    // });
-
-    // Drain the remaining events on version 3 and verify that we got everything. We don't verify the count
-    // because at this stage, the total events which will get polled will be determined by how far back the rewind
-    // managed to get (and test run duration might be variable)
-    // TestUtils.waitForNonDeterministicAssertion(10, TimeUnit.SECONDS, true, () -> {
-    // pollChangeEventsFromChangeCaptureConsumer(polledChangeEvents, veniceChangelogConsumer);
-    // pollChangeEventsFromChangeCaptureConsumer(polledChangeEvents, veniceChangelogConsumer);
-    // pollChangeEventsFromChangeCaptureConsumer(polledChangeEvents, veniceChangelogConsumer);
-    // for (int i = 20; i < 40; i++) {
-    // String key = Integer.toString(i);
-    // ChangeEvent<Utf8> changeEvent = polledChangeEvents.get(key).getValue();
-    // Assert.assertNotNull(changeEvent);
-    // Assert.assertNull(changeEvent.getPreviousValue());
-    // if (i < 30) {
-    // Assert.assertEquals(changeEvent.getCurrentValue().toString(), "stream_" + i);
-    // } else {
-    // Assert.assertNull(changeEvent.getCurrentValue());
-    // }
-    // }
-    // });
-    //
-    // allChangeEvents.putAll(polledChangeEvents);
-    // polledChangeEvents.clear();
-    //
-    // // This should get everything submitted to the CC topic on this version since the timestamp is before anything
-    // got
-    // // transmitted
-    // veniceChangelogConsumer.seekToTimestamp(timestamp);
-
     // test pause and resume
     veniceChangelogConsumer.pause();
     polledChangeEvents.clear();
@@ -661,12 +605,6 @@ public class TestChangelogConsumer {
     });
     veniceChangelogConsumer.resume();
 
-    // This should get everything submitted to the CC topic on this version since the timestamp is before anything got
-    // transmitted
-    // TestUtils.waitForNonDeterministicAssertion(5, TimeUnit.SECONDS, () -> {
-    // pollChangeEventsFromChangeCaptureConsumer(polledChangeEvents, veniceChangelogConsumer);
-    // Assert.assertEquals(polledChangeEvents.size(), 42);
-    // });
     allChangeEvents.putAll(polledChangeEvents);
     polledChangeEvents.clear();
 

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/consumer/TestChangelogConsumer.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/consumer/TestChangelogConsumer.java
@@ -191,7 +191,17 @@ public class TestChangelogConsumer {
         .setNativeReplicationEnabled(true)
         .setPartitionCount(3);
     MetricsRepository metricsRepository = new MetricsRepository();
-    ControllerClient controllerClient = createStoreForJob(clusterName, keySchemaStr, valueSchemaStr, props, storeParms);
+    ControllerClient setupControllerClient =
+        createStoreForJob(clusterName, keySchemaStr, valueSchemaStr, props, storeParms);
+
+    // This is a dumb check that we're doing just to make static analysis happy
+    TestUtils.waitForNonDeterministicAssertion(
+        5,
+        TimeUnit.SECONDS,
+        () -> Assert.assertEquals(setupControllerClient.getStore(storeName).getStore().getCurrentVersion(), 0));
+
+    ControllerClient controllerClient =
+        new ControllerClient(clusterName, childDatacenters.get(0).getControllerConnectString());
 
     // Write Records to the store for version v1, the push job will contain 100 records.
     TestWriteUtils.runPushJob("Run push job", props);

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/consumer/TestChangelogConsumer.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/consumer/TestChangelogConsumer.java
@@ -191,11 +191,7 @@ public class TestChangelogConsumer {
         .setNativeReplicationEnabled(true)
         .setPartitionCount(3);
     MetricsRepository metricsRepository = new MetricsRepository();
-    ControllerClient setupControllerClient =
-        createStoreForJob(clusterName, keySchemaStr, valueSchemaStr, props, storeParms);
-
-    ControllerClient controllerClient =
-        new ControllerClient(clusterName, childDatacenters.get(0).getControllerConnectString());
+    ControllerClient controllerClient = createStoreForJob(clusterName, keySchemaStr, valueSchemaStr, props, storeParms);
 
     // Write Records to the store for version v1, the push job will contain 100 records.
     TestWriteUtils.runPushJob("Run push job", props);


### PR DESCRIPTION
There exists a deadlocking race condition when a version swap happens. The version swap data change listener locks itself and then proceeds with the version swap on the consumer.  However, other function calls would also call refresh() on the metadata repository.  This in turn would trigger more callbacks on the data change listener.  In some scenarios, this can cause deadlocking.

This change makes sure that we no longer leverage manual refreshes and instead let the whole process get driven by the scheduled metadata refresh.  This also makes the refresh time configurable, and seems to speed up tests (yay!) as there were frequent retries on consuming events as we had to wait for the version swap to happen internally before we could consume the events we expected.

<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat], [protocol]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## Summary, imperative, start upper case, don't end with a period
<!--
Describe
- What changes to make and why you are making these changes.
- How are you going to achieve your goal.
- Describe what testings you have done, for example, performance testing etc.

If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

Resolves #XXX

## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [ ] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.