### PR TITLE
[router][dvc] use async getPartitionStatus method in dvc peer finding

### DIFF
--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/PushStatusStoreTest.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/PushStatusStoreTest.java
@@ -356,16 +356,14 @@ public class PushStatusStoreTest {
 
       // case 2: throw exception for non-existing store
       try {
-        CompletableFuture<Map<CharSequence, Integer>> future2 =
-            reader.getPartitionStatusAsync("non-existed-store-name", 1, 0, Optional.empty(), Optional.empty());
+        reader.getPartitionStatusAsync("non-existed-store-name", 1, 0, Optional.empty(), Optional.empty());
       } catch (VeniceException e) {
         assertTrue(e.getMessage().contains("Failed to read push status of partition:1 store:non-existed-store-name"));
       }
 
       // case 3: throw exception for non-existed version
       try {
-        CompletableFuture<Map<CharSequence, Integer>> future3 =
-            reader.getPartitionStatusAsync(storeName, 100, 0, Optional.empty(), Optional.empty());
+        reader.getPartitionStatusAsync(storeName, 100, 0, Optional.empty(), Optional.empty());
       } catch (VeniceException e) {
         assertTrue(e.getMessage().contains("Failed to read push status of partition:100 store:" + storeName));
       }

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/PushStatusStoreTest.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/PushStatusStoreTest.java
@@ -35,6 +35,7 @@ import com.linkedin.venice.controller.VeniceHelixAdmin;
 import com.linkedin.venice.controllerapi.ControllerClient;
 import com.linkedin.venice.controllerapi.JobStatusQueryResponse;
 import com.linkedin.venice.controllerapi.UpdateStoreQueryParams;
+import com.linkedin.venice.exceptions.VeniceException;
 import com.linkedin.venice.hadoop.VenicePushJob;
 import com.linkedin.venice.integration.utils.D2TestUtils;
 import com.linkedin.venice.integration.utils.DaVinciTestContext;
@@ -63,6 +64,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Properties;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
@@ -70,6 +72,7 @@ import org.apache.avro.Schema;
 import org.apache.avro.util.Utf8;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.testng.Assert;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.BeforeMethod;
@@ -331,6 +334,41 @@ public class PushStatusStoreTest {
       TestUtils.waitForNonDeterministicAssertion(TEST_TIMEOUT_MS, TimeUnit.MILLISECONDS, () -> {
         assertEquals(reader.getPartitionStatus(storeName, 1, 0, Optional.empty()).size(), 0);
       });
+    }
+  }
+
+  @Test(timeOut = TEST_TIMEOUT_MS * 2)
+  public void testGetPartitionStatusAsync() throws Exception {
+    VeniceProperties backendConfig = getBackendConfigBuilder().build();
+    Properties vpjProperties = getVPJProperties();
+    // case 1: happy path
+    runVPJ(vpjProperties, 1, cluster);
+    try (DaVinciClient daVinciClient =
+        ServiceFactory.getGenericAvroDaVinciClient(storeName, cluster, new DaVinciConfig(), backendConfig)) {
+      daVinciClient.subscribeAll().get();
+      CompletableFuture<Map<CharSequence, Integer>> future1 =
+          reader.getPartitionStatusAsync(storeName, 1, 0, Optional.empty(), Optional.empty());
+      future1.whenComplete((result, throwable) -> {
+        {
+          Assert.assertEquals(result.size(), 1);
+        }
+      }).join();
+
+      // case 2: throw exception for non-existing store
+      try {
+        CompletableFuture<Map<CharSequence, Integer>> future2 =
+            reader.getPartitionStatusAsync("non-existed-store-name", 1, 0, Optional.empty(), Optional.empty());
+      } catch (VeniceException e) {
+        assertTrue(e.getMessage().contains("Failed to read push status of partition:1 store:non-existed-store-name"));
+      }
+
+      // case 3: throw exception for non-existed version
+      try {
+        CompletableFuture<Map<CharSequence, Integer>> future3 =
+            reader.getPartitionStatusAsync(storeName, 100, 0, Optional.empty(), Optional.empty());
+      } catch (VeniceException e) {
+        assertTrue(e.getMessage().contains("Failed to read push status of partition:100 store:" + storeName));
+      }
     }
   }
 

--- a/services/venice-router/src/test/java/com/linkedin/venice/router/TestMetaDataHandler.java
+++ b/services/venice-router/src/test/java/com/linkedin/venice/router/TestMetaDataHandler.java
@@ -84,6 +84,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
@@ -1555,6 +1556,16 @@ public class TestMetaDataHandler {
     String storeVersion = "3";
     String storePartition = "30";
 
+    // Set up empty map for instance results from PushStatusStore
+    Mockito.doReturn(CompletableFuture.completedFuture(new HashMap<CharSequence, Integer>()))
+        .when(pushStatusStoreReader)
+        .getPartitionStatusAsync(
+            storeName,
+            Integer.valueOf(storeVersion),
+            Integer.valueOf(storePartition),
+            Optional.empty(),
+            Optional.empty());
+
     Store store = Mockito.mock(Store.class);
     Mockito.doReturn(store).when(storeRepository).getStore(storeName);
     Mockito.doReturn(isBlobTransferEnabled).when(store).isBlobTransferEnabled();
@@ -1650,6 +1661,9 @@ public class TestMetaDataHandler {
       }
     };
 
+    CompletableFuture<Map<CharSequence, Integer>> instanceResultsFromPushStatusStoreFuture =
+        CompletableFuture.completedFuture(instanceResultsFromPushStatusStore);
+
     Map<String, Boolean> instanceHealth = new HashMap<String, Boolean>() {
       {
         put("ltx1-test.prod.linkedin.com_137", true);
@@ -1660,9 +1674,9 @@ public class TestMetaDataHandler {
 
     List<String> expectedResult = Arrays.asList("ltx1-test.prod.linkedin.com_137", "ltx1-test2.prod.linkedin.com_137");
 
-    Mockito.doReturn(instanceResultsFromPushStatusStore)
+    Mockito.doReturn(instanceResultsFromPushStatusStoreFuture)
         .when(pushStatusStoreReader)
-        .getPartitionStatus(storeName, storeVersion, storePartition, Optional.empty());
+        .getPartitionStatusAsync(storeName, storeVersion, storePartition, Optional.empty(), Optional.empty());
 
     instanceHealth.forEach((instance, isLive) -> {
       Mockito.doReturn(isLive).when(pushStatusStoreReader).isInstanceAlive(storeName, instance);
@@ -1719,6 +1733,8 @@ public class TestMetaDataHandler {
         put("ltx1-test2.prod.linkedin.com_137", 1);
       }
     };
+    CompletableFuture<Map<CharSequence, Integer>> instanceResultsFromPushStatusStoreFuture =
+        CompletableFuture.completedFuture(instanceResultsFromPushStatusStore);
 
     Map<String, Boolean> instanceHealth = new HashMap<String, Boolean>() {
       {
@@ -1730,12 +1746,13 @@ public class TestMetaDataHandler {
 
     List<String> expectedResult = Collections.emptyList();
 
-    Mockito.doReturn(instanceResultsFromPushStatusStore)
+    Mockito.doReturn(instanceResultsFromPushStatusStoreFuture)
         .when(pushStatusStoreReader)
-        .getPartitionStatus(
+        .getPartitionStatusAsync(
             storeName,
             Integer.valueOf(storeVersion),
             Integer.valueOf(storePartition),
+            Optional.empty(),
             Optional.empty());
 
     instanceHealth.forEach((instance, isLive) -> {

--- a/services/venice-router/src/test/java/com/linkedin/venice/router/TestMetaDataHandler.java
+++ b/services/venice-router/src/test/java/com/linkedin/venice/router/TestMetaDataHandler.java
@@ -1561,8 +1561,8 @@ public class TestMetaDataHandler {
         .when(pushStatusStoreReader)
         .getPartitionStatusAsync(
             storeName,
-            Integer.valueOf(storeVersion),
-            Integer.valueOf(storePartition),
+            Integer.parseInt(storeVersion),
+            Integer.parseInt(storePartition),
             Optional.empty(),
             Optional.empty());
 


### PR DESCRIPTION

## Problem Statement
DVC peer discovery involves calls to router _**pushStatusStoreReader.getPartitionStatus**_ for fetching instance information. Within method getPartitionStatus, it waits for a response using **_PushStatusValue pushStatusValue = client.get(pushStatusKey).get(60, TimeUnit.SECONDS)._**

However, if the same Netty thread does: (1) initiates the original blob discovery request, (2) subsequently calls getPartitionStatus, which blocks while waiting for a response, and (3) also handles incoming requests from the thin client, it becomes unable to process these incoming requests because it remains blocked, waiting for a response to its own initial request.


## Solution
Add a new async getPartitionStatus and use it in peers finding. 


###  Code changes
- [ ] Added new code behind **a config**. If so list the config names and their default values in the PR description.
- [ ] Introduced new **log lines**. 
- [ ] Confirmed if logs need to be **rate limited** to avoid excessive logging.

###  **Concurrency-Specific Checks**
Both reviewer and PR author to verify
- [ ] Code has **no race conditions** or **thread safety issues**.
- [ ] Proper **synchronization mechanisms** (e.g., `synchronized`, `RWLock`) are used where needed.
- [ ] No **blocking calls** inside critical sections that could lead to deadlocks or performance degradation.
- [ ] Verified **thread-safe collections** are used (e.g., `ConcurrentHashMap`, `CopyOnWriteArrayList`).
- [ ] Validated proper exception handling in multi-threaded code to avoid silent thread termination.


## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->

- [ ] New unit tests added.
- [ ] New integration tests added.
- [ ] Modified or extended existing tests.
- [ ] Verified backward compatibility (if applicable).

## Does this PR introduce any user-facing or breaking changes?
<!--  
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [ ] No. You can skip the rest of this section.
- [ ] Yes. Clearly explain the behavior change and its impact.