### PR TITLE
[server] Add time lag threshold support for fast server restart

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -325,7 +325,7 @@ subprojects {
     doFirst {
       def versionOverrides = [
 //        project(':internal:venice-common').file('src/main/resources/avro/StoreVersionState/v5', PathValidation.DIRECTORY)
-          project(':internal:venice-common').file('src/main/resources/avro/PartitionState/v17', PathValidation.DIRECTORY),
+//          project(':internal:venice-common').file('src/main/resources/avro/PartitionState/v17', PathValidation.DIRECTORY),
           project(':services:venice-controller').file('src/main/resources/avro/AdminOperation/v89', PathValidation.DIRECTORY),
           project(':internal:venice-common').file('src/main/resources/avro/StoreMetaValue/v34', PathValidation.DIRECTORY)
       ]

--- a/build.gradle
+++ b/build.gradle
@@ -324,8 +324,6 @@ subprojects {
 
     doFirst {
       def versionOverrides = [
-//        project(':internal:venice-common').file('src/main/resources/avro/StoreVersionState/v5', PathValidation.DIRECTORY)
-//          project(':internal:venice-common').file('src/main/resources/avro/PartitionState/v17', PathValidation.DIRECTORY),
           project(':services:venice-controller').file('src/main/resources/avro/AdminOperation/v89', PathValidation.DIRECTORY),
           project(':internal:venice-common').file('src/main/resources/avro/StoreMetaValue/v34', PathValidation.DIRECTORY)
       ]

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/config/VeniceServerConfig.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/config/VeniceServerConfig.java
@@ -34,6 +34,7 @@ import static com.linkedin.venice.ConfigKeys.FAST_AVRO_FIELD_LIMIT_PER_METHOD;
 import static com.linkedin.venice.ConfigKeys.FREEZE_INGESTION_IF_READY_TO_SERVE_OR_LOCAL_DATA_EXISTS;
 import static com.linkedin.venice.ConfigKeys.GRPC_READ_SERVER_PORT;
 import static com.linkedin.venice.ConfigKeys.GRPC_SERVER_WORKER_THREAD_COUNT;
+import static com.linkedin.venice.ConfigKeys.HEARTBEAT_LAG_THRESHOLD_FOR_FAST_ONLINE_TRANSITION_IN_RESTART;
 import static com.linkedin.venice.ConfigKeys.HELIX_HYBRID_STORE_QUOTA_ENABLED;
 import static com.linkedin.venice.ConfigKeys.HYBRID_QUOTA_ENFORCEMENT_ENABLED;
 import static com.linkedin.venice.ConfigKeys.IDENTITY_PARSER_CLASS;
@@ -487,6 +488,7 @@ public class VeniceServerConfig extends VeniceClusterConfig {
 
   private final long sharedConsumerNonExistingTopicCleanupDelayMS;
   private final int offsetLagDeltaRelaxFactorForFastOnlineTransitionInRestart;
+  private final long heartbeatLagThresholdForFastOnlineTransitionInRestart;
 
   /**
    * Boolean flag indicating if it is a Da Vinci application.
@@ -890,6 +892,9 @@ public class VeniceServerConfig extends VeniceClusterConfig {
 
     offsetLagDeltaRelaxFactorForFastOnlineTransitionInRestart =
         serverProperties.getInt(OFFSET_LAG_DELTA_RELAX_FACTOR_FOR_FAST_ONLINE_TRANSITION_IN_RESTART, 2);
+    heartbeatLagThresholdForFastOnlineTransitionInRestart =
+        serverProperties.getInt(HEARTBEAT_LAG_THRESHOLD_FOR_FAST_ONLINE_TRANSITION_IN_RESTART, -1);
+
     enableKafkaConsumerOffsetCollection =
         serverProperties.getBoolean(SERVER_KAFKA_CONSUMER_OFFSET_COLLECTION_ENABLED, true);
     dedicatedDrainerQueueEnabled =
@@ -1574,6 +1579,10 @@ public class VeniceServerConfig extends VeniceClusterConfig {
 
   public int getOffsetLagDeltaRelaxFactorForFastOnlineTransitionInRestart() {
     return offsetLagDeltaRelaxFactorForFastOnlineTransitionInRestart;
+  }
+
+  public long getHeartbeatLagThresholdForFastOnlineTransitionInRestart() {
+    return heartbeatLagThresholdForFastOnlineTransitionInRestart;
   }
 
   public boolean isKafkaConsumerOffsetCollectionEnabled() {

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/config/VeniceServerConfig.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/config/VeniceServerConfig.java
@@ -204,7 +204,7 @@ import static com.linkedin.venice.ConfigKeys.STORE_WRITER_BUFFER_NOTIFY_DELTA;
 import static com.linkedin.venice.ConfigKeys.STORE_WRITER_NUMBER;
 import static com.linkedin.venice.ConfigKeys.SYSTEM_SCHEMA_CLUSTER_NAME;
 import static com.linkedin.venice.ConfigKeys.SYSTEM_SCHEMA_INITIALIZATION_AT_START_TIME_ENABLED;
-import static com.linkedin.venice.ConfigKeys.TIME_LAG_THRESHOLD_FOR_FAST_ONLINE_TRANSITION_IN_RESTART;
+import static com.linkedin.venice.ConfigKeys.TIME_LAG_THRESHOLD_FOR_FAST_ONLINE_TRANSITION_IN_RESTART_MINUTES;
 import static com.linkedin.venice.ConfigKeys.UNREGISTER_METRIC_FOR_DELETED_STORE_ENABLED;
 import static com.linkedin.venice.ConfigKeys.UNSORTED_INPUT_DRAINER_SIZE;
 import static com.linkedin.venice.ConfigKeys.USE_DA_VINCI_SPECIFIC_EXECUTION_STATUS_FOR_ERROR;
@@ -488,7 +488,7 @@ public class VeniceServerConfig extends VeniceClusterConfig {
 
   private final long sharedConsumerNonExistingTopicCleanupDelayMS;
   private final int offsetLagDeltaRelaxFactorForFastOnlineTransitionInRestart;
-  private final long timeLagThresholdForFastOnlineTransitionInRestart;
+  private final int timeLagThresholdForFastOnlineTransitionInRestartMinutes;
 
   /**
    * Boolean flag indicating if it is a Da Vinci application.
@@ -892,8 +892,8 @@ public class VeniceServerConfig extends VeniceClusterConfig {
 
     offsetLagDeltaRelaxFactorForFastOnlineTransitionInRestart =
         serverProperties.getInt(OFFSET_LAG_DELTA_RELAX_FACTOR_FOR_FAST_ONLINE_TRANSITION_IN_RESTART, 2);
-    timeLagThresholdForFastOnlineTransitionInRestart =
-        serverProperties.getInt(TIME_LAG_THRESHOLD_FOR_FAST_ONLINE_TRANSITION_IN_RESTART, -1);
+    timeLagThresholdForFastOnlineTransitionInRestartMinutes =
+        serverProperties.getInt(TIME_LAG_THRESHOLD_FOR_FAST_ONLINE_TRANSITION_IN_RESTART_MINUTES, -1);
 
     enableKafkaConsumerOffsetCollection =
         serverProperties.getBoolean(SERVER_KAFKA_CONSUMER_OFFSET_COLLECTION_ENABLED, true);
@@ -1581,8 +1581,8 @@ public class VeniceServerConfig extends VeniceClusterConfig {
     return offsetLagDeltaRelaxFactorForFastOnlineTransitionInRestart;
   }
 
-  public long getTimeLagThresholdForFastOnlineTransitionInRestart() {
-    return timeLagThresholdForFastOnlineTransitionInRestart;
+  public int getTimeLagThresholdForFastOnlineTransitionInRestartMinutes() {
+    return timeLagThresholdForFastOnlineTransitionInRestartMinutes;
   }
 
   public boolean isKafkaConsumerOffsetCollectionEnabled() {

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/config/VeniceServerConfig.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/config/VeniceServerConfig.java
@@ -34,7 +34,6 @@ import static com.linkedin.venice.ConfigKeys.FAST_AVRO_FIELD_LIMIT_PER_METHOD;
 import static com.linkedin.venice.ConfigKeys.FREEZE_INGESTION_IF_READY_TO_SERVE_OR_LOCAL_DATA_EXISTS;
 import static com.linkedin.venice.ConfigKeys.GRPC_READ_SERVER_PORT;
 import static com.linkedin.venice.ConfigKeys.GRPC_SERVER_WORKER_THREAD_COUNT;
-import static com.linkedin.venice.ConfigKeys.HEARTBEAT_LAG_THRESHOLD_FOR_FAST_ONLINE_TRANSITION_IN_RESTART;
 import static com.linkedin.venice.ConfigKeys.HELIX_HYBRID_STORE_QUOTA_ENABLED;
 import static com.linkedin.venice.ConfigKeys.HYBRID_QUOTA_ENFORCEMENT_ENABLED;
 import static com.linkedin.venice.ConfigKeys.IDENTITY_PARSER_CLASS;
@@ -205,6 +204,7 @@ import static com.linkedin.venice.ConfigKeys.STORE_WRITER_BUFFER_NOTIFY_DELTA;
 import static com.linkedin.venice.ConfigKeys.STORE_WRITER_NUMBER;
 import static com.linkedin.venice.ConfigKeys.SYSTEM_SCHEMA_CLUSTER_NAME;
 import static com.linkedin.venice.ConfigKeys.SYSTEM_SCHEMA_INITIALIZATION_AT_START_TIME_ENABLED;
+import static com.linkedin.venice.ConfigKeys.TIME_LAG_THRESHOLD_FOR_FAST_ONLINE_TRANSITION_IN_RESTART;
 import static com.linkedin.venice.ConfigKeys.UNREGISTER_METRIC_FOR_DELETED_STORE_ENABLED;
 import static com.linkedin.venice.ConfigKeys.UNSORTED_INPUT_DRAINER_SIZE;
 import static com.linkedin.venice.ConfigKeys.USE_DA_VINCI_SPECIFIC_EXECUTION_STATUS_FOR_ERROR;
@@ -488,7 +488,7 @@ public class VeniceServerConfig extends VeniceClusterConfig {
 
   private final long sharedConsumerNonExistingTopicCleanupDelayMS;
   private final int offsetLagDeltaRelaxFactorForFastOnlineTransitionInRestart;
-  private final long heartbeatLagThresholdForFastOnlineTransitionInRestart;
+  private final long timeLagThresholdForFastOnlineTransitionInRestart;
 
   /**
    * Boolean flag indicating if it is a Da Vinci application.
@@ -892,8 +892,8 @@ public class VeniceServerConfig extends VeniceClusterConfig {
 
     offsetLagDeltaRelaxFactorForFastOnlineTransitionInRestart =
         serverProperties.getInt(OFFSET_LAG_DELTA_RELAX_FACTOR_FOR_FAST_ONLINE_TRANSITION_IN_RESTART, 2);
-    heartbeatLagThresholdForFastOnlineTransitionInRestart =
-        serverProperties.getInt(HEARTBEAT_LAG_THRESHOLD_FOR_FAST_ONLINE_TRANSITION_IN_RESTART, -1);
+    timeLagThresholdForFastOnlineTransitionInRestart =
+        serverProperties.getInt(TIME_LAG_THRESHOLD_FOR_FAST_ONLINE_TRANSITION_IN_RESTART, -1);
 
     enableKafkaConsumerOffsetCollection =
         serverProperties.getBoolean(SERVER_KAFKA_CONSUMER_OFFSET_COLLECTION_ENABLED, true);
@@ -1581,8 +1581,8 @@ public class VeniceServerConfig extends VeniceClusterConfig {
     return offsetLagDeltaRelaxFactorForFastOnlineTransitionInRestart;
   }
 
-  public long getHeartbeatLagThresholdForFastOnlineTransitionInRestart() {
-    return heartbeatLagThresholdForFastOnlineTransitionInRestart;
+  public long getTimeLagThresholdForFastOnlineTransitionInRestart() {
+    return timeLagThresholdForFastOnlineTransitionInRestart;
   }
 
   public boolean isKafkaConsumerOffsetCollectionEnabled() {

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTask.java
@@ -1771,12 +1771,33 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
 
   @Override
   protected long measureHybridHeartbeatLag(PartitionConsumptionState partitionConsumptionState, boolean shouldLogLag) {
+    // Da Vinci does not have heartbeat monitoring service.
+    if (isDaVinciClient()) {
+      return Long.MAX_VALUE;
+    }
     if (partitionConsumptionState.getLeaderFollowerState().equals(LEADER)) {
       return getHeartbeatMonitoringService()
           .getReplicaLeaderMaxHeartbeatLag(partitionConsumptionState, storeName, versionNumber, shouldLogLag);
     } else {
       return getHeartbeatMonitoringService()
           .getReplicaFollowerHeartbeatLag(partitionConsumptionState, storeName, versionNumber, shouldLogLag);
+    }
+  }
+
+  @Override
+  protected long measureHybridHeartbeatTimestamp(
+      PartitionConsumptionState partitionConsumptionState,
+      boolean shouldLogLag) {
+    // Da Vinci does not have heartbeat monitoring service.
+    if (isDaVinciClient()) {
+      return 0;
+    }
+    if (partitionConsumptionState.getLeaderFollowerState().equals(LEADER)) {
+      return getHeartbeatMonitoringService()
+          .getReplicaLeaderMinHeartbeatTimestamp(partitionConsumptionState, storeName, versionNumber, shouldLogLag);
+    } else {
+      return getHeartbeatMonitoringService()
+          .getReplicaFollowerHeartbeatTimestamp(partitionConsumptionState, storeName, versionNumber, shouldLogLag);
     }
   }
 

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/PartitionConsumptionState.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/PartitionConsumptionState.java
@@ -624,7 +624,7 @@ public class PartitionConsumptionState {
   }
 
   public boolean getReadyToServeInOffsetRecord() {
-    return offsetRecord.getPreviousStatusesEntry(PREVIOUSLY_READY_TO_SERVE).equals(TRUE);
+    return TRUE.equals(offsetRecord.getPreviousStatusesEntry(PREVIOUSLY_READY_TO_SERVE));
   }
 
   /**

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/PartitionConsumptionState.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/PartitionConsumptionState.java
@@ -1,5 +1,7 @@
 package com.linkedin.davinci.kafka.consumer;
 
+import static java.util.concurrent.TimeUnit.MINUTES;
+
 import com.linkedin.davinci.helix.LeaderFollowerPartitionStateModel;
 import com.linkedin.davinci.utils.ByteArrayKey;
 import com.linkedin.venice.kafka.protocol.GUID;
@@ -36,6 +38,7 @@ import org.apache.avro.generic.GenericRecord;
  */
 public class PartitionConsumptionState {
   private static final int MAX_INCREMENTAL_PUSH_ENTRY_NUM = 50;
+  private static final long DEFAULT_HEARTBEAT_LAG_THRESHOLD_MS = MINUTES.toMillis(2); // Default is 2 minutes.
   private static final String PREVIOUSLY_READY_TO_SERVE = "previouslyReadyToServe";
   private static final String TRUE = "true";
 
@@ -213,6 +216,8 @@ public class PartitionConsumptionState {
   private volatile Lazy<VeniceWriter<byte[], byte[], byte[]>> veniceWriterLazyRef;
 
   private BooleanSupplier isCurrentVersion;
+
+  private long readyToServeTimeLagThreshold = DEFAULT_HEARTBEAT_LAG_THRESHOLD_MS;
 
   public PartitionConsumptionState(
       String replicaId,
@@ -863,5 +868,13 @@ public class PartitionConsumptionState {
 
   public PubSubContext getPubSubContext() {
     return pubSubContext;
+  }
+
+  public long getReadyToServeTimeLagThreshold() {
+    return readyToServeTimeLagThreshold;
+  }
+
+  public void setReadyToServeTimeLagThreshold(long readyToServeTimeLagThreshold) {
+    this.readyToServeTimeLagThreshold = readyToServeTimeLagThreshold;
   }
 }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/PartitionConsumptionState.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/PartitionConsumptionState.java
@@ -217,7 +217,7 @@ public class PartitionConsumptionState {
 
   private BooleanSupplier isCurrentVersion;
 
-  private long readyToServeTimeLagThreshold = DEFAULT_HEARTBEAT_LAG_THRESHOLD_MS;
+  private long readyToServeTimeLagThresholdInMs = DEFAULT_HEARTBEAT_LAG_THRESHOLD_MS;
 
   public PartitionConsumptionState(
       String replicaId,
@@ -870,11 +870,11 @@ public class PartitionConsumptionState {
     return pubSubContext;
   }
 
-  public long getReadyToServeTimeLagThreshold() {
-    return readyToServeTimeLagThreshold;
+  public long getReadyToServeTimeLagThresholdInMs() {
+    return readyToServeTimeLagThresholdInMs;
   }
 
-  public void setReadyToServeTimeLagThreshold(long readyToServeTimeLagThreshold) {
-    this.readyToServeTimeLagThreshold = readyToServeTimeLagThreshold;
+  public void setReadyToServeTimeLagThresholdInMs(long readyToServeTimeLagThresholdInMs) {
+    this.readyToServeTimeLagThresholdInMs = readyToServeTimeLagThresholdInMs;
   }
 }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
@@ -2175,8 +2175,9 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
       newPartitionConsumptionState.getOffsetRecord()
           .setHeartbeatTimestamp(HeartbeatMonitoringService.INVALID_HEARTBEAT_TIMESTAMP);
       newPartitionConsumptionState.getOffsetRecord().setOffsetLag(OffsetRecord.DEFAULT_OFFSET_LAG);
+      // This ready-to-serve check is acceptable in SIT thread as it happens before subscription.
       if (!isCompletedReport) {
-        getReadyToServeChecker().apply(newPartitionConsumptionState);
+        getDefaultReadyToServeChecker().apply(newPartitionConsumptionState);
       }
     } catch (VeniceInconsistentStoreMetadataException e) {
       hostLevelIngestionStats.recordInconsistentStoreMetadata();
@@ -4830,10 +4831,6 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
 
   boolean isDaVinciClient() {
     return isDaVinciClient;
-  }
-
-  ReadyToServeCheck getReadyToServeChecker() {
-    return defaultReadyToServeChecker;
   }
 
   VeniceConcurrentHashMap<String, Long> getConsumedBytesSinceLastSync() {

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
@@ -2886,6 +2886,7 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
     ps.getOffsetRecord().setOffsetLag(measureHybridOffsetLag(ps, false));
     // Measure and save real-time heartbeat timestamp.
     ps.getOffsetRecord().setHeartbeatTimestamp(measureHybridHeartbeatTimestamp(ps, false));
+    ps.getOffsetRecord().setLastCheckpointTimestamp(System.currentTimeMillis());
   }
 
   void setIngestionException(int partitionId, Exception e) {

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/ingestion/heartbeat/HeartbeatMonitoringService.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/ingestion/heartbeat/HeartbeatMonitoringService.java
@@ -54,6 +54,8 @@ public class HeartbeatMonitoringService extends AbstractVeniceService {
   public static final int DEFAULT_REPORTER_THREAD_SLEEP_INTERVAL_SECONDS = 60;
   public static final int DEFAULT_LAG_LOGGING_THREAD_SLEEP_INTERVAL_SECONDS = 60;
   public static final long DEFAULT_STALE_HEARTBEAT_LOG_THRESHOLD_MILLIS = TimeUnit.MINUTES.toMillis(10);
+  public static final long INVALID_HEARTBEAT_TIMESTAMP = 0;
+  public static final long INVALID_HEARTBEAT_LAG = Long.MAX_VALUE;
 
   private static final Logger LOGGER = LogManager.getLogger(HeartbeatMonitoringService.class);
   private static final int DEFAULT_LAG_MONITOR_CLEANUP_CYCLE = 5;
@@ -373,13 +375,82 @@ public class HeartbeatMonitoringService extends AbstractVeniceService {
 
   /**
    * Get maximum heartbeat lag from all regions (except separate RT regions) for a given LEADER replica.
-   * @return Max leader heartbeat lag, or Long.MAX_VALUE if any region's heartbeat is unknown.
+   * @return Max leader heartbeat lag, or {@link #INVALID_HEARTBEAT_LAG} if any region's heartbeat is unknown.
    */
   public long getReplicaLeaderMaxHeartbeatLag(
       PartitionConsumptionState partitionConsumptionState,
       String storeName,
       int version,
       boolean shouldLogLag) {
+    return getReplicaLeaderMaxHeartbeatLag(
+        partitionConsumptionState,
+        storeName,
+        version,
+        shouldLogLag,
+        System.currentTimeMillis());
+  }
+
+  /**
+   * Get minimum heartbeat timestamp from all regions (except separate RT regions) for a given LEADER replica.
+   * @return Min leader heartbeat timestamp, or {@link #INVALID_HEARTBEAT_TIMESTAMP} if any region's heartbeat is unknown.
+   */
+  public long getReplicaLeaderMinHeartbeatTimestamp(
+      PartitionConsumptionState partitionConsumptionState,
+      String storeName,
+      int version,
+      boolean shouldLogLag) {
+    // Use a fixed timestamp so there is no value overflow.
+    long currentTimestamp = System.currentTimeMillis();
+    long lag =
+        getReplicaLeaderMaxHeartbeatLag(partitionConsumptionState, storeName, version, shouldLogLag, currentTimestamp);
+    if (lag == Long.MAX_VALUE) {
+      return INVALID_HEARTBEAT_TIMESTAMP;
+    } else {
+      return currentTimestamp - lag;
+    }
+  }
+
+  /**
+   * Get heartbeat lag from local region for a given FOLLOWER replica.
+   * @return Follower heartbeat lag, or {@link #INVALID_HEARTBEAT_LAG} if local region's heartbeat is unknown.
+   */
+  public long getReplicaFollowerHeartbeatLag(
+      PartitionConsumptionState partitionConsumptionState,
+      String storeName,
+      int version,
+      boolean shouldLogLag) {
+    return getReplicaFollowerHeartbeatLag(
+        partitionConsumptionState,
+        storeName,
+        version,
+        shouldLogLag,
+        System.currentTimeMillis());
+  }
+
+  /**
+   * Get heartbeat timestamp from local region for a given FOLLOWER replica.
+   * @return Follower heartbeat timestamp, or {@link #INVALID_HEARTBEAT_TIMESTAMP} if local region's heartbeat is unknown.
+   */
+  public long getReplicaFollowerHeartbeatTimestamp(
+      PartitionConsumptionState partitionConsumptionState,
+      String storeName,
+      int version,
+      boolean shouldLogLag) {
+    long currentTimestamp = System.currentTimeMillis();
+    long lag =
+        getReplicaFollowerHeartbeatLag(partitionConsumptionState, storeName, version, shouldLogLag, currentTimestamp);
+    if (lag == INVALID_HEARTBEAT_LAG) {
+      return INVALID_HEARTBEAT_TIMESTAMP;
+    }
+    return currentTimestamp - lag;
+  }
+
+  long getReplicaLeaderMaxHeartbeatLag(
+      PartitionConsumptionState partitionConsumptionState,
+      String storeName,
+      int version,
+      boolean shouldLogLag,
+      long currentTimestamp) {
     Map<String, HeartbeatTimeStampEntry> replicaTimestampMap =
         getLeaderHeartbeatTimeStamps().getOrDefault(storeName, Collections.emptyMap())
             .getOrDefault(version, Collections.emptyMap())
@@ -390,7 +461,6 @@ public class HeartbeatMonitoringService extends AbstractVeniceService {
       }
       return Long.MAX_VALUE;
     }
-    long currentTimestamp = System.currentTimeMillis();
     long maxLag = 0;
     /**
      * When initializing A/A leader lag entry, we will initialize towards all available regions, so scanning this map
@@ -424,15 +494,12 @@ public class HeartbeatMonitoringService extends AbstractVeniceService {
     return maxLag;
   }
 
-  /**
-   * Get maximum heartbeat lag from local region for a given FOLLOWER replica.
-   * @return Follower heartbeat lag, or Long.MAX_VALUE if local region's heartbeat is unknown.
-   */
-  public long getReplicaFollowerHeartbeatLag(
+  long getReplicaFollowerHeartbeatLag(
       PartitionConsumptionState partitionConsumptionState,
       String storeName,
       int version,
-      boolean shouldLogLag) {
+      boolean shouldLogLag,
+      long currentTimestamp) {
     HeartbeatTimeStampEntry followerReplicaTimestamp =
         getFollowerHeartbeatTimeStamps().getOrDefault(storeName, Collections.emptyMap())
             .getOrDefault(version, Collections.emptyMap())
@@ -452,7 +519,7 @@ public class HeartbeatMonitoringService extends AbstractVeniceService {
       }
       return Long.MAX_VALUE;
     }
-    long heartbeatLag = System.currentTimeMillis() - followerReplicaTimestamp.timestamp;
+    long heartbeatLag = currentTimestamp - followerReplicaTimestamp.timestamp;
     if (shouldLogLag) {
       LOGGER.info(
           "Replica: {} has follower heartbeat lag: {}ms from local region.",

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/ingestion/heartbeat/HeartbeatMonitoringService.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/ingestion/heartbeat/HeartbeatMonitoringService.java
@@ -54,7 +54,7 @@ public class HeartbeatMonitoringService extends AbstractVeniceService {
   public static final int DEFAULT_REPORTER_THREAD_SLEEP_INTERVAL_SECONDS = 60;
   public static final int DEFAULT_LAG_LOGGING_THREAD_SLEEP_INTERVAL_SECONDS = 60;
   public static final long DEFAULT_STALE_HEARTBEAT_LOG_THRESHOLD_MILLIS = TimeUnit.MINUTES.toMillis(10);
-  public static final long INVALID_HEARTBEAT_TIMESTAMP = 0;
+  public static final long INVALID_MESSAGE_TIMESTAMP = 0;
   public static final long INVALID_HEARTBEAT_LAG = Long.MAX_VALUE;
 
   private static final Logger LOGGER = LogManager.getLogger(HeartbeatMonitoringService.class);
@@ -392,7 +392,7 @@ public class HeartbeatMonitoringService extends AbstractVeniceService {
 
   /**
    * Get minimum heartbeat timestamp from all regions (except separate RT regions) for a given LEADER replica.
-   * @return Min leader heartbeat timestamp, or {@link #INVALID_HEARTBEAT_TIMESTAMP} if any region's heartbeat is unknown.
+   * @return Min leader heartbeat timestamp, or {@link #INVALID_MESSAGE_TIMESTAMP} if any region's heartbeat is unknown.
    */
   public long getReplicaLeaderMinHeartbeatTimestamp(
       PartitionConsumptionState partitionConsumptionState,
@@ -404,7 +404,7 @@ public class HeartbeatMonitoringService extends AbstractVeniceService {
     long lag =
         getReplicaLeaderMaxHeartbeatLag(partitionConsumptionState, storeName, version, shouldLogLag, currentTimestamp);
     if (lag == Long.MAX_VALUE) {
-      return INVALID_HEARTBEAT_TIMESTAMP;
+      return INVALID_MESSAGE_TIMESTAMP;
     } else {
       return currentTimestamp - lag;
     }
@@ -429,7 +429,7 @@ public class HeartbeatMonitoringService extends AbstractVeniceService {
 
   /**
    * Get heartbeat timestamp from local region for a given FOLLOWER replica.
-   * @return Follower heartbeat timestamp, or {@link #INVALID_HEARTBEAT_TIMESTAMP} if local region's heartbeat is unknown.
+   * @return Follower heartbeat timestamp, or {@link #INVALID_MESSAGE_TIMESTAMP} if local region's heartbeat is unknown.
    */
   public long getReplicaFollowerHeartbeatTimestamp(
       PartitionConsumptionState partitionConsumptionState,
@@ -440,7 +440,7 @@ public class HeartbeatMonitoringService extends AbstractVeniceService {
     long lag =
         getReplicaFollowerHeartbeatLag(partitionConsumptionState, storeName, version, shouldLogLag, currentTimestamp);
     if (lag == INVALID_HEARTBEAT_LAG) {
-      return INVALID_HEARTBEAT_TIMESTAMP;
+      return INVALID_MESSAGE_TIMESTAMP;
     }
     return currentTimestamp - lag;
   }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/ingestion/heartbeat/HeartbeatMonitoringService.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/ingestion/heartbeat/HeartbeatMonitoringService.java
@@ -54,7 +54,7 @@ public class HeartbeatMonitoringService extends AbstractVeniceService {
   public static final int DEFAULT_REPORTER_THREAD_SLEEP_INTERVAL_SECONDS = 60;
   public static final int DEFAULT_LAG_LOGGING_THREAD_SLEEP_INTERVAL_SECONDS = 60;
   public static final long DEFAULT_STALE_HEARTBEAT_LOG_THRESHOLD_MILLIS = TimeUnit.MINUTES.toMillis(10);
-  public static final long INVALID_MESSAGE_TIMESTAMP = 0;
+  public static final long INVALID_MESSAGE_TIMESTAMP = -1;
   public static final long INVALID_HEARTBEAT_LAG = Long.MAX_VALUE;
 
   private static final Logger LOGGER = LogManager.getLogger(HeartbeatMonitoringService.class);

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/SITFastReadyToServeTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/SITFastReadyToServeTest.java
@@ -1,0 +1,141 @@
+package com.linkedin.davinci.kafka.consumer;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doCallRealMethod;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import com.linkedin.davinci.config.VeniceServerConfig;
+import com.linkedin.venice.meta.BufferReplayPolicy;
+import com.linkedin.venice.meta.HybridStoreConfig;
+import com.linkedin.venice.meta.HybridStoreConfigImpl;
+import com.linkedin.venice.offsets.OffsetRecord;
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+import org.testng.annotations.Test;
+
+
+public class SITFastReadyToServeTest {
+  @Test
+  public void testReadyToServeWithHeartbeatLag() {
+    StoreIngestionTask storeIngestionTask = mock(StoreIngestionTask.class);
+    VeniceServerConfig serverConfig = mock(VeniceServerConfig.class);
+    doReturn(TimeUnit.MINUTES.toMillis(5)).when(serverConfig)
+        .getHeartbeatLagThresholdForFastOnlineTransitionInRestart();
+    doReturn(serverConfig).when(storeIngestionTask).getServerConfig();
+    OffsetRecord record = mock(OffsetRecord.class);
+    PartitionConsumptionState pcs = mock(PartitionConsumptionState.class);
+    doReturn(record).when(pcs).getOffsetRecord();
+    doReturn("test_v1-1").when(pcs).getReplicaId();
+    doCallRealMethod().when(storeIngestionTask).checkFastReadyToServeWithPreviousHeartbeatLag(any());
+
+    // Case 1: Prev HB timestamp is not preserved.
+    storeIngestionTask.checkFastReadyToServeWithPreviousHeartbeatLag(pcs);
+    verify(pcs, never()).lagHasCaughtUp();
+
+    // Case 2: Growth is within bound
+    long currentTimestamp = System.currentTimeMillis();
+    doReturn(currentTimestamp - TimeUnit.MINUTES.toMillis(1)).when(record).getLastCheckpointTimestamp();
+    doReturn(currentTimestamp - TimeUnit.MINUTES.toMillis(10)).when(record).getHeartbeatTimestamp();
+    storeIngestionTask.checkFastReadyToServeWithPreviousHeartbeatLag(pcs);
+    verify(pcs, times(1)).lagHasCaughtUp();
+
+    // Case 3: Growth is out of bound
+    doReturn(currentTimestamp - TimeUnit.MINUTES.toMillis(7)).when(record).getLastCheckpointTimestamp();
+    storeIngestionTask.checkFastReadyToServeWithPreviousHeartbeatLag(pcs);
+    verify(pcs, times(1)).lagHasCaughtUp();
+    verify(pcs, times(1)).setReadyToServeTimeLagThreshold(eq(TimeUnit.MINUTES.toMillis(3)));
+  }
+
+  @Test
+  public void testReadyToServeWithOffsetLag() {
+    StoreIngestionTask storeIngestionTask = mock(StoreIngestionTask.class);
+    VeniceServerConfig serverConfig = mock(VeniceServerConfig.class);
+    doReturn(2).when(serverConfig).getOffsetLagDeltaRelaxFactorForFastOnlineTransitionInRestart();
+    doReturn(serverConfig).when(storeIngestionTask).getServerConfig();
+    OffsetRecord record = mock(OffsetRecord.class);
+    PartitionConsumptionState pcs = mock(PartitionConsumptionState.class);
+    doReturn(record).when(pcs).getOffsetRecord();
+    doReturn("test_v1-1").when(pcs).getReplicaId();
+    doCallRealMethod().when(storeIngestionTask).checkFastReadyToServeWithPreviousOffsetLag(any());
+    HybridStoreConfig hybridStoreConfig =
+        new HybridStoreConfigImpl(100L, -100L, -1L, BufferReplayPolicy.REWIND_FROM_SOP);
+    doReturn(Optional.of(hybridStoreConfig)).when(storeIngestionTask).getHybridStoreConfig();
+    doReturn(1).when(storeIngestionTask).getPartitionCount();
+
+    // Case 1: Prev HB timestamp is not preserved.
+    storeIngestionTask.checkFastReadyToServeWithPreviousOffsetLag(pcs);
+    verify(pcs, never()).lagHasCaughtUp();
+
+    // Case 2: Growth is within bound
+    hybridStoreConfig.setOffsetLagThresholdToGoOnline(100);
+    doReturn(200L).when(storeIngestionTask).measureHybridOffsetLag(pcs, true);
+    doReturn(100L).when(record).getOffsetLag();
+    storeIngestionTask.checkFastReadyToServeWithPreviousOffsetLag(pcs);
+    verify(pcs, times(1)).lagHasCaughtUp();
+
+    // Case 3: Growth is out of bound
+    doReturn(400L).when(storeIngestionTask).measureHybridOffsetLag(pcs, true);
+    storeIngestionTask.checkFastReadyToServeWithPreviousOffsetLag(pcs);
+    verify(pcs, times(1)).lagHasCaughtUp();
+  }
+
+  @Test
+  public void testReadyToServeConfigBranch() {
+    StoreIngestionTask storeIngestionTask = mock(StoreIngestionTask.class);
+    VeniceServerConfig serverConfig = mock(VeniceServerConfig.class);
+    doReturn(2).when(serverConfig).getOffsetLagDeltaRelaxFactorForFastOnlineTransitionInRestart();
+    doReturn(serverConfig).when(storeIngestionTask).getServerConfig();
+    PartitionConsumptionState pcs = mock(PartitionConsumptionState.class);
+    doReturn("test_v1-1").when(pcs).getReplicaId();
+    doCallRealMethod().when(storeIngestionTask).checkFastReadyToServeForReplica(any());
+
+    // Case 1: Hybrid config invalid
+    doReturn(Optional.empty()).when(storeIngestionTask).getHybridStoreConfig();
+    storeIngestionTask.checkFastReadyToServeForReplica(pcs);
+    verify(storeIngestionTask, times(0)).checkFastReadyToServeWithPreviousHeartbeatLag(pcs);
+    verify(storeIngestionTask, times(0)).checkFastReadyToServeWithPreviousOffsetLag(pcs);
+
+    // Case 2: Previous not ready
+    doReturn(Optional.of(mock(HybridStoreConfig.class))).when(storeIngestionTask).getHybridStoreConfig();
+    doReturn(false).when(pcs).getReadyToServeInOffsetRecord();
+    storeIngestionTask.checkFastReadyToServeForReplica(pcs);
+    verify(storeIngestionTask, times(0)).checkFastReadyToServeWithPreviousHeartbeatLag(pcs);
+    verify(storeIngestionTask, times(0)).checkFastReadyToServeWithPreviousOffsetLag(pcs);
+
+    // Case 3: No fast-restart config enabled
+    doReturn(true).when(pcs).getReadyToServeInOffsetRecord();
+    doReturn(false).when(storeIngestionTask).isHeartbeatLagRelaxEnabled();
+    doReturn(false).when(serverConfig).isUseHeartbeatLagForReadyToServeCheckEnabled();
+    doReturn(false).when(storeIngestionTask).isOffsetLagDeltaRelaxEnabled();
+    storeIngestionTask.checkFastReadyToServeForReplica(pcs);
+    verify(storeIngestionTask, times(0)).checkFastReadyToServeWithPreviousHeartbeatLag(pcs);
+    verify(storeIngestionTask, times(0)).checkFastReadyToServeWithPreviousOffsetLag(pcs);
+
+    // Case 4: Lag fast-start config enabled
+    doReturn(true).when(storeIngestionTask).isHeartbeatLagRelaxEnabled();
+    doReturn(false).when(serverConfig).isUseHeartbeatLagForReadyToServeCheckEnabled();
+    doReturn(true).when(storeIngestionTask).isOffsetLagDeltaRelaxEnabled();
+    storeIngestionTask.checkFastReadyToServeForReplica(pcs);
+    verify(storeIngestionTask, times(0)).checkFastReadyToServeWithPreviousHeartbeatLag(pcs);
+    verify(storeIngestionTask, times(1)).checkFastReadyToServeWithPreviousOffsetLag(pcs);
+
+    // Case 5: Lag fast-start config enabled (cont.)
+    doReturn(false).when(storeIngestionTask).isHeartbeatLagRelaxEnabled();
+    doReturn(true).when(serverConfig).isUseHeartbeatLagForReadyToServeCheckEnabled();
+    storeIngestionTask.checkFastReadyToServeForReplica(pcs);
+    verify(storeIngestionTask, times(0)).checkFastReadyToServeWithPreviousHeartbeatLag(pcs);
+    verify(storeIngestionTask, times(2)).checkFastReadyToServeWithPreviousOffsetLag(pcs);
+
+    // Case 5: HB fast-start config enabled
+    doReturn(true).when(storeIngestionTask).isHeartbeatLagRelaxEnabled();
+    doReturn(true).when(serverConfig).isUseHeartbeatLagForReadyToServeCheckEnabled();
+    storeIngestionTask.checkFastReadyToServeForReplica(pcs);
+    verify(storeIngestionTask, times(1)).checkFastReadyToServeWithPreviousHeartbeatLag(pcs);
+    verify(storeIngestionTask, times(2)).checkFastReadyToServeWithPreviousOffsetLag(pcs);
+  }
+}

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/SITFastReadyToServeTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/SITFastReadyToServeTest.java
@@ -21,32 +21,31 @@ import org.testng.annotations.Test;
 
 public class SITFastReadyToServeTest {
   @Test
-  public void testReadyToServeWithHeartbeatLag() {
+  public void testReadyToServeWithMessageTimeLag() {
     StoreIngestionTask storeIngestionTask = mock(StoreIngestionTask.class);
     VeniceServerConfig serverConfig = mock(VeniceServerConfig.class);
-    doReturn(TimeUnit.MINUTES.toMillis(5)).when(serverConfig)
-        .getHeartbeatLagThresholdForFastOnlineTransitionInRestart();
+    doReturn(TimeUnit.MINUTES.toMillis(5)).when(serverConfig).getTimeLagThresholdForFastOnlineTransitionInRestart();
     doReturn(serverConfig).when(storeIngestionTask).getServerConfig();
     OffsetRecord record = mock(OffsetRecord.class);
     PartitionConsumptionState pcs = mock(PartitionConsumptionState.class);
     doReturn(record).when(pcs).getOffsetRecord();
     doReturn("test_v1-1").when(pcs).getReplicaId();
-    doCallRealMethod().when(storeIngestionTask).checkFastReadyToServeWithPreviousHeartbeatLag(any());
+    doCallRealMethod().when(storeIngestionTask).checkFastReadyToServeWithPreviousTimeLag(any());
 
     // Case 1: Prev HB timestamp is not preserved.
-    storeIngestionTask.checkFastReadyToServeWithPreviousHeartbeatLag(pcs);
+    storeIngestionTask.checkFastReadyToServeWithPreviousTimeLag(pcs);
     verify(pcs, never()).lagHasCaughtUp();
 
     // Case 2: Growth is within bound
     long currentTimestamp = System.currentTimeMillis();
     doReturn(currentTimestamp - TimeUnit.MINUTES.toMillis(1)).when(record).getLastCheckpointTimestamp();
     doReturn(currentTimestamp - TimeUnit.MINUTES.toMillis(10)).when(record).getHeartbeatTimestamp();
-    storeIngestionTask.checkFastReadyToServeWithPreviousHeartbeatLag(pcs);
+    storeIngestionTask.checkFastReadyToServeWithPreviousTimeLag(pcs);
     verify(pcs, times(1)).lagHasCaughtUp();
 
     // Case 3: Growth is out of bound
     doReturn(currentTimestamp - TimeUnit.MINUTES.toMillis(7)).when(record).getLastCheckpointTimestamp();
-    storeIngestionTask.checkFastReadyToServeWithPreviousHeartbeatLag(pcs);
+    storeIngestionTask.checkFastReadyToServeWithPreviousTimeLag(pcs);
     verify(pcs, times(1)).lagHasCaughtUp();
     verify(pcs, times(1)).setReadyToServeTimeLagThreshold(eq(TimeUnit.MINUTES.toMillis(3)));
   }
@@ -97,45 +96,45 @@ public class SITFastReadyToServeTest {
     // Case 1: Hybrid config invalid
     doReturn(Optional.empty()).when(storeIngestionTask).getHybridStoreConfig();
     storeIngestionTask.checkFastReadyToServeForReplica(pcs);
-    verify(storeIngestionTask, times(0)).checkFastReadyToServeWithPreviousHeartbeatLag(pcs);
+    verify(storeIngestionTask, times(0)).checkFastReadyToServeWithPreviousTimeLag(pcs);
     verify(storeIngestionTask, times(0)).checkFastReadyToServeWithPreviousOffsetLag(pcs);
 
     // Case 2: Previous not ready
     doReturn(Optional.of(mock(HybridStoreConfig.class))).when(storeIngestionTask).getHybridStoreConfig();
     doReturn(false).when(pcs).getReadyToServeInOffsetRecord();
     storeIngestionTask.checkFastReadyToServeForReplica(pcs);
-    verify(storeIngestionTask, times(0)).checkFastReadyToServeWithPreviousHeartbeatLag(pcs);
+    verify(storeIngestionTask, times(0)).checkFastReadyToServeWithPreviousTimeLag(pcs);
     verify(storeIngestionTask, times(0)).checkFastReadyToServeWithPreviousOffsetLag(pcs);
 
     // Case 3: No fast-restart config enabled
     doReturn(true).when(pcs).getReadyToServeInOffsetRecord();
-    doReturn(false).when(storeIngestionTask).isHeartbeatLagRelaxEnabled();
+    doReturn(false).when(storeIngestionTask).isTimeLagRelaxEnabled();
     doReturn(false).when(serverConfig).isUseHeartbeatLagForReadyToServeCheckEnabled();
     doReturn(false).when(storeIngestionTask).isOffsetLagDeltaRelaxEnabled();
     storeIngestionTask.checkFastReadyToServeForReplica(pcs);
-    verify(storeIngestionTask, times(0)).checkFastReadyToServeWithPreviousHeartbeatLag(pcs);
+    verify(storeIngestionTask, times(0)).checkFastReadyToServeWithPreviousTimeLag(pcs);
     verify(storeIngestionTask, times(0)).checkFastReadyToServeWithPreviousOffsetLag(pcs);
 
     // Case 4: Lag fast-start config enabled
-    doReturn(true).when(storeIngestionTask).isHeartbeatLagRelaxEnabled();
+    doReturn(true).when(storeIngestionTask).isTimeLagRelaxEnabled();
     doReturn(false).when(serverConfig).isUseHeartbeatLagForReadyToServeCheckEnabled();
     doReturn(true).when(storeIngestionTask).isOffsetLagDeltaRelaxEnabled();
     storeIngestionTask.checkFastReadyToServeForReplica(pcs);
-    verify(storeIngestionTask, times(0)).checkFastReadyToServeWithPreviousHeartbeatLag(pcs);
+    verify(storeIngestionTask, times(0)).checkFastReadyToServeWithPreviousTimeLag(pcs);
     verify(storeIngestionTask, times(1)).checkFastReadyToServeWithPreviousOffsetLag(pcs);
 
     // Case 5: Lag fast-start config enabled (cont.)
-    doReturn(false).when(storeIngestionTask).isHeartbeatLagRelaxEnabled();
+    doReturn(false).when(storeIngestionTask).isTimeLagRelaxEnabled();
     doReturn(true).when(serverConfig).isUseHeartbeatLagForReadyToServeCheckEnabled();
     storeIngestionTask.checkFastReadyToServeForReplica(pcs);
-    verify(storeIngestionTask, times(0)).checkFastReadyToServeWithPreviousHeartbeatLag(pcs);
+    verify(storeIngestionTask, times(0)).checkFastReadyToServeWithPreviousTimeLag(pcs);
     verify(storeIngestionTask, times(2)).checkFastReadyToServeWithPreviousOffsetLag(pcs);
 
     // Case 5: HB fast-start config enabled
-    doReturn(true).when(storeIngestionTask).isHeartbeatLagRelaxEnabled();
+    doReturn(true).when(storeIngestionTask).isTimeLagRelaxEnabled();
     doReturn(true).when(serverConfig).isUseHeartbeatLagForReadyToServeCheckEnabled();
     storeIngestionTask.checkFastReadyToServeForReplica(pcs);
-    verify(storeIngestionTask, times(1)).checkFastReadyToServeWithPreviousHeartbeatLag(pcs);
+    verify(storeIngestionTask, times(1)).checkFastReadyToServeWithPreviousTimeLag(pcs);
     verify(storeIngestionTask, times(2)).checkFastReadyToServeWithPreviousOffsetLag(pcs);
   }
 }

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/SITFastReadyToServeTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/SITFastReadyToServeTest.java
@@ -24,7 +24,7 @@ public class SITFastReadyToServeTest {
   public void testReadyToServeWithMessageTimeLag() {
     StoreIngestionTask storeIngestionTask = mock(StoreIngestionTask.class);
     VeniceServerConfig serverConfig = mock(VeniceServerConfig.class);
-    doReturn(TimeUnit.MINUTES.toMillis(5)).when(serverConfig).getTimeLagThresholdForFastOnlineTransitionInRestart();
+    doReturn(5).when(serverConfig).getTimeLagThresholdForFastOnlineTransitionInRestartMinutes();
     doReturn(serverConfig).when(storeIngestionTask).getServerConfig();
     OffsetRecord record = mock(OffsetRecord.class);
     PartitionConsumptionState pcs = mock(PartitionConsumptionState.class);
@@ -47,7 +47,7 @@ public class SITFastReadyToServeTest {
     doReturn(currentTimestamp - TimeUnit.MINUTES.toMillis(7)).when(record).getLastCheckpointTimestamp();
     storeIngestionTask.checkFastReadyToServeWithPreviousTimeLag(pcs);
     verify(pcs, times(1)).lagHasCaughtUp();
-    verify(pcs, times(1)).setReadyToServeTimeLagThreshold(eq(TimeUnit.MINUTES.toMillis(3)));
+    verify(pcs, times(1)).setReadyToServeTimeLagThresholdInMs(eq(TimeUnit.MINUTES.toMillis(8)));
   }
 
   @Test

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/stats/ingestion/heartbeat/HeartbeatMonitoringServiceTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/stats/ingestion/heartbeat/HeartbeatMonitoringServiceTest.java
@@ -73,7 +73,12 @@ public class HeartbeatMonitoringServiceTest {
     doCallRealMethod().when(heartbeatMonitoringService)
         .getReplicaLeaderMaxHeartbeatLag(any(), anyString(), anyInt(), anyBoolean());
     doCallRealMethod().when(heartbeatMonitoringService)
+        .getReplicaLeaderMaxHeartbeatLag(any(), anyString(), anyInt(), anyBoolean(), anyLong());
+
+    doCallRealMethod().when(heartbeatMonitoringService)
         .getReplicaFollowerHeartbeatLag(any(), anyString(), anyInt(), anyBoolean());
+    doCallRealMethod().when(heartbeatMonitoringService)
+        .getReplicaFollowerHeartbeatLag(any(), anyString(), anyInt(), anyBoolean(), anyLong());
 
     Map<String, Map<Integer, Map<Integer, Map<String, HeartbeatTimeStampEntry>>>> leaderMap =
         new VeniceConcurrentHashMap<>();

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/stats/ingestion/heartbeat/HeartbeatMonitoringServiceTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/stats/ingestion/heartbeat/HeartbeatMonitoringServiceTest.java
@@ -131,12 +131,12 @@ public class HeartbeatMonitoringServiceTest {
     lag = heartbeatMonitoringService.getReplicaLeaderMaxHeartbeatLag(pcs, store, version, true);
     Assert.assertEquals(lag, Long.MAX_VALUE);
     timestamp = heartbeatMonitoringService.getReplicaLeaderMinHeartbeatTimestamp(pcs, store, version, true);
-    Assert.assertEquals(timestamp, HeartbeatMonitoringService.INVALID_HEARTBEAT_TIMESTAMP);
+    Assert.assertEquals(timestamp, HeartbeatMonitoringService.INVALID_MESSAGE_TIMESTAMP);
     // Replica not found in leader map.
     lag = heartbeatMonitoringService.getReplicaLeaderMaxHeartbeatLag(pcs, store, 2, true);
     Assert.assertEquals(lag, Long.MAX_VALUE);
     timestamp = heartbeatMonitoringService.getReplicaLeaderMinHeartbeatTimestamp(pcs, store, 2, true);
-    Assert.assertEquals(timestamp, HeartbeatMonitoringService.INVALID_HEARTBEAT_TIMESTAMP);
+    Assert.assertEquals(timestamp, HeartbeatMonitoringService.INVALID_MESSAGE_TIMESTAMP);
 
     /**
      * Validating Follower Lag
@@ -173,12 +173,12 @@ public class HeartbeatMonitoringServiceTest {
     lag = heartbeatMonitoringService.getReplicaFollowerHeartbeatLag(pcs, store, version, true);
     Assert.assertEquals(lag, Long.MAX_VALUE);
     timestamp = heartbeatMonitoringService.getReplicaFollowerHeartbeatTimestamp(pcs, store, version, true);
-    Assert.assertEquals(timestamp, HeartbeatMonitoringService.INVALID_HEARTBEAT_TIMESTAMP);
+    Assert.assertEquals(timestamp, HeartbeatMonitoringService.INVALID_MESSAGE_TIMESTAMP);
     // Replica not found in follower map.
     lag = heartbeatMonitoringService.getReplicaFollowerHeartbeatLag(pcs, store, 2, true);
     Assert.assertEquals(lag, Long.MAX_VALUE);
     timestamp = heartbeatMonitoringService.getReplicaFollowerHeartbeatTimestamp(pcs, store, 2, true);
-    Assert.assertEquals(timestamp, HeartbeatMonitoringService.INVALID_HEARTBEAT_TIMESTAMP);
+    Assert.assertEquals(timestamp, HeartbeatMonitoringService.INVALID_MESSAGE_TIMESTAMP);
 
   }
 

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/stats/ingestion/heartbeat/HeartbeatMonitoringServiceTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/stats/ingestion/heartbeat/HeartbeatMonitoringServiceTest.java
@@ -73,10 +73,14 @@ public class HeartbeatMonitoringServiceTest {
     doCallRealMethod().when(heartbeatMonitoringService)
         .getReplicaLeaderMaxHeartbeatLag(any(), anyString(), anyInt(), anyBoolean());
     doCallRealMethod().when(heartbeatMonitoringService)
+        .getReplicaLeaderMinHeartbeatTimestamp(any(), anyString(), anyInt(), anyBoolean());
+    doCallRealMethod().when(heartbeatMonitoringService)
         .getReplicaLeaderMaxHeartbeatLag(any(), anyString(), anyInt(), anyBoolean(), anyLong());
 
     doCallRealMethod().when(heartbeatMonitoringService)
         .getReplicaFollowerHeartbeatLag(any(), anyString(), anyInt(), anyBoolean());
+    doCallRealMethod().when(heartbeatMonitoringService)
+        .getReplicaFollowerHeartbeatTimestamp(any(), anyString(), anyInt(), anyBoolean());
     doCallRealMethod().when(heartbeatMonitoringService)
         .getReplicaFollowerHeartbeatLag(any(), anyString(), anyInt(), anyBoolean(), anyLong());
 
@@ -98,41 +102,41 @@ public class HeartbeatMonitoringServiceTest {
     leaderMap.put(store, new VeniceConcurrentHashMap<>());
     leaderMap.get(store).put(version, new VeniceConcurrentHashMap<>());
     leaderMap.get(store).get(version).put(partition, new VeniceConcurrentHashMap<>());
+    long currentTime = System.currentTimeMillis();
     leaderMap.get(store)
         .get(version)
         .get(partition)
-        .put(
-            "dc-0",
-            new HeartbeatTimeStampEntry(System.currentTimeMillis() - TimeUnit.MINUTES.toMillis(5), true, true));
+        .put("dc-0", new HeartbeatTimeStampEntry(currentTime - TimeUnit.MINUTES.toMillis(5), true, true));
     leaderMap.get(store)
         .get(version)
         .get(partition)
-        .put(
-            "dc-1",
-            new HeartbeatTimeStampEntry(System.currentTimeMillis() - TimeUnit.MINUTES.toMillis(10), true, true));
+        .put("dc-1", new HeartbeatTimeStampEntry(currentTime - TimeUnit.MINUTES.toMillis(10), true, true));
     leaderMap.get(store)
         .get(version)
         .get(partition)
-        .put(
-            "dc-1_sep",
-            new HeartbeatTimeStampEntry(System.currentTimeMillis() - TimeUnit.MINUTES.toMillis(100), true, true));
+        .put("dc-1_sep", new HeartbeatTimeStampEntry(currentTime - TimeUnit.MINUTES.toMillis(100), true, true));
 
     // Check valid leader lag
     long lag = heartbeatMonitoringService.getReplicaLeaderMaxHeartbeatLag(pcs, store, version, true);
     Assert.assertTrue(lag >= TimeUnit.MINUTES.toMillis(10));
     Assert.assertTrue(lag < TimeUnit.MINUTES.toMillis(11));
+    long timestamp = heartbeatMonitoringService.getReplicaLeaderMinHeartbeatTimestamp(pcs, store, version, true);
+    Assert.assertEquals(timestamp, currentTime - TimeUnit.MINUTES.toMillis(10));
+
     // Add unavailable region
     leaderMap.get(store)
         .get(version)
         .get(partition)
-        .put(
-            "dc-2",
-            new HeartbeatTimeStampEntry(System.currentTimeMillis() - TimeUnit.MINUTES.toMillis(20), false, false));
+        .put("dc-2", new HeartbeatTimeStampEntry(currentTime - TimeUnit.MINUTES.toMillis(20), false, false));
     lag = heartbeatMonitoringService.getReplicaLeaderMaxHeartbeatLag(pcs, store, version, true);
     Assert.assertEquals(lag, Long.MAX_VALUE);
+    timestamp = heartbeatMonitoringService.getReplicaLeaderMinHeartbeatTimestamp(pcs, store, version, true);
+    Assert.assertEquals(timestamp, HeartbeatMonitoringService.INVALID_HEARTBEAT_TIMESTAMP);
     // Replica not found in leader map.
     lag = heartbeatMonitoringService.getReplicaLeaderMaxHeartbeatLag(pcs, store, 2, true);
     Assert.assertEquals(lag, Long.MAX_VALUE);
+    timestamp = heartbeatMonitoringService.getReplicaLeaderMinHeartbeatTimestamp(pcs, store, 2, true);
+    Assert.assertEquals(timestamp, HeartbeatMonitoringService.INVALID_HEARTBEAT_TIMESTAMP);
 
     /**
      * Validating Follower Lag
@@ -143,35 +147,39 @@ public class HeartbeatMonitoringServiceTest {
     followerMap.get(store)
         .get(version)
         .get(partition)
-        .put(
-            "dc-1",
-            new HeartbeatTimeStampEntry(System.currentTimeMillis() - TimeUnit.MINUTES.toMillis(10), true, true));
+        .put("dc-1", new HeartbeatTimeStampEntry(currentTime - TimeUnit.MINUTES.toMillis(10), true, true));
 
     // Check valid follower lag
     lag = heartbeatMonitoringService.getReplicaFollowerHeartbeatLag(pcs, store, version, true);
     Assert.assertTrue(lag >= TimeUnit.MINUTES.toMillis(10));
+    timestamp = heartbeatMonitoringService.getReplicaFollowerHeartbeatTimestamp(pcs, store, version, true);
+    Assert.assertEquals(timestamp, currentTime - TimeUnit.MINUTES.toMillis(10));
+
     // Add unrelated region
     followerMap.get(store)
         .get(version)
         .get(partition)
-        .put(
-            "dc-0",
-            new HeartbeatTimeStampEntry(System.currentTimeMillis() - TimeUnit.MINUTES.toMillis(20), true, true));
+        .put("dc-0", new HeartbeatTimeStampEntry(currentTime - TimeUnit.MINUTES.toMillis(20), true, true));
     lag = heartbeatMonitoringService.getReplicaFollowerHeartbeatLag(pcs, store, version, true);
     Assert.assertTrue(lag >= TimeUnit.MINUTES.toMillis(10));
     Assert.assertTrue(lag < TimeUnit.MINUTES.toMillis(20));
+    timestamp = heartbeatMonitoringService.getReplicaFollowerHeartbeatTimestamp(pcs, store, version, true);
+    Assert.assertEquals(timestamp, currentTime - TimeUnit.MINUTES.toMillis(10));
     // Set local region lag to be invalid
     followerMap.get(store)
         .get(version)
         .get(partition)
-        .put(
-            "dc-1",
-            new HeartbeatTimeStampEntry(System.currentTimeMillis() - TimeUnit.MINUTES.toMillis(10), true, false));
+        .put("dc-1", new HeartbeatTimeStampEntry(currentTime - TimeUnit.MINUTES.toMillis(10), true, false));
     lag = heartbeatMonitoringService.getReplicaFollowerHeartbeatLag(pcs, store, version, true);
     Assert.assertEquals(lag, Long.MAX_VALUE);
+    timestamp = heartbeatMonitoringService.getReplicaFollowerHeartbeatTimestamp(pcs, store, version, true);
+    Assert.assertEquals(timestamp, HeartbeatMonitoringService.INVALID_HEARTBEAT_TIMESTAMP);
     // Replica not found in follower map.
     lag = heartbeatMonitoringService.getReplicaFollowerHeartbeatLag(pcs, store, 2, true);
     Assert.assertEquals(lag, Long.MAX_VALUE);
+    timestamp = heartbeatMonitoringService.getReplicaFollowerHeartbeatTimestamp(pcs, store, 2, true);
+    Assert.assertEquals(timestamp, HeartbeatMonitoringService.INVALID_HEARTBEAT_TIMESTAMP);
+
   }
 
   @Test

--- a/internal/venice-common/src/main/java/com/linkedin/venice/ConfigKeys.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/ConfigKeys.java
@@ -2176,11 +2176,11 @@ public class ConfigKeys {
       "offset.lag.delta.relax.factor.for.fast.online.transition.in.restart";
 
   /*
-   * This config will specify the heartbeat lag threshold to be used for heartbeat lag comparison in making partition
+   * This config will specify the time lag threshold to be used for time lag comparison in making partition
    * online faster. Default value is -1 meaning disabled.
    */
-  public static final String HEARTBEAT_LAG_THRESHOLD_FOR_FAST_ONLINE_TRANSITION_IN_RESTART =
-      "heartbeat.lag.threshold.for.fast.online.transition.in.restart";
+  public static final String TIME_LAG_THRESHOLD_FOR_FAST_ONLINE_TRANSITION_IN_RESTART =
+      "time.lag.threshold.for.fast.online.transition.in.restart";
 
   /**
    * Enable offset collection for kafka topic partition from kafka consumer metrics.

--- a/internal/venice-common/src/main/java/com/linkedin/venice/ConfigKeys.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/ConfigKeys.java
@@ -2179,8 +2179,8 @@ public class ConfigKeys {
    * This config will specify the time lag threshold to be used for time lag comparison in making partition
    * online faster. Default value is -1 meaning disabled.
    */
-  public static final String TIME_LAG_THRESHOLD_FOR_FAST_ONLINE_TRANSITION_IN_RESTART =
-      "time.lag.threshold.for.fast.online.transition.in.restart";
+  public static final String TIME_LAG_THRESHOLD_FOR_FAST_ONLINE_TRANSITION_IN_RESTART_MINUTES =
+      "time.lag.threshold.for.fast.online.transition.in.restart.minutes";
 
   /**
    * Enable offset collection for kafka topic partition from kafka consumer metrics.

--- a/internal/venice-common/src/main/java/com/linkedin/venice/ConfigKeys.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/ConfigKeys.java
@@ -2175,6 +2175,13 @@ public class ConfigKeys {
   public static final String OFFSET_LAG_DELTA_RELAX_FACTOR_FOR_FAST_ONLINE_TRANSITION_IN_RESTART =
       "offset.lag.delta.relax.factor.for.fast.online.transition.in.restart";
 
+  /*
+   * This config will specify the heartbeat lag threshold to be used for heartbeat lag comparison in making partition
+   * online faster. Default value is -1 meaning disabled.
+   */
+  public static final String HEARTBEAT_LAG_THRESHOLD_FOR_FAST_ONLINE_TRANSITION_IN_RESTART =
+      "heartbeat.lag.threshold.for.fast.online.transition.in.restart";
+
   /**
    * Enable offset collection for kafka topic partition from kafka consumer metrics.
    */

--- a/internal/venice-common/src/main/java/com/linkedin/venice/offsets/OffsetRecord.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/offsets/OffsetRecord.java
@@ -128,6 +128,14 @@ public class OffsetRecord {
     this.partitionState.heartbeatTimestamp = heartbeatTimestamp;
   }
 
+  public long getLastCheckpointTimestamp() {
+    return this.partitionState.lastCheckpointTimestamp;
+  }
+
+  public void setLastCheckpointTimestamp(long timestamp) {
+    this.partitionState.lastCheckpointTimestamp = timestamp;
+  }
+
   /**
    * @return the last messageTimeStamp across all producers tracked by this OffsetRecord
    */

--- a/internal/venice-common/src/main/java/com/linkedin/venice/offsets/OffsetRecord.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/offsets/OffsetRecord.java
@@ -120,6 +120,14 @@ public class OffsetRecord {
     this.partitionState.offsetLag = offsetLag;
   }
 
+  public long getHeartbeatTimestamp() {
+    return this.partitionState.heartbeatTimestamp;
+  }
+
+  public void setHeartbeatTimestamp(long heartbeatTimestamp) {
+    this.partitionState.heartbeatTimestamp = heartbeatTimestamp;
+  }
+
   /**
    * @return the last messageTimeStamp across all producers tracked by this OffsetRecord
    */

--- a/internal/venice-common/src/main/java/com/linkedin/venice/serialization/avro/AvroProtocolDefinition.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/serialization/avro/AvroProtocolDefinition.java
@@ -56,7 +56,7 @@ public enum AvroProtocolDefinition {
    * Used to persist the state of a partition in Storage Nodes, including offset,
    * Data Ingest Validation state, etc.
    */
-  PARTITION_STATE(24, 17, PartitionState.class),
+  PARTITION_STATE(24, 18, PartitionState.class),
 
   /**
    * Used to persist state related to a store-version, including Start of Buffer Replay


### PR DESCRIPTION
<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat], [protocol]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## [server] Add time lag threshold support for fast server restart
This PR adds support for checkpointing replica's message (today only stores heartbeat) timestamp in OffsetRecord and use it in server fast restart feature. 
The semantic of the fast restart threshold will be changed:
**Before**: The offset relax factor is controlled by a config. If previous ready to serve replica comes back with previous lag + lag threshold * factor > current lag we will allow it to be ready to serve.
**Now**: The time lag threshold will be controlled by a config. If previous ready to serve replica comes back with certain  time lag, we will allow it to be ready to serve.
**Config name**: "time.lag.threshold.for.fast.online.transition.in.restart.minutes", default -1 (disabled)

## Solution
<!--
Describe
- What changes you are making and why. 
- How these changes solve the problem.
- Any performance considerations or trade-offs. 
- Describe what testings you have done, for example, performance testing etc.
-->


###  Code changes
- [x] Added new code behind **a config**. If so list the config names and their default values in the PR description.
- [ ] Introduced new **log lines**. 
  - [ ] Confirmed if logs need to be **rate limited** to avoid excessive logging.

###  **Concurrency-Specific Checks**
Both reviewer and PR author to verify
- [ ] Code has **no race conditions** or **thread safety issues**.
- [ ] Proper **synchronization mechanisms** (e.g., `synchronized`, `RWLock`) are used where needed.
- [ ] No **blocking calls** inside critical sections that could lead to deadlocks or performance degradation.
- [ ] Verified **thread-safe collections** are used (e.g., `ConcurrentHashMap`, `CopyOnWriteArrayList`).
- [ ] Validated proper exception handling in multi-threaded code to avoid silent thread termination.


## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->

- [ ] New unit tests added.
- [ ] New integration tests added.
- [ ] Modified or extended existing tests.
- [ ] Verified backward compatibility (if applicable).

## Does this PR introduce any user-facing or breaking changes?
<!--  
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [ ] No. You can skip the rest of this section.
- [x] Yes. Clearly explain the behavior change and its impact.