### PR TITLE
[controller] change in naming convention of versioned RT topics

### DIFF
--- a/internal/venice-common/src/main/java/com/linkedin/venice/meta/Version.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/meta/Version.java
@@ -305,7 +305,7 @@ public interface Version extends Comparable<Version>, DataModelBackedStructure<S
     int lastIndexOfVersionSeparator = kafkaTopic.lastIndexOf(VERSION_SEPARATOR);
 
     if (lastIndexOfVersionSeparator == 0) {
-      throw new IllegalArgumentException(
+      throw new VeniceException(
           "There is nothing prior to the version separator '" + VERSION_SEPARATOR + "' in the provided topic name: '"
               + kafkaTopic + "'");
     } else if (lastIndexOfVersionSeparator == -1) {
@@ -402,12 +402,7 @@ public interface Version extends Comparable<Version>, DataModelBackedStructure<S
     if (!isRealTimeTopic(kafkaTopic)) {
       throw new VeniceException("Kafka topic: " + kafkaTopic + " is not a real-time topic");
     }
-    String topicWithoutRTVersionSuffix = kafkaTopic;
-    try {
-      topicWithoutRTVersionSuffix = removeRTVersionSuffix(kafkaTopic);
-    } catch (IllegalArgumentException e) {
-      // nothing to do, it could be an old styled real time topic
-    }
+    String topicWithoutRTVersionSuffix = removeRTVersionSuffix(kafkaTopic);
     if (topicWithoutRTVersionSuffix.endsWith(REAL_TIME_TOPIC_SUFFIX)) {
       return topicWithoutRTVersionSuffix
           .substring(0, topicWithoutRTVersionSuffix.length() - REAL_TIME_TOPIC_SUFFIX.length());

--- a/internal/venice-common/src/main/java/com/linkedin/venice/meta/Version.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/meta/Version.java
@@ -403,12 +403,12 @@ public interface Version extends Comparable<Version>, DataModelBackedStructure<S
       throw new VeniceException("Kafka topic: " + kafkaTopic + " is not a real-time topic");
     }
     String topicWithoutRTVersionSuffix = removeRTVersionSuffix(kafkaTopic);
-    if (topicWithoutRTVersionSuffix.endsWith(REAL_TIME_TOPIC_SUFFIX)) {
-      return topicWithoutRTVersionSuffix
-          .substring(0, topicWithoutRTVersionSuffix.length() - REAL_TIME_TOPIC_SUFFIX.length());
-    }
-    return topicWithoutRTVersionSuffix
-        .substring(0, topicWithoutRTVersionSuffix.length() - SEPARATE_REAL_TIME_TOPIC_SUFFIX.length());
+
+    String suffix = topicWithoutRTVersionSuffix.endsWith(REAL_TIME_TOPIC_SUFFIX)
+        ? REAL_TIME_TOPIC_SUFFIX
+        : SEPARATE_REAL_TIME_TOPIC_SUFFIX;
+
+    return topicWithoutRTVersionSuffix.substring(0, topicWithoutRTVersionSuffix.length() - suffix.length());
   }
 
   static String parseStoreFromStreamReprocessingTopic(String kafkaTopic) {

--- a/internal/venice-common/src/main/java/com/linkedin/venice/utils/Utils.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/utils/Utils.java
@@ -1,6 +1,7 @@
 package com.linkedin.venice.utils;
 
 import static com.linkedin.venice.HttpConstants.LOCALHOST;
+import static com.linkedin.venice.meta.Version.REAL_TIME_TOPIC_SUFFIX;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -88,7 +89,7 @@ public class Utils {
   public static final AtomicBoolean SUPPRESS_SYSTEM_EXIT = new AtomicBoolean();
   public static final String SEPARATE_TOPIC_SUFFIX = "_sep";
   public static final String FATAL_DATA_VALIDATION_ERROR = "fatal data validation problem";
-  public static final String REAL_TIME_TOPIC_TEMPLATE = "%s_v%d" + Version.REAL_TIME_TOPIC_SUFFIX;
+  public static final String REAL_TIME_TOPIC_TEMPLATE = "%s" + REAL_TIME_TOPIC_SUFFIX + "_v%d";
 
   /**
    * Print an error and exit with error code 1
@@ -575,7 +576,7 @@ public class Utils {
    * {@link Utils#getRealTimeTopicName(Version)}
    */
   public static String composeRealTimeTopic(String storeName) {
-    return storeName + Version.REAL_TIME_TOPIC_SUFFIX;
+    return storeName + REAL_TIME_TOPIC_SUFFIX;
   }
 
   public static String composeRealTimeTopic(String storeName, int versionNumber) {

--- a/internal/venice-common/src/main/java/com/linkedin/venice/utils/Utils.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/utils/Utils.java
@@ -89,7 +89,6 @@ public class Utils {
   public static final AtomicBoolean SUPPRESS_SYSTEM_EXIT = new AtomicBoolean();
   public static final String SEPARATE_TOPIC_SUFFIX = "_sep";
   public static final String FATAL_DATA_VALIDATION_ERROR = "fatal data validation problem";
-  public static final String REAL_TIME_TOPIC_TEMPLATE = "%s" + REAL_TIME_TOPIC_SUFFIX + "_v%d";
 
   /**
    * Print an error and exit with error code 1
@@ -580,7 +579,7 @@ public class Utils {
   }
 
   public static String composeRealTimeTopic(String storeName, int versionNumber) {
-    return String.format(REAL_TIME_TOPIC_TEMPLATE, storeName, versionNumber);
+    return String.format(Version.REAL_TIME_TOPIC_TEMPLATE, storeName, versionNumber);
   }
 
   /**

--- a/internal/venice-common/src/test/java/com/linkedin/venice/meta/TestVersion.java
+++ b/internal/venice-common/src/test/java/com/linkedin/venice/meta/TestVersion.java
@@ -96,7 +96,7 @@ public class TestVersion {
     try {
       Version.parseStoreFromRealTimeTopic(invalidRealTimeTopic2);
       Assert.fail("VeniceException should be thrown for invalid real-time topic");
-    } catch (IllegalArgumentException e) {
+    } catch (VeniceException e) {
 
     }
   }

--- a/internal/venice-common/src/test/java/com/linkedin/venice/meta/TestVersion.java
+++ b/internal/venice-common/src/test/java/com/linkedin/venice/meta/TestVersion.java
@@ -75,8 +75,14 @@ public class TestVersion {
     String validRealTimeTopic = "abc_rt";
     assertEquals(Version.parseStoreFromRealTimeTopic(validRealTimeTopic), "abc");
 
-    String validRealTimeTopic2 = "abc_v1_rt";
+    String validRealTimeTopic2 = Utils.composeRealTimeTopic("abc", 1);
     assertEquals(Version.parseStoreFromRealTimeTopic(validRealTimeTopic2), "abc");
+
+    String validRealTimeTopic3 = Utils.composeRealTimeTopic("abc_v", 1);
+    assertEquals(Version.parseStoreFromRealTimeTopic(validRealTimeTopic3), "abc_v");
+
+    String validRealTimeTopic4 = Utils.composeRealTimeTopic("abc_v1", 1);
+    assertEquals(Version.parseStoreFromRealTimeTopic(validRealTimeTopic4), "abc_v1");
 
     String invalidRealTimeTopic = "abc";
     try {

--- a/internal/venice-common/src/test/java/com/linkedin/venice/meta/TestVersion.java
+++ b/internal/venice-common/src/test/java/com/linkedin/venice/meta/TestVersion.java
@@ -91,6 +91,14 @@ public class TestVersion {
     } catch (VeniceException e) {
 
     }
+
+    String invalidRealTimeTopic2 = "_v1_rt";
+    try {
+      Version.parseStoreFromRealTimeTopic(invalidRealTimeTopic2);
+      Assert.fail("VeniceException should be thrown for invalid real-time topic");
+    } catch (IllegalArgumentException e) {
+
+    }
   }
 
   @Test

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/controller/TestHybridStoreRepartitioningWithMultiDataCenter.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/controller/TestHybridStoreRepartitioningWithMultiDataCenter.java
@@ -317,7 +317,7 @@ public class TestHybridStoreRepartitioningWithMultiDataCenter {
       TestUtils.waitForNonDeterministicAssertion(30, TimeUnit.SECONDS, () -> {
         Assert.assertEquals(controllerClient.getStore(storeName).getStore().getVersions().size(), 2);
         // rt version should not change because there is no more partition count update
-        String expectedRealTimeTopicName = storeName + "_v2" + Version.REAL_TIME_TOPIC_SUFFIX;
+        String expectedRealTimeTopicName = Utils.composeRealTimeTopic(storeName, 2);
         // verify rt topic name
         verifyStoreState(
             childControllerClients[0],
@@ -412,7 +412,7 @@ public class TestHybridStoreRepartitioningWithMultiDataCenter {
         StoreInfo storeInfo = childControllerClients[idx].getStore(storeName).getStore();
         Assert.assertEquals(storeInfo.getVersions().size(), 2);
 
-        String expectedRealTimeTopicNameInBackupVersion = storeName + "_v3" + Version.REAL_TIME_TOPIC_SUFFIX;
+        String expectedRealTimeTopicNameInBackupVersion = Utils.composeRealTimeTopic(storeName, 3);
         // because we updated partition count, rt version should increase to v2
         String expectedRealTimeTopicName = Utils.composeRealTimeTopic(storeName, 4);
 

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestStoreMigration.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestStoreMigration.java
@@ -212,10 +212,10 @@ public class TestStoreMigration {
     Assert.assertEquals(
         storeInfo.getHybridStoreConfig().getRealTimeTopicName(),
         Utils.composeRealTimeTopic(storeName, 1));
-    // we set largestUsedRTVersionNumber=2 before VPJ, so the version would have rt=<store_name>_v2_rt
+    // we set largestUsedRTVersionNumber=2 before VPJ, so the version would have rt=<store_name>_rt_v2
     Assert.assertEquals(
         storeInfo.getVersions().get(0).getHybridStoreConfig().getRealTimeTopicName(),
-        storeName + "_v2" + Version.REAL_TIME_TOPIC_SUFFIX);
+        Utils.composeRealTimeTopic(storeName, 2));
 
     // Test abort migration on parent controller
     try (ControllerClient srcParentControllerClient = new ControllerClient(srcClusterName, parentControllerUrl);

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceHelixAdmin.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceHelixAdmin.java
@@ -15,6 +15,7 @@ import static com.linkedin.venice.meta.HybridStoreConfigImpl.DEFAULT_REWIND_TIME
 import static com.linkedin.venice.meta.Store.NON_EXISTING_VERSION;
 import static com.linkedin.venice.meta.Version.DEFAULT_RT_VERSION_NUMBER;
 import static com.linkedin.venice.meta.Version.PushType;
+import static com.linkedin.venice.meta.Version.REAL_TIME_TOPIC_SUFFIX;
 import static com.linkedin.venice.meta.VersionStatus.ERROR;
 import static com.linkedin.venice.meta.VersionStatus.KILLED;
 import static com.linkedin.venice.meta.VersionStatus.NOT_CREATED;
@@ -2062,6 +2063,12 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
   }
 
   private void checkStoreNameConflict(String storeName, boolean allowSystemStore) {
+    if (storeName.endsWith(REAL_TIME_TOPIC_SUFFIX)) {
+      throw new VeniceException(
+          "Store name: " + storeName + " ends with a keyword - `" + REAL_TIME_TOPIC_SUFFIX + "`"
+              + " reserved for internal usage, please change it.");
+    }
+
     if (storeName.equals(AbstractVeniceAggStats.STORE_NAME_FOR_TOTAL_STAT)) {
       throw new VeniceException("Store name: " + storeName + " clashes with the internal usage, please change it");
     }

--- a/services/venice-controller/src/test/java/com/linkedin/venice/controller/kafka/TestTopicCleanupService.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/controller/kafka/TestTopicCleanupService.java
@@ -201,7 +201,7 @@ public class TestTopicCleanupService {
   @Test
   public void testCleanupVeniceTopics() {
     String clusterName = "clusterName";
-    String rtVersionPrefix = "_v1" + Version.REAL_TIME_TOPIC_SUFFIX;
+    String rtVersionPrefix = Version.REAL_TIME_TOPIC_SUFFIX + "_v1";
     String storeName1 = Utils.getUniqueString("store1");
     String storeName2 = Utils.getUniqueString("store2");
     String storeName3 = Utils.getUniqueString("store3");

--- a/services/venice-controller/src/test/java/com/linkedin/venice/controller/server/CreateVersionTest.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/controller/server/CreateVersionTest.java
@@ -774,7 +774,7 @@ public class CreateVersionTest {
 
     // Test Case 1: Real-time topic returns NO_OP
     Version mockVersion1 = mock(Version.class);
-    String responseTopic1 = "test_store_v1" + Version.REAL_TIME_TOPIC_SUFFIX;
+    String responseTopic1 = Utils.composeRealTimeTopic("test_store", 1);
     CompressionStrategy result1 = createVersion.getCompressionStrategy(mockVersion1, responseTopic1);
     assertEquals(result1, CompressionStrategy.NO_OP);
 


### PR DESCRIPTION
<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat], [protocol]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## Problem Statement
<!--
Describe
- What problem are you trying to solve
- What issues or limitations exist in the current code
- Why this change is necessary 
-->
PR https://github.com/linkedin/venice/pull/1555/ made RT topics versioned, i.e. they will be named like "storeName_v1_rt" "storeName_v2_rt". This has a problem; given an RT name, we cannot deterministically tell the store name.
e.g. if the RT name is "myStore_v1_rt", the store name, could be "myStore" (if the store is following RT versioning), or it could also be "myStore_v1" (if the store is not following the RT versioning).
The root of the problem is the special keyword "v1" in the end of the store name. 

Special keyword "rt" in the end of the store name, also creates problem.  If we are provided a kafka topic name "store_rt_v1", we cannot tell if it is a VT topic of `store_rt` or an RT topic of `store`

## Solution
<!--
Describe
- What changes you are making and why. 
- How these changes solve the problem.
- Any performance considerations or trade-offs. 
- Describe what testings you have done, for example, performance testing etc.
-->
The solution is to move versions after the `_rt` not before it, so the versioned names would be "storeName_rt_v1", "storeName_rt_v2".

For the second problem, we will disallow any store to have `_rt` as a suffix.

###  Code changes
- [ ] Added new code behind **a config**. If so list the config names and their default values in the PR description.
- [ ] Introduced new **log lines**. 
  - [ ] Confirmed if logs need to be **rate limited** to avoid excessive logging.

###  **Concurrency-Specific Checks**
Both reviewer and PR author to verify
- [x] Code has **no race conditions** or **thread safety issues**.
- [ ] Proper **synchronization mechanisms** (e.g., `synchronized`, `RWLock`) are used where needed.
- [ ] No **blocking calls** inside critical sections that could lead to deadlocks or performance degradation.
- [ ] Verified **thread-safe collections** are used (e.g., `ConcurrentHashMap`, `CopyOnWriteArrayList`).
- [ ] Validated proper exception handling in multi-threaded code to avoid silent thread termination.


## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->

- [ ] New unit tests added.
- [ ] New integration tests added.
- [x] Modified or extended existing tests.
- [ ] Verified backward compatibility (if applicable).

## Does this PR introduce any user-facing or breaking changes?
<!--  
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Clearly explain the behavior change and its impact.