### PR TITLE
[controller] Add latency metrics for addVersion

### DIFF
--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceHelixAdmin.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceHelixAdmin.java
@@ -2907,7 +2907,7 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
             store.addVersion(version, true, currentRTVersionNumber);
             repository.updateStore(store);
 
-            addVersionLatencyStats.recordHandleAddVersionWithSourceVersionExistLatency(
+            addVersionLatencyStats.recordExistingSourceVersionHandlingLatency(
                 LatencyUtils.getElapsedTimeFromMsToMs(cloneSourceVersionTimestamp));
           } else {
             if (versionNumber == VERSION_ID_UNSET) {
@@ -2929,7 +2929,7 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
                 numberOfPartitions,
                 clusterConfig,
                 useFastKafkaOperationTimeout);
-            addVersionLatencyStats.recordCreateBatchTopicsLatency(LatencyUtils.getElapsedTimeFromMsToMs(startTime));
+            addVersionLatencyStats.recordBatchTopicCreationLatency(LatencyUtils.getElapsedTimeFromMsToMs(startTime));
 
             String sourceKafkaBootstrapServers = null;
 
@@ -3015,7 +3015,7 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
                   numberOfPartitions,
                   clusterConfig,
                   useFastKafkaOperationTimeout);
-              addVersionLatencyStats.recordCreateBatchTopicsLatency(
+              addVersionLatencyStats.recordBatchTopicCreationLatency(
                   LatencyUtils.getElapsedTimeFromMsToMs(createBatchTopicInParentTimestamp));
             }
 
@@ -3073,7 +3073,7 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
                       new HashMap<>());
                 }
                 addVersionLatencyStats
-                    .recordSendStartOfPushLatency(LatencyUtils.getElapsedTimeFromMsToMs(sendStartOfPushTimestamp));
+                    .recordStartOfPushLatency(LatencyUtils.getElapsedTimeFromMsToMs(sendStartOfPushTimestamp));
               } finally {
                 if (veniceWriter != null) {
                   veniceWriter.close();
@@ -3095,7 +3095,7 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
                 version.kafkaTopicName(),
                 numberOfPartitions,
                 replicationFactor);
-            addVersionLatencyStats.recordHelixStorageClusterResourcesCreationLatency(
+            addVersionLatencyStats.recordHelixResourceCreationLatency(
                 LatencyUtils.getElapsedTimeFromMsToMs(helixResourceCreationStartTime));
           }
         }
@@ -3107,8 +3107,8 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
             try {
               long retireOldStoreStartTimestamp = System.currentTimeMillis();
               retireOldStoreVersions(clusterName, storeName, true, currentVersionBeforePush);
-              addVersionLatencyStats.recordRetireOldStoreVersionsLatency(
-                  LatencyUtils.getElapsedTimeFromMsToMs(retireOldStoreStartTimestamp));
+              addVersionLatencyStats
+                  .recordRetireOldVersionsLatency(LatencyUtils.getElapsedTimeFromMsToMs(retireOldStoreStartTimestamp));
             } catch (Throwable t) {
               LOGGER.error(
                   "Failed to delete previous backup version while pushing {} to store {} in cluster {}",
@@ -3131,8 +3131,8 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
               offlinePushStrategy,
               clusterConfig.getOffLineJobWaitTimeInMilliseconds(),
               replicationFactor);
-          addVersionLatencyStats.recordWaitTimeForResourcesAssignmentLatency(
-              LatencyUtils.getElapsedTimeFromMsToMs(startWaitingTimestamp));
+          addVersionLatencyStats
+              .recordResourceAssignmentWaitLatency(LatencyUtils.getElapsedTimeFromMsToMs(startWaitingTimestamp));
         } catch (VeniceNoClusterException e) {
           if (!isLeaderControllerFor(clusterName)) {
             int versionNumberInProgress = version == null ? versionNumber : version.getNumber();
@@ -3164,7 +3164,7 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
           long createVersionStartTime = System.currentTimeMillis();
           handleVersionCreationFailure(clusterName, storeName, failedVersionNumber, statusDetails);
           addVersionLatencyStats
-              .recordHandleVersionCreationFailureLatency(LatencyUtils.getElapsedTimeFromMsToMs(createVersionStartTime));
+              .recordVersionCreationFailureLatency(LatencyUtils.getElapsedTimeFromMsToMs(createVersionStartTime));
         }
       } catch (Throwable e1) {
         String handlingErrorMsg = "Exception occurred while handling version " + versionNumber

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceHelixAdmin.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceHelixAdmin.java
@@ -2920,7 +2920,7 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
               }
               version = new VersionImpl(storeName, versionNumber, pushJobId, numberOfPartitions);
             }
-            long startTime = System.currentTimeMillis();
+            long createBatchTopicStartTime = System.currentTimeMillis();
             topicToCreationTime.computeIfAbsent(version.kafkaTopicName(), topic -> System.currentTimeMillis());
             createBatchTopics(
                 version,
@@ -2929,7 +2929,8 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
                 numberOfPartitions,
                 clusterConfig,
                 useFastKafkaOperationTimeout);
-            addVersionLatencyStats.recordBatchTopicCreationLatency(LatencyUtils.getElapsedTimeFromMsToMs(startTime));
+            addVersionLatencyStats
+                .recordBatchTopicCreationLatency(LatencyUtils.getElapsedTimeFromMsToMs(createBatchTopicStartTime));
 
             String sourceKafkaBootstrapServers = null;
 

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/kafka/consumer/AdminExecutionTask.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/kafka/consumer/AdminExecutionTask.java
@@ -654,7 +654,6 @@ public class AdminExecutionTask implements Callable<Void> {
         storeName,
         clusterName,
         versionNumber);
-
     if (isParentController) {
       if (checkPreConditionForReplicateAddVersion(clusterName, storeName)) {
         // Parent controller mirrors new version to src or dest cluster if the store is migrating

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/stats/AddVersionLatencyStats.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/stats/AddVersionLatencyStats.java
@@ -9,73 +9,96 @@ import io.tehuti.metrics.stats.Max;
 
 /**
  * This class is used to track the latency of various operations related to adding a version in Venice.
- *
- * It includes metrics for:
+ * <p>
+ * The following sensors are tracked:
  * <ul>
- * <li>Handling add version requests when the source version exists</li>
- * <li>Creating batch topics (for both child and parent controllers)</li>
- * <li>Waiting for node resources assignment</li>
- * <li>Creating Helix storage cluster resources</li>
- * <li>Retiring old store versions</li>
- * <li>Sending the start of a push</li>
- * <li>Handling version creation failures</li>
+ *   <li><b>existingSourceVersionHandlingLatencySensor</b> –
+ *       Measures latency when handling add version requests with an existing source version.</li>
+ *   <li><b>batchTopicCreationLatencySensor</b> –
+ *       Tracks latency for creating batch topics (used by both child and parent controllers).</li>
+ *   <li><b>resourceAssignmentWaitLatencySensor</b> –
+ *       Captures time spent waiting for node resource assignments.</li>
+ *   <li><b>helixResourceCreationLatencySensor</b> –
+ *       Monitors the latency of creating Helix storage cluster resources.</li>
+ *   <li><b>retireOldVersionsLatencySensor</b> –
+ *       Records the time taken to retire outdated store versions.</li>
+ *   <li><b>startOfPushLatencySensor</b> –
+ *       Measures latency for sending the start-of-push signal.</li>
+ *   <li><b>versionCreationFailureLatencySensor</b> –
+ *       Tracks latency during version creation failure handling.</li>
  * </ul>
- * Each metric is using Milliseconds as the unit of measurement.
+ * Each metric uses milliseconds as the unit of measurement.
  */
 public class AddVersionLatencyStats extends AbstractVeniceStats {
-  private final Sensor retireOldStoreVersionsLatencySensor;
-  private final Sensor waitTimeForResourcesAssignmentLatencySensor;
-  private final Sensor handleVersionCreationFailureLatencySensor;
-  private final Sensor handleAddVersionWithSourceVersionExistLatencySensor;
-  private final Sensor sendStartOfPushLatencySensor;
-  private final Sensor topicCreationLatencySensor;
-  private final Sensor helixStorageClusterResourcesCreationLatencySensor;
+  /** Measures the time taken to retire outdated store versions. */
+  private final Sensor retireOldVersionsLatencySensor;
+
+  /** Captures the latency while waiting for node resource assignments. */
+  private final Sensor resourceAssignmentWaitLatencySensor;
+
+  /** Tracks latency during the handling of version creation failures. */
+  private final Sensor versionCreationFailureLatencySensor;
+
+  /** Measures latency for add version requests where the source version already exists. */
+  private final Sensor existingSourceVersionHandlingLatencySensor;
+
+  /** Records the time taken to send the start-of-push signal. */
+  private final Sensor startOfPushLatencySensor;
+
+  /** Tracks latency for creating batch topics, applicable to both parent and child controllers. */
+  private final Sensor batchTopicCreationLatencySensor;
+
+  /** Monitors the time required to create Helix storage cluster resources. */
+  private final Sensor helixResourceCreationLatencySensor;
 
   public AddVersionLatencyStats(MetricsRepository metricsRepository, String name) {
     super(metricsRepository, name);
-    retireOldStoreVersionsLatencySensor =
-        registerSensorIfAbsent("add_version_retire_old_store_versions_latency", new Avg(), new Max());
-    waitTimeForResourcesAssignmentLatencySensor =
-        registerSensorIfAbsent("add_version_wait_time_for_resources_assignment_latency", new Avg(), new Max());
-    handleVersionCreationFailureLatencySensor =
-        registerSensorIfAbsent("add_version_handle_version_creation_failure_latency", new Avg(), new Max());
-    handleAddVersionWithSourceVersionExistLatencySensor = registerSensorIfAbsent(
-        "add_version_handle_add_version_with_source_version_exist_latency",
-        new Avg(),
-        new Max());
-    sendStartOfPushLatencySensor =
-        registerSensorIfAbsent("add_version_send_start_of_push_latency", new Avg(), new Max());
-    topicCreationLatencySensor =
-        registerSensorIfAbsent("add_version_create_batch_topics_latency", new Avg(), new Max());
-    helixStorageClusterResourcesCreationLatencySensor =
-        registerSensorIfAbsent("add_version_helix_storage_cluster_resources_creation_latency", new Avg(), new Max());
+    retireOldVersionsLatencySensor =
+        registerSensorIfAbsent("add_version_retire_old_versions_latency", new Avg(), new Max());
+
+    resourceAssignmentWaitLatencySensor =
+        registerSensorIfAbsent("add_version_resource_assignment_wait_latency", new Avg(), new Max());
+
+    versionCreationFailureLatencySensor =
+        registerSensorIfAbsent("add_version_creation_failure_latency", new Avg(), new Max());
+
+    existingSourceVersionHandlingLatencySensor =
+        registerSensorIfAbsent("add_version_existing_source_handling_latency", new Avg(), new Max());
+
+    startOfPushLatencySensor = registerSensorIfAbsent("add_version_start_of_push_latency", new Avg(), new Max());
+
+    batchTopicCreationLatencySensor =
+        registerSensorIfAbsent("add_version_batch_topic_creation_latency", new Avg(), new Max());
+
+    helixResourceCreationLatencySensor =
+        registerSensorIfAbsent("add_version_helix_resource_creation_latency", new Avg(), new Max());
   }
 
-  public void recordRetireOldStoreVersionsLatency(long latency) {
-    retireOldStoreVersionsLatencySensor.record(latency);
+  public void recordRetireOldVersionsLatency(long latency) {
+    retireOldVersionsLatencySensor.record(latency);
   }
 
-  public void recordWaitTimeForResourcesAssignmentLatency(long latency) {
-    waitTimeForResourcesAssignmentLatencySensor.record(latency);
+  public void recordResourceAssignmentWaitLatency(long latency) {
+    resourceAssignmentWaitLatencySensor.record(latency);
   }
 
-  public void recordHandleAddVersionWithSourceVersionExistLatency(long latency) {
-    handleAddVersionWithSourceVersionExistLatencySensor.record(latency);
+  public void recordExistingSourceVersionHandlingLatency(long latency) {
+    existingSourceVersionHandlingLatencySensor.record(latency);
   }
 
-  public void recordSendStartOfPushLatency(long latency) {
-    sendStartOfPushLatencySensor.record(latency);
+  public void recordStartOfPushLatency(long latency) {
+    startOfPushLatencySensor.record(latency);
   }
 
-  public void recordCreateBatchTopicsLatency(long latency) {
-    topicCreationLatencySensor.record(latency);
+  public void recordBatchTopicCreationLatency(long latency) {
+    batchTopicCreationLatencySensor.record(latency);
   }
 
-  public void recordHelixStorageClusterResourcesCreationLatency(long latency) {
-    helixStorageClusterResourcesCreationLatencySensor.record(latency);
+  public void recordHelixResourceCreationLatency(long latency) {
+    helixResourceCreationLatencySensor.record(latency);
   }
 
-  public void recordHandleVersionCreationFailureLatency(long latency) {
-    handleVersionCreationFailureLatencySensor.record(latency);
+  public void recordVersionCreationFailureLatency(long latency) {
+    versionCreationFailureLatencySensor.record(latency);
   }
 }

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/stats/AddVersionLatencyStats.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/stats/AddVersionLatencyStats.java
@@ -7,9 +7,24 @@ import io.tehuti.metrics.stats.Avg;
 import io.tehuti.metrics.stats.Max;
 
 
+/**
+ * This class is used to track the latency of various operations related to adding a version in Venice.
+ *
+ * It includes metrics for:
+ * <ul>
+ * <li>Handling add version requests when the source version exists</li>
+ * <li>Creating batch topics (for both child and parent controllers)</li>
+ * <li>Waiting for node resources assignment</li>
+ * <li>Creating Helix storage cluster resources</li>
+ * <li>Retiring old store versions</li>
+ * <li>Sending the start of a push</li>
+ * <li>Handling version creation failures</li>
+ * </ul>
+ * Each metric is using Milliseconds as the unit of measurement.
+ */
 public class AddVersionLatencyStats extends AbstractVeniceStats {
-  private final Sensor retiredVersionLatencySensor;
-  private final Sensor waitTimeForResourcesSensor;
+  private final Sensor retireOldStoreVersionsLatencySensor;
+  private final Sensor waitTimeForResourcesAssignmentLatencySensor;
   private final Sensor handleVersionCreationFailureLatencySensor;
   private final Sensor handleAddVersionWithSourceVersionExistLatencySensor;
   private final Sensor sendStartOfPushLatencySensor;
@@ -18,8 +33,10 @@ public class AddVersionLatencyStats extends AbstractVeniceStats {
 
   public AddVersionLatencyStats(MetricsRepository metricsRepository, String name) {
     super(metricsRepository, name);
-    retiredVersionLatencySensor = registerSensorIfAbsent("add_version_retired_version_latency", new Avg(), new Max());
-    waitTimeForResourcesSensor = registerSensorIfAbsent("add_version_wait_time_for_resources", new Avg(), new Max());
+    retireOldStoreVersionsLatencySensor =
+        registerSensorIfAbsent("add_version_retire_old_store_versions_latency", new Avg(), new Max());
+    waitTimeForResourcesAssignmentLatencySensor =
+        registerSensorIfAbsent("add_version_wait_time_for_resources_assignment_latency", new Avg(), new Max());
     handleVersionCreationFailureLatencySensor =
         registerSensorIfAbsent("add_version_handle_version_creation_failure_latency", new Avg(), new Max());
     handleAddVersionWithSourceVersionExistLatencySensor = registerSensorIfAbsent(
@@ -34,16 +51,12 @@ public class AddVersionLatencyStats extends AbstractVeniceStats {
         registerSensorIfAbsent("add_version_helix_storage_cluster_resources_creation_latency", new Avg(), new Max());
   }
 
-  public void recordRetiredVersionLatency(long latency) {
-    retiredVersionLatencySensor.record(latency);
+  public void recordRetireOldStoreVersionsLatency(long latency) {
+    retireOldStoreVersionsLatencySensor.record(latency);
   }
 
-  public void recordWaitTimeForResources(long latency) {
-    waitTimeForResourcesSensor.record(latency);
-  }
-
-  public void recordHandleVersionCreationFailureLatency(long latency) {
-    handleVersionCreationFailureLatencySensor.record(latency);
+  public void recordWaitTimeForResourcesAssignmentLatency(long latency) {
+    waitTimeForResourcesAssignmentLatencySensor.record(latency);
   }
 
   public void recordHandleAddVersionWithSourceVersionExistLatency(long latency) {
@@ -60,5 +73,9 @@ public class AddVersionLatencyStats extends AbstractVeniceStats {
 
   public void recordHelixStorageClusterResourcesCreationLatency(long latency) {
     helixStorageClusterResourcesCreationLatencySensor.record(latency);
+  }
+
+  public void recordHandleVersionCreationFailureLatency(long latency) {
+    handleVersionCreationFailureLatencySensor.record(latency);
   }
 }

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/stats/AddVersionLatencyStats.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/stats/AddVersionLatencyStats.java
@@ -1,6 +1,7 @@
 package com.linkedin.venice.controller.stats;
 
 import com.linkedin.venice.stats.AbstractVeniceStats;
+import com.linkedin.venice.stats.TehutiUtils;
 import io.tehuti.metrics.MetricsRepository;
 import io.tehuti.metrics.Sensor;
 import io.tehuti.metrics.stats.Avg;
@@ -53,25 +54,59 @@ public class AddVersionLatencyStats extends AbstractVeniceStats {
 
   public AddVersionLatencyStats(MetricsRepository metricsRepository, String name) {
     super(metricsRepository, name);
-    retireOldVersionsLatencySensor =
-        registerSensorIfAbsent("add_version_retire_old_versions_latency", new Avg(), new Max());
 
-    resourceAssignmentWaitLatencySensor =
-        registerSensorIfAbsent("add_version_resource_assignment_wait_latency", new Avg(), new Max());
+    String retireOldVersionsLatencySensorName = "add_version_retire_old_versions_latency";
+    retireOldVersionsLatencySensor = registerSensorIfAbsent(
+        retireOldVersionsLatencySensorName,
+        new Avg(),
+        new Max(),
+        TehutiUtils.getPercentileStat(getName() + AbstractVeniceStats.DELIMITER + retireOldVersionsLatencySensorName));
 
-    versionCreationFailureLatencySensor =
-        registerSensorIfAbsent("add_version_creation_failure_latency", new Avg(), new Max());
+    String resourceAssignmentWaitLatencySensorName = "add_version_resource_assignment_wait_latency";
+    resourceAssignmentWaitLatencySensor = registerSensorIfAbsent(
+        resourceAssignmentWaitLatencySensorName,
+        new Avg(),
+        new Max(),
+        TehutiUtils
+            .getPercentileStat(getName() + AbstractVeniceStats.DELIMITER + resourceAssignmentWaitLatencySensorName));
 
-    existingSourceVersionHandlingLatencySensor =
-        registerSensorIfAbsent("add_version_existing_source_handling_latency", new Avg(), new Max());
+    String versionCreationFailureLatencySensorName = "add_version_creation_failure_latency";
+    versionCreationFailureLatencySensor = registerSensorIfAbsent(
+        versionCreationFailureLatencySensorName,
+        new Avg(),
+        new Max(),
+        TehutiUtils
+            .getPercentileStat(getName() + AbstractVeniceStats.DELIMITER + versionCreationFailureLatencySensorName));
 
-    startOfPushLatencySensor = registerSensorIfAbsent("add_version_start_of_push_latency", new Avg(), new Max());
+    String existingSourceVersionHandlingLatencySensorName = "add_version_existing_source_handling_latency";
+    existingSourceVersionHandlingLatencySensor = registerSensorIfAbsent(
+        existingSourceVersionHandlingLatencySensorName,
+        new Avg(),
+        new Max(),
+        TehutiUtils.getPercentileStat(
+            getName() + AbstractVeniceStats.DELIMITER + existingSourceVersionHandlingLatencySensorName));
 
-    batchTopicCreationLatencySensor =
-        registerSensorIfAbsent("add_version_batch_topic_creation_latency", new Avg(), new Max());
+    String startOfPushLatencySensorName = "add_version_start_of_push_latency";
+    startOfPushLatencySensor = registerSensorIfAbsent(
+        startOfPushLatencySensorName,
+        new Avg(),
+        new Max(),
+        TehutiUtils.getPercentileStat(getName() + AbstractVeniceStats.DELIMITER + startOfPushLatencySensorName));
 
-    helixResourceCreationLatencySensor =
-        registerSensorIfAbsent("add_version_helix_resource_creation_latency", new Avg(), new Max());
+    String batchTopicCreationLatencySensorName = "add_version_batch_topic_creation_latency";
+    batchTopicCreationLatencySensor = registerSensorIfAbsent(
+        "add_version_batch_topic_creation_latency",
+        new Avg(),
+        new Max(),
+        TehutiUtils.getPercentileStat(getName() + AbstractVeniceStats.DELIMITER + batchTopicCreationLatencySensorName));
+
+    String helixResourceCreationLatencySensorName = "add_version_helix_resource_creation_latency";
+    helixResourceCreationLatencySensor = registerSensorIfAbsent(
+        helixResourceCreationLatencySensorName,
+        new Avg(),
+        new Max(),
+        TehutiUtils
+            .getPercentileStat(getName() + AbstractVeniceStats.DELIMITER + helixResourceCreationLatencySensorName));
   }
 
   public void recordRetireOldVersionsLatency(long latency) {

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/stats/AddVersionLatencyStats.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/stats/AddVersionLatencyStats.java
@@ -1,0 +1,64 @@
+package com.linkedin.venice.controller.stats;
+
+import com.linkedin.venice.stats.AbstractVeniceStats;
+import io.tehuti.metrics.MetricsRepository;
+import io.tehuti.metrics.Sensor;
+import io.tehuti.metrics.stats.Avg;
+import io.tehuti.metrics.stats.Max;
+
+
+public class AddVersionLatencyStats extends AbstractVeniceStats {
+  private final Sensor retiredVersionLatencySensor;
+  private final Sensor waitTimeForResourcesSensor;
+  private final Sensor handleVersionCreationFailureLatencySensor;
+  private final Sensor handleAddVersionWithSourceVersionExistLatencySensor;
+  private final Sensor sendStartOfPushLatencySensor;
+  private final Sensor topicCreationLatencySensor;
+  private final Sensor helixStorageClusterResourcesCreationLatencySensor;
+
+  public AddVersionLatencyStats(MetricsRepository metricsRepository, String name) {
+    super(metricsRepository, name);
+    retiredVersionLatencySensor = registerSensorIfAbsent("add_version_retired_version_latency", new Avg(), new Max());
+    waitTimeForResourcesSensor = registerSensorIfAbsent("add_version_wait_time_for_resources", new Avg(), new Max());
+    handleVersionCreationFailureLatencySensor =
+        registerSensorIfAbsent("add_version_handle_version_creation_failure_latency", new Avg(), new Max());
+    handleAddVersionWithSourceVersionExistLatencySensor = registerSensorIfAbsent(
+        "add_version_handle_add_version_with_source_version_exist_latency",
+        new Avg(),
+        new Max());
+    sendStartOfPushLatencySensor =
+        registerSensorIfAbsent("add_version_send_start_of_push_latency", new Avg(), new Max());
+    topicCreationLatencySensor =
+        registerSensorIfAbsent("add_version_create_batch_topics_latency", new Avg(), new Max());
+    helixStorageClusterResourcesCreationLatencySensor =
+        registerSensorIfAbsent("add_version_helix_storage_cluster_resources_creation_latency", new Avg(), new Max());
+  }
+
+  public void recordRetiredVersionLatency(long latency) {
+    retiredVersionLatencySensor.record(latency);
+  }
+
+  public void recordWaitTimeForResources(long latency) {
+    waitTimeForResourcesSensor.record(latency);
+  }
+
+  public void recordHandleVersionCreationFailureLatency(long latency) {
+    handleVersionCreationFailureLatencySensor.record(latency);
+  }
+
+  public void recordHandleAddVersionWithSourceVersionExistLatency(long latency) {
+    handleAddVersionWithSourceVersionExistLatencySensor.record(latency);
+  }
+
+  public void recordSendStartOfPushLatency(long latency) {
+    sendStartOfPushLatencySensor.record(latency);
+  }
+
+  public void recordCreateBatchTopicsLatency(long latency) {
+    topicCreationLatencySensor.record(latency);
+  }
+
+  public void recordHelixStorageClusterResourcesCreationLatency(long latency) {
+    helixStorageClusterResourcesCreationLatencySensor.record(latency);
+  }
+}


### PR DESCRIPTION
<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat], [protocol]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## Problem Statement
We have seen the high latency in addVersion (10-80s) on avg. To find the bottleneck of the operation, we will add the latency metrics to measure heavy ops step. This result will enable us to detect the bottleneck and modify the code correspondingly.

## Solution
Add `AddVersionLatencyStats` at cluster level. There are multiple sensors added:
| **Sensor Name**                                  | **Description**                                                                 |
|--------------------------------------------------|---------------------------------------------------------------------------------|
| `retireOldVersionsLatencySensor`                | Measures the time taken to retire outdated store versions.                      |
| `resourceAssignmentWaitLatencySensor`           | Captures the latency while waiting for node resource assignments.              |
| `versionCreationFailureLatencySensor`           | Tracks latency during the handling of version creation failures.               |
| `existingSourceVersionHandlingLatencySensor`    | Measures latency for add version requests where the source version exists.     |
| `startOfPushLatencySensor`                      | Records the time taken to send the start-of-push signal.                        |
| `batchTopicCreationLatencySensor`               | Tracks latency for creating batch topics (used by both parent and child controllers). |
| `helixResourceCreationLatencySensor`            | Monitors the time required to create Helix storage cluster resources.          |


###  Code changes
- [ ] Added new code behind **a config**. If so list the config names and their default values in the PR description.
- [ ] Introduced new **log lines**. 
  - [ ] Confirmed if logs need to be **rate limited** to avoid excessive logging.

###  **Concurrency-Specific Checks**
Both reviewer and PR author to verify
- [ ] Code has **no race conditions** or **thread safety issues**.
- [ ] Proper **synchronization mechanisms** (e.g., `synchronized`, `RWLock`) are used where needed.
- [ ] No **blocking calls** inside critical sections that could lead to deadlocks or performance degradation.
- [ ] Verified **thread-safe collections** are used (e.g., `ConcurrentHashMap`, `CopyOnWriteArrayList`).
- [ ] Validated proper exception handling in multi-threaded code to avoid silent thread termination.


## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->

- [ ] New unit tests added.
- [ ] New integration tests added.
- [ ] Modified or extended existing tests.
- [ ] Verified backward compatibility (if applicable).

## Does this PR introduce any user-facing or breaking changes?
<!--  
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [ ] No. You can skip the rest of this section.
- [ ] Yes. Clearly explain the behavior change and its impact.