### PR TITLE
[server] Initialize follower HB entry before waiting for latch to complete

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/helix/LeaderFollowerPartitionStateModel.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/helix/LeaderFollowerPartitionStateModel.java
@@ -98,7 +98,7 @@ public class LeaderFollowerPartitionStateModel extends AbstractPartitionStateMod
       // PUSHED is set for future versions of a target region push with deferred swap
       // ONLINE is set for future versions of a push with deferred swap
       boolean isFutureVersionReady = Utils.isFutureVersionReady(resourceName, getStoreRepo());
-
+      logger.info("DEBUGGING: {} {} {} {}", isFutureVersionReady, isCurrentVersion, currentVersion, version);
       /**
        * For current version and already completed future versions, firstly create a latch, then start ingestion and wait
        * for ingestion completion to make sure that the state transition waits until this new replica finished consuming
@@ -122,11 +122,11 @@ public class LeaderFollowerPartitionStateModel extends AbstractPartitionStateMod
         }
         throw e;
       }
+      heartbeatMonitoringService
+          .updateLagMonitor(message.getResourceName(), getPartition(), HeartbeatLagMonitorAction.SET_FOLLOWER_MONITOR);
       if (isCurrentVersion || isFutureVersionReady) {
         waitConsumptionCompleted(resourceName, notifier);
       }
-      heartbeatMonitoringService
-          .updateLagMonitor(message.getResourceName(), getPartition(), HeartbeatLagMonitorAction.SET_FOLLOWER_MONITOR);
     });
   }
 

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/helix/AbstractVenicePartitionStateModelTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/helix/AbstractVenicePartitionStateModelTest.java
@@ -52,7 +52,7 @@ public abstract class AbstractVenicePartitionStateModelTest<MODEL_TYPE extends A
   protected ParticipantStateTransitionStats mockParticipantStateTransitionStats;
 
   @BeforeMethod
-  public void setUp() {
+  public void setUp() throws InterruptedException {
     this.storeName = Utils.getUniqueString("stateModelTestStore");
     this.systemStoreName =
         VeniceSystemStoreUtils.getDaVinciPushStatusStoreName(Utils.getUniqueString("stateModelTestStore"));
@@ -108,5 +108,5 @@ public abstract class AbstractVenicePartitionStateModelTest<MODEL_TYPE extends A
 
   protected abstract MODEL_TYPE getParticipantStateModel();
 
-  protected abstract NOTIFIER_TYPE getNotifier();
+  protected abstract NOTIFIER_TYPE getNotifier() throws InterruptedException;
 }

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/helix/VeniceLeaderFollowerStateModelTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/helix/VeniceLeaderFollowerStateModelTest.java
@@ -3,7 +3,9 @@ package com.linkedin.davinci.helix;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -15,17 +17,21 @@ import static org.mockito.Mockito.when;
 
 import com.linkedin.davinci.config.VeniceServerConfig;
 import com.linkedin.davinci.config.VeniceStoreVersionConfig;
+import com.linkedin.davinci.stats.ingestion.heartbeat.HeartbeatLagMonitorAction;
 import com.linkedin.davinci.stats.ingestion.heartbeat.HeartbeatMonitoringService;
 import com.linkedin.venice.meta.Store;
 import com.linkedin.venice.meta.StoreVersionInfo;
 import com.linkedin.venice.meta.Version;
 import com.linkedin.venice.meta.VersionImpl;
 import com.linkedin.venice.meta.VersionStatus;
+import com.linkedin.venice.utils.TestUtils;
 import io.tehuti.metrics.MetricsRepository;
 import java.time.Duration;
 import java.util.HashSet;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
 import org.mockito.Mockito;
+import org.testng.Assert;
 import org.testng.annotations.Test;
 
 
@@ -55,8 +61,13 @@ public class VeniceLeaderFollowerStateModelTest extends
   }
 
   @Override
-  protected LeaderFollowerIngestionProgressNotifier getNotifier() {
-    return mock(LeaderFollowerIngestionProgressNotifier.class);
+  protected LeaderFollowerIngestionProgressNotifier getNotifier() throws InterruptedException {
+    LeaderFollowerIngestionProgressNotifier mockNotifier = mock(LeaderFollowerIngestionProgressNotifier.class);
+    doAnswer(invocation -> {
+      Thread.sleep(3000);
+      return null; // or return a value if needed
+    }).when(mockNotifier).waitConsumptionCompleted(anyString(), anyInt(), anyInt(), any());
+    return mockNotifier;
   }
 
   @Test
@@ -188,5 +199,25 @@ public class VeniceLeaderFollowerStateModelTest extends
     testStateModel.onBecomeDroppedFromOffline(mockMessage, mockContext);
     verify(mockParticipantStateTransitionStats, times(2)).incrementThreadBlockedOnOfflineToDroppedTransitionCount();
     verify(mockParticipantStateTransitionStats, times(2)).decrementThreadBlockedOnOfflineToDroppedTransitionCount();
+  }
+
+  @Test
+  public void testSetHeartbeatMonitoringWhen() throws InterruptedException {
+    // when(mockStore.getVersion(1)).thenReturn(null);
+    when(mockStore.getCurrentVersion()).thenReturn(1);
+    when(mockReadOnlyStoreRepository.waitVersion(eq(storeName), eq(version), any(), anyLong()))
+        .thenReturn(new StoreVersionInfo(mockStore, null));
+    CompletableFuture<Void> future = CompletableFuture.runAsync(() -> {
+      testStateModel.onBecomeStandbyFromOffline(mockMessage, mockContext);
+    });
+    try {
+      TestUtils.waitForNonDeterministicAssertion(1, TimeUnit.SECONDS, () -> {
+        verify(spyHeartbeatMonitoringService)
+            .updateLagMonitor(any(), eq(testPartition), eq(HeartbeatLagMonitorAction.SET_FOLLOWER_MONITOR));
+        Assert.assertFalse(future.isDone());
+      });
+    } finally {
+      future.complete(null);
+    }
   }
 }


### PR DESCRIPTION


<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat], [protocol]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## [server] Initialize follower HB entry before waiting for latch to complete
When using heartbeat lag for ready-to-serve check, we identified this issue: HB follower entry was not initialized in the participant model when going from offline to standby and current version replica bootstrap times out waiting for latch to complete. This is a dead lock in behavior and we should adjust the order.

## Solution
<!--
Describe
- What changes you are making and why. 
- How these changes solve the problem.
- Any performance considerations or trade-offs. 
- Describe what testings you have done, for example, performance testing etc.
-->


###  Code changes
- [ ] Added new code behind **a config**. If so list the config names and their default values in the PR description.
- [ ] Introduced new **log lines**. 
  - [ ] Confirmed if logs need to be **rate limited** to avoid excessive logging.

###  **Concurrency-Specific Checks**
Both reviewer and PR author to verify
- [ ] Code has **no race conditions** or **thread safety issues**.
- [ ] Proper **synchronization mechanisms** (e.g., `synchronized`, `RWLock`) are used where needed.
- [ ] No **blocking calls** inside critical sections that could lead to deadlocks or performance degradation.
- [ ] Verified **thread-safe collections** are used (e.g., `ConcurrentHashMap`, `CopyOnWriteArrayList`).
- [ ] Validated proper exception handling in multi-threaded code to avoid silent thread termination.


## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->

- [x] New unit tests added.
- [ ] New integration tests added.
- [ ] Modified or extended existing tests.
- [ ] Verified backward compatibility (if applicable).

## Does this PR introduce any user-facing or breaking changes?
<!--  
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [ ] No. You can skip the rest of this section.
- [ ] Yes. Clearly explain the behavior change and its impact.