### PR TITLE
[router][dvc] dvc blob transfer query both version-level and partition-level push status from router

### DIFF
--- a/internal/venice-common/src/main/java/com/linkedin/venice/pushstatushelper/PushStatusStoreReader.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/pushstatushelper/PushStatusStoreReader.java
@@ -139,7 +139,7 @@ public class PushStatusStoreReader implements Closeable {
   }
 
   /**
-   * If it is batch reporting, then only query with version; else query with version and partitionId.
+   * If it is batch reporting, then only query with version-level key; else query with partition-level key.
    * @param storeName store name
    * @param version version
    * @param partitionId partition id
@@ -158,7 +158,7 @@ public class PushStatusStoreReader implements Closeable {
     try {
       AvroSpecificStoreClient<PushStatusKey, PushStatusValue> client = getVeniceClient(storeName);
       PushStatusKey pushStatusKey = isBatchReporting
-          ? PushStatusStoreUtils.getPushKey(version)
+          ? PushStatusStoreUtils.getPushKey(version, incrementalPushVersion)
           : PushStatusStoreUtils.getPushKey(version, partitionId, incrementalPushVersion, incrementalPushPrefix);
 
       // Get the CompletableFuture from the client and transform it

--- a/internal/venice-common/src/test/java/com/linkedin/venice/pushstatushelper/PushStatusStoreReaderTest.java
+++ b/internal/venice-common/src/test/java/com/linkedin/venice/pushstatushelper/PushStatusStoreReaderTest.java
@@ -412,8 +412,13 @@ public class PushStatusStoreReaderTest {
     when(storeClientMock.get(any(PushStatusKey.class))).thenReturn(CompletableFuture.completedFuture(mockStatusValue));
 
     // Execute the method
-    CompletableFuture<Map<CharSequence, Integer>> future = storeReaderSpy
-        .getPartitionStatusAsync(storeName, version, partitionId, incrementalPushVersion, incrementalPushPrefix);
+    CompletableFuture<Map<CharSequence, Integer>> future = storeReaderSpy.getPartitionOrVersionStatusAsync(
+        storeName,
+        version,
+        partitionId,
+        incrementalPushVersion,
+        incrementalPushPrefix,
+        false);
 
     Map<CharSequence, Integer> result = future.get(5, TimeUnit.SECONDS);
 
@@ -441,8 +446,13 @@ public class PushStatusStoreReaderTest {
     }));
 
     // Execute the method
-    CompletableFuture<Map<String, Integer>> future = storeReaderSpy
-        .getPartitionStatusAsync(storeName, version, partitionId, incrementalPushVersion, incrementalPushPrefix);
+    CompletableFuture<Map<String, Integer>> future = storeReaderSpy.getPartitionOrVersionStatusAsync(
+        storeName,
+        version,
+        partitionId,
+        incrementalPushVersion,
+        incrementalPushPrefix,
+        false);
 
     try {
       future.get(5, TimeUnit.SECONDS);

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/davinci/DaVinciUserApp.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/davinci/DaVinciUserApp.java
@@ -16,6 +16,7 @@ import static com.linkedin.venice.ConfigKeys.BLOB_TRANSFER_SSL_ENABLED;
 import static com.linkedin.venice.ConfigKeys.DATA_BASE_PATH;
 import static com.linkedin.venice.ConfigKeys.DAVINCI_P2P_BLOB_TRANSFER_CLIENT_PORT;
 import static com.linkedin.venice.ConfigKeys.DAVINCI_P2P_BLOB_TRANSFER_SERVER_PORT;
+import static com.linkedin.venice.ConfigKeys.DAVINCI_PUSH_STATUS_CHECK_INTERVAL_IN_MS;
 import static com.linkedin.venice.ConfigKeys.PUSH_STATUS_STORE_ENABLED;
 import static com.linkedin.venice.ConfigKeys.SERVER_INGESTION_ISOLATION_CONNECTION_TIMEOUT_SECONDS;
 import static com.linkedin.venice.ConfigKeys.SERVER_INGESTION_MODE;
@@ -65,6 +66,7 @@ public class DaVinciUserApp {
     String storageClass = args[8]; // DISK or MEMORY_BACKED_BY_DISK
     boolean recordTransformerEnabled = Boolean.parseBoolean(args[9]);
     boolean blobTransferDaVinciSSLEnabled = Boolean.parseBoolean(args[10]);
+    boolean batchPushReportEnabled = Boolean.parseBoolean(args[11]);
 
     D2Client d2Client = new D2ClientBuilder().setZkHosts(zkHosts)
         .setZkSessionTimeout(3, TimeUnit.SECONDS)
@@ -96,6 +98,10 @@ public class DaVinciUserApp {
       extraBackendConfig.put(SSL_KEYMANAGER_ALGORITHM, "SunX509");
       extraBackendConfig.put(SSL_TRUSTMANAGER_ALGORITHM, "SunX509");
       extraBackendConfig.put(SSL_SECURE_RANDOM_IMPLEMENTATION, "SHA1PRNG");
+    }
+
+    if (batchPushReportEnabled) {
+      extraBackendConfig.put(DAVINCI_PUSH_STATUS_CHECK_INTERVAL_IN_MS, "10");
     }
 
     // convert the storage class string to enum

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/DaVinciClientRecordTransformerTest.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/DaVinciClientRecordTransformerTest.java
@@ -630,7 +630,8 @@ public class DaVinciClientRecordTransformerTest {
         Integer.toString(port2),
         StorageClass.DISK.toString(),
         "true",
-        "true");
+        "true",
+        "false");
 
     // Wait for the first DaVinci Client to complete ingestion
     Thread.sleep(60000);

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/DaVinciClientTest.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/DaVinciClientTest.java
@@ -1208,6 +1208,7 @@ public class DaVinciClientTest {
         Integer.toString(port2),
         StorageClass.DISK.toString(),
         "false",
+        "false",
         "false");
     // Sleep long enough so the forked Da Vinci app process can finish ingestion.
     Thread.sleep(60000);
@@ -1258,8 +1259,8 @@ public class DaVinciClientTest {
    * For the local P2P testing, need to setup two different directories and ports for the two Da Vinci clients in order
    * to avoid conflicts.
    */
-  @Test(timeOut = 2 * TEST_TIMEOUT)
-  public void testBlobP2PTransferAmongDVC() throws Exception {
+  @Test(timeOut = 2 * TEST_TIMEOUT, dataProviderClass = DataProviderUtils.class, dataProvider = "True-and-False")
+  public void testBlobP2PTransferAmongDVC(boolean batchPushReportEnable) throws Exception {
     String dvcPath1 = Utils.getTempDataDirectory().getAbsolutePath();
     String zkHosts = cluster.getZk().getAddress();
     int port1 = TestUtils.getFreePort();
@@ -1286,7 +1287,8 @@ public class DaVinciClientTest {
         Integer.toString(port2),
         StorageClass.DISK.toString(),
         "false",
-        "true");
+        "true",
+        String.valueOf(batchPushReportEnable));
 
     // Wait for the first DaVinci Client to complete ingestion
     Thread.sleep(60000);
@@ -1320,6 +1322,12 @@ public class DaVinciClientTest {
         .put(SSL_KEYMANAGER_ALGORITHM, "SunX509")
         .put(SSL_TRUSTMANAGER_ALGORITHM, "SunX509")
         .put(SSL_SECURE_RANDOM_IMPLEMENTATION, "SHA1PRNG");
+
+    if (batchPushReportEnable) {
+      // if batch push report is enabled, the peer finding expects to query at version level, but it should not affect
+      // performance.
+      configBuilder.put(DAVINCI_PUSH_STATUS_CHECK_INTERVAL_IN_MS, "10");
+    }
 
     VeniceProperties backendConfig2 = configBuilder.build();
     DaVinciConfig dvcConfig = new DaVinciConfig().setIsolated(true);
@@ -1401,7 +1409,8 @@ public class DaVinciClientTest {
         Integer.toString(port2),
         storageClass,
         "false",
-        "true");
+        "true",
+        "false");
 
     // Wait for the first DaVinci Client to complete ingestion
     Thread.sleep(60000);

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/PushStatusStoreTest.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/PushStatusStoreTest.java
@@ -347,7 +347,7 @@ public class PushStatusStoreTest {
         ServiceFactory.getGenericAvroDaVinciClient(storeName, cluster, new DaVinciConfig(), backendConfig)) {
       daVinciClient.subscribeAll().get();
       CompletableFuture<Map<CharSequence, Integer>> future1 =
-          reader.getPartitionStatusAsync(storeName, 1, 0, Optional.empty(), Optional.empty());
+          reader.getPartitionOrVersionStatusAsync(storeName, 1, 0, Optional.empty(), Optional.empty(), false);
       future1.whenComplete((result, throwable) -> {
         {
           Assert.assertEquals(result.size(), 1);
@@ -356,17 +356,43 @@ public class PushStatusStoreTest {
 
       // case 2: throw exception for non-existing store
       try {
-        reader.getPartitionStatusAsync("non-existed-store-name", 1, 0, Optional.empty(), Optional.empty());
+        reader.getPartitionOrVersionStatusAsync(
+            "non-existed-store-name",
+            1,
+            0,
+            Optional.empty(),
+            Optional.empty(),
+            false);
       } catch (VeniceException e) {
         assertTrue(e.getMessage().contains("Failed to read push status of partition:1 store:non-existed-store-name"));
       }
 
-      // case 3: throw exception for non-existed version
-      try {
-        reader.getPartitionStatusAsync(storeName, 100, 0, Optional.empty(), Optional.empty());
-      } catch (VeniceException e) {
-        assertTrue(e.getMessage().contains("Failed to read push status of partition:100 store:" + storeName));
-      }
+      // case 3: query non-existed version should return empty
+      CompletableFuture<Map<CharSequence, Integer>> future3 =
+          reader.getPartitionOrVersionStatusAsync(storeName, 100, 0, Optional.empty(), Optional.empty(), false);
+      future3.whenComplete((result, throwable) -> {
+        {
+          Assert.assertEquals(result.size(), 0);
+        }
+      }).join();
+
+      // case 4: query non existed partition should return empty
+      CompletableFuture<Map<CharSequence, Integer>> future4 =
+          reader.getPartitionOrVersionStatusAsync(storeName, 100, 10000, Optional.empty(), Optional.empty(), false);
+      future4.whenComplete((result, throwable) -> {
+        {
+          Assert.assertEquals(result.size(), 0);
+        }
+      }).join();
+
+      // case 5: query version level request should be empty
+      CompletableFuture<Map<CharSequence, Integer>> future5 =
+          reader.getPartitionOrVersionStatusAsync(storeName, 1, 0, Optional.empty(), Optional.empty(), true);
+      future5.whenComplete((result, throwable) -> {
+        {
+          Assert.assertEquals(result.size(), 0);
+        }
+      }).join();
     }
   }
 


### PR DESCRIPTION
<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat], [protocol]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## Problem Statement
As some Venice DVC clients transition to batch reporting, which reports push status at the version level, while metadata handlers in routers continue querying at the partition level to find blob transfer peers. This mismatch results in empty peer returns, causing blob transfer failures for stores using batch reporting.


<!--
Describe
- What problem are you trying to solve
- What issues or limitations exist in the current code
- Why this change is necessary 
-->


## Solution
This PR updates the router to query both partition and version levels for identifying completed DVC peers during push operations. It prioritizes querying the partition level first; if the response indicates errors or is empty, it then falls back to querying the version level.


###  Code changes
- [ ] Added new code behind **a config**. If so list the config names and their default values in the PR description.
- [ ] Introduced new **log lines**. 
- [ ] Confirmed if logs need to be **rate limited** to avoid excessive logging.

###  **Concurrency-Specific Checks**
Both reviewer and PR author to verify
- [ ] Code has **no race conditions** or **thread safety issues**.
- [ ] Proper **synchronization mechanisms** (e.g., `synchronized`, `RWLock`) are used where needed.
- [ ] No **blocking calls** inside critical sections that could lead to deadlocks or performance degradation.
- [ ] Verified **thread-safe collections** are used (e.g., `ConcurrentHashMap`, `CopyOnWriteArrayList`).
- [ ] Validated proper exception handling in multi-threaded code to avoid silent thread termination.


## How was this PR tested?
unit test. 
integration test:

> 2025-04-30 10:50:32 - [] INFO [MetaDataHandler] [Venice-Store-Deserialization-t0] No partition instances found for store: test-store_6918be47841e9_b9c9dab version: 1 partition: 0, will try version-level
2025-04-30 10:50:32 - [] INFO [MetaDataHandler] [Venice-Store-Deserialization-t1] 1 ready to serve nodes were found for store test-store_6918be47841e9_b9c9dab version 1 partition 0 from version level push report
2025-04-30 10:50:32 - [] INFO [NettyP2PBlobTransferManager] [TestNG-method=testBlobP2PTransferAmongDVC-1] Discovered 1 unique peers store test-store_6918be47841e9_b9c9dab version 1 partition 0, peers are [localhost]

- [x] New unit tests added.
- [x] New integration tests added.
- [ ] Modified or extended existing tests.
- [ ] Verified backward compatibility (if applicable).

## Does this PR introduce any user-facing or breaking changes?
<!--  
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [ ] No. You can skip the rest of this section.
- [ ] Yes. Clearly explain the behavior change and its impact.