### PR TITLE
[test] Move some integration tests to bucket 1440

### DIFF
--- a/internal/venice-test-common/build.gradle
+++ b/internal/venice-test-common/build.gradle
@@ -213,7 +213,11 @@ def integrationTestBuckets = [
       "com.linkedin.venice.controller.Test*"],
   "1440": [
       "com.linkedin.venice.endToEnd.DataRecoveryTest",
-      "com.linkedin.venice.controllerapi.TestControllerClient"],
+      "com.linkedin.venice.controllerapi.TestControllerClient",
+      "com.linkedin.venice.endToEnd.TestAdminOperationWithPreviousVersion",
+      "com.linkedin.venice.endToEnd.TestMaterializedViewEndToEnd",
+      "com.linkedin.venice.endToEnd.TestDeferredVersionSwap"
+  ],
   "1500":[
       "com.linkedin.venice.multicluster.TestMetadataOperationInMultiCluster",
       "com.linkedin.venice.endToEnd.MetaSystemStoreTest",


### PR DESCRIPTION
Move some integration tests to bucket 1440

## Problem Statement
- Move lengthy test to some other buckets to reduce CI time.


## Solution
- Moving below tests to bucket 1440
```
      "com.linkedin.venice.endToEnd.TestAdminOperationWithPreviousVersion",
      "com.linkedin.venice.endToEnd.TestMaterializedViewEndToEnd",
      "com.linkedin.venice.endToEnd.TestDeferredVersionSwap"
```


###  Code changes
- [ ] Added new code behind **a config**. If so list the config names and their default values in the PR description.
- [ ] Introduced new **log lines**. 
  - [ ] Confirmed if logs need to be **rate limited** to avoid excessive logging.

###  **Concurrency-Specific Checks**
Both reviewer and PR author to verify
- [ ] Code has **no race conditions** or **thread safety issues**.
- [ ] Proper **synchronization mechanisms** (e.g., `synchronized`, `RWLock`) are used where needed.
- [ ] No **blocking calls** inside critical sections that could lead to deadlocks or performance degradation.
- [ ] Verified **thread-safe collections** are used (e.g., `ConcurrentHashMap`, `CopyOnWriteArrayList`).
- [ ] Validated proper exception handling in multi-threaded code to avoid silent thread termination.


## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->

- [ ] New unit tests added.
- [ ] New integration tests added.
- [ ] Modified or extended existing tests.
- [ ] Verified backward compatibility (if applicable).

## Does this PR introduce any user-facing or breaking changes?
<!--  
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Clearly explain the behavior change and its impact.