### PR TITLE
[server][controller] Add PubSubPosition resolve and diff APIs in TopicManager

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/SharedKafkaConsumer.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/SharedKafkaConsumer.java
@@ -427,7 +427,10 @@ class SharedKafkaConsumer implements PubSubConsumerAdapter {
   }
 
   @Override
-  public synchronized PubSubPosition decodePosition(PubSubTopicPartition partition, ByteBuffer buffer) {
-    return delegate.decodePosition(partition, buffer);
+  public synchronized PubSubPosition decodePosition(
+      PubSubTopicPartition partition,
+      int positionTypeId,
+      ByteBuffer buffer) {
+    return delegate.decodePosition(partition, positionTypeId, buffer);
   }
 }

--- a/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/adapter/kafka/consumer/ApacheKafkaConsumerAdapter.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/adapter/kafka/consumer/ApacheKafkaConsumerAdapter.java
@@ -654,7 +654,15 @@ public class ApacheKafkaConsumerAdapter implements PubSubConsumerAdapter {
   }
 
   @Override
-  public PubSubPosition decodePosition(PubSubTopicPartition partition, ByteBuffer buffer) {
+  public PubSubPosition decodePosition(PubSubTopicPartition partition, int positionTypeId, ByteBuffer buffer) {
+    if (buffer == null || buffer.remaining() == 0) {
+      throw new VeniceException("Buffer cannot be null or empty for partition: " + partition);
+    }
+    if (positionTypeId != PubSubPositionTypeRegistry.APACHE_KAFKA_OFFSET_POSITION_TYPE_ID) {
+      throw new VeniceException(
+          "Position type ID: " + positionTypeId + " is not supported for partition: " + partition
+              + ". Expected type ID: " + PubSubPositionTypeRegistry.APACHE_KAFKA_OFFSET_POSITION_TYPE_ID);
+    }
     try {
       return new ApacheKafkaOffsetPosition(buffer);
     } catch (IOException e) {

--- a/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/api/EarliestPosition.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/api/EarliestPosition.java
@@ -45,6 +45,12 @@ final class EarliestPosition implements PubSubPosition {
   }
 
   @Override
+  public boolean isSymbolic() {
+    // EarliestPosition is a symbolic position
+    return true;
+  }
+
+  @Override
   public String toString() {
     return NAME;
   }

--- a/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/api/LatestPosition.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/api/LatestPosition.java
@@ -33,6 +33,12 @@ final class LatestPosition implements PubSubPosition {
   }
 
   @Override
+  public boolean isSymbolic() {
+    // LatestPosition is a symbolic position
+    return true;
+  }
+
+  @Override
   public int getHeapSize() {
     return SHALLOW_CLASS_OVERHEAD;
   }

--- a/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/api/PubSubConsumerAdapter.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/api/PubSubConsumerAdapter.java
@@ -318,21 +318,23 @@ public interface PubSubConsumerAdapter extends AutoCloseable, Closeable {
    * Decodes the given type-encoded byte array into a {@link PubSubPosition} for the specified topic partition.
    *
    * @param partition The topic partition this position belongs to.
+   * @param positionTypeId The type ID of the position, which indicates how to decode the byte array.
    * @param data The byte array containing the encoded position.
    * @return The decoded {@link PubSubPosition}.
    * @throws IllegalArgumentException if the data cannot be decoded into a valid {@link PubSubPosition}.
    */
-  default PubSubPosition decodePosition(PubSubTopicPartition partition, byte[] data) {
-    return decodePosition(partition, ByteBuffer.wrap(data));
+  default PubSubPosition decodePosition(PubSubTopicPartition partition, int positionTypeId, byte[] data) {
+    return decodePosition(partition, positionTypeId, ByteBuffer.wrap(data));
   }
 
   /**
    * Decodes the given {@link ByteBuffer} into a {@link PubSubPosition} for the specified topic partition.
    *
    * @param partition The topic partition this position belongs to.
+   * @param positionTypeId The type ID of the position, which indicates how to decode the byte buffer.
    * @param buffer The {@link ByteBuffer} containing the encoded position.
    * @return The decoded {@link PubSubPosition}.
    * @throws IllegalArgumentException if the buffer cannot be decoded into a valid {@link PubSubPosition}.
    */
-  PubSubPosition decodePosition(PubSubTopicPartition partition, ByteBuffer buffer);
+  PubSubPosition decodePosition(PubSubTopicPartition partition, int positionTypeId, ByteBuffer buffer);
 }

--- a/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/api/PubSubPosition.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/api/PubSubPosition.java
@@ -18,6 +18,10 @@ public interface PubSubPosition extends Measurable {
 
   int hashCode();
 
+  default boolean isSymbolic() {
+    return false;
+  }
+
   /**
    * Position wrapper is used to wrap the position type and the position value.
    * This is used to serialize and deserialize the position object when sending and receiving it over the wire.

--- a/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/manager/TopicManager.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/manager/TopicManager.java
@@ -28,6 +28,7 @@ import com.linkedin.venice.pubsub.PubSubTopicPartitionInfo;
 import com.linkedin.venice.pubsub.PubSubTopicRepository;
 import com.linkedin.venice.pubsub.api.PubSubAdminAdapter;
 import com.linkedin.venice.pubsub.api.PubSubConsumerAdapter;
+import com.linkedin.venice.pubsub.api.PubSubPosition;
 import com.linkedin.venice.pubsub.api.PubSubTopic;
 import com.linkedin.venice.pubsub.api.PubSubTopicPartition;
 import com.linkedin.venice.pubsub.api.exceptions.PubSubClientException;
@@ -40,6 +41,7 @@ import com.linkedin.venice.utils.RetryUtils;
 import com.linkedin.venice.utils.Utils;
 import it.unimi.dsi.fastutil.ints.Int2LongMap;
 import java.io.Closeable;
+import java.nio.ByteBuffer;
 import java.time.Duration;
 import java.util.Arrays;
 import java.util.List;
@@ -803,6 +805,51 @@ public class TopicManager implements Closeable {
    */
   public void prefetchAndCacheLatestOffset(PubSubTopicPartition pubSubTopicPartition) {
     topicMetadataFetcher.populateCacheWithLatestOffset(pubSubTopicPartition);
+  }
+
+  /**
+   * Resolves a {@link PubSubPosition} from the given serialized buffer using the specified position type ID.
+   * This API is part of the Topic Manager (TM) interface because TM has access to a consumer instance
+   * capable of performing lookups from {@link PubSubTopicPartition} to PubSub-specific objects
+   * (e.g., {@code Shard} in LinkedIn's Xinfra clients), which may be required by some PubSub client implementations.
+   *
+   * @param partition The topic-partition context.
+   * @param positionTypeId The type ID used to identify how to deserialize the position.
+   * @param buffer The serialized form of the position.
+   * @return The resolved {@link PubSubPosition}.
+   */
+  public PubSubPosition resolvePosition(PubSubTopicPartition partition, int positionTypeId, ByteBuffer buffer) {
+    return topicMetadataFetcher.resolvePosition(partition, positionTypeId, buffer);
+  }
+
+  /**
+   * Computes the difference between two positions within a given topic-partition.
+   * This API is part of the Topic Manager (TM) interface because TM has access to a consumer instance
+   * capable of performing lookups from {@link PubSubTopicPartition} to PubSub-specific objects
+   * (e.g., {@code Shard} in LinkedIn's Xinfra clients), which may be required by some PubSub client implementations.
+   *
+   * @param partition The topic-partition context.
+   * @param position1 The first position.
+   * @param position2 The second position.
+   * @return The difference between the two positions, in number of records.
+   */
+  public long diffPosition(PubSubTopicPartition partition, PubSubPosition position1, PubSubPosition position2) {
+    return topicMetadataFetcher.diffPosition(partition, position1, position2);
+  }
+
+  /**
+   * Compares two positions within the context of a specific topic-partition.
+   * This API is part of the Topic Manager (TM) interface because TM has access to a consumer instance
+   * capable of performing lookups from {@link PubSubTopicPartition} to PubSub-specific objects
+   * (e.g., {@code Shard} in LinkedIn's Xinfra clients), which may be required by some PubSub client implementations.
+   *
+   * @param partition The topic-partition context.
+   * @param position1 The first position.
+   * @param position2 The second position.
+   * @return A negative number if position1 < position2, 0 if equal, and a positive number if position1 > position2.
+   */
+  public long comparePosition(PubSubTopicPartition partition, PubSubPosition position1, PubSubPosition position2) {
+    return topicMetadataFetcher.comparePosition(partition, position1, position2);
   }
 
   public String getPubSubClusterAddress() {

--- a/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/manager/TopicMetadataFetcher.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/manager/TopicMetadataFetcher.java
@@ -21,6 +21,7 @@ import com.linkedin.venice.pubsub.api.DefaultPubSubMessage;
 import com.linkedin.venice.pubsub.api.PubSubAdminAdapter;
 import com.linkedin.venice.pubsub.api.PubSubConsumerAdapter;
 import com.linkedin.venice.pubsub.api.PubSubMessageDeserializer;
+import com.linkedin.venice.pubsub.api.PubSubPosition;
 import com.linkedin.venice.pubsub.api.PubSubTopic;
 import com.linkedin.venice.pubsub.api.PubSubTopicPartition;
 import com.linkedin.venice.pubsub.api.exceptions.PubSubClientRetriableException;
@@ -37,6 +38,7 @@ import it.unimi.dsi.fastutil.ints.Int2LongMaps;
 import it.unimi.dsi.fastutil.ints.Int2LongOpenHashMap;
 import java.io.Closeable;
 import java.io.IOException;
+import java.nio.ByteBuffer;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -674,6 +676,33 @@ class TopicMetadataFetcher implements Closeable {
         assignedPartitions,
         this);
     pubSubConsumerAdapter.batchUnsubscribe(assignedPartitions);
+  }
+
+  public PubSubPosition resolvePosition(PubSubTopicPartition partition, int positionTypeId, ByteBuffer buffer) {
+    PubSubConsumerAdapter pubSubConsumerAdapter = acquireConsumer();
+    try {
+      return pubSubConsumerAdapter.decodePosition(partition, positionTypeId, buffer);
+    } finally {
+      releaseConsumer(pubSubConsumerAdapter);
+    }
+  }
+
+  public long diffPosition(PubSubTopicPartition partition, PubSubPosition position1, PubSubPosition position2) {
+    PubSubConsumerAdapter pubSubConsumerAdapter = acquireConsumer();
+    try {
+      return pubSubConsumerAdapter.positionDifference(partition, position1, position2);
+    } finally {
+      releaseConsumer(pubSubConsumerAdapter);
+    }
+  }
+
+  public long comparePosition(PubSubTopicPartition partition, PubSubPosition position1, PubSubPosition position2) {
+    PubSubConsumerAdapter pubSubConsumerAdapter = acquireConsumer();
+    try {
+      return pubSubConsumerAdapter.comparePositions(partition, position1, position2);
+    } finally {
+      releaseConsumer(pubSubConsumerAdapter);
+    }
   }
 
   void invalidateKey(PubSubTopicPartition pubSubTopicPartition) {

--- a/internal/venice-common/src/test/java/com/linkedin/venice/pubsub/adapter/kafka/consumer/ApacheKafkaConsumerAdapterTest.java
+++ b/internal/venice-common/src/test/java/com/linkedin/venice/pubsub/adapter/kafka/consumer/ApacheKafkaConsumerAdapterTest.java
@@ -1,5 +1,6 @@
 package com.linkedin.venice.pubsub.adapter.kafka.consumer;
 
+import static com.linkedin.venice.pubsub.PubSubPositionTypeRegistry.APACHE_KAFKA_OFFSET_POSITION_TYPE_ID;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.eq;
@@ -842,7 +843,8 @@ public class ApacheKafkaConsumerAdapterTest {
     ApacheKafkaOffsetPosition original = new ApacheKafkaOffsetPosition(expectedOffset);
     ByteBuffer buffer = original.getWireFormatBytes();
 
-    PubSubPosition decoded = kafkaConsumerAdapter.decodePosition(pubSubTopicPartition, buffer);
+    PubSubPosition decoded =
+        kafkaConsumerAdapter.decodePosition(pubSubTopicPartition, APACHE_KAFKA_OFFSET_POSITION_TYPE_ID, buffer);
     assertTrue(decoded instanceof ApacheKafkaOffsetPosition);
     assertEquals(((ApacheKafkaOffsetPosition) decoded).getInternalOffset(), expectedOffset);
   }
@@ -850,6 +852,6 @@ public class ApacheKafkaConsumerAdapterTest {
   @Test(expectedExceptions = VeniceException.class)
   public void testDecodePositionWithInvalidBuffer() {
     ByteBuffer invalidBuffer = ByteBuffer.wrap(new byte[] {}); // Too short to decode
-    kafkaConsumerAdapter.decodePosition(pubSubTopicPartition, invalidBuffer);
+    kafkaConsumerAdapter.decodePosition(pubSubTopicPartition, APACHE_KAFKA_OFFSET_POSITION_TYPE_ID, invalidBuffer);
   }
 }

--- a/internal/venice-common/src/test/java/com/linkedin/venice/pubsub/api/EarliestPositionTest.java
+++ b/internal/venice-common/src/test/java/com/linkedin/venice/pubsub/api/EarliestPositionTest.java
@@ -18,6 +18,8 @@ public class EarliestPositionTest {
 
     assertNotNull(instance1);
     assertSame(instance1, instance2, "Should return the same singleton instance");
+    assertTrue(instance1.isSymbolic(), "EarliestPosition should be symbolic");
+    assertTrue(instance2.isSymbolic(), "EarliestPosition should be symbolic");
   }
 
   @Test

--- a/internal/venice-common/src/test/java/com/linkedin/venice/pubsub/api/LatestPositionTest.java
+++ b/internal/venice-common/src/test/java/com/linkedin/venice/pubsub/api/LatestPositionTest.java
@@ -18,6 +18,8 @@ public class LatestPositionTest {
 
     assertNotNull(instance1, "Singleton instance should not be null");
     assertSame(instance1, instance2, "Should return the same singleton instance");
+    assertTrue(instance1.isSymbolic(), "LatestPosition should be symbolic");
+    assertEquals(instance2.isSymbolic(), true, "LatestPosition should be symbolic");
   }
 
   @Test

--- a/internal/venice-test-common/src/main/java/com/linkedin/venice/pubsub/mock/adapter/consumer/MockInMemoryConsumerAdapter.java
+++ b/internal/venice-test-common/src/main/java/com/linkedin/venice/pubsub/mock/adapter/consumer/MockInMemoryConsumerAdapter.java
@@ -269,7 +269,7 @@ public class MockInMemoryConsumerAdapter implements PubSubConsumerAdapter {
   }
 
   @Override
-  public PubSubPosition decodePosition(PubSubTopicPartition partition, ByteBuffer buffer) {
+  public PubSubPosition decodePosition(PubSubTopicPartition partition, int positionTypeId, ByteBuffer buffer) {
     try {
       if (buffer.remaining() < Long.BYTES) {
         throw new VeniceException("Buffer too short to decode InMemoryPubSubPosition: " + buffer);


### PR DESCRIPTION
<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat], [protocol]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## Add PubSubPosition resolve and diff APIs in TopicManager


###  Code changes
- [ ] Added new code behind **a config**. If so list the config names and their default values in the PR description.
- [ ] Introduced new **log lines**. 
  - [ ] Confirmed if logs need to be **rate limited** to avoid excessive logging.

###  **Concurrency-Specific Checks**
Both reviewer and PR author to verify
- [ ] Code has **no race conditions** or **thread safety issues**.
- [ ] Proper **synchronization mechanisms** (e.g., `synchronized`, `RWLock`) are used where needed.
- [ ] No **blocking calls** inside critical sections that could lead to deadlocks or performance degradation.
- [ ] Verified **thread-safe collections** are used (e.g., `ConcurrentHashMap`, `CopyOnWriteArrayList`).
- [ ] Validated proper exception handling in multi-threaded code to avoid silent thread termination.


## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->

- [ ] New unit tests added.
- [ ] New integration tests added.
- [ ] Modified or extended existing tests.
- [ ] Verified backward compatibility (if applicable).

## Does this PR introduce any user-facing or breaking changes?
<!--  
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [ ] No. You can skip the rest of this section.
- [ ] Yes. Clearly explain the behavior change and its impact.