### PR TITLE
[server][dvc] Propagate pub-sub dependencies to participant consumption state

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/config/VeniceClusterConfig.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/config/VeniceClusterConfig.java
@@ -54,7 +54,7 @@ import org.apache.logging.log4j.Logger;
  * class that maintains config very specific to a Venice cluster
  */
 public class VeniceClusterConfig {
-  private static final Logger LOGGER = LogManager.getLogger(VeniceServerConfig.class);
+  private static final Logger LOGGER = LogManager.getLogger(VeniceClusterConfig.class);
 
   private final String clusterName;
   private final String zookeeperAddress;

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/config/VeniceServerConfig.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/config/VeniceServerConfig.java
@@ -42,7 +42,6 @@ import static com.linkedin.venice.ConfigKeys.INGESTION_MEMORY_LIMIT_STORE_LIST;
 import static com.linkedin.venice.ConfigKeys.INGESTION_MLOCK_ENABLED;
 import static com.linkedin.venice.ConfigKeys.INGESTION_USE_DA_VINCI_CLIENT;
 import static com.linkedin.venice.ConfigKeys.KAFKA_FETCH_THROTTLER_FACTORS_PER_SECOND;
-import static com.linkedin.venice.ConfigKeys.KAFKA_PRODUCER_METRICS;
 import static com.linkedin.venice.ConfigKeys.KEY_VALUE_PROFILING_ENABLED;
 import static com.linkedin.venice.ConfigKeys.KME_REGISTRATION_FROM_MESSAGE_HEADER_ENABLED;
 import static com.linkedin.venice.ConfigKeys.LEADER_FOLLOWER_STATE_TRANSITION_THREAD_POOL_STRATEGY;
@@ -489,7 +488,6 @@ public class VeniceServerConfig extends VeniceClusterConfig {
   private final long sharedConsumerNonExistingTopicCleanupDelayMS;
   private final int offsetLagDeltaRelaxFactorForFastOnlineTransitionInRestart;
 
-  private final Set<String> kafkaProducerMetrics;
   /**
    * Boolean flag indicating if it is a Da Vinci application.
    */
@@ -879,17 +877,6 @@ public class VeniceServerConfig extends VeniceClusterConfig {
     systemSchemaClusterName = serverProperties.getString(SYSTEM_SCHEMA_CLUSTER_NAME, "");
     sharedConsumerNonExistingTopicCleanupDelayMS = serverProperties
         .getLong(SERVER_SHARED_CONSUMER_NON_EXISTING_TOPIC_CLEANUP_DELAY_MS, TimeUnit.MINUTES.toMillis(10));
-
-    List<String> kafkaProducerMetricsList = serverProperties.getList(
-        KAFKA_PRODUCER_METRICS,
-        Arrays.asList(
-            "outgoing-byte-rate",
-            "record-send-rate",
-            "batch-size-max",
-            "batch-size-avg",
-            "buffer-available-bytes",
-            "buffer-exhausted-rate"));
-    kafkaProducerMetrics = new HashSet<>(kafkaProducerMetricsList);
 
     isDaVinciClient = serverProperties.getBoolean(INGESTION_USE_DA_VINCI_CLIENT, false);
     unsubscribeAfterBatchpushEnabled = serverProperties.getBoolean(SERVER_UNSUB_AFTER_BATCHPUSH, false);

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/KafkaStoreIngestionService.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/KafkaStoreIngestionService.java
@@ -58,6 +58,8 @@ import com.linkedin.venice.meta.VersionStatus;
 import com.linkedin.venice.offsets.OffsetRecord;
 import com.linkedin.venice.pubsub.PubSubClientsFactory;
 import com.linkedin.venice.pubsub.PubSubConstants;
+import com.linkedin.venice.pubsub.PubSubContext;
+import com.linkedin.venice.pubsub.PubSubPositionDeserializer;
 import com.linkedin.venice.pubsub.PubSubProducerAdapterFactory;
 import com.linkedin.venice.pubsub.PubSubTopicPartitionImpl;
 import com.linkedin.venice.pubsub.PubSubTopicRepository;
@@ -170,6 +172,7 @@ public class KafkaStoreIngestionService extends AbstractVeniceService implements
   private final boolean isIsolatedIngestion;
 
   private final TopicManagerRepository topicManagerRepository;
+
   private ExecutorService participantStoreConsumerExecutorService;
 
   private ExecutorService ingestionExecutorService;
@@ -192,6 +195,7 @@ public class KafkaStoreIngestionService extends AbstractVeniceService implements
   private final ResourceAutoClosableLockManager<String> topicLockManager;
 
   private final PubSubTopicRepository pubSubTopicRepository = new PubSubTopicRepository();
+  private final PubSubContext pubSubContext;
   private final KafkaValueSerializer kafkaValueSerializer;
   private final IngestionThrottler ingestionThrottler;
   private final ExecutorService aaWCWorkLoadProcessingThreadPool;
@@ -302,6 +306,11 @@ public class KafkaStoreIngestionService extends AbstractVeniceService implements
             .build();
     this.topicManagerRepository =
         new TopicManagerRepository(topicManagerContext, serverConfig.getKafkaBootstrapServers());
+    this.pubSubContext = new PubSubContext.Builder().setTopicManagerRepository(topicManagerRepository)
+        .setPubSubPositionTypeRegistry(serverConfig.getPubSubPositionTypeRegistry())
+        .setPubSubPositionDeserializer(new PubSubPositionDeserializer(serverConfig.getPubSubPositionTypeRegistry()))
+        .setPubSubTopicRepository(pubSubTopicRepository)
+        .build();
 
     VeniceNotifier notifier = new LogNotifier();
     this.leaderFollowerNotifiers.add(notifier);
@@ -487,12 +496,12 @@ public class KafkaStoreIngestionService extends AbstractVeniceService implements
         serverConfig.getIngestionTaskReusableObjectsStrategy().supplier();
 
     ingestionTaskFactory = StoreIngestionTaskFactory.builder()
+        .setPubSubContext(pubSubContext)
         .setVeniceWriterFactory(veniceWriterFactory)
         .setStorageMetadataService(storageMetadataService)
         .setLeaderFollowerNotifiersQueue(leaderFollowerNotifiers)
         .setSchemaRepository(schemaRepo)
         .setMetadataRepository(metadataRepo)
-        .setTopicManagerRepository(topicManagerRepository)
         .setHostLevelIngestionStats(hostLevelIngestionStats)
         .setVersionedDIVStats(versionedDIVStats)
         .setDaVinciRecordTransformerStats(recordTransformerStats)
@@ -507,7 +516,6 @@ public class KafkaStoreIngestionService extends AbstractVeniceService implements
         .setMetaStoreWriter(metaStoreWriter)
         .setCompressorFactory(compressorFactory)
         .setVeniceViewWriterFactory(viewWriterFactory)
-        .setPubSubTopicRepository(pubSubTopicRepository)
         .setRunnableForKillIngestionTasksForNonCurrentVersions(
             serverConfig.getIngestionMemoryLimit() > 0 ? () -> killConsumptionTaskForNonCurrentVersions() : null)
         .setHeartbeatMonitoringService(heartbeatMonitoringService)
@@ -1405,6 +1413,10 @@ public class KafkaStoreIngestionService extends AbstractVeniceService implements
 
   public final ReadOnlyStoreRepository getMetadataRepo() {
     return metadataRepo;
+  }
+
+  public PubSubContext getPubSubContext() {
+    return pubSubContext;
   }
 
   private boolean ingestionTaskHasAnySubscription(String topic) {

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/PartitionConsumptionState.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/PartitionConsumptionState.java
@@ -8,6 +8,7 @@ import com.linkedin.venice.kafka.validation.checksum.CheckSum;
 import com.linkedin.venice.kafka.validation.checksum.CheckSumType;
 import com.linkedin.venice.meta.Version;
 import com.linkedin.venice.offsets.OffsetRecord;
+import com.linkedin.venice.pubsub.PubSubContext;
 import com.linkedin.venice.pubsub.PubSubTopicPartitionImpl;
 import com.linkedin.venice.pubsub.PubSubTopicRepository;
 import com.linkedin.venice.pubsub.api.PubSubPosition;
@@ -42,6 +43,7 @@ public class PartitionConsumptionState {
   private final int partition;
   private final boolean hybrid;
   private final OffsetRecord offsetRecord;
+  private final PubSubContext pubSubContext;
 
   private GUID leaderGUID;
 
@@ -212,11 +214,17 @@ public class PartitionConsumptionState {
 
   private BooleanSupplier isCurrentVersion;
 
-  public PartitionConsumptionState(String replicaId, int partition, OffsetRecord offsetRecord, boolean hybrid) {
+  public PartitionConsumptionState(
+      String replicaId,
+      int partition,
+      OffsetRecord offsetRecord,
+      PubSubContext pubSubContext,
+      boolean hybrid) {
     this.replicaId = replicaId;
     this.partition = partition;
     this.hybrid = hybrid;
     this.offsetRecord = offsetRecord;
+    this.pubSubContext = pubSubContext;
     this.errorReported = false;
     this.lagCaughtUp = false;
     this.lagCaughtUpTimeInMs = 0;
@@ -851,5 +859,9 @@ public class PartitionConsumptionState {
   public void clearPendingReportIncPushVersionList() {
     pendingReportIncPushVersionList.clear();
     offsetRecord.setPendingReportIncPushVersionList(pendingReportIncPushVersionList);
+  }
+
+  public PubSubContext getPubSubContext() {
+    return pubSubContext;
   }
 }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTaskFactory.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTaskFactory.java
@@ -20,8 +20,7 @@ import com.linkedin.venice.meta.ReadOnlySchemaRepository;
 import com.linkedin.venice.meta.ReadOnlyStoreRepository;
 import com.linkedin.venice.meta.Store;
 import com.linkedin.venice.meta.Version;
-import com.linkedin.venice.pubsub.PubSubTopicRepository;
-import com.linkedin.venice.pubsub.manager.TopicManagerRepository;
+import com.linkedin.venice.pubsub.PubSubContext;
 import com.linkedin.venice.serialization.avro.InternalAvroSpecificSerializer;
 import com.linkedin.venice.system.store.MetaStoreWriter;
 import com.linkedin.venice.utils.DiskUsage;
@@ -111,7 +110,6 @@ public class StoreIngestionTaskFactory {
     private Queue<VeniceNotifier> leaderFollowerNotifiers;
     private ReadOnlySchemaRepository schemaRepo;
     private ReadOnlyStoreRepository metadataRepo;
-    private TopicManagerRepository topicManagerRepository;
     private AggVersionedDaVinciRecordTransformerStats daVinciRecordTransformerStats;
     private AggHostLevelIngestionStats ingestionStats;
     private AggVersionedDIVStats versionedDIVStats;
@@ -125,7 +123,7 @@ public class StoreIngestionTaskFactory {
     private RemoteIngestionRepairService remoteIngestionRepairService;
     private MetaStoreWriter metaStoreWriter;
     private StorageEngineBackedCompressorFactory compressorFactory;
-    private PubSubTopicRepository pubSubTopicRepository;
+    private PubSubContext pubSubContext;
     private Runnable runnableForKillIngestionTasksForNonCurrentVersions;
     private ExecutorService aaWCWorkLoadProcessingThreadPool;
     private ExecutorService aaWCIngestionStorageLookupThreadPool;
@@ -220,12 +218,12 @@ public class StoreIngestionTaskFactory {
       return set(() -> this.metadataRepo = metadataRepo);
     }
 
-    public TopicManagerRepository getTopicManagerRepository() {
-      return topicManagerRepository;
+    public Builder setPubSubContext(PubSubContext pubSubContext) {
+      return set(() -> this.pubSubContext = pubSubContext);
     }
 
-    public Builder setTopicManagerRepository(TopicManagerRepository topicManagerRepository) {
-      return set(() -> this.topicManagerRepository = topicManagerRepository);
+    public PubSubContext getPubSubContext() {
+      return pubSubContext;
     }
 
     public AggVersionedDaVinciRecordTransformerStats getDaVinciRecordTransformerStats() {
@@ -316,14 +314,6 @@ public class StoreIngestionTaskFactory {
 
     public Builder setCompressorFactory(StorageEngineBackedCompressorFactory compressorFactory) {
       return set(() -> this.compressorFactory = compressorFactory);
-    }
-
-    public PubSubTopicRepository getPubSubTopicRepository() {
-      return pubSubTopicRepository;
-    }
-
-    public Builder setPubSubTopicRepository(PubSubTopicRepository pubSubTopicRepository) {
-      return set(() -> this.pubSubTopicRepository = pubSubTopicRepository);
     }
 
     public Runnable getRunnableForKillIngestionTasksForNonCurrentVersions() {

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/ActiveActiveStoreIngestionTaskTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/ActiveActiveStoreIngestionTaskTest.java
@@ -69,6 +69,7 @@ import com.linkedin.venice.meta.VersionImpl;
 import com.linkedin.venice.meta.ZKStore;
 import com.linkedin.venice.partitioner.DefaultVenicePartitioner;
 import com.linkedin.venice.pubsub.ImmutablePubSubMessage;
+import com.linkedin.venice.pubsub.PubSubContext;
 import com.linkedin.venice.pubsub.PubSubTopicPartitionImpl;
 import com.linkedin.venice.pubsub.PubSubTopicRepository;
 import com.linkedin.venice.pubsub.adapter.kafka.common.ApacheKafkaOffsetPosition;
@@ -219,7 +220,7 @@ public class ActiveActiveStoreIngestionTaskTest {
 
     // Set up IngestionTask Builder
     StoreIngestionTaskFactory.Builder builder = new StoreIngestionTaskFactory.Builder();
-    builder.setPubSubTopicRepository(TOPIC_REPOSITORY);
+    builder.setPubSubContext(new PubSubContext.Builder().setPubSubTopicRepository(TOPIC_REPOSITORY).build());
     builder.setHostLevelIngestionStats(mock(AggHostLevelIngestionStats.class));
     builder.setAggKafkaConsumerService(mock(AggKafkaConsumerService.class));
     builder.setMetadataRepository(readOnlyStoreRepository);

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/PushTimeoutTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/PushTimeoutTest.java
@@ -18,6 +18,7 @@ import com.linkedin.venice.exceptions.VeniceTimeoutException;
 import com.linkedin.venice.meta.Store;
 import com.linkedin.venice.meta.Version;
 import com.linkedin.venice.offsets.OffsetRecord;
+import com.linkedin.venice.pubsub.PubSubContext;
 import com.linkedin.venice.pubsub.PubSubTopicPartitionImpl;
 import com.linkedin.venice.pubsub.PubSubTopicRepository;
 import com.linkedin.venice.utils.ExceptionCaptorNotifier;
@@ -57,7 +58,7 @@ public class PushTimeoutTest {
         .setLeaderFollowerNotifiersQueue(notifiers)
         .setServerConfig(mockVeniceServerConfig)
         .setHostLevelIngestionStats(mockAggStoreIngestionStats)
-        .setPubSubTopicRepository(pubSubTopicRepository);
+        .setPubSubContext(new PubSubContext.Builder().setPubSubTopicRepository(pubSubTopicRepository).build());
 
     StorageService storageService = mock(StorageService.class);
     doReturn(new ReferenceCounted<>(mock(StorageEngine.class), se -> {})).when(storageService)
@@ -124,7 +125,7 @@ public class PushTimeoutTest {
         .setStorageMetadataService(mockStorageMetadataService)
         .setServerConfig(mockVeniceServerConfig)
         .setHostLevelIngestionStats(mockAggStoreIngestionStats)
-        .setPubSubTopicRepository(pubSubTopicRepository);
+        .setPubSubContext(new PubSubContext.Builder().setPubSubTopicRepository(pubSubTopicRepository).build());
 
     StorageService storageService = mock(StorageService.class);
     doReturn(new ReferenceCounted<>(mock(StorageEngine.class), se -> {})).when(storageService)

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/StorageUtilizationManagerTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/StorageUtilizationManagerTest.java
@@ -13,6 +13,7 @@ import com.linkedin.venice.meta.Store;
 import com.linkedin.venice.meta.Version;
 import com.linkedin.venice.meta.VersionStatus;
 import com.linkedin.venice.offsets.OffsetRecord;
+import com.linkedin.venice.pubsub.PubSubContext;
 import com.linkedin.venice.utils.Utils;
 import com.linkedin.venice.utils.concurrent.VeniceConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
@@ -41,12 +42,14 @@ public class StorageUtilizationManagerTest {
   private Version version;
   private StorageUtilizationManager quotaEnforcer;
   private StorageUtilizationManager hybridQuotaEnforcer;
+  private PubSubContext pubSubContext;
 
   @BeforeClass
   public void setUp() {
     storageEngine = mock(StorageEngine.class);
     store = mock(Store.class);
     version = mock(Version.class);
+    pubSubContext = new PubSubContext.Builder().build();
   }
 
   @BeforeMethod
@@ -57,7 +60,7 @@ public class StorageUtilizationManagerTest {
 
     for (int i = 1; i <= storePartitionCount; i++) {
       PartitionConsumptionState pcs =
-          new PartitionConsumptionState(Utils.getReplicaId(topic, i), i, mock(OffsetRecord.class), true);
+          new PartitionConsumptionState(Utils.getReplicaId(topic, i), i, mock(OffsetRecord.class), pubSubContext, true);
       partitionConsumptionStateMap.put(i, pcs);
     }
 
@@ -65,7 +68,7 @@ public class StorageUtilizationManagerTest {
     when(mockOffsetRecord.getLeaderTopic()).thenReturn(realTimeTopic);
     for (int i = 1; i <= storePartitionCount; i++) {
       PartitionConsumptionState pcs =
-          new PartitionConsumptionState(Utils.getReplicaId(realTimeTopic, i), i, mockOffsetRecord, true);
+          new PartitionConsumptionState(Utils.getReplicaId(realTimeTopic, i), i, mockOffsetRecord, pubSubContext, true);
       pcs.setLeaderFollowerState(LEADER);
       hybridPartitionConsumptionStateMap.put(i, pcs);
     }

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTaskTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTaskTest.java
@@ -155,6 +155,9 @@ import com.linkedin.venice.partitioner.VenicePartitioner;
 import com.linkedin.venice.pubsub.ImmutablePubSubMessage;
 import com.linkedin.venice.pubsub.PubSubConsumerAdapterContext;
 import com.linkedin.venice.pubsub.PubSubConsumerAdapterFactory;
+import com.linkedin.venice.pubsub.PubSubContext;
+import com.linkedin.venice.pubsub.PubSubPositionDeserializer;
+import com.linkedin.venice.pubsub.PubSubPositionTypeRegistry;
 import com.linkedin.venice.pubsub.PubSubTopicPartitionImpl;
 import com.linkedin.venice.pubsub.PubSubTopicRepository;
 import com.linkedin.venice.pubsub.adapter.kafka.common.ApacheKafkaOffsetPosition;
@@ -173,6 +176,7 @@ import com.linkedin.venice.pubsub.manager.TopicManager;
 import com.linkedin.venice.pubsub.manager.TopicManagerRepository;
 import com.linkedin.venice.pubsub.mock.InMemoryPubSubBroker;
 import com.linkedin.venice.pubsub.mock.InMemoryPubSubPosition;
+import com.linkedin.venice.pubsub.mock.InMemoryPubSubPositionFactory;
 import com.linkedin.venice.pubsub.mock.SimplePartitioner;
 import com.linkedin.venice.pubsub.mock.adapter.MockInMemoryPartitionPosition;
 import com.linkedin.venice.pubsub.mock.adapter.consumer.MockInMemoryConsumerAdapter;
@@ -351,6 +355,7 @@ public abstract class StoreIngestionTaskTest {
     IngestionNotificationDispatcher.PROGRESS_REPORT_INTERVAL = -1; // Report all the time.
   }
 
+  private PubSubContext pubSubContext;
   private InMemoryPubSubBroker inMemoryLocalKafkaBroker;
   private InMemoryPubSubBroker inMemoryRemoteKafkaBroker;
   private MockInMemoryConsumerAdapter inMemoryLocalKafkaConsumer;
@@ -610,6 +615,16 @@ public abstract class StoreIngestionTaskTest {
     doNothing().when(regionStats).recordByteSizePerPoll(anyDouble());
     doNothing().when(regionStats).recordPollResultNum(anyInt());
     doReturn(regionStats).when(kafkaConsumerServiceStats).getStoreStats(anyString());
+
+    PubSubPositionTypeRegistry positionTypeRegistry =
+        InMemoryPubSubPositionFactory.getPositionTypeRegistryWithInMemoryPosition();
+    PubSubPositionDeserializer pubSubPositionDeserializer = new PubSubPositionDeserializer(positionTypeRegistry);
+
+    pubSubContext = new PubSubContext.Builder().setPubSubTopicRepository(pubSubTopicRepository)
+        .setTopicManagerRepository(mockTopicManagerRepository)
+        .setPubSubPositionTypeRegistry(positionTypeRegistry)
+        .setPubSubPositionDeserializer(pubSubPositionDeserializer)
+        .build();
   }
 
   private VeniceWriter getVeniceWriter(String topic, PubSubProducerAdapter producerAdapter) {
@@ -1146,6 +1161,9 @@ public abstract class StoreIngestionTaskTest {
     remoteKafkaConsumerService.start();
 
     prepareAggKafkaConsumerServiceMock();
+    PubSubContext pubSubContext = new PubSubContext.Builder().setTopicManagerRepository(mockTopicManagerRepository)
+        .setPubSubTopicRepository(pubSubTopicRepository)
+        .build();
 
     return StoreIngestionTaskFactory.builder()
         .setHeartbeatMonitoringService(mock(HeartbeatMonitoringService.class))
@@ -1154,7 +1172,7 @@ public abstract class StoreIngestionTaskTest {
         .setLeaderFollowerNotifiersQueue(leaderFollowerNotifiers)
         .setSchemaRepository(mockSchemaRepo)
         .setMetadataRepository(mockMetadataRepo)
-        .setTopicManagerRepository(mockTopicManagerRepository)
+        .setPubSubContext(pubSubContext)
         .setHostLevelIngestionStats(mockAggStoreIngestionStats)
         .setVersionedDIVStats(mockVersionedDIVStats)
         .setVersionedIngestionStats(mockVersionedStorageIngestionStats)
@@ -1164,7 +1182,6 @@ public abstract class StoreIngestionTaskTest {
         .setDiskUsage(diskUsage)
         .setAggKafkaConsumerService(aggKafkaConsumerService)
         .setCompressorFactory(new StorageEngineBackedCompressorFactory(mockStorageMetadataService))
-        .setPubSubTopicRepository(pubSubTopicRepository)
         .setPartitionStateSerializer(partitionStateSerializer)
         .setRunnableForKillIngestionTasksForNonCurrentVersions(runnableForKillNonCurrentVersion)
         .setReusableObjectsSupplier(IngestionTaskReusableObjects.Strategy.SINGLETON_THREAD_LOCAL.supplier())
@@ -3785,8 +3802,12 @@ public abstract class StoreIngestionTaskTest {
             null);
 
     OffsetRecord mockOffsetRecord = mock(OffsetRecord.class);
-    PartitionConsumptionState partitionConsumptionState =
-        new PartitionConsumptionState(Utils.getReplicaId(topic, PARTITION_FOO), PARTITION_FOO, mockOffsetRecord, true);
+    PartitionConsumptionState partitionConsumptionState = new PartitionConsumptionState(
+        Utils.getReplicaId(topic, PARTITION_FOO),
+        PARTITION_FOO,
+        mockOffsetRecord,
+        pubSubContext,
+        true);
 
     long producerTimestamp = System.currentTimeMillis();
     LeaderMetadataWrapper mockLeaderMetadataWrapper = mock(LeaderMetadataWrapper.class);
@@ -3937,12 +3958,10 @@ public abstract class StoreIngestionTaskTest {
         .getRefCountedStorageEngine(anyString());
 
     StoreIngestionTaskFactory ingestionTaskFactory = TestUtils.getStoreIngestionTaskBuilder(storeName)
-        .setTopicManagerRepository(mockTopicManagerRepository)
+        .setPubSubContext(pubSubContext)
         .setStorageMetadataService(mockStorageMetadataService)
         .setMetadataRepository(mockReadOnlyStoreRepository)
-        .setTopicManagerRepository(mockTopicManagerRepository)
         .setServerConfig(mockVeniceServerConfig)
-        .setPubSubTopicRepository(pubSubTopicRepository)
         .build();
 
     LeaderFollowerStoreIngestionTask ingestionTask =
@@ -4038,7 +4057,7 @@ public abstract class StoreIngestionTaskTest {
     doReturn(mock(ReadOnlySchemaRepository.class)).when(builder).getSchemaRepo();
     doReturn(mock(AggKafkaConsumerService.class)).when(builder).getAggKafkaConsumerService();
     doReturn(mockAggStoreIngestionStats).when(builder).getIngestionStats();
-    doReturn(pubSubTopicRepository).when(builder).getPubSubTopicRepository();
+    doReturn(pubSubContext).when(builder).getPubSubContext();
 
     Version version = mock(Version.class);
     doReturn(1).when(version).getPartitionCount();
@@ -4073,7 +4092,7 @@ public abstract class StoreIngestionTaskTest {
     OffsetRecord offsetRecord = mock(OffsetRecord.class);
     doReturn(pubSubTopicRepository.getTopic(versionTopicName)).when(offsetRecord).getLeaderTopic(any());
     PartitionConsumptionState partitionConsumptionState =
-        new PartitionConsumptionState(Utils.getReplicaId(versionTopicName, 0), 0, offsetRecord, false);
+        new PartitionConsumptionState(Utils.getReplicaId(versionTopicName, 0), 0, offsetRecord, pubSubContext, false);
 
     long localVersionTopicOffset = 100L;
     long remoteVersionTopicOffset = 200L;
@@ -4287,7 +4306,7 @@ public abstract class StoreIngestionTaskTest {
     doReturn(mock(ReadOnlySchemaRepository.class)).when(builder).getSchemaRepo();
     doReturn(mock(AggKafkaConsumerService.class)).when(builder).getAggKafkaConsumerService();
     doReturn(mockAggStoreIngestionStats).when(builder).getIngestionStats();
-    doReturn(pubSubTopicRepository).when(builder).getPubSubTopicRepository();
+    doReturn(pubSubContext).when(builder).getPubSubContext();
 
     // Prepare the meaningful store version
     Version version = mock(Version.class);
@@ -4706,7 +4725,7 @@ public abstract class StoreIngestionTaskTest {
     OffsetRecord offsetRecord = mock(OffsetRecord.class);
     doReturn(pubSubTopic).when(offsetRecord).getLeaderTopic(any());
     PartitionConsumptionState partitionConsumptionState =
-        new PartitionConsumptionState(Utils.getReplicaId(pubSubTopic, 0), 0, offsetRecord, false);
+        new PartitionConsumptionState(Utils.getReplicaId(pubSubTopic, 0), 0, offsetRecord, pubSubContext, false);
 
     storeIngestionTaskUnderTest.updateLeaderTopicOnFollower(partitionConsumptionState);
     storeIngestionTaskUnderTest.startConsumingAsLeader(partitionConsumptionState);
@@ -4807,9 +4826,8 @@ public abstract class StoreIngestionTaskTest {
     StoreIngestionTaskFactory ingestionTaskFactory = TestUtils.getStoreIngestionTaskBuilder(storeName)
         .setStorageMetadataService(mockStorageMetadataService)
         .setMetadataRepository(mockReadOnlyStoreRepository)
-        .setTopicManagerRepository(mockTopicManagerRepository)
+        .setPubSubContext(pubSubContext)
         .setServerConfig(mockVeniceServerConfig)
-        .setPubSubTopicRepository(pubSubTopicRepository)
         .setVeniceWriterFactory(veniceWriterFactory)
         .build();
     LeaderFollowerStoreIngestionTask ingestionTask =
@@ -4906,9 +4924,8 @@ public abstract class StoreIngestionTaskTest {
     StoreIngestionTaskFactory ingestionTaskFactory = TestUtils.getStoreIngestionTaskBuilder(storeName)
         .setStorageMetadataService(mockStorageMetadataService)
         .setMetadataRepository(mockReadOnlyStoreRepository)
-        .setTopicManagerRepository(mockTopicManagerRepository)
+        .setPubSubContext(pubSubContext)
         .setServerConfig(mockVeniceServerConfig)
-        .setPubSubTopicRepository(pubSubTopicRepository)
         .setVeniceWriterFactory(veniceWriterFactory)
         .build();
     LeaderFollowerStoreIngestionTask ingestionTask =
@@ -5581,7 +5598,7 @@ public abstract class StoreIngestionTaskTest {
     doReturn(mock(ReadOnlySchemaRepository.class)).when(builder).getSchemaRepo();
     doReturn(mock(AggKafkaConsumerService.class)).when(builder).getAggKafkaConsumerService();
     doReturn(mockAggStoreIngestionStats).when(builder).getIngestionStats();
-    doReturn(pubSubTopicRepository).when(builder).getPubSubTopicRepository();
+    doReturn(pubSubContext).when(builder).getPubSubContext();
 
     Version version = mock(Version.class);
     doReturn(1).when(version).getPartitionCount();

--- a/internal/venice-common/src/main/java/com/linkedin/venice/ConfigKeys.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/ConfigKeys.java
@@ -1070,12 +1070,6 @@ public class ConfigKeys {
       "freeze.ingestion.if.ready.to.serve.or.local.data.exists";
 
   /**
-   * a comma seperated list of kafka producer metrics that will be reported.
-   * For ex. "outgoing-byte-rate,record-send-rate,batch-size-max,batch-size-avg,buffer-available-bytes,buffer-exhausted-rate"
-   */
-  public static final String KAFKA_PRODUCER_METRICS = "list.of.producer.metrics.from.kafka";
-
-  /**
    * Whether to print logs that are used for troubleshooting only.
    */
   public static final String SERVER_DEBUG_LOGGING_ENABLED = "server.debug.logging.enabled";

--- a/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/PubSubContext.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/PubSubContext.java
@@ -1,0 +1,76 @@
+package com.linkedin.venice.pubsub;
+
+import com.linkedin.venice.pubsub.manager.TopicManager;
+import com.linkedin.venice.pubsub.manager.TopicManagerRepository;
+
+
+/**
+ * {@code PubSubContext} is a container class that holds all the core components required
+ * for managing PubSub infrastructure, including topic managers, position registry,
+ * position deserializer, and topic repository.
+ */
+public class PubSubContext {
+  private final TopicManagerRepository topicManagerRepository;
+  private final PubSubPositionTypeRegistry pubSubPositionTypeRegistry;
+  private final PubSubPositionDeserializer pubSubPositionDeserializer;
+  private final PubSubTopicRepository pubSubTopicRepository;
+
+  private PubSubContext(Builder builder) {
+    this.topicManagerRepository = builder.topicManagerRepository;
+    this.pubSubPositionTypeRegistry = builder.pubSubPositionTypeRegistry;
+    this.pubSubPositionDeserializer = builder.pubSubPositionDeserializer;
+    this.pubSubTopicRepository = builder.pubSubTopicRepository;
+  }
+
+  public TopicManager getTopicManager(String topicName) {
+    return topicManagerRepository.getTopicManager(topicName);
+  }
+
+  public TopicManagerRepository getTopicManagerRepository() {
+    return topicManagerRepository;
+  }
+
+  public PubSubPositionTypeRegistry getPubSubPositionTypeRegistry() {
+    return pubSubPositionTypeRegistry;
+  }
+
+  public PubSubPositionDeserializer getPubSubPositionDeserializer() {
+    return pubSubPositionDeserializer;
+  }
+
+  public PubSubTopicRepository getPubSubTopicRepository() {
+    return pubSubTopicRepository;
+  }
+
+  // Builder for PubSubContext
+  public static class Builder {
+    private TopicManagerRepository topicManagerRepository;
+    private PubSubPositionTypeRegistry pubSubPositionTypeRegistry;
+    private PubSubPositionDeserializer pubSubPositionDeserializer;
+    private PubSubTopicRepository pubSubTopicRepository;
+
+    public Builder setTopicManagerRepository(TopicManagerRepository topicManagerRepository) {
+      this.topicManagerRepository = topicManagerRepository;
+      return this;
+    }
+
+    public Builder setPubSubPositionTypeRegistry(PubSubPositionTypeRegistry pubSubPositionTypeRegistry) {
+      this.pubSubPositionTypeRegistry = pubSubPositionTypeRegistry;
+      return this;
+    }
+
+    public Builder setPubSubPositionDeserializer(PubSubPositionDeserializer pubSubPositionDeserializer) {
+      this.pubSubPositionDeserializer = pubSubPositionDeserializer;
+      return this;
+    }
+
+    public Builder setPubSubTopicRepository(PubSubTopicRepository pubSubTopicRepository) {
+      this.pubSubTopicRepository = pubSubTopicRepository;
+      return this;
+    }
+
+    public PubSubContext build() {
+      return new PubSubContext(this);
+    }
+  }
+}

--- a/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/manager/TopicManager.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/manager/TopicManager.java
@@ -233,7 +233,7 @@ public class TopicManager implements Closeable {
   }
 
   protected void waitUntilTopicCreated(PubSubTopic topicName, int partitionCount, long deadlineMs) {
-    long startTimeMs = System.nanoTime();
+    long startTimeMs = System.currentTimeMillis();
     while (!containsTopicAndAllPartitionsAreOnline(topicName, partitionCount)) {
       if (System.currentTimeMillis() > deadlineMs) {
         throw new PubSubOpTimeoutException(

--- a/internal/venice-common/src/test/java/com/linkedin/venice/pubsub/PubSubContextTest.java
+++ b/internal/venice-common/src/test/java/com/linkedin/venice/pubsub/PubSubContextTest.java
@@ -1,0 +1,47 @@
+package com.linkedin.venice.pubsub;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertSame;
+
+import com.linkedin.venice.pubsub.manager.TopicManager;
+import com.linkedin.venice.pubsub.manager.TopicManagerRepository;
+import org.mockito.Mockito;
+import org.testng.annotations.Test;
+
+
+public class PubSubContextTest {
+  @Test
+  public void testBuilderAndGetters() {
+    TopicManagerRepository mockRepo = Mockito.mock(TopicManagerRepository.class);
+    PubSubPositionTypeRegistry mockRegistry = Mockito.mock(PubSubPositionTypeRegistry.class);
+    PubSubPositionDeserializer mockDeserializer = Mockito.mock(PubSubPositionDeserializer.class);
+    PubSubTopicRepository mockTopicRepo = Mockito.mock(PubSubTopicRepository.class);
+
+    PubSubContext context = new PubSubContext.Builder().setTopicManagerRepository(mockRepo)
+        .setPubSubPositionTypeRegistry(mockRegistry)
+        .setPubSubPositionDeserializer(mockDeserializer)
+        .setPubSubTopicRepository(mockTopicRepo)
+        .build();
+
+    assertSame(context.getTopicManagerRepository(), mockRepo);
+    assertSame(context.getPubSubPositionTypeRegistry(), mockRegistry);
+    assertSame(context.getPubSubPositionDeserializer(), mockDeserializer);
+    assertSame(context.getPubSubTopicRepository(), mockTopicRepo);
+  }
+
+  @Test
+  public void testGetTopicManager() {
+    String topicName = "test-topic";
+    TopicManager mockTopicManager = Mockito.mock(TopicManager.class);
+    TopicManagerRepository mockRepo = Mockito.mock(TopicManagerRepository.class);
+    Mockito.when(mockRepo.getTopicManager(topicName)).thenReturn(mockTopicManager);
+
+    PubSubContext context = new PubSubContext.Builder().setTopicManagerRepository(mockRepo).build();
+
+    TopicManager result = context.getTopicManager(topicName);
+    assertNotNull(result);
+    assertEquals(result, mockTopicManager);
+    Mockito.verify(mockRepo, Mockito.times(1)).getTopicManager(topicName);
+  }
+}

--- a/internal/venice-test-common/src/main/java/com/linkedin/venice/pubsub/mock/InMemoryPubSubPosition.java
+++ b/internal/venice-test-common/src/main/java/com/linkedin/venice/pubsub/mock/InMemoryPubSubPosition.java
@@ -2,10 +2,13 @@ package com.linkedin.venice.pubsub.mock;
 
 import com.linkedin.venice.pubsub.api.PubSubPosition;
 import com.linkedin.venice.pubsub.api.PubSubPositionWireFormat;
+import com.linkedin.venice.utils.ByteUtils;
 import java.nio.ByteBuffer;
 
 
 public class InMemoryPubSubPosition implements PubSubPosition {
+  public static final int INMEMORY_PUBSUB_POSITION_TYPE_ID = -42;
+
   private final long internalOffset;
 
   private InMemoryPubSubPosition(long offset) {
@@ -33,10 +36,17 @@ public class InMemoryPubSubPosition implements PubSubPosition {
     return new InMemoryPubSubPosition(offset);
   }
 
+  public static InMemoryPubSubPosition of(ByteBuffer buffer) {
+    if (buffer == null || buffer.limit() < Long.BYTES) {
+      throw new IllegalArgumentException("Buffer must contain at least " + Long.BYTES + " bytes");
+    }
+    return of(ByteUtils.readLong(ByteUtils.extractByteArray(buffer), 0)); // peek without advancing
+  }
+
   @Override
   public PubSubPositionWireFormat getPositionWireFormat() {
     PubSubPositionWireFormat wireFormat = new PubSubPositionWireFormat();
-    wireFormat.type = -42;
+    wireFormat.type = INMEMORY_PUBSUB_POSITION_TYPE_ID;
     ByteBuffer buffer = ByteBuffer.allocate(Long.BYTES);
     buffer.putLong(internalOffset);
     buffer.flip();

--- a/internal/venice-test-common/src/main/java/com/linkedin/venice/pubsub/mock/InMemoryPubSubPositionFactory.java
+++ b/internal/venice-test-common/src/main/java/com/linkedin/venice/pubsub/mock/InMemoryPubSubPositionFactory.java
@@ -1,0 +1,38 @@
+package com.linkedin.venice.pubsub.mock;
+
+import static com.linkedin.venice.pubsub.mock.InMemoryPubSubPosition.*;
+
+import com.linkedin.venice.pubsub.PubSubPositionFactory;
+import com.linkedin.venice.pubsub.PubSubPositionTypeRegistry;
+import com.linkedin.venice.pubsub.api.PubSubPosition;
+import it.unimi.dsi.fastutil.ints.Int2ObjectMap;
+import it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap;
+import java.nio.ByteBuffer;
+
+
+public class InMemoryPubSubPositionFactory extends PubSubPositionFactory {
+  /**
+   * Constructs a factory with the given position type ID.
+   *
+   * @param positionTypeId the unique integer identifier for the position type
+   */
+  public InMemoryPubSubPositionFactory(int positionTypeId) {
+    super(positionTypeId);
+  }
+
+  @Override
+  public PubSubPosition createFromByteBuffer(ByteBuffer buffer) {
+    return InMemoryPubSubPosition.of(buffer);
+  }
+
+  @Override
+  public String getPubSubPositionClassName() {
+    return InMemoryPubSubPosition.class.getName();
+  }
+
+  public static PubSubPositionTypeRegistry getPositionTypeRegistryWithInMemoryPosition() {
+    Int2ObjectMap<String> typeIdToFactory = new Int2ObjectOpenHashMap<>(1);
+    typeIdToFactory.put(INMEMORY_PUBSUB_POSITION_TYPE_ID, InMemoryPubSubPositionFactory.class.getName());
+    return new PubSubPositionTypeRegistry(typeIdToFactory);
+  }
+}

--- a/internal/venice-test-common/src/main/java/com/linkedin/venice/utils/TestUtils.java
+++ b/internal/venice-test-common/src/main/java/com/linkedin/venice/utils/TestUtils.java
@@ -78,8 +78,10 @@ import com.linkedin.venice.meta.ZKStore;
 import com.linkedin.venice.offsets.OffsetRecord;
 import com.linkedin.venice.partitioner.DefaultVenicePartitioner;
 import com.linkedin.venice.partitioner.VenicePartitioner;
+import com.linkedin.venice.pubsub.PubSubContext;
 import com.linkedin.venice.pubsub.PubSubPositionTypeRegistry;
 import com.linkedin.venice.pubsub.PubSubProducerAdapterFactory;
+import com.linkedin.venice.pubsub.PubSubTopicRepository;
 import com.linkedin.venice.pubsub.api.PubSubTopicType;
 import com.linkedin.venice.pubsub.manager.TopicManagerRepository;
 import com.linkedin.venice.pushmonitor.ExecutionStatus;
@@ -894,7 +896,10 @@ public class TestUtils {
         .setLeaderFollowerNotifiersQueue(new ArrayDeque<>())
         .setSchemaRepository(mock(ReadOnlySchemaRepository.class))
         .setMetadataRepository(mockReadOnlyStoreRepository)
-        .setTopicManagerRepository(mock(TopicManagerRepository.class))
+        .setPubSubContext(
+            new PubSubContext.Builder().setPubSubTopicRepository(new PubSubTopicRepository())
+                .setTopicManagerRepository(mock(TopicManagerRepository.class))
+                .build())
         .setHostLevelIngestionStats(mock(AggHostLevelIngestionStats.class))
         .setVersionedDIVStats(mock(AggVersionedDIVStats.class))
         .setVersionedIngestionStats(mock(AggVersionedIngestionStats.class))

--- a/internal/venice-test-common/src/test/java/com/linkedin/venice/pubsub/mock/InMemoryPubSubPositionTest.java
+++ b/internal/venice-test-common/src/test/java/com/linkedin/venice/pubsub/mock/InMemoryPubSubPositionTest.java
@@ -1,0 +1,77 @@
+package com.linkedin.venice.pubsub.mock;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertThrows;
+import static org.testng.Assert.assertTrue;
+
+import com.linkedin.venice.pubsub.PubSubPositionDeserializer;
+import com.linkedin.venice.pubsub.PubSubPositionTypeRegistry;
+import com.linkedin.venice.pubsub.api.PubSubPosition;
+import com.linkedin.venice.pubsub.api.PubSubPositionWireFormat;
+import java.nio.ByteBuffer;
+import org.testng.annotations.Test;
+
+
+public class InMemoryPubSubPositionTest {
+  @Test
+  public void testCreationAndAccessors() {
+    InMemoryPubSubPosition pos = InMemoryPubSubPosition.of(123L);
+    assertEquals(pos.getInternalOffset(), 123L);
+    assertEquals(pos.getNumericOffset(), 123L);
+
+    InMemoryPubSubPosition same = InMemoryPubSubPosition.of(123L);
+    assertEquals(pos, same);
+    assertEquals(pos.hashCode(), same.hashCode());
+    assertEquals(pos.toString(), "InMemoryPubSubPosition{123}");
+  }
+
+  @Test
+  public void testNextPreviousAndDelta() {
+    InMemoryPubSubPosition base = InMemoryPubSubPosition.of(10L);
+    assertEquals(base.getNextPosition(), InMemoryPubSubPosition.of(11L));
+    assertEquals(base.getPreviousPosition(), InMemoryPubSubPosition.of(9L));
+    assertEquals(base.getPositionAfterNRecords(5L), InMemoryPubSubPosition.of(15L));
+    assertEquals(base.getPositionAfterNRecords(0L), base);
+
+    InMemoryPubSubPosition zero = InMemoryPubSubPosition.of(0L);
+    assertEquals(zero.getPreviousPosition(), InMemoryPubSubPosition.of(-1L));
+
+    InMemoryPubSubPosition minusOne = InMemoryPubSubPosition.of(-1L);
+    assertEquals(minusOne.getPreviousPosition(), InMemoryPubSubPosition.of(-2L));
+
+    // Validate exception for invalid previous position
+    InMemoryPubSubPosition invalid = InMemoryPubSubPosition.of(-2L);
+    assertThrows(IllegalStateException.class, invalid::getPreviousPosition);
+  }
+
+  @Test
+  public void testWireFormatSerializationAndDeserialization() {
+    long offset = 999L;
+    InMemoryPubSubPosition original = InMemoryPubSubPosition.of(offset);
+    PubSubPositionWireFormat wireFormat = original.getPositionWireFormat();
+
+    PubSubPositionTypeRegistry registry = InMemoryPubSubPositionFactory.getPositionTypeRegistryWithInMemoryPosition();
+    PubSubPositionDeserializer deserializer = new PubSubPositionDeserializer(registry);
+
+    // test repeated deserialization
+    for (int i = 0; i < 5; i++) {
+      PubSubPosition deserialized = deserializer.toPosition(wireFormat);
+      assertTrue(deserialized instanceof InMemoryPubSubPosition);
+      assertEquals(deserialized, original);
+      assertEquals(((InMemoryPubSubPosition) deserialized).getInternalOffset(), offset);
+    }
+  }
+
+  @Test
+  public void testOfFromByteBuffer() {
+    long offset = 888L;
+    ByteBuffer buffer = ByteBuffer.allocate(Long.BYTES);
+    buffer.putLong(offset);
+    buffer.flip();
+    InMemoryPubSubPosition position = InMemoryPubSubPosition.of(buffer);
+    assertEquals(position.getInternalOffset(), offset);
+
+    assertThrows(IllegalArgumentException.class, () -> InMemoryPubSubPosition.of((ByteBuffer) null));
+    assertThrows(IllegalArgumentException.class, () -> InMemoryPubSubPosition.of(ByteBuffer.allocate(2)));
+  }
+}

--- a/services/venice-server/src/test/java/com/linkedin/venice/listener/StorageReadRequestHandlerTest.java
+++ b/services/venice-server/src/test/java/com/linkedin/venice/listener/StorageReadRequestHandlerTest.java
@@ -83,6 +83,7 @@ import com.linkedin.venice.offsets.OffsetRecord;
 import com.linkedin.venice.partitioner.VenicePartitioner;
 import com.linkedin.venice.protocols.VeniceClientRequest;
 import com.linkedin.venice.protocols.VeniceServerResponse;
+import com.linkedin.venice.pubsub.PubSubContext;
 import com.linkedin.venice.pubsub.mock.SimplePartitioner;
 import com.linkedin.venice.read.RequestType;
 import com.linkedin.venice.read.protocol.request.router.MultiGetRouterRequestKeyV1;
@@ -191,6 +192,8 @@ public class StorageReadRequestHandlerTest {
       new ChunkedValueManifestSerializer(true);
   private final KeyWithChunkingSuffixSerializer keyWithChunkingSuffixSerializer = new KeyWithChunkingSuffixSerializer();
 
+  private PubSubContext pubSubContext;
+
   @BeforeMethod
   public void setUp() {
     doReturn(store).when(storeRepository).getStoreOrThrow(any());
@@ -207,6 +210,7 @@ public class StorageReadRequestHandlerTest {
 
     RocksDBServerConfig rocksDBServerConfig = mock(RocksDBServerConfig.class);
     doReturn(rocksDBServerConfig).when(serverConfig).getRocksDBServerConfig();
+    pubSubContext = new PubSubContext.Builder().build();
   }
 
   @AfterMethod
@@ -550,6 +554,7 @@ public class StorageReadRequestHandlerTest {
         Utils.getReplicaId(topic, expectedPartitionId),
         expectedPartitionId,
         new OffsetRecord(AvroProtocolDefinition.PARTITION_STATE.getSerializer()),
+        pubSubContext,
         false);
     expectedAdminResponse.addPartitionConsumptionState(state);
     doReturn(expectedAdminResponse).when(ingestionMetadataRetriever).getConsumptionSnapshots(eq(topic), any());


### PR DESCRIPTION
## Propagate pub-sub dependencies to participant consumption state

This change makes pub-sub related dependencies available in  
ParticipantConsumptionState, enabling correct serialization,  
deserialization, and comparison of PubSubPosition objects.  

###  Code changes
- [ ] Added new code behind **a config**. If so list the config names and their default values in the PR description.
- [ ] Introduced new **log lines**. 
  - [ ] Confirmed if logs need to be **rate limited** to avoid excessive logging.

###  **Concurrency-Specific Checks**
Both reviewer and PR author to verify
- [ ] Code has **no race conditions** or **thread safety issues**.
- [ ] Proper **synchronization mechanisms** (e.g., `synchronized`, `RWLock`) are used where needed.
- [ ] No **blocking calls** inside critical sections that could lead to deadlocks or performance degradation.
- [ ] Verified **thread-safe collections** are used (e.g., `ConcurrentHashMap`, `CopyOnWriteArrayList`).
- [ ] Validated proper exception handling in multi-threaded code to avoid silent thread termination.


## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->

- [ ] New unit tests added.
- [ ] New integration tests added.
- [ ] Modified or extended existing tests.
- [ ] Verified backward compatibility (if applicable).

## Does this PR introduce any user-facing or breaking changes?
<!--  
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [ ] No. You can skip the rest of this section.
- [ ] Yes. Clearly explain the behavior change and its impact.