### PR TITLE
[vpj][controller] Fix push job status for target region push w/ deferred swap

### DIFF
--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/VenicePushJob.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/VenicePushJob.java
@@ -410,15 +410,16 @@ public class VenicePushJob implements AutoCloseable {
 
     pushJobSettingToReturn.isTargetedRegionPushEnabled = props.getBoolean(TARGETED_REGION_PUSH_ENABLED, false);
     pushJobSettingToReturn.isSystemSchemaReaderEnabled = props.getBoolean(SYSTEM_SCHEMA_READER_ENABLED, false);
-    if (pushJobSettingToReturn.isIncrementalPush && pushJobSettingToReturn.isTargetedRegionPushEnabled) {
+    pushJobSettingToReturn.isTargetRegionPushWithDeferredSwapEnabled =
+        props.getBoolean(TARGETED_REGION_PUSH_WITH_DEFERRED_SWAP, false);
+    if (pushJobSettingToReturn.isIncrementalPush && (pushJobSettingToReturn.isTargetedRegionPushEnabled
+        || pushJobSettingToReturn.isTargetRegionPushWithDeferredSwapEnabled)) {
       throw new VeniceException("Incremental push is not supported while using targeted region push mode");
     }
 
-    // If target region push with deferred version swap is enabled, enable deferVersionSwap and
-    // isTargetedRegionPushEnabled
-    if (props.getBoolean(TARGETED_REGION_PUSH_WITH_DEFERRED_SWAP, false)) {
+    // If target region push with deferred version swap is enabled, enable deferVersionSwap
+    if (pushJobSettingToReturn.isTargetRegionPushWithDeferredSwapEnabled) {
       pushJobSettingToReturn.deferVersionSwap = true;
-      pushJobSettingToReturn.isTargetRegionPushWithDeferredSwapEnabled = true;
     }
 
     if (pushJobSettingToReturn.isTargetRegionPushWithDeferredSwapEnabled

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/VenicePushJob.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/VenicePushJob.java
@@ -2155,11 +2155,13 @@ public class VenicePushJob implements AutoCloseable {
       }
     }
 
-    Set<String> nonTargetRegionsList = getNonTargetRegions();
-    if (nonTargetRegionsList.isEmpty()) {
-      throw new VeniceException(
-          "Target region list cannot contain all regions:" + pushJobSetting.targetedRegions
-              + ". Please remove one or more of the regions from the target region push list.");
+    if (jobSetting.isTargetedRegionPushEnabled || jobSetting.isTargetRegionPushWithDeferredSwapEnabled) {
+      Set<String> nonTargetRegionsList = getNonTargetRegions();
+      if (nonTargetRegionsList.isEmpty()) {
+        throw new VeniceException(
+            "Target region list cannot contain all regions:" + pushJobSetting.targetedRegions
+                + ". Please remove one or more of the regions from the target region push list.");
+      }
     }
 
     HybridStoreConfig hybridStoreConfig = storeResponse.getStore().getHybridStoreConfig();

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/VenicePushJob.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/VenicePushJob.java
@@ -855,7 +855,7 @@ public class VenicePushJob implements AutoCloseable {
             pushJobSetting,
             pushJobSetting.targetedRegions,
             pushJobSetting.isTargetedRegionPushEnabled,
-            pushJobSetting.isTargetRegionPushWithDeferredSwapEnabled);
+            false);
       }
 
       updatePushJobDetailsWithCheckpoint(PushJobCheckpoints.JOB_STATUS_POLLING_COMPLETED);

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/VenicePushJob.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/VenicePushJob.java
@@ -706,13 +706,6 @@ public class VenicePushJob implements AutoCloseable {
       validateStoreSettingAndPopulate(controllerClient, pushJobSetting);
       inputStorageQuotaTracker = new InputStorageQuotaTracker(pushJobSetting.storeStorageQuota);
 
-      Set<String> nonTargetRegionsList = getNonTargetRegions();
-      if (nonTargetRegionsList.isEmpty()) {
-        throw new VeniceException(
-            "Target region list cannot contain all regions:" + pushJobSetting.targetedRegions
-                + ". Please remove one or more of the regions from the target region push list.");
-      }
-
       if (pushJobSetting.isSourceETL) {
         MultiSchemaResponse allValueSchemaResponses = controllerClient.getAllValueSchema(pushJobSetting.storeName);
         MultiSchemaResponse.Schema[] allValueSchemas = allValueSchemaResponses.getSchemas();
@@ -2160,6 +2153,13 @@ public class VenicePushJob implements AutoCloseable {
         throw new VeniceException(
             "The store either does not have native replication mode enabled or set up default source fabric.");
       }
+    }
+
+    Set<String> nonTargetRegionsList = getNonTargetRegions();
+    if (nonTargetRegionsList.isEmpty()) {
+      throw new VeniceException(
+          "Target region list cannot contain all regions:" + pushJobSetting.targetedRegions
+              + ". Please remove one or more of the regions from the target region push list.");
     }
 
     HybridStoreConfig hybridStoreConfig = storeResponse.getStore().getHybridStoreConfig();

--- a/clients/venice-push-job/src/test/java/com/linkedin/venice/hadoop/TestVenicePushJobCheckpoints.java
+++ b/clients/venice-push-job/src/test/java/com/linkedin/venice/hadoop/TestVenicePushJobCheckpoints.java
@@ -921,7 +921,8 @@ public class TestVenicePushJobCheckpoints {
             anyInt(),
             anyBoolean())).thenReturn(versionCreationResponse);
     JobStatusQueryResponse jobStatusQueryResponse = createJobStatusQueryResponseMock(executionStatus);
-    when(controllerClient.queryOverallJobStatus(anyString(), any(), any())).thenReturn(jobStatusQueryResponse);
+    when(controllerClient.queryOverallJobStatus(anyString(), any(), any(), anyBoolean()))
+        .thenReturn(jobStatusQueryResponse);
 
     doAnswer(invocation -> {
       return null;

--- a/clients/venice-push-job/src/test/java/com/linkedin/venice/hadoop/VenicePushJobTest.java
+++ b/clients/venice-push-job/src/test/java/com/linkedin/venice/hadoop/VenicePushJobTest.java
@@ -276,7 +276,7 @@ public class VenicePushJobTest {
     ControllerClient client = mock(ControllerClient.class);
     JobStatusQueryResponse response = mock(JobStatusQueryResponse.class);
     doReturn("UNKNOWN").when(response).getStatus();
-    doReturn(response).when(client).queryOverallJobStatus(anyString(), eq(Optional.empty()), eq(null));
+    doReturn(response).when(client).queryOverallJobStatus(anyString(), eq(Optional.empty()), eq(null), anyBoolean());
     try (VenicePushJob pushJob = getSpyVenicePushJob(vpjProps, client)) {
       PushJobSetting pushJobSetting = pushJob.getPushJobSetting();
       pushJobSetting.jobStatusInUnknownStateTimeoutMs = 10;
@@ -308,7 +308,7 @@ public class VenicePushJobTest {
     doReturn(unknownResponse).doReturn(unknownResponse)
         .doReturn(completedResponse)
         .when(client)
-        .queryOverallJobStatus(anyString(), eq(Optional.empty()), eq(null));
+        .queryOverallJobStatus(anyString(), eq(Optional.empty()), eq(null), anyBoolean());
     try (VenicePushJob pushJob = getSpyVenicePushJob(vpjProps, client)) {
       PushJobSetting pushJobSetting = pushJob.getPushJobSetting();
       pushJobSetting.jobStatusInUnknownStateTimeoutMs = 100_000_000;
@@ -654,7 +654,7 @@ public class VenicePushJobTest {
     JobStatusQueryResponse response = mockJobStatusQuery();
 
     try (VenicePushJob pushJob = getSpyVenicePushJob(props, client)) {
-      doReturn(response).when(client).queryOverallJobStatus(anyString(), any(), anyString());
+      doReturn(response).when(client).queryOverallJobStatus(anyString(), any(), anyString(), anyBoolean());
       skipVPJValidation(pushJob);
       try {
         pushJob.run();
@@ -670,7 +670,7 @@ public class VenicePushJobTest {
     props.put(TARGETED_REGION_PUSH_LIST, "dc-0, dc-1");
     client = getClient();
     try (VenicePushJob pushJob = getSpyVenicePushJob(props, client)) {
-      doReturn(response).when(client).queryOverallJobStatus(anyString(), any(), anyString());
+      doReturn(response).when(client).queryOverallJobStatus(anyString(), any(), anyString(), anyBoolean());
       skipVPJValidation(pushJob);
       pushJob.run();
       Assert.assertEquals(pushJob.getPushJobSetting().targetedRegions, "dc-0, dc-1");
@@ -692,7 +692,7 @@ public class VenicePushJobTest {
       Map<String, String> extraInfo = response.getExtraInfo();
       // one of the regions failed, so should fail
       extraInfo.put("dc-0", ExecutionStatus.NOT_STARTED.toString());
-      doReturn(response).when(client).queryOverallJobStatus(anyString(), any(), anyString());
+      doReturn(response).when(client).queryOverallJobStatus(anyString(), any(), anyString(), anyBoolean());
       try {
         pushJob.run();
         fail("Test should fail, but doesn't.");
@@ -718,7 +718,7 @@ public class VenicePushJobTest {
       skipVPJValidation(pushJob);
 
       JobStatusQueryResponse response = mockJobStatusQuery();
-      doReturn(response).when(client).queryOverallJobStatus(anyString(), any(), anyString());
+      doReturn(response).when(client).queryOverallJobStatus(anyString(), any(), anyString(), anyBoolean());
 
       VersionCreationResponse mockVersionCreationResponse = mockVersionCreationResponse(client);
       mockVersionCreationResponse.setKafkaSourceRegion(null);
@@ -767,7 +767,7 @@ public class VenicePushJobTest {
       skipVPJValidation(pushJob);
 
       JobStatusQueryResponse response = mockJobStatusQuery();
-      doReturn(response).when(client).queryOverallJobStatus(anyString(), any(), anyString());
+      doReturn(response).when(client).queryOverallJobStatus(anyString(), any(), anyString(), anyBoolean());
       // skip the mocking for repush
       doCallRealMethod().doNothing().when(pushJob).run();
       pushJob.run();
@@ -788,7 +788,7 @@ public class VenicePushJobTest {
       skipVPJValidation(pushJob);
 
       JobStatusQueryResponse response = mockJobStatusQuery();
-      doReturn(response).when(client).queryOverallJobStatus(anyString(), any(), anyString());
+      doReturn(response).when(client).queryOverallJobStatus(anyString(), any(), anyString(), anyBoolean());
       mockVersionCreationResponse(client);
 
       doThrow(new VeniceValidationException("error")).when(pushJob).postPushValidation();
@@ -973,7 +973,7 @@ public class VenicePushJobTest {
     properties.put(VALUE_FIELD_PROP, "name");
     JobStatusQueryResponse response = mockJobStatusQuery();
     ControllerClient client = getClient();
-    doReturn(response).when(client).queryOverallJobStatus(anyString(), any(), eq(null));
+    doReturn(response).when(client).queryOverallJobStatus(anyString(), any(), eq(null), anyBoolean());
     try (final VenicePushJob vpj = getSpyVenicePushJob(properties, client)) {
       skipVPJValidation(vpj);
       vpj.run();
@@ -993,7 +993,7 @@ public class VenicePushJobTest {
       storeInfo.setViewConfigs(viewConfigs);
       storeInfo.setVersions(Collections.singletonList(version));
     }, true);
-    doReturn(response).when(client).queryOverallJobStatus(anyString(), any(), eq(null));
+    doReturn(response).when(client).queryOverallJobStatus(anyString(), any(), eq(null), anyBoolean());
     MultiSchemaResponse valueSchemaResponse = getMultiSchemaResponse();
     MultiSchemaResponse.Schema[] schemas = new MultiSchemaResponse.Schema[1];
     schemas[0] = getBasicSchema();

--- a/clients/venice-push-job/src/test/java/com/linkedin/venice/hadoop/VenicePushJobTest.java
+++ b/clients/venice-push-job/src/test/java/com/linkedin/venice/hadoop/VenicePushJobTest.java
@@ -667,13 +667,9 @@ public class VenicePushJobTest {
       }
     }
 
-    props.put(TARGETED_REGION_PUSH_LIST, "dc-0, dc-1");
-    client = getClient();
-    try (VenicePushJob pushJob = getSpyVenicePushJob(props, client)) {
-      doReturn(response).when(client).queryOverallJobStatus(anyString(), any(), anyString(), anyBoolean());
-      skipVPJValidation(pushJob);
-      pushJob.run();
-      Assert.assertEquals(pushJob.getPushJobSetting().targetedRegions, "dc-0, dc-1");
+    props.put(TARGETED_REGION_PUSH_LIST, "dc-0");
+    try (VenicePushJob pushJob = new VenicePushJob(PUSH_JOB_ID, props)) {
+      Assert.assertEquals(pushJob.getPushJobSetting().targetedRegions, "dc-0");
     }
   }
 
@@ -683,7 +679,7 @@ public class VenicePushJobTest {
     props.put(KEY_FIELD_PROP, "id");
     props.put(VALUE_FIELD_PROP, "name");
     props.put(TARGETED_REGION_PUSH_ENABLED, true);
-    props.put(TARGETED_REGION_PUSH_LIST, "dc-0, dc-1");
+    props.put(TARGETED_REGION_PUSH_LIST, "dc-0");
     ControllerClient client = getClient();
     try (VenicePushJob pushJob = getSpyVenicePushJob(props, client)) {
       skipVPJValidation(pushJob);
@@ -703,6 +699,10 @@ public class VenicePushJobTest {
       extraInfo.put("dc-0", ExecutionStatus.COMPLETED.toString());
       extraInfo.put("dc-1", ExecutionStatus.COMPLETED.toString());
       // both regions completed, so should succeed
+
+      ControllerResponse dataRecoveryResponse = new ControllerResponse();
+      doReturn(dataRecoveryResponse).when(client)
+          .dataRecovery(anyString(), anyString(), anyString(), anyInt(), anyBoolean(), anyBoolean(), any());
       pushJob.run();
     }
   }

--- a/clients/venice-push-job/src/test/java/com/linkedin/venice/hadoop/VenicePushJobTest.java
+++ b/clients/venice-push-job/src/test/java/com/linkedin/venice/hadoop/VenicePushJobTest.java
@@ -290,7 +290,7 @@ public class VenicePushJobTest {
       pushJobSetting.storeResponse.setStore(storeInfo);
       VeniceException exception = Assert.expectThrows(
           VeniceException.class,
-          () -> pushJob.pollStatusUntilComplete(null, client, pushJobSetting, null, false));
+          () -> pushJob.pollStatusUntilComplete(null, client, pushJobSetting, null, false, false));
       Assert
           .assertEquals(exception.getMessage(), "Failing push-job for store abc which is still running after 0 hours.");
     }
@@ -320,7 +320,7 @@ public class VenicePushJobTest {
       StoreInfo storeInfo = new StoreInfo();
       storeInfo.setBootstrapToOnlineTimeoutInHours(10);
       pushJobSetting.storeResponse.setStore(storeInfo);
-      pushJob.pollStatusUntilComplete(null, client, pushJobSetting, null, false);
+      pushJob.pollStatusUntilComplete(null, client, pushJobSetting, null, false, false);
     } catch (Exception e) {
       fail("The test should be completed successfully without any timeout exception");
     }

--- a/clients/venice-push-job/src/test/java/com/linkedin/venice/hadoop/VenicePushJobTest.java
+++ b/clients/venice-push-job/src/test/java/com/linkedin/venice/hadoop/VenicePushJobTest.java
@@ -1015,6 +1015,26 @@ public class VenicePushJobTest {
     }
   }
 
+  @Test
+  public void testTargetedRegionPushWithDeferredSwapConfigValidation() throws Exception {
+    Properties props = getVpjRequiredProperties();
+    props.put(TARGETED_REGION_PUSH_WITH_DEFERRED_SWAP, false);
+    props.put(TARGETED_REGION_PUSH_LIST, "dc-0");
+    try (VenicePushJob pushJob = new VenicePushJob(PUSH_JOB_ID, props)) {
+      fail("Test should fail, but doesn't.");
+    } catch (VeniceException e) {
+      assertEquals(e.getMessage(), "Targeted region push list is only supported when targeted region push is enabled");
+    }
+
+    props.put(TARGETED_REGION_PUSH_WITH_DEFERRED_SWAP, true);
+    props.put(INCREMENTAL_PUSH, true);
+    try (VenicePushJob pushJob = new VenicePushJob(PUSH_JOB_ID, props)) {
+      fail("Test should fail, but doesn't.");
+    } catch (VeniceException e) {
+      assertEquals(e.getMessage(), "Incremental push is not supported while using targeted region push mode");
+    }
+  }
+
   private SchemaResponse getKeySchemaResponse() {
     SchemaResponse response = new SchemaResponse();
     response.setId(1);

--- a/clients/venice-push-job/src/test/java/com/linkedin/venice/hadoop/VenicePushJobTest.java
+++ b/clients/venice-push-job/src/test/java/com/linkedin/venice/hadoop/VenicePushJobTest.java
@@ -1035,6 +1035,26 @@ public class VenicePushJobTest {
     }
   }
 
+  @Test(expectedExceptions = VeniceException.class, expectedExceptionsMessageRegExp = "Target region list cannot contain all regions.*")
+  public void testTargetRegionPushWithAllRegions() {
+    Properties props = getVpjRequiredProperties();
+    props.put(TARGETED_REGION_PUSH_WITH_DEFERRED_SWAP, true);
+    props.put(TARGETED_REGION_PUSH_LIST, "dc-0, dc-1");
+
+    ControllerClient client = getClient(storeInfo -> {
+      storeInfo.setColoToCurrentVersions(new HashMap<String, Integer>() {
+        {
+          put("dc-0", 1);
+          put("dc-1", 1);
+        }
+      });
+    });
+
+    try (VenicePushJob pushJob = getSpyVenicePushJob(props, client)) {
+      pushJob.run();
+    }
+  }
+
   private SchemaResponse getKeySchemaResponse() {
     SchemaResponse response = new SchemaResponse();
     response.setId(1);

--- a/internal/venice-common/src/main/java/com/linkedin/venice/controllerapi/ControllerApiConstants.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/controllerapi/ControllerApiConstants.java
@@ -241,6 +241,7 @@ public class ControllerApiConstants {
    * String representation of the list of regions that is separated by comma for targeted region push
    */
   public static final String TARGETED_REGIONS = "targeted_regions";
+  public static final String TARGET_REGION_PUSH_WITH_DEFERRED_SWAP = "target_region_push_with_deferred_swap";
 
   public static final String STORAGE_NODE_READ_QUOTA_ENABLED = "storage_node_read_quota_enabled";
 

--- a/internal/venice-common/src/main/java/com/linkedin/venice/controllerapi/ControllerClient.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/controllerapi/ControllerClient.java
@@ -65,6 +65,7 @@ import static com.linkedin.venice.controllerapi.ControllerApiConstants.STORE_CON
 import static com.linkedin.venice.controllerapi.ControllerApiConstants.STORE_SIZE;
 import static com.linkedin.venice.controllerapi.ControllerApiConstants.STORE_TYPE;
 import static com.linkedin.venice.controllerapi.ControllerApiConstants.TARGETED_REGIONS;
+import static com.linkedin.venice.controllerapi.ControllerApiConstants.TARGET_REGION_PUSH_WITH_DEFERRED_SWAP;
 import static com.linkedin.venice.controllerapi.ControllerApiConstants.TOPIC;
 import static com.linkedin.venice.controllerapi.ControllerApiConstants.TO_BE_STOPPED_INSTANCES;
 import static com.linkedin.venice.controllerapi.ControllerApiConstants.UPSTREAM_OFFSET;
@@ -780,8 +781,21 @@ public class ControllerClient implements Closeable {
   public JobStatusQueryResponse queryOverallJobStatus(
       String kafkaTopic,
       Optional<String> incrementalPushVersion,
+      String targetedRegions,
+      boolean isTargetRegionPushWithDeferredSwap) {
+    return queryJobStatus(
+        kafkaTopic,
+        incrementalPushVersion,
+        5 * QUERY_JOB_STATUS_TIMEOUT,
+        targetedRegions,
+        isTargetRegionPushWithDeferredSwap);
+  }
+
+  public JobStatusQueryResponse queryOverallJobStatus(
+      String kafkaTopic,
+      Optional<String> incrementalPushVersion,
       String targetedRegions) {
-    return queryJobStatus(kafkaTopic, incrementalPushVersion, 5 * QUERY_JOB_STATUS_TIMEOUT, targetedRegions);
+    return queryOverallJobStatus(kafkaTopic, incrementalPushVersion, null, false);
   }
 
   public JobStatusQueryResponse queryOverallJobStatus(String kafkaTopic, Optional<String> incrementalPushVersion) {
@@ -789,7 +803,7 @@ public class ControllerClient implements Closeable {
   }
 
   public JobStatusQueryResponse queryJobStatus(String kafkaTopic) {
-    return queryJobStatus(kafkaTopic, Optional.empty(), QUERY_JOB_STATUS_TIMEOUT, null);
+    return queryJobStatus(kafkaTopic, Optional.empty(), QUERY_JOB_STATUS_TIMEOUT, null, false);
   }
 
   /**
@@ -798,25 +812,28 @@ public class ControllerClient implements Closeable {
    * target is a parent controller.
    */
   public JobStatusQueryResponse queryJobStatus(String kafkaTopic, Optional<String> incrementalPushVersion) {
-    return queryJobStatus(kafkaTopic, incrementalPushVersion, QUERY_JOB_STATUS_TIMEOUT, null);
+    return queryJobStatus(kafkaTopic, incrementalPushVersion, QUERY_JOB_STATUS_TIMEOUT, null, false);
   }
 
   public JobStatusQueryResponse queryJobStatus(
       String kafkaTopic,
       Optional<String> incrementalPushVersion,
       String targetedRegions) {
-    return queryJobStatus(kafkaTopic, incrementalPushVersion, QUERY_JOB_STATUS_TIMEOUT, targetedRegions);
+    return queryJobStatus(kafkaTopic, incrementalPushVersion, QUERY_JOB_STATUS_TIMEOUT, targetedRegions, false);
   }
 
   public JobStatusQueryResponse queryJobStatus(
       String kafkaTopic,
       Optional<String> incrementalPushVersion,
       int timeoutMs,
-      String targetedRegions) {
+      String targetedRegions,
+      boolean isTargetRegionPushWithDeferredSwap) {
     String storeName = Version.parseStoreFromKafkaTopicName(kafkaTopic);
     int version = Version.parseVersionFromKafkaTopicName(kafkaTopic);
-    QueryParams params =
-        newParams().add(NAME, storeName).add(VERSION, version).add(INCREMENTAL_PUSH_VERSION, incrementalPushVersion);
+    QueryParams params = newParams().add(NAME, storeName)
+        .add(VERSION, version)
+        .add(INCREMENTAL_PUSH_VERSION, incrementalPushVersion)
+        .add(TARGET_REGION_PUSH_WITH_DEFERRED_SWAP, isTargetRegionPushWithDeferredSwap);
 
     if (StringUtils.isNotEmpty(targetedRegions)) {
       params.add(TARGETED_REGIONS, targetedRegions);

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/controller/TestIncrementalPush.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/controller/TestIncrementalPush.java
@@ -104,7 +104,8 @@ public class TestIncrementalPush {
                 Version.composeKafkaTopic(storeName, 1),
                 Optional.of(incPushTopic),
                 null,
-                null)
+                null,
+                false)
             .getExecutionStatus()
             .equals(ExecutionStatus.START_OF_INCREMENTAL_PUSH_RECEIVED));
 
@@ -159,7 +160,7 @@ public class TestIncrementalPush {
         TimeUnit.SECONDS,
         () -> cluster.getLeaderVeniceController()
             .getVeniceAdmin()
-            .getOffLinePushStatus(cluster.getClusterName(), versionTopic1, Optional.of(incPushV1), null, null)
+            .getOffLinePushStatus(cluster.getClusterName(), versionTopic1, Optional.of(incPushV1), null, null, false)
             .getExecutionStatus()
             .equals(ExecutionStatus.END_OF_INCREMENTAL_PUSH_RECEIVED));
 
@@ -187,7 +188,7 @@ public class TestIncrementalPush {
         TimeUnit.SECONDS,
         () -> cluster.getLeaderVeniceController()
             .getVeniceAdmin()
-            .getOffLinePushStatus(cluster.getClusterName(), versionTopic2, Optional.of(incPushV1), null, null)
+            .getOffLinePushStatus(cluster.getClusterName(), versionTopic2, Optional.of(incPushV1), null, null, false)
             .getExecutionStatus()
             .equals(ExecutionStatus.END_OF_INCREMENTAL_PUSH_RECEIVED));
 
@@ -199,7 +200,7 @@ public class TestIncrementalPush {
         TimeUnit.SECONDS,
         () -> cluster.getLeaderVeniceController()
             .getVeniceAdmin()
-            .getOffLinePushStatus(cluster.getClusterName(), versionTopic2, Optional.of(incPush2), null, null)
+            .getOffLinePushStatus(cluster.getClusterName(), versionTopic2, Optional.of(incPush2), null, null, false)
             .getExecutionStatus()
             .equals(ExecutionStatus.START_OF_INCREMENTAL_PUSH_RECEIVED));
   }

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestDeferredVersionSwap.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestDeferredVersionSwap.java
@@ -203,23 +203,23 @@ public class TestDeferredVersionSwap {
   @Test(timeOut = TEST_TIMEOUT)
   public void testDeferredVersionSwapWithHybridStore() throws IOException {
     File inputDir = getTempDataDirectory();
-    TestWriteUtils.writeSimpleAvroFileWithStringToV3Schema(inputDir, 100, 100);
+    TestWriteUtils.writeSimpleAvroFileWithIntToIntSchema(inputDir, 10);
     // Setup job properties
     String inputDirPath = "file://" + inputDir.getAbsolutePath();
     String storeName = Utils.getUniqueString("testDeferredVersionSwapWithHybridStore");
     Properties props =
         IntegrationTestPushUtils.defaultVPJProps(multiRegionMultiClusterWrapper, inputDirPath, storeName);
-    String keySchemaStr = "\"string\"";
+    String keySchemaStr = "\"int\"";
+    String valueSchemaStr = "\"int\"";
     UpdateStoreQueryParams storeParams = new UpdateStoreQueryParams().setUnusedSchemaDeletionEnabled(true)
         .setHybridOffsetLagThreshold(TEST_TIMEOUT)
         .setHybridRewindSeconds(2L)
         .setActiveActiveReplicationEnabled(true)
-        .setIncrementalPushEnabled(true)
         .setTargetRegionSwapWaitTime(1);
     String parentControllerURLs = multiRegionMultiClusterWrapper.getControllerConnectString();
 
     try (ControllerClient parentControllerClient = new ControllerClient(CLUSTER_NAMES[0], parentControllerURLs)) {
-      createStoreForJob(CLUSTER_NAMES[0], keySchemaStr, NAME_RECORD_V3_SCHEMA.toString(), props, storeParams).close();
+      createStoreForJob(CLUSTER_NAMES[0], keySchemaStr, valueSchemaStr, props, storeParams).close();
 
       // Start push job with target region push enabled
       props.put(TARGETED_REGION_PUSH_WITH_DEFERRED_SWAP, true);

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestDeferredVersionSwap.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestDeferredVersionSwap.java
@@ -138,7 +138,7 @@ public class TestDeferredVersionSwap {
     TestWriteUtils.writeSimpleAvroFileWithStringToV3Schema(inputDir, 100, 100);
     // Setup job properties
     String inputDirPath = "file://" + inputDir.getAbsolutePath();
-    String storeName = Utils.getUniqueString("testDeferredVersionSwap");
+    String storeName = Utils.getUniqueString("testDeferredVersionSwapMultiplePushes");
     Properties props =
         IntegrationTestPushUtils.defaultVPJProps(multiRegionMultiClusterWrapper, inputDirPath, storeName);
     String keySchemaStr = "\"string\"";
@@ -195,6 +195,68 @@ public class TestDeferredVersionSwap {
 
         coloVersions.forEach((colo, version) -> {
           Assert.assertEquals((int) version, 2);
+        });
+      });
+    }
+  }
+
+  @Test(timeOut = TEST_TIMEOUT)
+  public void testDeferredVersionSwapWithHybridStore() throws IOException {
+    File inputDir = getTempDataDirectory();
+    TestWriteUtils.writeSimpleAvroFileWithStringToV3Schema(inputDir, 100, 100);
+    // Setup job properties
+    String inputDirPath = "file://" + inputDir.getAbsolutePath();
+    String storeName = Utils.getUniqueString("testDeferredVersionSwapWithHybridStore");
+    Properties props =
+        IntegrationTestPushUtils.defaultVPJProps(multiRegionMultiClusterWrapper, inputDirPath, storeName);
+    String keySchemaStr = "\"string\"";
+    UpdateStoreQueryParams storeParams = new UpdateStoreQueryParams().setUnusedSchemaDeletionEnabled(true)
+        .setHybridOffsetLagThreshold(TEST_TIMEOUT)
+        .setHybridRewindSeconds(2L)
+        .setActiveActiveReplicationEnabled(true)
+        .setIncrementalPushEnabled(true)
+        .setTargetRegionSwapWaitTime(1);
+    String parentControllerURLs = multiRegionMultiClusterWrapper.getControllerConnectString();
+
+    try (ControllerClient parentControllerClient = new ControllerClient(CLUSTER_NAMES[0], parentControllerURLs)) {
+      createStoreForJob(CLUSTER_NAMES[0], keySchemaStr, NAME_RECORD_V3_SCHEMA.toString(), props, storeParams).close();
+
+      // Start push job with target region push enabled
+      props.put(TARGETED_REGION_PUSH_WITH_DEFERRED_SWAP, true);
+      props.put(TARGETED_REGION_PUSH_LIST, TARGET_REGION);
+      TestWriteUtils.runPushJob("Test push job", props);
+      TestUtils.waitForNonDeterministicPushCompletion(
+          Version.composeKafkaTopic(storeName, 1),
+          parentControllerClient,
+          30,
+          TimeUnit.SECONDS);
+
+      // Version should only be swapped in the target region
+      TestUtils.waitForNonDeterministicAssertion(1, TimeUnit.MINUTES, () -> {
+        Map<String, Integer> coloVersions =
+            parentControllerClient.getStore(storeName).getStore().getColoToCurrentVersions();
+
+        coloVersions.forEach((colo, version) -> {
+          if (colo.equals(TARGET_REGION)) {
+            Assert.assertEquals((int) version, 1);
+          } else {
+            Assert.assertEquals((int) version, 0);
+          }
+        });
+      });
+
+      TestUtils.waitForNonDeterministicAssertion(30, TimeUnit.SECONDS, () -> {
+        StoreInfo parentStore = parentControllerClient.getStore(storeName).getStore();
+        Assert.assertEquals(parentStore.getVersion(1).get().getStatus(), VersionStatus.PUSHED);
+      });
+
+      // Version should be swapped in all regions
+      TestUtils.waitForNonDeterministicAssertion(2, TimeUnit.MINUTES, () -> {
+        Map<String, Integer> coloVersions =
+            parentControllerClient.getStore(storeName).getStore().getColoToCurrentVersions();
+
+        coloVersions.forEach((colo, version) -> {
+          Assert.assertEquals((int) version, 1);
         });
       });
     }

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestDeferredVersionSwap.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestDeferredVersionSwap.java
@@ -3,7 +3,7 @@ package com.linkedin.venice.endToEnd;
 import static com.linkedin.venice.ConfigKeys.CONTROLLER_DEFERRED_VERSION_SWAP_SERVICE_ENABLED;
 import static com.linkedin.venice.ConfigKeys.CONTROLLER_DEFERRED_VERSION_SWAP_SLEEP_MS;
 import static com.linkedin.venice.utils.IntegrationTestPushUtils.createStoreForJob;
-import static com.linkedin.venice.utils.TestUtils.*;
+import static com.linkedin.venice.utils.TestUtils.assertCommand;
 import static com.linkedin.venice.utils.TestWriteUtils.NAME_RECORD_V3_SCHEMA;
 import static com.linkedin.venice.utils.TestWriteUtils.getTempDataDirectory;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.TARGETED_REGION_PUSH_LIST;
@@ -208,7 +208,7 @@ public class TestDeferredVersionSwap {
   @Test(timeOut = TEST_TIMEOUT * 2)
   public void testDeferredVersionSwapWithFailedPush() throws IOException {
     // Always mark the status as ERROR for dc-1 to mimic a push failing
-    multiRegionMultiClusterWrapper.useLeaderErrorNotifier("dc-1");
+    multiRegionMultiClusterWrapper.failPushInRegion("dc-1");
 
     // Setup job properties
     File inputDir = getTempDataDirectory();

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestDeferredVersionSwap.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestDeferredVersionSwap.java
@@ -5,6 +5,7 @@ import static com.linkedin.venice.ConfigKeys.CONTROLLER_DEFERRED_VERSION_SWAP_SL
 import static com.linkedin.venice.utils.IntegrationTestPushUtils.createStoreForJob;
 import static com.linkedin.venice.utils.TestWriteUtils.NAME_RECORD_V3_SCHEMA;
 import static com.linkedin.venice.utils.TestWriteUtils.getTempDataDirectory;
+import static com.linkedin.venice.vpj.VenicePushJobConstants.TARGETED_REGION_PUSH_LIST;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.TARGETED_REGION_PUSH_WITH_DEFERRED_SWAP;
 
 import com.linkedin.venice.controllerapi.ControllerClient;
@@ -80,7 +81,6 @@ public class TestDeferredVersionSwap {
     String keySchemaStr = "\"string\"";
     UpdateStoreQueryParams storeParms = new UpdateStoreQueryParams().setUnusedSchemaDeletionEnabled(true);
     storeParms.setTargetRegionSwapWaitTime(1);
-    storeParms.setTargetRegionSwap(TARGET_REGION);
     String parentControllerURLs = multiRegionMultiClusterWrapper.getControllerConnectString();
 
     try (ControllerClient parentControllerClient = new ControllerClient(CLUSTER_NAMES[0], parentControllerURLs)) {
@@ -88,6 +88,7 @@ public class TestDeferredVersionSwap {
 
       // Start push job with target region push enabled
       props.put(TARGETED_REGION_PUSH_WITH_DEFERRED_SWAP, true);
+      props.put(TARGETED_REGION_PUSH_LIST, TARGET_REGION);
       TestWriteUtils.runPushJob("Test push job", props);
       TestUtils.waitForNonDeterministicPushCompletion(
           Version.composeKafkaTopic(storeName, 1),
@@ -127,6 +128,74 @@ public class TestDeferredVersionSwap {
       TestUtils.waitForNonDeterministicAssertion(30, TimeUnit.SECONDS, () -> {
         StoreInfo parentStore = parentControllerClient.getStore(storeName).getStore();
         Assert.assertEquals(parentStore.getVersion(1).get().getStatus(), VersionStatus.ONLINE);
+      });
+    }
+  }
+
+  @Test(timeOut = TEST_TIMEOUT)
+  public void testDeferredVersionSwapMultiplePushes() throws IOException {
+    File inputDir = getTempDataDirectory();
+    TestWriteUtils.writeSimpleAvroFileWithStringToV3Schema(inputDir, 100, 100);
+    // Setup job properties
+    String inputDirPath = "file://" + inputDir.getAbsolutePath();
+    String storeName = Utils.getUniqueString("testDeferredVersionSwap");
+    Properties props =
+        IntegrationTestPushUtils.defaultVPJProps(multiRegionMultiClusterWrapper, inputDirPath, storeName);
+    String keySchemaStr = "\"string\"";
+    UpdateStoreQueryParams storeParms = new UpdateStoreQueryParams().setUnusedSchemaDeletionEnabled(true);
+    storeParms.setTargetRegionSwapWaitTime(1);
+    String parentControllerURLs = multiRegionMultiClusterWrapper.getControllerConnectString();
+
+    try (ControllerClient parentControllerClient = new ControllerClient(CLUSTER_NAMES[0], parentControllerURLs)) {
+      createStoreForJob(CLUSTER_NAMES[0], keySchemaStr, NAME_RECORD_V3_SCHEMA.toString(), props, storeParms).close();
+
+      // Start push job with target region push enabled
+      props.put(TARGETED_REGION_PUSH_WITH_DEFERRED_SWAP, true);
+      props.put(TARGETED_REGION_PUSH_LIST, TARGET_REGION);
+      TestWriteUtils.runPushJob("Test push job", props);
+      TestUtils.waitForNonDeterministicPushCompletion(
+          Version.composeKafkaTopic(storeName, 1),
+          parentControllerClient,
+          30,
+          TimeUnit.SECONDS);
+
+      // Version should only be swapped in the target region
+      TestUtils.waitForNonDeterministicAssertion(1, TimeUnit.MINUTES, () -> {
+        Map<String, Integer> coloVersions =
+            parentControllerClient.getStore(storeName).getStore().getColoToCurrentVersions();
+
+        coloVersions.forEach((colo, version) -> {
+          if (colo.equals(TARGET_REGION)) {
+            Assert.assertEquals((int) version, 1);
+          } else {
+            Assert.assertEquals((int) version, 0);
+          }
+        });
+      });
+
+      TestUtils.waitForNonDeterministicAssertion(30, TimeUnit.SECONDS, () -> {
+        StoreInfo parentStore = parentControllerClient.getStore(storeName).getStore();
+        Assert.assertEquals(parentStore.getVersion(1).get().getStatus(), VersionStatus.PUSHED);
+      });
+
+      // Start a normal push
+      props.put(TARGETED_REGION_PUSH_WITH_DEFERRED_SWAP, false);
+      props.remove(TARGETED_REGION_PUSH_LIST);
+      TestWriteUtils.runPushJob("Test push job 2", props);
+      TestUtils.waitForNonDeterministicPushCompletion(
+          Version.composeKafkaTopic(storeName, 2),
+          parentControllerClient,
+          30,
+          TimeUnit.SECONDS);
+
+      // Verify that the latest version is 2
+      TestUtils.waitForNonDeterministicAssertion(2, TimeUnit.MINUTES, () -> {
+        Map<String, Integer> coloVersions =
+            parentControllerClient.getStore(storeName).getStore().getColoToCurrentVersions();
+
+        coloVersions.forEach((colo, version) -> {
+          Assert.assertEquals((int) version, 2);
+        });
       });
     }
   }

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/integration/utils/VeniceTwoLayerMultiRegionMultiClusterWrapper.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/integration/utils/VeniceTwoLayerMultiRegionMultiClusterWrapper.java
@@ -453,7 +453,7 @@ public class VeniceTwoLayerMultiRegionMultiClusterWrapper extends ProcessWrapper
     }
   }
 
-  public void useLeaderErrorNotifier(String regions) {
+  public void failPushInRegion(String regions) {
     Set<String> regionsList = RegionUtils.parseRegionsFilterList(regions);
     for (VeniceMultiClusterWrapper childRegion: getChildRegions()) {
       for (Map.Entry<String, VeniceClusterWrapper> cluster: childRegion.getClusters().entrySet()) {

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/integration/utils/VeniceTwoLayerMultiRegionMultiClusterWrapper.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/integration/utils/VeniceTwoLayerMultiRegionMultiClusterWrapper.java
@@ -17,8 +17,11 @@ import static com.linkedin.venice.ConfigKeys.PARTICIPANT_MESSAGE_STORE_ENABLED;
 import static com.linkedin.venice.integration.utils.VeniceClusterWrapperConstants.CHILD_REGION_NAME_PREFIX;
 import static com.linkedin.venice.integration.utils.VeniceClusterWrapperConstants.DEFAULT_PARENT_DATA_CENTER_REGION_NAME;
 
+import com.linkedin.davinci.helix.HelixParticipationService;
+import com.linkedin.davinci.notifier.LeaderErrorNotifier;
 import com.linkedin.venice.exceptions.VeniceException;
 import com.linkedin.venice.pubsub.api.PubSubSecurityProtocol;
+import com.linkedin.venice.utils.RegionUtils;
 import com.linkedin.venice.utils.Time;
 import com.linkedin.venice.utils.Utils;
 import java.io.File;
@@ -30,6 +33,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Properties;
+import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import org.apache.commons.io.IOUtils;
@@ -444,6 +448,30 @@ public class VeniceTwoLayerMultiRegionMultiClusterWrapper extends ProcessWrapper
         }
         for (VeniceRouterWrapper router: clusterWrapper.getVeniceRouters()) {
           LOGGER.info("--> Router: {}", router.getAddressForLogging());
+        }
+      }
+    }
+  }
+
+  public void useLeaderErrorNotifier(String regions) {
+    Set<String> regionsList = RegionUtils.parseRegionsFilterList(regions);
+    for (VeniceMultiClusterWrapper childRegion: getChildRegions()) {
+      for (Map.Entry<String, VeniceClusterWrapper> cluster: childRegion.getClusters().entrySet()) {
+        if (regionsList.contains(childRegion.getRegionName())) {
+          LeaderErrorNotifier leaderErrorNotifier = null;
+          List<VeniceServerWrapper> veniceServerWrapperList = cluster.getValue().getVeniceServers();
+          for (VeniceServerWrapper veniceServerWrapper: veniceServerWrapperList) {
+            // Add error notifier which will report leader to be in ERROR instead of COMPLETE
+            HelixParticipationService participationService =
+                veniceServerWrapper.getVeniceServer().getHelixParticipationService();
+            leaderErrorNotifier = new LeaderErrorNotifier(
+                participationService.getVeniceOfflinePushMonitorAccessor(),
+                null,
+                participationService.getStatusStoreWriter(),
+                participationService.getHelixReadOnlyStoreRepository(),
+                participationService.getInstance().getNodeId());
+            participationService.replaceAndAddTestIngestionNotifier(leaderErrorNotifier);
+          }
         }
       }
     }

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/Admin.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/Admin.java
@@ -497,7 +497,8 @@ public interface Admin extends AutoCloseable, Closeable {
       String kafkaTopic,
       Optional<String> incrementalPushVersion,
       String region,
-      String targetedRegions);
+      String targetedRegions,
+      boolean isTargetRegionPushWithDeferredSwap);
 
   /**
    * Return the ssl or non-ssl bootstrap servers based on the given flag.

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceHelixAdmin.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceHelixAdmin.java
@@ -6505,10 +6505,20 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
     return getOffLinePushStatus(clusterName, kafkaTopic, Optional.empty(), null, null);
   }
 
-  /**
-   * @see Admin#getOffLinePushStatus(String, String, Optional, String, String).
-   */
   @Override
+  public OfflinePushStatusInfo getOffLinePushStatus(
+      String clusterName,
+      String kafkaTopic,
+      Optional<String> incrementalPushVersion,
+      String region,
+      String targetedRegions,
+      boolean isTargetRegionPushWithDeferredSwap) {
+    return getOffLinePushStatus(clusterName, kafkaTopic, incrementalPushVersion, region, targetedRegions);
+  }
+
+  /**
+   * @see Admin#getOffLinePushStatus(String, String, Optional, String, String, boolean).
+   */
   public OfflinePushStatusInfo getOffLinePushStatus(
       String clusterName,
       String kafkaTopic,

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceParentHelixAdmin.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceParentHelixAdmin.java
@@ -3749,7 +3749,7 @@ public class VeniceParentHelixAdmin implements Admin {
           // status PUSHED is set when batch store's target region push is completed, but other region are yet to
           // complete
           if (currentReturnStatus.equals(ExecutionStatus.COMPLETED)) {
-            if (isTargetRegionPushWithDeferredSwapForCurrentVersion) {
+            if (isTargetRegionPush && !isVersionPushed) {
               parentStore.updateVersionStatus(versionNum, PUSHED);
               repository.updateStore(parentStore);
             } else { // status ONLINE is set when all region finishes ingestion for either regular or target region

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceParentHelixAdmin.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceParentHelixAdmin.java
@@ -3608,7 +3608,8 @@ public class VeniceParentHelixAdmin implements Admin {
       String kafkaTopic,
       Optional<String> incrementalPushVersion,
       String region,
-      String targetedRegions) {
+      String targetedRegions,
+      boolean isTargetRegionPushWithDeferredSwap) {
     Map<String, ControllerClient> controllerClients = getVeniceHelixAdmin().getControllerClientMap(clusterName);
     if (region != null) {
       if (!controllerClients.containsKey(region)) {
@@ -3626,14 +3627,20 @@ public class VeniceParentHelixAdmin implements Admin {
       offlinePushStatusInfo.setUncompletedPartitions(response.getUncompletedPartitions());
       return offlinePushStatusInfo;
     }
-    return getOffLineJobStatus(clusterName, kafkaTopic, controllerClients, incrementalPushVersion, targetedRegions);
+    return getOffLineJobStatus(
+        clusterName,
+        kafkaTopic,
+        controllerClients,
+        incrementalPushVersion,
+        targetedRegions,
+        isTargetRegionPushWithDeferredSwap);
   }
 
   OfflinePushStatusInfo getOffLineJobStatus(
       String clusterName,
       String kafkaTopic,
       Map<String, ControllerClient> controllerClients) {
-    return getOffLineJobStatus(clusterName, kafkaTopic, controllerClients, Optional.empty(), null);
+    return getOffLineJobStatus(clusterName, kafkaTopic, controllerClients, Optional.empty(), null, false);
   }
 
   /**
@@ -3650,7 +3657,8 @@ public class VeniceParentHelixAdmin implements Admin {
       String kafkaTopic,
       Map<String, ControllerClient> controllerClients,
       Optional<String> incrementalPushVersion,
-      String targetedRegions) {
+      String targetedRegions,
+      boolean isTargetRegionPushWithDeferredSwap) {
     Set<String> childRegions = controllerClients.keySet();
     Map<String, ExecutionStatus> statuses = new HashMap<>();
     Map<String, String> extraInfo = new HashMap<>();
@@ -3661,8 +3669,10 @@ public class VeniceParentHelixAdmin implements Admin {
 
     for (Map.Entry<String, ControllerClient> entry: controllerClients.entrySet()) {
       String region = entry.getKey();
-      // if targetedRegions is present, only query the targeted regions
-      if (!targetedRegionSet.isEmpty() && !targetedRegionSet.contains(region)) {
+      // if targetedRegions is present, and it is not a target region push with deferred swap, only query the targeted
+      // regions
+      // otherwise, query all regions
+      if (!targetedRegionSet.isEmpty() && !targetedRegionSet.contains(region) && !isTargetRegionPushWithDeferredSwap) {
         continue;
       }
       ControllerClient controllerClient = entry.getValue();
@@ -3717,13 +3727,14 @@ public class VeniceParentHelixAdmin implements Admin {
           Version storeVersion = parentStore.getVersion(versionNum);
           boolean isVersionPushed = storeVersion != null && storeVersion.getStatus().equals(PUSHED);
           boolean isHybridStore = storeVersion != null && storeVersion.getHybridStoreConfig() != null;
+          boolean isTargetRegionPushWithDeferredSwapForCurrentVersion = isTargetRegionPush && !isVersionPushed;
           // Truncate topic after push is in terminal state if
           // 1. Its a hybrid store or regular push. (Hybrid store target push uses repush where isTargetRegionPush is
           // false)
           // 2. If target region push is enabled and job to push data only to target region completed (status == PUSHED)
           if (!isTargetRegionPush // regular push
               || isVersionPushed // target region push
-              || isHybridStore) {
+              || isHybridStore || isTargetRegionPushWithDeferredSwapForCurrentVersion) {
             LOGGER
                 .info("Truncating parent VT {} after push status {}", kafkaTopic, currentReturnStatus.getRootStatus());
             truncateTopicsOptionally(
@@ -3736,7 +3747,7 @@ public class VeniceParentHelixAdmin implements Admin {
           // status PUSHED is set when batch store's target region push is completed, but other region are yet to
           // complete
           if (currentReturnStatus.equals(ExecutionStatus.COMPLETED)) {
-            if (isTargetRegionPush && !isVersionPushed) {
+            if (isTargetRegionPushWithDeferredSwapForCurrentVersion) {
               parentStore.updateVersionStatus(versionNum, PUSHED);
               repository.updateStore(parentStore);
             } else { // status ONLINE is set when all region finishes ingestion for either regular or target region
@@ -3845,8 +3856,11 @@ public class VeniceParentHelixAdmin implements Admin {
       boolean incPushEnabledBatchPushSuccess = !incrementalPushVersion.isPresent() && store.isIncrementalPushEnabled();
       boolean nonIncPushBatchSuccess = !store.isIncrementalPushEnabled() && !currentReturnStatus.isError();
       boolean isDeferredVersionSwap = version != null && version.isVersionSwapDeferred();
+      boolean isTargetRegionPushWithDeferredSwap =
+          isDeferredVersionSwap && !StringUtils.isEmpty(version.getTargetSwapRegion());
 
-      if ((failedBatchPush || nonIncPushBatchSuccess && !isDeferredVersionSwap || incPushEnabledBatchPushSuccess)
+      if ((failedBatchPush || nonIncPushBatchSuccess && !isDeferredVersionSwap || incPushEnabledBatchPushSuccess
+          || isTargetRegionPushWithDeferredSwap)
           && !getMultiClusterConfigs().getCommonConfig().disableParentTopicTruncationUponCompletion()) {
         LOGGER.info("Truncating kafka topic: {} with job status: {}", kafkaTopic, currentReturnStatus);
         truncateKafkaTopic(kafkaTopic);

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceParentHelixAdmin.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceParentHelixAdmin.java
@@ -3727,7 +3727,8 @@ public class VeniceParentHelixAdmin implements Admin {
           Version storeVersion = parentStore.getVersion(versionNum);
           boolean isVersionPushed = storeVersion != null && storeVersion.getStatus().equals(PUSHED);
           boolean isHybridStore = storeVersion != null && storeVersion.getHybridStoreConfig() != null;
-          boolean isTargetRegionPushWithDeferredSwapForCurrentVersion = isTargetRegionPush && !isVersionPushed;
+          boolean isTargetRegionPushWithDeferredSwapForCurrentVersion =
+              isTargetRegionPush && version.isVersionSwapDeferred();
           // Truncate topic after push is in terminal state if
           // 1. Its a hybrid store or regular push. (Hybrid store target push uses repush where isTargetRegionPush is
           // false)

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceParentHelixAdmin.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceParentHelixAdmin.java
@@ -3732,6 +3732,7 @@ public class VeniceParentHelixAdmin implements Admin {
           // 1. Its a hybrid store or regular push. (Hybrid store target push uses repush where isTargetRegionPush is
           // false)
           // 2. If target region push is enabled and job to push data only to target region completed (status == PUSHED)
+          // 3. If it is a target region push with deferred swap and a majority of regions have reached terminal status
           if (!isTargetRegionPush // regular push
               || isVersionPushed // target region push
               || isHybridStore || isTargetRegionPushWithDeferredSwapForCurrentVersion) {
@@ -3848,6 +3849,7 @@ public class VeniceParentHelixAdmin implements Admin {
        * 1. the store is not incremental push enabled and the push completed (no ERROR)
        * 2. this is a failed batch push
        * 3. the store is incremental push enabled and same incPushToRT and batch push finished
+       * 4. it is a target region push with deferred swap (targetRegions != null and deferVersionSwap == true)
        */
       Store store = getVeniceHelixAdmin().getStore(clusterName, Version.parseStoreFromKafkaTopicName(kafkaTopic));
       boolean failedBatchPush = !incrementalPushVersion.isPresent() && currentReturnStatus.isError();

--- a/services/venice-controller/src/test/java/com/linkedin/venice/controller/server/JobRoutesTest.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/controller/server/JobRoutesTest.java
@@ -1,5 +1,6 @@
 package com.linkedin.venice.controller.server;
 
+import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.anyString;
 import static org.mockito.Mockito.doReturn;
@@ -26,7 +27,7 @@ public class JobRoutesTest {
     Admin mockAdmin = mock(VeniceParentHelixAdmin.class);
     doReturn(true).when(mockAdmin).isLeaderControllerFor(anyString());
     doReturn(new Admin.OfflinePushStatusInfo(ExecutionStatus.COMPLETED)).when(mockAdmin)
-        .getOffLinePushStatus(anyString(), anyString(), any(), any(), any(), any());
+        .getOffLinePushStatus(anyString(), anyString(), any(), any(), any(), anyBoolean());
 
     doReturn(2).when(mockAdmin).getReplicationFactor(anyString(), anyString());
 

--- a/services/venice-controller/src/test/java/com/linkedin/venice/controller/server/JobRoutesTest.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/controller/server/JobRoutesTest.java
@@ -26,7 +26,7 @@ public class JobRoutesTest {
     Admin mockAdmin = mock(VeniceParentHelixAdmin.class);
     doReturn(true).when(mockAdmin).isLeaderControllerFor(anyString());
     doReturn(new Admin.OfflinePushStatusInfo(ExecutionStatus.COMPLETED)).when(mockAdmin)
-        .getOffLinePushStatus(anyString(), anyString(), any(), any(), any());
+        .getOffLinePushStatus(anyString(), anyString(), any(), any(), any(), any());
 
     doReturn(2).when(mockAdmin).getReplicationFactor(anyString(), anyString());
 
@@ -35,7 +35,7 @@ public class JobRoutesTest {
     int version = 5;
     JobRoutes jobRoutes = new JobRoutes(false, Optional.empty());
     JobStatusQueryResponse response =
-        jobRoutes.populateJobStatus(cluster, store, version, mockAdmin, Optional.empty(), null, null);
+        jobRoutes.populateJobStatus(cluster, store, version, mockAdmin, Optional.empty(), null, null, false);
 
     Map<String, String> extraInfo = response.getExtraInfo();
     LOGGER.info("extraInfo: {}", extraInfo);


### PR DESCRIPTION
<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat], [protocol]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## Summary, imperative, start upper case, don't end with a period
<!--
Describe
- What changes to make and why you are making these changes.
- How are you going to achieve your goal.
- Describe what testings you have done, for example, performance testing etc.

If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

For a target region push with deferred swap, we only poll for the job status of the target regions. This, however, is incorrect because we ingest data in all regions concurrently so the push completion should mean that >50% of all regions are in terminal status. Once the push is in terminal status, we need to truncate the kafka topic so that future pushes can start, but for target region push with deferred swap, this isn't the case currently. We only truncate the kafka topic once we roll forward in the remaining non target regions. This is also incorrect because when a push is marked as complete (when >50% of the regions are in terminal status), we should be able to start another push regardless if the version is swapped in all regions

Changes included for a target region push w/ deferred swap:
- Poll job status for *all* regions
- Truncate kafka topic once >50% of all regions are in terminal status

## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
Integration test

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.