### PR TITLE
[router] Use Helix FAULT_ZONE_TYPE as the group for HAR routing

### DIFF
--- a/internal/venice-common/src/main/java/com/linkedin/venice/ConfigKeys.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/ConfigKeys.java
@@ -1101,12 +1101,6 @@ public class ConfigKeys {
   public static final String ROUTER_MULTI_KEY_ROUTING_STRATEGY = "router.multi.key.routing.strategy";
 
   /**
-   * The Helix virtual group field name in domain, and the allowed values: {@link com.linkedin.venice.helix.HelixInstanceConfigRepository#GROUP_FIELD_NAME_IN_DOMAIN}
-   * and {@link com.linkedin.venice.helix.HelixInstanceConfigRepository#ZONE_FIELD_NAME_IN_DOMAIN}.
-   */
-  public static final String ROUTER_HELIX_VIRTUAL_GROUP_FIELD_IN_DOMAIN = "router.helix.virtual.group.field.in.domain";
-
-  /**
    * Helix group selection strategy when Helix assisted routing is enabled.
    * Available strategies listed here: {@literal HelixGroupSelectionStrategyEnum}.
    */

--- a/internal/venice-common/src/main/java/com/linkedin/venice/utils/HelixUtils.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/utils/HelixUtils.java
@@ -35,8 +35,11 @@ import org.apache.logging.log4j.Logger;
 /**
  * Helper functions for Helix.
  */
-public class HelixUtils {
+public final class HelixUtils {
   private static final Logger LOGGER = LogManager.getLogger(HelixUtils.class);
+
+  private HelixUtils() {
+  }
 
   /**
    * Retry 3 times for each helix operation in case of getting the error by default.

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/router/TestRead.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/router/TestRead.java
@@ -152,7 +152,6 @@ public abstract class TestRead {
     extraProperties.put(ConfigKeys.ROUTER_HTTPASYNCCLIENT_CONNECTION_WARMING_ENABLED, true);
     extraProperties.put(ConfigKeys.ROUTER_HTTPASYNCCLIENT_CONNECTION_WARMING_SLEEP_INTERVAL_MS, 1);
     extraProperties.put(ConfigKeys.ROUTER_MULTI_KEY_ROUTING_STRATEGY, HELIX_ASSISTED_ROUTING.name());
-    extraProperties.put(ConfigKeys.ROUTER_HELIX_VIRTUAL_GROUP_FIELD_IN_DOMAIN, "zone");
     extraProperties.put(ConfigKeys.ROUTER_HTTP_CLIENT5_SKIP_CIPHER_CHECK_ENABLED, "true");
     extraProperties.put(ConfigKeys.ROUTER_HTTP2_INBOUND_ENABLED, isRouterHttp2Enabled());
     extraProperties.put(ConfigKeys.SERVER_HTTP2_INBOUND_ENABLED, true);

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceHelixAdmin.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceHelixAdmin.java
@@ -6874,7 +6874,7 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
         helixClusterConfig.setDelayRebalaceEnabled(true);
       }
       helixClusterConfig.setPersistBestPossibleAssignment(true);
-      // Topology and fault zone type fields are used by CRUSH alg. Helix would apply the constrains on CRUSH alg to
+      // Topology and fault zone type fields are used by CRUSH alg. Helix would apply the constraints on CRUSH alg to
       // choose proper instance to hold the replica.
       helixClusterConfig.setTopology("/" + HelixUtils.TOPOLOGY_CONSTRAINT);
       helixClusterConfig.setFaultZoneType(HelixUtils.TOPOLOGY_CONSTRAINT);

--- a/services/venice-router/src/main/java/com/linkedin/venice/router/RouterServer.java
+++ b/services/venice-router/src/main/java/com/linkedin/venice/router/RouterServer.java
@@ -1007,7 +1007,7 @@ public class RouterServer extends AbstractVeniceService {
         /**
          * This statement should be invoked after {@link #manager} is connected.
          */
-        instanceConfigRepository = new HelixInstanceConfigRepository(manager, config.isUseGroupFieldInHelixDomain());
+        instanceConfigRepository = new HelixInstanceConfigRepository(manager);
         instanceConfigRepository.refresh();
         helixGroupSelector = new HelixGroupSelector(
             metricsRepository,

--- a/services/venice-router/src/main/java/com/linkedin/venice/router/VeniceRouterConfig.java
+++ b/services/venice-router/src/main/java/com/linkedin/venice/router/VeniceRouterConfig.java
@@ -38,7 +38,6 @@ import static com.linkedin.venice.ConfigKeys.ROUTER_ENABLE_READ_THROTTLING;
 import static com.linkedin.venice.ConfigKeys.ROUTER_FULL_PENDING_QUEUE_SERVER_OOR_MS;
 import static com.linkedin.venice.ConfigKeys.ROUTER_HEART_BEAT_ENABLED;
 import static com.linkedin.venice.ConfigKeys.ROUTER_HELIX_ASSISTED_ROUTING_GROUP_SELECTION_STRATEGY;
-import static com.linkedin.venice.ConfigKeys.ROUTER_HELIX_VIRTUAL_GROUP_FIELD_IN_DOMAIN;
 import static com.linkedin.venice.ConfigKeys.ROUTER_HTTP2_HEADER_TABLE_SIZE;
 import static com.linkedin.venice.ConfigKeys.ROUTER_HTTP2_INBOUND_ENABLED;
 import static com.linkedin.venice.ConfigKeys.ROUTER_HTTP2_INITIAL_WINDOW_SIZE;
@@ -100,8 +99,6 @@ import static com.linkedin.venice.ConfigKeys.SSL_TO_STORAGE_NODES;
 import static com.linkedin.venice.ConfigKeys.SYSTEM_SCHEMA_CLUSTER_NAME;
 import static com.linkedin.venice.ConfigKeys.UNREGISTER_METRIC_FOR_DELETED_STORE_ENABLED;
 import static com.linkedin.venice.ConfigKeys.ZOOKEEPER_ADDRESS;
-import static com.linkedin.venice.helix.HelixInstanceConfigRepository.GROUP_FIELD_NAME_IN_DOMAIN;
-import static com.linkedin.venice.helix.HelixInstanceConfigRepository.ZONE_FIELD_NAME_IN_DOMAIN;
 import static com.linkedin.venice.router.api.VeniceMultiKeyRoutingStrategy.LEAST_LOADED_ROUTING;
 import static com.linkedin.venice.router.api.routing.helix.HelixGroupSelectionStrategyEnum.LEAST_LOADED;
 
@@ -197,14 +194,13 @@ public class VeniceRouterConfig implements RouterRetryConfig {
   private final long maxRouterReadCapacityCu;
   private final boolean helixHybridStoreQuotaEnabled;
   private final int ioThreadCountInPoolMode;
-  private final boolean useGroupFieldInHelixDomain;
   private final VeniceMultiKeyRoutingStrategy multiKeyRoutingStrategy;
   private final HelixGroupSelectionStrategyEnum helixGroupSelectionStrategy;
   private final String systemSchemaClusterName;
   private final int clientSslHandshakeThreads;
   private final int maxConcurrentSslHandshakes;
   private final int resolveThreads;
-  private final int resolveQueueCapacity;;
+  private final int resolveQueueCapacity;
   private final int clientResolutionRetryAttempts;
   private final long clientResolutionRetryBackoffMs;
   private final int clientSslHandshakeQueueCapacity;
@@ -355,18 +351,6 @@ public class VeniceRouterConfig implements RouterRetryConfig {
       readQuotaThrottlingLeaseTimeoutMs =
           props.getLong(ROUTER_READ_QUOTA_THROTTLING_LEASE_TIMEOUT_MS, 6 * Time.MS_PER_HOUR);
 
-      String helixVirtualGroupFieldNameInDomain =
-          props.getString(ROUTER_HELIX_VIRTUAL_GROUP_FIELD_IN_DOMAIN, GROUP_FIELD_NAME_IN_DOMAIN);
-      if (helixVirtualGroupFieldNameInDomain.equals(GROUP_FIELD_NAME_IN_DOMAIN)) {
-        useGroupFieldInHelixDomain = true;
-      } else if (helixVirtualGroupFieldNameInDomain.equals(ZONE_FIELD_NAME_IN_DOMAIN)) {
-        useGroupFieldInHelixDomain = false;
-      } else {
-        throw new VeniceException(
-            "Unknown value: " + helixVirtualGroupFieldNameInDomain + " for config: "
-                + ROUTER_HELIX_VIRTUAL_GROUP_FIELD_IN_DOMAIN + ", and " + "allowed values: ["
-                + GROUP_FIELD_NAME_IN_DOMAIN + ", " + ZONE_FIELD_NAME_IN_DOMAIN + "]");
-      }
       String multiKeyRoutingStrategyStr =
           props.getString(ROUTER_MULTI_KEY_ROUTING_STRATEGY, LEAST_LOADED_ROUTING.name());
       VeniceMultiKeyRoutingStrategy multiKeyRoutingStrategyEnum;
@@ -707,10 +691,6 @@ public class VeniceRouterConfig implements RouterRetryConfig {
 
   public int getIoThreadCountInPoolMode() {
     return ioThreadCountInPoolMode;
-  }
-
-  public boolean isUseGroupFieldInHelixDomain() {
-    return useGroupFieldInHelixDomain;
   }
 
   public VeniceMultiKeyRoutingStrategy getMultiKeyRoutingStrategy() {

--- a/services/venice-router/src/test/java/com/linkedin/venice/router/TestVeniceRouterConfig.java
+++ b/services/venice-router/src/test/java/com/linkedin/venice/router/TestVeniceRouterConfig.java
@@ -5,18 +5,14 @@ import static com.linkedin.venice.ConfigKeys.CLUSTER_TO_D2;
 import static com.linkedin.venice.ConfigKeys.KAFKA_BOOTSTRAP_SERVERS;
 import static com.linkedin.venice.ConfigKeys.LISTENER_PORT;
 import static com.linkedin.venice.ConfigKeys.LISTENER_SSL_PORT;
-import static com.linkedin.venice.ConfigKeys.ROUTER_HELIX_VIRTUAL_GROUP_FIELD_IN_DOMAIN;
 import static com.linkedin.venice.ConfigKeys.ZOOKEEPER_ADDRESS;
-import static org.testng.Assert.assertFalse;
-import static org.testng.Assert.assertThrows;
-import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.assertEquals;
 
 import com.linkedin.venice.exceptions.VeniceException;
-import com.linkedin.venice.helix.HelixInstanceConfigRepository;
 import com.linkedin.venice.utils.PropertyBuilder;
 import com.linkedin.venice.utils.VeniceProperties;
+import java.util.Map;
 import java.util.TreeMap;
-import org.testng.Assert;
 import org.testng.annotations.Test;
 
 
@@ -25,24 +21,9 @@ public class TestVeniceRouterConfig {
   public void basicConstruction() {
     VeniceProperties props = getPropertyBuilderWithBasicConfigsFilledIn().build();
     VeniceRouterConfig routerConfig = new VeniceRouterConfig(props);
-    assertTrue(routerConfig.isUseGroupFieldInHelixDomain());
-
-    props = getPropertyBuilderWithBasicConfigsFilledIn()
-        .put(ROUTER_HELIX_VIRTUAL_GROUP_FIELD_IN_DOMAIN, HelixInstanceConfigRepository.GROUP_FIELD_NAME_IN_DOMAIN)
-        .build();
-    routerConfig = new VeniceRouterConfig(props);
-    assertTrue(routerConfig.isUseGroupFieldInHelixDomain());
-
-    props = getPropertyBuilderWithBasicConfigsFilledIn()
-        .put(ROUTER_HELIX_VIRTUAL_GROUP_FIELD_IN_DOMAIN, HelixInstanceConfigRepository.ZONE_FIELD_NAME_IN_DOMAIN)
-        .build();
-    routerConfig = new VeniceRouterConfig(props);
-    assertFalse(routerConfig.isUseGroupFieldInHelixDomain());
-
-    props =
-        getPropertyBuilderWithBasicConfigsFilledIn().put(ROUTER_HELIX_VIRTUAL_GROUP_FIELD_IN_DOMAIN, "bogus").build();
-    final VeniceProperties finalProps = props;
-    assertThrows(VeniceException.class, () -> new VeniceRouterConfig(finalProps));
+    Map<String, String> clusterToD2Map = routerConfig.getClusterToD2Map();
+    assertEquals(clusterToD2Map.size(), 1);
+    assertEquals(clusterToD2Map.get("blah"), "blahD2");
   }
 
   private PropertyBuilder getPropertyBuilderWithBasicConfigsFilledIn() {
@@ -59,22 +40,22 @@ public class TestVeniceRouterConfig {
     String retryThresholdConfig = "1-10:20,11-50:50,51-200:80,201-:1000";
     TreeMap<Integer, Integer> retryThresholdMap =
         VeniceRouterConfig.parseRetryThresholdForBatchGet(retryThresholdConfig);
-    Assert.assertEquals((int) retryThresholdMap.get(1), 20);
-    Assert.assertEquals((int) retryThresholdMap.get(11), 50);
-    Assert.assertEquals((int) retryThresholdMap.get(51), 80);
-    Assert.assertEquals((int) retryThresholdMap.get(201), 1000);
+    assertEquals((int) retryThresholdMap.get(1), 20);
+    assertEquals((int) retryThresholdMap.get(11), 50);
+    assertEquals((int) retryThresholdMap.get(51), 80);
+    assertEquals((int) retryThresholdMap.get(201), 1000);
 
-    Assert.assertEquals((int) retryThresholdMap.floorEntry(1).getValue(), 20);
-    Assert.assertEquals((int) retryThresholdMap.floorEntry(30).getValue(), 50);
-    Assert.assertEquals((int) retryThresholdMap.floorEntry(500).getValue(), 1000);
+    assertEquals((int) retryThresholdMap.floorEntry(1).getValue(), 20);
+    assertEquals((int) retryThresholdMap.floorEntry(30).getValue(), 50);
+    assertEquals((int) retryThresholdMap.floorEntry(500).getValue(), 1000);
 
     // Config with un-ordered range
     String unorderedRetryThresholdConfig = "51-200:80,11-50:50,201-:1000,1-10:20";
     retryThresholdMap = VeniceRouterConfig.parseRetryThresholdForBatchGet(unorderedRetryThresholdConfig);
-    Assert.assertEquals((int) retryThresholdMap.get(1), 20);
-    Assert.assertEquals((int) retryThresholdMap.get(11), 50);
-    Assert.assertEquals((int) retryThresholdMap.get(51), 80);
-    Assert.assertEquals((int) retryThresholdMap.get(201), 1000);
+    assertEquals((int) retryThresholdMap.get(1), 20);
+    assertEquals((int) retryThresholdMap.get(11), 50);
+    assertEquals((int) retryThresholdMap.get(51), 80);
+    assertEquals((int) retryThresholdMap.get(201), 1000);
   }
 
   @Test(expectedExceptions = VeniceException.class)

--- a/services/venice-server/src/main/java/com/linkedin/venice/server/VeniceServer.java
+++ b/services/venice-server/src/main/java/com/linkedin/venice/server/VeniceServer.java
@@ -362,7 +362,7 @@ public class VeniceServer {
         });
 
     CompletableFuture<HelixInstanceConfigRepository> helixInstanceFuture = managerFuture.thenApply(manager -> {
-      HelixInstanceConfigRepository helixData = new HelixInstanceConfigRepository(manager, false);
+      HelixInstanceConfigRepository helixData = new HelixInstanceConfigRepository(manager);
       helixData.refresh();
       return helixData;
     });


### PR DESCRIPTION
<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat], [protocol]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## Problem Statement
<!--
Describe
- What problem are you trying to solve
- What issues or limitations exist in the current code
- Why this change is necessary 
-->
Today, routers only support `zone` and `group` as the `FAULT_ZONE_TYPE` when the routing strategy is `HELIX_ASSISTED` (HAR). Assuming `FAULT_ZONE_TYPE` is set to `zone`, routers will look for a property with key `zone` in the Helix `DOMAIN` of all server instances to find a replica to route requests to.

When the `FAULT_ZONE_TYPE` changes (say to `group`), Helix will immediately start rebalancing replicas and the constraints we create for HAR are no longer valid. Currently, the value of `FAULT_ZONE_TYPE` that routers look for is configured through it's configs. To make routers use the updated `FAULT_ZONE_TYPE` (`group`), we need to update the configs of the routers and deploy them. This process is slow and there will be performance degradation when the value set in router configs does not align with the value being used by Helix.

## Solution
<!--
Describe
- What changes you are making and why. 
- How these changes solve the problem.
- Any performance considerations or trade-offs. 
- Describe what testings you have done, for example, performance testing etc.
-->
This commit changes router logic to use Helix's `FAULT_ZONE_TYPE` as the key in the `DOMAIN`.

###  Code changes
- [ ] Added new code behind **a config**. If so list the config names and their default values in the PR description.
- [X] Introduced new **log lines**. 
  - [X] Confirmed if logs need to be **rate limited** to avoid excessive logging.

###  **Concurrency-Specific Checks**
Both reviewer and PR author to verify
- [X] Code has **no race conditions** or **thread safety issues**.
- [X] Proper **synchronization mechanisms** (e.g., `synchronized`, `RWLock`) are used where needed.
- [X] No **blocking calls** inside critical sections that could lead to deadlocks or performance degradation.
- [X] Verified **thread-safe collections** are used (e.g., `ConcurrentHashMap`, `CopyOnWriteArrayList`).
- [X] Validated proper exception handling in multi-threaded code to avoid silent thread termination.


## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
Updated unit tests
- [ ] New unit tests added.
- [ ] New integration tests added.
- [X] Modified or extended existing tests.
- [X] Verified backward compatibility (if applicable).

## Does this PR introduce any user-facing or breaking changes?
<!--  
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [X] No. You can skip the rest of this section.
- [ ] Yes. Clearly explain the behavior change and its impact.