### PR TITLE
[controller] extract real time topic names, before store versions are deleted

### DIFF
--- a/internal/venice-common/src/main/java/com/linkedin/venice/utils/Utils.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/utils/Utils.java
@@ -620,6 +620,10 @@ public class Utils {
     }
   }
 
+  public static Set<String> getAllRealTimeTopicNames(Store store) {
+    return store.getVersions().stream().map(Utils::getRealTimeTopicName).collect(Collectors.toSet());
+  }
+
   static String getRealTimeTopicName(
       String storeName,
       List<Version> versions,

--- a/internal/venice-common/src/test/java/com/linkedin/venice/utils/UtilsTest.java
+++ b/internal/venice-common/src/test/java/com/linkedin/venice/utils/UtilsTest.java
@@ -270,11 +270,10 @@ public class UtilsTest {
     when(mockVersions.get(1).getHybridStoreConfig()).thenReturn(mockHybridConfig);
     when(mockVersions.get(2).getHybridStoreConfig()).thenReturn(mockHybridConfig);
 
-    when(mockHybridConfig.getRealTimeTopicName())
-        .thenReturn("RealTimeTopic_v1", "RealTimeTopic_v2", "RealTimeTopic_v3");
+    when(mockHybridConfig.getRealTimeTopicName()).thenReturn("StoreName_v1_rt", "StoreName_v2_rt", "StoreName_v3_rt");
 
     Set<String> result = Utils.getAllRealTimeTopicNames(mockStore);
-    assertEquals(result, new HashSet<>(Arrays.asList("RealTimeTopic_v1", "RealTimeTopic_v2", "RealTimeTopic_v3")));
+    assertEquals(result, new HashSet<>(Arrays.asList("StoreName_v1_rt", "StoreName_v2_rt", "StoreName_v3_rt")));
   }
 
   @Test

--- a/internal/venice-common/src/test/java/com/linkedin/venice/utils/UtilsTest.java
+++ b/internal/venice-common/src/test/java/com/linkedin/venice/utils/UtilsTest.java
@@ -28,6 +28,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -250,6 +251,30 @@ public class UtilsTest {
     assertEquals(Utils.resolveKafkaUrlForSepTopic(""), "");
     assertEquals(Utils.resolveKafkaUrlForSepTopic(originalKafkaUrlForSep), originalKafkaUrl);
     assertEquals(Utils.resolveKafkaUrlForSepTopic(originalKafkaUrl), originalKafkaUrl);
+  }
+
+  @Test
+  void testGetRealTimeTopicNames() {
+    Store mockStore = mock(Store.class);
+    List<Version> mockVersions = new ArrayList<>();
+    mockVersions.add(mock(Version.class));
+    mockVersions.add(mock(Version.class));
+    mockVersions.add(mock(Version.class));
+    HybridStoreConfig mockHybridConfig = mock(HybridStoreConfig.class);
+
+    when(mockStore.getName()).thenReturn("TestStore");
+    when(mockStore.getVersions()).thenReturn(mockVersions);
+    when(mockStore.getCurrentVersion()).thenReturn(1);
+    when(mockStore.getHybridStoreConfig()).thenReturn(mockHybridConfig);
+    when(mockVersions.get(0).getHybridStoreConfig()).thenReturn(mockHybridConfig);
+    when(mockVersions.get(1).getHybridStoreConfig()).thenReturn(mockHybridConfig);
+    when(mockVersions.get(2).getHybridStoreConfig()).thenReturn(mockHybridConfig);
+
+    when(mockHybridConfig.getRealTimeTopicName())
+        .thenReturn("RealTimeTopic_v1", "RealTimeTopic_v2", "RealTimeTopic_v3");
+
+    Set<String> result = Utils.getAllRealTimeTopicNames(mockStore);
+    assertEquals(result, new HashSet<>(Arrays.asList("RealTimeTopic_v1", "RealTimeTopic_v2", "RealTimeTopic_v3")));
   }
 
   @Test

--- a/internal/venice-common/src/test/java/com/linkedin/venice/utils/UtilsTest.java
+++ b/internal/venice-common/src/test/java/com/linkedin/venice/utils/UtilsTest.java
@@ -262,7 +262,7 @@ public class UtilsTest {
     mockVersions.add(mock(Version.class));
     HybridStoreConfig mockHybridConfig = mock(HybridStoreConfig.class);
 
-    when(mockStore.getName()).thenReturn("TestStore");
+    when(mockStore.getName()).thenReturn("StoreName");
     when(mockStore.getVersions()).thenReturn(mockVersions);
     when(mockStore.getCurrentVersion()).thenReturn(1);
     when(mockStore.getHybridStoreConfig()).thenReturn(mockHybridConfig);

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceHelixAdmin.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceHelixAdmin.java
@@ -1160,6 +1160,10 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
         }
       }
       if (store != null) {
+        List<PubSubTopic> rtTopics = Utils.getAllRealTimeTopicNames(store)
+            .stream()
+            .map(pubSubTopicRepository::getTopic)
+            .collect(Collectors.toList());
         // Delete All versions and push statues
         deleteAllVersionsInStore(clusterName, storeName);
         resources.getPushMonitor().cleanupStoreStatus(storeName);
@@ -1167,17 +1171,18 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
         truncateOldTopics(clusterName, store, true);
 
         if (!store.isMigrating() && !isAbortMigrationCleanup) {
-          // for RT topic block on deletion so that next create store does not see the lingering RT topic which could
-          // have different partition count
-          PubSubTopic rtTopic = pubSubTopicRepository.getTopic(Utils.getRealTimeTopicName(store));
           // Some implementations of PubSubAdminAdapter may retry multiple times to get/update topic's config in order
           // to truncate it. Because of this, `truncateKafkaTopic` may take long enough time to make `delete store`
           // operation time out. Therefore, we check for the existence of RT topic before trying to truncate it.
           // No known implementation of PubSubAdminAdapter does retries for `containsTopic`.
-          if (getTopicManager().containsTopic(rtTopic)) {
-            truncateKafkaTopic(rtTopic.getName());
-            if (waitOnRTTopicDeletion && getTopicManager().containsTopic(rtTopic)) {
-              throw new VeniceRetriableException("Waiting for RT topic deletion for store: " + storeName);
+          for (PubSubTopic rtTopic: rtTopics) {
+            if (getTopicManager().containsTopic(rtTopic)) {
+              // for RT topic block on deletion so that next create store does not see the lingering RT topic which
+              // could have different partition count
+              truncateKafkaTopic(rtTopic.getName());
+              if (waitOnRTTopicDeletion && getTopicManager().containsTopic(rtTopic)) {
+                throw new VeniceRetriableException("Waiting for RT topic deletion for store: " + storeName);
+              }
             }
           }
         }


### PR DESCRIPTION
<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat], [protocol]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## extract real time topic names, before current version is unset in `deleteStore`
<!--
Describe
- What changes to make and why you are making these changes.
- How are you going to achieve your goal.
- Describe what testings you have done, for example, performance testing etc.

If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->
Current Version is needed to determine the RT topic name, so extract the real time topic names before it is unset in `deleteStore`

Resolves #XXX

## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.