### PR TITLE
[vpj] Adjust max records per mapper based on Kafka end-offsets

### DIFF
--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/input/kafka/KafkaInputFormat.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/input/kafka/KafkaInputFormat.java
@@ -1,6 +1,7 @@
 package com.linkedin.venice.hadoop.input.kafka;
 
 import static com.linkedin.venice.vpj.VenicePushJobConstants.KAFKA_INPUT_BROKER_URL;
+import static com.linkedin.venice.vpj.VenicePushJobConstants.KAFKA_INPUT_MAX_MAPPER_COUNT;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.KAFKA_INPUT_MAX_RECORDS_PER_MAPPER;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.KAFKA_INPUT_TOPIC;
 
@@ -101,9 +102,10 @@ public class KafkaInputFormat implements InputFormat<KafkaInputMapperKey, KafkaI
   public InputSplit[] getSplitsByRecordsPerSplit(JobConf job, long maxRecordsPerSplit) {
     Map<PubSubTopicPartition, Long> latestOffsets = getLatestOffsets(job);
     long totalEndOffset = latestOffsets.values().stream().mapToLong(Long::longValue).sum();
+    long maxMapperCount = job.getLong(KAFKA_INPUT_MAX_MAPPER_COUNT, DEFAULT_MAX_KIF_MAPPER_COUNT);
     long totalSplitEstimate = totalEndOffset / maxRecordsPerSplit;
-    if (totalSplitEstimate > DEFAULT_MAX_KIF_MAPPER_COUNT) {
-      maxRecordsPerSplit = totalSplitEstimate / DEFAULT_MAX_KIF_MAPPER_COUNT;
+    if (totalSplitEstimate > maxMapperCount) {
+      maxRecordsPerSplit = totalEndOffset / maxMapperCount;
     }
 
     List<InputSplit> splits = new LinkedList<>();

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/vpj/VenicePushJobConstants.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/vpj/VenicePushJobConstants.java
@@ -107,7 +107,7 @@ public final class VenicePushJobConstants {
   public static final String KAFKA_INPUT_FABRIC = "kafka.input.fabric";
   public static final String KAFKA_INPUT_BROKER_URL = "kafka.input.broker.url";
   // Optional
-  public static final String KAFKA_INPUT_MAX_RECORDS_PER_MAPPER = "kafka.input.max.records.per.mapper";
+  public static final String KAFKA_MAPPER_MULTIPLICATION_FACTOR = "kafka.mapper.multiplication.factor";
   public static final String KAFKA_INPUT_MAX_MAPPER_COUNT = "kafka.input.max.mapper.count";
 
   public static final String KAFKA_INPUT_COMBINER_ENABLED = "kafka.input.combiner.enabled";

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/vpj/VenicePushJobConstants.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/vpj/VenicePushJobConstants.java
@@ -108,6 +108,8 @@ public final class VenicePushJobConstants {
   public static final String KAFKA_INPUT_BROKER_URL = "kafka.input.broker.url";
   // Optional
   public static final String KAFKA_INPUT_MAX_RECORDS_PER_MAPPER = "kafka.input.max.records.per.mapper";
+  public static final String KAFKA_INPUT_MAX_MAPPER_COUNT = "kafka.input.max.mapper.count";
+
   public static final String KAFKA_INPUT_COMBINER_ENABLED = "kafka.input.combiner.enabled";
   // Whether to build a new dict in the repushed version or not while the original version has already enabled dict
   // compression.

--- a/clients/venice-push-job/src/test/java/com/linkedin/venice/hadoop/VenicePushJobTest.java
+++ b/clients/venice-push-job/src/test/java/com/linkedin/venice/hadoop/VenicePushJobTest.java
@@ -15,7 +15,6 @@ import static com.linkedin.venice.vpj.VenicePushJobConstants.DEFER_VERSION_SWAP;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.INCREMENTAL_PUSH;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.INPUT_PATH_PROP;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.KAFKA_INPUT_BROKER_URL;
-import static com.linkedin.venice.vpj.VenicePushJobConstants.KAFKA_INPUT_MAX_RECORDS_PER_MAPPER;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.KAFKA_INPUT_TOPIC;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.KEY_FIELD_PROP;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.LEGACY_AVRO_KEY_FIELD_PROP;
@@ -400,7 +399,6 @@ public class VenicePushJobTest {
     repushProps.setProperty(SOURCE_KAFKA, "true");
     repushProps.setProperty(KAFKA_INPUT_TOPIC, Version.composeKafkaTopic(TEST_STORE, REPUSH_VERSION));
     repushProps.setProperty(KAFKA_INPUT_BROKER_URL, "localhost");
-    repushProps.setProperty(KAFKA_INPUT_MAX_RECORDS_PER_MAPPER, "5");
     return repushProps;
   }
 

--- a/clients/venice-push-job/src/test/java/com/linkedin/venice/hadoop/input/kafka/TestKafkaInputDictTrainer.java
+++ b/clients/venice-push-job/src/test/java/com/linkedin/venice/hadoop/input/kafka/TestKafkaInputDictTrainer.java
@@ -324,11 +324,11 @@ public class TestKafkaInputDictTrainer {
     PubSubTopicPartition topicPartition1 =
         new PubSubTopicPartitionImpl(PUB_SUB_TOPIC_REPOSITORY.getTopic("test_topic"), 1);
     Map<PubSubTopicPartition, Long> map = new HashMap<>();
-    map.put(topicPartition, 10000L);
-    map.put(topicPartition1, 10000L);
+    map.put(topicPartition, 100L);
+    map.put(topicPartition1, 100L);
     doReturn(map).when(mockFormat).getLatestOffsets(job);
-    doCallRealMethod().when(mockFormat).getSplitsByRecordsPerSplit(job, 1000);
-    InputSplit[] splits = mockFormat.getSplitsByRecordsPerSplit(job, 1000);
+    doCallRealMethod().when(mockFormat).getSplitsByRecordsPerSplit(job, 10);
+    InputSplit[] splits = mockFormat.getSplitsByRecordsPerSplit(job, 10);
     Assert.assertEquals(splits.length, 20);
   }
 }

--- a/clients/venice-push-job/src/test/java/com/linkedin/venice/hadoop/input/kafka/TestKafkaInputDictTrainer.java
+++ b/clients/venice-push-job/src/test/java/com/linkedin/venice/hadoop/input/kafka/TestKafkaInputDictTrainer.java
@@ -1,6 +1,7 @@
 package com.linkedin.venice.hadoop.input.kafka;
 
 import static com.linkedin.venice.vpj.VenicePushJobConstants.KAFKA_INPUT_MAX_MAPPER_COUNT;
+import static com.linkedin.venice.vpj.VenicePushJobConstants.KAFKA_MAPPER_MULTIPLICATION_FACTOR;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.eq;
@@ -315,10 +316,11 @@ public class TestKafkaInputDictTrainer {
   }
 
   @Test
-  public void testgetSplitsByRecordsPerSplit() {
+  public void testgetSplitsByRecordsPerSplit() throws IOException {
     KafkaInputFormat mockFormat = mock(KafkaInputFormat.class);
     JobConf job = mock(JobConf.class);
     doReturn(100L).when(job).getLong(KAFKA_INPUT_MAX_MAPPER_COUNT, 10000L);
+    doReturn(3L).when(job).getLong(KAFKA_MAPPER_MULTIPLICATION_FACTOR, 3);
     PubSubTopicPartition topicPartition =
         new PubSubTopicPartitionImpl(PUB_SUB_TOPIC_REPOSITORY.getTopic("test_topic"), 0);
     PubSubTopicPartition topicPartition1 =
@@ -330,5 +332,9 @@ public class TestKafkaInputDictTrainer {
     doCallRealMethod().when(mockFormat).getSplitsByRecordsPerSplit(job, 10);
     InputSplit[] splits = mockFormat.getSplitsByRecordsPerSplit(job, 10);
     Assert.assertEquals(splits.length, 20);
+    doCallRealMethod().when(mockFormat).getSplits(job, 10);
+    doReturn(splits).when(mockFormat).getSplitsByRecordsPerSplit(job, 3);
+    InputSplit[] splits1 = mockFormat.getSplits(job, 10);
+    Assert.assertEquals(splits1.length, 20);
   }
 }

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/consumer/ConsumerIntegrationTestWithSchemaReader.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/consumer/ConsumerIntegrationTestWithSchemaReader.java
@@ -2,7 +2,6 @@ package com.linkedin.venice.consumer;
 
 import static com.linkedin.venice.utils.IntegrationTestPushUtils.defaultVPJProps;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.KAFKA_INPUT_FABRIC;
-import static com.linkedin.venice.vpj.VenicePushJobConstants.KAFKA_INPUT_MAX_RECORDS_PER_MAPPER;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.SOURCE_KAFKA;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.SYSTEM_SCHEMA_READER_ENABLED;
 
@@ -68,7 +67,7 @@ public class ConsumerIntegrationTestWithSchemaReader extends ConsumerIntegration
     Properties vpjProps = defaultVPJProps(cluster, "Ignored", store);
     vpjProps.setProperty(SOURCE_KAFKA, "true");
     vpjProps.setProperty(KAFKA_INPUT_FABRIC, "dc-0");
-    vpjProps.setProperty(KAFKA_INPUT_MAX_RECORDS_PER_MAPPER, "5");
+    // vpjProps.setProperty(KAFKA_INPUT_MAX_RECORDS_PER_MAPPER, "5");
     vpjProps.setProperty(SYSTEM_SCHEMA_READER_ENABLED, "true");
     IntegrationTestPushUtils.runVPJ(vpjProps);
 

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/consumer/TestBootstrappingChangelogConsumer.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/consumer/TestBootstrappingChangelogConsumer.java
@@ -38,7 +38,6 @@ import static com.linkedin.venice.utils.TestWriteUtils.writeSimpleAvroFile;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.DEFAULT_KEY_FIELD_PROP;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.DEFAULT_VALUE_FIELD_PROP;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.KAFKA_INPUT_BROKER_URL;
-import static com.linkedin.venice.vpj.VenicePushJobConstants.KAFKA_INPUT_MAX_RECORDS_PER_MAPPER;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.SOURCE_KAFKA;
 import static org.testng.AssertJUnit.assertEquals;
 import static org.testng.AssertJUnit.assertFalse;
@@ -367,7 +366,7 @@ public class TestBootstrappingChangelogConsumer {
       props = defaultVPJProps(clusterWrapper, inputDirPath, storeName);
       props.setProperty(SOURCE_KAFKA, "true");
       props.setProperty(KAFKA_INPUT_BROKER_URL, clusterWrapper.getPubSubBrokerWrapper().getAddress());
-      props.setProperty(KAFKA_INPUT_MAX_RECORDS_PER_MAPPER, "5");
+      // props.setProperty(KAFKA_INPUT_MAX_RECORDS_PER_MAPPER, "5");
       IntegrationTestPushUtils.runVPJ(props);
 
       clusterWrapper.useControllerClient(controllerClient -> {

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/consumer/TestChangelogConsumer.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/consumer/TestChangelogConsumer.java
@@ -30,7 +30,6 @@ import static com.linkedin.venice.utils.TestWriteUtils.getTempDataDirectory;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.DEFAULT_KEY_FIELD_PROP;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.DEFAULT_VALUE_FIELD_PROP;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.KAFKA_INPUT_BROKER_URL;
-import static com.linkedin.venice.vpj.VenicePushJobConstants.KAFKA_INPUT_MAX_RECORDS_PER_MAPPER;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.REPUSH_TTL_ENABLE;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.REWIND_TIME_IN_SECONDS_OVERRIDE;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.SOURCE_KAFKA;
@@ -495,7 +494,7 @@ public class TestChangelogConsumer {
     // run repush. Repush will reapply all existing events to the new store and trim all events from the RT
     props.setProperty(SOURCE_KAFKA, "true");
     props.setProperty(KAFKA_INPUT_BROKER_URL, clusterWrapper.getPubSubBrokerWrapper().getAddress());
-    props.setProperty(KAFKA_INPUT_MAX_RECORDS_PER_MAPPER, "5");
+    // props.setProperty(KAFKA_INPUT_MAX_RECORDS_PER_MAPPER, "5");
     // intentionally stop re-consuming from RT so stale records don't affect the testing results
     props.put(REWIND_TIME_IN_SECONDS_OVERRIDE, 0);
     IntegrationTestPushUtils.runVPJ(props);

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/PartialUpdateTest.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/PartialUpdateTest.java
@@ -33,7 +33,6 @@ import static com.linkedin.venice.vpj.VenicePushJobConstants.DEFAULT_VALUE_FIELD
 import static com.linkedin.venice.vpj.VenicePushJobConstants.ENABLE_WRITE_COMPUTE;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.INCREMENTAL_PUSH;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.KAFKA_INPUT_BROKER_URL;
-import static com.linkedin.venice.vpj.VenicePushJobConstants.KAFKA_INPUT_MAX_RECORDS_PER_MAPPER;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.REPUSH_TTL_ENABLE;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.REPUSH_TTL_START_TIMESTAMP;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.REWIND_TIME_IN_SECONDS_OVERRIDE;
@@ -271,7 +270,7 @@ public class PartialUpdateTest {
           IntegrationTestPushUtils.defaultVPJProps(multiRegionMultiClusterWrapper, "dummyInputPath", storeName);
       props.setProperty(SOURCE_KAFKA, "true");
       props.setProperty(KAFKA_INPUT_BROKER_URL, veniceCluster.getPubSubBrokerWrapper().getAddress());
-      props.setProperty(KAFKA_INPUT_MAX_RECORDS_PER_MAPPER, "5");
+      // props.setProperty(KAFKA_INPUT_MAX_RECORDS_PER_MAPPER, "5");
       // intentionally stop re-consuming from RT so stale records don't affect the testing results
       // props.put(REWIND_TIME_IN_SECONDS_OVERRIDE, 0);
       IntegrationTestPushUtils.runVPJ(props);
@@ -982,7 +981,7 @@ public class PartialUpdateTest {
           IntegrationTestPushUtils.defaultVPJProps(multiRegionMultiClusterWrapper, "dummyInputPath", storeName);
       props.setProperty(SOURCE_KAFKA, "true");
       props.setProperty(KAFKA_INPUT_BROKER_URL, veniceCluster.getPubSubBrokerWrapper().getAddress());
-      props.setProperty(KAFKA_INPUT_MAX_RECORDS_PER_MAPPER, "5");
+      // props.setProperty(KAFKA_INPUT_MAX_RECORDS_PER_MAPPER, "5");
       // intentionally stop re-consuming from RT so stale records don't affect the testing results
       props.put(REWIND_TIME_IN_SECONDS_OVERRIDE, 0);
       IntegrationTestPushUtils.runVPJ(props);
@@ -1303,7 +1302,7 @@ public class PartialUpdateTest {
         IntegrationTestPushUtils.defaultVPJProps(multiRegionMultiClusterWrapper, "dummyInputPath", storeName);
     props.setProperty(SOURCE_KAFKA, "true");
     props.setProperty(KAFKA_INPUT_BROKER_URL, veniceCluster.getPubSubBrokerWrapper().getAddress());
-    props.setProperty(KAFKA_INPUT_MAX_RECORDS_PER_MAPPER, "5");
+    // props.setProperty(KAFKA_INPUT_MAX_RECORDS_PER_MAPPER, "5");
     props.setProperty(REPUSH_TTL_ENABLE, "true");
     // Override the TTL repush start TS to work with logical TS setup.
     props.setProperty(REPUSH_TTL_START_TIMESTAMP, String.valueOf(FRESH_TS));
@@ -1597,7 +1596,7 @@ public class PartialUpdateTest {
         IntegrationTestPushUtils.defaultVPJProps(multiRegionMultiClusterWrapper, "dummyInputPath", storeName);
     props.setProperty(SOURCE_KAFKA, "true");
     props.setProperty(KAFKA_INPUT_BROKER_URL, veniceCluster.getPubSubBrokerWrapper().getAddress());
-    props.setProperty(KAFKA_INPUT_MAX_RECORDS_PER_MAPPER, "5");
+    // props.setProperty(KAFKA_INPUT_MAX_RECORDS_PER_MAPPER, "5");
     IntegrationTestPushUtils.runVPJ(props);
     PubSubTopic storeVersionTopicV3 = PUB_SUB_TOPIC_REPOSITORY.getTopic(Version.composeKafkaTopic(storeName, 3));
     try (ControllerClient parentControllerClient = new ControllerClient(CLUSTER_NAME, parentControllerUrl)) {
@@ -1866,7 +1865,7 @@ public class PartialUpdateTest {
         IntegrationTestPushUtils.defaultVPJProps(multiRegionMultiClusterWrapper, "dummyInputPath", storeName);
     props.setProperty(SOURCE_KAFKA, "true");
     props.setProperty(KAFKA_INPUT_BROKER_URL, veniceCluster.getPubSubBrokerWrapper().getAddress());
-    props.setProperty(KAFKA_INPUT_MAX_RECORDS_PER_MAPPER, "5");
+    // props.setProperty(KAFKA_INPUT_MAX_RECORDS_PER_MAPPER, "5");
     IntegrationTestPushUtils.runVPJ(props);
     try (ControllerClient parentControllerClient = new ControllerClient(CLUSTER_NAME, parentControllerUrl)) {
       TestUtils.waitForNonDeterministicPushCompletion(

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestActiveActiveIngestion.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestActiveActiveIngestion.java
@@ -18,7 +18,6 @@ import static com.linkedin.venice.vpj.VenicePushJobConstants.DATA_WRITER_COMPUTE
 import static com.linkedin.venice.vpj.VenicePushJobConstants.DEFAULT_KEY_FIELD_PROP;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.DEFAULT_VALUE_FIELD_PROP;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.KAFKA_INPUT_BROKER_URL;
-import static com.linkedin.venice.vpj.VenicePushJobConstants.KAFKA_INPUT_MAX_RECORDS_PER_MAPPER;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.REPUSH_TTL_ENABLE;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.REWIND_TIME_IN_SECONDS_OVERRIDE;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.SOURCE_KAFKA;
@@ -358,7 +357,7 @@ public class TestActiveActiveIngestion {
     // run repush with targeted region push
     props.setProperty(SOURCE_KAFKA, "true");
     props.setProperty(KAFKA_INPUT_BROKER_URL, clusterWrapper.getPubSubBrokerWrapper().getAddress());
-    props.setProperty(KAFKA_INPUT_MAX_RECORDS_PER_MAPPER, "5");
+    // props.setProperty(KAFKA_INPUT_MAX_RECORDS_PER_MAPPER, "5");
     props.setProperty(TARGETED_REGION_PUSH_ENABLED, "true");
     // intentionally stop re-consuming from RT so stale records don't affect the testing results
     props.setProperty(REWIND_TIME_IN_SECONDS_OVERRIDE, "0");

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestBatch.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestBatch.java
@@ -42,7 +42,6 @@ import static com.linkedin.venice.vpj.VenicePushJobConstants.DEFAULT_VALUE_FIELD
 import static com.linkedin.venice.vpj.VenicePushJobConstants.INCREMENTAL_PUSH;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.KAFKA_INPUT_BROKER_URL;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.KAFKA_INPUT_COMBINER_ENABLED;
-import static com.linkedin.venice.vpj.VenicePushJobConstants.KAFKA_INPUT_MAX_RECORDS_PER_MAPPER;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.KAFKA_INPUT_TOPIC;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.SEND_CONTROL_MESSAGES_DIRECTLY;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.SOURCE_ETL;
@@ -651,7 +650,7 @@ public abstract class TestBatch {
           properties.setProperty(SOURCE_KAFKA, "true");
           properties.setProperty(VENICE_STORE_NAME_PROP, storeName);
           properties.setProperty(KAFKA_INPUT_BROKER_URL, veniceCluster.getPubSubBrokerWrapper().getAddress());
-          properties.setProperty(KAFKA_INPUT_MAX_RECORDS_PER_MAPPER, "5");
+          // properties.setProperty(KAFKA_INPUT_MAX_RECORDS_PER_MAPPER, "5");
           properties.setProperty(SEND_CONTROL_MESSAGES_DIRECTLY, String.valueOf(sendDirectControlMessage));
           properties.setProperty(COMPRESSION_METRIC_COLLECTION_ENABLED, String.valueOf(true));
         },
@@ -705,7 +704,7 @@ public abstract class TestBatch {
            * This is used to make sure the first mapper doesn't contain any real messages, but just control messages.
            * So that {@link AbstractVeniceMapper#maybeSprayAllPartitions} won't be invoked.
            */
-          properties.setProperty(KAFKA_INPUT_MAX_RECORDS_PER_MAPPER, "2");
+          // properties.setProperty(KAFKA_INPUT_MAX_RECORDS_PER_MAPPER, "2");
         },
         validator,
         storeName,
@@ -842,7 +841,7 @@ public abstract class TestBatch {
           properties -> {
             properties.setProperty(SOURCE_KAFKA, "true");
             properties.setProperty(KAFKA_INPUT_BROKER_URL, veniceCluster.getPubSubBrokerWrapper().getAddress());
-            properties.setProperty(KAFKA_INPUT_MAX_RECORDS_PER_MAPPER, "5");
+            // properties.setProperty(KAFKA_INPUT_MAX_RECORDS_PER_MAPPER, "5");
             properties.setProperty(KAFKA_INPUT_COMBINER_ENABLED, combiner);
           },
           dataValidator,
@@ -1052,7 +1051,7 @@ public abstract class TestBatch {
       properties.setProperty(SOURCE_KAFKA, "true");
       properties.setProperty(VENICE_STORE_NAME_PROP, storeName);
       properties.setProperty(KAFKA_INPUT_BROKER_URL, veniceCluster.getPubSubBrokerWrapper().getAddress());
-      properties.setProperty(KAFKA_INPUT_MAX_RECORDS_PER_MAPPER, "5");
+      // properties.setProperty(KAFKA_INPUT_MAX_RECORDS_PER_MAPPER, "5");
       properties.setProperty(SEND_CONTROL_MESSAGES_DIRECTLY, sendDirectControlMessage.toString());
     }, storeName);
   }
@@ -1439,7 +1438,7 @@ public abstract class TestBatch {
           properties.setProperty(SOURCE_KAFKA, "true");
           properties.setProperty(KAFKA_INPUT_TOPIC, Version.composeKafkaTopic(storeName, 1));
           properties.setProperty(KAFKA_INPUT_BROKER_URL, veniceCluster.getPubSubBrokerWrapper().getAddress());
-          properties.setProperty(KAFKA_INPUT_MAX_RECORDS_PER_MAPPER, "5");
+          // properties.setProperty(KAFKA_INPUT_MAX_RECORDS_PER_MAPPER, "5");
         },
         emptyValidator,
         storeName,

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestVsonStoreBatch.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestVsonStoreBatch.java
@@ -11,7 +11,6 @@ import static com.linkedin.venice.utils.TestWriteUtils.writeSimpleVsonFileWithUs
 import static com.linkedin.venice.utils.TestWriteUtils.writeVsonByteAndShort;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.DATA_WRITER_COMPUTE_JOB_CLASS;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.KAFKA_INPUT_BROKER_URL;
-import static com.linkedin.venice.vpj.VenicePushJobConstants.KAFKA_INPUT_MAX_RECORDS_PER_MAPPER;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.KAFKA_INPUT_TOPIC;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.KEY_FIELD_PROP;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.SOURCE_KAFKA;
@@ -272,7 +271,7 @@ public class TestVsonStoreBatch {
           properties.setProperty(SOURCE_KAFKA, "true");
           properties.setProperty(KAFKA_INPUT_TOPIC, Version.composeKafkaTopic(storeName, 1));
           properties.setProperty(KAFKA_INPUT_BROKER_URL, veniceCluster.getPubSubBrokerWrapper().getAddress());
-          properties.setProperty(KAFKA_INPUT_MAX_RECORDS_PER_MAPPER, "5");
+          // properties.setProperty(KAFKA_INPUT_MAX_RECORDS_PER_MAPPER, "5");
         },
         validator,
         new UpdateStoreQueryParams(),

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/hadoop/TestVenicePushJob.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/hadoop/TestVenicePushJob.java
@@ -16,7 +16,6 @@ import static com.linkedin.venice.vpj.VenicePushJobConstants.ENABLE_WRITE_COMPUT
 import static com.linkedin.venice.vpj.VenicePushJobConstants.INCREMENTAL_PUSH;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.KAFKA_INPUT_BROKER_URL;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.KAFKA_INPUT_FABRIC;
-import static com.linkedin.venice.vpj.VenicePushJobConstants.KAFKA_INPUT_MAX_RECORDS_PER_MAPPER;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.KAFKA_INPUT_TOPIC;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.KEY_FIELD_PROP;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.MAP_REDUCE_PARTITIONER_CLASS_CONFIG;
@@ -596,7 +595,7 @@ public class TestVenicePushJob {
     props.setProperty(SOURCE_KAFKA, "true");
     props.setProperty(KAFKA_INPUT_TOPIC, Version.composeKafkaTopic(storeName, 1));
     props.setProperty(KAFKA_INPUT_BROKER_URL, veniceCluster.getPubSubBrokerWrapper().getAddress());
-    props.setProperty(KAFKA_INPUT_MAX_RECORDS_PER_MAPPER, "5");
+    // props.setProperty(KAFKA_INPUT_MAX_RECORDS_PER_MAPPER, "5");
     // This repush should succeed
     IntegrationTestPushUtils.runVPJ(props);
     TestUtils.waitForNonDeterministicAssertion(
@@ -646,7 +645,7 @@ public class TestVenicePushJob {
     // setup repush job settings, without any broker url or topic name
     props.setProperty(SOURCE_KAFKA, "true");
     props.setProperty(KAFKA_INPUT_FABRIC, "dc-0");
-    props.setProperty(KAFKA_INPUT_MAX_RECORDS_PER_MAPPER, "5");
+    // props.setProperty(KAFKA_INPUT_MAX_RECORDS_PER_MAPPER, "5");
     // convert to RT policy
     TestUtils.assertCommand(
         veniceCluster.updateStore(

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/hadoop/input/kafka/TestKafkaInputFormat.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/hadoop/input/kafka/TestKafkaInputFormat.java
@@ -2,7 +2,7 @@ package com.linkedin.venice.hadoop.input.kafka;
 
 import static com.linkedin.venice.pubsub.PubSubConstants.PUBSUB_OPERATION_TIMEOUT_MS_DEFAULT_VALUE;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.KAFKA_INPUT_BROKER_URL;
-import static com.linkedin.venice.vpj.VenicePushJobConstants.KAFKA_INPUT_MAX_RECORDS_PER_MAPPER;
+import static com.linkedin.venice.vpj.VenicePushJobConstants.KAFKA_INPUT_MAX_MAPPER_COUNT;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.KAFKA_INPUT_TOPIC;
 
 import com.linkedin.venice.integration.utils.PubSubBrokerWrapper;
@@ -86,9 +86,9 @@ public class TestKafkaInputFormat {
       JobConf conf,
       long maxRecordsPerMapper,
       List<long[]> expectedSplit) throws IOException {
-    if (maxRecordsPerMapper > 0) {
-      conf.set(KAFKA_INPUT_MAX_RECORDS_PER_MAPPER, Long.toString(maxRecordsPerMapper));
-    }
+    // if (maxRecordsPerMapper > 0) {
+    // conf.set(KAFKA_INPUT_MAX_RECORDS_PER_MAPPER, Long.toString(maxRecordsPerMapper));
+    // }
     InputSplit[] splits = kafkaInputFormat.getSplits(conf, 100);
     Assert.assertEquals(splits.length, expectedSplit.size());
     Arrays.stream(splits).forEach(split -> Assert.assertTrue(split instanceof KafkaInputSplit));
@@ -128,6 +128,7 @@ public class TestKafkaInputFormat {
     JobConf conf = new JobConf();
     conf.set(KAFKA_INPUT_BROKER_URL, pubSubBrokerWrapper.getAddress());
     conf.set(KAFKA_INPUT_TOPIC, topic.getName());
+    conf.set(KAFKA_INPUT_MAX_MAPPER_COUNT, "6");
     Map<PubSubTopicPartition, Long> latestOffsets = kafkaInputFormat.getLatestOffsets(conf);
     PubSubTopicPartition partition0 = new PubSubTopicPartitionImpl(topic, 0);
     PubSubTopicPartition partition1 = new PubSubTopicPartitionImpl(topic, 1);


### PR DESCRIPTION
<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat], [protocol]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## Problem Statement
<!--
Describe
- What problem are you trying to solve
- What issues or limitations exist in the current code
- Why this change is necessary 
-->

When a Kafka topic has a very high end-offset, KIF (Kafka InputFormat) can generate an excessive number of input splits. This not only slows down the MapReduce job but can also exceed the system’s metadata split size limit, potentially causing failures.


## Solution
<!--
Describe
- What changes you are making and why. 
- How these changes solve the problem.
- Any performance considerations or trade-offs. 
- Describe what testings you have done, for example, performance testing etc.
-->

This PR addresses the issue by dynamically adjusting the maxRecordsPerSplit based on the total end-offset of the topic. This helps control the number of input splits, ensuring more efficient job execution and avoiding metadata size overflows.

###  Code changes
- [ ] Added new code behind **a config**. If so list the config names and their default values in the PR description.
- [ ] Introduced new **log lines**. 
  - [ ] Confirmed if logs need to be **rate limited** to avoid excessive logging.

###  **Concurrency-Specific Checks**
Both reviewer and PR author to verify
- [ ] Code has **no race conditions** or **thread safety issues**.
- [ ] Proper **synchronization mechanisms** (e.g., `synchronized`, `RWLock`) are used where needed.
- [ ] No **blocking calls** inside critical sections that could lead to deadlocks or performance degradation.
- [ ] Verified **thread-safe collections** are used (e.g., `ConcurrentHashMap`, `CopyOnWriteArrayList`).
- [ ] Validated proper exception handling in multi-threaded code to avoid silent thread termination.


## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->

- [ ] New unit tests added.
- [ ] New integration tests added.
- [ ] Modified or extended existing tests.
- [ ] Verified backward compatibility (if applicable).

## Does this PR introduce any user-facing or breaking changes?
<!--  
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [ ] No. You can skip the rest of this section.
- [ ] Yes. Clearly explain the behavior change and its impact.