### PR TITLE
[compat][server][dvc] Use PartitionState v17 to persist numeric last consumed VT offset for GlobalDIV

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -319,7 +319,6 @@ subprojects {
     doFirst {
       def versionOverrides = [
 //        project(':internal:venice-common').file('src/main/resources/avro/StoreVersionState/v5', PathValidation.DIRECTORY)
-        project(':internal:venice-common').file('src/main/resources/avro/PartitionState/v16', PathValidation.DIRECTORY),
       ]
 
       def schemaDirs = [sourceDir]

--- a/internal/venice-common/src/main/java/com/linkedin/venice/offsets/OffsetRecord.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/offsets/OffsetRecord.java
@@ -7,9 +7,7 @@ import com.linkedin.venice.guid.GuidUtils;
 import com.linkedin.venice.kafka.protocol.GUID;
 import com.linkedin.venice.kafka.protocol.state.PartitionState;
 import com.linkedin.venice.kafka.protocol.state.ProducerPartitionState;
-import com.linkedin.venice.pubsub.PubSubPositionDeserializer;
 import com.linkedin.venice.pubsub.PubSubTopicRepository;
-import com.linkedin.venice.pubsub.adapter.kafka.common.ApacheKafkaOffsetPosition;
 import com.linkedin.venice.pubsub.api.PubSubTopic;
 import com.linkedin.venice.serialization.avro.InternalAvroSpecificSerializer;
 import com.linkedin.venice.utils.concurrent.VeniceConcurrentHashMap;
@@ -313,14 +311,11 @@ public class OffsetRecord {
   }
 
   public void setLatestConsumedVtOffset(long latestConsumedVtOffset) {
-    this.partitionState.setLastConsumedVersionTopicPubSubPosition(
-        ApacheKafkaOffsetPosition.of(latestConsumedVtOffset).getPositionWireFormat().getRawBytes());
+    this.partitionState.setLastConsumedVersionTopicOffset(latestConsumedVtOffset);
   }
 
   public long getLatestConsumedVtOffset() {
-    return PubSubPositionDeserializer.DEFAULT_DESERIALIZER
-        .convertToPosition(partitionState.getLastConsumedVersionTopicPubSubPosition())
-        .getNumericOffset();
+    return this.partitionState.getLastConsumedVersionTopicOffset();
   }
 
   /**

--- a/internal/venice-common/src/main/java/com/linkedin/venice/serialization/avro/AvroProtocolDefinition.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/serialization/avro/AvroProtocolDefinition.java
@@ -55,7 +55,7 @@ public enum AvroProtocolDefinition {
    * Used to persist the state of a partition in Storage Nodes, including offset,
    * Data Ingest Validation state, etc.
    */
-  PARTITION_STATE(24, 16, PartitionState.class),
+  PARTITION_STATE(24, 17, PartitionState.class),
 
   /**
    * Used to persist state related to a store-version, including Start of Buffer Replay


### PR DESCRIPTION
## [compat][server][dvc] Use PartitionState v17 schema to persist numeric last consumed VT offset for GlobalDIV

Switches from hardcoded PubSub position bytes to storing the numeric last consumed VT offset 
directly. The previous hardcoded bytes encoded the numeric offset in a static Kafka-specific 
format, which would require special handling in the future. 

Since this field is not currently used (GlobalDIV is not enabled), we can safely migrate to 
a numeric field now. The byte-based PubSub position field will be populated dynamically 
rather than using the existing hardcoded value.

###  Code changes
- [ ] Added new code behind **a config**. If so list the config names and their default values in the PR description.
- [ ] Introduced new **log lines**. 
  - [ ] Confirmed if logs need to be **rate limited** to avoid excessive logging.

###  **Concurrency-Specific Checks**
Both reviewer and PR author to verify
- [ ] Code has **no race conditions** or **thread safety issues**.
- [ ] Proper **synchronization mechanisms** (e.g., `synchronized`, `RWLock`) are used where needed.
- [ ] No **blocking calls** inside critical sections that could lead to deadlocks or performance degradation.
- [ ] Verified **thread-safe collections** are used (e.g., `ConcurrentHashMap`, `CopyOnWriteArrayList`).
- [ ] Validated proper exception handling in multi-threaded code to avoid silent thread termination.


## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->

- [ ] New unit tests added.
- [ ] New integration tests added.
- [ ] Modified or extended existing tests.
- [ ] Verified backward compatibility (if applicable).

## Does this PR introduce any user-facing or breaking changes?
<!--  
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [ ] No. You can skip the rest of this section.
- [ ] Yes. Clearly explain the behavior change and its impact.