### PR TITLE
[server][dvc] Tracking transferring partitions at SE to prevent entire store drop

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/ingestion/DefaultIngestionBackend.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/ingestion/DefaultIngestionBackend.java
@@ -152,6 +152,8 @@ public class DefaultIngestionBackend implements IngestionBackend {
           Arrays.toString(partitionFolderDir.list()));
     }
 
+    storageEngine.markPartitionBlobTransferBootstrapStarted(partitionId);
+
     return blobTransferManager.get(storeName, versionNumber, partitionId, tableFormat)
         .handle((inputStream, throwable) -> {
           updateBlobTransferResponseStats(throwable == null, storeName, versionNumber);
@@ -174,6 +176,11 @@ public class DefaultIngestionBackend implements IngestionBackend {
                   Arrays.toString(partitionFolderDir.list()));
             }
           }
+
+          if (storageService.getStorageEngine(kafkaTopic) != null) {
+            storageService.getStorageEngine(kafkaTopic).markPartitionBlobTransferBootstrapCompleted(partitionId);
+          }
+
           return null;
         });
   }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/ingestion/DefaultIngestionBackend.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/ingestion/DefaultIngestionBackend.java
@@ -152,7 +152,8 @@ public class DefaultIngestionBackend implements IngestionBackend {
           Arrays.toString(partitionFolderDir.list()));
     }
 
-    if (!storageEngine.tryMarkPartitionBlobTransferStarted(partitionId)) {
+    if (storageService.getStorageEngine(kafkaTopic) == null
+        || !storageService.getStorageEngine(kafkaTopic).tryMarkPartitionBlobTransferStarted(partitionId)) {
       LOGGER.info(
           "Skipping blob transfer for replica {} - storage engine is marked for dropping",
           Utils.getReplicaId(kafkaTopic, partitionId));

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/storage/StorageService.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/storage/StorageService.java
@@ -503,10 +503,10 @@ public class StorageService extends AbstractVeniceService {
     Set<Integer> remainingPartitions = storageEngine.getPartitionIds();
     LOGGER.info("Dropped partition {} of {}, remaining partitions={}", partition, kafkaTopic, remainingPartitions);
 
+    // Check if blob transfer is enabled and if there are ongoing transfers
     if (storeConfig.isBlobTransferEnabled() && storageEngine.isAnyOngoingBlobTransferPartitions()) {
-      LOGGER.info(
-          "skip remove StorageEngine for replica {} as there is on-going blob transfer.",
-          Utils.getReplicaId(kafkaTopic, partition));
+      LOGGER.info("Skip removing StorageEngine for {} as there are ongoing blob transfers", kafkaTopic);
+      storageEngine.markStorageEngineDropping();
       return;
     }
 

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/storage/StorageService.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/storage/StorageService.java
@@ -506,11 +506,13 @@ public class StorageService extends AbstractVeniceService {
     // Check if blob transfer is enabled and if there are ongoing transfers
     if (storeConfig.isBlobTransferEnabled() && storageEngine.isAnyOngoingBlobTransferPartitions()) {
       LOGGER.info("Skip removing StorageEngine for {} as there are ongoing blob transfers", kafkaTopic);
-      storageEngine.markStorageEngineDropping();
       return;
     }
 
     if (remainingPartitions.isEmpty() && removeEmptyStorageEngine) {
+      if (storeConfig.isBlobTransferEnabled()) {
+        storageEngine.markStorageEngineDropping();
+      }
       removeStorageEngine(kafkaTopic);
     }
   }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/store/AbstractStorageEngine.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/store/AbstractStorageEngine.java
@@ -762,19 +762,22 @@ public abstract class AbstractStorageEngine<Partition extends AbstractStoragePar
   }
 
   /**
-   * Similar with partitionList, we use a set to record the ongoing blob transfer partitions.
-   * Those partitions have ongoing transfer files, but not added into partitionList yet.
-   * @return true if there is at least one partition with ongoing blob transfer bootstrap, false if it is empty.
+   * Mark the storage engine for dropping.
+   * @return true if the storage engine was successfully marked for dropping, false if there are ongoing blob transfers
    */
   @Override
-  public synchronized boolean isAnyOngoingBlobTransferPartitions() {
-    return !inProgressBlobTransferPartitions.isEmpty();
-  }
+  public synchronized boolean tryMarkStorageEngineForDropping() {
+    if (!inProgressBlobTransferPartitions.isEmpty()) {
+      LOGGER.info(
+          "Cannot mark storage engine {} for dropping - ongoing blob transfers: {}",
+          getStoreVersionName(),
+          inProgressBlobTransferPartitions);
+      return false;
+    }
 
-  @Override
-  public synchronized void markStorageEngineDropping() {
     markedForDrop = true;
     LOGGER.info("Storage engine {} marked for dropping", getStoreVersionName());
+    return true;
   }
 
   /**

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/store/AbstractStorageEngine.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/store/AbstractStorageEngine.java
@@ -817,11 +817,6 @@ public abstract class AbstractStorageEngine<Partition extends AbstractStoragePar
           "Marked replica {} as blob transfer bootstrap completed, current transferring partitions: {}",
           Utils.getReplicaId(getStoreVersionName(), partitionId),
           inProgressBlobTransferPartitions);
-    } else {
-      LOGGER.info(
-          "Marked replica {} was not marked as blob transfer bootstrap started, current transferring partitions: {}",
-          Utils.getReplicaId(getStoreVersionName(), partitionId),
-          inProgressBlobTransferPartitions);
     }
   }
 }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/store/DelegatingStorageEngine.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/store/DelegatingStorageEngine.java
@@ -222,6 +222,21 @@ public class DelegatingStorageEngine<P extends AbstractStoragePartition> impleme
   }
 
   @Override
+  public boolean isAnyOngoingBlobTransferPartitions() {
+    return this.delegate.isAnyOngoingBlobTransferPartitions();
+  }
+
+  @Override
+  public void markPartitionBlobTransferBootstrapStarted(int partitionId) {
+    this.delegate.markPartitionBlobTransferBootstrapStarted(partitionId);
+  }
+
+  @Override
+  public void markPartitionBlobTransferBootstrapCompleted(int partitionId) {
+    this.delegate.markPartitionBlobTransferBootstrapCompleted(partitionId);
+  }
+
+  @Override
   public P getPartitionOrThrow(int partitionId) {
     return this.delegate.getPartitionOrThrow(partitionId);
   }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/store/DelegatingStorageEngine.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/store/DelegatingStorageEngine.java
@@ -222,13 +222,8 @@ public class DelegatingStorageEngine<P extends AbstractStoragePartition> impleme
   }
 
   @Override
-  public void markStorageEngineDropping() {
-    this.delegate.markStorageEngineDropping();
-  }
-
-  @Override
-  public boolean isAnyOngoingBlobTransferPartitions() {
-    return this.delegate.isAnyOngoingBlobTransferPartitions();
+  public boolean tryMarkStorageEngineForDropping() {
+    return this.delegate.tryMarkStorageEngineForDropping();
   }
 
   @Override

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/store/DelegatingStorageEngine.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/store/DelegatingStorageEngine.java
@@ -222,13 +222,18 @@ public class DelegatingStorageEngine<P extends AbstractStoragePartition> impleme
   }
 
   @Override
+  public void markStorageEngineDropping() {
+    this.delegate.markStorageEngineDropping();
+  }
+
+  @Override
   public boolean isAnyOngoingBlobTransferPartitions() {
     return this.delegate.isAnyOngoingBlobTransferPartitions();
   }
 
   @Override
-  public void markPartitionBlobTransferBootstrapStarted(int partitionId) {
-    this.delegate.markPartitionBlobTransferBootstrapStarted(partitionId);
+  public boolean tryMarkPartitionBlobTransferStarted(int partitionId) {
+    return this.delegate.tryMarkPartitionBlobTransferStarted(partitionId);
   }
 
   @Override

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/store/StorageEngine.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/store/StorageEngine.java
@@ -176,4 +176,13 @@ public interface StorageEngine<Partition extends AbstractStoragePartition> exten
   default StorageEngineStats getStats() {
     return StorageEngineNoOpStats.SINGLETON;
   }
+
+  /**
+   * Check if there are any ongoing blob transfer partitions at SE level, and related add and remove methods.
+   */
+  boolean isAnyOngoingBlobTransferPartitions();
+
+  void markPartitionBlobTransferBootstrapStarted(int partitionId);
+
+  void markPartitionBlobTransferBootstrapCompleted(int partitionId);
 }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/store/StorageEngine.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/store/StorageEngine.java
@@ -178,11 +178,16 @@ public interface StorageEngine<Partition extends AbstractStoragePartition> exten
   }
 
   /**
+   * Mark the storage engine as start dropping.
+   */
+  void markStorageEngineDropping();
+
+  /**
    * Check if there are any ongoing blob transfer partitions at SE level, and related add and remove methods.
    */
   boolean isAnyOngoingBlobTransferPartitions();
 
-  void markPartitionBlobTransferBootstrapStarted(int partitionId);
+  boolean tryMarkPartitionBlobTransferStarted(int partitionId);
 
   void markPartitionBlobTransferBootstrapCompleted(int partitionId);
 }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/store/StorageEngine.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/store/StorageEngine.java
@@ -180,13 +180,11 @@ public interface StorageEngine<Partition extends AbstractStoragePartition> exten
   /**
    * Mark the storage engine as start dropping.
    */
-  void markStorageEngineDropping();
+  boolean tryMarkStorageEngineForDropping();
 
   /**
    * Check if there are any ongoing blob transfer partitions at SE level, and related add and remove methods.
    */
-  boolean isAnyOngoingBlobTransferPartitions();
-
   boolean tryMarkPartitionBlobTransferStarted(int partitionId);
 
   void markPartitionBlobTransferBootstrapCompleted(int partitionId);

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/store/AbstractStorageEngineTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/store/AbstractStorageEngineTest.java
@@ -286,4 +286,21 @@ public abstract class AbstractStorageEngineTest<ASE extends AbstractStorageEngin
     Assert.assertTrue(StorageService.isMetadataPartition(AbstractStorageEngine.METADATA_PARTITION_ID));
     Assert.assertFalse(StorageService.isMetadataPartition(AbstractStorageEngine.METADATA_PARTITION_ID + 1));
   }
+
+  @Test
+  public void testInProgressBlobTransferPartitionsModification() {
+    testStoreEngine.tryMarkPartitionBlobTransferStarted(0);
+    testStoreEngine.tryMarkPartitionBlobTransferStarted(1);
+    Assert.assertTrue(testStoreEngine.isAnyOngoingBlobTransferPartitions());
+
+    testStoreEngine.markPartitionBlobTransferBootstrapCompleted(1);
+    Assert.assertTrue(testStoreEngine.isAnyOngoingBlobTransferPartitions());
+    testStoreEngine.markPartitionBlobTransferBootstrapCompleted(0);
+    Assert.assertFalse(testStoreEngine.isAnyOngoingBlobTransferPartitions());
+
+    testStoreEngine.markStorageEngineDropping();
+    Assert.assertFalse(
+        testStoreEngine.isAnyOngoingBlobTransferPartitions(),
+        "Storage engine should not have any ongoing blob transfer partitions after marking it as dropping.");
+  }
 }

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/store/AbstractStorageEngineTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/store/AbstractStorageEngineTest.java
@@ -286,21 +286,4 @@ public abstract class AbstractStorageEngineTest<ASE extends AbstractStorageEngin
     Assert.assertTrue(StorageService.isMetadataPartition(AbstractStorageEngine.METADATA_PARTITION_ID));
     Assert.assertFalse(StorageService.isMetadataPartition(AbstractStorageEngine.METADATA_PARTITION_ID + 1));
   }
-
-  @Test
-  public void testInProgressBlobTransferPartitionsModification() {
-    testStoreEngine.tryMarkPartitionBlobTransferStarted(0);
-    testStoreEngine.tryMarkPartitionBlobTransferStarted(1);
-    Assert.assertTrue(testStoreEngine.isAnyOngoingBlobTransferPartitions());
-
-    testStoreEngine.markPartitionBlobTransferBootstrapCompleted(1);
-    Assert.assertTrue(testStoreEngine.isAnyOngoingBlobTransferPartitions());
-    testStoreEngine.markPartitionBlobTransferBootstrapCompleted(0);
-    Assert.assertFalse(testStoreEngine.isAnyOngoingBlobTransferPartitions());
-
-    testStoreEngine.markStorageEngineDropping();
-    Assert.assertFalse(
-        testStoreEngine.isAnyOngoingBlobTransferPartitions(),
-        "Storage engine should not have any ongoing blob transfer partitions after marking it as dropping.");
-  }
 }


### PR DESCRIPTION
<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat], [protocol]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## Problem Statement
During server bootstrap, a partition is transferring files. However, after all the files are transferred, RocksDB becomes corrupted.

The root cause is that, simultaneously, another partition is being dropped. Because the partition list becomes empty at this point, the system begins to drop the entire store and its storage engine. Meanwhile, the partition that is transferring files has not yet been added to the partition list. As a result, the directory for the newly transferred files is no longer valid.

The relevant code logic is as follows:

- `KafkaStoreIngestionService#dropStoragePartitionGracefully`
  - calls `storageService.dropStorePartition`
    - calls `removeStorageEngine(kafkaTopic)`
      - calls `storageEngine.drop()`
        - calls `super.drop()` (since `partitionList` is empty, only `dropMetadataPartition` is executed)
          - `RocksDBStorageEngine#drop` eventually calls `storeDbDir.delete()`


## Solution
1. At the storage engine level, implement a set to keep track of all partitions that are currently undergoing transfers.

2. Within `bootstrapFromBlobs`, add a partition to this tracking set at the beginning of a transfer; once the partition is included in the partition list via `addStoragePartition`, remove it from the in-progress transfer set.

3. When attempting to drop a storage engine, if there are any partitions with ongoing transfers, do not proceed with the drop entire store. If the drop store is initiated when there are no active blob transfer partitions, set the storage engine's "markedForDrop" flag. While this flag is set, any attempted blob transfers should be skipped.

###  Code changes
- [ ] Added new code behind **a config**. If so list the config names and their default values in the PR description.
- [ ] Introduced new **log lines**. 
- [ ] Confirmed if logs need to be **rate limited** to avoid excessive logging.

###  **Concurrency-Specific Checks**
Both reviewer and PR author to verify
- [ ] Code has **no race conditions** or **thread safety issues**.
- [ ] Proper **synchronization mechanisms** (e.g., `synchronized`, `RWLock`) are used where needed.
- [ ] No **blocking calls** inside critical sections that could lead to deadlocks or performance degradation.
- [ ] Verified **thread-safe collections** are used (e.g., `ConcurrentHashMap`, `CopyOnWriteArrayList`).
- [ ] Validated proper exception handling in multi-threaded code to avoid silent thread termination.


## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->

- [ ] New unit tests added.
- [ ] New integration tests added.
- [ ] Modified or extended existing tests.
- [ ] Verified backward compatibility (if applicable).

## Does this PR introduce any user-facing or breaking changes?
<!--  
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Clearly explain the behavior change and its impact.