### PR TITLE
[thin-client] Change reader schema behavior to use writer schema

### DIFF
--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/client/AvroGenericDaVinciClientTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/client/AvroGenericDaVinciClientTest.java
@@ -88,7 +88,10 @@ public class AvroGenericDaVinciClientTest {
 
     ReadOnlySchemaRepository mockSchemaRepository = mock(ReadOnlySchemaRepository.class);
     Schema mockKeySchema = new Schema.Parser().parse("{\"type\": \"int\"}");
+    SchemaEntry mockValueSchemaEntry = mock(SchemaEntry.class);
+    when(mockValueSchemaEntry.getId()).thenReturn(1);
     when(mockSchemaRepository.getKeySchema(anyString())).thenReturn(new SchemaEntry(1, mockKeySchema));
+    when(mockSchemaRepository.getSupersetOrLatestValueSchema(anyString())).thenReturn(mockValueSchemaEntry);
     when(mockBackend.getSchemaRepository()).thenReturn(mockSchemaRepository);
 
     // Use reflection to set the private static daVinciBackend field

--- a/clients/venice-client/src/main/java/com/linkedin/venice/fastclient/DispatchingAvroGenericStoreClient.java
+++ b/clients/venice-client/src/main/java/com/linkedin/venice/fastclient/DispatchingAvroGenericStoreClient.java
@@ -663,7 +663,8 @@ public class DispatchingAvroGenericStoreClient<K, V> extends InternalAvroStoreCl
   }
 
   protected RecordDeserializer<V> getDataRecordDeserializer(int schemaId) throws VeniceClientException {
-    return storeDeserializerCache.getDeserializer(schemaId, metadata.getLatestValueSchemaId());
+    // Always use the writer schema as reader schema
+    return storeDeserializerCache.getDeserializer(schemaId, schemaId);
   }
 
   private RecordDeserializer<GenericRecord> getComputeResultRecordDeserializer(Schema resultSchema) {

--- a/clients/venice-thin-client/src/main/java/com/linkedin/venice/client/store/AvroGenericStoreClientImpl.java
+++ b/clients/venice-thin-client/src/main/java/com/linkedin/venice/client/store/AvroGenericStoreClientImpl.java
@@ -43,31 +43,14 @@ public class AvroGenericStoreClientImpl<K, V> extends AbstractAvroStoreClient<K,
   public RecordDeserializer<V> getDataRecordDeserializer(int writerSchemaId) throws VeniceClientException {
     SchemaReader schemaReader = getSchemaReader();
 
-    // Get latest value schema
-    Schema readerSchema = schemaReader.getLatestValueSchema();
-    if (readerSchema == null) {
-      throw new VeniceClientException("Failed to get latest value schema for store: " + getStoreName());
-    }
-
     Schema writerSchema = schemaReader.getValueSchema(writerSchemaId);
     if (writerSchema == null) {
       throw new VeniceClientException(
           "Failed to get value schema for store: " + getStoreName() + " and id: " + writerSchemaId);
     }
 
-    /**
-     * The reason to fetch the latest value schema before fetching the writer schema since internally
-     * it will fetch all the available value schemas when no value schema is present in {@link SchemaReader},
-     * which means the latest value schema could be pretty accurate even the following read requests are
-     * asking for older schema versions.
-     *
-     * The reason to fetch latest value schema again after fetching the writer schema is that the new fetched
-     * writer schema could be newer than the cached value schema versions.
-     * When the latest value schema is present in {@link SchemaReader}, the following invocation is very cheap.
-      */
-    readerSchema = schemaReader.getLatestValueSchema();
-
-    return getDeserializerFromFactory(writerSchema, readerSchema);
+    // Always use the writer schema as the reader schema.
+    return getDeserializerFromFactory(writerSchema, writerSchema);
   }
 
   protected RecordDeserializer<V> getDeserializerFromFactory(Schema writer, Schema reader) {

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/client/store/AvroGenericStoreClientImplTest.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/client/store/AvroGenericStoreClientImplTest.java
@@ -36,6 +36,7 @@ import java.util.TreeSet;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import org.apache.avro.AvroRuntimeException;
 import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericData;
 import org.apache.logging.log4j.LogManager;
@@ -489,13 +490,13 @@ public class AvroGenericStoreClientImplTest {
       LOGGER.info("Execute test for transport client: {}", entry.getKey());
 
       // Query value 1 while not having encountered any schema yet.
-      // The current logic will always pull all the value schemas if no schema is available yet.
+      // The current logic will always read with the writer schema which will not have field c.
       Object value = entry.getValue().get(key).get();
       Assert.assertTrue(value instanceof GenericData.Record);
       GenericData.Record recordValue = (GenericData.Record) value;
       Assert.assertEquals(recordValue.get("a"), 100L);
       Assert.assertEquals(recordValue.get("b").toString(), "test_b_value");
-      Assert.assertEquals(recordValue.get("c").toString(), "c_default_value");
+      Assert.assertThrows(AvroRuntimeException.class, () -> recordValue.get("c"));
 
       // Query value 2 while having already encountered schema v1 but not schema v2 yet.
       Object value2 = entry.getValue().get(key2).get();

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/PartialUpdateTest.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/PartialUpdateTest.java
@@ -45,6 +45,7 @@ import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertThrows;
 import static org.testng.Assert.assertTrue;
 
 import com.linkedin.avroutil1.compatibility.AvroCompatibilityHelper;
@@ -134,6 +135,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
+import org.apache.avro.AvroRuntimeException;
 import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericData;
 import org.apache.avro.generic.GenericDatumWriter;
@@ -2169,7 +2171,8 @@ public class PartialUpdateTest {
                 assertNotNull(value, "Key " + key + " should not be missing!");
                 assertEquals(value.get("firstName").toString(), "first_name_" + key);
                 assertEquals(value.get("lastName").toString(), "last_name_" + key);
-                assertEquals(value.get("age"), -1);
+                // We haven't written anything with the new schema yet
+                assertThrows(AvroRuntimeException.class, () -> value.get("age"));
               }
             } catch (Exception e) {
               throw new VeniceException(e);

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/fastclient/FastClientIndividualFeatureConfigurationTest.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/fastclient/FastClientIndividualFeatureConfigurationTest.java
@@ -4,6 +4,7 @@ import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertThrows;
 import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.fail;
 
@@ -41,6 +42,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
+import org.apache.avro.AvroRuntimeException;
 import org.apache.avro.generic.GenericData;
 import org.apache.avro.generic.GenericRecord;
 import org.apache.logging.log4j.LogManager;
@@ -300,7 +302,8 @@ public class FastClientIndividualFeatureConfigurationTest extends AbstractClient
     for (int i = 0; i < recordCnt; ++i) {
       String key = keyPrefix + i;
       assertEquals((int) resultMap.get(key).get(VALUE_FIELD_NAME), i);
-      assertNull(resultMap.get(key).get(SECOND_VALUE_FIELD_NAME));
+      // The newly added field should not be involved when reading data that was written with value schema v1
+      assertThrows(AvroRuntimeException.class, () -> resultMap.get(key).get(SECOND_VALUE_FIELD_NAME));
     }
     VersionCreationResponse creationResponse = veniceCluster.getNewVersion(storeName, false);
     assertFalse(creationResponse.isError());


### PR DESCRIPTION
## Problem Statement
Reader schema in Venice generic client today can be somewhat unpredictable from user’s perspective and create side effects such **as longer detection and mitigation time** when a bad schema is added.

## Solution
Client libraries always use the writer schema as reader schema:
This would give users full control over the reader schema behavior. Since a bad schema can only create impact after a data push or write. In addition, a data version rollback will take care of the mitigation without  restart. With colo by colo push this will also allow users to roll out new schemas one colo at a time.

For read compute and similar features such as the DVRT we will keep today's behavior for now. Which is to use the latest superset or value schema to deserialize and used as the input/base to perform transformations.

###  Code changes
- [ ] Added new code behind **a config**. If so list the config names and their default values in the PR description.
- [ ] Introduced new **log lines**. 
  - [ ] Confirmed if logs need to be **rate limited** to avoid excessive logging.

###  **Concurrency-Specific Checks**
Both reviewer and PR author to verify
- [ ] Code has **no race conditions** or **thread safety issues**.
- [ ] Proper **synchronization mechanisms** (e.g., `synchronized`, `RWLock`) are used where needed.
- [ ] No **blocking calls** inside critical sections that could lead to deadlocks or performance degradation.
- [ ] Verified **thread-safe collections** are used (e.g., `ConcurrentHashMap`, `CopyOnWriteArrayList`).
- [ ] Validated proper exception handling in multi-threaded code to avoid silent thread termination.


## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->

- [ ] New unit tests added.
- [ ] New integration tests added.
- [x] Modified or extended existing tests.
- [x] Verified backward compatibility (if applicable).

## Does this PR introduce any user-facing or breaking changes?
<!--  
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [ ] No. You can skip the rest of this section.
- [x] Yes. Clearly explain the behavior change and its impact.
   Reader schema for generic clients (TC, FC, DVC) will be changed from best effort latest value schema to always use writer schema 