### PR TITLE
[server][controller][dvc][cc] Lazily instantiate PubSubPositionFactory on demand

### DIFF
--- a/internal/venice-common/src/test/java/com/linkedin/venice/pubsub/PubSubPositionTypeRegistryTest.java
+++ b/internal/venice-common/src/test/java/com/linkedin/venice/pubsub/PubSubPositionTypeRegistryTest.java
@@ -85,8 +85,11 @@ public class PubSubPositionTypeRegistryTest {
   public void testRegistryRejectsUnknownClassName() {
     Int2ObjectMap<String> userMap = new Int2ObjectOpenHashMap<>();
     userMap.put(99, "com.example.NonExistentPositionClass");
-    Exception exception = expectThrows(VeniceException.class, () -> new PubSubPositionTypeRegistry(userMap));
-    assertTrue(exception.getMessage().contains("Failed to create factory for"), "Got: " + exception.getMessage());
+    PubSubPositionTypeRegistry registry = new PubSubPositionTypeRegistry(userMap);
+    Exception exception = expectThrows(VeniceException.class, () -> registry.getFactoryByTypeId(99));
+    assertTrue(
+        exception.getMessage().contains("Failed to lazily create factory for com.example.NonExistentPositionClass"),
+        "Got: " + exception.getMessage());
     assertTrue(ExceptionUtils.recursiveClassEquals(exception.getCause(), ClassNotFoundException.class));
   }
 


### PR DESCRIPTION
## Lazily instantiate PubSubPositionFactory on demand  

Previously, all PubSubPositionFactory implementations were eagerly instantiated at startup  
based on configuration. This caused runtime failures when new factory class names were  
added in config before the corresponding code was deployed.  

This change defers factory instantiation to the first usage via computeIfAbsent on a  
ConcurrentHashMap, avoiding unnecessary class loading and improving robustness in mixed-  
version rollouts.  


## AI Generate Summary of Changes

> This pull request refactors the `PubSubPositionTypeRegistry` class to improve memory efficiency and error handling by switching to a lazy initialization approach for `PubSubPositionFactory` instances. It also updates the test cases to align with the new lazy-loading behavior.
> 
> ### Refactoring for Lazy Initialization:
> * Replaced the eager initialization of `typeIdToFactoryMap` with a lazy-loading approach using `VeniceConcurrentHashMap` and `computeIfAbsent`. This ensures that `PubSubPositionFactory` instances are only created when accessed. (`internal/venice-common/src/main/java/com/linkedin/venice/pubsub/PubSubPositionTypeRegistry.java`, [[1]](diffhunk://#diff-8583e49cca7aff87c5ec8aff4cca612848e2437ac8f960f7bc445bbeaab14aa0L101-R102) [[2]](diffhunk://#diff-8583e49cca7aff87c5ec8aff4cca612848e2437ac8f960f7bc445bbeaab14aa0L178-R195)
> 
> * Removed the `instantiateFactories` method, as factory instances are now created on demand instead of being preloaded. (`internal/venice-common/src/main/java/com/linkedin/venice/pubsub/PubSubPositionTypeRegistry.java`, [internal/venice-common/src/main/java/com/linkedin/venice/pubsub/PubSubPositionTypeRegistry.javaL265-L286](diffhunk://#diff-8583e49cca7aff87c5ec8aff4cca612848e2437ac8f960f7bc445bbeaab14aa0L265-L286))
> 
> ### Constructor and Dependency Updates:
> * Updated the constructor of `PubSubPositionTypeRegistry` to stop preloading factory instances into `typeIdToFactoryMap`, aligning with the lazy-loading design. (`internal/venice-common/src/main/java/com/linkedin/venice/pubsub/PubSubPositionTypeRegistry.java`, [internal/venice-common/src/main/java/com/linkedin/venice/pubsub/PubSubPositionTypeRegistry.javaL123](diffhunk://#diff-8583e49cca7aff87c5ec8aff4cca612848e2437ac8f960f7bc445bbeaab14aa0L123))
> 
> ### Test Case Adjustments:
> * Modified the test case `testRegistryRejectsUnknownClassName` to validate the lazy initialization behavior by triggering factory creation during runtime instead of during registry construction. (`internal/venice-common/src/test/java/com/linkedin/venice/pubsub/PubSubPositionTypeRegistryTest.java`, [internal/venice-common/src/test/java/com/linkedin/venice/pubsub/PubSubPositionTypeRegistryTest.javaL88-R92](diffhunk://#diff-19df5bb5b2f8cc8d883f72090856180ec199a23934ef520091e123e61a5842c4L88-R92))
> 
> 

###  Code changes
- [ ] Added new code behind **a config**. If so list the config names and their default values in the PR description.
- [ ] Introduced new **log lines**. 
  - [ ] Confirmed if logs need to be **rate limited** to avoid excessive logging.

###  **Concurrency-Specific Checks**
Both reviewer and PR author to verify
- [x] Code has **no race conditions** or **thread safety issues**.
- [x] Proper **synchronization mechanisms** (e.g., `synchronized`, `RWLock`) are used where needed.
- [x] No **blocking calls** inside critical sections that could lead to deadlocks or performance degradation.
- [x] Verified **thread-safe collections** are used (e.g., `ConcurrentHashMap`, `CopyOnWriteArrayList`).
- [x] Validated proper exception handling in multi-threaded code to avoid silent thread termination.


## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->

- [ ] New unit tests added.
- [ ] New integration tests added.
- [x] Modified or extended existing tests.
- [x] Verified backward compatibility (if applicable).

## Does this PR introduce any user-facing or breaking changes?
<!--  
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [ ] No. You can skip the rest of this section.
- [ ] Yes. Clearly explain the behavior change and its impact.