### PR TITLE
[build] Fix catch-all module publishing order

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -174,7 +174,7 @@ publishing {
 }
 
 afterEvaluate {
-  publishing.ensureCatchAllModuleGetsPublishedLast()
+  mavenPublishing.ensureCatchAllModuleGetsPublishedLast(publishing.repositories)
 }
 
 def parser = new XmlSlurper()
@@ -602,7 +602,7 @@ subprojects {
 
   // Only publish artifacts for projects that are at the leaf level
   if (isLeafSubModule) {
-    publishing.configureArtifactPublishing(project, testJar)
+    mavenPublishing.configureArtifactPublishing(project, testJar)
   }
 }
 

--- a/gradle/helper/publishing.gradle
+++ b/gradle/helper/publishing.gradle
@@ -1,4 +1,4 @@
-ext.publishing = [
+ext.mavenPublishing = [
     configureArtifactPublishing: { currentProject, testJar ->
       publishing {
         publications {
@@ -36,22 +36,17 @@ ext.publishing = [
       }
     },
 
-    ensureCatchAllModuleGetsPublishedLast: {
+    ensureCatchAllModuleGetsPublishedLast: { repositories ->
       // Ensure that the 'all-modules' module is published last
-      publishing.repositories.each { repo ->
+      repositories.each { repo ->
         def allModulesMavenRepoTaskName = getPublishingTaskForRepo('all-modules', repo.name)
-        tasks.named(allModulesMavenRepoTaskName) {
-          dependsOn tasks.matching {
-            it.name != allModulesMavenRepoTaskName
-                && it.name.startsWith('publish')
-                && it.name.endsWith(getMavenRepositoryPublicationTaskSuffix(repo.name))
-          }
+        def otherModulesMavenRepoTaskNames = rootProject.tasks.matching {
+          it.name != allModulesMavenRepoTaskName
+              && it.name.startsWith('publish')
+              && it.name.endsWith(getMavenRepositoryPublicationTaskSuffix(repo.name))
         }
-      }
-
-      tasks.matching { it.name.startsWith("publish") }.each { task ->
-        task.doLast {
-          println "✅ Published: ${task.name}"
+        rootProject.tasks.named(allModulesMavenRepoTaskName) {
+          dependsOn otherModulesMavenRepoTaskNames
         }
       }
     }


### PR DESCRIPTION
<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat], [protocol]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## Problem Statement
<!--
Describe
- What problem are you trying to solve
- What issues or limitations exist in the current code
- Why this change is necessary 
-->
In a previous PR (#1995), I tried to make `all-modules` publish last, and in the latest commit, due to refactoring, it didn't work as intended - and the result was almost a no-op. This PR fixes the issue and makes the feature work.

## Solution
<!--
Describe
- What changes you are making and why. 
- How these changes solve the problem.
- Any performance considerations or trade-offs. 
- Describe what testings you have done, for example, performance testing etc.
-->
Fixed refactored build code

###  Code changes
- [ ] Added new code behind **a config**. If so list the config names and their default values in the PR description.
- [ ] Introduced new **log lines**. 
  - [ ] Confirmed if logs need to be **rate limited** to avoid excessive logging.

###  **Concurrency-Specific Checks**
Both reviewer and PR author to verify
- [x] Code has **no race conditions** or **thread safety issues**.
- [x] Proper **synchronization mechanisms** (e.g., `synchronized`, `RWLock`) are used where needed.
- [x] No **blocking calls** inside critical sections that could lead to deadlocks or performance degradation.
- [x] Verified **thread-safe collections** are used (e.g., `ConcurrentHashMap`, `CopyOnWriteArrayList`).
- [x] Validated proper exception handling in multi-threaded code to avoid silent thread termination.


## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
Tried locally on `mavenLocal`

- [ ] New unit tests added.
- [ ] New integration tests added.
- [ ] Modified or extended existing tests.
- [x] Verified backward compatibility (if applicable).

## Does this PR introduce any user-facing or breaking changes?
<!--  
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Clearly explain the behavior change and its impact.