### PR TITLE
[server] Deprecate OffsetRecord field leaderOffset and its usage to avoid ready-to-serve check using wrong offset; Fix bug that persist VT offset into upstream offset map

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/ActiveActiveStoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/ActiveActiveStoreIngestionTask.java
@@ -965,9 +965,8 @@ public class ActiveActiveStoreIngestionTask extends LeaderFollowerStoreIngestion
     Set<String> sourceKafkaServers = getKafkaUrlSetFromTopicSwitch(partitionConsumptionState.getTopicSwitch());
     Map<String, Long> upstreamOffsetsByKafkaURLs = new HashMap<>(sourceKafkaServers.size());
     sourceKafkaServers.forEach(sourceKafkaURL -> {
-      Long upstreamStartOffset =
-          partitionConsumptionState.getLatestProcessedUpstreamRTOffsetWithNoDefault(sourceKafkaURL);
-      if (upstreamStartOffset == null || upstreamStartOffset < 0) {
+      long upstreamStartOffset = partitionConsumptionState.getLatestProcessedUpstreamRTOffset(sourceKafkaURL);
+      if (upstreamStartOffset < 0) {
         if (rewindStartTimestamp > 0) {
           PubSubTopicPartition newSourceTopicPartition =
               resolveTopicPartitionWithKafkaURL(newSourceTopic, partitionConsumptionState, sourceKafkaURL);

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTask.java
@@ -1044,8 +1044,6 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
           calculateLeaderUpstreamOffsetWithTopicSwitch(partitionConsumptionState, leaderTopic, Collections.emptyList())
               .getOrDefault(OffsetRecord.NON_AA_REPLICATION_UPSTREAM_OFFSET_MAP_KEY, OffsetRecord.LOWEST_OFFSET);
     }
-    partitionConsumptionState.getOffsetRecord()
-        .setLeaderUpstreamOffset(OffsetRecord.NON_AA_REPLICATION_UPSTREAM_OFFSET_MAP_KEY, upstreamStartOffset);
 
     consumerSubscribe(leaderTopic, partitionConsumptionState, upstreamStartOffset, leaderSourceKafkaURL);
     syncConsumedUpstreamRTOffsetMapIfNeeded(

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/PartitionConsumptionState.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/PartitionConsumptionState.java
@@ -773,19 +773,6 @@ public class PartitionConsumptionState {
     return latestProcessedUpstreamRTOffset;
   }
 
-  public Long getLatestProcessedUpstreamRTOffsetWithNoDefault(String kafkaUrl) {
-    long latestProcessedUpstreamRTOffset = latestProcessedUpstreamRTOffsetMap.getOrDefault(kafkaUrl, -1L);
-    if (latestProcessedUpstreamRTOffset < 0) {
-      /**
-       * When processing {@link TopicSwitch} control message, only the checkpoint upstream offset maps in {@link OffsetRecord}
-       * will be updated, since those offset are not processed yet; so when leader try to get the upstream offsets for the very
-       * first time, there are no records in {@link #latestProcessedUpstreamRTOffsetMap} yet.
-       */
-      return getOffsetRecord().getUpstreamOffsetWithNoDefault(kafkaUrl);
-    }
-    return latestProcessedUpstreamRTOffset;
-  }
-
   /**
    * The caller of this API should be interested in which offset currently leader should consume from now.
    * 1. If currently leader should consume from real-time topic, return upstream RT offset;

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTaskTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTaskTest.java
@@ -3914,11 +3914,7 @@ public abstract class StoreIngestionTaskTest {
       doReturn(1000L).when(mock).getLeaderOffset(anyString(), any());
       System.out.println(mockOR.getLeaderTopic(null));
       doReturn(1000L).when(mockOR).getUpstreamOffset(anyString());
-      if (aaConfig == AA_ON) {
-        doReturn(1000L).when(mock).getLatestProcessedUpstreamRTOffsetWithNoDefault(anyString());
-      } else {
-        doReturn(1000L).when(mock).getLatestProcessedUpstreamRTOffset(anyString());
-      }
+      doReturn(1000L).when(mock).getLatestProcessedUpstreamRTOffset(anyString());
       doReturn(mockOR).when(mock).getOffsetRecord();
       System.out.println("inside mock" + mockOR.getLeaderTopic(null));
       return mock;
@@ -3935,12 +3931,7 @@ public abstract class StoreIngestionTaskTest {
     Supplier<PartitionConsumptionState> mockPcsSupplier2 = () -> {
       PartitionConsumptionState mock = mockPcsSupplier.get();
       doReturn(-1L).when(mock).getLeaderOffset(anyString(), any());
-
-      if (aaConfig == AA_ON) {
-        doReturn(-1L).when(mock).getLatestProcessedUpstreamRTOffsetWithNoDefault(anyString());
-      } else {
-        doReturn(-1L).when(mock).getLatestProcessedUpstreamRTOffset(anyString());
-      }
+      doReturn(-1L).when(mock).getLatestProcessedUpstreamRTOffset(anyString());
       doReturn(new PubSubTopicPartitionImpl(rtTopic, 0)).when(mock).getSourceTopicPartition(any());
       return mock;
     };

--- a/internal/venice-common/src/main/java/com/linkedin/venice/offsets/OffsetRecord.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/offsets/OffsetRecord.java
@@ -248,7 +248,7 @@ public class OffsetRecord {
    * call this API to get the latest upstream offset.
    */
   public long getUpstreamOffset(String kafkaURL) {
-    return getUpstreamOffsetFromPartitionState(this.partitionState, kafkaURL);
+    return partitionState.upstreamOffsetMap.getOrDefault(kafkaURL, -1L);
   }
 
   /**
@@ -390,12 +390,5 @@ public class OffsetRecord {
    */
   public byte[] toBytes() {
     return serializer.serialize(PARTITION_STATE_STRING, partitionState);
-  }
-
-  /**
-   * Return the single entry value from upstreamOffsetMap in native replication.
-   */
-  private Long getUpstreamOffsetFromPartitionState(PartitionState partitionState, String kafkaURL) {
-    return partitionState.upstreamOffsetMap.get(kafkaURL);
   }
 }

--- a/internal/venice-common/src/main/java/com/linkedin/venice/offsets/OffsetRecord.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/offsets/OffsetRecord.java
@@ -213,8 +213,6 @@ public class OffsetRecord {
 
   public void setLeaderUpstreamOffset(String upstreamKafkaURL, long leaderOffset) {
     partitionState.upstreamOffsetMap.put(upstreamKafkaURL, leaderOffset);
-    // Set this field as well so that we can rollback
-    partitionState.leaderOffset = leaderOffset;
   }
 
   public void setLeaderGUID(GUID guid) {
@@ -250,14 +248,6 @@ public class OffsetRecord {
    * call this API to get the latest upstream offset.
    */
   public long getUpstreamOffset(String kafkaURL) {
-    Long upstreamOffset = getUpstreamOffsetFromPartitionState(this.partitionState, kafkaURL);
-    if (upstreamOffset == null) {
-      return partitionState.leaderOffset;
-    }
-    return upstreamOffset;
-  }
-
-  public Long getUpstreamOffsetWithNoDefault(String kafkaURL) {
     return getUpstreamOffsetFromPartitionState(this.partitionState, kafkaURL);
   }
 
@@ -346,10 +336,6 @@ public class OffsetRecord {
   }
 
   private String getPartitionUpstreamOffsetString() {
-    if (this.partitionState.upstreamOffsetMap.isEmpty()) {
-      // Fall back to use the "leaderOffset" field
-      return Long.toString(this.partitionState.leaderOffset);
-    }
     return this.partitionState.upstreamOffsetMap.toString();
   }
 


### PR DESCRIPTION
<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat], [protocol]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## [server] Deprecate OffsetRecord field leaderOffset and its usage to avoid ready-to-serve check using wrong offset; Fix bug that persist VT offset into upstream offset map
No we should not use this OffsetRecord#leaderOffset anymore.

**_This PR fixes two issues._**

**The first issue is:**
This is legacy field and we already replaced it with upstreamOffsetMap. However, we are still updating this field from all the regions and our offset fetch logic can fall back can still hit this value in corner case.

Let's say we subscribe to region 1,2,3 when we promote this replica to LEADER role. If one of the consumer failed to subscribe the region (say 3), then it will not consuming any data from that, and in PartitionConsumptionState and OffsetRecord nothing is persisted for this region. 

However, in the RTS check, when we are measuring offset lag for this region, we will eventually fall back to leaderOffset as persisted offset, if all the map in PCS does not contain region offset value. This is **WRONG**, because it is updated by all the regions. So essentially we are doing lag for region 3 = end offset of region 3 - persisted offset of region 1. And if Region 1 has more data and higher offset, this can be < 0 and mark it ready to serve before it is truly ready after consumer repair service kicks in.

**The second issue is:**
In non-AGG bug fix PR: #1547 , there is a regression introduced during refactor - previously we will only checkpoint calculated upstream offset map during TopicSwitch, not during any standby -> leader, but during the refactor we merged two methods, but the checkpoint should not happen unless we are consuming RTs. Actually, we should not checkpoint to OffsetRecord at all in the method, we should only do the in memory update and only sync to OffsetRecord during formal checkpoint time.

The fix is just simply remove the line, and add a unit test to test against the behavior.

## Solution
<!--
Describe
- What changes you are making and why. 
- How these changes solve the problem.
- Any performance considerations or trade-offs. 
- Describe what testings you have done, for example, performance testing etc.
-->

This PR fixes it by removing the whole concept of this field. We should return -1 for the offset if no offset has checkpointed to this region.

###  Code changes
- [ ] Added new code behind **a config**. If so list the config names and their default values in the PR description.
- [ ] Introduced new **log lines**. 
  - [ ] Confirmed if logs need to be **rate limited** to avoid excessive logging.

###  **Concurrency-Specific Checks**
Both reviewer and PR author to verify
- [ ] Code has **no race conditions** or **thread safety issues**.
- [ ] Proper **synchronization mechanisms** (e.g., `synchronized`, `RWLock`) are used where needed.
- [ ] No **blocking calls** inside critical sections that could lead to deadlocks or performance degradation.
- [ ] Verified **thread-safe collections** are used (e.g., `ConcurrentHashMap`, `CopyOnWriteArrayList`).
- [ ] Validated proper exception handling in multi-threaded code to avoid silent thread termination.


## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->

- [x] New unit tests added.
- [ ] New integration tests added.
- [x] Modified or extended existing tests.
- [ ] Verified backward compatibility (if applicable).

## Does this PR introduce any user-facing or breaking changes?
<!--  
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Clearly explain the behavior change and its impact.