### PR TITLE
[changelog][client] Add protection for null positions

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/consumer/VeniceChangelogConsumerImpl.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/consumer/VeniceChangelogConsumerImpl.java
@@ -1047,14 +1047,12 @@ public class VeniceChangelogConsumerImpl<K, V> implements VeniceChangelogConsume
       if (localOffset == null) {
         localOffset = new ArrayList<>();
       }
-      List<Long> highWatermarkOffsets =
-          versionSwap.getLocalHighWatermarks() == null ? new ArrayList<>() : versionSwap.getLocalHighWatermarks();
+      List<Long> highWatermarkOffsets = versionSwap.localHighWatermarks == null
+          ? new ArrayList<>()
+          : new ArrayList<>(versionSwap.getLocalHighWatermarks());
       if (RmdUtils.hasOffsetAdvanced(localOffset, highWatermarkOffsets)) {
 
         currentVersionHighWatermarks.putIfAbsent(pubSubTopicPartition.getPartitionNumber(), new ConcurrentHashMap<>());
-        List<Long> highWatermarkOffsets = versionSwap.localHighWatermarks == null
-            ? new ArrayList<>()
-            : new ArrayList<>(versionSwap.getLocalHighWatermarks());
         currentVersionHighWatermarks.get(pubSubTopicPartition.getPartitionNumber())
             .put(upstreamPartition, highWatermarkOffsets);
       }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/consumer/VeniceChangelogConsumerImpl.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/consumer/VeniceChangelogConsumerImpl.java
@@ -1043,11 +1043,20 @@ public class VeniceChangelogConsumerImpl<K, V> implements VeniceChangelogConsume
       List<Long> localOffset = (List<Long>) currentVersionHighWatermarks
           .getOrDefault(pubSubTopicPartition.getPartitionNumber(), Collections.EMPTY_MAP)
           .getOrDefault(upstreamPartition, Collections.EMPTY_LIST);
-      if (RmdUtils.hasOffsetAdvanced(localOffset, versionSwap.getLocalHighWatermarks())) {
+      // safety checks
+      if (localOffset == null) {
+        localOffset = new ArrayList<>();
+      }
+      List<Long> highWatermarkOffsets =
+          versionSwap.getLocalHighWatermarks() == null ? new ArrayList<>() : versionSwap.getLocalHighWatermarks();
+      if (RmdUtils.hasOffsetAdvanced(localOffset, highWatermarkOffsets)) {
 
-        currentVersionHighWatermarks.putIfAbsent(pubSubTopicPartition.getPartitionNumber(), new HashMap<>());
+        currentVersionHighWatermarks.putIfAbsent(pubSubTopicPartition.getPartitionNumber(), new ConcurrentHashMap<>());
+        List<Long> highWatermarkOffsets = versionSwap.localHighWatermarks == null
+            ? new ArrayList<>()
+            : new ArrayList<>(versionSwap.getLocalHighWatermarks());
         currentVersionHighWatermarks.get(pubSubTopicPartition.getPartitionNumber())
-            .put(upstreamPartition, versionSwap.getLocalHighWatermarks());
+            .put(upstreamPartition, highWatermarkOffsets);
       }
       switchToNewTopic(newServingVersionTopic, topicSuffix, pubSubTopicPartition.getPartitionNumber());
       chunkAssembler.clearBuffer();

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/consumer/VeniceChangelogConsumerImplTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/consumer/VeniceChangelogConsumerImplTest.java
@@ -272,11 +272,6 @@ public class VeniceChangelogConsumerImplTest {
 
   @Test
   public void testAdjustCheckpoints() {
-    // protected static void adjustSeekCheckPointsBasedOnHeartbeats(
-    // Map<Integer, VeniceChangeCoordinate> checkpoints,
-    // Map<Integer, Long> currentVersionLastHeartbeat,
-    // PubSubConsumerAdapter consumerAdapter,
-    // List<PubSubTopicPartition> topicPartitionList)
     PubSubConsumerAdapter mockConsumer = Mockito.mock(PubSubConsumerAdapter.class);
     Map<Integer, VeniceChangeCoordinate> checkpoints = new HashMap<>();
     Map<Integer, Long> currentVersionLastHeartbeat = new HashMap<>();
@@ -385,6 +380,27 @@ public class VeniceChangelogConsumerImplTest {
         topicPartitionList);
 
     Assert.assertNotEquals(checkpoints.get(0), aheadCoordinate);
+
+    // Let's throw some nulls at it now
+    Mockito.when(mockConsumer.getPositionByTimestamp(partition0, 1L)).thenReturn(null);
+    Mockito.when(mockConsumer.getPositionByTimestamp(partition1, 2L)).thenReturn(null);
+    Mockito.when(mockConsumer.getPositionByTimestamp(partition2, 1L)).thenReturn(null);
+
+    VeniceChangeCoordinate formerCorodinate0 = checkpoints.get(0);
+    VeniceChangeCoordinate formerCorodinate1 = checkpoints.get(1);
+    VeniceChangeCoordinate formerCorodinate2 = checkpoints.get(2);
+
+    VeniceAfterImageConsumerImpl.adjustSeekCheckPointsBasedOnHeartbeats(
+        checkpoints,
+        currentVersionLastHeartbeat,
+        mockConsumer,
+        topicPartitionList);
+
+    // This should have left everything the same
+    Assert.assertEquals(checkpoints.get(0), formerCorodinate0);
+    Assert.assertEquals(checkpoints.get(1), formerCorodinate1);
+    Assert.assertEquals(checkpoints.get(2), formerCorodinate2);
+
   }
 
   @Test


### PR DESCRIPTION
## Problem Statement

It seems under certain scenarios the PubSub API will throw a null position.  In the previous code this wasn't really expected.

## Solution

We can add protections to both scenarios where we can't find the EOP message (for whatever reason) and if we can't get a position for a heatbeat.

Also adding some other null checks

###  Code changes
- [ ] Added new code behind **a config**. If so list the config names and their default values in the PR description.
- [ ] Introduced new **log lines**. 
  - [ ] Confirmed if logs need to be **rate limited** to avoid excessive logging.

###  **Concurrency-Specific Checks**
Both reviewer and PR author to verify
- [ ] Code has **no race conditions** or **thread safety issues**.
- [ ] Proper **synchronization mechanisms** (e.g., `synchronized`, `RWLock`) are used where needed.
- [ ] No **blocking calls** inside critical sections that could lead to deadlocks or performance degradation.
- [ ] Verified **thread-safe collections** are used (e.g., `ConcurrentHashMap`, `CopyOnWriteArrayList`).
- [ ] Validated proper exception handling in multi-threaded code to avoid silent thread termination.


## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->

- [ ] New unit tests added.
- [ ] New integration tests added.
- [ ] Modified or extended existing tests.
- [ ] Verified backward compatibility (if applicable).

## Does this PR introduce any user-facing or breaking changes?
<!--  
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [ ] No. You can skip the rest of this section.
- [ ] Yes. Clearly explain the behavior change and its impact.