### PR TITLE
[vpj] Report empty input source as user error

### DIFF
--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/VenicePushJob.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/VenicePushJob.java
@@ -852,9 +852,7 @@ public class VenicePushJob implements AutoCloseable {
         } else if (e instanceof VeniceInvalidInputException) {
           /**
            * We use {@link PushJobCheckpoints.INVALID_INPUT_FILE} for the scenario where the input
-           * data path contains no data as well in the avro flow. Note this is at the beginning of data input
-           * validation flow as opposed to the later stages where certain stage can genuinely have no data as part
-           * of its input
+           * data path contains no data as well in the avro flow.
            */
           updatePushJobDetailsWithCheckpoint(PushJobCheckpoints.INVALID_INPUT_FILE);
         }

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/VenicePushJob.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/VenicePushJob.java
@@ -849,6 +849,14 @@ public class VenicePushJob implements AutoCloseable {
       try {
         if (e instanceof VeniceResourceAccessException) {
           updatePushJobDetailsWithCheckpoint(PushJobCheckpoints.WRITE_ACL_FAILED);
+        } else if (e instanceof VeniceInvalidInputException) {
+          /**
+           * We use {@link PushJobCheckpoints.INVALID_INPUT_FILE} for the scenario where the input
+           * data path contains no data as well in the avro flow. Note this is at the beginning of data input
+           * validation flow as opposed to the later stages where certain stage can genuinely have no data as part
+           * of its input
+           */
+          updatePushJobDetailsWithCheckpoint(PushJobCheckpoints.INVALID_INPUT_FILE);
         }
         pushJobDetails.overallStatus.add(getPushJobDetailsStatusTuple(PushJobDetailsStatus.ERROR.getValue()));
         pushJobDetails.failureDetails = e.toString();

--- a/clients/venice-push-job/src/test/java/com/linkedin/venice/hadoop/TestDefaultInputDataInfoProvider.java
+++ b/clients/venice-push-job/src/test/java/com/linkedin/venice/hadoop/TestDefaultInputDataInfoProvider.java
@@ -106,8 +106,7 @@ public class TestDefaultInputDataInfoProvider {
     VeniceProperties props = VeniceProperties.empty();
     try (DefaultInputDataInfoProvider provider = new DefaultInputDataInfoProvider(pushJobSetting, props)) {
       File inputDir = getTempDataDirectory();
-      InputDataInfoProvider.InputDataInfo inputDataInfo =
-          provider.validateInputAndGetInfo("file://" + inputDir.getAbsolutePath());
+      provider.validateInputAndGetInfo("file://" + inputDir.getAbsolutePath());
     }
   }
 }

--- a/clients/venice-push-job/src/test/java/com/linkedin/venice/hadoop/TestDefaultInputDataInfoProvider.java
+++ b/clients/venice-push-job/src/test/java/com/linkedin/venice/hadoop/TestDefaultInputDataInfoProvider.java
@@ -9,6 +9,7 @@ import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertTrue;
 
 import com.linkedin.venice.etl.ETLValueSchemaTransformation;
+import com.linkedin.venice.hadoop.exceptions.VeniceInvalidInputException;
 import com.linkedin.venice.utils.KeyAndValueSchemas;
 import com.linkedin.venice.utils.TestWriteUtils;
 import com.linkedin.venice.utils.VeniceProperties;
@@ -95,6 +96,18 @@ public class TestDefaultInputDataInfoProvider {
       byte[] dictionary = provider.trainZstdDictionary();
       assertNotNull(dictionary);
       assertNotEquals(dictionary.length, 0);
+    }
+  }
+
+  @Test(expectedExceptions = VeniceInvalidInputException.class)
+  public void testInvalidInputSource() throws Exception {
+    PushJobSetting pushJobSetting = new PushJobSetting();
+
+    VeniceProperties props = VeniceProperties.empty();
+    try (DefaultInputDataInfoProvider provider = new DefaultInputDataInfoProvider(pushJobSetting, props)) {
+      File inputDir = getTempDataDirectory();
+      InputDataInfoProvider.InputDataInfo inputDataInfo =
+          provider.validateInputAndGetInfo("file://" + inputDir.getAbsolutePath());
     }
   }
 }


### PR DESCRIPTION
## Problem Statement
Currently, as part of `DefaultInputDataInfoProvider`, we throw `RuntimeException` when the source is empty or invalid. However, we want to treat this as user error instead of an runtime exception.

## Solution
Treating invalid input as user error by throwing the appropriate exception, helps `VenicePushJob` classify the error correctly with the right checkpoint. 

**Note**: `DefaultInputDataInfoProvider` is an API that can be extended for various input data info providers. We don't have the right structure / abstractions for handle errors as part of this API and as a result, extension of this API may still need to handle invalid input as recommended by this PR. However, we can't enforce consistent handling across the implementations and to enforce that would be out of the scope for this bug fix.

###  Code changes
- Throw `VeniceInvalidInputException` instead of `RuntimeException`
- Emit the right push job checkpoint `INVALID_INPUT_FILE` in case of `VeniceInvalidInputException`

###  **Concurrency-Specific Checks**
Both reviewer and PR author to verify
- [x] Code has **no race conditions** or **thread safety issues**.
- [x] Proper **synchronization mechanisms** (e.g., `synchronized`, `RWLock`) are used where needed.
- [x] No **blocking calls** inside critical sections that could lead to deadlocks or performance degradation.
- [x] Verified **thread-safe collections** are used (e.g., `ConcurrentHashMap`, `CopyOnWriteArrayList`).
- [x] Validated proper exception handling in multi-threaded code to avoid silent thread termination.


## How was this PR tested?
- [x] New unit tests added.

## Does this PR introduce any user-facing or breaking changes?
- [x] No. You can skip the rest of this section.