### PR TITLE
[controller] Refactor code to reduce call to check access in CreateVersion

### DIFF
--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/server/AdminSparkServer.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/server/AdminSparkServer.java
@@ -300,11 +300,7 @@ public class AdminSparkServer extends AbstractVeniceService {
     StoresRoutes storesRoutes = new StoresRoutes(sslEnabled, accessController, pubSubTopicRepository);
     JobRoutes jobRoutes = new JobRoutes(sslEnabled, accessController);
     SkipAdminRoute skipAdminRoute = new SkipAdminRoute(sslEnabled, accessController);
-    CreateVersion createVersion = new CreateVersion(
-        sslEnabled,
-        accessController,
-        this.checkReadMethodForKafka,
-        disableParentRequestTopicForStreamPushes);
+    CreateVersion createVersion = new CreateVersion(sslEnabled, accessController, this.checkReadMethodForKafka);
     CreateStore createStoreRoute = new CreateStore(sslEnabled, accessController);
     NodesAndReplicas nodesAndReplicas = new NodesAndReplicas(sslEnabled, accessController);
     SchemaRoutes schemaRoutes = new SchemaRoutes(sslEnabled, accessController);

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/server/CreateVersion.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/server/CreateVersion.java
@@ -420,9 +420,11 @@ public class CreateVersion extends AbstractRoute {
       VersionCreationResponse responseObject = new VersionCreationResponse();
       response.type(HttpConstants.JSON);
       try {
+        boolean missingWriteAccess = !hasWriteAccessToTopic(request);
+        boolean missingReadAccess = this.checkReadMethodForKafka && !hasReadAccessToTopic(request);
+
         // Also allow allowList users to run this command
-        if (!isAllowListUser(request)
-            && (!hasWriteAccessToTopic(request) || (this.checkReadMethodForKafka && !hasReadAccessToTopic(request)))) {
+        if (!isAllowListUser(request) && (missingWriteAccess || missingReadAccess)) {
           response.status(HttpStatus.SC_FORBIDDEN);
           String userId = getPrincipalId(request);
 
@@ -431,8 +433,6 @@ public class CreateVersion extends AbstractRoute {
            * help partners to unblock by themselves.
            */
           String errorMsg;
-          boolean missingWriteAccess = !hasWriteAccessToTopic(request);
-          boolean missingReadAccess = this.checkReadMethodForKafka && !hasReadAccessToTopic(request);
           if (missingWriteAccess && missingReadAccess) {
             errorMsg = "[Error] Missing [read] and [write] ACLs for user \"" + userId
                 + "\". Please setup ACLs for your store.";

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/server/CreateVersion.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/server/CreateVersion.java
@@ -468,7 +468,6 @@ public class CreateVersion extends AbstractRoute {
     }
     if (missingReadAccess) {
       errorMessage = String.format(errorMessage, "read");
-      ;
     }
     responseObject.setError(errorMessage);
     responseObject.setErrorType(ErrorType.BAD_REQUEST);

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/server/CreateVersion.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/server/CreateVersion.java
@@ -465,7 +465,7 @@ public class CreateVersion extends AbstractRoute {
     response.status(HttpStatus.SC_FORBIDDEN);
     VersionCreationResponse responseObject = new VersionCreationResponse();
     String userId = getPrincipalId(request);
-    String errorMessage = "Missing [{}] ACLs for user " + userId + ". Please setup ACLs for your store.";
+    String errorMessage = "Missing [{}] ACLs for user \"" + userId + "\". Please setup ACLs for your store.";
     if (missingWriteAccess) {
       errorMessage = String.format(errorMessage, "write");
     }

--- a/services/venice-controller/src/test/java/com/linkedin/venice/controller/server/CreateVersionTest.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/controller/server/CreateVersionTest.java
@@ -149,7 +149,7 @@ public class CreateVersionTest {
     /**
      * Build a CreateVersion route.
      */
-    CreateVersion createVersion = new CreateVersion(true, Optional.of(accessClient), checkReadMethod, false);
+    CreateVersion createVersion = new CreateVersion(true, Optional.of(accessClient), checkReadMethod);
     Route createVersionRoute = createVersion.requestTopicForPushing(admin);
 
     // Not an allowlist user.
@@ -215,7 +215,7 @@ public class CreateVersionTest {
     assertTrue(store.isIncrementalPushEnabled());
 
     // Build a CreateVersion route.
-    CreateVersion createVersion = new CreateVersion(true, Optional.of(accessClient), false, false);
+    CreateVersion createVersion = new CreateVersion(true, Optional.of(accessClient), false);
     Route createVersionRoute = createVersion.requestTopicForPushing(admin);
     doReturn(Boolean.toString(pushToSeparateTopicEnabled)).when(request)
         .queryParamOrDefault(SEPARATE_REAL_TIME_TOPIC_ENABLED, "false");
@@ -274,7 +274,7 @@ public class CreateVersionTest {
     assertTrue(store.isIncrementalPushEnabled());
 
     // Build a CreateVersion route.
-    CreateVersion createVersion = new CreateVersion(true, Optional.of(accessClient), false, false);
+    CreateVersion createVersion = new CreateVersion(true, Optional.of(accessClient), false);
     Route createVersionRoute = createVersion.requestTopicForPushing(admin);
 
     Object result = createVersionRoute.handle(request, response);
@@ -329,7 +329,7 @@ public class CreateVersionTest {
     assertTrue(admin.isParent());
 
     // Build a CreateVersion route.
-    CreateVersion createVersion = new CreateVersion(true, Optional.of(accessClient), false, false);
+    CreateVersion createVersion = new CreateVersion(true, Optional.of(accessClient), false);
     Route createVersionRoute = createVersion.requestTopicForPushing(admin);
     Object result = createVersionRoute.handle(request, response);
     assertNotNull(result);
@@ -515,7 +515,7 @@ public class CreateVersionTest {
 
   @Test
   public void testValidatePushTypeForIncrementalPushPushType() {
-    CreateVersion createVersion = new CreateVersion(true, Optional.of(accessClient), false, false);
+    CreateVersion createVersion = new CreateVersion(true, Optional.of(accessClient), false);
 
     // push type is INCREMENTAL and store is not hybrid
     Store store1 = mock(Store.class);
@@ -613,7 +613,7 @@ public class CreateVersionTest {
 
   @Test
   public void testVerifyAndConfigurePartitionerSettings() {
-    CreateVersion createVersion = new CreateVersion(true, Optional.of(accessClient), false, false);
+    CreateVersion createVersion = new CreateVersion(true, Optional.of(accessClient), false);
 
     VersionCreationResponse response = new VersionCreationResponse();
     PartitionerConfig storePartitionerConfig = mock(PartitionerConfig.class);
@@ -662,7 +662,7 @@ public class CreateVersionTest {
 
   @Test
   public void testDetermineResponseTopic() {
-    CreateVersion createVersion = new CreateVersion(true, Optional.of(accessClient), false, false);
+    CreateVersion createVersion = new CreateVersion(true, Optional.of(accessClient), false);
 
     String storeName = "test_store";
     String vtName = Version.composeKafkaTopic(storeName, 1);
@@ -738,7 +738,7 @@ public class CreateVersionTest {
 
   @Test
   public void testGetCompressionStrategy() {
-    CreateVersion createVersion = new CreateVersion(true, Optional.of(accessClient), false, false);
+    CreateVersion createVersion = new CreateVersion(true, Optional.of(accessClient), false);
 
     // Test Case 1: Real-time topic returns NO_OP
     Version mockVersion1 = mock(Version.class);
@@ -756,7 +756,7 @@ public class CreateVersionTest {
 
   @Test
   public void testConfigureSourceFabric() {
-    CreateVersion createVersion = new CreateVersion(true, Optional.of(accessClient), false, false);
+    CreateVersion createVersion = new CreateVersion(true, Optional.of(accessClient), false);
 
     // Test Case 1: Native replication enabled and non-incremental push type
     Admin mockAdmin1 = mock(Admin.class);
@@ -829,7 +829,7 @@ public class CreateVersionTest {
     VersionCreationResponse response = new VersionCreationResponse();
 
     when(admin.isParent()).thenReturn(true);
-    CreateVersion createVersionNotOk = new CreateVersion(true, Optional.of(accessClient), false, true);
+    CreateVersion createVersionNotOk = new CreateVersion(true, Optional.of(accessClient), false);
     VeniceException ex = expectThrows(
         VeniceException.class,
         () -> createVersionNotOk.handleStreamPushType(admin, store, request, response));
@@ -844,7 +844,7 @@ public class CreateVersionTest {
     when(store.getName()).thenReturn(STORE_NAME);
     RequestTopicForPushRequest request = new RequestTopicForPushRequest("CLUSTER_NAME", STORE_NAME, STREAM, "JOB_ID");
     VersionCreationResponse response = new VersionCreationResponse();
-    CreateVersion createVersionOk = new CreateVersion(true, Optional.of(accessClient), false, false);
+    CreateVersion createVersionOk = new CreateVersion(true, Optional.of(accessClient), false);
 
     // Case 1: No hybrid version
     when(admin.isParent()).thenReturn(false);
@@ -873,7 +873,7 @@ public class CreateVersionTest {
     Store store = mock(Store.class);
     String clusterName = "testCluster";
     String storeName = "testStore";
-    CreateVersion createVersion = new CreateVersion(true, Optional.of(accessClient), false, false);
+    CreateVersion createVersion = new CreateVersion(true, Optional.of(accessClient), false);
 
     // Case 1: Admin is parent, store has AA replication, and AA replication is enabled in all regions
     when(admin.isParent()).thenReturn(true);
@@ -902,7 +902,7 @@ public class CreateVersionTest {
     String configValue = "TestValue";
     String storeName = "testStore";
 
-    CreateVersion createVersion = new CreateVersion(true, Optional.of(accessClient), false, false);
+    CreateVersion createVersion = new CreateVersion(true, Optional.of(accessClient), false);
 
     // Case 1: Config is applied as AA replication is enabled
     String result = createVersion.applyConfigBasedOnReplication(configType, configValue, storeName, isAARCheckEnabled);
@@ -930,7 +930,7 @@ public class CreateVersionTest {
     Store store = mock(Store.class);
     RequestTopicForPushRequest request = new RequestTopicForPushRequest(clusterName, storeName, pushType, pushJobId);
     VersionCreationResponse response = new VersionCreationResponse();
-    CreateVersion createVersion = new CreateVersion(true, Optional.of(accessClient), false, false);
+    CreateVersion createVersion = new CreateVersion(true, Optional.of(accessClient), false);
     Lazy<Boolean> isActiveActiveReplicationEnabledInAllRegions = Lazy.of(() -> true);
 
     // Mock admin methods
@@ -1012,8 +1012,7 @@ public class CreateVersionTest {
 
   @Test
   public void testEmptyPushThrowsNoStoreFoundException() throws Exception {
-    CreateVersion createVersion =
-        new CreateVersion(false, Optional.of(NoOpDynamicAccessController.INSTANCE), false, false);
+    CreateVersion createVersion = new CreateVersion(false, Optional.of(NoOpDynamicAccessController.INSTANCE), false);
     Route emptyPushRoute = createVersion.emptyPush(admin);
 
     when(request.queryParams(NAME)).thenReturn(STORE_NAME);
@@ -1034,8 +1033,7 @@ public class CreateVersionTest {
 
   @Test
   public void testEmptyPushCreatesNewVersionAndReturnsSuccess() throws Exception {
-    CreateVersion createVersion =
-        new CreateVersion(false, Optional.of(NoOpDynamicAccessController.INSTANCE), false, false);
+    CreateVersion createVersion = new CreateVersion(false, Optional.of(NoOpDynamicAccessController.INSTANCE), false);
     Route emptyPushRoute = createVersion.emptyPush(admin);
 
     // Required params
@@ -1074,8 +1072,7 @@ public class CreateVersionTest {
 
   @Test
   public void testEmptyPushWithTheDuplicatePushJobIdSkipsSopAndEop() throws Exception {
-    CreateVersion createVersion =
-        new CreateVersion(false, Optional.of(NoOpDynamicAccessController.INSTANCE), false, false);
+    CreateVersion createVersion = new CreateVersion(false, Optional.of(NoOpDynamicAccessController.INSTANCE), false);
     Route emptyPushRoute = createVersion.emptyPush(admin);
 
     // Set up required query params


### PR DESCRIPTION
### Problem
Right now, when we call `requestTopicForPushing`, we may call `hasWriteAccessToTopic` and `hasReadAccessToTopic` twice if it fails one check, which is not necessary. The call is quite expensive on memory profiling result. Refactor the code to reduce the calls.

### Solution
- Only request access check unless necessary
- Remove `disableParentRequestTopicForStreamPushes` due to unused params
###  Code changes
- [ ] Added new code behind **a config**. If so list the config names and their default values in the PR description.
- [ ] Introduced new **log lines**. 
  - [ ] Confirmed if logs need to be **rate limited** to avoid excessive logging.

###  **Concurrency-Specific Checks**
Both reviewer and PR author to verify
- [ ] Code has **no race conditions** or **thread safety issues**.
- [ ] Proper **synchronization mechanisms** (e.g., `synchronized`, `RWLock`) are used where needed.
- [ ] No **blocking calls** inside critical sections that could lead to deadlocks or performance degradation.
- [ ] Verified **thread-safe collections** are used (e.g., `ConcurrentHashMap`, `CopyOnWriteArrayList`).
- [ ] Validated proper exception handling in multi-threaded code to avoid silent thread termination.


## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->

- [ ] New unit tests added.
- [ ] New integration tests added.
- [ ] Modified or extended existing tests.
- [ ] Verified backward compatibility (if applicable).

## Does this PR introduce any user-facing or breaking changes?
<!--  
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [ ] No. You can skip the rest of this section.
- [ ] Yes. Clearly explain the behavior change and its impact.