### PR TITLE
[server] Fix key count metric exception

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
@@ -2657,10 +2657,6 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
      */
     if (shouldSyncOffset(partitionConsumptionState, record, leaderProducedRecordContext)) {
       updateOffsetMetadataAndSyncOffset(partitionConsumptionState);
-      if (isHybridMode()) {
-        hostLevelIngestionStats.recordTotalDuplicateKeys(storageEngine.getStats().getDuplicateKeyCountEstimate());
-        hostLevelIngestionStats.recordTotalKeyCount(storageEngine.getStats().getKeyCountEstimate());
-      }
     }
   }
 

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/AggVersionedStorageEngineStats.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/AggVersionedStorageEngineStats.java
@@ -77,6 +77,20 @@ public class AggVersionedStorageEngineStats extends
       return 0;
     }
 
+    public long getKeyCountEstimate() {
+      if (storageEngine != null) {
+        return storageEngine.getStats().getKeyCountEstimate();
+      }
+      return 0;
+    }
+
+    public long getDuplicateKeyCountEstimate() {
+      if (storageEngine != null) {
+        return storageEngine.getStats().getDuplicateKeyCountEstimate();
+      }
+      return 0;
+    }
+
     public void recordRocksDBOpenFailure() {
       rocksDBOpenFailureCount.incrementAndGet();
     }
@@ -113,6 +127,22 @@ public class AggVersionedStorageEngineStats extends
           return stats.rocksDBOpenFailureCount.get();
         }
       }, "rocksdb_open_failure_count"));
+      registerSensor(new AsyncGauge((ignored, ignored2) -> {
+        StorageEngineStatsWrapper stats = getStats();
+        if (stats == null) {
+          return StatsErrorCode.NULL_STORAGE_ENGINE_STATS.code;
+        } else {
+          return stats.getKeyCountEstimate();
+        }
+      }, "rocksdb_key_count_estimate"));
+      registerSensor(new AsyncGauge((ignored, ignored2) -> {
+        StorageEngineStatsWrapper stats = getStats();
+        if (stats == null) {
+          return StatsErrorCode.NULL_STORAGE_ENGINE_STATS.code;
+        } else {
+          return stats.getDuplicateKeyCountEstimate();
+        }
+      }, "rocksdb_duplicate_key_count_estimate"));
     }
   }
 }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/HostLevelIngestionStats.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/HostLevelIngestionStats.java
@@ -154,8 +154,6 @@ public class HostLevelIngestionStats extends AbstractVeniceStats {
   private final LongAdderRateGauge batchProcessingRequestRecordsSensor;
   private final Sensor batchProcessingRequestLatencySensor;
   private final LongAdderRateGauge batchProcessingRequestErrorSensor;
-  private final Sensor totalDuplicateKeyCount;
-  private final Sensor totalKeyCountEstimate;
 
   /**
    * @param totalStats the total stats singleton instance, or null if we are constructing the total stats
@@ -500,16 +498,6 @@ public class HostLevelIngestionStats extends AbstractVeniceStats {
         totalStats,
         () -> totalStats.batchProcessingRequestLatencySensor,
         avgAndMax());
-    this.totalDuplicateKeyCount = registerPerStoreAndTotalSensor(
-        "rocksdb_duplicate_key_count",
-        totalStats,
-        () -> totalStats.totalDuplicateKeyCount,
-        avgAndMax());
-    this.totalKeyCountEstimate = registerPerStoreAndTotalSensor(
-        "rocksdb_key_count",
-        totalStats,
-        () -> totalStats.totalKeyCountEstimate,
-        avgAndMax());
   }
 
   private Measurable measurable(
@@ -530,14 +518,6 @@ public class HostLevelIngestionStats extends AbstractVeniceStats {
   /** Record a host-level byte consumption rate across all store versions */
   public void recordTotalBytesConsumed(long bytes) {
     totalBytesConsumedRate.record(bytes);
-  }
-
-  public void recordTotalDuplicateKeys(long count) {
-    totalDuplicateKeyCount.record(count);
-  }
-
-  public void recordTotalKeyCount(long count) {
-    totalKeyCountEstimate.record(count);
   }
 
   /** Record a host-level record consumption rate across all store versions */

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/store/AbstractStorageEngine.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/store/AbstractStorageEngine.java
@@ -430,7 +430,7 @@ public abstract class AbstractStorageEngine<Partition extends AbstractStoragePar
     });
   }
 
-  public <T> T executeWithSafeGuard(int partitionId, Callable<T> callable) {
+  protected <T> T executeWithSafeGuard(int partitionId, Callable<T> callable) {
     ReadWriteLock readWriteLock = getRWLockForPartitionOrThrow(partitionId);
     readWriteLock.readLock().lock();
     try {

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/store/AbstractStorageEngine.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/store/AbstractStorageEngine.java
@@ -430,7 +430,7 @@ public abstract class AbstractStorageEngine<Partition extends AbstractStoragePar
     });
   }
 
-  private <T> T executeWithSafeGuard(int partitionId, Callable<T> callable) {
+  public <T> T executeWithSafeGuard(int partitionId, Callable<T> callable) {
     ReadWriteLock readWriteLock = getRWLockForPartitionOrThrow(partitionId);
     readWriteLock.readLock().lock();
     try {

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/store/StorageEngineNoOpStats.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/store/StorageEngineNoOpStats.java
@@ -42,6 +42,6 @@ public class StorageEngineNoOpStats implements StorageEngineStats {
 
   @Override
   public long getKeyCountEstimate() {
-    return -1;
+    return 0;
   }
 }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/store/StorageEngineNoOpStats.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/store/StorageEngineNoOpStats.java
@@ -37,7 +37,7 @@ public class StorageEngineNoOpStats implements StorageEngineStats {
 
   @Override
   public long getDuplicateKeyCountEstimate() {
-    return -1;
+    return 0;
   }
 
   @Override

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/store/rocksdb/RocksDBStorageEngine.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/store/rocksdb/RocksDBStorageEngine.java
@@ -169,7 +169,7 @@ public class RocksDBStorageEngine extends AbstractStorageEngine<RocksDBStoragePa
   private long getStatSumAcrossPartitions(ToLongFunction<RocksDBStoragePartition> statGetter) {
     long sum = 0;
     for (RocksDBStoragePartition partition: getPartitions()) {
-      sum += statGetter.applyAsLong(partition);
+      sum += executeWithSafeGuard(partition.getPartitionId(), () -> statGetter.applyAsLong(partition));
     }
     return sum;
   }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/store/rocksdb/RocksDBStoragePartition.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/store/rocksdb/RocksDBStoragePartition.java
@@ -835,9 +835,7 @@ public class RocksDBStoragePartition extends AbstractStoragePartition {
   public long getKeyCountEstimate() {
     readCloseRWLock.readLock().lock();
     try {
-      if (isClosed) {
-        return 0;
-      }
+      makeSureRocksDBIsStillOpen();
       return getRocksDBStatValue("rocksdb.estimate-num-keys");
     } finally {
       readCloseRWLock.readLock().unlock();

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/store/rocksdb/RocksDBStoragePartition.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/store/rocksdb/RocksDBStoragePartition.java
@@ -965,7 +965,9 @@ public class RocksDBStoragePartition extends AbstractStoragePartition {
   public long getRocksDBStatValue(String statName) {
     readCloseRWLock.readLock().lock();
     try {
-      makeSureRocksDBIsStillOpen();
+      if (isClosed) {
+        return 0;
+      }
       return rocksDB.getLongProperty(statName);
     } catch (RocksDBException e) {
       throw new VeniceException(

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/store/rocksdb/RocksDBStoragePartition.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/store/rocksdb/RocksDBStoragePartition.java
@@ -833,13 +833,7 @@ public class RocksDBStoragePartition extends AbstractStoragePartition {
   }
 
   public long getKeyCountEstimate() {
-    readCloseRWLock.readLock().lock();
-    try {
-      makeSureRocksDBIsStillOpen();
-      return getRocksDBStatValue("rocksdb.estimate-num-keys");
-    } finally {
-      readCloseRWLock.readLock().unlock();
-    }
+    return getRocksDBStatValue("rocksdb.estimate-num-keys");
   }
 
   public void deleteFilesInDirectory(String fullPath) {

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/stats/AggVersionedStorageEngineStatsTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/stats/AggVersionedStorageEngineStatsTest.java
@@ -14,7 +14,7 @@ import org.testng.annotations.Test;
 
 public class AggVersionedStorageEngineStatsTest {
   @Test
-  public void testVersionedStatss() {
+  public void testVersionedStats() {
     String storeName = "testStore";
     MetricsRepository metricsRepository = mock(MetricsRepository.class);
     doReturn(mock(Sensor.class)).when(metricsRepository).sensor(anyString(), any());
@@ -23,7 +23,9 @@ public class AggVersionedStorageEngineStatsTest {
     AggVersionedStorageEngineStats stats =
         new AggVersionedStorageEngineStats(metricsRepository, metadataRepository, false);
     stats.addStore(storeName);
-
+    AggVersionedStorageEngineStats.StorageEngineStatsReporter reporter =
+        new AggVersionedStorageEngineStats.StorageEngineStatsReporter(metricsRepository, storeName, "cluster1");
+    reporter.registerStats();
     stats.getStats(storeName, 1).getKeyCountEstimate();
     stats.getStats(storeName, 1).getDuplicateKeyCountEstimate();
 

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/stats/AggVersionedStorageEngineStatsTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/stats/AggVersionedStorageEngineStatsTest.java
@@ -1,14 +1,14 @@
 package com.linkedin.davinci.stats;
 
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 
 import com.linkedin.venice.meta.ReadOnlyStoreRepository;
 import com.linkedin.venice.meta.Store;
+import io.tehuti.Metric;
 import io.tehuti.metrics.MetricsRepository;
-import io.tehuti.metrics.Sensor;
+import org.testng.Assert;
 import org.testng.annotations.Test;
 
 
@@ -16,18 +16,16 @@ public class AggVersionedStorageEngineStatsTest {
   @Test
   public void testVersionedStats() {
     String storeName = "testStore";
-    MetricsRepository metricsRepository = mock(MetricsRepository.class);
-    doReturn(mock(Sensor.class)).when(metricsRepository).sensor(anyString(), any());
+    MetricsRepository metricsRepository = new MetricsRepository();
     ReadOnlyStoreRepository metadataRepository = mock(ReadOnlyStoreRepository.class);
     doReturn(mock(Store.class)).when(metadataRepository).getStoreOrThrow(anyString());
     AggVersionedStorageEngineStats stats =
         new AggVersionedStorageEngineStats(metricsRepository, metadataRepository, false);
     stats.addStore(storeName);
-    AggVersionedStorageEngineStats.StorageEngineStatsReporter reporter =
-        new AggVersionedStorageEngineStats.StorageEngineStatsReporter(metricsRepository, storeName, "cluster1");
-    reporter.registerStats();
     stats.getStats(storeName, 1).getKeyCountEstimate();
     stats.getStats(storeName, 1).getDuplicateKeyCountEstimate();
-
+    metricsRepository.getMetric(".testStore_future--rocksdb_duplicate_key_count_estimate.Gauge");
+    Metric metric = metricsRepository.getMetric(".testStore_total--rocksdb_key_count_estimate.Gauge");
+    Assert.assertEquals(metric.value(), 0.0);
   }
 }

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/stats/AggVersionedStorageEngineStatsTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/stats/AggVersionedStorageEngineStatsTest.java
@@ -1,0 +1,31 @@
+package com.linkedin.davinci.stats;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+
+import com.linkedin.venice.meta.ReadOnlyStoreRepository;
+import com.linkedin.venice.meta.Store;
+import io.tehuti.metrics.MetricsRepository;
+import io.tehuti.metrics.Sensor;
+import org.testng.annotations.Test;
+
+
+public class AggVersionedStorageEngineStatsTest {
+  @Test
+  public void testVersionedStatss() {
+    String storeName = "testStore";
+    MetricsRepository metricsRepository = mock(MetricsRepository.class);
+    doReturn(mock(Sensor.class)).when(metricsRepository).sensor(anyString(), any());
+    ReadOnlyStoreRepository metadataRepository = mock(ReadOnlyStoreRepository.class);
+    doReturn(mock(Store.class)).when(metadataRepository).getStoreOrThrow(anyString());
+    AggVersionedStorageEngineStats stats =
+        new AggVersionedStorageEngineStats(metricsRepository, metadataRepository, false);
+    stats.addStore(storeName);
+
+    stats.getStats(storeName, 1).getKeyCountEstimate();
+    stats.getStats(storeName, 1).getDuplicateKeyCountEstimate();
+
+  }
+}

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/stats/AggVersionedStorageEngineStatsTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/stats/AggVersionedStorageEngineStatsTest.java
@@ -24,8 +24,9 @@ public class AggVersionedStorageEngineStatsTest {
     stats.addStore(storeName);
     stats.getStats(storeName, 1).getKeyCountEstimate();
     stats.getStats(storeName, 1).getDuplicateKeyCountEstimate();
-    metricsRepository.getMetric(".testStore_future--rocksdb_duplicate_key_count_estimate.Gauge");
-    Metric metric = metricsRepository.getMetric(".testStore_total--rocksdb_key_count_estimate.Gauge");
+    Metric metric = metricsRepository.getMetric(".testStore_total--rocksdb_duplicate_key_count_estimate.Gauge");
+    Assert.assertEquals(metric.value(), 0.0);
+    metric = metricsRepository.getMetric(".testStore_total--rocksdb_key_count_estimate.Gauge");
     Assert.assertEquals(metric.value(), 0.0);
   }
 }

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/store/rocksdb/RocksDBStorageEngineTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/store/rocksdb/RocksDBStorageEngineTest.java
@@ -205,8 +205,8 @@ public class RocksDBStorageEngineTest extends AbstractStorageEngineTest<RocksDBS
     Assert.assertEquals(persistedPartitionIds.size(), 2);
     Assert.assertTrue(persistedPartitionIds.contains(PARTITION_ID));
     Assert.assertTrue(persistedPartitionIds.contains(METADATA_PARTITION_ID));
-    // Assert.assertEquals(2, rocksDBStorageEngine.getStats().getKeyCountEstimate());
-    // Assert.assertEquals(0, rocksDBStorageEngine.getStats().getDuplicateKeyCountEstimate());
+    Assert.assertEquals(2, rocksDBStorageEngine.getStats().getKeyCountEstimate());
+    Assert.assertEquals(0, rocksDBStorageEngine.getStats().getDuplicateKeyCountEstimate());
   }
 
   @Test

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/kafka/consumer/AdminConsumptionTask.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/kafka/consumer/AdminConsumptionTask.java
@@ -723,7 +723,11 @@ public class AdminConsumptionTask implements Runnable, Closeable {
     long executionId = adminOperation.executionId;
     try {
       checkAndValidateMessage(adminOperation, record);
-      LOGGER.info("Received admin message: {} offset: {}", adminOperation, record.getPosition());
+      LOGGER.info(
+          "Received admin operation: {}, message {} offset: {}",
+          AdminMessageType.valueOf(adminOperation).name(),
+          adminOperation,
+          record.getPosition());
       consecutiveDuplicateMessageCount = 0;
     } catch (DuplicateDataException e) {
       // Previously processed message, safe to skip


### PR DESCRIPTION
<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat], [protocol]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## Problem Statement
<!--
Describe
- What problem are you trying to solve
- What issues or limitations exist in the current code
- Why this change is necessary 
-->

During key count metric collection we sometime see the associated rocksdb intances are closed which cause exception in the drainer thread blocking ingestion.

## Solution
<!--
Describe
- What changes you are making and why. 
- How these changes solve the problem.
- Any performance considerations or trade-offs. 
- Describe what testings you have done, for example, performance testing etc.
-->

This PR fixes that by checking for closed DB during metric collection.

###  Code changes
- [ ] Added new code behind **a config**. If so list the config names and their default values in the PR description.
- [ ] Introduced new **log lines**. 
  - [ ] Confirmed if logs need to be **rate limited** to avoid excessive logging.

###  **Concurrency-Specific Checks**
Both reviewer and PR author to verify
- [ ] Code has **no race conditions** or **thread safety issues**.
- [ ] Proper **synchronization mechanisms** (e.g., `synchronized`, `RWLock`) are used where needed.
- [ ] No **blocking calls** inside critical sections that could lead to deadlocks or performance degradation.
- [ ] Verified **thread-safe collections** are used (e.g., `ConcurrentHashMap`, `CopyOnWriteArrayList`).
- [ ] Validated proper exception handling in multi-threaded code to avoid silent thread termination.


## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->

- [ ] New unit tests added.
- [ ] New integration tests added.
- [ ] Modified or extended existing tests.
- [ ] Verified backward compatibility (if applicable).

## Does this PR introduce any user-facing or breaking changes?
<!--  
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [ ] No. You can skip the rest of this section.
- [ ] Yes. Clearly explain the behavior change and its impact.