### PR TITLE
[changelog] Add back synchronization around poll()

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/consumer/VeniceAfterImageConsumerImpl.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/consumer/VeniceAfterImageConsumerImpl.java
@@ -109,7 +109,7 @@ public class VeniceAfterImageConsumerImpl<K, V> extends VeniceChangelogConsumerI
       return CompletableFuture.completedFuture(null);
     }
     return CompletableFuture.supplyAsync(() -> {
-      subscriptionLock.writeLock().lock();
+      boolean lockAcquired = false;
       Set<VeniceChangeCoordinate> checkpoints = new HashSet<>();
       try {
         // TODO: This implementation basically just scans the version topic until it finds the EOP message. The
@@ -173,13 +173,17 @@ public class VeniceAfterImageConsumerImpl<K, V> extends VeniceChangelogConsumerI
           LOGGER.info(
               "Seeking to EOP for partitions: " + partitions.toString() + " for version topic: "
                   + targetTopic.getName());
+          subscriptionLock.writeLock().lock();
+          lockAcquired = true;
           this.synchronousSeekToCheckpoint(checkpoints);
           LOGGER.info(
               "Seeked to EOP for partitions: " + partitions.toString() + " for version topic: "
                   + targetTopic.getName());
         }
       } finally {
-        subscriptionLock.writeLock().unlock();
+        if (lockAcquired) {
+          subscriptionLock.writeLock().unlock();
+        }
       }
       return null;
     }, seekExecutorService);

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/consumer/VeniceChangelogConsumerImpl.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/consumer/VeniceChangelogConsumerImpl.java
@@ -692,8 +692,7 @@ public class VeniceChangelogConsumerImpl<K, V> implements VeniceChangelogConsume
     boolean lockAcquired = false;
     try {
       // the pubsubconsumer internally is completely unthreadsafe, so we need an exclusive lock to poll (ugh)
-      subscriptionLock.writeLock().tryLock(timeoutInMs, TimeUnit.MILLISECONDS);
-      lockAcquired = true;
+      lockAcquired = subscriptionLock.writeLock().tryLock(timeoutInMs, TimeUnit.MILLISECONDS);
       messagesMap = pubSubConsumer.poll(timeoutInMs);
     } catch (Exception e) {
       LOGGER.error("Error polling records with exception:", e);


### PR DESCRIPTION
## Problem Statement
It seems that our pubsub consumer adapter doesn't even tolerate concurrent calls to poll, so removing locking on this function is pointless. 

## Solution
So we add back an exclusive lock on the poll and in order to reduce the pause time on the version swap seek we shrink the scope of the read lock on version swap to just the short part.



###  Code changes
- [ ] Added new code behind **a config**. If so list the config names and their default values in the PR description.
- [ ] Introduced new **log lines**. 
  - [ ] Confirmed if logs need to be **rate limited** to avoid excessive logging.

###  **Concurrency-Specific Checks**
Both reviewer and PR author to verify
- [ ] Code has **no race conditions** or **thread safety issues**.
- [ ] Proper **synchronization mechanisms** (e.g., `synchronized`, `RWLock`) are used where needed.
- [ ] No **blocking calls** inside critical sections that could lead to deadlocks or performance degradation.
- [ ] Verified **thread-safe collections** are used (e.g., `ConcurrentHashMap`, `CopyOnWriteArrayList`).
- [ ] Validated proper exception handling in multi-threaded code to avoid silent thread termination.


## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->

- [ ] New unit tests added.
- [ ] New integration tests added.
- [ ] Modified or extended existing tests.
- [ ] Verified backward compatibility (if applicable).

## Does this PR introduce any user-facing or breaking changes?
<!--  
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [ ] No. You can skip the rest of this section.
- [ ] Yes. Clearly explain the behavior change and its impact.