### PR TITLE
[server] Emit versioned storage quota stats and keep SIT open for current store version

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/config/VeniceClusterConfig.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/config/VeniceClusterConfig.java
@@ -329,7 +329,7 @@ public class VeniceClusterConfig {
     return kafkaFetchQuotaUnorderedRecordPerSecond;
   }
 
-  public String getRegionName() {
+  public final String getRegionName() {
     return regionName;
   }
 

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/config/VeniceServerConfig.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/config/VeniceServerConfig.java
@@ -218,12 +218,14 @@ import com.linkedin.davinci.kafka.consumer.RemoteIngestionRepairService;
 import com.linkedin.davinci.store.rocksdb.RocksDBServerConfig;
 import com.linkedin.davinci.validation.DataIntegrityValidator;
 import com.linkedin.venice.ConfigKeys;
+import com.linkedin.venice.acl.VeniceComponent;
 import com.linkedin.venice.authorization.DefaultIdentityParser;
 import com.linkedin.venice.exceptions.ConfigurationException;
 import com.linkedin.venice.exceptions.VeniceException;
 import com.linkedin.venice.meta.IngestionMode;
 import com.linkedin.venice.pubsub.PubSubClientsFactory;
 import com.linkedin.venice.throttle.VeniceRateLimiter;
+import com.linkedin.venice.utils.LogContext;
 import com.linkedin.venice.utils.Time;
 import com.linkedin.venice.utils.Utils;
 import com.linkedin.venice.utils.VeniceProperties;
@@ -645,6 +647,7 @@ public class VeniceServerConfig extends VeniceClusterConfig {
 
   private final boolean isParticipantMessageStoreEnabled;
   private final long consumerPollTrackerStaleThresholdInSeconds;
+  private final LogContext logContext;
 
   public VeniceServerConfig(VeniceProperties serverProperties) throws ConfigurationException {
     this(serverProperties, Collections.emptyMap());
@@ -655,6 +658,10 @@ public class VeniceServerConfig extends VeniceClusterConfig {
     super(serverProperties, kafkaClusterMap);
     listenerPort = serverProperties.getInt(LISTENER_PORT, 0);
     listenerHostname = serverProperties.getString(LISTENER_HOSTNAME, () -> Utils.getHostName());
+    logContext = new LogContext.Builder().setComponentName(VeniceComponent.SERVER.name())
+        .setRegionName(getRegionName())
+        .setInstanceName(Utils.getHelixNodeIdentifier(listenerHostname, listenerPort))
+        .build();
     isGrpcEnabled = serverProperties.getBoolean(ENABLE_GRPC_READ_SERVER, false);
     grpcPort = isGrpcEnabled ? serverProperties.getInt(GRPC_READ_SERVER_PORT) : -1;
 
@@ -2040,5 +2047,9 @@ public class VeniceServerConfig extends VeniceClusterConfig {
 
   public long getConsumerPollTrackerStaleThresholdSeconds() {
     return consumerPollTrackerStaleThresholdInSeconds;
+  }
+
+  public LogContext getLogContext() {
+    return logContext;
   }
 }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/helix/AbstractPartitionStateModel.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/helix/AbstractPartitionStateModel.java
@@ -11,6 +11,7 @@ import com.linkedin.venice.meta.Store;
 import com.linkedin.venice.meta.Version;
 import com.linkedin.venice.pushmonitor.ExecutionStatus;
 import com.linkedin.venice.pushmonitor.HybridStoreQuotaStatus;
+import com.linkedin.venice.utils.LogContext;
 import com.linkedin.venice.utils.Timer;
 import com.linkedin.venice.utils.Utils;
 import java.util.concurrent.CompletableFuture;
@@ -101,11 +102,13 @@ public abstract class AbstractPartitionStateModel extends StateModel {
     // Change name to indicate which st is occupied this thread.
     Thread.currentThread().setName("Helix-ST-" + message.getResourceName() + "-" + partition + "-" + from + "->" + to);
     try {
+      LogContext.setStructuredLogContext(storeAndServerConfigs.getLogContext());
       handler.run();
       logCompletion(from, to, message, context, rollback);
     } finally {
       // Once st is terminated, change the name to indicate this thread will not be occupied by this st.
       Thread.currentThread().setName("Inactive ST thread.");
+      LogContext.clearLogContext();
     }
   }
 

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/helix/HelixParticipationService.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/helix/HelixParticipationService.java
@@ -171,7 +171,10 @@ public class HelixParticipationService extends AbstractVeniceService
 
   @Override
   public boolean startInner() {
-    LOGGER.info("Attempting to start HelixParticipation service");
+    LOGGER.info(
+        "Attempting to start HelixParticipation service for participant: {} in cluster: {}",
+        participantName,
+        clusterName);
     VeniceServerConfig config = veniceConfigLoader.getVeniceServerConfig();
     HelixManagerProperty helixManagerProperty = buildHelixManagerProperty(config);
     helixManager = new SafeHelixManager(

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/helix/LeaderFollowerPartitionStateModelFactory.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/helix/LeaderFollowerPartitionStateModelFactory.java
@@ -1,6 +1,7 @@
 package com.linkedin.davinci.helix;
 
 import com.linkedin.davinci.config.VeniceConfigLoader;
+import com.linkedin.davinci.config.VeniceStoreVersionConfig;
 import com.linkedin.davinci.ingestion.IngestionBackend;
 import com.linkedin.davinci.stats.ParticipantStateTransitionStats;
 import com.linkedin.davinci.stats.ingestion.heartbeat.HeartbeatMonitoringService;
@@ -8,6 +9,7 @@ import com.linkedin.venice.helix.HelixPartitionStatusAccessor;
 import com.linkedin.venice.meta.ReadOnlyStoreRepository;
 import com.linkedin.venice.utils.HelixUtils;
 import com.linkedin.venice.utils.LogContext;
+import com.linkedin.venice.utils.Utils;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
 
@@ -48,12 +50,18 @@ public class LeaderFollowerPartitionStateModelFactory extends AbstractStateModel
 
   @Override
   public LeaderFollowerPartitionStateModel createNewStateModel(String resourceName, String partitionName) {
-    LogContext.setRegionLogContext(getConfigService().getVeniceServerConfig().getRegionName());
-    logger.info("Creating LeaderFollowerParticipantModel handler for partition: {}", partitionName);
+    // TODO: we should cache config object and reuse it for all the partitions of the same store.
+    VeniceStoreVersionConfig storeVersionConfig =
+        getConfigService().getStoreConfig(HelixUtils.getResourceName(partitionName));
+    int partitionId = HelixUtils.getPartitionId(partitionName);
+    LogContext.setStructuredLogContext(storeVersionConfig.getLogContext());
+    logger.info(
+        "Creating LeaderFollowerParticipantModel handler for partition: {}",
+        Utils.getReplicaId(resourceName, partitionId));
     return new LeaderFollowerPartitionStateModel(
         getIngestionBackend(),
-        getConfigService().getStoreConfig(HelixUtils.getResourceName(partitionName)),
-        HelixUtils.getPartitionId(partitionName),
+        storeVersionConfig,
+        partitionId,
         leaderFollowerStateModelNotifier,
         getStoreMetadataRepo(),
         partitionPushStatusAccessorFuture,

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/KafkaStoreIngestionService.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/KafkaStoreIngestionService.java
@@ -1415,8 +1415,13 @@ public class KafkaStoreIngestionService extends AbstractVeniceService implements
     LOGGER.info("Offset reset to beginning - Kafka Partition: {}-{}.", topic, partitionId);
   }
 
-  // For testing purpose only.
+  @VisibleForTesting
   public KafkaValueSerializer getKafkaValueSerializer() {
     return kafkaValueSerializer;
+  }
+
+  @VisibleForTesting
+  protected Map<String, StoreIngestionTask> getTopicNameToIngestionTaskMap() {
+    return topicNameToIngestionTaskMap;
   }
 }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StorageUtilizationManager.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StorageUtilizationManager.java
@@ -188,9 +188,10 @@ public class StorageUtilizationManager implements StoreDataChangedListener {
     versionIsOnline = isVersionOnline(version);
     if (this.storeQuotaInBytes != store.getStorageQuotaInByte() || !store.isHybridStoreDiskQuotaEnabled()) {
       LOGGER.info(
-          "Store: {} changed, updated quota from {} to {} and store quota is {}enabled, "
+          "Store: {} changed, updated quota in: versionTopic: {} from: {} to: {} and store quota is {}enabled, "
               + "so we reset the store quota and resume all partitions.",
           this.storeName,
+          this.versionTopic,
           this.storeQuotaInBytes,
           store.getStorageQuotaInByte(),
           store.isHybridStoreDiskQuotaEnabled() ? "" : "not ");

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StorageUtilizationManager.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StorageUtilizationManager.java
@@ -415,8 +415,7 @@ public class StorageUtilizationManager implements StoreDataChangedListener {
       if (partitionCount == 0) {
         return 0.;
       }
-      quota *= partitionConsumptionSizeMap.size();
-      quota /= partitionCount;
+      quota = diskQuotaPerPartition * partitionConsumptionSizeMap.size();
     }
 
     long usage = 0;

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
@@ -4822,4 +4822,7 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
     return (isGlobalRtDivEnabled()) ? pcs.getLatestConsumedVtOffset() : pcs.getLatestProcessedLocalVersionTopicOffset();
   }
 
+  public StorageUtilizationManager getStorageUtilizationManager() {
+    return storageUtilizationManager;
+  }
 }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
@@ -53,6 +53,7 @@ import com.linkedin.davinci.utils.InMemoryChunkAssembler;
 import com.linkedin.davinci.validation.DataIntegrityValidator;
 import com.linkedin.davinci.validation.PartitionTracker;
 import com.linkedin.venice.ConfigKeys;
+import com.linkedin.venice.annotation.VisibleForTesting;
 import com.linkedin.venice.common.VeniceSystemStoreType;
 import com.linkedin.venice.common.VeniceSystemStoreUtils;
 import com.linkedin.venice.compression.CompressionStrategy;
@@ -242,6 +243,7 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
   protected final TopicManagerRepository topicManagerRepository;
   /** Per-partition consumption state map */
   protected final ConcurrentMap<Integer, PartitionConsumptionState> partitionConsumptionStateMap;
+  private final AtomicInteger activeReplicaCount = new AtomicInteger(0);
   protected final AbstractStoreBufferService storeBufferService;
 
   /**
@@ -493,7 +495,6 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
     this.storageEngine = Objects.requireNonNull(refCountedStorageEngine.get());
 
     this.serverConfig = builder.getServerConfig();
-
     this.defaultReadyToServeChecker = getDefaultReadyToServeChecker();
 
     this.aggKafkaConsumerService = Objects.requireNonNull(builder.getAggKafkaConsumerService());
@@ -696,6 +697,8 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
   }
 
   public synchronized void subscribePartition(PubSubTopicPartition topicPartition) {
+    activeReplicaCount.incrementAndGet();
+    LOGGER.info("Bootstrap replica: {}. Active replica count in SIT: {}", topicPartition, activeReplicaCount.get());
     subscribePartition(topicPartition, true);
   }
 
@@ -745,7 +748,9 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
    * This is always a Helix triggered action.
    */
   public CompletableFuture<Void> dropStoragePartitionGracefully(PubSubTopicPartition topicPartition) {
+    activeReplicaCount.decrementAndGet();
     int partitionId = topicPartition.getPartitionNumber();
+    LOGGER.info("Drop replica: {}. Active replica count in SIT: {}", topicPartition, activeReplicaCount.get());
     synchronized (this) {
       if (isRunning()) {
         LOGGER.info(
@@ -767,13 +772,15 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
   }
 
   /**
-   * Drops a partition synchrnously. This is invoked when processing a DROP_PARTITION message.
+   * Drops a partition synchronously. This is invoked when processing a DROP_PARTITION message.
    */
   private void dropPartitionSynchronously(PubSubTopicPartition topicPartition) {
-    LOGGER.info("{} Dropping partition: {}", ingestionTaskName, topicPartition);
+    LOGGER.info("Dropping replica: {}", topicPartition);
     int partition = topicPartition.getPartitionNumber();
+    LOGGER.info("Removing storage utilization manager for replica: {}", topicPartition);
+    storageUtilizationManager.removePartition(partition);
     this.storageService.dropStorePartition(storeVersionConfig, partition, true);
-    LOGGER.info("{} Dropped partition: {}", ingestionTaskName, topicPartition);
+    LOGGER.info("Dropped replica: {}", topicPartition);
   }
 
   public boolean hasAnySubscription() {
@@ -1628,7 +1635,7 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
    */
   @Override
   public void run() {
-    LogContext.setRegionLogContext(serverConfig.getRegionName());
+    LogContext.setStructuredLogContext(serverConfig.getLogContext());
     CountDownLatch shutdownLatch = gracefulShutdownLatch.get();
     boolean doFlush = true;
     try {
@@ -2255,7 +2262,12 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
          * two variables to avoid the race condition.
          */
         partitionConsumptionStateMap.remove(partition);
-        storageUtilizationManager.removePartition(partition);
+        if (consumerAction.isHelixTriggeredAction()) {
+          LOGGER.info(
+              "Removing tracking of replica: {} from storage utilization manager as this UNSUBSCRIBE is helix triggered action",
+              topicPartition);
+          storageUtilizationManager.removePartition(partition);
+        }
         getDataIntegrityValidator().clearPartition(partition);
         // Reset the error partition tracking
         PartitionExceptionInfo partitionExceptionInfo = partitionIngestionExceptionList.get(partition);
@@ -2608,7 +2620,7 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
         errorMessage += ". Consumption will be halted.";
         ingestionNotificationDispatcher
             .reportError(Collections.singletonList(partitionConsumptionState), errorMessage, e);
-        unSubscribePartition(new PubSubTopicPartitionImpl(versionTopic, faultyPartition));
+        unSubscribePartition(new PubSubTopicPartitionImpl(versionTopic, faultyPartition), false);
       } else {
         LOGGER.warn(
             "{}. Consumption will continue because it is either a current version replica or EOP has already been received. {}",
@@ -4384,7 +4396,7 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
             if (!REDUNDANT_LOGGING_FILTER.isRedundantException(msg)) {
               LOGGER.info(msg);
             }
-            unSubscribePartition(new PubSubTopicPartitionImpl(versionTopic, partition));
+            unSubscribePartition(new PubSubTopicPartitionImpl(versionTopic, partition), false);
           }
           partitionConsumptionState.recordReadyToServeInOffsetRecord();
         } else {
@@ -4788,7 +4800,7 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
     this.versionRole = versionRole;
   }
 
-  // For testing only
+  @VisibleForTesting
   Map<Integer, PartitionConsumptionState> getPartitionConsumptionStateMap() {
     return partitionConsumptionStateMap;
   }
@@ -4824,5 +4836,16 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
 
   public StorageUtilizationManager getStorageUtilizationManager() {
     return storageUtilizationManager;
+  }
+
+  /**
+   * Checks whether there are any replicas currently present on this host.
+   * <p>
+   * For batch-only stores, a replica might be removed from the PCS map but still physically
+   * present on the host. {@code activeReplicaCount} counter tracks the replica's lifecycle
+   * from the bootstrap stage through to the drop stage.
+   */
+  protected boolean hasReplicas() {
+    return activeReplicaCount.get() > 0;
   }
 }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/IngestionStats.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/IngestionStats.java
@@ -646,7 +646,7 @@ public class IngestionStats {
    * @return The disk quota usage as a double value, or 0 if unavailable.
    */
   public double getStorageQuotaUsed() {
-    if (ingestionTask == null) {
+    if (!hasActiveIngestionTask()) {
       return 0;
     }
     StorageUtilizationManager storageManager = ingestionTask.getStorageUtilizationManager();

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/IngestionStats.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/IngestionStats.java
@@ -4,6 +4,7 @@ import static com.linkedin.venice.stats.StatsErrorCode.INACTIVE_STORE_INGESTION_
 
 import com.linkedin.davinci.config.VeniceServerConfig;
 import com.linkedin.davinci.kafka.consumer.PartitionConsumptionState;
+import com.linkedin.davinci.kafka.consumer.StorageUtilizationManager;
 import com.linkedin.davinci.kafka.consumer.StoreIngestionTask;
 import com.linkedin.venice.stats.LongAdderRateGauge;
 import com.linkedin.venice.utils.RegionUtils;
@@ -64,6 +65,8 @@ public class IngestionStats {
   public static final String BATCH_PROCESSING_REQUEST_RECORDS = "batch_processing_request_records";
   public static final String BATCH_PROCESSING_REQUEST_LATENCY = "batch_processing_request_latency";
   public static final String BATCH_PROCESSING_REQUEST_ERROR = "batch_processing_request_error";
+
+  public static final String STORAGE_QUOTA_USED = "storage_quota_used";
 
   private static final MetricConfig METRIC_CONFIG = new MetricConfig();
   private StoreIngestionTask ingestionTask;
@@ -635,5 +638,18 @@ public class IngestionStats {
      This can cause problems when metrics are aggregated. Use only when zero makes semantic sense.
     */
     return Double.isFinite(value) ? value : 0;
+  }
+
+  /**
+   * Retrieves the storage quota usage for the current ingestion task.
+   *
+   * @return The disk quota usage as a double value, or 0 if unavailable.
+   */
+  public double getStorageQuotaUsed() {
+    if (ingestionTask == null) {
+      return 0;
+    }
+    StorageUtilizationManager storageManager = ingestionTask.getStorageUtilizationManager();
+    return (storageManager != null) ? storageManager.getDiskQuotaUsage() : 0;
   }
 }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/IngestionStatsReporter.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/IngestionStatsReporter.java
@@ -32,6 +32,7 @@ import static com.linkedin.davinci.stats.IngestionStats.OFFSET_REGRESSION_DCR_ER
 import static com.linkedin.davinci.stats.IngestionStats.PRODUCER_CALLBACK_LATENCY;
 import static com.linkedin.davinci.stats.IngestionStats.READY_TO_SERVE_WITH_RT_LAG_METRIC_NAME;
 import static com.linkedin.davinci.stats.IngestionStats.RECORDS_CONSUMED_METRIC_NAME;
+import static com.linkedin.davinci.stats.IngestionStats.STORAGE_QUOTA_USED;
 import static com.linkedin.davinci.stats.IngestionStats.SUBSCRIBE_ACTION_PREP_LATENCY;
 import static com.linkedin.davinci.stats.IngestionStats.TIMESTAMP_REGRESSION_DCR_ERROR;
 import static com.linkedin.davinci.stats.IngestionStats.TOMBSTONE_CREATION_DCR;
@@ -82,6 +83,8 @@ public class IngestionStatsReporter extends AbstractVeniceStatsReporter<Ingestio
             this,
             () -> (double) getStats().getWriteComputeErrorCode(),
             WRITE_COMPUTE_OPERATION_FAILURE));
+
+    registerSensor(new IngestionStatsGauge(this, () -> getStats().getStorageQuotaUsed(), 0, STORAGE_QUOTA_USED));
 
     registerSensor(
         new IngestionStatsGauge(this, () -> (double) getStats().getFollowerOffsetLag(), 0, FOLLOWER_OFFSET_LAG));

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/KafkaStoreIngestionServiceTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/KafkaStoreIngestionServiceTest.java
@@ -24,6 +24,7 @@ import com.linkedin.davinci.config.VeniceClusterConfig;
 import com.linkedin.davinci.config.VeniceConfigLoader;
 import com.linkedin.davinci.config.VeniceServerConfig;
 import com.linkedin.davinci.config.VeniceStoreVersionConfig;
+import com.linkedin.davinci.helix.LeaderFollowerPartitionStateModel;
 import com.linkedin.davinci.storage.StorageMetadataService;
 import com.linkedin.davinci.storage.StorageService;
 import com.linkedin.davinci.store.AbstractStorageEngineTest;
@@ -78,6 +79,7 @@ import java.util.Set;
 import java.util.concurrent.ConcurrentSkipListMap;
 import java.util.concurrent.PriorityBlockingQueue;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.function.Function;
 import org.apache.avro.Schema;
@@ -581,6 +583,16 @@ public abstract class KafkaStoreIngestionServiceTest {
     storeConfigField.setAccessible(true);
     storeConfigField.set(storeIngestionTask, config);
 
+    Field activeReplicaCountField = StoreIngestionTask.class.getDeclaredField("activeReplicaCount");
+    activeReplicaCountField.setAccessible(true);
+    AtomicInteger activeReplicaCount = new AtomicInteger(0);
+    activeReplicaCountField.set(storeIngestionTask, activeReplicaCount);
+
+    StorageUtilizationManager storageUtilizationManager = mock(StorageUtilizationManager.class);
+    Field storageUtilizationManagerField = StoreIngestionTask.class.getDeclaredField("storageUtilizationManager");
+    storageUtilizationManagerField.setAccessible(true);
+    storageUtilizationManagerField.set(storeIngestionTask, storageUtilizationManager);
+
     // Verify that when the ingestion task is running, it drops the store partition asynchronously
     when(storeIngestionTask.isRunning()).thenReturn(true);
     kafkaStoreIngestionService.dropStoragePartitionGracefully(config, partitionId);
@@ -654,6 +666,190 @@ public abstract class KafkaStoreIngestionServiceTest {
       Assert.assertNull(kafkaStoreIngestionService.getStoreIngestionTask(topicName));
     });
     kafkaStoreIngestionService.close();
+  }
+
+  @Test
+  public void testIdleSitCleanupSkipsCurrentVersionSitWithReplicas() {
+    kafkaStoreIngestionService = new KafkaStoreIngestionService(
+        mockStorageService,
+        mockVeniceConfigLoader,
+        storageMetadataService,
+        mockClusterInfoProvider,
+        mockMetadataRepo,
+        mockSchemaRepo,
+        mockLiveClusterConfigRepo,
+        new MetricsRepository(),
+        Optional.empty(),
+        Optional.empty(),
+        AvroProtocolDefinition.PARTITION_STATE.getSerializer(),
+        Optional.empty(),
+        null,
+        false,
+        compressorFactory,
+        Optional.empty(),
+        null,
+        false,
+        null,
+        mockPubSubClientsFactory,
+        Optional.empty(),
+        null,
+        null,
+        null);
+    kafkaStoreIngestionService.start();
+    String topicName = "test-store_v1";
+    String storeName = Version.parseStoreFromKafkaTopicName(topicName);
+    Store mockStore = new ZKStore(
+        storeName,
+        "unit-test",
+        0,
+        PersistenceType.ROCKS_DB,
+        RoutingStrategy.CONSISTENT_HASH,
+        ReadStrategy.ANY_OF_ONLINE,
+        OfflinePushStrategy.WAIT_ALL_REPLICAS,
+        1);
+
+    mockStore.addVersion(new VersionImpl(storeName, 1, "test-job-id"));
+    mockStore.setCurrentVersion(1);
+    doReturn(mockStore).when(mockMetadataRepo).getStore(storeName);
+    doReturn(mockStore).when(mockMetadataRepo).getStoreOrThrow(storeName);
+    doReturn(new StoreVersionInfo(mockStore, mockStore.getVersion(1))).when(mockMetadataRepo)
+        .waitVersion(eq(storeName), eq(1), any());
+    VeniceProperties veniceProperties = AbstractStorageEngineTest.getServerProperties(PersistenceType.ROCKS_DB);
+    VeniceStoreVersionConfig config = new VeniceStoreVersionConfig(topicName, veniceProperties);
+    kafkaStoreIngestionService.startConsumption(config, 0);
+    // kafkaStoreIngestionService.stopConsumptionAndWait(config, 0, 1, 1, true);
+    final StoreIngestionTask storeIngestionTask = kafkaStoreIngestionService.getStoreIngestionTask(topicName);
+    // Unsubscribe from partition 0 to make the store ingestion task idle
+    Set<PubSubTopicPartition> topicPartitionsToUnsubscribe = new HashSet<>();
+    topicPartitionsToUnsubscribe.add(new PubSubTopicPartitionImpl(pubSubTopicRepository.getTopic(topicName), 0));
+    storeIngestionTask.consumerBatchUnsubscribe(topicPartitionsToUnsubscribe);
+    // Verify that the store ingestion task is marked as idle and eventually closed
+    TestUtils.waitForNonDeterministicAssertion(1, TimeUnit.MINUTES, () -> {
+      Assert.assertTrue(storeIngestionTask.isIdleOverThreshold());
+    });
+    // verify has active replicas
+    assertTrue(storeIngestionTask.hasReplicas());
+    assertTrue(storeIngestionTask.isCurrentVersion.getAsBoolean());
+    // verify SIT is not null and it is not closed
+    assertNotNull(kafkaStoreIngestionService.getStoreIngestionTask(topicName));
+    assertTrue(kafkaStoreIngestionService.getStoreIngestionTask(topicName).isRunning());
+
+    kafkaStoreIngestionService.close();
+  }
+
+  @Test
+  public void testPromoteToLeader() {
+    kafkaStoreIngestionService = new KafkaStoreIngestionService(
+        mockStorageService,
+        mockVeniceConfigLoader,
+        storageMetadataService,
+        mockClusterInfoProvider,
+        mockMetadataRepo,
+        mockSchemaRepo,
+        mockLiveClusterConfigRepo,
+        new MetricsRepository(),
+        Optional.empty(),
+        Optional.empty(),
+        AvroProtocolDefinition.PARTITION_STATE.getSerializer(),
+        Optional.empty(),
+        null,
+        false,
+        compressorFactory,
+        Optional.empty(),
+        null,
+        false,
+        null,
+        mockPubSubClientsFactory,
+        Optional.empty(),
+        null,
+        null,
+        null);
+
+    VeniceProperties veniceProperties = AbstractStorageEngineTest.getServerProperties(PersistenceType.ROCKS_DB);
+    PubSubTopic topic = pubSubTopicRepository.getTopic("test-store_v1");
+    VeniceStoreVersionConfig veniceStoreVersionConfig = new VeniceStoreVersionConfig(topic.getName(), veniceProperties);
+    int partitionId = 0;
+    LeaderFollowerPartitionStateModel.LeaderSessionIdChecker checker =
+        mock(LeaderFollowerPartitionStateModel.LeaderSessionIdChecker.class);
+
+    // Case: SIT does not exist for the topic
+    assertFalse(kafkaStoreIngestionService.getTopicNameToIngestionTaskMap().containsKey(topic.getName()));
+    kafkaStoreIngestionService.promoteToLeader(veniceStoreVersionConfig, partitionId, checker);
+    assertFalse(kafkaStoreIngestionService.getTopicNameToIngestionTaskMap().containsKey(topic.getName()));
+
+    // Case: SIT exists for the topic but is not running
+    StoreIngestionTask storeIngestionTask = mock(StoreIngestionTask.class);
+    kafkaStoreIngestionService.getTopicNameToIngestionTaskMap().put(topic.getName(), storeIngestionTask);
+    doReturn(false).when(storeIngestionTask).isRunning();
+    kafkaStoreIngestionService.promoteToLeader(veniceStoreVersionConfig, partitionId, checker);
+    verify(storeIngestionTask, never()).promoteToLeader(
+        any(PubSubTopicPartition.class),
+        any(LeaderFollowerPartitionStateModel.LeaderSessionIdChecker.class));
+
+    // Case: SIT exists for the topic and is running
+    assertTrue(kafkaStoreIngestionService.getTopicNameToIngestionTaskMap().containsKey(topic.getName()));
+    doReturn(true).when(storeIngestionTask).isRunning();
+    kafkaStoreIngestionService.promoteToLeader(veniceStoreVersionConfig, partitionId, checker);
+    verify(storeIngestionTask).promoteToLeader(
+        any(PubSubTopicPartition.class),
+        any(LeaderFollowerPartitionStateModel.LeaderSessionIdChecker.class));
+  }
+
+  @Test
+  public void testDemoteToStandby() {
+    kafkaStoreIngestionService = new KafkaStoreIngestionService(
+        mockStorageService,
+        mockVeniceConfigLoader,
+        storageMetadataService,
+        mockClusterInfoProvider,
+        mockMetadataRepo,
+        mockSchemaRepo,
+        mockLiveClusterConfigRepo,
+        new MetricsRepository(),
+        Optional.empty(),
+        Optional.empty(),
+        AvroProtocolDefinition.PARTITION_STATE.getSerializer(),
+        Optional.empty(),
+        null,
+        false,
+        compressorFactory,
+        Optional.empty(),
+        null,
+        false,
+        null,
+        mockPubSubClientsFactory,
+        Optional.empty(),
+        null,
+        null,
+        null);
+
+    VeniceProperties veniceProperties = AbstractStorageEngineTest.getServerProperties(PersistenceType.ROCKS_DB);
+    PubSubTopic topic = pubSubTopicRepository.getTopic("test-store_v1");
+    VeniceStoreVersionConfig veniceStoreVersionConfig = new VeniceStoreVersionConfig(topic.getName(), veniceProperties);
+    int partitionId = 0;
+    LeaderFollowerPartitionStateModel.LeaderSessionIdChecker checker =
+        mock(LeaderFollowerPartitionStateModel.LeaderSessionIdChecker.class);
+
+    // Case: SIT does not exist for the topic
+    assertFalse(kafkaStoreIngestionService.getTopicNameToIngestionTaskMap().containsKey(topic.getName()));
+    kafkaStoreIngestionService.demoteToStandby(veniceStoreVersionConfig, partitionId, checker);
+    assertFalse(kafkaStoreIngestionService.getTopicNameToIngestionTaskMap().containsKey(topic.getName()));
+
+    // Case: SIT exists for the topic but is not running
+    StoreIngestionTask storeIngestionTask = mock(StoreIngestionTask.class);
+    kafkaStoreIngestionService.getTopicNameToIngestionTaskMap().put(topic.getName(), storeIngestionTask);
+    doReturn(false).when(storeIngestionTask).isRunning();
+    kafkaStoreIngestionService.demoteToStandby(veniceStoreVersionConfig, partitionId, checker);
+    verify(storeIngestionTask, never()).demoteToStandby(
+        any(PubSubTopicPartition.class),
+        any(LeaderFollowerPartitionStateModel.LeaderSessionIdChecker.class));
+
+    // Case: SIT exists for the topic and is running
+    doReturn(true).when(storeIngestionTask).isRunning();
+    kafkaStoreIngestionService.demoteToStandby(veniceStoreVersionConfig, partitionId, checker);
+    verify(storeIngestionTask).demoteToStandby(
+        any(PubSubTopicPartition.class),
+        any(LeaderFollowerPartitionStateModel.LeaderSessionIdChecker.class));
   }
 
   @Test

--- a/internal/venice-client-common/src/main/java/com/linkedin/venice/utils/DaemonThreadFactory.java
+++ b/internal/venice-client-common/src/main/java/com/linkedin/venice/utils/DaemonThreadFactory.java
@@ -3,7 +3,6 @@ package com.linkedin.venice.utils;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.atomic.AtomicInteger;
 import javax.annotation.Nullable;
-import org.apache.logging.log4j.ThreadContext;
 
 
 /**
@@ -32,7 +31,7 @@ public class DaemonThreadFactory implements ThreadFactory {
       try {
         r.run();
       } finally {
-        ThreadContext.clearAll(); // prevent context leakage across tasks
+        LogContext.clearLogContext();
       }
     };
 

--- a/internal/venice-client-common/src/main/java/com/linkedin/venice/utils/LogContext.java
+++ b/internal/venice-client-common/src/main/java/com/linkedin/venice/utils/LogContext.java
@@ -23,16 +23,18 @@ public class LogContext {
   public static final String LOG_CONTEXT_KEY = "logContext";
 
   private final String regionName;
+  private final String instanceName;
   private final String componentName;
   private final String value;
 
   private LogContext(Builder builder) {
     this.regionName = builder.regionName;
     this.componentName = builder.componentName;
-    if (StringUtils.isBlank(regionName) && StringUtils.isBlank(componentName)) {
+    this.instanceName = builder.instanceName;
+    if (StringUtils.isBlank(regionName) && StringUtils.isBlank(componentName) && StringUtils.isBlank(instanceName)) {
       this.value = "";
     } else {
-      this.value = String.format("%s--%s", componentName, regionName);
+      this.value = String.format("%s:%s:%s", componentName, regionName, instanceName);
     }
   }
 
@@ -97,6 +99,13 @@ public class LogContext {
   }
 
   /**
+   * @return The instance name stored in this LogContext.
+   */
+  public String getInstanceName() {
+    return instanceName;
+  }
+
+  /**
    * @return The value of the log context in the form {@code componentName|regionName}.
    */
   public String getValue() {
@@ -123,8 +132,9 @@ public class LogContext {
    * Builder for {@link LogContext}.
    */
   public static class Builder {
-    private String regionName;
     private String componentName;
+    private String regionName;
+    private String instanceName;
 
     /**
      * Sets the region name to be included in the LogContext.
@@ -145,6 +155,17 @@ public class LogContext {
      */
     public Builder setComponentName(String componentName) {
       this.componentName = componentName;
+      return this;
+    }
+
+    /**
+     * Sets the instance name to be included in the LogContext.
+     *
+     * @param instanceName The name of the instance.
+     * @return This builder instance.
+     */
+    public Builder setInstanceName(String instanceName) {
+      this.instanceName = instanceName;
       return this;
     }
 

--- a/internal/venice-client-common/src/test/java/com/linkedin/venice/utils/LogContextTest.java
+++ b/internal/venice-client-common/src/test/java/com/linkedin/venice/utils/LogContextTest.java
@@ -13,6 +13,7 @@ import org.testng.annotations.Test;
 public class LogContextTest {
   private static final String REGION_NAME = "us-west-1";
   private static final String COMPONENT_NAME = "router";
+  private static final String INSTANCE_ID = "instance_1235";
 
   @BeforeMethod
   public void setUp() {
@@ -26,12 +27,16 @@ public class LogContextTest {
 
   @Test
   public void testBuilderCreatesCorrectContext() {
-    LogContext context = LogContext.newBuilder().setRegionName(REGION_NAME).setComponentName(COMPONENT_NAME).build();
+    LogContext context = LogContext.newBuilder()
+        .setRegionName(REGION_NAME)
+        .setInstanceName(INSTANCE_ID)
+        .setComponentName(COMPONENT_NAME)
+        .build();
 
     assertNotNull(context);
     assertEquals(context.getRegionName(), REGION_NAME);
     assertEquals(context.getComponentName(), COMPONENT_NAME);
-    assertEquals(context.toString(), COMPONENT_NAME + "--" + REGION_NAME);
+    assertEquals(context.toString(), COMPONENT_NAME + ":" + REGION_NAME + ":" + INSTANCE_ID);
   }
 
   @Test

--- a/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/adapter/kafka/admin/ApacheKafkaAdminAdapter.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/adapter/kafka/admin/ApacheKafkaAdminAdapter.java
@@ -44,6 +44,7 @@ import org.apache.kafka.common.errors.RetriableException;
 import org.apache.kafka.common.errors.TimeoutException;
 import org.apache.kafka.common.errors.TopicExistsException;
 import org.apache.kafka.common.errors.UnknownTopicOrPartitionException;
+import org.apache.kafka.common.record.TimestampType;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -433,7 +434,7 @@ public class ApacheKafkaAdminAdapter implements PubSubAdminAdapter {
             minIsrConfig -> topicProperties
                 .put(TopicConfig.MIN_IN_SYNC_REPLICAS_CONFIG, Integer.toString(minIsrConfig)));
     // Just in case the Kafka cluster isn't configured as expected.
-    topicProperties.put(TopicConfig.MESSAGE_TIMESTAMP_TYPE_CONFIG, "LogAppendTime");
+    topicProperties.put(TopicConfig.MESSAGE_TIMESTAMP_TYPE_CONFIG, TimestampType.LOG_APPEND_TIME.toString());
     return topicProperties;
   }
 

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestHybridQuota.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestHybridQuota.java
@@ -1,9 +1,12 @@
 package com.linkedin.venice.endToEnd;
 
+import static com.linkedin.venice.ConfigKeys.CONTROLLER_BACKUP_VERSION_DEFAULT_RETENTION_MS;
 import static com.linkedin.venice.ConfigKeys.HELIX_HYBRID_STORE_QUOTA_ENABLED;
 import static com.linkedin.venice.ConfigKeys.HYBRID_QUOTA_ENFORCEMENT_ENABLED;
 import static com.linkedin.venice.ConfigKeys.PERSISTENCE_TYPE;
 import static com.linkedin.venice.ConfigKeys.SERVER_CONSUMER_POOL_SIZE_PER_KAFKA_CLUSTER;
+import static com.linkedin.venice.ConfigKeys.SERVER_IDLE_INGESTION_TASK_CLEANUP_INTERVAL_IN_SECONDS;
+import static com.linkedin.venice.ConfigKeys.SERVER_UNSUB_AFTER_BATCHPUSH;
 import static com.linkedin.venice.ConfigKeys.SSL_TO_KAFKA_LEGACY;
 import static com.linkedin.venice.pubsub.PubSubConstants.PUBSUB_OPERATION_TIMEOUT_MS_DEFAULT_VALUE;
 import static com.linkedin.venice.utils.IntegrationTestPushUtils.createStoreForJob;
@@ -16,8 +19,10 @@ import static com.linkedin.venice.utils.TestWriteUtils.getTempDataDirectory;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
 
+import com.linkedin.venice.controller.VeniceHelixAdmin;
 import com.linkedin.venice.controllerapi.ControllerClient;
 import com.linkedin.venice.controllerapi.ControllerResponse;
+import com.linkedin.venice.controllerapi.StoreResponse;
 import com.linkedin.venice.controllerapi.UpdateStoreQueryParams;
 import com.linkedin.venice.exceptions.VeniceException;
 import com.linkedin.venice.helix.HelixAdapterSerializer;
@@ -29,6 +34,7 @@ import com.linkedin.venice.helix.ZkClientFactory;
 import com.linkedin.venice.integration.utils.ServiceFactory;
 import com.linkedin.venice.integration.utils.VeniceClusterCreateOptions;
 import com.linkedin.venice.integration.utils.VeniceClusterWrapper;
+import com.linkedin.venice.integration.utils.VeniceServerWrapper;
 import com.linkedin.venice.meta.PersistenceType;
 import com.linkedin.venice.meta.Store;
 import com.linkedin.venice.meta.Version;
@@ -41,7 +47,9 @@ import com.linkedin.venice.utils.TestWriteUtils;
 import com.linkedin.venice.utils.Time;
 import com.linkedin.venice.utils.Utils;
 import com.linkedin.venice.utils.locks.ClusterLockManager;
+import io.tehuti.metrics.MetricsRepository;
 import java.io.File;
+import java.io.IOException;
 import java.util.Optional;
 import java.util.Properties;
 import java.util.concurrent.TimeUnit;
@@ -70,32 +78,28 @@ public class TestHybridQuota {
   public void setUp() {
     Properties extraProperties = new Properties();
     extraProperties.setProperty(PERSISTENCE_TYPE, PersistenceType.ROCKS_DB.name());
+    // Added a server with shared consumer enabled.
+    Properties serverPropertiesWithSharedConsumer = new Properties();
+    serverPropertiesWithSharedConsumer.setProperty(SSL_TO_KAFKA_LEGACY, "false");
+    extraProperties.put(HELIX_HYBRID_STORE_QUOTA_ENABLED, true);
+    extraProperties.put(HYBRID_QUOTA_ENFORCEMENT_ENABLED, true);
+    extraProperties.put(SERVER_CONSUMER_POOL_SIZE_PER_KAFKA_CLUSTER, "3");
+    extraProperties.put(CONTROLLER_BACKUP_VERSION_DEFAULT_RETENTION_MS, TimeUnit.DAYS.toMillis(7) + "");
+    extraProperties.put(CONTROLLER_BACKUP_VERSION_DEFAULT_RETENTION_MS, 0);
+    extraProperties.put(SERVER_IDLE_INGESTION_TASK_CLEANUP_INTERVAL_IN_SECONDS, "2");
+    extraProperties.put(SERVER_UNSUB_AFTER_BATCHPUSH, "false");
 
     // N.B.: RF 2 with 3 servers is important, in order to test both the leader and follower code paths
     VeniceClusterCreateOptions options = new VeniceClusterCreateOptions.Builder().numberOfControllers(1)
-        .numberOfServers(0)
-        .numberOfRouters(0)
-        .replicationFactor(2)
+        .numberOfServers(3)
+        .numberOfRouters(1)
+        .replicationFactor(1)
         .partitionSize(1000000)
         .sslToStorageNodes(false)
         .sslToKafka(false)
         .extraProperties(extraProperties)
         .build();
     sharedVenice = ServiceFactory.getVeniceCluster(options);
-
-    Properties routerProperties = new Properties();
-    routerProperties.put(HELIX_HYBRID_STORE_QUOTA_ENABLED, true);
-
-    sharedVenice.addVeniceRouter(routerProperties);
-    // Added a server with shared consumer enabled.
-    Properties serverPropertiesWithSharedConsumer = new Properties();
-    serverPropertiesWithSharedConsumer.setProperty(SSL_TO_KAFKA_LEGACY, "false");
-    extraProperties.put(HELIX_HYBRID_STORE_QUOTA_ENABLED, true);
-    extraProperties.put(HYBRID_QUOTA_ENFORCEMENT_ENABLED, true);
-    extraProperties.setProperty(SERVER_CONSUMER_POOL_SIZE_PER_KAFKA_CLUSTER, "3");
-    sharedVenice.addVeniceServer(serverPropertiesWithSharedConsumer, extraProperties);
-    sharedVenice.addVeniceServer(serverPropertiesWithSharedConsumer, extraProperties);
-    sharedVenice.addVeniceServer(serverPropertiesWithSharedConsumer, extraProperties);
     LOGGER.info("Finished creating VeniceClusterWrapper");
   }
 
@@ -243,12 +247,12 @@ public class TestHybridQuota {
               .setStorageQuotaInByte(storageQuotaInByte));
       if (isStreamReprocessing) {
         veniceProducer = getSamzaProducer(sharedVenice, storeName, Version.PushType.STREAM_REPROCESSING); // new
-                                                                                                          // producer,
-                                                                                                          // new DIV
-                                                                                                          // segment.
+        // producer,
+        // new DIV
+        // segment.
       } else {
         veniceProducer = getSamzaProducer(sharedVenice, storeName, Version.PushType.STREAM); // new producer, new DIV
-                                                                                             // segment.
+        // segment.
       }
       for (int i = 1; i <= 20; i++) {
         try {
@@ -291,12 +295,12 @@ public class TestHybridQuota {
         }
         if (isStreamReprocessing) {
           veniceProducer = getSamzaProducer(sharedVenice, storeName, Version.PushType.STREAM_REPROCESSING); // new
-                                                                                                            // producer,
-                                                                                                            // new DIV
-                                                                                                            // segment.
+          // producer,
+          // new DIV
+          // segment.
         } else {
           veniceProducer = getSamzaProducer(sharedVenice, storeName, Version.PushType.STREAM); // new producer, new DIV
-                                                                                               // segment.
+          // segment.
         }
 
         sendStreamingRecord(veniceProducer, storeName, 21);
@@ -337,4 +341,132 @@ public class TestHybridQuota {
     }
   }
 
+  @Test
+  // test batch store quota updates
+  public void testBatchStoreQuotaUpdates() throws IOException {
+    String storeName = Utils.getUniqueString("test-batch-store-quota-updates");
+    // Create store
+    File inputDir = getTempDataDirectory();
+    String inputDirPath = "file://" + inputDir.getAbsolutePath();
+    Schema recordSchema = TestWriteUtils.writeSimpleAvroFileWithStringToStringSchema(inputDir, 100);
+
+    Properties props = IntegrationTestPushUtils.defaultVPJProps(sharedVenice, inputDirPath, storeName);
+    try (ControllerClient controllerClient = createStoreForJob(sharedVenice.getClusterName(), recordSchema, props)) {
+      // run a push to create the store
+      IntegrationTestPushUtils.runVPJ(props, 1, controllerClient);
+      TestUtils.waitForNonDeterministicAssertion(60, TimeUnit.SECONDS, () -> {
+        StoreResponse storeResponse = TestUtils.assertCommand(controllerClient.getStore(storeName));
+        assertEquals(storeResponse.getStore().getCurrentVersion(), 1);
+      });
+
+      // Create a store with hybrid quota enabled
+      ControllerResponse response =
+          controllerClient.updateStore(storeName, new UpdateStoreQueryParams().setStorageQuotaInByte(1024));
+      Assert.assertFalse(response.isError());
+      TestUtils.waitForNonDeterministicAssertion(60, TimeUnit.SECONDS, () -> {
+        StoreResponse storeResponse = TestUtils.assertCommand(controllerClient.getStore(storeName));
+        assertEquals(storeResponse.getStore().getStorageQuotaInByte(), 1024);
+      });
+
+      Utils.sleep(TimeUnit.SECONDS.toMillis(10));
+      for (VeniceServerWrapper veniceServerWrapper: sharedVenice.getVeniceServers()) {
+        printStorageQuotaUsage(veniceServerWrapper, storeName);
+      }
+
+      LOGGER.info("### new version push job started for store: {}", storeName);
+      response = controllerClient.updateStore(storeName, new UpdateStoreQueryParams().setStorageQuotaInByte(-1));
+      Assert.assertFalse(response.isError());
+      // run another push to create a second version
+      TestWriteUtils.writeSimpleAvroFileWithStringToStringSchema(inputDir, 10000);
+      IntegrationTestPushUtils.runVPJ(props, 2, controllerClient);
+      TestUtils.waitForNonDeterministicAssertion(60, TimeUnit.SECONDS, () -> {
+        StoreResponse storeResponse = TestUtils.assertCommand(controllerClient.getStore(storeName));
+        assertEquals(storeResponse.getStore().getCurrentVersion(), 2);
+      });
+      IntegrationTestPushUtils.runVPJ(props, 3, controllerClient);
+      TestUtils.waitForNonDeterministicAssertion(60, TimeUnit.SECONDS, () -> {
+        StoreResponse storeResponse = TestUtils.assertCommand(controllerClient.getStore(storeName));
+        assertEquals(storeResponse.getStore().getCurrentVersion(), 3);
+      });
+      // LOGGER.info(
+      // "### All metrics: {}",
+      // sharedVenice.getVeniceServers().get(0).getVeniceServer().getMetricsRepository().metrics().keySet());
+
+      for (VeniceServerWrapper veniceServerWrapper: sharedVenice.getVeniceServers()) {
+        boolean isQuotaViolated = printStorageQuotaUsage(veniceServerWrapper, storeName);
+        LOGGER.info(
+            "### Storage quota usage for store {} on server {}: isQuotaViolated: {}",
+            storeName,
+            veniceServerWrapper.getAddress(),
+            isQuotaViolated);
+        if (isQuotaViolated) {
+          VeniceServerWrapper serverWrapper = sharedVenice.getVeniceServers().get(0);
+          VeniceHelixAdmin helixAdmin = sharedVenice.getVeniceControllers().get(0).getVeniceHelixAdmin();
+          String instance = Utils.getHelixNodeIdentifier(serverWrapper.getHost(), serverWrapper.getPort());
+          helixAdmin.disableReplica(sharedVenice.getClusterName(), storeName + "_v3", instance, 1);
+          break;
+        }
+      }
+
+      Utils.sleep(30 * Time.MS_PER_SECOND);
+
+      // update quota to 2048
+      response = controllerClient.updateStore(storeName, new UpdateStoreQueryParams().setStorageQuotaInByte(512));
+      Assert.assertFalse(response.isError());
+      TestUtils.waitForNonDeterministicAssertion(60, TimeUnit.SECONDS, () -> {
+        StoreResponse storeResponse = TestUtils.assertCommand(controllerClient.getStore(storeName));
+        assertEquals(storeResponse.getStore().getStorageQuotaInByte(), 512);
+      });
+      for (VeniceServerWrapper veniceServerWrapper: sharedVenice.getVeniceServers()) {
+        printStorageQuotaUsage(veniceServerWrapper, storeName);
+      }
+      Utils.sleep(TimeUnit.SECONDS.toMillis(20));
+      for (VeniceServerWrapper veniceServerWrapper: sharedVenice.getVeniceServers()) {
+        printStorageQuotaUsage(veniceServerWrapper, storeName);
+      }
+
+    }
+  }
+
+  private boolean printStorageQuotaUsage(VeniceServerWrapper veniceServerWrapper, String storeName) {
+    MetricsRepository metricsRepository = veniceServerWrapper.getVeniceServer().getMetricsRepository();
+
+    // Assert.assertEquals(metricsRepository.getMetric(readQuotaRejectedQPSString).value(), 1d / 30d, 0.05);
+    // prod-ltx1/venice-server/venice-server-war.i001.venice-server.LSSSearchL2MemberEmbeddings--storage_quota_used.Gauge.rrd
+    // String readQuotaRejectedQPSString = "." + storeName + "--storage_quota_used.Gauge";
+
+    String storageQuotaUsedString = "." + storeName + "--storage_quota_used.Gauge";
+    // _current--storage_quota_used.IngestionStatsGauge
+    String currentVersionStorageQuotaUsedString = "." + storeName + "_current--storage_quota_used.IngestionStatsGauge";
+    String futureVersionStorageQuotaUsedString = "." + storeName + "_future--storage_quota_used.IngestionStatsGauge";
+    // .test-batch-store-quota-updates_67af944501383_cad489f0_total--storage_quota_used.IngestionStatsGauge
+    String totalStorageQuotaUsedString = "." + storeName + "_total--storage_quota_used.IngestionStatsGauge";
+
+    // add null check for the metric
+    // double storageQuotaUsed = metricsRepository.getMetric(storageQuotaUsedString).value();
+    double storageQuotaUsed = metricsRepository.getMetric(storageQuotaUsedString) != null
+        ? metricsRepository.getMetric(storageQuotaUsedString).value()
+        : 0.0;
+    double currentVersionStorageQuotaUsed = metricsRepository.getMetric(currentVersionStorageQuotaUsedString) != null
+        ? metricsRepository.getMetric(currentVersionStorageQuotaUsedString).value()
+        : 0.0;
+    double futureVersionStorageQuotaUsed = metricsRepository.getMetric(futureVersionStorageQuotaUsedString) != null
+        ? metricsRepository.getMetric(futureVersionStorageQuotaUsedString).value()
+        : 0.0;
+    double totalStorageQuotaUsed = metricsRepository.getMetric(totalStorageQuotaUsedString) != null
+        ? metricsRepository.getMetric(totalStorageQuotaUsedString).value()
+        : 0.0;
+
+    LOGGER.info(
+        "#### ==> Storage quota used on: {} for store {}: storageQuotaUsed: {}, currentVersionStorageQuotaUsed: {}, futureVersionStorageQuotaUsed: {}, totalStorageQuotaUsed: {}",
+        veniceServerWrapper.getAddress(),
+        storeName,
+        storageQuotaUsed,
+        currentVersionStorageQuotaUsed,
+        futureVersionStorageQuotaUsed,
+        totalStorageQuotaUsed);
+
+    // if non zero return true
+    return currentVersionStorageQuotaUsed > 1.0d;
+  }
 }

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceControllerClusterConfig.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceControllerClusterConfig.java
@@ -203,6 +203,7 @@ import static com.linkedin.venice.utils.ByteUtils.generateHumanReadableByteCount
 import com.linkedin.venice.ConfigKeys;
 import com.linkedin.venice.PushJobCheckpoints;
 import com.linkedin.venice.SSLConfig;
+import com.linkedin.venice.acl.VeniceComponent;
 import com.linkedin.venice.authorization.DefaultIdentityParser;
 import com.linkedin.venice.client.store.ClientConfig;
 import com.linkedin.venice.controllerapi.ControllerRoute;
@@ -1148,7 +1149,10 @@ public class VeniceControllerClusterConfig {
         props.getLong(CONTROLLER_DEFERRED_VERSION_SWAP_SLEEP_MS, TimeUnit.MINUTES.toMillis(1));
     this.deferredVersionSwapServiceEnabled = props.getBoolean(CONTROLLER_DEFERRED_VERSION_SWAP_SERVICE_ENABLED, false);
     this.skipDeferredVersionSwapForDVCEnabled = props.getBoolean(SKIP_DEFERRED_VERSION_SWAP_FOR_DVC_ENABLED, true);
-    this.logContext = new LogContext.Builder().setRegionName(regionName).setComponentName("controller").build();
+    this.logContext = new LogContext.Builder().setRegionName(regionName)
+        .setInstanceName(Utils.getHelixNodeIdentifier(adminHostname, adminPort))
+        .setComponentName(VeniceComponent.CONTROLLER.name())
+        .build();
     this.deferredVersionSwapBufferTime = props.getDouble(DEFERRED_VERSION_SWAP_BUFFER_TIME, 1.1);
   }
 


### PR DESCRIPTION


## Emit versioned storage quota stats and keep SIT open for current store version

This change enables emission of versioned storage quota usage stats by adding a new  
metric. To ensure accurate quota tracking, we no longer shut down SIT belonging to  
the current version during idle task cleanup.  

Shutting down SIT prematurely:  
1) Clears partition consumption state maps, which are required to compute quota usage.  
2) Removes the store change listener, StorageUtilizationManager, which is needed   
   to react to quota config changes.  

These changes help maintain quota observability and ensure that the metrics remain  
 accurate for online versions.  


###  Code changes
- [ ] Added new code behind **a config**. If so list the config names and their default values in the PR description.
- [ ] Introduced new **log lines**. 
  - [ ] Confirmed if logs need to be **rate limited** to avoid excessive logging.

###  **Concurrency-Specific Checks**
Both reviewer and PR author to verify
- [ ] Code has **no race conditions** or **thread safety issues**.
- [ ] Proper **synchronization mechanisms** (e.g., `synchronized`, `RWLock`) are used where needed.
- [ ] No **blocking calls** inside critical sections that could lead to deadlocks or performance degradation.
- [ ] Verified **thread-safe collections** are used (e.g., `ConcurrentHashMap`, `CopyOnWriteArrayList`).
- [ ] Validated proper exception handling in multi-threaded code to avoid silent thread termination.


## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->

- [ ] New unit tests added.
- [ ] New integration tests added.
- [ ] Modified or extended existing tests.
- [ ] Verified backward compatibility (if applicable).

## Does this PR introduce any user-facing or breaking changes?
<!--  
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [ ] No. You can skip the rest of this section.
- [ ] Yes. Clearly explain the behavior change and its impact.