### PR TITLE
[vpj] Return Zstd configs after initialization

### DIFF
--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/DefaultInputDataInfoProvider.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/DefaultInputDataInfoProvider.java
@@ -159,11 +159,12 @@ public class DefaultInputDataInfoProvider implements InputDataInfoProvider {
   }
 
   @Override
-  public void initZstdConfig(int numFiles) {
+  public PushJobZstdConfig initZstdConfig(int numFiles) {
     if (pushJobZstdConfig != null) {
-      return;
+      return pushJobZstdConfig;
     }
     pushJobZstdConfig = new PushJobZstdConfig(props, numFiles);
+    return pushJobZstdConfig;
   }
 
   // Vson-based file store key / value schema string as separated properties in file header

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/InputDataInfoProvider.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/InputDataInfoProvider.java
@@ -61,7 +61,7 @@ public interface InputDataInfoProvider extends Closeable {
 
   InputDataInfo validateInputAndGetInfo(String inputUri) throws Exception;
 
-  void initZstdConfig(int numFiles);
+  PushJobZstdConfig initZstdConfig(int numFiles);
 
   /**
    * This function loads training samples from recordReader abstraction for building the Zstd dictionary.

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/KafkaInputDataInfoProvider.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/KafkaInputDataInfoProvider.java
@@ -30,7 +30,7 @@ public class KafkaInputDataInfoProvider implements InputDataInfoProvider {
   }
 
   @Override
-  public void initZstdConfig(int numFiles) {
+  public PushJobZstdConfig initZstdConfig(int numFiles) {
     throw new VeniceUnsupportedOperationException("Zstd for KafkaInputDataInfoProvider");
   }
 


### PR DESCRIPTION
<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat], [protocol]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## Problem Statement
<!--
Describe
- What problem are you trying to solve
- What issues or limitations exist in the current code
- Why this change is necessary 
-->
In a previous PR, we made the `pushJobZstdConfig` field private, and it broke an internal consumer using this field. Ideally, we should not be relying on member variables to open access for some custom implementations.

## Solution
<!--
Describe
- What changes you are making and why. 
- How these changes solve the problem.
- Any performance considerations or trade-offs. 
- Describe what testings you have done, for example, performance testing etc.
-->
This change makes the `initZstdConfig` function return the `pushJobZstdConfig` object so the caller has a handle on the object.

This change is backwards compatible because a `void` function now returns an object. Since it was previously `void`, it is guaranteed that no one is expecting any value to be returned.

###  Code changes
- [ ] Added new code behind **a config**. If so list the config names and their default values in the PR description.
- [ ] Introduced new **log lines**. 
  - [X] Confirmed if logs need to be **rate limited** to avoid excessive logging.

###  **Concurrency-Specific Checks**
Both reviewer and PR author to verify
- [x] Code has **no race conditions** or **thread safety issues**.
- [x] Proper **synchronization mechanisms** (e.g., `synchronized`, `RWLock`) are used where needed.
- [x] No **blocking calls** inside critical sections that could lead to deadlocks or performance degradation.
- [x] Verified **thread-safe collections** are used (e.g., `ConcurrentHashMap`, `CopyOnWriteArrayList`).
- [x] Validated proper exception handling in multi-threaded code to avoid silent thread termination.


## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->

- [ ] New unit tests added.
- [ ] New integration tests added.
- [ ] Modified or extended existing tests.
- [x] Verified backward compatibility (if applicable).

## Does this PR introduce any user-facing or breaking changes?
<!--  
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Clearly explain the behavior change and its impact.