### PR TITLE
[server][vpj][controller] Fix ClassNotFoundException in ApacheKafkaProducer when serializers are passed as strings

### DIFF
--- a/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/adapter/kafka/producer/ApacheKafkaProducerConfig.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/adapter/kafka/producer/ApacheKafkaProducerConfig.java
@@ -96,8 +96,8 @@ public class ApacheKafkaProducerConfig {
     }
 
     // Do not remove the following configurations unless you fully understand the implications.
-    producerProperties.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, ByteArraySerializer.class.getName());
-    producerProperties.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, ByteArraySerializer.class.getName());
+    producerProperties.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, ByteArraySerializer.class);
+    producerProperties.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, ByteArraySerializer.class);
   }
 
   /**


### PR DESCRIPTION
<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat], [protocol]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

##  Fix ClassNotFoundException in ApacheKafkaProducer when serializers are passed as strings  


When serializer classes were specified as strings in the producer configuration, Kafka attempted  
to load them using `Thread.currentThread().getContextClassLoader()`, which led to  
ClassNotFoundException issues, particularly in JDK 11 environments. To address this, the producer  
adapter now explicitly loads serializer classes, ensuring they are correctly resolved regardless of  
the class loader context. This change improves reliability and prevents unexpected failures due to  
class loading inconsistencies.   

## How was this PR tested?
CI

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.