### PR TITLE
[samza] Make ChainedPubSubCallback also take in SendMessageErrorLoggerCallback when sending messages

### DIFF
--- a/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/api/PubSubProducerCallback.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/api/PubSubProducerCallback.java
@@ -8,7 +8,12 @@ public interface PubSubProducerCallback {
   /**
    * exception will be null if request was completed without an error.
    */
-
   void onCompletion(PubSubProduceResult produceResult, Exception exception);
 
+  /**
+   * Add internal callback into the current callback. Default behavior is doing nothing.
+   */
+  default void setInternalCallback(PubSubProducerCallback internalCallback) {
+
+  }
 }

--- a/internal/venice-common/src/main/java/com/linkedin/venice/writer/ChainedPubSubCallback.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/writer/ChainedPubSubCallback.java
@@ -31,17 +31,13 @@ public class ChainedPubSubCallback implements PubSubProducerCallback {
   }
 
   /**
-   * Insert an internal {@link PubSubProducerCallback} when the main callback and the dependent callbacks are the type
-   * of {@link CompletableFutureCallback}
+   * Insert an internal {@link PubSubProducerCallback} to main callback and the dependent callbacks.
    */
-  public void maybeSetInternalCallback(PubSubProducerCallback internalCallback) {
-    if (callback instanceof CompletableFutureCallback) {
-      ((CompletableFutureCallback) callback).setCallback(internalCallback);
-    }
+  @Override
+  public void setInternalCallback(PubSubProducerCallback internalCallback) {
+    callback.setInternalCallback(internalCallback);
     for (PubSubProducerCallback dependentCallback: dependentCallbackList) {
-      if (dependentCallback instanceof CompletableFutureCallback) {
-        ((CompletableFutureCallback) dependentCallback).setCallback(internalCallback);
-      }
+      dependentCallback.setInternalCallback(internalCallback);
     }
   }
 

--- a/internal/venice-common/src/main/java/com/linkedin/venice/writer/ChainedPubSubCallback.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/writer/ChainedPubSubCallback.java
@@ -5,6 +5,12 @@ import com.linkedin.venice.pubsub.api.PubSubProducerCallback;
 import java.util.List;
 
 
+/**
+ * This class bundles a main {@link PubSubProducerCallback} and a list of dependent {@link PubSubProducerCallback}.
+ * When it completes either successfully or exceptionally, it will pass on the same result to the main callback and the
+ * list of the dependent callbacks.
+ * This class is intended to be used inside {@link BatchingVeniceWriter} for compacting buffered messages with the same key.
+ */
 public class ChainedPubSubCallback implements PubSubProducerCallback {
   private final List<PubSubProducerCallback> dependentCallbackList;
   private final PubSubProducerCallback callback;
@@ -21,6 +27,21 @@ public class ChainedPubSubCallback implements PubSubProducerCallback {
     callback.onCompletion(produceResult, exception);
     for (PubSubProducerCallback producerCallback: dependentCallbackList) {
       producerCallback.onCompletion(produceResult, exception);
+    }
+  }
+
+  /**
+   * Insert an internal {@link PubSubProducerCallback} when the main callback and the dependent callbacks are the type
+   * of {@link CompletableFutureCallback}
+   */
+  public void maybeSetInternalCallback(PubSubProducerCallback internalCallback) {
+    if (callback instanceof CompletableFutureCallback) {
+      ((CompletableFutureCallback) callback).setCallback(internalCallback);
+    }
+    for (PubSubProducerCallback dependentCallback: dependentCallbackList) {
+      if (dependentCallback instanceof CompletableFutureCallback) {
+        ((CompletableFutureCallback) dependentCallback).setCallback(internalCallback);
+      }
     }
   }
 

--- a/internal/venice-common/src/main/java/com/linkedin/venice/writer/CompletableFutureCallback.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/writer/CompletableFutureCallback.java
@@ -27,7 +27,9 @@ public class CompletableFutureCallback implements PubSubProducerCallback, Measur
 
   @Override
   public void onCompletion(PubSubProduceResult produceResult, Exception e) {
-    callback.onCompletion(produceResult, e);
+    if (callback != null) {
+      callback.onCompletion(produceResult, e);
+    }
     if (e == null) {
       completableFuture.complete(null);
     } else {
@@ -39,7 +41,8 @@ public class CompletableFutureCallback implements PubSubProducerCallback, Measur
     return callback;
   }
 
-  public void setCallback(PubSubProducerCallback callback) {
+  @Override
+  public void setInternalCallback(PubSubProducerCallback callback) {
     this.callback = callback;
   }
 

--- a/internal/venice-common/src/main/java/com/linkedin/venice/writer/VeniceWriter.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/writer/VeniceWriter.java
@@ -1520,13 +1520,8 @@ public class VeniceWriter<K, V, U> extends AbstractVeniceWriter<K, V, U> {
     PubSubProducerCallback outputCallback = inputCallback;
     if (inputCallback == null) {
       outputCallback = internalCallback;
-    } else if (inputCallback instanceof CompletableFutureCallback) {
-      CompletableFutureCallback completableFutureCallBack = (CompletableFutureCallback) inputCallback;
-      if (completableFutureCallBack.getCallback() == null) {
-        completableFutureCallBack.setCallback(internalCallback);
-      }
-    } else if (inputCallback instanceof ChainedPubSubCallback) {
-      ((ChainedPubSubCallback) inputCallback).maybeSetInternalCallback(internalCallback);
+    } else {
+      inputCallback.setInternalCallback(internalCallback);
     }
     return outputCallback;
   }

--- a/internal/venice-common/src/test/java/com/linkedin/venice/writer/BatchingVeniceWriterTest.java
+++ b/internal/venice-common/src/test/java/com/linkedin/venice/writer/BatchingVeniceWriterTest.java
@@ -113,8 +113,8 @@ public class BatchingVeniceWriterTest {
     CompletableFutureCallback callback2 = new CompletableFutureCallback(completableFuture2);
     CompletableFutureCallback callback3 = new CompletableFutureCallback(completableFuture3);
     CompletableFutureCallback callback4 = new CompletableFutureCallback(completableFuture4);
-    callback1.setCallback(mock(PubSubProducerCallback.class));
-    callback4.setCallback(mock(PubSubProducerCallback.class));
+    callback1.setInternalCallback(mock(PubSubProducerCallback.class));
+    callback4.setInternalCallback(mock(PubSubProducerCallback.class));
 
     // Create different objects for each message to make sure buffer index map is working properly for byte array.
     String key = "a";

--- a/internal/venice-common/src/test/java/com/linkedin/venice/writer/VeniceWriterUnitTest.java
+++ b/internal/venice-common/src/test/java/com/linkedin/venice/writer/VeniceWriterUnitTest.java
@@ -763,7 +763,6 @@ public class VeniceWriterUnitTest {
     VeniceWriter writer = mock(VeniceWriter.class);
     doCallRealMethod().when(writer).setInternalCallback(any(), any());
     PubSubProducerCallback messageCallback = mock(PubSubProducerCallback.class);
-    PubSubProducerCallback inputCallback1 = null;
     CompletableFutureCallback inputCallback2 = new CompletableFutureCallback(new CompletableFuture<>());
     CompletableFutureCallback mainCallback = new CompletableFutureCallback(new CompletableFuture<>());
     CompletableFutureCallback dependentCallback1 = new CompletableFutureCallback(new CompletableFuture<>());
@@ -775,7 +774,7 @@ public class VeniceWriterUnitTest {
 
     PubSubProducerCallback resultCallback;
     // Case 1: Null input
-    resultCallback = writer.setInternalCallback(inputCallback1, messageCallback);
+    resultCallback = writer.setInternalCallback(null, messageCallback);
     Assert.assertEquals(resultCallback, messageCallback);
     // Case 2: CompletableCallback input
     resultCallback = writer.setInternalCallback(inputCallback2, messageCallback);

--- a/internal/venice-common/src/test/java/com/linkedin/venice/writer/WriterCallbackTest.java
+++ b/internal/venice-common/src/test/java/com/linkedin/venice/writer/WriterCallbackTest.java
@@ -3,16 +3,19 @@ package com.linkedin.venice.writer;
 import static org.mockito.Mockito.mock;
 
 import com.linkedin.venice.exceptions.VeniceException;
+import com.linkedin.venice.kafka.protocol.KafkaMessageEnvelope;
+import com.linkedin.venice.pubsub.api.PubSubProduceResult;
 import com.linkedin.venice.pubsub.api.PubSubProducerCallback;
 import com.linkedin.venice.utils.DataProviderUtils;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
+import org.apache.logging.log4j.Logger;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
 
-public class ChainedCallbackTest {
+public class WriterCallbackTest {
   @Test(dataProvider = "True-and-False", dataProviderClass = DataProviderUtils.class)
   public void testSetDependentFuture(boolean hasException) {
     CompletableFuture<Void> future = new CompletableFuture<>();
@@ -26,9 +29,9 @@ public class ChainedCallbackTest {
     list.add(callback1);
     list.add(callback2);
     ChainedPubSubCallback chainedPubSubCallback = new ChainedPubSubCallback(callback, list);
-    callback.setCallback(mock(PubSubProducerCallback.class));
-    callback1.setCallback(mock(PubSubProducerCallback.class));
-    callback2.setCallback(mock(PubSubProducerCallback.class));
+    callback.setInternalCallback(mock(PubSubProducerCallback.class));
+    callback1.setInternalCallback(mock(PubSubProducerCallback.class));
+    callback2.setInternalCallback(mock(PubSubProducerCallback.class));
     if (hasException) {
       chainedPubSubCallback.onCompletion(null, new VeniceException("Test"));
       Assert.assertTrue(future.isCompletedExceptionally());
@@ -40,5 +43,16 @@ public class ChainedCallbackTest {
       Assert.assertTrue(dependentFuture1.isDone());
       Assert.assertTrue(dependentFuture2.isDone());
     }
+  }
+
+  @Test(dataProvider = "True-and-False", dataProviderClass = DataProviderUtils.class)
+  public void testCompletableFutureCallback(boolean setInternalCallback) {
+    CompletableFutureCallback callback = new CompletableFutureCallback(new CompletableFuture<>());
+    if (setInternalCallback) {
+      callback.setInternalCallback(
+          new SendMessageErrorLoggerCallback(mock(KafkaMessageEnvelope.class), mock(Logger.class)));
+    }
+    callback.onCompletion(mock(PubSubProduceResult.class), null);
+
   }
 }


### PR DESCRIPTION

<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat], [protocol]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## [samza] Make ChainedPubSubCallback also take in SendMessageErrorLoggerCallback when sending messages

During the testing of the BatchingVeniceWriter, NPE was thrown in VeniceWriter producer callback thread, as we always call onCompletion() API for the PubSubCallback. 
For CompletableFutureCallback, when VW sends message, it will insert an internal SendMessageErrorLoggerCallback and onCompletion() will also invoke it. However, ChainedPubSubCallback does not register the same callback, but will still invoke onCompletion() API and will also invoke it's internal callback's onCompletion() API. If internal callback is a CompletableFutureCallback, NPE will be thrown.

This PR address the issue and verify through test logs that it does not appear.

## Solution
<!--
Describe
- What changes you are making and why. 
- How these changes solve the problem.
- Any performance considerations or trade-offs. 
- Describe what testings you have done, for example, performance testing etc.
-->


###  Code changes
- [ ] Added new code behind **a config**. If so list the config names and their default values in the PR description.
- [ ] Introduced new **log lines**. 
  - [ ] Confirmed if logs need to be **rate limited** to avoid excessive logging.

###  **Concurrency-Specific Checks**
Both reviewer and PR author to verify
- [ ] Code has **no race conditions** or **thread safety issues**.
- [ ] Proper **synchronization mechanisms** (e.g., `synchronized`, `RWLock`) are used where needed.
- [ ] No **blocking calls** inside critical sections that could lead to deadlocks or performance degradation.
- [ ] Verified **thread-safe collections** are used (e.g., `ConcurrentHashMap`, `CopyOnWriteArrayList`).
- [ ] Validated proper exception handling in multi-threaded code to avoid silent thread termination.


## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->

- [x] New unit tests added.
- [ ] New integration tests added.
- [ ] Modified or extended existing tests.
- [ ] Verified backward compatibility (if applicable).

## Does this PR introduce any user-facing or breaking changes?
<!--  
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Clearly explain the behavior change and its impact.