### PR TITLE
[changelog][client] Partial rollback of checkpoint maintenance

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/consumer/VeniceChangelogConsumerImpl.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/consumer/VeniceChangelogConsumerImpl.java
@@ -1000,17 +1000,9 @@ public class VeniceChangelogConsumerImpl<K, V> implements VeniceChangelogConsume
       Integer upstreamPartition) {
     int partitionId = pubSubTopicPartition.getPartitionNumber();
     List<Long> localOffset = (List<Long>) currentVersionHighWatermarks.getOrDefault(partitionId, Collections.EMPTY_MAP)
-        .getOrDefault(upstreamPartition, Collections.EMPTY_LIST);
-    if (localOffset != null) {
-      if (RmdUtils.hasOffsetAdvanced(localOffset, recordCheckpointVector)) {
-        currentVersionHighWatermarks.putIfAbsent(pubSubTopicPartition.getPartitionNumber(), new HashMap<>());
-        // We need to merge
-        currentVersionHighWatermarks.get(pubSubTopicPartition.getPartitionNumber())
-            .put(upstreamPartition, RmdUtils.mergeOffsetVectors(localOffset, recordCheckpointVector));
-        return false;
-      } else {
-        return true;
-      }
+        .getOrDefault(upstreamPartition, new ArrayList<>());
+    if (recordCheckpointVector != null) {
+      return !RmdUtils.hasOffsetAdvanced(localOffset, recordCheckpointVector);
     }
     // Has not met version swap message after client initialization.
     return false;

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/consumer/TestChangelogConsumer.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/consumer/TestChangelogConsumer.java
@@ -725,7 +725,7 @@ public class TestChangelogConsumer {
     versionTopicConsumer.seekToBeginningOfPush().get();
     TestUtils.waitForNonDeterministicAssertion(10, TimeUnit.SECONDS, true, () -> {
       pollAfterImageEventsFromChangeCaptureConsumer(versionTopicEvents, versionTopicConsumer);
-      Assert.assertEquals(versionTopicEvents.size(), 10);
+      Assert.assertEquals(versionTopicEvents.size(), 30);
     });
 
     // Verify version swap count matches with version count - 1 (since we don't transmit from version 0 to version 1).


### PR DESCRIPTION
## [changelog][client] Partial rollback of checkpoint maintenance

It's been reported that since patching a stricter checkpoint tracking on afterimageconsumer we've been filtering too many messages.

this doesn't effect the correctness of the consumer, but it does mean consumers will get played back more events then maybe strictly necessary.  However, as it stands this is causing some production issues, so this change just reverts that tweak back to what it was doing originally.

Resolves #XXX

## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [ ] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.