### PR TITLE
[controller][admin-tool] Add support for get-dead-stores API and admin tool command

### DIFF
--- a/clients/venice-admin-tool/src/main/java/com/linkedin/venice/AdminTool.java
+++ b/clients/venice-admin-tool/src/main/java/com/linkedin/venice/AdminTool.java
@@ -510,6 +510,7 @@ public class AdminTool {
           break;
         case GET_DEAD_STORES:
           getDeadStores(cmd);
+          break;
         case COMPARE_STORE:
           compareStore(cmd);
           break;

--- a/clients/venice-admin-tool/src/main/java/com/linkedin/venice/AdminTool.java
+++ b/clients/venice-admin-tool/src/main/java/com/linkedin/venice/AdminTool.java
@@ -2834,10 +2834,10 @@ public class AdminTool {
 
   private static void getDeadStores(CommandLine cmd) {
     String clusterName = getRequiredArgument(cmd, Arg.CLUSTER);
-    String storeName = getOptionalArgument(cmd, Arg.STORE);
+    Optional<String> storeName = Optional.ofNullable(getOptionalArgument(cmd, Arg.STORE));
     boolean includeSystemStores = Boolean.parseBoolean(getOptionalArgument(cmd, Arg.INCLUDE_SYSTEM_STORES));
 
-    MultiStoreInfoResponse response = controllerClient.getDeadStores(clusterName, storeName, includeSystemStores);
+    MultiStoreInfoResponse response = controllerClient.getDeadStores(clusterName, includeSystemStores, storeName);
     printObject(response);
   }
 

--- a/clients/venice-admin-tool/src/main/java/com/linkedin/venice/AdminTool.java
+++ b/clients/venice-admin-tool/src/main/java/com/linkedin/venice/AdminTool.java
@@ -43,6 +43,7 @@ import com.linkedin.venice.controllerapi.MultiNodesStatusResponse;
 import com.linkedin.venice.controllerapi.MultiReplicaResponse;
 import com.linkedin.venice.controllerapi.MultiSchemaResponse;
 import com.linkedin.venice.controllerapi.MultiStoragePersonaResponse;
+import com.linkedin.venice.controllerapi.MultiStoreInfoResponse;
 import com.linkedin.venice.controllerapi.MultiStoreResponse;
 import com.linkedin.venice.controllerapi.MultiStoreStatusResponse;
 import com.linkedin.venice.controllerapi.MultiStoreTopicsResponse;
@@ -507,6 +508,8 @@ public class AdminTool {
         case REPUSH_STORE:
           repushStore(cmd);
           break;
+        case GET_DEAD_STORES:
+          getDeadStores(cmd);
         case COMPARE_STORE:
           compareStore(cmd);
           break;
@@ -2825,6 +2828,15 @@ public class AdminTool {
   private static void repushStore(CommandLine cmd) {
     String storeName = getRequiredArgument(cmd, Arg.STORE);
     RepushJobResponse response = controllerClient.repushStore(storeName);
+    printObject(response);
+  }
+
+  private static void getDeadStores(CommandLine cmd) {
+    String clusterName = getRequiredArgument(cmd, Arg.CLUSTER);
+    String storeName = getOptionalArgument(cmd, Arg.STORE);
+    boolean includeSystemStores = Boolean.parseBoolean(getOptionalArgument(cmd, Arg.INCLUDE_SYSTEM_STORES));
+
+    MultiStoreInfoResponse response = controllerClient.getDeadStores(clusterName, storeName, includeSystemStores);
     printObject(response);
   }
 

--- a/clients/venice-admin-tool/src/main/java/com/linkedin/venice/Command.java
+++ b/clients/venice-admin-tool/src/main/java/com/linkedin/venice/Command.java
@@ -467,6 +467,10 @@ public enum Command {
       "repush-store", "Copy the current serving version's data into a new version and repush it to the store",
       new Arg[] { URL, STORE }, new Arg[] { CLUSTER }
   ),
+  GET_DEAD_STORES(
+      "get-dead-stores", "Get the stores that are considered dead via ACL DB and Store Discovery",
+      new Arg[] { URL, CLUSTER }, new Arg[] { STORE, INCLUDE_SYSTEM_STORES }
+  ),
   LIST_STORE_PUSH_INFO(
       "list-store-push-info", "List information about current pushes and push history for a specific store.",
       new Arg[] { URL, STORE }, new Arg[] { CLUSTER, PARTITION_DETAIL_ENABLED }

--- a/internal/venice-common/src/main/java/com/linkedin/venice/controllerapi/ControllerClient.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/controllerapi/ControllerClient.java
@@ -1227,6 +1227,12 @@ public class ControllerClient implements Closeable {
     return request(ControllerRoute.REPUSH_STORE, params, RepushJobResponse.class);
   }
 
+  public MultiStoreInfoResponse getDeadStores(String clusterName, String storeName, boolean includeSystemStores) {
+    QueryParams params =
+        newParams().add(CLUSTER, clusterName).add(NAME, storeName).add(INCLUDE_SYSTEM_STORES, includeSystemStores);
+    return request(ControllerRoute.GET_DEAD_STORES, params, MultiStoreInfoResponse.class);
+  }
+
   public VersionResponse getStoreLargestUsedVersion(String clusterName, String storeName) {
     QueryParams params = newParams().add(CLUSTER, clusterName).add(NAME, storeName);
     return request(ControllerRoute.GET_STORE_LARGEST_USED_VERSION, params, VersionResponse.class);

--- a/internal/venice-common/src/main/java/com/linkedin/venice/controllerapi/ControllerClient.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/controllerapi/ControllerClient.java
@@ -1227,9 +1227,12 @@ public class ControllerClient implements Closeable {
     return request(ControllerRoute.REPUSH_STORE, params, RepushJobResponse.class);
   }
 
-  public MultiStoreInfoResponse getDeadStores(String clusterName, String storeName, boolean includeSystemStores) {
-    QueryParams params =
-        newParams().add(CLUSTER, clusterName).add(NAME, storeName).add(INCLUDE_SYSTEM_STORES, includeSystemStores);
+  public MultiStoreInfoResponse getDeadStores(
+      String clusterName,
+      boolean includeSystemStores,
+      Optional<String> storeName) {
+    QueryParams params = newParams().add(CLUSTER, clusterName).add(INCLUDE_SYSTEM_STORES, includeSystemStores);
+    storeName.ifPresent(s -> params.add(NAME, s));
     return request(ControllerRoute.GET_DEAD_STORES, params, MultiStoreInfoResponse.class);
   }
 

--- a/internal/venice-common/src/main/java/com/linkedin/venice/controllerapi/ControllerRoute.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/controllerapi/ControllerRoute.java
@@ -274,7 +274,7 @@ public enum ControllerRoute {
   REPUSH_STORE("/trigger_repush", HttpMethod.POST, Arrays.asList(NAME)),
   GET_STORE_LARGEST_USED_VERSION("/get_store_largest_used_version", HttpMethod.GET, Arrays.asList(CLUSTER, NAME)),
 
-  GET_DEAD_STORES("/get_dead_stores", HttpMethod.GET, Arrays.asList(CLUSTER, NAME, INCLUDE_SYSTEM_STORES)),
+  GET_DEAD_STORES("/get_dead_stores", HttpMethod.GET, Arrays.asList(CLUSTER), NAME, INCLUDE_SYSTEM_STORES),
   LIST_STORE_PUSH_INFO("/list_store_push_info", HttpMethod.GET, Arrays.asList(CLUSTER, NAME, PARTITION_DETAIL_ENABLED)),
   GET_REGION_PUSH_DETAILS(
       "/get_region_push_details", HttpMethod.GET, Arrays.asList(CLUSTER, NAME, PARTITION_DETAIL_ENABLED)

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceHelixAdmin.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceHelixAdmin.java
@@ -696,7 +696,7 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
               ParticipantMessageKey.getClassSchema()));
     }
 
-    if (isParent() && multiClusterConfigs.isDeadStoreEndpointEnabled()) {
+    if (multiClusterConfigs.isDeadStoreEndpointEnabled()) {
       Class<? extends DeadStoreStats> deadStoreStatsClass =
           ReflectUtils.loadClass(multiClusterConfigs.getDeadStoreStatsClassName());
       try {


### PR DESCRIPTION
 ## Problem Statement
 There was no public way for users to programmatically query which stores are considered "dead" by Venice.
     This made it difficult to surface lifecycle decisions driven by ACL access logs and discovery mechanisms.
     Additionally, there was no CLI toolchain integration for easily invoking or testing this logic in staging or production.

 ## Solution
 Introduced a new `GET_DEAD_STORES` endpoint in `ControllerRoute`, mapped it to the existing ACL-based evaluation logic.
 Added a method `getDeadStores` to `ControllerClient` which wraps the request to the controller.
 Implemented a matching CLI command in `AdminTool` that allows users to call this endpoint from the terminal using:
     ```
     ./venice-admin-tool.sh get-dead-stores -url <url> -cluster <cluster> [-store <store>] [-include_system_stores true]
     ```
     This enables debugging store lifecycle states, validating access audits, and surfacing potential deletions.

 ### Code changes
 - [x] Added `GET_DEAD_STORES` route to `ControllerRoute`
     - [x] Exposed `getDeadStores(...)` method in `ControllerClient`
     - [x] Added new admin tool command handler `GET_DEAD_STORES` with param parsing
 - [x] Printed `MultiStoreInfoResponse` object as output for clarity

 ### Logging
 - [ ] No new logs introduced directly in this diff. (Relies on controller logic already logging ACL decisions if needed)

 ## Does this PR introduce any user-facing or breaking changes?
     - [x] No breaking changes. This is an additive feature.
 - [x] Adds new CLI command and controller endpoint for observability and debugging
