### PR TITLE
[controller][server] Deprecated the Helix Message Channel

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/config/VeniceServerConfig.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/config/VeniceServerConfig.java
@@ -1091,9 +1091,10 @@ public class VeniceServerConfig extends VeniceClusterConfig {
     deleteUnassignedPartitionsOnStartup =
         serverProperties.getBoolean(SERVER_DELETE_UNASSIGNED_PARTITIONS_ON_STARTUP, false);
     aclInMemoryCacheTTLMs = serverProperties.getInt(ACL_IN_MEMORY_CACHE_TTL_MS, -1); // acl caching is disabled by
+                                                                                     // default
     aaWCIngestionStorageLookupThreadPoolSize =
         serverProperties.getInt(SERVER_AA_WC_INGESTION_STORAGE_LOOKUP_THREAD_POOL_SIZE, 4);
-    this.isParticipantMessageStoreEnabled = serverProperties.getBoolean(PARTICIPANT_MESSAGE_STORE_ENABLED, false);
+    this.isParticipantMessageStoreEnabled = serverProperties.getBoolean(PARTICIPANT_MESSAGE_STORE_ENABLED, true);
     idleIngestionTaskCleanupIntervalInSeconds =
         serverProperties.getInt(SERVER_IDLE_INGESTION_TASK_CLEANUP_INTERVAL_IN_SECONDS, -1);
     useHeartbeatLagForReadyToServeCheckEnabled =

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/KafkaStoreIngestionService.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/KafkaStoreIngestionService.java
@@ -555,6 +555,9 @@ public class KafkaStoreIngestionService extends AbstractVeniceService implements
       participantStoreConsumerExecutorService = Executors.newSingleThreadExecutor(
           new DaemonThreadFactory("ParticipantStoreConsumptionTask", serverConfig.getRegionName()));
       participantStoreConsumerExecutorService.submit(participantStoreConsumptionTask);
+      LOGGER.info("{} submitted.", ParticipantStoreConsumptionTask.class.getSimpleName());
+    } else {
+      LOGGER.info("{} is disabled.", ParticipantStoreConsumptionTask.class.getSimpleName());
     }
     final int idleIngestionTaskCleanupIntervalInSeconds = serverConfig.getIdleIngestionTaskCleanupIntervalInSeconds();
     if (idleStoreIngestionTaskKillerExecutor != null) {
@@ -585,7 +588,9 @@ public class KafkaStoreIngestionService extends AbstractVeniceService implements
       try {
         return versionNumber == metadataRepo.getStoreOrThrow(storeName).getCurrentVersion();
       } catch (VeniceNoStoreException e) {
-        LOGGER.warn("Unable to find store meta-data for {}", veniceStoreVersionConfig.getStoreVersionName(), e);
+        LOGGER.warn(
+            "Unable to find store meta-data for {}. Will return that current version is false.",
+            veniceStoreVersionConfig.getStoreVersionName());
         return false;
       }
     };

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/ParticipantStoreConsumptionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/ParticipantStoreConsumptionTask.java
@@ -1,7 +1,6 @@
 package com.linkedin.davinci.kafka.consumer;
 
 import com.linkedin.davinci.stats.ParticipantStoreConsumptionStats;
-import com.linkedin.venice.client.store.AvroGenericStoreClient;
 import com.linkedin.venice.client.store.AvroSpecificStoreClient;
 import com.linkedin.venice.client.store.ClientConfig;
 import com.linkedin.venice.client.store.ClientFactory;
@@ -15,11 +14,15 @@ import com.linkedin.venice.participant.protocol.enums.ParticipantMessageType;
 import com.linkedin.venice.service.ICProvider;
 import com.linkedin.venice.utils.ExceptionUtils;
 import com.linkedin.venice.utils.RedundantExceptionFilter;
+import com.linkedin.venice.utils.SystemTime;
+import com.linkedin.venice.utils.Time;
+import com.linkedin.venice.utils.Utils;
 import com.linkedin.venice.utils.concurrent.VeniceConcurrentHashMap;
 import java.io.Closeable;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Function;
 import org.apache.commons.lang3.Validate;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -41,6 +44,8 @@ public class ParticipantStoreConsumptionTask implements Runnable, Closeable {
   private final Map<String, AvroSpecificStoreClient<ParticipantMessageKey, ParticipantMessageValue>> clientMap =
       new VeniceConcurrentHashMap<>();
   private final ICProvider icProvider;
+  private final Function<ClientConfig<ParticipantMessageValue>, AvroSpecificStoreClient<ParticipantMessageKey, ParticipantMessageValue>> clientConstructor;
+  private final Time time;
 
   public ParticipantStoreConsumptionTask(
       StoreIngestionService storeIngestionService,
@@ -49,12 +54,39 @@ public class ParticipantStoreConsumptionTask implements Runnable, Closeable {
       ClientConfig<ParticipantMessageValue> clientConfig,
       long participantMessageConsumptionDelayMs,
       ICProvider icProvider) {
+    this(
+        storeIngestionService,
+        clusterInfoProvider,
+        stats,
+        clientConfig,
+        participantMessageConsumptionDelayMs,
+        icProvider,
+        ClientFactory::getAndStartSpecificAvroClient,
+        SystemTime.INSTANCE);
+  }
+
+  /** Test constructor */
+  ParticipantStoreConsumptionTask(
+      StoreIngestionService storeIngestionService,
+      ClusterInfoProvider clusterInfoProvider,
+      ParticipantStoreConsumptionStats stats,
+      ClientConfig<ParticipantMessageValue> clientConfig,
+      long participantMessageConsumptionDelayMs,
+      ICProvider icProvider,
+      Function<ClientConfig<ParticipantMessageValue>, AvroSpecificStoreClient<ParticipantMessageKey, ParticipantMessageValue>> clientConstructor,
+      Time time) {
     this.stats = Validate.notNull(stats);
     this.storeIngestionService = Validate.notNull(storeIngestionService);
     this.clusterInfoProvider = Validate.notNull(clusterInfoProvider);
     this.clientConfig = Validate.notNull(clientConfig);
     this.participantMessageConsumptionDelayMs = participantMessageConsumptionDelayMs;
     this.icProvider = icProvider;
+    this.clientConstructor = clientConstructor;
+    this.time = time;
+    LOGGER.info(
+        "{} constructed with participantMessageConsumptionDelayMs: {}.",
+        getClass().getSimpleName(),
+        this.participantMessageConsumptionDelayMs);
   }
 
   @Override
@@ -63,7 +95,7 @@ public class ParticipantStoreConsumptionTask implements Runnable, Closeable {
     while (!isClosing.get() && !Thread.currentThread().isInterrupted()) {
       stats.recordHeartbeat();
       try {
-        Thread.sleep(participantMessageConsumptionDelayMs);
+        this.time.sleep(participantMessageConsumptionDelayMs);
 
         for (String topic: storeIngestionService.getIngestingTopicsWithVersionStatusNotOnline()) {
           try {
@@ -72,6 +104,12 @@ public class ParticipantStoreConsumptionTask implements Runnable, Closeable {
             key.resourceName = topic;
             String clusterName = clusterInfoProvider.getVeniceCluster(Version.parseStoreFromKafkaTopicName(topic));
             if (clusterName == null) {
+              if (LOGGER.isWarnEnabled()) {
+                String msg = "Cluster name not found for topic " + topic;
+                if (!EXCEPTION_FILTER.isRedundantException(msg)) {
+                  LOGGER.warn(msg);
+                }
+              }
               continue;
             }
 
@@ -84,19 +122,32 @@ public class ParticipantStoreConsumptionTask implements Runnable, Closeable {
               value = getParticipantStoreClient(clusterName).get(key).get();
             }
 
-            if (value != null && value.messageType == ParticipantMessageType.KILL_PUSH_JOB.getValue()) {
+            if (value == null) {
+              continue;
+            }
+
+            if (value.messageType == ParticipantMessageType.KILL_PUSH_JOB.getValue()) {
               KillPushJob killPushJobMessage = (KillPushJob) value.messageUnion;
+              long lag = this.time.getMilliseconds() - killPushJobMessage.getTimestamp();
               LOGGER.info(
                   "Terminating ingestion task for store-version: {} in cluster: {}. KILL signal timestamp: {}, message age: {}ms.",
                   topic,
                   clusterName,
                   killPushJobMessage.getTimestamp(),
-                  System.currentTimeMillis() - killPushJobMessage.getTimestamp());
+                  lag);
               if (storeIngestionService.killConsumptionTask(topic)) {
                 // emit metrics only when a confirmed kill is made
                 stats.recordKilledPushJobs();
-                stats.recordKillPushJobLatency(Long.max(0, System.currentTimeMillis() - killPushJobMessage.timestamp));
+                stats.recordKillPushJobLatency(Long.max(0, lag));
+              } else {
+                LOGGER.warn(
+                    "Failed to kill Consumption for topic: {}, timestamp: {}",
+                    topic,
+                    killPushJobMessage.getTimestamp());
               }
+            } else {
+              // Should never happen... so this is basically just defensive code.
+              LOGGER.warn("Got an unexpected record from the Participant Store: {}", value);
             }
           } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
@@ -134,24 +185,30 @@ public class ParticipantStoreConsumptionTask implements Runnable, Closeable {
 
   private AvroSpecificStoreClient<ParticipantMessageKey, ParticipantMessageValue> getParticipantStoreClient(
       String clusterName) {
+    AvroSpecificStoreClient<ParticipantMessageKey, ParticipantMessageValue> client;
     try {
-      clientMap.computeIfAbsent(clusterName, k -> {
+      client = clientMap.computeIfAbsent(clusterName, k -> {
         ClientConfig<ParticipantMessageValue> newClientConfig = ClientConfig.cloneConfig(clientConfig)
             .setStoreName(VeniceSystemStoreUtils.getParticipantStoreNameForCluster(clusterName))
             .setSpecificValueClass(ParticipantMessageValue.class)
             .setStatsPrefix(CLIENT_STATS_PREFIX);
-        return ClientFactory.getAndStartSpecificAvroClient(newClientConfig);
+        return this.clientConstructor.apply(newClientConfig);
       });
+      if (client == null) {
+        throw new NullPointerException("Got a null client out of the constructor function!");
+      }
+      return client;
     } catch (Exception e) {
       stats.recordFailedInitialization();
       LOGGER.error("Failed to get participant client for cluster: {}", clusterName, e);
+      throw e;
     }
-    return clientMap.get(clusterName);
   }
 
   @Override
   public void close() {
     isClosing.set(true);
-    clientMap.values().forEach(AvroGenericStoreClient::close);
+    clientMap.values().forEach(Utils::closeQuietlyWithErrorLogged);
+    LOGGER.info("Closed {}", getClass().getSimpleName());
   }
 }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/ParticipantStoreConsumptionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/ParticipantStoreConsumptionTask.java
@@ -20,6 +20,7 @@ import com.linkedin.venice.utils.Utils;
 import com.linkedin.venice.utils.concurrent.VeniceConcurrentHashMap;
 import java.io.Closeable;
 import java.util.Map;
+import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Function;
@@ -195,10 +196,7 @@ public class ParticipantStoreConsumptionTask implements Runnable, Closeable {
             .setStatsPrefix(CLIENT_STATS_PREFIX);
         return this.clientConstructor.apply(newClientConfig);
       });
-      if (client == null) {
-        throw new NullPointerException("Got a null client out of the constructor function!");
-      }
-      return client;
+      return Objects.requireNonNull(client, "Got a null client out of the constructor function!");
     } catch (Exception e) {
       stats.recordFailedInitialization();
       LOGGER.error("Failed to get participant client for cluster: {}", clusterName, e);

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
@@ -4653,6 +4653,7 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
    */
   public boolean isTransientRecordBufferUsed(PartitionConsumptionState partitionConsumptionState) {
     return this.isWriteComputationEnabled && partitionConsumptionState.isEndOfPushReceived();
+    // && !this.isDataRecovery; TODO: Decide if this extra condition is useful...
   }
 
   // Visible for unit test.

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/HostLevelIngestionStats.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/HostLevelIngestionStats.java
@@ -490,7 +490,19 @@ public class HostLevelIngestionStats extends AbstractVeniceStats {
     if (isTotalStats()) {
       return (i1, i2) -> sitMap.values().stream().mapToLong(total).sum();
     }
-    return (i1, i2) -> individual.applyAsLong(sitMap.get(storeName));
+
+    return (i1, i2) -> {
+      StoreIngestionTask sit = sitMap.get(storeName);
+      if (sit == null) {
+        /**
+         * N.B.: For the metrics we currently support, 0 is a sensible fallback in cases where the SIT is not found,
+         *       but if new cases emerge where that would not be desirable, we could make this configurable so that
+         *       the caller can specify some {@link StatsErrorCode} instead...
+         */
+        return 0;
+      }
+      return individual.applyAsLong(sit);
+    };
   }
 
   private Measurable measurable(Map<String, StoreIngestionTask> m, String s, ToLongFunction<StoreIngestionTask> f) {

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/config/VeniceServerConfigTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/config/VeniceServerConfigTest.java
@@ -178,14 +178,19 @@ public class VeniceServerConfigTest {
     assertEquals(config1.getIngestionMemoryLimit(), 20 * 1024 * 1024l);
   }
 
+  // TODO: Delete this test once we fully delete the HelixMessagingChannel.
   @Test
   public void testParticipantStoreConfigs() {
     Properties props = populatedBasicProperties();
     VeniceServerConfig config = new VeniceServerConfig(new VeniceProperties(props));
-    assertFalse(config.isParticipantMessageStoreEnabled());
+    assertTrue(config.isParticipantMessageStoreEnabled());
 
     props.put(PARTICIPANT_MESSAGE_STORE_ENABLED, "true");
     config = new VeniceServerConfig(new VeniceProperties(props));
     assertTrue(config.isParticipantMessageStoreEnabled());
+
+    props.put(PARTICIPANT_MESSAGE_STORE_ENABLED, "false");
+    config = new VeniceServerConfig(new VeniceProperties(props));
+    assertFalse(config.isParticipantMessageStoreEnabled());
   }
 }

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/ParticipantStoreConsumptionTaskTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/ParticipantStoreConsumptionTaskTest.java
@@ -1,0 +1,189 @@
+package com.linkedin.davinci.kafka.consumer;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyDouble;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.timeout;
+import static org.mockito.Mockito.verify;
+
+import com.linkedin.davinci.stats.ParticipantStoreConsumptionStats;
+import com.linkedin.util.clock.Time;
+import com.linkedin.venice.client.store.AvroSpecificStoreClient;
+import com.linkedin.venice.client.store.ClientConfig;
+import com.linkedin.venice.meta.ClusterInfoProvider;
+import com.linkedin.venice.participant.protocol.KillPushJob;
+import com.linkedin.venice.participant.protocol.ParticipantMessageKey;
+import com.linkedin.venice.participant.protocol.ParticipantMessageValue;
+import com.linkedin.venice.participant.protocol.enums.ParticipantMessageType;
+import com.linkedin.venice.utils.SleepStallingMockTime;
+import com.linkedin.venice.utils.Utils;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.function.Function;
+import org.testng.annotations.Test;
+
+
+public class ParticipantStoreConsumptionTaskTest {
+  private static final long WAIT = 1 * Time.MS_PER_SECOND;
+  private static final long EXPECTED_LAG = 100;
+  private static final String CLIENT_CTOR_EXPLANATION =
+      "The clientConstructor should not be called more than 3 times, since it failed twice and succeeded once, after which the result should be cached.";
+  private SleepStallingMockTime mockTime = new SleepStallingMockTime();
+  private long participantMessageConsumptionDelayMs = 1;
+  private int iterations;
+
+  @Test
+  public void testOverallRunFlow() throws InterruptedException {
+    StoreIngestionService storeIngestionService = mock(StoreIngestionService.class);
+    ClusterInfoProvider clusterInfoProvider = mock(ClusterInfoProvider.class);
+    ParticipantStoreConsumptionStats stats = mock(ParticipantStoreConsumptionStats.class);
+    ClientConfig<ParticipantMessageValue> clientConfig = mock(ClientConfig.class);
+    Function<ClientConfig<ParticipantMessageValue>, AvroSpecificStoreClient<ParticipantMessageKey, ParticipantMessageValue>> clientConstructor =
+        mock(Function.class);
+    AvroSpecificStoreClient<ParticipantMessageKey, ParticipantMessageValue> client =
+        mock(AvroSpecificStoreClient.class);
+    doReturn(CompletableFuture.completedFuture(null)).when(client).get(any());
+
+    String clusterName = "venice-0";
+    Set<String> ingestingStoreVersions = new HashSet<>();
+    String storeName = Utils.getUniqueString("participantStoreTest");
+    String v1 = storeName + "_v1";
+    String v2 = storeName + "_v2";
+    ingestingStoreVersions.add(v1);
+    ingestingStoreVersions.add(v2);
+    doReturn(ingestingStoreVersions).when(storeIngestionService).getIngestingTopicsWithVersionStatusNotOnline();
+
+    ParticipantStoreConsumptionTask task = new ParticipantStoreConsumptionTask(
+        storeIngestionService,
+        clusterInfoProvider,
+        stats,
+        clientConfig,
+        participantMessageConsumptionDelayMs,
+        null,
+        clientConstructor,
+        mockTime);
+    CompletableFuture.runAsync(task);
+
+    // Stalled on the first sleep, none of the mocks should be called yet.
+    iterations = 0;
+    verify(storeIngestionService, never()).getIngestingTopicsWithVersionStatusNotOnline();
+    verify(clusterInfoProvider, never()).getVeniceCluster(any());
+    verify(clientConstructor, never()).apply(any());
+    verify(client, never()).get(any());
+    verify(stats, timeout(WAIT).times(iterations + 1)).recordHeartbeat();
+    verify(stats, never()).recordFailedInitialization();
+    verify(stats, never()).recordKillPushJobFailedConsumption();
+    verify(stats, never()).recordKilledPushJobs();
+    verify(stats, never()).recordKillPushJobLatency(anyDouble());
+    verify(storeIngestionService, never()).killConsumptionTask(any());
+
+    // 1st sleep
+    iterate();
+    verify(storeIngestionService, timeout(WAIT).times(iterations)).getIngestingTopicsWithVersionStatusNotOnline();
+    // N.B. This one still returns null
+    verify(clusterInfoProvider, timeout(WAIT).times(iterations * 2)).getVeniceCluster(storeName);
+    verify(clientConstructor, never()).apply(any());
+    verify(client, never()).get(any());
+    verify(stats, timeout(WAIT).times(iterations + 1)).recordHeartbeat();
+    verify(stats, never()).recordFailedInitialization();
+    verify(stats, never()).recordKillPushJobFailedConsumption();
+    verify(stats, never()).recordKilledPushJobs();
+    verify(stats, never()).recordKillPushJobLatency(anyDouble());
+    verify(storeIngestionService, never()).killConsumptionTask(any());
+
+    // 2nd sleep, after setting up the return of the clusterInfoProvider
+    doReturn(clusterName).when(clusterInfoProvider).getVeniceCluster(storeName);
+    iterate();
+    verify(storeIngestionService, timeout(WAIT).times(iterations)).getIngestingTopicsWithVersionStatusNotOnline();
+    verify(clusterInfoProvider, timeout(WAIT).times(iterations * 2)).getVeniceCluster(storeName);
+    verify(clientConstructor, timeout(WAIT).times(2)).apply(any()); // N.B. This one still returns null
+    verify(client, never()).get(any());
+    verify(stats, timeout(WAIT).times(iterations + 1)).recordHeartbeat();
+    verify(stats, timeout(WAIT).times(2)).recordFailedInitialization();
+    verify(stats, timeout(WAIT).times(2)).recordKillPushJobFailedConsumption();
+    verify(stats, never()).recordKilledPushJobs();
+    verify(stats, never()).recordKillPushJobLatency(anyDouble());
+    verify(storeIngestionService, never()).killConsumptionTask(any());
+
+    // 3rd sleep, after setting up the return of the clientConstructor
+    doReturn(client).when(clientConstructor).apply(any());
+    iterate();
+    verify(storeIngestionService, timeout(WAIT).times(iterations)).getIngestingTopicsWithVersionStatusNotOnline();
+    verify(clusterInfoProvider, timeout(WAIT).times(iterations * 2)).getVeniceCluster(storeName);
+    verify(clientConstructor, timeout(WAIT).times(3).description(CLIENT_CTOR_EXPLANATION)).apply(any());
+    // N.B. This one still returns a completed CF containing null
+    verify(client, timeout(WAIT).times((iterations - 2) * 2)).get(any());
+    verify(stats, timeout(WAIT).times(iterations + 1)).recordHeartbeat();
+    verify(stats, timeout(WAIT).times(2)).recordFailedInitialization();
+    verify(stats, timeout(WAIT).times(2)).recordKillPushJobFailedConsumption();
+    verify(stats, never()).recordKilledPushJobs();
+    verify(stats, never()).recordKillPushJobLatency(anyDouble());
+    verify(storeIngestionService, never()).killConsumptionTask(any());
+
+    // 4th sleep, after making the client return something invalid
+    ParticipantMessageKey key = new ParticipantMessageKey();
+    key.setMessageType(ParticipantMessageType.KILL_PUSH_JOB.getValue());
+    key.setResourceName(v1);
+    ParticipantMessageValue value = new ParticipantMessageValue();
+    value.setMessageType(-1); // invalid
+    doReturn(CompletableFuture.completedFuture(value)).when(client).get(key);
+    iterate();
+    verify(storeIngestionService, timeout(WAIT).times(iterations)).getIngestingTopicsWithVersionStatusNotOnline();
+    verify(clusterInfoProvider, timeout(WAIT).times(iterations * 2)).getVeniceCluster(storeName);
+    verify(clientConstructor, timeout(WAIT).times(3).description(CLIENT_CTOR_EXPLANATION)).apply(any());
+    verify(client, timeout(WAIT).times((iterations - 2) * 2)).get(any());
+    verify(stats, timeout(WAIT).times(iterations + 1)).recordHeartbeat();
+    verify(stats, timeout(WAIT).times(2)).recordFailedInitialization();
+    verify(stats, timeout(WAIT).times(2)).recordKillPushJobFailedConsumption();
+    verify(stats, never()).recordKilledPushJobs();
+    verify(stats, never()).recordKillPushJobLatency(anyDouble());
+    verify(storeIngestionService, never()).killConsumptionTask(any());
+
+    // 5th sleep, after making the client return something valid
+    value = new ParticipantMessageValue();
+    value.setMessageType(ParticipantMessageType.KILL_PUSH_JOB.getValue());
+    KillPushJob killPushJobMessage = new KillPushJob();
+    killPushJobMessage.setTimestamp(this.mockTime.getMilliseconds() - EXPECTED_LAG);
+    value.setMessageUnion(killPushJobMessage);
+    doReturn(CompletableFuture.completedFuture(value)).when(client).get(key);
+    iterate();
+    verify(storeIngestionService, timeout(WAIT).times(iterations)).getIngestingTopicsWithVersionStatusNotOnline();
+    verify(clusterInfoProvider, timeout(WAIT).times(iterations * 2)).getVeniceCluster(storeName);
+    verify(clientConstructor, timeout(WAIT).times(3).description(CLIENT_CTOR_EXPLANATION)).apply(any());
+    verify(client, timeout(WAIT).times((iterations - 2) * 2)).get(any());
+    verify(stats, timeout(WAIT).times(iterations + 1)).recordHeartbeat();
+    verify(stats, timeout(WAIT).times(2)).recordFailedInitialization();
+    verify(stats, timeout(WAIT).times(2)).recordKillPushJobFailedConsumption();
+    verify(stats, never()).recordKilledPushJobs();
+    verify(stats, never()).recordKillPushJobLatency(anyDouble());
+    verify(storeIngestionService, timeout(WAIT).times(1)).killConsumptionTask(v1);
+    verify(storeIngestionService, never()).killConsumptionTask(v2);
+
+    // 6th sleep, after making the client return something valid and succeeding to kill the job (finally!)
+    doReturn(true).when(storeIngestionService).killConsumptionTask(v1);
+    iterate();
+    verify(storeIngestionService, timeout(WAIT).times(iterations)).getIngestingTopicsWithVersionStatusNotOnline();
+    verify(clusterInfoProvider, timeout(WAIT).times(iterations * 2)).getVeniceCluster(storeName);
+    verify(clientConstructor, timeout(WAIT).times(3).description(CLIENT_CTOR_EXPLANATION)).apply(any());
+    verify(client, timeout(WAIT).times((iterations - 2) * 2)).get(any());
+    verify(stats, timeout(WAIT).times(iterations + 1)).recordHeartbeat();
+    verify(stats, timeout(WAIT).times(2)).recordFailedInitialization();
+    verify(stats, timeout(WAIT).times(2)).recordKillPushJobFailedConsumption();
+    verify(stats, timeout(WAIT).times(1)).recordKilledPushJobs();
+    // +2 because we created the message two iterations ago...
+    verify(stats, timeout(WAIT).times(1)).recordKillPushJobLatency(EXPECTED_LAG + 2);
+    verify(storeIngestionService, timeout(WAIT).times(2)).killConsumptionTask(v1);
+    verify(storeIngestionService, never()).killConsumptionTask(v2);
+
+    task.close();
+    verify(client, timeout(WAIT).times(1)).close();
+  }
+
+  private void iterate() {
+    iterations++;
+    mockTime.advanceTime(participantMessageConsumptionDelayMs);
+  }
+}

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/store/rocksdb/RocksDBStoragePartitionTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/store/rocksdb/RocksDBStoragePartitionTest.java
@@ -259,6 +259,10 @@ public class RocksDBStoragePartitionTest {
     removeDir(storeDir);
   }
 
+  /**
+   * This test takes way too long... both per-permutation and because there are so many permutations.
+   * TODO: Speed it up, or else refactor the permutations into several subclasses so they can run concurrently.
+   */
   @Test(dataProvider = "Six-True-and-False", dataProviderClass = DataProviderUtils.class)
   public void testIngestion(
       boolean sorted,
@@ -277,6 +281,7 @@ public class RocksDBStoragePartitionTest {
     options.setCreateIfMissing(true);
 
     int padding = 100;
+    // TODO: decide if we really need this many records? this might be the cause of the slowness...
     int numberOfRecords = 101000;
     Map<String, String> inputRecords = generateInput(numberOfRecords, sorted, padding);
     Properties extraProps = new Properties();

--- a/internal/venice-common/src/main/java/com/linkedin/venice/ConfigKeys.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/ConfigKeys.java
@@ -1653,11 +1653,6 @@ public class ConfigKeys {
   public static final String CONTROLLER_EARLY_DELETE_BACKUP_ENABLED = "controller.early.delete.backup.enabled";
 
   /**
-   * Flag to indicate which push monitor controller will pick up for an upcoming push
-   */
-  public static final String PUSH_MONITOR_TYPE = "push.monitor.type";
-
-  /**
    * Flag to enable the participant message store setup and write operations to the store.
    */
   public static final String PARTICIPANT_MESSAGE_STORE_ENABLED = "participant.message.store.enabled";
@@ -1679,6 +1674,7 @@ public class ConfigKeys {
    * Flag to enable the controller to send kill push job helix messages to the storage node upon consuming kill push job
    * admin messages.
    */
+  @Deprecated
   public static final String ADMIN_HELIX_MESSAGING_CHANNEL_ENABLED = "admin.helix.messaging.channel.enabled";
 
   /**

--- a/internal/venice-common/src/main/java/com/linkedin/venice/helix/HelixCustomizedViewOfflinePushRepository.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/helix/HelixCustomizedViewOfflinePushRepository.java
@@ -190,10 +190,10 @@ public class HelixCustomizedViewOfflinePushRepository extends HelixBaseRoutingRe
           this.liveInstancesMap = Collections.unmodifiableMap(liveInstanceSnapshot);
         }
         updates = resourceAssignment.updateResourceAssignment(newResourceAssignment);
-        LOGGER.info("Updated resource assignment and live instances for .");
       }
       LOGGER.info(
-          "Customized view is changed. The number of active resources is {}, and the deleted resources are {}.",
+          "Customized view is changed: {}. The number of active resources is {}, and the deleted resources are {}.",
+          updates,
           resourcesInCustomizedView.size(),
           updates.getDeletedResource());
       // Notify listeners that listen on customized view data change

--- a/internal/venice-common/src/main/java/com/linkedin/venice/helix/HelixExternalViewRepository.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/helix/HelixExternalViewRepository.java
@@ -154,9 +154,8 @@ public class HelixExternalViewRepository extends HelixBaseRoutingRepository impl
         this.liveInstancesMap = Collections.unmodifiableMap(liveInstanceSnapshot);
       }
       updates = resourceAssignment.updateResourceAssignment(newResourceAssignment);
-      LOGGER.info("Updated resource assignment and live instances.");
     }
-    LOGGER.info("External view is changed.");
+    LOGGER.info("External view is changed: {}", updates);
     // Start sending notification to listeners. As we can not get the changed data only from Helix, so we just notify
     // all listeners.
     // And assume that the listener would compare and decide how to handle this event.

--- a/internal/venice-common/src/main/java/com/linkedin/venice/helix/HelixStatusMessageChannel.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/helix/HelixStatusMessageChannel.java
@@ -31,6 +31,7 @@ import org.apache.logging.log4j.Logger;
  * Only one Helix message type is used, so channel is similar to a dispatcher that receive all of control messages and
  * dispatch them to related handlers.
  */
+@Deprecated
 public class HelixStatusMessageChannel implements StatusMessageChannel {
   private static final Logger LOGGER = LogManager.getLogger(HelixStatusMessageChannel.class);
 

--- a/internal/venice-common/src/main/java/com/linkedin/venice/helix/ResourceAssignment.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/helix/ResourceAssignment.java
@@ -127,5 +127,11 @@ public class ResourceAssignment {
     public Set<String> getNewResources() {
       return newResources;
     }
+
+    @Override
+    public String toString() {
+      return ResourceAssignmentChanges.class.getSimpleName() + " { " + deletedResources.size() + " deleted, "
+          + updatedResources.size() + " updated, " + newResources.size() + " created }";
+    }
   }
 }

--- a/internal/venice-common/src/main/java/com/linkedin/venice/stats/HelixMessageChannelStats.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/stats/HelixMessageChannelStats.java
@@ -6,6 +6,7 @@ import io.tehuti.metrics.stats.Count;
 import io.tehuti.metrics.stats.Total;
 
 
+@Deprecated
 public class HelixMessageChannelStats extends AbstractVeniceStats {
   private static final String NAME_SUFFIX = "-helix_message_channel";
   /**

--- a/internal/venice-common/src/main/java/com/linkedin/venice/stats/StatsErrorCode.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/stats/StatsErrorCode.java
@@ -148,11 +148,6 @@ public enum StatsErrorCode {
   KAFKA_CLIENT_METRICS_DEFAULT(-24),
 
   /**
-   * There was an exception when retrieving a metric value.  Please consult application logs to determine the root cause!
-   */
-  UNKNOWN_METRIC_EXCEPTION(-25),
-
-  /**
    * This metric should not be emitted as it is a metric specific to an A/A store.
    */
   ACTIVE_ACTIVE_NOT_ENABLED(-25);

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/controller/TestEnablingSSLPushInVeniceHelixAdminWithIsolatedEnvironment.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/controller/TestEnablingSSLPushInVeniceHelixAdminWithIsolatedEnvironment.java
@@ -24,12 +24,12 @@ public class TestEnablingSSLPushInVeniceHelixAdminWithIsolatedEnvironment extend
 
   @BeforeMethod(alwaysRun = true)
   public void setUp() throws Exception {
-    setupCluster(false, new MetricsRepository());
+    setupCluster(new MetricsRepository());
   }
 
   @AfterMethod(alwaysRun = true)
   public void cleanUp() {
-    cleanupCluster();
+    super.cleanUp();
   }
 
   @Override

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/controller/TestTopicRequestOnHybridDeleteWithHMC.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/controller/TestTopicRequestOnHybridDeleteWithHMC.java
@@ -1,0 +1,9 @@
+package com.linkedin.venice.controller;
+
+@Deprecated
+public class TestTopicRequestOnHybridDeleteWithHMC extends TestTopicRequestOnHybridDelete {
+  @Override
+  protected boolean enableHelixMessagingChannel() {
+    return true;
+  }
+}

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/controller/TestVeniceHelixAdminWithIsolatedEnvironment.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/controller/TestVeniceHelixAdminWithIsolatedEnvironment.java
@@ -46,12 +46,12 @@ public class TestVeniceHelixAdminWithIsolatedEnvironment extends AbstractTestVen
 
   @BeforeMethod(alwaysRun = true)
   public void setUp() throws Exception {
-    setupCluster(false, new MetricsRepository());
+    setupCluster(new MetricsRepository());
   }
 
   @AfterMethod(alwaysRun = true)
   public void cleanUp() {
-    cleanupCluster();
+    super.cleanUp();
   }
 
   @Test(timeOut = TOTAL_TIMEOUT_FOR_LONG_TEST_MS)

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/controller/TestVeniceHelixAdminWithSharedEnvironment.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/controller/TestVeniceHelixAdminWithSharedEnvironment.java
@@ -78,9 +78,6 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.Properties;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import org.apache.avro.Schema;
@@ -108,16 +105,12 @@ public class TestVeniceHelixAdminWithSharedEnvironment extends AbstractTestVenic
 
   @BeforeClass(alwaysRun = true)
   public void setUp() throws Exception {
-    setupCluster(true, metricsRepository);
+    setupCluster(metricsRepository);
   }
 
   @AfterClass(alwaysRun = true)
   public void cleanUp() {
-    // Controller shutdown needs to complete within 5 minutes
-    ExecutorService ex = Executors.newSingleThreadExecutor();
-    Future clusterShutdownFuture = ex.submit(this::cleanupCluster);
-    TestUtils.waitForNonDeterministicCompletion(5, TimeUnit.MINUTES, clusterShutdownFuture::isDone);
-    ex.shutdownNow();
+    super.cleanUp();
   }
 
   @Test(timeOut = TOTAL_TIMEOUT_FOR_SHORT_TEST_MS)

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/DataRecoveryTest.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/DataRecoveryTest.java
@@ -1,12 +1,10 @@
 package com.linkedin.venice.endToEnd;
 
 import static com.linkedin.davinci.store.rocksdb.RocksDBServerConfig.ROCKSDB_PLAIN_TABLE_FORMAT_ENABLED;
-import static com.linkedin.venice.ConfigKeys.ADMIN_HELIX_MESSAGING_CHANNEL_ENABLED;
 import static com.linkedin.venice.ConfigKeys.ALLOW_CLUSTER_WIPE;
 import static com.linkedin.venice.ConfigKeys.MIN_NUMBER_OF_UNUSED_KAFKA_TOPICS_TO_PRESERVE;
 import static com.linkedin.venice.ConfigKeys.NATIVE_REPLICATION_SOURCE_FABRIC;
 import static com.linkedin.venice.ConfigKeys.PARENT_KAFKA_CLUSTER_FABRIC_LIST;
-import static com.linkedin.venice.ConfigKeys.PARTICIPANT_MESSAGE_STORE_ENABLED;
 import static com.linkedin.venice.ConfigKeys.SERVER_DATABASE_CHECKSUM_VERIFICATION_ENABLED;
 import static com.linkedin.venice.ConfigKeys.SERVER_DATABASE_SYNC_BYTES_INTERNAL_FOR_DEFERRED_WRITE_MODE;
 import static com.linkedin.venice.ConfigKeys.TOPIC_CLEANUP_SLEEP_INTERVAL_BETWEEN_TOPIC_LIST_FETCH_MS;
@@ -79,8 +77,6 @@ public class DataRecoveryTest {
     controllerProps.put(ALLOW_CLUSTER_WIPE, "true");
     controllerProps.put(TOPIC_CLEANUP_SLEEP_INTERVAL_BETWEEN_TOPIC_LIST_FETCH_MS, "1000");
     controllerProps.put(MIN_NUMBER_OF_UNUSED_KAFKA_TOPICS_TO_PRESERVE, "0");
-    controllerProps.put(ADMIN_HELIX_MESSAGING_CHANNEL_ENABLED, Boolean.FALSE.toString());
-    controllerProps.put(PARTICIPANT_MESSAGE_STORE_ENABLED, Boolean.TRUE.toString());
     VeniceMultiRegionClusterCreateOptions.Builder optionsBuilder =
         new VeniceMultiRegionClusterCreateOptions.Builder().numberOfRegions(NUMBER_OF_CHILD_DATACENTERS)
             .numberOfClusters(NUMBER_OF_CLUSTERS)

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/MetaSystemStoreTest.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/MetaSystemStoreTest.java
@@ -111,7 +111,7 @@ public class MetaSystemStoreTest {
     Utils.closeQuietlyWithErrorLogged(venice);
   }
 
-  @Test(timeOut = 60 * Time.MS_PER_SECOND)
+  @Test(timeOut = 120 * Time.MS_PER_SECOND)
   public void bootstrapMetaSystemStore() throws ExecutionException, InterruptedException {
     // Create a new regular store.
     String regularVeniceStoreName = Utils.getUniqueString("venice_store");
@@ -130,7 +130,7 @@ public class MetaSystemStoreTest {
     TestUtils.waitForNonDeterministicPushCompletion(
         versionCreationResponse.getKafkaTopic(),
         parentControllerClient,
-        10,
+        20,
         TimeUnit.SECONDS);
     String metaSystemStoreName = VeniceSystemStoreType.META_STORE.getSystemStoreName(regularVeniceStoreName);
 
@@ -244,7 +244,7 @@ public class MetaSystemStoreTest {
     /**
      * Wait for the RT topic deletion.
      */
-    TestUtils.waitForNonDeterministicAssertion(30, TimeUnit.SECONDS, () -> {
+    TestUtils.waitForNonDeterministicAssertion(60, TimeUnit.SECONDS, () -> {
       ControllerResponse response = controllerClient.checkResourceCleanupForStoreCreation(metaSystemStoreName);
       if (response.isError()) {
         fail("The store cleanup for meta system store: " + metaSystemStoreName + " is not done yet");

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/PartialUpdateTest.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/PartialUpdateTest.java
@@ -195,7 +195,6 @@ public class PartialUpdateTest {
         Boolean.toString(isHeartbeatReadyToServeCheckEnabled()));
     Properties controllerProps = new Properties();
     controllerProps.put(ConfigKeys.CONTROLLER_AUTO_MATERIALIZE_META_SYSTEM_STORE, true);
-    controllerProps.put(ConfigKeys.PARTICIPANT_MESSAGE_STORE_ENABLED, false);
     VeniceMultiRegionClusterCreateOptions.Builder optionsBuilder =
         new VeniceMultiRegionClusterCreateOptions.Builder().numberOfRegions(NUMBER_OF_CHILD_DATACENTERS)
             .numberOfClusters(NUMBER_OF_CLUSTERS)

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/ParticipantStoreTest.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/ParticipantStoreTest.java
@@ -21,8 +21,6 @@ import com.linkedin.venice.integration.utils.VeniceMultiRegionClusterCreateOptio
 import com.linkedin.venice.integration.utils.VeniceRouterWrapper;
 import com.linkedin.venice.integration.utils.VeniceServerWrapper;
 import com.linkedin.venice.integration.utils.VeniceTwoLayerMultiRegionMultiClusterWrapper;
-import com.linkedin.venice.meta.Store;
-import com.linkedin.venice.meta.StoreDataChangedListener;
 import com.linkedin.venice.meta.StoreInfo;
 import com.linkedin.venice.meta.Version;
 import com.linkedin.venice.meta.VersionStatus;
@@ -37,7 +35,6 @@ import io.tehuti.Metric;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicInteger;
 import org.apache.commons.io.IOUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -90,7 +87,7 @@ public class ParticipantStoreTest {
     IOUtils.closeQuietly(venice);
   }
 
-  // @Test(timeOut = 60 * Time.MS_PER_SECOND)
+  @Test(timeOut = 60 * Time.MS_PER_SECOND)
   // TODO: killed_push_jobs_count seems to be a broken metric in L/F (at least for participant stores)
   public void testParticipantStoreKill() {
     VersionCreationResponse versionCreationResponse = getNewStoreVersion(parentControllerClient, true);
@@ -112,22 +109,26 @@ public class ParticipantStoreTest {
     ControllerResponse response = parentControllerClient.killOfflinePushJob(topicName);
     assertFalse(response.isError());
     verifyKillMessageInParticipantStore(topicName, true);
+    String requestMetricExample =
+        VeniceSystemStoreUtils.getParticipantStoreNameForCluster(clusterName) + "--success_request_key_count.Avg";
     TestUtils.waitForNonDeterministicAssertion(30, TimeUnit.SECONDS, true, () -> {
       // Poll job status to verify the job is indeed killed
       assertEquals(controllerClient.queryJobStatus(topicName).getStatus(), ExecutionStatus.ERROR.toString());
+
+      // Verify participant store consumption stats
+      // (not sure why these are flaky, but they are, so we're putting them in the non-deterministic assertion loop...)
+      Map<String, ? extends Metric> metrics =
+          veniceLocalCluster.getVeniceServers().iterator().next().getMetricsRepository().metrics();
+      assertEquals(getMetric(metrics, metricPrefix + "--killed_push_jobs.Count").value(), 1.0);
+      assertTrue(getMetric(metrics, metricPrefix + "--kill_push_job_latency.Avg").value() > 0);
+      assertTrue(getMetric(metrics, ".venice-client_" + requestMetricExample).value() > 0);
     });
-    // Verify participant store consumption stats
-    String requestMetricExample =
-        VeniceSystemStoreUtils.getParticipantStoreNameForCluster(clusterName) + "--success_request_key_count.Avg";
-    Map<String, ? extends Metric> metrics =
-        veniceLocalCluster.getVeniceServers().iterator().next().getMetricsRepository().metrics();
-    assertEquals(metrics.get(metricPrefix + "--killed_push_jobs.Count").value(), 1.0);
-    assertTrue(metrics.get(metricPrefix + "--kill_push_job_latency.Avg").value() > 0);
-    // One from the server stats and the other from the client stats.
-    assertTrue(metrics.get("." + requestMetricExample).value() > 0);
-    // "." will be replaced by "_" in AbstractVeniceStats constructor to ensure Tahuti is able to parse metric name by
-    // ".".
-    assertTrue(metrics.get(".venice-client_" + requestMetricExample).value() > 0);
+  }
+
+  private static Metric getMetric(Map<String, ? extends Metric> metrics, String name) {
+    Metric metric = metrics.get(name);
+    assertNotNull(metric, "Metric '" + name + "' was not found!");
+    return metric;
   }
 
   @Test(timeOut = 60 * Time.MS_PER_SECOND)
@@ -249,40 +250,6 @@ public class ParticipantStoreTest {
     parentControllerClient
         .deleteOldVersion(storeName, Version.parseVersionFromKafkaTopicName(topicNameForOnlineVersion));
     verifyKillMessageInParticipantStore(topicNameForOnlineVersion, true);
-  }
-
-  static class TestListener implements StoreDataChangedListener {
-    AtomicInteger creationCount = new AtomicInteger(0);
-    AtomicInteger changeCount = new AtomicInteger(0);
-    AtomicInteger deletionCount = new AtomicInteger(0);
-
-    @Override
-    public void handleStoreCreated(Store store) {
-      creationCount.incrementAndGet();
-    }
-
-    @Override
-    public void handleStoreDeleted(String storeName) {
-      deletionCount.incrementAndGet();
-    }
-
-    @Override
-    public void handleStoreChanged(Store store) {
-      LOGGER.info("Received handleStoreChanged: {}", store);
-      changeCount.incrementAndGet();
-    }
-
-    public int getCreationCount() {
-      return creationCount.get();
-    }
-
-    public int getChangeCount() {
-      return changeCount.get();
-    }
-
-    public int getDeletionCount() {
-      return deletionCount.get();
-    }
   }
 
   private void verifyKillMessageInParticipantStore(String topic, boolean shouldPresent) {

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestProducerBatching.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestProducerBatching.java
@@ -81,7 +81,6 @@ public class TestProducerBatching {
         KafkaConsumerServiceDelegator.ConsumerPoolStrategyType.CURRENT_VERSION_PRIORITIZATION.name());
     Properties controllerProps = new Properties();
     controllerProps.put(ConfigKeys.CONTROLLER_AUTO_MATERIALIZE_META_SYSTEM_STORE, true);
-    controllerProps.put(ConfigKeys.PARTICIPANT_MESSAGE_STORE_ENABLED, false);
     VeniceMultiRegionClusterCreateOptions.Builder optionsBuilder =
         new VeniceMultiRegionClusterCreateOptions.Builder().numberOfRegions(NUMBER_OF_CHILD_DATACENTERS)
             .numberOfClusters(NUMBER_OF_CLUSTERS)

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/fastclient/grpc/VeniceGrpcEndToEndTest.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/fastclient/grpc/VeniceGrpcEndToEndTest.java
@@ -2,7 +2,6 @@ package com.linkedin.venice.fastclient.grpc;
 
 import static com.linkedin.venice.ConfigKeys.CONTROLLER_AUTO_MATERIALIZE_META_SYSTEM_STORE;
 import static com.linkedin.venice.ConfigKeys.GRPC_SERVER_WORKER_THREAD_COUNT;
-import static com.linkedin.venice.ConfigKeys.PARTICIPANT_MESSAGE_STORE_ENABLED;
 import static com.linkedin.venice.ConfigKeys.SERVER_HTTP2_INBOUND_ENABLED;
 import static com.linkedin.venice.ConfigKeys.SERVER_QUOTA_ENFORCEMENT_ENABLED;
 
@@ -65,7 +64,6 @@ public class VeniceGrpcEndToEndTest {
     Utils.thisIsLocalhost();
 
     Properties props = new Properties();
-    props.setProperty(PARTICIPANT_MESSAGE_STORE_ENABLED, "false");
     props.setProperty(CONTROLLER_AUTO_MATERIALIZE_META_SYSTEM_STORE, "true");
     props.put(SERVER_HTTP2_INBOUND_ENABLED, "true");
     props.put(SERVER_QUOTA_ENFORCEMENT_ENABLED, "true");

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/integration/utils/IntegrationTestUtils.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/integration/utils/IntegrationTestUtils.java
@@ -6,12 +6,24 @@ import static com.linkedin.venice.ConfigKeys.KAFKA_BOOTSTRAP_SERVERS;
 import static com.linkedin.venice.ConfigKeys.KAFKA_LINGER_MS;
 import static com.linkedin.venice.ConfigKeys.PERSISTENCE_TYPE;
 import static com.linkedin.venice.ConfigKeys.ZOOKEEPER_ADDRESS;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
 
+import com.linkedin.venice.common.VeniceSystemStoreUtils;
+import com.linkedin.venice.controller.VeniceHelixAdmin;
 import com.linkedin.venice.helix.ZkClientFactory;
 import com.linkedin.venice.meta.PersistenceType;
+import com.linkedin.venice.meta.Store;
+import com.linkedin.venice.pubsub.PubSubTopicRepository;
+import com.linkedin.venice.pubsub.api.PubSubTopic;
+import com.linkedin.venice.pubsub.manager.TopicManager;
 import com.linkedin.venice.utils.PropertyBuilder;
+import com.linkedin.venice.utils.TestUtils;
 import com.linkedin.venice.utils.Time;
+import com.linkedin.venice.utils.Utils;
 import com.linkedin.venice.utils.VeniceProperties;
+import java.util.concurrent.TimeUnit;
 import org.apache.helix.zookeeper.impl.client.ZkClient;
 import org.apache.zookeeper.CreateMode;
 
@@ -61,5 +73,25 @@ public class IntegrationTestUtils {
     if (!zkClient.exists(zkBasePath)) {
       zkClient.create(zkBasePath, null, CreateMode.PERSISTENT);
     }
+  }
+
+  /**
+   * Participant store should be set up by child controller.
+   */
+  public static void verifyParticipantMessageStoreSetup(
+      VeniceHelixAdmin veniceAdmin,
+      String clusterName,
+      PubSubTopicRepository pubSubTopicRepository) {
+    TopicManager topicManager = veniceAdmin.getTopicManager();
+    String participantStoreName = VeniceSystemStoreUtils.getParticipantStoreNameForCluster(clusterName);
+    PubSubTopic participantStoreRt = pubSubTopicRepository.getTopic(Utils.composeRealTimeTopic(participantStoreName));
+    TestUtils.waitForNonDeterministicAssertion(15, TimeUnit.SECONDS, () -> {
+      Store store = veniceAdmin.getStore(clusterName, participantStoreName);
+      assertNotNull(store);
+      assertEquals(store.getVersions().size(), 1);
+    });
+    TestUtils.waitForNonDeterministicAssertion(60, TimeUnit.SECONDS, () -> {
+      assertTrue(topicManager.containsTopic(participantStoreRt));
+    });
   }
 }

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/router/TestRead.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/router/TestRead.java
@@ -161,7 +161,6 @@ public abstract class TestRead {
     extraProperties.put(ConfigKeys.ROUTER_CLIENT_IP_SPOOFING_CHECK_ENABLED, isRouterClientIPSpoofingCheckEnabled());
     extraProperties.put(ConfigKeys.SERVER_HTTP2_INBOUND_ENABLED, true);
     extraProperties.put(ConfigKeys.ROUTER_PER_STORE_ROUTER_QUOTA_BUFFER, 0.0);
-    extraProperties.put(ConfigKeys.PARTICIPANT_MESSAGE_STORE_ENABLED, false);
 
     VeniceClusterCreateOptions options = new VeniceClusterCreateOptions.Builder().numberOfControllers(1)
         .numberOfServers(1)
@@ -286,7 +285,8 @@ public abstract class TestRead {
       return;
     }
 
-    double maxInflightRequestCount = getAggregateRouterMetricValue(".total--in_flight_request_count.Max");
+    double maxInflightRequestCount =
+        getAggregateRouterMetricValue("." + this.storeName + "--in_flight_request_count.Max");
     Assert.assertEquals(maxInflightRequestCount, 0.0, "There should be no in-flight requests yet!");
 
     String UNKNOWN_FIELD_NAME = "unknown_field";
@@ -342,18 +342,18 @@ public abstract class TestRead {
         }
 
         double maxInflightRequestCountAfterQueries =
-            getAggregateRouterMetricValue(".total--in_flight_request_count.Max");
+            getAggregateRouterMetricValue("." + this.storeName + "--in_flight_request_count.Max");
         Assert.assertTrue(maxInflightRequestCountAfterQueries > 0.0, "There should be in-flight requests now!");
 
         // Check retry requests
         Assert.assertTrue(
-            getAggregateRouterMetricValue(".total--retry_count.LambdaStat") > 0,
+            getAggregateRouterMetricValue("." + this.storeName + "--retry_count.LambdaStat") > 0,
             "After " + rounds + " reads, there should be some single-get retry requests");
         Assert.assertTrue(
-            getAggregateRouterMetricValue(".total--retry_delay.Avg") > 0,
+            getAggregateRouterMetricValue("." + this.storeName + "--retry_delay.Avg") > 0,
             "After " + rounds + " reads, there should be some single-get retry requests");
         Assert.assertTrue(
-            getAggregateRouterMetricValue(".total--multiget_streaming_retry_count.LambdaStat") > 0,
+            getAggregateRouterMetricValue("." + this.storeName + "--multiget_streaming_retry_count.LambdaStat") > 0,
             "After " + rounds + " reads, there should be some batch-get retry requests");
 
         // Check Router connection pool metrics
@@ -405,9 +405,12 @@ public abstract class TestRead {
         // 1. We do MAX_KEY_LIMIT * 2 because we do a batch get and a batch compute
         // 2. And then + 2 because we also do two single get requests
         expectedLookupCount += rounds * (MAX_KEY_LIMIT * 2 + 2.0);
-        Assert.assertEquals(getAggregateRouterMetricValue(".total--request_usage.Total"), expectedLookupCount, 0.0001);
         Assert.assertEquals(
-            getAggregateRouterMetricValue(".total--read_quota_usage_kps.Total"),
+            getAggregateRouterMetricValue("." + this.storeName + "--request_usage.Total"),
+            expectedLookupCount,
+            0.0001);
+        Assert.assertEquals(
+            getAggregateRouterMetricValue("." + this.storeName + "--read_quota_usage_kps.Total"),
             expectedLookupCount,
             0.0001);
 
@@ -415,26 +418,29 @@ public abstract class TestRead {
         if (!isRouterHttp2ClientEnabled()) {
           if (readComputeEnabled) {
             Assert.assertTrue(
-                getMaxServerMetricValue(".total--compute_storage_engine_read_compute_efficiency.Max") > 1.0);
-            Assert.assertEquals(getAggregateRouterMetricValue(".total--compute_multiget_fallback.Total"), 0.0);
+                getMaxServerMetricValue(
+                    "." + this.storeName + "--compute_storage_engine_read_compute_efficiency.Max") > 1.0);
             Assert.assertEquals(
-                clientMetrics.getMetric("." + storeName + "--compute_streaming_multiget_fallback.OccurrenceRate")
+                getAggregateRouterMetricValue("." + this.storeName + "--compute_multiget_fallback.Total"),
+                0.0);
+            Assert.assertEquals(
+                clientMetrics.getMetric("." + this.storeName + "--compute_streaming_multiget_fallback.OccurrenceRate")
                     .value(),
                 0.0);
           } else {
             Assert.assertEquals(
-                getAggregateRouterMetricValue(".total--compute_multiget_fallback.Total"),
+                getAggregateRouterMetricValue("." + this.storeName + "--compute_multiget_fallback.Total"),
                 (double) MAX_KEY_LIMIT);
             Assert.assertTrue(
-                clientMetrics.getMetric("." + storeName + "--compute_streaming_multiget_fallback.OccurrenceRate")
+                clientMetrics.getMetric("." + this.storeName + "--compute_streaming_multiget_fallback.OccurrenceRate")
                     .value() > 0);
           }
         }
 
         // Verify storage node metrics
-        Assert.assertTrue(getMaxServerMetricValue(".total--records_consumed.Rate") > 0.0);
-        Assert.assertTrue(getMaxServerMetricValue(".total--multiget_request_size_in_bytes.Max") > 0.0);
-        Assert.assertTrue(getMaxServerMetricValue(".total--compute_request_size_in_bytes.Max") > 0.0);
+        Assert.assertTrue(getMaxServerMetricValue("." + this.storeName + "--records_consumed.Rate") > 0.0);
+        Assert.assertTrue(getMaxServerMetricValue("." + this.storeName + "--multiget_request_size_in_bytes.Max") > 0.0);
+        Assert.assertTrue(getMaxServerMetricValue("." + this.storeName + "--compute_request_size_in_bytes.Max") > 0.0);
 
         for (VeniceServerWrapper veniceServerWrapper: veniceCluster.getVeniceServers()) {
           Map<String, ? extends Metric> metrics = veniceServerWrapper.getMetricsRepository().metrics();
@@ -464,7 +470,8 @@ public abstract class TestRead {
         storeClient.batchGet(keySet).get();
         fail("Should receive exception since the batch request key count exceeds cluster-level threshold");
       } catch (Exception e) {
-        double unhealthyRequestCount = getAggregateRouterMetricValue(".total--multiget_unhealthy_request.Count");
+        double unhealthyRequestCount =
+            getAggregateRouterMetricValue("." + this.storeName + "--multiget_unhealthy_request.Count");
         Assert.assertEquals(unhealthyRequestCount, 0.0, "There should not be any unhealthy requests!");
         LOGGER.info(e);
       }
@@ -481,14 +488,15 @@ public abstract class TestRead {
       });
 
       // Single get quota test
-      int throttledRequestsForSingleGet = (int) getAggregateRouterMetricValue(".total--throttled_request.Count");
+      int throttledRequestsForSingleGet =
+          (int) getAggregateRouterMetricValue("." + this.storeName + "--throttled_request.Count");
       Assert.assertEquals(
           throttledRequestsForSingleGet,
           0,
           "The throttled_request metric should be at zero before the test.");
 
       double throttledRequestLatencyForSingleGet =
-          getAggregateRouterMetricValue(".total--throttled_request_latency.Max");
+          getAggregateRouterMetricValue("." + this.storeName + "--throttled_request_latency.Max");
       Assert.assertEquals(
           throttledRequestLatencyForSingleGet,
           0.0,
@@ -517,13 +525,13 @@ public abstract class TestRead {
               + numberOfRequests + " requests)");
 
       int throttledRequestsForSingleGetAfterQueries =
-          (int) getAggregateRouterMetricValue(".total--throttled_request.Count");
+          (int) getAggregateRouterMetricValue("." + this.storeName + "--throttled_request.Count");
       Assert.assertEquals(
           throttledRequestsForSingleGetAfterQueries,
           quotaExceptionsCount,
           "The throttled_request metric is inconsistent with the number of quota exceptions received by the client!");
 
-      getAggregateRouterMetricValue(".total--throttled_request_latency.Max");
+      getAggregateRouterMetricValue("." + this.storeName + "--throttled_request_latency.Max");
       /** TODO Re-enable this assertion once we stop throwing batch get quota exceptions from {@link com.linkedin.venice.router.api.VeniceDelegateMode} */
       // Assert.assertTrue(throttledRequestLatencyForSingleGetAfterQueries > 0.0, "There should be single get throttled
       // request latency now!");
@@ -531,14 +539,14 @@ public abstract class TestRead {
       // Batch get quota test
 
       int throttledRequestsForBatchGet =
-          (int) getAggregateRouterMetricValue(".total--multiget_throttled_request.Count");
+          (int) getAggregateRouterMetricValue("." + this.storeName + "--multiget_throttled_request.Count");
       Assert.assertEquals(
           throttledRequestsForBatchGet,
           0,
           "The throttled_request metric should be at zero before the test.");
 
       double throttledRequestLatencyForBatchGet =
-          getAggregateRouterMetricValue(".total--multiget_throttled_request_latency.Max");
+          getAggregateRouterMetricValue("." + this.storeName + "--multiget_throttled_request_latency.Max");
       Assert.assertEquals(
           throttledRequestLatencyForBatchGet,
           0.0,
@@ -591,13 +599,13 @@ public abstract class TestRead {
               + " ms for " + numberOfRequests + " requests)");
 
       int throttledRequestsForBatchGetAfterQueries =
-          (int) getAggregateRouterMetricValue(".total--multiget_streaming_throttled_request.Count");
+          (int) getAggregateRouterMetricValue("." + this.storeName + "--multiget_streaming_throttled_request.Count");
       Assert.assertEquals(
           throttledRequestsForBatchGetAfterQueries,
           quotaExceptionsCountForBatchGet,
           "The throttled_request metric is inconsistent with the number of quota exceptions received by the client!");
 
-      getAggregateRouterMetricValue(".total--multiget_throttled_request_latency.Max");
+      getAggregateRouterMetricValue("." + this.storeName + "--multiget_throttled_request_latency.Max");
       veniceCluster.stopAndRestartAllVeniceRouters();
       for (VeniceRouterWrapper routerWrapper: veniceCluster.getVeniceRouters()) {
         Assert.assertEquals(routerWrapper.getRouter().getInFlightRequestRate(), 0.0);

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/router/TestRetryQuotaRejection.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/router/TestRetryQuotaRejection.java
@@ -1,6 +1,5 @@
 package com.linkedin.venice.router;
 
-import static com.linkedin.venice.ConfigKeys.PARTICIPANT_MESSAGE_STORE_ENABLED;
 import static com.linkedin.venice.ConfigKeys.ROUTER_ENABLE_READ_THROTTLING;
 import static com.linkedin.venice.ConfigKeys.SERVER_QUOTA_ENFORCEMENT_ENABLED;
 import static org.testng.Assert.assertEquals;
@@ -85,7 +84,6 @@ public class TestRetryQuotaRejection {
     extraProperties.put(ConfigKeys.ROUTER_STORAGE_NODE_CLIENT_TYPE, StorageNodeClientType.APACHE_HTTP_ASYNC_CLIENT);
     extraProperties.put(ROUTER_ENABLE_READ_THROTTLING, false);
     extraProperties.put(SERVER_QUOTA_ENFORCEMENT_ENABLED, "true");
-    extraProperties.put(PARTICIPANT_MESSAGE_STORE_ENABLED, "false");
 
     veniceCluster = ServiceFactory.getVeniceCluster(
         new VeniceClusterCreateOptions.Builder().numberOfControllers(1)

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/storagenode/StorageNodeComputeTest.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/storagenode/StorageNodeComputeTest.java
@@ -284,7 +284,7 @@ public class StorageNodeComputeTest {
   /**
    * The goal of this test is to find the breaking point at which a compute request gets split into more than 1 part.
    */
-  @Test(timeOut = 30000, groups = { "flaky" })
+  @Test(timeOut = 30000, enabled = false, groups = { "flaky" })
   public void testComputeRequestSize() throws Exception {
     UpdateStoreQueryParams params = new UpdateStoreQueryParams();
     params.setReadComputationEnabled(true);

--- a/internal/venice-test-common/src/main/java/com/linkedin/venice/utils/SleepStallingMockTime.java
+++ b/internal/venice-test-common/src/main/java/com/linkedin/venice/utils/SleepStallingMockTime.java
@@ -1,0 +1,55 @@
+package com.linkedin.venice.utils;
+
+public class SleepStallingMockTime implements Time {
+  private static final double INITIAL_WAIT_TIME = 0.1;
+  private volatile long currentTimeMillis;
+  private double waitTime = INITIAL_WAIT_TIME;
+
+  public SleepStallingMockTime() {
+    this.currentTimeMillis = System.currentTimeMillis();
+  }
+
+  public SleepStallingMockTime(long currentTimeMillis) {
+    this.currentTimeMillis = currentTimeMillis;
+  }
+
+  @Override
+  public long getMilliseconds() {
+    return this.currentTimeMillis;
+  }
+
+  @Override
+  public long getNanoseconds() {
+    return this.currentTimeMillis * Time.NS_PER_MS;
+  }
+
+  @Override
+  public void sleep(long ms) throws InterruptedException {
+    long endTime = this.currentTimeMillis + ms;
+    while (this.currentTimeMillis < endTime) {
+      /**
+       * A simple adaptive mutex... it will spin for a little while and eventually start sleeping with exponential
+       * backoff, until the condition is met (which will only happen if a sufficiently large amount is passed into
+       * {@link #advanceTime(long)}). The intent is to strike a balance between minimizing test time and CPU overhead.
+       */
+      synchronized (this) {
+        long waitTime = getWaitTime();
+        if (waitTime > 0) {
+          wait(waitTime);
+        }
+      }
+    }
+  }
+
+  private synchronized long getWaitTime() {
+    long currentWaitTime = (long) Math.floor(this.waitTime);
+    this.waitTime *= 2;
+    return currentWaitTime;
+  }
+
+  public synchronized void advanceTime(long ms) {
+    this.currentTimeMillis = this.currentTimeMillis + ms;
+    this.waitTime = INITIAL_WAIT_TIME;
+    notifyAll();
+  }
+}

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceControllerClusterConfig.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceControllerClusterConfig.java
@@ -912,8 +912,8 @@ public class VeniceControllerClusterConfig {
     this.parentControllerMaxErroredTopicNumToKeep = props.getInt(PARENT_CONTROLLER_MAX_ERRORED_TOPIC_NUM_TO_KEEP, 0);
 
     this.pushJobStatusStoreClusterName = props.getString(PUSH_JOB_STATUS_STORE_CLUSTER_NAME, "");
-    this.participantMessageStoreEnabled = props.getBoolean(PARTICIPANT_MESSAGE_STORE_ENABLED, false);
-    this.adminHelixMessagingChannelEnabled = props.getBoolean(ADMIN_HELIX_MESSAGING_CHANNEL_ENABLED, true);
+    this.participantMessageStoreEnabled = props.getBoolean(PARTICIPANT_MESSAGE_STORE_ENABLED, true);
+    this.adminHelixMessagingChannelEnabled = props.getBoolean(ADMIN_HELIX_MESSAGING_CHANNEL_ENABLED, false);
     if (!adminHelixMessagingChannelEnabled && !participantMessageStoreEnabled) {
       throw new VeniceException(
           "Cannot perform kill push job if both " + ADMIN_HELIX_MESSAGING_CHANNEL_ENABLED + " and "

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceHelixAdmin.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceHelixAdmin.java
@@ -219,6 +219,7 @@ import com.linkedin.venice.system.store.MetaStoreWriter;
 import com.linkedin.venice.systemstore.schemas.StoreMetaKey;
 import com.linkedin.venice.systemstore.schemas.StoreMetaValue;
 import com.linkedin.venice.utils.AvroSchemaUtils;
+import com.linkedin.venice.utils.DaemonThreadFactory;
 import com.linkedin.venice.utils.EncodingUtils;
 import com.linkedin.venice.utils.ExceptionUtils;
 import com.linkedin.venice.utils.HelixUtils;
@@ -8077,7 +8078,7 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
   @Override
   public void close() {
     long closeStartTime = System.currentTimeMillis();
-    ExecutorService ex = Executors.newSingleThreadExecutor();
+    ExecutorService ex = Executors.newSingleThreadExecutor(new DaemonThreadFactory("HelixManagerDisconnect"));
     try {
       // This disconnect sometimes hangs... hence why we treat it this way...
       Future helixManagerDisconnectFuture = ex.submit(this.helixManager::disconnect);


### PR DESCRIPTION
The Helix Message Channel is a legacy mechanism for letting the controller send kill job commands to the servers. It has been replaced a long time ago by the Participant Store but the config defaults did not reflect that.

This commit aligns the default config with production best practices. A later commit will delete this code entirely.

Miscellaneous:

- Refactored the flow of the ParticipantStoreConsumptionTask run loop a little bit. Added extensive unit testing for it.

- Refactored the VeniceHelixAdmin::close function so that it cannot hang forever waiting for the HelixManager to disconnect...

- Added a SleepStallingMockTime to help with multi-threaded testing.

###  Code changes
- [ ] Added new code behind **a config**. If so list the config names and their default values in the PR description.
- [x] Introduced new **log lines**. 
  - [x] Confirmed if logs need to be **rate limited** to avoid excessive logging.

###  **Concurrency-Specific Checks**
Both reviewer and PR author to verify
- [x] Code has **no race conditions** or **thread safety issues**.
- [x] Proper **synchronization mechanisms** (e.g., `synchronized`, `RWLock`) are used where needed.
- [x] No **blocking calls** inside critical sections that could lead to deadlocks or performance degradation.
- [x] Verified **thread-safe collections** are used (e.g., `ConcurrentHashMap`, `CopyOnWriteArrayList`).
- [x] Validated proper exception handling in multi-threaded code to avoid silent thread termination.


## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->

- [x] New unit tests added.
- [ ] New integration tests added.
- [x] Modified or extended existing tests.
- [ ] Verified backward compatibility (if applicable).

## Does this PR introduce any user-facing or breaking changes?
<!--  
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Clearly explain the behavior change and its impact.