### PR TITLE
[controller] Check dvc heartbeat in all regions & update version swap logic for deferred swap service

### DIFF
--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/VenicePushJob.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/VenicePushJob.java
@@ -806,7 +806,7 @@ public class VenicePushJob implements AutoCloseable {
             pushJobSetting,
             pushJobSetting.targetedRegions,
             pushJobSetting.isTargetedRegionPushEnabled,
-            false);
+            pushJobSetting.isTargetRegionPushWithDeferredSwapEnabled);
       }
 
       updatePushJobDetailsWithCheckpoint(PushJobCheckpoints.JOB_STATUS_POLLING_COMPLETED);

--- a/internal/venice-common/src/main/java/com/linkedin/venice/meta/VersionStatus.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/meta/VersionStatus.java
@@ -8,24 +8,51 @@ import java.util.Map;
 
 
 /**
- * Enums of status of verion.
+ * Enums of status of version.
  */
 public enum VersionStatus implements VeniceEnumValue {
-  NOT_CREATED(0), STARTED(1),
-  // Version has been pushed to venice(offline job related to this version has been completed), but is not ready to
-  // serve read request because the writes to this store is disabled.
+  /**
+   * This version hasn't been created yet. It is not persisted in ZK
+   */
+  NOT_CREATED(0),
+
+  /**
+   * Version has been pushed to venice(offline job related to this version has been completed), but is not ready to
+   * serve read request because the writes to this store is disabled
+   */
+  STARTED(1),
+
+  /**
+   * Version has been pushed to venice and is ready to serve read request. Intermediate status after a push job succeeds before DeferredVersionSwapService
+   * flips the status to ONLINE. This status only exists in the parent
+   */
   PUSHED(2),
-  // Version has been pushed to venice and is ready to serve read request.
+
+  /**
+   * Version is serving read requests
+   */
   ONLINE(3),
-  // Version is created and persisted inside ZK, but controller hasn't finished preparation works yet.
+
+  /**
+   * Version is not serving read requests, and it's relevant push job has failed
+   */
   ERROR(4),
-  // Version is created and persisted inside ZK, but controller hasn't finished preparation works yet.
-  // For parent version status, ERROR also means that push failed in all regions, and it is not being served
+
+  /**
+   * Version is created and persisted inside ZK. Currently not used
+   */
   CREATED(5),
-  // Version has been pushed to Venice and is ready to serve in some regions, but failed in other regions.
-  // This version status only exists in parent.
+
+  /**
+   * Version has been pushed to Venice and is serving read traffic in some regions, but failed in other regions.
+   * This status only exists in the parent
+   */
   PARTIALLY_ONLINE(6),
-  // This version has been killed.
+
+  /**
+   * Version is killed. Intermediate status after a push job is killed or fails before DeferredVersionSwapService flips the status to
+   * either ERROR or PARTIALLY_ONLINE
+   */
   KILLED(7);
 
   private final int value;

--- a/internal/venice-common/src/main/java/com/linkedin/venice/meta/VersionStatus.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/meta/VersionStatus.java
@@ -16,8 +16,11 @@ public enum VersionStatus implements VeniceEnumValue {
   // serve read request because the writes to this store is disabled.
   PUSHED(2),
   // Version has been pushed to venice and is ready to serve read request.
-  ONLINE(3), ERROR(4),
+  ONLINE(3),
   // Version is created and persisted inside ZK, but controller hasn't finished preparation works yet.
+  ERROR(4),
+  // Version is created and persisted inside ZK, but controller hasn't finished preparation works yet.
+  // For parent version status, ERROR also means that push failed in all regions, and it is not being served
   CREATED(5),
   // Version has been pushed to Venice and is ready to serve in some regions, but failed in other regions.
   // This version status only exists in parent.

--- a/internal/venice-common/src/main/java/com/linkedin/venice/meta/VersionStatus.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/meta/VersionStatus.java
@@ -17,14 +17,13 @@ public enum VersionStatus implements VeniceEnumValue {
   NOT_CREATED(0),
 
   /**
-   * Version has been pushed to venice(offline job related to this version has been completed), but is not ready to
-   * serve read request because the writes to this store is disabled
+   * Version has been created and started to ingest new data, but has not completed ingestion and is not ready to serve read traffic
    */
   STARTED(1),
 
   /**
-   * Version has been pushed to venice and is ready to serve read request. Intermediate status after a push job succeeds before DeferredVersionSwapService
-   * flips the status to ONLINE. This status only exists in the parent
+   * Version has been pushed to venice and is ready to serve read request. Intermediate status after a push job succeeds in all child regions
+   * before DeferredVersionSwapService flips the status to ONLINE. This status only exists in the parent
    */
   PUSHED(2),
 

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestDeferredVersionSwap.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestDeferredVersionSwap.java
@@ -254,7 +254,6 @@ public class TestDeferredVersionSwap {
 
       // Start push job with target region push enabled and check that it fails
       props.put(TARGETED_REGION_PUSH_WITH_DEFERRED_SWAP, true);
-      props.put(TARGETED_REGION_PUSH_LIST, REGION3);
       try {
         TestWriteUtils.runPushJob("Test push job", props);
       } catch (Exception e) {
@@ -284,7 +283,7 @@ public class TestDeferredVersionSwap {
 
       TestUtils.waitForNonDeterministicAssertion(30, TimeUnit.SECONDS, () -> {
         StoreInfo parentStore = parentControllerClient.getStore(storeName).getStore();
-        Assert.assertEquals(parentStore.getVersion(1).get().getStatus(), VersionStatus.ERROR);
+        Assert.assertEquals(parentStore.getVersion(1).get().getStatus(), VersionStatus.PARTIALLY_ONLINE);
       });
 
       // Verify that we can create a new version
@@ -418,7 +417,6 @@ public class TestDeferredVersionSwap {
 
       // Start push job with target region push enabled
       props.put(TARGETED_REGION_PUSH_WITH_DEFERRED_SWAP, true);
-      props.put(TARGETED_REGION_PUSH_LIST, REGION1);
       TestWriteUtils.runPushJob("Test push job", props);
       TestUtils.waitForNonDeterministicPushCompletion(
           Version.composeKafkaTopic(storeName, 1),
@@ -432,7 +430,7 @@ public class TestDeferredVersionSwap {
             parentControllerClient.getStore(storeName).getStore().getColoToCurrentVersions();
 
         coloVersions.forEach((colo, version) -> {
-          if (colo.equals(REGION1)) {
+          if (colo.equals(REGION3)) {
             Assert.assertEquals((int) version, 1);
           } else {
             Assert.assertEquals((int) version, 0);

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestDeferredVersionSwap.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestDeferredVersionSwap.java
@@ -373,7 +373,7 @@ public class TestDeferredVersionSwap {
         });
         TestUtils.waitForNonDeterministicAssertion(30, TimeUnit.SECONDS, () -> {
           StoreInfo parentStore = parentControllerClient.getStore(storeName).getStore();
-          Assert.assertEquals(parentStore.getVersion(1).get().getStatus(), VersionStatus.ERROR);
+          Assert.assertEquals(parentStore.getVersion(1).get().getStatus(), VersionStatus.PARTIALLY_ONLINE);
         });
       }
 

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestDeferredVersionSwap.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestDeferredVersionSwap.java
@@ -284,7 +284,7 @@ public class TestDeferredVersionSwap {
 
       TestUtils.waitForNonDeterministicAssertion(30, TimeUnit.SECONDS, () -> {
         StoreInfo parentStore = parentControllerClient.getStore(storeName).getStore();
-        Assert.assertEquals(parentStore.getVersion(1).get().getStatus(), VersionStatus.PARTIALLY_ONLINE);
+        Assert.assertEquals(parentStore.getVersion(1).get().getStatus(), VersionStatus.ERROR);
       });
 
       // Verify that we can create a new version
@@ -373,7 +373,7 @@ public class TestDeferredVersionSwap {
         });
         TestUtils.waitForNonDeterministicAssertion(30, TimeUnit.SECONDS, () -> {
           StoreInfo parentStore = parentControllerClient.getStore(storeName).getStore();
-          Assert.assertEquals(parentStore.getVersion(1).get().getStatus(), VersionStatus.PARTIALLY_ONLINE);
+          Assert.assertEquals(parentStore.getVersion(1).get().getStatus(), VersionStatus.ERROR);
         });
       }
 

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestDeferredVersionSwap.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestDeferredVersionSwap.java
@@ -9,10 +9,13 @@ import static com.linkedin.venice.utils.TestWriteUtils.getTempDataDirectory;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.TARGETED_REGION_PUSH_LIST;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.TARGETED_REGION_PUSH_WITH_DEFERRED_SWAP;
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
 
 import com.linkedin.venice.controllerapi.ControllerClient;
 import com.linkedin.venice.controllerapi.JobStatusQueryResponse;
 import com.linkedin.venice.controllerapi.UpdateStoreQueryParams;
+import com.linkedin.venice.controllerapi.VersionCreationResponse;
+import com.linkedin.venice.exceptions.VeniceException;
 import com.linkedin.venice.integration.utils.ServiceFactory;
 import com.linkedin.venice.integration.utils.VeniceMultiRegionClusterCreateOptions;
 import com.linkedin.venice.integration.utils.VeniceTwoLayerMultiRegionMultiClusterWrapper;
@@ -21,27 +24,33 @@ import com.linkedin.venice.meta.Version;
 import com.linkedin.venice.meta.VersionStatus;
 import com.linkedin.venice.pushmonitor.ExecutionStatus;
 import com.linkedin.venice.utils.IntegrationTestPushUtils;
+import com.linkedin.venice.utils.RegionUtils;
 import com.linkedin.venice.utils.TestUtils;
 import com.linkedin.venice.utils.TestWriteUtils;
 import com.linkedin.venice.utils.Utils;
 import java.io.File;
 import java.io.IOException;
+import java.util.HashSet;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Properties;
+import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.IntStream;
 import org.testng.Assert;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
+import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 
 public class TestDeferredVersionSwap {
-  private static final int NUMBER_OF_CHILD_DATACENTERS = 2;
+  private static final int NUMBER_OF_CHILD_DATACENTERS = 3;
   private static final int NUMBER_OF_CLUSTERS = 1;
   private VeniceTwoLayerMultiRegionMultiClusterWrapper multiRegionMultiClusterWrapper;
-  private static final String TARGET_REGION = "dc-0";
+  private static final String REGION1 = "dc-0";
+  private static final String REGION2 = "dc-1";
+  private static final String REGION3 = "dc-2";
   private static final String[] CLUSTER_NAMES =
       IntStream.range(0, NUMBER_OF_CLUSTERS).mapToObj(i -> "venice-cluster" + i).toArray(String[]::new);
   private static final int TEST_TIMEOUT = 120_000;
@@ -74,8 +83,21 @@ public class TestDeferredVersionSwap {
     Utils.closeQuietlyWithErrorLogged(multiRegionMultiClusterWrapper);
   }
 
-  @Test(timeOut = TEST_TIMEOUT)
-  public void testDeferredVersionSwap() throws IOException {
+  @DataProvider(name = "regionsProvider")
+  public Object[][] regionsProvider() {
+    Set<String> singleRegion = new HashSet<>();
+    singleRegion.add(REGION1);
+
+    Set<String> twoRegions = new HashSet<>();
+    twoRegions.add(REGION1);
+    twoRegions.add(REGION2);
+
+    return new Object[][] { { RegionUtils.composeRegionList(singleRegion) },
+        { RegionUtils.composeRegionList(twoRegions) }, };
+  }
+
+  @Test(timeOut = TEST_TIMEOUT, dataProvider = "regionsProvider")
+  public void testDeferredVersionSwap(String targetRegions) throws IOException {
     File inputDir = getTempDataDirectory();
     TestWriteUtils.writeSimpleAvroFileWithStringToV3Schema(inputDir, 100, 100);
     // Setup job properties
@@ -87,13 +109,14 @@ public class TestDeferredVersionSwap {
     UpdateStoreQueryParams storeParms = new UpdateStoreQueryParams().setUnusedSchemaDeletionEnabled(true);
     storeParms.setTargetRegionSwapWaitTime(1);
     String parentControllerURLs = multiRegionMultiClusterWrapper.getControllerConnectString();
+    Set<String> targetRegionsList = RegionUtils.parseRegionsFilterList(targetRegions);
 
     try (ControllerClient parentControllerClient = new ControllerClient(CLUSTER_NAMES[0], parentControllerURLs)) {
       createStoreForJob(CLUSTER_NAMES[0], keySchemaStr, NAME_RECORD_V3_SCHEMA.toString(), props, storeParms).close();
 
       // Start push job with target region push enabled
       props.put(TARGETED_REGION_PUSH_WITH_DEFERRED_SWAP, true);
-      props.put(TARGETED_REGION_PUSH_LIST, TARGET_REGION);
+      props.put(TARGETED_REGION_PUSH_LIST, targetRegions);
       TestWriteUtils.runPushJob("Test push job", props);
       TestUtils.waitForNonDeterministicPushCompletion(
           Version.composeKafkaTopic(storeName, 1),
@@ -107,7 +130,7 @@ public class TestDeferredVersionSwap {
             parentControllerClient.getStore(storeName).getStore().getColoToCurrentVersions();
 
         coloVersions.forEach((colo, version) -> {
-          if (colo.equals(TARGET_REGION)) {
+          if (targetRegionsList.contains(colo)) {
             Assert.assertEquals((int) version, 1);
           } else {
             Assert.assertEquals((int) version, 0);
@@ -137,8 +160,8 @@ public class TestDeferredVersionSwap {
     }
   }
 
-  @Test(timeOut = TEST_TIMEOUT)
-  public void testDeferredVersionSwapMultiplePushes() throws IOException {
+  @Test(timeOut = TEST_TIMEOUT, dataProvider = "regionsProvider")
+  public void testDeferredVersionSwapMultiplePushes(String targetRegions) throws IOException {
     File inputDir = getTempDataDirectory();
     TestWriteUtils.writeSimpleAvroFileWithStringToV3Schema(inputDir, 100, 100);
     // Setup job properties
@@ -150,13 +173,14 @@ public class TestDeferredVersionSwap {
     UpdateStoreQueryParams storeParms = new UpdateStoreQueryParams().setUnusedSchemaDeletionEnabled(true);
     storeParms.setTargetRegionSwapWaitTime(1);
     String parentControllerURLs = multiRegionMultiClusterWrapper.getControllerConnectString();
+    Set<String> targetRegionsList = RegionUtils.parseRegionsFilterList(targetRegions);
 
     try (ControllerClient parentControllerClient = new ControllerClient(CLUSTER_NAMES[0], parentControllerURLs)) {
       createStoreForJob(CLUSTER_NAMES[0], keySchemaStr, NAME_RECORD_V3_SCHEMA.toString(), props, storeParms).close();
 
       // Start push job with target region push enabled
       props.put(TARGETED_REGION_PUSH_WITH_DEFERRED_SWAP, true);
-      props.put(TARGETED_REGION_PUSH_LIST, TARGET_REGION);
+      props.put(TARGETED_REGION_PUSH_LIST, targetRegions);
       TestWriteUtils.runPushJob("Test push job", props);
       TestUtils.waitForNonDeterministicPushCompletion(
           Version.composeKafkaTopic(storeName, 1),
@@ -170,7 +194,7 @@ public class TestDeferredVersionSwap {
             parentControllerClient.getStore(storeName).getStore().getColoToCurrentVersions();
 
         coloVersions.forEach((colo, version) -> {
-          if (colo.equals(TARGET_REGION)) {
+          if (targetRegionsList.contains(colo)) {
             Assert.assertEquals((int) version, 1);
           } else {
             Assert.assertEquals((int) version, 0);
@@ -205,16 +229,19 @@ public class TestDeferredVersionSwap {
     }
   }
 
-  @Test(timeOut = TEST_TIMEOUT * 2)
-  public void testDeferredVersionSwapWithFailedPush() throws IOException {
-    // Always mark the status as ERROR for dc-1 to mimic a push failing
-    multiRegionMultiClusterWrapper.failPushInRegion("dc-1");
+  @Test(timeOut = TEST_TIMEOUT * 2, dataProvider = "regionsProvider")
+  public void testDeferredVersionSwapWithFailedPushInNonTargetRegions(String failingRegions) throws IOException {
+    // Always mark the status as ERROR in regions
+    Set<String> failingRegionsList = RegionUtils.parseRegionsFilterList(failingRegions);
+    for (String failingRegion: failingRegionsList) {
+      multiRegionMultiClusterWrapper.failPushInRegion(failingRegion);
+    }
 
     // Setup job properties
     File inputDir = getTempDataDirectory();
     TestWriteUtils.writeSimpleAvroFileWithStringToV3Schema(inputDir, 100, 100);
     String inputDirPath = "file://" + inputDir.getAbsolutePath();
-    String storeName = Utils.getUniqueString("testDeferredVersionSwapMultiplePushes");
+    String storeName = Utils.getUniqueString("testDeferredVersionSwapWithFailedPushInNonTargetRegions");
     Properties props =
         IntegrationTestPushUtils.defaultVPJProps(multiRegionMultiClusterWrapper, inputDirPath, storeName);
     String keySchemaStr = "\"string\"";
@@ -225,10 +252,14 @@ public class TestDeferredVersionSwap {
     try (ControllerClient parentControllerClient = new ControllerClient(CLUSTER_NAMES[0], parentControllerURLs)) {
       createStoreForJob(CLUSTER_NAMES[0], keySchemaStr, NAME_RECORD_V3_SCHEMA.toString(), props, storeParms).close();
 
-      // Start push job with target region push enabled
+      // Start push job with target region push enabled and check that it fails
       props.put(TARGETED_REGION_PUSH_WITH_DEFERRED_SWAP, true);
-      props.put(TARGETED_REGION_PUSH_LIST, TARGET_REGION);
-      TestWriteUtils.runPushJob("Test push job", props);
+      props.put(TARGETED_REGION_PUSH_LIST, REGION3);
+      try {
+        TestWriteUtils.runPushJob("Test push job", props);
+      } catch (Exception e) {
+        assertEquals(e.getClass(), VeniceException.class);
+      }
 
       // Wait for job to fail
       TestUtils.waitForNonDeterministicAssertion(1, TimeUnit.MINUTES, true, () -> {
@@ -238,14 +269,129 @@ public class TestDeferredVersionSwap {
         assertEquals(executionStatus, ExecutionStatus.ERROR);
       });
 
-      // Verify that we can run another push
-      TestWriteUtils.runPushJob("Test push job 2", props);
+      TestUtils.waitForNonDeterministicAssertion(1, TimeUnit.MINUTES, () -> {
+        Map<String, Integer> coloVersions =
+            parentControllerClient.getStore(storeName).getStore().getColoToCurrentVersions();
+
+        coloVersions.forEach((colo, version) -> {
+          if (!failingRegionsList.contains(colo)) {
+            Assert.assertEquals((int) version, 1);
+          } else {
+            Assert.assertEquals((int) version, 0);
+          }
+        });
+      });
+
+      TestUtils.waitForNonDeterministicAssertion(30, TimeUnit.SECONDS, () -> {
+        StoreInfo parentStore = parentControllerClient.getStore(storeName).getStore();
+        Assert.assertEquals(parentStore.getVersion(1).get().getStatus(), VersionStatus.PARTIALLY_ONLINE);
+      });
+
+      // Verify that we can create a new version
+      VersionCreationResponse versionCreationResponse = parentControllerClient.requestTopicForWrites(
+          storeName,
+          1000,
+          Version.PushType.BATCH,
+          Version.guidBasedDummyPushId(),
+          true,
+          true,
+          false,
+          Optional.empty(),
+          Optional.empty(),
+          Optional.empty(),
+          false,
+          -1);
+      assertFalse(versionCreationResponse.isError());
+    }
+  }
+
+  @Test(timeOut = TEST_TIMEOUT * 2, dataProvider = "regionsProvider")
+  public void testDeferredVersionSwapWithFailedPushInTargetRegions(String failingRegions) throws IOException {
+    // Always mark the status as ERROR in regions
+    Set<String> failingRegionsList = RegionUtils.parseRegionsFilterList(failingRegions);
+    for (String failingRegion: failingRegionsList) {
+      multiRegionMultiClusterWrapper.failPushInRegion(failingRegion);
+    }
+
+    // Setup job properties
+    File inputDir = getTempDataDirectory();
+    TestWriteUtils.writeSimpleAvroFileWithStringToV3Schema(inputDir, 100, 100);
+    String inputDirPath = "file://" + inputDir.getAbsolutePath();
+    String storeName = Utils.getUniqueString("testDeferredVersionSwapWithFailedPushInTargetRegions");
+    Properties props =
+        IntegrationTestPushUtils.defaultVPJProps(multiRegionMultiClusterWrapper, inputDirPath, storeName);
+    String keySchemaStr = "\"string\"";
+    UpdateStoreQueryParams storeParms = new UpdateStoreQueryParams().setUnusedSchemaDeletionEnabled(true);
+    storeParms.setTargetRegionSwapWaitTime(1);
+    String parentControllerURLs = multiRegionMultiClusterWrapper.getControllerConnectString();
+
+    try (ControllerClient parentControllerClient = new ControllerClient(CLUSTER_NAMES[0], parentControllerURLs)) {
+      createStoreForJob(CLUSTER_NAMES[0], keySchemaStr, NAME_RECORD_V3_SCHEMA.toString(), props, storeParms).close();
+
+      // Start push job with target region push enabled and check that it fails
+      props.put(TARGETED_REGION_PUSH_WITH_DEFERRED_SWAP, true);
+      props.put(TARGETED_REGION_PUSH_LIST, REGION1 + ", " + REGION2);
+      try {
+        TestWriteUtils.runPushJob("Test push job", props);
+      } catch (Exception e) {
+        assertEquals(e.getClass(), VeniceException.class);
+      }
+
+      // Wait for job to fail
       TestUtils.waitForNonDeterministicAssertion(1, TimeUnit.MINUTES, true, () -> {
         JobStatusQueryResponse jobStatusQueryResponse = assertCommand(
             parentControllerClient.queryOverallJobStatus(Version.composeKafkaTopic(storeName, 1), Optional.empty()));
         ExecutionStatus executionStatus = ExecutionStatus.valueOf(jobStatusQueryResponse.getStatus());
         assertEquals(executionStatus, ExecutionStatus.ERROR);
       });
+
+      if (failingRegionsList.size() == 2) {
+        TestUtils.waitForNonDeterministicAssertion(1, TimeUnit.MINUTES, () -> {
+          Map<String, Integer> coloVersions =
+              parentControllerClient.getStore(storeName).getStore().getColoToCurrentVersions();
+
+          coloVersions.forEach((colo, version) -> {
+            Assert.assertEquals((int) version, 0);
+          });
+        });
+        TestUtils.waitForNonDeterministicAssertion(30, TimeUnit.SECONDS, () -> {
+          StoreInfo parentStore = parentControllerClient.getStore(storeName).getStore();
+          Assert.assertEquals(parentStore.getVersion(1).get().getStatus(), VersionStatus.ERROR);
+        });
+      } else if (failingRegionsList.size() == 1) {
+        TestUtils.waitForNonDeterministicAssertion(1, TimeUnit.MINUTES, () -> {
+          Map<String, Integer> coloVersions =
+              parentControllerClient.getStore(storeName).getStore().getColoToCurrentVersions();
+
+          coloVersions.forEach((colo, version) -> {
+            if (!failingRegionsList.contains(colo)) {
+              Assert.assertEquals((int) version, 1);
+            } else {
+              Assert.assertEquals((int) version, 0);
+            }
+          });
+        });
+        TestUtils.waitForNonDeterministicAssertion(30, TimeUnit.SECONDS, () -> {
+          StoreInfo parentStore = parentControllerClient.getStore(storeName).getStore();
+          Assert.assertEquals(parentStore.getVersion(1).get().getStatus(), VersionStatus.PARTIALLY_ONLINE);
+        });
+      }
+
+      // Verify that we can create a new version
+      VersionCreationResponse versionCreationResponse = parentControllerClient.requestTopicForWrites(
+          storeName,
+          1000,
+          Version.PushType.BATCH,
+          Version.guidBasedDummyPushId(),
+          true,
+          true,
+          false,
+          Optional.empty(),
+          Optional.empty(),
+          Optional.empty(),
+          false,
+          -1);
+      assertFalse(versionCreationResponse.isError());
     }
   }
 
@@ -272,7 +418,7 @@ public class TestDeferredVersionSwap {
 
       // Start push job with target region push enabled
       props.put(TARGETED_REGION_PUSH_WITH_DEFERRED_SWAP, true);
-      props.put(TARGETED_REGION_PUSH_LIST, TARGET_REGION);
+      props.put(TARGETED_REGION_PUSH_LIST, REGION1);
       TestWriteUtils.runPushJob("Test push job", props);
       TestUtils.waitForNonDeterministicPushCompletion(
           Version.composeKafkaTopic(storeName, 1),
@@ -286,7 +432,7 @@ public class TestDeferredVersionSwap {
             parentControllerClient.getStore(storeName).getStore().getColoToCurrentVersions();
 
         coloVersions.forEach((colo, version) -> {
-          if (colo.equals(TARGET_REGION)) {
+          if (colo.equals(REGION1)) {
             Assert.assertEquals((int) version, 1);
           } else {
             Assert.assertEquals((int) version, 0);

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/DeferredVersionSwapService.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/DeferredVersionSwapService.java
@@ -142,7 +142,6 @@ public class DeferredVersionSwapService extends AbstractVeniceService {
       if (targetRegionStoreResponse.isError()) {
         String message = "Got error when fetching targetRegionStore: " + targetRegionStoreResponse.getStore();
         logMessageIfNotRedundant(message);
-        return true;
       }
 
       StoreInfo targetRegionStore = targetRegionStoreResponse.getStore();
@@ -152,22 +151,25 @@ public class DeferredVersionSwapService extends AbstractVeniceService {
         String message =
             "Unable to find version " + targetVersionNum + " for store: " + storeName + " in region " + region;
         logMessageIfNotRedundant(message);
-        return false;
       }
 
-      if (version.get().getIsDavinciHeartbeatReported()) {
-        String message = "Skipping version swap for store: " + storeName + " on version: " + targetVersionNum
-            + " as there is a davinci heartbeat in region: " + region;
-        logMessageIfNotRedundant(message);
-        return true;
+      if (version.isPresent()) {
+        if (version.get().getIsDavinciHeartbeatReported()) {
+          String message = "Skipping version swap for store: " + storeName + " on version: " + targetVersionNum
+              + " as there is a davinci heartbeat in region: " + region;
+          logMessageIfNotRedundant(message);
+          return true;
+        }
       }
 
       // Check the previous version for a dvc heartbeat if we can't find the target version number
-      if (!version.isPresent() && previousVersion.get().getIsDavinciHeartbeatReported()) {
-        String message = "Skipping version swap for store: " + storeName + " on the previous version: "
-            + previousVersion.get().getNumber() + " as there is a davinci heartbeat in region: " + region;
-        logMessageIfNotRedundant(message);
-        return true;
+      if (!version.isPresent() && previousVersion.isPresent()) {
+        if (previousVersion.get().getIsDavinciHeartbeatReported()) {
+          String message = "Skipping version swap for store: " + storeName + " on the previous version: "
+              + previousVersion.get().getNumber() + " as there is a davinci heartbeat in region: " + region;
+          logMessageIfNotRedundant(message);
+          return true;
+        }
       }
     }
 

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/DeferredVersionSwapService.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/DeferredVersionSwapService.java
@@ -2,6 +2,7 @@ package com.linkedin.venice.controller;
 
 import static com.linkedin.venice.meta.VersionStatus.ERROR;
 import static com.linkedin.venice.meta.VersionStatus.ONLINE;
+import static com.linkedin.venice.meta.VersionStatus.PARTIALLY_ONLINE;
 
 import com.github.benmanes.caffeine.cache.Cache;
 import com.github.benmanes.caffeine.cache.Caffeine;
@@ -178,7 +179,7 @@ public class DeferredVersionSwapService extends AbstractVeniceService {
 
   /**
    * Roll forward to the specified version for a list of regions. Once the roll forward is done, traffic will be served from
-   * that version and the version status will be updated to ONLINE or ERROR
+   * that version and the version status will be updated to ONLINE or PARTIALLY_ONLINE
    * @param regions the list of regions to update the version status
    * @param store the store of the version to roll forward in
    * @param targetVersion the version to start serving traffic in
@@ -208,9 +209,12 @@ public class DeferredVersionSwapService extends AbstractVeniceService {
       repository.updateStore(store);
       LOGGER.info("Updated parent version status to ONLINE for version: {} in store: {}", targetVersionNum, storeName);
     } else {
-      store.updateVersionStatus(targetVersionNum, ERROR);
+      store.updateVersionStatus(targetVersionNum, VersionStatus.PARTIALLY_ONLINE);
       repository.updateStore(store);
-      LOGGER.info("Updated parent version status to ERROR for version: {} in store: {}", targetVersionNum, storeName);
+      LOGGER.info(
+          "Updated parent version status to PARTIALLY_ONLINE for version: {} in store: {}",
+          targetVersionNum,
+          storeName);
     }
   }
 
@@ -305,7 +309,7 @@ public class DeferredVersionSwapService extends AbstractVeniceService {
   /**
    * Gets a list of eligible regions to roll forward in. A region is eligible to be rolled forward if it's push status is
    * COMPLETED. If there are no eligible regions to roll forward in or if not all regions have reached a terminal status, null is
-   * returned and the version status is marked as ERROR as only the target regions are serving traffic from the new version
+   * returned and the version status is marked as PARTIALLY_ONLINE as only the target regions are serving traffic from the new version
    * @param nonTargetRegions list of regions to check eligibility for
    * @param pushStatusInfo wrapper containing push status information
    * @param repository repository to update store
@@ -327,7 +331,7 @@ public class DeferredVersionSwapService extends AbstractVeniceService {
           + "as push failed in all non target regions. Failed non target regions: " + failedNonTargetRegions
           + ", non target regions: " + nonTargetRegions;
       logMessageIfNotRedundant(message);
-      store.updateVersionStatus(targetVersionNum, ERROR);
+      store.updateVersionStatus(targetVersionNum, PARTIALLY_ONLINE);
       repository.updateStore(store);
       return null;
     } else if ((failedNonTargetRegions.size() + completedNonTargetRegions.size()) != nonTargetRegions.size()) {

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceParentHelixAdmin.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceParentHelixAdmin.java
@@ -1502,22 +1502,17 @@ public class VeniceParentHelixAdmin implements Admin {
     boolean isTargetRegionPushWithDeferredSwap = !StringUtils.isEmpty(targetedRegions) && versionSwapDeferred;
     if (isTargetRegionPushWithDeferredSwap) {
       validateTargetedRegions(targetedRegions, clusterName);
-      Set<String> targetRegions = RegionUtils.parseRegionsFilterList(targetedRegions);
-      StoreInfo childStore = getStoreInChildRegion(targetRegions.iterator().next(), clusterName, storeName);
-      Optional<Version> currentVersionInChild = childStore.getVersion(childStore.getCurrentVersion());
-      if (currentVersionInChild.isPresent()) {
-        boolean skipTargetRegionPushForDavinci = currentVersionInChild.get().getIsDavinciHeartbeatReported()
-            && multiClusterConfigs.isSkipDeferredVersionSwapForDVCEnabled();
-        if (skipTargetRegionPushForDavinci) {
-          LOGGER.info(
-              "Skip setting targetedRegions and versionSwapDeferred values for store: {} "
-                  + "because isSkipDeferredVersionSwapForDVCEnabled: {} and isDavinciHeartbeatReported: {}",
-              storeName,
-              multiClusterConfigs.isSkipDeferredVersionSwapForDVCEnabled(),
-              currentVersionInChild.get().getIsDavinciHeartbeatReported());
-          targetedRegions = "";
-          versionSwapDeferred = false;
-        }
+      boolean skipTargetRegionPushForDavinci = isDavinciHeartbeatReported(clusterName, storeName)
+          && multiClusterConfigs.isSkipDeferredVersionSwapForDVCEnabled();
+      if (skipTargetRegionPushForDavinci) {
+        LOGGER.info(
+            "Skip setting targetedRegions and versionSwapDeferred values for store: {} "
+                + "because isSkipDeferredVersionSwapForDVCEnabled: {} and isDavinciHeartbeatReported: {}",
+            storeName,
+            multiClusterConfigs.isSkipDeferredVersionSwapForDVCEnabled(),
+            isDavinciHeartbeatReported(clusterName, storeName));
+        targetedRegions = "";
+        versionSwapDeferred = false;
       }
     }
 
@@ -1635,6 +1630,26 @@ public class VeniceParentHelixAdmin implements Admin {
     }
 
     return newVersion;
+  }
+
+  /**
+   * Checks if there is a davinci heartbeat reported in any region for the current version
+   * @param clusterName name of the cluster the store is in
+   * @param storeName name of the store to check for a davinci heartbeat
+   * @return
+   */
+  private boolean isDavinciHeartbeatReported(String clusterName, String storeName) {
+    Map<String, ControllerClient> clientMap = getVeniceHelixAdmin().getControllerClientMap(clusterName);
+    for (String region: clientMap.keySet()) {
+      StoreInfo childStore = getStoreInChildRegion(region, clusterName, storeName);
+      Optional<Version> currentVersionInChild = childStore.getVersion(childStore.getCurrentVersion());
+      if (currentVersionInChild.isPresent()) {
+        if (currentVersionInChild.get().getIsDavinciHeartbeatReported()) {
+          return true;
+        }
+      }
+    }
+    return false;
   }
 
   /**
@@ -3774,6 +3789,7 @@ public class VeniceParentHelixAdmin implements Admin {
           }
           // status PUSHED is set when batch store's target region push is completed, but other region are yet to
           // complete
+          // somehow removing the outer if makes the status ERROR instead of KILLED
           if (currentReturnStatus.equals(ExecutionStatus.COMPLETED)) {
             if (isTargetRegionPush && !isVersionPushed) {
               parentStore.updateVersionStatus(versionNum, PUSHED);

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceParentHelixAdmin.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceParentHelixAdmin.java
@@ -1644,6 +1644,11 @@ public class VeniceParentHelixAdmin implements Admin {
       StoreInfo childStore = getStoreInChildRegion(region, clusterName, storeName);
       Optional<Version> currentVersionInChild = childStore.getVersion(childStore.getCurrentVersion());
       if (currentVersionInChild.isPresent()) {
+        LOGGER.info(
+            "isDavinciHeartbeatReported: {}, region: {}, storeName: {}",
+            currentVersionInChild.get().getIsDavinciHeartbeatReported(),
+            region,
+            storeName);
         if (currentVersionInChild.get().getIsDavinciHeartbeatReported()) {
           return true;
         }

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceParentHelixAdmin.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceParentHelixAdmin.java
@@ -3789,7 +3789,6 @@ public class VeniceParentHelixAdmin implements Admin {
           }
           // status PUSHED is set when batch store's target region push is completed, but other region are yet to
           // complete
-          // somehow removing the outer if makes the status ERROR instead of KILLED
           if (currentReturnStatus.equals(ExecutionStatus.COMPLETED)) {
             if (isTargetRegionPush && !isVersionPushed) {
               parentStore.updateVersionStatus(versionNum, PUSHED);

--- a/services/venice-controller/src/test/java/com/linkedin/venice/controller/TestDeferredVersionSwapService.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/controller/TestDeferredVersionSwapService.java
@@ -407,10 +407,10 @@ public class TestDeferredVersionSwapService {
 
       // one target region, 2 non target regions: one succeeded, one failed -> swap
       verify(admin, atLeast(1)).rollForwardToFutureVersion(clusterName, storeName3, region2);
-      verify(store3, atLeast(1)).updateVersionStatus(3, VersionStatus.ERROR);
+      verify(store3, atLeast(1)).updateVersionStatus(3, VersionStatus.PARTIALLY_ONLINE);
 
       // one target region, 2 non target regions: both failed -> do not swap
-      verify(store4, atLeast(1)).updateVersionStatus(3, VersionStatus.ERROR);
+      verify(store4, atLeast(1)).updateVersionStatus(3, VersionStatus.PARTIALLY_ONLINE);
 
       // one target region, 2 non target regions: one failed, one in progress -> do not swap
       verify(admin, never())
@@ -418,7 +418,7 @@ public class TestDeferredVersionSwapService {
 
       // two target regions: 1 completed, 1 failed, 1 completed non target region -> swap
       verify(admin, atLeast(1)).rollForwardToFutureVersion(clusterName, storeName6, region3);
-      verify(store6, atLeast(1)).updateVersionStatus(3, VersionStatus.ERROR);
+      verify(store6, atLeast(1)).updateVersionStatus(3, VersionStatus.PARTIALLY_ONLINE);
     });
   }
 

--- a/services/venice-controller/src/test/java/com/linkedin/venice/controller/TestDeferredVersionSwapService.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/controller/TestDeferredVersionSwapService.java
@@ -407,10 +407,10 @@ public class TestDeferredVersionSwapService {
 
       // one target region, 2 non target regions: one succeeded, one failed -> swap
       verify(admin, atLeast(1)).rollForwardToFutureVersion(clusterName, storeName3, region2);
-      verify(store3, atLeast(1)).updateVersionStatus(3, VersionStatus.PARTIALLY_ONLINE);
+      verify(store3, atLeast(1)).updateVersionStatus(3, VersionStatus.ERROR);
 
       // one target region, 2 non target regions: both failed -> do not swap
-      verify(store4, atLeast(1)).updateVersionStatus(3, VersionStatus.PARTIALLY_ONLINE);
+      verify(store4, atLeast(1)).updateVersionStatus(3, VersionStatus.ERROR);
 
       // one target region, 2 non target regions: one failed, one in progress -> do not swap
       verify(admin, never())
@@ -418,7 +418,7 @@ public class TestDeferredVersionSwapService {
 
       // two target regions: 1 completed, 1 failed, 1 completed non target region -> swap
       verify(admin, atLeast(1)).rollForwardToFutureVersion(clusterName, storeName6, region3);
-      verify(store6, atLeast(1)).updateVersionStatus(3, VersionStatus.PARTIALLY_ONLINE);
+      verify(store6, atLeast(1)).updateVersionStatus(3, VersionStatus.ERROR);
     });
   }
 


### PR DESCRIPTION
<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat], [protocol]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## Problem Statement
<!--
Describe
- What problem are you trying to solve
- What issues or limitations exist in the current code
- Why this change is necessary 
-->

**1. Davinci heartbeat check in deferred version swap service + parent admin**
Currently, in the deferred version swap service, we check for a dvc heartbeat for only one target region before skipping the store, but a dvc client can only be present in some regions and not all regions. To accurately skip a dvc store, we will need to check for a dvc heartbeat in *all* regions instead.

**2. Version swap logic in deferred version swap service**
Currently, the version swaps happen in the following cases:

1. Version status is `PUSHED` (this is set upon successful push in *all* regions)
2. Target region is complete in > 50% of the target regions
3. Non target regions have all reached terminal status
4. Non target regions is complete in > 50% of non target regions

And it fails to account for cases where:

1. Push is successful in *some* regions, but not all (version status is marked as `KILLED`)

**3. Code readability in deferred version swap service**
The code in the deferred version swap service has gotten to a point where there are a lot of checks and early exits and it is difficult to understand what is happening in the code at a glance

## Solution
<!--
Describe
- What changes you are making and why. 
- How these changes solve the problem.
- Any performance considerations or trade-offs. 
- Describe what testings you have done, for example, performance testing etc.
-->
**Overview of changes (green represents changed logic):**
![Blank diagram](https://github.com/user-attachments/assets/b9203fef-e26b-49d8-ad10-a31e029a9f66)


**1. Davinci heartbeat check in deferred version swap service + parent admin**
Query all regions and check for a dvc heartbeat instead of only checking *one* target region. If there is a dvc heartbeat reported in *any* region, we will skip the store and not perform a version swap

**2. Version swap logic in deferred version swap service**
Update the version swap logic to check for KILLED parent version statuses to account for push completions in only *some* regions. This changes the version swap logic to perform version swaps in cases like this:

<table>
<tr><td>

|regions| push status | final version|
|--|--|--|
|region1(target region)| completed| 1 |
|region2| failed|0 |
|region3| completed|1|

</td><td>

|regions| push status | final version|
|--|--|--|
|region1(target region)| completed| 1 |
|region2(target region)| failed|0 |
|region3| completed|1|

</td></tr> </table>

<table>
<tr><td>

|regions| push status | final version|
|--|--|--|
|region1(target region)| completed| 1 |
|region2| failed|0 |
|region3| failed|0|

</td><td>

|regions| push status | final version|
|--|--|--|
|region1(target region)| failed| 0 |
|region2(target region)| failed|0 |
|region3| completed|0|

</td></tr> </table>

**3. Code readability in deferred version swap service**

1. Refactored logical chunks of code into separate methods to improve readability & added block comments to each method
2. Added more thorough e2e testing to account for edge cases (failing pushes in target regions, multiple target regions, etc)

###  Code changes
- [ ] Added new code behind **a config**. If so list the config names and their default values in the PR description.
- [x] Introduced new **log lines**. 
  - [x] Confirmed if logs need to be **rate limited** to avoid excessive logging.

###  **Concurrency-Specific Checks**
Both reviewer and PR author to verify
- [x] Code has **no race conditions** or **thread safety issues**.
- [x] Proper **synchronization mechanisms** (e.g., `synchronized`, `RWLock`) are used where needed.
- [x] No **blocking calls** inside critical sections that could lead to deadlocks or performance degradation.
- [x] Verified **thread-safe collections** are used (e.g., `ConcurrentHashMap`, `CopyOnWriteArrayList`).
- [x] Validated proper exception handling in multi-threaded code to avoid silent thread termination.


## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->

- [ ] New unit tests added.
- [x] New integration tests added.
- [x] Modified or extended existing tests.
- [ ] Verified backward compatibility (if applicable).

## Does this PR introduce any user-facing or breaking changes?
<!--  
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Clearly explain the behavior change and its impact.