### PR TITLE
add new store properties schema to replace old

### DIFF
--- a/internal/venice-common/src/main/resources/avro/StorePropertiesPayloadRecord/v1/StorePropertiesPayloadRecord.avsc
+++ b/internal/venice-common/src/main/resources/avro/StorePropertiesPayloadRecord/v1/StorePropertiesPayloadRecord.avsc
@@ -1,0 +1,47 @@
+{
+  "type": "record",
+  "name": "StorePropertiesPayloadRecord",
+  "namespace": "com.linkedin.venice.metadata.payload",
+  "doc": "This record will store store properties",
+  "fields": [
+    {
+      "name": "storeMetaValueSchemaVersion",
+      "doc": "Store metadata schema version",
+      "type": "int",
+      "default": 1
+    },
+    {
+      "name": "storeMetaValueAvro",
+      "doc": "Store metadata, serialization of com.linkedin.venice.systemstore.schemas.StoreMetaValue",
+      "type": "bytes",
+      "default": ""
+    },
+    {
+      "name": "helixGroupInfo",
+      "doc": "Helix group information, maps replicas to their respective groups",
+      "type": [
+        "null",
+        {
+          "type": "map",
+          "values": "int"
+        }
+      ],
+      "default": null
+    },
+    {
+      "name": "routingInfo",
+      "doc": "Routing table information, maps resource to partition ID to a list of replicas",
+      "type": [
+        "null",
+        {
+          "type": "map",
+          "values": {
+            "type": "array",
+            "items": "string"
+          }
+        }
+      ],
+      "default": null
+    }
+  ]
+}


### PR DESCRIPTION
<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat], [protocol]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## Adding a new schema to replace `StorePropertiesResponseRecord` due to schema referencing
<!--
Describe
- What changes to make and why you are making these changes.
- How are you going to achieve your goal.
- Describe what testings you have done, for example, performance testing etc.

If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

Schema to by used in https://github.com/linkedin/venice/pull/1596

## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->

Schema is not used in code path.

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.