### PR TITLE
[common] Add getLastUpdateTimestamp to RmdUtils

### DIFF
--- a/internal/venice-client-common/src/main/java/com/linkedin/venice/schema/rmd/RmdUtils.java
+++ b/internal/venice-client-common/src/main/java/com/linkedin/venice/schema/rmd/RmdUtils.java
@@ -1,12 +1,15 @@
 package com.linkedin.venice.schema.rmd;
 
 import static com.linkedin.venice.schema.rmd.RmdConstants.REPLICATION_CHECKPOINT_VECTOR_FIELD_POS;
+import static com.linkedin.venice.schema.rmd.RmdConstants.TIMESTAMP_FIELD_NAME;
 import static com.linkedin.venice.schema.rmd.RmdConstants.TIMESTAMP_FIELD_POS;
+import static com.linkedin.venice.schema.rmd.v1.CollectionRmdTimestamp.*;
 
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import org.antlr.v4.runtime.misc.NotNull;
+import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericRecord;
 
 
@@ -127,5 +130,50 @@ public class RmdUtils {
     }
 
     return mergedVector;
+  }
+
+  static public long getLastUpdateTimestamp(Object object) {
+    // The replication metadata object contains a single field called "timestamp" which is a union of a long and a
+    // record.
+    // if the type is a long, we just return that
+    Object timestampRecord = ((GenericRecord) object).get(TIMESTAMP_FIELD_NAME);
+    if (RmdUtils.getRmdTimestampType(timestampRecord).equals(RmdTimestampType.VALUE_LEVEL_TIMESTAMP)) {
+      // return early
+      return (Long) timestampRecord;
+    }
+
+    // If the type is a record, then we need to iterate over the fields and find the latest timestamp of any of the
+    // fields
+    // the field types we're interested will either be of type long, or another record. Record is used to bookkeeping
+    // operations
+    // on fields which are collection types like arrays or maps.
+    Long lastUpdatedTimestamp = -1L;
+    // iterate through the fields, this is only a two level deep structure, so a loop with a single embedded loop will
+    // fit the bill
+    for (Schema.Field field: ((GenericRecord) timestampRecord).getSchema().getFields()) {
+      // if the field is a record, then we need to iterate through the fields of the record
+      if (field.schema().getType().equals(Schema.Type.RECORD)) {
+        for (Schema.Field recordField: field.schema().getFields()) {
+          // if the field is a long, then we have the timestamp
+          if (recordField.schema().getType().equals(Schema.Type.LONG)
+              && recordField.schema().getName().equals(TOP_LEVEL_TS_FIELD_NAME)) {
+            return (Long) ((GenericRecord) timestampRecord).get(recordField.name());
+          }
+          // if the field is an array of longs
+          if (recordField.schema().getType().equals(Schema.Type.ARRAY)
+              && recordField.schema().getElementType().getType().equals(Schema.Type.LONG)
+              && (recordField.schema().getName().equals(ACTIVE_ELEM_TS_FIELD_NAME)
+                  || recordField.schema().getName().equals(DELETED_ELEM_TS_FIELD_NAME))) {
+            for (Long timestamp: (List<Long>) ((GenericRecord) timestampRecord).get(recordField.name())) {
+              lastUpdatedTimestamp = Math.max(lastUpdatedTimestamp, timestamp);
+            }
+          }
+        }
+      } else if (field.schema().getType().equals(Schema.Type.LONG)) {
+        lastUpdatedTimestamp =
+            Math.max(lastUpdatedTimestamp, (Long) ((GenericRecord) timestampRecord).get(field.name()));
+      }
+    }
+    return lastUpdatedTimestamp;
   }
 }

--- a/internal/venice-client-common/src/test/java/com/linkedin/venice/schema/rmd/TestRmdUtils.java
+++ b/internal/venice-client-common/src/test/java/com/linkedin/venice/schema/rmd/TestRmdUtils.java
@@ -2,8 +2,11 @@ package com.linkedin.venice.schema.rmd;
 
 import static com.linkedin.venice.schema.rmd.RmdConstants.REPLICATION_CHECKPOINT_VECTOR_FIELD_NAME;
 import static com.linkedin.venice.schema.rmd.RmdConstants.TIMESTAMP_FIELD_NAME;
+import static com.linkedin.venice.schema.rmd.v1.CollectionRmdTimestamp.*;
 
 import com.linkedin.venice.schema.AvroSchemaParseUtils;
+import com.linkedin.venice.schema.rmd.v1.RmdSchemaGeneratorV1;
+import com.linkedin.venice.utils.TestWriteUtils;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -25,79 +28,17 @@ public class TestRmdUtils {
           + "    \"type\" : \"string\",\n" + "    \"default\" : \"default_name\"\n" + "  }, {\n"
           + "    \"name\" : \"age\",\n" + "    \"type\" : \"int\",\n" + "    \"default\" : -1\n" + "  } ]\n" + "}";
 
-  private static final String RMD_COLLECTION_RECORD = "        {\n" + "            \"name\": \"creatives\",\n"
-      + "            \"type\": {\n" + "                \"type\": \"record\",\n"
-      + "                \"name\": \"map_CollectionMetadata_0\",\n"
-      + "                \"doc\": \"structure that maintains all of the necessary metadata to perform deterministic conflict resolution on collection fields.\",\n"
-      + "                \"fields\": [\n" + "                    {\n"
-      + "                        \"name\": \"topLevelFieldTimestamp\",\n"
-      + "                        \"type\": \"long\",\n"
-      + "                        \"doc\": \"Timestamp of the last partial update attempting to set every element of this collection.\",\n"
-      + "                        \"default\": 0\n" + "                    },\n" + "                    {\n"
-      + "                        \"name\": \"topLevelColoID\",\n" + "                        \"type\": \"int\",\n"
-      + "                        \"doc\": \"ID of the colo from which the last successfully applied partial update was sent.\",\n"
-      + "                        \"default\": -1\n" + "                    },\n" + "                    {\n"
-      + "                        \"name\": \"putOnlyPartLength\",\n" + "                        \"type\": \"int\",\n"
-      + "                        \"doc\": \"Length of the put-only part of the collection which starts from index 0.\",\n"
-      + "                        \"default\": 0\n" + "                    },\n" + "                    {\n"
-      + "                        \"name\": \"activeElementsTimestamps\",\n" + "                        \"type\": {\n"
-      + "                            \"type\": \"array\",\n" + "                            \"items\": \"long\"\n"
-      + "                        },\n"
-      + "                        \"doc\": \"Timestamps of each active element in the user's collection. This is a parallel array with the user's collection.\",\n"
-      + "                        \"default\": []\n" + "                    },\n" + "                    {\n"
-      + "                        \"name\": \"deletedElementsIdentities\",\n" + "                        \"type\": {\n"
-      + "                            \"type\": \"array\",\n" + "                            \"items\": \"string\"\n"
-      + "                        },\n"
-      + "                        \"doc\": \"The tombstone array of deleted elements. This is a parallel array with deletedElementsTimestamps\",\n"
-      + "                        \"default\": []\n" + "                    },\n" + "                    {\n"
-      + "                        \"name\": \"deletedElementsTimestamps\",\n" + "                        \"type\": {\n"
-      + "                            \"type\": \"array\",\n" + "                            \"items\": \"long\"\n"
-      + "                        },\n"
-      + "                        \"doc\": \"Timestamps of each deleted element. This is a parallel array with deletedElementsIdentity.\",\n"
-      + "                        \"default\": []\n" + "                    }\n" + "                ]\n"
-      + "            },\n" + "            \"doc\": \"timestamp when creatives of the record was last updated\",\n"
-      + "            \"default\": {\n" + "                \"deletedElementsTimestamps\": [],\n"
-      + "                \"deletedElementsIdentities\": [],\n" + "                \"topLevelColoID\": -1,\n"
-      + "                \"putOnlyPartLength\": 0,\n" + "                \"activeElementsTimestamps\": [],\n"
-      + "                \"topLevelFieldTimestamp\": 0\n" + "            }\n" + "        }";
-
-  private static final String RMD_TIMESTAMP_RECORD =
-      "{\n" + "    \"type\": \"record\",\n" + "    \"name\": \"ValueTest\",\n" + "    \"fields\": [\n" + "        {\n"
-          + "            \"name\": \"account\",\n" + "            \"type\": \"long\",\n"
-          + "            \"doc\": \"timestamp when account of the record was last updated\",\n"
-          + "            \"default\": 0\n" + "        },\n" + "        {\n"
-          + "            \"name\": \"campaignGroup\",\n" + "            \"type\": \"long\",\n"
-          + "            \"doc\": \"timestamp when campaignGroup of the record was last updated\",\n"
-          + "            \"default\": 0\n" + "        },\n" + "        {\n" + "            \"name\": \"campaign\",\n"
-          + "            \"type\": \"long\",\n"
-          + "            \"doc\": \"timestamp when campaign of the record was last updated\",\n"
-          + "            \"default\": 0\n" + "        },\n" + RMD_COLLECTION_RECORD + "    ]\n" + "}";
-
-  private static final String RMD_RECORD_SCHEMA_STR = "{\n" + "    \"type\": \"record\",\n"
-      + "    \"name\": \"ValueTest_MetadataRecord\",\n" + "    \"fields\": [\n" + "        {\n"
-      + "            \"name\": \"timestamp\",\n" + "            \"type\": [\n" + "                \"long\",\n"
-      + RMD_TIMESTAMP_RECORD + "                \n" + "            ]\n" + "        },\n" + "        {\n"
-      + "            \"name\": \"replication_checkpoint_vector\",\n" + "            \"type\": {\n"
-      + "                \"type\": \"array\",\n" + "                \"items\": \"long\"\n" + "            },\n"
-      + "            \"doc\": \"high watermark remote checkpoints which touched this record\",\n"
-      + "            \"default\": []\n" + "        }\n" + "    ]\n" + "}";
-
   private Schema valueSchema;
   private Schema rmdSchema;
-  private Schema rmdSchemaWithPerFieldTimestamp;
-  private Schema timestampRecordSchema;
   private GenericRecord rmdRecordWithValueLevelTimeStamp;
   private GenericRecord rmdRecordWithPerFieldLevelTimeStamp;
   private GenericRecord rmdRecordWithValidPerFieldLevelTimestamp;
   private GenericRecord rmdRecordWithOnlyRootLevelTimestamp;
-  private GenericRecord timestampRecord;
 
   @BeforeClass
   public void setUp() {
     valueSchema = AvroSchemaParseUtils.parseSchemaFromJSONStrictValidation(VALUE_RECORD_SCHEMA_STR);
     rmdSchema = RmdSchemaGenerator.generateMetadataSchema(valueSchema, 1);
-    rmdSchemaWithPerFieldTimestamp = AvroSchemaParseUtils.parseSchemaFromJSONStrictValidation(RMD_RECORD_SCHEMA_STR);
-    timestampRecordSchema = AvroSchemaParseUtils.parseSchemaFromJSONStrictValidation(RMD_TIMESTAMP_RECORD);
   }
 
   @BeforeMethod
@@ -113,12 +54,25 @@ public class TestRmdUtils {
     rmdRecordWithPerFieldLevelTimeStamp.put(REPLICATION_CHECKPOINT_VECTOR_FIELD_NAME, vectors);
 
     // This one is actually valid (TODO, refactor the rest of the tests to use this)
-    rmdRecordWithValidPerFieldLevelTimestamp = new GenericData.Record(rmdSchemaWithPerFieldTimestamp);
-    rmdRecordWithOnlyRootLevelTimestamp = new GenericData.Record(rmdSchemaWithPerFieldTimestamp);
-    timestampRecord = new GenericData.Record(timestampRecordSchema);
-    timestampRecord.put("account", 10L);
-    timestampRecord.put("campaignGroup", 20L);
-    timestampRecord.put("campaign", 30L);
+    RmdSchemaGeneratorV1 rmdSchemaGeneratorV1 = new RmdSchemaGeneratorV1();
+    Schema timestampSchema = rmdSchemaGeneratorV1.generateMetadataSchema(TestWriteUtils.USER_WITH_STRING_MAP_SCHEMA);
+    Schema mapFieldSchema = timestampSchema.getField("timestamp").schema().getTypes().get(1).getField("value").schema();
+
+    GenericRecord mapFieldRecord = new GenericData.Record(mapFieldSchema);
+    long[] activeElemTs = { 10L, 20L };
+    long[] deletedElemTs = { 5L };
+    mapFieldRecord.put(ACTIVE_ELEM_TS_FIELD_NAME, activeElemTs);
+    mapFieldRecord.put(TOP_LEVEL_TS_FIELD_NAME, 1L);
+    mapFieldRecord.put(DELETED_ELEM_TS_FIELD_NAME, deletedElemTs);
+
+    GenericRecord timestampRecord =
+        new GenericData.Record(timestampSchema.getField("timestamp").schema().getTypes().get(1));
+    timestampRecord.put("key", 10L);
+    timestampRecord.put("age", 30L);
+    timestampRecord.put("value", mapFieldRecord);
+
+    rmdRecordWithValidPerFieldLevelTimestamp = new GenericData.Record(timestampSchema);
+    rmdRecordWithOnlyRootLevelTimestamp = new GenericData.Record(timestampSchema);
     rmdRecordWithValidPerFieldLevelTimestamp.put(TIMESTAMP_FIELD_NAME, timestampRecord);
     rmdRecordWithOnlyRootLevelTimestamp.put(TIMESTAMP_FIELD_NAME, 0L);
   }


### PR DESCRIPTION
## [common] Add getLastUpdateTimestamp to RmdUtils

This allows for extracting the latest timestamp of all operations enacted on a record given some RMD

Resolves #XXX

## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [ ] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.