### PR TITLE
[controller] Fix RT topic validation in TopicCleanupService

### DIFF
--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/kafka/TopicCleanupService.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/kafka/TopicCleanupService.java
@@ -435,7 +435,7 @@ public class TopicCleanupService extends AbstractVeniceService {
           String clusterDiscovered = admin.discoverCluster(storeName).getFirst();
           Store store = admin.getStore(clusterDiscovered, storeName);
           LOGGER.warn("Find topic discrepancy case: {}", pubSubTopic);
-          if (!isStillValidRealtimeTopic(pubSubTopic, store) || !isStillValidVersionTopic(pubSubTopic, store)) {
+          if (!isStillValidPubSubTopic(pubSubTopic, store)) {
             if (checkIfDanglingTopicConsistentlyFound(pubSubTopic)) {
               LOGGER.warn("Will remove consistently found dangling topic {}.", pubSubTopic);
               topicsToCleanup.add(pubSubTopic);
@@ -457,25 +457,17 @@ public class TopicCleanupService extends AbstractVeniceService {
     return topicsToCleanup;
   }
 
-  private boolean isStillValidRealtimeTopic(PubSubTopic pubSubTopic, Store store) {
-    if (pubSubTopic.isRealTime() && !store.isHybrid()) {
-      for (Version version: store.getVersions()) {
-        if (version.getHybridStoreConfig() != null) {
-          break;
-        }
-      }
-      return false;
-    }
-    return true;
-  }
-
-  private boolean isStillValidVersionTopic(PubSubTopic pubSubTopic, Store store) {
+  /**
+   * Check if the given topic is still valid based on its type and associated store metadata.
+   */
+  private boolean isStillValidPubSubTopic(PubSubTopic pubSubTopic, Store store) {
     if (pubSubTopic.isVersionTopicOrStreamReprocessingTopic() || pubSubTopic.isViewTopic()) {
       int versionNum = Version.parseVersionFromKafkaTopicName(pubSubTopic.getName());
-      if (!store.containsVersion(versionNum)) {
-        return false;
-      }
+      return store.containsVersion(versionNum);
+    } else if (pubSubTopic.isRealTime()) {
+      return Version.containsHybridVersion(store.getVersions());
     }
+
     return true;
   }
 


### PR DESCRIPTION
## Problem Statement
In TopicCleanupService, we collectDanglingTopics, one of the task is to determine whether the RT topic is valid or not. However, there is a logic bug within the check.
```
private boolean isStillValidRealtimeTopic(PubSubTopic pubSubTopic, Store store) {
  if (pubSubTopic.isRealTime() && !store.isHybrid()) {
    for (Version version: store.getVersions()) {
      if (version.getHybridStoreConfig() != null) {
        break; // should return True here instead of break;
      }
    }
    return false;
  }
  return true;
} 
```
## Solution
- Update the validation for RT topic to check containHybridVersion directly.
- Refactor code to have unified entry point to validate pubsub topic.


###  Code changes
- [ ] Added new code behind **a config**. If so list the config names and their default values in the PR description.
- [ ] Introduced new **log lines**. 
  - [ ] Confirmed if logs need to be **rate limited** to avoid excessive logging.

###  **Concurrency-Specific Checks**
Both reviewer and PR author to verify
- [ ] Code has **no race conditions** or **thread safety issues**.
- [ ] Proper **synchronization mechanisms** (e.g., `synchronized`, `RWLock`) are used where needed.
- [ ] No **blocking calls** inside critical sections that could lead to deadlocks or performance degradation.
- [ ] Verified **thread-safe collections** are used (e.g., `ConcurrentHashMap`, `CopyOnWriteArrayList`).
- [ ] Validated proper exception handling in multi-threaded code to avoid silent thread termination.


## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->

- [ ] New unit tests added.
- [ ] New integration tests added.
- [ ] Modified or extended existing tests.
- [ ] Verified backward compatibility (if applicable).

## Does this PR introduce any user-facing or breaking changes?
<!--  
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Clearly explain the behavior change and its impact.