### PR TITLE
[build] Make "all-modules" be published after all other modules are published

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -174,28 +174,7 @@ publishing {
 }
 
 afterEvaluate {
-  // Make all-modules get published after all other modules are published
-  def allModulesMavenLocalTaskName = mavenPublishing.getPublishingTaskForMavenLocal('all-modules')
-  tasks.named(allModulesMavenLocalTaskName) {
-    dependsOn tasks.matching {
-      it.name != allModulesMavenLocalTaskName
-        && it.name.startsWith('publish')
-        && it.name.endsWith(mavenPublishing.getMavenLocalPublicationTaskSuffix())
-    }
-  }
-
-  publishing.repositories.findAll { it.name != 'MavenLocal' }
-      .each { repo ->
-        def repoName = repo.name
-        def allModulesMavenRepoTaskName = mavenPublishing.getPublishingTaskForRepo('all-modules', repoName)
-        tasks.named(allModulesMavenRepoTaskName) {
-          dependsOn tasks.matching {
-            it.name != allModulesMavenLocalTaskName
-                && it.name.startsWith('publish')
-                && it.name.endsWith(mavenPublishing.getMavenRepositoryPublicationTaskSuffix(repoName))
-      }
-    }
-  }
+  publishing.ensureCatchAllModuleGetsPublishedLast()
 }
 
 def parser = new XmlSlurper()
@@ -621,7 +600,7 @@ subprojects {
 
   // Only publish artifacts for projects that are at the leaf level
   if (isLeafSubModule) {
-    mavenPublishing.configureArtifactPublishing(project, testJar)
+    publishing.configureArtifactPublishing(project, testJar)
   }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -173,6 +173,31 @@ publishing {
   }
 }
 
+afterEvaluate {
+  // Make all-modules get published after all other modules are published
+  def allModulesMavenLocalTaskName = mavenPublishing.getPublishingTaskForMavenLocal('all-modules')
+  tasks.named(allModulesMavenLocalTaskName) {
+    dependsOn tasks.matching {
+      it.name != allModulesMavenLocalTaskName
+        && it.name.startsWith('publish')
+        && it.name.endsWith(mavenPublishing.getMavenLocalPublicationTaskSuffix())
+    }
+  }
+
+  publishing.repositories.findAll { it.name != 'MavenLocal' }
+      .each { repo ->
+        def repoName = repo.name
+        def allModulesMavenRepoTaskName = mavenPublishing.getPublishingTaskForRepo('all-modules', repoName)
+        tasks.named(allModulesMavenRepoTaskName) {
+          dependsOn tasks.matching {
+            it.name != allModulesMavenLocalTaskName
+                && it.name.startsWith('publish')
+                && it.name.endsWith(mavenPublishing.getMavenRepositoryPublicationTaskSuffix(repoName))
+      }
+    }
+  }
+}
+
 def parser = new XmlSlurper()
 parser.setFeature("http://apache.org/xml/features/disallow-doctype-decl", false)
 parser.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false)
@@ -596,7 +621,7 @@ subprojects {
 
   // Only publish artifacts for projects that are at the leaf level
   if (isLeafSubModule) {
-    publishing.configureArtifactPublishing(project, testJar)
+    mavenPublishing.configureArtifactPublishing(project, testJar)
   }
 }
 

--- a/clients/venice-admin-tool/build.gradle
+++ b/clients/venice-admin-tool/build.gradle
@@ -33,9 +33,6 @@ dependencies {
   testImplementation project(':internal:venice-common').sourceSets.test.output
 }
 
-apply from: "$rootDir/gradle/helper/publishing.gradle"
-apply from: "$rootDir/gradle/helper/packaging.gradle"
-
 jar {
   manifest {
     attributes = ['Implementation-Title'  : 'Venice Admin Tool',

--- a/clients/venice-push-job/build.gradle
+++ b/clients/venice-push-job/build.gradle
@@ -109,9 +109,6 @@ dependencies {
   runtimeOnly libraries.httpClient
 }
 
-apply from: "$rootDir/gradle/helper/publishing.gradle"
-apply from: "$rootDir/gradle/helper/packaging.gradle"
-
 jar {
   manifest {
     attributes 'Main-Class': 'com.linkedin.venice.hadoop.VenicePushJob'

--- a/gradle/helper/packaging.gradle
+++ b/gradle/helper/packaging.gradle
@@ -5,13 +5,13 @@ ext.packaging = [
 ]
 
 // workaround for missing gradle shadow plugin feature, see https://github.com/johnrengelman/shadow/issues/41
-private Set<SourceDirectorySet> collectSourceSetsIncludingSubmodules(Project project){
+private static Set<SourceDirectorySet> collectSourceSetsIncludingSubmodules(Project project){
   Set<SourceDirectorySet> result = [].toSet()
   recursiveCollectSourceSets(project, [].toSet(), result)
   return result
 }
 
-private void recursiveCollectSourceSets(Project visitingProject,
+private static void recursiveCollectSourceSets(Project visitingProject,
     Set<Project> visitedProjects,
     Set<SourceDirectorySet> collectedSourceSets) {
   if (!visitedProjects.contains(visitingProject)) {

--- a/gradle/helper/publishing.gradle
+++ b/gradle/helper/publishing.gradle
@@ -1,4 +1,4 @@
-ext.mavenPublishing = [
+ext.publishing = [
     configureArtifactPublishing: { currentProject, testJar ->
       publishing {
         publications {
@@ -36,28 +36,52 @@ ext.mavenPublishing = [
       }
     },
 
-    getMavenLocalPublicationTaskSuffix: {
-      return "PublicationToMavenLocal"
-    },
+    ensureCatchAllModuleGetsPublishedLast: {
+      // Ensure that the 'all-modules' module is published last
+      publishing.repositories.each { repo ->
+        def allModulesMavenRepoTaskName = getPublishingTaskForRepo('all-modules', repo.name)
+        tasks.named(allModulesMavenRepoTaskName) {
+          dependsOn tasks.matching {
+            it.name != allModulesMavenRepoTaskName
+                && it.name.startsWith('publish')
+                && it.name.endsWith(getMavenRepositoryPublicationTaskSuffix(repo.name))
+          }
+        }
+      }
 
-    getMavenRepositoryPublicationTaskSuffix: { repositoryName ->
-      return "PublicationTo${repositoryName}Repository"
-    },
-
-    getPublishingTaskForMavenLocal: { moduleName ->
-      def moduleNameCapitalized = capitalizeFirstLetter(moduleName)
-      return "publish${moduleNameCapitalized}${mavenPublishing.getMavenLocalPublicationTaskSuffix()}"
-    },
-
-    getPublishingTaskForRepo: { moduleName, repositoryName ->
-      def moduleNameCapitalized = capitalizeFirstLetter(moduleName)
-      return "publish${moduleNameCapitalized}${mavenPublishing.getMavenRepositoryPublicationTaskSuffix(repositoryName)}"
+      tasks.matching { it.name.startsWith("publish") }.each { task ->
+        task.doLast {
+          println "✅ Published: ${task.name}"
+        }
+      }
     }
 ]
 
-def capitalizeFirstLetter(String str) {
+static def getMavenRepositoryPublicationTaskSuffix(String repositoryName) {
+  if (!repositoryName) {
+    throw new IllegalArgumentException("Repository name must not be null or empty")
+  }
+
+  if (repositoryName == 'MavenLocal') {
+    return 'PublicationToMavenLocal'
+  }
+
+  return "PublicationTo${repositoryName}Repository"
+}
+
+static def capitalizeFirstLetter(String str) {
   if (!str || str.isEmpty()) {
     return str
   }
   return str[0].toUpperCase() + str.substring(1)
+}
+
+static def getPublishingTaskForRepo(String moduleName, String repositoryName) {
+  if (!repositoryName) {
+    throw new IllegalArgumentException("Repository name must not be null or empty")
+  }
+
+  def moduleNameCapitalized = capitalizeFirstLetter(moduleName)
+  def repositoryPublicationTaskSuffix = getMavenRepositoryPublicationTaskSuffix(repositoryName)
+  return "publish${moduleNameCapitalized}${repositoryPublicationTaskSuffix}"
 }

--- a/gradle/helper/publishing.gradle
+++ b/gradle/helper/publishing.gradle
@@ -1,42 +1,63 @@
-ext.publishing = [
+ext.mavenPublishing = [
     configureArtifactPublishing: { currentProject, testJar ->
-      if (currentProject.version != project.DEFAULT_VERSION) {
-        println "Will publish ${currentProject.path} at ${currentProject.group}:${currentProject.name}:${currentProject.version}"
+      publishing {
+        publications {
+          "${currentProject.name}" (MavenPublication) {
+            groupId currentProject.group
+            artifactId currentProject.name
+            version currentProject.version
 
-        publishing {
-          publications {
-            "${currentProject.name}" (MavenPublication) {
-              groupId currentProject.group
-              artifactId currentProject.name
-              version currentProject.version
+            from currentProject.components.java
 
-              from currentProject.components.java
+            artifact testJar
 
-              artifact testJar
+            //we strive to meet https://central.sonatype.org/pages/requirements.html
+            pom {
+              name = 'Venice'
+              description = 'Derived Data Platform for planet-scale workloads'
+              url = 'https://github.com/linkedin/venice'
 
-              //we strive to meet https://central.sonatype.org/pages/requirements.html
-              pom {
-                name = 'Venice'
-                description = 'Derived Data Platform for planet-scale workloads'
+              licenses {
+                license {
+                  name = 'BSD 2-Clause'
+                  url = 'https://raw.githubusercontent.com/linkedin/venice/main/LICENSE'
+                }
+              }
+              scm {
+                connection = 'scm:git:git://github.com:linkedin/venice.git'
+                developerConnection = 'scm:git:ssh://github.com:linkedin/venice.git'
                 url = 'https://github.com/linkedin/venice'
-
-                licenses {
-                  license {
-                    name = 'BSD 2-Clause'
-                    url = 'https://raw.githubusercontent.com/linkedin/venice/main/LICENSE'
-                  }
-                }
-                scm {
-                  connection = 'scm:git:git://github.com:linkedin/venice.git'
-                  developerConnection = 'scm:git:ssh://github.com:linkedin/venice.git'
-                  url = 'https://github.com/linkedin/venice'
-                }
               }
             }
           }
-
-          //repositories inherited from parent build.gradle
         }
+
+        //repositories inherited from parent build.gradle
       }
+    },
+
+    getMavenLocalPublicationTaskSuffix: {
+      return "PublicationToMavenLocal"
+    },
+
+    getMavenRepositoryPublicationTaskSuffix: { repositoryName ->
+      return "PublicationTo${repositoryName}Repository"
+    },
+
+    getPublishingTaskForMavenLocal: { moduleName ->
+      def moduleNameCapitalized = capitalizeFirstLetter(moduleName)
+      return "publish${moduleNameCapitalized}${mavenPublishing.getMavenLocalPublicationTaskSuffix()}"
+    },
+
+    getPublishingTaskForRepo: { moduleName, repositoryName ->
+      def moduleNameCapitalized = capitalizeFirstLetter(moduleName)
+      return "publish${moduleNameCapitalized}${mavenPublishing.getMavenRepositoryPublicationTaskSuffix(repositoryName)}"
     }
 ]
+
+def capitalizeFirstLetter(String str) {
+  if (!str || str.isEmpty()) {
+    return str
+  }
+  return str[0].toUpperCase() + str.substring(1)
+}


### PR DESCRIPTION
<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat], [protocol]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## Problem Statement
<!--
Describe
- What problem are you trying to solve
- What issues or limitations exist in the current code
- Why this change is necessary 
-->
We have a special gradle module called `all-modules`. This is supposed to be a single-module to add watchers on to know when new versions of Venice are released. By default, Gradle publish plugin publishes to Maven repo in alphabetical order. Due to it's name, `all-modules` is the first module that gets published.

## Solution
<!--
Describe
- What changes you are making and why. 
- How these changes solve the problem.
- Any performance considerations or trade-offs. 
- Describe what testings you have done, for example, performance testing etc.
-->
By ensuring that `all-modules` gets published last, we can use the same watcher to also ensure that all other modules have been published successfully, and the published version is ready to be used.

###  Code changes
- [ ] Added new code behind **a config**. If so list the config names and their default values in the PR description.
- [ ] Introduced new **log lines**. 
  - [ ] Confirmed if logs need to be **rate limited** to avoid excessive logging.

###  **Concurrency-Specific Checks**
Both reviewer and PR author to verify
- [X] Code has **no race conditions** or **thread safety issues**.
- [X] Proper **synchronization mechanisms** (e.g., `synchronized`, `RWLock`) are used where needed.
- [x] No **blocking calls** inside critical sections that could lead to deadlocks or performance degradation.
- [X] Verified **thread-safe collections** are used (e.g., `ConcurrentHashMap`, `CopyOnWriteArrayList`).
- [X] Validated proper exception handling in multi-threaded code to avoid silent thread termination.


## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
Tried manually locally. This is a build-only change

- [ ] New unit tests added.
- [ ] New integration tests added.
- [ ] Modified or extended existing tests.
- [ ] Verified backward compatibility (if applicable).

## Does this PR introduce any user-facing or breaking changes?
<!--  
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [X] No. You can skip the rest of this section.
- [ ] Yes. Clearly explain the behavior change and its impact.