### PR TITLE
[changelog][client] Some clean up and bug fixes in CDC

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/consumer/VeniceAfterImageConsumerImpl.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/consumer/VeniceAfterImageConsumerImpl.java
@@ -139,12 +139,7 @@ public class VeniceAfterImageConsumerImpl<K, V> extends VeniceChangelogConsumerI
             int counter = 0;
             while (true) {
               counter++;
-              if (counter > 500) {
-                LOGGER.info("This is taking a while.....");
-              }
-              LOGGER.info("POLLING " + consumerAdapter.getAssignment().toString());
               polledResults = consumerAdapter.poll(5000L);
-              LOGGER.info("POLLED");
               // Loop through all polled messages
               for (Map.Entry<PubSubTopicPartition, List<PubSubMessage<KafkaKey, KafkaMessageEnvelope, Long>>> entry: polledResults
                   .entrySet()) {

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/consumer/VeniceChangelogConsumerImpl.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/consumer/VeniceChangelogConsumerImpl.java
@@ -398,7 +398,7 @@ public class VeniceChangelogConsumerImpl<K, V> implements VeniceChangelogConsume
     });
   }
 
-  private PubSubTopic getCurrentServingVersionTopic() {
+  protected PubSubTopic getCurrentServingVersionTopic() {
     Store store = storeRepository.getStore(storeName);
     int currentVersion = store.getCurrentVersion();
     if (changelogClientConfig.getViewName() == null || changelogClientConfig.getViewName().isEmpty()) {
@@ -1141,10 +1141,9 @@ public class VeniceChangelogConsumerImpl<K, V> implements VeniceChangelogConsume
 
       Iterator<Map.Entry<Integer, Long>> heartbeatIterator = currentVersionLastHeartbeat.entrySet().iterator();
       while (heartbeatIterator.hasNext()) {
-        changeCaptureStats.recordLag(System.currentTimeMillis() - heartbeatIterator.next().getValue());
+        Long lag = System.currentTimeMillis() - heartbeatIterator.next().getValue();
+        changeCaptureStats.recordLag(lag);
       }
-
-      currentVersionLastHeartbeat.forEachValue(1, changeCaptureStats::recordLag);
 
       int maxVersion = -1;
       int minVersion = Integer.MAX_VALUE;

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/consumer/VeniceChangelogConsumerImplTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/consumer/VeniceChangelogConsumerImplTest.java
@@ -203,7 +203,8 @@ public class VeniceChangelogConsumerImplTest {
     ChangelogClientConfig changelogClientConfig = getChangelogClientConfig(d2ControllerClient).setViewName("");
 
     VeniceChangelogConsumerImpl mockInternalSeekConsumer = Mockito.mock(VeniceChangelogConsumerImpl.class);
-    Mockito.when(mockInternalSeekConsumer.subscribe(any())).thenReturn(CompletableFuture.completedFuture(null));
+    Mockito.when(mockInternalSeekConsumer.internalSubscribe(any(), any()))
+        .thenReturn(CompletableFuture.completedFuture(null));
     Mockito.when(mockInternalSeekConsumer.getPubSubConsumer()).thenReturn(mockPubSubConsumer);
     prepareChangeCaptureRecordsToBePolled(
         0L,
@@ -244,7 +245,7 @@ public class VeniceChangelogConsumerImplTest {
 
     veniceChangelogConsumer.seekToEndOfPush(partitionSet).get();
 
-    Mockito.verify(mockInternalSeekConsumer).subscribe(partitionSet);
+    Mockito.verify(mockInternalSeekConsumer).internalSubscribe(partitionSet, oldVersionTopic);
     Mockito.verify(mockInternalSeekConsumer).unsubscribe(partitionSet);
     PubSubTopicPartition pubSubTopicPartition = new PubSubTopicPartitionImpl(oldVersionTopic, 0);
     Mockito.verify(mockPubSubConsumer).subscribe(pubSubTopicPartition, 10);
@@ -431,14 +432,19 @@ public class VeniceChangelogConsumerImplTest {
     String storeName = "Leppalúði_store";
 
     NativeMetadataRepositoryViewAdapter mockRepository = Mockito.mock(NativeMetadataRepositoryViewAdapter.class);
+
+    Version mockVersion = Mockito.mock(Version.class);
+    Mockito.when(mockVersion.kafkaTopicName()).thenReturn(storeName + "_v5");
+
     Store mockStore = Mockito.mock(Store.class);
     Mockito.when(mockStore.getCurrentVersion()).thenReturn(5);
     Mockito.when(mockRepository.getStore(storeName)).thenReturn(mockStore);
+    Mockito.when(mockStore.getVersion(5)).thenReturn(mockVersion);
 
     VersionSwapDataChangeListener changeListener =
         new VersionSwapDataChangeListener(mockConsumer, mockRepository, storeName, "");
-    changeListener.handleStoreChanged(null);
-    Mockito.verify(mockConsumer).seekToEndOfPush(Mockito.anySet());
+    changeListener.handleStoreChanged(mockStore);
+    Mockito.verify(mockConsumer).internalSeekToEndOfPush(Mockito.anySet(), Mockito.any());
 
   }
 

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/consumer/VeniceChangelogConsumerImplTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/consumer/VeniceChangelogConsumerImplTest.java
@@ -427,7 +427,8 @@ public class VeniceChangelogConsumerImplTest {
     Set<PubSubTopicPartition> topicPartitionSet = new HashSet<>();
     topicPartitionSet.add(topicPartition);
     Mockito.when(mockConsumer.getTopicAssignment()).thenReturn(topicPartitionSet);
-    Mockito.when(mockConsumer.seekToEndOfPush(Mockito.anySet())).thenReturn(CompletableFuture.completedFuture(null));
+    Mockito.when(mockConsumer.internalSeekToEndOfPush(Mockito.anySet(), Mockito.any()))
+        .thenReturn(CompletableFuture.completedFuture(null));
 
     String storeName = "Leppalúði_store";
 

--- a/internal/venice-client-common/src/main/java/com/linkedin/venice/schema/rmd/RmdUtils.java
+++ b/internal/venice-client-common/src/main/java/com/linkedin/venice/schema/rmd/RmdUtils.java
@@ -97,6 +97,8 @@ public class RmdUtils {
       }
       if (advancedOffset.get(i) < baseOffset.get(i)) {
         return false;
+      } else if (advancedOffset.get(i) > baseOffset.get(i)) {
+        return true;
       }
     }
     return true;

--- a/internal/venice-client-common/src/test/java/com/linkedin/venice/schema/rmd/TestRmdUtils.java
+++ b/internal/venice-client-common/src/test/java/com/linkedin/venice/schema/rmd/TestRmdUtils.java
@@ -78,8 +78,11 @@ public class TestRmdUtils {
 
     Assert.assertFalse(RmdUtils.hasOffsetAdvanced(list1, list2));
     Assert.assertFalse(RmdUtils.hasOffsetAdvanced(list1, Collections.emptyList()));
+    Assert.assertTrue(RmdUtils.hasOffsetAdvanced(list1, list3));
+    Assert.assertFalse(RmdUtils.hasOffsetAdvanced(list3, list1));
     Assert.assertTrue(RmdUtils.hasOffsetAdvanced(list2, list1));
     Assert.assertTrue(RmdUtils.hasOffsetAdvanced(Collections.emptyList(), list2));
+    Assert.assertTrue(RmdUtils.hasOffsetAdvanced(Collections.emptyList(), Collections.emptyList()));
 
     List<Long> mergedList = RmdUtils.mergeOffsetVectors(list2, list1);
     Assert.assertEquals(mergedList.get(0), list2.get(0));

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/consumer/TestChangelogConsumer.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/consumer/TestChangelogConsumer.java
@@ -273,7 +273,7 @@ public class TestChangelogConsumer {
     }
   }
 
-  @Test(timeOut = TEST_TIMEOUT, priority = 3)
+  @Test(timeOut = TEST_TIMEOUT * 10, priority = 3)
   public void testAAIngestionWithStoreView() throws Exception {
     // Set up the store
     Long timestamp = System.currentTimeMillis();
@@ -705,27 +705,27 @@ public class TestChangelogConsumer {
     });
 
     versionTopicEvents.clear();
-    TestUtils.waitForNonDeterministicAssertion(10, TimeUnit.SECONDS, true, () -> {
+    TestUtils.waitForNonDeterministicAssertion(1000, TimeUnit.SECONDS, true, () -> {
       pollAfterImageEventsFromChangeCaptureConsumer(versionTopicEvents, versionTopicConsumer);
       // At this point, the consumer should have auto tracked to version 4, and since we didn't apply any nearline
       // writes to version 4, there should be no events to consume at this point
-      Assert.assertEquals(versionTopicEvents.size(), 42);
+      Assert.assertEquals(versionTopicEvents.size(), 0);
     });
 
-    // The current topic had nothing in the push, but 42 messages got played on top
+    // The repush should result in nothing getting placed on the RT, so this seek should put us at the tail of events
     versionTopicConsumer.seekToEndOfPush().get();
     TestUtils.waitForNonDeterministicAssertion(10, TimeUnit.SECONDS, true, () -> {
       pollAfterImageEventsFromChangeCaptureConsumer(versionTopicEvents, versionTopicConsumer);
-      pollAfterImageEventsFromChangeCaptureConsumer(versionTopicEvents, versionTopicConsumer);
-      pollAfterImageEventsFromChangeCaptureConsumer(versionTopicEvents, versionTopicConsumer);
       // Again, no events to consume here.
-      Assert.assertEquals(versionTopicEvents.size(), 42);
+      Assert.assertEquals(versionTopicEvents.size(), 0);
     });
 
+    // Following repush with TTL, we played 20 events, 10 puts, 10 deletes. This should result in a VT with 10 events in
+    // it
     versionTopicConsumer.seekToBeginningOfPush().get();
     TestUtils.waitForNonDeterministicAssertion(10, TimeUnit.SECONDS, true, () -> {
       pollAfterImageEventsFromChangeCaptureConsumer(versionTopicEvents, versionTopicConsumer);
-      Assert.assertEquals(versionTopicEvents.size(), 42);
+      Assert.assertEquals(versionTopicEvents.size(), 10);
     });
 
     // Verify version swap count matches with version count - 1 (since we don't transmit from version 0 to version 1).

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/consumer/TestChangelogConsumer.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/consumer/TestChangelogConsumer.java
@@ -171,7 +171,7 @@ public class TestChangelogConsumer {
   }
 
   // This is a beefier test, so giving it a bit more time
-  @Test(timeOut = TEST_TIMEOUT * 3, priority = 3)
+  @Test(timeOut = TEST_TIMEOUT, priority = 3)
   public void testVersionSwapInALoop() throws Exception {
     // create a active-active enabled store and run batch push job
     // batch job contains 100 records


### PR DESCRIPTION
## [changelog][client] Some clean up and bug fixes in CDC
A few fixes that include:

**RMDUtils.hasOffsetAdvanced**: This method did not handle correctly some cases where the offset vectors dimensionality didn't line up 

**VeniceAfterImageConsumer**: Version swap could get stuck if the store repo for in the internal consumer and external consumer were out of sync. This change adds a new method where the outer consumer can instruct the inner consumer directly which version it wants to seek on.

**Heartbeats in CDC**: There was it seemed a forgotten and not so clever lambda attempt to record the timestamp.  This did some unfortunate math and failed to perform a System.currentTimeMillis - timestamp, which in turn recorded a very large value. This fixes that and it now reports the lag correctly.

Resolves #XXX

## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.