### PR TITLE
[dvc] wrap server metadata request with ic provider and add d2 cache

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/repository/NativeMetadataRepository.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/repository/NativeMetadataRepository.java
@@ -119,7 +119,7 @@ public abstract class NativeMetadataRepository
       ICProvider icProvider) {
     NativeMetadataRepository nativeMetadataRepository;
     if (clientConfig.isUseRequestBasedMetaRepository()) {
-      nativeMetadataRepository = new RequestBasedMetaRepository(clientConfig, backendConfig);
+      nativeMetadataRepository = new RequestBasedMetaRepository(clientConfig, backendConfig, icProvider);
     } else {
       nativeMetadataRepository = new ThinClientMetaStoreBasedRepository(clientConfig, backendConfig, icProvider);
     }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/repository/RequestBasedMetaRepository.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/repository/RequestBasedMetaRepository.java
@@ -2,6 +2,7 @@ package com.linkedin.davinci.repository;
 
 import static com.linkedin.venice.client.store.ClientConfig.defaultGenericClientConfig;
 
+import com.linkedin.venice.client.exceptions.ServiceDiscoveryException;
 import com.linkedin.venice.client.schema.RouterBackedSchemaReader;
 import com.linkedin.venice.client.store.AvroGenericStoreClientImpl;
 import com.linkedin.venice.client.store.ClientConfig;
@@ -9,6 +10,7 @@ import com.linkedin.venice.client.store.D2ServiceDiscovery;
 import com.linkedin.venice.client.store.InternalAvroStoreClient;
 import com.linkedin.venice.client.store.transport.D2TransportClient;
 import com.linkedin.venice.client.store.transport.TransportClientResponse;
+import com.linkedin.venice.exceptions.VeniceRetriableException;
 import com.linkedin.venice.meta.QueryAction;
 import com.linkedin.venice.meta.Store;
 import com.linkedin.venice.meta.StoreConfig;
@@ -19,13 +21,18 @@ import com.linkedin.venice.schema.SchemaEntry;
 import com.linkedin.venice.serialization.avro.AvroProtocolDefinition;
 import com.linkedin.venice.serializer.FastSerializerDeserializerFactory;
 import com.linkedin.venice.serializer.RecordDeserializer;
+import com.linkedin.venice.service.ICProvider;
 import com.linkedin.venice.systemstore.schemas.StoreClusterConfig;
 import com.linkedin.venice.systemstore.schemas.StoreMetaValue;
 import com.linkedin.venice.systemstore.schemas.StoreProperties;
+import com.linkedin.venice.utils.RetryUtils;
 import com.linkedin.venice.utils.VeniceProperties;
 import com.linkedin.venice.utils.concurrent.VeniceConcurrentHashMap;
+import java.time.Duration;
+import java.util.Collections;
 import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.Callable;
 import org.apache.avro.Schema;
 
 
@@ -38,6 +45,7 @@ public class RequestBasedMetaRepository extends NativeMetadataRepository {
   // storeName -> T
   VeniceConcurrentHashMap<String, SchemaData> storeSchemaMap = new VeniceConcurrentHashMap<>();
 
+  private final ICProvider icProvider;
   private final D2TransportClient d2DiscoveryTransportClient;
   private D2ServiceDiscovery d2ServiceDiscovery;
 
@@ -51,8 +59,11 @@ public class RequestBasedMetaRepository extends NativeMetadataRepository {
   VeniceConcurrentHashMap<Integer, RecordDeserializer<StoreMetaValue>> storeMetaValueDeserializers =
       new VeniceConcurrentHashMap<>();
 
-  public RequestBasedMetaRepository(ClientConfig clientConfig, VeniceProperties backendConfig) {
+  public RequestBasedMetaRepository(ClientConfig clientConfig, VeniceProperties backendConfig, ICProvider icProvider) {
     super(clientConfig, backendConfig);
+
+    // Invocation Context
+    this.icProvider = icProvider;
 
     // D2 Transport Client
     this.d2ServiceDiscovery = new D2ServiceDiscovery();
@@ -90,7 +101,7 @@ public class RequestBasedMetaRepository extends NativeMetadataRepository {
   @Override
   protected Store fetchStoreFromRemote(String storeName, String clusterName) {
     // Fetch store, bypass cache
-    StoreMetaValue storeMetaValue = fetchAndCacheStoreMetaValue(storeName);
+    StoreMetaValue storeMetaValue = fetchAndCacheStoreMetaValueWithICProvider(storeName);
     StoreProperties storeProperties = storeMetaValue.storeProperties;
     return new ZKStore(storeProperties);
   }
@@ -99,9 +110,33 @@ public class RequestBasedMetaRepository extends NativeMetadataRepository {
   protected SchemaData getSchemaData(String storeName) {
     if (!storeSchemaMap.containsKey(storeName)) {
       // Cache miss
-      fetchAndCacheStoreMetaValue(storeName);
+      fetchAndCacheStoreMetaValueWithICProvider(storeName);
     }
     return storeSchemaMap.get(storeName);
+  }
+
+  protected StoreMetaValue fetchAndCacheStoreMetaValueWithICProvider(String storeName) {
+    final Callable<StoreMetaValue> fetchAndCache = () -> fetchAndCacheStoreMetaValue(storeName);
+    final Callable<StoreMetaValue> icWrappedFetchAndCache =
+        icProvider == null ? fetchAndCache : () -> icProvider.call(getClass().getCanonicalName(), fetchAndCache);
+
+    StoreMetaValue storeMetaValue = RetryUtils.executeWithMaxAttempt(() -> {
+      try {
+        return icWrappedFetchAndCache.call();
+      } catch (ServiceDiscoveryException e) {
+        throw e;
+      } catch (Exception e) {
+        throw new VeniceRetriableException(
+            "Failed to get data from meta store using request based for store: " + storeName,
+            e);
+      }
+    }, 10, Duration.ofSeconds(1), Collections.singletonList(VeniceRetriableException.class));
+
+    if (storeMetaValue == null) {
+      throw new RuntimeException("Encountered an error while fetching meta value: " + storeName);
+    }
+
+    return storeMetaValue;
   }
 
   protected StoreMetaValue fetchAndCacheStoreMetaValue(String storeName) {

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/repository/RequestBasedMetaRepositoryTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/repository/RequestBasedMetaRepositoryTest.java
@@ -71,7 +71,7 @@ public class RequestBasedMetaRepositoryTest {
   }
 
   @Test
-  public void testRequestBasedMetaRepositoryFetchStoreConfigFromRemote() {
+  public void testFetchStoreConfigFromRemote() {
 
     // Mock RequestBasedMetaRepository
     RequestBasedMetaRepository requestBasedMetaRepository = getMockRequestBasedMetaRepository();
@@ -87,7 +87,7 @@ public class RequestBasedMetaRepositoryTest {
   }
 
   @Test
-  public void testRequestBasedMetaRepositoryFetchStoreFromRemote() {
+  public void testFetchStoreFromRemote() {
 
     // Mock RequestBasedMetaRepository
     RequestBasedMetaRepository requestBasedMetaRepository = getMockRequestBasedMetaRepository();
@@ -103,27 +103,16 @@ public class RequestBasedMetaRepositoryTest {
   }
 
   @Test
-  public void testRequestBasedMetaRepositoryFetchAndCacheStorePropertiesPayloadRecord() {
+  public void testFetchAndCacheStorePropertiesPayloadRecordWithICProvider() {
 
     // Mock RequestBasedMetaRepository
     RequestBasedMetaRepository requestBasedMetaRepository = getMockRequestBasedMetaRepository();
-    when(requestBasedMetaRepository.fetchAndCacheStoreMetaValue(store.getName())).thenCallRealMethod();
+    when(requestBasedMetaRepository.fetchStoreProperties(store.getName())).thenCallRealMethod();
+    when(requestBasedMetaRepository.fetchAndCacheStorePropertiesWithICProvider(store.getName())).thenCallRealMethod();
 
-    // Test FetchAndCacheStoreMetaValue
-    StoreMetaValue storeMetaValue = requestBasedMetaRepository.fetchAndCacheStoreMetaValue(store.getName());
-    Assert.assertNotNull(storeMetaValue);
-    Assert.assertNotNull(storeMetaValue.getStoreProperties());
-    Assert.assertEquals(storeMetaValue.getStoreProperties().getName().toString(), store.getName());
-    Assert.assertEquals(storeMetaValue.getStoreProperties().getOwner().toString(), store.getOwner());
-    Assert.assertEquals(storeMetaValue.getStoreProperties().getVersions().size(), store.getVersions().size());
-    Assert.assertEquals(storeMetaValue.getStoreKeySchemas().getKeySchemaMap().size(), 1);
-    Assert.assertEquals(storeMetaValue.getStoreValueSchemas().getValueSchemaMap().size(), 2);
-
-    // Test icProvicer
-    when(requestBasedMetaRepository.fetchAndCacheStoreMetaValueWithICProvider(store.getName())).thenCallRealMethod();
-
-    // Test FetchAndCacheStoreMetaValue
-    storeMetaValue = requestBasedMetaRepository.fetchAndCacheStoreMetaValueWithICProvider(store.getName());
+    // Test fetchAndCacheStorePropertiesWithICProvider
+    StoreMetaValue storeMetaValue =
+        requestBasedMetaRepository.fetchAndCacheStorePropertiesWithICProvider(store.getName());
     Assert.assertNotNull(storeMetaValue);
     Assert.assertNotNull(storeMetaValue.getStoreProperties());
     Assert.assertEquals(storeMetaValue.getStoreProperties().getName().toString(), store.getName());
@@ -134,7 +123,7 @@ public class RequestBasedMetaRepositoryTest {
   }
 
   @Test
-  public void testRequestBasedMetaRepositoryGetMaxValueSchemaId() {
+  public void testGetMaxValueSchemaId() {
 
     // Mock RequestBasedMetaRepository
     RequestBasedMetaRepository requestBasedMetaRepository = getMockRequestBasedMetaRepository();
@@ -159,7 +148,7 @@ public class RequestBasedMetaRepositoryTest {
   }
 
   @Test
-  public void testRequestBasedMetaRepositoryCacheStoreSchema() {
+  public void testCacheStoreSchema() {
 
     // Mock RequestBasedMetaRepository
     RequestBasedMetaRepository requestBasedMetaRepository = getMockRequestBasedMetaRepository();
@@ -178,7 +167,9 @@ public class RequestBasedMetaRepositoryTest {
 
     // Initialize class variables
     requestBasedMetaRepository.storeSchemaMap = new VeniceConcurrentHashMap<>();
+    requestBasedMetaRepository.d2TransportClientMap = new VeniceConcurrentHashMap<>();
     requestBasedMetaRepository.schemaMap = new VeniceConcurrentHashMap<>();
+    ;
     requestBasedMetaRepository.storeMetaValueSchemaReader =
         getMockRouterBackedSchemaReader(AvroProtocolDefinition.METADATA_SYSTEM_SCHEMA_STORE);
     requestBasedMetaRepository.storePropertiesSchemaReader =

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/repository/RequestBasedMetaRepositoryTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/repository/RequestBasedMetaRepositoryTest.java
@@ -118,6 +118,19 @@ public class RequestBasedMetaRepositoryTest {
     Assert.assertEquals(storeMetaValue.getStoreProperties().getVersions().size(), store.getVersions().size());
     Assert.assertEquals(storeMetaValue.getStoreKeySchemas().getKeySchemaMap().size(), 1);
     Assert.assertEquals(storeMetaValue.getStoreValueSchemas().getValueSchemaMap().size(), 2);
+
+    // Test icProvicer
+    when(requestBasedMetaRepository.fetchAndCacheStoreMetaValueWithICProvider(store.getName())).thenCallRealMethod();
+
+    // Test FetchAndCacheStoreMetaValue
+    storeMetaValue = requestBasedMetaRepository.fetchAndCacheStoreMetaValueWithICProvider(store.getName());
+    Assert.assertNotNull(storeMetaValue);
+    Assert.assertNotNull(storeMetaValue.getStoreProperties());
+    Assert.assertEquals(storeMetaValue.getStoreProperties().getName().toString(), store.getName());
+    Assert.assertEquals(storeMetaValue.getStoreProperties().getOwner().toString(), store.getOwner());
+    Assert.assertEquals(storeMetaValue.getStoreProperties().getVersions().size(), store.getVersions().size());
+    Assert.assertEquals(storeMetaValue.getStoreKeySchemas().getKeySchemaMap().size(), 1);
+    Assert.assertEquals(storeMetaValue.getStoreValueSchemas().getValueSchemaMap().size(), 2);
   }
 
   @Test


### PR DESCRIPTION
<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat], [protocol]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## Problem Statement
<!--
Describe
- What problem are you trying to solve
- What issues or limitations exist in the current code
- Why this change is necessary 
-->
DVC NativeMetadataRepository uses a icProvider to wrap store metadata requests to enable request contexting. This request wrapper was unused in RequestBasedMetaRepository. 
Additionally, executing d2 discovery for every invocation is wasteful.

## Solution
<!--
Describe
- What changes you are making and why. 
- How these changes solve the problem.
- Any performance considerations or trade-offs. 
- Describe what testings you have done, for example, performance testing etc.
-->
Wrap app server requests for metadata with the icProvider wrapper.
Cache storename to service name in map, only trigger rediscovery on exceptions.

###  Code changes
- [x] Wrap `getStoreProperties` call with icProvider
- [x] Split D2 Discovery and D2 client creation
- [x] Add retry to rediscover d2 service on failures

###  **Concurrency-Specific Checks**
Both reviewer and PR author to verify
- [x] Code has **no race conditions** or **thread safety issues**.
- [x] Proper **synchronization mechanisms** (e.g., `synchronized`, `RWLock`) are used where needed.
- [x] No **blocking calls** inside critical sections that could lead to deadlocks or performance degradation.
- [x] Verified **thread-safe collections** are used (e.g., `ConcurrentHashMap`, `CopyOnWriteArrayList`).
- [x] Validated proper exception handling in multi-threaded code to avoid silent thread termination.


## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->

- [ ] New unit tests added.
- [ ] New integration tests added.
- [ ] Modified or extended existing tests.
- [x] Verified backward compatibility (if applicable).

## Does this PR introduce any user-facing or breaking changes?
<!--  
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Clearly explain the behavior change and its impact.