### PR TITLE
[controller] Modify the error message to contain current schema version

### DIFF
--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/kafka/protocol/serializer/AdminOperationSerializer.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/kafka/protocol/serializer/AdminOperationSerializer.java
@@ -74,7 +74,13 @@ public class AdminOperationSerializer {
     Schema targetSchema = getSchema(targetSchemaId);
 
     // Validate non-default usage for new semantic
-    SemanticDetector.traverseAndValidate(object, LATEST_SCHEMA, targetSchema, "AdminOperation", null);
+    try {
+      SemanticDetector.traverseAndValidate(object, LATEST_SCHEMA, targetSchema, "AdminOperation", null);
+    } catch (VeniceProtocolException e) {
+      throw new VeniceProtocolException(
+          String.format("Current schema version: %s. New semantic is being used. %s", targetSchemaId, e.getMessage()),
+          e);
+    }
 
     // If writer schema is not the latest schema, we need to deserialize the serialized bytes to GenericRecord with
     // the writer schema, then serialize it to bytes with the writer schema.

--- a/services/venice-controller/src/test/java/com/linkedin/venice/controller/kafka/protocol/admin/AdminOperationSerializerTest.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/controller/kafka/protocol/admin/AdminOperationSerializerTest.java
@@ -58,7 +58,7 @@ public class AdminOperationSerializerTest {
       adminOperationSerializer.serialize(adminMessage, 74);
     } catch (VeniceProtocolException e) {
       String expectedMessage =
-          "Field AdminOperation.payloadUnion.UpdateStore.separateRealTimeTopicEnabled: Boolean value true is not the default value false or false";
+          "Current schema version: 74. New semantic is being used. Field AdminOperation.payloadUnion.UpdateStore.separateRealTimeTopicEnabled: Boolean value true is not the default value false or false";
       assertEquals(e.getMessage(), expectedMessage);
     }
 


### PR DESCRIPTION
[controller] Modify the error message to contain current schema version
## Problem Statement
- Modify the error message to contain more information .

```
Before: Field AdminOperation.payloadUnion.UpdateStore.separateRealTimeTopicEnabled: Boolean value true is not the default value false or false
After: Current schema version: 74. New semantic is being used. Field AdminOperation.payloadUnion.UpdateStore.separateRealTimeTopicEnabled: Boolean value true is not the default value false or false
```

###  Code changes
- [ ] Added new code behind **a config**. If so list the config names and their default values in the PR description.
- [ ] Introduced new **log lines**. 
  - [ ] Confirmed if logs need to be **rate limited** to avoid excessive logging.

###  **Concurrency-Specific Checks**
Both reviewer and PR author to verify
- [ ] Code has **no race conditions** or **thread safety issues**.
- [ ] Proper **synchronization mechanisms** (e.g., `synchronized`, `RWLock`) are used where needed.
- [ ] No **blocking calls** inside critical sections that could lead to deadlocks or performance degradation.
- [ ] Verified **thread-safe collections** are used (e.g., `ConcurrentHashMap`, `CopyOnWriteArrayList`).
- [ ] Validated proper exception handling in multi-threaded code to avoid silent thread termination.


## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->

- [ ] New unit tests added.
- [ ] New integration tests added.
- [x] Modified or extended existing tests.
- [ ] Verified backward compatibility (if applicable).

## Does this PR introduce any user-facing or breaking changes?
<!--  
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Clearly explain the behavior change and its impact.