### PR TITLE
[vpj] Avoid duplicate emission of terminal failure statuses to controller

### DIFF
--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/PushJobSetting.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/PushJobSetting.java
@@ -45,6 +45,7 @@ public class PushJobSetting implements Serializable {
   public int controllerStatusPollRetries;
   public long pollJobStatusIntervalMs;
   public long jobStatusInUnknownStateTimeoutMs;
+  public long pushJobTimeoutOverrideMs;
   public boolean sendControlMessagesDirectly;
   public boolean isSourceETL;
   public boolean enableWriteCompute;

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/PushJobSetting.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/PushJobSetting.java
@@ -40,7 +40,6 @@ public class PushJobSetting implements Serializable {
   public boolean isIncrementalPush;
   public String incrementalPushVersion;
   public boolean isDuplicateKeyAllowed;
-  public boolean enablePushJobStatusUpload;
   public int controllerRetries;
   public int controllerStatusPollRetries;
   public long pollJobStatusIntervalMs;

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/VenicePushJob.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/VenicePushJob.java
@@ -82,6 +82,7 @@ import static com.linkedin.venice.vpj.VenicePushJobConstants.VENICE_STORE_NAME_P
 
 import com.linkedin.avroutil1.compatibility.AvroCompatibilityHelper;
 import com.linkedin.venice.PushJobCheckpoints;
+import com.linkedin.venice.annotation.VisibleForTesting;
 import com.linkedin.venice.compression.CompressionStrategy;
 import com.linkedin.venice.compression.ZstdWithDictCompressor;
 import com.linkedin.venice.controllerapi.ControllerClient;
@@ -1734,7 +1735,7 @@ public class VenicePushJob implements AutoCloseable {
   private final Object lastReportedStatusLock = new Object();
 
   private static PushJobDetailsStatus getCurrentOverallStatus(PushJobDetails pushJobDetails) {
-    if (pushJobDetails != null && !pushJobDetails.overallStatus.isEmpty()) {
+    if (pushJobDetails != null && pushJobDetails.overallStatus != null && !pushJobDetails.overallStatus.isEmpty()) {
       return PushJobDetailsStatus
           .valueOf(pushJobDetails.overallStatus.get(pushJobDetails.overallStatus.size() - 1).status);
     }
@@ -1788,7 +1789,8 @@ public class VenicePushJob implements AutoCloseable {
     return false;
   }
 
-  private void sendPushJobDetailsToController() {
+  @VisibleForTesting
+  void sendPushJobDetailsToController() {
     if (shouldSkipPushJobStatusUpdate()) {
       return;
     }
@@ -2829,5 +2831,13 @@ public class VenicePushJob implements AutoCloseable {
 
   PushJobDetails getPushJobDetails() {
     return pushJobDetails;
+  }
+
+  @VisibleForTesting
+  void addPushJobDetailsOverallStatus(PushJobDetailsStatus pushJobDetailsStatus) {
+    if (pushJobDetails.overallStatus == null) {
+      pushJobDetails.overallStatus = new ArrayList<>();
+    }
+    pushJobDetails.overallStatus.add(getPushJobDetailsStatusTuple(pushJobDetailsStatus.getValue()));
   }
 }

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/VenicePushJob.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/VenicePushJob.java
@@ -926,7 +926,7 @@ public class VenicePushJob implements AutoCloseable {
       cancel();
       throw new VeniceTimeoutException(
           "Failing push-job for store " + pushJobSetting.storeName + " which is still running after " + timeoutMs
-              + " ms.");
+              + " ms (" + TimeUnit.MILLISECONDS.toHours(timeoutMs) + " hours)");
     }, timeoutMs, TimeUnit.MILLISECONDS);
   }
 

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/vpj/VenicePushJobConstants.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/vpj/VenicePushJobConstants.java
@@ -247,11 +247,6 @@ public final class VenicePushJobConstants {
    */
   public static final String JOB_EXEC_ID = "job.execution.id";
 
-  /**
-   * Config to enable the service that uploads push job statuses to the controller using
-   * {@code ControllerClient.uploadPushJobStatus()}, the job status is then packaged and sent to dedicated Kafka channel.
-   */
-  public static final String PUSH_JOB_STATUS_UPLOAD_ENABLE = "push.job.status.upload.enable";
   public static final String REDUCER_SPECULATIVE_EXECUTION_ENABLE = "reducer.speculative.execution.enable";
 
   /**

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/vpj/VenicePushJobConstants.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/vpj/VenicePushJobConstants.java
@@ -52,6 +52,7 @@ public final class VenicePushJobConstants {
   public static final String CONTROLLER_REQUEST_RETRY_ATTEMPTS = "controller.request.retry.attempts";
   public static final String POLL_JOB_STATUS_INTERVAL_MS = "poll.job.status.interval.ms";
   public static final String JOB_STATUS_IN_UNKNOWN_STATE_TIMEOUT_MS = "job.status.in.unknown.state.timeout.ms";
+  public static final String PUSH_JOB_TIMEOUT_OVERRIDE_MS = "push.job.timeout.override.ms";
   public static final String SEND_CONTROL_MESSAGES_DIRECTLY = "send.control.messages.directly";
   public static final String SOURCE_ETL = "source.etl";
   public static final String ETL_VALUE_SCHEMA_TRANSFORMATION = "etl.value.schema.transformation";

--- a/clients/venice-push-job/src/test/java/com/linkedin/venice/hadoop/TestVenicePushJobCheckpoints.java
+++ b/clients/venice-push-job/src/test/java/com/linkedin/venice/hadoop/TestVenicePushJobCheckpoints.java
@@ -8,7 +8,6 @@ import static com.linkedin.venice.vpj.VenicePushJobConstants.D2_ZK_HOSTS_PREFIX;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.INPUT_PATH_PROP;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.KEY_FIELD_PROP;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.POLL_JOB_STATUS_INTERVAL_MS;
-import static com.linkedin.venice.vpj.VenicePushJobConstants.PUSH_JOB_STATUS_UPLOAD_ENABLE;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.SOURCE_GRID_FABRIC;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.SSL_KEY_PASSWORD_PROPERTY_NAME;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.SSL_KEY_STORE_PASSWORD_PROPERTY_NAME;
@@ -605,7 +604,6 @@ public class TestVenicePushJobCheckpoints {
     props.setProperty(SSL_TRUST_STORE_PROPERTY_NAME, "test");
     props.setProperty(SSL_KEY_STORE_PASSWORD_PROPERTY_NAME, "test");
     props.setProperty(SSL_KEY_PASSWORD_PROPERTY_NAME, "test");
-    props.setProperty(PUSH_JOB_STATUS_UPLOAD_ENABLE, "true");
     return props;
   }
 

--- a/clients/venice-push-job/src/test/java/com/linkedin/venice/hadoop/VenicePushJobTest.java
+++ b/clients/venice-push-job/src/test/java/com/linkedin/venice/hadoop/VenicePushJobTest.java
@@ -21,7 +21,6 @@ import static com.linkedin.venice.vpj.VenicePushJobConstants.KEY_FIELD_PROP;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.LEGACY_AVRO_KEY_FIELD_PROP;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.LEGACY_AVRO_VALUE_FIELD_PROP;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.PARENT_CONTROLLER_REGION_NAME;
-import static com.linkedin.venice.vpj.VenicePushJobConstants.PUSH_JOB_STATUS_UPLOAD_ENABLE;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.PUSH_JOB_TIMEOUT_OVERRIDE_MS;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.REPUSH_TTL_ENABLE;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.REPUSH_TTL_SECONDS;
@@ -648,7 +647,6 @@ public class VenicePushJobTest {
     Properties props = getVpjRequiredProperties();
     props.put(KEY_FIELD_PROP, "id");
     props.put(VALUE_FIELD_PROP, "name");
-    props.put(PUSH_JOB_STATUS_UPLOAD_ENABLE, "true");
     ControllerClient client = getClient();
 
     try (VenicePushJob pushJob = getSpyVenicePushJob(props, client)) {
@@ -684,21 +682,8 @@ public class VenicePushJobTest {
   }
 
   @Test
-  public void testSkipStatusUpdateWhenUploadDisabled() {
-    Properties props = getVpjRequiredProperties();
-    props.put(PUSH_JOB_STATUS_UPLOAD_ENABLE, "false"); // upload disabled
-    ControllerClient client = getClient();
-    try (VenicePushJob pushJob = getSpyVenicePushJob(props, client)) {
-      pushJob.addPushJobDetailsOverallStatus(PushJobDetailsStatus.STARTED);
-      pushJob.sendPushJobDetailsToController();
-      verify(client, never()).sendPushJobDetails(anyString(), anyInt(), any(byte[].class));
-    }
-  }
-
-  @Test
   public void testSendNonTerminalThenTerminalStatus() {
     Properties props = getVpjRequiredProperties();
-    props.put(PUSH_JOB_STATUS_UPLOAD_ENABLE, "true");
     ControllerClient client = getClient();
     try (VenicePushJob pushJob = getSpyVenicePushJob(props, client)) {
       PushJobDetails pushJobDetails = pushJob.getPushJobDetails();
@@ -715,7 +700,6 @@ public class VenicePushJobTest {
   @Test
   public void testSendStatusAgainIfDifferentTerminalStatus() {
     Properties props = getVpjRequiredProperties();
-    props.put(PUSH_JOB_STATUS_UPLOAD_ENABLE, "true");
     ControllerClient client = getClient();
     try (VenicePushJob pushJob = getSpyVenicePushJob(props, client)) {
       PushJobDetails pushJobDetails = pushJob.getPushJobDetails();
@@ -734,7 +718,6 @@ public class VenicePushJobTest {
   @Test
   public void testSkipRepeatedFailedStatus() {
     Properties props = getVpjRequiredProperties();
-    props.put(PUSH_JOB_STATUS_UPLOAD_ENABLE, "true");
     ControllerClient client = getClient();
     try (VenicePushJob pushJob = getSpyVenicePushJob(props, client)) {
       PushJobDetails pushJobDetails = pushJob.getPushJobDetails();
@@ -751,7 +734,6 @@ public class VenicePushJobTest {
   @Test
   public void testHandleExceptionDuringSendPushDetailsToController() {
     Properties props = getVpjRequiredProperties();
-    props.put(PUSH_JOB_STATUS_UPLOAD_ENABLE, "true");
     ControllerClient client = mock(ControllerClient.class);
     when(client.sendPushJobDetails(anyString(), anyInt(), any(byte[].class))).thenThrow(new RuntimeException("fake"));
 

--- a/clients/venice-push-job/src/test/java/com/linkedin/venice/hadoop/VenicePushJobTest.java
+++ b/clients/venice-push-job/src/test/java/com/linkedin/venice/hadoop/VenicePushJobTest.java
@@ -21,6 +21,7 @@ import static com.linkedin.venice.vpj.VenicePushJobConstants.KEY_FIELD_PROP;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.LEGACY_AVRO_KEY_FIELD_PROP;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.LEGACY_AVRO_VALUE_FIELD_PROP;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.PARENT_CONTROLLER_REGION_NAME;
+import static com.linkedin.venice.vpj.VenicePushJobConstants.PUSH_JOB_TIMEOUT_OVERRIDE_MS;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.REPUSH_TTL_ENABLE;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.REPUSH_TTL_SECONDS;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.REPUSH_TTL_START_TIMESTAMP;
@@ -292,6 +293,7 @@ public class VenicePushJobTest {
     props.put(KEY_FIELD_PROP, "id");
     props.put(VALUE_FIELD_PROP, "name");
     props.put(DATA_WRITER_COMPUTE_JOB_CLASS, dataWriterJobClass.getCanonicalName());
+    props.put(PUSH_JOB_TIMEOUT_OVERRIDE_MS, 2);
     ControllerClient client = getClient();
     JobStatusQueryResponse response = mock(JobStatusQueryResponse.class);
     doReturn("UNKNOWN").when(response).getStatus();
@@ -331,6 +333,7 @@ public class VenicePushJobTest {
     props.put(KEY_FIELD_PROP, "id");
     props.put(VALUE_FIELD_PROP, "name");
     props.put(DATA_WRITER_COMPUTE_JOB_CLASS, dataWriterJobClass.getCanonicalName());
+    props.put(PUSH_JOB_TIMEOUT_OVERRIDE_MS, 5L);
     ControllerClient client = getClient();
     JobStatusQueryResponse response = mock(JobStatusQueryResponse.class);
     doReturn("SUCCESS").when(response).getStatus();
@@ -339,7 +342,7 @@ public class VenicePushJobTest {
 
     try (VenicePushJob pushJob = getSpyVenicePushJob(props, client)) {
       StoreInfo storeInfo = new StoreInfo();
-      storeInfo.setBootstrapToOnlineTimeoutInHours(0);
+      storeInfo.setBootstrapToOnlineTimeoutInHours(1);
       PushJobSetting pushJobSetting = pushJob.getPushJobSetting();
       pushJobSetting.storeResponse = new StoreResponse();
       pushJobSetting.storeResponse.setStore(storeInfo);

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/DaVinciClientDiskFullTest.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/DaVinciClientDiskFullTest.java
@@ -17,7 +17,6 @@ import static com.linkedin.venice.utils.IntegrationTestPushUtils.createStoreForJ
 import static com.linkedin.venice.utils.IntegrationTestPushUtils.defaultVPJProps;
 import static com.linkedin.venice.utils.IntegrationTestPushUtils.runVPJ;
 import static com.linkedin.venice.utils.TestWriteUtils.getTempDataDirectory;
-import static com.linkedin.venice.vpj.VenicePushJobConstants.PUSH_JOB_STATUS_UPLOAD_ENABLE;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNotNull;
@@ -265,7 +264,6 @@ public class DaVinciClientDiskFullTest {
         TestWriteUtils
             .writeSimpleAvroFileWithStringToStringSchema(inputDir, largePushRecordCount, largePushRecordMinSize);
         final Properties vpjPropertiesForV2 = defaultVPJProps(venice, inputDirPath, storeName);
-        vpjPropertiesForV2.setProperty(PUSH_JOB_STATUS_UPLOAD_ENABLE, "true");
 
         SentPushJobDetailsTrackerImpl pushJobDetailsTracker = new SentPushJobDetailsTrackerImpl();
 

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/PushJobDetailsTest.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/PushJobDetailsTest.java
@@ -16,7 +16,6 @@ import static com.linkedin.venice.utils.TestWriteUtils.getTempDataDirectory;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.DEFAULT_KEY_FIELD_PROP;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.DEFAULT_VALUE_FIELD_PROP;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.INCREMENTAL_PUSH;
-import static com.linkedin.venice.vpj.VenicePushJobConstants.PUSH_JOB_STATUS_UPLOAD_ENABLE;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNotNull;
@@ -361,7 +360,6 @@ public class PushJobDetailsTest {
               .setActiveActiveReplicationEnabled(true)
               .setIncrementalPushEnabled(true));
       Properties pushJobProps = defaultVPJProps(multiRegionMultiClusterWrapper, inputDirPathForFullPush, testStoreName);
-      pushJobProps.setProperty(PUSH_JOB_STATUS_UPLOAD_ENABLE, String.valueOf(true));
       try (VenicePushJob testPushJob = new VenicePushJob("test-push-job-details-job", pushJobProps)) {
         testPushJob.run();
       }
@@ -378,7 +376,6 @@ public class PushJobDetailsTest {
       // case 2: successful incremental push job
       Properties pushJobPropsInc =
           defaultVPJProps(multiRegionMultiClusterWrapper, inputDirPathForIncPush, testStoreName);
-      pushJobPropsInc.setProperty(PUSH_JOB_STATUS_UPLOAD_ENABLE, String.valueOf(true));
       pushJobPropsInc.setProperty(INCREMENTAL_PUSH, String.valueOf(true));
       try (VenicePushJob testPushJob = new VenicePushJob("test-push-job-details-job-with-inc-push", pushJobPropsInc)) {
         testPushJob.run();
@@ -416,7 +413,6 @@ public class PushJobDetailsTest {
 
       // case 4: failed incremental push job, non-user error
       pushJobPropsInc = defaultVPJProps(multiRegionMultiClusterWrapper, inputDirPathForIncPush, testStoreName);
-      pushJobPropsInc.setProperty(PUSH_JOB_STATUS_UPLOAD_ENABLE, String.valueOf(true));
       pushJobPropsInc.setProperty(INCREMENTAL_PUSH, String.valueOf(true));
       try (VenicePushJob testPushJob =
           new VenicePushJob("test-push-job-details-job-with-inc-push-v2", pushJobPropsInc)) {
@@ -438,7 +434,6 @@ public class PushJobDetailsTest {
       parentControllerClient.updateStore(testStoreName, queryParams);
 
       pushJobProps = defaultVPJProps(multiRegionMultiClusterWrapper, inputDirPathWithDupKeys, testStoreName);
-      pushJobProps.setProperty(PUSH_JOB_STATUS_UPLOAD_ENABLE, String.valueOf(true));
       try (final VenicePushJob testPushJob = new VenicePushJob("test-push-job-details-job-v3", pushJobProps)) {
         assertThrows(VeniceException.class, testPushJob::run); // Push job should fail
       }
@@ -455,7 +450,6 @@ public class PushJobDetailsTest {
 
       // case 6: failed incremental push job, user error
       pushJobPropsInc = defaultVPJProps(multiRegionMultiClusterWrapper, inputDirPathWithDupKeys, testStoreName);
-      pushJobPropsInc.setProperty(PUSH_JOB_STATUS_UPLOAD_ENABLE, String.valueOf(true));
       pushJobPropsInc.setProperty(INCREMENTAL_PUSH, String.valueOf(true));
       try (VenicePushJob testPushJob =
           new VenicePushJob("test-push-job-details-job-with-inc-push-v3", pushJobPropsInc)) {

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestPushJobWithNativeReplication.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestPushJobWithNativeReplication.java
@@ -21,7 +21,6 @@ import static com.linkedin.venice.vpj.VenicePushJobConstants.DEFAULT_KEY_FIELD_P
 import static com.linkedin.venice.vpj.VenicePushJobConstants.DEFAULT_VALUE_FIELD_PROP;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.INCREMENTAL_PUSH;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.INPUT_PATH_PROP;
-import static com.linkedin.venice.vpj.VenicePushJobConstants.PUSH_JOB_STATUS_UPLOAD_ENABLE;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.SEND_CONTROL_MESSAGES_DIRECTLY;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.TARGETED_REGION_PUSH_ENABLED;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.TARGETED_REGION_PUSH_WITH_DEFERRED_SWAP;
@@ -877,7 +876,6 @@ public class TestPushJobWithNativeReplication {
     String storeName = Utils.getUniqueString(storeNamePrefix);
     Properties props =
         IntegrationTestPushUtils.defaultVPJProps(multiRegionMultiClusterWrapper, inputDirPath, storeName);
-    props.setProperty(PUSH_JOB_STATUS_UPLOAD_ENABLE, "true");
     props.put(SEND_CONTROL_MESSAGES_DIRECTLY, true);
 
     UpdateStoreQueryParams updateStoreParams = updateStoreParamsTransformer

--- a/internal/venice-test-common/src/main/java/com/linkedin/venice/utils/TestWriteUtils.java
+++ b/internal/venice-test-common/src/main/java/com/linkedin/venice/utils/TestWriteUtils.java
@@ -11,7 +11,6 @@ import static com.linkedin.venice.vpj.VenicePushJobConstants.KEY_INPUT_FILE_DATA
 import static com.linkedin.venice.vpj.VenicePushJobConstants.KEY_ZSTD_COMPRESSION_DICTIONARY;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.PARENT_CONTROLLER_REGION_NAME;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.POLL_JOB_STATUS_INTERVAL_MS;
-import static com.linkedin.venice.vpj.VenicePushJobConstants.PUSH_JOB_STATUS_UPLOAD_ENABLE;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.SOURCE_GRID_FABRIC;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.SSL_KEY_PASSWORD_PROPERTY_NAME;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.SSL_KEY_STORE_PASSWORD_PROPERTY_NAME;
@@ -902,7 +901,6 @@ public class TestWriteUtils {
     props.setProperty(SSL_TRUST_STORE_PROPERTY_NAME, "test");
     props.setProperty(SSL_KEY_STORE_PASSWORD_PROPERTY_NAME, "test");
     props.setProperty(SSL_KEY_PASSWORD_PROPERTY_NAME, "test");
-    props.setProperty(PUSH_JOB_STATUS_UPLOAD_ENABLE, "false");
     props.setProperty(CONTROLLER_REQUEST_RETRY_ATTEMPTS, "5");
     return props;
   }


### PR DESCRIPTION
## Avoid duplicate emission of terminal failure statuses to controller

Venice Push Job could previously send multiple terminal failure statuses (ERROR, KILLED) to the  
controller—once during status polling (e.g., ERROR) and again later if the job was canceled      
(e.g., ERROR or KILLED). This led to misleading metrics and inaccurate SLO reporting.            
This change introduces a check to track the last reported status and skip sending updates if it  
was already terminal.                                                                            

Also, fixed an issue in `setupPushJobTimeoutMonitor()` where a 0-hour bootstrap timeout               
would cause the job to be canceled immediately, making several tests flaky due to unexpected     
KILLED or ERROR statuses in checkpoint validations.                                              

To address this, we now skip setting up the timeout monitor if the timeout is ≤ 0. Additionally, 
a new config was added to override the timeout value (in milliseconds) for testing purposes,     
allowing more precise and controlled timeout behavior without triggering premature cancellations.

###  Code changes
- [ ] Added new code behind **a config**. If so list the config names and their default values in the PR description.
- [ ] Introduced new **log lines**. 
  - [ ] Confirmed if logs need to be **rate limited** to avoid excessive logging.

###  **Concurrency-Specific Checks**
Both reviewer and PR author to verify
- [ ] Code has **no race conditions** or **thread safety issues**.
- [ ] Proper **synchronization mechanisms** (e.g., `synchronized`, `RWLock`) are used where needed.
- [ ] No **blocking calls** inside critical sections that could lead to deadlocks or performance degradation.
- [ ] Verified **thread-safe collections** are used (e.g., `ConcurrentHashMap`, `CopyOnWriteArrayList`).
- [ ] Validated proper exception handling in multi-threaded code to avoid silent thread termination.


## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->

- [ ] New unit tests added.
- [ ] New integration tests added.
- [ ] Modified or extended existing tests.
- [ ] Verified backward compatibility (if applicable).

## Does this PR introduce any user-facing or breaking changes?
<!--  
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [ ] No. You can skip the rest of this section.
- [ ] Yes. Clearly explain the behavior change and its impact.