### PR TITLE
[controller] Emit metric for ONLINE parent version status mismatch

### DIFF
--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestDeferredVersionSwap.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestDeferredVersionSwap.java
@@ -24,6 +24,7 @@ import com.linkedin.venice.client.store.ClientConfig;
 import com.linkedin.venice.client.store.ClientFactory;
 import com.linkedin.venice.client.store.StatTrackingStoreClient;
 import com.linkedin.venice.common.VeniceSystemStoreType;
+import com.linkedin.venice.controller.Admin;
 import com.linkedin.venice.controllerapi.ControllerClient;
 import com.linkedin.venice.controllerapi.ControllerResponse;
 import com.linkedin.venice.controllerapi.StoreResponse;
@@ -36,6 +37,8 @@ import com.linkedin.venice.integration.utils.VeniceClusterWrapper;
 import com.linkedin.venice.integration.utils.VeniceMultiClusterWrapper;
 import com.linkedin.venice.integration.utils.VeniceMultiRegionClusterCreateOptions;
 import com.linkedin.venice.integration.utils.VeniceTwoLayerMultiRegionMultiClusterWrapper;
+import com.linkedin.venice.meta.ReadWriteStoreRepository;
+import com.linkedin.venice.meta.Store;
 import com.linkedin.venice.meta.StoreInfo;
 import com.linkedin.venice.meta.Version;
 import com.linkedin.venice.meta.VersionStatus;
@@ -518,6 +521,89 @@ public class TestDeferredVersionSwap {
       });
 
       client2.close();
+    }
+  }
+
+  @Test(timeOut = TEST_TIMEOUT)
+  public void testDeferredVersionSwapWithParentVersionMismatch() throws IOException {
+    File inputDir = getTempDataDirectory();
+    TestWriteUtils.writeSimpleAvroFileWithStringToV3Schema(inputDir, 100, 100);
+    // Setup job properties
+    String inputDirPath = "file://" + inputDir.getAbsolutePath();
+    String storeName = Utils.getUniqueString("testDeferredVersionSwap");
+    Properties props =
+        IntegrationTestPushUtils.defaultVPJProps(multiRegionMultiClusterWrapper, inputDirPath, storeName);
+    String keySchemaStr = "\"string\"";
+    UpdateStoreQueryParams storeParms = new UpdateStoreQueryParams().setUnusedSchemaDeletionEnabled(true);
+    storeParms.setTargetRegionSwapWaitTime(1);
+    String parentControllerURLs = multiRegionMultiClusterWrapper.getControllerConnectString();
+    Set<String> targetRegionsList = RegionUtils.parseRegionsFilterList(REGION1);
+
+    try (ControllerClient parentControllerClient = new ControllerClient(CLUSTER_NAMES[0], parentControllerURLs)) {
+      createStoreForJob(CLUSTER_NAMES[0], keySchemaStr, NAME_RECORD_V3_SCHEMA.toString(), props, storeParms).close();
+
+      // Start push job with target region push enabled
+      props.put(TARGETED_REGION_PUSH_WITH_DEFERRED_SWAP, true);
+      props.put(TARGETED_REGION_PUSH_LIST, REGION1);
+      IntegrationTestPushUtils.runVPJ(props);
+      TestUtils.waitForNonDeterministicPushCompletion(
+          Version.composeKafkaTopic(storeName, 1),
+          parentControllerClient,
+          30,
+          TimeUnit.SECONDS);
+
+      // Version should only be swapped in the target region
+      TestUtils.waitForNonDeterministicAssertion(1, TimeUnit.MINUTES, () -> {
+        Map<String, Integer> coloVersions =
+            parentControllerClient.getStore(storeName).getStore().getColoToCurrentVersions();
+
+        coloVersions.forEach((colo, version) -> {
+          if (targetRegionsList.contains(colo)) {
+            Assert.assertEquals((int) version, 1);
+          } else {
+            Assert.assertEquals((int) version, 0);
+          }
+        });
+      });
+
+      TestUtils.waitForNonDeterministicAssertion(30, TimeUnit.SECONDS, () -> {
+        StoreInfo parentStore = parentControllerClient.getStore(storeName).getStore();
+        Assert.assertEquals(parentStore.getVersion(1).get().getStatus(), VersionStatus.PUSHED);
+      });
+
+      // Forcibly mark parent version status as ONLINE to confirm that version swap will still happen if non target
+      // regions are not swapped yet
+      Admin admin =
+          multiRegionMultiClusterWrapper.getLeaderParentControllerWithRetries(CLUSTER_NAMES[0]).getVeniceAdmin();
+      ReadWriteStoreRepository storeRepository =
+          admin.getHelixVeniceClusterResources(CLUSTER_NAMES[0]).getStoreMetadataRepository();
+      Store store1 = storeRepository.getStore(storeName);
+      store1.updateVersionStatus(1, VersionStatus.ONLINE);
+      storeRepository.updateStore(store1);
+      TestUtils.waitForNonDeterministicAssertion(30, TimeUnit.SECONDS, () -> {
+        StoreInfo parentStore = parentControllerClient.getStore(storeName).getStore();
+        Assert.assertEquals(parentStore.getVersion(1).get().getStatus(), VersionStatus.ONLINE);
+      });
+
+      // Version should be swapped in all regions
+      TestUtils.waitForNonDeterministicAssertion(2, TimeUnit.MINUTES, () -> {
+        Map<String, Integer> coloVersions =
+            parentControllerClient.getStore(storeName).getStore().getColoToCurrentVersions();
+
+        coloVersions.forEach((colo, version) -> {
+          Assert.assertEquals((int) version, 1);
+        });
+      });
+
+      // Check that child version status is marked as ONLINE if it didn't fail
+      for (VeniceMultiClusterWrapper childDatacenter: childDatacenters) {
+        ControllerClient childControllerClient =
+            new ControllerClient(CLUSTER_NAMES[0], childDatacenter.getControllerConnectString());
+        StoreResponse store = childControllerClient.getStore(storeName);
+        Optional<Version> version = store.getStore().getVersion(1);
+        assertNotNull(version);
+        assertEquals(version.get().getStatus(), VersionStatus.ONLINE);
+      }
     }
   }
 

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/DeferredVersionSwapService.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/DeferredVersionSwapService.java
@@ -22,6 +22,7 @@ import com.linkedin.venice.utils.LatencyUtils;
 import com.linkedin.venice.utils.LogContext;
 import com.linkedin.venice.utils.RedundantExceptionFilter;
 import com.linkedin.venice.utils.RegionUtils;
+import com.linkedin.venice.utils.Utils;
 import java.time.LocalDateTime;
 import java.time.ZoneOffset;
 import java.util.Collections;
@@ -65,8 +66,8 @@ public class DeferredVersionSwapService extends AbstractVeniceService {
   private Set<String> stalledVersionSwapSet = new HashSet<>();
   private Map<String, Integer> failedRollforwardRetryCountMap = new HashMap<>();
   private static final int MAX_ROLL_FORWARD_RETRY_LIMIT = 5;
-  private static final Set<VersionStatus> versionSwapCompletionStatuses = new HashSet<>();
-  private static final Set<VersionStatus> terminalPushVersionStatuses = new HashSet<>();
+  private static final Set<VersionStatus> versionSwapCompletionStatuses = Utils.setOf(ONLINE, PARTIALLY_ONLINE, ERROR);
+  private static final Set<VersionStatus> terminalPushVersionStatuses = Utils.setOf(ONLINE, KILLED);
 
   public DeferredVersionSwapService(
       VeniceParentHelixAdmin admin,
@@ -75,13 +76,6 @@ public class DeferredVersionSwapService extends AbstractVeniceService {
     this.veniceParentHelixAdmin = admin;
     this.veniceControllerMultiClusterConfig = multiClusterConfig;
     this.deferredVersionSwapStats = deferredVersionSwapStats;
-
-    versionSwapCompletionStatuses.add(ONLINE);
-    versionSwapCompletionStatuses.add(PARTIALLY_ONLINE);
-    versionSwapCompletionStatuses.add(ERROR);
-
-    terminalPushVersionStatuses.add(ONLINE);
-    terminalPushVersionStatuses.add(KILLED);
   }
 
   @Override

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/DeferredVersionSwapService.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/DeferredVersionSwapService.java
@@ -1,6 +1,5 @@
 package com.linkedin.venice.controller;
 
-import static com.linkedin.venice.meta.VersionStatus.*;
 import static com.linkedin.venice.meta.VersionStatus.ERROR;
 import static com.linkedin.venice.meta.VersionStatus.KILLED;
 import static com.linkedin.venice.meta.VersionStatus.ONLINE;

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/DeferredVersionSwapService.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/DeferredVersionSwapService.java
@@ -1,6 +1,8 @@
 package com.linkedin.venice.controller;
 
+import static com.linkedin.venice.meta.VersionStatus.*;
 import static com.linkedin.venice.meta.VersionStatus.ERROR;
+import static com.linkedin.venice.meta.VersionStatus.KILLED;
 import static com.linkedin.venice.meta.VersionStatus.ONLINE;
 import static com.linkedin.venice.meta.VersionStatus.PARTIALLY_ONLINE;
 
@@ -253,26 +255,28 @@ public class DeferredVersionSwapService extends AbstractVeniceService {
   }
 
   /**
-   * Checks if the version is online in all target regions
-   * @param targetRegions
+   * Checks if all the regions have a version status
+   * @param regions
    * @param clusterName
    * @param storeName
    * @param targetVersionNum
+   * @param versionStatus
    * @return
    */
-  private boolean isVersionOnlineInRegions(
-      Set<String> targetRegions,
+  private boolean doesRegionsHaveVersionStatus(
+      Set<String> regions,
       String clusterName,
       String storeName,
-      int targetVersionNum) {
-    for (String targetRegion: targetRegions) {
-      Version targetRegionVersion = getVersionFromStoreInRegion(clusterName, targetRegion, storeName, targetVersionNum);
+      int targetVersionNum,
+      Set<VersionStatus> versionStatus) {
+    for (String region: regions) {
+      Version regionVersion = getVersionFromStoreInRegion(clusterName, region, storeName, targetVersionNum);
 
-      if (targetRegionVersion == null) {
+      if (regionVersion == null) {
         return false;
       }
 
-      if (targetRegionVersion.getStatus() != ONLINE && targetRegionVersion.getStatus() != VersionStatus.KILLED) {
+      if (!versionStatus.contains(regionVersion.getStatus())) {
         return false;
       }
     }
@@ -299,24 +303,39 @@ public class DeferredVersionSwapService extends AbstractVeniceService {
     }
 
     // The version could've been manually rolled forward in non target regions. If that is the case, we should check if
-    // we emitted any stalled
-    // metric for it and remove it if so
+    // we emitted any stalled metric for it and remove it if so
+    Set<VersionStatus> versionSwapCompletionStatuses = new HashSet<>();
+    versionSwapCompletionStatuses.add(ONLINE);
+    versionSwapCompletionStatuses.add(PARTIALLY_ONLINE);
+    versionSwapCompletionStatuses.add(ERROR);
+
     if (stalledVersionSwapSet.contains(storeName)) {
-      boolean didPushCompleteInNonTargetRegions =
-          isVersionOnlineInRegions(nonTargetRegions, clusterName, storeName, targetVersion.getNumber());
+      boolean didPushCompleteInNonTargetRegions = doesRegionsHaveVersionStatus(
+          nonTargetRegions,
+          clusterName,
+          storeName,
+          targetVersion.getNumber(),
+          versionSwapCompletionStatuses);
       if (didPushCompleteInNonTargetRegions) {
         stalledVersionSwapSet.remove(storeName);
         deferredVersionSwapStats.recordDeferredVersionSwapStalledVersionSwapSensor(stalledVersionSwapSet.size());
       }
     }
 
+    Set<String> targetRegions = RegionUtils.parseRegionsFilterList(targetRegionsString);
+    Set<VersionStatus> terminalPushVersionStatuses = new HashSet<>();
+    terminalPushVersionStatuses.add(ONLINE);
+    terminalPushVersionStatuses.add(KILLED);
     switch (targetVersion.getStatus()) {
       case STARTED:
         // Because the parent status is updated when we poll for the job status, the parent status will not always be an
         // accurate representation of push status if vpj runs away
-        Set<String> targetRegions = RegionUtils.parseRegionsFilterList(targetRegionsString);
-        boolean didPushCompleteInTargetRegions =
-            isVersionOnlineInRegions(targetRegions, clusterName, storeName, targetVersion.getNumber());
+        boolean didPushCompleteInTargetRegions = doesRegionsHaveVersionStatus(
+            targetRegions,
+            clusterName,
+            storeName,
+            targetVersion.getNumber(),
+            terminalPushVersionStatuses);
         if (didPushCompleteInTargetRegions) {
           deferredVersionSwapStats.recordDeferredVersionSwapParentChildStatusMismatchSensor();
           String message =
@@ -335,6 +354,23 @@ public class DeferredVersionSwapService extends AbstractVeniceService {
       case KILLED:
         logMessageIfNotRedundant("Entering version swap loop for: " + storeName + " on version: " + targetVersionNum);
         return true;
+      case ONLINE:
+        // This should not happen, but if it does, we should still perform a version swap and log a metric for it
+        boolean didVersionSwapCompleteInNonTargetRegions = doesRegionsHaveVersionStatus(
+            nonTargetRegions,
+            clusterName,
+            storeName,
+            targetVersion.getNumber(),
+            versionSwapCompletionStatuses);
+
+        if (!didVersionSwapCompleteInNonTargetRegions) {
+          deferredVersionSwapStats.recordDeferredVersionSwapParentChildStatusMismatchSensor();
+          String message =
+              "Parent status is already ONLINE, but version swap has not happened in the non target regions. "
+                  + "Continuing with deferred swap for store: " + storeName + " for version: " + targetVersionNum;
+          logMessageIfNotRedundant(message);
+          return true;
+        }
     }
 
     return false;

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/DeferredVersionSwapService.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/DeferredVersionSwapService.java
@@ -66,8 +66,9 @@ public class DeferredVersionSwapService extends AbstractVeniceService {
   private Set<String> stalledVersionSwapSet = new HashSet<>();
   private Map<String, Integer> failedRollforwardRetryCountMap = new HashMap<>();
   private static final int MAX_ROLL_FORWARD_RETRY_LIMIT = 5;
-  private static final Set<VersionStatus> versionSwapCompletionStatuses = Utils.setOf(ONLINE, PARTIALLY_ONLINE, ERROR);
-  private static final Set<VersionStatus> terminalPushVersionStatuses = Utils.setOf(ONLINE, KILLED);
+  private static final Set<VersionStatus> VERSION_SWAP_COMPLETION_STATUSES =
+      Utils.setOf(ONLINE, PARTIALLY_ONLINE, ERROR);
+  private static final Set<VersionStatus> TERMINAL_PUSH_VERSION_STATUSES = Utils.setOf(ONLINE, KILLED);
 
   public DeferredVersionSwapService(
       VeniceParentHelixAdmin admin,
@@ -312,7 +313,7 @@ public class DeferredVersionSwapService extends AbstractVeniceService {
           clusterName,
           storeName,
           targetVersion.getNumber(),
-          versionSwapCompletionStatuses);
+          VERSION_SWAP_COMPLETION_STATUSES);
       if (didPushCompleteInNonTargetRegions) {
         stalledVersionSwapSet.remove(storeName);
         deferredVersionSwapStats.recordDeferredVersionSwapStalledVersionSwapSensor(stalledVersionSwapSet.size());
@@ -329,7 +330,7 @@ public class DeferredVersionSwapService extends AbstractVeniceService {
             clusterName,
             storeName,
             targetVersion.getNumber(),
-            terminalPushVersionStatuses);
+            TERMINAL_PUSH_VERSION_STATUSES);
         if (didPushCompleteInTargetRegions) {
           deferredVersionSwapStats.recordDeferredVersionSwapParentChildStatusMismatchSensor();
           String message =
@@ -355,7 +356,7 @@ public class DeferredVersionSwapService extends AbstractVeniceService {
             clusterName,
             storeName,
             targetVersion.getNumber(),
-            versionSwapCompletionStatuses);
+            VERSION_SWAP_COMPLETION_STATUSES);
 
         if (!didVersionSwapCompleteInNonTargetRegions) {
           deferredVersionSwapStats.recordDeferredVersionSwapParentChildStatusMismatchSensor();

--- a/services/venice-controller/src/test/java/com/linkedin/venice/controller/TestDeferredVersionSwapService.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/controller/TestDeferredVersionSwapService.java
@@ -611,4 +611,63 @@ public class TestDeferredVersionSwapService {
       verify(store, atLeast(1)).updateVersionStatus(versionTwo, VersionStatus.PARTIALLY_ONLINE);
     });
   }
+
+  @Test
+  public void testDeferredVersionSwapWithOnlineParent() throws Exception {
+    String storeName = "testStore";
+    Map<Integer, VersionStatus> versions = new HashMap<>();
+    versions.put(versionOne, VersionStatus.ONLINE);
+    versions.put(versionTwo, VersionStatus.ONLINE);
+    Store store = mockStore(versionOne, 1, region1, versions, storeName);
+    doReturn(versionTwo).when(store).getLargestUsedVersionNumber();
+
+    List<Store> storeList = new ArrayList<>();
+    storeList.add(store);
+    doReturn(storeList).when(admin).getAllStores(clusterName);
+    doReturn(true).when(admin).isLeaderControllerFor(clusterName);
+
+    Version versionOneImpl = new VersionImpl(storeName, versionOne);
+    Version versionTwoImpl = new VersionImpl(storeName, versionTwo);
+    versionTwoImpl.setStatus(VersionStatus.PUSHED);
+    List<Version> versionList = new ArrayList<>();
+    versionList.add(versionOneImpl);
+    versionList.add(versionTwoImpl);
+    StoreResponse storeResponse = getStoreResponse(versionList);
+
+    Map<String, ControllerClient> controllerClientMap = mockControllerClients(versionList);
+    for (Map.Entry<String, ControllerClient> entry: controllerClientMap.entrySet()) {
+      ControllerClient controllerClient = entry.getValue();
+      doReturn(storeResponse).when(controllerClient).getStore(storeName);
+    }
+
+    mockVeniceHelixAdmin(controllerClientMap);
+    Map<String, Integer> coloToVersions = new HashMap<>();
+    coloToVersions.put(region1, versionTwo);
+    coloToVersions.put(region2, versionOne);
+    coloToVersions.put(region3, versionOne);
+
+    doReturn(coloToVersions).when(admin).getCurrentVersionsForMultiColos(any(), any());
+
+    Long time = LocalDateTime.now().toEpochSecond(ZoneOffset.UTC);
+    Admin.OfflinePushStatusInfo offlinePushStatusInfoWithCompletedPush = getOfflinePushStatusInfo(
+        ExecutionStatus.COMPLETED.toString(),
+        ExecutionStatus.COMPLETED.toString(),
+        ExecutionStatus.COMPLETED.toString(),
+        time - TimeUnit.MINUTES.toSeconds(90),
+        time - TimeUnit.MINUTES.toSeconds(30),
+        time - TimeUnit.MINUTES.toSeconds(30));
+
+    String kafkaTopicName = Version.composeKafkaTopic(storeName, versionTwo);
+    doReturn(offlinePushStatusInfoWithCompletedPush).when(admin).getOffLinePushStatus(clusterName, kafkaTopicName);
+
+    DeferredVersionSwapStats deferredVersionSwapStats = mock(DeferredVersionSwapStats.class);
+    DeferredVersionSwapService deferredVersionSwapService =
+        new DeferredVersionSwapService(admin, veniceControllerMultiClusterConfig, deferredVersionSwapStats);
+
+    deferredVersionSwapService.startInner();
+
+    TestUtils.waitForNonDeterministicAssertion(5, TimeUnit.SECONDS, () -> {
+      verify(deferredVersionSwapStats, atLeast(1)).recordDeferredVersionSwapParentChildStatusMismatchSensor();
+    });
+  }
 }


### PR DESCRIPTION
<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat], [protocol]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## Problem Statement
<!--
Describe
- What problem are you trying to solve
- What issues or limitations exist in the current code
- Why this change is necessary 
-->
We have observed that there are cases where a store is eligible to enter the DeferredVersionSwapService loop and perform a version swap, but it does not seem to be entering at all. This could be due to the parent version status being marked ONLINE already even though a swap did not happen, leading to a version status mismatch and roll forward never happening. This pr adds a check to account for this case if it is happening and emit a metric

## Solution
<!--
Describe
- What changes you are making and why. 
- How these changes solve the problem.
- Any performance considerations or trade-offs. 
- Describe what testings you have done, for example, performance testing etc.
-->
Emit a metric if the parent version status is marked ONLINE and allow it to enter the DeferredVersionSwapService loop to perform a version swap

###  Code changes
- [ ] Added new code behind **a config**. If so list the config names and their default values in the PR description.
- [x] Introduced new **log lines**. 
  - [x] Confirmed if logs need to be **rate limited** to avoid excessive logging.

###  **Concurrency-Specific Checks**
Both reviewer and PR author to verify
- [ ] Code has **no race conditions** or **thread safety issues**.
- [ ] Proper **synchronization mechanisms** (e.g., `synchronized`, `RWLock`) are used where needed.
- [ ] No **blocking calls** inside critical sections that could lead to deadlocks or performance degradation.
- [ ] Verified **thread-safe collections** are used (e.g., `ConcurrentHashMap`, `CopyOnWriteArrayList`).
- [ ] Validated proper exception handling in multi-threaded code to avoid silent thread termination.


## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->

- [x] New unit tests added.
- [x] New integration tests added.
- [ ] Modified or extended existing tests.
- [ ] Verified backward compatibility (if applicable).

New unit and e2e test

## Does this PR introduce any user-facing or breaking changes?
<!--  
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Clearly explain the behavior change and its impact.