### PR TITLE
[server][vpj] Alter collection field delete to use schema defaults

### DIFF
--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/replication/merge/helper/MapCollectionMergeTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/replication/merge/helper/MapCollectionMergeTest.java
@@ -63,7 +63,7 @@ public class MapCollectionMergeTest extends SortBasedCollectionFieldOperationHan
     );
     applyAllOperationsOnValue(
         allCollectionOps,
-        ExpectedCollectionResults.createExpectedMapResult(MAP_FIELD_NAME, Collections.emptyMap()));
+        ExpectedCollectionResults.createExpectedMapResult(MAP_FIELD_NAME, null));
   }
 
   @Test
@@ -135,7 +135,7 @@ public class MapCollectionMergeTest extends SortBasedCollectionFieldOperationHan
         new DeleteMapOperation(12L, COLO_ID_2, MAP_FIELD_NAME));
     applyAllOperationsOnValue(
         allCollectionOps,
-        ExpectedCollectionResults.createExpectedMapResult(MAP_FIELD_NAME, Collections.emptyMap()));
+        ExpectedCollectionResults.createExpectedMapResult(MAP_FIELD_NAME, null));
   }
 
   @Test
@@ -179,7 +179,7 @@ public class MapCollectionMergeTest extends SortBasedCollectionFieldOperationHan
         new PutMapOperation(10L, COLO_ID_2, map1, MAP_FIELD_NAME));
     applyAllOperationsOnValue(
         allCollectionOps,
-        ExpectedCollectionResults.createExpectedMapResult(MAP_FIELD_NAME, Collections.emptyMap()));
+        ExpectedCollectionResults.createExpectedMapResult(MAP_FIELD_NAME, null));
   }
 
   @Test
@@ -860,10 +860,9 @@ public class MapCollectionMergeTest extends SortBasedCollectionFieldOperationHan
      *    All entries are deleted.
      */
     List<CollectionOperation> allCollectionOps = getCollectionOpsForTestCase22();
-    Map<String, Object> expectedMapResult = Collections.emptyMap();
     applyAllOperationsOnValue(
         allCollectionOps,
-        ExpectedCollectionResults.createExpectedMapResult(MAP_FIELD_NAME, expectedMapResult));
+        ExpectedCollectionResults.createExpectedMapResult(MAP_FIELD_NAME, null));
   }
 
   private List<CollectionOperation> getCollectionOpsForTestCase22() {

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/input/kafka/ttl/VeniceRmdTTLFilter.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/input/kafka/ttl/VeniceRmdTTLFilter.java
@@ -138,7 +138,7 @@ public abstract class VeniceRmdTTLFilter<INPUT_VALUE> extends AbstractVeniceFilt
       }
     }
     UpdateResultStatus updateResultStatus =
-        mergeRecordHelper.deleteRecord(valueRecord, (GenericRecord) rmdTimestampObject, filterTimestamp, 0);
+        mergeRecordHelper.deleteRecord(valueRecord, (GenericRecord) rmdTimestampObject, filterTimestamp, -1);
     if (updateResultStatus.equals(UpdateResultStatus.COMPLETELY_UPDATED)) {
       // This means the record is fully stale, we should drop it.
       return true;


### PR DESCRIPTION
## [server][vpj] Alter collection field delete to use schema defaults

Prior to this, the FieldOpHandler was assuming an empty collection should be the result of clearing a field which is of a collection type.  However, this is contrary to the behavior of other types which instead set the field value to the default value specified in the schema.  This change normalizes that behavior.

Additionally, tweaked TTL repush to provide the incoming colo id as -1 so that should timestamp ties occurr, the TTL repush insert loses out to what's in the store.  This is basically a tweak of if the timestamp in ttl repush should be inclusive or not.  Setting to -1 seems to make this behavior consistent regardless of what colo this comes from (where previously it's possible for a particular colo to be zero indexed).


## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->

## Does this PR introduce any user-facing changes?

This will change how empty collections are treated by TTL repush and field delete.

- [ ] No. You can skip the rest of this section.
- [x] Yes. Make sure to explain your proposed changes and call out the behavior change.