### PR TITLE
[dvc][server]Add elapsedTimeSinceLastPolledRecordsInMs field to Topic…

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/KafkaConsumerService.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/KafkaConsumerService.java
@@ -578,8 +578,13 @@ public abstract class KafkaConsumerService extends AbstractKafkaConsumerService 
         long lastSuccessfulPollTimestamp = partitionStats.getLastSuccessfulPollTimestamp();
         long elapsedTimeSinceLastConsumerPollInMs = ConsumptionTask.DEFAULT_TOPIC_PARTITION_NO_POLL_TIMESTAMP;
         long elapsedTimeSinceLastRecordForPartitionInMs = ConsumptionTask.DEFAULT_TOPIC_PARTITION_NO_POLL_TIMESTAMP;
+
+        // Consumer level elapsed time
+        elapsedTimeSinceLastConsumerPollInMs =
+            LatencyUtils.getElapsedTimeFromMsToMs(consumptionTask.getLastSuccessfulPollTimestamp());
+
+        // Partition level elapsed time
         if (lastSuccessfulPollTimestamp > 0) {
-          elapsedTimeSinceLastConsumerPollInMs = LatencyUtils.getElapsedTimeFromMsToMs(lastSuccessfulPollTimestamp);
           elapsedTimeSinceLastRecordForPartitionInMs =
               LatencyUtils.getElapsedTimeFromMsToMs(lastSuccessfulPollTimestamp);
         }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/KafkaConsumerService.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/KafkaConsumerService.java
@@ -576,11 +576,10 @@ public abstract class KafkaConsumerService extends AbstractKafkaConsumerService 
         double msgRate = partitionStats.getMessageRate();
         double byteRate = partitionStats.getBytesRate();
         long lastSuccessfulPollTimestamp = partitionStats.getLastSuccessfulPollTimestamp();
-        long elapsedTimeSinceLastConsumerPollInMs = ConsumptionTask.DEFAULT_TOPIC_PARTITION_NO_POLL_TIMESTAMP;
         long elapsedTimeSinceLastRecordForPartitionInMs = ConsumptionTask.DEFAULT_TOPIC_PARTITION_NO_POLL_TIMESTAMP;
 
         // Consumer level elapsed time
-        elapsedTimeSinceLastConsumerPollInMs =
+        long elapsedTimeSinceLastConsumerPollInMs =
             LatencyUtils.getElapsedTimeFromMsToMs(consumptionTask.getLastSuccessfulPollTimestamp());
 
         // Partition level elapsed time

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/KafkaConsumerService.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/KafkaConsumerService.java
@@ -577,9 +577,11 @@ public abstract class KafkaConsumerService extends AbstractKafkaConsumerService 
         double byteRate = partitionStats.getBytesRate();
         long lastSuccessfulPollTimestamp = partitionStats.getLastSuccessfulPollTimestamp();
         long elapsedTimeSinceLastPollInMs = ConsumptionTask.DEFAULT_TOPIC_PARTITION_NO_POLL_TIMESTAMP;
+        long elapsedTimeSinceLastPolledRecordsInMs = ConsumptionTask.DEFAULT_TOPIC_PARTITION_NO_POLL_TIMESTAMP;
         if (lastSuccessfulPollTimestamp != ConsumptionTask.DEFAULT_TOPIC_PARTITION_NO_POLL_TIMESTAMP) {
           elapsedTimeSinceLastPollInMs =
               LatencyUtils.getElapsedTimeFromMsToMs(consumptionTask.getLastSuccessfulPollTimestamp());
+          elapsedTimeSinceLastPolledRecordsInMs = LatencyUtils.getElapsedTimeFromMsToMs(lastSuccessfulPollTimestamp);
         }
         PubSubTopic destinationVersionTopic = consumptionTask.getDestinationIdentifier(topicPartition);
         String destinationVersionTopicName = destinationVersionTopic == null ? "" : destinationVersionTopic.getName();
@@ -590,6 +592,7 @@ public abstract class KafkaConsumerService extends AbstractKafkaConsumerService 
             byteRate,
             consumerIdStr,
             elapsedTimeSinceLastPollInMs,
+            elapsedTimeSinceLastPolledRecordsInMs,
             destinationVersionTopicName);
         topicPartitionIngestionInfoMap.put(topicPartition, topicPartitionIngestionInfo);
       }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/KafkaConsumerService.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/KafkaConsumerService.java
@@ -576,12 +576,12 @@ public abstract class KafkaConsumerService extends AbstractKafkaConsumerService 
         double msgRate = partitionStats.getMessageRate();
         double byteRate = partitionStats.getBytesRate();
         long lastSuccessfulPollTimestamp = partitionStats.getLastSuccessfulPollTimestamp();
-        long elapsedTimeSinceLastPollInMs = ConsumptionTask.DEFAULT_TOPIC_PARTITION_NO_POLL_TIMESTAMP;
-        long elapsedTimeSinceLastPolledRecordsInMs = ConsumptionTask.DEFAULT_TOPIC_PARTITION_NO_POLL_TIMESTAMP;
-        if (lastSuccessfulPollTimestamp != ConsumptionTask.DEFAULT_TOPIC_PARTITION_NO_POLL_TIMESTAMP) {
-          elapsedTimeSinceLastPollInMs =
-              LatencyUtils.getElapsedTimeFromMsToMs(consumptionTask.getLastSuccessfulPollTimestamp());
-          elapsedTimeSinceLastPolledRecordsInMs = LatencyUtils.getElapsedTimeFromMsToMs(lastSuccessfulPollTimestamp);
+        long elapsedTimeSinceLastConsumerPollInMs = ConsumptionTask.DEFAULT_TOPIC_PARTITION_NO_POLL_TIMESTAMP;
+        long elapsedTimeSinceLastRecordForPartitionInMs = ConsumptionTask.DEFAULT_TOPIC_PARTITION_NO_POLL_TIMESTAMP;
+        if (lastSuccessfulPollTimestamp > 0) {
+          elapsedTimeSinceLastConsumerPollInMs = LatencyUtils.getElapsedTimeFromMsToMs(lastSuccessfulPollTimestamp);
+          elapsedTimeSinceLastRecordForPartitionInMs =
+              LatencyUtils.getElapsedTimeFromMsToMs(lastSuccessfulPollTimestamp);
         }
         PubSubTopic destinationVersionTopic = consumptionTask.getDestinationIdentifier(topicPartition);
         String destinationVersionTopicName = destinationVersionTopic == null ? "" : destinationVersionTopic.getName();
@@ -591,8 +591,8 @@ public abstract class KafkaConsumerService extends AbstractKafkaConsumerService 
             msgRate,
             byteRate,
             consumerIdStr,
-            elapsedTimeSinceLastPollInMs,
-            elapsedTimeSinceLastPolledRecordsInMs,
+            elapsedTimeSinceLastConsumerPollInMs,
+            elapsedTimeSinceLastRecordForPartitionInMs,
             destinationVersionTopicName);
         topicPartitionIngestionInfoMap.put(topicPartition, topicPartitionIngestionInfo);
       }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/TopicPartitionIngestionInfo.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/TopicPartitionIngestionInfo.java
@@ -11,7 +11,7 @@ public class TopicPartitionIngestionInfo {
   private double byteRate;
   private String consumerIdStr;
   private long elapsedTimeSinceLastPollInMs;
-
+  private long elapsedTimeSinceLastPolledRecordsInMs;
   private String versionTopicName;
 
   @JsonCreator
@@ -22,6 +22,7 @@ public class TopicPartitionIngestionInfo {
       @JsonProperty("byteRate") double byteRate,
       @JsonProperty("consumerIdStr") String consumerIdStr,
       @JsonProperty("elapsedTimeSinceLastPollInMs") long elapsedTimeSinceLastPollInMs,
+      @JsonProperty("elapsedTimeSinceLastPolledRecordsInMs") long elapsedTimeSinceLastPolledRecordsInMs,
       @JsonProperty("versionTopicName") String versionTopicName) {
     this.latestOffset = latestOffset;
     this.offsetLag = offsetLag;
@@ -29,6 +30,7 @@ public class TopicPartitionIngestionInfo {
     this.byteRate = byteRate;
     this.consumerIdStr = consumerIdStr;
     this.elapsedTimeSinceLastPollInMs = elapsedTimeSinceLastPollInMs;
+    this.elapsedTimeSinceLastPolledRecordsInMs = elapsedTimeSinceLastPolledRecordsInMs;
     this.versionTopicName = versionTopicName;
   }
 
@@ -76,6 +78,14 @@ public class TopicPartitionIngestionInfo {
     this.elapsedTimeSinceLastPollInMs = elapsedTimeSinceLastPollInMs;
   }
 
+  public long getElapsedTimeSinceLastPolledRecordsInMs() {
+    return elapsedTimeSinceLastPolledRecordsInMs;
+  }
+
+  public void setElapsedTimeSinceLastPolledRecordsInMs(long elapsedTimeSinceLastPolledRecordsInMs) {
+    this.elapsedTimeSinceLastPolledRecordsInMs = elapsedTimeSinceLastPolledRecordsInMs;
+  }
+
   public String getVersionTopicName() {
     return versionTopicName;
   }
@@ -99,6 +109,8 @@ public class TopicPartitionIngestionInfo {
         && Double.doubleToLongBits(this.byteRate) == Double.doubleToLongBits(topicPartitionIngestionInfo.getByteRate())
         && this.consumerIdStr.equals(topicPartitionIngestionInfo.getConsumerIdStr())
         && this.elapsedTimeSinceLastPollInMs == topicPartitionIngestionInfo.getElapsedTimeSinceLastPollInMs()
+        && this.elapsedTimeSinceLastPolledRecordsInMs == topicPartitionIngestionInfo
+            .getElapsedTimeSinceLastPolledRecordsInMs()
         && this.versionTopicName.equals(topicPartitionIngestionInfo.getVersionTopicName());
   }
 
@@ -110,6 +122,7 @@ public class TopicPartitionIngestionInfo {
     result = 31 * result + Double.hashCode(byteRate);
     result = 31 * result + consumerIdStr.hashCode();
     result = 31 * result + Long.hashCode(elapsedTimeSinceLastPollInMs);
+    result = 31 * result + Long.hashCode(elapsedTimeSinceLastPolledRecordsInMs);
     result = 31 * result + versionTopicName.hashCode();
     return result;
   }
@@ -118,6 +131,7 @@ public class TopicPartitionIngestionInfo {
   public String toString() {
     return "{" + "latestOffset:" + latestOffset + ", offsetLag:" + offsetLag + ", msgRate:" + msgRate + ", byteRate:"
         + byteRate + ", consumerIdStr:" + consumerIdStr + ", elapsedTimeSinceLastPollInMs:"
-        + elapsedTimeSinceLastPollInMs + ", versionTopicName:" + versionTopicName + '}';
+        + elapsedTimeSinceLastPollInMs + ", elapsedTimeSinceLastPolledRecordsInMs:"
+        + elapsedTimeSinceLastPolledRecordsInMs + ", versionTopicName:" + versionTopicName + '}';
   }
 }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/TopicPartitionIngestionInfo.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/TopicPartitionIngestionInfo.java
@@ -10,8 +10,19 @@ public class TopicPartitionIngestionInfo {
   private double msgRate;
   private double byteRate;
   private String consumerIdStr;
-  private long elapsedTimeSinceLastPollInMs;
-  private long elapsedTimeSinceLastPolledRecordsInMs;
+  /**
+   * Tracks how much time has passed since the last Kafka consumer poll operation, regardless of whether any records were received.
+   * This field helps monitor the overall consumer health and polling activity.
+   * For example, if this value is too high, it might indicate that the consumer is not actively polling or is experiencing issues.
+   */
+  private long elapsedTimeSinceLastConsumerPollInMs;
+  /**
+   * Tracks how much time has passed since the last time any records were actually received for this specific topic partition.
+   * Unlike elapsedTimeSinceLastConsumerPollInMs which tracks any poll attempt, this field only considers polls that returned data
+   * for this particular partition.
+   * This helps identify partitions that haven't received new data for a while, which could indicate upstream issues or partition-specific delays.
+   */
+  private long elapsedTimeSinceLastRecordForPartitionInMs;
   private String versionTopicName;
 
   @JsonCreator
@@ -21,16 +32,16 @@ public class TopicPartitionIngestionInfo {
       @JsonProperty("msgRate") double msgRate,
       @JsonProperty("byteRate") double byteRate,
       @JsonProperty("consumerIdStr") String consumerIdStr,
-      @JsonProperty("elapsedTimeSinceLastPollInMs") long elapsedTimeSinceLastPollInMs,
-      @JsonProperty("elapsedTimeSinceLastPolledRecordsInMs") long elapsedTimeSinceLastPolledRecordsInMs,
+      @JsonProperty("elapsedTimeSinceLastPollInMs") long elapsedTimeSinceLastConsumerPollInMs,
+      @JsonProperty("elapsedTimeSinceLastPolledRecordsInMs") long elapsedTimeSinceLastRecordForPartitionInMs,
       @JsonProperty("versionTopicName") String versionTopicName) {
     this.latestOffset = latestOffset;
     this.offsetLag = offsetLag;
     this.msgRate = msgRate;
     this.byteRate = byteRate;
     this.consumerIdStr = consumerIdStr;
-    this.elapsedTimeSinceLastPollInMs = elapsedTimeSinceLastPollInMs;
-    this.elapsedTimeSinceLastPolledRecordsInMs = elapsedTimeSinceLastPolledRecordsInMs;
+    this.elapsedTimeSinceLastConsumerPollInMs = elapsedTimeSinceLastConsumerPollInMs;
+    this.elapsedTimeSinceLastRecordForPartitionInMs = elapsedTimeSinceLastRecordForPartitionInMs;
     this.versionTopicName = versionTopicName;
   }
 
@@ -70,20 +81,20 @@ public class TopicPartitionIngestionInfo {
     this.consumerIdStr = consumerIdStr;
   }
 
-  public long getElapsedTimeSinceLastPollInMs() {
-    return elapsedTimeSinceLastPollInMs;
+  public long getElapsedTimeSinceLastConsumerPollInMs() {
+    return elapsedTimeSinceLastConsumerPollInMs;
   }
 
-  public void setElapsedTimeSinceLastPollInMs(long elapsedTimeSinceLastPollInMs) {
-    this.elapsedTimeSinceLastPollInMs = elapsedTimeSinceLastPollInMs;
+  public void setElapsedTimeSinceLastConsumerPollInMs(long elapsedTimeSinceLastConsumerPollInMs) {
+    this.elapsedTimeSinceLastConsumerPollInMs = elapsedTimeSinceLastConsumerPollInMs;
   }
 
-  public long getElapsedTimeSinceLastPolledRecordsInMs() {
-    return elapsedTimeSinceLastPolledRecordsInMs;
+  public long getElapsedTimeSinceLastRecordForPartitionInMs() {
+    return elapsedTimeSinceLastRecordForPartitionInMs;
   }
 
-  public void setElapsedTimeSinceLastPolledRecordsInMs(long elapsedTimeSinceLastPolledRecordsInMs) {
-    this.elapsedTimeSinceLastPolledRecordsInMs = elapsedTimeSinceLastPolledRecordsInMs;
+  public void setElapsedTimeSinceLastRecordForPartitionInMs(long elapsedTimeSinceLastRecordForPartitionInMs) {
+    this.elapsedTimeSinceLastRecordForPartitionInMs = elapsedTimeSinceLastRecordForPartitionInMs;
   }
 
   public String getVersionTopicName() {
@@ -108,9 +119,10 @@ public class TopicPartitionIngestionInfo {
         && Double.doubleToLongBits(this.msgRate) == Double.doubleToLongBits(topicPartitionIngestionInfo.getMsgRate())
         && Double.doubleToLongBits(this.byteRate) == Double.doubleToLongBits(topicPartitionIngestionInfo.getByteRate())
         && this.consumerIdStr.equals(topicPartitionIngestionInfo.getConsumerIdStr())
-        && this.elapsedTimeSinceLastPollInMs == topicPartitionIngestionInfo.getElapsedTimeSinceLastPollInMs()
-        && this.elapsedTimeSinceLastPolledRecordsInMs == topicPartitionIngestionInfo
-            .getElapsedTimeSinceLastPolledRecordsInMs()
+        && this.elapsedTimeSinceLastConsumerPollInMs == topicPartitionIngestionInfo
+            .getElapsedTimeSinceLastConsumerPollInMs()
+        && this.elapsedTimeSinceLastRecordForPartitionInMs == topicPartitionIngestionInfo
+            .getElapsedTimeSinceLastRecordForPartitionInMs()
         && this.versionTopicName.equals(topicPartitionIngestionInfo.getVersionTopicName());
   }
 
@@ -121,8 +133,8 @@ public class TopicPartitionIngestionInfo {
     result = 31 * result + Double.hashCode(msgRate);
     result = 31 * result + Double.hashCode(byteRate);
     result = 31 * result + consumerIdStr.hashCode();
-    result = 31 * result + Long.hashCode(elapsedTimeSinceLastPollInMs);
-    result = 31 * result + Long.hashCode(elapsedTimeSinceLastPolledRecordsInMs);
+    result = 31 * result + Long.hashCode(elapsedTimeSinceLastConsumerPollInMs);
+    result = 31 * result + Long.hashCode(elapsedTimeSinceLastRecordForPartitionInMs);
     result = 31 * result + versionTopicName.hashCode();
     return result;
   }
@@ -130,8 +142,8 @@ public class TopicPartitionIngestionInfo {
   @Override
   public String toString() {
     return "{" + "latestOffset:" + latestOffset + ", offsetLag:" + offsetLag + ", msgRate:" + msgRate + ", byteRate:"
-        + byteRate + ", consumerIdStr:" + consumerIdStr + ", elapsedTimeSinceLastPollInMs:"
-        + elapsedTimeSinceLastPollInMs + ", elapsedTimeSinceLastPolledRecordsInMs:"
-        + elapsedTimeSinceLastPolledRecordsInMs + ", versionTopicName:" + versionTopicName + '}';
+        + byteRate + ", consumerIdStr:" + consumerIdStr + ", elapsedTimeSinceLastConsumerPollInMs:"
+        + elapsedTimeSinceLastConsumerPollInMs + ", elapsedTimeSinceLastRecordForPartitionInMs:"
+        + elapsedTimeSinceLastRecordForPartitionInMs + ", versionTopicName:" + versionTopicName + '}';
   }
 }

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/consumer/TopicPartitionIngestionInfoTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/consumer/TopicPartitionIngestionInfoTest.java
@@ -20,7 +20,7 @@ public class TopicPartitionIngestionInfoTest {
   public void testJsonParse() throws Exception {
     PubSubTopic versionTopic = pubSubTopicRepository.getTopic("test_store_v1");
     TopicPartitionIngestionInfo topicPartitionIngestionInfo =
-        new TopicPartitionIngestionInfo(0, 1, 2.0, 4.0, "consumerIdStr", 7, versionTopic.getName());
+        new TopicPartitionIngestionInfo(0, 1, 2.0, 4.0, "consumerIdStr", 7, 8, versionTopic.getName());
     String kafkaUrl = "localhost:1234";
     PubSubTopicPartition pubSubTopicPartition = new PubSubTopicPartitionImpl(versionTopic, 0);
     Map<String, Map<String, TopicPartitionIngestionInfo>> topicPartitionIngestionContext = new HashMap<>();
@@ -35,5 +35,49 @@ public class TopicPartitionIngestionInfoTest {
     Assert.assertEquals(
         topicPartitionIngestionContexts.get(kafkaUrl).get(pubSubTopicPartition.toString()),
         topicPartitionIngestionInfo);
+  }
+
+  @Test
+  public void testElapsedTimeSinceLastPolledRecordsInMs() {
+    long elapsedTimeSinceLastPollInMs = 100;
+    long elapsedTimeSinceLastPolledRecordsInMs = 200;
+    TopicPartitionIngestionInfo info = new TopicPartitionIngestionInfo(
+        0,
+        1,
+        2.0,
+        4.0,
+        "testConsumer",
+        elapsedTimeSinceLastPollInMs,
+        elapsedTimeSinceLastPolledRecordsInMs,
+        "test_store_v1");
+
+    Assert.assertEquals(info.getElapsedTimeSinceLastPollInMs(), elapsedTimeSinceLastPollInMs);
+    Assert.assertEquals(info.getElapsedTimeSinceLastPolledRecordsInMs(), elapsedTimeSinceLastPolledRecordsInMs);
+
+    String infoString = info.toString();
+    Assert.assertTrue(
+        infoString.contains("elapsedTimeSinceLastPolledRecordsInMs:" + elapsedTimeSinceLastPolledRecordsInMs));
+
+    TopicPartitionIngestionInfo sameInfo = new TopicPartitionIngestionInfo(
+        0,
+        1,
+        2.0,
+        4.0,
+        "testConsumer",
+        elapsedTimeSinceLastPollInMs,
+        elapsedTimeSinceLastPolledRecordsInMs,
+        "test_store_v1");
+    Assert.assertEquals(info, sameInfo);
+
+    TopicPartitionIngestionInfo differentInfo = new TopicPartitionIngestionInfo(
+        0,
+        1,
+        2.0,
+        4.0,
+        "testConsumer",
+        elapsedTimeSinceLastPollInMs,
+        300,
+        "test_store_v1");
+    Assert.assertNotEquals(info, differentInfo);
   }
 }

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/consumer/TopicPartitionIngestionInfoTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/consumer/TopicPartitionIngestionInfoTest.java
@@ -39,45 +39,47 @@ public class TopicPartitionIngestionInfoTest {
 
   @Test
   public void testElapsedTimeSinceLastPolledRecordsInMs() {
-    long elapsedTimeSinceLastPollInMs = 100;
-    long elapsedTimeSinceLastPolledRecordsInMs = 200;
+    long elapsedTimeSinceLastConsumerPollInMs = 100;
+    long elapsedTimeSinceLastRecordForPartitionInMs = 200;
     TopicPartitionIngestionInfo info = new TopicPartitionIngestionInfo(
-        0,
-        1,
-        2.0,
-        4.0,
-        "testConsumer",
-        elapsedTimeSinceLastPollInMs,
-        elapsedTimeSinceLastPolledRecordsInMs,
-        "test_store_v1");
-
-    Assert.assertEquals(info.getElapsedTimeSinceLastPollInMs(), elapsedTimeSinceLastPollInMs);
-    Assert.assertEquals(info.getElapsedTimeSinceLastPolledRecordsInMs(), elapsedTimeSinceLastPolledRecordsInMs);
-
+        0L,
+        0L,
+        0.0,
+        0.0,
+        "consumer1",
+        elapsedTimeSinceLastConsumerPollInMs,
+        elapsedTimeSinceLastRecordForPartitionInMs,
+        "test-topic");
+    Assert.assertEquals(info.getElapsedTimeSinceLastConsumerPollInMs(), elapsedTimeSinceLastConsumerPollInMs);
+    Assert
+        .assertEquals(info.getElapsedTimeSinceLastRecordForPartitionInMs(), elapsedTimeSinceLastRecordForPartitionInMs);
     String infoString = info.toString();
     Assert.assertTrue(
-        infoString.contains("elapsedTimeSinceLastPolledRecordsInMs:" + elapsedTimeSinceLastPolledRecordsInMs));
+        infoString.contains("elapsedTimeSinceLastConsumerPollInMs:" + elapsedTimeSinceLastConsumerPollInMs));
+    Assert.assertTrue(
+        infoString
+            .contains("elapsedTimeSinceLastRecordForPartitionInMs:" + elapsedTimeSinceLastRecordForPartitionInMs));
 
     TopicPartitionIngestionInfo sameInfo = new TopicPartitionIngestionInfo(
-        0,
-        1,
-        2.0,
-        4.0,
-        "testConsumer",
-        elapsedTimeSinceLastPollInMs,
-        elapsedTimeSinceLastPolledRecordsInMs,
-        "test_store_v1");
+        0L,
+        0L,
+        0.0,
+        0.0,
+        "consumer1",
+        elapsedTimeSinceLastConsumerPollInMs,
+        elapsedTimeSinceLastRecordForPartitionInMs,
+        "test-topic");
     Assert.assertEquals(info, sameInfo);
 
     TopicPartitionIngestionInfo differentInfo = new TopicPartitionIngestionInfo(
-        0,
-        1,
-        2.0,
-        4.0,
-        "testConsumer",
-        elapsedTimeSinceLastPollInMs,
+        0L,
+        0L,
+        0.0,
+        0.0,
+        "consumer1",
+        elapsedTimeSinceLastConsumerPollInMs,
         300,
-        "test_store_v1");
+        "test-topic");
     Assert.assertNotEquals(info, differentInfo);
   }
 }

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/KafkaConsumerServiceTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/KafkaConsumerServiceTest.java
@@ -212,13 +212,25 @@ public class KafkaConsumerServiceTest {
           consumerService.getIngestionInfoFor(versionTopic, topicPartition);
       Assert.assertEquals(topicPartitionIngestionInfoMap.size(), 1);
       Assert.assertTrue(topicPartitionIngestionInfoMap.containsKey(topicPartition));
-      Assert.assertTrue(topicPartitionIngestionInfoMap.get(topicPartition).getConsumerIdStr().contains("0"));
-      Assert.assertTrue(topicPartitionIngestionInfoMap.get(topicPartition).getConsumerIdStr().contains(testKafkaUrl));
-      Assert.assertTrue(topicPartitionIngestionInfoMap.get(topicPartition).getMsgRate() > 0);
-      Assert.assertTrue(topicPartitionIngestionInfoMap.get(topicPartition).getByteRate() > 0);
-      Assert.assertEquals(
-          topicPartitionIngestionInfoMap.get(topicPartition).getVersionTopicName(),
-          topicForStoreName3.getName());
+      TopicPartitionIngestionInfo info = topicPartitionIngestionInfoMap.get(topicPartition);
+      Assert.assertTrue(info.getConsumerIdStr().contains("0"));
+      Assert.assertTrue(info.getConsumerIdStr().contains(testKafkaUrl));
+      Assert.assertTrue(info.getMsgRate() > 0);
+      Assert.assertTrue(info.getByteRate() > 0);
+      Assert.assertEquals(info.getVersionTopicName(), topicForStoreName3.getName());
+      Assert.assertTrue(
+          info.getElapsedTimeSinceLastConsumerPollInMs() >= 0,
+          "elapsedTimeSinceLastConsumerPollInMs should be non-negative");
+      Assert.assertTrue(
+          info.getElapsedTimeSinceLastRecordForPartitionInMs() >= 0,
+          "elapsedTimeSinceLastRecordForPartitionInMs should be non-negative");
+      String infoString = info.toString();
+      Assert.assertTrue(
+          infoString.contains("elapsedTimeSinceLastConsumerPollInMs:"),
+          "toString should contain elapsedTimeSinceLastConsumerPollInMs field");
+      Assert.assertTrue(
+          infoString.contains("elapsedTimeSinceLastRecordForPartitionInMs:"),
+          "toString should contain elapsedTimeSinceLastRecordForPartitionInMs field");
       verify(mockIngestionThrottler, atLeastOnce()).maybeThrottleBandwidth(anyInt());
       verify(mockIngestionThrottler, atLeastOnce())
           .maybeThrottleRecordRate(eq(ConsumerPoolType.AA_WC_LEADER_POOL), anyInt());

--- a/services/venice-server/src/test/java/com/linkedin/venice/listener/OutboundHttpWrapperHandlerTest.java
+++ b/services/venice-server/src/test/java/com/linkedin/venice/listener/OutboundHttpWrapperHandlerTest.java
@@ -259,8 +259,10 @@ public class OutboundHttpWrapperHandlerTest {
     int expectedPartitionId = 12345;
     String jsonStr = "{\n" + "\"kafkaUrl\" : {\n" + "  TP(topic: \"" + topic + "\", partition: " + expectedPartitionId
         + ") : {\n" + "      \"latestOffset\" : 0,\n" + "      \"offsetLag\" : 1,\n" + "      \"msgRate\" : 2.0,\n"
-        + "      \"byteRate\" : 4.0,\n" + "      \"consumerIdx\" : 6,\n"
-        + "      \"elapsedTimeSinceLastPollInMs\" : 7\n" + "    }\n" + "  }\n" + "}";
+        + "      \"byteRate\" : 6.0,\n" + "      \"consumerIdStr\" : \"consumer1\",\n"
+        + "      \"elapsedTimeSinceLastConsumerPollInMs\" : 7,\n"
+        + "      \"elapsedTimeSinceLastRecordForPartitionInMs\" : 8,\n"
+        + "      \"versionTopicName\" : \"test_store_v1\"\n" + "    }\n" + "  }\n" + "}";
     msg.setPayload(jsonStr.getBytes());
     StatsHandler statsHandler = mock(StatsHandler.class);
     ChannelHandlerContext mockCtx = mock(ChannelHandlerContext.class);

--- a/services/venice-server/src/test/java/com/linkedin/venice/listener/StorageReadRequestHandlerTest.java
+++ b/services/venice-server/src/test/java/com/linkedin/venice/listener/StorageReadRequestHandlerTest.java
@@ -581,8 +581,10 @@ public class StorageReadRequestHandlerTest {
     ReplicaIngestionResponse expectedReplicaIngestionResponse = new ReplicaIngestionResponse();
     String jsonStr = "{\n" + "\"kafkaUrl\" : {\n" + "  TP(topic: \"" + topic + "\", partition: " + expectedPartitionId
         + ") : {\n" + "      \"latestOffset\" : 0,\n" + "      \"offsetLag\" : 1,\n" + "      \"msgRate\" : 2.0,\n"
-        + "      \"byteRate\" : 4.0,\n" + "      \"consumerIdx\" : 6,\n"
-        + "      \"elapsedTimeSinceLastPollInMs\" : 7\n" + "    }\n" + "  }\n" + "}";
+        + "      \"byteRate\" : 6.0,\n" + "      \"consumerIdStr\" : \"consumer1\",\n"
+        + "      \"elapsedTimeSinceLastConsumerPollInMs\" : 7,\n"
+        + "      \"elapsedTimeSinceLastRecordForPartitionInMs\" : 8,\n"
+        + "      \"versionTopicName\" : \"test_store_v1\"\n" + "    }\n" + "  }\n" + "}";
     byte[] expectedTopicPartitionContext = jsonStr.getBytes();
     expectedReplicaIngestionResponse.setPayload(expectedTopicPartitionContext);
     doReturn(expectedReplicaIngestionResponse).when(ingestionMetadataRetriever)


### PR DESCRIPTION
We need to track elapsed time since last records were polled for each topic partition. This information helps to debug slow ingestion issues by providing more granular timing data through admin tool query. The new field `elapsedTimeSinceLastPolledRecordsInMs` is different from `elapsedTimeSinceLastPollInMs` as it specifically tracks when actual records were last received for a topic partition.

## How was this PR tested?
- Added unit test `testElapsedTimeSinceLastPolledRecordsInMs` to verify the new field
- Updated existing `testJsonParse` to include the new field
- All tests pass successfully

## Does this PR introduce any user-facing changes?
- [x] No. You can skip the rest of this section.