### PR TITLE
[test] Add test to ensure Kafka serializer and deserializer configs remain consistent

### DIFF
--- a/internal/venice-common/src/test/java/com/linkedin/venice/pubsub/adapter/kafka/consumer/ApacheKafkaConsumerConfigTest.java
+++ b/internal/venice-common/src/test/java/com/linkedin/venice/pubsub/adapter/kafka/consumer/ApacheKafkaConsumerConfigTest.java
@@ -3,7 +3,11 @@ package com.linkedin.venice.pubsub.adapter.kafka.consumer;
 import static com.linkedin.venice.pubsub.adapter.kafka.producer.ApacheKafkaProducerConfig.KAFKA_BOOTSTRAP_SERVERS;
 import static com.linkedin.venice.pubsub.adapter.kafka.producer.ApacheKafkaProducerConfig.SSL_KAFKA_BOOTSTRAP_SERVERS;
 import static com.linkedin.venice.pubsub.adapter.kafka.producer.ApacheKafkaProducerConfig.SSL_TO_KAFKA_LEGACY;
+import static org.apache.kafka.clients.consumer.ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG;
+import static org.apache.kafka.clients.consumer.ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG;
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNotEquals;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertTrue;
 
@@ -13,6 +17,7 @@ import java.util.Properties;
 import org.apache.kafka.clients.admin.AdminClientConfig;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.common.serialization.ByteArrayDeserializer;
 import org.testng.annotations.Test;
 
 
@@ -72,5 +77,35 @@ public class ApacheKafkaConsumerConfigTest {
     assertNotNull(consumerProps);
     assertTrue(consumerProps.containsKey(ConsumerConfig.RECEIVE_BUFFER_CONFIG));
     assertEquals(consumerProps.get(ConsumerConfig.RECEIVE_BUFFER_CONFIG), "98765");
+  }
+
+  /**
+   * Ensures that the Kafka consumer's key and value serializer configurations remain unchanged.
+   * This test helps catch unintended modifications that could lead to serialization issues in
+   * certain environments. A failure here indicates that the serializer configurations may work
+   * in the test environment but could cause issues in other runtime environments.
+   */
+  @Test
+  public void testKeyAndValueDeserializerConfigConsistency() {
+    Properties props = new Properties();
+    ApacheKafkaConsumerConfig apacheKafkaConsumerConfig =
+        new ApacheKafkaConsumerConfig(new VeniceProperties(props), "test");
+    Properties consumerProps = apacheKafkaConsumerConfig.getConsumerProperties();
+    assertNotNull(consumerProps);
+
+    // Ensure the deserializer is not incorrectly set as a String
+    assertNotEquals(consumerProps.get(KEY_DESERIALIZER_CLASS_CONFIG), ByteArrayDeserializer.class.getName());
+    assertFalse(
+        consumerProps.get(KEY_DESERIALIZER_CLASS_CONFIG) instanceof String,
+        "Key deserializer should not be a string class name");
+
+    assertNotEquals(consumerProps.get(VALUE_DESERIALIZER_CLASS_CONFIG), ByteArrayDeserializer.class.getName());
+    assertFalse(
+        consumerProps.get(VALUE_DESERIALIZER_CLASS_CONFIG) instanceof String,
+        "Value deserializer should not be a string class name");
+
+    // Ensure the deserializer is set as a class
+    assertEquals(consumerProps.get(KEY_DESERIALIZER_CLASS_CONFIG), ByteArrayDeserializer.class);
+    assertEquals(consumerProps.get(VALUE_DESERIALIZER_CLASS_CONFIG), ByteArrayDeserializer.class);
   }
 }

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestServerStorePropertiesEndpoint.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestServerStorePropertiesEndpoint.java
@@ -17,6 +17,7 @@ import com.linkedin.venice.security.SSLFactory;
 import com.linkedin.venice.serializer.FastSerializerDeserializerFactory;
 import com.linkedin.venice.serializer.RecordDeserializer;
 import com.linkedin.venice.utils.SslUtils;
+import com.linkedin.venice.utils.Time;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Random;
@@ -31,6 +32,7 @@ import org.testng.annotations.Test;
 
 public class TestServerStorePropertiesEndpoint extends AbstractClientEndToEndSetup {
   private static final Logger LOGGER = LogManager.getLogger(TestServerStorePropertiesEndpoint.class);
+  private static final int TIME_OUT = 120 * Time.MS_PER_SECOND;
 
   private Random RANDOM;
 

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/integration/utils/VeniceServerWrapper.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/integration/utils/VeniceServerWrapper.java
@@ -5,8 +5,11 @@ import static com.linkedin.davinci.store.rocksdb.RocksDBServerConfig.ROCKSDB_OPT
 import static com.linkedin.davinci.store.rocksdb.RocksDBServerConfig.ROCKSDB_PLAIN_TABLE_FORMAT_ENABLED;
 import static com.linkedin.davinci.store.rocksdb.RocksDBServerConfig.ROCKSDB_RMD_BLOCK_CACHE_SIZE_IN_BYTES;
 import static com.linkedin.venice.ConfigKeys.ADMIN_PORT;
+import static com.linkedin.venice.ConfigKeys.BLOB_TRANSFER_MANAGER_ENABLED;
 import static com.linkedin.venice.ConfigKeys.CLUSTER_DISCOVERY_D2_SERVICE;
 import static com.linkedin.venice.ConfigKeys.DATA_BASE_PATH;
+import static com.linkedin.venice.ConfigKeys.DAVINCI_P2P_BLOB_TRANSFER_CLIENT_PORT;
+import static com.linkedin.venice.ConfigKeys.DAVINCI_P2P_BLOB_TRANSFER_SERVER_PORT;
 import static com.linkedin.venice.ConfigKeys.ENABLE_GRPC_READ_SERVER;
 import static com.linkedin.venice.ConfigKeys.ENABLE_SERVER_ALLOW_LIST;
 import static com.linkedin.venice.ConfigKeys.GRPC_READ_SERVER_PORT;
@@ -213,6 +216,8 @@ public class VeniceServerWrapper extends ProcessWrapper implements MetricsAware 
       boolean isGrpcEnabled = Boolean.parseBoolean(featureProperties.getProperty(ENABLE_GRPC_READ_SERVER, "false"));
       boolean isPlainTableEnabled =
           Boolean.parseBoolean(featureProperties.getProperty(ROCKSDB_PLAIN_TABLE_FORMAT_ENABLED, "false"));
+      boolean isBlobTransferManagerEnabled =
+          Boolean.parseBoolean(featureProperties.getProperty(BLOB_TRANSFER_MANAGER_ENABLED, "false"));
       int numGrpcWorkerThreads = Integer.parseInt(
           featureProperties.getProperty(
               GRPC_SERVER_WORKER_THREAD_COUNT,
@@ -285,6 +290,10 @@ public class VeniceServerWrapper extends ProcessWrapper implements MetricsAware 
         serverPropsBuilder.put(ROCKSDB_OPTIONS_USE_DIRECT_READS, false); // Required by PlainTable format
       }
 
+      if (isBlobTransferManagerEnabled) {
+        serverPropsBuilder.put(DAVINCI_P2P_BLOB_TRANSFER_SERVER_PORT, TestUtils.getFreePort());
+        serverPropsBuilder.put(DAVINCI_P2P_BLOB_TRANSFER_CLIENT_PORT, TestUtils.getFreePort());
+      }
       // Add additional config from PubSubBrokerWrapper to server.properties iff the key is not already present
       Map<String, String> brokerDetails =
           PubSubBrokerWrapper.getBrokerDetailsForClients(Collections.singletonList(pubSubBrokerWrapper));

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/restart/TestRestartServerAfterDeletingSstFilesWithActiveActiveIngestion.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/restart/TestRestartServerAfterDeletingSstFilesWithActiveActiveIngestion.java
@@ -110,74 +110,67 @@ public class TestRestartServerAfterDeletingSstFilesWithActiveActiveIngestion {
   List<Integer> allIncPushKeys = new ArrayList<>(); // all keys ingested via incremental push
   List<Integer> allNonIncPushKeysUntilLastVersion = new ArrayList<>(); // all keys ingested only via batch push
 
-  @BeforeClass
+  @BeforeClass(alwaysRun = true)
   public void setUp() throws Exception {
-    try {
-      String stringSchemaStr = "\"string\"";
-      serializer = new AvroSerializer(AvroCompatibilityHelper.parse(stringSchemaStr));
-      Properties serverProperties = new Properties();
-      serverProperties.setProperty(ConfigKeys.SERVER_PROMOTION_TO_LEADER_REPLICA_DELAY_SECONDS, Long.toString(1));
-      serverProperties.put(ROCKSDB_PLAIN_TABLE_FORMAT_ENABLED, false);
-      serverProperties.put(SERVER_DATABASE_CHECKSUM_VERIFICATION_ENABLED, true);
-      serverProperties.put(PERSISTENCE_TYPE, PersistenceType.ROCKS_DB);
-      serverProperties.setProperty(SERVER_DATABASE_SYNC_BYTES_INTERNAL_FOR_DEFERRED_WRITE_MODE, "300");
-      serverProperties.put(
-          CHILD_DATA_CENTER_KAFKA_URL_PREFIX + "." + DEFAULT_PARENT_DATA_CENTER_REGION_NAME,
-          "localhost:" + TestUtils.getFreePort());
-      VeniceMultiRegionClusterCreateOptions.Builder optionsBuilder =
-          new VeniceMultiRegionClusterCreateOptions.Builder().numberOfRegions(NUMBER_OF_COLOS)
-              .numberOfClusters(1)
-              .numberOfParentControllers(1)
-              .numberOfChildControllers(2)
-              .numberOfServers(numServers)
-              .numberOfRouters(1)
-              .replicationFactor(NUMBER_OF_REPLICAS)
-              .forkServer(false)
-              .serverProperties(serverProperties);
-      multiRegionMultiClusterWrapper =
-          ServiceFactory.getVeniceTwoLayerMultiRegionMultiClusterWrapper(optionsBuilder.build());
+    String stringSchemaStr = "\"string\"";
+    serializer = new AvroSerializer(AvroCompatibilityHelper.parse(stringSchemaStr));
+    Properties serverProperties = new Properties();
+    serverProperties.setProperty(ConfigKeys.SERVER_PROMOTION_TO_LEADER_REPLICA_DELAY_SECONDS, Long.toString(1));
+    serverProperties.put(ROCKSDB_PLAIN_TABLE_FORMAT_ENABLED, false);
+    serverProperties.put(SERVER_DATABASE_CHECKSUM_VERIFICATION_ENABLED, true);
+    serverProperties.put(PERSISTENCE_TYPE, PersistenceType.ROCKS_DB);
+    serverProperties.setProperty(SERVER_DATABASE_SYNC_BYTES_INTERNAL_FOR_DEFERRED_WRITE_MODE, "300");
+    serverProperties.put(
+        CHILD_DATA_CENTER_KAFKA_URL_PREFIX + "." + DEFAULT_PARENT_DATA_CENTER_REGION_NAME,
+        "localhost:" + TestUtils.getFreePort());
+    VeniceMultiRegionClusterCreateOptions.Builder optionsBuilder =
+        new VeniceMultiRegionClusterCreateOptions.Builder().numberOfRegions(NUMBER_OF_COLOS)
+            .numberOfClusters(1)
+            .numberOfParentControllers(1)
+            .numberOfChildControllers(2)
+            .numberOfServers(numServers)
+            .numberOfRouters(1)
+            .replicationFactor(NUMBER_OF_REPLICAS)
+            .forkServer(false)
+            .serverProperties(serverProperties);
+    multiRegionMultiClusterWrapper =
+        ServiceFactory.getVeniceTwoLayerMultiRegionMultiClusterWrapper(optionsBuilder.build());
 
-      List<VeniceMultiClusterWrapper> childDatacenters = multiRegionMultiClusterWrapper.getChildRegions();
-      List<VeniceControllerWrapper> parentControllers = multiRegionMultiClusterWrapper.getParentControllers();
-      String clusterName = "venice-cluster0";
-      for (int colo = 0; colo < NUMBER_OF_COLOS; colo++) {
-        clusterWrappers.add(colo, childDatacenters.get(colo).getClusters().get(clusterName));
-      }
-
-      String parentControllerURLs =
-          parentControllers.stream().map(VeniceControllerWrapper::getControllerUrl).collect(Collectors.joining(","));
-      parentControllerClient = new ControllerClient(clusterName, parentControllerURLs);
-      TestUtils.assertCommand(
-          parentControllerClient.configureActiveActiveReplicationForCluster(
-              true,
-              VeniceUserStoreType.INCREMENTAL_PUSH.toString(),
-              Optional.empty()));
-      // create an active-active enabled store
-      File inputDir = getTempDataDirectory();
-      Schema recordSchema = TestWriteUtils.writeSimpleAvroFileWithStringToStringSchema(inputDir);
-      String inputDirPath = "file:" + inputDir.getAbsolutePath();
-      Properties props =
-          IntegrationTestPushUtils.defaultVPJProps(multiRegionMultiClusterWrapper, inputDirPath, STORE_NAME);
-      String keySchemaStr = recordSchema.getField(DEFAULT_KEY_FIELD_PROP).schema().toString();
-      String valueSchemaStr = recordSchema.getField(DEFAULT_VALUE_FIELD_PROP).schema().toString();
-      UpdateStoreQueryParams storeParms = new UpdateStoreQueryParams().setActiveActiveReplicationEnabled(true)
-          .setHybridRewindSeconds(500)
-          .setHybridOffsetLagThreshold(2)
-          .setNativeReplicationEnabled(true)
-          .setBackupVersionRetentionMs(1)
-          .setIncrementalPushEnabled(true)
-          .setPartitionCount(NUMBER_OF_PARTITIONS)
-          .setReplicationFactor(NUMBER_OF_REPLICAS);
-      createStoreForJob(clusterName, keySchemaStr, valueSchemaStr, props, storeParms).close();
-    } catch (Exception e) {
-      Utils.closeQuietlyWithErrorLogged(parentControllerClient);
-      Utils.closeQuietlyWithErrorLogged(multiRegionMultiClusterWrapper);
-      parentControllerClient = null;
-      multiRegionMultiClusterWrapper = null;
+    List<VeniceMultiClusterWrapper> childDatacenters = multiRegionMultiClusterWrapper.getChildRegions();
+    List<VeniceControllerWrapper> parentControllers = multiRegionMultiClusterWrapper.getParentControllers();
+    String clusterName = "venice-cluster0";
+    for (int colo = 0; colo < NUMBER_OF_COLOS; colo++) {
+      clusterWrappers.add(colo, childDatacenters.get(colo).getClusters().get(clusterName));
     }
+
+    String parentControllerURLs =
+        parentControllers.stream().map(VeniceControllerWrapper::getControllerUrl).collect(Collectors.joining(","));
+    parentControllerClient = new ControllerClient(clusterName, parentControllerURLs);
+    TestUtils.assertCommand(
+        parentControllerClient.configureActiveActiveReplicationForCluster(
+            true,
+            VeniceUserStoreType.INCREMENTAL_PUSH.toString(),
+            Optional.empty()));
+    // create an active-active enabled store
+    File inputDir = getTempDataDirectory();
+    Schema recordSchema = TestWriteUtils.writeSimpleAvroFileWithStringToStringSchema(inputDir);
+    String inputDirPath = "file:" + inputDir.getAbsolutePath();
+    Properties props =
+        IntegrationTestPushUtils.defaultVPJProps(multiRegionMultiClusterWrapper, inputDirPath, STORE_NAME);
+    String keySchemaStr = recordSchema.getField(DEFAULT_KEY_FIELD_PROP).schema().toString();
+    String valueSchemaStr = recordSchema.getField(DEFAULT_VALUE_FIELD_PROP).schema().toString();
+    UpdateStoreQueryParams storeParms = new UpdateStoreQueryParams().setActiveActiveReplicationEnabled(true)
+        .setHybridRewindSeconds(500)
+        .setHybridOffsetLagThreshold(2)
+        .setNativeReplicationEnabled(true)
+        .setBackupVersionRetentionMs(1)
+        .setIncrementalPushEnabled(true)
+        .setPartitionCount(NUMBER_OF_PARTITIONS)
+        .setReplicationFactor(NUMBER_OF_REPLICAS);
+    createStoreForJob(clusterName, keySchemaStr, valueSchemaStr, props, storeParms).close();
   }
 
-  @AfterClass
+  @AfterClass(alwaysRun = true)
   public void cleanUp() {
     if (parentControllerClient != null) {
       parentControllerClient.disableAndDeleteStore(STORE_NAME);


### PR DESCRIPTION

<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat], [protocol]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## Add test to ensure Kafka serializer and deserializer configs remain consistent

This test verifies that the key and value serializer and deserializer configurations for the Kafka 
clients are correctly set as `Class` objects rather than string class names. It helps catch  
unintended modifications that could lead to serialization issues in specific environments,   
even if tests pass in a controlled CI environment. A failure indicates a misconfiguration that   
could cause incompatibilities due to class loading behavior differences across JVMs.  

## How was this PR tested?
UT
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.