### PR TITLE
[controller] Fix bug in ProtocolVersionAutoDetectionService

### DIFF
--- a/internal/venice-common/src/main/java/com/linkedin/venice/controllerapi/AdminOperationProtocolVersionControllerResponse.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/controllerapi/AdminOperationProtocolVersionControllerResponse.java
@@ -6,8 +6,8 @@ import java.util.Map;
 
 public class AdminOperationProtocolVersionControllerResponse extends ControllerResponse {
   private long localAdminOperationProtocolVersion = -1;
-  private String requestUrl = "";
-  private Map<String, Long> controllerUrlToVersionMap = new HashMap<>();
+  private String localControllerName = "";
+  private Map<String, Long> controllerNameToVersionMap = new HashMap<>();
 
   public void setLocalAdminOperationProtocolVersion(long adminOperationProtocolVersion) {
     this.localAdminOperationProtocolVersion = adminOperationProtocolVersion;
@@ -17,19 +17,19 @@ public class AdminOperationProtocolVersionControllerResponse extends ControllerR
     return localAdminOperationProtocolVersion;
   }
 
-  public void setRequestUrl(String url) {
-    this.requestUrl = url;
+  public void setLocalControllerName(String controllerName) {
+    this.localControllerName = controllerName;
   }
 
-  public String getRequestUrl() {
-    return requestUrl;
+  public String getLocalControllerName() {
+    return localControllerName;
   }
 
-  public void setControllerUrlToVersionMap(Map<String, Long> urlToVersionMap) {
-    this.controllerUrlToVersionMap = urlToVersionMap;
+  public void setControllerNameToVersionMap(Map<String, Long> controllerNameToVersionMap) {
+    this.controllerNameToVersionMap = controllerNameToVersionMap;
   }
 
-  public Map<String, Long> getControllerUrlToVersionMap() {
-    return controllerUrlToVersionMap;
+  public Map<String, Long> getControllerNameToVersionMap() {
+    return controllerNameToVersionMap;
   }
 }

--- a/internal/venice-common/src/main/java/com/linkedin/venice/controllerapi/AdminOperationProtocolVersionControllerResponse.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/controllerapi/AdminOperationProtocolVersionControllerResponse.java
@@ -1,5 +1,6 @@
 package com.linkedin.venice.controllerapi;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -31,5 +32,26 @@ public class AdminOperationProtocolVersionControllerResponse extends ControllerR
 
   public Map<String, Long> getControllerNameToVersionMap() {
     return controllerNameToVersionMap;
+  }
+
+  /*
+   * This method is used to convert the object to a string representation.
+   * AdminOperationProtocolVersionControllerResponse {"localAdminOperationProtocolVersion": 4, "cluster": "venice0,
+   * "requestUrl": "host7", "controllerUrlToVersionMap": {host7=4, host9=6, host8=5}}
+   */
+  @JsonIgnore
+  public String toString() {
+    return new StringBuilder().append(this.getClass().getSimpleName())
+        .append(" {")
+        .append("\"localAdminOperationProtocolVersion\": ")
+        .append(localAdminOperationProtocolVersion)
+        .append(", \"cluster\": \"")
+        .append(getCluster())
+        .append(", \"localControllerName\": \"")
+        .append(localControllerName)
+        .append("\", \"controllerNameToVersionMap\": ")
+        .append(controllerNameToVersionMap.toString())
+        .append("}")
+        .toString();
   }
 }

--- a/internal/venice-common/src/main/java/com/linkedin/venice/controllerapi/AdminOperationProtocolVersionControllerResponse.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/controllerapi/AdminOperationProtocolVersionControllerResponse.java
@@ -1,6 +1,5 @@
 package com.linkedin.venice.controllerapi;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -32,26 +31,5 @@ public class AdminOperationProtocolVersionControllerResponse extends ControllerR
 
   public Map<String, Long> getControllerNameToVersionMap() {
     return controllerNameToVersionMap;
-  }
-
-  /*
-   * This method is used to convert the object to a string representation.
-   * AdminOperationProtocolVersionControllerResponse {"localAdminOperationProtocolVersion": 4, "cluster": "venice0,
-   * "requestUrl": "host7", "controllerUrlToVersionMap": {host7=4, host9=6, host8=5}}
-   */
-  @JsonIgnore
-  public String toString() {
-    return new StringBuilder().append(this.getClass().getSimpleName())
-        .append(" {")
-        .append("\"localAdminOperationProtocolVersion\": ")
-        .append(localAdminOperationProtocolVersion)
-        .append(", \"cluster\": \"")
-        .append(getCluster())
-        .append(", \"localControllerName\": \"")
-        .append(localControllerName)
-        .append("\", \"controllerNameToVersionMap\": ")
-        .append(controllerNameToVersionMap.toString())
-        .append("}")
-        .toString();
   }
 }

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/controller/TestAdminOperationVersionDetection.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/controller/TestAdminOperationVersionDetection.java
@@ -1,6 +1,6 @@
 package com.linkedin.venice.controller;
 
-import static com.linkedin.venice.ConfigKeys.*;
+import static com.linkedin.venice.ConfigKeys.CONTROLLER_SSL_ENABLED;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/controller/TestAdminOperationVersionDetection.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/controller/TestAdminOperationVersionDetection.java
@@ -47,7 +47,7 @@ public class TestAdminOperationVersionDetection {
             .numberOfServers(1)
             .numberOfRouters(1)
             .replicationFactor(1)
-            .sslToStorageNodes(true)
+            .sslToStorageNodes(false)
             .forkServer(false)
             .serverProperties(serverProperties)
             .parentControllerProperties(parentControllerProperties);
@@ -73,7 +73,7 @@ public class TestAdminOperationVersionDetection {
     assertEquals(
         response.getLocalAdminOperationProtocolVersion(),
         AdminOperationSerializer.LATEST_SCHEMA_ID_FOR_ADMIN_OPERATION);
-    Map<String, Long> urlToVersionMap = response.getControllerUrlToVersionMap();
+    Map<String, Long> urlToVersionMap = response.getControllerNameToVersionMap();
     assertEquals(urlToVersionMap.size(), 2);
     assertEquals(response.getCluster(), clusterName);
   }
@@ -97,7 +97,7 @@ public class TestAdminOperationVersionDetection {
     assertEquals(
         response.getLocalAdminOperationProtocolVersion(),
         AdminOperationSerializer.LATEST_SCHEMA_ID_FOR_ADMIN_OPERATION);
-    Map<String, Long> urlToVersionMap = response.getControllerUrlToVersionMap();
+    Map<String, Long> urlToVersionMap = response.getControllerNameToVersionMap();
     assertEquals(urlToVersionMap.size(), 2);
     assertEquals(response.getCluster(), clusterName);
   }

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/controller/TestAdminOperationVersionDetection.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/controller/TestAdminOperationVersionDetection.java
@@ -73,8 +73,8 @@ public class TestAdminOperationVersionDetection {
     assertEquals(
         response.getLocalAdminOperationProtocolVersion(),
         AdminOperationSerializer.LATEST_SCHEMA_ID_FOR_ADMIN_OPERATION);
-    Map<String, Long> urlToVersionMap = response.getControllerNameToVersionMap();
-    assertEquals(urlToVersionMap.size(), 2);
+    Map<String, Long> controllerNameToVersionMap = response.getControllerNameToVersionMap();
+    assertEquals(controllerNameToVersionMap.size(), 2);
     assertEquals(response.getCluster(), clusterName);
   }
 
@@ -97,8 +97,8 @@ public class TestAdminOperationVersionDetection {
     assertEquals(
         response.getLocalAdminOperationProtocolVersion(),
         AdminOperationSerializer.LATEST_SCHEMA_ID_FOR_ADMIN_OPERATION);
-    Map<String, Long> urlToVersionMap = response.getControllerNameToVersionMap();
-    assertEquals(urlToVersionMap.size(), 2);
+    Map<String, Long> controllerNameToVersionMap = response.getControllerNameToVersionMap();
+    assertEquals(controllerNameToVersionMap.size(), 2);
     assertEquals(response.getCluster(), clusterName);
   }
 }

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/controller/TestAdminOperationVersionDetection.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/controller/TestAdminOperationVersionDetection.java
@@ -1,5 +1,6 @@
 package com.linkedin.venice.controller;
 
+import static com.linkedin.venice.ConfigKeys.*;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 
@@ -36,8 +37,10 @@ public class TestAdminOperationVersionDetection {
   @BeforeClass(alwaysRun = true)
   public void setUp() throws Exception {
     // Create multi-region multi-cluster setup
-    Properties parentControllerProperties = new Properties();
+    Properties controllerProperties = new Properties();
+    controllerProperties.put(CONTROLLER_SSL_ENABLED, "false");
     Properties serverProperties = new Properties();
+    serverProperties.put(CONTROLLER_SSL_ENABLED, "false");
 
     VeniceMultiRegionClusterCreateOptions.Builder optionsBuilder =
         new VeniceMultiRegionClusterCreateOptions.Builder().numberOfRegions(NUMBER_OF_CHILD_DATACENTERS)
@@ -47,10 +50,11 @@ public class TestAdminOperationVersionDetection {
             .numberOfServers(1)
             .numberOfRouters(1)
             .replicationFactor(1)
-            .sslToStorageNodes(false)
+            .sslToStorageNodes(true)
             .forkServer(false)
             .serverProperties(serverProperties)
-            .parentControllerProperties(parentControllerProperties);
+            .parentControllerProperties(controllerProperties)
+            .childControllerProperties(controllerProperties);
     multiRegionMultiClusterWrapper =
         ServiceFactory.getVeniceTwoLayerMultiRegionMultiClusterWrapper(optionsBuilder.build());
   }

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestProtocolVersionAutoDetection.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestProtocolVersionAutoDetection.java
@@ -51,6 +51,7 @@ public class TestProtocolVersionAutoDetection {
             .numberOfRouters(1)
             .replicationFactor(1)
             .forkServer(false)
+            .sslToStorageNodes(false)
             .parentControllerProperties(parentControllerProps);
     multiRegionMultiClusterWrapper =
         ServiceFactory.getVeniceTwoLayerMultiRegionMultiClusterWrapper(optionsBuilder.build());

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestProtocolVersionAutoDetection.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestProtocolVersionAutoDetection.java
@@ -1,7 +1,6 @@
 package com.linkedin.venice.endToEnd;
 
-import static com.linkedin.venice.ConfigKeys.CONTROLLER_PROTOCOL_VERSION_AUTO_DETECTION_SERVICE_ENABLED;
-import static com.linkedin.venice.ConfigKeys.CONTROLLER_PROTOCOL_VERSION_AUTO_DETECTION_SLEEP_MS;
+import static com.linkedin.venice.ConfigKeys.*;
 import static com.linkedin.venice.controller.kafka.protocol.serializer.AdminOperationSerializer.LATEST_SCHEMA_ID_FOR_ADMIN_OPERATION;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
@@ -41,6 +40,10 @@ public class TestProtocolVersionAutoDetection {
     Properties parentControllerProps = new Properties();
     parentControllerProps.put(CONTROLLER_PROTOCOL_VERSION_AUTO_DETECTION_SERVICE_ENABLED, true);
     parentControllerProps.put(CONTROLLER_PROTOCOL_VERSION_AUTO_DETECTION_SLEEP_MS, SERVICE_INTERVAL_MS);
+    parentControllerProps.put(CONTROLLER_SSL_ENABLED, "false");
+
+    Properties childControllerProps = new Properties();
+    childControllerProps.put(CONTROLLER_SSL_ENABLED, "false");
 
     VeniceMultiRegionClusterCreateOptions.Builder optionsBuilder =
         new VeniceMultiRegionClusterCreateOptions.Builder().numberOfRegions(NUMBER_OF_CHILD_DATACENTERS)
@@ -51,8 +54,9 @@ public class TestProtocolVersionAutoDetection {
             .numberOfRouters(1)
             .replicationFactor(1)
             .forkServer(false)
-            .sslToStorageNodes(false)
-            .parentControllerProperties(parentControllerProps);
+            .sslToStorageNodes(true)
+            .parentControllerProperties(parentControllerProps)
+            .childControllerProperties(childControllerProps);
     multiRegionMultiClusterWrapper =
         ServiceFactory.getVeniceTwoLayerMultiRegionMultiClusterWrapper(optionsBuilder.build());
     childDatacenters = multiRegionMultiClusterWrapper.getChildRegions();

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestProtocolVersionAutoDetection.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestProtocolVersionAutoDetection.java
@@ -100,7 +100,7 @@ public class TestProtocolVersionAutoDetection {
       AdminOperationProtocolVersionControllerResponse parentResponse =
           parentControllerClient.getAdminOperationProtocolVersionFromControllers(clusterName);
       assertEquals(parentResponse.getLocalAdminOperationProtocolVersion(), LATEST_SCHEMA_ID_FOR_ADMIN_OPERATION);
-      assertEquals(parentResponse.getControllerUrlToVersionMap().size(), 2);
+      assertEquals(parentResponse.getControllerNameToVersionMap().size(), 2);
     }
 
     // child controller
@@ -109,7 +109,7 @@ public class TestProtocolVersionAutoDetection {
       AdminOperationProtocolVersionControllerResponse childResponse =
           dc0ControllerClient.getAdminOperationProtocolVersionFromControllers(clusterName);
       assertEquals(childResponse.getLocalAdminOperationProtocolVersion(), LATEST_SCHEMA_ID_FOR_ADMIN_OPERATION);
-      assertEquals(childResponse.getControllerUrlToVersionMap().size(), 2);
+      assertEquals(childResponse.getControllerNameToVersionMap().size(), 2);
     }
   }
 }

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/Admin.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/Admin.java
@@ -1045,4 +1045,6 @@ public interface Admin extends AutoCloseable, Closeable {
   LogContext getLogContext();
 
   VeniceControllerClusterConfig getControllerConfig(String clusterName);
+
+  String getControllerName();
 }

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/ProtocolVersionAutoDetectionService.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/ProtocolVersionAutoDetectionService.java
@@ -55,7 +55,7 @@ public class ProtocolVersionAutoDetectionService extends AbstractVeniceService {
   @Override
   public boolean startInner() throws Exception {
     LOGGER.info("Starting {}", getClass().getSimpleName());
-    executor.scheduleAtFixedRate(getRunnableTask(), 0, sleepIntervalInMs, TimeUnit.MILLISECONDS);
+    executor.scheduleAtFixedRate(getRunnableTask(), sleepIntervalInMs, sleepIntervalInMs, TimeUnit.MILLISECONDS);
     return true;
   }
 

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/ProtocolVersionAutoDetectionService.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/ProtocolVersionAutoDetectionService.java
@@ -96,7 +96,7 @@ public class ProtocolVersionAutoDetectionService extends AbstractVeniceService {
             "Failed to get admin operation protocol version from child controller " + entry.getKey() + ": "
                 + response.getError());
       }
-      Map<String, Long> controllerUrlToVersionMap = response.getControllerUrlToVersionMap();
+      Map<String, Long> controllerUrlToVersionMap = response.getControllerNameToVersionMap();
       regionToControllerToVersionMap.put(entry.getKey(), controllerUrlToVersionMap);
     }
 

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/ProtocolVersionAutoDetectionService.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/ProtocolVersionAutoDetectionService.java
@@ -96,8 +96,8 @@ public class ProtocolVersionAutoDetectionService extends AbstractVeniceService {
             "Failed to get admin operation protocol version from child controller " + entry.getKey() + ": "
                 + response.getError());
       }
-      Map<String, Long> controllerUrlToVersionMap = response.getControllerNameToVersionMap();
-      regionToControllerToVersionMap.put(entry.getKey(), controllerUrlToVersionMap);
+      Map<String, Long> controllerNameToVersionMap = response.getControllerNameToVersionMap();
+      regionToControllerToVersionMap.put(entry.getKey(), controllerNameToVersionMap);
     }
 
     LOGGER.info("All controller versions for cluster {}: {}", clusterName, regionToControllerToVersionMap);

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceHelixAdmin.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceHelixAdmin.java
@@ -7801,7 +7801,7 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
     // Get the version from the current controller - leader
     Instance leaderController = getLeaderController(clusterName);
 
-    controllerNameToAdminOperationVersionMap.put(controllerName, getLocalAdminOperationProtocolVersion());
+    controllerNameToAdminOperationVersionMap.put(getControllerName(), getLocalAdminOperationProtocolVersion());
 
     // Create the controller client to reuse
     // (this is controller client to communicate with other controllers in the same cluster, the same region)

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceHelixAdmin.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceHelixAdmin.java
@@ -7791,7 +7791,7 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
   /**
    * Get the admin operation protocol versions from controllers (leader + standby) for specific cluster.
    * @param clusterName: the cluster name
-   * @return map (controllerUrl: version). Example: {http://localhost:1234=1, http://localhost:1235=1}*/
+   * @return map (controllerUrl(http): version). Example: {http://localhost:1234=1, http://localhost:1235=1}*/
   @Override
   public Map<String, Long> getAdminOperationVersionFromControllers(String clusterName) {
     checkControllerLeadershipFor(clusterName);

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceHelixAdmin.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceHelixAdmin.java
@@ -7796,12 +7796,12 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
   public Map<String, Long> getAdminOperationVersionFromControllers(String clusterName) {
     checkControllerLeadershipFor(clusterName);
 
-    Map<String, Long> controllerUrlToAdminOperationVersionMap = new HashMap<>();
+    Map<String, Long> controllerNameToAdminOperationVersionMap = new HashMap<>();
 
     // Get the version from the current controller - leader
     Instance leaderController = getLeaderController(clusterName);
 
-    controllerUrlToAdminOperationVersionMap.put(controllerName, getLocalAdminOperationProtocolVersion());
+    controllerNameToAdminOperationVersionMap.put(controllerName, getLocalAdminOperationProtocolVersion());
 
     // Create the controller client to reuse
     // (this is controller client to communicate with other controllers in the same cluster, the same region)
@@ -7824,11 +7824,11 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
             "Failed to get admin operation protocol version from standby controller: " + standbyControllerUrl
                 + ", error message: " + response.getError());
       }
-      controllerUrlToAdminOperationVersionMap
+      controllerNameToAdminOperationVersionMap
           .put(response.getLocalControllerName(), response.getLocalAdminOperationProtocolVersion());
     }
 
-    return controllerUrlToAdminOperationVersionMap;
+    return controllerNameToAdminOperationVersionMap;
   }
 
   /**

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceHelixAdmin.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceHelixAdmin.java
@@ -7387,6 +7387,7 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
         if (instanceNameAndState.getValue().equals(helixState)) {
           // Found the Venice controller, adding to the return list
           String id = instanceNameAndState.getKey();
+          // TODO: Update the instance constructor when Helix NodeId is changed to use secure port.
           controllers.add(
               new Instance(
                   id,
@@ -7814,6 +7815,10 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
     List<Instance> standbyControllers = getControllersByHelixState(clusterName, HelixState.STANDBY_STATE);
 
     for (Instance standbyController: standbyControllers) {
+      // In production, leader and standby share the secure port but have different hostnames—no conflict.
+      // In tests, both run on 'localhost' with the same secure port, which confuses routing.
+      // Hence, we need to disable SSL for local integration tests.
+      // RCA: Helix uses an insecure port from the instance ID, while secure port comes from shared multiClusterConfig.
       String standbyControllerUrl = standbyController.getUrl(getSslFactory().isPresent());
 
       // Get the admin operation protocol version from standby controller
@@ -8053,7 +8058,8 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
     multiClusterConfigs.addClusterConfig(config);
   }
 
-  String getControllerName() {
+  @Override
+  public String getControllerName() {
     return controllerName;
   }
 

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceHelixAdmin.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceHelixAdmin.java
@@ -7791,7 +7791,7 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
   /**
    * Get the admin operation protocol versions from controllers (leader + standby) for specific cluster.
    * @param clusterName: the cluster name
-   * @return map (controllerUrl: version). Example: {localhost_1234=1, localhost_1235=1}*/
+   * @return map (controllerName: version). Example: {localhost_1234=1, localhost_1235=1}*/
   @Override
   public Map<String, Long> getAdminOperationVersionFromControllers(String clusterName) {
     checkControllerLeadershipFor(clusterName);
@@ -7800,10 +7800,8 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
 
     // Get the version from the current controller - leader
     Instance leaderController = getLeaderController(clusterName);
-    putControllerUrlToAdminOperationVersionMap(
-        controllerUrlToAdminOperationVersionMap,
-        leaderController,
-        getLocalAdminOperationProtocolVersion());
+
+    controllerUrlToAdminOperationVersionMap.put(controllerName, getLocalAdminOperationProtocolVersion());
 
     // Create the controller client to reuse
     // (this is controller client to communicate with other controllers in the same cluster, the same region)
@@ -7826,27 +7824,11 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
             "Failed to get admin operation protocol version from standby controller: " + standbyControllerUrl
                 + ", error message: " + response.getError());
       }
-      putControllerUrlToAdminOperationVersionMap(
-          controllerUrlToAdminOperationVersionMap,
-          standbyController,
-          response.getLocalAdminOperationProtocolVersion());
+      controllerUrlToAdminOperationVersionMap
+          .put(response.getLocalControllerName(), response.getLocalAdminOperationProtocolVersion());
     }
 
     return controllerUrlToAdminOperationVersionMap;
-  }
-
-  /**
-   * Put the controller URL and admin operation protocol version into the map.
-   * @param controllerUrlToAdminOperationVersionMap: map to put the controller URL and version
-   * @param controller: the controller instance
-   * @param adminOperationProtocolVersion: the admin operation protocol version
-   */
-  private void putControllerUrlToAdminOperationVersionMap(
-      Map<String, Long> controllerUrlToAdminOperationVersionMap,
-      Instance controller,
-      long adminOperationProtocolVersion) {
-    String controllerUrl = controller.getHost() + "_" + controller.getPort();
-    controllerUrlToAdminOperationVersionMap.put(controllerUrl, adminOperationProtocolVersion);
   }
 
   /**

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceParentHelixAdmin.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceParentHelixAdmin.java
@@ -4547,6 +4547,11 @@ public class VeniceParentHelixAdmin implements Admin {
     return getVeniceHelixAdmin().getLocalAdminOperationProtocolVersion();
   }
 
+  @Override
+  public String getControllerName() {
+    return getVeniceHelixAdmin().getControllerName();
+  }
+
   /**
    * Unsupported operation in the parent controller.
    */

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/server/ControllerRoutes.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/server/ControllerRoutes.java
@@ -258,7 +258,7 @@ public class ControllerRoutes extends AbstractRoute {
       response.type(HttpConstants.JSON);
       try {
         String clusterName = request.queryParams(CLUSTER);
-        String currentUrl = getRequestURL(request, false);
+        String currentUrl = getRequestURL(request);
 
         responseObject.setCluster(clusterName);
         Map<String, Long> controllerUrlToVersionMap = admin.getAdminOperationVersionFromControllers(clusterName);

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/server/ControllerRoutes.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/server/ControllerRoutes.java
@@ -258,7 +258,7 @@ public class ControllerRoutes extends AbstractRoute {
       response.type(HttpConstants.JSON);
       try {
         String clusterName = request.queryParams(CLUSTER);
-        String currentUrl = getRequestURL(request);
+        String currentUrl = getRequestURL(request, false);
 
         responseObject.setCluster(clusterName);
         Map<String, Long> controllerUrlToVersionMap = admin.getAdminOperationVersionFromControllers(clusterName);
@@ -302,16 +302,16 @@ public class ControllerRoutes extends AbstractRoute {
   }
 
   /**
-   * Get the request base URL from the request object.
+   * Get the request base URL from the request object with HTTP as protocol.
    * Example:
    * request.url() = https://localhost:8080/venice/cluster/clusterName/leaderController?param1=value1&param2=value2
-   * base URL: https://localhost:8080
-   * @return the base URL
+   * base URL with https: https://localhost:8080
+   * @return the base URL with http http://localhost:8080
    */
   private String getRequestURL(Request request) {
     try {
       URL url = new URL(request.url());
-      return url.getProtocol() + "://" + url.getHost() + (url.getPort() != -1 ? ":" + url.getPort() : "");
+      return HttpConstants.HTTP + "://" + url.getHost() + (url.getPort() != -1 ? ":" + url.getPort() : "");
     } catch (Exception e) {
       throw new VeniceException("Invalid URL: " + request.url(), e);
     }

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/server/ControllerRoutes.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/server/ControllerRoutes.java
@@ -25,7 +25,6 @@ import com.linkedin.venice.controllerapi.LeaderControllerResponse;
 import com.linkedin.venice.controllerapi.PubSubTopicConfigResponse;
 import com.linkedin.venice.controllerapi.StoppableNodeStatusResponse;
 import com.linkedin.venice.exceptions.ErrorType;
-import com.linkedin.venice.exceptions.VeniceException;
 import com.linkedin.venice.protocols.controller.LeaderControllerGrpcRequest;
 import com.linkedin.venice.protocols.controller.LeaderControllerGrpcResponse;
 import com.linkedin.venice.pubsub.PubSubTopicConfiguration;
@@ -34,7 +33,6 @@ import com.linkedin.venice.pubsub.api.PubSubTopic;
 import com.linkedin.venice.pubsub.manager.TopicManager;
 import com.linkedin.venice.utils.ObjectMapperFactory;
 import com.linkedin.venice.utils.Utils;
-import java.net.URL;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -261,7 +259,7 @@ public class ControllerRoutes extends AbstractRoute {
         responseObject.setCluster(clusterName);
         Map<String, Long> controllerNameToVersionMap = admin.getAdminOperationVersionFromControllers(clusterName);
         responseObject.setControllerNameToVersionMap(controllerNameToVersionMap);
-        responseObject.setLocalControllerName(getControllerName(request));
+        responseObject.setLocalControllerName(admin.getControllerName());
         responseObject.setLocalAdminOperationProtocolVersion(admin.getLocalAdminOperationProtocolVersion());
       } catch (Throwable e) {
         responseObject.setError(e);
@@ -281,28 +279,13 @@ public class ControllerRoutes extends AbstractRoute {
       response.type(HttpConstants.JSON);
       try {
         responseObject.setLocalAdminOperationProtocolVersion(admin.getLocalAdminOperationProtocolVersion());
-        responseObject.setLocalControllerName(getControllerName(request));
+        responseObject.setLocalControllerName(admin.getControllerName());
       } catch (Throwable e) {
         responseObject.setError(e);
         AdminSparkServer.handleError(e, request, response);
       }
       return AdminSparkServer.OBJECT_MAPPER.writeValueAsString(responseObject);
     };
-  }
-
-  /**
-   * Get controller name from the request object.
-   * Example:
-   * request.url() = https://localhost:8080/venice/cluster/clusterName/leaderController?param1=value1&param2=value2
-   * @return "localhost_8080"
-   */
-  private String getControllerName(Request request) {
-    try {
-      URL url = new URL(request.url());
-      return url.getHost() + (url.getPort() != -1 ? "_" + url.getPort() : "");
-    } catch (Exception e) {
-      throw new VeniceException("Invalid URL: " + request.url(), e);
-    }
   }
 
   @FunctionalInterface

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/server/ControllerRoutes.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/server/ControllerRoutes.java
@@ -291,7 +291,7 @@ public class ControllerRoutes extends AbstractRoute {
   }
 
   /**
-   * Get controller name from URL.
+   * Get controller name from the request object.
    * Example:
    * request.url() = https://localhost:8080/venice/cluster/clusterName/leaderController?param1=value1&param2=value2
    * @return "localhost_8080"

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/server/ControllerRoutes.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/server/ControllerRoutes.java
@@ -302,16 +302,15 @@ public class ControllerRoutes extends AbstractRoute {
   }
 
   /**
-   * Get the request base URL from the request object with HTTP as protocol.
+   * Get the request base URL from the request object.
    * Example:
    * request.url() = https://localhost:8080/venice/cluster/clusterName/leaderController?param1=value1&param2=value2
-   * base URL with https: https://localhost:8080
-   * @return the base URL with http http://localhost:8080
+   * @return the base URL: localhost_8080
    */
   private String getRequestURL(Request request) {
     try {
       URL url = new URL(request.url());
-      return HttpConstants.HTTP + "://" + url.getHost() + (url.getPort() != -1 ? ":" + url.getPort() : "");
+      return url.getHost() + (url.getPort() != -1 ? "_" + url.getPort() : "");
     } catch (Exception e) {
       throw new VeniceException("Invalid URL: " + request.url(), e);
     }

--- a/services/venice-controller/src/test/java/com/linkedin/venice/controller/TestProtocolVersionAutoDetectionService.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/controller/TestProtocolVersionAutoDetectionService.java
@@ -216,13 +216,13 @@ public class TestProtocolVersionAutoDetectionService {
       for (Map.Entry<String, Long> entry: hostToVersionMap.entrySet()) {
         String hostName = entry.getKey();
         long version = entry.getValue();
-        response.getControllerUrlToVersionMap().put(hostName, version);
+        response.getControllerNameToVersionMap().put(hostName, version);
         if (hostToClusterToLeaderStateMap.containsKey(hostName)) {
           Map<String, Boolean> clusterToStateMap = hostToClusterToLeaderStateMap.get(hostName);
           if (clusterToStateMap.get(clusterName) != null && clusterToStateMap.get(clusterName)) {
             // Add the local version for leader controller
             response.setLocalAdminOperationProtocolVersion(version);
-            response.setRequestUrl(hostName);
+            response.setLocalControllerName(hostName);
             response.setCluster(clusterName);
           }
         }

--- a/services/venice-controller/src/test/java/com/linkedin/venice/controller/TestVeniceHelixAdmin.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/controller/TestVeniceHelixAdmin.java
@@ -1044,10 +1044,10 @@ public class TestVeniceHelixAdmin {
     // Mock response for standby controllers
     AdminOperationProtocolVersionControllerResponse response1 = new AdminOperationProtocolVersionControllerResponse();
     response1.setLocalAdminOperationProtocolVersion(1);
-    response1.setRequestUrl("standbyHost1_1234");
+    response1.setLocalControllerName("standbyHost1_1234");
     AdminOperationProtocolVersionControllerResponse response2 = new AdminOperationProtocolVersionControllerResponse();
     response2.setLocalAdminOperationProtocolVersion(2);
-    response2.setRequestUrl("standbyHost2_1234");
+    response2.setLocalControllerName("standbyHost2_1234");
 
     List<Instance> standbyControllers = new ArrayList<>();
     standbyControllers.add(new Instance("1", "standbyHost1", 1234));
@@ -1091,7 +1091,7 @@ public class TestVeniceHelixAdmin {
 
     AdminOperationProtocolVersionControllerResponse response1 = new AdminOperationProtocolVersionControllerResponse();
     response1.setLocalAdminOperationProtocolVersion(1);
-    response1.setRequestUrl("http://standbyHost1:1234");
+    response1.setLocalControllerName("standbyHost1_1234");
     AdminOperationProtocolVersionControllerResponse failedResponse =
         new AdminOperationProtocolVersionControllerResponse();
     failedResponse.setError("Failed to get version");

--- a/services/venice-controller/src/test/java/com/linkedin/venice/controller/TestVeniceHelixAdmin.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/controller/TestVeniceHelixAdmin.java
@@ -1036,6 +1036,7 @@ public class TestVeniceHelixAdmin {
     doCallRealMethod().when(veniceParentHelixAdmin).getAdminOperationVersionFromControllers(clusterName);
     doCallRealMethod().when(veniceHelixAdmin).getAdminOperationVersionFromControllers(clusterName);
     doReturn(Optional.empty()).when(veniceHelixAdmin).getSslFactory();
+    doReturn("leaderHost_1234").when(veniceHelixAdmin).getControllerName();
     doNothing().when(veniceHelixAdmin).checkControllerLeadershipFor(clusterName);
 
     // Mock current version in leader is 2
@@ -1078,6 +1079,8 @@ public class TestVeniceHelixAdmin {
     VeniceParentHelixAdmin veniceParentHelixAdmin = mock(VeniceParentHelixAdmin.class);
     VeniceHelixAdmin veniceHelixAdmin = mock(VeniceHelixAdmin.class);
     when(veniceParentHelixAdmin.getVeniceHelixAdmin()).thenReturn(veniceHelixAdmin);
+    doReturn(Optional.empty()).when(veniceHelixAdmin).getSslFactory();
+    doReturn("leaderHost_1234").when(veniceHelixAdmin).getControllerName();
     doCallRealMethod().when(veniceParentHelixAdmin).getAdminOperationVersionFromControllers(clusterName);
     doCallRealMethod().when(veniceHelixAdmin).getAdminOperationVersionFromControllers(clusterName);
 

--- a/services/venice-controller/src/test/java/com/linkedin/venice/controller/TestVeniceHelixAdmin.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/controller/TestVeniceHelixAdmin.java
@@ -1035,6 +1035,8 @@ public class TestVeniceHelixAdmin {
     when(veniceParentHelixAdmin.getVeniceHelixAdmin()).thenReturn(veniceHelixAdmin);
     doCallRealMethod().when(veniceParentHelixAdmin).getAdminOperationVersionFromControllers(clusterName);
     doCallRealMethod().when(veniceHelixAdmin).getAdminOperationVersionFromControllers(clusterName);
+    doReturn(Optional.empty()).when(veniceHelixAdmin).getSslFactory();
+    doNothing().when(veniceHelixAdmin).checkControllerLeadershipFor(clusterName);
 
     // Mock current version in leader is 2
     when(veniceHelixAdmin.getLocalAdminOperationProtocolVersion()).thenReturn(2L);
@@ -1042,10 +1044,10 @@ public class TestVeniceHelixAdmin {
     // Mock response for standby controllers
     AdminOperationProtocolVersionControllerResponse response1 = new AdminOperationProtocolVersionControllerResponse();
     response1.setLocalAdminOperationProtocolVersion(1);
-    response1.setRequestUrl("http://standbyHost1:1234");
+    response1.setRequestUrl("standbyHost1_1234");
     AdminOperationProtocolVersionControllerResponse response2 = new AdminOperationProtocolVersionControllerResponse();
     response2.setLocalAdminOperationProtocolVersion(2);
-    response2.setRequestUrl("http://standbyHost2:1234");
+    response2.setRequestUrl("standbyHost2_1234");
 
     List<Instance> standbyControllers = new ArrayList<>();
     standbyControllers.add(new Instance("1", "standbyHost1", 1234));
@@ -1065,14 +1067,9 @@ public class TestVeniceHelixAdmin {
 
       Map<String, Long> urlToVersionMap = veniceParentHelixAdmin.getAdminOperationVersionFromControllers(clusterName);
       assertEquals(urlToVersionMap.size(), 3);
-      assertTrue(
-          urlToVersionMap.containsKey("http://standbyHost1:1234")
-              && urlToVersionMap.get("http://standbyHost1:1234") == 1L);
-      assertTrue(
-          urlToVersionMap.containsKey("http://standbyHost2:1234")
-              && urlToVersionMap.get("http://standbyHost2:1234") == 2L);
-      assertTrue(
-          urlToVersionMap.containsKey("http://leaderHost:1234") && urlToVersionMap.get("http://leaderHost:1234") == 2L);
+      assertTrue(urlToVersionMap.containsKey("standbyHost1_1234") && urlToVersionMap.get("standbyHost1_1234") == 1L);
+      assertTrue(urlToVersionMap.containsKey("standbyHost2_1234") && urlToVersionMap.get("standbyHost2_1234") == 2L);
+      assertTrue(urlToVersionMap.containsKey("leaderHost_1234") && urlToVersionMap.get("leaderHost_1234") == 2L);
     }
   }
 

--- a/services/venice-controller/src/test/java/com/linkedin/venice/controller/TestVeniceHelixAdmin.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/controller/TestVeniceHelixAdmin.java
@@ -1066,11 +1066,18 @@ public class TestVeniceHelixAdmin {
       when(client.getLocalAdminOperationProtocolVersion("http://standbyHost1:1234")).thenReturn(response1);
       when(client.getLocalAdminOperationProtocolVersion("http://standbyHost2:1234")).thenReturn(response2);
 
-      Map<String, Long> urlToVersionMap = veniceParentHelixAdmin.getAdminOperationVersionFromControllers(clusterName);
-      assertEquals(urlToVersionMap.size(), 3);
-      assertTrue(urlToVersionMap.containsKey("standbyHost1_1234") && urlToVersionMap.get("standbyHost1_1234") == 1L);
-      assertTrue(urlToVersionMap.containsKey("standbyHost2_1234") && urlToVersionMap.get("standbyHost2_1234") == 2L);
-      assertTrue(urlToVersionMap.containsKey("leaderHost_1234") && urlToVersionMap.get("leaderHost_1234") == 2L);
+      Map<String, Long> controllerNameToVersionMap =
+          veniceParentHelixAdmin.getAdminOperationVersionFromControllers(clusterName);
+      assertEquals(controllerNameToVersionMap.size(), 3);
+      assertTrue(
+          controllerNameToVersionMap.containsKey("standbyHost1_1234")
+              && controllerNameToVersionMap.get("standbyHost1_1234") == 1L);
+      assertTrue(
+          controllerNameToVersionMap.containsKey("standbyHost2_1234")
+              && controllerNameToVersionMap.get("standbyHost2_1234") == 2L);
+      assertTrue(
+          controllerNameToVersionMap.containsKey("leaderHost_1234")
+              && controllerNameToVersionMap.get("leaderHost_1234") == 2L);
     }
   }
 

--- a/services/venice-controller/src/test/java/com/linkedin/venice/controller/server/ControllerRoutesTest.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/controller/server/ControllerRoutesTest.java
@@ -219,7 +219,7 @@ public class ControllerRoutesTest {
         localAdminOperationVersionRoute.handle(request, mock(Response.class)).toString(),
         AdminOperationProtocolVersionControllerResponse.class);
     assertEquals(response.getLocalAdminOperationProtocolVersion(), 1L);
-    assertEquals(response.getControllerUrlToVersionMap().size(), 0);
+    assertEquals(response.getControllerNameToVersionMap().size(), 0);
   }
 
   @Test
@@ -250,9 +250,9 @@ public class ControllerRoutesTest {
         adminOperationVersionRoute.handle(request, mock(Response.class)).toString(),
         AdminOperationProtocolVersionControllerResponse.class);
     assertEquals(response.getLocalAdminOperationProtocolVersion(), 1L);
-    assertEquals(response.getControllerUrlToVersionMap().size(), 3);
-    assertEquals(response.getControllerUrlToVersionMap(), urlToVersionMap);
-    assertEquals(response.getRequestUrl(), leaderControllerHost);
+    assertEquals(response.getControllerNameToVersionMap().size(), 3);
+    assertEquals(response.getControllerNameToVersionMap(), urlToVersionMap);
+    assertEquals(response.getLocalControllerName(), leaderControllerHost);
     assertEquals(response.getCluster(), TEST_CLUSTER);
   }
 }

--- a/services/venice-controller/src/test/java/com/linkedin/venice/controller/server/ControllerRoutesTest.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/controller/server/ControllerRoutesTest.java
@@ -229,16 +229,18 @@ public class ControllerRoutesTest {
         new Instance(TEST_NODE_ID, TEST_HOST, TEST_PORT, TEST_SSL_PORT, TEST_GRPC_PORT, TEST_GRPC_SSL_PORT);
 
     doReturn(leaderController).when(mockAdmin).getLeaderController(anyString());
-    String leaderControllerHost = String.format("http://%s:%s", TEST_HOST, TEST_PORT);
+    String leaderControllerHostHttps = String.format("https://%s:%s", TEST_HOST, TEST_PORT);
+    String leaderControllerHostHttp = String.format("http://%s:%s", TEST_HOST, TEST_PORT);
+
     Request request = mock(Request.class);
     doReturn(TEST_CLUSTER).when(request).queryParams(eq(ControllerApiConstants.CLUSTER));
     doReturn(1L).when(mockAdmin).getLocalAdminOperationProtocolVersion();
-    doReturn(leaderControllerHost + "/get_admin_operation_version_from_controllers").when(request).url();
+    doReturn(leaderControllerHostHttps + "/get_admin_operation_version_from_controllers").when(request).url();
 
     Map<String, Long> urlToVersionMap = new HashMap<>();
     urlToVersionMap.put("http://localhost:8080", 1L);
     urlToVersionMap.put("http://localhost:8081", 2L);
-    urlToVersionMap.put(leaderControllerHost, 1L);
+    urlToVersionMap.put(leaderControllerHostHttp, 1L);
     doReturn(urlToVersionMap).when(mockAdmin).getAdminOperationVersionFromControllers(anyString());
 
     Route adminOperationVersionRoute =
@@ -250,7 +252,7 @@ public class ControllerRoutesTest {
     assertEquals(response.getLocalAdminOperationProtocolVersion(), 1L);
     assertEquals(response.getControllerUrlToVersionMap().size(), 3);
     assertEquals(response.getControllerUrlToVersionMap(), urlToVersionMap);
-    assertEquals(response.getRequestUrl(), leaderControllerHost);
+    assertEquals(response.getRequestUrl(), leaderControllerHostHttp);
     assertEquals(response.getCluster(), TEST_CLUSTER);
   }
 }

--- a/services/venice-controller/src/test/java/com/linkedin/venice/controller/server/ControllerRoutesTest.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/controller/server/ControllerRoutesTest.java
@@ -230,7 +230,7 @@ public class ControllerRoutesTest {
 
     doReturn(leaderController).when(mockAdmin).getLeaderController(anyString());
     String leaderControllerHostHttps = String.format("https://%s:%s", TEST_HOST, TEST_PORT);
-    String leaderControllerHostHttp = String.format("http://%s:%s", TEST_HOST, TEST_PORT);
+    String leaderControllerHost = String.format("%s_%s", TEST_HOST, TEST_PORT);
 
     Request request = mock(Request.class);
     doReturn(TEST_CLUSTER).when(request).queryParams(eq(ControllerApiConstants.CLUSTER));
@@ -238,9 +238,9 @@ public class ControllerRoutesTest {
     doReturn(leaderControllerHostHttps + "/get_admin_operation_version_from_controllers").when(request).url();
 
     Map<String, Long> urlToVersionMap = new HashMap<>();
-    urlToVersionMap.put("http://localhost:8080", 1L);
-    urlToVersionMap.put("http://localhost:8081", 2L);
-    urlToVersionMap.put(leaderControllerHostHttp, 1L);
+    urlToVersionMap.put("localhost_8080", 1L);
+    urlToVersionMap.put("localhost_8081", 2L);
+    urlToVersionMap.put(leaderControllerHost, 1L);
     doReturn(urlToVersionMap).when(mockAdmin).getAdminOperationVersionFromControllers(anyString());
 
     Route adminOperationVersionRoute =
@@ -252,7 +252,7 @@ public class ControllerRoutesTest {
     assertEquals(response.getLocalAdminOperationProtocolVersion(), 1L);
     assertEquals(response.getControllerUrlToVersionMap().size(), 3);
     assertEquals(response.getControllerUrlToVersionMap(), urlToVersionMap);
-    assertEquals(response.getRequestUrl(), leaderControllerHostHttp);
+    assertEquals(response.getRequestUrl(), leaderControllerHost);
     assertEquals(response.getCluster(), TEST_CLUSTER);
   }
 }

--- a/services/venice-controller/src/test/java/com/linkedin/venice/controller/server/ControllerRoutesTest.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/controller/server/ControllerRoutesTest.java
@@ -207,6 +207,8 @@ public class ControllerRoutesTest {
 
     doReturn(leaderController).when(mockAdmin).getLeaderController(anyString());
     String leaderControllerHost = String.format("http://%s:%s", TEST_HOST, TEST_PORT);
+    doReturn(leaderControllerHost).when(mockAdmin).getControllerName();
+
     Request request = mock(Request.class);
     doReturn(TEST_CLUSTER).when(request).queryParams(eq(ControllerApiConstants.CLUSTER));
     doReturn(1L).when(mockAdmin).getLocalAdminOperationProtocolVersion();
@@ -231,6 +233,7 @@ public class ControllerRoutesTest {
     doReturn(leaderController).when(mockAdmin).getLeaderController(anyString());
     String leaderControllerHostHttps = String.format("https://%s:%s", TEST_HOST, TEST_PORT);
     String leaderControllerHost = String.format("%s_%s", TEST_HOST, TEST_PORT);
+    doReturn(leaderControllerHost).when(mockAdmin).getControllerName();
 
     Request request = mock(Request.class);
     doReturn(TEST_CLUSTER).when(request).queryParams(eq(ControllerApiConstants.CLUSTER));

--- a/services/venice-controller/src/test/java/com/linkedin/venice/controller/server/ControllerRoutesTest.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/controller/server/ControllerRoutesTest.java
@@ -237,11 +237,11 @@ public class ControllerRoutesTest {
     doReturn(1L).when(mockAdmin).getLocalAdminOperationProtocolVersion();
     doReturn(leaderControllerHostHttps + "/get_admin_operation_version_from_controllers").when(request).url();
 
-    Map<String, Long> urlToVersionMap = new HashMap<>();
-    urlToVersionMap.put("localhost_8080", 1L);
-    urlToVersionMap.put("localhost_8081", 2L);
-    urlToVersionMap.put(leaderControllerHost, 1L);
-    doReturn(urlToVersionMap).when(mockAdmin).getAdminOperationVersionFromControllers(anyString());
+    Map<String, Long> controllerNameToVersionMap = new HashMap<>();
+    controllerNameToVersionMap.put("localhost_8080", 1L);
+    controllerNameToVersionMap.put("localhost_8081", 2L);
+    controllerNameToVersionMap.put(leaderControllerHost, 1L);
+    doReturn(controllerNameToVersionMap).when(mockAdmin).getAdminOperationVersionFromControllers(anyString());
 
     Route adminOperationVersionRoute =
         new ControllerRoutes(false, Optional.empty(), pubSubTopicRepository, requestHandler)
@@ -251,7 +251,7 @@ public class ControllerRoutesTest {
         AdminOperationProtocolVersionControllerResponse.class);
     assertEquals(response.getLocalAdminOperationProtocolVersion(), 1L);
     assertEquals(response.getControllerNameToVersionMap().size(), 3);
-    assertEquals(response.getControllerNameToVersionMap(), urlToVersionMap);
+    assertEquals(response.getControllerNameToVersionMap(), controllerNameToVersionMap);
     assertEquals(response.getLocalControllerName(), leaderControllerHost);
     assertEquals(response.getCluster(), TEST_CLUSTER);
   }


### PR DESCRIPTION
## Problem Statement
During testing, we identified the following issues:

### 1. Leadership Check Fails on Startup
- **Cause:** `initialDelay` is set to `0`, so the task runs immediately. This triggers a leadership check before the host is fully initialized.
- **Effect:** Although the host is the leader, it fails the check because it's not ready. The second retry usually succeeds.
- **Solution:** Increase the `initialDelay` to give the host time to complete setup before the check runs.

### 2. Protocol Mismatch in URL Comparison
- **Cause:** The `controllerUrlToVersionMap` uses `http://` as keys, but incoming `requestURL`s are in `https://`.
- **Effect:** Lookup in the map fails due to the protocol mismatch, as no matching key is found.
- **Solution:** Use HTTP/HTTPS based on SSL Factory, and remove the protocol from the key string of `controllerUrlToVersionMap`

## Solution
1. Increase the initial delay == sleep duration
2. Use HTTP/HTTPS based on SSL Factory, and remove the protocol from the key string of `controllerUrlToVersionMap`

**Note**: During the PR development time, I found one interesting symptom that requires me to disable SSL in integration test. However, HTTPs on production should work.

Issue: When we look for leader/standby in Helix, the port we see is HTTP port, and HTTPs port is defined by multiClusterConfig. 

On production, we have different host and the SAME port number. However, at local, we have SAME host (localhost) and different port for different controllers.

When we have Instance, we can get the URL by `getUrl(https)`. The issue is that `getUrl(true)` will return the same url for any controller with the same host (localhost) and the same port (`multiClusterConfigs.getAdminSecurePort()`). When `getUrl(false)` we wont have issue because the port in Helix is respected.

Hence, I need to disable HTTPs in integration test, else, the request will be routed back to leader.


###  Code changes
- [ ] Added new code behind **a config**. If so list the config names and their default values in the PR description.
- [ ] Introduced new **log lines**. 
  - [ ] Confirmed if logs need to be **rate limited** to avoid excessive logging.

###  **Concurrency-Specific Checks**
Both reviewer and PR author to verify
- [x] Code has **no race conditions** or **thread safety issues**.
- [x] Proper **synchronization mechanisms** (e.g., `synchronized`, `RWLock`) are used where needed.
- [x] No **blocking calls** inside critical sections that could lead to deadlocks or performance degradation.
- [x] Verified **thread-safe collections** are used (e.g., `ConcurrentHashMap`, `CopyOnWriteArrayList`).
- [x] Validated proper exception handling in multi-threaded code to avoid silent thread termination.


## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->

- [ ] New unit tests added.
- [ ] New integration tests added.
- [x] Modified or extended existing tests.
- [ ] Verified backward compatibility (if applicable).

## Does this PR introduce any user-facing or breaking changes?
<!--  
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [ ] No. You can skip the rest of this section.
- [ ] Yes. Clearly explain the behavior change and its impact.