### PR TITLE
[server][controller][dvc] Cache VeniceSystemStoreType for faster lookup

### DIFF
--- a/internal/venice-common/src/main/java/com/linkedin/venice/common/VeniceSystemStoreType.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/common/VeniceSystemStoreType.java
@@ -218,8 +218,13 @@ public enum VeniceSystemStoreType {
    * @return The corresponding VeniceSystemStoreType if found; otherwise, null.
    */
   public static VeniceSystemStoreType getSystemStoreType(String storeName) {
-    if (storeName == null || !storeName.startsWith(Store.SYSTEM_STORE_NAME_PREFIX)) {
+    if (storeName == null || storeName.isEmpty()) {
       return null;
+    }
+    // perform lookup before prefix check to avoid prefix check for cached entries
+    VeniceSystemStoreType cachedStoreType = STORE_TYPE_CACHE.get(storeName);
+    if (cachedStoreType != null || !storeName.startsWith(Store.SYSTEM_STORE_NAME_PREFIX)) {
+      return cachedStoreType;
     }
 
     return STORE_TYPE_CACHE.computeIfAbsent(storeName, key -> {

--- a/internal/venice-common/src/main/java/com/linkedin/venice/common/VeniceSystemStoreType.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/common/VeniceSystemStoreType.java
@@ -1,5 +1,6 @@
 package com.linkedin.venice.common;
 
+import com.linkedin.venice.annotation.VisibleForTesting;
 import com.linkedin.venice.authorization.AceEntry;
 import com.linkedin.venice.authorization.AclBinding;
 import com.linkedin.venice.authorization.Method;
@@ -14,10 +15,12 @@ import com.linkedin.venice.status.protocol.BatchJobHeartbeatKey;
 import com.linkedin.venice.status.protocol.BatchJobHeartbeatValue;
 import com.linkedin.venice.systemstore.schemas.StoreMetaKey;
 import com.linkedin.venice.systemstore.schemas.StoreMetaValue;
+import com.linkedin.venice.utils.concurrent.VeniceConcurrentHashMap;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 
 
 /**
@@ -206,16 +209,27 @@ public enum VeniceSystemStoreType {
     return systemStoreAclBinding;
   }
 
+  private static final Map<String, VeniceSystemStoreType> STORE_TYPE_CACHE = new VeniceConcurrentHashMap<>(64);
+
+  /**
+   * Retrieves the VeniceSystemStoreType for the given store name, using caching for improved performance.
+   *
+   * @param storeName The name of the store.
+   * @return The corresponding VeniceSystemStoreType if found; otherwise, null.
+   */
   public static VeniceSystemStoreType getSystemStoreType(String storeName) {
-    if (storeName == null) {
+    if (storeName == null || !storeName.startsWith(Store.SYSTEM_STORE_NAME_PREFIX)) {
       return null;
     }
-    for (VeniceSystemStoreType systemStoreType: VALUES) {
-      if (storeName.startsWith(systemStoreType.getPrefix()) && !systemStoreType.getPrefix().equals(storeName)) {
-        return systemStoreType;
+
+    return STORE_TYPE_CACHE.computeIfAbsent(storeName, key -> {
+      for (VeniceSystemStoreType systemStoreType: VALUES) {
+        if (storeName.startsWith(systemStoreType.getPrefix()) && !systemStoreType.getPrefix().equals(storeName)) {
+          return systemStoreType;
+        }
       }
-    }
-    return null;
+      return null;
+    });
   }
 
   /**
@@ -248,5 +262,10 @@ public enum VeniceSystemStoreType {
       userStoreName = systemStoreType.extractRegularStoreName(storeName);
     }
     return userStoreName;
+  }
+
+  @VisibleForTesting
+  static Map<String, VeniceSystemStoreType> getStoreTypeCache() {
+    return STORE_TYPE_CACHE;
   }
 }

--- a/internal/venice-common/src/test/java/com/linkedin/venice/common/TestVeniceSystemStoreType.java
+++ b/internal/venice-common/src/test/java/com/linkedin/venice/common/TestVeniceSystemStoreType.java
@@ -2,8 +2,13 @@ package com.linkedin.venice.common;
 
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertTrue;
 
 import com.linkedin.venice.meta.Store;
+import com.linkedin.venice.utils.Utils;
 import java.util.HashSet;
 import java.util.List;
 import org.testng.Assert;
@@ -17,17 +22,17 @@ public class TestVeniceSystemStoreType {
     String schemaStore = "venice_system_store_METADATA_SYSTEM_SCHEMA_STORE";
     String heartBeatStore = VeniceSystemStoreType.BATCH_JOB_HEARTBEAT_STORE.getPrefix();
 
-    Assert.assertEquals(VeniceSystemStoreType.extractUserStoreName(userStoreName), userStoreName);
-    Assert.assertEquals(
+    assertEquals(VeniceSystemStoreType.extractUserStoreName(userStoreName), userStoreName);
+    assertEquals(
         VeniceSystemStoreType.extractUserStoreName(VeniceSystemStoreType.META_STORE.getSystemStoreName(userStoreName)),
         userStoreName);
-    Assert.assertEquals(
+    assertEquals(
         VeniceSystemStoreType
             .extractUserStoreName(VeniceSystemStoreType.DAVINCI_PUSH_STATUS_STORE.getSystemStoreName(userStoreName)),
         userStoreName);
-    Assert.assertEquals(VeniceSystemStoreType.extractUserStoreName(schemaStore), schemaStore);
-    Assert.assertEquals(VeniceSystemStoreType.extractUserStoreName(heartBeatStore), heartBeatStore);
-    Assert.assertNull(VeniceSystemStoreType.extractUserStoreName(null));
+    assertEquals(VeniceSystemStoreType.extractUserStoreName(schemaStore), schemaStore);
+    assertEquals(VeniceSystemStoreType.extractUserStoreName(heartBeatStore), heartBeatStore);
+    assertNull(VeniceSystemStoreType.extractUserStoreName(null));
   }
 
   @Test
@@ -37,13 +42,13 @@ public class TestVeniceSystemStoreType {
     doReturn(true).when(userStoreWithSystemStoresEnabled).isDaVinciPushStatusStoreEnabled();
     doReturn(true).when(userStoreWithSystemStoresEnabled).isStoreMetaSystemStoreEnabled();
 
-    Assert.assertTrue(VeniceSystemStoreType.getEnabledSystemStoreTypes(userStoreWithNothingEnabled).isEmpty());
+    assertTrue(VeniceSystemStoreType.getEnabledSystemStoreTypes(userStoreWithNothingEnabled).isEmpty());
     List<VeniceSystemStoreType> enabledSystemStores =
         VeniceSystemStoreType.getEnabledSystemStoreTypes(userStoreWithSystemStoresEnabled);
-    Assert.assertEquals(enabledSystemStores.size(), 2);
+    assertEquals(enabledSystemStores.size(), 2);
     HashSet<VeniceSystemStoreType> systemStoreSet = new HashSet<>(enabledSystemStores);
-    Assert.assertTrue(systemStoreSet.contains(VeniceSystemStoreType.META_STORE));
-    Assert.assertTrue(systemStoreSet.contains(VeniceSystemStoreType.DAVINCI_PUSH_STATUS_STORE));
+    assertTrue(systemStoreSet.contains(VeniceSystemStoreType.META_STORE));
+    assertTrue(systemStoreSet.contains(VeniceSystemStoreType.DAVINCI_PUSH_STATUS_STORE));
   }
 
   @Test
@@ -51,11 +56,81 @@ public class TestVeniceSystemStoreType {
     String dvcpushStatusStore = "venice_system_store_davinci_push_status_store_abc";
     String metaStore = "venice_system_store_meta_store_abc";
     String userStore = "userStore";
-    Assert.assertEquals(
+    assertEquals(
         VeniceSystemStoreUtils.extractSystemStoreType(dvcpushStatusStore),
         VeniceSystemStoreUtils.DAVINCI_PUSH_STATUS_STORE_STR);
-    Assert
-        .assertEquals(VeniceSystemStoreUtils.extractSystemStoreType(metaStore), VeniceSystemStoreUtils.META_STORE_STR);
-    Assert.assertNull(VeniceSystemStoreUtils.extractSystemStoreType(userStore));
+    assertEquals(VeniceSystemStoreUtils.extractSystemStoreType(metaStore), VeniceSystemStoreUtils.META_STORE_STR);
+    assertNull(VeniceSystemStoreUtils.extractSystemStoreType(userStore));
+  }
+
+  @Test
+  public void testGetSystemStoreTypeWithValidSystemStoreNames() {
+    String ps3StoreName =
+        VeniceSystemStoreType.DAVINCI_PUSH_STATUS_STORE.getSystemStoreName(Utils.getUniqueString("test_store_ps3"));
+    assertFalse(
+        VeniceSystemStoreType.getStoreTypeCache().containsKey(ps3StoreName),
+        "Cache should not have store info for " + ps3StoreName);
+    assertEquals(
+        VeniceSystemStoreType.getSystemStoreType(ps3StoreName),
+        VeniceSystemStoreType.DAVINCI_PUSH_STATUS_STORE,
+        "Failed to detect Push Status System Store");
+    assertTrue(
+        VeniceSystemStoreType.getStoreTypeCache().containsKey(ps3StoreName),
+        "Cache should have store info for " + ps3StoreName);
+
+    String metaStoreName =
+        VeniceSystemStoreType.META_STORE.getSystemStoreName(Utils.getUniqueString("test_store_meta"));
+    assertFalse(
+        VeniceSystemStoreType.getStoreTypeCache().containsKey(metaStoreName),
+        "Cache should not have store info for " + metaStoreName);
+    assertEquals(
+        VeniceSystemStoreType.getSystemStoreType(metaStoreName),
+        VeniceSystemStoreType.META_STORE,
+        "Failed to detect Meta Store");
+    assertTrue(
+        VeniceSystemStoreType.getStoreTypeCache().containsKey(metaStoreName),
+        "Cache should have store info for " + metaStoreName);
+
+    String batchJobHeartbeatStoreName = VeniceSystemStoreType.BATCH_JOB_HEARTBEAT_STORE
+        .getSystemStoreName(Utils.getUniqueString("test_store_batch_job_heartbeat"));
+    assertFalse(
+        VeniceSystemStoreType.getStoreTypeCache().containsKey(batchJobHeartbeatStoreName),
+        "Cache should not have store info for " + batchJobHeartbeatStoreName);
+    assertEquals(
+        VeniceSystemStoreType.getSystemStoreType(batchJobHeartbeatStoreName),
+        VeniceSystemStoreType.BATCH_JOB_HEARTBEAT_STORE,
+        "Failed to detect Batch Job Heartbeat Store");
+    assertTrue(
+        VeniceSystemStoreType.getStoreTypeCache().containsKey(batchJobHeartbeatStoreName),
+        "Cache should have store info for " + batchJobHeartbeatStoreName);
+  }
+
+  @Test
+  public void testGetSystemStoreTypeWithInvalidOrNonSystemStoreNames() {
+    String userStoreName = Utils.getUniqueString("test_store_user");
+    assertFalse(
+        VeniceSystemStoreType.getStoreTypeCache().containsKey(userStoreName),
+        "Cache should not have store info for " + userStoreName);
+    assertNull(VeniceSystemStoreType.getSystemStoreType(userStoreName), "Expected null for non-system store");
+    assertFalse(
+        VeniceSystemStoreType.getStoreTypeCache().containsKey(userStoreName),
+        "Cache should not have store info for " + userStoreName);
+
+    assertNull(
+        VeniceSystemStoreType.getSystemStoreType("meta_store"),
+        "Should return null when store name matches prefix exactly");
+
+    assertNull(VeniceSystemStoreType.getSystemStoreType(null), "Expected null for null store name");
+
+    assertNull(VeniceSystemStoreType.getSystemStoreType(""), "Expected null for empty store name");
+
+    // Ensure exact prefix matches are ignored
+    assertNull(
+        VeniceSystemStoreType.getSystemStoreType(VeniceSystemStoreType.META_STORE.getPrefix()),
+        "Should return null for exact prefix match");
+
+    Assert.assertNotNull(
+        VeniceSystemStoreType.getSystemStoreType(VeniceSystemStoreType.META_STORE.getPrefix() + "-extra"),
+        "Should detect system store when prefix is followed by extra characters");
   }
 }


### PR DESCRIPTION

## Cache VeniceSystemStoreType for faster lookup
CPU profiles for venice-server showed that approximately 5% of execution time was spent  
in VeniceSystemStoreType::getSystemStoreType(). This change improves performance by  
introducing a cache to store computed store types for quick retrieval, eliminating redundant  
iterations over all system store types in repeated lookups.  


![image](https://github.com/user-attachments/assets/489c841e-e266-489c-9473-6c60dec66468)


## How was this PR tested?
UT

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.