### PR TITLE
[server][da-vinci-client] Return proper error code from getTopicPartitionEndOffSet

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
@@ -2413,12 +2413,9 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
           Duration.ofMillis(500),
           Duration.ofSeconds(5),
           Arrays.asList(PubSubTopicDoesNotExistException.class, PubSubOpTimeoutException.class, VeniceException.class));
-    } catch (PubSubTopicDoesNotExistException | PubSubOpTimeoutException e) {
+    } catch (Exception e) {
       LOGGER.error("Failed to get end offset for topic-partition: {} even after 10 retries", topicPartition, e);
       return StatsErrorCode.LAG_MEASUREMENT_FAILURE.code;
-    } catch (Exception e) {
-      LOGGER.error("Could not find latest offset for {} even after 10 retries", pubSubTopic.getName());
-      return -1;
     }
   }
 

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
@@ -2407,7 +2407,7 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
           throw new VeniceException("Latest offset is unknown. Check if the topic: " + topicPartition + " exists.");
         }
         return offset;
-      }, 10, Duration.ofMillis(10), Duration.ofMillis(500), Duration.ofSeconds(5), RETRY_FAILURE_TYPES);
+      }, 10, Duration.ofMillis(10), Duration.ofMillis(500), Duration.ofSeconds(60), RETRY_FAILURE_TYPES);
     } catch (Exception e) {
       LOGGER.error(
           "Failed to get end offset for topic-partition: {} with kafka url {}  even after 10 retries",

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
@@ -2414,7 +2414,11 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
           Duration.ofSeconds(5),
           Arrays.asList(PubSubTopicDoesNotExistException.class, PubSubOpTimeoutException.class, VeniceException.class));
     } catch (Exception e) {
-      LOGGER.error("Failed to get end offset for topic-partition: {} even after 10 retries", topicPartition, e);
+      LOGGER.error(
+          "Failed to get end offset for topic-partition: {} with kafka url {}  even after 10 retries",
+          topicPartition,
+          kafkaUrl,
+          e);
       return StatsErrorCode.LAG_MEASUREMENT_FAILURE.code;
     }
   }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
@@ -173,6 +173,8 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
   private static final Logger LOGGER = LogManager.getLogger(StoreIngestionTask.class);
 
   private static final String CONSUMER_TASK_ID_FORMAT = "SIT-%s";
+  public static final List<Class<? extends Throwable>> RETRY_FAILURE_TYPES =
+      Collections.singletonList(VeniceException.class);
   public static long SCHEMA_POLLING_DELAY_MS = SECONDS.toMillis(5);
   public static long STORE_VERSION_POLLING_DELAY_MS = MINUTES.toMillis(1);
 
@@ -2405,12 +2407,7 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
           throw new VeniceException("Latest offset is unknown. Check if the topic: " + topicPartition + " exists.");
         }
         return offset;
-      },
-          10,
-          Duration.ofMillis(10),
-          Duration.ofMillis(500),
-          Duration.ofSeconds(5),
-          Collections.singletonList(VeniceException.class));
+      }, 10, Duration.ofMillis(10), Duration.ofMillis(500), Duration.ofSeconds(5), RETRY_FAILURE_TYPES);
     } catch (Exception e) {
       LOGGER.error(
           "Failed to get end offset for topic-partition: {} with kafka url {}  even after 10 retries",

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
@@ -91,8 +91,6 @@ import com.linkedin.venice.pubsub.PubSubTopicRepository;
 import com.linkedin.venice.pubsub.api.PubSubMessage;
 import com.linkedin.venice.pubsub.api.PubSubTopic;
 import com.linkedin.venice.pubsub.api.PubSubTopicPartition;
-import com.linkedin.venice.pubsub.api.exceptions.PubSubOpTimeoutException;
-import com.linkedin.venice.pubsub.api.exceptions.PubSubTopicDoesNotExistException;
 import com.linkedin.venice.pubsub.api.exceptions.PubSubUnsubscribedTopicPartitionException;
 import com.linkedin.venice.pubsub.manager.TopicManager;
 import com.linkedin.venice.pubsub.manager.TopicManagerRepository;
@@ -2412,7 +2410,7 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
           Duration.ofMillis(10),
           Duration.ofMillis(500),
           Duration.ofSeconds(5),
-          Arrays.asList(PubSubTopicDoesNotExistException.class, PubSubOpTimeoutException.class, VeniceException.class));
+          Collections.singletonList(VeniceException.class));
     } catch (Exception e) {
       LOGGER.error(
           "Failed to get end offset for topic-partition: {} with kafka url {}  even after 10 retries",


### PR DESCRIPTION
<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat], [protocol]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

##  Return proper error code from getTopicPartitionEndOffSet
<!--
Describe
- What changes to make and why you are making these changes.
- How are you going to achieve your goal.
- Describe what testings you have done, for example, performance testing etc.

If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

 Return value from `getTopicPartitionEndOffSet` used to indicate the status of the invalid/non-existent topic vs valid LOWEST_OFFSET return value. But in PR https://github.com/linkedin/venice/pull/1232 that assumption was violated. This caused some partitions to think it has caught up even when it has not due to some transient issues. This PR fixes that.


## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
GHCI
## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.