### PR TITLE
Use LogContext in all controller services for region-aware logging  

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/helix/HelixParticipationService.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/helix/HelixParticipationService.java
@@ -375,7 +375,8 @@ public class HelixParticipationService extends AbstractVeniceService
         zkClient,
         new HelixAdapterSerializer(),
         veniceConfigLoader.getVeniceClusterConfig().getRefreshAttemptsForZkReconnect(),
-        veniceConfigLoader.getVeniceClusterConfig().getRefreshIntervalForZkReconnectInMs());
+        veniceConfigLoader.getVeniceClusterConfig().getRefreshIntervalForZkReconnectInMs(),
+        veniceServerConfig.getRegionName());
 
     /**
      * The accessor can only get created successfully after helix manager is created.

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/helix/LeaderFollowerPartitionStateModelFactory.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/helix/LeaderFollowerPartitionStateModelFactory.java
@@ -7,6 +7,7 @@ import com.linkedin.davinci.stats.ingestion.heartbeat.HeartbeatMonitoringService
 import com.linkedin.venice.helix.HelixPartitionStatusAccessor;
 import com.linkedin.venice.meta.ReadOnlyStoreRepository;
 import com.linkedin.venice.utils.HelixUtils;
+import com.linkedin.venice.utils.LogContext;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
 
@@ -47,6 +48,7 @@ public class LeaderFollowerPartitionStateModelFactory extends AbstractStateModel
 
   @Override
   public LeaderFollowerPartitionStateModel createNewStateModel(String resourceName, String partitionName) {
+    LogContext.setRegionLogContext(getConfigService().getVeniceServerConfig().getRegionName());
     logger.info("Creating LeaderFollowerParticipantModel handler for partition: {}", partitionName);
     return new LeaderFollowerPartitionStateModel(
         getIngestionBackend(),

--- a/internal/venice-client-common/src/main/java/com/linkedin/venice/utils/DaemonThreadFactory.java
+++ b/internal/venice-client-common/src/main/java/com/linkedin/venice/utils/DaemonThreadFactory.java
@@ -13,9 +13,9 @@ import org.apache.logging.log4j.ThreadContext;
 public class DaemonThreadFactory implements ThreadFactory {
   protected final AtomicInteger threadNumber;
   private final String namePrefix;
-  private final String logContext;
+  private final Object logContext;
 
-  public DaemonThreadFactory(String threadNamePrefix, @Nullable String logContext) {
+  public DaemonThreadFactory(String threadNamePrefix, @Nullable Object logContext) {
     this.threadNumber = new AtomicInteger(0);
     this.namePrefix = threadNamePrefix;
     this.logContext = logContext;
@@ -28,7 +28,7 @@ public class DaemonThreadFactory implements ThreadFactory {
   @Override
   public Thread newThread(Runnable r) {
     Runnable wrapped = () -> {
-      LogContext.setRegionLogContext(logContext);
+      LogContext.setLogContext(logContext);
       try {
         r.run();
       } finally {

--- a/internal/venice-client-common/src/main/java/com/linkedin/venice/utils/LogContext.java
+++ b/internal/venice-client-common/src/main/java/com/linkedin/venice/utils/LogContext.java
@@ -2,6 +2,8 @@ package com.linkedin.venice.utils;
 
 import javax.annotation.Nullable;
 import org.apache.commons.lang.StringUtils;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.ThreadContext;
 
 
@@ -11,6 +13,8 @@ import org.apache.logging.log4j.ThreadContext;
  * via Log4j2's {@link ThreadContext}.
  */
 public class LogContext {
+  private static final Logger LOGGER = LogManager.getLogger(LogContext.class);
+  public static final LogContext EMPTY = new LogContext(new Builder());
   /**
    * Key used in the logging context (e.g., ThreadContext/MDC) to tag log lines
    * with the component and region name. Helps disambiguate log output in
@@ -48,9 +52,33 @@ public class LogContext {
     }
   }
 
+  public static void setLogContext(Object logContext) {
+    if (logContext instanceof String) {
+      putLogContextKeyValue((String) logContext);
+    } else if (logContext instanceof LogContext) {
+      putLogContextKeyValue(((LogContext) logContext).getValue());
+    }
+  }
+
   private static void putLogContextKeyValue(String value) {
-    if (StringUtils.isNotBlank(value)) {
-      ThreadContext.put(LOG_CONTEXT_KEY, value);
+    try {
+      if (StringUtils.isNotBlank(value)) {
+        ThreadContext.put(LOG_CONTEXT_KEY, value);
+      }
+    } catch (Exception e) {
+      LOGGER.debug("Failed to clear ThreadContext", e);
+      // Ignore any exceptions that occur while setting the log context.
+      // This is a best-effort operation and should not disrupt normal logging.
+    }
+  }
+
+  public static void clearLogContext() {
+    try {
+      ThreadContext.remove(LOG_CONTEXT_KEY);
+    } catch (Exception e) {
+      // Ignore any exceptions that occur while clearing the log context.
+      // This is a best-effort operation and should not disrupt normal logging.
+      LOGGER.debug("Failed to clear ThreadContext", e);
     }
   }
 

--- a/internal/venice-client-common/src/main/java/com/linkedin/venice/utils/LogContext.java
+++ b/internal/venice-client-common/src/main/java/com/linkedin/venice/utils/LogContext.java
@@ -32,7 +32,7 @@ public class LogContext {
     if (StringUtils.isBlank(regionName) && StringUtils.isBlank(componentName)) {
       this.value = "";
     } else {
-      this.value = String.format("%s|%s", componentName, regionName);
+      this.value = String.format("%s--%s", componentName, regionName);
     }
   }
 

--- a/internal/venice-client-common/src/main/java/com/linkedin/venice/utils/concurrent/ThreadPoolFactory.java
+++ b/internal/venice-client-common/src/main/java/com/linkedin/venice/utils/concurrent/ThreadPoolFactory.java
@@ -27,7 +27,7 @@ public final class ThreadPoolFactory {
   public static ThreadPoolExecutor createThreadPool(
       int threadCount,
       String threadNamePrefix,
-      @Nullable String logContext,
+      @Nullable Object logContext,
       int capacity,
       BlockingQueueType blockingQueueType) {
     ThreadPoolExecutor executor = new ThreadPoolExecutor(

--- a/internal/venice-client-common/src/test/java/com/linkedin/venice/utils/LogContextTest.java
+++ b/internal/venice-client-common/src/test/java/com/linkedin/venice/utils/LogContextTest.java
@@ -16,12 +16,12 @@ public class LogContextTest {
 
   @BeforeMethod
   public void setUp() {
-    ThreadContext.clearAll();
+    LogContext.clearLogContext();
   }
 
   @AfterMethod
   public void tearDown() {
-    ThreadContext.clearAll();
+    LogContext.clearLogContext();
   }
 
   @Test
@@ -113,5 +113,63 @@ public class LogContextTest {
 
     LogContext.setStructuredLogContext(second);
     assertEquals(ThreadContext.get(LogContext.LOG_CONTEXT_KEY), second.toString());
+  }
+
+  @Test
+  public void testSetLogContextWithString() {
+    String expected = "test-region";
+    LogContext.setLogContext(expected);
+
+    String actual = ThreadContext.get(LogContext.LOG_CONTEXT_KEY);
+    assertNotNull(actual);
+    assertEquals(actual, expected);
+  }
+
+  @Test
+  public void testSetLogContextWithLogContextObject() {
+    LogContext context = LogContext.newBuilder().setComponentName("server").setRegionName("us-east-1").build();
+
+    LogContext.setLogContext(context);
+
+    String actual = ThreadContext.get(LogContext.LOG_CONTEXT_KEY);
+    assertNotNull(actual);
+    assertEquals(actual, context.toString());
+  }
+
+  @Test
+  public void testSetLogContextWithNull() {
+    LogContext.setLogContext(null);
+    String actual = ThreadContext.get(LogContext.LOG_CONTEXT_KEY);
+    assertNull(actual);
+  }
+
+  @Test
+  public void testSetLogContextWithUnsupportedType() {
+    Object unsupported = new Object();
+    LogContext.setLogContext(unsupported);
+
+    String actual = ThreadContext.get(LogContext.LOG_CONTEXT_KEY);
+    assertNull(actual); // Nothing should have been set
+  }
+
+  @Test
+  public void testClearLogContextRemovesKey() {
+    ThreadContext.put(LogContext.LOG_CONTEXT_KEY, "test-value");
+    assertNotNull(ThreadContext.get(LogContext.LOG_CONTEXT_KEY));
+
+    LogContext.clearLogContext();
+
+    assertNull(ThreadContext.get(LogContext.LOG_CONTEXT_KEY));
+  }
+
+  @Test
+  public void testClearLogContextDoesNotThrowWhenKeyAbsent() {
+    assertNull(ThreadContext.get(LogContext.LOG_CONTEXT_KEY));
+
+    // Should not throw any exception even if the key is not present
+    LogContext.clearLogContext();
+
+    // Still null, but no exception occurred
+    assertNull(ThreadContext.get(LogContext.LOG_CONTEXT_KEY));
   }
 }

--- a/internal/venice-client-common/src/test/java/com/linkedin/venice/utils/LogContextTest.java
+++ b/internal/venice-client-common/src/test/java/com/linkedin/venice/utils/LogContextTest.java
@@ -31,7 +31,7 @@ public class LogContextTest {
     assertNotNull(context);
     assertEquals(context.getRegionName(), REGION_NAME);
     assertEquals(context.getComponentName(), COMPONENT_NAME);
-    assertEquals(context.toString(), COMPONENT_NAME + "|" + REGION_NAME);
+    assertEquals(context.toString(), COMPONENT_NAME + "--" + REGION_NAME);
   }
 
   @Test

--- a/internal/venice-common/src/main/java/com/linkedin/venice/helix/HelixBaseRoutingRepository.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/helix/HelixBaseRoutingRepository.java
@@ -75,7 +75,7 @@ public abstract class HelixBaseRoutingRepository
 
   public HelixBaseRoutingRepository(SafeHelixManager manager) {
     this.manager = manager;
-    listenerManager = new ListenerManager<>(); // TODO make thread count configurable
+    listenerManager = new ListenerManager<>(null); // TODO make thread count configurable
     keyBuilder = new PropertyKey.Builder(manager.getClusterName());
     dataSource = new HashMap<>();
   }

--- a/internal/venice-common/src/main/java/com/linkedin/venice/listener/ListenerManager.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/listener/ListenerManager.java
@@ -28,10 +28,10 @@ public class ListenerManager<T> {
 
   private static final Logger LOGGER = LogManager.getLogger(ListenerManager.class);
 
-  public ListenerManager() {
+  public ListenerManager(Object logContext) {
     listenerMap = new ConcurrentHashMap<>();
     // TODO maybe we can share the thread pool with other use-cases.
-    threadPool = Executors.newFixedThreadPool(threadCount, new DaemonThreadFactory("Venice-controller"));
+    threadPool = Executors.newFixedThreadPool(threadCount, new DaemonThreadFactory("Venice-controller", logContext));
   }
 
   public synchronized void subscribe(String key, T listener) {

--- a/internal/venice-common/src/test/java/com/linkedin/venice/helix/OfflinePushMonitorAccessorTest.java
+++ b/internal/venice-common/src/test/java/com/linkedin/venice/helix/OfflinePushMonitorAccessorTest.java
@@ -10,6 +10,7 @@ import static org.mockito.Mockito.when;
 
 import com.linkedin.venice.pushmonitor.OfflinePushStatus;
 import com.linkedin.venice.pushmonitor.PartitionStatus;
+import com.linkedin.venice.utils.LogContext;
 import java.util.Arrays;
 import java.util.Optional;
 import org.apache.helix.manager.zk.ZkBaseDataAccessor;
@@ -23,8 +24,11 @@ public class OfflinePushMonitorAccessorTest {
   public void testErrorInGettingOfflinePushStatusCreationTimeIsHandled() {
     ZkBaseDataAccessor<OfflinePushStatus> mockOfflinePushStatusAccessor = mock(ZkBaseDataAccessor.class);
     doThrow(new RuntimeException()).when(mockOfflinePushStatusAccessor).getStat(anyString(), anyInt());
-    VeniceOfflinePushMonitorAccessor accessor =
-        new VeniceOfflinePushMonitorAccessor("cluster0", mockOfflinePushStatusAccessor, mock(ZkBaseDataAccessor.class));
+    VeniceOfflinePushMonitorAccessor accessor = new VeniceOfflinePushMonitorAccessor(
+        "cluster0",
+        mockOfflinePushStatusAccessor,
+        mock(ZkBaseDataAccessor.class),
+        LogContext.EMPTY);
     Optional<Long> ctime = accessor.getOfflinePushStatusCreationTime("test");
     Assert.assertFalse(ctime.isPresent());
   }
@@ -33,8 +37,11 @@ public class OfflinePushMonitorAccessorTest {
   public void testNullStatWillReturnEmptyOptional() {
     ZkBaseDataAccessor<OfflinePushStatus> mockOfflinePushStatusAccessor = mock(ZkBaseDataAccessor.class);
     doReturn(null).when(mockOfflinePushStatusAccessor).getStat(anyString(), anyInt());
-    VeniceOfflinePushMonitorAccessor accessor =
-        new VeniceOfflinePushMonitorAccessor("cluster0", mockOfflinePushStatusAccessor, mock(ZkBaseDataAccessor.class));
+    VeniceOfflinePushMonitorAccessor accessor = new VeniceOfflinePushMonitorAccessor(
+        "cluster0",
+        mockOfflinePushStatusAccessor,
+        mock(ZkBaseDataAccessor.class),
+        LogContext.EMPTY);
     Optional<Long> ctime = accessor.getOfflinePushStatusCreationTime("test");
     Assert.assertFalse(ctime.isPresent());
   }
@@ -44,8 +51,11 @@ public class OfflinePushMonitorAccessorTest {
     ZkBaseDataAccessor<OfflinePushStatus> mockOfflinePushStatusAccessor = mock(ZkBaseDataAccessor.class);
     ZkBaseDataAccessor<PartitionStatus> mockPartitionStatusAccessor = mock(ZkBaseDataAccessor.class);
     doReturn(null).when(mockOfflinePushStatusAccessor).getStat(anyString(), anyInt());
-    VeniceOfflinePushMonitorAccessor accessor =
-        new VeniceOfflinePushMonitorAccessor("cluster0", mockOfflinePushStatusAccessor, mockPartitionStatusAccessor);
+    VeniceOfflinePushMonitorAccessor accessor = new VeniceOfflinePushMonitorAccessor(
+        "cluster0",
+        mockOfflinePushStatusAccessor,
+        mockPartitionStatusAccessor,
+        LogContext.EMPTY);
     when(mockPartitionStatusAccessor.exists(anyString(), anyInt())).thenReturn(true);
     when(mockPartitionStatusAccessor.update(anyString(), any(), anyInt())).thenReturn(true);
     accessor.batchUpdateReplicaIncPushStatus("test_topic", 0, "test_instance_id", 100L, Arrays.asList("a", "b"));

--- a/internal/venice-common/src/test/java/com/linkedin/venice/listener/TestListenerManager.java
+++ b/internal/venice-common/src/test/java/com/linkedin/venice/listener/TestListenerManager.java
@@ -3,6 +3,7 @@ package com.linkedin.venice.listener;
 import com.linkedin.venice.meta.PartitionAssignment;
 import com.linkedin.venice.meta.RoutingDataRepository;
 import com.linkedin.venice.pushmonitor.ReadOnlyPartitionStatus;
+import com.linkedin.venice.utils.LogContext;
 import com.linkedin.venice.utils.TestUtils;
 import com.linkedin.venice.utils.Utils;
 import java.util.concurrent.TimeUnit;
@@ -11,7 +12,8 @@ import org.testng.annotations.Test;
 
 
 public class TestListenerManager {
-  private ListenerManager<RoutingDataRepository.RoutingDataChangedListener> manager = new ListenerManager<>();
+  private ListenerManager<RoutingDataRepository.RoutingDataChangedListener> manager =
+      new ListenerManager<>(LogContext.EMPTY);
   private final static int TEST_TIME_OUT = 500;
 
   @Test

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/controller/AbstractTestVeniceHelixAdmin.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/controller/AbstractTestVeniceHelixAdmin.java
@@ -37,6 +37,7 @@ import com.linkedin.venice.pubsub.api.PubSubTopic;
 import com.linkedin.venice.pubsub.manager.TopicManager;
 import com.linkedin.venice.stats.HelixMessageChannelStats;
 import com.linkedin.venice.utils.HelixUtils;
+import com.linkedin.venice.utils.LogContext;
 import com.linkedin.venice.utils.MockTestStateModelFactory;
 import com.linkedin.venice.utils.TestUtils;
 import com.linkedin.venice.utils.Time;
@@ -164,7 +165,8 @@ class AbstractTestVeniceHelixAdmin {
         new ZkClient(zkAddress),
         new HelixAdapterSerializer(),
         3,
-        1000);
+        1000,
+        LogContext.EMPTY);
 
     MockTestStateModelFactory stateModelFactory;
 

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/controller/TestIncrementalPush.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/controller/TestIncrementalPush.java
@@ -23,6 +23,7 @@ import com.linkedin.venice.meta.Version;
 import com.linkedin.venice.pushmonitor.ExecutionStatus;
 import com.linkedin.venice.pushmonitor.OfflinePushStatus;
 import com.linkedin.venice.utils.IntegrationTestPushUtils;
+import com.linkedin.venice.utils.LogContext;
 import com.linkedin.venice.utils.TestUtils;
 import com.linkedin.venice.utils.TestWriteUtils;
 import com.linkedin.venice.utils.Time;
@@ -111,8 +112,13 @@ public class TestIncrementalPush {
             .equals(ExecutionStatus.START_OF_INCREMENTAL_PUSH_RECEIVED));
 
     ZkClient zkClient = ZkClientFactory.newZkClient(cluster.getZk().getAddress());
-    VeniceOfflinePushMonitorAccessor accessor =
-        new VeniceOfflinePushMonitorAccessor(cluster.getClusterName(), zkClient, new HelixAdapterSerializer(), 1, 0);
+    VeniceOfflinePushMonitorAccessor accessor = new VeniceOfflinePushMonitorAccessor(
+        cluster.getClusterName(),
+        zkClient,
+        new HelixAdapterSerializer(),
+        1,
+        0,
+        LogContext.EMPTY);
 
     // Even after consuming SOIP, we should see replica current status not flipped to non-terminal status
     TestUtils.waitForNonDeterministicAssertion(30, TimeUnit.SECONDS, () -> {

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestHelixCustomizedView.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestHelixCustomizedView.java
@@ -123,8 +123,13 @@ public class TestHelixCustomizedView {
      */
     ZkClient zkClient = ZkClientFactory.newZkClient(veniceCluster.getZk().getAddress());
     HelixAdapterSerializer adapterSerializer = new HelixAdapterSerializer();
-    VeniceOfflinePushMonitorAccessor offlinePushStatusAccessor =
-        new VeniceOfflinePushMonitorAccessor(veniceCluster.getClusterName(), zkClient, adapterSerializer, 3, 1000);
+    VeniceOfflinePushMonitorAccessor offlinePushStatusAccessor = new VeniceOfflinePushMonitorAccessor(
+        veniceCluster.getClusterName(),
+        zkClient,
+        adapterSerializer,
+        3,
+        1000,
+        veniceCluster.getRegionName());
     HelixUtils.create(
         offlinePushStatusAccessor.getOfflinePushStatusAccessor(),
         offlinePushStatusAccessor.getOfflinePushStatuesParentPath() + "/invalid_topic",

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/helix/HelixOfflinePushMonitorAccessorTest.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/helix/HelixOfflinePushMonitorAccessorTest.java
@@ -12,6 +12,7 @@ import com.linkedin.venice.pushmonitor.OfflinePushStatus;
 import com.linkedin.venice.pushmonitor.PartitionStatus;
 import com.linkedin.venice.pushmonitor.ReadOnlyPartitionStatus;
 import com.linkedin.venice.utils.HelixUtils;
+import com.linkedin.venice.utils.LogContext;
 import com.linkedin.venice.utils.Utils;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -40,7 +41,13 @@ public class HelixOfflinePushMonitorAccessorTest {
     zk = ServiceFactory.getZkServer();
     String zkAddress = zk.getAddress();
     zkClient = ZkClientFactory.newZkClient(zkAddress);
-    accessor = new VeniceOfflinePushMonitorAccessor(clusterName, zkClient, new HelixAdapterSerializer(), 1, 0);
+    accessor = new VeniceOfflinePushMonitorAccessor(
+        clusterName,
+        zkClient,
+        new HelixAdapterSerializer(),
+        1,
+        0,
+        LogContext.EMPTY);
   }
 
   @AfterMethod

--- a/internal/venice-test-common/src/main/java/com/linkedin/venice/utils/TestUtils.java
+++ b/internal/venice-test-common/src/main/java/com/linkedin/venice/utils/TestUtils.java
@@ -649,8 +649,13 @@ public class TestUtils {
       String stateModelDef) {
     ZkClient foo = new ZkClient(zkAddress);
     foo.close();
-    VeniceOfflinePushMonitorAccessor offlinePushStatusAccessor =
-        new VeniceOfflinePushMonitorAccessor(cluster, new ZkClient(zkAddress), new HelixAdapterSerializer(), 3, 1000);
+    VeniceOfflinePushMonitorAccessor offlinePushStatusAccessor = new VeniceOfflinePushMonitorAccessor(
+        cluster,
+        new ZkClient(zkAddress),
+        new HelixAdapterSerializer(),
+        3,
+        1000,
+        cluster);
     MockTestStateModelFactory stateModelFactory = new MockTestStateModelFactory(offlinePushStatusAccessor);
     return getParticipant(cluster, nodeId, zkAddress, httpPort, stateModelFactory, stateModelDef);
   }

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/Admin.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/Admin.java
@@ -46,6 +46,7 @@ import com.linkedin.venice.system.store.MetaStoreReader;
 import com.linkedin.venice.system.store.MetaStoreWriter;
 import com.linkedin.venice.systemstore.schemas.StoreMetaKey;
 import com.linkedin.venice.systemstore.schemas.StoreMetaValue;
+import com.linkedin.venice.utils.LogContext;
 import com.linkedin.venice.utils.Pair;
 import com.linkedin.venice.utils.VeniceProperties;
 import com.linkedin.venice.writer.VeniceWriterFactory;
@@ -1043,4 +1044,6 @@ public interface Admin extends AutoCloseable, Closeable {
   HelixVeniceClusterResources getHelixVeniceClusterResources(String cluster);
 
   PubSubTopicRepository getPubSubTopicRepository();
+
+  LogContext getLogContext();
 }

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/DeferredVersionSwapService.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/DeferredVersionSwapService.java
@@ -17,6 +17,7 @@ import com.linkedin.venice.meta.Version;
 import com.linkedin.venice.meta.VersionStatus;
 import com.linkedin.venice.pushmonitor.ExecutionStatus;
 import com.linkedin.venice.service.AbstractVeniceService;
+import com.linkedin.venice.utils.LogContext;
 import com.linkedin.venice.utils.RedundantExceptionFilter;
 import com.linkedin.venice.utils.RegionUtils;
 import java.time.LocalDateTime;
@@ -378,6 +379,7 @@ public class DeferredVersionSwapService extends AbstractVeniceService {
 
   private Runnable getRunnableForDeferredVersionSwap() {
     return () -> {
+      LogContext.setStructuredLogContext(veniceControllerMultiClusterConfig.getLogContext());
       if (stop.get()) {
         return;
       }

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/DisabledPartitionEnablerService.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/DisabledPartitionEnablerService.java
@@ -1,6 +1,7 @@
 package com.linkedin.venice.controller;
 
 import com.linkedin.venice.service.AbstractVeniceService;
+import com.linkedin.venice.utils.LogContext;
 import com.linkedin.venice.utils.SystemTime;
 import com.linkedin.venice.utils.Time;
 import java.util.Set;
@@ -55,6 +56,7 @@ public class DisabledPartitionEnablerService extends AbstractVeniceService {
   private class DisabledPartitionEnablerTask implements Runnable {
     @Override
     public void run() {
+      LogContext.setStructuredLogContext(multiClusterConfig.getLogContext());
       while (!stop.get()) {
         try {
           time.sleep(sleepInterval);

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/HelixVeniceClusterResources.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/HelixVeniceClusterResources.java
@@ -149,7 +149,8 @@ public class HelixVeniceClusterResources implements VeniceResource {
         zkClient,
         adapterSerializer,
         config.getRefreshAttemptsForZkReconnect(),
-        config.getRefreshIntervalForZkReconnectInMs());
+        config.getRefreshIntervalForZkReconnectInMs(),
+        config.getLogContext());
     String aggregateRealTimeSourceKafkaUrl =
         config.getChildDataCenterKafkaUrlMap().get(config.getAggregateRealTimeSourceRegion());
     boolean unregisterMetricEnabled = config.isUnregisterMetricForDeletedStoreEnabled();

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/StoreBackupVersionCleanupService.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/StoreBackupVersionCleanupService.java
@@ -13,6 +13,7 @@ import com.linkedin.venice.meta.Store;
 import com.linkedin.venice.meta.Version;
 import com.linkedin.venice.security.SSLFactory;
 import com.linkedin.venice.service.AbstractVeniceService;
+import com.linkedin.venice.utils.LogContext;
 import com.linkedin.venice.utils.ObjectMapperFactory;
 import com.linkedin.venice.utils.SystemTime;
 import com.linkedin.venice.utils.Time;
@@ -315,6 +316,7 @@ public class StoreBackupVersionCleanupService extends AbstractVeniceService {
   private class StoreBackupVersionCleanupTask implements Runnable {
     @Override
     public void run() {
+      LogContext.setStructuredLogContext(multiClusterConfig.getLogContext());
       boolean interruptReceived = false;
       while (!stop.get()) {
         try {

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/StoreGraveyardCleanupService.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/StoreGraveyardCleanupService.java
@@ -2,6 +2,7 @@ package com.linkedin.venice.controller;
 
 import com.linkedin.venice.exceptions.ResourceStillExistsException;
 import com.linkedin.venice.service.AbstractVeniceService;
+import com.linkedin.venice.utils.LogContext;
 import com.linkedin.venice.utils.SystemTime;
 import com.linkedin.venice.utils.Time;
 import java.util.List;
@@ -59,6 +60,7 @@ public class StoreGraveyardCleanupService extends AbstractVeniceService {
   private class StoreGraveyardCleanupTask implements Runnable {
     @Override
     public void run() {
+      LogContext.setStructuredLogContext(multiClusterConfig.getLogContext());
       LOGGER.info("Started running {}", getClass().getSimpleName());
       while (!stop.get()) {
         try {

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/UnusedValueSchemaCleanupService.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/UnusedValueSchemaCleanupService.java
@@ -7,6 +7,7 @@ import com.linkedin.venice.meta.Version;
 import com.linkedin.venice.schema.SchemaEntry;
 import com.linkedin.venice.service.AbstractVeniceService;
 import com.linkedin.venice.utils.DaemonThreadFactory;
+import com.linkedin.venice.utils.LogContext;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.HashSet;
@@ -45,6 +46,7 @@ public class UnusedValueSchemaCleanupService extends AbstractVeniceService {
 
   private Runnable getRunnableForSchemaCleanup() {
     return () -> {
+      LogContext.setStructuredLogContext(multiClusterConfig.getLogContext());
       if (stop) {
         return;
       }

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceController.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceController.java
@@ -36,6 +36,7 @@ import com.linkedin.venice.service.ICProvider;
 import com.linkedin.venice.servicediscovery.AsyncRetryingServiceDiscoveryAnnouncer;
 import com.linkedin.venice.servicediscovery.ServiceDiscoveryAnnouncer;
 import com.linkedin.venice.system.store.ControllerClientBackedSystemSchemaInitializer;
+import com.linkedin.venice.utils.LogContext;
 import com.linkedin.venice.utils.PropertyBuilder;
 import com.linkedin.venice.utils.SslUtils;
 import com.linkedin.venice.utils.Utils;
@@ -96,6 +97,7 @@ public class VeniceController {
   private final Optional<SupersetSchemaGenerator> externalSupersetSchemaGenerator;
   private final PubSubTopicRepository pubSubTopicRepository;
   private final PubSubClientsFactory pubSubClientsFactory;
+  private final LogContext logContext;
 
   /**
    * Allocates a new {@code VeniceController} object.
@@ -145,6 +147,7 @@ public class VeniceController {
 
   public VeniceController(VeniceControllerContext ctx) {
     this.multiClusterConfigs = new VeniceControllerMultiClusterConfig(ctx.getPropertiesList());
+    this.logContext = multiClusterConfigs.getLogContext();
     this.metricsRepository = ctx.getMetricsRepository();
     this.serviceDiscoveryAnnouncers = ctx.getServiceDiscoveryAnnouncers();
     Optional<SSLConfig> sslConfig = multiClusterConfigs.getSslConfig();
@@ -323,7 +326,7 @@ public class VeniceController {
     grpcExecutor = ThreadPoolFactory.createThreadPool(
         multiClusterConfigs.getGrpcServerThreadCount(),
         CONTROLLER_GRPC_SERVER_THREAD_NAME,
-        multiClusterConfigs.getRegionName(),
+        multiClusterConfigs.getLogContext(),
         Integer.MAX_VALUE,
         BlockingQueueType.LINKED_BLOCKING_QUEUE);
 

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceControllerClusterConfig.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceControllerClusterConfig.java
@@ -217,6 +217,7 @@ import com.linkedin.venice.pubsub.api.PubSubSecurityProtocol;
 import com.linkedin.venice.pushmonitor.LeakedPushStatusCleanUpService;
 import com.linkedin.venice.status.BatchJobHeartbeatConfigs;
 import com.linkedin.venice.utils.HelixUtils;
+import com.linkedin.venice.utils.LogContext;
 import com.linkedin.venice.utils.RegionUtils;
 import com.linkedin.venice.utils.Time;
 import com.linkedin.venice.utils.Utils;
@@ -595,6 +596,7 @@ public class VeniceControllerClusterConfig {
   private final boolean isPreFetchDeadStoreStatsEnabled;
   private final long deadStoreStatsPreFetchIntervalInMs;
   private final VeniceProperties deadStoreStatsConfigs;
+  private final LogContext logContext;
 
   public VeniceControllerClusterConfig(VeniceProperties props) {
     this.props = props;
@@ -1130,6 +1132,7 @@ public class VeniceControllerClusterConfig {
         props.getLong(CONTROLLER_DEFERRED_VERSION_SWAP_SLEEP_MS, TimeUnit.MINUTES.toMillis(1));
     this.deferredVersionSwapServiceEnabled = props.getBoolean(CONTROLLER_DEFERRED_VERSION_SWAP_SERVICE_ENABLED, false);
     this.skipDeferredVersionSwapForDVCEnabled = props.getBoolean(SKIP_DEFERRED_VERSION_SWAP_FOR_DVC_ENABLED, true);
+    this.logContext = new LogContext.Builder().setRegionName(regionName).setComponentName("controller").build();
   }
 
   public VeniceProperties getProps() {
@@ -2112,5 +2115,9 @@ public class VeniceControllerClusterConfig {
       throw new ConfigurationException(
           CONTROLLER_HELIX_INSTANCE_CAPACITY + " cannot be <  " + CONTROLLER_HELIX_RESOURCE_CAPACITY_WEIGHT);
     }
+  }
+
+  public LogContext getLogContext() {
+    return logContext;
   }
 }

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceControllerMultiClusterConfig.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceControllerMultiClusterConfig.java
@@ -5,6 +5,7 @@ import com.linkedin.venice.controllerapi.ControllerRoute;
 import com.linkedin.venice.exceptions.VeniceNoClusterException;
 import com.linkedin.venice.pubsub.PubSubAdminAdapterFactory;
 import com.linkedin.venice.pubsub.PubSubClientsFactory;
+import com.linkedin.venice.utils.LogContext;
 import com.linkedin.venice.utils.VeniceProperties;
 import java.time.Duration;
 import java.util.Collection;
@@ -360,5 +361,9 @@ public class VeniceControllerMultiClusterConfig {
 
   public boolean isRealTimeTopicVersioningEnabled() {
     return getCommonConfig().getRealTimeTopicVersioningEnabled();
+  }
+
+  public LogContext getLogContext() {
+    return getCommonConfig().getLogContext();
   }
 }

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceParentHelixAdmin.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceParentHelixAdmin.java
@@ -235,6 +235,7 @@ import com.linkedin.venice.systemstore.schemas.StoreMetaKey;
 import com.linkedin.venice.systemstore.schemas.StoreMetaValue;
 import com.linkedin.venice.utils.AvroSchemaUtils;
 import com.linkedin.venice.utils.CollectionUtils;
+import com.linkedin.venice.utils.LogContext;
 import com.linkedin.venice.utils.ObjectMapperFactory;
 import com.linkedin.venice.utils.Pair;
 import com.linkedin.venice.utils.PartitionUtils;
@@ -363,6 +364,7 @@ public class VeniceParentHelixAdmin implements Admin {
   private final SupersetSchemaGenerator defaultSupersetSchemaGenerator = new DefaultSupersetSchemaGenerator();
 
   private final IdentityParser identityParser;
+  private final LogContext logContext;
 
   // New fabric controller client map per cluster per fabric
   private final Map<String, Map<String, ControllerClient>> newFabricControllerClientMap =
@@ -433,6 +435,7 @@ public class VeniceParentHelixAdmin implements Admin {
     Validate.notNull(writeComputeSchemaConverter);
     this.veniceHelixAdmin = veniceHelixAdmin;
     this.multiClusterConfigs = multiClusterConfigs;
+    this.logContext = multiClusterConfigs.getLogContext();
     this.waitingTimeForConsumptionMs = this.multiClusterConfigs.getParentControllerWaitingTimeForConsumptionMs();
     this.veniceWriterMap = new ConcurrentHashMap<>();
     this.adminTopicMetadataAccessor = new ZkAdminTopicMetadataAccessor(
@@ -5752,5 +5755,10 @@ public class VeniceParentHelixAdmin implements Admin {
   @Override
   public PubSubTopicRepository getPubSubTopicRepository() {
     return pubSubTopicRepository;
+  }
+
+  @Override
+  public LogContext getLogContext() {
+    return getVeniceHelixAdmin().getLogContext();
   }
 }

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/kafka/TopicCleanupService.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/kafka/TopicCleanupService.java
@@ -17,6 +17,7 @@ import com.linkedin.venice.pubsub.api.PubSubTopicType;
 import com.linkedin.venice.pubsub.manager.TopicManager;
 import com.linkedin.venice.service.AbstractVeniceService;
 import com.linkedin.venice.utils.ExceptionUtils;
+import com.linkedin.venice.utils.LogContext;
 import com.linkedin.venice.utils.Time;
 import com.linkedin.venice.utils.VeniceProperties;
 import java.util.ArrayList;
@@ -177,6 +178,7 @@ public class TopicCleanupService extends AbstractVeniceService {
   private class TopicCleanupTask implements Runnable {
     @Override
     public void run() {
+      LogContext.setStructuredLogContext(multiClusterConfigs.getLogContext());
       while (!stop.get()) {
         try {
           Thread.sleep(sleepIntervalBetweenTopicListFetchMs);

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/kafka/consumer/AdminConsumerService.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/kafka/consumer/AdminConsumerService.java
@@ -236,7 +236,7 @@ public class AdminConsumerService extends AbstractVeniceService {
      * {@link KAFKA_CLIENT_ID_CONFIG} can be used to identify different consumers while checking Kafka related metrics.
      */
     kafkaConsumerProperties
-        .setProperty(KAFKA_CLIENT_ID_CONFIG, clusterName + (logContext != null ? logContext.toString() : ""));
+        .setProperty(KAFKA_CLIENT_ID_CONFIG, (logContext != null ? logContext + "--" : "") + clusterName);
     kafkaConsumerProperties.setProperty(KAFKA_AUTO_OFFSET_RESET_CONFIG, "earliest");
     /**
      * Reason to disable auto_commit

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/kafka/consumer/AdminConsumerService.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/kafka/consumer/AdminConsumerService.java
@@ -16,6 +16,7 @@ import com.linkedin.venice.pubsub.api.PubSubConsumerAdapter;
 import com.linkedin.venice.pubsub.api.PubSubMessageDeserializer;
 import com.linkedin.venice.service.AbstractVeniceService;
 import com.linkedin.venice.utils.DaemonThreadFactory;
+import com.linkedin.venice.utils.LogContext;
 import com.linkedin.venice.utils.VeniceProperties;
 import com.linkedin.venice.utils.locks.AutoCloseableLock;
 import io.tehuti.metrics.MetricsRepository;
@@ -46,6 +47,7 @@ public class AdminConsumerService extends AbstractVeniceService {
   private final PubSubTopicRepository pubSubTopicRepository;
   private final String localKafkaServerUrl;
   private final PubSubMessageDeserializer pubSubMessageDeserializer;
+  private final LogContext logContext;
 
   public AdminConsumerService(
       VeniceHelixAdmin admin,
@@ -54,6 +56,7 @@ public class AdminConsumerService extends AbstractVeniceService {
       PubSubTopicRepository pubSubTopicRepository,
       PubSubMessageDeserializer pubSubMessageDeserializer) {
     this.config = config;
+    this.logContext = config.getLogContext();
     this.admin = admin;
     this.adminTopicMetadataAccessor =
         new ZkAdminTopicMetadataAccessor(admin.getZkClient(), admin.getAdapterSerializer());
@@ -69,7 +72,7 @@ public class AdminConsumerService extends AbstractVeniceService {
     }
     this.localKafkaServerUrl = admin.getKafkaBootstrapServers(admin.isSslToKafka());
     this.consumerFactory = admin.getPubSubConsumerAdapterFactory();
-    this.threadFactory = new DaemonThreadFactory("AdminConsumerService", config.getRegionName());
+    this.threadFactory = new DaemonThreadFactory("AdminConsumerService", logContext);
   }
 
   @Override
@@ -232,7 +235,8 @@ public class AdminConsumerService extends AbstractVeniceService {
     /**
      * {@link KAFKA_CLIENT_ID_CONFIG} can be used to identify different consumers while checking Kafka related metrics.
      */
-    kafkaConsumerProperties.setProperty(KAFKA_CLIENT_ID_CONFIG, clusterName);
+    kafkaConsumerProperties
+        .setProperty(KAFKA_CLIENT_ID_CONFIG, clusterName + (logContext != null ? logContext.toString() : ""));
     kafkaConsumerProperties.setProperty(KAFKA_AUTO_OFFSET_RESET_CONFIG, "earliest");
     /**
      * Reason to disable auto_commit

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/kafka/consumer/AdminConsumptionTask.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/kafka/consumer/AdminConsumptionTask.java
@@ -289,7 +289,7 @@ public class AdminConsumptionTask implements Runnable, Closeable {
         60,
         TimeUnit.SECONDS,
         new LinkedBlockingQueue<>(MAX_WORKER_QUEUE_SIZE),
-        new DaemonThreadFactory(String.format("Venice-Admin-Execution-Task-%s", clusterName), regionName));
+        new DaemonThreadFactory(String.format("Venice-Admin-Execution-Task-%s", clusterName), admin.getLogContext()));
     this.undelegatedRecords = new LinkedList<>();
     this.stats.setAdminConsumptionFailedOffset(failingOffset);
     this.pubSubTopic = pubSubTopicRepository.getTopic(topic);

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/logcompaction/LogCompactionService.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/logcompaction/LogCompactionService.java
@@ -7,6 +7,7 @@ import com.linkedin.venice.controller.repush.RepushJobRequest;
 import com.linkedin.venice.controllerapi.RepushJobResponse;
 import com.linkedin.venice.meta.StoreInfo;
 import com.linkedin.venice.service.AbstractVeniceService;
+import com.linkedin.venice.utils.LogContext;
 import java.util.Set;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
@@ -79,6 +80,7 @@ public class LogCompactionService extends AbstractVeniceService {
 
     @Override
     public void run() {
+      LogContext.setStructuredLogContext(multiClusterConfigs.getLogContext());
       try {
         compactStoresInClusters();
       } catch (Throwable e) {

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/systemstore/SystemStoreRepairTask.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/systemstore/SystemStoreRepairTask.java
@@ -60,7 +60,7 @@ public class SystemStoreRepairTask implements Runnable {
 
   @Override
   public void run() {
-    LogContext.setStructuredLogContext(parentAdmin.getLogContext());
+    LogContext.setStructuredLogContext(getParentAdmin().getLogContext());
     for (String clusterName: getParentAdmin().getClustersLeaderOf()) {
       if (!getClusterToSystemStoreHealthCheckStatsMap().containsKey(clusterName)) {
         continue;

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/systemstore/SystemStoreRepairTask.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/systemstore/SystemStoreRepairTask.java
@@ -10,6 +10,7 @@ import com.linkedin.venice.controllerapi.ControllerClient;
 import com.linkedin.venice.meta.Store;
 import com.linkedin.venice.meta.Version;
 import com.linkedin.venice.pushmonitor.ExecutionStatus;
+import com.linkedin.venice.utils.LogContext;
 import com.linkedin.venice.utils.concurrent.VeniceConcurrentHashMap;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -59,6 +60,7 @@ public class SystemStoreRepairTask implements Runnable {
 
   @Override
   public void run() {
+    LogContext.setStructuredLogContext(parentAdmin.getLogContext());
     for (String clusterName: getParentAdmin().getClustersLeaderOf()) {
       if (!getClusterToSystemStoreHealthCheckStatsMap().containsKey(clusterName)) {
         continue;

--- a/services/venice-controller/src/main/java/com/linkedin/venice/pushmonitor/AbstractPushMonitor.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/pushmonitor/AbstractPushMonitor.java
@@ -146,7 +146,8 @@ public abstract class AbstractPushMonitor
         controllerConfig.getDaVinciPushStatusScanNoReportRetryMaxAttempt(),
         controllerConfig.getDaVinciPushStatusScanMaxOfflineInstanceCount(),
         controllerConfig.getDaVinciPushStatusScanMaxOfflineInstanceRatio(),
-        controllerConfig.useDaVinciSpecificExecutionStatusForError());
+        controllerConfig.useDaVinciSpecificExecutionStatusForError(),
+        controllerConfig.getLogContext());
     this.isOfflinePushMonitorDaVinciPushStatusEnabled = controllerConfig.isDaVinciPushStatusEnabled();
     this.regionName = controllerConfig.getRegionName();
     this.veniceWriterFactory = veniceWriterFactory;

--- a/services/venice-controller/src/main/java/com/linkedin/venice/pushmonitor/PushStatusCollector.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/pushmonitor/PushStatusCollector.java
@@ -4,6 +4,8 @@ import com.linkedin.venice.meta.ReadWriteStoreRepository;
 import com.linkedin.venice.meta.Store;
 import com.linkedin.venice.meta.Version;
 import com.linkedin.venice.pushstatushelper.PushStatusStoreReader;
+import com.linkedin.venice.utils.DaemonThreadFactory;
+import com.linkedin.venice.utils.LogContext;
 import com.linkedin.venice.utils.concurrent.VeniceConcurrentHashMap;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -48,6 +50,7 @@ public class PushStatusCollector {
 
   private final Map<String, Integer> topicToNoDaVinciStatusRetryCountMap = new HashMap<>();
   private final boolean useDaVinciSpecificExecutionStatusForError;
+  private final LogContext logContext;
 
   public PushStatusCollector(
       ReadWriteStoreRepository storeRepository,
@@ -60,7 +63,8 @@ public class PushStatusCollector {
       int daVinciPushStatusNoReportRetryMaxAttempts,
       int daVinciPushStatusScanMaxOfflineInstanceCount,
       double daVinciPushStatusScanMaxOfflineInstanceRatio,
-      boolean useDaVinciSpecificExecutionStatusForError) {
+      boolean useDaVinciSpecificExecutionStatusForError,
+      LogContext logContext) {
     this.storeRepository = storeRepository;
     this.pushStatusStoreReader = pushStatusStoreReader;
     this.pushCompletedHandler = pushCompletedHandler;
@@ -72,6 +76,7 @@ public class PushStatusCollector {
     this.daVinciPushStatusScanMaxOfflineInstanceCount = daVinciPushStatusScanMaxOfflineInstanceCount;
     this.daVinciPushStatusScanMaxOfflineInstanceRatio = daVinciPushStatusScanMaxOfflineInstanceRatio;
     this.useDaVinciSpecificExecutionStatusForError = useDaVinciSpecificExecutionStatusForError;
+    this.logContext = logContext;
   }
 
   public void start() {
@@ -82,11 +87,14 @@ public class PushStatusCollector {
 
     if (isStarted.compareAndSet(false, true)) {
       if (offlinePushCheckScheduler == null || offlinePushCheckScheduler.isShutdown()) {
-        offlinePushCheckScheduler = Executors.newScheduledThreadPool(1);
+        offlinePushCheckScheduler =
+            Executors.newScheduledThreadPool(1, new DaemonThreadFactory("OfflinePushCheckScheduler", logContext));
         LOGGER.info("Created a new offline push check scheduler");
       }
       if (pushStatusStoreScanExecutor == null || pushStatusStoreScanExecutor.isShutdown()) {
-        pushStatusStoreScanExecutor = Executors.newFixedThreadPool(daVinciPushStatusScanThreadNumber);
+        pushStatusStoreScanExecutor = Executors.newFixedThreadPool(
+            daVinciPushStatusScanThreadNumber,
+            new DaemonThreadFactory("PushStatusStoreScanExecutor", logContext));
         LOGGER.info("Created a new push status store executor with {} threads", daVinciPushStatusScanThreadNumber);
       }
       offlinePushCheckScheduler
@@ -118,6 +126,7 @@ public class PushStatusCollector {
   }
 
   private void scanDaVinciPushStatus() {
+    LogContext.setStructuredLogContext(logContext);
     List<CompletableFuture<TopicPushStatus>> resultList = new ArrayList<>();
     for (Map.Entry<String, TopicPushStatus> entry: topicToPushStatusMap.entrySet()) {
       String topicName = entry.getKey();

--- a/services/venice-controller/src/test/java/com/linkedin/venice/controller/kafka/consumer/TestAdminConsumerService.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/controller/kafka/consumer/TestAdminConsumerService.java
@@ -8,10 +8,19 @@ import static com.linkedin.venice.ConfigKeys.CLUSTER_TO_SERVER_D2;
 import static com.linkedin.venice.ConfigKeys.DEFAULT_MAX_NUMBER_OF_PARTITIONS;
 import static com.linkedin.venice.ConfigKeys.DEFAULT_PARTITION_SIZE;
 import static com.linkedin.venice.ConfigKeys.KAFKA_BOOTSTRAP_SERVERS;
+import static com.linkedin.venice.ConfigKeys.KAFKA_CLIENT_ID_CONFIG;
+import static com.linkedin.venice.ConfigKeys.LOCAL_REGION_NAME;
 import static com.linkedin.venice.ConfigKeys.NATIVE_REPLICATION_FABRIC_ALLOWLIST;
 import static com.linkedin.venice.ConfigKeys.ZOOKEEPER_ADDRESS;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
 
 import com.linkedin.venice.controller.VeniceControllerClusterConfig;
 import com.linkedin.venice.controller.VeniceHelixAdmin;
@@ -19,6 +28,7 @@ import com.linkedin.venice.helix.HelixAdapterSerializer;
 import com.linkedin.venice.kafka.protocol.KafkaMessageEnvelope;
 import com.linkedin.venice.pubsub.PubSubConsumerAdapterFactory;
 import com.linkedin.venice.pubsub.PubSubTopicRepository;
+import com.linkedin.venice.pubsub.api.PubSubConsumerAdapter;
 import com.linkedin.venice.pubsub.api.PubSubMessageDeserializer;
 import com.linkedin.venice.serialization.avro.OptimizedKafkaValueSerializer;
 import com.linkedin.venice.utils.PropertyBuilder;
@@ -28,7 +38,9 @@ import com.linkedin.venice.utils.Utils;
 import com.linkedin.venice.utils.VeniceProperties;
 import com.linkedin.venice.utils.pools.LandFillObjectPool;
 import io.tehuti.metrics.MetricsRepository;
+import java.lang.reflect.Method;
 import java.util.Collections;
+import java.util.Properties;
 import org.apache.helix.zookeeper.impl.client.ZkClient;
 import org.testng.Assert;
 import org.testng.annotations.Test;
@@ -102,5 +114,67 @@ public class TestAdminConsumerService {
       Utils.closeQuietlyWithErrorLogged(adminConsumerService1);
       Utils.closeQuietlyWithErrorLogged(adminConsumerService2);
     }
+  }
+
+  @Test
+  public void testCreateKafkaConsumerWithExpectedKafkaProperties() throws Exception {
+    MetricsRepository metricsRepository = new MetricsRepository();
+
+    String clusterName = "clusterName";
+    String region = "dc-0";
+
+    VeniceProperties props = new PropertyBuilder().put(TestUtils.getPropertiesForControllerConfig())
+        .put(ZOOKEEPER_ADDRESS, "localhost:2181")
+        .put(KAFKA_BOOTSTRAP_SERVERS, "localhost:9092")
+        .put(DEFAULT_PARTITION_SIZE, "25GB")
+        .put(DEFAULT_MAX_NUMBER_OF_PARTITIONS, "4096")
+        .put(CLUSTER_TO_D2, TestUtils.getClusterToD2String(Collections.singletonMap(clusterName, "dummy_d2")))
+        .put(
+            CLUSTER_TO_SERVER_D2,
+            TestUtils.getClusterToD2String(Collections.singletonMap(clusterName, "dummy_server_d2")))
+        .put(ADMIN_TOPIC_SOURCE_REGION, region)
+        .put(NATIVE_REPLICATION_FABRIC_ALLOWLIST, region)
+        .put(CHILD_DATA_CENTER_KAFKA_URL_PREFIX + "." + region, "blah")
+        .put(CHILD_CLUSTER_ALLOWLIST, clusterName)
+        .put(LOCAL_REGION_NAME, region)
+        .put(SslUtils.getVeniceLocalSslProperties())
+        .build();
+    VeniceControllerClusterConfig controllerConfig = new VeniceControllerClusterConfig(props);
+
+    PubSubConsumerAdapterFactory consumerFactory = mock(PubSubConsumerAdapterFactory.class);
+    PubSubConsumerAdapter mockConsumer = mock(PubSubConsumerAdapter.class);
+    when(consumerFactory.create(any(), eq(false), any(), eq(clusterName))).thenReturn(mockConsumer);
+
+    VeniceHelixAdmin admin = mock(VeniceHelixAdmin.class);
+    doReturn(mock(ZkClient.class)).when(admin).getZkClient();
+    doReturn(mock(HelixAdapterSerializer.class)).when(admin).getAdapterSerializer();
+    doReturn(consumerFactory).when(admin).getPubSubConsumerAdapterFactory();
+    doReturn("localhost:1234").when(admin).getKafkaBootstrapServers(true);
+    doReturn(false).when(admin).isSslToKafka();
+    VeniceProperties veniceProperties = mock(VeniceProperties.class);
+    Properties pubSubProperties = new Properties();
+    when(veniceProperties.toProperties()).thenReturn(pubSubProperties);
+    when(admin.getPubSubSSLProperties(anyString())).thenReturn(veniceProperties);
+
+    PubSubTopicRepository pubSubTopicRepository = new PubSubTopicRepository();
+    PubSubMessageDeserializer deserializer = new PubSubMessageDeserializer(
+        new OptimizedKafkaValueSerializer(),
+        new LandFillObjectPool<>(KafkaMessageEnvelope::new),
+        new LandFillObjectPool<>(KafkaMessageEnvelope::new));
+
+    AdminConsumerService service =
+        new AdminConsumerService(admin, controllerConfig, metricsRepository, pubSubTopicRepository, deserializer);
+
+    // Access private createKafkaConsumer via reflection
+    Method method = AdminConsumerService.class.getDeclaredMethod("createKafkaConsumer", String.class);
+    method.setAccessible(true);
+    PubSubConsumerAdapter result = (PubSubConsumerAdapter) method.invoke(service, clusterName);
+
+    assertNotNull(result);
+    verify(admin).getPubSubSSLProperties(anyString());
+    verify(consumerFactory).create(any(VeniceProperties.class), eq(false), eq(deserializer), eq(clusterName));
+    String clientId = pubSubProperties.getProperty(KAFKA_CLIENT_ID_CONFIG);
+    assertNotNull(clientId, "Client ID should not be null");
+    assertTrue(clientId.contains(controllerConfig.getLogContext().toString()), "Got: " + clientId);
   }
 }

--- a/services/venice-controller/src/test/java/com/linkedin/venice/controller/systemstore/SystemStoreRepairTaskTest.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/controller/systemstore/SystemStoreRepairTaskTest.java
@@ -17,6 +17,7 @@ import com.linkedin.venice.controller.stats.SystemStoreHealthCheckStats;
 import com.linkedin.venice.controllerapi.ControllerClient;
 import com.linkedin.venice.controllerapi.SystemStoreHeartbeatResponse;
 import com.linkedin.venice.meta.Store;
+import com.linkedin.venice.utils.LogContext;
 import com.linkedin.venice.utils.concurrent.VeniceConcurrentHashMap;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -42,6 +43,7 @@ public class SystemStoreRepairTaskTest {
     VeniceParentHelixAdmin parentHelixAdmin = mock(VeniceParentHelixAdmin.class);
     List<String> leaderClusterList = Arrays.asList("venice-1", "venice-3");
     doReturn(leaderClusterList).when(parentHelixAdmin).getClustersLeaderOf();
+    doReturn(LogContext.EMPTY).when(parentHelixAdmin).getLogContext();
     doReturn(parentHelixAdmin).when(systemStoreRepairTask).getParentAdmin();
 
     doCallRealMethod().when(systemStoreRepairTask).run();

--- a/services/venice-controller/src/test/java/com/linkedin/venice/pushmonitor/PushStatusCollectorTest.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/pushmonitor/PushStatusCollectorTest.java
@@ -11,6 +11,7 @@ import com.linkedin.venice.meta.ReadWriteStoreRepository;
 import com.linkedin.venice.meta.Store;
 import com.linkedin.venice.meta.Version;
 import com.linkedin.venice.pushstatushelper.PushStatusStoreReader;
+import com.linkedin.venice.utils.LogContext;
 import com.linkedin.venice.utils.TestUtils;
 import java.util.Collections;
 import java.util.Map;
@@ -79,7 +80,8 @@ public class PushStatusCollectorTest {
         1,
         20,
         1,
-        true);
+        true,
+        LogContext.EMPTY);
     pushStatusCollector.start();
 
     pushStatusCollector.subscribeTopic(regularStoreTopicV1, 10);
@@ -236,7 +238,8 @@ public class PushStatusCollectorTest {
         1,
         20,
         1,
-        true);
+        true,
+        LogContext.EMPTY);
     pushStatusCollector.start();
 
     pushCompletedCount.set(0);
@@ -333,7 +336,8 @@ public class PushStatusCollectorTest {
         0,
         20,
         1,
-        true);
+        true,
+        LogContext.EMPTY);
     pushStatusCollector.start();
 
     pushCompletedCount.set(0);


### PR DESCRIPTION
## Use LogContext in all controller services for region-aware logging  

Updated all controller services to consistently use LogContext for structured logging.  
This enables region-aware log tagging across threads, improves log traceability,  
and unifies how context is passed into background threads via thread factories.  

This change ensures that services like HelixParticipationService, AdminConsumerService,  
AggKafkaConsumerService, and others propagate regional identity through ThreadContext  
using the standardized logContext key.  


## Solution
<!--
Describe
- What changes you are making and why. 
- How these changes solve the problem.
- Any performance considerations or trade-offs. 
- Describe what testings you have done, for example, performance testing etc.
-->


###  Code changes
- [ ] Added new code behind **a config**. If so list the config names and their default values in the PR description.
- [ ] Introduced new **log lines**. 
  - [ ] Confirmed if logs need to be **rate limited** to avoid excessive logging.

###  **Concurrency-Specific Checks**
Both reviewer and PR author to verify
- [ ] Code has **no race conditions** or **thread safety issues**.
- [ ] Proper **synchronization mechanisms** (e.g., `synchronized`, `RWLock`) are used where needed.
- [ ] No **blocking calls** inside critical sections that could lead to deadlocks or performance degradation.
- [ ] Verified **thread-safe collections** are used (e.g., `ConcurrentHashMap`, `CopyOnWriteArrayList`).
- [ ] Validated proper exception handling in multi-threaded code to avoid silent thread termination.


## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->

- [ ] New unit tests added.
- [ ] New integration tests added.
- [ ] Modified or extended existing tests.
- [ ] Verified backward compatibility (if applicable).

## Does this PR introduce any user-facing or breaking changes?
<!--  
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [ ] No. You can skip the rest of this section.
- [ ] Yes. Clearly explain the behavior change and its impact.