### PR TITLE
[server][dvc][vpj][controller] Add getPositionByTimestamp as a replacement for offsetForTime

### DIFF
--- a/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/adapter/kafka/consumer/ApacheKafkaConsumerAdapter.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/adapter/kafka/consumer/ApacheKafkaConsumerAdapter.java
@@ -344,7 +344,7 @@ public class ApacheKafkaConsumerAdapter implements PubSubConsumerAdapter {
 
   @Override
   public boolean hasSubscription(PubSubTopicPartition pubSubTopicPartition) {
-    pubSubTopicPartition = Objects.requireNonNull(pubSubTopicPartition, "PubSubTopicPartition cannot be null");
+    Objects.requireNonNull(pubSubTopicPartition, "PubSubTopicPartition cannot be null");
     String topic = pubSubTopicPartition.getPubSubTopic().getName();
     int partition = pubSubTopicPartition.getPartitionNumber();
     TopicPartition tp = new TopicPartition(topic, partition);
@@ -431,8 +431,8 @@ public class ApacheKafkaConsumerAdapter implements PubSubConsumerAdapter {
           new TopicPartition(pubSubTopicPartition.getTopicName(), pubSubTopicPartition.getPartitionNumber());
       Map<TopicPartition, OffsetAndTimestamp> topicPartitionOffsetMap =
           this.kafkaConsumer.offsetsForTimes(Collections.singletonMap(topicPartition, timestamp), timeout);
-      if (topicPartitionOffsetMap.isEmpty()) {
-        return -1L;
+      if (topicPartitionOffsetMap == null || topicPartitionOffsetMap.isEmpty()) {
+        return null;
       }
       OffsetAndTimestamp offsetAndTimestamp = topicPartitionOffsetMap.get(topicPartition);
       if (offsetAndTimestamp == null) {
@@ -460,8 +460,8 @@ public class ApacheKafkaConsumerAdapter implements PubSubConsumerAdapter {
           pubSubTopicPartition.getPartitionNumber());
       Map<TopicPartition, OffsetAndTimestamp> topicPartitionOffsetMap =
           this.kafkaConsumer.offsetsForTimes(Collections.singletonMap(topicPartition, timestamp));
-      if (topicPartitionOffsetMap.isEmpty()) {
-        return -1L;
+      if (topicPartitionOffsetMap == null || topicPartitionOffsetMap.isEmpty()) {
+        return null;
       }
       OffsetAndTimestamp offsetAndTimestamp = topicPartitionOffsetMap.get(topicPartition);
       if (offsetAndTimestamp == null) {
@@ -477,6 +477,27 @@ public class ApacheKafkaConsumerAdapter implements PubSubConsumerAdapter {
           "Failed to fetch offset for time: " + timestamp + " for: " + pubSubTopicPartition,
           e);
     }
+  }
+
+  @Override
+  public PubSubPosition getPositionByTimestamp(
+      PubSubTopicPartition pubSubTopicPartition,
+      long timestamp,
+      Duration timeout) {
+    Long offset = offsetForTime(pubSubTopicPartition, timestamp, timeout);
+    if (offset == null) {
+      return null;
+    }
+    return new ApacheKafkaOffsetPosition(offset);
+  }
+
+  @Override
+  public PubSubPosition getPositionByTimestamp(PubSubTopicPartition pubSubTopicPartition, long timestamp) {
+    Long offset = offsetForTime(pubSubTopicPartition, timestamp);
+    if (offset == null) {
+      return null;
+    }
+    return new ApacheKafkaOffsetPosition(offset);
   }
 
   @Override

--- a/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/api/PubSubConsumerAdapter.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/api/PubSubConsumerAdapter.java
@@ -185,12 +185,50 @@ public interface PubSubConsumerAdapter extends AutoCloseable, Closeable {
    *
    * @param pubSubTopicPartition The PubSub topic-partition for which to fetch the offset.
    * @param timestamp The target timestamp to search for in milliseconds since the Unix epoch.
+   * @param timeout The maximum duration to wait for the operation to complete.
+   * @return The offset of the first message with a timestamp greater than or equal to the target timestamp,
+   *         or {@code null} if no such message is found for the partition.
+   * @throws PubSubOpTimeoutException If the operation times out while fetching the offset.
+   * @throws PubSubClientException If there is an error while attempting to fetch the offset.
+   */
+  @UnderDevelopment("Under development and may change in the future.")
+  default PubSubPosition getPositionByTimestamp(
+      PubSubTopicPartition pubSubTopicPartition,
+      long timestamp,
+      Duration timeout) {
+    throw new UnsupportedOperationException("getPositionByTimestamp is not supported");
+  }
+
+  /**
+   * Retrieves the offset of the first message with a timestamp greater than or equal to the target
+   * timestamp for the specified PubSub topic-partition. If no such message is found, {@code null}
+   * will be returned for the partition.
+   *
+   * @param pubSubTopicPartition The PubSub topic-partition for which to fetch the offset.
+   * @param timestamp The target timestamp to search for in milliseconds since the Unix epoch.
    * @return The offset of the first message with a timestamp greater than or equal to the target timestamp,
    *         or {@code null} if no such message is found for the partition.
    * @throws PubSubOpTimeoutException If the operation times out while fetching the offset.
    * @throws PubSubClientException If there is an error while attempting to fetch the offset.
    */
   Long offsetForTime(PubSubTopicPartition pubSubTopicPartition, long timestamp);
+
+  /**
+   * Retrieves the offset of the first message with a timestamp greater than or equal to the target
+   * timestamp for the specified PubSub topic-partition. If no such message is found, {@code null}
+   * will be returned for the partition.
+   *
+   * @param pubSubTopicPartition The PubSub topic-partition for which to fetch the offset.
+   * @param timestamp The target timestamp to search for in milliseconds since the Unix epoch.
+   * @return The offset of the first message with a timestamp greater than or equal to the target timestamp,
+   *         or {@code null} if no such message is found for the partition.
+   * @throws PubSubOpTimeoutException If the operation times out while fetching the offset.
+   * @throws PubSubClientException If there is an error while attempting to fetch the offset.
+   */
+  @UnderDevelopment("Under development and may change in the future.")
+  default PubSubPosition getPositionByTimestamp(PubSubTopicPartition pubSubTopicPartition, long timestamp) {
+    throw new UnsupportedOperationException("getPositionByTimestamp is not supported");
+  }
 
   /**
    * Retrieves the beginning offset for the specified PubSub topic-partition.


### PR DESCRIPTION
## Add getPositionByTimestamp as a replacement for offsetForTime in PubSubConsumerAdapter

Introduced new default methods `getPositionByTimestamp` in `PubSubConsumerAdapter`  
to fetch offsets based on timestamps, returning a `PubSubPosition` object.  
This replaces the `offsetForTime` API, which previously returned a numeric offset.  


## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
UT/CI
## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.