### PR TITLE
[tc][fc][dvc][router] Remove duplication of metrics for Exponential histograms in Otel

### DIFF
--- a/clients/venice-thin-client/src/main/java/com/linkedin/venice/client/stats/BasicClientStats.java
+++ b/clients/venice-thin-client/src/main/java/com/linkedin/venice/client/stats/BasicClientStats.java
@@ -9,6 +9,7 @@ import static com.linkedin.venice.stats.dimensions.VeniceMetricsDimensions.VENIC
 import static com.linkedin.venice.stats.dimensions.VeniceMetricsDimensions.VENICE_STORE_NAME;
 import static com.linkedin.venice.stats.dimensions.VeniceResponseStatusCategory.FAIL;
 import static com.linkedin.venice.stats.dimensions.VeniceResponseStatusCategory.SUCCESS;
+import static com.linkedin.venice.stats.metrics.ModuleMetricEntityInterface.getUniqueMetricEntities;
 import static com.linkedin.venice.utils.CollectionUtils.setOf;
 import static org.apache.hc.core5.http.HttpStatus.SC_NOT_FOUND;
 import static org.apache.hc.core5.http.HttpStatus.SC_OK;
@@ -31,6 +32,7 @@ import com.linkedin.venice.stats.metrics.MetricEntityStateOneEnum;
 import com.linkedin.venice.stats.metrics.MetricEntityStateThreeEnums;
 import com.linkedin.venice.stats.metrics.MetricType;
 import com.linkedin.venice.stats.metrics.MetricUnit;
+import com.linkedin.venice.stats.metrics.ModuleMetricEntityInterface;
 import com.linkedin.venice.stats.metrics.TehutiMetricNameEnum;
 import io.tehuti.metrics.MetricsRepository;
 import io.tehuti.metrics.Sensor;
@@ -44,7 +46,6 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
-import java.util.stream.Collectors;
 import org.apache.http.HttpStatus;
 
 
@@ -53,10 +54,8 @@ import org.apache.http.HttpStatus;
  * by thin, fast and DaVinci clients.
  */
 public class BasicClientStats extends AbstractVeniceHttpStats {
-  public static final Collection<MetricEntity> CLIENT_METRIC_ENTITIES = Collections.unmodifiableList(
-      Arrays.stream(BasicClientMetricEntity.values())
-          .map(BasicClientMetricEntity::getMetricEntity)
-          .collect(Collectors.toList()));
+  public static final Collection<MetricEntity> CLIENT_METRIC_ENTITIES =
+      getUniqueMetricEntities(BasicClientMetricEntity.class);
 
   private static final String SYSTEM_STORE_NAME_PREFIX = "venice_system_store_";
 
@@ -375,7 +374,7 @@ public class BasicClientStats extends AbstractVeniceHttpStats {
     }
   }
 
-  public enum BasicClientMetricEntity {
+  public enum BasicClientMetricEntity implements ModuleMetricEntityInterface {
     /**
      * Count of all requests during response handling along with response codes
      */
@@ -437,6 +436,7 @@ public class BasicClientStats extends AbstractVeniceHttpStats {
       this.metricEntity = new MetricEntity(metricName, metricType, unit, description, dimensions);
     }
 
+    @Override
     public MetricEntity getMetricEntity() {
       return metricEntity;
     }

--- a/clients/venice-thin-client/src/test/java/com/linkedin/venice/client/stats/BasicClientStatsTest.java
+++ b/clients/venice-thin-client/src/test/java/com/linkedin/venice/client/stats/BasicClientStatsTest.java
@@ -39,8 +39,10 @@ import io.tehuti.Metric;
 import io.tehuti.metrics.MetricsRepository;
 import java.util.Collection;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 import org.apache.commons.httpclient.HttpStatus;
 import org.testng.Assert;
 import org.testng.annotations.Test;
@@ -185,6 +187,7 @@ public class BasicClientStatsTest {
     Attributes expectedAttributes = getExpectedAttributes(storeName, httpStatus, category);
     Collection<MetricData> metricsData = inMemoryMetricReader.collectAllMetrics();
     Assert.assertFalse(metricsData.isEmpty());
+    assertEquals(metricsData.size(), 2, "There should be two metrics recorded: call_time and call_count");
 
     LongPointData callCountData = getLongPointData(metricsData, "call_count", otelPrefix);
     validateLongPointData(callCountData, 1, expectedAttributes);
@@ -249,7 +252,9 @@ public class BasicClientStatsTest {
             "Latency for all DaVinci Client responses",
             Utils.setOf(VENICE_STORE_NAME, VENICE_REQUEST_METHOD, VENICE_RESPONSE_STATUS_CODE_CATEGORY)));
 
+    Set<String> uniqueMetricEntitiesNames = new HashSet<>();
     for (BasicClientStats.BasicClientMetricEntity metric: BasicClientStats.BasicClientMetricEntity.values()) {
+      uniqueMetricEntitiesNames.add(metric.getMetricEntity().getMetricName());
       MetricEntity actual = metric.getMetricEntity();
       MetricEntity expected = expectedMetrics.get(metric);
 
@@ -278,7 +283,7 @@ public class BasicClientStatsTest {
     // Assert size
     assertEquals(
         CLIENT_METRIC_ENTITIES.size(),
-        expectedMetricEntities.size(),
+        uniqueMetricEntitiesNames.size(),
         "Unexpected size of CLIENT_METRIC_ENTITIES");
 
     // Assert contents

--- a/internal/venice-client-common/src/main/java/com/linkedin/venice/stats/VeniceOpenTelemetryMetricsRepository.java
+++ b/internal/venice-client-common/src/main/java/com/linkedin/venice/stats/VeniceOpenTelemetryMetricsRepository.java
@@ -39,8 +39,10 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -179,9 +181,17 @@ public class VeniceOpenTelemetryMetricsRepository {
           "metricEntities cannot be empty if exponential Histogram is enabled, List all the metrics used in this service using setMetricEntities method");
     }
 
+    // find all the unique metric names which are of type HISTOGRAM: passing in the same name
+    // multiple times will result in the same metric being registered multiple times.
+    // ModuleMetricEntityInterface#getUniqueMetricEntities method will take care of this if used,
+    // this is an additional check to cases that doesn't use that method.
+    Set<String> uniqueMetricNamesSet = new HashSet<>();
     for (MetricEntity metricEntity: metricsConfig.getMetricEntities()) {
       if (metricEntity.getMetricType() == MetricType.HISTOGRAM) {
-        metricNames.add(getFullMetricName(getMetricPrefix(metricEntity), metricEntity.getMetricName()));
+        String fullMetricName = getFullMetricName(getMetricPrefix(metricEntity), metricEntity.getMetricName());
+        if (uniqueMetricNamesSet.add(fullMetricName)) {
+          metricNames.add(fullMetricName);
+        }
       }
     }
 

--- a/internal/venice-client-common/src/main/java/com/linkedin/venice/stats/VeniceOpenTelemetryMetricsRepository.java
+++ b/internal/venice-client-common/src/main/java/com/linkedin/venice/stats/VeniceOpenTelemetryMetricsRepository.java
@@ -172,8 +172,7 @@ public class VeniceOpenTelemetryMetricsRepository {
    * 2. If we don't configure exponential histogram aggregation for every histogram: it could lead to observability miss
    */
   private void setExponentialHistogramAggregation(SdkMeterProviderBuilder builder, VeniceMetricsConfig metricsConfig) {
-    // Set to keep track of all unique metric names which are of type HISTOGRAM
-    Set<String> metricNames = new HashSet<>();
+    Set<String> uniqueHistogramMetricNames = new HashSet<>();
 
     Collection<MetricEntity> metricEntities = metricsConfig.getMetricEntities();
     if (metricEntities == null || metricsConfig.getMetricEntities().isEmpty()) {
@@ -183,12 +182,12 @@ public class VeniceOpenTelemetryMetricsRepository {
 
     for (MetricEntity metricEntity: metricsConfig.getMetricEntities()) {
       if (metricEntity.getMetricType() == MetricType.HISTOGRAM) {
-        metricNames.add(getFullMetricName(getMetricPrefix(metricEntity), metricEntity.getMetricName()));
+        uniqueHistogramMetricNames.add(getFullMetricName(getMetricPrefix(metricEntity), metricEntity.getMetricName()));
       }
     }
 
     // Register views for all MetricType.HISTOGRAM metrics to be aggregated/exported as exponential histograms
-    for (String metricName: metricNames) {
+    for (String metricName: uniqueHistogramMetricNames) {
       InstrumentSelector selector =
           InstrumentSelector.builder().setType(InstrumentType.HISTOGRAM).setName(metricName).build();
 

--- a/internal/venice-client-common/src/main/java/com/linkedin/venice/stats/metrics/ModuleMetricEntityInterface.java
+++ b/internal/venice-client-common/src/main/java/com/linkedin/venice/stats/metrics/ModuleMetricEntityInterface.java
@@ -1,0 +1,53 @@
+package com.linkedin.venice.stats.metrics;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+
+
+/**
+ * Every venice Module that defines its set of {@link MetricEntity} should implement this interface.
+ */
+public interface ModuleMetricEntityInterface {
+  MetricEntity getMetricEntity();
+
+  /**
+   * Get all the unique {@link MetricEntity} from the provided enum classes based on the metric name.
+   * This will also check if there are multiple metric entities with the same name across the provided
+   * enum classes with different metric types and throw.
+   */
+  static Collection<MetricEntity> getUniqueMetricEntities(Class<? extends ModuleMetricEntityInterface>... enumClasses) {
+    if (enumClasses == null || enumClasses.length == 0) {
+      throw new IllegalArgumentException("Enum classes passed to getUniqueMetricEntities cannot be null or empty");
+    }
+
+    Map<String, MetricEntity> uniqueMetricsByName = new HashMap<>();
+    for (Class<? extends ModuleMetricEntityInterface> enumClass: enumClasses) {
+      ModuleMetricEntityInterface[] constants = enumClass.getEnumConstants();
+      for (ModuleMetricEntityInterface constant: constants) {
+        MetricEntity metric = constant.getMetricEntity();
+        String metricName = metric.getMetricName();
+
+        // Add only if not already present and validate if already present
+        if (uniqueMetricsByName.containsKey(metricName)) {
+          MetricEntity existingMetric = uniqueMetricsByName.get(metricName);
+          if (!existingMetric.getMetricType().equals(metric.getMetricType())) {
+            throw new IllegalArgumentException(
+                "Multiple metric entities with the same name but different types found for metric : " + metricName
+                    + " among the provided enum classes: " + Arrays.toString(enumClasses));
+          }
+        } else {
+          uniqueMetricsByName.put(metricName, metric);
+        }
+      }
+    }
+
+    if (uniqueMetricsByName.isEmpty()) {
+      throw new IllegalArgumentException("No metric entities found in the provided enum classes");
+    }
+
+    return uniqueMetricsByName.values();
+  }
+
+}

--- a/internal/venice-client-common/src/test/java/com/linkedin/venice/stats/metrics/ModuleMetricEntityInterfaceTest.java
+++ b/internal/venice-client-common/src/test/java/com/linkedin/venice/stats/metrics/ModuleMetricEntityInterfaceTest.java
@@ -1,0 +1,150 @@
+package com.linkedin.venice.stats.metrics;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+
+import com.linkedin.venice.stats.dimensions.VeniceMetricsDimensions;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+import org.testng.annotations.Test;
+
+
+public class ModuleMetricEntityInterfaceTest {
+  private static final Set<VeniceMetricsDimensions> TEST_DIMENSIONS = Collections.singleton(null);
+  private static final String TEST_DESC = "test Description";
+
+  @Test(expectedExceptions = IllegalArgumentException.class, expectedExceptionsMessageRegExp = "Enum classes passed to getUniqueMetricEntities cannot be null or empty")
+  public void testNullVarargs() {
+    ModuleMetricEntityInterface.getUniqueMetricEntities((Class<? extends ModuleMetricEntityInterface>[]) null);
+  }
+
+  @Test(expectedExceptions = IllegalArgumentException.class, expectedExceptionsMessageRegExp = "Enum classes passed to getUniqueMetricEntities cannot be null or empty")
+  public void testEmptyVarargs() {
+    ModuleMetricEntityInterface.getUniqueMetricEntities();
+  }
+
+  @Test(expectedExceptions = IllegalArgumentException.class, expectedExceptionsMessageRegExp = "No metric entities found in the provided enum classes")
+  public void testNoMetricsFound() {
+    ModuleMetricEntityInterface.getUniqueMetricEntities(EmptyEnum.class);
+  }
+
+  @Test
+  public void testSingleEnum() {
+    Collection<MetricEntity> metrics = ModuleMetricEntityInterface.getUniqueMetricEntities(SingleEnum.class);
+
+    assertEquals(metrics.size(), 1);
+    MetricEntity m = metrics.iterator().next();
+    assertEquals(m.getMetricName(), "enum_one");
+    assertEquals(m.getMetricType(), MetricType.COUNTER);
+    assertEquals(m.getUnit(), MetricUnit.NUMBER);
+  }
+
+  @Test
+  public void testDistinctEnums() {
+    Collection<MetricEntity> metrics = ModuleMetricEntityInterface.getUniqueMetricEntities(TwoDistinctEnum.class);
+
+    assertEquals(metrics.size(), 2);
+    Set<String> names = new HashSet<>();
+    for (MetricEntity m: metrics) {
+      names.add(m.getMetricName());
+    }
+    assertTrue(names.contains("enum_one"));
+    assertTrue(names.contains("enum_two"));
+  }
+
+  /** Duplicate name and same type: should be deduped */
+  @Test
+  public void testDuplicateMetricsSameTypeAndUnit() {
+    Collection<MetricEntity> metrics = ModuleMetricEntityInterface.getUniqueMetricEntities(DuplicateEnum.class);
+
+    // only one unique name “enum_dup”
+    assertEquals(metrics.size(), 1);
+
+    // and it should be the instance from DuplicateEnum.ENUM_ONE by implementation
+    MetricEntity m = metrics.iterator().next();
+    assertTrue(m == DuplicateEnum.ENUM_ONE.getMetricEntity());
+  }
+
+  /** Duplicate name, different type: should throw */
+  @Test(expectedExceptions = IllegalArgumentException.class, expectedExceptionsMessageRegExp = "Multiple metric entities with the same name but different types.*")
+  public void testConflictMetricsDifferentUnit() {
+    ModuleMetricEntityInterface.getUniqueMetricEntities(ConflictEnum.class);
+  }
+
+  private enum EmptyEnum implements ModuleMetricEntityInterface {
+    ;
+    @Override
+    public MetricEntity getMetricEntity() {
+      return null;
+    }
+  }
+
+  private enum SingleEnum implements ModuleMetricEntityInterface {
+    ENUM_ONE(new MetricEntity("enum_one", MetricType.COUNTER, MetricUnit.NUMBER, TEST_DESC, TEST_DIMENSIONS));
+
+    private final MetricEntity metric;
+
+    SingleEnum(MetricEntity m) {
+      this.metric = m;
+    }
+
+    @Override
+    public MetricEntity getMetricEntity() {
+      return metric;
+    }
+  }
+
+  private enum TwoDistinctEnum implements ModuleMetricEntityInterface {
+    ENUM_ONE(new MetricEntity("enum_one", MetricType.COUNTER, MetricUnit.NUMBER, TEST_DESC, TEST_DIMENSIONS)),
+    ENUM_TWO(new MetricEntity("enum_two", MetricType.HISTOGRAM, MetricUnit.MILLISECOND, TEST_DESC, TEST_DIMENSIONS));
+
+    private final MetricEntity metric;
+
+    TwoDistinctEnum(MetricEntity m) {
+      this.metric = m;
+    }
+
+    @Override
+    public MetricEntity getMetricEntity() {
+      return metric;
+    }
+  }
+
+  private enum DuplicateEnum implements ModuleMetricEntityInterface {
+    ENUM_ONE(new MetricEntity("enum_dup", MetricType.COUNTER, MetricUnit.NUMBER, TEST_DESC, TEST_DIMENSIONS)),
+    ENUM_TWO(new MetricEntity("enum_dup", MetricType.COUNTER, MetricUnit.NUMBER, TEST_DESC, TEST_DIMENSIONS));
+
+    private final MetricEntity metric;
+
+    DuplicateEnum(MetricEntity m) {
+      this.metric = m;
+    }
+
+    @Override
+    public MetricEntity getMetricEntity() {
+      return metric;
+    }
+  }
+
+  private enum ConflictEnum implements ModuleMetricEntityInterface {
+    ENUM_CONFLICT_ONE(
+        new MetricEntity("enum_conflict", MetricType.COUNTER, MetricUnit.NUMBER, TEST_DESC, TEST_DIMENSIONS)
+    ),
+    ENUM_CONFLICT_TWO(
+        new MetricEntity("enum_conflict", MetricType.HISTOGRAM, MetricUnit.NUMBER, TEST_DESC, TEST_DIMENSIONS)
+    );
+
+    private final MetricEntity metric;
+
+    ConflictEnum(MetricEntity m) {
+      this.metric = m;
+    }
+
+    @Override
+    public MetricEntity getMetricEntity() {
+      return metric;
+    }
+  }
+}

--- a/services/venice-router/src/main/java/com/linkedin/venice/router/RouterServer.java
+++ b/services/venice-router/src/main/java/com/linkedin/venice/router/RouterServer.java
@@ -88,6 +88,7 @@ import com.linkedin.venice.stats.VeniceJVMStats;
 import com.linkedin.venice.stats.VeniceMetricsRepository;
 import com.linkedin.venice.stats.ZkClientStatusStats;
 import com.linkedin.venice.stats.metrics.MetricEntity;
+import com.linkedin.venice.stats.metrics.ModuleMetricEntityInterface;
 import com.linkedin.venice.throttle.EventThrottler;
 import com.linkedin.venice.utils.DaemonThreadFactory;
 import com.linkedin.venice.utils.HelixUtils;
@@ -114,7 +115,6 @@ import java.net.InetSocketAddress;
 import java.net.SocketAddress;
 import java.time.Duration;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.LinkedHashMap;
@@ -128,7 +128,6 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
-import java.util.stream.Collectors;
 import org.apache.helix.InstanceType;
 import org.apache.helix.manager.zk.ZKHelixManager;
 import org.apache.helix.zookeeper.impl.client.ZkClient;
@@ -202,8 +201,8 @@ public class RouterServer extends AbstractVeniceService {
 
   public static final String ROUTER_SERVICE_NAME = "venice-router";
   public static final String ROUTER_SERVICE_METRIC_PREFIX = "router";
-  public static final Collection<MetricEntity> ROUTER_SERVICE_METRIC_ENTITIES = Collections.unmodifiableList(
-      Arrays.stream(RouterMetricEntity.values()).map(RouterMetricEntity::getMetricEntity).collect(Collectors.toList()));
+  public static final Collection<MetricEntity> ROUTER_SERVICE_METRIC_ENTITIES =
+      ModuleMetricEntityInterface.getUniqueMetricEntities(RouterMetricEntity.class);
   /**
    * Thread number used to monitor the listening port;
    */

--- a/services/venice-router/src/main/java/com/linkedin/venice/router/stats/RouterMetricEntity.java
+++ b/services/venice-router/src/main/java/com/linkedin/venice/router/stats/RouterMetricEntity.java
@@ -14,13 +14,14 @@ import com.linkedin.venice.stats.dimensions.VeniceMetricsDimensions;
 import com.linkedin.venice.stats.metrics.MetricEntity;
 import com.linkedin.venice.stats.metrics.MetricType;
 import com.linkedin.venice.stats.metrics.MetricUnit;
+import com.linkedin.venice.stats.metrics.ModuleMetricEntityInterface;
 import java.util.Set;
 
 
 /**
  * List all Metric entities for router
  */
-public enum RouterMetricEntity {
+public enum RouterMetricEntity implements ModuleMetricEntityInterface {
   /**
    * Count of all requests during response handling along with response codes
    */
@@ -106,6 +107,7 @@ public enum RouterMetricEntity {
     this.metricEntity = new MetricEntity(this.name().toLowerCase(), metricType, unit, description, dimensionsList);
   }
 
+  @Override
   public MetricEntity getMetricEntity() {
     return metricEntity;
   }


### PR DESCRIPTION
## Problem Statement
To set up exponential histogram for certain metrics, multiple views are registered with all the relevant metric names. If there are more than 1 `MetricEntity(ME)` with the same name (for instance, `CALL_TIME` and `CALL_TIME_DVC` both have the same metric name: `call_time`), passing all of them to `setExponentialHistogramAggregation` will result in duplicate metrics (attaching an image for reference)
<img width="1463" alt="image" src="https://github.com/user-attachments/assets/b35ed0ad-e26f-4abd-807f-e64b4c5883db" />

## Solution
Added `getUniqueMetricEntities` to 
1. get only unique ME based on metric names instead of duplications
2. validate if there are multiple ME with the same name but with different types.

###  Code changes
- [ ] Added new code behind **a config**. If so list the config names and their default values in the PR description.
- [ ] Introduced new **log lines**. 
  - [ ] Confirmed if logs need to be **rate limited** to avoid excessive logging.

###  **Concurrency-Specific Checks**
Both reviewer and PR author to verify
- [x] Code has **no race conditions** or **thread safety issues**.
- [x] Proper **synchronization mechanisms** (e.g., `synchronized`, `RWLock`) are used where needed.
- [x] No **blocking calls** inside critical sections that could lead to deadlocks or performance degradation.
- [x] Verified **thread-safe collections** are used (e.g., `ConcurrentHashMap`, `CopyOnWriteArrayList`).
- [x] Validated proper exception handling in multi-threaded code to avoid silent thread termination.


## How was this PR tested?
- [x] New unit tests added.
- [ ] New integration tests added.
- [x] Modified or extended existing tests.
- [ ] Verified backward compatibility (if applicable).

## Does this PR introduce any user-facing or breaking changes?
- [x] No. You can skip the rest of this section.
- [ ] Yes. Clearly explain the behavior change and its impact.