### PR TITLE
[vpj] Enforce record size limit on batch pushes for uncompressed record sizes

### DIFF
--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/PushJobSetting.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/PushJobSetting.java
@@ -116,6 +116,7 @@ public class PushJobSetting implements Serializable {
   public boolean chunkingEnabled;
   public boolean rmdChunkingEnabled;
   public int maxRecordSizeBytes;
+  public boolean enableUncompressedRecordSizeLimit;
   public String kafkaSourceRegion;
   public transient RepushInfoResponse repushInfoResponse;
 

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/VenicePushJob.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/VenicePushJob.java
@@ -360,6 +360,8 @@ public class VenicePushJob implements AutoCloseable {
     pushJobSettingToReturn.suppressEndOfPushMessage = props.getBoolean(SUPPRESS_END_OF_PUSH_MESSAGE, false);
     pushJobSettingToReturn.deferVersionSwap = props.getBoolean(DEFER_VERSION_SWAP, false);
     pushJobSettingToReturn.repushTTLEnabled = props.getBoolean(REPUSH_TTL_ENABLE, false);
+    pushJobSettingToReturn.enableUncompressedRecordSizeLimit =
+        props.getBoolean(VeniceWriter.ENABLE_UNCOMPRESSED_RECORD_SIZE_LIMIT, false);
 
     if (pushJobSettingToReturn.repushTTLEnabled && !pushJobSettingToReturn.isSourceKafka) {
       throw new VeniceException("Repush with TTL is only supported while using Kafka Input Format");
@@ -1538,13 +1540,12 @@ public class VenicePushJob implements AutoCloseable {
     if (inputStorageQuotaTracker.exceedQuota(totalInputDataSizeInBytes)) {
       updatePushJobDetailsWithCheckpoint(PushJobCheckpoints.QUOTA_EXCEEDED);
       Long storeQuota = inputStorageQuotaTracker.getStoreStorageQuota();
-      String errorMessage = String.format(
+      return String.format(
           "Storage quota exceeded. Store quota %s, Input data size %s."
               + " Please request at least %s additional quota.",
           generateHumanReadableByteCountString(storeQuota),
           generateHumanReadableByteCountString(totalInputDataSizeInBytes),
           generateHumanReadableByteCountString(totalInputDataSizeInBytes - storeQuota));
-      return errorMessage;
     }
     // Write ACL failed
     final long writeAclFailureCount = dataWriterTaskTracker.getWriteAclAuthorizationFailureCount();
@@ -1558,14 +1559,15 @@ public class VenicePushJob implements AutoCloseable {
       final long duplicateKeyWithDistinctValueCount = dataWriterTaskTracker.getDuplicateKeyWithDistinctValueCount();
       if (duplicateKeyWithDistinctValueCount > 0) {
         updatePushJobDetailsWithCheckpoint(PushJobCheckpoints.DUP_KEY_WITH_DIFF_VALUE);
-        String errorMessage = String.format(
+        return String.format(
             "Input data has at least %d keys that appear more than once but have different values",
             duplicateKeyWithDistinctValueCount);
-        return errorMessage;
       }
     }
     // Record too large
-    final long recordTooLargeFailureCount = dataWriterTaskTracker.getRecordTooLargeFailureCount();
+    final long recordTooLargeFailureCount = this.pushJobSetting.enableUncompressedRecordSizeLimit
+        ? dataWriterTaskTracker.getUncompressedRecordTooLargeFailureCount()
+        : dataWriterTaskTracker.getRecordTooLargeFailureCount();
     if (recordTooLargeFailureCount > 0) {
       updatePushJobDetailsWithCheckpoint(PushJobCheckpoints.RECORD_TOO_LARGE_FAILED);
 
@@ -1574,13 +1576,28 @@ public class VenicePushJob implements AutoCloseable {
       final int recordSizeLimit = (pushJobDetails.chunkingEnabled)
           ? getVeniceWriter(pushJobSetting).getMaxRecordSizeBytes()
           : getVeniceWriter(pushJobSetting).getMaxSizeForUserPayloadPerMessageInBytes();
-      final String errorMessage = String.format(
-          "Input data has at least %d records that exceed the maximum record limit of %s",
+
+      return String.format(
+          "Input data has at least %d records that exceed the maximum record limit of %s%s",
           recordTooLargeFailureCount,
-          generateHumanReadableByteCountString(recordSizeLimit));
-      return errorMessage;
+          generateHumanReadableByteCountString(recordSizeLimit),
+          formatRecordTooLargeCompressionStatus());
     }
     return null;
+  }
+
+  /* Helper function to format part of the record too large compression status */
+  private String formatRecordTooLargeCompressionStatus() {
+    if (this.pushJobSetting.storeCompressionStrategy != null
+        && this.pushJobSetting.storeCompressionStrategy.isCompressionEnabled()) {
+      if (this.pushJobSetting.enableUncompressedRecordSizeLimit) {
+        return " before compression";
+      } else {
+        return " after compression";
+      }
+    }
+
+    return "";
   }
 
   /** Transform per colo {@link ExecutionStatus} to per colo {@link PushJobDetailsStatus} */

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/mapreduce/counter/MRJobCounterHelper.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/mapreduce/counter/MRJobCounterHelper.java
@@ -24,6 +24,7 @@ public class MRJobCounterHelper {
   private static final String EMPTY_RECORD = "empty record";
   private static final String AUTHORIZATION_FAILURES = "authorization failures";
   private static final String RECORD_TOO_LARGE_FAILURES = "record too large failures";
+  private static final String UNCOMPRESSED_RECORD_TOO_LARGE_FAILURES = "uncompressed record too large failures";
 
   private static final String COUNTER_GROUP_DATA_QUALITY = "Data quality";
   private static final String DUPLICATE_KEY_WITH_IDENTICAL_VALUE = "duplicate key with identical value";
@@ -66,6 +67,9 @@ public class MRJobCounterHelper {
   public static final GroupAndCounterNames RECORD_TOO_LARGE_FAILURE_GROUP_COUNTER_NAME =
       new GroupAndCounterNames(COUNTER_GROUP_DATA_QUALITY, RECORD_TOO_LARGE_FAILURES);
 
+  public static final GroupAndCounterNames UNCOMPRESSED_RECORD_TOO_LARGE_FAILURE_GROUP_COUNTER_NAME =
+      new GroupAndCounterNames(COUNTER_GROUP_DATA_QUALITY, UNCOMPRESSED_RECORD_TOO_LARGE_FAILURES);
+
   public static final GroupAndCounterNames OUTPUT_RECORD_COUNT_GROUP_COUNTER_NAME =
       new GroupAndCounterNames(COUNTER_GROUP_KAFKA, COUNTER_OUTPUT_RECORDS);
 
@@ -102,6 +106,10 @@ public class MRJobCounterHelper {
 
   public static void incrRecordTooLargeFailureCount(Reporter reporter, long amount) {
     incrAmountWithGroupCounterName(reporter, RECORD_TOO_LARGE_FAILURE_GROUP_COUNTER_NAME, amount);
+  }
+
+  public static void incrUncompressedRecordTooLargeFailureCount(Reporter reporter, long amount) {
+    incrAmountWithGroupCounterName(reporter, UNCOMPRESSED_RECORD_TOO_LARGE_FAILURE_GROUP_COUNTER_NAME, amount);
   }
 
   public static void incrTotalKeySize(Reporter reporter, long amount) {
@@ -156,6 +164,10 @@ public class MRJobCounterHelper {
     return getCountWithGroupCounterName(reporter, RECORD_TOO_LARGE_FAILURE_GROUP_COUNTER_NAME);
   }
 
+  public static long getUncompressedRecordTooLargeFailureCount(Reporter reporter) {
+    return getCountWithGroupCounterName(reporter, UNCOMPRESSED_RECORD_TOO_LARGE_FAILURE_GROUP_COUNTER_NAME);
+  }
+
   public static long getTotalKeySize(Reporter reporter) {
     return getCountWithGroupCounterName(reporter, TOTAL_KEY_SIZE_GROUP_COUNTER_NAME);
   }
@@ -190,6 +202,10 @@ public class MRJobCounterHelper {
 
   public static long getRecordTooLargeFailureCount(Counters counters) {
     return getCountFromCounters(counters, RECORD_TOO_LARGE_FAILURE_GROUP_COUNTER_NAME);
+  }
+
+  public static long getUncompressedRecordTooLargeFailureCount(Counters counters) {
+    return getCountFromCounters(counters, UNCOMPRESSED_RECORD_TOO_LARGE_FAILURE_GROUP_COUNTER_NAME);
   }
 
   public static long getTotalKeySize(Counters counters) {

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/mapreduce/datawriter/task/CounterBackedMapReduceDataWriterTaskTracker.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/mapreduce/datawriter/task/CounterBackedMapReduceDataWriterTaskTracker.java
@@ -51,6 +51,11 @@ public class CounterBackedMapReduceDataWriterTaskTracker implements DataWriterTa
   }
 
   @Override
+  public long getUncompressedRecordTooLargeFailureCount() {
+    return MRJobCounterHelper.getUncompressedRecordTooLargeFailureCount(counters);
+  }
+
+  @Override
   public long getWriteAclAuthorizationFailureCount() {
     return MRJobCounterHelper.getWriteAclAuthorizationFailureCount(counters);
   }

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/mapreduce/datawriter/task/ReporterBackedMapReduceDataWriterTaskTracker.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/mapreduce/datawriter/task/ReporterBackedMapReduceDataWriterTaskTracker.java
@@ -79,6 +79,11 @@ public class ReporterBackedMapReduceDataWriterTaskTracker implements DataWriterT
   }
 
   @Override
+  public void trackUncompressedRecordTooLargeFailure() {
+    MRJobCounterHelper.incrUncompressedRecordTooLargeFailureCount(reporter, 1);
+  }
+
+  @Override
   public void trackRecordSentToPubSub() {
     MRJobCounterHelper.incrOutputRecordCount(reporter, 1);
   }
@@ -121,6 +126,11 @@ public class ReporterBackedMapReduceDataWriterTaskTracker implements DataWriterT
   @Override
   public long getRecordTooLargeFailureCount() {
     return MRJobCounterHelper.getRecordTooLargeFailureCount(reporter);
+  }
+
+  @Override
+  public long getUncompressedRecordTooLargeFailureCount() {
+    return MRJobCounterHelper.getUncompressedRecordTooLargeFailureCount(reporter);
   }
 
   @Override

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/task/datawriter/AbstractPartitionWriter.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/task/datawriter/AbstractPartitionWriter.java
@@ -172,6 +172,7 @@ public abstract class AbstractPartitionWriter extends AbstractDataWriterTask imp
 
   private VeniceProperties props;
   private long telemetryMessageInterval;
+  private boolean enableUncompressedRecordSizeLimit;
   private DuplicateKeyPrinter duplicateKeyPrinter;
   private Exception sendException = null;
 
@@ -297,7 +298,9 @@ public abstract class AbstractPartitionWriter extends AbstractDataWriterTask imp
     if (this.hasRecordTooLargeFailure) {
       return true;
     }
-    final boolean hasRecordTooLargeFailure = dataWriterTaskTracker.getRecordTooLargeFailureCount() > 0;
+    final boolean hasRecordTooLargeFailure = (dataWriterTaskTracker.getRecordTooLargeFailureCount() > 0
+        || (dataWriterTaskTracker.getUncompressedRecordTooLargeFailureCount() > 0
+            && this.enableUncompressedRecordSizeLimit));
     if (hasRecordTooLargeFailure) {
       this.hasRecordTooLargeFailure = true;
     }
@@ -590,6 +593,8 @@ public abstract class AbstractPartitionWriter extends AbstractDataWriterTask imp
     this.enableWriteCompute = (props.containsKey(ENABLE_WRITE_COMPUTE)) && props.getBoolean(ENABLE_WRITE_COMPUTE);
     this.duplicateKeyPrinter = initDuplicateKeyPrinter(props);
     this.telemetryMessageInterval = props.getInt(TELEMETRY_MESSAGE_INTERVAL, 10000);
+    this.enableUncompressedRecordSizeLimit =
+        props.getBoolean(VeniceWriter.ENABLE_UNCOMPRESSED_RECORD_SIZE_LIMIT, false);
     this.callback = new PartitionWriterProducerCallback();
     initStorageQuotaFields(props);
     /**

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/task/datawriter/DataWriterTaskTracker.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/task/datawriter/DataWriterTaskTracker.java
@@ -34,6 +34,9 @@ public interface DataWriterTaskTracker extends TaskTracker {
   default void trackRecordTooLargeFailure() {
   }
 
+  default void trackUncompressedRecordTooLargeFailure() {
+  }
+
   default void trackRecordSentToPubSub() {
   }
 
@@ -77,6 +80,10 @@ public interface DataWriterTaskTracker extends TaskTracker {
   }
 
   default long getRecordTooLargeFailureCount() {
+    return 0;
+  }
+
+  default long getUncompressedRecordTooLargeFailureCount() {
     return 0;
   }
 

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/spark/datawriter/task/DataWriterAccumulators.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/spark/datawriter/task/DataWriterAccumulators.java
@@ -23,6 +23,7 @@ public class DataWriterAccumulators implements Serializable {
   public final LongAccumulator duplicateKeyWithIdenticalValueCounter;
   public final LongAccumulator writeAclAuthorizationFailureCounter;
   public final LongAccumulator recordTooLargeFailureCounter;
+  public final LongAccumulator uncompressedRecordTooLargeFailureCounter;
   public final LongAccumulator duplicateKeyWithDistinctValueCounter;
   public final LongAccumulator partitionWriterCloseCounter;
   public final LongAccumulator repushTtlFilteredRecordCounter;
@@ -41,6 +42,7 @@ public class DataWriterAccumulators implements Serializable {
     repushTtlFilteredRecordCounter = sparkContext.longAccumulator("Repush TTL Filtered Records");
     writeAclAuthorizationFailureCounter = sparkContext.longAccumulator("ACL Authorization Failures");
     recordTooLargeFailureCounter = sparkContext.longAccumulator("Record Too Large Failures");
+    uncompressedRecordTooLargeFailureCounter = sparkContext.longAccumulator("Uncompressed Record Too Large Failures");
     duplicateKeyWithIdenticalValueCounter = sparkContext.longAccumulator("Duplicate Key With Identical Value");
     duplicateKeyWithDistinctValueCounter = sparkContext.longAccumulator("Duplicate Key With Distinct Value");
   }

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/spark/datawriter/task/SparkDataWriterTaskTracker.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/spark/datawriter/task/SparkDataWriterTaskTracker.java
@@ -56,6 +56,11 @@ public class SparkDataWriterTaskTracker implements DataWriterTaskTracker {
   }
 
   @Override
+  public void trackUncompressedRecordTooLargeFailure() {
+    accumulators.uncompressedRecordTooLargeFailureCounter.add(1);
+  }
+
+  @Override
   public void trackRecordSentToPubSub() {
     accumulators.outputRecordCounter.add(1);
   }
@@ -113,6 +118,11 @@ public class SparkDataWriterTaskTracker implements DataWriterTaskTracker {
   @Override
   public long getRecordTooLargeFailureCount() {
     return accumulators.recordTooLargeFailureCounter.value();
+  }
+
+  @Override
+  public long getUncompressedRecordTooLargeFailureCount() {
+    return accumulators.uncompressedRecordTooLargeFailureCounter.value();
   }
 
   @Override

--- a/clients/venice-push-job/src/test/java/com/linkedin/venice/hadoop/VenicePushJobTest.java
+++ b/clients/venice-push-job/src/test/java/com/linkedin/venice/hadoop/VenicePushJobTest.java
@@ -921,6 +921,46 @@ public class VenicePushJobTest {
   }
 
   /**
+   * Tests that the error message for the {@link com.linkedin.venice.PushJobCheckpoints#RECORD_TOO_LARGE_FAILED} code path of
+   * {@link VenicePushJob#updatePushJobDetailsWithJobDetails(DataWriterTaskTracker)} uses maxRecordSizeBytes.
+   */
+  @Test(dataProvider = "Boolean-Compression", dataProviderClass = DataProviderUtils.class)
+  public void testUpdatePushJobDetailsWithJobDetailsRecordTooLargeWithCompression(
+      boolean enableUncompressedMaxRecordSizeLimit,
+      CompressionStrategy compressionStrategy) {
+    try (final VenicePushJob vpj = getSpyVenicePushJob(getVpjRequiredProperties(), getClient())) {
+      // Setup push job settings and mocks
+      PushJobDetails pushJobDetails = vpj.getPushJobDetails();
+
+      setPushJobSettingDefaults(vpj.getPushJobSetting());
+      vpj.setInputStorageQuotaTracker(mock(InputStorageQuotaTracker.class));
+      vpj.getPushJobSetting().enableUncompressedRecordSizeLimit = enableUncompressedMaxRecordSizeLimit;
+      vpj.getPushJobSetting().storeCompressionStrategy = compressionStrategy;
+
+      final DataWriterTaskTracker dataWriterTaskTracker = mock(DataWriterTaskTracker.class);
+      doReturn(1L).when(dataWriterTaskTracker).getRecordTooLargeFailureCount();
+      doReturn(1L).when(dataWriterTaskTracker).getUncompressedRecordTooLargeFailureCount();
+
+      // The value of chunkingEnabled should dictate the error message returned
+      final String errorMessage = vpj.updatePushJobDetailsWithJobDetails(dataWriterTaskTracker);
+      Assert.assertTrue(
+          errorMessage.contains("records that exceed the maximum record limit of"),
+          "Unexpected error message: " + errorMessage);
+
+      if (compressionStrategy.isCompressionEnabled()) {
+        if (enableUncompressedMaxRecordSizeLimit) {
+          Assert.assertTrue(errorMessage.contains("before compression"), "Unexpected error message: " + errorMessage);
+        } else {
+          Assert.assertTrue(errorMessage.contains("after compression"), "Unexpected error message: " + errorMessage);
+        }
+      }
+
+      final int latestCheckpoint = pushJobDetails.pushJobLatestCheckpoint;
+      Assert.assertEquals(latestCheckpoint, PushJobCheckpoints.RECORD_TOO_LARGE_FAILED.getValue());
+    }
+  }
+
+  /**
    * These are mainly for code coverage for the code paths of {@link VenicePushJob#getVeniceWriter(PushJobSetting)} and
    * {@link VenicePushJob#getVeniceWriterProperties(PushJobSetting)}.
    */

--- a/clients/venice-push-job/src/test/java/com/linkedin/venice/hadoop/mapreduce/datawriter/reduce/TestVeniceReducer.java
+++ b/clients/venice-push-job/src/test/java/com/linkedin/venice/hadoop/mapreduce/datawriter/reduce/TestVeniceReducer.java
@@ -313,6 +313,12 @@ public class TestVeniceReducer extends AbstractTestVeniceMR {
 
     when(
         mockReporter.getCounter(
+            MRJobCounterHelper.UNCOMPRESSED_RECORD_TOO_LARGE_FAILURE_GROUP_COUNTER_NAME.getGroupName(),
+            MRJobCounterHelper.UNCOMPRESSED_RECORD_TOO_LARGE_FAILURE_GROUP_COUNTER_NAME.getCounterName()))
+                .thenReturn(zeroCounters);
+
+    when(
+        mockReporter.getCounter(
             MRJobCounterHelper.DUP_KEY_WITH_DISTINCT_VALUE_GROUP_COUNTER_NAME.getGroupName(),
             MRJobCounterHelper.DUP_KEY_WITH_DISTINCT_VALUE_GROUP_COUNTER_NAME.getCounterName()))
                 .thenReturn(nonZeroCounters);

--- a/internal/venice-common/src/main/java/com/linkedin/venice/writer/VeniceWriter.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/writer/VeniceWriter.java
@@ -140,6 +140,12 @@ public class VeniceWriter<K, V, U> extends AbstractVeniceWriter<K, V, U> {
    */
   public static final String MAX_RECORD_SIZE_BYTES = VENICE_WRITER_CONFIG_PREFIX + "max.record.size.bytes";
 
+  /**
+  * Enable maximum record size before record compression. Default: false
+  * */
+  public static final String ENABLE_UNCOMPRESSED_RECORD_SIZE_LIMIT =
+      VENICE_WRITER_CONFIG_PREFIX + "enable.uncompressed.record.size.limit";
+
   public static final String PRODUCER_THREAD_COUNT = VENICE_WRITER_CONFIG_PREFIX + "producer.thread.count";
   public static final String PRODUCER_QUEUE_SIZE = VENICE_WRITER_CONFIG_PREFIX + "producer.queue.size";
 


### PR DESCRIPTION
<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat], [protocol]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## Problem Statement
<!--
Describe
- What problem are you trying to solve
- What issues or limitations exist in the current code
- Why this change is necessary 
-->
Currently, the max record size enforcement is on the compressed size of the record. This causes some uncertainly since two record of the same uncompressed size may have different compressed sizes.


## Solution
<!--
Describe
- What changes you are making and why. 
- How these changes solve the problem.
- Any performance considerations or trade-offs. 
- Describe what testings you have done, for example, performance testing etc.
-->
We would like to enforce the max record size pre-compression in the InputProcessor.

This enforcement will be gated using a VPJ config `venice.writer.enable.uncompressed.record.size.limit`

###  Code changes
- [ ] Added new code behind **a config**. If so list the config names and their default values in the PR description.
- [ ] Introduced new **log lines**. 
  - [ ] Confirmed if logs need to be **rate limited** to avoid excessive logging.

###  **Concurrency-Specific Checks**
Both reviewer and PR author to verify
- [x] Code has **no race conditions** or **thread safety issues**.
- [x] Proper **synchronization mechanisms** (e.g., `synchronized`, `RWLock`) are used where needed.
- [x] No **blocking calls** inside critical sections that could lead to deadlocks or performance degradation.
- [x] Verified **thread-safe collections** are used (e.g., `ConcurrentHashMap`, `CopyOnWriteArrayList`).
- [x] Validated proper exception handling in multi-threaded code to avoid silent thread termination.


## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->

- [x] New unit tests added.
- [x] New integration tests added.
- [ ] Modified or extended existing tests.
- [ ] Verified backward compatibility (if applicable).

## Does this PR introduce any user-facing or breaking changes?
<!--  
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Clearly explain the behavior change and its impact.