### PR TITLE
[client] Add Otel 'retry_key_count' metrics for clients

### DIFF
--- a/clients/venice-thin-client/src/main/java/com/linkedin/venice/client/stats/ClientMetricEntity.java
+++ b/clients/venice-thin-client/src/main/java/com/linkedin/venice/client/stats/ClientMetricEntity.java
@@ -1,5 +1,6 @@
 package com.linkedin.venice.client.stats;
 
+import static com.linkedin.venice.stats.dimensions.VeniceMetricsDimensions.VENICE_MESSAGE_TYPE;
 import static com.linkedin.venice.stats.dimensions.VeniceMetricsDimensions.VENICE_REQUEST_METHOD;
 import static com.linkedin.venice.stats.dimensions.VeniceMetricsDimensions.VENICE_REQUEST_RETRY_TYPE;
 import static com.linkedin.venice.stats.dimensions.VeniceMetricsDimensions.VENICE_STORE_NAME;
@@ -20,6 +21,14 @@ public enum ClientMetricEntity implements ModuleMetricEntityInterface {
   RETRY_COUNT(
       MetricType.COUNTER, MetricUnit.NUMBER, "Count of all retry requests for client",
       setOf(VENICE_STORE_NAME, VENICE_REQUEST_METHOD, VENICE_REQUEST_RETRY_TYPE)
+  ),
+
+  /**
+   * Client retry key count.
+   */
+  RETRY_KEY_COUNT(
+      MetricType.MIN_MAX_COUNT_SUM_AGGREGATIONS, MetricUnit.NUMBER, "Key count of retry requests for client",
+      setOf(VENICE_STORE_NAME, VENICE_REQUEST_METHOD, VENICE_MESSAGE_TYPE)
   );
 
   private final MetricEntity entity;

--- a/clients/venice-thin-client/src/test/java/com/linkedin/venice/client/stats/BasicClientStatsTest.java
+++ b/clients/venice-thin-client/src/test/java/com/linkedin/venice/client/stats/BasicClientStatsTest.java
@@ -1,6 +1,7 @@
 package com.linkedin.venice.client.stats;
 
 import static com.linkedin.venice.client.stats.BasicClientStats.CLIENT_METRIC_ENTITIES;
+import static com.linkedin.venice.client.stats.ClientMetricEntity.RETRY_KEY_COUNT;
 import static com.linkedin.venice.read.RequestType.SINGLE_GET;
 import static com.linkedin.venice.stats.ClientType.DAVINCI_CLIENT;
 import static com.linkedin.venice.stats.ClientType.THIN_CLIENT;
@@ -17,6 +18,7 @@ import static com.linkedin.venice.stats.dimensions.VeniceMetricsDimensions.VENIC
 import static com.linkedin.venice.stats.dimensions.VeniceMetricsDimensions.VENICE_STORE_NAME;
 import static com.linkedin.venice.stats.dimensions.VeniceResponseStatusCategory.SUCCESS;
 import static com.linkedin.venice.utils.OpenTelemetryDataPointTestUtils.validateExponentialHistogramPointData;
+import static com.linkedin.venice.utils.OpenTelemetryDataPointTestUtils.validateHistogramPointData;
 import static com.linkedin.venice.utils.OpenTelemetryDataPointTestUtils.validateLongPointData;
 import static org.apache.http.HttpStatus.SC_OK;
 import static org.testng.Assert.assertEquals;
@@ -207,6 +209,54 @@ public class BasicClientStatsTest {
         1);
   }
 
+  @Test(dataProviderClass = DataProviderUtils.class, dataProvider = "True-and-False")
+  public void testRetryKeyCountMetrics(boolean isRequest) {
+    for (ClientType client: ClientType.values()) {
+      // verify that the following works for all client types.
+      InMemoryMetricReader inMemoryMetricReader = InMemoryMetricReader.create();
+      ClientStats stats = createClientStats(inMemoryMetricReader, client);
+
+      int keyCount = 10;
+
+      if (isRequest) {
+        stats.recordRetryRequestKeyCount(keyCount);
+      } else {
+        stats.recordRetryRequestSuccessKeyCount(keyCount);
+      }
+
+      // Check Tehuti metrics
+      Map<String, ? extends Metric> metrics = stats.getMetricsRepository().metrics();
+      String storeName = "test_store";
+      if (isRequest) {
+        Assert.assertEquals(
+            (int) metrics.get(String.format(".%s--retry_request_key_count.Max", storeName)).value(),
+            keyCount);
+        Assert.assertEquals(
+            (int) metrics.get(String.format(".%s--retry_request_key_count.Avg", storeName)).value(),
+            keyCount);
+      } else {
+        Assert.assertEquals(
+            (int) metrics.get(String.format(".%s--retry_request_success_key_count.Max", storeName)).value(),
+            keyCount);
+        Assert.assertEquals(
+            (int) metrics.get(String.format(".%s--retry_request_success_key_count.Avg", storeName)).value(),
+            keyCount);
+      }
+
+      // Check OpenTelemetry metrics
+      Attributes expectedAttr = getAttributes(storeName, isRequest ? REQUEST : RESPONSE);
+      validateHistogramPointData(
+          inMemoryMetricReader,
+          keyCount,
+          keyCount,
+          1,
+          keyCount,
+          expectedAttr,
+          RETRY_KEY_COUNT.getMetricEntity().getMetricName(),
+          client.getMetricsPrefix());
+    }
+  }
+
   private BasicClientStats createStats(InMemoryMetricReader inMemoryMetricReader, ClientType clientType) {
     String storeName = "test_store";
     VeniceMetricsRepository metricsRepository =
@@ -349,6 +399,14 @@ public class BasicClientStatsTest {
             MetricUnit.NUMBER,
             "Count of all retry requests for client",
             Utils.setOf(VENICE_STORE_NAME, VENICE_REQUEST_METHOD, VENICE_REQUEST_RETRY_TYPE)));
+    expectedMetrics.put(
+        RETRY_KEY_COUNT,
+        new MetricEntity(
+            "retry_key_count",
+            MetricType.MIN_MAX_COUNT_SUM_AGGREGATIONS,
+            MetricUnit.NUMBER,
+            "Key count of retry requests for client",
+            Utils.setOf(VENICE_STORE_NAME, VENICE_REQUEST_METHOD, VENICE_MESSAGE_TYPE)));
 
     Set<String> uniqueMetricEntitiesNames = new HashSet<>();
 


### PR DESCRIPTION
## Problem Statement
Add a new 'retry_key_count' OTel metrics for clients. Its corresponding techuti metrics are 'retry_request_key_count' and 'retry_request_success_key_count'. Similar to another OTel metric 'key_count', We tag the new metric 'retry_key_count' with 'request/response' dimension.


###  Code changes
- [ ] Added new code behind **a config**. If so list the config names and their default values in the PR description.
- [ ] Introduced new **log lines**. 
  - [ ] Confirmed if logs need to be **rate limited** to avoid excessive logging.

###  **Concurrency-Specific Checks**
Both reviewer and PR author to verify
- [ ] Code has **no race conditions** or **thread safety issues**.
- [ ] Proper **synchronization mechanisms** (e.g., `synchronized`, `RWLock`) are used where needed.
- [ ] No **blocking calls** inside critical sections that could lead to deadlocks or performance degradation.
- [ ] Verified **thread-safe collections** are used (e.g., `ConcurrentHashMap`, `CopyOnWriteArrayList`).
- [ ] Validated proper exception handling in multi-threaded code to avoid silent thread termination.


## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->

- [x] New unit tests added.
- [ ] New integration tests added.
- [ ] Modified or extended existing tests.
- [ ] Verified backward compatibility (if applicable).

## Does this PR introduce any user-facing or breaking changes?
<!--  
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Clearly explain the behavior change and its impact.