### PR TITLE
[vpj] [server] fix bug in SIT in deciding if compression is needed

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTask.java
@@ -3237,10 +3237,11 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
       return false; // Not leader, don't compress
     }
     PubSubTopic leaderTopic = partitionConsumptionState.getOffsetRecord().getLeaderTopic(pubSubTopicRepository);
-    if (realTimeTopic != null && !realTimeTopic.equals(leaderTopic)) {
+    if (realTimeTopic == null || !realTimeTopic.equals(leaderTopic)) {
       return false; // We're consuming from version topic (don't compress it)
+    } else {
+      return !compressionStrategy.equals(CompressionStrategy.NO_OP);
     }
-    return !compressionStrategy.equals(CompressionStrategy.NO_OP);
   }
 
   private PubSubMessageProcessedResult processMessage(

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTask.java
@@ -3237,8 +3237,10 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
       return false; // Not leader, don't compress
     }
     PubSubTopic leaderTopic = partitionConsumptionState.getOffsetRecord().getLeaderTopic(pubSubTopicRepository);
+    // if we are consuming from a version topic, don't compress
+    // if we are consuming from a real time topic, compress if the compression strategy is not no_op
     if (realTimeTopic == null || !realTimeTopic.equals(leaderTopic)) {
-      return false; // We're consuming from version topic (don't compress it)
+      return false;
     } else {
       return !compressionStrategy.equals(CompressionStrategy.NO_OP);
     }

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/LeaderFolloweStorageIngestionTaskTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/LeaderFolloweStorageIngestionTaskTest.java
@@ -1,0 +1,56 @@
+package com.linkedin.davinci.kafka.consumer;
+
+import static com.linkedin.davinci.kafka.consumer.LeaderFollowerStateType.LEADER;
+import static org.mockito.Answers.CALLS_REAL_METHODS;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doCallRealMethod;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.withSettings;
+
+import com.linkedin.venice.compression.CompressionStrategy;
+import com.linkedin.venice.meta.Version;
+import com.linkedin.venice.pubsub.PubSubTopicRepository;
+import com.linkedin.venice.pubsub.api.PubSubTopic;
+import com.linkedin.venice.utils.Utils;
+import java.lang.reflect.Field;
+import org.mockito.Answers;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+
+public class LeaderFolloweStorageIngestionTaskTest {
+  PubSubTopicRepository pubSubTopicRepository = new PubSubTopicRepository();
+  String store = "test_store";
+
+  @Test
+  public void test() throws NoSuchFieldException, IllegalAccessException {
+    PubSubTopic realTimeTopic = pubSubTopicRepository.getTopic(Utils.composeRealTimeTopic(store));
+    PubSubTopic versionTopic = pubSubTopicRepository.getTopic(store + Version.VERSION_SEPARATOR + "1");
+    PartitionConsumptionState partitionConsumptionState =
+        mock(PartitionConsumptionState.class, Answers.RETURNS_DEEP_STUBS);
+    doReturn(LEADER).when(partitionConsumptionState).getLeaderFollowerState();
+
+    LeaderFollowerStoreIngestionTask leaderFollowerStoreIngestionTask =
+        mock(LeaderFollowerStoreIngestionTask.class, withSettings().defaultAnswer(CALLS_REAL_METHODS));
+    doCallRealMethod().when(leaderFollowerStoreIngestionTask).shouldCompressData(any());
+    Field field = leaderFollowerStoreIngestionTask.getClass().getSuperclass().getDeclaredField("compressionStrategy");
+    field.setAccessible(true);
+    field.set(leaderFollowerStoreIngestionTask, CompressionStrategy.ZSTD_WITH_DICT);
+
+    // test 1 - do compress for real time topic
+    field = leaderFollowerStoreIngestionTask.getClass().getSuperclass().getDeclaredField("realTimeTopic");
+    field.setAccessible(true);
+    field.set(leaderFollowerStoreIngestionTask, realTimeTopic);
+    when(partitionConsumptionState.getOffsetRecord().getLeaderTopic(any())).thenReturn(realTimeTopic);
+    Assert.assertTrue(leaderFollowerStoreIngestionTask.shouldCompressData(partitionConsumptionState));
+
+    // test 2 - do not compress for version topic
+    field = leaderFollowerStoreIngestionTask.getClass().getSuperclass().getDeclaredField("realTimeTopic");
+    field.setAccessible(true);
+    field.set(leaderFollowerStoreIngestionTask, null);
+    when(partitionConsumptionState.getOffsetRecord().getLeaderTopic(any())).thenReturn(versionTopic);
+    Assert.assertFalse(leaderFollowerStoreIngestionTask.shouldCompressData(partitionConsumptionState));
+  }
+}

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestMultiDatacenterVenicePushJob.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestMultiDatacenterVenicePushJob.java
@@ -1,7 +1,5 @@
 package com.linkedin.venice.endToEnd;
 
-import static com.linkedin.venice.ConfigKeys.CONTROLLER_DEFERRED_VERSION_SWAP_SERVICE_ENABLED;
-import static com.linkedin.venice.ConfigKeys.CONTROLLER_DEFERRED_VERSION_SWAP_SLEEP_MS;
 import static com.linkedin.venice.utils.IntegrationTestPushUtils.createStoreForJob;
 import static com.linkedin.venice.utils.TestWriteUtils.NAME_RECORD_V3_SCHEMA;
 import static com.linkedin.venice.utils.TestWriteUtils.getTempDataDirectory;
@@ -45,8 +43,6 @@ public class TestMultiDatacenterVenicePushJob {
   public void setUp() {
     String clusterName = CLUSTER_NAMES[0];
     Properties controllerProps = new Properties();
-    controllerProps.put(CONTROLLER_DEFERRED_VERSION_SWAP_SLEEP_MS, 100);
-    controllerProps.put(CONTROLLER_DEFERRED_VERSION_SWAP_SERVICE_ENABLED, true);
     Properties serverProperties = new Properties();
 
     VeniceMultiRegionClusterCreateOptions.Builder optionsBuilder =
@@ -81,6 +77,7 @@ public class TestMultiDatacenterVenicePushJob {
   }
 
   @Test(timeOut = TEST_TIMEOUT)
+  // Runs a VPJ and verifies remote consumption for compression enabled batch store in a multi-region setup
   public void testVPJWithCompressionEnabledBatchStore() throws IOException {
     File inputDir = getTempDataDirectory();
     TestWriteUtils.writeSimpleAvroFileWithStringToV3Schema(inputDir, 100, 100);

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestMultiDatacenterVenicePushJob.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestMultiDatacenterVenicePushJob.java
@@ -1,0 +1,137 @@
+package com.linkedin.venice.endToEnd;
+
+import static com.linkedin.venice.ConfigKeys.CONTROLLER_DEFERRED_VERSION_SWAP_SERVICE_ENABLED;
+import static com.linkedin.venice.ConfigKeys.CONTROLLER_DEFERRED_VERSION_SWAP_SLEEP_MS;
+import static com.linkedin.venice.utils.IntegrationTestPushUtils.createStoreForJob;
+import static com.linkedin.venice.utils.TestWriteUtils.NAME_RECORD_V3_SCHEMA;
+import static com.linkedin.venice.utils.TestWriteUtils.getTempDataDirectory;
+
+import com.linkedin.venice.compression.CompressionStrategy;
+import com.linkedin.venice.controllerapi.ControllerClient;
+import com.linkedin.venice.controllerapi.UpdateStoreQueryParams;
+import com.linkedin.venice.integration.utils.ServiceFactory;
+import com.linkedin.venice.integration.utils.VeniceMultiClusterWrapper;
+import com.linkedin.venice.integration.utils.VeniceMultiRegionClusterCreateOptions;
+import com.linkedin.venice.integration.utils.VeniceTwoLayerMultiRegionMultiClusterWrapper;
+import com.linkedin.venice.utils.IntegrationTestPushUtils;
+import com.linkedin.venice.utils.TestUtils;
+import com.linkedin.venice.utils.TestWriteUtils;
+import com.linkedin.venice.utils.Utils;
+import java.io.File;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Properties;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.IntStream;
+import org.testng.Assert;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+
+public class TestMultiDatacenterVenicePushJob {
+  private static final int TEST_TIMEOUT = 30_000;
+  private static final int NUMBER_OF_CHILD_DATACENTERS = 2;
+  private static final int NUMBER_OF_CLUSTERS = 1;
+  private static final String[] CLUSTER_NAMES =
+      IntStream.range(0, NUMBER_OF_CLUSTERS).mapToObj(i -> "venice-cluster" + i).toArray(String[]::new);
+  ControllerClient parentControllerClient;
+  ControllerClient[] childControllerClients;
+  VeniceTwoLayerMultiRegionMultiClusterWrapper multiRegionMultiClusterWrapper;
+  private List<VeniceMultiClusterWrapper> childDatacenters;
+
+  @BeforeClass
+  public void setUp() {
+    String clusterName = CLUSTER_NAMES[0];
+    Properties controllerProps = new Properties();
+    controllerProps.put(CONTROLLER_DEFERRED_VERSION_SWAP_SLEEP_MS, 100);
+    controllerProps.put(CONTROLLER_DEFERRED_VERSION_SWAP_SERVICE_ENABLED, true);
+    Properties serverProperties = new Properties();
+
+    VeniceMultiRegionClusterCreateOptions.Builder optionsBuilder =
+        new VeniceMultiRegionClusterCreateOptions.Builder().numberOfRegions(NUMBER_OF_CHILD_DATACENTERS)
+            .numberOfClusters(NUMBER_OF_CLUSTERS)
+            .numberOfParentControllers(1)
+            .numberOfChildControllers(1)
+            .numberOfServers(1)
+            .numberOfRouters(1)
+            .replicationFactor(1)
+            .forkServer(false)
+            .parentControllerProperties(controllerProps)
+            .childControllerProperties(controllerProps)
+            .serverProperties(serverProperties);
+    multiRegionMultiClusterWrapper =
+        ServiceFactory.getVeniceTwoLayerMultiRegionMultiClusterWrapper(optionsBuilder.build());
+    childDatacenters = multiRegionMultiClusterWrapper.getChildRegions();
+    String parentControllerURLs = multiRegionMultiClusterWrapper.getControllerConnectString();
+    parentControllerClient = new ControllerClient(clusterName, parentControllerURLs);
+    childControllerClients = new ControllerClient[childDatacenters.size()];
+    for (int i = 0; i < childDatacenters.size(); i++) {
+      childControllerClients[i] =
+          new ControllerClient(clusterName, childDatacenters.get(i).getControllerConnectString());
+    }
+  }
+
+  @AfterClass(alwaysRun = true)
+  public void cleanUp() {
+    parentControllerClient.close();
+    Arrays.stream(childControllerClients).forEach(ControllerClient::close);
+    Utils.closeQuietlyWithErrorLogged(multiRegionMultiClusterWrapper);
+  }
+
+  @Test(timeOut = TEST_TIMEOUT)
+  public void testVPJWithCompressionEnabledBatchStore() throws IOException {
+    File inputDir = getTempDataDirectory();
+    TestWriteUtils.writeSimpleAvroFileWithStringToV3Schema(inputDir, 100, 100);
+    // Setup job properties
+    String inputDirPath = "file://" + inputDir.getAbsolutePath();
+    String storeName = Utils.getUniqueString("TestVPJWithCompressionEnabledBatchStore");
+    Properties props =
+        IntegrationTestPushUtils.defaultVPJProps(multiRegionMultiClusterWrapper, inputDirPath, storeName);
+    String keySchemaStr = "\"string\"";
+    createStoreForJob(
+        CLUSTER_NAMES[0],
+        keySchemaStr,
+        NAME_RECORD_V3_SCHEMA.toString(),
+        props,
+        new UpdateStoreQueryParams().setCompressionStrategy(CompressionStrategy.ZSTD_WITH_DICT)).close();
+    TestWriteUtils.runPushJob("Test push job", props);
+    TestUtils.waitForNonDeterministicAssertion(1, TimeUnit.MINUTES, () -> {
+      Assert.assertEquals(parentControllerClient.getStore(storeName).getStore().getVersions().size(), 1);
+      for (ControllerClient childControllerClient: childControllerClients) {
+        Assert.assertEquals(childControllerClient.getStore(storeName).getStore().getCurrentVersion(), 1);
+      }
+    });
+  }
+
+  @Test(timeOut = TEST_TIMEOUT)
+  public void testVPJWithCompressionEnabledHybridStore() throws IOException {
+    File inputDir = getTempDataDirectory();
+    TestWriteUtils.writeSimpleAvroFileWithStringToV3Schema(inputDir, 100, 100);
+    // Setup job properties
+    String inputDirPath = "file://" + inputDir.getAbsolutePath();
+    String storeName = Utils.getUniqueString("TestVPJWithCompressionEnabledHybridStore");
+    Properties props =
+        IntegrationTestPushUtils.defaultVPJProps(multiRegionMultiClusterWrapper, inputDirPath, storeName);
+    String keySchemaStr = "\"string\"";
+    createStoreForJob(
+        CLUSTER_NAMES[0],
+        keySchemaStr,
+        NAME_RECORD_V3_SCHEMA.toString(),
+        props,
+        new UpdateStoreQueryParams().setCompressionStrategy(CompressionStrategy.ZSTD_WITH_DICT)
+            .setHybridRewindSeconds(1000)
+            .setActiveActiveReplicationEnabled(true)
+            .setHybridOffsetLagThreshold(1000)).close();
+    TestWriteUtils.runPushJob("Test push job", props);
+    TestUtils.waitForNonDeterministicAssertion(1, TimeUnit.MINUTES, () -> {
+      Assert.assertEquals(parentControllerClient.getStore(storeName).getStore().getVersions().size(), 1);
+      Assert.assertNotNull(parentControllerClient.getStore(storeName).getStore().getHybridStoreConfig());
+      for (ControllerClient childControllerClient: childControllerClients) {
+        Assert.assertNotNull(childControllerClient.getStore(storeName).getStore().getHybridStoreConfig());
+        Assert.assertEquals(childControllerClient.getStore(storeName).getStore().getCurrentVersion(), 1);
+      }
+    });
+  }
+}


### PR DESCRIPTION
<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat], [protocol]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## Problem Statement
<!--
Describe
- What problem are you trying to solve
- What issues or limitations exist in the current code
- Why this change is necessary 
-->
Before [the change](https://github.com/linkedin/venice/pull/1555) , for batch-only store, we always return false for `shouldCompressionData()` when leaderTopic is null or VT and **`realTimeTopic` would never be `null` even if the store is batch only**.
After the change, for batch-only store, since realTimeTopic is now null, `realTimeTopic != null` would break the if condition immediately, and then `!compressionStrategy.equals(CompressionStrategy.NO_OP)` would return true for a compression enabled store; as a result, we compress the compressed data in VT again.

```
protected boolean shouldCompressData(PartitionConsumptionState partitionConsumptionState) {
  if (!isLeader(partitionConsumptionState)) {
    return false; // Not leader, don't compress
  }
  PubSubTopic leaderTopic = partitionConsumptionState.getOffsetRecord().getLeaderTopic(pubSubTopicRepository);
  if (realTimeTopic != null && !realTimeTopic.equals(leaderTopic)) {
    return false; // We're consuming from version topic (don't compress it)
  }
  return !compressionStrategy.equals(CompressionStrategy.NO_OP);
} 
```

Fix bug in SIT in deciding if compression is needed

## Solution
<!--
Describe
- What changes you are making and why. 
- How these changes solve the problem.
- Any performance considerations or trade-offs. 
- Describe what testings you have done, for example, performance testing etc.
-->

Fix the `if-else` conditions. Added an integration for two region batch store with compression enabled. The test fails without the fix with error

```
2025-04-17 17:43:12,372 [ERROR] LogNotifier – Push errored for replica: TestVPJWithCompressionEnabledBatchStore_27cb7a1de2e5_afe9723b_v1-2 message fatal data validation problem for replica: TestVPJWithCompressionEnabledBatchStore_27cb7a1de2e5_afe9723b_v1-2. Incoming record topic-partition: TestVPJWithCompressionEnabledBatchStore_27cb7a1de2e5_afe9723b_v1-2 offset: 42. Consumption will be halted.
com.linkedin.venice.exceptions.validation.CorruptDataException: CORRUPT data detected for producer GUID: cd665c7f3d47476480f53cc8e66426a4; message type: CONTROL_MESSAGE (END_OF_SEGMENT); partition: 2; previous successful offset (in same segment): 41; incoming offset: 42; previous segment: 0; incoming segment: 0; previous sequence number: 39; incoming sequence number: 39; consumer record timestamp: 1744936988708
```
	

###  Code changes
- [ ] Added new code behind **a config**. If so list the config names and their default values in the PR description.
- [ ] Introduced new **log lines**. 
  - [ ] Confirmed if logs need to be **rate limited** to avoid excessive logging.

###  **Concurrency-Specific Checks**
Both reviewer and PR author to verify
- [x] Code has **no race conditions** or **thread safety issues**.
- [x] Proper **synchronization mechanisms** (e.g., `synchronized`, `RWLock`) are used where needed.
- [x] No **blocking calls** inside critical sections that could lead to deadlocks or performance degradation.
- [x] Verified **thread-safe collections** are used (e.g., `ConcurrentHashMap`, `CopyOnWriteArrayList`).
- [x] Validated proper exception handling in multi-threaded code to avoid silent thread termination.


## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->

- [ ] New unit tests added.
- [ ] New integration tests added.
- [ ] Modified or extended existing tests.
- [ ] Verified backward compatibility (if applicable).

## Does this PR introduce any user-facing or breaking changes?
<!--  
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [ ] No. You can skip the rest of this section.
- [ ] Yes. Clearly explain the behavior change and its impact.