### PR TITLE
[router][client] Unused router metrics cleanup

### DIFF
--- a/internal/venice-client-common/src/main/java/com/linkedin/venice/read/RequestType.java
+++ b/internal/venice-client-common/src/main/java/com/linkedin/venice/read/RequestType.java
@@ -31,4 +31,16 @@ public enum RequestType implements VeniceDimensionInterface {
   public String getDimensionValue() {
     return name().toLowerCase();
   }
+
+  public static boolean isSingleGet(RequestType requestType) {
+    return requestType == SINGLE_GET;
+  }
+
+  public static boolean isCompute(RequestType requestType) {
+    return requestType == COMPUTE;
+  }
+
+  public static boolean isStreaming(RequestType requestType) {
+    return requestType == MULTI_GET_STREAMING || requestType == COMPUTE_STREAMING;
+  }
 }

--- a/internal/venice-client-common/src/test/java/com/linkedin/venice/read/RequestTypeTest.java
+++ b/internal/venice-client-common/src/test/java/com/linkedin/venice/read/RequestTypeTest.java
@@ -1,0 +1,35 @@
+package com.linkedin.venice.read;
+
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+
+import org.testng.annotations.Test;
+
+
+public class RequestTypeTest {
+  @Test
+  public void testBooleanFuncInRequestType() {
+    // Test the boolean functions in RequestType enum.
+    for (RequestType requestType: RequestType.values()) {
+      if (requestType == RequestType.SINGLE_GET) {
+        assertTrue(RequestType.isSingleGet(requestType), "SINGLE_GET should be recognized as a single GET");
+      } else {
+        assertFalse(RequestType.isSingleGet(requestType), requestType + " should not be recognized as a single GET");
+      }
+
+      if (requestType == RequestType.COMPUTE) {
+        assertTrue(RequestType.isCompute(requestType), "COMPUTE should be recognized as a compute request");
+      } else {
+        assertFalse(RequestType.isCompute(requestType), requestType + " should not be recognized as a compute request");
+      }
+
+      if (requestType == RequestType.MULTI_GET_STREAMING || requestType == RequestType.COMPUTE_STREAMING) {
+        assertTrue(RequestType.isStreaming(requestType), requestType + " should be recognized as a streaming request");
+      } else {
+        assertFalse(
+            RequestType.isStreaming(requestType),
+            requestType + " should not be recognized as a streaming request");
+      }
+    }
+  }
+}


### PR DESCRIPTION
This is part of an effort to reduce metric usage across Venice services and this PR is targeting venice router metrics.

For `SINGLE_GET` request type, this PR removes the following metrics:
"--key_num"
"--fanout_request_count"
"--multiget_fallback"
"--unavailable_replica_streaming_request"

For `MULTIGET_STREAMING`:
"--multiget_streaming_read_quota_usage_kps"
"--multiget_streaming_request_usage"
"--multiget_streaming_multiget_fallback"

For `COMPUTE_STREAMING`:
"--compute_streaming_request_usage"


## Solution
CI and unit tests


###  Code changes
- [ ] Added new code behind **a config**. If so list the config names and their default values in the PR description.
- [ ] Introduced new **log lines**. 
  - [ ] Confirmed if logs need to be **rate limited** to avoid excessive logging.

###  **Concurrency-Specific Checks**
Both reviewer and PR author to verify
- [ ] Code has **no race conditions** or **thread safety issues**.
- [ ] Proper **synchronization mechanisms** (e.g., `synchronized`, `RWLock`) are used where needed.
- [ ] No **blocking calls** inside critical sections that could lead to deadlocks or performance degradation.
- [ ] Verified **thread-safe collections** are used (e.g., `ConcurrentHashMap`, `CopyOnWriteArrayList`).
- [ ] Validated proper exception handling in multi-threaded code to avoid silent thread termination.


## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->

- [x] New unit tests added.
- [ ] New integration tests added.
- [ ] Modified or extended existing tests.
- [ ] Verified backward compatibility (if applicable).

## Does this PR introduce any user-facing or breaking changes?
<!--  
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Clearly explain the behavior change and its impact.