### PR TITLE
[controller] Fail roll forward if not all partitions have enough ready to serve replicas

### DIFF
--- a/internal/venice-common/src/main/java/com/linkedin/venice/controllerapi/ControllerClient.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/controllerapi/ControllerClient.java
@@ -655,7 +655,13 @@ public class ControllerClient implements Closeable {
 
   public ControllerResponse rollForwardToFutureVersion(String storeName, String regionFilter) {
     QueryParams params = newParams().add(NAME, storeName).add(REGIONS_FILTER, regionFilter);
-    return request(ControllerRoute.ROLL_FORWARD_TO_FUTURE_VERSION, params, ControllerResponse.class);
+    ControllerResponse response =
+        request(ControllerRoute.ROLL_FORWARD_TO_FUTURE_VERSION, params, ControllerResponse.class);
+    if (response.isError()) {
+      throw new VeniceException(
+          "Failed to roll forward to future version for store: " + storeName + " with error: " + response.getError());
+    }
+    return response;
   }
 
   public ControllerResponse rollForwardToFutureVersion(String storeName) {

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceParentHelixAdmin.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceParentHelixAdmin.java
@@ -618,7 +618,7 @@ public class VeniceParentHelixAdmin implements Admin {
     return getVeniceHelixAdmin().isClusterValid(clusterName);
   }
 
-  private void sendAdminMessageAndWaitForConsumed(String clusterName, String storeName, AdminOperation message) {
+  void sendAdminMessageAndWaitForConsumed(String clusterName, String storeName, AdminOperation message) {
     if (!veniceWriterMap.containsKey(clusterName)) {
       throw new VeniceException("Cluster: " + clusterName + " is not started yet!");
     }
@@ -802,7 +802,7 @@ public class VeniceParentHelixAdmin implements Admin {
    * ongoing admin operation is being performed.
    * This lock is held when generating, writing and processing the admin messages for the given store.
    */
-  private void acquireAdminMessageLock(String clusterName, String storeName) {
+  void acquireAdminMessageLock(String clusterName, String storeName) {
     try {
       if (clusterName == null) {
         throw new VeniceException("Cannot acquire admin message lock with a null cluster name");
@@ -830,7 +830,7 @@ public class VeniceParentHelixAdmin implements Admin {
     }
   }
 
-  private void releaseAdminMessageLock(String clusterName, String storeName) {
+  void releaseAdminMessageLock(String clusterName, String storeName) {
     if (clusterName == null) {
       throw new VeniceException("Cannot release admin message lock with null cluster name");
     }
@@ -2111,7 +2111,7 @@ public class VeniceParentHelixAdmin implements Admin {
     acquireAdminMessageLock(clusterName, storeName);
     try {
       getVeniceHelixAdmin().checkPreConditionForUpdateStoreMetadata(clusterName, storeName);
-      // Send admin message to set backup version as current version. Child controllers will execute the admin message.
+      // Send admin message to set future version as current version. Child controllers will execute the admin message.
       RollForwardCurrentVersion rollForwardCurrentVersion =
           (RollForwardCurrentVersion) AdminMessageType.ROLLFORWARD_CURRENT_VERSION.getNewInstance();
       rollForwardCurrentVersion.clusterName = clusterName;
@@ -2121,17 +2121,52 @@ public class VeniceParentHelixAdmin implements Admin {
       message.operationType = AdminMessageType.ROLLFORWARD_CURRENT_VERSION.getValue();
       message.payloadUnion = rollForwardCurrentVersion;
 
-      Map<String, String> futureVersions = getFutureVersionsForMultiColos(clusterName, storeName);
-      int futureVersion = 0;
-      for (Map.Entry<String, String> entry: futureVersions.entrySet()) {
-        futureVersion = Integer.parseInt(entry.getValue());
-        if (futureVersion > 0) {
+      Map<String, String> futureVersionsBeforeRollForward = getFutureVersionsForMultiColos(clusterName, storeName);
+      int futureVersionBeforeRollForward = 0;
+      for (Map.Entry<String, String> entry: futureVersionsBeforeRollForward.entrySet()) {
+        futureVersionBeforeRollForward = Integer.parseInt(entry.getValue());
+        if (futureVersionBeforeRollForward > 0) {
           break;
         }
       }
+
+      if (futureVersionBeforeRollForward <= 0) {
+        throw new VeniceException("Roll forward failed without any future version");
+      }
+
+      LOGGER.info(
+          "Sending roll forward command to future version {} for store {} to child controllers",
+          futureVersionBeforeRollForward,
+          storeName);
       sendAdminMessageAndWaitForConsumed(clusterName, storeName, message);
-      LOGGER.info("Truncating topic {} after rollforward", Version.composeKafkaTopic(storeName, futureVersion));
-      truncateKafkaTopic(Version.composeKafkaTopic(storeName, futureVersion));
+      LOGGER.info(
+          "Truncating topic {} after child controllers consumed the roll forward messages to not block new versions",
+          Version.composeKafkaTopic(storeName, futureVersionBeforeRollForward));
+      truncateKafkaTopic(Version.composeKafkaTopic(storeName, futureVersionBeforeRollForward));
+
+      // check whether the roll forward is successful in all regions
+      Map<String, Integer> currentVersionsAfterRollForward = getCurrentVersionsForMultiColos(clusterName, storeName);
+      Map<String, Integer> failedRegions = new HashMap<>();
+      for (Map.Entry<String, Integer> entry: currentVersionsAfterRollForward.entrySet()) {
+        int currentVersionAfterRollForward = entry.getValue();
+        if (currentVersionAfterRollForward != futureVersionBeforeRollForward) {
+          failedRegions.put(entry.getKey(), currentVersionAfterRollForward);
+        }
+      }
+      if (!failedRegions.isEmpty()) {
+        StringBuilder sb = new StringBuilder();
+        sb.append("Roll forward failed in regions: ");
+        for (Map.Entry<String, Integer> entry: failedRegions.entrySet()) {
+          sb.append(entry.getKey()).append(" with current version: ").append(entry.getValue()).append(",");
+        }
+        sb.append(". Roll forward will be retried until it is successful.");
+        throw new VeniceException(sb.toString());
+      } else {
+        LOGGER.info(
+            "Roll forward to future version {} is successful in all regions for store {}",
+            futureVersionBeforeRollForward,
+            storeName);
+      }
     } finally {
       releaseAdminMessageLock(clusterName, storeName);
     }

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/server/StoresRoutes.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/server/StoresRoutes.java
@@ -680,7 +680,11 @@ public class StoresRoutes extends AbstractRoute {
         String clusterName = request.queryParams(CLUSTER);
         String storeName = request.queryParams(NAME);
         String regionFilter = request.queryParamOrDefault(REGIONS_FILTER, "");
-        admin.rollForwardToFutureVersion(clusterName, storeName, regionFilter);
+        try {
+          admin.rollForwardToFutureVersion(clusterName, storeName, regionFilter);
+        } catch (Exception e) {
+          veniceResponse.setError("Roll forward failed for store " + storeName, e);
+        }
 
         veniceResponse.setCluster(clusterName);
         veniceResponse.setName(storeName);

--- a/services/venice-controller/src/test/java/com/linkedin/venice/controller/TestVeniceHelixAdmin.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/controller/TestVeniceHelixAdmin.java
@@ -9,6 +9,7 @@ import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
 import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doCallRealMethod;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doReturn;
@@ -23,6 +24,7 @@ import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.expectThrows;
+import static org.testng.Assert.fail;
 
 import com.linkedin.venice.common.VeniceSystemStoreType;
 import com.linkedin.venice.controller.kafka.consumer.AdminConsumerService;
@@ -32,8 +34,10 @@ import com.linkedin.venice.controller.stats.VeniceAdminStats;
 import com.linkedin.venice.controllerapi.AdminOperationProtocolVersionControllerResponse;
 import com.linkedin.venice.controllerapi.ControllerClient;
 import com.linkedin.venice.exceptions.VeniceException;
+import com.linkedin.venice.helix.HelixCustomizedViewOfflinePushRepository;
 import com.linkedin.venice.helix.HelixExternalViewRepository;
 import com.linkedin.venice.helix.HelixState;
+import com.linkedin.venice.ingestion.control.RealTimeTopicSwitcher;
 import com.linkedin.venice.meta.DataReplicationPolicy;
 import com.linkedin.venice.meta.HybridStoreConfig;
 import com.linkedin.venice.meta.Instance;
@@ -51,6 +55,7 @@ import com.linkedin.venice.pubsub.PubSubTopicRepository;
 import com.linkedin.venice.pubsub.api.PubSubTopic;
 import com.linkedin.venice.pubsub.manager.TopicManager;
 import com.linkedin.venice.pushmonitor.ExecutionStatus;
+import com.linkedin.venice.utils.DataProviderUtils;
 import com.linkedin.venice.utils.HelixUtils;
 import com.linkedin.venice.utils.Utils;
 import com.linkedin.venice.utils.locks.ClusterLockManager;
@@ -76,6 +81,9 @@ import org.testng.annotations.Test;
 public class TestVeniceHelixAdmin {
   private static final PubSubTopicRepository PUB_SUB_TOPIC_REPOSITORY = new PubSubTopicRepository();
 
+  private static final String clusterName = "test-cluster";
+  private static final String storeName = "test-store";
+
   @Test
   public void testDropResources() {
     VeniceHelixAdmin veniceHelixAdmin = mock(VeniceHelixAdmin.class);
@@ -83,7 +91,6 @@ public class TestVeniceHelixAdmin {
     String storeName = "abc";
     String instance = "node_1";
     String kafkaTopic = Version.composeKafkaTopic(storeName, 1);
-    String clusterName = "venice-cluster";
     nodes.add(instance);
     Map<String, List<String>> listMap = new HashMap<>();
     List<String> partitions = new ArrayList<>(3);
@@ -216,8 +223,6 @@ public class TestVeniceHelixAdmin {
 
   @Test
   public void testCreateOrUpdateRealTimeTopics() {
-    String clusterName = "testCluster";
-    String storeName = "testStore";
     Store store = mock(Store.class, RETURNS_DEEP_STUBS);
     when(store.getName()).thenReturn(storeName);
     Version version = mock(Version.class);
@@ -234,7 +239,7 @@ public class TestVeniceHelixAdmin {
     ArgumentCaptor<PubSubTopic> pubSubTopicArgumentCaptor = ArgumentCaptor.forClass(PubSubTopic.class);
     verify(veniceHelixAdmin, times(1))
         .createOrUpdateRealTimeTopic(eq(clusterName), eq(store), eq(version), pubSubTopicArgumentCaptor.capture());
-    assertEquals(pubSubTopicArgumentCaptor.getValue().getName(), "testStore_rt");
+    assertEquals(pubSubTopicArgumentCaptor.getValue().getName(), storeName + "_rt");
 
     // Case 2: Both regular and separate real-time topics are required
     when(version.isSeparateRealTimeTopicEnabled()).thenReturn(true);
@@ -250,8 +255,6 @@ public class TestVeniceHelixAdmin {
 
   @Test
   public void testCreateOrUpdateRealTimeTopic() {
-    String clusterName = "testCluster";
-    String storeName = "testStore";
     int partitionCount = 10;
     Store store = mock(Store.class, RETURNS_DEEP_STUBS);
     when(store.getName()).thenReturn(storeName);
@@ -333,8 +336,6 @@ public class TestVeniceHelixAdmin {
 
   @Test
   public void testEnsureRealTimeTopicExistsForUserSystemStores() {
-    String clusterName = "testCluster";
-    String storeName = "testStore";
     String systemStoreName = VeniceSystemStoreType.DAVINCI_PUSH_STATUS_STORE.getSystemStoreName(storeName);
     int partitionCount = 10;
     Store userStore = mock(Store.class, RETURNS_DEEP_STUBS);
@@ -452,8 +453,6 @@ public class TestVeniceHelixAdmin {
 
   @Test
   public void testValidateStoreSetupForRTWrites() {
-    String clusterName = "testCluster";
-    String storeName = "testStore";
     String pushJobId = "pushJob123";
     VeniceHelixAdmin veniceHelixAdmin = mock(VeniceHelixAdmin.class);
     Store store = mock(Store.class, RETURNS_DEEP_STUBS);
@@ -506,8 +505,6 @@ public class TestVeniceHelixAdmin {
 
   @Test
   public void testValidateTopicPresenceAndState() {
-    String clusterName = "testCluster";
-    String storeName = "testStore";
     String pushJobId = "pushJob123";
     PubSubTopic topic = mock(PubSubTopic.class);
     int partitionCount = 10;
@@ -572,8 +569,6 @@ public class TestVeniceHelixAdmin {
 
   @Test
   public void testValidateTopicForIncrementalPush() {
-    String clusterName = "testCluster";
-    String storeName = "testStore";
     String pushJobId = "pushJob123";
     int partitionCount = 10;
     Store store = mock(Store.class);
@@ -676,8 +671,6 @@ public class TestVeniceHelixAdmin {
 
   @Test
   public void testGetReferenceHybridVersionForRealTimeWrites() {
-    String clusterName = "testCluster";
-    String storeName = "testStore";
     String pushJobId = "pushJob123";
     Store store = mock(Store.class, RETURNS_DEEP_STUBS);
     VeniceHelixAdmin veniceHelixAdmin = mock(VeniceHelixAdmin.class);
@@ -743,8 +736,6 @@ public class TestVeniceHelixAdmin {
 
   @Test
   public void testGetIncrementalPushVersion() {
-    String clusterName = "testCluster";
-    String storeName = "testStore";
     String pushJobId = "pushJob123";
 
     VeniceHelixAdmin veniceHelixAdmin = mock(VeniceHelixAdmin.class);
@@ -811,8 +802,6 @@ public class TestVeniceHelixAdmin {
 
   @Test
   public void testGetReferenceVersionForStreamingWrites() {
-    String clusterName = "testCluster";
-    String storeName = "testStore";
     String pushJobId = "pushJob123";
     int partitionCount = 10;
 
@@ -822,7 +811,7 @@ public class TestVeniceHelixAdmin {
     Store store = mock(Store.class);
     Version hybridVersion = mock(Version.class);
     PubSubTopicRepository topicRepository = new PubSubTopicRepository();
-    PubSubTopic rtTopic = topicRepository.getTopic("testStore_rt");
+    PubSubTopic rtTopic = topicRepository.getTopic(storeName + "_rt");
 
     doReturn(storeName).when(store).getName();
     doReturn(storeName).when(hybridVersion).getStoreName();
@@ -906,8 +895,6 @@ public class TestVeniceHelixAdmin {
 
   @Test
   public void testCleanupWhenPushCompleteWithViewConfigs() {
-    String clusterName = "test-cluster";
-    String storeName = "test-store";
     String viewName = "testMaterializedView";
     int versionNumber = 1;
     String versionTopicName = Version.composeKafkaTopic(storeName, versionNumber);
@@ -966,8 +953,6 @@ public class TestVeniceHelixAdmin {
 
   @Test
   public void testGetAdminTopicMetadata() {
-    String clusterName = "test-cluster";
-    String storeName = "test-store";
     VeniceHelixAdmin veniceHelixAdmin = mock(VeniceHelixAdmin.class);
     doCallRealMethod().when(veniceHelixAdmin).getAdminTopicMetadata(clusterName, Optional.of(storeName));
     doCallRealMethod().when(veniceHelixAdmin).getAdminTopicMetadata(clusterName, Optional.empty());
@@ -999,8 +984,6 @@ public class TestVeniceHelixAdmin {
 
   @Test
   public void testUpdateAdminTopicMetadata() {
-    String clusterName = "test-cluster";
-    String storeName = "test-store";
     long executionId = 10L;
     Long offset = 10L;
     Long upstreamOffset = 1L;
@@ -1038,7 +1021,6 @@ public class TestVeniceHelixAdmin {
 
   @Test
   public void testGetAdminOperationVersionsFromControllers() {
-    String clusterName = "test-cluster";
     VeniceParentHelixAdmin veniceParentHelixAdmin = mock(VeniceParentHelixAdmin.class);
     VeniceHelixAdmin veniceHelixAdmin = mock(VeniceHelixAdmin.class);
     when(veniceParentHelixAdmin.getVeniceHelixAdmin()).thenReturn(veniceHelixAdmin);
@@ -1087,7 +1069,6 @@ public class TestVeniceHelixAdmin {
 
   @Test
   public void testFailedGetAdminOperationVersionsForStandbyControllers() {
-    String clusterName = "test-cluster";
     VeniceParentHelixAdmin veniceParentHelixAdmin = mock(VeniceParentHelixAdmin.class);
     VeniceHelixAdmin veniceHelixAdmin = mock(VeniceHelixAdmin.class);
     when(veniceParentHelixAdmin.getVeniceHelixAdmin()).thenReturn(veniceHelixAdmin);
@@ -1142,10 +1123,91 @@ public class TestVeniceHelixAdmin {
 
   @Test
   public void testGetControllersWithInvalidHelixState() {
-    String clusterName = "test-cluster";
     VeniceHelixAdmin veniceHelixAdmin = mock(VeniceHelixAdmin.class);
     doCallRealMethod().when(veniceHelixAdmin).getControllersByHelixState(any(), any());
 
     expectThrows(VeniceException.class, () -> veniceHelixAdmin.getControllersByHelixState(clusterName, "state"));
+  }
+
+  /** Skip if regionFilter doesn’t include this region */
+  @Test
+  public void testRollForwardSkipRegionFilter() {
+    VeniceHelixAdmin mockVeniceHelixAdmin = mock(VeniceHelixAdmin.class);
+    doReturn(false).when(mockVeniceHelixAdmin).isCurrentRegionPartOfRegionFilter(anyString());
+    doCallRealMethod().when(mockVeniceHelixAdmin).rollForwardToFutureVersion(anyString(), anyString(), anyString());
+    mockVeniceHelixAdmin.rollForwardToFutureVersion(clusterName, storeName, "test");
+
+    // should bail out before even checking future versions
+    verify(mockVeniceHelixAdmin, never()).getOnlineFutureVersion(any(), any());
+  }
+
+  /** No future version → just return (no exception) */
+  @Test
+  public void testRollForwardNoFutureVersions() {
+    VeniceHelixAdmin mockVeniceHelixAdmin = mock(VeniceHelixAdmin.class);
+    doReturn(true).when(mockVeniceHelixAdmin).isCurrentRegionPartOfRegionFilter(anyString());
+    doCallRealMethod().when(mockVeniceHelixAdmin).rollForwardToFutureVersion(anyString(), anyString(), anyString());
+    // pretend there is no future version
+    doReturn(0).when(mockVeniceHelixAdmin).getOnlineFutureVersion(eq(clusterName), eq(storeName));
+
+    // should simply return, not throw, and never attempt a metadata update
+    mockVeniceHelixAdmin.rollForwardToFutureVersion(clusterName, storeName, "test");
+    verify(mockVeniceHelixAdmin, never()).storeMetadataUpdate(any(), any(), any());
+  }
+
+  /**
+  * isPartitionReadyToServe=>true: Future version exists and partitions are ready → success
+  * isPartitionReadyToServe=>false: Future version exists but partitions aren’t ready → exception
+  */
+  @Test(dataProvider = "True-and-False", dataProviderClass = DataProviderUtils.class)
+  public void testRollForwardPartitionNotReady(boolean isPartitionReadyToServe) {
+    VeniceHelixAdmin mockVeniceHelixAdmin = mock(VeniceHelixAdmin.class);
+    doReturn(true).when(mockVeniceHelixAdmin).isCurrentRegionPartOfRegionFilter(anyString());
+    doReturn(2).when(mockVeniceHelixAdmin).getOnlineFutureVersion(clusterName, storeName);
+
+    // build a fake Store whose version 2 has 2 partitions but only 1 ready replica
+    Store mockStore = mock(Store.class);
+    when(mockStore.isEnableWrites()).thenReturn(true);
+    when(mockStore.getCurrentVersion()).thenReturn(1);
+
+    Version v2 = mock(Version.class);
+    when(v2.getPartitionCount()).thenReturn(2);
+    when(v2.getMinActiveReplicas()).thenReturn(isPartitionReadyToServe ? 1 : 2);
+    when(mockStore.getVersion(2)).thenReturn(v2);
+
+    // stub the repository to return only 1 ready instance per partition
+    HelixCustomizedViewOfflinePushRepository repo = mock(HelixCustomizedViewOfflinePushRepository.class);
+    when(repo.getReadyToServeInstances(anyString(), anyInt()))
+        .thenReturn(Collections.singletonList(new Instance("node1id", "node1", 1234)));
+
+    HelixVeniceClusterResources mockClusterResources = mock(HelixVeniceClusterResources.class);
+    doReturn(repo).when(mockClusterResources).getCustomizedViewRepository();
+    doReturn(mockClusterResources).when(mockVeniceHelixAdmin).getHelixVeniceClusterResources(clusterName);
+
+    RealTimeTopicSwitcher mockTopicSwitcher = mock(RealTimeTopicSwitcher.class);
+    doReturn(mockTopicSwitcher).when(mockVeniceHelixAdmin).getRealTimeTopicSwitcher();
+    doNothing().when(mockTopicSwitcher).transmitVersionSwapMessage(any(), anyInt(), anyInt());
+
+    // intercept the lambda passed to storeMetadataUpdate and run it on our mockStore
+    doAnswer(inv -> {
+      VeniceHelixAdmin.StoreMetadataOperation updater = inv.getArgument(2);
+      updater.update(mockStore);
+      return null;
+    }).when(mockVeniceHelixAdmin).storeMetadataUpdate(eq(clusterName), eq(storeName), any());
+    doCallRealMethod().when(mockVeniceHelixAdmin).rollForwardToFutureVersion(anyString(), anyString(), anyString());
+
+    try {
+      mockVeniceHelixAdmin.rollForwardToFutureVersion(clusterName, storeName, "test");
+      if (!isPartitionReadyToServe) {
+        fail("Expected VeniceException to be thrown");
+      }
+    } catch (VeniceException e) {
+      if (isPartitionReadyToServe) {
+        fail("Expected VeniceException not to be thrown");
+      }
+      assertTrue(
+          e.getMessage().contains("as the following partitions do not have enough ready-to-serve instances"),
+          "Actual message: " + e.getMessage());
+    }
   }
 }

--- a/services/venice-controller/src/test/java/com/linkedin/venice/controller/TestVeniceParentHelixAdmin.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/controller/TestVeniceParentHelixAdmin.java
@@ -11,6 +11,7 @@ import static org.mockito.Mockito.anyInt;
 import static org.mockito.Mockito.anyString;
 import static org.mockito.Mockito.atLeast;
 import static org.mockito.Mockito.doCallRealMethod;
+import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.eq;
@@ -3260,6 +3261,60 @@ public class TestVeniceParentHelixAdmin extends AbstractTestVeniceParentHelixAdm
 
     veniceParentHelixAdmin.updateAdminOperationProtocolVersion(clusterName, adminProtocolVersion);
     verify(adminConsumerService, times(1)).updateAdminOperationProtocolVersion(clusterName, adminProtocolVersion);
+  }
+
+  @Test(expectedExceptions = VeniceException.class, expectedExceptionsMessageRegExp = "Roll forward failed without any future version")
+  public void testRollForwardNoFutureVersions() {
+    VeniceParentHelixAdmin adminSpy = spy(parentAdmin);
+    doNothing().when(adminSpy).acquireAdminMessageLock(clusterName, storeName);
+    doNothing().when(adminSpy).releaseAdminMessageLock(clusterName, storeName);
+    doReturn(Collections.emptyMap()).when(adminSpy).getFutureVersionsForMultiColos(clusterName, storeName);
+    adminSpy.rollForwardToFutureVersion(clusterName, storeName, "");
+  }
+
+  @Test
+  public void testRollForwardSuccess() {
+    VeniceParentHelixAdmin adminSpy = spy(parentAdmin);
+    doNothing().when(adminSpy).acquireAdminMessageLock(clusterName, storeName);
+    doNothing().when(adminSpy).releaseAdminMessageLock(clusterName, storeName);
+
+    Map<String, String> future = Collections.singletonMap("r1", "5");
+    doReturn(future).when(adminSpy).getFutureVersionsForMultiColos(clusterName, storeName);
+
+    doNothing().when(adminSpy)
+        .sendAdminMessageAndWaitForConsumed(eq(clusterName), eq(storeName), any(AdminOperation.class));
+    doReturn(true).when(adminSpy).truncateKafkaTopic(Version.composeKafkaTopic(storeName, 5));
+
+    Map<String, Integer> after = Collections.singletonMap("r1", 5);
+    doReturn(after).when(adminSpy).getCurrentVersionsForMultiColos(clusterName, storeName);
+
+    adminSpy.rollForwardToFutureVersion(clusterName, storeName, "r1");
+
+    verify(adminSpy).sendAdminMessageAndWaitForConsumed(eq(clusterName), eq(storeName), any(AdminOperation.class));
+    verify(adminSpy).truncateKafkaTopic(Version.composeKafkaTopic(storeName, 5));
+  }
+
+  @Test(expectedExceptions = VeniceException.class, expectedExceptionsMessageRegExp = "Roll forward failed in regions.*")
+  public void testRollForwardPartialFailure() {
+    VeniceParentHelixAdmin adminSpy = spy(parentAdmin);
+    doNothing().when(adminSpy).acquireAdminMessageLock(clusterName, storeName);
+    doNothing().when(adminSpy).releaseAdminMessageLock(clusterName, storeName);
+
+    Map<String, String> future = new HashMap<>();
+    future.put("r1", "5");
+    future.put("r2", "5");
+    doReturn(future).when(adminSpy).getFutureVersionsForMultiColos(clusterName, storeName);
+
+    doNothing().when(adminSpy)
+        .sendAdminMessageAndWaitForConsumed(eq(clusterName), eq(storeName), any(AdminOperation.class));
+    doReturn(true).when(adminSpy).truncateKafkaTopic(anyString());
+
+    Map<String, Integer> after = new HashMap<>();
+    after.put("r1", 5);
+    after.put("r2", 4); // mismatch
+    doReturn(after).when(adminSpy).getCurrentVersionsForMultiColos(clusterName, storeName);
+
+    adminSpy.rollForwardToFutureVersion(clusterName, storeName, null);
   }
 
   private Store setupForStoreViewConfigUpdateTest(String storeName) {


### PR DESCRIPTION
## Problem Statement
`rollForwardToFutureVersion` in parent controller adds a message in admin channel and once consumed by the child controllers, it truncates the parent kafka topic and succeeds. The child controllers consumes this message and roll forward to the future version if present with out checking whether the future version partitions have enough ready to serve replicas. This might result in read failures if there is some rebalancing or some host goes down around that time.

## Solution
The issue can happen via
1. rebalances during cluster expansion or host swap: Helix will be handling the rebalancing (3-4-3) and the [PR](https://github.com/linkedin/venice/pull/1715) makes state transition of the completed future version follow similar path to the current version and wait until its ready to serve before marking it as STANDBY.
2. one/more host can suddenly go down leading to having less than min active replicas for one or more partitions: This PR fixes this issue by making the child controllers to check the readiness of the all partitions of the future version before doing roll forward. If one or more regions fails the check, roll forward will fail in those regions and parent controller will throw an exception with the details and go ahead with truncating the parent topic to not block the new push. The message in admin channel is still valid and will be retried until it succeeds after getting enough ready to serve replicas.  

###  Code changes
- [ ] Added new code behind **a config**. If so list the config names and their default values in the PR description.
- [x] Introduced new **log lines**. 
  - [x] Confirmed if logs need to be **rate limited** to avoid excessive logging.

###  **Concurrency-Specific Checks**
Both reviewer and PR author to verify
- [x] Code has **no race conditions** or **thread safety issues**.
- [ ] Proper **synchronization mechanisms** (e.g., `synchronized`, `RWLock`) are used where needed.
- [ ] No **blocking calls** inside critical sections that could lead to deadlocks or performance degradation.
- [ ] Verified **thread-safe collections** are used (e.g., `ConcurrentHashMap`, `CopyOnWriteArrayList`).
- [ ] Validated proper exception handling in multi-threaded code to avoid silent thread termination.


## How was this PR tested?
- [x] New unit tests added.
- [x] New integration tests added.
- [x] Modified or extended existing tests.
- [ ] Verified backward compatibility (if applicable).

## Does this PR introduce any user-facing or breaking changes?
- [ ] No. You can skip the rest of this section.
- [x] Yes. Clearly explain the behavior change and its impact.
Roll forward to future version can fail by throwing an exception and will be retried automatically. 