### PR TITLE
[log-compaction][controller]add storeName for RepushJobResponse initialisation

### DIFF
--- a/internal/venice-client-common/src/main/java/com/linkedin/venice/controllerapi/RepushJobResponse.java
+++ b/internal/venice-client-common/src/main/java/com/linkedin/venice/controllerapi/RepushJobResponse.java
@@ -13,7 +13,8 @@ public class RepushJobResponse extends ControllerResponse {
     this.executionId = DEFAULT_EXECUTION_ID;
   }
 
-  public RepushJobResponse(String executionId) {
+  public RepushJobResponse(String storeName, String executionId) {
+    this.setName(storeName);
     this.executionId = executionId;
   }
 

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestHybrid.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestHybrid.java
@@ -1121,7 +1121,7 @@ public class TestHybrid {
     public RepushJobResponse repush(RepushJobRequest repushJobRequest) {
       latch.countDown();
       LOGGER.info("Repush job triggered for store: " + repushJobRequest.toString());
-      return new RepushJobResponse(Utils.getUniqueString("repush-execId"));
+      return new RepushJobResponse(repushJobRequest.getStoreName(), Utils.getUniqueString("repush-execId"));
     }
 
     public static CountDownLatch getLatch() {


### PR DESCRIPTION
## Problem Statement
Currently, `RepushJobResponse` doesn't take in storeName on initialisation. `RepushJobResponse` extends `ControllerReponse` which does have storeName.

## Solution
Add `storeName` as `RepushJobResponse` constructor variable. Leverage `setName` in `ControllerResponse` parent class to populate `storeName`.


###  Code changes
- [ ] Added new code behind **a config**. If so list the config names and their default values in the PR description.
- [ ] Introduced new **log lines**. 
  - [ ] Confirmed if logs need to be **rate limited** to avoid excessive logging.

###  **Concurrency-Specific Checks**
Both reviewer and PR author to verify
- [ ] Code has **no race conditions** or **thread safety issues**.
- [ ] Proper **synchronization mechanisms** (e.g., `synchronized`, `RWLock`) are used where needed.
- [ ] No **blocking calls** inside critical sections that could lead to deadlocks or performance degradation.
- [ ] Verified **thread-safe collections** are used (e.g., `ConcurrentHashMap`, `CopyOnWriteArrayList`).
- [ ] Validated proper exception handling in multi-threaded code to avoid silent thread termination.


## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->

- [ ] New unit tests added.
- [ ] New integration tests added.
- [ ] Modified or extended existing tests.
- [ ] Verified backward compatibility (if applicable).

## Does this PR introduce any user-facing or breaking changes?
<!--  
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [ ] No. You can skip the rest of this section.
- [ ] Yes. Clearly explain the behavior change and its impact.