### PR TITLE
[cc] Drop comparePosition and diff from PubSubPosition; migrate to PubSubUtil

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/consumer/VeniceAfterImageConsumerImpl.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/consumer/VeniceAfterImageConsumerImpl.java
@@ -7,6 +7,7 @@ import com.linkedin.venice.exceptions.VeniceException;
 import com.linkedin.venice.kafka.protocol.ControlMessage;
 import com.linkedin.venice.kafka.protocol.enums.ControlMessageType;
 import com.linkedin.venice.offsets.OffsetRecord;
+import com.linkedin.venice.pubsub.PubSubUtil;
 import com.linkedin.venice.pubsub.api.DefaultPubSubMessage;
 import com.linkedin.venice.pubsub.api.PubSubConsumerAdapter;
 import com.linkedin.venice.pubsub.api.PubSubMessage;
@@ -143,7 +144,7 @@ public class VeniceAfterImageConsumerImpl<K, V> extends VeniceChangelogConsumerI
         // No need to do anything here, we already have the EOP checkpoint, so we'll default to that
       } else {
         PubSubPosition eopPosition = checkpoints.get(topicPartition.getPartitionNumber()).getPosition();
-        if (heartbeatTimestampPosition.comparePosition(eopPosition) > 0) {
+        if (PubSubUtil.comparePubSubPositions(heartbeatTimestampPosition, eopPosition) > 0) {
           checkpoints.put(
               topicPartition.getPartitionNumber(),
               new VeniceChangeCoordinate(

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/consumer/VeniceChangeCoordinate.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/consumer/VeniceChangeCoordinate.java
@@ -3,6 +3,7 @@ package com.linkedin.davinci.consumer;
 import com.linkedin.venice.exceptions.VeniceException;
 import com.linkedin.venice.meta.Version;
 import com.linkedin.venice.pubsub.PubSubPositionDeserializer;
+import com.linkedin.venice.pubsub.PubSubUtil;
 import com.linkedin.venice.pubsub.api.PubSubPosition;
 import com.linkedin.venice.pubsub.api.PubSubPositionWireFormat;
 import java.io.ByteArrayInputStream;
@@ -67,7 +68,7 @@ public class VeniceChangeCoordinate implements Externalizable {
       // but it DOESNT account for version rollbacks.
       return topic.compareTo(other.topic);
     }
-    return pubSubPosition.comparePosition(other.pubSubPosition);
+    return PubSubUtil.comparePubSubPositions(pubSubPosition, other.pubSubPosition);
   }
 
   // These methods contain 'need to know' information and expose underlying details.

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/consumer/VeniceChangelogConsumerImplTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/consumer/VeniceChangelogConsumerImplTest.java
@@ -287,10 +287,11 @@ public class VeniceChangelogConsumerImplTest {
     topicPartitionList.add(partition1);
     topicPartitionList.add(partition2);
 
+    long offset = 1L;
     PubSubPosition aheadPosition = new PubSubPosition() {
       @Override
       public long getNumericOffset() {
-        return 2;
+        return offset + 1; // greater than 1
       }
 
       @Override
@@ -307,7 +308,7 @@ public class VeniceChangelogConsumerImplTest {
     PubSubPosition behindPosition = new PubSubPosition() {
       @Override
       public long getNumericOffset() {
-        return 1;
+        return offset;
       }
 
       @Override
@@ -336,7 +337,7 @@ public class VeniceChangelogConsumerImplTest {
     PubSubPosition newerAheadPosition = new PubSubPosition() {
       @Override
       public long getNumericOffset() {
-        return 3; // greater than 2
+        return offset + 2; // greater than 1
       }
 
       @Override

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/consumer/VeniceChangelogConsumerImplTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/consumer/VeniceChangelogConsumerImplTest.java
@@ -289,18 +289,8 @@ public class VeniceChangelogConsumerImplTest {
 
     PubSubPosition aheadPosition = new PubSubPosition() {
       @Override
-      public int comparePosition(PubSubPosition other) {
-        return 1;
-      }
-
-      @Override
-      public long diff(PubSubPosition other) {
-        return 0;
-      }
-
-      @Override
       public long getNumericOffset() {
-        return 0;
+        return 2;
       }
 
       @Override
@@ -316,18 +306,8 @@ public class VeniceChangelogConsumerImplTest {
 
     PubSubPosition behindPosition = new PubSubPosition() {
       @Override
-      public int comparePosition(PubSubPosition other) {
-        return -1;
-      }
-
-      @Override
-      public long diff(PubSubPosition other) {
-        return 0;
-      }
-
-      @Override
       public long getNumericOffset() {
-        return 0;
+        return 1;
       }
 
       @Override
@@ -352,13 +332,29 @@ public class VeniceChangelogConsumerImplTest {
     checkpoints.put(1, behindCoordinate);
     checkpoints.put(2, otherCoordinate);
 
-    // the heartbeat is ahead
-    Mockito.when(mockConsumer.getPositionByTimestamp(partition0, 1L)).thenReturn(aheadPosition);
+    // The heartbeat is ahead of the checkpoint — should update
+    PubSubPosition newerAheadPosition = new PubSubPosition() {
+      @Override
+      public long getNumericOffset() {
+        return 3; // greater than 2
+      }
 
-    // the heartbeat is behind
+      @Override
+      public PubSubPositionWireFormat getPositionWireFormat() {
+        return null;
+      }
+
+      @Override
+      public int getHeapSize() {
+        return 0;
+      }
+    };
+    Mockito.when(mockConsumer.getPositionByTimestamp(partition0, 1L)).thenReturn(newerAheadPosition);
+
+    // The heartbeat is behind the checkpoint — should not update
     Mockito.when(mockConsumer.getPositionByTimestamp(partition1, 2L)).thenReturn(behindPosition);
 
-    // the heartbeat doesn't exist
+    // The heartbeat exists, but EOP already exists — and heartbeat is not newer — should not update
     Mockito.when(mockConsumer.getPositionByTimestamp(partition2, 1L)).thenReturn(aheadPosition);
 
     VeniceAfterImageConsumerImpl.adjustSeekCheckPointsBasedOnHeartbeats(
@@ -367,28 +363,33 @@ public class VeniceChangelogConsumerImplTest {
         mockConsumer,
         topicPartitionList);
 
-    Assert.assertNotEquals(checkpoints.get(0), aheadCoordinate);
-    Assert.assertEquals(checkpoints.get(1), behindCoordinate);
-    Assert.assertEquals(checkpoints.get(2), otherCoordinate);
+    // Should replace with a new VeniceChangeCoordinate (same data but different object)
+    Assert.assertNotSame(checkpoints.get(0), aheadCoordinate, "Expected new coordinate at partition 0");
 
+    // Should remain unchanged
+    Assert.assertEquals(checkpoints.get(1), behindCoordinate, "Coordinate at partition 1 should not change");
+    Assert.assertEquals(checkpoints.get(2), otherCoordinate, "Coordinate at partition 2 should not change");
+
+    // Test case: checkpoint is removed; fallback to heartbeat
     checkpoints.remove(1);
-
     VeniceAfterImageConsumerImpl.adjustSeekCheckPointsBasedOnHeartbeats(
         checkpoints,
         currentVersionLastHeartbeat,
         mockConsumer,
         topicPartitionList);
+    Assert.assertEquals(
+        checkpoints.get(1).getPosition().getNumericOffset(),
+        behindPosition.getNumericOffset(),
+        "Partition 1 should have fallback heartbeat checkpoint added");
 
-    Assert.assertNotEquals(checkpoints.get(0), aheadCoordinate);
-
-    // Let's throw some nulls at it now
+    // Simulate all heartbeat positions as null
     Mockito.when(mockConsumer.getPositionByTimestamp(partition0, 1L)).thenReturn(null);
     Mockito.when(mockConsumer.getPositionByTimestamp(partition1, 2L)).thenReturn(null);
     Mockito.when(mockConsumer.getPositionByTimestamp(partition2, 1L)).thenReturn(null);
 
-    VeniceChangeCoordinate formerCorodinate0 = checkpoints.get(0);
-    VeniceChangeCoordinate formerCorodinate1 = checkpoints.get(1);
-    VeniceChangeCoordinate formerCorodinate2 = checkpoints.get(2);
+    VeniceChangeCoordinate formerCoordinate0 = checkpoints.get(0);
+    VeniceChangeCoordinate formerCoordinate1 = checkpoints.get(1);
+    VeniceChangeCoordinate formerCoordinate2 = checkpoints.get(2);
 
     VeniceAfterImageConsumerImpl.adjustSeekCheckPointsBasedOnHeartbeats(
         checkpoints,
@@ -396,11 +397,10 @@ public class VeniceChangelogConsumerImplTest {
         mockConsumer,
         topicPartitionList);
 
-    // This should have left everything the same
-    Assert.assertEquals(checkpoints.get(0), formerCorodinate0);
-    Assert.assertEquals(checkpoints.get(1), formerCorodinate1);
-    Assert.assertEquals(checkpoints.get(2), formerCorodinate2);
-
+    // Nothing should change because no heartbeat positions were available
+    Assert.assertEquals(checkpoints.get(0), formerCoordinate0);
+    Assert.assertEquals(checkpoints.get(1), formerCoordinate1);
+    Assert.assertEquals(checkpoints.get(2), formerCoordinate2);
   }
 
   @Test

--- a/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/adapter/kafka/common/ApacheKafkaOffsetPosition.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/adapter/kafka/common/ApacheKafkaOffsetPosition.java
@@ -43,44 +43,6 @@ public class ApacheKafkaOffsetPosition implements PubSubPosition {
             .readLong());
   }
 
-  /**
-   * @param other the other position to compare to
-   * @return returns 0 if the positions are equal,
-   *         -1 if this position is less than the other position,
-   *          and 1 if this position is greater than the other position
-   */
-  @Override
-  public int comparePosition(PubSubPosition other) {
-    validatePositionIsComparable(other);
-    ApacheKafkaOffsetPosition otherPosition = (ApacheKafkaOffsetPosition) other;
-    return Long.compare(offset, otherPosition.offset);
-  }
-
-  /**
-   * @return the difference between this position and the other position
-   *
-   * @throws IllegalArgumentException if position is null or positions are not comparable
-   */
-  @Override
-  public long diff(PubSubPosition other) {
-    validatePositionIsComparable(other);
-    ApacheKafkaOffsetPosition otherPosition = (ApacheKafkaOffsetPosition) other;
-    return offset - otherPosition.offset;
-  }
-
-  /**
-   * Checks if the other position is comparable to this position
-   */
-  private void validatePositionIsComparable(PubSubPosition other) {
-    if (other == null) {
-      throw new IllegalArgumentException("Cannot compare ApacheKafkaOffsetPosition with null");
-    }
-
-    if (!(other instanceof ApacheKafkaOffsetPosition)) {
-      throw new IllegalArgumentException("Cannot compare ApacheKafkaOffsetPosition with " + other.getClass().getName());
-    }
-  }
-
   public long getOffset() {
     return offset;
   }

--- a/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/api/EarliestPosition.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/api/EarliestPosition.java
@@ -37,16 +37,6 @@ final class EarliestPosition implements PubSubPosition {
   }
 
   @Override
-  public int comparePosition(PubSubPosition other) {
-    throw new UnsupportedOperationException("Cannot compare EARLIEST position");
-  }
-
-  @Override
-  public long diff(PubSubPosition other) {
-    throw new UnsupportedOperationException("Cannot diff EARLIEST position");
-  }
-
-  @Override
   public PubSubPositionWireFormat getPositionWireFormat() {
     PubSubPositionWireFormat wireFormat = new PubSubPositionWireFormat();
     wireFormat.setType(EARLIEST_POSITION_RESERVED_TYPE_ID);

--- a/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/api/LatestPosition.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/api/LatestPosition.java
@@ -37,16 +37,6 @@ final class LatestPosition implements PubSubPosition {
   }
 
   @Override
-  public int comparePosition(PubSubPosition other) {
-    throw new UnsupportedOperationException("Cannot compare LATEST position");
-  }
-
-  @Override
-  public long diff(PubSubPosition other) {
-    throw new UnsupportedOperationException("Cannot diff LATEST position");
-  }
-
-  @Override
   public PubSubPositionWireFormat getPositionWireFormat() {
     PubSubPositionWireFormat wireFormat = new PubSubPositionWireFormat();
     wireFormat.setType(LATEST_POSITION_RESERVED_TYPE_ID);

--- a/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/api/PubSubPosition.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/api/PubSubPosition.java
@@ -1,7 +1,6 @@
 package com.linkedin.venice.pubsub.api;
 
 import com.linkedin.venice.annotation.RestrictedApi;
-import com.linkedin.venice.annotation.UnderDevelopment;
 import com.linkedin.venice.memory.Measurable;
 import com.linkedin.venice.pubsub.PubSubPositionDeserializer;
 
@@ -10,30 +9,13 @@ import com.linkedin.venice.pubsub.PubSubPositionDeserializer;
  * Represents a position of a message in a partition of a topic.
  */
 public interface PubSubPosition extends Measurable {
-  /**
-   * @param other the other position to compare to
-   * @return returns 0 if the positions are equal,
-   *          -1 if this position is less than the other position,
-   *          and 1 if this position is greater than the other position
-   */
-  @RestrictedApi("DO NOT USE THIS API for new code")
-  @UnderDevelopment("Compare API is under development and may change in the future.")
-  int comparePosition(PubSubPosition other);
-
-  /**
-   * @return the difference between this position and the other position
-   */
-  @RestrictedApi("DO NOT USE THIS API for new code")
-  @UnderDevelopment("Compare API is under development and may change in the future.")
-  long diff(PubSubPosition other);
+  @RestrictedApi("This API facilitates the transition from numeric offsets to PubSubPosition. "
+      + "It should be removed once the codebase fully adopts PubSubPosition.")
+  long getNumericOffset();
 
   boolean equals(Object obj);
 
   int hashCode();
-
-  @RestrictedApi("This API facilitates the transition from numeric offsets to PubSubPosition. "
-      + "It should be removed once the codebase fully adopts PubSubPosition.")
-  long getNumericOffset();
 
   /**
    * Position wrapper is used to wrap the position type and the position value.

--- a/internal/venice-common/src/test/java/com/linkedin/venice/pubsub/adapter/kafka/common/ApacheKafkaOffsetPositionTest.java
+++ b/internal/venice-common/src/test/java/com/linkedin/venice/pubsub/adapter/kafka/common/ApacheKafkaOffsetPositionTest.java
@@ -1,10 +1,8 @@
 package com.linkedin.venice.pubsub.adapter.kafka.common;
 
-import static org.mockito.Mockito.mock;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNotEquals;
-import static org.testng.Assert.assertTrue;
 
 import com.linkedin.venice.offsets.OffsetRecord;
 import com.linkedin.venice.pubsub.PubSubPositionTypeRegistry;
@@ -16,56 +14,6 @@ import org.testng.annotations.Test;
 
 /** Unit tests for ApacheKafkaOffsetPosition */
 public class ApacheKafkaOffsetPositionTest {
-  @Test
-  public void testComparePosition() {
-    ApacheKafkaOffsetPosition position1 = ApacheKafkaOffsetPosition.of(1);
-    ApacheKafkaOffsetPosition position2 = ApacheKafkaOffsetPosition.of(2);
-    ApacheKafkaOffsetPosition position3 = ApacheKafkaOffsetPosition.of(3);
-
-    assertTrue(position1.comparePosition(position2) < 0);
-    assertTrue(position2.comparePosition(position1) > 0);
-    assertEquals(position1.comparePosition(position1), 0);
-    assertTrue(position2.comparePosition(position3) < 0);
-    assertTrue(position3.comparePosition(position2) > 0);
-  }
-
-  @Test
-  public void testDiff() {
-    ApacheKafkaOffsetPosition position1 = ApacheKafkaOffsetPosition.of(1);
-    ApacheKafkaOffsetPosition position2 = ApacheKafkaOffsetPosition.of(2);
-    ApacheKafkaOffsetPosition position3 = ApacheKafkaOffsetPosition.of(3);
-
-    assertEquals(position1.diff(position2), -1);
-    assertEquals(position2.diff(position1), 1);
-    assertEquals(position1.diff(position1), 0);
-    assertEquals(position2.diff(position3), -1);
-    assertEquals(position3.diff(position2), 1);
-  }
-
-  @Test(expectedExceptions = IllegalArgumentException.class, expectedExceptionsMessageRegExp = "Cannot compare ApacheKafkaOffsetPosition with null")
-  public void testComparePositionWithNull() {
-    ApacheKafkaOffsetPosition position1 = ApacheKafkaOffsetPosition.of(1);
-    position1.comparePosition(null);
-  }
-
-  @Test(expectedExceptions = IllegalArgumentException.class, expectedExceptionsMessageRegExp = "Cannot compare ApacheKafkaOffsetPosition with null")
-  public void testDiffWithNull() {
-    ApacheKafkaOffsetPosition position1 = ApacheKafkaOffsetPosition.of(1);
-    position1.diff(null);
-  }
-
-  @Test(expectedExceptions = IllegalArgumentException.class, expectedExceptionsMessageRegExp = "Cannot compare ApacheKafkaOffsetPosition with .*")
-  public void testComparePositionWithDifferentType() {
-    ApacheKafkaOffsetPosition position1 = ApacheKafkaOffsetPosition.of(1);
-    position1.comparePosition(mock(PubSubPosition.class));
-  }
-
-  @Test(expectedExceptions = IllegalArgumentException.class, expectedExceptionsMessageRegExp = "Cannot compare ApacheKafkaOffsetPosition with .*")
-  public void testDiffWithDifferentType() {
-    ApacheKafkaOffsetPosition position1 = ApacheKafkaOffsetPosition.of(1);
-    position1.diff(mock(PubSubPosition.class));
-  }
-
   @Test
   public void testEquals() {
     ApacheKafkaOffsetPosition position1 = ApacheKafkaOffsetPosition.of(1);

--- a/internal/venice-common/src/test/java/com/linkedin/venice/pubsub/api/EarliestPositionTest.java
+++ b/internal/venice-common/src/test/java/com/linkedin/venice/pubsub/api/EarliestPositionTest.java
@@ -70,22 +70,6 @@ public class EarliestPositionTest {
     assertThrows(UnsupportedOperationException.class, () -> instance.getNumericOffset());
   }
 
-  @Test
-  public void testComparePositionThrows() {
-    EarliestPosition instance = EarliestPosition.getInstance();
-    PubSubPosition dummy = new DummyPosition();
-
-    assertThrows(UnsupportedOperationException.class, () -> instance.comparePosition(dummy));
-  }
-
-  @Test
-  public void testDiffThrows() {
-    EarliestPosition instance = EarliestPosition.getInstance();
-    PubSubPosition dummy = new DummyPosition();
-
-    assertThrows(UnsupportedOperationException.class, () -> instance.diff(dummy));
-  }
-
   public static class DummyPosition implements PubSubPosition {
     public int getHeapSize() {
       return 0;

--- a/internal/venice-common/src/test/java/com/linkedin/venice/pubsub/api/LatestPositionTest.java
+++ b/internal/venice-common/src/test/java/com/linkedin/venice/pubsub/api/LatestPositionTest.java
@@ -6,7 +6,6 @@ import static org.testng.Assert.assertSame;
 import static org.testng.Assert.assertThrows;
 import static org.testng.Assert.assertTrue;
 
-import com.linkedin.venice.pubsub.api.EarliestPositionTest.DummyPosition;
 import java.lang.reflect.Constructor;
 import org.testng.annotations.Test;
 
@@ -64,21 +63,5 @@ public class LatestPositionTest {
   public void testNumericOffset() {
     LatestPosition instance = LatestPosition.getInstance();
     assertThrows(UnsupportedOperationException.class, () -> instance.getNumericOffset());
-  }
-
-  @Test
-  public void testComparePositionThrows() {
-    LatestPosition instance = LatestPosition.getInstance();
-    PubSubPosition dummy = new DummyPosition();
-
-    assertThrows(UnsupportedOperationException.class, () -> instance.comparePosition(dummy));
-  }
-
-  @Test
-  public void testDiffThrows() {
-    LatestPosition instance = LatestPosition.getInstance();
-    PubSubPosition dummy = new DummyPosition();
-
-    assertThrows(UnsupportedOperationException.class, () -> instance.diff(dummy));
   }
 }

--- a/internal/venice-test-common/src/main/java/com/linkedin/venice/unit/kafka/InMemoryPubSubPosition.java
+++ b/internal/venice-test-common/src/main/java/com/linkedin/venice/unit/kafka/InMemoryPubSubPosition.java
@@ -12,26 +12,6 @@ public class InMemoryPubSubPosition implements PubSubPosition {
   }
 
   @Override
-  public int comparePosition(PubSubPosition other) {
-    if (!(other instanceof InMemoryPubSubPosition)) {
-      throw new IllegalArgumentException(
-          "InMemoryPubSubPosition can only be compared with another InMemoryPubSubPosition");
-    }
-    InMemoryPubSubPosition otherPosition = (InMemoryPubSubPosition) other;
-    return Long.compare(this.internalOffset, otherPosition.internalOffset);
-  }
-
-  @Override
-  public long diff(PubSubPosition other) {
-    if (!(other instanceof InMemoryPubSubPosition)) {
-      throw new IllegalArgumentException(
-          "InMemoryPubSubPosition can only be compared with another InMemoryPubSubPosition");
-    }
-    InMemoryPubSubPosition otherPosition = (InMemoryPubSubPosition) other;
-    return this.internalOffset - otherPosition.internalOffset;
-  }
-
-  @Override
   public long getNumericOffset() {
     return internalOffset;
   }


### PR DESCRIPTION
## [pubsub] Move comparePosition and diff methods to PubSubUtil; remove from PubSubPosition  

Removed the comparePosition and diff APIs from PubSubPosition. These methods will be supported  
through a separate service in the future (e.g., TopicManager).  

For now, the logic has been moved to static utility methods:  
- PubSubUtil.comparePubSubPositions  
- PubSubUtil.diffPubSubPositions  



###  Code changes
- [ ] Added new code behind **a config**. If so list the config names and their default values in the PR description.
- [ ] Introduced new **log lines**. 
  - [ ] Confirmed if logs need to be **rate limited** to avoid excessive logging.

###  **Concurrency-Specific Checks**
Both reviewer and PR author to verify
- [ ] Code has **no race conditions** or **thread safety issues**.
- [ ] Proper **synchronization mechanisms** (e.g., `synchronized`, `RWLock`) are used where needed.
- [ ] No **blocking calls** inside critical sections that could lead to deadlocks or performance degradation.
- [ ] Verified **thread-safe collections** are used (e.g., `ConcurrentHashMap`, `CopyOnWriteArrayList`).
- [ ] Validated proper exception handling in multi-threaded code to avoid silent thread termination.


## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->

- [ ] New unit tests added.
- [ ] New integration tests added.
- [ ] Modified or extended existing tests.
- [ ] Verified backward compatibility (if applicable).

## Does this PR introduce any user-facing or breaking changes?
<!--  
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [ ] No. You can skip the rest of this section.
- [ ] Yes. Clearly explain the behavior change and its impact.