### PR TITLE
[fast-client] Fixed a race condition to avoid wrong replicas

### DIFF
--- a/clients/venice-client/src/main/java/com/linkedin/venice/fastclient/meta/RequestBasedMetadata.java
+++ b/clients/venice-client/src/main/java/com/linkedin/venice/fastclient/meta/RequestBasedMetadata.java
@@ -174,7 +174,7 @@ public class RequestBasedMetadata extends AbstractStoreMetadata {
   @Override
   public List<String> getReplicas(int version, int partitionId) {
     String key = getVersionPartitionMapKey(version, partitionId);
-    return readyToServeInstancesMap.getOrDefault(key, Collections.emptyList());
+    return Collections.unmodifiableList(readyToServeInstancesMap.getOrDefault(key, Collections.emptyList()));
   }
 
   private String getVersionPartitionMapKey(int version, int partition) {


### PR DESCRIPTION




<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat], [protocol]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## Problem Statement
<!--
Describe
- What problem are you trying to solve
- What issues or limitations exist in the current code
- Why this change is necessary 
-->
Previously, the replcias returned by {@link RequestBasedMetadata#getReplicas} can be modified by the shuffle operation in {@link LeastLoadedClientRoutingStrategy#getReplicas}, while some other requests are reading the partition assignment. The List is not thread-safe, so the temp state of shuffle can be read, which can result in identical replicas assigned to the same partition, which would break the retry request.

## Solution
<!--
Describe
- What changes you are making and why. 
- How these changes solve the problem.
- Any performance considerations or trade-offs. 
- Describe what testings you have done, for example, performance testing etc.
-->
The fix is to return a read-only copy from {@link RequestBasedMetadata#getReplicas}, and if there is a need to shuffle the read-only list, the user will make a copy to avoid the race condition.

###  Code changes
- [ ] Added new code behind **a config**. If so list the config names and their default values in the PR description.
- [ ] Introduced new **log lines**. 
  - [ ] Confirmed if logs need to be **rate limited** to avoid excessive logging.

###  **Concurrency-Specific Checks**
Both reviewer and PR author to verify
- [ ] Code has **no race conditions** or **thread safety issues**.
- [ ] Proper **synchronization mechanisms** (e.g., `synchronized`, `RWLock`) are used where needed.
- [ ] No **blocking calls** inside critical sections that could lead to deadlocks or performance degradation.
- [ ] Verified **thread-safe collections** are used (e.g., `ConcurrentHashMap`, `CopyOnWriteArrayList`).
- [ ] Validated proper exception handling in multi-threaded code to avoid silent thread termination.


## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
CI

- [ ] New unit tests added.
- [ ] New integration tests added.
- [ ] Modified or extended existing tests.
- [ ] Verified backward compatibility (if applicable).

## Does this PR introduce any user-facing or breaking changes?
<!--  
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Clearly explain the behavior change and its impact.