### PR TITLE
[test] Fix flaky test TestActiveActiveIngestion::testLeaderLagWithIgnoredData

### DIFF
--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestActiveActiveIngestion.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestActiveActiveIngestion.java
@@ -181,7 +181,7 @@ public class TestActiveActiveIngestion {
     String keySchemaStr = recordSchema.getField(DEFAULT_KEY_FIELD_PROP).schema().toString();
     String valueSchemaStr = recordSchema.getField(DEFAULT_VALUE_FIELD_PROP).schema().toString();
     UpdateStoreQueryParams storeParms = new UpdateStoreQueryParams().setActiveActiveReplicationEnabled(true)
-        .setHybridRewindSeconds(604800) // 7 days
+        .setHybridRewindSeconds(360)
         .setHybridOffsetLagThreshold(0)
         .setChunkingEnabled(true)
         .setNativeReplicationEnabled(true)

--- a/services/venice-controller/src/main/java/com/linkedin/venice/ingestion/control/RealTimeTopicSwitcher.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/ingestion/control/RealTimeTopicSwitcher.java
@@ -227,7 +227,12 @@ public class RealTimeTopicSwitcher {
         && topicManager.containsTopic(pubSubTopicRepository.getTopic(rtForPreviousVersion));
     boolean rtExistsForNextVersion =
         nextStoreVersion.isHybrid() && topicManager.containsTopic(pubSubTopicRepository.getTopic(rtForNextVersion));
-    LOGGER.info("Previous store version - {}, nextStoreVersion - {}, ");
+    LOGGER.info(
+        "Previous store version - {}, nextStoreVersion - {}, RT for previous version - {}, RT for next version - {}",
+        previousStoreVersion,
+        nextStoreVersion,
+        rtForPreviousVersion,
+        rtForNextVersion);
 
     if (rtExistsForPreviousVersion || rtExistsForNextVersion) {
       if (rtExistsForPreviousVersion) {


### PR DESCRIPTION
## Fix flakiness in active-active ingestion test by anchoring on MARKER record

The test runs verification checks immediately after the push completes, which may happen  
before the leader has processed all real-time records. This led to nondeterministic results  
due to timing differences in ingestion and verification steps.  

To fix this, a fresh MARKER record is appended to the RT, and the test waits until it can  
be fetched. This ensures that all prior records have been processed (either accepted or  
dropped in DCR) by the leader before verification begins, making the test deterministic.  


## Solution
<!--
Describe
- What changes you are making and why. 
- How these changes solve the problem.
- Any performance considerations or trade-offs. 
- Describe what testings you have done, for example, performance testing etc.
-->


###  Code changes
- [ ] Added new code behind **a config**. If so list the config names and their default values in the PR description.
- [ ] Introduced new **log lines**. 
  - [ ] Confirmed if logs need to be **rate limited** to avoid excessive logging.

###  **Concurrency-Specific Checks**
Both reviewer and PR author to verify
- [ ] Code has **no race conditions** or **thread safety issues**.
- [ ] Proper **synchronization mechanisms** (e.g., `synchronized`, `RWLock`) are used where needed.
- [ ] No **blocking calls** inside critical sections that could lead to deadlocks or performance degradation.
- [ ] Verified **thread-safe collections** are used (e.g., `ConcurrentHashMap`, `CopyOnWriteArrayList`).
- [ ] Validated proper exception handling in multi-threaded code to avoid silent thread termination.


## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->

- [ ] New unit tests added.
- [ ] New integration tests added.
- [ ] Modified or extended existing tests.
- [ ] Verified backward compatibility (if applicable).

## Does this PR introduce any user-facing or breaking changes?
<!--  
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [ ] No. You can skip the rest of this section.
- [ ] Yes. Clearly explain the behavior change and its impact.