### PR TITLE
[server] Do not register separate RT region heartbeat metrics for follower

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/ingestion/heartbeat/HeartbeatMonitoringService.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/ingestion/heartbeat/HeartbeatMonitoringService.java
@@ -14,7 +14,6 @@ import io.tehuti.metrics.MetricsRepository;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
-import java.util.stream.Collectors;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -64,7 +63,7 @@ public class HeartbeatMonitoringService extends AbstractVeniceService {
       Set<String> regionNames,
       String localRegionName,
       HeartbeatMonitoringServiceStats heartbeatMonitoringServiceStats) {
-    this.regionNames = regionNames.stream().filter(x -> !Utils.isSeparateTopicRegion(x)).collect(Collectors.toSet());
+    this.regionNames = regionNames;
     this.localRegionName = localRegionName;
     this.reportingThread = new HeartbeatReporterThread();
     this.lagLoggingThread = new HeartbeatLagLoggingThread();

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/ingestion/heartbeat/HeartbeatStatReporter.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/ingestion/heartbeat/HeartbeatStatReporter.java
@@ -3,6 +3,7 @@ package com.linkedin.davinci.stats.ingestion.heartbeat;
 import static com.linkedin.venice.stats.StatsErrorCode.NULL_INGESTION_STATS;
 
 import com.linkedin.davinci.stats.AbstractVeniceStatsReporter;
+import com.linkedin.venice.utils.Utils;
 import io.tehuti.metrics.MetricsRepository;
 import io.tehuti.metrics.stats.AsyncGauge;
 import java.util.Set;
@@ -29,7 +30,18 @@ public class HeartbeatStatReporter extends AbstractVeniceStatsReporter<Heartbeat
         if (getStats() == null) {
           return NULL_INGESTION_STATS.code;
         }
+        return getStats().getReadyToServeLeaderLag(region).getAvg();
+      }, LEADER_METRIC_PREFIX + region + AVG));
 
+      // Do not register follower heartbeat metrics for separate RT region.
+      if (Utils.isSeparateTopicRegion(region)) {
+        continue;
+      }
+
+      registerSensor(new AsyncGauge((ignored, ignored2) -> {
+        if (getStats() == null) {
+          return NULL_INGESTION_STATS.code;
+        }
         return getStats().getReadyToServeFollowerLag(region).getMax();
       }, FOLLOWER_METRIC_PREFIX + region + MAX));
 
@@ -37,15 +49,6 @@ public class HeartbeatStatReporter extends AbstractVeniceStatsReporter<Heartbeat
         if (getStats() == null) {
           return NULL_INGESTION_STATS.code;
         }
-
-        return getStats().getReadyToServeLeaderLag(region).getAvg();
-      }, LEADER_METRIC_PREFIX + region + AVG));
-
-      registerSensor(new AsyncGauge((ignored, ignored2) -> {
-        if (getStats() == null) {
-          return NULL_INGESTION_STATS.code;
-        }
-
         return getStats().getReadyToServeFollowerLag(region).getAvg();
       }, FOLLOWER_METRIC_PREFIX + region + AVG));
 
@@ -53,7 +56,6 @@ public class HeartbeatStatReporter extends AbstractVeniceStatsReporter<Heartbeat
         if (getStats() == null) {
           return NULL_INGESTION_STATS.code;
         }
-
         return getStats().getCatchingUpFollowerLag(region).getMax();
       }, CATCHUP_UP_FOLLOWER_METRIC_PREFIX + region + MAX));
 
@@ -61,7 +63,6 @@ public class HeartbeatStatReporter extends AbstractVeniceStatsReporter<Heartbeat
         if (getStats() == null) {
           return NULL_INGESTION_STATS.code;
         }
-
         return getStats().getCatchingUpFollowerLag(region).getAvg();
       }, CATCHUP_UP_FOLLOWER_METRIC_PREFIX + region + AVG));
     }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/ingestion/heartbeat/HeartbeatStatReporter.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/ingestion/heartbeat/HeartbeatStatReporter.java
@@ -10,11 +10,11 @@ import java.util.Set;
 
 
 public class HeartbeatStatReporter extends AbstractVeniceStatsReporter<HeartbeatStat> {
-  private static final String LEADER_METRIC_PREFIX = "heartbeat_delay_ms_leader-";
-  private static final String FOLLOWER_METRIC_PREFIX = "heartbeat_delay_ms_follower-";
-  private static final String CATCHUP_UP_FOLLOWER_METRIC_PREFIX = "catching_up_heartbeat_delay_ms_follower-";
-  private static final String MAX = "-Max";
-  private static final String AVG = "-Avg";
+  static final String LEADER_METRIC_PREFIX = "heartbeat_delay_ms_leader-";
+  static final String FOLLOWER_METRIC_PREFIX = "heartbeat_delay_ms_follower-";
+  static final String CATCHUP_UP_FOLLOWER_METRIC_PREFIX = "catching_up_heartbeat_delay_ms_follower-";
+  static final String MAX = "-Max";
+  static final String AVG = "-Avg";
 
   public HeartbeatStatReporter(MetricsRepository metricsRepository, String storeName, Set<String> regions) {
     super(metricsRepository, storeName);

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestDumpIngestionContext.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestDumpIngestionContext.java
@@ -131,7 +131,7 @@ public class TestDumpIngestionContext {
       LOGGER.info("Heartbeat Info with topic filtering:\n" + heartbeatInfoMap);
       Assert.assertEquals(heartbeatInfoMap.keySet().stream().filter(x -> x.endsWith("dc-0")).count(), 3);
       Assert.assertEquals(
-          heartbeatInfoMap.keySet().stream().filter(x -> x.endsWith("dc-1")).count() * 2,
+          heartbeatInfoMap.keySet().stream().filter(x -> x.contains("dc-1")).count() * 2,
           heartbeatInfoMap.values().stream().filter(x -> x.getLeaderState().equals("LEADER")).count());
 
       heartbeatInfoMap = serverWrapper.getVeniceServer()


### PR DESCRIPTION
## [server] Do not register separate RT region heartbeat metrics for follower
Separate HB metrics should only be applied to leader, not for follower. This will reduce unnecessary metric count.


## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
New Unit Test.
## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.