### PR TITLE
[server][controller][dvc] Add PubSubPosition position compare, diff, and decode APIs in PubSubConsumerAdapter

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/SharedKafkaConsumer.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/SharedKafkaConsumer.java
@@ -15,6 +15,7 @@ import com.linkedin.venice.pubsub.api.exceptions.PubSubUnsubscribedTopicPartitio
 import com.linkedin.venice.utils.SystemTime;
 import com.linkedin.venice.utils.Time;
 import com.linkedin.venice.utils.concurrent.VeniceConcurrentHashMap;
+import java.nio.ByteBuffer;
 import java.time.Duration;
 import java.util.Collection;
 import java.util.Collections;
@@ -407,5 +408,26 @@ class SharedKafkaConsumer implements PubSubConsumerAdapter {
   @Override
   public List<PubSubTopicPartitionInfo> partitionsFor(PubSubTopic topic) {
     throw new UnsupportedOperationException("partitionsFor is not supported in SharedKafkaConsumer");
+  }
+
+  @Override
+  public synchronized long comparePositions(
+      PubSubTopicPartition partition,
+      PubSubPosition position1,
+      PubSubPosition position2) {
+    return delegate.comparePositions(partition, position1, position2);
+  }
+
+  @Override
+  public synchronized long positionDifference(
+      PubSubTopicPartition partition,
+      PubSubPosition position1,
+      PubSubPosition position2) {
+    return delegate.positionDifference(partition, position1, position2);
+  }
+
+  @Override
+  public synchronized PubSubPosition decodePosition(PubSubTopicPartition partition, ByteBuffer buffer) {
+    return delegate.decodePosition(partition, buffer);
   }
 }

--- a/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/adapter/kafka/common/ApacheKafkaOffsetPosition.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/adapter/kafka/common/ApacheKafkaOffsetPosition.java
@@ -43,7 +43,7 @@ public class ApacheKafkaOffsetPosition implements PubSubPosition {
             .readLong());
   }
 
-  public long getOffset() {
+  public long getInternalOffset() {
     return offset;
   }
 

--- a/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/api/LatestPosition.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/api/LatestPosition.java
@@ -7,15 +7,16 @@ import java.nio.ByteBuffer;
 
 
 /**
- * Represents a special {@link PubSubPosition} indicating the latest available message in a partition.
- * <p>
- * This position acts as a symbolic marker used to initiate consumption from the most recent offset in a topic-partition.
- * All PubSub adapters are required to support this position and map it to the appropriate "latest" offset or
- * equivalent marker in the underlying PubSub system (e.g., Kafka's "latest" offset).
- * <p>
- * This class is typically treated as a singleton and has a fixed, reserved position type ID,
- * explicitly defined in code and used during serialization.
- * <p>
+ * Represents a special {@link PubSubPosition} that indicates the latest available position in a partition.
+ *
+ * <p>This symbolic marker is used to initiate consumption from the end of a topic-partition,
+ * meaning the offset that would be assigned to the next message (i.e., one past the last existing message).</p>
+ *
+ * <p>All PubSub adapters are required to support this position and resolve it to the appropriate
+ * end position in the underlying PubSub system (e.g., Kafka's endOffset or equivalent).</p>
+ *
+ * <p>This class is treated as a singleton and has a fixed, reserved position type ID.
+ * This ID is explicitly defined in code and used during serialization and deserialization.</p>
  */
 final class LatestPosition implements PubSubPosition {
   private static final LatestPosition INSTANCE = new LatestPosition();

--- a/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/api/PubSubConsumerAdapter.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/api/PubSubConsumerAdapter.java
@@ -8,6 +8,7 @@ import com.linkedin.venice.pubsub.api.exceptions.PubSubOpTimeoutException;
 import com.linkedin.venice.pubsub.api.exceptions.PubSubTopicDoesNotExistException;
 import com.linkedin.venice.pubsub.api.exceptions.PubSubUnsubscribedTopicPartitionException;
 import java.io.Closeable;
+import java.nio.ByteBuffer;
 import java.time.Duration;
 import java.util.Collection;
 import java.util.List;
@@ -269,4 +270,47 @@ public interface PubSubConsumerAdapter extends AutoCloseable, Closeable {
    *         or {@code null} if the topic does not exist.
    */
   List<PubSubTopicPartitionInfo> partitionsFor(PubSubTopic pubSubTopic);
+
+  /**
+   * Compares two PubSub positions within the specified topic partition.
+   *
+   * @param partition The topic partition where the comparison is being performed.
+   * @param position1 The first PubSub position.
+   * @param position2 The second PubSub position.
+   * @return A negative value if {@code position1} is behind {@code position2}, zero if equal,
+   *         or a positive value if {@code position1} is ahead of {@code position2}.
+   */
+  long comparePositions(PubSubTopicPartition partition, PubSubPosition position1, PubSubPosition position2);
+
+  /**
+   * Computes the absolute difference between two PubSub positions within the specified topic partition.
+   *
+   * @param partition The topic partition for which the difference is calculated.
+   * @param position1 The first PubSub position.
+   * @param position2 The second PubSub position.
+   * @return The absolute number of messages (or offset units) between {@code position1} and {@code position2}.
+   */
+  long positionDifference(PubSubTopicPartition partition, PubSubPosition position1, PubSubPosition position2);
+
+  /**
+   * Decodes the given type-encoded byte array into a {@link PubSubPosition} for the specified topic partition.
+   *
+   * @param partition The topic partition this position belongs to.
+   * @param data The byte array containing the encoded position.
+   * @return The decoded {@link PubSubPosition}.
+   * @throws IllegalArgumentException if the data cannot be decoded into a valid {@link PubSubPosition}.
+   */
+  default PubSubPosition decodePosition(PubSubTopicPartition partition, byte[] data) {
+    return decodePosition(partition, ByteBuffer.wrap(data));
+  }
+
+  /**
+   * Decodes the given type-encoded {@link ByteBuffer} into a {@link PubSubPosition} for the specified topic partition.
+   *
+   * @param partition The topic partition this position belongs to.
+   * @param buffer The {@link ByteBuffer} containing the encoded position.
+   * @return The decoded {@link PubSubPosition}.
+   * @throws IllegalArgumentException if the buffer cannot be decoded into a valid {@link PubSubPosition}.
+   */
+  PubSubPosition decodePosition(PubSubTopicPartition partition, ByteBuffer buffer);
 }

--- a/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/api/PubSubConsumerAdapter.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/api/PubSubConsumerAdapter.java
@@ -283,12 +283,26 @@ public interface PubSubConsumerAdapter extends AutoCloseable, Closeable {
   long comparePositions(PubSubTopicPartition partition, PubSubPosition position1, PubSubPosition position2);
 
   /**
-   * Computes the absolute difference between two PubSub positions within the specified topic partition.
+   * Computes the relative difference between two {@link PubSubPosition} instances for a given
+   * {@link PubSubTopicPartition}, as {@code position1 - position2}.
+   * <p>
+   * Implementations must resolve symbolic positions such as {@link PubSubSymbolicPosition#EARLIEST}
+   * and {@link PubSubSymbolicPosition#LATEST} to concrete positions based on the partition's
+   * start and end positions. This ensures that symbolic references can be treated consistently
+   * during subtraction.
+   *
+   * <p>For example:
+   * <ul>
+   *   <li>If both positions are concrete, the result is the logical offset difference between them.</li>
+   *   <li>If {@code position1} is symbolic (e.g., EARLIEST), it must be resolved to the concrete beginning position.</li>
+   *   <li>If {@code position2} is symbolic (e.g., LATEST), it must be resolved to the concrete end position.</li>
+   * </ul>
    *
    * @param partition The topic partition for which the difference is calculated.
-   * @param position1 The first PubSub position.
-   * @param position2 The second PubSub position.
-   * @return The absolute number of messages (or offset units) between {@code position1} and {@code position2}.
+   * @param position1 The first PubSub position (minuend).
+   * @param position2 The second PubSub position (subtrahend).
+   * @return The signed offset difference between {@code position1} and {@code position2}.
+   * @throws IllegalArgumentException if either position is {@code null}, or if symbolic positions cannot be resolved.
    */
   long positionDifference(PubSubTopicPartition partition, PubSubPosition position1, PubSubPosition position2);
 
@@ -305,7 +319,7 @@ public interface PubSubConsumerAdapter extends AutoCloseable, Closeable {
   }
 
   /**
-   * Decodes the given type-encoded {@link ByteBuffer} into a {@link PubSubPosition} for the specified topic partition.
+   * Decodes the given {@link ByteBuffer} into a {@link PubSubPosition} for the specified topic partition.
    *
    * @param partition The topic partition this position belongs to.
    * @param buffer The {@link ByteBuffer} containing the encoded position.

--- a/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/api/PubSubConsumerAdapter.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/api/PubSubConsumerAdapter.java
@@ -1,5 +1,7 @@
 package com.linkedin.venice.pubsub.api;
 
+import static com.linkedin.venice.pubsub.PubSubConstants.PUBSUB_CONSUMER_API_DEFAULT_TIMEOUT_MS_DEFAULT_VALUE;
+
 import com.linkedin.venice.pubsub.PubSubConstants;
 import com.linkedin.venice.pubsub.PubSubTopicPartitionInfo;
 import com.linkedin.venice.pubsub.api.exceptions.PubSubClientException;
@@ -231,6 +233,12 @@ public interface PubSubConsumerAdapter extends AutoCloseable, Closeable {
   Long beginningOffset(PubSubTopicPartition pubSubTopicPartition, Duration timeout);
 
   PubSubPosition beginningPosition(PubSubTopicPartition pubSubTopicPartition, Duration timeout);
+
+  default PubSubPosition beginningPosition(PubSubTopicPartition pubSubTopicPartition) {
+    return beginningPosition(
+        pubSubTopicPartition,
+        Duration.ofMillis(PUBSUB_CONSUMER_API_DEFAULT_TIMEOUT_MS_DEFAULT_VALUE));
+  }
 
   /**
    * Retrieves the end offsets for a collection of PubSub topic-partitions. The end offset represents

--- a/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/api/PubSubSymbolicPosition.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/api/PubSubSymbolicPosition.java
@@ -8,9 +8,14 @@ final public class PubSubSymbolicPosition {
    * @see EarliestPosition
    */
   public static final PubSubPosition EARLIEST = EarliestPosition.getInstance();
+
   /**
    * Singleton instance representing the latest retrievable position in a partition.
    * Acts as a symbolic marker to start consuming from the tail of the stream.
+   *
+   * When resolved, this maps to the end position of the topic partition, which is defined
+   * as the offset of the last record in the topic plus one (i.e., the offset that would be
+   * assigned to the next produced record).
    *
    * @see LatestPosition
    */

--- a/internal/venice-common/src/test/java/com/linkedin/venice/pubsub/PubSubUtilTest.java
+++ b/internal/venice-common/src/test/java/com/linkedin/venice/pubsub/PubSubUtilTest.java
@@ -191,37 +191,6 @@ public class PubSubUtilTest {
   }
 
   @Test
-  public void testDiffWithNullPositionsThrowsException() {
-    assertThrows(() -> PubSubUtil.diffPubSubPositions(null, PubSubSymbolicPosition.EARLIEST));
-    assertThrows(() -> PubSubUtil.diffPubSubPositions(PubSubSymbolicPosition.LATEST, null));
-  }
-
-  @Test
-  public void testDiffWithSymbolicPositions() {
-    assertEquals(PubSubUtil.diffPubSubPositions(PubSubSymbolicPosition.EARLIEST, PubSubSymbolicPosition.EARLIEST), 0L);
-    assertEquals(PubSubUtil.diffPubSubPositions(PubSubSymbolicPosition.LATEST, PubSubSymbolicPosition.LATEST), 0L);
-    assertEquals(
-        PubSubUtil.diffPubSubPositions(PubSubSymbolicPosition.EARLIEST, PubSubSymbolicPosition.LATEST),
-        Long.MIN_VALUE);
-    assertEquals(
-        PubSubUtil.diffPubSubPositions(PubSubSymbolicPosition.LATEST, PubSubSymbolicPosition.EARLIEST),
-        Long.MAX_VALUE);
-  }
-
-  @Test
-  public void testDiffWithNumericPositions() {
-    PubSubPosition pos1 = mock(PubSubPosition.class);
-    PubSubPosition pos2 = mock(PubSubPosition.class);
-
-    when(pos1.getNumericOffset()).thenReturn(150L);
-    when(pos2.getNumericOffset()).thenReturn(100L);
-
-    assertEquals(PubSubUtil.diffPubSubPositions(pos1, pos2), 50L);
-    assertEquals(PubSubUtil.diffPubSubPositions(pos2, pos1), -50L);
-    assertEquals(PubSubUtil.diffPubSubPositions(pos1, pos1), 0L);
-  }
-
-  @Test
   public void testCompareWithNullPositionsThrowsException() {
     expectThrows(
         IllegalArgumentException.class,

--- a/internal/venice-common/src/test/java/com/linkedin/venice/pubsub/adapter/kafka/common/ApacheKafkaOffsetPositionFactoryTest.java
+++ b/internal/venice-common/src/test/java/com/linkedin/venice/pubsub/adapter/kafka/common/ApacheKafkaOffsetPositionFactoryTest.java
@@ -34,7 +34,7 @@ public class ApacheKafkaOffsetPositionFactoryTest {
 
     PubSubPosition deserialized = factory.createFromWireFormat(wireFormat);
     assertTrue(deserialized instanceof ApacheKafkaOffsetPosition);
-    assertEquals(((ApacheKafkaOffsetPosition) deserialized).getOffset(), 12345L);
+    assertEquals(((ApacheKafkaOffsetPosition) deserialized).getInternalOffset(), 12345L);
   }
 
   @Test
@@ -44,7 +44,7 @@ public class ApacheKafkaOffsetPositionFactoryTest {
 
     PubSubPosition deserialized = factory.createFromByteBuffer(buffer);
     assertTrue(deserialized instanceof ApacheKafkaOffsetPosition);
-    assertEquals(((ApacheKafkaOffsetPosition) deserialized).getOffset(), 67890L);
+    assertEquals(((ApacheKafkaOffsetPosition) deserialized).getInternalOffset(), 67890L);
   }
 
   @Test

--- a/internal/venice-common/src/test/java/com/linkedin/venice/pubsub/adapter/kafka/common/ApacheKafkaOffsetPositionTest.java
+++ b/internal/venice-common/src/test/java/com/linkedin/venice/pubsub/adapter/kafka/common/ApacheKafkaOffsetPositionTest.java
@@ -45,17 +45,17 @@ public class ApacheKafkaOffsetPositionTest {
   }
 
   @Test
-  public void testGetOffset() throws IOException {
+  public void testGetInternalOffset() throws IOException {
     ApacheKafkaOffsetPosition position1 = ApacheKafkaOffsetPosition.of(1234);
-    assertEquals(position1.getOffset(), 1234);
+    assertEquals(position1.getInternalOffset(), 1234);
     PubSubPositionWireFormat wireFormat = position1.getPositionWireFormat();
     ApacheKafkaOffsetPosition position2 = new ApacheKafkaOffsetPosition(wireFormat.rawBytes);
-    assertEquals(position2.getOffset(), position1.getOffset());
+    assertEquals(position2.getInternalOffset(), position1.getInternalOffset());
     assertEquals(position1, position2);
   }
 
   @Test(expectedExceptions = NullPointerException.class)
-  public void testGetOffsetWithNull() throws IOException {
+  public void testGetInternalOffsetWithNull() throws IOException {
     new ApacheKafkaOffsetPosition(null);
   }
 
@@ -65,7 +65,7 @@ public class ApacheKafkaOffsetPositionTest {
     PubSubPositionWireFormat wireFormat = kafkaPosition.getPositionWireFormat();
     assertEquals(wireFormat.type, PubSubPositionTypeRegistry.APACHE_KAFKA_OFFSET_POSITION_TYPE_ID);
     ApacheKafkaOffsetPosition kafkaPosition2 = new ApacheKafkaOffsetPosition(wireFormat.rawBytes);
-    assertEquals(kafkaPosition2.getOffset(), kafkaPosition.getOffset());
+    assertEquals(kafkaPosition2.getInternalOffset(), kafkaPosition.getInternalOffset());
     assertEquals(kafkaPosition2, kafkaPosition);
   }
 

--- a/internal/venice-common/src/test/java/com/linkedin/venice/pubsub/adapter/kafka/consumer/ApacheKafkaConsumerAdapterTest.java
+++ b/internal/venice-common/src/test/java/com/linkedin/venice/pubsub/adapter/kafka/consumer/ApacheKafkaConsumerAdapterTest.java
@@ -515,7 +515,7 @@ public class ApacheKafkaConsumerAdapterTest {
     PubSubPosition position = kafkaConsumerAdapter.beginningPosition(pubSubTopicPartition, Duration.ofMillis(500));
     assertNotNull(position);
     assertTrue(position instanceof ApacheKafkaOffsetPosition);
-    assertEquals(((ApacheKafkaOffsetPosition) position).getOffset(), 0L);
+    assertEquals(((ApacheKafkaOffsetPosition) position).getInternalOffset(), 0L);
 
     // Case 2: return empty response
     doReturn(Collections.emptyMap()).when(internalKafkaConsumer)
@@ -550,8 +550,8 @@ public class ApacheKafkaConsumerAdapterTest {
         .endPositions(Arrays.asList(pubSubTopicPartition1, pubSubTopicPartition2), Duration.ofMillis(500));
     assertTrue(actualPositions.get(pubSubTopicPartition1) instanceof ApacheKafkaOffsetPosition);
     assertTrue(actualPositions.get(pubSubTopicPartition2) instanceof ApacheKafkaOffsetPosition);
-    assertEquals(((ApacheKafkaOffsetPosition) actualPositions.get(pubSubTopicPartition1)).getOffset(), 500L);
-    assertEquals(((ApacheKafkaOffsetPosition) actualPositions.get(pubSubTopicPartition2)).getOffset(), 600L);
+    assertEquals(((ApacheKafkaOffsetPosition) actualPositions.get(pubSubTopicPartition1)).getInternalOffset(), 500L);
+    assertEquals(((ApacheKafkaOffsetPosition) actualPositions.get(pubSubTopicPartition2)).getInternalOffset(), 600L);
   }
 
   @Test(expectedExceptions = PubSubOpTimeoutException.class)
@@ -571,7 +571,7 @@ public class ApacheKafkaConsumerAdapterTest {
     PubSubPosition position = kafkaConsumerAdapter.endPosition(pubSubTopicPartition);
     assertNotNull(position);
     assertTrue(position instanceof ApacheKafkaOffsetPosition);
-    assertEquals(((ApacheKafkaOffsetPosition) position).getOffset(), expectedOffset);
+    assertEquals(((ApacheKafkaOffsetPosition) position).getInternalOffset(), expectedOffset);
 
     // Case 2: return empty response
     doReturn(Collections.emptyMap()).when(internalKafkaConsumer)
@@ -666,7 +666,7 @@ public class ApacheKafkaConsumerAdapterTest {
         kafkaConsumerAdapter.getPositionByTimestamp(pubSubTopicPartition, timestamp, Duration.ofMillis(500));
     assertNotNull(position);
     assertTrue(position instanceof ApacheKafkaOffsetPosition);
-    assertEquals(((ApacheKafkaOffsetPosition) position).getOffset(), expectedOffset);
+    assertEquals(((ApacheKafkaOffsetPosition) position).getInternalOffset(), expectedOffset);
   }
 
   @Test
@@ -685,7 +685,7 @@ public class ApacheKafkaConsumerAdapterTest {
     PubSubPosition position = kafkaConsumerAdapter.getPositionByTimestamp(pubSubTopicPartition, timestamp);
     assertNotNull(position);
     assertTrue(position instanceof ApacheKafkaOffsetPosition);
-    assertEquals(((ApacheKafkaOffsetPosition) position).getOffset(), expectedOffset);
+    assertEquals(((ApacheKafkaOffsetPosition) position).getInternalOffset(), expectedOffset);
   }
 
   @Test
@@ -844,7 +844,7 @@ public class ApacheKafkaConsumerAdapterTest {
 
     PubSubPosition decoded = kafkaConsumerAdapter.decodePosition(pubSubTopicPartition, buffer);
     assertTrue(decoded instanceof ApacheKafkaOffsetPosition);
-    assertEquals(((ApacheKafkaOffsetPosition) decoded).getOffset(), expectedOffset);
+    assertEquals(((ApacheKafkaOffsetPosition) decoded).getInternalOffset(), expectedOffset);
   }
 
   @Test(expectedExceptions = VeniceException.class)

--- a/internal/venice-test-common/src/main/java/com/linkedin/venice/pubsub/mock/adapter/consumer/MockInMemoryConsumerAdapter.java
+++ b/internal/venice-test-common/src/main/java/com/linkedin/venice/pubsub/mock/adapter/consumer/MockInMemoryConsumerAdapter.java
@@ -205,7 +205,7 @@ public class MockInMemoryConsumerAdapter implements PubSubConsumerAdapter {
 
   @Override
   public synchronized PubSubPosition beginningPosition(PubSubTopicPartition pubSubTopicPartition, Duration timeout) {
-    return PubSubSymbolicPosition.EARLIEST;
+    return InMemoryPubSubPosition.of(0);
   }
 
   @Override
@@ -265,7 +265,7 @@ public class MockInMemoryConsumerAdapter implements PubSubConsumerAdapter {
     PubSubPosition resolved1 = resolveSymbolicPosition(partition, position1);
     PubSubPosition resolved2 = resolveSymbolicPosition(partition, position2);
 
-    // Case 1: Both resolved to concrete InMemoryPubSubPosition
+    // Case 1: Both resolved to concrete ApacheKafkaOffsetPosition
     if (resolved1 instanceof InMemoryPubSubPosition && resolved2 instanceof InMemoryPubSubPosition) {
       long offset1 = ((InMemoryPubSubPosition) resolved1).getInternalOffset();
       long offset2 = ((InMemoryPubSubPosition) resolved2).getInternalOffset();
@@ -300,7 +300,7 @@ public class MockInMemoryConsumerAdapter implements PubSubConsumerAdapter {
 
   private PubSubPosition resolveSymbolicPosition(PubSubTopicPartition partition, PubSubPosition position) {
     if (position == PubSubSymbolicPosition.EARLIEST) {
-      return beginningPosition(partition, Duration.ofMillis(60000));
+      return beginningPosition(partition);
     } else if (position == PubSubSymbolicPosition.LATEST) {
       return endPosition(partition);
     }

--- a/internal/venice-test-common/src/main/java/com/linkedin/venice/pubsub/mock/adapter/consumer/MockInMemoryConsumerAdapter.java
+++ b/internal/venice-test-common/src/main/java/com/linkedin/venice/pubsub/mock/adapter/consumer/MockInMemoryConsumerAdapter.java
@@ -2,6 +2,7 @@ package com.linkedin.venice.pubsub.mock.adapter.consumer;
 
 import com.linkedin.venice.exceptions.VeniceException;
 import com.linkedin.venice.pubsub.PubSubTopicPartitionInfo;
+import com.linkedin.venice.pubsub.PubSubUtil;
 import com.linkedin.venice.pubsub.api.DefaultPubSubMessage;
 import com.linkedin.venice.pubsub.api.PubSubConsumerAdapter;
 import com.linkedin.venice.pubsub.api.PubSubPosition;
@@ -258,53 +259,13 @@ public class MockInMemoryConsumerAdapter implements PubSubConsumerAdapter {
 
   @Override
   public long positionDifference(PubSubTopicPartition partition, PubSubPosition position1, PubSubPosition position2) {
-    if (position1 == null || position2 == null) {
-      throw new IllegalArgumentException("Positions cannot be null");
-    }
-
-    PubSubPosition resolved1 = resolveSymbolicPosition(partition, position1);
-    PubSubPosition resolved2 = resolveSymbolicPosition(partition, position2);
-
-    // Case 1: Both resolved to concrete ApacheKafkaOffsetPosition
-    if (resolved1 instanceof InMemoryPubSubPosition && resolved2 instanceof InMemoryPubSubPosition) {
-      long offset1 = ((InMemoryPubSubPosition) resolved1).getInternalOffset();
-      long offset2 = ((InMemoryPubSubPosition) resolved2).getInternalOffset();
-      return offset1 - offset2;
-    }
-
-    // Case 2: Both unresolved symbolic positions and equal
-    if (resolved1 == resolved2
-        && (resolved1 == PubSubSymbolicPosition.EARLIEST || resolved1 == PubSubSymbolicPosition.LATEST)) {
-      return 0L;
-    }
-
-    // Case 3: One is EARLIEST, one is concrete
-    if (resolved1 == PubSubSymbolicPosition.EARLIEST && resolved2 instanceof InMemoryPubSubPosition) {
-      return -((InMemoryPubSubPosition) resolved2).getInternalOffset();
-    }
-    if (resolved2 == PubSubSymbolicPosition.EARLIEST && resolved1 instanceof InMemoryPubSubPosition) {
-      return ((InMemoryPubSubPosition) resolved1).getInternalOffset();
-    }
-
-    // Case 4: One is LATEST, one is concrete
-    if (resolved1 == PubSubSymbolicPosition.LATEST && resolved2 instanceof InMemoryPubSubPosition) {
-      return Long.MAX_VALUE - ((InMemoryPubSubPosition) resolved2).getInternalOffset();
-    }
-    if (resolved2 == PubSubSymbolicPosition.LATEST && resolved1 instanceof InMemoryPubSubPosition) {
-      return ((InMemoryPubSubPosition) resolved1).getInternalOffset() - Long.MAX_VALUE;
-    }
-
-    throw new IllegalArgumentException(
-        "Unsupported position types: " + resolved1.getClass().getName() + " vs " + resolved2.getClass().getName());
-  }
-
-  private PubSubPosition resolveSymbolicPosition(PubSubTopicPartition partition, PubSubPosition position) {
-    if (position == PubSubSymbolicPosition.EARLIEST) {
-      return beginningPosition(partition);
-    } else if (position == PubSubSymbolicPosition.LATEST) {
-      return endPosition(partition);
-    }
-    return position;
+    return PubSubUtil.computeOffsetDelta(
+        partition,
+        position1,
+        position2,
+        this,
+        InMemoryPubSubPosition.class,
+        InMemoryPubSubPosition::getInternalOffset);
   }
 
   @Override

--- a/internal/venice-test-common/src/test/java/com/linkedin/venice/pubsub/mock/MockInMemoryPubSubClientTest.java
+++ b/internal/venice-test-common/src/test/java/com/linkedin/venice/pubsub/mock/MockInMemoryPubSubClientTest.java
@@ -2,6 +2,7 @@ package com.linkedin.venice.pubsub.mock;
 
 import static org.mockito.Mockito.mock;
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
 
 import com.linkedin.venice.kafka.protocol.KafkaMessageEnvelope;
 import com.linkedin.venice.message.KafkaKey;
@@ -23,10 +24,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.concurrent.CompletableFuture;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.testng.Assert;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
@@ -58,88 +57,74 @@ public class MockInMemoryPubSubClientTest {
     PubSubTopic topic = TOPIC_REPOSITORY.getTopic("test-topic");
     PubSubTopicPartition topicPartition = new PubSubTopicPartitionImpl(topic, partitionId);
 
-    // 1. Create topic
+    // 1. Create a single-partition topic
     PubSubTopicConfiguration config =
-        new PubSubTopicConfiguration(Optional.of(1111L), false, Optional.of(1), 12L, Optional.of(24L)); // Defaults are
-                                                                                                        // fine for
-                                                                                                        // in-memory
+        new PubSubTopicConfiguration(Optional.of(1111L), false, Optional.of(1), 12L, Optional.of(24L));
     adminAdapter.createTopic(topic, 1, 1, config);
-    Assert.assertTrue(adminAdapter.containsTopicWithPartitionCheck(topicPartition), "Topic creation failed");
+    assertTrue(adminAdapter.containsTopicWithPartitionCheck(topicPartition), "Topic creation failed");
 
-    // 2. Produce 500 messages
+    // 2. Produce 500 dummy messages and track their offsets and values
     List<KafkaMessageEnvelope> expectedValues = new ArrayList<>();
     List<Long> producedOffsets = new ArrayList<>();
     for (int i = 0; i < recordCount; i++) {
       KafkaKey key = PubSubHelper.getDummyKey();
       KafkaMessageEnvelope value = PubSubHelper.getDummyValue();
-      CompletableFuture<PubSubProduceResult> future = producerAdapter
-          .sendMessage(topicPartition.getTopicName(), topicPartition.getPartitionNumber(), key, value, null, null);
-      PubSubProduceResult result = future.get();
+      PubSubProduceResult result =
+          producerAdapter.sendMessage(topic.getName(), partitionId, key, value, null, null).get();
       producedOffsets.add(result.getOffset());
       expectedValues.add(value);
     }
 
-    // 3. Verify produce offsets
+    // 3. Validate offsets are contiguous starting from 0
     for (int i = 0; i < recordCount; i++) {
-      assertEquals((long) producedOffsets.get(i), i, "Mismatch in produced offset at index " + i);
+      assertEquals((long) producedOffsets.get(i), i, "Offset mismatch at index " + i);
     }
 
+    // Confirm topic's offset range matches number of produced records
     long positionDiff = consumerAdapter
         .positionDifference(topicPartition, PubSubSymbolicPosition.LATEST, PubSubSymbolicPosition.EARLIEST);
-    assertEquals(positionDiff, recordCount, "Position difference should match the number of produced records");
+    assertEquals(positionDiff, recordCount, "Offset range mismatch");
 
-    // 4. Subscribe consumer from EARLIEST
+    // 4. Subscribe from the earliest offset
     consumerAdapter.subscribe(topicPartition, PubSubSymbolicPosition.EARLIEST);
 
-    // 5. Poll records
+    // 5. Consume messages and validate offset continuity and lag
     List<KafkaMessageEnvelope> consumedValues = new ArrayList<>();
     List<InMemoryPubSubPosition> consumedOffsets = new ArrayList<>();
     int retries = 0;
-    while (consumedValues.size() < recordCount && retries < 10000) {
+    while (consumedValues.size() < recordCount && retries++ < 10000) {
       Map<PubSubTopicPartition, List<DefaultPubSubMessage>> polled = consumerAdapter.poll(100);
       List<DefaultPubSubMessage> messages = polled.get(topicPartition);
       if (messages != null) {
         for (DefaultPubSubMessage msg: messages) {
-          consumedOffsets.add((InMemoryPubSubPosition) msg.getPosition());
+          InMemoryPubSubPosition position = (InMemoryPubSubPosition) msg.getPosition();
+          consumedOffsets.add(position);
           consumedValues.add(msg.getValue());
 
-          positionDiff =
-              consumerAdapter.positionDifference(topicPartition, PubSubSymbolicPosition.LATEST, msg.getPosition()) - 1; // -1
-                                                                                                                        // because
-                                                                                                                        // latest
-                                                                                                                        // is
-                                                                                                                        // lastRecord
-                                                                                                                        // position
-                                                                                                                        // +
-                                                                                                                        // 1
-          // create vars for assertions
-
+          // Validate lag from current message to end of topic
+          long expectedRemaining = recordCount - consumedValues.size();
+          long lagToLatest =
+              consumerAdapter.positionDifference(topicPartition, PubSubSymbolicPosition.LATEST, position) - 1;
           assertEquals(
-              positionDiff,
-              recordCount - consumedValues.size(),
-              "Position difference should match the number of remaining records: " + positionDiff + ", consumed: "
-                  + consumedValues.size());
+              lagToLatest,
+              expectedRemaining,
+              "Unexpected lag to latest. Expected: " + expectedRemaining + ", Got: " + lagToLatest);
 
-          // compute lag with self
-          long selfLag = consumerAdapter.positionDifference(topicPartition, msg.getPosition(), msg.getPosition());
-          assertEquals(
-              selfLag,
-              0,
-              "Self lag should be zero for the same position: "
-                  + ((InMemoryPubSubPosition) msg.getPosition()).getInternalOffset());
-
+          // Validate zero lag when comparing position to itself
+          long selfLag = consumerAdapter.positionDifference(topicPartition, position, position);
+          assertEquals(selfLag, 0, "Expected zero self lag at offset: " + position.getInternalOffset());
         }
       }
-      retries++;
     }
 
-    assertEquals(consumedOffsets.size(), recordCount, "Did not consume all expected records");
-    assertEquals(consumedValues.size(), recordCount, "Mismatch in consumed values count");
+    // Ensure all messages were consumed
+    assertEquals(consumedOffsets.size(), recordCount, "Not all offsets consumed");
+    assertEquals(consumedValues.size(), recordCount, "Not all values consumed");
 
-    // 6. Validate offsets and values
+    // 6. Validate offset continuity and message content integrity
     for (int i = 0; i < recordCount; i++) {
-      assertEquals(consumedOffsets.get(i).getInternalOffset(), i, "Mismatch in consumed offset at index " + i);
-      assertEquals(consumedValues.get(i), expectedValues.get(i), "Mismatch in value at offset " + i);
+      assertEquals(consumedOffsets.get(i).getInternalOffset(), i, "Offset mismatch at index " + i);
+      assertEquals(consumedValues.get(i), expectedValues.get(i), "Value mismatch at offset " + i);
     }
   }
 }


### PR DESCRIPTION
<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat], [protocol]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->


## Add PubSubPosition position compare, diff, and decode APIs in PubSubConsumerAdapter

This change introduces three new methods in the PubSubConsumerAdapter interface to standardize
handling of PubSubPosition objects:

- comparePositions(): compares two positions for ordering
- positionDifference(): returns signed difference (p1 - p2), with symbolic resolution
- decodePosition(): reconstructs PubSubPosition from a ByteBuffer or byte[]

These APIs allow Venice components (controller, server, Da Vinci) to reason about
topic positions uniformly across symbolic and concrete implementations.

###  Code changes
- [ ] Added new code behind **a config**. If so list the config names and their default values in the PR description.
- [ ] Introduced new **log lines**. 
  - [ ] Confirmed if logs need to be **rate limited** to avoid excessive logging.

###  **Concurrency-Specific Checks**
Both reviewer and PR author to verify
- [ ] Code has **no race conditions** or **thread safety issues**.
- [ ] Proper **synchronization mechanisms** (e.g., `synchronized`, `RWLock`) are used where needed.
- [ ] No **blocking calls** inside critical sections that could lead to deadlocks or performance degradation.
- [ ] Verified **thread-safe collections** are used (e.g., `ConcurrentHashMap`, `CopyOnWriteArrayList`).
- [ ] Validated proper exception handling in multi-threaded code to avoid silent thread termination.


## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->

- [ ] New unit tests added.
- [ ] New integration tests added.
- [ ] Modified or extended existing tests.
- [ ] Verified backward compatibility (if applicable).

## Does this PR introduce any user-facing or breaking changes?
<!--  
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [ ] No. You can skip the rest of this section.
- [ ] Yes. Clearly explain the behavior change and its impact.