### PR TITLE
[controller] Mark push status as ERROR for killed jobs

### DIFF
--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceHelixAdmin.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceHelixAdmin.java
@@ -6737,10 +6737,14 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
     Long statusUpdateTimestamp = statusAndDetails.getStatusUpdateTimestamp();
     if (executionStatus.equals(ExecutionStatus.NOT_CREATED)) {
       StringBuilder moreDetailsBuilder = new StringBuilder(details == null ? "" : details + " and ");
+      Version version = store.getVersion(versionNumber);
 
       // Check whether cluster is in maintenance mode or not
       if (maintenanceSignal != null) {
         moreDetailsBuilder.append("Cluster: ").append(clusterName).append(" is in maintenance mode");
+      } else if (version != null && version.getStatus() == KILLED) {
+        moreDetailsBuilder.append("Push job was killed for: ").append(kafkaTopic);
+        return new OfflinePushStatusInfo(ExecutionStatus.ERROR, statusUpdateTimestamp, moreDetailsBuilder.toString());
       } else {
         moreDetailsBuilder.append("Version creation for topic: ").append(kafkaTopic).append(" got delayed");
       }

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceParentHelixAdmin.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceParentHelixAdmin.java
@@ -3764,9 +3764,11 @@ public class VeniceParentHelixAdmin implements Admin {
         getFinalReturnStatus(statuses, childRegions, numChildRegionsFailedToFetchStatus, currentReturnStatusDetails);
 
     // Do not delete parent Kafka if its part of targeted colo push to prevent concurrent pushes
+    String storeName = Version.parseStoreFromKafkaTopicName(kafkaTopic);
+    int versionNum = Version.parseVersionFromKafkaTopicName(kafkaTopic);
     if (currentReturnStatus.isTerminal()) {
-      String storeName = Version.parseStoreFromKafkaTopicName(kafkaTopic);
-      int versionNum = Version.parseVersionFromKafkaTopicName(kafkaTopic);
+      LOGGER.info("Received terminal status: {} for topic: {}", currentReturnStatus, kafkaTopic);
+
       HelixVeniceClusterResources resources = getVeniceHelixAdmin().getHelixVeniceClusterResources(clusterName);
 
       try (AutoCloseableLock ignore = resources.getClusterLockManager().createStoreWriteLock(storeName)) {
@@ -3818,8 +3820,6 @@ public class VeniceParentHelixAdmin implements Admin {
     } else {
       // If the aggregate status is not terminal, but the parent version status is marked as KILLED, we should mark the
       // push job status as terminal (ERROR) as job was killed
-      String storeName = Version.parseStoreFromKafkaTopicName(kafkaTopic);
-      int versionNum = Version.parseVersionFromKafkaTopicName(kafkaTopic);
       Store parentStore = getStore(clusterName, storeName);
       Version parentStoreVersion = parentStore.getVersion(versionNum);
       if (parentStoreVersion.getStatus().equals(KILLED)) {

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceParentHelixAdmin.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceParentHelixAdmin.java
@@ -72,7 +72,9 @@ import static com.linkedin.venice.meta.HybridStoreConfigImpl.DEFAULT_HYBRID_TIME
 import static com.linkedin.venice.meta.HybridStoreConfigImpl.DEFAULT_REAL_TIME_TOPIC_NAME;
 import static com.linkedin.venice.meta.HybridStoreConfigImpl.DEFAULT_REWIND_TIME_IN_SECONDS;
 import static com.linkedin.venice.meta.Version.VERSION_SEPARATOR;
-import static com.linkedin.venice.meta.VersionStatus.*;
+import static com.linkedin.venice.meta.VersionStatus.KILLED;
+import static com.linkedin.venice.meta.VersionStatus.ONLINE;
+import static com.linkedin.venice.meta.VersionStatus.PUSHED;
 import static com.linkedin.venice.serialization.avro.AvroProtocolDefinition.BATCH_JOB_HEARTBEAT;
 import static com.linkedin.venice.serialization.avro.AvroProtocolDefinition.PUSH_JOB_DETAILS;
 import static com.linkedin.venice.views.VeniceView.VIEW_NAME_SEPARATOR;

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceParentHelixAdmin.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceParentHelixAdmin.java
@@ -3774,7 +3774,7 @@ public class VeniceParentHelixAdmin implements Admin {
         LOGGER.info("Received terminal status: {} for topic: {}", currentReturnStatus, kafkaTopic);
 
         // Do not truncate the parent version topic if it is a push w/ deferred swap to prevent concurrent pushes
-        // Otherwise, truncate the parent version topic and updating the version status
+        // Otherwise, truncate the parent version topic and update the version status
         boolean isDeferredSwap = version != null && version.isVersionSwapDeferred();
         if (!isDeferredSwap || !StringUtils.isEmpty(targetedRegions)) {
           handleTerminalJobStatus(
@@ -3793,8 +3793,7 @@ public class VeniceParentHelixAdmin implements Admin {
         // If the aggregate status is not terminal, but the parent version status is marked as KILLED, we should mark
         // the
         // push job status as terminal (ERROR) as job was killed
-        Version parentStoreVersion = parentStore.getVersion(versionNum);
-        if (parentStoreVersion.getStatus().equals(KILLED)) {
+        if (version.getStatus().equals(KILLED)) {
           LOGGER.info(
               "Marking execution status as ERROR for store {} because parent version status is KILLED",
               storeName);

--- a/services/venice-controller/src/test/java/com/linkedin/venice/controller/TestVeniceParentHelixAdmin.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/controller/TestVeniceParentHelixAdmin.java
@@ -1861,9 +1861,9 @@ public class TestVeniceParentHelixAdmin extends AbstractTestVeniceParentHelixAdm
     TopicManager topicManager = mock(TopicManager.class);
 
     Map<String, ControllerClient> notCreatedMap = new HashMap<>();
-    notCreatedMap.put("cluster", clientMap.get(ExecutionStatus.NOT_CREATED));
+    notCreatedMap.put("cluster", clientMap.get(ExecutionStatus.ERROR));
     notCreatedMap.put("cluster2", clientMap.get(ExecutionStatus.NOT_CREATED));
-    notCreatedMap.put("cluster3", clientMap.get(ExecutionStatus.NOT_CREATED));
+    notCreatedMap.put("cluster3", clientMap.get(ExecutionStatus.ERROR));
 
     Set<PubSubTopic> pubSubTopics = new HashSet<>();
     pubSubTopics.add(pubSubTopicRepository.getTopic("topic_v1"));
@@ -1877,6 +1877,13 @@ public class TestVeniceParentHelixAdmin extends AbstractTestVeniceParentHelixAdm
     doReturn(version).when(store).getVersion(anyInt());
     doReturn(VersionStatus.KILLED).when(version).getStatus();
     doReturn(Version.PushType.BATCH).when(version).getPushType();
+
+    HelixVeniceClusterResources resources = mock(HelixVeniceClusterResources.class);
+    doReturn(mock(ClusterLockManager.class)).when(resources).getClusterLockManager();
+    doReturn(resources).when(internalAdmin).getHelixVeniceClusterResources(anyString());
+    ReadWriteStoreRepository repository = mock(ReadWriteStoreRepository.class);
+    doReturn(repository).when(resources).getStoreMetadataRepository();
+    doReturn(store).when(repository).getStore(anyString());
 
     Admin.OfflinePushStatusInfo offlineJobStatus =
         parentAdmin.getOffLineJobStatus("IGNORED", "topic1_v1", notCreatedMap);


### PR DESCRIPTION
<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat], [protocol]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## Problem Statement
<!--
Describe
- What problem are you trying to solve
- What issues or limitations exist in the current code
- Why this change is necessary 
-->
When a repush job is killed, an incorrect push status of `NOT_CREATED` is sometimes surfaced. This causes vpj to continue to poll for the job status for 24 hours until it times out as it never receives a terminal job status. This also makes it difficult to triage as we have to dig through the logs to find out if the job was killed due to another push being submitted vs actually failing due to falling out of the 24 hour sla

## Solution
<!--
Describe
- What changes you are making and why. 
- How these changes solve the problem.
- Any performance considerations or trade-offs. 
- Describe what testings you have done, for example, performance testing etc.
-->
When a push job is killed, the version statuses are marked as `KILLED`. We can use this status to know if a job was killed even if the aggregate push status is not in a terminal state. This pr adds a check to `getOfflineJobStatus` to check for a `KILLED` version status and if it is `KILLED`, we will mark the push job as `ERROR` so vpj stops polling

###  Code changes
- [ ] Added new code behind **a config**. If so list the config names and their default values in the PR description.
- [x] Introduced new **log lines**. 
  - [x] Confirmed if logs need to be **rate limited** to avoid excessive logging.

###  **Concurrency-Specific Checks**
Both reviewer and PR author to verify
- [x] Code has **no race conditions** or **thread safety issues**.
- [x] Proper **synchronization mechanisms** (e.g., `synchronized`, `RWLock`) are used where needed.
- [x] No **blocking calls** inside critical sections that could lead to deadlocks or performance degradation.
- [x] Verified **thread-safe collections** are used (e.g., `ConcurrentHashMap`, `CopyOnWriteArrayList`).
- [x] Validated proper exception handling in multi-threaded code to avoid silent thread termination.


## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->

- [x] New unit tests added.
- [ ] New integration tests added.
- [ ] Modified or extended existing tests.
- [ ] Verified backward compatibility (if applicable).

## Does this PR introduce any user-facing or breaking changes?
<!--  
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Clearly explain the behavior change and its impact.