### PR TITLE
[server][dvc][cdc] Fix PubSubPosition serialization helper to include typeId

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/consumer/VeniceChangeCoordinate.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/consumer/VeniceChangeCoordinate.java
@@ -41,7 +41,8 @@ public class VeniceChangeCoordinate implements Externalizable {
   public void readExternal(ObjectInput in) throws IOException, ClassNotFoundException {
     this.topic = in.readUTF();
     this.partition = in.readInt();
-    this.pubSubPosition = PubSubPosition.getPositionFromWireFormat((PubSubPositionWireFormat) in.readObject());
+    this.pubSubPosition =
+        PubSubPositionDeserializer.getPositionFromWireFormat((PubSubPositionWireFormat) in.readObject());
   }
 
   // Partition and store name can be publicly accessible

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTask.java
@@ -1678,7 +1678,7 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
         sourceTopicOffset,
         kafkaClusterId,
         DEFAULT_TERM_ID,
-        consumedPosition.getWireFormatBytes());
+        consumedPosition.toWireFormatBuffer());
     partitionConsumptionState.setLastLeaderPersistFuture(leaderProducedRecordContext.getPersistedToDBFuture());
     long beforeProduceTimestampNS = System.nanoTime();
     produceFunction.accept(callback, leaderMetadataWrapper);
@@ -2196,7 +2196,7 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
         consumedPosition.getNumericOffset(),
         kafkaClusterId,
         DEFAULT_TERM_ID,
-        consumedPosition.getWireFormatBytes());
+        consumedPosition.toWireFormatBuffer());
     LeaderCompleteState leaderCompleteState =
         LeaderCompleteState.getLeaderCompleteState(partitionConsumptionState.isCompletionReported());
     /**

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/store/view/ChangeCaptureViewWriter.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/store/view/ChangeCaptureViewWriter.java
@@ -135,7 +135,7 @@ public class ChangeCaptureViewWriter extends VeniceViewWriter {
     if (maxColoIdValue > -1) {
       highWaterMarkOffsets = new ArrayList<>(Collections.nCopies(maxColoIdValue + 1, 0L));
       highWaterMarkPubSubPositions = new ArrayList<>(
-          Collections.nCopies(maxColoIdValue + 1, PubSubSymbolicPosition.EARLIEST.getWireFormatBytes()));
+          Collections.nCopies(maxColoIdValue + 1, PubSubSymbolicPosition.EARLIEST.toWireFormatBuffer()));
       for (String url: sortedWaterMarkOffsets.keySet()) {
         highWaterMarkOffsets.set(
             kafkaClusterUrlToIdMap.getInt(url),

--- a/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/PubSubPositionDeserializer.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/PubSubPositionDeserializer.java
@@ -1,10 +1,10 @@
 package com.linkedin.venice.pubsub;
 
+import static com.linkedin.venice.pubsub.api.PubSubPosition.PUBSUB_POSITION_WIRE_FORMAT_SERIALIZER;
+
 import com.linkedin.venice.exceptions.VeniceException;
 import com.linkedin.venice.pubsub.api.PubSubPosition;
 import com.linkedin.venice.pubsub.api.PubSubPositionWireFormat;
-import com.linkedin.venice.serialization.avro.AvroProtocolDefinition;
-import com.linkedin.venice.serialization.avro.InternalAvroSpecificSerializer;
 import java.nio.ByteBuffer;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -41,7 +41,7 @@ public class PubSubPositionDeserializer {
    * @param positionWireFormat the wire format position
    * @return concrete position object represented by the wire format
    */
-  public PubSubPosition convertToPosition(PubSubPositionWireFormat positionWireFormat) {
+  public PubSubPosition toPosition(PubSubPositionWireFormat positionWireFormat) {
     if (positionWireFormat == null) {
       throw new IllegalArgumentException("Cannot deserialize null wire format position");
     }
@@ -59,31 +59,50 @@ public class PubSubPositionDeserializer {
     return factory.createFromWireFormat(positionWireFormat);
   }
 
-  public PubSubPosition convertToPosition(byte[] positionWireFormatBytes) {
+  public PubSubPosition toPosition(byte[] positionWireFormatBytes) {
     if (positionWireFormatBytes == null) {
       throw new IllegalArgumentException("Cannot deserialize null wire format position");
     }
-    InternalAvroSpecificSerializer<PubSubPositionWireFormat> wireFormatSerializer =
-        AvroProtocolDefinition.PUBSUB_POSITION_WIRE_FORMAT.getSerializer();
-    PubSubPositionWireFormat wireFormat = wireFormatSerializer.deserialize(positionWireFormatBytes, null);
-    return convertToPosition(wireFormat);
+    PubSubPositionWireFormat wireFormat =
+        PUBSUB_POSITION_WIRE_FORMAT_SERIALIZER.deserialize(positionWireFormatBytes, null);
+    return toPosition(wireFormat);
   }
 
-  public PubSubPosition convertToPosition(ByteBuffer positionWireFormatBytes) {
+  public PubSubPosition toPosition(ByteBuffer positionWireFormatBytes) {
     if (positionWireFormatBytes == null) {
       throw new IllegalArgumentException("Cannot deserialize null wire format position");
     }
-    InternalAvroSpecificSerializer<PubSubPositionWireFormat> wireFormatSerializer =
-        AvroProtocolDefinition.PUBSUB_POSITION_WIRE_FORMAT.getSerializer();
-    PubSubPositionWireFormat wireFormat = wireFormatSerializer.deserialize(positionWireFormatBytes.array(), null);
-    return convertToPosition(wireFormat);
+    PubSubPositionWireFormat wireFormat =
+        PUBSUB_POSITION_WIRE_FORMAT_SERIALIZER.deserialize(positionWireFormatBytes.array(), null);
+    return toPosition(wireFormat);
   }
 
+  /**
+   * Convenience method for converting a serialized byte array representing a
+   * {@link PubSubPositionWireFormat} into a concrete {@link PubSubPosition} instance.
+   *
+   * <p>This uses the {@link #DEFAULT_DESERIALIZER} with the reserved position type registry.
+   * Recommended only for use in non-critical paths or tests where custom registries are not required.</p>
+   *
+   * @param positionWireFormatBytes the serialized bytes of {@link PubSubPositionWireFormat}
+   * @return deserialized {@link PubSubPosition} object
+   * @throws VeniceException if deserialization fails or type ID is unrecognized
+   */
   public static PubSubPosition getPositionFromWireFormat(byte[] positionWireFormatBytes) {
-    return DEFAULT_DESERIALIZER.convertToPosition(positionWireFormatBytes);
+    return DEFAULT_DESERIALIZER.toPosition(positionWireFormatBytes);
   }
 
+  /**
+   * Convenience method for converting a {@link PubSubPositionWireFormat} record into a concrete {@link PubSubPosition}.
+   *
+   * <p>This uses the {@link #DEFAULT_DESERIALIZER} with the reserved position type registry.
+   * Prefer constructing your own {@link PubSubPositionDeserializer} with a custom registry if needed.</p>
+   *
+   * @param positionWireFormat the wire format record to convert
+   * @return deserialized {@link PubSubPosition} object
+   * @throws VeniceException if the type ID in the wire format is unrecognized
+   */
   public static PubSubPosition getPositionFromWireFormat(PubSubPositionWireFormat positionWireFormat) {
-    return DEFAULT_DESERIALIZER.convertToPosition(positionWireFormat);
+    return DEFAULT_DESERIALIZER.toPosition(positionWireFormat);
   }
 }

--- a/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/PubSubPositionDeserializer.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/PubSubPositionDeserializer.java
@@ -5,6 +5,7 @@ import static com.linkedin.venice.pubsub.api.PubSubPosition.PUBSUB_POSITION_WIRE
 import com.linkedin.venice.exceptions.VeniceException;
 import com.linkedin.venice.pubsub.api.PubSubPosition;
 import com.linkedin.venice.pubsub.api.PubSubPositionWireFormat;
+import com.linkedin.venice.utils.ByteUtils;
 import java.nio.ByteBuffer;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -73,7 +74,7 @@ public class PubSubPositionDeserializer {
       throw new IllegalArgumentException("Cannot deserialize null wire format position");
     }
     PubSubPositionWireFormat wireFormat =
-        PUBSUB_POSITION_WIRE_FORMAT_SERIALIZER.deserialize(positionWireFormatBytes.array(), null);
+        PUBSUB_POSITION_WIRE_FORMAT_SERIALIZER.deserialize(ByteUtils.extractByteArray(positionWireFormatBytes), null);
     return toPosition(wireFormat);
   }
 
@@ -90,6 +91,10 @@ public class PubSubPositionDeserializer {
    */
   public static PubSubPosition getPositionFromWireFormat(byte[] positionWireFormatBytes) {
     return DEFAULT_DESERIALIZER.toPosition(positionWireFormatBytes);
+  }
+
+  public static PubSubPosition getPositionFromWireFormat(ByteBuffer positionWireFormatBuffer) {
+    return DEFAULT_DESERIALIZER.toPosition(positionWireFormatBuffer);
   }
 
   /**

--- a/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/api/PubSubPosition.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/api/PubSubPosition.java
@@ -2,7 +2,8 @@ package com.linkedin.venice.pubsub.api;
 
 import com.linkedin.venice.annotation.RestrictedApi;
 import com.linkedin.venice.memory.Measurable;
-import com.linkedin.venice.pubsub.PubSubPositionDeserializer;
+import com.linkedin.venice.serialization.avro.AvroProtocolDefinition;
+import com.linkedin.venice.serialization.avro.InternalAvroSpecificSerializer;
 import java.nio.ByteBuffer;
 
 
@@ -10,6 +11,9 @@ import java.nio.ByteBuffer;
  * Represents a position of a message in a partition of a topic.
  */
 public interface PubSubPosition extends Measurable {
+  InternalAvroSpecificSerializer<PubSubPositionWireFormat> PUBSUB_POSITION_WIRE_FORMAT_SERIALIZER =
+      AvroProtocolDefinition.PUBSUB_POSITION_WIRE_FORMAT.getSerializer();
+
   @RestrictedApi("This API facilitates the transition from numeric offsets to PubSubPosition. "
       + "It should be removed once the codebase fully adopts PubSubPosition.")
   long getNumericOffset();
@@ -33,11 +37,17 @@ public interface PubSubPosition extends Measurable {
    * Returns the serialized wire format bytes of this position.
    * @return byte array representing the position in wire format
    */
-  default ByteBuffer getWireFormatBytes() {
-    return getPositionWireFormat().getRawBytes();
+  default ByteBuffer toWireFormatBuffer() {
+    return PUBSUB_POSITION_WIRE_FORMAT_SERIALIZER.serialize(getPositionWireFormat());
   }
 
-  static PubSubPosition getPositionFromWireFormat(PubSubPositionWireFormat positionWireFormat) {
-    return PubSubPositionDeserializer.getPositionFromWireFormat(positionWireFormat);
+  /**
+   * Serializes this position to a wire format and returns the result as a byte array.
+   * This method bypasses ByteBuffer and directly returns the backing array.
+   *
+   * @return a byte array representing the serialized wire format of this position
+   */
+  default byte[] toWireFormatBytes() {
+    return PUBSUB_POSITION_WIRE_FORMAT_SERIALIZER.serialize(null, getPositionWireFormat());
   }
 }

--- a/internal/venice-common/src/test/java/com/linkedin/venice/pubsub/PubSubPositionDeserializerTest.java
+++ b/internal/venice-common/src/test/java/com/linkedin/venice/pubsub/PubSubPositionDeserializerTest.java
@@ -10,7 +10,6 @@ import com.linkedin.venice.pubsub.adapter.kafka.common.ApacheKafkaOffsetPosition
 import com.linkedin.venice.pubsub.api.PubSubPosition;
 import com.linkedin.venice.pubsub.api.PubSubPositionWireFormat;
 import com.linkedin.venice.pubsub.api.PubSubSymbolicPosition;
-import java.nio.ByteBuffer;
 import org.testng.annotations.Test;
 
 
@@ -32,8 +31,8 @@ public class PubSubPositionDeserializerTest {
     assertTrue(positionFromBytes instanceof ApacheKafkaOffsetPosition);
     assertEquals(positionFromBytes, position);
 
-    ByteBuffer wireFormatBuffer = position1.toWireFormatBuffer();
-    PubSubPosition positionFromBuffer = PubSubPositionDeserializer.getPositionFromWireFormat(wireFormatBuffer.array());
+    PubSubPosition positionFromBuffer =
+        PubSubPositionDeserializer.getPositionFromWireFormat(position1.toWireFormatBuffer());
     assertTrue(positionFromBuffer instanceof ApacheKafkaOffsetPosition);
     assertEquals(positionFromBuffer, position);
   }

--- a/internal/venice-common/src/test/java/com/linkedin/venice/pubsub/PubSubPositionDeserializerTest.java
+++ b/internal/venice-common/src/test/java/com/linkedin/venice/pubsub/PubSubPositionDeserializerTest.java
@@ -1,6 +1,7 @@
 package com.linkedin.venice.pubsub;
 
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertSame;
 import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.expectThrows;
 
@@ -8,8 +9,8 @@ import com.linkedin.venice.exceptions.VeniceException;
 import com.linkedin.venice.pubsub.adapter.kafka.common.ApacheKafkaOffsetPosition;
 import com.linkedin.venice.pubsub.api.PubSubPosition;
 import com.linkedin.venice.pubsub.api.PubSubPositionWireFormat;
-import com.linkedin.venice.serialization.avro.AvroProtocolDefinition;
-import com.linkedin.venice.serialization.avro.InternalAvroSpecificSerializer;
+import com.linkedin.venice.pubsub.api.PubSubSymbolicPosition;
+import java.nio.ByteBuffer;
 import org.testng.annotations.Test;
 
 
@@ -18,17 +19,27 @@ import org.testng.annotations.Test;
  */
 public class PubSubPositionDeserializerTest {
   @Test
-  public void testConvertToPositionForApacheKafkaPosition() {
+  public void testToPositionForApacheKafkaPosition() {
     ApacheKafkaOffsetPosition position = ApacheKafkaOffsetPosition.of(123);
     PubSubPositionWireFormat wireFormat = position.getPositionWireFormat();
 
     PubSubPosition position1 = PubSubPositionDeserializer.getPositionFromWireFormat(wireFormat);
     assertTrue(position1 instanceof ApacheKafkaOffsetPosition);
     assertEquals(position1, position);
+
+    byte[] wireFormatBytes = position1.toWireFormatBytes();
+    PubSubPosition positionFromBytes = PubSubPositionDeserializer.getPositionFromWireFormat(wireFormatBytes);
+    assertTrue(positionFromBytes instanceof ApacheKafkaOffsetPosition);
+    assertEquals(positionFromBytes, position);
+
+    ByteBuffer wireFormatBuffer = position1.toWireFormatBuffer();
+    PubSubPosition positionFromBuffer = PubSubPositionDeserializer.getPositionFromWireFormat(wireFormatBuffer.array());
+    assertTrue(positionFromBuffer instanceof ApacheKafkaOffsetPosition);
+    assertEquals(positionFromBuffer, position);
   }
 
   @Test
-  public void testConvertToPositionForUnsupportedPosition() {
+  public void testToPositionForUnsupportedPosition() {
     PubSubPositionWireFormat wireFormat = new PubSubPositionWireFormat();
     wireFormat.type = Integer.MAX_VALUE;
     Exception e =
@@ -37,16 +48,32 @@ public class PubSubPositionDeserializerTest {
   }
 
   @Test
-  public void testConvertToPositionFromWireFormatPositionBytes() {
-    ApacheKafkaOffsetPosition kafkaPosition = ApacheKafkaOffsetPosition.of(567);
-    PubSubPositionWireFormat kafkaPositionWireFormat = kafkaPosition.getPositionWireFormat();
-    InternalAvroSpecificSerializer<PubSubPositionWireFormat> wireFormatSerializer =
-        AvroProtocolDefinition.PUBSUB_POSITION_WIRE_FORMAT.getSerializer();
-    byte[] wireFormatBytes = wireFormatSerializer.serialize(kafkaPositionWireFormat).array();
+  public void testSerDerForSymbolicPositions() {
+    byte[] startPositionWireFormatBytes = PubSubSymbolicPosition.EARLIEST.toWireFormatBytes();
+    PubSubPosition positionFromBytes =
+        PubSubPositionDeserializer.getPositionFromWireFormat(startPositionWireFormatBytes);
+    assertTrue(positionFromBytes.isSymbolic());
+    assertEquals(
+        positionFromBytes,
+        PubSubSymbolicPosition.EARLIEST,
+        "Expected position to be EARLIEST, but got: " + positionFromBytes);
+    assertSame(
+        positionFromBytes,
+        PubSubSymbolicPosition.EARLIEST,
+        "Expected position to be EARLIEST, but got: " + positionFromBytes);
 
-    PubSubPosition position = PubSubPositionDeserializer.getPositionFromWireFormat(wireFormatBytes);
-    assertTrue(position instanceof ApacheKafkaOffsetPosition);
-    assertEquals(position, kafkaPosition);
+    byte[] endPositionWireFormatBytes = PubSubSymbolicPosition.LATEST.toWireFormatBytes();
+    PubSubPosition positionFromEndBytes =
+        PubSubPositionDeserializer.getPositionFromWireFormat(endPositionWireFormatBytes);
+    assertTrue(positionFromEndBytes.isSymbolic());
+    assertEquals(
+        positionFromEndBytes,
+        PubSubSymbolicPosition.LATEST,
+        "Expected position to be LATEST, but got: " + positionFromEndBytes);
+    assertSame(
+        positionFromEndBytes,
+        PubSubSymbolicPosition.LATEST,
+        "Expected position to be LATEST, but got: " + positionFromEndBytes);
   }
 
   @Test(expectedExceptions = IllegalArgumentException.class, expectedExceptionsMessageRegExp = "Cannot deserialize null wire format position")

--- a/internal/venice-common/src/test/java/com/linkedin/venice/pubsub/manager/TopicManagerTest.java
+++ b/internal/venice-common/src/test/java/com/linkedin/venice/pubsub/manager/TopicManagerTest.java
@@ -169,7 +169,7 @@ public class TopicManagerTest {
     recordValue.producerMetadata.messageTimestamp = producerTimestamp;
     recordValue.leaderMetadataFooter = new LeaderMetadata();
     recordValue.leaderMetadataFooter.hostName = "localhost";
-    recordValue.leaderMetadataFooter.upstreamPubSubPosition = PubSubSymbolicPosition.LATEST.getWireFormatBytes();
+    recordValue.leaderMetadataFooter.upstreamPubSubPosition = PubSubSymbolicPosition.LATEST.toWireFormatBuffer();
 
     if (isDataRecord) {
       Put put = new Put();

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestFatalDataValidationExceptionHandling.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestFatalDataValidationExceptionHandling.java
@@ -307,7 +307,7 @@ public class TestFatalDataValidationExceptionHandling {
             pubSubPosition0.getNumericOffset(),
             0,
             DEFAULT_TERM_ID,
-            pubSubPosition0.getWireFormatBytes()));
+            pubSubPosition0.toWireFormatBuffer()));
     vw1.flush();
 
     PubSubPosition pubSubPosition1 = new ApacheKafkaOffsetPosition(1);
@@ -320,7 +320,7 @@ public class TestFatalDataValidationExceptionHandling {
             pubSubPosition1.getNumericOffset(),
             0,
             DEFAULT_TERM_ID,
-            pubSubPosition1.getWireFormatBytes()));
+            pubSubPosition1.toWireFormatBuffer()));
 
     PubSubPosition pubSubPosition2 = new ApacheKafkaOffsetPosition(2);
     vw2.put(
@@ -332,7 +332,7 @@ public class TestFatalDataValidationExceptionHandling {
             pubSubPosition2.getNumericOffset(),
             0,
             DEFAULT_TERM_ID,
-            pubSubPosition2.getWireFormatBytes()));
+            pubSubPosition2.toWireFormatBuffer()));
     vw2.flush();
 
     PubSubPosition pubSubPosition3 = new ApacheKafkaOffsetPosition(3);
@@ -345,7 +345,7 @@ public class TestFatalDataValidationExceptionHandling {
             pubSubPosition3.getNumericOffset(),
             0,
             DEFAULT_TERM_ID,
-            pubSubPosition3.getWireFormatBytes()));
+            pubSubPosition3.toWireFormatBuffer()));
     vw1.flush();
     vw1.closePartition(0);
     vw1.flush();

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestHybridMultiRegion.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestHybridMultiRegion.java
@@ -274,7 +274,7 @@ public class TestHybridMultiRegion {
                 upstreamPosition1.getNumericOffset(),
                 0,
                 DEFAULT_TERM_ID,
-                upstreamPosition1.getWireFormatBytes()));
+                upstreamPosition1.toWireFormatBuffer()));
         veniceWriter1.flush();
 
         PubSubPosition upstreamPosition2 = new ApacheKafkaOffsetPosition(1);
@@ -287,7 +287,7 @@ public class TestHybridMultiRegion {
                 upstreamPosition2.getNumericOffset(),
                 0,
                 DEFAULT_TERM_ID,
-                upstreamPosition2.getWireFormatBytes()));
+                upstreamPosition2.toWireFormatBuffer()));
         veniceWriter2.flush();
 
         PubSubPosition upstreamPositionIPlusFive;
@@ -302,7 +302,7 @@ public class TestHybridMultiRegion {
                   upstreamPositionIPlusFive.getNumericOffset(),
                   0,
                   DEFAULT_TERM_ID,
-                  upstreamPositionIPlusFive.getWireFormatBytes()));
+                  upstreamPositionIPlusFive.toWireFormatBuffer()));
         }
         veniceWriter1.flush();
 
@@ -316,7 +316,7 @@ public class TestHybridMultiRegion {
                 upstreamPosition3.getNumericOffset(),
                 0,
                 DEFAULT_TERM_ID,
-                upstreamPosition3.getWireFormatBytes()));
+                upstreamPosition3.toWireFormatBuffer()));
 
         for (int i = 5; i < 10; ++i) {
           upstreamPositionIPlusFive = new ApacheKafkaOffsetPosition(i + 5);
@@ -329,7 +329,7 @@ public class TestHybridMultiRegion {
                   upstreamPositionIPlusFive.getNumericOffset(),
                   0,
                   DEFAULT_TERM_ID,
-                  upstreamPositionIPlusFive.getWireFormatBytes()));
+                  upstreamPositionIPlusFive.toWireFormatBuffer()));
         }
         veniceWriter2.flush();
         veniceWriter1.broadcastEndOfPush(Collections.emptyMap());

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/kafka/KafkaConsumptionTest.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/kafka/KafkaConsumptionTest.java
@@ -301,7 +301,7 @@ public class KafkaConsumptionTest {
     recordValue.producerMetadata.producerGUID = new GUID();
     recordValue.producerMetadata.messageTimestamp = producerTimestamp;
     recordValue.leaderMetadataFooter = new LeaderMetadata();
-    recordValue.leaderMetadataFooter.upstreamPubSubPosition = PubSubSymbolicPosition.EARLIEST.getWireFormatBytes();
+    recordValue.leaderMetadataFooter.upstreamPubSubPosition = PubSubSymbolicPosition.EARLIEST.toWireFormatBuffer();
     recordValue.leaderMetadataFooter.hostName = "localhost";
 
     if (isDataRecord) {


### PR DESCRIPTION
### Fix PubSubPosition serialization to include both typeId and value payload

Previously, only the raw bytes of the position were being serialized, omitting the type ID  
and producing an incomplete PubSubPositionWireFormat. This caused deserialization failures  
when attempting to reconstruct the full position.  

This change ensures that the full PubSubPositionWireFormat—including the type ID and raw  
bytes—is serialized and used consistently during conversion.  

###  Code changes
- [ ] Added new code behind **a config**. If so list the config names and their default values in the PR description.
- [ ] Introduced new **log lines**. 
  - [ ] Confirmed if logs need to be **rate limited** to avoid excessive logging.

###  **Concurrency-Specific Checks**
Both reviewer and PR author to verify
- [ ] Code has **no race conditions** or **thread safety issues**.
- [ ] Proper **synchronization mechanisms** (e.g., `synchronized`, `RWLock`) are used where needed.
- [ ] No **blocking calls** inside critical sections that could lead to deadlocks or performance degradation.
- [ ] Verified **thread-safe collections** are used (e.g., `ConcurrentHashMap`, `CopyOnWriteArrayList`).
- [ ] Validated proper exception handling in multi-threaded code to avoid silent thread termination.


## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->

- [ ] New unit tests added.
- [ ] New integration tests added.
- [ ] Modified or extended existing tests.
- [ ] Verified backward compatibility (if applicable).

## Does this PR introduce any user-facing or breaking changes?
<!--  
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [ ] No. You can skip the rest of this section.
- [ ] Yes. Clearly explain the behavior change and its impact.