### PR TITLE
[controller] Fix getAdminOperationVersionFromControllers to skip standby controllers when no found

### DIFF
--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/controller/TestAdminOperationVersionDetection.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/controller/TestAdminOperationVersionDetection.java
@@ -26,7 +26,8 @@ public class TestAdminOperationVersionDetection {
   private static final int TEST_TIMEOUT = 30 * Time.MS_PER_SECOND;
   private static final int NUMBER_OF_CHILD_DATACENTERS = 2;
   private static final int NUMBER_OF_CLUSTERS = 1;
-  private static final int NUMBER_OF_CONTROLLERS = 2;
+  private static final int NUMBER_OF_PARENT_CONTROLLERS = 2;
+  private static final int NUMBER_OF_CHILD_CONTROLLERS = 1;
 
   private VeniceTwoLayerMultiRegionMultiClusterWrapper multiRegionMultiClusterWrapper;
   private static final String[] CLUSTER_NAMES =
@@ -45,8 +46,8 @@ public class TestAdminOperationVersionDetection {
     VeniceMultiRegionClusterCreateOptions.Builder optionsBuilder =
         new VeniceMultiRegionClusterCreateOptions.Builder().numberOfRegions(NUMBER_OF_CHILD_DATACENTERS)
             .numberOfClusters(NUMBER_OF_CLUSTERS)
-            .numberOfParentControllers(NUMBER_OF_CONTROLLERS)
-            .numberOfChildControllers(NUMBER_OF_CONTROLLERS)
+            .numberOfParentControllers(NUMBER_OF_PARENT_CONTROLLERS)
+            .numberOfChildControllers(NUMBER_OF_CHILD_CONTROLLERS)
             .numberOfServers(1)
             .numberOfRouters(1)
             .replicationFactor(1)
@@ -82,7 +83,7 @@ public class TestAdminOperationVersionDetection {
     assertEquals(response.getCluster(), clusterName);
   }
 
-  @Test(timeOut = TEST_TIMEOUT)
+  @Test(timeOut = TEST_TIMEOUT * 2)
   public void testAdminOperationVersionForChildControllers() {
     String clusterName = CLUSTER_NAMES[0]; // "venice-cluster0"
 
@@ -102,7 +103,10 @@ public class TestAdminOperationVersionDetection {
         response.getLocalAdminOperationProtocolVersion(),
         AdminOperationSerializer.LATEST_SCHEMA_ID_FOR_ADMIN_OPERATION);
     Map<String, Long> controllerNameToVersionMap = response.getControllerNameToVersionMap();
-    assertEquals(controllerNameToVersionMap.size(), 2);
+    // Child controller only have one controller, no standby controller, so the size should be 1.
+    // We will skip standby controllers if we cannot find standby controller in Helix.
+    // If we increase NUMBER_OF_CHILD_CONTROLLERS = 2, then the size will be 2.
+    assertEquals(controllerNameToVersionMap.size(), 1);
     assertEquals(response.getCluster(), clusterName);
   }
 }

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceHelixAdmin.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceHelixAdmin.java
@@ -7801,7 +7801,12 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
         getSslFactory());
 
     // Get version for standby controllers
-    List<Instance> standbyControllers = getControllersByHelixState(clusterName, HelixState.STANDBY_STATE);
+    List<Instance> standbyControllers = new ArrayList<>();
+    try {
+      standbyControllers = getControllersByHelixState(clusterName, HelixState.STANDBY_STATE);
+    } catch (VeniceException e) {
+      LOGGER.warn("No standby controllers found for cluster: {}. Error: {}", clusterName, e.getMessage());
+    }
 
     for (Instance standbyController: standbyControllers) {
       // In production, leader and standby share the secure port but have different hostnames—no conflict.


### PR DESCRIPTION
## Problem Statement

In `ProtocolVersionAutoDetectionService`, we try to broadcast the request to get local admin protocol version from leader controller to standby controller so that when there is standby-> leader transition, the leader will always be able to understand the message inside the admin topic queue. 

However, when testing, we found a new corner case that the leader actually has no standby. Then, the task of ProtocolVersionAutoDetectionService keeps failing. 

## Solution
In case we cannot find standby controller from external view, we should continue and finish the task instead of failing the task. Hence, we will log the no found error and continue finishing the request.

I put the logic to find standby controllers inside the try-catch only (not the whole for loop below) since I think we should fail the task in case there is issue with broadcasting the request. 

###  Code changes
- [ ] Added new code behind **a config**. If so list the config names and their default values in the PR description.
- [x] Introduced new **log lines**. 
  - [x] Confirmed if logs need to be **rate limited** to avoid excessive logging.

###  **Concurrency-Specific Checks**
Both reviewer and PR author to verify
- [x] Code has **no race conditions** or **thread safety issues**.
- [x] Proper **synchronization mechanisms** (e.g., `synchronized`, `RWLock`) are used where needed.
- [x] No **blocking calls** inside critical sections that could lead to deadlocks or performance degradation.
- [x] Verified **thread-safe collections** are used (e.g., `ConcurrentHashMap`, `CopyOnWriteArrayList`).
- [x] Validated proper exception handling in multi-threaded code to avoid silent thread termination.


## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->

- [x] New unit tests added.
- [ ] New integration tests added.
- [x] Modified or extended existing tests.
- [ ] Verified backward compatibility (if applicable).

## Does this PR introduce any user-facing or breaking changes?
<!--  
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Clearly explain the behavior change and its impact.