### PR TITLE
[controller] Fixing race condition in STANDBY->LEADER for Dead Store Stats

### DIFF
--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/controller/TestVeniceHelixAdminWithIsolatedEnvironment.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/controller/TestVeniceHelixAdminWithIsolatedEnvironment.java
@@ -321,6 +321,7 @@ public class TestVeniceHelixAdminWithIsolatedEnvironment extends AbstractTestVen
     int newAdminPort = controllerConfig.getAdminPort() + 100;
     PropertyBuilder builder = new PropertyBuilder().put(controllerProps.toProperties())
         .put("admin.port", newAdminPort)
+        .put("controller.cluster.name", clusterName)
         .put("controller.dead.store.endpoint.enabled", true)
         .put("controller.dead.store.stats.class.name", MockDeadStoreStats.class.getName());
     VeniceProperties newControllerProps = builder.build();
@@ -331,12 +332,7 @@ public class TestVeniceHelixAdminWithIsolatedEnvironment extends AbstractTestVen
         new MetricsRepository(),
         D2TestUtils.getAndStartD2Client(zkAddress),
         pubSubTopicRepository,
-        pubSubBrokerWrapper.getPubSubClientsFactory()) {
-      @Override
-      public boolean isParent() {
-        return true;
-      }
-    };
+        pubSubBrokerWrapper.getPubSubClientsFactory());
 
     Assert.assertTrue(admin.deadStoreStats instanceof MockDeadStoreStats);
   }

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/controller/TestVeniceHelixResources.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/controller/TestVeniceHelixResources.java
@@ -64,7 +64,6 @@ public class TestVeniceHelixResources {
     when(controllerConfig.getDaVinciPushStatusScanIntervalInSeconds()).thenReturn(5);
     when(controllerConfig.isDaVinciPushStatusEnabled()).thenReturn(true);
     when(controllerConfig.getOffLineJobWaitTimeInMilliseconds()).thenReturn(120000L);
-    when(controllerConfig.isParent()).thenReturn(true);
     when(controllerConfig.isDeadStoreEndpointEnabled()).thenReturn(true);
     when(controllerConfig.getDeadStoreStatsPreFetchRefreshIntervalInMs()).thenReturn(100L); // Must be Long
 

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/DeadStoreStatsPreFetchTask.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/DeadStoreStatsPreFetchTask.java
@@ -1,10 +1,12 @@
 package com.linkedin.venice.controller;
 
+import com.linkedin.venice.exceptions.VeniceException;
 import com.linkedin.venice.meta.StoreInfo;
 import com.linkedin.venice.utils.Utils;
 import java.io.Closeable;
 import java.util.List;
 import java.util.Objects;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Collectors;
 import org.apache.logging.log4j.LogManager;
@@ -39,6 +41,15 @@ public class DeadStoreStatsPreFetchTask implements Runnable, Closeable {
     logger.info("Started {}", taskId);
     isRunning.set(true);
     try {
+      // wait for 60 seconds for controller to become leader as it's required to be leader for dead store stats
+      long deadline = System.currentTimeMillis() + TimeUnit.SECONDS.toMillis(60);
+      while (!admin.isLeaderControllerFor(clusterName)) {
+        if (System.currentTimeMillis() > deadline) {
+          throw new VeniceException("Timed out waiting for controller to become leader for cluster: " + clusterName);
+        }
+        Utils.sleep(10_000); // sleep for 10 seconds
+      }
+
       logger.debug("Initial fetch of dead store stats for cluster: {}", clusterName);
       admin.preFetchDeadStoreStats(clusterName, getStoresInCluster());
     } catch (Exception e) {

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/HelixVeniceClusterResources.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/HelixVeniceClusterResources.java
@@ -207,7 +207,8 @@ public class HelixVeniceClusterResources implements VeniceResource {
           config.getErrorPartitionProcessingCycleDelay());
     }
 
-    if (config.isParent() && config.isDeadStoreEndpointEnabled() && config.isPreFetchDeadStoreStatsEnabled()) {
+    if (config.isDeadStoreEndpointEnabled() && config.isPreFetchDeadStoreStatsEnabled()) {
+      LOGGER.info("Dead store stats pre-fetch task is enabled for cluster: {}", clusterName);
       deadStoreStatsPreFetchTask =
           new DeadStoreStatsPreFetchTask(clusterName, admin, config.getDeadStoreStatsPreFetchRefreshIntervalInMs());
     }

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceControllerMultiClusterConfig.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceControllerMultiClusterConfig.java
@@ -348,6 +348,9 @@ public class VeniceControllerMultiClusterConfig {
   }
 
   public boolean isDeadStoreEndpointEnabled(String clusterName) {
+    if (!clusterToControllerConfigMap.containsKey(clusterName)) {
+      return false; // can be the case where venice-controllers isn't a configmap in current tests
+    }
     return getControllerConfig(clusterName).isDeadStoreEndpointEnabled();
   }
 

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceControllerMultiClusterConfig.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceControllerMultiClusterConfig.java
@@ -347,8 +347,8 @@ public class VeniceControllerMultiClusterConfig {
     return getCommonConfig().getDeadStoreStatsConfigs();
   }
 
-  public boolean isDeadStoreEndpointEnabled() {
-    return getCommonConfig().isDeadStoreEndpointEnabled();
+  public boolean isDeadStoreEndpointEnabled(String clusterName) {
+    return getControllerConfig(clusterName).isDeadStoreEndpointEnabled();
   }
 
   public long getTimeSinceLastLogCompactionThresholdMS() {

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceControllerStateModel.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceControllerStateModel.java
@@ -304,9 +304,9 @@ public class VeniceControllerStateModel extends StateModel {
        * its dependent service.
        */
       clusterResources.stopLeakedPushStatusCleanUpService();
+      clusterResources.stopDeadStoreStatsPreFetchTask();
       clusterResources.clear();
       clusterResources.stopErrorPartitionResetTask();
-      clusterResources.stopDeadStoreStatsPreFetchTask();
       clusterResources = null;
     }
   }

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceControllerStateModel.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceControllerStateModel.java
@@ -305,8 +305,8 @@ public class VeniceControllerStateModel extends StateModel {
        */
       clusterResources.stopLeakedPushStatusCleanUpService();
       clusterResources.stopDeadStoreStatsPreFetchTask();
-      clusterResources.clear();
       clusterResources.stopErrorPartitionResetTask();
+      clusterResources.clear();
       clusterResources = null;
     }
   }

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceHelixAdmin.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceHelixAdmin.java
@@ -696,7 +696,7 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
               ParticipantMessageKey.getClassSchema()));
     }
 
-    if (isParent() && multiClusterConfigs.isDeadStoreEndpointEnabled()) {
+    if (multiClusterConfigs.isDeadStoreEndpointEnabled(controllerClusterName)) {
       Class<? extends DeadStoreStats> deadStoreStatsClass =
           ReflectUtils.loadClass(multiClusterConfigs.getDeadStoreStatsClassName());
       try {
@@ -8270,7 +8270,7 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
   @Override
   public List<StoreInfo> getDeadStores(String clusterName, String storeName, boolean includeSystemStores) {
     checkControllerLeadershipFor(clusterName);
-    if (!multiClusterConfigs.isDeadStoreEndpointEnabled()) {
+    if (!multiClusterConfigs.isDeadStoreEndpointEnabled(clusterName)) {
       throw new VeniceUnsupportedOperationException("Dead store stats is not enabled.");
     }
 

--- a/services/venice-controller/src/test/java/com/linkedin/venice/controller/DeadStoreStatsPreFetchTaskTest.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/controller/DeadStoreStatsPreFetchTaskTest.java
@@ -24,6 +24,7 @@ public class DeadStoreStatsPreFetchTaskTest {
     mockStore = mock(Store.class);
     mockAdmin.deadStoreStats = mockStats;
     when(mockAdmin.getAllStores("test-cluster")).thenReturn(Collections.singletonList(mockStore));
+    when(mockAdmin.isLeaderControllerFor("test-cluster")).thenReturn(true);
   }
 
   @Test


### PR DESCRIPTION
## Problem Statement
 There is a race condition where the `DeadStoreStatsPreFetchTask` begins execution before the controller has officially become the leader for a given cluster.
 This results in exceptions such as:
     `VeniceException: This controller:<host> is not the leader controller for cluster: <cluster>`
     The issue occurs because `initClusterResources()` triggers the task during the STANDBY->LEADER transition, before `VeniceHelixAdmin` is ready.

## Solution
 Added a leadership check with a 60-second timeout to `DeadStoreStatsPreFetchTask.run()` to block pre-fetching until the controller becomes leader.
     This ensures we don’t prematurely call `preFetchDeadStoreStats()` on a non-leader node.
     Also updated `clearResources()` to call `stopDeadStoreStatsPreFetchTask()` **before** `clusterResources.clear()` to ensure the task shuts down cleanly and avoids side effects.

 ### Code changes
 - [x] Added new code behind a config: **getDeadStoreStatsPreFetchTaskRefreshIntervalMs** and **isPreFetchDeadStoreStatsEnabled**.
     - [x] Introduced new log lines: startup logs and error handling around leadership waiting logic.
 - [x] Added retry logic with timeout for leadership wait in `DeadStoreStatsPreFetchTask`.

### Concurrency-Specific Checks
 - [x] No race conditions — wait is bounded by timeout and `AtomicBoolean` is used for task lifecycle.
     - [x] Synchronization is already handled by task init and shutdown in `HelixVeniceClusterResources`.
     - [x] No blocking calls in critical sections; leadership wait is at task startup only.
 - [x] No unguarded shared state access; `isRunning` flag safely governs loop.
     - [x] Proper exception handling for timeout and retry scenarios.

 ## Does this PR introduce any user-facing or breaking changes?
- [x] No. This is purely internal logic cleanup to make leadership-based pre-fetching more reliable.