### PR TITLE
[server][controller][dvc][vpj][cc] Extend DefaultPubSubMessage with explicitly defined getter methods  

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/consumer/VeniceAfterImageConsumerImpl.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/consumer/VeniceAfterImageConsumerImpl.java
@@ -152,7 +152,7 @@ public class VeniceAfterImageConsumerImpl<K, V> extends VeniceChangelogConsumerI
                       endOfPushConsumedPerPartitionMap.put(pubSubTopicPartition.getPartitionNumber(), true);
                       VeniceChangeCoordinate coordinate = new VeniceChangeCoordinate(
                           pubSubTopicPartition.getPubSubTopic().getName(),
-                          message.getOffset(),
+                          message.getPosition(),
                           pubSubTopicPartition.getPartitionNumber());
                       checkpoints.add(coordinate);
                       Set<Integer> unsubSet = new HashSet<>();

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/consumer/VeniceChangelogConsumerImpl.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/consumer/VeniceChangelogConsumerImpl.java
@@ -637,7 +637,7 @@ public class VeniceChangelogConsumerImpl<K, V> implements VeniceChangelogConsume
                     null,
                     null,
                     message.getTopicPartition(),
-                    message.getOffset(),
+                    message.getPosition(),
                     0,
                     0,
                     false));
@@ -761,7 +761,7 @@ public class VeniceChangelogConsumerImpl<K, V> implements VeniceChangelogConsume
               keyDeserializer.deserialize(keyBytes),
               changeEvent,
               pubSubTopicPartition,
-              message.getOffset(),
+              message.getPosition(),
               message.getPubSubMessageTime(),
               message.getPayloadSize(),
               false));
@@ -775,7 +775,7 @@ public class VeniceChangelogConsumerImpl<K, V> implements VeniceChangelogConsume
         LOGGER.info(
             "Encounter RMD extraction exception for delete OP. partition={}, offset={}, key={}, rmd={}, rmd_id={}",
             message.getPartition(),
-            message.getOffset(),
+            message.getPosition(),
             keyDeserializer.deserialize(keyBytes),
             delete.getReplicationMetadataPayload(),
             delete.getReplicationMetadataVersionId(),
@@ -809,7 +809,7 @@ public class VeniceChangelogConsumerImpl<K, V> implements VeniceChangelogConsume
           put.getSchemaId(),
           keyBytes,
           put.getPutValue(),
-          message.getOffset().getNumericOffset(),
+          message.getPosition().getNumericOffset(),
           deserializerProvider,
           readerSchemaId,
           compressor);
@@ -826,7 +826,7 @@ public class VeniceChangelogConsumerImpl<K, V> implements VeniceChangelogConsume
             put.getPutValue(),
             pubSubTopicPartition,
             readerSchemaId,
-            message.getOffset().getNumericOffset());
+            message.getPosition().getNumericOffset());
       } catch (Exception ex) {
         throw new VeniceException(ex);
       }
@@ -843,7 +843,7 @@ public class VeniceChangelogConsumerImpl<K, V> implements VeniceChangelogConsume
           LOGGER.info(
               "Encounter RMD extraction exception for PUT OP. partition={}, offset={}, key={}, value={}, rmd={}, rmd_id={}",
               message.getPartition(),
-              message.getOffset(),
+              message.getPosition(),
               keyDeserializer.deserialize(keyBytes),
               assembledObject,
               put.getReplicationMetadataPayload(),
@@ -867,7 +867,7 @@ public class VeniceChangelogConsumerImpl<K, V> implements VeniceChangelogConsume
                 recordChangeEvent,
                 keyDeserializer.deserialize(keyBytes),
                 pubSubTopicPartition,
-                message.getOffset(),
+                message.getPosition(),
                 message.getPubSubMessageTime(),
                 payloadSize));
       } else {
@@ -877,7 +877,7 @@ public class VeniceChangelogConsumerImpl<K, V> implements VeniceChangelogConsume
                 keyDeserializer.deserialize(keyBytes),
                 changeEvent,
                 pubSubTopicPartition,
-                message.getOffset(),
+                message.getPosition(),
                 message.getPubSubMessageTime(),
                 payloadSize,
                 false));

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/ActiveActiveStoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/ActiveActiveStoreIngestionTask.java
@@ -479,7 +479,7 @@ public class ActiveActiveStoreIngestionTask extends LeaderFollowerStoreIngestion
         : Collections.singletonList(0L);
 
     // get the source offset and the id
-    long sourceOffset = consumerRecord.getOffset().getNumericOffset();
+    long sourceOffset = consumerRecord.getPosition().getNumericOffset();
     final MergeConflictResult mergeConflictResult;
 
     aggVersionedIngestionStats.recordTotalDCR(storeName, versionNumber);
@@ -571,7 +571,7 @@ public class ActiveActiveStoreIngestionTask extends LeaderFollowerStoreIngestion
         aggVersionedIngestionStats.recordTombStoneCreationDCR(storeName, versionNumber);
         partitionConsumptionState.setTransientRecord(
             kafkaClusterId,
-            consumerRecord.getOffset().getNumericOffset(),
+            consumerRecord.getPosition().getNumericOffset(),
             keyBytes,
             valueSchemaId,
             rmdRecord);
@@ -579,7 +579,7 @@ public class ActiveActiveStoreIngestionTask extends LeaderFollowerStoreIngestion
         int valueLen = updatedValueBytes.remaining();
         partitionConsumptionState.setTransientRecord(
             kafkaClusterId,
-            consumerRecord.getOffset().getNumericOffset(),
+            consumerRecord.getPosition().getNumericOffset(),
             keyBytes,
             updatedValueBytes.array(),
             updatedValueBytes.position(),
@@ -868,7 +868,7 @@ public class ActiveActiveStoreIngestionTask extends LeaderFollowerStoreIngestion
                   oldValueManifest,
                   oldRmdManifest);
       LeaderProducedRecordContext leaderProducedRecordContext = LeaderProducedRecordContext
-          .newDeleteRecord(kafkaClusterId, consumerRecord.getOffset().getNumericOffset(), key, deletePayload);
+          .newDeleteRecord(kafkaClusterId, consumerRecord.getPosition().getNumericOffset(), key, deletePayload);
       produceToLocalKafka(
           consumerRecord,
           partitionConsumptionState,
@@ -899,7 +899,7 @@ public class ActiveActiveStoreIngestionTask extends LeaderFollowerStoreIngestion
           consumerRecord,
           partitionConsumptionState,
           LeaderProducedRecordContext
-              .newPutRecord(kafkaClusterId, consumerRecord.getOffset().getNumericOffset(), key, updatedPut),
+              .newPutRecord(kafkaClusterId, consumerRecord.getPosition().getNumericOffset(), key, updatedPut),
           produceToTopicFunction,
           partition,
           kafkaUrl,
@@ -932,7 +932,7 @@ public class ActiveActiveStoreIngestionTask extends LeaderFollowerStoreIngestion
     if (partitionConsumptionState.getLeaderFollowerState() == LEADER && partitionConsumptionState.isHybrid()
         && consumerRecord.getTopicPartition().getPubSubTopic().isRealTime()) {
       partitionConsumptionState
-          .updateLatestRTOffsetTriedToProduceToVTMap(kafkaUrl, consumerRecord.getOffset().getNumericOffset());
+          .updateLatestRTOffsetTriedToProduceToVTMap(kafkaUrl, consumerRecord.getPosition().getNumericOffset());
     }
   }
 
@@ -1280,7 +1280,7 @@ public class ActiveActiveStoreIngestionTask extends LeaderFollowerStoreIngestion
               kafkaClusterIdToUrlMap,
               recordSourceKafkaUrl,
               consumerRecord.getTopicPartition(),
-              consumerRecord.getOffset().getNumericOffset(),
+              consumerRecord.getPosition().getNumericOffset(),
               type.toString() + (type == MessageType.CONTROL_MESSAGE
                   ? "/" + ControlMessageType.valueOf((ControlMessage) kafkaValue.getPayloadUnion())
                   : ""),

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderProducerCallback.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderProducerCallback.java
@@ -210,7 +210,7 @@ public class LeaderProducerCallback implements ChunkAwareCallback {
             ingestionTask.ingestionTaskName,
             endOfPushReceived,
             sourceConsumerRecord.getTopicPartition(),
-            sourceConsumerRecord.getOffset(),
+            sourceConsumerRecord.getPosition(),
             oe);
         // If EOP is not received yet, set the ingestion task exception so that ingestion will fail eventually.
         if (!endOfPushReceived) {

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreBufferService.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreBufferService.java
@@ -783,7 +783,7 @@ public class StoreBufferService extends AbstractStoreBufferService {
     }
 
     @Override
-    public PubSubPosition getOffset() {
+    public PubSubPosition getPosition() {
       return null;
     }
 

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/validation/PartitionTracker.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/validation/PartitionTracker.java
@@ -252,7 +252,7 @@ public class PartitionTracker {
     trackSequenceNumber(segment, consumerRecord, endOfPushReceived, tolerateMissingMsgs, hasPreviousSegment);
     // This is the last step, because we want failures in the previous steps to short-circuit execution.
     trackCheckSum(segment, consumerRecord, endOfPushReceived, tolerateMissingMsgs);
-    segment.setLastSuccessfulOffset(consumerRecord.getOffset().getNumericOffset());
+    segment.setLastSuccessfulOffset(consumerRecord.getPosition().getNumericOffset());
     segment.setNewSegment(false);
   }
 
@@ -783,7 +783,7 @@ public class PartitionTracker {
         sb.append("; previous successful offset (in same segment): ").append(segment.getLastSuccessfulOffset());
       }
       sb.append("; incoming offset: ")
-          .append(consumerRecord.getOffset())
+          .append(consumerRecord.getPosition())
           .append("; previous segment: ")
           .append(previousSegment)
           .append("; incoming segment: ")

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/ActiveActiveStoreIngestionTaskTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/ActiveActiveStoreIngestionTaskTest.java
@@ -141,7 +141,7 @@ public class ActiveActiveStoreIngestionTaskTest {
     when(consumerRecord.getKey()).thenReturn(kafkaKey);
     KafkaMessageEnvelope kafkaValue = new KafkaMessageEnvelope();
     when(consumerRecord.getValue()).thenReturn(kafkaValue);
-    when(consumerRecord.getOffset()).thenReturn(ApacheKafkaOffsetPosition.of(1));
+    when(consumerRecord.getPosition()).thenReturn(ApacheKafkaOffsetPosition.of(1));
     kafkaValue.messageType = MessageType.DELETE.getValue();
     Delete deletePayload = new Delete();
     kafkaValue.payloadUnion = deletePayload;
@@ -384,7 +384,7 @@ public class ActiveActiveStoreIngestionTaskTest {
     ByteBuffer updatedValueBytes = ByteUtils.prependIntHeaderToByteBuffer(valueBytes, 1);
     ByteBuffer updatedRmdBytes = ByteBuffer.wrap(new byte[] { 0xa, 0xb });
     DefaultPubSubMessage consumerRecord = mock(DefaultPubSubMessage.class);
-    when(consumerRecord.getOffset()).thenReturn(ApacheKafkaOffsetPosition.of(100L));
+    when(consumerRecord.getPosition()).thenReturn(ApacheKafkaOffsetPosition.of(100L));
 
     Put updatedPut = new Put();
     updatedPut.putValue = ByteUtils.prependIntHeaderToByteBuffer(updatedValueBytes, valueSchemaId, resultReuseInput);
@@ -392,7 +392,7 @@ public class ActiveActiveStoreIngestionTaskTest {
     updatedPut.replicationMetadataVersionId = rmdProtocolVersionID;
     updatedPut.replicationMetadataPayload = updatedRmdBytes;
     LeaderProducedRecordContext leaderProducedRecordContext = LeaderProducedRecordContext
-        .newPutRecord(kafkaClusterId, consumerRecord.getOffset().getNumericOffset(), updatedKeyBytes, updatedPut);
+        .newPutRecord(kafkaClusterId, consumerRecord.getPosition().getNumericOffset(), updatedKeyBytes, updatedPut);
 
     PartitionConsumptionState.TransientRecord transientRecord =
         new PartitionConsumptionState.TransientRecord(new byte[] { 0xa }, 0, 0, 0, 0, 0);

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTaskTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTaskTest.java
@@ -376,7 +376,7 @@ public class LeaderFollowerStoreIngestionTaskTest {
     ControlMessage controlMessage = mock(ControlMessage.class);
     doReturn(controlMessage).when(kafkaValue).getPayloadUnion();
     doReturn(ControlMessageType.START_OF_SEGMENT.getValue()).when(controlMessage).getControlMessageType();
-    doReturn(ApacheKafkaOffsetPosition.of(seqNumber)).when(pubSubMessage).getOffset();
+    doReturn(ApacheKafkaOffsetPosition.of(seqNumber)).when(pubSubMessage).getPosition();
     return pubSubMessageProcessedResultWrapper;
   }
 }

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/RegionNameUtilTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/RegionNameUtilTest.java
@@ -17,7 +17,7 @@ public class RegionNameUtilTest {
     regionIdToNameMap.put(1, "region1");
     regionIdToNameMap.put(2, "region2");
 
-    PubSubHelper.MutablePubSubMessage message = PubSubHelper.getDummyPubSubMessage(false);
+    PubSubHelper.MutableDefaultPubSubMessage message = PubSubHelper.getDummyPubSubMessage(false);
     message.getValue().leaderMetadataFooter = new LeaderMetadata();
 
     message.getValue().leaderMetadataFooter.upstreamKafkaClusterId = 0;

--- a/clients/venice-admin-tool/src/main/java/com/linkedin/venice/ControlMessageDumper.java
+++ b/clients/venice-admin-tool/src/main/java/com/linkedin/venice/ControlMessageDumper.java
@@ -92,7 +92,7 @@ public class ControlMessageDumper {
           ControlMessage msg = (ControlMessage) envelope.payloadUnion;
           ControlMessageType msgType = ControlMessageType.valueOf(msg);
           System.out.println();
-          System.out.println("offset: " + record.getOffset());
+          System.out.println("offset: " + record.getPosition());
           System.out.println("segment: " + metadata.segmentNumber);
           System.out.println("sequence number: " + metadata.messageSequenceNumber);
           System.out.println("timestamp1: " + metadata.messageTimestamp);

--- a/clients/venice-admin-tool/src/main/java/com/linkedin/venice/DumpAdminMessages.java
+++ b/clients/venice-admin-tool/src/main/java/com/linkedin/venice/DumpAdminMessages.java
@@ -83,7 +83,7 @@ public class DumpAdminMessages {
           Put put = (Put) messageEnvelope.payloadUnion;
           AdminOperation adminMessage = deserializer.deserialize(put.putValue, put.schemaId);
           AdminOperationInfo adminOperationInfo = new AdminOperationInfo();
-          adminOperationInfo.offset = record.getOffset().getNumericOffset();
+          adminOperationInfo.offset = record.getPosition().getNumericOffset();
           adminOperationInfo.schemaId = put.schemaId;
           adminOperationInfo.adminOperation = adminMessage.toString();
           adminOperationInfo.operationType = AdminMessageType.valueOf(adminMessage).name();

--- a/clients/venice-admin-tool/src/main/java/com/linkedin/venice/KafkaTopicDumper.java
+++ b/clients/venice-admin-tool/src/main/java/com/linkedin/venice/KafkaTopicDumper.java
@@ -381,7 +381,7 @@ public class KafkaTopicDumper implements AutoCloseable {
         while (recordIterator.hasNext() && processedMessageCount < messageCount) {
           DefaultPubSubMessage record = recordIterator.next();
           // Exit early if endOffset is reached
-          if (record.getOffset().getNumericOffset() > endOffset) {
+          if (record.getPosition().getNumericOffset() > endOffset) {
             LOGGER.info("Reached endOffset: {}. Total messages processed: {}", endOffset, processedMessageCount);
             return processedMessageCount;
           }
@@ -396,7 +396,7 @@ public class KafkaTopicDumper implements AutoCloseable {
           LOGGER.info(
               "Consumed {} messages; last consumed message offset: {}",
               processedMessageCount,
-              lastProcessedRecord.getOffset());
+              lastProcessedRecord.getPosition());
           lastReportedCount = processedMessageCount;
         }
 
@@ -476,7 +476,7 @@ public class KafkaTopicDumper implements AutoCloseable {
 
       LOGGER.info(
           "Offset:{}; {}; {}; ProducerMd=(guid:{},seg:{},seq:{},mts:{},lts:{}); LeaderMd=(host:{},uo:{},ukcId:{}){}",
-          record.getOffset(),
+          record.getPosition(),
           kafkaKey.isControlMessage() ? CONTROL_REC : REGULAR_REC,
           msgType,
           GuidUtils.getHexFromGuid(producerMetadata.producerGUID),
@@ -489,7 +489,7 @@ public class KafkaTopicDumper implements AutoCloseable {
           leaderMetadata == null ? "-" : leaderMetadata.upstreamKafkaClusterId,
           chunkMetadata);
     } catch (Exception e) {
-      LOGGER.error("Encounter exception when processing record for offset {}", record.getOffset(), e);
+      LOGGER.error("Encounter exception when processing record for offset {}", record.getPosition(), e);
     }
   }
 
@@ -502,7 +502,7 @@ public class KafkaTopicDumper implements AutoCloseable {
     MessageType msgType = MessageType.valueOf(kafkaMessageEnvelope);
     LOGGER.info(
         "[Record Data] Offset:{}; {}; {}",
-        record.getOffset(),
+        record.getPosition(),
         msgType.toString(),
         buildDataRecordLog(record, logReplicationMetadata));
 
@@ -568,7 +568,7 @@ public class KafkaTopicDumper implements AutoCloseable {
           throw new VeniceException("Unknown data type.");
       }
     } catch (Exception e) {
-      LOGGER.error("Encounter exception when processing record for offset: {}", record.getOffset(), e);
+      LOGGER.error("Encounter exception when processing record for offset: {}", record.getPosition(), e);
     }
     return logReplicationMetadata
         ? String
@@ -621,7 +621,7 @@ public class KafkaTopicDumper implements AutoCloseable {
     return String.format(
         "Offset:%s; %s; SourceKafkaServers: %s; SourceTopicName: %s; RewindStartTimestamp: %s; "
             + "ProducerMd=(guid:%s,seg:%s,seq:%s,mts:%s,lts:%s); LeaderMd=(host:%s,uo:%s,ukcId:%s)",
-        record.getOffset(),
+        record.getPosition(),
         ControlMessageType.TOPIC_SWITCH.name(),
         topicSwitch.sourceKafkaServers,
         topicSwitch.sourceTopicName,
@@ -646,7 +646,7 @@ public class KafkaTopicDumper implements AutoCloseable {
       }
       // build the record
       GenericRecord convertedRecord = new GenericData.Record(outputSchema);
-      convertedRecord.put(VENICE_ETL_OFFSET_FIELD, record.getOffset());
+      convertedRecord.put(VENICE_ETL_OFFSET_FIELD, record.getPosition());
 
       byte[] keyBytes = kafkaKey.getKey();
       Decoder keyDecoder = decoderFactory.binaryDecoder(keyBytes, null);
@@ -673,7 +673,7 @@ public class KafkaTopicDumper implements AutoCloseable {
           convertedRecord.put(VENICE_ETL_VALUE_FIELD, valueRecord);
           break;
         case DELETE:
-          convertedRecord.put(VENICE_ETL_DELETED_TS_FIELD, record.getOffset());
+          convertedRecord.put(VENICE_ETL_DELETED_TS_FIELD, record.getPosition());
           break;
         case UPDATE:
           LOGGER.info("Found update message! continue");
@@ -683,7 +683,7 @@ public class KafkaTopicDumper implements AutoCloseable {
       }
       dataFileWriter.append(convertedRecord);
     } catch (Exception e) {
-      LOGGER.error("Failed when building record for offset {}", record.getOffset(), e);
+      LOGGER.error("Failed when building record for offset {}", record.getPosition(), e);
     }
   }
 

--- a/clients/venice-admin-tool/src/main/java/com/linkedin/venice/RecoverStoreMetadata.java
+++ b/clients/venice-admin-tool/src/main/java/com/linkedin/venice/RecoverStoreMetadata.java
@@ -112,8 +112,8 @@ public class RecoverStoreMetadata {
 
       while (recordsIterator.hasNext()) {
         DefaultPubSubMessage record = recordsIterator.next();
-        if (record.getOffset().getNumericOffset() % 1000 == 0) {
-          System.out.println("Consumed " + record.getOffset() + " messages");
+        if (record.getPosition().getNumericOffset() % 1000 == 0) {
+          System.out.println("Consumed " + record.getPosition() + " messages");
         }
         messageEnvelope = record.getValue();
         // check message type

--- a/clients/venice-admin-tool/src/main/java/com/linkedin/venice/TopicMessageFinder.java
+++ b/clients/venice-admin-tool/src/main/java/com/linkedin/venice/TopicMessageFinder.java
@@ -111,14 +111,14 @@ public class TopicMessageFinder {
       }
       long lastRecordTimestamp = 0;
       for (DefaultPubSubMessage record: messages.get(assignedPubSubTopicPartition)) {
-        if (record.getOffset().getNumericOffset() >= endOffset) {
+        if (record.getPosition().getNumericOffset() >= endOffset) {
           done = true;
           break;
         }
         KafkaKey kafkaKey = record.getKey();
         if (Arrays.equals(kafkaKey.getKey(), serializedKey)) {
           KafkaMessageEnvelope value = record.getValue();
-          LOGGER.info("Offset: {}, Value: {}", record.getOffset(), value.toString());
+          LOGGER.info("Offset: {}, Value: {}", record.getPosition(), value.toString());
         }
         lastRecordTimestamp = record.getPubSubMessageTime();
         recordCnt++;

--- a/clients/venice-admin-tool/src/test/java/com/linkedin/venice/TestKafkaTopicDumper.java
+++ b/clients/venice-admin-tool/src/test/java/com/linkedin/venice/TestKafkaTopicDumper.java
@@ -452,7 +452,7 @@ public class TestKafkaTopicDumper {
       DefaultPubSubMessage message = mock(DefaultPubSubMessage.class);
       PubSubPosition pubSubPosition = mock(PubSubPosition.class);
       when(pubSubPosition.getNumericOffset()).thenReturn(startOffset + i);
-      when(message.getOffset()).thenReturn(pubSubPosition);
+      when(message.getPosition()).thenReturn(pubSubPosition);
       messages.add(message);
     }
     return messages;

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/input/kafka/KafkaInputRecordReader.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/input/kafka/KafkaInputRecordReader.java
@@ -167,7 +167,7 @@ public class KafkaInputRecordReader implements RecordReader<KafkaInputMapperKey,
       }
       pubSubMessage = recordIterator.hasNext() ? recordIterator.next() : null;
       if (pubSubMessage != null) {
-        currentOffset = pubSubMessage.getOffset().getNumericOffset();
+        currentOffset = pubSubMessage.getPosition().getNumericOffset();
 
         KafkaKey kafkaKey = pubSubMessage.getKey();
         KafkaMessageEnvelope kafkaMessageEnvelope = pubSubMessage.getValue();
@@ -179,7 +179,7 @@ public class KafkaInputRecordReader implements RecordReader<KafkaInputMapperKey,
 
         MessageType messageType = MessageType.valueOf(kafkaMessageEnvelope);
 
-        key.offset = pubSubMessage.getOffset().getNumericOffset();
+        key.offset = pubSubMessage.getPosition().getNumericOffset();
         if (isSourceVersionChunkingEnabled) {
           RawKeyBytesAndChunkedKeySuffix rawKeyAndChunkedKeySuffix =
               splitCompositeKey(kafkaKey.getKey(), messageType, getSchemaIdFromValue(kafkaMessageEnvelope));
@@ -189,7 +189,7 @@ public class KafkaInputRecordReader implements RecordReader<KafkaInputMapperKey,
         } else {
           key.key = ByteBuffer.wrap(kafkaKey.getKey(), 0, kafkaKey.getKeyLength());
         }
-        value.offset = pubSubMessage.getOffset().getNumericOffset();
+        value.offset = pubSubMessage.getPosition().getNumericOffset();
         switch (messageType) {
           case PUT:
             Put put = (Put) kafkaMessageEnvelope.payloadUnion;
@@ -210,7 +210,7 @@ public class KafkaInputRecordReader implements RecordReader<KafkaInputMapperKey,
           default:
             throw new IOException(
                 "Unexpected '" + messageType + "' message from Kafka topic partition: " + topicPartition
-                    + " with offset: " + pubSubMessage.getOffset());
+                    + " with offset: " + pubSubMessage.getPosition());
         }
         if (taskTracker != null) {
           taskTracker.trackPutOrDeleteRecord();

--- a/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/ImmutablePubSubMessage.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/ImmutablePubSubMessage.java
@@ -65,7 +65,7 @@ public class ImmutablePubSubMessage implements DefaultPubSubMessage {
   }
 
   @Override
-  public PubSubPosition getOffset() {
+  public PubSubPosition getPosition() {
     return pubSubPosition;
   }
 

--- a/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/adapter/kafka/ApacheKafkaOffsetPosition.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/adapter/kafka/ApacheKafkaOffsetPosition.java
@@ -85,7 +85,7 @@ public class ApacheKafkaOffsetPosition implements PubSubPosition {
 
   @Override
   public String toString() {
-    return String.format("KafkaOffset: %s", offset);
+    return offset + "";
   }
 
   @Override

--- a/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/api/DefaultPubSubMessage.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/api/DefaultPubSubMessage.java
@@ -4,5 +4,38 @@ import com.linkedin.venice.kafka.protocol.KafkaMessageEnvelope;
 import com.linkedin.venice.message.KafkaKey;
 
 
+/**
+ * A default implementation of {@link PubSubMessage} that represents a message in a pub-sub system
+ * with a {@link KafkaKey} as the key, a {@link KafkaMessageEnvelope} as the value, and a
+ * {@link PubSubPosition} to track the message's offset within the topic-partition.
+ */
 public interface DefaultPubSubMessage extends PubSubMessage<KafkaKey, KafkaMessageEnvelope, PubSubPosition> {
+  /**
+   * Retrieves the key associated with this message.
+   *
+   * @return the {@link KafkaKey} representing the message key.
+   */
+  KafkaKey getKey();
+
+  /**
+   * Retrieves the value payload of this message.
+   *
+   * @return the {@link KafkaMessageEnvelope} containing the message data.
+   */
+  KafkaMessageEnvelope getValue();
+
+  /**
+   * Retrieves the position of this message within the underlying topic-partition.
+   *
+   * @return the {@link PubSubPosition} representing the message offset.
+   */
+  PubSubPosition getPosition();
+
+  /**
+   * @Deprecated use {@link #getPosition()} instead.
+   * @return position of this message within the underlying topic-partition.
+   */
+  default PubSubPosition getOffset() {
+    return getPosition();
+  }
 }

--- a/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/manager/TopicMetadataFetcher.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/manager/TopicMetadataFetcher.java
@@ -638,7 +638,8 @@ class TopicMetadataFetcher implements Closeable {
           throw new VeniceException(message);
         }
         allConsumedRecords.addAll(consumedBatch);
-      } while (allConsumedRecords.get(allConsumedRecords.size() - 1).getOffset().getNumericOffset() + 1 < latestOffset);
+      } while (allConsumedRecords.get(allConsumedRecords.size() - 1).getPosition().getNumericOffset()
+          + 1 < latestOffset);
 
       return allConsumedRecords;
     } finally {

--- a/internal/venice-common/src/test/java/com/linkedin/venice/pubsub/adapter/kafka/ApacheKafkaOffsetPositionTest.java
+++ b/internal/venice-common/src/test/java/com/linkedin/venice/pubsub/adapter/kafka/ApacheKafkaOffsetPositionTest.java
@@ -93,7 +93,7 @@ public class ApacheKafkaOffsetPositionTest {
   @Test
   public void testToString() {
     ApacheKafkaOffsetPosition position1 = ApacheKafkaOffsetPosition.of(1);
-    assertEquals(position1.toString(), "KafkaOffset: 1");
+    assertEquals(position1.toString(), "1");
   }
 
   @Test

--- a/internal/venice-common/src/test/java/com/linkedin/venice/pubsub/api/PubSubMessageDeserializerTest.java
+++ b/internal/venice-common/src/test/java/com/linkedin/venice/pubsub/api/PubSubMessageDeserializerTest.java
@@ -86,7 +86,7 @@ public class PubSubMessageDeserializerTest {
     assertEquals(actualKey.getKeyHeaderByte(), key.getKeyHeaderByte());
     assertEquals(actualKey.getKey(), key.getKey());
     assertEquals(message.getValue(), value);
-    assertEquals(message.getOffset(), position);
+    assertEquals(message.getPosition(), position);
   }
 
   @Test
@@ -108,7 +108,7 @@ public class PubSubMessageDeserializerTest {
     assertEquals(actualKey.getKeyHeaderByte(), key.getKeyHeaderByte());
     assertEquals(actualKey.getKey(), key.getKey());
     assertEquals(message.getValue(), value);
-    assertEquals(message.getOffset(), position);
+    assertEquals(message.getPosition(), position);
   }
 
   @Test
@@ -129,7 +129,7 @@ public class PubSubMessageDeserializerTest {
     assertEquals(actualKey.getKeyHeaderByte(), key.getKeyHeaderByte());
     assertEquals(actualKey.getKey(), key.getKey());
     assertEquals(message.getValue(), value);
-    assertEquals(message.getOffset(), position);
+    assertEquals(message.getPosition(), position);
   }
 
   private KafkaMessageEnvelope getDummyValue() {

--- a/internal/venice-common/src/test/java/com/linkedin/venice/pubsub/manager/TopicMetadataFetcherTest.java
+++ b/internal/venice-common/src/test/java/com/linkedin/venice/pubsub/manager/TopicMetadataFetcherTest.java
@@ -374,9 +374,9 @@ public class TopicMetadataFetcherTest {
     List<DefaultPubSubMessage> allConsumedRecords =
         topicMetadataFetcher.consumeLatestRecords(topicPartition, numRecordsToRead);
     assertTrue(allConsumedRecords.size() >= numRecordsToRead);
-    long firstOffset = allConsumedRecords.get(0).getOffset().getNumericOffset();
+    long firstOffset = allConsumedRecords.get(0).getPosition().getNumericOffset();
     assertEquals(firstOffset, 5);
-    long lastOffset = allConsumedRecords.get(allConsumedRecords.size() - 1).getOffset().getNumericOffset();
+    long lastOffset = allConsumedRecords.get(allConsumedRecords.size() - 1).getPosition().getNumericOffset();
     assertEquals(lastOffset, 11);
     verify(consumerMock, times(2)).subscribe(topicPartition, consumePastOffset);
     verify(consumerMock, times(6)).poll(anyLong()); // 3 from prev test and 3 from this test

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/pubsub/api/consumer/PubSubConsumerAdapterTest.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/pubsub/api/consumer/PubSubConsumerAdapterTest.java
@@ -835,7 +835,7 @@ public class PubSubConsumerAdapterTest {
       if (partitionMessages != null && !partitionMessages.isEmpty()) {
         minRecordsToConsume -= partitionMessages.size();
         offsetOfLastConsumedMessage =
-            partitionMessages.get(partitionMessages.size() - 1).getOffset().getNumericOffset();
+            partitionMessages.get(partitionMessages.size() - 1).getPosition().getNumericOffset();
       }
     }
     assertTrue(offsetOfLastConsumedMessage > 0, "Offset of last consumed message should be greater than 0");
@@ -854,7 +854,7 @@ public class PubSubConsumerAdapterTest {
       Map<PubSubTopicPartition, List<DefaultPubSubMessage>> messages = pubSubConsumerAdapter.poll(15);
       List<DefaultPubSubMessage> partitionMessages = messages.get(partition);
       if (partitionMessages != null && !partitionMessages.isEmpty()) {
-        offsetOfFirstConsumedMessage = partitionMessages.get(0).getOffset().getNumericOffset();
+        offsetOfFirstConsumedMessage = partitionMessages.get(0).getPosition().getNumericOffset();
         minRecordsToConsume--;
       }
     }
@@ -987,7 +987,7 @@ public class PubSubConsumerAdapterTest {
         }
         // update first consumed offset
         Long oldVal =
-            firstConsumedOffsetMap.putIfAbsent(partition, partitionMessages.get(0).getOffset().getNumericOffset());
+            firstConsumedOffsetMap.putIfAbsent(partition, partitionMessages.get(0).getPosition().getNumericOffset());
         if (oldVal == null) {
           // assert offset is zero since this is the first time we are consuming from this topic-partition and
           // and we started consuming from the beginning (-1 last consumed offset)
@@ -995,7 +995,7 @@ public class PubSubConsumerAdapterTest {
         }
         // update last consumed offset
         lastConsumedOffsetMap
-            .put(partition, partitionMessages.get(partitionMessages.size() - 1).getOffset().getNumericOffset());
+            .put(partition, partitionMessages.get(partitionMessages.size() - 1).getPosition().getNumericOffset());
         // update number of messages consumed so far
         numMessagesConsumedMap
             .compute(partition, (k, v) -> v == null ? partitionMessages.size() : v + partitionMessages.size());
@@ -1053,7 +1053,7 @@ public class PubSubConsumerAdapterTest {
         }
         // update last consumed offset
         lastConsumedOffsetMap
-            .put(partition, partitionMessages.get(partitionMessages.size() - 1).getOffset().getNumericOffset());
+            .put(partition, partitionMessages.get(partitionMessages.size() - 1).getPosition().getNumericOffset());
         int consumedCountSoFar = numMessagesConsumedMap.getOrDefault(partition, 0) + partitionMessages.size();
         // verify lastConsumedOffset matches records consumed so far
         assertEquals(
@@ -1105,7 +1105,7 @@ public class PubSubConsumerAdapterTest {
         }
         // check A1 starts from 0
         Long oldVal =
-            firstConsumedOffsetMap.putIfAbsent(partition, partitionMessages.get(0).getOffset().getNumericOffset());
+            firstConsumedOffsetMap.putIfAbsent(partition, partitionMessages.get(0).getPosition().getNumericOffset());
         if (oldVal == null) {
           // we reset the offset for A1 to beginning; so the first consumed offset should be 0
           assertEquals(firstConsumedOffsetMap.get(partition), Long.valueOf(0), "First consumed offset should be 0");
@@ -1113,7 +1113,7 @@ public class PubSubConsumerAdapterTest {
 
         // update last consumed offset
         lastConsumedOffsetMap
-            .put(partition, partitionMessages.get(partitionMessages.size() - 1).getOffset().getNumericOffset());
+            .put(partition, partitionMessages.get(partitionMessages.size() - 1).getPosition().getNumericOffset());
         int consumedCountSoFar = numMessagesConsumedMap.getOrDefault(partition, 0) + partitionMessages.size();
         // verify lastConsumedOffset matches records consumed so far
         assertEquals(
@@ -1184,7 +1184,7 @@ public class PubSubConsumerAdapterTest {
         }
         // update last consumed offset
         lastConsumedOffsetMap
-            .put(partition, partitionMessages.get(partitionMessages.size() - 1).getOffset().getNumericOffset());
+            .put(partition, partitionMessages.get(partitionMessages.size() - 1).getPosition().getNumericOffset());
         int consumedCountSoFar = numMessagesConsumedMap.getOrDefault(partition, 0) + partitionMessages.size();
         // verify lastConsumedOffset matches records consumed so far
         assertEquals(
@@ -1236,7 +1236,7 @@ public class PubSubConsumerAdapterTest {
     assertTrue(messages.get(partitionA0).size() > 0, "Should have messages for A0");
     // offset should be at the first message
     assertEquals(
-        messages.get(partitionA0).get(0).getOffset().getNumericOffset(),
+        messages.get(partitionA0).get(0).getPosition().getNumericOffset(),
         0,
         "Poll should start from the beginning");
   }
@@ -1330,7 +1330,7 @@ public class PubSubConsumerAdapterTest {
         }
         // check offset of the last consumed message and see if it is one less than the end offset; if yes bar is met
         if (partitionMessages.get(partitionMessages.size() - 1)
-            .getOffset()
+            .getPosition()
             .getNumericOffset() == endOffsets.get(partition) - 1) {
           consumptionBarMet.add(partition);
         }
@@ -1374,7 +1374,7 @@ public class PubSubConsumerAdapterTest {
         }
         // check offset of the last consumed message and see if it is one less than the end offset; if yes bar is met
         if (partitionMessages.get(partitionMessages.size() - 1)
-            .getOffset()
+            .getPosition()
             .getNumericOffset() == endOffsets.get(partition) - 1) {
           consumptionBarMet.add(partition);
         }
@@ -1434,7 +1434,7 @@ public class PubSubConsumerAdapterTest {
         }
         // check offset of the last consumed message and see if it is one less than the end offset; if yes bar is met
         if (partitionMessages.get(partitionMessages.size() - 1)
-            .getOffset()
+            .getPosition()
             .getNumericOffset() == endOffsets.get(partition) - 1) {
           consumptionBarMet.add(partition);
         }

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/pubsub/manager/TopicManagerE2ETest.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/pubsub/manager/TopicManagerE2ETest.java
@@ -26,7 +26,7 @@ import com.linkedin.venice.pubsub.api.PubSubTopicPartition;
 import com.linkedin.venice.pubsub.api.exceptions.PubSubTopicDoesNotExistException;
 import com.linkedin.venice.stats.StatsErrorCode;
 import com.linkedin.venice.utils.PubSubHelper;
-import com.linkedin.venice.utils.PubSubHelper.MutablePubSubMessage;
+import com.linkedin.venice.utils.PubSubHelper.MutableDefaultPubSubMessage;
 import com.linkedin.venice.utils.Time;
 import com.linkedin.venice.utils.Utils;
 import com.linkedin.venice.utils.VeniceProperties;
@@ -152,7 +152,7 @@ public class TopicManagerE2ETest {
     int numMessages = 250;
     PubSubProducerAdapter pubSubProducerAdapter = pubSubProducerAdapterLazy.get();
     PubSubTopicPartition topicPartition = new PubSubTopicPartitionImpl(testTopic, 0);
-    List<MutablePubSubMessage> messages =
+    List<MutableDefaultPubSubMessage> messages =
         PubSubHelper.produceMessages(pubSubProducerAdapter, topicPartition, numMessages, 2, false);
     long timeBeforeProduce = messages.get(0).getTimestampBeforeProduce() - 10;
     long tsOfLastDataMessage = messages.get(messages.size() - 1).getValue().getProducerMetadata().getMessageTimestamp();
@@ -312,9 +312,12 @@ public class TopicManagerE2ETest {
 
     // produce messages to the topic-partitions: p0, p1, p2
     PubSubProducerAdapter pubSubProducerAdapter = pubSubProducerAdapterLazy.get();
-    List<MutablePubSubMessage> p0Messages = PubSubHelper.produceMessages(pubSubProducerAdapter, p0, 10, 10, false);
-    List<MutablePubSubMessage> p1Messages = PubSubHelper.produceMessages(pubSubProducerAdapter, p1, 14, 10, false);
-    List<MutablePubSubMessage> p2Messages = PubSubHelper.produceMessages(pubSubProducerAdapter, p2, 19, 10, false);
+    List<MutableDefaultPubSubMessage> p0Messages =
+        PubSubHelper.produceMessages(pubSubProducerAdapter, p0, 10, 10, false);
+    List<MutableDefaultPubSubMessage> p1Messages =
+        PubSubHelper.produceMessages(pubSubProducerAdapter, p1, 14, 10, false);
+    List<MutableDefaultPubSubMessage> p2Messages =
+        PubSubHelper.produceMessages(pubSubProducerAdapter, p2, 19, 10, false);
 
     // get the latest offsets
     latestOffsets = topicManager.getTopicLatestOffsets(existingTopic);

--- a/internal/venice-test-common/src/main/java/com/linkedin/venice/utils/ChunkingTestUtils.java
+++ b/internal/venice-test-common/src/main/java/com/linkedin/venice/utils/ChunkingTestUtils.java
@@ -105,7 +105,7 @@ public final class ChunkingTestUtils {
       DefaultPubSubMessage firstMessage,
       int numberOfChunks,
       PubSubTopicPartition pubSubTopicPartition) {
-    long newOffset = firstMessage.getOffset().getNumericOffset() + numberOfChunks;
+    long newOffset = firstMessage.getPosition().getNumericOffset() + numberOfChunks;
     byte[] chunkKeyWithSuffix = KEY_WITH_CHUNKING_SUFFIX_SERIALIZER.serializeNonChunkedKey(serializedKey);
     KafkaKey kafkaKey = new KafkaKey(MessageType.PUT, chunkKeyWithSuffix);
     KafkaMessageEnvelope messageEnvelope = createKafkaMessageEnvelope(

--- a/internal/venice-test-common/src/main/java/com/linkedin/venice/utils/PubSubHelper.java
+++ b/internal/venice-test-common/src/main/java/com/linkedin/venice/utils/PubSubHelper.java
@@ -81,7 +81,7 @@ public class PubSubHelper {
                 throw new RuntimeException(e);
               } finally {
                 // update the offset and timestamp after produce (and delay) so that each message has a unique timestamp
-                message.setOffset(result.getPubSubPosition());
+                message.setPosition(result.getPubSubPosition());
                 message.setTimestampAfterProduce(System.currentTimeMillis());
               }
             }
@@ -147,7 +147,7 @@ public class PubSubHelper {
       return this;
     }
 
-    public MutableDefaultPubSubMessage setOffset(PubSubPosition position) {
+    public MutableDefaultPubSubMessage setPosition(PubSubPosition position) {
       this.position = position;
       return this;
     }


### PR DESCRIPTION
## Extend DefaultPubSubMessage with explicit getter methods for key, value, and position

Previously, DefaultPubSubMessage was a marker interface extending PubSubMessage without  
defining any explicit methods. This change introduces explicit getter methods for key,  
value, and position, ensuring a consistent API for retrieving message components.  

- Added `getKey()`, `getValue()`, and `getPosition()` to expose KafkaKey, KafkaMessageEnvelope,  
  and PubSubPosition directly.  
- Improves clarity and enforceability of message structure in pub-sub implementations.  

## How was this PR tested?
CI
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.