### PR TITLE
[venice-test-common] Fix test flakiness

### DIFF
--- a/.github/workflows/VeniceCI-E2ETests.yml
+++ b/.github/workflows/VeniceCI-E2ETests.yml
@@ -2673,6 +2673,101 @@ jobs:
           key: ${{ secrets.BUILDPULSE_ACCESS_KEY_ID }}
           secret: ${{ secrets.BUILDPULSE_SECRET_ACCESS_KEY }}
 
+  IntegrationTests_1450:
+    name: IntegrationTests_1450
+    strategy:
+      fail-fast: false
+      matrix:
+        jdk: [17]
+    runs-on: ubuntu-latest
+    permissions:
+     id-token: write
+     contents: read
+     checks: write
+     pull-requests: write
+     issues: write
+    timeout-minutes: 120
+    concurrency:
+     group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-jdk${{ matrix.jdk }}-IntegrationTests_1450
+     cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Set up JDK
+        uses: actions/setup-java@v4
+        with:
+          java-version: ${{ matrix.jdk }}
+          distribution: 'temurin'
+          cache: 'gradle'
+      - shell: bash
+        run: |
+          git remote set-head origin --auto
+          git remote add upstream https://github.com/linkedin/venice
+          git fetch upstream
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+        with:
+          add-job-summary: never
+      - name: Run Integration Tests
+        run: ./gradlew --continue --no-daemon -DforkEvery=1 -DmaxParallelForks=1 integrationTests_1450
+      - name: Package Build Artifacts
+        if: success() || failure()
+        shell: bash
+        run: |
+          mkdir ${{ github.job }}-artifacts
+          echo "Repository owner: ${{ github.repository_owner }}"
+          echo "Repository name: ${{ github.repository }}"
+          echo "event name: ${{ github.event_name }}"
+          find . -path "**/build/reports/*" -or -path "**/build/test-results/*" > artifacts.list
+          rsync -R --files-from=artifacts.list . ${{ github.job }}-artifacts
+          tar -zcvf ${{ github.job }}-jdk${{ matrix.jdk }}-logs.tar.gz ${{ github.job }}-artifacts
+      - name: Generate Fork Repo Test Reports
+        if: ${{ (github.repository_owner != 'linkedin') && (success() || failure()) }}
+        uses: dorny/test-reporter@v1.9.1
+        env:
+         NODE_OPTIONS: --max-old-space-size=9182
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          name: ${{ github.job }} Test Reports       # Name where it report the test results
+          path: '**/TEST-*.xml'
+          fail-on-error: 'false'
+          max-annotations: '10'
+          list-tests: 'all'
+          list-suites: 'all'
+          reporter: java-junit
+      - name: Publish Test Report
+        continue-on-error: true
+        env:
+          NODE_OPTIONS: "--max_old_space_size=8192"
+        uses: mikepenz/action-junit-report@v5
+        if: always()
+        with:
+          check_name: ${{ github.job }}-jdk${{ matrix.jdk }} Report
+          comment: false
+          annotate_only: true
+          flaky_summary: true
+          commit: ${{github.event.workflow_run.head_sha}}
+          detailed_summary: true
+          report_paths: '**/build/test-results/test/TEST-*.xml'
+      - name: Upload Build Artifacts
+        if: success() || failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ github.job }}
+          path: ${{ github.job }}-jdk${{ matrix.jdk }}-logs.tar.gz
+          retention-days: 30
+      - name: Upload test results to BuildPulse for flaky test detection
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main' && !cancelled()
+        uses: buildpulse/buildpulse-action@main
+        with:
+          account: 100582612927
+          repository: 100441445875
+          path: |
+            **/TEST-*.xml
+          key: ${{ secrets.BUILDPULSE_ACCESS_KEY_ID }}
+          secret: ${{ secrets.BUILDPULSE_SECRET_ACCESS_KEY }}
+
   IntegrationTests_1500:
     name: IntegrationTests_1500
     strategy:
@@ -2964,7 +3059,7 @@ jobs:
       matrix:
         jdk: [17]
     runs-on: ubuntu-latest
-    needs: [IntegrationTests_1000, IntegrationTests_1010, IntegrationTests_1020, IntegrationTests_1030, IntegrationTests_1040, IntegrationTests_1050, IntegrationTests_1060, IntegrationTests_1070, IntegrationTests_1080, IntegrationTests_1090, IntegrationTests_1100, IntegrationTests_1110, IntegrationTests_1120, IntegrationTests_1130, IntegrationTests_1200, IntegrationTests_1210, IntegrationTests_1220, IntegrationTests_1230, IntegrationTests_1240, IntegrationTests_1250, IntegrationTests_1260, IntegrationTests_1270, IntegrationTests_1280, IntegrationTests_1400, IntegrationTests_1410, IntegrationTests_1420, IntegrationTests_1430, IntegrationTests_1440, IntegrationTests_1500, IntegrationTests_1550, IntegrationTests_9999]
+    needs: [IntegrationTests_1000, IntegrationTests_1010, IntegrationTests_1020, IntegrationTests_1030, IntegrationTests_1040, IntegrationTests_1050, IntegrationTests_1060, IntegrationTests_1070, IntegrationTests_1080, IntegrationTests_1090, IntegrationTests_1100, IntegrationTests_1110, IntegrationTests_1120, IntegrationTests_1130, IntegrationTests_1200, IntegrationTests_1210, IntegrationTests_1220, IntegrationTests_1230, IntegrationTests_1240, IntegrationTests_1250, IntegrationTests_1260, IntegrationTests_1270, IntegrationTests_1280, IntegrationTests_1400, IntegrationTests_1410, IntegrationTests_1420, IntegrationTests_1430, IntegrationTests_1440, IntegrationTests_1450, IntegrationTests_1500, IntegrationTests_1550, IntegrationTests_9999]
     timeout-minutes: 20
     steps:
     - name: NoOp

--- a/internal/venice-test-common/build.gradle
+++ b/internal/venice-test-common/build.gradle
@@ -218,6 +218,9 @@ def integrationTestBuckets = [
       "com.linkedin.venice.endToEnd.TestMaterializedViewEndToEnd",
       "com.linkedin.venice.endToEnd.TestDeferredVersionSwap"
   ],
+  "1450": [
+      "com.linkedin.venice.controller.TestVeniceHelixAdminWithSharedEnvironment"
+  ],
   "1500":[
       "com.linkedin.venice.multicluster.TestMetadataOperationInMultiCluster",
       "com.linkedin.venice.endToEnd.MetaSystemStoreTest",
@@ -233,6 +236,12 @@ def integrationTestBuckets = [
         "com.linkedin.venice.endToEnd.TestStaleDataVisibility"]
 ]
 
+def integrationTestExcludes = [
+    "1430":[
+        "com.linkedin.venice.controller.TestVeniceHelixAdminWithSharedEnvironment"
+    ]
+]
+
 integrationTestBuckets.each { name, patterns ->
   task "integrationTests_${name}" (type: Test) {
     ext {
@@ -241,6 +250,10 @@ integrationTestBuckets.each { name, patterns ->
     filter {
       patterns.each { pattern ->
         includeTestsMatching pattern
+      }
+      integrationTestExcludes.get(name, []).each {
+        excludedPattern ->
+          excludeTestsMatching excludedPattern
       }
     }
     configure integrationTestConfigs


### PR DESCRIPTION
## Problem Statement
Integration test flakiness with `TestVeniceHelixAdminWithSharedEnvironment`.

## Solution
Move `TestVeniceHelixAdminWithSharedEnvironment` to separate integration test bucket

###  Code changes
- [ ] Added new code behind **a config**. If so list the config names and their default values in the PR description.
- [ ] Introduced new **log lines**. 
  - [ ] Confirmed if logs need to be **rate limited** to avoid excessive logging.

###  **Concurrency-Specific Checks**
None

## How was this PR tested?
`./gradlew test`

## Does this PR introduce any user-facing or breaking changes?
- [X] No. You can skip the rest of this section.
- [ ] Yes. Clearly explain the behavior change and its impact.