### PR TITLE
[samza] Use concurrent hashmap for key schema string

### DIFF
--- a/integrations/venice-samza/src/main/java/com/linkedin/venice/samza/VeniceSystemProducer.java
+++ b/integrations/venice-samza/src/main/java/com/linkedin/venice/samza/VeniceSystemProducer.java
@@ -38,7 +38,6 @@ import com.linkedin.venice.serialization.avro.AvroProtocolDefinition;
 import com.linkedin.venice.serialization.avro.SchemaPresenceChecker;
 import com.linkedin.venice.serializer.FastSerializerDeserializerFactory;
 import com.linkedin.venice.serializer.RecordSerializer;
-import com.linkedin.venice.utils.BoundedHashMap;
 import com.linkedin.venice.utils.Pair;
 import com.linkedin.venice.utils.PartitionUtils;
 import com.linkedin.venice.utils.SystemTime;
@@ -136,7 +135,7 @@ public class VeniceSystemProducer implements SystemProducer, Closeable {
   private Schema keySchema;
   private String canonicalKeySchemaStr;
   // To avoid the excessive usage of the cache in case each message is using a unique key schema
-  private final Map<Schema, String> canonicalSchemaStrCache = new BoundedHashMap<>(10, true);
+  private final Map<Schema, String> canonicalSchemaStrCache = new VeniceConcurrentHashMap<>(10);
 
   private D2Client primaryControllerColoD2Client;
   private D2Client childColoD2Client;


### PR DESCRIPTION
<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat], [protocol]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## Use concurrent hashmap for key schema string
<!--
Describe
- What changes to make and why you are making these changes.
- How are you going to achieve your goal.
- Describe what testings you have done, for example, performance testing etc.

If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

Key schema access in 'send' method hits the following exception. This PR fixes that.
Caused by: java.util.ConcurrentModificationException
      at java.util.HashMap.computeIfAbsent(HashMap.java:1134) ~[?:?]
      at com.linkedin.venice.samza.VeniceSystemProducer.send(VeniceSystemProducer.java:689) ~[com.linkedin.venice-venice-samza-0.4.140.jar:?]
      at com.linkedin.livenice.samza.VeniceSystemProducer.send(VeniceSystemProducer.java:191) ~[com.linkedin.samza-li-venice-venice-samza-4.0.41.jar:?]
## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
CI
## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [ ] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.