### PR TITLE
[dvc][server] Refactored Transient Record usage code

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/ActiveActiveStoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/ActiveActiveStoreIngestionTask.java
@@ -1293,12 +1293,12 @@ public class ActiveActiveStoreIngestionTask extends LeaderFollowerStoreIngestion
   }
 
   /**
-   * For Active-Active this buffer is always used.
+   * For Active-Active this buffer is always used, as long as we're post-EOP.
    * @return
    */
   @Override
-  public boolean isTransientRecordBufferUsed() {
-    return true;
+  public boolean isTransientRecordBufferUsed(PartitionConsumptionState partitionConsumptionState) {
+    return partitionConsumptionState.isEndOfPushReceived();
   }
 
   @Override

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTask.java
@@ -2372,7 +2372,7 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
    * The caller of this function should only process this {@param consumerRecord} further if the return is
    * {@link DelegateConsumerRecordResult#QUEUED_TO_DRAINER}.
    *
-   * This function assumes {@link #shouldProcessRecord(PubSubMessage)} has been called which happens in
+   * This function assumes {@link #shouldProcessRecord(DefaultPubSubMessage)} has been called which happens in
    * {@link StoreIngestionTask#produceToStoreBufferServiceOrKafka(Iterable, PubSubTopicPartition, String, int)}
    * before calling this and the it was decided that this record needs to be processed. It does not perform any
    * validation check on the PartitionConsumptionState object to keep the goal of the function simple and not overload.
@@ -3288,7 +3288,7 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
          * For WC enabled stores update the transient record map with the latest {key,value}. This is needed only for messages
          * received from RT. Messages received from VT have been persisted to disk already before switching to RT topic.
          */
-        if (isWriteComputationEnabled && partitionConsumptionState.isEndOfPushReceived()) {
+        if (isTransientRecordBufferUsed(partitionConsumptionState)) {
           partitionConsumptionState.setTransientRecord(
               kafkaClusterId,
               consumerRecord.getPosition().getNumericOffset(),
@@ -3423,7 +3423,7 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
         /**
          * For WC enabled stores update the transient record map with the latest {key,null} for similar reason as mentioned in PUT above.
          */
-        if (isWriteComputationEnabled && partitionConsumptionState.isEndOfPushReceived()) {
+        if (isTransientRecordBufferUsed(partitionConsumptionState)) {
           partitionConsumptionState
               .setTransientRecord(kafkaClusterId, consumerRecord.getPosition().getNumericOffset(), keyBytes, -1, null);
         }

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/ActiveActiveStoreIngestionTaskTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/ActiveActiveStoreIngestionTaskTest.java
@@ -374,7 +374,7 @@ public class ActiveActiveStoreIngestionTaskTest {
             .build();
     VeniceWriter<byte[], byte[], byte[]> writer =
         new VeniceWriter(veniceWriterOptions, VeniceProperties.empty(), mockedProducer);
-    when(ingestionTask.isTransientRecordBufferUsed()).thenReturn(true);
+    when(ingestionTask.isTransientRecordBufferUsed(any())).thenReturn(true);
     when(ingestionTask.getVeniceWriter(any())).thenReturn(Lazy.of(() -> writer));
     StringBuilder stringBuilder = new StringBuilder();
     for (int i = 0; i < 50000; i++) {

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/LeaderProducerCallbackTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/LeaderProducerCallbackTest.java
@@ -55,14 +55,14 @@ public class LeaderProducerCallbackTest {
     inMemoryLogAppender.start();
     LoggerContext ctx = ((LoggerContext) LogManager.getContext(false));
     Configuration config = ctx.getConfiguration();
-    doReturn(true).when(ingestionTaskMock).isTransientRecordBufferUsed();
+    doReturn(true).when(ingestionTaskMock).isTransientRecordBufferUsed(any());
     doReturn(null).when(partitionConsumptionStateMock).getTransientRecord(any());
     doReturn(true).when(partitionConsumptionStateMock).isEndOfPushReceived();
     doReturn(mock(KafkaKey.class)).when(sourceConsumerRecordMock).getKey();
 
     try {
       config.addLoggerAppender(
-          (org.apache.logging.log4j.core.Logger) LogManager.getLogger(LeaderFollowerStoreIngestionTask.class),
+          (org.apache.logging.log4j.core.Logger) LogManager.getLogger(LeaderProducerCallback.class),
           inMemoryLogAppender);
 
       LeaderProducerCallback leaderProducerCallback = new LeaderProducerCallback(

--- a/internal/venice-common/src/test/java/com/linkedin/venice/writer/VeniceWriterUnitTest.java
+++ b/internal/venice-common/src/test/java/com/linkedin/venice/writer/VeniceWriterUnitTest.java
@@ -216,7 +216,7 @@ public class VeniceWriterUnitTest {
     when(kafkaKey.getKey()).thenReturn(new byte[] { 0xa });
     when(leaderProducerCallback.getSourceConsumerRecord()).thenReturn(record);
     LeaderFollowerStoreIngestionTask storeIngestionTask = mock(LeaderFollowerStoreIngestionTask.class);
-    when(storeIngestionTask.isTransientRecordBufferUsed()).thenReturn(true);
+    when(storeIngestionTask.isTransientRecordBufferUsed(any())).thenReturn(true);
     when(leaderProducerCallback.getIngestionTask()).thenReturn(storeIngestionTask);
     doCallRealMethod().when(leaderProducerCallback).setChunkingInfo(any(), any(), any(), any(), any(), any(), any());
     writer.put(


### PR DESCRIPTION
There was an inconsistency where the transient record cache (which is used for WC and AA ingestion) had different criteria for whether to write and read to it. We would not write to it when pre-EOP (which is the right behavior), but we would systematically read from it in the setChunkingInfo function of the LeaderProducerCallback, regardless of the EOP status.

This commit adds an extra PartitionConsumptionState parameter to the SIT::isTransientRecordBufferUsed function, and calls this function in more locations, thus eliminating duplicate conditions littered across the code.

Miscellaneous:

- Fixed the logger class name in the LeaderProducerCallback.

- Eliminated a few unused partitionId parameters in SIT functions.

###  Code changes
- [ ] Added new code behind **a config**. If so list the config names and their default values in the PR description.
- [ ] Introduced new **log lines**. 
  - [ ] Confirmed if logs need to be **rate limited** to avoid excessive logging.

###  **Concurrency-Specific Checks**
Both reviewer and PR author to verify
- [ ] Code has **no race conditions** or **thread safety issues**.
- [ ] Proper **synchronization mechanisms** (e.g., `synchronized`, `RWLock`) are used where needed.
- [ ] No **blocking calls** inside critical sections that could lead to deadlocks or performance degradation.
- [ ] Verified **thread-safe collections** are used (e.g., `ConcurrentHashMap`, `CopyOnWriteArrayList`).
- [ ] Validated proper exception handling in multi-threaded code to avoid silent thread termination.


## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->

- [ ] New unit tests added.
- [ ] New integration tests added.
- [x] Modified or extended existing tests.
- [ ] Verified backward compatibility (if applicable).

## Does this PR introduce any user-facing or breaking changes?
<!--  
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Clearly explain the behavior change and its impact.