### PR TITLE
[dvc][server] Add exponential backoff to other HelixUtils methods with retries

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/helix/HelixParticipationService.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/helix/HelixParticipationService.java
@@ -305,7 +305,7 @@ public class HelixParticipationService extends AbstractVeniceService
     HelixAdmin admin = new ZKHelixAdmin(zkAddress);
     try {
       // Check whether the cluster is ready or not at first to prevent zk no node exception.
-      HelixUtils.checkClusterSetup(admin, clusterName, MAX_RETRY, RETRY_INTERVAL_SEC);
+      HelixUtils.checkClusterSetup(admin, clusterName, MAX_RETRY);
       List<String> instances = admin.getInstancesInCluster(clusterName);
       if (instances.contains(instance.getNodeId())) {
         LOGGER.info("{} is not a new node to cluster: {}, skip the cleaning up.", instance.getNodeId(), clusterName);

--- a/internal/venice-common/src/main/java/com/linkedin/venice/helix/HelixSchemaAccessor.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/helix/HelixSchemaAccessor.java
@@ -97,11 +97,8 @@ public class HelixSchemaAccessor {
   }
 
   public List<SchemaEntry> getAllValueSchemas(String storeName) {
-    return HelixUtils.getChildren(
-        schemaAccessor,
-        getValueSchemaParentPath(storeName).toString(),
-        refreshAttemptsForZkReconnect,
-        refreshIntervalForZkReconnectInMs);
+    return HelixUtils
+        .getChildren(schemaAccessor, getValueSchemaParentPath(storeName).toString(), refreshAttemptsForZkReconnect);
   }
 
   public DerivedSchemaEntry getDerivedSchema(String storeName, String derivedSchemaIdPair) {
@@ -113,8 +110,7 @@ public class HelixSchemaAccessor {
     return HelixUtils.getChildren(
         derivedSchemaAccessor,
         getDerivedSchemaParentPath(storeName).toString(),
-        refreshAttemptsForZkReconnect,
-        refreshIntervalForZkReconnectInMs);
+        refreshAttemptsForZkReconnect);
   }
 
   public void createKeySchema(String storeName, SchemaEntry schemaEntry) {
@@ -238,8 +234,7 @@ public class HelixSchemaAccessor {
     return HelixUtils.getChildren(
         replicationMetadataSchemaAccessor,
         getReplicationMetadataSchemaParentPath(storeName).toString(),
-        refreshAttemptsForZkReconnect,
-        refreshIntervalForZkReconnectInMs);
+        refreshAttemptsForZkReconnect);
   }
 
   public void addReplicationMetadataSchema(String storeName, RmdSchemaEntry rmdSchemaEntry) {

--- a/internal/venice-common/src/main/java/com/linkedin/venice/helix/VeniceOfflinePushMonitorAccessor.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/helix/VeniceOfflinePushMonitorAccessor.java
@@ -127,11 +127,8 @@ public class VeniceOfflinePushMonitorAccessor implements OfflinePushAccessor {
   @Override
   public List<OfflinePushStatus> loadOfflinePushStatusesAndPartitionStatuses() {
     LOGGER.info("Start loading all offline pushes statuses from ZK in cluster: {}.", clusterName);
-    List<OfflinePushStatus> offlinePushStatuses = HelixUtils.getChildren(
-        offlinePushStatusAccessor,
-        offlinePushStatusParentPath,
-        refreshAttemptsForZkReconnect,
-        refreshIntervalForZkReconnectInMs);
+    List<OfflinePushStatus> offlinePushStatuses =
+        HelixUtils.getChildren(offlinePushStatusAccessor, offlinePushStatusParentPath, refreshAttemptsForZkReconnect);
     Iterator<OfflinePushStatus> iterator = offlinePushStatuses.iterator();
     while (iterator.hasNext()) {
       OfflinePushStatus pushStatus = iterator.next();
@@ -414,11 +411,8 @@ public class VeniceOfflinePushMonitorAccessor implements OfflinePushAccessor {
    */
   protected List<PartitionStatus> getPartitionStatuses(String topic, int partitionCount) {
     LOGGER.debug("Start reading partition status from ZK for topic: {} in cluster: {}.", topic, clusterName);
-    List<PartitionStatus> zkResult = HelixUtils.getChildren(
-        partitionStatusAccessor,
-        getOfflinePushStatusPath(topic),
-        refreshAttemptsForZkReconnect,
-        refreshIntervalForZkReconnectInMs);
+    List<PartitionStatus> zkResult =
+        HelixUtils.getChildren(partitionStatusAccessor, getOfflinePushStatusPath(topic), refreshAttemptsForZkReconnect);
     LOGGER.debug("Read {} partition status from ZK for topic: {} in cluster: {}.", zkResult.size(), topic, clusterName);
 
     if (zkResult.isEmpty()) {

--- a/services/venice-router/src/main/java/com/linkedin/venice/router/RouterServer.java
+++ b/services/venice-router/src/main/java/com/linkedin/venice/router/RouterServer.java
@@ -963,7 +963,7 @@ public class RouterServer extends AbstractVeniceService {
           // TODO: Remove this check once test constructor is removed or otherwise fixed.
           LOGGER.info("Not connecting to Helix because the HelixManager is null (the test constructor was used)");
         } else {
-          HelixUtils.connectHelixManager(manager, 30, 1);
+          HelixUtils.connectHelixManager(manager, 30);
           LOGGER.info("{} finished connectHelixManager()", this);
         }
       } catch (VeniceException ve) {


### PR DESCRIPTION
<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat], [protocol]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## Problem Statement
The `HelixUtils` class has been updated in [PR 1734](https://github.com/linkedin/venice/pull/1734) in order to add exponential backoff to improve resiliency against temporary ZK connection issues through a new `handleFailedHelixOperation` method, compared with the previous implementation which would make immediate retries instead of waiting exponentially between retries.

This PR aims to integrate this new exponential backoff implementation to other methods in `HelixUtils` with retry logic, that is:

- `getChildren`
- `connectHelixManager`
- `checkClusterSetup`

Additionally, these 3 methods had inconsistent implementation patterns for retry logic, which have been refactored to more closely match the implementation in [PR 1734](https://github.com/linkedin/venice/pull/1734).

## Solution
The 3 methods now use exponential backoff retry logic through the `handleFailedHelixOperation` method.

###  Code changes
- [ ] Added new code behind **a config**. If so list the config names and their default values in the PR description.
- [ ] Introduced new **log lines**. 
  - [ ] Confirmed if logs need to be **rate limited** to avoid excessive logging.

###  **Concurrency-Specific Checks**
Both reviewer and PR author to verify
- [ ] Code has **no race conditions** or **thread safety issues**.
- [ ] Proper **synchronization mechanisms** (e.g., `synchronized`, `RWLock`) are used where needed.
- [ ] No **blocking calls** inside critical sections that could lead to deadlocks or performance degradation.
- [ ] Verified **thread-safe collections** are used (e.g., `ConcurrentHashMap`, `CopyOnWriteArrayList`).
- [ ] Validated proper exception handling in multi-threaded code to avoid silent thread termination.


## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->

- [x] New unit tests added.
- [ ] New integration tests added.
- [ ] Modified or extended existing tests.
- [ ] Verified backward compatibility (if applicable).

## Does this PR introduce any user-facing or breaking changes?
<!--  
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Clearly explain the behavior change and its impact.