### PR TITLE
[server][dvc][vpj][controller] Add beginningPosition and endPosition(s) as replacements for beginningOffset and endOffset(s)

### DIFF
--- a/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/adapter/kafka/consumer/ApacheKafkaConsumerAdapter.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/adapter/kafka/consumer/ApacheKafkaConsumerAdapter.java
@@ -495,7 +495,7 @@ public class ApacheKafkaConsumerAdapter implements PubSubConsumerAdapter {
   @Override
   public PubSubPosition beginningPosition(PubSubTopicPartition pubSubTopicPartition, Duration timeout) {
     Long beginningOffset = beginningOffset(pubSubTopicPartition, timeout);
-    return beginningOffset != null ? new ApacheKafkaOffsetPosition(beginningOffset) : PubSubPosition.LATEST;
+    return beginningOffset != null ? new ApacheKafkaOffsetPosition(beginningOffset) : PubSubPosition.EARLIEST;
   }
 
   @Override

--- a/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/adapter/kafka/consumer/ApacheKafkaConsumerAdapter.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/adapter/kafka/consumer/ApacheKafkaConsumerAdapter.java
@@ -493,6 +493,12 @@ public class ApacheKafkaConsumerAdapter implements PubSubConsumerAdapter {
   }
 
   @Override
+  public PubSubPosition beginningPosition(PubSubTopicPartition pubSubTopicPartition, Duration timeout) {
+    Long beginningOffset = beginningOffset(pubSubTopicPartition, timeout);
+    return beginningOffset != null ? new ApacheKafkaOffsetPosition(beginningOffset) : PubSubPosition.LATEST;
+  }
+
+  @Override
   public Map<PubSubTopicPartition, Long> endOffsets(Collection<PubSubTopicPartition> partitions, Duration timeout) {
     Map<TopicPartition, PubSubTopicPartition> pubSubTopicPartitionMapping = new HashMap<>(partitions.size());
     for (PubSubTopicPartition pubSubTopicPartition: partitions) {
@@ -518,6 +524,20 @@ public class ApacheKafkaConsumerAdapter implements PubSubConsumerAdapter {
   }
 
   @Override
+  public Map<PubSubTopicPartition, PubSubPosition> endPositions(
+      Collection<PubSubTopicPartition> partitions,
+      Duration timeout) {
+    Map<PubSubTopicPartition, Long> endOffsets = endOffsets(partitions, timeout);
+    Map<PubSubTopicPartition, PubSubPosition> pubSubTopicPartitionOffsetMap = new HashMap<>(endOffsets.size());
+    for (Map.Entry<PubSubTopicPartition, Long> entry: endOffsets.entrySet()) {
+      PubSubPosition endPosition =
+          entry.getValue() != null ? new ApacheKafkaOffsetPosition(entry.getValue()) : PubSubPosition.LATEST;
+      pubSubTopicPartitionOffsetMap.put(entry.getKey(), endPosition);
+    }
+    return pubSubTopicPartitionOffsetMap;
+  }
+
+  @Override
   public Long endOffset(PubSubTopicPartition pubSubTopicPartition) {
     try {
       TopicPartition topicPartition = new TopicPartition(
@@ -535,6 +555,12 @@ public class ApacheKafkaConsumerAdapter implements PubSubConsumerAdapter {
     } catch (Exception e) {
       throw new PubSubClientException("Failed to fetch end offset for " + pubSubTopicPartition, e);
     }
+  }
+
+  @Override
+  public PubSubPosition endPosition(PubSubTopicPartition pubSubTopicPartition) {
+    Long endOffset = endOffset(pubSubTopicPartition);
+    return endOffset != null ? new ApacheKafkaOffsetPosition(endOffset) : PubSubPosition.LATEST;
   }
 
   /**

--- a/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/api/PubSubConsumerAdapter.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/api/PubSubConsumerAdapter.java
@@ -204,6 +204,11 @@ public interface PubSubConsumerAdapter extends AutoCloseable, Closeable {
    */
   Long beginningOffset(PubSubTopicPartition pubSubTopicPartition, Duration timeout);
 
+  @UnderDevelopment("This method is under development and may be subject to change.")
+  default PubSubPosition beginningPosition(PubSubTopicPartition pubSubTopicPartition, Duration timeout) {
+    throw new UnsupportedOperationException("beginningPosition is not supported");
+  }
+
   /**
    * Retrieves the end offsets for a collection of PubSub topic-partitions. The end offset represents
    * the highest offset available in each specified partition, i.e., offset of the last message + 1.
@@ -218,6 +223,13 @@ public interface PubSubConsumerAdapter extends AutoCloseable, Closeable {
    */
   Map<PubSubTopicPartition, Long> endOffsets(Collection<PubSubTopicPartition> partitions, Duration timeout);
 
+  @UnderDevelopment
+  default Map<PubSubTopicPartition, PubSubPosition> endPositions(
+      Collection<PubSubTopicPartition> partitions,
+      Duration timeout) {
+    throw new UnsupportedOperationException("endPositions is not supported");
+  }
+
   /**
    * Retrieves the end offset for the specified PubSub topic-partition. The end offset represents
    * the highest offset available in each specified partition, i.e., offset of the last message + 1.
@@ -229,6 +241,11 @@ public interface PubSubConsumerAdapter extends AutoCloseable, Closeable {
    * @throws PubSubClientException If there is an error while attempting to fetch the end offset.
    */
   Long endOffset(PubSubTopicPartition pubSubTopicPartition);
+
+  @UnderDevelopment
+  default PubSubPosition endPosition(PubSubTopicPartition pubSubTopicPartition) {
+    throw new UnsupportedOperationException("endPosition is not supported");
+  }
 
   /**
    * Retrieves the list of partitions associated with a given Pub-Sub topic.

--- a/internal/venice-common/src/test/java/com/linkedin/venice/pubsub/adapter/kafka/consumer/ApacheKafkaConsumerAdapterTest.java
+++ b/internal/venice-common/src/test/java/com/linkedin/venice/pubsub/adapter/kafka/consumer/ApacheKafkaConsumerAdapterTest.java
@@ -513,6 +513,12 @@ public class ApacheKafkaConsumerAdapterTest {
     assertNotNull(position);
     assertTrue(position instanceof ApacheKafkaOffsetPosition);
     assertEquals(((ApacheKafkaOffsetPosition) position).getOffset(), 0L);
+
+    // Case 2: return empty response
+    doReturn(Collections.emptyMap()).when(internalKafkaConsumer)
+        .beginningOffsets(Collections.singleton(topicPartition), Duration.ofMillis(500));
+    position = kafkaConsumerAdapter.beginningPosition(pubSubTopicPartition, Duration.ofMillis(500));
+    assertEquals(position, PubSubPosition.EARLIEST);
   }
 
   @Test
@@ -563,5 +569,11 @@ public class ApacheKafkaConsumerAdapterTest {
     assertNotNull(position);
     assertTrue(position instanceof ApacheKafkaOffsetPosition);
     assertEquals(((ApacheKafkaOffsetPosition) position).getOffset(), expectedOffset);
+
+    // Case 2: return empty response
+    doReturn(Collections.emptyMap()).when(internalKafkaConsumer)
+        .endOffsets(eq(Collections.singleton(topicPartition)), any(Duration.class));
+    position = kafkaConsumerAdapter.endPosition(pubSubTopicPartition);
+    assertEquals(position, PubSubPosition.LATEST);
   }
 }


### PR DESCRIPTION

<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat], [protocol]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## Add beginningPosition and endPosition(s) as replacements for beginningOffset and endOffset(s)

Introduced `beginningPosition` and `endPosition(s)` methods in `PubSubConsumerAdapter`  
to fetch positions (PubSubPosition` objects). These replace `beginningOffset` and `endOffset(s)`,  
which previously returned numeric offsets.  

## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
CI

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [X] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.