### PR TITLE
[controller] Add PreConnectCallback to ensure correct instance tags on existing participants

### DIFF
--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/ControllerInstanceTagRefresher.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/ControllerInstanceTagRefresher.java
@@ -1,0 +1,82 @@
+package com.linkedin.venice.controller;
+
+import com.linkedin.venice.exceptions.VeniceException;
+import com.linkedin.venice.helix.SafeHelixManager;
+import java.util.HashSet;
+import java.util.Set;
+import org.apache.helix.ConfigAccessor;
+import org.apache.helix.PreConnectCallback;
+import org.apache.helix.model.InstanceConfig;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+
+/**
+ * PreConnectCallback is called after the participant registers its info in the cluster but before marking itself as
+ * LIVEINSTANCE. If the instance is already a participant of the cluster, then we need this logic to update Instance tags
+ * in the case of KSAP assigning this controller participant to another cluster
+ */
+public class ControllerInstanceTagRefresher implements PreConnectCallback {
+  private static final Logger LOGGER = LogManager.getLogger(ControllerInstanceTagRefresher.class);
+  private SafeHelixManager helixManager;
+  private final VeniceControllerMultiClusterConfig multiClusterConfigs;
+
+  public ControllerInstanceTagRefresher(
+      SafeHelixManager helixManager,
+      VeniceControllerMultiClusterConfig multiClusterConfigs) {
+    this.helixManager = helixManager;
+    this.multiClusterConfigs = multiClusterConfigs;
+  }
+
+  @Override
+  public void onPreConnect() {
+    try {
+      String instanceName = helixManager.getInstanceName();
+      ConfigAccessor configAccessor = helixManager.getConfigAccessor();
+      InstanceConfig instanceConfig = configAccessor.getInstanceConfig(helixManager.getClusterName(), instanceName);
+
+      if (instanceConfig == null) {
+        LOGGER.warn("No InstanceConfig found for {}. Creating new config.", instanceName);
+        instanceConfig = new InstanceConfig(instanceName);
+      }
+
+      Set<String> currentTags = new HashSet<>(instanceConfig.getTags());
+      Set<String> expectedTags = new HashSet<>(multiClusterConfigs.getControllerInstanceTagList());
+
+      // Determine tags to add and remove
+      Set<String> tagsToAdd = new HashSet<>(expectedTags);
+      tagsToAdd.removeAll(currentTags);
+
+      Set<String> tagsToRemove = new HashSet<>(currentTags);
+      tagsToRemove.removeAll(expectedTags);
+
+      // Apply changes if there are any differences
+      if (!tagsToAdd.isEmpty() || !tagsToRemove.isEmpty()) {
+        LOGGER.info(
+            "Instance '{}' tag differences detected. Adding: {}, Removing: {}",
+            instanceName,
+            tagsToAdd,
+            tagsToRemove);
+
+        // Add new tags
+        for (String tag: tagsToAdd) {
+          instanceConfig.addTag(tag);
+        }
+
+        // Remove obsolete tags
+        for (String tag: tagsToRemove) {
+          instanceConfig.removeTag(tag);
+        }
+
+        // Persist the updated configuration
+        configAccessor.setInstanceConfig(helixManager.getClusterName(), instanceName, instanceConfig);
+        LOGGER.info("Updated InstanceConfig tags for '{}'.", instanceName);
+      } else {
+        LOGGER.info("Instance '{}' already contains all expected tags.", instanceName);
+      }
+    } catch (Exception e) {
+      LOGGER.error("Failed to apply instance tags in PreConnectCallback", e);
+      throw new VeniceException("PreConnectCallback failed to apply instance tags", e);
+    }
+  }
+}

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceHelixAdmin.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceHelixAdmin.java
@@ -827,16 +827,15 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
     InstanceConfig.Builder defaultInstanceConfigBuilder =
         new InstanceConfig.Builder().setPort(Integer.toString(multiClusterConfigs.getAdminPort()));
 
-    List<String> instanceTagList = multiClusterConfigs.getControllerInstanceTagList();
-    for (String instanceTag: instanceTagList) {
-      defaultInstanceConfigBuilder.addTag(instanceTag);
-    }
-
     HelixManagerProperty helixManagerProperty =
         new HelixManagerProperty.Builder().setDefaultInstanceConfigBuilder(defaultInstanceConfigBuilder).build();
 
     SafeHelixManager tempManager = new SafeHelixManager(
         new ZKHelixManager(controllerClusterName, controllerName, instanceType, zkAddress, null, helixManagerProperty));
+
+    // for refreshing the instance config list if the controller is already a participant in venice-controller cluster
+    // but assigned to another venice cluster
+    tempManager.addPreConnectCallback(new ControllerInstanceTagRefresher(tempManager, multiClusterConfigs));
     StateMachineEngine stateMachine = tempManager.getStateMachineEngine();
     stateMachine.registerStateModelFactory(LeaderStandbySMD.name, controllerStateModelFactory);
     try {

--- a/services/venice-controller/src/test/java/com/linkedin/venice/controller/TestControllerInstanceTagRefresher.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/controller/TestControllerInstanceTagRefresher.java
@@ -1,0 +1,76 @@
+package com.linkedin.venice.controller;
+
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.anyString;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.linkedin.venice.exceptions.VeniceException;
+import com.linkedin.venice.helix.SafeHelixManager;
+import java.util.Arrays;
+import java.util.List;
+import org.apache.helix.ConfigAccessor;
+import org.apache.helix.model.InstanceConfig;
+import org.testng.annotations.Test;
+
+
+public class TestControllerInstanceTagRefresher {
+  @Test
+  public void testOnPreConnect_addAndRemoveTags() {
+    SafeHelixManager mockManager = mock(SafeHelixManager.class);
+    ConfigAccessor mockAccessor = mock(ConfigAccessor.class);
+    InstanceConfig mockConfig = new InstanceConfig("instance1");
+    mockConfig.addTag("old-tag");
+
+    VeniceControllerMultiClusterConfig mockConfigSource = mock(VeniceControllerMultiClusterConfig.class);
+    List<String> expectedTags = Arrays.asList("new-tag-1", "new-tag-2");
+
+    when(mockManager.getInstanceName()).thenReturn("instance1");
+    when(mockManager.getClusterName()).thenReturn("test-cluster");
+    when(mockManager.getConfigAccessor()).thenReturn(mockAccessor);
+    when(mockAccessor.getInstanceConfig("test-cluster", "instance1")).thenReturn(mockConfig);
+    when(mockConfigSource.getControllerInstanceTagList()).thenReturn(expectedTags);
+
+    ControllerInstanceTagRefresher refresher = new ControllerInstanceTagRefresher(mockManager, mockConfigSource);
+    refresher.onPreConnect();
+
+    verify(mockAccessor).setInstanceConfig(eq("test-cluster"), eq("instance1"), any(InstanceConfig.class));
+  }
+
+  @Test(expectedExceptions = VeniceException.class)
+  public void testOnPreConnect_throwsException() {
+    SafeHelixManager mockManager = mock(SafeHelixManager.class);
+    VeniceControllerMultiClusterConfig mockConfigSource = mock(VeniceControllerMultiClusterConfig.class);
+
+    when(mockManager.getInstanceName()).thenThrow(new RuntimeException("Boom"));
+
+    ControllerInstanceTagRefresher refresher = new ControllerInstanceTagRefresher(mockManager, mockConfigSource);
+    refresher.onPreConnect(); // should throw
+  }
+
+  @Test
+  public void testOnPreConnect_noChangesNeeded() {
+    SafeHelixManager mockManager = mock(SafeHelixManager.class);
+    ConfigAccessor mockAccessor = mock(ConfigAccessor.class);
+    InstanceConfig mockConfig = new InstanceConfig("instance1");
+    mockConfig.addTag("tag1");
+    mockConfig.addTag("tag2");
+
+    VeniceControllerMultiClusterConfig mockConfigSource = mock(VeniceControllerMultiClusterConfig.class);
+    List<String> expectedTags = Arrays.asList("tag1", "tag2");
+
+    when(mockManager.getInstanceName()).thenReturn("instance1");
+    when(mockManager.getClusterName()).thenReturn("cluster");
+    when(mockManager.getConfigAccessor()).thenReturn(mockAccessor);
+    when(mockAccessor.getInstanceConfig("cluster", "instance1")).thenReturn(mockConfig);
+    when(mockConfigSource.getControllerInstanceTagList()).thenReturn(expectedTags);
+
+    ControllerInstanceTagRefresher refresher = new ControllerInstanceTagRefresher(mockManager, mockConfigSource);
+    refresher.onPreConnect();
+
+    verify(mockAccessor, never()).setInstanceConfig(anyString(), anyString(), any());
+  }
+}


### PR DESCRIPTION
 ## Problem Statement
 Currently, Venice controllers rely on `defaultInstanceConfigBuilder` to assign instance tags during registration.
 However, this logic is only invoked when the controller is a *new* participant in the cluster.
 When a controller already exists as a participant (e.g. in a deployment that reassigns the controller as part of another cluster), Helix does not reapply instance tags from the builder.
 As a result, instance tags can become stale or incorrect (e.g., if the controller was reassigned to a new Venice cluster or reused across environments). This causes Helix to make incorrect partition assignments, or skip assignment altogether.

 ## Solution
 Introduced a `ControllerInstanceTagRefresher` using Helix's `addPreConnectCallback` API.
 This callback runs after instance registration but *before* the node becomes LIVE, which ensures:
 - We can read and modify the `InstanceConfig`.
 - Tags are corrected before the controller receives assignments.

 We:
 - Compute tag differences between config and expected state.
 - Add or remove tags accordingly.
 - Persist changes back to ZooKeeper *only* if necessary.

 This ensures consistency between desired controller role (e.g., KSAP reassignments) and actual cluster metadata, even during restarts.

 ###  Code changes
 - [x] Added new code behind **existing logic flow** (no new config gate).
 - [x] Introduced new **log lines**.
   - [x] Confirmed log lines are informative and not high-frequency; no rate limiting required.

 ### **Concurrency-Specific Checks**
 - [x] Code has **no race conditions** or **thread safety issues**.
 - [x] No shared mutable state; only Helix APIs and per-instance config updates.
 - [x] No blocking calls inside critical sections.
 - [x] All data structures used are scoped and thread-local to `onPreConnect`.

 ## How was this PR tested?
 - [x] New unit tests added for:
       - Correct tagging behavior (add/remove)
   - No-op when tags match
   - Exception path
 - [x] Validated manually in EI controllers: incorrect tag was corrected on restart.

 ## Does this PR introduce any user-facing or breaking changes?
 - [x] No.
