### PR TITLE
[cc] Change Count metrics for CDC from Count to Rate, and fix the metrics reporter name for BootstrappingConsumer

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/consumer/VeniceChangelogConsumerClientFactory.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/consumer/VeniceChangelogConsumerClientFactory.java
@@ -137,7 +137,8 @@ public class VeniceChangelogConsumerClientFactory {
       ChangelogClientConfig newStoreChangelogClientConfig =
           getNewStoreChangelogClientConfig(storeName).setSpecificKey(keyClass)
               .setSpecificValue(valueClass)
-              .setSpecificValueSchema(valueSchema);
+              .setSpecificValueSchema(valueSchema)
+              .setConsumerName(consumerName);
 
       if (globalChangelogClientConfig.isExperimentalClientEnabled()) {
         return new BootstrappingVeniceChangelogConsumerDaVinciRecordTransformerImpl<K, V>(
@@ -250,20 +251,6 @@ public class VeniceChangelogConsumerClientFactory {
       }
       return viewConfig.getViewClassName();
     };
-  }
-
-  private String cleanConsumerId(String consumerId, String viewName) {
-    String adjustedConsumerId;
-    if (!StringUtils.isEmpty(viewName)) {
-      if (StringUtils.isEmpty(consumerId)) {
-        adjustedConsumerId = viewName;
-      } else {
-        adjustedConsumerId = consumerId + "-" + viewName;
-      }
-    } else {
-      adjustedConsumerId = consumerId;
-    }
-    return adjustedConsumerId;
   }
 
   protected void setViewClassGetter(ViewClassGetter viewClassGetter) {

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/consumer/stats/BasicConsumerStats.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/consumer/stats/BasicConsumerStats.java
@@ -24,9 +24,9 @@ import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.common.AttributesBuilder;
 import io.tehuti.metrics.MetricsRepository;
 import io.tehuti.metrics.stats.Avg;
-import io.tehuti.metrics.stats.Count;
 import io.tehuti.metrics.stats.Gauge;
 import io.tehuti.metrics.stats.Max;
+import io.tehuti.metrics.stats.Rate;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
@@ -116,7 +116,7 @@ public class BasicConsumerStats extends AbstractVeniceStats {
         otelRepository,
         this::registerSensor,
         BasicConsumerTehutiMetricName.RECORDS_CONSUMED,
-        Arrays.asList(new Avg(), new Max(), new Count()),
+        Arrays.asList(new Avg(), new Max(), new Rate()),
         baseDimensionsMap,
         baseAttributes);
 
@@ -125,7 +125,7 @@ public class BasicConsumerStats extends AbstractVeniceStats {
         otelRepository,
         this::registerSensor,
         BasicConsumerTehutiMetricName.POLL_SUCCESS_COUNT,
-        Collections.singletonList(new Count()),
+        Collections.singletonList(new Rate()),
         baseDimensionsMap,
         VeniceResponseStatusCategory.class);
 
@@ -134,7 +134,7 @@ public class BasicConsumerStats extends AbstractVeniceStats {
         otelRepository,
         this::registerSensor,
         BasicConsumerTehutiMetricName.POLL_FAIL_COUNT,
-        Collections.singletonList(new Count()),
+        Collections.singletonList(new Rate()),
         baseDimensionsMap,
         VeniceResponseStatusCategory.class);
 
@@ -143,7 +143,7 @@ public class BasicConsumerStats extends AbstractVeniceStats {
         otelRepository,
         this::registerSensor,
         BasicConsumerTehutiMetricName.VERSION_SWAP_SUCCESS_COUNT,
-        Collections.singletonList(new Count()),
+        Collections.singletonList(new Rate()),
         baseDimensionsMap,
         VeniceResponseStatusCategory.class);
 
@@ -152,7 +152,7 @@ public class BasicConsumerStats extends AbstractVeniceStats {
         otelRepository,
         this::registerSensor,
         BasicConsumerTehutiMetricName.VERSION_SWAP_FAIL_COUNT,
-        Collections.singletonList(new Count()),
+        Collections.singletonList(new Rate()),
         baseDimensionsMap,
         VeniceResponseStatusCategory.class);
 
@@ -161,7 +161,7 @@ public class BasicConsumerStats extends AbstractVeniceStats {
         otelRepository,
         this::registerSensor,
         BasicConsumerTehutiMetricName.CHUNKED_RECORD_SUCCESS_COUNT,
-        Collections.singletonList(new Count()),
+        Collections.singletonList(new Rate()),
         baseDimensionsMap,
         VeniceResponseStatusCategory.class);
 
@@ -170,7 +170,7 @@ public class BasicConsumerStats extends AbstractVeniceStats {
         otelRepository,
         this::registerSensor,
         BasicConsumerTehutiMetricName.CHUNKED_RECORD_FAIL_COUNT,
-        Collections.singletonList(new Count()),
+        Collections.singletonList(new Rate()),
         baseDimensionsMap,
         VeniceResponseStatusCategory.class);
   }

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/stats/BasicConsumerStatsTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/stats/BasicConsumerStatsTest.java
@@ -24,6 +24,7 @@ import static com.linkedin.venice.stats.dimensions.VeniceResponseStatusCategory.
 import static com.linkedin.venice.utils.OpenTelemetryDataPointTestUtils.validateHistogramPointData;
 import static com.linkedin.venice.utils.OpenTelemetryDataPointTestUtils.validateLongPointData;
 import static org.testng.Assert.assertEquals;
+import static org.testng.AssertJUnit.assertTrue;
 
 import com.linkedin.davinci.consumer.stats.BasicConsumerStats;
 import com.linkedin.venice.stats.ClientType;
@@ -66,10 +67,10 @@ public class BasicConsumerStatsTest {
 
     consumerStats.emitCurrentConsumingVersionMetrics((int) minVersion, (int) maxVersion);
 
-    validateTehutiMetrics(tehutiMetricPrefix + "--" + MINIMUM_CONSUMING_VERSION.getMetricName() + ".Gauge", minVersion);
-    validateTehutiMetrics(tehutiMetricPrefix + "--" + MAXIMUM_CONSUMING_VERSION.getMetricName() + ".Gauge", maxVersion);
+    validateTehutiMetric(tehutiMetricPrefix + "--" + MINIMUM_CONSUMING_VERSION.getMetricName() + ".Gauge", minVersion);
+    validateTehutiMetric(tehutiMetricPrefix + "--" + MAXIMUM_CONSUMING_VERSION.getMetricName() + ".Gauge", maxVersion);
 
-    validateMinMaxSumAggregationsOtelMetrics(
+    validateMinMaxSumAggregationsOtelMetric(
         storeName,
         CURRENT_CONSUMING_VERSION.getMetricEntity().getMetricName(),
         minVersion,
@@ -83,9 +84,9 @@ public class BasicConsumerStatsTest {
     double delay = 100;
     consumerStats.emitHeartBeatDelayMetrics((long) delay);
 
-    validateTehutiMetrics(tehutiMetricPrefix + "--" + MAX_PARTITION_LAG.getMetricName() + ".Max", delay);
+    validateTehutiMetric(tehutiMetricPrefix + "--" + MAX_PARTITION_LAG.getMetricName() + ".Max", delay);
 
-    validateMinMaxSumAggregationsOtelMetrics(
+    validateMinMaxSumAggregationsOtelMetric(
         storeName,
         HEART_BEAT_DELAY.getMetricEntity().getMetricName(),
         delay,
@@ -97,51 +98,56 @@ public class BasicConsumerStatsTest {
   @Test
   public void testEmitPollSuccessCountMetrics() {
     consumerStats.emitPollCountMetrics(SUCCESS);
-    validateTehutiMetrics(tehutiMetricPrefix + "--" + POLL_SUCCESS_COUNT.getMetricName() + ".Count", 1);
-    validateLongCounterOtelMetrics(storeName, POLL_COUNT.getMetricEntity().getMetricName(), 1, SUCCESS);
+    validateTehutiRateMetric(tehutiMetricPrefix + "--" + POLL_SUCCESS_COUNT.getMetricName() + ".Rate");
+    validateLongCounterOtelMetric(storeName, POLL_COUNT.getMetricEntity().getMetricName(), 1, SUCCESS);
   }
 
   @Test
   public void testEmitPollFailCallCountMetrics() {
     consumerStats.emitPollCountMetrics(FAIL);
-    validateTehutiMetrics(tehutiMetricPrefix + "--" + POLL_FAIL_COUNT.getMetricName() + ".Count", 1);
-    validateLongCounterOtelMetrics(storeName, POLL_COUNT.getMetricEntity().getMetricName(), 1, FAIL);
+    validateTehutiRateMetric(tehutiMetricPrefix + "--" + POLL_FAIL_COUNT.getMetricName() + ".Rate");
+    validateLongCounterOtelMetric(storeName, POLL_COUNT.getMetricEntity().getMetricName(), 1, FAIL);
   }
 
   @Test
   public void testEmitVersionSwapSuccessCountMetrics() {
     consumerStats.emitVersionSwapCountMetrics(SUCCESS);
-    validateTehutiMetrics(tehutiMetricPrefix + "--" + VERSION_SWAP_SUCCESS_COUNT.getMetricName() + ".Count", 1);
-    validateLongCounterOtelMetrics(storeName, VERSION_SWAP_COUNT.getMetricEntity().getMetricName(), 1, SUCCESS);
+    validateTehutiRateMetric(tehutiMetricPrefix + "--" + VERSION_SWAP_SUCCESS_COUNT.getMetricName() + ".Rate");
+    validateLongCounterOtelMetric(storeName, VERSION_SWAP_COUNT.getMetricEntity().getMetricName(), 1, SUCCESS);
   }
 
   @Test
   public void testEmitVersionSwapFailCountMetrics() {
     consumerStats.emitVersionSwapCountMetrics(FAIL);
-    validateTehutiMetrics(tehutiMetricPrefix + "--" + VERSION_SWAP_FAIL_COUNT.getMetricName() + ".Count", 1);
-    validateLongCounterOtelMetrics(storeName, VERSION_SWAP_COUNT.getMetricEntity().getMetricName(), 1, FAIL);
+    validateTehutiRateMetric(tehutiMetricPrefix + "--" + VERSION_SWAP_FAIL_COUNT.getMetricName() + ".Rate");
+    validateLongCounterOtelMetric(storeName, VERSION_SWAP_COUNT.getMetricEntity().getMetricName(), 1, FAIL);
   }
 
   @Test
   public void testEmitChunkedRecordSuccessCountMetrics() {
     consumerStats.emitChunkedRecordCountMetrics(SUCCESS);
-    validateTehutiMetrics(tehutiMetricPrefix + "--" + CHUNKED_RECORD_SUCCESS_COUNT.getMetricName() + ".Count", 1);
-    validateLongCounterOtelMetrics(storeName, CHUNKED_RECORD_COUNT.getMetricEntity().getMetricName(), 1, SUCCESS);
+    validateTehutiRateMetric(tehutiMetricPrefix + "--" + CHUNKED_RECORD_SUCCESS_COUNT.getMetricName() + ".Rate");
+    validateLongCounterOtelMetric(storeName, CHUNKED_RECORD_COUNT.getMetricEntity().getMetricName(), 1, SUCCESS);
   }
 
   @Test
   public void testEmitChunkedRecordFailCountMetrics() {
     consumerStats.emitChunkedRecordCountMetrics(FAIL);
-    validateTehutiMetrics(tehutiMetricPrefix + "--" + CHUNKED_RECORD_FAIL_COUNT.getMetricName() + ".Count", 1);
-    validateLongCounterOtelMetrics(storeName, CHUNKED_RECORD_COUNT.getMetricEntity().getMetricName(), 1, FAIL);
+    validateTehutiRateMetric(tehutiMetricPrefix + "--" + CHUNKED_RECORD_FAIL_COUNT.getMetricName() + ".Rate");
+    validateLongCounterOtelMetric(storeName, CHUNKED_RECORD_COUNT.getMetricEntity().getMetricName(), 1, FAIL);
   }
 
-  private void validateTehutiMetrics(String metricName, double expectedValue) {
+  private void validateTehutiMetric(String metricName, double expectedValue) {
     Map<String, ? extends Metric> metrics = metricsRepository.metrics();
     assertEquals(metrics.get(metricName).value(), expectedValue);
   }
 
-  private void validateMinMaxSumAggregationsOtelMetrics(
+  private void validateTehutiRateMetric(String metricName) {
+    Map<String, ? extends Metric> metrics = metricsRepository.metrics();
+    assertTrue(metrics.get(metricName).value() > 0);
+  }
+
+  private void validateMinMaxSumAggregationsOtelMetric(
       String storeName,
       String metricName,
       double expectedMin,
@@ -161,7 +167,7 @@ public class BasicConsumerStatsTest {
         otelMetricPrefix);
   }
 
-  private void validateLongCounterOtelMetrics(
+  private void validateLongCounterOtelMetric(
       String storeName,
       String metricName,
       double expectedValue,


### PR DESCRIPTION
<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat], [protocol]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## Problem Statement
<!--
Describe
- What problem are you trying to solve
- What issues or limitations exist in the current code
- Why this change is necessary 
-->

1. The current CDC metrics such as `records_consumed.Count` sample at the minute level, so we're unable to see at the second level granularity.
2. The metrics format for the BootstrappingConsumer is incorrect. It looks like this: `vcc---chunked_record_fail_count.Count.rrd`. It's missing the store name in the metric.

## Solution
<!--
Describe
- What changes you are making and why. 
- How these changes solve the problem.
- Any performance considerations or trade-offs. 
- Describe what testings you have done, for example, performance testing etc.
-->

1. Change some of the CDC metrics from Count to Rate so we can see at the second level granularity. This has been confirmed by performing a jar drop on a test client, and reading the Rate metrics.
2.  For the BootstrappingConsumer, we're not providing a way for that client to read the `consumerName`. So we add it to the `ChangelogClientConfig`. We also need to remove the `viewName` when constructing the `consumerName`. The BootstrappingConsumer doesn't support Views, so if we add the `consumerName` to `ChangelogClientConfig`, we end up with this metrics format: `vcc-store-name-String--chunked_record_fail_count.Rate.rrd`. As you can see, String is included in the metric name due to `viewName` being null, which is incorrect. To fix this, we just remove the `viewName` altogether. This has also been verified to work with a jar drop.

###  Code changes
- [ ] Added new code behind **a config**. If so list the config names and their default values in the PR description.
- [ ] Introduced new **log lines**. 
  - [ ] Confirmed if logs need to be **rate limited** to avoid excessive logging.

###  **Concurrency-Specific Checks**
Both reviewer and PR author to verify
- [X] Code has **no race conditions** or **thread safety issues**.
- [X] Proper **synchronization mechanisms** (e.g., `synchronized`, `RWLock`) are used where needed.
- [X] No **blocking calls** inside critical sections that could lead to deadlocks or performance degradation.
- [X] Verified **thread-safe collections** are used (e.g., `ConcurrentHashMap`, `CopyOnWriteArrayList`).
- [X] Validated proper exception handling in multi-threaded code to avoid silent thread termination.


## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->

- [ ] New unit tests added.
- [ ] New integration tests added.
- [X] Modified or extended existing tests.
- [X] Verified backward compatibility (if applicable).

## Does this PR introduce any user-facing or breaking changes?
<!--  
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [X] No. You can skip the rest of this section.
- [ ] Yes. Clearly explain the behavior change and its impact.