### PR TITLE
[changelog][client] Add viewname to changelog client factory

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/consumer/VeniceChangelogConsumerClientFactory.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/consumer/VeniceChangelogConsumerClientFactory.java
@@ -71,12 +71,28 @@ public class VeniceChangelogConsumerClientFactory {
    * each consumer can only subscribe to certain partitions. Multiple such consumers can work in parallel.
    */
   public <K, V> VeniceChangelogConsumer<K, V> getChangelogConsumer(String storeName, String consumerId, Class clazz) {
-    return storeClientMap.computeIfAbsent(suffixConsumerIdToStore(storeName, consumerId), name -> {
+    return getChangelogConsumer(storeName, consumerId, clazz, globalChangelogClientConfig.getViewName());
+  }
+
+  public <K, V> VeniceChangelogConsumer<K, V> getChangelogConsumer(
+      String storeName,
+      String consumerId,
+      Class clazz,
+      String viewNameOverride) {
+    String adjustedConsumerId;
+    if (!StringUtils.isEmpty(viewNameOverride)) {
+      adjustedConsumerId = consumerId + "-" + viewNameOverride;
+    } else {
+      adjustedConsumerId = consumerId;
+    }
+    return storeClientMap.computeIfAbsent(suffixConsumerIdToStore(storeName, adjustedConsumerId), name -> {
       ChangelogClientConfig newStoreChangelogClientConfig =
           getNewStoreChangelogClientConfig(storeName).setSpecificValue(clazz);
       newStoreChangelogClientConfig.setConsumerName(name);
+      newStoreChangelogClientConfig.setViewName(viewNameOverride);
       String viewClass = getViewClass(newStoreChangelogClientConfig, storeName);
-      String consumerName = suffixConsumerIdToStore(storeName + "-" + viewClass.getClass().getSimpleName(), consumerId);
+      String consumerName =
+          suffixConsumerIdToStore(storeName + "-" + viewClass.getClass().getSimpleName(), adjustedConsumerId);
       if (viewClass.equals(ChangeCaptureView.class.getCanonicalName())) {
         // TODO: This is a little bit of a hack. This is to deal with the an issue where the before image change
         // capture topic doesn't follow the same naming convention as view topics.

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/consumer/VeniceChangelogConsumerClientFactory.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/consumer/VeniceChangelogConsumerClientFactory.java
@@ -81,7 +81,11 @@ public class VeniceChangelogConsumerClientFactory {
       String viewNameOverride) {
     String adjustedConsumerId;
     if (!StringUtils.isEmpty(viewNameOverride)) {
-      adjustedConsumerId = consumerId + "-" + viewNameOverride;
+      if (StringUtils.isEmpty(consumerId)) {
+        adjustedConsumerId = viewNameOverride;
+      } else {
+        adjustedConsumerId = consumerId + "-" + viewNameOverride;
+      }
     } else {
       adjustedConsumerId = consumerId;
     }

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/consumer/VeniceChangelogConsumerClientFactoryTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/consumer/VeniceChangelogConsumerClientFactoryTest.java
@@ -84,6 +84,7 @@ public class VeniceChangelogConsumerClientFactoryTest {
     mockStoreInfo.setViewConfigs(viewConfigMap);
     Mockito.when(mockStoreResponse.getStore()).thenReturn(mockStoreInfo);
     Mockito.when(mockControllerClient.getStore(STORE_NAME)).thenReturn(mockStoreResponse);
+    Mockito.when(mockControllerClient.retryableRequest(Mockito.anyInt(), Mockito.any())).thenReturn(mockStoreResponse);
     VeniceChangelogConsumer consumer = veniceChangelogConsumerClientFactory.getChangelogConsumer(STORE_NAME);
 
     Assert.assertTrue(consumer instanceof VeniceAfterImageConsumerImpl);


### PR DESCRIPTION
## [changelog][client] Add viewname to changelog client factory

This is to enable cases where we need to be able to consume different views for different stores.

Resolves #XXX

## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [ ] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.