### PR TITLE
[server] Global RT DIV: State Transitions

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/ActiveActiveStoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/ActiveActiveStoreIngestionTask.java
@@ -1124,7 +1124,7 @@ public class ActiveActiveStoreIngestionTask extends LeaderFollowerStoreIngestion
     // Update leader topic.
     partitionConsumptionState.getOffsetRecord().setLeaderTopic(newSourceTopic);
     // Calculate leader offset and start consumption
-    prepareOffsetCheckpointAndStartConsumptionAsLeader(newSourceTopic, partitionConsumptionState);
+    prepareOffsetCheckpointAndStartConsumptionAsLeader(newSourceTopic, partitionConsumptionState, false);
   }
 
   /**

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/ActiveActiveStoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/ActiveActiveStoreIngestionTask.java
@@ -1,7 +1,6 @@
 package com.linkedin.davinci.kafka.consumer;
 
 import static com.linkedin.davinci.kafka.consumer.LeaderFollowerStateType.LEADER;
-import static com.linkedin.davinci.validation.PartitionTracker.TopicType.*;
 import static com.linkedin.venice.VeniceConstants.REWIND_TIME_DECIDED_BY_SERVER;
 import static com.linkedin.venice.writer.VeniceWriter.APP_DEFAULT_LOGICAL_TS;
 
@@ -1555,13 +1554,6 @@ public class ActiveActiveStoreIngestionTask extends LeaderFollowerStoreIngestion
         leaderTopic,
         partitionConsumptionState.getPartition(),
         leaderOffsetByKafkaURL);
-  }
-
-  @Override
-  protected void loadGlobalRtDiv(int partition) {
-    kafkaClusterIdToUrlMap.forEach((clusterId, brokerUrl) -> {
-      loadGlobalRtDiv(partition, brokerUrl);
-    });
   }
 
   private long calculateRewindStartTime(PartitionConsumptionState partitionConsumptionState) {

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTask.java
@@ -1009,17 +1009,11 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
     }
     partitionConsumptionState.getOffsetRecord().setLeaderTopic(newSourceTopic);
 
-    prepareOffsetCheckpointAndStartConsumptionAsLeader(newSourceTopic, partitionConsumptionState);
+    prepareOffsetCheckpointAndStartConsumptionAsLeader(newSourceTopic, partitionConsumptionState, false);
 
     // In case new topic is empty and leader can never become online
     // TODO: Remove this once after AGG store migration.
     maybeApplyReadyToServeCheck(partitionConsumptionState);
-  }
-
-  void prepareOffsetCheckpointAndStartConsumptionAsLeader(
-      PubSubTopic leaderTopic,
-      PartitionConsumptionState partitionConsumptionState) {
-    prepareOffsetCheckpointAndStartConsumptionAsLeader(leaderTopic, partitionConsumptionState, false);
   }
 
   /**
@@ -4229,7 +4223,7 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
     LOGGER.info(
         "Leader replica: {} unsubscribe finished for future resubscribe.",
         partitionConsumptionState.getReplicaId());
-    prepareOffsetCheckpointAndStartConsumptionAsLeader(leaderTopic, partitionConsumptionState);
+    prepareOffsetCheckpointAndStartConsumptionAsLeader(leaderTopic, partitionConsumptionState, false);
   }
 
   protected void queueUpVersionTopicWritesWithViewWriters(

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTask.java
@@ -3731,7 +3731,7 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
     LeaderProducerCallback divCallback = createProducerCallback(
         divMessage,
         partitionConsumptionState,
-        leaderProducedRecordContext,
+        new LeaderProducedRecordContext(leaderProducedRecordContext),
         partition,
         brokerUrl,
         beforeProcessingRecordTimestampNs);

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTask.java
@@ -550,7 +550,7 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
           consumerSubscribe(
               topic,
               partitionConsumptionState,
-              partitionConsumptionState.getLatestProcessedLocalVersionTopicOffset(),
+              partitionConsumptionState.getLocalVtSubscribeOffset(isGlobalRtDivEnabled()),
               localKafkaServer);
           /**
            * When switching leader to follower, we may adjust the underlying storage partition to optimize the performance.
@@ -741,7 +741,7 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
             consumerSubscribe(
                 currentLeaderTopic,
                 partitionConsumptionState,
-                partitionConsumptionState.getLatestProcessedLocalVersionTopicOffset(),
+                partitionConsumptionState.getLocalVtSubscribeOffset(isGlobalRtDivEnabled()),
                 localKafkaServer);
           }
 
@@ -938,7 +938,6 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
      * this case, the newly selected leader will resume the consumption from RT specified in TS at the offset
      * checkpointed in leader offset metadata.
      */
-
     final int partition = partitionConsumptionState.getPartition();
     final OffsetRecord offsetRecord = partitionConsumptionState.getOffsetRecord();
     if (isNativeReplicationEnabled) {
@@ -4158,12 +4157,12 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
     consumerSubscribe(
         versionTopic,
         partitionConsumptionState,
-        latestProcessedLocalVersionTopicOffset,
+        partitionConsumptionState.getLocalVtSubscribeOffset(isGlobalRtDivEnabled()),
         localKafkaServer);
     LOGGER.info(
         "Follower replica: {} resubscribe to offset: {}",
         partitionConsumptionState.getReplicaId(),
-        latestProcessedLocalVersionTopicOffset);
+        partitionConsumptionState.getLocalVtSubscribeOffset(isGlobalRtDivEnabled()));
   }
 
   protected void resubscribeAsLeader(PartitionConsumptionState partitionConsumptionState) throws InterruptedException {

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTask.java
@@ -550,7 +550,7 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
           consumerSubscribe(
               topic,
               partitionConsumptionState,
-              partitionConsumptionState.getLocalVtSubscribeOffset(isGlobalRtDivEnabled()),
+              getLocalVtSubscribeOffset(partitionConsumptionState),
               localKafkaServer);
           /**
            * When switching leader to follower, we may adjust the underlying storage partition to optimize the performance.
@@ -741,7 +741,7 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
             consumerSubscribe(
                 currentLeaderTopic,
                 partitionConsumptionState,
-                partitionConsumptionState.getLocalVtSubscribeOffset(isGlobalRtDivEnabled()),
+                getLocalVtSubscribeOffset(partitionConsumptionState),
                 localKafkaServer);
           }
 
@@ -4153,16 +4153,12 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
     LOGGER.info(
         "Follower replica: {} unsubscribe finished for future resubscribe.",
         partitionConsumptionState.getReplicaId());
-    long latestProcessedLocalVersionTopicOffset = partitionConsumptionState.getLatestProcessedLocalVersionTopicOffset();
-    consumerSubscribe(
-        versionTopic,
-        partitionConsumptionState,
-        partitionConsumptionState.getLocalVtSubscribeOffset(isGlobalRtDivEnabled()),
-        localKafkaServer);
+    long subscribeOffset = getLocalVtSubscribeOffset(partitionConsumptionState);
+    consumerSubscribe(versionTopic, partitionConsumptionState, subscribeOffset, localKafkaServer);
     LOGGER.info(
         "Follower replica: {} resubscribe to offset: {}",
         partitionConsumptionState.getReplicaId(),
-        partitionConsumptionState.getLocalVtSubscribeOffset(isGlobalRtDivEnabled()));
+        subscribeOffset);
   }
 
   protected void resubscribeAsLeader(PartitionConsumptionState partitionConsumptionState) throws InterruptedException {

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTask.java
@@ -741,7 +741,7 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
             consumerSubscribe(
                 currentLeaderTopic,
                 partitionConsumptionState,
-                getLocalVtSubscribeOffset(partitionConsumptionState),
+                partitionConsumptionState.getLatestProcessedLocalVersionTopicOffset(),
                 localKafkaServer);
           }
 
@@ -4153,12 +4153,15 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
     LOGGER.info(
         "Follower replica: {} unsubscribe finished for future resubscribe.",
         partitionConsumptionState.getReplicaId());
-    long subscribeOffset = getLocalVtSubscribeOffset(partitionConsumptionState);
-    consumerSubscribe(versionTopic, partitionConsumptionState, subscribeOffset, localKafkaServer);
+    consumerSubscribe(
+        versionTopic,
+        partitionConsumptionState,
+        partitionConsumptionState.getLatestProcessedLocalVersionTopicOffset(),
+        localKafkaServer);
     LOGGER.info(
         "Follower replica: {} resubscribe to offset: {}",
         partitionConsumptionState.getReplicaId(),
-        subscribeOffset);
+        partitionConsumptionState.getLatestProcessedLocalVersionTopicOffset());
   }
 
   protected void resubscribeAsLeader(PartitionConsumptionState partitionConsumptionState) throws InterruptedException {

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTask.java
@@ -1038,6 +1038,7 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
     }
 
     consumerSubscribe(leaderTopic, partitionConsumptionState, upstreamStartOffset, leaderSourceKafkaURL);
+    // TODO: set to null
     syncConsumedUpstreamRTOffsetMapIfNeeded(
         partitionConsumptionState,
         Collections.singletonMap(leaderSourceKafkaURL, upstreamStartOffset));
@@ -3808,8 +3809,49 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
    */
   private void restoreProducerStatesForLeaderConsumption(int partition) {
     consumerDiv.clearPartition(partition);
-    cloneProducerStates(partition, consumerDiv);
-    // TODO: the Global RT DIV version needs to be implemented in a future PR
+    if (isGlobalRtDivEnabled()) {
+      loadGlobalRtDiv(partition);
+    } else {
+      cloneProducerStates(partition, consumerDiv);
+    }
+  }
+
+  /**
+   * Load the stored Global RT DIV object from the storage engine into the Consumer DIV during state transition
+   * to LEADER. The RT DIV needs to be loaded per-broker url, and the latest consumed RT offset needs to be updated.
+   */
+  private void loadGlobalRtDiv(int partition) {
+    PartitionConsumptionState pcs = partitionConsumptionStateMap.get(partition);
+    final PubSubTopic topic = pcs.getOffsetRecord().getLeaderTopic(pubSubTopicRepository);
+    final PubSubTopicPartition topicPartition = new PubSubTopicPartitionImpl(topic, pcs.getPartition());
+
+    kafkaClusterIdToUrlMap.forEach((clusterId, brokerUrl) -> {
+      String globalRtDivKey = getGlobalRtDivKeyName(brokerUrl);
+      byte[] keyBytes = globalRtDivKey.getBytes();
+      final ChunkedValueManifestContainer valueManifestContainer = new ChunkedValueManifestContainer();
+      GenericRecord valueRecord = readStoredValueRecord(
+          pcs,
+          keyBytes,
+          AvroProtocolDefinition.GLOBAL_RT_DIV_STATE.getCurrentProtocolVersion(),
+          topicPartition,
+          valueManifestContainer);
+      if (valueRecord == null) {
+        return; // it may not exist (e.g. this is the first leader to be elected)
+      }
+
+      Object value = valueRecord.get(globalRtDivKey);
+      if (value instanceof GlobalRtDivState) {
+        GlobalRtDivState globalRtDivState = (GlobalRtDivState) value;
+        final Map<CharSequence, ProducerPartitionState> producerStates = globalRtDivState.getProducerStates();
+        TopicType realTimeTopicType = TopicType.of(REALTIME_TOPIC_TYPE, brokerUrl);
+        consumerDiv.setPartitionState(realTimeTopicType, pcs.getPartition(), producerStates);
+        final long latestConsumedRtOffset = globalRtDivState.getLatestOffset(); // LCRO
+        pcs.updateLatestConsumedRtOffset(brokerUrl, latestConsumedRtOffset);
+      } else {
+        LOGGER.warn("Unable to load Global RT DIV: {}", globalRtDivKey);
+        // TODO: should we throw? or if we don't throw, which offset should the subscribe occur at?
+      }
+    });
   }
 
   /**

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTask.java
@@ -12,6 +12,7 @@ import static com.linkedin.davinci.validation.PartitionTracker.TopicType.VERSION
 import static com.linkedin.venice.kafka.protocol.enums.ControlMessageType.END_OF_PUSH;
 import static com.linkedin.venice.kafka.protocol.enums.ControlMessageType.START_OF_SEGMENT;
 import static com.linkedin.venice.kafka.protocol.enums.MessageType.UPDATE;
+import static com.linkedin.venice.offsets.OffsetRecord.NON_AA_REPLICATION_UPSTREAM_OFFSET_MAP_KEY;
 import static com.linkedin.venice.pubsub.api.PubSubMessageHeaders.VENICE_LEADER_COMPLETION_STATE_HEADER;
 import static com.linkedin.venice.writer.VeniceWriter.APP_DEFAULT_LOGICAL_TS;
 import static com.linkedin.venice.writer.VeniceWriter.DEFAULT_LEADER_METADATA_WRAPPER;
@@ -915,7 +916,7 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
           topicSwitch.rewindStartTimestamp,
           partitionConsumptionState.getReplicaId());
     }
-    return Collections.singletonMap(OffsetRecord.NON_AA_REPLICATION_UPSTREAM_OFFSET_MAP_KEY, upstreamStartOffset);
+    return Collections.singletonMap(NON_AA_REPLICATION_UPSTREAM_OFFSET_MAP_KEY, upstreamStartOffset);
   }
 
   @Override
@@ -961,7 +962,7 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
     }
     partitionConsumptionState.setLeaderFollowerState(LEADER);
     final PubSubTopic leaderTopic = offsetRecord.getLeaderTopic(pubSubTopicRepository);
-    prepareOffsetCheckpointAndStartConsumptionAsLeader(leaderTopic, partitionConsumptionState);
+    prepareOffsetCheckpointAndStartConsumptionAsLeader(leaderTopic, partitionConsumptionState, true);
   }
 
   private boolean switchAwayFromStreamReprocessingTopic(PubSubTopic currentLeaderTopic, PubSubTopic topicSwitchTopic) {
@@ -1015,6 +1016,12 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
     maybeApplyReadyToServeCheck(partitionConsumptionState);
   }
 
+  void prepareOffsetCheckpointAndStartConsumptionAsLeader(
+      PubSubTopic leaderTopic,
+      PartitionConsumptionState partitionConsumptionState) {
+    prepareOffsetCheckpointAndStartConsumptionAsLeader(leaderTopic, partitionConsumptionState, false);
+  }
+
   /**
    * This method does a few things for leader topic-partition subscription:
    * (1) Calculate Kafka URL to leader subscribe offset map.
@@ -1023,18 +1030,20 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
    */
   void prepareOffsetCheckpointAndStartConsumptionAsLeader(
       PubSubTopic leaderTopic,
-      PartitionConsumptionState partitionConsumptionState) {
+      PartitionConsumptionState partitionConsumptionState,
+      boolean isTransition) {
     Set<String> leaderSourceKafkaURLs = getConsumptionSourceKafkaAddress(partitionConsumptionState);
     if (leaderSourceKafkaURLs.size() != 1) {
       throw new VeniceException("In L/F mode, expect only one leader source Kafka URL. Got: " + leaderSourceKafkaURLs);
     }
+    boolean useLcro = isTransition && isGlobalRtDivEnabled();
     long upstreamStartOffset = partitionConsumptionState
-        .getLeaderOffset(OffsetRecord.NON_AA_REPLICATION_UPSTREAM_OFFSET_MAP_KEY, pubSubTopicRepository);
+        .getLeaderOffset(NON_AA_REPLICATION_UPSTREAM_OFFSET_MAP_KEY, pubSubTopicRepository, useLcro);
     String leaderSourceKafkaURL = leaderSourceKafkaURLs.iterator().next();
     if (upstreamStartOffset < 0 && leaderTopic.isRealTime()) {
       upstreamStartOffset =
           calculateLeaderUpstreamOffsetWithTopicSwitch(partitionConsumptionState, leaderTopic, Collections.emptyList())
-              .getOrDefault(OffsetRecord.NON_AA_REPLICATION_UPSTREAM_OFFSET_MAP_KEY, OffsetRecord.LOWEST_OFFSET);
+              .getOrDefault(NON_AA_REPLICATION_UPSTREAM_OFFSET_MAP_KEY, OffsetRecord.LOWEST_OFFSET);
     }
 
     consumerSubscribe(leaderTopic, partitionConsumptionState, upstreamStartOffset, leaderSourceKafkaURL);
@@ -1523,7 +1532,7 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
         (sourceKafkaUrl, upstreamTopic) -> upstreamTopic.isRealTime()
             ? partitionConsumptionState.getLatestProcessedUpstreamRTOffset(sourceKafkaUrl)
             : partitionConsumptionState.getLatestProcessedUpstreamVersionTopicOffset(),
-        () -> OffsetRecord.NON_AA_REPLICATION_UPSTREAM_OFFSET_MAP_KEY,
+        () -> NON_AA_REPLICATION_UPSTREAM_OFFSET_MAP_KEY,
         dryRun);
   }
 
@@ -2984,15 +2993,15 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
   }
 
   private final Predicate<? super PartitionConsumptionState> FOLLOWER_OFFSET_LAG_FILTER =
-      pcs -> pcs.getLatestProcessedUpstreamRTOffset(OffsetRecord.NON_AA_REPLICATION_UPSTREAM_OFFSET_MAP_KEY) != -1
+      pcs -> pcs.getLatestProcessedUpstreamRTOffset(NON_AA_REPLICATION_UPSTREAM_OFFSET_MAP_KEY) != -1
           && !pcs.getLeaderFollowerState().equals(LEADER);
   private final Predicate<? super PartitionConsumptionState> BATCH_FOLLOWER_OFFSET_LAG_FILTER =
       pcs -> !pcs.isEndOfPushReceived()
-          && pcs.getLatestProcessedUpstreamRTOffset(OffsetRecord.NON_AA_REPLICATION_UPSTREAM_OFFSET_MAP_KEY) != -1
+          && pcs.getLatestProcessedUpstreamRTOffset(NON_AA_REPLICATION_UPSTREAM_OFFSET_MAP_KEY) != -1
           && !pcs.getLeaderFollowerState().equals(LEADER);
   private final Predicate<? super PartitionConsumptionState> HYBRID_FOLLOWER_OFFSET_LAG_FILTER =
       pcs -> pcs.isEndOfPushReceived() && pcs.isHybrid()
-          && pcs.getLatestProcessedUpstreamRTOffset(OffsetRecord.NON_AA_REPLICATION_UPSTREAM_OFFSET_MAP_KEY) != -1
+          && pcs.getLatestProcessedUpstreamRTOffset(NON_AA_REPLICATION_UPSTREAM_OFFSET_MAP_KEY) != -1
           && !pcs.getLeaderFollowerState().equals(LEADER);
 
   private long getFollowerOffsetLag(Predicate<? super PartitionConsumptionState> partitionConsumptionStateFilter) {
@@ -3067,7 +3076,7 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
   protected long getLatestPersistedUpstreamOffsetForHybridOffsetLagMeasurement(
       PartitionConsumptionState pcs,
       String ignoredUpstreamKafkaUrl) {
-    return pcs.getLatestProcessedUpstreamRTOffset(OffsetRecord.NON_AA_REPLICATION_UPSTREAM_OFFSET_MAP_KEY);
+    return pcs.getLatestProcessedUpstreamRTOffset(NON_AA_REPLICATION_UPSTREAM_OFFSET_MAP_KEY);
   }
 
   /**
@@ -3076,14 +3085,14 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
   protected long getLatestConsumedUpstreamOffsetForHybridOffsetLagMeasurement(
       PartitionConsumptionState pcs,
       String ignoredKafkaUrl) {
-    return pcs.getLeaderConsumedUpstreamRTOffset(OffsetRecord.NON_AA_REPLICATION_UPSTREAM_OFFSET_MAP_KEY);
+    return pcs.getLeaderConsumedUpstreamRTOffset(NON_AA_REPLICATION_UPSTREAM_OFFSET_MAP_KEY);
   }
 
   protected void updateLatestInMemoryLeaderConsumedRTOffset(
       PartitionConsumptionState pcs,
       String ignoredKafkaUrl,
       long offset) {
-    pcs.updateLeaderConsumedUpstreamRTOffset(OffsetRecord.NON_AA_REPLICATION_UPSTREAM_OFFSET_MAP_KEY, offset);
+    pcs.updateLeaderConsumedUpstreamRTOffset(NON_AA_REPLICATION_UPSTREAM_OFFSET_MAP_KEY, offset);
   }
 
   @Override
@@ -3671,7 +3680,8 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
       Map<CharSequence, ProducerPartitionState> rtDivPartitionStates) {
     ByteBuffer emptyBuffer = ByteBuffer.allocate(0); // TODO: use this PubSubPosition instead of latestOffset
     final long offset = previousMessage.getPosition().getNumericOffset();
-    GlobalRtDivState globalRtDiv = new GlobalRtDivState(brokerUrl, rtDivPartitionStates, offset, emptyBuffer);
+    String url = (isActiveActiveReplicationEnabled()) ? brokerUrl : NON_AA_REPLICATION_UPSTREAM_OFFSET_MAP_KEY;
+    GlobalRtDivState globalRtDiv = new GlobalRtDivState(url, rtDivPartitionStates, offset, emptyBuffer);
     byte[] valueBytes = ByteUtils.extractByteArray(globalRtDivStateSerializer.serialize(globalRtDiv));
     try {
       valueBytes = compressor.get().compress(valueBytes);
@@ -3816,42 +3826,44 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
     }
   }
 
+  protected void loadGlobalRtDiv(int partition) {
+    loadGlobalRtDiv(partition, NON_AA_REPLICATION_UPSTREAM_OFFSET_MAP_KEY);
+  }
+
   /**
    * Load the stored Global RT DIV object from the storage engine into the Consumer DIV during state transition
    * to LEADER. The RT DIV needs to be loaded per-broker url, and the latest consumed RT offset needs to be updated.
    */
-  private void loadGlobalRtDiv(int partition) {
+  void loadGlobalRtDiv(int partition, String brokerUrl) {
     PartitionConsumptionState pcs = partitionConsumptionStateMap.get(partition);
     final PubSubTopic topic = pcs.getOffsetRecord().getLeaderTopic(pubSubTopicRepository);
     final PubSubTopicPartition topicPartition = new PubSubTopicPartitionImpl(topic, pcs.getPartition());
 
-    kafkaClusterIdToUrlMap.forEach((clusterId, brokerUrl) -> {
-      String globalRtDivKey = getGlobalRtDivKeyName(brokerUrl);
-      byte[] keyBytes = globalRtDivKey.getBytes();
-      final ChunkedValueManifestContainer valueManifestContainer = new ChunkedValueManifestContainer();
-      GenericRecord valueRecord = readStoredValueRecord(
-          pcs,
-          keyBytes,
-          AvroProtocolDefinition.GLOBAL_RT_DIV_STATE.getCurrentProtocolVersion(),
-          topicPartition,
-          valueManifestContainer);
-      if (valueRecord == null) {
-        return; // it may not exist (e.g. this is the first leader to be elected)
-      }
+    String globalRtDivKey = getGlobalRtDivKeyName(brokerUrl);
+    byte[] keyBytes = globalRtDivKey.getBytes();
+    final ChunkedValueManifestContainer valueManifestContainer = new ChunkedValueManifestContainer();
+    GenericRecord valueRecord = readStoredValueRecord(
+        pcs,
+        keyBytes,
+        AvroProtocolDefinition.GLOBAL_RT_DIV_STATE.getCurrentProtocolVersion(),
+        topicPartition,
+        valueManifestContainer);
+    if (valueRecord == null) {
+      return; // it may not exist (e.g. this is the first leader to be elected)
+    }
 
-      Object value = valueRecord.get(globalRtDivKey);
-      if (value instanceof GlobalRtDivState) {
-        GlobalRtDivState globalRtDivState = (GlobalRtDivState) value;
-        final Map<CharSequence, ProducerPartitionState> producerStates = globalRtDivState.getProducerStates();
-        TopicType realTimeTopicType = TopicType.of(REALTIME_TOPIC_TYPE, brokerUrl);
-        consumerDiv.setPartitionState(realTimeTopicType, pcs.getPartition(), producerStates);
-        final long latestConsumedRtOffset = globalRtDivState.getLatestOffset(); // LCRO
-        pcs.updateLatestConsumedRtOffset(brokerUrl, latestConsumedRtOffset);
-      } else {
-        LOGGER.warn("Unable to load Global RT DIV: {}", globalRtDivKey);
-        // TODO: should we throw? or if we don't throw, which offset should the subscribe occur at?
-      }
-    });
+    Object value = valueRecord.get(globalRtDivKey);
+    if (value instanceof GlobalRtDivState) {
+      GlobalRtDivState globalRtDivState = (GlobalRtDivState) value;
+      final Map<CharSequence, ProducerPartitionState> producerStates = globalRtDivState.getProducerStates();
+      PartitionTracker.TopicType realTimeTopicType = PartitionTracker.TopicType.of(REALTIME_TOPIC_TYPE, brokerUrl);
+      consumerDiv.setPartitionState(realTimeTopicType, pcs.getPartition(), producerStates);
+      final long latestConsumedRtOffset = globalRtDivState.getLatestOffset(); // LCRO
+      pcs.updateLatestConsumedRtOffset(brokerUrl, latestConsumedRtOffset);
+    } else {
+      LOGGER.warn("Unable to load Global RT DIV: {}", globalRtDivKey);
+      // TODO: should we throw? or if we don't throw, which offset should the subscribe occur at?
+    }
   }
 
   /**

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderProducedRecordContext.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderProducedRecordContext.java
@@ -137,6 +137,16 @@ public class LeaderProducedRecordContext implements Measurable {
     return new LeaderProducedRecordContext(consumedKafkaClusterId, consumedOffset, DELETE, keyBytes, valueUnion);
   }
 
+  public LeaderProducedRecordContext(LeaderProducedRecordContext context) {
+    this(
+        context.consumedKafkaClusterId,
+        context.consumedOffset,
+        context.messageType,
+        context.keyBytes,
+        context.valueUnion,
+        new CompletableFuture());
+  }
+
   private LeaderProducedRecordContext(
       int consumedKafkaClusterId,
       long consumedOffset,

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/PartitionConsumptionState.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/PartitionConsumptionState.java
@@ -815,15 +815,8 @@ public class PartitionConsumptionState {
     return this.latestProcessedLocalVersionTopicOffset;
   }
 
-  /**
-   * When Global RT DIV is enabled, the latest consumed VT offset (LCVO) should be used during subscription.
-   * Otherwise, the drainer's latest processed VT offset is traditionally used.
-   */
-  public long getLocalVtSubscribeOffset(boolean isGlobalRtDivEnabled) {
-    // TODO: fallback to latestProcessed if LCVO == -1?
-    return (isGlobalRtDivEnabled)
-        ? offsetRecord.getLatestConsumedVtOffset()
-        : getLatestProcessedLocalVersionTopicOffset();
+  public long getLatestConsumedVtOffset() {
+    return offsetRecord.getLatestConsumedVtOffset();
   }
 
   public void updateLatestProcessedUpstreamVersionTopicOffset(long offset) {

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/PartitionConsumptionState.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/PartitionConsumptionState.java
@@ -810,8 +810,20 @@ public class PartitionConsumptionState {
     this.latestProcessedLocalVersionTopicOffset = offset;
   }
 
+  // TODO: this is called all over, do we need to analyze every usage since we're switching to subscribing to LCVO?
   public long getLatestProcessedLocalVersionTopicOffset() {
     return this.latestProcessedLocalVersionTopicOffset;
+  }
+
+  /**
+   * When Global RT DIV is enabled, the latest consumed VT offset (LCVO) should be used during subscription.
+   * Otherwise, the drainer's latest processed VT offset is traditionally used.
+   */
+  public long getLocalVtSubscribeOffset(boolean isGlobalRtDivEnabled) {
+    // TODO: fallback to latestProcessed if LCVO == -1?
+    return (isGlobalRtDivEnabled)
+        ? offsetRecord.getLatestConsumedVtOffset()
+        : getLatestProcessedLocalVersionTopicOffset();
   }
 
   public void updateLatestProcessedUpstreamVersionTopicOffset(long offset) {

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/PartitionConsumptionState.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/PartitionConsumptionState.java
@@ -787,16 +787,21 @@ public class PartitionConsumptionState {
     return latestProcessedUpstreamRTOffset;
   }
 
+  public long getLeaderOffset(String kafkaURL, PubSubTopicRepository pubSubTopicRepository) {
+    return getLeaderOffset(kafkaURL, pubSubTopicRepository, false);
+  }
+
   /**
    * The caller of this API should be interested in which offset currently leader should consume from now.
    * 1. If currently leader should consume from real-time topic, return upstream RT offset;
+   *    If Global RT DIV is enabled, use the value of LCRO from the Global RT DIV from StorageEngine.
    * 2. if currently leader should consume from version topic, return either remote VT offset or local VT offset, depending
    *    on whether the remote consumption flag is on.
    */
-  public long getLeaderOffset(String kafkaURL, PubSubTopicRepository pubSubTopicRepository) {
+  public long getLeaderOffset(String kafkaURL, PubSubTopicRepository pubSubTopicRepository, boolean useLcro) {
     PubSubTopic leaderTopic = getOffsetRecord().getLeaderTopic(pubSubTopicRepository);
     if (leaderTopic != null && !leaderTopic.isVersionTopic()) {
-      return getLatestProcessedUpstreamRTOffset(kafkaURL);
+      return (useLcro) ? getLatestConsumedRtOffset(kafkaURL) : getLatestProcessedUpstreamRTOffset(kafkaURL);
     } else {
       return consumeRemotely()
           ? getLatestProcessedUpstreamVersionTopicOffset()

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/PartitionConsumptionState.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/PartitionConsumptionState.java
@@ -829,7 +829,6 @@ public class PartitionConsumptionState {
     this.latestProcessedLocalVersionTopicOffset = offset;
   }
 
-  // TODO: this is called all over, do we need to analyze every usage since we're switching to subscribing to LCVO?
   public long getLatestProcessedLocalVersionTopicOffset() {
     return this.latestProcessedLocalVersionTopicOffset;
   }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/PartitionConsumptionState.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/PartitionConsumptionState.java
@@ -170,6 +170,11 @@ public class PartitionConsumptionState {
    */
   private final ConcurrentMap<String, Long> consumedUpstreamRTOffsetMap;
 
+  /**
+   * For Global RT DIV. When the RT DIV is loaded from disk, the LCRO must remain in-memory before the subscribe().
+   */
+  private final ConcurrentMap<String, Long> latestConsumedRtOffsetMap;
+
   // stores the SOP control message's producer timestamp.
   private long startOfPushTimestamp = 0;
 
@@ -251,6 +256,7 @@ public class PartitionConsumptionState {
     // Restore in-memory consumption RT upstream offset map and latest processed RT upstream offset map from the
     // checkpoint upstream offset map
     consumedUpstreamRTOffsetMap = new VeniceConcurrentHashMap<>();
+    latestConsumedRtOffsetMap = new VeniceConcurrentHashMap<>();
     latestProcessedUpstreamRTOffsetMap = new VeniceConcurrentHashMap<>();
     if (offsetRecord.getLeaderTopic() != null && Version.isRealTimeTopic(offsetRecord.getLeaderTopic())) {
       offsetRecord.cloneUpstreamOffsetMap(consumedUpstreamRTOffsetMap);
@@ -712,6 +718,14 @@ public class PartitionConsumptionState {
 
   public long getLeaderConsumedUpstreamRTOffset(String kafkaUrl) {
     return consumedUpstreamRTOffsetMap.getOrDefault(kafkaUrl, 0L);
+  }
+
+  public void updateLatestConsumedRtOffset(String brokerUrl, long offset) {
+    latestConsumedRtOffsetMap.put(brokerUrl, offset);
+  }
+
+  public long getLatestConsumedRtOffset(String brokerUrl) {
+    return latestConsumedRtOffsetMap.getOrDefault(brokerUrl, 0L);
   }
 
   public void updateLatestProcessedUpstreamRTOffset(String kafkaUrl, long offset) {

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreBufferService.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreBufferService.java
@@ -732,6 +732,7 @@ public class StoreBufferService extends AbstractStoreBufferService {
             continue;
           } else if (node instanceof SyncVtDivNode) {
             ((SyncVtDivNode) node).execute();
+            continue;
           }
 
           processRecord(

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
@@ -2248,7 +2248,7 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
       // processConsumerActions.
       storageMetadataService.clearOffset(kafkaVersionTopic, partition);
       storageMetadataService.clearStoreVersionState(kafkaVersionTopic);
-      drainerDiv.clearPartition(partition);
+      getDataIntegrityValidator().clearPartition(partition);
       throw e;
     }
   }
@@ -2287,8 +2287,7 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
         partitionConsumptionStateMap.put(partition, newPartitionConsumptionState);
 
         // Load the VT segments from the offset record into the appropriate data integrity validator
-        final KafkaDataIntegrityValidator div = (isGlobalRtDivEnabled()) ? consumerDiv : drainerDiv;
-        div.setPartitionState(PartitionTracker.VERSION_TOPIC, partition, offsetRecord);
+        getDataIntegrityValidator().setPartitionState(PartitionTracker.VERSION_TOPIC, partition, offsetRecord);
 
         long consumptionStatePrepTimeStart = System.currentTimeMillis();
         if (!checkDatabaseIntegrity(partition, topic, offsetRecord, newPartitionConsumptionState)) {
@@ -2361,7 +2360,7 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
          */
         partitionConsumptionStateMap.remove(partition);
         storageUtilizationManager.removePartition(partition);
-        drainerDiv.clearPartition(partition);
+        getDataIntegrityValidator().clearPartition(partition);
         // Reset the error partition tracking
         PartitionExceptionInfo partitionExceptionInfo = partitionIngestionExceptionList.get(partition);
         if (partitionExceptionInfo != null) {
@@ -2447,7 +2446,7 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
           ingestionTaskName,
           topicPartition);
     }
-    drainerDiv.clearPartition(partition);
+    getDataIntegrityValidator().clearPartition(partition);
     storageMetadataService.clearOffset(topicPartition.getPubSubTopic().getName(), partition);
   }
 
@@ -4922,6 +4921,11 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
 
   boolean isGlobalRtDivEnabled() {
     return isGlobalRtDivEnabled; // mainly for unit test mocks
+  }
+
+  /** When Global RT DIV is enabled the ConsumptionTask's DIV is exclusively used to validate data integrity. */
+  KafkaDataIntegrityValidator getDataIntegrityValidator() {
+    return (isGlobalRtDivEnabled()) ? consumerDiv : drainerDiv;
   }
 
   /**

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
@@ -2316,7 +2316,7 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
         reportStoreVersionTopicOffsetRewindMetrics(newPartitionConsumptionState);
 
         // Subscribe to local version topic.
-        long subscribeOffset = newPartitionConsumptionState.getLocalVtSubscribeOffset(isGlobalRtDivEnabled());
+        long subscribeOffset = getLocalVtSubscribeOffset(newPartitionConsumptionState);
         consumerSubscribe(
             topicPartition.getPubSubTopic(),
             newPartitionConsumptionState,
@@ -4927,5 +4927,14 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
 
   boolean isGlobalRtDivEnabled() {
     return isGlobalRtDivEnabled; // mainly for unit test mocks
+  }
+
+  /**
+   * When Global RT DIV is enabled, the latest consumed VT offset (LCVO) should be used during subscription.
+   * Otherwise, the drainer's latest processed VT offset is traditionally used.
+   */
+  long getLocalVtSubscribeOffset(PartitionConsumptionState pcs) {
+    // TODO: fallback to latestProcessed if LCVO == -1?
+    return (isGlobalRtDivEnabled()) ? pcs.getLatestConsumedVtOffset() : pcs.getLatestProcessedLocalVersionTopicOffset();
   }
 }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
@@ -1348,7 +1348,7 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
           metricsEnabled,
           elapsedTimeForPuttingIntoQueue);
       totalBytesRead += recordSize;
-      if (isGlobalRtDivEnabled) {
+      if (isGlobalRtDivEnabled()) {
         consumedBytesSinceLastSync.compute(kafkaUrl, (k, v) -> (v == null) ? recordSize : v + recordSize);
       }
     }
@@ -1875,7 +1875,7 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
   }
 
   protected void updateOffsetMetadataAndSyncOffset(PartitionConsumptionState pcs) {
-    updateOffsetMetadataAndSyncOffset(isGlobalRtDivEnabled() ? this.consumerDiv : this.drainerDiv, pcs);
+    updateOffsetMetadataAndSyncOffset(getDataIntegrityValidator(), pcs);
   }
 
   protected void updateOffsetMetadataAndSyncOffset(KafkaDataIntegrityValidator div, PartitionConsumptionState pcs) {

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
@@ -2316,12 +2316,13 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
         reportStoreVersionTopicOffsetRewindMetrics(newPartitionConsumptionState);
 
         // Subscribe to local version topic.
+        long subscribeOffset = newPartitionConsumptionState.getLocalVtSubscribeOffset(isGlobalRtDivEnabled());
         consumerSubscribe(
             topicPartition.getPubSubTopic(),
             newPartitionConsumptionState,
-            offsetRecord.getLocalVersionTopicOffset(),
+            subscribeOffset,
             localKafkaServer);
-        LOGGER.info("Subscribed to: {} Offset {}", topicPartition, offsetRecord.getLocalVersionTopicOffset());
+        LOGGER.info("Subscribed to: {} Offset {}", topicPartition, subscribeOffset);
         storageUtilizationManager.initPartition(partition);
         break;
       case UNSUBSCRIBE:

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
@@ -2286,14 +2286,9 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
 
         partitionConsumptionStateMap.put(partition, newPartitionConsumptionState);
 
-        /**
-         * TODO:
-         * 'kafkaDataIntegrityValidator' is used by drainer threads and we need to transfer its full responsibility to the
-         * consumer DIV which resides in the consumer thread and then gradually retire the use of drainer DIV.
-         * However, given that DIV heartbeat is yet implemented, so keep drainer DIV the way as is today and let the
-         * VERSION_TOPIC to contain both rt and vt messages.
-         */
-        drainerDiv.setPartitionState(PartitionTracker.VERSION_TOPIC, partition, offsetRecord);
+        // Load the VT segments from the offset record into the appropriate data integrity validator
+        final KafkaDataIntegrityValidator div = (isGlobalRtDivEnabled()) ? consumerDiv : drainerDiv;
+        div.setPartitionState(PartitionTracker.VERSION_TOPIC, partition, offsetRecord);
 
         long consumptionStatePrepTimeStart = System.currentTimeMillis();
         if (!checkDatabaseIntegrity(partition, topic, offsetRecord, newPartitionConsumptionState)) {

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/validation/KafkaDataIntegrityValidator.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/validation/KafkaDataIntegrityValidator.java
@@ -2,11 +2,13 @@ package com.linkedin.davinci.validation;
 
 import com.linkedin.venice.exceptions.validation.DataValidationException;
 import com.linkedin.venice.kafka.protocol.GUID;
+import com.linkedin.venice.kafka.protocol.state.ProducerPartitionState;
 import com.linkedin.venice.offsets.OffsetRecord;
 import com.linkedin.venice.pubsub.api.DefaultPubSubMessage;
 import com.linkedin.venice.utils.SparseConcurrentList;
 import com.linkedin.venice.utils.lazy.Lazy;
 import java.util.HashSet;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.IntFunction;
@@ -74,6 +76,14 @@ public class KafkaDataIntegrityValidator {
 
   public void setPartitionState(PartitionTracker.TopicType type, int partition, OffsetRecord offsetRecord) {
     registerPartition(partition).setPartitionState(type, offsetRecord, this.maxAgeInMs);
+  }
+
+  public void setPartitionState(
+      PartitionTracker.TopicType type,
+      int partition,
+      Map<CharSequence, ProducerPartitionState> producerPartitionStateMap) {
+    // TODO: can maxAgeInMs be used without offsetRecord.getMaxMessageTimeInMs()?
+    registerPartition(partition).setPartitionState(type, producerPartitionStateMap, DISABLED);
   }
 
   /**

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/validation/PartitionTracker.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/validation/PartitionTracker.java
@@ -108,6 +108,8 @@ public class PartitionTracker {
     return latestConsumedVtOffset.get();
   }
 
+  // TODO: should max be correct because it should always be increasing except for when LCVO is loaded from disk,
+  // in which case that should be when the PCS is created?
   public void updateLatestConsumedVtOffset(long offset) {
     latestConsumedVtOffset.updateAndGet(current -> Math.max(current, offset));
   }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/validation/PartitionTracker.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/validation/PartitionTracker.java
@@ -226,7 +226,7 @@ public class PartitionTracker {
     ProducerPartitionState state;
     if (TopicType.isVersionTopic(type)) {
       state = offsetRecord.getProducerPartitionState(guid);
-      offsetRecord.setLatestConsumedVtOffset(latestConsumedVtOffset.get());
+      offsetRecord.setLatestConsumedVtOffset(getLatestConsumedVtOffset());
     } else {
       state = offsetRecord.getRealTimeProducerState(type.getKafkaUrl(), guid);
     }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/validation/PartitionTracker.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/validation/PartitionTracker.java
@@ -139,8 +139,15 @@ public class PartitionTracker {
   public void setPartitionState(TopicType type, OffsetRecord offsetRecord, long maxAgeInMs) {
     long minimumRequiredRecordProducerTimestamp =
         maxAgeInMs == DISABLED ? DISABLED : offsetRecord.getMaxMessageTimeInMs() - maxAgeInMs;
+    setPartitionState(type, offsetRecord.getProducerPartitionStateMap(), minimumRequiredRecordProducerTimestamp);
+  }
+
+  public void setPartitionState(
+      TopicType type,
+      Map<CharSequence, ProducerPartitionState> producerPartitionStateMap,
+      long minimumRequiredRecordProducerTimestamp) {
     Iterator<Map.Entry<CharSequence, ProducerPartitionState>> iterator =
-        offsetRecord.getProducerPartitionStateMap().entrySet().iterator();
+        producerPartitionStateMap.entrySet().iterator();
     Map.Entry<CharSequence, ProducerPartitionState> entry;
     GUID producerGuid;
     ProducerPartitionState producerPartitionState;

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTaskTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTaskTest.java
@@ -3908,7 +3908,7 @@ public abstract class StoreIngestionTaskTest {
     doReturn(topicSwitchWrapper).when(mockPcs).getTopicSwitch();
     OffsetRecord mockOffsetRecord = mock(OffsetRecord.class);
     doReturn(pubSubTopicRepository.getTopic("test_rt")).when(mockOffsetRecord).getLeaderTopic(any());
-    doReturn(1000L).when(mockPcs).getLeaderOffset(anyString(), any());
+    doReturn(1000L).when(mockPcs).getLeaderOffset(anyString(), any(), anyBoolean());
     doReturn(mockOffsetRecord).when(mockPcs).getOffsetRecord();
     // Test whether consumedUpstreamRTOffsetMap is updated when leader subscribes to RT after state transition
     ingestionTask.startConsumingAsLeader(mockPcs);
@@ -3923,7 +3923,7 @@ public abstract class StoreIngestionTaskTest {
       doReturn(topicSwitchWrapper).when(mock).getTopicSwitch();
       OffsetRecord mockOR = mock(OffsetRecord.class);
       doReturn(rtTopic).when(mockOR).getLeaderTopic(any());
-      doReturn(1000L).when(mock).getLeaderOffset(anyString(), any());
+      doReturn(1000L).when(mock).getLeaderOffset(anyString(), any(), anyBoolean());
       System.out.println(mockOR.getLeaderTopic(null));
       doReturn(1000L).when(mockOR).getUpstreamOffset(anyString());
       doReturn(1000L).when(mock).getLatestProcessedUpstreamRTOffset(anyString());
@@ -3942,7 +3942,7 @@ public abstract class StoreIngestionTaskTest {
     // Test alternative branch of the code
     Supplier<PartitionConsumptionState> mockPcsSupplier2 = () -> {
       PartitionConsumptionState mock = mockPcsSupplier.get();
-      doReturn(-1L).when(mock).getLeaderOffset(anyString(), any());
+      doReturn(-1L).when(mock).getLeaderOffset(anyString(), any(), anyBoolean());
       doReturn(-1L).when(mock).getLatestProcessedUpstreamRTOffset(anyString());
       doReturn(new PubSubTopicPartitionImpl(rtTopic, 0)).when(mock).getSourceTopicPartition(any());
       return mock;
@@ -5832,7 +5832,8 @@ public abstract class StoreIngestionTaskTest {
     LeaderFollowerStoreIngestionTask ingestionTask =
         aaEnabled ? mock(ActiveActiveStoreIngestionTask.class) : mock(LeaderFollowerStoreIngestionTask.class);
     doCallRealMethod().when(ingestionTask).resubscribeAsLeader(any());
-    doCallRealMethod().when(ingestionTask).prepareOffsetCheckpointAndStartConsumptionAsLeader(any(), any());
+    doCallRealMethod().when(ingestionTask)
+        .prepareOffsetCheckpointAndStartConsumptionAsLeader(any(), any(), anyBoolean());
     PubSubTopicRepository topicRepository = new PubSubTopicRepository();
     when(ingestionTask.getPubSubTopicRepository()).thenReturn(topicRepository);
     OffsetRecord offsetRecord = mock(OffsetRecord.class);
@@ -5860,7 +5861,7 @@ public abstract class StoreIngestionTaskTest {
     when(ingestionTask.getConsumptionSourceKafkaAddress(pcs)).thenReturn(upstreamUrlSet);
     when(pcs.getLatestProcessedUpstreamRTOffsetMap()).thenReturn(upstreamOffsetMap);
     doCallRealMethod().when(pcs).getLatestProcessedUpstreamRTOffset(anyString());
-    doCallRealMethod().when(pcs).getLeaderOffset(anyString(), any());
+    doCallRealMethod().when(pcs).getLeaderOffset(anyString(), any(), anyBoolean());
     ingestionTask.resubscribeAsLeader(pcs);
 
     ArgumentCaptor<String> urlCaptor = ArgumentCaptor.forClass(String.class);
@@ -5884,7 +5885,8 @@ public abstract class StoreIngestionTaskTest {
   public void testResubscribeAsLeaderFromVersionTopic(boolean aaEnabled) throws InterruptedException {
     LeaderFollowerStoreIngestionTask ingestionTask =
         aaEnabled ? mock(ActiveActiveStoreIngestionTask.class) : mock(LeaderFollowerStoreIngestionTask.class);
-    doCallRealMethod().when(ingestionTask).prepareOffsetCheckpointAndStartConsumptionAsLeader(any(), any());
+    doCallRealMethod().when(ingestionTask)
+        .prepareOffsetCheckpointAndStartConsumptionAsLeader(any(), any(), anyBoolean());
     PubSubTopicRepository topicRepository = new PubSubTopicRepository();
     when(ingestionTask.getPubSubTopicRepository()).thenReturn(topicRepository);
     InternalAvroSpecificSerializer<PartitionState> partitionStateSerializer =
@@ -5910,7 +5912,7 @@ public abstract class StoreIngestionTaskTest {
     doCallRealMethod().when(pcs).getLeaderOffset(anyString(), any());
     when(pcs.getLatestProcessedUpstreamVersionTopicOffset()).thenReturn(100L);
     when(pcs.consumeRemotely()).thenReturn(true);
-    ingestionTask.prepareOffsetCheckpointAndStartConsumptionAsLeader(pubSubTopic, pcs);
+    ingestionTask.prepareOffsetCheckpointAndStartConsumptionAsLeader(pubSubTopic, pcs, false);
 
     if (aaEnabled) {
       Assert.assertEquals(offsetRecord.getUpstreamOffset("dc-1"), -1);

--- a/internal/venice-common/src/main/java/com/linkedin/venice/offsets/OffsetRecord.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/offsets/OffsetRecord.java
@@ -9,6 +9,7 @@ import com.linkedin.venice.kafka.protocol.state.PartitionState;
 import com.linkedin.venice.kafka.protocol.state.ProducerPartitionState;
 import com.linkedin.venice.pubsub.PubSubTopicRepository;
 import com.linkedin.venice.pubsub.adapter.kafka.ApacheKafkaOffsetPosition;
+import com.linkedin.venice.pubsub.api.PubSubPosition;
 import com.linkedin.venice.pubsub.api.PubSubTopic;
 import com.linkedin.venice.serialization.avro.InternalAvroSpecificSerializer;
 import com.linkedin.venice.utils.concurrent.VeniceConcurrentHashMap;
@@ -318,10 +319,10 @@ public class OffsetRecord {
 
   public long getLatestConsumedVtOffset() {
     try {
-      return ApacheKafkaOffsetPosition.of(this.partitionState.getLastConsumedVersionTopicPubSubPosition())
-          .getNumericOffset();
+      PubSubPosition pos = ApacheKafkaOffsetPosition.of(partitionState.getLastConsumedVersionTopicPubSubPosition());
+      return pos.getNumericOffset();
     } catch (IOException e) {
-      throw new VeniceException(e);
+      return -1;
     }
   }
 
@@ -338,12 +339,12 @@ public class OffsetRecord {
 
   @Override
   public String toString() {
-    return "OffsetRecord{" + "localVersionTopicOffset=" + getLocalVersionTopicOffset() + ", upstreamOffset="
-        + getPartitionUpstreamOffsetString() + ", leaderTopic=" + getLeaderTopic() + ", offsetLag=" + getOffsetLag()
-        + ", eventTimeEpochMs=" + getMaxMessageTimeInMs() + ", latestProducerProcessingTimeInMs="
-        + getLatestProducerProcessingTimeInMs() + ", isEndOfPushReceived=" + isEndOfPushReceived() + ", databaseInfo="
-        + getDatabaseInfo() + ", realTimeProducerState=" + getRealTimeProducerState() + ", recordTransformerClassHash="
-        + getRecordTransformerClassHash() + '}';
+    return "OffsetRecord{" + "localVersionTopicOffset=" + getLocalVersionTopicOffset() + ", latestConsumedVtOffset="
+        + getLatestConsumedVtOffset() + ", upstreamOffset=" + getPartitionUpstreamOffsetString() + ", leaderTopic="
+        + getLeaderTopic() + ", offsetLag=" + getOffsetLag() + ", eventTimeEpochMs=" + getMaxMessageTimeInMs()
+        + ", latestProducerProcessingTimeInMs=" + getLatestProducerProcessingTimeInMs() + ", isEndOfPushReceived="
+        + isEndOfPushReceived() + ", databaseInfo=" + getDatabaseInfo() + ", realTimeProducerState="
+        + getRealTimeProducerState() + ", recordTransformerClassHash=" + getRecordTransformerClassHash() + '}';
   }
 
   /**


### PR DESCRIPTION
<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat], [protocol]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## Summary
<!--
Describe
- What problem are you trying to solve
- What issues or limitations exist in the current code
- Why this change is necessary 
-->
The VT and RT DIV need to be loaded from disk, replace the in-memory DIV, and the latest consumed offset needs to be used when subscribing to VT and RT. This happens primarily during the state transitions (`OFFLINE_TO_STANDBY`, `STANDBY_TO_LEADER`, etc.).

###  Code changes
- [X] Added new code behind **a config**. If so list the config names and their default values in the PR description.

* Use the LCVO from the VT DIV from the `OffsetRecord` to subscribe to VT in `processCommonConsumerAction#SUBSCRIBE` and in the  `LEADER_TO_STANDBY` transition.
* Added mode in `prepareOffsetCheckpointAndStartConsumptionAsLeader()` and `getLeaderOffset()` to use LCRO from the Global RT DIV rather than the `latestProcessedUpstreamRtOffset`, which is set by the drainer.
* Added LCRO map in PCS to store the LCRO when the `GlobalRtDivState` is loaded from disk. This will be used as the subscribe offset for RT later in `startConsumingAsLeader()` / `prepareOffsetCheckpointAndStartConsumptionAsLeader()`.
* `LeaderProducedRecordContext` cannot be reused when creating the `LeaderProducerCallback`, because it's used by the previous message, so it needs to be cloned when passed into the callback.
* Fixed `SyncVtDivNode` progressing with a `FakePubSubRecord` and causing NPE because it's missing a `continue`. The `SyncVtDivNode.execute()` should be the only code that the drainer executes, because it's a non-standard operation.
* Changed `OffsetRecord.getLatestConsumedVtOffset()` to return `-1` by default rather than throwing an `Exception`.
* Added a version of the `setPartitionState()` method in `KafkaDataIntegrityValidator` and `PartitionTracker` that supports `ProducerPartitionState`, which is the format of the `GlobalRtDivState` avro object.
* Added helper `getDataIntegrityValidator()` which will return the `consumerDiv` or `drainerDiv` based on the value of the `isGlobalRtDivEnabled()` feature flag.

###  **Concurrency-Specific Checks**
Both reviewer and PR author to verify
- [X] Code has **no race conditions** or **thread safety issues**.
- [X] Proper **synchronization mechanisms** (e.g., `synchronized`, `RWLock`) are used where needed.
- [X] No **blocking calls** inside critical sections that could lead to deadlocks or performance degradation.
- [X] Verified **thread-safe collections** are used (e.g., `ConcurrentHashMap`, `CopyOnWriteArrayList`).
- [X] Validated proper exception handling in multi-threaded code to avoid silent thread termination.

## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
- [X] Verified backward compatibility (if applicable).

Used existing unit tests. Will do more testing later in the integration test phase.

## Does this PR introduce any user-facing or breaking changes?
<!--  
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [X] No. You can skip the rest of this section.