### PR TITLE
[server][dvc] Fast failover transfer request when sender's RocksDB partition is not ready.

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/store/rocksdb/RocksDBStoragePartition.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/store/rocksdb/RocksDBStoragePartition.java
@@ -534,7 +534,12 @@ public class RocksDBStoragePartition extends AbstractStoragePartition {
 
   @Override
   public synchronized void createSnapshot() {
+    makeSureRocksDBIsStillOpen();
     createSnapshot(rocksDB, fullPathForPartitionDBSnapshot);
+  }
+
+  public synchronized boolean isRocksDBPartitionBlobTransferInProgress() {
+    return blobTransferInProgress;
   }
 
   @Override


### PR DESCRIPTION
<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat], [protocol]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## Problem Statement
In [PR #1944](https://github.com/linkedin/venice/pull/1944) To prevent a race condition between dropping a store and a blob transfer, [PR #1944](https://github.com/linkedin/venice/pull/1944) modified the StorageEngine to include partitions that are actively being transferred. A key effect is that these StoragePartition objects are created with a **null** RocksDB instance until the transfer is complete.

The existing code in BlobSnapshotManager relied on `storageEngineRepository.getLocalStorageEngine(topicName).containsPartition(partitionId)` ([link](https://github.com/linkedin/venice/blob/main/clients/da-vinci-client/src/main/java/com/linkedin/davinci/blobtransfer/BlobSnapshotManager.java#L136)) to determine if a partition was ready for a snapshot and then fast failover to 404 error. This check is no longer sufficient because it now returns **true** for these new, in-progress partitions which are not actually ready.

The execution flow is becomes:
1. A blob transfer request arrives for an in-progress partition with **null** rocksDB.
2. The containsPartition() check incorrectly passes.
3.  blobSnapshotManager.getTransferMetadata() is called. Inside this method, the concurrent user count is incremented, and successCountedAsActiveCurrentUser is set to true. 
4. Snapshot manager will then try to create a snapshot but failed, due to rocksDB=null, throwing an exception, catch by the outer catch and return 404 error to receiver. 
5. **Unable to do cleanup or recreate snapshot due to active user is never decreased.** 
An exception is thrown at `transferPartitionMetadata = blobSnapshotManager.getTransferMetadata(blobTransferRequest, successCountedAsActiveCurrentUser);`, which causes the channel not to be marked with `SUCCESS_COUNTED`. As a result, when the connection breaks, the active user count is not decremented. Consequently, periodic snapshot TS HashMap cleanup fails to occur as they thought there is active user. 
Even if this partition becomes ready and is able to create a snapshot, it will no longer be able to do so as active user check as well. 


<img width="909" height="412" alt="Screenshot 2025-07-28 at 11 27 18 AM" src="https://github.com/user-attachments/assets/13f442ef-4538-4d94-b855-4d91e32e3734" />



## Solution
<!--
Describe
- What changes you are making and why. 
- How these changes solve the problem.
- Any performance considerations or trade-offs. 
- Describe what testings you have done, for example, performance testing etc.
-->
Enhance the fast failover logic by verifying whether the partition has the `isRocksDBPartitionBlobTransferInProgress` flag set.

###  Code changes
- [ ] Added new code behind **a config**. If so list the config names and their default values in the PR description.
- [ ] Introduced new **log lines**. 
- [ ] Confirmed if logs need to be **rate limited** to avoid excessive logging.

###  **Concurrency-Specific Checks**
Both reviewer and PR author to verify
- [ ] Code has **no race conditions** or **thread safety issues**.
- [ ] Proper **synchronization mechanisms** (e.g., `synchronized`, `RWLock`) are used where needed.
- [ ] No **blocking calls** inside critical sections that could lead to deadlocks or performance degradation.
- [ ] Verified **thread-safe collections** are used (e.g., `ConcurrentHashMap`, `CopyOnWriteArrayList`).
- [ ] Validated proper exception handling in multi-threaded code to avoid silent thread termination.


## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->

- [ ] New unit tests added.
- [ ] New integration tests added.
- [ ] Modified or extended existing tests.
- [ ] Verified backward compatibility (if applicable).

## Does this PR introduce any user-facing or breaking changes?
<!--  
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [ ] No. You can skip the rest of this section.
- [ ] Yes. Clearly explain the behavior change and its impact.