### PR TITLE
[server] Delete RT offset emission metrics

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTask.java
@@ -2063,19 +2063,10 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
     }
   }
 
-  private void recordRegionHybridConsumptionStats(
-      int kafkaClusterId,
-      int producedRecordSize,
-      long upstreamOffset,
-      long currentTimeMs) {
+  private void recordRegionHybridConsumptionStats(int kafkaClusterId, int producedRecordSize, long currentTimeMs) {
     if (kafkaClusterId >= 0) {
-      versionedIngestionStats.recordRegionHybridConsumption(
-          storeName,
-          versionNumber,
-          kafkaClusterId,
-          producedRecordSize,
-          upstreamOffset,
-          currentTimeMs);
+      versionedIngestionStats
+          .recordRegionHybridConsumption(storeName, versionNumber, kafkaClusterId, producedRecordSize, currentTimeMs);
       hostLevelIngestionStats.recordTotalRegionHybridBytesConsumed(kafkaClusterId, producedRecordSize, currentTimeMs);
     }
   }
@@ -2435,7 +2426,6 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
         recordRegionHybridConsumptionStats(
             kafkaClusterId,
             consumerRecord.getPayloadSize(),
-            consumerRecord.getPosition().getNumericOffset(),
             beforeProcessingBatchRecordsTimestampMs);
         updateLatestInMemoryLeaderConsumedRTOffset(
             partitionConsumptionState,

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/AggVersionedIngestionStats.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/AggVersionedIngestionStats.java
@@ -90,12 +90,10 @@ public class AggVersionedIngestionStats
       int version,
       int regionId,
       long bytesConsumed,
-      long offsetConsumed,
       long currentTimeMs) {
     recordVersionedAndTotalStat(storeName, version, stat -> {
       stat.recordRegionHybridBytesConsumed(regionId, bytesConsumed, currentTimeMs);
       stat.recordRegionHybridRecordsConsumed(regionId, 1, currentTimeMs);
-      stat.recordRegionHybridAvgConsumedOffset(regionId, offsetConsumed, currentTimeMs);
     });
   }
 

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/IngestionStatsReporter.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/IngestionStatsReporter.java
@@ -372,12 +372,6 @@ public class IngestionStatsReporter extends AbstractVeniceStatsReporter<Ingestio
                 () -> getStats().getRegionHybridRecordsConsumed(regionId),
                 0,
                 regionNamePrefix + "_rt_records_consumed"));
-        registerSensor(
-            new IngestionStatsGauge(
-                this,
-                () -> getStats().getRegionHybridAvgConsumedOffset(regionId),
-                0,
-                regionNamePrefix + "_rt_consumed_offset"));
       }
     }
   }


### PR DESCRIPTION
## [server] Delete RT offset emission metrics  

Currently, we emit `_rt_consumed_offset` as a metric, but it hasn't been very useful.  
Additionally, it won't be supported after migrating to non-numeric position types.  
Hence, we're removing it to reduce noise and simplify the metrics surface.  


###  Code changes
- [ ] Added new code behind **a config**. If so list the config names and their default values in the PR description.
- [ ] Introduced new **log lines**. 
  - [ ] Confirmed if logs need to be **rate limited** to avoid excessive logging.

###  **Concurrency-Specific Checks**
Both reviewer and PR author to verify
- [ ] Code has **no race conditions** or **thread safety issues**.
- [ ] Proper **synchronization mechanisms** (e.g., `synchronized`, `RWLock`) are used where needed.
- [ ] No **blocking calls** inside critical sections that could lead to deadlocks or performance degradation.
- [ ] Verified **thread-safe collections** are used (e.g., `ConcurrentHashMap`, `CopyOnWriteArrayList`).
- [ ] Validated proper exception handling in multi-threaded code to avoid silent thread termination.


## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->

- [ ] New unit tests added.
- [ ] New integration tests added.
- [ ] Modified or extended existing tests.
- [ ] Verified backward compatibility (if applicable).

## Does this PR introduce any user-facing or breaking changes?
<!--  
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [ ] No. You can skip the rest of this section.
- [ ] Yes. Clearly explain the behavior change and its impact.