### PR TITLE
[server][dvc] clean up partition folder and offset after decide to use blob transfer

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/DaVinciBackend.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/DaVinciBackend.java
@@ -304,8 +304,7 @@ public class DaVinciBackend implements Closeable {
             "Ingestion isolated and Cache are incompatible configs!!  Aborting start up!");
       }
 
-      if (backendConfig.isBlobTransferManagerEnabled() && backendConfig.isBlobTransferSslEnabled()
-          && backendConfig.isBlobTransferAclEnabled()) {
+      if (BlobTransferUtils.isBlobTransferManagerEnabled(backendConfig, isIsolatedIngestion())) {
         aggVersionedBlobTransferStats =
             new AggVersionedBlobTransferStats(metricsRepository, storeRepository, configLoader.getVeniceServerConfig());
 

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/blobtransfer/BlobSnapshotManager.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/blobtransfer/BlobSnapshotManager.java
@@ -119,6 +119,13 @@ public class BlobSnapshotManager {
     // check if the concurrent user count exceeds the limit
     checkIfConcurrentUserExceedsLimit(topicName, partitionId);
 
+    // check if storageEngineRepository has this store partition, so exit early if not, otherwise won't be able to
+    // create snapshot
+    if (storageEngineRepository.getLocalStorageEngine(topicName) == null
+        || !storageEngineRepository.getLocalStorageEngine(topicName).containsPartition(partitionId)) {
+      throw new VeniceException("No storage engine found for topic: " + topicName + " partition: " + partitionId);
+    }
+
     boolean isHybrid = isStoreHybrid(payload.getStoreName(), versionNum);
     if (!isHybrid) {
       increaseConcurrentUserCount(topicName, partitionId);

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/ingestion/DefaultIngestionBackend.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/ingestion/DefaultIngestionBackend.java
@@ -83,6 +83,7 @@ public class DefaultIngestionBackend implements IngestionBackend {
     if (!storeAndVersion.getFirst().isBlobTransferEnabled() || blobTransferManager == null) {
       runnable.run();
     } else {
+      // Open store for lag check and later metadata update for offset/StoreVersionState
       storageService.openStore(storeConfig, svsSupplier);
 
       BlobTransferTableFormat requestTableFormat =

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/ingestion/DefaultIngestionBackend.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/ingestion/DefaultIngestionBackend.java
@@ -129,7 +129,8 @@ public class DefaultIngestionBackend implements IngestionBackend {
 
     // After decide to bootstrap from blobs transfer, close the partition, clean up the offset and partition folder.
     String kafkaTopic = Version.composeKafkaTopic(storeName, versionNumber);
-    if (storageService.getStorageEngine(kafkaTopic).containsPartition(partitionId)) {
+    if (storageService.getStorageEngine(kafkaTopic) != null
+        && storageService.getStorageEngine(kafkaTopic).containsPartition(partitionId)) {
       storageService.getStorageEngine(kafkaTopic).closePartition(partitionId);
       LOGGER.info("Closed partition {} for store {} before bootstrap from blob transfer", partitionId, storeName);
     }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/ingestion/DefaultIngestionBackend.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/ingestion/DefaultIngestionBackend.java
@@ -129,8 +129,9 @@ public class DefaultIngestionBackend implements IngestionBackend {
     // After decide to bootstrap from blobs transfer, close the partition, clean up the offset and partition folder,
     // but the metadata partition is not removed.
     String kafkaTopic = Version.composeKafkaTopic(storeName, versionNumber);
-    if (storageService.getStorageEngine(kafkaTopic) != null) {
-      storageService.getStorageEngine(kafkaTopic).dropPartitionAndWholeStore(partitionId, false);
+    AbstractStorageEngine storageEngine = storageService.getStorageEngine(kafkaTopic);
+    if (storageEngine != null) {
+      storageEngine.dropPartition(partitionId, false);
     }
     LOGGER.info("Clean up the offset and delete partition folder for topic {} partition {}", kafkaTopic, partitionId);
 

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/store/AbstractStorageEngine.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/store/AbstractStorageEngine.java
@@ -272,6 +272,16 @@ public abstract class AbstractStorageEngine<Partition extends AbstractStoragePar
    * @param partitionId - id of partition to retrieve and remove
    */
   public synchronized void dropPartition(int partitionId) {
+    dropPartitionAndWholeStore(partitionId, true);
+  }
+
+  /**
+   * Removes and returns a partition from the current store
+   *
+   * @param partitionId - id of partition to retrieve and remove
+   * @param dropWholeStore - if true, the whole store will be dropped if ALL partitions are removed
+   */
+  public synchronized void dropPartitionAndWholeStore(int partitionId, boolean dropWholeStore) {
     /**
      * The caller of this method should ensure that:
      * 1. The SimpleKafkaConsumerTask associated with this partition is shutdown
@@ -298,7 +308,7 @@ public abstract class AbstractStorageEngine<Partition extends AbstractStoragePar
     AbstractStoragePartition partition = this.partitionList.remove(partitionId);
     partition.drop();
 
-    if (getNumberOfPartitions() == 0) {
+    if (getNumberOfPartitions() == 0 && dropWholeStore) {
       if (!suppressLogs) {
         LOGGER.info("All Partitions deleted for Store {}", getStoreVersionName());
       }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/store/AbstractStorageEngine.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/store/AbstractStorageEngine.java
@@ -272,16 +272,16 @@ public abstract class AbstractStorageEngine<Partition extends AbstractStoragePar
    * @param partitionId - id of partition to retrieve and remove
    */
   public synchronized void dropPartition(int partitionId) {
-    dropPartitionAndWholeStore(partitionId, true);
+    dropPartition(partitionId, true);
   }
 
   /**
    * Removes and returns a partition from the current store
    *
    * @param partitionId - id of partition to retrieve and remove
-   * @param dropWholeStore - if true, the whole store will be dropped if ALL partitions are removed
+   * @param dropMetadataPartitionWhenEmpty - if true, the whole store will be dropped if ALL partitions are removed
    */
-  public synchronized void dropPartitionAndWholeStore(int partitionId, boolean dropWholeStore) {
+  public synchronized void dropPartition(int partitionId, boolean dropMetadataPartitionWhenEmpty) {
     /**
      * The caller of this method should ensure that:
      * 1. The SimpleKafkaConsumerTask associated with this partition is shutdown
@@ -308,7 +308,7 @@ public abstract class AbstractStorageEngine<Partition extends AbstractStoragePar
     AbstractStoragePartition partition = this.partitionList.remove(partitionId);
     partition.drop();
 
-    if (getNumberOfPartitions() == 0 && dropWholeStore) {
+    if (getNumberOfPartitions() == 0 && dropMetadataPartitionWhenEmpty) {
       if (!suppressLogs) {
         LOGGER.info("All Partitions deleted for Store {}", getStoreVersionName());
       }

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/blobtransfer/BlobSnapshotManagerTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/blobtransfer/BlobSnapshotManagerTest.java
@@ -53,6 +53,7 @@ public class BlobSnapshotManagerTest {
   public void testHybridSnapshot() {
     AbstractStorageEngine storageEngine = Mockito.mock(AbstractStorageEngine.class);
     Mockito.doReturn(storageEngine).when(storageEngineRepository).getLocalStorageEngine(TOPIC_NAME);
+    Mockito.doReturn(true).when(storageEngine).containsPartition(PARTITION_ID);
 
     AbstractStoragePartition storagePartition = Mockito.mock(AbstractStoragePartition.class);
     Mockito.doReturn(storagePartition).when(storageEngine).getPartitionOrThrow(PARTITION_ID);
@@ -93,6 +94,7 @@ public class BlobSnapshotManagerTest {
     AbstractStoragePartition storagePartition = Mockito.mock(AbstractStoragePartition.class);
     AbstractStorageEngine storageEngine = Mockito.mock(AbstractStorageEngine.class);
     Mockito.doReturn(storageEngine).when(storageEngineRepository).getLocalStorageEngine(TOPIC_NAME);
+    Mockito.doReturn(true).when(storageEngine).containsPartition(PARTITION_ID);
     Mockito.doReturn(storagePartition).when(storageEngine).getPartitionOrThrow(PARTITION_ID);
     Mockito.doNothing().when(storagePartition).createSnapshot();
 
@@ -124,6 +126,7 @@ public class BlobSnapshotManagerTest {
     AbstractStoragePartition storagePartition = Mockito.mock(AbstractStoragePartition.class);
     AbstractStorageEngine storageEngine = Mockito.mock(AbstractStorageEngine.class);
     Mockito.doReturn(storageEngine).when(storageEngineRepository).getLocalStorageEngine(TOPIC_NAME);
+    Mockito.doReturn(true).when(storageEngine).containsPartition(PARTITION_ID);
     Mockito.doReturn(storagePartition).when(storageEngine).getPartitionOrThrow(PARTITION_ID);
     Mockito.doNothing().when(storagePartition).createSnapshot();
 
@@ -167,6 +170,7 @@ public class BlobSnapshotManagerTest {
     AbstractStoragePartition storagePartition = Mockito.mock(AbstractStoragePartition.class);
     AbstractStorageEngine storageEngine = Mockito.mock(AbstractStorageEngine.class);
     Mockito.doReturn(storageEngine).when(storageEngineRepository).getLocalStorageEngine(TOPIC_NAME);
+    Mockito.doReturn(true).when(storageEngine).containsPartition(PARTITION_ID);
     Mockito.doReturn(storagePartition).when(storageEngine).getPartitionOrThrow(PARTITION_ID);
     Mockito.doNothing().when(storagePartition).createSnapshot();
 
@@ -207,6 +211,7 @@ public class BlobSnapshotManagerTest {
     AbstractStoragePartition storagePartition = Mockito.mock(AbstractStoragePartition.class);
     AbstractStorageEngine storageEngine = Mockito.mock(AbstractStorageEngine.class);
     Mockito.doReturn(storageEngine).when(storageEngineRepository).getLocalStorageEngine(TOPIC_NAME);
+    Mockito.doReturn(true).when(storageEngine).containsPartition(PARTITION_ID);
     Mockito.doReturn(storagePartition).when(storageEngine).getPartitionOrThrow(PARTITION_ID);
     Mockito.doNothing().when(storagePartition).createSnapshot();
 
@@ -250,6 +255,7 @@ public class BlobSnapshotManagerTest {
     AbstractStoragePartition storagePartition = Mockito.mock(AbstractStoragePartition.class);
     AbstractStorageEngine storageEngine = Mockito.mock(AbstractStorageEngine.class);
     Mockito.doReturn(storageEngine).when(storageEngineRepository).getLocalStorageEngine(TOPIC_NAME);
+    Mockito.doReturn(true).when(storageEngine).containsPartition(PARTITION_ID);
     Mockito.doReturn(storagePartition).when(storageEngine).getPartitionOrThrow(PARTITION_ID);
     Mockito.doNothing().when(storagePartition).createSnapshot();
 

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/blobtransfer/BlobTransferUtilsTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/blobtransfer/BlobTransferUtilsTest.java
@@ -1,0 +1,37 @@
+package com.linkedin.davinci.blobtransfer;
+
+import com.linkedin.davinci.config.VeniceServerConfig;
+import com.linkedin.venice.exceptions.VeniceException;
+import org.mockito.Mockito;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+
+public class BlobTransferUtilsTest {
+  @Test
+  public void testIsBlobTransferManagerEnabled() {
+    VeniceServerConfig serverConfig = Mockito.mock(VeniceServerConfig.class);
+    boolean isIsolatedIngestionDisabled = false;
+    Mockito.when(serverConfig.isBlobTransferManagerEnabled()).thenReturn(true);
+    Mockito.when(serverConfig.isBlobTransferSslEnabled()).thenReturn(true);
+    Mockito.when(serverConfig.isBlobTransferAclEnabled()).thenReturn(true);
+
+    // Case 1: test when all conditions are met
+    boolean result = BlobTransferUtils.isBlobTransferManagerEnabled(serverConfig, isIsolatedIngestionDisabled);
+    Assert.assertTrue(result);
+
+    // Case 2: isolatedIngestionEnabled is true
+    boolean isIsolatedIngestionEnabled = true;
+    Assert.expectThrows(
+        VeniceException.class,
+        () -> BlobTransferUtils.isBlobTransferManagerEnabled(serverConfig, isIsolatedIngestionEnabled));
+
+    // Case 3: assert when blob transfer manager is enabled but SSL and ACL are not enabled, and it is not isolated
+    // ingestion
+    Mockito.when(serverConfig.isBlobTransferSslEnabled()).thenReturn(false);
+    Mockito.when(serverConfig.isBlobTransferAclEnabled()).thenReturn(false);
+    Assert.expectThrows(
+        VeniceException.class,
+        () -> BlobTransferUtils.isBlobTransferManagerEnabled(serverConfig, isIsolatedIngestionDisabled));
+  }
+}

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/blobtransfer/TestNettyP2PBlobTransferManager.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/blobtransfer/TestNettyP2PBlobTransferManager.java
@@ -14,6 +14,7 @@ import com.linkedin.davinci.config.VeniceConfigLoader;
 import com.linkedin.davinci.stats.AggVersionedBlobTransferStats;
 import com.linkedin.davinci.storage.StorageEngineRepository;
 import com.linkedin.davinci.storage.StorageMetadataService;
+import com.linkedin.davinci.store.AbstractStorageEngine;
 import com.linkedin.venice.ConfigKeys;
 import com.linkedin.venice.blobtransfer.BlobFinder;
 import com.linkedin.venice.blobtransfer.BlobPeersDiscoveryResponse;
@@ -95,6 +96,10 @@ public class TestNettyP2PBlobTransferManager {
     StorageEngineRepository storageEngineRepository = mock(StorageEngineRepository.class);
     GlobalChannelTrafficShapingHandler globalChannelTrafficShapingHandler =
         getGlobalChannelTrafficShapingHandlerInstance(2000000, 2000000);
+
+    AbstractStorageEngine storageEngine = Mockito.mock(AbstractStorageEngine.class);
+    Mockito.doReturn(storageEngine).when(storageEngineRepository).getLocalStorageEngine(Mockito.anyString());
+    Mockito.doReturn(true).when(storageEngine).containsPartition(Mockito.anyInt());
 
     sslFactory = Optional.of(SslUtils.getVeniceLocalSslFactory());
 

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/blobtransfer/TestP2PFileTransferServerHandler.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/blobtransfer/TestP2PFileTransferServerHandler.java
@@ -9,6 +9,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.linkedin.davinci.blobtransfer.server.P2PFileTransferServerHandler;
 import com.linkedin.davinci.storage.StorageEngineRepository;
 import com.linkedin.davinci.storage.StorageMetadataService;
+import com.linkedin.davinci.store.AbstractStorageEngine;
 import com.linkedin.venice.kafka.protocol.state.PartitionState;
 import com.linkedin.venice.kafka.protocol.state.StoreVersionState;
 import com.linkedin.venice.meta.ReadOnlyStoreRepository;
@@ -149,6 +150,9 @@ public class TestP2PFileTransferServerHandler {
 
   @Test
   public void testFailOnAccessPath() throws IOException {
+    AbstractStorageEngine localStorageEngine = Mockito.mock(AbstractStorageEngine.class);
+    Mockito.doReturn(localStorageEngine).when(storageEngineRepository).getLocalStorageEngine(Mockito.any());
+    Mockito.doReturn(true).when(localStorageEngine).containsPartition(Mockito.anyInt());
     // prepare response from metadata service for the metadata preparation
     StoreVersionState storeVersionState = new StoreVersionState();
     Mockito.doReturn(storeVersionState).when(storageMetadataService).getStoreVersionState(Mockito.any());
@@ -180,6 +184,10 @@ public class TestP2PFileTransferServerHandler {
 
   @Test
   public void testTransferSingleFileAndSingleMetadataForBatchStore() throws IOException {
+    AbstractStorageEngine localStorageEngine = Mockito.mock(AbstractStorageEngine.class);
+    Mockito.doReturn(localStorageEngine).when(storageEngineRepository).getLocalStorageEngine(Mockito.any());
+    Mockito.doReturn(true).when(localStorageEngine).containsPartition(Mockito.anyInt());
+
     // prepare response from metadata service
     StoreVersionState storeVersionState = new StoreVersionState();
     Mockito.doReturn(storeVersionState).when(storageMetadataService).getStoreVersionState(Mockito.any());
@@ -234,6 +242,10 @@ public class TestP2PFileTransferServerHandler {
 
   @Test
   public void testTransferMultipleFiles() throws IOException {
+    AbstractStorageEngine localStorageEngine = Mockito.mock(AbstractStorageEngine.class);
+    Mockito.doReturn(localStorageEngine).when(storageEngineRepository).getLocalStorageEngine(Mockito.any());
+    Mockito.doReturn(true).when(localStorageEngine).containsPartition(Mockito.anyInt());
+
     // prepare response from metadata service
     StoreVersionState storeVersionState = new StoreVersionState();
     Mockito.doReturn(storeVersionState).when(storageMetadataService).getStoreVersionState(Mockito.any());

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/ingestion/DefaultIngestionBackendTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/ingestion/DefaultIngestionBackendTest.java
@@ -173,7 +173,7 @@ public class DefaultIngestionBackendTest {
   public void testStartConsumptionWithClosePartition() {
     AbstractStorageEngine storageEngine = Mockito.mock(AbstractStorageEngine.class);
     when(storageEngine.containsPartition(PARTITION)).thenReturn(true);
-    doNothing().when(storageEngine).dropPartitionAndWholeStore(PARTITION, false);
+    doNothing().when(storageEngine).dropPartition(PARTITION, false);
 
     String kafkaTopic = Version.composeKafkaTopic(STORE_NAME, VERSION_NUMBER);
     when(store.isBlobTransferEnabled()).thenReturn(true);

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/ingestion/DefaultIngestionBackendTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/ingestion/DefaultIngestionBackendTest.java
@@ -173,7 +173,7 @@ public class DefaultIngestionBackendTest {
   public void testStartConsumptionWithClosePartition() {
     AbstractStorageEngine storageEngine = Mockito.mock(AbstractStorageEngine.class);
     when(storageEngine.containsPartition(PARTITION)).thenReturn(true);
-    doNothing().when(storageEngine).closePartition(PARTITION);
+    doNothing().when(storageEngine).dropPartitionAndWholeStore(PARTITION, false);
 
     String kafkaTopic = Version.composeKafkaTopic(STORE_NAME, VERSION_NUMBER);
     when(store.isBlobTransferEnabled()).thenReturn(true);

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/ingestion/DefaultIngestionBackendTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/ingestion/DefaultIngestionBackendTest.java
@@ -170,6 +170,30 @@ public class DefaultIngestionBackendTest {
   }
 
   @Test
+  public void testStartConsumptionWithClosePartition() {
+    AbstractStorageEngine storageEngine = Mockito.mock(AbstractStorageEngine.class);
+    when(storageEngine.containsPartition(PARTITION)).thenReturn(true);
+    doNothing().when(storageEngine).closePartition(PARTITION);
+
+    String kafkaTopic = Version.composeKafkaTopic(STORE_NAME, VERSION_NUMBER);
+    when(store.isBlobTransferEnabled()).thenReturn(true);
+    when(store.isHybrid()).thenReturn(true);
+    when(blobTransferManager.get(eq(STORE_NAME), eq(VERSION_NUMBER), eq(PARTITION), eq(BLOB_TRANSFER_FORMAT)))
+        .thenReturn(CompletableFuture.completedFuture(null));
+    when(veniceServerConfig.getRocksDBPath()).thenReturn(BASE_DIR);
+    RocksDBServerConfig rocksDBServerConfig = Mockito.mock(RocksDBServerConfig.class);
+    when(rocksDBServerConfig.isRocksDBPlainTableFormatEnabled()).thenReturn(false);
+    when(veniceServerConfig.getRocksDBServerConfig()).thenReturn(rocksDBServerConfig);
+    when(storageService.getStorageEngine(kafkaTopic)).thenReturn(storageEngine);
+
+    ingestionBackend.startConsumption(storeConfig, PARTITION);
+    verify(blobTransferManager).get(eq(STORE_NAME), eq(VERSION_NUMBER), eq(PARTITION), eq(BLOB_TRANSFER_FORMAT));
+    verify(aggVersionedBlobTransferStats).recordBlobTransferResponsesCount(eq(STORE_NAME), eq(VERSION_NUMBER));
+    verify(aggVersionedBlobTransferStats)
+        .recordBlobTransferResponsesBasedOnBoostrapStatus(eq(STORE_NAME), eq(VERSION_NUMBER), eq(true));
+  }
+
+  @Test
   public void testHasCurrentVersionBootstrapping() {
     KafkaStoreIngestionService mockIngestionService = mock(KafkaStoreIngestionService.class);
     DefaultIngestionBackend ingestionBackend =

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/BlobP2PTransferAmongServersTest.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/BlobP2PTransferAmongServersTest.java
@@ -1,6 +1,5 @@
 package com.linkedin.venice.endToEnd;
 
-import static com.linkedin.davinci.store.AbstractStorageEngine.METADATA_PARTITION_ID;
 import static com.linkedin.davinci.store.rocksdb.RocksDBServerConfig.ROCKSDB_PLAIN_TABLE_FORMAT_ENABLED;
 import static com.linkedin.venice.integration.utils.VeniceClusterWrapper.DEFAULT_KEY_SCHEMA;
 import static com.linkedin.venice.meta.StoreStatus.FULLLY_REPLICATED;
@@ -27,8 +26,6 @@ import com.linkedin.venice.utils.Utils;
 import java.io.File;
 import java.nio.file.Files;
 import java.nio.file.Paths;
-import java.util.Arrays;
-import java.util.List;
 import java.util.Properties;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
@@ -80,20 +77,6 @@ public class BlobP2PTransferAmongServersTest {
       Assert.assertTrue(Files.exists(Paths.get(snapshotPath1)));
       String snapshotPath2 = RocksDBUtils.composeSnapshotDir(path2 + "/rocksdb", storeName + "_v1", partitionId);
       Assert.assertTrue(Files.exists(Paths.get(snapshotPath2)));
-    }
-
-    // cleanup and restart server 1
-    FileUtils.deleteDirectory(
-        new File(RocksDBUtils.composePartitionDbDir(path1 + "/rocksdb", storeName + "_v1", METADATA_PARTITION_ID)));
-    for (int partitionId = 0; partitionId < PARTITION_COUNT; partitionId++) {
-      FileUtils.deleteDirectory(
-          new File(RocksDBUtils.composePartitionDbDir(path1 + "/rocksdb", storeName + "_v1", partitionId)));
-      // both partition db and snapshot should be deleted
-      Assert.assertFalse(
-          Files.exists(
-              Paths.get(RocksDBUtils.composePartitionDbDir(path1 + "/rocksdb", storeName + "_v1", partitionId))));
-      Assert.assertFalse(
-          Files.exists(Paths.get(RocksDBUtils.composeSnapshotDir(path1 + "/rocksdb", storeName + "_v1", partitionId))));
     }
 
     cluster.stopAndRestartVeniceServer(server1Port);
@@ -159,27 +142,19 @@ public class BlobP2PTransferAmongServersTest {
       Assert.assertTrue(Files.exists(Paths.get(snapshotPath2)));
     }
 
-    // cleanup and restart server 1
-    FileUtils.deleteDirectory(
-        new File(RocksDBUtils.composePartitionDbDir(path1 + "/rocksdb", storeName + "_v1", METADATA_PARTITION_ID)));
-
-    List<String> paths = Arrays.asList(path1, path2);
-
-    // clean up all snapshot files on server 1 and server 2,
+    // clean up all snapshot files on server 2,
     // to simulate the case that snapshot is not existed on server2,
     // should return 404 in response
-    for (String path: paths) {
-      for (int i = 0; i < PARTITION_COUNT; i++) {
-        FileUtils
-            .deleteDirectory(new File(RocksDBUtils.composePartitionDbDir(path + "/rocksdb", storeName + "_v1", i)));
-        // both partition db and snapshot should be deleted
-        Assert.assertFalse(
-            Files.exists(Paths.get(RocksDBUtils.composePartitionDbDir(path + "/rocksdb", storeName + "_v1", i))));
-        Assert.assertFalse(
-            Files.exists(Paths.get(RocksDBUtils.composeSnapshotDir(path + "/rocksdb", storeName + "_v1", i))));
-      }
+    for (int i = 0; i < PARTITION_COUNT; i++) {
+      FileUtils.deleteDirectory(new File(RocksDBUtils.composePartitionDbDir(path2 + "/rocksdb", storeName + "_v1", i)));
+      // both partition db and snapshot should be deleted
+      Assert.assertFalse(
+          Files.exists(Paths.get(RocksDBUtils.composePartitionDbDir(path2 + "/rocksdb", storeName + "_v1", i))));
+      Assert.assertFalse(
+          Files.exists(Paths.get(RocksDBUtils.composeSnapshotDir(path2 + "/rocksdb", storeName + "_v1", i))));
     }
 
+    // cleanup and restart server 1
     cluster.stopAndRestartVeniceServer(server1Port);
     TestUtils.waitForNonDeterministicAssertion(2, TimeUnit.MINUTES, () -> {
       Assert.assertTrue(server1.isRunning());
@@ -233,20 +208,7 @@ public class BlobP2PTransferAmongServersTest {
       Assert.assertTrue(Files.exists(Paths.get(snapshotPath2)));
     }
 
-    // cleanup and restart server 1
-    FileUtils.deleteDirectory(
-        new File(RocksDBUtils.composePartitionDbDir(path1 + "/rocksdb", storeName + "_v1", METADATA_PARTITION_ID)));
-    for (int partitionId = 0; partitionId < PARTITION_COUNT; partitionId++) {
-      FileUtils.deleteDirectory(
-          new File(RocksDBUtils.composePartitionDbDir(path1 + "/rocksdb", storeName + "_v1", partitionId)));
-      // both partition db and snapshot should be deleted
-      Assert.assertFalse(
-          Files.exists(
-              Paths.get(RocksDBUtils.composePartitionDbDir(path1 + "/rocksdb", storeName + "_v1", partitionId))));
-      Assert.assertFalse(
-          Files.exists(Paths.get(RocksDBUtils.composeSnapshotDir(path1 + "/rocksdb", storeName + "_v1", partitionId))));
-    }
-
+    // restart server 1
     cluster.stopAndRestartVeniceServer(server1Port);
     TestUtils.waitForNonDeterministicAssertion(2, TimeUnit.MINUTES, () -> {
       Assert.assertTrue(server1.isRunning());
@@ -428,18 +390,6 @@ public class BlobP2PTransferAmongServersTest {
 
     // cleanup and stop server 1
     cluster.stopVeniceServer(server1Port);
-    FileUtils.deleteDirectory(
-        new File(RocksDBUtils.composePartitionDbDir(path1 + "/rocksdb", storeName + "_v1", METADATA_PARTITION_ID)));
-    for (int partitionId = 0; partitionId < PARTITION_COUNT; partitionId++) {
-      FileUtils.deleteDirectory(
-          new File(RocksDBUtils.composePartitionDbDir(path1 + "/rocksdb", storeName + "_v1", partitionId)));
-      // both partition db and snapshot should be deleted
-      Assert.assertFalse(
-          Files.exists(
-              Paths.get(RocksDBUtils.composePartitionDbDir(path1 + "/rocksdb", storeName + "_v1", partitionId))));
-      Assert.assertFalse(
-          Files.exists(Paths.get(RocksDBUtils.composeSnapshotDir(path1 + "/rocksdb", storeName + "_v1", partitionId))));
-    }
 
     // send records to server 2 only
     SystemProducer veniceProducer = null;

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/DaVinciClientTest.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/DaVinciClientTest.java
@@ -14,6 +14,7 @@ import static com.linkedin.venice.CommonConfigKeys.SSL_TRUSTSTORE_LOCATION;
 import static com.linkedin.venice.CommonConfigKeys.SSL_TRUSTSTORE_PASSWORD;
 import static com.linkedin.venice.CommonConfigKeys.SSL_TRUSTSTORE_TYPE;
 import static com.linkedin.venice.ConfigKeys.BLOB_TRANSFER_ACL_ENABLED;
+import static com.linkedin.venice.ConfigKeys.BLOB_TRANSFER_DISABLED_OFFSET_LAG_THRESHOLD;
 import static com.linkedin.venice.ConfigKeys.BLOB_TRANSFER_MANAGER_ENABLED;
 import static com.linkedin.venice.ConfigKeys.BLOB_TRANSFER_SSL_ENABLED;
 import static com.linkedin.venice.ConfigKeys.CLIENT_SYSTEM_STORE_REPOSITORY_REFRESH_INTERVAL_SECONDS;
@@ -1308,6 +1309,7 @@ public class DaVinciClientTest {
         .put(BLOB_TRANSFER_MANAGER_ENABLED, true)
         .put(BLOB_TRANSFER_SSL_ENABLED, true)
         .put(BLOB_TRANSFER_ACL_ENABLED, true)
+        .put(BLOB_TRANSFER_DISABLED_OFFSET_LAG_THRESHOLD, -1000000)
         .put(SSL_KEYSTORE_TYPE, "JKS")
         .put(SSL_KEYSTORE_LOCATION, SslUtils.getPathForResource(LOCAL_KEYSTORE_JKS))
         .put(SSL_KEYSTORE_PASSWORD, LOCAL_PASSWORD)
@@ -1327,6 +1329,7 @@ public class DaVinciClientTest {
         VeniceRouterWrapper.CLUSTER_DISCOVERY_D2_SERVICE_NAME,
         new MetricsRepository(),
         backendConfig2)) {
+      // Case 1: Start a fresh client, and see if it can bootstrap from the first one
       DaVinciClient<Integer, Object> client2 = factory2.getAndStartGenericAvroClient(storeName, dvcConfig);
       client2.subscribeAll().get();
 
@@ -1335,6 +1338,28 @@ public class DaVinciClientTest {
         Assert.assertTrue(Files.exists(Paths.get(snapshotPath)));
       }
 
+      for (int i = 0; i < 3; i++) {
+        String partitionPath2 = RocksDBUtils.composePartitionDbDir(dvcPath2 + "/rocksdb", storeName + "_v1", i);
+        Assert.assertTrue(Files.exists(Paths.get(partitionPath2)));
+        String snapshotPath2 = RocksDBUtils.composeSnapshotDir(dvcPath2 + "/rocksdb", storeName + "_v1", i);
+        Assert.assertFalse(Files.exists(Paths.get(snapshotPath2)));
+      }
+
+      // Case 2: Restart the second Da Vinci client to see if it can re-bootstrap from the first one with retained old
+      // data.
+      client2.close();
+      // wait and restart, and verify old data is retained before subscribing
+      Thread.sleep(3000);
+      for (int i = 0; i < 3; i++) {
+        // Verify that the folder is not clean up.
+        String partitionPath2 = RocksDBUtils.composePartitionDbDir(dvcPath2 + "/rocksdb", storeName + "_v1", i);
+        Assert.assertTrue(Files.exists(Paths.get(partitionPath2)));
+        String snapshotPath2 = RocksDBUtils.composeSnapshotDir(dvcPath2 + "/rocksdb", storeName + "_v1", i);
+        Assert.assertFalse(Files.exists(Paths.get(snapshotPath2)));
+      }
+
+      client2.start();
+      client2.subscribeAll().get();
       for (int i = 0; i < 3; i++) {
         String partitionPath2 = RocksDBUtils.composePartitionDbDir(dvcPath2 + "/rocksdb", storeName + "_v1", i);
         Assert.assertTrue(Files.exists(Paths.get(partitionPath2)));

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/DaVinciClientTest.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/DaVinciClientTest.java
@@ -1401,7 +1401,7 @@ public class DaVinciClientTest {
         Integer.toString(port2),
         storageClass,
         "false",
-        "false");
+        "true");
 
     // Wait for the first DaVinci Client to complete ingestion
     Thread.sleep(60000);

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestBatchForRocksDB.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestBatchForRocksDB.java
@@ -1,7 +1,9 @@
 package com.linkedin.venice.endToEnd;
 
 import static com.linkedin.davinci.store.rocksdb.RocksDBServerConfig.ROCKSDB_PLAIN_TABLE_FORMAT_ENABLED;
+import static com.linkedin.venice.ConfigKeys.BLOB_TRANSFER_ACL_ENABLED;
 import static com.linkedin.venice.ConfigKeys.BLOB_TRANSFER_MANAGER_ENABLED;
+import static com.linkedin.venice.ConfigKeys.BLOB_TRANSFER_SSL_ENABLED;
 import static com.linkedin.venice.ConfigKeys.DATA_BASE_PATH;
 import static com.linkedin.venice.ConfigKeys.ENABLE_BLOB_TRANSFER;
 import static com.linkedin.venice.ConfigKeys.PERSISTENCE_TYPE;
@@ -34,6 +36,8 @@ public class TestBatchForRocksDB extends TestBatch {
     serverProperties.setProperty(SERVER_DATABASE_SYNC_BYTES_INTERNAL_FOR_DEFERRED_WRITE_MODE, "300");
     serverProperties.setProperty(ENABLE_BLOB_TRANSFER, "true");
     serverProperties.setProperty(BLOB_TRANSFER_MANAGER_ENABLED, "true");
+    serverProperties.setProperty(BLOB_TRANSFER_ACL_ENABLED, "true");
+    serverProperties.setProperty(BLOB_TRANSFER_SSL_ENABLED, "true");
     serverProperties.setProperty(DATA_BASE_PATH, BASE_DATA_PATH_1);
     veniceClusterWrapper.addVeniceServer(new Properties(), serverProperties);
     serverProperties.setProperty(DATA_BASE_PATH, BASE_DATA_PATH_2);

--- a/services/venice-server/src/main/java/com/linkedin/venice/server/VeniceServer.java
+++ b/services/venice-server/src/main/java/com/linkedin/venice/server/VeniceServer.java
@@ -477,8 +477,7 @@ public class VeniceServer {
     /**
      * Initialize Blob transfer manager for Service
      */
-    if (serverConfig.isBlobTransferManagerEnabled() && serverConfig.isBlobTransferSslEnabled()
-        && serverConfig.isBlobTransferAclEnabled()) {
+    if (BlobTransferUtils.isBlobTransferManagerEnabled(serverConfig, false)) {
       aggVersionedBlobTransferStats = new AggVersionedBlobTransferStats(metricsRepository, metadataRepo, serverConfig);
 
       P2PBlobTransferConfig p2PBlobTransferConfig = new P2PBlobTransferConfig(


### PR DESCRIPTION
<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat], [protocol]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## Problem Statement
Before initiating bootstrap from blob transfer, ensure the RocksDB folder is cleaned up. Otherwise, both existing old blobs and newly transferred blobs may coexist. During blob transfer, if a transferred file shares the same name as a pre-existing file, it will overwrite the old file. However, if the file names differ, particularly for MANIFEST files, both old and new blobs will persist, necessitating a cleanup of the entire partition's RocksDB folder.

Before clean up this partition folder, we need to make sure that the partition is closed and also clean up the offset. 

## Solution
1. Clean up partition folder.
2. Close partition storage engine.
3. Clean partition offset. 


###  Code changes
- [ ] Added new code behind **a config**. If so list the config names and their default values in the PR description.
- [ ] Introduced new **log lines**. 
  - [ ] Confirmed if logs need to be **rate limited** to avoid excessive logging.

###  **Concurrency-Specific Checks**
Both reviewer and PR author to verify
- [ ] Code has **no race conditions** or **thread safety issues**.
- [ ] Proper **synchronization mechanisms** (e.g., `synchronized`, `RWLock`) are used where needed.
- [ ] No **blocking calls** inside critical sections that could lead to deadlocks or performance degradation.
- [ ] Verified **thread-safe collections** are used (e.g., `ConcurrentHashMap`, `CopyOnWriteArrayList`).
- [ ] Validated proper exception handling in multi-threaded code to avoid silent thread termination.


## How was this PR tested?
 
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->

- [ ] New unit tests added.
- [ ] New integration tests added.
- [x] Modified or extended existing tests.
- [ ] Verified backward compatibility (if applicable).

## Does this PR introduce any user-facing or breaking changes?
<!--  
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [ ] No. You can skip the rest of this section.
- [ ] Yes. Clearly explain the behavior change and its impact.