### PR TITLE
[controller] Add leader discovery for parent helix admin for updateAdminOperationProtocolVersion API

### DIFF
--- a/internal/venice-client-common/src/main/java/com/linkedin/venice/exceptions/VeniceProtocolException.java
+++ b/internal/venice-client-common/src/main/java/com/linkedin/venice/exceptions/VeniceProtocolException.java
@@ -5,4 +5,8 @@ public class VeniceProtocolException extends VeniceException {
     super(message);
     super.errorType = ErrorType.PROTOCOL_ERROR;
   }
+
+  public VeniceProtocolException(String message, Throwable throwable) {
+    super(message, throwable, ErrorType.PROTOCOL_ERROR);
+  }
 }

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/controller/kafka/consumer/AdminConsumptionTaskIntegrationTest.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/controller/kafka/consumer/AdminConsumptionTaskIntegrationTest.java
@@ -217,8 +217,8 @@ public class AdminConsumptionTaskIntegrationTest {
 
     String clusterName = venice.getClusterNames()[0];
 
-    // Get the child controller
-    VeniceControllerWrapper controller = venice.getChildRegions().get(0).getLeaderController(clusterName);
+    // Get the parent controller
+    VeniceControllerWrapper controller = venice.getParentControllers().get(0);
     Admin admin = controller.getVeniceAdmin();
 
     AdminConsumerService adminConsumerService = controller.getAdminConsumerServiceByCluster(clusterName);

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceHelixAdmin.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceHelixAdmin.java
@@ -7582,11 +7582,11 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
   }
 
   /**
-   * Update the version of admin operation protocol in admin topic metadata
+   * Unsupported operation in the child controller.
    */
   public void updateAdminOperationProtocolVersion(String clusterName, Long adminOperationProtocolVersion) {
-    getAdminConsumerService(clusterName)
-        .updateAdminOperationProtocolVersion(clusterName, adminOperationProtocolVersion);
+    throw new VeniceUnsupportedOperationException(
+        "updateAdminOperationProtocolVersion is not supported for child controller");
   }
 
   /**

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceParentHelixAdmin.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceParentHelixAdmin.java
@@ -4371,7 +4371,9 @@ public class VeniceParentHelixAdmin implements Admin {
    */
   @Override
   public void updateAdminOperationProtocolVersion(String clusterName, Long adminOperationProtocolVersion) {
-    getVeniceHelixAdmin().updateAdminOperationProtocolVersion(clusterName, adminOperationProtocolVersion);
+    getVeniceHelixAdmin().checkControllerLeadershipFor(clusterName);
+    getVeniceHelixAdmin().getAdminConsumerService(clusterName)
+        .updateAdminOperationProtocolVersion(clusterName, adminOperationProtocolVersion);
   }
 
   /**

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/kafka/protocol/serializer/AdminOperationSerializer.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/kafka/protocol/serializer/AdminOperationSerializer.java
@@ -2,7 +2,7 @@ package com.linkedin.venice.controller.kafka.protocol.serializer;
 
 import com.linkedin.avroutil1.compatibility.AvroCompatibilityHelper;
 import com.linkedin.venice.controller.kafka.protocol.admin.AdminOperation;
-import com.linkedin.venice.exceptions.VeniceMessageException;
+import com.linkedin.venice.exceptions.VeniceProtocolException;
 import com.linkedin.venice.serialization.avro.AvroProtocolDefinition;
 import com.linkedin.venice.utils.Utils;
 import java.io.ByteArrayInputStream;
@@ -85,7 +85,7 @@ public class AdminOperationSerializer {
       GenericRecord genericRecord = datumReader.read(null, decoder);
       return serialize(genericRecord, targetSchema, targetSchemaId);
     } catch (IOException e) {
-      throw new VeniceMessageException(
+      throw new VeniceProtocolException(
           "Could not deserialize bytes back into GenericRecord object with reader version: " + targetSchema,
           e);
     }
@@ -99,7 +99,7 @@ public class AdminOperationSerializer {
     try {
       return reader.read(null, decoder);
     } catch (IOException e) {
-      throw new VeniceMessageException(
+      throw new VeniceProtocolException(
           "Could not deserialize bytes back into AdminOperation object with schema id: " + writerSchemaId,
           e);
     }
@@ -113,13 +113,13 @@ public class AdminOperationSerializer {
       }
       return protocolSchemaMap;
     } catch (IOException e) {
-      throw new VeniceMessageException("Could not initialize " + AdminOperationSerializer.class.getSimpleName(), e);
+      throw new VeniceProtocolException("Could not initialize " + AdminOperationSerializer.class.getSimpleName(), e);
     }
   }
 
   public static Schema getSchema(int schemaId) {
     if (!PROTOCOL_MAP.containsKey(schemaId)) {
-      throw new VeniceMessageException("Admin operation schema version: " + schemaId + " doesn't exist");
+      throw new VeniceProtocolException("Admin operation schema version: " + schemaId + " doesn't exist");
     }
     return PROTOCOL_MAP.get(schemaId);
   }
@@ -136,7 +136,7 @@ public class AdminOperationSerializer {
       encoder.flush();
       return byteArrayOutputStream.toByteArray();
     } catch (IOException e) {
-      throw new VeniceMessageException(
+      throw new VeniceProtocolException(
           "Could not serialize object: " + object.getClass().getTypeName() + " with writer schema id: "
               + writerSchemaId,
           e);

--- a/services/venice-controller/src/test/java/com/linkedin/venice/controller/TestVeniceHelixAdmin.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/controller/TestVeniceHelixAdmin.java
@@ -1028,17 +1028,4 @@ public class TestVeniceHelixAdmin {
     verify(executionIdAccessor, never()).updateLastSucceededExecutionId(anyString(), anyLong());
     verify(adminConsumerService, times(1)).updateAdminTopicMetadata(clusterName, executionId, offset, upstreamOffset);
   }
-
-  @Test
-  public void testUpdateAdminOperationProtocolVersion() {
-    String clusterName = "test-cluster";
-    Long adminProtocolVersion = 10L;
-    VeniceHelixAdmin veniceHelixAdmin = mock(VeniceHelixAdmin.class);
-    doCallRealMethod().when(veniceHelixAdmin).updateAdminOperationProtocolVersion(clusterName, adminProtocolVersion);
-    AdminConsumerService adminConsumerService = mock(AdminConsumerService.class);
-    when(veniceHelixAdmin.getAdminConsumerService(clusterName)).thenReturn(adminConsumerService);
-
-    veniceHelixAdmin.updateAdminOperationProtocolVersion(clusterName, adminProtocolVersion);
-    verify(adminConsumerService, times(1)).updateAdminOperationProtocolVersion(clusterName, adminProtocolVersion);
-  }
 }

--- a/services/venice-controller/src/test/java/com/linkedin/venice/controller/TestVeniceParentHelixAdmin.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/controller/TestVeniceParentHelixAdmin.java
@@ -28,6 +28,7 @@ import static org.testng.Assert.assertTrue;
 import com.linkedin.venice.common.VeniceSystemStoreUtils;
 import com.linkedin.venice.compression.CompressionStrategy;
 import com.linkedin.venice.controller.kafka.AdminTopicUtils;
+import com.linkedin.venice.controller.kafka.consumer.AdminConsumerService;
 import com.linkedin.venice.controller.kafka.consumer.AdminConsumptionTask;
 import com.linkedin.venice.controller.kafka.protocol.admin.AdminOperation;
 import com.linkedin.venice.controller.kafka.protocol.admin.DeleteStore;
@@ -3205,6 +3206,22 @@ public class TestVeniceParentHelixAdmin extends AbstractTestVeniceParentHelixAdm
           -1,
           DEFAULT_RT_VERSION_NUMBER);
     }
+  }
+
+  @Test
+  public void testUpdateAdminOperationProtocolVersion() {
+    String clusterName = "test-cluster";
+    Long adminProtocolVersion = 10L;
+    VeniceParentHelixAdmin veniceParentHelixAdmin = mock(VeniceParentHelixAdmin.class);
+    VeniceHelixAdmin veniceHelixAdmin = mock(VeniceHelixAdmin.class);
+    when(veniceParentHelixAdmin.getVeniceHelixAdmin()).thenReturn(veniceHelixAdmin);
+    doCallRealMethod().when(veniceParentHelixAdmin)
+        .updateAdminOperationProtocolVersion(clusterName, adminProtocolVersion);
+    AdminConsumerService adminConsumerService = mock(AdminConsumerService.class);
+    when(veniceHelixAdmin.getAdminConsumerService(clusterName)).thenReturn(adminConsumerService);
+
+    veniceParentHelixAdmin.updateAdminOperationProtocolVersion(clusterName, adminProtocolVersion);
+    verify(adminConsumerService, times(1)).updateAdminOperationProtocolVersion(clusterName, adminProtocolVersion);
   }
 
   private Store setupForStoreViewConfigUpdateTest(String storeName) {

--- a/services/venice-controller/src/test/java/com/linkedin/venice/controller/kafka/protocol/admin/AdminOperationSerializerTest.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/controller/kafka/protocol/admin/AdminOperationSerializerTest.java
@@ -11,7 +11,6 @@ import static org.testng.Assert.expectThrows;
 
 import com.linkedin.venice.controller.kafka.protocol.enums.AdminMessageType;
 import com.linkedin.venice.controller.kafka.protocol.serializer.AdminOperationSerializer;
-import com.linkedin.venice.exceptions.VeniceMessageException;
 import com.linkedin.venice.exceptions.VeniceProtocolException;
 import java.nio.ByteBuffer;
 import java.util.Collections;
@@ -24,9 +23,9 @@ public class AdminOperationSerializerTest {
 
   @Test
   public void testGetSchema() {
-    expectThrows(VeniceMessageException.class, () -> AdminOperationSerializer.getSchema(0));
+    expectThrows(VeniceProtocolException.class, () -> AdminOperationSerializer.getSchema(0));
     expectThrows(
-        VeniceMessageException.class,
+        VeniceProtocolException.class,
         () -> AdminOperationSerializer.getSchema(AdminOperationSerializer.LATEST_SCHEMA_ID_FOR_ADMIN_OPERATION + 1));
   }
 


### PR DESCRIPTION
[controller] Add leader discovery for parent helix admin

## Problem Statement
- Currently, `updateAdminOperationProtocolVersion` API will not fail if the request is sent to non-leader, which can cause the racing issue if Helix has a state transfer in the middle of the request.
- `updateAdminOperationProtocolVersion` for child controller is not necessary since we never try to consume the config from child controller.


## Solution
- Add leader discovery for parent helix admin for updateAdminOperationProtocolVersion API to allow us to fail if the current parent controller is not leader.
- Removing support for `updateAdminOperationProtocolVersion` in child controller
- Convert all execeptions in AdminOperationSerializer to `VeniceProtocolException`

###  Code changes
- [ ] Added new code behind **a config**. If so list the config names and their default values in the PR description.
- [ ] Introduced new **log lines**. 
  - [ ] Confirmed if logs need to be **rate limited** to avoid excessive logging.

###  **Concurrency-Specific Checks**
Both reviewer and PR author to verify
- [ ] Code has **no race conditions** or **thread safety issues**.
- [ ] Proper **synchronization mechanisms** (e.g., `synchronized`, `RWLock`) are used where needed.
- [ ] No **blocking calls** inside critical sections that could lead to deadlocks or performance degradation.
- [ ] Verified **thread-safe collections** are used (e.g., `ConcurrentHashMap`, `CopyOnWriteArrayList`).
- [ ] Validated proper exception handling in multi-threaded code to avoid silent thread termination.


## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->

- [ ] New unit tests added.
- [ ] New integration tests added.
- [x] Modified or extended existing tests.
- [ ] Verified backward compatibility (if applicable).

## Does this PR introduce any user-facing or breaking changes?
<!--  
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Clearly explain the behavior change and its impact.