### PR TITLE
[server][dvc] Migrate from long offset to PubSubPosition abstraction in server code 

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/consumer/InternalLocalBootstrappingVeniceChangelogConsumer.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/consumer/InternalLocalBootstrappingVeniceChangelogConsumer.java
@@ -490,10 +490,10 @@ class InternalLocalBootstrappingVeniceChangelogConsumer<K, V> extends VeniceAfte
             LOGGER.info(
                 "No local checkpoint found for partition: {}， will initialize checkpoint to offset: {}",
                 partition,
-                offsetRecord.getLocalVersionTopicOffset());
+                offsetRecord.getCheckpointedLocalVtPosition());
             localCheckpoint = new VeniceChangeCoordinate(
                 getTopicPartition(partition).getPubSubTopic().getName(),
-                offsetRecord.getLocalVersionTopicOffset(),
+                offsetRecord.getCheckpointedLocalVtPosition(),
                 partition);
           } else {
             localCheckpoint = VeniceChangeCoordinate

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/consumer/InternalLocalBootstrappingVeniceChangelogConsumer.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/consumer/InternalLocalBootstrappingVeniceChangelogConsumer.java
@@ -35,7 +35,6 @@ import com.linkedin.venice.kafka.protocol.state.StoreVersionState;
 import com.linkedin.venice.meta.PersistenceType;
 import com.linkedin.venice.meta.Store;
 import com.linkedin.venice.offsets.OffsetRecord;
-import com.linkedin.venice.pubsub.adapter.kafka.common.ApacheKafkaOffsetPosition;
 import com.linkedin.venice.pubsub.api.PubSubConsumerAdapter;
 import com.linkedin.venice.pubsub.api.PubSubMessage;
 import com.linkedin.venice.pubsub.api.PubSubPosition;
@@ -494,10 +493,7 @@ class InternalLocalBootstrappingVeniceChangelogConsumer<K, V> extends VeniceAfte
                 offsetRecord.getLocalVersionTopicOffset());
             localCheckpoint = new VeniceChangeCoordinate(
                 getTopicPartition(partition).getPubSubTopic().getName(),
-                offsetRecord.getLocalVersionTopicOffset() == -1
-                    ? PubSubSymbolicPosition.EARLIEST
-                    // TODO: Remove once we populate PubSubPosition for local version topic offset
-                    : ApacheKafkaOffsetPosition.of(offsetRecord.getLocalVersionTopicOffset()),
+                offsetRecord.getLocalVersionTopicOffset(),
                 partition);
           } else {
             localCheckpoint = VeniceChangeCoordinate

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/consumer/VeniceAfterImageConsumerImpl.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/consumer/VeniceAfterImageConsumerImpl.java
@@ -1,7 +1,5 @@
 package com.linkedin.davinci.consumer;
 
-import static com.linkedin.venice.pubsub.api.PubSubSymbolicPosition.LATEST;
-
 import com.linkedin.davinci.repository.NativeMetadataRepositoryViewAdapter;
 import com.linkedin.venice.exceptions.VeniceException;
 import com.linkedin.venice.kafka.protocol.ControlMessage;
@@ -140,7 +138,7 @@ public class VeniceAfterImageConsumerImpl<K, V> extends VeniceChangelogConsumerI
             topicPartition.getPartitionNumber(),
             new VeniceChangeCoordinate(
                 topicPartition.getPubSubTopic().getName(),
-                LATEST,
+                PubSubSymbolicPosition.LATEST,
                 topicPartition.getPartitionNumber()));
       } else if (checkpoints.get(topicPartition.getPartitionNumber()) == null) {
         LOGGER.warn("No EOP checkpoint found for partition: {}", topicPartition.getPartitionNumber());

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/ingestion/DefaultIngestionBackend.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/ingestion/DefaultIngestionBackend.java
@@ -300,7 +300,7 @@ public class DefaultIngestionBackend implements IngestionBackend {
       }
     } else {
       if (offsetRecord.getOffsetLag() == 0
-          && offsetRecord.getLocalVersionTopicOffset() == PubSubSymbolicPosition.EARLIEST) {
+          && PubSubSymbolicPosition.EARLIEST.equals(offsetRecord.getLocalVersionTopicOffset())) {
         LOGGER.info(
             "Offset lag is 0 and topic offset is EARLIEST for replica {}.",
             Utils.getReplicaId(topicName, partition));

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/ingestion/DefaultIngestionBackend.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/ingestion/DefaultIngestionBackend.java
@@ -16,6 +16,7 @@ import com.linkedin.venice.meta.Store;
 import com.linkedin.venice.meta.StoreVersionInfo;
 import com.linkedin.venice.meta.Version;
 import com.linkedin.venice.offsets.OffsetRecord;
+import com.linkedin.venice.pubsub.api.PubSubSymbolicPosition;
 import com.linkedin.venice.store.rocksdb.RocksDBUtils;
 import com.linkedin.venice.utils.Utils;
 import com.linkedin.venice.utils.concurrent.VeniceConcurrentHashMap;
@@ -298,8 +299,11 @@ public class DefaultIngestionBackend implements IngestionBackend {
         return false;
       }
     } else {
-      if (offsetRecord.getOffsetLag() == 0 && offsetRecord.getLocalVersionTopicOffset() == -1) {
-        LOGGER.info("Offset lag is 0 and topic offset is -1 for replica {}.", Utils.getReplicaId(topicName, partition));
+      if (offsetRecord.getOffsetLag() == 0
+          && offsetRecord.getLocalVersionTopicOffset() == PubSubSymbolicPosition.EARLIEST) {
+        LOGGER.info(
+            "Offset lag is 0 and topic offset is EARLIEST for replica {}.",
+            Utils.getReplicaId(topicName, partition));
         return true;
       }
 

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/ingestion/DefaultIngestionBackend.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/ingestion/DefaultIngestionBackend.java
@@ -300,7 +300,7 @@ public class DefaultIngestionBackend implements IngestionBackend {
       }
     } else {
       if (offsetRecord.getOffsetLag() == 0
-          && PubSubSymbolicPosition.EARLIEST.equals(offsetRecord.getLocalVersionTopicOffset())) {
+          && PubSubSymbolicPosition.EARLIEST.equals(offsetRecord.getCheckpointedLocalVtPosition())) {
         LOGGER.info(
             "Offset lag is 0 and topic offset is EARLIEST for replica {}.",
             Utils.getReplicaId(topicName, partition));

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/AbstractKafkaConsumerService.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/AbstractKafkaConsumerService.java
@@ -2,6 +2,7 @@ package com.linkedin.davinci.kafka.consumer;
 
 import com.linkedin.davinci.ingestion.consumption.ConsumedDataReceiver;
 import com.linkedin.venice.pubsub.api.DefaultPubSubMessage;
+import com.linkedin.venice.pubsub.api.PubSubPosition;
 import com.linkedin.venice.pubsub.api.PubSubTopic;
 import com.linkedin.venice.pubsub.api.PubSubTopicPartition;
 import com.linkedin.venice.service.AbstractVeniceService;
@@ -33,7 +34,7 @@ public abstract class AbstractKafkaConsumerService extends AbstractVeniceService
 
   public abstract void startConsumptionIntoDataReceiver(
       PartitionReplicaIngestionContext partitionReplicaIngestionContext,
-      long lastReadOffset,
+      PubSubPosition lastReadOffset,
       ConsumedDataReceiver<List<DefaultPubSubMessage>> consumedDataReceiver);
 
   public abstract long getLatestOffsetBasedOnMetrics(

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/AbstractKafkaConsumerService.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/AbstractKafkaConsumerService.java
@@ -34,7 +34,7 @@ public abstract class AbstractKafkaConsumerService extends AbstractVeniceService
 
   public abstract void startConsumptionIntoDataReceiver(
       PartitionReplicaIngestionContext partitionReplicaIngestionContext,
-      PubSubPosition lastReadOffset,
+      PubSubPosition lastReadPosition,
       ConsumedDataReceiver<List<DefaultPubSubMessage>> consumedDataReceiver);
 
   public abstract long getLatestOffsetBasedOnMetrics(

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/ActiveActiveStoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/ActiveActiveStoreIngestionTask.java
@@ -978,7 +978,7 @@ public class ActiveActiveStoreIngestionTask extends LeaderFollowerStoreIngestion
     Map<String, PubSubPosition> upstreamOffsetsByKafkaURLs = new HashMap<>(sourceKafkaServers.size());
     sourceKafkaServers.forEach(sourceKafkaURL -> {
       PubSubPosition upstreamStartOffset = partitionConsumptionState.getLatestProcessedUpstreamRTOffset(sourceKafkaURL);
-      if (upstreamStartOffset == PubSubSymbolicPosition.EARLIEST) {
+      if (PubSubSymbolicPosition.EARLIEST.equals(upstreamStartOffset)) {
         if (rewindStartTimestamp > 0) {
           PubSubTopicPartition newSourceTopicPartition =
               resolveTopicPartitionWithKafkaURL(newSourceTopic, partitionConsumptionState, sourceKafkaURL);

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/ActiveActiveStoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/ActiveActiveStoreIngestionTask.java
@@ -1084,11 +1084,11 @@ public class ActiveActiveStoreIngestionTask extends LeaderFollowerStoreIngestion
    */
   public void consumerSubscribe(
       PubSubTopicPartition pubSubTopicPartition,
-      PubSubPosition startOffset,
+      PubSubPosition startPosition,
       String pubSubAddress) {
     VeniceServerConfig serverConfig = getServerConfig();
     if (isDaVinciClient() || serverConfig.getKafkaClusterUrlToIdMap().containsKey(pubSubAddress)) {
-      super.consumerSubscribe(pubSubTopicPartition, startOffset, pubSubAddress);
+      super.consumerSubscribe(pubSubTopicPartition, startPosition, pubSubAddress);
       return;
     }
     LOGGER.error(
@@ -1146,13 +1146,13 @@ public class ActiveActiveStoreIngestionTask extends LeaderFollowerStoreIngestion
   }
 
   /**
-   * Process {@link TopicSwitch} control message at given partition offset for a specific {@link PartitionConsumptionState}.
+   * Process {@link TopicSwitch} control message at given partition position for a specific {@link PartitionConsumptionState}.
    */
   @Override
   protected void processTopicSwitch(
       ControlMessage controlMessage,
       int partition,
-      PubSubPosition offset,
+      PubSubPosition position,
       PartitionConsumptionState partitionConsumptionState) {
     TopicSwitch topicSwitch = (TopicSwitch) controlMessage.controlMessageUnion;
     ingestionNotificationDispatcher.reportTopicSwitchReceived(partitionConsumptionState);

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/AggKafkaConsumerService.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/AggKafkaConsumerService.java
@@ -13,6 +13,7 @@ import com.linkedin.venice.pubsub.PubSubConsumerAdapterFactory;
 import com.linkedin.venice.pubsub.api.DefaultPubSubMessage;
 import com.linkedin.venice.pubsub.api.PubSubConsumerAdapter;
 import com.linkedin.venice.pubsub.api.PubSubMessageDeserializer;
+import com.linkedin.venice.pubsub.api.PubSubPosition;
 import com.linkedin.venice.pubsub.api.PubSubTopic;
 import com.linkedin.venice.pubsub.api.PubSubTopicPartition;
 import com.linkedin.venice.pubsub.manager.TopicManager;
@@ -431,7 +432,7 @@ public class AggKafkaConsumerService extends AbstractVeniceService {
       final String kafkaURL,
       StoreIngestionTask storeIngestionTask,
       PartitionReplicaIngestionContext partitionReplicaIngestionContext,
-      long lastOffset) {
+      PubSubPosition lastOffset) {
     PubSubTopic versionTopic = storeIngestionTask.getVersionTopic();
     PubSubTopicPartition pubSubTopicPartition = partitionReplicaIngestionContext.getPubSubTopicPartition();
     AbstractKafkaConsumerService consumerService =

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/IngestionNotificationDispatcher.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/IngestionNotificationDispatcher.java
@@ -288,7 +288,7 @@ class IngestionNotificationDispatcher {
         notifier -> notifier.dataRecoveryCompleted(
             topic,
             pcs.getPartition(),
-            pcs.getOffsetRecord().getLocalVersionTopicOffset().getNumericOffset(),
+            pcs.getOffsetRecord().getCheckpointedLocalVtPosition().getNumericOffset(),
             ""));
   }
 

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/IngestionNotificationDispatcher.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/IngestionNotificationDispatcher.java
@@ -111,7 +111,8 @@ class IngestionNotificationDispatcher {
     report(
         pcs,
         ExecutionStatus.STARTED,
-        notifier -> notifier.restarted(topic, pcs.getPartition(), pcs.getLatestProcessedLocalVersionTopicOffset()));
+        notifier -> notifier
+            .restarted(topic, pcs.getPartition(), pcs.getLatestProcessedLocalVersionTopicOffset().getNumericOffset()));
   }
 
   void reportCatchUpVersionTopicOffsetLag(PartitionConsumptionState pcs) {
@@ -137,7 +138,7 @@ class IngestionNotificationDispatcher {
       notifier.completed(
           topic,
           pcs.getPartition(),
-          pcs.getLatestProcessedLocalVersionTopicOffset(),
+          pcs.getLatestProcessedLocalVersionTopicOffset().getNumericOffset(),
           pcs.getLeaderFollowerState().toString());
       pcs.releaseLatch();
       pcs.completionReported();
@@ -170,8 +171,10 @@ class IngestionNotificationDispatcher {
     report(
         pcs,
         HybridStoreQuotaStatus.QUOTA_NOT_VIOLATED,
-        notifier -> notifier
-            .quotaNotViolated(topic, pcs.getPartition(), pcs.getLatestProcessedLocalVersionTopicOffset()),
+        notifier -> notifier.quotaNotViolated(
+            topic,
+            pcs.getPartition(),
+            pcs.getLatestProcessedLocalVersionTopicOffset().getNumericOffset()),
         () -> checkQuotaStatusReported(pcs.getPartition(), HybridStoreQuotaStatus.QUOTA_NOT_VIOLATED));
   }
 
@@ -179,7 +182,10 @@ class IngestionNotificationDispatcher {
     report(
         pcs,
         HybridStoreQuotaStatus.QUOTA_VIOLATED,
-        notifier -> notifier.quotaViolated(topic, pcs.getPartition(), pcs.getLatestProcessedLocalVersionTopicOffset()),
+        notifier -> notifier.quotaViolated(
+            topic,
+            pcs.getPartition(),
+            pcs.getLatestProcessedLocalVersionTopicOffset().getNumericOffset()),
         () -> checkQuotaStatusReported(pcs.getPartition(), HybridStoreQuotaStatus.QUOTA_VIOLATED));
   }
 
@@ -202,7 +208,8 @@ class IngestionNotificationDispatcher {
     report(
         pcs,
         ExecutionStatus.PROGRESS,
-        notifier -> notifier.progress(topic, pcs.getPartition(), pcs.getLatestProcessedLocalVersionTopicOffset()),
+        notifier -> notifier
+            .progress(topic, pcs.getPartition(), pcs.getLatestProcessedLocalVersionTopicOffset().getNumericOffset()),
         () -> {
 
           // Progress reporting happens too frequently for each Kafka Pull,
@@ -234,8 +241,10 @@ class IngestionNotificationDispatcher {
     report(
         pcs,
         ExecutionStatus.END_OF_PUSH_RECEIVED,
-        notifier -> notifier
-            .endOfPushReceived(topic, pcs.getPartition(), pcs.getLatestProcessedLocalVersionTopicOffset()));
+        notifier -> notifier.endOfPushReceived(
+            topic,
+            pcs.getPartition(),
+            pcs.getLatestProcessedLocalVersionTopicOffset().getNumericOffset()));
   }
 
   void reportStartOfIncrementalPushReceived(PartitionConsumptionState pcs, String version) {
@@ -245,7 +254,7 @@ class IngestionNotificationDispatcher {
         notifier -> notifier.startOfIncrementalPushReceived(
             topic,
             pcs.getPartition(),
-            pcs.getLatestProcessedLocalVersionTopicOffset(),
+            pcs.getLatestProcessedLocalVersionTopicOffset().getNumericOffset(),
             version));
   }
 
@@ -256,7 +265,7 @@ class IngestionNotificationDispatcher {
         notifier -> notifier.endOfIncrementalPushReceived(
             topic,
             pcs.getPartition(),
-            pcs.getLatestProcessedLocalVersionTopicOffset(),
+            pcs.getLatestProcessedLocalVersionTopicOffset().getNumericOffset(),
             version));
   }
 
@@ -267,7 +276,7 @@ class IngestionNotificationDispatcher {
         notifier -> notifier.batchEndOfIncrementalPushReceived(
             topic,
             pcs.getPartition(),
-            pcs.getLatestProcessedLocalVersionTopicOffset(),
+            pcs.getLatestProcessedLocalVersionTopicOffset().getNumericOffset(),
             pcs.getPendingReportIncPushVersionList()));
   }
 
@@ -275,16 +284,21 @@ class IngestionNotificationDispatcher {
     report(
         pcs,
         ExecutionStatus.TOPIC_SWITCH_RECEIVED,
-        notifier -> notifier
-            .topicSwitchReceived(topic, pcs.getPartition(), pcs.getLatestProcessedLocalVersionTopicOffset()));
+        notifier -> notifier.topicSwitchReceived(
+            topic,
+            pcs.getPartition(),
+            pcs.getLatestProcessedLocalVersionTopicOffset().getNumericOffset()));
   }
 
   void reportDataRecoveryCompleted(PartitionConsumptionState pcs) {
     report(
         pcs,
         ExecutionStatus.DATA_RECOVERY_COMPLETED,
-        notifier -> notifier
-            .dataRecoveryCompleted(topic, pcs.getPartition(), pcs.getOffsetRecord().getLocalVersionTopicOffset(), ""));
+        notifier -> notifier.dataRecoveryCompleted(
+            topic,
+            pcs.getPartition(),
+            pcs.getOffsetRecord().getLocalVersionTopicOffset().getNumericOffset(),
+            ""));
   }
 
   void reportError(int partition, String message, Exception consumerEx) {
@@ -357,7 +371,7 @@ class IngestionNotificationDispatcher {
 
   void reportStopped(PartitionConsumptionState pcs) {
     report(pcs, "STOPPED", notifier -> {
-      notifier.stopped(topic, pcs.getPartition(), pcs.getLatestProcessedLocalVersionTopicOffset());
+      notifier.stopped(topic, pcs.getPartition(), pcs.getLatestProcessedLocalVersionTopicOffset().getNumericOffset());
     }, () -> true);
   }
 

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/IngestionNotificationDispatcher.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/IngestionNotificationDispatcher.java
@@ -112,7 +112,7 @@ class IngestionNotificationDispatcher {
         pcs,
         ExecutionStatus.STARTED,
         notifier -> notifier
-            .restarted(topic, pcs.getPartition(), pcs.getLatestProcessedLocalVersionTopicOffset().getNumericOffset()));
+            .restarted(topic, pcs.getPartition(), pcs.getLatestProcessedVtPosition().getNumericOffset()));
   }
 
   void reportCatchUpVersionTopicOffsetLag(PartitionConsumptionState pcs) {
@@ -138,7 +138,7 @@ class IngestionNotificationDispatcher {
       notifier.completed(
           topic,
           pcs.getPartition(),
-          pcs.getLatestProcessedLocalVersionTopicOffset().getNumericOffset(),
+          pcs.getLatestProcessedVtPosition().getNumericOffset(),
           pcs.getLeaderFollowerState().toString());
       pcs.releaseLatch();
       pcs.completionReported();
@@ -149,7 +149,7 @@ class IngestionNotificationDispatcher {
         LOGGER.error(
             "Processing completed WITH ERRORS for Replica: {}, Last Offset: {}",
             pcs.getReplicaId(),
-            pcs.getLatestProcessedLocalVersionTopicOffset());
+            pcs.getLatestProcessedVtPosition());
         return false;
       }
       if (!forceCompletion && !pcs.isComplete()) {
@@ -171,10 +171,8 @@ class IngestionNotificationDispatcher {
     report(
         pcs,
         HybridStoreQuotaStatus.QUOTA_NOT_VIOLATED,
-        notifier -> notifier.quotaNotViolated(
-            topic,
-            pcs.getPartition(),
-            pcs.getLatestProcessedLocalVersionTopicOffset().getNumericOffset()),
+        notifier -> notifier
+            .quotaNotViolated(topic, pcs.getPartition(), pcs.getLatestProcessedVtPosition().getNumericOffset()),
         () -> checkQuotaStatusReported(pcs.getPartition(), HybridStoreQuotaStatus.QUOTA_NOT_VIOLATED));
   }
 
@@ -182,10 +180,8 @@ class IngestionNotificationDispatcher {
     report(
         pcs,
         HybridStoreQuotaStatus.QUOTA_VIOLATED,
-        notifier -> notifier.quotaViolated(
-            topic,
-            pcs.getPartition(),
-            pcs.getLatestProcessedLocalVersionTopicOffset().getNumericOffset()),
+        notifier -> notifier
+            .quotaViolated(topic, pcs.getPartition(), pcs.getLatestProcessedVtPosition().getNumericOffset()),
         () -> checkQuotaStatusReported(pcs.getPartition(), HybridStoreQuotaStatus.QUOTA_VIOLATED));
   }
 
@@ -208,8 +204,7 @@ class IngestionNotificationDispatcher {
     report(
         pcs,
         ExecutionStatus.PROGRESS,
-        notifier -> notifier
-            .progress(topic, pcs.getPartition(), pcs.getLatestProcessedLocalVersionTopicOffset().getNumericOffset()),
+        notifier -> notifier.progress(topic, pcs.getPartition(), pcs.getLatestProcessedVtPosition().getNumericOffset()),
         () -> {
 
           // Progress reporting happens too frequently for each Kafka Pull,
@@ -241,10 +236,8 @@ class IngestionNotificationDispatcher {
     report(
         pcs,
         ExecutionStatus.END_OF_PUSH_RECEIVED,
-        notifier -> notifier.endOfPushReceived(
-            topic,
-            pcs.getPartition(),
-            pcs.getLatestProcessedLocalVersionTopicOffset().getNumericOffset()));
+        notifier -> notifier
+            .endOfPushReceived(topic, pcs.getPartition(), pcs.getLatestProcessedVtPosition().getNumericOffset()));
   }
 
   void reportStartOfIncrementalPushReceived(PartitionConsumptionState pcs, String version) {
@@ -254,7 +247,7 @@ class IngestionNotificationDispatcher {
         notifier -> notifier.startOfIncrementalPushReceived(
             topic,
             pcs.getPartition(),
-            pcs.getLatestProcessedLocalVersionTopicOffset().getNumericOffset(),
+            pcs.getLatestProcessedVtPosition().getNumericOffset(),
             version));
   }
 
@@ -265,7 +258,7 @@ class IngestionNotificationDispatcher {
         notifier -> notifier.endOfIncrementalPushReceived(
             topic,
             pcs.getPartition(),
-            pcs.getLatestProcessedLocalVersionTopicOffset().getNumericOffset(),
+            pcs.getLatestProcessedVtPosition().getNumericOffset(),
             version));
   }
 
@@ -276,7 +269,7 @@ class IngestionNotificationDispatcher {
         notifier -> notifier.batchEndOfIncrementalPushReceived(
             topic,
             pcs.getPartition(),
-            pcs.getLatestProcessedLocalVersionTopicOffset().getNumericOffset(),
+            pcs.getLatestProcessedVtPosition().getNumericOffset(),
             pcs.getPendingReportIncPushVersionList()));
   }
 
@@ -284,10 +277,8 @@ class IngestionNotificationDispatcher {
     report(
         pcs,
         ExecutionStatus.TOPIC_SWITCH_RECEIVED,
-        notifier -> notifier.topicSwitchReceived(
-            topic,
-            pcs.getPartition(),
-            pcs.getLatestProcessedLocalVersionTopicOffset().getNumericOffset()));
+        notifier -> notifier
+            .topicSwitchReceived(topic, pcs.getPartition(), pcs.getLatestProcessedVtPosition().getNumericOffset()));
   }
 
   void reportDataRecoveryCompleted(PartitionConsumptionState pcs) {
@@ -371,7 +362,7 @@ class IngestionNotificationDispatcher {
 
   void reportStopped(PartitionConsumptionState pcs) {
     report(pcs, "STOPPED", notifier -> {
-      notifier.stopped(topic, pcs.getPartition(), pcs.getLatestProcessedLocalVersionTopicOffset().getNumericOffset());
+      notifier.stopped(topic, pcs.getPartition(), pcs.getLatestProcessedVtPosition().getNumericOffset());
     }, () -> true);
   }
 

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/KafkaConsumerService.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/KafkaConsumerService.java
@@ -430,7 +430,7 @@ public abstract class KafkaConsumerService extends AbstractKafkaConsumerService 
   @Override
   public void startConsumptionIntoDataReceiver(
       PartitionReplicaIngestionContext partitionReplicaIngestionContext,
-      PubSubPosition lastReadOffset,
+      PubSubPosition lastReadPosition,
       ConsumedDataReceiver<List<DefaultPubSubMessage>> consumedDataReceiver) {
     PubSubTopic versionTopic = consumedDataReceiver.destinationIdentifier();
     PubSubTopicPartition topicPartition = partitionReplicaIngestionContext.getPubSubTopicPartition();
@@ -459,7 +459,7 @@ public abstract class KafkaConsumerService extends AbstractKafkaConsumerService 
        * {@link KafkaConsumerService.ConsumptionTask} will not be able to funnel the messages.
        */
       consumptionTask.setDataReceiver(topicPartition, consumedDataReceiver);
-      consumer.subscribe(consumedDataReceiver.destinationIdentifier(), topicPartition, lastReadOffset);
+      consumer.subscribe(consumedDataReceiver.destinationIdentifier(), topicPartition, lastReadPosition);
       consumerPollTracker.recordSubscribed(topicPartition);
     }
   }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/KafkaConsumerService.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/KafkaConsumerService.java
@@ -14,6 +14,7 @@ import com.linkedin.venice.pubsub.PubSubConsumerAdapterFactory;
 import com.linkedin.venice.pubsub.api.DefaultPubSubMessage;
 import com.linkedin.venice.pubsub.api.PubSubConsumerAdapter;
 import com.linkedin.venice.pubsub.api.PubSubMessageDeserializer;
+import com.linkedin.venice.pubsub.api.PubSubPosition;
 import com.linkedin.venice.pubsub.api.PubSubTopic;
 import com.linkedin.venice.pubsub.api.PubSubTopicPartition;
 import com.linkedin.venice.utils.ExceptionUtils;
@@ -429,7 +430,7 @@ public abstract class KafkaConsumerService extends AbstractKafkaConsumerService 
   @Override
   public void startConsumptionIntoDataReceiver(
       PartitionReplicaIngestionContext partitionReplicaIngestionContext,
-      long lastReadOffset,
+      PubSubPosition lastReadOffset,
       ConsumedDataReceiver<List<DefaultPubSubMessage>> consumedDataReceiver) {
     PubSubTopic versionTopic = consumedDataReceiver.destinationIdentifier();
     PubSubTopicPartition topicPartition = partitionReplicaIngestionContext.getPubSubTopicPartition();

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/KafkaConsumerServiceDelegator.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/KafkaConsumerServiceDelegator.java
@@ -4,6 +4,7 @@ import com.linkedin.davinci.config.VeniceServerConfig;
 import com.linkedin.davinci.ingestion.consumption.ConsumedDataReceiver;
 import com.linkedin.venice.exceptions.VeniceException;
 import com.linkedin.venice.pubsub.api.DefaultPubSubMessage;
+import com.linkedin.venice.pubsub.api.PubSubPosition;
 import com.linkedin.venice.pubsub.api.PubSubTopic;
 import com.linkedin.venice.pubsub.api.PubSubTopicPartition;
 import com.linkedin.venice.utils.concurrent.VeniceConcurrentHashMap;
@@ -195,7 +196,7 @@ public class KafkaConsumerServiceDelegator extends AbstractKafkaConsumerService 
   @Override
   public void startConsumptionIntoDataReceiver(
       PartitionReplicaIngestionContext partitionReplicaIngestionContext,
-      long lastReadOffset,
+      PubSubPosition lastReadOffset,
       ConsumedDataReceiver<List<DefaultPubSubMessage>> consumedDataReceiver) {
     assignKafkaConsumerServiceFor(partitionReplicaIngestionContext)
         .startConsumptionIntoDataReceiver(partitionReplicaIngestionContext, lastReadOffset, consumedDataReceiver);

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/KafkaConsumerServiceDelegator.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/KafkaConsumerServiceDelegator.java
@@ -196,10 +196,10 @@ public class KafkaConsumerServiceDelegator extends AbstractKafkaConsumerService 
   @Override
   public void startConsumptionIntoDataReceiver(
       PartitionReplicaIngestionContext partitionReplicaIngestionContext,
-      PubSubPosition lastReadOffset,
+      PubSubPosition lastReadPosition,
       ConsumedDataReceiver<List<DefaultPubSubMessage>> consumedDataReceiver) {
     assignKafkaConsumerServiceFor(partitionReplicaIngestionContext)
-        .startConsumptionIntoDataReceiver(partitionReplicaIngestionContext, lastReadOffset, consumedDataReceiver);
+        .startConsumptionIntoDataReceiver(partitionReplicaIngestionContext, lastReadPosition, consumedDataReceiver);
   }
 
   @Override

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTask.java
@@ -1028,7 +1028,7 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
     PubSubPosition upstreamStartOffset = partitionConsumptionState
         .getLeaderOffset(OffsetRecord.NON_AA_REPLICATION_UPSTREAM_OFFSET_MAP_KEY, pubSubTopicRepository, useLcro);
     String leaderSourceKafkaURL = leaderSourceKafkaURLs.iterator().next();
-    if (upstreamStartOffset == PubSubSymbolicPosition.EARLIEST && leaderTopic.isRealTime()) {
+    if (PubSubSymbolicPosition.EARLIEST.equals(upstreamStartOffset) && leaderTopic.isRealTime()) {
       upstreamStartOffset =
           calculateLeaderUpstreamOffsetWithTopicSwitch(partitionConsumptionState, leaderTopic, Collections.emptyList())
               .getOrDefault(OffsetRecord.NON_AA_REPLICATION_UPSTREAM_OFFSET_MAP_KEY, PubSubSymbolicPosition.EARLIEST);

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTask.java
@@ -1454,7 +1454,7 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
       upstreamTopic = versionTopic;
     }
     if (upstreamTopic.isRealTime()) {
-      offsetRecord.updateUpstreamOffsets(partitionConsumptionState.getLatestProcessedRtPositions());
+      offsetRecord.checkpointRtPositions(partitionConsumptionState.getLatestProcessedRtPositions());
     } else {
       offsetRecord.checkpointRemoteVtPosition(partitionConsumptionState.getLatestProcessedRemoteVtPosition());
     }
@@ -2635,7 +2635,7 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
           case TOPIC_SWITCH:
             /**
              * For TOPIC_SWITCH message we should use -1 as consumedOffset. This will ensure that it does not update the
-             * setLeaderUpstreamOffset in:
+             * checkpointRtPosition in:
              * {@link #updateOffsetsAsRemoteConsumeLeader(PartitionConsumptionState, LeaderProducedRecordContext, String, PubSubMessage, UpdateVersionTopicOffset, UpdateUpstreamTopicOffset)}
              * The leaderUpstreamOffset is set from the TS message config itself. We should not override it.
              */

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/PartitionConsumptionState.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/PartitionConsumptionState.java
@@ -295,7 +295,7 @@ public class PartitionConsumptionState {
     }
     // Restore in-memory latest consumed version topic position and leader info from the checkpoint version topic
     // position
-    this.latestProcessedVtPosition = offsetRecord.getLocalVersionTopicOffset();
+    this.latestProcessedVtPosition = offsetRecord.getCheckpointedLocalVtPosition();
     this.latestProcessedRemoteVtPosition = offsetRecord.getCheckpointedRemoteVtPosition();
     this.leaderHostId = offsetRecord.getLeaderHostId();
     this.leaderGUID = offsetRecord.getLeaderGUID();

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/PartitionConsumptionState.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/PartitionConsumptionState.java
@@ -1,7 +1,6 @@
 package com.linkedin.davinci.kafka.consumer;
 
 import static java.util.concurrent.TimeUnit.MINUTES;
-import static com.linkedin.venice.pubsub.api.PubSubSymbolicPosition.EARLIEST;
 
 import com.linkedin.davinci.helix.LeaderFollowerPartitionStateModel;
 import com.linkedin.davinci.utils.ByteArrayKey;
@@ -298,7 +297,7 @@ public class PartitionConsumptionState {
   }
 
   public boolean isStarted() {
-    return getLatestProcessedLocalVersionTopicOffset() != EARLIEST;
+    return !PubSubSymbolicPosition.EARLIEST.equals(getLatestProcessedLocalVersionTopicOffset());
   }
 
   public final boolean isEndOfPushReceived() {
@@ -725,7 +724,7 @@ public class PartitionConsumptionState {
   public PubSubPosition getLatestProcessedUpstreamRTOffset(String kafkaUrl) {
     PubSubPosition latestProcessedUpstreamRTOffset =
         getLatestProcessedUpstreamRTOffsetMap().getOrDefault(kafkaUrl, PubSubSymbolicPosition.EARLIEST);
-    if (latestProcessedUpstreamRTOffset == PubSubSymbolicPosition.EARLIEST) {
+    if (PubSubSymbolicPosition.EARLIEST.equals(latestProcessedUpstreamRTOffset)) {
       /**
        * When processing {@link TopicSwitch} control message, only the checkpoint upstream offset maps in {@link OffsetRecord}
        * will be updated, since those offset are not processed yet; so when leader try to get the upstream offsets for the very

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/PartitionConsumptionState.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/PartitionConsumptionState.java
@@ -290,8 +290,8 @@ public class PartitionConsumptionState {
     divRtCheckpointPositions = new VeniceConcurrentHashMap<>(3);
     latestProcessedRtPositions = new VeniceConcurrentHashMap<>(3);
     if (offsetRecord.getLeaderTopic() != null && Version.isRealTimeTopic(offsetRecord.getLeaderTopic())) {
-      offsetRecord.cloneUpstreamOffsetMap(latestConsumedRtPositions);
-      offsetRecord.cloneUpstreamOffsetMap(latestProcessedRtPositions);
+      offsetRecord.cloneRtPositionCheckpoints(latestConsumedRtPositions);
+      offsetRecord.cloneRtPositionCheckpoints(latestProcessedRtPositions);
     }
     // Restore in-memory latest consumed version topic position and leader info from the checkpoint version topic
     // position
@@ -863,7 +863,7 @@ public class PartitionConsumptionState {
        * will be updated, since those offset are not processed yet; so when leader try to get the upstream offsets for the very
        * first time, there are no records in {@link #latestProcessedRtPositions} yet.
        */
-      return getOffsetRecord().getUpstreamOffset(pubSubBrokerAddress);
+      return getOffsetRecord().getCheckpointedRtPosition(pubSubBrokerAddress);
     }
     return rtPosition;
   }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/SharedKafkaConsumer.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/SharedKafkaConsumer.java
@@ -154,7 +154,7 @@ class SharedKafkaConsumer implements PubSubConsumerAdapter {
   synchronized void subscribe(
       PubSubTopic versionTopic,
       PubSubTopicPartition topicPartitionToSubscribe,
-      long lastReadOffset) {
+      PubSubPosition lastReadOffset) {
     long delegateSubscribeStartTime = System.currentTimeMillis();
     this.delegate.subscribe(topicPartitionToSubscribe, lastReadOffset);
     PubSubTopic previousVersionTopic =

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/SharedKafkaConsumer.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/SharedKafkaConsumer.java
@@ -154,9 +154,9 @@ class SharedKafkaConsumer implements PubSubConsumerAdapter {
   synchronized void subscribe(
       PubSubTopic versionTopic,
       PubSubTopicPartition topicPartitionToSubscribe,
-      PubSubPosition lastReadOffset) {
+      PubSubPosition lastReadPosition) {
     long delegateSubscribeStartTime = System.currentTimeMillis();
-    this.delegate.subscribe(topicPartitionToSubscribe, lastReadOffset);
+    this.delegate.subscribe(topicPartitionToSubscribe, lastReadPosition);
     PubSubTopic previousVersionTopic =
         subscribedTopicPartitionToVersionTopic.put(topicPartitionToSubscribe, versionTopic);
     if (previousVersionTopic != null && !previousVersionTopic.equals(versionTopic)) {

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
@@ -911,7 +911,7 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
       PartitionConsumptionState partitionConsumptionState) {
     String replicaId = getReplicaId(topic, partitionId);
     boolean returnStatus = true;
-    if (!PubSubSymbolicPosition.EARLIEST.equals(offsetRecord.getLocalVersionTopicOffset())) {
+    if (!PubSubSymbolicPosition.EARLIEST.equals(offsetRecord.getCheckpointedLocalVtPosition())) {
       StoreVersionState storeVersionState = storageEngine.getStoreVersionState();
       if (storeVersionState != null) {
         LOGGER.info("Found storeVersionState for replica: {}: checkDatabaseIntegrity will proceed", replicaId);
@@ -2144,7 +2144,7 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
     // Once storage node restart, send the "START" status to controller to rebuild the task status.
     // If this storage node has never consumed data from this topic, instead of sending "START" here, we send it
     // once START_OF_PUSH message has been read.
-    if (!PubSubSymbolicPosition.EARLIEST.equals(offsetRecord.getLocalVersionTopicOffset())) {
+    if (!PubSubSymbolicPosition.EARLIEST.equals(offsetRecord.getCheckpointedLocalVtPosition())) {
       StoreVersionState storeVersionState = storageEngine.getStoreVersionState();
       if (storeVersionState != null) {
         boolean sorted = storeVersionState.sorted;
@@ -2792,7 +2792,7 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
     pcs.resetProcessedRecordSizeSinceLastSync();
     String msg = "Offset synced for replica: " + pcs.getReplicaId() + " - localVtOffset: {}";
     if (!REDUNDANT_LOGGING_FILTER.isRedundantException(msg)) {
-      LOGGER.info(msg, offsetRecord.getLocalVersionTopicOffset());
+      LOGGER.info(msg, offsetRecord.getCheckpointedLocalVtPosition());
     }
   }
 

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
@@ -4821,7 +4821,7 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
    * Otherwise, the drainer's latest processed VT offset is traditionally used.
    */
   PubSubPosition getLocalVtSubscribeOffset(PartitionConsumptionState pcs) {
-    return (isGlobalRtDivEnabled()) ? pcs.getLatestConsumedVtOffset() : pcs.getLatestProcessedLocalVersionTopicOffset();
+    return (isGlobalRtDivEnabled()) ? pcs.getLatestConsumedVtOffset() : pcs.getLatestProcessedVtPosition();
   }
 
   public StorageUtilizationManager getStorageUtilizationManager() {

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
@@ -4821,7 +4821,7 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
    * Otherwise, the drainer's latest processed VT offset is traditionally used.
    */
   PubSubPosition getLocalVtSubscribeOffset(PartitionConsumptionState pcs) {
-    return (isGlobalRtDivEnabled()) ? pcs.getLatestConsumedVtOffset() : pcs.getLatestProcessedVtPosition();
+    return (isGlobalRtDivEnabled()) ? pcs.getLatestConsumedVtPosition() : pcs.getLatestProcessedVtPosition();
   }
 
   public StorageUtilizationManager getStorageUtilizationManager() {

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/store/view/ChangeCaptureViewWriter.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/store/view/ChangeCaptureViewWriter.java
@@ -13,6 +13,7 @@ import com.linkedin.venice.kafka.protocol.VersionSwap;
 import com.linkedin.venice.kafka.protocol.enums.ControlMessageType;
 import com.linkedin.venice.message.KafkaKey;
 import com.linkedin.venice.meta.Version;
+import com.linkedin.venice.pubsub.api.PubSubPosition;
 import com.linkedin.venice.pubsub.api.PubSubSymbolicPosition;
 import com.linkedin.venice.schema.rmd.RmdUtils;
 import com.linkedin.venice.utils.VeniceProperties;
@@ -125,7 +126,8 @@ public class ChangeCaptureViewWriter extends VeniceViewWriter {
       return;
     }
 
-    Map<String, Long> sortedWaterMarkOffsets = partitionConsumptionState.getLatestProcessedUpstreamRTOffsetMap();
+    Map<String, PubSubPosition> sortedWaterMarkOffsets =
+        partitionConsumptionState.getLatestProcessedUpstreamRTOffsetMap();
 
     List<Long> highWaterMarkOffsets;
     /**
@@ -139,7 +141,10 @@ public class ChangeCaptureViewWriter extends VeniceViewWriter {
       for (String url: sortedWaterMarkOffsets.keySet()) {
         highWaterMarkOffsets.set(
             kafkaClusterUrlToIdMap.getInt(url),
-            partitionConsumptionState.getLatestProcessedUpstreamRTOffsetMap().get(url));
+            partitionConsumptionState.getLatestProcessedUpstreamRTOffsetMap().get(url).getNumericOffset());
+        highWaterMarkPubSubPositions.set(
+            kafkaClusterUrlToIdMap.getInt(url),
+            partitionConsumptionState.getLatestProcessedUpstreamRTOffsetMap().get(url).toWireFormatBuffer());
       }
     } else {
       highWaterMarkOffsets = Collections.emptyList();

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/store/view/ChangeCaptureViewWriter.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/store/view/ChangeCaptureViewWriter.java
@@ -126,8 +126,7 @@ public class ChangeCaptureViewWriter extends VeniceViewWriter {
       return;
     }
 
-    Map<String, PubSubPosition> sortedWaterMarkOffsets =
-        partitionConsumptionState.getLatestProcessedUpstreamRTOffsetMap();
+    Map<String, PubSubPosition> sortedWaterMarkOffsets = partitionConsumptionState.getLatestProcessedRtPositions();
 
     List<Long> highWaterMarkOffsets;
     /**
@@ -141,10 +140,10 @@ public class ChangeCaptureViewWriter extends VeniceViewWriter {
       for (String url: sortedWaterMarkOffsets.keySet()) {
         highWaterMarkOffsets.set(
             kafkaClusterUrlToIdMap.getInt(url),
-            partitionConsumptionState.getLatestProcessedUpstreamRTOffsetMap().get(url).getNumericOffset());
+            partitionConsumptionState.getLatestProcessedRtPositions().get(url).getNumericOffset());
         highWaterMarkPubSubPositions.set(
             kafkaClusterUrlToIdMap.getInt(url),
-            partitionConsumptionState.getLatestProcessedUpstreamRTOffsetMap().get(url).toWireFormatBuffer());
+            partitionConsumptionState.getLatestProcessedRtPositions().get(url).toWireFormatBuffer());
       }
     } else {
       highWaterMarkOffsets = Collections.emptyList();

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/validation/DataIntegrityValidator.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/validation/DataIntegrityValidator.java
@@ -5,6 +5,7 @@ import com.linkedin.venice.kafka.protocol.GUID;
 import com.linkedin.venice.kafka.protocol.state.ProducerPartitionState;
 import com.linkedin.venice.offsets.OffsetRecord;
 import com.linkedin.venice.pubsub.api.DefaultPubSubMessage;
+import com.linkedin.venice.pubsub.api.PubSubPosition;
 import com.linkedin.venice.utils.SparseConcurrentList;
 import com.linkedin.venice.utils.lazy.Lazy;
 import java.util.HashSet;
@@ -166,7 +167,7 @@ public class DataIntegrityValidator {
         this.logCompactionDelayInMs);
   }
 
-  public void updateLatestConsumedVtOffset(int partition, long offset) {
+  public void updateLatestConsumedVtOffset(int partition, PubSubPosition offset) {
     PartitionTracker partitionTracker = registerPartition(partition);
     partitionTracker.updateLatestConsumedVtOffset(offset);
   }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/validation/DataIntegrityValidator.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/validation/DataIntegrityValidator.java
@@ -169,7 +169,7 @@ public class DataIntegrityValidator {
 
   public void updateLatestConsumedVtOffset(int partition, PubSubPosition offset) {
     PartitionTracker partitionTracker = registerPartition(partition);
-    partitionTracker.updateLatestConsumedVtOffset(offset);
+    partitionTracker.updateLatestConsumedVtPosition(offset);
   }
 
   /**

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/validation/PartitionTracker.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/validation/PartitionTracker.java
@@ -83,7 +83,7 @@ public class PartitionTracker {
   /**
    * The equivalent for RT is not stored. It's the instantaneous offset when a DIV sync is triggered.
    */
-  private final AtomicReference<PubSubPosition> latestConsumedVtOffset =
+  private final AtomicReference<PubSubPosition> latestConsumedVtPosition =
       new AtomicReference(PubSubSymbolicPosition.EARLIEST);
 
   /**
@@ -107,12 +107,12 @@ public class PartitionTracker {
     return partition;
   }
 
-  public PubSubPosition getLatestConsumedVtOffset() {
-    return latestConsumedVtOffset.get();
+  public PubSubPosition getLatestConsumedVtPosition() {
+    return latestConsumedVtPosition.get();
   }
 
-  public void updateLatestConsumedVtOffset(PubSubPosition offset) {
-    latestConsumedVtOffset.updateAndGet(current -> offset);
+  public void updateLatestConsumedVtPosition(PubSubPosition vtPosition) {
+    latestConsumedVtPosition.updateAndGet(current -> vtPosition);
   }
 
   public final String toString() {
@@ -201,7 +201,7 @@ public class PartitionTracker {
     for (Map.Entry<GUID, Segment> entry: vtSegments.entrySet()) {
       destProducerTracker.setSegment(PartitionTracker.VERSION_TOPIC, entry.getKey(), new Segment(entry.getValue()));
     }
-    destProducerTracker.updateLatestConsumedVtOffset(latestConsumedVtOffset.get());
+    destProducerTracker.updateLatestConsumedVtPosition(latestConsumedVtPosition.get());
   }
 
   /**
@@ -229,7 +229,7 @@ public class PartitionTracker {
     ProducerPartitionState state;
     if (TopicType.isVersionTopic(type)) {
       state = offsetRecord.getProducerPartitionState(guid);
-      offsetRecord.setLatestConsumedVtPosition(getLatestConsumedVtOffset());
+      offsetRecord.setLatestConsumedVtPosition(getLatestConsumedVtPosition());
     } else {
       state = offsetRecord.getRealTimeProducerState(type.getKafkaUrl(), guid);
     }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/validation/PartitionTracker.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/validation/PartitionTracker.java
@@ -23,6 +23,8 @@ import com.linkedin.venice.kafka.validation.Segment;
 import com.linkedin.venice.kafka.validation.checksum.CheckSumType;
 import com.linkedin.venice.offsets.OffsetRecord;
 import com.linkedin.venice.pubsub.api.DefaultPubSubMessage;
+import com.linkedin.venice.pubsub.api.PubSubPosition;
+import com.linkedin.venice.pubsub.api.PubSubSymbolicPosition;
 import com.linkedin.venice.utils.ByteUtils;
 import com.linkedin.venice.utils.CollectionUtils;
 import com.linkedin.venice.utils.LatencyUtils;
@@ -37,7 +39,7 @@ import java.util.Iterator;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
-import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import org.apache.logging.log4j.LogManager;
@@ -81,7 +83,8 @@ public class PartitionTracker {
   /**
    * The equivalent for RT is not stored. It's the instantaneous offset when a DIV sync is triggered.
    */
-  private final AtomicLong latestConsumedVtOffset = new AtomicLong(0L);
+  private final AtomicReference<PubSubPosition> latestConsumedVtOffset =
+      new AtomicReference(PubSubSymbolicPosition.EARLIEST);
 
   /**
    * rtSegments is a map of source broker URL to a map of GUID to Segment.
@@ -104,11 +107,11 @@ public class PartitionTracker {
     return partition;
   }
 
-  public long getLatestConsumedVtOffset() {
+  public PubSubPosition getLatestConsumedVtOffset() {
     return latestConsumedVtOffset.get();
   }
 
-  public void updateLatestConsumedVtOffset(long offset) {
+  public void updateLatestConsumedVtOffset(PubSubPosition offset) {
     latestConsumedVtOffset.updateAndGet(current -> offset);
   }
 

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/validation/PartitionTracker.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/validation/PartitionTracker.java
@@ -229,7 +229,7 @@ public class PartitionTracker {
     ProducerPartitionState state;
     if (TopicType.isVersionTopic(type)) {
       state = offsetRecord.getProducerPartitionState(guid);
-      offsetRecord.setLatestConsumedVtOffset(getLatestConsumedVtOffset());
+      offsetRecord.setLatestConsumedVtPosition(getLatestConsumedVtOffset());
     } else {
       state = offsetRecord.getRealTimeProducerState(type.getKafkaUrl(), guid);
     }

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/consumer/InternalLocalBootstrappingVeniceChangelogConsumerTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/consumer/InternalLocalBootstrappingVeniceChangelogConsumerTest.java
@@ -4,7 +4,6 @@ import static com.linkedin.venice.ConfigKeys.CLUSTER_NAME;
 import static com.linkedin.venice.ConfigKeys.KAFKA_BOOTSTRAP_SERVERS;
 import static com.linkedin.venice.ConfigKeys.ZOOKEEPER_ADDRESS;
 import static com.linkedin.venice.offsets.OffsetRecord.LOWEST_OFFSET;
-import static com.linkedin.venice.pubsub.api.PubSubSymbolicPosition.EARLIEST;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyLong;
@@ -50,6 +49,7 @@ import com.linkedin.venice.pubsub.api.DefaultPubSubMessage;
 import com.linkedin.venice.pubsub.api.PubSubConsumerAdapter;
 import com.linkedin.venice.pubsub.api.PubSubMessage;
 import com.linkedin.venice.pubsub.api.PubSubPosition;
+import com.linkedin.venice.pubsub.api.PubSubSymbolicPosition;
 import com.linkedin.venice.pubsub.api.PubSubTopic;
 import com.linkedin.venice.pubsub.api.PubSubTopicPartition;
 import com.linkedin.venice.schema.SchemaEntry;
@@ -232,8 +232,8 @@ public class InternalLocalBootstrappingVeniceChangelogConsumerTest {
     verify(mockStorageService, times(1)).openStoreForNewPartition(any(), eq(1), any());
     verify(metadataRepository, times(2)).subscribe(storeName);
     // During reading from lo
-    verify(pubSubConsumer, times(1)).subscribe(topicPartition_0, EARLIEST, true);
-    verify(pubSubConsumer, times(1)).subscribe(topicPartition_1, EARLIEST, true);
+    verify(pubSubConsumer, times(1)).subscribe(topicPartition_0, PubSubSymbolicPosition.EARLIEST, true);
+    verify(pubSubConsumer, times(1)).subscribe(topicPartition_1, PubSubSymbolicPosition.EARLIEST, true);
     verify(pubSubConsumer, times(1)).subscribe(topicPartition_0, p1, true);
     verify(pubSubConsumer, times(1)).subscribe(topicPartition_1, p1, true);
     verify(pubSubConsumer, times(2)).poll(anyLong());

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/ingestion/DefaultIngestionBackendTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/ingestion/DefaultIngestionBackendTest.java
@@ -97,7 +97,7 @@ public class DefaultIngestionBackendTest {
         .thenReturn(storageEngine);
 
     when(offsetRecord.getOffsetLag()).thenReturn(0L);
-    when(offsetRecord.getLocalVersionTopicOffset()).thenReturn(PubSubSymbolicPosition.EARLIEST);
+    when(offsetRecord.getCheckpointedLocalVtPosition()).thenReturn(PubSubSymbolicPosition.EARLIEST);
     when(storageMetadataService.getLastOffset(Version.composeKafkaTopic(STORE_NAME, VERSION_NUMBER), PARTITION))
         .thenReturn(offsetRecord);
 
@@ -188,7 +188,7 @@ public class DefaultIngestionBackendTest {
   public void testNotStartBootstrapFromBlobTransferWhenNotLaggingForHybridStore() {
     long laggingThreshold = 1000L;
     when(offsetRecord.getOffsetLag()).thenReturn(10L);
-    when(offsetRecord.getLocalVersionTopicOffset()).thenReturn(PubSubUtil.fromKafkaOffset(10L));
+    when(offsetRecord.getCheckpointedLocalVtPosition()).thenReturn(PubSubUtil.fromKafkaOffset(10L));
     when(storageMetadataService.getLastOffset(Version.composeKafkaTopic(STORE_NAME, VERSION_NUMBER), PARTITION))
         .thenReturn(offsetRecord);
 

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/ingestion/DefaultIngestionBackendTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/ingestion/DefaultIngestionBackendTest.java
@@ -31,6 +31,8 @@ import com.linkedin.venice.meta.Store;
 import com.linkedin.venice.meta.StoreVersionInfo;
 import com.linkedin.venice.meta.Version;
 import com.linkedin.venice.offsets.OffsetRecord;
+import com.linkedin.venice.pubsub.PubSubUtil;
+import com.linkedin.venice.pubsub.api.PubSubSymbolicPosition;
 import java.io.InputStream;
 import java.time.Duration;
 import java.util.concurrent.CompletableFuture;
@@ -95,7 +97,7 @@ public class DefaultIngestionBackendTest {
         .thenReturn(storageEngine);
 
     when(offsetRecord.getOffsetLag()).thenReturn(0L);
-    when(offsetRecord.getLocalVersionTopicOffset()).thenReturn(-1L);
+    when(offsetRecord.getLocalVersionTopicOffset()).thenReturn(PubSubSymbolicPosition.EARLIEST);
     when(storageMetadataService.getLastOffset(Version.composeKafkaTopic(STORE_NAME, VERSION_NUMBER), PARTITION))
         .thenReturn(offsetRecord);
 
@@ -186,7 +188,7 @@ public class DefaultIngestionBackendTest {
   public void testNotStartBootstrapFromBlobTransferWhenNotLaggingForHybridStore() {
     long laggingThreshold = 1000L;
     when(offsetRecord.getOffsetLag()).thenReturn(10L);
-    when(offsetRecord.getLocalVersionTopicOffset()).thenReturn(10L);
+    when(offsetRecord.getLocalVersionTopicOffset()).thenReturn(PubSubUtil.fromKafkaOffset(10L));
     when(storageMetadataService.getLastOffset(Version.composeKafkaTopic(STORE_NAME, VERSION_NUMBER), PARTITION))
         .thenReturn(offsetRecord);
 

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/ingestion/main/MainIngestionStorageMetadataServiceTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/ingestion/main/MainIngestionStorageMetadataServiceTest.java
@@ -39,7 +39,7 @@ public class MainIngestionStorageMetadataServiceTest {
     assertNotNull(offsetRecord1);
 
     OffsetRecord offsetRecord2 = new OffsetRecord(PARTITION_STATE.getSerializer());
-    offsetRecord2.setCheckpointLocalVersionTopicOffset(PubSubUtil.fromKafkaOffset(10));
+    offsetRecord2.setCheckpointLocalVersionTopicPosition(PubSubUtil.fromKafkaOffset(10));
 
     mainIngestionStorageMetadataService.putOffsetRecord(topicName, partition, offsetRecord2);
     OffsetRecord offsetRecord3 = mainIngestionStorageMetadataService.getLastOffset(topicName, partition);

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/ingestion/main/MainIngestionStorageMetadataServiceTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/ingestion/main/MainIngestionStorageMetadataServiceTest.java
@@ -11,6 +11,7 @@ import com.linkedin.davinci.config.VeniceConfigLoader;
 import com.linkedin.davinci.config.VeniceServerConfig;
 import com.linkedin.davinci.stats.MetadataUpdateStats;
 import com.linkedin.venice.offsets.OffsetRecord;
+import com.linkedin.venice.pubsub.PubSubUtil;
 import com.linkedin.venice.serialization.avro.InternalAvroSpecificSerializer;
 import com.linkedin.venice.utils.VeniceProperties;
 import java.util.function.BiConsumer;
@@ -38,7 +39,7 @@ public class MainIngestionStorageMetadataServiceTest {
     assertNotNull(offsetRecord1);
 
     OffsetRecord offsetRecord2 = new OffsetRecord(PARTITION_STATE.getSerializer());
-    offsetRecord2.setCheckpointLocalVersionTopicOffset(10);
+    offsetRecord2.setCheckpointLocalVersionTopicOffset(PubSubUtil.fromKafkaOffset(10));
 
     mainIngestionStorageMetadataService.putOffsetRecord(topicName, partition, offsetRecord2);
     OffsetRecord offsetRecord3 = mainIngestionStorageMetadataService.getLastOffset(topicName, partition);

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/ingestion/main/MainIngestionStorageMetadataServiceTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/ingestion/main/MainIngestionStorageMetadataServiceTest.java
@@ -39,7 +39,7 @@ public class MainIngestionStorageMetadataServiceTest {
     assertNotNull(offsetRecord1);
 
     OffsetRecord offsetRecord2 = new OffsetRecord(PARTITION_STATE.getSerializer());
-    offsetRecord2.setCheckpointLocalVersionTopicPosition(PubSubUtil.fromKafkaOffset(10));
+    offsetRecord2.checkpointLocalVtPosition(PubSubUtil.fromKafkaOffset(10));
 
     mainIngestionStorageMetadataService.putOffsetRecord(topicName, partition, offsetRecord2);
     OffsetRecord offsetRecord3 = mainIngestionStorageMetadataService.getLastOffset(topicName, partition);

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/ActiveActiveStoreIngestionTaskTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/ActiveActiveStoreIngestionTaskTest.java
@@ -768,27 +768,28 @@ public class ActiveActiveStoreIngestionTaskTest {
     when(mockServerConfig.getKafkaClusterUrlToIdMap()).thenReturn(kafkaClusterUrlToIdMap);
 
     // Set up real method call
-    doCallRealMethod().when(ingestionTask).consumerSubscribe(any(), anyLong(), anyString());
+    doCallRealMethod().when(ingestionTask).consumerSubscribe(any(), any(), anyString());
 
     PubSubTopicPartition pubSubTopicPartition = new PubSubTopicPartitionImpl(TOPIC_REPOSITORY.getTopic("test"), 0);
+    PubSubPosition p100 = ApacheKafkaOffsetPosition.of(100L);
     VeniceException exception = expectThrows(
         VeniceException.class,
-        () -> ingestionTask.consumerSubscribe(pubSubTopicPartition, 100L, "invalidPubSubAddress"));
+        () -> ingestionTask.consumerSubscribe(pubSubTopicPartition, p100, "invalidPubSubAddress"));
     assertNotNull(exception.getMessage(), "Exception message should not be null");
     assertTrue(
         exception.getMessage().contains("is not in the pubsub cluster map"),
         "Exception message should contain the expected message but found: " + exception.getMessage());
 
-    verify(ingestionTask, times(1)).consumerSubscribe(pubSubTopicPartition, 100L, "invalidPubSubAddress");
+    verify(ingestionTask, times(1)).consumerSubscribe(pubSubTopicPartition, p100, "invalidPubSubAddress");
 
     // Case 2: DaVinci client
     ActiveActiveStoreIngestionTask dvcIngestionTask = mock(ActiveActiveStoreIngestionTask.class);
-    doCallRealMethod().when(dvcIngestionTask).consumerSubscribe(any(), anyLong(), anyString());
+    doCallRealMethod().when(dvcIngestionTask).consumerSubscribe(any(), any(), anyString());
     when(dvcIngestionTask.getServerConfig()).thenReturn(mockServerConfig);
     when(dvcIngestionTask.isDaVinciClient()).thenReturn(true);
     when(mockServerConfig.getKafkaClusterUrlToIdMap()).thenReturn(Object2IntMaps.emptyMap());
     try {
-      dvcIngestionTask.consumerSubscribe(pubSubTopicPartition, 100L, "validPubSubAddress");
+      dvcIngestionTask.consumerSubscribe(pubSubTopicPartition, p100, "validPubSubAddress");
     } catch (Exception e) {
       if (e.getMessage() != null) {
         assertFalse(
@@ -796,7 +797,7 @@ public class ActiveActiveStoreIngestionTaskTest {
             "Exception message should not contain the expected message but found: " + e.getMessage());
       }
     }
-    verify(dvcIngestionTask, times(1)).consumerSubscribe(pubSubTopicPartition, 100L, "validPubSubAddress");
+    verify(dvcIngestionTask, times(1)).consumerSubscribe(pubSubTopicPartition, p100, "validPubSubAddress");
   }
 
   @Test(dataProvider = "True-and-False", dataProviderClass = DataProviderUtils.class)

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/AggKafkaConsumerServiceTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/AggKafkaConsumerServiceTest.java
@@ -23,6 +23,7 @@ import com.linkedin.venice.pubsub.PubSubTopicPartitionImpl;
 import com.linkedin.venice.pubsub.PubSubTopicRepository;
 import com.linkedin.venice.pubsub.api.PubSubConsumerAdapter;
 import com.linkedin.venice.pubsub.api.PubSubMessageDeserializer;
+import com.linkedin.venice.pubsub.api.PubSubSymbolicPosition;
 import com.linkedin.venice.pubsub.api.PubSubTopic;
 import com.linkedin.venice.pubsub.api.PubSubTopicPartition;
 import com.linkedin.venice.pubsub.manager.TopicManager;
@@ -131,15 +132,22 @@ public class AggKafkaConsumerServiceTest {
         topicPartition,
         PartitionReplicaIngestionContext.VersionRole.CURRENT,
         PartitionReplicaIngestionContext.WorkloadType.NON_AA_OR_WRITE_COMPUTE);
-    StorePartitionDataReceiver dataReceiver = (StorePartitionDataReceiver) aggKafkaConsumerServiceSpy
-        .subscribeConsumerFor(PUBSUB_URL, storeIngestionTask, partitionReplicaIngestionContext, -1);
+    StorePartitionDataReceiver dataReceiver =
+        (StorePartitionDataReceiver) aggKafkaConsumerServiceSpy.subscribeConsumerFor(
+            PUBSUB_URL,
+            storeIngestionTask,
+            partitionReplicaIngestionContext,
+            PubSubSymbolicPosition.EARLIEST);
 
     // regular pubsub url uses the default cluster id
     Assert.assertEquals(dataReceiver.getKafkaClusterId(), 0);
     verify(topicManager).prefetchAndCacheLatestOffset(topicPartition);
 
-    dataReceiver = (StorePartitionDataReceiver) aggKafkaConsumerServiceSpy
-        .subscribeConsumerFor(PUBSUB_URL_SEP, storeIngestionTask, partitionReplicaIngestionContext, -1);
+    dataReceiver = (StorePartitionDataReceiver) aggKafkaConsumerServiceSpy.subscribeConsumerFor(
+        PUBSUB_URL_SEP,
+        storeIngestionTask,
+        partitionReplicaIngestionContext,
+        PubSubSymbolicPosition.EARLIEST);
     // pubsub url for sep topic uses a different cluster id
     Assert.assertEquals(dataReceiver.getKafkaClusterId(), 1);
 

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/KafkaConsumerServiceTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/KafkaConsumerServiceTest.java
@@ -25,6 +25,7 @@ import com.linkedin.venice.pubsub.PubSubConsumerAdapterFactory;
 import com.linkedin.venice.pubsub.PubSubPositionTypeRegistry;
 import com.linkedin.venice.pubsub.PubSubTopicPartitionImpl;
 import com.linkedin.venice.pubsub.PubSubTopicRepository;
+import com.linkedin.venice.pubsub.adapter.kafka.common.ApacheKafkaOffsetPosition;
 import com.linkedin.venice.pubsub.adapter.kafka.consumer.ApacheKafkaConsumerAdapter;
 import com.linkedin.venice.pubsub.api.DefaultPubSubMessage;
 import com.linkedin.venice.pubsub.api.PubSubConsumerAdapter;
@@ -190,7 +191,10 @@ public class KafkaConsumerServiceTest {
 
     ConsumedDataReceiver consumedDataReceiver = mock(ConsumedDataReceiver.class);
     when(consumedDataReceiver.destinationIdentifier()).thenReturn(versionTopic);
-    consumerService.startConsumptionIntoDataReceiver(partitionReplicaIngestionContext, 0, consumedDataReceiver);
+    consumerService.startConsumptionIntoDataReceiver(
+        partitionReplicaIngestionContext,
+        ApacheKafkaOffsetPosition.of(0),
+        consumedDataReceiver);
 
     SharedKafkaConsumer assignedConsumer = consumerService.assignConsumerFor(versionTopic, topicPartition);
     Set<PubSubTopicPartition> consumerAssignedPartitions = new HashSet<>();

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTaskTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTaskTest.java
@@ -598,7 +598,7 @@ public class LeaderFollowerStoreIngestionTaskTest {
     doReturn(consumerDiv).when(mockIngestionTask).getConsumerDiv();
     doReturn(true).when(mockIngestionTask).isGlobalRtDivEnabled();
 
-    // delegateConsumerRecord() should cause updateLatestConsumedVtOffset() to be called
+    // delegateConsumerRecord() should cause updateLatestConsumedVtPosition() to be called
     mockIngestionTask.delegateConsumerRecord(cm, 0, "testURL", 0, 0, 0);
     verify(consumerDiv, times(1)).updateLatestConsumedVtOffset(0, cm.getMessage().getPosition());
   }
@@ -669,7 +669,7 @@ public class LeaderFollowerStoreIngestionTaskTest {
     when(mockOffsetRecord.getLeaderTopic()).thenReturn("test");
     when(mockOffsetRecord.isEndOfPushReceived()).thenReturn(true);
     PubSubPosition p0 = ApacheKafkaOffsetPosition.of(0L);
-    doReturn(p0).when(mockOffsetRecord).getLocalVersionTopicOffset();
+    doReturn(p0).when(mockOffsetRecord).getCheckpointedLocalVtPosition();
 
     when(mockStorageMetadataService.getLastOffset(any(), anyInt())).thenReturn(mockOffsetRecord);
     when(mockConsumerAction.getTopicPartition()).thenReturn(mockTopicPartition);

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTaskTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTaskTest.java
@@ -522,11 +522,10 @@ public class LeaderFollowerStoreIngestionTaskTest {
     DefaultPubSubMessage mockMessage = mock(DefaultPubSubMessage.class);
     PubSubTopicPartition mockTopicPartition = mock(PubSubTopicPartition.class);
     LeaderProducedRecordContext context = mock(LeaderProducedRecordContext.class);
-    PubSubPosition positionMock = mock(PubSubPosition.class);
-    doReturn(positionMock).when(context).getConsumedPosition();
+    PubSubPosition p3 = ApacheKafkaOffsetPosition.of(offset);
+    doReturn(p3).when(context).getConsumedPosition();
     doReturn(partition).when(mockTopicPartition).getPartitionNumber();
-    doReturn(offset).when(positionMock).getNumericOffset();
-    doReturn(positionMock).when(mockMessage).getPosition();
+    doReturn(p3).when(mockMessage).getPosition();
     doReturn(mockTopicPartition).when(mockMessage).getTopicPartition();
     doReturn(messageTime).when(mockMessage).getPubSubMessageTime();
     VeniceWriter mockWriter = mock(VeniceWriter.class);
@@ -601,7 +600,7 @@ public class LeaderFollowerStoreIngestionTaskTest {
 
     // delegateConsumerRecord() should cause updateLatestConsumedVtOffset() to be called
     mockIngestionTask.delegateConsumerRecord(cm, 0, "testURL", 0, 0, 0);
-    verify(consumerDiv, times(1)).updateLatestConsumedVtOffset(0, 1L);
+    verify(consumerDiv, times(1)).updateLatestConsumedVtOffset(0, cm.getMessage().getPosition());
   }
 
   @Test
@@ -669,6 +668,9 @@ public class LeaderFollowerStoreIngestionTaskTest {
     OffsetRecord mockOffsetRecord = mock(OffsetRecord.class);
     when(mockOffsetRecord.getLeaderTopic()).thenReturn("test");
     when(mockOffsetRecord.isEndOfPushReceived()).thenReturn(true);
+    PubSubPosition p0 = ApacheKafkaOffsetPosition.of(0L);
+    doReturn(p0).when(mockOffsetRecord).getLocalVersionTopicOffset();
+
     when(mockStorageMetadataService.getLastOffset(any(), anyInt())).thenReturn(mockOffsetRecord);
     when(mockConsumerAction.getTopicPartition()).thenReturn(mockTopicPartition);
     when(mockPartitionConsumptionState.getOffsetRecord()).thenReturn(mockOffsetRecord);

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/PushTimeoutTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/PushTimeoutTest.java
@@ -155,7 +155,7 @@ public class PushTimeoutTest {
      * will determine that base topic is caught up.
      */
     PubSubPosition p1 = ApacheKafkaOffsetPosition.of(1L);
-    doReturn(p1).when(mockOffsetRecord).getLocalVersionTopicOffset();
+    doReturn(p1).when(mockOffsetRecord).getCheckpointedLocalVtPosition();
     doReturn(mockOffsetRecord).when(mockStorageMetadataService).getLastOffset(eq(versionTopic), eq(0));
 
     LeaderFollowerStoreIngestionTask leaderFollowerStoreIngestionTask = new LeaderFollowerStoreIngestionTask(

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/PushTimeoutTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/PushTimeoutTest.java
@@ -21,6 +21,8 @@ import com.linkedin.venice.offsets.OffsetRecord;
 import com.linkedin.venice.pubsub.PubSubContext;
 import com.linkedin.venice.pubsub.PubSubTopicPartitionImpl;
 import com.linkedin.venice.pubsub.PubSubTopicRepository;
+import com.linkedin.venice.pubsub.adapter.kafka.common.ApacheKafkaOffsetPosition;
+import com.linkedin.venice.pubsub.api.PubSubPosition;
 import com.linkedin.venice.utils.ExceptionCaptorNotifier;
 import com.linkedin.venice.utils.ReferenceCounted;
 import com.linkedin.venice.utils.TestUtils;
@@ -152,7 +154,8 @@ public class PushTimeoutTest {
      * Return 0 as the max offset for VT and 1 as the overall consume progress, so reportIfCatchUpVersionTopicOffset()
      * will determine that base topic is caught up.
      */
-    doReturn(1L).when(mockOffsetRecord).getLocalVersionTopicOffset();
+    PubSubPosition p1 = ApacheKafkaOffsetPosition.of(1L);
+    doReturn(p1).when(mockOffsetRecord).getLocalVersionTopicOffset();
     doReturn(mockOffsetRecord).when(mockStorageMetadataService).getLastOffset(eq(versionTopic), eq(0));
 
     LeaderFollowerStoreIngestionTask leaderFollowerStoreIngestionTask = new LeaderFollowerStoreIngestionTask(

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/SharedKafkaConsumerTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/SharedKafkaConsumerTest.java
@@ -12,6 +12,7 @@ import com.linkedin.venice.pubsub.PubSubTopicPartitionImpl;
 import com.linkedin.venice.pubsub.PubSubTopicRepository;
 import com.linkedin.venice.pubsub.api.DefaultPubSubMessage;
 import com.linkedin.venice.pubsub.api.PubSubConsumerAdapter;
+import com.linkedin.venice.pubsub.api.PubSubSymbolicPosition;
 import com.linkedin.venice.pubsub.api.PubSubTopic;
 import com.linkedin.venice.pubsub.api.PubSubTopicPartition;
 import com.linkedin.venice.utils.SystemTime;
@@ -53,7 +54,7 @@ public class SharedKafkaConsumerTest {
     PubSubTopicPartition nonExistentPubSubTopicPartition = new PubSubTopicPartitionImpl(nonExistingTopic1, 1);
     assignmentReturnedConsumer.add(nonExistentPubSubTopicPartition);
     when(consumer.getAssignment()).thenReturn(assignmentReturnedConsumer);
-    sharedConsumer.subscribe(nonExistingTopic1, nonExistentPubSubTopicPartition, -1);
+    sharedConsumer.subscribe(nonExistingTopic1, nonExistentPubSubTopicPartition, PubSubSymbolicPosition.EARLIEST);
 
     Map<PubSubTopicPartition, List<DefaultPubSubMessage>> pubSubMessagesReturnedByConsumer = new HashMap<>();
     doReturn(pubSubMessagesReturnedByConsumer).when(consumer).poll(anyLong());

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTaskTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTaskTest.java
@@ -161,7 +161,7 @@ import com.linkedin.venice.pubsub.PubSubPositionDeserializer;
 import com.linkedin.venice.pubsub.PubSubPositionTypeRegistry;
 import com.linkedin.venice.pubsub.PubSubTopicPartitionImpl;
 import com.linkedin.venice.pubsub.PubSubTopicRepository;
-import com.linkedin.venice.pubsub.adapter.kafka.common.ApacheKafkaOffsetPosition;
+import com.linkedin.venice.pubsub.PubSubUtil;
 import com.linkedin.venice.pubsub.api.DefaultPubSubMessage;
 import com.linkedin.venice.pubsub.api.PubSubConsumerAdapter;
 import com.linkedin.venice.pubsub.api.PubSubMessageDeserializer;
@@ -169,6 +169,7 @@ import com.linkedin.venice.pubsub.api.PubSubMessageHeaders;
 import com.linkedin.venice.pubsub.api.PubSubPosition;
 import com.linkedin.venice.pubsub.api.PubSubProduceResult;
 import com.linkedin.venice.pubsub.api.PubSubProducerAdapter;
+import com.linkedin.venice.pubsub.api.PubSubSymbolicPosition;
 import com.linkedin.venice.pubsub.api.PubSubTopic;
 import com.linkedin.venice.pubsub.api.PubSubTopicPartition;
 import com.linkedin.venice.pubsub.api.PubSubTopicType;
@@ -529,7 +530,7 @@ public abstract class StoreIngestionTaskTest {
     pubSubTopic = pubSubTopicRepository.getTopic(topic);
     fooTopicPartition = new PubSubTopicPartitionImpl(pubSubTopic, PARTITION_FOO);
     barTopicPartition = new PubSubTopicPartitionImpl(pubSubTopic, PARTITION_BAR);
-    mockedPubSubPosition = mock(PubSubPosition.class);
+    mockedPubSubPosition = InMemoryPubSubPosition.of(10);
 
     inMemoryLocalKafkaBroker = new InMemoryPubSubBroker("local");
     inMemoryLocalKafkaBroker.createTopic(topic, PARTITION_COUNT);
@@ -1208,7 +1209,7 @@ public abstract class StoreIngestionTaskTest {
       StoreIngestionTask storeIngestionTask = invocation.getArgument(1, StoreIngestionTask.class);
       PartitionReplicaIngestionContext partitionReplicaIngestionContext =
           invocation.getArgument(2, PartitionReplicaIngestionContext.class);
-      long offset = invocation.getArgument(3, Long.class);
+      PubSubPosition offset = invocation.getArgument(3, PubSubPosition.class);
       KafkaConsumerService kafkaConsumerService;
       int kafkaClusterId;
       boolean local = kafkaUrl.equals(inMemoryLocalKafkaBroker.getPubSubBrokerAddress());
@@ -1233,7 +1234,7 @@ public abstract class StoreIngestionTaskTest {
       }
 
       return null;
-    }).when(aggKafkaConsumerService).subscribeConsumerFor(anyString(), any(), any(), anyLong());
+    }).when(aggKafkaConsumerService).subscribeConsumerFor(anyString(), any(), any(), any(PubSubPosition.class));
 
     doAnswer(invocation -> {
       PubSubTopic versionTopic = invocation.getArgument(0, PubSubTopic.class);
@@ -1484,7 +1485,9 @@ public abstract class StoreIngestionTaskTest {
       verifyPut(aaConfig, true);
       verifyDelete(aaConfig, true, false);
       // Verify it commits the offset to Offset Manager
-      OffsetRecord expectedOffsetRecordForDeleteMessage = getOffsetRecord(deleteProduceResult.getOffset());
+      long currentOffset = deleteProduceResult.getOffset();
+      OffsetRecord expectedOffsetRecordForDeleteMessage =
+          getOffsetRecord(InMemoryPubSubPosition.of(currentOffset), Optional.empty());
       verify(mockStorageMetadataService, timeout(TEST_TIMEOUT_MS))
           .put(topic, PARTITION_FOO, expectedOffsetRecordForDeleteMessage);
 
@@ -1586,7 +1589,9 @@ public abstract class StoreIngestionTaskTest {
           .put(PARTITION_FOO, putKeyFoo2, ByteBuffer.wrap(ValueRecord.create(SCHEMA_ID, putValue).serialize()));
 
       // Verify it commits the offset to Offset Manager
-      OffsetRecord expectedOffsetRecordForLastMessage = getOffsetRecord(putMetadata4.getOffset());
+      long currentOffset = putMetadata4.getOffset();
+      OffsetRecord expectedOffsetRecordForLastMessage =
+          getOffsetRecord(InMemoryPubSubPosition.of(currentOffset), Optional.empty());
       verify(mockStorageMetadataService, timeout(TEST_TIMEOUT_MS))
           .put(topic, PARTITION_FOO, expectedOffsetRecordForLastMessage);
     }, aaConfig);
@@ -1611,7 +1616,8 @@ public abstract class StoreIngestionTaskTest {
       verify(mockSchemaRepo, timeout(TEST_TIMEOUT_MS)).hasValueSchema(storeNameWithoutVersionInfo, EXISTING_SCHEMA_ID);
 
       // Verify it commits the offset to Offset Manager
-      OffsetRecord expected = getOffsetRecord(fooLastOffset.getInternalOffset());
+      long currentOffset = fooLastOffset.getInternalOffset();
+      OffsetRecord expected = getOffsetRecord(InMemoryPubSubPosition.of(currentOffset), Optional.empty());
       verify(mockStorageMetadataService, timeout(TEST_TIMEOUT_MS)).put(topic, PARTITION_FOO, expected);
     }, aaConfig);
   }
@@ -1648,7 +1654,8 @@ public abstract class StoreIngestionTaskTest {
       verify(mockAbstractStorageEngine, timeout(TEST_TIMEOUT_MS))
           .put(PARTITION_FOO, putKeyFoo, ByteBuffer.wrap(ValueRecord.create(EXISTING_SCHEMA_ID, putValue).serialize()));
 
-      OffsetRecord expected = getOffsetRecord(existingSchemaOffset.getInternalOffset());
+      long currentOffset = existingSchemaOffset.getInternalOffset();
+      OffsetRecord expected = getOffsetRecord(InMemoryPubSubPosition.of(currentOffset), Optional.empty());
       verify(mockStorageMetadataService, timeout(TEST_TIMEOUT_MS)).put(topic, PARTITION_FOO, expected);
     }, aaConfig);
     runTest(config);
@@ -1693,7 +1700,9 @@ public abstract class StoreIngestionTaskTest {
           verify(mockLogNotifier, never()).started(topic, PARTITION_BAR);
         }, aaConfig);
     config.setBeforeStartingConsumption(() -> {
-      doReturn(getOffsetRecord(STARTING_OFFSET)).when(mockStorageMetadataService).getLastOffset(anyString(), anyInt());
+      doReturn(getOffsetRecord(InMemoryPubSubPosition.of(STARTING_OFFSET), Optional.empty()))
+          .when(mockStorageMetadataService)
+          .getLastOffset(anyString(), anyInt());
     });
     runTest(config);
   }
@@ -1845,7 +1854,7 @@ public abstract class StoreIngestionTaskTest {
     final InternalAvroSpecificSerializer<PartitionState> partitionStateSerializer =
         AvroProtocolDefinition.PARTITION_STATE.getSerializer();
     OffsetRecord offsetRecord = new OffsetRecord(partitionStateSerializer);
-    offsetRecord.endOfPushReceived(2L);
+    offsetRecord.endOfPushReceived();
     offsetRecord.setPreviousStatusesEntry("previouslyReadyToServe", "true");
     testConfig.setOffsetRecord(offsetRecord);
     runTest(testConfig);
@@ -2610,8 +2619,9 @@ public abstract class StoreIngestionTaskTest {
       // Deferred write is not going to commit offset for every message, but will commit offset for every control
       // message
       // The following verification is for START_OF_PUSH control message
+      long currentOffset = putMetadata.getOffset() - 1;
       verify(mockStorageMetadataService, times(1))
-          .put(topic, PARTITION_FOO, getOffsetRecord(putMetadata.getOffset() - 1));
+          .put(topic, PARTITION_FOO, getOffsetRecord(InMemoryPubSubPosition.of(currentOffset), Optional.empty()));
       // Check database mode switches from deferred-write to transactional after EOP control message
       StoragePartitionConfig deferredWritePartitionConfig = new StoragePartitionConfig(topic, PARTITION_FOO);
       deferredWritePartitionConfig.setDeferredWrite(true);
@@ -2657,8 +2667,9 @@ public abstract class StoreIngestionTaskTest {
       // Deferred write is not going to commit offset for every message, but will commit offset for every control
       // message
       // The following verification is for START_OF_PUSH control message
+      long currentOffset = putMetadata.getOffset() - 1;
       verify(mockStorageMetadataService, times(1))
-          .put(topic, PARTITION_FOO, getOffsetRecord(putMetadata.getOffset() - 1));
+          .put(topic, PARTITION_FOO, getOffsetRecord(InMemoryPubSubPosition.of(currentOffset), Optional.empty()));
       // Check database mode switches from deferred-write to transactional after EOP control message
       StoragePartitionConfig deferredWritePartitionConfig = new StoragePartitionConfig(topic, PARTITION_FOO);
       boolean deferredWrite;
@@ -3268,16 +3279,17 @@ public abstract class StoreIngestionTaskTest {
     inMemoryLocalKafkaBroker.createTopic(rtTopic, partitionCount);
     inMemoryRemoteKafkaBroker.createTopic(rtTopic, partitionCount);
 
+    PubSubPosition p0 = InMemoryPubSubPosition.of(0);
     aggKafkaConsumerService.subscribeConsumerFor(
         inMemoryLocalKafkaBroker.getPubSubBrokerAddress(),
         storeIngestionTaskUnderTest,
         fooRtPartitionReplicaIngestionContext,
-        0);
+        p0);
     aggKafkaConsumerService.subscribeConsumerFor(
         inMemoryRemoteKafkaBroker.getPubSubBrokerAddress(),
         storeIngestionTaskUnderTest,
         fooRtPartitionReplicaIngestionContext,
-        0);
+        p0);
 
     VeniceWriter localRtWriter = getVeniceWriter(rtTopic, new MockInMemoryProducerAdapter(inMemoryLocalKafkaBroker));
     VeniceWriter remoteRtWriter = getVeniceWriter(rtTopic, new MockInMemoryProducerAdapter(inMemoryRemoteKafkaBroker));
@@ -3397,19 +3409,20 @@ public abstract class StoreIngestionTaskTest {
         topicSwitchWithSourceRealTimeTopic,
         pubSubTopicRepository.getTopic(topicSwitchWithSourceRealTimeTopic.sourceTopicName.toString()));
 
+    InMemoryPubSubPosition p5 = InMemoryPubSubPosition.of(5);
     OffsetRecord mockOffsetRecordLagCaughtUp = mock(OffsetRecord.class);
-    doReturn(5L).when(mockOffsetRecordLagCaughtUp).getLocalVersionTopicOffset();
+    doReturn(p5).when(mockOffsetRecordLagCaughtUp).getLocalVersionTopicOffset();
     doReturn(rtTopic).when(mockOffsetRecordLagCaughtUp).getLeaderTopic(any());
-    doReturn(5L).when(mockOffsetRecordLagCaughtUp).getUpstreamOffset(inMemoryLocalKafkaBroker.getPubSubBrokerAddress());
-    doReturn(5L).when(mockOffsetRecordLagCaughtUp)
+    doReturn(p5).when(mockOffsetRecordLagCaughtUp).getUpstreamOffset(inMemoryLocalKafkaBroker.getPubSubBrokerAddress());
+    doReturn(p5).when(mockOffsetRecordLagCaughtUp)
         .getUpstreamOffset(inMemoryRemoteKafkaBroker.getPubSubBrokerAddress());
 
     OffsetRecord mockOffsetRecordLagCaughtUpTimestampLagging = mock(OffsetRecord.class);
-    doReturn(5L).when(mockOffsetRecordLagCaughtUpTimestampLagging).getLocalVersionTopicOffset();
+    doReturn(p5).when(mockOffsetRecordLagCaughtUpTimestampLagging).getLocalVersionTopicOffset();
     doReturn(rtTopic).when(mockOffsetRecordLagCaughtUpTimestampLagging).getLeaderTopic(any());
-    doReturn(5L).when(mockOffsetRecordLagCaughtUpTimestampLagging)
+    doReturn(p5).when(mockOffsetRecordLagCaughtUpTimestampLagging)
         .getUpstreamOffset(inMemoryLocalKafkaBroker.getPubSubBrokerAddress());
-    doReturn(5L).when(mockOffsetRecordLagCaughtUpTimestampLagging)
+    doReturn(p5).when(mockOffsetRecordLagCaughtUpTimestampLagging)
         .getUpstreamOffset(inMemoryRemoteKafkaBroker.getPubSubBrokerAddress());
     doReturn(System.currentTimeMillis() - MS_PER_HOUR).when(mockOffsetRecordLagCaughtUpTimestampLagging)
         .getLatestProducerProcessingTimeInMs();
@@ -3442,7 +3455,6 @@ public abstract class StoreIngestionTaskTest {
     doReturn(true).when(mockPcsHybridButBufferReplayNotStarted).isHybrid();
     doReturn(null).when(mockPcsHybridButBufferReplayNotStarted).getTopicSwitch();
     assertFalse(storeIngestionTaskUnderTest.isReadyToServe(mockPcsHybridButBufferReplayNotStarted));
-
     // case 5: Replication lag is caught up
     PartitionConsumptionState mockPcsBufferReplayStartedLagCaughtUp = mock(PartitionConsumptionState.class);
     doReturn(true).when(mockPcsBufferReplayStartedLagCaughtUp).isEndOfPushReceived();
@@ -3454,7 +3466,10 @@ public abstract class StoreIngestionTaskTest {
     doReturn(5L).when(mockTopicManager).getLatestOffsetCached(any(), anyInt());
     doReturn(5L).when(mockTopicManagerRemoteKafka).getLatestOffsetCached(any(), anyInt());
     doReturn(0).when(mockPcsBufferReplayStartedLagCaughtUp).getPartition();
-    doReturn(0).when(mockPcsBufferReplayStartedLagCaughtUp).getPartition();
+    doReturn(PubSubSymbolicPosition.EARLIEST).when(mockPcsBufferReplayStartedLagCaughtUp)
+        .getLatestProcessedUpstreamRTOffset(anyString());
+    doReturn(PubSubSymbolicPosition.EARLIEST).when(mockPcsBufferReplayStartedLagCaughtUp)
+        .getLatestProcessedLocalVersionTopicOffset();
     storeIngestionTaskUnderTest.setPartitionConsumptionState(0, mockPcsBufferReplayStartedLagCaughtUp);
     if (nodeType == NodeType.LEADER) {
       // case 5a: leader replica => partition is ready to serve
@@ -3487,6 +3502,10 @@ public abstract class StoreIngestionTaskTest {
     doReturn(5L).when(mockTopicManager).getLatestOffsetCached(any(), anyInt());
     doReturn(150L).when(mockTopicManagerRemoteKafka).getLatestOffsetCached(any(), anyInt());
     doReturn(150L).when(aggKafkaConsumerService).getLatestOffsetBasedOnMetrics(anyString(), any(), any());
+    doReturn(PubSubSymbolicPosition.EARLIEST).when(mockPcsBufferReplayStartedRemoteLagging)
+        .getLatestProcessedUpstreamRTOffset(anyString());
+    doReturn(PubSubSymbolicPosition.EARLIEST).when(mockPcsBufferReplayStartedRemoteLagging)
+        .getLatestProcessedLocalVersionTopicOffset();
 
     long endOffset =
         storeIngestionTaskUnderTest.getTopicPartitionEndOffSet(localKafkaConsumerService.kafkaUrl, pubSubTopic, 1);
@@ -3511,6 +3530,10 @@ public abstract class StoreIngestionTaskTest {
     // case 7: If there are issues in replication from remote RT -> local VT, leader won't be marked completed,
     // but both DaVinci replica and storage node will be marked ready to serve if leader were to be completed
     PartitionConsumptionState mockPcsOffsetLagCaughtUpTimestampLagging = mock(PartitionConsumptionState.class);
+    doReturn(PubSubSymbolicPosition.EARLIEST).when(mockPcsOffsetLagCaughtUpTimestampLagging)
+        .getLatestProcessedUpstreamRTOffset(anyString());
+    doReturn(PubSubSymbolicPosition.EARLIEST).when(mockPcsOffsetLagCaughtUpTimestampLagging)
+        .getLatestProcessedLocalVersionTopicOffset();
     doReturn(true).when(mockPcsOffsetLagCaughtUpTimestampLagging).isEndOfPushReceived();
     doReturn(false).when(mockPcsOffsetLagCaughtUpTimestampLagging).isComplete();
     doReturn(true).when(mockPcsOffsetLagCaughtUpTimestampLagging).isWaitingForReplicationLag();
@@ -3615,11 +3638,14 @@ public abstract class StoreIngestionTaskTest {
         topicSwitchWithMultipleSourceKafkaServers,
         pubSubTopicRepository.getTopic(topicSwitchWithMultipleSourceKafkaServers.sourceTopicName.toString()));
 
+    InMemoryPubSubPosition p5 = InMemoryPubSubPosition.of(5);
+    InMemoryPubSubPosition p150 = InMemoryPubSubPosition.of(150);
+
     OffsetRecord mockOffsetRecord = mock(OffsetRecord.class);
-    doReturn(5L).when(mockOffsetRecord).getLocalVersionTopicOffset();
+    doReturn(p5).when(mockOffsetRecord).getLocalVersionTopicOffset();
     doReturn(rtTopic).when(mockOffsetRecord).getLeaderTopic(any());
-    doReturn(5L).when(mockOffsetRecord).getUpstreamOffset(inMemoryLocalKafkaBroker.getPubSubBrokerAddress());
-    doReturn(5L).when(mockOffsetRecord).getUpstreamOffset(inMemoryRemoteKafkaBroker.getPubSubBrokerAddress());
+    doReturn(p5).when(mockOffsetRecord).getUpstreamOffset(inMemoryLocalKafkaBroker.getPubSubBrokerAddress());
+    doReturn(p5).when(mockOffsetRecord).getUpstreamOffset(inMemoryRemoteKafkaBroker.getPubSubBrokerAddress());
 
     // Local replication are caught up but remote replication are not. A/A storage node replica is not ready to serve
     // Since host has caught up to lag in local VT, DaVinci replica will be marked ready to serve
@@ -3630,12 +3656,13 @@ public abstract class StoreIngestionTaskTest {
     doReturn(hybridConfig == HYBRID).when(mockPcsMultipleSourceKafkaServers).isHybrid();
     doReturn(topicSwitchWithMultipleSourceKafkaServersWrapper).when(mockPcsMultipleSourceKafkaServers).getTopicSwitch();
     doReturn(mockOffsetRecord).when(mockPcsMultipleSourceKafkaServers).getOffsetRecord();
-    doReturn(5L).when(mockTopicManager).getLatestOffsetCached(any(), anyInt());
-    doReturn(150L).when(mockTopicManagerRemoteKafka).getLatestOffsetCached(any(), anyInt());
-    doReturn(150L).when(aggKafkaConsumerService).getLatestOffsetBasedOnMetrics(anyString(), any(), any());
+    doReturn(p5.getInternalOffset()).when(mockTopicManager).getLatestOffsetCached(any(), anyInt());
+    doReturn(p150.getInternalOffset()).when(mockTopicManagerRemoteKafka).getLatestOffsetCached(any(), anyInt());
+    doReturn(p150.getInternalOffset()).when(aggKafkaConsumerService)
+        .getLatestOffsetBasedOnMetrics(anyString(), any(), any());
     doReturn(0).when(mockPcsMultipleSourceKafkaServers).getPartition();
     doReturn(0).when(mockPcsMultipleSourceKafkaServers).getPartition();
-    doReturn(5L).when(mockPcsMultipleSourceKafkaServers).getLatestProcessedLocalVersionTopicOffset();
+    doReturn(p5).when(mockPcsMultipleSourceKafkaServers).getLatestProcessedLocalVersionTopicOffset();
     if (nodeType == NodeType.LEADER) {
       doReturn(LeaderFollowerStateType.LEADER).when(mockPcsMultipleSourceKafkaServers).getLeaderFollowerState();
     } else {
@@ -3885,6 +3912,8 @@ public abstract class StoreIngestionTaskTest {
 
     long producerTimestamp = System.currentTimeMillis();
     LeaderMetadataWrapper mockLeaderMetadataWrapper = mock(LeaderMetadataWrapper.class);
+    InMemoryPubSubPosition p10 = InMemoryPubSubPosition.of(10L);
+    doReturn(p10).when(mockLeaderMetadataWrapper).getUpstreamPosition();
     KafkaMessageEnvelope kafkaMessageEnvelope =
         getHeartbeatKME(producerTimestamp, mockLeaderMetadataWrapper, generateHeartbeatMessage(CheckSumType.NONE), "0");
 
@@ -3990,9 +4019,10 @@ public abstract class StoreIngestionTaskTest {
     doReturn(mockOffsetRecord).when(mockPcs).getOffsetRecord();
     doReturn(PARTITION_FOO).when(mockPcs).getPartition();
     doReturn(PARTITION_FOO).when(mockPcs).getPartition();
-    storeIngestionTaskUnderTest.processTopicSwitch(controlMessage, PARTITION_FOO, 10, mockPcs);
+    PubSubPosition p10 = InMemoryPubSubPosition.of(10L);
+    storeIngestionTaskUnderTest.processTopicSwitch(controlMessage, PARTITION_FOO, p10, mockPcs);
     verify(mockTopicManagerRemoteKafka, never()).getOffsetByTime(any(), anyLong());
-    verify(mockOffsetRecord, never()).setLeaderUpstreamOffset(anyString(), anyLong());
+    verify(mockOffsetRecord, never()).setLeaderUpstreamOffset(anyString(), any(PubSubPosition.class));
   }
 
   @Test(dataProvider = "aaConfigProvider")
@@ -4060,29 +4090,35 @@ public abstract class StoreIngestionTaskTest {
         new TopicSwitchWrapper(topicSwitch, pubSubTopicRepository.getTopic(topicSwitch.sourceTopicName.toString()));
     PubSubTopic newSourceTopic = pubSubTopicRepository.getTopic(topicSwitch.sourceTopicName.toString());
     PartitionConsumptionState mockPcs = mock(PartitionConsumptionState.class);
+    doReturn(PubSubSymbolicPosition.EARLIEST).when(mockPcs).getLeaderConsumedUpstreamRTOffset(anyString());
+    doReturn(PubSubSymbolicPosition.EARLIEST).when(mockPcs).getLatestProcessedUpstreamRTOffset(anyString());
     doReturn(IN_TRANSITION_FROM_STANDBY_TO_LEADER).when(mockPcs).getLeaderFollowerState();
     doReturn(topicSwitchWrapper).when(mockPcs).getTopicSwitch();
     OffsetRecord mockOffsetRecord = mock(OffsetRecord.class);
     doReturn(pubSubTopicRepository.getTopic("test_rt")).when(mockOffsetRecord).getLeaderTopic(any());
-    doReturn(1000L).when(mockPcs).getLeaderOffset(anyString(), any(), anyBoolean());
+
+    PubSubPosition p1000 = InMemoryPubSubPosition.of(1000L);
+    doReturn(p1000).when(mockPcs).getLeaderOffset(anyString(), any(), anyBoolean());
     doReturn(mockOffsetRecord).when(mockPcs).getOffsetRecord();
     // Test whether consumedUpstreamRTOffsetMap is updated when leader subscribes to RT after state transition
     ingestionTask.startConsumingAsLeader(mockPcs);
     verify(mockPcs, times(1)).updateLeaderConsumedUpstreamRTOffset(
         eq(aaConfig == AA_ON ? "localhost" : OffsetRecord.NON_AA_REPLICATION_UPSTREAM_OFFSET_MAP_KEY),
-        eq(1000L));
+        eq(p1000));
 
     PubSubTopic rtTopic = pubSubTopicRepository.getTopic("test_rt");
     Supplier<PartitionConsumptionState> mockPcsSupplier = () -> {
       PartitionConsumptionState mock = mock(PartitionConsumptionState.class);
+      doReturn(PubSubSymbolicPosition.EARLIEST).when(mock).getLeaderConsumedUpstreamRTOffset(anyString());
+      doReturn(PubSubSymbolicPosition.EARLIEST).when(mock).getLatestProcessedUpstreamRTOffset(anyString());
       doReturn(LeaderFollowerStateType.LEADER).when(mock).getLeaderFollowerState();
       doReturn(topicSwitchWrapper).when(mock).getTopicSwitch();
       OffsetRecord mockOR = mock(OffsetRecord.class);
       doReturn(rtTopic).when(mockOR).getLeaderTopic(any());
-      doReturn(1000L).when(mock).getLeaderOffset(anyString(), any(), anyBoolean());
+      doReturn(p1000).when(mock).getLeaderOffset(anyString(), any(), anyBoolean());
       System.out.println(mockOR.getLeaderTopic(null));
-      doReturn(1000L).when(mockOR).getUpstreamOffset(anyString());
-      doReturn(1000L).when(mock).getLatestProcessedUpstreamRTOffset(anyString());
+      doReturn(p1000).when(mockOR).getUpstreamOffset(anyString());
+      doReturn(p1000).when(mock).getLatestProcessedUpstreamRTOffset(anyString());
       doReturn(mockOR).when(mock).getOffsetRecord();
       System.out.println("inside mock" + mockOR.getLeaderTopic(null));
       return mock;
@@ -4093,25 +4129,25 @@ public abstract class StoreIngestionTaskTest {
     ingestionTask.leaderExecuteTopicSwitch(mockPcs, topicSwitch, newSourceTopic);
     verify(mockPcs, times(1)).updateLeaderConsumedUpstreamRTOffset(
         eq(aaConfig == AA_ON ? "localhost" : OffsetRecord.NON_AA_REPLICATION_UPSTREAM_OFFSET_MAP_KEY),
-        eq(1000L));
+        eq(p1000));
 
     // Test alternative branch of the code
     Supplier<PartitionConsumptionState> mockPcsSupplier2 = () -> {
       PartitionConsumptionState mock = mockPcsSupplier.get();
-      doReturn(-1L).when(mock).getLeaderOffset(anyString(), any(), anyBoolean());
-      doReturn(-1L).when(mock).getLatestProcessedUpstreamRTOffset(anyString());
+      doReturn(PubSubSymbolicPosition.EARLIEST).when(mock).getLeaderOffset(anyString(), any(), anyBoolean());
+      doReturn(PubSubSymbolicPosition.EARLIEST).when(mock).getLatestProcessedUpstreamRTOffset(anyString());
       doReturn(new PubSubTopicPartitionImpl(rtTopic, 0)).when(mock).getSourceTopicPartition(any());
       return mock;
     };
     mockPcs = mockPcsSupplier2.get();
     ingestionTask.leaderExecuteTopicSwitch(mockPcs, topicSwitch, newSourceTopic);
-    verify(mockPcs, never()).updateLeaderConsumedUpstreamRTOffset(anyString(), anyLong());
+    verify(mockPcs, never()).updateLeaderConsumedUpstreamRTOffset(anyString(), any());
 
     // One more branch
     mockPcs = mockPcsSupplier2.get();
     topicSwitch.rewindStartTimestamp = 0;
     ingestionTask.leaderExecuteTopicSwitch(mockPcs, topicSwitch, newSourceTopic);
-    verify(mockPcs, never()).updateLeaderConsumedUpstreamRTOffset(anyString(), anyLong());
+    verify(mockPcs, never()).updateLeaderConsumedUpstreamRTOffset(anyString(), any());
   }
 
   @Test
@@ -4168,8 +4204,8 @@ public abstract class StoreIngestionTaskTest {
     PartitionConsumptionState partitionConsumptionState =
         new PartitionConsumptionState(Utils.getReplicaId(versionTopicName, 0), 0, offsetRecord, pubSubContext, false);
 
-    long localVersionTopicOffset = 100L;
-    long remoteVersionTopicOffset = 200L;
+    PubSubPosition localVersionTopicOffset = InMemoryPubSubPosition.of(100L);
+    PubSubPosition remoteVersionTopicOffset = InMemoryPubSubPosition.of(200L);
     partitionConsumptionState.updateLatestProcessedLocalVersionTopicOffset(localVersionTopicOffset);
     partitionConsumptionState.updateLatestProcessedUpstreamVersionTopicOffset(remoteVersionTopicOffset);
 
@@ -4471,6 +4507,8 @@ public abstract class StoreIngestionTaskTest {
             HybridStoreConfigImpl.DEFAULT_HYBRID_TIME_LAG_THRESHOLD,
             BufferReplayPolicy.REWIND_FROM_EOP));
 
+    InMemoryPubSubPosition p0 = InMemoryPubSubPosition.of(0L);
+    InMemoryPubSubPosition p2 = InMemoryPubSubPosition.of(2L);
     StoreIngestionTaskTestConfig testConfig = new StoreIngestionTaskTestConfig(Utils.setOf(PARTITION_FOO), () -> {
       // Verify it retrieves the offset from the OffSet Manager
       verify(mockStorageMetadataService, timeout(TEST_TIMEOUT_MS)).getLastOffset(topic, PARTITION_FOO);
@@ -4483,12 +4521,15 @@ public abstract class StoreIngestionTaskTest {
       } else {
         // If the pcs is non-null, then we perform additional checks to ensure that it was not synced
         Assert.assertEquals(
-            pcs.getLatestProcessedLocalVersionTopicOffset(),
-            0L,
+            pcs.getLatestProcessedLocalVersionTopicOffset().getNumericOffset(),
+            p0.getNumericOffset(),
             "pcs.getLatestProcessedLocalVersionTopicOffset() for PARTITION_FOO is expected to be zero!");
         OffsetRecord offsetRecord = pcs.getOffsetRecord();
         assertNotNull(offsetRecord);
-        Assert.assertEquals(offsetRecord.getLocalVersionTopicOffset(), 0L);
+        Assert.assertEquals(
+            PubSubUtil.comparePubSubPositions(offsetRecord.getLocalVersionTopicOffset(), p0),
+            0,
+            "offsetRecord.getLocalVersionTopicOffset() for PARTITION_FOO is expected to be zero!");
       }
 
       // verify 2 messages were processed
@@ -4497,14 +4538,21 @@ public abstract class StoreIngestionTaskTest {
       assertNotNull(pcs, "pcs for PARTITION_FOO is null!");
       OffsetRecord offsetRecord = pcs.getOffsetRecord();
       assertNotNull(offsetRecord);
-      Assert.assertEquals(pcs.getLatestProcessedLocalVersionTopicOffset(), 2L); // PCS updated
-      Assert.assertEquals(offsetRecord.getLocalVersionTopicOffset(), 0L); // offsetRecord hasn't been updated yet
+      Assert.assertEquals(pcs.getLatestProcessedLocalVersionTopicOffset(), p2); // PCS updated
+      Assert.assertEquals(PubSubUtil.comparePubSubPositions(offsetRecord.getLocalVersionTopicOffset(), p0), 0); // offsetRecord
+                                                                                                                // hasn't
+                                                                                                                // been
+                                                                                                                // updated
+                                                                                                                // yet
 
       storeIngestionTaskUnderTest.close();
 
       // Verify the OffsetRecord is synced up with pcs and get persisted only once during shutdown
       verify(mockStorageMetadataService, timeout(TEST_TIMEOUT_MS).times(1)).put(eq(topic), eq(PARTITION_FOO), any());
-      Assert.assertEquals(offsetRecord.getLocalVersionTopicOffset(), 2L);
+      Assert.assertEquals(
+          PubSubUtil.comparePubSubPositions(offsetRecord.getLocalVersionTopicOffset(), p2),
+          0,
+          "offsetRecord.getLocalVersionTopicOffset() for PARTITION_FOO is expected to be 2!");
 
       // Verify that the underlying storage engine sync function is invoked.
       verify(mockAbstractStorageEngine, timeout(TEST_TIMEOUT_MS).times(1)).sync(eq(PARTITION_FOO));
@@ -5423,11 +5471,13 @@ public abstract class StoreIngestionTaskTest {
     String storeName = "test_store";
     int version = 1;
     // No rewind, then nothing would happen
+    PubSubPosition p10 = InMemoryPubSubPosition.of(10);
+    PubSubPosition p11 = InMemoryPubSubPosition.of(11);
     LeaderFollowerStoreIngestionTask.checkAndHandleUpstreamOffsetRewind(
         mock(PartitionConsumptionState.class),
         mock(DefaultPubSubMessage.class),
-        11,
-        10,
+        p11,
+        p10,
         mock(LeaderFollowerStoreIngestionTask.class));
 
     // Rewind with batch only store, nothing would happen
@@ -5441,14 +5491,14 @@ public abstract class StoreIngestionTaskTest {
     LeaderFollowerStoreIngestionTask.checkAndHandleUpstreamOffsetRewind(
         mock(PartitionConsumptionState.class),
         mock(DefaultPubSubMessage.class),
-        10,
-        11,
+        p10,
+        p11,
         mockTask1);
     verify(mockStats1).recordBenignLeaderOffsetRewind(storeName, version);
 
     // Benign rewind
     final long messageOffset = 10;
-    PubSubPosition messagePosition = ApacheKafkaOffsetPosition.of(messageOffset);
+    PubSubPosition messagePosition = InMemoryPubSubPosition.of(messageOffset);
     KafkaKey key = new KafkaKey(MessageType.PUT, "test_key".getBytes());
     KafkaMessageEnvelope messsageEnvelope = new KafkaMessageEnvelope();
     LeaderMetadata leaderMetadata = new LeaderMetadata();
@@ -5493,7 +5543,8 @@ public abstract class StoreIngestionTaskTest {
     when(mockTask2.getVersionedDIVStats()).thenReturn(mockStats2);
     IngestionNotificationDispatcher ingestionNotificationDispatcher = mock(IngestionNotificationDispatcher.class);
     when(mockTask2.getIngestionNotificationDispatcher()).thenReturn(ingestionNotificationDispatcher);
-    LeaderFollowerStoreIngestionTask.checkAndHandleUpstreamOffsetRewind(mockState2, consumedRecord, 10, 11, mockTask2);
+    LeaderFollowerStoreIngestionTask
+        .checkAndHandleUpstreamOffsetRewind(mockState2, consumedRecord, p10, p11, mockTask2);
     verify(mockStats2).recordBenignLeaderOffsetRewind("test_store", 1);
     verify(mockStats2, never()).recordPotentiallyLossyLeaderOffsetRewind(storeName, version);
 
@@ -5507,7 +5558,7 @@ public abstract class StoreIngestionTaskTest {
     VeniceException exception = Assert.expectThrows(
         VeniceException.class,
         () -> LeaderFollowerStoreIngestionTask
-            .checkAndHandleUpstreamOffsetRewind(mockState2, consumedRecord, 10, 11, mockTask2));
+            .checkAndHandleUpstreamOffsetRewind(mockState2, consumedRecord, p10, p11, mockTask2));
     assertTrue(
         exception.getMessage().contains("Failing the job because lossy rewind happens before receiving EndOfPush."));
     // Verify that the VT offset is also in the error message
@@ -5699,9 +5750,10 @@ public abstract class StoreIngestionTaskTest {
     PubSubTopicPartition versionTopicPartition = new PubSubTopicPartitionImpl(versionTopic, PARTITION_FOO);
     PubSubTopicPartition rtPartition = new PubSubTopicPartitionImpl(rtTopic, PARTITION_FOO);
     DefaultPubSubMessage vtRecord =
-        new ImmutablePubSubMessage(key, value, versionTopicPartition, ApacheKafkaOffsetPosition.of(1), 0, 0);
+        new ImmutablePubSubMessage(key, value, versionTopicPartition, InMemoryPubSubPosition.of(1), 0, 0);
 
     PartitionConsumptionState pcs = mock(PartitionConsumptionState.class);
+    when(pcs.getLatestProcessedLocalVersionTopicOffset()).thenReturn(PubSubSymbolicPosition.EARLIEST);
     when(pcs.getLeaderFollowerState()).thenReturn(LeaderFollowerStateType.LEADER);
     doReturn(true).when(pcs).consumeRemotely();
     doReturn(false).when(pcs).skipKafkaMessage();
@@ -5719,7 +5771,7 @@ public abstract class StoreIngestionTaskTest {
 
     doReturn(pubSubTopicRepository.getTopic(rtTopicName)).when(offsetRecord).getLeaderTopic(any());
     DefaultPubSubMessage rtRecord =
-        new ImmutablePubSubMessage(key, value, rtPartition, ApacheKafkaOffsetPosition.of(0), 0, 0);
+        new ImmutablePubSubMessage(key, value, rtPartition, InMemoryPubSubPosition.of(0), 0, 0);
     assertFalse(ingestionTask.shouldProcessRecord(rtRecord), "RT DIV from RT should not be processed");
   }
 
@@ -5790,7 +5842,7 @@ public abstract class StoreIngestionTaskTest {
     brokerIdToUrlMap.forEach((brokerId, url) -> {
       verify(ingestionTask, times(1)).loadGlobalRtDiv(eq(PARTITION_FOO), eq(url));
     });
-    verify(pcs, times(brokerIdToUrlMap.size())).updateLatestConsumedRtOffset(any(), anyLong());
+    verify(pcs, times(brokerIdToUrlMap.size())).updateLatestConsumedRtOffset(any(), any());
   }
 
   @Test
@@ -5905,6 +5957,7 @@ public abstract class StoreIngestionTaskTest {
       when(pcs.isEndOfPushReceived()).thenReturn(true);
       when(pcs.isLatchCreated()).thenReturn(false);
       when(pcs.isLatchReleased()).thenReturn(false);
+      when(pcs.getLatestProcessedLocalVersionTopicOffset()).thenReturn(PubSubSymbolicPosition.EARLIEST);
       storeIngestionTaskUnderTest.reportIfCatchUpVersionTopicOffset(pcs);
       verify(storeIngestionTaskUnderTest, never()).measureLagWithCallToPubSub(anyString(), any(), eq(P), anyLong());
 
@@ -5943,13 +5996,13 @@ public abstract class StoreIngestionTaskTest {
       upstreamUrlSet.add("dc-2");
       upstreamUrlSet.add("dc-3");
     }
-    Map<String, Long> upstreamOffsetMap = new HashMap<>();
+    Map<String, PubSubPosition> upstreamOffsetMap = new HashMap<>();
     if (aaEnabled) {
-      upstreamOffsetMap.put("dc-1", 100L);
-      upstreamOffsetMap.put("dc-2", 20L);
-      upstreamOffsetMap.put("dc-3", 3L);
+      upstreamOffsetMap.put("dc-1", InMemoryPubSubPosition.of(100L));
+      upstreamOffsetMap.put("dc-2", InMemoryPubSubPosition.of(20L));
+      upstreamOffsetMap.put("dc-3", InMemoryPubSubPosition.of(3L));
     } else {
-      upstreamOffsetMap.put(OffsetRecord.NON_AA_REPLICATION_UPSTREAM_OFFSET_MAP_KEY, 1000L);
+      upstreamOffsetMap.put(OffsetRecord.NON_AA_REPLICATION_UPSTREAM_OFFSET_MAP_KEY, InMemoryPubSubPosition.of(1000L));
     }
     when(ingestionTask.getConsumptionSourceKafkaAddress(pcs)).thenReturn(upstreamUrlSet);
     when(pcs.getLatestProcessedUpstreamRTOffsetMap()).thenReturn(upstreamOffsetMap);
@@ -5958,19 +6011,27 @@ public abstract class StoreIngestionTaskTest {
     ingestionTask.resubscribeAsLeader(pcs);
 
     ArgumentCaptor<String> urlCaptor = ArgumentCaptor.forClass(String.class);
-    ArgumentCaptor<Long> offsetCaptor = ArgumentCaptor.forClass(Long.class);
+    ArgumentCaptor<PubSubPosition> offsetCaptor = ArgumentCaptor.forClass(PubSubPosition.class);
     verify(ingestionTask, times(aaEnabled ? 3 : 1))
         .consumerSubscribe(any(), any(), offsetCaptor.capture(), urlCaptor.capture());
     List<String> urls = urlCaptor.getAllValues();
-    List<Long> offsets = offsetCaptor.getAllValues();
+    List<PubSubPosition> offsets = offsetCaptor.getAllValues();
     if (aaEnabled) {
       Assert.assertEquals(urls.size(), 3);
       Assert.assertEquals(offsets.size(), 3);
-      Assert.assertEquals(offsets.get(0) + offsets.get(1) + offsets.get(2), 123L);
+      InMemoryPubSubPosition p1 = (InMemoryPubSubPosition) offsets.get(0);
+      InMemoryPubSubPosition p2 = (InMemoryPubSubPosition) offsets.get(1);
+      InMemoryPubSubPosition p3 = (InMemoryPubSubPosition) offsets.get(2);
+      long sum = p1.getInternalOffset() + p2.getInternalOffset() + p3.getInternalOffset();
+      Assert.assertEquals(
+          sum,
+          123L,
+          "The sum of offsets should be equal to the sum of upstream offsets: 100 + 20 + 3 = 123 but got " + sum);
     } else {
+      InMemoryPubSubPosition p1 = (InMemoryPubSubPosition) offsets.get(0);
       Assert.assertEquals(urls.size(), 1);
       Assert.assertEquals(offsets.size(), 1);
-      Assert.assertEquals(offsets.get(0).longValue(), 1000L);
+      Assert.assertEquals(p1.getInternalOffset(), 1000L);
     }
   }
 
@@ -5998,21 +6059,24 @@ public abstract class StoreIngestionTaskTest {
       upstreamUrlSet.add("dc-2");
       upstreamUrlSet.add("dc-3");
     }
-    Map<String, Long> upstreamOffsetMap = new HashMap<>();
+    Map<String, PubSubPosition> upstreamOffsetMap = new HashMap<>();
     when(ingestionTask.getConsumptionSourceKafkaAddress(pcs)).thenReturn(upstreamUrlSet);
     when(pcs.getLatestProcessedUpstreamRTOffsetMap()).thenReturn(upstreamOffsetMap);
     doCallRealMethod().when(pcs).getLatestProcessedUpstreamRTOffset(anyString());
     doCallRealMethod().when(pcs).getLeaderOffset(anyString(), any());
-    when(pcs.getLatestProcessedUpstreamVersionTopicOffset()).thenReturn(100L);
+    PubSubPosition p100 = InMemoryPubSubPosition.of(100L);
+    when(pcs.getLatestProcessedUpstreamVersionTopicOffset()).thenReturn(p100);
     when(pcs.consumeRemotely()).thenReturn(true);
     ingestionTask.prepareOffsetCheckpointAndStartConsumptionAsLeader(pubSubTopic, pcs, false);
 
     if (aaEnabled) {
-      Assert.assertEquals(offsetRecord.getUpstreamOffset("dc-1"), -1);
-      Assert.assertEquals(offsetRecord.getUpstreamOffset("dc-2"), -1);
-      Assert.assertEquals(offsetRecord.getUpstreamOffset("dc-3"), -1);
+      Assert.assertEquals(offsetRecord.getUpstreamOffset("dc-1"), PubSubSymbolicPosition.EARLIEST);
+      Assert.assertEquals(offsetRecord.getUpstreamOffset("dc-2"), PubSubSymbolicPosition.EARLIEST);
+      Assert.assertEquals(offsetRecord.getUpstreamOffset("dc-3"), PubSubSymbolicPosition.EARLIEST);
     } else {
-      Assert.assertEquals(offsetRecord.getUpstreamOffset(OffsetRecord.NON_AA_REPLICATION_UPSTREAM_OFFSET_MAP_KEY), -1);
+      Assert.assertEquals(
+          offsetRecord.getUpstreamOffset(OffsetRecord.NON_AA_REPLICATION_UPSTREAM_OFFSET_MAP_KEY),
+          PubSubSymbolicPosition.EARLIEST);
     }
 
   }

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/store/rocksdb/RocksDBStorageEngineTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/store/rocksdb/RocksDBStorageEngineTest.java
@@ -135,7 +135,7 @@ public class RocksDBStorageEngineTest extends AbstractStorageEngineTest<RocksDBS
     GUID guid = new GUID();
     offsetRecord.setRealtimeTopicProducerState(kafkaUrl, guid, ppState);
     PubSubPosition p666 = ApacheKafkaOffsetPosition.of(666L);
-    offsetRecord.setCheckpointLocalVersionTopicPosition(p666);
+    offsetRecord.checkpointLocalVtPosition(p666);
     rocksDBStorageEngine.putPartitionOffset(PARTITION_ID, offsetRecord);
     Assert.assertEquals(rocksDBStorageEngine.getPartitionOffset(PARTITION_ID).get().getLocalVersionTopicOffset(), p666);
     ProducerPartitionState ppStateFromRocksDB =

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/store/rocksdb/RocksDBStorageEngineTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/store/rocksdb/RocksDBStorageEngineTest.java
@@ -135,7 +135,7 @@ public class RocksDBStorageEngineTest extends AbstractStorageEngineTest<RocksDBS
     GUID guid = new GUID();
     offsetRecord.setRealtimeTopicProducerState(kafkaUrl, guid, ppState);
     PubSubPosition p666 = ApacheKafkaOffsetPosition.of(666L);
-    offsetRecord.setCheckpointLocalVersionTopicOffset(p666);
+    offsetRecord.setCheckpointLocalVersionTopicPosition(p666);
     rocksDBStorageEngine.putPartitionOffset(PARTITION_ID, offsetRecord);
     Assert.assertEquals(rocksDBStorageEngine.getPartitionOffset(PARTITION_ID).get().getLocalVersionTopicOffset(), p666);
     ProducerPartitionState ppStateFromRocksDB =

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/store/rocksdb/RocksDBStorageEngineTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/store/rocksdb/RocksDBStorageEngineTest.java
@@ -137,7 +137,9 @@ public class RocksDBStorageEngineTest extends AbstractStorageEngineTest<RocksDBS
     PubSubPosition p666 = ApacheKafkaOffsetPosition.of(666L);
     offsetRecord.checkpointLocalVtPosition(p666);
     rocksDBStorageEngine.putPartitionOffset(PARTITION_ID, offsetRecord);
-    Assert.assertEquals(rocksDBStorageEngine.getPartitionOffset(PARTITION_ID).get().getLocalVersionTopicOffset(), p666);
+    Assert.assertEquals(
+        rocksDBStorageEngine.getPartitionOffset(PARTITION_ID).get().getCheckpointedLocalVtPosition(),
+        p666);
     ProducerPartitionState ppStateFromRocksDB =
         rocksDBStorageEngine.getPartitionOffset(PARTITION_ID).get().getRealTimeProducerState(kafkaUrl, guid);
     Assert.assertEquals(ppStateFromRocksDB.getSegmentNumber(), segment);

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/store/rocksdb/RocksDBStorageEngineTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/store/rocksdb/RocksDBStorageEngineTest.java
@@ -20,6 +20,8 @@ import com.linkedin.venice.meta.ReadOnlyStoreRepository;
 import com.linkedin.venice.meta.Store;
 import com.linkedin.venice.meta.Version;
 import com.linkedin.venice.offsets.OffsetRecord;
+import com.linkedin.venice.pubsub.adapter.kafka.common.ApacheKafkaOffsetPosition;
+import com.linkedin.venice.pubsub.api.PubSubPosition;
 import com.linkedin.venice.serialization.avro.AvroProtocolDefinition;
 import com.linkedin.venice.utils.Utils;
 import com.linkedin.venice.utils.VeniceProperties;
@@ -132,9 +134,10 @@ public class RocksDBStorageEngineTest extends AbstractStorageEngineTest<RocksDBS
     ProducerPartitionState ppState = createProducerPartitionState(segment, sequence);
     GUID guid = new GUID();
     offsetRecord.setRealtimeTopicProducerState(kafkaUrl, guid, ppState);
-    offsetRecord.setCheckpointLocalVersionTopicOffset(666L);
+    PubSubPosition p666 = ApacheKafkaOffsetPosition.of(666L);
+    offsetRecord.setCheckpointLocalVersionTopicOffset(p666);
     rocksDBStorageEngine.putPartitionOffset(PARTITION_ID, offsetRecord);
-    Assert.assertEquals(rocksDBStorageEngine.getPartitionOffset(PARTITION_ID).get().getLocalVersionTopicOffset(), 666L);
+    Assert.assertEquals(rocksDBStorageEngine.getPartitionOffset(PARTITION_ID).get().getLocalVersionTopicOffset(), p666);
     ProducerPartitionState ppStateFromRocksDB =
         rocksDBStorageEngine.getPartitionOffset(PARTITION_ID).get().getRealTimeProducerState(kafkaUrl, guid);
     Assert.assertEquals(ppStateFromRocksDB.getSegmentNumber(), segment);

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/store/view/ChangeCaptureViewWriterTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/store/view/ChangeCaptureViewWriterTest.java
@@ -78,15 +78,13 @@ public class ChangeCaptureViewWriterTest {
     PartitionConsumptionState mockLeaderPartitionConsumptionState = mock(PartitionConsumptionState.class);
     Mockito.when(mockLeaderPartitionConsumptionState.getLeaderFollowerState())
         .thenReturn(LeaderFollowerStateType.LEADER);
-    Mockito.when(mockLeaderPartitionConsumptionState.getLatestProcessedUpstreamRTOffsetMap())
-        .thenReturn(highWaterMarks);
+    Mockito.when(mockLeaderPartitionConsumptionState.getLatestProcessedRtPositions()).thenReturn(highWaterMarks);
     Mockito.when(mockLeaderPartitionConsumptionState.getPartition()).thenReturn(1);
 
     PartitionConsumptionState mockFollowerPartitionConsumptionState = mock(PartitionConsumptionState.class);
     Mockito.when(mockFollowerPartitionConsumptionState.getLeaderFollowerState())
         .thenReturn(LeaderFollowerStateType.STANDBY);
-    Mockito.when(mockFollowerPartitionConsumptionState.getLatestProcessedUpstreamRTOffsetMap())
-        .thenReturn(highWaterMarks);
+    Mockito.when(mockFollowerPartitionConsumptionState.getLatestProcessedRtPositions()).thenReturn(highWaterMarks);
     Mockito.when(mockFollowerPartitionConsumptionState.getPartition()).thenReturn(1);
 
     VersionSwap versionSwapMessage = new VersionSwap();

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/store/view/ChangeCaptureViewWriterTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/store/view/ChangeCaptureViewWriterTest.java
@@ -21,6 +21,8 @@ import com.linkedin.venice.meta.Version;
 import com.linkedin.venice.meta.VersionImpl;
 import com.linkedin.venice.pubsub.PubSubClientsFactory;
 import com.linkedin.venice.pubsub.PubSubProducerAdapterFactory;
+import com.linkedin.venice.pubsub.adapter.kafka.common.ApacheKafkaOffsetPosition;
+import com.linkedin.venice.pubsub.api.PubSubPosition;
 import com.linkedin.venice.pubsub.api.PubSubProduceResult;
 import com.linkedin.venice.schema.rmd.RmdSchemaGenerator;
 import com.linkedin.venice.utils.VeniceProperties;
@@ -69,10 +71,10 @@ public class ChangeCaptureViewWriterTest {
 
   @Test
   public void testConstructVersionSwapMessage() {
-    Map<String, Long> highWaterMarks = new HashMap<>();
-    highWaterMarks.put(LOR_1, 111L);
-    highWaterMarks.put(LTX_1, 99L);
-    highWaterMarks.put(LVA_1, 22222L);
+    Map<String, PubSubPosition> highWaterMarks = new HashMap<>();
+    highWaterMarks.put(LOR_1, ApacheKafkaOffsetPosition.of(111L));
+    highWaterMarks.put(LTX_1, ApacheKafkaOffsetPosition.of(99L));
+    highWaterMarks.put(LVA_1, ApacheKafkaOffsetPosition.of(22222L));
     PartitionConsumptionState mockLeaderPartitionConsumptionState = mock(PartitionConsumptionState.class);
     Mockito.when(mockLeaderPartitionConsumptionState.getLeaderFollowerState())
         .thenReturn(LeaderFollowerStateType.LEADER);
@@ -183,9 +185,16 @@ public class ChangeCaptureViewWriterTest {
     VersionSwap sentVersionSwapMessage = (VersionSwap) sentControlMessage.controlMessageUnion;
     Assert.assertEquals(sentVersionSwapMessage.oldServingVersionTopic, Version.composeKafkaTopic(STORE_NAME, 1));
     Assert.assertEquals(sentVersionSwapMessage.newServingVersionTopic, Version.composeKafkaTopic(STORE_NAME, 2));
-    Assert.assertEquals(sentVersionSwapMessage.localHighWatermarks.get(0), highWaterMarks.get(LTX_1));
-    Assert.assertEquals(sentVersionSwapMessage.localHighWatermarks.get(1), highWaterMarks.get(LVA_1));
-    Assert.assertEquals(sentVersionSwapMessage.localHighWatermarks.get(2), highWaterMarks.get(LOR_1));
+    Assert.assertEquals(
+        (long) sentVersionSwapMessage.localHighWatermarks.get(0),
+        highWaterMarks.get(LTX_1).getNumericOffset());
+    Assert.assertEquals(
+        (long) sentVersionSwapMessage.localHighWatermarks.get(1),
+        highWaterMarks.get(LVA_1).getNumericOffset());
+    Assert.assertEquals(
+        (long) sentVersionSwapMessage.localHighWatermarks.get(2),
+        highWaterMarks.get(LOR_1).getNumericOffset());
+    // TODO(sushantmane): Add assertions to verify the correctness localHighWatermarks with PubSubPosition
   }
 
   @Test

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/validation/TestPartitionTracker.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/validation/TestPartitionTracker.java
@@ -452,7 +452,7 @@ public class TestPartitionTracker {
     Segment firstSegment = new Segment(partitionId, 0, checkSumType);
     Segment secondSegment = new Segment(partitionId, 1, checkSumType);
     long offset = 10;
-    OffsetRecord record = TestUtils.getOffsetRecord(offset);
+    OffsetRecord record = TestUtils.getOffsetRecord(ApacheKafkaOffsetPosition.of(offset), Optional.empty());
 
     // Send SOS with check sum type set to checkpoint-able checkSumType.
     ControlMessage startOfSegment = getStartOfSegment(checkSumType);

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/task/datawriter/CompositeVeniceWriter.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/task/datawriter/CompositeVeniceWriter.java
@@ -3,12 +3,12 @@ package com.linkedin.venice.hadoop.task.datawriter;
 import static com.linkedin.venice.writer.VeniceWriter.APP_DEFAULT_LOGICAL_TS;
 import static com.linkedin.venice.writer.VeniceWriter.DEFAULT_TERM_ID;
 import static com.linkedin.venice.writer.VeniceWriter.DEFAULT_UPSTREAM_KAFKA_CLUSTER_ID;
-import static com.linkedin.venice.writer.VeniceWriter.DEFAULT_UPSTREAM_PUBSUB_POSITION;
 
 import com.linkedin.venice.annotation.NotThreadsafe;
 import com.linkedin.venice.exceptions.VeniceException;
 import com.linkedin.venice.pubsub.api.PubSubProduceResult;
 import com.linkedin.venice.pubsub.api.PubSubProducerCallback;
+import com.linkedin.venice.pubsub.api.PubSubSymbolicPosition;
 import com.linkedin.venice.utils.lazy.Lazy;
 import com.linkedin.venice.writer.AbstractVeniceWriter;
 import com.linkedin.venice.writer.ComplexVeniceWriter;
@@ -200,7 +200,7 @@ public class CompositeVeniceWriter<K, V, U> extends AbstractVeniceWriter<K, V, U
           putMetadata);
     }
     LeaderMetadataWrapper leaderMetadataWrapper = new LeaderMetadataWrapper(
-        DEFAULT_UPSTREAM_PUBSUB_POSITION,
+        PubSubSymbolicPosition.EARLIEST,
         DEFAULT_UPSTREAM_KAFKA_CLUSTER_ID,
         DEFAULT_TERM_ID,
         viewPartitionMap);

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/task/datawriter/CompositeVeniceWriter.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/task/datawriter/CompositeVeniceWriter.java
@@ -3,7 +3,6 @@ package com.linkedin.venice.hadoop.task.datawriter;
 import static com.linkedin.venice.writer.VeniceWriter.APP_DEFAULT_LOGICAL_TS;
 import static com.linkedin.venice.writer.VeniceWriter.DEFAULT_TERM_ID;
 import static com.linkedin.venice.writer.VeniceWriter.DEFAULT_UPSTREAM_KAFKA_CLUSTER_ID;
-import static com.linkedin.venice.writer.VeniceWriter.DEFAULT_UPSTREAM_OFFSET;
 import static com.linkedin.venice.writer.VeniceWriter.DEFAULT_UPSTREAM_PUBSUB_POSITION;
 
 import com.linkedin.venice.annotation.NotThreadsafe;
@@ -201,10 +200,9 @@ public class CompositeVeniceWriter<K, V, U> extends AbstractVeniceWriter<K, V, U
           putMetadata);
     }
     LeaderMetadataWrapper leaderMetadataWrapper = new LeaderMetadataWrapper(
-        DEFAULT_UPSTREAM_OFFSET,
+        DEFAULT_UPSTREAM_PUBSUB_POSITION,
         DEFAULT_UPSTREAM_KAFKA_CLUSTER_ID,
         DEFAULT_TERM_ID,
-        DEFAULT_UPSTREAM_PUBSUB_POSITION,
         viewPartitionMap);
     // We only need to pass the logical timestamp to the main writer as it's only used for write conflict resolution
     // in the venice server or TTL repush. So we don't need to pass it to view topics.

--- a/internal/venice-common/src/main/java/com/linkedin/venice/offsets/OffsetRecord.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/offsets/OffsetRecord.java
@@ -1,7 +1,6 @@
 package com.linkedin.venice.offsets;
 
 import static com.linkedin.venice.pubsub.PubSubUtil.fromKafkaOffset;
-import static com.linkedin.venice.writer.VeniceWriter.DEFAULT_UPSTREAM_PUBSUB_POSITION;
 
 import com.linkedin.venice.exceptions.VeniceException;
 import com.linkedin.venice.guid.GuidUtils;
@@ -73,9 +72,9 @@ public class OffsetRecord {
     emptyPartitionState.lastUpdate = 0;
     emptyPartitionState.databaseInfo = new VeniceConcurrentHashMap<>();
     emptyPartitionState.previousStatuses = new VeniceConcurrentHashMap<>();
-    emptyPartitionState.leaderOffset = DEFAULT_UPSTREAM_PUBSUB_POSITION.getNumericOffset();
+    emptyPartitionState.leaderOffset = PubSubSymbolicPosition.EARLIEST.getNumericOffset();
     emptyPartitionState.upstreamOffsetMap = new VeniceConcurrentHashMap<>();
-    emptyPartitionState.upstreamVersionTopicOffset = DEFAULT_UPSTREAM_PUBSUB_POSITION.getNumericOffset();
+    emptyPartitionState.upstreamVersionTopicOffset = PubSubSymbolicPosition.EARLIEST.getNumericOffset();
     emptyPartitionState.pendingReportIncrementalPushVersions = new ArrayList<>();
     emptyPartitionState.setRealtimeTopicProducerStates(new VeniceConcurrentHashMap<>());
     emptyPartitionState.upstreamRealTimeTopicPubSubPositionMap = new VeniceConcurrentHashMap<>();

--- a/internal/venice-common/src/main/java/com/linkedin/venice/offsets/OffsetRecord.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/offsets/OffsetRecord.java
@@ -90,6 +90,7 @@ public class OffsetRecord {
   }
 
   public PubSubPosition getLocalVersionTopicOffset() {
+    // TODO: Replace with lastProcessedVersionTopicPubSubPosition
     return fromKafkaOffset(this.partitionState.offset);
   }
 
@@ -101,15 +102,13 @@ public class OffsetRecord {
     return partitionState.getPreviousStatuses().getOrDefault(key, NULL_STRING).toString();
   }
 
-  public void setCheckpointLocalVersionTopicOffset(PubSubPosition offset) {
-    if (offset == null) {
-      throw new IllegalArgumentException("Offset cannot be null.");
+  public void setCheckpointLocalVersionTopicPosition(PubSubPosition vtPosition) {
+    if (vtPosition == null || vtPosition.getPositionWireFormat() == null) {
+      String msg = (vtPosition == null) ? "Position" : "Position wire format";
+      throw new IllegalArgumentException(msg + " cannot be null");
     }
-    if (offset.getPositionWireFormat() == null) {
-      throw new IllegalArgumentException("Offset cannot be symbolic." + offset);
-    }
-    this.partitionState.lastProcessedVersionTopicPubSubPosition = offset.toWireFormatBuffer();
-    this.partitionState.offset = offset.getNumericOffset();
+    this.partitionState.lastProcessedVersionTopicPubSubPosition = vtPosition.toWireFormatBuffer();
+    this.partitionState.offset = vtPosition.getNumericOffset();
   }
 
   public PubSubPosition getCheckpointUpstreamVersionTopicOffset() {

--- a/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/PubSubUtil.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/PubSubUtil.java
@@ -7,6 +7,7 @@ import static com.linkedin.venice.ConfigKeys.PUBSUB_SECURITY_PROTOCOL;
 import static com.linkedin.venice.ConfigKeys.PUBSUB_SECURITY_PROTOCOL_LEGACY;
 import static com.linkedin.venice.pubsub.PubSubConstants.PUBSUB_CLIENT_CONFIG_PREFIX;
 
+import com.linkedin.venice.pubsub.adapter.kafka.common.ApacheKafkaOffsetPosition;
 import com.linkedin.venice.pubsub.api.PubSubConsumerAdapter;
 import com.linkedin.venice.pubsub.api.PubSubPosition;
 import com.linkedin.venice.pubsub.api.PubSubSecurityProtocol;
@@ -14,6 +15,7 @@ import com.linkedin.venice.pubsub.api.PubSubSymbolicPosition;
 import com.linkedin.venice.pubsub.api.PubSubTopicPartition;
 import com.linkedin.venice.utils.Utils;
 import com.linkedin.venice.utils.VeniceProperties;
+import java.nio.ByteBuffer;
 import java.util.Properties;
 
 
@@ -295,5 +297,23 @@ public final class PubSubUtil {
    */
   public static long calculateSeekOffset(long baseOffset, boolean isInclusive) {
     return isInclusive ? baseOffset : baseOffset + 1;
+  }
+
+  /**
+   * Get the Kafka offset position buffer for the given offset.
+   * This is temporarily used to convert the offset to a buffer during the transition to using
+   * {@link com.linkedin.venice.pubsub.api.PubSubPosition} in the OffsetRecord.
+   * @param offset the offset to convert
+   * @return a ByteBuffer representing the Kafka offset position
+   */
+  public static ByteBuffer toKafkaPositionWf(long offset) {
+    return ApacheKafkaOffsetPosition.of(offset).toWireFormatBuffer();
+  }
+
+  public static PubSubPosition fromKafkaOffset(long offset) {
+    if (offset == -1) {
+      return PubSubSymbolicPosition.EARLIEST; // -1 is start offset
+    }
+    return ApacheKafkaOffsetPosition.of(offset);
   }
 }

--- a/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/PubSubUtil.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/PubSubUtil.java
@@ -202,21 +202,21 @@ public final class PubSubUtil {
       throw new IllegalArgumentException("Positions cannot be null");
     }
 
-    if ((position1 == PubSubSymbolicPosition.EARLIEST && position2 == PubSubSymbolicPosition.EARLIEST)
-        || (position1 == PubSubSymbolicPosition.LATEST && position2 == PubSubSymbolicPosition.LATEST)) {
+    if ((PubSubSymbolicPosition.EARLIEST.equals(position1) && PubSubSymbolicPosition.EARLIEST.equals(position2))
+        || (PubSubSymbolicPosition.LATEST.equals(position1) && PubSubSymbolicPosition.LATEST.equals(position2))) {
       return 0;
     }
 
-    if (position1 == PubSubSymbolicPosition.EARLIEST) {
+    if (PubSubSymbolicPosition.EARLIEST.equals(position1)) {
       return -1;
     }
-    if (position1 == PubSubSymbolicPosition.LATEST) {
+    if (PubSubSymbolicPosition.LATEST.equals(position1)) {
       return 1;
     }
-    if (position2 == PubSubSymbolicPosition.EARLIEST) {
+    if (PubSubSymbolicPosition.EARLIEST.equals(position2)) {
       return 1;
     }
-    if (position2 == PubSubSymbolicPosition.LATEST) {
+    if (PubSubSymbolicPosition.LATEST.equals(position2)) {
       return -1;
     }
 
@@ -252,23 +252,23 @@ public final class PubSubUtil {
 
     // Case 2: Equal symbolic positions
     if (resolved1 == resolved2
-        && (resolved1 == PubSubSymbolicPosition.EARLIEST || resolved1 == PubSubSymbolicPosition.LATEST)) {
+        && (PubSubSymbolicPosition.EARLIEST.equals(resolved1) || PubSubSymbolicPosition.LATEST.equals(resolved1))) {
       return 0L;
     }
 
     // Case 3: One is EARLIEST, one is concrete
-    if (resolved1 == PubSubSymbolicPosition.EARLIEST && concretePositionClass.isInstance(resolved2)) {
+    if (PubSubSymbolicPosition.EARLIEST.equals(resolved1) && concretePositionClass.isInstance(resolved2)) {
       return -offsetExtractor.getInternalOffset(concretePositionClass.cast(resolved2));
     }
-    if (resolved2 == PubSubSymbolicPosition.EARLIEST && concretePositionClass.isInstance(resolved1)) {
+    if (PubSubSymbolicPosition.EARLIEST.equals(resolved2) && concretePositionClass.isInstance(resolved1)) {
       return offsetExtractor.getInternalOffset(concretePositionClass.cast(resolved1));
     }
 
     // Case 4: One is LATEST, one is concrete
-    if (resolved1 == PubSubSymbolicPosition.LATEST && concretePositionClass.isInstance(resolved2)) {
+    if (PubSubSymbolicPosition.LATEST.equals(resolved1) && concretePositionClass.isInstance(resolved2)) {
       return Long.MAX_VALUE - offsetExtractor.getInternalOffset(concretePositionClass.cast(resolved2));
     }
-    if (resolved2 == PubSubSymbolicPosition.LATEST && concretePositionClass.isInstance(resolved1)) {
+    if (PubSubSymbolicPosition.LATEST.equals(resolved2) && concretePositionClass.isInstance(resolved1)) {
       return offsetExtractor.getInternalOffset(concretePositionClass.cast(resolved1)) - Long.MAX_VALUE;
     }
 
@@ -280,9 +280,9 @@ public final class PubSubUtil {
       PubSubTopicPartition partition,
       PubSubPosition position,
       PubSubConsumerAdapter consumerAdapter) {
-    if (position == PubSubSymbolicPosition.EARLIEST) {
+    if (PubSubSymbolicPosition.EARLIEST.equals(position)) {
       return consumerAdapter.beginningPosition(partition);
-    } else if (position == PubSubSymbolicPosition.LATEST) {
+    } else if (PubSubSymbolicPosition.LATEST.equals(position)) {
       return consumerAdapter.endPosition(partition);
     }
     return position;

--- a/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/adapter/kafka/consumer/ApacheKafkaConsumerAdapter.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/adapter/kafka/consumer/ApacheKafkaConsumerAdapter.java
@@ -158,10 +158,10 @@ public class ApacheKafkaConsumerAdapter implements PubSubConsumerAdapter {
     kafkaConsumer.assign(topicPartitionList);
 
     String logMessage;
-    if (position == PubSubSymbolicPosition.EARLIEST) {
+    if (PubSubSymbolicPosition.EARLIEST.equals(position)) {
       kafkaConsumer.seekToBeginning(Collections.singletonList(topicPartition));
       logMessage = PubSubSymbolicPosition.EARLIEST + " (beginning)";
-    } else if (position == PubSubSymbolicPosition.LATEST) {
+    } else if (PubSubSymbolicPosition.LATEST.equals(position)) {
       kafkaConsumer.seekToEnd(Collections.singletonList(topicPartition));
       logMessage = PubSubSymbolicPosition.LATEST + " (end)";
     } else if (position instanceof ApacheKafkaOffsetPosition) {

--- a/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/api/EarliestPosition.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/api/EarliestPosition.java
@@ -76,6 +76,6 @@ final class EarliestPosition implements PubSubPosition {
 
   @Override
   public long getNumericOffset() {
-    return -1;
+    return -1L;
   }
 }

--- a/internal/venice-common/src/main/java/com/linkedin/venice/writer/LeaderMetadataWrapper.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/writer/LeaderMetadataWrapper.java
@@ -1,6 +1,6 @@
 package com.linkedin.venice.writer;
 
-import java.nio.ByteBuffer;
+import com.linkedin.venice.pubsub.api.PubSubPosition;
 import java.util.Map;
 import java.util.Set;
 
@@ -11,35 +11,28 @@ import java.util.Set;
  */
 
 public class LeaderMetadataWrapper {
-  private final long upstreamOffset;
+  private final PubSubPosition upstreamPosition;
   private final int upstreamKafkaClusterId;
   private final Map<String, Set<Integer>> viewPartitionMap;
-  private final ByteBuffer upstreamPubSubPosition;
   private final long termId;
 
-  public LeaderMetadataWrapper(
-      long upstreamOffset,
-      int upstreamKafkaClusterId,
-      long termId,
-      ByteBuffer upstreamPubSubPosition) {
-    this(upstreamOffset, upstreamKafkaClusterId, termId, upstreamPubSubPosition, null);
+  public LeaderMetadataWrapper(PubSubPosition upstreamPosition, int upstreamKafkaClusterId, long termId) {
+    this(upstreamPosition, upstreamKafkaClusterId, termId, null);
   }
 
   public LeaderMetadataWrapper(
-      long upstreamOffset,
+      PubSubPosition upstreamPosition,
       int upstreamKafkaClusterId,
       long termId,
-      ByteBuffer upstreamPubSubPosition,
       Map<String, Set<Integer>> viewPartitionMap) {
-    this.upstreamOffset = upstreamOffset;
+    this.upstreamPosition = upstreamPosition;
     this.upstreamKafkaClusterId = upstreamKafkaClusterId;
     this.termId = termId;
-    this.upstreamPubSubPosition = upstreamPubSubPosition;
     this.viewPartitionMap = viewPartitionMap;
   }
 
-  public long getUpstreamOffset() {
-    return upstreamOffset;
+  public PubSubPosition getUpstreamPosition() {
+    return upstreamPosition;
   }
 
   public int getUpstreamKafkaClusterId() {
@@ -48,10 +41,6 @@ public class LeaderMetadataWrapper {
 
   public Map<String, Set<Integer>> getViewPartitionMap() {
     return viewPartitionMap;
-  }
-
-  public ByteBuffer getUpstreamPubSubPosition() {
-    return upstreamPubSubPosition;
   }
 
   public long getTermId() {

--- a/internal/venice-common/src/main/java/com/linkedin/venice/writer/VeniceWriter.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/writer/VeniceWriter.java
@@ -39,7 +39,6 @@ import com.linkedin.venice.partitioner.VenicePartitioner;
 import com.linkedin.venice.pubsub.api.EmptyPubSubMessageHeaders;
 import com.linkedin.venice.pubsub.api.PubSubMessageHeader;
 import com.linkedin.venice.pubsub.api.PubSubMessageHeaders;
-import com.linkedin.venice.pubsub.api.PubSubPosition;
 import com.linkedin.venice.pubsub.api.PubSubProduceResult;
 import com.linkedin.venice.pubsub.api.PubSubProducerAdapter;
 import com.linkedin.venice.pubsub.api.PubSubProducerCallback;
@@ -182,16 +181,6 @@ public class VeniceWriter<K, V, U> extends AbstractVeniceWriter<K, V, U> {
    */
   public static final int DEFAULT_MAX_ATTEMPTS_WHEN_TOPIC_MISSING = 30;
 
-  /**
-   * The default value of the "upstreamOffset" field in avro record {@link LeaderMetadata}.
-   *
-   * Even though we have set the default value for "upstreamOffset" field as -1, the initial value for the long field
-   * "upstreamOffset" is still 0 when we construct a LeaderMetadata record. Default field values are primarily used
-   * when reading records that don't have those fields, typically when we deserialize a record from older version to
-   * newer version.
-   */
-  public static final PubSubPosition DEFAULT_UPSTREAM_PUBSUB_POSITION = PubSubSymbolicPosition.EARLIEST;
-
   public static final int DEFAULT_UPSTREAM_KAFKA_CLUSTER_ID =
       (int) AvroCompatibilityHelper.getSpecificDefaultValue(LeaderMetadata.SCHEMA$.getField("upstreamKafkaClusterId"));
 
@@ -239,7 +228,7 @@ public class VeniceWriter<K, V, U> extends AbstractVeniceWriter<K, V, U> {
   public static final ByteBuffer EMPTY_BYTE_BUFFER = ByteBuffer.wrap(EMPTY_BYTE_ARRAY);
 
   public static final LeaderMetadataWrapper DEFAULT_LEADER_METADATA_WRAPPER =
-      new LeaderMetadataWrapper(DEFAULT_UPSTREAM_PUBSUB_POSITION, DEFAULT_UPSTREAM_KAFKA_CLUSTER_ID, DEFAULT_TERM_ID);
+      new LeaderMetadataWrapper(PubSubSymbolicPosition.EARLIEST, DEFAULT_UPSTREAM_KAFKA_CLUSTER_ID, DEFAULT_TERM_ID);
 
   // Immutable state
   private final PubSubMessageHeader protocolSchemaHeader;
@@ -1696,7 +1685,7 @@ public class VeniceWriter<K, V, U> extends AbstractVeniceWriter<K, V, U> {
         leaderMetadataWrapper.getViewPartitionMap() == null
             ? DEFAULT_LEADER_METADATA_WRAPPER
             : new LeaderMetadataWrapper(
-                DEFAULT_UPSTREAM_PUBSUB_POSITION,
+                PubSubSymbolicPosition.EARLIEST,
                 DEFAULT_UPSTREAM_KAFKA_CLUSTER_ID,
                 DEFAULT_TERM_ID,
                 leaderMetadataWrapper.getViewPartitionMap());

--- a/internal/venice-common/src/test/java/com/linkedin/venice/offsets/TestInMemoryOffsetManager.java
+++ b/internal/venice-common/src/test/java/com/linkedin/venice/offsets/TestInMemoryOffsetManager.java
@@ -14,11 +14,11 @@ public class TestInMemoryOffsetManager {
 
     OffsetManager om = new InMemoryOffsetManager();
     OffsetRecord record = new OffsetRecord(AvroProtocolDefinition.PARTITION_STATE.getSerializer());
-    record.setCheckpointLocalVersionTopicPosition(ApacheKafkaOffsetPosition.of(1234));
+    record.checkpointLocalVtPosition(ApacheKafkaOffsetPosition.of(1234));
     OffsetRecord oldRecord = new OffsetRecord(AvroProtocolDefinition.PARTITION_STATE.getSerializer());
-    oldRecord.setCheckpointLocalVersionTopicPosition(ApacheKafkaOffsetPosition.of(234));
+    oldRecord.checkpointLocalVtPosition(ApacheKafkaOffsetPosition.of(234));
     OffsetRecord newRecord = new OffsetRecord(AvroProtocolDefinition.PARTITION_STATE.getSerializer());
-    newRecord.setCheckpointLocalVersionTopicPosition(ApacheKafkaOffsetPosition.of(11234));
+    newRecord.checkpointLocalVtPosition(ApacheKafkaOffsetPosition.of(11234));
 
     om.put(topic, 0, record);
     Assert.assertEquals(om.getLastOffset(topic, 0), record);

--- a/internal/venice-common/src/test/java/com/linkedin/venice/offsets/TestInMemoryOffsetManager.java
+++ b/internal/venice-common/src/test/java/com/linkedin/venice/offsets/TestInMemoryOffsetManager.java
@@ -14,11 +14,11 @@ public class TestInMemoryOffsetManager {
 
     OffsetManager om = new InMemoryOffsetManager();
     OffsetRecord record = new OffsetRecord(AvroProtocolDefinition.PARTITION_STATE.getSerializer());
-    record.setCheckpointLocalVersionTopicOffset(ApacheKafkaOffsetPosition.of(1234));
+    record.setCheckpointLocalVersionTopicPosition(ApacheKafkaOffsetPosition.of(1234));
     OffsetRecord oldRecord = new OffsetRecord(AvroProtocolDefinition.PARTITION_STATE.getSerializer());
-    oldRecord.setCheckpointLocalVersionTopicOffset(ApacheKafkaOffsetPosition.of(234));
+    oldRecord.setCheckpointLocalVersionTopicPosition(ApacheKafkaOffsetPosition.of(234));
     OffsetRecord newRecord = new OffsetRecord(AvroProtocolDefinition.PARTITION_STATE.getSerializer());
-    newRecord.setCheckpointLocalVersionTopicOffset(ApacheKafkaOffsetPosition.of(11234));
+    newRecord.setCheckpointLocalVersionTopicPosition(ApacheKafkaOffsetPosition.of(11234));
 
     om.put(topic, 0, record);
     Assert.assertEquals(om.getLastOffset(topic, 0), record);

--- a/internal/venice-common/src/test/java/com/linkedin/venice/offsets/TestInMemoryOffsetManager.java
+++ b/internal/venice-common/src/test/java/com/linkedin/venice/offsets/TestInMemoryOffsetManager.java
@@ -1,5 +1,6 @@
 package com.linkedin.venice.offsets;
 
+import com.linkedin.venice.pubsub.adapter.kafka.common.ApacheKafkaOffsetPosition;
 import com.linkedin.venice.serialization.avro.AvroProtocolDefinition;
 import com.linkedin.venice.utils.Utils;
 import org.testng.Assert;
@@ -13,11 +14,11 @@ public class TestInMemoryOffsetManager {
 
     OffsetManager om = new InMemoryOffsetManager();
     OffsetRecord record = new OffsetRecord(AvroProtocolDefinition.PARTITION_STATE.getSerializer());
-    record.setCheckpointLocalVersionTopicOffset(1234);
+    record.setCheckpointLocalVersionTopicOffset(ApacheKafkaOffsetPosition.of(1234));
     OffsetRecord oldRecord = new OffsetRecord(AvroProtocolDefinition.PARTITION_STATE.getSerializer());
-    oldRecord.setCheckpointLocalVersionTopicOffset(234);
+    oldRecord.setCheckpointLocalVersionTopicOffset(ApacheKafkaOffsetPosition.of(234));
     OffsetRecord newRecord = new OffsetRecord(AvroProtocolDefinition.PARTITION_STATE.getSerializer());
-    newRecord.setCheckpointLocalVersionTopicOffset(11234);
+    newRecord.setCheckpointLocalVersionTopicOffset(ApacheKafkaOffsetPosition.of(11234));
 
     om.put(topic, 0, record);
     Assert.assertEquals(om.getLastOffset(topic, 0), record);

--- a/internal/venice-common/src/test/java/com/linkedin/venice/offsets/TestOffsetRecord.java
+++ b/internal/venice-common/src/test/java/com/linkedin/venice/offsets/TestOffsetRecord.java
@@ -52,16 +52,16 @@ public class TestOffsetRecord {
     OffsetRecord offsetRecord = TestUtils.getOffsetRecord(ApacheKafkaOffsetPosition.of(100), Optional.empty());
     PubSubPosition p1 = ApacheKafkaOffsetPosition.of(1L);
     PubSubPosition p2 = ApacheKafkaOffsetPosition.of(2L);
-    offsetRecord.setLeaderUpstreamOffset(TEST_KAFKA_URL1, p1);
+    offsetRecord.checkpointRtPosition(TEST_KAFKA_URL1, p1);
 
-    Assert.assertEquals(offsetRecord.getUpstreamOffset(TEST_KAFKA_URL1), p1);
+    Assert.assertEquals(offsetRecord.getCheckpointedRtPosition(TEST_KAFKA_URL1), p1);
 
     Map<String, PubSubPosition> testMap = new HashMap<>();
     testMap.put(TEST_KAFKA_URL2, p2);
-    offsetRecord.updateUpstreamOffsets(testMap);
+    offsetRecord.checkpointRtPositions(testMap);
     // no upstream found for it so fall back to use the leaderOffset which is 1
-    Assert.assertEquals(offsetRecord.getUpstreamOffset(TEST_KAFKA_URL1), p1);
-    Assert.assertEquals(offsetRecord.getUpstreamOffset(TEST_KAFKA_URL2), p2);
+    Assert.assertEquals(offsetRecord.getCheckpointedRtPosition(TEST_KAFKA_URL1), p1);
+    Assert.assertEquals(offsetRecord.getCheckpointedRtPosition(TEST_KAFKA_URL2), p2);
   }
 
   @Test

--- a/internal/venice-common/src/test/java/com/linkedin/venice/offsets/TestOffsetRecord.java
+++ b/internal/venice-common/src/test/java/com/linkedin/venice/offsets/TestOffsetRecord.java
@@ -5,12 +5,15 @@ import static org.testng.Assert.assertNull;
 
 import com.linkedin.venice.kafka.protocol.GUID;
 import com.linkedin.venice.kafka.protocol.state.ProducerPartitionState;
+import com.linkedin.venice.pubsub.adapter.kafka.common.ApacheKafkaOffsetPosition;
+import com.linkedin.venice.pubsub.api.PubSubPosition;
 import com.linkedin.venice.serialization.avro.AvroProtocolDefinition;
 import com.linkedin.venice.utils.TestUtils;
 import com.linkedin.venice.utils.concurrent.VeniceConcurrentHashMap;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Optional;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
@@ -32,36 +35,38 @@ public class TestOffsetRecord {
 
   @Test
   public void testToBytes() {
-    OffsetRecord offsetRecord1 = TestUtils.getOffsetRecord(100);
+    OffsetRecord offsetRecord1 = TestUtils.getOffsetRecord(ApacheKafkaOffsetPosition.of(100), Optional.empty());
     OffsetRecord offsetRecord2 =
         new OffsetRecord(offsetRecord1.toBytes(), AvroProtocolDefinition.PARTITION_STATE.getSerializer());
     Assert.assertTrue(offsetRecord2.getProducerPartitionStateMap() instanceof VeniceConcurrentHashMap);
     Assert.assertEquals(offsetRecord2, offsetRecord1);
 
-    offsetRecord1 = TestUtils.getOffsetRecord(100);
-    offsetRecord1.endOfPushReceived(100);
+    offsetRecord1 = TestUtils.getOffsetRecord(ApacheKafkaOffsetPosition.of(100), Optional.empty());
+    offsetRecord1.endOfPushReceived();
     offsetRecord2 = new OffsetRecord(offsetRecord1.toBytes(), AvroProtocolDefinition.PARTITION_STATE.getSerializer());
     Assert.assertEquals(offsetRecord2, offsetRecord1);
   }
 
   @Test
   public void testResetUpstreamOffsetMap() {
-    OffsetRecord offsetRecord = TestUtils.getOffsetRecord(100);
-    offsetRecord.setLeaderUpstreamOffset(TEST_KAFKA_URL1, 1L);
+    OffsetRecord offsetRecord = TestUtils.getOffsetRecord(ApacheKafkaOffsetPosition.of(100), Optional.empty());
+    PubSubPosition p1 = ApacheKafkaOffsetPosition.of(1L);
+    PubSubPosition p2 = ApacheKafkaOffsetPosition.of(2L);
+    offsetRecord.setLeaderUpstreamOffset(TEST_KAFKA_URL1, p1);
 
-    Assert.assertEquals(offsetRecord.getUpstreamOffset(TEST_KAFKA_URL1), 1L);
+    Assert.assertEquals(offsetRecord.getUpstreamOffset(TEST_KAFKA_URL1), p1);
 
-    Map<String, Long> testMap = new HashMap<>();
-    testMap.put(TEST_KAFKA_URL2, 2L);
+    Map<String, PubSubPosition> testMap = new HashMap<>();
+    testMap.put(TEST_KAFKA_URL2, p2);
     offsetRecord.updateUpstreamOffsets(testMap);
     // no upstream found for it so fall back to use the leaderOffset which is 1
-    Assert.assertEquals(offsetRecord.getUpstreamOffset(TEST_KAFKA_URL1), 1L);
-    Assert.assertEquals(offsetRecord.getUpstreamOffset(TEST_KAFKA_URL2), 2L);
+    Assert.assertEquals(offsetRecord.getUpstreamOffset(TEST_KAFKA_URL1), p1);
+    Assert.assertEquals(offsetRecord.getUpstreamOffset(TEST_KAFKA_URL2), p2);
   }
 
   @Test
   public void testBatchUpdateEOIP() {
-    OffsetRecord offsetRecord = TestUtils.getOffsetRecord(100);
+    OffsetRecord offsetRecord = TestUtils.getOffsetRecord(ApacheKafkaOffsetPosition.of(100), Optional.empty());
     offsetRecord.setPendingReportIncPushVersionList(Arrays.asList("a", "b", "c"));
     Assert.assertEquals(offsetRecord.getPendingReportIncPushVersionList(), Arrays.asList("a", "b", "c"));
   }

--- a/internal/venice-common/src/test/java/com/linkedin/venice/pubsub/api/EarliestPositionTest.java
+++ b/internal/venice-common/src/test/java/com/linkedin/venice/pubsub/api/EarliestPositionTest.java
@@ -51,8 +51,8 @@ public class EarliestPositionTest {
     assertEquals(reflectionInstance.toString(), "EARLIEST");
 
     // Check equality
-    assertTrue(instance.equals(reflectionInstance), "Instances should be equal despite being different objects");
-    assertTrue(reflectionInstance.equals(instance), "Equality should be symmetric");
+    assertEquals(reflectionInstance, instance, "Instances should be equal despite being different objects");
+    assertEquals(instance, reflectionInstance, "Equality should be symmetric");
 
     // Check hashCode consistency
     assertEquals(instance.hashCode(), reflectionInstance.hashCode(), "Hash codes must match for equal instances");

--- a/internal/venice-common/src/test/java/com/linkedin/venice/writer/VeniceWriterUnitTest.java
+++ b/internal/venice-common/src/test/java/com/linkedin/venice/writer/VeniceWriterUnitTest.java
@@ -43,6 +43,7 @@ import com.linkedin.venice.kafka.protocol.enums.MessageType;
 import com.linkedin.venice.kafka.validation.Segment;
 import com.linkedin.venice.message.KafkaKey;
 import com.linkedin.venice.partitioner.DefaultVenicePartitioner;
+import com.linkedin.venice.pubsub.adapter.kafka.common.ApacheKafkaOffsetPosition;
 import com.linkedin.venice.pubsub.api.DefaultPubSubMessage;
 import com.linkedin.venice.pubsub.api.PubSubMessageHeader;
 import com.linkedin.venice.pubsub.api.PubSubMessageHeaders;
@@ -717,7 +718,7 @@ public class VeniceWriterUnitTest {
           0,
           1,
           null,
-          new LeaderMetadataWrapper(0, 0, 0, ByteBuffer.allocate(0)),
+          new LeaderMetadataWrapper(ApacheKafkaOffsetPosition.of(0), 0, 0),
           APP_DEFAULT_LOGICAL_TS,
           null,
           null,

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/BlobP2PTransferAmongServersTest.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/BlobP2PTransferAmongServersTest.java
@@ -120,7 +120,9 @@ public class BlobP2PTransferAmongServersTest {
             server1.getVeniceServer().getStorageMetadataService().getLastOffset("test-store_v1", partitionId);
         OffsetRecord offsetServer2 =
             server2.getVeniceServer().getStorageMetadataService().getLastOffset("test-store_v1", partitionId);
-        Assert.assertEquals(offsetServer1.getLocalVersionTopicOffset(), offsetServer2.getLocalVersionTopicOffset());
+        Assert.assertEquals(
+            offsetServer1.getCheckpointedLocalVtPosition(),
+            offsetServer2.getCheckpointedLocalVtPosition());
       }
     });
   }
@@ -323,7 +325,9 @@ public class BlobP2PTransferAmongServersTest {
             server1.getVeniceServer().getStorageMetadataService().getLastOffset(storeName + "_v1", partitionId);
         OffsetRecord offsetRecord2 =
             server2.getVeniceServer().getStorageMetadataService().getLastOffset(storeName + "_v1", partitionId);
-        Assert.assertEquals(offsetRecord2.getLocalVersionTopicOffset(), offsetRecord1.getLocalVersionTopicOffset());
+        Assert.assertEquals(
+            offsetRecord2.getCheckpointedLocalVtPosition(),
+            offsetRecord1.getCheckpointedLocalVtPosition());
       }
     });
 
@@ -389,7 +393,9 @@ public class BlobP2PTransferAmongServersTest {
             server1.getVeniceServer().getStorageMetadataService().getLastOffset(storeName + "_v1", partitionId);
         OffsetRecord offsetServer2 =
             server2.getVeniceServer().getStorageMetadataService().getLastOffset(storeName + "_v1", partitionId);
-        Assert.assertEquals(offsetServer1.getLocalVersionTopicOffset(), offsetServer2.getLocalVersionTopicOffset());
+        Assert.assertEquals(
+            offsetServer1.getCheckpointedLocalVtPosition(),
+            offsetServer2.getCheckpointedLocalVtPosition());
       }
     });
   }

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestFatalDataValidationExceptionHandling.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestFatalDataValidationExceptionHandling.java
@@ -303,11 +303,7 @@ public class TestFatalDataValidationExceptionHandling {
         stringSerializer.serialize("value_writer_1"),
         1,
         null,
-        new LeaderMetadataWrapper(
-            pubSubPosition0.getNumericOffset(),
-            0,
-            DEFAULT_TERM_ID,
-            pubSubPosition0.toWireFormatBuffer()));
+        new LeaderMetadataWrapper(pubSubPosition0, 0, DEFAULT_TERM_ID));
     vw1.flush();
 
     PubSubPosition pubSubPosition1 = new ApacheKafkaOffsetPosition(1);
@@ -316,11 +312,7 @@ public class TestFatalDataValidationExceptionHandling {
         stringSerializer.serialize("value_writer_2"),
         1,
         null,
-        new LeaderMetadataWrapper(
-            pubSubPosition1.getNumericOffset(),
-            0,
-            DEFAULT_TERM_ID,
-            pubSubPosition1.toWireFormatBuffer()));
+        new LeaderMetadataWrapper(pubSubPosition1, 0, DEFAULT_TERM_ID));
 
     PubSubPosition pubSubPosition2 = new ApacheKafkaOffsetPosition(2);
     vw2.put(
@@ -328,11 +320,7 @@ public class TestFatalDataValidationExceptionHandling {
         stringSerializer.serialize("value_writer_3"),
         1,
         null,
-        new LeaderMetadataWrapper(
-            pubSubPosition2.getNumericOffset(),
-            0,
-            DEFAULT_TERM_ID,
-            pubSubPosition2.toWireFormatBuffer()));
+        new LeaderMetadataWrapper(pubSubPosition2, 0, DEFAULT_TERM_ID));
     vw2.flush();
 
     PubSubPosition pubSubPosition3 = new ApacheKafkaOffsetPosition(3);
@@ -341,11 +329,7 @@ public class TestFatalDataValidationExceptionHandling {
         stringSerializer.serialize("value_writer_4"),
         1,
         null,
-        new LeaderMetadataWrapper(
-            pubSubPosition3.getNumericOffset(),
-            0,
-            DEFAULT_TERM_ID,
-            pubSubPosition3.toWireFormatBuffer()));
+        new LeaderMetadataWrapper(pubSubPosition3, 0, DEFAULT_TERM_ID));
     vw1.flush();
     vw1.closePartition(0);
     vw1.flush();

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestHybridMultiRegion.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestHybridMultiRegion.java
@@ -270,11 +270,7 @@ public class TestHybridMultiRegion {
             stringSerializer.serialize("value_writer_1"),
             1,
             null,
-            new LeaderMetadataWrapper(
-                upstreamPosition1.getNumericOffset(),
-                0,
-                DEFAULT_TERM_ID,
-                upstreamPosition1.toWireFormatBuffer()));
+            new LeaderMetadataWrapper(upstreamPosition1, 0, DEFAULT_TERM_ID));
         veniceWriter1.flush();
 
         PubSubPosition upstreamPosition2 = new ApacheKafkaOffsetPosition(1);
@@ -283,11 +279,7 @@ public class TestHybridMultiRegion {
             stringSerializer.serialize("value_writer_2"),
             1,
             null,
-            new LeaderMetadataWrapper(
-                upstreamPosition2.getNumericOffset(),
-                0,
-                DEFAULT_TERM_ID,
-                upstreamPosition2.toWireFormatBuffer()));
+            new LeaderMetadataWrapper(upstreamPosition2, 0, DEFAULT_TERM_ID));
         veniceWriter2.flush();
 
         PubSubPosition upstreamPositionIPlusFive;
@@ -298,11 +290,7 @@ public class TestHybridMultiRegion {
               stringSerializer.serialize("value_" + i),
               1,
               null,
-              new LeaderMetadataWrapper(
-                  upstreamPositionIPlusFive.getNumericOffset(),
-                  0,
-                  DEFAULT_TERM_ID,
-                  upstreamPositionIPlusFive.toWireFormatBuffer()));
+              new LeaderMetadataWrapper(upstreamPositionIPlusFive, 0, DEFAULT_TERM_ID));
         }
         veniceWriter1.flush();
 
@@ -312,11 +300,7 @@ public class TestHybridMultiRegion {
             stringSerializer.serialize("value_x"),
             1,
             null,
-            new LeaderMetadataWrapper(
-                upstreamPosition3.getNumericOffset(),
-                0,
-                DEFAULT_TERM_ID,
-                upstreamPosition3.toWireFormatBuffer()));
+            new LeaderMetadataWrapper(upstreamPosition3, 0, DEFAULT_TERM_ID));
 
         for (int i = 5; i < 10; ++i) {
           upstreamPositionIPlusFive = new ApacheKafkaOffsetPosition(i + 5);
@@ -325,11 +309,7 @@ public class TestHybridMultiRegion {
               stringSerializer.serialize("value_" + i),
               1,
               null,
-              new LeaderMetadataWrapper(
-                  upstreamPositionIPlusFive.getNumericOffset(),
-                  0,
-                  DEFAULT_TERM_ID,
-                  upstreamPositionIPlusFive.toWireFormatBuffer()));
+              new LeaderMetadataWrapper(upstreamPositionIPlusFive, 0, DEFAULT_TERM_ID));
         }
         veniceWriter2.flush();
         veniceWriter1.broadcastEndOfPush(Collections.emptyMap());

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestPushJobWithNativeReplication.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestPushJobWithNativeReplication.java
@@ -276,7 +276,8 @@ public class TestPushJobWithNativeReplication {
             StorageMetadataService metadataService = serverInRemoteFabric.getStorageMetadataService();
             OffsetRecord offsetRecord = metadataService.getLastOffset(versionTopic, partitionId);
 
-            Assert.assertTrue(offsetRecord.getLocalVersionTopicOffset() <= latestOffsetInVersionTopic);
+            Assert
+                .assertTrue(offsetRecord.getLocalVersionTopicOffset().getNumericOffset() <= latestOffsetInVersionTopic);
           });
         });
   }

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestPushJobWithNativeReplication.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestPushJobWithNativeReplication.java
@@ -276,8 +276,8 @@ public class TestPushJobWithNativeReplication {
             StorageMetadataService metadataService = serverInRemoteFabric.getStorageMetadataService();
             OffsetRecord offsetRecord = metadataService.getLastOffset(versionTopic, partitionId);
 
-            Assert
-                .assertTrue(offsetRecord.getLocalVersionTopicOffset().getNumericOffset() <= latestOffsetInVersionTopic);
+            Assert.assertTrue(
+                offsetRecord.getCheckpointedLocalVtPosition().getNumericOffset() <= latestOffsetInVersionTopic);
           });
         });
   }

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestRocksDBOffsetStore.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestRocksDBOffsetStore.java
@@ -45,7 +45,8 @@ public class TestRocksDBOffsetStore {
     String storeName = veniceCluster.createStore(keyCount);
     String storeTopicName = storeName + "_v1";
     StorageMetadataService storageMetadataService = serverWrapper.getVeniceServer().getStorageMetadataService();
-    Assert.assertTrue(storageMetadataService.getLastOffset(storeTopicName, 0).getLocalVersionTopicOffset() != -1);
+    Assert.assertTrue(
+        storageMetadataService.getLastOffset(storeTopicName, 0).getLocalVersionTopicOffset().getNumericOffset() != -1);
     veniceCluster.stopVeniceServer(serverWrapper.getPort());
     TestUtils.waitForNonDeterministicAssertion(
         30,
@@ -54,7 +55,8 @@ public class TestRocksDBOffsetStore {
             veniceCluster.getRandomVeniceRouter().getRoutingDataRepository().containsKafkaTopic(storeTopicName)));
     veniceCluster.restartVeniceServer(serverWrapper.getPort());
     storageMetadataService = veniceCluster.getVeniceServers().get(0).getVeniceServer().getStorageMetadataService();
-    Assert.assertTrue(storageMetadataService.getLastOffset(storeTopicName, 0).getLocalVersionTopicOffset() != -1);
+    Assert.assertTrue(
+        storageMetadataService.getLastOffset(storeTopicName, 0).getLocalVersionTopicOffset().getNumericOffset() != -1);
     try (AvroGenericStoreClient<Integer, Integer> client = ClientFactory.getAndStartGenericAvroClient(
         ClientConfig.defaultGenericClientConfig(storeName).setVeniceURL(veniceCluster.getRandomRouterURL()))) {
       TestUtils.waitForNonDeterministicAssertion(30, TimeUnit.SECONDS, false, true, () -> {

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestRocksDBOffsetStore.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestRocksDBOffsetStore.java
@@ -46,7 +46,9 @@ public class TestRocksDBOffsetStore {
     String storeTopicName = storeName + "_v1";
     StorageMetadataService storageMetadataService = serverWrapper.getVeniceServer().getStorageMetadataService();
     Assert.assertTrue(
-        storageMetadataService.getLastOffset(storeTopicName, 0).getLocalVersionTopicOffset().getNumericOffset() != -1);
+        storageMetadataService.getLastOffset(storeTopicName, 0)
+            .getCheckpointedLocalVtPosition()
+            .getNumericOffset() != -1);
     veniceCluster.stopVeniceServer(serverWrapper.getPort());
     TestUtils.waitForNonDeterministicAssertion(
         30,
@@ -56,7 +58,9 @@ public class TestRocksDBOffsetStore {
     veniceCluster.restartVeniceServer(serverWrapper.getPort());
     storageMetadataService = veniceCluster.getVeniceServers().get(0).getVeniceServer().getStorageMetadataService();
     Assert.assertTrue(
-        storageMetadataService.getLastOffset(storeTopicName, 0).getLocalVersionTopicOffset().getNumericOffset() != -1);
+        storageMetadataService.getLastOffset(storeTopicName, 0)
+            .getCheckpointedLocalVtPosition()
+            .getNumericOffset() != -1);
     try (AvroGenericStoreClient<Integer, Integer> client = ClientFactory.getAndStartGenericAvroClient(
         ClientConfig.defaultGenericClientConfig(storeName).setVeniceURL(veniceCluster.getRandomRouterURL()))) {
       TestUtils.waitForNonDeterministicAssertion(30, TimeUnit.SECONDS, false, true, () -> {

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/kafka/KafkaConsumptionTest.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/kafka/KafkaConsumptionTest.java
@@ -213,8 +213,12 @@ public class KafkaConsumptionTest {
         pubSubTopicPartition,
         PartitionReplicaIngestionContext.VersionRole.CURRENT,
         PartitionReplicaIngestionContext.WorkloadType.AA_OR_WRITE_COMPUTE);
-    StorePartitionDataReceiver localDataReceiver = (StorePartitionDataReceiver) aggKafkaConsumerService
-        .subscribeConsumerFor(localKafkaUrl, storeIngestionTask, partitionReplicaIngestionContext, -1);
+    StorePartitionDataReceiver localDataReceiver =
+        (StorePartitionDataReceiver) aggKafkaConsumerService.subscribeConsumerFor(
+            localKafkaUrl,
+            storeIngestionTask,
+            partitionReplicaIngestionContext,
+            PubSubSymbolicPosition.EARLIEST);
     Assert
         .assertTrue(aggKafkaConsumerService.hasConsumerAssignedFor(localKafkaUrl, versionTopic, pubSubTopicPartition));
 
@@ -222,8 +226,12 @@ public class KafkaConsumptionTest {
     consumerProperties = new Properties();
     consumerProperties.put(KAFKA_BOOTSTRAP_SERVERS, remoteKafkaUrl);
     aggKafkaConsumerService.createKafkaConsumerService(consumerProperties);
-    StorePartitionDataReceiver remoteDataReceiver = (StorePartitionDataReceiver) aggKafkaConsumerService
-        .subscribeConsumerFor(remoteKafkaUrl, storeIngestionTask, partitionReplicaIngestionContext, -1);
+    StorePartitionDataReceiver remoteDataReceiver =
+        (StorePartitionDataReceiver) aggKafkaConsumerService.subscribeConsumerFor(
+            remoteKafkaUrl,
+            storeIngestionTask,
+            partitionReplicaIngestionContext,
+            PubSubSymbolicPosition.EARLIEST);
     Assert
         .assertTrue(aggKafkaConsumerService.hasConsumerAssignedFor(remoteKafkaUrl, versionTopic, pubSubTopicPartition));
 

--- a/internal/venice-test-common/src/main/java/com/linkedin/venice/offsets/InMemoryOffsetManager.java
+++ b/internal/venice-test-common/src/main/java/com/linkedin/venice/offsets/InMemoryOffsetManager.java
@@ -26,8 +26,8 @@ public class InMemoryOffsetManager implements OffsetManager {
         return newMap;
       } else {
         map.compute(partitionId, (partition, oldRecord) -> {
-          if (oldRecord == null || oldRecord.getLocalVersionTopicOffset()
-              .getNumericOffset() < record.getLocalVersionTopicOffset().getNumericOffset()) {
+          if (oldRecord == null || oldRecord.getCheckpointedLocalVtPosition()
+              .getNumericOffset() < record.getCheckpointedLocalVtPosition().getNumericOffset()) {
             return record;
           } else {
             return oldRecord;

--- a/internal/venice-test-common/src/main/java/com/linkedin/venice/offsets/InMemoryOffsetManager.java
+++ b/internal/venice-test-common/src/main/java/com/linkedin/venice/offsets/InMemoryOffsetManager.java
@@ -26,7 +26,8 @@ public class InMemoryOffsetManager implements OffsetManager {
         return newMap;
       } else {
         map.compute(partitionId, (partition, oldRecord) -> {
-          if (oldRecord == null || oldRecord.getLocalVersionTopicOffset() < record.getLocalVersionTopicOffset()) {
+          if (oldRecord == null || oldRecord.getLocalVersionTopicOffset()
+              .getNumericOffset() < record.getLocalVersionTopicOffset().getNumericOffset()) {
             return record;
           } else {
             return oldRecord;

--- a/internal/venice-test-common/src/main/java/com/linkedin/venice/pubsub/mock/adapter/consumer/MockInMemoryConsumerAdapter.java
+++ b/internal/venice-test-common/src/main/java/com/linkedin/venice/pubsub/mock/adapter/consumer/MockInMemoryConsumerAdapter.java
@@ -3,6 +3,7 @@ package com.linkedin.venice.pubsub.mock.adapter.consumer;
 import com.linkedin.venice.exceptions.VeniceException;
 import com.linkedin.venice.pubsub.PubSubTopicPartitionInfo;
 import com.linkedin.venice.pubsub.PubSubUtil;
+import com.linkedin.venice.pubsub.adapter.kafka.common.ApacheKafkaOffsetPosition;
 import com.linkedin.venice.pubsub.api.DefaultPubSubMessage;
 import com.linkedin.venice.pubsub.api.PubSubConsumerAdapter;
 import com.linkedin.venice.pubsub.api.PubSubPosition;
@@ -99,6 +100,9 @@ public class MockInMemoryConsumerAdapter implements PubSubConsumerAdapter {
     } else if (position instanceof InMemoryPubSubPosition) {
       long inputOffset = ((InMemoryPubSubPosition) position).getInternalOffset();
       seekOffset = PubSubUtil.calculateSeekOffset(inputOffset, isInclusive);
+    } else if (position instanceof ApacheKafkaOffsetPosition) {
+      seekOffset =
+          PubSubUtil.calculateSeekOffset(((ApacheKafkaOffsetPosition) position).getInternalOffset(), isInclusive);
     } else {
       throw new IllegalArgumentException("Unsupported PubSubPosition type: " + position.getClass());
     }

--- a/internal/venice-test-common/src/main/java/com/linkedin/venice/pubsub/mock/adapter/consumer/MockInMemoryConsumerAdapter.java
+++ b/internal/venice-test-common/src/main/java/com/linkedin/venice/pubsub/mock/adapter/consumer/MockInMemoryConsumerAdapter.java
@@ -88,9 +88,9 @@ public class MockInMemoryConsumerAdapter implements PubSubConsumerAdapter {
 
     long seekOffset;
 
-    if (position == PubSubSymbolicPosition.EARLIEST) {
+    if (PubSubSymbolicPosition.EARLIEST.equals(position)) {
       seekOffset = 0L; // start from first available record
-    } else if (position == PubSubSymbolicPosition.LATEST) {
+    } else if (PubSubSymbolicPosition.LATEST.equals(position)) {
       PubSubPosition resolved = endPosition(pubSubTopicPartition);
       if (!(resolved instanceof InMemoryPubSubPosition)) {
         throw new IllegalStateException(

--- a/internal/venice-test-common/src/main/java/com/linkedin/venice/utils/TestUtils.java
+++ b/internal/venice-test-common/src/main/java/com/linkedin/venice/utils/TestUtils.java
@@ -82,6 +82,8 @@ import com.linkedin.venice.pubsub.PubSubContext;
 import com.linkedin.venice.pubsub.PubSubPositionTypeRegistry;
 import com.linkedin.venice.pubsub.PubSubProducerAdapterFactory;
 import com.linkedin.venice.pubsub.PubSubTopicRepository;
+import com.linkedin.venice.pubsub.adapter.kafka.common.ApacheKafkaOffsetPosition;
+import com.linkedin.venice.pubsub.api.PubSubPosition;
 import com.linkedin.venice.pubsub.api.PubSubTopicType;
 import com.linkedin.venice.pubsub.manager.TopicManagerRepository;
 import com.linkedin.venice.pushmonitor.ExecutionStatus;
@@ -693,19 +695,17 @@ public class TestUtils {
     return participant;
   }
 
-  public static OffsetRecord getOffsetRecord(long currentOffset) {
-    return getOffsetRecord(currentOffset, Optional.empty());
-  }
-
   public static OffsetRecord getOffsetRecord(long currentOffset, boolean complete) {
-    return getOffsetRecord(currentOffset, complete ? Optional.of(1000L) : Optional.of(0L));
+    return getOffsetRecord(
+        ApacheKafkaOffsetPosition.of(currentOffset),
+        complete ? Optional.of(ApacheKafkaOffsetPosition.of(1000L)) : Optional.of(ApacheKafkaOffsetPosition.of(0L)));
   }
 
-  public static OffsetRecord getOffsetRecord(long currentOffset, Optional<Long> endOfPushOffset) {
+  public static OffsetRecord getOffsetRecord(PubSubPosition currentOffset, Optional<PubSubPosition> endOfPushOffset) {
     OffsetRecord offsetRecord = new OffsetRecord(partitionStateSerializer);
     offsetRecord.setCheckpointLocalVersionTopicOffset(currentOffset);
     if (endOfPushOffset.isPresent()) {
-      offsetRecord.endOfPushReceived(endOfPushOffset.get());
+      offsetRecord.endOfPushReceived();
     }
     return offsetRecord;
   }

--- a/internal/venice-test-common/src/main/java/com/linkedin/venice/utils/TestUtils.java
+++ b/internal/venice-test-common/src/main/java/com/linkedin/venice/utils/TestUtils.java
@@ -701,9 +701,9 @@ public class TestUtils {
         complete ? Optional.of(ApacheKafkaOffsetPosition.of(1000L)) : Optional.of(ApacheKafkaOffsetPosition.of(0L)));
   }
 
-  public static OffsetRecord getOffsetRecord(PubSubPosition currentOffset, Optional<PubSubPosition> endOfPushOffset) {
+  public static OffsetRecord getOffsetRecord(PubSubPosition currentPosition, Optional<PubSubPosition> endOfPushOffset) {
     OffsetRecord offsetRecord = new OffsetRecord(partitionStateSerializer);
-    offsetRecord.setCheckpointLocalVersionTopicOffset(currentOffset);
+    offsetRecord.setCheckpointLocalVersionTopicPosition(currentPosition);
     if (endOfPushOffset.isPresent()) {
       offsetRecord.endOfPushReceived();
     }

--- a/internal/venice-test-common/src/main/java/com/linkedin/venice/utils/TestUtils.java
+++ b/internal/venice-test-common/src/main/java/com/linkedin/venice/utils/TestUtils.java
@@ -703,7 +703,7 @@ public class TestUtils {
 
   public static OffsetRecord getOffsetRecord(PubSubPosition currentPosition, Optional<PubSubPosition> endOfPushOffset) {
     OffsetRecord offsetRecord = new OffsetRecord(partitionStateSerializer);
-    offsetRecord.setCheckpointLocalVersionTopicPosition(currentPosition);
+    offsetRecord.checkpointLocalVtPosition(currentPosition);
     if (endOfPushOffset.isPresent()) {
       offsetRecord.endOfPushReceived();
     }

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceHelixAdmin.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceHelixAdmin.java
@@ -1452,9 +1452,13 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
    */
   @Override
   public void sendPushJobDetails(PushJobStatusRecordKey key, PushJobDetails value) {
+    String pushJobDetailsStoreClusterName = getPushJobStatusStoreClusterName();
+    if (pushJobDetailsStoreClusterName == null || pushJobDetailsStoreClusterName.isEmpty()) {
+      return;
+    }
     if (isParent()) {
       String lastDualWriteError = "";
-      for (Map.Entry<String, ControllerClient> entry: getControllerClientMap(getPushJobStatusStoreClusterName())
+      for (Map.Entry<String, ControllerClient> entry: getControllerClientMap(pushJobDetailsStoreClusterName)
           .entrySet()) {
         LOGGER.info(
             "Sending controller request to send push job details: {} to region: {} for: {}",

--- a/services/venice-controller/src/test/java/com/linkedin/venice/controller/kafka/consumer/AdminConsumptionTaskTest.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/controller/kafka/consumer/AdminConsumptionTaskTest.java
@@ -1325,7 +1325,7 @@ public class AdminConsumptionTaskTest {
         AdminOperationSerializer.LATEST_SCHEMA_ID_FOR_ADMIN_OPERATION);
     final PubSubPosition position = future.get(TIMEOUT, TimeUnit.MILLISECONDS).getPubSubPosition();
     OffsetRecord offsetRecord = offsetManager.getLastOffset(topicName, AdminTopicUtils.ADMIN_TOPIC_PARTITION_ID);
-    offsetRecord.setCheckpointLocalVersionTopicPosition(position);
+    offsetRecord.checkpointLocalVtPosition(position);
     offsetManager.put(topicName, AdminTopicUtils.ADMIN_TOPIC_PARTITION_ID, offsetRecord);
     executionIdAccessor.updateLastSucceededExecutionIdMap(clusterName, storeName, 3L);
     executionIdAccessor.updateLastSucceededExecutionId(clusterName, 3L);

--- a/services/venice-controller/src/test/java/com/linkedin/venice/controller/kafka/consumer/AdminConsumptionTaskTest.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/controller/kafka/consumer/AdminConsumptionTaskTest.java
@@ -1309,8 +1309,8 @@ public class AdminConsumptionTaskTest {
   public void testMigrateFromOffsetManagerToMetadataAccessor()
       throws InterruptedException, ExecutionException, TimeoutException, IOException {
     AdminConsumptionTask task = getAdminConsumptionTask(new RandomPollStrategy(), false);
-    // Populate the topic with message and mimic the behavior where some message were processed when offset manager was
-    // in use.
+    // Populate the topic with message and mimic the behavior where some message were processed
+    // when offset manager was in use.
     veniceWriter.put(
         emptyKeyBytes,
         getStoreCreationMessage(clusterName, storeName, owner, keySchema, valueSchema, 1L),
@@ -1323,9 +1323,9 @@ public class AdminConsumptionTaskTest {
         emptyKeyBytes,
         getKillOfflinePushJobMessage(clusterName, storeTopicName, 3L),
         AdminOperationSerializer.LATEST_SCHEMA_ID_FOR_ADMIN_OPERATION);
-    final PubSubPosition offset = future.get(TIMEOUT, TimeUnit.MILLISECONDS).getPubSubPosition();
+    final PubSubPosition position = future.get(TIMEOUT, TimeUnit.MILLISECONDS).getPubSubPosition();
     OffsetRecord offsetRecord = offsetManager.getLastOffset(topicName, AdminTopicUtils.ADMIN_TOPIC_PARTITION_ID);
-    offsetRecord.setCheckpointLocalVersionTopicOffset(offset);
+    offsetRecord.setCheckpointLocalVersionTopicPosition(position);
     offsetManager.put(topicName, AdminTopicUtils.ADMIN_TOPIC_PARTITION_ID, offsetRecord);
     executionIdAccessor.updateLastSucceededExecutionIdMap(clusterName, storeName, 3L);
     executionIdAccessor.updateLastSucceededExecutionId(clusterName, 3L);
@@ -1334,7 +1334,7 @@ public class AdminConsumptionTaskTest {
     TestUtils.waitForNonDeterministicAssertion(
         TIMEOUT,
         TimeUnit.MILLISECONDS,
-        () -> Assert.assertEquals(InMemoryPubSubPosition.of(getLastOffset(clusterName)), offset));
+        () -> Assert.assertEquals(InMemoryPubSubPosition.of(getLastOffset(clusterName)), position));
     TestUtils.waitForNonDeterministicAssertion(
         TIMEOUT,
         TimeUnit.MILLISECONDS,

--- a/services/venice-controller/src/test/java/com/linkedin/venice/controller/kafka/consumer/AdminConsumptionTaskTest.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/controller/kafka/consumer/AdminConsumptionTaskTest.java
@@ -1323,7 +1323,7 @@ public class AdminConsumptionTaskTest {
         emptyKeyBytes,
         getKillOfflinePushJobMessage(clusterName, storeTopicName, 3L),
         AdminOperationSerializer.LATEST_SCHEMA_ID_FOR_ADMIN_OPERATION);
-    final long offset = future.get(TIMEOUT, TimeUnit.MILLISECONDS).getOffset();
+    final PubSubPosition offset = future.get(TIMEOUT, TimeUnit.MILLISECONDS).getPubSubPosition();
     OffsetRecord offsetRecord = offsetManager.getLastOffset(topicName, AdminTopicUtils.ADMIN_TOPIC_PARTITION_ID);
     offsetRecord.setCheckpointLocalVersionTopicOffset(offset);
     offsetManager.put(topicName, AdminTopicUtils.ADMIN_TOPIC_PARTITION_ID, offsetRecord);
@@ -1334,7 +1334,7 @@ public class AdminConsumptionTaskTest {
     TestUtils.waitForNonDeterministicAssertion(
         TIMEOUT,
         TimeUnit.MILLISECONDS,
-        () -> Assert.assertEquals(getLastOffset(clusterName), offset));
+        () -> Assert.assertEquals(InMemoryPubSubPosition.of(getLastOffset(clusterName)), offset));
     TestUtils.waitForNonDeterministicAssertion(
         TIMEOUT,
         TimeUnit.MILLISECONDS,


### PR DESCRIPTION
## Migrate from long offset to PubSubPosition abstraction in server code 

- Replaced raw offset usage (e.g., long, -1, LOWEST_OFFSET) with PubSubPosition  
  and PubSubSymbolicPosition across consumer and ingestion components  
- Updated method names like getLatestProcessedRtPosition, setLatestProcessedVtPosition,  
  and getLeaderPosition to reflect the new abstraction  
- Changed method signatures and logic to use PubSubPosition instead of long  
  for subscription, topic switch, and checkpoint tracking  

Note: When checkpointing positions to OffsetRecord, we still convert long to  
ApacheKafkaOffsetPosition (a PubSubPosition subtype) since all adapters support it.  
We'll gradually migrate to persisting actual positions natively.  

###  Code changes
- [ ] Added new code behind **a config**. If so list the config names and their default values in the PR description.
- [ ] Introduced new **log lines**. 
  - [ ] Confirmed if logs need to be **rate limited** to avoid excessive logging.

###  **Concurrency-Specific Checks**
Both reviewer and PR author to verify
- [ ] Code has **no race conditions** or **thread safety issues**.
- [ ] Proper **synchronization mechanisms** (e.g., `synchronized`, `RWLock`) are used where needed.
- [ ] No **blocking calls** inside critical sections that could lead to deadlocks or performance degradation.
- [ ] Verified **thread-safe collections** are used (e.g., `ConcurrentHashMap`, `CopyOnWriteArrayList`).
- [ ] Validated proper exception handling in multi-threaded code to avoid silent thread termination.


## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->

- [ ] New unit tests added.
- [ ] New integration tests added.
- [ ] Modified or extended existing tests.
- [ ] Verified backward compatibility (if applicable).

## Does this PR introduce any user-facing or breaking changes?
<!--  
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [ ] No. You can skip the rest of this section.
- [ ] Yes. Clearly explain the behavior change and its impact.