### PR TITLE
[server] Separate RT Drainer Assignment

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreBufferService.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreBufferService.java
@@ -156,7 +156,7 @@ public class StoreBufferService extends AbstractStoreBufferService {
    * different naming conventions for RT (_rt) and Separate RT (_rt_sep), different drainers might be assigned while
    * the same drainer handling both topics would be more ideal for concurrency. Normalizing topic name fixes this issue.
    */
-  public int computeTopicHashCode(PubSubTopic topic) {
+  private int computeTopicHashCode(PubSubTopic topic) {
     if (topic.isSeparateRealTimeTopic()) {
       return sepRtHashCodeCache.computeIfAbsent(topic, inputTopic -> {
         String realTimeTopicName = Utils.getRealTimeTopicNameFromSeparateRealTimeTopic(inputTopic.getName());

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreBufferService.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreBufferService.java
@@ -5,6 +5,8 @@ import static java.util.Collections.reverseOrder;
 import static java.util.Comparator.comparing;
 import static java.util.stream.Collectors.toList;
 
+import com.github.benmanes.caffeine.cache.Caffeine;
+import com.github.benmanes.caffeine.cache.LoadingCache;
 import com.linkedin.davinci.stats.StoreBufferServiceStats;
 import com.linkedin.davinci.utils.LockAssistedCompletableFuture;
 import com.linkedin.davinci.validation.PartitionTracker;
@@ -23,7 +25,6 @@ import com.linkedin.venice.pubsub.api.PubSubTopicPartition;
 import com.linkedin.venice.utils.DaemonThreadFactory;
 import com.linkedin.venice.utils.Utils;
 import com.linkedin.venice.utils.collections.MemoryBoundBlockingQueue;
-import com.linkedin.venice.utils.concurrent.VeniceConcurrentHashMap;
 import io.tehuti.metrics.MetricsRepository;
 import java.util.ArrayList;
 import java.util.List;
@@ -69,7 +70,7 @@ public class StoreBufferService extends AbstractStoreBufferService {
 
   private final RecordHandler leaderRecordHandler;
   private final StoreBufferServiceStats storeBufferServiceStats;
-  private final VeniceConcurrentHashMap<PubSubTopic, Integer> sepRtHashCodeCache = new VeniceConcurrentHashMap<>();
+  private final LoadingCache<PubSubTopic, Integer> hashCodeCache;
 
   private final boolean isSorted;
 
@@ -142,6 +143,19 @@ public class StoreBufferService extends AbstractStoreBufferService {
             this::getTotalRemainingMemory,
             this::getMaxMemoryUsagePerDrainer,
             this::getMinMemoryUsagePerDrainer);
+    /*
+     * {@link #getDrainerIndexForConsumerRecord} hashes the topic name and partition to determine a drainer. Due to the
+     * different naming conventions for RT (_rt) and Separate RT (_rt_sep), different drainers might be assigned while
+     * the same drainer handling both topics would help with concurrency. Normalizing the topic name fixes this issue.
+     */
+    this.hashCodeCache = Caffeine.newBuilder().maximumSize(2000).build(topic -> {
+      if (topic.isSeparateRealTimeTopic()) {
+        String realTimeTopicName = Utils.getRealTimeTopicNameFromSeparateRealTimeTopic(topic.getName());
+        PubSubTopic normalizedTopic = new PubSubTopicImpl(realTimeTopicName);
+        return normalizedTopic.hashCode();
+      }
+      return topic.hashCode();
+    });
   }
 
   protected MemoryBoundBlockingQueue<QueueNode> getDrainerForConsumerRecord(
@@ -151,29 +165,13 @@ public class StoreBufferService extends AbstractStoreBufferService {
     return blockingQueueArr.get(drainerIndex);
   }
 
-  /**
-   * {@link #getDrainerIndexForConsumerRecord} hashes the topic name and partition to determine a drainer. Due to the
-   * different naming conventions for RT (_rt) and Separate RT (_rt_sep), different drainers might be assigned while
-   * the same drainer handling both topics would be more ideal for concurrency. Normalizing topic name fixes this issue.
-   */
-  private int computeTopicHashCode(PubSubTopic topic) {
-    if (topic.isSeparateRealTimeTopic()) {
-      return sepRtHashCodeCache.computeIfAbsent(topic, inputTopic -> {
-        String realTimeTopicName = Utils.getRealTimeTopicNameFromSeparateRealTimeTopic(inputTopic.getName());
-        PubSubTopic normalizedTopic = new PubSubTopicImpl(realTimeTopicName);
-        return normalizedTopic.hashCode();
-      });
-    }
-    return topic.hashCode();
-  }
-
   protected int getDrainerIndexForConsumerRecord(DefaultPubSubMessage consumerRecord, int partition) {
     /**
      * This will guarantee that 'topicHash' will be a positive integer, whose maximum value is
      * {@link Integer.MAX_VALUE} / 2 + 1, which could make sure 'topicHash + consumerRecord.partition()' should be
      * positive for most time to guarantee even partition assignment.
      */
-    int topicHash = Math.abs(computeTopicHashCode(consumerRecord.getTopicPartition().getPubSubTopic()) / 2);
+    int topicHash = Math.abs(hashCodeCache.get(consumerRecord.getTopicPartition().getPubSubTopic()) / 2);
     return Math.abs((topicHash + partition) % this.drainerNum);
   }
 

--- a/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/PubSubTopicRepository.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/PubSubTopicRepository.java
@@ -6,8 +6,7 @@ import com.linkedin.venice.pubsub.api.PubSubTopic;
 
 
 public class PubSubTopicRepository {
-  LoadingCache<String, PubSubTopic> topicCache =
-      Caffeine.newBuilder().maximumSize(2000).build(topicName -> new PubSubTopicImpl(topicName));
+  LoadingCache<String, PubSubTopic> topicCache = Caffeine.newBuilder().maximumSize(2000).build(PubSubTopicImpl::new);
 
   public PubSubTopic getTopic(String topicName) {
     return topicCache.get(topicName);

--- a/internal/venice-common/src/main/java/com/linkedin/venice/utils/Utils.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/utils/Utils.java
@@ -25,6 +25,7 @@ import com.linkedin.venice.meta.Store;
 import com.linkedin.venice.meta.StoreInfo;
 import com.linkedin.venice.meta.StoreVersionInfo;
 import com.linkedin.venice.meta.Version;
+import com.linkedin.venice.pubsub.PubSubTopicImpl;
 import com.linkedin.venice.pubsub.PubSubTopicRepository;
 import com.linkedin.venice.pubsub.api.PubSubTopic;
 import com.linkedin.venice.pubsub.api.PubSubTopicPartition;
@@ -690,6 +691,15 @@ public class Utils {
 
   public static String getSeparateRealTimeTopicName(StoreInfo storeInfo) {
     return getSeparateRealTimeTopicName(Utils.getRealTimeTopicName(storeInfo));
+  }
+
+  public static int calculateTopicHashCode(PubSubTopic topic) {
+    if (topic.isSeparateRealTimeTopic()) {
+      String realTimeTopicName = Utils.getRealTimeTopicNameFromSeparateRealTimeTopic(topic.getName());
+      PubSubTopic normalizedTopic = new PubSubTopicImpl(realTimeTopicName);
+      return normalizedTopic.hashCode();
+    }
+    return topic.hashCode();
   }
 
   private static class TimeUnitInfo {

--- a/internal/venice-common/src/test/java/com/linkedin/venice/utils/UtilsTest.java
+++ b/internal/venice-common/src/test/java/com/linkedin/venice/utils/UtilsTest.java
@@ -417,6 +417,15 @@ public class UtilsTest {
   }
 
   @Test
+  public void testCalculateTopicHashCode() {
+    String store = "test_store";
+    PubSubTopicRepository pubSubTopicRepository = new PubSubTopicRepository();
+    PubSubTopic rt = pubSubTopicRepository.getTopic(Utils.composeRealTimeTopic(store));
+    PubSubTopic sepRt = pubSubTopicRepository.getTopic(Utils.getSeparateRealTimeTopicName(rt.getName()));
+    Assert.assertEquals(Utils.calculateTopicHashCode(rt), Utils.calculateTopicHashCode(sepRt));
+  }
+
+  @Test
   public void testGetLeaderTopicFromPubSubTopic() {
     PubSubTopicRepository pubSubTopicRepository = new PubSubTopicRepository();
     String store = "test_store";


### PR DESCRIPTION
<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat], [protocol]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## Problem Statement
<!--
Describe
- What problem are you trying to solve
- What issues or limitations exist in the current code
- Why this change is necessary 
-->
Drainers are assigned by hashing the topic name and partition. Separate RT has a suffix of `_rt_sep` and RT has a suffix of `_rt`, meaning that they can be assigned to different drainers and thus run into concurrency issues.

## Solution
<!--
Describe
- What changes you are making and why. 
- How these changes solve the problem.
- Any performance considerations or trade-offs. 
- Describe what testings you have done, for example, performance testing etc.
-->
Separate RT should be hashed and assigned drainers like RT.

###  **Concurrency-Specific Checks**
Both reviewer and PR author to verify
- [X] Code has **no race conditions** or **thread safety issues**.
- [X] Proper **synchronization mechanisms** (e.g., `synchronized`, `RWLock`) are used where needed.
- [X] No **blocking calls** inside critical sections that could lead to deadlocks or performance degradation.
- [X] Verified **thread-safe collections** are used (e.g., `ConcurrentHashMap`, `CopyOnWriteArrayList`).
- [X] Validated proper exception handling in multi-threaded code to avoid silent thread termination.


## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
- [X] New unit tests added.
Added new unit test `testGetDrainerIndexForConsumerRecordSeparateRt()`.

## Does this PR introduce any user-facing or breaking changes?
<!--  
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [X] No. You can skip the rest of this section.