### PR TITLE
[controller] Fix dvc heartbeat value in store and version config

### DIFF
--- a/internal/venice-common/src/main/java/com/linkedin/venice/ConfigKeys.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/ConfigKeys.java
@@ -2456,10 +2456,22 @@ public class ConfigKeys {
    */
   public static final String CONTROLLER_HELIX_RESOURCE_CAPACITY_WEIGHT = "controller.helix.default.instance.capacity";
 
+  /**
+   * Specifies how frequently the deferred version swap service runs. Default value is 1 minute
+   */
   public static final String CONTROLLER_DEFERRED_VERSION_SWAP_SLEEP_MS = "controller.deferred.version.swap.sleep.ms";
+
+  /**
+   * Enables / disables the deferred version swap service. Default value is disabled
+   */
   public static final String CONTROLLER_DEFERRED_VERSION_SWAP_SERVICE_ENABLED =
       "controller.deferred.version.swap.service.enabled";
 
+  /**
+   * Enables / disables allowing dvc clients to perform a target region push with deferred swap. When enabled, dvc clients
+   * will be skipped and target regions will not be set and the deferred version swap service will skip checking stores with
+   * isDavinciHeartbeatReported set to true. Default value is enabled
+   */
   public static final String DEFERRED_VERSION_SWAP_SERVICE_WITH_DVC_CHECK_ENABLED =
       "deferred.version.swap.service.with.dvc.check.enabled";
 

--- a/internal/venice-common/src/main/java/com/linkedin/venice/ConfigKeys.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/ConfigKeys.java
@@ -2470,10 +2470,9 @@ public class ConfigKeys {
   /**
    * Enables / disables allowing dvc clients to perform a target region push with deferred swap. When enabled, dvc clients
    * will be skipped and target regions will not be set and the deferred version swap service will skip checking stores with
-   * isDavinciHeartbeatReported set to true. Default value is enabled
+   * isDavinciHeartbeatReported set to true. This is a temporary config until delayed ingestion for dvc is complete. Default value is enabled
    */
-  public static final String DEFERRED_VERSION_SWAP_SERVICE_WITH_DVC_CHECK_ENABLED =
-      "deferred.version.swap.service.with.dvc.check.enabled";
+  public static final String SKIP_DEFERRED_VERSION_SWAP_FOR_DVC_ENABLED = "skip.deferred.version.swap.for.dvc.enabled";
 
   /*
    * Both Router and Server will maintain an in-memory cache for connection-level ACLs and the following config

--- a/internal/venice-common/src/main/java/com/linkedin/venice/ConfigKeys.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/ConfigKeys.java
@@ -2460,6 +2460,9 @@ public class ConfigKeys {
   public static final String CONTROLLER_DEFERRED_VERSION_SWAP_SERVICE_ENABLED =
       "controller.deferred.version.swap.service.enabled";
 
+  public static final String DEFERRED_VERSION_SWAP_SERVICE_WITH_DVC_CHECK_ENABLED =
+      "deferred.version.swap.service.with.dvc.check.enabled";
+
   /*
    * Both Router and Server will maintain an in-memory cache for connection-level ACLs and the following config
    * controls the TTL of the cache per entry.

--- a/internal/venice-common/src/main/java/com/linkedin/venice/meta/AbstractStore.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/meta/AbstractStore.java
@@ -162,8 +162,6 @@ public abstract class AbstractStore implements Store {
 
       version.setTargetSwapRegionWaitTime(getTargetSwapRegionWaitTime());
 
-      version.setIsDavinciHeartbeatReported(getIsDavinciHeartbeatReported());
-
       HybridStoreConfig hybridStoreConfig = getHybridStoreConfig();
       if (hybridStoreConfig != null) {
         version.setHybridStoreConfig(hybridStoreConfig.clone());

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/DeferredVersionSwapService.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/DeferredVersionSwapService.java
@@ -119,13 +119,14 @@ public class DeferredVersionSwapService extends AbstractVeniceService {
 
             List<Store> stores = veniceParentHelixAdmin.getAllStores(cluster);
             for (Store store: stores) {
-              if (StringUtils.isEmpty(store.getTargetSwapRegion())) {
-                continue;
-              }
-
               int targetVersionNum = store.getLargestUsedVersionNumber();
               Version targetVersion = store.getVersion(targetVersionNum);
               if (targetVersion == null) {
+                continue;
+              }
+
+              String targetRegionsString = targetVersion.getTargetSwapRegion();
+              if (StringUtils.isEmpty(targetRegionsString)) {
                 continue;
               }
 
@@ -139,7 +140,7 @@ public class DeferredVersionSwapService extends AbstractVeniceService {
               // proceeding further
               String storeName = store.getName();
               String kafkaTopicName = Version.composeKafkaTopic(storeName, targetVersionNum);
-              Set<String> targetRegions = RegionUtils.parseRegionsFilterList(store.getTargetSwapRegion());
+              Set<String> targetRegions = RegionUtils.parseRegionsFilterList(targetRegionsString);
               Map<String, Long> storePushCompletionTimes = storePushCompletionTimeCache.getIfPresent(kafkaTopicName);
               if (storePushCompletionTimes != null) {
                 if (!didWaitTimeElapseInTargetRegions(
@@ -159,32 +160,34 @@ public class DeferredVersionSwapService extends AbstractVeniceService {
                   veniceParentHelixAdmin.getCurrentVersionsForMultiColos(cluster, storeName);
               Set<String> remainingRegions = getRegionsForVersionSwap(coloToVersions, targetRegions);
 
-              StoreResponse targetRegionStoreResponse =
-                  getStoreForRegion(cluster, getTargetRegion(targetRegions), storeName);
-              if (targetRegionStoreResponse.isError()) {
-                LOGGER.warn("Got error when fetching targetRegionStore: {}", targetRegionStoreResponse.getError());
-                continue;
-              }
-
-              StoreInfo targetRegionStore = targetRegionStoreResponse.getStore();
-              Optional<Version> version = targetRegionStore.getVersion(targetVersionNum);
-              if (!version.isPresent()) {
-                LOGGER.warn(
-                    "Unable to find version {} for store: {} in regions: {}",
-                    targetVersionNum,
-                    storeName,
-                    store.getTargetSwapRegion());
-                continue;
-              }
-
               // Do not perform version swap for davinci stores
               // TODO remove this check once DVC delayed ingestion is completed
-              if (version.get().getIsDavinciHeartbeatReported()) {
-                LOGGER.info(
-                    "Skipping version swap for store: {} on version: {} as it is davinci",
-                    storeName,
-                    targetVersionNum);
-                continue;
+              if (veniceControllerMultiClusterConfig.isDeferredVersionSwapServiceWithDvcHeartbeatEnabled()) {
+                StoreResponse targetRegionStoreResponse =
+                    getStoreForRegion(cluster, getTargetRegion(targetRegions), storeName);
+                if (targetRegionStoreResponse.isError()) {
+                  LOGGER.warn("Got error when fetching targetRegionStore: {}", targetRegionStoreResponse.getError());
+                  continue;
+                }
+
+                StoreInfo targetRegionStore = targetRegionStoreResponse.getStore();
+                Optional<Version> version = targetRegionStore.getVersion(targetVersionNum);
+                if (!version.isPresent()) {
+                  LOGGER.warn(
+                      "Unable to find version {} for store: {} in regions: {}",
+                      targetVersionNum,
+                      storeName,
+                      targetRegionsString);
+                  continue;
+                }
+
+                if (version.get().getIsDavinciHeartbeatReported()) {
+                  LOGGER.info(
+                      "Skipping version swap for store: {} on version: {} as it is davinci",
+                      storeName,
+                      targetVersionNum);
+                  continue;
+                }
               }
 
               // Check that push is completed in target regions
@@ -280,7 +283,7 @@ public class DeferredVersionSwapService extends AbstractVeniceService {
 
               // TODO add call for postStoreVersionSwap() once it is implemented
 
-              String regionsToRollForward = String.join(",\\s*", nonTargetRegionsCompleted);
+              String regionsToRollForward = RegionUtils.composeRegionList(nonTargetRegionsCompleted);
               LOGGER.info("Issuing roll forward message for store: {} in regions: {}", storeName, regionsToRollForward);
               veniceParentHelixAdmin.rollForwardToFutureVersion(cluster, storeName, regionsToRollForward);
 

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/DeferredVersionSwapService.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/DeferredVersionSwapService.java
@@ -162,7 +162,7 @@ public class DeferredVersionSwapService extends AbstractVeniceService {
 
               // Do not perform version swap for davinci stores
               // TODO remove this check once DVC delayed ingestion is completed
-              if (veniceControllerMultiClusterConfig.isDeferredVersionSwapServiceWithDvcHeartbeatEnabled()) {
+              if (veniceControllerMultiClusterConfig.isSkipDeferredVersionSwapForDVCEnabled()) {
                 StoreResponse targetRegionStoreResponse =
                     getStoreForRegion(cluster, getTargetRegion(targetRegions), storeName);
                 if (targetRegionStoreResponse.isError()) {

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceControllerClusterConfig.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceControllerClusterConfig.java
@@ -105,7 +105,6 @@ import static com.linkedin.venice.ConfigKeys.DEFAULT_PARTITION_SIZE;
 import static com.linkedin.venice.ConfigKeys.DEFAULT_READ_STRATEGY;
 import static com.linkedin.venice.ConfigKeys.DEFAULT_REPLICA_FACTOR;
 import static com.linkedin.venice.ConfigKeys.DEFAULT_ROUTING_STRATEGY;
-import static com.linkedin.venice.ConfigKeys.DEFERRED_VERSION_SWAP_SERVICE_WITH_DVC_CHECK_ENABLED;
 import static com.linkedin.venice.ConfigKeys.DELAY_TO_REBALANCE_MS;
 import static com.linkedin.venice.ConfigKeys.DEPRECATED_TOPIC_MAX_RETENTION_MS;
 import static com.linkedin.venice.ConfigKeys.DEPRECATED_TOPIC_RETENTION_MS;
@@ -168,6 +167,7 @@ import static com.linkedin.venice.ConfigKeys.REFRESH_ATTEMPTS_FOR_ZK_RECONNECT;
 import static com.linkedin.venice.ConfigKeys.REFRESH_INTERVAL_FOR_ZK_RECONNECT_MS;
 import static com.linkedin.venice.ConfigKeys.REPLICATION_METADATA_VERSION;
 import static com.linkedin.venice.ConfigKeys.SERVICE_DISCOVERY_REGISTRATION_RETRY_MS;
+import static com.linkedin.venice.ConfigKeys.SKIP_DEFERRED_VERSION_SWAP_FOR_DVC_ENABLED;
 import static com.linkedin.venice.ConfigKeys.SSL_KAFKA_BOOTSTRAP_SERVERS;
 import static com.linkedin.venice.ConfigKeys.SSL_TO_KAFKA_LEGACY;
 import static com.linkedin.venice.ConfigKeys.STORAGE_ENGINE_OVERHEAD_RATIO;
@@ -556,7 +556,7 @@ public class VeniceControllerClusterConfig {
   private boolean isHybridStorePartitionCountUpdateEnabled;
   private final long deferredVersionSwapSleepMs;
   private final boolean deferredVersionSwapServiceEnabled;
-  private final boolean deferredVersionSwapServiceWithDvcHeartbeatEnabled;
+  private final boolean skipDeferredVersionSwapForDVCEnabled;
 
   private final Map<ClusterConfig.GlobalRebalancePreferenceKey, Integer> helixGlobalRebalancePreference;
   private final List<String> helixInstanceCapacityKeys;
@@ -1068,8 +1068,7 @@ public class VeniceControllerClusterConfig {
     this.deferredVersionSwapSleepMs =
         props.getLong(CONTROLLER_DEFERRED_VERSION_SWAP_SLEEP_MS, TimeUnit.MINUTES.toMillis(1));
     this.deferredVersionSwapServiceEnabled = props.getBoolean(CONTROLLER_DEFERRED_VERSION_SWAP_SERVICE_ENABLED, false);
-    this.deferredVersionSwapServiceWithDvcHeartbeatEnabled =
-        props.getBoolean(DEFERRED_VERSION_SWAP_SERVICE_WITH_DVC_CHECK_ENABLED, true);
+    this.skipDeferredVersionSwapForDVCEnabled = props.getBoolean(SKIP_DEFERRED_VERSION_SWAP_FOR_DVC_ENABLED, true);
   }
 
   public VeniceProperties getProps() {
@@ -1588,8 +1587,8 @@ public class VeniceControllerClusterConfig {
     return deferredVersionSwapServiceEnabled;
   }
 
-  public boolean isDeferredVersionSwapServiceWithDvcHeartbeatEnabled() {
-    return deferredVersionSwapServiceWithDvcHeartbeatEnabled;
+  public boolean isSkipDeferredVersionSwapForDVCEnabled() {
+    return skipDeferredVersionSwapForDVCEnabled;
   }
 
   public long getTerminalStateTopicCheckerDelayMs() {

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceControllerClusterConfig.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceControllerClusterConfig.java
@@ -105,6 +105,7 @@ import static com.linkedin.venice.ConfigKeys.DEFAULT_PARTITION_SIZE;
 import static com.linkedin.venice.ConfigKeys.DEFAULT_READ_STRATEGY;
 import static com.linkedin.venice.ConfigKeys.DEFAULT_REPLICA_FACTOR;
 import static com.linkedin.venice.ConfigKeys.DEFAULT_ROUTING_STRATEGY;
+import static com.linkedin.venice.ConfigKeys.DEFERRED_VERSION_SWAP_SERVICE_WITH_DVC_CHECK_ENABLED;
 import static com.linkedin.venice.ConfigKeys.DELAY_TO_REBALANCE_MS;
 import static com.linkedin.venice.ConfigKeys.DEPRECATED_TOPIC_MAX_RETENTION_MS;
 import static com.linkedin.venice.ConfigKeys.DEPRECATED_TOPIC_RETENTION_MS;
@@ -555,6 +556,7 @@ public class VeniceControllerClusterConfig {
   private boolean isHybridStorePartitionCountUpdateEnabled;
   private final long deferredVersionSwapSleepMs;
   private final boolean deferredVersionSwapServiceEnabled;
+  private final boolean deferredVersionSwapServiceWithDvcHeartbeatEnabled;
 
   private final Map<ClusterConfig.GlobalRebalancePreferenceKey, Integer> helixGlobalRebalancePreference;
   private final List<String> helixInstanceCapacityKeys;
@@ -1066,6 +1068,8 @@ public class VeniceControllerClusterConfig {
     this.deferredVersionSwapSleepMs =
         props.getLong(CONTROLLER_DEFERRED_VERSION_SWAP_SLEEP_MS, TimeUnit.MINUTES.toMillis(1));
     this.deferredVersionSwapServiceEnabled = props.getBoolean(CONTROLLER_DEFERRED_VERSION_SWAP_SERVICE_ENABLED, false);
+    this.deferredVersionSwapServiceWithDvcHeartbeatEnabled =
+        props.getBoolean(DEFERRED_VERSION_SWAP_SERVICE_WITH_DVC_CHECK_ENABLED, true);
   }
 
   public VeniceProperties getProps() {
@@ -1582,6 +1586,10 @@ public class VeniceControllerClusterConfig {
 
   public boolean isDeferredVersionSwapServiceEnabled() {
     return deferredVersionSwapServiceEnabled;
+  }
+
+  public boolean isDeferredVersionSwapServiceWithDvcHeartbeatEnabled() {
+    return deferredVersionSwapServiceWithDvcHeartbeatEnabled;
   }
 
   public long getTerminalStateTopicCheckerDelayMs() {

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceControllerMultiClusterConfig.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceControllerMultiClusterConfig.java
@@ -231,6 +231,10 @@ public class VeniceControllerMultiClusterConfig {
     return getCommonConfig().isDeferredVersionSwapServiceEnabled();
   }
 
+  public boolean isDeferredVersionSwapServiceWithDvcHeartbeatEnabled() {
+    return getCommonConfig().isDeferredVersionSwapServiceWithDvcHeartbeatEnabled();
+  }
+
   public boolean isControllerEnforceSSLOnly() {
     return getCommonConfig().isControllerEnforceSSLOnly();
   }

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceControllerMultiClusterConfig.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceControllerMultiClusterConfig.java
@@ -231,8 +231,8 @@ public class VeniceControllerMultiClusterConfig {
     return getCommonConfig().isDeferredVersionSwapServiceEnabled();
   }
 
-  public boolean isDeferredVersionSwapServiceWithDvcHeartbeatEnabled() {
-    return getCommonConfig().isDeferredVersionSwapServiceWithDvcHeartbeatEnabled();
+  public boolean isSkipDeferredVersionSwapForDVCEnabled() {
+    return getCommonConfig().isSkipDeferredVersionSwapForDVCEnabled();
   }
 
   public boolean isControllerEnforceSSLOnly() {

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceParentHelixAdmin.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceParentHelixAdmin.java
@@ -1487,6 +1487,9 @@ public class VeniceParentHelixAdmin implements Admin {
         boolean skipTargetRegionPushForDavinci = currentVersionInChild.get().getIsDavinciHeartbeatReported()
             && multiClusterConfigs.isSkipDeferredVersionSwapForDVCEnabled();
         if (skipTargetRegionPushForDavinci) {
+          LOGGER.info(
+              "Skip setting targetedRegions and versionSwapDeferred values for store: {} during a target region push with deferred swap",
+              storeName);
           targetedRegions = "";
           versionSwapDeferred = false;
         }

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceParentHelixAdmin.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceParentHelixAdmin.java
@@ -1473,6 +1473,26 @@ public class VeniceParentHelixAdmin implements Admin {
       boolean versionSwapDeferred,
       String targetedRegions,
       int repushSourceVersion) {
+
+    // For target region pushes with deferred swap enabled, check if we should skip target region push for dvc clients
+    // A store with dvc clients can be skipped if there is a dvc heartbeat reported for the current version and
+    // DEFERRED_VERSION_SWAP_SERVICE_WITH_DVC_CHECK_ENABLED is set to true
+    boolean isTargetRegionPushWithDeferredSwap = !StringUtils.isEmpty(targetedRegions) && versionSwapDeferred;
+    if (isTargetRegionPushWithDeferredSwap) {
+      validateTargetedRegions(targetedRegions, clusterName);
+      Set<String> targetRegions = RegionUtils.parseRegionsFilterList(targetedRegions);
+      StoreInfo childStore = getStoreInChildRegion(targetRegions.iterator().next(), clusterName, storeName);
+      Optional<Version> currentVersionInChild = childStore.getVersion(childStore.getCurrentVersion());
+      if (currentVersionInChild.isPresent()) {
+        boolean skipTargetRegionPushForDavinci = currentVersionInChild.get().getIsDavinciHeartbeatReported()
+            && multiClusterConfigs.isDeferredVersionSwapServiceWithDvcHeartbeatEnabled();
+        if (skipTargetRegionPushForDavinci) {
+          targetedRegions = "";
+          versionSwapDeferred = false;
+        }
+      }
+    }
+
     Optional<String> currentPushTopic =
         getTopicForCurrentPushJob(clusterName, storeName, pushType.isIncremental(), Version.isPushIdRePush(pushJobId));
 

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceParentHelixAdmin.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceParentHelixAdmin.java
@@ -1485,7 +1485,7 @@ public class VeniceParentHelixAdmin implements Admin {
       Optional<Version> currentVersionInChild = childStore.getVersion(childStore.getCurrentVersion());
       if (currentVersionInChild.isPresent()) {
         boolean skipTargetRegionPushForDavinci = currentVersionInChild.get().getIsDavinciHeartbeatReported()
-            && multiClusterConfigs.isDeferredVersionSwapServiceWithDvcHeartbeatEnabled();
+            && multiClusterConfigs.isSkipDeferredVersionSwapForDVCEnabled();
         if (skipTargetRegionPushForDavinci) {
           targetedRegions = "";
           versionSwapDeferred = false;

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceParentHelixAdmin.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceParentHelixAdmin.java
@@ -1488,8 +1488,11 @@ public class VeniceParentHelixAdmin implements Admin {
             && multiClusterConfigs.isSkipDeferredVersionSwapForDVCEnabled();
         if (skipTargetRegionPushForDavinci) {
           LOGGER.info(
-              "Skip setting targetedRegions and versionSwapDeferred values for store: {} during a target region push with deferred swap",
-              storeName);
+              "Skip setting targetedRegions and versionSwapDeferred values for store: {} "
+                  + "because isSkipDeferredVersionSwapForDVCEnabled: {} and isDavinciHeartbeatReported: {}",
+              storeName,
+              multiClusterConfigs.isSkipDeferredVersionSwapForDVCEnabled(),
+              currentVersionInChild.get().getIsDavinciHeartbeatReported());
           targetedRegions = "";
           versionSwapDeferred = false;
         }

--- a/services/venice-controller/src/main/java/com/linkedin/venice/pushmonitor/PushStatusCollector.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/pushmonitor/PushStatusCollector.java
@@ -182,7 +182,7 @@ public class PushStatusCollector {
         // Mark that there is a dvc heartbeat reported for this version
         int versionNum = Version.parseVersionFromVersionTopicName(pushStatus.topicName);
         Version version = store.getVersion(versionNum);
-        if (!version.getIsDavinciHeartbeatReported()) {
+        if (version != null && !version.getIsDavinciHeartbeatReported()) {
           store.updateVersionForDaVinciHeartbeat(versionNum, true);
           store.setIsDavinciHeartbeatReported(true);
           storeRepository.updateStore(store);

--- a/services/venice-controller/src/test/java/com/linkedin/venice/controller/TestDeferredVersionSwapService.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/controller/TestDeferredVersionSwapService.java
@@ -50,6 +50,7 @@ public class TestDeferredVersionSwapService {
     doReturn(clusters).when(veniceControllerMultiClusterConfig).getClusters();
     doReturn(10L).when(veniceControllerMultiClusterConfig).getDeferredVersionSwapSleepMs();
     doReturn(true).when(veniceControllerMultiClusterConfig).isDeferredVersionSwapServiceEnabled();
+    doReturn(true).when(veniceControllerMultiClusterConfig).isDeferredVersionSwapServiceWithDvcHeartbeatEnabled();
   }
 
   private Store mockStore(
@@ -69,6 +70,8 @@ public class TestDeferredVersionSwapService {
       doReturn(n).when(v).getNumber();
       doReturn(s).when(v).getStatus();
       doReturn(v).when(store).getVersion(n);
+      doReturn(targetRegions).when(v).getTargetSwapRegion();
+      doReturn(waitTime).when(v).getTargetSwapRegionWaitTime();
       versionList.add(v);
     });
     doReturn(versionList).when(store).getVersions();

--- a/services/venice-controller/src/test/java/com/linkedin/venice/controller/TestDeferredVersionSwapService.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/controller/TestDeferredVersionSwapService.java
@@ -50,7 +50,7 @@ public class TestDeferredVersionSwapService {
     doReturn(clusters).when(veniceControllerMultiClusterConfig).getClusters();
     doReturn(10L).when(veniceControllerMultiClusterConfig).getDeferredVersionSwapSleepMs();
     doReturn(true).when(veniceControllerMultiClusterConfig).isDeferredVersionSwapServiceEnabled();
-    doReturn(true).when(veniceControllerMultiClusterConfig).isDeferredVersionSwapServiceWithDvcHeartbeatEnabled();
+    doReturn(true).when(veniceControllerMultiClusterConfig).isSkipDeferredVersionSwapForDVCEnabled();
   }
 
   private Store mockStore(

--- a/services/venice-controller/src/test/java/com/linkedin/venice/controller/TestVeniceParentHelixAdmin.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/controller/TestVeniceParentHelixAdmin.java
@@ -3051,7 +3051,7 @@ public class TestVeniceParentHelixAdmin extends AbstractTestVeniceParentHelixAdm
             "",
             -1);
     doReturn("region1").when(config).getRegionName();
-    doReturn(true).when(config).isDeferredVersionSwapServiceWithDvcHeartbeatEnabled();
+    doReturn(true).when(config).isSkipDeferredVersionSwapForDVCEnabled();
     try (PartialMockVeniceParentHelixAdmin partialMockParentAdmin =
         spy(new PartialMockVeniceParentHelixAdmin(internalAdmin, config))) {
       VeniceWriter veniceWriter = mock(VeniceWriter.class);

--- a/services/venice-controller/src/test/java/com/linkedin/venice/controller/TestVeniceParentHelixAdmin.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/controller/TestVeniceParentHelixAdmin.java
@@ -3001,6 +3001,108 @@ public class TestVeniceParentHelixAdmin extends AbstractTestVeniceParentHelixAdm
     assertEquals(finalStatus, ExecutionStatus.DVC_INGESTION_ERROR_OTHER);
   }
 
+  @Test
+  public void testIncrementVersionIdempotentForTargetRegionsWithDvcClient() {
+    String storeName = Utils.getUniqueString("testIncrementVersionIdempotentForTargetRegionsWithDvcClient");
+    Store store = new ZKStore(
+        storeName,
+        "test_owner",
+        1,
+        PersistenceType.ROCKS_DB,
+        RoutingStrategy.CONSISTENT_HASH,
+        ReadStrategy.ANY_OF_ONLINE,
+        OfflinePushStrategy.WAIT_N_MINUS_ONE_REPLCIA_PER_PARTITION,
+        1);
+
+    Version version = new VersionImpl(storeName, 1, Utils.getUniqueString("test_push_id"));
+    store.addVersion(version);
+    store.updateVersionForDaVinciHeartbeat(1, true);
+    store.setCurrentVersion(1);
+    doReturn(store).when(internalAdmin).getStore(clusterName, storeName);
+
+    Map<String, ControllerClient> controllerClientMap = new HashMap<>();
+    ControllerClient client = mock(ControllerClient.class);
+    StoreResponse storeResponse = new StoreResponse();
+    storeResponse.setStore(StoreInfo.fromStore(store));
+    doReturn(storeResponse).when(client).getStore(storeName);
+    mockControllerClients(storeName);
+    controllerClientMap.put("region1", client);
+    doReturn(controllerClientMap).when(internalAdmin).getControllerClientMap(clusterName);
+
+    String nextPushJobId = Utils.getUniqueString("test_push_id");
+    doReturn(new Pair<>(true, version)).when(internalAdmin)
+        .addVersionAndTopicOnly(
+            clusterName,
+            storeName,
+            nextPushJobId,
+            -1,
+            1,
+            1,
+            false,
+            false,
+            Version.PushType.BATCH,
+            null,
+            null,
+            Optional.empty(),
+            -1,
+            1,
+            Optional.empty(),
+            false,
+            "",
+            -1);
+    doReturn("region1").when(config).getRegionName();
+    doReturn(true).when(config).isDeferredVersionSwapServiceWithDvcHeartbeatEnabled();
+    try (PartialMockVeniceParentHelixAdmin partialMockParentAdmin =
+        spy(new PartialMockVeniceParentHelixAdmin(internalAdmin, config))) {
+      VeniceWriter veniceWriter = mock(VeniceWriter.class);
+      partialMockParentAdmin.setVeniceWriterForCluster(clusterName, veniceWriter);
+      doReturn(CompletableFuture.completedFuture(new SimplePubSubProduceResultImpl(topicName, partitionId, 1, -1)))
+          .when(veniceWriter)
+          .put(any(), any(), anyInt());
+      when(zkClient.readData(zkMetadataNodePath, null)).thenReturn(null)
+          .thenReturn(
+              AdminTopicMetadataAccessor
+                  .generateMetadataMap(Optional.of(1L), Optional.of(-1L), Optional.of(1L), Optional.empty()));
+      partialMockParentAdmin.incrementVersionIdempotent(
+          clusterName,
+          storeName,
+          nextPushJobId,
+          1,
+          1,
+          Version.PushType.BATCH,
+          false,
+          false,
+          null,
+          Optional.empty(),
+          Optional.empty(),
+          -1,
+          Optional.empty(),
+          true,
+          "region1",
+          -1);
+
+      verify(internalAdmin).addVersionAndTopicOnly(
+          clusterName,
+          storeName,
+          nextPushJobId,
+          -1,
+          1,
+          1,
+          false,
+          false,
+          Version.PushType.BATCH,
+          null,
+          null,
+          Optional.empty(),
+          -1,
+          1,
+          Optional.empty(),
+          false,
+          "",
+          -1);
+    }
+  }
+
   private Store setupForStoreViewConfigUpdateTest(String storeName) {
     Store store = TestUtils.createTestStore(storeName, "test", System.currentTimeMillis());
     store.setActiveActiveReplicationEnabled(true);

--- a/services/venice-controller/src/test/java/com/linkedin/venice/pushmonitor/PushStatusCollectorTest.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/pushmonitor/PushStatusCollectorTest.java
@@ -1,5 +1,6 @@
 package com.linkedin.venice.pushmonitor;
 
+import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.atLeast;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
@@ -8,6 +9,7 @@ import static org.mockito.Mockito.when;
 
 import com.linkedin.venice.meta.ReadWriteStoreRepository;
 import com.linkedin.venice.meta.Store;
+import com.linkedin.venice.meta.Version;
 import com.linkedin.venice.pushstatushelper.PushStatusStoreReader;
 import com.linkedin.venice.utils.TestUtils;
 import java.util.Collections;
@@ -49,6 +51,10 @@ public class PushStatusCollectorTest {
     Store daVinciStore = mock(Store.class);
     when(daVinciStore.isDaVinciPushStatusStoreEnabled()).thenReturn(true);
     when(storeRepository.getStore(daVinciStoreName)).thenReturn(daVinciStore);
+    when(daVinciStore.getIsDavinciHeartbeatReported()).thenReturn(true);
+    Version versionMock = mock(Version.class);
+    when(versionMock.getIsDavinciHeartbeatReported()).thenReturn(true);
+    when(daVinciStore.getVersion(anyInt())).thenReturn(versionMock);
 
     String regularStoreName = "regularStore";
     String regularStoreTopicV1 = "regularStore_v1";
@@ -209,6 +215,10 @@ public class PushStatusCollectorTest {
     Store daVinciStore = mock(Store.class);
     when(daVinciStore.isDaVinciPushStatusStoreEnabled()).thenReturn(true);
     when(storeRepository.getStore(daVinciStoreName)).thenReturn(daVinciStore);
+    when(daVinciStore.getIsDavinciHeartbeatReported()).thenReturn(true);
+    Version versionMock = mock(Version.class);
+    when(versionMock.getIsDavinciHeartbeatReported()).thenReturn(true);
+    when(daVinciStore.getVersion(anyInt())).thenReturn(versionMock);
 
     AtomicInteger pushCompletedCount = new AtomicInteger();
     AtomicInteger pushErrorCount = new AtomicInteger();
@@ -302,6 +312,10 @@ public class PushStatusCollectorTest {
     Store daVinciStore = mock(Store.class);
     when(daVinciStore.isDaVinciPushStatusStoreEnabled()).thenReturn(true);
     when(storeRepository.getStore(daVinciStoreName)).thenReturn(daVinciStore);
+    when(daVinciStore.getIsDavinciHeartbeatReported()).thenReturn(true);
+    Version versionMock = mock(Version.class);
+    when(versionMock.getIsDavinciHeartbeatReported()).thenReturn(true);
+    when(daVinciStore.getVersion(anyInt())).thenReturn(versionMock);
 
     AtomicInteger pushCompletedCount = new AtomicInteger();
     AtomicInteger pushErrorCount = new AtomicInteger();


### PR DESCRIPTION
<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat], [protocol]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## Summary, imperative, start upper case, don't end with a period
<!--
Describe
- What changes to make and why you are making these changes.
- How are you going to achieve your goal.
- Describe what testings you have done, for example, performance testing etc.

If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

The current dvc heartbeat is set from checking if there is a dvc push status and if the status is `NOT_CREATED` This, however, is inaccurate because the status is set to `NOT_STARTED` when there is no status found  if we're under the num of polling retry attempts. We should, instead, check if `daVinciStatus.isNoDaVinciStatusReport` returns false before marking if there is a heartbeat reported and mark it as false otherwise if we've exceeded the dvc status retry attempts

Other minor changes included:
* Gate dvc heartbeat check behind controller config `skip.deferred.version.swap.for.dvc.enabled`
* Do not set target regions for stores with a dvc heartbeat reported if `skip.deferred.version.swap.for.dvc.enabled` is enabled
* Check version target region config instead of store target region config in deferred version swap service

## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
Unit and e2e tests

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.