### PR TITLE
[vpj] Prevent regular batch push when there are TTL re-pushes

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -321,7 +321,6 @@ subprojects {
     doFirst {
       def versionOverrides = [
 //        project(':internal:venice-common').file('src/main/resources/avro/StoreVersionState/v5', PathValidation.DIRECTORY)
-          project(':internal:venice-common').file('src/main/resources/avro/StoreMetaValue/v31', PathValidation.DIRECTORY),
           project(':internal:venice-common').file('src/main/resources/avro/PartitionState/v17', PathValidation.DIRECTORY),
       ]
 

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/PushJobSetting.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/PushJobSetting.java
@@ -166,5 +166,6 @@ public class PushJobSetting implements Serializable {
 
   public boolean isBatchWriteOptimizationForHybridStoreEnabled;
   public boolean isSortedIngestionEnabled;
+  public boolean allowRegularPushWithTTLRepush;
 
 }

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/VenicePushJob.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/VenicePushJob.java
@@ -289,6 +289,8 @@ public class VenicePushJob implements AutoCloseable {
         pushJobSetting.jobStartTimeMs + "_" + props.getString(JOB_EXEC_URL, "failed_to_obtain_execution_url");
     if (pushJobSetting.isSourceKafka) {
       pushId = pushJobSetting.repushTTLEnabled ? Version.generateTTLRePushId(pushId) : Version.generateRePushId(pushId);
+    } else if (pushJobSetting.allowRegularPushWithTTLRepush) {
+      pushId = Version.generateRegularPushWithTTLRePushId(pushId);
     }
     pushJobDetails.pushId = pushId;
   }
@@ -741,7 +743,7 @@ public class VenicePushJob implements AutoCloseable {
           LOGGER.info("Overriding re-push rewind time in seconds to: {}", pushJobSetting.rewindTimeInSecondsOverride);
         }
       }
-      validateRegularPushWithTTLRepush(controllerClient, pushJobSetting);
+      checkRegularPushWithTTLRepush(controllerClient, pushJobSetting);
       // Create new store version, topic and fetch Kafka url from backend
       createNewStoreVersion(
           pushJobSetting,
@@ -2074,7 +2076,7 @@ public class VenicePushJob implements AutoCloseable {
   }
 
   // Visible for unit testing
-  void validateRegularPushWithTTLRepush(ControllerClient controllerClient, PushJobSetting setting) {
+  void checkRegularPushWithTTLRepush(ControllerClient controllerClient, PushJobSetting setting) {
     if (setting.allowRegularPushWithTTLRepush) {
       return;
     }

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/vpj/VenicePushJobConstants.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/vpj/VenicePushJobConstants.java
@@ -342,4 +342,5 @@ public final class VenicePushJobConstants {
   public static final String DATA_WRITER_COMPUTE_JOB_CLASS = "data.writer.compute.job.class";
 
   public static final String PUSH_TO_SEPARATE_REALTIME_TOPIC = "push.to.separate.realtime.topic";
+  public static final String ALLOW_REGULAR_PUSH_WITH_TTL_REPUSH = "allow.regular.push.with.ttl.repush";
 }

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/vpj/VenicePushJobConstants.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/vpj/VenicePushJobConstants.java
@@ -342,5 +342,10 @@ public final class VenicePushJobConstants {
   public static final String DATA_WRITER_COMPUTE_JOB_CLASS = "data.writer.compute.job.class";
 
   public static final String PUSH_TO_SEPARATE_REALTIME_TOPIC = "push.to.separate.realtime.topic";
+  /**
+   * Currently regular batch pushes are not compatible with TTL re-push enabled stores. This is because a regular batch
+   * push does not provide any RMD to be used for TTL. You can use the TIMESTAMP_FIELD_PROP to provide record level
+   * timestamp to perform compatible batch push or use this setting to override the batch push and TTL re-push check.
+   */
   public static final String ALLOW_REGULAR_PUSH_WITH_TTL_REPUSH = "allow.regular.push.with.ttl.repush";
 }

--- a/clients/venice-push-job/src/test/java/com/linkedin/venice/hadoop/VenicePushJobTest.java
+++ b/clients/venice-push-job/src/test/java/com/linkedin/venice/hadoop/VenicePushJobTest.java
@@ -1293,23 +1293,23 @@ public class VenicePushJobTest {
     PushJobSetting pushJobSetting = venicePushJob.getPushJobSetting();
     pushJobSetting.inputHasRecords = true;
     pushJobSetting.isIncrementalPush = true;
-    venicePushJob.validateRegularPushWithTTLRepush(mockControllerClient, venicePushJob.getPushJobSetting());
+    venicePushJob.checkRegularPushWithTTLRepush(mockControllerClient, venicePushJob.getPushJobSetting());
     venicePushJob = new VenicePushJob(PUSH_JOB_ID, props);
     pushJobSetting = venicePushJob.getPushJobSetting();
     pushJobSetting.inputHasRecords = true;
     pushJobSetting.isSourceKafka = true;
-    venicePushJob.validateRegularPushWithTTLRepush(mockControllerClient, venicePushJob.getPushJobSetting());
+    venicePushJob.checkRegularPushWithTTLRepush(mockControllerClient, venicePushJob.getPushJobSetting());
     venicePushJob = new VenicePushJob(PUSH_JOB_ID, props);
     pushJobSetting = venicePushJob.getPushJobSetting();
     pushJobSetting.inputHasRecords = false;
-    venicePushJob.validateRegularPushWithTTLRepush(mockControllerClient, venicePushJob.getPushJobSetting());
+    venicePushJob.checkRegularPushWithTTLRepush(mockControllerClient, venicePushJob.getPushJobSetting());
     // Regular batch push should be rejected
     final VenicePushJob failPushJob = new VenicePushJob(PUSH_JOB_ID, props);
     pushJobSetting = failPushJob.getPushJobSetting();
     pushJobSetting.inputHasRecords = true;
     Assert.assertThrows(
         VeniceException.class,
-        () -> failPushJob.validateRegularPushWithTTLRepush(mockControllerClient, failPushJob.getPushJobSetting()));
+        () -> failPushJob.checkRegularPushWithTTLRepush(mockControllerClient, failPushJob.getPushJobSetting()));
   }
 
   private SchemaResponse getKeySchemaResponse() {

--- a/clients/venice-push-job/src/test/java/com/linkedin/venice/hadoop/VenicePushJobTest.java
+++ b/clients/venice-push-job/src/test/java/com/linkedin/venice/hadoop/VenicePushJobTest.java
@@ -2,7 +2,6 @@ package com.linkedin.venice.hadoop;
 
 import static com.linkedin.venice.ConfigKeys.MULTI_REGION;
 import static com.linkedin.venice.hadoop.VenicePushJob.getExecutionStatusFromControllerResponse;
-import static com.linkedin.venice.meta.Version.VENICE_TTL_RE_PUSH_PUSH_ID_PREFIX;
 import static com.linkedin.venice.status.BatchJobHeartbeatConfigs.HEARTBEAT_ENABLED_CONFIG;
 import static com.linkedin.venice.utils.ByteUtils.BYTES_PER_MB;
 import static com.linkedin.venice.utils.TestWriteUtils.NAME_RECORD_V1_SCHEMA;
@@ -1287,9 +1286,7 @@ public class VenicePushJobTest {
     doReturn(false).when(mockStoreResponse).isError();
     StoreInfo mockStoreInfo = mock(StoreInfo.class);
     doReturn(mockStoreInfo).when(mockStoreResponse).getStore();
-    Version mockVersion = mock(Version.class);
-    doReturn(VENICE_TTL_RE_PUSH_PUSH_ID_PREFIX + "test-push-id").when(mockVersion).getPushJobId();
-    doReturn(Collections.singletonList(mockVersion)).when(mockStoreInfo).getVersions();
+    doReturn(true).when(mockStoreInfo).isTTLRepushEnabled();
     // Re-push, incremental and empty pushes should be allowed
     Properties props = getVpjRequiredProperties();
     VenicePushJob venicePushJob = new VenicePushJob(PUSH_JOB_ID, props);

--- a/internal/venice-common/src/main/java/com/linkedin/venice/controllerapi/ControllerApiConstants.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/controllerapi/ControllerApiConstants.java
@@ -273,4 +273,5 @@ public class ControllerApiConstants {
    * Params for repush job
    */
   public static final String SOURCE_REGION = "source_region";
+  public static final String TTL_REPUSH_ENABLED = "ttl_repush_enabled";
 }

--- a/internal/venice-common/src/main/java/com/linkedin/venice/controllerapi/UpdateStoreQueryParams.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/controllerapi/UpdateStoreQueryParams.java
@@ -70,6 +70,7 @@ import static com.linkedin.venice.controllerapi.ControllerApiConstants.STORE_VIE
 import static com.linkedin.venice.controllerapi.ControllerApiConstants.TARGET_SWAP_REGION;
 import static com.linkedin.venice.controllerapi.ControllerApiConstants.TARGET_SWAP_REGION_WAIT_TIME;
 import static com.linkedin.venice.controllerapi.ControllerApiConstants.TIME_LAG_TO_GO_ONLINE;
+import static com.linkedin.venice.controllerapi.ControllerApiConstants.TTL_REPUSH_ENABLED;
 import static com.linkedin.venice.controllerapi.ControllerApiConstants.UNUSED_SCHEMA_DELETION_ENABLED;
 import static com.linkedin.venice.controllerapi.ControllerApiConstants.UPDATED_CONFIGS_LIST;
 import static com.linkedin.venice.controllerapi.ControllerApiConstants.VERSION;
@@ -159,6 +160,7 @@ public class UpdateStoreQueryParams extends QueryParams {
             .setMinCompactionLagSeconds(srcStore.getMinCompactionLagSeconds())
             .setNearlineProducerCountPerWriter(srcStore.getNearlineProducerCountPerWriter())
             .setIsDavinciHeartbeatReported(srcStore.getIsDavinciHeartbeatReported())
+            .setTTLRepushEnabled(srcStore.isTTLRepushEnabled())
             // TODO: This needs probably some refinement, but since we only support one kind of view type today, this is
             // still easy to parse
             .setStoreViews(
@@ -815,6 +817,14 @@ public class UpdateStoreQueryParams extends QueryParams {
 
   public Optional<Boolean> isGlobalRtDivEnabled() {
     return getBoolean(GLOBAL_RT_DIV_ENABLED);
+  }
+
+  public UpdateStoreQueryParams setTTLRepushEnabled(boolean ttlRepushEnabled) {
+    return putBoolean(TTL_REPUSH_ENABLED, ttlRepushEnabled);
+  }
+
+  public Optional<Boolean> isTTLRepushEnabled() {
+    return getBoolean(TTL_REPUSH_ENABLED);
   }
 
   // ***************** above this line are getters and setters *****************

--- a/internal/venice-common/src/main/java/com/linkedin/venice/meta/ReadOnlyStore.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/meta/ReadOnlyStore.java
@@ -1640,6 +1640,16 @@ public class ReadOnlyStore implements Store {
   }
 
   @Override
+  public boolean isTTLRepushEnabled() {
+    return delegate.isTTLRepushEnabled();
+  }
+
+  @Override
+  public void setTTLRepushEnabled(boolean ttlRepushEnabled) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
   public String toString() {
     return this.delegate.toString();
   }

--- a/internal/venice-common/src/main/java/com/linkedin/venice/meta/Store.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/meta/Store.java
@@ -357,4 +357,8 @@ public interface Store {
   boolean isGlobalRtDivEnabled();
 
   void setGlobalRtDivEnabled(boolean globalRtDivEnabled);
+
+  boolean isTTLRepushEnabled();
+
+  void setTTLRepushEnabled(boolean ttlRepushEnabled);
 }

--- a/internal/venice-common/src/main/java/com/linkedin/venice/meta/StoreInfo.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/meta/StoreInfo.java
@@ -85,6 +85,7 @@ public class StoreInfo {
     storeInfo.setTargetRegionSwapWaitTime(store.getTargetSwapRegionWaitTime());
     storeInfo.setIsDavinciHeartbeatReported(store.getIsDavinciHeartbeatReported());
     storeInfo.setGlobalRtDivEnabled(store.isGlobalRtDivEnabled());
+    storeInfo.setTTLRepushEnabled(store.isTTLRepushEnabled());
     return storeInfo;
   }
 
@@ -358,6 +359,10 @@ public class StoreInfo {
   private int targetRegionSwapWaitTime;
   private boolean isDavinciHeartbeatReported;
   private boolean globalRtDivEnabled = false;
+  /**
+   * Self-managed config that's set to true once there is a TTL re-push.
+   */
+  private boolean ttlRepushEnabled = false;
 
   public StoreInfo() {
   }
@@ -934,5 +939,13 @@ public class StoreInfo {
 
   public boolean isGlobalRtDivEnabled() {
     return this.globalRtDivEnabled;
+  }
+
+  public void setTTLRepushEnabled(boolean ttlRepushEnabled) {
+    this.ttlRepushEnabled = ttlRepushEnabled;
+  }
+
+  public boolean isTTLRepushEnabled() {
+    return this.ttlRepushEnabled;
   }
 }

--- a/internal/venice-common/src/main/java/com/linkedin/venice/meta/SystemStore.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/meta/SystemStore.java
@@ -767,6 +767,16 @@ public class SystemStore extends AbstractStore {
   }
 
   @Override
+  public boolean isTTLRepushEnabled() {
+    return zkSharedStore.isTTLRepushEnabled();
+  }
+
+  @Override
+  public void setTTLRepushEnabled(boolean ttlRepushEnabled) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
   public boolean isGlobalRtDivEnabled() {
     return zkSharedStore.isGlobalRtDivEnabled();
   }

--- a/internal/venice-common/src/main/java/com/linkedin/venice/meta/Version.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/meta/Version.java
@@ -37,6 +37,12 @@ public interface Version extends Comparable<Version>, DataModelBackedStructure<S
   String VENICE_RE_PUSH_PUSH_ID_PREFIX = "venice_re_push_";
 
   String VENICE_TTL_RE_PUSH_PUSH_ID_PREFIX = "venice_ttl_re_push_";
+
+  /**
+   * Prefix used in push id to indicate a regular batch push is made to a store with TTL re-push enabled. This disables
+   * the TTL re-push enabled flag for the corresponding store.
+   */
+  String VENICE_REGULAR_PUSH_WITH_TTL_RE_PUSH_PREFIX = "venice_regular_push_with_ttl_re_push_";
   int DEFAULT_RT_VERSION_NUMBER = 0;
 
   /**
@@ -522,6 +528,10 @@ public interface Version extends Comparable<Version>, DataModelBackedStructure<S
     return VENICE_TTL_RE_PUSH_PUSH_ID_PREFIX + pushId;
   }
 
+  static String generateRegularPushWithTTLRePushId(String pushId) {
+    return VENICE_REGULAR_PUSH_WITH_TTL_RE_PUSH_PREFIX + pushId;
+  }
+
   static boolean isPushIdTTLRePush(String pushId) {
     if (pushId == null || pushId.isEmpty()) {
       return false;
@@ -534,6 +544,13 @@ public interface Version extends Comparable<Version>, DataModelBackedStructure<S
       return false;
     }
     return pushId.startsWith(VENICE_RE_PUSH_PUSH_ID_PREFIX);
+  }
+
+  static boolean isPushIdRegularPushWithTTLRePush(String pushId) {
+    if (pushId == null || pushId.isEmpty()) {
+      return false;
+    }
+    return pushId.startsWith(VENICE_REGULAR_PUSH_WITH_TTL_RE_PUSH_PREFIX);
   }
 
   static boolean containsHybridVersion(List<Version> versions) {

--- a/internal/venice-common/src/main/java/com/linkedin/venice/meta/ZKStore.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/meta/ZKStore.java
@@ -237,6 +237,7 @@ public class ZKStore extends AbstractStore implements DataModelBackedStructure<S
     setTargetSwapRegionWaitTime(store.getTargetSwapRegionWaitTime());
     setIsDavinciHeartbeatReported(store.getIsDavinciHeartbeatReported());
     setGlobalRtDivEnabled(store.isGlobalRtDivEnabled());
+    setTTLRepushEnabled(store.isTTLRepushEnabled());
 
     for (Version storeVersion: store.getVersions()) {
       forceAddVersion(storeVersion.cloneVersion(), true);
@@ -999,6 +1000,16 @@ public class ZKStore extends AbstractStore implements DataModelBackedStructure<S
   @Override
   public void setGlobalRtDivEnabled(boolean globalRtDivEnabled) {
     this.storeProperties.globalRtDivEnabled = globalRtDivEnabled;
+  }
+
+  @Override
+  public boolean isTTLRepushEnabled() {
+    return this.storeProperties.ttlRepushEnabled;
+  }
+
+  @Override
+  public void setTTLRepushEnabled(boolean ttlRepushEnabled) {
+    this.storeProperties.ttlRepushEnabled = ttlRepushEnabled;
   }
 
   @Override

--- a/internal/venice-common/src/main/java/com/linkedin/venice/serialization/avro/AvroProtocolDefinition.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/serialization/avro/AvroProtocolDefinition.java
@@ -147,7 +147,7 @@ public enum AvroProtocolDefinition {
   /**
    * Value schema for metadata system store.
    */
-  METADATA_SYSTEM_SCHEMA_STORE(31, StoreMetaValue.class),
+  METADATA_SYSTEM_SCHEMA_STORE(32, StoreMetaValue.class),
 
   /**
    * Key schema for push status system store.

--- a/internal/venice-common/src/test/java/com/linkedin/venice/meta/TestVersion.java
+++ b/internal/venice-common/src/test/java/com/linkedin/venice/meta/TestVersion.java
@@ -172,6 +172,10 @@ public class TestVersion {
   public void testPushId() {
     String pushId = VENICE_TTL_RE_PUSH_PUSH_ID_PREFIX + System.currentTimeMillis();
     assertTrue(Version.isPushIdTTLRePush(pushId));
+    String regularPushWithRePushId =
+        Version.generateRegularPushWithTTLRePushId(Long.toString(System.currentTimeMillis()));
+    assertTrue(Version.isPushIdRegularPushWithTTLRePush(regularPushWithRePushId));
+    assertFalse(Version.isPushIdRegularPushWithTTLRePush(pushId));
   }
 
   @Test

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/hadoop/TestVenicePushJob.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/hadoop/TestVenicePushJob.java
@@ -686,13 +686,14 @@ public class TestVenicePushJob {
                 .setChunkingEnabled(true)
                 .setRmdChunkingEnabled(true)));
     controllerClient.emptyPush(storeName, "test-empty-push", 1000000L);
-    // Enable repush ttl
+    // Enable ttl re-push
     props.setProperty(REPUSH_TTL_ENABLE, "true");
     props.setProperty(SOURCE_KAFKA, "true");
     IntegrationTestPushUtils.runVPJ(props);
     StoreResponse response = controllerClient.getStore(storeName);
     Assert.assertFalse(response.isError());
     Assert.assertEquals(response.getStore().getVersions().size(), 2);
+    Assert.assertTrue(response.getStore().isTTLRepushEnabled());
     props.remove(REPUSH_TTL_ENABLE);
     props.remove(SOURCE_KAFKA);
     // A regular batch push should fail

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/hadoop/TestVenicePushJob.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/hadoop/TestVenicePushJob.java
@@ -20,6 +20,7 @@ import static com.linkedin.venice.vpj.VenicePushJobConstants.KAFKA_INPUT_MAX_REC
 import static com.linkedin.venice.vpj.VenicePushJobConstants.KAFKA_INPUT_TOPIC;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.KEY_FIELD_PROP;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.MAP_REDUCE_PARTITIONER_CLASS_CONFIG;
+import static com.linkedin.venice.vpj.VenicePushJobConstants.REPUSH_TTL_ENABLE;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.SEND_CONTROL_MESSAGES_DIRECTLY;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.SOURCE_KAFKA;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.SUPPRESS_END_OF_PUSH_MESSAGE;
@@ -663,5 +664,38 @@ public class TestVenicePushJob {
         Assert.assertEquals(avroClient.get(Integer.toString(i)).get().toString(), "test_name_" + i);
       }
     }
+  }
+
+  @Test(timeOut = TEST_TIMEOUT, expectedExceptions = VeniceException.class, expectedExceptionsMessageRegExp = ".*regular batch push is not allowed with TTL re-push")
+  public void testRegularBatchPushWithTTLRepush() throws Exception {
+    File inputDir = getTempDataDirectory();
+    String storeName = Utils.getUniqueString("store");
+    Schema recordSchema = writeSimpleAvroFileWithStringToStringSchema(inputDir);
+    ControllerClient controllerClient =
+        new ControllerClient(veniceCluster.getClusterName(), veniceCluster.getRandomRouterURL());
+    String inputDirPath = "file://" + inputDir.getAbsolutePath();
+    Properties props = defaultVPJProps(veniceCluster, inputDirPath, storeName);
+    createStoreForJob(veniceCluster.getClusterName(), recordSchema, props);
+    TestUtils.assertCommand(
+        controllerClient.updateStore(
+            storeName,
+            new UpdateStoreQueryParams().setHybridOffsetLagThreshold(1)
+                .setHybridRewindSeconds(0)
+                .setActiveActiveReplicationEnabled(true)
+                .setNativeReplicationEnabled(true)
+                .setChunkingEnabled(true)
+                .setRmdChunkingEnabled(true)));
+    controllerClient.emptyPush(storeName, "test-empty-push", 1000000L);
+    // Enable repush ttl
+    props.setProperty(REPUSH_TTL_ENABLE, "true");
+    props.setProperty(SOURCE_KAFKA, "true");
+    IntegrationTestPushUtils.runVPJ(props);
+    StoreResponse response = controllerClient.getStore(storeName);
+    Assert.assertFalse(response.isError());
+    Assert.assertEquals(response.getStore().getVersions().size(), 2);
+    props.remove(REPUSH_TTL_ENABLE);
+    props.remove(SOURCE_KAFKA);
+    // A regular batch push should fail
+    IntegrationTestPushUtils.runVPJ(props);
   }
 }

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceHelixAdmin.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceHelixAdmin.java
@@ -3162,6 +3162,10 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
               }
             }
           }
+          if (Version.isPushIdTTLRePush(pushJobId) && !store.isTTLRepushEnabled()) {
+            store.setTTLRepushEnabled(true);
+            repository.updateStore(store);
+          }
           if (startIngestion) {
             // We need to prepare to monitor before creating helix resource.
             startMonitorOfflinePush(
@@ -5488,6 +5492,7 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
     Optional<Integer> targetSwapRegionWaitTime = params.getTargetRegionSwapWaitTime();
     Optional<Boolean> isDavinciHeartbeatReported = params.getIsDavinciHeartbeatReported();
     Optional<Boolean> globalRtDivEnabled = params.isGlobalRtDivEnabled();
+    Optional<Boolean> ttlRepushEnabled = params.isTTLRepushEnabled();
 
     final Optional<HybridStoreConfig> newHybridStoreConfig;
     if (hybridRewindSeconds.isPresent() || hybridOffsetLagThreshold.isPresent() || hybridTimeLagThreshold.isPresent()
@@ -5814,6 +5819,11 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
 
       globalRtDivEnabled.ifPresent(aBool -> storeMetadataUpdate(clusterName, storeName, store -> {
         store.setGlobalRtDivEnabled(aBool);
+        return store;
+      }));
+
+      ttlRepushEnabled.ifPresent(aBool -> storeMetadataUpdate(clusterName, storeName, store -> {
+        store.setTTLRepushEnabled(aBool);
         return store;
       }));
 

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceHelixAdmin.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceHelixAdmin.java
@@ -3162,8 +3162,12 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
               }
             }
           }
+          // Check the push job id to self-manage the ttlRepushEnabled store property.
           if (Version.isPushIdTTLRePush(pushJobId) && !store.isTTLRepushEnabled()) {
             store.setTTLRepushEnabled(true);
+            repository.updateStore(store);
+          } else if (Version.isPushIdRegularPushWithTTLRePush(pushJobId) && store.isTTLRepushEnabled()) {
+            store.setTTLRepushEnabled(false);
             repository.updateStore(store);
           }
           if (startIngestion) {


### PR DESCRIPTION
## Problem Statement
Regular batch push and TTL re-push today are incompatible features. This is because regular batch push will wipe out the RMD needed to perform TTL re-push.


## Solution
Added a new self-managed `storeProperties.ttlRepushEnabled` property to signal ttl-repush is enabled for a given store. The property is set to true once a TTL re-push is attempted for a store. Once the property is set to true we will disallow regular batch push.

We allow incremental push, re-push, empty pushes and batch push with record level timestamp to go through. Users can also override this check via VPJ property allow.regular.push.with.ttl.repush.


###  Code changes
- [ ] Added new code behind **a config**. If so list the config names and their default values in the PR description.
- [ ] Introduced new **log lines**. 
  - [ ] Confirmed if logs need to be **rate limited** to avoid excessive logging.

###  **Concurrency-Specific Checks**
Both reviewer and PR author to verify
- [ ] Code has **no race conditions** or **thread safety issues**.
- [ ] Proper **synchronization mechanisms** (e.g., `synchronized`, `RWLock`) are used where needed.
- [ ] No **blocking calls** inside critical sections that could lead to deadlocks or performance degradation.
- [ ] Verified **thread-safe collections** are used (e.g., `ConcurrentHashMap`, `CopyOnWriteArrayList`).
- [ ] Validated proper exception handling in multi-threaded code to avoid silent thread termination.


## How was this PR tested?
New integration test and unit test

- [ ] New unit tests added.
- [ ] New integration tests added.
- [ ] Modified or extended existing tests.
- [ ] Verified backward compatibility (if applicable).

## Does this PR introduce any user-facing or breaking changes?
<!--  
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [ ] No. You can skip the rest of this section.
- [ ] Yes. Clearly explain the behavior change and its impact.