### PR TITLE
[server] Don't pause ingestion of real time data when quota is exceeded

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StorageUtilizationManager.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StorageUtilizationManager.java
@@ -324,6 +324,14 @@ public class StorageUtilizationManager implements StoreDataChangedListener {
    * partition without affecting partition subscription
    */
   private void pausePartition(int partition, String consumingTopic) {
+    if (Version.isRealTimeTopic(consumingTopic) && !Version.isIncrementalPushTopic(consumingTopic)) {
+      // We do not pause consumption from real time topics. The intent of this is that we still should drain
+      // the messages which have been submitted to the queue as best as we are able to. Ideally our mechanisms
+      // which kill the producer upstream have kicked in within a timely manner. We don't give the same preferential
+      // treatment to incremental push jobs as those have a lower priority and if we pause ingestion the job will
+      // at some point terminate.
+      return;
+    }
     pausePartition.execute(consumingTopic, partition);
     this.pausedPartitions.add(partition);
   }

--- a/internal/venice-common/src/main/java/com/linkedin/venice/meta/Version.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/meta/Version.java
@@ -452,10 +452,15 @@ public interface Version extends Comparable<Version>, DataModelBackedStructure<S
     return "";
   }
 
-  static boolean isRealTimeTopic(String kafkaTopic) {
-    String topicWithoutVersionSuffix = removeRTVersionSuffix(kafkaTopic);
+  static boolean isRealTimeTopic(String topicName) {
+    String topicWithoutVersionSuffix = removeRTVersionSuffix(topicName);
     return topicWithoutVersionSuffix.endsWith(REAL_TIME_TOPIC_SUFFIX)
         || topicWithoutVersionSuffix.endsWith(SEPARATE_REAL_TIME_TOPIC_SUFFIX);
+  }
+
+  static boolean isIncrementalPushTopic(String topicName) {
+    String topicWithoutVersionSuffix = removeRTVersionSuffix(topicName);
+    return topicWithoutVersionSuffix.endsWith(SEPARATE_REAL_TIME_TOPIC_SUFFIX);
   }
 
   static boolean isStreamReprocessingTopic(String kafkaTopic) {


### PR DESCRIPTION
## Problem Statement

Today it is the behavior of the venice server to pause all ingestion when a particular store hits it's quota limit.  Unfortunately, this has some issues in practice.  Most notably, when we pause the ingestion on realtime data we get alerts due to lagged heartbeats, and other parts of the system which depend on timely heartbeat deliveries start to panic.  We can't just drop data between heartbeats as that would be tantamount to corrupted checkpoints and data loss.  Moreover, squelching the alerts and halting the ingestion on a time compacted topic means that we're just waiting around for data to get dropped at some point, even if the user comes around eventually to request more quota.

## Solution

So to improve the experience a bit, we'll change the policy to the following.  We will drain the realtime topic of data even if quota is violated, and instead rely on our existing enforcement mechanism which kills/prevents the user from producing the data upstream.  Ingestion may still pause if the server begins to run out of disk completely, but so long as it has available disk it will make a best effort to drain the writes in the queue.

We do not do the same for incremental push.  The reason being that, for incremental push we don't have a latency sla for when that type of data is consumed (so no alert spew) and we utilize e2e acknowledgement on the push job (so if the job fails due to timeout because of paused ingestion, the user can just retry with their input and no data ends up getting lost).


###  Code changes
- [ ] Added new code behind **a config**. If so list the config names and their default values in the PR description.
- [ ] Introduced new **log lines**. 
  - [ ] Confirmed if logs need to be **rate limited** to avoid excessive logging.

###  **Concurrency-Specific Checks**
Both reviewer and PR author to verify
- [ ] Code has **no race conditions** or **thread safety issues**.
- [ ] Proper **synchronization mechanisms** (e.g., `synchronized`, `RWLock`) are used where needed.
- [ ] No **blocking calls** inside critical sections that could lead to deadlocks or performance degradation.
- [ ] Verified **thread-safe collections** are used (e.g., `ConcurrentHashMap`, `CopyOnWriteArrayList`).
- [ ] Validated proper exception handling in multi-threaded code to avoid silent thread termination.


## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->

- [ ] New unit tests added.
- [ ] New integration tests added.
- [ ] Modified or extended existing tests.
- [ ] Verified backward compatibility (if applicable).

## Does this PR introduce any user-facing or breaking changes?
<!--  
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [ ] No. You can skip the rest of this section.
- [ ] Yes. Clearly explain the behavior change and its impact.