### PR TITLE
[server]  Adjust dynamic throttler limiting at faster rate

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/IngestionThrottler.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/IngestionThrottler.java
@@ -107,12 +107,19 @@ public class IngestionThrottler implements Closeable {
     this.poolTypeRecordThrottlerMap = new VeniceConcurrentHashMap<>();
     this.poolTypeRecordThrottlerMap.put(
         ConsumerPoolType.AA_WC_LEADER_POOL,
-        new EventThrottler(
-            serverConfig.getAaWCLeaderQuotaRecordsPerSecond(),
-            serverConfig.getKafkaFetchQuotaTimeWindow(),
-            "aa_wc_leader_records_count",
-            false,
-            EventThrottler.BLOCK_STRATEGY));
+        isAdaptiveThrottlerEnabled
+            ? new VeniceAdaptiveIngestionThrottler(
+                serverConfig.getAdaptiveThrottlerSignalIdleThreshold(),
+                serverConfig.getAaWCLeaderQuotaRecordsPerSecond(),
+                serverConfig.getThrottlerFactorsForAAWCLeader(),
+                serverConfig.getKafkaFetchQuotaTimeWindow(),
+                "aa_wc_leader_records_count")
+            : new EventThrottler(
+                serverConfig.getAaWCLeaderQuotaRecordsPerSecond(),
+                serverConfig.getKafkaFetchQuotaTimeWindow(),
+                "aa_wc_leader_records_count",
+                false,
+                EventThrottler.BLOCK_STRATEGY));
     this.poolTypeRecordThrottlerMap.put(
         ConsumerPoolType.SEP_RT_LEADER_POOL,
         new EventThrottler(

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/IngestionThrottler.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/IngestionThrottler.java
@@ -65,8 +65,9 @@ public class IngestionThrottler implements Closeable {
     EventThrottler globalRecordThrottler;
     EventThrottler globalBandwidthThrottler;
     VeniceAdaptiveIngestionThrottler globalBandwidthAdaptiveIngestionThrottler;
+    boolean isAdaptiveThrottlerEnabled = serverConfig.isAdaptiveThrottlerEnabled();
 
-    if (serverConfig.isAdaptiveThrottlerEnabled()) {
+    if (isAdaptiveThrottlerEnabled) {
       globalRecordThrottler = null;
       globalRecordAdaptiveIngestionThrottler = new VeniceAdaptiveIngestionThrottler(
           serverConfig.getAdaptiveThrottlerSignalIdleThreshold(),
@@ -122,12 +123,19 @@ public class IngestionThrottler implements Closeable {
             EventThrottler.BLOCK_STRATEGY));
     this.poolTypeRecordThrottlerMap.put(
         ConsumerPoolType.CURRENT_VERSION_AA_WC_LEADER_POOL,
-        new EventThrottler(
-            serverConfig.getCurrentVersionAAWCLeaderQuotaRecordsPerSecond(),
-            serverConfig.getKafkaFetchQuotaTimeWindow(),
-            "current_version_aa_wc_leader_records_count",
-            false,
-            EventThrottler.BLOCK_STRATEGY));
+        isAdaptiveThrottlerEnabled
+            ? new VeniceAdaptiveIngestionThrottler(
+                serverConfig.getAdaptiveThrottlerSignalIdleThreshold(),
+                serverConfig.getCurrentVersionAAWCLeaderQuotaRecordsPerSecond(),
+                serverConfig.getThrottlerFactorsForCurrentVersionAAWCLeader(),
+                serverConfig.getKafkaFetchQuotaTimeWindow(),
+                "current_version_aa_wc_leader_records_count")
+            : new EventThrottler(
+                serverConfig.getCurrentVersionAAWCLeaderQuotaRecordsPerSecond(),
+                serverConfig.getKafkaFetchQuotaTimeWindow(),
+                "current_version_aa_wc_leader_records_count",
+                false,
+                EventThrottler.BLOCK_STRATEGY));
     this.poolTypeRecordThrottlerMap.put(
         ConsumerPoolType.CURRENT_VERSION_SEP_RT_LEADER_POOL,
         new EventThrottler(
@@ -146,12 +154,19 @@ public class IngestionThrottler implements Closeable {
             EventThrottler.BLOCK_STRATEGY));
     this.poolTypeRecordThrottlerMap.put(
         ConsumerPoolType.NON_CURRENT_VERSION_AA_WC_LEADER_POOL,
-        new EventThrottler(
-            serverConfig.getNonCurrentVersionAAWCLeaderQuotaRecordsPerSecond(),
-            serverConfig.getKafkaFetchQuotaTimeWindow(),
-            "non_current_version_aa_wc_leader_records_count",
-            false,
-            EventThrottler.BLOCK_STRATEGY));
+        isAdaptiveThrottlerEnabled
+            ? new VeniceAdaptiveIngestionThrottler(
+                serverConfig.getAdaptiveThrottlerSignalIdleThreshold(),
+                serverConfig.getNonCurrentVersionAAWCLeaderQuotaRecordsPerSecond(),
+                serverConfig.getThrottlerFactorsForNonCurrentVersionAAWCLeader(),
+                serverConfig.getKafkaFetchQuotaTimeWindow(),
+                "non_current_version_aa_wc_leader_records_count")
+            : new EventThrottler(
+                serverConfig.getNonCurrentVersionAAWCLeaderQuotaRecordsPerSecond(),
+                serverConfig.getKafkaFetchQuotaTimeWindow(),
+                "non_current_version_aa_wc_leader_records_count",
+                false,
+                EventThrottler.BLOCK_STRATEGY));
     this.poolTypeRecordThrottlerMap.put(
         ConsumerPoolType.NON_CURRENT_VERSION_NON_AA_WC_LEADER_POOL,
         new EventThrottler(
@@ -211,10 +226,9 @@ public class IngestionThrottler implements Closeable {
     }
 
     this.finalRecordThrottler =
-        serverConfig.isAdaptiveThrottlerEnabled() ? globalRecordAdaptiveIngestionThrottler : globalRecordThrottler;
-    this.finalBandwidthThrottler = serverConfig.isAdaptiveThrottlerEnabled()
-        ? globalBandwidthAdaptiveIngestionThrottler
-        : globalBandwidthThrottler;
+        isAdaptiveThrottlerEnabled ? globalRecordAdaptiveIngestionThrottler : globalRecordThrottler;
+    this.finalBandwidthThrottler =
+        isAdaptiveThrottlerEnabled ? globalBandwidthAdaptiveIngestionThrottler : globalBandwidthThrottler;
   }
 
   public void maybeThrottleRecordRate(ConsumerPoolType poolType, int count) {

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/VeniceAdaptiveIngestionThrottlerTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/VeniceAdaptiveIngestionThrottlerTest.java
@@ -14,9 +14,9 @@ public class VeniceAdaptiveIngestionThrottlerTest {
         new VeniceAdaptiveIngestionThrottler(10, 100, factors, 10, "test");
     adaptiveIngestionThrottler.registerLimiterSignal(() -> true);
     adaptiveIngestionThrottler.checkSignalAndAdjustThrottler();
-    Assert.assertEquals(adaptiveIngestionThrottler.getCurrentThrottlerIndex(), 2);
-    adaptiveIngestionThrottler.checkSignalAndAdjustThrottler();
     Assert.assertEquals(adaptiveIngestionThrottler.getCurrentThrottlerIndex(), 1);
+    adaptiveIngestionThrottler.checkSignalAndAdjustThrottler();
+    Assert.assertEquals(adaptiveIngestionThrottler.getCurrentThrottlerIndex(), 0);
     adaptiveIngestionThrottler.checkSignalAndAdjustThrottler();
     Assert.assertEquals(adaptiveIngestionThrottler.getCurrentThrottlerIndex(), 0);
     adaptiveIngestionThrottler.checkSignalAndAdjustThrottler();


### PR DESCRIPTION
<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat], [protocol]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

##  Adjust dynamic throttler limiting at faster rate
<!--
Describe
- What changes to make and why you are making these changes.
- How are you going to achieve your goal.
- Describe what testings you have done, for example, performance testing etc.

If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

For dynamic throttling, during limiting signals, such as high read latency or heartbeat lag, step down should be faster than step up to prevent further breach of SLA and quicker recovery. This PR also adds throttler for leader pool type for AAWC ingestion (both non-current/current versions).

## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
GHCI
## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.