### PR TITLE
[controller] Using Ideal State instead-of ZK Store Config for Min Active Replicas

### DIFF
--- a/internal/venice-common/src/main/java/com/linkedin/venice/utils/HelixUtils.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/utils/HelixUtils.java
@@ -22,6 +22,7 @@ import org.apache.helix.manager.zk.ZkBaseDataAccessor;
 import org.apache.helix.model.CloudConfig;
 import org.apache.helix.model.CustomizedStateConfig;
 import org.apache.helix.model.HelixConfigScope;
+import org.apache.helix.model.IdealState;
 import org.apache.helix.model.InstanceConfig;
 import org.apache.helix.model.LiveInstance;
 import org.apache.helix.model.MaintenanceSignal;
@@ -341,6 +342,12 @@ public class HelixUtils {
     } else {
       return true;
     }
+  }
+
+  public static IdealState getIdealState(String clusterName, String resourceName, SafeHelixManager manager) {
+    PropertyKey.Builder keyBuilder = new PropertyKey.Builder(clusterName);
+    SafeHelixDataAccessor accessor = manager.getHelixDataAccessor();
+    return accessor.getProperty(keyBuilder.idealStates(resourceName));
   }
 
   /**

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/InstanceStatusDecider.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/InstanceStatusDecider.java
@@ -3,10 +3,10 @@ package com.linkedin.venice.controller;
 import com.linkedin.venice.exceptions.VeniceException;
 import com.linkedin.venice.helix.Replica;
 import com.linkedin.venice.helix.ResourceAssignment;
+import com.linkedin.venice.helix.SafeHelixDataAccessor;
 import com.linkedin.venice.meta.Partition;
 import com.linkedin.venice.meta.PartitionAssignment;
 import com.linkedin.venice.meta.RoutingDataRepository;
-import com.linkedin.venice.meta.Version;
 import com.linkedin.venice.utils.HelixUtils;
 import com.linkedin.venice.utils.LatencyUtils;
 import com.linkedin.venice.utils.Pair;
@@ -16,6 +16,8 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
+import org.apache.helix.PropertyKey;
+import org.apache.helix.model.IdealState;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -140,17 +142,16 @@ public class InstanceStatusDecider {
                         result.getSecond()));
                 break;
               }
+              SafeHelixDataAccessor accessor = resources.getHelixManager().getHelixDataAccessor();
+              PropertyKey.Builder keyBuilder = accessor.keyBuilder();
 
-              Version version = resources.getStoreMetadataRepository()
-                  .getStore(Version.parseStoreFromKafkaTopicName(resourceName))
-                  .getVersion(Version.parseVersionFromKafkaTopicName(resourceName));
-
-              if (version != null) {
-                result = willTriggerRebalance(partitionAssignmentAfterRemoving, version.getMinActiveReplicas());
+              IdealState idealState = accessor.getProperty(keyBuilder.idealStates(resourceName));
+              if (idealState != null && idealState.isEnabled() && idealState.isValid()) {
+                result = willTriggerRebalance(partitionAssignmentAfterRemoving, idealState.getMinActiveReplicas());
               } else {
                 result = new Pair<>(
                     false,
-                    "Cannot find the version info. Ignore it since it's been deleted. " + "Resource: " + resourceName);
+                    "Cannot find the ideal state. Ignore it since it does not exist. Resource: " + resourceName);
               }
 
               if (result.getFirst()) {

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/InstanceStatusDecider.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/InstanceStatusDecider.java
@@ -3,7 +3,6 @@ package com.linkedin.venice.controller;
 import com.linkedin.venice.exceptions.VeniceException;
 import com.linkedin.venice.helix.Replica;
 import com.linkedin.venice.helix.ResourceAssignment;
-import com.linkedin.venice.helix.SafeHelixDataAccessor;
 import com.linkedin.venice.meta.Partition;
 import com.linkedin.venice.meta.PartitionAssignment;
 import com.linkedin.venice.meta.RoutingDataRepository;
@@ -16,7 +15,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
-import org.apache.helix.PropertyKey;
 import org.apache.helix.model.IdealState;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -142,10 +140,8 @@ public class InstanceStatusDecider {
                         result.getSecond()));
                 break;
               }
-              SafeHelixDataAccessor accessor = resources.getHelixManager().getHelixDataAccessor();
-              PropertyKey.Builder keyBuilder = accessor.keyBuilder();
 
-              IdealState idealState = accessor.getProperty(keyBuilder.idealStates(resourceName));
+              IdealState idealState = HelixUtils.getIdealState(clusterName, resourceName, resources.getHelixManager());
               if (idealState != null && idealState.isEnabled() && idealState.isValid()) {
                 result = willTriggerRebalance(partitionAssignmentAfterRemoving, idealState.getMinActiveReplicas());
               } else {

--- a/services/venice-controller/src/test/java/com/linkedin/venice/controller/TestInstanceStatusDecider.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/controller/TestInstanceStatusDecider.java
@@ -5,6 +5,7 @@ import static org.mockito.Mockito.anyInt;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import com.linkedin.venice.helix.HelixCustomizedViewOfflinePushRepository;
 import com.linkedin.venice.helix.HelixReadWriteStoreRepository;
@@ -29,6 +30,7 @@ import java.util.Collections;
 import java.util.EnumMap;
 import java.util.List;
 import org.apache.helix.PropertyKey;
+import org.apache.helix.model.IdealState;
 import org.apache.helix.model.LiveInstance;
 import org.testng.Assert;
 import org.testng.annotations.BeforeMethod;
@@ -51,26 +53,37 @@ public class TestInstanceStatusDecider {
     clusterName = Utils.getUniqueString("TestInstanceStatusDecider");
     resources = mock(HelixVeniceClusterResources.class);
     routingDataRepository = mock(HelixCustomizedViewOfflinePushRepository.class);
-
     readWriteStoreRepository = mock(HelixReadWriteStoreRepository.class);
     mockMonitor = mock(PushMonitorDelegator.class);
 
     doAnswer(invocation -> {
       PartitionAssignment partitionAssignment = invocation.getArgument(0);
       int partitionId = invocation.getArgument(1);
-
       return partitionAssignment.getPartition(partitionId).getReadyToServeInstances();
     }).when(routingDataRepository).getReadyToServeInstances(any(PartitionAssignment.class), anyInt());
 
     SafeHelixManager manager = mock(SafeHelixManager.class);
-
     accessor = mock(SafeHelixDataAccessor.class);
     doReturn(routingDataRepository).when(resources).getCustomizedViewRepository();
     doReturn(readWriteStoreRepository).when(resources).getStoreMetadataRepository();
     doReturn(mockMonitor).when(resources).getPushMonitor();
     doReturn(manager).when(resources).getHelixManager();
     doReturn(accessor).when(manager).getHelixDataAccessor();
-    doReturn(new LiveInstance("test_1")).when(accessor).getProperty(any(PropertyKey.class));
+
+    // mock different invocations of PropertyKey
+    doAnswer(invocation -> {
+      PropertyKey key = invocation.getArgument(0);
+      if (key.getPath().contains("LIVEINSTANCES")) {
+        return mock(LiveInstance.class);
+      } else if (key.getPath().contains("IDEALSTATES")) {
+        IdealState idealState = mock(IdealState.class);
+        when(idealState.isEnabled()).thenReturn(true);
+        when(idealState.isValid()).thenReturn(true);
+        when(idealState.getMinActiveReplicas()).thenReturn(2);
+        return idealState;
+      }
+      return null;
+    }).when(accessor).getProperty(any(PropertyKey.class));
   }
 
   @Test

--- a/services/venice-controller/src/test/java/com/linkedin/venice/controller/TestInstanceStatusDecider.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/controller/TestInstanceStatusDecider.java
@@ -69,21 +69,6 @@ public class TestInstanceStatusDecider {
     doReturn(mockMonitor).when(resources).getPushMonitor();
     doReturn(manager).when(resources).getHelixManager();
     doReturn(accessor).when(manager).getHelixDataAccessor();
-
-    // mock different invocations of PropertyKey
-    doAnswer(invocation -> {
-      PropertyKey key = invocation.getArgument(0);
-      if (key.getPath().contains("LIVEINSTANCES")) {
-        return mock(LiveInstance.class);
-      } else if (key.getPath().contains("IDEALSTATES")) {
-        IdealState idealState = mock(IdealState.class);
-        when(idealState.isEnabled()).thenReturn(true);
-        when(idealState.isValid()).thenReturn(true);
-        when(idealState.getMinActiveReplicas()).thenReturn(2);
-        return idealState;
-      }
-      return null;
-    }).when(accessor).getProperty(any(PropertyKey.class));
   }
 
   @Test
@@ -292,6 +277,22 @@ public class TestInstanceStatusDecider {
     }
 
     doReturn(store).when(readWriteStoreRepository).getStore(storeName);
+
+    // Create valid ideal state
+    IdealState idealState = mock(IdealState.class);
+    when(idealState.isEnabled()).thenReturn(true);
+    when(idealState.isValid()).thenReturn(true);
+    when(idealState.getMinActiveReplicas()).thenReturn(replicationFactor - 1);
+
+    doAnswer(invocation -> {
+      PropertyKey key = invocation.getArgument(0);
+      if (key.getPath().contains("LIVEINSTANCES")) {
+        return mock(LiveInstance.class);
+      } else if (key.getPath().contains("IDEALSTATES")) {
+        return idealState;
+      }
+      return null;
+    }).when(accessor).getProperty(any(PropertyKey.class));
 
   }
 }


### PR DESCRIPTION
## Problem Statement
After a Store Migration, a Store's ZK Config may still have the old cluster's min active replica config and because a Store's ZK Config is something we're not trying to have be the SOT for MAR, there's a need to use Ideal State instead of ZK Store Config for Min Active Replicas. A Repush will fix the inconsistency of MAR in the Store's ZK Config but we should be looking at SOT to avoid the problem seen here

<!--
Describe
- What problem are you trying to solve
- What issues or limitations exist in the current code
- Why this change is necessary 
-->


## Solution
./gradlew build