### PR TITLE
[server] Move storage quota record before unsub operation

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
@@ -1570,6 +1570,7 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
     processIngestionException();
     maybeUnsubscribeCompletedPartitions(store);
 
+    // record before consumer unsub as it might lead to stale metrics after unsub
     if (emitMetrics.get()) {
       recordQuotaMetrics();
       recordMaxIdleTime();

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
@@ -1570,6 +1570,11 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
     processIngestionException();
     maybeUnsubscribeCompletedPartitions(store);
 
+    if (emitMetrics.get()) {
+      recordQuotaMetrics();
+      recordMaxIdleTime();
+    }
+
     /**
      * Check whether current consumer has any subscription or not since 'poll' function will throw
      * {@link IllegalStateException} with empty subscription.
@@ -1603,10 +1608,7 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
       return;
     }
     resetIdleCounter();
-    if (emitMetrics.get()) {
-      recordQuotaMetrics();
-      recordMaxIdleTime();
-    }
+    idleCounter = 0;
 
     /**
      * While using the shared consumer, we still need to check hybrid quota here since the actual disk usage could change

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
@@ -1609,7 +1609,6 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
       return;
     }
     resetIdleCounter();
-    idleCounter = 0;
 
     /**
      * While using the shared consumer, we still need to check hybrid quota here since the actual disk usage could change

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTaskTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTaskTest.java
@@ -2145,6 +2145,7 @@ public abstract class StoreIngestionTaskTest {
           .batchUnsubscribe(Collections.singleton(fooTopicPartition));
       verify(mockLocalKafkaConsumer, never()).unSubscribe(barTopicPartition);
     }, aaConfig);
+
     config.setBeforeStartingConsumption(() -> {
       Store mockStore = mock(Store.class);
       doReturn(storeNameWithoutVersionInfo).when(mockStore).getName();
@@ -2155,6 +2156,8 @@ public abstract class StoreIngestionTaskTest {
       doAnswer(invocation -> false).when(aggKafkaConsumerService).hasAnyConsumerAssignedForVersionTopic(any());
     }).setHybridStoreConfig(this.hybridStoreConfig).setExtraServerProperties(extraServerProperties);
     runTest(config);
+    HostLevelIngestionStats stats = storeIngestionTaskUnderTest.hostLevelIngestionStats;
+    verify(stats, timeout(TEST_TIMEOUT_MS)).recordStorageQuotaUsed(anyDouble());
   }
 
   @Test(dataProvider = "aaConfigProvider")

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTaskTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTaskTest.java
@@ -2157,7 +2157,7 @@ public abstract class StoreIngestionTaskTest {
     }).setHybridStoreConfig(this.hybridStoreConfig).setExtraServerProperties(extraServerProperties);
     runTest(config);
     HostLevelIngestionStats stats = storeIngestionTaskUnderTest.hostLevelIngestionStats;
-    verify(stats, timeout(TEST_TIMEOUT_MS)).recordStorageQuotaUsed(anyDouble());
+    verify(stats, times(1)).recordStorageQuotaUsed(anyDouble());
   }
 
   @Test(dataProvider = "aaConfigProvider")

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceParentHelixAdmin.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceParentHelixAdmin.java
@@ -3803,10 +3803,12 @@ public class VeniceParentHelixAdmin implements Admin {
             if (isTargetRegionPush && !isVersionPushed) {
               parentStore.updateVersionStatus(versionNum, PUSHED);
               repository.updateStore(parentStore);
+              LOGGER.info("Updating parent store version {} status to {}", kafkaTopic, PUSHED);
             } else { // status ONLINE is set when all region finishes ingestion for either regular or target region
                      // push.
               parentStore.updateVersionStatus(versionNum, ONLINE);
               repository.updateStore(parentStore);
+              LOGGER.info("Updating parent store version {} status to {}", kafkaTopic, ONLINE);
             }
           }
         }


### PR DESCRIPTION
<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat], [protocol]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## Problem Statement
<!--
Describe
- What problem are you trying to solve
- What issues or limitations exist in the current code
- Why this change is necessary 
-->

The quota update operation currently is not recorded if batch stores are unsubscribed after pushjob completed which leads to stale metric.

## Solution
<!--
Describe
- What changes you are making and why. 
- How these changes solve the problem.
- Any performance considerations or trade-offs. 
- Describe what testings you have done, for example, performance testing etc.
-->

This PR fixed that issue by moving the recording quota before unsub opetation.

###  Code changes
- [ ] Added new code behind **a config**. If so list the config names and their default values in the PR description.
- [ ] Introduced new **log lines**. 
  - [ ] Confirmed if logs need to be **rate limited** to avoid excessive logging.

###  **Concurrency-Specific Checks**
Both reviewer and PR author to verify
- [x] Code has **no race conditions** or **thread safety issues**.
- [x] Proper **synchronization mechanisms** (e.g., `synchronized`, `RWLock`) are used where needed.
- [x] No **blocking calls** inside critical sections that could lead to deadlocks or performance degradation.
- [x] Verified **thread-safe collections** are used (e.g., `ConcurrentHashMap`, `CopyOnWriteArrayList`).
- [x] Validated proper exception handling in multi-threaded code to avoid silent thread termination.


## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->

- [ ] New unit tests added.
- [ ] New integration tests added.
- [x] Modified or extended existing tests.
- [ ] Verified backward compatibility (if applicable).

## Does this PR introduce any user-facing or breaking changes?
<!--  
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [ ] No. You can skip the rest of this section.
- [ ] Yes. Clearly explain the behavior change and its impact.