### PR TITLE
[controller] System store init resiliency tweak

### DIFF
--- a/internal/venice-common/src/main/java/com/linkedin/venice/common/VeniceSystemStoreUtils.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/common/VeniceSystemStoreUtils.java
@@ -17,12 +17,13 @@ public class VeniceSystemStoreUtils {
   private static final String PUSH_JOB_DETAILS_STORE_NAME =
       String.format(Store.SYSTEM_STORE_FORMAT, PUSH_JOB_DETAILS_STORE);
   public static final String SEPARATOR = "_";
+  public static final int DEFAULT_USER_SYSTEM_STORE_PARTITION_COUNT = 1;
   public static final UpdateStoreQueryParams DEFAULT_USER_SYSTEM_STORE_UPDATE_QUERY_PARAMS =
       new UpdateStoreQueryParams().setHybridRewindSeconds(TimeUnit.DAYS.toSeconds(1)) // 1 day rewind
           .setHybridOffsetLagThreshold(1)
           .setHybridTimeLagThreshold(-1) // Explicitly disable hybrid time lag measurement on system store
           .setWriteComputationEnabled(true)
-          .setPartitionCount(1);
+          .setPartitionCount(DEFAULT_USER_SYSTEM_STORE_PARTITION_COUNT);
 
   public static String getParticipantStoreNameForCluster(String clusterName) {
     return String.format(PARTICIPANT_STORE_FORMAT, clusterName);

--- a/internal/venice-common/src/main/java/com/linkedin/venice/helix/HelixSchemaAccessor.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/helix/HelixSchemaAccessor.java
@@ -119,12 +119,12 @@ public class HelixSchemaAccessor {
 
   public void createKeySchema(String storeName, SchemaEntry schemaEntry) {
     HelixUtils.create(schemaAccessor, getKeySchemaPath(storeName), schemaEntry);
-    logger.info("Set up key schema: {} for store: {}.", schemaEntry, storeName);
+    logger.info("Set up key schema ID {} for store: {}.", schemaEntry.getId(), storeName);
   }
 
   public void addValueSchema(String storeName, SchemaEntry schemaEntry) {
     HelixUtils.create(schemaAccessor, getValueSchemaPath(storeName, String.valueOf(schemaEntry.getId())), schemaEntry);
-    logger.info("Added value schema: {} for store: {}.", schemaEntry, storeName);
+    logger.info("Added value schema ID {} for store: {}.", schemaEntry.getId(), storeName);
   }
 
   public void addDerivedSchema(String storeName, DerivedSchemaEntry derivedSchemaEntry) {
@@ -135,7 +135,11 @@ public class HelixSchemaAccessor {
             String.valueOf(derivedSchemaEntry.getValueSchemaID()),
             String.valueOf(derivedSchemaEntry.getId())),
         derivedSchemaEntry);
-    logger.info("Added derived schema: {} for store: {}.", derivedSchemaEntry, storeName);
+    logger.info(
+        "Added derived schema ID {}/{} for store: {}.",
+        derivedSchemaEntry.getValueSchemaID(),
+        derivedSchemaEntry.getId(),
+        storeName);
   }
 
   public void removeDerivedSchema(String storeName, String derivedSchemaIdPair) {

--- a/internal/venice-common/src/main/java/com/linkedin/venice/helix/HelixSchemaAccessor.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/helix/HelixSchemaAccessor.java
@@ -119,12 +119,12 @@ public class HelixSchemaAccessor {
 
   public void createKeySchema(String storeName, SchemaEntry schemaEntry) {
     HelixUtils.create(schemaAccessor, getKeySchemaPath(storeName), schemaEntry);
-    logger.info("Set up key schema ID {} for store: {}.", schemaEntry.getId(), storeName);
+    logger.info("Set up key schema ID: {} for store: {}.", schemaEntry.getId(), storeName);
   }
 
   public void addValueSchema(String storeName, SchemaEntry schemaEntry) {
     HelixUtils.create(schemaAccessor, getValueSchemaPath(storeName, String.valueOf(schemaEntry.getId())), schemaEntry);
-    logger.info("Added value schema ID {} for store: {}.", schemaEntry.getId(), storeName);
+    logger.info("Added value schema ID: {} for store: {}.", schemaEntry.getId(), storeName);
   }
 
   public void addDerivedSchema(String storeName, DerivedSchemaEntry derivedSchemaEntry) {
@@ -136,7 +136,7 @@ public class HelixSchemaAccessor {
             String.valueOf(derivedSchemaEntry.getId())),
         derivedSchemaEntry);
     logger.info(
-        "Added derived schema ID {}/{} for store: {}.",
+        "Added derived schema ID: {}/{} for store: {}.",
         derivedSchemaEntry.getValueSchemaID(),
         derivedSchemaEntry.getId(),
         storeName);

--- a/internal/venice-common/src/main/java/com/linkedin/venice/utils/PartitionUtils.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/utils/PartitionUtils.java
@@ -2,6 +2,7 @@ package com.linkedin.venice.utils;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.linkedin.venice.ConfigKeys;
+import com.linkedin.venice.common.VeniceSystemStoreUtils;
 import com.linkedin.venice.exceptions.VeniceException;
 import com.linkedin.venice.meta.PartitionerConfig;
 import com.linkedin.venice.meta.PartitionerConfigImpl;
@@ -40,6 +41,10 @@ public class PartitionUtils {
           storePartitionCount,
           storeName);
       return storePartitionCount;
+    }
+
+    if (VeniceSystemStoreUtils.isUserSystemStore(storeName)) {
+      return VeniceSystemStoreUtils.DEFAULT_USER_SYSTEM_STORE_PARTITION_COUNT;
     }
 
     if (storageQuota == Store.UNLIMITED_STORAGE_QUOTA) {

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceHelixAdmin.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceHelixAdmin.java
@@ -3509,12 +3509,11 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
       Version version = store.getVersion(store.getLargestUsedVersionNumber());
       int partitionCount = version != null ? version.getPartitionCount() : store.getPartitionCount();
       if (partitionCount == 0) {
-        LOGGER.error(
-            "Failed to create real time topic for user system store: {} because both store and version have partition count set to 0.",
-            storeName);
-        throw new VeniceException(
-            "Failed to create real time topic for user system store: " + storeName
-                + " because both store and version have partition count set to 0.");
+        partitionCount = VeniceSystemStoreUtils.DEFAULT_USER_SYSTEM_STORE_PARTITION_COUNT;
+        LOGGER.warn(
+            "UNEXPECTED! The partition count is set to 0 both in the store config and version config for user system store: {}. Will use the default partition count ({}) to create the RT topic.",
+            storeName,
+            partitionCount);
       }
       VeniceControllerClusterConfig clusterConfig = getControllerConfig(clusterName);
       LOGGER.info(

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceParentHelixAdmin.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceParentHelixAdmin.java
@@ -4249,7 +4249,7 @@ public class VeniceParentHelixAdmin implements Admin {
     if (Objects.equals(sourceFabric, destinationFabric)) {
       throw new VeniceException(
           String.format(
-              "Source ({}) and destination ({}) cannot be the same data center",
+              "Source (%s) and destination (%s) cannot be the same data center",
               sourceFabric,
               destinationFabric));
     }


### PR DESCRIPTION
In a system store creation code path, made use of default partition count rather than failing, in some scenario.

Miscellaneous:

- Reduced log message size in HelixSchemaAccessor, by printing only schema IDs and not full schema literals.

- Fixed string interpolation in VeniceParentHelixAdmin::initiateDataRecovery.

###  Code changes
- [ ] Added new code behind **a config**. If so list the config names and their default values in the PR description.
- [ ] Introduced new **log lines**. 
  - [ ] Confirmed if logs need to be **rate limited** to avoid excessive logging.

Reduced log volume, actually.

###  **Concurrency-Specific Checks**
Both reviewer and PR author to verify
- [ ] Code has **no race conditions** or **thread safety issues**.
- [ ] Proper **synchronization mechanisms** (e.g., `synchronized`, `RWLock`) are used where needed.
- [ ] No **blocking calls** inside critical sections that could lead to deadlocks or performance degradation.
- [ ] Verified **thread-safe collections** are used (e.g., `ConcurrentHashMap`, `CopyOnWriteArrayList`).
- [ ] Validated proper exception handling in multi-threaded code to avoid silent thread termination.


## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->

- [ ] New unit tests added.
- [ ] New integration tests added.
- [x] Modified or extended existing tests.
- [ ] Verified backward compatibility (if applicable).

## Does this PR introduce any user-facing or breaking changes?
<!--  
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Clearly explain the behavior change and its impact.