### PR TITLE
[controller][test] Log server status and dvc status during status polling and fix flaky tests

### DIFF
--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTaskTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTaskTest.java
@@ -1598,16 +1598,15 @@ public abstract class StoreIngestionTaskTest {
 
   @Test(dataProvider = "aaConfigProvider")
   public void testNotifier(AAConfig aaConfig) throws Exception {
-    localVeniceWriter.broadcastStartOfPush(new HashMap<>());
+    localVeniceWriter.broadcastStartOfPush(Collections.emptyMap());
     long fooLastOffset = getOffset(localVeniceWriter.put(putKeyFoo, putValue, SCHEMA_ID));
     long barLastOffset = getOffset(localVeniceWriter.put(putKeyBar, putValue, SCHEMA_ID));
-    localVeniceWriter.broadcastEndOfPush(new HashMap<>());
-    localVeniceWriter.broadcastEndOfPush(new HashMap<>());
     doReturn(fooLastOffset + 1).when(mockTopicManager).getLatestOffsetCachedNonBlocking(any(), eq(PARTITION_FOO));
     doReturn(barLastOffset + 1).when(mockTopicManager).getLatestOffsetCachedNonBlocking(any(), eq(PARTITION_BAR));
+    localVeniceWriter.broadcastEndOfPush(Collections.emptyMap());
 
-    Utils.sleep(1000);
     runTest(Utils.setOf(PARTITION_FOO, PARTITION_BAR), () -> {
+      Utils.sleep(1000);
       /**
        * Considering that the {@link VeniceWriter} will send an {@link ControlMessageType#END_OF_PUSH},
        * we need to add 1 to last data message offset.

--- a/internal/venice-common/src/main/java/com/linkedin/venice/pushmonitor/ExecutionStatusWithDetails.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/pushmonitor/ExecutionStatusWithDetails.java
@@ -50,4 +50,10 @@ public class ExecutionStatusWithDetails {
   public Long getStatusUpdateTimestamp() {
     return statusUpdateTimestamp;
   }
+
+  @Override
+  public String toString() {
+    return "ExecutionStatusWithDetails{" + "status=" + status + ", details='" + details + '\''
+        + ", noDaVinciStatusReport=" + noDaVinciStatusReport + ", statusUpdateTimestamp=" + statusUpdateTimestamp + '}';
+  }
 }

--- a/internal/venice-common/src/test/java/com/linkedin/venice/pushmonitor/ExecutionStatusWithDetailsTest.java
+++ b/internal/venice-common/src/test/java/com/linkedin/venice/pushmonitor/ExecutionStatusWithDetailsTest.java
@@ -1,6 +1,7 @@
 package com.linkedin.venice.pushmonitor;
 
-import org.testng.Assert;
+import static org.testng.Assert.assertEquals;
+
 import org.testng.annotations.Test;
 
 
@@ -9,7 +10,16 @@ public class ExecutionStatusWithDetailsTest {
   public void testExecutionStatusWithDetailsGetter() {
     ExecutionStatusWithDetails executionStatusWithDetails =
         new ExecutionStatusWithDetails(ExecutionStatus.ERROR, "dummyString", false);
-    Assert.assertEquals(executionStatusWithDetails.getStatus(), ExecutionStatus.ERROR);
-    Assert.assertEquals(executionStatusWithDetails.getDetails(), "dummyString");
+    assertEquals(executionStatusWithDetails.getStatus(), ExecutionStatus.ERROR);
+    assertEquals(executionStatusWithDetails.getDetails(), "dummyString");
+  }
+
+  @Test
+  public void testToStringMethod() {
+    ExecutionStatusWithDetails instance =
+        new ExecutionStatusWithDetails(ExecutionStatus.COMPLETED, "Success", false, 1627890000000L);
+    String expected =
+        "ExecutionStatusWithDetails{status=COMPLETED, details='Success', noDaVinciStatusReport=false, statusUpdateTimestamp=1627890000000}";
+    assertEquals(instance.toString(), expected, "Unexpected toString output");
   }
 }

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestControllerGrpcEndpoints.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestControllerGrpcEndpoints.java
@@ -69,7 +69,7 @@ public class TestControllerGrpcEndpoints {
     Utils.closeQuietlyWithErrorLogged(veniceCluster);
   }
 
-  @Test(timeOut = TIMEOUT_MS, invocationCount = 10000)
+  @Test(timeOut = TIMEOUT_MS)
   public void testGrpcEndpointsWithGrpcClient() {
     String storeName = Utils.getUniqueString("test_grpc_store");
     String controllerGrpcUrl = veniceCluster.getLeaderVeniceController().getControllerGrpcUrl();

--- a/services/venice-controller/src/main/java/com/linkedin/venice/pushmonitor/PushStatusCollector.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/pushmonitor/PushStatusCollector.java
@@ -194,9 +194,8 @@ public class PushStatusCollector {
       }
 
       LOGGER.info(
-          "Received DaVinci status: {} with details: {} for topic: {}. Server status: {}",
-          daVinciStatus.getStatus(),
-          daVinciStatus.getDetails(),
+          "Received DaVinci status: {} for topic: {} and server status: {}",
+          daVinciStatus,
           pushStatus.topicName,
           pushStatus.getServerStatus());
       ExecutionStatusWithDetails serverStatus = pushStatus.getServerStatus();

--- a/services/venice-controller/src/main/java/com/linkedin/venice/pushmonitor/PushStatusCollector.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/pushmonitor/PushStatusCollector.java
@@ -156,7 +156,11 @@ public class PushStatusCollector {
       String storeName = Version.parseStoreFromKafkaTopicName(pushStatus.topicName);
       Store store = storeRepository.getStore(storeName);
       if (daVinciStatus.isNoDaVinciStatusReport()) {
-        LOGGER.info("Received empty DaVinci status report for topic: {}", pushStatus.topicName);
+        LOGGER.info(
+            "Received empty DaVinci status report for topic: {}. Server status: {}, DvcStatus: {}",
+            pushStatus.topicName,
+            pushStatus.getServerStatus(),
+            daVinciStatus);
         // poll DaVinci status more
         int noDaVinciStatusRetryAttempts = topicToNoDaVinciStatusRetryCountMap.compute(pushStatus.topicName, (k, v) -> {
           if (v == null) {
@@ -190,10 +194,11 @@ public class PushStatusCollector {
       }
 
       LOGGER.info(
-          "Received DaVinci status: {} with details: {} for topic: {}",
+          "Received DaVinci status: {} with details: {} for topic: {}. Server status: {}",
           daVinciStatus.getStatus(),
           daVinciStatus.getDetails(),
-          pushStatus.topicName);
+          pushStatus.topicName,
+          pushStatus.getServerStatus());
       ExecutionStatusWithDetails serverStatus = pushStatus.getServerStatus();
       if (serverStatus == null) {
         continue;


### PR DESCRIPTION
<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat], [protocol]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## [controller][test] Log server status and dvc status during status polling and fix flaky tests

This PR includes logging improvement in the `PushStatusCollector` class and fixes flaky tests  
in TestMultiDataCenterAdminOperations and StoreIngestionTaskTest


## AI Generated Summary
### Test Improvements:

* `internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestMultiDataCenterAdminOperations.java`: 
  - Increased the `NUMBER_OF_CLUSTERS` to 2 and ensured `venice-cluster1` is not used for testing failed admin messages.
  - Added `alwaysRun = true` to the `@BeforeClass` and `@AfterClass` annotations to ensure setup and cleanup methods always run. [[1]](diffhunk://#diff-cde9da822dbd8ce1d89e314bb66a504ef2b1118dee32264c0220a87a2d510724L65-R67) [[2]](diffhunk://#diff-cde9da822dbd8ce1d89e314bb66a504ef2b1118dee32264c0220a87a2d510724L105-R107)
  - Removed outdated comments about a known bug in the controller and updated the cluster name used in `testFailedAdminMessages`. [[1]](diffhunk://#diff-cde9da822dbd8ce1d89e314bb66a504ef2b1118dee32264c0220a87a2d510724L119-L131) [[2]](diffhunk://#diff-cde9da822dbd8ce1d89e314bb66a504ef2b1118dee32264c0220a87a2d510724L167-R156)
  - Added a timeout to the `testAdminOperationMessageWithSpecificSchemaId` test method.

* `clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTaskTest.java`: 
  - Replaced `new HashMap<>()` with `Collections.emptyMap()` in `testNotifier` to use a more efficient way of creating empty maps.

### Logging Improvement:

* `services/venice-controller/src/main/java/com/linkedin/venice/pushmonitor/PushStatusCollector.java`: 
  - Enhanced logging in `scanDaVinciPushStatus` to include server status and DaVinci status details for better debugging. [[1]](diffhunk://#diff-95fedcc48731d944a6c51ae065e9c44fe32d2c99063a69a95f857632d966da53L159-R163) [[2]](diffhunk://#diff-95fedcc48731d944a6c51ae065e9c44fe32d2c99063a69a95f857632d966da53L193-R201)


## How was this PR tested?
CI
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.