### PR TITLE
[server] Mark latch as created in SIT for future versions

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/helix/LeaderFollowerPartitionStateModel.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/helix/LeaderFollowerPartitionStateModel.java
@@ -13,7 +13,6 @@ import com.linkedin.venice.helix.HelixState;
 import com.linkedin.venice.meta.ReadOnlyStoreRepository;
 import com.linkedin.venice.meta.Store;
 import com.linkedin.venice.meta.Version;
-import com.linkedin.venice.meta.VersionStatus;
 import com.linkedin.venice.utils.LatencyUtils;
 import com.linkedin.venice.utils.Utils;
 import java.util.concurrent.CompletableFuture;
@@ -98,9 +97,7 @@ public class LeaderFollowerPartitionStateModel extends AbstractPartitionStateMod
       // A future version is ready to serve if it's status is either PUSHED or ONLINE
       // PUSHED is set for future versions of a target region push with deferred swap
       // ONLINE is set for future versions of a push with deferred swap
-      boolean isFutureVersionReady =
-          currentVersion < version && (store.getVersionStatus(version).equals(VersionStatus.PUSHED)
-              || store.getVersionStatus(version).equals(VersionStatus.ONLINE));
+      boolean isFutureVersionReady = Utils.isFutureVersionReady(resourceName, getStoreRepo());
 
       /**
        * For current version and already completed future versions, firstly create a latch, then start ingestion and wait

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/helix/LeaderFollowerPartitionStateModelDualPoolFactory.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/helix/LeaderFollowerPartitionStateModelDualPoolFactory.java
@@ -46,8 +46,17 @@ public class LeaderFollowerPartitionStateModelDualPoolFactory extends LeaderFoll
      * Allocate different thread pools for future and non-future version Helix state transitions to avoid an issue
      * that future version push is blocked when the long-running state transitions for current versions occupy all
      * threads in the thread pool.
+     *
+     * If it is a future version that is not ready to serve yet, it will use a separate thread pool.
+     * If it is a future version that is ready to serve (PUSHED, ONLINE), it will use the same thread pool as current versions
+     * pool to not block future pushes as it can be a long-running transition
      */
-    return Utils.isFutureVersion(resourceName, storeMetadataRepo) ? futureVersionExecutorService : executorService;
+    if (Utils.isFutureVersion(resourceName, storeMetadataRepo)
+        && !Utils.isFutureVersionReady(resourceName, storeMetadataRepo)) {
+      return futureVersionExecutorService;
+    }
+
+    return executorService;
   }
 
   @Override

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTask.java
@@ -1845,7 +1845,7 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
          * push status is not COMPLETED; from router point of view, there is no online replica after
          * the rebalance.
          */
-        if (isCurrentVersion.getAsBoolean()) {
+        if (isCurrentVersion.getAsBoolean() || Utils.isFutureVersionReady(versionTopic.getName(), storeRepository)) {
           pcs.lagHasCaughtUp();
           reportCompleted(pcs, true);
         }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
@@ -14,9 +14,7 @@ import static com.linkedin.venice.ConfigKeys.KAFKA_BOOTSTRAP_SERVERS;
 import static com.linkedin.venice.LogMessages.KILLED_JOB_MESSAGE;
 import static com.linkedin.venice.kafka.protocol.enums.ControlMessageType.START_OF_SEGMENT;
 import static com.linkedin.venice.pubsub.PubSubConstants.UNKNOWN_LATEST_OFFSET;
-import static com.linkedin.venice.utils.Utils.FATAL_DATA_VALIDATION_ERROR;
-import static com.linkedin.venice.utils.Utils.closeQuietlyWithErrorLogged;
-import static com.linkedin.venice.utils.Utils.getReplicaId;
+import static com.linkedin.venice.utils.Utils.*;
 import static java.util.Comparator.comparingInt;
 import static java.util.concurrent.TimeUnit.HOURS;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
@@ -479,6 +477,8 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
 
     this.storeBufferService = builder.getStoreBufferService();
     this.isCurrentVersion = isCurrentVersion;
+    boolean useVHybrid = version.isUseVersionLevelHybridConfig();
+    HybridStoreConfig hybridStoreConfig1 = store.getHybridStoreConfig();
     this.hybridStoreConfig = Optional.ofNullable(
         version.isUseVersionLevelHybridConfig() ? version.getHybridStoreConfig() : store.getHybridStoreConfig());
 
@@ -2173,7 +2173,8 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
             hybridStoreConfig.isPresent());
         newPartitionConsumptionState.setCurrentVersionSupplier(isCurrentVersion);
 
-        if (isCurrentVersion.getAsBoolean()) {
+        boolean isFutureVersionReady = isFutureVersionReady(kafkaVersionTopic, storeRepository);
+        if (isCurrentVersion.getAsBoolean() || isFutureVersionReady) {
           // Latch creation is in StateModelIngestionProgressNotifier#startConsumption() from the Helix transition
           newPartitionConsumptionState.setLatchCreated();
         }
@@ -4318,6 +4319,7 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
       Properties localConsumerProps,
       String remoteKafkaSourceAddress,
       boolean consumeRemotely) {
+    VeniceProperties veniceProperties = serverConfig.getClusterProperties();
     Properties newConsumerProps = serverConfig.getClusterProperties().getPropertiesCopy();
     newConsumerProps.putAll(localConsumerProps);
     newConsumerProps.setProperty(KAFKA_BOOTSTRAP_SERVERS, remoteKafkaSourceAddress);

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
@@ -14,7 +14,10 @@ import static com.linkedin.venice.ConfigKeys.KAFKA_BOOTSTRAP_SERVERS;
 import static com.linkedin.venice.LogMessages.KILLED_JOB_MESSAGE;
 import static com.linkedin.venice.kafka.protocol.enums.ControlMessageType.START_OF_SEGMENT;
 import static com.linkedin.venice.pubsub.PubSubConstants.UNKNOWN_LATEST_OFFSET;
-import static com.linkedin.venice.utils.Utils.*;
+import static com.linkedin.venice.utils.Utils.FATAL_DATA_VALIDATION_ERROR;
+import static com.linkedin.venice.utils.Utils.closeQuietlyWithErrorLogged;
+import static com.linkedin.venice.utils.Utils.getReplicaId;
+import static com.linkedin.venice.utils.Utils.isFutureVersionReady;
 import static java.util.Comparator.comparingInt;
 import static java.util.concurrent.TimeUnit.HOURS;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
@@ -477,8 +480,6 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
 
     this.storeBufferService = builder.getStoreBufferService();
     this.isCurrentVersion = isCurrentVersion;
-    boolean useVHybrid = version.isUseVersionLevelHybridConfig();
-    HybridStoreConfig hybridStoreConfig1 = store.getHybridStoreConfig();
     this.hybridStoreConfig = Optional.ofNullable(
         version.isUseVersionLevelHybridConfig() ? version.getHybridStoreConfig() : store.getHybridStoreConfig());
 
@@ -4319,7 +4320,6 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
       Properties localConsumerProps,
       String remoteKafkaSourceAddress,
       boolean consumeRemotely) {
-    VeniceProperties veniceProperties = serverConfig.getClusterProperties();
     Properties newConsumerProps = serverConfig.getClusterProperties().getPropertiesCopy();
     newConsumerProps.putAll(localConsumerProps);
     newConsumerProps.setProperty(KAFKA_BOOTSTRAP_SERVERS, remoteKafkaSourceAddress);

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/helix/VeniceLeaderFollowerStateModelTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/helix/VeniceLeaderFollowerStateModelTest.java
@@ -103,6 +103,9 @@ public class VeniceLeaderFollowerStateModelTest extends
     // When its future version that is completed, it should have a latch in place.
     when(mockStore.getCurrentVersion()).thenReturn(0);
     when(mockStore.getVersionStatus(1)).thenReturn(VersionStatus.PUSHED);
+    Version mockVersion = mock(Version.class);
+    when(mockStore.getVersion(1)).thenReturn(mockVersion);
+    when(mockVersion.getStatus()).thenReturn(VersionStatus.PUSHED);
     testStateModel.onBecomeStandbyFromOffline(mockMessage, mockContext);
     verify(mockNotifier, times(2)).startConsumption(mockMessage.getResourceName(), testPartition);
     verify(mockNotifier, times(2)).waitConsumptionCompleted(
@@ -113,6 +116,7 @@ public class VeniceLeaderFollowerStateModelTest extends
 
     // When its future version that is not completed, it should not have a latch in place
     when(mockStore.getVersionStatus(1)).thenReturn(VersionStatus.STARTED);
+    when(mockVersion.getStatus()).thenReturn(VersionStatus.STARTED);
     testStateModel.onBecomeStandbyFromOffline(mockMessage, mockContext);
     verify(mockNotifier, times(2)).startConsumption(mockMessage.getResourceName(), testPartition);
     verify(mockNotifier, times(2)).waitConsumptionCompleted(

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTaskTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTaskTest.java
@@ -1,6 +1,7 @@
 package com.linkedin.davinci.kafka.consumer;
 
 import static com.linkedin.davinci.kafka.consumer.LeaderFollowerStoreIngestionTask.VIEW_WRITER_CLOSE_TIMEOUT_IN_MS;
+import static com.linkedin.venice.ConfigKeys.KAFKA_BOOTSTRAP_SERVERS;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyDouble;
@@ -49,8 +50,10 @@ import com.linkedin.venice.kafka.protocol.enums.MessageType;
 import com.linkedin.venice.kafka.protocol.state.GlobalRtDivState;
 import com.linkedin.venice.message.KafkaKey;
 import com.linkedin.venice.meta.MaterializedViewParameters;
+import com.linkedin.venice.meta.ReadOnlyStoreRepository;
 import com.linkedin.venice.meta.Store;
 import com.linkedin.venice.meta.Version;
+import com.linkedin.venice.meta.VersionStatus;
 import com.linkedin.venice.meta.ViewConfig;
 import com.linkedin.venice.meta.ViewConfigImpl;
 import com.linkedin.venice.offsets.InMemoryStorageMetadataService;
@@ -63,14 +66,18 @@ import com.linkedin.venice.pubsub.api.PubSubPosition;
 import com.linkedin.venice.pubsub.api.PubSubProduceResult;
 import com.linkedin.venice.pubsub.api.PubSubTopic;
 import com.linkedin.venice.pubsub.api.PubSubTopicPartition;
+import com.linkedin.venice.pubsub.manager.TopicManager;
+import com.linkedin.venice.pubsub.manager.TopicManagerRepository;
 import com.linkedin.venice.schema.SchemaEntry;
 import com.linkedin.venice.serialization.avro.AvroProtocolDefinition;
 import com.linkedin.venice.serialization.avro.InternalAvroSpecificSerializer;
+import com.linkedin.venice.stats.StatsErrorCode;
 import com.linkedin.venice.utils.ByteUtils;
 import com.linkedin.venice.utils.ReferenceCounted;
 import com.linkedin.venice.utils.TestUtils;
 import com.linkedin.venice.utils.Time;
 import com.linkedin.venice.utils.Utils;
+import com.linkedin.venice.utils.VeniceProperties;
 import com.linkedin.venice.utils.lazy.Lazy;
 import com.linkedin.venice.views.MaterializedView;
 import com.linkedin.venice.writer.VeniceWriter;
@@ -106,6 +113,10 @@ public class LeaderFollowerStoreIngestionTaskTest {
 
   private VeniceViewWriterFactory mockVeniceViewWriterFactory;
   private HostLevelIngestionStats hostLevelIngestionStats;
+  private StorageMetadataService mockStorageMetadataService;
+  private ReadOnlyStoreRepository storeRepository;
+  private VeniceServerConfig mockVeniceServerConfig;
+  private TopicManagerRepository mockTopicManagerRepository;
 
   @Test
   public void testCheckWhetherToCloseUnusedVeniceWriter() {
@@ -212,14 +223,14 @@ public class LeaderFollowerStoreIngestionTaskTest {
     mockStorageService = mock(StorageService.class);
     doReturn(new ReferenceCounted<>(mock(StorageEngine.class), se -> {})).when(mockStorageService)
         .getRefCountedStorageEngine(anyString());
-    VeniceServerConfig mockVeniceServerConfig = mock(VeniceServerConfig.class);
+    mockVeniceServerConfig = mock(VeniceServerConfig.class);
     doReturn(Object2IntMaps.emptyMap()).when(mockVeniceServerConfig).getKafkaClusterUrlToIdMap();
     PubSubTopicRepository pubSubTopicRepository = new PubSubTopicRepository();
     hostLevelIngestionStats = mock(HostLevelIngestionStats.class);
     AggHostLevelIngestionStats aggHostLevelIngestionStats = mock(AggHostLevelIngestionStats.class);
     doReturn(hostLevelIngestionStats).when(aggHostLevelIngestionStats).getStoreStats(storeName);
     StorageMetadataService inMemoryStorageMetadataService = new InMemoryStorageMetadataService();
-    StoreIngestionTaskFactory.Builder builder = TestUtils.getStoreIngestionTaskBuilder(storeName)
+    StoreIngestionTaskFactory.Builder builder = TestUtils.getStoreIngestionTaskBuilder(storeName, true)
         .setServerConfig(mockVeniceServerConfig)
         .setPubSubTopicRepository(pubSubTopicRepository)
         .setVeniceViewWriterFactory(mockVeniceViewWriterFactory)
@@ -244,11 +255,14 @@ public class LeaderFollowerStoreIngestionTaskTest {
     mockConsumerAction = mock(ConsumerAction.class);
 
     mockProperties = new Properties();
+    mockProperties.put(KAFKA_BOOTSTRAP_SERVERS, "kashfkjashf");
     mockBooleanSupplier = mock(BooleanSupplier.class);
     mockVeniceStoreVersionConfig = mock(VeniceStoreVersionConfig.class);
     String versionTopic = version.kafkaTopicName();
     doReturn(versionTopic).when(mockVeniceStoreVersionConfig).getStoreVersionName();
-
+    mockStorageMetadataService = builder.getStorageMetadataService();
+    storeRepository = builder.getMetadataRepo();
+    mockTopicManagerRepository = builder.getTopicManagerRepository();
     leaderFollowerStoreIngestionTask = spy(
         new LeaderFollowerStoreIngestionTask(
             mockStorageService,
@@ -611,5 +625,48 @@ public class LeaderFollowerStoreIngestionTaskTest {
     doReturn(ControlMessageType.START_OF_SEGMENT.getValue()).when(mockControlMessage).getControlMessageType();
     assertFalse(
         mockIngestionTask.shouldSyncOffsetFromSnapshot(nonSegmentControlMessage, mockPartitionConsumptionState));
+  }
+
+  @Test
+  public void testFutureVersionLatchStatus() throws InterruptedException {
+    setUp();
+    when(mockConsumerAction.getType()).thenReturn(ConsumerActionType.SUBSCRIBE);
+    when(mockConsumerAction.getTopic()).thenReturn("test-topic");
+    when(mockConsumerAction.getPartition()).thenReturn(0);
+    LeaderFollowerPartitionStateModel.LeaderSessionIdChecker mockLeaderSessionIdChecker =
+        mock(LeaderFollowerPartitionStateModel.LeaderSessionIdChecker.class);
+    when(mockConsumerAction.getLeaderSessionIdChecker()).thenReturn(mockLeaderSessionIdChecker);
+    when(mockLeaderSessionIdChecker.isSessionIdValid()).thenReturn(true);
+    mockTopicPartition = mock(PubSubTopicPartition.class);
+    PubSubTopic pubSubTopic = mock(PubSubTopic.class);
+    when(mockTopicPartition.getPubSubTopic()).thenReturn(pubSubTopic);
+    when(pubSubTopic.getName()).thenReturn("test-topic");
+    OffsetRecord mockOffsetRecord = mock(OffsetRecord.class);
+    when(mockOffsetRecord.getLeaderTopic()).thenReturn("test");
+    when(mockOffsetRecord.isEndOfPushReceived()).thenReturn(true);
+    when(mockStorageMetadataService.getLastOffset(any(), anyInt())).thenReturn(mockOffsetRecord);
+    when(mockConsumerAction.getTopicPartition()).thenReturn(mockTopicPartition);
+    when(mockPartitionConsumptionState.getOffsetRecord()).thenReturn(mockOffsetRecord);
+    when(mockBooleanSupplier.getAsBoolean()).thenReturn(false);
+    when(storeRepository.getStore(anyString())).thenReturn(mockStore);
+    Version mockVersion = mock(Version.class);
+    when(mockVersion.getStatus()).thenReturn(VersionStatus.ONLINE);
+    when(mockStore.getVersion(1)).thenReturn(mockVersion);
+    when(mockStore.getCurrentVersion()).thenReturn(0);
+    when(mockVersion.isHybrid()).thenReturn(true);
+    VeniceProperties properties = new VeniceProperties();
+    when(mockVeniceServerConfig.getClusterProperties()).thenReturn(properties);
+    when(mockVeniceServerConfig.getKafkaConsumerConfigsForLocalConsumption()).thenReturn(properties);
+    TopicManager mockTopicManager = mock(TopicManager.class);
+    doReturn(mockTopicManager).when(mockTopicManagerRepository).getLocalTopicManager();
+    doReturn(mockTopicManager).when(mockTopicManagerRepository).getTopicManager(anyString());
+    doReturn((long) StatsErrorCode.LAG_MEASUREMENT_FAILURE.code).when(mockTopicManager)
+        .getLatestOffsetCached(any(), anyInt());
+    doReturn(0L).when(mockTopicManager).getLatestOffsetCached(any(), anyInt());
+    doReturn(10L).when(mockTopicManager).getLatestOffsetCached(any(), anyInt());
+    leaderFollowerStoreIngestionTask.processCommonConsumerAction(mockConsumerAction);
+
+    // Verify that we enter the block
+    verify(leaderFollowerStoreIngestionTask, times(1)).measureLagWithCallToPubSub(any(), any(), anyInt(), anyLong());
   }
 }

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTaskTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTaskTest.java
@@ -255,7 +255,7 @@ public class LeaderFollowerStoreIngestionTaskTest {
     mockConsumerAction = mock(ConsumerAction.class);
 
     mockProperties = new Properties();
-    mockProperties.put(KAFKA_BOOTSTRAP_SERVERS, "kashfkjashf");
+    mockProperties.put(KAFKA_BOOTSTRAP_SERVERS, "bootStrapServers");
     mockBooleanSupplier = mock(BooleanSupplier.class);
     mockVeniceStoreVersionConfig = mock(VeniceStoreVersionConfig.class);
     String versionTopic = version.kafkaTopicName();

--- a/internal/venice-common/src/main/java/com/linkedin/venice/utils/Utils.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/utils/Utils.java
@@ -1004,7 +1004,7 @@ public class Utils {
     try {
       String storeName = Version.parseStoreFromKafkaTopicName(resourceName);
       int versionNum = Version.parseVersionFromKafkaTopicName(resourceName);
-      Store store = metadataRepo.getStore(storeName);
+      Store store = metadataRepo.getStoreOrThrow(storeName);
       if (store == null) {
         LOGGER.warn("Store {} is not in store repository.", storeName);
         return false;

--- a/internal/venice-common/src/test/java/com/linkedin/venice/utils/UtilsTest.java
+++ b/internal/venice-common/src/test/java/com/linkedin/venice/utils/UtilsTest.java
@@ -22,6 +22,7 @@ import com.linkedin.venice.meta.Store;
 import com.linkedin.venice.meta.StoreInfo;
 import com.linkedin.venice.meta.StoreVersionInfo;
 import com.linkedin.venice.meta.Version;
+import com.linkedin.venice.meta.VersionStatus;
 import com.linkedin.venice.pubsub.PubSubTopicRepository;
 import com.linkedin.venice.pubsub.api.PubSubTopic;
 import com.linkedin.venice.serialization.avro.AvroProtocolDefinition;
@@ -551,5 +552,23 @@ public class UtilsTest {
         Utils.waitStoreVersionOrThrow(Version.composeKafkaTopic(storeName, 1), storeRepository);
     Assert.assertEquals(storeVersionInfo.getStore(), store);
     Assert.assertEquals(storeVersionInfo.getVersion(), version);
+  }
+
+  @Test
+  public void testIsFutureVersionReady() {
+    ReadOnlyStoreRepository storeRepository = mock(ReadOnlyStoreRepository.class);
+    String storeName = "testIsFutureVersionReady";
+    String resource = "testIsFutureVersionReady_v1";
+
+    // Setup store and version
+    Store store = mock(Store.class);
+    Version version = mock(Version.class);
+    doReturn(version).when(store).getVersion(anyInt());
+    doReturn(store).when(storeRepository).getStoreOrThrow(storeName);
+    doReturn(0).when(store).getCurrentVersion();
+    doReturn(VersionStatus.PUSHED).when(version).getStatus();
+
+    boolean ready = Utils.isFutureVersionReady(resource, storeRepository);
+    Assert.assertTrue(ready);
   }
 }

--- a/internal/venice-test-common/src/main/java/com/linkedin/venice/utils/TestUtils.java
+++ b/internal/venice-test-common/src/main/java/com/linkedin/venice/utils/TestUtils.java
@@ -825,6 +825,10 @@ public class TestUtils {
   }
 
   public static StoreIngestionTaskFactory.Builder getStoreIngestionTaskBuilder(String storeName) {
+    return getStoreIngestionTaskBuilder(storeName, false);
+  }
+
+  public static StoreIngestionTaskFactory.Builder getStoreIngestionTaskBuilder(String storeName, boolean isHybrid) {
     VeniceServerConfig mockVeniceServerConfig = mock(VeniceServerConfig.class);
     doReturn(false).when(mockVeniceServerConfig).isHybridQuotaEnabled();
     VeniceProperties mockVeniceProperties = mock(VeniceProperties.class);
@@ -859,8 +863,14 @@ public class TestUtils {
     doReturn(false).when(mockStore).isIncrementalPushEnabled();
 
     version.setHybridStoreConfig(null);
-    doReturn(null).when(mockStore).getHybridStoreConfig();
-    doReturn(false).when(mockStore).isHybrid();
+    if (isHybrid) {
+      HybridStoreConfig hybridStoreConfig = mock(HybridStoreConfig.class);
+      doReturn(hybridStoreConfig).when(mockStore).getHybridStoreConfig();
+      doReturn(true).when(mockStore).isHybrid();
+    } else {
+      doReturn(null).when(mockStore).getHybridStoreConfig();
+      doReturn(false).when(mockStore).isHybrid();
+    }
 
     version.setBufferReplayEnabledForHybrid(true);
 


### PR DESCRIPTION
<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat], [protocol]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## Problem Statement
<!--
Describe
- What problem are you trying to solve
- What issues or limitations exist in the current code
- Why this change is necessary 
-->
During ST from offline to standby, ready to serve future versions will take a latch to stall the transition until the future version replica is ready to serve. This is to account for manual and automatic deferred swaps that can make future versions online at any moment and if ST is not stalled for future versions, it is possible that there won't be enough replicas.

The problem with the current state is that in SIT, there is short circuit logic for current versions holding a latch to release the latch for hybrid stores that have caught up to VT, but this logic is not being applied to future versions that are now holding a latch too. This results in the future version holding the latch forever and blocking new pushes because it can use up the entire future version thread pool if ingestion is not finished in time

## Solution
<!--
Describe
- What changes you are making and why. 
- How these changes solve the problem.
- Any performance considerations or trade-offs. 
- Describe what testings you have done, for example, performance testing etc.
-->
1. Mark the latch as `CREATED` for future ready to serve versions. It takes the latch in `onBecomeStandbyFromOffline` if the future version is ready to serve
2. Release the latch in `reportIfCatchUpVersionTopicOffset` for future ready to serve versions
3. Use the current version thread pool for future versions that are already ready (ONLINE or PUSHED status) to not block new pushes

###  Code changes
- [ ] Added new code behind **a config**. If so list the config names and their default values in the PR description.
- [ ] Introduced new **log lines**. 
  - [ ] Confirmed if logs need to be **rate limited** to avoid excessive logging.

###  **Concurrency-Specific Checks**
Both reviewer and PR author to verify
- [ ] Code has **no race conditions** or **thread safety issues**.
- [ ] Proper **synchronization mechanisms** (e.g., `synchronized`, `RWLock`) are used where needed.
- [ ] No **blocking calls** inside critical sections that could lead to deadlocks or performance degradation.
- [ ] Verified **thread-safe collections** are used (e.g., `ConcurrentHashMap`, `CopyOnWriteArrayList`).
- [ ] Validated proper exception handling in multi-threaded code to avoid silent thread termination.


## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->

- [x] New unit tests added.
- [ ] New integration tests added.
- [ ] Modified or extended existing tests.
- [ ] Verified backward compatibility (if applicable).

Added new unit test, `testFutureVersionLatchStatus`, to verify that future versions enter the code block to release the latch

## Does this PR introduce any user-facing or breaking changes?
<!--  
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Clearly explain the behavior change and its impact.