### PR TITLE
[controller][test] Use dynamic position type registry for ad-hoc producer construction 

### DIFF
--- a/internal/venice-client-common/src/main/java/com/linkedin/venice/utils/VeniceProperties.java
+++ b/internal/venice-client-common/src/main/java/com/linkedin/venice/utils/VeniceProperties.java
@@ -40,19 +40,11 @@ public class VeniceProperties implements Serializable {
   }
 
   public VeniceProperties(Properties properties) {
-    Map<String, String> tmpProps = new HashMap<>(properties.size());
-    for (Map.Entry<Object, Object> e: properties.entrySet()) {
-      tmpProps.put(e.getKey().toString(), e.getValue() == null ? null : e.getValue().toString());
-    }
-    props = Collections.unmodifiableMap(tmpProps);
+    this.props = Collections.unmodifiableMap(convertToStringMap(properties));
   }
 
-  public VeniceProperties(Map<CharSequence, CharSequence> properties) {
-    Map<String, String> tmpProps = new HashMap<>(properties.size());
-    for (Map.Entry<CharSequence, CharSequence> e: properties.entrySet()) {
-      tmpProps.put(e.getKey().toString(), e.getValue() == null ? null : e.getValue().toString());
-    }
-    props = Collections.unmodifiableMap(tmpProps);
+  public VeniceProperties(Map<String, String> properties) {
+    this.props = Collections.unmodifiableMap(new HashMap<>(properties));
   }
 
   public static VeniceProperties empty() {
@@ -593,5 +585,19 @@ public class VeniceProperties implements Serializable {
 
   public Map<String, String> getAsMap() {
     return props;
+  }
+
+  public static VeniceProperties fromCharSequenceMap(Map<CharSequence, CharSequence> properties) {
+    return new VeniceProperties(convertToStringMap(properties));
+  }
+
+  private static Map<String, String> convertToStringMap(Map<?, ?> input) {
+    Map<String, String> result = new HashMap<>(input.size());
+    for (Map.Entry<?, ?> entry: input.entrySet()) {
+      String key = entry.getKey().toString();
+      String value = entry.getValue() == null ? null : entry.getValue().toString();
+      result.put(key, value);
+    }
+    return result;
   }
 }

--- a/internal/venice-client-common/src/test/java/com/linkedin/venice/utils/VenicePropertiesTest.java
+++ b/internal/venice-client-common/src/test/java/com/linkedin/venice/utils/VenicePropertiesTest.java
@@ -53,7 +53,7 @@ public class VenicePropertiesTest {
 
   @Test
   public void testClipAndFilterNamespaceTwoNamespaces() {
-    Map<CharSequence, CharSequence> props = new HashMap<>();
+    Map<String, String> props = new HashMap<>();
     props.put("kafka.key1", "value1");
     props.put("pubsub.kafka.key1", "value1");
     props.put("kafka.key2", "value2");
@@ -96,7 +96,7 @@ public class VenicePropertiesTest {
     props.put("database.host", "localhost");
     props.put("database.port", "5432");
 
-    VeniceProperties veniceProperties = new VeniceProperties(props);
+    VeniceProperties veniceProperties = VeniceProperties.fromCharSequenceMap(props);
 
     VeniceProperties kafkaProps = veniceProperties.clipAndFilterNamespace("kafka.");
     Properties kafkaProperties = kafkaProps.toProperties();
@@ -108,7 +108,7 @@ public class VenicePropertiesTest {
 
   @Test
   public void testClipAndFilterNamespaceNoMatchingProperties() {
-    Map<CharSequence, CharSequence> props = new HashMap<>();
+    Map<String, String> props = new HashMap<>();
     props.put("app.config.path", "/usr/local/");
     props.put("logging.level", "DEBUG");
 
@@ -122,7 +122,7 @@ public class VenicePropertiesTest {
 
   @Test
   public void testClipAndFilterNamespaceWithEmptyNamespacesSet() {
-    Map<CharSequence, CharSequence> props = new HashMap<>();
+    Map<String, String> props = new HashMap<>();
     props.put("kafka.key1", "value1");
     props.put("database.host", "localhost");
 
@@ -141,7 +141,7 @@ public class VenicePropertiesTest {
     props.put("kafka.key2", "value2");
     props.put("kafka.key3", "value3");
 
-    VeniceProperties veniceProperties = new VeniceProperties(props);
+    VeniceProperties veniceProperties = VeniceProperties.fromCharSequenceMap(props);
 
     VeniceProperties filteredProps = veniceProperties.clipAndFilterNamespace("kafka.");
     Properties resultProperties = filteredProps.toProperties();

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/consumer/ConsumerIntegrationTest.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/consumer/ConsumerIntegrationTest.java
@@ -194,6 +194,7 @@ public abstract class ConsumerIntegrationTest {
             .setVeniceProperties(props)
             .setPubSubMessageSerializer(pubSubMessageSerializer)
             .setBrokerAddress(cluster.getPubSubBrokerWrapper().getAddress())
+            .setPubSubPositionTypeRegistry(cluster.getPubSubBrokerWrapper().getPubSubPositionTypeRegistry())
             .build();
     return new VeniceWriterWithNewerProtocol(
         veniceWriterOptions,

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/kafka/KafkaConsumptionTest.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/kafka/KafkaConsumptionTest.java
@@ -289,6 +289,7 @@ public class KafkaConsumptionTest {
         new PubSubProducerAdapterContext.Builder().setVeniceProperties(new VeniceProperties(properties))
             .setBrokerAddress(pubSubBrokerWrapper.getAddress())
             .setProducerName("test-producer")
+            .setPubSubPositionTypeRegistry(pubSubBrokerWrapper.getPubSubPositionTypeRegistry())
             .build();
     PubSubProducerAdapter producerAdapter =
         pubSubBrokerWrapper.getPubSubClientsFactory().getProducerAdapterFactory().create(producerAdapterContext);

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/kafka/KafkaConsumptionTest.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/kafka/KafkaConsumptionTest.java
@@ -189,13 +189,9 @@ public class KafkaConsumptionTest {
         new LandFillObjectPool<>(KafkaMessageEnvelope::new),
         new LandFillObjectPool<>(KafkaMessageEnvelope::new));
 
-    Properties pubSubProps = new Properties();
-    pubSubProps.putAll(pubSubClientProperties);
-    VeniceProperties veniceProperties = new VeniceProperties(pubSubProps);
-
     AggKafkaConsumerService aggKafkaConsumerService = new AggKafkaConsumerService(
         pubSubConsumerAdapterFactory,
-        k -> veniceProperties,
+        k -> new VeniceProperties(pubSubClientProperties),
         veniceServerConfig,
         mockIngestionThrottler,
         kafkaClusterBasedRecordThrottler,

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/pubsub/adapter/kafka/producer/ApacheKafkaProducerAdapterITest.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/pubsub/adapter/kafka/producer/ApacheKafkaProducerAdapterITest.java
@@ -96,6 +96,7 @@ public class ApacheKafkaProducerAdapterITest {
     ApacheKafkaProducerConfig producerConfig = new ApacheKafkaProducerConfig(
         new PubSubProducerAdapterContext.Builder().setBrokerAddress(pubSubBrokerWrapper.getAddress())
             .setVeniceProperties(new VeniceProperties(properties))
+            .setPubSubPositionTypeRegistry(pubSubBrokerWrapper.getPubSubPositionTypeRegistry())
             .build());
     producerAdapter = new ApacheKafkaProducerAdapter(producerConfig);
   }

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/pubsub/api/admin/PubSubAdminAdapterTest.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/pubsub/api/admin/PubSubAdminAdapterTest.java
@@ -124,6 +124,7 @@ public class PubSubAdminAdapterTest {
             .create(
                 new PubSubProducerAdapterContext.Builder().setVeniceProperties(veniceProperties)
                     .setProducerName(clientId)
+                    .setPubSubPositionTypeRegistry(pubSubBrokerWrapper.getPubSubPositionTypeRegistry())
                     .build()));
   }
 

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/pubsub/api/consumer/PubSubConsumerAdapterTest.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/pubsub/api/consumer/PubSubConsumerAdapterTest.java
@@ -121,6 +121,7 @@ public class PubSubConsumerAdapterTest {
                 new PubSubProducerAdapterContext.Builder().setVeniceProperties(veniceProperties)
                     .setProducerName(clientId)
                     .setBrokerAddress(pubSubBrokerWrapper.getAddress())
+                    .setPubSubPositionTypeRegistry(pubSubBrokerWrapper.getPubSubPositionTypeRegistry())
                     .build()));
     pubSubAdminAdapterLazy =
         Lazy.of(() -> pubSubClientsFactory.getAdminAdapterFactory().create(veniceProperties, pubSubTopicRepository));

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/pubsub/manager/TopicManagerE2ETest.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/pubsub/manager/TopicManagerE2ETest.java
@@ -98,6 +98,7 @@ public class TopicManagerE2ETest {
                 new PubSubProducerAdapterContext.Builder().setVeniceProperties(veniceProperties)
                     .setBrokerAddress(pubSubBrokerWrapper.getAddress())
                     .setProducerName(clientId)
+                    .setPubSubPositionTypeRegistry(pubSubBrokerWrapper.getPubSubPositionTypeRegistry())
                     .build()));
     pubSubAdminAdapterLazy =
         Lazy.of(() -> pubSubClientsFactory.getAdminAdapterFactory().create(veniceProperties, pubSubTopicRepository));

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/pubsub/manager/TopicManagerIntegrationTest.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/pubsub/manager/TopicManagerIntegrationTest.java
@@ -49,6 +49,7 @@ public class TopicManagerIntegrationTest extends TopicManagerTest {
             new PubSubProducerAdapterContext.Builder().setVeniceProperties(VeniceProperties.empty())
                 .setProducerName("topicManagerTestProducer")
                 .setBrokerAddress(pubSubBrokerWrapper.getAddress())
+                .setPubSubPositionTypeRegistry(pubSubBrokerWrapper.getPubSubPositionTypeRegistry())
                 .build());
   }
 

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceParentHelixAdmin.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceParentHelixAdmin.java
@@ -2499,7 +2499,7 @@ public class VeniceParentHelixAdmin implements Admin {
         try {
           PartitionUtils.getVenicePartitioner(
               partitionerConfigRecord.partitionerClass.toString(),
-              new VeniceProperties(partitionerConfigRecord.partitionerParams),
+              VeniceProperties.fromCharSequenceMap(partitionerConfigRecord.partitionerParams),
               getKeySchema(clusterName, storeName).getSchema());
         } catch (PartitionerSchemaMismatchException e) {
           String errorMessage = errorMessagePrefix + e.getMessage();


### PR DESCRIPTION
<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat], [protocol]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## Use dynamic position type registry for ad-hoc producer construction
PubSub producers require access to the position type registry during construction. For  
pub-sub backends not defined in the Venice OSS repo, the registry contents may differ.  
Producers created inside the controller or server already receive the updated registry.  
However, ad-hoc producers previously used only the reserved registry. This change updates  
the logic to ensure ad-hoc producers also use the dynamic registry.  

## Solution
<!--
Describe
- What changes you are making and why. 
- How these changes solve the problem.
- Any performance considerations or trade-offs. 
- Describe what testings you have done, for example, performance testing etc.
-->


###  Code changes
- [ ] Added new code behind **a config**. If so list the config names and their default values in the PR description.
- [ ] Introduced new **log lines**. 
  - [ ] Confirmed if logs need to be **rate limited** to avoid excessive logging.

###  **Concurrency-Specific Checks**
Both reviewer and PR author to verify
- [x] Code has **no race conditions** or **thread safety issues**.
- [x] Proper **synchronization mechanisms** (e.g., `synchronized`, `RWLock`) are used where needed.
- [x] No **blocking calls** inside critical sections that could lead to deadlocks or performance degradation.
- [x] Verified **thread-safe collections** are used (e.g., `ConcurrentHashMap`, `CopyOnWriteArrayList`).
- [x] Validated proper exception handling in multi-threaded code to avoid silent thread termination.


## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->

- [ ] New unit tests added.
- [ ] New integration tests added.
- [x] Modified or extended existing tests.
- [ ] Verified backward compatibility (if applicable).

## Does this PR introduce any user-facing or breaking changes?
<!--  
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [ ] No. You can skip the rest of this section.
- [x] Yes. Clearly explain the behavior change and its impact.