### PR TITLE
[changelog][client] Clean up cdc locking

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/consumer/VeniceAfterImageConsumerImpl.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/consumer/VeniceAfterImageConsumerImpl.java
@@ -1,9 +1,12 @@
 package com.linkedin.davinci.consumer;
 
+import static com.linkedin.davinci.consumer.VeniceChangelogConsumerClientFactory.*;
+
 import com.linkedin.davinci.repository.NativeMetadataRepositoryViewAdapter;
 import com.linkedin.venice.exceptions.VeniceException;
 import com.linkedin.venice.kafka.protocol.ControlMessage;
 import com.linkedin.venice.kafka.protocol.enums.ControlMessageType;
+import com.linkedin.venice.offsets.OffsetRecord;
 import com.linkedin.venice.pubsub.api.DefaultPubSubMessage;
 import com.linkedin.venice.pubsub.api.PubSubConsumerAdapter;
 import com.linkedin.venice.pubsub.api.PubSubMessage;
@@ -11,13 +14,13 @@ import com.linkedin.venice.pubsub.api.PubSubTopic;
 import com.linkedin.venice.pubsub.api.PubSubTopicPartition;
 import com.linkedin.venice.utils.lazy.Lazy;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ExecutionException;
 import java.util.concurrent.atomic.AtomicBoolean;
 import org.apache.kafka.common.errors.UnknownTopicOrPartitionException;
 import org.apache.logging.log4j.LogManager;
@@ -30,7 +33,7 @@ public class VeniceAfterImageConsumerImpl<K, V> extends VeniceChangelogConsumerI
   // in the context of seeking to EOP in the event of the user calling that seek or a version push.
   // TODO: We shouldn't use this in the long run. Once the EOP position is queryable from venice and version
   // swap is produced to VT, then we should remove this as it's no longer needed.
-  final private Lazy<VeniceChangelogConsumerImpl<K, V>> internalSeekConsumer;
+  final private Lazy<PubSubConsumerAdapter> internalSeekConsumer;
   AtomicBoolean versionSwapThreadScheduled = new AtomicBoolean(false);
   private final VersionSwapDataChangeListener<K, V> versionSwapListener;
 
@@ -39,17 +42,15 @@ public class VeniceAfterImageConsumerImpl<K, V> extends VeniceChangelogConsumerI
         changelogClientConfig,
         consumer,
         Lazy.of(
-            () -> new VeniceChangelogConsumerImpl<K, V>(
-                changelogClientConfig,
-                VeniceChangelogConsumerClientFactory.getConsumer(
-                    changelogClientConfig.getConsumerProperties(),
-                    changelogClientConfig.getStoreName() + "-" + "internal"))));
+            () -> getConsumer(
+                changelogClientConfig.getConsumerProperties(),
+                changelogClientConfig.getStoreName() + "-" + "internal")));
   }
 
   protected VeniceAfterImageConsumerImpl(
       ChangelogClientConfig changelogClientConfig,
       PubSubConsumerAdapter consumer,
-      Lazy<VeniceChangelogConsumerImpl<K, V>> seekConsumer) {
+      Lazy<PubSubConsumerAdapter> seekConsumer) {
     super(changelogClientConfig, consumer);
     internalSeekConsumer = seekConsumer;
     versionSwapListener = new VersionSwapDataChangeListener<K, V>(
@@ -108,22 +109,32 @@ public class VeniceAfterImageConsumerImpl<K, V> extends VeniceChangelogConsumerI
       return CompletableFuture.completedFuture(null);
     }
     return CompletableFuture.supplyAsync(() -> {
-      synchronized (internalSeekConsumer) {
-        try {
-          // TODO: This implementation basically just scans the version topic until it finds the EOP message. The
-          // approach
-          // we'd like to do is instead add the offset of the EOP message in the VT, and then just seek to that offset.
-          // We'll do that in a future patch.
-          internalSeekConsumer.get().unsubscribeAll();
-          internalSeekConsumer.get().internalSubscribe(partitions, targetTopic).get();
+      // We need exclusive access in this code section HOWEVER, we also want user poll requests to go through. So here,
+      // we'll
+      // take the subscription read lock, and we'll lock the internalSeekConsumer as it's stateful. We'll then acquire
+      // the
+      // exclusive lock on the subscriptions just before applying changes to the main consumer.
+      subscriptionLock.readLock().lock();
+      Set<VeniceChangeCoordinate> checkpoints = new HashSet<>();
+      try {
+        // TODO: This implementation basically just scans the version topic until it finds the EOP message. The
+        // approach
+        // we'd like to do is instead add the offset of the EOP message in the VT, and then just seek to that offset.
+        // We'll do that in a future patch.
 
-          // We need to get the internal consumer as we have to intercept the control messages that we would normally
-          // filter out from the user
-          PubSubConsumerAdapter consumerAdapter = internalSeekConsumer.get().getPubSubConsumer();
+        // We need to get the internal consumer as we have to intercept the control messages that we would normally
+        // filter out from the user
+        synchronized (internalSeekConsumer) {
+          PubSubConsumerAdapter consumerAdapter = internalSeekConsumer.get();
+          consumerAdapter.batchUnsubscribe(consumerAdapter.getAssignment());
+          List<PubSubTopicPartition> topicPartitionList =
+              getPartitionListToSubscribe(partitions, Collections.EMPTY_SET, targetTopic);
 
+          for (PubSubTopicPartition topicPartition: topicPartitionList) {
+            consumerAdapter.subscribe(topicPartition, OffsetRecord.LOWEST_OFFSET);
+          }
           Map<PubSubTopicPartition, List<DefaultPubSubMessage>> polledResults;
           Map<Integer, Boolean> endOfPushConsumedPerPartitionMap = new HashMap<>();
-          Set<VeniceChangeCoordinate> checkpoints = new HashSet<>();
 
           // Initialize map with all false entries for each partition
           for (Integer partition: partitions) {
@@ -132,53 +143,48 @@ public class VeniceAfterImageConsumerImpl<K, V> extends VeniceChangelogConsumerI
 
           // poll until we get EOP for all partitions
           LOGGER.info("Polling for EOP messages for partitions: " + partitions.toString());
-          synchronized (consumerAdapter) {
-            LOGGER.info("GOT LOCK");
-            int counter = 0;
-            while (true) {
-              counter++;
-              polledResults = consumerAdapter.poll(5000L);
-              // Loop through all polled messages
-              for (Map.Entry<PubSubTopicPartition, List<DefaultPubSubMessage>> entry: polledResults.entrySet()) {
-                PubSubTopicPartition pubSubTopicPartition = entry.getKey();
-                List<DefaultPubSubMessage> messageList = entry.getValue();
-                for (DefaultPubSubMessage message: messageList) {
-                  if (message.getKey().isControlMessage()) {
-                    ControlMessage controlMessage = (ControlMessage) message.getValue().getPayloadUnion();
-                    ControlMessageType controlMessageType = ControlMessageType.valueOf(controlMessage);
-                    if (controlMessageType.equals(ControlMessageType.END_OF_PUSH)) {
-                      LOGGER.info("Found EOP message for partition: " + pubSubTopicPartition.getPartitionNumber());
-                      // note down the partition and offset and mark that we've got the thing
-                      endOfPushConsumedPerPartitionMap.put(pubSubTopicPartition.getPartitionNumber(), true);
-                      VeniceChangeCoordinate coordinate = new VeniceChangeCoordinate(
-                          pubSubTopicPartition.getPubSubTopic().getName(),
-                          message.getPosition(),
-                          pubSubTopicPartition.getPartitionNumber());
-                      checkpoints.add(coordinate);
-                      Set<Integer> unsubSet = new HashSet<>();
-                      unsubSet.add(pubSubTopicPartition.getPartitionNumber());
-                      internalSeekConsumer.get().unsubscribe(unsubSet);
-                      // No need to look at the rest of the messages for this partition that we might have polled
-                      break;
-                    }
+          while (true) {
+            polledResults = consumerAdapter.poll(5000L);
+            // Loop through all polled messages
+            for (Map.Entry<PubSubTopicPartition, List<DefaultPubSubMessage>> entry: polledResults.entrySet()) {
+              PubSubTopicPartition pubSubTopicPartition = entry.getKey();
+              List<DefaultPubSubMessage> messageList = entry.getValue();
+              for (DefaultPubSubMessage message: messageList) {
+                if (message.getKey().isControlMessage()) {
+                  ControlMessage controlMessage = (ControlMessage) message.getValue().getPayloadUnion();
+                  ControlMessageType controlMessageType = ControlMessageType.valueOf(controlMessage);
+                  if (controlMessageType.equals(ControlMessageType.END_OF_PUSH)) {
+                    LOGGER.info("Found EOP message for partition: " + pubSubTopicPartition.getPartitionNumber());
+                    // note down the partition and offset and mark that we've got the thing
+                    endOfPushConsumedPerPartitionMap.put(pubSubTopicPartition.getPartitionNumber(), true);
+                    VeniceChangeCoordinate coordinate = new VeniceChangeCoordinate(
+                        pubSubTopicPartition.getPubSubTopic().getName(),
+                        message.getPosition(),
+                        pubSubTopicPartition.getPartitionNumber());
+                    checkpoints.add(coordinate);
+                    // No need to look at the rest of the messages for this partition that we might have polled
+                    consumerAdapter.unSubscribe(pubSubTopicPartition);
+                    break;
                   }
                 }
               }
-              if (endOfPushConsumedPerPartitionMap.values().stream().allMatch(e -> e)) {
-                LOGGER.info("Found EOP messages for all partitions: " + partitions.toString());
-                // We polled all EOP messages, stop polling!
-                break;
-              }
+            }
+            if (endOfPushConsumedPerPartitionMap.values().stream().allMatch(e -> e)) {
+              LOGGER.info("Found EOP messages for all partitions: " + partitions.toString());
+              // We polled all EOP messages, stop polling!
+              break;
             }
           }
-          LOGGER.info("Seeking to EOP for partitions: " + partitions.toString());
-          this.seekToCheckpoint(checkpoints).get();
-          LOGGER.info("Seeked to EOP for partitions: " + partitions.toString());
-        } catch (InterruptedException | ExecutionException | VeniceCoordinateOutOfRangeException e) {
-          throw new VeniceException(
-              "Seek to End of Push Failed for store: " + storeName + " partitions: " + partitions.toString(),
-              e);
+          LOGGER.info(
+              "Seeking to EOP for partitions: " + partitions.toString() + " for version topic: "
+                  + targetTopic.getName());
+          this.synchronousSeekToCheckpoint(checkpoints);
+          LOGGER.info(
+              "Seeked to EOP for partitions: " + partitions.toString() + " for version topic: "
+                  + targetTopic.getName());
         }
+      } finally {
+        subscriptionLock.readLock().unlock();
       }
       return null;
     });

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/consumer/VeniceChangelogConsumerImplTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/consumer/VeniceChangelogConsumerImplTest.java
@@ -206,14 +206,12 @@ public class VeniceChangelogConsumerImplTest {
     prepareVersionTopicRecordsToBePolled(0L, 5L, mockPubSubConsumer, oldVersionTopic, 0, true);
     ChangelogClientConfig changelogClientConfig = getChangelogClientConfig(d2ControllerClient).setViewName("");
 
-    VeniceChangelogConsumerImpl mockInternalSeekConsumer = Mockito.mock(VeniceChangelogConsumerImpl.class);
-    Mockito.when(mockInternalSeekConsumer.internalSubscribe(any(), any()))
-        .thenReturn(CompletableFuture.completedFuture(null));
-    Mockito.when(mockInternalSeekConsumer.getPubSubConsumer()).thenReturn(mockPubSubConsumer);
+    PubSubConsumerAdapter mockInternalSeekConsumer = Mockito.mock(PubSubConsumerAdapter.class);
+
     prepareChangeCaptureRecordsToBePolled(
         0L,
         10L,
-        mockPubSubConsumer,
+        mockInternalSeekConsumer,
         oldVersionTopic,
         0,
         oldVersionTopic,
@@ -249,8 +247,6 @@ public class VeniceChangelogConsumerImplTest {
 
     veniceChangelogConsumer.seekToEndOfPush(partitionSet).get();
 
-    Mockito.verify(mockInternalSeekConsumer).internalSubscribe(partitionSet, oldVersionTopic);
-    Mockito.verify(mockInternalSeekConsumer).unsubscribe(partitionSet);
     PubSubTopicPartition pubSubTopicPartition = new PubSubTopicPartitionImpl(oldVersionTopic, 0);
     Mockito.verify(mockPubSubConsumer).subscribe(pubSubTopicPartition, 10);
   }

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/consumer/TestChangelogConsumer.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/consumer/TestChangelogConsumer.java
@@ -171,7 +171,7 @@ public class TestChangelogConsumer {
   }
 
   // This is a beefier test, so giving it a bit more time
-  @Test(timeOut = TEST_TIMEOUT, priority = 3)
+  @Test(timeOut = TEST_TIMEOUT * 3, priority = 3)
   public void testVersionSwapInALoop() throws Exception {
     // create a active-active enabled store and run batch push job
     // batch job contains 100 records
@@ -273,7 +273,7 @@ public class TestChangelogConsumer {
     }
   }
 
-  @Test(timeOut = TEST_TIMEOUT * 10, priority = 3)
+  @Test(timeOut = TEST_TIMEOUT, priority = 3)
   public void testAAIngestionWithStoreView() throws Exception {
     // Set up the store
     Long timestamp = System.currentTimeMillis();


### PR DESCRIPTION
This is mostly a clean up PR, though there may be some bugs getting fixed here.  The locking structure of the ChangelogConsumer was a little too convoluted, and didn't seem to offer adequate safety for some scenarios.  For example, some users have reported seeking exceptions when polling when subscriptions change on the client (as there is a period of time where the consumer would have no subscriptions before getting new subscriptions).

This accomplishes the above with three main refactors.  They are:

1.  **Use pubsubAdapter directly instead of a seperate CDC client** 
When doing seek to EOP The implementation was just directly accessing the pubsubAdapter in the wrapped CDC client anyway, and the CDC client is significantly heavier.  So we swap that type out.

2. **Unify all locking with a ReentrentReadWriteLock** 
The previous implementation made liberal use of synchronized() on the pubsubadapter as well as a few other objects.  The downside of doing this was that it could it sieze up client calls to poll() unnecessarily.  Using a proper readwritelock should allow for better concurrency and concurrency that makes more sense.

3. **Add sync api's to reduce deadlock risk** 
So, an observed problem was that if you go N degrees deep on async functions, it's easy to lose track of who holds what lock.  It was actually pretty easy to get into scenarios where a main function call would syncrhonize on an object, and then call a function which would spawn an async thread which would need to lock the same object in order to do any work.  To solve this, we introduce syncApi's which can be called directly and avoid introducing extra locking threads.

<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat], [protocol]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## Problem Statement
<!--
Describe
- What problem are you trying to solve
- What issues or limitations exist in the current code
- Why this change is necessary 
-->


## Solution
<!--
Describe
- What changes you are making and why. 
- How these changes solve the problem.
- Any performance considerations or trade-offs. 
- Describe what testings you have done, for example, performance testing etc.
-->


###  Code changes
- [ ] Added new code behind **a config**. If so list the config names and their default values in the PR description.
- [ ] Introduced new **log lines**. 
  - [ ] Confirmed if logs need to be **rate limited** to avoid excessive logging.

###  **Concurrency-Specific Checks**
Both reviewer and PR author to verify
- [ ] Code has **no race conditions** or **thread safety issues**.
- [ ] Proper **synchronization mechanisms** (e.g., `synchronized`, `RWLock`) are used where needed.
- [ ] No **blocking calls** inside critical sections that could lead to deadlocks or performance degradation.
- [ ] Verified **thread-safe collections** are used (e.g., `ConcurrentHashMap`, `CopyOnWriteArrayList`).
- [ ] Validated proper exception handling in multi-threaded code to avoid silent thread termination.


## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->

- [ ] New unit tests added.
- [ ] New integration tests added.
- [ ] Modified or extended existing tests.
- [ ] Verified backward compatibility (if applicable).

## Does this PR introduce any user-facing or breaking changes?
<!--  
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [ ] No. You can skip the rest of this section.
- [ ] Yes. Clearly explain the behavior change and its impact.