### PR TITLE
[cc] Relax strict type check in ApacheKafkaConsumerAdapter to support non-ApacheKafkaOffsetPosition fallback

### DIFF
--- a/internal/venice-common/src/test/java/com/linkedin/venice/pubsub/adapter/kafka/consumer/ApacheKafkaConsumerAdapterTest.java
+++ b/internal/venice-common/src/test/java/com/linkedin/venice/pubsub/adapter/kafka/consumer/ApacheKafkaConsumerAdapterTest.java
@@ -166,11 +166,6 @@ public class ApacheKafkaConsumerAdapterTest {
     kafkaConsumerAdapter.subscribe(pubSubTopicPartition, null);
   }
 
-  @Test(expectedExceptions = IllegalArgumentException.class)
-  public void testSubscribeWithInvalidPubSubPositionType() {
-    kafkaConsumerAdapter.subscribe(pubSubTopicPartition, mock(PubSubPosition.class));
-  }
-
   @Test
   public void testSubscribeWithApacheKafkaOffsetPosition() {
     ApacheKafkaOffsetPosition offsetPosition = ApacheKafkaOffsetPosition.of(50);


### PR DESCRIPTION
## [pubsub] Relax strict type check in ApacheKafkaConsumerAdapter to support non-ApacheKafkaOffsetPosition fallback

This change removes the hard check that lastReadPubSubPosition must be an instance  
of ApacheKafkaOffsetPosition. Instead, the adapter now attempts to call  
getNumericOffset() and seek based on that offset if the position type is not symbolic  
and not ApacheKafkaOffsetPosition.  

This allows safer rollback scenarios where the position deserialized may have been  
written by other PubSubClients using a newer implementation (e.g., with a non-default  
PubSubPosition type), but is being read using the legacy Kafka-based consumer.  

This fallback path enables mixed-version compatibility during migration and rollout.  
It will be deprecated in the future once full enforcement is feasible.  

Logging is updated to indicate when the fallback logic is used.  .


###  Code changes
- [ ] Added new code behind **a config**. If so list the config names and their default values in the PR description.
- [ ] Introduced new **log lines**. 
  - [ ] Confirmed if logs need to be **rate limited** to avoid excessive logging.

###  **Concurrency-Specific Checks**
Both reviewer and PR author to verify
- [ ] Code has **no race conditions** or **thread safety issues**.
- [ ] Proper **synchronization mechanisms** (e.g., `synchronized`, `RWLock`) are used where needed.
- [ ] No **blocking calls** inside critical sections that could lead to deadlocks or performance degradation.
- [ ] Verified **thread-safe collections** are used (e.g., `ConcurrentHashMap`, `CopyOnWriteArrayList`).
- [ ] Validated proper exception handling in multi-threaded code to avoid silent thread termination.


## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->

- [ ] New unit tests added.
- [ ] New integration tests added.
- [ ] Modified or extended existing tests.
- [ ] Verified backward compatibility (if applicable).

## Does this PR introduce any user-facing or breaking changes?
<!--  
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [ ] No. You can skip the rest of this section.
- [ ] Yes. Clearly explain the behavior change and its impact.