### PR TITLE
[server][da-vinci] Reuse StuckConsumerRepairStats object in Stuck consumer repair service

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/AggKafkaConsumerService.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/AggKafkaConsumerService.java
@@ -77,6 +77,8 @@ public class AggKafkaConsumerService extends AbstractVeniceService {
   private final Function<String, Boolean> isAAOrWCEnabledFunc;
   private final ReadOnlyStoreRepository metadataRepository;
 
+  private final StuckConsumerRepairStats stuckConsumerStats;
+
   private final static String STUCK_CONSUMER_MSG =
       "Didn't find any suspicious ingestion task, and please contact developers to investigate it further";
   private static final String CONSUMER_POLL_WARNING_MESSAGE_PREFIX =
@@ -115,6 +117,7 @@ public class AggKafkaConsumerService extends AbstractVeniceService {
     this.kafkaClusterUrlResolver = serverConfig.getKafkaClusterUrlResolver();
     this.metadataRepository = metadataRepository;
     if (serverConfig.isStuckConsumerRepairEnabled()) {
+      this.stuckConsumerStats = new StuckConsumerRepairStats(metricsRepository);
       this.stuckConsumerRepairExecutorService = Executors.newSingleThreadScheduledExecutor(
           new DaemonThreadFactory(this.getClass().getName() + "-StuckConsumerRepair", serverConfig.getRegionName()));
       int intervalInSeconds = serverConfig.getStuckConsumerRepairIntervalSecond();
@@ -128,12 +131,15 @@ public class AggKafkaConsumerService extends AbstractVeniceService {
               TimeUnit.SECONDS.toMillis(serverConfig.getNonExistingTopicIngestionTaskKillThresholdSecond()),
               TimeUnit.SECONDS.toMillis(serverConfig.getNonExistingTopicCheckRetryIntervalSecond()),
               TimeUnit.SECONDS.toMillis(serverConfig.getConsumerPollTrackerStaleThresholdSeconds()),
-              new StuckConsumerRepairStats(metricsRepository),
+              stuckConsumerStats,
               killIngestionTaskRunnable),
           intervalInSeconds,
           intervalInSeconds,
           TimeUnit.SECONDS);
       LOGGER.info("Started stuck consumer repair service with checking interval: {} seconds", intervalInSeconds);
+    } else {
+      this.stuckConsumerStats = null;
+      LOGGER.info("Stuck consumer repair service is disabled");
     }
     this.isAAOrWCEnabledFunc = isAAOrWCEnabledFunc;
     this.pubSubPropertiesSupplier = pubSubPropertiesSupplier;


### PR DESCRIPTION
## Problem Statement
Today, we create a new StuckConsumerRepairStats object for each invocation round in the stuck consumer repair service. This is not necessary and we can reuse the same stats object for better efficiency across the whole life cycle of the repair service.

###  Code changes
- [ ] Added new code behind **a config**. If so list the config names and their default values in the PR description.
- [ ] Introduced new **log lines**. 
  - [ ] Confirmed if logs need to be **rate limited** to avoid excessive logging.

###  **Concurrency-Specific Checks**
Both reviewer and PR author to verify
- [ ] Code has **no race conditions** or **thread safety issues**.
- [ ] Proper **synchronization mechanisms** (e.g., `synchronized`, `RWLock`) are used where needed.
- [ ] No **blocking calls** inside critical sections that could lead to deadlocks or performance degradation.
- [ ] Verified **thread-safe collections** are used (e.g., `ConcurrentHashMap`, `CopyOnWriteArrayList`).
- [ ] Validated proper exception handling in multi-threaded code to avoid silent thread termination.

## How was this PR tested?
CI passed.

- [ ] New unit tests added.
- [ ] New integration tests added.
- [ ] Modified or extended existing tests.
- [ ] Verified backward compatibility (if applicable).

## Does this PR introduce any user-facing or breaking changes?
<!--  
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Clearly explain the behavior change and its impact.