### PR TITLE
[dvc] Do not unsubscribe store from store repository during Da Vinci shutdown

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/StoreBackend.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/StoreBackend.java
@@ -90,6 +90,7 @@ public class StoreBackend {
       version.delete();
     }
 
+    backend.getStoreRepository().unsubscribe(storeName);
   }
 
   public boolean isManaged() {

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/StoreBackend.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/StoreBackend.java
@@ -72,8 +72,6 @@ public class StoreBackend {
       setDaVinciCurrentVersion(null);
       version.close();
     }
-
-    backend.getStoreRepository().unsubscribe(storeName);
   }
 
   synchronized void delete() {
@@ -92,7 +90,6 @@ public class StoreBackend {
       version.delete();
     }
 
-    backend.getStoreRepository().unsubscribe(storeName);
   }
 
   public boolean isManaged() {


### PR DESCRIPTION
<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat], [protocol]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## [dvc] Do not unsubscribe store from store repository during Da Vinci shutdown
Da Vinci client throws a lot of exception during shutdown due to the fact that it is unsubscribing to store repo while doing other checkpointing in async way. They will throw exception when store is not found from the repo.
There are two ways to fix it: (1) Just don't unsubscribe it from store repository, as the subscription is fixed during client life cycle and there is no harm to keep the existing subscription during shutdown (2) Make all the shutdown work first and then perform unsubscribe, which will have more changes and potentially slow down. This PR goes with (1) as it is simpler and cleaner to achieve.

## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
Existing test
## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.