### PR TITLE
[WIP] Deprecate parent VT to track concurrent pushes

### DIFF
--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestDeferredVersionSwap.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestDeferredVersionSwap.java
@@ -240,7 +240,7 @@ public class TestDeferredVersionSwap {
 
       TestUtils.waitForNonDeterministicAssertion(30, TimeUnit.SECONDS, () -> {
         StoreInfo parentStore = parentControllerClient.getStore(storeName).getStore();
-        Assert.assertEquals(parentStore.getVersion(1).get().getStatus(), VersionStatus.PUSHED);
+        Assert.assertEquals(parentStore.getVersion(1).get().getStatus(), VersionStatus.ONLINE);
       });
 
       // Verify that we can't create a new version

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceHelixAdmin.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceHelixAdmin.java
@@ -2956,6 +2956,7 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
             }
             long createBatchTopicStartTime = System.currentTimeMillis();
             topicToCreationTime.computeIfAbsent(version.kafkaTopicName(), topic -> System.currentTimeMillis());
+            if (!isParent()) {
             createBatchTopics(
                 version,
                 pushType,
@@ -2965,7 +2966,7 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
                 useFastKafkaOperationTimeout);
             addVersionLatencyStats
                 .recordBatchTopicCreationLatency(LatencyUtils.getElapsedTimeFromMsToMs(createBatchTopicStartTime));
-
+            }
             String sourceKafkaBootstrapServers = null;
 
             store = repository.getStore(storeName);

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceHelixAdmin.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceHelixAdmin.java
@@ -2957,6 +2957,7 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
             long createBatchTopicStartTime = System.currentTimeMillis();
             topicToCreationTime.computeIfAbsent(version.kafkaTopicName(), topic -> System.currentTimeMillis());
             if (!isParent()) {
+            topicToCreationTime.computeIfAbsent(version.kafkaTopicName(), topic -> System.currentTimeMillis());
             createBatchTopics(
                 version,
                 pushType,

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceParentHelixAdmin.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceParentHelixAdmin.java
@@ -1281,6 +1281,9 @@ public class VeniceParentHelixAdmin implements Admin {
     // latestTopic = Optional.of(versionTopics.get(0));
     // }
     Store store = getStore(clusterName, storeName);
+    if (store == null) {
+      return Optional.empty();
+    }
     int lastVersionNum = store.getLargestUsedVersionNumber();
     Version lastVersion = lastVersionNum > 0 ? store.getVersion(lastVersionNum) : null;
     Optional<String> latestTopic = Optional.empty();
@@ -1305,92 +1308,90 @@ public class VeniceParentHelixAdmin implements Admin {
         return Optional.of(latestTopic.get());
       }
 
-      if (!isTopicTruncated(latestTopicName)) {
+      /**
+       * Check whether the corresponding version exists or not, since it is possible that last push
+       * meets Kafka topic creation timeout.
+       * When Kafka topic creation timeout happens, topic/job could be still running, but the version
+       * should not exist according to the logic in {@link VeniceHelixAdmin#addVersion}.
+       * However, it is possible that a different request enters this code section when the topic has been created but
+       * either the version information has not been persisted to Zk or the in-memory Store object. In this case, it
+       * is desirable to add a delay to topic deletion.
+       *
+       * If the corresponding version doesn't exist, this function will issue command to kill job to deprecate
+       * the incomplete topic/job.
+       */
+      StoreVersionInfo storeVersionPair =
+          getVeniceHelixAdmin().waitVersion(clusterName, storeName, versionNumber, Duration.ofSeconds(30));
+      if (storeVersionPair.getVersion() == null) {
+        // TODO: Guard this topic deletion code using a store-level lock instead.
+        // Long inMemoryTopicCreationTime = getVeniceHelixAdmin().getInMemoryTopicCreationTime(latestTopicName);
+        // if (inMemoryTopicCreationTime != null
+        // && SystemTime.INSTANCE.getMilliseconds() < (inMemoryTopicCreationTime + TOPIC_DELETION_DELAY_MS)) {
+        // throw new VeniceException(
+        // "Failed to get version information but the topic exists and has been created recently. Try again after some
+        // time.");
+        // }
+
+        killOfflinePush(clusterName, latestTopicName, true);
+        LOGGER.info("Found topic: {} without the corresponding version, will kill it", latestTopicName);
+        return Optional.empty();
+      }
+
+      /**
+       * If Parent Controller could not infer the job status from topic retention policy, it will check the actual
+       * job status by sending requests to each individual datacenter.
+       * If the job is still running, Parent Controller will block current push.
+       */
+      final long SLEEP_MS_BETWEEN_RETRY = TimeUnit.SECONDS.toMillis(10);
+      ExecutionStatus jobStatus = ExecutionStatus.PROGRESS;
+      Map<String, String> extraInfo = new HashMap<>();
+
+      int retryTimes = 5;
+      int current = 0;
+      while (current++ < retryTimes) {
+        OfflinePushStatusInfo offlineJobStatus = getOffLinePushStatus(clusterName, latestTopicName);
+        jobStatus = offlineJobStatus.getExecutionStatus();
+        extraInfo = offlineJobStatus.getExtraInfo();
+        if (!extraInfo.containsValue(ExecutionStatus.UNKNOWN.toString())) {
+          break;
+        }
+        // Retry since there is a connection failure when querying job status against each datacenter
+        try {
+          timer.sleep(SLEEP_MS_BETWEEN_RETRY);
+        } catch (InterruptedException e) {
+          throw new VeniceException("Received InterruptedException during sleep between 'getOffLinePushStatus' calls");
+        }
+      }
+      if (extraInfo.containsValue(ExecutionStatus.UNKNOWN.toString())) {
+        // TODO: Do we need to throw exception here??
+        LOGGER.error(
+            "Failed to get job status for topic: {} after retrying {} times, extra info: {}",
+            latestTopicName,
+            retryTimes,
+            extraInfo);
+      }
+      if (!jobStatus.isTerminal()) {
+        LOGGER.info(
+            "Job status: {} for Kafka topic: {} is not terminal, extra info: {}",
+            jobStatus,
+            latestTopicName,
+            extraInfo);
+        if (latestTopic.isPresent()) {
+          return Optional.of(latestTopic.get());
+        }
+        return Optional.empty();
+      } else {
         /**
-         * Check whether the corresponding version exists or not, since it is possible that last push
-         * meets Kafka topic creation timeout.
-         * When Kafka topic creation timeout happens, topic/job could be still running, but the version
-         * should not exist according to the logic in {@link VeniceHelixAdmin#addVersion}.
-         * However, it is possible that a different request enters this code section when the topic has been created but
-         * either the version information has not been persisted to Zk or the in-memory Store object. In this case, it
-         * is desirable to add a delay to topic deletion.
-         *
-         * If the corresponding version doesn't exist, this function will issue command to kill job to deprecate
-         * the incomplete topic/job.
+         * If the job status of latestKafkaTopic is terminal and it is not an incremental push,
+         * it will be truncated in {@link #getOffLinePushStatus(String, String)}.
          */
-        StoreVersionInfo storeVersionPair =
-            getVeniceHelixAdmin().waitVersion(clusterName, storeName, versionNumber, Duration.ofSeconds(30));
-        if (storeVersionPair.getVersion() == null) {
-          // TODO: Guard this topic deletion code using a store-level lock instead.
-          Long inMemoryTopicCreationTime = getVeniceHelixAdmin().getInMemoryTopicCreationTime(latestTopicName);
-          if (inMemoryTopicCreationTime != null
-              && SystemTime.INSTANCE.getMilliseconds() < (inMemoryTopicCreationTime + TOPIC_DELETION_DELAY_MS)) {
-            throw new VeniceException(
-                "Failed to get version information but the topic exists and has been created recently. Try again after some time.");
-          }
-
-          killOfflinePush(clusterName, latestTopicName, true);
-          LOGGER.info("Found topic: {} without the corresponding version, will kill it", latestTopicName);
-          return Optional.empty();
-        }
-
-        /**
-         * If Parent Controller could not infer the job status from topic retention policy, it will check the actual
-         * job status by sending requests to each individual datacenter.
-         * If the job is still running, Parent Controller will block current push.
-         */
-        final long SLEEP_MS_BETWEEN_RETRY = TimeUnit.SECONDS.toMillis(10);
-        ExecutionStatus jobStatus = ExecutionStatus.PROGRESS;
-        Map<String, String> extraInfo = new HashMap<>();
-
-        int retryTimes = 5;
-        int current = 0;
-        while (current++ < retryTimes) {
-          OfflinePushStatusInfo offlineJobStatus = getOffLinePushStatus(clusterName, latestTopicName);
-          jobStatus = offlineJobStatus.getExecutionStatus();
-          extraInfo = offlineJobStatus.getExtraInfo();
-          if (!extraInfo.containsValue(ExecutionStatus.UNKNOWN.toString())) {
-            break;
-          }
-          // Retry since there is a connection failure when querying job status against each datacenter
-          try {
-            timer.sleep(SLEEP_MS_BETWEEN_RETRY);
-          } catch (InterruptedException e) {
-            throw new VeniceException(
-                "Received InterruptedException during sleep between 'getOffLinePushStatus' calls");
-          }
-        }
-        if (extraInfo.containsValue(ExecutionStatus.UNKNOWN.toString())) {
-          // TODO: Do we need to throw exception here??
-          LOGGER.error(
-              "Failed to get job status for topic: {} after retrying {} times, extra info: {}",
-              latestTopicName,
-              retryTimes,
-              extraInfo);
-        }
-        if (!jobStatus.isTerminal()) {
-          LOGGER.info(
-              "Job status: {} for Kafka topic: {} is not terminal, extra info: {}",
-              jobStatus,
-              latestTopicName,
-              extraInfo);
-          if (latestTopic.isPresent()) {
-            return Optional.of(latestTopic.get());
-          }
-          return Optional.empty();
-        } else {
-          /**
-           * If the job status of latestKafkaTopic is terminal and it is not an incremental push,
-           * it will be truncated in {@link #getOffLinePushStatus(String, String)}.
-           */
-          /*   if (!isIncrementalPush) {
-            Map<String, Integer> currentVersionsMap = getCurrentVersionsForMultiColos(clusterName, storeName);
-            truncateTopicsBasedOnMaxErroredTopicNumToKeep(
-                versionTopics.stream().map(vt -> vt.getName()).collect(Collectors.toList()),
-                isRepush,
-                currentVersionsMap);
-          } */
-        }
+        /*   if (!isIncrementalPush) {
+          Map<String, Integer> currentVersionsMap = getCurrentVersionsForMultiColos(clusterName, storeName);
+          truncateTopicsBasedOnMaxErroredTopicNumToKeep(
+              versionTopics.stream().map(vt -> vt.getName()).collect(Collectors.toList()),
+              isRepush,
+              currentVersionsMap);
+        } */
       }
     }
     return Optional.empty();

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceParentHelixAdmin.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceParentHelixAdmin.java
@@ -1275,27 +1275,34 @@ public class VeniceParentHelixAdmin implements Admin {
       boolean isIncrementalPush,
       boolean isRepush) {
     // The first/last topic in the list is the latest/oldest version topic
-    List<PubSubTopic> versionTopics = getKafkaTopicsByAge(storeName);
-    Optional<PubSubTopic> latestTopic = Optional.empty();
-    if (!versionTopics.isEmpty()) {
-      latestTopic = Optional.of(versionTopics.get(0));
+    // List<PubSubTopic> versionTopics = getKafkaTopicsByAge(storeName);
+    // Optional<PubSubTopic> latestTopic = Optional.empty();
+    // if (!versionTopics.isEmpty()) {
+    // latestTopic = Optional.of(versionTopics.get(0));
+    // }
+    Store store = getStore(clusterName, storeName);
+    int lastVersionNum = store.getLargestUsedVersionNumber();
+    Version lastVersion = lastVersionNum > 0 ? store.getVersion(lastVersionNum) : null;
+    Optional<String> latestTopic = Optional.empty();
+    if (lastVersion != null && lastVersion.getStatus() != ERROR && lastVersion.getStatus() != KILLED
+        && lastVersion.getStatus() != ONLINE) {
+      latestTopic = Optional.of(Version.composeKafkaTopic(storeName, lastVersionNum));
     }
-
     /**
      * Check current topic retention to decide whether the previous job is already done or not
      */
     if (latestTopic.isPresent()) {
       LOGGER.debug("Latest kafka topic for store: {} is {}", storeName, latestTopic.get());
-      final String latestTopicName = latestTopic.get().getName();
+      final String latestTopicName = latestTopic.get();
       int versionNumber = Version.parseVersionFromKafkaTopicName(latestTopicName);
-      Store store = getStore(clusterName, storeName);
+
       Version version = store.getVersion(versionNumber);
       if (version != null && version.isVersionSwapDeferred()) {
         LOGGER.error(
             "There is already future version {} exists for store {}, please wait till the future version is made current.",
             versionNumber,
             storeName);
-        return Optional.of(latestTopic.get().getName());
+        return Optional.of(latestTopic.get());
       }
 
       if (!isTopicTruncated(latestTopicName)) {
@@ -1368,7 +1375,7 @@ public class VeniceParentHelixAdmin implements Admin {
               latestTopicName,
               extraInfo);
           if (latestTopic.isPresent()) {
-            return Optional.of(latestTopic.get().getName());
+            return Optional.of(latestTopic.get());
           }
           return Optional.empty();
         } else {
@@ -1376,13 +1383,13 @@ public class VeniceParentHelixAdmin implements Admin {
            * If the job status of latestKafkaTopic is terminal and it is not an incremental push,
            * it will be truncated in {@link #getOffLinePushStatus(String, String)}.
            */
-          if (!isIncrementalPush) {
+          /*   if (!isIncrementalPush) {
             Map<String, Integer> currentVersionsMap = getCurrentVersionsForMultiColos(clusterName, storeName);
             truncateTopicsBasedOnMaxErroredTopicNumToKeep(
                 versionTopics.stream().map(vt -> vt.getName()).collect(Collectors.toList()),
                 isRepush,
                 currentVersionsMap);
-          }
+          } */
         }
       }
     }
@@ -3985,12 +3992,12 @@ public class VeniceParentHelixAdmin implements Admin {
         || isHybridStore // Push is to a hybrid store
     ) {
       LOGGER.info("Truncating parent VT {} after push status {}", kafkaTopic, currentReturnStatus.getRootStatus());
-      truncateTopicsOptionally(
+      /* truncateTopicsOptionally(
           clusterName,
           kafkaTopic,
           incrementalPushVersion,
           currentReturnStatus,
-          currentReturnStatusDetails);
+          currentReturnStatusDetails); */
     }
 
     // Update the parent version status for all pushes except for target region push w/ deferred swap as it's handled
@@ -5604,7 +5611,7 @@ public class VeniceParentHelixAdmin implements Admin {
       } else {
         if (storeB.getLargestUsedVersionNumber() >= versionNum) {
           // Version was added but then deleted due to errors
-          result.addVersionStateDiff(fabricA, fabricB, versionNum, version.getStatus(), VersionStatus.ERROR);
+          result.addVersionStateDiff(fabricA, fabricB, versionNum, version.getStatus(), ERROR);
         } else {
           result.addVersionStateDiff(fabricA, fabricB, versionNum, version.getStatus(), VersionStatus.NOT_CREATED);
         }
@@ -5612,7 +5619,7 @@ public class VeniceParentHelixAdmin implements Admin {
     }
     for (Version version: versionsB) {
       if (storeA.getLargestUsedVersionNumber() >= version.getNumber()) {
-        result.addVersionStateDiff(fabricA, fabricB, version.getNumber(), VersionStatus.ERROR, version.getStatus());
+        result.addVersionStateDiff(fabricA, fabricB, version.getNumber(), ERROR, version.getStatus());
       } else {
         result
             .addVersionStateDiff(fabricA, fabricB, version.getNumber(), VersionStatus.NOT_CREATED, version.getStatus());


### PR DESCRIPTION
<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat], [protocol]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## Problem Statement
<!--
Describe
- What problem are you trying to solve
- What issues or limitations exist in the current code
- Why this change is necessary 
-->

Today parent controller creates a version topic in parent region just to track current push status and block future pushes till the current push finishes. This is waste of kafka resources just to block concurrent pushes.

## Solution
<!--
Describe
- What changes you are making and why. 
- How these changes solve the problem.
- Any performance considerations or trade-offs. 
- Describe what testings you have done, for example, performance testing etc.
-->

This PR tries to use parent colo store version status to detect previous push status. Today parent store version statuses for completed push are as either KILLED/ERROR/ONLINE which imply that the push has finished from user perspective and they can trigger another push.

###  Code changes
- [ ] Added new code behind **a config**. If so list the config names and their default values in the PR description.
- [ ] Introduced new **log lines**. 
  - [ ] Confirmed if logs need to be **rate limited** to avoid excessive logging.

###  **Concurrency-Specific Checks**
Both reviewer and PR author to verify
- [ ] Code has **no race conditions** or **thread safety issues**.
- [ ] Proper **synchronization mechanisms** (e.g., `synchronized`, `RWLock`) are used where needed.
- [ ] No **blocking calls** inside critical sections that could lead to deadlocks or performance degradation.
- [ ] Verified **thread-safe collections** are used (e.g., `ConcurrentHashMap`, `CopyOnWriteArrayList`).
- [ ] Validated proper exception handling in multi-threaded code to avoid silent thread termination.


## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->

- [ ] New unit tests added.
- [ ] New integration tests added.
- [ ] Modified or extended existing tests.
- [ ] Verified backward compatibility (if applicable).

## Does this PR introduce any user-facing or breaking changes?
<!--  
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [ ] No. You can skip the rest of this section.
- [ ] Yes. Clearly explain the behavior change and its impact.