### PR TITLE
[server] Global RT DIV: Leader

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTask.java
@@ -4082,4 +4082,8 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
       return supplier.get();
     }
   }
+
+  protected void updateOffsetMetadataAndSyncOffsetForLeaders(PartitionConsumptionState pcs) {
+    updateOffsetMetadataAndSyncOffset(kafkaDataIntegrityValidatorForLeaders, pcs);
+  }
 }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTask.java
@@ -3481,7 +3481,25 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
                   GlobalRtDivState divState =
                       new GlobalRtDivState(kafkaUrl, producerStates, consumerRecord.getOffset());
                   byte[] valueBytes = ByteUtils.extractByteArray(serializer.serialize(divState));
-                  veniceWriter.get().sendGlobalRtDivMessage(partition, GLOBAL_RT_DIV_KEY.getBytes(), valueBytes);
+                  // veniceWriter.get().sendGlobalRtDivMessage(partition, GLOBAL_RT_DIV_KEY.getBytes(), valueBytes);
+                  int dummyValueSchemaId = 0;
+                  LeaderProducerCallback divCallback = null;// createProducerCallback(consumerRecord,
+                                                            // partitionConsumptionState, leaderProducedRecordContext,
+                                                            // partition, kafkaUrl, beforeProcessingRecordTimestampNs);
+                  veniceWriter.get()
+                      .put(
+                          GLOBAL_RT_DIV_KEY.getBytes(),
+                          valueBytes,
+                          partition,
+                          dummyValueSchemaId,
+                          divCallback,
+                          leaderMetadataWrapper,
+                          APP_DEFAULT_LOGICAL_TS,
+                          null,
+                          null,
+                          null,
+                          false);
+                  // requires pubsubmessage
                   // updateOffsetMetadataAndSyncOffsetForLeaders(partitionConsumptionState);
                   // syncOffset(partitionConsumptionState, record, leaderProducedRecordContext);
                 }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTask.java
@@ -2405,6 +2405,12 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
           partitionConsumptionState.getVeniceWriterLazyRef().ifPresent(vw -> vw.flush());
           partitionConsumptionState.setVeniceWriterLazyRef(veniceWriterForRealTime);
         }
+
+        if (isGlobalRtDivEnabled() && consumerRecord.getTopicPartition().getPubSubTopic().isRealTime()
+            && msgType != MessageType.GLOBAL_RT_DIV) {
+          kafkaDataIntegrityValidatorForLeaders.updateLatestConsumedVtOffset(partition, consumerRecord.getOffset());
+        }
+
         /**
          * Materialized view need to produce to the corresponding view topic for the batch portion of the data. This is
          * achieved in the following ways:

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTask.java
@@ -3603,6 +3603,11 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
     final long offset = previousMessage.getPosition().getNumericOffset();
     GlobalRtDivState globalRtDiv = new GlobalRtDivState(brokerUrl, rtDiv, offset, emptyBuffer);
     byte[] valueBytes = ByteUtils.extractByteArray(serializer.serialize(globalRtDiv));
+    try {
+      valueBytes = compressor.get().compress(valueBytes);
+    } catch (IOException e) {
+      LOGGER.error("Failed to compress GlobalRtDivState. Will proceed without {} compression", compressionStrategy, e);
+    }
 
     // Create PubSubMessage for the LeaderProducerCallback to enqueue the RT + VT DIV to the drainer
     KafkaKey divKey = new KafkaKey(MessageType.GLOBAL_RT_DIV, keyBytes);

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTask.java
@@ -4174,8 +4174,4 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
       return supplier.get();
     }
   }
-
-  protected void updateOffsetMetadataAndSyncOffsetForLeaders(PartitionConsumptionState pcs) {
-    updateOffsetMetadataAndSyncOffset(kafkaDataIntegrityValidatorForLeaders, pcs);
-  }
 }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderProducerCallback.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderProducerCallback.java
@@ -266,7 +266,6 @@ public class LeaderProducerCallback implements ChunkAwareCallback {
   }
 
   private void recordProducerStats(int producedRecordSize, int producedRecordNum) {
-    // TODO: skip?
     ingestionTask.getVersionIngestionStats()
         .recordLeaderProduced(
             ingestionTask.getStoreName(),

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderProducerCallback.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderProducerCallback.java
@@ -266,6 +266,7 @@ public class LeaderProducerCallback implements ChunkAwareCallback {
   }
 
   private void recordProducerStats(int producedRecordSize, int producedRecordNum) {
+    // TODO: skip?
     ingestionTask.getVersionIngestionStats()
         .recordLeaderProduced(
             ingestionTask.getStoreName(),

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
@@ -2731,7 +2731,7 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
     // The Global RT DIV is sent on a per-broker basis, so divide the size limit by the number of brokers
     final long syncBytesInterval = getSyncBytesInterval(pcs) / getConsumedBytesSinceLastSync().size();
     boolean shouldSync = false;
-    if (!record.getKey().isControlMessage()) { // TODO: should the control message logic remain?
+    if (!record.getKey().isControlMessage()) {
       shouldSync = (syncBytesInterval > 0 && (getConsumedBytesSinceLastSync().get(kafkaUrl) >= syncBytesInterval));
     }
     return shouldSync;

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
@@ -2723,10 +2723,7 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
     // No Op
   }
 
-  protected boolean shouldSendGlobalRtDiv(
-      PubSubMessage<KafkaKey, KafkaMessageEnvelope, Long> record,
-      PartitionConsumptionState pcs,
-      String kafkaUrl) {
+  protected boolean shouldSendGlobalRtDiv(DefaultPubSubMessage record, PartitionConsumptionState pcs, String kafkaUrl) {
     if (!isGlobalRtDivEnabled()) {
       return false;
     }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
@@ -2732,7 +2732,7 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
     final long syncBytesInterval = getSyncBytesInterval(pcs) / getConsumedBytesSinceLastSync().size();
     boolean shouldSync = false;
     if (!record.getKey().isControlMessage()) {
-      shouldSync = (syncBytesInterval > 0 && (getConsumedBytesSinceLastSync().get(kafkaUrl) >= syncBytesInterval));
+      shouldSync = syncBytesInterval > 0 && (getConsumedBytesSinceLastSync().get(kafkaUrl) >= syncBytesInterval);
     }
     return shouldSync;
   }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
@@ -1310,11 +1310,6 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
           beforeProcessingBatchRecordsTimestampMs,
           metricsEnabled,
           elapsedTimeForPuttingIntoQueue);
-
-      if (shouldSyncOffset(partitionConsumptionState, record, null, false)) {
-        updateOffsetMetadataAndSyncOffsetForLeaders(partitionConsumptionState);
-        // syncOffset(partitionConsumptionState, record, leaderProducedRecordContext);
-      }
     }
 
     /**
@@ -2736,7 +2731,7 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
    * 1. Every ControlMessage
    * 2. Record count based strategy, which doesn't work well for stores with very small key/value pairs.
    */
-  private boolean shouldSyncOffset(
+  boolean shouldSyncOffset(
       PartitionConsumptionState pcs,
       DefaultPubSubMessage record,
       LeaderProducedRecordContext leaderProducedRecordContext,
@@ -2769,7 +2764,7 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
       if (controlMessageType != START_OF_SEGMENT && controlMessageType != ControlMessageType.END_OF_SEGMENT) {
         syncOffset = true;
       }
-    } else {
+    } else { // TODO: make atomic / per-colo broker map
       syncOffset = (syncBytesInterval > 0 && (pcs.getProcessedRecordSizeSinceLastSync() >= syncBytesInterval));
     }
     return syncOffset;

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
@@ -1833,12 +1833,6 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
   }
 
   protected void updateOffsetMetadataAndSyncOffset(PartitionConsumptionState pcs) {
-    updateOffsetMetadataAndSyncOffset(kafkaDataIntegrityValidator, pcs);
-  }
-
-  protected abstract void updateOffsetMetadataAndSyncOffsetForLeaders(PartitionConsumptionState pcs);
-
-  protected void updateOffsetMetadataAndSyncOffset(KafkaDataIntegrityValidator div, PartitionConsumptionState pcs) {
     /**
      * Offset metadata and producer states must be updated at the same time in OffsetRecord; otherwise, one checkpoint
      * could be ahead of the other.
@@ -1851,7 +1845,8 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
      * consumer DIV which resides in the consumer thread and then gradually retire the use of drainer DIV.
      * Keep drainer DIV the way as is today (containing both rt and vt messages).
      */
-    div.updateOffsetRecordForPartition(PartitionTracker.VERSION_TOPIC, pcs.getPartition(), pcs.getOffsetRecord());
+    this.kafkaDataIntegrityValidator
+        .updateOffsetRecordForPartition(PartitionTracker.VERSION_TOPIC, pcs.getPartition(), pcs.getOffsetRecord());
     // update the offset metadata in the OffsetRecord.
     updateOffsetMetadataInOffsetRecord(pcs);
     syncOffset(kafkaVersionTopic, pcs);

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/validation/DivSnapshot.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/validation/DivSnapshot.java
@@ -1,0 +1,15 @@
+package com.linkedin.davinci.validation;
+
+/**
+ * Wrapper class for {@link PartitionTracker} with latestConsumedRtOffset (LCRO) for the ConsumptionTask to enqueue
+ * to the Drainer. Contains the VT DIV (Segments) + LCVO and RT DIV (Segments) + LCRO.
+ */
+public class DivSnapshot {
+  public PartitionTracker partitionTracker;
+  public long latestConsumedRtOffset; // LCVO is in PartitionTracker
+
+  public DivSnapshot(PartitionTracker partitionTracker, long latestConsumedRtOffset) {
+    this.partitionTracker = partitionTracker;
+    this.latestConsumedRtOffset = latestConsumedRtOffset;
+  }
+}

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/validation/DivSnapshot.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/validation/DivSnapshot.java
@@ -5,8 +5,8 @@ package com.linkedin.davinci.validation;
  * to the Drainer. Contains the VT DIV (Segments) + LCVO and RT DIV (Segments) + LCRO.
  */
 public class DivSnapshot {
-  private PartitionTracker partitionTracker;
-  private long latestConsumedRtOffset; // LCVO is in PartitionTracker
+  private final PartitionTracker partitionTracker;
+  private final long latestConsumedRtOffset; // LCVO is in PartitionTracker
 
   public DivSnapshot(PartitionTracker partitionTracker, long latestConsumedRtOffset) {
     this.partitionTracker = partitionTracker;

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/validation/DivSnapshot.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/validation/DivSnapshot.java
@@ -5,11 +5,19 @@ package com.linkedin.davinci.validation;
  * to the Drainer. Contains the VT DIV (Segments) + LCVO and RT DIV (Segments) + LCRO.
  */
 public class DivSnapshot {
-  public PartitionTracker partitionTracker;
-  public long latestConsumedRtOffset; // LCVO is in PartitionTracker
+  private PartitionTracker partitionTracker;
+  private long latestConsumedRtOffset; // LCVO is in PartitionTracker
 
   public DivSnapshot(PartitionTracker partitionTracker, long latestConsumedRtOffset) {
     this.partitionTracker = partitionTracker;
     this.latestConsumedRtOffset = latestConsumedRtOffset;
+  }
+
+  public PartitionTracker getPartitionTracker() {
+    return partitionTracker;
+  }
+
+  public long getLatestConsumedRtOffset() {
+    return latestConsumedRtOffset;
   }
 }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/validation/KafkaDataIntegrityValidator.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/validation/KafkaDataIntegrityValidator.java
@@ -117,11 +117,12 @@ public class KafkaDataIntegrityValidator {
    */
   // TODO: does this need synchronized because it can be called from multiple consumer threads?
   public PartitionTracker cloneProducerStates(int partition, String brokerUrl) {
-    PartitionTracker partitionTracker = partitionTrackerCreator.apply(partition);
-    if (this.partitionTrackers.contains(partition)) {
-      this.partitionTrackers.get(partition).cloneProducerStates(partitionTracker, brokerUrl); // for a single broker
+    PartitionTracker clonedPartitionTracker = partitionTrackerCreator.apply(partition);
+    final PartitionTracker existingPartitionTracker = this.partitionTrackers.get(partition);
+    if (existingPartitionTracker != null) {
+      existingPartitionTracker.cloneProducerStates(clonedPartitionTracker, brokerUrl); // for a single broker
     }
-    return partitionTracker;
+    return clonedPartitionTracker;
   }
 
   /**
@@ -148,7 +149,8 @@ public class KafkaDataIntegrityValidator {
   }
 
   public void updateLatestConsumedVtOffset(int partition, long offset) {
-    partitionTrackers.get(partition).updateLatestConsumedVtOffset(offset); // TODO: should null check be added here?
+    PartitionTracker partitionTracker = registerPartition(partition);
+    partitionTracker.updateLatestConsumedVtOffset(offset); // TODO: should null check be added here?
   }
 
   /**

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/validation/KafkaDataIntegrityValidator.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/validation/KafkaDataIntegrityValidator.java
@@ -147,6 +147,10 @@ public class KafkaDataIntegrityValidator {
         this.kafkaLogCompactionDelayInMs);
   }
 
+  public void updateLatestConsumedVtOffset(int partition, long offset) {
+    partitionTrackers.get(partition).updateLatestConsumedVtOffset(offset); // TODO: should null check be added here?
+  }
+
   /**
    * N.B. Intended for tests only
    *

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/validation/KafkaDataIntegrityValidator.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/validation/KafkaDataIntegrityValidator.java
@@ -115,7 +115,6 @@ public class KafkaDataIntegrityValidator {
   /**
    * Returns the RT DIV state for a given partition and broker URL, and the VT DIV state
    */
-  // TODO: does this need synchronized because it can be called from multiple consumer threads?
   public PartitionTracker cloneProducerStates(int partition, String brokerUrl) {
     PartitionTracker clonedPartitionTracker = partitionTrackerCreator.apply(partition);
     final PartitionTracker existingPartitionTracker = this.partitionTrackers.get(partition);
@@ -150,7 +149,7 @@ public class KafkaDataIntegrityValidator {
 
   public void updateLatestConsumedVtOffset(int partition, long offset) {
     PartitionTracker partitionTracker = registerPartition(partition);
-    partitionTracker.updateLatestConsumedVtOffset(offset); // TODO: should null check be added here?
+    partitionTracker.updateLatestConsumedVtOffset(offset);
   }
 
   /**

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/validation/KafkaDataIntegrityValidator.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/validation/KafkaDataIntegrityValidator.java
@@ -112,6 +112,12 @@ public class KafkaDataIntegrityValidator {
     this.partitionTrackers.get(partition).cloneProducerStates(destPartitionTracker);
   }
 
+  public PartitionTracker cloneProducerStates(int partition) {
+    PartitionTracker partitionTracker = partitionTrackerCreator.apply(partition);
+    this.partitionTrackers.get(partition).cloneProducerStates(partitionTracker);
+    return partitionTracker;
+  }
+
   /**
    * Only check for missing sequence number; segment starting from a positive sequence number is acceptable considering
    * real-time buffer replay would start in the middle of a segment; checksum is also ignored for the same reason.

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/validation/KafkaDataIntegrityValidator.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/validation/KafkaDataIntegrityValidator.java
@@ -115,9 +115,12 @@ public class KafkaDataIntegrityValidator {
   /**
    * Returns the RT DIV state for a given partition and broker URL, and the VT DIV state
    */
+  // TODO: does this need synchronized because it can be called from multiple consumer threads?
   public PartitionTracker cloneProducerStates(int partition, String brokerUrl) {
     PartitionTracker partitionTracker = partitionTrackerCreator.apply(partition);
-    this.partitionTrackers.get(partition).cloneProducerStates(partitionTracker, brokerUrl); // single broker
+    if (this.partitionTrackers.contains(partition)) {
+      this.partitionTrackers.get(partition).cloneProducerStates(partitionTracker, brokerUrl); // for a single broker
+    }
     return partitionTracker;
   }
 

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/validation/KafkaDataIntegrityValidator.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/validation/KafkaDataIntegrityValidator.java
@@ -109,12 +109,15 @@ public class KafkaDataIntegrityValidator {
 
   public void cloneProducerStates(int partition, KafkaDataIntegrityValidator newValidator) {
     PartitionTracker destPartitionTracker = newValidator.registerPartition(partition);
-    this.partitionTrackers.get(partition).cloneProducerStates(destPartitionTracker);
+    this.partitionTrackers.get(partition).cloneProducerStates(destPartitionTracker, null);
   }
 
-  public PartitionTracker cloneProducerStates(int partition) {
+  /**
+   * Returns the RT DIV state for a given partition and broker URL, and the VT DIV state
+   */
+  public PartitionTracker cloneProducerStates(int partition, String brokerUrl) {
     PartitionTracker partitionTracker = partitionTrackerCreator.apply(partition);
-    this.partitionTrackers.get(partition).cloneProducerStates(partitionTracker);
+    this.partitionTrackers.get(partition).cloneProducerStates(partitionTracker, brokerUrl); // single broker
     return partitionTracker;
   }
 

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/validation/PartitionTracker.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/validation/PartitionTracker.java
@@ -75,7 +75,7 @@ public class PartitionTracker {
   // TODO: clear vtSegments
   private final VeniceConcurrentHashMap<GUID, Segment> vtSegments = new VeniceConcurrentHashMap<>();
   /**
-   * The equivalent for RT is not stored. The
+   * The equivalent for RT is not stored. It's the instantaneous offset when a DIV sync is triggered.
    */
   private long latestConsumedVtOffset;
 

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/validation/PartitionTracker.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/validation/PartitionTracker.java
@@ -137,6 +137,11 @@ public class PartitionTracker {
     }
   }
 
+  public ProducerPartitionState getPartitionState(TopicType type, GUID guid) {
+    Segment segment = getSegments(type).get(guid);
+    return (segment != null) ? segment.toProducerPartitionState() : new ProducerPartitionState();
+  }
+
   private void setSegment(TopicType type, GUID guid, Segment segment) {
     Segment previousSegment = getSegments(type).put(guid, segment);
     if (previousSegment == null) {

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/validation/PartitionTracker.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/validation/PartitionTracker.java
@@ -73,6 +73,9 @@ public class PartitionTracker {
   private final String topicName;
   private final int partition;
   // TODO: clear vtSegments
+  /**
+   * There should only be one {@link ConsumptionTask} for VT, so there shouldn't need to be any locking.
+   */
   private final VeniceConcurrentHashMap<GUID, Segment> vtSegments = new VeniceConcurrentHashMap<>();
   /**
    * The equivalent for RT is not stored. It's the instantaneous offset when a DIV sync is triggered.
@@ -81,6 +84,7 @@ public class PartitionTracker {
 
   /**
    * rtSegments is a map of source broker URL to a map of GUID to Segment.
+   * There should only be one {@link ConsumptionTask} for each broker URL, so there shouldn't need to be any locking.
    */
   private final VeniceConcurrentHashMap<String, VeniceConcurrentHashMap<GUID, Segment>> rtSegments =
       new VeniceConcurrentHashMap<>();

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTaskTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTaskTest.java
@@ -438,7 +438,7 @@ public class LeaderFollowerStoreIngestionTaskTest {
         serializer.deserialize(valueBytes, AvroProtocolDefinition.GLOBAL_RT_DIV_STATE.getCurrentProtocolVersion());
     assertNotNull(globalRtDiv);
 
-    // Verify the callback has PartitionTracker (VT + RT DIV)
+    // Verify the callback has DivSnapshot (VT + RT DIV)
     LeaderProducerCallback callback = callbackArgumentCaptor.getValue();
     PubSubMessage<KafkaKey, KafkaMessageEnvelope, Long> callbackPayload = callback.getSourceConsumerRecord();
     assertEquals(callbackPayload.getKey().getKey(), keyBytes);

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTaskTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTaskTest.java
@@ -1,6 +1,7 @@
 package com.linkedin.davinci.kafka.consumer;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyDouble;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyLong;
@@ -48,6 +49,7 @@ import com.linkedin.venice.partitioner.DefaultVenicePartitioner;
 import com.linkedin.venice.pubsub.PubSubTopicRepository;
 import com.linkedin.venice.pubsub.adapter.kafka.ApacheKafkaOffsetPosition;
 import com.linkedin.venice.pubsub.api.DefaultPubSubMessage;
+import com.linkedin.venice.pubsub.api.PubSubPosition;
 import com.linkedin.venice.pubsub.api.PubSubTopic;
 import com.linkedin.venice.pubsub.api.PubSubTopicPartition;
 import com.linkedin.venice.schema.SchemaEntry;
@@ -397,10 +399,12 @@ public class LeaderFollowerStoreIngestionTaskTest {
     int partition = 1;
     long offset = 3L;
     long messageTime = 5;
-    PubSubMessage mockMessage = mock(PubSubMessage.class);
+    DefaultPubSubMessage mockMessage = mock(DefaultPubSubMessage.class);
     PubSubTopicPartition mockTopicPartition = mock(PubSubTopicPartition.class);
+    PubSubPosition position = mock(PubSubPosition.class);
     doReturn(partition).when(mockTopicPartition).getPartitionNumber();
-    doReturn(offset).when(mockMessage).getOffset();
+    doReturn(offset).when(position).getNumericOffset();
+    doReturn(position).when(mockMessage).getOffset();
     doReturn(mockTopicPartition).when(mockMessage).getTopicPartition();
     doReturn(messageTime).when(mockMessage).getPubSubMessageTime();
     VeniceWriter mockWriter = mock(VeniceWriter.class);
@@ -440,7 +444,7 @@ public class LeaderFollowerStoreIngestionTaskTest {
 
     // Verify the callback has DivSnapshot (VT + RT DIV)
     LeaderProducerCallback callback = callbackArgumentCaptor.getValue();
-    PubSubMessage<KafkaKey, KafkaMessageEnvelope, Long> callbackPayload = callback.getSourceConsumerRecord();
+    DefaultPubSubMessage callbackPayload = callback.getSourceConsumerRecord();
     assertEquals(callbackPayload.getKey().getKey(), keyBytes);
     assertEquals(callbackPayload.getKey().getKeyHeaderByte(), MessageType.GLOBAL_RT_DIV.getKeyHeaderByte());
     assertEquals(callbackPayload.getValue().getMessageType(), MessageType.PUT.getValue());

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTaskTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTaskTest.java
@@ -446,6 +446,9 @@ public class LeaderFollowerStoreIngestionTaskTest {
     assertEquals(callbackPayload.getValue().getMessageType(), MessageType.PUT.getValue());
     assertEquals(callbackPayload.getPartition(), partition);
     assertTrue(callbackPayload.getValue().payloadUnion instanceof DivSnapshot); // direct access bc the KME is a mock
+    DivSnapshot divSnapshot = (DivSnapshot) callbackPayload.getValue().payloadUnion;
+    assertEquals(divSnapshot.getLatestConsumedRtOffset(), offset);
+    assertEquals(divSnapshot.getPartitionTracker().getPartition(), partition);
   }
 
   @Test

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTaskTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTaskTest.java
@@ -5600,7 +5600,7 @@ public abstract class StoreIngestionTaskTest {
     doCallRealMethod().when(storeIngestionTask).shouldSendGlobalRtDiv(any(), any(), any());
     doReturn(isGlobalRtDivEnabled).when(storeIngestionTask).isGlobalRtDivEnabled();
     doReturn(1L).when(storeIngestionTask).getSyncBytesInterval(any()); // just needs to be greater than 0
-    PubSubMessage message = mock(PubSubMessage.class);
+    DefaultPubSubMessage message = mock(DefaultPubSubMessage.class);
     KafkaKey key = mock(KafkaKey.class);
     doReturn(false).when(key).isControlMessage();
     doReturn(key).when(message).getKey();

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTaskTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTaskTest.java
@@ -5607,11 +5607,11 @@ public abstract class StoreIngestionTaskTest {
     PartitionConsumptionState pcs = mock(PartitionConsumptionState.class);
     doReturn(100L).when(pcs).getProcessedRecordSizeSinceLastSync(); // just needs to be greater than syncBytesInterval
     VeniceConcurrentHashMap<String, Long> lastProcessedMap = new VeniceConcurrentHashMap<>();
-    String kafkaUrl = "localhost:1234";
-    lastProcessedMap.put(kafkaUrl, 100L); // just needs to be greater than syncBytesInterval
-    doReturn(lastProcessedMap).when(storeIngestionTask).getProcessedRecordSizeSinceLastSync();
+    String brokerUrl = "localhost:1234";
+    lastProcessedMap.put(brokerUrl, 100L); // just needs to be greater than syncBytesInterval
+    doReturn(lastProcessedMap).when(storeIngestionTask).getConsumedBytesSinceLastSync();
 
-    boolean shouldSendGlobalRtDiv = storeIngestionTask.shouldSendGlobalRtDiv(message, pcs, kafkaUrl);
+    boolean shouldSendGlobalRtDiv = storeIngestionTask.shouldSendGlobalRtDiv(message, pcs, brokerUrl);
     boolean shouldSyncOffset = storeIngestionTask.shouldSyncOffset(pcs, message, null);
 
     // Feature flag should stop drainer from syncing OffsetRecord, and ConsumptionTask should send Global RT DIV

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTaskTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTaskTest.java
@@ -209,6 +209,7 @@ import com.linkedin.venice.utils.TestUtils;
 import com.linkedin.venice.utils.Time;
 import com.linkedin.venice.utils.Utils;
 import com.linkedin.venice.utils.VeniceProperties;
+import com.linkedin.venice.utils.concurrent.VeniceConcurrentHashMap;
 import com.linkedin.venice.utils.lazy.Lazy;
 import com.linkedin.venice.utils.pools.LandFillObjectPool;
 import com.linkedin.venice.writer.LeaderCompleteState;
@@ -5585,6 +5586,40 @@ public abstract class StoreIngestionTaskTest {
     DefaultPubSubMessage rtRecord =
         new ImmutablePubSubMessage(key, value, rtPartition, ApacheKafkaOffsetPosition.of(0), 0, 0);
     assertFalse(ingestionTask.shouldProcessRecord(rtRecord), "RT DIV from RT should not be processed");
+  }
+
+  /**
+   * Tests that the {@link StoreIngestionTask#isGlobalRtDivEnabled} feature flag stops the drainer from syncing
+   * OffsetRecord from {@link StoreIngestionTask#updateOffsetMetadataAndSyncOffset}, and the {@link ConsumptionTask}
+   * should send Global RT DIV in {@link LeaderFollowerStoreIngestionTask#sendGlobalRtDivMessage} instead.
+   */
+  @Test(dataProvider = "True-and-False", dataProviderClass = DataProviderUtils.class)
+  public void testShouldSendGlobalRtDiv(boolean isGlobalRtDivEnabled) {
+    StoreIngestionTask storeIngestionTask = mock(StoreIngestionTask.class);
+    doCallRealMethod().when(storeIngestionTask).shouldSyncOffset(any(), any(), any());
+    doCallRealMethod().when(storeIngestionTask).shouldSendGlobalRtDiv(any(), any(), any());
+    doReturn(isGlobalRtDivEnabled).when(storeIngestionTask).isGlobalRtDivEnabled();
+    doReturn(1L).when(storeIngestionTask).getSyncBytesInterval(any()); // just needs to be greater than 0
+    PubSubMessage message = mock(PubSubMessage.class);
+    KafkaKey key = mock(KafkaKey.class);
+    doReturn(false).when(key).isControlMessage();
+    doReturn(key).when(message).getKey();
+    PartitionConsumptionState pcs = mock(PartitionConsumptionState.class);
+    doReturn(100L).when(pcs).getProcessedRecordSizeSinceLastSync(); // just needs to be greater than syncBytesInterval
+    VeniceConcurrentHashMap<String, Long> lastProcessedMap = new VeniceConcurrentHashMap<>();
+    String kafkaUrl = "localhost:1234";
+    lastProcessedMap.put(kafkaUrl, 100L); // just needs to be greater than syncBytesInterval
+    doReturn(lastProcessedMap).when(storeIngestionTask).getProcessedRecordSizeSinceLastSync();
+
+    boolean shouldSendGlobalRtDiv = storeIngestionTask.shouldSendGlobalRtDiv(message, pcs, kafkaUrl);
+    boolean shouldSyncOffset = storeIngestionTask.shouldSyncOffset(pcs, message, null);
+
+    // Feature flag should stop drainer from syncing OffsetRecord, and ConsumptionTask should send Global RT DIV
+    if (isGlobalRtDivEnabled) {
+      assertTrue(shouldSendGlobalRtDiv && !shouldSyncOffset);
+    } else {
+      assertTrue(shouldSyncOffset && !shouldSendGlobalRtDiv);
+    }
   }
 
   @Test

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTaskTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTaskTest.java
@@ -5585,7 +5585,6 @@ public abstract class StoreIngestionTaskTest {
     DefaultPubSubMessage rtRecord =
         new ImmutablePubSubMessage(key, value, rtPartition, ApacheKafkaOffsetPosition.of(0), 0, 0);
     assertFalse(ingestionTask.shouldProcessRecord(rtRecord), "RT DIV from RT should not be processed");
-
   }
 
   @Test

--- a/internal/venice-common/src/main/java/com/linkedin/venice/kafka/validation/Segment.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/kafka/validation/Segment.java
@@ -410,6 +410,20 @@ public class Segment {
     return deduped;
   }
 
+  public ProducerPartitionState toProducerPartitionState() {
+    ProducerPartitionState pps = new ProducerPartitionState();
+    pps.segmentNumber = segmentNumber;
+    pps.segmentStatus = getStatus().getValue();
+    pps.messageSequenceNumber = sequenceNumber;
+    pps.checksumState = ByteBuffer.wrap(checkSum.getEncodedState());
+    pps.checksumType = checkSum.getType().getValue();
+    pps.aggregates = aggregates;
+    pps.debugInfo = debugInfo;
+    pps.messageTimestamp = lastRecordProducerTimestamp;
+    pps.isRegistered = registered;
+    return pps;
+  }
+
   // Only for testing.
   public void setStarted(boolean started) {
     this.started = started;

--- a/internal/venice-common/src/main/java/com/linkedin/venice/writer/ComplexVeniceWriter.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/writer/ComplexVeniceWriter.java
@@ -239,7 +239,8 @@ public class ComplexVeniceWriter<K, V, U> extends VeniceWriter<K, V, U> {
         APP_DEFAULT_LOGICAL_TS,
         putMetadata,
         null,
-        null);
+        null,
+        true);
   }
 
   public String getViewName() {

--- a/internal/venice-common/src/main/java/com/linkedin/venice/writer/VeniceWriter.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/writer/VeniceWriter.java
@@ -2196,7 +2196,7 @@ public class VeniceWriter<K, V, U> extends AbstractVeniceWriter<K, V, U> {
    * @param messageType an instance of the {@link MessageType} enum.
    * @return A {@link KafkaMessageEnvelope} for producing into Kafka
    */
-  protected KafkaMessageEnvelope getKafkaMessageEnvelope(
+  public KafkaMessageEnvelope getKafkaMessageEnvelope(
       MessageType messageType,
       boolean isEndOfSegment,
       int partition,

--- a/internal/venice-common/src/test/java/com/linkedin/venice/writer/VeniceWriterUnitTest.java
+++ b/internal/venice-common/src/test/java/com/linkedin/venice/writer/VeniceWriterUnitTest.java
@@ -687,8 +687,8 @@ public class VeniceWriterUnitTest {
     ChunkedValueManifestSerializer manifestSerializer = new ChunkedValueManifestSerializer(true);
     final VeniceKafkaSerializer<Object> serializer = new VeniceAvroKafkaSerializer(TestWriteUtils.STRING_SCHEMA);
     final VeniceWriterOptions options = new VeniceWriterOptions.Builder("testTopic").setPartitionCount(1)
-        .setKeySerializer(serializer)
-        .setValueSerializer(serializer)
+        .setKeyPayloadSerializer(serializer)
+        .setValuePayloadSerializer(serializer)
         .setChunkingEnabled(true)
         .setMaxRecordSizeBytes(maxRecordSizeBytes)
         .build();

--- a/internal/venice-common/src/test/java/com/linkedin/venice/writer/VeniceWriterUnitTest.java
+++ b/internal/venice-common/src/test/java/com/linkedin/venice/writer/VeniceWriterUnitTest.java
@@ -15,6 +15,7 @@ import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.longThat;
 import static org.mockito.Mockito.atLeast;
+import static org.mockito.Mockito.clearInvocations;
 import static org.mockito.Mockito.doCallRealMethod;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
@@ -670,6 +671,87 @@ public class VeniceWriterUnitTest {
         assertTrue(e instanceof RecordTooLargeException);
         Assert.assertNotEquals(size, SMALL_VALUE_SIZE, "Small records shouldn't throw RecordTooLargeException");
       }
+    }
+  }
+
+  /**
+   * Testing that VeniceWriter does not throw when calling put() with Global RT DIV messages
+   * and does not enforce size limits on them
+   */
+  @Test(timeOut = TIMEOUT)
+  public void testPutGlobalRtDiv() {
+    final int maxRecordSizeBytes = BYTES_PER_MB; // 1MB
+    CompletableFuture mockedFuture = mock(CompletableFuture.class);
+    PubSubProducerAdapter mockedProducer = mock(PubSubProducerAdapter.class);
+    when(mockedProducer.sendMessage(any(), any(), any(), any(), any(), any())).thenReturn(mockedFuture);
+    ChunkedValueManifestSerializer manifestSerializer = new ChunkedValueManifestSerializer(true);
+    final VeniceKafkaSerializer<Object> serializer = new VeniceAvroKafkaSerializer(TestWriteUtils.STRING_SCHEMA);
+    final VeniceWriterOptions options = new VeniceWriterOptions.Builder("testTopic").setPartitionCount(1)
+        .setKeySerializer(serializer)
+        .setValueSerializer(serializer)
+        .setChunkingEnabled(true)
+        .setMaxRecordSizeBytes(maxRecordSizeBytes)
+        .build();
+    VeniceProperties props = VeniceProperties.empty();
+    final VeniceWriter<Object, Object, Object> writer = new VeniceWriter<>(options, props, mockedProducer);
+
+    // "small" < maxSizeForUserPayloadPerMessageInBytes < "large" < maxRecordSizeBytes < "too large"
+    final int SMALL_VALUE_SIZE = maxRecordSizeBytes / 2;
+    final int LARGE_VALUE_SIZE = maxRecordSizeBytes - BYTES_PER_KB; // offset to account for the size of the key
+    final int TOO_LARGE_VALUE_SIZE = maxRecordSizeBytes * 2;
+
+    // Even when the value is too large, there should not be an exception thrown for Global RT DIV (non-put) messages
+    for (int size: Arrays.asList(SMALL_VALUE_SIZE, LARGE_VALUE_SIZE, TOO_LARGE_VALUE_SIZE)) {
+      char[] valueChars = new char[size];
+      Arrays.fill(valueChars, '*');
+      writer.put(
+          String.format("test-key-%d", size).getBytes(),
+          new String(valueChars).getBytes(),
+          0,
+          1,
+          null,
+          new LeaderMetadataWrapper(0, 0),
+          APP_DEFAULT_LOGICAL_TS,
+          null,
+          null,
+          null,
+          false);
+
+      ArgumentCaptor<KafkaKey> keyArgumentCaptor = ArgumentCaptor.forClass(KafkaKey.class);
+      ArgumentCaptor<KafkaMessageEnvelope> kmeArgumentCaptor = ArgumentCaptor.forClass(KafkaMessageEnvelope.class);
+      verify(mockedProducer, atLeast(1))
+          .sendMessage(any(), any(), keyArgumentCaptor.capture(), kmeArgumentCaptor.capture(), any(), any());
+
+      // KafkaKey for Global RT DIV message should always have messageType == GLOBAL_RT_DIV rather than PUT
+      // (Some control messages are also created in the process of sending the Global RT DIV message)
+      keyArgumentCaptor.getAllValues().forEach(key -> assertTrue(key.isGlobalRtDiv() || key.isControlMessage()));
+
+      for (KafkaMessageEnvelope kme: kmeArgumentCaptor.getAllValues()) {
+        if (kme.messageType == MessageType.CONTROL_MESSAGE.getValue()) {
+          ControlMessage controlMessage = ((ControlMessage) kme.getPayloadUnion());
+          assertEquals(ControlMessageType.START_OF_SEGMENT.getValue(), controlMessage.getControlMessageType());
+        } else {
+          Put put = (Put) kme.payloadUnion;
+          assertEquals(kme.messageType, MessageType.PUT.getValue(), "KME should have type == PUT, not GLOBAL_RT_DIV");
+          if (size == SMALL_VALUE_SIZE) {
+            // The schemaId of the PutValue should indicate that the contents are a GlobalRtDivState object
+            assertEquals(put.getSchemaId(), AvroProtocolDefinition.GLOBAL_RT_DIV_STATE.getCurrentProtocolVersion());
+          } else {
+            // The schemaId of the outer PutValue should indicate that the contents are a chunked object
+            assertTrue(put.getSchemaId() == CHUNK_VALUE_SCHEMA_ID || put.getSchemaId() == CHUNK_MANIFEST_SCHEMA_ID);
+            if (put.getSchemaId() == CHUNK_MANIFEST_SCHEMA_ID) {
+              // The schemaId of the inner ChunkedValueManifest should finally indicate that it's a GlobalRtDivState
+              ChunkedValueManifest chunkedValueManifest = manifestSerializer.deserialize(
+                  put.getPutValue().array(),
+                  AvroProtocolDefinition.CHUNKED_VALUE_MANIFEST.getCurrentProtocolVersion());
+              assertEquals(
+                  chunkedValueManifest.schemaId,
+                  AvroProtocolDefinition.GLOBAL_RT_DIV_STATE.getCurrentProtocolVersion());
+            }
+          }
+        }
+      }
+      clearInvocations(mockedProducer); // important for the non-chunked messages don't appear in the next iteration
     }
   }
 

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/consumer/VeniceWriterWithNewerProtocol.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/consumer/VeniceWriterWithNewerProtocol.java
@@ -20,7 +20,7 @@ class VeniceWriterWithNewerProtocol extends VeniceWriter<String, String, byte[]>
   }
 
   @Override
-  protected KafkaMessageEnvelope getKafkaMessageEnvelope(
+  public KafkaMessageEnvelope getKafkaMessageEnvelope(
       MessageType messageType,
       boolean isEndOfSegment,
       int partition,


### PR DESCRIPTION
## Summary

![DIV-Producer](https://github.com/user-attachments/assets/47a30d4c-b8c0-4b41-9ca3-6ed56f0fd1f3)

When the `isGlobalRtDivEnabled()` feature flag is enabled, the drainer will no longer sync the VT DIV to the `OffsetRecord` in the StorageEngine. In the `ConsumptionTask` stage, leader will produce a (Global) RT DIV to VT to replicate to the followers. On the callback, it will enqueue a `DivSnapshot` (VT DIV + RT DIV) to the `Drainer`. `Drainer` will put the RT DIV (possibly chunked) in the storage engine, and sync the `OffsetRecord` with VT DIV. Note that the `GlobalRtDivState` will be compressed because it's being sent to VT.

The Drainer component will be handled in a future PR.

### Per-Broker Global RT DIV

Note that the Global RT DIV is on a per-broker / region basis. `PartitionTracker#rtSegments` is a map of `Broker URL -> Producer GUID -> Segment` whereas the VT version is only `Producer GUID -> Segment`. There should only be one `ConsumptionTask` per broker / region and only one per VT, so there should not be any contention with the `Map` with this setup. The latest consumed RT offset (LCRO) is not stored in-memory, it is simply the offset of the last consumed message that triggered the DIV to be synced.

### When to Sync?
The `syncBytesInterval` from the drainer syncing `OffsetRecord` is reused.

However, since the Global RT DIV is per-broker, the tally for how many bytes have been consumed since the last Global RT DIV sync also needs to be per-broker, and needs to be divided by the number of brokers in order to be proportional.

### Changes

* [functional] Added the send Global RT DIV code inside `LeaderFollowerStoreIngestionTask#produceToLocalKafka()`.
* [class] Created container class `DivSnapshot` which contains VT DIV + RT DIV + `latestConsumedVtOffset` + `latestConsumedRtOffset` for the consumer to enqueue to the drainer via `LeaderProducerCallback`.
* [functional] Created method to convert `Segment` into `ProducerPartitionState`. Below is a diagram describing the relationship between these two entities.
* [functional] Created method to clone the VT + RT DIV in `PartitionTracker`.
* [functional] Added `latestConsumedVtOffset` (LCVO) to `PartitionTracker` which is updated as VT is being consumed.

### VT + RT DIV Details
![VT + RT DIV](https://github.com/user-attachments/assets/f71cc645-f9e6-4f4a-abfa-ad352a0c0c56)

### `Segment` and `ProducerPartitionState` Conversion
![pps](https://github.com/user-attachments/assets/0563feb4-a83c-4b51-9654-412863e0b1fb)

### Global RT DIV Message Payload
![DIV-Payload](https://github.com/user-attachments/assets/139263dd-3bb1-46b0-888a-677bb8dd25f7)
Identical to the existing `PUT` requests other than a few changes:
* **In general:** the Key's `MessageType` is changed from `PUT` to `GLOBAL_RT_DIV`.
* If chunking is necessary, the `schemaId` of the `GlobalRtDivState` is in the `ChunkedValueManifest`. The usage of `ChunkedValueManifest` and `Chunk` `schemaId` remains.

## How was This PR Tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
1. `testShouldSendGlobalRtDiv()` verifies that upon enabling the `GlobalRtDiv` feature flag, the DIV / `OffsetRecord` is synced by the consumer rather than the drainer.
2. `testSendGlobalRtDivMessage()` verifies that `LeaderFollowerStoreIngestionTask` correctly serializes `GlobalRtDivState` from `VeniceWriter#put()` and includes `DivSnapshot` in the callback for the drainer to use.
3. `testPutGlobalRtDiv()` verifies the output when `put()` is called with `GlobalRtDivState`.
4. `testUpdateLatestConsumedVtOffset() verifies that LCVO is being updated correctly.
5. `testToProducerPartitionState()` verifies the conversion between `Segment` and `ProducerPartitionState`.
TODO: trying to add an integration test.

## Does this PR Introduce Any User-Facing Changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [X] No. You can skip the rest of this section.