### PR TITLE
[controller] Check target region version status for DeferredVersionSwapService

### DIFF
--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/DeferredVersionSwapService.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/DeferredVersionSwapService.java
@@ -493,6 +493,9 @@ public class DeferredVersionSwapService extends AbstractVeniceService {
         fetchNonTargetRegionStoreRetryCountMap.remove(regionKafkaTopicName);
       }
 
+      String message =
+          "Region " + nonTargetRegion + " has status " + version.getStatus() + " for topic " + kafkaTopicName;
+      logMessageIfNotRedundant(message);
       if (version.getStatus().equals(VersionStatus.PUSHED)) {
         completedNonTargetRegions.add(nonTargetRegion);
       } else if (version.getStatus().equals(ERROR) || version.getStatus().equals(VersionStatus.KILLED)) {

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceParentHelixAdmin.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceParentHelixAdmin.java
@@ -3900,14 +3900,16 @@ public class VeniceParentHelixAdmin implements Admin {
       parentStore.updateVersionStatus(versionNum, PUSHED);
       repository.updateStore(parentStore);
       LOGGER.info(
-          "Updating parent store version {} status to {} for target region push w/ deferred swap",
+          "Updating parent store {} version {} status to {} for target region push w/ deferred swap",
+          parentStore.getName(),
           versionNum,
           PUSHED);
     } else if (failedRegions.size() > 0) {
       parentStore.updateVersionStatus(versionNum, ERROR);
       repository.updateStore(parentStore);
       LOGGER.info(
-          "Updating parent store version {} status to {} for target region push w/ deferred swap",
+          "Updating parent store {} version {} status to {} for target region push w/ deferred swap",
+          parentStore.getName(),
           versionNum,
           ERROR);
     }

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/stats/DeferredVersionSwapStats.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/stats/DeferredVersionSwapStats.java
@@ -12,12 +12,13 @@ public class DeferredVersionSwapStats extends AbstractVeniceStats {
   private final Sensor deferredVersionSwapThrowableSensor;
   private final Sensor deferredVersionSwapFailedRollForwardSensor;
   private final Sensor deferredVersionSwapStalledVersionSwapSensor;
-  private final Sensor deferredVersionSwapRunawayVpjSensor;
+  private final Sensor deferredVersionSwapParentChildStatusMismatchSensor;
   private final static String DEFERRED_VERSION_SWAP_ERROR = "deferred_version_swap_error";
   private final static String DEFERRED_VERSION_SWAP_THROWABLE = "deferred_version_swap_throwable";
   private final static String DEFERRED_VERSION_SWAP_FAILED_ROLL_FORWARD = "deferred_version_swap_failed_roll_forward";
   private static final String DEFERRED_VERSION_SWAP_STALLED_VERSION_SWAP = "deferred_version_swap_stalled_version_swap";
-  private static final String DEFERRED_VERSION_SWAP_RUNAWAY_VPJ_SENSOR = "deferred_version_swap_runaway_vpj";
+  private static final String DEFERRED_VERSION_SWAP_PARENT_CHILD_STATUS_MISMATCH_SENSOR =
+      "deferred_version_swap_parent_child_status_mismatch";
 
   public DeferredVersionSwapStats(MetricsRepository metricsRepository) {
     super(metricsRepository, "DeferredVersionSwap");
@@ -27,7 +28,8 @@ public class DeferredVersionSwapStats extends AbstractVeniceStats {
         registerSensorIfAbsent(DEFERRED_VERSION_SWAP_FAILED_ROLL_FORWARD, new Count());
     deferredVersionSwapStalledVersionSwapSensor =
         registerSensorIfAbsent(DEFERRED_VERSION_SWAP_STALLED_VERSION_SWAP, new Gauge());
-    deferredVersionSwapRunawayVpjSensor = registerSensorIfAbsent(DEFERRED_VERSION_SWAP_RUNAWAY_VPJ_SENSOR, new Count());
+    deferredVersionSwapParentChildStatusMismatchSensor =
+        registerSensorIfAbsent(DEFERRED_VERSION_SWAP_PARENT_CHILD_STATUS_MISMATCH_SENSOR, new Count());
   }
 
   public void recordDeferredVersionSwapErrorSensor() {
@@ -46,7 +48,7 @@ public class DeferredVersionSwapStats extends AbstractVeniceStats {
     deferredVersionSwapStalledVersionSwapSensor.record(value);
   }
 
-  public void recordDeferredVersionSwapRunawayVpjSensor() {
-    deferredVersionSwapRunawayVpjSensor.record();
+  public void recordDeferredVersionSwapParentChildStatusMismatchSensor() {
+    deferredVersionSwapParentChildStatusMismatchSensor.record();
   }
 }

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/stats/DeferredVersionSwapStats.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/stats/DeferredVersionSwapStats.java
@@ -12,10 +12,12 @@ public class DeferredVersionSwapStats extends AbstractVeniceStats {
   private final Sensor deferredVersionSwapThrowableSensor;
   private final Sensor deferredVersionSwapFailedRollForwardSensor;
   private final Sensor deferredVersionSwapStalledVersionSwapSensor;
+  private final Sensor deferredVersionSwapRunawayVpjSensor;
   private final static String DEFERRED_VERSION_SWAP_ERROR = "deferred_version_swap_error";
   private final static String DEFERRED_VERSION_SWAP_THROWABLE = "deferred_version_swap_throwable";
   private final static String DEFERRED_VERSION_SWAP_FAILED_ROLL_FORWARD = "deferred_version_swap_failed_roll_forward";
   private static final String DEFERRED_VERSION_SWAP_STALLED_VERSION_SWAP = "deferred_version_swap_stalled_version_swap";
+  private static final String DEFERRED_VERSION_SWAP_RUNAWAY_VPJ_SENSOR = "deferred_version_swap_runaway_vpj";
 
   public DeferredVersionSwapStats(MetricsRepository metricsRepository) {
     super(metricsRepository, "DeferredVersionSwap");
@@ -25,6 +27,7 @@ public class DeferredVersionSwapStats extends AbstractVeniceStats {
         registerSensorIfAbsent(DEFERRED_VERSION_SWAP_FAILED_ROLL_FORWARD, new Count());
     deferredVersionSwapStalledVersionSwapSensor =
         registerSensorIfAbsent(DEFERRED_VERSION_SWAP_STALLED_VERSION_SWAP, new Gauge());
+    deferredVersionSwapRunawayVpjSensor = registerSensorIfAbsent(DEFERRED_VERSION_SWAP_RUNAWAY_VPJ_SENSOR, new Count());
   }
 
   public void recordDeferredVersionSwapErrorSensor() {
@@ -41,5 +44,9 @@ public class DeferredVersionSwapStats extends AbstractVeniceStats {
 
   public void recordDeferredVersionSwapStalledVersionSwapSensor(double value) {
     deferredVersionSwapStalledVersionSwapSensor.record(value);
+  }
+
+  public void recordDeferredVersionSwapRunawayVpjSensor() {
+    deferredVersionSwapRunawayVpjSensor.record();
   }
 }

--- a/services/venice-controller/src/test/java/com/linkedin/venice/controller/TestDeferredVersionSwapService.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/controller/TestDeferredVersionSwapService.java
@@ -489,4 +489,63 @@ public class TestDeferredVersionSwapService {
       verify(mockDeferredVersionSwapStats, atLeast(1)).recordDeferredVersionSwapStalledVersionSwapSensor(1.0);
     });
   }
+
+  @Test
+  public void testDeferredVersionSwapWithRunawayVPJ() throws Exception {
+    String storeName = "testStore";
+    Map<Integer, VersionStatus> versions = new HashMap<>();
+    versions.put(versionOne, VersionStatus.ONLINE);
+    versions.put(versionTwo, VersionStatus.STARTED);
+    Store store = mockStore(versionOne, 1, region1, versions, storeName);
+    doReturn(versionTwo).when(store).getLargestUsedVersionNumber();
+
+    List<Store> storeList = new ArrayList<>();
+    storeList.add(store);
+    doReturn(storeList).when(admin).getAllStores(clusterName);
+    doReturn(true).when(admin).isLeaderControllerFor(clusterName);
+
+    Version versionOneImpl = new VersionImpl(storeName, versionOne);
+    Version versionTwoImpl = new VersionImpl(storeName, versionTwo);
+    versionTwoImpl.setStatus(VersionStatus.ONLINE);
+    List<Version> versionList = new ArrayList<>();
+    versionList.add(versionOneImpl);
+    versionList.add(versionTwoImpl);
+    StoreResponse storeResponse = getStoreResponse(versionList);
+
+    Map<String, ControllerClient> controllerClientMap = mockControllerClients(versionList);
+    for (Map.Entry<String, ControllerClient> entry: controllerClientMap.entrySet()) {
+      ControllerClient controllerClient = entry.getValue();
+      doReturn(storeResponse).when(controllerClient).getStore(storeName);
+    }
+
+    mockVeniceHelixAdmin(controllerClientMap);
+    Map<String, Integer> coloToVersions = new HashMap<>();
+    coloToVersions.put(region1, versionTwo);
+    coloToVersions.put(region2, versionOne);
+    coloToVersions.put(region3, versionOne);
+
+    doReturn(coloToVersions).when(admin).getCurrentVersionsForMultiColos(any(), any());
+
+    Long time = LocalDateTime.now().toEpochSecond(ZoneOffset.UTC);
+    Admin.OfflinePushStatusInfo offlinePushStatusInfoWithCompletedPush = getOfflinePushStatusInfo(
+        ExecutionStatus.COMPLETED.toString(),
+        ExecutionStatus.COMPLETED.toString(),
+        ExecutionStatus.COMPLETED.toString(),
+        time - TimeUnit.MINUTES.toSeconds(90),
+        time - TimeUnit.MINUTES.toSeconds(30),
+        time - TimeUnit.MINUTES.toSeconds(30));
+
+    String kafkaTopicName = Version.composeKafkaTopic(storeName, versionTwo);
+    doReturn(offlinePushStatusInfoWithCompletedPush).when(admin).getOffLinePushStatus(clusterName, kafkaTopicName);
+
+    DeferredVersionSwapStats deferredVersionSwapStats = mock(DeferredVersionSwapStats.class);
+    DeferredVersionSwapService deferredVersionSwapService =
+        new DeferredVersionSwapService(admin, veniceControllerMultiClusterConfig, deferredVersionSwapStats);
+
+    deferredVersionSwapService.startInner();
+
+    TestUtils.waitForNonDeterministicAssertion(5, TimeUnit.SECONDS, () -> {
+      verify(deferredVersionSwapStats, atLeast(1)).recordDeferredVersionSwapRunawayVpjSensor();
+    });
+  }
 }

--- a/services/venice-controller/src/test/java/com/linkedin/venice/controller/TestDeferredVersionSwapService.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/controller/TestDeferredVersionSwapService.java
@@ -545,7 +545,7 @@ public class TestDeferredVersionSwapService {
     deferredVersionSwapService.startInner();
 
     TestUtils.waitForNonDeterministicAssertion(5, TimeUnit.SECONDS, () -> {
-      verify(deferredVersionSwapStats, atLeast(1)).recordDeferredVersionSwapRunawayVpjSensor();
+      verify(deferredVersionSwapStats, atLeast(1)).recordDeferredVersionSwapParentChildStatusMismatchSensor();
     });
   }
 }


### PR DESCRIPTION
<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat], [protocol]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## Problem Statement
<!--
Describe
- What problem are you trying to solve
- What issues or limitations exist in the current code
- Why this change is necessary 
-->
When VPJ stops polling early, the parent version status will never be updated to `PUSHED`. This causes the DeferredVersionSwapService to never perform a version swap for a store because it thinks the push isn't complete yet. 

## Solution
<!--
Describe
- What changes you are making and why. 
- How these changes solve the problem.
- Any performance considerations or trade-offs. 
- Describe what testings you have done, for example, performance testing etc.
-->
When checking if a push is complete, we will also check if the target version status is ONLINE. If the target version status is ONLINE, that means the push is complete in the target region and we can start monitoring the push for a version swap

###  Code changes
- [ ] Added new code behind **a config**. If so list the config names and their default values in the PR description.
- [ ] Introduced new **log lines**. 
  - [ ] Confirmed if logs need to be **rate limited** to avoid excessive logging.

###  **Concurrency-Specific Checks**
Both reviewer and PR author to verify
- [x] Code has **no race conditions** or **thread safety issues**.
- [x] Proper **synchronization mechanisms** (e.g., `synchronized`, `RWLock`) are used where needed.
- [x] No **blocking calls** inside critical sections that could lead to deadlocks or performance degradation.
- [x] Verified **thread-safe collections** are used (e.g., `ConcurrentHashMap`, `CopyOnWriteArrayList`).
- [x] Validated proper exception handling in multi-threaded code to avoid silent thread termination.


## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->

- [ ] New unit tests added.
- [ ] New integration tests added.
- [ ] Modified or extended existing tests.
- [ ] Verified backward compatibility (if applicable).

Existing tests
## Does this PR introduce any user-facing or breaking changes?
<!--  
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Clearly explain the behavior change and its impact.