### PR TITLE
[protocol] Add gRPC countByBucket RPC method to VeniceReadService protocol

### DIFF
--- a/internal/venice-common/src/main/proto/VeniceReadService.proto
+++ b/internal/venice-common/src/main/proto/VeniceReadService.proto
@@ -7,6 +7,7 @@ service VeniceReadService {
   rpc get (VeniceClientRequest) returns (VeniceServerResponse) {}
   rpc batchGet(VeniceClientRequest) returns (VeniceServerResponse) {}
   rpc countByValue(CountByValueRequest) returns (CountByValueResponse) {}
+  rpc countByBucket(CountByBucketRequest) returns (CountByBucketResponse) {}
 }
 
 message VeniceClientRequest {
@@ -47,4 +48,40 @@ message CountByValueResponse {
 
 message ValueCount {
   map<string, int32> valueToCounts = 1;
+}
+
+// CountByBucket protocol - supports nested predicates
+message BucketPredicate {
+  oneof predicate_type {
+    ComparisonPredicate comparison = 1;
+    LogicalPredicate logical = 2;
+  }
+}
+
+message ComparisonPredicate {
+  string operator = 1;     // "GT", "GTE", "LT", "LTE", "EQ", "IN"
+  string field_type = 2;   // "LONG", "INT", "FLOAT", "DOUBLE", "STRING"
+  string value = 3;
+}
+
+message LogicalPredicate {
+  string operator = 1;     // "AND", "OR"
+  repeated BucketPredicate predicates = 2;
+}
+
+message CountByBucketRequest {
+  repeated bytes keys = 1;
+  string resourceName = 2;
+  repeated string fieldNames = 3;
+  map<string, BucketPredicate> bucketPredicates = 4;
+}
+
+message CountByBucketResponse {
+  map<string, BucketCount> fieldToBucketCounts = 1;
+  uint32 errorCode = 2;
+  string errorMessage = 3;
+}
+
+message BucketCount {
+  map<string, int32> bucketToCounts = 1;
 }


### PR DESCRIPTION
## Problem Statement

Venice currently supports CountByValue aggregation for facet counting, but lacks support for CountByBucket aggregation. The main challenge is defining a protocol to pass complex, potentially nested predicates from client to server, as identified in VIP-5 Facet Counting proposal.

The current limitation is that there's no way for clients to send bucket definitions (with predicates like "age > 18 AND age < 65") to the server for server-side CountByBucket processing.

## Solution

This PR introduces the core protocol definition for CountByBucket aggregation, solving the key challenge of predicate serialization mentioned in VIP-5. The solution includes:

1. **Recursive Predicate Protocol**: Added `BucketPredicate` message that supports nested logical operations (AND/OR) through recursive structure
2. **Complete Operator Support**: Covers all existing Venice predicate operators (GT, GTE, LT, LTE, EQ, IN)
3. **Full Type Coverage**: Supports all Venice data types (LONG, INT, FLOAT, DOUBLE, STRING)
4. **Extensible Design**: String-based operators and types allow easy addition of new predicates without protocol changes

The protocol design enables complex queries like:
- `bucket_young_adults`: age >= 18 AND age <= 35
- `bucket_high_earners`: salary > 100000 OR (role = "senior" AND experience >= 5)

### Code changes
- [ ] Added new code behind **a config**. If so list the config names and their default values in the PR description.
- [ ] Introduced new **log lines**.
  - [ ] Confirmed if logs need to be **rate limited** to avoid excessive logging.

### Concurrency-Specific Checks
Both reviewer and PR author to verify:
- [x] Code has **no race conditions** or **thread safety issues**. (Protocol definition only)
- [x] Proper **synchronization mechanisms** (e.g., `synchronized`, `RWLock`) are used where needed. (Not applicable)
- [x] No **blocking calls** inside critical sections that could lead to deadlocks or performance degradation. (Not applicable)
- [x] Verified **thread-safe collections** are used (e.g., `ConcurrentHashMap`, `CopyOnWriteArrayList`). (Not applicable)
- [x] Validated proper exception handling in multi-threaded code to avoid silent thread termination. (Not applicable)

## How was this PR tested?

This PR only adds protocol definitions and does not include implementation logic. Testing will be covered in subsequent PRs that implement:
- Predicate serialization/deserialization
- Server-side CountByBucket processor
- Client-side integration

- [ ] New unit tests added.
- [ ] New integration tests added.
- [ ] Modified or extended existing tests.
- [x] Verified backward compatibility (if applicable). - Only additive changes to protocol

## Does this PR introduce any user-facing or breaking changes?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Clearly explain the behavior change and its impact.

This PR only adds new protocol messages and RPC method definition. No existing functionality is modified.