### PR TITLE
[server][dvc] Remove unused parameter 'storeConfig' in RocksDBStoragePartition

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/store/AbstractStorageEngine.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/store/AbstractStorageEngine.java
@@ -433,15 +433,6 @@ public abstract class AbstractStorageEngine<Partition extends AbstractStoragePar
     }
   }
 
-  /**
-   * Create snapshot for the given partition
-   * @param storagePartitionConfig
-   */
-  public synchronized void createSnapshot(StoragePartitionConfig storagePartitionConfig) {
-    AbstractStoragePartition partition = getPartitionOrThrow(storagePartitionConfig.getPartitionId());
-    partition.createSnapshot();
-  }
-
   private void executeWithSafeGuard(int partitionId, Runnable runnable) {
     executeWithSafeGuard(partitionId, () -> {
       runnable.run();

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/store/rocksdb/ReplicationMetadataRocksDBStoragePartition.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/store/rocksdb/ReplicationMetadataRocksDBStoragePartition.java
@@ -3,7 +3,6 @@ package com.linkedin.davinci.store.rocksdb;
 import static com.linkedin.davinci.store.rocksdb.RocksDBSstFileWriter.DEFAULT_COLUMN_FAMILY_INDEX;
 import static com.linkedin.davinci.store.rocksdb.RocksDBSstFileWriter.REPLICATION_METADATA_COLUMN_FAMILY_INDEX;
 
-import com.linkedin.davinci.config.VeniceStoreVersionConfig;
 import com.linkedin.davinci.stats.RocksDBMemoryStats;
 import com.linkedin.davinci.store.StoragePartitionConfig;
 import com.linkedin.venice.exceptions.VeniceException;
@@ -40,8 +39,7 @@ public class ReplicationMetadataRocksDBStoragePartition extends RocksDBStoragePa
       String dbDir,
       RocksDBMemoryStats rocksDBMemoryStats,
       RocksDBThrottler rocksDbThrottler,
-      RocksDBServerConfig rocksDBServerConfig,
-      VeniceStoreVersionConfig storeConfig) {
+      RocksDBServerConfig rocksDBServerConfig) {
     super(
         storagePartitionConfig,
         factory,
@@ -49,8 +47,7 @@ public class ReplicationMetadataRocksDBStoragePartition extends RocksDBStoragePa
         rocksDBMemoryStats,
         rocksDbThrottler,
         rocksDBServerConfig,
-        Arrays.asList(RocksDB.DEFAULT_COLUMN_FAMILY, REPLICATION_METADATA_COLUMN_FAMILY),
-        storeConfig);
+        Arrays.asList(RocksDB.DEFAULT_COLUMN_FAMILY, REPLICATION_METADATA_COLUMN_FAMILY));
     this.fullPathForTempSSTFileDir = RocksDBUtils.composeTempRMDSSTFileDir(dbDir, storeNameAndVersion, partitionId);
     if (deferredWrite) {
       this.rocksDBSstFileWriter = new RocksDBSstFileWriter(

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/store/rocksdb/RocksDBStorageEngine.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/store/rocksdb/RocksDBStorageEngine.java
@@ -136,8 +136,7 @@ public class RocksDBStorageEngine extends AbstractStorageEngine<RocksDBStoragePa
           rocksDbPath,
           memoryStats,
           rocksDbThrottler,
-          rocksDBServerConfig,
-          storeConfig);
+          rocksDBServerConfig);
     } else {
       return new ReplicationMetadataRocksDBStoragePartition(
           storagePartitionConfig,
@@ -145,8 +144,7 @@ public class RocksDBStorageEngine extends AbstractStorageEngine<RocksDBStoragePa
           rocksDbPath,
           memoryStats,
           rocksDbThrottler,
-          rocksDBServerConfig,
-          storeConfig);
+          rocksDBServerConfig);
     }
   }
 

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/store/rocksdb/RocksDBStoragePartition.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/store/rocksdb/RocksDBStoragePartition.java
@@ -5,7 +5,6 @@ import static org.rocksdb.TickerType.COMPACTION_KEY_DROP_NEWER_ENTRY;
 import static org.rocksdb.TickerType.COMPACTION_KEY_DROP_USER;
 
 import com.linkedin.davinci.callback.BytesStreamingCallback;
-import com.linkedin.davinci.config.VeniceStoreVersionConfig;
 import com.linkedin.davinci.stats.RocksDBMemoryStats;
 import com.linkedin.davinci.store.AbstractStorageIterator;
 import com.linkedin.davinci.store.AbstractStoragePartition;
@@ -93,7 +92,6 @@ public class RocksDBStoragePartition extends AbstractStoragePartition {
   protected final String storeName;
   protected final String storeNameAndVersion;
   protected final int storeVersion;
-  protected final boolean blobTransferEnabled;
   protected final int partitionId;
   private final String fullPathForPartitionDB;
 
@@ -169,8 +167,7 @@ public class RocksDBStoragePartition extends AbstractStoragePartition {
       RocksDBMemoryStats rocksDBMemoryStats,
       RocksDBThrottler rocksDbThrottler,
       RocksDBServerConfig rocksDBServerConfig,
-      List<byte[]> columnFamilyNameList,
-      VeniceStoreVersionConfig storeConfig) {
+      List<byte[]> columnFamilyNameList) {
     super(storagePartitionConfig.getPartitionId());
     this.factory = factory;
     this.rocksDBServerConfig = rocksDBServerConfig;
@@ -180,7 +177,6 @@ public class RocksDBStoragePartition extends AbstractStoragePartition {
     this.partitionId = storagePartitionConfig.getPartitionId();
     this.replicaId = Utils.getReplicaId(storagePartitionConfig.getStoreName(), partitionId);
     this.aggStatistics = factory.getAggStatistics();
-    this.blobTransferEnabled = storeConfig.isBlobTransferEnabled();
 
     // If writing to offset metadata partition METADATA_PARTITION_ID enable WAL write to sync up offset on server
     // restart,
@@ -217,8 +213,7 @@ public class RocksDBStoragePartition extends AbstractStoragePartition {
     this.expectedChecksumSupplier = Optional.empty();
     this.rocksDBThrottler = rocksDbThrottler;
     this.fullPathForTempSSTFileDir = RocksDBUtils.composeTempSSTFileDir(dbDir, storeNameAndVersion, partitionId);
-    this.fullPathForPartitionDBSnapshot =
-        blobTransferEnabled ? RocksDBUtils.composeSnapshotDir(dbDir, storeNameAndVersion, partitionId) : null;
+    this.fullPathForPartitionDBSnapshot = RocksDBUtils.composeSnapshotDir(dbDir, storeNameAndVersion, partitionId);
 
     if (deferredWrite) {
       this.rocksDBSstFileWriter = new RocksDBSstFileWriter(
@@ -291,8 +286,7 @@ public class RocksDBStoragePartition extends AbstractStoragePartition {
       String dbDir,
       RocksDBMemoryStats rocksDBMemoryStats,
       RocksDBThrottler rocksDbThrottler,
-      RocksDBServerConfig rocksDBServerConfig,
-      VeniceStoreVersionConfig storeConfig) {
+      RocksDBServerConfig rocksDBServerConfig) {
     // If not specified, RocksDB inserts values into DEFAULT_COLUMN_FAMILY.
     this(
         storagePartitionConfig,
@@ -301,8 +295,7 @@ public class RocksDBStoragePartition extends AbstractStoragePartition {
         rocksDBMemoryStats,
         rocksDbThrottler,
         rocksDBServerConfig,
-        Collections.singletonList(RocksDB.DEFAULT_COLUMN_FAMILY),
-        storeConfig);
+        Collections.singletonList(RocksDB.DEFAULT_COLUMN_FAMILY));
   }
 
   private void checkMemoryLimit(long memoryLimit, SstFileManager sstFileManager, String dbPath) {
@@ -355,10 +348,6 @@ public class RocksDBStoragePartition extends AbstractStoragePartition {
 
   protected EnvOptions getEnvOptions() {
     return envOptions;
-  }
-
-  protected Boolean getBlobTransferEnabled() {
-    return blobTransferEnabled;
   }
 
   protected Options getStoreOptions(StoragePartitionConfig storagePartitionConfig, boolean isRMD) {
@@ -518,9 +507,7 @@ public class RocksDBStoragePartition extends AbstractStoragePartition {
 
   @Override
   public synchronized void createSnapshot() {
-    if (blobTransferEnabled) {
-      createSnapshot(rocksDB, fullPathForPartitionDBSnapshot);
-    }
+    createSnapshot(rocksDB, fullPathForPartitionDBSnapshot);
   }
 
   @Override

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTaskTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTaskTest.java
@@ -1030,7 +1030,6 @@ public abstract class StoreIngestionTaskTest {
     } else {
       mockDeepCopyStorageEngine = spy(new DeepCopyStorageEngine(mockAbstractStorageEngine));
       doReturn(mockDeepCopyStorageEngine).when(mockStorageEngineRepository).getLocalStorageEngine(topic);
-      doNothing().when(mockDeepCopyStorageEngine).createSnapshot(any());
     }
 
     inMemoryLocalKafkaConsumer =

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/store/rocksdb/ReplicationMetadataRocksDBStoragePartitionTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/store/rocksdb/ReplicationMetadataRocksDBStoragePartitionTest.java
@@ -179,8 +179,7 @@ public class ReplicationMetadataRocksDBStoragePartitionTest extends AbstractStor
         DATA_BASE_DIR,
         null,
         ROCKSDB_THROTTLER,
-        rocksDBServerConfig,
-        storeConfig);
+        rocksDBServerConfig);
 
     Map<String, Pair<String, String>> inputRecords = generateInputWithMetadata(100);
     for (Map.Entry<String, Pair<String, String>> entry: inputRecords.entrySet()) {
@@ -312,8 +311,7 @@ public class ReplicationMetadataRocksDBStoragePartitionTest extends AbstractStor
         DATA_BASE_DIR,
         null,
         ROCKSDB_THROTTLER,
-        rocksDBServerConfig,
-        storeConfig);
+        rocksDBServerConfig);
 
     final int syncPerRecords = 100;
     final int interruptedRecord = 345;
@@ -371,8 +369,7 @@ public class ReplicationMetadataRocksDBStoragePartitionTest extends AbstractStor
                 DATA_BASE_DIR,
                 null,
                 ROCKSDB_THROTTLER,
-                rocksDBServerConfig,
-                storeConfig);
+                rocksDBServerConfig);
             Options storeOptions = storagePartition.getOptions();
             Assert.assertEquals(storeOptions.level0FileNumCompactionTrigger(), 100);
           }
@@ -444,8 +441,7 @@ public class ReplicationMetadataRocksDBStoragePartitionTest extends AbstractStor
         DATA_BASE_DIR,
         null,
         ROCKSDB_THROTTLER,
-        rocksDBServerConfig,
-        storeConfig);
+        rocksDBServerConfig);
     // Test deletion
     String toBeDeletedKey = KEY_PREFIX + 10;
     Assert.assertNotNull(storagePartition.get(toBeDeletedKey.getBytes()));

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/store/rocksdb/RocksDBStoragePartitionTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/store/rocksdb/RocksDBStoragePartitionTest.java
@@ -170,8 +170,7 @@ public class RocksDBStoragePartitionTest {
         DATA_BASE_DIR,
         null,
         ROCKSDB_THROTTLER,
-        rocksDBServerConfig,
-        storeConfig);
+        rocksDBServerConfig);
     // Insert the first 300 [0, 300) entries with blob db disabled
     for (int i = 0; i < 300; i++) {
       storagePartition.put(largeEntryList.get(i).getKey().getBytes(), largeEntryList.get(i).getValue().getBytes());
@@ -196,8 +195,7 @@ public class RocksDBStoragePartitionTest {
         DATA_BASE_DIR,
         null,
         ROCKSDB_THROTTLER,
-        rocksDBServerConfig,
-        storeConfig);
+        rocksDBServerConfig);
     // Insert [300, 700) entries with blob db enabled
     for (int i = 300; i < 700; i++) {
       storagePartition.put(largeEntryList.get(i).getKey().getBytes(), largeEntryList.get(i).getValue().getBytes());
@@ -238,8 +236,7 @@ public class RocksDBStoragePartitionTest {
         DATA_BASE_DIR,
         null,
         ROCKSDB_THROTTLER,
-        rocksDBServerConfig,
-        storeConfig);
+        rocksDBServerConfig);
     // Insert [700, 1000) entries with blob db enabled
     for (int i = 700; i < 1000; i++) {
       storagePartition.put(largeEntryList.get(i).getKey().getBytes(), largeEntryList.get(i).getValue().getBytes());
@@ -308,8 +305,7 @@ public class RocksDBStoragePartitionTest {
         DATA_BASE_DIR,
         null,
         ROCKSDB_THROTTLER,
-        rocksDBServerConfig,
-        storeConfig);
+        rocksDBServerConfig);
     final int syncPerRecords = 100;
     final int interruptedRecord = 345;
 
@@ -355,8 +351,7 @@ public class RocksDBStoragePartitionTest {
                 DATA_BASE_DIR,
                 null,
                 ROCKSDB_THROTTLER,
-                rocksDBServerConfig,
-                storeConfig);
+                rocksDBServerConfig);
             Options storeOptions = storagePartition.getOptions();
             Assert.assertEquals(storeOptions.level0FileNumCompactionTrigger(), 100);
           }
@@ -433,8 +428,7 @@ public class RocksDBStoragePartitionTest {
         DATA_BASE_DIR,
         null,
         ROCKSDB_THROTTLER,
-        rocksDBServerConfig,
-        storeConfig);
+        rocksDBServerConfig);
 
     // Test deletion
     String toBeDeletedKey = KEY_PREFIX + 10;
@@ -476,8 +470,7 @@ public class RocksDBStoragePartitionTest {
         DATA_BASE_DIR,
         null,
         ROCKSDB_THROTTLER,
-        rocksDBServerConfig,
-        storeConfig);
+        rocksDBServerConfig);
     final int syncPerRecords = 100;
     final int interruptedRecord1 = 345;
     final int interruptedRecord2 = 645;
@@ -516,8 +509,7 @@ public class RocksDBStoragePartitionTest {
             DATA_BASE_DIR,
             null,
             ROCKSDB_THROTTLER,
-            rocksDBServerConfig,
-            storeConfig);
+            rocksDBServerConfig);
         Options storeOptions = storagePartition.getOptions();
         Assert.assertEquals(storeOptions.level0FileNumCompactionTrigger(), 100);
         if (sorted) {
@@ -571,8 +563,7 @@ public class RocksDBStoragePartitionTest {
         DATA_BASE_DIR,
         null,
         ROCKSDB_THROTTLER,
-        rocksDBServerConfig,
-        storeConfig);
+        rocksDBServerConfig);
 
     storagePartition.rocksDB.compactRange();
 
@@ -655,8 +646,7 @@ public class RocksDBStoragePartitionTest {
         DATA_BASE_DIR,
         null,
         ROCKSDB_THROTTLER,
-        rocksDBServerConfig,
-        storeConfig);
+        rocksDBServerConfig);
     final int syncPerRecords = 100;
     final int interruptedRecord = 345;
 
@@ -701,8 +691,7 @@ public class RocksDBStoragePartitionTest {
                 DATA_BASE_DIR,
                 null,
                 ROCKSDB_THROTTLER,
-                rocksDBServerConfig,
-                storeConfig);
+                rocksDBServerConfig);
             Options storeOptions = storagePartition.getOptions();
             Assert.assertEquals(storeOptions.level0FileNumCompactionTrigger(), 100);
           }
@@ -758,8 +747,7 @@ public class RocksDBStoragePartitionTest {
         DATA_BASE_DIR,
         null,
         ROCKSDB_THROTTLER,
-        rocksDBServerConfig,
-        storeConfig);
+        rocksDBServerConfig);
     // Test deletion
     String toBeDeletedKey = KEY_PREFIX + 10;
     Assert.assertNotNull(storagePartition.get(toBeDeletedKey.getBytes()));
@@ -792,8 +780,7 @@ public class RocksDBStoragePartitionTest {
         DATA_BASE_DIR,
         null,
         ROCKSDB_THROTTLER,
-        rocksDBServerConfig,
-        storeConfig);
+        rocksDBServerConfig);
 
     Optional<Supplier<byte[]>> checksumSupplier = Optional.of(() -> new byte[16]);
     storagePartition.beginBatchWrite(new HashMap<>(), checksumSupplier);
@@ -828,8 +815,7 @@ public class RocksDBStoragePartitionTest {
         DATA_BASE_DIR,
         null,
         ROCKSDB_THROTTLER,
-        rocksDBServerConfig,
-        storeConfig);
+        rocksDBServerConfig);
 
     storagePartition.close();
     try {
@@ -867,8 +853,7 @@ public class RocksDBStoragePartitionTest {
         DATA_BASE_DIR,
         null,
         ROCKSDB_THROTTLER,
-        rocksDBServerConfig,
-        storeConfig);
+        rocksDBServerConfig);
 
     StoragePartitionConfig testConfig = new StoragePartitionConfig(storeName, partitionId);
     testConfig.setReadWriteLeaderForRMDCF(true);
@@ -898,8 +883,7 @@ public class RocksDBStoragePartitionTest {
         DATA_BASE_DIR,
         null,
         ROCKSDB_THROTTLER,
-        rocksDBServerConfig,
-        storeConfig);
+        rocksDBServerConfig);
 
     testConfig = new StoragePartitionConfig(storeName, partitionId);
     testConfig.setReadWriteLeaderForRMDCF(true);
@@ -948,8 +932,7 @@ public class RocksDBStoragePartitionTest {
         DATA_BASE_DIR,
         null,
         ROCKSDB_THROTTLER,
-        rocksDBServerConfig,
-        storeConfig);
+        rocksDBServerConfig);
 
     // By default, it is write only
     Options writeOnlyOptions = storagePartition.getOptions();
@@ -970,8 +953,7 @@ public class RocksDBStoragePartitionTest {
         DATA_BASE_DIR,
         null,
         ROCKSDB_THROTTLER,
-        rocksDBServerConfig,
-        storeConfig);
+        rocksDBServerConfig);
     Options readWriteOptions = storagePartition.getOptions();
     Assert.assertEquals(readWriteOptions.level0FileNumCompactionTrigger(), 10);
     Assert.assertEquals(readWriteOptions.level0SlowdownWritesTrigger(), 20);
@@ -1046,8 +1028,7 @@ public class RocksDBStoragePartitionTest {
           DATA_BASE_DIR,
           null,
           ROCKSDB_THROTTLER,
-          rocksDBServerConfig,
-          storeConfig);
+          rocksDBServerConfig);
       RocksDBStoragePartition finalStoragePartition = storagePartition;
       Assert.expectThrows(MemoryLimitExhaustedException.class, () -> {
         String keyPrefix = "key_prefix_";
@@ -1088,8 +1069,7 @@ public class RocksDBStoragePartitionTest {
               DATA_BASE_DIR,
               null,
               ROCKSDB_THROTTLER,
-              finalRocksDBServerConfig,
-              storeConfig));
+              finalRocksDBServerConfig));
     } finally {
       if (storagePartition != null) {
         storagePartition.close();
@@ -1099,8 +1079,8 @@ public class RocksDBStoragePartitionTest {
     }
   }
 
-  @Test(dataProviderClass = DataProviderUtils.class, dataProvider = "True-and-False")
-  public void testCreateSnapshot(boolean blobTransferEnabled) {
+  @Test
+  public void testCreateSnapshot() {
     String storeName = Version.composeKafkaTopic(Utils.getUniqueString("test_store"), 1);
     String storeDir = getTempDatabaseDir(storeName);
     int partitionId = 0;
@@ -1116,17 +1096,13 @@ public class RocksDBStoragePartitionTest {
     RocksDBStorageEngineFactory factory = new RocksDBStorageEngineFactory(serverConfig);
     VeniceStoreVersionConfig storeConfig = new VeniceStoreVersionConfig(storeName, veniceServerProperties);
 
-    // Set the blob transfer enabled flag
-    storeConfig.setBlobTransferEnabled(blobTransferEnabled);
-
     RocksDBStoragePartition storagePartition = new RocksDBStoragePartition(
         partitionConfig,
         factory,
         DATA_BASE_DIR,
         null,
         ROCKSDB_THROTTLER,
-        rocksDBServerConfig,
-        storeConfig);
+        rocksDBServerConfig);
 
     try (MockedStatic<RocksDBStoragePartition> rocksDBStoragePartition =
         Mockito.mockStatic(RocksDBStoragePartition.class)) {
@@ -1135,13 +1111,9 @@ public class RocksDBStoragePartitionTest {
             return null;
           });
       storagePartition.createSnapshot();
-      if (blobTransferEnabled) {
-        rocksDBStoragePartition
-            .verify(() -> RocksDBStoragePartition.createSnapshot(Mockito.any(), Mockito.any()), Mockito.times(1));
-      } else {
-        rocksDBStoragePartition
-            .verify(() -> RocksDBStoragePartition.createSnapshot(Mockito.any(), Mockito.any()), Mockito.never());
-      }
+
+      rocksDBStoragePartition
+          .verify(() -> RocksDBStoragePartition.createSnapshot(Mockito.any(), Mockito.any()), Mockito.times(1));
     }
 
     if (storagePartition != null) {
@@ -1258,8 +1230,7 @@ public class RocksDBStoragePartitionTest {
         DATA_BASE_DIR,
         null,
         ROCKSDB_THROTTLER,
-        rocksDBServerConfig,
-        storeConfig);
+        rocksDBServerConfig);
 
     // DiskLimitExhaustedException
     try {

--- a/internal/venice-test-common/src/jmh/java/com/linkedin/venice/benchmark/ReplicationConsumptionBenchmark.java
+++ b/internal/venice-test-common/src/jmh/java/com/linkedin/venice/benchmark/ReplicationConsumptionBenchmark.java
@@ -102,8 +102,7 @@ public class ReplicationConsumptionBenchmark {
         DATA_BASE_DIR,
         null,
         ROCKSDB_THROTTLER,
-        rocksDBServerConfig,
-        storeConfig);
+        rocksDBServerConfig);
     syncPerRecords = 10000;
 
     // JMH benchmark relies on System.exit to finish one round of benchmark run, otherwise it will hang there.
@@ -165,8 +164,7 @@ public class ReplicationConsumptionBenchmark {
         DATA_BASE_DIR,
         null,
         ROCKSDB_THROTTLER,
-        rocksDBServerConfig,
-        storeConfig);
+        rocksDBServerConfig);
     // Test deletion
     String toBeDeletedKey = KEY_PREFIX + 10;
     storagePartition.delete(toBeDeletedKey.getBytes());

--- a/internal/venice-test-common/src/jmh/java/com/linkedin/venice/benchmark/RocksDBLookupApiBenchmark.java
+++ b/internal/venice-test-common/src/jmh/java/com/linkedin/venice/benchmark/RocksDBLookupApiBenchmark.java
@@ -116,8 +116,7 @@ public class RocksDBLookupApiBenchmark {
         DATA_BASE_DIR,
         null,
         new RocksDBThrottler(3),
-        new RocksDBServerConfig(veniceServerProperties),
-        storeConfig);
+        new RocksDBServerConfig(veniceServerProperties));
 
     // Populate the database
     for (int i = 0; i < ROW_CNT; ++i) {


### PR DESCRIPTION
<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat], [protocol]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## Problem Statement
In the previous code logic, when creating a snapshot in RocksDBStoragePartition, there was a double-check to confirm if the store config still had blob transfer enabled:

> this.blobTransferEnabled = storeConfig.isBlobTransferEnabled();
if (blobTransferEnabled) { 
    createSnapshot(rocksDB, fullPathForPartitionDBSnapshot); 
}

However, this double-check is unnecessary because the `createSnapshot` method in RocksDBStoragePartition is only invoked by the BlobSnapshotManager upon receiving a blob transfer request.

A store will only begin the blob transfer process if it is both store-version level enabled for blob transfer and cluster-level enabled, as seen in `DefaultIngestionBackend#startConsumption` with `bootstrapFromBlobs`.

Thus, adding a double-check at the server side (snapshot manager) is redundant.

## Solution
1. Remove the blobTransferEnabled flag in RocksDBStoragePartition.
2. Due to blobTransferEnabled is removed, the parameter storeConfig in RocksDBStoragePartition will never be called. therefore, remove storeConfig parameter as well. 

<!--
Describe
- What changes you are making and why. 
- How these changes solve the problem.
- Any performance considerations or trade-offs. 
- Describe what testings you have done, for example, performance testing etc.
-->


###  Code changes
- [ ] Added new code behind **a config**. If so list the config names and their default values in the PR description.
- [ ] Introduced new **log lines**. 
  - [ ] Confirmed if logs need to be **rate limited** to avoid excessive logging.

###  **Concurrency-Specific Checks**
Both reviewer and PR author to verify
- [ ] Code has **no race conditions** or **thread safety issues**.
- [ ] Proper **synchronization mechanisms** (e.g., `synchronized`, `RWLock`) are used where needed.
- [ ] No **blocking calls** inside critical sections that could lead to deadlocks or performance degradation.
- [ ] Verified **thread-safe collections** are used (e.g., `ConcurrentHashMap`, `CopyOnWriteArrayList`).
- [ ] Validated proper exception handling in multi-threaded code to avoid silent thread termination.


## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->

- [ ] New unit tests added.
- [ ] New integration tests added.
- [ ] Modified or extended existing tests.
- [ ] Verified backward compatibility (if applicable).

## Does this PR introduce any user-facing or breaking changes?
<!--  
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [ ] No. You can skip the rest of this section.
- [ ] Yes. Clearly explain the behavior change and its impact.