### PR TITLE
[build][admin-tool] Bumped up avro-util version and optimize help text of admin tool

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -39,7 +39,7 @@ if (project.hasProperty('overrideBuildEnvironment')) {
 }
 
 def avroVersion = '1.10.2'
-def avroUtilVersion = '0.4.22'
+def avroUtilVersion = '0.4.30'
 def grpcVersion = '1.49.2'
 // N.B.: The build should also work when substituting Kafka from the Apache fork to LinkedIn's fork:
 def kafkaGroup = 'org.apache.kafka' // 'com.linkedin.kafka'

--- a/clients/venice-admin-tool/src/main/java/com/linkedin/venice/AdminTool.java
+++ b/clients/venice-admin-tool/src/main/java/com/linkedin/venice/AdminTool.java
@@ -2453,12 +2453,6 @@ public class AdminTool {
       for (Arg arg: foundCommand.getOptionalArgs()) {
         createOpt(arg, arg.isParameterized(), arg.getHelpText(), options);
       }
-      Options parameterOptionsForHelp = new Options();
-      for (Object obj: options.getOptions()) {
-        Option o = (Option) obj;
-        parameterOptionsForHelp.addOption(o);
-      }
-      options.addOptionGroup(commandGroup);
     }
 
     /* Commands */

--- a/clients/venice-admin-tool/src/main/java/com/linkedin/venice/AdminTool.java
+++ b/clients/venice-admin-tool/src/main/java/com/linkedin/venice/AdminTool.java
@@ -654,7 +654,7 @@ public class AdminTool {
     CommandLine cmd = parser.parse(options, args);
 
     if (cmd.hasOption(Arg.HELP.first())) {
-      printUsageAndExit(commandGroup, parameterOptionsForHelp);
+      printUsageAndExit(commandGroup, parameterOptionsForHelp, cmd);
     } else if (cmd.hasOption(Command.CONVERT_VSON_SCHEMA.toString())) {
       convertVsonSchemaAndExit(cmd);
     }
@@ -2427,7 +2427,39 @@ public class AdminTool {
 
   /* Things that are not commands */
 
-  private static void printUsageAndExit(OptionGroup commandGroup, Options options) {
+  private static void printUsageAndExit(OptionGroup commandGroup, Options options, CommandLine cmd) {
+    /**
+     * Get the first command if it is available, otherwise print all commands.
+     */
+    Command foundCommand = null;
+    for (Command c: Command.values()) {
+      if (cmd.hasOption(c.toString())) {
+        foundCommand = c;
+      }
+    }
+    Command[] commands = Command.values();
+    if (foundCommand != null) {
+      commands = new Command[] { foundCommand };
+      commandGroup = new OptionGroup();
+      createCommandOpt(foundCommand, commandGroup);
+
+      /**
+       * Gather all the options belonging to the found command.
+       */
+      options = new Options();
+      for (Arg arg: foundCommand.getRequiredArgs()) {
+        createOpt(arg, arg.isParameterized(), arg.getHelpText(), options);
+      }
+      for (Arg arg: foundCommand.getOptionalArgs()) {
+        createOpt(arg, arg.isParameterized(), arg.getHelpText(), options);
+      }
+      Options parameterOptionsForHelp = new Options();
+      for (Object obj: options.getOptions()) {
+        Option o = (Option) obj;
+        parameterOptionsForHelp.addOption(o);
+      }
+      options.addOptionGroup(commandGroup);
+    }
 
     /* Commands */
     String command = "java -jar "
@@ -2443,7 +2475,6 @@ public class AdminTool {
 
     /* Examples */
     System.out.println("\nExamples:");
-    Command[] commands = Command.values();
     Arrays.sort(commands, Command.commandComparator);
     for (Command c: commands) {
       StringJoiner exampleArgs = new StringJoiner(" ");


### PR DESCRIPTION

<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat], [protocol]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## Problem Statement
<!--
Describe
- What problem are you trying to solve
- What issues or limitations exist in the current code
- Why this change is necessary 
-->
Bumped up avro-util version to pick up the recent fixes of fast-avro. Optimized the help text for admin tool.

## Solution
<!--
Describe
- What changes you are making and why. 
- How these changes solve the problem.
- Any performance considerations or trade-offs. 
- Describe what testings you have done, for example, performance testing etc.
-->
Bumped up avro-util version to pick up the recent fixes of fast-avro. Optimized the help text for admin tool.
When supplying a specfic command with `-h`, it will only print the help for that specific command. Example output:

```
java -jar clients/venice-admin-tool/build/libs/venice-admin-tool-all.jar --kill-job -h
usage: java -jar venice-admin-tool-all.jar --<command> [parameters]

Commands:
    --kill-job   Kill a running push job.
                 Requires: --url --store --version
                 Optional args: --cluster
usage: Parameters:
 -c,--cluster <arg>   Name of Venice cluster
    --kill-job        Kill a running push job.
                      Requires: --url --store --version
                      Optional args: --cluster
 -s,--store <arg>     Name of Venice store
 -u,--url <arg>       Venice url, eg. http://localhost:1689  This can be a router or a controller
 -v,--version <arg>   Active store version number

Examples:
java -jar venice-admin-tool-all.jar --kill-job --url <url> --store <store> --version <version> [--cluster <cluster>]
```

###  Code changes
- [ ] Added new code behind **a config**. If so list the config names and their default values in the PR description.
- [ ] Introduced new **log lines**. 
  - [ ] Confirmed if logs need to be **rate limited** to avoid excessive logging.

###  **Concurrency-Specific Checks**
Both reviewer and PR author to verify
- [ ] Code has **no race conditions** or **thread safety issues**.
- [ ] Proper **synchronization mechanisms** (e.g., `synchronized`, `RWLock`) are used where needed.
- [ ] No **blocking calls** inside critical sections that could lead to deadlocks or performance degradation.
- [ ] Verified **thread-safe collections** are used (e.g., `ConcurrentHashMap`, `CopyOnWriteArrayList`).
- [ ] Validated proper exception handling in multi-threaded code to avoid silent thread termination.


## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
CI

- [ ] New unit tests added.
- [ ] New integration tests added.
- [ ] Modified or extended existing tests.
- [ ] Verified backward compatibility (if applicable).

## Does this PR introduce any user-facing or breaking changes?
<!--  
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Clearly explain the behavior change and its impact.