### PR TITLE
Split OpenTelemetry data points for export

### DIFF
--- a/internal/venice-client-common/src/main/java/com/linkedin/venice/stats/MetricDataRangeDecorator.java
+++ b/internal/venice-client-common/src/main/java/com/linkedin/venice/stats/MetricDataRangeDecorator.java
@@ -1,0 +1,302 @@
+package com.linkedin.venice.stats;
+
+import io.opentelemetry.sdk.common.InstrumentationScopeInfo;
+import io.opentelemetry.sdk.metrics.data.AggregationTemporality;
+import io.opentelemetry.sdk.metrics.data.Data;
+import io.opentelemetry.sdk.metrics.data.DoublePointData;
+import io.opentelemetry.sdk.metrics.data.ExponentialHistogramData;
+import io.opentelemetry.sdk.metrics.data.ExponentialHistogramPointData;
+import io.opentelemetry.sdk.metrics.data.GaugeData;
+import io.opentelemetry.sdk.metrics.data.HistogramData;
+import io.opentelemetry.sdk.metrics.data.HistogramPointData;
+import io.opentelemetry.sdk.metrics.data.LongPointData;
+import io.opentelemetry.sdk.metrics.data.MetricData;
+import io.opentelemetry.sdk.metrics.data.MetricDataType;
+import io.opentelemetry.sdk.metrics.data.PointData;
+import io.opentelemetry.sdk.metrics.data.SumData;
+import io.opentelemetry.sdk.metrics.data.SummaryData;
+import io.opentelemetry.sdk.metrics.data.SummaryPointData;
+import io.opentelemetry.sdk.metrics.internal.data.ImmutableSumData;
+import io.opentelemetry.sdk.resources.Resource;
+import java.util.AbstractCollection;
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.NoSuchElementException;
+
+
+/**
+ * A decorator for {@link MetricData} that restricts the range of points returned
+ * based on the specified start and end indices.
+ *
+ * <p>This allows selective access to a subset of data points within a given metric.
+ * The decorator ensures that only points within the specified index range are accessible.
+ *
+ * <p>Usage Example:
+ * <pre>
+ * MetricData originalMetricData = ...;
+ * MetricDataRangeDecorator decorator = new MetricDataRangeDecorator(originalMetricData, 2, 5);
+ * Collection<PointData> filteredPoints = decorator.getData().getPoints();
+ * </pre>
+ *
+ * @param <T> The type of {@link PointData} contained in the metric data.
+ */
+public class MetricDataRangeDecorator<T extends PointData> implements MetricData {
+  private final MetricData originalMetricData;
+  private final int startIndex;
+  private final int endIndex;
+
+  public MetricDataRangeDecorator(MetricData originalMetricData, int startIndex, int endIndex) {
+    if (startIndex < 0 || endIndex > originalMetricData.getData().getPoints().size() || startIndex > endIndex) {
+      throw new IllegalArgumentException("Invalid range specified");
+    }
+    this.originalMetricData = originalMetricData;
+    this.startIndex = startIndex;
+    this.endIndex = endIndex;
+  }
+
+  @Override
+  public MetricDataType getType() {
+    return originalMetricData.getType();
+  }
+
+  @Override
+  public String getName() {
+    return originalMetricData.getName();
+  }
+
+  @Override
+  public String getDescription() {
+    return originalMetricData.getDescription();
+  }
+
+  @Override
+  public String getUnit() {
+    return originalMetricData.getUnit();
+  }
+
+  @Override
+  public Resource getResource() {
+    return originalMetricData.getResource();
+  }
+
+  @Override
+  public InstrumentationScopeInfo getInstrumentationScopeInfo() {
+    return originalMetricData.getInstrumentationScopeInfo();
+  }
+
+  /**
+   * Returns the metric data for the specified type.
+   *
+   * <p>This method decorates the original metric data with a range filter applied to the points.
+   * It ensures that the returned data is of the correct type and can be cast to the expected type
+   * in the calling code.
+   *
+   * @return the metric data with the range filter applied.
+   * @throws ClassCastException if the original metric data is not of the expected type.
+   */
+  @Override
+  public Data<?> getData() {
+    Data<?> originalData = originalMetricData.getData();
+
+    switch (originalMetricData.getType()) {
+      case EXPONENTIAL_HISTOGRAM:
+        return new ExponentialHistogramData() {
+          @Override
+          public AggregationTemporality getAggregationTemporality() {
+            return ((ExponentialHistogramData) originalData).getAggregationTemporality();
+          }
+
+          @Override
+          public Collection<ExponentialHistogramPointData> getPoints() {
+            return createPointCollection((ExponentialHistogramData) originalData);
+          }
+        };
+
+      case DOUBLE_GAUGE:
+        return new GaugeData<DoublePointData>() {
+          @Override
+          public Collection<DoublePointData> getPoints() {
+            return createPointCollection((GaugeData<DoublePointData>) originalData);
+          }
+        };
+
+      case LONG_GAUGE:
+        return new GaugeData<LongPointData>() {
+          @Override
+          public Collection<LongPointData> getPoints() {
+            return createPointCollection((GaugeData<LongPointData>) originalData);
+          }
+        };
+
+      case DOUBLE_SUM:
+        return new SumData<DoublePointData>() {
+          @Override
+          public AggregationTemporality getAggregationTemporality() {
+            return ((ImmutableSumData<DoublePointData>) originalData).getAggregationTemporality();
+          }
+
+          @Override
+          public Collection<DoublePointData> getPoints() {
+            return createPointCollection((ImmutableSumData<DoublePointData>) originalData);
+          }
+
+          @Override
+          public boolean isMonotonic() {
+            return ((ImmutableSumData<DoublePointData>) originalData).isMonotonic();
+          }
+        };
+
+      case LONG_SUM:
+        return new SumData<LongPointData>() {
+          @Override
+          public AggregationTemporality getAggregationTemporality() {
+            return ((ImmutableSumData<LongPointData>) originalData).getAggregationTemporality();
+          }
+
+          @Override
+          public Collection<LongPointData> getPoints() {
+            return createPointCollection((ImmutableSumData<LongPointData>) originalData);
+          }
+
+          @Override
+          public boolean isMonotonic() {
+            return ((ImmutableSumData<LongPointData>) originalData).isMonotonic();
+          }
+        };
+
+      case HISTOGRAM:
+        return new HistogramData() {
+          @Override
+          public AggregationTemporality getAggregationTemporality() {
+            return ((HistogramData) originalData).getAggregationTemporality();
+          }
+
+          @Override
+          public Collection<HistogramPointData> getPoints() {
+            return createPointCollection((HistogramData) originalData);
+          }
+        };
+
+      case SUMMARY:
+        return new SummaryData() {
+          @Override
+          public Collection<SummaryPointData> getPoints() {
+            return createPointCollection((SummaryData) originalData);
+          }
+        };
+
+      default:
+        throw new IllegalStateException("Unsupported MetricData type: " + originalMetricData.getType());
+    }
+  }
+
+  /**
+   * Override the open source method only to help type cast to SumData.
+   */
+  @Override
+  public SumData<DoublePointData> getDoubleSumData() {
+    if (getType() == MetricDataType.DOUBLE_SUM) {
+      return (SumData<DoublePointData>) getData();
+    }
+    return ImmutableSumData.empty();
+  }
+
+  /**
+   * Creates a collection that wraps the original points and applies the range filter.
+   */
+  private <T extends PointData> Collection<T> createPointCollection(Data<T> originalData) {
+    return new AbstractCollection<T>() {
+      @Override
+      public Iterator<T> iterator() {
+        return new RangeIterator<>(originalData.getPoints().iterator(), startIndex, endIndex);
+      }
+
+      @Override
+      public int size() {
+        return Math.max(0, endIndex - startIndex);
+      }
+    };
+  }
+
+  /**
+   * Compares this {@link MetricDataRangeDecorator} with the specified object for equality.
+   *
+   * <p>This method performs a one-way equality check:
+   * <ul>
+   *   <li>If the object is the same instance, it returns {@code true}.</li>
+   *   <li>If the object is a {@link MetricDataRangeDecorator}, it compares the underlying
+   *       {@link MetricData} and the start and end indices of both decorators.</li>
+   *   <li>If the object is a plain {@link MetricData}, it is considered equal only if the
+   *       decorator represents the full range (start index = 0, end index = size of points)
+   *       and the underlying {@link MetricData} is equal.</li>
+   * </ul>
+   *
+   * <p><b>Note:</b> This equality comparison works only one way:
+   * - {@code decorator.equals(original)} will return {@code true} if the decorator covers the full range.
+   * - {@code original.equals(decorator)} will always return {@code false}.
+   *
+   * @param obj the object to compare this decorator with
+   * @return {@code true} if the object is equal to this decorator; {@code false} otherwise
+   */
+  @Override
+  public boolean equals(Object obj) {
+    if (this == obj) {
+      return true;
+    }
+    if (obj instanceof MetricDataRangeDecorator) {
+      MetricDataRangeDecorator<?> other = (MetricDataRangeDecorator<?>) obj;
+      return this.startIndex == other.startIndex && this.endIndex == other.endIndex
+          && this.originalMetricData.equals(other.originalMetricData);
+    }
+    return this.startIndex == 0 && this.endIndex == originalMetricData.getData().getPoints().size()
+        && originalMetricData.equals(obj);
+  }
+
+  @Override
+  public int hashCode() {
+    if (startIndex == 0 && endIndex == originalMetricData.getData().getPoints().size()) {
+      return originalMetricData.hashCode();
+    }
+    return 31 * originalMetricData.hashCode() + startIndex + endIndex;
+  }
+
+  @Override
+  public String toString() {
+    return "MetricDataRangeDecorator{" + "originalMetricData=" + originalMetricData + ", startIndex=" + startIndex
+        + ", endIndex=" + endIndex + '}';
+  }
+
+  /**
+   * An iterator that applies a range filter to the original iterator.
+  */
+  private static class RangeIterator<T> implements Iterator<T> {
+    private final Iterator<T> iterator;
+    private final int endIndex;
+    private int currentIndex = 0;
+
+    RangeIterator(Iterator<T> iterator, int startIndex, int endIndex) {
+      this.iterator = iterator;
+      this.endIndex = endIndex;
+
+      // Skip elements until reaching startIndex
+      while (currentIndex < startIndex && iterator.hasNext()) {
+        iterator.next();
+        currentIndex++;
+      }
+    }
+
+    @Override
+    public boolean hasNext() {
+      return currentIndex < endIndex && iterator.hasNext();
+    }
+
+    @Override
+    public T next() {
+      if (!hasNext()) {
+        throw new NoSuchElementException();
+      }
+      currentIndex++;
+      return iterator.next();
+    }
+  }
+}

--- a/internal/venice-client-common/src/main/java/com/linkedin/venice/stats/SplitOtlpHttpMetricExporter.java
+++ b/internal/venice-client-common/src/main/java/com/linkedin/venice/stats/SplitOtlpHttpMetricExporter.java
@@ -1,0 +1,146 @@
+package com.linkedin.venice.stats;
+
+import io.opentelemetry.sdk.common.CompletableResultCode;
+import io.opentelemetry.sdk.common.export.MemoryMode;
+import io.opentelemetry.sdk.metrics.Aggregation;
+import io.opentelemetry.sdk.metrics.InstrumentType;
+import io.opentelemetry.sdk.metrics.data.AggregationTemporality;
+import io.opentelemetry.sdk.metrics.data.MetricData;
+import io.opentelemetry.sdk.metrics.export.MetricExporter;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+
+
+/**
+ * A MetricExporter that splits the input metrics into batches and exports each batch separately.
+ * maxBatchSize is the maximum number of metric points allowed in a single batch.
+ *
+ * For instance, the below metric has metric points and if maxBatchSize is 1, then this will be
+ * split into 2 batches:
+ * ....
+ * name=venice.thin_client.call_time, description=Latency based on all responses, unit=MILLISECOND,
+ * type=EXPONENTIAL_HISTOGRAM, data=ImmutableExponentialHistogramData{aggregationTemporality=DELTA,
+ * points=[
+ * ImmutableExponentialHistogramPointData{......},
+ * ImmutableExponentialHistogramPointData{......}
+ * ]}},
+ * ....
+ */
+public class SplitOtlpHttpMetricExporter implements MetricExporter {
+  private final MetricExporter delegate;
+  private final int maxBatchSize;
+
+  public SplitOtlpHttpMetricExporter(MetricExporter delegate, int maxBatchSize) {
+    this.delegate = delegate;
+    this.maxBatchSize = maxBatchSize;
+  }
+
+  /**
+   * Export the input metrics in batches by leveraging the delegate exporter.
+   */
+  @Override
+  public CompletableResultCode export(Collection<MetricData> metrics) {
+    Collection<CompletableResultCode> results = new ArrayList<>();
+    splitIntoBatches(metrics, maxBatchSize, results);
+    return CompletableResultCode.ofAll(results);
+  }
+
+  @Override
+  public CompletableResultCode flush() {
+    return delegate.flush();
+  }
+
+  @Override
+  public CompletableResultCode shutdown() {
+    return delegate.shutdown();
+  }
+
+  @Override
+  public MemoryMode getMemoryMode() {
+    return delegate.getMemoryMode();
+  }
+
+  @Override
+  public Aggregation getDefaultAggregation(InstrumentType instrumentType) {
+    return delegate.getDefaultAggregation(instrumentType);
+  }
+
+  @Override
+  public AggregationTemporality getAggregationTemporality(InstrumentType instrumentType) {
+    return delegate.getAggregationTemporality(instrumentType);
+  }
+
+  /**
+   * Splits a collection of {@link MetricData} into batches and exports them based on a specified maximum batch size.
+   *
+   * <p>The splitting logic follows these rules:
+   * <ul>
+   *   <li>Metrics are added to a batch until adding another would exceed {@code maxBatchSize}.</li>
+   *   <li>If adding a metric would exceed the batch size, the current batch is exported first.</li>
+   *   <li>Large metrics (where the number of points exceeds {@code maxBatchSize}) are split into chunks:
+   *     <ul>
+   *       <li>Full-sized chunks ({@code maxBatchSize}) are exported immediately.</li>
+   *       <li>The last chunk (if smaller than {@code maxBatchSize}) is added to a new batch.</li>
+   *     </ul>
+   *   </li>
+   *   <li>Before processing a large metric, any existing batch is exported to prevent unnecessary splits.</li>
+   *   <li>Any remaining batch after iteration is exported at the end.</li>
+   * </ul>
+   * </p>
+   *
+   * @param metrics       The collection of {@link MetricData} to be batched and exported.
+   * @param maxBatchSize  The maximum number of metric points allowed per batch.
+   * @param results       A collection to store the result codes of each export operation.
+   */
+  private void splitIntoBatches(
+      Collection<MetricData> metrics,
+      int maxBatchSize,
+      Collection<CompletableResultCode> results) {
+    List<MetricData> currentBatch = new ArrayList<>();
+    int currentBatchSize = 0;
+
+    for (MetricData metricData: metrics) {
+      int metricSize = metricData.getData().getPoints().size();
+
+      // Export current batch before splitting a large MetricData to reduce number of split
+      if (!currentBatch.isEmpty() && metricSize > maxBatchSize) {
+        results.add(delegate.export(currentBatch));
+        currentBatch = new ArrayList<>();
+        currentBatchSize = 0;
+      }
+
+      if (metricSize > maxBatchSize) {
+        int startIndex = 0;
+        while (startIndex < metricSize) {
+          int endIndex = Math.min(startIndex + maxBatchSize, metricSize);
+          MetricData subMetricData = new MetricDataRangeDecorator<>(metricData, startIndex, endIndex);
+
+          if (endIndex - startIndex == maxBatchSize) {
+            // Export full-sized split immediately
+            results.add(delegate.export(Collections.singletonList(subMetricData)));
+          } else {
+            currentBatch.add(subMetricData);
+            currentBatchSize += endIndex - startIndex;
+          }
+          startIndex = endIndex;
+        }
+      } else {
+        if (currentBatchSize + metricSize > maxBatchSize) {
+          results.add(delegate.export(currentBatch));
+          currentBatch = new ArrayList<>();
+          currentBatchSize = 0;
+        }
+
+        currentBatch.add(metricData);
+        currentBatchSize += metricSize;
+      }
+    }
+
+    // Export any remaining batch
+    if (!currentBatch.isEmpty()) {
+      results.add(delegate.export(currentBatch));
+    }
+  }
+}

--- a/internal/venice-client-common/src/test/java/com/linkedin/venice/stats/MetricDataRangeDecoratorTest.java
+++ b/internal/venice-client-common/src/test/java/com/linkedin/venice/stats/MetricDataRangeDecoratorTest.java
@@ -1,0 +1,78 @@
+package com.linkedin.venice.stats;
+
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertSame;
+import static org.testng.Assert.assertTrue;
+
+import io.opentelemetry.sdk.metrics.data.GaugeData;
+import io.opentelemetry.sdk.metrics.data.MetricData;
+import io.opentelemetry.sdk.metrics.data.MetricDataType;
+import io.opentelemetry.sdk.metrics.data.PointData;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.List;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+
+public class MetricDataRangeDecoratorTest {
+  private MetricData original;
+  private List<PointData> originalPoints;
+
+  @BeforeMethod
+  public void setUp() {
+    // Mock an original MetricData with 5 dummy points
+    original = mock(MetricData.class);
+    originalPoints = new ArrayList<>();
+    for (int i = 0; i < 5; i++) {
+      originalPoints.add(mock(PointData.class));
+    }
+    GaugeData<PointData> data = mock(GaugeData.class);
+    when(data.getPoints()).thenReturn(originalPoints);
+    when(original.getType()).thenReturn(MetricDataType.DOUBLE_GAUGE);
+    doReturn(data).when(original).getData();
+  }
+
+  @Test
+  public void testGetDataPointsRange() {
+    // when selecting range [1,4)
+    MetricDataRangeDecorator<PointData> decorator = new MetricDataRangeDecorator<>(original, 1, 4);
+    GaugeData<PointData> decoratedData = (GaugeData<PointData>) decorator.getData();
+    Collection<PointData> filtered = decoratedData.getPoints();
+
+    // then only points at indices 1,2,3 are returned
+    assertEquals(filtered.size(), 3);
+    Iterator<PointData> it = filtered.iterator();
+    assertSame(it.next(), originalPoints.get(1));
+    assertSame(it.next(), originalPoints.get(2));
+    assertSame(it.next(), originalPoints.get(3));
+  }
+
+  @Test
+  public void testEqualsAndHashCode() {
+    // full-range decorator should equal the original and share hashCode
+    MetricDataRangeDecorator<PointData> fullDecorator =
+        new MetricDataRangeDecorator<>(original, 0, originalPoints.size());
+    assertTrue(fullDecorator.equals(original));
+    assertEquals(fullDecorator.hashCode(), original.hashCode());
+
+    // partial-range decorator should not equal the original
+    MetricDataRangeDecorator<PointData> partialDecorator = new MetricDataRangeDecorator<>(original, 1, 4);
+    assertFalse(partialDecorator.equals(original));
+    // but should equal another decorator with the same range & underlying
+    assertTrue(partialDecorator.equals(new MetricDataRangeDecorator<>(original, 1, 4)));
+    // and its hashCode follows: 31*origHash + startIndex + endIndex
+    int expectedHash = 31 * original.hashCode() + 1 + 4;
+    assertEquals(partialDecorator.hashCode(), expectedHash);
+  }
+
+  @Test(expectedExceptions = IllegalArgumentException.class)
+  public void testInvalidRangeThrows() {
+    new MetricDataRangeDecorator<>(original, 4, 1);
+  }
+}

--- a/internal/venice-client-common/src/test/java/com/linkedin/venice/stats/SplitOtlpHttpMetricExporterTest.java
+++ b/internal/venice-client-common/src/test/java/com/linkedin/venice/stats/SplitOtlpHttpMetricExporterTest.java
@@ -1,0 +1,74 @@
+package com.linkedin.venice.stats;
+
+import static org.mockito.ArgumentMatchers.anyCollection;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertTrue;
+
+import io.opentelemetry.sdk.common.CompletableResultCode;
+import io.opentelemetry.sdk.metrics.data.Data;
+import io.opentelemetry.sdk.metrics.data.MetricData;
+import io.opentelemetry.sdk.metrics.data.PointData;
+import io.opentelemetry.sdk.metrics.export.MetricExporter;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+
+public class SplitOtlpHttpMetricExporterTest {
+  private MetricExporter delegate;
+  private SplitOtlpHttpMetricExporter exporter;
+  private MetricData metric;
+
+  @BeforeMethod
+  public void setUp() {
+    // Mock the delegate exporter and a single MetricData
+    delegate = mock(MetricExporter.class);
+    exporter = new SplitOtlpHttpMetricExporter(delegate, 3);
+    metric = mock(MetricData.class);
+    Data<PointData> data = mock(Data.class);
+    doReturn(data).when(metric).getData();
+  }
+
+  @Test
+  public void testExportSmallerThanBatchSize() {
+    // given a metric with 2 points (< maxBatchSize)
+    Collection<PointData> points = Arrays.asList(mock(PointData.class), mock(PointData.class));
+    Data data = metric.getData();
+    doReturn(points).when(data).getPoints();
+    when(delegate.export(anyCollection())).thenReturn(CompletableResultCode.ofSuccess());
+
+    // when exporting
+    CompletableResultCode result = exporter.export(Collections.singletonList(metric));
+
+    // then delegate.export called once with the full batch and overall result is success
+    verify(delegate, times(1)).export(anyCollection());
+    assertTrue(result.isSuccess());
+  }
+
+  @Test
+  public void testExportLargerThanBatchSize() {
+    // given a metric with 10 points (> maxBatchSize)
+    List<PointData> points = new ArrayList<>();
+    for (int i = 0; i < 10; i++) {
+      points.add(mock(PointData.class));
+    }
+    Data data = metric.getData();
+    doReturn(points).when(data).getPoints();
+    when(delegate.export(anyCollection())).thenReturn(CompletableResultCode.ofSuccess());
+
+    // when exporting
+    CompletableResultCode result = exporter.export(Collections.singletonList(metric));
+
+    // then delegate.export called 4 times (3 full chunks + 1 remainder) and overall result is success
+    verify(delegate, times(4)).export(anyCollection());
+    assertTrue(result.isSuccess());
+  }
+}


### PR DESCRIPTION
## Problem Statement
Currently the export from OpenTelemetry happens on 1 big `POST` which some metric receiving component (like fluentbit) might not handle properly. This is okay with only few metrics/timeseries being emitted, but once we start emitting more metrics, this might result in data loss depends on sheer amount of the metrics and the capability of the underlying metrics pipeline. 

## Solution
Split OpenTelemetry data points for export if needed by the underlying metrics processing frameworks. 

Added the below configs:
`otel.venice.metrics.enable.split.export`
`otel.venice.metrics.number.of.samples.per.split`

Test:
```
1 big export without using `SplitOtlpHttpMetricExporter`
Got 3087 bytes
127.0.0.1 - - [20/Jun/2025 11:16:49] "POST / HTTP/1.1" 200 -

With `SplitOtlpHttpMetricExporter`  and `maxBatchSize` as 1 => split exports:
Got 356 bytes
127.0.0.1 - - [23/Jun/2025 10:39:04] "POST / HTTP/1.1" 200 -
Got 312 bytes
127.0.0.1 - - [23/Jun/2025 10:39:04] "POST / HTTP/1.1" 200 -
Got 490 bytes
127.0.0.1 - - [23/Jun/2025 10:39:04] "POST / HTTP/1.1" 200 -
Got 486 bytes
127.0.0.1 - - [23/Jun/2025 10:39:04] "POST / HTTP/1.1" 200 -
Got 495 bytes
127.0.0.1 - - [23/Jun/2025 10:39:04] "POST / HTTP/1.1" 200 -
Got 506 bytes
127.0.0.1 - - [23/Jun/2025 10:39:04] "POST / HTTP/1.1" 200 -
Got 468 bytes
127.0.0.1 - - [23/Jun/2025 10:39:04] "POST / HTTP/1.1" 200 -
Got 459 bytes
127.0.0.1 - - [23/Jun/2025 10:39:04] "POST / HTTP/1.1" 200 -
```

###  Code changes
- [x] Added new code behind **a config**. If so list the config names and their default values in the PR description.
- [ ] Introduced new **log lines**. 
  - [ ] Confirmed if logs need to be **rate limited** to avoid excessive logging.

###  **Concurrency-Specific Checks**
Both reviewer and PR author to verify
- [ ] Code has **no race conditions** or **thread safety issues**.
- [ ] Proper **synchronization mechanisms** (e.g., `synchronized`, `RWLock`) are used where needed.
- [ ] No **blocking calls** inside critical sections that could lead to deadlocks or performance degradation.
- [ ] Verified **thread-safe collections** are used (e.g., `ConcurrentHashMap`, `CopyOnWriteArrayList`).
- [ ] Validated proper exception handling in multi-threaded code to avoid silent thread termination.


## How was this PR tested?
- [x] New unit tests added.
- [ ] New integration tests added.
- [ ] Modified or extended existing tests.
- [ ] Verified backward compatibility (if applicable).

## Does this PR introduce any user-facing or breaking changes?
- [ ] No. You can skip the rest of this section.
- [ ] Yes. Clearly explain the behavior change and its impact.