### PR TITLE
[server][dvc] IngestionTaskReusableObjects.Strategy config

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/config/VeniceServerConfig.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/config/VeniceServerConfig.java
@@ -122,6 +122,7 @@ import static com.linkedin.venice.ConfigKeys.SERVER_INGESTION_ISOLATION_APPLICAT
 import static com.linkedin.venice.ConfigKeys.SERVER_INGESTION_ISOLATION_SERVICE_PORT;
 import static com.linkedin.venice.ConfigKeys.SERVER_INGESTION_MODE;
 import static com.linkedin.venice.ConfigKeys.SERVER_INGESTION_TASK_MAX_IDLE_COUNT;
+import static com.linkedin.venice.ConfigKeys.SERVER_INGESTION_TASK_REUSABLE_OBJECTS_STRATEGY;
 import static com.linkedin.venice.ConfigKeys.SERVER_KAFKA_CONSUMER_OFFSET_COLLECTION_ENABLED;
 import static com.linkedin.venice.ConfigKeys.SERVER_KAFKA_MAX_POLL_RECORDS;
 import static com.linkedin.venice.ConfigKeys.SERVER_LEADER_COMPLETE_STATE_CHECK_IN_FOLLOWER_VALID_INTERVAL_MS;
@@ -212,6 +213,7 @@ import static com.linkedin.venice.utils.ByteUtils.generateHumanReadableByteCount
 
 import com.github.luben.zstd.Zstd;
 import com.linkedin.davinci.helix.LeaderFollowerPartitionStateModelFactory;
+import com.linkedin.davinci.ingestion.utils.IngestionTaskReusableObjects;
 import com.linkedin.davinci.kafka.consumer.KafkaConsumerService;
 import com.linkedin.davinci.kafka.consumer.KafkaConsumerServiceDelegator;
 import com.linkedin.davinci.kafka.consumer.RemoteIngestionRepairService;
@@ -648,6 +650,7 @@ public class VeniceServerConfig extends VeniceClusterConfig {
   private final boolean isParticipantMessageStoreEnabled;
   private final long consumerPollTrackerStaleThresholdInSeconds;
   private final LogContext logContext;
+  private final IngestionTaskReusableObjects.Strategy ingestionTaskReusableObjectsStrategy;
 
   public VeniceServerConfig(VeniceProperties serverProperties) throws ConfigurationException {
     this(serverProperties, Collections.emptyMap());
@@ -1107,6 +1110,10 @@ public class VeniceServerConfig extends VeniceClusterConfig {
         serverProperties.getInt(SERVER_LOAD_CONTROLLER_COMPUTE_LATENCY_ACCEPT_THRESHOLD_IN_MS, 100);
     consumerPollTrackerStaleThresholdInSeconds = serverProperties
         .getLong(SERVER_CONSUMER_POLL_TRACKER_STALE_THRESHOLD_IN_SECONDS, TimeUnit.MINUTES.toSeconds(15));
+    this.ingestionTaskReusableObjectsStrategy = IngestionTaskReusableObjects.Strategy.valueOf(
+        serverProperties.getString(
+            SERVER_INGESTION_TASK_REUSABLE_OBJECTS_STRATEGY,
+            IngestionTaskReusableObjects.Strategy.THREAD_LOCAL_PER_INGESTION_TASK.name()));
   }
 
   List<Double> extractThrottleLimitFactorsFor(VeniceProperties serverProperties, String configKey) {
@@ -2051,5 +2058,9 @@ public class VeniceServerConfig extends VeniceClusterConfig {
 
   public LogContext getLogContext() {
     return logContext;
+  }
+
+  public IngestionTaskReusableObjects.Strategy getIngestionTaskReusableObjectsStrategy() {
+    return this.ingestionTaskReusableObjectsStrategy;
   }
 }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/ingestion/utils/IngestionTaskReusableObjects.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/ingestion/utils/IngestionTaskReusableObjects.java
@@ -1,0 +1,75 @@
+package com.linkedin.davinci.ingestion.utils;
+
+import com.linkedin.avroutil1.compatibility.AvroCompatibilityHelper;
+import java.nio.ByteBuffer;
+import java.util.function.Supplier;
+import org.apache.avro.io.BinaryDecoder;
+
+
+public class IngestionTaskReusableObjects {
+  private static final ThreadLocal<IngestionTaskReusableObjects> SINGLETON =
+      ThreadLocal.withInitial(IngestionTaskReusableObjects::new);
+  private static final IngestionTaskReusableObjects NO_REUSE_SINGLETON = new IngestionTaskReusableObjects(null, null);
+  private static final byte[] BINARY_DECODER_PARAM = new byte[16];
+
+  private final ByteBuffer reusedByteBuffer;
+  private final BinaryDecoder binaryDecoder;
+
+  private IngestionTaskReusableObjects(ByteBuffer reusedByteBuffer, BinaryDecoder binaryDecoder) {
+    this.reusedByteBuffer = reusedByteBuffer;
+    this.binaryDecoder = binaryDecoder;
+  }
+
+  private IngestionTaskReusableObjects() {
+    this(
+        ByteBuffer.allocate(1024 * 1024),
+        AvroCompatibilityHelper.newBinaryDecoder(BINARY_DECODER_PARAM, 0, BINARY_DECODER_PARAM.length, null));
+  }
+
+  public BinaryDecoder getBinaryDecoder() {
+    return binaryDecoder;
+  }
+
+  public ByteBuffer getReusedByteBuffer() {
+    return reusedByteBuffer;
+  }
+
+  public enum Strategy {
+    /**
+     * No re-use, will pass null into the relevant code paths, which will result in new objects getting allocated on the
+     * fly, and needing to be garbage collected.
+     */
+    NO_REUSE(() -> IngestionTaskReusableObjects.NO_REUSE_SINGLETON),
+
+    /**
+     * Thread-local per {@link com.linkedin.davinci.kafka.consumer.ActiveActiveStoreIngestionTask}. This avoids hot path
+     * allocations but is likely not very efficient, since there can be many AASIT and each will have its own
+     * independent set of objects, even if/when the AASIT becomes dormant. This is the first mode which was built, and
+     * it is considered stable.
+     */
+    THREAD_LOCAL_PER_INGESTION_TASK(new Supplier<IngestionTaskReusableObjects>() {
+      private final ThreadLocal<IngestionTaskReusableObjects> o =
+          ThreadLocal.withInitial(IngestionTaskReusableObjects::new);
+
+      @Override
+      public IngestionTaskReusableObjects get() {
+        return o.get();
+      }
+    }),
+
+    /**
+     * Thread-local per JVM. Likely the most efficient.
+     */
+    SINGLETON_THREAD_LOCAL(() -> IngestionTaskReusableObjects.SINGLETON.get());
+
+    private final Supplier<IngestionTaskReusableObjects> supplier;
+
+    Strategy(Supplier<IngestionTaskReusableObjects> supplier) {
+      this.supplier = supplier;
+    }
+
+    public Supplier<IngestionTaskReusableObjects> supplier() {
+      return this.supplier;
+    }
+  }
+}

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/KafkaStoreIngestionService.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/KafkaStoreIngestionService.java
@@ -18,6 +18,7 @@ import com.linkedin.davinci.config.VeniceConfigLoader;
 import com.linkedin.davinci.config.VeniceServerConfig;
 import com.linkedin.davinci.config.VeniceStoreVersionConfig;
 import com.linkedin.davinci.helix.LeaderFollowerPartitionStateModel;
+import com.linkedin.davinci.ingestion.utils.IngestionTaskReusableObjects;
 import com.linkedin.davinci.listener.response.AdminResponse;
 import com.linkedin.davinci.listener.response.ReplicaIngestionResponse;
 import com.linkedin.davinci.notifier.LogNotifier;
@@ -115,6 +116,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.function.BiConsumer;
 import java.util.function.BooleanSupplier;
+import java.util.function.Supplier;
 import org.apache.avro.Schema;
 import org.apache.helix.manager.zk.ZKHelixAdmin;
 import org.apache.logging.log4j.LogManager;
@@ -478,6 +480,9 @@ public class KafkaStoreIngestionService extends AbstractVeniceService implements
           new AggVersionedDaVinciRecordTransformerStats(metricsRepository, metadataRepo, serverConfig);
     }
 
+    Supplier<IngestionTaskReusableObjects> reusableObjectsSupplier =
+        serverConfig.getIngestionTaskReusableObjectsStrategy().supplier();
+
     ingestionTaskFactory = StoreIngestionTaskFactory.builder()
         .setVeniceWriterFactory(veniceWriterFactory)
         .setStorageMetadataService(storageMetadataService)
@@ -505,6 +510,7 @@ public class KafkaStoreIngestionService extends AbstractVeniceService implements
         .setHeartbeatMonitoringService(heartbeatMonitoringService)
         .setAAWCWorkLoadProcessingThreadPool(aaWCWorkLoadProcessingThreadPool)
         .setAAWCIngestionStorageLookupThreadPool(aaWCIngestionStorageLookupThreadPool)
+        .setReusableObjectsSupplier(reusableObjectsSupplier)
         .build();
   }
 

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTaskFactory.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTaskFactory.java
@@ -4,6 +4,7 @@ import com.linkedin.davinci.client.DaVinciRecordTransformerConfig;
 import com.linkedin.davinci.compression.StorageEngineBackedCompressorFactory;
 import com.linkedin.davinci.config.VeniceServerConfig;
 import com.linkedin.davinci.config.VeniceStoreVersionConfig;
+import com.linkedin.davinci.ingestion.utils.IngestionTaskReusableObjects;
 import com.linkedin.davinci.notifier.VeniceNotifier;
 import com.linkedin.davinci.stats.AggHostLevelIngestionStats;
 import com.linkedin.davinci.stats.AggVersionedDIVStats;
@@ -31,6 +32,7 @@ import java.util.Properties;
 import java.util.Queue;
 import java.util.concurrent.ExecutorService;
 import java.util.function.BooleanSupplier;
+import java.util.function.Supplier;
 import org.apache.helix.manager.zk.ZKHelixAdmin;
 
 
@@ -127,6 +129,7 @@ public class StoreIngestionTaskFactory {
     private Runnable runnableForKillIngestionTasksForNonCurrentVersions;
     private ExecutorService aaWCWorkLoadProcessingThreadPool;
     private ExecutorService aaWCIngestionStorageLookupThreadPool;
+    private Supplier<IngestionTaskReusableObjects> reusableObjectsSupplier;
 
     private interface Setter {
       void apply();
@@ -345,6 +348,14 @@ public class StoreIngestionTaskFactory {
 
     public ExecutorService getAAWCWorkLoadProcessingThreadPool() {
       return this.aaWCWorkLoadProcessingThreadPool;
+    }
+
+    public Builder setReusableObjectsSupplier(Supplier<IngestionTaskReusableObjects> reusableObjectsSupplier) {
+      return set(() -> this.reusableObjectsSupplier = reusableObjectsSupplier);
+    }
+
+    public Supplier<IngestionTaskReusableObjects> getReusableObjectsSupplier() {
+      return this.reusableObjectsSupplier;
     }
   }
 }

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/ActiveActiveStoreIngestionTaskTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/ActiveActiveStoreIngestionTaskTest.java
@@ -26,6 +26,7 @@ import static org.testng.Assert.expectThrows;
 import com.github.luben.zstd.Zstd;
 import com.linkedin.davinci.config.VeniceServerConfig;
 import com.linkedin.davinci.config.VeniceStoreVersionConfig;
+import com.linkedin.davinci.ingestion.utils.IngestionTaskReusableObjects;
 import com.linkedin.davinci.stats.AggHostLevelIngestionStats;
 import com.linkedin.davinci.stats.AggVersionedDIVStats;
 import com.linkedin.davinci.stats.AggVersionedIngestionStats;
@@ -200,8 +201,8 @@ public class ActiveActiveStoreIngestionTaskTest {
     Assert.assertEquals("Hello World", new String(resultByteArray));
   }
 
-  @Test
-  public void testisReadyToServeAnnouncedWithRTLag() {
+  @Test(dataProviderClass = DataProviderUtils.class, dataProvider = "ingestionTaskReusableObjectsStrategy")
+  public void testisReadyToServeAnnouncedWithRTLag(IngestionTaskReusableObjects.Strategy itroStrategy) {
     // Setup store/schema/storage repository
     ReadOnlyStoreRepository readOnlyStoreRepository = mock(ReadOnlyStoreRepository.class);
     ReadOnlySchemaRepository readOnlySchemaRepository = mock(ReadOnlySchemaRepository.class);
@@ -224,6 +225,7 @@ public class ActiveActiveStoreIngestionTaskTest {
     builder.setMetadataRepository(readOnlyStoreRepository);
     builder.setServerConfig(serverConfig);
     builder.setSchemaRepository(readOnlySchemaRepository);
+    builder.setReusableObjectsSupplier(itroStrategy.supplier());
 
     // Set up version config and store config
     HybridStoreConfig hybridStoreConfig =

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/KafkaStoreIngestionServiceTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/KafkaStoreIngestionServiceTest.java
@@ -25,6 +25,7 @@ import com.linkedin.davinci.config.VeniceConfigLoader;
 import com.linkedin.davinci.config.VeniceServerConfig;
 import com.linkedin.davinci.config.VeniceStoreVersionConfig;
 import com.linkedin.davinci.helix.LeaderFollowerPartitionStateModel;
+import com.linkedin.davinci.ingestion.utils.IngestionTaskReusableObjects;
 import com.linkedin.davinci.storage.StorageMetadataService;
 import com.linkedin.davinci.storage.StorageService;
 import com.linkedin.davinci.store.AbstractStorageEngineTest;
@@ -162,6 +163,8 @@ public abstract class KafkaStoreIngestionServiceTest {
     doReturn(30l).when(mockVeniceServerConfig).getKafkaFetchQuotaTimeWindow();
     doReturn(PubSubPositionTypeRegistry.RESERVED_POSITION_TYPE_REGISTRY).when(mockVeniceServerConfig)
         .getPubSubPositionTypeRegistry();
+    doReturn(IngestionTaskReusableObjects.Strategy.SINGLETON_THREAD_LOCAL).when(mockVeniceServerConfig)
+        .getIngestionTaskReusableObjectsStrategy();
 
     VeniceClusterConfig mockVeniceClusterConfig = mock(VeniceClusterConfig.class);
     Properties properties = new Properties();

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTaskTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTaskTest.java
@@ -86,6 +86,7 @@ import com.linkedin.davinci.config.VeniceStoreVersionConfig;
 import com.linkedin.davinci.helix.LeaderFollowerPartitionStateModel;
 import com.linkedin.davinci.helix.StateModelIngestionProgressNotifier;
 import com.linkedin.davinci.ingestion.LagType;
+import com.linkedin.davinci.ingestion.utils.IngestionTaskReusableObjects;
 import com.linkedin.davinci.notifier.LogNotifier;
 import com.linkedin.davinci.notifier.PushStatusNotifier;
 import com.linkedin.davinci.notifier.VeniceNotifier;
@@ -1158,6 +1159,7 @@ public abstract class StoreIngestionTaskTest {
         .setPubSubTopicRepository(pubSubTopicRepository)
         .setPartitionStateSerializer(partitionStateSerializer)
         .setRunnableForKillIngestionTasksForNonCurrentVersions(runnableForKillNonCurrentVersion)
+        .setReusableObjectsSupplier(IngestionTaskReusableObjects.Strategy.SINGLETON_THREAD_LOCAL.supplier())
         .setAAWCWorkLoadProcessingThreadPool(
             Executors.newFixedThreadPool(2, new DaemonThreadFactory("AA_WC_PARALLEL_PROCESSING")))
         .setAAWCIngestionStorageLookupThreadPool(

--- a/internal/venice-common/src/main/java/com/linkedin/venice/ConfigKeys.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/ConfigKeys.java
@@ -2777,4 +2777,11 @@ public class ConfigKeys {
    */
   public static final String SERVER_USE_HEARTBEAT_LAG_FOR_READY_TO_SERVE_CHECK_ENABLED =
       "server.use.heartbeat.lag.for.ready.to.serve.check.enabled";
+
+  /**
+   * The strategy for how to share memory-heavy objects used in the ingestion hot path.
+   */
+  public static final String SERVER_INGESTION_TASK_REUSABLE_OBJECTS_STRATEGY =
+      "server.ingestion.task.reusable.objects.strategy";
+
 }

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/integration/utils/VeniceServerWrapper.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/integration/utils/VeniceServerWrapper.java
@@ -31,6 +31,7 @@ import static com.linkedin.venice.ConfigKeys.SERVER_DELETE_UNASSIGNED_PARTITIONS
 import static com.linkedin.venice.ConfigKeys.SERVER_DISK_FULL_THRESHOLD;
 import static com.linkedin.venice.ConfigKeys.SERVER_HTTP2_INBOUND_ENABLED;
 import static com.linkedin.venice.ConfigKeys.SERVER_INGESTION_HEARTBEAT_INTERVAL_MS;
+import static com.linkedin.venice.ConfigKeys.SERVER_INGESTION_TASK_REUSABLE_OBJECTS_STRATEGY;
 import static com.linkedin.venice.ConfigKeys.SERVER_LEADER_COMPLETE_STATE_CHECK_IN_FOLLOWER_VALID_INTERVAL_MS;
 import static com.linkedin.venice.ConfigKeys.SERVER_MAX_WAIT_FOR_VERSION_INFO_MS_CONFIG;
 import static com.linkedin.venice.ConfigKeys.SERVER_NETTY_GRACEFUL_SHUTDOWN_PERIOD_SECONDS;
@@ -46,6 +47,7 @@ import static com.linkedin.venice.integration.utils.VeniceTwoLayerMultiRegionMul
 import static com.linkedin.venice.meta.PersistenceType.ROCKS_DB;
 
 import com.linkedin.davinci.config.VeniceConfigLoader;
+import com.linkedin.davinci.ingestion.utils.IngestionTaskReusableObjects;
 import com.linkedin.venice.client.store.ClientConfig;
 import com.linkedin.venice.exceptions.VeniceException;
 import com.linkedin.venice.helix.AllowlistAccessor;
@@ -274,6 +276,14 @@ public class VeniceServerWrapper extends ProcessWrapper implements MetricsAware 
           .put(SERVER_RESUBSCRIPTION_TRIGGERED_BY_VERSION_INGESTION_CONTEXT_CHANGE_ENABLED, true)
           .put(ROCKSDB_BLOCK_CACHE_SIZE_IN_BYTES, 512 * 1024 * 1024L)
           .put(ROCKSDB_RMD_BLOCK_CACHE_SIZE_IN_BYTES, 128 * 1024 * 1024L)
+
+          /**
+           * Experimental mode... overriding the main code default to take it through its paces in integration tests.
+           * TODO: Remove this override once this is certified to become the new main code default.
+           */
+          .put(
+              SERVER_INGESTION_TASK_REUSABLE_OBJECTS_STRATEGY,
+              IngestionTaskReusableObjects.Strategy.SINGLETON_THREAD_LOCAL)
           .put(SERVER_DELETE_UNASSIGNED_PARTITIONS_ON_STARTUP, serverDeleteUnassignedPartitionsOnStartup);
       if (sslToKafka) {
         serverPropsBuilder.put(PUBSUB_SECURITY_PROTOCOL_LEGACY, PubSubSecurityProtocol.SSL.name());

--- a/internal/venice-test-common/src/main/java/com/linkedin/venice/utils/DataProviderUtils.java
+++ b/internal/venice-test-common/src/main/java/com/linkedin/venice/utils/DataProviderUtils.java
@@ -6,6 +6,7 @@ import static com.linkedin.venice.compression.CompressionStrategy.ZSTD_WITH_DICT
 
 import com.linkedin.avroutil1.compatibility.AvroCompatibilityHelper;
 import com.linkedin.davinci.client.DaVinciConfig;
+import com.linkedin.davinci.ingestion.utils.IngestionTaskReusableObjects;
 import com.linkedin.davinci.kafka.consumer.KafkaConsumerService;
 import com.linkedin.davinci.store.cache.backend.ObjectCacheConfig;
 import com.linkedin.venice.kafka.validation.checksum.CheckSumType;
@@ -156,6 +157,11 @@ public class DataProviderUtils {
   @DataProvider(name = "sharedConsumerStrategy")
   public static Object[][] sharedConsumerStrategy() {
     return allPermutationGenerator(KafkaConsumerService.ConsumerAssignmentStrategy.values());
+  }
+
+  @DataProvider(name = "ingestionTaskReusableObjectsStrategy")
+  public static Object[][] ingestionTaskReusableObjectsStrategy() {
+    return allPermutationGenerator(IngestionTaskReusableObjects.Strategy.values());
   }
 
   /**

--- a/internal/venice-test-common/src/main/java/com/linkedin/venice/utils/TestUtils.java
+++ b/internal/venice-test-common/src/main/java/com/linkedin/venice/utils/TestUtils.java
@@ -18,6 +18,7 @@ import static org.testng.Assert.assertTrue;
 
 import com.github.luben.zstd.Zstd;
 import com.linkedin.davinci.config.VeniceServerConfig;
+import com.linkedin.davinci.ingestion.utils.IngestionTaskReusableObjects;
 import com.linkedin.davinci.kafka.consumer.AggKafkaConsumerService;
 import com.linkedin.davinci.kafka.consumer.StoreBufferService;
 import com.linkedin.davinci.kafka.consumer.StoreIngestionTaskFactory;
@@ -903,6 +904,7 @@ public class TestUtils {
         .setServerConfig(mock(VeniceServerConfig.class))
         .setServerConfig(mockVeniceServerConfig)
         .setPartitionStateSerializer(mock(InternalAvroSpecificSerializer.class))
+        .setReusableObjectsSupplier(IngestionTaskReusableObjects.Strategy.SINGLETON_THREAD_LOCAL.supplier())
         .setIsDaVinciClient(false);
   }
 


### PR DESCRIPTION
The AASIT hangs on to a private property of thread-local type, where each instance can contain a 1 MB blob. When there are lots of AASIT instances, accessed from lots of ingestion threads, this can add up to a lot of big thread-local state.

In a production heap dump with 191 AASIT instances, 51% of all bytes were occupied by byte[] (though not all of them came from this particular AASIT field).

With this commit, the default behavior is the same as before, but a new config allows passing an enum to select alternative behaviors:

server.ingestion.task.reusable.objects.strategy

And the valid values are:

- NO_REUSE: will pass null into the relevant code paths, which will result in new objects getting allocated on the fly, and needing to be garbage collected.

- THREAD_LOCAL_PER_INGESTION_TASK: This avoids hot path allocations but is likely not very efficient , since there can be many AASIT and each will have its own independent set of objects, even if/when the AASIT becomes dormant. This is the first mode which was built, and it is considered stable.

- SINGLETON_THREAD_LOCAL: Likely the most efficient.

Test changes:

- Integration tests override this setting to SINGLETON_THREAD_LOCAL.

###  Code changes
- [x] Added new code behind **a config**. If so list the config names and their default values in the PR description.
- [ ] Introduced new **log lines**. 
  - [ ] Confirmed if logs need to be **rate limited** to avoid excessive logging.

###  **Concurrency-Specific Checks**
Both reviewer and PR author to verify
- [x] Code has **no race conditions** or **thread safety issues**.
- [x] Proper **synchronization mechanisms** (e.g., `synchronized`, `RWLock`) are used where needed.
- [x] No **blocking calls** inside critical sections that could lead to deadlocks or performance degradation.
- [x] Verified **thread-safe collections** are used (e.g., `ConcurrentHashMap`, `CopyOnWriteArrayList`).
- [x] Validated proper exception handling in multi-threaded code to avoid silent thread termination.


## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->

- [ ] New unit tests added.
- [ ] New integration tests added.
- [x] Modified or extended existing tests.
- [x] Verified backward compatibility (if applicable).

## Does this PR introduce any user-facing or breaking changes?
<!--  
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [ ] No. You can skip the rest of this section.
- [x] Yes. Clearly explain the behavior change and its impact.

New opt-in server config, as described above.