### PR TITLE
[doc] Fix links in stream processor user guide

### DIFF
--- a/docs/user_guide/write_api/stream_processor.md
+++ b/docs/user_guide/write_api/stream_processor.md
@@ -14,7 +14,7 @@ processor has well-defined semantics around when to ensure that produced data is
 checkpoint its progress relative to its consumption progress in upstream data sources, whereas the online producer 
 library is a lower-level building block which leaves these reliability details up to the user.
 
-For Apache Samza, the integration point is done at the level of the [VeniceSystemProducer](https://github.com/linkedin/venice/blob/main/clients/venice-samza/src/main/java/com/linkedin/venice/samza/VeniceSystemProducer.java)
-and [VeniceSystemFactory](https://github.com/linkedin/venice/blob/main/clients/venice-samza/src/main/java/com/linkedin/venice/samza/VeniceSystemFactory.java).
+For Apache Samza, the integration point is done at the level of the [VeniceSystemProducer](https://github.com/linkedin/venice/blob/main/integrations/venice-samza/src/main/java/com/linkedin/venice/samza/VeniceSystemProducer.java)
+and [VeniceSystemFactory](https://github.com/linkedin/venice/blob/main/integrations/venice-samza/src/main/java/com/linkedin/venice/samza/VeniceSystemFactory.java).
 
 More details to come.


### PR DESCRIPTION
## Problem Statement
The Venice documentation page for Stream Processor under Write APIs contained incorrect GitHub links for VeniceSystemProducer and VeniceSystemFactory classes, pointing to non-existent locations.

## Solution
Updated the links in stream_processor.md to link to the correct locations of these classes in the `integrations/venice-samza` directory instead of the incorrect `clients/venice-samza` directory.

###  Code changes
- [ ] Added new code behind **a config**. If so list the config names and their default values in the PR description.
- [ ] Introduced new **log lines**. 
 - [ ] Confirmed if logs need to be **rate limited** to avoid excessive logging.

###  **Concurrency-Specific Checks**
Both reviewer and PR author to verify
- [ ] Code has **no race conditions** or **thread safety issues**.
- [ ] Proper **synchronization mechanisms** (e.g., `synchronized`, `RWLock`) are used where needed.
- [ ] No **blocking calls** inside critical sections that could lead to deadlocks or performance degradation.
- [ ] Verified **thread-safe collections** are used (e.g., `ConcurrentHashMap`, `CopyOnWriteArrayList`).
- [ ] Validated proper exception handling in multi-threaded code to avoid silent thread termination.

## How was this PR tested?

- [ ] New unit tests added.
- [ ] New integration tests added.
- [ ] Modified or extended existing tests.
- [ ] Verified backward compatibility (if applicable).
- [x] Manually verified that links point to existing files in the repository.

## Does this PR introduce any user-facing or breaking changes?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Clearly explain the behavior change and its impact.