### PR TITLE
[server] Delete ignored upstream RT offset tracking from PCS

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/ActiveActiveStoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/ActiveActiveStoreIngestionTask.java
@@ -1191,9 +1191,9 @@ public class ActiveActiveStoreIngestionTask extends LeaderFollowerStoreIngestion
   }
 
   /**
-   * For A/A, there are multiple entries in upstreamOffsetMap during RT ingestion.
-   * If the current DataReplicationPolicy is on Aggregate mode, A/A will check the upstream offset lags from all regions;
-   * otherwise, only check the upstream offset lag from the local region.
+   * Returns the latest processed upstream real-time offset for the given region.
+   * This is used to compute hybrid offset lag on a per-region basis, which is then
+   * used in conjunction with lag from other regions to determine ready-to-serve status.
    */
   @Override
   protected long getLatestPersistedUpstreamOffsetForHybridOffsetLagMeasurement(
@@ -1322,9 +1322,6 @@ public class ActiveActiveStoreIngestionTask extends LeaderFollowerStoreIngestion
   }
 
   /**
-   * For stores in aggregate mode this is optimistic and returns the minimum lag of all fabric. This is because in
-   * aggregate mode duplicate msg consumption happen from all fabric. So it should be fine to consider the lowest lag.
-   *
    * For stores in active/active mode, if no fabric is unreachable, return the maximum lag of all fabrics. If only one
    * fabric is unreachable, return the maximum lag of other fabrics. If more than one fabrics are unreachable, return
    * Long.MAX_VALUE, which means the partition is not ready-to-serve.
@@ -1332,7 +1329,6 @@ public class ActiveActiveStoreIngestionTask extends LeaderFollowerStoreIngestion
    * unreachable fabric and make the decision. For example, we should not let partition ready-to-serve when the only
    * source fabric is unreachable.
    *
-   * In non-aggregate mode of consumption only return the local fabric lag
    * @param sourceRealTimeTopicKafkaURLs
    * @param partitionConsumptionState
    * @param shouldLogLag

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/ActiveActiveStoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/ActiveActiveStoreIngestionTask.java
@@ -539,9 +539,6 @@ public class ActiveActiveStoreIngestionTask extends LeaderFollowerStoreIngestion
 
     if (mergeConflictResult.isUpdateIgnored()) {
       hostLevelIngestionStats.recordUpdateIgnoredDCR();
-      // Record the last ignored offset
-      partitionConsumptionState
-          .updateLatestIgnoredUpstreamRTOffset(kafkaClusterIdToUrlMap.get(kafkaClusterId), sourceOffset);
       return new PubSubMessageProcessedResult(
           new MergeConflictResultWrapper(
               mergeConflictResult,
@@ -907,34 +904,6 @@ public class ActiveActiveStoreIngestionTask extends LeaderFollowerStoreIngestion
   }
 
   @Override
-  protected void produceToLocalKafka(
-      DefaultPubSubMessage consumerRecord,
-      PartitionConsumptionState partitionConsumptionState,
-      LeaderProducedRecordContext leaderProducedRecordContext,
-      BiConsumer<ChunkAwareCallback, LeaderMetadataWrapper> produceFunction,
-      int partition,
-      String kafkaUrl,
-      int kafkaClusterId,
-      long beforeProcessingRecordTimestampNs) {
-    super.produceToLocalKafka(
-        consumerRecord,
-        partitionConsumptionState,
-        leaderProducedRecordContext,
-        produceFunction,
-        partition,
-        kafkaUrl,
-        kafkaClusterId,
-        beforeProcessingRecordTimestampNs);
-    // Update the partition consumption state to say that we've transmitted the message to kafka (but haven't
-    // necessarily received an ack back yet).
-    if (partitionConsumptionState.getLeaderFollowerState() == LEADER && partitionConsumptionState.isHybrid()
-        && consumerRecord.getTopicPartition().getPubSubTopic().isRealTime()) {
-      partitionConsumptionState
-          .updateLatestRTOffsetTriedToProduceToVTMap(kafkaUrl, consumerRecord.getPosition().getNumericOffset());
-    }
-  }
-
-  @Override
   protected Map<String, Long> calculateLeaderUpstreamOffsetWithTopicSwitch(
       PartitionConsumptionState partitionConsumptionState,
       PubSubTopic newSourceTopic,
@@ -1230,7 +1199,7 @@ public class ActiveActiveStoreIngestionTask extends LeaderFollowerStoreIngestion
   protected long getLatestPersistedUpstreamOffsetForHybridOffsetLagMeasurement(
       PartitionConsumptionState pcs,
       String upstreamKafkaUrl) {
-    return pcs.getLatestProcessedUpstreamRTOffsetWithIgnoredMessages(upstreamKafkaUrl);
+    return pcs.getLatestProcessedUpstreamRTOffset(upstreamKafkaUrl);
   }
 
   /**

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/PartitionConsumptionState.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/PartitionConsumptionState.java
@@ -198,18 +198,6 @@ public class PartitionConsumptionState {
   private long latestProcessedUpstreamVersionTopicOffset;
 
   /**
-   * This keeps track of those offsets which have been screened during conflict resolution. This needs to be kept
-   * separate from the drainers notion of per colo offsets because the ingestion task will screen offsets at a higher
-   * offset then those which have been drained.  This is used for determining the lag of a leader consumer relative
-   * to a source topic when the latest messages have been consumed but not applied due to certain writes not getting
-   * applied after losing on conflict resolution to a pre-existing/conflicting write.
-   *
-   * key: source Kafka url
-   * value: Latest ignored upstream RT offset
-   */
-  private final Map<String, Long> latestIgnoredUpstreamRTOffsetMap;
-
-  /**
    * This keeps track of the latest RT offsets from a specific broker which have been produced to VT. When a message
    * is consumed out of RT it can be produced to VT but not yet committed to local storage for the leader.  We only
    * commit a message to a drainer queue after we've produced to the local VT.  This map tracks what messages have been
@@ -275,9 +263,6 @@ public class PartitionConsumptionState {
     this.latestProcessedUpstreamVersionTopicOffset = offsetRecord.getCheckpointUpstreamVersionTopicOffset();
     this.leaderHostId = offsetRecord.getLeaderHostId();
     this.leaderGUID = offsetRecord.getLeaderGUID();
-    // We don't restore ignored offsets from the persisted offset record today. Doing so would only be useful
-    // if it was useful to skip ahead through a large number of dropped offsets at the start of consumption.
-    this.latestIgnoredUpstreamRTOffsetMap = new HashMap<>();
     // On start, we haven't sent anything
     this.latestRTOffsetTriedToProduceToVTMap = new HashMap<>();
     this.lastVTProduceCallFuture = CompletableFuture.completedFuture(null);
@@ -419,8 +404,6 @@ public class PartitionConsumptionState {
         .append(latestProcessedUpstreamVersionTopicOffset)
         .append(", latestProcessedUpstreamRTOffsetMap=")
         .append(latestProcessedUpstreamRTOffsetMap)
-        .append(", latestIgnoredUpstreamRTOffsetMap=")
-        .append(latestIgnoredUpstreamRTOffsetMap)
         .append(", latestRTOffsetTriedToProduceToVTMap")
         .append(latestRTOffsetTriedToProduceToVTMap)
         .append(", offsetRecord=")
@@ -738,48 +721,6 @@ public class PartitionConsumptionState {
 
   public void updateLatestProcessedUpstreamRTOffset(String kafkaUrl, long offset) {
     latestProcessedUpstreamRTOffsetMap.put(kafkaUrl, offset);
-  }
-
-  public void updateLatestRTOffsetTriedToProduceToVTMap(String kafkaUrl, long offset) {
-    latestRTOffsetTriedToProduceToVTMap.put(kafkaUrl, offset);
-  }
-
-  public long getLatestRTOffsetTriedToProduceToVTMap(String kafkaUrl) {
-    return latestRTOffsetTriedToProduceToVTMap.getOrDefault(kafkaUrl, -1L);
-  }
-
-  public void updateLatestIgnoredUpstreamRTOffset(String kafkaUrl, long offset) {
-    latestIgnoredUpstreamRTOffsetMap.put(kafkaUrl, offset);
-  }
-
-  public long getLatestIgnoredUpstreamRTOffset(String kafkaUrl) {
-    return latestIgnoredUpstreamRTOffsetMap.getOrDefault(kafkaUrl, -1L);
-  }
-
-  public long getLatestProcessedUpstreamRTOffsetWithIgnoredMessages(String kafkaUrl) {
-    long lastOffsetFullyProcessed = getLatestProcessedUpstreamRTOffset(kafkaUrl);
-    long lastOffsetIgnored = getLatestIgnoredUpstreamRTOffset(kafkaUrl);
-    long offsetTriedToProduceToVT = getLatestRTOffsetTriedToProduceToVTMap(kafkaUrl);
-
-    // we've committed messages at a higher offset then the last thing we ignored. Return the processed offset
-    if (lastOffsetFullyProcessed >= lastOffsetIgnored) {
-      return lastOffsetFullyProcessed;
-    }
-
-    // We have messages which have been ignored at a higher offset then what we've processed but we still have committed
-    // all messages to local storage that we've produced to upstream VT. In this case, return the ignored offset as the
-    // highest offset. Technically speaking, processed should never be 'greater' then produced, it can at most be
-    // 'equal',
-    // but we'll include the broader comparison as it's still technically correct.
-    if (lastOffsetFullyProcessed >= offsetTriedToProduceToVT) {
-      return lastOffsetIgnored;
-    }
-
-    // We have messages that we're still waiting to commit, though the most recent messages we've ignored (probably
-    // after failing a comparison against record in the transient record cache). In this case we'll return the offset
-    // of what's been processed
-    return lastOffsetFullyProcessed;
-
   }
 
   public long getLatestProcessedUpstreamRTOffset(String kafkaUrl) {

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
@@ -1241,8 +1241,6 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
       long beforeProcessingPerRecordTimestampNs = System.nanoTime();
       partitionConsumptionState.setLatestPolledMessageTimestampInMs(beforeProcessingBatchRecordsTimestampMs);
       if (!shouldProcessRecord(record)) {
-        partitionConsumptionState
-            .updateLatestIgnoredUpstreamRTOffset(kafkaUrl, record.getPosition().getNumericOffset());
         continue;
       }
 
@@ -1307,10 +1305,6 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
         partitionConsumptionState.setLatestPolledMessageTimestampInMs(beforeProcessingBatchRecordsTimestampMs);
       }
       if (!shouldProcessRecord(record)) {
-        if (partitionConsumptionState != null) {
-          partitionConsumptionState
-              .updateLatestIgnoredUpstreamRTOffset(kafkaUrl, record.getPosition().getNumericOffset());
-        }
         continue;
       }
       waitReadyToProcessRecord(record);


### PR DESCRIPTION
## Delete ignored upstream RT offset tracking from PCS  

Remove tracking of ignored upstream RT offsets from PartitionConsumptionState (PCS).  
This was previously used to compute lag when a leader ignored messages and there was  
no guarantee of future data. Now that heartbeat messages ensure continuous traffic,  
this mechanism is no longer needed and can be safely removed to simplify the code.  




###  Code changes
- [ ] Added new code behind **a config**. If so list the config names and their default values in the PR description.
- [ ] Introduced new **log lines**. 
  - [ ] Confirmed if logs need to be **rate limited** to avoid excessive logging.

###  **Concurrency-Specific Checks**
Both reviewer and PR author to verify
- [ ] Code has **no race conditions** or **thread safety issues**.
- [ ] Proper **synchronization mechanisms** (e.g., `synchronized`, `RWLock`) are used where needed.
- [ ] No **blocking calls** inside critical sections that could lead to deadlocks or performance degradation.
- [ ] Verified **thread-safe collections** are used (e.g., `ConcurrentHashMap`, `CopyOnWriteArrayList`).
- [ ] Validated proper exception handling in multi-threaded code to avoid silent thread termination.


## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->

- [ ] New unit tests added.
- [ ] New integration tests added.
- [ ] Modified or extended existing tests.
- [ ] Verified backward compatibility (if applicable).

## Does this PR introduce any user-facing or breaking changes?
<!--  
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [ ] No. You can skip the rest of this section.
- [ ] Yes. Clearly explain the behavior change and its impact.