### PR TITLE
[server] Improve ReadQuotaEnforcementHandler init() behavior and visibility

### DIFF
--- a/services/venice-server/src/main/java/com/linkedin/venice/listener/HttpChannelInitializer.java
+++ b/services/venice-server/src/main/java/com/linkedin/venice/listener/HttpChannelInitializer.java
@@ -146,8 +146,7 @@ public class HttpChannelInitializer extends ChannelInitializer<SocketChannel> {
           storeMetadataRepository,
           customizedViewRepository,
           nodeId,
-          quotaUsageStats,
-          metricsRepository);
+          quotaUsageStats);
     } else {
       this.quotaEnforcer = null;
     }

--- a/services/venice-server/src/main/java/com/linkedin/venice/listener/ReadQuotaEnforcementHandler.java
+++ b/services/venice-server/src/main/java/com/linkedin/venice/listener/ReadQuotaEnforcementHandler.java
@@ -552,22 +552,27 @@ public class ReadQuotaEnforcementHandler extends SimpleChannelInboundHandler<Rou
     return stats;
   }
 
+  // For unit testing only
   void setInitialized(boolean initialized) {
     this.initialized = initialized;
   }
 
+  // For unit testing only
   void setInitializedVolatile(boolean initializedVolatile) {
     this.initializedVolatile = initializedVolatile;
   }
 
+  // For unit testing only
   VeniceRateLimiter getStoreVersionRateLimiter(String storeVersion) {
     return storeVersionRateLimiters.get(storeVersion);
   }
 
+  // For unit testing only
   void setStoreVersionRateLimiter(String storeVersion, VeniceRateLimiter rateLimiter) {
     storeVersionRateLimiters.put(storeVersion, rateLimiter);
   }
 
+  // For unit testing only
   void setStorageNodeRateLimiter(VeniceRateLimiter rateLimiter) {
     storageNodeRateLimiter = rateLimiter;
   }

--- a/services/venice-server/src/test/java/com/linkedin/venice/listener/ReadQuotaEnforcementHandlerTest.java
+++ b/services/venice-server/src/test/java/com/linkedin/venice/listener/ReadQuotaEnforcementHandlerTest.java
@@ -53,6 +53,7 @@ import com.linkedin.venice.stats.ServerReadQuotaUsageStats;
 import com.linkedin.venice.throttle.GuavaRateLimiter;
 import com.linkedin.venice.throttle.TokenBucket;
 import com.linkedin.venice.throttle.VeniceRateLimiter;
+import com.linkedin.venice.utils.TestUtils;
 import com.linkedin.venice.utils.Utils;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.handler.codec.http.HttpResponseStatus;
@@ -233,7 +234,7 @@ public class ReadQuotaEnforcementHandlerTest {
     when(routerRequest.isRetryRequest()).thenReturn(false);
     when(storeRepository.getStore(storeName)).thenReturn(store);
     when(store.isStorageNodeReadQuotaEnabled()).thenReturn(true);
-    assertTrue(quotaEnforcementHandler.isInitialized());
+    TestUtils.waitForNonDeterministicAssertion(10, SECONDS, () -> assertTrue(quotaEnforcementHandler.isInitialized()));
     VeniceRateLimiter veniceRateLimiter = mock(VeniceRateLimiter.class);
     quotaEnforcementHandler.setStoreVersionRateLimiter(resourceName, veniceRateLimiter);
     when(veniceRateLimiter.tryAcquirePermit(1)).thenReturn(false);
@@ -278,7 +279,7 @@ public class ReadQuotaEnforcementHandlerTest {
     when(routerRequest.isRetryRequest()).thenReturn(false);
     when(storeRepository.getStore(storeName)).thenReturn(store);
     when(store.isStorageNodeReadQuotaEnabled()).thenReturn(true);
-    assertTrue(quotaEnforcementHandler.isInitialized());
+    TestUtils.waitForNonDeterministicAssertion(10, SECONDS, () -> assertTrue(quotaEnforcementHandler.isInitialized()));
     assertNull(quotaEnforcementHandler.getStoreVersionRateLimiter(resourceName));
     VeniceRateLimiter storageNodeRateLimiter = mock(VeniceRateLimiter.class);
     quotaEnforcementHandler.setStorageNodeRateLimiter(storageNodeRateLimiter);
@@ -320,7 +321,7 @@ public class ReadQuotaEnforcementHandlerTest {
     when(routerRequest.isRetryRequest()).thenReturn(false);
     when(storeRepository.getStore(storeName)).thenReturn(store);
     when(store.isStorageNodeReadQuotaEnabled()).thenReturn(true);
-    assertTrue(quotaEnforcementHandler.isInitialized());
+    TestUtils.waitForNonDeterministicAssertion(10, SECONDS, () -> assertTrue(quotaEnforcementHandler.isInitialized()));
     VeniceRateLimiter veniceRateLimiter = mock(VeniceRateLimiter.class);
     when(veniceRateLimiter.tryAcquirePermit(1)).thenReturn(true);
     quotaEnforcementHandler.setStoreVersionRateLimiter(resourceName, veniceRateLimiter);
@@ -776,6 +777,7 @@ public class ReadQuotaEnforcementHandlerTest {
    * @param refillTimeMs  The length of the refill interval
    */
   void runTest(String resourceName, long capacity, long refillAmount, long refillTimeMs) {
+    TestUtils.waitForNonDeterministicAssertion(10, SECONDS, () -> assertTrue(quotaEnforcementHandler.isInitialized()));
     AtomicInteger allowed = new AtomicInteger(0);
     AtomicInteger blocked = new AtomicInteger(0);
 


### PR DESCRIPTION
## Problem Statement
Previously the init() call in ReadQuotaEnforcementHandler is made async due to CV repository may not be ready by the time when the constructor of ReadQuotaEnforcementHandler is called. The async init() implementation had several flaws which are addressed in this PR:
  1. Exceptions thrown in init() are not caught and logged resulting in silent failures.
  2. If init() fails or takes too long to finish all requests are failing open without invoking recordAllowedUnintentionally which also results in silent failure.
  3. The async init was done by the common fork join pool which comes with some undesirable traits like it could be exhausted, no control over external dependencies and etc.

## Solution
1. A single thread executor with DaemonThreadFactory will be used to perform the async init. The executor is also shutdown after submitting the initialization task so no resource hogging once we are done with async initializaiton.

2. Requests that are allowed while waiting for ReadQuotaEnforcementHandler initialization are considered for fail open quota requests and will invoke recordAllowedUnintentionally. Only requests for stores that do not have storage node quota enabled will be allowed without leaving any metric trace from the ReadQuotaEnforcementHandler.


###  Code changes
- [ ] Added new code behind **a config**. If so list the config names and their default values in the PR description.
- [x] Introduced new **log lines**. 
  - [x] Confirmed if logs need to be **rate limited** to avoid excessive logging.

###  **Concurrency-Specific Checks**
Both reviewer and PR author to verify
- [x] Code has **no race conditions** or **thread safety issues**.
- [x] Proper **synchronization mechanisms** (e.g., `synchronized`, `RWLock`) are used where needed.
- [x] No **blocking calls** inside critical sections that could lead to deadlocks or performance degradation.
- [x] Verified **thread-safe collections** are used (e.g., `ConcurrentHashMap`, `CopyOnWriteArrayList`).
- [x] Validated proper exception handling in multi-threaded code to avoid silent thread termination.


## How was this PR tested?
New unit tests and existing integration tests

- [x] New unit tests added.
- [ ] New integration tests added.
- [ ] Modified or extended existing tests.
- [ ] Verified backward compatibility (if applicable).

## Does this PR introduce any user-facing or breaking changes?
<!--  
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Clearly explain the behavior change and its impact.