### PR TITLE
[server] Allow retry for fetching RMD deserializer

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/replication/merge/RmdSerDe.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/replication/merge/RmdSerDe.java
@@ -36,7 +36,7 @@ public class RmdSerDe {
   private BiIntKeyCache<RecordDeserializer<GenericRecord>> deserializerCache;
   private final boolean fastAvroEnabled;
 
-  private final static int DEFAULT_DELAY_TIME_BETWEEN_RETRIES = 2; // seconds
+  private final static int DEFAULT_DELAY_TIME_BETWEEN_RETRIES = 1; // seconds
 
   public RmdSerDe(StringAnnotatedStoreSchemaCache annotatedStoreSchemaCache, int rmdVersionId) {
     this(annotatedStoreSchemaCache, rmdVersionId, true);
@@ -152,7 +152,7 @@ public class RmdSerDe {
   }
 
   // For testing purpose only.
-  public void setDeserializerCache(BiIntKeyCache<RecordDeserializer<GenericRecord>> deserializerCache) {
+  void setDeserializerCache(BiIntKeyCache<RecordDeserializer<GenericRecord>> deserializerCache) {
     this.deserializerCache = deserializerCache;
   }
 }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/replication/merge/RmdSerDe.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/replication/merge/RmdSerDe.java
@@ -76,7 +76,7 @@ public class RmdSerDe {
             rmdWithValueSchemaID.position(),
             rmdWithValueSchemaID.remaining());
 
-    // We allow 5 retries of 2 sec delay between each attempt to get the deserializer in case of a slow schema
+    // We allow 5 retries of 1 sec delay between each attempt to get the deserializer in case of a slow schema
     // repository.
     GenericRecord rmdRecord = getRmdDeserializerWithRetry(valueSchemaId, valueSchemaId, 5).deserialize(binaryDecoder);
     rmdWithValueSchemaId.setValueSchemaId(valueSchemaId);

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/replication/merge/RmdSerDe.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/replication/merge/RmdSerDe.java
@@ -8,9 +8,12 @@ import com.linkedin.venice.exceptions.VeniceException;
 import com.linkedin.venice.schema.rmd.RmdSchemaEntry;
 import com.linkedin.venice.serializer.RecordDeserializer;
 import com.linkedin.venice.serializer.RecordSerializer;
+import com.linkedin.venice.utils.RetryUtils;
 import com.linkedin.venice.utils.SparseConcurrentList;
 import com.linkedin.venice.utils.collections.BiIntKeyCache;
 import java.nio.ByteBuffer;
+import java.time.Duration;
+import java.util.Collections;
 import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericRecord;
 import org.apache.avro.io.OptimizedBinaryDecoder;
@@ -30,8 +33,10 @@ public class RmdSerDe {
   private final int rmdVersionId;
   private final SparseConcurrentList<Schema> rmdSchemaIndexedByValueSchemaId;
   private final SparseConcurrentList<RecordSerializer<GenericRecord>> rmdSerializerIndexedByValueSchemaId;
-  private final BiIntKeyCache<RecordDeserializer<GenericRecord>> deserializerCache;
+  private BiIntKeyCache<RecordDeserializer<GenericRecord>> deserializerCache;
   private final boolean fastAvroEnabled;
+
+  private final static int DEFAULT_DELAY_TIME_BETWEEN_RETRIES = 2; // seconds
 
   public RmdSerDe(StringAnnotatedStoreSchemaCache annotatedStoreSchemaCache, int rmdVersionId) {
     this(annotatedStoreSchemaCache, rmdVersionId, true);
@@ -70,7 +75,10 @@ public class RmdSerDe {
             rmdWithValueSchemaID.array(), // bytes of replication metadata with NO value schema ID.
             rmdWithValueSchemaID.position(),
             rmdWithValueSchemaID.remaining());
-    GenericRecord rmdRecord = getRmdDeserializer(valueSchemaId, valueSchemaId).deserialize(binaryDecoder);
+
+    // We allow 5 retries of 2 sec delay between each attempt to get the deserializer in case of a slow schema
+    // repository.
+    GenericRecord rmdRecord = getRmdDeserializerWithRetry(valueSchemaId, valueSchemaId, 5).deserialize(binaryDecoder);
     rmdWithValueSchemaId.setValueSchemaId(valueSchemaId);
     rmdWithValueSchemaId.setRmdProtocolVersionId(rmdVersionId);
     rmdWithValueSchemaId.setRmdRecord(rmdRecord);
@@ -99,7 +107,12 @@ public class RmdSerDe {
   private Schema generateRmdSchema(final int valueSchemaId) {
     RmdSchemaEntry rmdSchemaEntry = this.annotatedStoreSchemaCache.getRmdSchema(valueSchemaId, this.rmdVersionId);
     if (rmdSchemaEntry == null) {
-      throw new VeniceException("Unable to fetch replication metadata schema from schema repository");
+      throw new VeniceException(
+          String.format(
+              "Unable to fetch replication metadata schema from schema repository for store: %s and value schema ID: %d and RMD version ID: %d",
+              annotatedStoreSchemaCache.getStoreName(),
+              valueSchemaId,
+              this.rmdVersionId));
     }
     return rmdSchemaEntry.getSchema();
   }
@@ -108,10 +121,38 @@ public class RmdSerDe {
     return this.deserializerCache.get(writerSchemaID, readerSchemaID);
   }
 
+  private RecordDeserializer<GenericRecord> getRmdDeserializerWithRetry(
+      int writerSchemaID,
+      int readerSchemaID,
+      int maxRetry) {
+    return RetryUtils.executeWithMaxAttempt(() -> {
+      try {
+        return this.deserializerCache.get(writerSchemaID, readerSchemaID);
+      } catch (VeniceException e) {
+        // Adjusting the error message to include the store name and schema IDs for better debugging.
+        throw new VeniceException(
+            String.format(
+                "Failed to fetch RMD deserializer for store: %s with writer schema ID: %d and reader schema ID: %d",
+                annotatedStoreSchemaCache.getStoreName(),
+                writerSchemaID,
+                readerSchemaID),
+            e);
+      }
+    },
+        maxRetry,
+        Duration.ofSeconds(DEFAULT_DELAY_TIME_BETWEEN_RETRIES),
+        Collections.singletonList(VeniceException.class));
+  }
+
   private RecordSerializer<GenericRecord> generateRmdSerializer(int valueSchemaId) {
     Schema replicationMetadataSchema = getRmdSchema(valueSchemaId);
     return fastAvroEnabled
         ? MapOrderPreservingFastSerDeFactory.getSerializer(replicationMetadataSchema)
         : MapOrderPreservingSerDeFactory.getSerializer(replicationMetadataSchema);
+  }
+
+  // For testing purpose only.
+  public void setDeserializerCache(BiIntKeyCache<RecordDeserializer<GenericRecord>> deserializerCache) {
+    this.deserializerCache = deserializerCache;
   }
 }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/replication/merge/StringAnnotatedStoreSchemaCache.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/replication/merge/StringAnnotatedStoreSchemaCache.java
@@ -105,4 +105,8 @@ public class StringAnnotatedStoreSchemaCache {
   public RmdSchemaEntry getRmdSchema(int valueSchemaId, int rmdSchemaProtocolId) {
     return rmdSchemaEntryMapCache.get(valueSchemaId, rmdSchemaProtocolId);
   }
+
+  public String getStoreName() {
+    return storeName;
+  }
 }

--- a/internal/venice-client-common/src/main/java/com/linkedin/venice/utils/RetryUtils.java
+++ b/internal/venice-client-common/src/main/java/com/linkedin/venice/utils/RetryUtils.java
@@ -285,7 +285,7 @@ public class RetryUtils {
   }
 
   private static <T> void logAttemptWithFailure(ExecutionAttemptedEvent<T> executionAttemptedEvent) {
-    LOGGER.error(
+    LOGGER.warn(
         "Execution failed with message {} on attempt count {}",
         executionAttemptedEvent.getLastFailure().getMessage(),
         executionAttemptedEvent.getAttemptCount());


### PR DESCRIPTION
RMD schemas are used to build the RMD deserializer objects. RMD schemas are retrieved and cached in memory by listening to the corresponding ZooKeeper node for any updates to the schemas. In this procedure, there could be delays in getting the most up-to-date schema updates. When it happened, the workflow to build the latest RMD deserializer object could fail and related StoreIngestionTask thread could terminate.

It is probably impossible to eliminate such delays and this change allows for retries in building the RMD deserializer object. The idea is to give more chances for the internal ZK listener to receive the schema updates even if the first several attempts might fail. However, we can't afford infinite retries as this is done in the shared consumer threads and it could impact other stores. In this change, we allow 5 retries with a 1-second interval between two consecutive attempts.

Minor change in RetryUtils.java to use a warning log instead of error.


###  Code changes
- [ ] Added new code behind **a config**. If so list the config names and their default values in the PR description.
- [ ] Introduced new **log lines**. 
  - [ ] Confirmed if logs need to be **rate limited** to avoid excessive logging.

###  **Concurrency-Specific Checks**
Both reviewer and PR author to verify
- [ ] Code has **no race conditions** or **thread safety issues**.
- [ ] Proper **synchronization mechanisms** (e.g., `synchronized`, `RWLock`) are used where needed.
- [ ] No **blocking calls** inside critical sections that could lead to deadlocks or performance degradation.
- [ ] Verified **thread-safe collections** are used (e.g., `ConcurrentHashMap`, `CopyOnWriteArrayList`).
- [ ] Validated proper exception handling in multi-threaded code to avoid silent thread termination.


## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->

- [x] New unit tests added.
- [ ] New integration tests added.
- [ ] Modified or extended existing tests.
- [ ] Verified backward compatibility (if applicable).

## Does this PR introduce any user-facing or breaking changes?
<!--  
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Clearly explain the behavior change and its impact.