### PR TITLE
[build] Increase releasing cadence from 2 times a week to daily

### DIFF
--- a/.github/workflows/build-and-upload-archives-on-schedule.yml
+++ b/.github/workflows/build-and-upload-archives-on-schedule.yml
@@ -2,7 +2,7 @@ name: Venice Publication Pipeline
 
 on:
   schedule:
-    - cron: "30 20 * * 2,4"
+    - cron: "30 20 * * 1-5"
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
## Problem Statement
Current releasing cadence is 2 times a week; each release contains multiple commits,
which makes it hard to investigate regressions and triage bugs.


## Solution
Increasing releasing cadence to every workday at 8:30pm.


###  Code changes
- [ ] Added new code behind **a config**. If so list the config names and their default values in the PR description.
- [ ] Introduced new **log lines**. 
  - [ ] Confirmed if logs need to be **rate limited** to avoid excessive logging.

###  **Concurrency-Specific Checks**
Both reviewer and PR author to verify
- [ ] Code has **no race conditions** or **thread safety issues**.
- [ ] Proper **synchronization mechanisms** (e.g., `synchronized`, `RWLock`) are used where needed.
- [ ] No **blocking calls** inside critical sections that could lead to deadlocks or performance degradation.
- [ ] Verified **thread-safe collections** are used (e.g., `ConcurrentHashMap`, `CopyOnWriteArrayList`).
- [ ] Validated proper exception handling in multi-threaded code to avoid silent thread termination.


## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->

- [ ] New unit tests added.
- [ ] New integration tests added.
- [ ] Modified or extended existing tests.
- [ ] Verified backward compatibility (if applicable).
- [x] Tested the new cron expression 

## Does this PR introduce any user-facing or breaking changes?
<!--  
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [ ] No. You can skip the rest of this section.
- [ ] Yes. Clearly explain the behavior change and its impact.