### PR TITLE
[server] Reject SOP if EOP has already been received to prevent regress in replica state

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
@@ -11,6 +11,8 @@ import static com.linkedin.davinci.kafka.consumer.LeaderFollowerStateType.STANDB
 import static com.linkedin.davinci.validation.DataIntegrityValidator.DISABLED;
 import static com.linkedin.venice.ConfigKeys.KAFKA_BOOTSTRAP_SERVERS;
 import static com.linkedin.venice.LogMessages.KILLED_JOB_MESSAGE;
+import static com.linkedin.venice.kafka.protocol.enums.ControlMessageType.END_OF_PUSH;
+import static com.linkedin.venice.kafka.protocol.enums.ControlMessageType.START_OF_PUSH;
 import static com.linkedin.venice.kafka.protocol.enums.ControlMessageType.START_OF_SEGMENT;
 import static com.linkedin.venice.pubsub.PubSubConstants.UNKNOWN_LATEST_OFFSET;
 import static com.linkedin.venice.utils.Utils.FATAL_DATA_VALIDATION_ERROR;
@@ -3078,6 +3080,18 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
       ControlMessage controlMessage,
       PartitionConsumptionState partitionConsumptionState) {
     StartOfPush startOfPush = (StartOfPush) controlMessage.controlMessageUnion;
+    if (partitionConsumptionState.isEndOfPushReceived()) {
+      LOGGER.warn(
+          "Received START_OF_PUSH after END_OF_PUSH for replica: {}. This may indicate out-of-order or "
+              + "duplicate control messages. Details: Incoming SoP: {}, Previous SoP timestamp: {}, Previous "
+              + "EoP timestamp: {}. The message will be ignored.",
+          partitionConsumptionState.getReplicaId(),
+          startOfPush,
+          partitionConsumptionState.getStartOfPushTimestamp(),
+          partitionConsumptionState.getEndOfPushTimestamp());
+      return;
+    }
+
     /*
      * Notify the underlying store engine about starting batch push.
      */

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/consumer/ConsumerIntegrationTest.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/consumer/ConsumerIntegrationTest.java
@@ -12,6 +12,7 @@ import com.linkedin.venice.integration.utils.ServiceFactory;
 import com.linkedin.venice.integration.utils.VeniceClusterCreateOptions;
 import com.linkedin.venice.integration.utils.VeniceClusterWrapper;
 import com.linkedin.venice.kafka.protocol.KafkaMessageEnvelope;
+import com.linkedin.venice.meta.Store;
 import com.linkedin.venice.partitioner.DefaultVenicePartitioner;
 import com.linkedin.venice.partitioner.VenicePartitioner;
 import com.linkedin.venice.pubsub.PubSubProducerAdapterContext;
@@ -132,7 +133,6 @@ public abstract class ConsumerIntegrationTest {
             .setHybridOffsetLagThreshold(streamingMessageLag));
     topicName = Utils.getRealTimeTopicName(
         cluster.getLeaderVeniceController().getVeniceAdmin().getStore(cluster.getClusterName(), store));
-    controllerClient.emptyPush(store, "test_push", 1);
     TestUtils.assertCommand(controllerClient.emptyPush(this.store, "test_push", 1), "empty push failed");
 
     TestUtils.waitForNonDeterministicAssertion(15, TimeUnit.SECONDS, () -> {
@@ -142,6 +142,8 @@ public abstract class ConsumerIntegrationTest {
           freshStoreResponse.getStore().getCurrentVersion(),
           version,
           "The empty push has not activated the store.");
+      Store routerStore = cluster.getVeniceRouters().get(0).getMetaDataRepository().getStore(store);
+      Assert.assertEquals(routerStore.getCurrentVersion(), version, "The empty push has not activated the store.");
     });
     client = ClientFactory.getAndStartGenericAvroClient(
         ClientConfig.defaultGenericClientConfig(store).setVeniceURL(cluster.getRandomRouterURL()));


### PR DESCRIPTION
## Reject SOP if EOP has already been received to prevent regress in replica state  

Currently, servers accept all START_OF_PUSH (SOP) messages—even when the replica is already  
in a COMPLETED state. This causes a regression in the replica's state when it processes an  
SOP, flipping its status from COMPLETED back to STARTED. As a result, the server becomes  
unavailable for reads, and the router fails to find any online replicas for the partition.  

This typically occurs when the controller receives a second empty push request from the client  
using the same push ID and re-issues the SOP and EOP messages on the client's behalf. Since  
the server already received the EOP during the first push, it ignores the second EOP as a  
duplicate—leaving the replica stuck in STARTED state indefinitely.  

This change fixes the issue by rejecting incoming SOP messages if the server has already  
received an EOP for that version and partition.  




###  Code changes
- [ ] Added new code behind **a config**. If so list the config names and their default values in the PR description.
- [ ] Introduced new **log lines**. 
  - [ ] Confirmed if logs need to be **rate limited** to avoid excessive logging.

###  **Concurrency-Specific Checks**
Both reviewer and PR author to verify
- [ ] Code has **no race conditions** or **thread safety issues**.
- [ ] Proper **synchronization mechanisms** (e.g., `synchronized`, `RWLock`) are used where needed.
- [ ] No **blocking calls** inside critical sections that could lead to deadlocks or performance degradation.
- [ ] Verified **thread-safe collections** are used (e.g., `ConcurrentHashMap`, `CopyOnWriteArrayList`).
- [ ] Validated proper exception handling in multi-threaded code to avoid silent thread termination.


## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->

- [ ] New unit tests added.
- [ ] New integration tests added.
- [ ] Modified or extended existing tests.
- [ ] Verified backward compatibility (if applicable).

## Does this PR introduce any user-facing or breaking changes?
<!--  
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [ ] No. You can skip the rest of this section.
- [ ] Yes. Clearly explain the behavior change and its impact.