### PR TITLE
[fast-client] delay version switch until the newly fetch version is ready

### DIFF
--- a/clients/venice-client/src/main/java/com/linkedin/venice/fastclient/meta/RequestBasedMetadata.java
+++ b/clients/venice-client/src/main/java/com/linkedin/venice/fastclient/meta/RequestBasedMetadata.java
@@ -427,7 +427,7 @@ public class RequestBasedMetadata extends AbstractStoreMetadata {
         String key = getVersionPartitionMapKey(fetchedCurrentVersion, partitionId);
         List<String> replicas = routingInfo.get(partitionId);
         if (!replicas.isEmpty()) {
-          readyToServeInstancesMap.put(key, routingInfo.get(partitionId));
+          readyToServeInstancesMap.put(key, replicas);
         }
       }
 


### PR DESCRIPTION


<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat], [protocol]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## Problem Statement
<!--
Describe
- What problem are you trying to solve
- What issues or limitations exist in the current code
- Why this change is necessary 
-->
No available replicas during version switch.



## Solution
<!--
Describe
- What changes you are making and why. 
- How these changes solve the problem.
- Any performance considerations or trade-offs. 
- Describe what testings you have done, for example, performance testing etc.
-->


Today, in Fast Client, during the metadata update, once a new version is discovered, Fast Client will switch to the new current version right away even though the routing info for the new current version doesn't contain replicas for every partition and this can happen as the metadata fetched is from Venice Server, which can be suffering from a delay from Zookeeper since Controller is making a decision about when to switch to the new version.

This PR will delay the current version switch until the returned routing info contains at least some ready-to-serve replicas for every partition.
There is an edge case when the being-used current version gets deleted, even the routing info is not complete, Fast Client will switch to the new version.

TODO: improve Venice Server metadata endpoint to force a refresh when the routing info is incomplete.

###  Code changes
- [ ] Added new code behind **a config**. If so list the config names and their default values in the PR description.
- [ ] Introduced new **log lines**. 
  - [ ] Confirmed if logs need to be **rate limited** to avoid excessive logging.

###  **Concurrency-Specific Checks**
Both reviewer and PR author to verify
- [ ] Code has **no race conditions** or **thread safety issues**.
- [ ] Proper **synchronization mechanisms** (e.g., `synchronized`, `RWLock`) are used where needed.
- [ ] No **blocking calls** inside critical sections that could lead to deadlocks or performance degradation.
- [ ] Verified **thread-safe collections** are used (e.g., `ConcurrentHashMap`, `CopyOnWriteArrayList`).
- [ ] Validated proper exception handling in multi-threaded code to avoid silent thread termination.


## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->

- [x] New unit tests added.
- [ ] New integration tests added.
- [ ] Modified or extended existing tests.
- [ ] Verified backward compatibility (if applicable).

## Does this PR introduce any user-facing or breaking changes?
<!--  
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [ ] No. You can skip the rest of this section.
- [ ] Yes. Clearly explain the behavior change and its impact.