### PR TITLE
[test][controller] fix bug and enable rt versioning in integration tests

### DIFF
--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/StoreBufferServiceTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/StoreBufferServiceTest.java
@@ -24,7 +24,6 @@ import com.linkedin.venice.kafka.protocol.ProducerMetadata;
 import com.linkedin.venice.kafka.protocol.Put;
 import com.linkedin.venice.kafka.protocol.enums.MessageType;
 import com.linkedin.venice.message.KafkaKey;
-import com.linkedin.venice.meta.Version;
 import com.linkedin.venice.pubsub.ImmutablePubSubMessage;
 import com.linkedin.venice.pubsub.PubSubTopicPartitionImpl;
 import com.linkedin.venice.pubsub.PubSubTopicRepository;
@@ -273,8 +272,9 @@ public class StoreBufferServiceTest {
   @Test(dataProviderClass = DataProviderUtils.class, dataProvider = "True-and-False")
   public void testGetDrainerIndexForConsumerRecordSeparateRt(boolean queueLeaderWrites) {
     String baseTopicName = Utils.getUniqueString("test_topic");
-    PubSubTopic rtTopic = pubSubTopicRepository.getTopic(Version.composeRealTimeTopic(baseTopicName));
-    PubSubTopic separateRtTopic = pubSubTopicRepository.getTopic(Version.composeSeparateRealTimeTopic(baseTopicName));
+    String realTimeTopic = Utils.composeRealTimeTopic(baseTopicName, 1);
+    PubSubTopic rtTopic = pubSubTopicRepository.getTopic(realTimeTopic);
+    PubSubTopic separateRtTopic = pubSubTopicRepository.getTopic(Utils.getSeparateRealTimeTopicName(realTimeTopic));
     List<PubSubTopic> topics = new ArrayList<>(Arrays.asList(rtTopic, separateRtTopic));
     StoreBufferService bufferService = new StoreBufferService(8, 10000, 1000, queueLeaderWrites, mockedStats, null);
     for (int partition = 0; partition < 64; ++partition) {

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTaskTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTaskTest.java
@@ -4888,7 +4888,7 @@ public abstract class StoreIngestionTaskTest {
     heartBeatFuture.complete(null);
     PubSubTopicPartition pubSubTopicPartition0 = new PubSubTopicPartitionImpl(pubsubTopic, 0);
     PubSubTopicPartition pubSubTopicPartition1 = new PubSubTopicPartitionImpl(pubsubTopic, 1);
-    PubSubTopic sepRTtopic = pubSubTopicRepository.getTopic(Version.composeSeparateRealTimeTopic(storeName));
+    PubSubTopic sepRTtopic = pubSubTopicRepository.getTopic(Utils.getSeparateRealTimeTopicName(storeName));
     PubSubTopicPartition pubSubTopicPartition1sep = new PubSubTopicPartitionImpl(sepRTtopic, 1);
 
     // all succeeded
@@ -5584,7 +5584,7 @@ public abstract class StoreIngestionTaskTest {
     value.payloadUnion = new Put();
     value.messageType = MessageType.PUT.getValue();
     PubSubTopic versionTopic = pubSubTopicRepository.getTopic(Version.composeKafkaTopic("testStore", 1));
-    PubSubTopic rtTopic = pubSubTopicRepository.getTopic(Version.composeRealTimeTopic("testStore"));
+    PubSubTopic rtTopic = pubSubTopicRepository.getTopic(Utils.composeRealTimeTopic("testStore", 1));
 
     PubSubTopicPartition versionTopicPartition = new PubSubTopicPartitionImpl(versionTopic, PARTITION_FOO);
     PubSubTopicPartition rtPartition = new PubSubTopicPartitionImpl(rtTopic, PARTITION_FOO);

--- a/internal/venice-common/src/main/java/com/linkedin/venice/utils/Utils.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/utils/Utils.java
@@ -574,7 +574,8 @@ public class Utils {
 
   /** This method should only be used for system stores.
    * For other stores, use {@link Utils#getRealTimeTopicName(Store)}, {@link Utils#getRealTimeTopicName(StoreInfo)} or
-   * {@link Utils#getRealTimeTopicName(Version)}
+   * {@link Utils#getRealTimeTopicName(Version)} in source code.
+   * For tests, use {@link Utils#composeRealTimeTopic(String, int)}
    */
   public static String composeRealTimeTopic(String storeName) {
     return storeName + REAL_TIME_TOPIC_SUFFIX;

--- a/internal/venice-common/src/test/java/com/linkedin/venice/meta/TestVersion.java
+++ b/internal/venice-common/src/test/java/com/linkedin/venice/meta/TestVersion.java
@@ -135,64 +135,41 @@ public class TestVersion {
     }
   }
 
-  @Test
-  public void testIsTopic() {
-    String topic = "abc_rt";
-    assertFalse(Version.isVersionTopic(topic));
-    assertTrue(Version.isRealTimeTopic(topic));
-    topic = "abc";
-    assertFalse(Version.isVersionTopic(topic));
-    topic = "abc_v12df";
-    assertFalse(Version.isVersionTopic(topic));
-    topic = "abc_v123";
-    assertTrue(Version.isVersionTopic(topic));
-    assertFalse(Version.isRealTimeTopic(topic));
-    assertTrue(Version.isVersionTopicOrStreamReprocessingTopic(topic));
-    topic = "abc_v123_sr";
-    assertFalse(Version.isVersionTopic(topic));
-    assertTrue(Version.isStreamReprocessingTopic(topic));
-    assertTrue(Version.isVersionTopicOrStreamReprocessingTopic(topic));
-    topic = "abc_v12ab3_sr";
-    assertFalse(Version.isVersionTopic(topic));
-    assertFalse(Version.isStreamReprocessingTopic(topic));
-    assertFalse(Version.isVersionTopicOrStreamReprocessingTopic(topic));
-    topic = "abc_v_sr";
-    assertFalse(Version.isVersionTopic(topic));
-    assertFalse(Version.isStreamReprocessingTopic(topic));
-    assertFalse(Version.isVersionTopicOrStreamReprocessingTopic(topic));
-
-    topic = "abc_rt_v1";
-    assertFalse(Version.isVersionTopic(topic));
-    assertTrue(Version.isRealTimeTopic(topic));
-
-    topic = "abc_rt_v1_sep";
-    assertFalse(Version.isVersionTopic(topic));
-    assertTrue(Version.isRealTimeTopic(topic));
+  private void verifyTopic(
+      String topic,
+      boolean isVT,
+      boolean isRT,
+      boolean isSR,
+      boolean isVTorSR,
+      boolean isVersioned) {
+    assert (Version.isVersionTopic(topic) == isVT);
+    assert (Version.isRealTimeTopic(topic) == isRT);
+    assert (Version.isStreamReprocessingTopic(topic) == isSR);
+    assert (Version.isVersionTopicOrStreamReprocessingTopic(topic) == isVTorSR);
+    assert (Version.isATopicThatIsVersioned(topic) == isVersioned);
   }
 
   @Test
-  public void testIsATopicThatIsVersioned() {
-    String topic = "abc_rt";
-    assertFalse(Version.isATopicThatIsVersioned(topic));
-    topic = "abc_v1_sr";
-    assertTrue(Version.isATopicThatIsVersioned(topic));
-    topic = "abc_v1";
-    assertTrue(Version.isATopicThatIsVersioned(topic));
-    topic = "abc_v1_cc";
-    assertTrue(Version.isATopicThatIsVersioned(topic));
+  public void testIsTopic() {
+    verifyTopic("abc_rt", false, true, false, false, false);
+    verifyTopic("abc", false, false, false, false, false);
+    verifyTopic("abc_v12df", false, false, false, false, false);
+    verifyTopic("abc_v123", true, false, false, true, true);
+    verifyTopic("abc_v123_sr", false, false, true, true, true);
+    verifyTopic("abc_v12ab3_sr", false, false, false, false, false);
+    verifyTopic("abc_v_sr", false, false, false, false, false);
+    verifyTopic("abc_v1", true, false, false, true, true);
+    verifyTopic("abc_v1_sr", false, false, true, true, true);
+    verifyTopic("abc_v1_cc", false, false, false, false, true);
+    verifyTopic("abc_mv", false, false, false, false, true);
+    verifyTopic("abc_rt_v1", false, true, false, false, false);
+    verifyTopic("abc_rt_v1_sep", false, true, false, false, false);
+  }
+
+  @Test
+  public void testPushId() {
     String pushId = VENICE_TTL_RE_PUSH_PUSH_ID_PREFIX + System.currentTimeMillis();
     assertTrue(Version.isPushIdTTLRePush(pushId));
-
-    // where is this method used ???? abora
-    topic = "abc_rt_v1";
-    assertFalse(Version.isATopicThatIsVersioned(topic));
-
-    topic = "abc_v1_rt_sep";
-    assertFalse(Version.isATopicThatIsVersioned(topic));
-
-    // from storeName_v1_rt to storeName_rt_v1
-    // from storeName_v1_rt_sep to storeName_rt_v1_sep
-
   }
 
   @Test

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/controller/VeniceParentHelixAdminTest.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/controller/VeniceParentHelixAdminTest.java
@@ -324,7 +324,7 @@ public class VeniceParentHelixAdminTest {
       try (TopicManagerRepository topicManagerRepo = IntegrationTestPushUtils
           .getTopicManagerRepo(PUBSUB_OPERATION_TIMEOUT_MS_DEFAULT_VALUE, 100, 0l, parentPubSub, pubSubTopicRepository);
           TopicManager topicManager = topicManagerRepo.getLocalTopicManager()) {
-        PubSubTopic metaStoreRT = pubSubTopicRepository.getTopic(Version.composeRealTimeTopic(metaSystemStoreName));
+        PubSubTopic metaStoreRT = pubSubTopicRepository.getTopic(Utils.composeRealTimeTopic(metaSystemStoreName));
         topicManager.createTopic(metaStoreRT, 1, 1, true);
         TestUtils.waitForNonDeterministicAssertion(
             30,

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/DaVinciClientTest.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/DaVinciClientTest.java
@@ -19,7 +19,6 @@ import static com.linkedin.venice.ConfigKeys.BLOB_TRANSFER_MANAGER_ENABLED;
 import static com.linkedin.venice.ConfigKeys.BLOB_TRANSFER_SSL_ENABLED;
 import static com.linkedin.venice.ConfigKeys.CLIENT_SYSTEM_STORE_REPOSITORY_REFRESH_INTERVAL_SECONDS;
 import static com.linkedin.venice.ConfigKeys.CLIENT_USE_SYSTEM_STORE_REPOSITORY;
-import static com.linkedin.venice.ConfigKeys.CONTROLLER_ENABLE_REAL_TIME_TOPIC_VERSIONING;
 import static com.linkedin.venice.ConfigKeys.D2_ZK_HOSTS_ADDRESS;
 import static com.linkedin.venice.ConfigKeys.DATA_BASE_PATH;
 import static com.linkedin.venice.ConfigKeys.DAVINCI_P2P_BLOB_TRANSFER_CLIENT_PORT;
@@ -171,7 +170,6 @@ public class DaVinciClientTest {
   private VeniceClusterWrapper cluster;
   private D2Client d2Client;
   private PubSubProducerAdapterFactory pubSubProducerAdapterFactory;
-  private final boolean REAL_TIME_TOPIC_VERSIONING_ENABLED = true;
 
   @BeforeClass
   public void setUp() {
@@ -179,7 +177,6 @@ public class DaVinciClientTest {
     Properties clusterConfig = new Properties();
     clusterConfig.put(PUSH_STATUS_STORE_ENABLED, true);
     clusterConfig.put(DAVINCI_PUSH_STATUS_SCAN_INTERVAL_IN_SECONDS, 3);
-    clusterConfig.put(CONTROLLER_ENABLE_REAL_TIME_TOPIC_VERSIONING, REAL_TIME_TOPIC_VERSIONING_ENABLED);
     VeniceClusterCreateOptions options = new VeniceClusterCreateOptions.Builder().numberOfControllers(1)
         .numberOfServers(2)
         .numberOfRouters(1)
@@ -1537,9 +1534,10 @@ public class DaVinciClientTest {
   }
 
   private void runIncrementalPush(String storeName, String incrementalPushVersion, int keyCount) throws Exception {
-    String realTimeTopicName = REAL_TIME_TOPIC_VERSIONING_ENABLED
-        ? Utils.composeRealTimeTopic(storeName, 1)
-        : Utils.composeRealTimeTopic(storeName);
+    String realTimeTopicName =
+        Boolean.parseBoolean(VeniceClusterWrapper.CONTROLLER_ENABLE_REAL_TIME_TOPIC_VERSIONING_IN_TESTS)
+            ? Utils.composeRealTimeTopic(storeName, 1)
+            : Utils.composeRealTimeTopic(storeName);
     VeniceWriterFactory vwFactory =
         IntegrationTestPushUtils.getVeniceWriterFactory(cluster.getPubSubBrokerWrapper(), pubSubProducerAdapterFactory);
     VeniceKafkaSerializer keySerializer = new VeniceAvroKafkaSerializer(DEFAULT_KEY_SCHEMA);

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/integration/utils/VeniceClusterWrapper.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/integration/utils/VeniceClusterWrapper.java
@@ -127,6 +127,8 @@ public class VeniceClusterWrapper extends ProcessWrapper {
   // cluster. e.g. controllers in a multi cluster wrapper.
   private String externalControllerDiscoveryURL = "";
 
+  public static final String CONTROLLER_ENABLE_REAL_TIME_TOPIC_VERSIONING_IN_TESTS = "true";
+
   private static final List<AvroProtocolDefinition> CLUSTER_LEADER_INITIALIZATION_ROUTINES = Arrays.asList(
       AvroProtocolDefinition.KAFKA_MESSAGE_ENVELOPE,
       AvroProtocolDefinition.PARTITION_STATE,
@@ -181,6 +183,12 @@ public class VeniceClusterWrapper extends ProcessWrapper {
     Map<Integer, VeniceServerWrapper> veniceServerWrappers = new HashMap<>();
     Map<Integer, VeniceRouterWrapper> veniceRouterWrappers = new HashMap<>();
     Map<String, String> nettyServerToGrpcAddress = new HashMap<>();
+    if (!options.getExtraProperties().containsKey(CONTROLLER_ENABLE_REAL_TIME_TOPIC_VERSIONING)) {
+      options.getExtraProperties()
+          .setProperty(
+              CONTROLLER_ENABLE_REAL_TIME_TOPIC_VERSIONING,
+              CONTROLLER_ENABLE_REAL_TIME_TOPIC_VERSIONING_IN_TESTS);
+    }
 
     Map<String, String> clusterToD2;
     if (options.getClusterToD2() == null || options.getClusterToD2().isEmpty()) {

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/integration/utils/VeniceClusterWrapper.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/integration/utils/VeniceClusterWrapper.java
@@ -1,6 +1,7 @@
 package com.linkedin.venice.integration.utils;
 
 import static com.linkedin.davinci.store.rocksdb.RocksDBServerConfig.ROCKSDB_PLAIN_TABLE_FORMAT_ENABLED;
+import static com.linkedin.venice.ConfigKeys.CONTROLLER_ENABLE_REAL_TIME_TOPIC_VERSIONING;
 import static com.linkedin.venice.ConfigKeys.DEFAULT_MAX_NUMBER_OF_PARTITIONS;
 import static com.linkedin.venice.ConfigKeys.ENABLE_GRPC_READ_SERVER;
 import static com.linkedin.venice.ConfigKeys.KAFKA_BOOTSTRAP_SERVERS;

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/integration/utils/VeniceMultiClusterWrapper.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/integration/utils/VeniceMultiClusterWrapper.java
@@ -1,5 +1,6 @@
 package com.linkedin.venice.integration.utils;
 
+import static com.linkedin.venice.ConfigKeys.CONTROLLER_ENABLE_REAL_TIME_TOPIC_VERSIONING;
 import static com.linkedin.venice.ConfigKeys.LOCAL_REGION_NAME;
 import static com.linkedin.venice.ConfigKeys.PARTICIPANT_MESSAGE_STORE_ENABLED;
 import static com.linkedin.venice.ConfigKeys.SYSTEM_SCHEMA_CLUSTER_NAME;
@@ -130,6 +131,9 @@ public class VeniceMultiClusterWrapper extends ProcessWrapper {
       }
       // Specify the system store cluster name
       Properties extraProperties = options.getExtraProperties();
+      extraProperties.setProperty(
+          CONTROLLER_ENABLE_REAL_TIME_TOPIC_VERSIONING,
+          VeniceClusterWrapper.CONTROLLER_ENABLE_REAL_TIME_TOPIC_VERSIONING_IN_TESTS);
       extraProperties.put(SYSTEM_SCHEMA_CLUSTER_NAME, clusterNames[0]);
       extraProperties.putAll(KafkaTestUtils.getLocalCommonKafkaSSLConfig(SslUtils.getTlsConfiguration()));
       pubBrokerDetails.forEach((key, value) -> extraProperties.putIfAbsent(key, value));

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/integration/utils/VeniceTwoLayerMultiRegionMultiClusterWrapper.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/integration/utils/VeniceTwoLayerMultiRegionMultiClusterWrapper.java
@@ -4,6 +4,7 @@ import static com.linkedin.venice.ConfigKeys.ACTIVE_ACTIVE_REAL_TIME_SOURCE_FABR
 import static com.linkedin.venice.ConfigKeys.ADMIN_TOPIC_SOURCE_REGION;
 import static com.linkedin.venice.ConfigKeys.AGGREGATE_REAL_TIME_SOURCE_REGION;
 import static com.linkedin.venice.ConfigKeys.CHILD_DATA_CENTER_KAFKA_URL_PREFIX;
+import static com.linkedin.venice.ConfigKeys.CONTROLLER_ENABLE_REAL_TIME_TOPIC_VERSIONING;
 import static com.linkedin.venice.ConfigKeys.KAFKA_CLUSTER_MAP_KEY_NAME;
 import static com.linkedin.venice.ConfigKeys.KAFKA_CLUSTER_MAP_KEY_OTHER_URLS;
 import static com.linkedin.venice.ConfigKeys.KAFKA_CLUSTER_MAP_KEY_URL;
@@ -83,6 +84,9 @@ public class VeniceTwoLayerMultiRegionMultiClusterWrapper extends ProcessWrapper
      */
     Properties defaultParentControllerProps = new Properties();
     defaultParentControllerProps.setProperty(PARTICIPANT_MESSAGE_STORE_ENABLED, "true");
+    defaultParentControllerProps.setProperty(
+        CONTROLLER_ENABLE_REAL_TIME_TOPIC_VERSIONING,
+        VeniceClusterWrapper.CONTROLLER_ENABLE_REAL_TIME_TOPIC_VERSIONING_IN_TESTS);
 
     ZkServerWrapper zkServer = null;
     PubSubBrokerWrapper parentPubSubBrokerWrapper = null;

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/server/StoresRoutes.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/server/StoresRoutes.java
@@ -512,7 +512,7 @@ public class StoresRoutes extends AbstractRoute {
   }
 
   /**
-   * @see Admin#deleteStore(String, String, int, boolean)
+   * @see Admin#deleteStore(String, String, boolean, int, boolean)
    */
   public Route deleteStore(Admin admin) {
     return new VeniceRouteHandler<TrackableControllerResponse>(TrackableControllerResponse.class) {

--- a/services/venice-controller/src/main/java/com/linkedin/venice/ingestion/control/RealTimeTopicSwitcher.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/ingestion/control/RealTimeTopicSwitcher.java
@@ -228,19 +228,24 @@ public class RealTimeTopicSwitcher {
         && topicManager.containsTopic(pubSubTopicRepository.getTopic(rtForPreviousVersion));
     boolean rtExistsForNextVersion =
         nextStoreVersion.isHybrid() && topicManager.containsTopic(pubSubTopicRepository.getTopic(rtForNextVersion));
+    LOGGER.info("Previous store version - {}, nextStoreVersion - {}, ");
 
     if (rtExistsForPreviousVersion || rtExistsForNextVersion) {
       if (rtExistsForPreviousVersion) {
         LOGGER.info(
-            "RT topic exists for store: {}, versionNum: {}. Broadcasting Version Swap message directly to RT.",
+            "RT topic exists for store: {}, versionNum: {}. Broadcasting Version Swap message directly to RT {} to switch to the next store version {}.",
             storeName,
-            previousVersion);
+            previousVersion,
+            rtForPreviousVersion,
+            nextVersion);
         broadcastVersionSwap(previousStoreVersion, nextStoreVersion, rtForPreviousVersion);
       }
       if (rtExistsForNextVersion && !rtForNextVersion.equals(rtForPreviousVersion)) {
         LOGGER.info(
-            "RT topic exists for store: {}, versionNum: {}. Broadcasting Version Swap message directly to RT.",
+            "RT topic exists for store: {}, versionNum: {}. Broadcasting Version Swap message directly to RT {} to switch to the next store version {}.",
             storeName,
+            nextVersion,
+            rtForNextVersion,
             nextVersion);
         // todo - when hybrid store repartition project completes, there can exist two different real time topics,
         // it is not clear yet, how to make CDC client, that depends on this `Version Swap` message, work in that case

--- a/services/venice-controller/src/main/java/com/linkedin/venice/ingestion/control/RealTimeTopicSwitcher.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/ingestion/control/RealTimeTopicSwitcher.java
@@ -222,7 +222,10 @@ public class RealTimeTopicSwitcher {
 
     // If there exists an RT, then broadcast the Version Swap message to it, otherwise broadcast it to the VT
     String storeName = store.getName();
-    if (!topicManager.containsTopic(pubSubTopicRepository.getTopic(Version.composeRealTimeTopic(storeName)))) {
+    boolean isNextStoreVersionHybrid = nextStoreVersion.isHybrid();
+    String nextStoreVersionRTTopic = Utils.getRealTimeTopicName(nextStoreVersion);
+    if (!(isNextStoreVersionHybrid
+        && topicManager.containsTopic(pubSubTopicRepository.getTopic(nextStoreVersionRTTopic)))) {
       // ToDo: Broadcast the Version Swap message to batch only view topics
       LOGGER.info("RT topic doesn't exist for store: {}. Broadcasting Version Swap message directly to VT.", storeName);
 
@@ -239,7 +242,7 @@ public class RealTimeTopicSwitcher {
       broadcastVersionSwap(previousStoreVersion, nextStoreVersion, nextStoreVersion.kafkaTopicName());
     } else {
       LOGGER.info("RT topic exists for store: {}. Broadcasting Version Swap message directly to RT.", storeName);
-      broadcastVersionSwap(previousStoreVersion, nextStoreVersion, Utils.getRealTimeTopicName(store));
+      broadcastVersionSwap(previousStoreVersion, nextStoreVersion, nextStoreVersionRTTopic);
     }
   }
 

--- a/services/venice-controller/src/main/java/com/linkedin/venice/ingestion/control/RealTimeTopicSwitcher.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/ingestion/control/RealTimeTopicSwitcher.java
@@ -242,6 +242,8 @@ public class RealTimeTopicSwitcher {
             "RT topic exists for store: {}, versionNum: {}. Broadcasting Version Swap message directly to RT.",
             storeName,
             nextVersion);
+        // todo - when hybrid store repartition project completes, there can exist two different real time topics,
+        // it is not clear yet, how to make CDC client, that depends on this `Version Swap` message, work in that case
         broadcastVersionSwap(previousStoreVersion, nextStoreVersion, rtForNextVersion);
       }
     } else {

--- a/services/venice-controller/src/test/java/com/linkedin/venice/controller/server/CreateVersionTest.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/controller/server/CreateVersionTest.java
@@ -229,7 +229,7 @@ public class CreateVersionTest {
     VersionCreationResponse versionCreateResponse =
         OBJECT_MAPPER.readValue(result.toString(), VersionCreationResponse.class);
     if (isSeparateTopicEnabled && pushToSeparateTopicEnabled) {
-      assertEquals(versionCreateResponse.getKafkaTopic(), Version.composeSeparateRealTimeTopic(STORE_NAME));
+      assertEquals(versionCreateResponse.getKafkaTopic(), Utils.getSeparateRealTimeTopicName(version));
     } else {
       assertEquals(versionCreateResponse.getKafkaTopic(), Utils.getRealTimeTopicName(store));
     }

--- a/services/venice-controller/src/test/java/com/linkedin/venice/ingestion/control/RealTimeTopicSwitcherTest.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/ingestion/control/RealTimeTopicSwitcherTest.java
@@ -7,6 +7,7 @@ import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
 import static org.mockito.Mockito.clearInvocations;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
@@ -133,10 +134,26 @@ public class RealTimeTopicSwitcherTest {
 
     Store mockStore = mock(Store.class);
     when(mockStore.getName()).thenReturn(storeName);
-    Version version1 = new VersionImpl(storeName, 1, "push1");
-    Version version2 = new VersionImpl(storeName, 2, "push2");
-    Version version3 = new VersionImpl(storeName, 3, "push3");
-    PubSubTopic realTimeTopic = pubSubTopicRepository.getTopic(Utils.getRealTimeTopicName(version1));
+    Version version1 = mock(Version.class, RETURNS_DEEP_STUBS);
+    Version version2 = mock(Version.class, RETURNS_DEEP_STUBS);
+    Version version3 = mock(Version.class, RETURNS_DEEP_STUBS);
+    when(version1.isHybrid()).thenReturn(true);
+    when(version2.isHybrid()).thenReturn(true);
+    when(version3.isHybrid()).thenReturn(true);
+    String realTimeTopicName = Utils.composeRealTimeTopic(storeName, 1);
+    when(version1.getNumber()).thenReturn(1);
+    when(version2.getNumber()).thenReturn(2);
+    when(version3.getNumber()).thenReturn(3);
+    when(version1.getStoreName()).thenReturn(storeName);
+    when(version2.getStoreName()).thenReturn(storeName);
+    when(version3.getStoreName()).thenReturn(storeName);
+    when(version1.kafkaTopicName()).thenReturn(Version.composeKafkaTopic(storeName, 1));
+    when(version2.kafkaTopicName()).thenReturn(Version.composeKafkaTopic(storeName, 2));
+    when(version3.kafkaTopicName()).thenReturn(Version.composeKafkaTopic(storeName, 3));
+    when(version1.getHybridStoreConfig().getRealTimeTopicName()).thenReturn(realTimeTopicName);
+    when(version2.getHybridStoreConfig().getRealTimeTopicName()).thenReturn(realTimeTopicName);
+    when(version3.getHybridStoreConfig().getRealTimeTopicName()).thenReturn(realTimeTopicName);
+    PubSubTopic realTimeTopic = pubSubTopicRepository.getTopic(realTimeTopicName);
 
     when(mockStore.getVersionOrThrow(1)).thenReturn(version1);
     when(mockStore.getVersionOrThrow(2)).thenReturn(version2);


### PR DESCRIPTION
<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat], [protocol]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## Problem Statement
<!--
Describe
- What problem are you trying to solve
- What issues or limitations exist in the current code
- Why this change is necessary 
-->
Use RT versioning in all the tests run. more on this feature is in https://github.com/linkedin/venice/pull/1555
Fixed a bug in RealTimeTopicSwitcher, in finding using RT topic name correctly.
Also fixed a bug in parseStoreFromRealTimeTopic in finding store from separate rt.

There are five scenarios where we have to consider where to send version swap message to.
1) both previous and next versions are batch - we can continue sending the VSM to the next vt topic, even though it is not required and does not serve any use case for CDC client **no change here**
2) prev version is batch and next version is hybrid - current code sends VSM to the RT (the only RT it thinks can exist), and this PR's change will send VSM to both RTs, **no change here** except that a VSM is written unnecessarily
3) prev version is hybrid and the next version is batch - **same as case 2**
4) both versions are hybrid and using the same RT - VSM will continue to be written to the RT **no change here**
5) both versions are hybrid and using different RTs - now we will send VSM to both the RTs, but this is not ideal for the CDC client that consumes this message, added a todo to handle it later when we actually start creating a new RT for partition count change (hybrid repartitioning project)

## Solution
<!--
Describe
- What changes you are making and why. 
- How these changes solve the problem.
- Any performance considerations or trade-offs. 
- Describe what testings you have done, for example, performance testing etc.
-->


###  Code changes
- [ ] Added new code behind **a config**. If so list the config names and their default values in the PR description.
- [ ] Introduced new **log lines**. 
  - [ ] Confirmed if logs need to be **rate limited** to avoid excessive logging.

###  **Concurrency-Specific Checks**
Both reviewer and PR author to verify
- [ ] Code has **no race conditions** or **thread safety issues**.
- [ ] Proper **synchronization mechanisms** (e.g., `synchronized`, `RWLock`) are used where needed.
- [ ] No **blocking calls** inside critical sections that could lead to deadlocks or performance degradation.
- [ ] Verified **thread-safe collections** are used (e.g., `ConcurrentHashMap`, `CopyOnWriteArrayList`).
- [ ] Validated proper exception handling in multi-threaded code to avoid silent thread termination.


## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->

- [ ] New unit tests added.
- [ ] New integration tests added.
- [ ] Modified or extended existing tests.
- [ ] Verified backward compatibility (if applicable).

## Does this PR introduce any user-facing or breaking changes?
<!--  
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [ ] No. You can skip the rest of this section.
- [ ] Yes. Clearly explain the behavior change and its impact.