### PR TITLE
[venice-thin-client] Removed async warmup in Venice Thin Client

### DIFF
--- a/clients/venice-thin-client/src/main/java/com/linkedin/venice/client/schema/RouterBackedSchemaReader.java
+++ b/clients/venice-thin-client/src/main/java/com/linkedin/venice/client/schema/RouterBackedSchemaReader.java
@@ -20,7 +20,6 @@ import com.linkedin.venice.service.ICProvider;
 import com.linkedin.venice.utils.AvroSchemaUtils;
 import com.linkedin.venice.utils.DaemonThreadFactory;
 import com.linkedin.venice.utils.ObjectMapperFactory;
-import com.linkedin.venice.utils.RetryUtils;
 import com.linkedin.venice.utils.concurrent.VeniceConcurrentHashMap;
 import java.io.IOException;
 import java.time.Duration;
@@ -31,7 +30,6 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
@@ -671,11 +669,7 @@ public class RouterBackedSchemaReader implements SchemaReader {
         responseFuture = (CompletableFuture<byte[]>) storeClient.getRaw(requestPath);
       }
 
-      response = RetryUtils.executeWithMaxAttempt(
-          () -> (responseFuture.get()),
-          5,
-          Duration.ofMillis(100),
-          Collections.singletonList(ExecutionException.class));
+      response = responseFuture.get(1, TimeUnit.SECONDS);
     } catch (Exception e) {
       throw new VeniceClientException(
           "Failed to execute request from path " + requestPath + ", storeClient: " + storeClient,

--- a/clients/venice-thin-client/src/main/java/com/linkedin/venice/client/store/AbstractAvroStoreClient.java
+++ b/clients/venice-thin-client/src/main/java/com/linkedin/venice/client/store/AbstractAvroStoreClient.java
@@ -540,6 +540,9 @@ public abstract class AbstractAvroStoreClient<K, V> extends InternalAvroStoreCli
       startWithExceptionThrownWhenFail();
     } catch (Exception e) {
       if (clientConfig.isForceClusterDiscoveryAtStartTime()) {
+        if (e instanceof VeniceClientException) {
+          throw (VeniceClientException) e;
+        }
         throw new VeniceClientException(
             "Failed to initializing Venice Client: " + getStoreName() + " with error: " + e.getMessage(),
             e);

--- a/clients/venice-thin-client/src/main/java/com/linkedin/venice/client/store/AbstractAvroStoreClient.java
+++ b/clients/venice-thin-client/src/main/java/com/linkedin/venice/client/store/AbstractAvroStoreClient.java
@@ -539,6 +539,11 @@ public abstract class AbstractAvroStoreClient<K, V> extends InternalAvroStoreCli
     try {
       startWithExceptionThrownWhenFail();
     } catch (Exception e) {
+      if (clientConfig.isForceClusterDiscoveryAtStartTime()) {
+        throw new VeniceClientException(
+            "Failed to initializing Venice Client: " + getStoreName() + " with error: " + e.getMessage(),
+            e);
+      }
       /**
        * We can't fail the start since the existing customers are relying on the best-effort start behavior.
        */
@@ -562,7 +567,6 @@ public abstract class AbstractAvroStoreClient<K, V> extends InternalAvroStoreCli
       if (started) {
         return;
       }
-      LOGGER.info("Starting Venice client for store: {}", getStoreName(), new RuntimeException("fake exception"));
       /**
        * The following function will try to warmup store metadata:
        * 1. Cluster discovery.

--- a/clients/venice-thin-client/src/main/java/com/linkedin/venice/client/store/AvroBlackHoleResponseStoreClientImpl.java
+++ b/clients/venice-thin-client/src/main/java/com/linkedin/venice/client/store/AvroBlackHoleResponseStoreClientImpl.java
@@ -8,7 +8,6 @@ import com.linkedin.venice.client.store.transport.TransportClient;
 import com.linkedin.venice.client.store.transport.TransportClientStreamingCallback;
 import com.linkedin.venice.compute.ComputeRequestWrapper;
 import com.linkedin.venice.read.RequestHeadersProvider;
-import com.linkedin.venice.serializer.RecordSerializer;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -54,7 +53,6 @@ public class AvroBlackHoleResponseStoreClientImpl<K, V> extends AvroGenericStore
   }
 
   private byte[] serializeComputeRequest(ComputeRequestWrapper computeRequestWrapper, Collection<K> keys) {
-    RecordSerializer keySerializer = getKeySerializerWithoutRetry();
     List<ByteBuffer> serializedKeyList = new ArrayList<>(keys.size());
     ByteBuffer serializedComputeRequest = ByteBuffer.wrap(computeRequestWrapper.serialize());
     for (K key: keys) {

--- a/clients/venice-thin-client/src/main/java/com/linkedin/venice/client/store/ClientConfig.java
+++ b/clients/venice-thin-client/src/main/java/com/linkedin/venice/client/store/ClientConfig.java
@@ -44,7 +44,6 @@ public class ClientConfig<T extends SpecificRecord> {
   // Performance-related settings
   private MetricsRepository metricsRepository = null;
   private Executor deserializationExecutor = null;
-  private Executor warmupExecutor = null;
   private BatchDeserializerType batchDeserializerType = BatchDeserializerType.BLOCKING;
   private boolean useFastAvro = true;
   private boolean retryOnRouterError = false;
@@ -111,7 +110,6 @@ public class ClientConfig<T extends SpecificRecord> {
         // Performance-related settings
         .setMetricsRepository(config.getMetricsRepository())
         .setDeserializationExecutor(config.getDeserializationExecutor())
-        .setWarmupExecutor(config.getWarmupExecutor())
         .setUseFastAvro(config.isUseFastAvro())
         .setRetryOnRouterError(config.isRetryOnRouterErrorEnabled())
         .setRetryOnAllErrors(config.isRetryOnAllErrorsEnabled())
@@ -332,21 +330,6 @@ public class ClientConfig<T extends SpecificRecord> {
    */
   public ClientConfig<T> setDeserializationExecutor(Executor deserializationExecutor) {
     this.deserializationExecutor = deserializationExecutor;
-    return this;
-  }
-
-  public Executor getWarmupExecutor() {
-    return warmupExecutor;
-  }
-
-  /**
-   * Provide an arbitrary executor to execute client warmup,
-   * rather than letting the client use its own internally-generated executor.
-   * If null, or unset, the client will use {@link java.util.concurrent.Executors#newFixedThreadPool(int)}
-   * with a single thread.
-   */
-  public ClientConfig<T> setWarmupExecutor(Executor warmupExecutor) {
-    this.warmupExecutor = warmupExecutor;
     return this;
   }
 

--- a/clients/venice-thin-client/src/main/java/com/linkedin/venice/client/store/D2ServiceDiscovery.java
+++ b/clients/venice-thin-client/src/main/java/com/linkedin/venice/client/store/D2ServiceDiscovery.java
@@ -55,9 +55,9 @@ public class D2ServiceDiscovery {
     for (int attempt = 0; attempt < maxAttempts; ++attempt) {
       try {
         if (attempt > 0) {
-          time.sleep(TimeUnit.SECONDS.toMillis(3));
+          time.sleep(100);
         }
-        TransportClientResponse response = client.get(requestPath, requestHeaders).get(3, TimeUnit.SECONDS);
+        TransportClientResponse response = client.get(requestPath, requestHeaders).get(1, TimeUnit.SECONDS);
 
         if (response == null) {
           /**

--- a/clients/venice-thin-client/src/main/java/com/linkedin/venice/client/store/DelegatingStoreClient.java
+++ b/clients/venice-thin-client/src/main/java/com/linkedin/venice/client/store/DelegatingStoreClient.java
@@ -115,4 +115,9 @@ public class DelegatingStoreClient<K, V> extends InternalAvroStoreClient<K, V> {
       StreamingCallback<GenericRecord, GenericRecord> callback) {
     innerStoreClient.computeWithKeyPrefixFilter(keyPrefix, computeRequestWrapper, callback);
   }
+
+  @Override
+  public void startWithExceptionThrownWhenFail() {
+    innerStoreClient.startWithExceptionThrownWhenFail();
+  }
 }

--- a/clients/venice-thin-client/src/main/java/com/linkedin/venice/client/store/InternalAvroStoreClient.java
+++ b/clients/venice-thin-client/src/main/java/com/linkedin/venice/client/store/InternalAvroStoreClient.java
@@ -48,4 +48,14 @@ public abstract class InternalAvroStoreClient<K, V> implements AvroGenericReadCo
       StreamingCallback<GenericRecord, GenericRecord> callback) {
     throw new VeniceClientException("ComputeWithKeyPrefixFilter is not supported by Venice Avro Store Client");
   }
+
+  /**
+   * This method is mainly for internal use.
+   * The default {#start()} method will not throw an exception if the client fails to start since it is a best
+   * effort to make it compatible with the existing usage of the client (customers can trigger the start() method
+   * even before the dependency is ready).
+   * This method is mainly used to the internal startupAware callback, and it will indicate the startup failure
+   * by throwing an exception.
+   */
+  public abstract void startWithExceptionThrownWhenFail();
 }

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/client/store/AvroGenericStoreClientImplTest.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/client/store/AvroGenericStoreClientImplTest.java
@@ -264,6 +264,20 @@ public class AvroGenericStoreClientImplTest {
 
   @Test
   public void getByStoreKeyTestWithNonExistingKey() throws Throwable {
+    String schema1Str = "\"string\"";
+
+    Map<Integer, String> valueSchemaEntries = new HashMap<>();
+    valueSchemaEntries.put(1, schema1Str);
+    // Push value schema
+    FullHttpResponse valueSchemaResponse = StoreClientTestUtils.constructHttpSchemaResponse(storeName, 1, schema1Str);
+    String valueSchemaPath = "/" + RouterBackedSchemaReader.TYPE_VALUE_SCHEMA + "/" + storeName + "/1";
+    routerServer.addResponseForUri(valueSchemaPath, valueSchemaResponse);
+
+    FullHttpResponse multiValueSchemaIDResponse =
+        StoreClientTestUtils.constructHttpMultiSchemaIdResponse(storeName, valueSchemaEntries);
+    String multiValueSchemaIDPath = "/" + RouterBackedSchemaReader.TYPE_ALL_VALUE_SCHEMA_IDS + "/" + storeName;
+    routerServer.addResponseForUri(multiValueSchemaIDPath, multiValueSchemaIDResponse);
+
     String key = "test_key";
     for (Map.Entry<String, AvroGenericStoreClient<String, Object>> entry: storeClients.entrySet()) {
       LOGGER.info("Execute test for transport client: {}", entry.getKey());
@@ -322,11 +336,26 @@ public class AvroGenericStoreClientImplTest {
     String keyStr = "test_key";
     String valueStr = "test_value";
 
+    String schema1Str = "\"string\"";
+
+    Map<Integer, String> valueSchemaEntries = new HashMap<>();
+    valueSchemaEntries.put(1, schema1Str);
+    // Push value schema
+    FullHttpResponse valueSchemaResponse = StoreClientTestUtils.constructHttpSchemaResponse(storeName, 1, schema1Str);
+    String valueSchemaPath = "/" + RouterBackedSchemaReader.TYPE_VALUE_SCHEMA + "/" + storeName + "/1";
+    routerServer.addResponseForUri(valueSchemaPath, valueSchemaResponse);
+
+    FullHttpResponse multiValueSchemaIDResponse =
+        StoreClientTestUtils.constructHttpMultiSchemaIdResponse(storeName, valueSchemaEntries);
+    String multiValueSchemaIDPath = "/" + RouterBackedSchemaReader.TYPE_ALL_VALUE_SCHEMA_IDS + "/" + storeName;
+    routerServer.addResponseForUri(multiValueSchemaIDPath, multiValueSchemaIDResponse);
+
     int nonExistingSchemaId = 2;
     FullHttpResponse valueResponse =
         StoreClientTestUtils.constructStoreResponse(nonExistingSchemaId, valueStr.getBytes());
     String storeRequestPath = "/" + someStoreClient.getRequestPathByKey(keyStr);
     routerServer.addResponseForUri(storeRequestPath, valueResponse);
+
     for (int i = 0; i < TEST_ITERATIONS; i++) {
       LOGGER.info("Iteration: {}", i);
       for (Map.Entry<String, AvroGenericStoreClient<String, Object>> entry: storeClients.entrySet()) {
@@ -337,7 +366,7 @@ public class AvroGenericStoreClientImplTest {
           Throwable cause = e.getCause();
           boolean causeOfCorrectType = cause instanceof VeniceClientException;
           boolean correctMessage =
-              cause.getMessage().contains("Failed to get latest value schema for store: test_store");
+              cause.getMessage().contains("Failed to get value schema for store: test_store and id: 2");
           if (!causeOfCorrectType || !correctMessage) {
             LOGGER.error(
                 "Received ExecutionException, as expected, but it doesn't have the right characteristics. Logging stacktrace. Client: {}",
@@ -367,6 +396,20 @@ public class AvroGenericStoreClientImplTest {
     String keyStr = "test_key";
     int valueSchemaId = 1;
     String valueStr = "test_value";
+
+    String schema1Str = "\"string\"";
+
+    Map<Integer, String> valueSchemaEntries = new HashMap<>();
+    valueSchemaEntries.put(1, schema1Str);
+    // Push value schema
+    FullHttpResponse valueSchemaResponse = StoreClientTestUtils.constructHttpSchemaResponse(storeName, 1, schema1Str);
+    String valueSchemaPath = "/" + RouterBackedSchemaReader.TYPE_VALUE_SCHEMA + "/" + storeName + "/1";
+    routerServer.addResponseForUri(valueSchemaPath, valueSchemaResponse);
+
+    FullHttpResponse multiValueSchemaIDResponse =
+        StoreClientTestUtils.constructHttpMultiSchemaIdResponse(storeName, valueSchemaEntries);
+    String multiValueSchemaIDPath = "/" + RouterBackedSchemaReader.TYPE_ALL_VALUE_SCHEMA_IDS + "/" + storeName;
+    routerServer.addResponseForUri(multiValueSchemaIDPath, multiValueSchemaIDResponse);
 
     FullHttpResponse valueResponse = StoreClientTestUtils.constructStoreResponse(valueSchemaId, valueStr.getBytes());
     valueResponse.headers().remove(HttpConstants.VENICE_SCHEMA_ID);

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/client/store/AvroSpecificStoreClientImplTest.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/client/store/AvroSpecificStoreClientImplTest.java
@@ -125,6 +125,11 @@ public class AvroSpecificStoreClientImplTest {
     String multiValueSchemaPath = "/" + RouterBackedSchemaReader.TYPE_VALUE_SCHEMA + "/" + storeName;
     routerServer.addResponseForUri(multiValueSchemaPath, multiValueSchemaResponse);
 
+    FullHttpResponse multiValueSchemaIDResponse =
+        StoreClientTestUtils.constructHttpMultiSchemaIdResponse(storeName, valueSchemaEntries);
+    String multiValueSchemaIDPath = "/" + RouterBackedSchemaReader.TYPE_ALL_VALUE_SCHEMA_IDS + "/" + storeName;
+    routerServer.addResponseForUri(multiValueSchemaIDPath, multiValueSchemaIDResponse);
+
     // Push store record
     TestKeyRecord testKey = new TestKeyRecord();
     testKey.long_field = 100;
@@ -171,6 +176,11 @@ public class AvroSpecificStoreClientImplTest {
         StoreClientTestUtils.constructHttpMultiSchemaResponse(storeName, valueSchemaEntries);
     String multiValueSchemaPath = "/" + RouterBackedSchemaReader.TYPE_VALUE_SCHEMA + "/" + storeName;
     routerServer.addResponseForUri(multiValueSchemaPath, multiValueSchemaResponse);
+
+    FullHttpResponse multiValueSchemaIDResponse =
+        StoreClientTestUtils.constructHttpMultiSchemaIdResponse(storeName, valueSchemaEntries);
+    String multiValueSchemaIDPath = "/" + RouterBackedSchemaReader.TYPE_ALL_VALUE_SCHEMA_IDS + "/" + storeName;
+    routerServer.addResponseForUri(multiValueSchemaIDPath, multiValueSchemaIDResponse);
 
     // Push store record
     TestKeyRecord testKey = new TestKeyRecord();

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/router/TestStreaming.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/router/TestStreaming.java
@@ -24,7 +24,6 @@ import com.linkedin.venice.compression.VeniceCompressor;
 import com.linkedin.venice.controllerapi.ControllerClient;
 import com.linkedin.venice.controllerapi.UpdateStoreQueryParams;
 import com.linkedin.venice.controllerapi.VersionCreationResponse;
-import com.linkedin.venice.exceptions.VeniceException;
 import com.linkedin.venice.exceptions.VeniceNoStoreException;
 import com.linkedin.venice.helix.HelixReadOnlySchemaRepository;
 import com.linkedin.venice.integration.utils.D2TestUtils;
@@ -486,8 +485,8 @@ public class TestStreaming {
               .setForceClusterDiscoveryAtStartTime(true));
       fail("An exception is expected here");
     } catch (Throwable t) {
-      if (!(t instanceof VeniceException) || !t.getMessage().contains("Failed to initializing Venice Client")) {
-        fail("Unexpected exception received: " + t.getClass());
+      if (!(t instanceof VeniceClientException) || !t.getMessage().contains("Failed to find d2 service")) {
+        fail("Unexpected exception received: " + t.getClass() + " with message: " + t.getMessage());
       }
     } finally {
       Utils.closeQuietlyWithErrorLogged(d2StoreClient);


### PR DESCRIPTION



<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat], [protocol]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## Problem Statement
<!--
Describe
- What problem are you trying to solve
- What issues or limitations exist in the current code
- Why this change is necessary 
-->
The async warmup in venice-thin-client has introduced a lot of confusions and issues in the past and the hope was to mitigate the cold start issue when the users don't start the client in the internal startup aware callback, which is typically this case, and that was why we introduced async warmup since the dependent d2 client might not be ready when `start` is invoked and we hope the startup procedure can be done before sending out the first request, but in practice, it doesn't hold true for most of the cases.

## Solution
<!--
Describe
- What changes you are making and why. 
- How these changes solve the problem.
- Any performance considerations or trade-offs. 
- Describe what testings you have done, for example, performance testing etc.
-->

We discovered a new way to invoke the `start` method of the store clients in the startup aware callback, and it will be more deterministic than the best-effort async warmup.
So this PR removes the async warmup completely.

This PR exposes a new method: InternalAvroStoreClient#startWithExceptionThrownWhenFail, and we will use this one in the proprietary layer.

###  Code changes
- [ ] Added new code behind **a config**. If so list the config names and their default values in the PR description.
- [ ] Introduced new **log lines**. 
  - [ ] Confirmed if logs need to be **rate limited** to avoid excessive logging.

###  **Concurrency-Specific Checks**
Both reviewer and PR author to verify
- [ ] Code has **no race conditions** or **thread safety issues**.
- [ ] Proper **synchronization mechanisms** (e.g., `synchronized`, `RWLock`) are used where needed.
- [ ] No **blocking calls** inside critical sections that could lead to deadlocks or performance degradation.
- [ ] Verified **thread-safe collections** are used (e.g., `ConcurrentHashMap`, `CopyOnWriteArrayList`).
- [ ] Validated proper exception handling in multi-threaded code to avoid silent thread termination.


## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->

- [x] New unit tests added.
- [ ] New integration tests added.
- [ ] Modified or extended existing tests.
- [ ] Verified backward compatibility (if applicable).

## Does this PR introduce any user-facing or breaking changes?
<!--  
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Clearly explain the behavior change and its impact.