### PR TITLE
[vpj] Push Job Timeout

### DIFF
--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/VenicePushJob.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/VenicePushJob.java
@@ -2578,7 +2578,7 @@ public class VenicePushJob implements AutoCloseable {
     sendPushJobDetailsToController();
   }
 
-  private void killJob(PushJobSetting pushJobSetting, ControllerClient controllerClient) {
+  void killJob(PushJobSetting pushJobSetting, ControllerClient controllerClient) {
     // Attempting to kill job. There's a race condition, but meh. Better kill when you know it's running
     killDataWriterJob();
     if (!pushJobSetting.isIncrementalPush) {

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/VenicePushJob.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/VenicePushJob.java
@@ -661,7 +661,7 @@ public class VenicePushJob implements AutoCloseable {
   public void run() {
     ScheduledExecutorService timeoutExecutor = Executors.newSingleThreadScheduledExecutor();
     long bootstrapToOnlineTimeoutInHours =
-        getPushJobSetting().storeResponse.getStore().getBootstrapToOnlineTimeoutInHours();
+        getStoreResponse(pushJobSetting.storeName).getStore().getBootstrapToOnlineTimeoutInHours();
     Future<?> timeoutFuture = timeoutExecutor.schedule(() -> {
       LOGGER.error("Timeout reached. Stopping the job.");
       cancel();

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/VenicePushJob.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/VenicePushJob.java
@@ -659,6 +659,12 @@ public class VenicePushJob implements AutoCloseable {
    * @throws VeniceException
    */
   public void run() {
+    Optional<SSLFactory> sslFactory = VPJSSLUtils.createSSLFactory(
+        pushJobSetting.enableSSL,
+        props.getString(SSL_FACTORY_CLASS_NAME, DEFAULT_SSL_FACTORY_CLASS_NAME),
+        this.sslProperties);
+    initControllerClient(pushJobSetting.storeName, sslFactory);
+
     ScheduledExecutorService timeoutExecutor = Executors.newSingleThreadScheduledExecutor();
     long bootstrapToOnlineTimeoutInHours =
         getStoreResponse(pushJobSetting.storeName).getStore().getBootstrapToOnlineTimeoutInHours();
@@ -677,11 +683,6 @@ public class VenicePushJob implements AutoCloseable {
 
   private void runPushJob() {
     try {
-      Optional<SSLFactory> sslFactory = VPJSSLUtils.createSSLFactory(
-          pushJobSetting.enableSSL,
-          props.getString(SSL_FACTORY_CLASS_NAME, DEFAULT_SSL_FACTORY_CLASS_NAME),
-          this.sslProperties);
-      initControllerClient(pushJobSetting.storeName, sslFactory);
       pushJobSetting.clusterName = controllerClient.getClusterName();
       LOGGER.info(
           "The store {} is discovered in Venice cluster {}",

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/VenicePushJob.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/VenicePushJob.java
@@ -164,7 +164,6 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.Properties;
 import java.util.Set;
-import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import org.apache.avro.Schema;
 import org.apache.commons.lang.StringUtils;
@@ -2306,7 +2305,6 @@ public class VenicePushJob implements AutoCloseable {
      * no more than {@link DEFAULT_JOB_STATUS_IN_UNKNOWN_STATE_TIMEOUT_MS}.
      */
     long unknownStateStartTimeMs = 0;
-    long pollStartTimeMs = System.currentTimeMillis();
 
     String topicToMonitor = getTopicToMonitor(pushJobSetting);
 
@@ -2375,14 +2373,6 @@ public class VenicePushJob implements AutoCloseable {
           LOGGER.info("Successfully pushed {} to all the regions", pushJobSetting.topic);
         }
         return;
-      }
-      long bootstrapToOnlineTimeoutInHours =
-          VenicePushJob.this.pushJobSetting.storeResponse.getStore().getBootstrapToOnlineTimeoutInHours();
-      long durationMs = LatencyUtils.getElapsedTimeFromMsToMs(pollStartTimeMs);
-      if (durationMs > TimeUnit.HOURS.toMillis(bootstrapToOnlineTimeoutInHours)) {
-        throw new VeniceException(
-            "Failing push-job for store " + VenicePushJob.this.pushJobSetting.storeResponse.getName()
-                + " which is still running after " + TimeUnit.MILLISECONDS.toHours(durationMs) + " hours.");
       }
       if (!overallStatus.equals(ExecutionStatus.UNKNOWN)) {
         unknownStateStartTimeMs = 0;

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/VenicePushJob.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/VenicePushJob.java
@@ -668,7 +668,8 @@ public class VenicePushJob implements AutoCloseable {
           pushJobSetting.storeName,
           pushJobSetting.clusterName);
 
-      long bootstrapToOnlineTimeoutInHours = getBootstrapToOnlineTimeoutInHours();
+      long bootstrapToOnlineTimeoutInHours =
+          getStoreResponse(pushJobSetting.storeName).getStore().getBootstrapToOnlineTimeoutInHours();
       timeoutExecutor.schedule(() -> {
         cancel();
         throw new VeniceException(
@@ -2642,12 +2643,6 @@ public class VenicePushJob implements AutoCloseable {
       throw new VeniceException("The push job is not initialized yet");
     }
     return getTopicToMonitor(this.pushJobSetting);
-  }
-
-  // Visible for testing
-  public long getBootstrapToOnlineTimeoutInHours() {
-    // getStoreResponse() is necessary because this is called at the very start of the job
-    return getStoreResponse(pushJobSetting.storeName).getStore().getBootstrapToOnlineTimeoutInHours();
   }
 
   private String getTopicToMonitor(PushJobSetting pushJobSetting) {

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/VenicePushJob.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/VenicePushJob.java
@@ -668,8 +668,7 @@ public class VenicePushJob implements AutoCloseable {
           pushJobSetting.storeName,
           pushJobSetting.clusterName);
 
-      long bootstrapToOnlineTimeoutInHours =
-          getStoreResponse(pushJobSetting.storeName).getStore().getBootstrapToOnlineTimeoutInHours();
+      long bootstrapToOnlineTimeoutInHours = getBootstrapToOnlineTimeoutInHours();
       timeoutExecutor.schedule(() -> {
         cancel();
         throw new VeniceException(
@@ -2643,6 +2642,12 @@ public class VenicePushJob implements AutoCloseable {
       throw new VeniceException("The push job is not initialized yet");
     }
     return getTopicToMonitor(this.pushJobSetting);
+  }
+
+  // Visible for testing
+  public long getBootstrapToOnlineTimeoutInHours() {
+    // getStoreResponse() is necessary because this is called at the very start of the job
+    return getStoreResponse(pushJobSetting.storeName).getStore().getBootstrapToOnlineTimeoutInHours();
   }
 
   private String getTopicToMonitor(PushJobSetting pushJobSetting) {

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/VenicePushJob.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/VenicePushJob.java
@@ -660,7 +660,8 @@ public class VenicePushJob implements AutoCloseable {
    */
   public void run() {
     ScheduledExecutorService timeoutExecutor = Executors.newSingleThreadScheduledExecutor();
-    long bootstrapToOnlineTimeoutInHours = pushJobSetting.storeResponse.getStore().getBootstrapToOnlineTimeoutInHours();
+    long bootstrapToOnlineTimeoutInHours =
+        getPushJobSetting().storeResponse.getStore().getBootstrapToOnlineTimeoutInHours();
     Future<?> timeoutFuture = timeoutExecutor.schedule(() -> {
       LOGGER.error("Timeout reached. Stopping the job.");
       cancel();
@@ -2602,7 +2603,7 @@ public class VenicePushJob implements AutoCloseable {
     }
   }
 
-  private void killDataWriterJob() {
+  void killDataWriterJob() {
     if (dataWriterComputeJob == null) {
       LOGGER.warn("No op to kill a null data writer job");
       return;

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/VenicePushJob.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/VenicePushJob.java
@@ -870,8 +870,8 @@ public class VenicePushJob implements AutoCloseable {
             ex);
       } finally {
         try {
-          killJob(pushJobSetting, controllerClient);
-          LOGGER.info("Successfully killed the failed push job.");
+          // killJob(pushJobSetting, controllerClient);
+          // LOGGER.info("Successfully killed the failed push job.");
         } catch (Exception ex) {
           LOGGER.info("Failed to stop and cleanup the job. New pushes might be blocked.", ex);
         }

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/mapreduce/datawriter/jobs/DataWriterMRJob.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/mapreduce/datawriter/jobs/DataWriterMRJob.java
@@ -328,7 +328,7 @@ public class DataWriterMRJob extends DataWriterComputeJob {
   }
 
   @Override
-  protected void runComputeJob() {
+  public void runComputeJob() {
     LOGGER.info("Triggering MR job for data writer");
     try {
       runningJob = JobUtils.runJobWithConfig(jobConf, jobClientWrapper);
@@ -346,6 +346,7 @@ public class DataWriterMRJob extends DataWriterComputeJob {
   public void kill() {
     if (runningJob == null) {
       LOGGER.warn("No op to kill a null running job");
+      super.kill();
       return;
     }
     try {

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/jobs/DataWriterComputeJob.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/jobs/DataWriterComputeJob.java
@@ -88,7 +88,7 @@ public abstract class DataWriterComputeJob implements ComputeJob {
 
   public abstract DataWriterTaskTracker getTaskTracker();
 
-  protected void validateJob() {
+  public void validateJob() {
     DataWriterTaskTracker dataWriterTaskTracker = getTaskTracker();
     if (dataWriterTaskTracker == null) {
       throw new VeniceException("DataWriterTaskTracker is not set. Unable to validate the job status.");

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/jobs/DataWriterComputeJob.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/jobs/DataWriterComputeJob.java
@@ -2,6 +2,7 @@ package com.linkedin.venice.jobs;
 
 import static com.linkedin.venice.ConfigKeys.PASS_THROUGH_CONFIG_PREFIXES_LIST_KEY;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.linkedin.venice.ConfigKeys;
 import com.linkedin.venice.exceptions.VeniceException;
 import com.linkedin.venice.hadoop.PushJobSetting;
@@ -88,6 +89,7 @@ public abstract class DataWriterComputeJob implements ComputeJob {
 
   public abstract DataWriterTaskTracker getTaskTracker();
 
+  @VisibleForTesting
   public void validateJob() {
     DataWriterTaskTracker dataWriterTaskTracker = getTaskTracker();
     if (dataWriterTaskTracker == null) {
@@ -160,7 +162,8 @@ public abstract class DataWriterComputeJob implements ComputeJob {
     }
   }
 
-  protected abstract void runComputeJob();
+  @VisibleForTesting
+  public abstract void runComputeJob();
 
   @Override
   public void configure(VeniceProperties properties) {

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/spark/datawriter/jobs/AbstractDataWriterSparkJob.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/spark/datawriter/jobs/AbstractDataWriterSparkJob.java
@@ -323,7 +323,7 @@ public abstract class AbstractDataWriterSparkJob extends DataWriterComputeJob {
   }
 
   @Override
-  protected void runComputeJob() {
+  public void runComputeJob() {
     // Load data from input path
     Dataset<Row> dataFrame = getInputDataFrame();
     validateDataFrame(dataFrame);

--- a/clients/venice-push-job/src/test/java/com/linkedin/venice/hadoop/VenicePushJobTest.java
+++ b/clients/venice-push-job/src/test/java/com/linkedin/venice/hadoop/VenicePushJobTest.java
@@ -335,11 +335,6 @@ public class VenicePushJobTest {
     doReturn(response).when(client).killOfflinePushJob(anyString());
 
     try (VenicePushJob pushJob = getSpyVenicePushJob(props, client)) {
-      StoreInfo storeInfo = new StoreInfo();
-      storeInfo.setBootstrapToOnlineTimeoutInHours(0);
-      PushJobSetting pushJobSetting = pushJob.getPushJobSetting();
-      pushJobSetting.storeResponse = new StoreResponse();
-      pushJobSetting.storeResponse.setStore(storeInfo);
       CountDownLatch runningJobLatch = new CountDownLatch(1);
       CountDownLatch killedJobLatch = new CountDownLatch(1);
       skipVPJValidation(pushJob);
@@ -369,6 +364,7 @@ public class VenicePushJobTest {
 
       try {
         doCallRealMethod().when(pushJob).runJobAndUpdateStatus();
+        doReturn(0L).when(pushJob).getBootstrapToOnlineTimeoutInHours(); // timeoutExecutor can immediately run
         DataWriterComputeJob dataWriterJob = spy(pushJob.getDataWriterComputeJob());
         pushJob.setDataWriterComputeJob(dataWriterJob);
         doNothing().when(dataWriterJob).validateJob();

--- a/clients/venice-push-job/src/test/java/com/linkedin/venice/hadoop/VenicePushJobTest.java
+++ b/clients/venice-push-job/src/test/java/com/linkedin/venice/hadoop/VenicePushJobTest.java
@@ -307,6 +307,8 @@ public class VenicePushJobTest {
       pushJobSetting.storeResponse.setStore(storeInfo);
       skipVPJValidation(pushJob);
       try {
+        DataWriterComputeJob dataWriterJob = spy(pushJob.getDataWriterComputeJob());
+        pushJob.setDataWriterComputeJob(dataWriterJob);
         pushJob.run();
         fail("Test should fail because pollStatusUntilComplete() never saw COMPLETE status, but doesn't.");
       } catch (VeniceException e) {
@@ -379,7 +381,6 @@ public class VenicePushJobTest {
         // Expected, because the data writer job is not configured to run successfully in this unit test environment
       }
       verify(pushJob, times(1)).cancel();
-      verify(pushJob.getDataWriterComputeJob(), times(1)).kill();
       assertEquals(pushJob.getDataWriterComputeJob().getStatus(), DataWriterComputeJob.Status.KILLED);
     }
   }

--- a/clients/venice-push-job/src/test/java/com/linkedin/venice/hadoop/VenicePushJobTest.java
+++ b/clients/venice-push-job/src/test/java/com/linkedin/venice/hadoop/VenicePushJobTest.java
@@ -278,15 +278,21 @@ public class VenicePushJobTest {
     }
   }
 
+  @DataProvider(name = "DataWriterJobClasses")
+  public Object[][] getDataWriterJobClasses() {
+    return new Object[][] { { DataWriterMRJob.class }, { DataWriterSparkJob.class } };
+  }
+
   /**
    * Test that VenicePushJob.cancel() is called after bootstrapToOnlineTimeoutInHours is reached.
    * UNKNOWN status is returned for pollStatusUntilComplete() to stall the job until cancel() can be called.
    */
-  @Test
-  public void testPushJobTimeout() throws Exception {
+  @Test(dataProvider = "DataWriterJobClasses")
+  public void testPushJobTimeout(Class<? extends DataWriterComputeJob> dataWriterJobClass) throws Exception {
     Properties props = getVpjRequiredProperties();
     props.put(KEY_FIELD_PROP, "id");
     props.put(VALUE_FIELD_PROP, "name");
+    props.put(DATA_WRITER_COMPUTE_JOB_CLASS, dataWriterJobClass.getName());
     ControllerClient client = getClient();
     JobStatusQueryResponse response = mock(JobStatusQueryResponse.class);
     doReturn("UNKNOWN").when(response).getStatus();
@@ -312,16 +318,11 @@ public class VenicePushJobTest {
     }
   }
 
-  @DataProvider(name = "DataWriterJobClasses")
-  public Object[][] getDataWriterJobClasses() {
-    return new Object[][] { { DataWriterMRJob.class }, { DataWriterSparkJob.class } };
-  }
-
   /**
    * Ensures that the data writer job is killed if the job times out. Uses an Answer to stall the data writer job
    * while it's running in order for it to get killed properly.
    */
-  @Test(timeOut = 5 * Time.MS_PER_SECOND, dataProvider = "DataWriterJobClasses")
+  @Test(dataProvider = "DataWriterJobClasses")
   public void testDataWriterComputeJobTimeout(Class<? extends DataWriterComputeJob> dataWriterJobClass)
       throws Exception {
     Properties props = getVpjRequiredProperties();

--- a/clients/venice-push-job/src/test/java/com/linkedin/venice/hadoop/VenicePushJobTest.java
+++ b/clients/venice-push-job/src/test/java/com/linkedin/venice/hadoop/VenicePushJobTest.java
@@ -335,6 +335,11 @@ public class VenicePushJobTest {
     doReturn(response).when(client).killOfflinePushJob(anyString());
 
     try (VenicePushJob pushJob = getSpyVenicePushJob(props, client)) {
+      StoreInfo storeInfo = new StoreInfo();
+      storeInfo.setBootstrapToOnlineTimeoutInHours(0);
+      PushJobSetting pushJobSetting = pushJob.getPushJobSetting();
+      pushJobSetting.storeResponse = new StoreResponse();
+      pushJobSetting.storeResponse.setStore(storeInfo);
       CountDownLatch runningJobLatch = new CountDownLatch(1);
       CountDownLatch killedJobLatch = new CountDownLatch(1);
       skipVPJValidation(pushJob);
@@ -364,7 +369,6 @@ public class VenicePushJobTest {
 
       try {
         doCallRealMethod().when(pushJob).runJobAndUpdateStatus();
-        doReturn(0L).when(pushJob).getBootstrapToOnlineTimeoutInHours(); // timeoutExecutor can immediately run
         DataWriterComputeJob dataWriterJob = spy(pushJob.getDataWriterComputeJob());
         pushJob.setDataWriterComputeJob(dataWriterJob);
         doNothing().when(dataWriterJob).validateJob();

--- a/clients/venice-push-job/src/test/java/com/linkedin/venice/hadoop/VenicePushJobTest.java
+++ b/clients/venice-push-job/src/test/java/com/linkedin/venice/hadoop/VenicePushJobTest.java
@@ -280,7 +280,7 @@ public class VenicePushJobTest {
 
   @DataProvider(name = "DataWriterJobClasses")
   public Object[][] getDataWriterJobClasses() {
-    return new Object[][] { { DataWriterMRJob.class }, { DataWriterSparkJob.class } };
+    return new Object[][] { { DataWriterSparkJob.class }, { DataWriterMRJob.class } };
   }
 
   /**

--- a/clients/venice-push-job/src/test/java/com/linkedin/venice/hadoop/VenicePushJobTest.java
+++ b/clients/venice-push-job/src/test/java/com/linkedin/venice/hadoop/VenicePushJobTest.java
@@ -39,7 +39,6 @@ import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.atLeast;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doCallRealMethod;
 import static org.mockito.Mockito.doNothing;
@@ -292,7 +291,7 @@ public class VenicePushJobTest {
     Properties props = getVpjRequiredProperties();
     props.put(KEY_FIELD_PROP, "id");
     props.put(VALUE_FIELD_PROP, "name");
-    props.put(DATA_WRITER_COMPUTE_JOB_CLASS, dataWriterJobClass.getName());
+    props.put(DATA_WRITER_COMPUTE_JOB_CLASS, dataWriterJobClass.getCanonicalName());
     ControllerClient client = getClient();
     JobStatusQueryResponse response = mock(JobStatusQueryResponse.class);
     doReturn("UNKNOWN").when(response).getStatus();
@@ -313,8 +312,8 @@ public class VenicePushJobTest {
       } catch (VeniceException e) {
         Assert.assertTrue(e.getMessage().contains("push job is still in unknown state."));
       }
-      verify(pushJob, atLeast(1)).cancel();
-      verify(pushJob, atLeast(1)).killDataWriterJob();
+      verify(pushJob, times(1)).cancel();
+      verify(pushJob, times(2)).killDataWriterJob();
     }
   }
 
@@ -348,7 +347,7 @@ public class VenicePushJobTest {
       /*
        * 1. Data writer job starts and status is set to RUNNING.
        * 2. Timeout thread kills the data writer job and status is set to KILLED.
-       * The latch is used to stall the validateJob() method until the data writer job is killed.
+       * The latch is used to stall the runComputeJob() method until the data writer job is killed.
        */
       Answer<Void> stallDataWriterJob = invocation -> {
         // At this point, the data writer job status is already set to RUNNING.
@@ -379,8 +378,8 @@ public class VenicePushJobTest {
       } catch (VeniceException e) {
         // Expected, because the data writer job is not configured to run successfully in this unit test environment
       }
-      verify(pushJob, atLeast(1)).cancel();
-      verify(pushJob, atLeast(1)).killDataWriterJob();
+      verify(pushJob, times(1)).cancel();
+      verify(pushJob, times(2)).killDataWriterJob();
       assertEquals(pushJob.getDataWriterComputeJob().getStatus(), DataWriterComputeJob.Status.KILLED);
     }
   }

--- a/clients/venice-push-job/src/test/java/com/linkedin/venice/hadoop/VenicePushJobTest.java
+++ b/clients/venice-push-job/src/test/java/com/linkedin/venice/hadoop/VenicePushJobTest.java
@@ -73,6 +73,7 @@ import com.linkedin.venice.exceptions.UndefinedPropertyException;
 import com.linkedin.venice.exceptions.VeniceException;
 import com.linkedin.venice.hadoop.exceptions.VeniceValidationException;
 import com.linkedin.venice.hadoop.task.datawriter.DataWriterTaskTracker;
+import com.linkedin.venice.jobs.DataWriterComputeJob;
 import com.linkedin.venice.message.KafkaKey;
 import com.linkedin.venice.meta.HybridStoreConfigImpl;
 import com.linkedin.venice.meta.MaterializedViewParameters;
@@ -99,8 +100,11 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
 import org.apache.avro.Schema;
+import org.mockito.stubbing.Answer;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
@@ -298,6 +302,66 @@ public class VenicePushJobTest {
         fail("Test should fail because pollStatusUntilComplete() never saw COMPLETE status, but doesn't.");
       } catch (VeniceException e) {
         Assert.assertTrue(e.getMessage().contains("push job is still in unknown state."));
+      }
+      verify(pushJob, atLeast(1)).cancel();
+      verify(pushJob, atLeast(1)).killDataWriterJob();
+    }
+  }
+
+  /**
+   * Ensures that the data writer job is killed if the job times out. Uses an Answer to stall the data writer job
+   * while it's running in order for it to get killed properly.
+   */
+  @Test
+  public void testDataWriterComputeJobTimeout() throws Exception {
+    Properties props = getVpjRequiredProperties();
+    props.put(KEY_FIELD_PROP, "key");
+    props.put(VALUE_FIELD_PROP, "value");
+    ControllerClient client = getClient();
+    JobStatusQueryResponse response = mock(JobStatusQueryResponse.class);
+    doReturn("SUCCESS").when(response).getStatus();
+    doReturn(response).when(client).queryOverallJobStatus(anyString(), any(), any(), anyBoolean());
+    doReturn(response).when(client).killOfflinePushJob(anyString());
+
+    try (VenicePushJob pushJob = getSpyVenicePushJob(props, client)) {
+      StoreInfo storeInfo = new StoreInfo();
+      storeInfo.setBootstrapToOnlineTimeoutInHours(0);
+      PushJobSetting pushJobSetting = pushJob.getPushJobSetting();
+      pushJobSetting.storeResponse = new StoreResponse();
+      pushJobSetting.storeResponse.setStore(storeInfo);
+      CountDownLatch runningJobLatch = new CountDownLatch(1);
+      CountDownLatch killedJobLatch = new CountDownLatch(1);
+      doNothing().when(pushJob).validateKeySchema(any());
+      doNothing().when(pushJob).validateValueSchema(any(), any(), anyBoolean());
+
+      /*
+       * 1. Data writer job starts and status is set to RUNNING.
+       * 2. Timeout thread kills the data writer job and status is set to KILLED.
+       * The latch is used to stall the validateJob() method until the data writer job is killed.
+       */
+      Answer<Void> stallDataWriterJob = invocation -> {
+        // At this point, the data writer job status is already set to RUNNING.
+        runningJobLatch.countDown(); // frees the VenicePushJob.killJob() method
+        killedJobLatch.await(5, TimeUnit.SECONDS); // waits for this data writer job to be killed
+        return null;
+      };
+
+      Answer<Void> killDataWriterJob = invocation -> {
+        runningJobLatch.await(5, TimeUnit.SECONDS); // waits for the data writer job status to be set to RUNNING
+        pushJob.killDataWriterJob();
+        killedJobLatch.countDown(); // frees the DataWriterComputeJob.validateJob() method
+        return null;
+      };
+
+      try {
+        doCallRealMethod().when(pushJob).runJobAndUpdateStatus();
+        DataWriterComputeJob dataWriterJob = spy(pushJob.getDataWriterComputeJob());
+        pushJob.setDataWriterComputeJob(dataWriterJob);
+        doAnswer(stallDataWriterJob).when(dataWriterJob).validateJob();
+        doAnswer(killDataWriterJob).when(pushJob).killJob(any(), any());
+        pushJob.run(); // data writer job will run in this main test thread
+      } catch (VeniceException e) {
+        assertTrue(e.getMessage().contains("No data found at source path"), e.getMessage());
       }
       verify(pushJob, atLeast(1)).cancel();
       verify(pushJob, atLeast(1)).killDataWriterJob();

--- a/clients/venice-push-job/src/test/java/com/linkedin/venice/hadoop/VenicePushJobTest.java
+++ b/clients/venice-push-job/src/test/java/com/linkedin/venice/hadoop/VenicePushJobTest.java
@@ -313,7 +313,7 @@ public class VenicePushJobTest {
         Assert.assertTrue(e.getMessage().contains("push job is still in unknown state."));
       }
       verify(pushJob, times(1)).cancel();
-      verify(pushJob, times(2)).killDataWriterJob();
+      verify(pushJob.getDataWriterComputeJob(), times(1)).kill();
     }
   }
 
@@ -379,7 +379,7 @@ public class VenicePushJobTest {
         // Expected, because the data writer job is not configured to run successfully in this unit test environment
       }
       verify(pushJob, times(1)).cancel();
-      verify(pushJob, times(2)).killDataWriterJob();
+      verify(pushJob.getDataWriterComputeJob(), times(1)).kill();
       assertEquals(pushJob.getDataWriterComputeJob().getStatus(), DataWriterComputeJob.Status.KILLED);
     }
   }

--- a/clients/venice-push-job/src/test/java/com/linkedin/venice/hadoop/VenicePushJobTest.java
+++ b/clients/venice-push-job/src/test/java/com/linkedin/venice/hadoop/VenicePushJobTest.java
@@ -383,8 +383,8 @@ public class VenicePushJobTest {
       }
       verify(pushJob, times(1)).cancel();
       verify(pushJob, times(1)).killJob(any(), any());
-      verify(runningJobLatch, times(1)).countDown();
-      verify(killedJobLatch, times(1)).countDown();
+      assertEquals(runningJobLatch.getCount(), 0);
+      assertEquals(killedJobLatch.getCount(), 0);
       verify(pushJob, times(1)).killDataWriterJob();
       verify(dataWriterJob, atLeast(1)).kill();
       assertEquals(pushJob.getDataWriterComputeJob().getStatus(), DataWriterComputeJob.Status.KILLED);

--- a/clients/venice-push-job/src/test/java/com/linkedin/venice/hadoop/VenicePushJobTest.java
+++ b/clients/venice-push-job/src/test/java/com/linkedin/venice/hadoop/VenicePushJobTest.java
@@ -355,14 +355,14 @@ public class VenicePushJobTest {
       Answer<Void> stallDataWriterJob = invocation -> {
         // At this point, the data writer job status is already set to RUNNING.
         runningJobLatch.countDown(); // frees VenicePushJob.killJob()
-        if (!killedJobLatch.await(5, TimeUnit.SECONDS)) { // waits for this data writer job to be killed
+        if (!killedJobLatch.await(10, TimeUnit.SECONDS)) { // waits for this data writer job to be killed
           fail("Timed out waiting for the data writer job to be killed.");
         }
         throw new VeniceException("No data found at source path");
       };
 
       Answer<Void> killDataWriterJob = invocation -> {
-        if (!runningJobLatch.await(5, TimeUnit.SECONDS)) { // waits for job status to be set to RUNNING
+        if (!runningJobLatch.await(10, TimeUnit.SECONDS)) { // waits for job status to be set to RUNNING
           fail("Timed out waiting for the data writer job status to be set to RUNNING");
         }
         pushJob.killDataWriterJob(); // sets job status to KILLED
@@ -382,6 +382,9 @@ public class VenicePushJobTest {
         // Expected, because the data writer job is not configured to run successfully in this unit test environment
       }
       verify(pushJob, times(1)).cancel();
+      verify(pushJob, times(1)).killJob(any(), any());
+      verify(runningJobLatch, times(1)).countDown();
+      verify(killedJobLatch, times(1)).countDown();
       verify(pushJob, times(1)).killDataWriterJob();
       verify(dataWriterJob, atLeast(1)).kill();
       assertEquals(pushJob.getDataWriterComputeJob().getStatus(), DataWriterComputeJob.Status.KILLED);


### PR DESCRIPTION
<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat], [protocol]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

Venice Push Job Diagram as a refresher:
![VPJ-Diagram](https://github.com/user-attachments/assets/45ea7ccb-547e-43f3-bf56-35dc24547f8a)

## Problem Statement
<!--
Describe
- What problem are you trying to solve
- What issues or limitations exist in the current code
- Why this change is necessary 
-->
There is no timeout on the Compute Engine `DataWriterComputeJob`. This leads to some push jobs taking days and even sometimes weeks to complete, which significantly delays the debugging process. There is an existing timeout (`bootstrapToOnlineTimeoutInHours`) on the job status polling, but that takes place after the data writer job portion (which is where we've been witnessing significant delays). With the increased frequency of KIF repushes, this issue will become even more pronounced.

## Solution
<!--
Describe
- What changes you are making and why. 
- How these changes solve the problem.
- Any performance considerations or trade-offs. 
- Describe what testings you have done, for example, performance testing etc.
-->
There should be a timeout on the entire push job as a whole. If exceeded, the push job should be cancelled. The existing configuration `bootstrapToOnlineTimeoutInHours` can be repurposed for this, and this should've be the original purpose of the configuration.

###  **Concurrency-Specific Checks**
Both reviewer and PR author to verify
- [X] Code has **no race conditions** or **thread safety issues**.
- [X] No **blocking calls** inside critical sections that could lead to deadlocks or performance degradation.
- [X] Verified **thread-safe collections** are used (e.g., `ConcurrentHashMap`, `CopyOnWriteArrayList`).
- [X] Validated proper exception handling in multi-threaded code to avoid silent thread termination.

## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
- [X] New unit tests added.
* Added `testPushJobTimeout()` which tests the poll job status gets cancelled.
* Added `testDataWriterComputeJobTimeout()` which tests the data writer job gets killed.
* Deprecated `testPushJobPollStatus()` and `testPushJobUnknownPollStatusDoesWaiting()`, which pertained to the old usage of the `bootstrapToOnlineTimeoutInHours` configuration.

## Does this PR introduce any user-facing or breaking changes?
<!--  
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [X] No. You can skip the rest of this section.