### PR TITLE
[test] Fix flakey dvc delayed ingestion and killed repush status test

### DIFF
--- a/internal/venice-test-common/build.gradle
+++ b/internal/venice-test-common/build.gradle
@@ -217,7 +217,7 @@ def integrationTestBuckets = [
       "com.linkedin.venice.controllerapi.TestControllerClient",
       "com.linkedin.venice.endToEnd.TestAdminOperationWithPreviousVersion",
       "com.linkedin.venice.endToEnd.TestMaterializedViewEndToEnd",
-      "com.linkedin.venice.endToEnd.TestDeferredVersionSwap"
+      "com.linkedin.venice.endToEnd.TestDeferredVersionSwap*",
   ],
   "1500":[
       "com.linkedin.venice.multicluster.TestMetadataOperationInMultiCluster",

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestDeferredVersionSwap.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestDeferredVersionSwap.java
@@ -591,6 +591,7 @@ public class TestDeferredVersionSwap {
     }
 
     verifyThatPushStatusStoreIsOnline(storeName);
+    verifyThatMetaStoreIsOnline(storeName);
 
     // Create dvc client in target region
     List<VeniceMultiClusterWrapper> childDatacenters = multiRegionMultiClusterWrapper.getChildRegions();
@@ -727,6 +728,7 @@ public class TestDeferredVersionSwap {
     }
 
     verifyThatPushStatusStoreIsOnline(storeName);
+    verifyThatMetaStoreIsOnline(storeName);
 
     // Create dvc client in target region
     List<VeniceMultiClusterWrapper> childDatacenters = multiRegionMultiClusterWrapper.getChildRegions();
@@ -808,6 +810,19 @@ public class TestDeferredVersionSwap {
         StoreResponse storeResponse = childControllerClient.getStore(pushStatusStoreName);
         Assert.assertFalse(storeResponse.isError());
         Assert.assertTrue(storeResponse.getStore().getCurrentVersion() > 0, pushStatusStoreName + " is not ready");
+      });
+    }
+  }
+
+  private void verifyThatMetaStoreIsOnline(String storeName) {
+    for (VeniceMultiClusterWrapper childDatacenter: childDatacenters) {
+      String metaStoreName = VeniceSystemStoreType.META_STORE.getSystemStoreName(storeName);
+      ControllerClient childControllerClient =
+          new ControllerClient(CLUSTER_NAMES[0], childDatacenter.getControllerConnectString());
+      TestUtils.waitForNonDeterministicAssertion(30, TimeUnit.SECONDS, () -> {
+        StoreResponse storeResponse = childControllerClient.getStore(metaStoreName);
+        Assert.assertFalse(storeResponse.isError());
+        Assert.assertTrue(storeResponse.getStore().getCurrentVersion() > 0, metaStoreName + " is not ready");
       });
     }
   }

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestDeferredVersionSwap.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestDeferredVersionSwap.java
@@ -6,13 +6,11 @@ import static com.linkedin.venice.ConfigKeys.CONTROLLER_DEFERRED_VERSION_SWAP_SL
 import static com.linkedin.venice.ConfigKeys.DATA_BASE_PATH;
 import static com.linkedin.venice.ConfigKeys.LOCAL_REGION_NAME;
 import static com.linkedin.venice.utils.IntegrationTestPushUtils.createStoreForJob;
-import static com.linkedin.venice.utils.TestUtils.assertCommand;
 import static com.linkedin.venice.utils.TestWriteUtils.NAME_RECORD_V3_SCHEMA;
 import static com.linkedin.venice.utils.TestWriteUtils.getTempDataDirectory;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.TARGETED_REGION_PUSH_LIST;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.TARGETED_REGION_PUSH_WITH_DEFERRED_SWAP;
 import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertTrue;
@@ -28,11 +26,9 @@ import com.linkedin.venice.client.store.StatTrackingStoreClient;
 import com.linkedin.venice.common.VeniceSystemStoreType;
 import com.linkedin.venice.controllerapi.ControllerClient;
 import com.linkedin.venice.controllerapi.ControllerResponse;
-import com.linkedin.venice.controllerapi.JobStatusQueryResponse;
 import com.linkedin.venice.controllerapi.StoreResponse;
 import com.linkedin.venice.controllerapi.UpdateStoreQueryParams;
 import com.linkedin.venice.controllerapi.VersionCreationResponse;
-import com.linkedin.venice.exceptions.VeniceException;
 import com.linkedin.venice.integration.utils.D2TestUtils;
 import com.linkedin.venice.integration.utils.DaVinciTestContext;
 import com.linkedin.venice.integration.utils.ServiceFactory;
@@ -43,7 +39,6 @@ import com.linkedin.venice.integration.utils.VeniceTwoLayerMultiRegionMultiClust
 import com.linkedin.venice.meta.StoreInfo;
 import com.linkedin.venice.meta.Version;
 import com.linkedin.venice.meta.VersionStatus;
-import com.linkedin.venice.pushmonitor.ExecutionStatus;
 import com.linkedin.venice.utils.IntegrationTestPushUtils;
 import com.linkedin.venice.utils.RegionUtils;
 import com.linkedin.venice.utils.StoreMigrationTestUtil;
@@ -263,170 +258,6 @@ public class TestDeferredVersionSwap {
           false,
           -1);
       assertTrue(versionCreationResponse.isError());
-    }
-  }
-
-  @Test(timeOut = TEST_TIMEOUT * 2, dataProvider = "regionsProvider")
-  public void testDeferredVersionSwapWithFailedPushInNonTargetRegions(String failingRegions) throws IOException {
-    // Always mark the status as ERROR in regions
-    Set<String> failingRegionsList = RegionUtils.parseRegionsFilterList(failingRegions);
-    for (String failingRegion: failingRegionsList) {
-      multiRegionMultiClusterWrapper.failPushInRegion(failingRegion);
-    }
-
-    // Setup job properties
-    File inputDir = getTempDataDirectory();
-    TestWriteUtils.writeSimpleAvroFileWithStringToV3Schema(inputDir, 100, 100);
-    String inputDirPath = "file://" + inputDir.getAbsolutePath();
-    String storeName = Utils.getUniqueString("testDeferredVersionSwapWithFailedPushInNonTargetRegions");
-    Properties props =
-        IntegrationTestPushUtils.defaultVPJProps(multiRegionMultiClusterWrapper, inputDirPath, storeName);
-    String keySchemaStr = "\"string\"";
-    UpdateStoreQueryParams storeParms = new UpdateStoreQueryParams().setUnusedSchemaDeletionEnabled(true);
-    storeParms.setTargetRegionSwapWaitTime(1);
-    String parentControllerURLs = multiRegionMultiClusterWrapper.getControllerConnectString();
-
-    try (ControllerClient parentControllerClient = new ControllerClient(CLUSTER_NAMES[0], parentControllerURLs)) {
-      createStoreForJob(CLUSTER_NAMES[0], keySchemaStr, NAME_RECORD_V3_SCHEMA.toString(), props, storeParms).close();
-
-      // Start push job with target region push enabled and check that it fails
-      props.put(TARGETED_REGION_PUSH_WITH_DEFERRED_SWAP, true);
-      try {
-        TestWriteUtils.runPushJob("Test push job", props);
-      } catch (Exception e) {
-        assertEquals(e.getClass(), VeniceException.class);
-      }
-
-      // Wait for job to fail
-      TestUtils.waitForNonDeterministicAssertion(1, TimeUnit.MINUTES, true, () -> {
-        JobStatusQueryResponse jobStatusQueryResponse = assertCommand(
-            parentControllerClient.queryOverallJobStatus(Version.composeKafkaTopic(storeName, 1), Optional.empty()));
-        ExecutionStatus executionStatus = ExecutionStatus.valueOf(jobStatusQueryResponse.getStatus());
-        assertEquals(executionStatus, ExecutionStatus.ERROR);
-      });
-
-      TestUtils.waitForNonDeterministicAssertion(1, TimeUnit.MINUTES, () -> {
-        Map<String, Integer> coloVersions =
-            parentControllerClient.getStore(storeName).getStore().getColoToCurrentVersions();
-
-        coloVersions.forEach((colo, version) -> {
-          if (!failingRegionsList.contains(colo)) {
-            Assert.assertEquals((int) version, 1);
-          } else {
-            Assert.assertEquals((int) version, 0);
-          }
-        });
-      });
-
-      TestUtils.waitForNonDeterministicAssertion(30, TimeUnit.SECONDS, () -> {
-        StoreInfo parentStore = parentControllerClient.getStore(storeName).getStore();
-        Assert.assertEquals(parentStore.getVersion(1).get().getStatus(), VersionStatus.PARTIALLY_ONLINE);
-      });
-
-      // Check that child version status is marked as ONLINE if it didn't fail
-      for (VeniceMultiClusterWrapper childDatacenter: childDatacenters) {
-        ControllerClient childControllerClient =
-            new ControllerClient(CLUSTER_NAMES[0], childDatacenter.getControllerConnectString());
-        if (!failingRegionsList.contains(childDatacenter.getRegionName())) {
-          StoreResponse store = childControllerClient.getStore(storeName);
-          Optional<Version> version = store.getStore().getVersion(1);
-          assertNotNull(version);
-          assertEquals(version.get().getStatus(), VersionStatus.ONLINE);
-        }
-      }
-
-      // Verify that we can create a new version
-      VersionCreationResponse versionCreationResponse = parentControllerClient.requestTopicForWrites(
-          storeName,
-          1000,
-          Version.PushType.BATCH,
-          Version.guidBasedDummyPushId(),
-          true,
-          true,
-          false,
-          Optional.empty(),
-          Optional.empty(),
-          Optional.empty(),
-          false,
-          -1);
-      assertFalse(versionCreationResponse.isError());
-    }
-  }
-
-  @Test(timeOut = TEST_TIMEOUT * 2, dataProvider = "regionsProvider")
-  public void testDeferredVersionSwapWithFailedPushInTargetRegions(String failingRegions) throws IOException {
-    // Always mark the status as ERROR in regions
-    Set<String> failingRegionsList = RegionUtils.parseRegionsFilterList(failingRegions);
-    for (String failingRegion: failingRegionsList) {
-      multiRegionMultiClusterWrapper.failPushInRegion(failingRegion);
-    }
-
-    // Setup job properties
-    File inputDir = getTempDataDirectory();
-    TestWriteUtils.writeSimpleAvroFileWithStringToV3Schema(inputDir, 100, 100);
-    String inputDirPath = "file://" + inputDir.getAbsolutePath();
-    String storeName = Utils.getUniqueString("testDeferredVersionSwapWithFailedPushInTargetRegions");
-    Properties props =
-        IntegrationTestPushUtils.defaultVPJProps(multiRegionMultiClusterWrapper, inputDirPath, storeName);
-    String keySchemaStr = "\"string\"";
-    UpdateStoreQueryParams storeParms = new UpdateStoreQueryParams().setUnusedSchemaDeletionEnabled(true);
-    storeParms.setTargetRegionSwapWaitTime(1);
-    String parentControllerURLs = multiRegionMultiClusterWrapper.getControllerConnectString();
-
-    try (ControllerClient parentControllerClient = new ControllerClient(CLUSTER_NAMES[0], parentControllerURLs)) {
-      createStoreForJob(CLUSTER_NAMES[0], keySchemaStr, NAME_RECORD_V3_SCHEMA.toString(), props, storeParms).close();
-
-      // Start push job with target region push enabled and check that it fails
-      String targetRegions = REGION1 + ", " + REGION2;
-      props.put(TARGETED_REGION_PUSH_WITH_DEFERRED_SWAP, true);
-      props.put(TARGETED_REGION_PUSH_LIST, targetRegions);
-      try {
-        TestWriteUtils.runPushJob("Test push job", props);
-      } catch (Exception e) {
-        assertEquals(e.getClass(), VeniceException.class);
-      }
-
-      // Wait for job to fail
-      TestUtils.waitForNonDeterministicAssertion(1, TimeUnit.MINUTES, true, () -> {
-        JobStatusQueryResponse jobStatusQueryResponse = assertCommand(
-            parentControllerClient.queryOverallJobStatus(Version.composeKafkaTopic(storeName, 1), Optional.empty()));
-        ExecutionStatus executionStatus = ExecutionStatus.valueOf(jobStatusQueryResponse.getStatus());
-        assertEquals(executionStatus, ExecutionStatus.ERROR);
-      });
-
-      TestUtils.waitForNonDeterministicAssertion(1, TimeUnit.MINUTES, () -> {
-        Map<String, Integer> coloVersions =
-            parentControllerClient.getStore(storeName).getStore().getColoToCurrentVersions();
-
-        coloVersions.forEach((colo, version) -> {
-          if (targetRegions.contains(colo) && !failingRegionsList.contains(colo)) {
-            Assert.assertEquals((int) version, 1);
-          } else {
-            Assert.assertEquals((int) version, 0);
-          }
-        });
-      });
-
-      TestUtils.waitForNonDeterministicAssertion(30, TimeUnit.SECONDS, () -> {
-        StoreInfo parentStore = parentControllerClient.getStore(storeName).getStore();
-        Assert.assertEquals(parentStore.getVersion(1).get().getStatus(), VersionStatus.ERROR);
-      });
-
-      // Verify that we can create a new version
-      VersionCreationResponse versionCreationResponse = parentControllerClient.requestTopicForWrites(
-          storeName,
-          1000,
-          Version.PushType.BATCH,
-          Version.guidBasedDummyPushId(),
-          true,
-          true,
-          false,
-          Optional.empty(),
-          Optional.empty(),
-          Optional.empty(),
-          false,
-          -1);
-      assertFalse(versionCreationResponse.isError());
     }
   }
 
@@ -688,117 +519,6 @@ public class TestDeferredVersionSwap {
 
       client2.close();
     }
-  }
-
-  @Test(timeOut = TEST_TIMEOUT)
-  public void testDvcDelayedIngestionWithFailingPushInTargetRegion() throws Exception {
-    // Setup job properties
-    UpdateStoreQueryParams storeParms = new UpdateStoreQueryParams().setUnusedSchemaDeletionEnabled(true);
-    storeParms.setTargetRegionSwapWaitTime(1);
-    String parentControllerURLs = multiRegionMultiClusterWrapper.getControllerConnectString();
-    String keySchemaStr = "\"int\"";
-    String valueSchemaStr = "\"int\"";
-
-    // Create store + start a normal push
-    int keyCount = 100;
-    File inputDir = getTempDataDirectory();
-    TestWriteUtils.writeSimpleAvroFileWithIntToIntSchema(inputDir, keyCount);
-    String inputDirPath = "file://" + inputDir.getAbsolutePath();
-    String storeName = Utils.getUniqueString("testDvcDelayedIngestionWithTargetRegion");
-    Properties props =
-        IntegrationTestPushUtils.defaultVPJProps(multiRegionMultiClusterWrapper, inputDirPath, storeName);
-    try (ControllerClient parentControllerClient = new ControllerClient(CLUSTER_NAMES[0], parentControllerURLs)) {
-      createStoreForJob(CLUSTER_NAMES[0], keySchemaStr, valueSchemaStr, props, storeParms).close();
-      TestWriteUtils.runPushJob("Test push job", props);
-      TestUtils.waitForNonDeterministicPushCompletion(
-          Version.composeKafkaTopic(storeName, 1),
-          parentControllerClient,
-          30,
-          TimeUnit.SECONDS);
-
-      // Version should only be swapped in all regions
-      TestUtils.waitForNonDeterministicAssertion(1, TimeUnit.MINUTES, () -> {
-        Map<String, Integer> coloVersions =
-            parentControllerClient.getStore(storeName).getStore().getColoToCurrentVersions();
-
-        coloVersions.forEach((colo, version) -> {
-          Assert.assertEquals((int) version, 1);
-        });
-      });
-    }
-
-    verifyThatPushStatusStoreIsOnline(storeName);
-    verifyThatMetaStoreIsOnline(storeName);
-
-    // Create dvc client in target region
-    List<VeniceMultiClusterWrapper> childDatacenters = multiRegionMultiClusterWrapper.getChildRegions();
-    VeniceClusterWrapper cluster1 = childDatacenters.get(0).getClusters().get(CLUSTER_NAMES[0]);
-    VeniceProperties backendConfig = DaVinciTestContext.getDaVinciPropertyBuilder(cluster1.getZk().getAddress())
-        .put(DATA_BASE_PATH, Utils.getTempDataDirectory().getAbsolutePath())
-        .put(LOCAL_REGION_NAME, REGION2)
-        .put(CLIENT_SYSTEM_STORE_REPOSITORY_REFRESH_INTERVAL_SECONDS, 1)
-        .build();
-    DaVinciClient<Object, Object> client1 =
-        ServiceFactory.getGenericAvroDaVinciClient(storeName, cluster1, new DaVinciConfig(), backendConfig);
-    client1.subscribeAll().get();
-
-    // Check that v1 is ingested
-    for (int i = 1; i <= keyCount; i++) {
-      assertNotNull(client1.get(i).get());
-    }
-
-    // Fail push in target region
-    multiRegionMultiClusterWrapper.failPushInRegion(REGION2);
-
-    // Do another push with target region enabled
-    int keyCount2 = 200;
-    File inputDir2 = getTempDataDirectory();
-    String inputDirPath2 = "file://" + inputDir2.getAbsolutePath();
-    TestWriteUtils.writeSimpleAvroFileWithIntToIntSchema(inputDir2, keyCount2);
-    Properties props2 =
-        IntegrationTestPushUtils.defaultVPJProps(multiRegionMultiClusterWrapper, inputDirPath2, storeName);
-    try (ControllerClient parentControllerClient = new ControllerClient(CLUSTER_NAMES[0], parentControllerURLs)) {
-      props2.put(TARGETED_REGION_PUSH_WITH_DEFERRED_SWAP, true);
-      props2.put(TARGETED_REGION_PUSH_LIST, REGION2);
-      try {
-        TestWriteUtils.runPushJob("Test push job", props2);
-      } catch (Exception e) {
-        assertEquals(e.getClass(), VeniceException.class);
-      }
-
-      // Version shouldn't be swapped in any region
-      TestUtils.waitForNonDeterministicAssertion(1, TimeUnit.MINUTES, () -> {
-        Map<String, Integer> coloVersions =
-            parentControllerClient.getStore(storeName).getStore().getColoToCurrentVersions();
-
-        coloVersions.forEach((colo, version) -> {
-          Assert.assertEquals((int) version, 1);
-        });
-      });
-
-      // Version status should be ERROR
-      TestUtils.waitForNonDeterministicAssertion(90, TimeUnit.SECONDS, () -> {
-        StoreInfo parentStore = parentControllerClient.getStore(storeName).getStore();
-        Assert.assertEquals(parentStore.getVersion(2).get().getStatus(), VersionStatus.ERROR);
-      });
-
-      // verify that dvc client did not ingest the version
-      TestUtils.waitForNonDeterministicAssertion(30, TimeUnit.SECONDS, () -> {
-        for (int i = 101; i <= keyCount2; i++) {
-          assertNull(client1.get(i).get());
-        }
-      });
-
-      // Wait for push completion
-      TestUtils.waitForNonDeterministicAssertion(30, TimeUnit.SECONDS, () -> {
-        String kafkaTopicName = Version.composeKafkaTopic(storeName, 2);
-        JobStatusQueryResponse response =
-            parentControllerClient.queryOverallJobStatus(kafkaTopicName, Optional.empty());
-        assertEquals(response.getStatus(), ExecutionStatus.ERROR.toString());
-      });
-    }
-
-    client1.close();
   }
 
   private void verifyThatPushStatusStoreIsOnline(String storeName) {

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestDeferredVersionSwap.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestDeferredVersionSwap.java
@@ -799,7 +799,7 @@ public class TestDeferredVersionSwap {
     client1.close();
   }
 
-  public void verifyThatPushStatusStoreIsOnline(String storeName) {
+  private void verifyThatPushStatusStoreIsOnline(String storeName) {
     for (VeniceMultiClusterWrapper childDatacenter: childDatacenters) {
       String pushStatusStoreName = VeniceSystemStoreType.DAVINCI_PUSH_STATUS_STORE.getSystemStoreName(storeName);
       ControllerClient childControllerClient =

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestDeferredVersionSwapWithFailingRegions.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestDeferredVersionSwapWithFailingRegions.java
@@ -1,0 +1,387 @@
+package com.linkedin.venice.endToEnd;
+
+import static com.linkedin.venice.ConfigKeys.CLIENT_SYSTEM_STORE_REPOSITORY_REFRESH_INTERVAL_SECONDS;
+import static com.linkedin.venice.ConfigKeys.CONTROLLER_DEFERRED_VERSION_SWAP_SERVICE_ENABLED;
+import static com.linkedin.venice.ConfigKeys.CONTROLLER_DEFERRED_VERSION_SWAP_SLEEP_MS;
+import static com.linkedin.venice.ConfigKeys.DATA_BASE_PATH;
+import static com.linkedin.venice.ConfigKeys.LOCAL_REGION_NAME;
+import static com.linkedin.venice.utils.IntegrationTestPushUtils.createStoreForJob;
+import static com.linkedin.venice.utils.TestUtils.assertCommand;
+import static com.linkedin.venice.utils.TestWriteUtils.NAME_RECORD_V3_SCHEMA;
+import static com.linkedin.venice.utils.TestWriteUtils.getTempDataDirectory;
+import static com.linkedin.venice.vpj.VenicePushJobConstants.TARGETED_REGION_PUSH_LIST;
+import static com.linkedin.venice.vpj.VenicePushJobConstants.TARGETED_REGION_PUSH_WITH_DEFERRED_SWAP;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertNull;
+
+import com.linkedin.davinci.client.DaVinciClient;
+import com.linkedin.davinci.client.DaVinciConfig;
+import com.linkedin.venice.common.VeniceSystemStoreType;
+import com.linkedin.venice.controllerapi.ControllerClient;
+import com.linkedin.venice.controllerapi.JobStatusQueryResponse;
+import com.linkedin.venice.controllerapi.StoreResponse;
+import com.linkedin.venice.controllerapi.UpdateStoreQueryParams;
+import com.linkedin.venice.controllerapi.VersionCreationResponse;
+import com.linkedin.venice.exceptions.VeniceException;
+import com.linkedin.venice.integration.utils.DaVinciTestContext;
+import com.linkedin.venice.integration.utils.ServiceFactory;
+import com.linkedin.venice.integration.utils.VeniceClusterWrapper;
+import com.linkedin.venice.integration.utils.VeniceMultiClusterWrapper;
+import com.linkedin.venice.integration.utils.VeniceMultiRegionClusterCreateOptions;
+import com.linkedin.venice.integration.utils.VeniceTwoLayerMultiRegionMultiClusterWrapper;
+import com.linkedin.venice.meta.StoreInfo;
+import com.linkedin.venice.meta.Version;
+import com.linkedin.venice.meta.VersionStatus;
+import com.linkedin.venice.pushmonitor.ExecutionStatus;
+import com.linkedin.venice.utils.IntegrationTestPushUtils;
+import com.linkedin.venice.utils.TestUtils;
+import com.linkedin.venice.utils.TestWriteUtils;
+import com.linkedin.venice.utils.Utils;
+import com.linkedin.venice.utils.VeniceProperties;
+import java.io.File;
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Properties;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.IntStream;
+import org.testng.Assert;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.Test;
+
+
+public class TestDeferredVersionSwapWithFailingRegions {
+  private static final int NUMBER_OF_CHILD_DATACENTERS = 3;
+  private static final int NUMBER_OF_CLUSTERS = 2;
+  private VeniceTwoLayerMultiRegionMultiClusterWrapper multiRegionMultiClusterWrapper;
+  private static final String FAILED_REGION = "dc-1";
+  private static final String[] CLUSTER_NAMES =
+      IntStream.range(0, NUMBER_OF_CLUSTERS).mapToObj(i -> "venice-cluster" + i).toArray(String[]::new);
+  private static final int TEST_TIMEOUT = 120_000;
+  private List<VeniceMultiClusterWrapper> childDatacenters;
+
+  @AfterClass(alwaysRun = true)
+  public void cleanUp() {
+    Utils.closeQuietlyWithErrorLogged(multiRegionMultiClusterWrapper);
+  }
+
+  @Test(timeOut = TEST_TIMEOUT * 2)
+  public void testDeferredVersionSwapWithFailedPushInNonTargetRegions() throws IOException {
+    setUpCluster();
+
+    multiRegionMultiClusterWrapper.failPushInRegion(FAILED_REGION);
+
+    // Setup job properties
+    File inputDir = getTempDataDirectory();
+    TestWriteUtils.writeSimpleAvroFileWithStringToV3Schema(inputDir, 100, 100);
+    String inputDirPath = "file://" + inputDir.getAbsolutePath();
+    String storeName = Utils.getUniqueString("testDeferredVersionSwapWithFailedPushInNonTargetRegions");
+    Properties props =
+        IntegrationTestPushUtils.defaultVPJProps(multiRegionMultiClusterWrapper, inputDirPath, storeName);
+    String keySchemaStr = "\"string\"";
+    UpdateStoreQueryParams storeParms = new UpdateStoreQueryParams().setUnusedSchemaDeletionEnabled(true);
+    storeParms.setTargetRegionSwapWaitTime(1);
+    String parentControllerURLs = multiRegionMultiClusterWrapper.getControllerConnectString();
+
+    try (ControllerClient parentControllerClient = new ControllerClient(CLUSTER_NAMES[0], parentControllerURLs)) {
+      createStoreForJob(CLUSTER_NAMES[0], keySchemaStr, NAME_RECORD_V3_SCHEMA.toString(), props, storeParms).close();
+
+      // Start push job with target region push enabled and check that it fails
+      props.put(TARGETED_REGION_PUSH_WITH_DEFERRED_SWAP, true);
+      try {
+        TestWriteUtils.runPushJob("Test push job", props);
+      } catch (Exception e) {
+        assertEquals(e.getClass(), VeniceException.class);
+      }
+
+      // Wait for job to fail
+      TestUtils.waitForNonDeterministicAssertion(1, TimeUnit.MINUTES, true, () -> {
+        JobStatusQueryResponse jobStatusQueryResponse = assertCommand(
+            parentControllerClient.queryOverallJobStatus(Version.composeKafkaTopic(storeName, 1), Optional.empty()));
+        ExecutionStatus executionStatus = ExecutionStatus.valueOf(jobStatusQueryResponse.getStatus());
+        assertEquals(executionStatus, ExecutionStatus.ERROR);
+      });
+
+      TestUtils.waitForNonDeterministicAssertion(1, TimeUnit.MINUTES, () -> {
+        Map<String, Integer> coloVersions =
+            parentControllerClient.getStore(storeName).getStore().getColoToCurrentVersions();
+
+        coloVersions.forEach((colo, version) -> {
+          if (!colo.equals(FAILED_REGION)) {
+            Assert.assertEquals((int) version, 1);
+          } else {
+            Assert.assertEquals((int) version, 0);
+          }
+        });
+      });
+
+      TestUtils.waitForNonDeterministicAssertion(30, TimeUnit.SECONDS, () -> {
+        StoreInfo parentStore = parentControllerClient.getStore(storeName).getStore();
+        Assert.assertEquals(parentStore.getVersion(1).get().getStatus(), VersionStatus.PARTIALLY_ONLINE);
+      });
+
+      // Check that child version status is marked as ONLINE if it didn't fail
+      for (VeniceMultiClusterWrapper childDatacenter: childDatacenters) {
+        ControllerClient childControllerClient =
+            new ControllerClient(CLUSTER_NAMES[0], childDatacenter.getControllerConnectString());
+        if (!childDatacenter.getRegionName().equals(FAILED_REGION)) {
+          StoreResponse store = childControllerClient.getStore(storeName);
+          Optional<Version> version = store.getStore().getVersion(1);
+          assertNotNull(version);
+          assertEquals(version.get().getStatus(), VersionStatus.ONLINE);
+        }
+      }
+
+      // Verify that we can create a new version
+      VersionCreationResponse versionCreationResponse = parentControllerClient.requestTopicForWrites(
+          storeName,
+          1000,
+          Version.PushType.BATCH,
+          Version.guidBasedDummyPushId(),
+          true,
+          true,
+          false,
+          Optional.empty(),
+          Optional.empty(),
+          Optional.empty(),
+          false,
+          -1);
+      assertFalse(versionCreationResponse.isError());
+    }
+  }
+
+  @Test(timeOut = TEST_TIMEOUT * 2)
+  public void testDeferredVersionSwapWithFailedPushInTargetRegions() throws IOException {
+    setUpCluster();
+
+    multiRegionMultiClusterWrapper.failPushInRegion(FAILED_REGION);
+
+    // Setup job properties
+    File inputDir = getTempDataDirectory();
+    TestWriteUtils.writeSimpleAvroFileWithStringToV3Schema(inputDir, 100, 100);
+    String inputDirPath = "file://" + inputDir.getAbsolutePath();
+    String storeName = Utils.getUniqueString("testDeferredVersionSwapWithFailedPushInTargetRegions");
+    Properties props =
+        IntegrationTestPushUtils.defaultVPJProps(multiRegionMultiClusterWrapper, inputDirPath, storeName);
+    String keySchemaStr = "\"string\"";
+    UpdateStoreQueryParams storeParms = new UpdateStoreQueryParams().setUnusedSchemaDeletionEnabled(true);
+    storeParms.setTargetRegionSwapWaitTime(1);
+    String parentControllerURLs = multiRegionMultiClusterWrapper.getControllerConnectString();
+
+    try (ControllerClient parentControllerClient = new ControllerClient(CLUSTER_NAMES[0], parentControllerURLs)) {
+      createStoreForJob(CLUSTER_NAMES[0], keySchemaStr, NAME_RECORD_V3_SCHEMA.toString(), props, storeParms).close();
+
+      // Start push job with target region push enabled and check that it fails
+      props.put(TARGETED_REGION_PUSH_WITH_DEFERRED_SWAP, true);
+      props.put(TARGETED_REGION_PUSH_LIST, FAILED_REGION);
+      try {
+        TestWriteUtils.runPushJob("Test push job", props);
+      } catch (Exception e) {
+        assertEquals(e.getClass(), VeniceException.class);
+      }
+
+      // Wait for job to fail
+      TestUtils.waitForNonDeterministicAssertion(1, TimeUnit.MINUTES, true, () -> {
+        JobStatusQueryResponse jobStatusQueryResponse = assertCommand(
+            parentControllerClient.queryOverallJobStatus(Version.composeKafkaTopic(storeName, 1), Optional.empty()));
+        ExecutionStatus executionStatus = ExecutionStatus.valueOf(jobStatusQueryResponse.getStatus());
+        assertEquals(executionStatus, ExecutionStatus.ERROR);
+      });
+
+      TestUtils.waitForNonDeterministicAssertion(1, TimeUnit.MINUTES, () -> {
+        Map<String, Integer> coloVersions =
+            parentControllerClient.getStore(storeName).getStore().getColoToCurrentVersions();
+
+        coloVersions.forEach((colo, version) -> {
+          Assert.assertEquals((int) version, 0);
+        });
+      });
+
+      TestUtils.waitForNonDeterministicAssertion(30, TimeUnit.SECONDS, () -> {
+        StoreInfo parentStore = parentControllerClient.getStore(storeName).getStore();
+        Assert.assertEquals(parentStore.getVersion(1).get().getStatus(), VersionStatus.ERROR);
+      });
+
+      // Verify that we can create a new version
+      VersionCreationResponse versionCreationResponse = parentControllerClient.requestTopicForWrites(
+          storeName,
+          1000,
+          Version.PushType.BATCH,
+          Version.guidBasedDummyPushId(),
+          true,
+          true,
+          false,
+          Optional.empty(),
+          Optional.empty(),
+          Optional.empty(),
+          false,
+          -1);
+      assertFalse(versionCreationResponse.isError());
+    }
+  }
+
+  @Test(timeOut = TEST_TIMEOUT)
+  public void testDvcDelayedIngestionWithFailingPushInTargetRegion() throws Exception {
+    setUpCluster();
+
+    // Setup job properties
+    UpdateStoreQueryParams storeParms = new UpdateStoreQueryParams().setUnusedSchemaDeletionEnabled(true);
+    storeParms.setTargetRegionSwapWaitTime(1);
+    String parentControllerURLs = multiRegionMultiClusterWrapper.getControllerConnectString();
+    String keySchemaStr = "\"int\"";
+    String valueSchemaStr = "\"int\"";
+
+    // Create store + start a normal push
+    int keyCount = 100;
+    File inputDir = getTempDataDirectory();
+    TestWriteUtils.writeSimpleAvroFileWithIntToIntSchema(inputDir, keyCount);
+    String inputDirPath = "file://" + inputDir.getAbsolutePath();
+    String storeName = Utils.getUniqueString("testDvcDelayedIngestionWithTargetRegion");
+    Properties props =
+        IntegrationTestPushUtils.defaultVPJProps(multiRegionMultiClusterWrapper, inputDirPath, storeName);
+    try (ControllerClient parentControllerClient = new ControllerClient(CLUSTER_NAMES[0], parentControllerURLs)) {
+      createStoreForJob(CLUSTER_NAMES[0], keySchemaStr, valueSchemaStr, props, storeParms).close();
+      TestWriteUtils.runPushJob("Test push job", props);
+      TestUtils.waitForNonDeterministicPushCompletion(
+          Version.composeKafkaTopic(storeName, 1),
+          parentControllerClient,
+          30,
+          TimeUnit.SECONDS);
+
+      // Version should only be swapped in all regions
+      TestUtils.waitForNonDeterministicAssertion(1, TimeUnit.MINUTES, () -> {
+        Map<String, Integer> coloVersions =
+            parentControllerClient.getStore(storeName).getStore().getColoToCurrentVersions();
+
+        coloVersions.forEach((colo, version) -> {
+          Assert.assertEquals((int) version, 1);
+        });
+      });
+    }
+
+    verifyThatPushStatusStoreIsOnline(storeName);
+    verifyThatMetaStoreIsOnline(storeName);
+
+    // Create dvc client in target region
+    List<VeniceMultiClusterWrapper> childDatacenters = multiRegionMultiClusterWrapper.getChildRegions();
+    VeniceClusterWrapper cluster1 = childDatacenters.get(0).getClusters().get(CLUSTER_NAMES[0]);
+    VeniceProperties backendConfig = DaVinciTestContext.getDaVinciPropertyBuilder(cluster1.getZk().getAddress())
+        .put(DATA_BASE_PATH, Utils.getTempDataDirectory().getAbsolutePath())
+        .put(LOCAL_REGION_NAME, FAILED_REGION)
+        .put(CLIENT_SYSTEM_STORE_REPOSITORY_REFRESH_INTERVAL_SECONDS, 1)
+        .build();
+    DaVinciClient<Object, Object> client1 =
+        ServiceFactory.getGenericAvroDaVinciClient(storeName, cluster1, new DaVinciConfig(), backendConfig);
+    client1.subscribeAll().get();
+
+    // Check that v1 is ingested
+    for (int i = 1; i <= keyCount; i++) {
+      assertNotNull(client1.get(i).get());
+    }
+
+    // Fail push in target region
+    multiRegionMultiClusterWrapper.failPushInRegion(FAILED_REGION);
+
+    // Do another push with target region enabled
+    int keyCount2 = 200;
+    File inputDir2 = getTempDataDirectory();
+    String inputDirPath2 = "file://" + inputDir2.getAbsolutePath();
+    TestWriteUtils.writeSimpleAvroFileWithIntToIntSchema(inputDir2, keyCount2);
+    Properties props2 =
+        IntegrationTestPushUtils.defaultVPJProps(multiRegionMultiClusterWrapper, inputDirPath2, storeName);
+    try (ControllerClient parentControllerClient = new ControllerClient(CLUSTER_NAMES[0], parentControllerURLs)) {
+      props2.put(TARGETED_REGION_PUSH_WITH_DEFERRED_SWAP, true);
+      props2.put(TARGETED_REGION_PUSH_LIST, FAILED_REGION);
+      try {
+        TestWriteUtils.runPushJob("Test push job", props2);
+      } catch (Exception e) {
+        assertEquals(e.getClass(), VeniceException.class);
+      }
+
+      // Version shouldn't be swapped in any region
+      TestUtils.waitForNonDeterministicAssertion(1, TimeUnit.MINUTES, () -> {
+        Map<String, Integer> coloVersions =
+            parentControllerClient.getStore(storeName).getStore().getColoToCurrentVersions();
+
+        coloVersions.forEach((colo, version) -> {
+          Assert.assertEquals((int) version, 1);
+        });
+      });
+
+      // Version status should be ERROR
+      TestUtils.waitForNonDeterministicAssertion(90, TimeUnit.SECONDS, () -> {
+        StoreInfo parentStore = parentControllerClient.getStore(storeName).getStore();
+        Assert.assertEquals(parentStore.getVersion(2).get().getStatus(), VersionStatus.ERROR);
+      });
+
+      // verify that dvc client did not ingest the version
+      TestUtils.waitForNonDeterministicAssertion(30, TimeUnit.SECONDS, () -> {
+        for (int i = 101; i <= keyCount2; i++) {
+          assertNull(client1.get(i).get());
+        }
+      });
+
+      // Wait for push completion
+      TestUtils.waitForNonDeterministicAssertion(30, TimeUnit.SECONDS, () -> {
+        String kafkaTopicName = Version.composeKafkaTopic(storeName, 2);
+        JobStatusQueryResponse response =
+            parentControllerClient.queryOverallJobStatus(kafkaTopicName, Optional.empty());
+        assertEquals(response.getStatus(), ExecutionStatus.ERROR.toString());
+      });
+    }
+
+    client1.close();
+  }
+
+  public void setUpCluster() {
+    Properties controllerProps = new Properties();
+    controllerProps.put(CONTROLLER_DEFERRED_VERSION_SWAP_SLEEP_MS, 100);
+    controllerProps.put(CONTROLLER_DEFERRED_VERSION_SWAP_SERVICE_ENABLED, true);
+    Properties serverProperties = new Properties();
+
+    VeniceMultiRegionClusterCreateOptions.Builder optionsBuilder =
+        new VeniceMultiRegionClusterCreateOptions.Builder().numberOfRegions(NUMBER_OF_CHILD_DATACENTERS)
+            .numberOfClusters(NUMBER_OF_CLUSTERS)
+            .numberOfParentControllers(1)
+            .numberOfChildControllers(1)
+            .numberOfServers(1)
+            .numberOfRouters(1)
+            .replicationFactor(1)
+            .forkServer(false)
+            .parentControllerProperties(controllerProps)
+            .childControllerProperties(controllerProps)
+            .serverProperties(serverProperties);
+    multiRegionMultiClusterWrapper =
+        ServiceFactory.getVeniceTwoLayerMultiRegionMultiClusterWrapper(optionsBuilder.build());
+    childDatacenters = multiRegionMultiClusterWrapper.getChildRegions();
+  }
+
+  private void verifyThatPushStatusStoreIsOnline(String storeName) {
+    for (VeniceMultiClusterWrapper childDatacenter: childDatacenters) {
+      String pushStatusStoreName = VeniceSystemStoreType.DAVINCI_PUSH_STATUS_STORE.getSystemStoreName(storeName);
+      ControllerClient childControllerClient =
+          new ControllerClient(CLUSTER_NAMES[0], childDatacenter.getControllerConnectString());
+      TestUtils.waitForNonDeterministicAssertion(30, TimeUnit.SECONDS, () -> {
+        StoreResponse storeResponse = childControllerClient.getStore(pushStatusStoreName);
+        Assert.assertFalse(storeResponse.isError());
+        Assert.assertTrue(storeResponse.getStore().getCurrentVersion() > 0, pushStatusStoreName + " is not ready");
+      });
+    }
+  }
+
+  private void verifyThatMetaStoreIsOnline(String storeName) {
+    for (VeniceMultiClusterWrapper childDatacenter: childDatacenters) {
+      String metaStoreName = VeniceSystemStoreType.META_STORE.getSystemStoreName(storeName);
+      ControllerClient childControllerClient =
+          new ControllerClient(CLUSTER_NAMES[0], childDatacenter.getControllerConnectString());
+      TestUtils.waitForNonDeterministicAssertion(30, TimeUnit.SECONDS, () -> {
+        StoreResponse storeResponse = childControllerClient.getStore(metaStoreName);
+        Assert.assertFalse(storeResponse.isError());
+        Assert.assertTrue(storeResponse.getStore().getCurrentVersion() > 0, metaStoreName + " is not ready");
+      });
+    }
+  }
+}

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestDeferredVersionSwapWithFailingRegions.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestDeferredVersionSwapWithFailingRegions.java
@@ -49,7 +49,7 @@ import java.util.Properties;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.IntStream;
 import org.testng.Assert;
-import org.testng.annotations.AfterClass;
+import org.testng.annotations.AfterMethod;
 import org.testng.annotations.Test;
 
 
@@ -63,7 +63,7 @@ public class TestDeferredVersionSwapWithFailingRegions {
   private static final int TEST_TIMEOUT = 120_000;
   private List<VeniceMultiClusterWrapper> childDatacenters;
 
-  @AfterClass(alwaysRun = true)
+  @AfterMethod(alwaysRun = true)
   public void cleanUp() {
     Utils.closeQuietlyWithErrorLogged(multiRegionMultiClusterWrapper);
   }

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestPushJobWithNativeReplication.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestPushJobWithNativeReplication.java
@@ -875,10 +875,12 @@ public class TestPushJobWithNativeReplication {
           for (VeniceMultiClusterWrapper childDatacenter: childDatacenters) {
             ControllerClient childControllerClient =
                 new ControllerClient(clusterName, childDatacenter.getControllerConnectString());
-            StoreResponse store = childControllerClient.getStore(storeName);
-            Optional<Version> version = store.getStore().getVersion(2);
-            assertNotNull(version);
-            assertEquals(version.get().getStatus(), VersionStatus.KILLED);
+            TestUtils.waitForNonDeterministicAssertion(30, TimeUnit.SECONDS, () -> {
+              StoreResponse store = childControllerClient.getStore(storeName);
+              Optional<Version> version = store.getStore().getVersion(2);
+              assertNotNull(version);
+              assertEquals(version.get().getStatus(), VersionStatus.KILLED);
+            });
           }
 
           TestUtils.waitForNonDeterministicAssertion(1, TimeUnit.MINUTES, true, () -> {


### PR DESCRIPTION
<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat], [protocol]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## Problem Statement
<!--
Describe
- What problem are you trying to solve
- What issues or limitations exist in the current code
- Why this change is necessary 
-->
The tests for dvc delayed ingestion are flakey because the push status store may not be ready yet when we start the dvc client. The current deferred swap tests share a common multiclusterwrapper and that is problematic because we modify the leader error notifier in some tests and it causes the other tests to have unexpected side effects. And the test for the killed repush job status is flakey because the admin message isn't always consumed right away and we need to wait for it to be consumed. 


## Solution
<!--
Describe
- What changes you are making and why. 
- How these changes solve the problem.
- Any performance considerations or trade-offs. 
- Describe what testings you have done, for example, performance testing etc.
-->
1. For dvc delayed ingestion tests, add a check to wait for the push status and meta store to be ready before starting the dvc client
2. Move failed target region push w/ deferred swap to a separate file to not corrupt the shared multi cluster wrapper
3. For the killed repush job test, add in a check that waits for the KILLED version status that happens after the admin message is consumed

###  Code changes
- [ ] Added new code behind **a config**. If so list the config names and their default values in the PR description.
- [ ] Introduced new **log lines**. 
  - [ ] Confirmed if logs need to be **rate limited** to avoid excessive logging.

###  **Concurrency-Specific Checks**
Both reviewer and PR author to verify
- [x] Code has **no race conditions** or **thread safety issues**.
- [x] Proper **synchronization mechanisms** (e.g., `synchronized`, `RWLock`) are used where needed.
- [x] No **blocking calls** inside critical sections that could lead to deadlocks or performance degradation.
- [x] Verified **thread-safe collections** are used (e.g., `ConcurrentHashMap`, `CopyOnWriteArrayList`).
- [x] Validated proper exception handling in multi-threaded code to avoid silent thread termination.


## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->

- [ ] New unit tests added.
- [ ] New integration tests added.
- [x] Modified or extended existing tests.
- [ ] Verified backward compatibility (if applicable).

## Does this PR introduce any user-facing or breaking changes?
<!--  
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Clearly explain the behavior change and its impact.