### PR TITLE
[test] Fix Argument List Too Long Issue in E2E Test DaVinciUserApp by Using Config File

### DIFF
--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/davinci/DaVinciUserApp.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/davinci/DaVinciUserApp.java
@@ -37,10 +37,11 @@ import com.linkedin.venice.endToEnd.TestStringRecordTransformer;
 import com.linkedin.venice.integration.utils.DaVinciTestContext;
 import com.linkedin.venice.utils.SslUtils;
 import io.tehuti.metrics.MetricsRepository;
+import java.io.FileInputStream;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
-import java.util.concurrent.ExecutionException;
+import java.util.Properties;
 import java.util.concurrent.TimeUnit;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -53,19 +54,30 @@ import org.apache.logging.log4j.Logger;
 public class DaVinciUserApp {
   private static final Logger LOGGER = LogManager.getLogger(DaVinciUserApp.class);
 
-  public static void main(String[] args) throws InterruptedException, ExecutionException {
-    String zkHosts = args[0];
-    String baseDataPath = args[1];
-    String storeName = args[2];
-    int sleepSeconds = Integer.parseInt(args[3]);
-    int heartbeatTimeoutSeconds = Integer.parseInt(args[4]);
-    boolean ingestionIsolation = Boolean.parseBoolean(args[5]);
-    int blobTransferServerPort = Integer.parseInt(args[6]);
-    int blobTransferClientPort = Integer.parseInt(args[7]);
-    String storageClass = args[8]; // DISK or MEMORY_BACKED_BY_DISK
-    boolean recordTransformerEnabled = Boolean.parseBoolean(args[9]);
-    boolean blobTransferDaVinciSSLEnabled = Boolean.parseBoolean(args[10]);
-    boolean batchPushReportEnabled = Boolean.parseBoolean(args[11]);
+  public static void main(String[] args) throws Exception {
+    if (args.length != 1) {
+      throw new IllegalArgumentException("Expected config file path");
+    }
+
+    // Load properties from file
+    Properties props = new Properties();
+    try (FileInputStream fis = new FileInputStream(args[0])) {
+      props.load(fis);
+    }
+
+    // Read properties
+    String zkHosts = props.getProperty("zk.hosts");
+    String baseDataPath = props.getProperty("base.data.path");
+    String storeName = props.getProperty("store.name");
+    int sleepSeconds = Integer.parseInt(props.getProperty("sleep.seconds"));
+    int heartbeatTimeoutSeconds = Integer.parseInt(props.getProperty("heartbeat.timeout.seconds"));
+    boolean ingestionIsolation = Boolean.parseBoolean(props.getProperty("ingestion.isolation"));
+    int blobTransferServerPort = Integer.parseInt(props.getProperty("blob.transfer.server.port"));
+    int blobTransferClientPort = Integer.parseInt(props.getProperty("blob.transfer.client.port"));
+    String storageClass = props.getProperty("storage.class");
+    boolean recordTransformerEnabled = Boolean.parseBoolean(props.getProperty("record.transformer.enabled"));
+    boolean blobTransferDaVinciSSLEnabled = Boolean.parseBoolean(props.getProperty("blob.transfer.ssl.enabled"));
+    boolean batchPushReportEnabled = Boolean.parseBoolean(props.getProperty("batch.push.report.enabled"));
 
     D2Client d2Client = new D2ClientBuilder().setZkHosts(zkHosts)
         .setZkSessionTimeout(3, TimeUnit.SECONDS)

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/davinci/DaVinciUserApp.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/davinci/DaVinciUserApp.java
@@ -76,7 +76,8 @@ public class DaVinciUserApp {
     int blobTransferClientPort = Integer.parseInt(props.getProperty("blob.transfer.client.port"));
     String storageClass = props.getProperty("storage.class");
     boolean recordTransformerEnabled = Boolean.parseBoolean(props.getProperty("record.transformer.enabled"));
-    boolean blobTransferDaVinciSSLEnabled = Boolean.parseBoolean(props.getProperty("blob.transfer.ssl.enabled"));
+    boolean blobTransferDaVinciManagerEnabled =
+        Boolean.parseBoolean(props.getProperty("blob.transfer.manager.enabled"));
     boolean batchPushReportEnabled = Boolean.parseBoolean(props.getProperty("batch.push.report.enabled"));
 
     D2Client d2Client = new D2ClientBuilder().setZkHosts(zkHosts)
@@ -89,12 +90,13 @@ public class DaVinciUserApp {
     extraBackendConfig.put(SERVER_INGESTION_MODE, ingestionIsolation ? ISOLATED : BUILT_IN);
     extraBackendConfig.put(SERVER_INGESTION_ISOLATION_CONNECTION_TIMEOUT_SECONDS, heartbeatTimeoutSeconds);
     extraBackendConfig.put(DATA_BASE_PATH, baseDataPath);
-    extraBackendConfig.put(DAVINCI_P2P_BLOB_TRANSFER_SERVER_PORT, blobTransferServerPort);
-    extraBackendConfig.put(DAVINCI_P2P_BLOB_TRANSFER_CLIENT_PORT, blobTransferClientPort);
     extraBackendConfig.put(PUSH_STATUS_STORE_ENABLED, true);
-    extraBackendConfig.put(BLOB_TRANSFER_MANAGER_ENABLED, true);
 
-    if (blobTransferDaVinciSSLEnabled) {
+    if (blobTransferDaVinciManagerEnabled) {
+      extraBackendConfig.put(BLOB_TRANSFER_MANAGER_ENABLED, true);
+      extraBackendConfig.put(DAVINCI_P2P_BLOB_TRANSFER_SERVER_PORT, blobTransferServerPort);
+      extraBackendConfig.put(DAVINCI_P2P_BLOB_TRANSFER_CLIENT_PORT, blobTransferClientPort);
+
       extraBackendConfig.put(BLOB_TRANSFER_SSL_ENABLED, true);
       extraBackendConfig.put(BLOB_TRANSFER_ACL_ENABLED, true);
 

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/DaVinciClientRecordTransformerTest.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/DaVinciClientRecordTransformerTest.java
@@ -76,6 +76,7 @@ import com.linkedin.venice.utils.Utils;
 import com.linkedin.venice.utils.VeniceProperties;
 import io.tehuti.metrics.MetricsRepository;
 import java.io.File;
+import java.io.FileWriter;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Paths;
@@ -663,20 +664,27 @@ public class DaVinciClientRecordTransformerTest {
     LOGGER.info("zkHosts is {}", zkHosts);
 
     // Start the first DaVinci Client using DaVinciUserApp for regular ingestion
-    ForkedJavaProcess.exec(
-        DaVinciUserApp.class,
-        zkHosts,
-        dvcPath1,
-        storeName,
-        "100",
-        "10",
-        "false",
-        Integer.toString(port1),
-        Integer.toString(port2),
-        StorageClass.DISK.toString(),
-        "true",
-        "true",
-        "false");
+    File configFile = File.createTempFile("dvc-config", ".properties");
+    Properties props = new Properties();
+    props.setProperty("zk.hosts", zkHosts);
+    props.setProperty("base.data.path", dvcPath1);
+    props.setProperty("store.name", storeName);
+    props.setProperty("sleep.seconds", "100");
+    props.setProperty("heartbeat.timeout.seconds", "10");
+    props.setProperty("ingestion.isolation", "false");
+    props.setProperty("blob.transfer.server.port", Integer.toString(port1));
+    props.setProperty("blob.transfer.client.port", Integer.toString(port2));
+    props.setProperty("storage.class", StorageClass.DISK.toString());
+    props.setProperty("record.transformer.enabled", "true");
+    props.setProperty("blob.transfer.ssl.enabled", "true");
+    props.setProperty("batch.push.report.enabled", "false");
+
+    // Write properties to file
+    try (FileWriter writer = new FileWriter(configFile)) {
+      props.store(writer, null);
+    }
+
+    ForkedJavaProcess.exec(DaVinciUserApp.class, configFile.getAbsolutePath());
 
     // Wait for the first DaVinci Client to complete ingestion
     Thread.sleep(60000);
@@ -735,6 +743,10 @@ public class DaVinciClientRecordTransformerTest {
         assertEquals(valueObj.toString(), expectedValue);
         assertEquals(recordTransformer.get(k), expectedValue);
       }
+    }
+    // clean up config file
+    if (configFile.exists()) {
+      Assert.assertTrue(configFile.delete(), "Failed to delete config file: " + configFile.getAbsolutePath());
     }
   }
 

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/DaVinciClientRecordTransformerTest.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/DaVinciClientRecordTransformerTest.java
@@ -664,7 +664,8 @@ public class DaVinciClientRecordTransformerTest {
     LOGGER.info("zkHosts is {}", zkHosts);
 
     // Start the first DaVinci Client using DaVinciUserApp for regular ingestion
-    File configFile = File.createTempFile("dvc-config", ".properties");
+    File configDir = Utils.getTempDataDirectory();
+    File configFile = new File(configDir, "dvc-config.properties");
     Properties props = new Properties();
     props.setProperty("zk.hosts", zkHosts);
     props.setProperty("base.data.path", dvcPath1);
@@ -676,7 +677,7 @@ public class DaVinciClientRecordTransformerTest {
     props.setProperty("blob.transfer.client.port", Integer.toString(port2));
     props.setProperty("storage.class", StorageClass.DISK.toString());
     props.setProperty("record.transformer.enabled", "true");
-    props.setProperty("blob.transfer.ssl.enabled", "true");
+    props.setProperty("blob.transfer.manager.enabled", "true");
     props.setProperty("batch.push.report.enabled", "false");
 
     // Write properties to file
@@ -743,10 +744,6 @@ public class DaVinciClientRecordTransformerTest {
         assertEquals(valueObj.toString(), expectedValue);
         assertEquals(recordTransformer.get(k), expectedValue);
       }
-    }
-    // clean up config file
-    if (configFile.exists()) {
-      Assert.assertTrue(configFile.delete(), "Failed to delete config file: " + configFile.getAbsolutePath());
     }
   }
 

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/DaVinciClientTest.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/DaVinciClientTest.java
@@ -129,6 +129,7 @@ import com.linkedin.venice.writer.VeniceWriterOptions;
 import io.tehuti.Metric;
 import io.tehuti.metrics.MetricsRepository;
 import java.io.File;
+import java.io.FileWriter;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.file.Files;
@@ -1293,20 +1294,27 @@ public class DaVinciClientTest {
     setUpStore(storeName, paramsConsumer, properties -> {}, true);
 
     // Start the first DaVinci Client using DaVinciUserApp for regular ingestion
-    ForkedJavaProcess.exec(
-        DaVinciUserApp.class,
-        zkHosts,
-        dvcPath1,
-        storeName,
-        "100",
-        "10",
-        "false",
-        Integer.toString(port1),
-        Integer.toString(port2),
-        StorageClass.DISK.toString(),
-        "false",
-        "true",
-        String.valueOf(batchPushReportEnable));
+    File configFile = File.createTempFile("dvc-config", ".properties");
+    Properties props = new Properties();
+    props.setProperty("zk.hosts", zkHosts);
+    props.setProperty("base.data.path", dvcPath1);
+    props.setProperty("store.name", storeName);
+    props.setProperty("sleep.seconds", "100");
+    props.setProperty("heartbeat.timeout.seconds", "10");
+    props.setProperty("ingestion.isolation", "false");
+    props.setProperty("blob.transfer.server.port", Integer.toString(port1));
+    props.setProperty("blob.transfer.client.port", Integer.toString(port2));
+    props.setProperty("storage.class", StorageClass.DISK.toString());
+    props.setProperty("record.transformer.enabled", "false");
+    props.setProperty("blob.transfer.ssl.enabled", "true");
+    props.setProperty("batch.push.report.enabled", String.valueOf(batchPushReportEnable));
+
+    // Write properties to file
+    try (FileWriter writer = new FileWriter(configFile)) {
+      props.store(writer, null);
+    }
+
+    ForkedJavaProcess.exec(DaVinciUserApp.class, configFile.getAbsolutePath());
 
     // Wait for the first DaVinci Client to complete ingestion
     Thread.sleep(60000);
@@ -1400,6 +1408,10 @@ public class DaVinciClientTest {
         Assert.assertTrue(Files.exists(Paths.get(snapshotPath1)));
       }
     }
+    // clean up config file
+    if (configFile.exists()) {
+      Assert.assertTrue(configFile.delete(), "Failed to delete config file: " + configFile.getAbsolutePath());
+    }
   }
 
   /**
@@ -1422,20 +1434,27 @@ public class DaVinciClientTest {
     setUpStore(storeName, paramsConsumer, properties -> {}, true);
 
     // Start the first DaVinci Client using DaVinciUserApp for regular ingestion
-    ForkedJavaProcess.exec(
-        DaVinciUserApp.class,
-        zkHosts,
-        dvcPath1,
-        storeName,
-        "100",
-        "10",
-        "false",
-        Integer.toString(port1),
-        Integer.toString(port2),
-        StorageClass.DISK.toString(),
-        "false",
-        "true",
-        "false");
+    File configFile = File.createTempFile("dvc-config", ".properties");
+    Properties props = new Properties();
+    props.setProperty("zk.hosts", zkHosts);
+    props.setProperty("base.data.path", dvcPath1);
+    props.setProperty("store.name", storeName);
+    props.setProperty("sleep.seconds", "100");
+    props.setProperty("heartbeat.timeout.seconds", "10");
+    props.setProperty("ingestion.isolation", "false");
+    props.setProperty("blob.transfer.server.port", Integer.toString(port1));
+    props.setProperty("blob.transfer.client.port", Integer.toString(port2));
+    props.setProperty("storage.class", StorageClass.DISK.toString());
+    props.setProperty("record.transformer.enabled", "false");
+    props.setProperty("blob.transfer.ssl.enabled", "true");
+    props.setProperty("batch.push.report.enabled", "false");
+
+    // Write properties to file
+    try (FileWriter writer = new FileWriter(configFile)) {
+      props.store(writer, null);
+    }
+
+    ForkedJavaProcess.exec(DaVinciUserApp.class, configFile.getAbsolutePath());
 
     // Wait for the first DaVinci Client to complete ingestion
     Thread.sleep(60000);
@@ -1533,6 +1552,11 @@ public class DaVinciClientTest {
         Assert.assertFalse(Files.exists(Paths.get(snapshotPath1)));
       }
     }
+
+    // clean up config file
+    if (configFile.exists()) {
+      Assert.assertTrue(configFile.delete(), "Failed to delete config file: " + configFile.getAbsolutePath());
+    }
   }
 
   @Test(timeOut = TEST_TIMEOUT)
@@ -1609,20 +1633,27 @@ public class DaVinciClientTest {
     setUpStore(storeName, paramsConsumer, properties -> {}, true);
 
     // Start the first DaVinci Client using DaVinciUserApp
-    ForkedJavaProcess forkedDaVinciUserApp = ForkedJavaProcess.exec(
-        DaVinciUserApp.class,
-        zkHosts,
-        dvcPath1,
-        storeName,
-        "100",
-        "10",
-        "false",
-        Integer.toString(port1),
-        Integer.toString(port2),
-        StorageClass.DISK.toString(),
-        "false",
-        "true",
-        "false");
+    File configFile = File.createTempFile("dvc-config", ".properties");
+    Properties props = new Properties();
+    props.setProperty("zk.hosts", zkHosts);
+    props.setProperty("base.data.path", dvcPath1);
+    props.setProperty("store.name", storeName);
+    props.setProperty("sleep.seconds", "100");
+    props.setProperty("heartbeat.timeout.seconds", "10");
+    props.setProperty("ingestion.isolation", "false");
+    props.setProperty("blob.transfer.server.port", Integer.toString(port1));
+    props.setProperty("blob.transfer.client.port", Integer.toString(port2));
+    props.setProperty("storage.class", StorageClass.DISK.toString());
+    props.setProperty("record.transformer.enabled", "false");
+    props.setProperty("blob.transfer.ssl.enabled", "true");
+    props.setProperty("batch.push.report.enabled", "false");
+
+    // Write properties to file
+    try (FileWriter writer = new FileWriter(configFile)) {
+      props.store(writer, null);
+    }
+
+    ForkedJavaProcess forkedDaVinciUserApp = ForkedJavaProcess.exec(DaVinciUserApp.class, configFile.getAbsolutePath());
 
     // Wait for the first DaVinci Client to complete ingestion
     Thread.sleep(60000);
@@ -1711,6 +1742,11 @@ public class DaVinciClientTest {
       } finally {
         client2.close();
       }
+    }
+
+    // clean up config file
+    if (configFile.exists()) {
+      Assert.assertTrue(configFile.delete(), "Failed to delete config file: " + configFile.getAbsolutePath());
     }
   }
 


### PR DESCRIPTION
## Problem Statement

In venice-client MP, the integration tests related to DaVinciUserApp failed because the argument list was too long.
```

2025-07-17T21:45:39.6303048Z Gradle suite > Gradle test > com.linkedin.venice.XinfraDaVinciClientTest > testBlobP2PTransferAmongDVCWithServerShutdown[0](false) FAILED
2025-07-17T21:45:39.6304084Z     java.io.IOException: Cannot run program "/export/apps/jdk/JDK-17_0_5-msft/bin/java": error=7, Argument list too long
2025-07-17T21:45:39.6304848Z         at java.base/java.lang.ProcessBuilder.start(ProcessBuilder.java:1143)
2025-07-17T21:45:39.6305474Z         at java.base/java.lang.ProcessBuilder.start(ProcessBuilder.java:1073)
2025-07-17T21:45:39.6306127Z         at com.linkedin.venice.utils.ForkedJavaProcess.exec(ForkedJavaProcess.java:67)
2025-07-17T21:45:39.6306819Z         at com.linkedin.venice.utils.ForkedJavaProcess.exec(ForkedJavaProcess.java:79)
2025-07-17T21:45:39.6307502Z         at com.linkedin.venice.utils.ForkedJavaProcess.exec(ForkedJavaProcess.java:88)
2025-07-17T21:45:39.6308183Z         at com.linkedin.venice.utils.ForkedJavaProcess.exec(ForkedJavaProcess.java:92)
2025-07-17T21:45:39.6309250Z         at com.linkedin.venice.endToEnd.DaVinciClientTest.testBlobP2PTransferAmongDVCWithServerShutdown(DaVinciClientTest.java:1479)
2025-07-17T21:45:39.6310194Z         at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)

```
```

Gradle suite > Gradle test > com.linkedin.venice.XinfraDaVinciClientTest > testBlobP2PTransferForNonLaggingDaVinciClient FAILED
    java.io.IOException: Cannot run program "/export/apps/jdk/JDK-17_0_5-msft/bin/java": error=7, Argument list too long
        at java.base/java.lang.ProcessBuilder.start(ProcessBuilder.java:1143)
        at java.base/java.lang.ProcessBuilder.start(ProcessBuilder.java:1073)
        at com.linkedin.venice.utils.ForkedJavaProcess.exec(ForkedJavaProcess.java:67)

```

## Solution
Passing a single config file instead of multiple parameters to define configs. 

###  Code changes
- [ ] Added new code behind **a config**. If so list the config names and their default values in the PR description.
- [ ] Introduced new **log lines**. 
- [ ] Confirmed if logs need to be **rate limited** to avoid excessive logging.

###  **Concurrency-Specific Checks**
Both reviewer and PR author to verify
- [ ] Code has **no race conditions** or **thread safety issues**.
- [ ] Proper **synchronization mechanisms** (e.g., `synchronized`, `RWLock`) are used where needed.
- [ ] No **blocking calls** inside critical sections that could lead to deadlocks or performance degradation.
- [ ] Verified **thread-safe collections** are used (e.g., `ConcurrentHashMap`, `CopyOnWriteArrayList`).
- [ ] Validated proper exception handling in multi-threaded code to avoid silent thread termination.


## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->

- [ ] New unit tests added.
- [ ] New integration tests added.
- [ ] Modified or extended existing tests.
- [ ] Verified backward compatibility (if applicable).

## Does this PR introduce any user-facing or breaking changes?
<!--  
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [ ] No. You can skip the rest of this section.
- [ ] Yes. Clearly explain the behavior change and its impact.