### PR TITLE
[router] Added metric for rejected connection when limit is breached

### DIFF
--- a/internal/alpini/netty4/alpini-netty4-base/src/main/java/com/linkedin/alpini/netty4/handlers/ConnectionControlHandler.java
+++ b/internal/alpini/netty4/alpini-netty4-base/src/main/java/com/linkedin/alpini/netty4/handlers/ConnectionControlHandler.java
@@ -42,8 +42,9 @@ public class ConnectionControlHandler extends ConnectionLimitHandler {
 
   public ConnectionControlHandler(
       @Nonnull IntSupplier connectionLimit,
-      @Nonnull Consumer<Integer> connectionCountRecorder) {
-    super(connectionLimit, connectionCountRecorder);
+      Consumer<Integer> connectionCountRecorder,
+      Consumer<Integer> rejectedConnectionCountRecorder) {
+    super(connectionLimit, connectionCountRecorder, rejectedConnectionCountRecorder);
   }
 
   @Override
@@ -59,6 +60,7 @@ public class ConnectionControlHandler extends ConnectionLimitHandler {
               "Connection limit exceeded! Active connections: {}, Limit: {}",
               getConnectedCount(),
               getConnectionLimit());
+          _rejectedConnectionCountRecorder.accept(1);
           parent.config().setAutoRead(false);
         }
       }).addListener(ignored -> _activeSemaphore.release());

--- a/internal/alpini/router/alpini-router-impl/src/main/java/com/linkedin/alpini/router/impl/Router.java
+++ b/internal/alpini/router/alpini-router-impl/src/main/java/com/linkedin/alpini/router/impl/Router.java
@@ -110,6 +110,8 @@ public interface Router extends ShutdownableResource {
 
     Builder connectionCountRecorder(@Nonnull Consumer<Integer> recorder);
 
+    Builder rejectedConnectionCountRecorder(@Nonnull Consumer<Integer> recorder);
+
     Builder connectionHandleMode(@Nonnull ConnectionHandleMode connectionHandleMode);
 
     Builder serverSocketOptions(Map<String, Object> serverSocketOptions);

--- a/internal/venice-client-common/src/main/java/com/linkedin/venice/stats/LongAdderRateGauge.java
+++ b/internal/venice-client-common/src/main/java/com/linkedin/venice/stats/LongAdderRateGauge.java
@@ -37,6 +37,11 @@ public class LongAdderRateGauge extends Gauge {
   }
 
   @Override
+  public void record(double value, long now) {
+    this.adder.add((long) value);
+  }
+
+  @Override
   public double measure(MetricConfig config, long currentTimeMs) {
     return getRate(currentTimeMs);
   }

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/router/TestStreaming.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/router/TestStreaming.java
@@ -568,6 +568,11 @@ public class TestStreaming {
       // Since connection limit is 0, the active connection counter would at most be incremented to 1
       Assert.assertTrue(Math.abs(maxValue - 1d) < 0.0001d);
       Assert.assertTrue(avgValue > 0 && avgValue < 1.0d);
+      TestUtils.waitForNonDeterministicAssertion(2, TimeUnit.MINUTES, () -> {
+        Map<String, ? extends Metric> latestRouterMetrics = routerMetricsRepositoryWithHttpAsyncClient.metrics();
+        double rejectedConnectionCount = latestRouterMetrics.get(".security--rejected_connection_count.Rate").value();
+        Assert.assertTrue(rejectedConnectionCount > 0);
+      });
       // Gauge metric might not be updated yet since it's only updated one time each one-minute time window
       // Assert.assertTrue(routerMetrics.get(".security--connection_count_gauge.Gauge").value() > 0);
     } finally {

--- a/services/venice-router/src/main/java/com/linkedin/venice/router/RouterServer.java
+++ b/services/venice-router/src/main/java/com/linkedin/venice/router/RouterServer.java
@@ -663,6 +663,7 @@ public class RouterServer extends AbstractVeniceService {
               .connectionLimit(config.getConnectionLimit())
               .connectionHandleMode(config.getConnectionHandleMode())
               .connectionCountRecorder(securityStats::recordLiveConnectionCount)
+              .rejectedConnectionCountRecorder(securityStats::recordRejectedConnectionCount)
               .timeoutProcessor(timeoutProcessor)
               .beforeHttpRequestHandler(ChannelPipeline.class, (pipeline) -> {
                 pipeline.addLast(
@@ -765,6 +766,7 @@ public class RouterServer extends AbstractVeniceService {
         .connectionLimit(config.getConnectionLimit())
         .connectionHandleMode(config.getConnectionHandleMode())
         .connectionCountRecorder(securityStats::recordLiveConnectionCount)
+        .rejectedConnectionCountRecorder(securityStats::recordRejectedConnectionCount)
         .timeoutProcessor(timeoutProcessor)
         .beforeHttpServerCodec(ChannelPipeline.class, sslFactory.isPresent() ? addSslInitializer : noop) // Compare once
                                                                                                          // per router.

--- a/services/venice-router/src/main/java/com/linkedin/venice/router/stats/SecurityStats.java
+++ b/services/venice-router/src/main/java/com/linkedin/venice/router/stats/SecurityStats.java
@@ -2,6 +2,7 @@ package com.linkedin.venice.router.stats;
 
 import com.linkedin.alpini.netty4.ssl.SslInitializer;
 import com.linkedin.venice.stats.AbstractVeniceStats;
+import com.linkedin.venice.stats.LongAdderRateGauge;
 import io.tehuti.metrics.MetricsRepository;
 import io.tehuti.metrics.Sensor;
 import io.tehuti.metrics.stats.AsyncGauge;
@@ -15,6 +16,7 @@ public class SecurityStats extends AbstractVeniceStats {
   private final Sensor sslErrorCountSensor;
   private final Sensor sslSuccessCountSensor;
   private final Sensor liveConnectionCountSensor;
+  private final Sensor rejectedConnectionCountSensor;
   private final Sensor nonSslConnectionCountSensor;
 
   private final AtomicInteger activeConnectionCount = new AtomicInteger();
@@ -26,6 +28,7 @@ public class SecurityStats extends AbstractVeniceStats {
     this.liveConnectionCountSensor = registerSensor("connection_count", new Avg(), new Max());
     registerSensor(new AsyncGauge((ignored1, ignored2) -> activeConnectionCount.get(), "connection_count_gauge"));
     this.nonSslConnectionCountSensor = registerSensor("non_ssl_request_count", new Avg(), new Max());
+    rejectedConnectionCountSensor = registerSensor("rejected_connection_count", new LongAdderRateGauge());
   }
 
   public void recordSslError() {
@@ -50,6 +53,10 @@ public class SecurityStats extends AbstractVeniceStats {
   public void recordLiveConnectionCount(int connectionCount) {
     this.activeConnectionCount.set(connectionCount);
     updateConnectionCountInCurrentMetricTimeWindow();
+  }
+
+  public void recordRejectedConnectionCount(int rejectedConnectionCount) {
+    this.rejectedConnectionCountSensor.record(rejectedConnectionCount);
   }
 
   /**


### PR DESCRIPTION
## Problem Statement
Missing a metric for rejected connection, which should be easier for
setting up alerts.


## Solution
A rate metric is added when connections are rejected due to breaching limit.
Metric name: rejected_connection_count


###  Code changes
- [ ] Added new code behind **a config**. If so list the config names and their default values in the PR description.
- [ ] Introduced new **log lines**. 
 - [ ] Confirmed if logs need to be **rate limited** to avoid excessive logging.

###  **Concurrency-Specific Checks**
Both reviewer and PR author to verify
- [ ] Code has **no race conditions** or **thread safety issues**.
- [ ] Proper **synchronization mechanisms** (e.g., `synchronized`, `RWLock`) are used where needed.
- [ ] No **blocking calls** inside critical sections that could lead to deadlocks or performance degradation.
- [ ] Verified **thread-safe collections** are used (e.g., `ConcurrentHashMap`, `CopyOnWriteArrayList`).
- [ ] Validated proper exception handling in multi-threaded code to avoid silent thread termination.


## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->

- [ ] New unit tests added.
- [x] New integration tests added.
- [ ] Modified or extended existing tests.
- [ ] Verified backward compatibility (if applicable).

## Does this PR introduce any user-facing or breaking changes?
<!--  
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Clearly explain the behavior change and its impact.