### PR TITLE
[controller] Fixed a bug when calculating real-time topic retention

### DIFF
--- a/services/venice-controller/src/test/java/com/linkedin/venice/ingestion/control/RealTimeTopicSwitcherRewindTest.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/ingestion/control/RealTimeTopicSwitcherRewindTest.java
@@ -62,7 +62,7 @@ public class RealTimeTopicSwitcherRewindTest {
     when(veniceWriterFactory.<byte[], byte[], byte[]>createVeniceWriter(any())).thenReturn(veniceWriter);
 
     // Methods under test
-    doCallRealMethod().when(topicReplicator).ensurePreconditions(any(), any(), any(), any());
+    doCallRealMethod().when(topicReplicator).ensurePreconditions(any(), any(), any());
     doCallRealMethod().when(topicReplicator).getRewindStartTime(any(), any(), anyLong());
     doCallRealMethod().when(topicReplicator).sendTopicSwitch(any(), any(), anyLong(), anyList());
   }
@@ -80,8 +80,9 @@ public class RealTimeTopicSwitcherRewindTest {
             BufferReplayPolicy.REWIND_FROM_EOP)));
     final PubSubTopic sourceTopicName = pubSubTopicRepository.getTopic("source topic name_v1");
     final PubSubTopic destinationTopicName = pubSubTopicRepository.getTopic("destination topic name_v1");
+    store.setHybridStoreConfig(hybridStoreConfig.get());
 
-    topicReplicator.ensurePreconditions(sourceTopicName, destinationTopicName, store, hybridStoreConfig);
+    topicReplicator.ensurePreconditions(sourceTopicName, destinationTopicName, store);
     long rewindStartTime =
         topicReplicator.getRewindStartTime(mock(Version.class), hybridStoreConfig, VERSION_CREATION_TIME_MS);
     assertEquals(
@@ -92,8 +93,9 @@ public class RealTimeTopicSwitcherRewindTest {
 
     verify(topicReplicator).sendTopicSwitch(sourceTopicName, destinationTopicName, rewindStartTime, null);
 
+    store.setHybridStoreConfig(null);
     try {
-      topicReplicator.ensurePreconditions(sourceTopicName, destinationTopicName, store, Optional.empty());
+      topicReplicator.ensurePreconditions(sourceTopicName, destinationTopicName, store);
       fail("topicReplicator.startBufferReplay should fail (FOR NOW) for non-Hybrid stores.");
     } catch (VeniceException e) {
       // expected
@@ -114,7 +116,8 @@ public class RealTimeTopicSwitcherRewindTest {
     final PubSubTopic sourceTopicName = pubSubTopicRepository.getTopic("source topic name_v1");
     final PubSubTopic destinationTopicName = pubSubTopicRepository.getTopic("destination topic name_v1");
 
-    topicReplicator.ensurePreconditions(sourceTopicName, destinationTopicName, store, hybridStoreConfig);
+    store.setHybridStoreConfig(hybridStoreConfig.get());
+    topicReplicator.ensurePreconditions(sourceTopicName, destinationTopicName, store);
     long rewindStartTime =
         topicReplicator.getRewindStartTime(mock(Version.class), hybridStoreConfig, VERSION_CREATION_TIME_MS);
     assertEquals(
@@ -125,8 +128,9 @@ public class RealTimeTopicSwitcherRewindTest {
 
     verify(topicReplicator).sendTopicSwitch(sourceTopicName, destinationTopicName, rewindStartTime, null);
 
+    store.setHybridStoreConfig(null);
     try {
-      topicReplicator.ensurePreconditions(sourceTopicName, destinationTopicName, store, Optional.empty());
+      topicReplicator.ensurePreconditions(sourceTopicName, destinationTopicName, store);
       fail("topicReplicator.startBufferReplay should fail (FOR NOW) for non-Hybrid stores.");
     } catch (VeniceException e) {
       // expected

--- a/services/venice-controller/src/test/java/com/linkedin/venice/ingestion/control/RealTimeTopicSwitcherTest.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/ingestion/control/RealTimeTopicSwitcherTest.java
@@ -24,6 +24,7 @@ import com.linkedin.venice.meta.VersionImpl;
 import com.linkedin.venice.pubsub.PubSubTopicRepository;
 import com.linkedin.venice.pubsub.api.PubSubTopic;
 import com.linkedin.venice.pubsub.manager.TopicManager;
+import com.linkedin.venice.utils.StoreUtils;
 import com.linkedin.venice.utils.Utils;
 import com.linkedin.venice.utils.VeniceProperties;
 import com.linkedin.venice.writer.VeniceWriter;
@@ -216,8 +217,8 @@ public class RealTimeTopicSwitcherTest {
     Store mockStore = mock(Store.class);
     HybridStoreConfig mockHybridConfig = mock(HybridStoreConfig.class);
 
-    doReturn(true).when(mockStore).isHybrid();
     doReturn(mockHybridConfig).when(mockStore).getHybridStoreConfig();
+    doReturn(true).when(mockStore).isHybrid();
     Version version = new VersionImpl(destTopic.getStoreName(), 1, "test-id");
     doReturn(version).when(mockStore).getVersion(Version.parseVersionFromKafkaTopicName(destTopic.getName()));
     doReturn(3600L).when(mockHybridConfig).getRewindTimeInSeconds();
@@ -225,13 +226,15 @@ public class RealTimeTopicSwitcherTest {
     doReturn(false).when(mockTopicManager).containsTopicAndAllPartitionsAreOnline(srcTopic);
     doReturn(true).when(mockTopicManager).containsTopicAndAllPartitionsAreOnline(destTopic);
 
-    leaderStorageNodeReplicator.ensurePreconditions(srcTopic, destTopic, mockStore, Optional.of(mockHybridConfig));
+    leaderStorageNodeReplicator.ensurePreconditions(srcTopic, destTopic, mockStore);
+
+    long retentionTime = StoreUtils.getExpectedRetentionTimeInMs(mockStore, mockStore.getHybridStoreConfig());
 
     verify(mockTopicManager).createTopic(
         eq(srcTopic),
         anyInt(),
         eq(KAFKA_RF_FOR_RT_TOPICS),
-        anyLong(),
+        eq(retentionTime),
         eq(false),
         eq(Optional.of(KAFKA_MIN_ISR_FOR_RT_TOPICS)),
         eq(false));


### PR DESCRIPTION


<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat], [protocol]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## Problem Statement
<!--
Describe
- What problem are you trying to solve
- What issues or limitations exist in the current code
- Why this change is necessary 
-->

Today, the real-time topic retention time can be calculated based on version-level rewind time config, which can be different from the store-level config and the version-level rewind time config can be overrided by a repush job.
When this happens, the real-time topic retention can be significantly lower than store-level rewind time, which makes the empty-push useless.

## Solution
<!--
Describe
- What changes you are making and why. 
- How these changes solve the problem.
- Any performance considerations or trade-offs. 
- Describe what testings you have done, for example, performance testing etc.
-->
Always use the store-level config to calculate the real-time topic retention.
The affected real-time topic retention policy will be corrected in the next push job.


###  Code changes
- [ ] Added new code behind **a config**. If so list the config names and their default values in the PR description.
- [ ] Introduced new **log lines**. 
  - [ ] Confirmed if logs need to be **rate limited** to avoid excessive logging.

###  **Concurrency-Specific Checks**
Both reviewer and PR author to verify
- [ ] Code has **no race conditions** or **thread safety issues**.
- [ ] Proper **synchronization mechanisms** (e.g., `synchronized`, `RWLock`) are used where needed.
- [ ] No **blocking calls** inside critical sections that could lead to deadlocks or performance degradation.
- [ ] Verified **thread-safe collections** are used (e.g., `ConcurrentHashMap`, `CopyOnWriteArrayList`).
- [ ] Validated proper exception handling in multi-threaded code to avoid silent thread termination.


## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->

- [ ] New unit tests added.
- [ ] New integration tests added.
- [ ] Modified or extended existing tests.
- [ ] Verified backward compatibility (if applicable).

## Does this PR introduce any user-facing or breaking changes?
<!--  
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [ ] No. You can skip the rest of this section.
- [ ] Yes. Clearly explain the behavior change and its impact.