### PR TITLE
[server][misc] Move leader->follower heartbeat tracking action to after transition complete

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/helix/LeaderFollowerPartitionStateModel.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/helix/LeaderFollowerPartitionStateModel.java
@@ -136,8 +136,6 @@ public class LeaderFollowerPartitionStateModel extends AbstractPartitionStateMod
   @Transition(to = HelixState.STANDBY_STATE, from = HelixState.LEADER_STATE)
   public void onBecomeStandbyFromLeader(Message message, NotificationContext context) {
     LeaderSessionIdChecker checker = new LeaderSessionIdChecker(leaderSessionId.incrementAndGet(), leaderSessionId);
-    heartbeatMonitoringService
-        .updateLagMonitor(message.getResourceName(), getPartition(), HeartbeatLagMonitorAction.SET_FOLLOWER_MONITOR);
     executeStateTransition(
         message,
         context,

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/KafkaStoreIngestionService.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/KafkaStoreIngestionService.java
@@ -50,6 +50,7 @@ import com.linkedin.venice.meta.ReadOnlyStoreRepository;
 import com.linkedin.venice.meta.ServerAdminAction;
 import com.linkedin.venice.meta.Store;
 import com.linkedin.venice.meta.StoreDataChangedListener;
+import com.linkedin.venice.meta.StoreVersionInfo;
 import com.linkedin.venice.meta.Version;
 import com.linkedin.venice.meta.VersionStatus;
 import com.linkedin.venice.offsets.OffsetRecord;
@@ -81,7 +82,6 @@ import com.linkedin.venice.utils.ComplementSet;
 import com.linkedin.venice.utils.DaemonThreadFactory;
 import com.linkedin.venice.utils.DiskUsage;
 import com.linkedin.venice.utils.LatencyUtils;
-import com.linkedin.venice.utils.Pair;
 import com.linkedin.venice.utils.SystemTime;
 import com.linkedin.venice.utils.Time;
 import com.linkedin.venice.utils.Utils;
@@ -563,10 +563,10 @@ public class KafkaStoreIngestionService extends AbstractVeniceService implements
     String storeName = Version.parseStoreFromKafkaTopicName(veniceStoreVersionConfig.getStoreVersionName());
     int versionNumber = Version.parseVersionFromKafkaTopicName(veniceStoreVersionConfig.getStoreVersionName());
 
-    Pair<Store, Version> storeVersionPair =
+    StoreVersionInfo storeVersionPair =
         Utils.waitStoreVersionOrThrow(veniceStoreVersionConfig.getStoreVersionName(), metadataRepo);
-    Store store = storeVersionPair.getFirst();
-    Version version = storeVersionPair.getSecond();
+    Store store = storeVersionPair.getStore();
+    Version version = storeVersionPair.getVersion();
 
     BooleanSupplier isVersionCurrent = () -> {
       try {

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTask.java
@@ -580,6 +580,11 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
           partitionConsumptionState.setLeaderFollowerState(STANDBY);
           updateLeaderTopicOnFollower(partitionConsumptionState);
         }
+        // Make sure we stop consuming from leader upstream before we switch heartbeat monitoring.
+        getHeartbeatMonitoringService().updateLagMonitor(
+            topicName,
+            partitionConsumptionState.getPartition(),
+            HeartbeatLagMonitorAction.SET_FOLLOWER_MONITOR);
         LOGGER.info("Replica: {} moved to standby/follower state", partitionConsumptionState.getReplicaId());
 
         /**

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/ingestion/heartbeat/HeartbeatMonitoringService.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/ingestion/heartbeat/HeartbeatMonitoringService.java
@@ -6,10 +6,10 @@ import com.linkedin.davinci.kafka.consumer.ReplicaHeartbeatInfo;
 import com.linkedin.davinci.stats.HeartbeatMonitoringServiceStats;
 import com.linkedin.venice.meta.ReadOnlyStoreRepository;
 import com.linkedin.venice.meta.Store;
+import com.linkedin.venice.meta.StoreVersionInfo;
 import com.linkedin.venice.meta.Version;
 import com.linkedin.venice.meta.VersionImpl;
 import com.linkedin.venice.service.AbstractVeniceService;
-import com.linkedin.venice.utils.Pair;
 import com.linkedin.venice.utils.Utils;
 import com.linkedin.venice.utils.concurrent.VeniceConcurrentHashMap;
 import io.tehuti.metrics.MetricConfig;
@@ -294,10 +294,10 @@ public class HeartbeatMonitoringService extends AbstractVeniceService {
     try {
       String storeName = Version.parseStoreFromKafkaTopicName(resourceName);
       int storeVersion = Version.parseVersionFromKafkaTopicName(resourceName);
-      Pair<Store, Version> res =
+      StoreVersionInfo res =
           getMetadataRepository().waitVersion(storeName, storeVersion, getMaxWaitForVersionInfo(), 200);
-      Store store = res.getFirst();
-      Version version = res.getSecond();
+      Store store = res.getStore();
+      Version version = res.getVersion();
       if (store == null) {
         LOGGER.error(
             "Failed to get store for resource: {} with trigger: {}. Will not update lag monitor.",

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/helix/LeaderFollowerPartitionStateModelTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/helix/LeaderFollowerPartitionStateModelTest.java
@@ -85,7 +85,7 @@ public class LeaderFollowerPartitionStateModelTest {
 
     // LEADER->STANDBY
     leaderFollowerPartitionStateModelSpy.onBecomeStandbyFromLeader(message, context);
-    verify(heartbeatMonitoringService)
+    verify(heartbeatMonitoringService, never())
         .updateLagMonitor(eq(resourceName), eq(partition), eq(HeartbeatLagMonitorAction.SET_FOLLOWER_MONITOR));
 
     // OFFLINE->STANDBY

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/helix/LeaderFollowerPartitionStateModelTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/helix/LeaderFollowerPartitionStateModelTest.java
@@ -90,7 +90,7 @@ public class LeaderFollowerPartitionStateModelTest {
 
     // OFFLINE->STANDBY
     leaderFollowerPartitionStateModelSpy.onBecomeStandbyFromOffline(message, context);
-    verify(heartbeatMonitoringService, times(2))
+    verify(heartbeatMonitoringService, times(1))
         .updateLagMonitor(eq(resourceName), eq(partition), eq(HeartbeatLagMonitorAction.SET_FOLLOWER_MONITOR));
 
     // STANDBY->OFFLINE

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/helix/VeniceLeaderFollowerStateModelTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/helix/VeniceLeaderFollowerStateModelTest.java
@@ -17,9 +17,9 @@ import com.linkedin.davinci.config.VeniceServerConfig;
 import com.linkedin.davinci.config.VeniceStoreVersionConfig;
 import com.linkedin.davinci.stats.ingestion.heartbeat.HeartbeatMonitoringService;
 import com.linkedin.venice.meta.Store;
+import com.linkedin.venice.meta.StoreVersionInfo;
 import com.linkedin.venice.meta.Version;
 import com.linkedin.venice.meta.VersionImpl;
-import com.linkedin.venice.utils.Pair;
 import io.tehuti.metrics.MetricsRepository;
 import java.time.Duration;
 import java.util.HashSet;
@@ -134,7 +134,7 @@ public class VeniceLeaderFollowerStateModelTest extends
     when(mockIngestionBackend.stopConsumption(any(VeniceStoreVersionConfig.class), eq(testPartition)))
         .thenReturn(CompletableFuture.completedFuture(null));
     when(mockReadOnlyStoreRepository.waitVersion(eq(storeName), eq(version), any(), anyLong()))
-        .thenReturn(Pair.create(mockStore, null));
+        .thenReturn(new StoreVersionInfo(mockStore, null));
     testStateModel.onBecomeOfflineFromStandby(mockMessage, mockContext);
     verify(spyHeartbeatMonitoringService).removeLagMonitor(any(), eq(testPartition));
   }

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/ingestion/DefaultIngestionBackendTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/ingestion/DefaultIngestionBackendTest.java
@@ -27,9 +27,9 @@ import com.linkedin.venice.exceptions.VenicePeersNotFoundException;
 import com.linkedin.venice.kafka.protocol.state.StoreVersionState;
 import com.linkedin.venice.meta.ReadOnlyStoreRepository;
 import com.linkedin.venice.meta.Store;
+import com.linkedin.venice.meta.StoreVersionInfo;
 import com.linkedin.venice.meta.Version;
 import com.linkedin.venice.offsets.OffsetRecord;
-import com.linkedin.venice.utils.Pair;
 import java.io.InputStream;
 import java.time.Duration;
 import java.util.concurrent.CompletableFuture;
@@ -82,7 +82,7 @@ public class DefaultIngestionBackendTest {
     MockitoAnnotations.openMocks(this);
     when(store.getName()).thenReturn(STORE_NAME);
     when(version.getNumber()).thenReturn(VERSION_NUMBER);
-    Pair<Store, Version> storeAndVersion = Pair.create(store, version);
+    StoreVersionInfo storeAndVersion = new StoreVersionInfo(store, version);
 
     when(storeConfig.getStoreVersionName()).thenReturn(STORE_VERSION);
     when(storeIngestionService.getMetadataRepo()).thenReturn(metadataRepo);

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/ingestion/IsolatedIngestionBackendTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/ingestion/IsolatedIngestionBackendTest.java
@@ -30,8 +30,8 @@ import com.linkedin.venice.exceptions.VeniceException;
 import com.linkedin.venice.exceptions.VeniceTimeoutException;
 import com.linkedin.venice.meta.ReadOnlyStoreRepository;
 import com.linkedin.venice.meta.Store;
+import com.linkedin.venice.meta.StoreVersionInfo;
 import com.linkedin.venice.meta.Version;
-import com.linkedin.venice.utils.Pair;
 import com.linkedin.venice.utils.TestUtils;
 import com.linkedin.venice.utils.concurrent.VeniceConcurrentHashMap;
 import java.util.HashMap;
@@ -57,7 +57,7 @@ public class IsolatedIngestionBackendTest {
       KafkaStoreIngestionService storeIngestionService = mock(KafkaStoreIngestionService.class);
       ReadOnlyStoreRepository repository = mock(ReadOnlyStoreRepository.class);
       when(repository.waitVersion(anyString(), anyInt(), any()))
-          .thenReturn(Pair.create(mock(Store.class), mock(Version.class)));
+          .thenReturn(new StoreVersionInfo(mock(Store.class), mock(Version.class)));
       when(storeIngestionService.getMetadataRepo()).thenReturn(repository);
       when(storeIngestionService.isPartitionConsuming(topic, partition)).thenReturn(true);
       when(backend.getStoreIngestionService()).thenReturn(storeIngestionService);
@@ -122,7 +122,7 @@ public class IsolatedIngestionBackendTest {
       KafkaStoreIngestionService storeIngestionService = mock(KafkaStoreIngestionService.class);
       ReadOnlyStoreRepository repository = mock(ReadOnlyStoreRepository.class);
       when(repository.waitVersion(anyString(), anyInt(), any()))
-          .thenReturn(Pair.create(mock(Store.class), mock(Version.class)));
+          .thenReturn(new StoreVersionInfo(mock(Store.class), mock(Version.class)));
       when(storeIngestionService.getMetadataRepo()).thenReturn(repository);
       when(storeIngestionService.isPartitionConsuming(topic, partition)).thenReturn(true);
       when(backend.getStoreIngestionService()).thenReturn(storeIngestionService);
@@ -171,7 +171,7 @@ public class IsolatedIngestionBackendTest {
        */
       executionFlag.set(0);
       topicIngestionStatusMap.clear();
-      when(repository.waitVersion(anyString(), anyInt(), any())).thenReturn(Pair.create(null, null));
+      when(repository.waitVersion(anyString(), anyInt(), any())).thenReturn(new StoreVersionInfo(null, null));
 
       Assert.assertThrows(VeniceException.class, () -> {
         backend.executeCommandWithRetry(topic, partition, START_CONSUMPTION, () -> {

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/KafkaStoreIngestionServiceTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/KafkaStoreIngestionServiceTest.java
@@ -41,6 +41,7 @@ import com.linkedin.venice.meta.ReadOnlyStoreRepository;
 import com.linkedin.venice.meta.ReadStrategy;
 import com.linkedin.venice.meta.RoutingStrategy;
 import com.linkedin.venice.meta.Store;
+import com.linkedin.venice.meta.StoreVersionInfo;
 import com.linkedin.venice.meta.Version;
 import com.linkedin.venice.meta.VersionImpl;
 import com.linkedin.venice.meta.VersionStatus;
@@ -59,7 +60,6 @@ import com.linkedin.venice.schema.SchemaEntry;
 import com.linkedin.venice.serialization.avro.AvroProtocolDefinition;
 import com.linkedin.venice.service.ICProvider;
 import com.linkedin.venice.utils.DataProviderUtils;
-import com.linkedin.venice.utils.Pair;
 import com.linkedin.venice.utils.TestUtils;
 import com.linkedin.venice.utils.VeniceProperties;
 import com.linkedin.venice.utils.locks.ResourceAutoClosableLockManager;
@@ -314,9 +314,9 @@ public abstract class KafkaStoreIngestionServiceTest {
     doReturn(toBeDeletedStore).when(mockMetadataRepo).getStore(deletedStoreName);
     doReturn(mockStore).when(mockMetadataRepo).getStoreOrThrow(storeName);
     doReturn(toBeDeletedStore).when(mockMetadataRepo).getStoreOrThrow(deletedStoreName);
-    doReturn(new Pair<>(mockStore, mockStore.getVersion(1))).when(mockMetadataRepo)
+    doReturn(new StoreVersionInfo(mockStore, mockStore.getVersion(1))).when(mockMetadataRepo)
         .waitVersion(eq(storeName), eq(1), any());
-    doReturn(new Pair<>(toBeDeletedStore, toBeDeletedStore.getVersion(1))).when(mockMetadataRepo)
+    doReturn(new StoreVersionInfo(toBeDeletedStore, toBeDeletedStore.getVersion(1))).when(mockMetadataRepo)
         .waitVersion(eq(deletedStoreName), eq(1), any());
     VeniceProperties veniceProperties = AbstractStorageEngineTest.getServerProperties(PersistenceType.ROCKS_DB);
     kafkaStoreIngestionService.startConsumption(new VeniceStoreVersionConfig(topic1, veniceProperties), 0);
@@ -330,7 +330,7 @@ public abstract class KafkaStoreIngestionServiceTest {
         0,
         "Expecting an empty set since all ingesting topics have version status of ONLINE");
     mockStore.addVersion(new VersionImpl(storeName, 2, "test-job-id"));
-    doReturn(new Pair<>(mockStore, mockStore.getVersion(2))).when(mockMetadataRepo)
+    doReturn(new StoreVersionInfo(mockStore, mockStore.getVersion(2))).when(mockMetadataRepo)
         .waitVersion(eq(storeName), eq(2), any());
     kafkaStoreIngestionService.startConsumption(new VeniceStoreVersionConfig(topic2, veniceProperties), 0);
     kafkaStoreIngestionService.startConsumption(new VeniceStoreVersionConfig(invalidTopic, veniceProperties), 0);
@@ -398,7 +398,7 @@ public abstract class KafkaStoreIngestionServiceTest {
     mockStore.addVersion(new VersionImpl(storeName, 1, "test-job-id"));
     doReturn(mockStore).when(mockMetadataRepo).getStore(storeName);
     doReturn(mockStore).when(mockMetadataRepo).getStoreOrThrow(storeName);
-    doReturn(new Pair<>(mockStore, mockStore.getVersion(1))).when(mockMetadataRepo)
+    doReturn(new StoreVersionInfo(mockStore, mockStore.getVersion(1))).when(mockMetadataRepo)
         .waitVersion(eq(storeName), eq(1), any());
     VeniceProperties veniceProperties = AbstractStorageEngineTest.getServerProperties(PersistenceType.ROCKS_DB);
     kafkaStoreIngestionService.startConsumption(new VeniceStoreVersionConfig(topicName, veniceProperties), 0);
@@ -470,7 +470,7 @@ public abstract class KafkaStoreIngestionServiceTest {
     mockStore.addVersion(new VersionImpl(storeName, 1, "test-job-id"));
     doReturn(mockStore).when(mockMetadataRepo).getStore(storeName);
     doReturn(mockStore).when(mockMetadataRepo).getStoreOrThrow(storeName);
-    doReturn(new Pair<>(mockStore, mockStore.getVersion(1))).when(mockMetadataRepo)
+    doReturn(new StoreVersionInfo(mockStore, mockStore.getVersion(1))).when(mockMetadataRepo)
         .waitVersion(eq(storeName), eq(1), any());
     VeniceProperties veniceProperties = AbstractStorageEngineTest.getServerProperties(PersistenceType.ROCKS_DB);
     VeniceStoreVersionConfig config = new VeniceStoreVersionConfig(topicName, veniceProperties);
@@ -640,7 +640,7 @@ public abstract class KafkaStoreIngestionServiceTest {
     mockStore.addVersion(new VersionImpl(storeName, 1, "test-job-id"));
     doReturn(mockStore).when(mockMetadataRepo).getStore(storeName);
     doReturn(mockStore).when(mockMetadataRepo).getStoreOrThrow(storeName);
-    doReturn(new Pair<>(mockStore, mockStore.getVersion(1))).when(mockMetadataRepo)
+    doReturn(new StoreVersionInfo(mockStore, mockStore.getVersion(1))).when(mockMetadataRepo)
         .waitVersion(eq(storeName), eq(1), any());
     VeniceProperties veniceProperties = AbstractStorageEngineTest.getServerProperties(PersistenceType.ROCKS_DB);
     VeniceStoreVersionConfig config = new VeniceStoreVersionConfig(topicName, veniceProperties);

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTaskTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTaskTest.java
@@ -26,6 +26,7 @@ import com.linkedin.davinci.config.VeniceStoreVersionConfig;
 import com.linkedin.davinci.helix.LeaderFollowerPartitionStateModel;
 import com.linkedin.davinci.stats.AggHostLevelIngestionStats;
 import com.linkedin.davinci.stats.HostLevelIngestionStats;
+import com.linkedin.davinci.stats.ingestion.heartbeat.HeartbeatMonitoringService;
 import com.linkedin.davinci.storage.StorageMetadataService;
 import com.linkedin.davinci.storage.StorageService;
 import com.linkedin.davinci.store.view.MaterializedViewWriter;
@@ -211,6 +212,7 @@ public class LeaderFollowerStoreIngestionTaskTest {
         .setServerConfig(mockVeniceServerConfig)
         .setPubSubTopicRepository(pubSubTopicRepository)
         .setVeniceViewWriterFactory(mockVeniceViewWriterFactory)
+        .setHeartbeatMonitoringService(mock(HeartbeatMonitoringService.class))
         .setCompressorFactory(new StorageEngineBackedCompressorFactory(inMemoryStorageMetadataService))
         .setHostLevelIngestionStats(aggHostLevelIngestionStats);
     when(builder.getSchemaRepo().getKeySchema(storeName)).thenReturn(new SchemaEntry(1, "\"string\""));

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/stats/ingestion/heartbeat/HeartbeatMonitoringServiceTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/stats/ingestion/heartbeat/HeartbeatMonitoringServiceTest.java
@@ -28,10 +28,10 @@ import com.linkedin.venice.meta.HybridStoreConfig;
 import com.linkedin.venice.meta.HybridStoreConfigImpl;
 import com.linkedin.venice.meta.ReadOnlyStoreRepository;
 import com.linkedin.venice.meta.Store;
+import com.linkedin.venice.meta.StoreVersionInfo;
 import com.linkedin.venice.meta.Version;
 import com.linkedin.venice.meta.VersionImpl;
 import com.linkedin.venice.utils.DataProviderUtils;
-import com.linkedin.venice.utils.Pair;
 import com.linkedin.venice.utils.concurrent.VeniceConcurrentHashMap;
 import io.tehuti.metrics.MetricsRepository;
 import java.time.Duration;
@@ -442,7 +442,7 @@ public class HeartbeatMonitoringServiceTest {
 
     // 1. Test when both store and version are null
     when(metadataRepo.waitVersion(eq(storeName), eq(storeVersion), any(Duration.class), anyLong()))
-        .thenReturn(Pair.create(null, null));
+        .thenReturn(new StoreVersionInfo(null, null));
     heartbeatMonitoringService.updateLagMonitor(resourceName, partition, HeartbeatLagMonitorAction.SET_LEADER_MONITOR);
     verify(metadataRepo).waitVersion(eq(storeName), eq(storeVersion), any(Duration.class), anyLong());
     verify(heartbeatMonitoringService, never()).addLeaderLagMonitor(any(Version.class), anyInt());
@@ -458,7 +458,7 @@ public class HeartbeatMonitoringServiceTest {
 
     // 2. Test when store is not null and version is null
     when(metadataRepo.waitVersion(eq(storeName), eq(storeVersion), any(Duration.class), anyLong()))
-        .thenReturn(Pair.create(store, null));
+        .thenReturn(new StoreVersionInfo(store, null));
     heartbeatMonitoringService.updateLagMonitor(resourceName, partition, HeartbeatLagMonitorAction.SET_LEADER_MONITOR);
     verify(metadataRepo, times(4)).waitVersion(eq(storeName), eq(storeVersion), any(Duration.class), anyLong());
     verify(heartbeatMonitoringService, never()).addLeaderLagMonitor(any(Version.class), anyInt());
@@ -474,7 +474,7 @@ public class HeartbeatMonitoringServiceTest {
 
     // 3. Test both store and version are not null
     when(metadataRepo.waitVersion(eq(storeName), eq(storeVersion), any(Duration.class), anyLong()))
-        .thenReturn(Pair.create(store, version));
+        .thenReturn(new StoreVersionInfo(store, version));
     heartbeatMonitoringService.updateLagMonitor(resourceName, partition, HeartbeatLagMonitorAction.SET_LEADER_MONITOR);
     verify(metadataRepo, times(7)).waitVersion(eq(storeName), eq(storeVersion), any(Duration.class), anyLong());
     verify(heartbeatMonitoringService).addLeaderLagMonitor(version, partition);

--- a/internal/venice-common/src/main/java/com/linkedin/venice/meta/ReadOnlyStoreRepository.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/meta/ReadOnlyStoreRepository.java
@@ -2,7 +2,6 @@ package com.linkedin.venice.meta;
 
 import com.linkedin.venice.VeniceResource;
 import com.linkedin.venice.exceptions.VeniceNoStoreException;
-import com.linkedin.venice.utils.Pair;
 import com.linkedin.venice.utils.Utils;
 import java.time.Duration;
 import java.util.List;
@@ -34,22 +33,22 @@ public interface ReadOnlyStoreRepository extends VeniceResource {
    *         (store, null) if store exists, but version still isn't after waiting for allowed time.
    *         (null, null) if store still doesn't exit after waiting for allowed time.
    */
-  default Pair<Store, Version> waitVersion(String storeName, int versionNumber, Duration timeout) {
+  default StoreVersionInfo waitVersion(String storeName, int versionNumber, Duration timeout) {
     return waitVersion(storeName, versionNumber, timeout, TimeUnit.SECONDS.toMillis(1));
   }
 
-  default Pair<Store, Version> waitVersion(String storeName, int versionNumber, Duration timeout, long delayMs) {
+  default StoreVersionInfo waitVersion(String storeName, int versionNumber, Duration timeout, long delayMs) {
     long expirationTime = System.currentTimeMillis() + timeout.toMillis() - delayMs;
     Store store = getStore(storeName);
     for (;;) {
       if (store != null) {
         Version version = store.getVersion(versionNumber);
         if (version != null) {
-          return new Pair<>(store, version);
+          return new StoreVersionInfo(store, version);
         }
       }
       if (expirationTime < System.currentTimeMillis() || !Utils.sleep(delayMs)) {
-        return new Pair<>(store, null);
+        return new StoreVersionInfo(store, null);
       }
       store = refreshOneStore(storeName);
     }

--- a/internal/venice-common/src/main/java/com/linkedin/venice/meta/StoreVersionInfo.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/meta/StoreVersionInfo.java
@@ -1,0 +1,19 @@
+package com.linkedin.venice.meta;
+
+public class StoreVersionInfo {
+  private final Store store;
+  private final Version version;
+
+  public StoreVersionInfo(Store store, Version version) {
+    this.store = store;
+    this.version = version;
+  }
+
+  public Store getStore() {
+    return store;
+  }
+
+  public Version getVersion() {
+    return version;
+  }
+}

--- a/internal/venice-common/src/main/java/com/linkedin/venice/utils/Utils.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/utils/Utils.java
@@ -23,6 +23,7 @@ import com.linkedin.venice.meta.ReadOnlyStoreRepository;
 import com.linkedin.venice.meta.RoutingDataRepository;
 import com.linkedin.venice.meta.Store;
 import com.linkedin.venice.meta.StoreInfo;
+import com.linkedin.venice.meta.StoreVersionInfo;
 import com.linkedin.venice.meta.Version;
 import com.linkedin.venice.pubsub.PubSubTopicRepository;
 import com.linkedin.venice.pubsub.api.PubSubTopic;
@@ -1012,17 +1013,17 @@ public class Utils {
     return params;
   }
 
-  public static Pair<Store, Version> waitStoreVersionOrThrow(
+  public static StoreVersionInfo waitStoreVersionOrThrow(
       String storeVersionName,
       ReadOnlyStoreRepository metadataRepo) {
     String storeName = Version.parseStoreFromKafkaTopicName(storeVersionName);
     int versionNumber = Version.parseVersionFromKafkaTopicName(storeVersionName);
 
-    Pair<Store, Version> storeVersionPair = metadataRepo.waitVersion(storeName, versionNumber, Duration.ofSeconds(30));
-    if (storeVersionPair.getFirst() == null) {
+    StoreVersionInfo storeVersionPair = metadataRepo.waitVersion(storeName, versionNumber, Duration.ofSeconds(30));
+    if (storeVersionPair.getStore() == null) {
       throw new VeniceException("Store " + storeName + " does not exist.");
     }
-    if (storeVersionPair.getSecond() == null) {
+    if (storeVersionPair.getVersion() == null) {
       throw new VeniceException("Store " + storeName + " version " + versionNumber + " does not exist.");
     }
     return storeVersionPair;

--- a/internal/venice-common/src/test/java/com/linkedin/venice/meta/ReadOnlyStoreRepositoryTest.java
+++ b/internal/venice-common/src/test/java/com/linkedin/venice/meta/ReadOnlyStoreRepositoryTest.java
@@ -13,7 +13,6 @@ import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertNull;
 
-import com.linkedin.venice.utils.Pair;
 import java.time.Duration;
 import org.testng.annotations.Test;
 
@@ -29,11 +28,11 @@ public class ReadOnlyStoreRepositoryTest {
     doCallRealMethod().when(readOnlyStoreRepository).waitVersion(anyString(), anyInt(), any(), anyLong());
     doReturn(store).when(readOnlyStoreRepository).refreshOneStore(anyString());
 
-    Pair<Store, Version> res = readOnlyStoreRepository.waitVersion("test", 1, Duration.ofMillis(5000));
+    StoreVersionInfo res = readOnlyStoreRepository.waitVersion("test", 1, Duration.ofMillis(5000));
     assertNotNull(res);
-    assertNotNull(res.getFirst(), "Store should not be null");
-    assertEquals(res.getFirst(), store, "Store should be the same");
-    assertNull(res.getSecond(), "Version should be null");
+    assertNotNull(res.getStore(), "Store should not be null");
+    assertEquals(res.getStore(), store, "Store should be the same");
+    assertNull(res.getVersion(), "Version should be null");
     verify(readOnlyStoreRepository).getStore("test");
     verify(readOnlyStoreRepository, atLeast(3)).refreshOneStore("test");
     verify(store, atLeast(3)).getVersion(1);
@@ -43,9 +42,9 @@ public class ReadOnlyStoreRepositoryTest {
 
     res = readOnlyStoreRepository.waitVersion("test", 1, Duration.ofMillis(5000), 10);
     assertNotNull(res);
-    assertNotNull(res.getFirst(), "Store should not be null");
-    assertEquals(res.getFirst(), store, "Store should be the same");
-    assertNotNull(res.getSecond(), "Version should not be null");
-    assertEquals(res.getSecond(), version, "Version should be the same");
+    assertNotNull(res.getStore(), "Store should not be null");
+    assertEquals(res.getStore(), store, "Store should be the same");
+    assertNotNull(res.getVersion(), "Version should not be null");
+    assertEquals(res.getVersion(), version, "Version should be the same");
   }
 }

--- a/internal/venice-common/src/test/java/com/linkedin/venice/meta/StoreVersionInfoTest.java
+++ b/internal/venice-common/src/test/java/com/linkedin/venice/meta/StoreVersionInfoTest.java
@@ -1,0 +1,18 @@
+package com.linkedin.venice.meta;
+
+import static org.mockito.Mockito.mock;
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+
+public class StoreVersionInfoTest {
+  @Test
+  public void testSetAndGet() {
+    Store store = mock(Store.class);
+    Version version = mock(Version.class);
+    StoreVersionInfo storeVersionInfo = new StoreVersionInfo(store, version);
+    Assert.assertEquals(storeVersionInfo.getStore(), store);
+    Assert.assertEquals(storeVersionInfo.getVersion(), version);
+  }
+}

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceHelixAdmin.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceHelixAdmin.java
@@ -146,6 +146,7 @@ import com.linkedin.venice.meta.StoreDataAudit;
 import com.linkedin.venice.meta.StoreGraveyard;
 import com.linkedin.venice.meta.StoreInfo;
 import com.linkedin.venice.meta.StoreName;
+import com.linkedin.venice.meta.StoreVersionInfo;
 import com.linkedin.venice.meta.SystemStoreAttributes;
 import com.linkedin.venice.meta.VeniceUserStoreType;
 import com.linkedin.venice.meta.Version;
@@ -4532,7 +4533,7 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
     return repository.getStore(storeName);
   }
 
-  Pair<Store, Version> waitVersion(String clusterName, String storeName, int versionNumber, Duration timeout) {
+  StoreVersionInfo waitVersion(String clusterName, String storeName, int versionNumber, Duration timeout) {
     checkControllerLeadershipFor(clusterName);
     ReadWriteStoreRepository repository = getHelixVeniceClusterResources(clusterName).getStoreMetadataRepository();
     return repository.waitVersion(storeName, versionNumber, timeout);

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceParentHelixAdmin.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceParentHelixAdmin.java
@@ -200,6 +200,7 @@ import com.linkedin.venice.meta.StoreConfig;
 import com.linkedin.venice.meta.StoreDataAudit;
 import com.linkedin.venice.meta.StoreGraveyard;
 import com.linkedin.venice.meta.StoreInfo;
+import com.linkedin.venice.meta.StoreVersionInfo;
 import com.linkedin.venice.meta.VeniceUserStoreType;
 import com.linkedin.venice.meta.Version;
 import com.linkedin.venice.meta.VersionStatus;
@@ -1234,9 +1235,9 @@ public class VeniceParentHelixAdmin implements Admin {
          * If the corresponding version doesn't exist, this function will issue command to kill job to deprecate
          * the incomplete topic/job.
          */
-        Pair<Store, Version> storeVersionPair =
+        StoreVersionInfo storeVersionPair =
             getVeniceHelixAdmin().waitVersion(clusterName, storeName, versionNumber, Duration.ofSeconds(30));
-        if (storeVersionPair.getSecond() == null) {
+        if (storeVersionPair.getVersion() == null) {
           // TODO: Guard this topic deletion code using a store-level lock instead.
           Long inMemoryTopicCreationTime = getVeniceHelixAdmin().getInMemoryTopicCreationTime(latestTopicName);
           if (inMemoryTopicCreationTime != null

--- a/services/venice-controller/src/test/java/com/linkedin/venice/controller/TestVeniceParentHelixAdmin.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/controller/TestVeniceParentHelixAdmin.java
@@ -71,6 +71,7 @@ import com.linkedin.venice.meta.RegionPushDetails;
 import com.linkedin.venice.meta.RoutingStrategy;
 import com.linkedin.venice.meta.Store;
 import com.linkedin.venice.meta.StoreInfo;
+import com.linkedin.venice.meta.StoreVersionInfo;
 import com.linkedin.venice.meta.Version;
 import com.linkedin.venice.meta.VersionImpl;
 import com.linkedin.venice.meta.VersionStatus;
@@ -949,7 +950,7 @@ public class TestVeniceParentHelixAdmin extends AbstractTestVeniceParentHelixAdm
     String pushJobId2 = "test_push_id2";
     store.addVersion(new VersionImpl(storeName, 1, pushJobId));
     doReturn(store).when(internalAdmin).getStore(clusterName, storeName);
-    doReturn(new Pair<>(store, store.getVersion(1))).when(internalAdmin)
+    doReturn(new StoreVersionInfo(store, store.getVersion(1))).when(internalAdmin)
         .waitVersion(eq(clusterName), eq(storeName), eq(1), any());
 
     try (PartialMockVeniceParentHelixAdmin partialMockParentAdmin =
@@ -985,7 +986,7 @@ public class TestVeniceParentHelixAdmin extends AbstractTestVeniceParentHelixAdm
     store.addVersion(version);
     doReturn(store).when(internalAdmin).getStore(clusterName, storeName);
     doReturn(version).when(store).getVersion(1);
-    doReturn(new Pair<>(store, version)).when(internalAdmin)
+    doReturn(new StoreVersionInfo(store, version)).when(internalAdmin)
         .waitVersion(eq(clusterName), eq(storeName), eq(version.getNumber()), any());
     try (PartialMockVeniceParentHelixAdmin partialMockParentAdmin =
         new PartialMockVeniceParentHelixAdmin(internalAdmin, config)) {
@@ -1156,7 +1157,7 @@ public class TestVeniceParentHelixAdmin extends AbstractTestVeniceParentHelixAdm
     Version version = new VersionImpl(storeName, 1, Version.guidBasedDummyPushId());
     store.addVersion(version);
     doReturn(store).when(internalAdmin).getStore(clusterName, storeName);
-    doReturn(new Pair<>(store, version)).when(internalAdmin)
+    doReturn(new StoreVersionInfo(store, version)).when(internalAdmin)
         .waitVersion(eq(clusterName), eq(storeName), eq(version.getNumber()), any());
     try (PartialMockVeniceParentHelixAdmin partialMockParentAdmin =
         new PartialMockVeniceParentHelixAdmin(internalAdmin, config)) {
@@ -2469,7 +2470,7 @@ public class TestVeniceParentHelixAdmin extends AbstractTestVeniceParentHelixAdm
     StoreInfo info = mock(StoreInfo.class);
     doReturn(response).when(client).getStore(anyString());
     doReturn(info).when(response).getStore();
-    doReturn(new Pair<>(store, store.getVersion(1))).when(internalAdmin)
+    doReturn(new StoreVersionInfo(store, store.getVersion(1))).when(internalAdmin)
         .waitVersion(eq(clusterName), eq(storeName), eq(1), any());
 
     Assert.assertFalse(mockParentAdmin.getTopicForCurrentPushJob(clusterName, storeName, false, false).isPresent());
@@ -2535,7 +2536,8 @@ public class TestVeniceParentHelixAdmin extends AbstractTestVeniceParentHelixAdm
 
     // When there is a regular topic, but there is no corresponding version
     store.deleteVersion(1);
-    doReturn(new Pair<>(store, null)).when(internalAdmin).waitVersion(eq(clusterName), eq(storeName), eq(1), any());
+    doReturn(new StoreVersionInfo(store, null)).when(internalAdmin)
+        .waitVersion(eq(clusterName), eq(storeName), eq(1), any());
 
     // If the in memory topic to creation time map doesn't contain topic info, then push will be killed
     doReturn(null).when(internalAdmin).getInMemoryTopicCreationTime(Version.composeKafkaTopic(storeName, 1));
@@ -2651,7 +2653,7 @@ public class TestVeniceParentHelixAdmin extends AbstractTestVeniceParentHelixAdm
       doReturn(-1).when(store).getRmdVersion();
       doReturn(store).when(internalAdmin).getStore(clusterName, storeName);
       doReturn(version).when(store).getVersion(1);
-      doReturn(new Pair<>(store, version)).when(internalAdmin)
+      doReturn(new StoreVersionInfo(store, version)).when(internalAdmin)
           .waitVersion(eq(clusterName), eq(storeName), eq(version.getNumber()), any());
       List<PubSubTopic> pubSubTopics =
           Arrays.asList(pubSubTopicRepository.getTopic(topicName), pubSubTopicRepository.getTopic(existingTopicName));


### PR DESCRIPTION
<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat], [protocol]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## [server][misc] Move leader->follower heartbeat tracking action to after transition complete
The bug happens is:
When a leader transits into follower, we will first clear leader HB entry and initialize follower HB entry and then submit request to transition into follower to KafkaStoreIngestionService.
The problem is, in between, leader will need to drain all the consumed messages before turning into follower and start consuming VT, and in between if we see any leader HB message, it will be recorded into leader entry but then this will remain as stale leader heartbeat and get recorded. 


## Solution
The fix is simple, just move the tracking change once we finished draining leader messages and update leader role in PartitionConsumptionState.

This PR also remove one of the big Pair usage in ReadOnlyStoreRepository#waitVersion. We should stop using Pair and use simple Java class to be less error prone and more semantic meaningful.

<!--
Describe
- What changes you are making and why. 
- How these changes solve the problem.
- Any performance considerations or trade-offs. 
- Describe what testings you have done, for example, performance testing etc.
-->


###  Code changes
- [ ] Added new code behind **a config**. If so list the config names and their default values in the PR description.
- [ ] Introduced new **log lines**. 
  - [ ] Confirmed if logs need to be **rate limited** to avoid excessive logging.

###  **Concurrency-Specific Checks**
Both reviewer and PR author to verify
- [x] Code has **no race conditions** or **thread safety issues**.
- [ ] Proper **synchronization mechanisms** (e.g., `synchronized`, `RWLock`) are used where needed.
- [ ] No **blocking calls** inside critical sections that could lead to deadlocks or performance degradation.
- [ ] Verified **thread-safe collections** are used (e.g., `ConcurrentHashMap`, `CopyOnWriteArrayList`).
- [ ] Validated proper exception handling in multi-threaded code to avoid silent thread termination.


## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->

- [ ] New unit tests added.
- [ ] New integration tests added.
- [x] Modified or extended existing tests.
- [ ] Verified backward compatibility (if applicable).

## Does this PR introduce any user-facing or breaking changes?
<!--  
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Clearly explain the behavior change and its impact.