### PR TITLE
[protocol] PartitionState/v16 Fix

### DIFF
--- a/internal/venice-common/src/main/resources/avro/PartitionState/v16/PartitionState.avsc
+++ b/internal/venice-common/src/main/resources/avro/PartitionState/v16/PartitionState.avsc
@@ -9,26 +9,6 @@
       "doc": "The last Kafka offset processed successfully in this partition from version topic.",
       "type": "long"
     }, {
-      "name": "lastProcessedVersionTopicPubSubPosition",
-      "doc": "The last PubSub position processed successfully in this partition from version topic",
-      "type": "bytes",
-      "default": ""
-    }, {
-      "name": "lastConsumedVersionTopicPubSubPosition",
-      "doc": "The last PubSub position consumed successfully in this partition from the version topic",
-      "type": "bytes",
-      "default": ""
-    }, {
-      "name": "latestObservedTermId",
-      "doc": "The most recent termId observed by this replica.",
-      "type": "long",
-      "default": -1
-    }, {
-      "name": "currentTermStartPubSubPosition",
-      "doc": "The pubsub position marking the start of the current leader's term in the version topic.",
-      "type": "bytes",
-      "default": ""
-    }, {
       "name": "offsetLag",
       "doc": "The last Kafka offset lag in this partition for fast online transition in server restart.",
       "type": "long",
@@ -230,6 +210,26 @@
         "int"
       ],
       "default": null
+    }, {
+      "name": "lastProcessedVersionTopicPubSubPosition",
+      "doc": "The last PubSub position processed successfully in this partition from version topic",
+      "type": "bytes",
+      "default": ""
+    }, {
+      "name": "lastConsumedVersionTopicPubSubPosition",
+      "doc": "The last PubSub position consumed successfully in this partition from the version topic. This is used during resubscription when the Global RT DIV feature is enabled.",
+      "type": "bytes",
+      "default": ""
+    }, {
+      "name": "latestObservedTermId",
+      "doc": "The most recent termId observed by this replica.",
+      "type": "long",
+      "default": -1
+    }, {
+      "name": "currentTermStartPubSubPosition",
+      "doc": "The pubsub position marking the start of the current leader's term in the version topic.",
+      "type": "bytes",
+      "default": ""
     }
   ]
 }


### PR DESCRIPTION
<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat], [protocol]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## Problem Statement
<!--
Describe
- What problem are you trying to solve
- What issues or limitations exist in the current code
- Why this change is necessary 
-->

`testStringMapInPartitionState()` in `TestAvroSchema` was testing serializing `PartitionState` with the current version and deserializing with `v10`. For some reason, it doesn't work if the fields are added before `upstreamOffsetMap`. Since `v10`, "java-key-class" and "avro.java.string" were added to upstreamOffsetMap:
```
    {
      "name": "upstreamOffsetMap",
      "type": {
        "type": "map",
        "values": "long",
        "java-key-class": "java.lang.String",
        "avro.java.string": "String"
      },
      "doc": "A map of upstream Kafka bootstrap server url -> the last Kafka offset consumed from upstream topic.",
      "default": {}
    }
````


## Solution
<!--
Describe
- What changes you are making and why. 
- How these changes solve the problem.
- Any performance considerations or trade-offs. 
- Describe what testings you have done, for example, performance testing etc.
-->
Move the new fields after `upstreamOffsetMap`.

## Does this PR introduce any user-facing or breaking changes?
<!--  
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [X] No. You can skip the rest of this section.