### PR TITLE
[controller] Delete Repush Source Backup Versions

### DIFF
--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/StoreBackupVersionCleanupService.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/StoreBackupVersionCleanupService.java
@@ -320,6 +320,9 @@ public class StoreBackupVersionCleanupService extends AbstractVeniceService {
     // Keep at least 1 backup version until we are past the retention period.
     if (isCurrentVersionRepushed && readyToBeRemovedVersions.size() >= versions.size() - 1 && !pastRetentionPeriod) {
       readyToBeRemovedVersions.remove(0); // choose the newest version
+      if (readyToBeRemovedVersions.isEmpty()) {
+        return false;
+      }
     }
 
     String storeName = store.getName();

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/StoreBackupVersionCleanupService.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/StoreBackupVersionCleanupService.java
@@ -11,6 +11,7 @@ import com.linkedin.venice.meta.Instance;
 import com.linkedin.venice.meta.QueryAction;
 import com.linkedin.venice.meta.Store;
 import com.linkedin.venice.meta.Version;
+import com.linkedin.venice.meta.VersionStatus;
 import com.linkedin.venice.security.SSLFactory;
 import com.linkedin.venice.service.AbstractVeniceService;
 import com.linkedin.venice.utils.LogContext;
@@ -293,35 +294,42 @@ public class StoreBackupVersionCleanupService extends AbstractVeniceService {
       return false;
     }
 
+    // First, consider any versions that can be deleted (invalid status: error or killed) and are not in use
+    List<Version> readyToBeRemovedVersions = versions.stream()
+        .filter(v -> v.getNumber() < currentVersion && VersionStatus.canDelete(v.getStatus()))
+        .collect(Collectors.toList());
+
     // This will delete backup versions which satisfy any of the following conditions
     // 1. Current version is from a repush, the version is from the chain of repushes into current version.
     // 2. Current version is from a repush, but still a lingering version older than retention period.
     // 3. Current version is not repush and is older than retention, delete any versions < current version.
-    long retentionThreshold = store.getLatestVersionPromoteToCurrentTimestamp() + defaultBackupVersionRetentionMs;
-    boolean pastRetentionPeriod = time.getMilliseconds() > retentionThreshold;
-    int repushSourceVersion = store.getVersionOrThrow(currentVersion).getRepushSourceVersion();
-    boolean isCurrentVersionRepushed = repushSourceVersion > NON_EXISTING_VERSION;
-    HashSet<Integer> repushChainVersions = new HashSet<>(); // all versions repushed into the current version
-    List<Version> readyToBeRemovedVersions = versions.stream()
-        .sorted((v1, v2) -> Integer.compare(v2.getNumber(), v1.getNumber())) // sort in descending order
-        .filter(v -> {
-          if (!isCurrentVersionRepushed) {
-            return v.getNumber() < currentVersion;
-          }
-          repushChainVersions.add(v.getRepushSourceVersion()); // descending order, so source can only appear later
-          return v.getNumber() < currentVersion && (repushChainVersions.contains(v.getNumber()) || pastRetentionPeriod);
-        })
-        .collect(Collectors.toList());
-
     if (readyToBeRemovedVersions.isEmpty()) {
-      return false;
-    }
+      long retentionThreshold = store.getLatestVersionPromoteToCurrentTimestamp() + defaultBackupVersionRetentionMs;
+      int repushSourceVersion = store.getVersionOrThrow(currentVersion).getRepushSourceVersion();
+      boolean isCurrentVersionRepushed = repushSourceVersion > NON_EXISTING_VERSION;
+      boolean pastRetention = time.getMilliseconds() > retentionThreshold;
+      HashSet<Integer> repushChainVersions = new HashSet<>(); // all versions repushed into the current version
+      readyToBeRemovedVersions = versions.stream()
+          .sorted((v1, v2) -> Integer.compare(v2.getNumber(), v1.getNumber())) // sort in descending order
+          .filter(v -> {
+            if (!isCurrentVersionRepushed) {
+              return v.getNumber() < currentVersion;
+            }
+            repushChainVersions.add(v.getRepushSourceVersion()); // descending order, so source can only appear later
+            return v.getNumber() < currentVersion && (repushChainVersions.contains(v.getNumber()) || pastRetention);
+          })
+          .collect(Collectors.toList());
 
-    // Keep at least 1 backup version until we are past the retention period.
-    if (isCurrentVersionRepushed && readyToBeRemovedVersions.size() >= versions.size() - 1 && !pastRetentionPeriod) {
-      readyToBeRemovedVersions.remove(0); // choose the newest version
       if (readyToBeRemovedVersions.isEmpty()) {
         return false;
+      }
+
+      // Keep at least 1 backup version until we are past the retention period.
+      if (isCurrentVersionRepushed && readyToBeRemovedVersions.size() >= versions.size() - 1 && !pastRetention) {
+        readyToBeRemovedVersions.remove(0); // choose the newest version
+        if (readyToBeRemovedVersions.isEmpty()) {
+          return false;
+        }
       }
     }
 

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/StoreBackupVersionCleanupService.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/StoreBackupVersionCleanupService.java
@@ -318,7 +318,7 @@ public class StoreBackupVersionCleanupService extends AbstractVeniceService {
     }
 
     // Do not remove all repush source versions if it results in no backup version, unless older than the retention time
-    if (readyToBeRemovedVersions.size() >= versions.size() - 1) {
+    if (isCurrentVersionRepushed && readyToBeRemovedVersions.size() >= versions.size() - 1) {
       for (int i = 0; i < readyToBeRemovedVersions.size(); i++) {
         Version v = readyToBeRemovedVersions.get(i);
         if (v.getCreatedTime() + defaultBackupVersionRetentionMs > time.getMilliseconds()) {

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/StoreBackupVersionCleanupService.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/StoreBackupVersionCleanupService.java
@@ -70,7 +70,7 @@ public class StoreBackupVersionCleanupService extends AbstractVeniceService {
   private final Thread cleanupThread;
   private final long sleepInterval;
   private final long defaultBackupVersionRetentionMs;
-  private static long waitTimeDeleteRepushSourceVersion = TimeUnit.MINUTES.toMillis(30);
+  private static long waitTimeDeleteRepushSourceVersion = TimeUnit.HOURS.toMillis(1);
   private final AtomicBoolean stop = new AtomicBoolean(false);
 
   private final Map<String, StoreBackupVersionCleanupServiceStats> clusterNameCleanupStatsMap =

--- a/services/venice-controller/src/test/java/com/linkedin/venice/controller/TestStoreBackupVersionCleanupService.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/controller/TestStoreBackupVersionCleanupService.java
@@ -38,8 +38,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
 import org.apache.http.HttpEntity;
 import org.apache.http.HttpResponse;
 import org.apache.http.HttpStatus;
@@ -53,15 +53,41 @@ import org.testng.annotations.Test;
 public class TestStoreBackupVersionCleanupService {
   private static final ObjectMapper OBJECT_MAPPER = ObjectMapperFactory.getInstance();
 
+  private static final String CLUSTER_NAME = "test_cluster";
+  private static final long DEFAULT_RETENTION_MS = TimeUnit.DAYS.toMillis(7);
+
   private VeniceHelixAdmin admin;
   private ZkRoutersClusterManager clusterManager;
   private HelixVeniceClusterResources mockClusterResource;
+  private VeniceControllerMultiClusterConfig config;
+  private VeniceControllerClusterConfig controllerConfig;
+  private LiveInstanceMonitor liveInstanceMonitor;
+  private MetricsRepository metricsRepository;
 
   @BeforeMethod
   public void setUp() throws Exception {
+    // Initialize common mocks
     admin = mock(VeniceHelixAdmin.class);
     mockClusterResource = mock(HelixVeniceClusterResources.class);
     clusterManager = mock(ZkRoutersClusterManager.class);
+    config = mock(VeniceControllerMultiClusterConfig.class);
+    controllerConfig = mock(VeniceControllerClusterConfig.class);
+    liveInstanceMonitor = mock(LiveInstanceMonitor.class);
+    metricsRepository = mock(MetricsRepository.class);
+
+    // Setup default mock behaviors
+    when(mockClusterResource.getRoutersClusterManager()).thenReturn(clusterManager);
+    when(admin.getHelixVeniceClusterResources(anyString())).thenReturn(mockClusterResource);
+    when(admin.getLiveInstanceMonitor(anyString())).thenReturn(liveInstanceMonitor);
+    when(config.getControllerConfig(anyString())).thenReturn(controllerConfig);
+    when(config.getBackupVersionDefaultRetentionMs()).thenReturn(DEFAULT_RETENTION_MS);
+    when(metricsRepository.sensor(anyString(), any())).thenReturn(mock(Sensor.class));
+
+    // Default test cluster setup
+    Set<String> clusters = new HashSet<>();
+    clusters.add(CLUSTER_NAME);
+    when(config.getClusters()).thenReturn(clusters);
+    when(admin.isLeaderControllerFor(any())).thenReturn(true);
   }
 
   private Store mockStore(
@@ -161,96 +187,88 @@ public class TestStoreBackupVersionCleanupService {
             -1));
   }
 
+  private StoreBackupVersionCleanupService createService() {
+    return new StoreBackupVersionCleanupService(admin, config, metricsRepository);
+  }
+
+  private void setupStoreWithVersions(Store store, Map<Integer, VersionStatus> versions, int currentVersion) {
+    doReturn(versions.keySet().stream().map(store::getVersion).collect(Collectors.toList())).when(store).getVersions();
+    for (Map.Entry<Integer, VersionStatus> entry: versions.entrySet()) {
+      when(store.getVersion(entry.getKey())).thenReturn(store.getVersion(entry.getKey()));
+    }
+    doReturn(store.getVersion(currentVersion)).when(store).getVersionOrThrow(currentVersion);
+  }
+
   @Test
   public void testCleanupBackupVersion() {
-    VeniceHelixAdmin admin = mock(VeniceHelixAdmin.class);
-    VeniceControllerMultiClusterConfig config = mock(VeniceControllerMultiClusterConfig.class);
-    long defaultRetentionMs = TimeUnit.DAYS.toMillis(7);
-    doReturn(defaultRetentionMs).when(config).getBackupVersionDefaultRetentionMs();
-    VeniceControllerClusterConfig controllerConfig = mock(VeniceControllerClusterConfig.class);
-    doReturn(controllerConfig).when(config).getControllerConfig(anyString());
-    doReturn(mockClusterResource).when(admin).getHelixVeniceClusterResources(anyString());
-    doReturn(clusterManager).when(mockClusterResource).getRoutersClusterManager();
-    StoreBackupVersionCleanupService service =
-        new StoreBackupVersionCleanupService(admin, config, mock(MetricsRepository.class));
+    StoreBackupVersionCleanupService service = createService();
 
-    String clusterName = "test_cluster";
-    // Store is not qualified because of short life time of backup version
+    // Test 1: Store not qualified due to recent backup version
     Map<Integer, VersionStatus> versions = new HashMap<>();
     versions.put(1, VersionStatus.ONLINE);
     versions.put(2, VersionStatus.ONLINE);
     Store storeWithFreshBackupVersion = mockStore(-1, System.currentTimeMillis(), versions, 2);
-    Assert.assertFalse(service.cleanupBackupVersion(storeWithFreshBackupVersion, clusterName));
+    Assert.assertFalse(service.cleanupBackupVersion(storeWithFreshBackupVersion, CLUSTER_NAME));
 
-    // Store is qualified, but only one version left
+    // Test 2: Store qualified but only has one version
     versions.clear();
     versions.put(2, VersionStatus.ONLINE);
-    Store storeWithOneVersion = mockStore(-1, System.currentTimeMillis() - defaultRetentionMs * 2, versions, 2);
-    Assert.assertFalse(service.cleanupBackupVersion(storeWithOneVersion, clusterName));
+    Store storeWithOneVersion = mockStore(-1, System.currentTimeMillis() - DEFAULT_RETENTION_MS * 2, versions, 2);
+    Assert.assertFalse(service.cleanupBackupVersion(storeWithOneVersion, CLUSTER_NAME));
 
-    // Store is qualified, and contains one removable version
+    // Test 3: Store qualified with one removable version
     versions.clear();
     versions.put(1, VersionStatus.ONLINE);
     versions.put(2, VersionStatus.ONLINE);
-    Store storeWithTwoVersions = mockStore(-1, System.currentTimeMillis() - defaultRetentionMs * 2, versions, 2);
-    Assert.assertTrue(service.cleanupBackupVersion(storeWithTwoVersions, clusterName));
-    verify(admin).deleteOldVersionInStore(clusterName, storeWithTwoVersions.getName(), 1);
+    Store storeWithTwoVersions = mockStore(-1, System.currentTimeMillis() - DEFAULT_RETENTION_MS * 2, versions, 2);
+    Assert.assertTrue(service.cleanupBackupVersion(storeWithTwoVersions, CLUSTER_NAME));
+    verify(admin).deleteOldVersionInStore(CLUSTER_NAME, storeWithTwoVersions.getName(), 1);
 
-    // Store is qualified, but rollback was executed
+    // Test 4: Store qualified but rollback was executed
     versions.clear();
     versions.put(1, VersionStatus.ONLINE);
     versions.put(2, VersionStatus.ONLINE);
     versions.put(3, VersionStatus.STARTED);
-    Store storeWithRollback = mockStore(-1, System.currentTimeMillis() - defaultRetentionMs * 2, versions, 1);
-    Assert.assertFalse(service.cleanupBackupVersion(storeWithRollback, clusterName));
+    Store storeWithRollback = mockStore(-1, System.currentTimeMillis() - DEFAULT_RETENTION_MS * 2, versions, 1);
+    Assert.assertFalse(service.cleanupBackupVersion(storeWithRollback, CLUSTER_NAME));
+
+    // Test 5: Store with push in progress
     StoreBackupVersionCleanupService.setMinBackupVersionCleanupDelay(100L);
     doReturn(true).when(controllerConfig).isBackupVersionReplicaReductionEnabled();
     versions.clear();
     versions.put(1, VersionStatus.ONLINE);
     versions.put(2, VersionStatus.ONLINE);
     versions.put(3, VersionStatus.STARTED);
-    Store storeWithPush = mockStore(-1, System.currentTimeMillis() - defaultRetentionMs * 2, versions, 2);
+    Store storeWithPush = mockStore(-1, System.currentTimeMillis() - DEFAULT_RETENTION_MS * 2, versions, 2);
     doReturn(1509711434L).when(storeWithPush).getBackupVersionRetentionMs();
-    Assert.assertFalse(service.cleanupBackupVersion(storeWithPush, clusterName));
-    verify(admin).updateIdealState(clusterName, Version.composeKafkaTopic(storeWithPush.getName(), 1), 2);
-
+    Assert.assertFalse(service.cleanupBackupVersion(storeWithPush, CLUSTER_NAME));
+    verify(admin).updateIdealState(CLUSTER_NAME, Version.composeKafkaTopic(storeWithPush.getName(), 1), 2);
   }
 
   @Test
   public void testCleanupBackupVersionRepush() {
-    VeniceHelixAdmin admin = mock(VeniceHelixAdmin.class);
-    VeniceControllerMultiClusterConfig config = mock(VeniceControllerMultiClusterConfig.class);
-    long defaultRetentionMs = TimeUnit.DAYS.toMillis(7);
-    doReturn(defaultRetentionMs).when(config).getBackupVersionDefaultRetentionMs();
-    long rolledbackTimestamp = System.currentTimeMillis() - defaultRetentionMs * 2;
-    VeniceControllerClusterConfig controllerConfig = mock(VeniceControllerClusterConfig.class);
-    doReturn(controllerConfig).when(config).getControllerConfig(anyString());
-    doReturn(mockClusterResource).when(admin).getHelixVeniceClusterResources(anyString());
-    doReturn(clusterManager).when(mockClusterResource).getRoutersClusterManager();
-    StoreBackupVersionCleanupService service =
-        new StoreBackupVersionCleanupService(admin, config, mock(MetricsRepository.class));
+    StoreBackupVersionCleanupService service = createService();
+    long rolledbackTimestamp = System.currentTimeMillis() - DEFAULT_RETENTION_MS * 2;
     long waitTimeDeleteRepushSourceVersion = 100; // bypasses whetherStoreReadyToBeCleanup() for repush cases
     StoreBackupVersionCleanupService.setWaitTimeDeleteRepushSourceVersion(waitTimeDeleteRepushSourceVersion);
 
     // Test case: One repush creating one backup version
-    // Store is not qualified because of short life time of backup version
-    String clusterName = "test_cluster";
     Map<Integer, VersionStatus> versions = new HashMap<>();
     versions.put(1, VersionStatus.ONLINE);
     versions.put(2, VersionStatus.ONLINE);
     Store storeWithFreshBackupVersion = mockStore(-1, System.currentTimeMillis(), versions, 2);
     Version currentVersion = storeWithFreshBackupVersion.getVersion(2);
-    doReturn(1).when(currentVersion).getRepushSourceVersion();
-    Assert.assertFalse(service.cleanupBackupVersion(storeWithFreshBackupVersion, clusterName));
+    when(currentVersion.getRepushSourceVersion()).thenReturn(1);
+    Assert.assertFalse(service.cleanupBackupVersion(storeWithFreshBackupVersion, CLUSTER_NAME));
 
     // Even if the repush was on a version created 6 months ago, the backup version should not be immediately deleted
     Version backupVersion = storeWithFreshBackupVersion.getVersion(1);
     doReturn(System.currentTimeMillis() - TimeUnit.DAYS.toMillis(6 * 30)).when(backupVersion).getCreatedTime();
-    Assert.assertFalse(service.cleanupBackupVersion(storeWithFreshBackupVersion, clusterName));
+    Assert.assertFalse(service.cleanupBackupVersion(storeWithFreshBackupVersion, CLUSTER_NAME));
 
     // The deletion condition should hinge on latestVersionPromoteToCurrentTimestamp
     doReturn(rolledbackTimestamp).when(storeWithFreshBackupVersion).getLatestVersionPromoteToCurrentTimestamp();
-    Assert.assertTrue(service.cleanupBackupVersion(storeWithFreshBackupVersion, clusterName));
+    Assert.assertTrue(service.cleanupBackupVersion(storeWithFreshBackupVersion, CLUSTER_NAME));
 
     versions.clear();
     versions.put(1, VersionStatus.ONLINE);
@@ -261,11 +279,11 @@ public class TestStoreBackupVersionCleanupService {
     doReturn(2).when(version).getRepushSourceVersion();
 
     // should delete version 2 as 1 is the true backup
-    Assert.assertTrue(service.cleanupBackupVersion(storeWithRollback, clusterName));
+    Assert.assertTrue(service.cleanupBackupVersion(storeWithRollback, CLUSTER_NAME));
     TestUtils.waitForNonDeterministicAssertion(
         1,
         TimeUnit.SECONDS,
-        () -> verify(admin, atLeast(1)).deleteOldVersionInStore(clusterName, storeWithRollback.getName(), 2));
+        () -> verify(admin, atLeast(1)).deleteOldVersionInStore(CLUSTER_NAME, storeWithRollback.getName(), 2));
 
     versions.clear();
     versions.put(1, VersionStatus.ONLINE);
@@ -277,11 +295,11 @@ public class TestStoreBackupVersionCleanupService {
     doReturn(1L).when(version).getCreatedTime();
 
     // should delete version 1 as it's lingering and not a repush source version.
-    Assert.assertTrue(service.cleanupBackupVersion(storeLingeringVersion, clusterName));
+    Assert.assertTrue(service.cleanupBackupVersion(storeLingeringVersion, CLUSTER_NAME));
     TestUtils.waitForNonDeterministicAssertion(
         1,
         TimeUnit.SECONDS,
-        () -> verify(admin, atLeast(1)).deleteOldVersionInStore(clusterName, storeLingeringVersion.getName(), 1));
+        () -> verify(admin, atLeast(1)).deleteOldVersionInStore(CLUSTER_NAME, storeLingeringVersion.getName(), 1));
 
     // Test case: Store with multiple repushed versions
     // Version 2 is repushed from Version 3 until Version 10
@@ -298,70 +316,66 @@ public class TestStoreBackupVersionCleanupService {
     }
 
     // Cleanup service should not run, since it hasn't been long enough since the latest version was promoted to current
-    Assert.assertFalse(service.cleanupBackupVersion(repushedStore, clusterName), "No versions should be cleaned up");
+    Assert.assertFalse(service.cleanupBackupVersion(repushedStore, CLUSTER_NAME), "No versions should be cleaned up");
     for (int v = minRepushedVersion; v < maxRepushedVersion; v++) {
-      verify(admin, never()).deleteOldVersionInStore(clusterName, repushedStore.getName(), v);
+      verify(admin, never()).deleteOldVersionInStore(CLUSTER_NAME, repushedStore.getName(), v);
     }
 
     // Versions 2..9 should be deleted, but not Version 1 or Version 10
     doReturn(System.currentTimeMillis() - 2 * waitTimeDeleteRepushSourceVersion).when(repushedStore)
         .getLatestVersionPromoteToCurrentTimestamp(); // cleanup service can run again
-    Assert.assertTrue(service.cleanupBackupVersion(repushedStore, clusterName));
-    verify(admin, never()).deleteOldVersionInStore(clusterName, repushedStore.getName(), 1);
+    Assert.assertTrue(service.cleanupBackupVersion(repushedStore, CLUSTER_NAME));
+    verify(admin, never()).deleteOldVersionInStore(CLUSTER_NAME, repushedStore.getName(), 1);
     for (int v = minRepushedVersion - 1; v < maxRepushedVersion; v++) { // version 2, 3, 4, ..., 9
       int versionNumber = v; // for compiler warning
       TestUtils.waitForNonDeterministicAssertion(
           1,
           TimeUnit.SECONDS,
-          () -> verify(admin, atLeast(1)).deleteOldVersionInStore(clusterName, repushedStore.getName(), versionNumber));
+          () -> verify(admin, atLeast(1))
+              .deleteOldVersionInStore(CLUSTER_NAME, repushedStore.getName(), versionNumber));
     }
-    verify(admin, never()).deleteOldVersionInStore(clusterName, repushedStore.getName(), maxRepushedVersion);
+    verify(admin, never()).deleteOldVersionInStore(CLUSTER_NAME, repushedStore.getName(), maxRepushedVersion);
 
     // Test case: Version 1 is repushed from Version 2 until Version 10
     // The latest backup version (9) should not be deleted unless retention time has passed
     clearInvocations(admin);
     version = repushedStore.getVersion(2);
     doReturn(1).when(version).getRepushSourceVersion();
-    Assert.assertTrue(service.cleanupBackupVersion(repushedStore, clusterName));
+    Assert.assertTrue(service.cleanupBackupVersion(repushedStore, CLUSTER_NAME));
     for (int v = 1; v < maxRepushedVersion - 1; v++) { // version 1, 2, 3, ..., 8
       int versionNumber = v; // for compiler warning
       TestUtils.waitForNonDeterministicAssertion(
           1,
           TimeUnit.SECONDS,
-          () -> verify(admin, atLeast(1)).deleteOldVersionInStore(clusterName, repushedStore.getName(), versionNumber));
+          () -> verify(admin, atLeast(1))
+              .deleteOldVersionInStore(CLUSTER_NAME, repushedStore.getName(), versionNumber));
     }
-    verify(admin, never()).deleteOldVersionInStore(clusterName, repushedStore.getName(), maxRepushedVersion - 1);
-    verify(admin, never()).deleteOldVersionInStore(clusterName, repushedStore.getName(), maxRepushedVersion);
+    verify(admin, never()).deleteOldVersionInStore(CLUSTER_NAME, repushedStore.getName(), maxRepushedVersion - 1);
+    verify(admin, never()).deleteOldVersionInStore(CLUSTER_NAME, repushedStore.getName(), maxRepushedVersion);
 
     // If the retention period has passed since promotion to current version, that version (9) should be deleted as well
     clearInvocations(admin);
     doReturn(0L).when(repushedStore).getLatestVersionPromoteToCurrentTimestamp();
-    Assert.assertTrue(service.cleanupBackupVersion(repushedStore, clusterName));
+    Assert.assertTrue(service.cleanupBackupVersion(repushedStore, CLUSTER_NAME));
     for (int v = 1; v < maxRepushedVersion; v++) { // version 1, 2, 3, ..., 9
       int versionNumber = v; // for compiler warning
       TestUtils.waitForNonDeterministicAssertion(
           1,
           TimeUnit.SECONDS,
-          () -> verify(admin, atLeast(1)).deleteOldVersionInStore(clusterName, repushedStore.getName(), versionNumber));
+          () -> verify(admin, atLeast(1))
+              .deleteOldVersionInStore(CLUSTER_NAME, repushedStore.getName(), versionNumber));
     }
-    verify(admin, never()).deleteOldVersionInStore(clusterName, repushedStore.getName(), maxRepushedVersion);
+    verify(admin, never()).deleteOldVersionInStore(CLUSTER_NAME, repushedStore.getName(), maxRepushedVersion);
   }
 
   @Test
   public void testMetadataBasedCleanupBackupVersion() throws IOException {
-    VeniceHelixAdmin admin = mock(VeniceHelixAdmin.class);
-    VeniceControllerMultiClusterConfig config = mock(VeniceControllerMultiClusterConfig.class);
-    long defaultRetentionMs = TimeUnit.DAYS.toMillis(7);
-    LiveInstanceMonitor liveInstanceMonitor = mock(LiveInstanceMonitor.class);
-    doReturn(liveInstanceMonitor).when(admin).getLiveInstanceMonitor(anyString());
-    doReturn(defaultRetentionMs).when(config).getBackupVersionDefaultRetentionMs();
     CloseableHttpAsyncClient asyncClient = mock(CloseableHttpAsyncClient.class);
     StatusLine statusLine = mock(StatusLine.class);
     CurrentVersionResponse currentVersionResponse = new CurrentVersionResponse();
     currentVersionResponse.setCurrentVersion(2);
     HttpResponse response = mock(HttpResponse.class);
-    Future future = CompletableFuture.completedFuture(response);
-    doReturn(future).when(asyncClient).execute(any(), eq(null));
+    doReturn(CompletableFuture.completedFuture(response)).when(asyncClient).execute(any(), eq(null));
     doReturn(HttpStatus.SC_OK).when(statusLine).getStatusCode();
     doReturn(statusLine).when(response).getStatusLine();
     HttpEntity entity = mock(HttpEntity.class);
@@ -369,22 +383,13 @@ public class TestStoreBackupVersionCleanupService {
 
     doReturn(new ByteArrayInputStream(OBJECT_MAPPER.writeValueAsBytes(currentVersionResponse))).when(entity)
         .getContent();
-    VeniceControllerClusterConfig controllerConfig = mock(VeniceControllerClusterConfig.class);
-    doReturn(controllerConfig).when(config).getControllerConfig(anyString());
     doReturn(true).when(controllerConfig).isBackupVersionMetadataFetchBasedCleanupEnabled();
-    doReturn(mockClusterResource).when(admin).getHelixVeniceClusterResources(anyString());
-    doReturn(clusterManager).when(mockClusterResource).getRoutersClusterManager();
     Set<Instance> instSet = new HashSet<>();
     instSet.add(new Instance("0", "localhost1", 1234));
-    MetricsRepository metricsRepository = mock(MetricsRepository.class);
-    doReturn(mock(Sensor.class)).when(metricsRepository).sensor(anyString(), any());
 
-    doReturn(Collections.emptySet()).when(clusterManager).getLiveRouterInstances();
-    StoreBackupVersionCleanupService service =
-        spy(new StoreBackupVersionCleanupService(admin, config, metricsRepository));
+    StoreBackupVersionCleanupService service = spy(createService());
     doReturn(asyncClient).when(service).getHttpAsyncClient();
 
-    String clusterName = "test_cluster";
     Map<Integer, VersionStatus> versions = new HashMap<>();
     // Store is qualified, and contains one removable version
     versions.put(1, VersionStatus.ONLINE);
@@ -392,8 +397,8 @@ public class TestStoreBackupVersionCleanupService {
     doReturn(instSet).when(clusterManager).getLiveRouterInstances();
     doReturn(instSet).when(liveInstanceMonitor).getAllLiveInstances();
 
-    Store storeWithTwoVersions = mockStore(-1, System.currentTimeMillis() - defaultRetentionMs * 2, versions, 2);
-    Assert.assertFalse(service.cleanupBackupVersion(storeWithTwoVersions, clusterName));
+    Store storeWithTwoVersions = mockStore(-1, System.currentTimeMillis() - DEFAULT_RETENTION_MS * 2, versions, 2);
+    Assert.assertFalse(service.cleanupBackupVersion(storeWithTwoVersions, CLUSTER_NAME));
 
     ServerCurrentVersionResponse versionResponse = new ServerCurrentVersionResponse();
     versionResponse.setCurrentVersion(2);
@@ -403,46 +408,27 @@ public class TestStoreBackupVersionCleanupService {
         .doReturn(new ByteArrayInputStream(OBJECT_MAPPER.writeValueAsBytes(currentVersionResponse)))
         .when(entity)
         .getContent();
-    Assert.assertTrue(service.cleanupBackupVersion(storeWithTwoVersions, clusterName));
+    Assert.assertTrue(service.cleanupBackupVersion(storeWithTwoVersions, CLUSTER_NAME));
   }
 
   @Test
   public void testCleanupBackupVersionSleepValidation() throws Exception {
-    VeniceControllerMultiClusterConfig config = mock(VeniceControllerMultiClusterConfig.class);
-    long defaultRetentionMs = TimeUnit.DAYS.toMillis(7);
-    LiveInstanceMonitor liveInstanceMonitor = mock(LiveInstanceMonitor.class);
-    doReturn(defaultRetentionMs).when(config).getBackupVersionDefaultRetentionMs();
-    doReturn(defaultRetentionMs).when(config).getBackupVersionDefaultRetentionMs();
-    VeniceControllerClusterConfig controllerConfig = mock(VeniceControllerClusterConfig.class);
-    doReturn(controllerConfig).when(config).getControllerConfig(any());
     doReturn(true).when(controllerConfig).isBackupVersionRetentionBasedCleanupEnabled();
-    doReturn(true).when(admin).isLeaderControllerFor(any());
-    doReturn(liveInstanceMonitor).when(admin).getLiveInstanceMonitor(anyString());
-    doReturn(mockClusterResource).when(admin).getHelixVeniceClusterResources(anyString());
-    doReturn(clusterManager).when(mockClusterResource).getRoutersClusterManager();
     doReturn(Collections.emptySet()).when(clusterManager).getLiveRouterInstances();
     Map<Integer, VersionStatus> versions = new HashMap<>();
     versions.put(1, VersionStatus.ONLINE);
     versions.put(2, VersionStatus.ONLINE);
-    Store storeWithTwoVersions = mockStore(-1, System.currentTimeMillis() - defaultRetentionMs * 2, versions, 2);
 
-    String clusterName = "test_cluster";
-    Set<String> clusters = new HashSet<>();
-    clusters.add(clusterName);
-    doReturn(clusters).when(config).getClusters();
-    List<Store> storeList = new ArrayList<>();
-    storeList.add(storeWithTwoVersions);
+    Store storeWithTwoVersions = mockStore(-1, System.currentTimeMillis() - DEFAULT_RETENTION_MS * 2, versions, 2);
+    List<Store> storeList = Collections.singletonList(storeWithTwoVersions);
     doReturn(storeList).when(admin).getAllStores(any());
     TestMockTime time = new TestMockTime();
-    MetricsRepository metricsRepository = mock(MetricsRepository.class);
-    when(metricsRepository.sensor(anyString(), any())).thenReturn(mock(Sensor.class));
     StoreBackupVersionCleanupService service =
         new StoreBackupVersionCleanupService(admin, config, time, metricsRepository);
     service.startInner();
     TestUtils.waitForNonDeterministicAssertion(
         1,
         TimeUnit.SECONDS,
-        () -> verify(admin, atLeast(1)).deleteOldVersionInStore(clusterName, storeWithTwoVersions.getName(), 1));
+        () -> verify(admin, atLeast(1)).deleteOldVersionInStore(CLUSTER_NAME, storeWithTwoVersions.getName(), 1));
   }
-
 }

--- a/services/venice-controller/src/test/java/com/linkedin/venice/controller/TestStoreBackupVersionCleanupService.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/controller/TestStoreBackupVersionCleanupService.java
@@ -321,12 +321,9 @@ public class TestStoreBackupVersionCleanupService {
     verify(admin, never()).deleteOldVersionInStore(clusterName, repushedStore.getName(), maxRepushedVersion - 1);
     verify(admin, never()).deleteOldVersionInStore(clusterName, repushedStore.getName(), maxRepushedVersion);
 
-    // If the retention period has passed, that version (9) should be deleted as well
+    // If the retention period has passed since promotion to current version, that version (9) should be deleted as well
     clearInvocations(admin);
-    for (int v = 1; v < maxRepushedVersion; v++) {
-      version = repushedStore.getVersion(v);
-      doReturn(0L).when(version).getCreatedTime();
-    }
+    doReturn(0L).when(repushedStore).getLatestVersionPromoteToCurrentTimestamp();
     Assert.assertTrue(service.cleanupBackupVersion(repushedStore, clusterName));
     for (int v = 1; v < maxRepushedVersion; v++) { // version 1, 2, 3, ..., 9
       int versionNumber = v; // for compiler warning


### PR DESCRIPTION
## Problem Statement
`cleanupBackupVersion()` in `StoreBackupVersionCleanupService` was not cleaning up all source backup versions from frequent repushes, which can lead to ingestion failures. It only cleans up one source backup source version.

## Solution
Delete all versions repushed into the current version, but keep one backup version subject to the retention period. Since the current version is based off these previous versions, they should be unnecessary except for the TTL repush case.

### Other Changes
* Reduced `waitTimeDeleteRepushSourceVersion` to `30 mins` from `1 hour`.
* Synced the comment saying that the source backup of the current repushed version would be deleted, but it was still respecting the 7 days backup because of the lack of parenthesis.
* Fixed `mockStore()` in `TestStoreBackupVersionCleanupService`:
    * It was not creating sequential versions, even when the versions were non-sequential.
    * It was not setting the `createdTime` for versions.

###  **Concurrency-Specific Checks**
Both reviewer and PR author to verify
- [X] No **blocking calls** inside critical sections that could lead to deadlocks or performance degradation.
- [X] Verified **thread-safe collections** are used (e.g., `ConcurrentHashMap`, `CopyOnWriteArrayList`).
    - `HashSet` was added, but it should be used in the same thread.

## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
- [X] Modified or extended existing tests.
    - Extended test cases in `testCleanupBackupVersion()` in `TestStoreBackupVersionCleanupService`

## Does this PR introduce any user-facing or breaking changes?
<!--  
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [X] No. You can skip the rest of this section.