### PR TITLE
VeniceRawPubsubSource for Spark.

### DIFF
--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/spark/input/pubsub/raw/VeniceRawPubsubSource.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/spark/input/pubsub/raw/VeniceRawPubsubSource.java
@@ -1,0 +1,33 @@
+package com.linkedin.venice.spark.input.pubsub.raw;
+
+import static com.linkedin.venice.spark.SparkConstants.*;
+
+import com.linkedin.venice.utils.VeniceProperties;
+import java.util.Map;
+import java.util.Properties;
+import org.apache.spark.sql.connector.catalog.Table;
+import org.apache.spark.sql.connector.catalog.TableProvider;
+import org.apache.spark.sql.connector.expressions.Transform;
+import org.apache.spark.sql.types.StructType;
+import org.apache.spark.sql.util.CaseInsensitiveStringMap;
+
+
+/**
+ * This is the entrypoint of the PubSub input source. It is used by Spark to create a DataFrame from a PubSub topic
+ * The Topic must conform to Venice PubSub Version-Topic Schema.
+ * This source does not support Realtime or versioned realtime topics at this point.
+ */
+@SuppressWarnings("unused")
+public class VeniceRawPubsubSource implements TableProvider {
+  @Override
+  public StructType inferSchema(CaseInsensitiveStringMap options) {
+    return RAW_PUBSUB_INPUT_TABLE_SCHEMA;
+  }
+
+  @Override
+  public Table getTable(StructType schema, Transform[] partitioning, Map<String, String> configs) {
+    Properties properties = new Properties();
+    properties.putAll(configs);
+    return new VeniceRawPubsubInputTable(new VeniceProperties(properties));
+  }
+}

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/spark/input/pubsub/raw/VeniceRawPubsubSource.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/spark/input/pubsub/raw/VeniceRawPubsubSource.java
@@ -1,6 +1,6 @@
 package com.linkedin.venice.spark.input.pubsub.raw;
 
-import static com.linkedin.venice.spark.SparkConstants.*;
+import static com.linkedin.venice.spark.SparkConstants.RAW_PUBSUB_INPUT_TABLE_SCHEMA;
 
 import com.linkedin.venice.utils.VeniceProperties;
 import java.util.Map;


### PR DESCRIPTION
[vpj][spark] PubSub backed Spark table source.

## Problem Statement
Last step of Venice Raw PubSub data source.

## Solution
This change covers the Schema of the table and allows the source to populate a spark table with defined Schema.

###  Code changes
- [ ] Added new code behind **a config**. If so list the config names and their default values in the PR description.
- [ ] Introduced new **log lines**. 
  - [ ] Confirmed if logs need to be **rate limited** to avoid excessive logging.

###  **Concurrency-Specific Checks**
Both reviewer and PR author to verify
- [ ] Code has **no race conditions** or **thread safety issues**.
- [ ] Proper **synchronization mechanisms** (e.g., `synchronized`, `RWLock`) are used where needed.
- [ ] No **blocking calls** inside critical sections that could lead to deadlocks or performance degradation.
- [ ] Verified **thread-safe collections** are used (e.g., `ConcurrentHashMap`, `CopyOnWriteArrayList`).
- [ ] Validated proper exception handling in multi-threaded code to avoid silent thread termination.


## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->

- [ ] New unit tests added.
- [ ] New integration tests added.
- [ ] Modified or extended existing tests.
- [ ] Verified backward compatibility (if applicable).

## Does this PR introduce any user-facing or breaking changes?
<!--  
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [ ] No. You can skip the rest of this section.
- [ ] Yes. Clearly explain the behavior change and its impact.