### PR TITLE
[server][dvc] Check for previous dvc pushstatus retry count

### DIFF
--- a/services/venice-controller/src/main/java/com/linkedin/venice/pushmonitor/PushStatusCollector.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/pushmonitor/PushStatusCollector.java
@@ -173,19 +173,15 @@ public class PushStatusCollector {
               pushStatus.getServerStatus(),
               daVinciStatus);
           // poll DaVinci status more
-          int noDaVinciStatusRetryAttempts =
-              topicToNoDaVinciStatusRetryCountMap.compute(pushStatus.topicName, (k, v) -> {
-                if (v == null) {
-                  return 1;
-                }
-                return v + 1;
-              });
-          if (noDaVinciStatusRetryAttempts <= daVinciPushStatusNoReportRetryMaxAttempts) {
-            daVinciStatus = new ExecutionStatusWithDetails(ExecutionStatus.NOT_STARTED, daVinciStatus.getDetails());
-            pushStatus.setDaVinciStatus(daVinciStatus);
-          }
-          // Update dvc heartbeat to false if there is no dvc status
-        } else if (store.getIsDavinciHeartbeatReported()) {
+          topicToNoDaVinciStatusRetryCountMap.compute(pushStatus.topicName, (k, v) -> {
+            if (v == null) {
+              return 1;
+            }
+            return v + 1;
+          });
+          daVinciStatus = new ExecutionStatusWithDetails(ExecutionStatus.NOT_STARTED, daVinciStatus.getDetails());
+          pushStatus.setDaVinciStatus(daVinciStatus);
+        } else if (store.getIsDavinciHeartbeatReported()) { // Update dvc heartbeat to false if there is no dvc status
           store.setIsDavinciHeartbeatReported(false);
           storeRepository.updateStore(store);
         }

--- a/services/venice-controller/src/main/java/com/linkedin/venice/pushmonitor/PushStatusCollector.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/pushmonitor/PushStatusCollector.java
@@ -183,13 +183,11 @@ public class PushStatusCollector {
           if (noDaVinciStatusRetryAttempts <= daVinciPushStatusNoReportRetryMaxAttempts) {
             daVinciStatus = new ExecutionStatusWithDetails(ExecutionStatus.NOT_STARTED, daVinciStatus.getDetails());
             pushStatus.setDaVinciStatus(daVinciStatus);
-          } else {
-            // Update dvc heartbeat to false if there is no dvc status
-            if (store.getIsDavinciHeartbeatReported()) {
-              store.setIsDavinciHeartbeatReported(false);
-              storeRepository.updateStore(store);
-            }
           }
+          // Update dvc heartbeat to false if there is no dvc status
+        } else if (store.getIsDavinciHeartbeatReported()) {
+          store.setIsDavinciHeartbeatReported(false);
+          storeRepository.updateStore(store);
         }
       } else {
         topicToNoDaVinciStatusRetryCountMap.remove(pushStatus.topicName);


### PR DESCRIPTION
<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat], [protocol]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## Problem Statement
<!--
Describe
- What problem are you trying to solve
- What issues or limitations exist in the current code
- Why this change is necessary 
-->
`topicToNoDaVinciStatusRetryCountMap` is a global variable that we use to track how many times we did not receive any DVC status report, and we call the above code periodically
        int noDaVinciStatusRetryAttempts = topicToNoDaVinciStatusRetryCountMap.compute(pushStatus.topicName, (k, v) -> {
          if (v == null) {
            return 1;
          }
          return v + 1;
        });
        if (noDaVinciStatusRetryAttempts <= daVinciPushStatusNoReportRetryMaxAttempts) {
          ...
        } else {
          topicToNoDaVinciStatusRetryCountMap.remove(pushStatus.topicName);
          ...
        }

Here, if we exceed daVinciPushStatusNoReportRetryMaxAttempts, then we remove it from the topicToNoDaVinciStatusRetryCountMap map, and the next call will again start the counter from 1 

## Solution
<!--
Describe
- What changes you are making and why. 
- How these changes solve the problem.
- Any performance considerations or trade-offs. 
- Describe what testings you have done, for example, performance testing etc.
-->
This PR check for previous dvc pushstatus query retry count before checking again.

###  Code changes
- [ ] Added new code behind **a config**. If so list the config names and their default values in the PR description.
- [ ] Introduced new **log lines**. 
  - [ ] Confirmed if logs need to be **rate limited** to avoid excessive logging.

###  **Concurrency-Specific Checks**
Both reviewer and PR author to verify
- [ ] Code has **no race conditions** or **thread safety issues**.
- [ ] Proper **synchronization mechanisms** (e.g., `synchronized`, `RWLock`) are used where needed.
- [ ] No **blocking calls** inside critical sections that could lead to deadlocks or performance degradation.
- [ ] Verified **thread-safe collections** are used (e.g., `ConcurrentHashMap`, `CopyOnWriteArrayList`).
- [ ] Validated proper exception handling in multi-threaded code to avoid silent thread termination.


## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->

- [ ] New unit tests added.
- [ ] New integration tests added.
- [ ] Modified or extended existing tests.
- [ ] Verified backward compatibility (if applicable).

## Does this PR introduce any user-facing or breaking changes?
<!--  
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [ ] No. You can skip the rest of this section.
- [ ] Yes. Clearly explain the behavior change and its impact.