### PR TITLE
[server] Do not track leader lag in when STANDBY->LEADER is paused due to migration

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/helix/LeaderFollowerPartitionStateModel.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/helix/LeaderFollowerPartitionStateModel.java
@@ -12,14 +12,11 @@ import com.linkedin.venice.helix.HelixState;
 import com.linkedin.venice.meta.ReadOnlyStoreRepository;
 import com.linkedin.venice.meta.Store;
 import com.linkedin.venice.meta.Version;
-import com.linkedin.venice.meta.VersionImpl;
 import com.linkedin.venice.utils.LatencyUtils;
-import com.linkedin.venice.utils.Pair;
 import com.linkedin.venice.utils.Utils;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
-import java.util.function.BiConsumer;
 import org.apache.helix.NotificationContext;
 import org.apache.helix.model.Message;
 import org.apache.helix.participant.statemachine.StateModelInfo;
@@ -120,8 +117,9 @@ public class LeaderFollowerPartitionStateModel extends AbstractPartitionStateMod
       if (isRegularStoreCurrentVersion) {
         waitConsumptionCompleted(resourceName, notifier);
       }
-      updateLagMonitor(
+      heartbeatMonitoringService.updateLagMonitor(
           message.getResourceName(),
+          getPartition(),
           heartbeatMonitoringService::addFollowerLagMonitor,
           false,
           messageToString(message));
@@ -136,8 +134,9 @@ public class LeaderFollowerPartitionStateModel extends AbstractPartitionStateMod
      * where a slice doesn't have a replicating leader.  While this state transition executes, there should be no
      * other leader in the slice.
      */
-    updateLagMonitor(
+    heartbeatMonitoringService.updateLagMonitor(
         message.getResourceName(),
+        getPartition(),
         heartbeatMonitoringService::addLeaderLagMonitor,
         false,
         messageToString(message));
@@ -151,8 +150,9 @@ public class LeaderFollowerPartitionStateModel extends AbstractPartitionStateMod
   @Transition(to = HelixState.STANDBY_STATE, from = HelixState.LEADER_STATE)
   public void onBecomeStandbyFromLeader(Message message, NotificationContext context) {
     LeaderSessionIdChecker checker = new LeaderSessionIdChecker(leaderSessionId.incrementAndGet(), leaderSessionId);
-    updateLagMonitor(
+    heartbeatMonitoringService.updateLagMonitor(
         message.getResourceName(),
+        getPartition(),
         heartbeatMonitoringService::addFollowerLagMonitor,
         false,
         messageToString(message));
@@ -165,8 +165,9 @@ public class LeaderFollowerPartitionStateModel extends AbstractPartitionStateMod
 
   @Transition(to = HelixState.OFFLINE_STATE, from = HelixState.STANDBY_STATE)
   public void onBecomeOfflineFromStandby(Message message, NotificationContext context) {
-    updateLagMonitor(
+    heartbeatMonitoringService.updateLagMonitor(
         message.getResourceName(),
+        getPartition(),
         heartbeatMonitoringService::removeLagMonitor,
         true,
         messageToString(message));
@@ -232,47 +233,6 @@ public class LeaderFollowerPartitionStateModel extends AbstractPartitionStateMod
   public void onBecomeOfflineFromError(Message message, NotificationContext context) {
     // Venice is not supporting automatically partition recovery. No-oped here.
     logger.warn("unexpected state transition from ERROR to OFFLINE");
-  }
-
-  void updateLagMonitor(
-      String resourceName,
-      BiConsumer<Version, Integer> lagMonFunction,
-      boolean isNullVersionValid,
-      String trigger) {
-    try {
-      String storeName = Version.parseStoreFromKafkaTopicName(resourceName);
-      int storeVersion = Version.parseVersionFromKafkaTopicName(resourceName);
-      Pair<Store, Version> res = getStoreRepo()
-          .waitVersion(storeName, storeVersion, getStoreAndServerConfigs().getServerMaxWaitForVersionInfo(), 200);
-      Store store = res.getFirst();
-      Version version = res.getSecond();
-      if (store == null) {
-        logger.error(
-            "Failed to get store for resource: {} with trigger: {}. Will not update lag monitor.",
-            Utils.getReplicaId(resourceName, getPartition()),
-            trigger);
-        return;
-      }
-      if (version == null && !isNullVersionValid) {
-        logger.error(
-            "Failed to get version for resource: {} with trigger: {}. Will not update lag monitor.",
-            Utils.getReplicaId(resourceName, getPartition()),
-            trigger);
-        return;
-      }
-      if (version == null) {
-        // During version deletion, the version will be deleted from ZK prior to servers perform resource deletion.
-        // It's valid to have null version when trying to remove lag monitor for the deleted resource.
-        version = new VersionImpl(storeName, storeVersion, "");
-      }
-      lagMonFunction.accept(version, getPartition());
-    } catch (Exception e) {
-      logger.error(
-          "Failed to update lag monitor for replica: {} with trigger: {}",
-          Utils.getReplicaId(resourceName, getPartition()),
-          trigger,
-          e);
-    }
   }
 
   private String messageToString(Message message) {

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/helix/LeaderFollowerPartitionStateModel.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/helix/LeaderFollowerPartitionStateModel.java
@@ -126,13 +126,6 @@ public class LeaderFollowerPartitionStateModel extends AbstractPartitionStateMod
   @Transition(to = HelixState.LEADER_STATE, from = HelixState.STANDBY_STATE)
   public void onBecomeLeaderFromStandby(Message message, NotificationContext context) {
     LeaderSessionIdChecker checker = new LeaderSessionIdChecker(leaderSessionId.incrementAndGet(), leaderSessionId);
-    /**
-     * We set up the lag monitor first for leader transitions because we want to monitor the amount of time
-     * when a slice doesn't have a replicating leader.  While this state transition executes, there should be no
-     * other leader in the slice.
-     */
-    heartbeatMonitoringService
-        .updateLagMonitor(message.getResourceName(), getPartition(), HeartbeatLagMonitorAction.SET_LEADER_MONITOR);
     executeStateTransition(
         message,
         context,

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTask.java
@@ -492,6 +492,12 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
           return;
         }
         if (store.isMigrationDuplicateStore()) {
+          heartbeatMonitoringService.updateLagMonitor(
+              getKafkaVersionTopic(),
+              partitionConsumptionState.getPartition(),
+              heartbeatMonitoringService::addFollowerLagMonitor,
+              false,
+              "Pause state transition from STANDBY to LEADER for replica as this store is undergoing migration");
           partitionConsumptionState.setLeaderFollowerState(PAUSE_TRANSITION_FROM_STANDBY_TO_LEADER);
           LOGGER.warn(
               "State transition from STANDBY to LEADER is paused for replica: {} as this store is undergoing migration",
@@ -634,6 +640,12 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
         case PAUSE_TRANSITION_FROM_STANDBY_TO_LEADER:
           Store store = storeRepository.getStoreOrThrow(storeName);
           if (!store.isMigrationDuplicateStore()) {
+            heartbeatMonitoringService.updateLagMonitor(
+                getKafkaVersionTopic(),
+                partitionConsumptionState.getPartition(),
+                heartbeatMonitoringService::addLeaderLagMonitor,
+                false,
+                "Resumed state transition from STANDBY to LEADER for replica as store migration is done.");
             partitionConsumptionState.setLeaderFollowerState(IN_TRANSITION_FROM_STANDBY_TO_LEADER);
             LOGGER.info(
                 "Resumed state transition from STANDBY to LEADER for replica: {}",

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTask.java
@@ -25,6 +25,7 @@ import com.linkedin.davinci.ingestion.LagType;
 import com.linkedin.davinci.listener.response.NoOpReadResponseStats;
 import com.linkedin.davinci.schema.merge.CollectionTimestampMergeRecordHelper;
 import com.linkedin.davinci.schema.merge.MergeRecordHelper;
+import com.linkedin.davinci.stats.ingestion.heartbeat.HeartbeatLagMonitorAction;
 import com.linkedin.davinci.stats.ingestion.heartbeat.HeartbeatMonitoringService;
 import com.linkedin.davinci.storage.StorageService;
 import com.linkedin.davinci.storage.chunking.ChunkedValueManifestContainer;
@@ -495,9 +496,7 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
           heartbeatMonitoringService.updateLagMonitor(
               getKafkaVersionTopic(),
               partitionConsumptionState.getPartition(),
-              heartbeatMonitoringService::addFollowerLagMonitor,
-              false,
-              "Pause state transition from STANDBY to LEADER for replica as this store is undergoing migration");
+              HeartbeatLagMonitorAction.SET_FOLLOWER_MONITOR);
           partitionConsumptionState.setLeaderFollowerState(PAUSE_TRANSITION_FROM_STANDBY_TO_LEADER);
           LOGGER.warn(
               "State transition from STANDBY to LEADER is paused for replica: {} as this store is undergoing migration",
@@ -643,9 +642,7 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
             heartbeatMonitoringService.updateLagMonitor(
                 getKafkaVersionTopic(),
                 partitionConsumptionState.getPartition(),
-                heartbeatMonitoringService::addLeaderLagMonitor,
-                false,
-                "Resumed state transition from STANDBY to LEADER for replica as store migration is done.");
+                HeartbeatLagMonitorAction.SET_LEADER_MONITOR);
             partitionConsumptionState.setLeaderFollowerState(IN_TRANSITION_FROM_STANDBY_TO_LEADER);
             LOGGER.info(
                 "Resumed state transition from STANDBY to LEADER for replica: {}",

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTask.java
@@ -683,7 +683,7 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
             startConsumingAsLeader(partitionConsumptionState);
 
             // Start tracking leader replication lag
-            heartbeatMonitoringService.updateLagMonitor(
+            getHeartbeatMonitoringService().updateLagMonitor(
                 getKafkaVersionTopic(),
                 partitionConsumptionState.getPartition(),
                 HeartbeatLagMonitorAction.SET_LEADER_MONITOR);
@@ -4229,5 +4229,9 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
 
   KafkaDataIntegrityValidator getKafkaDataIntegrityValidatorForLeaders() {
     return kafkaDataIntegrityValidatorForLeaders; // mainly for testing
+  }
+
+  HeartbeatMonitoringService getHeartbeatMonitoringService() {
+    return heartbeatMonitoringService;
   }
 }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/ingestion/heartbeat/HeartbeatLagMonitorAction.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/ingestion/heartbeat/HeartbeatLagMonitorAction.java
@@ -1,0 +1,18 @@
+package com.linkedin.davinci.stats.ingestion.heartbeat;
+
+/**
+ * A simple Enum class representing all the actions for heartbeat lag monitoring setup.
+ */
+public enum HeartbeatLagMonitorAction {
+  SET_LEADER_MONITOR("STANDBY->LEADER"), SET_FOLLOWER_MONITOR("LEADER->STANDBY"), REMOVE_MONITOR("STANDBY->OFFLINE");
+
+  private final String trigger;
+
+  HeartbeatLagMonitorAction(String trigger) {
+    this.trigger = trigger;
+  }
+
+  public String getTrigger() {
+    return trigger;
+  }
+}

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/ingestion/heartbeat/HeartbeatMonitoringService.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/ingestion/heartbeat/HeartbeatMonitoringService.java
@@ -299,7 +299,7 @@ public class HeartbeatMonitoringService extends AbstractVeniceService {
       Store store = res.getFirst();
       Version version = res.getSecond();
       if (store == null) {
-        getLogger().error(
+        LOGGER.error(
             "Failed to get store for resource: {} with trigger: {}. Will not update lag monitor.",
             Utils.getReplicaId(resourceName, partitionId),
             heartbeatLagMonitorAction.getTrigger());
@@ -307,7 +307,7 @@ public class HeartbeatMonitoringService extends AbstractVeniceService {
       }
       if (version == null) {
         if (!HeartbeatLagMonitorAction.REMOVE_MONITOR.equals(heartbeatLagMonitorAction)) {
-          getLogger().error(
+          LOGGER.error(
               "Failed to get version for resource: {} with trigger: {}. Will not update lag monitor.",
               Utils.getReplicaId(resourceName, partitionId),
               heartbeatLagMonitorAction.getTrigger());
@@ -330,7 +330,7 @@ public class HeartbeatMonitoringService extends AbstractVeniceService {
         default:
       }
     } catch (Exception e) {
-      getLogger().error(
+      LOGGER.error(
           "Failed to update lag monitor for replica: {} with trigger: {}",
           Utils.getReplicaId(resourceName, partitionId),
           heartbeatLagMonitorAction.getTrigger(),
@@ -344,10 +344,6 @@ public class HeartbeatMonitoringService extends AbstractVeniceService {
 
   Duration getMaxWaitForVersionInfo() {
     return maxWaitForVersionInfo;
-  }
-
-  static Logger getLogger() {
-    return LOGGER;
   }
 
   private void recordHeartbeat(

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/ingestion/heartbeat/HeartbeatMonitoringService.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/ingestion/heartbeat/HeartbeatMonitoringService.java
@@ -457,8 +457,7 @@ public class HeartbeatMonitoringService extends AbstractVeniceService {
   }
 
   AggregatedHeartbeatLagEntry getMaxHeartbeatLag(
-      Map<String, Map<Integer, Map<Integer, Map<String, HeartbeatTimeStampEntry>>>> heartbeatTimestamps,
-      boolean isLeaderLag) {
+      Map<String, Map<Integer, Map<Integer, Map<String, HeartbeatTimeStampEntry>>>> heartbeatTimestamps) {
     long currentTimestamp = System.currentTimeMillis();
     long minHeartbeatTimestampForCurrentVersion = Long.MAX_VALUE;
     long minHeartbeatTimestampForNonCurrentVersion = Long.MAX_VALUE;
@@ -491,11 +490,11 @@ public class HeartbeatMonitoringService extends AbstractVeniceService {
   }
 
   public AggregatedHeartbeatLagEntry getMaxLeaderHeartbeatLag() {
-    return getMaxHeartbeatLag(leaderHeartbeatTimeStamps, true);
+    return getMaxHeartbeatLag(leaderHeartbeatTimeStamps);
   }
 
   public AggregatedHeartbeatLagEntry getMaxFollowerHeartbeatLag() {
-    return getMaxHeartbeatLag(leaderHeartbeatTimeStamps, false);
+    return getMaxHeartbeatLag(followerHeartbeatTimeStamps);
   }
 
   @FunctionalInterface

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/ingestion/heartbeat/HeartbeatMonitoringService.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/ingestion/heartbeat/HeartbeatMonitoringService.java
@@ -294,11 +294,12 @@ public class HeartbeatMonitoringService extends AbstractVeniceService {
     try {
       String storeName = Version.parseStoreFromKafkaTopicName(resourceName);
       int storeVersion = Version.parseVersionFromKafkaTopicName(resourceName);
-      Pair<Store, Version> res = metadataRepository.waitVersion(storeName, storeVersion, maxWaitForVersionInfo, 200);
+      Pair<Store, Version> res =
+          getMetadataRepository().waitVersion(storeName, storeVersion, getMaxWaitForVersionInfo(), 200);
       Store store = res.getFirst();
       Version version = res.getSecond();
       if (store == null) {
-        logger.error(
+        getLogger().error(
             "Failed to get store for resource: {} with trigger: {}. Will not update lag monitor.",
             Utils.getReplicaId(resourceName, partitionId),
             heartbeatLagMonitorAction.getTrigger());
@@ -306,7 +307,7 @@ public class HeartbeatMonitoringService extends AbstractVeniceService {
       }
       if (version == null) {
         if (!HeartbeatLagMonitorAction.REMOVE_MONITOR.equals(heartbeatLagMonitorAction)) {
-          logger.error(
+          getLogger().error(
               "Failed to get version for resource: {} with trigger: {}. Will not update lag monitor.",
               Utils.getReplicaId(resourceName, partitionId),
               heartbeatLagMonitorAction.getTrigger());
@@ -329,12 +330,24 @@ public class HeartbeatMonitoringService extends AbstractVeniceService {
         default:
       }
     } catch (Exception e) {
-      logger.error(
+      getLogger().error(
           "Failed to update lag monitor for replica: {} with trigger: {}",
           Utils.getReplicaId(resourceName, partitionId),
           heartbeatLagMonitorAction.getTrigger(),
           e);
     }
+  }
+
+  ReadOnlyStoreRepository getMetadataRepository() {
+    return metadataRepository;
+  }
+
+  Duration getMaxWaitForVersionInfo() {
+    return maxWaitForVersionInfo;
+  }
+
+  static Logger getLogger() {
+    return LOGGER;
   }
 
   private void recordHeartbeat(

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/ingestion/heartbeat/HeartbeatMonitoringService.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/ingestion/heartbeat/HeartbeatMonitoringService.java
@@ -1,5 +1,6 @@
 package com.linkedin.davinci.stats.ingestion.heartbeat;
 
+import com.linkedin.davinci.config.VeniceServerConfig;
 import com.linkedin.davinci.kafka.consumer.LeaderFollowerStateType;
 import com.linkedin.davinci.kafka.consumer.ReplicaHeartbeatInfo;
 import com.linkedin.davinci.stats.HeartbeatMonitoringServiceStats;
@@ -17,7 +18,6 @@ import java.time.Duration;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
-import java.util.function.BiConsumer;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -47,7 +47,6 @@ public class HeartbeatMonitoringService extends AbstractVeniceService {
   public static final long DEFAULT_STALE_HEARTBEAT_LOG_THRESHOLD_MILLIS = TimeUnit.MINUTES.toMillis(10);
 
   private static final Logger LOGGER = LogManager.getLogger(HeartbeatMonitoringService.class);
-
   private final ReadOnlyStoreRepository metadataRepository;
   private final Thread reportingThread;
   private final Thread lagLoggingThread;
@@ -60,16 +59,16 @@ public class HeartbeatMonitoringService extends AbstractVeniceService {
   private final Map<String, Map<Integer, Map<Integer, Map<String, HeartbeatTimeStampEntry>>>> leaderHeartbeatTimeStamps;
   private final HeartbeatVersionedStats versionStatsReporter;
   private final HeartbeatMonitoringServiceStats heartbeatMonitoringServiceStats;
-  private final Duration serverMaxWaitForVersionInfo = Duration.ofMillis(5000);
+  private final Duration maxWaitForVersionInfo;
 
   public HeartbeatMonitoringService(
       MetricsRepository metricsRepository,
       ReadOnlyStoreRepository metadataRepository,
-      Set<String> regionNames,
-      String localRegionName,
+      VeniceServerConfig serverConfig,
       HeartbeatMonitoringServiceStats heartbeatMonitoringServiceStats) {
-    this.regionNames = regionNames;
-    this.localRegionName = localRegionName;
+    this.regionNames = serverConfig.getRegionNames();
+    this.localRegionName = serverConfig.getRegionName();
+    this.maxWaitForVersionInfo = serverConfig.getServerMaxWaitForVersionInfo();
     this.reportingThread = new HeartbeatReporterThread();
     this.lagLoggingThread = new HeartbeatLagLoggingThread();
     this.followerHeartbeatTimeStamps = new VeniceConcurrentHashMap<>();
@@ -285,6 +284,59 @@ public class HeartbeatMonitoringService extends AbstractVeniceService {
     recordHeartbeat(store, version, partition, region, timestamp, followerHeartbeatTimeStamps, isReadyToServe, true);
   }
 
+  /**
+   * Update lag monitor for a given resource replica based on different heartbeat lag monitor action.
+   */
+  public void updateLagMonitor(
+      String resourceName,
+      int partitionId,
+      HeartbeatLagMonitorAction heartbeatLagMonitorAction) {
+    try {
+      String storeName = Version.parseStoreFromKafkaTopicName(resourceName);
+      int storeVersion = Version.parseVersionFromKafkaTopicName(resourceName);
+      Pair<Store, Version> res = metadataRepository.waitVersion(storeName, storeVersion, maxWaitForVersionInfo, 200);
+      Store store = res.getFirst();
+      Version version = res.getSecond();
+      if (store == null) {
+        logger.error(
+            "Failed to get store for resource: {} with trigger: {}. Will not update lag monitor.",
+            Utils.getReplicaId(resourceName, partitionId),
+            heartbeatLagMonitorAction.getTrigger());
+        return;
+      }
+      if (version == null) {
+        if (!HeartbeatLagMonitorAction.REMOVE_MONITOR.equals(heartbeatLagMonitorAction)) {
+          logger.error(
+              "Failed to get version for resource: {} with trigger: {}. Will not update lag monitor.",
+              Utils.getReplicaId(resourceName, partitionId),
+              heartbeatLagMonitorAction.getTrigger());
+          return;
+        }
+        // During version deletion, the version will be deleted from ZK prior to servers perform resource deletion.
+        // It's valid to have null version when trying to remove lag monitor for the deleted resource.
+        version = new VersionImpl(storeName, storeVersion, "");
+      }
+      switch (heartbeatLagMonitorAction) {
+        case SET_LEADER_MONITOR:
+          addLeaderLagMonitor(version, partitionId);
+          break;
+        case SET_FOLLOWER_MONITOR:
+          addFollowerLagMonitor(version, partitionId);
+          break;
+        case REMOVE_MONITOR:
+          removeLagMonitor(version, partitionId);
+          break;
+        default:
+      }
+    } catch (Exception e) {
+      logger.error(
+          "Failed to update lag monitor for replica: {} with trigger: {}",
+          Utils.getReplicaId(resourceName, partitionId),
+          heartbeatLagMonitorAction.getTrigger(),
+          e);
+    }
+  }
+
   private void recordHeartbeat(
       String store,
       int version,
@@ -299,7 +351,7 @@ public class HeartbeatMonitoringService extends AbstractVeniceService {
         perVersionMap.computeIfPresent(version, (versionKey, perPartitionMap) -> {
           perPartitionMap.computeIfPresent(partition, (partitionKey, perRegionMap) -> {
             // If we are retaining only the highest timestamp for a given heartbeat, if the current held heartbeat
-            // is of a higher value AND was an entry was consumed (not a place holder value by the process) then
+            // is of a higher value AND was an entry was consumed (not a placeholder value by the process) then
             // we will No-Op in favor of retaining that higher timestamp. This behavior is specific to follower
             // nodes because the intent of this metric is to only show the lag of the follower relative to the leader
             if (retainHighestTimeStamp && perRegionMap.get(region) != null
@@ -383,48 +435,6 @@ public class HeartbeatMonitoringService extends AbstractVeniceService {
           }
         }
       }
-    }
-  }
-
-  public void updateLagMonitor(
-      String resourceName,
-      int partitionId,
-      BiConsumer<Version, Integer> lagMonFunction,
-      boolean isNullVersionValid,
-      String trigger) {
-    try {
-      String storeName = Version.parseStoreFromKafkaTopicName(resourceName);
-      int storeVersion = Version.parseVersionFromKafkaTopicName(resourceName);
-      Pair<Store, Version> res =
-          metadataRepository.waitVersion(storeName, storeVersion, serverMaxWaitForVersionInfo, 200);
-      Store store = res.getFirst();
-      Version version = res.getSecond();
-      if (store == null) {
-        logger.error(
-            "Failed to get store for resource: {} with trigger: {}. Will not update lag monitor.",
-            Utils.getReplicaId(resourceName, partitionId),
-            trigger);
-        return;
-      }
-      if (version == null && !isNullVersionValid) {
-        logger.error(
-            "Failed to get version for resource: {} with trigger: {}. Will not update lag monitor.",
-            Utils.getReplicaId(resourceName, partitionId),
-            trigger);
-        return;
-      }
-      if (version == null) {
-        // During version deletion, the version will be deleted from ZK prior to servers perform resource deletion.
-        // It's valid to have null version when trying to remove lag monitor for the deleted resource.
-        version = new VersionImpl(storeName, storeVersion, "");
-      }
-      lagMonFunction.accept(version, partitionId);
-    } catch (Exception e) {
-      logger.error(
-          "Failed to update lag monitor for replica: {} with trigger: {}",
-          Utils.getReplicaId(resourceName, partitionId),
-          trigger,
-          e);
     }
   }
 

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/helix/LeaderFollowerParticipantModelFactoryTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/helix/LeaderFollowerParticipantModelFactoryTest.java
@@ -1,5 +1,8 @@
 package com.linkedin.davinci.helix;
 
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+
 import com.linkedin.davinci.config.VeniceConfigLoader;
 import com.linkedin.davinci.config.VeniceServerConfig;
 import com.linkedin.davinci.config.VeniceStoreVersionConfig;
@@ -14,6 +17,7 @@ import com.linkedin.venice.utils.DaemonThreadFactory;
 import com.linkedin.venice.utils.HelixUtils;
 import com.linkedin.venice.utils.TestUtils;
 import io.tehuti.metrics.MetricsRepository;
+import java.time.Duration;
 import java.util.HashSet;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -52,12 +56,12 @@ public class LeaderFollowerParticipantModelFactoryTest {
 
   @BeforeMethod
   public void setupTestCase() {
-    mockIngestionBackend = Mockito.mock(IngestionBackend.class);
-    mockConfigLoader = Mockito.mock(VeniceConfigLoader.class);
-    mockServerConfig = Mockito.mock(VeniceServerConfig.class);
-    mockStoreConfig = Mockito.mock(VeniceStoreVersionConfig.class);
-    mockReadOnlyStoreRepository = Mockito.mock(ReadOnlyStoreRepository.class);
-    mockStore = Mockito.mock(Store.class);
+    mockIngestionBackend = mock(IngestionBackend.class);
+    mockConfigLoader = mock(VeniceConfigLoader.class);
+    mockServerConfig = mock(VeniceServerConfig.class);
+    mockStoreConfig = mock(VeniceStoreVersionConfig.class);
+    mockReadOnlyStoreRepository = mock(ReadOnlyStoreRepository.class);
+    mockStore = mock(Store.class);
     Mockito.when(mockConfigLoader.getVeniceServerConfig()).thenReturn(mockServerConfig);
     Mockito.when(mockConfigLoader.getStoreConfig(resourceName)).thenReturn(mockStoreConfig);
     Mockito.when(mockStoreConfig.getStoreVersionName()).thenReturn(resourceName);
@@ -65,23 +69,21 @@ public class LeaderFollowerParticipantModelFactoryTest {
         .thenReturn(mockStore);
     Mockito.when(mockStore.getBootstrapToOnlineTimeoutInHours()).thenReturn(Store.BOOTSTRAP_TO_ONLINE_TIMEOUT_IN_HOURS);
 
-    mockMessage = Mockito.mock(Message.class);
+    mockMessage = mock(Message.class);
     Mockito.when(mockMessage.getResourceName()).thenReturn(resourceName);
-
+    VeniceServerConfig veniceServerConfig = mock(VeniceServerConfig.class);
+    doReturn(new HashSet<>()).when(veniceServerConfig).getRegionNames();
+    doReturn("local").when(veniceServerConfig).getRegionName();
+    doReturn(Duration.ofSeconds(5)).when(veniceServerConfig).getServerMaxWaitForVersionInfo();
     factory = new LeaderFollowerPartitionStateModelFactory(
         mockIngestionBackend,
         mockConfigLoader,
         this.executorService,
-        Mockito.mock(ParticipantStateTransitionStats.class),
+        mock(ParticipantStateTransitionStats.class),
         mockReadOnlyStoreRepository,
         null,
         null,
-        new HeartbeatMonitoringService(
-            new MetricsRepository(),
-            mockReadOnlyStoreRepository,
-            new HashSet<>(),
-            "local",
-            null));
+        new HeartbeatMonitoringService(new MetricsRepository(), mockReadOnlyStoreRepository, veniceServerConfig, null));
   }
 
   @Test

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/helix/LeaderFollowerPartitionStateModelTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/helix/LeaderFollowerPartitionStateModelTest.java
@@ -2,12 +2,10 @@ package com.linkedin.davinci.helix;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
-import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -17,13 +15,11 @@ import com.linkedin.davinci.config.VeniceStoreVersionConfig;
 import com.linkedin.davinci.ingestion.IngestionBackend;
 import com.linkedin.davinci.kafka.consumer.KafkaStoreIngestionService;
 import com.linkedin.davinci.stats.ParticipantStateTransitionStats;
+import com.linkedin.davinci.stats.ingestion.heartbeat.HeartbeatLagMonitorAction;
 import com.linkedin.davinci.stats.ingestion.heartbeat.HeartbeatMonitoringService;
 import com.linkedin.venice.helix.HelixPartitionStatusAccessor;
 import com.linkedin.venice.meta.ReadOnlyStoreRepository;
 import com.linkedin.venice.meta.Store;
-import com.linkedin.venice.meta.Version;
-import com.linkedin.venice.utils.Pair;
-import java.time.Duration;
 import java.util.concurrent.CompletableFuture;
 import org.apache.helix.NotificationContext;
 import org.apache.helix.model.Message;
@@ -51,10 +47,12 @@ public class LeaderFollowerPartitionStateModelTest {
     ingestionBackend = mock(IngestionBackend.class);
     storeIngestionService = mock(KafkaStoreIngestionService.class);
     doReturn(storeIngestionService).when(ingestionBackend).getStoreIngestionService();
+    doReturn(CompletableFuture.completedFuture(null)).when(ingestionBackend).stopConsumption(any(), anyInt());
+
     storeAndServerConfigs = mock(VeniceStoreVersionConfig.class);
     notifier = mock(LeaderFollowerIngestionProgressNotifier.class);
     metadataRepo = mock(ReadOnlyStoreRepository.class);
-    partitionPushStatusAccessorFuture = mock(CompletableFuture.class);
+    partitionPushStatusAccessorFuture = CompletableFuture.completedFuture(mock(HelixPartitionStatusAccessor.class));
     threadPoolStats = mock(ParticipantStateTransitionStats.class);
     heartbeatMonitoringService = mock(HeartbeatMonitoringService.class);
     leaderFollowerPartitionStateModel = new LeaderFollowerPartitionStateModel(
@@ -73,32 +71,30 @@ public class LeaderFollowerPartitionStateModelTest {
   public void testUpdateLagMonitor() {
     Message message = mock(Message.class);
     NotificationContext context = mock(NotificationContext.class);
-    Store store = mock(Store.class);
-    Version version = mock(Version.class);
     when(message.getResourceName()).thenReturn(resourceName);
+    Store store = mock(Store.class);
+    doReturn(store).when(metadataRepo).getStoreOrThrow(anyString());
 
     LeaderFollowerPartitionStateModel leaderFollowerPartitionStateModelSpy = spy(leaderFollowerPartitionStateModel);
 
-    // test when both store and version are null
-    when(metadataRepo.waitVersion(eq(storeName), eq(storeVersion), any(Duration.class), anyLong()))
-        .thenReturn(Pair.create(null, null));
+    // STANDBY->LEADER
     leaderFollowerPartitionStateModelSpy.onBecomeLeaderFromStandby(message, context);
-    verify(metadataRepo).waitVersion(eq(storeName), eq(storeVersion), any(Duration.class), anyLong());
-    verify(heartbeatMonitoringService, never()).addLeaderLagMonitor(any(Version.class), anyInt());
+    verify(heartbeatMonitoringService)
+        .updateLagMonitor(eq(resourceName), eq(partition), eq(HeartbeatLagMonitorAction.SET_LEADER_MONITOR));
 
-    // test when store is not null and version is null
-    when(metadataRepo.waitVersion(eq(storeName), eq(storeVersion), any(Duration.class), anyLong()))
-        .thenReturn(Pair.create(store, null));
-    leaderFollowerPartitionStateModelSpy.onBecomeLeaderFromStandby(message, context);
-    verify(metadataRepo, times(2)).waitVersion(eq(storeName), eq(storeVersion), any(Duration.class), anyLong());
-    verify(heartbeatMonitoringService, never()).addLeaderLagMonitor(any(Version.class), anyInt());
+    // LEADER->STANDBY
+    leaderFollowerPartitionStateModelSpy.onBecomeStandbyFromLeader(message, context);
+    verify(heartbeatMonitoringService)
+        .updateLagMonitor(eq(resourceName), eq(partition), eq(HeartbeatLagMonitorAction.SET_FOLLOWER_MONITOR));
 
-    // test both store and version are not null
-    when(metadataRepo.waitVersion(eq(storeName), eq(storeVersion), any(Duration.class), anyLong()))
-        .thenReturn(Pair.create(store, version));
-    doNothing().when(leaderFollowerPartitionStateModelSpy).executeStateTransition(any(), any(), any());
-    leaderFollowerPartitionStateModelSpy.onBecomeLeaderFromStandby(message, context);
-    verify(metadataRepo, times(3)).waitVersion(eq(storeName), eq(storeVersion), any(Duration.class), anyLong());
-    verify(heartbeatMonitoringService).addLeaderLagMonitor(version, partition);
+    // OFFLINE->STANDBY
+    leaderFollowerPartitionStateModelSpy.onBecomeStandbyFromOffline(message, context);
+    verify(heartbeatMonitoringService, times(2))
+        .updateLagMonitor(eq(resourceName), eq(partition), eq(HeartbeatLagMonitorAction.SET_FOLLOWER_MONITOR));
+
+    // STANDBY->OFFLINE
+    leaderFollowerPartitionStateModelSpy.onBecomeOfflineFromStandby(message, context);
+    verify(heartbeatMonitoringService)
+        .updateLagMonitor(eq(resourceName), eq(partition), eq(HeartbeatLagMonitorAction.REMOVE_MONITOR));
   }
 }

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/helix/LeaderFollowerPartitionStateModelTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/helix/LeaderFollowerPartitionStateModelTest.java
@@ -6,6 +6,7 @@ import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -79,7 +80,7 @@ public class LeaderFollowerPartitionStateModelTest {
 
     // STANDBY->LEADER
     leaderFollowerPartitionStateModelSpy.onBecomeLeaderFromStandby(message, context);
-    verify(heartbeatMonitoringService)
+    verify(heartbeatMonitoringService, never())
         .updateLagMonitor(eq(resourceName), eq(partition), eq(HeartbeatLagMonitorAction.SET_LEADER_MONITOR));
 
     // LEADER->STANDBY

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/helix/VeniceLeaderFollowerStateModelTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/helix/VeniceLeaderFollowerStateModelTest.java
@@ -4,6 +4,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.reset;
@@ -12,6 +13,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.linkedin.davinci.config.VeniceServerConfig;
 import com.linkedin.davinci.config.VeniceStoreVersionConfig;
 import com.linkedin.davinci.stats.ingestion.heartbeat.HeartbeatMonitoringService;
 import com.linkedin.venice.meta.Store;
@@ -19,6 +21,7 @@ import com.linkedin.venice.meta.Version;
 import com.linkedin.venice.meta.VersionImpl;
 import com.linkedin.venice.utils.Pair;
 import io.tehuti.metrics.MetricsRepository;
+import java.time.Duration;
 import java.util.HashSet;
 import java.util.concurrent.CompletableFuture;
 import org.mockito.Mockito;
@@ -31,12 +34,12 @@ public class VeniceLeaderFollowerStateModelTest extends
 
   @Override
   protected LeaderFollowerPartitionStateModel getParticipantStateModel() {
-    HeartbeatMonitoringService heartbeatMonitoringService = new HeartbeatMonitoringService(
-        new MetricsRepository(),
-        mockReadOnlyStoreRepository,
-        new HashSet<>(),
-        "local",
-        null);
+    VeniceServerConfig serverConfig = mock(VeniceServerConfig.class);
+    doReturn(new HashSet<>()).when(serverConfig).getRegionNames();
+    doReturn("local").when(serverConfig).getRegionName();
+    doReturn(Duration.ofSeconds(5)).when(serverConfig).getServerMaxWaitForVersionInfo();
+    HeartbeatMonitoringService heartbeatMonitoringService =
+        new HeartbeatMonitoringService(new MetricsRepository(), mockReadOnlyStoreRepository, serverConfig, null);
     spyHeartbeatMonitoringService = spy(heartbeatMonitoringService);
     return new LeaderFollowerPartitionStateModel(
         mockIngestionBackend,

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTaskTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTaskTest.java
@@ -98,6 +98,7 @@ import com.linkedin.davinci.stats.AggVersionedDaVinciRecordTransformerStats;
 import com.linkedin.davinci.stats.AggVersionedIngestionStats;
 import com.linkedin.davinci.stats.HostLevelIngestionStats;
 import com.linkedin.davinci.stats.KafkaConsumerServiceStats;
+import com.linkedin.davinci.stats.ingestion.heartbeat.HeartbeatMonitoringService;
 import com.linkedin.davinci.storage.StorageEngineRepository;
 import com.linkedin.davinci.storage.StorageMetadataService;
 import com.linkedin.davinci.storage.StorageService;
@@ -1118,6 +1119,7 @@ public abstract class StoreIngestionTaskTest {
     prepareAggKafkaConsumerServiceMock();
 
     return StoreIngestionTaskFactory.builder()
+        .setHeartbeatMonitoringService(mock(HeartbeatMonitoringService.class))
         .setVeniceWriterFactory(mockWriterFactory)
         .setStorageEngineRepository(mockStorageEngineRepository)
         .setStorageMetadataService(offsetManager)

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/stats/ingestion/heartbeat/HeartbeatMonitoringServiceTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/stats/ingestion/heartbeat/HeartbeatMonitoringServiceTest.java
@@ -11,9 +11,14 @@ import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doCallRealMethod;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import com.linkedin.davinci.config.VeniceServerConfig;
 import com.linkedin.davinci.kafka.consumer.LeaderFollowerStateType;
@@ -26,6 +31,7 @@ import com.linkedin.venice.meta.Store;
 import com.linkedin.venice.meta.Version;
 import com.linkedin.venice.meta.VersionImpl;
 import com.linkedin.venice.utils.DataProviderUtils;
+import com.linkedin.venice.utils.Pair;
 import com.linkedin.venice.utils.concurrent.VeniceConcurrentHashMap;
 import io.tehuti.metrics.MetricsRepository;
 import java.time.Duration;
@@ -49,7 +55,7 @@ public class HeartbeatMonitoringServiceTest {
     HeartbeatMonitoringService heartbeatMonitoringService = mock(HeartbeatMonitoringService.class);
     doCallRealMethod().when(heartbeatMonitoringService).getHeartbeatInfo(anyString(), anyInt(), anyBoolean());
     heartbeatMonitoringService.getHeartbeatInfo("", -1, false);
-    Mockito.verify(heartbeatMonitoringService, Mockito.times(2))
+    Mockito.verify(heartbeatMonitoringService, times(2))
         .getHeartbeatInfoFromMap(any(), anyString(), anyLong(), anyString(), anyInt(), anyBoolean());
   }
 
@@ -418,5 +424,68 @@ public class HeartbeatMonitoringServiceTest {
     Assert.assertTrue(heartbeatStatReporter.getMetricsRepository().metrics().containsKey(catchingUpFollowerMetricName));
     Assert.assertFalse(
         heartbeatStatReporter.getMetricsRepository().metrics().containsKey(catchingUpFollowerMetricNameForSepRT));
+  }
+
+  @Test
+  public void testUpdateLagMonitor() {
+    HeartbeatMonitoringService heartbeatMonitoringService = mock(HeartbeatMonitoringService.class);
+    doCallRealMethod().when(heartbeatMonitoringService).updateLagMonitor(anyString(), anyInt(), any());
+    ReadOnlyStoreRepository metadataRepo = mock(ReadOnlyStoreRepository.class);
+    doReturn(metadataRepo).when(heartbeatMonitoringService).getMetadataRepository();
+    Store store = mock(Store.class);
+    Version version = mock(Version.class);
+
+    String storeName = "foo";
+    int storeVersion = 1;
+    int partition = 256;
+    String resourceName = Version.composeKafkaTopic(storeName, storeVersion);
+
+    // 1. Test when both store and version are null
+    when(metadataRepo.waitVersion(eq(storeName), eq(storeVersion), any(Duration.class), anyLong()))
+        .thenReturn(Pair.create(null, null));
+    heartbeatMonitoringService.updateLagMonitor(resourceName, partition, HeartbeatLagMonitorAction.SET_LEADER_MONITOR);
+    verify(metadataRepo).waitVersion(eq(storeName), eq(storeVersion), any(Duration.class), anyLong());
+    verify(heartbeatMonitoringService, never()).addLeaderLagMonitor(any(Version.class), anyInt());
+
+    heartbeatMonitoringService
+        .updateLagMonitor(resourceName, partition, HeartbeatLagMonitorAction.SET_FOLLOWER_MONITOR);
+    verify(metadataRepo, times(2)).waitVersion(eq(storeName), eq(storeVersion), any(Duration.class), anyLong());
+    verify(heartbeatMonitoringService, never()).addFollowerLagMonitor(any(Version.class), anyInt());
+
+    heartbeatMonitoringService.updateLagMonitor(resourceName, partition, HeartbeatLagMonitorAction.REMOVE_MONITOR);
+    verify(metadataRepo, times(3)).waitVersion(eq(storeName), eq(storeVersion), any(Duration.class), anyLong());
+    verify(heartbeatMonitoringService, never()).removeLagMonitor(any(Version.class), anyInt());
+
+    // 2. Test when store is not null and version is null
+    when(metadataRepo.waitVersion(eq(storeName), eq(storeVersion), any(Duration.class), anyLong()))
+        .thenReturn(Pair.create(store, null));
+    heartbeatMonitoringService.updateLagMonitor(resourceName, partition, HeartbeatLagMonitorAction.SET_LEADER_MONITOR);
+    verify(metadataRepo, times(4)).waitVersion(eq(storeName), eq(storeVersion), any(Duration.class), anyLong());
+    verify(heartbeatMonitoringService, never()).addLeaderLagMonitor(any(Version.class), anyInt());
+
+    heartbeatMonitoringService
+        .updateLagMonitor(resourceName, partition, HeartbeatLagMonitorAction.SET_FOLLOWER_MONITOR);
+    verify(metadataRepo, times(5)).waitVersion(eq(storeName), eq(storeVersion), any(Duration.class), anyLong());
+    verify(heartbeatMonitoringService, never()).addFollowerLagMonitor(any(Version.class), anyInt());
+
+    heartbeatMonitoringService.updateLagMonitor(resourceName, partition, HeartbeatLagMonitorAction.REMOVE_MONITOR);
+    verify(metadataRepo, times(6)).waitVersion(eq(storeName), eq(storeVersion), any(Duration.class), anyLong());
+    verify(heartbeatMonitoringService).removeLagMonitor(any(Version.class), anyInt());
+
+    // 3. Test both store and version are not null
+    when(metadataRepo.waitVersion(eq(storeName), eq(storeVersion), any(Duration.class), anyLong()))
+        .thenReturn(Pair.create(store, version));
+    heartbeatMonitoringService.updateLagMonitor(resourceName, partition, HeartbeatLagMonitorAction.SET_LEADER_MONITOR);
+    verify(metadataRepo, times(7)).waitVersion(eq(storeName), eq(storeVersion), any(Duration.class), anyLong());
+    verify(heartbeatMonitoringService).addLeaderLagMonitor(version, partition);
+
+    heartbeatMonitoringService
+        .updateLagMonitor(resourceName, partition, HeartbeatLagMonitorAction.SET_FOLLOWER_MONITOR);
+    verify(metadataRepo, times(8)).waitVersion(eq(storeName), eq(storeVersion), any(Duration.class), anyLong());
+    verify(heartbeatMonitoringService).addFollowerLagMonitor(version, partition);
+
+    heartbeatMonitoringService.updateLagMonitor(resourceName, partition, HeartbeatLagMonitorAction.REMOVE_MONITOR);
+    verify(metadataRepo, times(9)).waitVersion(eq(storeName), eq(storeVersion), any(Duration.class), anyLong());
+    verify(heartbeatMonitoringService, times(2)).removeLagMonitor(any(Version.class), anyInt());
   }
 }

--- a/services/venice-server/src/main/java/com/linkedin/venice/server/VeniceServer.java
+++ b/services/venice-server/src/main/java/com/linkedin/venice/server/VeniceServer.java
@@ -375,12 +375,8 @@ public class VeniceServer {
     HeartbeatMonitoringServiceStats heartbeatMonitoringServiceStats =
         new HeartbeatMonitoringServiceStats(metricsRepository, clusterConfig.getClusterName());
 
-    heartbeatMonitoringService = new HeartbeatMonitoringService(
-        metricsRepository,
-        metadataRepo,
-        serverConfig.getRegionNames(),
-        serverConfig.getRegionName(),
-        heartbeatMonitoringServiceStats);
+    heartbeatMonitoringService =
+        new HeartbeatMonitoringService(metricsRepository, metadataRepo, serverConfig, heartbeatMonitoringServiceStats);
     services.add(heartbeatMonitoringService);
 
     this.zkHelixAdmin = Lazy.of(() -> new ZKHelixAdmin(serverConfig.getZookeeperAddress()));


### PR DESCRIPTION
<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat], [protocol]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## [server] Do not track leader lag in when STANDBY->LEADER is paused due to migration
During migration dest cluster leader is not actually promoted to leader and is still replicating local VT. During this stage, we should not track leader lag as it is not valid. We should track follower lag and once this stage is lifted we can track leader lag. 


## Solution
<!--
Describe
- What changes you are making and why. 
- How these changes solve the problem.
- Any performance considerations or trade-offs. 
- Describe what testings you have done, for example, performance testing etc.
-->

There are two ways to fix it:
1. Remove leader lag tracking when transition is paused and resumed it after
2. Just move the whole leader tracking when it is fully transitioned into leader

In this PR we change to (2), as follower will already been tracking leader replication lag, so when leader truly stuck during transition, follower lag will be going up and alarm.

Also, this PR fixes a small bug when calculating the max follower lag. It was using the leader map and changed to follower map. It is not used today so no current impact.


###  Code changes
- [ ] Added new code behind **a config**. If so list the config names and their default values in the PR description.
- [ ] Introduced new **log lines**. 
  - [ ] Confirmed if logs need to be **rate limited** to avoid excessive logging.

###  **Concurrency-Specific Checks**
Both reviewer and PR author to verify
- [ ] Code has **no race conditions** or **thread safety issues**.
- [ ] Proper **synchronization mechanisms** (e.g., `synchronized`, `RWLock`) are used where needed.
- [ ] No **blocking calls** inside critical sections that could lead to deadlocks or performance degradation.
- [ ] Verified **thread-safe collections** are used (e.g., `ConcurrentHashMap`, `CopyOnWriteArrayList`).
- [ ] Validated proper exception handling in multi-threaded code to avoid silent thread termination.


## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->

- [ ] New unit tests added.
- [ ] New integration tests added.
- [x] Modified or extended existing tests.
- [ ] Verified backward compatibility (if applicable).

## Does this PR introduce any user-facing or breaking changes?
<!--  
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Clearly explain the behavior change and its impact.