### PR TITLE
[admin-tool] Use numeric offset in Admin tool

### DIFF
--- a/internal/venice-common/src/main/java/com/linkedin/venice/writer/VeniceWriterFactory.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/writer/VeniceWriterFactory.java
@@ -70,8 +70,8 @@ public class VeniceWriterFactory {
             ? pubSubPositionTypeRegistry
             : PubSubPositionTypeRegistry.fromPropertiesOrDefault(veniceProperties),
         "PubSubPositionTypeRegistry cannot be null when creating VeniceWriterFactory");
-    LOGGER.info(
-        "### MARKER ### Creating VeniceWriterFactory with properties: {} defaultBrokerAddress: {} pubSubPositionTypeRegistry: {} pubSubProducerAdapterFactory: {}",
+    LOGGER.debug(
+        "Creating VeniceWriterFactory with properties: {} defaultBrokerAddress: {} pubSubPositionTypeRegistry: {} pubSubProducerAdapterFactory: {}",
         this.veniceProperties,
         this.defaultBrokerAddress,
         this.pubSubPositionTypeRegistry,

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/kafka/EndToEndKafkaWithSASLTest.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/kafka/EndToEndKafkaWithSASLTest.java
@@ -36,7 +36,7 @@ import org.apache.avro.generic.GenericRecord;
 import org.apache.avro.generic.IndexedRecord;
 import org.apache.kafka.common.config.SslConfigs;
 import org.testng.Assert;
-import org.testng.annotations.AfterClass;
+import org.testng.annotations.AfterMethod;
 import org.testng.annotations.Test;
 
 
@@ -45,9 +45,11 @@ public class EndToEndKafkaWithSASLTest {
   private PubSubBrokerWrapper pubSubBrokerWrapper;
   private VeniceClusterWrapper veniceCluster;
 
-  @AfterClass(alwaysRun = true)
+  @AfterMethod(alwaysRun = true)
   public void cleanUp() {
     Utils.closeQuietlyWithErrorLogged(veniceCluster);
+    Utils.closeQuietlyWithErrorLogged(pubSubBrokerWrapper);
+    Utils.closeQuietlyWithErrorLogged(zkServer);
   }
 
   @Test(timeOut = 60 * Time.MS_PER_SECOND)


### PR DESCRIPTION
<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat], [protocol]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## [admin-tool] Use numeric position in Admin tool
Replaced all `record.getPosition()` calls with `record.getPosition().getNumericOffset()`  
in KafkaTopicDumper. Also switched a non-critical log in VeniceWriterFactory from  
`info` to `debug`. Updated `EndToEndKafkaWithSASLTest` to use `@AfterMethod`  
instead of `@AfterClass` for better resource cleanup.  

> 
> 
> ## AI Generated Summary of Changes
> This pull request introduces several changes across multiple files, primarily focusing on improving logging precision, modifying test cleanup behavior, and adjusting logging levels. Below is a categorized summary of the most important changes:
> 
> ### Logging Improvements:
> * Updated all instances of `record.getPosition()` to use `record.getPosition().getNumericOffset()` for more precise logging of Kafka offsets in `KafkaTopicDumper.java`. This change affects multiple methods, including `fetchAndProcess`, `logRecordMetadata`, `logDataRecord`, `buildDataRecordLog`, `constructTopicSwitchLog`, and `writeToFile`. [[1]](diffhunk://#diff-9f8d01344e6a9320192e924c20caf7ee3c4f205c69c432b20f18d7cbf9f4e149L399-R399) [[2]](diffhunk://#diff-9f8d01344e6a9320192e924c20caf7ee3c4f205c69c432b20f18d7cbf9f4e149L479-R479) [[3]](diffhunk://#diff-9f8d01344e6a9320192e924c20caf7ee3c4f205c69c432b20f18d7cbf9f4e149L492-R495) [[4]](diffhunk://#diff-9f8d01344e6a9320192e924c20caf7ee3c4f205c69c432b20f18d7cbf9f4e149L505-R508) [[5]](diffhunk://#diff-9f8d01344e6a9320192e924c20caf7ee3c4f205c69c432b20f18d7cbf9f4e149L571-R577) [[6]](diffhunk://#diff-9f8d01344e6a9320192e924c20caf7ee3c4f205c69c432b20f18d7cbf9f4e149L624-R630) [[7]](diffhunk://#diff-9f8d01344e6a9320192e924c20caf7ee3c4f205c69c432b20f18d7cbf9f4e149L649-R655) [[8]](diffhunk://#diff-9f8d01344e6a9320192e924c20caf7ee3c4f205c69c432b20f18d7cbf9f4e149L676-R682) [[9]](diffhunk://#diff-9f8d01344e6a9320192e924c20caf7ee3c4f205c69c432b20f18d7cbf9f4e149L686-R692)
> 
> * Changed a logging statement in `VeniceWriterFactory.java` from `LOGGER.info` to `LOGGER.debug` to reduce verbosity for non-critical logs.
> 
> ### Test Cleanup Enhancements:
> * Replaced `@AfterClass` with `@AfterMethod` in `EndToEndKafkaWithSASLTest.java` to ensure resources are cleaned up after each test method instead of after the entire test class. Additionally, added cleanup for `pubSubBrokerWrapper` and `zkServer`. [[1]](diffhunk://#diff-b3166384d9b2b60a9104e3bf20a86f0886201fd07b47fe1f3eb348b4c34f3378L39-R39) [[2]](diffhunk://#diff-b3166384d9b2b60a9104e3bf20a86f0886201fd07b47fe1f3eb348b4c34f3378L48-R52)
> 



###  Code changes
- [ ] Added new code behind **a config**. If so list the config names and their default values in the PR description.
- [ ] Introduced new **log lines**. 
  - [ ] Confirmed if logs need to be **rate limited** to avoid excessive logging.

###  **Concurrency-Specific Checks**
Both reviewer and PR author to verify
- [ ] Code has **no race conditions** or **thread safety issues**.
- [ ] Proper **synchronization mechanisms** (e.g., `synchronized`, `RWLock`) are used where needed.
- [ ] No **blocking calls** inside critical sections that could lead to deadlocks or performance degradation.
- [ ] Verified **thread-safe collections** are used (e.g., `ConcurrentHashMap`, `CopyOnWriteArrayList`).
- [ ] Validated proper exception handling in multi-threaded code to avoid silent thread termination.


## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->

- [ ] New unit tests added.
- [ ] New integration tests added.
- [ ] Modified or extended existing tests.
- [ ] Verified backward compatibility (if applicable).

## Does this PR introduce any user-facing or breaking changes?
<!--  
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [ ] No. You can skip the rest of this section.
- [ ] Yes. Clearly explain the behavior change and its impact.