### PR TITLE
[admin-tool] Add validate-store-deleted command to AdminTool CLI

### DIFF
--- a/clients/venice-admin-tool/src/main/java/com/linkedin/venice/AdminTool.java
+++ b/clients/venice-admin-tool/src/main/java/com/linkedin/venice/AdminTool.java
@@ -62,6 +62,7 @@ import com.linkedin.venice.controllerapi.RoutersClusterConfigResponse;
 import com.linkedin.venice.controllerapi.SchemaResponse;
 import com.linkedin.venice.controllerapi.StoragePersonaResponse;
 import com.linkedin.venice.controllerapi.StoreComparisonResponse;
+import com.linkedin.venice.controllerapi.StoreDeletedValidationResponse;
 import com.linkedin.venice.controllerapi.StoreHealthAuditResponse;
 import com.linkedin.venice.controllerapi.StoreMigrationResponse;
 import com.linkedin.venice.controllerapi.StoreResponse;
@@ -519,6 +520,9 @@ public class AdminTool {
           break;
         case GET_DEAD_STORES:
           getDeadStores(cmd);
+          break;
+        case VALIDATE_STORE_DELETED:
+          validateStoreDeleted(cmd);
           break;
         case COMPARE_STORE:
           compareStore(cmd);
@@ -2921,6 +2925,14 @@ public class AdminTool {
     boolean includeSystemStores = Boolean.parseBoolean(getOptionalArgument(cmd, Arg.INCLUDE_SYSTEM_STORES));
 
     MultiStoreInfoResponse response = controllerClient.getDeadStores(clusterName, includeSystemStores, storeName);
+    printObject(response);
+  }
+
+  private static void validateStoreDeleted(CommandLine cmd) {
+    String clusterName = getRequiredArgument(cmd, Arg.CLUSTER);
+    String storeName = getRequiredArgument(cmd, Arg.STORE);
+
+    StoreDeletedValidationResponse response = controllerClient.validateStoreDeleted(clusterName, storeName);
     printObject(response);
   }
 

--- a/clients/venice-admin-tool/src/main/java/com/linkedin/venice/Command.java
+++ b/clients/venice-admin-tool/src/main/java/com/linkedin/venice/Command.java
@@ -478,6 +478,10 @@ public enum Command {
       "get-dead-stores", "Get the stores that are considered dead via ACL DB and Store Discovery",
       new Arg[] { URL, CLUSTER }, new Arg[] { STORE, INCLUDE_SYSTEM_STORES }
   ),
+  VALIDATE_STORE_DELETED(
+      "validate-store-deleted", "Validate whether a store has been fully deleted from the cluster",
+      new Arg[] { URL, CLUSTER, STORE }
+  ),
   LIST_STORE_PUSH_INFO(
       "list-store-push-info", "List information about current pushes and push history for a specific store.",
       new Arg[] { URL, STORE }, new Arg[] { CLUSTER, PARTITION_DETAIL_ENABLED }

--- a/internal/venice-common/src/main/java/com/linkedin/venice/controllerapi/ControllerClient.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/controllerapi/ControllerClient.java
@@ -281,8 +281,8 @@ public class ControllerClient implements Closeable {
     return request(ControllerRoute.GET_INUSE_SCHEMA_IDS, params, SchemaUsageResponse.class);
   }
 
-  public StoreDeletedValidationResponse validateStoreDeleted(String storeName) {
-    QueryParams params = newParams().add(NAME, storeName);
+  public StoreDeletedValidationResponse validateStoreDeleted(String clusterName, String storeName) {
+    QueryParams params = newParams().add(CLUSTER, clusterName).add(NAME, storeName);
     return request(ControllerRoute.VALIDATE_STORE_DELETED, params, StoreDeletedValidationResponse.class);
   }
 

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceParentHelixAdmin.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceParentHelixAdmin.java
@@ -5995,7 +5995,7 @@ public class VeniceParentHelixAdmin implements Admin {
       ControllerClient controllerClient = entry.getValue();
       try {
         // Make the API call to the child controller
-        StoreDeletedValidationResponse response = controllerClient.validateStoreDeleted(storeName);
+        StoreDeletedValidationResponse response = controllerClient.validateStoreDeleted(clusterName, storeName);
         if (response.isError()) {
           errors.add("Failed to validate store deletion in region " + regionName + ": " + response.getError());
         } else {


### PR DESCRIPTION
## Problem Statement

The Venice Admin Tool CLI was missing the `validate-store-deleted` command, even though the REST API endpoint `/validate_store_deleted` already exists and is fully functional in the backend. This created an inconsistency where users could only access this functionality via direct REST API calls, but not through the convenient CLI interface that other admin operations provide.

The existing `ControllerClient.validateStoreDeleted()` method also had an incorrect signature - it was missing the required `clusterName` parameter that the REST endpoint expects, causing it to fail when called.## Solution

Added the missing `validate-store-deleted` command to the AdminTool CLI to provide consistent access to the store deletion validation functionality:

**Key Changes:**
- **Command.java**: Added `VALIDATE_STORE_DELETED` enum entry with required args `[URL, CLUSTER, STORE]`
- **AdminTool.java**: Added `validateStoreDeleted()` method and case handler in the main switch statement
- **ControllerClient.java**: Fixed method signature to include `clusterName` parameter and pass it to the REST request
- **VeniceParentHelixAdmin.java**: Updated call to pass `clusterName` to the ControllerClient


This change provides no new functionality - it simply exposes existing backend validation logic through the CLI interface for better user experience and consistency with other admin operations.

### Code changes
- [x] Added new code behind **a config**. If so list the config names and their default values in the PR description.
  - No new configs added - uses existing validate-store-deleted REST endpoint
- [ ] Introduced new **log lines**. 
  - [ ] Confirmed if logs need to be **rate limited** to avoid excessive logging.
  - No new log lines introduced

### **Concurrency-Specific Checks**
Both reviewer and PR author to verify
- [x] Code has **no race conditions** or **thread safety issues**.
- [x] Proper **synchronization mechanisms** (e.g., `synchronized`, `RWLock`) are used where needed.
- [x] No **blocking calls** inside critical sections that could lead to deadlocks or performance degradation.
- [x] Verified **thread-safe collections** are used (e.g., `ConcurrentHashMap`, `CopyOnWriteArrayList`).
- [x] Validated proper exception handling in multi-threaded code to avoid silent thread termination.
