### PR TITLE
[venice-samza] Use a thread-safe bounded cache for schema parsing

### DIFF
--- a/integrations/venice-samza/build.gradle
+++ b/integrations/venice-samza/build.gradle
@@ -18,6 +18,7 @@ dependencies {
 
   implementation libraries.log4j2api
   implementation libraries.samzaApi
+  implementation libraries.caffeine
 }
 
 ext {

--- a/integrations/venice-samza/src/test/java/com/linkedin/venice/samza/VeniceSystemProducerTest.java
+++ b/integrations/venice-samza/src/test/java/com/linkedin/venice/samza/VeniceSystemProducerTest.java
@@ -26,8 +26,6 @@ import com.linkedin.venice.controllerapi.D2ControllerClient;
 import com.linkedin.venice.controllerapi.MultiSchemaResponse;
 import com.linkedin.venice.controllerapi.StoreResponse;
 import com.linkedin.venice.controllerapi.VersionCreationResponse;
-import com.linkedin.venice.kafka.protocol.KafkaMessageEnvelope;
-import com.linkedin.venice.kafka.protocol.state.PartitionState;
 import com.linkedin.venice.meta.StoreInfo;
 import com.linkedin.venice.meta.Version;
 import com.linkedin.venice.meta.VersionImpl;
@@ -327,10 +325,10 @@ public class VeniceSystemProducerTest {
       canonicalSchemaStrCache.get(schema);
     }
 
-    canonicalSchemaStrCache.get(KafkaMessageEnvelope.SCHEMA$);
-    canonicalSchemaStrCache.get(PartitionState.getClassSchema());
+    long cacheSize = canonicalSchemaStrCache.estimatedSize();
     Assert.assertTrue(
         canonicalSchemaStrCache.estimatedSize() < 10,
-        "The size of the cache shouldn't go beyond 10 when specifying the maximum size as 3 even with estimation");
+        "The size of the cache shouldn't go beyond 10 when specifying the maximum size as 3 even with estimation, but got: "
+            + cacheSize);
   }
 }

--- a/integrations/venice-samza/src/test/java/com/linkedin/venice/samza/VeniceSystemProducerTest.java
+++ b/integrations/venice-samza/src/test/java/com/linkedin/venice/samza/VeniceSystemProducerTest.java
@@ -18,16 +18,24 @@ import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.fail;
 
+import com.github.benmanes.caffeine.cache.Caffeine;
+import com.github.benmanes.caffeine.cache.LoadingCache;
+import com.linkedin.avroutil1.compatibility.AvroCompatibilityHelper;
+import com.linkedin.venice.compute.protocol.response.ComputeResponseRecordV1;
 import com.linkedin.venice.controllerapi.ControllerClient;
 import com.linkedin.venice.controllerapi.D2ControllerClient;
 import com.linkedin.venice.controllerapi.MultiSchemaResponse;
 import com.linkedin.venice.controllerapi.StoreResponse;
 import com.linkedin.venice.controllerapi.VersionCreationResponse;
+import com.linkedin.venice.kafka.protocol.KafkaMessageEnvelope;
+import com.linkedin.venice.kafka.protocol.state.PartitionState;
+import com.linkedin.venice.kafka.protocol.state.StoreVersionState;
 import com.linkedin.venice.meta.StoreInfo;
 import com.linkedin.venice.meta.Version;
 import com.linkedin.venice.meta.VersionImpl;
 import com.linkedin.venice.pushmonitor.ExecutionStatus;
 import com.linkedin.venice.pushmonitor.RouterBasedPushMonitor;
+import com.linkedin.venice.read.protocol.response.MultiGetResponseRecordV1;
 import com.linkedin.venice.utils.Pair;
 import com.linkedin.venice.utils.SystemTime;
 import com.linkedin.venice.writer.VeniceWriter;
@@ -308,6 +316,30 @@ public class VeniceSystemProducerTest {
     assertEquals(options.getProducerThreadCount(), 2);
     assertEquals(options.getProducerQueueSize(), 102400000);
     assertEquals(properties.getProperty(KAFKA_BUFFER_MEMORY), "10240");
+  }
 
+  @Test
+  public void testSchemaCache() {
+    final LoadingCache<Schema, String> canonicalSchemaStrCache =
+        Caffeine.newBuilder().maximumSize(3).build(AvroCompatibilityHelper::toParsingForm);
+    canonicalSchemaStrCache.get(KafkaMessageEnvelope.SCHEMA$);
+    canonicalSchemaStrCache.get(KafkaMessageEnvelope.SCHEMA$);
+    canonicalSchemaStrCache.get(PartitionState.getClassSchema());
+    canonicalSchemaStrCache.get(StoreVersionState.getClassSchema());
+    canonicalSchemaStrCache.get(MultiGetResponseRecordV1.SCHEMA$);
+    canonicalSchemaStrCache.get(ComputeResponseRecordV1.getClassSchema());
+    canonicalSchemaStrCache.get(KafkaMessageEnvelope.SCHEMA$);
+
+    for (int i = 0; i < 100; ++i) {
+      Schema.Field field1 = new Schema.Field("field1", Schema.create(Schema.Type.STRING), "doc", "default");
+      Schema schema = Schema.createRecord("test_record" + i, "doc", "namespace", false, Arrays.asList(field1));
+      canonicalSchemaStrCache.get(schema);
+    }
+
+    canonicalSchemaStrCache.get(KafkaMessageEnvelope.SCHEMA$);
+    canonicalSchemaStrCache.get(PartitionState.getClassSchema());
+    Assert.assertTrue(
+        canonicalSchemaStrCache.estimatedSize() < 10,
+        "The size of the cache shouldn't go beyond 10 when specifying the maximum size as 3 even with estimation");
   }
 }

--- a/integrations/venice-samza/src/test/java/com/linkedin/venice/samza/VeniceSystemProducerTest.java
+++ b/integrations/venice-samza/src/test/java/com/linkedin/venice/samza/VeniceSystemProducerTest.java
@@ -331,7 +331,8 @@ public class VeniceSystemProducerTest {
     canonicalSchemaStrCache.get(KafkaMessageEnvelope.SCHEMA$);
 
     for (int i = 0; i < 100; ++i) {
-      Schema.Field field1 = new Schema.Field("field1", Schema.create(Schema.Type.STRING), "doc", "default");
+      Schema.Field field1 =
+          AvroCompatibilityHelper.createSchemaField("field1", Schema.create(Schema.Type.STRING), "doc", "default");
       Schema schema = Schema.createRecord("test_record" + i, "doc", "namespace", false, Arrays.asList(field1));
       canonicalSchemaStrCache.get(schema);
     }

--- a/integrations/venice-samza/src/test/java/com/linkedin/venice/samza/VeniceSystemProducerTest.java
+++ b/integrations/venice-samza/src/test/java/com/linkedin/venice/samza/VeniceSystemProducerTest.java
@@ -21,7 +21,6 @@ import static org.testng.Assert.fail;
 import com.github.benmanes.caffeine.cache.Caffeine;
 import com.github.benmanes.caffeine.cache.LoadingCache;
 import com.linkedin.avroutil1.compatibility.AvroCompatibilityHelper;
-import com.linkedin.venice.compute.protocol.response.ComputeResponseRecordV1;
 import com.linkedin.venice.controllerapi.ControllerClient;
 import com.linkedin.venice.controllerapi.D2ControllerClient;
 import com.linkedin.venice.controllerapi.MultiSchemaResponse;
@@ -29,13 +28,11 @@ import com.linkedin.venice.controllerapi.StoreResponse;
 import com.linkedin.venice.controllerapi.VersionCreationResponse;
 import com.linkedin.venice.kafka.protocol.KafkaMessageEnvelope;
 import com.linkedin.venice.kafka.protocol.state.PartitionState;
-import com.linkedin.venice.kafka.protocol.state.StoreVersionState;
 import com.linkedin.venice.meta.StoreInfo;
 import com.linkedin.venice.meta.Version;
 import com.linkedin.venice.meta.VersionImpl;
 import com.linkedin.venice.pushmonitor.ExecutionStatus;
 import com.linkedin.venice.pushmonitor.RouterBasedPushMonitor;
-import com.linkedin.venice.read.protocol.response.MultiGetResponseRecordV1;
 import com.linkedin.venice.utils.Pair;
 import com.linkedin.venice.utils.SystemTime;
 import com.linkedin.venice.writer.VeniceWriter;
@@ -322,13 +319,6 @@ public class VeniceSystemProducerTest {
   public void testSchemaCache() {
     final LoadingCache<Schema, String> canonicalSchemaStrCache =
         Caffeine.newBuilder().maximumSize(3).build(AvroCompatibilityHelper::toParsingForm);
-    canonicalSchemaStrCache.get(KafkaMessageEnvelope.SCHEMA$);
-    canonicalSchemaStrCache.get(KafkaMessageEnvelope.SCHEMA$);
-    canonicalSchemaStrCache.get(PartitionState.getClassSchema());
-    canonicalSchemaStrCache.get(StoreVersionState.getClassSchema());
-    canonicalSchemaStrCache.get(MultiGetResponseRecordV1.SCHEMA$);
-    canonicalSchemaStrCache.get(ComputeResponseRecordV1.getClassSchema());
-    canonicalSchemaStrCache.get(KafkaMessageEnvelope.SCHEMA$);
 
     for (int i = 0; i < 100; ++i) {
       Schema.Field field1 =

--- a/internal/venice-client-common/src/main/java/com/linkedin/venice/utils/BoundedHashMap.java
+++ b/internal/venice-client-common/src/main/java/com/linkedin/venice/utils/BoundedHashMap.java
@@ -2,11 +2,13 @@ package com.linkedin.venice.utils;
 
 import java.util.LinkedHashMap;
 import java.util.Map;
+import javax.annotation.concurrent.NotThreadSafe;
 
 
 /**
  * A map implementation with a bounded size.
  */
+@NotThreadSafe
 public class BoundedHashMap<K, V> extends LinkedHashMap<K, V> {
   private static final long serialVersionUID = 1L;
   private static final float DEFAULT_LOAD_FACTOR = 0.75f;


### PR DESCRIPTION
<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat], [protocol]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## Summary, imperative, start upper case, don't end with a period
Use a thread-safe bounded cache for schema parsing
<!--
Describe
- What changes to make and why you are making these changes.
- How are you going to achieve your goal.
- Describe what testings you have done, for example, performance testing etc.

If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->


## How was this PR tested?
CI
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.