### PR TITLE
[server][da-vinci] Bumped up RocksDB to 9.11.2 to pick up the recent blobDB optimization

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -132,7 +132,7 @@ ext.libraries = [
     pulsarIoCommon: "${pulsarGroup}:pulsar-io-common:${pulsarVersion}",
     r2: "com.linkedin.pegasus:r2:${pegasusVersion}",
     restliCommon: "com.linkedin.pegasus:restli-common:${pegasusVersion}",
-    rocksdbjni: 'org.rocksdb:rocksdbjni:8.8.1',
+    rocksdbjni: 'org.rocksdb:rocksdbjni:9.11.2',
     samzaApi: 'org.apache.samza:samza-api:1.5.1',
     beamSdk: 'org.apache.beam:beam-sdks-java-core:2.60.0',
     beamExtensionAvro: 'org.apache.beam:beam-sdks-java-extensions-avro:2.60.0',

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/store/rocksdb/RocksDBSstFileWriter.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/store/rocksdb/RocksDBSstFileWriter.java
@@ -454,7 +454,7 @@ public class RocksDBSstFileWriter {
       for (LiveFileMetaData file: oldIngestedSSTFiles) {
         if (Arrays.equals(file.columnFamilyName(), columnFamilyHandle.getName())) {
           count++;
-          rocksDB.deleteFile(file.fileName());
+          rocksDB.deprecated_deleteFile(file.fileName());
         }
       }
       LOGGER.info(


### PR DESCRIPTION


<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat], [protocol]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## Problem Statement
<!--
Describe
- What problem are you trying to solve
- What issues or limitations exist in the current code
- Why this change is necessary 
-->
We are seeing the blobDB garbage file size is increasing and we need to reduce the space amplification to some reasonable level.

## Solution
<!--
Describe
- What changes you are making and why. 
- How these changes solve the problem.
- Any performance considerations or trade-offs. 
- Describe what testings you have done, for example, performance testing etc.
-->

RocksDB-9.7.0 introduced some optimization regarding the blob GC trigger and I hope this can help alleviate the space amplification concerns.
```
Changed the semantics of the BlobDB configuration option blob_garbage_collection_force_threshold to define
a threshold for the overall garbage ratio of all blob files currently eligible for garbage collection (accordin
g to blob_garbage_collection_age_cutoff). This can provide better control over space amplification at the cos
t of slightly higher write amplification.
```

###  Code changes
- [ ] Added new code behind **a config**. If so list the config names and their default values in the PR description.
- [ ] Introduced new **log lines**. 
  - [ ] Confirmed if logs need to be **rate limited** to avoid excessive logging.

###  **Concurrency-Specific Checks**
Both reviewer and PR author to verify
- [ ] Code has **no race conditions** or **thread safety issues**.
- [ ] Proper **synchronization mechanisms** (e.g., `synchronized`, `RWLock`) are used where needed.
- [ ] No **blocking calls** inside critical sections that could lead to deadlocks or performance degradation.
- [ ] Verified **thread-safe collections** are used (e.g., `ConcurrentHashMap`, `CopyOnWriteArrayList`).
- [ ] Validated proper exception handling in multi-threaded code to avoid silent thread termination.


## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->

- [ ] New unit tests added.
- [ ] New integration tests added.
- [ ] Modified or extended existing tests.
- [ ] Verified backward compatibility (if applicable).

## Does this PR introduce any user-facing or breaking changes?
<!--  
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Clearly explain the behavior change and its impact.