### PR TITLE
[controller] Add metric sensor to catch the failed admin message serialization

### DIFF
--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceParentHelixAdmin.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceParentHelixAdmin.java
@@ -176,6 +176,7 @@ import com.linkedin.venice.exceptions.ResourceStillExistsException;
 import com.linkedin.venice.exceptions.VeniceException;
 import com.linkedin.venice.exceptions.VeniceHttpException;
 import com.linkedin.venice.exceptions.VeniceNoStoreException;
+import com.linkedin.venice.exceptions.VeniceProtocolException;
 import com.linkedin.venice.exceptions.VeniceUnsupportedOperationException;
 import com.linkedin.venice.helix.HelixReadOnlyStoreConfigRepository;
 import com.linkedin.venice.helix.HelixReadOnlyZKSharedSchemaRepository;
@@ -648,6 +649,17 @@ public class VeniceParentHelixAdmin implements Admin {
         }
         // TODO Remove the admin command execution tracking code since no one is using it (might not even be working).
         adminCommandExecutionTracker.startTrackingExecution(execution);
+      } catch (VeniceProtocolException e) {
+        LOGGER.error(
+            "Failed to serialize admin message in cluster {}: {}. "
+                + "Please check the schema compatibility. Full error message: {}",
+            clusterName,
+            message,
+            e.getMessage());
+        getVeniceHelixAdmin().getHelixVeniceClusterResources(clusterName)
+            .getVeniceAdminStats()
+            .recordFailedSerializingAdminOperationMessageCount();
+        throw e;
       }
     } finally {
       releaseAdminMessageExecutionIdLock(clusterName);

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/stats/VeniceAdminStats.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/stats/VeniceAdminStats.java
@@ -26,6 +26,13 @@ public class VeniceAdminStats extends AbstractVeniceStats {
    */
   private final Sensor successfullyStartedUserIncrementalPushParentAdminCountSensor;
 
+  /**
+   * A counter reporting the number of failed serialization attempts of admin operations.
+   * This metric is used to monitor the health of serialization of admin operations in parent admin by using the dynamic
+   * version in the serializer.
+   */
+  private final Sensor failedSerializingAdminOperationMessageCount;
+
   public VeniceAdminStats(MetricsRepository metricsRepository, String name) {
     super(metricsRepository, name);
 
@@ -35,6 +42,8 @@ public class VeniceAdminStats extends AbstractVeniceStats {
         registerSensorIfAbsent("successfully_started_user_batch_push_parent_admin_count", new Count());
     successfullyStartedUserIncrementalPushParentAdminCountSensor =
         registerSensorIfAbsent("successful_started_user_incremental_push_parent_admin_count", new Count());
+    failedSerializingAdminOperationMessageCount =
+        registerSensorIfAbsent("failed_serializing_admin_operation_message_count", new Count());
   }
 
   public void recordUnexpectedTopicAbsenceCount() {
@@ -47,5 +56,9 @@ public class VeniceAdminStats extends AbstractVeniceStats {
 
   public void recordSuccessfullyStartedUserIncrementalPushParentAdminCount() {
     successfullyStartedUserIncrementalPushParentAdminCountSensor.record();
+  }
+
+  public void recordFailedSerializingAdminOperationMessageCount() {
+    failedSerializingAdminOperationMessageCount.record();
   }
 }


### PR DESCRIPTION
[controller] Add metric to catch the failed admin message serialization

## Problem Statement
Add stat metric to capture VeniceProtocolException in serializing admin operation message.

## Solution
- Add stat metric to capture VeniceProtocolException in serializing admin operation message.
- Add error log line for debug purpose


###  Code changes
- [ ] Added new code behind **a config**. If so list the config names and their default values in the PR description.
- [x] Introduced new **log lines**. 
  - [x] Confirmed if logs need to be **rate limited** to avoid excessive logging.

###  **Concurrency-Specific Checks**
Both reviewer and PR author to verify
- [ ] Code has **no race conditions** or **thread safety issues**.
- [ ] Proper **synchronization mechanisms** (e.g., `synchronized`, `RWLock`) are used where needed.
- [ ] No **blocking calls** inside critical sections that could lead to deadlocks or performance degradation.
- [ ] Verified **thread-safe collections** are used (e.g., `ConcurrentHashMap`, `CopyOnWriteArrayList`).
- [ ] Validated proper exception handling in multi-threaded code to avoid silent thread termination.


## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->

- [ ] New unit tests added.
- [ ] New integration tests added.
- [ ] Modified or extended existing tests.
- [ ] Verified backward compatibility (if applicable).

## Does this PR introduce any user-facing or breaking changes?
<!--  
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [ ] No. You can skip the rest of this section.
- [ ] Yes. Clearly explain the behavior change and its impact.