### PR TITLE
[controller] Avoid writing SOP and EOP for duplicate empty push requests

### DIFF
--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/server/CreateVersion.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/server/CreateVersion.java
@@ -810,6 +810,12 @@ public class CreateVersion extends AbstractRoute {
               storeName,
               clusterName);
           admin.writeEndOfPush(clusterName, storeName, versionNumber, true);
+        } else {
+          LOGGER.info(
+              "Empty push job: {} for store: {} in cluster: {} is a duplicate empty push. No new version was created and no SOP/EOP was sent again.",
+              pushJobId,
+              storeName,
+              clusterName);
         }
 
         /** TODO: Poll {@link com.linkedin.venice.controller.VeniceParentHelixAdmin#getOffLineJobStatus(String, String, Map, TopicManager)} until it is terminal... */


### PR DESCRIPTION
## [controller] Avoid writing SOP and EOP for duplicate empty push requests

When the controller receives a duplicate empty push request with the same push job ID, it
correctly skips creating a new version. However, it still proceeds to broadcast START_OF_PUSH
and END_OF_PUSH control messages, which is unnecessary and can lead to replica state
regression or confusion.

This commit fixes that by ensuring SOP and EOP are not sent when the version already exists.


> ## AI Generate Summary of Changes
> 
> This pull request enhances the `emptyPush` functionality in the `CreateVersion` class by adding validation for store existence, ensuring proper handling of duplicate push job IDs, and introducing comprehensive tests to cover new scenarios. These changes improve error handling, logging, and test coverage.
> 
> ### Enhancements to `emptyPush` functionality:
> 
> * Added a check to validate whether the store exists before proceeding with an empty push. If the store is not found, a `VeniceNoStoreException` is thrown, and an error is logged.
> * Introduced logic to skip sending Start of Push (SOP) and End of Push (EOP) messages if the push job ID corresponds to an existing version, avoiding redundant operations.
> 
> ### Test additions and improvements:
> 
> * Added a new test, `testEmptyPushThrowsNoStoreFoundException`, to verify that an appropriate error response is returned when the store is missing during an empty push.
> * Added a new test, `testEmptyPushCreatesNewVersionAndReturnsSuccess`, to ensure that a new version is created successfully and the correct response is returned.
> * Added a new test, `testEmptyPushWithTheDuplicatePushJobIdSkipsSopAndEop`, to confirm that SOP and EOP are not sent for duplicate push job IDs.
> 
> ### Miscellaneous updates:
> 
> * Imported `HashSet` to support the new logic for handling previous versions.
> * Added `NoOpDynamicAccessController` and `SC_NOT_FOUND` imports in the test file to support new test cases. [[1]](diffhunk://#diff-887997680261628c5daa4e3d0bc5d0804339b94fcec52ad7350e6d8d8886b0dfR57) [[2]](diffhunk://#diff-887997680261628c5daa4e3d0bc5d0804339b94fcec52ad7350e6d8d8886b0dfR33-R43)
> 
> 

###  Code changes
- [ ] Added new code behind **a config**. If so list the config names and their default values in the PR description.
- [x] Introduced new **log lines**. 
  - [x] Confirmed if logs need to be **rate limited** to avoid excessive logging.

###  **Concurrency-Specific Checks**
Both reviewer and PR author to verify
- [x] Code has **no race conditions** or **thread safety issues**.
- [x] Proper **synchronization mechanisms** (e.g., `synchronized`, `RWLock`) are used where needed.
- [x] No **blocking calls** inside critical sections that could lead to deadlocks or performance degradation.
- [x] Verified **thread-safe collections** are used (e.g., `ConcurrentHashMap`, `CopyOnWriteArrayList`).
- [x] Validated proper exception handling in multi-threaded code to avoid silent thread termination.


## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->

- [x] New unit tests added.
- [ ] New integration tests added.
- [ ] Modified or extended existing tests.
- [ ] Verified backward compatibility (if applicable).

## Does this PR introduce any user-facing or breaking changes?
<!--  
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [ ] No. You can skip the rest of this section.
- [ ] Yes. Clearly explain the behavior change and its impact.