### PR TITLE
[controller] Apply SemanticDetector inside AdminOperationSerializer to detect bad usage for new semantics

### DIFF
--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/controller/kafka/consumer/AdminConsumptionTaskIntegrationTest.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/controller/kafka/consumer/AdminConsumptionTaskIntegrationTest.java
@@ -369,7 +369,6 @@ public class AdminConsumptionTaskIntegrationTest {
       String owner,
       long executionId,
       int writerSchemaId) {
-    // TODO: Check back this step when we introduce the semantic check for new version in milestone 3
     UpdateStore updateStore = (UpdateStore) AdminMessageType.UPDATE_STORE.getNewInstance();
     updateStore.clusterName = clusterName;
     updateStore.storeName = storeName;

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestAdminOperationWithPreviousVersion.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestAdminOperationWithPreviousVersion.java
@@ -1,0 +1,656 @@
+package com.linkedin.venice.endToEnd;
+
+import static com.linkedin.venice.utils.TestStoragePersonaUtils.*;
+import static com.linkedin.venice.utils.TestWriteUtils.*;
+import static org.testng.Assert.*;
+
+import com.linkedin.venice.ConfigKeys;
+import com.linkedin.venice.controller.Admin;
+import com.linkedin.venice.controller.kafka.AdminTopicUtils;
+import com.linkedin.venice.controller.kafka.protocol.serializer.AdminOperationSerializer;
+import com.linkedin.venice.controllerapi.AdminTopicMetadataResponse;
+import com.linkedin.venice.controllerapi.ControllerClient;
+import com.linkedin.venice.controllerapi.ControllerResponse;
+import com.linkedin.venice.controllerapi.NewStoreResponse;
+import com.linkedin.venice.controllerapi.StoreResponse;
+import com.linkedin.venice.controllerapi.UpdateStoragePersonaQueryParams;
+import com.linkedin.venice.controllerapi.UpdateStoreQueryParams;
+import com.linkedin.venice.controllerapi.VersionCreationResponse;
+import com.linkedin.venice.exceptions.VeniceException;
+import com.linkedin.venice.integration.utils.ServiceFactory;
+import com.linkedin.venice.integration.utils.VeniceControllerWrapper;
+import com.linkedin.venice.integration.utils.VeniceMultiClusterWrapper;
+import com.linkedin.venice.integration.utils.VeniceMultiRegionClusterCreateOptions;
+import com.linkedin.venice.integration.utils.VeniceTwoLayerMultiRegionMultiClusterWrapper;
+import com.linkedin.venice.meta.Store;
+import com.linkedin.venice.meta.StoreInfo;
+import com.linkedin.venice.meta.Version;
+import com.linkedin.venice.persona.StoragePersona;
+import com.linkedin.venice.pubsub.PubSubTopicRepository;
+import com.linkedin.venice.pubsub.api.PubSubTopic;
+import com.linkedin.venice.pubsub.manager.TopicManager;
+import com.linkedin.venice.schema.writecompute.WriteComputeSchemaConverter;
+import com.linkedin.venice.utils.TestUtils;
+import com.linkedin.venice.utils.TestWriteUtils;
+import com.linkedin.venice.utils.Time;
+import com.linkedin.venice.utils.Utils;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import org.apache.avro.Schema;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.testng.Assert;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+
+public class TestAdminOperationWithPreviousVersion {
+  private static final Logger LOGGER = LogManager.getLogger(TestMultiDataCenterAdminOperations.class);
+  private static final int TEST_TIMEOUT = 360 * Time.MS_PER_SECOND;
+  private static final int NUMBER_OF_CHILD_DATACENTERS = 2;
+  private static final int NUMBER_OF_CLUSTERS = 2;
+
+  // Do not use venice-cluster1 as it is used for testing failed admin messages
+  private static final String[] CLUSTER_NAMES =
+      IntStream.range(0, NUMBER_OF_CLUSTERS).mapToObj(i -> "venice-cluster" + i).toArray(String[]::new); // ["venice-cluster0",
+  // "venice-cluster1",
+  // ...];
+
+  private List<VeniceControllerWrapper> parentControllers;
+  private VeniceTwoLayerMultiRegionMultiClusterWrapper multiRegionMultiClusterWrapper;
+  private ControllerClient parentControllerClient;
+  private String clusterName;
+  private Map<String, Boolean> operationTypeMap = getAllPayloadUnionTypes();
+  private Admin veniceAdmin;
+  static final String KEY_SCHEMA = "\"string\"";
+  static final String VALUE_SCHEMA = "\"string\"";
+  private List<ControllerClient> childControllerClients = new ArrayList<>();
+
+  @BeforeClass(alwaysRun = true)
+  public void setUp() {
+    Properties serverProperties = new Properties();
+    serverProperties.setProperty(ConfigKeys.SERVER_PROMOTION_TO_LEADER_REPLICA_DELAY_SECONDS, Long.toString(1));
+    VeniceMultiRegionClusterCreateOptions.Builder optionsBuilder =
+        new VeniceMultiRegionClusterCreateOptions.Builder().numberOfRegions(NUMBER_OF_CHILD_DATACENTERS)
+            .numberOfClusters(NUMBER_OF_CLUSTERS)
+            .numberOfParentControllers(1)
+            .numberOfChildControllers(1)
+            .numberOfServers(1)
+            .numberOfRouters(1)
+            .replicationFactor(1)
+            .forkServer(false)
+            .serverProperties(serverProperties);
+    multiRegionMultiClusterWrapper =
+        ServiceFactory.getVeniceTwoLayerMultiRegionMultiClusterWrapper(optionsBuilder.build());
+
+    List<VeniceMultiClusterWrapper> childClusters = multiRegionMultiClusterWrapper.getChildRegions();
+    parentControllers = multiRegionMultiClusterWrapper.getParentControllers();
+
+    LOGGER.info(
+        "parentControllers: {}",
+        parentControllers.stream().map(VeniceControllerWrapper::getControllerUrl).collect(Collectors.joining(", ")));
+
+    int i = 0;
+    for (VeniceMultiClusterWrapper multiClusterWrapper: childClusters) {
+      LOGGER.info(
+          "childCluster{} controllers: {}",
+          i++,
+          multiClusterWrapper.getControllers()
+              .values()
+              .stream()
+              .map(VeniceControllerWrapper::getControllerUrl)
+              .collect(Collectors.joining(", ")));
+    }
+
+    clusterName = CLUSTER_NAMES[0];
+    VeniceControllerWrapper parentController = parentControllers.get(0);
+    parentControllerClient = new ControllerClient(clusterName, parentController.getControllerUrl());
+
+    // Pinning the version to the previous version
+    AdminTopicMetadataResponse updateProtocolVersionResponse =
+        parentControllerClient.updateAdminOperationProtocolVersion(
+            clusterName,
+            (long) (AdminOperationSerializer.LATEST_SCHEMA_ID_FOR_ADMIN_OPERATION - 1));
+    assertFalse(updateProtocolVersionResponse.isError(), "Failed to update protocol version");
+
+    veniceAdmin = multiRegionMultiClusterWrapper.getParentControllers().get(0).getVeniceAdmin();
+    PubSubTopicRepository pubSubTopicRepository = veniceAdmin.getPubSubTopicRepository();
+    TopicManager topicManager = veniceAdmin.getTopicManager();
+    PubSubTopic adminTopic = pubSubTopicRepository.getTopic(AdminTopicUtils.getTopicNameFromClusterName(clusterName));
+    topicManager.createTopic(adminTopic, 1, 1, true);
+
+    ControllerClient dc0Client = ControllerClient.constructClusterControllerClient(
+        clusterName,
+        multiRegionMultiClusterWrapper.getChildRegions().get(0).getControllerConnectString());
+    ControllerClient dc1Client = ControllerClient.constructClusterControllerClient(
+        clusterName,
+        multiRegionMultiClusterWrapper.getChildRegions().get(1).getControllerConnectString());
+    childControllerClients.add(dc0Client);
+    childControllerClients.add(dc1Client);
+  }
+
+  @AfterClass(alwaysRun = true)
+  public void cleanUp() {
+    AdminTopicMetadataResponse updateProtocolVersionResponse =
+        parentControllerClient.updateAdminOperationProtocolVersion(
+            clusterName,
+            (long) (AdminOperationSerializer.LATEST_SCHEMA_ID_FOR_ADMIN_OPERATION));
+    assertFalse(updateProtocolVersionResponse.isError(), "Failed to update protocol version");
+    multiRegionMultiClusterWrapper.close();
+
+    System.out.println(operationTypeMap);
+    for (Map.Entry<String, Boolean> entry: operationTypeMap.entrySet()) {
+      assertTrue(entry.getValue(), "Operation type " + entry.getKey() + " was not tested");
+    }
+  }
+
+  @Test(timeOut = TEST_TIMEOUT)
+  public void testStoreCreation() {
+    markAsTested("StoreCreation");
+
+    clusterName = CLUSTER_NAMES[0];
+    VeniceControllerWrapper parentController = parentControllers.get(0);
+    parentControllerClient = new ControllerClient(clusterName, parentController.getControllerUrl());
+    String storeName = Utils.getUniqueString("test-store");
+
+    // Create store
+    NewStoreResponse newStoreResponse =
+        parentControllerClient.createNewStore(storeName, "test", "\"string\"", "\"string\"");
+    Assert.assertFalse(newStoreResponse.isError());
+
+    // Empty push
+    emptyPushToStore(parentControllerClient, storeName, 1);
+  }
+
+  @Test(timeOut = TEST_TIMEOUT)
+  public void testPauseStore() {
+    markAsTested("PauseStore");
+    markAsTested("ResumeStore");
+
+    String storeName = Utils.getUniqueString("testDisableStoreWriter");
+    veniceAdmin.createStore(clusterName, storeName, "testOwner", KEY_SCHEMA, VALUE_SCHEMA);
+    veniceAdmin.updateStore(clusterName, storeName, new UpdateStoreQueryParams().setBatchGetLimit(100));
+    veniceAdmin.setStoreWriteability(clusterName, storeName, false);
+    Store store = veniceAdmin.getStore(clusterName, storeName);
+
+    // Store has been disabled, can not accept a new version
+    Assert.assertThrows(
+        VeniceException.class,
+        () -> veniceAdmin.incrementVersionIdempotent(clusterName, storeName, Version.guidBasedDummyPushId(), 1, 1));
+
+    Assert.assertEquals(veniceAdmin.getStore(clusterName, storeName).getVersions(), store.getVersions());
+
+    // Store has been disabled, can not accept a new version
+    Assert.assertThrows(
+        VeniceException.class,
+        () -> veniceAdmin.incrementVersionIdempotent(clusterName, storeName, Version.guidBasedDummyPushId(), 1, 1));
+
+    Assert.assertEquals(veniceAdmin.getStore(clusterName, storeName).getVersions(), store.getVersions());
+
+    // Resume store
+    veniceAdmin.setStoreWriteability(clusterName, storeName, true);
+
+    emptyPushToStore(parentControllerClient, storeName, 1);
+    store = veniceAdmin.getStore(clusterName, storeName);
+    Assert.assertTrue(store.isEnableWrites());
+    Assert.assertEquals(store.getVersions().size(), 1);
+    Assert.assertEquals(store.peekNextVersion().getNumber(), 2);
+  }
+
+  @Test(timeOut = TEST_TIMEOUT)
+  public void testKillOfflinePushJob() {
+    markAsTested("KillOfflinePushJob");
+
+    String storeName = Utils.getUniqueString("testKillOfflinePushJob");
+    veniceAdmin.createStore(clusterName, storeName, "testOwner", KEY_SCHEMA, VALUE_SCHEMA);
+
+    // Empty push
+    VersionCreationResponse vcr = parentControllerClient.emptyPush(storeName, Utils.getUniqueString("empty-push"), 1L);
+    Assert.assertFalse(vcr.isError());
+    // No wait to kill the push job
+    // Kill push job
+    parentControllerClient.killOfflinePushJob(Version.composeKafkaTopic(storeName, 1));
+
+    // Check version
+    for (ControllerClient childControllerClient: childControllerClients) {
+      TestUtils.waitForNonDeterministicAssertion(10, TimeUnit.SECONDS, false, true, () -> {
+        StoreResponse storeResponse = childControllerClient.getStore(storeName);
+        Assert.assertFalse(storeResponse.isError());
+        StoreInfo storeInfo = storeResponse.getStore();
+        assertEquals(storeInfo.getVersions().size(), 0);
+      });
+    }
+
+  }
+
+  @Test(timeOut = TEST_TIMEOUT)
+  public void testDisableStoreRead() {
+    markAsTested("DisableStoreRead");
+    markAsTested("EnableStoreRead");
+
+    String storeName = setUpTestStore().getName();
+
+    emptyPushToStore(parentControllerClient, storeName, 1);
+
+    UpdateStoreQueryParams disableReadParams = new UpdateStoreQueryParams().setEnableReads(false);
+    ControllerResponse response = parentControllerClient.updateStore(storeName, disableReadParams);
+    assertFalse(response.isError());
+
+    for (ControllerClient childControllerClient: childControllerClients) {
+      TestUtils.waitForNonDeterministicAssertion(10, TimeUnit.SECONDS, false, true, () -> {
+        StoreResponse storeResponse = childControllerClient.getStore(storeName);
+        Assert.assertFalse(storeResponse.isError());
+        StoreInfo storeInfo = storeResponse.getStore();
+        assertFalse(storeInfo.isEnableStoreReads());
+      });
+    }
+
+    UpdateStoreQueryParams enableReadParams = new UpdateStoreQueryParams().setEnableReads(true);
+    response = parentControllerClient.updateStore(storeName, enableReadParams);
+    assertFalse(response.isError());
+    for (ControllerClient childControllerClient: childControllerClients) {
+      TestUtils.waitForNonDeterministicAssertion(10, TimeUnit.SECONDS, false, true, () -> {
+        StoreResponse storeResponse = childControllerClient.getStore(storeName);
+        Assert.assertFalse(storeResponse.isError());
+        StoreInfo storeInfo = storeResponse.getStore();
+        assertTrue(storeInfo.isEnableStoreReads());
+      });
+    }
+  }
+
+  @Test
+  public void testDeleteAllVersions() {
+    markAsTested("DeleteAllVersions");
+
+    String storeName = setUpTestStore().getName();
+    emptyPushToStore(parentControllerClient, storeName, 1);
+
+    // Disable read and write
+    UpdateStoreQueryParams disableParams = new UpdateStoreQueryParams().setEnableReads(false).setEnableWrites(false);
+    ControllerResponse response = parentControllerClient.updateStore(storeName, disableParams);
+    assertFalse(response.isError());
+
+    // Delete all versions
+    response = parentControllerClient.deleteAllVersions(storeName);
+    assertFalse(response.isError());
+    TestUtils.waitForNonDeterministicAssertion(10, TimeUnit.SECONDS, false, true, () -> {
+      StoreResponse storeResponse = parentControllerClient.getStore(storeName);
+      Assert.assertFalse(storeResponse.isError());
+      StoreInfo storeInfo = storeResponse.getStore();
+      assertEquals(storeInfo.getVersions().size(), 0);
+    });
+  }
+
+  @Test
+  public void testSetStoreOwner() {
+    markAsTested("SetStoreOwner");
+    String storeName = setUpTestStore().getName();
+    String newOwner = "newOwner";
+    UpdateStoreQueryParams updateStoreQueryParams = new UpdateStoreQueryParams().setOwner(newOwner);
+    ControllerResponse response = parentControllerClient.updateStore(storeName, updateStoreQueryParams);
+    assertFalse(response.isError());
+    TestUtils.waitForNonDeterministicAssertion(10, TimeUnit.SECONDS, false, true, () -> {
+      StoreResponse storeResponse = parentControllerClient.getStore(storeName);
+      Assert.assertFalse(storeResponse.isError());
+      StoreInfo storeInfo = storeResponse.getStore();
+      assertEquals(storeInfo.getOwner(), newOwner);
+    });
+  }
+
+  @Test
+  public void testSetStorePartitionCount() {
+    markAsTested("SetStorePartitionCount");
+    String storeName = setUpTestStore().getName();
+    int newPartitionCount = 1;
+    UpdateStoreQueryParams updateStoreQueryParams = new UpdateStoreQueryParams().setPartitionCount(newPartitionCount);
+    ControllerResponse response = parentControllerClient.updateStore(storeName, updateStoreQueryParams);
+    assertFalse(response.isError());
+    TestUtils.waitForNonDeterministicAssertion(10, TimeUnit.SECONDS, false, true, () -> {
+      StoreResponse storeResponse = parentControllerClient.getStore(storeName);
+      Assert.assertFalse(storeResponse.isError());
+      StoreInfo storeInfo = storeResponse.getStore();
+      assertEquals(storeInfo.getPartitionCount(), newPartitionCount);
+    });
+  }
+
+  @Test
+  public void testSetStoreCurrentVersion() {
+    markAsTested("SetStoreCurrentVersion");
+
+    String storeName = setUpTestStore().getName();
+
+    // Empty push
+    emptyPushToStore(parentControllerClient, storeName, 1);
+
+    int newCurrentVersion = 0;
+    UpdateStoreQueryParams updateStoreQueryParams = new UpdateStoreQueryParams().setCurrentVersion(newCurrentVersion);
+    ControllerResponse response = parentControllerClient.updateStore(storeName, updateStoreQueryParams);
+    assertFalse(response.isError());
+    TestUtils.waitForNonDeterministicAssertion(10, TimeUnit.SECONDS, false, true, () -> {
+      StoreResponse storeResponse = parentControllerClient.getStore(storeName);
+      Assert.assertFalse(storeResponse.isError());
+      StoreInfo storeInfo = storeResponse.getStore();
+      assertEquals(storeInfo.getCurrentVersion(), newCurrentVersion);
+    });
+  }
+
+  @Test(timeOut = TEST_TIMEOUT)
+  public void testUpdateStore() {
+    markAsTested("UpdateStore");
+    clusterName = CLUSTER_NAMES[0];
+    VeniceControllerWrapper parentController = parentControllers.get(0);
+    parentControllerClient = new ControllerClient(clusterName, parentController.getControllerUrl());
+    String storeName = Utils.getUniqueString("test-store");
+
+    // Create store
+    NewStoreResponse newStoreResponse =
+        parentControllerClient.createNewStore(storeName, "test", "\"string\"", "\"string\"");
+    Assert.assertFalse(newStoreResponse.isError());
+
+    // Empty push
+    emptyPushToStore(parentControllerClient, storeName, 1);
+
+    // Store update
+    ControllerResponse updateStore =
+        parentControllerClient.updateStore(storeName, new UpdateStoreQueryParams().setBatchGetLimit(100));
+    Assert.assertFalse(updateStore.isError());
+
+    for (ControllerClient childControllerClient: childControllerClients) {
+      TestUtils.waitForNonDeterministicAssertion(10, TimeUnit.SECONDS, false, true, () -> {
+        StoreResponse storeResponse = childControllerClient.getStore(storeName);
+        Assert.assertFalse(storeResponse.isError());
+        StoreInfo storeInfo = storeResponse.getStore();
+        assertEquals(storeInfo.getBatchGetLimit(), 100);
+      });
+    }
+  }
+
+  @Test
+  public void testDeleteStore() {
+    markAsTested("DeleteStore");
+    String storeName = setUpTestStore().getName();
+    // Disable read and write
+    UpdateStoreQueryParams disableParams = new UpdateStoreQueryParams().setEnableReads(false).setEnableWrites(false);
+    ControllerResponse response = parentControllerClient.updateStore(storeName, disableParams);
+    assertFalse(response.isError());
+
+    // Delete store
+    response = parentControllerClient.deleteStore(storeName);
+    assertFalse(response.isError());
+    TestUtils.waitForNonDeterministicAssertion(10, TimeUnit.SECONDS, false, true, () -> {
+      StoreResponse storeResponse = parentControllerClient.getStore(storeName);
+      Assert.assertTrue(storeResponse.isError());
+    });
+  }
+
+  @Test
+  public void testDeleteOldVersion() {
+    markAsTested("DeleteOldVersion");
+
+    String storeName = setUpTestStore().getName();
+
+    // version 1
+    emptyPushToStore(parentControllerClient, storeName, 1);
+
+    // version 2
+    emptyPushToStore(parentControllerClient, storeName, 2);
+
+    ControllerResponse response = parentControllerClient.deleteOldVersion(storeName, 1);
+    assertFalse(response.isError());
+    TestUtils.waitForNonDeterministicAssertion(10, TimeUnit.SECONDS, false, true, () -> {
+      StoreResponse storeResponse = parentControllerClient.getStore(storeName);
+      Assert.assertFalse(storeResponse.isError());
+      StoreInfo storeInfo = storeResponse.getStore();
+      assertEquals(storeInfo.getVersions().size(), 1);
+    });
+
+  }
+
+  @Test
+  public void testDerivedSchemaCreation() {
+    markAsTested("DerivedSchemaCreation");
+
+    Store storeInfo = setUpTestStore();
+    String storeName = storeInfo.getName();
+    String recordSchemaStr = TestWriteUtils.USER_WITH_DEFAULT_SCHEMA.toString();
+    Schema derivedSchema = WriteComputeSchemaConverter.getInstance().convertFromValueRecordSchemaStr(recordSchemaStr);
+
+    veniceAdmin.addDerivedSchema(clusterName, storeName, 1, derivedSchema.toString());
+    Assert.assertEquals(veniceAdmin.getDerivedSchemas(clusterName, storeName).size(), 1);
+  }
+
+  @Test
+  public void testValueSchemaCreation() {
+    markAsTested("ValueSchemaCreation");
+    markAsTested("DeleteUnusedValueSchemas");
+
+    Store storeInfo = setUpTestStore();
+    String storeName = storeInfo.getName();
+
+    // When read compute is enabled, we will generate superset schema and add value schema into it
+    UpdateStoreQueryParams updateStoreQueryParams = new UpdateStoreQueryParams().setReadComputationEnabled(true);
+    ControllerResponse response = parentControllerClient.updateStore(storeName, updateStoreQueryParams);
+    assertFalse(response.isError());
+
+    parentControllerClient.deleteValueSchemas(storeName, new ArrayList<>(1));
+  }
+
+  @Test
+  public void testStoragePersona() {
+    markAsTested("CreateStoragePersona");
+    markAsTested("UpdateStoragePersona");
+    markAsTested("DeleteStoragePersona");
+    long totalQuota = 1000;
+    StoragePersona persona = createDefaultPersona();
+    persona.setQuotaNumber(totalQuota * 3);
+    List<String> stores = new ArrayList<>();
+    Store store1 = setUpTestStore();
+
+    parentControllerClient
+        .updateStore(store1.getName(), new UpdateStoreQueryParams().setStorageQuotaInByte(totalQuota));
+    stores.add(store1.getName());
+    persona.getStoresToEnforce().add(stores.get(0));
+
+    ControllerClient controllerClient = new ControllerClient(
+        multiRegionMultiClusterWrapper.getClusterNames()[0],
+        multiRegionMultiClusterWrapper.getControllerConnectString());
+
+    ControllerResponse response = controllerClient.createStoragePersona(
+        persona.getName(),
+        persona.getQuotaNumber(),
+        persona.getStoresToEnforce(),
+        persona.getOwners());
+    assertFalse(response.isError());
+    Store store2 = setUpTestStore();
+
+    parentControllerClient
+        .updateStore(store2.getName(), new UpdateStoreQueryParams().setStorageQuotaInByte(totalQuota * 2));
+
+    stores.add(store2.getName());
+    persona.setStoresToEnforce(new HashSet<>(stores));
+    response = controllerClient.updateStoragePersona(
+        persona.getName(),
+        new UpdateStoragePersonaQueryParams().setStoresToEnforce(new HashSet<>(stores)));
+    assertFalse(response.isError());
+    TestUtils.waitForNonDeterministicAssertion(
+        60,
+        TimeUnit.SECONDS,
+        () -> Assert.assertEquals(controllerClient.getStoragePersona(persona.getName()).getStoragePersona(), persona));
+
+    response = parentControllerClient.deleteStoragePersona(persona.getName());
+    if (response.isError())
+      throw new VeniceException(response.getError());
+    Assert.assertFalse(response.isError());
+    TestUtils.waitForNonDeterministicAssertion(
+        60,
+        TimeUnit.SECONDS,
+        () -> Assert.assertNull(parentControllerClient.getStoragePersona(persona.getName()).getStoragePersona()));
+  }
+
+  @Test
+  public void testRollbackCurrentVersion() {
+    markAsTested("RollbackCurrentVersion");
+    markAsTested("RollForwardCurrentVersion");
+
+    String storeName = setUpTestStore().getName();
+    emptyPushToStore(parentControllerClient, storeName, 1);
+    emptyPushToStore(parentControllerClient, storeName, 2);
+    // Should roll back to version 1
+    parentControllerClient.rollbackToBackupVersion(storeName);
+    for (ControllerClient childControllerClient: childControllerClients) {
+      TestUtils.waitForNonDeterministicAssertion(10, TimeUnit.SECONDS, false, true, () -> {
+        StoreResponse storeResponse = childControllerClient.getStore(storeName);
+        Assert.assertFalse(storeResponse.isError());
+        StoreInfo storeInfo = storeResponse.getStore();
+        assertEquals(storeInfo.getCurrentVersion(), 1);
+      });
+    }
+
+    // roll forward only in dc-0
+    parentControllerClient
+        .rollForwardToFutureVersion(storeName, multiRegionMultiClusterWrapper.getChildRegionNames().get(0));
+    for (ControllerClient childControllerClient: childControllerClients) {
+      TestUtils.waitForNonDeterministicAssertion(10, TimeUnit.SECONDS, false, true, () -> {
+        StoreResponse storeResponse = childControllerClient.getStore(storeName);
+        Assert.assertFalse(storeResponse.isError());
+        StoreInfo storeInfo = storeResponse.getStore();
+        assertEquals(storeInfo.getCurrentVersion(), childControllerClient == childControllerClients.get(1) ? 1 : 2);
+      });
+    }
+  }
+
+  @Test
+  public void testEnableNativeReplicationForCluster() {
+    markAsTested("EnableNativeReplicationForCluster");
+    String storeName = setUpTestStore().getName();
+
+    emptyPushToStore(parentControllerClient, storeName, 1);
+
+    UpdateStoreQueryParams updateStoreQueryParams = new UpdateStoreQueryParams().setNativeReplicationEnabled(true);
+    ControllerResponse response = parentControllerClient.updateStore(storeName, updateStoreQueryParams);
+
+    assertFalse(response.isError());
+    TestUtils.waitForNonDeterministicAssertion(10, TimeUnit.SECONDS, false, true, () -> {
+      StoreResponse storeResponse = parentControllerClient.getStore(storeName);
+      Assert.assertFalse(storeResponse.isError());
+      StoreInfo storeInfo = storeResponse.getStore();
+      assertTrue(storeInfo.isNativeReplicationEnabled());
+    });
+  }
+
+  @Test
+  public void testEnableActiveActiveReplicationForCluster() {
+    markAsTested("EnableActiveActiveReplicationForCluster");
+
+    String storeName = setUpTestStore().getName();
+    emptyPushToStore(parentControllerClient, storeName, 1);
+
+    UpdateStoreQueryParams updateStoreQueryParams =
+        new UpdateStoreQueryParams().setActiveActiveReplicationEnabled(true);
+    ControllerResponse response = parentControllerClient.updateStore(storeName, updateStoreQueryParams);
+
+    assertFalse(response.isError());
+    TestUtils.waitForNonDeterministicAssertion(10, TimeUnit.SECONDS, false, true, () -> {
+      StoreResponse storeResponse = parentControllerClient.getStore(storeName);
+      Assert.assertFalse(storeResponse.isError());
+      StoreInfo storeInfo = storeResponse.getStore();
+      assertTrue(storeInfo.isActiveActiveReplicationEnabled());
+    });
+  }
+
+  @Test
+  public void testConfigureActiveActiveReplicationForCluster() {
+    markAsTested("ConfigureActiveActiveReplicationForCluster");
+  }
+
+  @Test
+  public void testConfigureNativeReplicationForCluster() {
+    // No usage found for this operation
+    // Check @code{AdminExecutionTask#handleEnableNativeReplicationForCluster}
+    markAsTested("ConfigureNativeReplicationForCluster");
+  }
+
+  @Test
+  public void testConfigureIncrementalPushForCluster() {
+    // No usage found for this operation
+    markAsTested("ConfigureIncrementalPushForCluster");
+  }
+
+  @Test
+  public void testMigrateStore() {
+    markAsTested("MigrateStore");
+  }
+
+  @Test
+  public void testAbortMigration() {
+    markAsTested("AbortMigration");
+  }
+
+  @Test
+  public void testAddVersion() {
+    markAsTested("AddVersion");
+  }
+
+  @Test
+  public void testMetadataSchemaCreation() {
+    markAsTested("MetadataSchemaCreation");
+  }
+
+  @Test
+  public void testSupersetSchemaCreation() {
+    markAsTested("SupersetSchemaCreation");
+  }
+
+  @Test
+  public void testPushStatusSystemStoreAutoCreationValidation() {
+    markAsTested("PushStatusSystemStoreAutoCreationValidation");
+  }
+
+  @Test
+  public void testMetaSystemStoreAutoCreationValidation() {
+    markAsTested("MetaSystemStoreAutoCreationValidation");
+  }
+
+  private void emptyPushToStore(ControllerClient parentControllerClient, String storeName, int expectedVersion) {
+    VersionCreationResponse vcr = parentControllerClient.emptyPush(storeName, Utils.getUniqueString("empty-push"), 1L);
+    Assert.assertFalse(vcr.isError());
+    assertEquals(
+        vcr.getVersion(),
+        expectedVersion,
+        "requesting a topic for a push should provide version number " + expectedVersion);
+
+    TestUtils.waitForNonDeterministicPushCompletion(
+        Version.composeKafkaTopic(storeName, expectedVersion),
+        parentControllerClient,
+        30,
+        TimeUnit.SECONDS);
+  }
+
+  private Store setUpTestStore() {
+    Store testStore =
+        TestUtils.createTestStore(Utils.getUniqueString("testStore"), "testStoreOwner", System.currentTimeMillis());
+    parentControllerClient
+        .createNewStore(testStore.getName(), testStore.getOwner(), STRING_SCHEMA.toString(), STRING_SCHEMA.toString());
+    return testStore;
+  }
+
+  private Map<String, Boolean> getAllPayloadUnionTypes() {
+    Schema latestSchema =
+        AdminOperationSerializer.getSchema(AdminOperationSerializer.LATEST_SCHEMA_ID_FOR_ADMIN_OPERATION);
+    List<Schema> payloadUnionSchemas = latestSchema.getField("payloadUnion").schema().getTypes();
+    return payloadUnionSchemas.stream()
+        .filter(schema -> schema.getType() == Schema.Type.RECORD) // Filter only RECORD types
+        .collect(Collectors.toMap(Schema::getName, schema -> false));
+  }
+
+  private void markAsTested(String operationType) {
+    operationTypeMap.put(operationType, true);
+  }
+}

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestAdminOperationWithPreviousVersion.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestAdminOperationWithPreviousVersion.java
@@ -201,7 +201,7 @@ public class TestAdminOperationWithPreviousVersion {
     store = veniceAdmin.getStore(clusterName, storeName);
     Assert.assertTrue(store.isEnableWrites());
     Assert.assertEquals(store.getVersions().size(), 1);
-    Assert.assertEquals(store.peekNextVersion().getNumber(), 2);
+    Assert.assertEquals(store.peekNextVersionNumber(), 2);
   }
 
   @Test(timeOut = TEST_TIMEOUT)

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestAdminOperationWithPreviousVersion.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestAdminOperationWithPreviousVersion.java
@@ -95,7 +95,7 @@ public class TestAdminOperationWithPreviousVersion {
   private Admin veniceAdmin;
   private List<ControllerClient> childControllerClients = new ArrayList<>();
   private VeniceMultiClusterWrapper multiClusterWrapperRegion0;
-  private static int countTestRun;
+  private int countTestRun;
   private Map<String, Boolean> operationTypeMap = getAllPayloadUnionTypes();
 
   @BeforeClass(alwaysRun = true)

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/kafka/protocol/serializer/AdminOperationSerializer.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/kafka/protocol/serializer/AdminOperationSerializer.java
@@ -73,6 +73,9 @@ public class AdminOperationSerializer {
     // Get the writer schema.
     Schema targetSchema = getSchema(targetSchemaId);
 
+    // Validate non-default usage for new semantic
+    SemanticDetector.traverseAndValidate(object, LATEST_SCHEMA, targetSchema, "AdminOperation", null);
+
     // If writer schema is not the latest schema, we need to deserialize the serialized bytes to GenericRecord with
     // the writer schema, then serialize it to bytes with the writer schema.
     try {

--- a/services/venice-controller/src/test/java/com/linkedin/venice/controller/kafka/protocol/admin/AdminOperationSerializerTest.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/controller/kafka/protocol/admin/AdminOperationSerializerTest.java
@@ -5,12 +5,14 @@ import static org.mockito.Mockito.anyInt;
 import static org.mockito.Mockito.doCallRealMethod;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.expectThrows;
 
 import com.linkedin.venice.controller.kafka.protocol.enums.AdminMessageType;
 import com.linkedin.venice.controller.kafka.protocol.serializer.AdminOperationSerializer;
 import com.linkedin.venice.exceptions.VeniceMessageException;
+import com.linkedin.venice.exceptions.VeniceProtocolException;
 import java.nio.ByteBuffer;
 import java.util.Collections;
 import org.mockito.Mockito;
@@ -41,7 +43,7 @@ public class AdminOperationSerializerTest {
     updateStore.enableWrites = true;
     updateStore.replicateAllConfigs = true;
     updateStore.updatedConfigsList = Collections.emptyList();
-    // Purposely set to true. This field doesn't exist in v74, will be dropped during serialization
+    // Purposely set to true. This field doesn't exist in v74, so it should throw an exception.
     // Default value of this field is False.
     updateStore.separateRealTimeTopicEnabled = true;
     AdminOperation adminMessage = new AdminOperation();
@@ -53,10 +55,18 @@ public class AdminOperationSerializerTest {
     doCallRealMethod().when(adminOperationSerializer).deserialize(any(), anyInt());
 
     // Serialize the AdminOperation object with writer schema id v74
-    byte[] serializedBytes = adminOperationSerializer.serialize(adminMessage, 74);
+    try {
+      adminOperationSerializer.serialize(adminMessage, 74);
+    } catch (VeniceProtocolException e) {
+      assertTrue(e.getMessage().contains("payloadUnion.UpdateStore.separateRealTimeTopicEnabled"));
+    }
 
-    // Deserialize the serialized bytes back into an AdminOperation object
-    // TODO: test that all the new fields only have default values, after the final deserialization.
+    // Set the separateRealTimeTopicEnabled to false
+    updateStore.separateRealTimeTopicEnabled = false;
+    adminMessage.payloadUnion = updateStore;
+
+    // Serialize the AdminOperation object with writer schema id v74, should not fail
+    byte[] serializedBytes = adminOperationSerializer.serialize(adminMessage, 74);
     AdminOperation deserializedOperation = adminOperationSerializer.deserialize(ByteBuffer.wrap(serializedBytes), 74);
     UpdateStore deserializedOperationPayloadUnion = (UpdateStore) deserializedOperation.getPayloadUnion();
     assertEquals(deserializedOperationPayloadUnion.clusterName.toString(), "clusterName");
@@ -68,7 +78,17 @@ public class AdminOperationSerializerTest {
     assertTrue(deserializedOperationPayloadUnion.enableWrites);
     assertTrue(deserializedOperationPayloadUnion.replicateAllConfigs);
     assertEquals(deserializedOperationPayloadUnion.updatedConfigsList, Collections.emptyList());
-    // The field separateRealTimeTopicEnabled should be set to false (default value) after deserialization
+
+    // Check value of new semantics are all set to default value
     assertFalse(deserializedOperationPayloadUnion.separateRealTimeTopicEnabled);
+    assertEquals(deserializedOperationPayloadUnion.maxRecordSizeBytes, -1);
+    assertEquals(deserializedOperationPayloadUnion.maxNearlineRecordSizeBytes, -1);
+    assertFalse(deserializedOperationPayloadUnion.unusedSchemaDeletionEnabled);
+    assertFalse(deserializedOperationPayloadUnion.blobTransferEnabled);
+    assertFalse(deserializedOperationPayloadUnion.nearlineProducerCompressionEnabled);
+    assertEquals(deserializedOperationPayloadUnion.nearlineProducerCountPerWriter, 1);
+    assertNull(deserializedOperationPayloadUnion.targetSwapRegion);
+    assertEquals(deserializedOperationPayloadUnion.targetSwapRegionWaitTime, 60);
+    assertFalse(deserializedOperationPayloadUnion.isDaVinciHeartBeatReported);
   }
 }

--- a/services/venice-controller/src/test/java/com/linkedin/venice/controller/kafka/protocol/admin/AdminOperationSerializerTest.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/controller/kafka/protocol/admin/AdminOperationSerializerTest.java
@@ -58,7 +58,9 @@ public class AdminOperationSerializerTest {
     try {
       adminOperationSerializer.serialize(adminMessage, 74);
     } catch (VeniceProtocolException e) {
-      assertTrue(e.getMessage().contains("payloadUnion.UpdateStore.separateRealTimeTopicEnabled"));
+      String expectedMessage =
+          "Field AdminOperation.payloadUnion.UpdateStore.separateRealTimeTopicEnabled: Boolean value true is not the default value false or false";
+      assertEquals(e.getMessage(), expectedMessage);
     }
 
     // Set the separateRealTimeTopicEnabled to false

--- a/services/venice-controller/src/test/java/com/linkedin/venice/controller/kafka/protocol/admin/AdminOperationSerializerTest.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/controller/kafka/protocol/admin/AdminOperationSerializerTest.java
@@ -85,7 +85,7 @@ public class AdminOperationSerializerTest {
     assertEquals(deserializedOperationPayloadUnion.maxNearlineRecordSizeBytes, -1);
     assertFalse(deserializedOperationPayloadUnion.unusedSchemaDeletionEnabled);
     assertFalse(deserializedOperationPayloadUnion.blobTransferEnabled);
-    assertFalse(deserializedOperationPayloadUnion.nearlineProducerCompressionEnabled);
+    assertTrue(deserializedOperationPayloadUnion.nearlineProducerCompressionEnabled);
     assertEquals(deserializedOperationPayloadUnion.nearlineProducerCountPerWriter, 1);
     assertNull(deserializedOperationPayloadUnion.targetSwapRegion);
     assertEquals(deserializedOperationPayloadUnion.targetSwapRegionWaitTime, 60);


### PR DESCRIPTION
## Problem Statement
Initial start: Producers (parent controllers) need to generate AdminConsumptionTask to put into the admin topic queue. Messages will be consumed by consumers (parent controllers + child controllers). If producers produce the message that consumers cannot read, we are having troubles.

Current solution: Child controllers when upgraded to the newer version, will need to be completed BEFORE parent controllers. (Since parent controllers is currently using their latest version code, and child controller don't have the schema for latest version yet).
## Solution

New solution:
We put a version number in parents' ZK metadata, specifying the version that producers will use (let's called it X)

Producer: OK, I will always use version X to produce message.
In deployment, parent and child controllers can freely upgrade to X+1, without any delay or order.

**(#1574 + This PR)** During the serialization, producers may figure out that the message with newer schema is using non-default value for the new field (the field that child controller don't know yet).

Producers fail the task **(This PR)**
- Sorry, we are not ready for this message 👎

Then, when they are all upgraded, we send a request to ZK:

OK, let's use X+1 from now on
=> Complete the deployment.

###  Code changes
- [ ] Added new code behind **a config**. If so list the config names and their default values in the PR description.
- [ ] Introduced new **log lines**. 
  - [ ] Confirmed if logs need to be **rate limited** to avoid excessive logging.

###  **Concurrency-Specific Checks**
Both reviewer and PR author to verify
- [ ] Code has **no race conditions** or **thread safety issues**.
- [ ] Proper **synchronization mechanisms** (e.g., `synchronized`, `RWLock`) are used where needed.
- [ ] No **blocking calls** inside critical sections that could lead to deadlocks or performance degradation.
- [ ] Verified **thread-safe collections** are used (e.g., `ConcurrentHashMap`, `CopyOnWriteArrayList`).
- [ ] Validated proper exception handling in multi-threaded code to avoid silent thread termination.


## How was this PR tested?
UTs & integration tests

## Does this PR introduce any user-facing or breaking changes?
<!--  
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Clearly explain the behavior change and its impact.