### PR TITLE
[server] Use correct offset when non-agg leader is resubscribing for workload change action

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/ActiveActiveStoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/ActiveActiveStoreIngestionTask.java
@@ -1533,7 +1533,7 @@ public class ActiveActiveStoreIngestionTask extends LeaderFollowerStoreIngestion
     syncConsumedUpstreamRTOffsetMapIfNeeded(partitionConsumptionState, leaderOffsetByKafkaURL);
 
     LOGGER.info(
-        "{}, as a leader, started consuming from topic {} partition {} with offset by Kafka URL mapping {}",
+        "{}, as a leader, started consuming from topic: {}, partition {}: with offset by Kafka URL mapping: {}",
         partitionConsumptionState.getReplicaId(),
         leaderTopic,
         partitionConsumptionState.getPartition(),

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTask.java
@@ -656,8 +656,8 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
              * results from drainer service to the DIV check validator that will be used in leader consumption thread
              */
             restoreProducerStatesForLeaderConsumption(partition);
+            startConsumingAsLeader(partitionConsumptionState);
 
-            startConsumingAsLeaderInTransitionFromStandby(partitionConsumptionState);
             /**
              * May adjust the underlying storage partition to optimize the ingestion performance.
              * Only adjust the underlying storage partition after batch portion as the compaction
@@ -868,14 +868,6 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
     return localVTOff + 1 >= localVTEndOffset;
   }
 
-  protected void startConsumingAsLeaderInTransitionFromStandby(PartitionConsumptionState partitionConsumptionState) {
-    if (partitionConsumptionState.getLeaderFollowerState() != IN_TRANSITION_FROM_STANDBY_TO_LEADER) {
-      throw new VeniceException(
-          String.format("Expect state %s but got %s", IN_TRANSITION_FROM_STANDBY_TO_LEADER, partitionConsumptionState));
-    }
-    startConsumingAsLeader(partitionConsumptionState);
-  }
-
   protected Map<String, Long> calculateLeaderUpstreamOffsetWithTopicSwitch(
       PartitionConsumptionState partitionConsumptionState,
       PubSubTopic newSourceTopic,
@@ -947,49 +939,14 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
       }
     }
 
-    Set<String> leaderSourceKafkaURLs = getConsumptionSourceKafkaAddress(partitionConsumptionState);
-    if (leaderSourceKafkaURLs.size() != 1) {
-      throw new VeniceException("In L/F mode, expect only one leader source Kafka URL. Got: " + leaderSourceKafkaURLs);
-    }
-
-    partitionConsumptionState.setLeaderFollowerState(LEADER);
     if (isDataRecovery && partitionConsumptionState.isBatchOnly() && partitionConsumptionState.consumeRemotely()) {
       // Batch-only store data recovery might consume from a previous version in remote colo.
       String dataRecoveryVersionTopic = Version.composeKafkaTopic(storeName, dataRecoverySourceVersionNumber);
       offsetRecord.setLeaderTopic(pubSubTopicRepository.getTopic(dataRecoveryVersionTopic));
     }
+    partitionConsumptionState.setLeaderFollowerState(LEADER);
     final PubSubTopic leaderTopic = offsetRecord.getLeaderTopic(pubSubTopicRepository);
-    final PubSubTopicPartition leaderTopicPartition = partitionConsumptionState.getSourceTopicPartition(leaderTopic);
-    long leaderStartOffset = partitionConsumptionState
-        .getLeaderOffset(OffsetRecord.NON_AA_REPLICATION_UPSTREAM_OFFSET_MAP_KEY, pubSubTopicRepository);
-    String leaderSourceKafkaURL = leaderSourceKafkaURLs.iterator().next();
-    if (leaderStartOffset < 0 && leaderTopic.isRealTime()) {
-      leaderStartOffset =
-          calculateLeaderUpstreamOffsetWithTopicSwitch(partitionConsumptionState, leaderTopic, Collections.emptyList())
-              .getOrDefault(OffsetRecord.NON_AA_REPLICATION_UPSTREAM_OFFSET_MAP_KEY, OffsetRecord.LOWEST_OFFSET);
-    }
-
-    // subscribe to the new upstream
-    LOGGER.info(
-        "Replica: {} has been promoted to the leader role for the partition. It will start consuming from: {} at offset: {} with the source Kafka URL: {}. Remote consumption flag: {}",
-        partitionConsumptionState.getReplicaId(),
-        leaderTopicPartition,
-        leaderStartOffset,
-        leaderSourceKafkaURL,
-        partitionConsumptionState.consumeRemotely());
-
-    consumerSubscribe(leaderTopic, partitionConsumptionState, leaderStartOffset, leaderSourceKafkaURL);
-
-    syncConsumedUpstreamRTOffsetMapIfNeeded(
-        partitionConsumptionState,
-        Collections.singletonMap(leaderSourceKafkaURL, leaderStartOffset));
-
-    LOGGER.info(
-        "The leader replica: {} started consuming from: {} at offset: {} url: {}",
-        partitionConsumptionState.getReplicaId(),
-        leaderTopicPartition,
-        leaderStartOffset,
-        leaderSourceKafkaURL);
+    prepareOffsetCheckpointAndStartConsumptionAsLeader(leaderTopic, partitionConsumptionState);
   }
 
   private boolean switchAwayFromStreamReprocessingTopic(PubSubTopic currentLeaderTopic, PubSubTopic topicSwitchTopic) {
@@ -1016,22 +973,6 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
     final PubSubTopicPartition newSourceTopicPartition =
         partitionConsumptionState.getSourceTopicPartition(newSourceTopic);
 
-    // Only use the latestProcessedUpstreamRTOffset if we are switching to the new topic from a VT topic or if we are
-    // switching to the same RT topic. The upstreamStartOffset won't be correct if we are already consuming from a RT
-    // topic. e.g. If we are already consuming from RT and would like to switch to some arbitrary topic.
-    boolean switchingToSameTopic = currentLeaderTopic.getName().equals(newSourceTopic.getName());
-    long upstreamStartOffset = switchingToSameTopic || currentLeaderTopic.isVersionTopic()
-        ? partitionConsumptionState
-            .getLatestProcessedUpstreamRTOffset(OffsetRecord.NON_AA_REPLICATION_UPSTREAM_OFFSET_MAP_KEY)
-        : OffsetRecord.LOWEST_OFFSET;
-    if (upstreamStartOffset < 0 && newSourceTopic.isRealTime()) {
-      upstreamStartOffset = calculateLeaderUpstreamOffsetWithTopicSwitch(
-          partitionConsumptionState,
-          newSourceTopic,
-          Collections.emptyList())
-              .getOrDefault(OffsetRecord.NON_AA_REPLICATION_UPSTREAM_OFFSET_MAP_KEY, OffsetRecord.LOWEST_OFFSET);
-    }
-
     // unsubscribe the old source and subscribe to the new source
     unsubscribeFromTopic(currentLeaderTopic, partitionConsumptionState);
     waitForLastLeaderPersistFuture(
@@ -1051,29 +992,48 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
           partitionConsumptionState.getReplicaId());
     }
     partitionConsumptionState.getOffsetRecord().setLeaderTopic(newSourceTopic);
+
+    prepareOffsetCheckpointAndStartConsumptionAsLeader(newSourceTopic, partitionConsumptionState);
+
+    // In case new topic is empty and leader can never become online
+    // TODO: Remove this once after AGG store migration.
+    maybeApplyReadyToServeCheck(partitionConsumptionState);
+  }
+
+  /**
+   * This method does a few things for leader topic-partition subscription:
+   * (1) Calculate Kafka URL to leader subscribe offset map.
+   * (2) Subscribe to all the Kafka upstream.
+   * (3) Potentially sync offset to PartitionConsumptionState map if needed.
+   */
+  void prepareOffsetCheckpointAndStartConsumptionAsLeader(
+      PubSubTopic leaderTopic,
+      PartitionConsumptionState partitionConsumptionState) {
+    Set<String> leaderSourceKafkaURLs = getConsumptionSourceKafkaAddress(partitionConsumptionState);
+    if (leaderSourceKafkaURLs.size() != 1) {
+      throw new VeniceException("In L/F mode, expect only one leader source Kafka URL. Got: " + leaderSourceKafkaURLs);
+    }
+    long upstreamStartOffset = partitionConsumptionState
+        .getLeaderOffset(OffsetRecord.NON_AA_REPLICATION_UPSTREAM_OFFSET_MAP_KEY, pubSubTopicRepository);
+    String leaderSourceKafkaURL = leaderSourceKafkaURLs.iterator().next();
+    if (upstreamStartOffset < 0 && leaderTopic.isRealTime()) {
+      upstreamStartOffset =
+          calculateLeaderUpstreamOffsetWithTopicSwitch(partitionConsumptionState, leaderTopic, Collections.emptyList())
+              .getOrDefault(OffsetRecord.NON_AA_REPLICATION_UPSTREAM_OFFSET_MAP_KEY, OffsetRecord.LOWEST_OFFSET);
+    }
     partitionConsumptionState.getOffsetRecord()
         .setLeaderUpstreamOffset(OffsetRecord.NON_AA_REPLICATION_UPSTREAM_OFFSET_MAP_KEY, upstreamStartOffset);
 
-    Set<String> sourceKafkaURLs = getConsumptionSourceKafkaAddress(partitionConsumptionState);
-    if (sourceKafkaURLs.size() != 1) {
-      throw new VeniceException("In L/F mode, expect only one leader source Kafka URL. Got: " + sourceKafkaURLs);
-    }
-    String sourceKafkaURL = sourceKafkaURLs.iterator().next();
-    consumerSubscribe(newSourceTopic, partitionConsumptionState, upstreamStartOffset, sourceKafkaURL);
-
+    consumerSubscribe(leaderTopic, partitionConsumptionState, upstreamStartOffset, leaderSourceKafkaURL);
     syncConsumedUpstreamRTOffsetMapIfNeeded(
         partitionConsumptionState,
-        Collections.singletonMap(sourceKafkaURL, upstreamStartOffset));
-
+        Collections.singletonMap(leaderSourceKafkaURL, upstreamStartOffset));
     LOGGER.info(
-        "Leader replica: {} successfully switched feed topic from: {} to: {} offset: {}",
+        "{}, as a leader, started consuming from topic {} partition {} with offset by Kafka URL {}",
         partitionConsumptionState.getReplicaId(),
-        currentLeaderTopic,
-        newSourceTopic,
+        leaderTopic,
+        partitionConsumptionState.getPartition(),
         upstreamStartOffset);
-
-    // In case new topic is empty and leader can never become online
-    maybeApplyReadyToServeCheck(partitionConsumptionState);
   }
 
   protected void syncConsumedUpstreamRTOffsetMapIfNeeded(
@@ -3956,18 +3916,7 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
     LOGGER.info(
         "Leader replica: {} unsubscribe finished for future resubscribe.",
         partitionConsumptionState.getReplicaId());
-    Set<String> leaderSourceKafkaURLs = getConsumptionSourceKafkaAddress(partitionConsumptionState);
-    for (String leaderSourceKafkaURL: leaderSourceKafkaURLs) {
-      String upstreamOffsetKey = isActiveActiveReplicationEnabled()
-          ? leaderSourceKafkaURL
-          : OffsetRecord.NON_AA_REPLICATION_UPSTREAM_OFFSET_MAP_KEY;
-      long leaderStartOffset = partitionConsumptionState.getLeaderOffset(upstreamOffsetKey, getPubSubTopicRepository());
-      consumerSubscribe(leaderTopic, partitionConsumptionState, leaderStartOffset, leaderSourceKafkaURL);
-      LOGGER.info(
-          "Leader replica: {} resubscribe to offset: {}",
-          partitionConsumptionState.getReplicaId(),
-          leaderStartOffset);
-    }
+    prepareOffsetCheckpointAndStartConsumptionAsLeader(leaderTopic, partitionConsumptionState);
   }
 
   protected void queueUpVersionTopicWritesWithViewWriters(

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTask.java
@@ -3947,7 +3947,7 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
 
   protected void resubscribeAsLeader(PartitionConsumptionState partitionConsumptionState) throws InterruptedException {
     OffsetRecord offsetRecord = partitionConsumptionState.getOffsetRecord();
-    PubSubTopic leaderTopic = offsetRecord.getLeaderTopic(pubSubTopicRepository);
+    PubSubTopic leaderTopic = offsetRecord.getLeaderTopic(getPubSubTopicRepository());
     int partition = partitionConsumptionState.getPartition();
     unsubscribeFromTopic(leaderTopic, partitionConsumptionState);
     waitForAllMessageToBeProcessedFromTopicPartition(
@@ -3958,7 +3958,10 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
         partitionConsumptionState.getReplicaId());
     Set<String> leaderSourceKafkaURLs = getConsumptionSourceKafkaAddress(partitionConsumptionState);
     for (String leaderSourceKafkaURL: leaderSourceKafkaURLs) {
-      long leaderStartOffset = partitionConsumptionState.getLeaderOffset(leaderSourceKafkaURL, pubSubTopicRepository);
+      String upstreamOffsetKey = isActiveActiveReplicationEnabled()
+          ? leaderSourceKafkaURL
+          : OffsetRecord.NON_AA_REPLICATION_UPSTREAM_OFFSET_MAP_KEY;
+      long leaderStartOffset = partitionConsumptionState.getLeaderOffset(upstreamOffsetKey, getPubSubTopicRepository());
       consumerSubscribe(leaderTopic, partitionConsumptionState, leaderStartOffset, leaderSourceKafkaURL);
       LOGGER.info(
           "Leader replica: {} resubscribe to offset: {}",

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTask.java
@@ -1029,7 +1029,7 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
         partitionConsumptionState,
         Collections.singletonMap(leaderSourceKafkaURL, upstreamStartOffset));
     LOGGER.info(
-        "{}, as a leader, started consuming from topic {} partition {} with offset by Kafka URL {}",
+        "{}, as a leader, started consuming from topic: {}, partition: {} with offset: {}",
         partitionConsumptionState.getReplicaId(),
         leaderTopic,
         partitionConsumptionState.getPartition(),

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/PartitionConsumptionState.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/PartitionConsumptionState.java
@@ -761,7 +761,7 @@ public class PartitionConsumptionState {
   }
 
   public long getLatestProcessedUpstreamRTOffset(String kafkaUrl) {
-    long latestProcessedUpstreamRTOffset = latestProcessedUpstreamRTOffsetMap.getOrDefault(kafkaUrl, -1L);
+    long latestProcessedUpstreamRTOffset = getLatestProcessedUpstreamRTOffsetMap().getOrDefault(kafkaUrl, -1L);
     if (latestProcessedUpstreamRTOffset < 0) {
       /**
        * When processing {@link TopicSwitch} control message, only the checkpoint upstream offset maps in {@link OffsetRecord}
@@ -793,7 +793,7 @@ public class PartitionConsumptionState {
    *    on whether the remote consumption flag is on.
    */
   public long getLeaderOffset(String kafkaURL, PubSubTopicRepository pubSubTopicRepository) {
-    PubSubTopic leaderTopic = offsetRecord.getLeaderTopic(pubSubTopicRepository);
+    PubSubTopic leaderTopic = getOffsetRecord().getLeaderTopic(pubSubTopicRepository);
     if (leaderTopic != null && !leaderTopic.isVersionTopic()) {
       return getLatestProcessedUpstreamRTOffset(kafkaURL);
     } else {

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
@@ -3620,7 +3620,7 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
    * This method unsubscribes topic-partition from the input.
    * If it is real-time topic and separate RT topic is enabled, it will also unsubscribe from separate real-time topic.
    */
-  public void unsubscribeFromTopic(PubSubTopic topic, PartitionConsumptionState partitionConsumptionState) {
+  protected void unsubscribeFromTopic(PubSubTopic topic, PartitionConsumptionState partitionConsumptionState) {
     consumerUnSubscribeForStateTransition(topic, partitionConsumptionState);
     if (isSeparatedRealtimeTopicEnabled() && topic.isRealTime()) {
       PubSubTopic separateRealTimeTopic =

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTaskTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTaskTest.java
@@ -3892,7 +3892,7 @@ public abstract class StoreIngestionTaskTest {
     doReturn(1000L).when(mockPcs).getLeaderOffset(anyString(), any());
     doReturn(mockOffsetRecord).when(mockPcs).getOffsetRecord();
     // Test whether consumedUpstreamRTOffsetMap is updated when leader subscribes to RT after state transition
-    ingestionTask.startConsumingAsLeaderInTransitionFromStandby(mockPcs);
+    ingestionTask.startConsumingAsLeader(mockPcs);
     verify(mockPcs, times(1)).updateLeaderConsumedUpstreamRTOffset(
         eq(aaConfig == AA_ON ? "localhost" : OffsetRecord.NON_AA_REPLICATION_UPSTREAM_OFFSET_MAP_KEY),
         eq(1000L));

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTaskTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTaskTest.java
@@ -5585,8 +5585,10 @@ public abstract class StoreIngestionTaskTest {
 
   @Test(dataProvider = "True-and-False", dataProviderClass = DataProviderUtils.class)
   public void testResubscribeAsLeader(boolean aaEnabled) throws InterruptedException {
-    LeaderFollowerStoreIngestionTask ingestionTask = mock(LeaderFollowerStoreIngestionTask.class);
+    LeaderFollowerStoreIngestionTask ingestionTask =
+        aaEnabled ? mock(ActiveActiveStoreIngestionTask.class) : mock(LeaderFollowerStoreIngestionTask.class);
     doCallRealMethod().when(ingestionTask).resubscribeAsLeader(any());
+    doCallRealMethod().when(ingestionTask).prepareOffsetCheckpointAndStartConsumptionAsLeader(any(), any());
     PubSubTopicRepository topicRepository = new PubSubTopicRepository();
     when(ingestionTask.getPubSubTopicRepository()).thenReturn(topicRepository);
     OffsetRecord offsetRecord = mock(OffsetRecord.class);

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTaskTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTaskTest.java
@@ -3904,6 +3904,7 @@ public abstract class StoreIngestionTaskTest {
       doReturn(topicSwitchWrapper).when(mock).getTopicSwitch();
       OffsetRecord mockOR = mock(OffsetRecord.class);
       doReturn(rtTopic).when(mockOR).getLeaderTopic(any());
+      doReturn(1000L).when(mock).getLeaderOffset(anyString(), any());
       System.out.println(mockOR.getLeaderTopic(null));
       doReturn(1000L).when(mockOR).getUpstreamOffset(anyString());
       if (aaConfig == AA_ON) {
@@ -3926,6 +3927,8 @@ public abstract class StoreIngestionTaskTest {
     // Test alternative branch of the code
     Supplier<PartitionConsumptionState> mockPcsSupplier2 = () -> {
       PartitionConsumptionState mock = mockPcsSupplier.get();
+      doReturn(-1L).when(mock).getLeaderOffset(anyString(), any());
+
       if (aaConfig == AA_ON) {
         doReturn(-1L).when(mock).getLatestProcessedUpstreamRTOffsetWithNoDefault(anyString());
       } else {


### PR DESCRIPTION

<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat], [protocol]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## [server] Use correct offset when non-agg leader is resubscribing for workload change action
In Non-Aggregate mode, we reserve special keyword for upstream offset map. During resubscribe as leader action, current code does not look for correct key in the map, and resubscribe to the beginning of the RT topic during pool jump. This will result in a spike in leader HB delay, and a lot of duplicate messages (skipped).
This PR fixes it by using the correct key for upstream offset based on SIT mode.

## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
Added new unit test and integration test to cover this fix.

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.