### PR TITLE
[server][controller] Superset schema generation should carry default if new value schema does not have default value

### DIFF
--- a/internal/venice-client-common/src/main/java/com/linkedin/venice/utils/AvroSupersetSchemaUtils.java
+++ b/internal/venice-client-common/src/main/java/com/linkedin/venice/utils/AvroSupersetSchemaUtils.java
@@ -15,6 +15,7 @@ import java.util.Objects;
 import java.util.stream.Collectors;
 import org.apache.avro.Schema;
 import org.apache.commons.lang.StringUtils;
+import org.apache.logging.log4j.LogManager;
 
 
 public class AvroSupersetSchemaUtils {
@@ -158,8 +159,18 @@ public class AvroSupersetSchemaUtils {
       if (fieldInExistingSchema != null) {
         fieldBuilder.setSchema(generateSupersetSchema(fieldInExistingSchema.schema(), fieldInNewSchema.schema()))
             .setDoc(fieldInNewSchema.doc() != null ? fieldInNewSchema.doc() : fieldInExistingSchema.doc());
+        if (!fieldInNewSchema.hasDefaultValue() && fieldInExistingSchema.hasDefaultValue()) {
+          fieldBuilder.setDefault(getFieldDefault(fieldInExistingSchema));
+        }
       }
-      fields.add(fieldBuilder.build());
+      Schema.Field geneartedField = fieldBuilder.build();
+      LogManager.getLogger(AvroSupersetSchemaUtils.class)
+          .info(
+              "generated: {} {} {}",
+              fieldInNewSchema.hasDefaultValue(),
+              geneartedField.hasDefaultValue(),
+              fieldInExistingSchema == null ? null : fieldInExistingSchema.hasDefaultValue());
+      fields.add(geneartedField);
     }
 
     for (Schema.Field fieldInExistingSchema: existingSchema.getFields()) {

--- a/internal/venice-client-common/src/main/java/com/linkedin/venice/utils/AvroSupersetSchemaUtils.java
+++ b/internal/venice-client-common/src/main/java/com/linkedin/venice/utils/AvroSupersetSchemaUtils.java
@@ -15,7 +15,6 @@ import java.util.Objects;
 import java.util.stream.Collectors;
 import org.apache.avro.Schema;
 import org.apache.commons.lang.StringUtils;
-import org.apache.logging.log4j.LogManager;
 
 
 public class AvroSupersetSchemaUtils {
@@ -142,9 +141,10 @@ public class AvroSupersetSchemaUtils {
   }
 
   /**
-   * Merge field schema from two schema object. The rule is: If a field exist in both new schema and old schema, we should
-   * generate the superset schema of these two versions of the same field, with new schema's information taking higher
-   * priority.
+   * Merge field schema from two schema object.
+   * The rule is: If a field exist in both new schema and old schema, we should generate the superset schema of these
+   * two versions of the same field, with new schema's information taking higher priority.
+   * For default value, if new schema does not have default value, we will still preserve the old default value.
    * @param newSchema new schema
    * @param existingSchema old schema
    * @return merged schema field
@@ -163,14 +163,8 @@ public class AvroSupersetSchemaUtils {
           fieldBuilder.setDefault(getFieldDefault(fieldInExistingSchema));
         }
       }
-      Schema.Field geneartedField = fieldBuilder.build();
-      LogManager.getLogger(AvroSupersetSchemaUtils.class)
-          .info(
-              "generated: {} {} {}",
-              fieldInNewSchema.hasDefaultValue(),
-              geneartedField.hasDefaultValue(),
-              fieldInExistingSchema == null ? null : fieldInExistingSchema.hasDefaultValue());
-      fields.add(geneartedField);
+      Schema.Field generatedField = fieldBuilder.build();
+      fields.add(generatedField);
     }
 
     for (Schema.Field fieldInExistingSchema: existingSchema.getFields()) {

--- a/internal/venice-client-common/src/test/java/com/linkedin/venice/schema/TestAvroSupersetSchemaUtils.java
+++ b/internal/venice-client-common/src/test/java/com/linkedin/venice/schema/TestAvroSupersetSchemaUtils.java
@@ -8,6 +8,8 @@ import static com.linkedin.venice.utils.TestWriteUtils.NAME_RECORD_V5_SCHEMA;
 import static com.linkedin.venice.utils.TestWriteUtils.NAME_RECORD_V6_SCHEMA;
 import static com.linkedin.venice.utils.TestWriteUtils.USER_SCHEMA;
 import static com.linkedin.venice.utils.TestWriteUtils.USER_WITH_DEFAULT_SCHEMA;
+import static com.linkedin.venice.utils.TestWriteUtils.USER_WITH_NESTED_RECORD_AND_DEFAULT_SCHEMA;
+import static com.linkedin.venice.utils.TestWriteUtils.USER_WITH_NESTED_RECORD_SCHEMA;
 import static com.linkedin.venice.utils.TestWriteUtils.loadFileAsString;
 
 import com.linkedin.avroutil1.compatibility.AvroCompatibilityHelper;
@@ -508,6 +510,16 @@ public class TestAvroSupersetSchemaUtils {
     Assert.assertEquals(
         AvroSupersetSchemaUtils.generateSupersetSchema(USER_SCHEMA, USER_WITH_DEFAULT_SCHEMA),
         USER_WITH_DEFAULT_SCHEMA);
+
+    // Test nested record default value carry in both direction.
+    Assert.assertEquals(
+        AvroSupersetSchemaUtils
+            .generateSupersetSchema(USER_WITH_NESTED_RECORD_AND_DEFAULT_SCHEMA, USER_WITH_NESTED_RECORD_SCHEMA),
+        USER_WITH_NESTED_RECORD_AND_DEFAULT_SCHEMA);
+    Assert.assertEquals(
+        AvroSupersetSchemaUtils
+            .generateSupersetSchema(USER_WITH_NESTED_RECORD_SCHEMA, USER_WITH_NESTED_RECORD_AND_DEFAULT_SCHEMA),
+        USER_WITH_NESTED_RECORD_AND_DEFAULT_SCHEMA);
   }
 
   @Test

--- a/internal/venice-client-common/src/test/java/com/linkedin/venice/schema/TestAvroSupersetSchemaUtils.java
+++ b/internal/venice-client-common/src/test/java/com/linkedin/venice/schema/TestAvroSupersetSchemaUtils.java
@@ -6,6 +6,8 @@ import static com.linkedin.venice.utils.TestWriteUtils.NAME_RECORD_V3_SCHEMA;
 import static com.linkedin.venice.utils.TestWriteUtils.NAME_RECORD_V4_SCHEMA;
 import static com.linkedin.venice.utils.TestWriteUtils.NAME_RECORD_V5_SCHEMA;
 import static com.linkedin.venice.utils.TestWriteUtils.NAME_RECORD_V6_SCHEMA;
+import static com.linkedin.venice.utils.TestWriteUtils.USER_SCHEMA;
+import static com.linkedin.venice.utils.TestWriteUtils.USER_WITH_DEFAULT_SCHEMA;
 import static com.linkedin.venice.utils.TestWriteUtils.loadFileAsString;
 
 import com.linkedin.avroutil1.compatibility.AvroCompatibilityHelper;
@@ -496,6 +498,16 @@ public class TestAvroSupersetSchemaUtils {
         AvroSupersetSchemaUtils.getLatestUpdateSchemaFromSchemaResponse(schemaResponse, 1);
     Assert.assertNotNull(retrievedSchema);
     Assert.assertEquals(retrievedSchema.getSchemaStr(), "dummySchemaStr2");
+  }
+
+  @Test
+  public void testSupersetSchemaKeepDefault() {
+    Assert.assertEquals(
+        AvroSupersetSchemaUtils.generateSupersetSchema(USER_WITH_DEFAULT_SCHEMA, USER_SCHEMA),
+        USER_WITH_DEFAULT_SCHEMA);
+    Assert.assertEquals(
+        AvroSupersetSchemaUtils.generateSupersetSchema(USER_SCHEMA, USER_WITH_DEFAULT_SCHEMA),
+        USER_WITH_DEFAULT_SCHEMA);
   }
 
   @Test

--- a/internal/venice-client-common/src/test/java/com/linkedin/venice/schema/TestAvroSupersetSchemaUtils.java
+++ b/internal/venice-client-common/src/test/java/com/linkedin/venice/schema/TestAvroSupersetSchemaUtils.java
@@ -505,21 +505,23 @@ public class TestAvroSupersetSchemaUtils {
   @Test
   public void testSupersetSchemaKeepDefault() {
     Assert.assertEquals(
-        AvroSupersetSchemaUtils.generateSupersetSchema(USER_WITH_DEFAULT_SCHEMA, USER_SCHEMA),
-        USER_WITH_DEFAULT_SCHEMA);
+        AvroSupersetSchemaUtils.generateSupersetSchema(USER_WITH_DEFAULT_SCHEMA, USER_SCHEMA).toString(),
+        USER_WITH_DEFAULT_SCHEMA.toString());
     Assert.assertEquals(
-        AvroSupersetSchemaUtils.generateSupersetSchema(USER_SCHEMA, USER_WITH_DEFAULT_SCHEMA),
-        USER_WITH_DEFAULT_SCHEMA);
+        AvroSupersetSchemaUtils.generateSupersetSchema(USER_SCHEMA, USER_WITH_DEFAULT_SCHEMA).toString(),
+        USER_WITH_DEFAULT_SCHEMA.toString());
 
     // Test nested record default value carry in both direction.
     Assert.assertEquals(
         AvroSupersetSchemaUtils
-            .generateSupersetSchema(USER_WITH_NESTED_RECORD_AND_DEFAULT_SCHEMA, USER_WITH_NESTED_RECORD_SCHEMA),
-        USER_WITH_NESTED_RECORD_AND_DEFAULT_SCHEMA);
+            .generateSupersetSchema(USER_WITH_NESTED_RECORD_AND_DEFAULT_SCHEMA, USER_WITH_NESTED_RECORD_SCHEMA)
+            .toString(),
+        USER_WITH_NESTED_RECORD_AND_DEFAULT_SCHEMA.toString());
     Assert.assertEquals(
         AvroSupersetSchemaUtils
-            .generateSupersetSchema(USER_WITH_NESTED_RECORD_SCHEMA, USER_WITH_NESTED_RECORD_AND_DEFAULT_SCHEMA),
-        USER_WITH_NESTED_RECORD_AND_DEFAULT_SCHEMA);
+            .generateSupersetSchema(USER_WITH_NESTED_RECORD_SCHEMA, USER_WITH_NESTED_RECORD_AND_DEFAULT_SCHEMA)
+            .toString(),
+        USER_WITH_NESTED_RECORD_AND_DEFAULT_SCHEMA.toString());
   }
 
   @Test

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/PartialUpdateTest.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/PartialUpdateTest.java
@@ -388,6 +388,86 @@ public class PartialUpdateTest {
     }
   }
 
+  @Test(timeOut = TEST_TIMEOUT_MS)
+  public void testUpdateValueWithOldSchemaWithFieldLevelRMD() {
+    final String storeName = Utils.getUniqueString("convertToFieldLevel");
+    String parentControllerUrl = parentController.getControllerUrl();
+    Schema schemaV1 = AvroCompatibilityHelper.parse(loadFileAsString("UserV1.avsc"));
+    Schema schemaV2 = AvroCompatibilityHelper.parse(loadFileAsString("UserV2.avsc"));
+
+    ReadOnlySchemaRepository schemaRepo = mock(ReadOnlySchemaRepository.class);
+    when(schemaRepo.getValueSchema(storeName, 1)).thenReturn(new SchemaEntry(1, schemaV1));
+    when(schemaRepo.getValueSchema(storeName, 2)).thenReturn(new SchemaEntry(2, schemaV2));
+
+    try (ControllerClient parentControllerClient = new ControllerClient(CLUSTER_NAME, parentControllerUrl)) {
+      assertCommand(
+          parentControllerClient
+              .createNewStore(storeName, "test_owner", STRING_SCHEMA.toString(), schemaV1.toString()));
+      UpdateStoreQueryParams updateStoreParams =
+          new UpdateStoreQueryParams().setStorageQuotaInByte(Store.UNLIMITED_STORAGE_QUOTA)
+              .setCompressionStrategy(CompressionStrategy.NO_OP)
+              .setActiveActiveReplicationEnabled(true)
+              .setChunkingEnabled(true)
+              .setRmdChunkingEnabled(true)
+              .setHybridRewindSeconds(10L)
+              .setHybridOffsetLagThreshold(2L);
+      ControllerResponse updateStoreResponse =
+          parentControllerClient.retryableRequest(5, c -> c.updateStore(storeName, updateStoreParams));
+      assertFalse(updateStoreResponse.isError(), "Update store got error: " + updateStoreResponse.getError());
+
+      VersionCreationResponse response = parentControllerClient.emptyPush(storeName, "test_push_id", 1000);
+      assertEquals(response.getVersion(), 1);
+      assertFalse(response.isError(), "Empty push to parent colo should succeed");
+      TestUtils.waitForNonDeterministicPushCompletion(
+          Version.composeKafkaTopic(storeName, 1),
+          parentControllerClient,
+          30,
+          TimeUnit.SECONDS);
+
+      assertCommand(parentControllerClient.addValueSchema(storeName, schemaV2.toString()));
+      UpdateStoreQueryParams updateStoreParams2 = new UpdateStoreQueryParams().setWriteComputationEnabled(true);
+      updateStoreResponse =
+          parentControllerClient.retryableRequest(5, c -> c.updateStore(storeName, updateStoreParams2));
+      assertFalse(updateStoreResponse.isError(), "Update store got error: " + updateStoreResponse.getError());
+
+      response = parentControllerClient.emptyPush(storeName, "test_push_id_v2", 1000);
+      assertEquals(response.getVersion(), 2);
+      assertFalse(response.isError(), "Empty push to parent colo should succeed");
+      TestUtils.waitForNonDeterministicPushCompletion(
+          Version.composeKafkaTopic(storeName, 2),
+          parentControllerClient,
+          30,
+          TimeUnit.SECONDS);
+    }
+    VeniceClusterWrapper veniceClusterWrapper = childDatacenters.get(0).getClusters().get(CLUSTER_NAME);
+    SystemProducer veniceProducer = getSamzaProducer(veniceClusterWrapper, storeName, Version.PushType.STREAM);
+    String key = "highway";
+    // Send first value with old schema;
+    GenericRecord record = new GenericData.Record(schemaV1);
+    record.put("id", "101");
+    record.put("name", "U.S. 101");
+    sendStreamingRecord(veniceProducer, storeName, key, record);
+    // Send first value with new schema;
+    GenericRecord recordV2 = new GenericData.Record(schemaV2);
+    recordV2.put("id", "280");
+    recordV2.put("name", "Interstate 280");
+    sendStreamingRecord(veniceProducer, storeName, key, recordV2);
+
+    try (AvroGenericStoreClient<Object, Object> storeReader = ClientFactory.getAndStartGenericAvroClient(
+        ClientConfig.defaultGenericClientConfig(storeName).setVeniceURL(veniceClusterWrapper.getRandomRouterURL()))) {
+      TestUtils.waitForNonDeterministicAssertion(10, TimeUnit.SECONDS, true, () -> {
+        try {
+          GenericRecord value = readValue(storeReader, key);
+          assertNotNull(value, "Key " + key + " should not be missing!");
+          assertEquals(value.get("id").toString(), "280");
+          assertEquals(value.get("name").toString(), "Interstate 280");
+        } catch (Exception e) {
+          throw new VeniceException(e);
+        }
+      });
+    }
+  }
+
   @Test(timeOut = TEST_TIMEOUT_MS, dataProvider = "True-and-False", dataProviderClass = DataProviderUtils.class)
   public void testIncrementalPushPartialUpdateNewFormat(boolean useSparkCompute) throws IOException {
     final String storeName = Utils.getUniqueString("inc_push_update_new_format");

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/PartialUpdateTest.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/PartialUpdateTest.java
@@ -447,7 +447,7 @@ public class PartialUpdateTest {
     record.put("id", "101");
     record.put("name", "U.S. 101");
     sendStreamingRecord(veniceProducer, storeName, key, record);
-    // Send first value with new schema;
+    // Send second value with new schema; Without default schema carry fix, it will fail SIT ingestion.
     GenericRecord recordV2 = new GenericData.Record(schemaV2);
     recordV2.put("id", "280");
     recordV2.put("name", "Interstate 280");

--- a/internal/venice-test-common/src/integrationTest/resources/UserV1.avsc
+++ b/internal/venice-test-common/src/integrationTest/resources/UserV1.avsc
@@ -1,0 +1,15 @@
+{
+  "type": "record",
+  "name": "User",
+  "namespace": "example.avro",
+  "fields": [
+    {
+      "name": "id",
+      "type": "string"
+    },
+    {
+      "name": "name",
+      "type": "string"
+    }
+  ]
+}

--- a/internal/venice-test-common/src/integrationTest/resources/UserV2.avsc
+++ b/internal/venice-test-common/src/integrationTest/resources/UserV2.avsc
@@ -1,0 +1,17 @@
+{
+  "type": "record",
+  "name": "User",
+  "namespace": "example.avro",
+  "fields": [
+    {
+      "name": "id",
+      "type": "string",
+      "default": "default_id"
+    },
+    {
+      "name": "name",
+      "type": "string",
+      "default": "default_name"
+    }
+  ]
+}

--- a/internal/venice-test-common/src/main/java/com/linkedin/venice/utils/TestWriteUtils.java
+++ b/internal/venice-test-common/src/main/java/com/linkedin/venice/utils/TestWriteUtils.java
@@ -93,6 +93,12 @@ public class TestWriteUtils {
       AvroCompatibilityHelper.parse(loadSchemaFileFromResource("valueSchema/SimpleUserWithDefault.avsc"));
   public static final Schema USER_WITH_FLOAT_ARRAY_SCHEMA =
       AvroCompatibilityHelper.parse(loadSchemaFileFromResource("valueSchema/UserWithFloatArray.avsc"));
+  public static final Schema USER_WITH_NESTED_RECORD_SCHEMA =
+      AvroCompatibilityHelper.parse(loadSchemaFileFromResource("valueSchema/UserWithNestedRecord.avsc"));
+
+  public static final Schema USER_WITH_NESTED_RECORD_AND_DEFAULT_SCHEMA =
+      AvroCompatibilityHelper.parse(loadSchemaFileFromResource("valueSchema/UserWithNestedRecord.avsc"));
+
   public static final Schema USER_WITH_STRING_MAP_SCHEMA =
       AvroCompatibilityHelper.parse(loadSchemaFileFromResource("valueSchema/UserWithStringMap.avsc"));
 

--- a/internal/venice-test-common/src/main/java/com/linkedin/venice/utils/TestWriteUtils.java
+++ b/internal/venice-test-common/src/main/java/com/linkedin/venice/utils/TestWriteUtils.java
@@ -97,7 +97,7 @@ public class TestWriteUtils {
       AvroCompatibilityHelper.parse(loadSchemaFileFromResource("valueSchema/UserWithNestedRecord.avsc"));
 
   public static final Schema USER_WITH_NESTED_RECORD_AND_DEFAULT_SCHEMA =
-      AvroCompatibilityHelper.parse(loadSchemaFileFromResource("valueSchema/UserWithNestedRecord.avsc"));
+      AvroCompatibilityHelper.parse(loadSchemaFileFromResource("valueSchema/UserWithNestedRecordAndDefault.avsc"));
 
   public static final Schema USER_WITH_STRING_MAP_SCHEMA =
       AvroCompatibilityHelper.parse(loadSchemaFileFromResource("valueSchema/UserWithStringMap.avsc"));

--- a/internal/venice-test-common/src/main/resources/valueSchema/UserWithNestedRecord.avsc
+++ b/internal/venice-test-common/src/main/resources/valueSchema/UserWithNestedRecord.avsc
@@ -1,0 +1,28 @@
+{
+  "type": "record",
+  "name": "ManyFloats",
+  "namespace": "example.avro",
+  "fields": [
+    {
+      "name": "key",
+      "type": "string"
+    },
+    {
+      "name": "value",
+      "type": {
+        "type": "record",
+        "name": "ValueRecord",
+        "fields": [
+          {
+            "name": "model",
+            "type": "float"
+          }
+        ]
+      }
+    },
+    {
+      "name": "age",
+      "type": "int"
+    }
+  ]
+}

--- a/internal/venice-test-common/src/main/resources/valueSchema/UserWithNestedRecordAndDefault.avsc
+++ b/internal/venice-test-common/src/main/resources/valueSchema/UserWithNestedRecordAndDefault.avsc
@@ -1,0 +1,32 @@
+{
+  "type": "record",
+  "name": "ManyFloats",
+  "namespace": "example.avro",
+  "fields": [
+    {
+      "name": "key",
+      "type": "string",
+      "default": "foo"
+    },
+    {
+      "name": "value",
+      "type": {
+        "type": "record",
+        "name": "ValueRecord",
+        "fields": [
+          {
+            "name": "model",
+            "type": "float",
+            "default": 1.0
+          }
+        ]
+      },
+      "default": { "model": 1.0 }
+    },
+    {
+      "name": "age",
+      "type": "int",
+      "default": 1
+    }
+  ]
+}


### PR DESCRIPTION

<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat], [protocol]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## [server][controller] Superset schema generation should carry default if new value schema does not have default value
This issue was detected via an legacy check in Active/Active Partial Update code that resulted in ingestion error:
1. User created store with schema v1(no default), v2(has default)
2. User put data with old value schema. 
3. User enabled and disabled AAWC, but user continue to put data with new value schema (or doesn't matter new->old, as long as old value and new value is using different schema id) 
4. When the logic checks incoming write, since it has field level RMD already, it will go to AAWC path to check and there we need to resolve the superset schema and there it will check if superset(v1, v2) is v1's superset schema, and superset(v2,v1) is v2's superset schema. 
In current implementation, new schema's default will always overwrite old schema's, but if new schema does not have default, it will also erase existing default, which I think is wrong. With this, the check in 4 throws exception.

This PR fixes it by porting the old value schema's default, if new schema does not have default, during superset schema generation logic. Although it is guarded in partial update enabled case, this is to make sure other feature - read compute will still achieve correct superset schema.

## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
New integration test and new unit test.

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.