### PR TITLE
[server] Add pool type information to Kafka consumer client ID

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/KafkaConsumerService.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/KafkaConsumerService.java
@@ -137,7 +137,7 @@ public abstract class KafkaConsumerService extends AbstractKafkaConsumerService 
       /**
        * We need to assign a unique client id across all the storage nodes, otherwise, they will fail into the same throttling bucket.
        */
-      consumerProperties.setProperty(KAFKA_CLIENT_ID_CONFIG, getUniqueClientId(kafkaUrl, i));
+      consumerProperties.setProperty(KAFKA_CLIENT_ID_CONFIG, getUniqueClientId(kafkaUrl, i, poolType));
       SharedKafkaConsumer pubSubConsumer = new SharedKafkaConsumer(
           pubSubConsumerAdapterFactory.create(
               new VeniceProperties(consumerProperties),
@@ -190,8 +190,8 @@ public abstract class KafkaConsumerService extends AbstractKafkaConsumerService 
       PubSubTopicPartition topicPartition) {
   }
 
-  private String getUniqueClientId(String kafkaUrl, int suffix) {
-    return Utils.getHostName() + "_" + kafkaUrl + "_" + suffix;
+  String getUniqueClientId(String kafkaUrl, int suffix, ConsumerPoolType poolType) {
+    return Utils.getHostName() + "_" + kafkaUrl + "_" + suffix + poolType.getStatSuffix();
   }
 
   @Override

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/KafkaConsumerServiceTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/KafkaConsumerServiceTest.java
@@ -94,7 +94,7 @@ public class KafkaConsumerServiceTest {
         ConsumerPoolType.REGULAR_POOL,
         factory,
         properties,
-        1000l,
+        1000L,
         2,
         mock(IngestionThrottler.class),
         mock(KafkaClusterBasedRecordThrottler.class),
@@ -419,6 +419,18 @@ public class KafkaConsumerServiceTest {
     Assert.assertNotEquals(consumerForT2P0, consumerForT2P1);
     Assert.assertEquals(consumerForT1P0, consumerForT1P2);
     Assert.assertEquals(consumerForT1P3, consumerForT2P1);
+  }
+
+  @Test
+  public void testGenerateConsumerId() {
+    String hostName = Utils.getHostName();
+    String kafkaUrl = "abc:1234";
+    int suffix = 3;
+    ConsumerPoolType poolType = ConsumerPoolType.SEP_RT_LEADER_POOL;
+    KafkaConsumerService consumerService = mock(KafkaConsumerService.class);
+    doCallRealMethod().when(consumerService).getUniqueClientId(anyString(), anyInt(), any());
+    String expectedResult = hostName + "_" + kafkaUrl + "_" + suffix + poolType.getStatSuffix();
+    Assert.assertEquals(consumerService.getUniqueClientId(kafkaUrl, suffix, poolType), expectedResult);
   }
 
   @Test


### PR DESCRIPTION
<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat], [protocol]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## [server] Add pool type information to Kafka consumer client ID
A simple fix for Kafka consumer ID generation.
Added the pool type so that different pool's consumer won't share same client ID.
This is helpful when debugging consumption with JMX.

## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
Added a new unit test
## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.