### PR TITLE
[fast-client] Add detailed logging with redundant filter for no replica error

### DIFF
--- a/clients/venice-client/src/main/java/com/linkedin/venice/fastclient/meta/HelixGroupRoutingStrategy.java
+++ b/clients/venice-client/src/main/java/com/linkedin/venice/fastclient/meta/HelixGroupRoutingStrategy.java
@@ -19,18 +19,13 @@ import java.util.concurrent.atomic.AtomicReference;
  */
 public class HelixGroupRoutingStrategy extends AbstractClientRoutingStrategy {
   protected AtomicReference<HelixGroupInfo> helixGroupInfoAtomicReference = new AtomicReference<>();
-  protected final InstanceHealthMonitor instanceHealthMonitor;
   protected final HelixGroupStats helixGroupStats;
 
-  public HelixGroupRoutingStrategy(
-      InstanceHealthMonitor instanceHealthMonitor,
-      MetricsRepository metricsRepository,
-      String storeName) {
-    this(instanceHealthMonitor, new HelixGroupStats(metricsRepository, storeName));
+  public HelixGroupRoutingStrategy(MetricsRepository metricsRepository, String storeName) {
+    this(new HelixGroupStats(metricsRepository, storeName));
   }
 
-  HelixGroupRoutingStrategy(InstanceHealthMonitor instanceHealthMonitor, HelixGroupStats helixGroupStats) {
-    this.instanceHealthMonitor = instanceHealthMonitor;
+  HelixGroupRoutingStrategy(HelixGroupStats helixGroupStats) {
     this.helixGroupInfoAtomicReference.set(new HelixGroupInfo(Collections.emptyMap()));
     this.helixGroupStats = helixGroupStats;
   }
@@ -48,7 +43,7 @@ public class HelixGroupRoutingStrategy extends AbstractClientRoutingStrategy {
     for (int i = 0; i < groupCnt; i++) {
       int tmpGroupId = groupIds.get((i + groupId) % groupCnt);
       for (String replica: replicas) {
-        if (instanceToGroupIdMapping.get(replica) == tmpGroupId && instanceHealthMonitor.isRequestAllowed(replica)) {
+        if (instanceToGroupIdMapping.get(replica) == tmpGroupId) {
           return replica;
         }
       }

--- a/clients/venice-client/src/main/java/com/linkedin/venice/fastclient/meta/HelixLeastLoadedGroupRoutingStrategy.java
+++ b/clients/venice-client/src/main/java/com/linkedin/venice/fastclient/meta/HelixLeastLoadedGroupRoutingStrategy.java
@@ -22,15 +22,12 @@ public class HelixLeastLoadedGroupRoutingStrategy extends HelixGroupRoutingStrat
    */
   private static final double AVG_LATENCY_SPECTRUM_FOR_GROUP_SELECTION = 1.5;
 
-  public HelixLeastLoadedGroupRoutingStrategy(
-      InstanceHealthMonitor instanceHealthMonitor,
-      MetricsRepository metricsRepository,
-      String storeName) {
-    super(instanceHealthMonitor, metricsRepository, storeName);
+  public HelixLeastLoadedGroupRoutingStrategy(MetricsRepository metricsRepository, String storeName) {
+    super(metricsRepository, storeName);
   }
 
-  HelixLeastLoadedGroupRoutingStrategy(InstanceHealthMonitor monitor, HelixGroupStats helixGroupStats) {
-    super(monitor, helixGroupStats);
+  HelixLeastLoadedGroupRoutingStrategy(HelixGroupStats helixGroupStats) {
+    super(helixGroupStats);
   }
 
   /**

--- a/clients/venice-client/src/main/java/com/linkedin/venice/fastclient/meta/LeastLoadedClientRoutingStrategy.java
+++ b/clients/venice-client/src/main/java/com/linkedin/venice/fastclient/meta/LeastLoadedClientRoutingStrategy.java
@@ -1,7 +1,6 @@
 package com.linkedin.venice.fastclient.meta;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 
@@ -27,19 +26,7 @@ public class LeastLoadedClientRoutingStrategy extends AbstractClientRoutingStrat
     if (replicas.isEmpty()) {
       return null;
     }
-    List<String> availReplicas = new ArrayList<>();
-    /**
-     * For even distribution, we need to shuffle the replicas.
-     */
-    Collections.shuffle(replicas);
-    for (String replica: replicas) {
-      if (instanceHealthMonitor.isRequestAllowed(replica)) {
-        availReplicas.add(replica);
-      }
-    }
-    if (availReplicas.isEmpty()) {
-      return null;
-    }
+    List<String> availReplicas = new ArrayList<>(replicas);
     /**
      * TODO: maybe we can apply the response-waiting-time-based rather than pending request counter based least-loaded strategy here
      * since application QPS normally is much lower and pending request count can be very low.

--- a/clients/venice-client/src/main/java/com/linkedin/venice/fastclient/meta/StoreMetadata.java
+++ b/clients/venice-client/src/main/java/com/linkedin/venice/fastclient/meta/StoreMetadata.java
@@ -34,7 +34,7 @@ public interface StoreMetadata extends SchemaReader {
   /**
    * This function is expected to return fully qualified URI, such as: "https://fake.host:8888".
    */
-  String getReplica(long requestId, int groupId, int version, int partitionId, Set<String> excludedInstances);
+  String getReplica(long requestId, int groupId, List<String> replicas, Set<String> excludedInstances);
 
   ChainedCompletableFuture<Integer, Integer> trackHealthBasedOnRequestToInstance(
       String instance,

--- a/clients/venice-client/src/test/java/com/linkedin/venice/fastclient/meta/HelixLeastLoadedGroupRoutingStrategyTest.java
+++ b/clients/venice-client/src/test/java/com/linkedin/venice/fastclient/meta/HelixLeastLoadedGroupRoutingStrategyTest.java
@@ -18,7 +18,6 @@ public class HelixLeastLoadedGroupRoutingStrategyTest {
 
   @Test
   public void testGetHelixGroupId() {
-    InstanceHealthMonitor monitor = mock(InstanceHealthMonitor.class);
     HelixGroupStats stats = mock(HelixGroupStats.class);
 
     Map<String, Integer> instanceToGroupIdMapping = new HashMap<>();
@@ -26,7 +25,7 @@ public class HelixLeastLoadedGroupRoutingStrategyTest {
     instanceToGroupIdMapping.put(instance2, 1);
     instanceToGroupIdMapping.put(instance3, 2);
 
-    HelixLeastLoadedGroupRoutingStrategy strategy = new HelixLeastLoadedGroupRoutingStrategy(monitor, stats);
+    HelixLeastLoadedGroupRoutingStrategy strategy = new HelixLeastLoadedGroupRoutingStrategy(stats);
     strategy.updateHelixGroupInfo(instanceToGroupIdMapping);
 
     doReturn(-1d).when(stats).getGroupResponseWaitingTimeAvg(0);

--- a/clients/venice-client/src/test/java/com/linkedin/venice/fastclient/meta/LeastLoadedClientRoutingStrategyTest.java
+++ b/clients/venice-client/src/test/java/com/linkedin/venice/fastclient/meta/LeastLoadedClientRoutingStrategyTest.java
@@ -5,6 +5,7 @@ import static org.mockito.Mockito.mock;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.function.Function;
@@ -35,7 +36,13 @@ public class LeastLoadedClientRoutingStrategyTest {
 
   public void runTest(InstanceHealthMonitor monitor, List<String> replicas, long requestId, String expectedReplica) {
     LeastLoadedClientRoutingStrategy strategy = new LeastLoadedClientRoutingStrategy(monitor);
-    String selectedReplica = strategy.getReplicas(requestId, -1, replicas);
+    List<String> filteredReplicas = new ArrayList<>();
+    for (String replica: replicas) {
+      if (monitor.isRequestAllowed(replica)) {
+        filteredReplicas.add(replica);
+      }
+    }
+    String selectedReplica = strategy.getReplicas(requestId, -1, filteredReplicas);
     assertEquals(selectedReplica, expectedReplica);
   }
 


### PR DESCRIPTION
## Problem Statement
Currently when there is a no available replica error we don't have enough logging/metric to determine exactly which or what combination of the following happened:
1. Some replicas are not available already in routing metadata
2. Replicas filtered due to blocked or unhealthy instances
3. Filtered due to request context for retry (original request already used the route)

## Solution
Extract the blocked and unhealthy instances out of routing strategy to AbstractStoreMetadata so it can be logged accurately in case of no available routes. Blocked/unhealthy instances will be provided as excluded instances so it will be filtered out already when performing the routing strategies.

###  Code changes
- [ ] Added new code behind **a config**. If so list the config names and their default values in the PR description.
- [ ] Introduced new **log lines**. 
  - [ ] Confirmed if logs need to be **rate limited** to avoid excessive logging.

###  **Concurrency-Specific Checks**
Both reviewer and PR author to verify
- [ ] Code has **no race conditions** or **thread safety issues**.
- [ ] Proper **synchronization mechanisms** (e.g., `synchronized`, `RWLock`) are used where needed.
- [ ] No **blocking calls** inside critical sections that could lead to deadlocks or performance degradation.
- [ ] Verified **thread-safe collections** are used (e.g., `ConcurrentHashMap`, `CopyOnWriteArrayList`).
- [ ] Validated proper exception handling in multi-threaded code to avoid silent thread termination.


## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->

- [ ] New unit tests added.
- [ ] New integration tests added.
- [ ] Modified or extended existing tests.
- [ ] Verified backward compatibility (if applicable).

## Does this PR introduce any user-facing or breaking changes?
<!--  
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [ ] No. You can skip the rest of this section.
- [ ] Yes. Clearly explain the behavior change and its impact.