### PR TITLE
[server][common] close MaterializedViewWriter properly in LFSIT

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTask.java
@@ -88,6 +88,8 @@ import com.linkedin.venice.storage.protocol.ChunkedValueManifest;
 import com.linkedin.venice.utils.ByteUtils;
 import com.linkedin.venice.utils.LatencyUtils;
 import com.linkedin.venice.utils.PartitionUtils;
+import com.linkedin.venice.utils.SystemTime;
+import com.linkedin.venice.utils.Time;
 import com.linkedin.venice.utils.Utils;
 import com.linkedin.venice.utils.concurrent.VeniceConcurrentHashMap;
 import com.linkedin.venice.utils.lazy.Lazy;
@@ -170,6 +172,7 @@ import org.apache.logging.log4j.Logger;
 public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
   private static final Logger LOGGER = LogManager.getLogger(LeaderFollowerStoreIngestionTask.class);
   public static final String GLOBAL_RT_DIV_KEY_PREFIX = "GLOBAL_RT_DIV_KEY.";
+  static final long VIEW_WRITER_CLOSE_TIMEOUT_IN_MS = 60000; // 60s
 
   /**
    * The new leader will stay inactive (not switch to any new topic or produce anything) for
@@ -215,6 +218,7 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
   private final Version version;
 
   protected final ExecutorService aaWCIngestionStorageLookupThreadPool;
+  private Time time = new SystemTime();
 
   public LeaderFollowerStoreIngestionTask(
       StorageService storageService,
@@ -411,9 +415,36 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
   }
 
   @Override
-  protected void closeVeniceViewWriters() {
+  protected void closeVeniceViewWriters(boolean doFlush) {
     if (!viewWriters.isEmpty()) {
-      viewWriters.forEach((k, v) -> v.close());
+      long gracefulCloseDeadline = time.getMilliseconds() + VIEW_WRITER_CLOSE_TIMEOUT_IN_MS;
+      viewWriters.forEach((k, v) -> v.close(doFlush));
+      // Short circuit last VT produce call future if it's incomplete to unblock any consumer thread(s) that are waiting
+      for (PartitionConsumptionState pcs: partitionConsumptionStateMap.values()) {
+        CompletableFuture<Void> lastVTProduceCallFuture = pcs.getLastVTProduceCallFuture();
+        if (!lastVTProduceCallFuture.isDone()) {
+          if (doFlush) {
+            long timeout = gracefulCloseDeadline - time.getMilliseconds();
+            if (timeout <= 0) {
+              lastVTProduceCallFuture.completeExceptionally(
+                  new VeniceException(
+                      "Completing the future forcefully since we exceeded the view writer graceful close timeout for: "
+                          + kafkaVersionTopic));
+            } else {
+              try {
+                lastVTProduceCallFuture.get(timeout, MILLISECONDS);
+              } catch (Exception e) {
+                lastVTProduceCallFuture.completeExceptionally(
+                    new VeniceException(
+                        "Exception caught when closing the view writer in ingestion task for: " + kafkaVersionTopic,
+                        e));
+              }
+            }
+          } else {
+            lastVTProduceCallFuture.complete(null);
+          }
+        }
+      }
     }
   }
 
@@ -4297,5 +4328,10 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
 
   HeartbeatMonitoringService getHeartbeatMonitoringService() {
     return heartbeatMonitoringService;
+  }
+
+  // Package private for unit test
+  void setTime(Time time) {
+    this.time = time;
   }
 }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/PartitionConsumptionState.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/PartitionConsumptionState.java
@@ -64,7 +64,11 @@ public class PartitionConsumptionState {
   private boolean isDataRecoveryCompleted;
   private LeaderFollowerStateType leaderFollowerState;
 
-  private CompletableFuture<Void> lastVTProduceCallFuture;
+  /**
+   * The VT produce future should be read/set by the same consumer thread during normal operation. Making it volatile
+   * since the SIT thread might want to shortcircuit this future when closing {@link LeaderFollowerStoreIngestionTask}.
+   */
+  private volatile CompletableFuture<Void> lastVTProduceCallFuture;
 
   /**
    * State machine that can only transition to LATCH_CREATED if LatchStatus is NONE, and transition to LATCH_RELEASED

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
@@ -1999,16 +1999,17 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
     } catch (Exception e) {
       LOGGER.error("{} Error while unsubscribing topic.", ingestionTaskName, e);
     }
+
+    try {
+      closeVeniceViewWriters(doFlush);
+    } catch (Exception e) {
+      LOGGER.error("Error while closing venice view writer", e);
+    }
+
     try {
       closeVeniceWriters(doFlush);
     } catch (Exception e) {
       LOGGER.error("Error while closing venice writers", e);
-    }
-
-    try {
-      closeVeniceViewWriters();
-    } catch (Exception e) {
-      LOGGER.error("Error while closing venice view writer", e);
     }
 
     if (topicManagerRepository != null) {
@@ -2027,7 +2028,7 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
   public void closeVeniceWriters(boolean doFlush) {
   }
 
-  protected void closeVeniceViewWriters() {
+  protected void closeVeniceViewWriters(boolean doFlush) {
   }
 
   /**

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/store/view/ChangeCaptureViewWriter.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/store/view/ChangeCaptureViewWriter.java
@@ -170,10 +170,10 @@ public class ChangeCaptureViewWriter extends VeniceViewWriter {
   }
 
   @Override
-  public void close() {
-    internalView.close();
+  public void close(boolean gracefulClose) {
+    internalView.close(gracefulClose);
     if (veniceWriter != null) {
-      veniceWriter.close();
+      veniceWriter.close(gracefulClose);
     }
   }
 

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/store/view/MaterializedViewWriter.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/store/view/MaterializedViewWriter.java
@@ -120,6 +120,14 @@ public class MaterializedViewWriter extends VeniceViewWriter {
     return internalView.getWriterClassName();
   }
 
+  @Override
+  public void close(boolean gracefulClose) {
+    internalView.close(gracefulClose);
+    if (veniceWriter.isPresent()) {
+      veniceWriter.get().close(gracefulClose);
+    }
+  }
+
   // Package private for testing
   VeniceWriterOptions buildWriterOptions() {
     return setProducerOptimizations(internalView.getWriterOptionsBuilder(materializedViewTopicName, version)).build();

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/store/view/ChangeCaptureViewWriterTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/store/view/ChangeCaptureViewWriterTest.java
@@ -295,8 +295,8 @@ public class ChangeCaptureViewWriterTest {
     Assert.assertEquals(changeEvents.get(2).previousValue.value, OLD_VALUE);
 
     // Test close
-    changeCaptureViewWriter.close();
-    Mockito.verify(mockVeniceWriter).close();
+    changeCaptureViewWriter.close(true);
+    Mockito.verify(mockVeniceWriter).close(true);
   }
 
 }

--- a/internal/venice-common/src/main/java/com/linkedin/venice/views/VeniceView.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/views/VeniceView.java
@@ -81,7 +81,7 @@ public abstract class VeniceView {
     // validation based on view implementation
   }
 
-  public void close() {
+  public void close(boolean gracefulClose) {
     // close out anything which should be shutdown
   }
 

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/view/TestView.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/view/TestView.java
@@ -40,7 +40,7 @@ public class TestView extends VeniceView {
   }
 
   @Override
-  public void close() {
+  public void close(boolean gracefulClose) {
     // close out anything which should be shutdown
   }
 

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/view/TestViewWriter.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/view/TestViewWriter.java
@@ -107,8 +107,8 @@ public class TestViewWriter extends VeniceViewWriter {
   }
 
   @Override
-  public void close() {
-    internalView.close();
+  public void close(boolean gracefulClose) {
+    internalView.close(gracefulClose);
   }
 
 }


### PR DESCRIPTION
## Problem Statement
MaterializedViewWriter did not implement the close() method defined in VeniceView. This means when SIT's internalClose is called the VeniceWriter in MaterializedViewWriter will not be closed. This can cause stuck consumer because a consumer thread could be waiting for the last VT produce future in checkAndWaitForLastVTProduceFuture to ensure CMs that don't need to be produced to view(s) will not be produced to VT out of order. Without closing/flushing the view writer and potentially shortcircuit the lastVTProduceCallFuture the consumer thread could be waiting on a lastVTProduceCallFuture forever and here is one example how this could occur with the old code:
  1. For each incoming record we get the lastVTProduceCallFuture to be part of a new future that is completed when the view writers for the current record and lastVTProduceCallFuture are completed. This new future is then set as the new lastVTProduceCallFuture.
  2. This chaining can go for many layers. i.e. {[(lastVTPCF1, viewWriterFuture1), viewWriterFuture2], viewWriterFuture3} The consumer thread could be waiting for the lastVTProduceCallFuture defined with { }. However, VT VW/producer could be closed already when we try to produce to VT in the callback of the lastVTProduceCallFuture defined with ( ). This will cause the handling thread, currently the common ForkJoinPool to terminate because version topic write is a runnable.
  3. This means the lastVTProduceCallFuture defined in [ ] will never complete and the same goes with the future defined with { } which depends on [ ] and ( ). Consumer thread waiting on { } will be stuck forever.

## Solution
The change closes the view writers first, wait or shortcircuit any incomplete lastVTProduceCallFuture and then close the VT writers.


###  Code changes
- [ ] Added new code behind **a config**. If so list the config names and their default values in the PR description.
- [ ] Introduced new **log lines**. 
  - [ ] Confirmed if logs need to be **rate limited** to avoid excessive logging.

###  **Concurrency-Specific Checks**
Both reviewer and PR author to verify
- [x] Code has **no race conditions** or **thread safety issues**.
- [x] Proper **synchronization mechanisms** (e.g., `synchronized`, `RWLock`) are used where needed.
- [x] No **blocking calls** inside critical sections that could lead to deadlocks or performance degradation.
- [x] Verified **thread-safe collections** are used (e.g., `ConcurrentHashMap`, `CopyOnWriteArrayList`).
- [x] Validated proper exception handling in multi-threaded code to avoid silent thread termination.


## How was this PR tested?
New unit test and existing integration tests

- [x] New unit tests added.
- [ ] New integration tests added.
- [ ] Modified or extended existing tests.
- [ ] Verified backward compatibility (if applicable).

## Does this PR introduce any user-facing or breaking changes?
<!--  
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Clearly explain the behavior change and its impact.