### PR TITLE
[server][controller][vpj][dvc][cc] Pass PubSubPositionTypeRegistry to admin clients

### DIFF
--- a/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/PubSubAdminAdapterContext.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/PubSubAdminAdapterContext.java
@@ -1,0 +1,120 @@
+package com.linkedin.venice.pubsub;
+
+import com.linkedin.venice.pubsub.api.PubSubSecurityProtocol;
+import com.linkedin.venice.utils.VeniceProperties;
+import io.tehuti.metrics.MetricsRepository;
+
+
+public class PubSubAdminAdapterContext {
+  private final String pubSubBrokerAddress;
+  private final String adminClientName;
+  private final VeniceProperties veniceProperties;
+  private final PubSubTopicRepository pubSubTopicRepository;
+  private final PubSubPositionTypeRegistry pubSubPositionTypeRegistry;
+  private final PubSubSecurityProtocol pubSubSecurityProtocol;
+  private final MetricsRepository metricsRepository;
+
+  private PubSubAdminAdapterContext(Builder builder) {
+    this.pubSubBrokerAddress = builder.pubSubBrokerAddress;
+    this.adminClientName = builder.adminClientName;
+    this.veniceProperties = builder.veniceProperties;
+    this.pubSubTopicRepository = builder.pubSubTopicRepository;
+    this.pubSubSecurityProtocol = builder.pubSubSecurityProtocol;
+    this.metricsRepository = builder.metricsRepository;
+    this.pubSubPositionTypeRegistry = builder.pubSubPositionTypeRegistry;
+  }
+
+  public String getPubSubBrokerAddress() {
+    return pubSubBrokerAddress;
+  }
+
+  public VeniceProperties getVeniceProperties() {
+    return veniceProperties;
+  }
+
+  public PubSubTopicRepository getPubSubTopicRepository() {
+    return pubSubTopicRepository;
+  }
+
+  public String getAdminClientName() {
+    return adminClientName;
+  }
+
+  public MetricsRepository getMetricsRepository() {
+    return metricsRepository;
+  }
+
+  public PubSubSecurityProtocol getPubSubSecurityProtocol() {
+    return pubSubSecurityProtocol;
+  }
+
+  public PubSubPositionTypeRegistry getPubSubPositionTypeRegistry() {
+    return pubSubPositionTypeRegistry;
+  }
+
+  public static class Builder {
+    private String pubSubBrokerAddress;
+    private String adminClientName;
+    private VeniceProperties veniceProperties;
+    private PubSubSecurityProtocol pubSubSecurityProtocol;
+    private PubSubTopicRepository pubSubTopicRepository;
+    private PubSubPositionTypeRegistry pubSubPositionTypeRegistry;
+    private MetricsRepository metricsRepository;
+
+    public Builder setPubSubBrokerAddress(String pubSubBrokerAddress) {
+      this.pubSubBrokerAddress = pubSubBrokerAddress;
+      return this;
+    }
+
+    public Builder setAdminClientName(String adminClientName) {
+      this.adminClientName = adminClientName;
+      return this;
+    }
+
+    public Builder setVeniceProperties(VeniceProperties veniceProperties) {
+      this.veniceProperties = veniceProperties;
+      return this;
+    }
+
+    public Builder setPubSubTopicRepository(PubSubTopicRepository pubSubTopicRepository) {
+      this.pubSubTopicRepository = pubSubTopicRepository;
+      return this;
+    }
+
+    public Builder setMetricsRepository(MetricsRepository metricsRepository) {
+      this.metricsRepository = metricsRepository;
+      return this;
+    }
+
+    public Builder setPubSubSecurityProtocol(PubSubSecurityProtocol pubSubSecurityProtocol) {
+      this.pubSubSecurityProtocol = pubSubSecurityProtocol;
+      return this;
+    }
+
+    public Builder setPubSubPositionTypeRegistry(PubSubPositionTypeRegistry pubSubPositionTypeRegistry) {
+      this.pubSubPositionTypeRegistry = pubSubPositionTypeRegistry;
+      return this;
+    }
+
+    public PubSubAdminAdapterContext build() {
+      if (veniceProperties == null) {
+        throw new IllegalArgumentException("Missing required properties. Please specify the properties.");
+      }
+      if (pubSubBrokerAddress == null) {
+        pubSubBrokerAddress = PubSubUtil.getPubSubBrokerAddressOrFail(veniceProperties);
+      }
+      if (pubSubTopicRepository == null) {
+        throw new IllegalArgumentException("Missing required topic repository. Please specify the topic repository.");
+      }
+      if (pubSubPositionTypeRegistry == null) {
+        throw new IllegalArgumentException(
+            "Missing required position type registry. Please specify the position type registry.");
+      }
+      if (pubSubSecurityProtocol == null) {
+        pubSubSecurityProtocol = PubSubUtil.getPubSubSecurityProtocolOrDefault(veniceProperties);
+      }
+      adminClientName = PubSubUtil.generatePubSubClientId(PubSubClientType.ADMIN, adminClientName, pubSubBrokerAddress);
+      return new PubSubAdminAdapterContext(this);
+    }
+  }
+}

--- a/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/PubSubAdminAdapterFactory.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/PubSubAdminAdapterFactory.java
@@ -1,8 +1,6 @@
 package com.linkedin.venice.pubsub;
 
 import com.linkedin.venice.pubsub.api.PubSubAdminAdapter;
-import com.linkedin.venice.pubsub.api.PubSubTopic;
-import com.linkedin.venice.utils.VeniceProperties;
 import java.io.Closeable;
 
 
@@ -23,14 +21,11 @@ public abstract class PubSubAdminAdapterFactory<ADAPTER extends PubSubAdminAdapt
   }
 
   /**
-   *
-   * @param veniceProperties            A copy of venice properties. Relevant producer configs will be extracted from
-   *                                    veniceProperties using prefix matching. For example, to construct kafka producer
-   *                                    configs that start with "kafka." prefix will be used.
-   * @param pubSubTopicRepository       A repo to cache created {@link PubSubTopic}s.
-   * @return                            Returns an instance of an admin adapter
+   * Creates a PubSub admin adapter.
+   * @param adminAdapterContext The context containing all dependencies and configurations required to create an admin adapter.
+   * @return An instance of the PubSub admin adapter.
    */
-  public abstract ADAPTER create(VeniceProperties veniceProperties, PubSubTopicRepository pubSubTopicRepository);
+  public abstract ADAPTER create(PubSubAdminAdapterContext adminAdapterContext);
 
   public abstract String getName();
 }

--- a/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/adapter/kafka/ApacheKafkaUtils.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/adapter/kafka/ApacheKafkaUtils.java
@@ -99,11 +99,11 @@ public class ApacheKafkaUtils {
         extractedValidProperties.put(configKey, configVal);
       }
     });
-    extractedValidProperties.put(CommonClientConfigs.SECURITY_PROTOCOL_CONFIG, securityProtocol.name());
 
     // Step 3: Copy SSL-related properties. These properties are mandatory if SSL is enabled,
     // but they typically do not have prefixes.
     validateAndCopyKafkaSSLConfig(securityProtocol, veniceProperties, extractedValidProperties);
+    extractedValidProperties.put(CommonClientConfigs.SECURITY_PROTOCOL_CONFIG, securityProtocol.name());
     return extractedValidProperties;
   }
 

--- a/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/adapter/kafka/ApacheKafkaUtils.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/adapter/kafka/ApacheKafkaUtils.java
@@ -99,12 +99,11 @@ public class ApacheKafkaUtils {
         extractedValidProperties.put(configKey, configVal);
       }
     });
+    extractedValidProperties.put(CommonClientConfigs.SECURITY_PROTOCOL_CONFIG, securityProtocol.name());
 
     // Step 3: Copy SSL-related properties. These properties are mandatory if SSL is enabled,
     // but they typically do not have prefixes.
     validateAndCopyKafkaSSLConfig(securityProtocol, veniceProperties, extractedValidProperties);
-
-    extractedValidProperties.put(CommonClientConfigs.SECURITY_PROTOCOL_CONFIG, securityProtocol.name());
     return extractedValidProperties;
   }
 
@@ -119,10 +118,6 @@ public class ApacheKafkaUtils {
       PubSubSecurityProtocol securityProtocol,
       VeniceProperties veniceProperties,
       Properties properties) {
-    if (securityProtocol == null) {
-      // No security protocol specified
-      return false;
-    }
     String kafkaProtocol = securityProtocol.name();
     if (!isKafkaProtocolValid(kafkaProtocol)) {
       throw new VeniceException("Invalid Kafka protocol specified: " + kafkaProtocol);
@@ -150,33 +145,5 @@ public class ApacheKafkaUtils {
         || kafkaProtocol.equals(PubSubSecurityProtocol.SSL.name())
         || kafkaProtocol.equals(PubSubSecurityProtocol.SASL_PLAINTEXT.name())
         || kafkaProtocol.equals(PubSubSecurityProtocol.SASL_SSL.name());
-  }
-
-  /**
-   * Generates a standardized and unique client ID for Kafka clients.
-   *
-   * <p>
-   * This ensures uniqueness in client IDs, preventing naming collisions that could cause
-   * `InstanceAlreadyExistsException` during JMX metric registration. If multiple Kafka clients
-   * share the same client ID, Kafka's internal JMX registration can fail, leading to errors.
-   * By appending a timestamp, this method guarantees that each generated ID is unique.
-   * </p>
-   *
-   * <p>
-   * If the provided client name is null, it defaults to "kc".
-   * If the broker address is null, it defaults to an empty string.
-   * The generated client ID follows the format:
-   * <pre>{@code clientName-brokerAddress-timestamp}</pre>
-   * </p>
-   *
-   * @param clientName    The name of the client (can be null, defaults to "kc").
-   * @param brokerAddress The broker address (can be null, defaults to an empty string).
-   * @return A unique client ID in the format: {@code clientName-brokerAddress-timestamp}.
-   */
-  public static String generateClientId(String clientName, String brokerAddress) {
-    String resolvedClientName = (clientName != null) ? clientName : "kc";
-    String resolvedBrokerAddress = (brokerAddress != null) ? brokerAddress : "";
-
-    return String.format("%s-%s-%d", resolvedClientName, resolvedBrokerAddress, System.currentTimeMillis());
   }
 }

--- a/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/adapter/kafka/admin/ApacheKafkaAdminAdapter.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/adapter/kafka/admin/ApacheKafkaAdminAdapter.java
@@ -57,26 +57,20 @@ public class ApacheKafkaAdminAdapter implements PubSubAdminAdapter {
   private final ApacheKafkaAdminConfig apacheKafkaAdminConfig;
   private final PubSubTopicRepository pubSubTopicRepository;
 
-  public ApacheKafkaAdminAdapter(
-      ApacheKafkaAdminConfig apacheKafkaAdminConfig,
-      PubSubTopicRepository pubSubTopicRepository) {
+  public ApacheKafkaAdminAdapter(ApacheKafkaAdminConfig apacheKafkaAdminConfig) {
     this(
         AdminClient.create(
             Objects.requireNonNull(
                 apacheKafkaAdminConfig.getAdminProperties(),
                 "Properties for kafka admin construction cannot be null!")),
-        apacheKafkaAdminConfig,
-        pubSubTopicRepository);
+        apacheKafkaAdminConfig);
   }
 
-  ApacheKafkaAdminAdapter(
-      AdminClient internalKafkaAdminClient,
-      ApacheKafkaAdminConfig apacheKafkaAdminConfig,
-      PubSubTopicRepository pubSubTopicRepository) {
+  ApacheKafkaAdminAdapter(AdminClient internalKafkaAdminClient, ApacheKafkaAdminConfig apacheKafkaAdminConfig) {
     this.apacheKafkaAdminConfig = Objects.requireNonNull(apacheKafkaAdminConfig, "Kafka admin config cannot be null!");
     this.internalKafkaAdminClient =
         Objects.requireNonNull(internalKafkaAdminClient, "Kafka admin client cannot be null!");
-    this.pubSubTopicRepository = pubSubTopicRepository;
+    this.pubSubTopicRepository = apacheKafkaAdminConfig.getPubSubTopicRepository();
     LOGGER.info("Created ApacheKafkaAdminAdapter with config: {}", apacheKafkaAdminConfig);
   }
 

--- a/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/adapter/kafka/admin/ApacheKafkaAdminAdapterFactory.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/adapter/kafka/admin/ApacheKafkaAdminAdapterFactory.java
@@ -1,10 +1,9 @@
 package com.linkedin.venice.pubsub.adapter.kafka.admin;
 
+import com.linkedin.venice.pubsub.PubSubAdminAdapterContext;
 import com.linkedin.venice.pubsub.PubSubAdminAdapterFactory;
 import com.linkedin.venice.pubsub.PubSubProducerAdapterFactory;
-import com.linkedin.venice.pubsub.PubSubTopicRepository;
 import com.linkedin.venice.pubsub.api.PubSubAdminAdapter;
-import com.linkedin.venice.utils.VeniceProperties;
 import java.io.IOException;
 
 
@@ -25,10 +24,8 @@ public class ApacheKafkaAdminAdapterFactory extends PubSubAdminAdapterFactory<Pu
   }
 
   @Override
-  public PubSubAdminAdapter create(VeniceProperties veniceProperties, PubSubTopicRepository pubSubTopicRepository) {
-    ApacheKafkaAdminConfig apacheKafkaAdminConfig = new ApacheKafkaAdminConfig(veniceProperties);
-    PubSubAdminAdapter pubSubAdminAdapter = new ApacheKafkaAdminAdapter(apacheKafkaAdminConfig, pubSubTopicRepository);
-    return pubSubAdminAdapter;
+  public PubSubAdminAdapter create(PubSubAdminAdapterContext adminAdapterContext) {
+    return new ApacheKafkaAdminAdapter(new ApacheKafkaAdminConfig(adminAdapterContext));
   }
 
   @Override

--- a/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/manager/TopicManager.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/manager/TopicManager.java
@@ -92,7 +92,7 @@ public class TopicManager implements Closeable {
                 .setPubSubPositionTypeRegistry(context.getPubSubPositionTypeRegistry())
                 .setMetricsRepository(context.getMetricsRepository())
                 .setVeniceProperties(context.getPubSubProperties(pubSubClusterAddress))
-                .setAdminClientName("TM")
+                .setAdminClientName("TopicManager")
                 .build());
     this.topicMetadataFetcher = new TopicMetadataFetcher(pubSubClusterAddress, context, stats, pubSubAdminAdapter);
     this.logger.info(

--- a/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/manager/TopicManager.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/manager/TopicManager.java
@@ -92,7 +92,7 @@ public class TopicManager implements Closeable {
                 .setPubSubPositionTypeRegistry(context.getPubSubPositionTypeRegistry())
                 .setMetricsRepository(context.getMetricsRepository())
                 .setVeniceProperties(context.getPubSubProperties(pubSubClusterAddress))
-                .setAdminClientName("TopicManager")
+                .setAdminClientName("TM")
                 .build());
     this.topicMetadataFetcher = new TopicMetadataFetcher(pubSubClusterAddress, context, stats, pubSubAdminAdapter);
     this.logger.info(

--- a/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/manager/TopicManager.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/manager/TopicManager.java
@@ -20,6 +20,7 @@ import static com.linkedin.venice.pubsub.manager.TopicManagerStats.SENSOR_TYPE.S
 import com.github.benmanes.caffeine.cache.Cache;
 import com.github.benmanes.caffeine.cache.Caffeine;
 import com.linkedin.venice.exceptions.VeniceException;
+import com.linkedin.venice.pubsub.PubSubAdminAdapterContext;
 import com.linkedin.venice.pubsub.PubSubConstants;
 import com.linkedin.venice.pubsub.PubSubTopicConfiguration;
 import com.linkedin.venice.pubsub.PubSubTopicPartitionImpl;
@@ -86,7 +87,13 @@ public class TopicManager implements Closeable {
     this.stats = new TopicManagerStats(context.getMetricsRepository(), pubSubClusterAddress);
     this.pubSubTopicRepository = context.getPubSubTopicRepository();
     this.pubSubAdminAdapter = context.getPubSubAdminAdapterFactory()
-        .create(context.getPubSubProperties(pubSubClusterAddress), pubSubTopicRepository);
+        .create(
+            new PubSubAdminAdapterContext.Builder().setPubSubTopicRepository(context.getPubSubTopicRepository())
+                .setPubSubPositionTypeRegistry(context.getPubSubPositionTypeRegistry())
+                .setMetricsRepository(context.getMetricsRepository())
+                .setVeniceProperties(context.getPubSubProperties(pubSubClusterAddress))
+                .setAdminClientName("TM")
+                .build());
     this.topicMetadataFetcher = new TopicMetadataFetcher(pubSubClusterAddress, context, stats, pubSubAdminAdapter);
     this.logger.info(
         "Created a topic manager for the pubsub cluster address: {} with context: {}",

--- a/internal/venice-common/src/test/java/com/linkedin/venice/pubsub/PubSubAdminAdapterContextTest.java
+++ b/internal/venice-common/src/test/java/com/linkedin/venice/pubsub/PubSubAdminAdapterContextTest.java
@@ -1,0 +1,91 @@
+package com.linkedin.venice.pubsub;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.expectThrows;
+
+import com.linkedin.venice.ConfigKeys;
+import com.linkedin.venice.pubsub.api.PubSubSecurityProtocol;
+import com.linkedin.venice.utils.VeniceProperties;
+import io.tehuti.metrics.MetricsRepository;
+import java.util.Properties;
+import org.testng.annotations.Test;
+
+
+public class PubSubAdminAdapterContextTest {
+  @Test
+  public void testBuildWithAllRequiredFields() {
+    VeniceProperties props = new VeniceProperties(new Properties());
+    PubSubAdminAdapterContext context = new PubSubAdminAdapterContext.Builder().setVeniceProperties(props)
+        .setPubSubBrokerAddress("localhost:1234")
+        .setAdminClientName("admin-client")
+        .setPubSubTopicRepository(new PubSubTopicRepository())
+        .setPubSubPositionTypeRegistry(PubSubPositionTypeRegistry.RESERVED_POSITION_TYPE_REGISTRY)
+        .setPubSubSecurityProtocol(PubSubSecurityProtocol.SSL)
+        .setMetricsRepository(new MetricsRepository())
+        .build();
+
+    assertEquals(context.getPubSubBrokerAddress(), "localhost:1234");
+    assertEquals(context.getAdminClientName().contains("admin-client"), true);
+    assertEquals(context.getPubSubSecurityProtocol(), PubSubSecurityProtocol.SSL);
+    assertNotNull(context.getMetricsRepository());
+    assertNotNull(context.getVeniceProperties());
+    assertNotNull(context.getPubSubTopicRepository());
+    assertNotNull(context.getPubSubPositionTypeRegistry());
+  }
+
+  @Test
+  public void testMissingVenicePropertiesThrows() {
+    IllegalArgumentException exception = expectThrows(
+        IllegalArgumentException.class,
+        () -> new PubSubAdminAdapterContext.Builder().setPubSubTopicRepository(new PubSubTopicRepository())
+            .setPubSubPositionTypeRegistry(PubSubPositionTypeRegistry.RESERVED_POSITION_TYPE_REGISTRY)
+            .build());
+    assertTrue(exception.getMessage().contains("Missing required properties"));
+  }
+
+  @Test
+  public void testMissingTopicRepositoryThrows() {
+    Properties rawProps = new Properties();
+    rawProps.setProperty(ConfigKeys.PUBSUB_BROKER_ADDRESS, "localhost:1234");
+    VeniceProperties props = new VeniceProperties(rawProps);
+    IllegalArgumentException exception = expectThrows(
+        IllegalArgumentException.class,
+        () -> new PubSubAdminAdapterContext.Builder().setVeniceProperties(props)
+            .setPubSubPositionTypeRegistry(PubSubPositionTypeRegistry.RESERVED_POSITION_TYPE_REGISTRY)
+            .build());
+    assertTrue(exception.getMessage().contains("Missing required topic repository"), "Got: " + exception.getMessage());
+  }
+
+  @Test
+  public void testMissingRegistryThrows() {
+    Properties rawProps = new Properties();
+    rawProps.setProperty(ConfigKeys.PUBSUB_BROKER_ADDRESS, "localhost:1234");
+    VeniceProperties props = new VeniceProperties(rawProps);
+    IllegalArgumentException exception = expectThrows(
+        IllegalArgumentException.class,
+        () -> new PubSubAdminAdapterContext.Builder().setVeniceProperties(props)
+            .setPubSubTopicRepository(new PubSubTopicRepository())
+            .build());
+    assertTrue(
+        exception.getMessage().contains("Missing required position type registry"),
+        "Got: " + exception.getMessage());
+  }
+
+  @Test
+  public void testDefaultSecurityProtocolAndBrokerFromProps() {
+    Properties rawProps = new Properties();
+    rawProps.setProperty("pubsub.broker.address", "localhost:4567");
+    VeniceProperties props = new VeniceProperties(rawProps);
+
+    PubSubAdminAdapterContext context = new PubSubAdminAdapterContext.Builder().setVeniceProperties(props)
+        .setPubSubTopicRepository(new PubSubTopicRepository())
+        .setPubSubPositionTypeRegistry(PubSubPositionTypeRegistry.RESERVED_POSITION_TYPE_REGISTRY)
+        .build();
+
+    assertEquals(context.getPubSubBrokerAddress(), "localhost:4567");
+    assertEquals(context.getPubSubSecurityProtocol(), PubSubSecurityProtocol.PLAINTEXT); // default
+    assertTrue(context.getAdminClientName().startsWith("ADMIN--"));
+  }
+}

--- a/internal/venice-common/src/test/java/com/linkedin/venice/pubsub/PubSubClientsFactoryTest.java
+++ b/internal/venice-common/src/test/java/com/linkedin/venice/pubsub/PubSubClientsFactoryTest.java
@@ -122,9 +122,9 @@ public class PubSubClientsFactoryTest {
     }
   }
 
-  protected static class TestPubSubAdminAdapterFactory extends PubSubAdminAdapterFactory {
+  protected static class TestPubSubAdminAdapterFactory extends PubSubAdminAdapterFactory<PubSubAdminAdapter> {
     @Override
-    public PubSubAdminAdapter create(VeniceProperties veniceProperties, PubSubTopicRepository pubSubTopicRepository) {
+    public PubSubAdminAdapter create(PubSubAdminAdapterContext context) {
       return null;
     }
 

--- a/internal/venice-common/src/test/java/com/linkedin/venice/pubsub/adapter/kafka/ApacheKafkaUtilsTest.java
+++ b/internal/venice-common/src/test/java/com/linkedin/venice/pubsub/adapter/kafka/ApacheKafkaUtilsTest.java
@@ -3,7 +3,6 @@ package com.linkedin.venice.pubsub.adapter.kafka;
 import static com.linkedin.venice.pubsub.adapter.kafka.ApacheKafkaUtils.KAFKA_SSL_MANDATORY_CONFIGS;
 import static com.linkedin.venice.pubsub.adapter.kafka.producer.ApacheKafkaProducerConfig.KAFKA_PRODUCER_CONFIG_PREFIXES;
 import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertNotEquals;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertSame;
 import static org.testng.Assert.assertThrows;
@@ -61,36 +60,6 @@ public class ApacheKafkaUtilsTest {
       assertTrue(headerMap.containsKey(header.key()));
       assertEquals(header.value(), headerMap.get(header.key()).getBytes());
     }
-  }
-
-  @Test
-  public void testGenerateClientId() throws InterruptedException {
-    // Case 1: Both clientName and brokerAddress are provided
-    String clientId1 = ApacheKafkaUtils.generateClientId("consumerA", "broker-123");
-    assertNotNull(clientId1, "Client ID should not be null");
-    assertTrue(clientId1.startsWith("consumerA-broker-123-"), "Client ID format is incorrect");
-
-    // Case 2: Only clientName is provided
-    String clientId2 = ApacheKafkaUtils.generateClientId("consumerB", null);
-    assertNotNull(clientId2, "Client ID should not be null");
-    assertTrue(clientId2.startsWith("consumerB--"), "Client ID format is incorrect");
-
-    // Case 3: Only brokerAddress is provided
-    String clientId3 = ApacheKafkaUtils.generateClientId(null, "broker-456");
-    assertNotNull(clientId3, "Client ID should not be null");
-    assertTrue(clientId3.startsWith("kc-broker-456-"), "Client ID format is incorrect");
-
-    // Case 4: Both parameters are null (defaults should be used)
-    String clientId4 = ApacheKafkaUtils.generateClientId(null, null);
-    assertNotNull(clientId4, "Client ID should not be null");
-    assertTrue(clientId4.startsWith("kc--"), "Client ID format is incorrect");
-
-    // Case 5: Ensure uniqueness between two generated IDs
-    String clientId5 = ApacheKafkaUtils.generateClientId("consumerC", "broker-789");
-    Thread.sleep(1); // Ensure timestamp difference
-    String clientId6 = ApacheKafkaUtils.generateClientId("consumerC", "broker-789");
-
-    assertNotEquals(clientId5, clientId6, "Generated Client IDs should be unique");
   }
 
   @Test

--- a/internal/venice-common/src/test/java/com/linkedin/venice/pubsub/adapter/kafka/admin/ApacheKafkaAdminAdapterTest.java
+++ b/internal/venice-common/src/test/java/com/linkedin/venice/pubsub/adapter/kafka/admin/ApacheKafkaAdminAdapterTest.java
@@ -79,8 +79,8 @@ public class ApacheKafkaAdminAdapterTest {
     pubSubTopicRepository = new PubSubTopicRepository();
     testPubSubTopic = pubSubTopicRepository.getTopic("test-topic");
     apacheKafkaAdminConfig = mock(ApacheKafkaAdminConfig.class);
-    kafkaAdminAdapter =
-        new ApacheKafkaAdminAdapter(internalKafkaAdminClientMock, apacheKafkaAdminConfig, pubSubTopicRepository);
+    when(apacheKafkaAdminConfig.getPubSubTopicRepository()).thenReturn(pubSubTopicRepository);
+    kafkaAdminAdapter = new ApacheKafkaAdminAdapter(internalKafkaAdminClientMock, apacheKafkaAdminConfig);
     sampleTopicConfiguration = new PubSubTopicConfiguration(
         Optional.of(Duration.ofDays(3).toMillis()),
         true,

--- a/internal/venice-common/src/test/java/com/linkedin/venice/pubsub/adapter/kafka/admin/ApacheKafkaAdminConfigTest.java
+++ b/internal/venice-common/src/test/java/com/linkedin/venice/pubsub/adapter/kafka/admin/ApacheKafkaAdminConfigTest.java
@@ -4,6 +4,9 @@ import static com.linkedin.venice.pubsub.adapter.kafka.admin.ApacheKafkaAdminCon
 import static com.linkedin.venice.pubsub.adapter.kafka.producer.ApacheKafkaProducerConfig.KAFKA_CONFIG_PREFIX;
 import static org.testng.Assert.assertEquals;
 
+import com.linkedin.venice.pubsub.PubSubAdminAdapterContext;
+import com.linkedin.venice.pubsub.PubSubPositionTypeRegistry;
+import com.linkedin.venice.pubsub.PubSubTopicRepository;
 import com.linkedin.venice.pubsub.adapter.kafka.ApacheKafkaUtils;
 import com.linkedin.venice.pubsub.api.PubSubSecurityProtocol;
 import com.linkedin.venice.utils.VeniceProperties;
@@ -19,6 +22,9 @@ public class ApacheKafkaAdminConfigTest {
       "org.apache.kafka.common.security.plain.PlainLoginModule required " + "username=\"foo\" password=\"bar\"\n";
 
   private static final String SASL_MECHANISM = "PLAIN";
+  private static final PubSubTopicRepository TOPIC_REPOSITORY = new PubSubTopicRepository();
+  private static final PubSubPositionTypeRegistry TYPE_REGISTRY =
+      PubSubPositionTypeRegistry.RESERVED_POSITION_TYPE_REGISTRY;
 
   @Test
   public void testSetupSaslInKafkaAdminPlaintext() {
@@ -51,7 +57,13 @@ public class ApacheKafkaAdminConfigTest {
       properties.put("kafka.ssl.secure.random.implementation", "SHA1PRNG");
     }
     VeniceProperties veniceProperties = new VeniceProperties(properties);
-    ApacheKafkaAdminConfig serverConfig = new ApacheKafkaAdminConfig(veniceProperties);
+    ApacheKafkaAdminConfig serverConfig = new ApacheKafkaAdminConfig(
+        new PubSubAdminAdapterContext.Builder().setVeniceProperties(veniceProperties)
+            .setPubSubSecurityProtocol(securityProtocol)
+            .setPubSubTopicRepository(TOPIC_REPOSITORY)
+            .setPubSubPositionTypeRegistry(TYPE_REGISTRY)
+            .setAdminClientName("testAdminClient")
+            .build());
     Properties adminProperties = serverConfig.getAdminProperties();
     assertEquals(SASL_JAAS_CONFIG, adminProperties.get("sasl.jaas.config"));
     assertEquals(SASL_MECHANISM, adminProperties.get("sasl.mechanism"));

--- a/internal/venice-common/src/test/java/com/linkedin/venice/pubsub/manager/TopicManagerTest.java
+++ b/internal/venice-common/src/test/java/com/linkedin/venice/pubsub/manager/TopicManagerTest.java
@@ -29,6 +29,7 @@ import com.linkedin.venice.meta.HybridStoreConfig;
 import com.linkedin.venice.meta.HybridStoreConfigImpl;
 import com.linkedin.venice.meta.Store;
 import com.linkedin.venice.meta.ZKStore;
+import com.linkedin.venice.pubsub.PubSubAdminAdapterContext;
 import com.linkedin.venice.pubsub.PubSubAdminAdapterFactory;
 import com.linkedin.venice.pubsub.PubSubConstants;
 import com.linkedin.venice.pubsub.PubSubConstantsOverrider;
@@ -107,7 +108,7 @@ public class TopicManagerTest {
     inMemoryKafkaBroker = new InMemoryKafkaBroker("local");
     PubSubAdminAdapterFactory pubSubAdminAdapterFactory = mock(ApacheKafkaAdminAdapterFactory.class);
     MockInMemoryAdminAdapter mockInMemoryAdminAdapter = new MockInMemoryAdminAdapter(inMemoryKafkaBroker);
-    doReturn(mockInMemoryAdminAdapter).when(pubSubAdminAdapterFactory).create(any(), eq(pubSubTopicRepository));
+    doReturn(mockInMemoryAdminAdapter).when(pubSubAdminAdapterFactory).create(any(PubSubAdminAdapterContext.class));
     MockInMemoryConsumer mockInMemoryConsumer =
         new MockInMemoryConsumer(inMemoryKafkaBroker, new RandomPollStrategy(), mock(PubSubConsumerAdapter.class));
     mockInMemoryConsumer.setMockInMemoryAdminAdapter(mockInMemoryAdminAdapter);
@@ -569,7 +570,7 @@ public class TopicManagerTest {
     PubSubConsumerAdapterFactory consumerAdapterFactory = mock(PubSubConsumerAdapterFactory.class);
     PubSubConsumerAdapter mockPubSubConsumer = mock(PubSubConsumerAdapter.class);
     doReturn(mockPubSubConsumer).when(consumerAdapterFactory).create(any(PubSubConsumerAdapterContext.class));
-    doReturn(mockPubSubAdminAdapter).when(adminAdapterFactory).create(any(), eq(pubSubTopicRepository));
+    doReturn(mockPubSubAdminAdapter).when(adminAdapterFactory).create(any(PubSubAdminAdapterContext.class));
 
     PubSubTopicConfiguration topicProperties =
         new PubSubTopicConfiguration(Optional.of(TimeUnit.DAYS.toMillis(1)), true, Optional.of(1), 4L, Optional.of(5L));
@@ -633,7 +634,7 @@ public class TopicManagerTest {
     PubSubAdminAdapterFactory adminAdapterFactory = mock(PubSubAdminAdapterFactory.class);
     PubSubConsumerAdapterFactory consumerAdapterFactory = mock(PubSubConsumerAdapterFactory.class);
     doReturn(mockPubSubConsumer).when(consumerAdapterFactory).create(any(PubSubConsumerAdapterContext.class));
-    doReturn(mockPubSubAdminAdapter).when(adminAdapterFactory).create(any(), eq(pubSubTopicRepository));
+    doReturn(mockPubSubAdminAdapter).when(adminAdapterFactory).create(any(PubSubAdminAdapterContext.class));
 
     Properties properties = new Properties();
     properties.put(ConfigKeys.KAFKA_BOOTSTRAP_SERVERS, "localhost:1234");

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestDeferredVersionSwap.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestDeferredVersionSwap.java
@@ -25,7 +25,6 @@ import com.linkedin.venice.client.store.AvroGenericStoreClient;
 import com.linkedin.venice.client.store.ClientConfig;
 import com.linkedin.venice.client.store.ClientFactory;
 import com.linkedin.venice.client.store.StatTrackingStoreClient;
-import com.linkedin.venice.common.VeniceSystemStoreType;
 import com.linkedin.venice.controllerapi.ControllerClient;
 import com.linkedin.venice.controllerapi.ControllerResponse;
 import com.linkedin.venice.controllerapi.JobStatusQueryResponse;
@@ -587,20 +586,6 @@ public class TestDeferredVersionSwap {
         coloVersions.forEach((colo, version) -> {
           Assert.assertEquals((int) version, 1);
         });
-      });
-    }
-
-    String childControllerURLs = multiRegionMultiClusterWrapper.getChildRegions().get(0).getControllerConnectString();
-    try (ControllerClient childControllerClient = new ControllerClient(CLUSTER_NAMES[0], childControllerURLs)) {
-      TestUtils.waitForNonDeterministicAssertion(30, TimeUnit.SECONDS, () -> {
-        String metaSystemStoreName = VeniceSystemStoreType.META_STORE.getSystemStoreName(storeName);
-        StoreInfo childStore = childControllerClient.getStore(metaSystemStoreName).getStore();
-        assertTrue(
-            childStore.getVersion(1).isPresent(),
-            "Version 1 should be present in child store: " + childStore.getName());
-        assertTrue(
-            childStore.getVersion(1).get().getStatus() == VersionStatus.ONLINE,
-            "Version 1 should be ONLINE in child store: " + childStore.getName());
       });
     }
 

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestDeferredVersionSwap.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestDeferredVersionSwap.java
@@ -25,6 +25,7 @@ import com.linkedin.venice.client.store.AvroGenericStoreClient;
 import com.linkedin.venice.client.store.ClientConfig;
 import com.linkedin.venice.client.store.ClientFactory;
 import com.linkedin.venice.client.store.StatTrackingStoreClient;
+import com.linkedin.venice.common.VeniceSystemStoreType;
 import com.linkedin.venice.controllerapi.ControllerClient;
 import com.linkedin.venice.controllerapi.ControllerResponse;
 import com.linkedin.venice.controllerapi.JobStatusQueryResponse;
@@ -586,6 +587,20 @@ public class TestDeferredVersionSwap {
         coloVersions.forEach((colo, version) -> {
           Assert.assertEquals((int) version, 1);
         });
+      });
+    }
+
+    String childControllerURLs = multiRegionMultiClusterWrapper.getChildRegions().get(0).getControllerConnectString();
+    try (ControllerClient childControllerClient = new ControllerClient(CLUSTER_NAMES[0], childControllerURLs)) {
+      TestUtils.waitForNonDeterministicAssertion(30, TimeUnit.SECONDS, () -> {
+        String metaSystemStoreName = VeniceSystemStoreType.META_STORE.getSystemStoreName(storeName);
+        StoreInfo childStore = childControllerClient.getStore(metaSystemStoreName).getStore();
+        assertTrue(
+            childStore.getVersion(1).isPresent(),
+            "Version 1 should be present in child store: " + childStore.getName());
+        assertTrue(
+            childStore.getVersion(1).get().getStatus() == VersionStatus.ONLINE,
+            "Version 1 should be ONLINE in child store: " + childStore.getName());
       });
     }
 

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/pubsub/adapter/kafka/consumer/ApacheKafkaConsumerTest.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/pubsub/adapter/kafka/consumer/ApacheKafkaConsumerTest.java
@@ -6,6 +6,7 @@ import static org.testng.Assert.assertTrue;
 import com.linkedin.venice.ConfigKeys;
 import com.linkedin.venice.integration.utils.PubSubBrokerWrapper;
 import com.linkedin.venice.integration.utils.ServiceFactory;
+import com.linkedin.venice.pubsub.PubSubAdminAdapterContext;
 import com.linkedin.venice.pubsub.PubSubConsumerAdapterContext;
 import com.linkedin.venice.pubsub.PubSubTopicConfiguration;
 import com.linkedin.venice.pubsub.PubSubTopicPartitionImpl;
@@ -48,8 +49,12 @@ public class ApacheKafkaConsumerTest {
             .build());
     consumer = new ApacheKafkaConsumerAdapter(apacheKafkaConsumerConfig);
     admin = new ApacheKafkaAdminAdapter(
-        new ApacheKafkaAdminConfig(new VeniceProperties(properties)),
-        pubSubTopicRepository);
+        new ApacheKafkaAdminConfig(
+            new PubSubAdminAdapterContext.Builder().setAdminClientName("testAdminClient")
+                .setVeniceProperties(new VeniceProperties(properties))
+                .setPubSubTopicRepository(pubSubTopicRepository)
+                .setPubSubPositionTypeRegistry(kafkaBroker.getPubSubPositionTypeRegistry())
+                .build()));
   }
 
   @AfterMethod

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/pubsub/api/admin/PubSubAdminAdapterTest.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/pubsub/api/admin/PubSubAdminAdapterTest.java
@@ -10,6 +10,7 @@ import com.linkedin.venice.ConfigKeys;
 import com.linkedin.venice.exceptions.VeniceException;
 import com.linkedin.venice.integration.utils.PubSubBrokerWrapper;
 import com.linkedin.venice.integration.utils.ServiceFactory;
+import com.linkedin.venice.pubsub.PubSubAdminAdapterContext;
 import com.linkedin.venice.pubsub.PubSubClientsFactory;
 import com.linkedin.venice.pubsub.PubSubConstants;
 import com.linkedin.venice.pubsub.PubSubConsumerAdapterContext;
@@ -116,7 +117,13 @@ public class PubSubAdminAdapterTest {
     properties.putAll(pubSubBrokerWrapper.getMergeableConfigs());
     VeniceProperties veniceProperties = new VeniceProperties(properties);
 
-    pubSubAdminAdapter = pubSubClientsFactory.getAdminAdapterFactory().create(veniceProperties, pubSubTopicRepository);
+    pubSubAdminAdapter = pubSubClientsFactory.getAdminAdapterFactory()
+        .create(
+            new PubSubAdminAdapterContext.Builder().setAdminClientName(clientId)
+                .setVeniceProperties(veniceProperties)
+                .setPubSubTopicRepository(pubSubTopicRepository)
+                .setPubSubPositionTypeRegistry(pubSubBrokerWrapper.getPubSubPositionTypeRegistry())
+                .build());
     pubSubConsumerAdapterLazy = Lazy.of(
         () -> pubSubClientsFactory.getConsumerAdapterFactory()
             .create(

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/pubsub/api/consumer/PubSubConsumerAdapterTest.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/pubsub/api/consumer/PubSubConsumerAdapterTest.java
@@ -14,6 +14,7 @@ import com.linkedin.venice.ConfigKeys;
 import com.linkedin.venice.integration.utils.PubSubBrokerWrapper;
 import com.linkedin.venice.integration.utils.ServiceFactory;
 import com.linkedin.venice.kafka.protocol.KafkaMessageEnvelope;
+import com.linkedin.venice.pubsub.PubSubAdminAdapterContext;
 import com.linkedin.venice.pubsub.PubSubClientsFactory;
 import com.linkedin.venice.pubsub.PubSubConstants;
 import com.linkedin.venice.pubsub.PubSubConsumerAdapterContext;
@@ -131,8 +132,14 @@ public class PubSubConsumerAdapterTest {
                     .setBrokerAddress(pubSubBrokerWrapper.getAddress())
                     .setPubSubPositionTypeRegistry(pubSubBrokerWrapper.getPubSubPositionTypeRegistry())
                     .build()));
-    pubSubAdminAdapterLazy =
-        Lazy.of(() -> pubSubClientsFactory.getAdminAdapterFactory().create(veniceProperties, pubSubTopicRepository));
+    pubSubAdminAdapterLazy = Lazy.of(
+        () -> pubSubClientsFactory.getAdminAdapterFactory()
+            .create(
+                new PubSubAdminAdapterContext.Builder().setAdminClientName(clientId)
+                    .setVeniceProperties(veniceProperties)
+                    .setPubSubTopicRepository(pubSubTopicRepository)
+                    .setPubSubPositionTypeRegistry(PubSubPositionTypeRegistry.fromPropertiesOrDefault(veniceProperties))
+                    .build()));
   }
 
   protected Properties getPubSubProperties() {

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/pubsub/manager/TopicManagerE2ETest.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/pubsub/manager/TopicManagerE2ETest.java
@@ -12,6 +12,7 @@ import com.linkedin.venice.ConfigKeys;
 import com.linkedin.venice.exceptions.VeniceException;
 import com.linkedin.venice.integration.utils.PubSubBrokerWrapper;
 import com.linkedin.venice.integration.utils.ServiceFactory;
+import com.linkedin.venice.pubsub.PubSubAdminAdapterContext;
 import com.linkedin.venice.pubsub.PubSubClientsFactory;
 import com.linkedin.venice.pubsub.PubSubConstants;
 import com.linkedin.venice.pubsub.PubSubConsumerAdapterContext;
@@ -102,8 +103,14 @@ public class TopicManagerE2ETest {
                     .setProducerName(clientId)
                     .setPubSubPositionTypeRegistry(pubSubBrokerWrapper.getPubSubPositionTypeRegistry())
                     .build()));
-    pubSubAdminAdapterLazy =
-        Lazy.of(() -> pubSubClientsFactory.getAdminAdapterFactory().create(veniceProperties, pubSubTopicRepository));
+    pubSubAdminAdapterLazy = Lazy.of(
+        () -> pubSubClientsFactory.getAdminAdapterFactory()
+            .create(
+                new PubSubAdminAdapterContext.Builder().setAdminClientName(clientId)
+                    .setVeniceProperties(veniceProperties)
+                    .setPubSubTopicRepository(pubSubTopicRepository)
+                    .setPubSubPositionTypeRegistry(pubSubBrokerWrapper.getPubSubPositionTypeRegistry())
+                    .build()));
     pubSubConsumerAdapterLazy = Lazy.of(
         () -> pubSubClientsFactory.getConsumerAdapterFactory()
             .create(

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/kafka/TopicCleanupService.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/kafka/TopicCleanupService.java
@@ -8,6 +8,7 @@ import com.linkedin.venice.exceptions.VeniceException;
 import com.linkedin.venice.exceptions.VeniceNoStoreException;
 import com.linkedin.venice.meta.Store;
 import com.linkedin.venice.meta.Version;
+import com.linkedin.venice.pubsub.PubSubAdminAdapterContext;
 import com.linkedin.venice.pubsub.PubSubAdminAdapterFactory;
 import com.linkedin.venice.pubsub.PubSubClientsFactory;
 import com.linkedin.venice.pubsub.PubSubTopicRepository;
@@ -125,9 +126,14 @@ public class TopicCleanupService extends AbstractVeniceService {
   }
 
   private PubSubAdminAdapter constructSourceOfTruthPubSubAdminAdapter(
-      PubSubAdminAdapterFactory<?> sourceOfTruthAdminAdapterFactory) {
+      PubSubAdminAdapterFactory<? extends PubSubAdminAdapter> sourceOfTruthAdminAdapterFactory) {
     VeniceProperties veniceProperties = admin.getPubSubSSLProperties(getTopicManager().getPubSubClusterAddress());
-    return sourceOfTruthAdminAdapterFactory.create(veniceProperties, pubSubTopicRepository);
+    return sourceOfTruthAdminAdapterFactory.create(
+        new PubSubAdminAdapterContext.Builder().setAdminClientName("SourceOfTruthAdminClient")
+            .setVeniceProperties(veniceProperties)
+            .setPubSubPositionTypeRegistry(multiClusterConfigs.getPubSubPositionTypeRegistry())
+            .setPubSubTopicRepository(pubSubTopicRepository)
+            .build());
   }
 
   // For test purpose

--- a/services/venice-controller/src/test/java/com/linkedin/venice/controller/kafka/TestTopicCleanupService.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/controller/kafka/TestTopicCleanupService.java
@@ -27,6 +27,7 @@ import com.linkedin.venice.meta.HybridStoreConfig;
 import com.linkedin.venice.meta.Store;
 import com.linkedin.venice.meta.StoreConfig;
 import com.linkedin.venice.meta.Version;
+import com.linkedin.venice.pubsub.PubSubAdminAdapterContext;
 import com.linkedin.venice.pubsub.PubSubClientsFactory;
 import com.linkedin.venice.pubsub.PubSubTopicRepository;
 import com.linkedin.venice.pubsub.adapter.kafka.admin.ApacheKafkaAdminAdapter;
@@ -260,7 +261,7 @@ public class TestTopicCleanupService {
 
     ApacheKafkaAdminAdapterFactory apacheKafkaAdminAdapterFactory = mock(ApacheKafkaAdminAdapterFactory.class);
     ApacheKafkaAdminAdapter apacheKafkaAdminAdapter = mock(ApacheKafkaAdminAdapter.class);
-    doReturn(apacheKafkaAdminAdapter).when(apacheKafkaAdminAdapterFactory).create(any(), eq(pubSubTopicRepository));
+    doReturn(apacheKafkaAdminAdapter).when(apacheKafkaAdminAdapterFactory).create(any(PubSubAdminAdapterContext.class));
 
     topicCleanupService.setSourceOfTruthPubSubAdminAdapter(apacheKafkaAdminAdapter);
     Pair<String, String> pair = new Pair<>(clusterName, "");


### PR DESCRIPTION
## Pass PubSubPositionTypeRegistry to admin clients

Introduced PubSubAdminAdapterContext to encapsulate all required configurations and
runtime dependencies for creating PubSub admin clients via factory APIs. This includes passing
components like PubSubPositionTypeRegistry and PubSubTopicRepository to downstream
consumers in a clean, unified way.

Updated all call sites to use this new context object when invoking
PubSubAdminAdapterFactory#create, replacing individual parameter passing.

## Solution
<!--
Describe
- What changes you are making and why. 
- How these changes solve the problem.
- Any performance considerations or trade-offs. 
- Describe what testings you have done, for example, performance testing etc.
-->


###  Code changes
- [ ] Added new code behind **a config**. If so list the config names and their default values in the PR description.
- [ ] Introduced new **log lines**. 
  - [ ] Confirmed if logs need to be **rate limited** to avoid excessive logging.

###  **Concurrency-Specific Checks**
Both reviewer and PR author to verify
- [ ] Code has **no race conditions** or **thread safety issues**.
- [ ] Proper **synchronization mechanisms** (e.g., `synchronized`, `RWLock`) are used where needed.
- [ ] No **blocking calls** inside critical sections that could lead to deadlocks or performance degradation.
- [ ] Verified **thread-safe collections** are used (e.g., `ConcurrentHashMap`, `CopyOnWriteArrayList`).
- [ ] Validated proper exception handling in multi-threaded code to avoid silent thread termination.


## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->

- [ ] New unit tests added.
- [ ] New integration tests added.
- [ ] Modified or extended existing tests.
- [ ] Verified backward compatibility (if applicable).

## Does this PR introduce any user-facing or breaking changes?
<!--  
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [ ] No. You can skip the rest of this section.
- [ ] Yes. Clearly explain the behavior change and its impact.