### PR TITLE
[admin-tool] Add store list filter to cluster-batch-task

### DIFF
--- a/clients/venice-admin-tool/src/main/java/com/linkedin/venice/Arg.java
+++ b/clients/venice-admin-tool/src/main/java/com/linkedin/venice/Arg.java
@@ -228,7 +228,10 @@ public enum Arg {
       "Type of system store to backfill. Supported types are davinci_push_status_store and meta_store"
   ), TASK_NAME("task-name", "tn", true, "Name of the task for cluster command. Supported command [PushSystemStore]."),
   CHECKPOINT_FILE("checkpoint-file", "cf", true, "Checkpoint file path for cluster command."),
-  THREAD_COUNT("thread-count", "tc", true, "Number of threads to execute. 1 if not specified"),
+  STORE_FILTER_FILE(
+      "store-filter-file", "sff", true,
+      "Store filter file path for cluster command. By default we will be performing cluster operation on the intersection of this file and stores in the cluster."
+  ), THREAD_COUNT("thread-count", "tc", true, "Number of threads to execute. 1 if not specified"),
   RETRY("retry", "r", false, "Retry this operation"),
   DISABLE_LOG("disable-log", "dl", false, "Disable logs from internal classes. Only print command output on console"),
   STORE_VIEW_CONFIGS(

--- a/clients/venice-admin-tool/src/main/java/com/linkedin/venice/Command.java
+++ b/clients/venice-admin-tool/src/main/java/com/linkedin/venice/Command.java
@@ -123,6 +123,7 @@ import static com.linkedin.venice.Arg.STORAGE_PERSONA;
 import static com.linkedin.venice.Arg.STORAGE_QUOTA;
 import static com.linkedin.venice.Arg.STORE;
 import static com.linkedin.venice.Arg.STORES;
+import static com.linkedin.venice.Arg.STORE_FILTER_FILE;
 import static com.linkedin.venice.Arg.STORE_SIZE;
 import static com.linkedin.venice.Arg.STORE_TYPE;
 import static com.linkedin.venice.Arg.STORE_VIEW_CONFIGS;
@@ -215,7 +216,7 @@ public enum Command {
   ),
   CLUSTER_BATCH_TASK(
       "cluster-batch-task", "Run specific task against all user stores in a cluster in parallel",
-      new Arg[] { URL, CLUSTER, TASK_NAME, CHECKPOINT_FILE }, new Arg[] { THREAD_COUNT }
+      new Arg[] { URL, CLUSTER, TASK_NAME, CHECKPOINT_FILE }, new Arg[] { THREAD_COUNT, STORE_FILTER_FILE }
   ),
   SET_VERSION(
       "set-version", "Set the version that will be served", new Arg[] { URL, STORE, VERSION }, new Arg[] { CLUSTER }


### PR DESCRIPTION
## [admin-tool] Add store list filter to cluster-batch-task

Add new optional parameter STORE_FILTER_FILE to CLUSTER_BATCH_TASK to perform cluster batch task only on the intersection of provided stores and stores in the cluster. This is useful when you have a list of problematic stores that you'd like to perform some repair on, e.g. re-push system store but instead of doing it to all stores in a cluster you can just run CLUSTER_BATCH_TASK with this store list for all clusters and it will only do what's necessary.

If needed in the future we can also add other set operations like complement. Which will do some operation on the stores in the cluster excluding stores in the provided filter file.

## How was this PR tested?
verified in test environment.

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [ ] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.