### PR TITLE
[controller] Check for child version status mismatch for deferred swap

### DIFF
--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestDeferredVersionSwap.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestDeferredVersionSwap.java
@@ -615,9 +615,9 @@ public class TestDeferredVersionSwap {
       ControllerClient controllerClient) {
     ReadWriteStoreRepository storeRepository =
         admin.getHelixVeniceClusterResources(CLUSTER_NAMES[0]).getStoreMetadataRepository();
-    Store store1 = storeRepository.getStore(storeName);
-    store1.updateVersionStatus(1, status);
-    storeRepository.updateStore(store1);
+    Store store = storeRepository.getStore(storeName);
+    store.updateVersionStatus(1, status);
+    storeRepository.updateStore(store);
     TestUtils.waitForNonDeterministicAssertion(30, TimeUnit.SECONDS, () -> {
       StoreInfo parentStore = controllerClient.getStore(storeName).getStore();
       Assert.assertEquals(parentStore.getVersion(1).get().getStatus(), status);

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestDeferredVersionSwap.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestDeferredVersionSwap.java
@@ -25,6 +25,7 @@ import com.linkedin.venice.client.store.ClientFactory;
 import com.linkedin.venice.client.store.StatTrackingStoreClient;
 import com.linkedin.venice.common.VeniceSystemStoreType;
 import com.linkedin.venice.controller.Admin;
+import com.linkedin.venice.controller.VeniceHelixAdmin;
 import com.linkedin.venice.controllerapi.ControllerClient;
 import com.linkedin.venice.controllerapi.ControllerResponse;
 import com.linkedin.venice.controllerapi.StoreResponse;
@@ -525,7 +526,7 @@ public class TestDeferredVersionSwap {
   }
 
   @Test(timeOut = TEST_TIMEOUT)
-  public void testDeferredVersionSwapWithParentVersionMismatch() throws IOException {
+  public void testDeferredVersionSwapWithVersionMismatch() throws IOException {
     File inputDir = getTempDataDirectory();
     TestWriteUtils.writeSimpleAvroFileWithStringToV3Schema(inputDir, 100, 100);
     // Setup job properties
@@ -571,19 +572,19 @@ public class TestDeferredVersionSwap {
         Assert.assertEquals(parentStore.getVersion(1).get().getStatus(), VersionStatus.PUSHED);
       });
 
-      // Forcibly mark parent version status as ONLINE to confirm that version swap will still happen if non target
+      // Forcibly mark parent version and child status as ONLINE to confirm that version swap will still happen if non
+      // target
       // regions are not swapped yet
       Admin admin =
           multiRegionMultiClusterWrapper.getLeaderParentControllerWithRetries(CLUSTER_NAMES[0]).getVeniceAdmin();
-      ReadWriteStoreRepository storeRepository =
-          admin.getHelixVeniceClusterResources(CLUSTER_NAMES[0]).getStoreMetadataRepository();
-      Store store1 = storeRepository.getStore(storeName);
-      store1.updateVersionStatus(1, VersionStatus.ONLINE);
-      storeRepository.updateStore(store1);
-      TestUtils.waitForNonDeterministicAssertion(30, TimeUnit.SECONDS, () -> {
-        StoreInfo parentStore = parentControllerClient.getStore(storeName).getStore();
-        Assert.assertEquals(parentStore.getVersion(1).get().getStatus(), VersionStatus.ONLINE);
-      });
+      updateVersionStatus(admin, storeName, VersionStatus.ONLINE, parentControllerClient);
+
+      for (VeniceMultiClusterWrapper childDatacenter: childDatacenters) {
+        VeniceHelixAdmin childAdmin = childDatacenter.getLeaderController(CLUSTER_NAMES[0]).getVeniceHelixAdmin();
+        ControllerClient childControllerClient =
+            new ControllerClient(CLUSTER_NAMES[0], childDatacenter.getControllerConnectString());
+        updateVersionStatus(childAdmin, storeName, VersionStatus.ONLINE, childControllerClient);
+      }
 
       // Version should be swapped in all regions
       TestUtils.waitForNonDeterministicAssertion(2, TimeUnit.MINUTES, () -> {
@@ -605,6 +606,22 @@ public class TestDeferredVersionSwap {
         assertEquals(version.get().getStatus(), VersionStatus.ONLINE);
       }
     }
+  }
+
+  private void updateVersionStatus(
+      Admin admin,
+      String storeName,
+      VersionStatus status,
+      ControllerClient controllerClient) {
+    ReadWriteStoreRepository storeRepository =
+        admin.getHelixVeniceClusterResources(CLUSTER_NAMES[0]).getStoreMetadataRepository();
+    Store store1 = storeRepository.getStore(storeName);
+    store1.updateVersionStatus(1, status);
+    storeRepository.updateStore(store1);
+    TestUtils.waitForNonDeterministicAssertion(30, TimeUnit.SECONDS, () -> {
+      StoreInfo parentStore = controllerClient.getStore(storeName).getStore();
+      Assert.assertEquals(parentStore.getVersion(1).get().getStatus(), status);
+    });
   }
 
   private void verifyThatPushStatusStoreIsOnline(String storeName) {

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/DeferredVersionSwapService.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/DeferredVersionSwapService.java
@@ -170,26 +170,23 @@ public class DeferredVersionSwapService extends AbstractVeniceService {
 
   /**
    * Gets the specified version for a store in a specific region
-   * @param clusterName name of the cluster the store is in
    * @param region name of the region to get the store from
    * @param storeName name of the store
    * @param targetVersionNum the version number to get
    * @return
    */
   private Version getVersionFromStoreInRegion(
-      String clusterName,
       String region,
       String storeName,
-      int targetVersionNum) {
-    StoreResponse targetRegionStoreResponse = getStoreForRegion(clusterName, region, storeName);
-
-    if (targetRegionStoreResponse.isError()) {
-      String message = "Got error when fetching targetRegionStore: " + targetRegionStoreResponse.getStore();
+      int targetVersionNum,
+      StoreResponse storeResponse) {
+    if (storeResponse.isError()) {
+      String message = "Got error when fetching targetRegionStore: " + storeResponse.getStore();
       logMessageIfNotRedundant(message);
       return null;
     }
 
-    StoreInfo targetRegionStore = targetRegionStoreResponse.getStore();
+    StoreInfo targetRegionStore = storeResponse.getStore();
     Optional<Version> version = targetRegionStore.getVersion(targetVersionNum);
     if (!version.isPresent()) {
       String message =
@@ -273,13 +270,26 @@ public class DeferredVersionSwapService extends AbstractVeniceService {
       int targetVersionNum,
       Set<VersionStatus> versionStatus) {
     for (String region: regions) {
-      Version regionVersion = getVersionFromStoreInRegion(clusterName, region, storeName, targetVersionNum);
+      StoreResponse storeResponse = getStoreForRegion(clusterName, region, storeName);
+      Version regionVersion = getVersionFromStoreInRegion(region, storeName, targetVersionNum, storeResponse);
+
+      if (storeResponse.isError()) {
+        String message = "Got error when fetching targetRegionStore: " + storeResponse.getStore();
+        logMessageIfNotRedundant(message);
+        return false;
+      }
 
       if (regionVersion == null) {
         return false;
       }
 
       if (!versionStatus.contains(regionVersion.getStatus())) {
+        return false;
+      }
+
+      // There is a version status mismatch if the version is marked as online and the future version is not the current
+      // version
+      if (regionVersion.getStatus() == ONLINE && storeResponse.getStore().getCurrentVersion() != targetVersionNum) {
         return false;
       }
     }
@@ -335,7 +345,7 @@ public class DeferredVersionSwapService extends AbstractVeniceService {
           deferredVersionSwapStats.recordDeferredVersionSwapParentChildStatusMismatchSensor();
           String message =
               "Push completed in target regions, parent status is still STARTED. Continuing with deferred swap for store: "
-                  + storeName + " for version: {}" + targetVersionNum;
+                  + storeName + " for version: " + targetVersionNum;
           logMessageIfNotRedundant(message);
           return true;
         }
@@ -416,6 +426,10 @@ public class DeferredVersionSwapService extends AbstractVeniceService {
       logMessageIfNotRedundant(message);
       store.updateVersionStatus(targetVersionNum, ERROR);
       repository.updateStore(store);
+
+      String kafkaTopic = Version.composeKafkaTopic(store.getName(), targetVersionNum);
+      LOGGER.info("Truncating kafka topic: {} after push failed in 1+ target regions", kafkaTopic);
+      veniceParentHelixAdmin.truncateKafkaTopic(kafkaTopic);
       return false;
     } else if (numCompletedTargetRegions + numFailedTargetRegions != targetRegions.size()) {
       // TODO remove after ramp as this is a temporary log to help with debugging
@@ -498,7 +512,8 @@ public class DeferredVersionSwapService extends AbstractVeniceService {
     Set<String> failedNonTargetRegions = new HashSet<>();
     Map<String, String> nonTargetRegionToStatus = new HashMap<>();
     for (String nonTargetRegion: nonTargetRegions) {
-      Version version = getVersionFromStoreInRegion(clusterName, nonTargetRegion, store.getName(), targetVersionNum);
+      StoreResponse storeResponse = getStoreForRegion(clusterName, nonTargetRegion, store.getName());
+      Version version = getVersionFromStoreInRegion(nonTargetRegion, store.getName(), targetVersionNum, storeResponse);
 
       // When a push is killed or errored out, the topic may have been cleaned up or controller is temporarily
       // unreachable so we will allow upto 5 retries before marking it as failed
@@ -528,6 +543,24 @@ public class DeferredVersionSwapService extends AbstractVeniceService {
         completedNonTargetRegions.add(nonTargetRegion);
       } else if (version.getStatus().equals(ERROR) || version.getStatus().equals(VersionStatus.KILLED)) {
         failedNonTargetRegions.add(nonTargetRegion);
+      } else if (version.getStatus().equals(ONLINE)) {
+        if (storeResponse.isError()) {
+          String message = "Got error when fetching targetRegionStore: " + storeResponse.getStore();
+          logMessageIfNotRedundant(message);
+          continue;
+        }
+
+        // The in memory store map is out of sync, and we should still allow roll forward to happen
+        // to make the future version current
+        StoreInfo childStore = storeResponse.getStore();
+        if (childStore.getCurrentVersion() < targetVersionNum) {
+          completedNonTargetRegions.add(nonTargetRegion);
+          String message = "Child version " + targetVersionNum + " status is ONLINE for store " + store.getName()
+              + " , but there is still a future version detected in region " + nonTargetRegion
+              + " and the current version is " + store.getCurrentVersion();
+          logMessageIfNotRedundant(message);
+          deferredVersionSwapStats.recordDeferredVersionSwapChildStatusMismatchSensor();
+        }
       }
 
       nonTargetRegionToStatus.put(nonTargetRegion, version.getStatus().toString());
@@ -540,6 +573,9 @@ public class DeferredVersionSwapService extends AbstractVeniceService {
       logMessageIfNotRedundant(message);
       store.updateVersionStatus(targetVersionNum, PARTIALLY_ONLINE);
       repository.updateStore(store);
+
+      LOGGER.info("Truncating kafka topic: {} after push failed in all non target regions", kafkaTopicName);
+      veniceParentHelixAdmin.truncateKafkaTopic(kafkaTopicName);
       return Collections.emptySet();
     } else if ((failedNonTargetRegions.size() + completedNonTargetRegions.size()) != nonTargetRegions.size()) {
       String message = "Skipping version swap for store: " + store.getName() + " on version: " + targetVersionNum
@@ -685,6 +721,9 @@ public class DeferredVersionSwapService extends AbstractVeniceService {
                     targetVersionNum,
                     storeName,
                     nonTargetRegionsCompleted);
+
+                LOGGER.info("Truncating kafka topic: {} after roll forward failed in 1+ regions", kafkaTopicName);
+                veniceParentHelixAdmin.truncateKafkaTopic(kafkaTopicName);
               }
             }
           }

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/DeferredVersionSwapService.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/DeferredVersionSwapService.java
@@ -556,9 +556,9 @@ public class DeferredVersionSwapService extends AbstractVeniceService {
         StoreInfo childStore = storeResponse.getStore();
         if (childStore.getCurrentVersion() < targetVersionNum) {
           completedNonTargetRegions.add(nonTargetRegion);
-          String message = "Child version " + targetVersionNum + " status is ONLINE for store " + parentStore.getName()
-              + " , but there is still a future version detected in region " + nonTargetRegion
-              + " and the current version is " + parentStore.getCurrentVersion();
+          String message = "Child version " + targetVersionNum + " status is ONLINE while the current version is "
+              + childStore.getCurrentVersion() + " for store " + parentStore.getName() + " in region "
+              + nonTargetRegion;
           logMessageIfNotRedundant(message);
           deferredVersionSwapStats.recordDeferredVersionSwapChildStatusMismatchSensor();
         }

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/stats/DeferredVersionSwapStats.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/stats/DeferredVersionSwapStats.java
@@ -13,12 +13,15 @@ public class DeferredVersionSwapStats extends AbstractVeniceStats {
   private final Sensor deferredVersionSwapFailedRollForwardSensor;
   private final Sensor deferredVersionSwapStalledVersionSwapSensor;
   private final Sensor deferredVersionSwapParentChildStatusMismatchSensor;
+  private final Sensor deferredVersionSwapChildStatusMismatchSensor;
   private final static String DEFERRED_VERSION_SWAP_ERROR = "deferred_version_swap_error";
   private final static String DEFERRED_VERSION_SWAP_THROWABLE = "deferred_version_swap_throwable";
   private final static String DEFERRED_VERSION_SWAP_FAILED_ROLL_FORWARD = "deferred_version_swap_failed_roll_forward";
   private static final String DEFERRED_VERSION_SWAP_STALLED_VERSION_SWAP = "deferred_version_swap_stalled_version_swap";
   private static final String DEFERRED_VERSION_SWAP_PARENT_CHILD_STATUS_MISMATCH_SENSOR =
       "deferred_version_swap_parent_child_status_mismatch";
+  private static final String DEFERRED_VERSION_SWAP_CHILD_STATUS_MISMATCH_SENSOR =
+      "deferred_version_swap_child_status_mismatch";
 
   public DeferredVersionSwapStats(MetricsRepository metricsRepository) {
     super(metricsRepository, "DeferredVersionSwap");
@@ -30,6 +33,8 @@ public class DeferredVersionSwapStats extends AbstractVeniceStats {
         registerSensorIfAbsent(DEFERRED_VERSION_SWAP_STALLED_VERSION_SWAP, new Gauge());
     deferredVersionSwapParentChildStatusMismatchSensor =
         registerSensorIfAbsent(DEFERRED_VERSION_SWAP_PARENT_CHILD_STATUS_MISMATCH_SENSOR, new Count());
+    deferredVersionSwapChildStatusMismatchSensor =
+        registerSensorIfAbsent(DEFERRED_VERSION_SWAP_CHILD_STATUS_MISMATCH_SENSOR, new Count());
   }
 
   public void recordDeferredVersionSwapErrorSensor() {
@@ -50,5 +55,9 @@ public class DeferredVersionSwapStats extends AbstractVeniceStats {
 
   public void recordDeferredVersionSwapParentChildStatusMismatchSensor() {
     deferredVersionSwapParentChildStatusMismatchSensor.record();
+  }
+
+  public void recordDeferredVersionSwapChildStatusMismatchSensor() {
+    deferredVersionSwapChildStatusMismatchSensor.record();
   }
 }

--- a/services/venice-controller/src/main/java/com/linkedin/venice/pushmonitor/AbstractPushMonitor.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/pushmonitor/AbstractPushMonitor.java
@@ -1175,8 +1175,6 @@ public abstract class AbstractPushMonitor
         }
       }
 
-      store.updateVersionStatus(versionNumber, newStatus);
-      LOGGER.info("Updated store: {} version: {} to status: {}", store.getName(), versionNumber, newStatus.toString());
       if (newStatus.equals(VersionStatus.ONLINE)) {
         if (versionNumber > store.getCurrentVersion()) {
           // Here we'll check if version swap is deferred. If so, we don't perform the setCurrentVersion. We'll continue
@@ -1231,12 +1229,13 @@ public abstract class AbstractPushMonitor
             boolean isVersionSwapDeferredInNonTargetRegion =
                 !targetRegions.isEmpty() && !targetRegions.contains(regionName) && version.isVersionSwapDeferred();
             if (isVersionSwapDeferredInNonTargetRegion) {
+              newStatus = VersionStatus.PUSHED;
               LOGGER.info(
-                  "Marking version status as PUSHED for version: {} in store: {} during a target region push w/ deferred swap"
+                  "Marking version status as {} for version: {} in store: {} during a target region push w/ deferred swap"
                       + "because it is a non target region",
+                  newStatus,
                   versionNumber,
                   storeName);
-              store.updateVersionStatus(versionNumber, VersionStatus.PUSHED);
             }
           }
         } else {
@@ -1248,7 +1247,9 @@ public abstract class AbstractPushMonitor
               versionNumber);
         }
       }
+      store.updateVersionStatus(versionNumber, newStatus);
       metadataRepository.updateStore(store);
+      LOGGER.info("Updated store: {} version: {} to status: {}", store.getName(), versionNumber, newStatus.toString());
     }
   }
 

--- a/services/venice-controller/src/test/java/com/linkedin/venice/controller/TestDeferredVersionSwapService.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/controller/TestDeferredVersionSwapService.java
@@ -513,6 +513,7 @@ public class TestDeferredVersionSwapService {
     versionList.add(versionOneImpl);
     versionList.add(versionTwoImpl);
     StoreResponse storeResponse = getStoreResponse(versionList);
+    storeResponse.getStore().setCurrentVersion(2);
 
     Map<String, ControllerClient> controllerClientMap = mockControllerClients(versionList);
     for (Map.Entry<String, ControllerClient> entry: controllerClientMap.entrySet()) {


### PR DESCRIPTION
<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat], [protocol]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## Problem Statement
<!--
Describe
- What problem are you trying to solve
- What issues or limitations exist in the current code
- Why this change is necessary 
-->
1. We've observed that sometimes the child status is `ONLINE` in the in memory store map even though it is `PUSHED` in zookeeper. This prevents an automatic version swap from happening because there is an assumption that `ONLINE` means that the version has been swapped already
2. When a roll forward fails after 5 tries, we stop trying to roll forward, but we do not truncate the parent topic and this blocks the next push

## Solution
<!--
Describe
- What changes you are making and why. 
- How these changes solve the problem.
- Any performance considerations or trade-offs. 
- Describe what testings you have done, for example, performance testing etc.
-->
1. Check that the current version is the same as the future version if the version status is ONLINE, otherwise continue and perform a roll forward
2. Truncate the parent topic after failed roll forward to unblock next push
3. Move updateVersionStatus to the end so that the version status update is only performed once

###  Code changes
- [ ] Added new code behind **a config**. If so list the config names and their default values in the PR description.
- [x] Introduced new **log lines**. 
  - [x] Confirmed if logs need to be **rate limited** to avoid excessive logging.

###  **Concurrency-Specific Checks**
Both reviewer and PR author to verify
- [ ] Code has **no race conditions** or **thread safety issues**.
- [ ] Proper **synchronization mechanisms** (e.g., `synchronized`, `RWLock`) are used where needed.
- [ ] No **blocking calls** inside critical sections that could lead to deadlocks or performance degradation.
- [ ] Verified **thread-safe collections** are used (e.g., `ConcurrentHashMap`, `CopyOnWriteArrayList`).
- [ ] Validated proper exception handling in multi-threaded code to avoid silent thread termination.


## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->

- [ ] New unit tests added.
- [ ] New integration tests added.
- [x] Modified or extended existing tests.
- [ ] Verified backward compatibility (if applicable).

## Does this PR introduce any user-facing or breaking changes?
<!--  
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Clearly explain the behavior change and its impact.