### PR TITLE
Add gRPC countByValue RPC method to VeniceReadService protocol

### DIFF
--- a/internal/venice-common/src/main/proto/VeniceReadService.proto
+++ b/internal/venice-common/src/main/proto/VeniceReadService.proto
@@ -6,6 +6,7 @@ option java_multiple_files = true;
 service VeniceReadService {
   rpc get (VeniceClientRequest) returns (VeniceServerResponse) {}
   rpc batchGet(VeniceClientRequest) returns (VeniceServerResponse) {}
+  rpc countByValue(CountByValueRequest) returns (CountByValueResponse) {}
 }
 
 message VeniceClientRequest {
@@ -29,4 +30,21 @@ message VeniceServerResponse {
 
   uint32 errorCode = 6;
   string errorMessage = 7;
+}
+
+message CountByValueRequest {
+  repeated bytes keys = 1;
+  string resourceName = 2;
+  int32 topK = 3;
+  repeated string fieldNames = 4;
+}
+
+message CountByValueResponse {
+  map<string, ValueCount> fieldToValueCounts = 1;
+  uint32 errorCode = 2;
+  string errorMessage = 3;
+}
+
+message ValueCount {
+  map<string, int32> valueToCounts = 1;
 }


### PR DESCRIPTION
**Title**: [protocol] Add gRPC countByValue RPC method to VeniceReadService

  ## Problem Statement

  The current VeniceReadService gRPC protocol only supports basic get and batchGet
  operations. To enable server-side countByValue aggregation functionality, we need to
  extend the protocol with new RPC methods and message types.

  This is a prerequisite change for implementing true server-side countByValue
  aggregation in the Venice fast-client, which will reduce network traffic and improve
  performance by moving aggregation logic from client to server.

  ## Solution

  Added new gRPC protocol definitions to `VeniceReadService.proto`:

  - **New RPC method**: `countByValue(CountByValueRequest) returns
  (CountByValueResponse)`
  - **New message types**:
    - `CountByValueRequest`: Contains keys, resource name, topK limit, and field names
    - `CountByValueResponse`: Returns field-to-value-count mappings with error handling
    - `ValueCount`: Helper message for value-to-count mappings

  This protocol extension follows gRPC best practices and maintains backward
  compatibility with existing get/batchGet operations.

  ###  Code changes
  - [x] Added new code behind **a config**. No configs required - protocol extension
  only.
  - [ ] Introduced new **log lines**.

  ###  **Concurrency-Specific Checks**
  - [x] Code has **no race conditions** or **thread safety issues**. (Protocol
  definition only)
  - [x] Proper **synchronization mechanisms** not applicable for protocol definitions.
  - [x] No **blocking calls** not applicable for protocol definitions.
  - [x] Verified **thread-safe collections** not applicable for protocol definitions.
  - [x] Validated proper exception handling in multi-threaded code not applicable for
  protocol definitions.

  ## How was this PR tested?

  - [x] New unit tests added. N/A - Protocol definition only.
  - [x] New integration tests added. N/A - Protocol definition only.
  - [x] Modified or extended existing tests. N/A - Protocol definition only.
  - [x] Verified backward compatibility. Yes - existing RPCs unchanged.

  ## Does this PR introduce any user-facing or breaking changes?

  - [x] No. You can skip the rest of this section.

  This PR only adds new protocol definitions without changing existing functionality.
  The new RPC methods will be implemented in a separate PR after this protocol change is
   merged.