### PR TITLE
[controller] Fix NPE in DeferredVersionSwapService

### DIFF
--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestDeferredVersionSwap.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestDeferredVersionSwap.java
@@ -63,7 +63,7 @@ public class TestDeferredVersionSwap {
   @BeforeClass
   public void setUp() {
     Properties controllerProps = new Properties();
-    controllerProps.put(CONTROLLER_DEFERRED_VERSION_SWAP_SLEEP_MS, 30000);
+    controllerProps.put(CONTROLLER_DEFERRED_VERSION_SWAP_SLEEP_MS, 100);
     controllerProps.put(CONTROLLER_DEFERRED_VERSION_SWAP_SERVICE_ENABLED, true);
     Properties serverProperties = new Properties();
 

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/DeferredVersionSwapService.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/DeferredVersionSwapService.java
@@ -131,10 +131,14 @@ public class DeferredVersionSwapService extends AbstractVeniceService {
    * @param targetRegions the list of regions to check if wait time has elapsed
    * @param store the store to check if the push wait time has elapsed
    * @param targetVersionNum the version to check if the push wait time has elapsed
+   * @param kafkaTopicName the name of the kafka topic for this target version
    * @return
    */
-  private boolean didCachedWaitTimeElapseInTargetRegions(Set<String> targetRegions, Store store, int targetVersionNum) {
-    String kafkaTopicName = Version.composeKafkaTopic(store.getName(), targetVersionNum);
+  private boolean didCachedWaitTimeElapseInTargetRegions(
+      Set<String> targetRegions,
+      Store store,
+      int targetVersionNum,
+      String kafkaTopicName) {
     Map<String, Long> storePushCompletionTimes = storePushCompletionTimeCache.getIfPresent(kafkaTopicName);
 
     // If there is no cached completion time, we should let the service continue the checks for the store as:
@@ -403,7 +407,11 @@ public class DeferredVersionSwapService extends AbstractVeniceService {
               String storeName = parentStore.getName();
               String kafkaTopicName = Version.composeKafkaTopic(storeName, targetVersionNum);
               Set<String> targetRegions = RegionUtils.parseRegionsFilterList(targetVersion.getTargetSwapRegion());
-              if (!didCachedWaitTimeElapseInTargetRegions(targetRegions, parentStore, targetVersionNum)) {
+              if (!didCachedWaitTimeElapseInTargetRegions(
+                  targetRegions,
+                  parentStore,
+                  targetVersionNum,
+                  kafkaTopicName)) {
                 continue;
               }
 

--- a/services/venice-controller/src/test/java/com/linkedin/venice/controller/TestDeferredVersionSwapService.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/controller/TestDeferredVersionSwapService.java
@@ -21,6 +21,7 @@ import com.linkedin.venice.utils.TestUtils;
 import java.time.LocalDateTime;
 import java.time.ZoneOffset;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -53,8 +54,7 @@ public class TestDeferredVersionSwapService {
     doReturn(true).when(veniceControllerMultiClusterConfig).isDeferredVersionSwapServiceEnabled();
     doReturn(true).when(veniceControllerMultiClusterConfig).isSkipDeferredVersionSwapForDVCEnabled();
 
-    List<String> clustersList = new ArrayList<>();
-    clustersList.add(clusterName);
+    List clustersList = Arrays.asList(clusterName);
     doReturn(clustersList).when(admin).getClustersLeaderOf();
   }
 

--- a/services/venice-controller/src/test/java/com/linkedin/venice/controller/TestDeferredVersionSwapService.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/controller/TestDeferredVersionSwapService.java
@@ -52,6 +52,10 @@ public class TestDeferredVersionSwapService {
     doReturn(10L).when(veniceControllerMultiClusterConfig).getDeferredVersionSwapSleepMs();
     doReturn(true).when(veniceControllerMultiClusterConfig).isDeferredVersionSwapServiceEnabled();
     doReturn(true).when(veniceControllerMultiClusterConfig).isSkipDeferredVersionSwapForDVCEnabled();
+
+    List<String> clustersList = new ArrayList<>();
+    clustersList.add(clusterName);
+    doReturn(clustersList).when(admin).getClustersLeaderOf();
   }
 
   private Store mockStore(
@@ -234,7 +238,7 @@ public class TestDeferredVersionSwapService {
 
     deferredVersionSwapService.startInner();
 
-    TestUtils.waitForNonDeterministicAssertion(5, TimeUnit.SECONDS, () -> {
+    TestUtils.waitForNonDeterministicAssertion(10, TimeUnit.SECONDS, () -> {
       // push completed in target region & wait time elapsed
       verify(admin, atLeast(1)).rollForwardToFutureVersion(clusterName, storeName1, region2);
 
@@ -397,7 +401,7 @@ public class TestDeferredVersionSwapService {
 
     deferredVersionSwapService.startInner();
 
-    TestUtils.waitForNonDeterministicAssertion(5, TimeUnit.SECONDS, () -> {
+    TestUtils.waitForNonDeterministicAssertion(10, TimeUnit.SECONDS, () -> {
       // one target region, 2 non target regions: one succeeded, one still in progress -> do not swap
       verify(admin, never())
           .rollForwardToFutureVersion(clusterName, storeName1, String.join(",\\s*", region2, region3));
@@ -509,7 +513,7 @@ public class TestDeferredVersionSwapService {
 
     deferredVersionSwapService.startInner();
 
-    TestUtils.waitForNonDeterministicAssertion(5, TimeUnit.SECONDS, () -> {
+    TestUtils.waitForNonDeterministicAssertion(10, TimeUnit.SECONDS, () -> {
       // one target region, 2 non target regions: all succeeded, wait time not elapsed -> do not swap
       verify(admin, never())
           .rollForwardToFutureVersion(clusterName, storeName1, String.join(",\\s*", region2, region3));

--- a/services/venice-controller/src/test/java/com/linkedin/venice/controller/TestDeferredVersionSwapService.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/controller/TestDeferredVersionSwapService.java
@@ -27,6 +27,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
+import org.testng.Assert;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
@@ -441,5 +442,82 @@ public class TestDeferredVersionSwapService {
         1,
         TimeUnit.SECONDS,
         () -> verify(admin, never()).rollForwardToFutureVersion(any(), any(), any()));
+  }
+
+  @Test
+  public void testDeferredVersionSwapCache() throws Exception {
+    Map<Integer, VersionStatus> versions = new HashMap<>();
+    int targetVersionNum = 2;
+    int completedVersionNum = 1;
+    versions.put(completedVersionNum, VersionStatus.ONLINE);
+    versions.put(targetVersionNum, VersionStatus.PUSHED);
+    String storeName1 = "testStore";
+    Store store1 = mockStore(completedVersionNum, 60, region1, versions, storeName1);
+
+    Long time = LocalDateTime.now().toEpochSecond(ZoneOffset.UTC);
+    List<Store> storeList = new ArrayList<>();
+    storeList.add(store1);
+    doReturn(storeList).when(admin).getAllStores(clusterName);
+    doReturn(2).when(store1).getLargestUsedVersionNumber();
+
+    Version targetVersion = new VersionImpl(storeName1, targetVersionNum);
+
+    ControllerClient controllerClient = mock(ControllerClient.class);
+    VeniceHelixAdmin veniceHelixAdmin = mock(VeniceHelixAdmin.class);
+    Map<String, ControllerClient> controllerClientMap = new HashMap<>();
+    controllerClientMap.put(region1, controllerClient);
+    controllerClientMap.put(region2, controllerClient);
+    controllerClientMap.put(region3, controllerClient);
+    StoreResponse storeResponse = new StoreResponse();
+    StoreInfo storeInfo = new StoreInfo();
+    List<Version> versionList = new ArrayList<>();
+    versionList.add(targetVersion);
+    storeInfo.setVersions(versionList);
+    storeResponse.setStore(storeInfo);
+
+    doReturn(storeResponse).when(controllerClient).getStore(any());
+    doReturn(veniceHelixAdmin).when(admin).getVeniceHelixAdmin();
+
+    HelixVeniceClusterResources resources = mock(HelixVeniceClusterResources.class);
+    ReadWriteStoreRepository repository = mock(ReadWriteStoreRepository.class);
+    doReturn(repository).when(resources).getStoreMetadataRepository();
+    doReturn(resources).when(veniceHelixAdmin).getHelixVeniceClusterResources(clusterName);
+    doReturn(store1).when(repository).getStore(storeName1);
+    doReturn(controllerClientMap).when(veniceHelixAdmin).getControllerClientMap(clusterName);
+
+    Map<String, Integer> coloToVersions = new HashMap<>();
+    coloToVersions.put(region1, 2);
+    coloToVersions.put(region2, 1);
+    coloToVersions.put(region3, 1);
+
+    doReturn(coloToVersions).when(admin).getCurrentVersionsForMultiColos(any(), any());
+
+    Admin.OfflinePushStatusInfo offlinePushStatusInfoWithOneOngoingPush = getOfflinePushStatusInfo(
+        ExecutionStatus.COMPLETED.toString(),
+        ExecutionStatus.COMPLETED.toString(),
+        ExecutionStatus.COMPLETED.toString(),
+        time - TimeUnit.MINUTES.toSeconds(30),
+        time - TimeUnit.MINUTES.toSeconds(30),
+        time - TimeUnit.MINUTES.toSeconds(30));
+
+    String kafkaTopicName1 = Version.composeKafkaTopic(storeName1, targetVersionNum);
+    doReturn(offlinePushStatusInfoWithOneOngoingPush).when(admin).getOffLinePushStatus(clusterName, kafkaTopicName1);
+    doReturn(true).when(admin).isLeaderControllerFor(clusterName);
+
+    DeferredVersionSwapService deferredVersionSwapService =
+        new DeferredVersionSwapService(admin, veniceControllerMultiClusterConfig, mock(DeferredVersionSwapStats.class));
+
+    deferredVersionSwapService.startInner();
+
+    TestUtils.waitForNonDeterministicAssertion(5, TimeUnit.SECONDS, () -> {
+      // one target region, 2 non target regions: all succeeded, wait time not elapsed -> do not swap
+      verify(admin, never())
+          .rollForwardToFutureVersion(clusterName, storeName1, String.join(",\\s*", region2, region3));
+
+      // verify that the wait time is cached
+      Assert.assertEquals(
+          deferredVersionSwapService.getStorePushCompletionTimes().getIfPresent(kafkaTopicName1),
+          offlinePushStatusInfoWithOneOngoingPush.getExtraInfoUpdateTimestamp());
+    });
   }
 }

--- a/services/venice-controller/src/test/java/com/linkedin/venice/controller/TestDeferredVersionSwapService.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/controller/TestDeferredVersionSwapService.java
@@ -238,7 +238,7 @@ public class TestDeferredVersionSwapService {
 
     deferredVersionSwapService.startInner();
 
-    TestUtils.waitForNonDeterministicAssertion(10, TimeUnit.SECONDS, () -> {
+    TestUtils.waitForNonDeterministicAssertion(5, TimeUnit.SECONDS, () -> {
       // push completed in target region & wait time elapsed
       verify(admin, atLeast(1)).rollForwardToFutureVersion(clusterName, storeName1, region2);
 
@@ -401,7 +401,7 @@ public class TestDeferredVersionSwapService {
 
     deferredVersionSwapService.startInner();
 
-    TestUtils.waitForNonDeterministicAssertion(10, TimeUnit.SECONDS, () -> {
+    TestUtils.waitForNonDeterministicAssertion(5, TimeUnit.SECONDS, () -> {
       // one target region, 2 non target regions: one succeeded, one still in progress -> do not swap
       verify(admin, never())
           .rollForwardToFutureVersion(clusterName, storeName1, String.join(",\\s*", region2, region3));
@@ -513,7 +513,7 @@ public class TestDeferredVersionSwapService {
 
     deferredVersionSwapService.startInner();
 
-    TestUtils.waitForNonDeterministicAssertion(10, TimeUnit.SECONDS, () -> {
+    TestUtils.waitForNonDeterministicAssertion(5, TimeUnit.SECONDS, () -> {
       // one target region, 2 non target regions: all succeeded, wait time not elapsed -> do not swap
       verify(admin, never())
           .rollForwardToFutureVersion(clusterName, storeName1, String.join(",\\s*", region2, region3));


### PR DESCRIPTION
<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat], [protocol]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## Problem Statement
<!--
Describe
- What problem are you trying to solve
- What issues or limitations exist in the current code
- Why this change is necessary 
-->

1. When we check if a store has a dvc heartbeat and get the child store in `isDavinciStore`, the store can be null and we need to exit early to avoid a NPE
2. We currently do not update the `storePushCompletionTimes` cache and this causes unnecessary cycles in the service 
3. The `extraInfoUpdateTimestamp` in `OfflinePushStatusInfo` is not guaranteed to contain a value for every region. This causes a NPE when we try to cast a null into a long value in L112 in `didWaitTimeElapseInTargetRegions`

## Solution
<!--
Describe
- What changes you are making and why. 
- How these changes solve the problem.
- Any performance considerations or trade-offs. 
- Describe what testings you have done, for example, performance testing etc.
-->

1. Add in an early exit in isDavinciStore to skip the rest of the checks if the store doesn't exist
2. Update `storePushCompletionTimes` cache with the completion times map if the wait time hasn't elapsed yet
3. Check if a region exists in the map before getting the value & casting it to a long

###  Code changes
- [ ] Added new code behind **a config**. If so list the config names and their default values in the PR description.
- [x] Introduced new **log lines**. 
  - [x] Confirmed if logs need to be **rate limited** to avoid excessive logging.

###  **Concurrency-Specific Checks**
Both reviewer and PR author to verify
- [x] Code has **no race conditions** or **thread safety issues**.
- [x] Proper **synchronization mechanisms** (e.g., `synchronized`, `RWLock`) are used where needed.
- [x] No **blocking calls** inside critical sections that could lead to deadlocks or performance degradation.
- [x] Verified **thread-safe collections** are used (e.g., `ConcurrentHashMap`, `CopyOnWriteArrayList`).
- [x] Validated proper exception handling in multi-threaded code to avoid silent thread termination.


## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->

- [ ] New unit tests added.
- [ ] New integration tests added.
- [ ] Modified or extended existing tests.
- [ ] Verified backward compatibility (if applicable).

Existing tests

## Does this PR introduce any user-facing or breaking changes?
<!--  
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Clearly explain the behavior change and its impact.