### PR TITLE
[dvc][server][doc] Add exponential backoff for zk update retries + doc cleanup

### DIFF
--- a/docs/dev_guide/how_to/workspace_setup.md
+++ b/docs/dev_guide/how_to/workspace_setup.md
@@ -93,8 +93,8 @@ with various values and find ones that work for you.
 ./gradlew :clients:da-vinci-client:jacocoTestCoverageVerification diffCoverage
 
 # Run a specific test in any module
-$ ./gradlew :sub-module:testType --tests "fully.qualified.name.of.the.test"
+./gradlew :sub-module:testType --tests "fully.qualified.name.of.the.test"
 
 # To run a specific integration test
-$ ./gradlew :internal:venice-test-common:integrationTest --tests "fully.qualified.name.of.the.test"
+./gradlew :internal:venice-test-common:integrationTest --tests "fully.qualified.name.of.the.test"
 ```

--- a/internal/venice-common/src/main/java/com/linkedin/venice/utils/HelixUtils.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/utils/HelixUtils.java
@@ -240,19 +240,19 @@ public final class HelixUtils {
     while (attempt < retryCount) {
       if (dataAccessor.update(path, dataUpdater, AccessOption.PERSISTENT)) {
         return;
-      } else {
-        double retryIntervalSec = Math.pow(2, attempt);
-        attempt++;
-        LOGGER.warn(
-            "dataAccessor.update() failed with path {} on attempt {}/{}. Will retry in {} seconds.",
-            path,
-            attempt,
-            retryCount,
-            retryIntervalSec);
-        Utils.sleep(TimeUnit.SECONDS.toMillis((long) retryIntervalSec));
       }
+      attempt++;
+      double retryIntervalSec = Math.pow(2, attempt - 1);
+      LOGGER.warn(
+          "compareAndUpdate failed with path {} on attempt {}/{}. Will retry in {} seconds.",
+          path,
+          attempt,
+          retryCount,
+          retryIntervalSec);
+      Utils.sleep(TimeUnit.SECONDS.toMillis((long) retryIntervalSec));
     }
-    throw new ZkDataAccessException(path, "compare and update", retryCount);
+    throw new VeniceException(
+        "Can not do operation compareAndUpdate on path " + path + " after retry" + attempt + "/" + retryCount);
   }
 
   /**

--- a/internal/venice-common/src/main/java/com/linkedin/venice/utils/HelixUtils.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/utils/HelixUtils.java
@@ -236,12 +236,21 @@ public final class HelixUtils {
       String path,
       int retryCount,
       DataUpdater<T> dataUpdater) {
-    int retry = 0;
-    while (retry < retryCount) {
+    int attempt = 0;
+    while (attempt < retryCount) {
       if (dataAccessor.update(path, dataUpdater, AccessOption.PERSISTENT)) {
         return;
+      } else {
+        double retryIntervalSec = Math.pow(2, attempt);
+        attempt++;
+        LOGGER.warn(
+            "dataAccessor.update() failed with path {} on attempt {}/{}. Will retry in {} seconds.",
+            path,
+            attempt,
+            retryCount,
+            retryIntervalSec);
+        Utils.sleep(TimeUnit.SECONDS.toMillis((long) retryIntervalSec));
       }
-      retry++;
     }
     throw new ZkDataAccessException(path, "compare and update", retryCount);
   }

--- a/internal/venice-common/src/main/java/com/linkedin/venice/utils/HelixUtils.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/utils/HelixUtils.java
@@ -253,7 +253,7 @@ public final class HelixUtils {
    */
   private static void handleFailedHelixOperation(String path, String helixOperation, int attempt, int retryCount) {
     if (attempt < retryCount) {
-      double retryIntervalSec = Math.pow(2, attempt);
+      long retryIntervalSec = (long) Math.pow(2, attempt);
       LOGGER.error(
           "{} failed with path {} on attempt {}/{}. Will retry in {} seconds.",
           helixOperation,
@@ -261,7 +261,7 @@ public final class HelixUtils {
           attempt,
           retryCount,
           retryIntervalSec);
-      Utils.sleep(TimeUnit.SECONDS.toMillis((long) retryIntervalSec));
+      Utils.sleep(TimeUnit.SECONDS.toMillis(retryIntervalSec));
     } else {
       throw new ZkDataAccessException(path, helixOperation, retryCount);
     }

--- a/internal/venice-common/src/main/java/com/linkedin/venice/utils/HelixUtils.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/utils/HelixUtils.java
@@ -238,7 +238,7 @@ public final class HelixUtils {
         return;
       }
       attempt++;
-      handleFailedHelixOperation(path, "compare and update", attempt, retryCount);
+      handleFailedHelixOperation(path, "compareAndUpdate", attempt, retryCount);
     }
   }
 

--- a/internal/venice-common/src/test/java/com/linkedin/venice/utils/TestHelixUtils.java
+++ b/internal/venice-common/src/test/java/com/linkedin/venice/utils/TestHelixUtils.java
@@ -84,6 +84,183 @@ public class TestHelixUtils {
   }
 
   @Test
+  public void testCreate() {
+    ZkBaseDataAccessor<String> mockDataAccessor = mock(ZkBaseDataAccessor.class);
+    String testPath = "/test/path";
+    String testData = "testData";
+
+    doReturn(true).when(mockDataAccessor).create(testPath, testData, AccessOption.PERSISTENT);
+
+    HelixUtils.create(mockDataAccessor, testPath, testData, 3);
+
+    verify(mockDataAccessor, times(1)).create(testPath, testData, AccessOption.PERSISTENT);
+  }
+
+  @Test
+  public void testCreateFailsAfterRetries() {
+    ZkBaseDataAccessor<String> mockDataAccessor = mock(ZkBaseDataAccessor.class);
+    String testPath = "/test/path";
+    String testData = "testData";
+
+    doReturn(false).when(mockDataAccessor).create(testPath, testData, AccessOption.PERSISTENT);
+
+    Assert.assertThrows(VeniceException.class, () -> {
+      HelixUtils.create(mockDataAccessor, testPath, testData, 3);
+    });
+  }
+
+  @Test
+  public void testCreateSucceedsAfterRetries() {
+    ZkBaseDataAccessor<String> mockDataAccessor = mock(ZkBaseDataAccessor.class);
+    String testPath = "/test/path";
+    String testData = "testData";
+
+    doReturn(false).doReturn(false)
+        .doReturn(true)
+        .when(mockDataAccessor)
+        .create(testPath, testData, AccessOption.PERSISTENT);
+
+    HelixUtils.create(mockDataAccessor, testPath, testData, 3);
+
+    verify(mockDataAccessor, times(3)).create(testPath, testData, AccessOption.PERSISTENT);
+  }
+
+  @Test
+  public void testUpdate() {
+    ZkBaseDataAccessor<String> mockDataAccessor = mock(ZkBaseDataAccessor.class);
+    String testPath = "/test/path";
+    String testData = "testData";
+
+    doReturn(true).when(mockDataAccessor).set(testPath, testData, AccessOption.PERSISTENT);
+
+    HelixUtils.update(mockDataAccessor, testPath, testData, 3);
+
+    verify(mockDataAccessor, times(1)).set(testPath, testData, AccessOption.PERSISTENT);
+  }
+
+  @Test
+  public void testUpdateFailsAfterRetries() {
+    ZkBaseDataAccessor<String> mockDataAccessor = mock(ZkBaseDataAccessor.class);
+    String testPath = "/test/path";
+    String testData = "testData";
+
+    doReturn(false).when(mockDataAccessor).set(testPath, testData, AccessOption.PERSISTENT);
+
+    Assert.assertThrows(VeniceException.class, () -> {
+      HelixUtils.update(mockDataAccessor, testPath, testData, 3);
+    });
+  }
+
+  @Test
+  public void testUpdateSucceedsAfterRetries() {
+    ZkBaseDataAccessor<String> mockDataAccessor = mock(ZkBaseDataAccessor.class);
+    String testPath = "/test/path";
+    String testData = "testData";
+
+    doReturn(false).doReturn(false)
+        .doReturn(true)
+        .when(mockDataAccessor)
+        .set(testPath, testData, AccessOption.PERSISTENT);
+
+    HelixUtils.update(mockDataAccessor, testPath, testData, 3);
+
+    verify(mockDataAccessor, times(3)).set(testPath, testData, AccessOption.PERSISTENT);
+  }
+
+  @Test
+  public void testUpdateChildren() {
+    ZkBaseDataAccessor<String> mockDataAccessor = mock(ZkBaseDataAccessor.class);
+    List<String> paths = new ArrayList<>();
+    paths.add("/test/path/child1");
+    paths.add("/test/path/child2");
+    List<String> data = new ArrayList<>();
+    data.add("data1");
+    data.add("data2");
+
+    boolean[] successResults = new boolean[] { true, true };
+    doReturn(successResults).when(mockDataAccessor).setChildren(paths, data, AccessOption.PERSISTENT);
+
+    HelixUtils.updateChildren(mockDataAccessor, paths, data, 3);
+
+    verify(mockDataAccessor, times(1)).setChildren(paths, data, AccessOption.PERSISTENT);
+  }
+
+  @Test
+  public void testUpdateChildrenFailsAfterRetries() {
+    ZkBaseDataAccessor<String> mockDataAccessor = mock(ZkBaseDataAccessor.class);
+    List<String> paths = new ArrayList<>();
+    paths.add("/test/path/child1");
+    paths.add("/test/path/child2");
+    List<String> data = new ArrayList<>();
+    data.add("data1");
+    data.add("data2");
+
+    boolean[] failedResults = new boolean[] { true, false };
+    doReturn(failedResults).when(mockDataAccessor).setChildren(paths, data, AccessOption.PERSISTENT);
+
+    Assert.assertThrows(VeniceException.class, () -> {
+      HelixUtils.updateChildren(mockDataAccessor, paths, data, 3);
+    });
+  }
+
+  @Test
+  public void testUpdateChildrenSucceedsAfterRetries() {
+    ZkBaseDataAccessor<String> mockDataAccessor = mock(ZkBaseDataAccessor.class);
+    List<String> paths = new ArrayList<>();
+    paths.add("/test/path/child1");
+    paths.add("/test/path/child2");
+    List<String> data = new ArrayList<>();
+    data.add("data1");
+    data.add("data2");
+
+    boolean[] successResults = new boolean[] { true, true };
+    boolean[] failedResults = new boolean[] { true, false };
+
+    doReturn(failedResults).doReturn(failedResults)
+        .doReturn(successResults)
+        .when(mockDataAccessor)
+        .setChildren(paths, data, AccessOption.PERSISTENT);
+
+    HelixUtils.updateChildren(mockDataAccessor, paths, data, 3);
+
+    verify(mockDataAccessor, times(3)).setChildren(paths, data, AccessOption.PERSISTENT);
+  }
+
+  @Test
+  public void testRemove() {
+    ZkBaseDataAccessor<String> mockDataAccessor = mock(ZkBaseDataAccessor.class);
+    String testPath = "/test/path";
+
+    doReturn(true).when(mockDataAccessor).remove(testPath, AccessOption.PERSISTENT);
+
+    HelixUtils.remove(mockDataAccessor, testPath, 3);
+
+    verify(mockDataAccessor, times(1)).remove(testPath, AccessOption.PERSISTENT);
+  }
+
+  @Test
+  public void testRemoveFailsAfterRetries() {
+    ZkBaseDataAccessor<String> mockDataAccessor = mock(ZkBaseDataAccessor.class);
+    String testPath = "/test/path";
+
+    doReturn(false).when(mockDataAccessor).remove(testPath, AccessOption.PERSISTENT);
+
+    Assert.assertThrows(VeniceException.class, () -> {
+      HelixUtils.remove(mockDataAccessor, testPath, 3);
+    });
+  }
+
+  @Test
+  public void testRemoveSucceedsAfterRetries() {
+    ZkBaseDataAccessor<String> mockDataAccessor = mock(ZkBaseDataAccessor.class);
+    String testPath = "/test/path";
+
+    doReturn(false).doReturn(false).doReturn(true).when(mockDataAccessor).remove(testPath, AccessOption.PERSISTENT);
+
+    HelixUtils.remove(mockDataAccessor, testPath, 3);
+  }
+
+  @Test
   public void testCompareAndUpdate() {
     ZkBaseDataAccessor<String> mockDataAccessor = mock(ZkBaseDataAccessor.class);
     String testPath = "/test/path";

--- a/internal/venice-common/src/test/java/com/linkedin/venice/utils/TestHelixUtils.java
+++ b/internal/venice-common/src/test/java/com/linkedin/venice/utils/TestHelixUtils.java
@@ -26,16 +26,16 @@ import org.testng.annotations.Test;
 
 
 public class TestHelixUtils {
-  private final String TEST_PATH = "/test/path";
-  private final String TEST_DATA = "testData";
+  private static final String TEST_PATH = "/test/path";
+  private static final String TEST_DATA = "testData";
   private static final int TEST_RETRY_COUNT = 3;
   private ZkBaseDataAccessor<String> mockDataAccessor;
   private DataUpdater<String> dataUpdater;
 
-  private final List<String> TEST_PATH_LIST = Arrays.asList("/test/path/child1", "/test/path/child2");
-  private final List<String> TEST_DATA_LIST = Arrays.asList("data1", "data2");
-  private final boolean[] SUCCESS_RESULTS = new boolean[] { true, true };
-  private final boolean[] FAILED_RESULTS = new boolean[] { true, false };
+  private static final List<String> TEST_PATH_LIST = Arrays.asList("/test/path/child1", "/test/path/child2");
+  private static final List<String> TEST_DATA_LIST = Arrays.asList("data1", "data2");
+  private static final boolean[] SUCCESS_RESULTS = new boolean[] { true, true };
+  private static final boolean[] FAILED_RESULTS = new boolean[] { true, false };
 
   @Test
   public void parsesHostnameFromInstanceName() {


### PR DESCRIPTION
## Problem Statement
- The current `compareAndUpdate` implementation in ZkBaseDataAccessor retries immediately when an update fails. As shown in [issue #656](https://github.com/linkedin/venice/issues/656), ZK replica status updates can be interrupted by temporary network issues or disconnects, causing partitions to move to error state
- The Venice Workspace Setup documentation examples for running tests have inconsistent formatting with unnecessary `$` prefixes

## Solution
- Added exponential backoff between retry attempts in the `compareAndUpdate` method, which will sleep for `2^retry` seconds (1s, 2s, 4s) between each attempt, improving resiliency against temporary ZK connection issues
- Removed unnecessary `$` prompts from command examples for clarity and consistency in documentation

### Code changes
- [ ] Added new code behind **a config**. If so list the config names and their default values in the PR description.
- [] Introduced new **log lines**. 
  - [] Confirmed if logs need to be **rate limited** to avoid excessive logging.

### **Concurrency-Specific Checks**
Both reviewer and PR author to verify
- [] Code has **no race conditions** or **thread safety issues**.
- [] Proper **synchronization mechanisms** (e.g., `synchronized`, `RWLock`) are used where needed.
- [] No **blocking calls** inside critical sections that could lead to deadlocks or performance degradation.
- [] Verified **thread-safe collections** are used (e.g., `ConcurrentHashMap`, `CopyOnWriteArrayList`).
- [] Validated proper exception handling in multi-threaded code to avoid silent thread termination.

## How was this PR tested?
- [] Modified or extended existing tests.
- [] Verified backward compatibility (if applicable).
  - Functionality remains the same, only the timing between retries has changed
  - Documentation changes are non-functional and do not affect behavior

## Does this PR introduce any user-facing or breaking changes?
- [x] No. You can skip the rest of this section.
- [ ] Yes. Clearly explain the behavior change and its impact.