### PR TITLE
[router] Fix in-flight request check in router shutdown

### DIFF
--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/integration/utils/VeniceRouterWrapper.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/integration/utils/VeniceRouterWrapper.java
@@ -70,7 +70,7 @@ public class VeniceRouterWrapper extends ProcessWrapper implements MetricsAware 
   private static final String ROUTER_SERVICE_METRIC_PREFIX = "router";
   private final VeniceProperties properties;
   private final String zkAddress;
-  private RouterServer service;
+  private RouterServer routerServer;
   private final String d2ClusterName;
   private final String clusterDiscoveryD2ClusterName;
   private final String regionName;
@@ -81,13 +81,13 @@ public class VeniceRouterWrapper extends ProcessWrapper implements MetricsAware 
       String regionName,
       String serviceName,
       File dataDirectory,
-      RouterServer service,
+      RouterServer routerServer,
       VeniceProperties properties,
       String zkAddress,
       String d2ClusterName,
       String clusterDiscoveryD2ClusterName) {
     super(serviceName, dataDirectory);
-    this.service = service;
+    this.routerServer = routerServer;
     this.properties = properties;
     this.zkAddress = zkAddress;
     this.d2ClusterName = d2ClusterName;
@@ -224,22 +224,22 @@ public class VeniceRouterWrapper extends ProcessWrapper implements MetricsAware 
   }
 
   public String getD2ServiceNameForCluster(String clusterName) {
-    return service.getConfig().getClusterToD2Map().get(clusterName);
+    return routerServer.getConfig().getClusterToD2Map().get(clusterName);
   }
 
   @Override
   protected void internalStart() throws Exception {
-    service.start();
+    routerServer.start();
     TestUtils.waitForNonDeterministicCompletion(
         IntegrationTestUtils.MAX_ASYNC_START_WAIT_TIME_MS,
         TimeUnit.MILLISECONDS,
-        () -> service.isRunning());
+        () -> routerServer.isRunning());
     LOGGER.info("Started VeniceRouterWrapper: {}", this);
   }
 
   @Override
   protected void internalStop() throws Exception {
-    service.stop();
+    routerServer.stop();
   }
 
   @Override
@@ -251,7 +251,7 @@ public class VeniceRouterWrapper extends ProcessWrapper implements MetricsAware 
 
     d2Servers.addAll(D2TestUtils.getD2Servers(zkAddress, clusterDiscoveryD2ClusterName, httpURI, httpsURI));
 
-    service = new RouterServer(
+    routerServer = new RouterServer(
         properties,
         d2Servers,
         Optional.empty(),
@@ -272,28 +272,32 @@ public class VeniceRouterWrapper extends ProcessWrapper implements MetricsAware 
   }
 
   public HelixBaseRoutingRepository getRoutingDataRepository() {
-    return service.getRoutingDataRepository();
+    return routerServer.getRoutingDataRepository();
   }
 
   public ReadOnlyStoreRepository getMetaDataRepository() {
-    return service.getMetadataRepository();
+    return routerServer.getMetadataRepository();
   }
 
   public ReadOnlySchemaRepository getSchemaRepository() {
-    return service.getSchemaRepository();
+    return routerServer.getSchemaRepository();
   }
 
   public ZkRoutersClusterManager getRoutersClusterManager() {
-    return service.getRoutersClusterManager();
+    return routerServer.getRoutersClusterManager();
   }
 
   @Override
   public MetricsRepository getMetricsRepository() {
-    return service.getMetricsRepository();
+    return routerServer.getMetricsRepository();
+  }
+
+  public RouterServer getRouter() {
+    return routerServer;
   }
 
   public void refresh() {
-    service.refresh();
+    routerServer.refresh();
   }
 
   @Override

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/router/TestRead.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/router/TestRead.java
@@ -555,7 +555,7 @@ public abstract class TestRead {
           queriesSent++;
           storeClient.batchGet(keySet).get();
           for (VeniceRouterWrapper routerWrapper: veniceCluster.getVeniceRouters()) {
-            Assert.assertTrue(routerWrapper.getRouter().hasInFlightRequest());
+            Assert.assertTrue(routerWrapper.getRouter().getInFlightRequestRate() > 0.0);
           }
         } catch (ExecutionException e) {
           Throwable cause = e.getCause();
@@ -600,7 +600,7 @@ public abstract class TestRead {
         routerWrapper.getRouter().stop();
       }
       for (VeniceRouterWrapper routerWrapper: veniceCluster.getVeniceRouters()) {
-        Assert.assertFalse(routerWrapper.getRouter().hasInFlightRequest());
+        Assert.assertEquals(routerWrapper.getRouter().getInFlightRequestRate(), 0.0);
       }
       /** TODO Re-enable this assertion once we stop throwing batch get quota exceptions from {@link com.linkedin.venice.router.api.VeniceDelegateMode} */
       // Assert.assertTrue(throttledRequestLatencyForBatchGetAfterQueries > 0.0, "There should be batch get throttled

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/router/TestRead.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/router/TestRead.java
@@ -389,6 +389,7 @@ public abstract class TestRead {
               "There should be some idle connections since test queries are finished");
         }
 
+        Assert.assertTrue(getRouterMetricValue("total_inflight_request_count") > 0.0);
         Assert.assertTrue(getAggregateRouterMetricValue(".localhost--response_waiting_time.50thPercentile") > 0);
         Assert.assertTrue(
             getAggregateRouterMetricValue(".localhost--multiget_streaming_response_waiting_time.50thPercentile") > 0);
@@ -553,6 +554,9 @@ public abstract class TestRead {
         try {
           queriesSent++;
           storeClient.batchGet(keySet).get();
+          for (VeniceRouterWrapper routerWrapper: veniceCluster.getVeniceRouters()) {
+            Assert.assertTrue(routerWrapper.getRouter().hasInFlightRequest());
+          }
         } catch (ExecutionException e) {
           Throwable cause = e.getCause();
           Assert.assertTrue(
@@ -592,6 +596,12 @@ public abstract class TestRead {
           "The throttled_request metric is inconsistent with the number of quota exceptions received by the client!");
 
       getAggregateRouterMetricValue(".total--multiget_throttled_request_latency.Max");
+      for (VeniceRouterWrapper routerWrapper: veniceCluster.getVeniceRouters()) {
+        routerWrapper.getRouter().stop();
+      }
+      for (VeniceRouterWrapper routerWrapper: veniceCluster.getVeniceRouters()) {
+        Assert.assertFalse(routerWrapper.getRouter().hasInFlightRequest());
+      }
       /** TODO Re-enable this assertion once we stop throwing batch get quota exceptions from {@link com.linkedin.venice.router.api.VeniceDelegateMode} */
       // Assert.assertTrue(throttledRequestLatencyForBatchGetAfterQueries > 0.0, "There should be batch get throttled
       // request latency now!");
@@ -600,6 +610,10 @@ public abstract class TestRead {
 
   private double getMaxServerMetricValue(String metricName) {
     return MetricsUtils.getMax(metricName, veniceCluster.getVeniceServers());
+  }
+
+  private double getRouterMetricValue(String metricName) {
+    return MetricsUtils.getMax(metricName, veniceCluster.getVeniceRouters());
   }
 
   private double getMaxRouterMetricValue(String metricName) {

--- a/services/venice-router/src/main/java/com/linkedin/venice/router/InFlightRequestStat.java
+++ b/services/venice-router/src/main/java/com/linkedin/venice/router/InFlightRequestStat.java
@@ -18,6 +18,7 @@ public class InFlightRequestStat {
   private final VeniceMetricsRepository localMetricRepo;
 
   private final Sensor totalInflightRequestSensor;
+  private final Metric metric;
 
   public InFlightRequestStat(VeniceRouterConfig config) {
     metricConfig = new MetricConfig().timeWindow(config.getRouterInFlightMetricWindowSeconds(), TimeUnit.SECONDS);
@@ -28,6 +29,7 @@ public class InFlightRequestStat {
             .build());
     totalInflightRequestSensor = localMetricRepo.sensor("total_inflight_request");
     totalInflightRequestSensor.add(TOTAL_INFLIGHT_REQUEST_COUNT, new Rate());
+    metric = localMetricRepo.getMetric(TOTAL_INFLIGHT_REQUEST_COUNT);
   }
 
   public Sensor getTotalInflightRequestSensor() {
@@ -35,7 +37,6 @@ public class InFlightRequestStat {
   }
 
   public double getInFlightRequestRate() {
-    Metric metric = localMetricRepo.getMetric(TOTAL_INFLIGHT_REQUEST_COUNT);
     // max return -infinity when there are no samples. validate only against finite value
     return Double.isFinite(metric.value()) ? metric.value() : 0.0;
   }

--- a/services/venice-router/src/main/java/com/linkedin/venice/router/InFlightRequestStat.java
+++ b/services/venice-router/src/main/java/com/linkedin/venice/router/InFlightRequestStat.java
@@ -1,0 +1,42 @@
+package com.linkedin.venice.router;
+
+import static com.linkedin.venice.router.RouterServer.ROUTER_SERVICE_METRIC_PREFIX;
+import static com.linkedin.venice.router.RouterServer.ROUTER_SERVICE_NAME;
+
+import com.linkedin.venice.stats.VeniceMetricsConfig;
+import com.linkedin.venice.stats.VeniceMetricsRepository;
+import io.tehuti.Metric;
+import io.tehuti.metrics.MetricConfig;
+import io.tehuti.metrics.Sensor;
+import io.tehuti.metrics.stats.Rate;
+import java.util.concurrent.TimeUnit;
+
+
+public class InFlightRequestStat {
+  public static final String TOTAL_INFLIGHT_REQUEST_COUNT = "total_inflight_request_count";
+  private final MetricConfig metricConfig;
+  private final VeniceMetricsRepository localMetricRepo;
+
+  private final Sensor totalInflightRequestSensor;
+
+  public InFlightRequestStat(VeniceRouterConfig config) {
+    metricConfig = new MetricConfig().timeWindow(config.getRouterInFlightMetricWindowSeconds(), TimeUnit.SECONDS);
+    localMetricRepo = new VeniceMetricsRepository(
+        new VeniceMetricsConfig.Builder().setServiceName(ROUTER_SERVICE_NAME)
+            .setMetricPrefix(ROUTER_SERVICE_METRIC_PREFIX)
+            .setTehutiMetricConfig(metricConfig)
+            .build());
+    totalInflightRequestSensor = localMetricRepo.sensor("total_inflight_request");
+    totalInflightRequestSensor.add(TOTAL_INFLIGHT_REQUEST_COUNT, new Rate());
+  }
+
+  public Sensor getTotalInflightRequestSensor() {
+    return totalInflightRequestSensor;
+  }
+
+  public double getInFlightRequestRate() {
+    Metric metric = localMetricRepo.getMetric(TOTAL_INFLIGHT_REQUEST_COUNT);
+    // max return -infinity when there are no samples. validate only against finite value
+    return Double.isFinite(metric.value()) ? metric.value() : 0.0;
+  }
+}

--- a/services/venice-router/src/main/java/com/linkedin/venice/router/RouterServer.java
+++ b/services/venice-router/src/main/java/com/linkedin/venice/router/RouterServer.java
@@ -859,10 +859,7 @@ public class RouterServer extends AbstractVeniceService {
         if (hasInFlightRequest()) {
           throw new VeniceException("There are still in-flight requests in router");
         }
-      },
-          10,
-          Duration.ofSeconds(config.getRouterNettyGracefulShutdownPeriodSeconds()),
-          Collections.singletonList(VeniceException.class));
+      }, 30, Duration.ofSeconds(1), Collections.singletonList(VeniceException.class));
     } catch (VeniceException e) {
       LOGGER.error(
           "There are still in-flight request during router shutdown, still continuing shutdown, it might cause unhealthy request in client");

--- a/services/venice-router/src/main/java/com/linkedin/venice/router/RouterServer.java
+++ b/services/venice-router/src/main/java/com/linkedin/venice/router/RouterServer.java
@@ -86,6 +86,7 @@ import com.linkedin.venice.service.AbstractVeniceService;
 import com.linkedin.venice.servicediscovery.ServiceDiscoveryAnnouncer;
 import com.linkedin.venice.stats.ThreadPoolStats;
 import com.linkedin.venice.stats.VeniceJVMStats;
+import com.linkedin.venice.stats.VeniceMetricsConfig;
 import com.linkedin.venice.stats.VeniceMetricsRepository;
 import com.linkedin.venice.stats.ZkClientStatusStats;
 import com.linkedin.venice.stats.metrics.MetricEntity;
@@ -110,7 +111,10 @@ import io.netty.channel.socket.nio.NioServerSocketChannel;
 import io.netty.handler.codec.http.FullHttpResponse;
 import io.netty.handler.codec.http.HttpResponseStatus;
 import io.netty.util.concurrent.DefaultThreadFactory;
+import io.tehuti.metrics.MetricConfig;
 import io.tehuti.metrics.MetricsRepository;
+import io.tehuti.metrics.Sensor;
+import io.tehuti.metrics.stats.Rate;
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
 import java.time.Duration;
@@ -214,6 +218,13 @@ public class RouterServer extends AbstractVeniceService {
   private final AggHostHealthStats aggHostHealthStats;
 
   private ScheduledExecutorService retryManagerExecutorService;
+
+  public static final String TOTAL_INFLIGHT_REQUEST_COUNT = "total_inflight_request_count";
+
+  private final MetricConfig metricConfig;
+  private final VeniceMetricsRepository localMetricRepo;
+
+  private final Sensor totalInflightRequestSensor;
 
   public static void main(String args[]) throws Exception {
     if (args.length != 1) {
@@ -341,7 +352,9 @@ public class RouterServer extends AbstractVeniceService {
             requestType,
             config.isKeyValueProfilingEnabled(),
             metadataRepository,
-            config.isUnregisterMetricForDeletedStoreEnabled()));
+            config.isUnregisterMetricForDeletedStoreEnabled(),
+            totalInflightRequestSensor,
+            localMetricRepo));
     this.schemaRepository = new HelixReadOnlySchemaRepositoryAdapter(
         new HelixReadOnlyZKSharedSchemaRepository(
             readOnlyZKSharedSystemStoreRepository,
@@ -406,6 +419,15 @@ public class RouterServer extends AbstractVeniceService {
     Class<IdentityParser> identityParserClass = ReflectUtils.loadClass(config.getIdentityParserClassName());
     this.identityParser = ReflectUtils.callConstructor(identityParserClass, new Class[0], new Object[0]);
 
+    metricConfig = new MetricConfig().timeWindow(config.getRouterInFlightMetricWindowSeconds(), TimeUnit.SECONDS);
+    localMetricRepo = new VeniceMetricsRepository(
+        new VeniceMetricsConfig.Builder().setServiceName(ROUTER_SERVICE_NAME)
+            .setMetricPrefix(ROUTER_SERVICE_METRIC_PREFIX)
+            .setTehutiMetricConfig(metricConfig)
+            .build());
+    totalInflightRequestSensor = localMetricRepo.sensor("total_inflight_request");
+    totalInflightRequestSensor.add(TOTAL_INFLIGHT_REQUEST_COUNT, new Rate());
+
     verifySslOk();
   }
 
@@ -446,7 +468,9 @@ public class RouterServer extends AbstractVeniceService {
             requestType,
             config.isKeyValueProfilingEnabled(),
             metadataRepository,
-            config.isUnregisterMetricForDeletedStoreEnabled()));
+            config.isUnregisterMetricForDeletedStoreEnabled(),
+            null,
+            null));
     this.schemaRepository = schemaRepository;
     this.storeConfigRepository = storeConfigRepository;
     this.liveInstanceMonitor = liveInstanceMonitor;

--- a/services/venice-router/src/main/java/com/linkedin/venice/router/RouterServer.java
+++ b/services/venice-router/src/main/java/com/linkedin/venice/router/RouterServer.java
@@ -72,7 +72,6 @@ import com.linkedin.venice.router.stats.AggRouterHttpRequestStats;
 import com.linkedin.venice.router.stats.HealthCheckStats;
 import com.linkedin.venice.router.stats.LongTailRetryStatsProvider;
 import com.linkedin.venice.router.stats.RouteHttpRequestStats;
-import com.linkedin.venice.router.stats.RouterHttpRequestStats;
 import com.linkedin.venice.router.stats.RouterMetricEntity;
 import com.linkedin.venice.router.stats.RouterStats;
 import com.linkedin.venice.router.stats.RouterThrottleStats;
@@ -111,6 +110,7 @@ import io.netty.channel.socket.nio.NioServerSocketChannel;
 import io.netty.handler.codec.http.FullHttpResponse;
 import io.netty.handler.codec.http.HttpResponseStatus;
 import io.netty.util.concurrent.DefaultThreadFactory;
+import io.tehuti.Metric;
 import io.tehuti.metrics.MetricConfig;
 import io.tehuti.metrics.MetricsRepository;
 import io.tehuti.metrics.Sensor;
@@ -952,7 +952,9 @@ public class RouterServer extends AbstractVeniceService {
   }
 
   public double getInFlightRequestRate() {
-    return RouterHttpRequestStats.getInFlightRequestRate();
+    Metric metric = localMetricRepo.getMetric(TOTAL_INFLIGHT_REQUEST_COUNT);
+    // max return -infinity when there are no samples. validate only against finite value
+    return Double.isFinite(metric.value()) ? metric.value() : 0.0;
   }
 
   private void handleExceptionInStartServices(VeniceException e, boolean async) throws VeniceException {

--- a/services/venice-router/src/main/java/com/linkedin/venice/router/RouterServer.java
+++ b/services/venice-router/src/main/java/com/linkedin/venice/router/RouterServer.java
@@ -857,7 +857,7 @@ public class RouterServer extends AbstractVeniceService {
     try {
       RetryUtils.executeWithMaxAttempt(() -> {
         if (hasInFlightRequest()) {
-          throw new VeniceException("There are still in-flight requests in router");
+          throw new VeniceException("There are still in-flight requests in router :" + getInFlightRequestCount());
         }
       }, 30, Duration.ofSeconds(1), Collections.singletonList(VeniceException.class));
     } catch (VeniceException e) {
@@ -928,6 +928,10 @@ public class RouterServer extends AbstractVeniceService {
 
   public boolean hasInFlightRequest() {
     return RouterHttpRequestStats.hasInFlightRequests();
+  }
+
+  public long getInFlightRequestCount() {
+    return RouterHttpRequestStats.getInFlightRequestCount();
   }
 
   private void handleExceptionInStartServices(VeniceException e, boolean async) throws VeniceException {

--- a/services/venice-router/src/main/java/com/linkedin/venice/router/RouterServer.java
+++ b/services/venice-router/src/main/java/com/linkedin/venice/router/RouterServer.java
@@ -855,7 +855,7 @@ public class RouterServer extends AbstractVeniceService {
     // Graceful shutdown: Wait till all the requests are drained
     try {
       RetryUtils.executeWithMaxAttempt(() -> {
-        if (RouterHttpRequestStats.hasInFlightRequests()) {
+        if (hasInFlightRequest()) {
           throw new VeniceException("There are still in-flight requests in router");
         }
       },
@@ -925,6 +925,10 @@ public class RouterServer extends AbstractVeniceService {
 
   public ReadOnlySchemaRepository getSchemaRepository() {
     return schemaRepository;
+  }
+
+  public boolean hasInFlightRequest() {
+    return RouterHttpRequestStats.hasInFlightRequests();
   }
 
   private void handleExceptionInStartServices(VeniceException e, boolean async) throws VeniceException {

--- a/services/venice-router/src/main/java/com/linkedin/venice/router/RouterServer.java
+++ b/services/venice-router/src/main/java/com/linkedin/venice/router/RouterServer.java
@@ -852,6 +852,7 @@ public class RouterServer extends AbstractVeniceService {
      * correctly.
      */
 
+    LOGGER.info("Waiting to make sure all in-flight requests are drained");
     // Graceful shutdown: Wait till all the requests are drained
     try {
       RetryUtils.executeWithMaxAttempt(() -> {
@@ -866,6 +867,7 @@ public class RouterServer extends AbstractVeniceService {
       LOGGER.error(
           "There are still in-flight request during router shutdown, still continuing shutdown, it might cause unhealthy request in client");
     }
+    LOGGER.info("Drained all in-flight requests, starting to shutdown the router.");
     storageNodeClient.close();
     workerEventLoopGroup.shutdownGracefully();
     serverEventLoopGroup.shutdownGracefully();

--- a/services/venice-router/src/main/java/com/linkedin/venice/router/RouterServer.java
+++ b/services/venice-router/src/main/java/com/linkedin/venice/router/RouterServer.java
@@ -469,8 +469,8 @@ public class RouterServer extends AbstractVeniceService {
             config.isKeyValueProfilingEnabled(),
             metadataRepository,
             config.isUnregisterMetricForDeletedStoreEnabled(),
-            null,
-            null));
+            totalInflightRequestSensor,
+            localMetricRepo));
     this.schemaRepository = schemaRepository;
     this.storeConfigRepository = storeConfigRepository;
     this.liveInstanceMonitor = liveInstanceMonitor;

--- a/services/venice-router/src/main/java/com/linkedin/venice/router/RouterServer.java
+++ b/services/venice-router/src/main/java/com/linkedin/venice/router/RouterServer.java
@@ -322,7 +322,6 @@ public class RouterServer extends AbstractVeniceService {
       D2Client d2Client,
       String d2ServiceName) {
     this(properties, serviceDiscoveryAnnouncers, accessController, sslFactory, metricsRepository, true);
-    inFlightRequestStat = new InFlightRequestStat(config);
     HelixReadOnlyZKSharedSystemStoreRepository readOnlyZKSharedSystemStoreRepository =
         new HelixReadOnlyZKSharedSystemStoreRepository(zkClient, adapter, config.getSystemSchemaClusterName());
     HelixReadOnlyStoreRepository readOnlyStoreRepository = new HelixReadOnlyStoreRepository(
@@ -407,6 +406,7 @@ public class RouterServer extends AbstractVeniceService {
 
     Class<IdentityParser> identityParserClass = ReflectUtils.loadClass(config.getIdentityParserClassName());
     this.identityParser = ReflectUtils.callConstructor(identityParserClass, new Class[0], new Object[0]);
+    inFlightRequestStat = new InFlightRequestStat(config);
     verifySslOk();
   }
 

--- a/services/venice-router/src/main/java/com/linkedin/venice/router/RouterServer.java
+++ b/services/venice-router/src/main/java/com/linkedin/venice/router/RouterServer.java
@@ -856,8 +856,9 @@ public class RouterServer extends AbstractVeniceService {
     // Graceful shutdown: Wait till all the requests are drained
     try {
       RetryUtils.executeWithMaxAttempt(() -> {
-        if (hasInFlightRequest()) {
-          throw new VeniceException("There are still in-flight requests in router :" + getInFlightRequestCount());
+        double inFlightRequestRate = getInFlightRequestRate();
+        if (inFlightRequestRate > 0.0) {
+          throw new VeniceException("There are still in-flight requests in router :" + inFlightRequestRate);
         }
       }, 30, Duration.ofSeconds(1), Collections.singletonList(VeniceException.class));
     } catch (VeniceException e) {
@@ -926,12 +927,8 @@ public class RouterServer extends AbstractVeniceService {
     return schemaRepository;
   }
 
-  public boolean hasInFlightRequest() {
-    return RouterHttpRequestStats.hasInFlightRequests();
-  }
-
-  public long getInFlightRequestCount() {
-    return RouterHttpRequestStats.getInFlightRequestCount();
+  public double getInFlightRequestRate() {
+    return RouterHttpRequestStats.getInFlightRequestRate();
   }
 
   private void handleExceptionInStartServices(VeniceException e, boolean async) throws VeniceException {

--- a/services/venice-router/src/main/java/com/linkedin/venice/router/VeniceRouterConfig.java
+++ b/services/venice-router/src/main/java/com/linkedin/venice/router/VeniceRouterConfig.java
@@ -154,6 +154,7 @@ public class VeniceRouterConfig implements RouterRetryConfig {
   private final int refreshAttemptsForZkReconnect;
   private final long refreshIntervalForZkReconnectInMs;
   private final int routerNettyGracefulShutdownPeriodSeconds;
+  private final int routerInFlightMetricWindowSeconds;
   private final boolean enforceSecureOnly;
   private final boolean dnsCacheEnabled;
   private final String hostPatternForDnsCache;
@@ -265,6 +266,7 @@ public class VeniceRouterConfig implements RouterRetryConfig {
       refreshIntervalForZkReconnectInMs =
           props.getLong(REFRESH_INTERVAL_FOR_ZK_RECONNECT_MS, java.util.concurrent.TimeUnit.SECONDS.toMillis(10));
       routerNettyGracefulShutdownPeriodSeconds = props.getInt(ROUTER_NETTY_GRACEFUL_SHUTDOWN_PERIOD_SECONDS, 10);
+      routerInFlightMetricWindowSeconds = props.getInt(ROUTER_NETTY_GRACEFUL_SHUTDOWN_PERIOD_SECONDS, 5);
       enforceSecureOnly = props.getBoolean(ENFORCE_SECURE_ROUTER, false);
 
       // This only needs to be enabled in some DC, where slow DNS lookup happens.
@@ -503,6 +505,10 @@ public class VeniceRouterConfig implements RouterRetryConfig {
 
   public int getRouterNettyGracefulShutdownPeriodSeconds() {
     return routerNettyGracefulShutdownPeriodSeconds;
+  }
+
+  public int getRouterInFlightMetricWindowSeconds() {
+    return routerInFlightMetricWindowSeconds;
   }
 
   public boolean isEnforcingSecureOnly() {

--- a/services/venice-router/src/main/java/com/linkedin/venice/router/stats/AggRouterHttpRequestStats.java
+++ b/services/venice-router/src/main/java/com/linkedin/venice/router/stats/AggRouterHttpRequestStats.java
@@ -5,9 +5,11 @@ import com.linkedin.venice.meta.ReadOnlyStoreRepository;
 import com.linkedin.venice.read.RequestType;
 import com.linkedin.venice.stats.AbstractVeniceAggStats;
 import com.linkedin.venice.stats.AbstractVeniceAggStoreStats;
+import com.linkedin.venice.stats.VeniceMetricsRepository;
 import com.linkedin.venice.utils.concurrent.VeniceConcurrentHashMap;
 import io.netty.handler.codec.http.HttpResponseStatus;
 import io.tehuti.metrics.MetricsRepository;
+import io.tehuti.metrics.Sensor;
 import java.util.Map;
 import java.util.function.Consumer;
 import java.util.function.Function;
@@ -29,7 +31,9 @@ public class AggRouterHttpRequestStats extends AbstractVeniceAggStoreStats<Route
         requestType,
         false,
         metadataRepository,
-        isUnregisterMetricForDeletedStoreEnabled);
+        isUnregisterMetricForDeletedStoreEnabled,
+        null,
+        null);
   }
 
   public AggRouterHttpRequestStats(
@@ -38,7 +42,9 @@ public class AggRouterHttpRequestStats extends AbstractVeniceAggStoreStats<Route
       RequestType requestType,
       boolean isKeyValueProfilingEnabled,
       ReadOnlyStoreRepository metadataRepository,
-      boolean isUnregisterMetricForDeletedStoreEnabled) {
+      boolean isUnregisterMetricForDeletedStoreEnabled,
+      Sensor totalInFlightRequestSensor,
+      VeniceMetricsRepository inflightMetricRepo) {
     super(cluster, metricsRepository, metadataRepository, isUnregisterMetricForDeletedStoreEnabled);
     // Disable store level non-streaming multi get stats reporting because it's no longer used in clients. We still
     // report to the total stats for visibility of potential old clients.
@@ -61,7 +67,9 @@ public class AggRouterHttpRequestStats extends AbstractVeniceAggStoreStats<Route
           clusterName,
           requestType,
           stats,
-          isKeyValueProfilingEnabled);
+          isKeyValueProfilingEnabled,
+          totalInFlightRequestSensor,
+          inflightMetricRepo);
     });
   }
 

--- a/services/venice-router/src/main/java/com/linkedin/venice/router/stats/AggRouterHttpRequestStats.java
+++ b/services/venice-router/src/main/java/com/linkedin/venice/router/stats/AggRouterHttpRequestStats.java
@@ -5,7 +5,6 @@ import com.linkedin.venice.meta.ReadOnlyStoreRepository;
 import com.linkedin.venice.read.RequestType;
 import com.linkedin.venice.stats.AbstractVeniceAggStats;
 import com.linkedin.venice.stats.AbstractVeniceAggStoreStats;
-import com.linkedin.venice.stats.VeniceMetricsRepository;
 import com.linkedin.venice.utils.concurrent.VeniceConcurrentHashMap;
 import io.netty.handler.codec.http.HttpResponseStatus;
 import io.tehuti.metrics.MetricsRepository;
@@ -32,7 +31,6 @@ public class AggRouterHttpRequestStats extends AbstractVeniceAggStoreStats<Route
         false,
         metadataRepository,
         isUnregisterMetricForDeletedStoreEnabled,
-        null,
         null);
   }
 
@@ -43,8 +41,7 @@ public class AggRouterHttpRequestStats extends AbstractVeniceAggStoreStats<Route
       boolean isKeyValueProfilingEnabled,
       ReadOnlyStoreRepository metadataRepository,
       boolean isUnregisterMetricForDeletedStoreEnabled,
-      Sensor totalInFlightRequestSensor,
-      VeniceMetricsRepository inflightMetricRepo) {
+      Sensor totalInFlightRequestSensor) {
     super(cluster, metricsRepository, metadataRepository, isUnregisterMetricForDeletedStoreEnabled);
     // Disable store level non-streaming multi get stats reporting because it's no longer used in clients. We still
     // report to the total stats for visibility of potential old clients.

--- a/services/venice-router/src/main/java/com/linkedin/venice/router/stats/AggRouterHttpRequestStats.java
+++ b/services/venice-router/src/main/java/com/linkedin/venice/router/stats/AggRouterHttpRequestStats.java
@@ -68,8 +68,7 @@ public class AggRouterHttpRequestStats extends AbstractVeniceAggStoreStats<Route
           requestType,
           stats,
           isKeyValueProfilingEnabled,
-          totalInFlightRequestSensor,
-          inflightMetricRepo);
+          totalInFlightRequestSensor);
     });
   }
 

--- a/services/venice-router/src/main/java/com/linkedin/venice/router/stats/RouterHttpRequestStats.java
+++ b/services/venice-router/src/main/java/com/linkedin/venice/router/stats/RouterHttpRequestStats.java
@@ -657,16 +657,10 @@ public class RouterHttpRequestStats extends AbstractVeniceHttpStats {
     return this.registerSensor(sensorName, stats);
   }
 
-  static public boolean hasInFlightRequests() {
+  static public double getInFlightRequestRate() {
     Metric metric = localMetricRepo.getMetric(TOTAL_INFLIGHT_REQUEST_COUNT);
     // max return -infinity when there are no samples. validate only against finite value
-    return Double.isFinite(metric.value()) && metric.value() > 0.0;
-  }
-
-  static public long getInFlightRequestCount() {
-    Metric metric = localMetricRepo.getMetric(TOTAL_INFLIGHT_REQUEST_COUNT);
-    // max return -infinity when there are no samples. validate only against finite value
-    return Double.isFinite(metric.value()) ? (long) metric.value() : 0;
+    return Double.isFinite(metric.value()) ? metric.value() : 0.0;
   }
 
   /** used only for testing */

--- a/services/venice-router/src/main/java/com/linkedin/venice/router/stats/RouterHttpRequestStats.java
+++ b/services/venice-router/src/main/java/com/linkedin/venice/router/stats/RouterHttpRequestStats.java
@@ -74,7 +74,7 @@ public class RouterHttpRequestStats extends AbstractVeniceHttpStats {
 
   private final static Sensor totalInflightRequestSensor = localMetricRepo.sensor("total_inflight_request");
   static {
-    totalInflightRequestSensor.add("total_inflight_request_count", new Total());
+    totalInflightRequestSensor.add("total_inflight_request_count", new Gauge());
   }
 
   /** metrics to track incoming requests */

--- a/services/venice-router/src/main/java/com/linkedin/venice/router/stats/RouterHttpRequestStats.java
+++ b/services/venice-router/src/main/java/com/linkedin/venice/router/stats/RouterHttpRequestStats.java
@@ -663,6 +663,12 @@ public class RouterHttpRequestStats extends AbstractVeniceHttpStats {
     return Double.isFinite(metric.value()) && metric.value() > 0.0;
   }
 
+  static public long getInFlightRequestCount() {
+    Metric metric = localMetricRepo.getMetric(TOTAL_INFLIGHT_REQUEST_COUNT);
+    // max return -infinity when there are no samples. validate only against finite value
+    return Double.isFinite(metric.value()) ? (long) metric.value() : 0;
+  }
+
   /** used only for testing */
   boolean emitOpenTelemetryMetrics() {
     return this.emitOpenTelemetryMetrics;

--- a/services/venice-router/src/main/java/com/linkedin/venice/router/stats/RouterHttpRequestStats.java
+++ b/services/venice-router/src/main/java/com/linkedin/venice/router/stats/RouterHttpRequestStats.java
@@ -66,6 +66,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 public class RouterHttpRequestStats extends AbstractVeniceHttpStats {
   private static final MetricConfig METRIC_CONFIG = new MetricConfig().timeWindow(10, TimeUnit.SECONDS);
+  private static final String TOTAL_INFLIGHT_REQUEST_COUNT = "total_inflight_request_count";
   private static final VeniceMetricsRepository localMetricRepo = new VeniceMetricsRepository(
       new VeniceMetricsConfig.Builder().setServiceName(ROUTER_SERVICE_NAME)
           .setMetricPrefix(ROUTER_SERVICE_METRIC_PREFIX)
@@ -74,7 +75,7 @@ public class RouterHttpRequestStats extends AbstractVeniceHttpStats {
 
   private final static Sensor totalInflightRequestSensor = localMetricRepo.sensor("total_inflight_request");
   static {
-    totalInflightRequestSensor.add("total_inflight_request_count", new Gauge());
+    totalInflightRequestSensor.add(TOTAL_INFLIGHT_REQUEST_COUNT, new Gauge());
   }
 
   /** metrics to track incoming requests */
@@ -658,9 +659,9 @@ public class RouterHttpRequestStats extends AbstractVeniceHttpStats {
   }
 
   static public boolean hasInFlightRequests() {
-    Metric metric = localMetricRepo.getMetric("total_inflight_request_count");
+    Metric metric = localMetricRepo.getMetric(TOTAL_INFLIGHT_REQUEST_COUNT);
     // max return -infinity when there are no samples. validate only against finite value
-    return Double.isFinite(metric.value()) ? metric.value() > 0.0 : false;
+    return Double.isFinite(metric.value()) && metric.value() > 0.0;
   }
 
   /** used only for testing */

--- a/services/venice-router/src/main/java/com/linkedin/venice/router/stats/RouterHttpRequestStats.java
+++ b/services/venice-router/src/main/java/com/linkedin/venice/router/stats/RouterHttpRequestStats.java
@@ -65,7 +65,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 
 public class RouterHttpRequestStats extends AbstractVeniceHttpStats {
-  private static final MetricConfig METRIC_CONFIG = new MetricConfig().timeWindow(10, TimeUnit.SECONDS);
+  private static final MetricConfig METRIC_CONFIG = new MetricConfig().timeWindow(5, TimeUnit.SECONDS);
   private static final String TOTAL_INFLIGHT_REQUEST_COUNT = "total_inflight_request_count";
   private static final VeniceMetricsRepository localMetricRepo = new VeniceMetricsRepository(
       new VeniceMetricsConfig.Builder().setServiceName(ROUTER_SERVICE_NAME)
@@ -75,7 +75,7 @@ public class RouterHttpRequestStats extends AbstractVeniceHttpStats {
 
   private final static Sensor totalInflightRequestSensor = localMetricRepo.sensor("total_inflight_request");
   static {
-    totalInflightRequestSensor.add(TOTAL_INFLIGHT_REQUEST_COUNT, new Gauge());
+    totalInflightRequestSensor.add(TOTAL_INFLIGHT_REQUEST_COUNT, new Rate());
   }
 
   /** metrics to track incoming requests */
@@ -622,7 +622,6 @@ public class RouterHttpRequestStats extends AbstractVeniceHttpStats {
      * there is no need to record into the sensor again. We just want to maintain the bookkeeping.
      */
     currentInFlightRequest.decrementAndGet();
-    totalInflightRequestSensor.record(-1);
   }
 
   public void recordAllowedRetryRequest() {

--- a/services/venice-router/src/main/java/com/linkedin/venice/router/stats/RouterHttpRequestStats.java
+++ b/services/venice-router/src/main/java/com/linkedin/venice/router/stats/RouterHttpRequestStats.java
@@ -74,7 +74,7 @@ public class RouterHttpRequestStats extends AbstractVeniceHttpStats {
 
   private final static Sensor totalInflightRequestSensor = localMetricRepo.sensor("total_inflight_request");
   static {
-    totalInflightRequestSensor.add("total_inflight_request_count", new Rate());
+    totalInflightRequestSensor.add("total_inflight_request_count", new Total());
   }
 
   /** metrics to track incoming requests */

--- a/services/venice-router/src/main/java/com/linkedin/venice/router/stats/RouterHttpRequestStats.java
+++ b/services/venice-router/src/main/java/com/linkedin/venice/router/stats/RouterHttpRequestStats.java
@@ -1,6 +1,5 @@
 package com.linkedin.venice.router.stats;
 
-import static com.linkedin.venice.router.RouterServer.TOTAL_INFLIGHT_REQUEST_COUNT;
 import static com.linkedin.venice.router.stats.RouterMetricEntity.ABORTED_RETRY_COUNT;
 import static com.linkedin.venice.router.stats.RouterMetricEntity.ALLOWED_RETRY_COUNT;
 import static com.linkedin.venice.router.stats.RouterMetricEntity.CALL_COUNT;
@@ -46,7 +45,6 @@ import com.linkedin.venice.stats.metrics.TehutiMetricNameEnum;
 import io.netty.handler.codec.http.HttpResponseStatus;
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.common.AttributesBuilder;
-import io.tehuti.Metric;
 import io.tehuti.metrics.MeasurableStat;
 import io.tehuti.metrics.MetricsRepository;
 import io.tehuti.metrics.Sensor;
@@ -142,8 +140,7 @@ public class RouterHttpRequestStats extends AbstractVeniceHttpStats {
       RequestType requestType,
       ScatterGatherStats scatterGatherStats,
       boolean isKeyValueProfilingEnabled,
-      Sensor totalInFlightRequestSensor,
-      VeniceMetricsRepository inflightMetricRepo) {
+      Sensor totalInFlightRequestSensor) {
     super(metricsRepository, storeName, requestType);
     VeniceOpenTelemetryMetricsRepository otelRepository = null;
     if (metricsRepository instanceof VeniceMetricsRepository) {
@@ -391,7 +388,6 @@ public class RouterHttpRequestStats extends AbstractVeniceHttpStats {
 
     metaStoreShadowReadSensor = registerSensor("meta_store_shadow_read", new OccurrenceRate());
     this.totalInFlightRequestSensor = totalInFlightRequestSensor;
-    this.inflightMetricRepo = inflightMetricRepo;
   }
 
   private String getDimensionName(VeniceMetricsDimensions dimension) {
@@ -647,12 +643,6 @@ public class RouterHttpRequestStats extends AbstractVeniceHttpStats {
    */
   private Sensor registerSensorFinal(String sensorName, MeasurableStat... stats) {
     return this.registerSensor(sensorName, stats);
-  }
-
-  static public double getInFlightRequestRate() {
-    Metric metric = inflightMetricRepo.getMetric(TOTAL_INFLIGHT_REQUEST_COUNT);
-    // max return -infinity when there are no samples. validate only against finite value
-    return Double.isFinite(metric.value()) ? metric.value() : 0.0;
   }
 
   /** used only for testing */

--- a/services/venice-router/src/test/java/com/linkedin/venice/router/RouteHttpRequestStatsTest.java
+++ b/services/venice-router/src/test/java/com/linkedin/venice/router/RouteHttpRequestStatsTest.java
@@ -1,8 +1,8 @@
 package com.linkedin.venice.router;
 
+import static com.linkedin.venice.router.InFlightRequestStat.TOTAL_INFLIGHT_REQUEST_COUNT;
 import static com.linkedin.venice.router.RouterServer.ROUTER_SERVICE_METRIC_PREFIX;
 import static com.linkedin.venice.router.RouterServer.ROUTER_SERVICE_NAME;
-import static com.linkedin.venice.router.RouterServer.TOTAL_INFLIGHT_REQUEST_COUNT;
 import static com.linkedin.venice.utils.TestUtils.waitForNonDeterministicAssertion;
 import static org.mockito.Mockito.mock;
 

--- a/services/venice-router/src/test/java/com/linkedin/venice/router/RouteHttpRequestStatsTest.java
+++ b/services/venice-router/src/test/java/com/linkedin/venice/router/RouteHttpRequestStatsTest.java
@@ -57,9 +57,9 @@ public class RouteHttpRequestStatsTest {
   @Test
   public void routerInFlightMetricTest() {
     routerHttpRequestStats.recordIncomingRequest();
-    Assert.assertTrue(RouterHttpRequestStats.hasInFlightRequests());
+    Assert.assertTrue(RouterHttpRequestStats.getInFlightRequestRate() > 0.0);
     // After waiting for metric time window, it wil be reset back to 0
     Utils.sleep(10000);
-    Assert.assertFalse(RouterHttpRequestStats.hasInFlightRequests());
+    Assert.assertEquals(RouterHttpRequestStats.getInFlightRequestRate(), 0.0);
   }
 }

--- a/services/venice-router/src/test/java/com/linkedin/venice/router/RouteHttpRequestStatsTest.java
+++ b/services/venice-router/src/test/java/com/linkedin/venice/router/RouteHttpRequestStatsTest.java
@@ -52,8 +52,13 @@ public class RouteHttpRequestStatsTest {
 
     Assert.assertEquals(stats.getPendingRequestCount("my_host1"), 1);
     Assert.assertEquals(stats.getPendingRequestCount("my_host2"), 0);
+  }
+
+  @Test
+  public void routerInFlightMetricTest() {
     routerHttpRequestStats.recordIncomingRequest();
     Assert.assertTrue(RouterHttpRequestStats.hasInFlightRequests());
+    // After waiting for metric time window, it wil be reset back to 0
     Utils.sleep(10000);
     Assert.assertFalse(RouterHttpRequestStats.hasInFlightRequests());
   }

--- a/services/venice-router/src/test/java/com/linkedin/venice/router/RouteHttpRequestStatsTest.java
+++ b/services/venice-router/src/test/java/com/linkedin/venice/router/RouteHttpRequestStatsTest.java
@@ -8,6 +8,7 @@ import com.linkedin.venice.router.httpclient.StorageNodeClient;
 import com.linkedin.venice.router.stats.RouteHttpRequestStats;
 import com.linkedin.venice.router.stats.RouterHttpRequestStats;
 import com.linkedin.venice.tehuti.MockTehutiReporter;
+import com.linkedin.venice.utils.Utils;
 import com.linkedin.venice.utils.metrics.MetricsRepositoryUtils;
 import io.tehuti.metrics.MetricsRepository;
 import org.testng.Assert;
@@ -53,5 +54,7 @@ public class RouteHttpRequestStatsTest {
     Assert.assertEquals(stats.getPendingRequestCount("my_host2"), 0);
     routerHttpRequestStats.recordIncomingRequest();
     Assert.assertTrue(RouterHttpRequestStats.hasInFlightRequests());
+    Utils.sleep(10000);
+    Assert.assertFalse(RouterHttpRequestStats.hasInFlightRequests());
   }
 }

--- a/services/venice-router/src/test/java/com/linkedin/venice/router/RouteHttpRequestStatsTest.java
+++ b/services/venice-router/src/test/java/com/linkedin/venice/router/RouteHttpRequestStatsTest.java
@@ -53,7 +53,5 @@ public class RouteHttpRequestStatsTest {
     Assert.assertEquals(stats.getPendingRequestCount("my_host2"), 0);
     routerHttpRequestStats.recordIncomingRequest();
     Assert.assertTrue(RouterHttpRequestStats.hasInFlightRequests());
-    routerHttpRequestStats.recordResponse();
-    Assert.assertFalse(RouterHttpRequestStats.hasInFlightRequests());
   }
 }

--- a/services/venice-router/src/test/java/com/linkedin/venice/router/RouteHttpRequestStatsTest.java
+++ b/services/venice-router/src/test/java/com/linkedin/venice/router/RouteHttpRequestStatsTest.java
@@ -53,5 +53,7 @@ public class RouteHttpRequestStatsTest {
     Assert.assertEquals(stats.getPendingRequestCount("my_host2"), 0);
     routerHttpRequestStats.recordIncomingRequest();
     Assert.assertTrue(RouterHttpRequestStats.hasInFlightRequests());
+    routerHttpRequestStats.recordResponse();
+    Assert.assertFalse(RouterHttpRequestStats.hasInFlightRequests());
   }
 }

--- a/services/venice-router/src/test/java/com/linkedin/venice/router/RouteHttpRequestStatsTest.java
+++ b/services/venice-router/src/test/java/com/linkedin/venice/router/RouteHttpRequestStatsTest.java
@@ -1,9 +1,7 @@
 package com.linkedin.venice.router;
 
-import static com.linkedin.venice.router.InFlightRequestStat.TOTAL_INFLIGHT_REQUEST_COUNT;
-import static com.linkedin.venice.router.RouterServer.ROUTER_SERVICE_METRIC_PREFIX;
-import static com.linkedin.venice.router.RouterServer.ROUTER_SERVICE_NAME;
 import static com.linkedin.venice.utils.TestUtils.waitForNonDeterministicAssertion;
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 
 import com.linkedin.alpini.router.monitoring.ScatterGatherStats;
@@ -11,15 +9,10 @@ import com.linkedin.venice.read.RequestType;
 import com.linkedin.venice.router.httpclient.StorageNodeClient;
 import com.linkedin.venice.router.stats.RouteHttpRequestStats;
 import com.linkedin.venice.router.stats.RouterHttpRequestStats;
-import com.linkedin.venice.stats.VeniceMetricsConfig;
-import com.linkedin.venice.stats.VeniceMetricsRepository;
 import com.linkedin.venice.tehuti.MockTehutiReporter;
 import com.linkedin.venice.utils.metrics.MetricsRepositoryUtils;
-import io.tehuti.Metric;
-import io.tehuti.metrics.MetricConfig;
 import io.tehuti.metrics.MetricsRepository;
 import io.tehuti.metrics.Sensor;
-import io.tehuti.metrics.stats.Rate;
 import java.util.concurrent.TimeUnit;
 import org.testng.Assert;
 import org.testng.annotations.BeforeSuite;
@@ -30,22 +23,17 @@ public class RouteHttpRequestStatsTest {
   private MockTehutiReporter reporter;
   private RouteHttpRequestStats stats;
   private RouterHttpRequestStats routerHttpRequestStats;
-
-  private VeniceMetricsRepository localMetricRepo;
+  private InFlightRequestStat inFlightRequestStat;
 
   @BeforeSuite
   public void setUp() {
     MetricsRepository metrics = MetricsRepositoryUtils.createSingleThreadedVeniceMetricsRepository();
     reporter = new MockTehutiReporter();
     metrics.addReporter(reporter);
-    MetricConfig metricConfig = new MetricConfig().timeWindow(1, TimeUnit.SECONDS);
-    localMetricRepo = new VeniceMetricsRepository(
-        new VeniceMetricsConfig.Builder().setServiceName(ROUTER_SERVICE_NAME)
-            .setMetricPrefix(ROUTER_SERVICE_METRIC_PREFIX)
-            .setTehutiMetricConfig(metricConfig)
-            .build());
-    Sensor totalInflightRequestSensor = localMetricRepo.sensor("total_inflight_request");
-    totalInflightRequestSensor.add(TOTAL_INFLIGHT_REQUEST_COUNT, new Rate());
+    VeniceRouterConfig mockConfig = mock(VeniceRouterConfig.class);
+    doReturn(1).when(mockConfig).getRouterInFlightMetricWindowSeconds();
+    inFlightRequestStat = new InFlightRequestStat(mockConfig);
+    Sensor totalInflightRequestSensor = inFlightRequestStat.getTotalInflightRequestSensor();
     stats = new RouteHttpRequestStats(metrics, mock(StorageNodeClient.class));
     routerHttpRequestStats = new RouterHttpRequestStats(
         metrics,
@@ -77,16 +65,10 @@ public class RouteHttpRequestStatsTest {
   @Test
   public void routerInFlightMetricTest() {
     routerHttpRequestStats.recordIncomingRequest();
-    Assert.assertTrue(getInFlightRequestRate() > 0.0);
+    Assert.assertTrue(inFlightRequestStat.getInFlightRequestRate() > 0.0);
     // After waiting for metric time window, it wil be reset back to 0
     waitForNonDeterministicAssertion(5, TimeUnit.SECONDS, true, () -> {
-      Assert.assertEquals(getInFlightRequestRate(), 0.0);
+      Assert.assertEquals(inFlightRequestStat.getInFlightRequestRate(), 0.0);
     });
-  }
-
-  public double getInFlightRequestRate() {
-    Metric metric = localMetricRepo.getMetric(TOTAL_INFLIGHT_REQUEST_COUNT);
-    // max return -infinity when there are no samples. validate only against finite value
-    return Double.isFinite(metric.value()) ? metric.value() : 0.0;
   }
 }

--- a/services/venice-router/src/test/java/com/linkedin/venice/router/stats/AggRouterHttpRequestStatsTest.java
+++ b/services/venice-router/src/test/java/com/linkedin/venice/router/stats/AggRouterHttpRequestStatsTest.java
@@ -38,8 +38,7 @@ public class AggRouterHttpRequestStatsTest {
         false,
         storeMetadataRepository,
         true,
-        mock(Sensor.class),
-        mock(VeniceMetricsRepository.class));
+        mock(Sensor.class));
 
     stats.recordRequest("store5");
     Assert.assertEquals(reporter.query(".total--request.Count").value(), 1d);
@@ -78,8 +77,7 @@ public class AggRouterHttpRequestStatsTest {
         true,
         storeMetadataRepository,
         true,
-        mock(Sensor.class),
-        mock(VeniceMetricsRepository.class));
+        mock(Sensor.class));
 
     for (int i = 1; i <= 100; i += 1) {
       stats.recordKeySize(i);
@@ -106,8 +104,7 @@ public class AggRouterHttpRequestStatsTest {
         false,
         storeMetadataRepository,
         true,
-        mock(Sensor.class),
-        mock(VeniceMetricsRepository.class));
+        mock(Sensor.class));
     AggRouterHttpRequestStats streamingMultiGetStats = new AggRouterHttpRequestStats(
         clusterName,
         metricsRepository,
@@ -115,8 +112,7 @@ public class AggRouterHttpRequestStatsTest {
         false,
         storeMetadataRepository,
         true,
-        mock(Sensor.class),
-        mock(VeniceMetricsRepository.class));
+        mock(Sensor.class));
     String storeName = Utils.getUniqueString("test-store");
     multiGetStats.recordRequest(storeName);
     streamingMultiGetStats.recordRequest(storeName);

--- a/services/venice-router/src/test/java/com/linkedin/venice/router/stats/AggRouterHttpRequestStatsTest.java
+++ b/services/venice-router/src/test/java/com/linkedin/venice/router/stats/AggRouterHttpRequestStatsTest.java
@@ -1,6 +1,7 @@
 package com.linkedin.venice.router.stats;
 
 import static io.netty.handler.codec.http.HttpResponseStatus.TOO_MANY_REQUESTS;
+import static org.mockito.Mockito.mock;
 
 import com.linkedin.venice.meta.ReadOnlyStoreRepository;
 import com.linkedin.venice.read.RequestType;
@@ -9,7 +10,7 @@ import com.linkedin.venice.tehuti.MockTehutiReporter;
 import com.linkedin.venice.utils.Utils;
 import io.netty.handler.codec.http.HttpResponseStatus;
 import io.tehuti.TehutiException;
-import org.mockito.Mockito;
+import io.tehuti.metrics.Sensor;
 import org.testng.Assert;
 import org.testng.annotations.BeforeSuite;
 import org.testng.annotations.Test;
@@ -25,7 +26,7 @@ public class AggRouterHttpRequestStatsTest {
     this.metricsRepository = new VeniceMetricsRepository();
     reporter = new MockTehutiReporter();
     metricsRepository.addReporter(reporter);
-    storeMetadataRepository = Mockito.mock(ReadOnlyStoreRepository.class);
+    storeMetadataRepository = mock(ReadOnlyStoreRepository.class);
   }
 
   @Test
@@ -34,8 +35,11 @@ public class AggRouterHttpRequestStatsTest {
         "test-cluster",
         metricsRepository,
         RequestType.SINGLE_GET,
+        false,
         storeMetadataRepository,
-        true);
+        true,
+        mock(Sensor.class),
+        mock(VeniceMetricsRepository.class));
 
     stats.recordRequest("store5");
     Assert.assertEquals(reporter.query(".total--request.Count").value(), 1d);
@@ -73,7 +77,9 @@ public class AggRouterHttpRequestStatsTest {
         RequestType.COMPUTE,
         true,
         storeMetadataRepository,
-        true);
+        true,
+        mock(Sensor.class),
+        mock(VeniceMetricsRepository.class));
 
     for (int i = 1; i <= 100; i += 1) {
       stats.recordKeySize(i);
@@ -97,14 +103,20 @@ public class AggRouterHttpRequestStatsTest {
         clusterName,
         metricsRepository,
         RequestType.MULTI_GET,
+        false,
         storeMetadataRepository,
-        true);
+        true,
+        mock(Sensor.class),
+        mock(VeniceMetricsRepository.class));
     AggRouterHttpRequestStats streamingMultiGetStats = new AggRouterHttpRequestStats(
         clusterName,
         metricsRepository,
         RequestType.MULTI_GET_STREAMING,
+        false,
         storeMetadataRepository,
-        true);
+        true,
+        mock(Sensor.class),
+        mock(VeniceMetricsRepository.class));
     String storeName = Utils.getUniqueString("test-store");
     multiGetStats.recordRequest(storeName);
     streamingMultiGetStats.recordRequest(storeName);

--- a/services/venice-router/src/test/java/com/linkedin/venice/router/stats/RouterHttpRequestStatsTest.java
+++ b/services/venice-router/src/test/java/com/linkedin/venice/router/stats/RouterHttpRequestStatsTest.java
@@ -55,7 +55,6 @@ public class RouterHttpRequestStatsTest {
         RequestType.SINGLE_GET,
         mock(ScatterGatherStats.class),
         false,
-        null,
         null);
 
     if (useVeniceMetricRepository && isOtelEnabled) {

--- a/services/venice-router/src/test/java/com/linkedin/venice/router/stats/RouterHttpRequestStatsTest.java
+++ b/services/venice-router/src/test/java/com/linkedin/venice/router/stats/RouterHttpRequestStatsTest.java
@@ -54,7 +54,9 @@ public class RouterHttpRequestStatsTest {
         clusterName,
         RequestType.SINGLE_GET,
         mock(ScatterGatherStats.class),
-        false);
+        false,
+        null,
+        null);
 
     if (useVeniceMetricRepository && isOtelEnabled) {
       assertTrue(routerHttpRequestStats.emitOpenTelemetryMetrics(), "Otel should be enabled");


### PR DESCRIPTION
<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat], [protocol]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## Fix in-flight request draining in router shutdown
<!--
Describe
- What changes to make and why you are making these changes.
- How are you going to achieve your goal.
- Describe what testings you have done, for example, performance testing etc.

If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->
Fix: Properly Track In-Flight Requests During Router Shutdown

When the router is shutting down, it checks for in-flight requests to ensure they are properly drained — otherwise, clients may encounter errors.

Currently, this uses a Rate sensor to increment and decrement the request count. However, calling record(-1) on a Rate sensor does not actually decrease the sensor’s rate value.  This can lead to incorrect tracking of in-flight requests and potentially leave requests unaccounted for during shutdown. 

This PR addresses that behavior to ensure request counts are accurately managed and clients don’t see unexpected errors during router shutdown by replacing the `Rate` with `Gauge` stat.

## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
CI tests
## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.