### PR TITLE
[controller] Improve davinci push status debugging logging by adding host information for remaining partitions.

### DIFF
--- a/services/venice-controller/src/main/java/com/linkedin/venice/pushmonitor/PushMonitorUtils.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/pushmonitor/PushMonitorUtils.java
@@ -23,6 +23,11 @@ import org.apache.logging.log4j.Logger;
  */
 public class PushMonitorUtils {
   private static long daVinciErrorInstanceWaitTime = 5;
+
+  private static final int INCOMPLETE_PARTITIONS_PRINT_THRESHOLD = 10;
+
+  private static final int INCOMPLETE_INSTANCES_PRINT_THRESHOLD = 10;
+
   protected static final RedundantExceptionFilter REDUNDANT_LOGGING_FILTER =
       new RedundantExceptionFilter(RedundantExceptionFilter.DEFAULT_BITSET_SIZE, TimeUnit.MINUTES.toMillis(10));
 
@@ -93,7 +98,7 @@ public class PushMonitorUtils {
       int offlineInstanceCount = 0;
       Optional<String> erroredInstance = Optional.empty();
       Set<String> offlineInstanceList = new HashSet<>();
-      Set<String> incompleteInstanceList = new HashSet<>();
+      Map<CharSequence, String> incompleteInstancesStatus = new HashMap<>();
       ExecutionStatus errorStatus = ExecutionStatus.ERROR;
       for (Map.Entry<CharSequence, Integer> entry: instances.entrySet()) {
         PushStatusStoreReader.InstanceStatus instanceStatus =
@@ -107,6 +112,10 @@ public class PushMonitorUtils {
         if (status == completeStatus) {
           completedInstanceCount++;
           continue;
+        }
+        if (incompleteInstancesStatus.size() < INCOMPLETE_INSTANCES_PRINT_THRESHOLD) {
+          // Keep at most INCOMPLETE_INSTANCES_PRINTING_THRESHOLD incomplete instances for logging purpose.
+          incompleteInstancesStatus.put(entry.getKey().toString(), status.name());
         }
         if (instanceStatus.equals(PushStatusStoreReader.InstanceStatus.DEAD)) {
           offlineInstanceCount++;
@@ -123,10 +132,6 @@ public class PushMonitorUtils {
           errorStatus = status;
           erroredInstance = Optional.of(entry.getKey().toString());
           break;
-        }
-        if (incompleteInstanceList.size() < 2) {
-          // Keep at most 2 incomplete instances for logging purpose.
-          incompleteInstanceList.add(entry.getKey().toString());
         }
       }
 
@@ -168,8 +173,11 @@ public class PushMonitorUtils {
             .append(". Live instance count: ")
             .append(liveInstanceCount);
       }
-      if (incompleteInstanceList.size() > 0) {
-        statusDetailStringBuilder.append(". Some example incomplete instances ").append(incompleteInstanceList);
+      if (!incompleteInstancesStatus.isEmpty()) {
+        statusDetailStringBuilder.append(". Some example incomplete instances: ");
+        incompleteInstancesStatus.forEach((instance, status) -> {
+          statusDetailStringBuilder.append(instance).append("-").append(status).append(",");
+        });
       }
       String statusDetail = statusDetailStringBuilder.toString();
       if (allInstancesCompleted) {
@@ -222,11 +230,11 @@ public class PushMonitorUtils {
   }
 
   /**
-   * @Deprecated.
    * This method checks Da Vinci client push status of all partitions from push status store and compute a final status.
    * Inside each partition, this method will compute status based on all active Da Vinci instances.
    * A Da Vinci instance sent heartbeat to controllers recently is considered active.
    */
+  @Deprecated
   public static ExecutionStatusWithDetails getDaVinciPartitionLevelPushStatusAndDetails(
       PushStatusStoreReader reader,
       String topicName,
@@ -263,6 +271,10 @@ public class PushMonitorUtils {
      * This cache is used to reduce the duplicate calls for liveness check as one host can host multiple partitions.
      */
     Map<String, PushStatusStoreReader.InstanceStatus> instanceLivenessCache = new HashMap<>();
+    /**
+     * Map to store incomplete partition details with their associated instances
+     */
+    Map<Integer, Set<String>> incompletePartitionInstances = new HashMap<>();
     for (int partitionId = 0; partitionId < partitionCount; partitionId++) {
       Map<CharSequence, Integer> instances =
           reader.getPartitionStatus(storeName, version, partitionId, incrementalPushVersion);
@@ -327,6 +339,19 @@ public class PushMonitorUtils {
         completedPartitions++;
       } else {
         incompletePartition.add(partitionId);
+        // Collect instance information for incomplete partitions
+        Set<String> partitionInstances = new HashSet<>();
+        for (Map.Entry<CharSequence, Integer> entry: instances.entrySet()) {
+          if (instancesToIgnore.contains(entry.getKey())) {
+            continue;
+          }
+          String instanceName = entry.getKey().toString();
+          ExecutionStatus status = ExecutionStatus.valueOf(entry.getValue());
+          if (status != completeStatus) {
+            partitionInstances.add(instanceName);
+          }
+        }
+        incompletePartitionInstances.put(partitionId, partitionInstances);
       }
     }
     boolean noDaVinciStatusReported = totalReplicaCount == 0;
@@ -381,9 +406,30 @@ public class PushMonitorUtils {
     int incompleteSize = incompletePartition.size();
     if (incompleteSize > 0) {
       List<Integer> list = new ArrayList<>(incompletePartition);
-      statusDetailStringBuilder.append(". Following partitions still not complete (capped at 10) ")
-          .append(list.subList(0, Math.min(10, list.size())))
-          .append(". Live replica count: ")
+      statusDetailStringBuilder.append(". Following partitions still not complete (capped at 10) ");
+
+      if (incompleteSize > INCOMPLETE_PARTITIONS_PRINT_THRESHOLD) {
+        // If more than 10 partitions, show only partition IDs like before
+        statusDetailStringBuilder.append(list.subList(0, INCOMPLETE_PARTITIONS_PRINT_THRESHOLD));
+      } else {
+        // If 10 or fewer partitions, show partition IDs with their associated instances
+        for (int i = 0; i < list.size(); i++) {
+          int partitionId = list.get(i);
+          List<String> instances = new ArrayList<>(incompletePartitionInstances.get(partitionId));
+          if (instances.size() > INCOMPLETE_INSTANCES_PRINT_THRESHOLD) {
+            instances = instances.subList(0, INCOMPLETE_INSTANCES_PRINT_THRESHOLD);
+          }
+          statusDetailStringBuilder.append("Partition: ").append(partitionId);
+          if (instances != null && !instances.isEmpty()) {
+            statusDetailStringBuilder.append(" (instances: ").append(instances).append(")");
+          }
+          if (i < list.size() - 1) {
+            statusDetailStringBuilder.append(", ");
+          }
+        }
+      }
+
+      statusDetailStringBuilder.append(". Live replica count: ")
           .append(liveReplicaCount)
           .append(", completed replica count: ")
           .append(completedReplicaCount)


### PR DESCRIPTION
<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat], [protocol]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## Problem Statement
<!--
Describe
- What problem are you trying to solve
- What issues or limitations exist in the current code
- Why this change is necessary 
-->
Currently, when a Venice Push Job (VPJ) hangs for a specific region, it's often due to one or a small subset of partitions not completing. However, VPJ does not explicitly surface which host with which partition is causing the delay. As a result, on-call engineers must investigate multiple sources—including controller and server logs, ZooKeeper—to identify the blocking partition and server.

One example logging:
`1827/1840 Da Vinci instances completed.. However, some instances are still reporting partition level status keys and they are not completed yet. 19/20 partitions completed in 7318 Da Vinci replicas.. Following partitions still not complete (capped at 10) [0]`

This challenge is even more pronounced for Da Vinci, where identifying the problematic host and partition requires additional human toil to query the system store with specific cmd. 



## Solution
<!--
Describe
- What changes you are making and why. 
- How these changes solve the problem.
- Any performance considerations or trade-offs. 
- Describe what testings you have done, for example, performance testing etc.
-->
To avoid polluting the controller logs and responses, we need to design intelligent logging logic that selectively outputs this information with partition id and davinci hostname.

###  Code changes
- [ ] Added new code behind **a config**. If so list the config names and their default values in the PR description.
- [ ] Introduced new **log lines**. 
  - [ ] Confirmed if logs need to be **rate limited** to avoid excessive logging.

###  **Concurrency-Specific Checks**
Both reviewer and PR author to verify
- [ ] Code has **no race conditions** or **thread safety issues**.
- [ ] Proper **synchronization mechanisms** (e.g., `synchronized`, `RWLock`) are used where needed.
- [ ] No **blocking calls** inside critical sections that could lead to deadlocks or performance degradation.
- [ ] Verified **thread-safe collections** are used (e.g., `ConcurrentHashMap`, `CopyOnWriteArrayList`).
- [ ] Validated proper exception handling in multi-threaded code to avoid silent thread termination.


## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->

- [ ] New unit tests added.
- [ ] New integration tests added.
- [ ] Modified or extended existing tests.
- [ ] Verified backward compatibility (if applicable).

## Does this PR introduce any user-facing or breaking changes?
<!--  
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [ ] No. You can skip the rest of this section.
- [ ] Yes. Clearly explain the behavior change and its impact.