### PR TITLE
[server][dvc] Add fast failover in client when server unexpected shutdowns during blob transfer

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/blobtransfer/client/NettyFileTransferClient.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/blobtransfer/client/NettyFileTransferClient.java
@@ -267,7 +267,7 @@ public class NettyFileTransferClient {
       // Attach the file handler to the pipeline
       // Attach the metadata handler to the pipeline
       ch.pipeline()
-          .addLast(new IdleStateHandler(0, 0, 60))
+          .addLast(new IdleStateHandler(60, 0, 0)) // READER_IDLE: timeout of 60 seconds
           .addLast(new MetadataAggregator(MAX_METADATA_CONTENT_LENGTH))
           .addLast(
               new P2PFileTransferClientHandler(


### PR DESCRIPTION
## Problem Statement
In the DVC use case, we observed scenarios where the client never receives any response—neither success nor failure—from certain hosts, resulting endless bootstrap.

One such case is: the client sends a request to the server, the server receives it, generates the snapshot, and begins the transfer. However, immediately afterward, the server host starts bootstrapping, which interrupts the transfer process entirely. The client, unaware of this interruption, continues waiting indefinitely for a response.



## Solution
1. To prevent indefinite waiting, as a final safeguard, we’ve added a client-side configurable timeout to avoid endless bootstrapping, implemented in [PR #1859](https://github.com/linkedin/venice/pull/1859).

2. To enable fast failover for incomplete transfers, this PR introduces the following improvements:
   - If the server shuts down gracefully (which triggers `ctx.closed`; server logs show it calls `channelInactive` and decrements the concurrent count), the client’s `channelInactive()` is invoked immediately. In this case, we add a “fastFailoverIncompleteTransfer” step: if `inputStreamFuture` is still incomplete at that time, we complete it exceptionally to initiate fast failover.
   - If the server shuts down unexpectedly, such as via `kill -9` or a crash, the timeout handler (`userEventTriggered`) will be triggered after the READER_IDLE period. At this point, we also call `fastFailoverIncompleteTransfer` to enable fast failover.


###  Code changes
- [ ] Added new code behind **a config**. If so list the config names and their default values in the PR description.
- [ ] Introduced new **log lines**. 
- [ ] Confirmed if logs need to be **rate limited** to avoid excessive logging.

###  **Concurrency-Specific Checks**
Both reviewer and PR author to verify
- [ ] Code has **no race conditions** or **thread safety issues**.
- [ ] Proper **synchronization mechanisms** (e.g., `synchronized`, `RWLock`) are used where needed.
- [ ] No **blocking calls** inside critical sections that could lead to deadlocks or performance degradation.
- [ ] Verified **thread-safe collections** are used (e.g., `ConcurrentHashMap`, `CopyOnWriteArrayList`).
- [ ] Validated proper exception handling in multi-threaded code to avoid silent thread termination.


## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->

- [ ] New unit tests added.
- [ ] New integration tests added.
- [ ] Modified or extended existing tests.
- [ ] Verified backward compatibility (if applicable).

## Does this PR introduce any user-facing or breaking changes?
<!--  
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [ ] No. You can skip the rest of this section.
- [ ] Yes. Clearly explain the behavior change and its impact.