### PR TITLE
[server][dvc] Replace numeric offsets with PubSubPosition in LeaderProducedRecordContext

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/ActiveActiveStoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/ActiveActiveStoreIngestionTask.java
@@ -569,17 +569,13 @@ public class ActiveActiveStoreIngestionTask extends LeaderFollowerStoreIngestion
       if (updatedValueBytes == null) {
         hostLevelIngestionStats.recordTombstoneCreatedDCR();
         aggVersionedIngestionStats.recordTombStoneCreationDCR(storeName, versionNumber);
-        partitionConsumptionState.setTransientRecord(
-            kafkaClusterId,
-            consumerRecord.getPosition().getNumericOffset(),
-            keyBytes,
-            valueSchemaId,
-            rmdRecord);
+        partitionConsumptionState
+            .setTransientRecord(kafkaClusterId, consumerRecord.getPosition(), keyBytes, valueSchemaId, rmdRecord);
       } else {
         int valueLen = updatedValueBytes.remaining();
         partitionConsumptionState.setTransientRecord(
             kafkaClusterId,
-            consumerRecord.getPosition().getNumericOffset(),
+            consumerRecord.getPosition(),
             keyBytes,
             updatedValueBytes.array(),
             updatedValueBytes.position(),
@@ -870,8 +866,8 @@ public class ActiveActiveStoreIngestionTask extends LeaderFollowerStoreIngestion
                   new DeleteMetadata(valueSchemaId, rmdProtocolVersionId, updatedRmdBytes),
                   oldValueManifest,
                   oldRmdManifest);
-      LeaderProducedRecordContext leaderProducedRecordContext = LeaderProducedRecordContext
-          .newDeleteRecord(kafkaClusterId, consumerRecord.getPosition().getNumericOffset(), key, deletePayload);
+      LeaderProducedRecordContext leaderProducedRecordContext =
+          LeaderProducedRecordContext.newDeleteRecord(kafkaClusterId, consumerRecord.getPosition(), key, deletePayload);
       produceToLocalKafka(
           consumerRecord,
           partitionConsumptionState,
@@ -901,8 +897,7 @@ public class ActiveActiveStoreIngestionTask extends LeaderFollowerStoreIngestion
       produceToLocalKafka(
           consumerRecord,
           partitionConsumptionState,
-          LeaderProducedRecordContext
-              .newPutRecord(kafkaClusterId, consumerRecord.getPosition().getNumericOffset(), key, updatedPut),
+          LeaderProducedRecordContext.newPutRecord(kafkaClusterId, consumerRecord.getPosition(), key, updatedPut),
           produceToTopicFunction,
           partition,
           kafkaUrl,

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderProducedRecordContext.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderProducedRecordContext.java
@@ -62,7 +62,7 @@ public class LeaderProducedRecordContext implements Measurable {
   /**
    * This is the position at which the message was produced in the Version Topic.
    */
-  private PubSubPosition producedPosition = PubSubSymbolicPosition.LATEST;
+  private PubSubPosition producedPosition = NO_UPSTREAM_POSITION;
 
   /**
    * This is the timestamp at which the message was produced in the Version Topic as

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderProducedRecordContext.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderProducedRecordContext.java
@@ -5,12 +5,15 @@ import static com.linkedin.venice.kafka.protocol.enums.MessageType.DELETE;
 import static com.linkedin.venice.kafka.protocol.enums.MessageType.PUT;
 import static com.linkedin.venice.memory.ClassSizeEstimator.getClassOverhead;
 import static com.linkedin.venice.memory.InstanceSizeEstimator.getSize;
+import static com.linkedin.venice.pubsub.api.PubSubSymbolicPosition.EARLIEST;
 
 import com.linkedin.venice.kafka.protocol.ControlMessage;
 import com.linkedin.venice.kafka.protocol.Delete;
 import com.linkedin.venice.kafka.protocol.Put;
 import com.linkedin.venice.kafka.protocol.enums.MessageType;
 import com.linkedin.venice.memory.Measurable;
+import com.linkedin.venice.pubsub.api.PubSubPosition;
+import com.linkedin.venice.pubsub.api.PubSubSymbolicPosition;
 import java.util.concurrent.CompletableFuture;
 
 
@@ -18,8 +21,8 @@ import java.util.concurrent.CompletableFuture;
  * This class holds all the necessary context information which is passed from
  * kafka consumer thread -> kafka producer callback thread -> drainer thread.
  *
- * All constructors are private by intention. This object should be created through the static utility function based on usecase.
- * Internally these utility function fills up the consumedOffset, messageType, keyBytes, valueUnion.
+ * All constructors are private by intention. This object should be created through the static utility function based on use case.
+ * Internally these utility function fills up the consumedPosition, messageType, keyBytes, valueUnion.
  *
  * consumer thread and drainer thread creates this object by calling the appropriate static utility function based on message type.
  *
@@ -27,20 +30,21 @@ import java.util.concurrent.CompletableFuture;
  *
  * drainer thread completes the persistedToDBFuture.
  */
-
 public class LeaderProducedRecordContext implements Measurable {
   private static final int PARTIAL_CLASS_OVERHEAD =
       getClassOverhead(LeaderProducedRecordContext.class) + getClassOverhead(CompletableFuture.class);
   private static final int NO_UPSTREAM = -1;
+  protected static final PubSubPosition NO_UPSTREAM_POSITION = EARLIEST;
+
   /**
    * Kafka cluster ID where the source kafka consumer record was consumed from.
    */
   private final int consumedKafkaClusterId;
   /**
-   * This is the offset of the source kafka consumer record from upstream kafka
+   * This is the offset of the source PubSub consumer record from upstream PubSub
    * topic ( which could be either Real-Time or Stream-Reprocessing topic or remote VT topic).
    */
-  private final long consumedOffset;
+  private final PubSubPosition consumedPosition;
 
   /**
    * Type of message should be only PUT/DELETE/CONTROL_MESSAGE and never be UPDATE.
@@ -56,9 +60,9 @@ public class LeaderProducedRecordContext implements Measurable {
   private final Object valueUnion;
 
   /**
-   * This is the offset at which the message was produced in the Version Topic.
+   * This is the position at which the message was produced in the Version Topic.
    */
-  private long producedOffset = -1;
+  private PubSubPosition producedPosition = PubSubSymbolicPosition.LATEST;
 
   /**
    * This is the timestamp at which the message was produced in the Version Topic as
@@ -79,7 +83,7 @@ public class LeaderProducedRecordContext implements Measurable {
 
   public static LeaderProducedRecordContext newControlMessageRecord(
       int consumedKafkaClusterId,
-      long consumedOffset,
+      PubSubPosition consumedOffset,
       byte[] keyBytes,
       ControlMessage valueUnion) {
     checkConsumedOffsetParam(consumedOffset);
@@ -92,12 +96,12 @@ public class LeaderProducedRecordContext implements Measurable {
   }
 
   public static LeaderProducedRecordContext newControlMessageRecord(byte[] keyBytes, ControlMessage valueUnion) {
-    return new LeaderProducedRecordContext(NO_UPSTREAM, NO_UPSTREAM, CONTROL_MESSAGE, keyBytes, valueUnion);
+    return new LeaderProducedRecordContext(NO_UPSTREAM, NO_UPSTREAM_POSITION, CONTROL_MESSAGE, keyBytes, valueUnion);
   }
 
   public static LeaderProducedRecordContext newPutRecord(
       int consumedKafkaClusterId,
-      long consumedOffset,
+      PubSubPosition consumedOffset,
       byte[] keyBytes,
       Put valueUnion) {
     checkConsumedOffsetParam(consumedOffset);
@@ -105,16 +109,16 @@ public class LeaderProducedRecordContext implements Measurable {
   }
 
   public static LeaderProducedRecordContext newChunkPutRecord(byte[] keyBytes, Put valueUnion) {
-    return new LeaderProducedRecordContext(NO_UPSTREAM, NO_UPSTREAM, PUT, keyBytes, valueUnion);
+    return new LeaderProducedRecordContext(NO_UPSTREAM, NO_UPSTREAM_POSITION, PUT, keyBytes, valueUnion);
   }
 
   public static LeaderProducedRecordContext newChunkDeleteRecord(byte[] keyBytes, Delete valueUnion) {
-    return new LeaderProducedRecordContext(NO_UPSTREAM, NO_UPSTREAM, DELETE, keyBytes, valueUnion);
+    return new LeaderProducedRecordContext(NO_UPSTREAM, NO_UPSTREAM_POSITION, DELETE, keyBytes, valueUnion);
   }
 
   public static LeaderProducedRecordContext newPutRecordWithFuture(
       int consumedKafkaClusterId,
-      long consumedOffset,
+      PubSubPosition consumedOffset,
       byte[] keyBytes,
       Put valueUnion,
       CompletableFuture<Void> persistedToDBFuture) {
@@ -130,7 +134,7 @@ public class LeaderProducedRecordContext implements Measurable {
 
   public static LeaderProducedRecordContext newDeleteRecord(
       int consumedKafkaClusterId,
-      long consumedOffset,
+      PubSubPosition consumedOffset,
       byte[] keyBytes,
       Delete valueUnion) {
     checkConsumedOffsetParam(consumedOffset);
@@ -139,22 +143,22 @@ public class LeaderProducedRecordContext implements Measurable {
 
   private LeaderProducedRecordContext(
       int consumedKafkaClusterId,
-      long consumedOffset,
+      PubSubPosition consumedPosition,
       MessageType messageType,
       byte[] keyBytes,
       Object valueUnion) {
-    this(consumedKafkaClusterId, consumedOffset, messageType, keyBytes, valueUnion, new CompletableFuture());
+    this(consumedKafkaClusterId, consumedPosition, messageType, keyBytes, valueUnion, new CompletableFuture());
   }
 
   private LeaderProducedRecordContext(
       int consumedKafkaClusterId,
-      long consumedOffset,
+      PubSubPosition consumedPosition,
       MessageType messageType,
       byte[] keyBytes,
       Object valueUnion,
       CompletableFuture persistedToDBFuture) {
     this.consumedKafkaClusterId = consumedKafkaClusterId;
-    this.consumedOffset = consumedOffset;
+    this.consumedPosition = consumedPosition;
     this.messageType = messageType;
     this.keyBytes = keyBytes;
     this.valueUnion = valueUnion;
@@ -165,16 +169,16 @@ public class LeaderProducedRecordContext implements Measurable {
     this.keyBytes = keyBytes;
   }
 
-  public void setProducedOffset(long producerOffset) {
-    this.producedOffset = producerOffset;
+  public void setProducedPosition(PubSubPosition producedPosition) {
+    this.producedPosition = producedPosition;
   }
 
   public int getConsumedKafkaClusterId() {
     return consumedKafkaClusterId;
   }
 
-  public long getConsumedOffset() {
-    return consumedOffset;
+  public PubSubPosition getConsumedPosition() {
+    return consumedPosition;
   }
 
   public MessageType getMessageType() {
@@ -189,8 +193,8 @@ public class LeaderProducedRecordContext implements Measurable {
     return valueUnion;
   }
 
-  public long getProducedOffset() {
-    return producedOffset;
+  public PubSubPosition getProducedPosition() {
+    return producedPosition;
   }
 
   public void setProducedTimestampMs(long timeMs) {
@@ -219,8 +223,8 @@ public class LeaderProducedRecordContext implements Measurable {
 
   @Override
   public String toString() {
-    return "{ consumedOffset: " + consumedOffset + ", messageType: " + messageType + ", producedOffset: "
-        + producedOffset + " }";
+    return "{ consumedOffset: " + consumedPosition + ", messageType: " + messageType + ", producedOffset: "
+        + producedPosition + " }";
   }
 
   /**
@@ -232,12 +236,12 @@ public class LeaderProducedRecordContext implements Measurable {
    *         false if the message does not (e.g. happens in cases of leader-generated chunks or TopicSwitch)
    */
   public boolean hasCorrespondingUpstreamMessage() {
-    return consumedOffset != NO_UPSTREAM;
+    return consumedPosition != NO_UPSTREAM_POSITION;
   }
 
-  private static void checkConsumedOffsetParam(long consumedOffset) {
-    if (consumedOffset < 0) {
-      throw new IllegalArgumentException("consumedOffset cannot be negative");
+  private static void checkConsumedOffsetParam(PubSubPosition consumedOffset) {
+    if (consumedOffset == null || consumedOffset == EARLIEST || consumedOffset == PubSubSymbolicPosition.LATEST) {
+      throw new IllegalArgumentException("consumedOffset cannot be null or symbolic");
     }
   }
 

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
@@ -8,11 +8,10 @@ import static com.linkedin.davinci.kafka.consumer.ConsumerActionType.SUBSCRIBE;
 import static com.linkedin.davinci.kafka.consumer.ConsumerActionType.UNSUBSCRIBE;
 import static com.linkedin.davinci.kafka.consumer.LeaderFollowerStateType.LEADER;
 import static com.linkedin.davinci.kafka.consumer.LeaderFollowerStateType.STANDBY;
+import static com.linkedin.davinci.kafka.consumer.LeaderProducedRecordContext.NO_UPSTREAM_POSITION;
 import static com.linkedin.davinci.validation.DataIntegrityValidator.DISABLED;
 import static com.linkedin.venice.ConfigKeys.KAFKA_BOOTSTRAP_SERVERS;
 import static com.linkedin.venice.LogMessages.KILLED_JOB_MESSAGE;
-import static com.linkedin.venice.kafka.protocol.enums.ControlMessageType.END_OF_PUSH;
-import static com.linkedin.venice.kafka.protocol.enums.ControlMessageType.START_OF_PUSH;
 import static com.linkedin.venice.kafka.protocol.enums.ControlMessageType.START_OF_SEGMENT;
 import static com.linkedin.venice.pubsub.PubSubConstants.UNKNOWN_LATEST_OFFSET;
 import static com.linkedin.venice.utils.Utils.FATAL_DATA_VALIDATION_ERROR;
@@ -4037,10 +4036,11 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
     // except
     // as needed in integration test.
     if (purgeTransientRecordBuffer && isTransientRecordBufferUsed(partitionConsumptionState)
-        && leaderProducedRecordContext != null && leaderProducedRecordContext.getConsumedOffset() != -1) {
+        && leaderProducedRecordContext != null
+        && leaderProducedRecordContext.getConsumedPosition() != NO_UPSTREAM_POSITION) {
       partitionConsumptionState.mayRemoveTransientRecord(
           leaderProducedRecordContext.getConsumedKafkaClusterId(),
-          leaderProducedRecordContext.getConsumedOffset(),
+          leaderProducedRecordContext.getConsumedPosition(),
           kafkaKey.getKey());
     }
 

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/ActiveActiveStoreIngestionTaskTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/ActiveActiveStoreIngestionTaskTest.java
@@ -392,10 +392,11 @@ public class ActiveActiveStoreIngestionTaskTest {
     updatedPut.replicationMetadataVersionId = rmdProtocolVersionID;
     updatedPut.replicationMetadataPayload = updatedRmdBytes;
     LeaderProducedRecordContext leaderProducedRecordContext = LeaderProducedRecordContext
-        .newPutRecord(kafkaClusterId, consumerRecord.getPosition().getNumericOffset(), updatedKeyBytes, updatedPut);
+        .newPutRecord(kafkaClusterId, consumerRecord.getPosition(), updatedKeyBytes, updatedPut);
 
+    PubSubPosition consumedPositionMock = mock(PubSubPosition.class);
     PartitionConsumptionState.TransientRecord transientRecord =
-        new PartitionConsumptionState.TransientRecord(new byte[] { 0xa }, 0, 0, 0, 0, 0);
+        new PartitionConsumptionState.TransientRecord(new byte[] { 0xa }, 0, 0, 0, 0, consumedPositionMock);
 
     PartitionConsumptionState partitionConsumptionState = mock(PartitionConsumptionState.class);
     when(partitionConsumptionState.getTransientRecord(any())).thenReturn(transientRecord);

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTaskTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTaskTest.java
@@ -482,10 +482,11 @@ public class LeaderFollowerStoreIngestionTaskTest {
     DefaultPubSubMessage mockMessage = mock(DefaultPubSubMessage.class);
     PubSubTopicPartition mockTopicPartition = mock(PubSubTopicPartition.class);
     LeaderProducedRecordContext context = mock(LeaderProducedRecordContext.class);
-    PubSubPosition position = mock(PubSubPosition.class);
+    PubSubPosition positionMock = mock(PubSubPosition.class);
+    doReturn(positionMock).when(context).getConsumedPosition();
     doReturn(partition).when(mockTopicPartition).getPartitionNumber();
-    doReturn(offset).when(position).getNumericOffset();
-    doReturn(position).when(mockMessage).getPosition();
+    doReturn(offset).when(positionMock).getNumericOffset();
+    doReturn(positionMock).when(mockMessage).getPosition();
     doReturn(mockTopicPartition).when(mockMessage).getTopicPartition();
     doReturn(messageTime).when(mockMessage).getPubSubMessageTime();
     VeniceWriter mockWriter = mock(VeniceWriter.class);

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/ProducedRecordTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/ProducedRecordTest.java
@@ -1,7 +1,10 @@
 package com.linkedin.davinci.kafka.consumer;
 
+import static org.mockito.Mockito.mock;
+
 import com.linkedin.venice.exceptions.VeniceMessageException;
 import com.linkedin.venice.kafka.protocol.Put;
+import com.linkedin.venice.pubsub.api.PubSubPosition;
 import java.nio.ByteBuffer;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
@@ -19,7 +22,8 @@ public class ProducedRecordTest {
     put1.putValue = ByteBuffer.wrap(value1);
     put1.schemaId = 5;
 
-    LeaderProducedRecordContext pr1 = LeaderProducedRecordContext.newPutRecord(-1, 1, key1, put1);
+    PubSubPosition consumedPositionMock = mock(PubSubPosition.class);
+    LeaderProducedRecordContext pr1 = LeaderProducedRecordContext.newPutRecord(-1, consumedPositionMock, key1, put1);
     CompletableFuture.runAsync(() -> pr1.completePersistedToDBFuture(null));
     pr1.getPersistedToDBFuture().get(10, TimeUnit.SECONDS);
   }
@@ -33,7 +37,8 @@ public class ProducedRecordTest {
     put1.putValue = ByteBuffer.wrap(value1);
     put1.schemaId = 5;
 
-    LeaderProducedRecordContext pr1 = LeaderProducedRecordContext.newPutRecord(-1, 1, key1, put1);
+    PubSubPosition consumedPositionMock = mock(PubSubPosition.class);
+    LeaderProducedRecordContext pr1 = LeaderProducedRecordContext.newPutRecord(-1, consumedPositionMock, key1, put1);
     CompletableFuture.runAsync(() -> pr1.completePersistedToDBFuture(new VeniceMessageException("test exception")));
 
     try {

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/StoreBufferServiceTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/StoreBufferServiceTest.java
@@ -52,11 +52,11 @@ public class StoreBufferServiceTest {
   private final KafkaMessageEnvelope value =
       new KafkaMessageEnvelope(MessageType.PUT.getValue(), new ProducerMetadata(), put, null);
   private final LeaderProducedRecordContext leaderContext =
-      LeaderProducedRecordContext.newPutRecord(0, 0, key.getKey(), put);
+      LeaderProducedRecordContext.newPutRecord(0, mock(PubSubPosition.class), key.getKey(), put);
   private static final int TIMEOUT_IN_MS = 1000;
   private final MetricsRepository mockMetricRepo = mock(MetricsRepository.class);
   private StoreBufferServiceStats mockedStats;
-  PubSubPosition mockPosition;
+  private PubSubPosition mockPosition;
 
   @BeforeMethod
   public void setUp() {

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTaskTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTaskTest.java
@@ -4132,8 +4132,8 @@ public abstract class StoreIngestionTaskTest {
 
     final int batchMessagesNum = 100;
     final List<Long> resubscriptionOffsetForLocalVT = Arrays.asList(30L, 70L);
-    final List<Long> resubscriptionOffsetForLocalRT = Arrays.asList(40L);
-    final List<Long> resubscriptionOffsetForRemoteRT = Arrays.asList(50L);
+    final List<Long> resubscriptionOffsetForLocalRT = Collections.singletonList(40L);
+    final List<Long> resubscriptionOffsetForRemoteRT = Collections.singletonList(50L);
 
     // Prepare resubscription number to be verified after ingestion.
     int totalResubscriptionTriggered = resubscriptionOffsetForLocalVT.size() + resubscriptionOffsetForLocalRT.size()
@@ -4965,6 +4965,7 @@ public abstract class StoreIngestionTaskTest {
     when(leaderProducedRecordContext.getMessageType()).thenReturn(MessageType.PUT);
     when(leaderProducedRecordContext.getValueUnion()).thenReturn(put);
     when(leaderProducedRecordContext.getKeyBytes()).thenReturn(putKeyFoo);
+    when(leaderProducedRecordContext.getConsumedPosition()).thenReturn(mockedPubSubPosition);
 
     Schema myKeySchema = Schema.create(Schema.Type.INT);
     SchemaEntry keySchemaEntry = mock(SchemaEntry.class);

--- a/clients/venice-push-job/src/test/java/com/linkedin/venice/hadoop/mapreduce/datawriter/reduce/TestVeniceReducer.java
+++ b/clients/venice-push-job/src/test/java/com/linkedin/venice/hadoop/mapreduce/datawriter/reduce/TestVeniceReducer.java
@@ -42,6 +42,7 @@ import com.linkedin.venice.meta.ViewConfig;
 import com.linkedin.venice.meta.ViewConfigImpl;
 import com.linkedin.venice.partitioner.DefaultVenicePartitioner;
 import com.linkedin.venice.pubsub.adapter.SimplePubSubProduceResultImpl;
+import com.linkedin.venice.pubsub.api.PubSubPosition;
 import com.linkedin.venice.pubsub.api.PubSubProduceResult;
 import com.linkedin.venice.pubsub.api.PubSubProducerCallback;
 import com.linkedin.venice.serialization.avro.VeniceAvroKafkaSerializer;
@@ -391,11 +392,15 @@ public class TestVeniceReducer extends AbstractTestVeniceMR {
     reducer.configure(setupJobConf(100));
 
     reducer.reduce(keyWritable1, values1.iterator(), mockCollector, mockReporter);
-    PubSubProduceResult produceResult1 = new SimplePubSubProduceResultImpl("topic-name", TASK_ID, 1, 1);
+    PubSubPosition pubSubPosition1Mock = mock(PubSubPosition.class);
+    PubSubProduceResult produceResult1 =
+        new SimplePubSubProduceResultImpl("topic-name", TASK_ID, pubSubPosition1Mock, 1);
     reducer.getCallback().onCompletion(produceResult1, null);
 
     reducer.reduce(keyWritable2, values2.iterator(), mockCollector, mockReporter);
-    PubSubProduceResult produceResult2 = new SimplePubSubProduceResultImpl("topic-name", TASK_ID, 2, 1);
+    PubSubPosition pubSubPosition2Mock = mock(PubSubPosition.class);
+    PubSubProduceResult produceResult2 =
+        new SimplePubSubProduceResultImpl("topic-name", TASK_ID, pubSubPosition2Mock, 1);
     reducer.getCallback().onCompletion(produceResult2, null);
 
     reducer.close();

--- a/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/adapter/SimplePubSubProduceResultImpl.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/adapter/SimplePubSubProduceResultImpl.java
@@ -2,6 +2,7 @@ package com.linkedin.venice.pubsub.adapter;
 
 import com.linkedin.venice.pubsub.api.PubSubPosition;
 import com.linkedin.venice.pubsub.api.PubSubProduceResult;
+import com.linkedin.venice.utils.Utils;
 
 
 /**
@@ -10,30 +11,19 @@ import com.linkedin.venice.pubsub.api.PubSubProduceResult;
 public class SimplePubSubProduceResultImpl implements PubSubProduceResult {
   private final String topic;
   private final int partition;
-  private final long offset;
   private final PubSubPosition pubSubPosition;
   private final int serializedSize;
 
-  public SimplePubSubProduceResultImpl(String topic, int partition, long offset, int serializedSize) {
-    this(topic, partition, offset, null, serializedSize);
-  }
-
-  public SimplePubSubProduceResultImpl(
-      String topic,
-      int partition,
-      long offset,
-      PubSubPosition pubSubPosition,
-      int serializedSize) {
+  public SimplePubSubProduceResultImpl(String topic, int partition, PubSubPosition pubSubPosition, int serializedSize) {
     this.topic = topic;
     this.partition = partition;
-    this.offset = offset;
     this.pubSubPosition = pubSubPosition;
     this.serializedSize = serializedSize;
   }
 
   @Override
   public long getOffset() {
-    return offset;
+    return pubSubPosition.getNumericOffset();
   }
 
   @Override
@@ -58,7 +48,7 @@ public class SimplePubSubProduceResultImpl implements PubSubProduceResult {
 
   @Override
   public String toString() {
-    return "[Topic: " + topic + ", " + "Partition: " + partition + ", " + "Offset: " + offset + ", "
-        + "PubSubPosition: " + pubSubPosition + ", " + "SerializedSize: " + serializedSize + "]";
+    return "[TP: " + Utils.getReplicaId(topic, partition) + ", pubSubPosition: " + pubSubPosition + ", serializedSize: "
+        + serializedSize + "]";
   }
 }

--- a/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/adapter/kafka/producer/ApacheKafkaProduceResult.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/adapter/kafka/producer/ApacheKafkaProduceResult.java
@@ -14,7 +14,6 @@ public class ApacheKafkaProduceResult extends SimplePubSubProduceResultImpl {
     super(
         recordMetadata.topic(),
         recordMetadata.partition(),
-        recordMetadata.offset(),
         new ApacheKafkaOffsetPosition(recordMetadata.offset()),
         recordMetadata.serializedKeySize() + recordMetadata.serializedValueSize());
   }

--- a/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/api/PubSubProduceResult.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/api/PubSubProduceResult.java
@@ -1,8 +1,5 @@
 package com.linkedin.venice.pubsub.api;
 
-import com.linkedin.venice.annotation.UnderDevelopment;
-
-
 /**
  * An interface implemented by specific PubSubProducerAdapters to return the result of a produce action.
  */
@@ -15,7 +12,6 @@ public interface PubSubProduceResult {
   /**
    * The position of the record in the topic/partition.
    */
-  @UnderDevelopment
   PubSubPosition getPubSubPosition();
 
   /**

--- a/internal/venice-common/src/test/java/com/linkedin/venice/memory/InstanceSizeEstimatorTest.java
+++ b/internal/venice-common/src/test/java/com/linkedin/venice/memory/InstanceSizeEstimatorTest.java
@@ -1,6 +1,7 @@
 package com.linkedin.venice.memory;
 
 import static com.linkedin.venice.kafka.protocol.enums.MessageType.PUT;
+import static org.mockito.Mockito.mock;
 
 import com.linkedin.davinci.kafka.consumer.LeaderProducedRecordContext;
 import com.linkedin.davinci.kafka.consumer.SBSQueueNodeFactory;
@@ -15,6 +16,7 @@ import com.linkedin.venice.pubsub.PubSubTopicPartitionImpl;
 import com.linkedin.venice.pubsub.PubSubTopicRepository;
 import com.linkedin.venice.pubsub.adapter.kafka.common.ApacheKafkaOffsetPosition;
 import com.linkedin.venice.pubsub.api.DefaultPubSubMessage;
+import com.linkedin.venice.pubsub.api.PubSubPosition;
 import com.linkedin.venice.pubsub.api.PubSubTopicPartition;
 import com.linkedin.venice.writer.VeniceWriter;
 import java.nio.ByteBuffer;
@@ -119,9 +121,10 @@ public class InstanceSizeEstimatorTest extends HeapSizeEstimatorTest {
       }
     }
 
+    PubSubPosition consumedPositionMock = mock(PubSubPosition.class);
     int kafkaClusterId = 0;
-    Supplier<LeaderProducedRecordContext> leaderProducedRecordContextSupplierForPut =
-        () -> LeaderProducedRecordContext.newPutRecord(kafkaClusterId, 0, new byte[10], vtPutSupplier.get());
+    Supplier<LeaderProducedRecordContext> leaderProducedRecordContextSupplierForPut = () -> LeaderProducedRecordContext
+        .newPutRecord(kafkaClusterId, consumedPositionMock, new byte[10], vtPutSupplier.get());
     List<Supplier<LeaderProducedRecordContext>> leaderProducedRecordContextSuppliers = new ArrayList<>();
     leaderProducedRecordContextSuppliers.add(leaderProducedRecordContextSupplierForPut);
 

--- a/internal/venice-common/src/test/java/com/linkedin/venice/pubsub/adapter/SimplePubSubProduceResultImplTest.java
+++ b/internal/venice-common/src/test/java/com/linkedin/venice/pubsub/adapter/SimplePubSubProduceResultImplTest.java
@@ -1,62 +1,38 @@
 package com.linkedin.venice.pubsub.adapter;
 
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertNull;
 
 import com.linkedin.venice.pubsub.api.PubSubPosition;
-import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 
 public class SimplePubSubProduceResultImplTest {
   private static final String TEST_TOPIC = "test-topic";
   private static final int TEST_PARTITION = 1;
-  private static final long TEST_OFFSET = 100L;
+  private static final PubSubPosition PUBSUB_POSITION = mock(PubSubPosition.class);
   private static final int TEST_SERIALIZED_SIZE = 256;
-
-  private PubSubPosition mockPubSubPosition;
-
-  @BeforeMethod
-  public void setUp() {
-    mockPubSubPosition = mock(PubSubPosition.class);
-  }
-
-  @Test
-  public void testConstructorWithoutPubSubPosition() {
-    SimplePubSubProduceResultImpl result =
-        new SimplePubSubProduceResultImpl(TEST_TOPIC, TEST_PARTITION, TEST_OFFSET, TEST_SERIALIZED_SIZE);
-
-    assertEquals(result.getTopic(), TEST_TOPIC);
-    assertEquals(result.getPartition(), TEST_PARTITION);
-    assertEquals(result.getOffset(), TEST_OFFSET);
-    assertEquals(result.getSerializedSize(), TEST_SERIALIZED_SIZE);
-    assertNull(result.getPubSubPosition());
-  }
 
   @Test
   public void testConstructorWithPubSubPosition() {
-    SimplePubSubProduceResultImpl result = new SimplePubSubProduceResultImpl(
-        TEST_TOPIC,
-        TEST_PARTITION,
-        TEST_OFFSET,
-        mockPubSubPosition,
-        TEST_SERIALIZED_SIZE);
+    SimplePubSubProduceResultImpl result =
+        new SimplePubSubProduceResultImpl(TEST_TOPIC, TEST_PARTITION, PUBSUB_POSITION, TEST_SERIALIZED_SIZE);
 
     assertEquals(result.getTopic(), TEST_TOPIC);
     assertEquals(result.getPartition(), TEST_PARTITION);
-    assertEquals(result.getOffset(), TEST_OFFSET);
+    assertEquals(result.getPubSubPosition(), PUBSUB_POSITION);
     assertEquals(result.getSerializedSize(), TEST_SERIALIZED_SIZE);
-    assertEquals(result.getPubSubPosition(), mockPubSubPosition);
+    assertEquals(result.getPubSubPosition(), PUBSUB_POSITION);
   }
 
   @Test
   public void testToString() {
+    when(PUBSUB_POSITION.toString()).thenReturn("123");
     SimplePubSubProduceResultImpl result =
-        new SimplePubSubProduceResultImpl(TEST_TOPIC, TEST_PARTITION, TEST_OFFSET, TEST_SERIALIZED_SIZE);
+        new SimplePubSubProduceResultImpl(TEST_TOPIC, TEST_PARTITION, PUBSUB_POSITION, TEST_SERIALIZED_SIZE);
 
-    String expectedString = "[Topic: " + TEST_TOPIC + ", Partition: " + TEST_PARTITION + ", Offset: " + TEST_OFFSET
-        + ", PubSubPosition: null, SerializedSize: " + TEST_SERIALIZED_SIZE + "]";
+    String expectedString = "[TP: test-topic-1, pubSubPosition: 123, serializedSize: 256]";
     assertEquals(result.toString(), expectedString);
   }
 }

--- a/internal/venice-common/src/test/java/com/linkedin/venice/writer/VeniceWriterUnitTest.java
+++ b/internal/venice-common/src/test/java/com/linkedin/venice/writer/VeniceWriterUnitTest.java
@@ -45,6 +45,7 @@ import com.linkedin.venice.partitioner.DefaultVenicePartitioner;
 import com.linkedin.venice.pubsub.api.DefaultPubSubMessage;
 import com.linkedin.venice.pubsub.api.PubSubMessageHeader;
 import com.linkedin.venice.pubsub.api.PubSubMessageHeaders;
+import com.linkedin.venice.pubsub.api.PubSubPosition;
 import com.linkedin.venice.pubsub.api.PubSubProducerAdapter;
 import com.linkedin.venice.pubsub.api.PubSubTopic;
 import com.linkedin.venice.pubsub.api.PubSubTopicPartition;
@@ -205,8 +206,9 @@ public class VeniceWriterUnitTest {
     String valueString = stringBuilder.toString();
 
     LeaderProducerCallback leaderProducerCallback = mock(LeaderProducerCallback.class);
+    PubSubPosition consumedPositionMock = mock(PubSubPosition.class);
     PartitionConsumptionState.TransientRecord transientRecord =
-        new PartitionConsumptionState.TransientRecord(new byte[] { 0xa }, 0, 0, 0, 0, 0);
+        new PartitionConsumptionState.TransientRecord(new byte[] { 0xa }, 0, 0, 0, 0, consumedPositionMock);
     PartitionConsumptionState partitionConsumptionState = mock(PartitionConsumptionState.class);
     when(leaderProducerCallback.getPartitionConsumptionState()).thenReturn(partitionConsumptionState);
     when(partitionConsumptionState.getTransientRecord(any())).thenReturn(transientRecord);

--- a/internal/venice-test-common/src/main/java/com/linkedin/venice/unit/kafka/InMemoryKafkaBroker.java
+++ b/internal/venice-test-common/src/main/java/com/linkedin/venice/unit/kafka/InMemoryKafkaBroker.java
@@ -42,7 +42,7 @@ public class InMemoryKafkaBroker {
    * @return the offset of the produced message
    * @throws IllegalArgumentException if the topic or partition does not exist.
    */
-  public long produce(String topicName, int partition, InMemoryKafkaMessage message) {
+  public InMemoryPubSubPosition produce(String topicName, int partition, InMemoryKafkaMessage message) {
     InMemoryKafkaTopic topic = getTopic(topicName);
     return topic.produce(partition, message);
   }

--- a/internal/venice-test-common/src/main/java/com/linkedin/venice/unit/kafka/InMemoryKafkaTopic.java
+++ b/internal/venice-test-common/src/main/java/com/linkedin/venice/unit/kafka/InMemoryKafkaTopic.java
@@ -29,10 +29,11 @@ class InMemoryKafkaTopic {
    * @return the offset of the produced message
    * @throws IllegalArgumentException if the partition does not exist
    */
-  synchronized long produce(int partition, InMemoryKafkaMessage message) throws IllegalArgumentException {
+  synchronized InMemoryPubSubPosition produce(int partition, InMemoryKafkaMessage message)
+      throws IllegalArgumentException {
     checkPartitionCount(partition);
     ArrayList<InMemoryKafkaMessage> partitionQueue = partitions[partition];
-    long nextOffset = partitionQueue.size();
+    InMemoryPubSubPosition nextOffset = new InMemoryPubSubPosition(partitionQueue.size());
     partitionQueue.add(message);
     return nextOffset;
   }

--- a/internal/venice-test-common/src/main/java/com/linkedin/venice/unit/kafka/InMemoryPubSubPosition.java
+++ b/internal/venice-test-common/src/main/java/com/linkedin/venice/unit/kafka/InMemoryPubSubPosition.java
@@ -1,0 +1,48 @@
+package com.linkedin.venice.unit.kafka;
+
+import com.linkedin.venice.pubsub.api.PubSubPosition;
+import com.linkedin.venice.pubsub.api.PubSubPositionWireFormat;
+
+
+public class InMemoryPubSubPosition implements PubSubPosition {
+  private final long internalOffset;
+
+  public InMemoryPubSubPosition(long offset) {
+    this.internalOffset = offset;
+  }
+
+  @Override
+  public int comparePosition(PubSubPosition other) {
+    if (!(other instanceof InMemoryPubSubPosition)) {
+      throw new IllegalArgumentException(
+          "InMemoryPubSubPosition can only be compared with another InMemoryPubSubPosition");
+    }
+    InMemoryPubSubPosition otherPosition = (InMemoryPubSubPosition) other;
+    return Long.compare(this.internalOffset, otherPosition.internalOffset);
+  }
+
+  @Override
+  public long diff(PubSubPosition other) {
+    if (!(other instanceof InMemoryPubSubPosition)) {
+      throw new IllegalArgumentException(
+          "InMemoryPubSubPosition can only be compared with another InMemoryPubSubPosition");
+    }
+    InMemoryPubSubPosition otherPosition = (InMemoryPubSubPosition) other;
+    return this.internalOffset - otherPosition.internalOffset;
+  }
+
+  @Override
+  public long getNumericOffset() {
+    return internalOffset;
+  }
+
+  @Override
+  public PubSubPositionWireFormat getPositionWireFormat() {
+    throw new UnsupportedOperationException("getPositionWireFormat is not supported in InMemoryPubSubPosition");
+  }
+
+  @Override
+  public int getHeapSize() {
+    return 0;
+  }
+}

--- a/internal/venice-test-common/src/main/java/com/linkedin/venice/unit/kafka/consumer/poll/DuplicatingPollStrategy.java
+++ b/internal/venice-test-common/src/main/java/com/linkedin/venice/unit/kafka/consumer/poll/DuplicatingPollStrategy.java
@@ -33,19 +33,18 @@ public class DuplicatingPollStrategy extends AbstractPollStrategy {
       return null;
     }
 
-    PubSubTopicPartition PubSubTopicPartition = nextPoll.getPubSubTopicPartition();
+    PubSubTopicPartition topicPartition = nextPoll.getPubSubTopicPartition();
     long offset = nextPoll.getOffset();
-    offset += getAmountOfDupes(PubSubTopicPartition);
+    offset += getAmountOfDupes(topicPartition);
 
-    PubSubTopicPartitionOffset nextPollWithAdjustedOffset =
-        new PubSubTopicPartitionOffset(PubSubTopicPartition, offset);
+    PubSubTopicPartitionOffset nextPollWithAdjustedOffset = new PubSubTopicPartitionOffset(topicPartition, offset);
 
     if (PubSubTopicPartitionOffsetsToDuplicate.contains(nextPoll)) {
-      if (!amountOfIntroducedDupes.containsKey(PubSubTopicPartition)) {
-        amountOfIntroducedDupes.put(PubSubTopicPartition, 0L);
+      if (!amountOfIntroducedDupes.containsKey(topicPartition)) {
+        amountOfIntroducedDupes.put(topicPartition, 0L);
       }
-      long previousAmountOfDupes = getAmountOfDupes(PubSubTopicPartition);
-      amountOfIntroducedDupes.put(PubSubTopicPartition, previousAmountOfDupes + 1);
+      long previousAmountOfDupes = getAmountOfDupes(topicPartition);
+      amountOfIntroducedDupes.put(topicPartition, previousAmountOfDupes + 1);
       PubSubTopicPartitionOffsetsToDuplicate.remove(nextPoll);
     }
 

--- a/internal/venice-test-common/src/main/java/com/linkedin/venice/unit/kafka/producer/MockInMemoryProducerAdapter.java
+++ b/internal/venice-test-common/src/main/java/com/linkedin/venice/unit/kafka/producer/MockInMemoryProducerAdapter.java
@@ -9,6 +9,7 @@ import com.linkedin.venice.pubsub.api.PubSubProducerAdapter;
 import com.linkedin.venice.pubsub.api.PubSubProducerCallback;
 import com.linkedin.venice.unit.kafka.InMemoryKafkaBroker;
 import com.linkedin.venice.unit.kafka.InMemoryKafkaMessage;
+import com.linkedin.venice.unit.kafka.InMemoryPubSubPosition;
 import it.unimi.dsi.fastutil.objects.Object2DoubleMap;
 import it.unimi.dsi.fastutil.objects.Object2DoubleMaps;
 import java.util.concurrent.CompletableFuture;
@@ -38,8 +39,9 @@ public class MockInMemoryProducerAdapter implements PubSubProducerAdapter {
       KafkaMessageEnvelope value,
       PubSubMessageHeaders headers,
       PubSubProducerCallback callback) {
-    long offset = broker.produce(topic, partition, new InMemoryKafkaMessage(key, value, headers));
-    PubSubProduceResult produceResult = new SimplePubSubProduceResultImpl(topic, partition, offset, -1);
+    InMemoryPubSubPosition inMemoryPubSubPosition =
+        broker.produce(topic, partition, new InMemoryKafkaMessage(key, value, headers));
+    PubSubProduceResult produceResult = new SimplePubSubProduceResultImpl(topic, partition, inMemoryPubSubPosition, -1);
     if (callback != null) {
       callback.onCompletion(produceResult, null);
     }

--- a/services/venice-controller/src/test/java/com/linkedin/venice/controller/TestVeniceParentHelixAdmin.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/controller/TestVeniceParentHelixAdmin.java
@@ -80,6 +80,7 @@ import com.linkedin.venice.meta.ViewConfigImpl;
 import com.linkedin.venice.meta.ZKStore;
 import com.linkedin.venice.partitioner.InvalidKeySchemaPartitioner;
 import com.linkedin.venice.pubsub.adapter.SimplePubSubProduceResultImpl;
+import com.linkedin.venice.pubsub.api.PubSubPosition;
 import com.linkedin.venice.pubsub.api.PubSubTopic;
 import com.linkedin.venice.pubsub.manager.TopicManager;
 import com.linkedin.venice.pushmonitor.ExecutionStatus;
@@ -299,9 +300,11 @@ public class TestVeniceParentHelixAdmin extends AbstractTestVeniceParentHelixAdm
 
   @Test
   public void testAddStore() {
-    doReturn(CompletableFuture.completedFuture(new SimplePubSubProduceResultImpl(topicName, partitionId, 1, -1)))
-        .when(veniceWriter)
-        .put(any(), any(), anyInt());
+    doReturn(
+        CompletableFuture
+            .completedFuture(new SimplePubSubProduceResultImpl(topicName, partitionId, mock(PubSubPosition.class), -1)))
+                .when(veniceWriter)
+                .put(any(), any(), anyInt());
     when(zkClient.readData(zkMetadataNodePath, null)).thenReturn(null)
         .thenReturn(
             AdminTopicMetadataAccessor.generateMetadataMap(
@@ -394,7 +397,9 @@ public class TestVeniceParentHelixAdmin extends AbstractTestVeniceParentHelixAdm
       when(veniceWriter.put(any(), any(), anyInt())).then(invocation -> {
         // Once we send message to topic through venice writer, return offset 1
         CompletableFuture future = mock(CompletableFuture.class);
-        doReturn(new SimplePubSubProduceResultImpl(adminTopic, partitionId, 1, -1)).when(future).get();
+        doReturn(new SimplePubSubProduceResultImpl(adminTopic, partitionId, mock(PubSubPosition.class), -1))
+            .when(future)
+            .get();
         return future;
       });
 
@@ -446,9 +451,11 @@ public class TestVeniceParentHelixAdmin extends AbstractTestVeniceParentHelixAdm
     String storeName = "test-store";
     when(internalAdmin.getLastExceptionForStore(clusterName, storeName)).thenReturn(null)
         .thenReturn(new VeniceException("mock exception"));
-    doReturn(CompletableFuture.completedFuture(new SimplePubSubProduceResultImpl(topicName, partitionId, 1, -1)))
-        .when(veniceWriter)
-        .put(any(), any(), anyInt());
+    doReturn(
+        CompletableFuture
+            .completedFuture(new SimplePubSubProduceResultImpl(topicName, partitionId, mock(PubSubPosition.class), -1)))
+                .when(veniceWriter)
+                .put(any(), any(), anyInt());
 
     when(zkClient.readData(zkMetadataNodePath, null)).thenReturn(null)
         .thenReturn(
@@ -475,9 +482,11 @@ public class TestVeniceParentHelixAdmin extends AbstractTestVeniceParentHelixAdm
   public void testSetStorePartitionCount() {
     String storeName = "test-store";
     when(internalAdmin.getLastExceptionForStore(clusterName, storeName)).thenReturn(null);
-    doReturn(CompletableFuture.completedFuture(new SimplePubSubProduceResultImpl(topicName, partitionId, 1, -1)))
-        .when(veniceWriter)
-        .put(any(), any(), anyInt());
+    doReturn(
+        CompletableFuture
+            .completedFuture(new SimplePubSubProduceResultImpl(topicName, partitionId, mock(PubSubPosition.class), -1)))
+                .when(veniceWriter)
+                .put(any(), any(), anyInt());
     when(zkClient.readData(zkMetadataNodePath, null)).thenReturn(
         AdminTopicMetadataAccessor.generateMetadataMap(
             Optional.of(1L),
@@ -514,9 +523,11 @@ public class TestVeniceParentHelixAdmin extends AbstractTestVeniceParentHelixAdm
             DirectionalSchemaCompatibilityType.FULL);
     doReturn(valueSchemaId).when(internalAdmin).getValueSchemaId(clusterName, storeName, valueSchemaStr);
 
-    doReturn(CompletableFuture.completedFuture(new SimplePubSubProduceResultImpl(topicName, partitionId, 1, -1)))
-        .when(veniceWriter)
-        .put(any(), any(), anyInt());
+    doReturn(
+        CompletableFuture
+            .completedFuture(new SimplePubSubProduceResultImpl(topicName, partitionId, mock(PubSubPosition.class), -1)))
+                .when(veniceWriter)
+                .put(any(), any(), anyInt());
 
     when(zkClient.readData(zkMetadataNodePath, null)).thenReturn(null)
         .thenReturn(
@@ -571,9 +582,11 @@ public class TestVeniceParentHelixAdmin extends AbstractTestVeniceParentHelixAdm
     doReturn(new GeneratedSchemaID(valueSchemaId, derivedSchemaId)).when(internalAdmin)
         .getDerivedSchemaId(clusterName, storeName, derivedSchemaStr);
 
-    doReturn(CompletableFuture.completedFuture(new SimplePubSubProduceResultImpl(topicName, partitionId, 1, -1)))
-        .when(veniceWriter)
-        .put(any(), any(), anyInt());
+    doReturn(
+        CompletableFuture
+            .completedFuture(new SimplePubSubProduceResultImpl(topicName, partitionId, mock(PubSubPosition.class), -1)))
+                .when(veniceWriter)
+                .put(any(), any(), anyInt());
 
     when(zkClient.readData(zkMetadataNodePath, null)).thenReturn(null)
         .thenReturn(
@@ -604,9 +617,11 @@ public class TestVeniceParentHelixAdmin extends AbstractTestVeniceParentHelixAdm
 
   @Test
   public void testDisableStoreRead() {
-    doReturn(CompletableFuture.completedFuture(new SimplePubSubProduceResultImpl(topicName, partitionId, 1, -1)))
-        .when(veniceWriter)
-        .put(any(), any(), anyInt());
+    doReturn(
+        CompletableFuture
+            .completedFuture(new SimplePubSubProduceResultImpl(topicName, partitionId, mock(PubSubPosition.class), -1)))
+                .when(veniceWriter)
+                .put(any(), any(), anyInt());
 
     when(zkClient.readData(zkMetadataNodePath, null)).thenReturn(null)
         .thenReturn(
@@ -645,9 +660,11 @@ public class TestVeniceParentHelixAdmin extends AbstractTestVeniceParentHelixAdm
 
   @Test
   public void testDisableStoreWrite() {
-    doReturn(CompletableFuture.completedFuture(new SimplePubSubProduceResultImpl(topicName, partitionId, 1, -1)))
-        .when(veniceWriter)
-        .put(any(), any(), anyInt());
+    doReturn(
+        CompletableFuture
+            .completedFuture(new SimplePubSubProduceResultImpl(topicName, partitionId, mock(PubSubPosition.class), -1)))
+                .when(veniceWriter)
+                .put(any(), any(), anyInt());
 
     when(zkClient.readData(zkMetadataNodePath, null)).thenReturn(null)
         .thenReturn(
@@ -690,9 +707,11 @@ public class TestVeniceParentHelixAdmin extends AbstractTestVeniceParentHelixAdm
     doThrow(new VeniceNoStoreException(storeName)).when(internalAdmin)
         .checkPreConditionForUpdateStoreMetadata(clusterName, storeName);
 
-    doReturn(CompletableFuture.completedFuture(new SimplePubSubProduceResultImpl(topicName, partitionId, 1, -1)))
-        .when(veniceWriter)
-        .put(any(), any(), anyInt());
+    doReturn(
+        CompletableFuture
+            .completedFuture(new SimplePubSubProduceResultImpl(topicName, partitionId, mock(PubSubPosition.class), -1)))
+                .when(veniceWriter)
+                .put(any(), any(), anyInt());
 
     parentAdmin.initStorageCluster(clusterName);
     assertThrows(VeniceNoStoreException.class, () -> parentAdmin.setStoreWriteability(clusterName, storeName, false));
@@ -700,9 +719,11 @@ public class TestVeniceParentHelixAdmin extends AbstractTestVeniceParentHelixAdm
 
   @Test
   public void testEnableStoreRead() {
-    doReturn(CompletableFuture.completedFuture(new SimplePubSubProduceResultImpl(topicName, partitionId, 1, -1)))
-        .when(veniceWriter)
-        .put(any(), any(), anyInt());
+    doReturn(
+        CompletableFuture
+            .completedFuture(new SimplePubSubProduceResultImpl(topicName, partitionId, mock(PubSubPosition.class), -1)))
+                .when(veniceWriter)
+                .put(any(), any(), anyInt());
 
     when(zkClient.readData(zkMetadataNodePath, null)).thenReturn(null)
         .thenReturn(
@@ -741,9 +762,11 @@ public class TestVeniceParentHelixAdmin extends AbstractTestVeniceParentHelixAdm
 
   @Test
   public void testEnableStoreWrite() {
-    doReturn(CompletableFuture.completedFuture(new SimplePubSubProduceResultImpl(topicName, partitionId, 1, -1)))
-        .when(veniceWriter)
-        .put(any(), any(), anyInt());
+    doReturn(
+        CompletableFuture
+            .completedFuture(new SimplePubSubProduceResultImpl(topicName, partitionId, mock(PubSubPosition.class), -1)))
+                .when(veniceWriter)
+                .put(any(), any(), anyInt());
 
     when(zkClient.readData(zkMetadataNodePath, null)).thenReturn(null)
         .thenReturn(
@@ -784,9 +807,11 @@ public class TestVeniceParentHelixAdmin extends AbstractTestVeniceParentHelixAdm
     PubSubTopic pubSubTopic = pubSubTopicRepository.getTopic("test_store_v1");
     doReturn(new HashSet<>(Arrays.asList(pubSubTopic))).when(topicManager).listTopics();
 
-    doReturn(CompletableFuture.completedFuture(new SimplePubSubProduceResultImpl(topicName, partitionId, 1, -1)))
-        .when(veniceWriter)
-        .put(any(), any(), anyInt());
+    doReturn(
+        CompletableFuture
+            .completedFuture(new SimplePubSubProduceResultImpl(topicName, partitionId, mock(PubSubPosition.class), -1)))
+                .when(veniceWriter)
+                .put(any(), any(), anyInt());
 
     when(zkClient.readData(zkMetadataNodePath, null)).thenReturn(null)
         .thenReturn(
@@ -856,9 +881,11 @@ public class TestVeniceParentHelixAdmin extends AbstractTestVeniceParentHelixAdm
       VeniceWriter veniceWriter = mock(VeniceWriter.class);
       partialMockParentAdmin.setVeniceWriterForCluster(clusterName, veniceWriter);
 
-      doReturn(CompletableFuture.completedFuture(new SimplePubSubProduceResultImpl(topicName, partitionId, 1, -1)))
-          .when(veniceWriter)
-          .put(any(), any(), anyInt());
+      doReturn(
+          CompletableFuture.completedFuture(
+              new SimplePubSubProduceResultImpl(topicName, partitionId, mock(PubSubPosition.class), -1)))
+                  .when(veniceWriter)
+                  .put(any(), any(), anyInt());
       when(zkClient.readData(zkMetadataNodePath, null)).thenReturn(null)
           .thenReturn(
               AdminTopicMetadataAccessor.generateMetadataMap(
@@ -994,9 +1021,11 @@ public class TestVeniceParentHelixAdmin extends AbstractTestVeniceParentHelixAdm
       partialMockParentAdmin.setOfflineJobStatus(ExecutionStatus.NEW);
       VeniceWriter veniceWriter = mock(VeniceWriter.class);
       partialMockParentAdmin.setVeniceWriterForCluster(clusterName, veniceWriter);
-      doReturn(CompletableFuture.completedFuture(new SimplePubSubProduceResultImpl(topicName, partitionId, 1, -1)))
-          .when(veniceWriter)
-          .put(any(), any(), anyInt());
+      doReturn(
+          CompletableFuture.completedFuture(
+              new SimplePubSubProduceResultImpl(topicName, partitionId, mock(PubSubPosition.class), -1)))
+                  .when(veniceWriter)
+                  .put(any(), any(), anyInt());
       Version newVersion = partialMockParentAdmin.incrementVersionIdempotent(
           clusterName,
           storeName,
@@ -1086,9 +1115,11 @@ public class TestVeniceParentHelixAdmin extends AbstractTestVeniceParentHelixAdm
       partialMockParentAdmin.setOfflineJobStatus(ExecutionStatus.NEW);
       VeniceWriter veniceWriter = mock(VeniceWriter.class);
       partialMockParentAdmin.setVeniceWriterForCluster(clusterName, veniceWriter);
-      doReturn(CompletableFuture.completedFuture(new SimplePubSubProduceResultImpl(topicName, partitionId, 1, -1)))
-          .when(veniceWriter)
-          .put(any(), any(), anyInt());
+      doReturn(
+          CompletableFuture.completedFuture(
+              new SimplePubSubProduceResultImpl(topicName, partitionId, mock(PubSubPosition.class), -1)))
+                  .when(veniceWriter)
+                  .put(any(), any(), anyInt());
       when(zkClient.readData(zkMetadataNodePath, null)).thenReturn(null)
           .thenReturn(
               AdminTopicMetadataAccessor.generateMetadataMap(
@@ -1899,9 +1930,11 @@ public class TestVeniceParentHelixAdmin extends AbstractTestVeniceParentHelixAdm
     Store store = TestUtils.createTestStore(storeName, "test", System.currentTimeMillis());
     doReturn(store).when(internalAdmin).getStore(clusterName, storeName);
 
-    doReturn(CompletableFuture.completedFuture(new SimplePubSubProduceResultImpl(topicName, partitionId, 1, -1)))
-        .when(veniceWriter)
-        .put(any(), any(), anyInt());
+    doReturn(
+        CompletableFuture
+            .completedFuture(new SimplePubSubProduceResultImpl(topicName, partitionId, mock(PubSubPosition.class), -1)))
+                .when(veniceWriter)
+                .put(any(), any(), anyInt());
 
     when(zkClient.readData(zkMetadataNodePath, null)).thenReturn(null)
         .thenReturn(
@@ -2035,9 +2068,11 @@ public class TestVeniceParentHelixAdmin extends AbstractTestVeniceParentHelixAdm
     Store store = TestUtils.createTestStore(storeName, "test", System.currentTimeMillis());
     doReturn(store).when(internalAdmin).getStore(clusterName, storeName);
 
-    doReturn(CompletableFuture.completedFuture(new SimplePubSubProduceResultImpl(topicName, partitionId, 1, -1)))
-        .when(veniceWriter)
-        .put(any(), any(), anyInt());
+    doReturn(
+        CompletableFuture
+            .completedFuture(new SimplePubSubProduceResultImpl(topicName, partitionId, mock(PubSubPosition.class), -1)))
+                .when(veniceWriter)
+                .put(any(), any(), anyInt());
 
     when(zkClient.readData(zkMetadataNodePath, null)).thenReturn(null)
         .thenReturn(
@@ -2065,9 +2100,11 @@ public class TestVeniceParentHelixAdmin extends AbstractTestVeniceParentHelixAdm
     Store store = TestUtils.createTestStore(storeName, "test", System.currentTimeMillis());
     doReturn(store).when(internalAdmin).getStore(clusterName, storeName);
 
-    doReturn(CompletableFuture.completedFuture(new SimplePubSubProduceResultImpl(topicName, partitionId, 1, -1)))
-        .when(veniceWriter)
-        .put(any(), any(), anyInt());
+    doReturn(
+        CompletableFuture
+            .completedFuture(new SimplePubSubProduceResultImpl(topicName, partitionId, mock(PubSubPosition.class), -1)))
+                .when(veniceWriter)
+                .put(any(), any(), anyInt());
 
     when(zkClient.readData(zkMetadataNodePath, null)).thenReturn(null)
         .thenReturn(
@@ -2109,9 +2146,11 @@ public class TestVeniceParentHelixAdmin extends AbstractTestVeniceParentHelixAdm
     store.setChunkingEnabled(true);
     doReturn(store).when(internalAdmin).getStore(clusterName, storeName);
 
-    doReturn(CompletableFuture.completedFuture(new SimplePubSubProduceResultImpl(topicName, partitionId, 1, -1)))
-        .when(veniceWriter)
-        .put(any(), any(), anyInt());
+    doReturn(
+        CompletableFuture
+            .completedFuture(new SimplePubSubProduceResultImpl(topicName, partitionId, mock(PubSubPosition.class), -1)))
+                .when(veniceWriter)
+                .put(any(), any(), anyInt());
 
     when(zkClient.readData(zkMetadataNodePath, null)).thenReturn(null)
         .thenReturn(
@@ -2286,9 +2325,11 @@ public class TestVeniceParentHelixAdmin extends AbstractTestVeniceParentHelixAdm
             new ViewConfigImpl(ChangeCaptureView.class.getCanonicalName(), Collections.emptyMap())));
     doReturn(store).when(internalAdmin).getStore(clusterName, storeName);
 
-    doReturn(CompletableFuture.completedFuture(new SimplePubSubProduceResultImpl(topicName, partitionId, 1, -1)))
-        .when(veniceWriter)
-        .put(any(), any(), anyInt());
+    doReturn(
+        CompletableFuture
+            .completedFuture(new SimplePubSubProduceResultImpl(topicName, partitionId, mock(PubSubPosition.class), -1)))
+                .when(veniceWriter)
+                .put(any(), any(), anyInt());
 
     when(zkClient.readData(zkMetadataNodePath, null)).thenReturn(null)
         .thenReturn(
@@ -2323,9 +2364,11 @@ public class TestVeniceParentHelixAdmin extends AbstractTestVeniceParentHelixAdm
     Store store = TestUtils.createTestStore(storeName, "test", System.currentTimeMillis());
     doReturn(store).when(internalAdmin).getStore(clusterName, storeName);
 
-    doReturn(CompletableFuture.completedFuture(new SimplePubSubProduceResultImpl(topicName, partitionId, 1, -1)))
-        .when(veniceWriter)
-        .put(any(), any(), anyInt());
+    doReturn(
+        CompletableFuture
+            .completedFuture(new SimplePubSubProduceResultImpl(topicName, partitionId, mock(PubSubPosition.class), -1)))
+                .when(veniceWriter)
+                .put(any(), any(), anyInt());
 
     parentAdmin.initStorageCluster(clusterName);
 
@@ -2373,9 +2416,11 @@ public class TestVeniceParentHelixAdmin extends AbstractTestVeniceParentHelixAdm
     doReturn(store).when(internalAdmin).getStore(eq(clusterName), eq(storeName));
     doReturn(store).when(internalAdmin).checkPreConditionForDeletion(eq(clusterName), eq(storeName));
 
-    doReturn(CompletableFuture.completedFuture(new SimplePubSubProduceResultImpl(topicName, partitionId, 1, -1)))
-        .when(veniceWriter)
-        .put(any(), any(), anyInt());
+    doReturn(
+        CompletableFuture
+            .completedFuture(new SimplePubSubProduceResultImpl(topicName, partitionId, mock(PubSubPosition.class), -1)))
+                .when(veniceWriter)
+                .put(any(), any(), anyInt());
 
     when(zkClient.readData(zkMetadataNodePath, null)).thenReturn(null)
         .thenReturn(
@@ -2720,9 +2765,11 @@ public class TestVeniceParentHelixAdmin extends AbstractTestVeniceParentHelixAdm
 
       VeniceWriter veniceWriter = mock(VeniceWriter.class);
       partialMockParentAdmin.setVeniceWriterForCluster(clusterName, veniceWriter);
-      doReturn(CompletableFuture.completedFuture(new SimplePubSubProduceResultImpl(topicName, partitionId, 1, -1)))
-          .when(veniceWriter)
-          .put(any(), any(), anyInt());
+      doReturn(
+          CompletableFuture.completedFuture(
+              new SimplePubSubProduceResultImpl(topicName, partitionId, mock(PubSubPosition.class), -1)))
+                  .when(veniceWriter)
+                  .put(any(), any(), anyInt());
       mockControllerClients(storeName);
 
       when(zkClient.readData(zkMetadataNodePath, null)).thenReturn(null)
@@ -2846,9 +2893,11 @@ public class TestVeniceParentHelixAdmin extends AbstractTestVeniceParentHelixAdm
     doReturn(store).when(internalAdmin).getStore(clusterName, storeA);
     doReturn(store).when(internalAdmin).getStore(clusterName, storeB);
     doReturn(0).when(store).getLargestUsedRTVersionNumber();
-    doReturn(CompletableFuture.completedFuture(new SimplePubSubProduceResultImpl(topicName, partitionId, 1, -1)))
-        .when(veniceWriter)
-        .put(any(), any(), anyInt());
+    doReturn(
+        CompletableFuture
+            .completedFuture(new SimplePubSubProduceResultImpl(topicName, partitionId, mock(PubSubPosition.class), -1)))
+                .when(veniceWriter)
+                .put(any(), any(), anyInt());
 
     when(zkClient.readData(zkMetadataNodePath, null)).thenReturn(
         AdminTopicMetadataAccessor.generateMetadataMap(
@@ -2899,9 +2948,11 @@ public class TestVeniceParentHelixAdmin extends AbstractTestVeniceParentHelixAdm
     Store store = TestUtils.createTestStore(storeName, "test", System.currentTimeMillis());
     doReturn(store).when(internalAdmin).getStore(clusterName, storeName);
 
-    doReturn(CompletableFuture.completedFuture(new SimplePubSubProduceResultImpl(topicName, partitionId, 1, -1)))
-        .when(veniceWriter)
-        .put(any(), any(), anyInt());
+    doReturn(
+        CompletableFuture
+            .completedFuture(new SimplePubSubProduceResultImpl(topicName, partitionId, mock(PubSubPosition.class), -1)))
+                .when(veniceWriter)
+                .put(any(), any(), anyInt());
 
     when(zkClient.readData(zkMetadataNodePath, null)).thenReturn(null)
         .thenReturn(
@@ -2970,9 +3021,11 @@ public class TestVeniceParentHelixAdmin extends AbstractTestVeniceParentHelixAdm
 
   @Test
   public void testSendAdminMessageAcquiresClusterReadLock() {
-    doReturn(CompletableFuture.completedFuture(new SimplePubSubProduceResultImpl(topicName, partitionId, 1, -1)))
-        .when(veniceWriter)
-        .put(any(), any(), anyInt());
+    doReturn(
+        CompletableFuture
+            .completedFuture(new SimplePubSubProduceResultImpl(topicName, partitionId, mock(PubSubPosition.class), -1)))
+                .when(veniceWriter)
+                .put(any(), any(), anyInt());
     when(zkClient.readData(zkMetadataNodePath, null)).thenReturn(null)
         .thenReturn(
             AdminTopicMetadataAccessor.generateMetadataMap(
@@ -3223,9 +3276,11 @@ public class TestVeniceParentHelixAdmin extends AbstractTestVeniceParentHelixAdm
     store.setChunkingEnabled(true);
     doReturn(store).when(internalAdmin).getStore(clusterName, storeName);
 
-    doReturn(CompletableFuture.completedFuture(new SimplePubSubProduceResultImpl(topicName, partitionId, 1, -1)))
-        .when(veniceWriter)
-        .put(any(), any(), anyInt());
+    doReturn(
+        CompletableFuture
+            .completedFuture(new SimplePubSubProduceResultImpl(topicName, partitionId, mock(PubSubPosition.class), -1)))
+                .when(veniceWriter)
+                .put(any(), any(), anyInt());
 
     when(zkClient.readData(zkMetadataNodePath, null)).thenReturn(null)
         .thenReturn(

--- a/services/venice-controller/src/test/java/com/linkedin/venice/controller/TestVeniceParentHelixAdminWithAcl.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/controller/TestVeniceParentHelixAdminWithAcl.java
@@ -5,6 +5,7 @@ import static org.mockito.Mockito.anyInt;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -22,6 +23,7 @@ import com.linkedin.venice.kafka.protocol.state.PartitionState;
 import com.linkedin.venice.meta.Store;
 import com.linkedin.venice.offsets.OffsetRecord;
 import com.linkedin.venice.pubsub.adapter.SimplePubSubProduceResultImpl;
+import com.linkedin.venice.pubsub.api.PubSubPosition;
 import com.linkedin.venice.serialization.avro.AvroProtocolDefinition;
 import com.linkedin.venice.serialization.avro.InternalAvroSpecificSerializer;
 import com.linkedin.venice.utils.TestUtils;
@@ -84,9 +86,11 @@ public class TestVeniceParentHelixAdminWithAcl extends AbstractTestVeniceParentH
             Optional.of(1L),
             Optional.of(LATEST_SCHEMA_ID_FOR_ADMIN_OPERATION)));
 
-    doReturn(CompletableFuture.completedFuture(new SimplePubSubProduceResultImpl(topicName, partitionId, 1, -1)))
-        .when(veniceWriter)
-        .put(any(), any(), anyInt());
+    doReturn(
+        CompletableFuture
+            .completedFuture(new SimplePubSubProduceResultImpl(topicName, partitionId, mock(PubSubPosition.class), -1)))
+                .when(veniceWriter)
+                .put(any(), any(), anyInt());
 
     String keySchemaStr = "\"string\"";
     String valueSchemaStr = "\"string\"";
@@ -111,9 +115,11 @@ public class TestVeniceParentHelixAdminWithAcl extends AbstractTestVeniceParentH
     String accessPerm =
         "{\"AccessPermissions\":{\"Read\":[\"user:user1\",\"group:group1\",\"service:app1\"],\"Write\":[\"user:user1\",\"group:group1\",\"service:app1\"],}}";
 
-    doReturn(CompletableFuture.completedFuture(new SimplePubSubProduceResultImpl(topicName, partitionId, 1, -1)))
-        .when(veniceWriter)
-        .put(any(), any(), anyInt());
+    doReturn(
+        CompletableFuture
+            .completedFuture(new SimplePubSubProduceResultImpl(topicName, partitionId, mock(PubSubPosition.class), -1)))
+                .when(veniceWriter)
+                .put(any(), any(), anyInt());
 
     String keySchemaStr = "\"string\"";
     String valueSchemaStr = "\"string\"";
@@ -134,9 +140,11 @@ public class TestVeniceParentHelixAdminWithAcl extends AbstractTestVeniceParentH
     doReturn(store).when(internalAdmin).getStore(eq(clusterName), eq(storeName));
     doReturn(store).when(internalAdmin).checkPreConditionForDeletion(eq(clusterName), eq(storeName));
 
-    doReturn(CompletableFuture.completedFuture(new SimplePubSubProduceResultImpl(topicName, partitionId, 1, -1)))
-        .when(veniceWriter)
-        .put(any(), any(), anyInt());
+    doReturn(
+        CompletableFuture
+            .completedFuture(new SimplePubSubProduceResultImpl(topicName, partitionId, mock(PubSubPosition.class), -1)))
+                .when(veniceWriter)
+                .put(any(), any(), anyInt());
 
     when(zkClient.readData(zkMetadataNodePath, null)).thenReturn(null)
         .thenReturn(


### PR DESCRIPTION
## Replace numeric offsets with PubSubPosition abstraction in LeaderProducedRecordContext

Refactored offset handling in LeaderProducedRecordContext class to use PubSubPosition  
instead of raw numeric offsets. This improves abstraction and prepares the codebase  
for more flexible position semantics.  

> ## AI Generate Summary of Changes
> This pull request refactors how offsets are handled in Kafka ingestion tasks by replacing numeric offsets with `PubSubPosition` objects, improving abstraction and consistency in the codebase. The most significant changes include updates to the `LeaderProducedRecordContext` class, modifications to methods across ingestion tasks to use `PubSubPosition`, and adjustments to utility functions and constructors.
> 
> ### Refactoring of Offset Handling
> 
> 
> * `LeaderProducedRecordContext.java`:
>   - Replaced `long consumedOffset` and `long producedOffset` fields with `PubSubPosition consumedPosition` and `PubSubPosition producedPosition`, respectively, to support more abstract position handling. [[1]](diffhunk://#diff-451a134ab2d1dde55befa2cc3b658fec3ea266814d5ce4350663000eacb9d965L22-R47) [[2]](diffhunk://#diff-451a134ab2d1dde55befa2cc3b658fec3ea266814d5ce4350663000eacb9d965L59-R65)
>   - Updated all static utility functions (e.g., `newPutRecord`, `newDeleteRecord`, `newControlMessageRecord`) to use `PubSubPosition` instead of numeric offsets. [[1]](diffhunk://#diff-451a134ab2d1dde55befa2cc3b658fec3ea266814d5ce4350663000eacb9d965L82-R86) [[2]](diffhunk://#diff-451a134ab2d1dde55befa2cc3b658fec3ea266814d5ce4350663000eacb9d965L133-R137)
>   - Added validation in `checkConsumedOffsetParam` to ensure `PubSubPosition` values are not symbolic (e.g., `EARLIEST` or `LATEST`).
> 
> ### Updates to Ingestion Tasks
> 
> * `ActiveActiveStoreIngestionTask.java`:
>   - Updated methods like `processActiveActiveMessage` and `producePutOrDeleteToKafka` to use `consumerRecord.getPosition()` instead of `consumerRecord.getPosition().getNumericOffset()`. [[1]](diffhunk://#diff-9ee5c502e0f36bca0cb6efa87e4bd7a0ad5c027bbe8c8613185e0a7b2512582aL572-R578) [[2]](diffhunk://#diff-9ee5c502e0f36bca0cb6efa87e4bd7a0ad5c027bbe8c8613185e0a7b2512582aL873-R870) [[3]](diffhunk://#diff-9ee5c502e0f36bca0cb6efa87e4bd7a0ad5c027bbe8c8613185e0a7b2512582aL904-R900)
> 
> * `LeaderFollowerStoreIngestionTask.java`:
>   - Modified methods such as `updateOffsetsAsRemoteConsumeLeader`, `processMessage`, and `produceToLocalKafkaHelper` to adopt `PubSubPosition` for both consumed and produced positions. [[1]](diffhunk://#diff-3491f6b6c8a1a74e9c271a31115b624707befba8e1824c3fd2a493799056afb1L1522-R1531) [[2]](diffhunk://#diff-3491f6b6c8a1a74e9c271a31115b624707befba8e1824c3fd2a493799056afb1L3304-R3303) [[3]](diffhunk://#diff-3491f6b6c8a1a74e9c271a31115b624707befba8e1824c3fd2a493799056afb1L3523-R3523)
> 
> ### Utility and Debugging Enhancements
> 
> * Improved `toString()` representation in `LeaderProducedRecordContext` to display `PubSubPosition` values instead of numeric offsets, aiding debugging.
> * Adjusted validation logic to ensure offsets are not symbolic, enhancing data integrity.
> 
> These changes improve the maintainability and extensibility of the code by abstracting offset handling, making it easier to adapt to different PubSub systems in the future.
> 
> 

###  Code changes
- [ ] Added new code behind **a config**. If so list the config names and their default values in the PR description.
- [ ] Introduced new **log lines**. 
  - [ ] Confirmed if logs need to be **rate limited** to avoid excessive logging.

###  **Concurrency-Specific Checks**
Both reviewer and PR author to verify
- [x] Code has **no race conditions** or **thread safety issues**.
- [ ] Proper **synchronization mechanisms** (e.g., `synchronized`, `RWLock`) are used where needed.
- [x] No **blocking calls** inside critical sections that could lead to deadlocks or performance degradation.
- [x] Verified **thread-safe collections** are used (e.g., `ConcurrentHashMap`, `CopyOnWriteArrayList`).
- [x] Validated proper exception handling in multi-threaded code to avoid silent thread termination.


## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->

- [ ] New unit tests added.
- [ ] New integration tests added.
- [x] Modified or extended existing tests.
- [x] Verified backward compatibility (if applicable).

## Does this PR introduce any user-facing or breaking changes?
<!--  
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [ ] No. You can skip the rest of this section.
- [ ] Yes. Clearly explain the behavior change and its impact.