### PR TITLE
[controller] versioning support for RT topics

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTask.java
@@ -3177,7 +3177,7 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
       return false; // Not leader, don't compress
     }
     PubSubTopic leaderTopic = partitionConsumptionState.getOffsetRecord().getLeaderTopic(pubSubTopicRepository);
-    if (!realTimeTopic.equals(leaderTopic)) {
+    if (realTimeTopic != null && !realTimeTopic.equals(leaderTopic)) {
       return false; // We're consuming from version topic (don't compress it)
     }
     return !compressionStrategy.equals(CompressionStrategy.NO_OP);

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StorageUtilizationManager.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StorageUtilizationManager.java
@@ -358,7 +358,7 @@ public class StorageUtilizationManager implements StoreDataChangedListener {
         consumingTopics.add(offsetRecord.getLeaderTopic());
         // For separate RT topic enabled SIT, we should include separate RT topic, if leader topic is a RT topic.
         if (isSeparateRealtimeTopicEnabled && Version.isRealTimeTopic(offsetRecord.getLeaderTopic())) {
-          consumingTopics.add(offsetRecord.getLeaderTopic() + Utils.SEPARATE_TOPIC_SUFFIX);
+          consumingTopics.add(Utils.getSeparateRealTimeTopicName(offsetRecord.getLeaderTopic()));
         }
       }
     }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StorageUtilizationManager.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StorageUtilizationManager.java
@@ -11,6 +11,7 @@ import com.linkedin.venice.meta.Version;
 import com.linkedin.venice.meta.VersionStatus;
 import com.linkedin.venice.offsets.OffsetRecord;
 import com.linkedin.venice.utils.RedundantExceptionFilter;
+import com.linkedin.venice.utils.Utils;
 import com.linkedin.venice.utils.concurrent.VeniceConcurrentHashMap;
 import com.linkedin.venice.utils.locks.AutoCloseableLock;
 import java.util.ArrayList;
@@ -357,7 +358,7 @@ public class StorageUtilizationManager implements StoreDataChangedListener {
         consumingTopics.add(offsetRecord.getLeaderTopic());
         // For separate RT topic enabled SIT, we should include separate RT topic, if leader topic is a RT topic.
         if (isSeparateRealtimeTopicEnabled && Version.isRealTimeTopic(offsetRecord.getLeaderTopic())) {
-          consumingTopics.add(Version.composeSeparateRealTimeTopic(storeName));
+          consumingTopics.add(offsetRecord.getLeaderTopic() + Utils.SEPARATE_TOPIC_SUFFIX);
         }
       }
     }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
@@ -416,10 +416,10 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
     // if version is not hybrid, it is not possible to create pub sub realTimeTopic, users of this field should do a
     // nullability check
     this.realTimeTopic = version.getHybridStoreConfig() != null
-        ? pubSubTopicRepository.getTopic(Utils.getRealTimeTopicName(version))
+        ? Objects.requireNonNull(pubSubTopicRepository.getTopic(Utils.getRealTimeTopicName(version)))
         : null;
     this.separateRealTimeTopic = version.isSeparateRealTimeTopicEnabled() && version.getHybridStoreConfig() != null
-        ? pubSubTopicRepository.getTopic(Utils.getSeparateRealTimeTopicName(version))
+        ? Objects.requireNonNull(pubSubTopicRepository.getTopic(Utils.getSeparateRealTimeTopicName(version)))
         : null;
     this.versionNumber = Version.parseVersionFromKafkaTopicName(kafkaVersionTopic);
     this.consumerActionsQueue = new PriorityBlockingQueue<>(CONSUMER_ACTION_QUEUE_INIT_CAPACITY);

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
@@ -3720,8 +3720,6 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
   protected void unsubscribeFromTopic(PubSubTopic topic, PartitionConsumptionState partitionConsumptionState) {
     consumerUnSubscribeForStateTransition(topic, partitionConsumptionState);
     if (isSeparatedRealtimeTopicEnabled() && topic.isRealTime()) {
-      PubSubTopic separateRealTimeTopic =
-          getPubSubTopicRepository().getTopic(Utils.getSeparateRealTimeTopicName(topic.getName()));
       consumerUnSubscribeForStateTransition(separateRealTimeTopic, partitionConsumptionState);
     }
   }
@@ -4779,7 +4777,7 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
   PubSubTopic resolveTopicWithKafkaURL(PubSubTopic topic, String kafkaURL) {
     if (topic.isRealTime() && getKafkaClusterUrlResolver() != null
         && !kafkaURL.equals(getKafkaClusterUrlResolver().apply(kafkaURL))) {
-      return getPubSubTopicRepository().getTopic(Utils.getSeparateRealTimeTopicName(topic.getName()));
+      return separateRealTimeTopic;
     }
     return topic;
   }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
@@ -413,9 +413,13 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
     this.storeName = versionTopic.getStoreName();
     this.isUserSystemStore = VeniceSystemStoreUtils.isUserSystemStore(storeName);
     this.isSystemStore = VeniceSystemStoreUtils.isSystemStore(storeName);
-    this.realTimeTopic = pubSubTopicRepository.getTopic(Utils.getRealTimeTopicName(version));
-    this.separateRealTimeTopic = version.isSeparateRealTimeTopicEnabled()
-        ? pubSubTopicRepository.getTopic(Version.composeSeparateRealTimeTopic(storeName))
+    // if version is not hybrid, it is not possible to create pub sub realTimeTopic, users of this field should do a
+    // nullability check
+    this.realTimeTopic = version.getHybridStoreConfig() != null
+        ? pubSubTopicRepository.getTopic(Utils.getRealTimeTopicName(version))
+        : null;
+    this.separateRealTimeTopic = version.isSeparateRealTimeTopicEnabled() && version.getHybridStoreConfig() != null
+        ? pubSubTopicRepository.getTopic(Utils.getSeparateRealTimeTopicName(version))
         : null;
     this.versionNumber = Version.parseVersionFromKafkaTopicName(kafkaVersionTopic);
     this.consumerActionsQueue = new PriorityBlockingQueue<>(CONSUMER_ACTION_QUEUE_INIT_CAPACITY);
@@ -3717,7 +3721,7 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
     consumerUnSubscribeForStateTransition(topic, partitionConsumptionState);
     if (isSeparatedRealtimeTopicEnabled() && topic.isRealTime()) {
       PubSubTopic separateRealTimeTopic =
-          getPubSubTopicRepository().getTopic(Version.composeSeparateRealTimeTopic(topic.getStoreName()));
+          getPubSubTopicRepository().getTopic(Utils.getSeparateRealTimeTopicName(topic.getName()));
       consumerUnSubscribeForStateTransition(separateRealTimeTopic, partitionConsumptionState);
     }
   }
@@ -4775,7 +4779,7 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
   PubSubTopic resolveTopicWithKafkaURL(PubSubTopic topic, String kafkaURL) {
     if (topic.isRealTime() && getKafkaClusterUrlResolver() != null
         && !kafkaURL.equals(getKafkaClusterUrlResolver().apply(kafkaURL))) {
-      return getPubSubTopicRepository().getTopic(Version.composeSeparateRealTimeTopic(topic.getStoreName()));
+      return getPubSubTopicRepository().getTopic(Utils.getSeparateRealTimeTopicName(topic.getName()));
     }
     return topic;
   }

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTaskTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTaskTest.java
@@ -222,6 +222,7 @@ import io.tehuti.metrics.MetricsRepository;
 import io.tehuti.metrics.Sensor;
 import it.unimi.dsi.fastutil.ints.Int2ObjectMaps;
 import it.unimi.dsi.fastutil.objects.Object2IntMaps;
+import java.lang.reflect.Field;
 import java.net.URL;
 import java.net.URLClassLoader;
 import java.nio.ByteBuffer;
@@ -5623,7 +5624,7 @@ public abstract class StoreIngestionTaskTest {
   }
 
   @Test
-  public void testResolveTopicPartitionWithKafkaURL() {
+  public void testResolveTopicPartitionWithKafkaURL() throws NoSuchFieldException, IllegalAccessException {
     StoreIngestionTask storeIngestionTask = mock(StoreIngestionTask.class);
     Function<String, String> resolver = Utils::resolveKafkaUrlForSepTopic;
     PubSubTopicRepository pubSubTopicRepository = new PubSubTopicRepository();
@@ -5640,6 +5641,10 @@ public abstract class StoreIngestionTaskTest {
     PubSubTopic separateRealTimeTopic =
         pubSubTopicRepository.getTopic(Utils.getSeparateRealTimeTopicName(realTimeTopic.getName()));
     PubSubTopic versionTopic = pubSubTopicRepository.getTopic(Version.composeKafkaTopic(store, 1));
+    Field field = storeIngestionTask.getClass().getSuperclass().getDeclaredField("separateRealTimeTopic");
+    field.setAccessible(true);
+    field.set(storeIngestionTask, separateRealTimeTopic);
+
     Assert.assertEquals(
         storeIngestionTask.resolveTopicPartitionWithKafkaURL(realTimeTopic, pcs, kafkaUrl).getPubSubTopic(),
         realTimeTopic);
@@ -5653,7 +5658,7 @@ public abstract class StoreIngestionTaskTest {
   }
 
   @Test
-  public void testUnsubscribeFromTopic() {
+  public void testUnsubscribeFromTopic() throws IllegalAccessException, NoSuchFieldException {
     StoreIngestionTask storeIngestionTask = mock(StoreIngestionTask.class);
     PubSubTopicRepository pubSubTopicRepository = new PubSubTopicRepository();
     doCallRealMethod().when(storeIngestionTask).unsubscribeFromTopic(any(), any());
@@ -5665,6 +5670,9 @@ public abstract class StoreIngestionTaskTest {
     PubSubTopic separateRealTimeTopic =
         pubSubTopicRepository.getTopic(Utils.getSeparateRealTimeTopicName(realTimeTopic.getName()));
     PubSubTopic versionTopic = pubSubTopicRepository.getTopic(Version.composeKafkaTopic(store, 1));
+    Field field = storeIngestionTask.getClass().getSuperclass().getDeclaredField("separateRealTimeTopic");
+    field.setAccessible(true);
+    field.set(storeIngestionTask, separateRealTimeTopic);
 
     doReturn(true).when(storeIngestionTask).isSeparatedRealtimeTopicEnabled();
     storeIngestionTask.unsubscribeFromTopic(realTimeTopic, pcs);

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTaskTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTaskTest.java
@@ -518,6 +518,7 @@ public abstract class StoreIngestionTaskTest {
 
     mockStorageEngineRepository = mock(StorageEngineRepository.class);
     storeInfo = mock(StoreInfo.class, RETURNS_DEEP_STUBS);
+    when(storeInfo.getName()).thenReturn(storeNameWithoutVersionInfo);
     when(storeInfo.getHybridStoreConfig().getRealTimeTopicName())
         .thenReturn(Utils.composeRealTimeTopic(storeNameWithoutVersionInfo));
 
@@ -3842,6 +3843,7 @@ public abstract class StoreIngestionTaskTest {
     doReturn(versionTopic).when(mockVeniceStoreVersionConfig).getStoreVersionName();
 
     Version mockVersion = mock(Version.class);
+    doReturn(storeName).when(mockVersion).getStoreName();
     doReturn(1).when(mockVersion).getPartitionCount();
     doReturn(VersionStatus.STARTED).when(mockVersion).getStatus();
 
@@ -3971,6 +3973,7 @@ public abstract class StoreIngestionTaskTest {
 
     Version version = mock(Version.class);
     doReturn(1).when(version).getPartitionCount();
+    doReturn("store").when(version).getStoreName();
     doReturn(null).when(version).getPartitionerConfig();
     doReturn(VersionStatus.ONLINE).when(version).getStatus();
     doReturn(true).when(version).isNativeReplicationEnabled();
@@ -4597,6 +4600,7 @@ public abstract class StoreIngestionTaskTest {
   public void testBatchOnlyStoreDataRecovery() {
     Version version = mock(Version.class);
     doReturn(1).when(version).getPartitionCount();
+    doReturn("store").when(version).getStoreName();
     doReturn(VersionStatus.STARTED).when(version).getStatus();
     doReturn(true).when(version).isNativeReplicationEnabled();
     DataRecoveryVersionConfig dataRecoveryVersionConfig = new DataRecoveryVersionConfigImpl("dc-0", false, 1);
@@ -4688,6 +4692,7 @@ public abstract class StoreIngestionTaskTest {
     VeniceStoreVersionConfig mockVeniceStoreVersionConfig = mock(VeniceStoreVersionConfig.class);
     doReturn(versionTopic).when(mockVeniceStoreVersionConfig).getStoreVersionName();
     Version mockVersion = mock(Version.class);
+    doReturn(storeName).when(mockVersion).getStoreName();
     doReturn(1).when(mockVersion).getPartitionCount();
     doReturn(VersionStatus.STARTED).when(mockVersion).getStatus();
     doReturn(true).when(mockVersion).isUseVersionLevelHybridConfig();
@@ -4780,6 +4785,7 @@ public abstract class StoreIngestionTaskTest {
     VeniceStoreVersionConfig mockVeniceStoreVersionConfig = mock(VeniceStoreVersionConfig.class);
     doReturn(versionTopic).when(mockVeniceStoreVersionConfig).getStoreVersionName();
     Version mockVersion = mock(Version.class);
+    doReturn(storeName).when(mockVersion).getStoreName();
     doReturn(2).when(mockVersion).getPartitionCount();
     doReturn(VersionStatus.STARTED).when(mockVersion).getStatus();
     doReturn(true).when(mockVersion).isUseVersionLevelHybridConfig();
@@ -5631,7 +5637,8 @@ public abstract class StoreIngestionTaskTest {
     String store = "test_store";
     String kafkaUrl = "localhost:1234";
     PubSubTopic realTimeTopic = pubSubTopicRepository.getTopic(Utils.composeRealTimeTopic(store));
-    PubSubTopic separateRealTimeTopic = pubSubTopicRepository.getTopic(Version.composeSeparateRealTimeTopic(store));
+    PubSubTopic separateRealTimeTopic =
+        pubSubTopicRepository.getTopic(Utils.getSeparateRealTimeTopicName(realTimeTopic.getName()));
     PubSubTopic versionTopic = pubSubTopicRepository.getTopic(Version.composeKafkaTopic(store, 1));
     Assert.assertEquals(
         storeIngestionTask.resolveTopicPartitionWithKafkaURL(realTimeTopic, pcs, kafkaUrl).getPubSubTopic(),
@@ -5655,7 +5662,8 @@ public abstract class StoreIngestionTaskTest {
     String store = "test_store";
     String kafkaUrl = "localhost:1234";
     PubSubTopic realTimeTopic = pubSubTopicRepository.getTopic(Utils.composeRealTimeTopic(store));
-    PubSubTopic separateRealTimeTopic = pubSubTopicRepository.getTopic(Version.composeSeparateRealTimeTopic(store));
+    PubSubTopic separateRealTimeTopic =
+        pubSubTopicRepository.getTopic(Utils.getSeparateRealTimeTopicName(realTimeTopic.getName()));
     PubSubTopic versionTopic = pubSubTopicRepository.getTopic(Version.composeKafkaTopic(store, 1));
 
     doReturn(true).when(storeIngestionTask).isSeparatedRealtimeTopicEnabled();
@@ -5699,6 +5707,7 @@ public abstract class StoreIngestionTaskTest {
 
     Version version = mock(Version.class);
     doReturn(1).when(version).getPartitionCount();
+    doReturn("store").when(version).getStoreName();
     doReturn(VersionStatus.STARTED).when(version).getStatus();
     doReturn(true).when(version).isNativeReplicationEnabled();
     DataRecoveryVersionConfig dataRecoveryVersionConfig = new DataRecoveryVersionConfigImpl("dc-0", false, 1);

--- a/internal/venice-common/src/main/java/com/linkedin/venice/ConfigKeys.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/ConfigKeys.java
@@ -2492,6 +2492,10 @@ public class ConfigKeys {
 
   public static final String SERVER_DELETE_UNASSIGNED_PARTITIONS_ON_STARTUP =
       "server.delete.unassigned.partitions.on.startup";
+  public static final String CONTROLLER_ENABLE_REAL_TIME_TOPIC_VERSIONING =
+      "controller.enable.realtime.topic.versioning";
+
+  public static final boolean DEFAULT_CONTROLLER_ENABLE_REAL_TIME_TOPIC_VERSIONING = false;
   public static final String CONTROLLER_ENABLE_HYBRID_STORE_PARTITION_COUNT_UPDATE =
       "controller.enable.hybrid.store.partition.count.update";
   public static final String PUSH_JOB_VIEW_CONFIGS = "push.job.view.configs";

--- a/internal/venice-common/src/main/java/com/linkedin/venice/meta/AbstractStore.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/meta/AbstractStore.java
@@ -175,7 +175,7 @@ public abstract class AbstractStore implements Store {
       HybridStoreConfig hybridStoreConfig = getHybridStoreConfig();
       if (hybridStoreConfig != null) {
         version.setHybridStoreConfig(hybridStoreConfig.clone());
-        if (currentRTVersionNumber > 0) {
+        if (currentRTVersionNumber > DEFAULT_RT_VERSION_NUMBER) {
           String newRealTimeTopicName = Utils.isRTVersioningApplicable(getName())
               ? getName() + "_v" + currentRTVersionNumber + Version.REAL_TIME_TOPIC_SUFFIX
               : DEFAULT_REAL_TIME_TOPIC_NAME;

--- a/internal/venice-common/src/main/java/com/linkedin/venice/meta/AbstractStore.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/meta/AbstractStore.java
@@ -174,13 +174,14 @@ public abstract class AbstractStore implements Store {
 
       HybridStoreConfig hybridStoreConfig = getHybridStoreConfig();
       if (hybridStoreConfig != null) {
-        version.setHybridStoreConfig(hybridStoreConfig.clone());
+        HybridStoreConfig clonedHybridStoreConfig = hybridStoreConfig.clone();
         if (currentRTVersionNumber > DEFAULT_RT_VERSION_NUMBER) {
           String newRealTimeTopicName = Utils.isRTVersioningApplicable(getName())
-              ? getName() + "_v" + currentRTVersionNumber + Version.REAL_TIME_TOPIC_SUFFIX
+              ? Utils.composeRealTimeTopic(getName(), currentRTVersionNumber)
               : DEFAULT_REAL_TIME_TOPIC_NAME;
-          version.getHybridStoreConfig().setRealTimeTopicName(newRealTimeTopicName);
+          clonedHybridStoreConfig.setRealTimeTopicName(newRealTimeTopicName);
         }
+        version.setHybridStoreConfig(clonedHybridStoreConfig);
       }
 
       version.setUseVersionLevelHybridConfig(true);

--- a/internal/venice-common/src/main/java/com/linkedin/venice/meta/AbstractStore.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/meta/AbstractStore.java
@@ -1,11 +1,13 @@
 package com.linkedin.venice.meta;
 
+import static com.linkedin.venice.meta.HybridStoreConfigImpl.DEFAULT_REAL_TIME_TOPIC_NAME;
 import static com.linkedin.venice.meta.Version.DEFAULT_RT_VERSION_NUMBER;
 
 import com.linkedin.venice.exceptions.StoreDisabledException;
 import com.linkedin.venice.exceptions.StoreVersionNotFoundException;
 import com.linkedin.venice.exceptions.VeniceException;
 import com.linkedin.venice.systemstore.schemas.StoreVersion;
+import com.linkedin.venice.utils.Utils;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -173,6 +175,12 @@ public abstract class AbstractStore implements Store {
       HybridStoreConfig hybridStoreConfig = getHybridStoreConfig();
       if (hybridStoreConfig != null) {
         version.setHybridStoreConfig(hybridStoreConfig.clone());
+        if (currentRTVersionNumber > 0) {
+          String newRealTimeTopicName = Utils.isRTVersioningApplicable(getName())
+              ? getName() + "_v" + currentRTVersionNumber + Version.REAL_TIME_TOPIC_SUFFIX
+              : DEFAULT_REAL_TIME_TOPIC_NAME;
+          version.getHybridStoreConfig().setRealTimeTopicName(newRealTimeTopicName);
+        }
       }
 
       version.setUseVersionLevelHybridConfig(true);

--- a/internal/venice-common/src/main/java/com/linkedin/venice/meta/Version.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/meta/Version.java
@@ -8,6 +8,7 @@ import com.linkedin.venice.compression.CompressionStrategy;
 import com.linkedin.venice.exceptions.VeniceException;
 import com.linkedin.venice.guid.GuidUtils;
 import com.linkedin.venice.systemstore.schemas.StoreVersion;
+import com.linkedin.venice.utils.Utils;
 import com.linkedin.venice.views.VeniceView;
 import java.time.Duration;
 import java.util.HashMap;
@@ -345,10 +346,16 @@ public interface Version extends Comparable<Version>, DataModelBackedStructure<S
     return storeName + VERSION_SEPARATOR + versionNumber;
   }
 
+  /**
+   * @Deprecated Use {@link Utils#composeRealTimeTopic(String)} instead.
+   */
   static String composeRealTimeTopic(String storeName) {
     return storeName + REAL_TIME_TOPIC_SUFFIX;
   }
 
+  /**
+   * @Deprecated Use overloaded methods {@link Utils#getSeparateRealTimeTopicName(String)} instead.
+   */
   static String composeSeparateRealTimeTopic(String storeName) {
     return storeName + SEPARATE_REAL_TIME_TOPIC_SUFFIX;
   }
@@ -372,10 +379,13 @@ public interface Version extends Comparable<Version>, DataModelBackedStructure<S
     if (!isRealTimeTopic(kafkaTopic)) {
       throw new VeniceException("Kafka topic: " + kafkaTopic + " is not a real-time topic");
     }
-    if (kafkaTopic.endsWith(REAL_TIME_TOPIC_SUFFIX)) {
+    int lastIndexOfVersionSeparator = kafkaTopic.lastIndexOf(VERSION_SEPARATOR);
+    // we only care about the prefix, so providing topic in place of store should work
+    if (lastIndexOfVersionSeparator != -1 && Utils.isRTVersioningApplicable(kafkaTopic)) {
+      return kafkaTopic.substring(0, lastIndexOfVersionSeparator);
+    } else {
       return kafkaTopic.substring(0, kafkaTopic.length() - REAL_TIME_TOPIC_SUFFIX.length());
     }
-    return kafkaTopic.substring(0, kafkaTopic.length() - SEPARATE_REAL_TIME_TOPIC_SUFFIX.length());
   }
 
   static String parseStoreFromStreamReprocessingTopic(String kafkaTopic) {

--- a/internal/venice-common/src/main/java/com/linkedin/venice/meta/Version.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/meta/Version.java
@@ -379,13 +379,14 @@ public interface Version extends Comparable<Version>, DataModelBackedStructure<S
     if (!isRealTimeTopic(kafkaTopic)) {
       throw new VeniceException("Kafka topic: " + kafkaTopic + " is not a real-time topic");
     }
+
     int lastIndexOfVersionSeparator = kafkaTopic.lastIndexOf(VERSION_SEPARATOR);
     // we only care about the prefix, so providing topic in place of store should work
     if (lastIndexOfVersionSeparator != -1 && Utils.isRTVersioningApplicable(kafkaTopic)) {
       return kafkaTopic.substring(0, lastIndexOfVersionSeparator);
-    } else {
-      return kafkaTopic.substring(0, kafkaTopic.length() - REAL_TIME_TOPIC_SUFFIX.length());
     }
+
+    return kafkaTopic.substring(0, kafkaTopic.length() - REAL_TIME_TOPIC_SUFFIX.length());
   }
 
   static String parseStoreFromStreamReprocessingTopic(String kafkaTopic) {

--- a/internal/venice-common/src/main/java/com/linkedin/venice/meta/ZKStore.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/meta/ZKStore.java
@@ -247,6 +247,8 @@ public class ZKStore extends AbstractStore implements DataModelBackedStructure<S
      */
     setLargestUsedVersionNumber(store.getLargestUsedVersionNumber());
 
+    setLargestUsedRTVersionNumber(store.getLargestUsedRTVersionNumber());
+
     // Clone systemStores
     Map<String, SystemStoreAttributes> clonedSystemStores = new HashMap<>();
     store.getSystemStores().forEach((k, v) -> clonedSystemStores.put(k, v.clone()));

--- a/internal/venice-common/src/test/java/com/linkedin/venice/meta/TestVersion.java
+++ b/internal/venice-common/src/test/java/com/linkedin/venice/meta/TestVersion.java
@@ -74,6 +74,10 @@ public class TestVersion {
   public void testParseStoreFromRealTimeTopic() {
     String validRealTimeTopic = "abc_rt";
     assertEquals(Version.parseStoreFromRealTimeTopic(validRealTimeTopic), "abc");
+
+    String validRealTimeTopic2 = "abc_v1_rt";
+    assertEquals(Version.parseStoreFromRealTimeTopic(validRealTimeTopic2), "abc");
+
     String invalidRealTimeTopic = "abc";
     try {
       Version.parseStoreFromRealTimeTopic(invalidRealTimeTopic);

--- a/internal/venice-common/src/test/java/com/linkedin/venice/utils/UtilsTest.java
+++ b/internal/venice-common/src/test/java/com/linkedin/venice/utils/UtilsTest.java
@@ -353,20 +353,6 @@ public class UtilsTest {
   }
 
   @Test
-  void testGetRealTimeTopicNameWithExceptionHandling() {
-    Version mockVersion1 = mock(Version.class);
-    Version mockVersion2 = mock(Version.class);
-
-    when(mockVersion1.isHybrid()).thenReturn(true);
-    when(mockVersion1.getHybridStoreConfig()).thenThrow(new VeniceException("Test Exception"));
-
-    when(mockVersion2.isHybrid()).thenReturn(false);
-
-    String result = Utils.getRealTimeTopicName(STORE_NAME, Lists.newArrayList(mockVersion1, mockVersion2), 1, null);
-    assertEquals(result, STORE_NAME + Version.REAL_TIME_TOPIC_SUFFIX);
-  }
-
-  @Test
   void testGetRealTimeTopicNameWithHybridVersion() {
     Version mockVersion = mock(Version.class);
     HybridStoreConfig mockHybridConfig = mock(HybridStoreConfig.class);

--- a/internal/venice-common/src/test/java/com/linkedin/venice/utils/UtilsTest.java
+++ b/internal/venice-common/src/test/java/com/linkedin/venice/utils/UtilsTest.java
@@ -356,7 +356,7 @@ public class UtilsTest {
   void testGetRealTimeTopicNameWithHybridVersion() {
     Version mockVersion = mock(Version.class);
     HybridStoreConfig mockHybridConfig = mock(HybridStoreConfig.class);
-    String expectedRealTimeTopicName = STORE_NAME + "_v1" + Version.REAL_TIME_TOPIC_SUFFIX;
+    String expectedRealTimeTopicName = Utils.composeRealTimeTopic(STORE_NAME, 1);
 
     when(mockVersion.isHybrid()).thenReturn(true);
     when(mockVersion.getHybridStoreConfig()).thenReturn(mockHybridConfig);

--- a/internal/venice-common/src/test/java/com/linkedin/venice/utils/UtilsTest.java
+++ b/internal/venice-common/src/test/java/com/linkedin/venice/utils/UtilsTest.java
@@ -1,7 +1,6 @@
 package com.linkedin.venice.utils;
 
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
@@ -46,6 +45,8 @@ import org.testng.collections.Lists;
  * Test cases for Venice {@link Utils}
  */
 public class UtilsTest {
+  final static String STORE_NAME = "TestStore";
+
   @Test
   public void testGetHelixNodeIdentifier() {
     int port = 1234;
@@ -173,7 +174,7 @@ public class UtilsTest {
   }
 
   @Test
-  public void testIterateOnMapOfLists() throws Exception {
+  public void testIterateOnMapOfLists() {
     Map<String, List<Integer>> mapOfLists = new HashMap<>();
     mapOfLists.put("list1", new ArrayList<>());
     mapOfLists.put("list2", Arrays.asList(1, 2, 3));
@@ -191,11 +192,11 @@ public class UtilsTest {
 
   @Test
   public void testParseMap() {
-    Map expectedMap = new HashMap<>();
+    Map<String, String> expectedMap = new HashMap<>();
     expectedMap.put("a", "b");
 
     assertEquals(Utils.parseJsonMapFromString("", "test_field").size(), 0);
-    Map validMap = Utils.parseJsonMapFromString("{\"a\":\"b\"}", "test_field");
+    Map<String, String> validMap = Utils.parseJsonMapFromString("{\"a\":\"b\"}", "test_field");
     assertEquals(validMap, expectedMap);
 
     VeniceException e = expectThrows(VeniceException.class, () -> Utils.parseJsonMapFromString("a=b", "test_field"));
@@ -255,6 +256,7 @@ public class UtilsTest {
 
   @Test
   void testGetRealTimeTopicNames() {
+    String storeName = "StoreName";
     Store mockStore = mock(Store.class);
     List<Version> mockVersions = new ArrayList<>();
     mockVersions.add(mock(Version.class));
@@ -262,10 +264,16 @@ public class UtilsTest {
     mockVersions.add(mock(Version.class));
     HybridStoreConfig mockHybridConfig = mock(HybridStoreConfig.class);
 
-    when(mockStore.getName()).thenReturn("StoreName");
+    when(mockStore.getName()).thenReturn(storeName);
     when(mockStore.getVersions()).thenReturn(mockVersions);
     when(mockStore.getCurrentVersion()).thenReturn(1);
     when(mockStore.getHybridStoreConfig()).thenReturn(mockHybridConfig);
+    when(mockVersions.get(0).getStoreName()).thenReturn(storeName);
+    when(mockVersions.get(1).getStoreName()).thenReturn(storeName);
+    when(mockVersions.get(2).getStoreName()).thenReturn(storeName);
+    when(mockVersions.get(0).isHybrid()).thenReturn(true);
+    when(mockVersions.get(1).isHybrid()).thenReturn(true);
+    when(mockVersions.get(2).isHybrid()).thenReturn(true);
     when(mockVersions.get(0).getHybridStoreConfig()).thenReturn(mockHybridConfig);
     when(mockVersions.get(1).getHybridStoreConfig()).thenReturn(mockHybridConfig);
     when(mockVersions.get(2).getHybridStoreConfig()).thenReturn(mockHybridConfig);
@@ -282,7 +290,7 @@ public class UtilsTest {
     List<Version> mockVersions = Collections.singletonList(mock(Version.class));
     HybridStoreConfig mockHybridConfig = mock(HybridStoreConfig.class);
 
-    when(mockStore.getName()).thenReturn("TestStore");
+    when(mockStore.getName()).thenReturn(STORE_NAME);
     when(mockStore.getVersions()).thenReturn(mockVersions);
     when(mockStore.getCurrentVersion()).thenReturn(1);
     when(mockStore.getHybridStoreConfig()).thenReturn(mockHybridConfig);
@@ -299,7 +307,7 @@ public class UtilsTest {
     List<Version> mockVersions = Collections.singletonList(mock(Version.class));
     HybridStoreConfig mockHybridConfig = mock(HybridStoreConfig.class);
 
-    when(mockStoreInfo.getName()).thenReturn("TestStore");
+    when(mockStoreInfo.getName()).thenReturn(STORE_NAME);
     when(mockStoreInfo.getVersions()).thenReturn(mockVersions);
     when(mockStoreInfo.getCurrentVersion()).thenReturn(1);
     when(mockStoreInfo.getHybridStoreConfig()).thenReturn(mockHybridConfig);
@@ -322,8 +330,8 @@ public class UtilsTest {
 
   @Test
   void testGetRealTimeTopicNameWithoutHybridConfig() {
-    String result = Utils.getRealTimeTopicName("TestStore", Collections.EMPTY_LIST, 0, null);
-    assertEquals(result, "TestStore" + Version.REAL_TIME_TOPIC_SUFFIX);
+    String result = Utils.getRealTimeTopicName(STORE_NAME, Collections.EMPTY_LIST, 0, null);
+    assertEquals(result, STORE_NAME + Version.REAL_TIME_TOPIC_SUFFIX);
   }
 
   @Test
@@ -340,7 +348,7 @@ public class UtilsTest {
     when(mockConfig1.getRealTimeTopicName()).thenReturn("RealTimeTopic1");
     when(mockConfig2.getRealTimeTopicName()).thenReturn("RealTimeTopic2");
 
-    String result = Utils.getRealTimeTopicName("TestStore", Lists.newArrayList(mockVersion1, mockVersion2), 1, null);
+    String result = Utils.getRealTimeTopicName(STORE_NAME, Lists.newArrayList(mockVersion1, mockVersion2), 1, null);
     assertTrue(result.equals("RealTimeTopic1") || result.equals("RealTimeTopic2"));
   }
 
@@ -354,21 +362,23 @@ public class UtilsTest {
 
     when(mockVersion2.isHybrid()).thenReturn(false);
 
-    String result = Utils.getRealTimeTopicName("TestStore", Lists.newArrayList(mockVersion1, mockVersion2), 1, null);
-    assertEquals(result, "TestStore" + Version.REAL_TIME_TOPIC_SUFFIX);
+    String result = Utils.getRealTimeTopicName(STORE_NAME, Lists.newArrayList(mockVersion1, mockVersion2), 1, null);
+    assertEquals(result, STORE_NAME + Version.REAL_TIME_TOPIC_SUFFIX);
   }
 
   @Test
-  void testGetRealTimeTopicNameWithVersion() {
+  void testGetRealTimeTopicNameWithHybridVersion() {
     Version mockVersion = mock(Version.class);
     HybridStoreConfig mockHybridConfig = mock(HybridStoreConfig.class);
+    String expectedRealTimeTopicName = STORE_NAME + "_v1" + Version.REAL_TIME_TOPIC_SUFFIX;
 
+    when(mockVersion.isHybrid()).thenReturn(true);
     when(mockVersion.getHybridStoreConfig()).thenReturn(mockHybridConfig);
-    when(mockVersion.getStoreName()).thenReturn("TestStore");
-    when(mockHybridConfig.getRealTimeTopicName()).thenReturn("RealTimeTopic");
+    when(mockVersion.getStoreName()).thenReturn(STORE_NAME);
+    when(mockHybridConfig.getRealTimeTopicName()).thenReturn(expectedRealTimeTopicName);
 
     String result = Utils.getRealTimeTopicName(mockVersion);
-    assertEquals(result, "RealTimeTopic");
+    assertEquals(result, expectedRealTimeTopicName);
   }
 
   @Test
@@ -377,63 +387,10 @@ public class UtilsTest {
     Version mockVersion = mock(Version.class);
 
     // Mock setup to trigger the exception path
-    when(mockVersion.getHybridStoreConfig()).thenReturn(null);
-    when(mockVersion.getStoreName()).thenReturn("TestStore");
+    when(mockVersion.isHybrid()).thenReturn(false);
+    when(mockVersion.getStoreName()).thenReturn(STORE_NAME);
     String result = Utils.getRealTimeTopicName(mockVersion);
-    assertEquals(result, "TestStore" + Version.REAL_TIME_TOPIC_SUFFIX);
-  }
-
-  @Test
-  void testRealTimeTopicNameWithHybridConfig() {
-    // Mock the Store and HybridStoreConfig
-    Store store = mock(Store.class);
-    HybridStoreConfig hybridStoreConfig = mock(HybridStoreConfig.class);
-
-    // Define behavior
-    when(store.getHybridStoreConfig()).thenReturn(hybridStoreConfig);
-    when(store.getName()).thenReturn("test-store");
-    when(hybridStoreConfig.getRealTimeTopicName()).thenReturn("real-time-topic");
-
-    // Test
-    String result = Utils.getRealTimeTopicNameFromStoreConfig(store);
-
-    // Validate
-    assertEquals(result, "real-time-topic");
-
-    // Verify calls
-    verify(store).getHybridStoreConfig();
-    verify(store).getName();
-    verify(hybridStoreConfig).getRealTimeTopicName();
-  }
-
-  @Test
-  void testRealTimeTopicNameEmptyWithHybridConfig() {
-    // Mock the Store and HybridStoreConfig
-    Store store = mock(Store.class);
-    HybridStoreConfig hybridStoreConfig = mock(HybridStoreConfig.class);
-
-    // Define behavior
-    when(store.getHybridStoreConfig()).thenReturn(hybridStoreConfig);
-    when(store.getName()).thenReturn("test-store");
-    when(hybridStoreConfig.getRealTimeTopicName()).thenReturn("");
-
-    String result = Utils.getRealTimeTopicNameFromStoreConfig(store);
-
-    assertEquals(result, "test-store_rt");
-  }
-
-  @Test
-  void testRealTimeTopicNameWithoutHybridConfig() {
-    // Mock the Store
-    Store store = mock(Store.class);
-
-    // Define behavior
-    when(store.getHybridStoreConfig()).thenReturn(null);
-    when(store.getName()).thenReturn("test-store");
-
-    String result = Utils.getRealTimeTopicNameFromStoreConfig(store);
-
-    assertEquals(result, "test-store_rt");
+    assertEquals(result, STORE_NAME + Version.REAL_TIME_TOPIC_SUFFIX);
   }
 
   @Test
@@ -473,65 +430,13 @@ public class UtilsTest {
     String store = "test_store";
     PubSubTopic versionTopic = pubSubTopicRepository.getTopic(Version.composeKafkaTopic(store, 1));
     PubSubTopic realTimeTopic = pubSubTopicRepository.getTopic(Utils.composeRealTimeTopic(store));
-    PubSubTopic separateRealTimeTopic = pubSubTopicRepository.getTopic(Version.composeSeparateRealTimeTopic(store));
+    PubSubTopic separateRealTimeTopic =
+        pubSubTopicRepository.getTopic(Utils.getSeparateRealTimeTopicName(realTimeTopic.getName()));
     Assert.assertEquals(Utils.resolveLeaderTopicFromPubSubTopic(pubSubTopicRepository, versionTopic), versionTopic);
     Assert.assertEquals(Utils.resolveLeaderTopicFromPubSubTopic(pubSubTopicRepository, realTimeTopic), realTimeTopic);
     Assert.assertEquals(
         Utils.resolveLeaderTopicFromPubSubTopic(pubSubTopicRepository, separateRealTimeTopic),
         realTimeTopic);
-  }
-
-  @Test
-  void testValidOldNameWithVersionIncrement() {
-    String oldName = "storeName_v1_rt";
-    String expectedNewName = "storeName_v2_rt";
-
-    String result = Utils.createNewRealTimeTopicName(oldName);
-
-    assertEquals(result, expectedNewName);
-  }
-
-  @Test
-  void testWithVersionIncrement() {
-    String oldName = "storeName_v11_v55_rt";
-    String expectedNewName = "storeName_v11_v56_rt";
-
-    String result = Utils.createNewRealTimeTopicName(oldName);
-
-    assertEquals(result, expectedNewName);
-  }
-
-  @Test
-  void testValidOldNameStartingNewVersion() {
-    String oldName = "storeName_rt";
-    String expectedNewName = "storeName_v2_rt";
-
-    String result = Utils.createNewRealTimeTopicName(oldName);
-
-    assertEquals(result, expectedNewName);
-  }
-
-  @Test
-  void testInvalidOldNameNull() {
-    assertThrows(IllegalArgumentException.class, () -> Utils.createNewRealTimeTopicName(null));
-  }
-
-  @Test
-  void testInvalidOldNameWithoutSuffix() {
-    String oldName = "storeName_v1";
-    assertThrows(IllegalArgumentException.class, () -> Utils.createNewRealTimeTopicName(oldName));
-  }
-
-  @Test
-  void testInvalidOldNameIncorrectFormat() {
-    String oldName = "storeName_v1_rt_extra";
-    assertThrows(IllegalArgumentException.class, () -> Utils.createNewRealTimeTopicName(oldName));
-  }
-
-  @Test
-  void testInvalidOldNameWithNonNumericVersion() {
-    String oldName = "storeName_vX_rt";
-    assertThrows(NumberFormatException.class, () -> Utils.createNewRealTimeTopicName(oldName));
   }
 
   @DataProvider(name = "booleanParsingData")

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/controller/TestHybridStoreRepartitioningWithMultiDataCenter.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/controller/TestHybridStoreRepartitioningWithMultiDataCenter.java
@@ -192,11 +192,8 @@ public class TestHybridStoreRepartitioningWithMultiDataCenter {
     parentControllerClient
         .sendEmptyPushAndWait(storeName, Utils.getUniqueString("empty-push"), 1L, 60L * Time.MS_PER_SECOND);
 
-    for (ControllerClient controllerClient: childControllerClients) {
-      Assert.assertEquals(controllerClient.getStore(storeName).getStore().getCurrentVersion(), 1);
-    }
-
     for (ControllerClient childControllerClient: childControllerClients) {
+      Assert.assertEquals(childControllerClient.getStore(storeName).getStore().getCurrentVersion(), 1);
       TestUtils.waitForNonDeterministicAssertion(30, TimeUnit.SECONDS, () -> {
         verifyStoreState(
             childControllerClient,
@@ -285,12 +282,9 @@ public class TestHybridStoreRepartitioningWithMultiDataCenter {
     parentControllerClient
         .sendEmptyPushAndWait(storeName, Utils.getUniqueString("empty-push"), 1L, 60L * Time.MS_PER_SECOND);
 
-    for (ControllerClient controllerClient: childControllerClients) {
-      Assert.assertEquals(controllerClient.getStore(storeName).getStore().getCurrentVersion(), 2);
-    }
-
     for (int i = 0; i < childControllerClients.length; i++) {
       final int idx = i;
+      Assert.assertEquals(childControllerClients[idx].getStore(storeName).getStore().getCurrentVersion(), 2);
       TestUtils.waitForNonDeterministicAssertion(30, TimeUnit.SECONDS, () -> {
         String expectedRealTimeTopicNameInBackupVersion = storeName + "_v1" + Version.REAL_TIME_TOPIC_SUFFIX;
         // because we updated partition count, rt version should increase to v2
@@ -299,7 +293,7 @@ public class TestHybridStoreRepartitioningWithMultiDataCenter {
 
         // verify rt topic name
         verifyStoreState(
-            childControllerClients[0],
+            childControllerClients[idx],
             storeName,
             2,
             expectedRealTimeTopicNameInStore,
@@ -318,9 +312,6 @@ public class TestHybridStoreRepartitioningWithMultiDataCenter {
 
     for (ControllerClient controllerClient: childControllerClients) {
       Assert.assertEquals(controllerClient.getStore(storeName).getStore().getCurrentVersion(), 3);
-    }
-
-    for (ControllerClient controllerClient: childControllerClients) {
       TestUtils.waitForNonDeterministicAssertion(30, TimeUnit.SECONDS, () -> {
         Assert.assertEquals(controllerClient.getStore(storeName).getStore().getVersions().size(), 2);
         // rt version should not change because there is no more partition count update
@@ -390,9 +381,6 @@ public class TestHybridStoreRepartitioningWithMultiDataCenter {
 
     for (ControllerClient controllerClient: childControllerClients) {
       Assert.assertEquals(controllerClient.getStore(storeName).getStore().getCurrentVersion(), 4);
-    }
-
-    for (ControllerClient controllerClient: childControllerClients) {
       TestUtils.waitForNonDeterministicAssertion(30, TimeUnit.SECONDS, () -> {
         String expectedRealTimeTopicName = storeName + "_v3" + Version.REAL_TIME_TOPIC_SUFFIX;
         verifyStoreState(
@@ -445,11 +433,8 @@ public class TestHybridStoreRepartitioningWithMultiDataCenter {
     parentControllerClient
         .sendEmptyPushAndWait(storeName, Utils.getUniqueString("empty-push"), 1L, 60L * Time.MS_PER_SECOND);
 
-    for (ControllerClient controllerClient: childControllerClients) {
-      Assert.assertEquals(controllerClient.getStore(storeName).getStore().getCurrentVersion(), 6);
-    }
-
     for (ControllerClient childControllerClient: childControllerClients) {
+      Assert.assertEquals(childControllerClient.getStore(storeName).getStore().getCurrentVersion(), 6);
       TestUtils.waitForNonDeterministicAssertion(30, TimeUnit.SECONDS, () -> {
         Assert.assertEquals(childControllerClient.getStore(storeName).getStore().getVersions().size(), 2);
 

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/controller/TestHybridStoreRepartitioningWithMultiDataCenter.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/controller/TestHybridStoreRepartitioningWithMultiDataCenter.java
@@ -8,7 +8,9 @@ import static com.linkedin.venice.ConfigKeys.DEFAULT_PARTITION_SIZE;
 import com.linkedin.venice.controllerapi.ControllerClient;
 import com.linkedin.venice.controllerapi.ControllerResponse;
 import com.linkedin.venice.controllerapi.NewStoreResponse;
+import com.linkedin.venice.controllerapi.StoreResponse;
 import com.linkedin.venice.controllerapi.UpdateStoreQueryParams;
+import com.linkedin.venice.exceptions.ErrorType;
 import com.linkedin.venice.integration.utils.ServiceFactory;
 import com.linkedin.venice.integration.utils.VeniceMultiClusterWrapper;
 import com.linkedin.venice.integration.utils.VeniceMultiRegionClusterCreateOptions;
@@ -44,9 +46,12 @@ public class TestHybridStoreRepartitioningWithMultiDataCenter {
   private VeniceTwoLayerMultiRegionMultiClusterWrapper multiRegionMultiClusterWrapper;
   List<TopicManager> topicManagers;
   PubSubTopicRepository pubSubTopicRepository = new PubSubTopicRepository();
+  ControllerClient parentControllerClient;
+  ControllerClient[] childControllerClients;
 
   @BeforeClass(alwaysRun = true)
   public void setUp() {
+    String clusterName = CLUSTER_NAMES[0];
     Properties controllerProps = new Properties();
     controllerProps.put(DEFAULT_NUMBER_OF_PARTITION_FOR_HYBRID, 2);
     controllerProps.put(DEFAULT_MAX_NUMBER_OF_PARTITIONS, 3);
@@ -65,8 +70,14 @@ public class TestHybridStoreRepartitioningWithMultiDataCenter {
             .childControllerProperties(controllerProps);
     multiRegionMultiClusterWrapper =
         ServiceFactory.getVeniceTwoLayerMultiRegionMultiClusterWrapper(optionsBuilder.build());
-
+    String parentControllerURLs = multiRegionMultiClusterWrapper.getControllerConnectString();
     childDatacenters = multiRegionMultiClusterWrapper.getChildRegions();
+    parentControllerClient = ControllerClient.constructClusterControllerClient(CLUSTER_NAMES[0], parentControllerURLs);
+    childControllerClients = new ControllerClient[childDatacenters.size()];
+    for (int i = 0; i < childDatacenters.size(); i++) {
+      childControllerClients[i] =
+          new ControllerClient(clusterName, childDatacenters.get(i).getControllerConnectString());
+    }
     topicManagers = new ArrayList<>(2);
     topicManagers
         .add(childDatacenters.get(0).getControllers().values().iterator().next().getVeniceAdmin().getTopicManager());
@@ -79,19 +90,14 @@ public class TestHybridStoreRepartitioningWithMultiDataCenter {
     Utils.closeQuietlyWithErrorLogged(multiRegionMultiClusterWrapper);
   }
 
+  /*
+  This tests verifies the stores that are present before rolling out RT versioning changes.
+  If the store does not have `realTimeTopicName` and/or `largestUsedRTVersion` configs, that came in RT Versioning changes,
+  it should still be able to return the right RT name and all store operations and push should work.
+   */
   @Test(timeOut = TEST_TIMEOUT)
-  public void testUpdateRealTimeTopicName() {
-    String storeName = Utils.getUniqueString("TestUpdateRealTimeTopicName");
-    String clusterName = CLUSTER_NAMES[0];
-    String parentControllerURLs = multiRegionMultiClusterWrapper.getControllerConnectString();
-
-    ControllerClient parentControllerClient =
-        ControllerClient.constructClusterControllerClient(clusterName, parentControllerURLs);
-    ControllerClient[] childControllerClients = new ControllerClient[childDatacenters.size()];
-    for (int i = 0; i < childDatacenters.size(); i++) {
-      childControllerClients[i] =
-          new ControllerClient(clusterName, childDatacenters.get(i).getControllerConnectString());
-    }
+  public void testOldStoresWithHybridStoreVersioning() {
+    String storeName = Utils.getUniqueString("TestOldStoresWithHybridStoreVersioning");
 
     NewStoreResponse newStoreResponse =
         parentControllerClient.retryableRequest(5, c -> c.createNewStore(storeName, "", "\"string\"", "\"string\""));
@@ -99,16 +105,38 @@ public class TestHybridStoreRepartitioningWithMultiDataCenter {
         newStoreResponse.isError(),
         "The NewStoreResponse returned an error: " + newStoreResponse.getError());
 
-    String newRealTimeTopicName = "NewRealTimeTopicName" + Version.REAL_TIME_TOPIC_SUFFIX;
+    for (ControllerClient childControllerClient: childControllerClients) {
+      TestUtils.waitForNonDeterministicAssertion(30, TimeUnit.SECONDS, () -> {
+        StoreInfo storeInfo = childControllerClient.getStore(storeName).getStore();
+        Assert.assertEquals(storeInfo.getLargestUsedRTVersionNumber(), 1);
+
+        // Assert.assertEquals(realTimeTopicNameInStore, newRealTimeTopicNameInCofnig);
+      });
+    }
+    // make it an old-style store by removing the rt name
+    String newRealTimeTopicNameInCofnig = "";
+    String newRealTimeTopicName = storeName + Version.REAL_TIME_TOPIC_SUFFIX;
     UpdateStoreQueryParams updateStoreParams = new UpdateStoreQueryParams();
     updateStoreParams.setIncrementalPushEnabled(true)
         .setBackupStrategy(BackupStrategy.KEEP_MIN_VERSIONS)
         .setNumVersionsToPreserve(2)
         .setHybridRewindSeconds(1000)
         .setActiveActiveReplicationEnabled(true)
-        .setRealTimeTopicName(newRealTimeTopicName)
+        .setRealTimeTopicName(newRealTimeTopicNameInCofnig)
+        .setLargestUsedRTVersionNumber(0)
         .setHybridOffsetLagThreshold(1000);
     TestWriteUtils.updateStore(storeName, parentControllerClient, updateStoreParams);
+
+    for (ControllerClient childControllerClient: childControllerClients) {
+      TestUtils.waitForNonDeterministicAssertion(30, TimeUnit.SECONDS, () -> {
+        StoreInfo storeInfo = childControllerClient.getStore(storeName).getStore();
+        Assert.assertNotNull(storeInfo.getHybridStoreConfig());
+        String realTimeTopicNameInStore = storeInfo.getHybridStoreConfig().getRealTimeTopicName();
+        Assert.assertEquals(storeInfo.getLargestUsedRTVersionNumber(), 0);
+
+        // Assert.assertEquals(realTimeTopicNameInStore, newRealTimeTopicNameInCofnig);
+      });
+    }
 
     // create new version by doing an empty push
     parentControllerClient
@@ -118,37 +146,41 @@ public class TestHybridStoreRepartitioningWithMultiDataCenter {
       Assert.assertEquals(controllerClient.getStore(storeName).getStore().getCurrentVersion(), 1);
     }
 
-    for (int i = 0; i < childControllerClients.length; i++) {
-      final int index = i;
+    for (ControllerClient childControllerClient: childControllerClients) {
       TestUtils.waitForNonDeterministicAssertion(30, TimeUnit.SECONDS, () -> {
-        StoreInfo storeInfo = childControllerClients[index].getStore(storeName).getStore();
+        StoreInfo storeInfo = childControllerClient.getStore(storeName).getStore();
+        Version version = storeInfo.getVersions().get(0);
         String realTimeTopicNameInStore = storeInfo.getHybridStoreConfig().getRealTimeTopicName();
-        String realTimeTopicNameInVersion = Utils.getRealTimeTopicName(storeInfo.getVersions().get(0));
+        String realTimeTopicNameInVersion = version.getHybridStoreConfig().getRealTimeTopicName();
+        String realTimeTopicInStoreThroughAPI = Utils.getRealTimeTopicName(storeInfo);
+        String realTimeTopicInVersionThroughAPI = Utils.getRealTimeTopicName(version);
 
-        Assert.assertEquals(realTimeTopicNameInVersion, newRealTimeTopicName);
-        Assert.assertEquals(realTimeTopicNameInStore, newRealTimeTopicName);
+        Assert.assertEquals(realTimeTopicNameInStore, newRealTimeTopicNameInCofnig);
+        Assert.assertEquals(realTimeTopicNameInVersion, newRealTimeTopicNameInCofnig);
+        Assert.assertEquals(realTimeTopicInStoreThroughAPI, newRealTimeTopicName);
+        Assert.assertEquals(realTimeTopicInVersionThroughAPI, newRealTimeTopicName);
       });
     }
   }
 
-  @Test(timeOut = TEST_TIMEOUT)
-  public void testHybridStoreRepartitioning() {
-    String storeName = Utils.getUniqueString("TestHybridStoreRepartitioning");
-    String clusterName = CLUSTER_NAMES[0];
-    String parentControllerURLs = multiRegionMultiClusterWrapper.getControllerConnectString();
-    ControllerClient parentControllerClient =
-        ControllerClient.constructClusterControllerClient(clusterName, parentControllerURLs);
-    ControllerClient[] childControllerClients = new ControllerClient[childDatacenters.size()];
-    for (int i = 0; i < childDatacenters.size(); i++) {
-      childControllerClients[i] =
-          new ControllerClient(clusterName, childDatacenters.get(i).getControllerConnectString());
-    }
+  /**
+   * This test creates a store, do a push, update it's partition count, delete it, recreate it, and do a push again.
+   * At all steps, RT name is verified.
+   */
+  @Test(timeOut = 5 * TEST_TIMEOUT)
+  public void testRealTimeTopicVersioning() {
+    String storeName = Utils.getUniqueString("TestRealTimeTopicVersioning");
 
     NewStoreResponse newStoreResponse =
         parentControllerClient.retryableRequest(5, c -> c.createNewStore(storeName, "", "\"string\"", "\"string\""));
     Assert.assertFalse(
         newStoreResponse.isError(),
         "The NewStoreResponse returned an error: " + newStoreResponse.getError());
+
+    for (ControllerClient controllerClient: childControllerClients) {
+      StoreInfo storeInfo = controllerClient.getStore(storeName).getStore();
+      Assert.assertEquals(storeInfo.getLargestUsedRTVersionNumber(), 1);
+    }
 
     UpdateStoreQueryParams updateStoreParams = new UpdateStoreQueryParams();
     updateStoreParams.setIncrementalPushEnabled(true)
@@ -159,12 +191,23 @@ public class TestHybridStoreRepartitioningWithMultiDataCenter {
         .setHybridOffsetLagThreshold(1000);
     TestWriteUtils.updateStore(storeName, parentControllerClient, updateStoreParams);
 
+    for (ControllerClient controllerClient: childControllerClients) {
+      TestUtils.waitForNonDeterministicAssertion(30, TimeUnit.SECONDS, () -> {
+        StoreInfo storeInfo = controllerClient.getStore(storeName).getStore();
+        Assert.assertEquals(storeInfo.getLargestUsedRTVersionNumber(), 1);
+      });
+    }
+
     // create new version by doing an empty push
     parentControllerClient
         .sendEmptyPushAndWait(storeName, Utils.getUniqueString("empty-push"), 1L, 60L * Time.MS_PER_SECOND);
 
     for (ControllerClient controllerClient: childControllerClients) {
-      Assert.assertEquals(controllerClient.getStore(storeName).getStore().getCurrentVersion(), 1);
+      StoreInfo storeInfo = controllerClient.getStore(storeName).getStore();
+      Assert.assertEquals(
+          storeInfo.getHybridStoreConfig().getRealTimeTopicName(),
+          storeName + "_v1" + Version.REAL_TIME_TOPIC_SUFFIX);
+      Assert.assertEquals(storeInfo.getCurrentVersion(), 1);
     }
 
     TestWriteUtils.updateStore(storeName, parentControllerClient, new UpdateStoreQueryParams().setPartitionCount(2));
@@ -174,10 +217,12 @@ public class TestHybridStoreRepartitioningWithMultiDataCenter {
       TestUtils.waitForNonDeterministicAssertion(30, TimeUnit.SECONDS, () -> {
         StoreInfo storeInfo = childControllerClients[index].getStore(storeName).getStore();
         String realTimeTopicNameInVersion = Utils.getRealTimeTopicName(storeInfo.getVersions().get(0));
-        PubSubTopic realTimePubSubTopic = pubSubTopicRepository.getTopic(realTimeTopicNameInVersion);
+        Assert.assertEquals(realTimeTopicNameInVersion, storeName + "_v1" + Version.REAL_TIME_TOPIC_SUFFIX);
 
+        PubSubTopic realTimePubSubTopic = pubSubTopicRepository.getTopic(realTimeTopicNameInVersion);
         // verify rt topic is created with the default partition count = 3
         Assert.assertEquals(topicManagers.get(index).getPartitionCount(realTimePubSubTopic), 3);
+        Assert.assertEquals(storeInfo.getLargestUsedRTVersionNumber(), 2);
       });
     }
 
@@ -195,79 +240,182 @@ public class TestHybridStoreRepartitioningWithMultiDataCenter {
         StoreInfo storeInfo = childControllerClients[idx].getStore(storeName).getStore();
         String realTimeTopicNameInBackupVersion = Utils.getRealTimeTopicName(storeInfo.getVersions().get(0));
         String realTimeTopicNameInCurrentVersion = Utils.getRealTimeTopicName(storeInfo.getVersions().get(1));
-        String expectedRealTimeTopicNameInStoreConfig =
-            Utils.createNewRealTimeTopicName(realTimeTopicNameInBackupVersion);
-        String actualRealTimeTopicNameInStoreConfig = storeInfo.getHybridStoreConfig().getRealTimeTopicName();
-        PubSubTopic newRtPubSubTopic = pubSubTopicRepository.getTopic(realTimeTopicNameInCurrentVersion);
+        String expectedRealTimeTopicNameInBackVersion = storeName + "_v1" + Version.REAL_TIME_TOPIC_SUFFIX;
+
+        // because we updated partition count, rt version should increase to v2
+        String expectedRealTimeTopicName = storeName + "_v2" + Version.REAL_TIME_TOPIC_SUFFIX;
 
         // verify rt topic name
-        Assert.assertNotEquals(realTimeTopicNameInBackupVersion, realTimeTopicNameInCurrentVersion);
-        Assert.assertEquals(realTimeTopicNameInCurrentVersion, actualRealTimeTopicNameInStoreConfig);
-        Assert.assertEquals(actualRealTimeTopicNameInStoreConfig, expectedRealTimeTopicNameInStoreConfig);
+        Assert.assertEquals(realTimeTopicNameInBackupVersion, expectedRealTimeTopicNameInBackVersion);
+        Assert.assertEquals(realTimeTopicNameInCurrentVersion, expectedRealTimeTopicName);
 
+        PubSubTopic newRtPubSubTopic = pubSubTopicRepository.getTopic(realTimeTopicNameInCurrentVersion);
         // verify rt topic is created with the updated partition count = 2
         Assert.assertEquals(topicManagers.get(idx).getPartitionCount(newRtPubSubTopic), 2);
+
+        // we updated partition count and create a new VT version, so largestUsedRTVersion should have increased
+        Assert.assertEquals(storeInfo.getLargestUsedRTVersionNumber(), 2);
       });
     }
-  }
 
-  @Test(timeOut = TEST_TIMEOUT)
-  public void testLargestUsedRTVersionNumber() {
-    String storeName = Utils.getUniqueString("TestLargestUsedRTVersionNumber");
-    String clusterName = CLUSTER_NAMES[0];
-    String parentControllerURLs = multiRegionMultiClusterWrapper.getControllerConnectString();
+    // create another version by doing an empty push
+    parentControllerClient
+        .sendEmptyPushAndWait(storeName, Utils.getUniqueString("empty-push"), 1L, 60L * Time.MS_PER_SECOND);
 
-    ControllerClient parentControllerClient =
-        ControllerClient.constructClusterControllerClient(clusterName, parentControllerURLs);
-    ControllerClient[] childControllerClients = new ControllerClient[childDatacenters.size()];
-    for (int i = 0; i < childDatacenters.size(); i++) {
-      childControllerClients[i] =
-          new ControllerClient(clusterName, childDatacenters.get(i).getControllerConnectString());
+    for (ControllerClient controllerClient: childControllerClients) {
+      Assert.assertEquals(controllerClient.getStore(storeName).getStore().getCurrentVersion(), 3);
     }
 
-    NewStoreResponse newStoreResponse =
+    for (ControllerClient controllerClient: childControllerClients) {
+      TestUtils.waitForNonDeterministicAssertion(30, TimeUnit.SECONDS, () -> {
+        StoreInfo storeInfo = controllerClient.getStore(storeName).getStore();
+        List<Version> versions = storeInfo.getVersions();
+        int versionCount = versions.size();
+        Assert.assertEquals(versionCount, 2);
+        String realTimeTopicNameInBackupVersion = Utils.getRealTimeTopicName(versions.get(0));
+        String realTimeTopicNameInCurrentVersion = Utils.getRealTimeTopicName(versions.get(1));
+
+        // rt version should not change because there is no more partition count update
+        String expectedRealTimeTopicName = storeName + "_v2" + Version.REAL_TIME_TOPIC_SUFFIX;
+
+        // verify rt topic name
+        Assert.assertEquals(realTimeTopicNameInBackupVersion, expectedRealTimeTopicName);
+        Assert.assertEquals(realTimeTopicNameInCurrentVersion, expectedRealTimeTopicName);
+
+        Assert.assertEquals(storeInfo.getLargestUsedRTVersionNumber(), 2);
+      });
+    }
+
+    // now delete and recreate the store with the same name
+
+    updateStoreParams = new UpdateStoreQueryParams();
+    updateStoreParams.setEnableReads(false).setEnableWrites(false);
+
+    TestWriteUtils.updateStore(storeName, parentControllerClient, updateStoreParams);
+
+    ControllerResponse deleteStoreResponse = parentControllerClient.retryableRequest(5, c -> c.deleteStore(storeName));
+    Assert.assertFalse(
+        deleteStoreResponse.isError(),
+        "The DeleteStoreResponse returned an error: " + deleteStoreResponse.getError());
+
+    for (ControllerClient controllerClient: childControllerClients) {
+      TestUtils.waitForNonDeterministicAssertion(30, TimeUnit.SECONDS, () -> {
+        StoreResponse getStoreResponse = controllerClient.getStore(storeName);
+        Assert.assertEquals(getStoreResponse.getErrorType(), ErrorType.STORE_NOT_FOUND);
+      });
+    }
+
+    newStoreResponse =
         parentControllerClient.retryableRequest(5, c -> c.createNewStore(storeName, "", "\"string\"", "\"string\""));
     Assert.assertFalse(
         newStoreResponse.isError(),
         "The NewStoreResponse returned an error: " + newStoreResponse.getError());
 
-    UpdateStoreQueryParams updateStoreParams = new UpdateStoreQueryParams();
-    updateStoreParams.setEnableReads(false).setEnableWrites(false);
+    for (ControllerClient controllerClient: childControllerClients) {
+      StoreInfo storeInfo = controllerClient.getStore(storeName).getStore();
+      Assert.assertEquals(storeInfo.getLargestUsedRTVersionNumber(), 3);
+    }
 
-    TestWriteUtils.updateStore(storeName, parentControllerClient, updateStoreParams);
-
-    ControllerResponse deleteStoreResponse =
-        childControllerClients[0].retryableRequest(5, c -> c.deleteStore(storeName));
-    Assert.assertFalse(
-        deleteStoreResponse.isError(),
-        "The DeleteStoreResponse returned an error: " + deleteStoreResponse.getError());
-
-    newStoreResponse =
-        childControllerClients[0].retryableRequest(5, c -> c.createNewStore(storeName, "", "\"string\"", "\"string\""));
-    Assert.assertFalse(
-        newStoreResponse.isError(),
-        "The NewStoreResponse returned an error: " + newStoreResponse.getError());
-
-    String newRealTimeTopicName = "NewRealTimeTopicName" + Version.REAL_TIME_TOPIC_SUFFIX;
+    // make it hybrid
     updateStoreParams = new UpdateStoreQueryParams();
     updateStoreParams.setIncrementalPushEnabled(true)
         .setBackupStrategy(BackupStrategy.KEEP_MIN_VERSIONS)
         .setNumVersionsToPreserve(2)
         .setHybridRewindSeconds(1000)
         .setActiveActiveReplicationEnabled(true)
-        .setRealTimeTopicName(newRealTimeTopicName)
         .setEnableWrites(true)
         .setEnableReads(true)
         .setHybridOffsetLagThreshold(1000);
     TestWriteUtils.updateStore(storeName, parentControllerClient, updateStoreParams);
 
-    // create new version by doing an empty push
+    TestUtils.waitForNonDeterministicAssertion(30, TimeUnit.SECONDS, () -> {
+      for (ControllerClient controllerClient: childControllerClients) {
+        StoreInfo storeInfo = controllerClient.getStore(storeName).getStore();
+        Assert.assertEquals(storeInfo.getLargestUsedRTVersionNumber(), 3);
+        Assert.assertEquals(Utils.getRealTimeTopicName(storeInfo), storeName + "_v3" + Version.REAL_TIME_TOPIC_SUFFIX);
+      }
+    });
+
+    // create a version by doing an empty push
     parentControllerClient
         .sendEmptyPushAndWait(storeName, Utils.getUniqueString("empty-push"), 1L, 60L * Time.MS_PER_SECOND);
 
     for (ControllerClient controllerClient: childControllerClients) {
-      Assert.assertEquals(controllerClient.getStore(storeName).getStore().getCurrentVersion(), 1);
-      Assert.assertEquals(controllerClient.getStore(storeName).getStore().getLargestUsedRTVersionNumber(), 0);
+      Assert.assertEquals(controllerClient.getStore(storeName).getStore().getCurrentVersion(), 4);
+    }
+
+    for (ControllerClient controllerClient: childControllerClients) {
+      TestUtils.waitForNonDeterministicAssertion(30, TimeUnit.SECONDS, () -> {
+        StoreInfo storeInfo = controllerClient.getStore(storeName).getStore();
+        String realTimeTopicNameInVersion = Utils.getRealTimeTopicName(storeInfo.getVersions().get(0));
+        Assert.assertEquals(realTimeTopicNameInVersion, storeName + "_v3" + Version.REAL_TIME_TOPIC_SUFFIX);
+        Assert.assertEquals(storeInfo.getLargestUsedRTVersionNumber(), 3);
+      });
+    }
+
+    TestWriteUtils.updateStore(storeName, parentControllerClient, new UpdateStoreQueryParams().setPartitionCount(1));
+
+    for (ControllerClient controllerClient: childControllerClients) {
+      // we updated partition count, so largestUsedRTVersion should have increased
+      Assert.assertEquals(controllerClient.getStore(storeName).getStore().getLargestUsedRTVersionNumber(), 4);
+    }
+
+    // create new version by doing an empty push
+    parentControllerClient
+        .sendEmptyPushAndWait(storeName, Utils.getUniqueString("empty-push"), 1L, 60L * Time.MS_PER_SECOND);
+
+    for (int i = 0; i < childControllerClients.length; i++) {
+      final int idx = i;
+      TestUtils.waitForNonDeterministicAssertion(30, TimeUnit.SECONDS, () -> {
+        StoreInfo storeInfo = childControllerClients[idx].getStore(storeName).getStore();
+        List<Version> versions = storeInfo.getVersions();
+        int versionCount = versions.size();
+        Assert.assertEquals(versionCount, 2);
+        String realTimeTopicNameInBackupVersion = Utils.getRealTimeTopicName(versions.get(0));
+        String realTimeTopicNameInCurrentVersion = Utils.getRealTimeTopicName(versions.get(1));
+        String expectedRealTimeTopicNameInBackVersion = storeName + "_v3" + Version.REAL_TIME_TOPIC_SUFFIX;
+
+        // because we updated partition count, rt version should increase to v2
+        String expectedRealTimeTopicName = storeName + "_v4" + Version.REAL_TIME_TOPIC_SUFFIX;
+
+        // verify rt topic name
+        Assert.assertEquals(realTimeTopicNameInBackupVersion, expectedRealTimeTopicNameInBackVersion);
+        Assert.assertEquals(realTimeTopicNameInCurrentVersion, expectedRealTimeTopicName);
+
+        PubSubTopic newRtPubSubTopic = pubSubTopicRepository.getTopic(realTimeTopicNameInCurrentVersion);
+        // verify rt topic is created with the updated partition count = 2
+        Assert.assertEquals(topicManagers.get(idx).getPartitionCount(newRtPubSubTopic), 1);
+
+        Assert.assertEquals(storeInfo.getLargestUsedRTVersionNumber(), 4);
+      });
+    }
+
+    // create another version by doing an empty push
+    parentControllerClient
+        .sendEmptyPushAndWait(storeName, Utils.getUniqueString("empty-push"), 1L, 60L * Time.MS_PER_SECOND);
+
+    for (ControllerClient controllerClient: childControllerClients) {
+      Assert.assertEquals(controllerClient.getStore(storeName).getStore().getCurrentVersion(), 6);
+    }
+
+    for (ControllerClient controllerClient: childControllerClients) {
+      TestUtils.waitForNonDeterministicAssertion(30, TimeUnit.SECONDS, () -> {
+        StoreInfo storeInfo = controllerClient.getStore(storeName).getStore();
+        List<Version> versions = storeInfo.getVersions();
+        int versionCount = versions.size();
+        Assert.assertEquals(versionCount, 2);
+        String realTimeTopicNameInBackupVersion = Utils.getRealTimeTopicName(versions.get(0));
+        String realTimeTopicNameInCurrentVersion = Utils.getRealTimeTopicName(versions.get(1));
+
+        // rt version should not change because there is no more partition count update
+        String expectedRealTimeTopicName = storeName + "_v4" + Version.REAL_TIME_TOPIC_SUFFIX;
+
+        // verify rt topic name
+        Assert.assertEquals(realTimeTopicNameInBackupVersion, expectedRealTimeTopicName);
+        Assert.assertEquals(realTimeTopicNameInCurrentVersion, expectedRealTimeTopicName);
+
+        Assert.assertEquals(storeInfo.getLargestUsedRTVersionNumber(), 4);
+      });
     }
   }
 }

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/controller/TestHybridStoreRepartitioningWithMultiDataCenter.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/controller/TestHybridStoreRepartitioningWithMultiDataCenter.java
@@ -4,6 +4,7 @@ import static com.linkedin.venice.ConfigKeys.CONTROLLER_ENABLE_HYBRID_STORE_PART
 import static com.linkedin.venice.ConfigKeys.DEFAULT_MAX_NUMBER_OF_PARTITIONS;
 import static com.linkedin.venice.ConfigKeys.DEFAULT_NUMBER_OF_PARTITION_FOR_HYBRID;
 import static com.linkedin.venice.ConfigKeys.DEFAULT_PARTITION_SIZE;
+import static com.linkedin.venice.meta.Version.DEFAULT_RT_VERSION_NUMBER;
 
 import com.linkedin.venice.controllerapi.ControllerClient;
 import com.linkedin.venice.controllerapi.ControllerResponse;
@@ -37,12 +38,11 @@ import org.testng.annotations.Test;
 
 
 public class TestHybridStoreRepartitioningWithMultiDataCenter {
-  private static final int TEST_TIMEOUT = 90_000; // ms
+  private static final int TEST_TIMEOUT = 60_000; // ms
   private static final int NUMBER_OF_CHILD_DATACENTERS = 2;
   private static final int NUMBER_OF_CLUSTERS = 1;
   private static final String[] CLUSTER_NAMES =
       IntStream.range(0, NUMBER_OF_CLUSTERS).mapToObj(i -> "venice-cluster" + i).toArray(String[]::new);
-  private List<VeniceMultiClusterWrapper> childDatacenters;
   private VeniceTwoLayerMultiRegionMultiClusterWrapper multiRegionMultiClusterWrapper;
   List<TopicManager> topicManagers;
   PubSubTopicRepository pubSubTopicRepository = new PubSubTopicRepository();
@@ -71,7 +71,7 @@ public class TestHybridStoreRepartitioningWithMultiDataCenter {
     multiRegionMultiClusterWrapper =
         ServiceFactory.getVeniceTwoLayerMultiRegionMultiClusterWrapper(optionsBuilder.build());
     String parentControllerURLs = multiRegionMultiClusterWrapper.getControllerConnectString();
-    childDatacenters = multiRegionMultiClusterWrapper.getChildRegions();
+    List<VeniceMultiClusterWrapper> childDatacenters = multiRegionMultiClusterWrapper.getChildRegions();
     parentControllerClient = ControllerClient.constructClusterControllerClient(CLUSTER_NAMES[0], parentControllerURLs);
     childControllerClients = new ControllerClient[childDatacenters.size()];
     for (int i = 0; i < childDatacenters.size(); i++) {
@@ -88,6 +88,60 @@ public class TestHybridStoreRepartitioningWithMultiDataCenter {
   @AfterClass(alwaysRun = true)
   public void cleanUp() {
     Utils.closeQuietlyWithErrorLogged(multiRegionMultiClusterWrapper);
+  }
+
+  private static void verifyStoreState(
+      ControllerClient controllerClient,
+      String storeName,
+      int expectedLargestUsedRTVersionNumber,
+      String expectedRealTimeTopicNameInStoreConfig,
+      String expectedRealTimeTopicNameInBackupVersionConfig,
+      String expectedRealTimeTopicNameInVersionConfig) {
+    StoreInfo storeInfo = controllerClient.getStore(storeName).getStore();
+    Assert.assertNotNull(storeInfo.getHybridStoreConfig());
+
+    String oldStyleRealTimeTopicName = Utils.composeRealTimeTopic(storeName);
+    String realTimeTopicNameInStoreConfig = storeInfo.getHybridStoreConfig().getRealTimeTopicName();
+    String realTimeTopicInStore = Utils.getRealTimeTopicName(storeInfo);
+    Assert.assertEquals(storeInfo.getLargestUsedRTVersionNumber(), expectedLargestUsedRTVersionNumber);
+    Assert.assertEquals(realTimeTopicNameInStoreConfig, expectedRealTimeTopicNameInStoreConfig);
+
+    List<Version> versions = storeInfo.getVersions();
+    if (versions.isEmpty()) {
+      Assert.assertEquals(
+          realTimeTopicInStore,
+          expectedRealTimeTopicNameInStoreConfig.isEmpty()
+              ? oldStyleRealTimeTopicName
+              : expectedRealTimeTopicNameInStoreConfig);
+      return;
+    }
+
+    Assert.assertEquals(
+        realTimeTopicInStore,
+        expectedRealTimeTopicNameInVersionConfig.isEmpty()
+            ? oldStyleRealTimeTopicName
+            : expectedRealTimeTopicNameInVersionConfig);
+
+    Version backupVersion = versions.get(0);
+    Version currentVersion = versions.get(versions.size() - 1);
+
+    String realTimeTopicNameInVersionConfig = currentVersion.getHybridStoreConfig().getRealTimeTopicName();
+    String realTimeTopicNameInBackupVersionConfig = backupVersion.getHybridStoreConfig().getRealTimeTopicName();
+    String realTimeTopicInVersion = Utils.getRealTimeTopicName(currentVersion);
+    String realTimeTopicInBackupVersion = Utils.getRealTimeTopicName(backupVersion);
+
+    Assert.assertEquals(realTimeTopicNameInVersionConfig, expectedRealTimeTopicNameInVersionConfig);
+    Assert.assertEquals(realTimeTopicNameInBackupVersionConfig, expectedRealTimeTopicNameInBackupVersionConfig);
+    Assert.assertEquals(
+        realTimeTopicInVersion,
+        expectedRealTimeTopicNameInVersionConfig.isEmpty()
+            ? oldStyleRealTimeTopicName
+            : expectedRealTimeTopicNameInVersionConfig);
+    Assert.assertEquals(
+        realTimeTopicInBackupVersion,
+        expectedRealTimeTopicNameInBackupVersionConfig.isEmpty()
+            ? oldStyleRealTimeTopicName
+            : expectedRealTimeTopicNameInBackupVersionConfig);
   }
 
   /*
@@ -109,21 +163,20 @@ public class TestHybridStoreRepartitioningWithMultiDataCenter {
       TestUtils.waitForNonDeterministicAssertion(30, TimeUnit.SECONDS, () -> {
         StoreInfo storeInfo = childControllerClient.getStore(storeName).getStore();
         Assert.assertEquals(storeInfo.getLargestUsedRTVersionNumber(), 1);
-
-        // Assert.assertEquals(realTimeTopicNameInStore, newRealTimeTopicNameInCofnig);
       });
     }
-    // make it an old-style store by removing the rt name
-    String newRealTimeTopicNameInCofnig = "";
-    String newRealTimeTopicName = storeName + Version.REAL_TIME_TOPIC_SUFFIX;
+
+    // make it an old-style store by removing the rt name and setting largestUsedRTVersionNumber to
+    // DEFAULT_RT_VERSION_NUMBER
+    String newRealTimeTopicNameInConfig = "";
     UpdateStoreQueryParams updateStoreParams = new UpdateStoreQueryParams();
     updateStoreParams.setIncrementalPushEnabled(true)
         .setBackupStrategy(BackupStrategy.KEEP_MIN_VERSIONS)
         .setNumVersionsToPreserve(2)
         .setHybridRewindSeconds(1000)
         .setActiveActiveReplicationEnabled(true)
-        .setRealTimeTopicName(newRealTimeTopicNameInCofnig)
-        .setLargestUsedRTVersionNumber(0)
+        .setRealTimeTopicName(newRealTimeTopicNameInConfig)
+        .setLargestUsedRTVersionNumber(DEFAULT_RT_VERSION_NUMBER)
         .setHybridOffsetLagThreshold(1000);
     TestWriteUtils.updateStore(storeName, parentControllerClient, updateStoreParams);
 
@@ -131,10 +184,7 @@ public class TestHybridStoreRepartitioningWithMultiDataCenter {
       TestUtils.waitForNonDeterministicAssertion(30, TimeUnit.SECONDS, () -> {
         StoreInfo storeInfo = childControllerClient.getStore(storeName).getStore();
         Assert.assertNotNull(storeInfo.getHybridStoreConfig());
-        String realTimeTopicNameInStore = storeInfo.getHybridStoreConfig().getRealTimeTopicName();
-        Assert.assertEquals(storeInfo.getLargestUsedRTVersionNumber(), 0);
-
-        // Assert.assertEquals(realTimeTopicNameInStore, newRealTimeTopicNameInCofnig);
+        verifyStoreState(childControllerClient, storeName, 0, newRealTimeTopicNameInConfig, null, null);
       });
     }
 
@@ -148,17 +198,13 @@ public class TestHybridStoreRepartitioningWithMultiDataCenter {
 
     for (ControllerClient childControllerClient: childControllerClients) {
       TestUtils.waitForNonDeterministicAssertion(30, TimeUnit.SECONDS, () -> {
-        StoreInfo storeInfo = childControllerClient.getStore(storeName).getStore();
-        Version version = storeInfo.getVersions().get(0);
-        String realTimeTopicNameInStore = storeInfo.getHybridStoreConfig().getRealTimeTopicName();
-        String realTimeTopicNameInVersion = version.getHybridStoreConfig().getRealTimeTopicName();
-        String realTimeTopicInStoreThroughAPI = Utils.getRealTimeTopicName(storeInfo);
-        String realTimeTopicInVersionThroughAPI = Utils.getRealTimeTopicName(version);
-
-        Assert.assertEquals(realTimeTopicNameInStore, newRealTimeTopicNameInCofnig);
-        Assert.assertEquals(realTimeTopicNameInVersion, newRealTimeTopicNameInCofnig);
-        Assert.assertEquals(realTimeTopicInStoreThroughAPI, newRealTimeTopicName);
-        Assert.assertEquals(realTimeTopicInVersionThroughAPI, newRealTimeTopicName);
+        verifyStoreState(
+            childControllerClient,
+            storeName,
+            0,
+            newRealTimeTopicNameInConfig,
+            newRealTimeTopicNameInConfig,
+            newRealTimeTopicNameInConfig);
       });
     }
   }
@@ -167,7 +213,7 @@ public class TestHybridStoreRepartitioningWithMultiDataCenter {
    * This test creates a store, do a push, update it's partition count, delete it, recreate it, and do a push again.
    * At all steps, RT name is verified.
    */
-  @Test(timeOut = 5 * TEST_TIMEOUT)
+  @Test(timeOut = 2 * TEST_TIMEOUT)
   public void testRealTimeTopicVersioning() {
     String storeName = Utils.getUniqueString("TestRealTimeTopicVersioning");
 
@@ -178,8 +224,7 @@ public class TestHybridStoreRepartitioningWithMultiDataCenter {
         "The NewStoreResponse returned an error: " + newStoreResponse.getError());
 
     for (ControllerClient controllerClient: childControllerClients) {
-      StoreInfo storeInfo = controllerClient.getStore(storeName).getStore();
-      Assert.assertEquals(storeInfo.getLargestUsedRTVersionNumber(), 1);
+      Assert.assertEquals(controllerClient.getStore(storeName).getStore().getLargestUsedRTVersionNumber(), 1);
     }
 
     UpdateStoreQueryParams updateStoreParams = new UpdateStoreQueryParams();
@@ -191,10 +236,10 @@ public class TestHybridStoreRepartitioningWithMultiDataCenter {
         .setHybridOffsetLagThreshold(1000);
     TestWriteUtils.updateStore(storeName, parentControllerClient, updateStoreParams);
 
-    for (ControllerClient controllerClient: childControllerClients) {
+    for (ControllerClient childControllerClient: childControllerClients) {
       TestUtils.waitForNonDeterministicAssertion(30, TimeUnit.SECONDS, () -> {
-        StoreInfo storeInfo = controllerClient.getStore(storeName).getStore();
-        Assert.assertEquals(storeInfo.getLargestUsedRTVersionNumber(), 1);
+        String expectedRealTimeTopicName = storeName + "_v1" + Version.REAL_TIME_TOPIC_SUFFIX;
+        verifyStoreState(childControllerClient, storeName, 1, expectedRealTimeTopicName, null, null);
       });
     }
 
@@ -202,12 +247,17 @@ public class TestHybridStoreRepartitioningWithMultiDataCenter {
     parentControllerClient
         .sendEmptyPushAndWait(storeName, Utils.getUniqueString("empty-push"), 1L, 60L * Time.MS_PER_SECOND);
 
-    for (ControllerClient controllerClient: childControllerClients) {
-      StoreInfo storeInfo = controllerClient.getStore(storeName).getStore();
-      Assert.assertEquals(
-          storeInfo.getHybridStoreConfig().getRealTimeTopicName(),
-          storeName + "_v1" + Version.REAL_TIME_TOPIC_SUFFIX);
+    for (ControllerClient childControllerClient: childControllerClients) {
+      String expectedRealTimeTopicName = storeName + "_v1" + Version.REAL_TIME_TOPIC_SUFFIX;
+      StoreInfo storeInfo = childControllerClient.getStore(storeName).getStore();
       Assert.assertEquals(storeInfo.getCurrentVersion(), 1);
+      verifyStoreState(
+          childControllerClient,
+          storeName,
+          1,
+          expectedRealTimeTopicName,
+          expectedRealTimeTopicName,
+          expectedRealTimeTopicName);
     }
 
     TestWriteUtils.updateStore(storeName, parentControllerClient, new UpdateStoreQueryParams().setPartitionCount(2));
@@ -215,14 +265,19 @@ public class TestHybridStoreRepartitioningWithMultiDataCenter {
     for (int i = 0; i < childControllerClients.length; i++) {
       final int index = i;
       TestUtils.waitForNonDeterministicAssertion(30, TimeUnit.SECONDS, () -> {
-        StoreInfo storeInfo = childControllerClients[index].getStore(storeName).getStore();
-        String realTimeTopicNameInVersion = Utils.getRealTimeTopicName(storeInfo.getVersions().get(0));
-        Assert.assertEquals(realTimeTopicNameInVersion, storeName + "_v1" + Version.REAL_TIME_TOPIC_SUFFIX);
-
-        PubSubTopic realTimePubSubTopic = pubSubTopicRepository.getTopic(realTimeTopicNameInVersion);
-        // verify rt topic is created with the default partition count = 3
+        String expectedRealTimeTopicNameInVersion = storeName + "_v1" + Version.REAL_TIME_TOPIC_SUFFIX;
+        String expectedRealTimeTopicNameInStore = storeName + "_v2" + Version.REAL_TIME_TOPIC_SUFFIX;
+        verifyStoreState(
+            childControllerClients[0],
+            storeName,
+            2,
+            expectedRealTimeTopicNameInStore,
+            expectedRealTimeTopicNameInVersion,
+            expectedRealTimeTopicNameInVersion);
+        PubSubTopic realTimePubSubTopic = pubSubTopicRepository.getTopic(expectedRealTimeTopicNameInVersion);
+        // verify rt topic is created with the default partition count = 3, note that updateStore has not yet created a
+        // new version with partition count = 2
         Assert.assertEquals(topicManagers.get(index).getPartitionCount(realTimePubSubTopic), 3);
-        Assert.assertEquals(storeInfo.getLargestUsedRTVersionNumber(), 2);
       });
     }
 
@@ -237,24 +292,23 @@ public class TestHybridStoreRepartitioningWithMultiDataCenter {
     for (int i = 0; i < childControllerClients.length; i++) {
       final int idx = i;
       TestUtils.waitForNonDeterministicAssertion(30, TimeUnit.SECONDS, () -> {
-        StoreInfo storeInfo = childControllerClients[idx].getStore(storeName).getStore();
-        String realTimeTopicNameInBackupVersion = Utils.getRealTimeTopicName(storeInfo.getVersions().get(0));
-        String realTimeTopicNameInCurrentVersion = Utils.getRealTimeTopicName(storeInfo.getVersions().get(1));
-        String expectedRealTimeTopicNameInBackVersion = storeName + "_v1" + Version.REAL_TIME_TOPIC_SUFFIX;
-
+        String expectedRealTimeTopicNameInBackupVersion = storeName + "_v1" + Version.REAL_TIME_TOPIC_SUFFIX;
         // because we updated partition count, rt version should increase to v2
-        String expectedRealTimeTopicName = storeName + "_v2" + Version.REAL_TIME_TOPIC_SUFFIX;
+        String expectedRealTimeTopicNameInStore = storeName + "_v2" + Version.REAL_TIME_TOPIC_SUFFIX;
+        String expectedRealTimeTopicNameInVersion = storeName + "_v2" + Version.REAL_TIME_TOPIC_SUFFIX;
 
         // verify rt topic name
-        Assert.assertEquals(realTimeTopicNameInBackupVersion, expectedRealTimeTopicNameInBackVersion);
-        Assert.assertEquals(realTimeTopicNameInCurrentVersion, expectedRealTimeTopicName);
+        verifyStoreState(
+            childControllerClients[0],
+            storeName,
+            2,
+            expectedRealTimeTopicNameInStore,
+            expectedRealTimeTopicNameInBackupVersion,
+            expectedRealTimeTopicNameInVersion);
 
-        PubSubTopic newRtPubSubTopic = pubSubTopicRepository.getTopic(realTimeTopicNameInCurrentVersion);
+        PubSubTopic newRtPubSubTopic = pubSubTopicRepository.getTopic(expectedRealTimeTopicNameInVersion);
         // verify rt topic is created with the updated partition count = 2
         Assert.assertEquals(topicManagers.get(idx).getPartitionCount(newRtPubSubTopic), 2);
-
-        // we updated partition count and create a new VT version, so largestUsedRTVersion should have increased
-        Assert.assertEquals(storeInfo.getLargestUsedRTVersionNumber(), 2);
       });
     }
 
@@ -268,21 +322,17 @@ public class TestHybridStoreRepartitioningWithMultiDataCenter {
 
     for (ControllerClient controllerClient: childControllerClients) {
       TestUtils.waitForNonDeterministicAssertion(30, TimeUnit.SECONDS, () -> {
-        StoreInfo storeInfo = controllerClient.getStore(storeName).getStore();
-        List<Version> versions = storeInfo.getVersions();
-        int versionCount = versions.size();
-        Assert.assertEquals(versionCount, 2);
-        String realTimeTopicNameInBackupVersion = Utils.getRealTimeTopicName(versions.get(0));
-        String realTimeTopicNameInCurrentVersion = Utils.getRealTimeTopicName(versions.get(1));
-
+        Assert.assertEquals(controllerClient.getStore(storeName).getStore().getVersions().size(), 2);
         // rt version should not change because there is no more partition count update
         String expectedRealTimeTopicName = storeName + "_v2" + Version.REAL_TIME_TOPIC_SUFFIX;
-
         // verify rt topic name
-        Assert.assertEquals(realTimeTopicNameInBackupVersion, expectedRealTimeTopicName);
-        Assert.assertEquals(realTimeTopicNameInCurrentVersion, expectedRealTimeTopicName);
-
-        Assert.assertEquals(storeInfo.getLargestUsedRTVersionNumber(), 2);
+        verifyStoreState(
+            childControllerClients[0],
+            storeName,
+            2,
+            expectedRealTimeTopicName,
+            expectedRealTimeTopicName,
+            expectedRealTimeTopicName);
       });
     }
 
@@ -312,8 +362,7 @@ public class TestHybridStoreRepartitioningWithMultiDataCenter {
         "The NewStoreResponse returned an error: " + newStoreResponse.getError());
 
     for (ControllerClient controllerClient: childControllerClients) {
-      StoreInfo storeInfo = controllerClient.getStore(storeName).getStore();
-      Assert.assertEquals(storeInfo.getLargestUsedRTVersionNumber(), 3);
+      Assert.assertEquals(controllerClient.getStore(storeName).getStore().getLargestUsedRTVersionNumber(), 3);
     }
 
     // make it hybrid
@@ -330,9 +379,8 @@ public class TestHybridStoreRepartitioningWithMultiDataCenter {
 
     TestUtils.waitForNonDeterministicAssertion(30, TimeUnit.SECONDS, () -> {
       for (ControllerClient controllerClient: childControllerClients) {
-        StoreInfo storeInfo = controllerClient.getStore(storeName).getStore();
-        Assert.assertEquals(storeInfo.getLargestUsedRTVersionNumber(), 3);
-        Assert.assertEquals(Utils.getRealTimeTopicName(storeInfo), storeName + "_v3" + Version.REAL_TIME_TOPIC_SUFFIX);
+        String expectedRealTimeTopicName = storeName + "_v3" + Version.REAL_TIME_TOPIC_SUFFIX;
+        verifyStoreState(controllerClient, storeName, 3, expectedRealTimeTopicName, null, null);
       }
     });
 
@@ -346,10 +394,14 @@ public class TestHybridStoreRepartitioningWithMultiDataCenter {
 
     for (ControllerClient controllerClient: childControllerClients) {
       TestUtils.waitForNonDeterministicAssertion(30, TimeUnit.SECONDS, () -> {
-        StoreInfo storeInfo = controllerClient.getStore(storeName).getStore();
-        String realTimeTopicNameInVersion = Utils.getRealTimeTopicName(storeInfo.getVersions().get(0));
-        Assert.assertEquals(realTimeTopicNameInVersion, storeName + "_v3" + Version.REAL_TIME_TOPIC_SUFFIX);
-        Assert.assertEquals(storeInfo.getLargestUsedRTVersionNumber(), 3);
+        String expectedRealTimeTopicName = storeName + "_v3" + Version.REAL_TIME_TOPIC_SUFFIX;
+        verifyStoreState(
+            controllerClient,
+            storeName,
+            3,
+            expectedRealTimeTopicName,
+            expectedRealTimeTopicName,
+            expectedRealTimeTopicName);
       });
     }
 
@@ -368,25 +420,24 @@ public class TestHybridStoreRepartitioningWithMultiDataCenter {
       final int idx = i;
       TestUtils.waitForNonDeterministicAssertion(30, TimeUnit.SECONDS, () -> {
         StoreInfo storeInfo = childControllerClients[idx].getStore(storeName).getStore();
-        List<Version> versions = storeInfo.getVersions();
-        int versionCount = versions.size();
-        Assert.assertEquals(versionCount, 2);
-        String realTimeTopicNameInBackupVersion = Utils.getRealTimeTopicName(versions.get(0));
-        String realTimeTopicNameInCurrentVersion = Utils.getRealTimeTopicName(versions.get(1));
-        String expectedRealTimeTopicNameInBackVersion = storeName + "_v3" + Version.REAL_TIME_TOPIC_SUFFIX;
+        Assert.assertEquals(storeInfo.getVersions().size(), 2);
 
+        String expectedRealTimeTopicNameInBackupVersion = storeName + "_v3" + Version.REAL_TIME_TOPIC_SUFFIX;
         // because we updated partition count, rt version should increase to v2
         String expectedRealTimeTopicName = storeName + "_v4" + Version.REAL_TIME_TOPIC_SUFFIX;
 
-        // verify rt topic name
-        Assert.assertEquals(realTimeTopicNameInBackupVersion, expectedRealTimeTopicNameInBackVersion);
-        Assert.assertEquals(realTimeTopicNameInCurrentVersion, expectedRealTimeTopicName);
-
-        PubSubTopic newRtPubSubTopic = pubSubTopicRepository.getTopic(realTimeTopicNameInCurrentVersion);
+        PubSubTopic newRtPubSubTopic = pubSubTopicRepository.getTopic(expectedRealTimeTopicName);
         // verify rt topic is created with the updated partition count = 2
         Assert.assertEquals(topicManagers.get(idx).getPartitionCount(newRtPubSubTopic), 1);
 
         Assert.assertEquals(storeInfo.getLargestUsedRTVersionNumber(), 4);
+        verifyStoreState(
+            childControllerClients[idx],
+            storeName,
+            4,
+            expectedRealTimeTopicName,
+            expectedRealTimeTopicNameInBackupVersion,
+            expectedRealTimeTopicName);
       });
     }
 
@@ -398,23 +449,19 @@ public class TestHybridStoreRepartitioningWithMultiDataCenter {
       Assert.assertEquals(controllerClient.getStore(storeName).getStore().getCurrentVersion(), 6);
     }
 
-    for (ControllerClient controllerClient: childControllerClients) {
+    for (ControllerClient childControllerClient: childControllerClients) {
       TestUtils.waitForNonDeterministicAssertion(30, TimeUnit.SECONDS, () -> {
-        StoreInfo storeInfo = controllerClient.getStore(storeName).getStore();
-        List<Version> versions = storeInfo.getVersions();
-        int versionCount = versions.size();
-        Assert.assertEquals(versionCount, 2);
-        String realTimeTopicNameInBackupVersion = Utils.getRealTimeTopicName(versions.get(0));
-        String realTimeTopicNameInCurrentVersion = Utils.getRealTimeTopicName(versions.get(1));
+        Assert.assertEquals(childControllerClient.getStore(storeName).getStore().getVersions().size(), 2);
 
         // rt version should not change because there is no more partition count update
         String expectedRealTimeTopicName = storeName + "_v4" + Version.REAL_TIME_TOPIC_SUFFIX;
-
-        // verify rt topic name
-        Assert.assertEquals(realTimeTopicNameInBackupVersion, expectedRealTimeTopicName);
-        Assert.assertEquals(realTimeTopicNameInCurrentVersion, expectedRealTimeTopicName);
-
-        Assert.assertEquals(storeInfo.getLargestUsedRTVersionNumber(), 4);
+        verifyStoreState(
+            childControllerClient,
+            storeName,
+            4,
+            expectedRealTimeTopicName,
+            expectedRealTimeTopicName,
+            expectedRealTimeTopicName);
       });
     }
   }

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/controller/TestIncrementalPush.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/controller/TestIncrementalPush.java
@@ -90,6 +90,7 @@ public class TestIncrementalPush {
     runVPJ(propsBatch, 1, controllerClient);
     String incPushTopic = "TEST_INC_PUSH";
 
+    storeInfo.set(controllerClient.getStore(storeName).getStore());
     VeniceWriter<String, String, byte[]> veniceWriterRt =
         cluster.getVeniceWriter(Utils.getRealTimeTopicName(storeInfo.get()));
     veniceWriterRt.broadcastStartOfIncrementalPush(incPushTopic, new HashMap<>());

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/controller/TestParentControllerWithMultiDataCenter.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/controller/TestParentControllerWithMultiDataCenter.java
@@ -122,7 +122,7 @@ public class TestParentControllerWithMultiDataCenter {
         newStoreResponse.isError(),
         "The NewStoreResponse returned an error: " + newStoreResponse.getError());
 
-    StoreInfo store = TestUtils.assertCommand(parentControllerClient.getStore(storeName)).getStore();
+    TestUtils.assertCommand(parentControllerClient.getStore(storeName));
 
     String metaSystemStoreTopic =
         Version.composeKafkaTopic(VeniceSystemStoreType.META_STORE.getSystemStoreName(storeName), 1);
@@ -148,12 +148,15 @@ public class TestParentControllerWithMultiDataCenter {
     topicManagers
         .add(childDatacenters.get(1).getControllers().values().iterator().next().getVeniceAdmin().getTopicManager());
 
+    StoreInfo store = parentControllerClient.getStore(storeName).getStore();
     String rtTopicName = Utils.getRealTimeTopicName(store);
     PubSubTopic rtPubSubTopic = pubSubTopicRepository.getTopic(rtTopicName);
+
     for (TopicManager topicManager: topicManagers) {
       Assert.assertTrue(topicManager.containsTopic(versionPubsubTopic));
       Assert.assertTrue(topicManager.containsTopic(rtPubSubTopic));
     }
+
     for (ControllerClient controllerClient: childControllerClients) {
       Assert.assertEquals(controllerClient.getStore(storeName).getStore().getCurrentVersion(), 1);
     }
@@ -208,12 +211,12 @@ public class TestParentControllerWithMultiDataCenter {
     // now both the versions should be batch-only, so rt topic should get deleted by TopicCleanupService
     for (TopicManager topicManager: topicManagers) {
       Assert.assertTrue(topicManager.containsTopic(versionPubsubTopic));
-      TestUtils.waitForNonDeterministicAssertion(
-          30,
-          TimeUnit.SECONDS,
-          true,
-          true,
-          () -> Assert.assertFalse(topicManager.containsTopic(rtPubSubTopic)));
+      TestUtils.waitForNonDeterministicAssertion(30, TimeUnit.SECONDS, true, true, () -> {
+        StoreInfo finalStore = parentControllerClient.getStore(storeName).getStore();
+        String finalRtTopicName = Utils.getRealTimeTopicName(finalStore);
+        PubSubTopic finalRtPubSubTopic = pubSubTopicRepository.getTopic(finalRtTopicName);
+        Assert.assertFalse(topicManager.containsTopic(finalRtPubSubTopic));
+      });
     }
 
     /*
@@ -609,6 +612,7 @@ public class TestParentControllerWithMultiDataCenter {
     String clusterName = CLUSTER_NAMES[0];
     String storeName = Utils.getUniqueString("testDeleteStore");
     String parentControllerURLs = multiRegionMultiClusterWrapper.getControllerConnectString();
+
     try (ControllerClient parentControllerClient = new ControllerClient(clusterName, parentControllerURLs);
         ControllerClient dc0Client =
             new ControllerClient(clusterName, childDatacenters.get(0).getControllerConnectString());
@@ -622,7 +626,9 @@ public class TestParentControllerWithMultiDataCenter {
       ControllerResponse response = parentControllerClient.updateStore(
           storeName,
           new UpdateStoreQueryParams().setHybridOffsetLagThreshold(1).setHybridRewindSeconds(60));
+
       Assert.assertFalse(response.isError(), "Update hybrid store returned an error");
+
       List<ControllerClient> childControllerClients = new ArrayList<>();
       childControllerClients.add(dc0Client);
       childControllerClients.add(dc1Client);
@@ -632,25 +638,29 @@ public class TestParentControllerWithMultiDataCenter {
           .add(childDatacenters.get(0).getControllers().values().iterator().next().getVeniceAdmin().getTopicManager());
       childDatacenterTopicManagers
           .add(childDatacenters.get(1).getControllers().values().iterator().next().getVeniceAdmin().getTopicManager());
+
+      StoreInfo storeInfo = parentControllerClient.getStore(storeName).getStore();
+      String storeRT = Utils.getRealTimeTopicName(storeInfo);
       String pushStatusSystemStoreRT =
           Utils.composeRealTimeTopic(VeniceSystemStoreUtils.getDaVinciPushStatusStoreName(storeName));
       String metaSystemStoreRT = Utils.composeRealTimeTopic(VeniceSystemStoreUtils.getMetaStoreName(storeName));
+
       // Ensure all the RT topics are created in all child datacenters
       TestUtils.waitForNonDeterministicAssertion(300, TimeUnit.SECONDS, false, true, () -> {
         for (TopicManager topicManager: childDatacenterTopicManagers) {
-          Assert.assertTrue(
-              topicManager.containsTopic(pubSubTopicRepository.getTopic(Utils.composeRealTimeTopic(storeName))));
+          Assert.assertTrue(topicManager.containsTopic(pubSubTopicRepository.getTopic(storeRT)));
           Assert.assertTrue(topicManager.containsTopic(pubSubTopicRepository.getTopic(pushStatusSystemStoreRT)));
           Assert.assertTrue(topicManager.containsTopic(pubSubTopicRepository.getTopic(metaSystemStoreRT)));
         }
       });
+
       response = parentControllerClient.disableAndDeleteStore(storeName);
       Assert.assertFalse(response.isError(), "Delete store returned an error");
+
       // Ensure all the RT topics are deleted in all child datacenters
       TestUtils.waitForNonDeterministicAssertion(600, TimeUnit.SECONDS, false, true, () -> {
         for (TopicManager topicManager: childDatacenterTopicManagers) {
-          Assert.assertFalse(
-              topicManager.containsTopic(pubSubTopicRepository.getTopic(Utils.composeRealTimeTopic(storeName))));
+          Assert.assertFalse(topicManager.containsTopic(pubSubTopicRepository.getTopic(storeRT)));
           Assert.assertFalse(topicManager.containsTopic(pubSubTopicRepository.getTopic(pushStatusSystemStoreRT)));
           Assert.assertFalse(topicManager.containsTopic(pubSubTopicRepository.getTopic(metaSystemStoreRT)));
         }

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/controller/TestVeniceHelixAdminWithIsolatedEnvironment.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/controller/TestVeniceHelixAdminWithIsolatedEnvironment.java
@@ -245,7 +245,7 @@ public class TestVeniceHelixAdminWithIsolatedEnvironment extends AbstractTestVen
           storeName,
           new UpdateStoreQueryParams().setStoreMigration(false).setEnableReads(false).setEnableWrites(false));
 
-      PubSubTopic rtTopic = pubSubTopicRepository.getTopic(Version.composeRealTimeTopic(storeName));
+      PubSubTopic rtTopic = pubSubTopicRepository.getTopic(Utils.composeRealTimeTopic(storeName, 1));
       veniceAdmin.getTopicManager().createTopic(rtTopic, 1, 1, true);
 
       Assert.assertTrue(veniceAdmin.getTopicManager().containsTopic(rtTopic));
@@ -260,7 +260,7 @@ public class TestVeniceHelixAdminWithIsolatedEnvironment extends AbstractTestVen
           clusterName,
           newStoreName,
           new UpdateStoreQueryParams().setStoreMigration(false).setEnableReads(false).setEnableWrites(false));
-      PubSubTopic newRtTopic = pubSubTopicRepository.getTopic(Version.composeRealTimeTopic(newStoreName));
+      PubSubTopic newRtTopic = pubSubTopicRepository.getTopic(newStoreName + "_v1" + Version.REAL_TIME_TOPIC_SUFFIX);
       veniceAdmin.getTopicManager().createTopic(newRtTopic, 1, 1, true);
       abort = false;
       Assert.assertTrue(veniceAdmin.getTopicManager().containsTopic(newRtTopic));

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/controller/TestVeniceHelixAdminWithIsolatedEnvironment.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/controller/TestVeniceHelixAdminWithIsolatedEnvironment.java
@@ -260,7 +260,7 @@ public class TestVeniceHelixAdminWithIsolatedEnvironment extends AbstractTestVen
           clusterName,
           newStoreName,
           new UpdateStoreQueryParams().setStoreMigration(false).setEnableReads(false).setEnableWrites(false));
-      PubSubTopic newRtTopic = pubSubTopicRepository.getTopic(newStoreName + "_v1" + Version.REAL_TIME_TOPIC_SUFFIX);
+      PubSubTopic newRtTopic = pubSubTopicRepository.getTopic(Utils.composeRealTimeTopic(newStoreName, 1));
       veniceAdmin.getTopicManager().createTopic(newRtTopic, 1, 1, true);
       abort = false;
       Assert.assertTrue(veniceAdmin.getTopicManager().containsTopic(newRtTopic));

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/controller/TestVeniceHelixAdminWithSharedEnvironment.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/controller/TestVeniceHelixAdminWithSharedEnvironment.java
@@ -1896,7 +1896,7 @@ public class TestVeniceHelixAdminWithSharedEnvironment extends AbstractTestVenic
     Store store = Objects.requireNonNull(veniceAdmin.getStore(clusterName, storeName), "Store should not be null");
     String rtTopic = Utils.getRealTimeTopicName(store);
     PubSubTopic rtPubSubTopic = pubSubTopicRepository.getTopic(rtTopic);
-    String incrementalPushRealTimeTopic = Version.composeSeparateRealTimeTopic(storeName);
+    String incrementalPushRealTimeTopic = Utils.getSeparateRealTimeTopicName(rtTopic);
     PubSubTopic incrementalPushRealTimePubSubTopic = pubSubTopicRepository.getTopic(incrementalPushRealTimeTopic);
     TestUtils.waitForNonDeterministicCompletion(
         TOTAL_TIMEOUT_FOR_SHORT_TEST_MS,
@@ -1928,6 +1928,10 @@ public class TestVeniceHelixAdminWithSharedEnvironment extends AbstractTestVenic
         TOTAL_TIMEOUT_FOR_SHORT_TEST_MS,
         TimeUnit.MILLISECONDS,
         () -> veniceAdmin.getCurrentVersion(clusterName, storeName) == 3);
+
+    store = Objects.requireNonNull(veniceAdmin.getStore(clusterName, storeName), "Store should not be null");
+    rtTopic = Utils.getRealTimeTopicName(store.getVersions().get(0));
+
     Assert.assertTrue(veniceAdmin.isTopicTruncated(rtTopic));
     Assert.assertTrue(veniceAdmin.isTopicTruncated(incrementalPushRealTimeTopic));
   }

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/DaVinciClientTest.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/DaVinciClientTest.java
@@ -1493,7 +1493,7 @@ public class DaVinciClientTest {
   }
 
   private void runIncrementalPush(String storeName, String incrementalPushVersion, int keyCount) throws Exception {
-    String realTimeTopicName = Version.composeRealTimeTopic(storeName);
+    String realTimeTopicName = storeName + "_v1" + Version.REAL_TIME_TOPIC_SUFFIX;
     VeniceWriterFactory vwFactory =
         IntegrationTestPushUtils.getVeniceWriterFactory(cluster.getPubSubBrokerWrapper(), pubSubProducerAdapterFactory);
     VeniceKafkaSerializer keySerializer = new VeniceAvroKafkaSerializer(DEFAULT_KEY_SCHEMA);

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/DaVinciClientTest.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/DaVinciClientTest.java
@@ -18,6 +18,7 @@ import static com.linkedin.venice.ConfigKeys.BLOB_TRANSFER_MANAGER_ENABLED;
 import static com.linkedin.venice.ConfigKeys.BLOB_TRANSFER_SSL_ENABLED;
 import static com.linkedin.venice.ConfigKeys.CLIENT_SYSTEM_STORE_REPOSITORY_REFRESH_INTERVAL_SECONDS;
 import static com.linkedin.venice.ConfigKeys.CLIENT_USE_SYSTEM_STORE_REPOSITORY;
+import static com.linkedin.venice.ConfigKeys.CONTROLLER_ENABLE_REAL_TIME_TOPIC_VERSIONING;
 import static com.linkedin.venice.ConfigKeys.D2_ZK_HOSTS_ADDRESS;
 import static com.linkedin.venice.ConfigKeys.DATA_BASE_PATH;
 import static com.linkedin.venice.ConfigKeys.DAVINCI_P2P_BLOB_TRANSFER_CLIENT_PORT;
@@ -166,6 +167,7 @@ public class DaVinciClientTest {
   private VeniceClusterWrapper cluster;
   private D2Client d2Client;
   private PubSubProducerAdapterFactory pubSubProducerAdapterFactory;
+  private final boolean REAL_TIME_TOPIC_VERSIONING_ENABLED = true;
 
   @BeforeClass
   public void setUp() {
@@ -174,6 +176,7 @@ public class DaVinciClientTest {
     clusterConfig.put(SERVER_PROMOTION_TO_LEADER_REPLICA_DELAY_SECONDS, 1L);
     clusterConfig.put(PUSH_STATUS_STORE_ENABLED, true);
     clusterConfig.put(DAVINCI_PUSH_STATUS_SCAN_INTERVAL_IN_SECONDS, 3);
+    clusterConfig.put(CONTROLLER_ENABLE_REAL_TIME_TOPIC_VERSIONING, REAL_TIME_TOPIC_VERSIONING_ENABLED);
     VeniceClusterCreateOptions options = new VeniceClusterCreateOptions.Builder().numberOfControllers(1)
         .numberOfServers(2)
         .numberOfRouters(1)
@@ -1493,7 +1496,9 @@ public class DaVinciClientTest {
   }
 
   private void runIncrementalPush(String storeName, String incrementalPushVersion, int keyCount) throws Exception {
-    String realTimeTopicName = storeName + "_v1" + Version.REAL_TIME_TOPIC_SUFFIX;
+    String realTimeTopicName = REAL_TIME_TOPIC_VERSIONING_ENABLED
+        ? Utils.composeRealTimeTopic(storeName, 1)
+        : Utils.composeRealTimeTopic(storeName);
     VeniceWriterFactory vwFactory =
         IntegrationTestPushUtils.getVeniceWriterFactory(cluster.getPubSubBrokerWrapper(), pubSubProducerAdapterFactory);
     VeniceKafkaSerializer keySerializer = new VeniceAvroKafkaSerializer(DEFAULT_KEY_SCHEMA);

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/DaVinciLiveUpdateSuppressionTest.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/DaVinciLiveUpdateSuppressionTest.java
@@ -156,6 +156,10 @@ public class DaVinciLiveUpdateSuppressionTest {
             new DaVinciConfig(),
             extraBackendConfigMap);
 
+    cluster.useControllerClient(client -> {
+      storeInfo.set(client.getStore(storeName).getStore());
+    });
+
     try (CachingDaVinciClientFactory ignored = daVinciTestContext.getDaVinciClientFactory();
         DaVinciClient<Integer, Integer> client = daVinciTestContext.getDaVinciClient();
         VeniceWriter<Object, Object, byte[]> realTimeProducer = vwFactory.createVeniceWriter(

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/PartialUpdateTest.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/PartialUpdateTest.java
@@ -1368,10 +1368,7 @@ public class PartialUpdateTest {
       assertCommand(
           parentControllerClient
               .createNewStore(storeName, "test_owner", STRING_SCHEMA.toString(), valueSchema.toString()));
-      StoreInfo storeInfo = TestUtils.assertCommand(parentControllerClient.getStore(storeName)).getStore();
-      String realTimeTopicName = Utils.getRealTimeTopicName(storeInfo);
-      PubSubTopic realTimeTopic = PUB_SUB_TOPIC_REPOSITORY.getTopic(realTimeTopicName);
-      realTimeTopicPartition = new PubSubTopicPartitionImpl(realTimeTopic, 0);
+      TestUtils.assertCommand(parentControllerClient.getStore(storeName)).getStore();
       UpdateStoreQueryParams updateStoreParams =
           new UpdateStoreQueryParams().setStorageQuotaInByte(Store.UNLIMITED_STORAGE_QUOTA)
               .setPartitionCount(1)
@@ -1395,6 +1392,12 @@ public class PartialUpdateTest {
           parentControllerClient,
           30,
           TimeUnit.SECONDS);
+
+      StoreInfo storeInfo = TestUtils.assertCommand(parentControllerClient.getStore(storeName)).getStore();
+      String realTimeTopicName = Utils.getRealTimeTopicName(storeInfo);
+      PubSubTopic realTimeTopic = PUB_SUB_TOPIC_REPOSITORY.getTopic(realTimeTopicName);
+      realTimeTopicPartition = new PubSubTopicPartitionImpl(realTimeTopic, 0);
+
       TestUtils.waitForNonDeterministicAssertion(ASSERTION_TIMEOUT_MS, TimeUnit.MILLISECONDS, true, () -> {
         verifyConsumerThreadPoolFor(
             multiRegionMultiClusterWrapper,
@@ -1413,6 +1416,7 @@ public class PartialUpdateTest {
             1,
             REPLICATION_FACTOR - 1);
       });
+
       // Enable write-compute for v1:
       // leader: CURRENT_VERSION_NON_AAWC_LEADER => CURRENT_VERSION_AAWC_LEADER
       // follower: CURRENT_VERSION_NON_AAWC_LEADER

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestAdminOperationWithPreviousVersion.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestAdminOperationWithPreviousVersion.java
@@ -145,6 +145,7 @@ public class TestAdminOperationWithPreviousVersion {
         ConfigKeys.TOPIC_CLEANUP_SLEEP_INTERVAL_BETWEEN_TOPIC_LIST_FETCH_MS,
         String.valueOf(Long.MAX_VALUE));
     parentControllerProperties.setProperty(ConfigKeys.OFFLINE_JOB_START_TIMEOUT_MS, "180000");
+    parentControllerProperties.setProperty(ConfigKeys.CONTROLLER_ENABLE_REAL_TIME_TOPIC_VERSIONING, "false");
 
     Properties serverProperties = new Properties();
     serverProperties.setProperty(ConfigKeys.SERVER_PROMOTION_TO_LEADER_REPLICA_DELAY_SECONDS, Long.toString(1));

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestEmptyPush.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestEmptyPush.java
@@ -28,7 +28,6 @@ import com.linkedin.venice.integration.utils.ServiceFactory;
 import com.linkedin.venice.integration.utils.VeniceClusterCreateOptions;
 import com.linkedin.venice.integration.utils.VeniceClusterWrapper;
 import com.linkedin.venice.meta.Store;
-import com.linkedin.venice.meta.StoreInfo;
 import com.linkedin.venice.meta.Version;
 import com.linkedin.venice.pubsub.api.PubSubTopic;
 import com.linkedin.venice.pubsub.manager.TopicManager;
@@ -112,12 +111,12 @@ public class TestEmptyPush {
                 .getTopicManagerRepo(
                     PUBSUB_OPERATION_TIMEOUT_MS_DEFAULT_VALUE,
                     100,
-                    0l,
+                    0L,
                     venice.getPubSubBrokerWrapper(),
                     venice.getPubSubTopicRepository())
                 .getTopicManager(venice.getPubSubBrokerWrapper().getAddress())) {
       controllerClient.createNewStore(storeName, "owner", STRING_SCHEMA.toString(), STRING_SCHEMA.toString());
-      StoreInfo storeInfo = TestUtils.assertCommand(controllerClient.getStore(storeName)).getStore();
+      TestUtils.assertCommand(controllerClient.getStore(storeName));
       controllerClient.updateStore(
           storeName,
           new UpdateStoreQueryParams().setStorageQuotaInByte(Store.UNLIMITED_STORAGE_QUOTA)
@@ -136,8 +135,9 @@ public class TestEmptyPush {
       assertNotNull(
           dictForVersion1,
           "Dict shouldn't be null for the empty push to a hybrid store without any records in RT");
-      PubSubTopic storeRealTimeTopic =
-          venice.getPubSubTopicRepository().getTopic(Utils.getRealTimeTopicName(storeInfo));
+
+      String realTimeTopic = Utils.getRealTimeTopicName(controllerClient.getStore(storeName).getStore());
+      PubSubTopic storeRealTimeTopic = venice.getPubSubTopicRepository().getTopic(realTimeTopic);
       assertTrue(topicManager.containsTopicAndAllPartitionsAreOnline(storeRealTimeTopic));
       // One time refresh of router metadata.
       venice.refreshAllRouterMetaData();

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestHybrid.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestHybrid.java
@@ -1254,7 +1254,6 @@ public class TestHybrid {
 
       try (
           ControllerClient controllerClient = createStoreForJob(venice.getClusterName(), recordSchema, vpjProperties)) {
-        StoreInfo storeInfo = TestUtils.assertCommand(controllerClient.getStore(storeName)).getStore();
         // Have 1 partition only, so that all keys are produced to the same partition
         ControllerResponse response = controllerClient.updateStore(
             storeName,
@@ -1285,6 +1284,8 @@ public class TestHybrid {
         AvroSerializer<String> stringSerializer = new AvroSerializer(STRING_SCHEMA);
         AvroGenericDeserializer<String> stringDeserializer =
             new AvroGenericDeserializer<>(STRING_SCHEMA, STRING_SCHEMA);
+        StoreInfo storeInfo = TestUtils.assertCommand(controllerClient.getStore(storeName)).getStore();
+
         try (VeniceWriter<byte[], byte[], byte[]> realTimeTopicWriter =
             TestUtils.getVeniceWriterFactory(veniceWriterProperties, pubSubProducerAdapterFactory)
                 .createVeniceWriter(new VeniceWriterOptions.Builder(Utils.getRealTimeTopicName(storeInfo)).build())) {
@@ -1442,7 +1443,6 @@ public class TestHybrid {
     try (ControllerClient controllerClient = createStoreForJob(venice.getClusterName(), recordSchema, vpjProperties);
         AvroGenericStoreClient client = ClientFactory.getAndStartGenericAvroClient(
             ClientConfig.defaultGenericClientConfig(storeName).setVeniceURL(venice.getRandomRouterURL()))) {
-      StoreInfo storeInfo = controllerClient.getStore(storeName).getStore();
       // Have 1 partition only, so that all keys are produced to the same partition
       ControllerResponse response = controllerClient.updateStore(
           storeName,
@@ -1469,6 +1469,8 @@ public class TestHybrid {
       String prefix = "foo_object_";
       PubSubProducerAdapterFactory pubSubProducerAdapterFactory =
           venice.getPubSubBrokerWrapper().getPubSubClientsFactory().getProducerAdapterFactory();
+      StoreInfo storeInfo = controllerClient.getStore(storeName).getStore();
+
       for (int i = 0; i < 2; i++) {
         try (VeniceWriter<byte[], byte[], byte[]> realTimeTopicWriter =
             TestUtils.getVeniceWriterFactory(veniceWriterProperties, pubSubProducerAdapterFactory)
@@ -1517,7 +1519,6 @@ public class TestHybrid {
     try (ControllerClient controllerClient = createStoreForJob(venice.getClusterName(), recordSchema, vpjProperties);
         AvroGenericStoreClient client = ClientFactory.getAndStartGenericAvroClient(
             ClientConfig.defaultGenericClientConfig(storeName).setVeniceURL(venice.getRandomRouterURL()))) {
-      StoreInfo storeInfo = TestUtils.assertCommand(controllerClient.getStore(storeName)).getStore();
       // Have 1 partition only, so that all keys are produced to the same partition
       ControllerResponse response = controllerClient.updateStore(
           storeName,
@@ -1539,6 +1540,7 @@ public class TestHybrid {
       String prefix = "hybrid_DIV_enhancement_";
       PubSubProducerAdapterFactory pubSubProducerAdapterFactory =
           venice.getPubSubBrokerWrapper().getPubSubClientsFactory().getProducerAdapterFactory();
+      StoreInfo storeInfo = TestUtils.assertCommand(controllerClient.getStore(storeName)).getStore();
 
       // chunk the data into 2 parts and send each part by different producers. Also, close the producers
       // as soon as it finishes writing. This makes sure that closing or switching producers won't
@@ -1572,8 +1574,6 @@ public class TestHybrid {
 
   @Test(timeOut = 180 * Time.MS_PER_SECOND)
   public void testHybridWithPartitionWiseConsumer() throws Exception {
-    final Properties extraProperties = new Properties();
-    extraProperties.setProperty(SERVER_PROMOTION_TO_LEADER_REPLICA_DELAY_SECONDS, Long.toString(1L));
     // Using partition count of 4 to trigger realtime topics from different store versions' store ingestion task will
     // share one consumer.
     final int partitionCount = 4;

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestHybridMultiRegion.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestHybridMultiRegion.java
@@ -109,8 +109,6 @@ public class TestHybridMultiRegion {
 
       // Create store at parent, make it a hybrid store
       controllerClient.createNewStore(storeName, "owner", STRING_SCHEMA.toString(), STRING_SCHEMA.toString());
-      StoreInfo storeInfo = TestUtils.assertCommand(controllerClient.getStore(storeName)).getStore();
-      String realTimeTopicName = Utils.getRealTimeTopicName(storeInfo);
       controllerClient.updateStore(
           storeName,
           new UpdateStoreQueryParams().setStorageQuotaInByte(Store.UNLIMITED_STORAGE_QUOTA)
@@ -142,6 +140,9 @@ public class TestHybridMultiRegion {
         Assert.assertFalse(jobStatus.isError(), "Error in getting JobStatusResponse: " + jobStatus.getError());
         assertEquals(jobStatus.getStatus(), "COMPLETED");
       });
+
+      StoreInfo storeInfo = TestUtils.assertCommand(controllerClient.getStore(storeName)).getStore();
+      String realTimeTopicName = Utils.getRealTimeTopicName(storeInfo);
 
       // And real-time topic should exist now.
       assertTrue(

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestSeparateRealtimeTopicIngestion.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestSeparateRealtimeTopicIngestion.java
@@ -47,6 +47,7 @@ import com.linkedin.venice.integration.utils.VeniceServerWrapper;
 import com.linkedin.venice.integration.utils.VeniceTwoLayerMultiRegionMultiClusterWrapper;
 import com.linkedin.venice.meta.ReadOnlySchemaRepository;
 import com.linkedin.venice.meta.Store;
+import com.linkedin.venice.meta.StoreInfo;
 import com.linkedin.venice.meta.Version;
 import com.linkedin.venice.pubsub.PubSubTopicPartitionImpl;
 import com.linkedin.venice.pubsub.PubSubTopicRepository;
@@ -189,8 +190,10 @@ public class TestSeparateRealtimeTopicIngestion {
 
       // Run one time Incremental Push
       String childControllerUrl = childDatacenters.get(0).getRandomController().getControllerUrl();
+      StoreInfo storeInfo;
       try (ControllerClient childControllerClient = new ControllerClient(CLUSTER_NAME, childControllerUrl)) {
         runVPJ(vpjProperties, 1, childControllerClient);
+        storeInfo = childControllerClient.getStore(storeName).getStore();
       }
       VeniceClusterWrapper veniceClusterWrapper = childDatacenters.get(0).getClusters().get(CLUSTER_NAME);
       validateData(storeName, veniceClusterWrapper);
@@ -215,9 +218,9 @@ public class TestSeparateRealtimeTopicIngestion {
         // total key count.
         Assert.assertTrue(offsetVector.get(3) >= 100);
       });
-      PubSubTopic realTimeTopic = PUB_SUB_TOPIC_REPOSITORY.getTopic(Utils.composeRealTimeTopic(storeName));
+      PubSubTopic realTimeTopic = PUB_SUB_TOPIC_REPOSITORY.getTopic(Utils.getRealTimeTopicName(storeInfo));
       PubSubTopic separateRealtimeTopic =
-          PUB_SUB_TOPIC_REPOSITORY.getTopic(Version.composeSeparateRealTimeTopic(storeName));
+          PUB_SUB_TOPIC_REPOSITORY.getTopic(Utils.getSeparateRealTimeTopicName(realTimeTopic.getName()));
       PubSubTopic versionTopicV1 = PUB_SUB_TOPIC_REPOSITORY.getTopic(Version.composeKafkaTopic(storeName, 1));
       PubSubTopic versionTopicV2 = PUB_SUB_TOPIC_REPOSITORY.getTopic(Version.composeKafkaTopic(storeName, 2));
       PubSubTopicPartition versionV1TopicPartition = new PubSubTopicPartitionImpl(versionTopicV1, 0);

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestStoreMigration.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestStoreMigration.java
@@ -212,6 +212,10 @@ public class TestStoreMigration {
     Assert.assertEquals(
         storeInfo.getHybridStoreConfig().getRealTimeTopicName(),
         storeName + "_v1" + Version.REAL_TIME_TOPIC_SUFFIX);
+    // we set largestUsedRTVersionNumber=2 before VPJ, so the version would have rt=<store_name>_v2_rt
+    Assert.assertEquals(
+        storeInfo.getVersions().get(0).getHybridStoreConfig().getRealTimeTopicName(),
+        storeName + "_v2" + Version.REAL_TIME_TOPIC_SUFFIX);
 
     // Test abort migration on parent controller
     try (ControllerClient srcParentControllerClient = new ControllerClient(srcClusterName, parentControllerUrl);

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestStoreMigration.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestStoreMigration.java
@@ -15,6 +15,7 @@ import static com.linkedin.venice.utils.TestWriteUtils.getTempDataDirectory;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.DEFAULT_KEY_FIELD_PROP;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.DEFAULT_VALUE_FIELD_PROP;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.SEND_CONTROL_MESSAGES_DIRECTLY;
+import static com.linkedin.venice.vpj.VenicePushJobConstants.VENICE_STORE_NAME_PROP;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNotNull;
@@ -208,6 +209,9 @@ public class TestStoreMigration {
 
     StoreInfo storeInfo = new ControllerClient(destClusterName, parentControllerUrl).getStore(storeName).getStore();
     Assert.assertEquals(storeInfo.getLargestUsedRTVersionNumber(), 2);
+    Assert.assertEquals(
+        storeInfo.getHybridStoreConfig().getRealTimeTopicName(),
+        storeName + "_v1" + Version.REAL_TIME_TOPIC_SUFFIX);
 
     // Test abort migration on parent controller
     try (ControllerClient srcParentControllerClient = new ControllerClient(srcClusterName, parentControllerUrl);
@@ -535,6 +539,7 @@ public class TestStoreMigration {
             .setHybridOffsetLagThreshold(2L)
             .setHybridStoreDiskQuotaEnabled(true)
             .setLargestUsedRTVersionNumber(2)
+            .setRealTimeTopicName(props.getProperty(VENICE_STORE_NAME_PROP) + "_v1" + Version.REAL_TIME_TOPIC_SUFFIX)
             .setCompressionStrategy(CompressionStrategy.ZSTD_WITH_DICT)
             .setStorageNodeReadQuotaEnabled(true); // enable this for using fast client
     IntegrationTestPushUtils.createStoreForJob(clusterName, keySchemaStr, valueSchemaStr, props, updateStoreQueryParams)

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestStoreMigration.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestStoreMigration.java
@@ -211,7 +211,7 @@ public class TestStoreMigration {
     Assert.assertEquals(storeInfo.getLargestUsedRTVersionNumber(), 2);
     Assert.assertEquals(
         storeInfo.getHybridStoreConfig().getRealTimeTopicName(),
-        storeName + "_v1" + Version.REAL_TIME_TOPIC_SUFFIX);
+        Utils.composeRealTimeTopic(storeName, 1));
     // we set largestUsedRTVersionNumber=2 before VPJ, so the version would have rt=<store_name>_v2_rt
     Assert.assertEquals(
         storeInfo.getVersions().get(0).getHybridStoreConfig().getRealTimeTopicName(),
@@ -543,7 +543,7 @@ public class TestStoreMigration {
             .setHybridOffsetLagThreshold(2L)
             .setHybridStoreDiskQuotaEnabled(true)
             .setLargestUsedRTVersionNumber(2)
-            .setRealTimeTopicName(props.getProperty(VENICE_STORE_NAME_PROP) + "_v1" + Version.REAL_TIME_TOPIC_SUFFIX)
+            .setRealTimeTopicName(Utils.composeRealTimeTopic(props.getProperty(VENICE_STORE_NAME_PROP), 1))
             .setCompressionStrategy(CompressionStrategy.ZSTD_WITH_DICT)
             .setStorageNodeReadQuotaEnabled(true); // enable this for using fast client
     IntegrationTestPushUtils.createStoreForJob(clusterName, keySchemaStr, valueSchemaStr, props, updateStoreQueryParams)

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/ingestionHeartbeat/IngestionHeartBeatTest.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/ingestionHeartbeat/IngestionHeartBeatTest.java
@@ -148,7 +148,7 @@ public class IngestionHeartBeatTest {
       assertCommand(
           parentControllerClient
               .createNewStore(storeName, "test_owner", keySchemaStr, NAME_RECORD_V1_SCHEMA.toString()));
-      StoreInfo storeInfo = TestUtils.assertCommand(parentControllerClient.getStore(storeName)).getStore();
+      TestUtils.assertCommand(parentControllerClient.getStore(storeName));
       UpdateStoreQueryParams updateStoreParams =
           new UpdateStoreQueryParams().setStorageQuotaInByte(Store.UNLIMITED_STORAGE_QUOTA)
               .setCompressionStrategy(CompressionStrategy.NO_OP)
@@ -206,6 +206,8 @@ public class IngestionHeartBeatTest {
           }
         });
       }
+
+      StoreInfo storeInfo = TestUtils.assertCommand(parentControllerClient.getStore(storeName)).getStore();
 
       // create consumer to consume from RT/VT to verify HB and Leader completed header
       for (int dc = 0; dc < NUMBER_OF_CHILD_DATACENTERS; dc++) {

--- a/internal/venice-test-common/src/main/java/com/linkedin/venice/utils/TestUtils.java
+++ b/internal/venice-test-common/src/main/java/com/linkedin/venice/utils/TestUtils.java
@@ -497,10 +497,7 @@ public class TestUtils {
       if (executionStatus.isError()) {
         throw new VeniceException("Unexpected push failure for topic: " + topicName + ": " + jobStatusQueryResponse);
       }
-      assertEquals(
-          executionStatus,
-          ExecutionStatus.COMPLETED,
-          "Push is yet to complete: " + jobStatusQueryResponse.toString());
+      assertEquals(executionStatus, ExecutionStatus.COMPLETED, "Push is yet to complete: " + jobStatusQueryResponse);
     });
   }
 

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/Admin.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/Admin.java
@@ -538,7 +538,7 @@ public interface Admin extends AutoCloseable, Closeable {
       List<String> toBeStoppedInstances,
       boolean isSSLEnabled);
 
-  boolean isRTTopicDeletionPermittedByAllControllers(String clusterName, String storeName);
+  boolean isRTTopicDeletionPermittedByAllControllers(String clusterName, String rtTopicName);
 
   /**
    * Check if this controller itself is the leader controller for a given cluster or not. Note that the controller can be

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceControllerClusterConfig.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceControllerClusterConfig.java
@@ -97,6 +97,7 @@ import static com.linkedin.venice.ConfigKeys.DAVINCI_PUSH_STATUS_SCAN_MAX_OFFLIN
 import static com.linkedin.venice.ConfigKeys.DAVINCI_PUSH_STATUS_SCAN_MAX_OFFLINE_INSTANCE_RATIO;
 import static com.linkedin.venice.ConfigKeys.DAVINCI_PUSH_STATUS_SCAN_NO_REPORT_RETRY_MAX_ATTEMPTS;
 import static com.linkedin.venice.ConfigKeys.DAVINCI_PUSH_STATUS_SCAN_THREAD_NUMBER;
+import static com.linkedin.venice.ConfigKeys.DEFAULT_CONTROLLER_ENABLE_REAL_TIME_TOPIC_VERSIONING;
 import static com.linkedin.venice.ConfigKeys.DEFAULT_MAX_NUMBER_OF_PARTITIONS;
 import static com.linkedin.venice.ConfigKeys.DEFAULT_MAX_RECORD_SIZE_BYTES;
 import static com.linkedin.venice.ConfigKeys.DEFAULT_NUMBER_OF_PARTITION;
@@ -559,8 +560,9 @@ public class VeniceControllerClusterConfig {
   private final Set<String> childDatacenters;
   private final long serviceDiscoveryRegistrationRetryMS;
 
-  private Set<PushJobCheckpoints> pushJobUserErrorCheckpoints;
-  private boolean isHybridStorePartitionCountUpdateEnabled;
+  private final Set<PushJobCheckpoints> pushJobUserErrorCheckpoints;
+  private final boolean isRealTimeTopicVersioningEnabled;
+  private final boolean isHybridStorePartitionCountUpdateEnabled;
   private final long deferredVersionSwapSleepMs;
   private final boolean deferredVersionSwapServiceEnabled;
   private final boolean skipDeferredVersionSwapForDVCEnabled;
@@ -1051,6 +1053,9 @@ public class VeniceControllerClusterConfig {
     this.timeSinceLastLogCompactionThresholdMS =
         props.getLong(TIME_SINCE_LAST_LOG_COMPACTION_THRESHOLD_MS, TimeUnit.HOURS.toMillis(24));
 
+    this.isRealTimeTopicVersioningEnabled = props.getBoolean(
+        ConfigKeys.CONTROLLER_ENABLE_REAL_TIME_TOPIC_VERSIONING,
+        DEFAULT_CONTROLLER_ENABLE_REAL_TIME_TOPIC_VERSIONING);
     this.isHybridStorePartitionCountUpdateEnabled =
         props.getBoolean(ConfigKeys.CONTROLLER_ENABLE_HYBRID_STORE_PARTITION_COUNT_UPDATE, false);
 
@@ -1927,6 +1932,10 @@ public class VeniceControllerClusterConfig {
 
   public boolean isHybridStorePartitionCountUpdateEnabled() {
     return isHybridStorePartitionCountUpdateEnabled;
+  }
+
+  public boolean getRealTimeTopicVersioningEnabled() {
+    return isRealTimeTopicVersioningEnabled;
   }
 
   /**

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceControllerMultiClusterConfig.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceControllerMultiClusterConfig.java
@@ -342,4 +342,8 @@ public class VeniceControllerMultiClusterConfig {
   public long getTimeSinceLastLogCompactionThresholdMS() {
     return getCommonConfig().getTimeSinceLastLogCompactionThresholdMS();
   }
+
+  public boolean isRealTimeTopicVersioningEnabled() {
+    return getCommonConfig().getRealTimeTopicVersioningEnabled();
+  }
 }

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceHelixAdmin.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceHelixAdmin.java
@@ -1090,7 +1090,9 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
       newStore.setNativeReplicationSourceFabric(config.getNativeReplicationSourceFabricAsDefaultForBatchOnly());
     }
     newStore.setLargestUsedVersionNumber(largestUsedVersionNumber);
-    newStore.setLargestUsedRTVersionNumber(largestUsedRTVersionNumber);
+    /* If this store existed previously, we do not want to use the same RT topic name that was used by the previous
+    store. To ensure this, increase largestUsedRTVersionNumber and new RT name will be different */
+    newStore.setLargestUsedRTVersionNumber(largestUsedRTVersionNumber + 1);
   }
 
   /**
@@ -3163,7 +3165,6 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
         store.getName(),
         version.getNumber(),
         clusterName);
-    String storeName = store.getName();
     // Create real-time topic if it doesn't exist; otherwise, update the retention time if necessary
     PubSubTopic realTimeTopic = getPubSubTopicRepository().getTopic(Utils.getRealTimeTopicName(version));
     createOrUpdateRealTimeTopic(clusterName, store, version, realTimeTopic);
@@ -3175,7 +3176,7 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
           clusterName,
           store,
           version,
-          getPubSubTopicRepository().getTopic(Version.composeSeparateRealTimeTopic(storeName)));
+          getPubSubTopicRepository().getTopic(Utils.getSeparateRealTimeTopicName(version)));
     }
   }
 
@@ -3582,7 +3583,8 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
       String pushJobId) {
     PubSubTopicRepository topicRepository = getPubSubTopicRepository();
     if (referenceHybridVersion.isSeparateRealTimeTopicEnabled()) {
-      PubSubTopic separateRtTopic = topicRepository.getTopic(Version.composeSeparateRealTimeTopic(store.getName()));
+      PubSubTopic separateRtTopic =
+          topicRepository.getTopic(Utils.getSeparateRealTimeTopicName(referenceHybridVersion));
       validateTopicPresenceAndState(
           clusterName,
           store.getName(),
@@ -3898,10 +3900,11 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
             executor.shutdownNow();
           }
         }
-      }
-      PubSubTopic rtTopic = pubSubTopicRepository.getTopic(Utils.getRealTimeTopicName(store));
-      if (!store.isHybrid() && getTopicManager().containsTopic(rtTopic)) {
-        safeDeleteRTTopic(clusterName, storeName);
+
+        PubSubTopic rtTopic = pubSubTopicRepository.getTopic(Utils.getRealTimeTopicName(deletedVersion.get()));
+        if (!store.isHybrid() && getTopicManager().containsTopic(rtTopic)) {
+          safeDeleteRTTopic(clusterName, deletedVersion.get());
+        }
       }
     }
   }
@@ -3916,27 +3919,29 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
     }
   }
 
-  private void safeDeleteRTTopic(String clusterName, String storeName) {
-    boolean rtDeletionPermitted = isRTTopicDeletionPermittedByAllControllers(clusterName, storeName);
+  private void safeDeleteRTTopic(String clusterName, Version version) {
+    String realTimeTopicName = Utils.getRealTimeTopicName(version);
+    boolean rtDeletionPermitted = isRTTopicDeletionPermittedByAllControllers(clusterName, realTimeTopicName);
+
     if (rtDeletionPermitted) {
-      String rtTopicToDelete = Utils.composeRealTimeTopic(storeName);
-      deleteRTTopicFromAllFabrics(rtTopicToDelete, clusterName);
+      deleteRTTopicFromAllFabrics(realTimeTopicName, clusterName);
       // Check if there is incremental push topic exist. If yes, delete it and send out to let other controller to
       // delete it.
-      String incrementalPushRTTopicToDelete = Version.composeSeparateRealTimeTopic(storeName);
+      String incrementalPushRTTopicToDelete = Utils.getSeparateRealTimeTopicName(version);
       if (getTopicManager().containsTopic(pubSubTopicRepository.getTopic(incrementalPushRTTopicToDelete))) {
         deleteRTTopicFromAllFabrics(incrementalPushRTTopicToDelete, clusterName);
       }
     }
   }
 
-  public boolean isRTTopicDeletionPermittedByAllControllers(String clusterName, String storeName) {
+  public boolean isRTTopicDeletionPermittedByAllControllers(String clusterName, String rtTopicName) {
     // Perform RT cleanup checks for batch only store that used to be hybrid. Check versions
     // to see if any version is still using RT before deleting the RT.
     // Since we perform this check everytime when a store version is deleted we can afford to do best effort
     // approach if some fabrics are unavailable or out of sync (temporarily).
-    String rtTopicName = Utils.composeRealTimeTopic(storeName);
     Map<String, ControllerClient> controllerClientMap = getControllerClientMap(clusterName);
+    String storeName = Version.parseStoreFromRealTimeTopic(rtTopicName);
+
     for (Map.Entry<String, ControllerClient> controllerClientEntry: controllerClientMap.entrySet()) {
       StoreResponse storeResponse;
       try {
@@ -4743,17 +4748,16 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
   }
 
   private void generateAndUpdateRealTimeTopicName(Store store) {
-    // get oldRealTimeTopicName from the store config because that will be more (or equally) recent than any version
-    // config
-    String oldRealTimeTopicName = Utils.getRealTimeTopicNameFromStoreConfig(store);
-    String newRealTimeTopicName = Utils.createNewRealTimeTopicName(oldRealTimeTopicName);
-    PubSubTopic newRealTimeTopic = getPubSubTopicRepository().getTopic(newRealTimeTopicName);
-
-    if (getTopicManager().containsTopic(newRealTimeTopic)) {
-      throw new VeniceException("Topic " + newRealTimeTopic + " should not exist.");
-    }
+    String newRealTimeTopicName = Utils.isRTVersioningApplicable(store.getName())
+        ? store.getName() + "_v" + (store.getLargestUsedRTVersionNumber() + 1) + Version.REAL_TIME_TOPIC_SUFFIX
+        : DEFAULT_REAL_TIME_TOPIC_NAME;
 
     store.getHybridStoreConfig().setRealTimeTopicName(newRealTimeTopicName);
+    // after partition count update, new VT, if is hybrid, has to use a new RT with the same partition count, so we
+    // increase
+    // `largestUsedRTVersionNumber`; this will ensure that a new RT is created when/if needed
+    store.setLargestUsedRTVersionNumber(store.getLargestUsedRTVersionNumber() + 1);
+    LOGGER.info("updated largestUsedRTVersionNumber to " + store.getLargestUsedRTVersionNumber());
   }
 
   void setStorePartitionerConfig(String clusterName, String storeName, PartitionerConfig partitionerConfig) {
@@ -5739,6 +5743,12 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
             oldStore.getName() + " was not a hybrid store.  In order to make it a hybrid store both "
                 + " rewind time in seconds and offset or time lag threshold must be specified");
       }
+
+      String newRealTimeTopicName =
+          oldStore.getLargestUsedRTVersionNumber() > 0 && Utils.isRTVersioningApplicable(oldStore.getName())
+              ? oldStore.getName() + "_v" + oldStore.getLargestUsedRTVersionNumber() + Version.REAL_TIME_TOPIC_SUFFIX
+              : DEFAULT_REAL_TIME_TOPIC_NAME;
+
       mergedHybridStoreConfig = new HybridStoreConfigImpl(
           hybridRewindSeconds.get(),
           // If not specified, offset/time lag threshold will be -1 and will not be used to determine whether
@@ -5747,7 +5757,7 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
           hybridTimeLagThreshold.orElse(DEFAULT_HYBRID_TIME_LAG_THRESHOLD),
           hybridDataReplicationPolicy.orElse(DataReplicationPolicy.NON_AGGREGATE),
           bufferReplayPolicy.orElse(BufferReplayPolicy.REWIND_FROM_EOP),
-          realTimeTopicName.orElse(DEFAULT_REAL_TIME_TOPIC_NAME));
+          realTimeTopicName.orElse(newRealTimeTopicName));
     }
     if (mergedHybridStoreConfig.getRewindTimeInSeconds() > 0
         && mergedHybridStoreConfig.getOffsetLagThresholdToGoOnline() < 0

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceHelixAdmin.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceHelixAdmin.java
@@ -1092,7 +1092,9 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
     newStore.setLargestUsedVersionNumber(largestUsedVersionNumber);
     /* If this store existed previously, we do not want to use the same RT topic name that was used by the previous
     store. To ensure this, increase largestUsedRTVersionNumber and new RT name will be different */
-    newStore.setLargestUsedRTVersionNumber(largestUsedRTVersionNumber + 1);
+    if (getMultiClusterConfigs().isRealTimeTopicVersioningEnabled()) {
+      newStore.setLargestUsedRTVersionNumber(largestUsedRTVersionNumber + 1);
+    }
   }
 
   /**

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceHelixAdmin.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceHelixAdmin.java
@@ -5744,8 +5744,8 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
                 + " rewind time in seconds and offset or time lag threshold must be specified");
       }
 
-      String newRealTimeTopicName =
-          oldStore.getLargestUsedRTVersionNumber() > 0 && Utils.isRTVersioningApplicable(oldStore.getName())
+      String newRealTimeTopicName = oldStore.getLargestUsedRTVersionNumber() > DEFAULT_RT_VERSION_NUMBER
+          && Utils.isRTVersioningApplicable(oldStore.getName())
               ? oldStore.getName() + "_v" + oldStore.getLargestUsedRTVersionNumber() + Version.REAL_TIME_TOPIC_SUFFIX
               : DEFAULT_REAL_TIME_TOPIC_NAME;
 

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/kafka/TopicCleanupService.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/kafka/TopicCleanupService.java
@@ -242,7 +242,7 @@ public class TopicCleanupService extends AbstractVeniceService {
         continue;
       }
 
-      if (!topic.isRealTime() || admin.isRTTopicDeletionPermittedByAllControllers(clusterDiscovered, storeName)) {
+      if (!topic.isRealTime() || admin.isRTTopicDeletionPermittedByAllControllers(clusterDiscovered, topic.getName())) {
         // delete if it is a VT topic or an RT topic eligible for deletion by the above condition
         deleteTopic(topic);
       } else {

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/server/CreateVersion.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/server/CreateVersion.java
@@ -253,12 +253,12 @@ public class CreateVersion extends AbstractRoute {
     if (pushType == PushType.INCREMENTAL) {
       // If incremental push with a dedicated real-time topic is enabled then use the separate real-time topic
       if (version.isSeparateRealTimeTopicEnabled() && request.isSeparateRealTimeTopicEnabled()) {
-        responseTopic = Version.composeSeparateRealTimeTopic(storeName);
+        responseTopic = Utils.getSeparateRealTimeTopicName(version);
       } else {
         responseTopic = Utils.getRealTimeTopicName(version);
       }
     } else if (pushType == PushType.STREAM) {
-      responseTopic = Version.composeRealTimeTopic(storeName);
+      responseTopic = Utils.getRealTimeTopicName(version);
     } else if (pushType == PushType.STREAM_REPROCESSING) {
       responseTopic = Version.composeStreamReprocessingTopic(storeName, version.getNumber());
     } else {
@@ -378,7 +378,7 @@ public class CreateVersion extends AbstractRoute {
     }
     response.setPartitions(referenceHybridVersion.getPartitionCount());
     response.setCompressionStrategy(CompressionStrategy.NO_OP);
-    response.setKafkaTopic(Version.composeRealTimeTopic(store.getName()));
+    response.setKafkaTopic(Utils.getRealTimeTopicName(referenceHybridVersion));
   }
 
   /**

--- a/services/venice-controller/src/main/java/com/linkedin/venice/ingestion/control/RealTimeTopicSwitcher.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/ingestion/control/RealTimeTopicSwitcher.java
@@ -145,8 +145,7 @@ public class RealTimeTopicSwitcher {
      */
     createRealTimeTopicIfNeeded(store, version, srcTopicName, hybridStoreConfig.get());
     if (version != null && version.isSeparateRealTimeTopicEnabled()) {
-      PubSubTopic separateRealTimeTopic =
-          pubSubTopicRepository.getTopic(Version.composeSeparateRealTimeTopic(store.getName()));
+      PubSubTopic separateRealTimeTopic = pubSubTopicRepository.getTopic(Utils.getRealTimeTopicName(store));
       createRealTimeTopicIfNeeded(store, version, separateRealTimeTopic, hybridStoreConfig.get());
     }
   }

--- a/services/venice-controller/src/main/java/com/linkedin/venice/ingestion/control/RealTimeTopicSwitcher.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/ingestion/control/RealTimeTopicSwitcher.java
@@ -145,7 +145,7 @@ public class RealTimeTopicSwitcher {
      */
     createRealTimeTopicIfNeeded(store, version, srcTopicName, hybridStoreConfig.get());
     if (version != null && version.isSeparateRealTimeTopicEnabled()) {
-      PubSubTopic separateRealTimeTopic = pubSubTopicRepository.getTopic(Utils.getRealTimeTopicName(store));
+      PubSubTopic separateRealTimeTopic = pubSubTopicRepository.getTopic(Utils.getSeparateRealTimeTopicName(version));
       createRealTimeTopicIfNeeded(store, version, separateRealTimeTopic, hybridStoreConfig.get());
     }
   }

--- a/services/venice-controller/src/test/java/com/linkedin/venice/controller/TestVeniceHelixAdmin.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/controller/TestVeniceHelixAdmin.java
@@ -576,8 +576,8 @@ public class TestVeniceHelixAdmin {
     doReturn(storeName).when(store).getName();
     doReturn(storeName).when(referenceHybridVersion).getStoreName();
     doReturn(partitionCount).when(referenceHybridVersion).getPartitionCount();
-    PubSubTopic separateRtTopic = topicRepository.getTopic(Version.composeSeparateRealTimeTopic(storeName));
     PubSubTopic rtTopic = topicRepository.getTopic(Utils.getRealTimeTopicName(referenceHybridVersion));
+    PubSubTopic separateRtTopic = topicRepository.getTopic(Utils.getSeparateRealTimeTopicName(rtTopic.getName()));
 
     VeniceHelixAdmin veniceHelixAdmin0 = mock(VeniceHelixAdmin.class);
     doReturn(topicRepository).when(veniceHelixAdmin0).getPubSubTopicRepository();

--- a/services/venice-controller/src/test/java/com/linkedin/venice/controller/kafka/TestTopicCleanupService.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/controller/kafka/TestTopicCleanupService.java
@@ -1,5 +1,6 @@
 package com.linkedin.venice.controller.kafka;
 
+import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.anyString;
@@ -200,6 +201,7 @@ public class TestTopicCleanupService {
   @Test
   public void testCleanupVeniceTopics() {
     String clusterName = "clusterName";
+    String rtVersionPrefix = "_v1" + Version.REAL_TIME_TOPIC_SUFFIX;
     String storeName1 = Utils.getUniqueString("store1");
     String storeName2 = Utils.getUniqueString("store2");
     String storeName3 = Utils.getUniqueString("store3");
@@ -212,32 +214,32 @@ public class TestTopicCleanupService {
     storeTopics.put(getPubSubTopic(storeName1, "_v2"), 1000L);
     storeTopics.put(getPubSubTopic(storeName1, "_v3"), Long.MAX_VALUE);
     storeTopics.put(getPubSubTopic(storeName1, "_v4"), 1000L);
-    storeTopics.put(getPubSubTopic(storeName1, "_rt"), Long.MAX_VALUE);
-    storeTopics.put(getPubSubTopic(storeName2, "_rt"), 1000L);
+    storeTopics.put(getPubSubTopic(storeName1, rtVersionPrefix), Long.MAX_VALUE);
+    storeTopics.put(getPubSubTopic(storeName2, rtVersionPrefix), 1000L);
     storeTopics.put(getPubSubTopic(storeName2, "_v1"), 1000L);
-    storeTopics.put(getPubSubTopic(storeName3, "_rt"), 1000L);
+    storeTopics.put(getPubSubTopic(storeName3, rtVersionPrefix), 1000L);
     storeTopics.put(getPubSubTopic(storeName3, "_v100"), Long.MAX_VALUE);
-    storeTopics.put(getPubSubTopic(storeName4, "_rt"), Long.MAX_VALUE);
+    storeTopics.put(getPubSubTopic(storeName4, rtVersionPrefix), Long.MAX_VALUE);
     storeTopics.put(getPubSubTopic(storeName5, "_v1"), Long.MAX_VALUE);
-    storeTopics.put(getPubSubTopic(storeName6, "_rt"), 1000L);
+    storeTopics.put(getPubSubTopic(storeName6, rtVersionPrefix), 1000L);
     storeTopics.put(getPubSubTopic(storeName6, "_v1"), Long.MAX_VALUE);
     storeTopics.put(getPubSubTopic(storeName6, "_v2"), Long.MAX_VALUE);
     storeTopics.put(getPubSubTopic(PubSubTopicType.ADMIN_TOPIC_PREFIX, "_cluster"), Long.MAX_VALUE);
 
     Map<PubSubTopic, Long> storeTopics2 = new HashMap<>();
     storeTopics2.put(getPubSubTopic(storeName1, "_v3"), Long.MAX_VALUE);
-    storeTopics2.put(getPubSubTopic(storeName1, "_rt"), Long.MAX_VALUE);
-    storeTopics2.put(getPubSubTopic(storeName2, "_rt"), 1000L);
-    storeTopics2.put(getPubSubTopic(storeName3, "_rt"), 1000L);
+    storeTopics2.put(getPubSubTopic(storeName1, rtVersionPrefix), Long.MAX_VALUE);
+    storeTopics2.put(getPubSubTopic(storeName2, rtVersionPrefix), 1000L);
+    storeTopics2.put(getPubSubTopic(storeName3, rtVersionPrefix), 1000L);
 
     Map<PubSubTopic, Long> remoteTopics = new HashMap<>();
-    remoteTopics.put(getPubSubTopic(storeName2, "_rt"), 1000L);
-    remoteTopics.put(getPubSubTopic(storeName3, "_rt"), 1000L);
-    remoteTopics.put(getPubSubTopic(storeName3, "_v1"), 1000L);
+    remoteTopics.put(getPubSubTopic(storeName2, rtVersionPrefix), 1000L);
+    remoteTopics.put(getPubSubTopic(storeName3, rtVersionPrefix), 1000L);
+    remoteTopics.put(getPubSubTopic(storeName3, rtVersionPrefix), 1000L);
 
     Map<PubSubTopic, Long> remoteTopics2 = new HashMap<>();
-    remoteTopics2.put(getPubSubTopic(storeName2, "_rt"), 1000L);
-    remoteTopics2.put(getPubSubTopic(storeName3, "_rt"), 1000L);
+    remoteTopics2.put(getPubSubTopic(storeName2, rtVersionPrefix), 1000L);
+    remoteTopics2.put(getPubSubTopic(storeName3, rtVersionPrefix), 1000L);
 
     when(topicManager.getAllTopicRetentions()).thenReturn(storeTopics).thenReturn(storeTopics2);
     when(remoteTopicManager.listTopics()).thenReturn(remoteTopics.keySet()).thenReturn(remoteTopics2.keySet());
@@ -252,7 +254,7 @@ public class TestTopicCleanupService {
     Set<PubSubTopic> pubSubTopicSet = new HashSet<>();
     pubSubTopicSet.addAll(storeTopics.keySet());
     pubSubTopicSet.remove(getPubSubTopic(storeName3, "_v100"));
-    pubSubTopicSet.remove(getPubSubTopic(storeName4, "_rt"));
+    pubSubTopicSet.remove(getPubSubTopic(storeName4, rtVersionPrefix));
     pubSubTopicSet.remove(getPubSubTopic(storeName5, "_v1"));
     pubSubTopicSet.remove(getPubSubTopic(PubSubTopicType.ADMIN_TOPIC_PREFIX, "_cluster"));
 
@@ -299,24 +301,31 @@ public class TestTopicCleanupService {
     doReturn(Collections.singletonList(hybridVersion)).when(store3).getVersions();
     doReturn(Collections.singletonList(batchVersion)).when(store6).getVersions();
     // simulating blocked delete
-    doReturn(false).when(admin).isRTTopicDeletionPermittedByAllControllers(anyString(), eq(storeName1));
-    doReturn(false).when(admin).isRTTopicDeletionPermittedByAllControllers(anyString(), eq(storeName2));
-    doReturn(false).when(admin).isRTTopicDeletionPermittedByAllControllers(anyString(), eq(storeName3));
-    doReturn(true).when(admin).isRTTopicDeletionPermittedByAllControllers(anyString(), eq(storeName4));
-    doReturn(true).when(admin).isRTTopicDeletionPermittedByAllControllers(anyString(), eq(storeName5));
-    doReturn(true).when(admin).isRTTopicDeletionPermittedByAllControllers(anyString(), eq(storeName6));
+    doReturn(false).when(admin)
+        .isRTTopicDeletionPermittedByAllControllers(anyString(), argThat(arg -> arg.startsWith(storeName1)));
+    doReturn(false).when(admin)
+        .isRTTopicDeletionPermittedByAllControllers(anyString(), argThat(arg -> arg.startsWith(storeName2)));
+    doReturn(false).when(admin)
+        .isRTTopicDeletionPermittedByAllControllers(anyString(), argThat(arg -> arg.startsWith(storeName3)));
+    doReturn(true).when(admin)
+        .isRTTopicDeletionPermittedByAllControllers(anyString(), argThat(arg -> arg.startsWith(storeName4)));
+    doReturn(true).when(admin)
+        .isRTTopicDeletionPermittedByAllControllers(anyString(), argThat(arg -> arg.startsWith(storeName5)));
+    doReturn(true).when(admin)
+        .isRTTopicDeletionPermittedByAllControllers(anyString(), argThat(arg -> arg.startsWith(storeName6)));
 
     topicCleanupService.cleanupVeniceTopics();
 
-    verify(topicManager, never()).ensureTopicIsDeletedAndBlockWithRetry(getPubSubTopic(storeName1, "_rt"));
+    verify(topicManager, never()).ensureTopicIsDeletedAndBlockWithRetry(getPubSubTopic(storeName1, rtVersionPrefix));
     verify(topicManager, atLeastOnce()).ensureTopicIsDeletedAndBlockWithRetry(getPubSubTopic(storeName1, "_v1"));
     verify(topicManager, atLeastOnce()).ensureTopicIsDeletedAndBlockWithRetry(getPubSubTopic(storeName1, "_v2"));
     verify(topicManager, never()).ensureTopicIsDeletedAndBlockWithRetry(getPubSubTopic(storeName1, "_v3"));
     verify(topicManager, never()).ensureTopicIsDeletedAndBlockWithRetry(getPubSubTopic(storeName1, "_v4"));
     verify(topicManager, atLeastOnce()).ensureTopicIsDeletedAndBlockWithRetry(getPubSubTopic(storeName2, "_v1"));
-    verify(topicManager, atLeastOnce()).ensureTopicIsDeletedAndBlockWithRetry(getPubSubTopic(storeName6, "_rt"));
+    verify(topicManager, atLeastOnce())
+        .ensureTopicIsDeletedAndBlockWithRetry(getPubSubTopic(storeName6, rtVersionPrefix));
     // Delete should be blocked by local VT
-    verify(topicManager, never()).ensureTopicIsDeletedAndBlockWithRetry(getPubSubTopic(storeName2, "_rt"));
+    verify(topicManager, never()).ensureTopicIsDeletedAndBlockWithRetry(getPubSubTopic(storeName2, rtVersionPrefix));
     // Delete should be blocked by remote VT
     verify(topicManager, never()).ensureTopicIsDeletedAndBlockWithRetry(getPubSubTopic(storeName3, "_rt"));
     verify(topicCleanupServiceStats, atLeastOnce()).recordDeletableTopicsCount(9);
@@ -324,17 +333,22 @@ public class TestTopicCleanupService {
     verify(topicCleanupServiceStats, atLeastOnce()).recordTopicDeleted();
 
     verify(topicManager, atLeastOnce()).ensureTopicIsDeletedAndBlockWithRetry(getPubSubTopic(storeName3, "_v100"));
-    verify(topicManager, atLeastOnce()).ensureTopicIsDeletedAndBlockWithRetry(getPubSubTopic(storeName4, "_rt"));
+    verify(topicManager, atLeastOnce())
+        .ensureTopicIsDeletedAndBlockWithRetry(getPubSubTopic(storeName4, rtVersionPrefix));
     verify(topicManager, atLeastOnce()).ensureTopicIsDeletedAndBlockWithRetry(getPubSubTopic(storeName5, "_v1"));
 
-    doReturn(true).when(admin).isRTTopicDeletionPermittedByAllControllers(anyString(), eq(storeName2));
-    doReturn(true).when(admin).isRTTopicDeletionPermittedByAllControllers(anyString(), eq(storeName3));
+    doReturn(true).when(admin)
+        .isRTTopicDeletionPermittedByAllControllers(anyString(), argThat(arg -> arg.startsWith(storeName2)));
+    doReturn(true).when(admin)
+        .isRTTopicDeletionPermittedByAllControllers(anyString(), argThat(arg -> arg.startsWith(storeName3)));
     topicCleanupService.cleanupVeniceTopics();
 
     verify(topicManager, never()).ensureTopicIsDeletedAndBlockWithRetry(getPubSubTopic(storeName1, "_v3"));
-    verify(topicManager, never()).ensureTopicIsDeletedAndBlockWithRetry(getPubSubTopic(storeName1, "_rt"));
-    verify(topicManager, atLeastOnce()).ensureTopicIsDeletedAndBlockWithRetry(getPubSubTopic(storeName2, "_rt"));
-    verify(topicManager, atLeastOnce()).ensureTopicIsDeletedAndBlockWithRetry(getPubSubTopic(storeName3, "_rt"));
+    verify(topicManager, never()).ensureTopicIsDeletedAndBlockWithRetry(getPubSubTopic(storeName1, rtVersionPrefix));
+    verify(topicManager, atLeastOnce())
+        .ensureTopicIsDeletedAndBlockWithRetry(getPubSubTopic(storeName2, rtVersionPrefix));
+    verify(topicManager, atLeastOnce())
+        .ensureTopicIsDeletedAndBlockWithRetry(getPubSubTopic(storeName3, rtVersionPrefix));
     verify(topicCleanupServiceStats, atLeastOnce()).recordDeletableTopicsCount(2);
     verify(topicCleanupServiceStats, never()).recordTopicDeletionError();
   }

--- a/services/venice-controller/src/test/java/com/linkedin/venice/controller/server/CreateVersionTest.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/controller/server/CreateVersionTest.java
@@ -698,16 +698,20 @@ public class CreateVersionTest {
 
     String storeName = "test_store";
     String vtName = Version.composeKafkaTopic(storeName, 1);
-    String rtName = Version.composeRealTimeTopic(storeName);
+    String rtName = storeName + Version.REAL_TIME_TOPIC_SUFFIX;
     String srTopicName = Version.composeStreamReprocessingTopic(storeName, 1);
-    String separateRtName = Version.composeSeparateRealTimeTopic(storeName);
+    String separateRtName = rtName + Utils.SEPARATE_TOPIC_SUFFIX;
 
     RequestTopicForPushRequest request = new RequestTopicForPushRequest("v0", storeName, INCREMENTAL, "JOB_ID");
 
     // Test Case: PushType.INCREMENTAL with separate real-time topic enabled
+    HybridStoreConfig mockHybridConfig = mock(HybridStoreConfig.class);
+    when(mockHybridConfig.getRealTimeTopicName()).thenReturn(rtName);
     Version mockVersion1 = mock(Version.class);
+    when(mockVersion1.getHybridStoreConfig()).thenReturn(mockHybridConfig);
     when(mockVersion1.kafkaTopicName()).thenReturn(vtName);
     when(mockVersion1.isSeparateRealTimeTopicEnabled()).thenReturn(true);
+    when(mockVersion1.getStoreName()).thenReturn(storeName);
     request.setSeparateRealTimeTopicEnabled(true);
     String result1 = createVersion.determineResponseTopic(storeName, mockVersion1, request);
     assertEquals(result1, separateRtName);
@@ -716,25 +720,32 @@ public class CreateVersionTest {
     // real-time topic flag
     mockVersion1 = mock(Version.class);
     when(mockVersion1.getStoreName()).thenReturn(storeName);
+    when(mockVersion1.getHybridStoreConfig()).thenReturn(mockHybridConfig);
     when(mockVersion1.kafkaTopicName()).thenReturn(vtName);
     when(mockVersion1.isSeparateRealTimeTopicEnabled()).thenReturn(true);
+    when(mockVersion1.getStoreName()).thenReturn(storeName);
+    when(mockVersion1.isHybrid()).thenReturn(true);
     request.setSeparateRealTimeTopicEnabled(false);
     result1 = createVersion.determineResponseTopic(storeName, mockVersion1, request);
     assertEquals(result1, rtName);
 
     // Test Case: PushType.INCREMENTAL without separate real-time topic enabled
     Version mockVersion2 = mock(Version.class);
+    when(mockVersion2.getHybridStoreConfig()).thenReturn(mockHybridConfig);
     when(mockVersion2.getStoreName()).thenReturn(storeName);
     when(mockVersion2.kafkaTopicName()).thenReturn(vtName);
     when(mockVersion2.isSeparateRealTimeTopicEnabled()).thenReturn(true);
+    when(mockVersion2.isHybrid()).thenReturn(true);
     request = new RequestTopicForPushRequest("v0", storeName, INCREMENTAL, "JOB_ID");
     String result2 = createVersion.determineResponseTopic(storeName, mockVersion2, request);
     assertEquals(result2, rtName);
 
     // Test Case: PushType.STREAM
     Version mockVersion3 = mock(Version.class);
+    when(mockVersion3.getHybridStoreConfig()).thenReturn(mockHybridConfig);
     when(mockVersion3.getStoreName()).thenReturn(storeName);
     when(mockVersion3.kafkaTopicName()).thenReturn(vtName);
+    when(mockVersion3.isHybrid()).thenReturn(true);
     request = new RequestTopicForPushRequest("v0", storeName, STREAM, "JOB_ID");
     String result3 = createVersion.determineResponseTopic(storeName, mockVersion3, request);
     assertEquals(result3, rtName);
@@ -763,7 +774,7 @@ public class CreateVersionTest {
 
     // Test Case 1: Real-time topic returns NO_OP
     Version mockVersion1 = mock(Version.class);
-    String responseTopic1 = Version.composeRealTimeTopic("test_store");
+    String responseTopic1 = "test_store_v1" + Version.REAL_TIME_TOPIC_SUFFIX;
     CompressionStrategy result1 = createVersion.getCompressionStrategy(mockVersion1, responseTopic1);
     assertEquals(result1, CompressionStrategy.NO_OP);
 
@@ -893,13 +904,14 @@ public class CreateVersionTest {
     // Case 5: Parent region; Aggregate mode and there is a hybrid version
     Version mockVersion = mock(Version.class);
     when(mockVersion.getPartitionCount()).thenReturn(42);
+    when(mockVersion.getStoreName()).thenReturn(STORE_NAME);
     when(admin.isParent()).thenReturn(true);
     when(store.getHybridStoreConfig().getDataReplicationPolicy()).thenReturn(AGGREGATE);
     when(admin.getReferenceVersionForStreamingWrites(anyString(), anyString(), anyString())).thenReturn(mockVersion);
     createVersionOk.handleStreamPushType(admin, store, request, response, Lazy.of(() -> true));
     assertEquals(response.getPartitions(), 42);
     assertEquals(response.getCompressionStrategy(), CompressionStrategy.NO_OP);
-    assertEquals(response.getKafkaTopic(), Version.composeRealTimeTopic(STORE_NAME));
+    assertEquals(response.getKafkaTopic(), Utils.getRealTimeTopicName(mockVersion));
   }
 
   @Test
@@ -943,6 +955,7 @@ public class CreateVersionTest {
 
     // Case 4: Child region; Non-aggregate mode and there is a hybrid version
     Version mockVersion = mock(Version.class);
+    when(mockVersion.getStoreName()).thenReturn(STORE_NAME);
     when(mockVersion.getPartitionCount()).thenReturn(42);
     when(admin.isParent()).thenReturn(false);
     when(store.getHybridStoreConfig().getDataReplicationPolicy()).thenReturn(DataReplicationPolicy.NON_AGGREGATE);
@@ -950,7 +963,7 @@ public class CreateVersionTest {
     createVersionOk.handleStreamPushType(admin, store, request, response, Lazy.of(() -> true));
     assertEquals(response.getPartitions(), 42);
     assertEquals(response.getCompressionStrategy(), CompressionStrategy.NO_OP);
-    assertEquals(response.getKafkaTopic(), Version.composeRealTimeTopic(STORE_NAME));
+    assertEquals(response.getKafkaTopic(), Utils.getRealTimeTopicName(mockVersion));
   }
 
   @Test


### PR DESCRIPTION
<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat], [protocol]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## add versioning in RT topics
<!--
Describe
- What changes to make and why you are making these changes.
- How are you going to achieve your goal.
- Describe what testings you have done, for example, performance testing etc.

If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

This PR will make RT topic to have version numbers in their name. It will help RT topic names to be unique when older RT is not compatible with the new RT.
Largest used RT version number will be saved in store config and will remain with it in the graveyard, if store is deleted.
When a new store is created with the same name, we will use the `largestUsedRTVersionNumber` to name the first RT in the recreated store, this way this RT will have different name from the RT of the deleted store. This will also avoid the problem when store recreation fails because the RT topic of the previous store is not fully cleaned up.
`largestUsedRTVersionNumber` will be increased in two cases :
- when store is recreated
- when partition count of the RT topic is changed and `controller.enable.hybrid.store.partition.count.update` is set (see PR#1404)

RT topics of SystemStores, UserSystemStores, ParticipationStores do not follow this versioning. Regular RT topic of stores and separate RT topics follow this versioning.

RT topic name is stored in store-version hybrid configs. If it is not found there, which would be the case for the existing stores, old RT naming convention is used. This way, old stores will work with the new code. Test `testOldStoresWithHybridStoreVersioning` verifies this.


## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
updated test `testHybridStoreRepartitioning`, `testOldStoresWithHybridStoreVersioning`

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.