### PR TITLE
[router] Enable SSL handshake offload to a thread pool and DNS resolve through a thread pool at the same time

### DIFF
--- a/internal/alpini/netty4/alpini-netty4-base/src/main/java/com/linkedin/alpini/netty4/handlers/ConnectionControlHandler.java
+++ b/internal/alpini/netty4/alpini-netty4-base/src/main/java/com/linkedin/alpini/netty4/handlers/ConnectionControlHandler.java
@@ -1,18 +1,8 @@
 package com.linkedin.alpini.netty4.handlers;
 
-import static io.netty.handler.codec.http.HttpHeaderValues.TEXT_PLAIN;
-
-import io.netty.buffer.Unpooled;
 import io.netty.channel.Channel;
-import io.netty.channel.ChannelFutureListener;
 import io.netty.channel.ChannelHandler;
 import io.netty.channel.ChannelHandlerContext;
-import io.netty.handler.codec.http.DefaultFullHttpResponse;
-import io.netty.handler.codec.http.FullHttpResponse;
-import io.netty.handler.codec.http.HttpHeaderNames;
-import io.netty.handler.codec.http.HttpResponseStatus;
-import io.netty.handler.codec.http.HttpVersion;
-import java.nio.charset.StandardCharsets;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.atomic.LongAdder;
 import java.util.function.Consumer;
@@ -70,16 +60,6 @@ public class ConnectionControlHandler extends ConnectionLimitHandler {
               getConnectedCount(),
               getConnectionLimit());
           parent.config().setAutoRead(false);
-          Channel clientChannel = ctx.channel(); // Get the current client's channel
-          if (clientChannel.isActive()) {
-            FullHttpResponse response = new DefaultFullHttpResponse(
-                HttpVersion.HTTP_1_1,
-                HttpResponseStatus.TOO_MANY_REQUESTS,
-                Unpooled.copiedBuffer("Connection limit exceeded on Venice routers", StandardCharsets.US_ASCII));
-            response.headers().set(HttpHeaderNames.CONTENT_LENGTH, response.content().readableBytes());
-            response.headers().set(HttpHeaderNames.CONTENT_TYPE, TEXT_PLAIN);
-            clientChannel.writeAndFlush(response).addListener(ChannelFutureListener.CLOSE);
-          }
         }
       }).addListener(ignored -> _activeSemaphore.release());
     }

--- a/internal/alpini/netty4/alpini-netty4-base/src/main/java/com/linkedin/alpini/netty4/handlers/ConnectionControlHandler.java
+++ b/internal/alpini/netty4/alpini-netty4-base/src/main/java/com/linkedin/alpini/netty4/handlers/ConnectionControlHandler.java
@@ -1,13 +1,25 @@
 package com.linkedin.alpini.netty4.handlers;
 
+import static io.netty.handler.codec.http.HttpHeaderValues.TEXT_PLAIN;
+
+import io.netty.buffer.Unpooled;
 import io.netty.channel.Channel;
+import io.netty.channel.ChannelFutureListener;
 import io.netty.channel.ChannelHandler;
 import io.netty.channel.ChannelHandlerContext;
+import io.netty.handler.codec.http.DefaultFullHttpResponse;
+import io.netty.handler.codec.http.FullHttpResponse;
+import io.netty.handler.codec.http.HttpHeaderNames;
+import io.netty.handler.codec.http.HttpResponseStatus;
+import io.netty.handler.codec.http.HttpVersion;
+import java.nio.charset.StandardCharsets;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.atomic.LongAdder;
 import java.util.function.IntSupplier;
 import javax.annotation.Nonnegative;
 import javax.annotation.Nonnull;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 
 /**
@@ -32,6 +44,7 @@ import javax.annotation.Nonnull;
  */
 @ChannelHandler.Sharable
 public class ConnectionControlHandler extends ConnectionLimitHandler {
+  private static final Logger LOGGER = LogManager.getLogger(ConnectionControlHandler.class);
   private final LongAdder _activeCount = new LongAdder();
   private final LongAdder _inactiveCount = new LongAdder();
   private final Semaphore _activeSemaphore = new Semaphore(1);
@@ -53,7 +66,21 @@ public class ConnectionControlHandler extends ConnectionLimitHandler {
     if (parent != null && _activeSemaphore.tryAcquire()) {
       parent.eventLoop().submit(() -> {
         if (getConnectedCount() > getConnectionLimit()) {
+          LOGGER.error(
+              "Connection limit exceeded! Active connections: {}, Limit: {}",
+              getConnectedCount(),
+              getConnectionLimit());
           parent.config().setAutoRead(false);
+          Channel clientChannel = ctx.channel(); // Get the current client's channel
+          if (clientChannel.isActive()) {
+            FullHttpResponse response = new DefaultFullHttpResponse(
+                HttpVersion.HTTP_1_1,
+                HttpResponseStatus.TOO_MANY_REQUESTS,
+                Unpooled.copiedBuffer("Connection limit exceeded on Venice routers", StandardCharsets.US_ASCII));
+            response.headers().set(HttpHeaderNames.CONTENT_LENGTH, response.content().readableBytes());
+            response.headers().set(HttpHeaderNames.CONTENT_TYPE, TEXT_PLAIN);
+            clientChannel.writeAndFlush(response).addListener(ChannelFutureListener.CLOSE);
+          }
         }
       }).addListener(ignored -> _activeSemaphore.release());
     }

--- a/internal/alpini/netty4/alpini-netty4-base/src/main/java/com/linkedin/alpini/netty4/handlers/ConnectionHandleMode.java
+++ b/internal/alpini/netty4/alpini-netty4-base/src/main/java/com/linkedin/alpini/netty4/handlers/ConnectionHandleMode.java
@@ -1,0 +1,15 @@
+package com.linkedin.alpini.netty4.handlers;
+
+public enum ConnectionHandleMode {
+  /**
+   * Fail fast when the connection limit is exceeded.
+   * {@link ConnectionLimitHandler} will be added into the pipeline to handle the connection limit.
+   */
+  FAIL_FAST_WHEN_LIMIT_EXCEEDED,
+
+  /**
+   * Stall when the connection limit is exceeded.
+   * {@link ConnectionControlHandler} will be added into the pipeline to handle the connection limit.
+   */
+  STALL_WHEN_LIMIT_EXCEEDED;
+}

--- a/internal/alpini/netty4/alpini-netty4-base/src/main/java/com/linkedin/alpini/netty4/handlers/ConnectionLimitHandler.java
+++ b/internal/alpini/netty4/alpini-netty4-base/src/main/java/com/linkedin/alpini/netty4/handlers/ConnectionLimitHandler.java
@@ -77,7 +77,7 @@ public class ConnectionLimitHandler extends ChannelInboundHandlerAdapter {
     int limit = _connectionLimit.getAsInt();
     _connectionCountRecorder.accept(count);
     if (count > limit) {
-      LOG.debug("Connection count {} exceeds {}", count, limit);
+      LOG.error("Connection count {} exceeds {}", count, limit);
 
       ctx.writeAndFlush(Unpooled.copiedBuffer(REJECT_MESSAGE, StandardCharsets.US_ASCII))
           .addListener(ChannelFutureListener.CLOSE);

--- a/internal/alpini/netty4/alpini-netty4-base/src/main/java/com/linkedin/alpini/netty4/ssl/SslInitializer.java
+++ b/internal/alpini/netty4/alpini-netty4-base/src/main/java/com/linkedin/alpini/netty4/ssl/SslInitializer.java
@@ -372,6 +372,11 @@ public class SslInitializer extends ChannelInitializer<Channel> {
       if (!ctx.isRemoved()) {
         next(ctx);
       }
+      if (ctx.channel().hasAttr(SSL_HANDSHAKE_START_TS)) {
+        // If SSL_HANDSHAKE_START_TS is set, then the handshake was started.
+        // If the connection closes mid-handshake, userEventTriggered might never fire.
+        _handshakesFailed.increment();
+      }
       super.channelInactive(ctx);
     }
 

--- a/internal/alpini/netty4/alpini-netty4-base/src/main/java/com/linkedin/alpini/netty4/ssl/SslInitializer.java
+++ b/internal/alpini/netty4/alpini-netty4-base/src/main/java/com/linkedin/alpini/netty4/ssl/SslInitializer.java
@@ -409,9 +409,12 @@ public class SslInitializer extends ChannelInitializer<Channel> {
       if (LOG.isDebugEnabled()) {
         LOG.debug("SSL enabled for channel: {}", ch.remoteAddress());
       }
-      // Noticed that SSL handshake task is not submitted yet, but here is the beginning of SSL initialization for each
-      // request
-      _queuedTaskNumberRecorder.accept(_sslExecutor.getQueue().size());
+      if (_sslExecutor != null) {
+        // Noticed that SSL handshake task is not submitted yet, but here is the beginning of SSL initialization for
+        // each
+        // request
+        _queuedTaskNumberRecorder.accept(_sslExecutor.getQueue().size());
+      }
       class SslDetect extends ByteToMessageDecoder implements Callable<String>, FutureListener<String> {
         private ChannelHandlerContext _channelHandlerContext;
         private ChannelPromise _resolvePromise;

--- a/internal/alpini/netty4/alpini-netty4-base/src/main/java/com/linkedin/alpini/netty4/ssl/SslInitializer.java
+++ b/internal/alpini/netty4/alpini-netty4-base/src/main/java/com/linkedin/alpini/netty4/ssl/SslInitializer.java
@@ -379,7 +379,7 @@ public class SslInitializer extends ChannelInitializer<Channel> {
       if (!ctx.isRemoved()) {
         next(ctx);
       }
-      if (ctx.channel().hasAttr(SSL_HANDSHAKE_START_TS)) {
+      if (ctx.channel().attr(SSL_HANDSHAKE_START_TS).get() != null) {
         // If SSL_HANDSHAKE_START_TS is set, then the handshake was started.
         // If the connection closes mid-handshake, userEventTriggered might never fire.
         _handshakesFailed.increment();

--- a/internal/alpini/netty4/alpini-netty4-base/src/test/java/com/linkedin/alpini/netty4/ssl/TestSslInitializer.java
+++ b/internal/alpini/netty4/alpini-netty4-base/src/test/java/com/linkedin/alpini/netty4/ssl/TestSslInitializer.java
@@ -1,6 +1,5 @@
 package com.linkedin.alpini.netty4.ssl;
 
-import com.linkedin.alpini.base.concurrency.Executors;
 import com.linkedin.alpini.base.misc.ExceptionUtil;
 import com.linkedin.alpini.base.misc.Time;
 import com.linkedin.venice.utils.TestUtils;
@@ -49,12 +48,13 @@ import java.security.Security;
 import java.security.cert.CertificateException;
 import java.util.List;
 import java.util.Optional;
+import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
-import java.util.concurrent.ExecutorService;
 import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -691,7 +691,8 @@ public class TestSslInitializer {
 
     int concurrency = 10;
 
-    ExecutorService sslExecutor = Executors.newSingleThreadExecutor();
+    ThreadPoolExecutor sslExecutor =
+        new ThreadPoolExecutor(1, 1, 0, TimeUnit.MILLISECONDS, new ArrayBlockingQueue<>(10));
     try {
       concurrentLocalGoodCertificates(
           concurrency,
@@ -947,7 +948,8 @@ public class TestSslInitializer {
 
     SslInitializer serverSslInitializer = serverOp.apply(new SslInitializer(sslEngineFactory, true, null));
     SslClientInitializer clientSslInitializer = new SslClientInitializer(sslEngineFactory);
-    ExecutorService sslExecutor = Executors.newSingleThreadExecutor();
+    ThreadPoolExecutor sslExecutor =
+        new ThreadPoolExecutor(1, 1, 0, TimeUnit.MILLISECONDS, new ArrayBlockingQueue<>(10));
     try {
       socketGoodCertificates(
           serverSslInitializer.enableSslTaskExecutor(sslExecutor),

--- a/internal/alpini/router/alpini-router-impl/src/main/java/com/linkedin/alpini/router/impl/Router.java
+++ b/internal/alpini/router/alpini-router-impl/src/main/java/com/linkedin/alpini/router/impl/Router.java
@@ -107,6 +107,8 @@ public interface Router extends ShutdownableResource {
 
     Builder connectionLimit(@Nonnull IntSupplier connectionLimit);
 
+    Builder connectionCountRecorder(@Nonnull Consumer<Integer> recorder);
+
     Builder serverSocketOptions(Map<String, Object> serverSocketOptions);
 
     Builder serverSocketOptions(@Nonnull String key, Object value);

--- a/internal/alpini/router/alpini-router-impl/src/main/java/com/linkedin/alpini/router/impl/Router.java
+++ b/internal/alpini/router/alpini-router-impl/src/main/java/com/linkedin/alpini/router/impl/Router.java
@@ -4,6 +4,7 @@ import com.linkedin.alpini.base.concurrency.AsyncFuture;
 import com.linkedin.alpini.base.concurrency.TimeoutProcessor;
 import com.linkedin.alpini.base.registry.ResourceRegistry;
 import com.linkedin.alpini.base.registry.ShutdownableResource;
+import com.linkedin.alpini.netty4.handlers.ConnectionHandleMode;
 import com.linkedin.alpini.router.api.Netty;
 import com.linkedin.alpini.router.api.ResourcePath;
 import com.linkedin.alpini.router.api.RouterTimeoutProcessor;
@@ -108,6 +109,8 @@ public interface Router extends ShutdownableResource {
     Builder connectionLimit(@Nonnull IntSupplier connectionLimit);
 
     Builder connectionCountRecorder(@Nonnull Consumer<Integer> recorder);
+
+    Builder connectionHandleMode(@Nonnull ConnectionHandleMode connectionHandleMode);
 
     Builder serverSocketOptions(Map<String, Object> serverSocketOptions);
 

--- a/internal/alpini/router/alpini-router-impl/src/main/java/com/linkedin/alpini/router/impl/netty4/Router4.java
+++ b/internal/alpini/router/alpini-router-impl/src/main/java/com/linkedin/alpini/router/impl/netty4/Router4.java
@@ -72,8 +72,7 @@ public class Router4<C extends Channel> implements Router.Builder, Router.Pipeli
   private IntSupplier _connectionLimit = () -> Integer.MAX_VALUE;
   // Default is a no-op consumer
   private Consumer<Integer> _connectionCountRecorder = (count) -> {};
-  private ConnectionHandleMode _connectionHandleMode = ConnectionHandleMode.FAIL_FAST_WHEN_LIMIT_EXCEEDED; // Default to
-                                                                                                           // fail fast
+  private ConnectionHandleMode _connectionHandleMode = ConnectionHandleMode.STALL_WHEN_LIMIT_EXCEEDED;
   private RouterTimeoutProcessor _timeoutProcessor;
   private final Map<String, Object> _serverSocketOptions = new HashMap<>();
   private BooleanSupplier _shutdownFlag;

--- a/internal/alpini/router/alpini-router-impl/src/main/java/com/linkedin/alpini/router/impl/netty4/Router4.java
+++ b/internal/alpini/router/alpini-router-impl/src/main/java/com/linkedin/alpini/router/impl/netty4/Router4.java
@@ -192,9 +192,12 @@ public class Router4<C extends Channel> implements Router.Builder, Router.Pipeli
     return this;
   }
 
+  /**
+   * Allow 0 limit to reject all connections as well as testing.
+   */
   @Override
   public Router.Builder connectionLimit(int connectionLimit) {
-    Preconditions.notLessThan(connectionLimit, 1, "connectionLimit");
+    Preconditions.notLessThan(connectionLimit, 0, "connectionLimit");
     return connectionLimit(() -> connectionLimit);
   }
 

--- a/internal/venice-client-common/src/main/java/com/linkedin/venice/stats/ThreadPoolStats.java
+++ b/internal/venice-client-common/src/main/java/com/linkedin/venice/stats/ThreadPoolStats.java
@@ -2,8 +2,6 @@ package com.linkedin.venice.stats;
 
 import io.tehuti.metrics.MetricsRepository;
 import io.tehuti.metrics.Sensor;
-import io.tehuti.metrics.stats.Avg;
-import io.tehuti.metrics.stats.Max;
 import java.util.concurrent.ThreadPoolExecutor;
 
 
@@ -28,8 +26,8 @@ public class ThreadPoolStats extends AbstractVeniceStats {
         new LambdaStat((ignored, ignored2) -> this.threadPoolExecutor.getActiveCount(), "active_thread_number"));
     maxThreadNumberSensor = registerSensor(
         new LambdaStat((ignored, ignored2) -> this.threadPoolExecutor.getMaximumPoolSize(), "max_thread_number"));
-    // queuedTasksNumberSensor = registerSensor(
-    // new LambdaStat((ignored, ignored2) -> this.threadPoolExecutor.getQueue().size(), "queued_task_number"));
+    registerSensor(
+        new LambdaStat((ignored, ignored2) -> this.threadPoolExecutor.getQueue().size(), "queued_task_number_gauge"));
     /**
      * If only registered as Gauge, the metric would show the queue size at the time of the metric collection, which is not
      * very useful. It can provide a better view of the queue size if we record the average and max queue size within
@@ -37,11 +35,7 @@ public class ThreadPoolStats extends AbstractVeniceStats {
      * As a result, we need the users of the thread pool to explicitly call the record function to record the queue size
      * during each new task submission.
      */
-    queuedTasksNumberSensor = registerSensor(
-        "queued_task_number",
-        new Avg(),
-        new Max(),
-        new LambdaStat((ignored, ignored2) -> this.threadPoolExecutor.getQueue().size(), "queued_task_number"));
+    queuedTasksNumberSensor = registerSensor("queued_task_number", avgAndMax());
   }
 
   public void recordQueuedTasksNumber(int queuedTasksNumber) {

--- a/internal/venice-client-common/src/main/java/com/linkedin/venice/stats/ThreadPoolStats.java
+++ b/internal/venice-client-common/src/main/java/com/linkedin/venice/stats/ThreadPoolStats.java
@@ -16,7 +16,7 @@ public class ThreadPoolStats extends AbstractVeniceStats {
 
   private Sensor maxThreadNumberSensor;
 
-  private Sensor queuedTasksNumberSensor;
+  private Sensor queuedTasksCountSensor;
 
   public ThreadPoolStats(MetricsRepository metricsRepository, ThreadPoolExecutor threadPoolExecutor, String name) {
     super(metricsRepository, name);
@@ -27,7 +27,7 @@ public class ThreadPoolStats extends AbstractVeniceStats {
     maxThreadNumberSensor = registerSensor(
         new LambdaStat((ignored, ignored2) -> this.threadPoolExecutor.getMaximumPoolSize(), "max_thread_number"));
     registerSensor(
-        new LambdaStat((ignored, ignored2) -> this.threadPoolExecutor.getQueue().size(), "queued_task_number_gauge"));
+        new LambdaStat((ignored, ignored2) -> this.threadPoolExecutor.getQueue().size(), "queued_task_count_gauge"));
     /**
      * If only registered as Gauge, the metric would show the queue size at the time of the metric collection, which is not
      * very useful. It can provide a better view of the queue size if we record the average and max queue size within
@@ -35,10 +35,11 @@ public class ThreadPoolStats extends AbstractVeniceStats {
      * As a result, we need the users of the thread pool to explicitly call the record function to record the queue size
      * during each new task submission.
      */
-    queuedTasksNumberSensor = registerSensor("queued_task_number", avgAndMax());
+    queuedTasksCountSensor = registerSensor("queued_task_count", avgAndMax());
   }
 
-  public void recordQueuedTasksNumber(int queuedTasksNumber) {
-    queuedTasksNumberSensor.record(this.threadPoolExecutor.getQueue().size());
+  public void recordQueuedTasksCount(int queuedTasksNumber) {
+    // TODO: remove the argument in the function; you don't need it
+    queuedTasksCountSensor.record(this.threadPoolExecutor.getQueue().size());
   }
 }

--- a/internal/venice-client-common/src/main/java/com/linkedin/venice/stats/ThreadPoolStats.java
+++ b/internal/venice-client-common/src/main/java/com/linkedin/venice/stats/ThreadPoolStats.java
@@ -2,6 +2,8 @@ package com.linkedin.venice.stats;
 
 import io.tehuti.metrics.MetricsRepository;
 import io.tehuti.metrics.Sensor;
+import io.tehuti.metrics.stats.Avg;
+import io.tehuti.metrics.stats.Max;
 import java.util.concurrent.ThreadPoolExecutor;
 
 
@@ -26,7 +28,23 @@ public class ThreadPoolStats extends AbstractVeniceStats {
         new LambdaStat((ignored, ignored2) -> this.threadPoolExecutor.getActiveCount(), "active_thread_number"));
     maxThreadNumberSensor = registerSensor(
         new LambdaStat((ignored, ignored2) -> this.threadPoolExecutor.getMaximumPoolSize(), "max_thread_number"));
+    // queuedTasksNumberSensor = registerSensor(
+    // new LambdaStat((ignored, ignored2) -> this.threadPoolExecutor.getQueue().size(), "queued_task_number"));
+    /**
+     * If only registered as Gauge, the metric would show the queue size at the time of the metric collection, which is not
+     * very useful. It can provide a better view of the queue size if we record the average and max queue size within
+     * the metric reporting time window which is usually 1 minute.
+     * As a result, we need the users of the thread pool to explicitly call the record function to record the queue size
+     * during each new task submission.
+     */
     queuedTasksNumberSensor = registerSensor(
+        "queued_task_number",
+        new Avg(),
+        new Max(),
         new LambdaStat((ignored, ignored2) -> this.threadPoolExecutor.getQueue().size(), "queued_task_number"));
+  }
+
+  public void recordQueuedTasksNumber(int queuedTasksNumber) {
+    queuedTasksNumberSensor.record(this.threadPoolExecutor.getQueue().size());
   }
 }

--- a/internal/venice-client-common/src/test/java/com/linkedin/venice/stats/ThreadPoolStatsTest.java
+++ b/internal/venice-client-common/src/test/java/com/linkedin/venice/stats/ThreadPoolStatsTest.java
@@ -34,7 +34,7 @@ public class ThreadPoolStatsTest {
         activeThreadNumber);
     Assert.assertEquals((int) reporter.query("." + name + "--max_thread_number.LambdaStat").value(), maxThreadNumber);
     Assert.assertEquals(
-        (int) reporter.query("." + name + "--queued_task_number_gauge.LambdaStat").value(),
+        (int) reporter.query("." + name + "--queued_task_count_gauge.LambdaStat").value(),
         queuedTaskNumber);
   }
 }

--- a/internal/venice-client-common/src/test/java/com/linkedin/venice/stats/ThreadPoolStatsTest.java
+++ b/internal/venice-client-common/src/test/java/com/linkedin/venice/stats/ThreadPoolStatsTest.java
@@ -33,6 +33,8 @@ public class ThreadPoolStatsTest {
         (int) reporter.query("." + name + "--active_thread_number.LambdaStat").value(),
         activeThreadNumber);
     Assert.assertEquals((int) reporter.query("." + name + "--max_thread_number.LambdaStat").value(), maxThreadNumber);
-    Assert.assertEquals((int) reporter.query("." + name + "--queued_task_number.LambdaStat").value(), queuedTaskNumber);
+    Assert.assertEquals(
+        (int) reporter.query("." + name + "--queued_task_number_gauge.LambdaStat").value(),
+        queuedTaskNumber);
   }
 }

--- a/internal/venice-common/src/main/java/com/linkedin/venice/ConfigKeys.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/ConfigKeys.java
@@ -1923,11 +1923,10 @@ public class ConfigKeys {
   public static final String ROUTER_CLIENT_SSL_HANDSHAKE_THREADS = "router.client.ssl.handshake.threads";
 
   /**
-   * Config to control if DNS resolution should be done before SSL handshake between clients and a router.
-   * If this is enabled, the above SSL handshake thread pool will be used to perform DNS resolution, because
-   * DNS resolution before SSL and separate SSL handshake thread pool are mutually exclusive features.
+   * Config to control the number of threads used for DNS resolution.
+   * If the value is positive, DNS resolution would be done before SSL handshake between clients and a router.
    */
-  public static final String ROUTER_RESOLVE_BEFORE_SSL = "router.resolve.before.ssl";
+  public static final String ROUTER_RESOLVE_THREADS = "router.resolve.threads";
 
   /**
    * Config to control the maximum number of concurrent DNS resolutions that can be done by the router.

--- a/internal/venice-common/src/main/java/com/linkedin/venice/ConfigKeys.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/ConfigKeys.java
@@ -1925,6 +1925,7 @@ public class ConfigKeys {
   /**
    * Config to control the number of threads used for DNS resolution.
    * If the value is positive, DNS resolution would be done before SSL handshake between clients and a router.
+   * 0 will disable the dns resolution but does not affect the SSL handshake.
    */
   public static final String ROUTER_RESOLVE_THREADS = "router.resolve.threads";
 

--- a/internal/venice-common/src/main/java/com/linkedin/venice/ConfigKeys.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/ConfigKeys.java
@@ -1930,9 +1930,14 @@ public class ConfigKeys {
   public static final String ROUTER_RESOLVE_THREADS = "router.resolve.threads";
 
   /**
+   * Config to control the queue capacity for the thread pool executor used for DNS resolution.
+   */
+  public static final String ROUTER_RESOLVE_QUEUE_CAPACITY = "router.resolve.queue.capacity";
+
+  /**
    * Config to control the maximum number of concurrent DNS resolutions that can be done by the router.
    */
-  public static final String ROUTER_MAX_CONCURRENT_RESOLUTIONS = "router.max.concurrent.resolutions";
+  public static final String ROUTER_MAX_CONCURRENT_SSL_HANDSHAKES = "router.max.concurrent.ssl.handshakes";
 
   /**
    * Config to control the maximum number of attempts to resolve a client host name before giving up.

--- a/internal/venice-common/src/main/java/com/linkedin/venice/ConfigKeys.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/ConfigKeys.java
@@ -1063,6 +1063,7 @@ public class ConfigKeys {
    */
   public static final String ROUTER_MAX_KEY_COUNT_IN_MULTIGET_REQ = "router.max.key_count.in.multiget.req";
   public static final String ROUTER_CONNECTION_LIMIT = "router.connection.limit";
+  public static final String ROUTER_CONNECTION_HANDLE_MODE = "router.connection.handle.mode";
   /**
    * The http client pool size being used in one Router;
    */

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/integration/utils/MockVeniceRouterWrapper.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/integration/utils/MockVeniceRouterWrapper.java
@@ -8,7 +8,7 @@ import static com.linkedin.venice.ConfigKeys.LISTENER_PORT;
 import static com.linkedin.venice.ConfigKeys.LISTENER_SSL_PORT;
 import static com.linkedin.venice.ConfigKeys.ROUTER_CLIENT_SSL_HANDSHAKE_THREADS;
 import static com.linkedin.venice.ConfigKeys.ROUTER_NETTY_GRACEFUL_SHUTDOWN_PERIOD_SECONDS;
-import static com.linkedin.venice.ConfigKeys.ROUTER_RESOLVE_BEFORE_SSL;
+import static com.linkedin.venice.ConfigKeys.ROUTER_RESOLVE_THREADS;
 import static com.linkedin.venice.ConfigKeys.ROUTER_STORAGE_NODE_CLIENT_TYPE;
 import static com.linkedin.venice.ConfigKeys.SSL_TO_STORAGE_NODES;
 import static com.linkedin.venice.ConfigKeys.ZOOKEEPER_ADDRESS;
@@ -139,8 +139,8 @@ public class MockVeniceRouterWrapper extends ProcessWrapper {
               CLUSTER_TO_SERVER_D2,
               TestUtils.getClusterToD2String(Collections.singletonMap(clusterName, serverD2ServiceName)))
           .put(ROUTER_NETTY_GRACEFUL_SHUTDOWN_PERIOD_SECONDS, 1)
-          .put(ROUTER_CLIENT_SSL_HANDSHAKE_THREADS, 10)
-          .put(ROUTER_RESOLVE_BEFORE_SSL, true)
+          .put(ROUTER_CLIENT_SSL_HANDSHAKE_THREADS, 5)
+          .put(ROUTER_RESOLVE_THREADS, 5)
           .put(ROUTER_STORAGE_NODE_CLIENT_TYPE, StorageNodeClientType.APACHE_HTTP_ASYNC_CLIENT.name())
           .put(extraConfigs);
       StoreConfig storeConfig = new StoreConfig("test");

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/integration/utils/VeniceRouterWrapper.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/integration/utils/VeniceRouterWrapper.java
@@ -15,7 +15,7 @@ import static com.linkedin.venice.ConfigKeys.ROUTER_HTTP_CLIENT_POOL_SIZE;
 import static com.linkedin.venice.ConfigKeys.ROUTER_MAX_OUTGOING_CONNECTION;
 import static com.linkedin.venice.ConfigKeys.ROUTER_MAX_OUTGOING_CONNECTION_PER_ROUTE;
 import static com.linkedin.venice.ConfigKeys.ROUTER_NETTY_GRACEFUL_SHUTDOWN_PERIOD_SECONDS;
-import static com.linkedin.venice.ConfigKeys.ROUTER_RESOLVE_BEFORE_SSL;
+import static com.linkedin.venice.ConfigKeys.ROUTER_RESOLVE_THREADS;
 import static com.linkedin.venice.ConfigKeys.ROUTER_STORAGE_NODE_CLIENT_TYPE;
 import static com.linkedin.venice.ConfigKeys.SSL_TO_STORAGE_NODES;
 import static com.linkedin.venice.ConfigKeys.SYSTEM_SCHEMA_CLUSTER_NAME;
@@ -147,8 +147,8 @@ public class VeniceRouterWrapper extends ProcessWrapper implements MetricsAware 
           .put(SSL_TO_STORAGE_NODES, sslToStorageNodes)
           .put(CLUSTER_TO_D2, TestUtils.getClusterToD2String(finalClusterToD2))
           .put(CLUSTER_TO_SERVER_D2, TestUtils.getClusterToD2String(finalClusterToServerD2))
-          .put(ROUTER_CLIENT_SSL_HANDSHAKE_THREADS, 10)
-          .put(ROUTER_RESOLVE_BEFORE_SSL, true)
+          .put(ROUTER_CLIENT_SSL_HANDSHAKE_THREADS, 5)
+          .put(ROUTER_RESOLVE_THREADS, 5)
           // Below configs are to attempt to minimize resource utilization in tests
           .put(ROUTER_CONNECTION_LIMIT, 20)
           .put(ROUTER_HTTP_CLIENT_POOL_SIZE, 2)

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/integration/utils/VeniceRouterWrapper.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/integration/utils/VeniceRouterWrapper.java
@@ -150,7 +150,7 @@ public class VeniceRouterWrapper extends ProcessWrapper implements MetricsAware 
           .put(ROUTER_CLIENT_SSL_HANDSHAKE_THREADS, 5)
           .put(ROUTER_RESOLVE_THREADS, 5)
           // Below configs are to attempt to minimize resource utilization in tests
-          .put(ROUTER_CONNECTION_LIMIT, 20)
+          .put(ROUTER_CONNECTION_LIMIT, 200)
           .put(ROUTER_HTTP_CLIENT_POOL_SIZE, 2)
           .put(ROUTER_MAX_OUTGOING_CONNECTION_PER_ROUTE, 2)
           .put(ROUTER_HTTPASYNCCLIENT_CONNECTION_WARMING_LOW_WATER_MARK, 1)

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/integration/utils/VeniceServerWrapper.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/integration/utils/VeniceServerWrapper.java
@@ -487,7 +487,10 @@ public class VeniceServerWrapper extends ProcessWrapper implements MetricsAware 
     Metric maxThreadNumber = reporter.query(".Venice_L/F_ST_thread_pool--max_thread_number.LambdaStat");
     Assert.assertNotNull(maxThreadNumber);
     Assert.assertTrue(maxThreadNumber.value() > 0);
-    Metric queuedTaskNumber = reporter.query(".Venice_L/F_ST_thread_pool--queued_task_number.LambdaStat");
+    Metric queuedTaskNumberGauge = reporter.query(".Venice_L/F_ST_thread_pool--queued_task_number_gauge.LambdaStat");
+    Assert.assertNotNull(queuedTaskNumberGauge);
+    Assert.assertTrue(queuedTaskNumberGauge.value() >= 0);
+    Metric queuedTaskNumber = reporter.query(".Venice_L/F_ST_thread_pool--queued_task_number.Avg");
     Assert.assertNotNull(queuedTaskNumber);
     Assert.assertTrue(queuedTaskNumber.value() >= 0);
   }

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/integration/utils/VeniceServerWrapper.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/integration/utils/VeniceServerWrapper.java
@@ -487,7 +487,7 @@ public class VeniceServerWrapper extends ProcessWrapper implements MetricsAware 
     Metric maxThreadNumber = reporter.query(".Venice_L/F_ST_thread_pool--max_thread_number.LambdaStat");
     Assert.assertNotNull(maxThreadNumber);
     Assert.assertTrue(maxThreadNumber.value() > 0);
-    Metric queuedTaskNumberGauge = reporter.query(".Venice_L/F_ST_thread_pool--queued_task_number_gauge.LambdaStat");
+    Metric queuedTaskNumberGauge = reporter.query(".Venice_L/F_ST_thread_pool--queued_task_count_gauge.LambdaStat");
     Assert.assertNotNull(queuedTaskNumberGauge);
     Assert.assertTrue(queuedTaskNumberGauge.value() >= 0);
   }

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/integration/utils/VeniceServerWrapper.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/integration/utils/VeniceServerWrapper.java
@@ -490,9 +490,6 @@ public class VeniceServerWrapper extends ProcessWrapper implements MetricsAware 
     Metric queuedTaskNumberGauge = reporter.query(".Venice_L/F_ST_thread_pool--queued_task_number_gauge.LambdaStat");
     Assert.assertNotNull(queuedTaskNumberGauge);
     Assert.assertTrue(queuedTaskNumberGauge.value() >= 0);
-    Metric queuedTaskNumber = reporter.query(".Venice_L/F_ST_thread_pool--queued_task_number.Avg");
-    Assert.assertNotNull(queuedTaskNumber);
-    Assert.assertTrue(queuedTaskNumber.value() >= 0);
   }
 
   @Override

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/router/TestStreaming.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/router/TestStreaming.java
@@ -51,6 +51,8 @@ import io.tehuti.metrics.MetricsRepository;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Properties;
@@ -191,7 +193,8 @@ public class TestStreaming {
   private Properties getRouterProperties(
       boolean enableNettyClient,
       boolean enableClientCompression,
-      boolean routerH2Enabled) {
+      boolean routerH2Enabled,
+      int connectionLimit) {
     // To trigger long-tail retry
     Properties routerProperties = new Properties();
     routerProperties.put(ConfigKeys.ROUTER_LONG_TAIL_RETRY_FOR_SINGLE_GET_THRESHOLD_MS, 1);
@@ -201,6 +204,7 @@ public class TestStreaming {
     routerProperties.put(ConfigKeys.ROUTER_STORAGE_NODE_CLIENT_TYPE, APACHE_HTTP_ASYNC_CLIENT.name());
     routerProperties.put(ConfigKeys.ROUTER_CLIENT_DECOMPRESSION_ENABLED, Boolean.toString(enableClientCompression));
     routerProperties.put(ConfigKeys.ROUTER_HTTP2_INBOUND_ENABLED, Boolean.toString(routerH2Enabled));
+    routerProperties.put(ConfigKeys.ROUTER_CONNECTION_LIMIT, Integer.toString(connectionLimit));
 
     return routerProperties;
   }
@@ -211,12 +215,12 @@ public class TestStreaming {
     // With Apache HAC on Router with client compression enabled
     veniceCluster.getVeniceRouters().forEach(router -> veniceCluster.removeVeniceRouter(router.getPort()));
     VeniceRouterWrapper veniceRouterWrapperWithHttpAsyncClient =
-        veniceCluster.addVeniceRouter(getRouterProperties(false, true, enableRouterHttp2));
+        veniceCluster.addVeniceRouter(getRouterProperties(false, true, enableRouterHttp2, 1000));
     MetricsRepository routerMetricsRepositoryWithHttpAsyncClient =
         veniceRouterWrapperWithHttpAsyncClient.getMetricsRepository();
     // With Netty Client on Router with client compression disabled
     VeniceRouterWrapper veniceRouterWrapperWithNettyClient =
-        veniceCluster.addVeniceRouter(getRouterProperties(true, false, enableRouterHttp2));
+        veniceCluster.addVeniceRouter(getRouterProperties(true, false, enableRouterHttp2, 1000));
     D2Client d2Client = null;
     AvroGenericStoreClient d2StoreClient = null;
     try {
@@ -488,6 +492,79 @@ public class TestStreaming {
     } finally {
       Utils.closeQuietlyWithErrorLogged(d2StoreClient);
       Utils.closeQuietlyWithErrorLogged(veniceRouterWrapperWithHttpAsyncClient);
+    }
+  }
+
+  @Test(timeOut = 600 * Time.MS_PER_SECOND)
+  public void testConnectionLimitRejection() throws Exception {
+    // Clear existing routers first
+    veniceCluster.getVeniceRouters().forEach(router -> veniceCluster.removeVeniceRouter(router.getPort()));
+    VeniceRouterWrapper veniceRouterRejectsAllConnections =
+        veniceCluster.addVeniceRouter(getRouterProperties(false, true, false, 0));
+    MetricsRepository routerMetricsRepositoryWithHttpAsyncClient =
+        veniceRouterRejectsAllConnections.getMetricsRepository();
+    D2Client d2Client = null;
+    AvroGenericStoreClient d2StoreClient = null;
+    try {
+      // test with D2 store client, since streaming support is only available with D2 client so far.
+      d2Client = D2TestUtils.getD2Client(veniceCluster.getZk().getAddress(), true, HttpProtocolVersion.HTTP_1_1);
+      D2TestUtils.startD2Client(d2Client);
+      MetricsRepository clientMetrics = new MetricsRepository();
+      d2StoreClient = ClientFactory.getAndStartGenericAvroClient(
+          ClientConfig.defaultGenericClientConfig(storeName)
+              .setD2ServiceName(VeniceRouterWrapper.CLUSTER_DISCOVERY_D2_SERVICE_NAME)
+              .setD2Client(d2Client)
+              .setMetricsRepository(clientMetrics)
+              .setUseFastAvro(false));
+
+      // Right now, all the streaming interfaces are still internal, and we will expose them once they are fully
+      // verified.
+      StatTrackingStoreClient trackingStoreClient = (StatTrackingStoreClient) d2StoreClient;
+
+      Set<String> keySet = new TreeSet<>();
+      for (int i = 0; i < MAX_KEY_LIMIT; ++i) {
+        keySet.add(KEY_PREFIX + i);
+      }
+
+      final List<String> errorMessagesFromRouter = new LinkedList<>();
+      // Streaming batch-get
+      CountDownLatch latch = new CountDownLatch(1);
+      trackingStoreClient.streamingBatchGet(keySet, new StreamingCallback<String, Object>() {
+        @Override
+        public void onRecordReceived(String key, Object value) {
+          // No-op
+        }
+
+        @Override
+        public void onCompletion(Optional<Exception> exception) {
+          if (exception.isPresent()) {
+            LOGGER.info("MultiGet onCompletion invoked with Venice Exception", exception.get());
+            errorMessagesFromRouter.add(exception.get().getMessage());
+          }
+          latch.countDown();
+        }
+      });
+      latch.await();
+      Assert.assertFalse(errorMessagesFromRouter.isEmpty());
+      // Verify that the error message contains 429
+      Assert.assertTrue(errorMessagesFromRouter.get(0).contains("429"));
+
+      // Verify some client-side metrics, and we could add verification for more metrics if necessary
+      String metricPrefix = "." + storeName;
+      Map<String, ? extends Metric> metrics = clientMetrics.metrics();
+      Assert.assertTrue(metrics.get(metricPrefix + "--multiget_streaming_request.OccurrenceRate").value() > 0);
+      Assert
+          .assertTrue(metrics.get(metricPrefix + "--multiget_streaming_unhealthy_request.OccurrenceRate").value() > 0);
+
+      // Verify some router metrics
+      Map<String, ? extends Metric> routerMetrics = routerMetricsRepositoryWithHttpAsyncClient.metrics();
+      Assert.assertTrue(routerMetrics.get(".security--connection_count.Max").value() > 0);
+    } finally {
+      Utils.closeQuietlyWithErrorLogged(veniceRouterRejectsAllConnections);
+      Utils.closeQuietlyWithErrorLogged(d2StoreClient);
+      if (d2Client != null) {
+        D2ClientUtils.shutdownClient(d2Client);
+      }
     }
   }
 }

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/router/TestStreaming.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/router/TestStreaming.java
@@ -559,6 +559,8 @@ public class TestStreaming {
       // Verify some router metrics
       Map<String, ? extends Metric> routerMetrics = routerMetricsRepositoryWithHttpAsyncClient.metrics();
       Assert.assertTrue(routerMetrics.get(".security--connection_count.Max").value() > 0);
+      Assert.assertTrue(routerMetrics.get(".security--connection_count.Min").value() > 0);
+      Assert.assertTrue(routerMetrics.get(".security--connection_count.Gauge").value() > 0);
     } finally {
       Utils.closeQuietlyWithErrorLogged(veniceRouterRejectsAllConnections);
       Utils.closeQuietlyWithErrorLogged(d2StoreClient);

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/router/TestStreaming.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/router/TestStreaming.java
@@ -560,7 +560,7 @@ public class TestStreaming {
       Map<String, ? extends Metric> routerMetrics = routerMetricsRepositoryWithHttpAsyncClient.metrics();
       Assert.assertTrue(routerMetrics.get(".security--connection_count.Max").value() > 0);
       Assert.assertTrue(routerMetrics.get(".security--connection_count.Min").value() > 0);
-      Assert.assertTrue(routerMetrics.get(".security--connection_count.Gauge").value() > 0);
+      Assert.assertTrue(routerMetrics.get(".security--connection_count_gauge.Gauge").value() > 0);
     } finally {
       Utils.closeQuietlyWithErrorLogged(veniceRouterRejectsAllConnections);
       Utils.closeQuietlyWithErrorLogged(d2StoreClient);

--- a/services/venice-router/src/main/java/com/linkedin/venice/router/RouterServer.java
+++ b/services/venice-router/src/main/java/com/linkedin/venice/router/RouterServer.java
@@ -698,8 +698,7 @@ public class RouterServer extends AbstractVeniceService {
             LINKED_BLOCKING_QUEUE);
         ThreadPoolStats sslHandshakeThreadPoolStats =
             new ThreadPoolStats(metricsRepository, sslHandshakeExecutor, "ssl_handshake_thread_pool");
-        sslInitializer
-            .enableSslTaskExecutor(sslHandshakeExecutor, sslHandshakeThreadPoolStats::recordQueuedTasksNumber);
+        sslInitializer.enableSslTaskExecutor(sslHandshakeExecutor, sslHandshakeThreadPoolStats::recordQueuedTasksCount);
       }
       if (config.getResolveThreads() > 0) {
         ThreadPoolExecutor dnsResolveExecutor = ThreadPoolFactory.createThreadPool(

--- a/services/venice-router/src/main/java/com/linkedin/venice/router/RouterServer.java
+++ b/services/venice-router/src/main/java/com/linkedin/venice/router/RouterServer.java
@@ -696,8 +696,10 @@ public class RouterServer extends AbstractVeniceService {
             "SSLHandShakeThread",
             config.getClientSslHandshakeQueueCapacity(),
             LINKED_BLOCKING_QUEUE);
-        new ThreadPoolStats(metricsRepository, sslHandshakeExecutor, "ssl_handshake_thread_pool");
-        sslInitializer.enableSslTaskExecutor(sslHandshakeExecutor);
+        ThreadPoolStats sslHandshakeThreadPoolStats =
+            new ThreadPoolStats(metricsRepository, sslHandshakeExecutor, "ssl_handshake_thread_pool");
+        sslInitializer
+            .enableSslTaskExecutor(sslHandshakeExecutor, sslHandshakeThreadPoolStats::recordQueuedTasksNumber);
       }
       if (config.getResolveThreads() > 0) {
         ThreadPoolExecutor dnsResolveExecutor = ThreadPoolFactory.createThreadPool(

--- a/services/venice-router/src/main/java/com/linkedin/venice/router/RouterServer.java
+++ b/services/venice-router/src/main/java/com/linkedin/venice/router/RouterServer.java
@@ -709,7 +709,7 @@ public class RouterServer extends AbstractVeniceService {
             LINKED_BLOCKING_QUEUE);
         new ThreadPoolStats(metricsRepository, dnsResolveExecutor, "dns_resolution_thread_pool");
         int clientSslHandshakeThreads = config.getClientSslHandshakeThreads();
-        int maxConcurrentResolution = config.getMaxConcurrentResolutions();
+        int maxConcurrentSslHandshakes = config.getMaxConcurrentSslHandshakes();
         int clientResolutionRetryAttempts = config.getClientResolutionRetryAttempts();
         long clientResolutionRetryBackoffMs = config.getClientResolutionRetryBackoffMs();
         if (useEpoll) {
@@ -721,7 +721,7 @@ public class RouterServer extends AbstractVeniceService {
             sslResolverEventLoopGroup,
             clientResolutionRetryAttempts,
             clientResolutionRetryBackoffMs,
-            maxConcurrentResolution);
+            maxConcurrentSslHandshakes);
       }
       sslInitializer.setIdentityParser(identityParser::parseIdentityFromCert);
       securityStats.registerSslHandshakeSensors(sslInitializer);

--- a/services/venice-router/src/main/java/com/linkedin/venice/router/RouterServer.java
+++ b/services/venice-router/src/main/java/com/linkedin/venice/router/RouterServer.java
@@ -661,6 +661,7 @@ public class RouterServer extends AbstractVeniceService {
               .bossPoolBuilder(EventLoopGroup.class, ignored -> serverEventLoopGroup)
               .ioWorkerPoolBuilder(EventLoopGroup.class, ignored -> workerEventLoopGroup)
               .connectionLimit(config.getConnectionLimit())
+              .connectionHandleMode(config.getConnectionHandleMode())
               .connectionCountRecorder(securityStats::recordLiveConnectionCount)
               .timeoutProcessor(timeoutProcessor)
               .beforeHttpRequestHandler(ChannelPipeline.class, (pipeline) -> {
@@ -762,6 +763,7 @@ public class RouterServer extends AbstractVeniceService {
         .bossPoolBuilder(EventLoopGroup.class, ignored -> serverEventLoopGroup)
         .ioWorkerPoolBuilder(EventLoopGroup.class, ignored -> workerEventLoopGroup)
         .connectionLimit(config.getConnectionLimit())
+        .connectionHandleMode(config.getConnectionHandleMode())
         .connectionCountRecorder(securityStats::recordLiveConnectionCount)
         .timeoutProcessor(timeoutProcessor)
         .beforeHttpServerCodec(ChannelPipeline.class, sslFactory.isPresent() ? addSslInitializer : noop) // Compare once

--- a/services/venice-router/src/main/java/com/linkedin/venice/router/RouterServer.java
+++ b/services/venice-router/src/main/java/com/linkedin/venice/router/RouterServer.java
@@ -705,7 +705,7 @@ public class RouterServer extends AbstractVeniceService {
         ThreadPoolExecutor dnsResolveExecutor = ThreadPoolFactory.createThreadPool(
             config.getResolveThreads(),
             "DNSResolveThread",
-            config.getResolveThreads(),
+            config.getResolveQueueCapacity(),
             LINKED_BLOCKING_QUEUE);
         new ThreadPoolStats(metricsRepository, dnsResolveExecutor, "dns_resolution_thread_pool");
         int clientSslHandshakeThreads = config.getClientSslHandshakeThreads();

--- a/services/venice-router/src/main/java/com/linkedin/venice/router/RouterSslVerificationHandler.java
+++ b/services/venice-router/src/main/java/com/linkedin/venice/router/RouterSslVerificationHandler.java
@@ -11,6 +11,7 @@ import io.netty.handler.ssl.SslHandler;
 import io.netty.handler.ssl.SslHandshakeCompletionEvent;
 import io.netty.util.ReferenceCountUtil;
 import java.io.IOException;
+import javax.annotation.Nonnull;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -21,11 +22,11 @@ public class RouterSslVerificationHandler extends SimpleChannelInboundHandler<Ht
   private final SecurityStats stats;
   private final boolean requireSsl;
 
-  public RouterSslVerificationHandler(SecurityStats stats) {
+  public RouterSslVerificationHandler(@Nonnull SecurityStats stats) {
     this(stats, true);
   }
 
-  public RouterSslVerificationHandler(SecurityStats stats, boolean requireSsl) {
+  public RouterSslVerificationHandler(@Nonnull SecurityStats stats, boolean requireSsl) {
     this.stats = stats;
     this.requireSsl = requireSsl;
   }
@@ -40,6 +41,8 @@ public class RouterSslVerificationHandler extends SimpleChannelInboundHandler<Ht
    */
   @Override
   public void channelRead0(ChannelHandlerContext ctx, HttpRequest req) throws IOException {
+    // Leverage user request to update connection count metric in the current metric time window.
+    stats.updateConnectionCountInCurrentMetricTimeWindow();
     SslHandler sslHandler = ctx.pipeline().get(SslHandler.class);
     if (sslHandler == null) {
       /**

--- a/services/venice-router/src/main/java/com/linkedin/venice/router/VeniceRouterConfig.java
+++ b/services/venice-router/src/main/java/com/linkedin/venice/router/VeniceRouterConfig.java
@@ -65,7 +65,7 @@ import static com.linkedin.venice.ConfigKeys.ROUTER_LONG_TAIL_RETRY_BUDGET_ENFOR
 import static com.linkedin.venice.ConfigKeys.ROUTER_LONG_TAIL_RETRY_FOR_BATCH_GET_THRESHOLD_MS;
 import static com.linkedin.venice.ConfigKeys.ROUTER_LONG_TAIL_RETRY_FOR_SINGLE_GET_THRESHOLD_MS;
 import static com.linkedin.venice.ConfigKeys.ROUTER_LONG_TAIL_RETRY_MAX_ROUTE_FOR_MULTI_KEYS_REQ;
-import static com.linkedin.venice.ConfigKeys.ROUTER_MAX_CONCURRENT_RESOLUTIONS;
+import static com.linkedin.venice.ConfigKeys.ROUTER_MAX_CONCURRENT_SSL_HANDSHAKES;
 import static com.linkedin.venice.ConfigKeys.ROUTER_MAX_KEY_COUNT_IN_MULTIGET_REQ;
 import static com.linkedin.venice.ConfigKeys.ROUTER_MAX_OUTGOING_CONNECTION;
 import static com.linkedin.venice.ConfigKeys.ROUTER_MAX_OUTGOING_CONNECTION_PER_ROUTE;
@@ -82,6 +82,7 @@ import static com.linkedin.venice.ConfigKeys.ROUTER_PER_NODE_CLIENT_THREAD_COUNT
 import static com.linkedin.venice.ConfigKeys.ROUTER_PER_STORE_ROUTER_QUOTA_BUFFER;
 import static com.linkedin.venice.ConfigKeys.ROUTER_QUOTA_CHECK_WINDOW;
 import static com.linkedin.venice.ConfigKeys.ROUTER_READ_QUOTA_THROTTLING_LEASE_TIMEOUT_MS;
+import static com.linkedin.venice.ConfigKeys.ROUTER_RESOLVE_QUEUE_CAPACITY;
 import static com.linkedin.venice.ConfigKeys.ROUTER_RESOLVE_THREADS;
 import static com.linkedin.venice.ConfigKeys.ROUTER_RETRY_MANAGER_CORE_POOL_SIZE;
 import static com.linkedin.venice.ConfigKeys.ROUTER_SINGLEGET_TARDY_LATENCY_MS;
@@ -198,8 +199,9 @@ public class VeniceRouterConfig implements RouterRetryConfig {
   private final HelixGroupSelectionStrategyEnum helixGroupSelectionStrategy;
   private final String systemSchemaClusterName;
   private final int clientSslHandshakeThreads;
+  private final int maxConcurrentSslHandshakes;
   private final int resolveThreads;
-  private final int maxConcurrentResolutions;
+  private final int resolveQueueCapacity;;
   private final int clientResolutionRetryAttempts;
   private final long clientResolutionRetryBackoffMs;
   private final int clientSslHandshakeQueueCapacity;
@@ -336,11 +338,12 @@ public class VeniceRouterConfig implements RouterRetryConfig {
           props.getInt(ROUTER_HTTPASYNCCLIENT_CLIENT_POOL_THREAD_COUNT, Runtime.getRuntime().availableProcessors());
 
       clientSslHandshakeThreads = props.getInt(ROUTER_CLIENT_SSL_HANDSHAKE_THREADS, 0);
+      maxConcurrentSslHandshakes = props.getInt(ROUTER_MAX_CONCURRENT_SSL_HANDSHAKES, 1000);
       resolveThreads = props.getInt(ROUTER_RESOLVE_THREADS, 0);
-      maxConcurrentResolutions = props.getInt(ROUTER_MAX_CONCURRENT_RESOLUTIONS, 100);
+      resolveQueueCapacity = props.getInt(ROUTER_RESOLVE_QUEUE_CAPACITY, 500000);
       clientResolutionRetryAttempts = props.getInt(ROUTER_CLIENT_RESOLUTION_RETRY_ATTEMPTS, 3);
       clientResolutionRetryBackoffMs = props.getLong(ROUTER_CLIENT_RESOLUTION_RETRY_BACKOFF_MS, 5 * Time.MS_PER_SECOND);
-      clientSslHandshakeQueueCapacity = props.getInt(ROUTER_CLIENT_SSL_HANDSHAKE_QUEUE_CAPACITY, Integer.MAX_VALUE);
+      clientSslHandshakeQueueCapacity = props.getInt(ROUTER_CLIENT_SSL_HANDSHAKE_QUEUE_CAPACITY, 500000);
 
       readQuotaThrottlingLeaseTimeoutMs =
           props.getLong(ROUTER_READ_QUOTA_THROTTLING_LEASE_TIMEOUT_MS, 6 * Time.MS_PER_HOUR);
@@ -792,8 +795,8 @@ public class VeniceRouterConfig implements RouterRetryConfig {
     return resolveThreads;
   }
 
-  public int getMaxConcurrentResolutions() {
-    return maxConcurrentResolutions;
+  public int getMaxConcurrentSslHandshakes() {
+    return maxConcurrentSslHandshakes;
   }
 
   public int getClientResolutionRetryAttempts() {

--- a/services/venice-router/src/main/java/com/linkedin/venice/router/VeniceRouterConfig.java
+++ b/services/venice-router/src/main/java/com/linkedin/venice/router/VeniceRouterConfig.java
@@ -82,7 +82,7 @@ import static com.linkedin.venice.ConfigKeys.ROUTER_PER_NODE_CLIENT_THREAD_COUNT
 import static com.linkedin.venice.ConfigKeys.ROUTER_PER_STORE_ROUTER_QUOTA_BUFFER;
 import static com.linkedin.venice.ConfigKeys.ROUTER_QUOTA_CHECK_WINDOW;
 import static com.linkedin.venice.ConfigKeys.ROUTER_READ_QUOTA_THROTTLING_LEASE_TIMEOUT_MS;
-import static com.linkedin.venice.ConfigKeys.ROUTER_RESOLVE_BEFORE_SSL;
+import static com.linkedin.venice.ConfigKeys.ROUTER_RESOLVE_THREADS;
 import static com.linkedin.venice.ConfigKeys.ROUTER_RETRY_MANAGER_CORE_POOL_SIZE;
 import static com.linkedin.venice.ConfigKeys.ROUTER_SINGLEGET_TARDY_LATENCY_MS;
 import static com.linkedin.venice.ConfigKeys.ROUTER_SINGLE_KEY_LONG_TAIL_RETRY_BUDGET_PERCENT_DECIMAL;
@@ -198,7 +198,7 @@ public class VeniceRouterConfig implements RouterRetryConfig {
   private final HelixGroupSelectionStrategyEnum helixGroupSelectionStrategy;
   private final String systemSchemaClusterName;
   private final int clientSslHandshakeThreads;
-  private final boolean resolveBeforeSSL;
+  private final int resolveThreads;
   private final int maxConcurrentResolutions;
   private final int clientResolutionRetryAttempts;
   private final long clientResolutionRetryBackoffMs;
@@ -336,7 +336,7 @@ public class VeniceRouterConfig implements RouterRetryConfig {
           props.getInt(ROUTER_HTTPASYNCCLIENT_CLIENT_POOL_THREAD_COUNT, Runtime.getRuntime().availableProcessors());
 
       clientSslHandshakeThreads = props.getInt(ROUTER_CLIENT_SSL_HANDSHAKE_THREADS, 0);
-      resolveBeforeSSL = props.getBoolean(ROUTER_RESOLVE_BEFORE_SSL, false);
+      resolveThreads = props.getInt(ROUTER_RESOLVE_THREADS, 0);
       maxConcurrentResolutions = props.getInt(ROUTER_MAX_CONCURRENT_RESOLUTIONS, 100);
       clientResolutionRetryAttempts = props.getInt(ROUTER_CLIENT_RESOLUTION_RETRY_ATTEMPTS, 3);
       clientResolutionRetryBackoffMs = props.getLong(ROUTER_CLIENT_RESOLUTION_RETRY_BACKOFF_MS, 5 * Time.MS_PER_SECOND);
@@ -788,8 +788,8 @@ public class VeniceRouterConfig implements RouterRetryConfig {
     return clientSslHandshakeThreads;
   }
 
-  public boolean isResolveBeforeSSL() {
-    return resolveBeforeSSL;
+  public int getResolveThreads() {
+    return resolveThreads;
   }
 
   public int getMaxConcurrentResolutions() {

--- a/services/venice-router/src/main/java/com/linkedin/venice/router/VeniceRouterConfig.java
+++ b/services/venice-router/src/main/java/com/linkedin/venice/router/VeniceRouterConfig.java
@@ -795,6 +795,10 @@ public class VeniceRouterConfig implements RouterRetryConfig {
     return resolveThreads;
   }
 
+  public int getResolveQueueCapacity() {
+    return resolveQueueCapacity;
+  }
+
   public int getMaxConcurrentSslHandshakes() {
     return maxConcurrentSslHandshakes;
   }

--- a/services/venice-router/src/main/java/com/linkedin/venice/router/stats/SecurityStats.java
+++ b/services/venice-router/src/main/java/com/linkedin/venice/router/stats/SecurityStats.java
@@ -9,33 +9,28 @@ import io.tehuti.metrics.stats.Avg;
 import io.tehuti.metrics.stats.Count;
 import io.tehuti.metrics.stats.Max;
 import io.tehuti.metrics.stats.Min;
-import java.util.function.IntSupplier;
 
 
 public class SecurityStats extends AbstractVeniceStats {
-  private final IntSupplier secureConnectionCountSupplier;
   private final Sensor sslErrorCount;
   private final Sensor sslSuccessCount;
-  private final Sensor sslLiveConnectionCount;
+  private final Sensor liveConnectionCount;
   private final Sensor nonSslConnectionCount;
 
-  public SecurityStats(MetricsRepository repository, String name, IntSupplier secureConnectionCountSupplier) {
+  public SecurityStats(MetricsRepository repository, String name) {
     super(repository, name);
-    this.secureConnectionCountSupplier = secureConnectionCountSupplier;
     this.sslErrorCount = registerSensor("ssl_error", new Count());
     this.sslSuccessCount = registerSensor("ssl_success", new Count());
-    this.sslLiveConnectionCount = registerSensor("ssl_connection_count", new Avg(), new Max(), new Min());
+    this.liveConnectionCount = registerSensor("connection_count", new Avg(), new Max(), new Min());
     this.nonSslConnectionCount = registerSensor("non_ssl_request_count", new Avg(), new Max());
   }
 
   public void recordSslError() {
     this.sslErrorCount.record();
-    recordLiveConnectionCount();
   }
 
   public void recordSslSuccess() {
     this.sslSuccessCount.record();
-    recordLiveConnectionCount();
   }
 
   /**
@@ -46,10 +41,10 @@ public class SecurityStats extends AbstractVeniceStats {
   }
 
   /**
-   * This function will be triggered in every ssl event.
+   * This function will be triggered in {@link com.linkedin.alpini.netty4.handlers.ConnectionControlHandler}.
    */
-  private void recordLiveConnectionCount() {
-    this.sslLiveConnectionCount.record(secureConnectionCountSupplier.getAsInt());
+  public void recordLiveConnectionCount(int connectionCount) {
+    this.liveConnectionCount.record(connectionCount);
   }
 
   public void registerSslHandshakeSensors(SslInitializer sslInitializer) {

--- a/services/venice-router/src/main/java/com/linkedin/venice/router/stats/SecurityStats.java
+++ b/services/venice-router/src/main/java/com/linkedin/venice/router/stats/SecurityStats.java
@@ -52,14 +52,17 @@ public class SecurityStats extends AbstractVeniceStats {
    */
   public void recordLiveConnectionCount(int connectionCount) {
     this.activeConnectionCount.set(connectionCount);
-    recordLiveConnectionCount();
+    updateConnectionCountInCurrentMetricTimeWindow();
   }
 
   /**
+   * Calling this function doesn't mean the active connection counter is updated; this function will only update
+   * the metric with the connection counter maintained above {@link SecurityStats#activeConnectionCount}
+   *
    * Since new connections or inactive connections events might not happen in each one-minute time window, a more
    * active path like data request path will be leveraged to record avg/max connections in each time window.
    */
-  public void recordLiveConnectionCount() {
+  public void updateConnectionCountInCurrentMetricTimeWindow() {
     this.liveConnectionCount.record(activeConnectionCount.get());
   }
 

--- a/services/venice-router/src/main/java/com/linkedin/venice/router/stats/SecurityStats.java
+++ b/services/venice-router/src/main/java/com/linkedin/venice/router/stats/SecurityStats.java
@@ -73,5 +73,9 @@ public class SecurityStats extends AbstractVeniceStats {
         new AsyncGauge(
             (ignored1, ignored2) -> sslInitializer.getHandshakesFailed(),
             "total_failed_ssl_handshake_count"));
+    registerSensor(
+        new AsyncGauge(
+            (ignored1, ignored2) -> sslInitializer.getHandshakesStarted() - sslInitializer.getHandshakesFailed(),
+            "active_ssl_connection_count"));
   }
 }

--- a/services/venice-server/src/main/java/com/linkedin/venice/listener/HttpChannelInitializer.java
+++ b/services/venice-server/src/main/java/com/linkedin/venice/listener/HttpChannelInitializer.java
@@ -22,6 +22,7 @@ import com.linkedin.venice.security.SSLFactory;
 import com.linkedin.venice.stats.AggServerHttpRequestStats;
 import com.linkedin.venice.stats.AggServerQuotaUsageStats;
 import com.linkedin.venice.stats.ServerConnectionStats;
+import com.linkedin.venice.stats.ThreadPoolStats;
 import com.linkedin.venice.utils.ReflectUtils;
 import com.linkedin.venice.utils.SslUtils;
 import com.linkedin.venice.utils.Utils;
@@ -38,7 +39,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.Executor;
+import java.util.concurrent.ThreadPoolExecutor;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -50,8 +51,9 @@ public class HttpChannelInitializer extends ChannelInitializer<SocketChannel> {
   private final AggServerHttpRequestStats singleGetStats;
   private final AggServerHttpRequestStats multiGetStats;
   private final AggServerHttpRequestStats computeStats;
+  private final ThreadPoolStats sslHandshakesThreadPoolStats;
   private final Optional<SSLFactory> sslFactory;
-  private final Executor sslHandshakeExecutor;
+  private final ThreadPoolExecutor sslHandshakeExecutor;
   private final Optional<ServerAclHandler> aclHandler;
   private final Optional<ServerStoreAclHandler> storeAclHandler;
   private final VerifySslHandler verifySsl = new VerifySslHandler();
@@ -70,7 +72,7 @@ public class HttpChannelInitializer extends ChannelInitializer<SocketChannel> {
       CompletableFuture<HelixCustomizedViewOfflinePushRepository> customizedViewRepository,
       MetricsRepository metricsRepository,
       Optional<SSLFactory> sslFactory,
-      Executor sslHandshakeExecutor,
+      ThreadPoolExecutor sslHandshakeExecutor,
       VeniceServerConfig serverConfig,
       Optional<StaticAccessController> routerAccessController,
       Optional<DynamicAccessController> storeAccessController,
@@ -113,6 +115,8 @@ public class HttpChannelInitializer extends ChannelInitializer<SocketChannel> {
 
     this.sslFactory = sslFactory;
     this.sslHandshakeExecutor = sslHandshakeExecutor;
+    this.sslHandshakesThreadPoolStats =
+        new ThreadPoolStats(metricsRepository, sslHandshakeExecutor, "ssl_handshake_thread_pool");
 
     Class<IdentityParser> identityParserClass = ReflectUtils.loadClass(serverConfig.getIdentityParserClassName());
     this.identityParser = ReflectUtils.callConstructor(identityParserClass, new Class[0], new Object[0]);
@@ -183,7 +187,8 @@ public class HttpChannelInitializer extends ChannelInitializer<SocketChannel> {
     if (sslFactory.isPresent()) {
       SslInitializer sslInitializer = new SslInitializer(SslUtils.toAlpiniSSLFactory(sslFactory.get()), false);
       if (sslHandshakeExecutor != null) {
-        sslInitializer.enableSslTaskExecutor(sslHandshakeExecutor);
+        sslInitializer
+            .enableSslTaskExecutor(sslHandshakeExecutor, sslHandshakesThreadPoolStats::recordQueuedTasksNumber);
       }
       sslInitializer.setIdentityParser(identityParser::parseIdentityFromCert);
       ch.pipeline().addLast(sslInitializer);

--- a/services/venice-server/src/main/java/com/linkedin/venice/listener/HttpChannelInitializer.java
+++ b/services/venice-server/src/main/java/com/linkedin/venice/listener/HttpChannelInitializer.java
@@ -188,7 +188,7 @@ public class HttpChannelInitializer extends ChannelInitializer<SocketChannel> {
       SslInitializer sslInitializer = new SslInitializer(SslUtils.toAlpiniSSLFactory(sslFactory.get()), false);
       if (sslHandshakeExecutor != null) {
         sslInitializer
-            .enableSslTaskExecutor(sslHandshakeExecutor, sslHandshakesThreadPoolStats::recordQueuedTasksNumber);
+            .enableSslTaskExecutor(sslHandshakeExecutor, sslHandshakesThreadPoolStats::recordQueuedTasksCount);
       }
       sslInitializer.setIdentityParser(identityParser::parseIdentityFromCert);
       ch.pipeline().addLast(sslInitializer);

--- a/services/venice-server/src/main/java/com/linkedin/venice/listener/ListenerService.java
+++ b/services/venice-server/src/main/java/com/linkedin/venice/listener/ListenerService.java
@@ -102,7 +102,6 @@ public class ListenerService extends AbstractVeniceService {
           serverConfig.getSslHandshakeThreadPoolSize(),
           "SSLHandShakeThread",
           serverConfig.getSslHandshakeQueueCapacity());
-      new ThreadPoolStats(metricsRepository, this.sslHandshakeExecutor, "ssl_handshake_thread_pool");
     }
 
     StorageReadRequestHandler requestHandler = createRequestHandler(

--- a/services/venice-server/src/test/java/com/linkedin/venice/listener/HttpChannelInitializerTest.java
+++ b/services/venice-server/src/test/java/com/linkedin/venice/listener/HttpChannelInitializerTest.java
@@ -20,7 +20,7 @@ import io.tehuti.metrics.MetricsRepository;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.Executor;
+import java.util.concurrent.ThreadPoolExecutor;
 import org.testng.Assert;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
@@ -33,7 +33,7 @@ public class HttpChannelInitializerTest {
   private Optional<SSLFactory> sslFactoryOptional;
 
   private SSLFactory sslFactory;
-  private Executor sslHandshakeExecutor;
+  private ThreadPoolExecutor sslHandshakeExecutor;
   private VeniceServerConfig serverConfig;
   private Optional<StaticAccessController> accessController;
   private Optional<DynamicAccessController> storeAccessController;
@@ -45,7 +45,7 @@ public class HttpChannelInitializerTest {
     metricsRepository = new MetricsRepository();
     sslFactory = mock(SSLFactory.class);
     sslFactoryOptional = Optional.of(sslFactory);
-    sslHandshakeExecutor = mock(Executor.class);
+    sslHandshakeExecutor = mock(ThreadPoolExecutor.class);
     accessController = Optional.of(mock(StaticAccessController.class));
     storeAccessController = Optional.of(mock(DynamicAccessController.class));
     requestHandler = mock(StorageReadRequestHandler.class);


### PR DESCRIPTION
## Summary
Previously a separate thread pool is only used for DNS resolution before SSL handshakes; it turns out that
we can assign a thread pool for SSL handshake as well. If both features are enabled, the execution order in
the Netty pipeline would be:
Decode, verify SSL is enabled -> Run DNS resolution asynchronously -> Retry DNS resolution within a budget
and if connection is active -> Regardless if resolution is successful, start SSL handshake if connection is still
active by swapping current handler to SSL handler -> SSL handshake -> log after handshake completes

Commends with "Step" prefix are added to improve readability of alpini SslInitializer.

Configs updates:
1. Changed "router.resolve.before.ssl" to "router.resolve.threads": 0 means DNS resolution before SSL is disabled; positive number represents the number of threads for DNS resolution.
2. Changed "router.max.concurrent.resolutions" to "router.max.concurrent.ssl.handshakes": the same config value has been used for max concurrent SSL handshakes limit, but it was wrongly named as resolution limit.

Other changes:
1. Measure latency of DNS resolution, add warning log when latency is higher than 5 seconds
3. Add debug level log when SSL handshake starts
4. First attempt to fix leaked pending SSL handshake metric, when connection is closed mid handshake, increase handshake failure counter.
5. Fixed a bug that max concurrent resolution limit is set to max ssl handshake limit
6. Added error log and return 429 when connection limits exceed; fixed the metric for connection count
7. Added request level SSL handshake task queue size metrics for both router and server.

## How was this PR tested?
Updated integration tests to enable both thread pools for DNS resolution and SSL handshake.

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [ ] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.