### PR TITLE
[server] Adding metric of pool current throttling limit and make factors easy to configure.

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/config/VeniceServerConfig.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/config/VeniceServerConfig.java
@@ -33,7 +33,7 @@ import static com.linkedin.venice.ConfigKeys.INGESTION_MEMORY_LIMIT;
 import static com.linkedin.venice.ConfigKeys.INGESTION_MEMORY_LIMIT_STORE_LIST;
 import static com.linkedin.venice.ConfigKeys.INGESTION_MLOCK_ENABLED;
 import static com.linkedin.venice.ConfigKeys.INGESTION_USE_DA_VINCI_CLIENT;
-import static com.linkedin.venice.ConfigKeys.KAFKA_FETCH_QUOTA_RECORDS_FACTORS_PER_SECOND;
+import static com.linkedin.venice.ConfigKeys.KAFKA_FETCH_THROTTLER_FACTORS_PER_SECOND;
 import static com.linkedin.venice.ConfigKeys.KAFKA_PRODUCER_METRICS;
 import static com.linkedin.venice.ConfigKeys.KEY_VALUE_PROFILING_ENABLED;
 import static com.linkedin.venice.ConfigKeys.KME_REGISTRATION_FROM_MESSAGE_HEADER_ENABLED;
@@ -67,11 +67,6 @@ import static com.linkedin.venice.ConfigKeys.SERVER_COMPUTE_FAST_AVRO_ENABLED;
 import static com.linkedin.venice.ConfigKeys.SERVER_COMPUTE_QUEUE_CAPACITY;
 import static com.linkedin.venice.ConfigKeys.SERVER_COMPUTE_THREAD_NUM;
 import static com.linkedin.venice.ConfigKeys.SERVER_CONSUMER_POOL_ALLOCATION_STRATEGY;
-import static com.linkedin.venice.ConfigKeys.SERVER_CONSUMER_POOL_RECORDS_LIMIT_FACTORS_FOR_CURRENT_VERSION_AA_WC_LEADER;
-import static com.linkedin.venice.ConfigKeys.SERVER_CONSUMER_POOL_RECORDS_LIMIT_FACTORS_FOR_CURRENT_VERSION_NON_AA_WC_LEADER;
-import static com.linkedin.venice.ConfigKeys.SERVER_CONSUMER_POOL_RECORDS_LIMIT_FACTORS_FOR_CURRENT_VERSION_SEPARATE_RT_LEADER;
-import static com.linkedin.venice.ConfigKeys.SERVER_CONSUMER_POOL_RECORDS_LIMIT_FACTORS_FOR_NON_CURRENT_VERSION_AA_WC_LEADER;
-import static com.linkedin.venice.ConfigKeys.SERVER_CONSUMER_POOL_RECORDS_LIMIT_FACTORS_FOR_NON_CURRENT_VERSION_NON_AA_WC_LEADER;
 import static com.linkedin.venice.ConfigKeys.SERVER_CONSUMER_POOL_SIZE_FOR_CURRENT_VERSION_AA_WC_LEADER;
 import static com.linkedin.venice.ConfigKeys.SERVER_CONSUMER_POOL_SIZE_FOR_CURRENT_VERSION_NON_AA_WC_LEADER;
 import static com.linkedin.venice.ConfigKeys.SERVER_CONSUMER_POOL_SIZE_FOR_CURRENT_VERSION_SEPARATE_RT_LEADER;
@@ -89,8 +84,6 @@ import static com.linkedin.venice.ConfigKeys.SERVER_DATABASE_SYNC_BYTES_INTERNAL
 import static com.linkedin.venice.ConfigKeys.SERVER_DB_READ_ONLY_FOR_BATCH_ONLY_STORE_ENABLED;
 import static com.linkedin.venice.ConfigKeys.SERVER_DEBUG_LOGGING_ENABLED;
 import static com.linkedin.venice.ConfigKeys.SERVER_DEDICATED_CONSUMER_POOL_FOR_AA_WC_LEADER_ENABLED;
-import static com.linkedin.venice.ConfigKeys.SERVER_DEDICATED_CONSUMER_POOL_RECORDS_LIMIT_FACTORS_FOR_AA_WC_LEADER;
-import static com.linkedin.venice.ConfigKeys.SERVER_DEDICATED_CONSUMER_POOL_RECORDS_LIMIT_FACTORS_FOR_SEP_RT_LEADER;
 import static com.linkedin.venice.ConfigKeys.SERVER_DEDICATED_CONSUMER_POOL_SIZE_FOR_AA_WC_LEADER;
 import static com.linkedin.venice.ConfigKeys.SERVER_DEDICATED_CONSUMER_POOL_SIZE_FOR_SEP_RT_LEADER;
 import static com.linkedin.venice.ConfigKeys.SERVER_DEDICATED_DRAINER_FOR_SORTED_INPUT_ENABLED;
@@ -172,6 +165,13 @@ import static com.linkedin.venice.ConfigKeys.SERVER_STUCK_CONSUMER_REPAIR_ENABLE
 import static com.linkedin.venice.ConfigKeys.SERVER_STUCK_CONSUMER_REPAIR_INTERVAL_SECOND;
 import static com.linkedin.venice.ConfigKeys.SERVER_STUCK_CONSUMER_REPAIR_THRESHOLD_SECOND;
 import static com.linkedin.venice.ConfigKeys.SERVER_SYSTEM_STORE_PROMOTION_TO_LEADER_REPLICA_DELAY_SECONDS;
+import static com.linkedin.venice.ConfigKeys.SERVER_THROTTLER_FACTORS_FOR_AA_WC_LEADER;
+import static com.linkedin.venice.ConfigKeys.SERVER_THROTTLER_FACTORS_FOR_CURRENT_VERSION_AA_WC_LEADER;
+import static com.linkedin.venice.ConfigKeys.SERVER_THROTTLER_FACTORS_FOR_CURRENT_VERSION_NON_AA_WC_LEADER;
+import static com.linkedin.venice.ConfigKeys.SERVER_THROTTLER_FACTORS_FOR_CURRENT_VERSION_SEPARATE_RT_LEADER;
+import static com.linkedin.venice.ConfigKeys.SERVER_THROTTLER_FACTORS_FOR_NON_CURRENT_VERSION_AA_WC_LEADER;
+import static com.linkedin.venice.ConfigKeys.SERVER_THROTTLER_FACTORS_FOR_NON_CURRENT_VERSION_NON_AA_WC_LEADER;
+import static com.linkedin.venice.ConfigKeys.SERVER_THROTTLER_FACTORS_FOR_SEP_RT_LEADER;
 import static com.linkedin.venice.ConfigKeys.SERVER_UNSUB_AFTER_BATCHPUSH;
 import static com.linkedin.venice.ConfigKeys.SERVER_ZSTD_DICT_COMPRESSION_LEVEL;
 import static com.linkedin.venice.ConfigKeys.SEVER_CALCULATE_QUOTA_USAGE_BASED_ON_PARTITIONS_ASSIGNMENT_ENABLED;
@@ -554,14 +554,14 @@ public class VeniceServerConfig extends VeniceClusterConfig {
   private final int consumerPoolSizeForNonCurrentVersionAAWCLeader;
   private final int consumerPoolSizeForCurrentVersionNonAAWCLeader;
   private final int consumerPoolSizeForNonCurrentVersionNonAAWCLeader;
-  private final List<Double> consumerPoolRecordsLimitFactorsForCurrentVersionAAWCLeader;
-  private final List<Double> consumerPoolRecordsLimitFactorsForCurrentVersionNonAAWCLeader;
-  private final List<Double> consumerPoolRecordsLimitFactorsForCurrentVersionSepRTLeader;
-  private final List<Double> consumerPoolRecordsLimitFactorsForNonCurrentVersionAAWCLeader;
-  private final List<Double> consumerPoolRecordsLimitFactorsForNonCurrentVersionNonAAWCLeader;
-  private final List<Double> kafkaFetchQuotaRecordsFactorsPerSecond;
-  private final List<Double> dedicatedConsumerPoolRecordsLimitFactorsForAAWCLeader;
-  private final List<Double> dedicatedConsumerPoolRecordsLimitFactorsForSepRTLeader;
+  private final List<Double> throttlerFactorsForCurrentVersionAAWCLeader;
+  private final List<Double> throttlerFactorsForCurrentVersionNonAAWCLeader;
+  private final List<Double> throttlerFactorsForCurrentVersionSepRTLeader;
+  private final List<Double> throttlerFactorsForNonCurrentVersionAAWCLeader;
+  private final List<Double> throttlerFactorsForNonCurrentVersionNonAAWCLeader;
+  private final List<Double> kafkaFetchThrottlerFactorsPerSecond;
+  private final List<Double> throttlerFactorsForAAWCLeader;
+  private final List<Double> throttlerFactorsForSepRTLeader;
   private final int dedicatedConsumerPoolSizeForAAWCLeader;
   private final int dedicatedConsumerPoolSizeForSepRTLeader;
   private final boolean useDaVinciSpecificExecutionStatusForError;
@@ -884,9 +884,7 @@ public class VeniceServerConfig extends VeniceClusterConfig {
     ingestionMlockEnabled = serverProperties.getBoolean(INGESTION_MLOCK_ENABLED, false);
     if (!serverProperties.getString(INGESTION_MEMORY_LIMIT_STORE_LIST, "").isEmpty()) {
       ingestionMemoryLimitStoreSet =
-          serverProperties.getList(INGESTION_MEMORY_LIMIT_STORE_LIST, Collections.emptyList())
-              .stream()
-              .collect(Collectors.toSet());
+          new HashSet<>(serverProperties.getList(INGESTION_MEMORY_LIMIT_STORE_LIST, Collections.emptyList()));
     } else {
       ingestionMemoryLimitStoreSet = Collections.emptySet();
     }
@@ -931,30 +929,24 @@ public class VeniceServerConfig extends VeniceClusterConfig {
     consumerPoolSizeForCurrentVersionAAWCLeader =
         serverProperties.getInt(SERVER_CONSUMER_POOL_SIZE_FOR_CURRENT_VERSION_AA_WC_LEADER, 10);
 
-    kafkaFetchQuotaRecordsFactorsPerSecond =
-        extractThrottleLimitFactorsFor(serverProperties, KAFKA_FETCH_QUOTA_RECORDS_FACTORS_PER_SECOND);
-    dedicatedConsumerPoolRecordsLimitFactorsForAAWCLeader = extractThrottleLimitFactorsFor(
+    kafkaFetchThrottlerFactorsPerSecond =
+        extractThrottleLimitFactorsFor(serverProperties, KAFKA_FETCH_THROTTLER_FACTORS_PER_SECOND);
+    throttlerFactorsForAAWCLeader =
+        extractThrottleLimitFactorsFor(serverProperties, SERVER_THROTTLER_FACTORS_FOR_AA_WC_LEADER);
+    throttlerFactorsForSepRTLeader =
+        extractThrottleLimitFactorsFor(serverProperties, SERVER_THROTTLER_FACTORS_FOR_SEP_RT_LEADER);
+    throttlerFactorsForCurrentVersionAAWCLeader =
+        extractThrottleLimitFactorsFor(serverProperties, SERVER_THROTTLER_FACTORS_FOR_CURRENT_VERSION_AA_WC_LEADER);
+    throttlerFactorsForCurrentVersionNonAAWCLeader =
+        extractThrottleLimitFactorsFor(serverProperties, SERVER_THROTTLER_FACTORS_FOR_CURRENT_VERSION_NON_AA_WC_LEADER);
+    throttlerFactorsForCurrentVersionSepRTLeader = extractThrottleLimitFactorsFor(
         serverProperties,
-        SERVER_DEDICATED_CONSUMER_POOL_RECORDS_LIMIT_FACTORS_FOR_AA_WC_LEADER);
-    dedicatedConsumerPoolRecordsLimitFactorsForSepRTLeader = extractThrottleLimitFactorsFor(
+        SERVER_THROTTLER_FACTORS_FOR_CURRENT_VERSION_SEPARATE_RT_LEADER);
+    throttlerFactorsForNonCurrentVersionAAWCLeader =
+        extractThrottleLimitFactorsFor(serverProperties, SERVER_THROTTLER_FACTORS_FOR_NON_CURRENT_VERSION_AA_WC_LEADER);
+    throttlerFactorsForNonCurrentVersionNonAAWCLeader = extractThrottleLimitFactorsFor(
         serverProperties,
-        SERVER_DEDICATED_CONSUMER_POOL_RECORDS_LIMIT_FACTORS_FOR_SEP_RT_LEADER);
-
-    consumerPoolRecordsLimitFactorsForCurrentVersionAAWCLeader = extractThrottleLimitFactorsFor(
-        serverProperties,
-        SERVER_CONSUMER_POOL_RECORDS_LIMIT_FACTORS_FOR_CURRENT_VERSION_AA_WC_LEADER);
-    consumerPoolRecordsLimitFactorsForCurrentVersionNonAAWCLeader = extractThrottleLimitFactorsFor(
-        serverProperties,
-        SERVER_CONSUMER_POOL_RECORDS_LIMIT_FACTORS_FOR_CURRENT_VERSION_NON_AA_WC_LEADER);
-    consumerPoolRecordsLimitFactorsForCurrentVersionSepRTLeader = extractThrottleLimitFactorsFor(
-        serverProperties,
-        SERVER_CONSUMER_POOL_RECORDS_LIMIT_FACTORS_FOR_CURRENT_VERSION_SEPARATE_RT_LEADER);
-    consumerPoolRecordsLimitFactorsForNonCurrentVersionAAWCLeader = extractThrottleLimitFactorsFor(
-        serverProperties,
-        SERVER_CONSUMER_POOL_RECORDS_LIMIT_FACTORS_FOR_NON_CURRENT_VERSION_AA_WC_LEADER);
-    consumerPoolRecordsLimitFactorsForNonCurrentVersionNonAAWCLeader = extractThrottleLimitFactorsFor(
-        serverProperties,
-        SERVER_CONSUMER_POOL_RECORDS_LIMIT_FACTORS_FOR_NON_CURRENT_VERSION_NON_AA_WC_LEADER);
+        SERVER_THROTTLER_FACTORS_FOR_NON_CURRENT_VERSION_NON_AA_WC_LEADER);
 
     consumerPoolSizeForCurrentVersionSepRTLeader =
         serverProperties.getInt(SERVER_CONSUMER_POOL_SIZE_FOR_CURRENT_VERSION_SEPARATE_RT_LEADER, 10);
@@ -1636,36 +1628,36 @@ public class VeniceServerConfig extends VeniceClusterConfig {
     return batchReportEOIPEnabled;
   }
 
-  public List<Double> getConsumerPoolRecordsLimitFactorsForCurrentVersionAAWCLeader() {
-    return consumerPoolRecordsLimitFactorsForCurrentVersionAAWCLeader;
+  public List<Double> getThrottlerFactorsForCurrentVersionAAWCLeader() {
+    return throttlerFactorsForCurrentVersionAAWCLeader;
   }
 
-  public List<Double> getConsumerPoolRecordsLimitFactorsForCurrentVersionNonAAWCLeader() {
-    return consumerPoolRecordsLimitFactorsForCurrentVersionNonAAWCLeader;
+  public List<Double> getThrottlerFactorsForCurrentVersionNonAAWCLeader() {
+    return throttlerFactorsForCurrentVersionNonAAWCLeader;
   }
 
-  public List<Double> getConsumerPoolRecordsLimitFactorsForCurrentVersionSepRTLeader() {
-    return consumerPoolRecordsLimitFactorsForCurrentVersionSepRTLeader;
+  public List<Double> getThrottlerFactorsForCurrentVersionSepRTLeader() {
+    return throttlerFactorsForCurrentVersionSepRTLeader;
   }
 
-  public List<Double> getConsumerPoolRecordsLimitFactorsForNonCurrentVersionAAWCLeader() {
-    return consumerPoolRecordsLimitFactorsForNonCurrentVersionAAWCLeader;
+  public List<Double> getThrottlerFactorsForNonCurrentVersionAAWCLeader() {
+    return throttlerFactorsForNonCurrentVersionAAWCLeader;
   }
 
-  public List<Double> getConsumerPoolRecordsLimitFactorsForNonCurrentVersionNonAAWCLeader() {
-    return consumerPoolRecordsLimitFactorsForNonCurrentVersionNonAAWCLeader;
+  public List<Double> getThrottlerFactorsForNonCurrentVersionNonAAWCLeader() {
+    return throttlerFactorsForNonCurrentVersionNonAAWCLeader;
   }
 
-  public List<Double> getKafkaFetchQuotaRecordsFactorsPerSecond() {
-    return kafkaFetchQuotaRecordsFactorsPerSecond;
+  public List<Double> getKafkaFetchThrottlerFactorsPerSecond() {
+    return kafkaFetchThrottlerFactorsPerSecond;
   }
 
-  public List<Double> getDedicatedConsumerPoolRecordsLimitFactorsForAAWCLeader() {
-    return dedicatedConsumerPoolRecordsLimitFactorsForAAWCLeader;
+  public List<Double> getThrottlerFactorsForAAWCLeader() {
+    return throttlerFactorsForAAWCLeader;
   }
 
-  public List<Double> getDedicatedConsumerPoolRecordsLimitFactorsForSepRTLeader() {
-    return dedicatedConsumerPoolRecordsLimitFactorsForSepRTLeader;
+  public List<Double> getThrottlerFactorsForSepRTLeader() {
+    return throttlerFactorsForSepRTLeader;
   }
 
   public enum IncrementalPushStatusWriteMode {

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/IngestionThrottler.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/IngestionThrottler.java
@@ -71,7 +71,7 @@ public class IngestionThrottler implements Closeable {
       globalRecordAdaptiveIngestionThrottler = new VeniceAdaptiveIngestionThrottler(
           serverConfig.getAdaptiveThrottlerSignalIdleThreshold(),
           serverConfig.getKafkaFetchQuotaRecordPerSecond(),
-          serverConfig.getKafkaFetchQuotaRecordsFactorsPerSecond(),
+          serverConfig.getKafkaFetchThrottlerFactorsPerSecond(),
           serverConfig.getKafkaFetchQuotaTimeWindow(),
           "kafka_consumption_records_count");
       globalRecordAdaptiveIngestionThrottler
@@ -81,7 +81,7 @@ public class IngestionThrottler implements Closeable {
       globalBandwidthAdaptiveIngestionThrottler = new VeniceAdaptiveIngestionThrottler(
           serverConfig.getAdaptiveThrottlerSignalIdleThreshold(),
           serverConfig.getKafkaFetchQuotaBytesPerSecond(),
-          serverConfig.getKafkaFetchQuotaRecordsFactorsPerSecond(),
+          serverConfig.getKafkaFetchThrottlerFactorsPerSecond(),
           serverConfig.getKafkaFetchQuotaTimeWindow(),
           "kafka_consumption_bandwidth");
       globalBandwidthAdaptiveIngestionThrottler

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/IngestionThrottler.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/IngestionThrottler.java
@@ -71,6 +71,7 @@ public class IngestionThrottler implements Closeable {
       globalRecordAdaptiveIngestionThrottler = new VeniceAdaptiveIngestionThrottler(
           serverConfig.getAdaptiveThrottlerSignalIdleThreshold(),
           serverConfig.getKafkaFetchQuotaRecordPerSecond(),
+          serverConfig.getKafkaFetchQuotaRecordsFactorsPerSecond(),
           serverConfig.getKafkaFetchQuotaTimeWindow(),
           "kafka_consumption_records_count");
       globalRecordAdaptiveIngestionThrottler
@@ -80,6 +81,7 @@ public class IngestionThrottler implements Closeable {
       globalBandwidthAdaptiveIngestionThrottler = new VeniceAdaptiveIngestionThrottler(
           serverConfig.getAdaptiveThrottlerSignalIdleThreshold(),
           serverConfig.getKafkaFetchQuotaBytesPerSecond(),
+          serverConfig.getKafkaFetchQuotaRecordsFactorsPerSecond(),
           serverConfig.getKafkaFetchQuotaTimeWindow(),
           "kafka_consumption_bandwidth");
       globalBandwidthAdaptiveIngestionThrottler

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/VeniceAdaptiveIngestionThrottler.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/VeniceAdaptiveIngestionThrottler.java
@@ -14,29 +14,36 @@ public class VeniceAdaptiveIngestionThrottler extends EventThrottler {
   private final List<BooleanSupplier> limiterSuppliers = new ArrayList<>();
   private final List<BooleanSupplier> boosterSuppliers = new ArrayList<>();
 
-  private final static int MAX_THROTTLERS = 7;
-  private final List<EventThrottler> eventThrottlers = new ArrayList<>(MAX_THROTTLERS);
+  private int throttlerNum;
+  private final List<EventThrottler> eventThrottlers = new ArrayList<>();
   private final int signalIdleThreshold;
   private int signalIdleCount = 0;
-  private int currentThrottlerIndex = MAX_THROTTLERS / 2;
+  private int currentThrottlerIndex = -1;
 
   public VeniceAdaptiveIngestionThrottler(
       int signalIdleThreshold,
       long quotaPerSecond,
+      List<Double> factors,
       long timeWindow,
       String throttlerName) {
     this.signalIdleThreshold = signalIdleThreshold;
-    double factor = 0.4;
     DecimalFormat decimalFormat = new DecimalFormat("0.0");
-    for (int i = 0; i < MAX_THROTTLERS; i++) {
+    throttlerNum = factors.size();
+    for (int i = 0; i < factors.size(); i++) {
+      Double factor = factors.get(i);
+      if (factor == 1.0D) {
+        currentThrottlerIndex = i;
+      }
       EventThrottler eventThrottler = new EventThrottler(
           (long) (quotaPerSecond * factor),
           timeWindow,
-          throttlerName + decimalFormat.format(factor),
+          throttlerName + decimalFormat.format(factors.get(i)),
           false,
           EventThrottler.BLOCK_STRATEGY);
       eventThrottlers.add(eventThrottler);
-      factor = factor + 0.2;
+    }
+    if (currentThrottlerIndex == -1) {
+      throw new IllegalArgumentException("No throttler factor of 1.0D found");
     }
   }
 
@@ -79,7 +86,7 @@ public class VeniceAdaptiveIngestionThrottler extends EventThrottler {
       if (supplier.getAsBoolean()) {
         isSignalIdle = false;
         signalIdleCount = 0;
-        if (currentThrottlerIndex < MAX_THROTTLERS - 1) {
+        if (currentThrottlerIndex < throttlerNum - 1) {
           currentThrottlerIndex++;
         }
         LOGGER.info(
@@ -92,7 +99,7 @@ public class VeniceAdaptiveIngestionThrottler extends EventThrottler {
       signalIdleCount += 1;
       LOGGER.info("No active signal found, increasing idle count to {}/{}", signalIdleCount, signalIdleThreshold);
       if (signalIdleCount == signalIdleThreshold) {
-        if (currentThrottlerIndex < MAX_THROTTLERS - 1) {
+        if (currentThrottlerIndex < throttlerNum - 1) {
           currentThrottlerIndex++;
         }
         LOGGER.info(
@@ -102,6 +109,10 @@ public class VeniceAdaptiveIngestionThrottler extends EventThrottler {
         signalIdleCount = 0;
       }
     }
+  }
+
+  public long getCurrentThrottlerRate() {
+    return eventThrottlers.get(currentThrottlerIndex).getMaxRatePerSecond();
   }
 
   // TEST

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/VeniceAdaptiveIngestionThrottler.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/VeniceAdaptiveIngestionThrottler.java
@@ -29,7 +29,7 @@ public class VeniceAdaptiveIngestionThrottler extends EventThrottler {
     this.signalIdleThreshold = signalIdleThreshold;
     DecimalFormat decimalFormat = new DecimalFormat("0.0");
     throttlerNum = factors.size();
-    for (int i = 0; i < factors.size(); i++) {
+    for (int i = 0; i < throttlerNum; i++) {
       Double factor = factors.get(i);
       if (factor == 1.0D) {
         currentThrottlerIndex = i;

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/VeniceAdaptiveIngestionThrottler.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/VeniceAdaptiveIngestionThrottler.java
@@ -30,20 +30,23 @@ public class VeniceAdaptiveIngestionThrottler extends EventThrottler {
     DecimalFormat decimalFormat = new DecimalFormat("0.0");
     throttlerNum = factors.size();
     for (int i = 0; i < throttlerNum; i++) {
-      Double factor = factors.get(i);
-      if (factor == 1.0D) {
+      if (factors.get(i) == 1.0D) {
         currentThrottlerIndex = i;
+        break;
       }
-      EventThrottler eventThrottler = new EventThrottler(
-          (long) (quotaPerSecond * factor),
-          timeWindow,
-          throttlerName + decimalFormat.format(factors.get(i)),
-          false,
-          EventThrottler.BLOCK_STRATEGY);
-      eventThrottlers.add(eventThrottler);
     }
     if (currentThrottlerIndex == -1) {
       throw new IllegalArgumentException("No throttler factor of 1.0D found");
+    }
+
+    for (Double factor: factors) {
+      EventThrottler eventThrottler = new EventThrottler(
+          (long) (quotaPerSecond * factor),
+          timeWindow,
+          throttlerName + decimalFormat.format(factor),
+          false,
+          EventThrottler.BLOCK_STRATEGY);
+      eventThrottlers.add(eventThrottler);
     }
   }
 

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/AdaptiveThrottlingServiceStats.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/AdaptiveThrottlingServiceStats.java
@@ -1,0 +1,31 @@
+package com.linkedin.davinci.stats;
+
+import com.linkedin.davinci.kafka.consumer.VeniceAdaptiveIngestionThrottler;
+import com.linkedin.venice.stats.AbstractVeniceStats;
+import io.tehuti.metrics.MetricsRepository;
+import io.tehuti.metrics.Sensor;
+import io.tehuti.metrics.stats.Gauge;
+import java.util.HashMap;
+import java.util.Map;
+
+
+public class AdaptiveThrottlingServiceStats extends AbstractVeniceStats {
+  private static final String ADAPTIVE_THROTTLING_SERVICE_SUFFIX = "-AdaptiveThrottlingService";
+  private final Map<String, Sensor> sensors = new HashMap<>();
+
+  public AdaptiveThrottlingServiceStats(MetricsRepository metricsRepository) {
+    super(metricsRepository, ADAPTIVE_THROTTLING_SERVICE_SUFFIX);
+  }
+
+  public void registerSensorForThrottler(VeniceAdaptiveIngestionThrottler throttler) {
+    String throttlerName = throttler.getThrottlerName();
+    sensors.put(throttlerName, registerSensorIfAbsent(throttlerName, new Gauge()));
+  }
+
+  public void recordThrottleLimitForThrottler(VeniceAdaptiveIngestionThrottler throttler) {
+    Sensor sensor = sensors.get(throttler.getThrottlerName());
+    if (sensor != null) {
+      sensor.record(throttler.getCurrentThrottlerRate());
+    }
+  }
+}

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/config/VeniceServerConfigTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/config/VeniceServerConfigTest.java
@@ -8,15 +8,15 @@ import static com.linkedin.venice.ConfigKeys.DATA_BASE_PATH;
 import static com.linkedin.venice.ConfigKeys.INGESTION_MEMORY_LIMIT;
 import static com.linkedin.venice.ConfigKeys.INGESTION_USE_DA_VINCI_CLIENT;
 import static com.linkedin.venice.ConfigKeys.KAFKA_BOOTSTRAP_SERVERS;
-import static com.linkedin.venice.ConfigKeys.KAFKA_FETCH_QUOTA_RECORDS_FACTORS_PER_SECOND;
-import static com.linkedin.venice.ConfigKeys.SERVER_CONSUMER_POOL_RECORDS_LIMIT_FACTORS_FOR_CURRENT_VERSION_AA_WC_LEADER;
-import static com.linkedin.venice.ConfigKeys.SERVER_CONSUMER_POOL_RECORDS_LIMIT_FACTORS_FOR_CURRENT_VERSION_NON_AA_WC_LEADER;
-import static com.linkedin.venice.ConfigKeys.SERVER_CONSUMER_POOL_RECORDS_LIMIT_FACTORS_FOR_NON_CURRENT_VERSION_AA_WC_LEADER;
-import static com.linkedin.venice.ConfigKeys.SERVER_CONSUMER_POOL_RECORDS_LIMIT_FACTORS_FOR_NON_CURRENT_VERSION_NON_AA_WC_LEADER;
-import static com.linkedin.venice.ConfigKeys.SERVER_DEDICATED_CONSUMER_POOL_RECORDS_LIMIT_FACTORS_FOR_AA_WC_LEADER;
-import static com.linkedin.venice.ConfigKeys.SERVER_DEDICATED_CONSUMER_POOL_RECORDS_LIMIT_FACTORS_FOR_SEP_RT_LEADER;
+import static com.linkedin.venice.ConfigKeys.KAFKA_FETCH_THROTTLER_FACTORS_PER_SECOND;
 import static com.linkedin.venice.ConfigKeys.SERVER_FORKED_PROCESS_JVM_ARGUMENT_LIST;
 import static com.linkedin.venice.ConfigKeys.SERVER_INGESTION_MODE;
+import static com.linkedin.venice.ConfigKeys.SERVER_THROTTLER_FACTORS_FOR_AA_WC_LEADER;
+import static com.linkedin.venice.ConfigKeys.SERVER_THROTTLER_FACTORS_FOR_CURRENT_VERSION_AA_WC_LEADER;
+import static com.linkedin.venice.ConfigKeys.SERVER_THROTTLER_FACTORS_FOR_CURRENT_VERSION_NON_AA_WC_LEADER;
+import static com.linkedin.venice.ConfigKeys.SERVER_THROTTLER_FACTORS_FOR_NON_CURRENT_VERSION_AA_WC_LEADER;
+import static com.linkedin.venice.ConfigKeys.SERVER_THROTTLER_FACTORS_FOR_NON_CURRENT_VERSION_NON_AA_WC_LEADER;
+import static com.linkedin.venice.ConfigKeys.SERVER_THROTTLER_FACTORS_FOR_SEP_RT_LEADER;
 import static com.linkedin.venice.ConfigKeys.ZOOKEEPER_ADDRESS;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
@@ -65,29 +65,23 @@ public class VeniceServerConfigTest {
 
     Map<String, Function<VeniceServerConfig, List<Double>>> configMap = new HashMap<>();
 
-    configMap.put(
-        KAFKA_FETCH_QUOTA_RECORDS_FACTORS_PER_SECOND,
-        VeniceServerConfig::getKafkaFetchQuotaRecordsFactorsPerSecond);
+    configMap.put(KAFKA_FETCH_THROTTLER_FACTORS_PER_SECOND, VeniceServerConfig::getKafkaFetchThrottlerFactorsPerSecond);
+
+    configMap.put(SERVER_THROTTLER_FACTORS_FOR_AA_WC_LEADER, VeniceServerConfig::getThrottlerFactorsForAAWCLeader);
+    configMap.put(SERVER_THROTTLER_FACTORS_FOR_SEP_RT_LEADER, VeniceServerConfig::getThrottlerFactorsForSepRTLeader);
 
     configMap.put(
-        SERVER_DEDICATED_CONSUMER_POOL_RECORDS_LIMIT_FACTORS_FOR_AA_WC_LEADER,
-        VeniceServerConfig::getDedicatedConsumerPoolRecordsLimitFactorsForAAWCLeader);
+        SERVER_THROTTLER_FACTORS_FOR_CURRENT_VERSION_AA_WC_LEADER,
+        VeniceServerConfig::getThrottlerFactorsForCurrentVersionAAWCLeader);
     configMap.put(
-        SERVER_DEDICATED_CONSUMER_POOL_RECORDS_LIMIT_FACTORS_FOR_SEP_RT_LEADER,
-        VeniceServerConfig::getDedicatedConsumerPoolRecordsLimitFactorsForSepRTLeader);
-
+        SERVER_THROTTLER_FACTORS_FOR_CURRENT_VERSION_NON_AA_WC_LEADER,
+        VeniceServerConfig::getThrottlerFactorsForCurrentVersionNonAAWCLeader);
     configMap.put(
-        SERVER_CONSUMER_POOL_RECORDS_LIMIT_FACTORS_FOR_CURRENT_VERSION_AA_WC_LEADER,
-        VeniceServerConfig::getConsumerPoolRecordsLimitFactorsForCurrentVersionAAWCLeader);
+        SERVER_THROTTLER_FACTORS_FOR_NON_CURRENT_VERSION_AA_WC_LEADER,
+        VeniceServerConfig::getThrottlerFactorsForNonCurrentVersionAAWCLeader);
     configMap.put(
-        SERVER_CONSUMER_POOL_RECORDS_LIMIT_FACTORS_FOR_CURRENT_VERSION_NON_AA_WC_LEADER,
-        VeniceServerConfig::getConsumerPoolRecordsLimitFactorsForCurrentVersionNonAAWCLeader);
-    configMap.put(
-        SERVER_CONSUMER_POOL_RECORDS_LIMIT_FACTORS_FOR_NON_CURRENT_VERSION_AA_WC_LEADER,
-        VeniceServerConfig::getConsumerPoolRecordsLimitFactorsForNonCurrentVersionAAWCLeader);
-    configMap.put(
-        SERVER_CONSUMER_POOL_RECORDS_LIMIT_FACTORS_FOR_NON_CURRENT_VERSION_NON_AA_WC_LEADER,
-        VeniceServerConfig::getConsumerPoolRecordsLimitFactorsForNonCurrentVersionNonAAWCLeader);
+        SERVER_THROTTLER_FACTORS_FOR_NON_CURRENT_VERSION_NON_AA_WC_LEADER,
+        VeniceServerConfig::getThrottlerFactorsForNonCurrentVersionNonAAWCLeader);
 
     // Looping through all the factors config keys and checking if the values are same as default values
     for (Map.Entry<String, Function<VeniceServerConfig, List<Double>>> entry: configMap.entrySet()) {

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/config/VeniceServerConfigTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/config/VeniceServerConfigTest.java
@@ -60,7 +60,6 @@ public class VeniceServerConfigTest {
   }
 
   @Test
-
   public void testConfig() {
     Properties props = populatedBasicProperties();
 

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/config/VeniceServerConfigTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/config/VeniceServerConfigTest.java
@@ -8,6 +8,13 @@ import static com.linkedin.venice.ConfigKeys.DATA_BASE_PATH;
 import static com.linkedin.venice.ConfigKeys.INGESTION_MEMORY_LIMIT;
 import static com.linkedin.venice.ConfigKeys.INGESTION_USE_DA_VINCI_CLIENT;
 import static com.linkedin.venice.ConfigKeys.KAFKA_BOOTSTRAP_SERVERS;
+import static com.linkedin.venice.ConfigKeys.KAFKA_FETCH_QUOTA_RECORDS_FACTORS_PER_SECOND;
+import static com.linkedin.venice.ConfigKeys.SERVER_CONSUMER_POOL_RECORDS_LIMIT_FACTORS_FOR_CURRENT_VERSION_AA_WC_LEADER;
+import static com.linkedin.venice.ConfigKeys.SERVER_CONSUMER_POOL_RECORDS_LIMIT_FACTORS_FOR_CURRENT_VERSION_NON_AA_WC_LEADER;
+import static com.linkedin.venice.ConfigKeys.SERVER_CONSUMER_POOL_RECORDS_LIMIT_FACTORS_FOR_NON_CURRENT_VERSION_AA_WC_LEADER;
+import static com.linkedin.venice.ConfigKeys.SERVER_CONSUMER_POOL_RECORDS_LIMIT_FACTORS_FOR_NON_CURRENT_VERSION_NON_AA_WC_LEADER;
+import static com.linkedin.venice.ConfigKeys.SERVER_DEDICATED_CONSUMER_POOL_RECORDS_LIMIT_FACTORS_FOR_AA_WC_LEADER;
+import static com.linkedin.venice.ConfigKeys.SERVER_DEDICATED_CONSUMER_POOL_RECORDS_LIMIT_FACTORS_FOR_SEP_RT_LEADER;
 import static com.linkedin.venice.ConfigKeys.SERVER_FORKED_PROCESS_JVM_ARGUMENT_LIST;
 import static com.linkedin.venice.ConfigKeys.SERVER_INGESTION_MODE;
 import static com.linkedin.venice.ConfigKeys.ZOOKEEPER_ADDRESS;
@@ -18,8 +25,13 @@ import static org.testng.Assert.expectThrows;
 import com.linkedin.venice.exceptions.VeniceException;
 import com.linkedin.venice.meta.IngestionMode;
 import com.linkedin.venice.utils.VeniceProperties;
+import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Properties;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 import org.testng.annotations.Test;
 
 
@@ -45,6 +57,57 @@ public class VeniceServerConfigTest {
     assertEquals(jvmArgs.size(), 2);
     assertEquals(jvmArgs.get(0), "-Xms256M");
     assertEquals(jvmArgs.get(1), "-Xmx256G");
+  }
+
+  @Test
+
+  public void testConfig() {
+    Properties props = populatedBasicProperties();
+
+    Map<String, Function<VeniceServerConfig, List<Double>>> configMap = new HashMap<>();
+
+    configMap.put(
+        KAFKA_FETCH_QUOTA_RECORDS_FACTORS_PER_SECOND,
+        VeniceServerConfig::getKafkaFetchQuotaRecordsFactorsPerSecond);
+
+    configMap.put(
+        SERVER_DEDICATED_CONSUMER_POOL_RECORDS_LIMIT_FACTORS_FOR_AA_WC_LEADER,
+        VeniceServerConfig::getDedicatedConsumerPoolRecordsLimitFactorsForAAWCLeader);
+    configMap.put(
+        SERVER_DEDICATED_CONSUMER_POOL_RECORDS_LIMIT_FACTORS_FOR_SEP_RT_LEADER,
+        VeniceServerConfig::getDedicatedConsumerPoolRecordsLimitFactorsForSepRTLeader);
+
+    configMap.put(
+        SERVER_CONSUMER_POOL_RECORDS_LIMIT_FACTORS_FOR_CURRENT_VERSION_AA_WC_LEADER,
+        VeniceServerConfig::getConsumerPoolRecordsLimitFactorsForCurrentVersionAAWCLeader);
+    configMap.put(
+        SERVER_CONSUMER_POOL_RECORDS_LIMIT_FACTORS_FOR_CURRENT_VERSION_NON_AA_WC_LEADER,
+        VeniceServerConfig::getConsumerPoolRecordsLimitFactorsForCurrentVersionNonAAWCLeader);
+    configMap.put(
+        SERVER_CONSUMER_POOL_RECORDS_LIMIT_FACTORS_FOR_NON_CURRENT_VERSION_AA_WC_LEADER,
+        VeniceServerConfig::getConsumerPoolRecordsLimitFactorsForNonCurrentVersionAAWCLeader);
+    configMap.put(
+        SERVER_CONSUMER_POOL_RECORDS_LIMIT_FACTORS_FOR_NON_CURRENT_VERSION_NON_AA_WC_LEADER,
+        VeniceServerConfig::getConsumerPoolRecordsLimitFactorsForNonCurrentVersionNonAAWCLeader);
+
+    // Looping through all the factors config keys and checking if the values are same as default values
+    for (Map.Entry<String, Function<VeniceServerConfig, List<Double>>> entry: configMap.entrySet()) {
+      VeniceServerConfig config = new VeniceServerConfig(new VeniceProperties(props));
+      List<Double> consumerPoolRecordsLimitFactors = entry.getValue().apply(config);
+      assertEquals(consumerPoolRecordsLimitFactors.size(), config.getDefaultConsumerPoolLimitFactorsList().size());
+      assertEquals(
+          consumerPoolRecordsLimitFactors.toArray(),
+          config.getDefaultConsumerPoolLimitFactorsList().toArray());
+      Double[] factors = new Double[] { 0.6D, 0.8D, 1.0D, 1.2D };
+      List<Double> factorsList = Arrays.asList(factors);
+      // Convert list of double to string with comma separated
+      String factorsListStr = factorsList.stream().map(String::valueOf).collect(Collectors.joining(", "));
+      props.put(entry.getKey(), factorsListStr);
+      config = new VeniceServerConfig(new VeniceProperties(props));
+      consumerPoolRecordsLimitFactors = entry.getValue().apply(config);
+      assertEquals(consumerPoolRecordsLimitFactors.size(), 4);
+      assertEquals(consumerPoolRecordsLimitFactors.toArray(), factors);
+    }
   }
 
   @Test

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/AdaptiveThrottlerSingalServiceTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/AdaptiveThrottlerSingalServiceTest.java
@@ -1,6 +1,9 @@
 package com.linkedin.davinci.kafka.consumer;
 
 import static com.linkedin.davinci.kafka.consumer.AdaptiveThrottlerSignalService.SINGLE_GET_LATENCY_P99_METRIC_NAME;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.when;
@@ -10,6 +13,7 @@ import com.linkedin.davinci.stats.ingestion.heartbeat.AggregatedHeartbeatLagEntr
 import com.linkedin.davinci.stats.ingestion.heartbeat.HeartbeatMonitoringService;
 import io.tehuti.Metric;
 import io.tehuti.metrics.MetricsRepository;
+import io.tehuti.metrics.Sensor;
 import java.util.concurrent.TimeUnit;
 import org.mockito.Mockito;
 import org.testng.Assert;
@@ -58,6 +62,8 @@ public class AdaptiveThrottlerSingalServiceTest {
   @Test
   public void testRegisterThrottler() {
     MetricsRepository metricsRepository = mock(MetricsRepository.class);
+    Sensor sensor = mock(Sensor.class);
+    doReturn(sensor).when(metricsRepository).sensor(anyString(), any());
     HeartbeatMonitoringService heartbeatMonitoringService = mock(HeartbeatMonitoringService.class);
     VeniceServerConfig veniceServerConfig = mock(VeniceServerConfig.class);
     when(veniceServerConfig.getAdaptiveThrottlerSingleGetLatencyThreshold()).thenReturn(10d);

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/VeniceAdaptiveIngestionThrottlerTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/VeniceAdaptiveIngestionThrottlerTest.java
@@ -1,5 +1,7 @@
 package com.linkedin.davinci.kafka.consumer;
 
+import java.util.Arrays;
+import java.util.List;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
@@ -7,8 +9,9 @@ import org.testng.annotations.Test;
 public class VeniceAdaptiveIngestionThrottlerTest {
   @Test
   public void testAdaptiveIngestionThrottler() {
+    List<Double> factors = Arrays.asList(0.4D, 0.6D, 0.8D, 1.0D, 1.2D, 1.4D);
     VeniceAdaptiveIngestionThrottler adaptiveIngestionThrottler =
-        new VeniceAdaptiveIngestionThrottler(10, 100, 10, "test");
+        new VeniceAdaptiveIngestionThrottler(10, 100, factors, 10, "test");
     adaptiveIngestionThrottler.registerLimiterSignal(() -> true);
     adaptiveIngestionThrottler.checkSignalAndAdjustThrottler();
     Assert.assertEquals(adaptiveIngestionThrottler.getCurrentThrottlerIndex(), 2);
@@ -18,12 +21,12 @@ public class VeniceAdaptiveIngestionThrottlerTest {
     Assert.assertEquals(adaptiveIngestionThrottler.getCurrentThrottlerIndex(), 0);
     adaptiveIngestionThrottler.checkSignalAndAdjustThrottler();
     Assert.assertEquals(adaptiveIngestionThrottler.getCurrentThrottlerIndex(), 0);
-    adaptiveIngestionThrottler = new VeniceAdaptiveIngestionThrottler(10, 100, 10, "test");
+    adaptiveIngestionThrottler = new VeniceAdaptiveIngestionThrottler(10, 100, factors, 10, "test");
     adaptiveIngestionThrottler.registerBoosterSignal(() -> true);
     adaptiveIngestionThrottler.checkSignalAndAdjustThrottler();
     Assert.assertEquals(adaptiveIngestionThrottler.getCurrentThrottlerIndex(), 4);
 
-    adaptiveIngestionThrottler = new VeniceAdaptiveIngestionThrottler(3, 100, 10, "test");
+    adaptiveIngestionThrottler = new VeniceAdaptiveIngestionThrottler(3, 100, factors, 10, "test");
 
     adaptiveIngestionThrottler.checkSignalAndAdjustThrottler();
     Assert.assertEquals(adaptiveIngestionThrottler.getCurrentThrottlerIndex(), 3);

--- a/internal/venice-common/src/main/java/com/linkedin/venice/ConfigKeys.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/ConfigKeys.java
@@ -94,8 +94,6 @@ public class ConfigKeys {
    */
   public static final String KAFKA_FETCH_QUOTA_RECORDS_PER_SECOND = "kafka.fetch.quota.records.per.second";
 
-  public static final String KAFKA_FETCH_QUOTA_RECORDS_FACTORS_PER_SECOND =
-      "kafka.fetch.quota.records.factors.per.second";
   /**
    * How many records that one server could consume from Kafka at most in one second from the specified regions.
    * If the consume rate reached this quota, the consumption thread will be blocked until there is the available quota.
@@ -2274,12 +2272,6 @@ public class ConfigKeys {
   public static final String SERVER_DEDICATED_CONSUMER_POOL_SIZE_FOR_SEP_RT_LEADER =
       "server.dedicated.consumer.pool.size.for.sep.rt.leader";
 
-  public static final String SERVER_DEDICATED_CONSUMER_POOL_RECORDS_LIMIT_FACTORS_FOR_AA_WC_LEADER =
-      "server_dedicated_consumer_pool_records_limit_factors_for_aa_wc_leader";
-
-  public static final String SERVER_DEDICATED_CONSUMER_POOL_RECORDS_LIMIT_FACTORS_FOR_SEP_RT_LEADER =
-      "server.dedicated.consumer.pool.records.limit.factors.for.sep.rt.leader";
-
   /**
    * Consumer Pool allocation strategy to rely on pool size to prioritize specific traffic. There will be 3 different
    * types strategy supported decided by #ConsumerPoolStrategyType.
@@ -2317,16 +2309,26 @@ public class ConfigKeys {
    */
   public static final String SERVER_CONSUMER_POOL_SIZE_FOR_NON_CURRENT_VERSION_NON_AA_WC_LEADER =
       "server.consumer.pool.size.for.non.current.version.non.aa.wc.leader";
-  public static final String SERVER_CONSUMER_POOL_RECORDS_LIMIT_FACTORS_FOR_CURRENT_VERSION_AA_WC_LEADER =
-      "server.consumer.pool.records.limit.factors.for.current.version.aa.wc.leader";
-  public static final String SERVER_CONSUMER_POOL_RECORDS_LIMIT_FACTORS_FOR_CURRENT_VERSION_SEPARATE_RT_LEADER =
-      "server.consumer.pool.records.limit.factors.for.current.version.separate.rt.leader";
-  public static final String SERVER_CONSUMER_POOL_RECORDS_LIMIT_FACTORS_FOR_NON_CURRENT_VERSION_AA_WC_LEADER =
-      "server.consumer.pool.records.limit.factors.for.non.current.version.aa.wc.leader";
-  public static final String SERVER_CONSUMER_POOL_RECORDS_LIMIT_FACTORS_FOR_CURRENT_VERSION_NON_AA_WC_LEADER =
-      "server.consumer.pool.records.limit.factors.for.current.version.non.aa.wc.leader";
-  public static final String SERVER_CONSUMER_POOL_RECORDS_LIMIT_FACTORS_FOR_NON_CURRENT_VERSION_NON_AA_WC_LEADER =
-      "server.consumer.pool.records.limit.factors.for.non.current.version.non.aa.wc.leader";
+
+  /**
+   * A string of comma separated number to specify different factors multiplying basic throttling limit
+   * KAFKA_FETCH_QUOTA_RECORDS_PER_SECOND, the factors will be comma separated numbers with ascending order,
+   * but we should include 1.0 as basic setting. For example, a string as: "0.8, 1.0, 1.2" means the basic setting is
+   * 1.0, and the max setting is 1.2 * basic throttling limit.
+   */
+  public static final String KAFKA_FETCH_THROTTLER_FACTORS_PER_SECOND = "kafka.fetch.throttler.factors.per.second";
+  public static final String SERVER_THROTTLER_FACTORS_FOR_AA_WC_LEADER = "server_throttler_factors_for_aa_wc_leader";
+  public static final String SERVER_THROTTLER_FACTORS_FOR_SEP_RT_LEADER = "server.throttler.factors.for.sep.rt.leader";
+  public static final String SERVER_THROTTLER_FACTORS_FOR_CURRENT_VERSION_AA_WC_LEADER =
+      "server.throttler.factors.for.current.version.aa.wc.leader";
+  public static final String SERVER_THROTTLER_FACTORS_FOR_CURRENT_VERSION_SEPARATE_RT_LEADER =
+      "server.throttler.factors.for.current.version.separate.rt.leader";
+  public static final String SERVER_THROTTLER_FACTORS_FOR_NON_CURRENT_VERSION_AA_WC_LEADER =
+      "server.throttler.factors.for.non.current.version.aa.wc.leader";
+  public static final String SERVER_THROTTLER_FACTORS_FOR_CURRENT_VERSION_NON_AA_WC_LEADER =
+      "server.throttler.factors.for.current.version.non.aa.wc.leader";
+  public static final String SERVER_THROTTLER_FACTORS_FOR_NON_CURRENT_VERSION_NON_AA_WC_LEADER =
+      "server.throttler.factors.for.non.current.version.non.aa.wc.leader";
 
   /**
    * Whether to enable record-level metrics when bootstrapping current version.

--- a/internal/venice-common/src/main/java/com/linkedin/venice/ConfigKeys.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/ConfigKeys.java
@@ -94,6 +94,8 @@ public class ConfigKeys {
    */
   public static final String KAFKA_FETCH_QUOTA_RECORDS_PER_SECOND = "kafka.fetch.quota.records.per.second";
 
+  public static final String KAFKA_FETCH_QUOTA_RECORDS_FACTORS_PER_SECOND =
+      "kafka.fetch.quota.records.factors.per.second";
   /**
    * How many records that one server could consume from Kafka at most in one second from the specified regions.
    * If the consume rate reached this quota, the consumption thread will be blocked until there is the available quota.
@@ -2272,6 +2274,12 @@ public class ConfigKeys {
   public static final String SERVER_DEDICATED_CONSUMER_POOL_SIZE_FOR_SEP_RT_LEADER =
       "server.dedicated.consumer.pool.size.for.sep.rt.leader";
 
+  public static final String SERVER_DEDICATED_CONSUMER_POOL_RECORDS_LIMIT_FACTORS_FOR_AA_WC_LEADER =
+      "server_dedicated_consumer_pool_records_limit_factors_for_aa_wc_leader";
+
+  public static final String SERVER_DEDICATED_CONSUMER_POOL_RECORDS_LIMIT_FACTORS_FOR_SEP_RT_LEADER =
+      "server.dedicated.consumer.pool.records.limit.factors.for.sep.rt.leader";
+
   /**
    * Consumer Pool allocation strategy to rely on pool size to prioritize specific traffic. There will be 3 different
    * types strategy supported decided by #ConsumerPoolStrategyType.
@@ -2309,6 +2317,16 @@ public class ConfigKeys {
    */
   public static final String SERVER_CONSUMER_POOL_SIZE_FOR_NON_CURRENT_VERSION_NON_AA_WC_LEADER =
       "server.consumer.pool.size.for.non.current.version.non.aa.wc.leader";
+  public static final String SERVER_CONSUMER_POOL_RECORDS_LIMIT_FACTORS_FOR_CURRENT_VERSION_AA_WC_LEADER =
+      "server.consumer.pool.records.limit.factors.for.current.version.aa.wc.leader";
+  public static final String SERVER_CONSUMER_POOL_RECORDS_LIMIT_FACTORS_FOR_CURRENT_VERSION_SEPARATE_RT_LEADER =
+      "server.consumer.pool.records.limit.factors.for.current.version.separate.rt.leader";
+  public static final String SERVER_CONSUMER_POOL_RECORDS_LIMIT_FACTORS_FOR_NON_CURRENT_VERSION_AA_WC_LEADER =
+      "server.consumer.pool.records.limit.factors.for.non.current.version.aa.wc.leader";
+  public static final String SERVER_CONSUMER_POOL_RECORDS_LIMIT_FACTORS_FOR_CURRENT_VERSION_NON_AA_WC_LEADER =
+      "server.consumer.pool.records.limit.factors.for.current.version.non.aa.wc.leader";
+  public static final String SERVER_CONSUMER_POOL_RECORDS_LIMIT_FACTORS_FOR_NON_CURRENT_VERSION_NON_AA_WC_LEADER =
+      "server.consumer.pool.records.limit.factors.for.non.current.version.non.aa.wc.leader";
 
   /**
    * Whether to enable record-level metrics when bootstrapping current version.

--- a/internal/venice-common/src/main/java/com/linkedin/venice/throttle/EventThrottler.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/throttle/EventThrottler.java
@@ -311,6 +311,10 @@ public class EventThrottler implements VeniceRateLimiter {
     return quota;
   }
 
+  public String getThrottlerName() {
+    return throttlerName;
+  }
+
   @Override
   public String toString() {
     return "EventThrottler{" + "maxRatePerSecondProvider=" + maxRatePerSecondProvider + ", enforcementIntervalMs="


### PR DESCRIPTION
<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat], [protocol]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->
This PR involve 2 major changes:
1. Having a new `AdaptiveThrottlingServiceStats` class to track the current throttling limit for a specific adaptive consumer pool added to `AdaptiveThrottlerSignalService`, this will help our monitoring for this feature. 
2. Making previous hardcoded throttling factors for each pool easy to configure, using a comma spearated string in the configuration file to indicate list of factors and # of factors.  We should have 1.0 to be added in to the config string, otherwise we will not have base throttle limit.  Configs added: 

`SERVER_THROTTLER_FACTORS_FOR_CURRENT_VERSION_AA_WC_LEADER`
`SERVER_THROTTLER_FACTORS_FOR_CURRENT_VERSION_NON_AA_WC_LEADER`
`SERVER_THROTTLER_FACTORS_FOR_CURRENT_VERSION_SEPARATE_RT_LEADER`
`SERVER_THROTTLER_FACTORS_FOR_NON_CURRENT_VERSION_AA_WC_LEADER`
`SERVER_THROTTLER_FACTORS_FOR_NON_CURRENT_VERSION_NON_AA_WC_LEADER`
`SERVER_THROTTLER_FACTORS_FOR_AA_WC_LEADER`
`SERVER_THROTTLER_FACTORS_FOR_SEP_RT_LEADER`
`KAFKA_FETCH_THROTTLER_FACTORS_PER_SECOND`

3. Besides, fixed a small issue for pool size configuration for `getConsumerPoolSizeForCurrentVersionNonAAWCLeader`.


## Summary, imperative, start upper case, don't end with a period
<!--
Describe
- What changes to make and why you are making these changes.
- How are you going to achieve your goal.
- Describe what testings you have done, for example, performance testing etc.

If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

Resolves #XXX

## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [ ] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.