### PR TITLE
[controller] Fix store migration after a target region push with deferred swap

### DIFF
--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestDeferredVersionSwap.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestDeferredVersionSwap.java
@@ -12,12 +12,21 @@ import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNotNull;
 
+import com.linkedin.d2.balancer.D2Client;
+import com.linkedin.venice.AdminTool;
+import com.linkedin.venice.client.store.AbstractAvroStoreClient;
+import com.linkedin.venice.client.store.AvroGenericStoreClient;
+import com.linkedin.venice.client.store.ClientConfig;
+import com.linkedin.venice.client.store.ClientFactory;
+import com.linkedin.venice.client.store.StatTrackingStoreClient;
 import com.linkedin.venice.controllerapi.ControllerClient;
+import com.linkedin.venice.controllerapi.ControllerResponse;
 import com.linkedin.venice.controllerapi.JobStatusQueryResponse;
 import com.linkedin.venice.controllerapi.StoreResponse;
 import com.linkedin.venice.controllerapi.UpdateStoreQueryParams;
 import com.linkedin.venice.controllerapi.VersionCreationResponse;
 import com.linkedin.venice.exceptions.VeniceException;
+import com.linkedin.venice.integration.utils.D2TestUtils;
 import com.linkedin.venice.integration.utils.ServiceFactory;
 import com.linkedin.venice.integration.utils.VeniceMultiClusterWrapper;
 import com.linkedin.venice.integration.utils.VeniceMultiRegionClusterCreateOptions;
@@ -28,6 +37,7 @@ import com.linkedin.venice.meta.VersionStatus;
 import com.linkedin.venice.pushmonitor.ExecutionStatus;
 import com.linkedin.venice.utils.IntegrationTestPushUtils;
 import com.linkedin.venice.utils.RegionUtils;
+import com.linkedin.venice.utils.StoreMigrationTestUtil;
 import com.linkedin.venice.utils.TestUtils;
 import com.linkedin.venice.utils.TestWriteUtils;
 import com.linkedin.venice.utils.Utils;
@@ -39,6 +49,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Properties;
 import java.util.Set;
+import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.IntStream;
 import org.testng.Assert;
@@ -54,7 +65,7 @@ import org.testng.annotations.Test;
  */
 public class TestDeferredVersionSwap {
   private static final int NUMBER_OF_CHILD_DATACENTERS = 3;
-  private static final int NUMBER_OF_CLUSTERS = 1;
+  private static final int NUMBER_OF_CLUSTERS = 2;
   private VeniceTwoLayerMultiRegionMultiClusterWrapper multiRegionMultiClusterWrapper;
   private static final String REGION1 = "dc-0";
   private static final String REGION2 = "dc-1";
@@ -500,4 +511,132 @@ public class TestDeferredVersionSwap {
     }
   }
 
+  @Test(timeOut = TEST_TIMEOUT)
+  public void testMigrateStore() throws IOException {
+    // Do a target region push
+    File inputDir = getTempDataDirectory();
+    TestWriteUtils.writeSimpleAvroFileWithStringToV3Schema(inputDir, 100, 100);
+    String inputDirPath = "file://" + inputDir.getAbsolutePath();
+    String storeName = Utils.getUniqueString("testDeferredVersionSwap");
+    Properties props =
+        IntegrationTestPushUtils.defaultVPJProps(multiRegionMultiClusterWrapper, inputDirPath, storeName);
+    String keySchemaStr = "\"string\"";
+    UpdateStoreQueryParams storeParms = new UpdateStoreQueryParams().setUnusedSchemaDeletionEnabled(true);
+    storeParms.setTargetRegionSwapWaitTime(1);
+    String parentControllerURLs = multiRegionMultiClusterWrapper.getControllerConnectString();
+    Set<String> targetRegionsList = RegionUtils.parseRegionsFilterList(REGION1);
+
+    String srcClusterName = CLUSTER_NAMES[0];
+    String destClusterName = CLUSTER_NAMES[1];
+    try (ControllerClient parentControllerClient = new ControllerClient(srcClusterName, parentControllerURLs)) {
+      createStoreForJob(srcClusterName, keySchemaStr, NAME_RECORD_V3_SCHEMA.toString(), props, storeParms).close();
+
+      // Start push job with target region push enabled
+      props.put(TARGETED_REGION_PUSH_WITH_DEFERRED_SWAP, true);
+      props.put(TARGETED_REGION_PUSH_LIST, REGION1);
+      TestWriteUtils.runPushJob("Test push job", props);
+      TestUtils.waitForNonDeterministicPushCompletion(
+          Version.composeKafkaTopic(storeName, 1),
+          parentControllerClient,
+          30,
+          TimeUnit.SECONDS);
+
+      // Version should only be swapped in the target region
+      TestUtils.waitForNonDeterministicAssertion(1, TimeUnit.MINUTES, () -> {
+        Map<String, Integer> coloVersions =
+            parentControllerClient.getStore(storeName).getStore().getColoToCurrentVersions();
+
+        coloVersions.forEach((colo, version) -> {
+          if (targetRegionsList.contains(colo)) {
+            Assert.assertEquals((int) version, 1);
+          } else {
+            Assert.assertEquals((int) version, 0);
+          }
+        });
+      });
+
+      TestUtils.waitForNonDeterministicAssertion(30, TimeUnit.SECONDS, () -> {
+        StoreInfo parentStore = parentControllerClient.getStore(storeName).getStore();
+        Assert.assertEquals(parentStore.getVersion(1).get().getStatus(), VersionStatus.PUSHED);
+      });
+
+      // Version should be swapped in all regions
+      TestUtils.waitForNonDeterministicAssertion(2, TimeUnit.MINUTES, () -> {
+        Map<String, Integer> coloVersions =
+            parentControllerClient.getStore(storeName).getStore().getColoToCurrentVersions();
+
+        coloVersions.forEach((colo, version) -> {
+          Assert.assertEquals((int) version, 1);
+        });
+      });
+
+      TestUtils.waitForNonDeterministicAssertion(30, TimeUnit.SECONDS, () -> {
+        StoreInfo parentStore = parentControllerClient.getStore(storeName).getStore();
+        Assert.assertEquals(parentStore.getVersion(1).get().getStatus(), VersionStatus.ONLINE);
+      });
+
+      // Check that child version status is marked as ONLINE if it didn't fail
+      for (VeniceMultiClusterWrapper childDatacenter: multiRegionMultiClusterWrapper.getChildRegions()) {
+        ControllerClient childControllerClient =
+            new ControllerClient(srcClusterName, childDatacenter.getControllerConnectString());
+        StoreResponse store = childControllerClient.getStore(storeName);
+        Optional<Version> version = store.getStore().getVersion(1);
+        assertNotNull(version);
+        assertEquals(version.get().getStatus(), VersionStatus.ONLINE);
+      }
+    }
+
+    // Do a store migration
+    VeniceMultiClusterWrapper multiClusterWrapper = multiRegionMultiClusterWrapper.getChildRegions().get(0);
+    String srcD2ServiceName = multiClusterWrapper.getClusterToD2().get(srcClusterName);
+    String destD2ServiceName = multiClusterWrapper.getClusterToD2().get(destClusterName);
+    D2Client d2Client =
+        D2TestUtils.getAndStartD2Client(multiClusterWrapper.getClusters().get(srcClusterName).getZk().getAddress());
+    ClientConfig clientConfig =
+        ClientConfig.defaultGenericClientConfig(storeName).setD2ServiceName(srcD2ServiceName).setD2Client(d2Client);
+
+    try (AvroGenericStoreClient<String, Object> client = ClientFactory.getAndStartGenericAvroClient(clientConfig)) {
+      try {
+        StoreMigrationTestUtil.startMigration(parentControllerURLs, storeName, srcClusterName, destClusterName);
+      } catch (Exception e) {
+        throw new RuntimeException(e);
+      }
+
+      // Complete store migration in all regions
+      for (VeniceMultiClusterWrapper childDatacenter: multiRegionMultiClusterWrapper.getChildRegions()) {
+        ControllerClient childControllerClient =
+            new ControllerClient(srcClusterName, childDatacenter.getControllerConnectString());
+        String[] completeMigration =
+            { "--complete-migration", "--url", parentControllerURLs, "--store", storeName, "--cluster-src",
+                srcClusterName, "--cluster-dest", destClusterName, "--fabric", childDatacenter.getRegionName() };
+
+        TestUtils.waitForNonDeterministicAssertion(30, TimeUnit.SECONDS, () -> {
+          AdminTool.main(completeMigration);
+
+          ControllerResponse discoveryResponse = childControllerClient.discoverCluster(storeName);
+          Assert.assertEquals(discoveryResponse.getCluster(), destClusterName);
+        });
+      }
+
+      // Check that the destCluster is now the discovery point
+      try (ControllerClient destParentControllerClient = new ControllerClient(destClusterName, parentControllerURLs)) {
+        TestUtils.waitForNonDeterministicAssertion(60, TimeUnit.SECONDS, () -> {
+          ControllerResponse discoveryResponse = destParentControllerClient.discoverCluster(storeName);
+          Assert.assertEquals(discoveryResponse.getCluster(), destClusterName);
+        });
+      }
+
+      TestUtils.waitForNonDeterministicAssertion(60, TimeUnit.SECONDS, () -> {
+        // StoreConfig in router might not be up-to-date. Keep reading from the store. Finally, router will find that
+        // cluster discovery changes and redirect the request to dest store. Client's d2ServiceName will be updated.
+        int key = ThreadLocalRandom.current().nextInt(20) + 1;
+        client.get(Integer.toString(key)).get();
+
+        AbstractAvroStoreClient<String, Object> castClient =
+            (AbstractAvroStoreClient<String, Object>) ((StatTrackingStoreClient<String, Object>) client)
+                .getInnerStoreClient();
+        Assert.assertTrue(castClient.toString().contains(destD2ServiceName));
+      });
+    }
+  }
 }

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestDeferredVersionSwap.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestDeferredVersionSwap.java
@@ -451,78 +451,19 @@ public class TestDeferredVersionSwap {
   }
 
   @Test(timeOut = TEST_TIMEOUT)
-  public void testDeferredVersionSwapWithHybridStore() throws IOException {
-    File inputDir = getTempDataDirectory();
-    TestWriteUtils.writeSimpleAvroFileWithIntToIntSchema(inputDir, 10);
-    // Setup job properties
-    String inputDirPath = "file://" + inputDir.getAbsolutePath();
-    String storeName = Utils.getUniqueString("testDeferredVersionSwapWithHybridStore");
-    Properties props =
-        IntegrationTestPushUtils.defaultVPJProps(multiRegionMultiClusterWrapper, inputDirPath, storeName);
-    String keySchemaStr = "\"int\"";
-    String valueSchemaStr = "\"int\"";
-    UpdateStoreQueryParams storeParams = new UpdateStoreQueryParams().setUnusedSchemaDeletionEnabled(true)
-        .setHybridOffsetLagThreshold(TEST_TIMEOUT)
-        .setHybridRewindSeconds(2L)
-        .setActiveActiveReplicationEnabled(true)
-        .setTargetRegionSwapWaitTime(1);
-    String parentControllerURLs = multiRegionMultiClusterWrapper.getControllerConnectString();
-
-    try (ControllerClient parentControllerClient = new ControllerClient(CLUSTER_NAMES[0], parentControllerURLs)) {
-      createStoreForJob(CLUSTER_NAMES[0], keySchemaStr, valueSchemaStr, props, storeParams).close();
-
-      // Start push job with target region push enabled
-      props.put(TARGETED_REGION_PUSH_WITH_DEFERRED_SWAP, true);
-      TestWriteUtils.runPushJob("Test push job", props);
-      TestUtils.waitForNonDeterministicPushCompletion(
-          Version.composeKafkaTopic(storeName, 1),
-          parentControllerClient,
-          30,
-          TimeUnit.SECONDS);
-
-      // Version should only be swapped in the target region
-      TestUtils.waitForNonDeterministicAssertion(1, TimeUnit.MINUTES, () -> {
-        Map<String, Integer> coloVersions =
-            parentControllerClient.getStore(storeName).getStore().getColoToCurrentVersions();
-
-        coloVersions.forEach((colo, version) -> {
-          if (colo.equals(REGION3)) {
-            Assert.assertEquals((int) version, 1);
-          } else {
-            Assert.assertEquals((int) version, 0);
-          }
-        });
-      });
-
-      TestUtils.waitForNonDeterministicAssertion(30, TimeUnit.SECONDS, () -> {
-        StoreInfo parentStore = parentControllerClient.getStore(storeName).getStore();
-        Assert.assertEquals(parentStore.getVersion(1).get().getStatus(), VersionStatus.PUSHED);
-      });
-
-      // Version should be swapped in all regions
-      TestUtils.waitForNonDeterministicAssertion(2, TimeUnit.MINUTES, () -> {
-        Map<String, Integer> coloVersions =
-            parentControllerClient.getStore(storeName).getStore().getColoToCurrentVersions();
-
-        coloVersions.forEach((colo, version) -> {
-          Assert.assertEquals((int) version, 1);
-        });
-      });
-    }
-  }
-
-  @Test(timeOut = TEST_TIMEOUT)
-  public void testDeferredVersionSwapThenMigrateStore() throws IOException {
+  public void testDeferredVersionSwapInHybridStoreThenMigrateStore() throws IOException {
     // Do a target region push
     File inputDir = getTempDataDirectory();
     TestWriteUtils.writeSimpleAvroFileWithStringToV3Schema(inputDir, 100, 100);
     String inputDirPath = "file://" + inputDir.getAbsolutePath();
-    String storeName = Utils.getUniqueString("testDeferredVersionSwap");
+    String storeName = Utils.getUniqueString("testDeferredVersionSwapInHybridStoreThenMigrateStore");
     Properties props =
         IntegrationTestPushUtils.defaultVPJProps(multiRegionMultiClusterWrapper, inputDirPath, storeName);
     String keySchemaStr = "\"string\"";
-    UpdateStoreQueryParams storeParms = new UpdateStoreQueryParams().setUnusedSchemaDeletionEnabled(true);
-    storeParms.setTargetRegionSwapWaitTime(1);
+    UpdateStoreQueryParams storeParms = new UpdateStoreQueryParams().setHybridOffsetLagThreshold(TEST_TIMEOUT)
+        .setHybridRewindSeconds(2L)
+        .setActiveActiveReplicationEnabled(true)
+        .setTargetRegionSwapWaitTime(1);
     String parentControllerURLs = multiRegionMultiClusterWrapper.getControllerConnectString();
     Set<String> targetRegionsList = RegionUtils.parseRegionsFilterList(REGION1);
 

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestDeferredVersionSwap.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestDeferredVersionSwap.java
@@ -512,7 +512,7 @@ public class TestDeferredVersionSwap {
   }
 
   @Test(timeOut = TEST_TIMEOUT)
-  public void testMigrateStore() throws IOException {
+  public void testDeferredVersionSwapThenMigrateStore() throws IOException {
     // Do a target region push
     File inputDir = getTempDataDirectory();
     TestWriteUtils.writeSimpleAvroFileWithStringToV3Schema(inputDir, 100, 100);

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceHelixAdmin.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceHelixAdmin.java
@@ -2885,6 +2885,12 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
             // Configs from the source clusters are source of truth
             version.setStatus(STARTED);
 
+            // Do not do a target region push w/ deferred swap for store migration
+            if (version.isVersionSwapDeferred() && !StringUtils.isEmpty(version.getTargetSwapRegion())) {
+              version.setVersionSwapDeferred(false);
+              version.setTargetSwapRegion("");
+            }
+
             if (store.containsVersion(version.getNumber())) {
               throwVersionAlreadyExists(storeName, version.getNumber());
             }

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceHelixAdmin.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceHelixAdmin.java
@@ -2886,11 +2886,9 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
             version.setStatus(STARTED);
 
             // Do not do a target region push w/ deferred swap for store migration. Setting the following two configs
-            // will
-            // enable target region push w/ deferred swap and this is not desirable as the version will never be swapped
-            // in the non
-            // target regions for store migration as the DeferredVersionSwapService relies on parent version status to
-            // coordinate the version swap
+            // will enable target region push w/ deferred swap and this is not desirable as the version will never be
+            // swapped in the non target regions for store migration as the DeferredVersionSwapService relies on parent
+            // version status to coordinate the version swap
             if (version.isVersionSwapDeferred() && !StringUtils.isEmpty(version.getTargetSwapRegion())) {
               version.setVersionSwapDeferred(false);
               version.setTargetSwapRegion("");

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceHelixAdmin.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceHelixAdmin.java
@@ -2885,7 +2885,12 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
             // Configs from the source clusters are source of truth
             version.setStatus(STARTED);
 
-            // Do not do a target region push w/ deferred swap for store migration
+            // Do not do a target region push w/ deferred swap for store migration. Setting the following two configs
+            // will
+            // enable target region push w/ deferred swap and this is not desirable as the version will never be swapped
+            // in the non
+            // target regions for store migration as the DeferredVersionSwapService relies on parent version status to
+            // coordinate the version swap
             if (version.isVersionSwapDeferred() && !StringUtils.isEmpty(version.getTargetSwapRegion())) {
               version.setVersionSwapDeferred(false);
               version.setTargetSwapRegion("");


### PR DESCRIPTION
<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat], [protocol]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## Problem Statement
<!--
Describe
- What problem are you trying to solve
- What issues or limitations exist in the current code
- Why this change is necessary 
-->
When a store does a target region push with deferred swap, it sets the following version level configs: `versionSwapDeferred` and `targetSwapRegions`. These two configs are how we know we are doing a target region push with deferred swap. When a store migration happens, we copy the child version configs over to the store and copy over `versionSwapDeferred` and `targetSwapRegion` configs as well. This is a problem because the controller now thinks we are doing a target region push with deferred swap and will only swap to the new version in the target region. The non target regions never get a chance to swap because the `DeferredVersionSwapService` thinks the version swap is complete already from the first push before store migration as the parent version status is already marked `ONLINE`.

## Solution
<!--
Describe
- What changes you are making and why. 
- How these changes solve the problem.
- Any performance considerations or trade-offs. 
- Describe what testings you have done, for example, performance testing etc.
-->
Do not set the version configs `versionSwapDeferred` and `targetSwapRegions` when cloning the version for a store migration. This will prevent store migration version creation from being picked up as a target region push with deferred swap and perform version swaps as normal (version is swapped right after ingestion finishes)

###  Code changes
- [ ] Added new code behind **a config**. If so list the config names and their default values in the PR description.
- [ ] Introduced new **log lines**. 
  - [ ] Confirmed if logs need to be **rate limited** to avoid excessive logging.

###  **Concurrency-Specific Checks**
Both reviewer and PR author to verify
- [x] Code has **no race conditions** or **thread safety issues**.
- [x] Proper **synchronization mechanisms** (e.g., `synchronized`, `RWLock`) are used where needed.
- [x] No **blocking calls** inside critical sections that could lead to deadlocks or performance degradation.
- [x] Verified **thread-safe collections** are used (e.g., `ConcurrentHashMap`, `CopyOnWriteArrayList`).
- [x] Validated proper exception handling in multi-threaded code to avoid silent thread termination.


## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->

- [ ] New unit tests added.
- [x] New integration tests added.
- [ ] Modified or extended existing tests.
- [ ] Verified backward compatibility (if applicable).

## Does this PR introduce any user-facing or breaking changes?
<!--  
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Clearly explain the behavior change and its impact.