### PR TITLE
[compat] Use KafkaMessageEnvelope v12 to support dual writing PubSubPositions

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -320,7 +320,6 @@ subprojects {
       def versionOverrides = [
 //        project(':internal:venice-common').file('src/main/resources/avro/StoreVersionState/v5', PathValidation.DIRECTORY)
         project(':internal:venice-common').file('src/main/resources/avro/PartitionState/v16', PathValidation.DIRECTORY),
-        project(':internal:venice-common').file('src/main/resources/avro/KafkaMessageEnvelope/v11', PathValidation.DIRECTORY)
       ]
 
       def schemaDirs = [sourceDir]

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/task/datawriter/CompositeVeniceWriter.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/task/datawriter/CompositeVeniceWriter.java
@@ -1,8 +1,10 @@
 package com.linkedin.venice.hadoop.task.datawriter;
 
 import static com.linkedin.venice.writer.VeniceWriter.APP_DEFAULT_LOGICAL_TS;
+import static com.linkedin.venice.writer.VeniceWriter.DEFAULT_TERM_ID;
 import static com.linkedin.venice.writer.VeniceWriter.DEFAULT_UPSTREAM_KAFKA_CLUSTER_ID;
 import static com.linkedin.venice.writer.VeniceWriter.DEFAULT_UPSTREAM_OFFSET;
+import static com.linkedin.venice.writer.VeniceWriter.DEFAULT_UPSTREAM_PUBSUB_POSITION;
 
 import com.linkedin.venice.annotation.NotThreadsafe;
 import com.linkedin.venice.exceptions.VeniceException;
@@ -165,8 +167,12 @@ public class CompositeVeniceWriter<K, V, U> extends AbstractVeniceWriter<K, V, U
           childCallback,
           putMetadata);
     }
-    LeaderMetadataWrapper leaderMetadataWrapper =
-        new LeaderMetadataWrapper(DEFAULT_UPSTREAM_OFFSET, DEFAULT_UPSTREAM_KAFKA_CLUSTER_ID, viewPartitionMap);
+    LeaderMetadataWrapper leaderMetadataWrapper = new LeaderMetadataWrapper(
+        DEFAULT_UPSTREAM_OFFSET,
+        DEFAULT_UPSTREAM_KAFKA_CLUSTER_ID,
+        DEFAULT_TERM_ID,
+        DEFAULT_UPSTREAM_PUBSUB_POSITION,
+        viewPartitionMap);
     // We only need to pass the logical timestamp to the main writer as it's only used for write conflict resolution
     // in the venice server or TTL repush. So we don't need to pass it to view topics.
     long passedTimestamp = logicalTimestamp > 0 ? logicalTimestamp : APP_DEFAULT_LOGICAL_TS;

--- a/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/api/PubSubPosition.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/api/PubSubPosition.java
@@ -4,6 +4,7 @@ import com.linkedin.venice.annotation.RestrictedApi;
 import com.linkedin.venice.annotation.UnderDevelopment;
 import com.linkedin.venice.memory.Measurable;
 import com.linkedin.venice.pubsub.PubSubPositionDeserializer;
+import java.nio.ByteBuffer;
 
 
 /**
@@ -41,6 +42,14 @@ public interface PubSubPosition extends Measurable {
    * @return the position wrapper
    */
   PubSubPositionWireFormat getPositionWireFormat();
+
+  /**
+   * Returns the serialized wire format bytes of this position.
+   * @return byte array representing the position in wire format
+   */
+  default ByteBuffer getWireFormatBytes() {
+    return getPositionWireFormat().getRawBytes();
+  }
 
   static PubSubPosition getPositionFromWireFormat(PubSubPositionWireFormat positionWireFormat) {
     return PubSubPositionDeserializer.getPositionFromWireFormat(positionWireFormat);

--- a/internal/venice-common/src/main/java/com/linkedin/venice/serialization/avro/AvroProtocolDefinition.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/serialization/avro/AvroProtocolDefinition.java
@@ -49,7 +49,7 @@ public enum AvroProtocolDefinition {
   /**
    * Used for the Kafka topics, including the main data topics as well as the admin topic.
    */
-  KAFKA_MESSAGE_ENVELOPE(23, 11, KafkaMessageEnvelope.class),
+  KAFKA_MESSAGE_ENVELOPE(23, 12, KafkaMessageEnvelope.class),
 
   /**
    * Used to persist the state of a partition in Storage Nodes, including offset,

--- a/internal/venice-common/src/main/java/com/linkedin/venice/writer/LeaderMetadataWrapper.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/writer/LeaderMetadataWrapper.java
@@ -1,5 +1,6 @@
 package com.linkedin.venice.writer;
 
+import java.nio.ByteBuffer;
 import java.util.Map;
 import java.util.Set;
 
@@ -13,17 +14,27 @@ public class LeaderMetadataWrapper {
   private final long upstreamOffset;
   private final int upstreamKafkaClusterId;
   private final Map<String, Set<Integer>> viewPartitionMap;
+  private final ByteBuffer upstreamPubSubPosition;
+  private final long termId;
 
-  public LeaderMetadataWrapper(long upstreamOffset, int upstreamKafkaClusterId) {
-    this(upstreamOffset, upstreamKafkaClusterId, null);
+  public LeaderMetadataWrapper(
+      long upstreamOffset,
+      int upstreamKafkaClusterId,
+      long termId,
+      ByteBuffer upstreamPubSubPosition) {
+    this(upstreamOffset, upstreamKafkaClusterId, termId, upstreamPubSubPosition, null);
   }
 
   public LeaderMetadataWrapper(
       long upstreamOffset,
       int upstreamKafkaClusterId,
+      long termId,
+      ByteBuffer upstreamPubSubPosition,
       Map<String, Set<Integer>> viewPartitionMap) {
     this.upstreamOffset = upstreamOffset;
     this.upstreamKafkaClusterId = upstreamKafkaClusterId;
+    this.termId = termId;
+    this.upstreamPubSubPosition = upstreamPubSubPosition;
     this.viewPartitionMap = viewPartitionMap;
   }
 
@@ -37,5 +48,13 @@ public class LeaderMetadataWrapper {
 
   public Map<String, Set<Integer>> getViewPartitionMap() {
     return viewPartitionMap;
+  }
+
+  public ByteBuffer getUpstreamPubSubPosition() {
+    return upstreamPubSubPosition;
+  }
+
+  public long getTermId() {
+    return termId;
   }
 }

--- a/internal/venice-common/src/main/java/com/linkedin/venice/writer/VeniceWriter.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/writer/VeniceWriter.java
@@ -1117,7 +1117,9 @@ public class VeniceWriter<K, V, U> extends AbstractVeniceWriter<K, V, U> {
       LeaderMetadataWrapper leaderMetadataWrapper) {
     LeaderMetadata leaderMetadata = new LeaderMetadata();
     leaderMetadata.upstreamOffset = leaderMetadataWrapper.getUpstreamOffset();
+    leaderMetadata.upstreamPubSubPosition = leaderMetadataWrapper.getUpstreamPubSubPosition();
     leaderMetadata.upstreamKafkaClusterId = leaderMetadataWrapper.getUpstreamKafkaClusterId();
+    leaderMetadata.termId = leaderMetadataWrapper.getTermId();
     leaderMetadata.hostName = writerId;
     kafkaMessageEnvelope.leaderMetadataFooter = leaderMetadata;
 
@@ -1317,6 +1319,7 @@ public class VeniceWriter<K, V, U> extends AbstractVeniceWriter<K, V, U> {
     VersionSwap versionSwap = new VersionSwap();
     versionSwap.oldServingVersionTopic = oldServingVersionTopic;
     versionSwap.newServingVersionTopic = newServingVersionTopic;
+    versionSwap.localHighWatermarkPubSubPositions = Collections.emptyList();
     controlMessage.controlMessageUnion = versionSwap;
     broadcastControlMessage(controlMessage, debugInfo);
     producerAdapter.flush();

--- a/internal/venice-common/src/main/java/com/linkedin/venice/writer/VeniceWriter.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/writer/VeniceWriter.java
@@ -193,6 +193,12 @@ public class VeniceWriter<K, V, U> extends AbstractVeniceWriter<K, V, U> {
   public static final int DEFAULT_UPSTREAM_KAFKA_CLUSTER_ID =
       (int) AvroCompatibilityHelper.getSpecificDefaultValue(LeaderMetadata.SCHEMA$.getField("upstreamKafkaClusterId"));
 
+  public static final ByteBuffer DEFAULT_UPSTREAM_PUBSUB_POSITION = (ByteBuffer) AvroCompatibilityHelper
+      .getSpecificDefaultValue(LeaderMetadata.SCHEMA$.getField("upstreamPubSubPosition"));
+
+  public static final long DEFAULT_TERM_ID =
+      (long) AvroCompatibilityHelper.getSpecificDefaultValue(LeaderMetadata.SCHEMA$.getField("termId"));
+
   /**
    * A static counter shared by all VeniceWriter instances to track the number of active VeniceWriter
    */
@@ -230,8 +236,11 @@ public class VeniceWriter<K, V, U> extends AbstractVeniceWriter<K, V, U> {
 
   public static final ByteBuffer EMPTY_BYTE_BUFFER = ByteBuffer.wrap(EMPTY_BYTE_ARRAY);
 
-  public static final LeaderMetadataWrapper DEFAULT_LEADER_METADATA_WRAPPER =
-      new LeaderMetadataWrapper(DEFAULT_UPSTREAM_OFFSET, DEFAULT_UPSTREAM_KAFKA_CLUSTER_ID);
+  public static final LeaderMetadataWrapper DEFAULT_LEADER_METADATA_WRAPPER = new LeaderMetadataWrapper(
+      DEFAULT_UPSTREAM_OFFSET,
+      DEFAULT_UPSTREAM_KAFKA_CLUSTER_ID,
+      DEFAULT_TERM_ID,
+      DEFAULT_UPSTREAM_PUBSUB_POSITION);
 
   // Immutable state
   private final PubSubMessageHeaders protocolSchemaHeaders;
@@ -274,7 +283,9 @@ public class VeniceWriter<K, V, U> extends AbstractVeniceWriter<K, V, U> {
     public DefaultLeaderMetadata(CharSequence hostName) {
       this.hostName = hostName;
       this.upstreamOffset = DEFAULT_LEADER_METADATA_WRAPPER.getUpstreamOffset();
+      this.upstreamPubSubPosition = DEFAULT_LEADER_METADATA_WRAPPER.getUpstreamPubSubPosition();
       this.upstreamKafkaClusterId = DEFAULT_LEADER_METADATA_WRAPPER.getUpstreamKafkaClusterId();
+      this.termId = DEFAULT_LEADER_METADATA_WRAPPER.getTermId();
     }
   }
 
@@ -1613,6 +1624,8 @@ public class VeniceWriter<K, V, U> extends AbstractVeniceWriter<K, V, U> {
             : new LeaderMetadataWrapper(
                 DEFAULT_UPSTREAM_OFFSET,
                 DEFAULT_UPSTREAM_KAFKA_CLUSTER_ID,
+                DEFAULT_TERM_ID,
+                DEFAULT_UPSTREAM_PUBSUB_POSITION,
                 leaderMetadataWrapper.getViewPartitionMap());
     MessageType keyMessageType = (isPutMessage) ? MessageType.PUT : MessageType.GLOBAL_RT_DIV;
     int schemaId =
@@ -2042,7 +2055,9 @@ public class VeniceWriter<K, V, U> extends AbstractVeniceWriter<K, V, U> {
     LeaderMetadata leaderMetadataFooter = new LeaderMetadata();
     leaderMetadataFooter.hostName = writerId;
     leaderMetadataFooter.upstreamOffset = leaderMetadataWrapper.getUpstreamOffset();
+    leaderMetadataFooter.upstreamPubSubPosition = leaderMetadataWrapper.getUpstreamPubSubPosition();
     leaderMetadataFooter.upstreamKafkaClusterId = leaderMetadataWrapper.getUpstreamKafkaClusterId();
+    leaderMetadataFooter.termId = leaderMetadataWrapper.getTermId();
 
     KafkaMessageEnvelope kafkaMessageEnvelope = new KafkaMessageEnvelope();
     kafkaMessageEnvelope.messageType = MessageType.CONTROL_MESSAGE.getValue();
@@ -2148,13 +2163,16 @@ public class VeniceWriter<K, V, U> extends AbstractVeniceWriter<K, V, U> {
     producerMetadata.messageTimestamp = time.getMilliseconds();
     producerMetadata.logicalTimestamp = logicalTs;
     kafkaValue.producerMetadata = producerMetadata;
+
     if (leaderMetadataWrapper == DEFAULT_LEADER_METADATA_WRAPPER) {
       kafkaValue.leaderMetadataFooter = this.defaultLeaderMetadata;
     } else {
       kafkaValue.leaderMetadataFooter = new LeaderMetadata();
       kafkaValue.leaderMetadataFooter.hostName = writerId;
       kafkaValue.leaderMetadataFooter.upstreamOffset = leaderMetadataWrapper.getUpstreamOffset();
+      kafkaValue.leaderMetadataFooter.upstreamPubSubPosition = leaderMetadataWrapper.getUpstreamPubSubPosition();
       kafkaValue.leaderMetadataFooter.upstreamKafkaClusterId = leaderMetadataWrapper.getUpstreamKafkaClusterId();
+      kafkaValue.leaderMetadataFooter.termId = leaderMetadataWrapper.getTermId();
     }
 
     return kafkaValue;

--- a/internal/venice-common/src/test/java/com/linkedin/venice/memory/InstanceSizeEstimatorTest.java
+++ b/internal/venice-common/src/test/java/com/linkedin/venice/memory/InstanceSizeEstimatorTest.java
@@ -87,7 +87,9 @@ public class InstanceSizeEstimatorTest extends HeapSizeEstimatorTest {
         new LeaderMetadata(
             null, // shared instance
             0L,
-            0));
+            0,
+            ByteBuffer.allocate(0),
+            -1L));
     kmeSuppliers.add(rtKmeSupplier);
     kmeSuppliers.add(vtKmeSupplier);
     // TODO: Add updates, deletes...

--- a/internal/venice-common/src/test/java/com/linkedin/venice/memory/InstanceSizeEstimatorTest.java
+++ b/internal/venice-common/src/test/java/com/linkedin/venice/memory/InstanceSizeEstimatorTest.java
@@ -88,7 +88,7 @@ public class InstanceSizeEstimatorTest extends HeapSizeEstimatorTest {
             null, // shared instance
             0L,
             0,
-            ByteBuffer.allocate(0),
+            null,
             -1L));
     kmeSuppliers.add(rtKmeSupplier);
     kmeSuppliers.add(vtKmeSupplier);

--- a/internal/venice-common/src/test/java/com/linkedin/venice/pubsub/manager/TopicManagerTest.java
+++ b/internal/venice-common/src/test/java/com/linkedin/venice/pubsub/manager/TopicManagerTest.java
@@ -44,6 +44,7 @@ import com.linkedin.venice.pubsub.api.PubSubAdminAdapter;
 import com.linkedin.venice.pubsub.api.PubSubConsumerAdapter;
 import com.linkedin.venice.pubsub.api.PubSubProducerAdapter;
 import com.linkedin.venice.pubsub.api.PubSubProducerCallback;
+import com.linkedin.venice.pubsub.api.PubSubSymbolicPosition;
 import com.linkedin.venice.pubsub.api.PubSubTopic;
 import com.linkedin.venice.pubsub.api.PubSubTopicPartition;
 import com.linkedin.venice.pubsub.api.exceptions.PubSubClientRetriableException;
@@ -166,6 +167,7 @@ public class TopicManagerTest {
     recordValue.producerMetadata.messageTimestamp = producerTimestamp;
     recordValue.leaderMetadataFooter = new LeaderMetadata();
     recordValue.leaderMetadataFooter.hostName = "localhost";
+    recordValue.leaderMetadataFooter.upstreamPubSubPosition = PubSubSymbolicPosition.LATEST.getWireFormatBytes();
 
     if (isDataRecord) {
       Put put = new Put();

--- a/internal/venice-common/src/test/java/com/linkedin/venice/writer/VeniceWriterUnitTest.java
+++ b/internal/venice-common/src/test/java/com/linkedin/venice/writer/VeniceWriterUnitTest.java
@@ -711,7 +711,7 @@ public class VeniceWriterUnitTest {
           0,
           1,
           null,
-          new LeaderMetadataWrapper(0, 0),
+          new LeaderMetadataWrapper(0, 0, 0, ByteBuffer.allocate(0)),
           APP_DEFAULT_LOGICAL_TS,
           null,
           null,

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestFatalDataValidationExceptionHandling.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestFatalDataValidationExceptionHandling.java
@@ -19,6 +19,7 @@ import static com.linkedin.venice.ConfigKeys.SERVER_SHARED_CONSUMER_ASSIGNMENT_S
 import static com.linkedin.venice.ConfigKeys.SSL_TO_KAFKA_LEGACY;
 import static com.linkedin.venice.status.BatchJobHeartbeatConfigs.HEARTBEAT_ENABLED_CONFIG;
 import static com.linkedin.venice.utils.TestWriteUtils.STRING_SCHEMA;
+import static com.linkedin.venice.writer.VeniceWriter.DEFAULT_TERM_ID;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -43,6 +44,8 @@ import com.linkedin.venice.meta.Version;
 import com.linkedin.venice.pubsub.PubSubPositionTypeRegistry;
 import com.linkedin.venice.pubsub.PubSubProducerAdapterFactory;
 import com.linkedin.venice.pubsub.PubSubTopicRepository;
+import com.linkedin.venice.pubsub.adapter.kafka.common.ApacheKafkaOffsetPosition;
+import com.linkedin.venice.pubsub.api.PubSubPosition;
 import com.linkedin.venice.pubsub.manager.TopicManager;
 import com.linkedin.venice.serializer.AvroSerializer;
 import com.linkedin.venice.status.PushJobDetailsStatus;
@@ -294,34 +297,55 @@ public class TestFatalDataValidationExceptionHandling {
     vw3.broadcastStartOfPush(false, Collections.emptyMap());
     vw3.flush();
 
+    PubSubPosition pubSubPosition0 = new ApacheKafkaOffsetPosition(0);
     vw1.put(
         stringSerializer.serialize("key_writer_1"),
         stringSerializer.serialize("value_writer_1"),
         1,
         null,
-        new LeaderMetadataWrapper(0, 0));
+        new LeaderMetadataWrapper(
+            pubSubPosition0.getNumericOffset(),
+            0,
+            DEFAULT_TERM_ID,
+            pubSubPosition0.getWireFormatBytes()));
     vw1.flush();
 
+    PubSubPosition pubSubPosition1 = new ApacheKafkaOffsetPosition(1);
     vw2.put(
         stringSerializer.serialize("key_writer_2"),
         stringSerializer.serialize("value_writer_2"),
         1,
         null,
-        new LeaderMetadataWrapper(1, 0));
+        new LeaderMetadataWrapper(
+            pubSubPosition1.getNumericOffset(),
+            0,
+            DEFAULT_TERM_ID,
+            pubSubPosition1.getWireFormatBytes()));
+
+    PubSubPosition pubSubPosition2 = new ApacheKafkaOffsetPosition(2);
     vw2.put(
         stringSerializer.serialize("key_writer_3"),
         stringSerializer.serialize("value_writer_3"),
         1,
         null,
-        new LeaderMetadataWrapper(2, 0));
+        new LeaderMetadataWrapper(
+            pubSubPosition2.getNumericOffset(),
+            0,
+            DEFAULT_TERM_ID,
+            pubSubPosition2.getWireFormatBytes()));
     vw2.flush();
 
+    PubSubPosition pubSubPosition3 = new ApacheKafkaOffsetPosition(3);
     vw1.put(
         stringSerializer.serialize("key_writer_4"),
         stringSerializer.serialize("value_writer_4"),
         1,
         null,
-        new LeaderMetadataWrapper(3, 0));
+        new LeaderMetadataWrapper(
+            pubSubPosition3.getNumericOffset(),
+            0,
+            DEFAULT_TERM_ID,
+            pubSubPosition3.getWireFormatBytes()));
     vw1.flush();
     vw1.closePartition(0);
     vw1.flush();

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestHybridMultiRegion.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestHybridMultiRegion.java
@@ -14,6 +14,7 @@ import static com.linkedin.venice.meta.BufferReplayPolicy.REWIND_FROM_EOP;
 import static com.linkedin.venice.meta.BufferReplayPolicy.REWIND_FROM_SOP;
 import static com.linkedin.venice.pubsub.PubSubConstants.PUBSUB_OPERATION_TIMEOUT_MS_DEFAULT_VALUE;
 import static com.linkedin.venice.utils.TestWriteUtils.STRING_SCHEMA;
+import static com.linkedin.venice.writer.VeniceWriter.DEFAULT_TERM_ID;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNotEquals;
@@ -39,6 +40,8 @@ import com.linkedin.venice.meta.Version;
 import com.linkedin.venice.meta.ZKStore;
 import com.linkedin.venice.pubsub.PubSubPositionTypeRegistry;
 import com.linkedin.venice.pubsub.PubSubProducerAdapterFactory;
+import com.linkedin.venice.pubsub.adapter.kafka.common.ApacheKafkaOffsetPosition;
+import com.linkedin.venice.pubsub.api.PubSubPosition;
 import com.linkedin.venice.pubsub.manager.TopicManager;
 import com.linkedin.venice.serializer.AvroSerializer;
 import com.linkedin.venice.systemstore.schemas.StoreProperties;
@@ -262,44 +265,73 @@ public class TestHybridMultiRegion {
          * key_9: value_9 with upstream offset: 14
          */
 
+        PubSubPosition upstreamPosition1 = new ApacheKafkaOffsetPosition(0);
         // Sending out dummy records first to push out SOS messages first.
         veniceWriter1.put(
             stringSerializer.serialize("key_writer_1"),
             stringSerializer.serialize("value_writer_1"),
             1,
             null,
-            new LeaderMetadataWrapper(0, 0));
+            new LeaderMetadataWrapper(
+                upstreamPosition1.getNumericOffset(),
+                0,
+                DEFAULT_TERM_ID,
+                upstreamPosition1.getWireFormatBytes()));
         veniceWriter1.flush();
+
+        PubSubPosition upstreamPosition2 = new ApacheKafkaOffsetPosition(1);
         veniceWriter2.put(
             stringSerializer.serialize("key_writer_2"),
             stringSerializer.serialize("value_writer_2"),
             1,
             null,
-            new LeaderMetadataWrapper(1, 0));
+            new LeaderMetadataWrapper(
+                upstreamPosition2.getNumericOffset(),
+                0,
+                DEFAULT_TERM_ID,
+                upstreamPosition2.getWireFormatBytes()));
         veniceWriter2.flush();
 
+        PubSubPosition upstreamPositionIPlusFive;
         for (int i = 0; i < 5; ++i) {
+          upstreamPositionIPlusFive = new ApacheKafkaOffsetPosition(i + 5);
           veniceWriter1.put(
               stringSerializer.serialize("key_" + i),
               stringSerializer.serialize("value_" + i),
               1,
               null,
-              new LeaderMetadataWrapper(i + 5, 0));
+              new LeaderMetadataWrapper(
+                  upstreamPositionIPlusFive.getNumericOffset(),
+                  0,
+                  DEFAULT_TERM_ID,
+                  upstreamPositionIPlusFive.getWireFormatBytes()));
         }
         veniceWriter1.flush();
+
+        PubSubPosition upstreamPosition3 = new ApacheKafkaOffsetPosition(2);
         veniceWriter2.put(
             stringSerializer.serialize("key_" + 0),
             stringSerializer.serialize("value_x"),
             1,
             null,
-            new LeaderMetadataWrapper(3, 0));
+            new LeaderMetadataWrapper(
+                upstreamPosition3.getNumericOffset(),
+                0,
+                DEFAULT_TERM_ID,
+                upstreamPosition3.getWireFormatBytes()));
+
         for (int i = 5; i < 10; ++i) {
+          upstreamPositionIPlusFive = new ApacheKafkaOffsetPosition(i + 5);
           veniceWriter2.put(
               stringSerializer.serialize("key_" + i),
               stringSerializer.serialize("value_" + i),
               1,
               null,
-              new LeaderMetadataWrapper(i + 5, 0));
+              new LeaderMetadataWrapper(
+                  upstreamPositionIPlusFive.getNumericOffset(),
+                  0,
+                  DEFAULT_TERM_ID,
+                  upstreamPositionIPlusFive.getWireFormatBytes()));
         }
         veniceWriter2.flush();
         veniceWriter1.broadcastEndOfPush(Collections.emptyMap());

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/kafka/KafkaConsumptionTest.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/kafka/KafkaConsumptionTest.java
@@ -37,6 +37,7 @@ import com.linkedin.venice.pubsub.PubSubTopicPartitionImpl;
 import com.linkedin.venice.pubsub.PubSubTopicRepository;
 import com.linkedin.venice.pubsub.api.PubSubMessageDeserializer;
 import com.linkedin.venice.pubsub.api.PubSubProducerAdapter;
+import com.linkedin.venice.pubsub.api.PubSubSymbolicPosition;
 import com.linkedin.venice.pubsub.api.PubSubTopic;
 import com.linkedin.venice.pubsub.api.PubSubTopicPartition;
 import com.linkedin.venice.pubsub.manager.TopicManager;
@@ -300,6 +301,7 @@ public class KafkaConsumptionTest {
     recordValue.producerMetadata.producerGUID = new GUID();
     recordValue.producerMetadata.messageTimestamp = producerTimestamp;
     recordValue.leaderMetadataFooter = new LeaderMetadata();
+    recordValue.leaderMetadataFooter.upstreamPubSubPosition = PubSubSymbolicPosition.EARLIEST.getWireFormatBytes();
     recordValue.leaderMetadataFooter.hostName = "localhost";
 
     if (isDataRecord) {


### PR DESCRIPTION
## [compat] Use KafkaMessageEnvelope v12 to support dual writing PubSubPositions

Upgrade to KafkaMessageEnvelope v12 to start dual writing PubSubPositions alongside
numeric offsets. This enables a gradual transition and sets the foundation for
eventually deprecating numeric offsets in the future.

###  Code changes
- [ ] Added new code behind **a config**. If so list the config names and their default values in the PR description.
- [ ] Introduced new **log lines**. 
  - [ ] Confirmed if logs need to be **rate limited** to avoid excessive logging.

###  **Concurrency-Specific Checks**
Both reviewer and PR author to verify
- [ ] Code has **no race conditions** or **thread safety issues**.
- [ ] Proper **synchronization mechanisms** (e.g., `synchronized`, `RWLock`) are used where needed.
- [ ] No **blocking calls** inside critical sections that could lead to deadlocks or performance degradation.
- [ ] Verified **thread-safe collections** are used (e.g., `ConcurrentHashMap`, `CopyOnWriteArrayList`).
- [ ] Validated proper exception handling in multi-threaded code to avoid silent thread termination.


## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->

- [ ] New unit tests added.
- [ ] New integration tests added.
- [ ] Modified or extended existing tests.
- [ ] Verified backward compatibility (if applicable).

## Does this PR introduce any user-facing or breaking changes?
<!--  
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [ ] No. You can skip the rest of this section.
- [ ] Yes. Clearly explain the behavior change and its impact.