### PR TITLE
[server] Per-Server Assembled Record Size Metric

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/HostLevelIngestionStats.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/HostLevelIngestionStats.java
@@ -299,11 +299,23 @@ public class HostLevelIngestionStats extends AbstractVeniceStats {
         new Max(),
         TehutiUtils.getPercentileStat(getName() + AbstractVeniceStats.DELIMITER + valueSizeSensorName));
 
-    this.assembledRecordSizeSensor = registerSensor(ASSEMBLED_RECORD_SIZE_IN_BYTES, avgAndMax());
+    this.assembledRecordSizeSensor = registerPerStoreAndTotalSensor(
+        ASSEMBLED_RECORD_SIZE_IN_BYTES,
+        totalStats,
+        () -> totalStats.assembledRecordSizeSensor,
+        new Max());
 
-    this.assembledRecordSizeRatioSensor = registerSensor(ASSEMBLED_RECORD_SIZE_RATIO, new Max());
+    this.assembledRecordSizeRatioSensor = registerPerStoreAndTotalSensor(
+        ASSEMBLED_RECORD_SIZE_RATIO,
+        totalStats,
+        () -> totalStats.assembledRecordSizeRatioSensor,
+        new Max());
 
-    this.assembledRmdSizeSensor = registerSensor(ASSEMBLED_RMD_SIZE_IN_BYTES, avgAndMax());
+    this.assembledRmdSizeSensor = registerPerStoreAndTotalSensor(
+        ASSEMBLED_RMD_SIZE_IN_BYTES,
+        totalStats,
+        () -> totalStats.assembledRmdSizeSensor,
+        new Max());
 
     String viewTimerSensorName = "total_view_writer_latency";
     this.viewProducerLatencySensor = registerPerStoreAndTotalSensor(

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/PartialUpdateTest.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/PartialUpdateTest.java
@@ -1033,9 +1033,9 @@ public class PartialUpdateTest {
       veniceProducer.stop();
     }
 
-    String baseMetricName = AbstractVeniceStats.getSensorFullName(storeName, ASSEMBLED_RMD_SIZE_IN_BYTES);
-    List<Double> assembledRmdSizes = MetricsUtils.getAvgMax(baseMetricName, veniceCluster.getVeniceServers());
-    MetricsUtils.validateMetricRange(assembledRmdSizes, 290000, 740000);
+    String metricName = AbstractVeniceStats.getSensorFullName(storeName, ASSEMBLED_RMD_SIZE_IN_BYTES) + ".Max";
+    double assembledRmdSize = MetricsUtils.getMax(metricName, veniceCluster.getVeniceServers());
+    assertTrue(assembledRmdSize >= 290000 && assembledRmdSize <= 740000);
   }
 
   @Test(timeOut = TEST_TIMEOUT_MS * 3)

--- a/internal/venice-test-common/src/main/java/com/linkedin/venice/tehuti/MetricsUtils.java
+++ b/internal/venice-test-common/src/main/java/com/linkedin/venice/tehuti/MetricsUtils.java
@@ -2,7 +2,6 @@ package com.linkedin.venice.tehuti;
 
 import io.tehuti.Metric;
 import io.tehuti.metrics.MetricsRepository;
-import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -31,20 +30,6 @@ public class MetricsUtils {
       int previousCount = count.getAndIncrement();
       return (left * previousCount + right) / (previousCount + 1);
     }, 0.0));
-  }
-
-  public static List<Double> getAvgMax(String baseMetricName, List<? extends MetricsAware> metricsAwareWrapperList) {
-    return Arrays.asList(
-        getAvg(baseMetricName + ".Avg", metricsAwareWrapperList),
-        getMax(baseMetricName + ".Max", metricsAwareWrapperList));
-  }
-
-  public static void validateMetricRange(List<Double> metricValues, double min, double max) throws Exception {
-    for (double value: metricValues) {
-      if (value < min || value > max) {
-        throw new Exception(String.format("Metric value %f is not in range [%f, %f]", value, min, max));
-      }
-    }
   }
 
   public static double getMetricValue(


### PR DESCRIPTION
<!--Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat], [protocol]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## Problem Statement
<!--
Describe
- What problem are you trying to solve
- What issues or limitations exist in the current code
- Why this change is necessary 
-->
 The `assembled_record_size` metric is currently per-store, but it would be useful to have a global / total view, so we can easily see that there's something awry within the cluster. Using `consolidate` on this per-server metric should give us the per-cluster level view.

## Solution
<!--
Describe
- What changes you are making and why. 
- How these changes solve the problem.
- Any performance considerations or trade-offs. 
- Describe what testings you have done, for example, performance testing etc.
-->
Adding per-server / total metric for `assembled_record_size`.

## Does this PR introduce any user-facing or breaking changes?
<!--  
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [X] No. You can skip the rest of this section.