### PR TITLE
[admin-tool] Add new command to compute partition id for a given key using store settings

### DIFF
--- a/clients/venice-admin-tool/src/main/java/com/linkedin/venice/AdminTool.java
+++ b/clients/venice-admin-tool/src/main/java/com/linkedin/venice/AdminTool.java
@@ -177,9 +177,6 @@ public class AdminTool {
   private static final String STATUS = "status";
   private static final String ERROR = "error";
   private static final String SUCCESS = "success";
-
-  private static final PubSubTopicRepository TOPIC_REPOSITORY = new PubSubTopicRepository();
-
   private static final ObjectMapper OBJECT_MAPPER = ObjectMapperFactory.getInstance();
 
   private static ControllerClient controllerClient;
@@ -197,6 +194,8 @@ public class AdminTool {
       "zookeeper.ssl.trustStore.type");
   private static final String DEFAULT_DATE_FORMAT = "yyyy-MM-dd hh:mm:ss";
   private static final String PST_TIME_ZONE = "America/Los_Angeles";
+
+  static final PubSubTopicRepository TOPIC_REPOSITORY = new PubSubTopicRepository();
 
   public static void main(String[] args) throws Exception {
     // Generate PubSubClientsFactory from java system properties, apache kafka adapter is the default one.
@@ -341,6 +340,9 @@ public class AdminTool {
           break;
         case SET_OWNER:
           setStoreOwner(cmd);
+          break;
+        case GET_PARTITION_ID:
+          getPartitionIdForKey(cmd);
           break;
         case SET_PARTITION_COUNT:
           setStorePartition(cmd);
@@ -1147,6 +1149,14 @@ public class AdminTool {
     String partitionNum = getRequiredArgument(cmd, Arg.PARTITION_COUNT, Command.SET_PARTITION_COUNT);
     PartitionResponse response = controllerClient.setStorePartitionCount(storeName, partitionNum);
     printSuccess(response);
+  }
+
+  private static void getPartitionIdForKey(CommandLine cmd) {
+    String storeName = getRequiredArgument(cmd, Arg.STORE, Command.GET_PARTITION_ID);
+    String key = getRequiredArgument(cmd, Arg.KEY, Command.GET_PARTITION_ID);
+    int version = Integer.parseInt(getOptionalArgument(cmd, Arg.VERSION, "-1"));
+    String keySchemaStr = controllerClient.getKeySchema(storeName).getSchemaStr();
+    TopicMessageFinder.findPartitionIdForKey(controllerClient, storeName, version, key, keySchemaStr);
   }
 
   private static void integerParam(CommandLine cmd, Arg param, Consumer<Integer> setter, Set<Arg> argSet) {

--- a/clients/venice-admin-tool/src/main/java/com/linkedin/venice/Command.java
+++ b/clients/venice-admin-tool/src/main/java/com/linkedin/venice/Command.java
@@ -275,6 +275,9 @@ public enum Command {
   SET_OWNER(
       "set-owner", "Update owner info of an existing store", new Arg[] { URL, STORE, OWNER }, new Arg[] { CLUSTER }
   ),
+  GET_PARTITION_ID(
+      "get-partition-id", "Get partition id for a key", new Arg[] { URL, CLUSTER, STORE, KEY }, new Arg[] { VERSION }
+  ),
   SET_PARTITION_COUNT(
       "set-partition-count", "Update the number of partitions of an existing store",
       new Arg[] { URL, STORE, PARTITION_COUNT }, new Arg[] { CLUSTER }

--- a/clients/venice-admin-tool/src/main/java/com/linkedin/venice/TopicMessageFinder.java
+++ b/clients/venice-admin-tool/src/main/java/com/linkedin/venice/TopicMessageFinder.java
@@ -204,13 +204,12 @@ public class TopicMessageFinder {
 
     byte[] keyBytes = TopicMessageFinder.serializeKey(key, keySchemaStr);
     int partitionId = partitioner.getPartitionId(keyBytes, partitionCount);
-    System.out.println("Partition ID for key: " + key + " in store: " + storeName + " is: " + partitionId);
     LOGGER.info("Partition ID for key: {} in store: {} is: {}", key, storeName, partitionId);
 
     return new KeyPartitionInfo(storeInfo, keyBytes, partitionId, partitionCount);
   }
 
-  static class KeyPartitionInfo {
+  protected static class KeyPartitionInfo {
     private final StoreInfo storeInfo;
     private final byte[] serializedKey;
     private final int partitionId;

--- a/clients/venice-admin-tool/src/main/java/com/linkedin/venice/TopicMessageFinder.java
+++ b/clients/venice-admin-tool/src/main/java/com/linkedin/venice/TopicMessageFinder.java
@@ -210,32 +210,32 @@ public class TopicMessageFinder {
     return new KeyPartitionInfo(storeInfo, keyBytes, partitionId, partitionCount);
   }
 
-  protected static class KeyPartitionInfo {
+  static class KeyPartitionInfo {
     private final StoreInfo storeInfo;
     private final byte[] serializedKey;
     private final int partitionId;
     private final int partitionCount;
 
-    public KeyPartitionInfo(StoreInfo storeInfo, byte[] serializedKey, int partitionId, int partitionCount) {
+    KeyPartitionInfo(StoreInfo storeInfo, byte[] serializedKey, int partitionId, int partitionCount) {
       this.storeInfo = storeInfo;
       this.serializedKey = serializedKey;
       this.partitionId = partitionId;
       this.partitionCount = partitionCount;
     }
 
-    public int getPartitionId() {
+    int getPartitionId() {
       return partitionId;
     }
 
-    public byte[] getSerializedKey() {
+    byte[] getSerializedKey() {
       return serializedKey;
     }
 
-    public int getPartitionCount() {
+    int getPartitionCount() {
       return partitionCount;
     }
 
-    public StoreInfo getStoreInfo() {
+    StoreInfo getStoreInfo() {
       return storeInfo;
     }
   }

--- a/clients/venice-admin-tool/src/test/java/com/linkedin/venice/TestAdminToolConsumption.java
+++ b/clients/venice-admin-tool/src/test/java/com/linkedin/venice/TestAdminToolConsumption.java
@@ -25,7 +25,9 @@ import com.linkedin.venice.kafka.protocol.Put;
 import com.linkedin.venice.kafka.protocol.enums.ControlMessageType;
 import com.linkedin.venice.kafka.protocol.enums.MessageType;
 import com.linkedin.venice.message.KafkaKey;
+import com.linkedin.venice.meta.PartitionerConfig;
 import com.linkedin.venice.meta.StoreInfo;
+import com.linkedin.venice.partitioner.DefaultVenicePartitioner;
 import com.linkedin.venice.pubsub.ImmutablePubSubMessage;
 import com.linkedin.venice.pubsub.PubSubTopicPartitionImpl;
 import com.linkedin.venice.pubsub.PubSubTopicRepository;
@@ -129,6 +131,10 @@ public class TestAdminToolConsumption {
     when(controllerClient.getStore(STORE_NAME)).thenReturn(storeResponse);
     when(storeResponse.getStore()).thenReturn(storeInfo);
     when(storeInfo.getHybridStoreConfig().getRealTimeTopicName()).thenReturn(Utils.composeRealTimeTopic(STORE_NAME));
+    PartitionerConfig partitionerConfig = mock(PartitionerConfig.class);
+    when(storeInfo.getPartitionerConfig()).thenReturn(partitionerConfig);
+    when(partitionerConfig.getPartitionerClass()).thenReturn(DefaultVenicePartitioner.class.getName());
+    when(partitionerConfig.getPartitionerParams()).thenReturn(new HashMap<>());
     String topic = storeInfo.getHybridStoreConfig().getRealTimeTopicName();
 
     int assignedPartition = 0;

--- a/clients/venice-admin-tool/src/test/java/com/linkedin/venice/TopicMessageFinderTest.java
+++ b/clients/venice-admin-tool/src/test/java/com/linkedin/venice/TopicMessageFinderTest.java
@@ -18,7 +18,6 @@ import com.linkedin.venice.meta.PartitionerConfig;
 import com.linkedin.venice.meta.StoreInfo;
 import com.linkedin.venice.meta.Version;
 import com.linkedin.venice.partitioner.DefaultVenicePartitioner;
-import com.linkedin.venice.partitioner.VenicePartitioner;
 import com.linkedin.venice.pubsub.PubSubTopicPartitionImpl;
 import com.linkedin.venice.pubsub.api.DefaultPubSubMessage;
 import com.linkedin.venice.pubsub.api.PubSubConsumerAdapter;
@@ -38,15 +37,12 @@ public class TopicMessageFinderTest {
   private StoreResponse mockStoreResponse;
   private Version mockVersion;
   private PartitionerConfig mockPartitionerConfig;
-  private VenicePartitioner mockPartitioner;
   private PubSubConsumerAdapter mockConsumer;
   private DefaultPubSubMessage mockMessage;
 
   private static final String STORE_NAME = "test_store";
-  private static final String TOPIC = "test_store_v1";
   private static final String KEY = "test_key-4";
   private static final int VERSION_NUMBER = 1;
-  private static final int PARTITION_ID = 2;
   private static final int PARTITION_COUNT = 3;
   private static final String KEY_SCHEMA_STR = "\"string\"";
 

--- a/clients/venice-admin-tool/src/test/java/com/linkedin/venice/TopicMessageFinderTest.java
+++ b/clients/venice-admin-tool/src/test/java/com/linkedin/venice/TopicMessageFinderTest.java
@@ -1,0 +1,160 @@
+package com.linkedin.venice;
+
+import static org.mockito.Mockito.anyInt;
+import static org.mockito.Mockito.anyLong;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.expectThrows;
+
+import com.linkedin.venice.controllerapi.ControllerClient;
+import com.linkedin.venice.controllerapi.StoreResponse;
+import com.linkedin.venice.exceptions.VeniceException;
+import com.linkedin.venice.exceptions.VeniceNoStoreException;
+import com.linkedin.venice.message.KafkaKey;
+import com.linkedin.venice.meta.PartitionerConfig;
+import com.linkedin.venice.meta.StoreInfo;
+import com.linkedin.venice.meta.Version;
+import com.linkedin.venice.partitioner.DefaultVenicePartitioner;
+import com.linkedin.venice.partitioner.VenicePartitioner;
+import com.linkedin.venice.pubsub.PubSubTopicPartitionImpl;
+import com.linkedin.venice.pubsub.api.DefaultPubSubMessage;
+import com.linkedin.venice.pubsub.api.PubSubConsumerAdapter;
+import com.linkedin.venice.pubsub.api.PubSubTopicPartition;
+import com.linkedin.venice.unit.kafka.SimplePartitioner;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Optional;
+import org.mockito.Mockito;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+
+public class TopicMessageFinderTest {
+  private ControllerClient mockControllerClient;
+  private StoreInfo mockStoreInfo;
+  private StoreResponse mockStoreResponse;
+  private Version mockVersion;
+  private PartitionerConfig mockPartitionerConfig;
+  private VenicePartitioner mockPartitioner;
+  private PubSubConsumerAdapter mockConsumer;
+  private DefaultPubSubMessage mockMessage;
+
+  private static final String STORE_NAME = "test_store";
+  private static final String TOPIC = "test_store_v1";
+  private static final String KEY = "test_key-4";
+  private static final int VERSION_NUMBER = 1;
+  private static final int PARTITION_ID = 2;
+  private static final int PARTITION_COUNT = 3;
+  private static final String KEY_SCHEMA_STR = "\"string\"";
+
+  @BeforeMethod
+  public void setUp() {
+    mockControllerClient = mock(ControllerClient.class);
+    mockStoreInfo = mock(StoreInfo.class);
+    mockVersion = mock(Version.class);
+    mockPartitionerConfig = mock(PartitionerConfig.class);
+    mockConsumer = mock(PubSubConsumerAdapter.class);
+    mockMessage = mock(DefaultPubSubMessage.class, Mockito.RETURNS_DEEP_STUBS);
+    mockStoreResponse = new StoreResponse();
+    mockStoreResponse.setStore(mockStoreInfo);
+  }
+
+  @Test
+  public void testFindPartitionIdForKeySuccess() {
+    when(mockControllerClient.getStore(STORE_NAME)).thenReturn(mockStoreResponse);
+    when(mockStoreInfo.getVersion(VERSION_NUMBER)).thenReturn(Optional.of(mockVersion));
+    when(mockVersion.getPartitionerConfig()).thenReturn(mockPartitionerConfig);
+    when(mockVersion.getPartitionCount()).thenReturn(PARTITION_COUNT);
+    when(mockPartitionerConfig.getPartitionerClass()).thenReturn(DefaultVenicePartitioner.class.getName());
+
+    int expectedPartitionId =
+        new DefaultVenicePartitioner().getPartitionId(KEY.getBytes(), 0, KEY.length(), PARTITION_COUNT);
+
+    TopicMessageFinder.KeyPartitionInfo partitionInfo =
+        TopicMessageFinder.findPartitionIdForKey(mockControllerClient, STORE_NAME, VERSION_NUMBER, KEY, KEY_SCHEMA_STR);
+
+    assertNotNull(partitionInfo);
+    assertEquals(partitionInfo.getPartitionId(), expectedPartitionId);
+    assertEquals(partitionInfo.getPartitionCount(), PARTITION_COUNT);
+
+    // test store level partitioner class is used when version is not found
+    when(mockStoreInfo.getVersion(VERSION_NUMBER)).thenReturn(Optional.empty());
+    mockPartitionerConfig = mock(PartitionerConfig.class);
+    when(mockStoreInfo.getPartitionerConfig()).thenReturn(mockPartitionerConfig);
+    when(mockStoreInfo.getPartitionCount()).thenReturn(PARTITION_COUNT);
+    when(mockPartitionerConfig.getPartitionerClass()).thenReturn(SimplePartitioner.class.getName());
+
+    expectedPartitionId = new SimplePartitioner().getPartitionId(KEY.getBytes(), PARTITION_COUNT);
+    partitionInfo =
+        TopicMessageFinder.findPartitionIdForKey(mockControllerClient, STORE_NAME, VERSION_NUMBER, KEY, KEY_SCHEMA_STR);
+    assertNotNull(partitionInfo);
+    assertEquals(partitionInfo.getPartitionId(), expectedPartitionId);
+    assertEquals(partitionInfo.getPartitionCount(), PARTITION_COUNT);
+  }
+
+  @Test(expectedExceptions = VeniceNoStoreException.class)
+  public void testFindPartitionIdForKeyStoreDoesNotExist() {
+    when(mockControllerClient.getStore(STORE_NAME)).thenReturn(null);
+
+    TopicMessageFinder.findPartitionIdForKey(mockControllerClient, STORE_NAME, VERSION_NUMBER, KEY, KEY_SCHEMA_STR);
+  }
+
+  @Test
+  public void testFindPartitionIdForKeyInvalidPartitionCount() {
+    when(mockControllerClient.getStore(STORE_NAME)).thenReturn(mockStoreResponse);
+    when(mockStoreInfo.getVersion(VERSION_NUMBER)).thenReturn(Optional.of(mockVersion));
+    when(mockVersion.getPartitionCount()).thenReturn(0);
+
+    Exception e = expectThrows(
+        VeniceException.class,
+        () -> TopicMessageFinder
+            .findPartitionIdForKey(mockControllerClient, STORE_NAME, VERSION_NUMBER, KEY, KEY_SCHEMA_STR));
+    assertTrue(e.getMessage().contains("Partition count for store: " + STORE_NAME + " is not set."));
+  }
+
+  @Test
+  public void testSerializeKey() {
+    byte[] serializedKey = TopicMessageFinder.serializeKey(KEY, KEY_SCHEMA_STR);
+    assertNotNull(serializedKey);
+  }
+
+  @Test
+  public void testConsumeMatchingKeyFound() {
+    PubSubTopicPartition mockPartition = mock(PubSubTopicPartitionImpl.class);
+    when(mockConsumer.poll(anyLong())).thenReturn(Collections.singletonMap(mockPartition, Arrays.asList(mockMessage)))
+        .thenReturn(Collections.emptyMap());
+    when(mockMessage.getPosition().getNumericOffset()).thenReturn(10L);
+    when(mockMessage.getKey()).thenReturn(new KafkaKey((byte) 0, KEY.getBytes()));
+    when(mockMessage.getPosition().getNumericOffset()).thenReturn(10L);
+
+    long recordsConsumed =
+        TopicMessageFinder.consume(mockConsumer, mockPartition, 0L, 20L, 5L, mockMessage.getKey().getKey());
+
+    assertTrue(recordsConsumed > 0);
+  }
+
+  @Test
+  public void testConsumeNoMatchingKey() {
+    PubSubTopicPartition mockPartition = mock(PubSubTopicPartitionImpl.class);
+    when(mockConsumer.poll(anyInt())).thenReturn(Collections.singletonMap(mockPartition, Arrays.asList(mockMessage)));
+    when(mockMessage.getKey()).thenReturn(new KafkaKey((byte) 0, "different_key".getBytes()));
+
+    long recordsConsumed = TopicMessageFinder.consume(mockConsumer, mockPartition, 0L, 20L, 5L, KEY.getBytes());
+
+    assertEquals(recordsConsumed, 0);
+  }
+
+  @Test
+  public void testConsumeExceedsEndOffset() {
+    PubSubTopicPartition mockPartition = mock(PubSubTopicPartitionImpl.class);
+    when(mockConsumer.poll(anyInt())).thenReturn(Collections.singletonMap(mockPartition, Arrays.asList(mockMessage)));
+    when(mockMessage.getPosition().getNumericOffset()).thenReturn(30L);
+
+    long recordsConsumed = TopicMessageFinder.consume(mockConsumer, mockPartition, 0L, 20L, 5L, KEY.getBytes());
+
+    assertEquals(recordsConsumed, 0);
+  }
+}

--- a/internal/venice-common/src/main/java/com/linkedin/venice/meta/PartitionerConfigImpl.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/meta/PartitionerConfigImpl.java
@@ -94,4 +94,10 @@ public class PartitionerConfigImpl implements PartitionerConfig {
   public PartitionerConfig clone() {
     return new PartitionerConfigImpl(getPartitionerClass(), getPartitionerParams(), getAmplificationFactor());
   }
+
+  @Override
+  public String toString() {
+    return "PartitionerConfig{" + "partitionerClass='" + getPartitionerClass() + '\'' + ", partitionerParams="
+        + getPartitionerParams() + '}';
+  }
 }


### PR DESCRIPTION


## Add new command to compute partition ID for a given key using store settings

This PR introduces the `--get-partition-id` command in `AdminTool`, allowing users to compute  
the partition ID for a given key based on store settings. The implementation includes the  
`findPartitionIdForKey` method in `TopicMessageFinder`, which retrieves store metadata,  
applies partitioner configurations, and determines the partition ID.  




## AI Generated Summary
This pull request introduces a new feature to the `venice-admin-tool` for retrieving partition IDs for keys, along with some refactoring and additional test coverage. The most important changes include the addition of the `GET_PARTITION_ID` command, the implementation of the `findPartitionIdForKey` method, and the creation of new test cases to ensure the functionality works as expected.

### New Feature: Retrieve Partition IDs for Keys

* [`AdminTool.java`](diffhunk://#diff-9b93374a0e8fdcc1936fa96a81be98ad2ded4c760b6b79ccb7642f68999dd695R344-R346): Added a new command `GET_PARTITION_ID` to the `Command` enum and implemented the `getPartitionIdForKey` method to handle the new command. [[1]](diffhunk://#diff-9b93374a0e8fdcc1936fa96a81be98ad2ded4c760b6b79ccb7642f68999dd695R344-R346) [[2]](diffhunk://#diff-9b93374a0e8fdcc1936fa96a81be98ad2ded4c760b6b79ccb7642f68999dd695R1154-R1161) [[3]](diffhunk://#diff-a48aa9152ae0b8c6e7eacb7a316b3b67f449f733754a259d164b19231952bfb5R278-R280)
* [`TopicMessageFinder.java`](diffhunk://#diff-11b5933a8857e786dce2beb6fcae10abf00aa8549ef9a97330a92acf3a4610afL51-R69): Implemented the `findPartitionIdForKey` method to determine the partition ID for a given key, and added a nested `KeyPartitionInfo` class to encapsulate the results. [[1]](diffhunk://#diff-11b5933a8857e786dce2beb6fcae10abf00aa8549ef9a97330a92acf3a4610afL51-R69) [[2]](diffhunk://#diff-11b5933a8857e786dce2beb6fcae10abf00aa8549ef9a97330a92acf3a4610afR153-R241)

### Refactoring

* [`AdminTool.java`](diffhunk://#diff-9b93374a0e8fdcc1936fa96a81be98ad2ded4c760b6b79ccb7642f68999dd695L180-L182): Moved the `PubSubTopicRepository` instantiation from a private static final field to a package-private static final field to improve accessibility. [[1]](diffhunk://#diff-9b93374a0e8fdcc1936fa96a81be98ad2ded4c760b6b79ccb7642f68999dd695L180-L182) [[2]](diffhunk://#diff-9b93374a0e8fdcc1936fa96a81be98ad2ded4c760b6b79ccb7642f68999dd695R198-R199)

### Test Coverage

* [`TopicMessageFinderTest.java`](diffhunk://#diff-fb1131bf4959172dcd92f16d974b8d8fb108ad52ff2c6b18b46685da2f326538R1-R160): Added comprehensive test cases for the `findPartitionIdForKey` method, including scenarios for successful partition ID retrieval, store not existing, invalid partition count, and key serialization.

### Additional Changes

* [`PartitionerConfigImpl.java`](diffhunk://#diff-b9cc0ebdecdf06d63305c61dffcedd9a8f4afb9d01d52d7c8499269196d3e21bR97-R102): Added a `toString` method for better logging and debugging of `PartitionerConfig` instances.
## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.