### PR TITLE
[repush][controller][admin-tool] Add admin tool command for repush store controller API

### DIFF
--- a/clients/venice-admin-tool/src/main/java/com/linkedin/venice/AdminTool.java
+++ b/clients/venice-admin-tool/src/main/java/com/linkedin/venice/AdminTool.java
@@ -55,6 +55,7 @@ import com.linkedin.venice.controllerapi.OwnerResponse;
 import com.linkedin.venice.controllerapi.PartitionResponse;
 import com.linkedin.venice.controllerapi.PubSubTopicConfigResponse;
 import com.linkedin.venice.controllerapi.ReadyForDataRecoveryResponse;
+import com.linkedin.venice.controllerapi.RepushJobResponse;
 import com.linkedin.venice.controllerapi.RoutersClusterConfigResponse;
 import com.linkedin.venice.controllerapi.SchemaResponse;
 import com.linkedin.venice.controllerapi.StoragePersonaResponse;
@@ -502,6 +503,9 @@ public class AdminTool {
           break;
         case LIST_CLUSTER_STALE_STORES:
           listClusterStaleStores(cmd);
+          break;
+        case REPUSH_STORE:
+          repushStore(cmd);
           break;
         case COMPARE_STORE:
           compareStore(cmd);
@@ -2814,6 +2818,12 @@ public class AdminTool {
     String clusterParam = getRequiredArgument(cmd, Arg.CLUSTER);
     String urlParam = getRequiredArgument(cmd, Arg.URL);
     ClusterStaleDataAuditResponse response = controllerClient.getClusterStaleStores(clusterParam, urlParam);
+    printObject(response);
+  }
+
+  private static void repushStore(CommandLine cmd) {
+    String storeName = getRequiredArgument(cmd, Arg.STORE);
+    RepushJobResponse response = controllerClient.repushStore(storeName);
     printObject(response);
   }
 

--- a/clients/venice-admin-tool/src/main/java/com/linkedin/venice/Command.java
+++ b/clients/venice-admin-tool/src/main/java/com/linkedin/venice/Command.java
@@ -461,7 +461,7 @@ public enum Command {
   ),
   LIST_CLUSTER_STALE_STORES(
       "list-cluster-stale-stores", "List all stores in a cluster which have stale replicas.", new Arg[] { URL, CLUSTER }
-  ), REPUSH_STORE("repush-store", "Repush store", new Arg[] { URL, STORE }),
+  ), REPUSH_STORE("repush-store", "Repush store", new Arg[] { URL, STORE }, new Arg[] { CLUSTER }),
   LIST_STORE_PUSH_INFO(
       "list-store-push-info", "List information about current pushes and push history for a specific store.",
       new Arg[] { URL, STORE }, new Arg[] { CLUSTER, PARTITION_DETAIL_ENABLED }

--- a/clients/venice-admin-tool/src/main/java/com/linkedin/venice/Command.java
+++ b/clients/venice-admin-tool/src/main/java/com/linkedin/venice/Command.java
@@ -461,7 +461,7 @@ public enum Command {
   ),
   LIST_CLUSTER_STALE_STORES(
       "list-cluster-stale-stores", "List all stores in a cluster which have stale replicas.", new Arg[] { URL, CLUSTER }
-  ), REPUSH_STORE("repush-store", "Repush store", new Arg[] { STORE }),
+  ), REPUSH_STORE("repush-store", "Repush store", new Arg[] { URL, CLUSTER, STORE }),
   LIST_STORE_PUSH_INFO(
       "list-store-push-info", "List information about current pushes and push history for a specific store.",
       new Arg[] { URL, STORE }, new Arg[] { CLUSTER, PARTITION_DETAIL_ENABLED }

--- a/clients/venice-admin-tool/src/main/java/com/linkedin/venice/Command.java
+++ b/clients/venice-admin-tool/src/main/java/com/linkedin/venice/Command.java
@@ -461,7 +461,7 @@ public enum Command {
   ),
   LIST_CLUSTER_STALE_STORES(
       "list-cluster-stale-stores", "List all stores in a cluster which have stale replicas.", new Arg[] { URL, CLUSTER }
-  ),
+  ), REPUSH_STORE("repush-store", "Repush store", new Arg[] { STORE }),
   LIST_STORE_PUSH_INFO(
       "list-store-push-info", "List information about current pushes and push history for a specific store.",
       new Arg[] { URL, STORE }, new Arg[] { CLUSTER, PARTITION_DETAIL_ENABLED }

--- a/clients/venice-admin-tool/src/main/java/com/linkedin/venice/Command.java
+++ b/clients/venice-admin-tool/src/main/java/com/linkedin/venice/Command.java
@@ -461,7 +461,11 @@ public enum Command {
   ),
   LIST_CLUSTER_STALE_STORES(
       "list-cluster-stale-stores", "List all stores in a cluster which have stale replicas.", new Arg[] { URL, CLUSTER }
-  ), REPUSH_STORE("repush-store", "Repush store", new Arg[] { URL, STORE }, new Arg[] { CLUSTER }),
+  ),
+  REPUSH_STORE(
+      "repush-store", "Copy the current serving version's data into a new version and repush it to the store",
+      new Arg[] { URL, STORE }, new Arg[] { CLUSTER }
+  ),
   LIST_STORE_PUSH_INFO(
       "list-store-push-info", "List information about current pushes and push history for a specific store.",
       new Arg[] { URL, STORE }, new Arg[] { CLUSTER, PARTITION_DETAIL_ENABLED }

--- a/clients/venice-admin-tool/src/main/java/com/linkedin/venice/Command.java
+++ b/clients/venice-admin-tool/src/main/java/com/linkedin/venice/Command.java
@@ -461,7 +461,7 @@ public enum Command {
   ),
   LIST_CLUSTER_STALE_STORES(
       "list-cluster-stale-stores", "List all stores in a cluster which have stale replicas.", new Arg[] { URL, CLUSTER }
-  ), REPUSH_STORE("repush-store", "Repush store", new Arg[] { URL, CLUSTER, STORE }),
+  ), REPUSH_STORE("repush-store", "Repush store", new Arg[] { URL, STORE }),
   LIST_STORE_PUSH_INFO(
       "list-store-push-info", "List information about current pushes and push history for a specific store.",
       new Arg[] { URL, STORE }, new Arg[] { CLUSTER, PARTITION_DETAIL_ENABLED }

--- a/internal/venice-client-common/src/main/java/com/linkedin/venice/controllerapi/ControllerResponse.java
+++ b/internal/venice-client-common/src/main/java/com/linkedin/venice/controllerapi/ControllerResponse.java
@@ -105,4 +105,11 @@ public class ControllerResponse { /* Uses Json Reflective Serializer, get withou
         .append(")")
         .toString();
   }
+
+  public void copyValueOf(ControllerResponse response) {
+    this.cluster = response.getCluster();
+    this.name = response.getName();
+    this.error = response.getError();
+    this.errorType = response.getErrorType();
+  }
 }

--- a/internal/venice-client-common/src/main/java/com/linkedin/venice/controllerapi/RepushJobResponse.java
+++ b/internal/venice-client-common/src/main/java/com/linkedin/venice/controllerapi/RepushJobResponse.java
@@ -20,4 +20,13 @@ public class RepushJobResponse extends ControllerResponse {
   public String getExecutionId() {
     return executionId;
   }
+
+  /** This method copies the values of another RepushJobInstance. This is to
+   * 1. put up with StoresRoutes::repushStore() and VeniceRouteHandler::internalHandle receiving the response through a
+   * response instance passed into the method rather than a return value
+   * 2. centralise the object field value duplication in this class to ensure all information are copied */
+  public void copyValueOf(RepushJobResponse response) {
+    super.copyValueOf(response);
+    this.executionId = response.getExecutionId();
+  }
 }

--- a/internal/venice-client-common/src/main/java/com/linkedin/venice/controllerapi/RepushJobResponse.java
+++ b/internal/venice-client-common/src/main/java/com/linkedin/venice/controllerapi/RepushJobResponse.java
@@ -8,7 +8,7 @@ public class RepushJobResponse extends ControllerResponse {
   public static final String DEFAULT_EXECUTION_ID = "-1";
 
   public RepushJobResponse() {
-    // TODO: ControlleResponse types need to have a default constructor which takes no arguments,
+    // TODO: ControllerResponse types need to have a default constructor which takes no arguments,
     // we either need to refactor that or make it so this class can populate executionId in a different way
     this.executionId = DEFAULT_EXECUTION_ID;
   }

--- a/internal/venice-common/src/main/java/com/linkedin/venice/controllerapi/ControllerClient.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/controllerapi/ControllerClient.java
@@ -1224,7 +1224,7 @@ public class ControllerClient implements Closeable {
     // (https://github.com/linkedin/venice/pull/1282#discussion_r1871510627)
     // TODO repush: add params from admin tool for repush: e.g. version, fabric etc.
     // TODO repush: add admin.repush()
-    return request(ControllerRoute.COMPACT_STORE, params, RepushJobResponse.class, repushJobDetails);
+    return request(ControllerRoute.REPUSH_STORE, params, RepushJobResponse.class, repushJobDetails);
   }
 
   public VersionResponse getStoreLargestUsedVersion(String clusterName, String storeName) {

--- a/internal/venice-common/src/main/java/com/linkedin/venice/controllerapi/ControllerClient.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/controllerapi/ControllerClient.java
@@ -1218,13 +1218,13 @@ public class ControllerClient implements Closeable {
    * @param storeName
    * @return //TODO LC:
    */
-  public RepushJobResponse triggerRepush(String storeName, byte[] repushJobDetails) {
+  public RepushJobResponse repushStore(String storeName) {
     QueryParams params = newParams().add(NAME, storeName);
     // TODO repush: Use byte[] to pass parameters instead of QueryParams as it is a post method. see
     // (https://github.com/linkedin/venice/pull/1282#discussion_r1871510627)
     // TODO repush: add params from admin tool for repush: e.g. version, fabric etc.
     // TODO repush: add admin.repush()
-    return request(ControllerRoute.REPUSH_STORE, params, RepushJobResponse.class, repushJobDetails);
+    return request(ControllerRoute.REPUSH_STORE, params, RepushJobResponse.class);
   }
 
   public VersionResponse getStoreLargestUsedVersion(String clusterName, String storeName) {

--- a/internal/venice-common/src/main/java/com/linkedin/venice/controllerapi/ControllerRoute.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/controllerapi/ControllerRoute.java
@@ -271,7 +271,7 @@ public enum ControllerRoute {
   ), GET_STALE_STORES_IN_CLUSTER("/get_stale_stores_in_cluster", HttpMethod.GET, Collections.singletonList(CLUSTER)),
   GET_STORES_IN_CLUSTER("/get_stores_in_cluster", HttpMethod.GET, Collections.singletonList(CLUSTER)),
   GET_STORES_FOR_COMPACTION("/get_stores_for_compaction", HttpMethod.GET, Collections.singletonList(CLUSTER)),
-  COMPACT_STORE("/trigger_repush", HttpMethod.POST, Arrays.asList(NAME)),
+  REPUSH_STORE("/trigger_repush", HttpMethod.POST, Arrays.asList(NAME)),
   GET_STORE_LARGEST_USED_VERSION("/get_store_largest_used_version", HttpMethod.GET, Arrays.asList(CLUSTER, NAME)),
   LIST_STORE_PUSH_INFO("/list_store_push_info", HttpMethod.GET, Arrays.asList(CLUSTER, NAME, PARTITION_DETAIL_ENABLED)),
   GET_REGION_PUSH_DETAILS(

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/controller/TestAdminToolEndToEnd.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/controller/TestAdminToolEndToEnd.java
@@ -203,6 +203,7 @@ public class TestAdminToolEndToEnd {
     }
   }
 
+  /** similar test logic to {@link TestHybrid#testHybridStoreLogCompaction()} & shares {@link com.linkedin.venice.endToEnd.TestHybrid.TestRepushOrchestratorImpl} */
   @Test(timeOut = TEST_TIMEOUT)
   public void testRepushStoreCommand() throws Exception {
     // create test store

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/controller/TestAdminToolEndToEnd.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/controller/TestAdminToolEndToEnd.java
@@ -230,7 +230,7 @@ public class TestAdminToolEndToEnd {
 
     // Validate repush triggered
     try {
-      if (TestHybrid.TestRepushOrchestratorImpl.latch.await(TEST_LOG_COMPACTION_TIMEOUT, TimeUnit.MILLISECONDS)) {
+      if (TestHybrid.TestRepushOrchestratorImpl.getLatch().await(TEST_LOG_COMPACTION_TIMEOUT, TimeUnit.MILLISECONDS)) {
         LOGGER.info("Log compaction job triggered");
       }
     } catch (InterruptedException e) {

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/controller/server/TestAdminSparkServer.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/controller/server/TestAdminSparkServer.java
@@ -2,6 +2,8 @@ package com.linkedin.venice.controller.server;
 
 import static com.linkedin.venice.utils.ByteUtils.BYTES_PER_MB;
 import static com.linkedin.venice.utils.TestUtils.assertCommand;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.spy;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.linkedin.venice.ConfigKeys;
@@ -10,6 +12,7 @@ import com.linkedin.venice.common.VeniceSystemStoreType;
 import com.linkedin.venice.controller.Admin;
 import com.linkedin.venice.controller.InstanceRemovableStatuses;
 import com.linkedin.venice.controller.VeniceHelixAdmin;
+import com.linkedin.venice.controller.repush.RepushJobRequest;
 import com.linkedin.venice.controllerapi.AdminCommandExecution;
 import com.linkedin.venice.controllerapi.ControllerApiConstants;
 import com.linkedin.venice.controllerapi.ControllerClient;
@@ -24,6 +27,7 @@ import com.linkedin.venice.controllerapi.MultiStoreTopicsResponse;
 import com.linkedin.venice.controllerapi.MultiVersionResponse;
 import com.linkedin.venice.controllerapi.NewStoreResponse;
 import com.linkedin.venice.controllerapi.OwnerResponse;
+import com.linkedin.venice.controllerapi.RepushJobResponse;
 import com.linkedin.venice.controllerapi.SchemaResponse;
 import com.linkedin.venice.controllerapi.StorageEngineOverheadRatioResponse;
 import com.linkedin.venice.controllerapi.StoreResponse;
@@ -1104,6 +1108,19 @@ public class TestAdminSparkServer extends AbstractTestAdminSparkServer {
   public void controllerClientReturns404ForNonexistentStoreQuery() {
     StoreResponse storeResponse = controllerClient.getStore("nonexistent");
     Assert.assertTrue(storeResponse.getError().contains("Http Status 404"));
+  }
+
+  @Test(timeOut = TEST_TIMEOUT)
+  public void testRepushStoreWithErrorResponse() throws Exception {
+    String testStoreName = "repush-test-store";
+    RepushJobResponse errorResponse = new RepushJobResponse();
+    errorResponse.setError("AH!");
+    Assert.assertTrue(errorResponse.isError());
+    Admin admin = spy(parentController.getVeniceAdmin());
+    doReturn(errorResponse).when(admin)
+        .repushStore(new RepushJobRequest(testStoreName, RepushJobRequest.MANUAL_TRIGGER));
+
+    controllerClient.repushStore(testStoreName);
   }
 
   @Test(timeOut = TEST_TIMEOUT)

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/controller/server/TestAdminSparkServer.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/controller/server/TestAdminSparkServer.java
@@ -2,8 +2,6 @@ package com.linkedin.venice.controller.server;
 
 import static com.linkedin.venice.utils.ByteUtils.BYTES_PER_MB;
 import static com.linkedin.venice.utils.TestUtils.assertCommand;
-import static org.mockito.Mockito.doReturn;
-import static org.mockito.Mockito.spy;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.linkedin.venice.ConfigKeys;
@@ -12,7 +10,6 @@ import com.linkedin.venice.common.VeniceSystemStoreType;
 import com.linkedin.venice.controller.Admin;
 import com.linkedin.venice.controller.InstanceRemovableStatuses;
 import com.linkedin.venice.controller.VeniceHelixAdmin;
-import com.linkedin.venice.controller.repush.RepushJobRequest;
 import com.linkedin.venice.controllerapi.AdminCommandExecution;
 import com.linkedin.venice.controllerapi.ControllerApiConstants;
 import com.linkedin.venice.controllerapi.ControllerClient;
@@ -27,7 +24,6 @@ import com.linkedin.venice.controllerapi.MultiStoreTopicsResponse;
 import com.linkedin.venice.controllerapi.MultiVersionResponse;
 import com.linkedin.venice.controllerapi.NewStoreResponse;
 import com.linkedin.venice.controllerapi.OwnerResponse;
-import com.linkedin.venice.controllerapi.RepushJobResponse;
 import com.linkedin.venice.controllerapi.SchemaResponse;
 import com.linkedin.venice.controllerapi.StorageEngineOverheadRatioResponse;
 import com.linkedin.venice.controllerapi.StoreResponse;
@@ -1108,19 +1104,6 @@ public class TestAdminSparkServer extends AbstractTestAdminSparkServer {
   public void controllerClientReturns404ForNonexistentStoreQuery() {
     StoreResponse storeResponse = controllerClient.getStore("nonexistent");
     Assert.assertTrue(storeResponse.getError().contains("Http Status 404"));
-  }
-
-  @Test(timeOut = TEST_TIMEOUT)
-  public void testRepushStoreWithErrorResponse() throws Exception {
-    String testStoreName = "repush-test-store";
-    RepushJobResponse errorResponse = new RepushJobResponse();
-    errorResponse.setError("AH!");
-    Assert.assertTrue(errorResponse.isError());
-    Admin admin = spy(parentController.getVeniceAdmin());
-    doReturn(errorResponse).when(admin)
-        .repushStore(new RepushJobRequest(testStoreName, RepushJobRequest.MANUAL_TRIGGER));
-
-    controllerClient.repushStore(testStoreName);
   }
 
   @Test(timeOut = TEST_TIMEOUT)

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestHybrid.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestHybrid.java
@@ -1110,7 +1110,7 @@ public class TestHybrid {
   }
 
   public static class TestRepushOrchestratorImpl implements RepushOrchestrator {
-    public static CountDownLatch latch = new CountDownLatch(1);
+    static CountDownLatch latch = new CountDownLatch(1);
 
     public TestRepushOrchestratorImpl(VeniceProperties props) {
     }
@@ -1120,6 +1120,10 @@ public class TestHybrid {
       latch.countDown();
       LOGGER.info("Repush job triggered for store: " + repushJobRequest.toString());
       return new RepushJobResponse(Utils.getUniqueString("repush-execId"));
+    }
+
+    public static CountDownLatch getLatch() {
+      return latch;
     }
   }
 

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestHybrid.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestHybrid.java
@@ -1098,7 +1098,7 @@ public class TestHybrid {
       throw new RuntimeException(e);
     }
 
-    // ok, now run run repush manually with the controller client.
+    // ok, now run repush manually with the controller client.
     // this call should be synchronous and the count down will trigger immediately..
     TestRepushOrchestratorImpl.latch = new CountDownLatch(1);
     sharedVenice.useControllerClient(client -> {
@@ -1110,7 +1110,7 @@ public class TestHybrid {
   }
 
   public static class TestRepushOrchestratorImpl implements RepushOrchestrator {
-    static CountDownLatch latch = new CountDownLatch(1);
+    public static CountDownLatch latch = new CountDownLatch(1);
 
     public TestRepushOrchestratorImpl(VeniceProperties props) {
     }

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestHybrid.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestHybrid.java
@@ -1102,7 +1102,7 @@ public class TestHybrid {
     // this call should be synchronous and the count down will trigger immediately..
     TestRepushOrchestratorImpl.latch = new CountDownLatch(1);
     sharedVenice.useControllerClient(client -> {
-      RepushJobResponse response = client.triggerRepush(storeName, null);
+      RepushJobResponse response = client.repushStore(storeName);
       Assert.assertFalse(response.isError(), "Repush failed with error: " + response.getError());
       // No waiting this time, this should countdown immediately
       Assert.assertEquals(TestRepushOrchestratorImpl.latch.getCount(), 0);

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/Admin.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/Admin.java
@@ -945,12 +945,12 @@ public interface Admin extends AutoCloseable, Closeable {
 
   /**
    * triggers repush for storeName for log compaction of store topic implemented in
-   * {@link VeniceHelixAdmin#compactStore}
+   * {@link VeniceHelixAdmin#repushStore}
    *
    * @param repushJobRequest contains params for repush job
    * @return data model of repush job run info
    */
-  RepushJobResponse compactStore(RepushJobRequest repushJobRequest) throws Exception;
+  RepushJobResponse repushStore(RepushJobRequest repushJobRequest) throws Exception;
 
   public CompactionManager getCompactionManager();
 

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/Admin.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/Admin.java
@@ -952,7 +952,7 @@ public interface Admin extends AutoCloseable, Closeable {
    */
   RepushJobResponse repushStore(RepushJobRequest repushJobRequest) throws Exception;
 
-  public CompactionManager getCompactionManager();
+  CompactionManager getCompactionManager();
 
   /**
    * @return the largest used version number for the given store from store graveyard.

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceHelixAdmin.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceHelixAdmin.java
@@ -8084,10 +8084,10 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
    * @param repushJobRequest@return
    */
   @Override
-  public RepushJobResponse compactStore(RepushJobRequest repushJobRequest) throws Exception {
+  public RepushJobResponse repushStore(RepushJobRequest repushJobRequest) throws Exception {
     Assert.isTrue(multiClusterConfigs.isLogCompactionEnabled(), "Log compaction is not enabled for this cluster!");
     try {
-      return compactionManager.compactStore(repushJobRequest);
+      return compactionManager.repushStore(repushJobRequest);
     } catch (Exception e) {
       LOGGER.error("Error while compacting store: {}", repushJobRequest.getStoreName(), e);
       throw e; // this method is the first common point for scheduled & adhoc log compaction, each has different error

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceHelixAdmin.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceHelixAdmin.java
@@ -8089,7 +8089,7 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
     try {
       return compactionManager.repushStore(repushJobRequest);
     } catch (Exception e) {
-      LOGGER.error("Error while compacting store: {}", repushJobRequest.getStoreName(), e);
+      LOGGER.error("Error while triggering repush for store: {}", repushJobRequest.getStoreName(), e);
       throw e; // this method is the first common point for scheduled & adhoc log compaction, each has different error
     }
   }

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceParentHelixAdmin.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceParentHelixAdmin.java
@@ -5009,10 +5009,10 @@ public class VeniceParentHelixAdmin implements Admin {
   }
 
   /**
-   * see {@link Admin#compactStore}
+   * see {@link Admin#repushStore}
    */
   @Override
-  public RepushJobResponse compactStore(RepushJobRequest repushJobRequest) throws Exception {
+  public RepushJobResponse repushStore(RepushJobRequest repushJobRequest) throws Exception {
     // TODO:
     // Repush implementation today with no parameter adjustments does a repush to all colo's. There's some discussion
     // about if this should instead be federated out and if this should be done in parent at all. Considering today
@@ -5021,7 +5021,7 @@ public class VeniceParentHelixAdmin implements Admin {
     // But when that day comes that we implement that kind of behavior dichotomy, we should code here that either honors
     // what's been passed in (parent getting a request for a repush in a child colo should forward that along) OR the
     // parent should just abort the request and return an error.
-    return veniceHelixAdmin.compactStore(repushJobRequest);
+    return veniceHelixAdmin.repushStore(repushJobRequest);
   }
 
   @Override

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/logcompaction/CompactionManager.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/logcompaction/CompactionManager.java
@@ -103,12 +103,12 @@ public class CompactionManager {
   /**
    * This function triggers a repush job to perform log compaction on the topic of a store.
    * <p>
-   * - intermediary between {@link com.linkedin.venice.controller.VeniceHelixAdmin#compactStore} and
+   * - intermediary between {@link com.linkedin.venice.controller.VeniceHelixAdmin#repushStore} and
    * {@link RepushOrchestrator#repush} - a wrapper around repush() - handles repush job status/response
    *
    * @param repushJobRequest
    */
-  public RepushJobResponse compactStore(RepushJobRequest repushJobRequest) throws Exception {
+  public RepushJobResponse repushStore(RepushJobRequest repushJobRequest) throws Exception {
     try {
       RepushJobResponse response = repushOrchestrator.repush(repushJobRequest);
 

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/logcompaction/LogCompactionService.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/logcompaction/LogCompactionService.java
@@ -24,7 +24,7 @@ import org.apache.logging.log4j.Logger;
  * 1. schedules {@link LogCompactionTask} periodically to perform log compaction for all stores in the cluster
  * controlled by the {@link com.linkedin.venice.controller.VeniceController} instance that runs this LogCompactionService instance
  * 2. checks for stores that are ready for log compaction with function {@link VeniceHelixAdmin#getStoresForCompaction(String)}
- * 3. triggers compaction for each store with function {@link VeniceHelixAdmin#compactStore(RepushJobRequest)}
+ * 3. triggers compaction for each store with function {@link VeniceHelixAdmin#repushStore(RepushJobRequest)}
  *
  * See {@link CompactionManager} for the logic to determine if a store is ready for compaction
  */
@@ -91,7 +91,7 @@ public class LogCompactionService extends AbstractVeniceService {
         for (StoreInfo storeInfo: admin.getStoresForCompaction(clusterName)) {
           try {
             RepushJobResponse response =
-                admin.compactStore(new RepushJobRequest(storeInfo.getName(), RepushJobRequest.SCHEDULED_TRIGGER));
+                admin.repushStore(new RepushJobRequest(storeInfo.getName(), RepushJobRequest.SCHEDULED_TRIGGER));
             LOGGER.info(
                 "log compaction triggered for cluster: {} store: {} | execution ID: {}",
                 clusterName,

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/server/AdminSparkServer.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/server/AdminSparkServer.java
@@ -13,7 +13,6 @@ import static com.linkedin.venice.controllerapi.ControllerRoute.CHECK_RESOURCE_C
 import static com.linkedin.venice.controllerapi.ControllerRoute.CLEANUP_INSTANCE_CUSTOMIZED_STATES;
 import static com.linkedin.venice.controllerapi.ControllerRoute.CLUSTER_DISCOVERY;
 import static com.linkedin.venice.controllerapi.ControllerRoute.CLUSTER_HEALTH_STORES;
-import static com.linkedin.venice.controllerapi.ControllerRoute.COMPACT_STORE;
 import static com.linkedin.venice.controllerapi.ControllerRoute.COMPARE_STORE;
 import static com.linkedin.venice.controllerapi.ControllerRoute.COMPLETE_MIGRATION;
 import static com.linkedin.venice.controllerapi.ControllerRoute.CONFIGURE_ACTIVE_ACTIVE_REPLICATION_FOR_CLUSTER;
@@ -82,6 +81,7 @@ import static com.linkedin.venice.controllerapi.ControllerRoute.REMOVE_DERIVED_S
 import static com.linkedin.venice.controllerapi.ControllerRoute.REMOVE_NODE;
 import static com.linkedin.venice.controllerapi.ControllerRoute.REMOVE_STORE_FROM_GRAVEYARD;
 import static com.linkedin.venice.controllerapi.ControllerRoute.REPLICATE_META_DATA;
+import static com.linkedin.venice.controllerapi.ControllerRoute.REPUSH_STORE;
 import static com.linkedin.venice.controllerapi.ControllerRoute.REQUEST_TOPIC;
 import static com.linkedin.venice.controllerapi.ControllerRoute.ROLLBACK_TO_BACKUP_VERSION;
 import static com.linkedin.venice.controllerapi.ControllerRoute.ROLL_FORWARD_TO_FUTURE_VERSION;
@@ -598,7 +598,7 @@ public class AdminSparkServer extends AbstractVeniceService {
         GET_STORES_FOR_COMPACTION.getPath(),
         new VeniceParentControllerRegionStateHandler(admin, storesRoutes.getStoresForCompaction(admin)));
     httpService.post(
-        COMPACT_STORE.getPath(),
+        REPUSH_STORE.getPath(),
         new VeniceParentControllerRegionStateHandler(admin, storesRoutes.compactStore(admin)));
     httpService.get(
         GET_STORE_LARGEST_USED_VERSION.getPath(),

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/server/AdminSparkServer.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/server/AdminSparkServer.java
@@ -599,7 +599,7 @@ public class AdminSparkServer extends AbstractVeniceService {
         new VeniceParentControllerRegionStateHandler(admin, storesRoutes.getStoresForCompaction(admin)));
     httpService.post(
         REPUSH_STORE.getPath(),
-        new VeniceParentControllerRegionStateHandler(admin, storesRoutes.compactStore(admin)));
+        new VeniceParentControllerRegionStateHandler(admin, storesRoutes.repushStore(admin)));
     httpService.get(
         GET_STORE_LARGEST_USED_VERSION.getPath(),
         new VeniceParentControllerRegionStateHandler(admin, storesRoutes.getStoreLargestUsedVersion(admin)));

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/server/StoresRoutes.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/server/StoresRoutes.java
@@ -979,9 +979,9 @@ public class StoresRoutes extends AbstractRoute {
   }
 
   /**
-   * @see Admin#compactStore(RepushJobRequest)
+   * @see Admin#repushStore(RepushJobRequest)
    */
-  public Route compactStore(Admin admin) {
+  public Route repushStore(Admin admin) {
     return new VeniceRouteHandler<RepushJobResponse>(RepushJobResponse.class) {
       @Override
       public void internalHandle(Request request, RepushJobResponse veniceResponse) {
@@ -989,7 +989,7 @@ public class StoresRoutes extends AbstractRoute {
         String storeName = request.queryParams(STORE_NAME);
         String sourceRegion = request.queryParamOrDefault(SOURCE_REGION, null);
         try {
-          admin.compactStore(new RepushJobRequest(storeName, sourceRegion, RepushJobRequest.MANUAL_TRIGGER));
+          admin.repushStore(new RepushJobRequest(storeName, sourceRegion, RepushJobRequest.MANUAL_TRIGGER));
 
           veniceResponse.setName(storeName);
         } catch (Exception e) {

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/server/StoresRoutes.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/server/StoresRoutes.java
@@ -989,9 +989,8 @@ public class StoresRoutes extends AbstractRoute {
         String storeName = request.queryParams(STORE_NAME);
         String sourceRegion = request.queryParamOrDefault(SOURCE_REGION, null);
         try {
-          admin.repushStore(new RepushJobRequest(storeName, sourceRegion, RepushJobRequest.MANUAL_TRIGGER));
-
-          veniceResponse.setName(storeName);
+          veniceResponse =
+              admin.repushStore(new RepushJobRequest(storeName, sourceRegion, RepushJobRequest.MANUAL_TRIGGER));
         } catch (Exception e) {
           veniceResponse.setError("Failed to compact store: " + storeName, e);
         }

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/server/StoresRoutes.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/server/StoresRoutes.java
@@ -29,7 +29,6 @@ import static com.linkedin.venice.controllerapi.ControllerApiConstants.WRITE_OPE
 import static com.linkedin.venice.controllerapi.ControllerRoute.ABORT_MIGRATION;
 import static com.linkedin.venice.controllerapi.ControllerRoute.BACKUP_VERSION;
 import static com.linkedin.venice.controllerapi.ControllerRoute.CLUSTER_HEALTH_STORES;
-import static com.linkedin.venice.controllerapi.ControllerRoute.COMPACT_STORE;
 import static com.linkedin.venice.controllerapi.ControllerRoute.COMPARE_STORE;
 import static com.linkedin.venice.controllerapi.ControllerRoute.COMPLETE_MIGRATION;
 import static com.linkedin.venice.controllerapi.ControllerRoute.CONFIGURE_ACTIVE_ACTIVE_REPLICATION_FOR_CLUSTER;
@@ -50,6 +49,7 @@ import static com.linkedin.venice.controllerapi.ControllerRoute.LIST_STORES;
 import static com.linkedin.venice.controllerapi.ControllerRoute.LIST_STORE_PUSH_INFO;
 import static com.linkedin.venice.controllerapi.ControllerRoute.MIGRATE_STORE;
 import static com.linkedin.venice.controllerapi.ControllerRoute.REMOVE_STORE_FROM_GRAVEYARD;
+import static com.linkedin.venice.controllerapi.ControllerRoute.REPUSH_STORE;
 import static com.linkedin.venice.controllerapi.ControllerRoute.ROLLBACK_TO_BACKUP_VERSION;
 import static com.linkedin.venice.controllerapi.ControllerRoute.ROLL_FORWARD_TO_FUTURE_VERSION;
 import static com.linkedin.venice.controllerapi.ControllerRoute.SEND_HEARTBEAT_TIMESTAMP_TO_SYSTEM_STORE;
@@ -985,7 +985,7 @@ public class StoresRoutes extends AbstractRoute {
     return new VeniceRouteHandler<RepushJobResponse>(RepushJobResponse.class) {
       @Override
       public void internalHandle(Request request, RepushJobResponse veniceResponse) {
-        AdminSparkServer.validateParams(request, COMPACT_STORE.getParams(), admin);
+        AdminSparkServer.validateParams(request, REPUSH_STORE.getParams(), admin);
         String storeName = request.queryParams(STORE_NAME);
         String sourceRegion = request.queryParamOrDefault(SOURCE_REGION, null);
         try {

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/server/StoresRoutes.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/server/StoresRoutes.java
@@ -989,11 +989,8 @@ public class StoresRoutes extends AbstractRoute {
         String storeName = request.queryParams(STORE_NAME);
         String sourceRegion = request.queryParamOrDefault(SOURCE_REGION, null);
         try {
-          veniceResponse =
-              admin.repushStore(new RepushJobRequest(storeName, sourceRegion, RepushJobRequest.MANUAL_TRIGGER));
-          if (veniceResponse.isError()) {
-            throw new VeniceException("Got error!!!!!", veniceResponse.getErrorType());
-          }
+          veniceResponse.copyValueOf(
+              admin.repushStore(new RepushJobRequest(storeName, sourceRegion, RepushJobRequest.MANUAL_TRIGGER)));
         } catch (Exception e) {
           veniceResponse.setError("Failed to compact store: " + storeName, e);
         }

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/server/StoresRoutes.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/server/StoresRoutes.java
@@ -991,6 +991,9 @@ public class StoresRoutes extends AbstractRoute {
         try {
           veniceResponse =
               admin.repushStore(new RepushJobRequest(storeName, sourceRegion, RepushJobRequest.MANUAL_TRIGGER));
+          if (veniceResponse.isError()) {
+            throw new VeniceException("Got error!!!!!", veniceResponse.getErrorType());
+          }
         } catch (Exception e) {
           veniceResponse.setError("Failed to compact store: " + storeName, e);
         }

--- a/services/venice-controller/src/test/java/com/linkedin/venice/controller/logcompaction/TestCompactionManager.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/controller/logcompaction/TestCompactionManager.java
@@ -104,7 +104,7 @@ public class TestCompactionManager {
   }
 
   @Test(expectedExceptions = VeniceException.class)
-  public void testCompactStoreWithNullResponse() throws Exception {
+  public void testRepushStoreWithNullResponse() throws Exception {
     // Setup a mocked RepushOrchestrator that returns null on repush()
     when(mockRepushOrchestrator.repush(any())).thenReturn(null);
 
@@ -112,7 +112,7 @@ public class TestCompactionManager {
     RepushJobRequest repushJobRequest =
         new RepushJobRequest(Utils.getUniqueString("store"), RepushJobRequest.MANUAL_TRIGGER);
 
-    // Call the compactStore method and expect a VeniceException
-    testCompactionManager.compactStore(repushJobRequest);
+    // Call the repushStore method and expect a VeniceException
+    testCompactionManager.repushStore(repushJobRequest);
   }
 }

--- a/services/venice-controller/src/test/java/com/linkedin/venice/controller/server/StoresRoutesTest.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/controller/server/StoresRoutesTest.java
@@ -3,17 +3,20 @@ package com.linkedin.venice.controller.server;
 import static com.linkedin.venice.exceptions.ErrorType.INCORRECT_CONTROLLER;
 import static com.linkedin.venice.exceptions.ErrorType.INVALID_CONFIG;
 import static com.linkedin.venice.exceptions.ErrorType.STORE_NOT_FOUND;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doCallRealMethod;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import com.linkedin.venice.controller.Admin;
 import com.linkedin.venice.controller.VeniceHelixAdmin;
 import com.linkedin.venice.controller.VeniceParentHelixAdmin;
 import com.linkedin.venice.controllerapi.ControllerApiConstants;
 import com.linkedin.venice.controllerapi.MultiStoreStatusResponse;
+import com.linkedin.venice.controllerapi.RepushJobResponse;
 import com.linkedin.venice.controllerapi.StoreResponse;
 import com.linkedin.venice.controllerapi.TrackableControllerResponse;
 import com.linkedin.venice.exceptions.VeniceException;
@@ -37,7 +40,7 @@ import spark.Response;
 import spark.Route;
 
 
-public class StoreRoutesTest {
+public class StoresRoutesTest {
   private static final String TEST_CLUSTER = "test_cluster";
   private static final String TEST_STORE_NAME = "test_store";
 
@@ -253,5 +256,34 @@ public class StoreRoutesTest {
             storesRoutes.getStore(mockAdmin).handle(request, mock(Response.class)).toString(),
             StoreResponse.class);
     Assert.assertEquals(response.getStore().getMaxRecordSizeBytes(), testMaxRecordSizeBytesValue);
+  }
+
+  @Test
+  public void testRepushStoreWithErrorResponse() throws Exception {
+    Admin mockAdmin = mock(Admin.class);
+    doReturn(true).when(mockAdmin).isLeaderControllerFor(TEST_CLUSTER);
+
+    Route repushStoreRoute = new StoresRoutes(false, Optional.empty(), pubSubTopicRepository).repushStore(mockAdmin);
+
+    Request request = mock(Request.class);
+    doReturn(TEST_STORE_NAME).when(request).queryParams(eq(ControllerApiConstants.NAME));
+
+    QueryParamsMap queryParamsMap = mock(QueryParamsMap.class);
+
+    Map<String, String[]> queryMap = new HashMap<>(1);
+    queryMap.put(ControllerApiConstants.NAME, new String[] { TEST_STORE_NAME });
+
+    doReturn(queryMap).when(queryParamsMap).toMap();
+    doReturn(queryParamsMap).when(request).queryMap();
+
+    RepushJobResponse errorResponse = new RepushJobResponse();
+    errorResponse.setError("AH!");
+    Assert.assertTrue(errorResponse.isError());
+
+    when(mockAdmin.repushStore(any())).thenReturn(errorResponse);
+
+    RepushJobResponse repushJobResponse = ObjectMapperFactory.getInstance()
+        .readValue(repushStoreRoute.handle(request, mock(Response.class)).toString(), RepushJobResponse.class);
+    Assert.assertTrue(repushJobResponse.isError());
   }
 }

--- a/services/venice-controller/src/test/java/com/linkedin/venice/controller/server/StoresRoutesTest.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/controller/server/StoresRoutesTest.java
@@ -276,11 +276,7 @@ public class StoresRoutesTest {
     queryMap.put(ControllerApiConstants.NAME, new String[] { TEST_STORE_NAME });
     doReturn(queryMap).when(queryParamsMap).toMap();
 
-    RepushJobResponse errorResponse = new RepushJobResponse();
-    errorResponse.setError("AH!");
-    Assert.assertTrue(errorResponse.isError());
-
-    when(mockAdmin.repushStore(any())).thenReturn(errorResponse);
+    when(mockAdmin.repushStore(any())).thenThrow(mock(Exception.class));
 
     RepushJobResponse repushJobResponse = ObjectMapperFactory.getInstance()
         .readValue(repushStoreRoute.handle(request, mock(Response.class)).toString(), RepushJobResponse.class);

--- a/services/venice-controller/src/test/java/com/linkedin/venice/controller/server/StoresRoutesTest.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/controller/server/StoresRoutesTest.java
@@ -266,15 +266,15 @@ public class StoresRoutesTest {
     Route repushStoreRoute = new StoresRoutes(false, Optional.empty(), pubSubTopicRepository).repushStore(mockAdmin);
 
     Request request = mock(Request.class);
+    doReturn(TEST_CLUSTER).when(request).queryParams(eq(ControllerApiConstants.CLUSTER));
     doReturn(TEST_STORE_NAME).when(request).queryParams(eq(ControllerApiConstants.NAME));
 
     QueryParamsMap queryParamsMap = mock(QueryParamsMap.class);
+    doReturn(queryParamsMap).when(request).queryMap();
 
     Map<String, String[]> queryMap = new HashMap<>(1);
     queryMap.put(ControllerApiConstants.NAME, new String[] { TEST_STORE_NAME });
-
     doReturn(queryMap).when(queryParamsMap).toMap();
-    doReturn(queryParamsMap).when(request).queryMap();
 
     RepushJobResponse errorResponse = new RepushJobResponse();
     errorResponse.setError("AH!");


### PR DESCRIPTION
## Problem Statement
Need to send request to new repush store controller API from admin tool. This allows store repush jobs to be triggered adhoc.


## Solution
add `repushStore()` command to venice-admin-tool
- `ControllerClient`
	- [x] add repushStore()
- `Command`
	- [x] add enum REPUSH
- `AdminTool`
	- [x] add REPUSH case
	- [x] add repush() method


###  Code changes
- [ ] Added new code behind **a config**. If so list the config names and their default values in the PR description.
- [ ] Introduced new **log lines**. 
  - [ ] Confirmed if logs need to be **rate limited** to avoid excessive logging.

###  **Concurrency-Specific Checks**
Both reviewer and PR author to verify
- [x] Code has **no race conditions** or **thread safety issues**.
- [x] Proper **synchronization mechanisms** (e.g., `synchronized`, `RWLock`) are used where needed.
- [x] No **blocking calls** inside critical sections that could lead to deadlocks or performance degradation.
- [x] Verified **thread-safe collections** are used (e.g., `ConcurrentHashMap`, `CopyOnWriteArrayList`).
- [x] Validated proper exception handling in multi-threaded code to avoid silent thread termination.


## How was this PR tested?
- [x] New unit tests added.
  - [x] `StoresRoutesTest::testRepushStoreWithErrorResponse()`
- [x] New integration tests added.
  - [x] `TestAdminToolEndToEnd::testRepushStoreCommand()`
  - [x] build `admin-tool.jar` locally & fire repush store request from local build
- [ ] Modified or extended existing tests.
- [ ] Verified backward compatibility (if applicable).

## Does this PR introduce any user-facing or breaking changes?
- [ ] No. You can skip the rest of this section.
- [x] Yes. Clearly explain the behavior change and its impact.
  - allows users to trigger repush job on store / using the `admin-tool` / with the args `--repush-store --url $CONTROLLER_URL --store $STORE_NAME`