### PR TITLE
Adding Store Discovery Metrics for CC/DVC users access history

### DIFF
--- a/internal/venice-client-common/src/main/java/com/linkedin/venice/stats/D2Stats.java
+++ b/internal/venice-client-common/src/main/java/com/linkedin/venice/stats/D2Stats.java
@@ -1,0 +1,27 @@
+package com.linkedin.venice.stats;
+
+import io.tehuti.metrics.MetricsRepository;
+import io.tehuti.metrics.Sensor;
+import io.tehuti.metrics.stats.Count;
+
+
+public class D2Stats extends AbstractVeniceStats {
+  private static final String METRIC_PREFIX = "d2_store_discovery";
+  private final Sensor storeDiscoverySuccessCount;
+  private final Sensor storeDiscoveryFailureCount;
+
+  public D2Stats(MetricsRepository metricsRepository, String storeName) {
+    super(metricsRepository, METRIC_PREFIX);
+    storeDiscoverySuccessCount = registerSensor(storeName + "-success_request_count", new Count());
+    storeDiscoveryFailureCount = registerSensor(storeName + "-failure_request_count", new Count());
+  }
+
+  public void recordStoreDiscoverySuccess() {
+    storeDiscoverySuccessCount.record();
+  }
+
+  public void recordStoreDiscoveryFailure() {
+    storeDiscoveryFailureCount.record();
+  }
+
+}

--- a/services/venice-router/src/main/java/com/linkedin/venice/router/RouterServer.java
+++ b/services/venice-router/src/main/java/com/linkedin/venice/router/RouterServer.java
@@ -601,7 +601,8 @@ public class RouterServer extends AbstractVeniceService {
         config.getKafkaBootstrapServers(),
         config.isSslToKafka(),
         versionFinder,
-        pushStatusStoreReader);
+        pushStatusStoreReader,
+        metricsRepository);
 
     // Setup stat tracking for exceptional case
     RouterExceptionAndTrackingUtils.setRouterStats(routerStats);

--- a/services/venice-router/src/test/java/com/linkedin/venice/router/TestMetaDataHandler.java
+++ b/services/venice-router/src/test/java/com/linkedin/venice/router/TestMetaDataHandler.java
@@ -694,6 +694,10 @@ public class TestMetaDataHandler {
     Assert.assertEquals(d2ServiceResponse.getD2Service(), d2Service);
     Assert.assertEquals(d2ServiceResponse.getName(), storeName);
     Assert.assertFalse(d2ServiceResponse.isError());
+    Assert.assertEquals(
+        metricsRepository.getMetric(".d2_store_discovery--" + storeName + "-success_request_count.Count").value(),
+        1.0,
+        "Request count should be 1 after first request");
 
     FullHttpResponse response2 = passRequestToMetadataHandler(
         "http://myRouterHost:4567/discover_cluster?store_name=" + storeName,
@@ -713,8 +717,8 @@ public class TestMetaDataHandler {
     Assert.assertFalse(d2ServiceResponse2.isError());
     Assert.assertEquals(
         metricsRepository.getMetric(".d2_store_discovery--" + storeName + "-success_request_count.Count").value(),
-        1.0,
-        "Request count should be 1 after first request");
+        2.0,
+        "Request count should be 2 after second request");
   }
 
   @Test


### PR DESCRIPTION
## Summary

This PR adds metrics to track D2 store discovery requests in Venice, specifically for MetaDataHandler’s `handleD2ServiceLookup` endpoint.

## Background

As discussed with @xunyin8, D2 store discovery calls are part of the initialization step for DVC and CC users so while a user may not be exercising the read/write path, their code could still be initializing the DVC and CC, which includes the D2 Store Discovery step. As part of the process before deleting a store (not detecting if a store is dead), we need to track the store discovery endpoint to ensure there were no inquiries against the store, otherwise it's still in use and can't be deleted yet.

## What’s New

- Introduced a new `D2Stats` class to track:
  - `storeDiscoverySuccessCount`
  - `storeDiscoveryFailureCount`
- Injected `MetricsRepository` into `MetaDataHandler`
- Captured store-specific D2 success/failure metrics inside `handleD2ServiceLookup`
- Added tests to validate success/failure metrics for store discovery in `TestMetaDataHandler`

## Why This Matters

- Helps track actual usage/access patterns across CC/DVC/TC/FC
- Enables us to infer store inactivity:
  - If no D2 discovery calls are made in 30+ days, it's likely that no clients (and no reads) exist for that store
- Sets the groundwork for future cleanup in auto-sunset workflows

## Example Metrics

```text
d2_store_discovery--<store_name>-success_request_count.Count
d2_store_discovery--<store_name>-failure_request_count.Count
```