### PR TITLE
[controller] Broadcast the adminOperation version check request to all controller instances instead of standby only

### DIFF
--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceHelixAdmin.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceHelixAdmin.java
@@ -7418,9 +7418,9 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
   /**
    * Get all live instance controllers from ZK /LIVEINSTANCES
    */
-  public List<Instance> getAllLiveInstanceControllers(String clusterName) {
+  public List<Instance> getAllLiveInstanceControllers() {
     final int maxAttempts = 10;
-    PropertyKey.Builder keyBuilder = new PropertyKey.Builder(clusterName);
+    PropertyKey.Builder keyBuilder = new PropertyKey.Builder(getControllerClusterName());
     for (int attempt = 1; attempt <= maxAttempts; ++attempt) {
       List<String> liveInstances = getHelixManager().getHelixDataAccessor().getChildNames(keyBuilder.liveInstances());
       if (liveInstances == null || liveInstances.isEmpty()) {
@@ -7840,7 +7840,7 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
         .constructClusterControllerClient(clusterName, leaderController.getUrl(sslEnabled), getSslFactory());
 
     // Get version for all controllers
-    List<Instance> liveInstances = getAllLiveInstanceControllers(clusterName);
+    List<Instance> liveInstances = getAllLiveInstanceControllers();
 
     for (Instance instance: liveInstances) {
       // In production, leader and standby share the secure port but have different hostnames—no conflict.
@@ -7852,7 +7852,7 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
         continue;
       }
 
-      String liveInstanceUrl = instance.getUrl(sslEnabled);
+      String liveInstanceUrl = instance.getUrl(getSslFactory().isPresent());
 
       // Get the admin operation protocol version from standby controller
       AdminOperationProtocolVersionControllerResponse response =
@@ -9307,6 +9307,10 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
 
   SafeHelixManager getHelixManager() {
     return helixManager;
+  }
+
+  String getControllerClusterName() {
+    return controllerClusterName;
   }
 
   String getPushJobStatusStoreClusterName() {

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceHelixAdmin.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceHelixAdmin.java
@@ -7416,6 +7416,41 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
   }
 
   /**
+   * Get all live instance controllers from ZK /LIVEINSTANCES
+   */
+  public List<Instance> getAllLiveInstanceControllers(String clusterName) {
+    final int maxAttempts = 10;
+    PropertyKey.Builder keyBuilder = new PropertyKey.Builder(clusterName);
+    for (int attempt = 1; attempt <= maxAttempts; ++attempt) {
+      List<String> liveInstances = getHelixManager().getHelixDataAccessor().getChildNames(keyBuilder.liveInstances());
+      if (liveInstances == null || liveInstances.isEmpty()) {
+        // Assignment is incomplete, try again later
+        LOGGER.warn("No live instance controllers found, attempt: {}/{}", attempt, maxAttempts);
+        Utils.sleep(5 * Time.MS_PER_SECOND);
+        continue;
+      }
+
+      List<Instance> controllers = new ArrayList<>();
+      for (String id: liveInstances) {
+        controllers.add(
+            new Instance(
+                id,
+                Utils.parseHostFromHelixNodeIdentifier(id),
+                Utils.parsePortFromHelixNodeIdentifier(id),
+                getMultiClusterConfigs().getAdminSecurePort(),
+                getMultiClusterConfigs().getAdminGrpcPort(),
+                getMultiClusterConfigs().getAdminSecureGrpcPort()));
+      }
+      return controllers;
+    }
+    String message = "Unable to find live instance controllers in ZK after " + maxAttempts + " attempts";
+    if (!EXCEPTION_FILTER.isRedundantException(message)) {
+      LOGGER.error(message);
+    }
+    throw new VeniceException(message);
+  }
+
+  /**
    * Add the given helix nodeId into the allowlist in ZK.
    */
   @Override
@@ -7785,7 +7820,7 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
   }
 
   /**
-   * Get the admin operation protocol versions from controllers (leader + standby) for specific cluster.
+   * Get the admin operation protocol versions from all controllers for specific cluster.
    * @param clusterName: the cluster name
    * @return map (controllerName: version). Example: {localhost_1234=1, localhost_1235=1}*/
   @Override
@@ -7804,24 +7839,33 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
     ControllerClient localControllerClient = ControllerClient
         .constructClusterControllerClient(clusterName, leaderController.getUrl(sslEnabled), getSslFactory());
 
-    // Get version for standby controllers
-    List<Instance> standbyControllers = getControllersByHelixState(clusterName, HelixState.STANDBY_STATE);
+    // Get version for all controllers
+    List<Instance> liveInstances = getAllLiveInstanceControllers(clusterName);
 
-    for (Instance standbyController: standbyControllers) {
+    for (Instance instance: liveInstances) {
       // In production, leader and standby share the secure port but have different hostnames—no conflict.
       // In tests, both run on 'localhost' with the same secure port, which confuses routing.
       // Hence, we need to disable SSL for local integration tests.
       // RCA: Helix uses an insecure port from the instance ID, while secure port comes from shared multiClusterConfig.
-      String standbyControllerUrl = standbyController.getUrl(sslEnabled);
+      if (Objects.equals(instance.getNodeId(), leaderController.getNodeId())) {
+        // If the instance is the leader controller, skip it as we already have its version.
+        continue;
+      }
+
+      String liveInstanceUrl = instance.getUrl(sslEnabled);
 
       // Get the admin operation protocol version from standby controller
       AdminOperationProtocolVersionControllerResponse response =
-          localControllerClient.getLocalAdminOperationProtocolVersion(standbyControllerUrl);
+          localControllerClient.getLocalAdminOperationProtocolVersion(liveInstanceUrl);
       if (response.isError()) {
-        throw new VeniceException(
-            "Failed to get admin operation protocol version from standby controller: " + standbyControllerUrl
-                + ", error message: " + response.getError());
+        String msg = "Failed to get admin operation protocol version from controller: " + liveInstanceUrl
+            + ", error message: " + response.getError();
+        if (!EXCEPTION_FILTER.isRedundantException(msg)) {
+          LOGGER.warn(msg);
+        }
+        continue;
       }
+
       controllerNameToAdminOperationVersionMap
           .put(response.getLocalControllerName(), response.getLocalAdminOperationProtocolVersion());
     }

--- a/services/venice-controller/src/test/java/com/linkedin/venice/controller/TestVeniceHelixAdmin.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/controller/TestVeniceHelixAdmin.java
@@ -39,7 +39,8 @@ import com.linkedin.venice.controllerapi.ControllerClient;
 import com.linkedin.venice.exceptions.VeniceException;
 import com.linkedin.venice.helix.HelixCustomizedViewOfflinePushRepository;
 import com.linkedin.venice.helix.HelixExternalViewRepository;
-import com.linkedin.venice.helix.HelixState;
+import com.linkedin.venice.helix.SafeHelixDataAccessor;
+import com.linkedin.venice.helix.SafeHelixManager;
 import com.linkedin.venice.ingestion.control.RealTimeTopicSwitcher;
 import com.linkedin.venice.meta.HybridStoreConfig;
 import com.linkedin.venice.meta.Instance;
@@ -1028,39 +1029,40 @@ public class TestVeniceHelixAdmin {
     // Mock current version in leader is 2
     when(veniceHelixAdmin.getLocalAdminOperationProtocolVersion()).thenReturn(2L);
 
-    // Mock response for standby controllers
+    // Mock response for non-leader controllers
     AdminOperationProtocolVersionControllerResponse response1 = new AdminOperationProtocolVersionControllerResponse();
     response1.setLocalAdminOperationProtocolVersion(1);
-    response1.setLocalControllerName("standbyHost1_1234");
+    response1.setLocalControllerName("controller1_1234");
     AdminOperationProtocolVersionControllerResponse response2 = new AdminOperationProtocolVersionControllerResponse();
     response2.setLocalAdminOperationProtocolVersion(2);
-    response2.setLocalControllerName("standbyHost2_1234");
+    response2.setLocalControllerName("controller2_1234");
 
-    List<Instance> standbyControllers = new ArrayList<>();
-    standbyControllers.add(new Instance("1", "standbyHost1", 1234));
-    standbyControllers.add(new Instance("2", "standbyHost2", 1234));
+    List<Instance> liveInstances = new ArrayList<>();
+    Instance leaderInstance = new Instance("4", "leaderHost", 1234);
+    liveInstances.add(new Instance("1", "controller1", 1234));
+    liveInstances.add(new Instance("2", "controller2", 1234));
+    liveInstances.add(leaderInstance);
 
-    when(veniceHelixAdmin.getControllersByHelixState(clusterName, HelixState.STANDBY_STATE))
-        .thenReturn(standbyControllers);
-    when(veniceHelixAdmin.getLeaderController(clusterName)).thenReturn(new Instance("3", "leaderHost", 1234));
+    when(veniceHelixAdmin.getAllLiveInstanceControllers(clusterName)).thenReturn(liveInstances);
+    when(veniceHelixAdmin.getLeaderController(clusterName)).thenReturn(leaderInstance);
 
     try (MockedStatic<ControllerClient> controllerClientMockedStatic = mockStatic(ControllerClient.class)) {
       ControllerClient client = mock(ControllerClient.class);
       controllerClientMockedStatic
           .when(() -> ControllerClient.constructClusterControllerClient(eq(clusterName), any(), any()))
           .thenReturn(client);
-      when(client.getLocalAdminOperationProtocolVersion("http://standbyHost1:1234")).thenReturn(response1);
-      when(client.getLocalAdminOperationProtocolVersion("http://standbyHost2:1234")).thenReturn(response2);
+      when(client.getLocalAdminOperationProtocolVersion("http://controller1:1234")).thenReturn(response1);
+      when(client.getLocalAdminOperationProtocolVersion("http://controller2:1234")).thenReturn(response2);
 
       Map<String, Long> controllerNameToVersionMap =
           veniceParentHelixAdmin.getAdminOperationVersionFromControllers(clusterName);
       assertEquals(controllerNameToVersionMap.size(), 3);
       assertTrue(
-          controllerNameToVersionMap.containsKey("standbyHost1_1234")
-              && controllerNameToVersionMap.get("standbyHost1_1234") == 1L);
+          controllerNameToVersionMap.containsKey("controller1_1234")
+              && controllerNameToVersionMap.get("controller1_1234") == 1L);
       assertTrue(
-          controllerNameToVersionMap.containsKey("standbyHost2_1234")
-              && controllerNameToVersionMap.get("standbyHost2_1234") == 2L);
+          controllerNameToVersionMap.containsKey("controller2_1234")
+              && controllerNameToVersionMap.get("controller2_1234") == 2L);
       assertTrue(
           controllerNameToVersionMap.containsKey("leaderHost_1234")
               && controllerNameToVersionMap.get("leaderHost_1234") == 2L);
@@ -1071,6 +1073,7 @@ public class TestVeniceHelixAdmin {
   public void testFailedGetAdminOperationVersionsForStandbyControllers() {
     VeniceParentHelixAdmin veniceParentHelixAdmin = mock(VeniceParentHelixAdmin.class);
     VeniceHelixAdmin veniceHelixAdmin = mock(VeniceHelixAdmin.class);
+
     when(veniceParentHelixAdmin.getVeniceHelixAdmin()).thenReturn(veniceHelixAdmin);
     doReturn(Optional.empty()).when(veniceHelixAdmin).getSslFactory();
     doReturn("leaderHost_1234").when(veniceHelixAdmin).getControllerName();
@@ -1080,20 +1083,19 @@ public class TestVeniceHelixAdmin {
     // Mock current version in leader is 2
     when(veniceHelixAdmin.getLocalAdminOperationProtocolVersion()).thenReturn(2L);
 
-    // Mock response for standby controllers
-    List<Instance> standbyControllers = new ArrayList<>();
-    standbyControllers.add(new Instance("1", "standbyHost1", 1234));
-    standbyControllers.add(new Instance("2", "standbyHost2", 1234));
+    // Mock response for controllers
+    ArrayList<Instance> instances = new ArrayList<>();
+    instances.add(new Instance("1", "controller1", 1234));
+    instances.add(new Instance("2", "controller2", 1234));
 
     AdminOperationProtocolVersionControllerResponse response1 = new AdminOperationProtocolVersionControllerResponse();
     response1.setLocalAdminOperationProtocolVersion(1);
-    response1.setLocalControllerName("standbyHost1_1234");
+    response1.setLocalControllerName("controller1_1234");
     AdminOperationProtocolVersionControllerResponse failedResponse =
         new AdminOperationProtocolVersionControllerResponse();
     failedResponse.setError("Failed to get version");
 
-    when(veniceHelixAdmin.getControllersByHelixState(clusterName, HelixState.STANDBY_STATE))
-        .thenReturn(standbyControllers);
+    when(veniceHelixAdmin.getAllLiveInstanceControllers(clusterName)).thenReturn(instances);
     when(veniceHelixAdmin.getLeaderController(clusterName)).thenReturn(new Instance("3", "leaderHost", 1234));
 
     try (MockedStatic<ControllerClient> controllerClientMockedStatic = mockStatic(ControllerClient.class)) {
@@ -1101,12 +1103,19 @@ public class TestVeniceHelixAdmin {
       controllerClientMockedStatic
           .when(() -> ControllerClient.constructClusterControllerClient(eq(clusterName), any(), any()))
           .thenReturn(client);
-      when(client.getLocalAdminOperationProtocolVersion("http://standbyHost1:1234")).thenReturn(response1);
-      when(client.getLocalAdminOperationProtocolVersion("http://standbyHost2:1234")).thenReturn(failedResponse);
+      when(client.getLocalAdminOperationProtocolVersion("http://controller1:1234")).thenReturn(response1);
+      when(client.getLocalAdminOperationProtocolVersion("http://controller2:1234")).thenReturn(failedResponse);
 
-      expectThrows(
-          VeniceException.class,
-          () -> veniceParentHelixAdmin.getAdminOperationVersionFromControllers(clusterName));
+      Map<String, Long> controllerNameToVersionMap =
+          veniceParentHelixAdmin.getAdminOperationVersionFromControllers(clusterName);
+
+      assertEquals(controllerNameToVersionMap.size(), 2);
+      assertTrue(
+          controllerNameToVersionMap.containsKey("controller1_1234")
+              && controllerNameToVersionMap.get("controller1_1234") == 1L);
+      assertTrue(
+          controllerNameToVersionMap.containsKey("leaderHost_1234")
+              && controllerNameToVersionMap.get("leaderHost_1234") == 2L);
     }
   }
 
@@ -1129,6 +1138,32 @@ public class TestVeniceHelixAdmin {
     doCallRealMethod().when(veniceHelixAdmin).getControllersByHelixState(any(), any());
 
     expectThrows(VeniceException.class, () -> veniceHelixAdmin.getControllersByHelixState(clusterName, "state"));
+  }
+
+  @Test
+  public void testGetAllLiveInstanceControllers() {
+    VeniceHelixAdmin veniceHelixAdmin = mock(VeniceHelixAdmin.class);
+    SafeHelixManager safeHelixManager = mock(SafeHelixManager.class);
+    SafeHelixDataAccessor safeHelixDataAccessor = mock(SafeHelixDataAccessor.class);
+    VeniceControllerMultiClusterConfig controllerMultiClusterConfig = mock(VeniceControllerMultiClusterConfig.class);
+
+    doCallRealMethod().when(veniceHelixAdmin).getAllLiveInstanceControllers(clusterName);
+    doReturn(safeHelixManager).when(veniceHelixAdmin).getHelixManager();
+    doReturn(safeHelixDataAccessor).when(safeHelixManager).getHelixDataAccessor();
+    doReturn(controllerMultiClusterConfig).when(veniceHelixAdmin).getMultiClusterConfigs();
+    doReturn(1235).when(controllerMultiClusterConfig).getAdminSecurePort();
+    doReturn(1236).when(controllerMultiClusterConfig).getAdminGrpcPort();
+    doReturn(1237).when(controllerMultiClusterConfig).getAdminSecureGrpcPort();
+
+    // When there is no live instance controller, it should throw an exception
+    doReturn(Collections.emptyList()).when(safeHelixDataAccessor).getChildNames(any());
+    expectThrows(VeniceException.class, () -> veniceHelixAdmin.getAllLiveInstanceControllers(clusterName));
+
+    // When there are live instance controllers, it should return the list
+    List<String> liveInstances = Arrays.asList("controller1_1234", "controller2_1234");
+    doReturn(liveInstances).when(safeHelixDataAccessor).getChildNames(any());
+    List<Instance> liveInstanceControllers = veniceHelixAdmin.getAllLiveInstanceControllers(clusterName);
+    assertEquals(liveInstanceControllers.size(), 2);
   }
 
   /** Skip if regionFilter doesn’t include this region */

--- a/services/venice-controller/src/test/java/com/linkedin/venice/controller/TestVeniceHelixAdmin.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/controller/TestVeniceHelixAdmin.java
@@ -1043,7 +1043,7 @@ public class TestVeniceHelixAdmin {
     liveInstances.add(new Instance("2", "controller2", 1234));
     liveInstances.add(leaderInstance);
 
-    when(veniceHelixAdmin.getAllLiveInstanceControllers(clusterName)).thenReturn(liveInstances);
+    when(veniceHelixAdmin.getAllLiveInstanceControllers()).thenReturn(liveInstances);
     when(veniceHelixAdmin.getLeaderController(clusterName)).thenReturn(leaderInstance);
 
     try (MockedStatic<ControllerClient> controllerClientMockedStatic = mockStatic(ControllerClient.class)) {
@@ -1095,7 +1095,7 @@ public class TestVeniceHelixAdmin {
         new AdminOperationProtocolVersionControllerResponse();
     failedResponse.setError("Failed to get version");
 
-    when(veniceHelixAdmin.getAllLiveInstanceControllers(clusterName)).thenReturn(instances);
+    when(veniceHelixAdmin.getAllLiveInstanceControllers()).thenReturn(instances);
     when(veniceHelixAdmin.getLeaderController(clusterName)).thenReturn(new Instance("3", "leaderHost", 1234));
 
     try (MockedStatic<ControllerClient> controllerClientMockedStatic = mockStatic(ControllerClient.class)) {
@@ -1147,22 +1147,23 @@ public class TestVeniceHelixAdmin {
     SafeHelixDataAccessor safeHelixDataAccessor = mock(SafeHelixDataAccessor.class);
     VeniceControllerMultiClusterConfig controllerMultiClusterConfig = mock(VeniceControllerMultiClusterConfig.class);
 
-    doCallRealMethod().when(veniceHelixAdmin).getAllLiveInstanceControllers(clusterName);
+    doCallRealMethod().when(veniceHelixAdmin).getAllLiveInstanceControllers();
     doReturn(safeHelixManager).when(veniceHelixAdmin).getHelixManager();
     doReturn(safeHelixDataAccessor).when(safeHelixManager).getHelixDataAccessor();
     doReturn(controllerMultiClusterConfig).when(veniceHelixAdmin).getMultiClusterConfigs();
     doReturn(1235).when(controllerMultiClusterConfig).getAdminSecurePort();
     doReturn(1236).when(controllerMultiClusterConfig).getAdminGrpcPort();
     doReturn(1237).when(controllerMultiClusterConfig).getAdminSecureGrpcPort();
+    when(veniceHelixAdmin.getControllerClusterName()).thenReturn("controllerClusterName");
 
     // When there is no live instance controller, it should throw an exception
     doReturn(Collections.emptyList()).when(safeHelixDataAccessor).getChildNames(any());
-    expectThrows(VeniceException.class, () -> veniceHelixAdmin.getAllLiveInstanceControllers(clusterName));
+    expectThrows(VeniceException.class, () -> veniceHelixAdmin.getAllLiveInstanceControllers());
 
     // When there are live instance controllers, it should return the list
     List<String> liveInstances = Arrays.asList("controller1_1234", "controller2_1234");
     doReturn(liveInstances).when(safeHelixDataAccessor).getChildNames(any());
-    List<Instance> liveInstanceControllers = veniceHelixAdmin.getAllLiveInstanceControllers(clusterName);
+    List<Instance> liveInstanceControllers = veniceHelixAdmin.getAllLiveInstanceControllers();
     assertEquals(liveInstanceControllers.size(), 2);
   }
 


### PR DESCRIPTION
## Problem Statement
When we have rebalancing stages, Helix can pick any instances in instances list, which means the controller with lower version can be picked even when it is not leader or standby. We will broadcast the request to all controllers instead of limiting the check for leader and standby only.


## Solution
Get the full list of controllers from Helix LIVEINSTANCES and broadcast the request to those instances.
- In case we dont find any live instances, we will let the task fail since it should not happen.
- If we get a list of live instances and one of them does not response good, we still continue the process and skip the check for that controller.

###  Code changes
- [ ] Added new code behind **a config**. If so list the config names and their default values in the PR description.
- [x] Introduced new **log lines**. 
  - [x] Confirmed if logs need to be **rate limited** to avoid excessive logging.

###  **Concurrency-Specific Checks**
Both reviewer and PR author to verify
- [ ] Code has **no race conditions** or **thread safety issues**.
- [ ] Proper **synchronization mechanisms** (e.g., `synchronized`, `RWLock`) are used where needed.
- [ ] No **blocking calls** inside critical sections that could lead to deadlocks or performance degradation.
- [ ] Verified **thread-safe collections** are used (e.g., `ConcurrentHashMap`, `CopyOnWriteArrayList`).
- [ ] Validated proper exception handling in multi-threaded code to avoid silent thread termination.


## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->

- [x] New unit tests added.
- [ ] New integration tests added.
- [x] Modified or extended existing tests.
- [ ] Verified backward compatibility (if applicable).

## Does this PR introduce any user-facing or breaking changes?
<!--  
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Clearly explain the behavior change and its impact.