### PR TITLE
[controller] Controller API to get all Admin Operation Version for leader+standby controllers given cluster name 

### DIFF
--- a/internal/venice-common/src/main/java/com/linkedin/venice/controllerapi/AdminOperationProtocolVersionControllerResponse.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/controllerapi/AdminOperationProtocolVersionControllerResponse.java
@@ -7,7 +7,7 @@ import java.util.Map;
 public class AdminOperationProtocolVersionControllerResponse extends ControllerResponse {
   private long localAdminOperationProtocolVersion = -1;
   private String requestUrl = "";
-  private Map<String, Long> urlToVersionMap = new HashMap<>();
+  private Map<String, Long> controllerUrlToVersionMap = new HashMap<>();
 
   public void setLocalAdminOperationProtocolVersion(long adminOperationProtocolVersion) {
     this.localAdminOperationProtocolVersion = adminOperationProtocolVersion;
@@ -25,11 +25,11 @@ public class AdminOperationProtocolVersionControllerResponse extends ControllerR
     return requestUrl;
   }
 
-  public void setUrlToVersionMap(Map<String, Long> urlToVersionMap) {
-    this.urlToVersionMap = urlToVersionMap;
+  public void setControllerUrlToVersionMap(Map<String, Long> urlToVersionMap) {
+    this.controllerUrlToVersionMap = urlToVersionMap;
   }
 
-  public Map<String, Long> getUrlToVersionMap() {
-    return urlToVersionMap;
+  public Map<String, Long> getControllerUrlToVersionMap() {
+    return controllerUrlToVersionMap;
   }
 }

--- a/internal/venice-common/src/main/java/com/linkedin/venice/controllerapi/AdminOperationProtocolVersionControllerResponse.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/controllerapi/AdminOperationProtocolVersionControllerResponse.java
@@ -1,12 +1,13 @@
 package com.linkedin.venice.controllerapi;
 
+import java.util.HashMap;
 import java.util.Map;
 
 
 public class AdminOperationProtocolVersionControllerResponse extends ControllerResponse {
   private long localAdminOperationProtocolVersion = -1;
-  private String requestUrl;
-  private Map<String, Long> urlToVersionMap;
+  private String requestUrl = "";
+  private Map<String, Long> urlToVersionMap = new HashMap<>();
 
   public void setLocalAdminOperationProtocolVersion(long adminOperationProtocolVersion) {
     this.localAdminOperationProtocolVersion = adminOperationProtocolVersion;

--- a/internal/venice-common/src/main/java/com/linkedin/venice/controllerapi/AdminOperationProtocolVersionControllerResponse.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/controllerapi/AdminOperationProtocolVersionControllerResponse.java
@@ -1,0 +1,34 @@
+package com.linkedin.venice.controllerapi;
+
+import java.util.Map;
+
+
+public class AdminOperationProtocolVersionControllerResponse extends ControllerResponse {
+  private long localAdminOperationProtocolVersion = -1;
+  private String requestUrl;
+  private Map<String, Long> urlToVersionMap;
+
+  public void setLocalAdminOperationProtocolVersion(long adminOperationProtocolVersion) {
+    this.localAdminOperationProtocolVersion = adminOperationProtocolVersion;
+  }
+
+  public long getLocalAdminOperationProtocolVersion() {
+    return localAdminOperationProtocolVersion;
+  }
+
+  public void setRequestUrl(String url) {
+    this.requestUrl = url;
+  }
+
+  public String getRequestUrl() {
+    return requestUrl;
+  }
+
+  public void setUrlToVersionMap(Map<String, Long> urlToVersionMap) {
+    this.urlToVersionMap = urlToVersionMap;
+  }
+
+  public Map<String, Long> getUrlToVersionMap() {
+    return urlToVersionMap;
+  }
+}

--- a/internal/venice-common/src/main/java/com/linkedin/venice/controllerapi/ControllerClient.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/controllerapi/ControllerClient.java
@@ -1412,6 +1412,23 @@ public class ControllerClient implements Closeable {
     return request(ControllerRoute.UPDATE_ADMIN_OPERATION_PROTOCOL_VERSION, params, AdminTopicMetadataResponse.class);
   }
 
+  public AdminOperationProtocolVersionControllerResponse getAdminOperationProtocolVersionFromControllers(
+      String clusterName) {
+    QueryParams params = newParams().add(CLUSTER, clusterName);
+    return request(
+        ControllerRoute.GET_ADMIN_OPERATION_VERSION_FROM_CONTROLLERS,
+        params,
+        AdminOperationProtocolVersionControllerResponse.class);
+  }
+
+  public AdminOperationProtocolVersionControllerResponse getLocalAdminOperationProtocolVersion() {
+    // TODO: Modify this method to send to given controller url
+    return request(
+        ControllerRoute.GET_LOCAL_ADMIN_OPERATION_PROTOCOL_VERSION,
+        newParams(),
+        AdminOperationProtocolVersionControllerResponse.class);
+  }
+
   public ControllerResponse deleteKafkaTopic(String topicName) {
     QueryParams params = newParams().add(TOPIC, topicName);
     return request(ControllerRoute.DELETE_KAFKA_TOPIC, params, ControllerResponse.class);

--- a/internal/venice-common/src/main/java/com/linkedin/venice/controllerapi/ControllerRoute.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/controllerapi/ControllerRoute.java
@@ -293,8 +293,13 @@ public enum ControllerRoute {
   UPDATE_ADMIN_OPERATION_PROTOCOL_VERSION(
       "/update_admin_operation_protocol_version", HttpMethod.POST,
       Arrays.asList(CLUSTER, ADMIN_OPERATION_PROTOCOL_VERSION)
+  ),
+  GET_ADMIN_OPERATION_VERSION_FROM_CONTROLLERS(
+      "/get_admin_operation_version_from_controllers", HttpMethod.GET, Collections.singletonList(CLUSTER)
+  ),
+  GET_LOCAL_ADMIN_OPERATION_PROTOCOL_VERSION(
+      "/get_local_admin_operation_protocol_version", HttpMethod.GET, Collections.emptyList()
   ), DELETE_KAFKA_TOPIC("/delete_kafka_topic", HttpMethod.POST, Arrays.asList(CLUSTER, TOPIC)),
-
   CREATE_STORAGE_PERSONA(
       "/create_storage_persona", HttpMethod.POST,
       Arrays.asList(CLUSTER, PERSONA_NAME, PERSONA_QUOTA, PERSONA_STORES, PERSONA_OWNERS)

--- a/internal/venice-common/src/main/java/com/linkedin/venice/helix/HelixState.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/helix/HelixState.java
@@ -24,4 +24,16 @@ public enum HelixState {
   public static final String ERROR_STATE = "ERROR";
   public static final String LEADER_STATE = "LEADER";
   public static final String STANDBY_STATE = "STANDBY";
+
+  public static boolean isValidHelixState(String state) {
+    if (state == null || state.isEmpty()) {
+      return false;
+    }
+    for (HelixState helixState: HelixState.values()) {
+      if (helixState.name().equals(state)) {
+        return true;
+      }
+    }
+    return false;
+  }
 }

--- a/internal/venice-common/src/test/java/com/linkedin/venice/helix/TestHelixState.java
+++ b/internal/venice-common/src/test/java/com/linkedin/venice/helix/TestHelixState.java
@@ -1,0 +1,18 @@
+package com.linkedin.venice.helix;
+
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+
+import org.testng.annotations.Test;
+
+
+/**
+ * Test validate HelixState.
+ */
+public class TestHelixState {
+  @Test
+  public void testValidateHelixState() {
+    assertTrue(HelixState.isValidHelixState(HelixState.STANDBY_STATE));
+    assertFalse(HelixState.isValidHelixState("start"));
+  }
+}

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/controller/TestAdminOperationVersionDetection.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/controller/TestAdminOperationVersionDetection.java
@@ -1,0 +1,108 @@
+package com.linkedin.venice.controller;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+
+import com.linkedin.venice.ConfigKeys;
+import com.linkedin.venice.controller.kafka.protocol.serializer.AdminOperationSerializer;
+import com.linkedin.venice.controllerapi.AdminOperationProtocolVersionControllerResponse;
+import com.linkedin.venice.controllerapi.ControllerClient;
+import com.linkedin.venice.integration.utils.ServiceFactory;
+import com.linkedin.venice.integration.utils.VeniceClusterWrapper;
+import com.linkedin.venice.integration.utils.VeniceControllerWrapper;
+import com.linkedin.venice.integration.utils.VeniceMultiClusterWrapper;
+import com.linkedin.venice.integration.utils.VeniceMultiRegionClusterCreateOptions;
+import com.linkedin.venice.integration.utils.VeniceTwoLayerMultiRegionMultiClusterWrapper;
+import com.linkedin.venice.utils.Time;
+import java.util.Map;
+import java.util.Properties;
+import java.util.stream.IntStream;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+
+public class TestAdminOperationVersionDetection {
+  private static final int TEST_TIMEOUT = 30 * Time.MS_PER_SECOND;
+  private static final int NUMBER_OF_CHILD_DATACENTERS = 2;
+  private static final int NUMBER_OF_CLUSTERS = 1;
+  private static final int NUMBER_OF_CONTROLLERS = 2;
+
+  private VeniceTwoLayerMultiRegionMultiClusterWrapper multiRegionMultiClusterWrapper;
+  private static final String[] CLUSTER_NAMES =
+      IntStream.range(0, NUMBER_OF_CLUSTERS).mapToObj(i -> "venice-cluster" + i).toArray(String[]::new); // ["venice-cluster0",
+  // "venice-cluster1",
+  // ...];
+
+  @BeforeClass(alwaysRun = true)
+  public void setUp() throws Exception {
+    // Create multi-region multi-cluster setup
+    Properties parentControllerProperties = new Properties();
+    Properties serverProperties = new Properties();
+    serverProperties.setProperty(ConfigKeys.SERVER_PROMOTION_TO_LEADER_REPLICA_DELAY_SECONDS, Long.toString(1));
+
+    VeniceMultiRegionClusterCreateOptions.Builder optionsBuilder =
+        new VeniceMultiRegionClusterCreateOptions.Builder().numberOfRegions(NUMBER_OF_CHILD_DATACENTERS)
+            .numberOfClusters(NUMBER_OF_CLUSTERS)
+            .numberOfParentControllers(NUMBER_OF_CONTROLLERS)
+            .numberOfChildControllers(NUMBER_OF_CONTROLLERS)
+            .numberOfServers(1)
+            .numberOfRouters(1)
+            .replicationFactor(1)
+            .sslToStorageNodes(true)
+            .forkServer(false)
+            .serverProperties(serverProperties)
+            .parentControllerProperties(parentControllerProperties);
+    multiRegionMultiClusterWrapper =
+        ServiceFactory.getVeniceTwoLayerMultiRegionMultiClusterWrapper(optionsBuilder.build());
+  }
+
+  @AfterClass(alwaysRun = true)
+  public void cleanUp() {
+    multiRegionMultiClusterWrapper.close();
+  }
+
+  @Test(timeOut = TEST_TIMEOUT)
+  public void testGetAdminOperationVersionForParentControllers() {
+    String clusterName = CLUSTER_NAMES[0]; // "venice-cluster0"
+    VeniceControllerWrapper parentController =
+        multiRegionMultiClusterWrapper.getLeaderParentControllerWithRetries(clusterName);
+    ControllerClient parentControllerClient = new ControllerClient(clusterName, parentController.getControllerUrl());
+
+    AdminOperationProtocolVersionControllerResponse response =
+        parentControllerClient.getAdminOperationProtocolVersionFromControllers(clusterName);
+    assertFalse(response.isError());
+    assertEquals(
+        response.getLocalAdminOperationProtocolVersion(),
+        AdminOperationSerializer.LATEST_SCHEMA_ID_FOR_ADMIN_OPERATION);
+    Map<String, Long> urlToVersionMap = response.getUrlToVersionMap();
+    // TODO: This result should be 2 when we actually forward request to standby
+    assertEquals(urlToVersionMap.size(), 1);
+    assertEquals(response.getCluster(), clusterName);
+  }
+
+  @Test(timeOut = TEST_TIMEOUT)
+  public void testAdminOperationVersionForChildControllers() {
+    String clusterName = CLUSTER_NAMES[0]; // "venice-cluster0"
+
+    VeniceMultiClusterWrapper childRegionMultiClusterWrapper = multiRegionMultiClusterWrapper.getChildRegions().get(0);
+    VeniceClusterWrapper childRegionClusterWrapper = childRegionMultiClusterWrapper.getClusters().get(clusterName);
+    ControllerClient childControllerClient = childRegionClusterWrapper.getVeniceControllers()
+        .stream()
+        .filter(controller -> controller.isLeaderController(clusterName))
+        .findFirst()
+        .map(controller -> new ControllerClient(clusterName, controller.getControllerUrl()))
+        .orElse(null);
+
+    AdminOperationProtocolVersionControllerResponse response =
+        childControllerClient.getAdminOperationProtocolVersionFromControllers(clusterName);
+    assertFalse(response.isError());
+    assertEquals(
+        response.getLocalAdminOperationProtocolVersion(),
+        AdminOperationSerializer.LATEST_SCHEMA_ID_FOR_ADMIN_OPERATION);
+    Map<String, Long> urlToVersionMap = response.getUrlToVersionMap();
+    // TODO: This result should be 2 when we actually forward request to standby
+    assertEquals(urlToVersionMap.size(), 1);
+    assertEquals(response.getCluster(), clusterName);
+  }
+}

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/controller/TestAdminOperationVersionDetection.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/controller/TestAdminOperationVersionDetection.java
@@ -75,7 +75,7 @@ public class TestAdminOperationVersionDetection {
     assertEquals(
         response.getLocalAdminOperationProtocolVersion(),
         AdminOperationSerializer.LATEST_SCHEMA_ID_FOR_ADMIN_OPERATION);
-    Map<String, Long> urlToVersionMap = response.getUrlToVersionMap();
+    Map<String, Long> urlToVersionMap = response.getControllerUrlToVersionMap();
     // TODO: This result should be 2 when we actually forward request to standby
     assertEquals(urlToVersionMap.size(), 1);
     assertEquals(response.getCluster(), clusterName);
@@ -100,7 +100,7 @@ public class TestAdminOperationVersionDetection {
     assertEquals(
         response.getLocalAdminOperationProtocolVersion(),
         AdminOperationSerializer.LATEST_SCHEMA_ID_FOR_ADMIN_OPERATION);
-    Map<String, Long> urlToVersionMap = response.getUrlToVersionMap();
+    Map<String, Long> urlToVersionMap = response.getControllerUrlToVersionMap();
     // TODO: This result should be 2 when we actually forward request to standby
     assertEquals(urlToVersionMap.size(), 1);
     assertEquals(response.getCluster(), clusterName);

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/Admin.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/Admin.java
@@ -977,6 +977,10 @@ public interface Admin extends AutoCloseable, Closeable {
 
   void updateAdminOperationProtocolVersion(String clusterName, Long adminOperationProtocolVersion);
 
+  Map<String, Long> getAdminOperationVersionFromControllers(String clusterName);
+
+  long getLocalAdminOperationProtocolVersion();
+
   void createStoragePersona(
       String clusterName,
       String name,

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceHelixAdmin.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceHelixAdmin.java
@@ -61,12 +61,14 @@ import com.linkedin.venice.controller.kafka.StoreStatusDecider;
 import com.linkedin.venice.controller.kafka.consumer.AdminConsumerService;
 import com.linkedin.venice.controller.kafka.protocol.admin.HybridStoreConfigRecord;
 import com.linkedin.venice.controller.kafka.protocol.admin.StoreViewConfigRecord;
+import com.linkedin.venice.controller.kafka.protocol.serializer.AdminOperationSerializer;
 import com.linkedin.venice.controller.logcompaction.CompactionManager;
 import com.linkedin.venice.controller.logcompaction.LogCompactionService;
 import com.linkedin.venice.controller.repush.RepushJobRequest;
 import com.linkedin.venice.controller.repush.RepushOrchestrator;
 import com.linkedin.venice.controller.stats.DisabledPartitionStats;
 import com.linkedin.venice.controller.stats.PushJobStatusStats;
+import com.linkedin.venice.controllerapi.AdminOperationProtocolVersionControllerResponse;
 import com.linkedin.venice.controllerapi.ControllerClient;
 import com.linkedin.venice.controllerapi.ControllerResponse;
 import com.linkedin.venice.controllerapi.ControllerRoute;
@@ -7240,6 +7242,20 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
    */
   @Override
   public Instance getLeaderController(String clusterName) {
+    List<Instance> leaderControllers = getControllersByHelixState(clusterName, HelixState.LEADER_STATE);
+    return leaderControllers.get(0);
+  }
+
+  /**
+   * Get controllers instance based on the given helix state.
+   * We look at the external view of the controller cluster to find the venice controller by the wanted state.
+   */
+  public List<Instance> getControllersByHelixState(String clusterName, String helixState) {
+    // Validate helix state
+    if (!HelixState.isValidHelixState(helixState)) {
+      throw new VeniceException("Invalid Helix state: " + helixState);
+    }
+
     if (!multiClusterConfigs.getClusters().contains(clusterName)) {
       throw new VeniceNoClusterException(clusterName);
     }
@@ -7248,35 +7264,44 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
     String partitionName = HelixUtils.getPartitionName(clusterName, 0);
     for (int attempt = 1; attempt <= maxAttempts; ++attempt) {
       ExternalView externalView = helixManager.getHelixDataAccessor().getProperty(keyBuilder.externalView(clusterName));
+      List<Instance> controllers = new ArrayList<>();
       if (externalView == null || externalView.getStateMap(partitionName) == null) {
         // Assignment is incomplete, try again later
         continue;
       }
       Map<String, String> veniceClusterStateMap = externalView.getStateMap(partitionName);
       for (Map.Entry<String, String> instanceNameAndState: veniceClusterStateMap.entrySet()) {
-        if (instanceNameAndState.getValue().equals(HelixState.LEADER_STATE)) {
-          // Found the Venice controller leader
+        if (instanceNameAndState.getValue().equals(helixState)) {
+          // Found the Venice controller, adding to the return list
           String id = instanceNameAndState.getKey();
-          return new Instance(
-              id,
-              Utils.parseHostFromHelixNodeIdentifier(id),
-              Utils.parsePortFromHelixNodeIdentifier(id),
-              multiClusterConfigs.getAdminSecurePort(),
-              multiClusterConfigs.getAdminGrpcPort(),
-              multiClusterConfigs.getAdminSecureGrpcPort());
+          controllers.add(
+              new Instance(
+                  id,
+                  Utils.parseHostFromHelixNodeIdentifier(id),
+                  Utils.parsePortFromHelixNodeIdentifier(id),
+                  multiClusterConfigs.getAdminSecurePort(),
+                  multiClusterConfigs.getAdminGrpcPort(),
+                  multiClusterConfigs.getAdminSecureGrpcPort()));
         }
       }
+
+      // Return the controllers if found
+      if (!controllers.isEmpty()) {
+        return controllers;
+      }
+
       if (attempt < maxAttempts) {
         LOGGER.warn(
-            "Venice controller leader does not exist for cluster: {}, attempt: {}/{}",
+            "Venice controller with state {} does not exist for cluster: {}, attempt: {}/{}",
+            helixState,
             clusterName,
             attempt,
             maxAttempts);
         Utils.sleep(5 * Time.MS_PER_SECOND);
       }
     }
-    String message =
-        "Unable to find Venice controller leader for cluster: " + clusterName + " after " + maxAttempts + " attempts";
+    String message = "Unable to find Venice controller" + helixState + "for cluster: " + clusterName + " after "
+        + maxAttempts + " attempts";
     LOGGER.error(message);
     throw new VeniceException(message);
   }
@@ -7647,6 +7672,51 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
   public void updateAdminOperationProtocolVersion(String clusterName, Long adminOperationProtocolVersion) {
     throw new VeniceUnsupportedOperationException(
         "updateAdminOperationProtocolVersion is not supported for child controller");
+  }
+
+  /**
+   * Get the admin operation protocol versions from controllers (leader + standby) for specific cluster.
+   * @param clusterName: the cluster name
+   * @return map (url: version). Example: {http://localhost:1234=1, http://localhost:1235=1}
+   */
+  @Override
+  public Map<String, Long> getAdminOperationVersionFromControllers(String clusterName) {
+    checkControllerLeadershipFor(clusterName);
+
+    Map<String, Long> UrlToAdminVersionMap = new HashMap<>();
+
+    // Get the version from the current controller - leader
+    String leaderControllerUrl = getLeaderController(clusterName).getUrl(false);
+    UrlToAdminVersionMap.put(leaderControllerUrl, getLocalAdminOperationProtocolVersion());
+
+    // Get version for standby controllers
+    List<Instance> standbyControllers = getControllersByHelixState(clusterName, HelixState.STANDBY_STATE);
+    for (Instance standbyController: standbyControllers) {
+      String standbyControllerUrl = standbyController.getUrl(false);
+
+      ControllerClient controllerClient =
+          ControllerClient.constructClusterControllerClient(clusterName, standbyControllerUrl, sslFactory);
+
+      // send controller client to get the admin operation protocol version from standby controller
+      AdminOperationProtocolVersionControllerResponse response =
+          controllerClient.getLocalAdminOperationProtocolVersion();
+      if (response.isError()) {
+        throw new VeniceException(
+            "Failed to get admin operation protocol version from standby controller: " + standbyControllerUrl
+                + ", error message: " + response.getError());
+      }
+      UrlToAdminVersionMap.put(response.getRequestUrl(), response.getLocalAdminOperationProtocolVersion());
+    }
+
+    return UrlToAdminVersionMap;
+  }
+
+  /**
+   * Get the local admin operation protocol version.
+   */
+  @Override
+  public long getLocalAdminOperationProtocolVersion() {
+    return AdminOperationSerializer.LATEST_SCHEMA_ID_FOR_ADMIN_OPERATION;
   }
 
   /**

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceHelixAdmin.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceHelixAdmin.java
@@ -7688,8 +7688,9 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
     String leaderControllerUrl = getLeaderController(clusterName).getUrl(false);
     controllerUrlToAdminOperationVersionMap.put(leaderControllerUrl, getLocalAdminOperationProtocolVersion());
 
-    // Create the controllerClient to reuse
-    ControllerClient controllerClient =
+    // Create the controller client to reuse
+    // (this is controller client to communicate with other controllers in the same cluster, the same region)
+    ControllerClient localControllerClient =
         ControllerClient.constructClusterControllerClient(clusterName, leaderControllerUrl, sslFactory);
 
     // Get version for standby controllers
@@ -7698,9 +7699,9 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
     for (Instance standbyController: standbyControllers) {
       String standbyControllerUrl = standbyController.getUrl(false);
 
-      // send controller client to get the admin operation protocol version from standby controller
+      // Get the admin operation protocol version from standby controller
       AdminOperationProtocolVersionControllerResponse response =
-          controllerClient.getLocalAdminOperationProtocolVersion();
+          localControllerClient.getLocalAdminOperationProtocolVersion();
       if (response.isError()) {
         throw new VeniceException(
             "Failed to get admin operation protocol version from standby controller: " + standbyControllerUrl

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceHelixAdmin.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceHelixAdmin.java
@@ -7677,17 +7677,16 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
   /**
    * Get the admin operation protocol versions from controllers (leader + standby) for specific cluster.
    * @param clusterName: the cluster name
-   * @return map (url: version). Example: {http://localhost:1234=1, http://localhost:1235=1}
-   */
+   * @return map (controllerUrl: version). Example: {http://localhost:1234=1, http://localhost:1235=1}*/
   @Override
   public Map<String, Long> getAdminOperationVersionFromControllers(String clusterName) {
     checkControllerLeadershipFor(clusterName);
 
-    Map<String, Long> UrlToAdminVersionMap = new HashMap<>();
+    Map<String, Long> controllerUrlToAdminOperationVersionMap = new HashMap<>();
 
     // Get the version from the current controller - leader
     String leaderControllerUrl = getLeaderController(clusterName).getUrl(false);
-    UrlToAdminVersionMap.put(leaderControllerUrl, getLocalAdminOperationProtocolVersion());
+    controllerUrlToAdminOperationVersionMap.put(leaderControllerUrl, getLocalAdminOperationProtocolVersion());
 
     // Get version for standby controllers
     List<Instance> standbyControllers = getControllersByHelixState(clusterName, HelixState.STANDBY_STATE);
@@ -7705,10 +7704,11 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
             "Failed to get admin operation protocol version from standby controller: " + standbyControllerUrl
                 + ", error message: " + response.getError());
       }
-      UrlToAdminVersionMap.put(response.getRequestUrl(), response.getLocalAdminOperationProtocolVersion());
+      controllerUrlToAdminOperationVersionMap
+          .put(response.getRequestUrl(), response.getLocalAdminOperationProtocolVersion());
     }
 
-    return UrlToAdminVersionMap;
+    return controllerUrlToAdminOperationVersionMap;
   }
 
   /**

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceHelixAdmin.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceHelixAdmin.java
@@ -7688,13 +7688,15 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
     String leaderControllerUrl = getLeaderController(clusterName).getUrl(false);
     controllerUrlToAdminOperationVersionMap.put(leaderControllerUrl, getLocalAdminOperationProtocolVersion());
 
+    // Create the controllerClient to reuse
+    ControllerClient controllerClient =
+        ControllerClient.constructClusterControllerClient(clusterName, leaderControllerUrl, sslFactory);
+
     // Get version for standby controllers
     List<Instance> standbyControllers = getControllersByHelixState(clusterName, HelixState.STANDBY_STATE);
+
     for (Instance standbyController: standbyControllers) {
       String standbyControllerUrl = standbyController.getUrl(false);
-
-      ControllerClient controllerClient =
-          ControllerClient.constructClusterControllerClient(clusterName, standbyControllerUrl, sslFactory);
 
       // send controller client to get the admin operation protocol version from standby controller
       AdminOperationProtocolVersionControllerResponse response =

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceHelixAdmin.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceHelixAdmin.java
@@ -7300,7 +7300,7 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
         Utils.sleep(5 * Time.MS_PER_SECOND);
       }
     }
-    String message = "Unable to find Venice controller" + helixState + "for cluster: " + clusterName + " after "
+    String message = "Unable to find Venice controller " + helixState + " for cluster: " + clusterName + " after "
         + maxAttempts + " attempts";
     LOGGER.error(message);
     throw new VeniceException(message);

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceParentHelixAdmin.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceParentHelixAdmin.java
@@ -4401,6 +4401,16 @@ public class VeniceParentHelixAdmin implements Admin {
         .updateAdminOperationProtocolVersion(clusterName, adminOperationProtocolVersion);
   }
 
+  @Override
+  public Map<String, Long> getAdminOperationVersionFromControllers(String clusterName) {
+    return getVeniceHelixAdmin().getAdminOperationVersionFromControllers(clusterName);
+  }
+
+  @Override
+  public long getLocalAdminOperationProtocolVersion() {
+    return getVeniceHelixAdmin().getLocalAdminOperationProtocolVersion();
+  }
+
   /**
    * Unsupported operation in the parent controller.
    */

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/server/AdminSparkServer.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/server/AdminSparkServer.java
@@ -35,6 +35,7 @@ import static com.linkedin.venice.controllerapi.ControllerRoute.END_OF_PUSH;
 import static com.linkedin.venice.controllerapi.ControllerRoute.EXECUTION;
 import static com.linkedin.venice.controllerapi.ControllerRoute.FUTURE_VERSION;
 import static com.linkedin.venice.controllerapi.ControllerRoute.GET_ACL;
+import static com.linkedin.venice.controllerapi.ControllerRoute.GET_ADMIN_OPERATION_VERSION_FROM_CONTROLLERS;
 import static com.linkedin.venice.controllerapi.ControllerRoute.GET_ADMIN_TOPIC_METADATA;
 import static com.linkedin.venice.controllerapi.ControllerRoute.GET_ALL_MIGRATION_PUSH_STRATEGIES;
 import static com.linkedin.venice.controllerapi.ControllerRoute.GET_ALL_REPLICATION_METADATA_SCHEMAS;
@@ -46,6 +47,7 @@ import static com.linkedin.venice.controllerapi.ControllerRoute.GET_HEARTBEAT_TI
 import static com.linkedin.venice.controllerapi.ControllerRoute.GET_INUSE_SCHEMA_IDS;
 import static com.linkedin.venice.controllerapi.ControllerRoute.GET_KAFKA_TOPIC_CONFIGS;
 import static com.linkedin.venice.controllerapi.ControllerRoute.GET_KEY_SCHEMA;
+import static com.linkedin.venice.controllerapi.ControllerRoute.GET_LOCAL_ADMIN_OPERATION_PROTOCOL_VERSION;
 import static com.linkedin.venice.controllerapi.ControllerRoute.GET_ONGOING_INCREMENTAL_PUSH_VERSIONS;
 import static com.linkedin.venice.controllerapi.ControllerRoute.GET_REGION_PUSH_DETAILS;
 import static com.linkedin.venice.controllerapi.ControllerRoute.GET_REPUSH_INFO;
@@ -651,6 +653,16 @@ public class AdminSparkServer extends AbstractVeniceService {
             admin,
             adminTopicMetadataRoutes
                 .updateAdminOperationProtocolVersion(admin, requestHandler.getClusterAdminOpsRequestHandler())));
+    httpService.get(
+        GET_ADMIN_OPERATION_VERSION_FROM_CONTROLLERS.getPath(),
+        new VeniceParentControllerRegionStateHandler(
+            admin,
+            controllerRoutes.getAdminOperationVersionFromControllers(admin)));
+    httpService.get(
+        GET_LOCAL_ADMIN_OPERATION_PROTOCOL_VERSION.getPath(),
+        new VeniceParentControllerRegionStateHandler(
+            admin,
+            controllerRoutes.getLocalAdminOperationProtocolVersion(admin)));
     httpService.post(
         DELETE_KAFKA_TOPIC.getPath(),
         new VeniceParentControllerRegionStateHandler(admin, storesRoutes.deleteKafkaTopic(admin)));

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/server/ControllerRoutes.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/server/ControllerRoutes.java
@@ -260,17 +260,17 @@ public class ControllerRoutes extends AbstractRoute {
         String currentUrl = request.url().split(request.uri())[0];
 
         responseObject.setCluster(clusterName);
-        Map<String, Long> urlToVersionMap = admin.getAdminOperationVersionFromControllers(clusterName);
-        responseObject.setUrlToVersionMap(urlToVersionMap);
+        Map<String, Long> controllerUrlToVersionMap = admin.getAdminOperationVersionFromControllers(clusterName);
+        responseObject.setControllerUrlToVersionMap(controllerUrlToVersionMap);
         responseObject.setRequestUrl(currentUrl);
 
-        if (urlToVersionMap.containsKey(currentUrl)) {
-          responseObject.setLocalAdminOperationProtocolVersion(urlToVersionMap.get(currentUrl));
+        if (controllerUrlToVersionMap.containsKey(currentUrl)) {
+          responseObject.setLocalAdminOperationProtocolVersion(controllerUrlToVersionMap.get(currentUrl));
         } else {
           // Should not happen
           throw new VeniceException(
               "The current controller URL: " + currentUrl + " is not in the urlToVersionMap in the response "
-                  + urlToVersionMap);
+                  + controllerUrlToVersionMap);
         }
 
       } catch (Throwable e) {

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/server/ControllerRoutes.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/server/ControllerRoutes.java
@@ -17,6 +17,7 @@ import com.linkedin.venice.HttpConstants;
 import com.linkedin.venice.acl.DynamicAccessController;
 import com.linkedin.venice.controller.Admin;
 import com.linkedin.venice.controller.InstanceRemovableStatuses;
+import com.linkedin.venice.controllerapi.AdminOperationProtocolVersionControllerResponse;
 import com.linkedin.venice.controllerapi.AggregatedHealthStatusRequest;
 import com.linkedin.venice.controllerapi.ChildAwareResponse;
 import com.linkedin.venice.controllerapi.ControllerResponse;
@@ -24,6 +25,7 @@ import com.linkedin.venice.controllerapi.LeaderControllerResponse;
 import com.linkedin.venice.controllerapi.PubSubTopicConfigResponse;
 import com.linkedin.venice.controllerapi.StoppableNodeStatusResponse;
 import com.linkedin.venice.exceptions.ErrorType;
+import com.linkedin.venice.exceptions.VeniceException;
 import com.linkedin.venice.protocols.controller.LeaderControllerGrpcRequest;
 import com.linkedin.venice.protocols.controller.LeaderControllerGrpcResponse;
 import com.linkedin.venice.pubsub.PubSubTopicConfiguration;
@@ -33,6 +35,7 @@ import com.linkedin.venice.pubsub.manager.TopicManager;
 import com.linkedin.venice.utils.ObjectMapperFactory;
 import com.linkedin.venice.utils.Utils;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import org.apache.commons.lang.StringUtils;
 import org.apache.http.HttpStatus;
@@ -241,6 +244,59 @@ public class ControllerRoutes extends AbstractRoute {
       String responseContent = AdminSparkServer.OBJECT_MAPPER.writeValueAsString(responseObject);
       LOGGER.info("[AggregatedHealthStatus] Response: {}", responseContent);
       return responseContent;
+    };
+  }
+
+  /**
+   * Get all admin operation protocol versions of the given cluster from controllers (leader + standby).
+   */
+  public Route getAdminOperationVersionFromControllers(Admin admin) {
+    return (request, response) -> {
+      AdminOperationProtocolVersionControllerResponse responseObject =
+          new AdminOperationProtocolVersionControllerResponse();
+      response.type(HttpConstants.JSON);
+      try {
+        String clusterName = request.queryParams(CLUSTER);
+        String currentUrl = request.url().split(request.uri())[0];
+
+        responseObject.setCluster(clusterName);
+        Map<String, Long> urlToVersionMap = admin.getAdminOperationVersionFromControllers(clusterName);
+        responseObject.setUrlToVersionMap(urlToVersionMap);
+        responseObject.setRequestUrl(currentUrl);
+
+        if (urlToVersionMap.containsKey(currentUrl)) {
+          responseObject.setLocalAdminOperationProtocolVersion(urlToVersionMap.get(currentUrl));
+        } else {
+          // Should not happen
+          throw new VeniceException(
+              "The current controller URL: " + currentUrl + " is not in the urlToVersionMap in the response "
+                  + urlToVersionMap);
+        }
+
+      } catch (Throwable e) {
+        responseObject.setError(e);
+        AdminSparkServer.handleError(e, request, response);
+      }
+      return AdminSparkServer.OBJECT_MAPPER.writeValueAsString(responseObject);
+    };
+  }
+
+  /**
+   * Get the local admin operation protocol version in current controller
+   */
+  public Route getLocalAdminOperationProtocolVersion(Admin admin) {
+    return (request, response) -> {
+      AdminOperationProtocolVersionControllerResponse responseObject =
+          new AdminOperationProtocolVersionControllerResponse();
+      response.type(HttpConstants.JSON);
+      try {
+        responseObject.setLocalAdminOperationProtocolVersion(admin.getLocalAdminOperationProtocolVersion());
+        responseObject.setRequestUrl(request.url().split(request.uri())[0]);
+      } catch (Throwable e) {
+        responseObject.setError(e);
+        AdminSparkServer.handleError(e, request, response);
+      }
+      return AdminSparkServer.OBJECT_MAPPER.writeValueAsString(responseObject);
     };
   }
 

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/server/ControllerRoutes.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/server/ControllerRoutes.java
@@ -313,7 +313,7 @@ public class ControllerRoutes extends AbstractRoute {
       URL url = new URL(request.url());
       return url.getProtocol() + "://" + url.getHost() + (url.getPort() != -1 ? ":" + url.getPort() : "");
     } catch (Exception e) {
-      throw new RuntimeException("Invalid URL: " + request.url(), e);
+      throw new VeniceException("Invalid URL: " + request.url(), e);
     }
   }
 

--- a/services/venice-controller/src/test/java/com/linkedin/venice/controller/TestVeniceHelixAdmin.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/controller/TestVeniceHelixAdmin.java
@@ -1125,7 +1125,17 @@ public class TestVeniceHelixAdmin {
     doCallRealMethod().when(veniceParentHelixAdmin).getLocalAdminOperationProtocolVersion();
 
     doCallRealMethod().when(veniceHelixAdmin).getLocalAdminOperationProtocolVersion();
-    assert veniceParentHelixAdmin
-        .getLocalAdminOperationProtocolVersion() == AdminOperationSerializer.LATEST_SCHEMA_ID_FOR_ADMIN_OPERATION;
+    assertEquals(
+        veniceParentHelixAdmin.getLocalAdminOperationProtocolVersion(),
+        AdminOperationSerializer.LATEST_SCHEMA_ID_FOR_ADMIN_OPERATION);
+  }
+
+  @Test
+  public void testGetControllersWithInvalidHelixState() {
+    String clusterName = "test-cluster";
+    VeniceHelixAdmin veniceHelixAdmin = mock(VeniceHelixAdmin.class);
+    doCallRealMethod().when(veniceHelixAdmin).getControllersByHelixState(any(), any());
+
+    expectThrows(VeniceException.class, () -> veniceHelixAdmin.getControllersByHelixState(clusterName, "state"));
   }
 }

--- a/services/venice-controller/src/test/java/com/linkedin/venice/controller/TestVeniceHelixAdmin.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/controller/TestVeniceHelixAdmin.java
@@ -26,12 +26,17 @@ import static org.testng.Assert.expectThrows;
 
 import com.linkedin.venice.common.VeniceSystemStoreType;
 import com.linkedin.venice.controller.kafka.consumer.AdminConsumerService;
+import com.linkedin.venice.controller.kafka.protocol.serializer.AdminOperationSerializer;
 import com.linkedin.venice.controller.stats.DisabledPartitionStats;
 import com.linkedin.venice.controller.stats.VeniceAdminStats;
+import com.linkedin.venice.controllerapi.AdminOperationProtocolVersionControllerResponse;
+import com.linkedin.venice.controllerapi.ControllerClient;
 import com.linkedin.venice.exceptions.VeniceException;
 import com.linkedin.venice.helix.HelixExternalViewRepository;
+import com.linkedin.venice.helix.HelixState;
 import com.linkedin.venice.meta.DataReplicationPolicy;
 import com.linkedin.venice.meta.HybridStoreConfig;
+import com.linkedin.venice.meta.Instance;
 import com.linkedin.venice.meta.MaterializedViewParameters;
 import com.linkedin.venice.meta.PartitionAssignment;
 import com.linkedin.venice.meta.ReadWriteStoreRepository;
@@ -63,6 +68,8 @@ import java.util.Properties;
 import java.util.Set;
 import org.mockito.ArgumentCaptor;
 import org.mockito.InOrder;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
 import org.testng.annotations.Test;
 
 
@@ -1027,5 +1034,98 @@ public class TestVeniceHelixAdmin {
         Optional.of(upstreamOffset));
     verify(executionIdAccessor, never()).updateLastSucceededExecutionId(anyString(), anyLong());
     verify(adminConsumerService, times(1)).updateAdminTopicMetadata(clusterName, executionId, offset, upstreamOffset);
+  }
+
+  @Test
+  public void testGetAdminOperationVersionsFromControllers() {
+    String clusterName = "test-cluster";
+    VeniceParentHelixAdmin veniceParentHelixAdmin = mock(VeniceParentHelixAdmin.class);
+    VeniceHelixAdmin veniceHelixAdmin = mock(VeniceHelixAdmin.class);
+    when(veniceParentHelixAdmin.getVeniceHelixAdmin()).thenReturn(veniceHelixAdmin);
+    doCallRealMethod().when(veniceParentHelixAdmin).getAdminOperationVersionFromControllers(clusterName);
+    doCallRealMethod().when(veniceHelixAdmin).getAdminOperationVersionFromControllers(clusterName);
+
+    // Mock current version in leader is 2
+    when(veniceHelixAdmin.getLocalAdminOperationProtocolVersion()).thenReturn(2L);
+
+    // Mock response for standby controllers
+    AdminOperationProtocolVersionControllerResponse response1 = new AdminOperationProtocolVersionControllerResponse();
+    response1.setLocalAdminOperationProtocolVersion(1);
+    response1.setRequestUrl("standbyHost1:1234");
+    AdminOperationProtocolVersionControllerResponse response2 = new AdminOperationProtocolVersionControllerResponse();
+    response2.setLocalAdminOperationProtocolVersion(2);
+    response2.setRequestUrl("standbyHost2:1234");
+
+    List<Instance> standbyControllers = new ArrayList<>();
+    standbyControllers.add(new Instance("1", "standbyHost1", 1234));
+    standbyControllers.add(new Instance("2", "standbyHost2", 1234));
+
+    when(veniceHelixAdmin.getControllersByHelixState(clusterName, HelixState.STANDBY_STATE))
+        .thenReturn(standbyControllers);
+    when(veniceHelixAdmin.getLeaderController(clusterName)).thenReturn(new Instance("3", "leaderHost", 1234));
+
+    try (MockedStatic<ControllerClient> controllerClientMockedStatic = Mockito.mockStatic(ControllerClient.class)) {
+      ControllerClient client = mock(ControllerClient.class);
+      controllerClientMockedStatic
+          .when(() -> ControllerClient.constructClusterControllerClient(eq(clusterName), any(), any()))
+          .thenReturn(client);
+      when(client.getLocalAdminOperationProtocolVersion()).thenReturn(response1).thenReturn(response2);
+
+      Map<String, Long> urlToVersionMap = veniceParentHelixAdmin.getAdminOperationVersionFromControllers(clusterName);
+      assertEquals(urlToVersionMap.size(), 3);
+    }
+  }
+
+  @Test
+  public void testFailedGetAdminOperationVersionsForStandbyControllers() {
+    String clusterName = "test-cluster";
+    VeniceParentHelixAdmin veniceParentHelixAdmin = mock(VeniceParentHelixAdmin.class);
+    VeniceHelixAdmin veniceHelixAdmin = mock(VeniceHelixAdmin.class);
+    when(veniceParentHelixAdmin.getVeniceHelixAdmin()).thenReturn(veniceHelixAdmin);
+    doCallRealMethod().when(veniceParentHelixAdmin).getAdminOperationVersionFromControllers(clusterName);
+    doCallRealMethod().when(veniceHelixAdmin).getAdminOperationVersionFromControllers(clusterName);
+
+    // Mock current version in leader is 2
+    when(veniceHelixAdmin.getLocalAdminOperationProtocolVersion()).thenReturn(2L);
+
+    // Mock response for standby controllers
+    List<Instance> standbyControllers = new ArrayList<>();
+    standbyControllers.add(new Instance("1", "standbyHost1", 1234));
+    standbyControllers.add(new Instance("2", "standbyHost2", 1234));
+
+    AdminOperationProtocolVersionControllerResponse response1 = new AdminOperationProtocolVersionControllerResponse();
+    response1.setLocalAdminOperationProtocolVersion(1);
+    response1.setRequestUrl("standbyHost1:1234");
+    AdminOperationProtocolVersionControllerResponse failedResponse =
+        new AdminOperationProtocolVersionControllerResponse();
+    failedResponse.setError("Failed to get version");
+
+    when(veniceHelixAdmin.getControllersByHelixState(clusterName, HelixState.STANDBY_STATE))
+        .thenReturn(standbyControllers);
+    when(veniceHelixAdmin.getLeaderController(clusterName)).thenReturn(new Instance("3", "leaderHost", 1234));
+
+    try (MockedStatic<ControllerClient> controllerClientMockedStatic = Mockito.mockStatic(ControllerClient.class)) {
+      ControllerClient client = mock(ControllerClient.class);
+      controllerClientMockedStatic
+          .when(() -> ControllerClient.constructClusterControllerClient(eq(clusterName), any(), any()))
+          .thenReturn(client);
+      when(client.getLocalAdminOperationProtocolVersion()).thenReturn(response1).thenReturn(failedResponse);
+
+      expectThrows(
+          VeniceException.class,
+          () -> veniceParentHelixAdmin.getAdminOperationVersionFromControllers(clusterName));
+    }
+  }
+
+  @Test
+  public void testGetLocalAdminOperationProtocolVersion() {
+    VeniceParentHelixAdmin veniceParentHelixAdmin = mock(VeniceParentHelixAdmin.class);
+    VeniceHelixAdmin veniceHelixAdmin = mock(VeniceHelixAdmin.class);
+    when(veniceParentHelixAdmin.getVeniceHelixAdmin()).thenReturn(veniceHelixAdmin);
+    doCallRealMethod().when(veniceParentHelixAdmin).getLocalAdminOperationProtocolVersion();
+
+    doCallRealMethod().when(veniceHelixAdmin).getLocalAdminOperationProtocolVersion();
+    assert veniceParentHelixAdmin
+        .getLocalAdminOperationProtocolVersion() == AdminOperationSerializer.LATEST_SCHEMA_ID_FOR_ADMIN_OPERATION;
   }
 }

--- a/services/venice-controller/src/test/java/com/linkedin/venice/controller/server/ControllerRoutesTest.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/controller/server/ControllerRoutesTest.java
@@ -14,6 +14,7 @@ import com.linkedin.venice.controller.Admin;
 import com.linkedin.venice.controller.ControllerRequestHandlerDependencies;
 import com.linkedin.venice.controller.InstanceRemovableStatuses;
 import com.linkedin.venice.controller.VeniceParentHelixAdmin;
+import com.linkedin.venice.controllerapi.AdminOperationProtocolVersionControllerResponse;
 import com.linkedin.venice.controllerapi.AggregatedHealthStatusRequest;
 import com.linkedin.venice.controllerapi.ControllerApiConstants;
 import com.linkedin.venice.controllerapi.LeaderControllerResponse;
@@ -196,5 +197,64 @@ public class ControllerRoutesTest {
         "reason2");
     assertEquals(removableAndNonRemovableStoppableResponse.getStoppableInstances().size(), 1);
     assertEquals(removableAndNonRemovableStoppableResponse.getStoppableInstances().get(0), "instance1_5000");
+  }
+
+  @Test
+  public void testGetLocalAdminOperationProtocolVersion() throws Exception {
+    doReturn(true).when(mockAdmin).isLeaderControllerFor(anyString());
+    Instance leaderController =
+        new Instance(TEST_NODE_ID, TEST_HOST, TEST_PORT, TEST_SSL_PORT, TEST_GRPC_PORT, TEST_GRPC_SSL_PORT);
+
+    doReturn(leaderController).when(mockAdmin).getLeaderController(anyString());
+    String leaderControllerHost =
+        String.format("http://%s:%s/get_admin_operation_protocol_version", TEST_HOST, TEST_PORT);
+    Request request = mock(Request.class);
+    doReturn(TEST_CLUSTER).when(request).queryParams(eq(ControllerApiConstants.CLUSTER));
+    doReturn(1L).when(mockAdmin).getLocalAdminOperationProtocolVersion();
+    doReturn(leaderControllerHost + "/get_local_admin_operation_protocol_version").when(request).url();
+    doReturn("/get_local_admin_operation_protocol_version").when(request).uri();
+
+    Route localAdminOperationVersionRoute =
+        new ControllerRoutes(false, Optional.empty(), pubSubTopicRepository, requestHandler)
+            .getLocalAdminOperationProtocolVersion(mockAdmin);
+    AdminOperationProtocolVersionControllerResponse response = OBJECT_MAPPER.readValue(
+        localAdminOperationVersionRoute.handle(request, mock(Response.class)).toString(),
+        AdminOperationProtocolVersionControllerResponse.class);
+    assertEquals(response.getLocalAdminOperationProtocolVersion(), 1L);
+    assertEquals(response.getUrlToVersionMap().size(), 0);
+  }
+
+  @Test
+  public void testGetAdminOperationVersionFromControllers() throws Exception {
+    doReturn(true).when(mockAdmin).isLeaderControllerFor(anyString());
+    Instance leaderController =
+        new Instance(TEST_NODE_ID, TEST_HOST, TEST_PORT, TEST_SSL_PORT, TEST_GRPC_PORT, TEST_GRPC_SSL_PORT);
+
+    doReturn(leaderController).when(mockAdmin).getLeaderController(anyString());
+    String leaderControllerHost =
+        String.format("http://%s:%s/get_admin_operation_protocol_version", TEST_HOST, TEST_PORT);
+    Request request = mock(Request.class);
+    doReturn(TEST_CLUSTER).when(request).queryParams(eq(ControllerApiConstants.CLUSTER));
+    doReturn(1L).when(mockAdmin).getLocalAdminOperationProtocolVersion();
+    doReturn(leaderControllerHost + "/get_admin_operation_version_from_controllers").when(request).url();
+    doReturn("/get_admin_operation_version_from_controllers").when(request).uri();
+
+    Map<String, Long> urlToVersionMap = new HashMap<>();
+    urlToVersionMap.put("http://localhost:8080", 1L);
+    urlToVersionMap.put("http://localhost:8081", 2L);
+    urlToVersionMap.put(leaderControllerHost, 1L);
+    doReturn(urlToVersionMap).when(mockAdmin).getAdminOperationVersionFromControllers(anyString());
+
+    Route adminOperationVersionRoute =
+        new ControllerRoutes(false, Optional.empty(), pubSubTopicRepository, requestHandler)
+            .getAdminOperationVersionFromControllers(mockAdmin);
+    AdminOperationProtocolVersionControllerResponse response = OBJECT_MAPPER.readValue(
+        adminOperationVersionRoute.handle(request, mock(Response.class)).toString(),
+        AdminOperationProtocolVersionControllerResponse.class);
+    assertEquals(response.getLocalAdminOperationProtocolVersion(), 1L);
+    assertEquals(response.getUrlToVersionMap().size(), 3);
+    assertEquals(response.getUrlToVersionMap(), urlToVersionMap);
+    assertEquals(response.getRequestUrl(), leaderControllerHost);
+    assertEquals(response.getCluster(), TEST_CLUSTER);
   }
 }

--- a/services/venice-controller/src/test/java/com/linkedin/venice/controller/server/ControllerRoutesTest.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/controller/server/ControllerRoutesTest.java
@@ -221,7 +221,7 @@ public class ControllerRoutesTest {
         localAdminOperationVersionRoute.handle(request, mock(Response.class)).toString(),
         AdminOperationProtocolVersionControllerResponse.class);
     assertEquals(response.getLocalAdminOperationProtocolVersion(), 1L);
-    assertEquals(response.getUrlToVersionMap().size(), 0);
+    assertEquals(response.getControllerUrlToVersionMap().size(), 0);
   }
 
   @Test
@@ -252,8 +252,8 @@ public class ControllerRoutesTest {
         adminOperationVersionRoute.handle(request, mock(Response.class)).toString(),
         AdminOperationProtocolVersionControllerResponse.class);
     assertEquals(response.getLocalAdminOperationProtocolVersion(), 1L);
-    assertEquals(response.getUrlToVersionMap().size(), 3);
-    assertEquals(response.getUrlToVersionMap(), urlToVersionMap);
+    assertEquals(response.getControllerUrlToVersionMap().size(), 3);
+    assertEquals(response.getControllerUrlToVersionMap(), urlToVersionMap);
     assertEquals(response.getRequestUrl(), leaderControllerHost);
     assertEquals(response.getCluster(), TEST_CLUSTER);
   }

--- a/services/venice-controller/src/test/java/com/linkedin/venice/controller/server/ControllerRoutesTest.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/controller/server/ControllerRoutesTest.java
@@ -211,7 +211,6 @@ public class ControllerRoutesTest {
     doReturn(TEST_CLUSTER).when(request).queryParams(eq(ControllerApiConstants.CLUSTER));
     doReturn(1L).when(mockAdmin).getLocalAdminOperationProtocolVersion();
     doReturn(leaderControllerHost + "/get_local_admin_operation_protocol_version").when(request).url();
-    doReturn("/get_local_admin_operation_protocol_version").when(request).uri();
 
     Route localAdminOperationVersionRoute =
         new ControllerRoutes(false, Optional.empty(), pubSubTopicRepository, requestHandler)
@@ -235,7 +234,6 @@ public class ControllerRoutesTest {
     doReturn(TEST_CLUSTER).when(request).queryParams(eq(ControllerApiConstants.CLUSTER));
     doReturn(1L).when(mockAdmin).getLocalAdminOperationProtocolVersion();
     doReturn(leaderControllerHost + "/get_admin_operation_version_from_controllers").when(request).url();
-    doReturn("/get_admin_operation_version_from_controllers").when(request).uri();
 
     Map<String, Long> urlToVersionMap = new HashMap<>();
     urlToVersionMap.put("http://localhost:8080", 1L);

--- a/services/venice-controller/src/test/java/com/linkedin/venice/controller/server/ControllerRoutesTest.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/controller/server/ControllerRoutesTest.java
@@ -206,8 +206,7 @@ public class ControllerRoutesTest {
         new Instance(TEST_NODE_ID, TEST_HOST, TEST_PORT, TEST_SSL_PORT, TEST_GRPC_PORT, TEST_GRPC_SSL_PORT);
 
     doReturn(leaderController).when(mockAdmin).getLeaderController(anyString());
-    String leaderControllerHost =
-        String.format("http://%s:%s/get_admin_operation_protocol_version", TEST_HOST, TEST_PORT);
+    String leaderControllerHost = String.format("http://%s:%s", TEST_HOST, TEST_PORT);
     Request request = mock(Request.class);
     doReturn(TEST_CLUSTER).when(request).queryParams(eq(ControllerApiConstants.CLUSTER));
     doReturn(1L).when(mockAdmin).getLocalAdminOperationProtocolVersion();
@@ -231,8 +230,7 @@ public class ControllerRoutesTest {
         new Instance(TEST_NODE_ID, TEST_HOST, TEST_PORT, TEST_SSL_PORT, TEST_GRPC_PORT, TEST_GRPC_SSL_PORT);
 
     doReturn(leaderController).when(mockAdmin).getLeaderController(anyString());
-    String leaderControllerHost =
-        String.format("http://%s:%s/get_admin_operation_protocol_version", TEST_HOST, TEST_PORT);
+    String leaderControllerHost = String.format("http://%s:%s", TEST_HOST, TEST_PORT);
     Request request = mock(Request.class);
     doReturn(TEST_CLUSTER).when(request).queryParams(eq(ControllerApiConstants.CLUSTER));
     doReturn(1L).when(mockAdmin).getLocalAdminOperationProtocolVersion();


### PR DESCRIPTION
[controller] Controller API to get all Admin Operation Version for leader+standby controllers given cluster name

## Problem Statement
We have introduced the new adminOperationProtocolVersion into the parent ZK at the cluster level, which is the SOT for all serialization. Additionally, we have implemented a new semantic detector that prevents message processing if it uses the new semantic.
Currently, after deployment, the on-call engineer must manually update the version pinning to the latest protocol version.
Proposal
To eliminate the manual task for on-call engineers, we propose automating the detection of the protocol version to use. The selected version should be the smallest protocol version among all consumers (child controllers + parent controllers).

## Solution
Implementation Steps:
1. **(This PR)** Introduce a new GET API for controllers to expose their local protocol version `/get_local_admin_operation_protocol_version`.
2. **(This PR)** Introduce a new GET API for controllers find all versions among leader + standby controllers of one specific cluster `/get_admin_operation_version_from_controllers`.
3. Start a dedicated background thread that periodically executes this task.
The leader parent controller will:
- Send /get_admin_operation_version_from_controllers requests to leader parent controller + leader child controllers. Then leader will send /get_local_admin_operation_protocol_version to its standby controllers to get the all versions, then find the smallest version.
- Update the parent ZK with the good version.

## Next step
- Currently, /get_local_admin_operation_protocol_version will always route to the leader of the cluster, we will send directly to the URLs in the next PR
- Setup service to trigger the job and update the parent ZK

## API spec
1. `/get_admin_operation_version_from_controllers`
```json
{
  "localAdminOperationProtocolVersion": 86,
  "cluster": "cluster0",
  "requestUrl": "http://localhost:1234",
  "controllerUrlToVersionMap": {
    "http://localhost:1234": 86,
    "http://localhost2:1234": 85,
    "http://localhost3:1234": 85
  }
}
```
3. `/get_local_admin_operation_protocol_version`
```json
{
  "localAdminOperationProtocolVersion": 86,
  "cluster": null,
  "requestUrl": "http://localhost:1234",
  "controllerUrlToVersionMap": {}
}
```
###  Code changes
- [ ] Added new code behind **a config**. If so list the config names and their default values in the PR description.
- [ ] Introduced new **log lines**. 
  - [ ] Confirmed if logs need to be **rate limited** to avoid excessive logging.

###  **Concurrency-Specific Checks**
Both reviewer and PR author to verify
- [ ] Code has **no race conditions** or **thread safety issues**.
- [ ] Proper **synchronization mechanisms** (e.g., `synchronized`, `RWLock`) are used where needed.
- [ ] No **blocking calls** inside critical sections that could lead to deadlocks or performance degradation.
- [ ] Verified **thread-safe collections** are used (e.g., `ConcurrentHashMap`, `CopyOnWriteArrayList`).
- [ ] Validated proper exception handling in multi-threaded code to avoid silent thread termination.


## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->

- [x] New unit tests added.
- [x] New integration tests added.
- [ ] Modified or extended existing tests.
- [ ] Verified backward compatibility (if applicable).

## Does this PR introduce any user-facing or breaking changes?
<!--  
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Clearly explain the behavior change and its impact.