### PR TITLE
[router] Removed SSL handshake offloading feature

### DIFF
--- a/internal/venice-client-common/src/main/java/com/linkedin/venice/serializer/AvroSerializer.java
+++ b/internal/venice-client-common/src/main/java/com/linkedin/venice/serializer/AvroSerializer.java
@@ -4,7 +4,6 @@ import com.linkedin.avroutil1.compatibility.AvroCompatibilityHelper;
 import com.linkedin.avroutil1.compatibility.AvroCompatibilityHelperCommon;
 import com.linkedin.venice.exceptions.VeniceException;
 import com.linkedin.venice.utils.AvroSchemaUtils;
-import com.linkedin.venice.utils.RedundantExceptionFilter;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.nio.ByteBuffer;
@@ -25,8 +24,6 @@ import org.apache.logging.log4j.Logger;
 public class AvroSerializer<K> implements RecordSerializer<K> {
   private static final Logger LOGGER = LogManager.getLogger(AvroSerializer.class);
   private static final ThreadLocal<ReusableObjects> REUSABLE_OBJECTS = ThreadLocal.withInitial(ReusableObjects::new);
-  private static final RedundantExceptionFilter REDUNDANT_EXCEPTION_FILTER =
-      RedundantExceptionFilter.getRedundantExceptionFilter();
 
   private final DatumWriter<K> genericDatumWriter;
   private final DatumWriter<K> specificDatumWriter;
@@ -78,11 +75,9 @@ public class AvroSerializer<K> implements RecordSerializer<K> {
        * seem to guarantee that it's in a clean state. We therefore set it to null here so that the next invocation
        * will create a brand new one.
        */
-      String errorMsg = "Caught a " + t.getClass().getSimpleName()
-          + " when serializing. Will reset the BinaryEncoder to avoid contaminating future serializations.";
-      if (!REDUNDANT_EXCEPTION_FILTER.isRedundantException(errorMsg)) {
-        LOGGER.error(errorMsg, t);
-      }
+      LOGGER.error(
+          "Caught a {} when serializing. Will reset the BinaryEncoder to avoid contaminating future serializations.",
+          t.getClass().getSimpleName());
       reusableObjects.binaryEncoder = null;
       if (AvroSchemaUtils.isUnresolvedUnionExceptionAvailable()) {
         UnresolvedUnionUtil.handleUnresolvedUnion(t);

--- a/internal/venice-common/src/main/java/com/linkedin/venice/ConfigKeys.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/ConfigKeys.java
@@ -2042,11 +2042,6 @@ public class ConfigKeys {
   public static final String DAVINCI_PUSH_STATUS_CHECK_INTERVAL_IN_MS = "davinci.push.status.check.interval.in.ms";
 
   /**
-   * The number of threads that will be used to perform SSL handshakes between clients and a router.
-   */
-  public static final String ROUTER_CLIENT_SSL_HANDSHAKE_THREADS = "router.client.ssl.handshake.threads";
-
-  /**
    * Config to control the number of threads used for DNS resolution.
    * If the value is positive, DNS resolution would be done before SSL handshake between clients and a router.
    * 0 will disable the dns resolution but does not affect the SSL handshake.

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/integration/utils/MockVeniceRouterWrapper.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/integration/utils/MockVeniceRouterWrapper.java
@@ -6,7 +6,6 @@ import static com.linkedin.venice.ConfigKeys.CLUSTER_TO_SERVER_D2;
 import static com.linkedin.venice.ConfigKeys.KAFKA_BOOTSTRAP_SERVERS;
 import static com.linkedin.venice.ConfigKeys.LISTENER_PORT;
 import static com.linkedin.venice.ConfigKeys.LISTENER_SSL_PORT;
-import static com.linkedin.venice.ConfigKeys.ROUTER_CLIENT_SSL_HANDSHAKE_THREADS;
 import static com.linkedin.venice.ConfigKeys.ROUTER_NETTY_GRACEFUL_SHUTDOWN_PERIOD_SECONDS;
 import static com.linkedin.venice.ConfigKeys.ROUTER_RESOLVE_THREADS;
 import static com.linkedin.venice.ConfigKeys.ROUTER_STORAGE_NODE_CLIENT_TYPE;
@@ -139,7 +138,6 @@ public class MockVeniceRouterWrapper extends ProcessWrapper {
               CLUSTER_TO_SERVER_D2,
               TestUtils.getClusterToD2String(Collections.singletonMap(clusterName, serverD2ServiceName)))
           .put(ROUTER_NETTY_GRACEFUL_SHUTDOWN_PERIOD_SECONDS, 1)
-          .put(ROUTER_CLIENT_SSL_HANDSHAKE_THREADS, 5)
           .put(ROUTER_RESOLVE_THREADS, 5)
           .put(ROUTER_STORAGE_NODE_CLIENT_TYPE, StorageNodeClientType.APACHE_HTTP_ASYNC_CLIENT.name())
           .put(extraConfigs);

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/integration/utils/VeniceRouterWrapper.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/integration/utils/VeniceRouterWrapper.java
@@ -8,7 +8,6 @@ import static com.linkedin.venice.ConfigKeys.LISTENER_PORT;
 import static com.linkedin.venice.ConfigKeys.LISTENER_SSL_PORT;
 import static com.linkedin.venice.ConfigKeys.LOCAL_REGION_NAME;
 import static com.linkedin.venice.ConfigKeys.MAX_READ_CAPACITY;
-import static com.linkedin.venice.ConfigKeys.ROUTER_CLIENT_SSL_HANDSHAKE_THREADS;
 import static com.linkedin.venice.ConfigKeys.ROUTER_CONNECTION_LIMIT;
 import static com.linkedin.venice.ConfigKeys.ROUTER_HTTP2_INBOUND_ENABLED;
 import static com.linkedin.venice.ConfigKeys.ROUTER_HTTPASYNCCLIENT_CONNECTION_WARMING_LOW_WATER_MARK;
@@ -148,7 +147,6 @@ public class VeniceRouterWrapper extends ProcessWrapper implements MetricsAware 
           .put(SSL_TO_STORAGE_NODES, sslToStorageNodes)
           .put(CLUSTER_TO_D2, TestUtils.getClusterToD2String(finalClusterToD2))
           .put(CLUSTER_TO_SERVER_D2, TestUtils.getClusterToD2String(finalClusterToServerD2))
-          .put(ROUTER_CLIENT_SSL_HANDSHAKE_THREADS, 5)
           .put(ROUTER_RESOLVE_THREADS, 5)
           // Below configs are to attempt to minimize resource utilization in tests
           .put(ROUTER_CONNECTION_LIMIT, 200)

--- a/services/venice-router/src/main/java/com/linkedin/venice/router/VeniceRouterConfig.java
+++ b/services/venice-router/src/main/java/com/linkedin/venice/router/VeniceRouterConfig.java
@@ -24,7 +24,6 @@ import static com.linkedin.venice.ConfigKeys.ROUTER_CLIENT_DECOMPRESSION_ENABLED
 import static com.linkedin.venice.ConfigKeys.ROUTER_CLIENT_RESOLUTION_RETRY_ATTEMPTS;
 import static com.linkedin.venice.ConfigKeys.ROUTER_CLIENT_RESOLUTION_RETRY_BACKOFF_MS;
 import static com.linkedin.venice.ConfigKeys.ROUTER_CLIENT_SSL_HANDSHAKE_QUEUE_CAPACITY;
-import static com.linkedin.venice.ConfigKeys.ROUTER_CLIENT_SSL_HANDSHAKE_THREADS;
 import static com.linkedin.venice.ConfigKeys.ROUTER_COMPUTE_TARDY_LATENCY_MS;
 import static com.linkedin.venice.ConfigKeys.ROUTER_CONNECTION_HANDLE_MODE;
 import static com.linkedin.venice.ConfigKeys.ROUTER_CONNECTION_LIMIT;
@@ -198,7 +197,6 @@ public class VeniceRouterConfig implements RouterRetryConfig {
   private final VeniceMultiKeyRoutingStrategy multiKeyRoutingStrategy;
   private final HelixGroupSelectionStrategyEnum helixGroupSelectionStrategy;
   private final String systemSchemaClusterName;
-  private final int clientSslHandshakeThreads;
   private final int maxConcurrentSslHandshakes;
   private final int resolveThreads;
   private final int resolveQueueCapacity;
@@ -342,7 +340,6 @@ public class VeniceRouterConfig implements RouterRetryConfig {
       ioThreadCountInPoolMode =
           props.getInt(ROUTER_HTTPASYNCCLIENT_CLIENT_POOL_THREAD_COUNT, Runtime.getRuntime().availableProcessors());
 
-      clientSslHandshakeThreads = props.getInt(ROUTER_CLIENT_SSL_HANDSHAKE_THREADS, 0);
       maxConcurrentSslHandshakes = props.getInt(ROUTER_MAX_CONCURRENT_SSL_HANDSHAKES, 1000);
       resolveThreads = props.getInt(ROUTER_RESOLVE_THREADS, 0);
       resolveQueueCapacity = props.getInt(ROUTER_RESOLVE_QUEUE_CAPACITY, 500000);
@@ -778,10 +775,6 @@ public class VeniceRouterConfig implements RouterRetryConfig {
     }
 
     return retryThresholdMap;
-  }
-
-  public int getClientSslHandshakeThreads() {
-    return clientSslHandshakeThreads;
   }
 
   public int getResolveThreads() {


### PR DESCRIPTION
## Problem Statement
Test results show that Netty SSL handshake offloading feature doesn't work with OpenSSL.


## Solution
Removed the SSL handshake offloading feature and all its related configs.


###  Code changes
- [ ] Added new code behind **a config**. If so list the config names and their default values in the PR description.
- [x] Introduced new **log lines**. 
 - [x] Confirmed if logs need to be **rate limited** to avoid excessive logging.

###  **Concurrency-Specific Checks**
Both reviewer and PR author to verify
- [ ] Code has **no race conditions** or **thread safety issues**.
- [ ] Proper **synchronization mechanisms** (e.g., `synchronized`, `RWLock`) are used where needed.
- [ ] No **blocking calls** inside critical sections that could lead to deadlocks or performance degradation.
- [ ] Verified **thread-safe collections** are used (e.g., `ConcurrentHashMap`, `CopyOnWriteArrayList`).
- [ ] Validated proper exception handling in multi-threaded code to avoid silent thread termination.


## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->

- [ ] New unit tests added.
- [ ] New integration tests added.
- [x] Modified or extended existing tests.
- [ ] Verified backward compatibility (if applicable).

## Does this PR introduce any user-facing or breaking changes?
<!--  
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Clearly explain the behavior change and its impact.