### PR TITLE
[dvc][server] Deprecated topic-wise shared consumer strategy

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/config/VeniceServerConfig.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/config/VeniceServerConfig.java
@@ -805,7 +805,7 @@ public class VeniceServerConfig extends VeniceClusterConfig {
     routerConnectionWarmingDelayMs = serverProperties.getLong(SERVER_ROUTER_CONNECTION_WARMING_DELAY_MS, 0);
     String sharedConsumerAssignmentStrategyStr = serverProperties.getString(
         SERVER_SHARED_CONSUMER_ASSIGNMENT_STRATEGY,
-        KafkaConsumerService.ConsumerAssignmentStrategy.TOPIC_WISE_SHARED_CONSUMER_ASSIGNMENT_STRATEGY.name());
+        KafkaConsumerService.ConsumerAssignmentStrategy.PARTITION_WISE_SHARED_CONSUMER_ASSIGNMENT_STRATEGY.name());
     try {
       sharedConsumerAssignmentStrategy =
           KafkaConsumerService.ConsumerAssignmentStrategy.valueOf(sharedConsumerAssignmentStrategyStr);

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/KafkaConsumerService.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/KafkaConsumerService.java
@@ -596,6 +596,7 @@ public abstract class KafkaConsumerService extends AbstractKafkaConsumerService 
    * respectively. Each strategy will have a specific extension of {@link KafkaConsumerService}.
    */
   public enum ConsumerAssignmentStrategy {
+    @Deprecated
     TOPIC_WISE_SHARED_CONSUMER_ASSIGNMENT_STRATEGY(TopicWiseKafkaConsumerService::new),
     PARTITION_WISE_SHARED_CONSUMER_ASSIGNMENT_STRATEGY(PartitionWiseKafkaConsumerService::new),
     STORE_AWARE_PARTITION_WISE_SHARED_CONSUMER_ASSIGNMENT_STRATEGY(StoreAwarePartitionWiseKafkaConsumerService::new);

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/AggKafkaConsumerServiceTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/AggKafkaConsumerServiceTest.java
@@ -1,6 +1,6 @@
 package com.linkedin.davinci.kafka.consumer;
 
-import static com.linkedin.davinci.kafka.consumer.KafkaConsumerService.ConsumerAssignmentStrategy.TOPIC_WISE_SHARED_CONSUMER_ASSIGNMENT_STRATEGY;
+import static com.linkedin.davinci.kafka.consumer.KafkaConsumerService.ConsumerAssignmentStrategy.PARTITION_WISE_SHARED_CONSUMER_ASSIGNMENT_STRATEGY;
 import static com.linkedin.davinci.kafka.consumer.KafkaConsumerServiceDelegator.ConsumerPoolStrategyType.DEFAULT;
 import static com.linkedin.venice.ConfigKeys.KAFKA_BOOTSTRAP_SERVERS;
 import static org.mockito.ArgumentMatchers.any;
@@ -85,7 +85,8 @@ public class AggKafkaConsumerServiceTest {
     when(serverConfig.getConsumerPoolStrategyType()).thenReturn(DEFAULT);
     when(serverConfig.getConsumerPoolSizePerKafkaCluster()).thenReturn(5);
     when(serverConfig.isUnregisterMetricForDeletedStoreEnabled()).thenReturn(Boolean.FALSE);
-    when(serverConfig.getSharedConsumerAssignmentStrategy()).thenReturn(TOPIC_WISE_SHARED_CONSUMER_ASSIGNMENT_STRATEGY);
+    when(serverConfig.getSharedConsumerAssignmentStrategy())
+        .thenReturn(PARTITION_WISE_SHARED_CONSUMER_ASSIGNMENT_STRATEGY);
     Sensor dummySensor = mock(Sensor.class);
     when(metricsRepository.sensor(anyString(), any())).thenReturn(dummySensor);
     PubSubConsumerAdapter adapter = mock(PubSubConsumerAdapter.class);

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/KafkaStoreIngestionServiceWithTopicWiseTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/KafkaStoreIngestionServiceWithTopicWiseTest.java
@@ -1,5 +1,6 @@
 package com.linkedin.davinci.kafka.consumer;
 
+@Deprecated
 public class KafkaStoreIngestionServiceWithTopicWiseTest extends KafkaStoreIngestionServiceTest {
   protected KafkaConsumerService.ConsumerAssignmentStrategy getConsumerAssignmentStrategy() {
     return KafkaConsumerService.ConsumerAssignmentStrategy.TOPIC_WISE_SHARED_CONSUMER_ASSIGNMENT_STRATEGY;

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/SITWithSAwarePWiseAndBufferAfterLeaderTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/SITWithSAwarePWiseAndBufferAfterLeaderTest.java
@@ -1,0 +1,16 @@
+package com.linkedin.davinci.kafka.consumer;
+
+public class SITWithSAwarePWiseAndBufferAfterLeaderTest extends StoreIngestionTaskTest {
+  protected KafkaConsumerService.ConsumerAssignmentStrategy getConsumerAssignmentStrategy() {
+    return KafkaConsumerService.ConsumerAssignmentStrategy.STORE_AWARE_PARTITION_WISE_SHARED_CONSUMER_ASSIGNMENT_STRATEGY;
+  }
+
+  protected boolean isStoreWriterBufferAfterLeaderLogicEnabled() {
+    return true;
+  }
+
+  @Override
+  protected boolean isAaWCParallelProcessingEnabled() {
+    return true;
+  }
+}

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/SITWithSAwarePWiseWithoutBufferAfterLeaderTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/SITWithSAwarePWiseWithoutBufferAfterLeaderTest.java
@@ -1,9 +1,8 @@
 package com.linkedin.davinci.kafka.consumer;
 
-@Deprecated
-public class SITWithTWiseWithoutBufferAfterLeaderTest extends StoreIngestionTaskTest {
+public class SITWithSAwarePWiseWithoutBufferAfterLeaderTest extends StoreIngestionTaskTest {
   protected KafkaConsumerService.ConsumerAssignmentStrategy getConsumerAssignmentStrategy() {
-    return KafkaConsumerService.ConsumerAssignmentStrategy.TOPIC_WISE_SHARED_CONSUMER_ASSIGNMENT_STRATEGY;
+    return KafkaConsumerService.ConsumerAssignmentStrategy.STORE_AWARE_PARTITION_WISE_SHARED_CONSUMER_ASSIGNMENT_STRATEGY;
   }
 
   protected boolean isStoreWriterBufferAfterLeaderLogicEnabled() {

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/SITWithTWiseAndBufferAfterLeaderTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/SITWithTWiseAndBufferAfterLeaderTest.java
@@ -1,5 +1,6 @@
 package com.linkedin.davinci.kafka.consumer;
 
+@Deprecated
 public class SITWithTWiseAndBufferAfterLeaderTest extends StoreIngestionTaskTest {
   protected KafkaConsumerService.ConsumerAssignmentStrategy getConsumerAssignmentStrategy() {
     return KafkaConsumerService.ConsumerAssignmentStrategy.TOPIC_WISE_SHARED_CONSUMER_ASSIGNMENT_STRATEGY;

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestTopicWiseSharedConsumerPoolResilience.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestTopicWiseSharedConsumerPoolResilience.java
@@ -38,6 +38,7 @@ import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 
+@Deprecated
 public class TestTopicWiseSharedConsumerPoolResilience {
   private static final Logger LOGGER = LogManager.getLogger(TestTopicWiseSharedConsumerPoolResilience.class);
 

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/kafka/KafkaConsumptionTest.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/kafka/KafkaConsumptionTest.java
@@ -145,8 +145,9 @@ public class KafkaConsumptionTest {
     remotePubSubBroker.close();
   }
 
-  @Test(dataProvider = "True-and-False", dataProviderClass = DataProviderUtils.class, timeOut = 10 * Time.MS_PER_SECOND)
-  public void testLocalAndRemoteConsumption(boolean isTopicWiseSharedConsumerAssignmentStrategy)
+  @Test(dataProvider = "sharedConsumerStrategy", dataProviderClass = DataProviderUtils.class, timeOut = 10
+      * Time.MS_PER_SECOND)
+  public void testLocalAndRemoteConsumption(KafkaConsumerService.ConsumerAssignmentStrategy sharedConsumerStrategy)
       throws ExecutionException, InterruptedException {
     // Prepare Aggregate Kafka Consumer Service.
     IngestionThrottler mockIngestionThrottler = mock(IngestionThrottler.class);
@@ -162,15 +163,7 @@ public class KafkaConsumptionTest {
     doReturn(true).when(veniceServerConfig).isLiveConfigBasedKafkaThrottlingEnabled();
     doReturn(KafkaConsumerServiceDelegator.ConsumerPoolStrategyType.DEFAULT).when(veniceServerConfig)
         .getConsumerPoolStrategyType();
-    if (isTopicWiseSharedConsumerAssignmentStrategy) {
-      doReturn(KafkaConsumerService.ConsumerAssignmentStrategy.TOPIC_WISE_SHARED_CONSUMER_ASSIGNMENT_STRATEGY)
-          .when(veniceServerConfig)
-          .getSharedConsumerAssignmentStrategy();
-    } else {
-      doReturn(KafkaConsumerService.ConsumerAssignmentStrategy.PARTITION_WISE_SHARED_CONSUMER_ASSIGNMENT_STRATEGY)
-          .when(veniceServerConfig)
-          .getSharedConsumerAssignmentStrategy();
-    }
+    doReturn(sharedConsumerStrategy).when(veniceServerConfig).getSharedConsumerAssignmentStrategy();
 
     String localKafkaUrl = localPubSubBroker.getAddress();
     String remoteKafkaUrl = remotePubSubBroker.getAddress();

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/restart/TestRestartController.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/restart/TestRestartController.java
@@ -3,7 +3,6 @@ package com.linkedin.venice.restart;
 import com.linkedin.venice.controller.VeniceHelixAdmin;
 import com.linkedin.venice.controllerapi.ControllerClient;
 import com.linkedin.venice.controllerapi.VersionCreationResponse;
-import com.linkedin.venice.exceptions.VeniceException;
 import com.linkedin.venice.integration.utils.ServiceFactory;
 import com.linkedin.venice.integration.utils.VeniceClusterCreateOptions;
 import com.linkedin.venice.integration.utils.VeniceClusterWrapper;
@@ -23,7 +22,7 @@ import org.testng.annotations.Test;
 
 @Test(singleThreaded = true)
 public class TestRestartController {
-  private static final int OPERATION_TIMEOUT_MS = 3 * Time.MS_PER_SECOND;
+  private static final int OPERATION_TIMEOUT_MS = 15 * Time.MS_PER_SECOND;
   private VeniceClusterWrapper cluster;
 
   @BeforeMethod
@@ -200,7 +199,7 @@ public class TestRestartController {
     VersionCreationResponse response = null;
     try {
       response = cluster.getNewVersion(storeName);
-    } catch (VeniceException e) {
+    } catch (Exception e) {
       // Some times, the leader controller would be changed after getting it from cluster. Just retry on the new leader.
       cluster.getLeaderVeniceController();
       response = cluster.getNewVersion(storeName);

--- a/internal/venice-test-common/src/main/java/com/linkedin/venice/utils/DataProviderUtils.java
+++ b/internal/venice-test-common/src/main/java/com/linkedin/venice/utils/DataProviderUtils.java
@@ -6,6 +6,7 @@ import static com.linkedin.venice.compression.CompressionStrategy.ZSTD_WITH_DICT
 
 import com.linkedin.avroutil1.compatibility.AvroCompatibilityHelper;
 import com.linkedin.davinci.client.DaVinciConfig;
+import com.linkedin.davinci.kafka.consumer.KafkaConsumerService;
 import com.linkedin.davinci.store.cache.backend.ObjectCacheConfig;
 import com.linkedin.venice.kafka.validation.checksum.CheckSumType;
 import com.linkedin.venice.meta.IngestionMode;
@@ -150,6 +151,11 @@ public class DataProviderUtils {
     }
 
     return resultingArray.toArray(new Object[resultingArray.size()][]);
+  }
+
+  @DataProvider(name = "sharedConsumerStrategy")
+  public static Object[][] sharedConsumerStrategy() {
+    return allPermutationGenerator(KafkaConsumerService.ConsumerAssignmentStrategy.values());
   }
 
   /**


### PR DESCRIPTION
Also changed the default for this config from topic-wise to partition-wise, which is the setting we have been running in production for many years now.

Test changes:

- Marked all t-wise related tests as deprecated.
- Added some test permutations for the new strategy, store-aware p-wise, which was missing in some cases.
- Deflaked TestRestartController.

###  Code changes
- [ ] Added new code behind **a config**. If so list the config names and their default values in the PR description.
- [ ] Introduced new **log lines**. 
  - [ ] Confirmed if logs need to be **rate limited** to avoid excessive logging.

###  **Concurrency-Specific Checks**
Both reviewer and PR author to verify
- [x] Code has **no race conditions** or **thread safety issues**.
- [x] Proper **synchronization mechanisms** (e.g., `synchronized`, `RWLock`) are used where needed.
- [x] No **blocking calls** inside critical sections that could lead to deadlocks or performance degradation.
- [x] Verified **thread-safe collections** are used (e.g., `ConcurrentHashMap`, `CopyOnWriteArrayList`).
- [x] Validated proper exception handling in multi-threaded code to avoid silent thread termination.


## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->

- [ ] New unit tests added.
- [ ] New integration tests added.
- [x] Modified or extended existing tests.
- [ ] Verified backward compatibility (if applicable).

## Does this PR introduce any user-facing or breaking changes?
<!--  
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Clearly explain the behavior change and its impact.