### PR TITLE
[server][controller] Add subscribe API with inclusive flag

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/consumer/InternalLocalBootstrappingVeniceChangelogConsumer.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/consumer/InternalLocalBootstrappingVeniceChangelogConsumer.java
@@ -164,15 +164,15 @@ class InternalLocalBootstrappingVeniceChangelogConsumer<K, V> extends VeniceAfte
           throw new VeniceException("Failed to decode local change capture coordinate checkpoint with exception: ", e);
         }
 
-        PubSubPosition earliestPosition;
+        PubSubPosition earliestOffset;
         PubSubTopicPartition topicPartition = getTopicPartition(partition);
         synchronized (pubSubConsumer) {
-          earliestPosition =
+          earliestOffset =
               pubSubConsumer.beginningPosition(topicPartition, getPubsubOffsetApiTimeoutDurationDefaultValue());
         }
-        VeniceChangeCoordinate earliestCheckpoint = earliestPosition == null
+        VeniceChangeCoordinate earliestCheckpoint = earliestOffset == null
             ? null
-            : new VeniceChangeCoordinate(topicPartition.getPubSubTopic().getName(), earliestPosition, partition);
+            : new VeniceChangeCoordinate(topicPartition.getPubSubTopic().getName(), earliestOffset, partition);
 
         // If earliest offset is larger than the local, we should just bootstrap from beginning.
         if (earliestCheckpoint != null && earliestCheckpoint.comparePosition(localCheckpoint) > -1) {

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/consumer/InternalLocalBootstrappingVeniceChangelogConsumer.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/consumer/InternalLocalBootstrappingVeniceChangelogConsumer.java
@@ -164,15 +164,15 @@ class InternalLocalBootstrappingVeniceChangelogConsumer<K, V> extends VeniceAfte
           throw new VeniceException("Failed to decode local change capture coordinate checkpoint with exception: ", e);
         }
 
-        PubSubPosition earliestOffset;
+        PubSubPosition earliestPosition;
         PubSubTopicPartition topicPartition = getTopicPartition(partition);
         synchronized (pubSubConsumer) {
-          earliestOffset =
+          earliestPosition =
               pubSubConsumer.beginningPosition(topicPartition, getPubsubOffsetApiTimeoutDurationDefaultValue());
         }
-        VeniceChangeCoordinate earliestCheckpoint = earliestOffset == null
+        VeniceChangeCoordinate earliestCheckpoint = earliestPosition == null
             ? null
-            : new VeniceChangeCoordinate(topicPartition.getPubSubTopic().getName(), earliestOffset, partition);
+            : new VeniceChangeCoordinate(topicPartition.getPubSubTopic().getName(), earliestPosition, partition);
 
         // If earliest offset is larger than the local, we should just bootstrap from beginning.
         if (earliestCheckpoint != null && earliestCheckpoint.comparePosition(localCheckpoint) > -1) {

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/SharedKafkaConsumer.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/SharedKafkaConsumer.java
@@ -384,11 +384,6 @@ class SharedKafkaConsumer implements PubSubConsumerAdapter {
   }
 
   @Override
-  public Long beginningOffset(PubSubTopicPartition partition, Duration timeout) {
-    throw new UnsupportedOperationException("beginningOffset is not supported in SharedKafkaConsumer");
-  }
-
-  @Override
   public PubSubPosition beginningPosition(PubSubTopicPartition pubSubTopicPartition, Duration timeout) {
     throw new UnsupportedOperationException("beginningPosition is not supported in SharedKafkaConsumer");
   }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/SharedKafkaConsumer.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/SharedKafkaConsumer.java
@@ -26,6 +26,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Supplier;
+import javax.annotation.Nonnull;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -137,6 +138,15 @@ class SharedKafkaConsumer implements PubSubConsumerAdapter {
   @UnderDevelopment(value = "This API may not be implemented in all PubSubConsumerAdapter implementations.")
   @Override
   public synchronized void subscribe(PubSubTopicPartition pubSubTopicPartition, PubSubPosition lastReadPubSubPosition) {
+    throw new VeniceException(
+        this.getClass().getSimpleName() + " does not support subscribe without specifying a version-topic.");
+  }
+
+  @Override
+  public void subscribe(
+      @Nonnull PubSubTopicPartition pubSubTopicPartition,
+      @Nonnull PubSubPosition position,
+      boolean isInclusive) {
     throw new VeniceException(
         this.getClass().getSimpleName() + " does not support subscribe without specifying a version-topic.");
   }
@@ -381,6 +391,13 @@ class SharedKafkaConsumer implements PubSubConsumerAdapter {
   @Override
   public PubSubPosition beginningPosition(PubSubTopicPartition pubSubTopicPartition, Duration timeout) {
     throw new UnsupportedOperationException("beginningPosition is not supported in SharedKafkaConsumer");
+  }
+
+  @Override
+  public Map<PubSubTopicPartition, PubSubPosition> beginningPositions(
+      Collection<PubSubTopicPartition> partitions,
+      Duration timeout) {
+    throw new UnsupportedOperationException("beginningPositions is not supported in SharedKafkaConsumer");
   }
 
   @Override

--- a/clients/venice-admin-tool/src/main/java/com/linkedin/venice/KafkaTopicDumper.java
+++ b/clients/venice-admin-tool/src/main/java/com/linkedin/venice/KafkaTopicDumper.java
@@ -298,9 +298,10 @@ public class KafkaTopicDumper implements AutoCloseable {
           partition);
       startingOffset = offsetForTime;
     }
-    Long partitionBeginningOffset =
-        consumer.beginningOffset(partition, getPubsubOffsetApiTimeoutDurationDefaultValue());
-    return Math.max(partitionBeginningOffset, startingOffset);
+    ;
+    return Math.max(
+        startingOffset,
+        consumer.beginningPosition(partition, getPubsubOffsetApiTimeoutDurationDefaultValue()).getNumericOffset());
   }
 
   /**

--- a/clients/venice-admin-tool/src/main/java/com/linkedin/venice/KafkaTopicDumper.java
+++ b/clients/venice-admin-tool/src/main/java/com/linkedin/venice/KafkaTopicDumper.java
@@ -298,7 +298,6 @@ public class KafkaTopicDumper implements AutoCloseable {
           partition);
       startingOffset = offsetForTime;
     }
-    ;
     return Math.max(
         startingOffset,
         consumer.beginningPosition(partition, getPubsubOffsetApiTimeoutDurationDefaultValue()).getNumericOffset());

--- a/clients/venice-admin-tool/src/test/java/com/linkedin/venice/TestKafkaTopicDumper.java
+++ b/clients/venice-admin-tool/src/test/java/com/linkedin/venice/TestKafkaTopicDumper.java
@@ -337,9 +337,9 @@ public class TestKafkaTopicDumper {
     long startOffset = -1;
     long startTimestamp = 123456789L;
     long offsetForTime = 1234L;
-    long beginningOffset = 0;
+    ApacheKafkaOffsetPosition startPosition = ApacheKafkaOffsetPosition.of(0L);
     when(consumerAdapter.offsetForTime(topicPartition, startTimestamp)).thenReturn(offsetForTime);
-    when(consumerAdapter.beginningOffset(eq(topicPartition), any())).thenReturn(beginningOffset);
+    when(consumerAdapter.beginningPosition(eq(topicPartition), any())).thenReturn(startPosition);
     long actualStartOffset =
         KafkaTopicDumper.calculateStartingOffset(consumerAdapter, topicPartition, startOffset, startTimestamp);
     assertEquals(actualStartOffset, offsetForTime);
@@ -357,18 +357,18 @@ public class TestKafkaTopicDumper {
 
     // Case 3: When start timestamp is non-negative and start offset is non-negative; but beginning offset is higher
     // than offsetForTime, beginning offset should be used as the start offset.
-    beginningOffset = 12356L;
+    startPosition = ApacheKafkaOffsetPosition.of(12356L);
     when(consumerAdapter.offsetForTime(topicPartition, startTimestamp)).thenReturn(startOffset);
-    when(consumerAdapter.beginningOffset(eq(topicPartition), any())).thenReturn(beginningOffset);
+    when(consumerAdapter.beginningPosition(eq(topicPartition), any())).thenReturn(startPosition);
     actualStartOffset =
         KafkaTopicDumper.calculateStartingOffset(consumerAdapter, topicPartition, startOffset, startTimestamp);
-    assertEquals(actualStartOffset, beginningOffset);
+    assertEquals(actualStartOffset, startPosition.getInternalOffset());
 
     // Case 4: When start timestamp is negative and start offset > beginning offset, start offset should be used.
     startOffset = 1234L;
     startTimestamp = -1;
     when(consumerAdapter.offsetForTime(topicPartition, startTimestamp)).thenReturn(null);
-    when(consumerAdapter.beginningOffset(eq(topicPartition), any())).thenReturn(0L);
+    when(consumerAdapter.beginningPosition(eq(topicPartition), any())).thenReturn(ApacheKafkaOffsetPosition.of(0L));
     actualStartOffset =
         KafkaTopicDumper.calculateStartingOffset(consumerAdapter, topicPartition, startOffset, startTimestamp);
     assertEquals(actualStartOffset, startOffset);

--- a/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/PubSubUtil.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/PubSubUtil.java
@@ -285,4 +285,15 @@ public final class PubSubUtil {
     }
     return position;
   }
+
+  /**
+   * Calculates the seek offset based on the base offset and inclusiveness flag.
+   *
+   * @param baseOffset the base offset to calculate from
+   * @param isInclusive if true, returns the base offset; if false, returns base offset + 1
+   * @return the calculated seek offset
+   */
+  public static long calculateSeekOffset(long baseOffset, boolean isInclusive) {
+    return isInclusive ? baseOffset : baseOffset + 1;
+  }
 }

--- a/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/adapter/kafka/consumer/ApacheKafkaConsumerAdapter.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/adapter/kafka/consumer/ApacheKafkaConsumerAdapter.java
@@ -506,16 +506,6 @@ public class ApacheKafkaConsumerAdapter implements PubSubConsumerAdapter {
   }
 
   @Override
-  public Long beginningOffset(PubSubTopicPartition pubSubTopicPartition, Duration timeout) {
-    ApacheKafkaOffsetPosition beginningPosition =
-        (ApacheKafkaOffsetPosition) beginningPosition(pubSubTopicPartition, timeout);
-    if (beginningPosition == null) {
-      return 0L;
-    }
-    return beginningPosition.getInternalOffset();
-  }
-
-  @Override
   public PubSubPosition beginningPosition(PubSubTopicPartition pubSubTopicPartition, Duration timeout) {
     return beginningPositions(Collections.singleton(pubSubTopicPartition), timeout).get(pubSubTopicPartition);
   }

--- a/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/adapter/kafka/consumer/ApacheKafkaConsumerAdapter.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/adapter/kafka/consumer/ApacheKafkaConsumerAdapter.java
@@ -1,5 +1,7 @@
 package com.linkedin.venice.pubsub.adapter.kafka.consumer;
 
+import static com.linkedin.venice.pubsub.PubSubUtil.calculateSeekOffset;
+
 import com.linkedin.venice.annotation.NotThreadsafe;
 import com.linkedin.venice.exceptions.VeniceException;
 import com.linkedin.venice.offsets.OffsetRecord;
@@ -158,10 +160,10 @@ public class ApacheKafkaConsumerAdapter implements PubSubConsumerAdapter {
     String logMessage;
     if (position == PubSubSymbolicPosition.EARLIEST) {
       kafkaConsumer.seekToBeginning(Collections.singletonList(topicPartition));
-      logMessage = "EARLIEST (start)";
+      logMessage = PubSubSymbolicPosition.EARLIEST + " (beginning)";
     } else if (position == PubSubSymbolicPosition.LATEST) {
       kafkaConsumer.seekToEnd(Collections.singletonList(topicPartition));
-      logMessage = "LATEST (end)";
+      logMessage = PubSubSymbolicPosition.LATEST + " (end)";
     } else if (position instanceof ApacheKafkaOffsetPosition) {
       ApacheKafkaOffsetPosition kafkaOffsetPosition = (ApacheKafkaOffsetPosition) position;
       long seekOffset = calculateSeekOffset(kafkaOffsetPosition.getInternalOffset(), isInclusive);
@@ -711,16 +713,5 @@ public class ApacheKafkaConsumerAdapter implements PubSubConsumerAdapter {
         pubSubMessageHeaders,
         pubSubPosition,
         consumerRecord.timestamp());
-  }
-
-  /**
-   * Calculates the seek offset based on the base offset and inclusiveness flag.
-   *
-   * @param baseOffset the base offset to calculate from
-   * @param isInclusive if true, returns the base offset; if false, returns base offset + 1
-   * @return the calculated seek offset
-   */
-  private long calculateSeekOffset(long baseOffset, boolean isInclusive) {
-    return isInclusive ? baseOffset : baseOffset + 1;
   }
 }

--- a/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/adapter/kafka/consumer/ApacheKafkaConsumerAdapter.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/adapter/kafka/consumer/ApacheKafkaConsumerAdapter.java
@@ -122,9 +122,21 @@ public class ApacheKafkaConsumerAdapter implements PubSubConsumerAdapter {
   public void subscribe(
       @Nonnull PubSubTopicPartition pubSubTopicPartition,
       @Nonnull PubSubPosition lastReadPubSubPosition) {
-    if (lastReadPubSubPosition == null) {
-      LOGGER
-          .error("Failed to subscribe to topic-partition: {} because last read position is null", pubSubTopicPartition);
+    subscribe(pubSubTopicPartition, lastReadPubSubPosition, false);
+  }
+
+  @Override
+  public void subscribe(
+      @Nonnull PubSubTopicPartition pubSubTopicPartition,
+      @Nonnull PubSubPosition position,
+      boolean isInclusive) {
+    LOGGER.info(
+        "Requested subscription to topic-partition: {} with position: {} isInclusive: {}",
+        pubSubTopicPartition,
+        position,
+        isInclusive);
+    if (position == null) {
+      LOGGER.error("Failed to subscribe to topic-partition: {} because position is null", pubSubTopicPartition);
       throw new IllegalArgumentException("Last read position cannot be null");
     }
 
@@ -133,7 +145,7 @@ public class ApacheKafkaConsumerAdapter implements PubSubConsumerAdapter {
       LOGGER.warn(
           "Already subscribed to topic-partition:{}, ignoring subscription request with position: {}",
           pubSubTopicPartition,
-          lastReadPubSubPosition);
+          position);
       return;
     }
 
@@ -144,27 +156,28 @@ public class ApacheKafkaConsumerAdapter implements PubSubConsumerAdapter {
     kafkaConsumer.assign(topicPartitionList);
 
     String logMessage;
-    if (lastReadPubSubPosition == PubSubSymbolicPosition.EARLIEST) {
+    if (position == PubSubSymbolicPosition.EARLIEST) {
       kafkaConsumer.seekToBeginning(Collections.singletonList(topicPartition));
-      logMessage = PubSubSymbolicPosition.EARLIEST.toString();
-    } else if (lastReadPubSubPosition == PubSubSymbolicPosition.LATEST) {
+      logMessage = "EARLIEST (start)";
+    } else if (position == PubSubSymbolicPosition.LATEST) {
       kafkaConsumer.seekToEnd(Collections.singletonList(topicPartition));
-      logMessage = PubSubSymbolicPosition.LATEST.toString();
-    } else if (lastReadPubSubPosition instanceof ApacheKafkaOffsetPosition) {
-      ApacheKafkaOffsetPosition kafkaOffsetPosition = (ApacheKafkaOffsetPosition) lastReadPubSubPosition;
-      long consumptionStartOffset = kafkaOffsetPosition.getInternalOffset() + 1;
-      kafkaConsumer.seek(topicPartition, consumptionStartOffset);
-      logMessage = "" + consumptionStartOffset;
+      logMessage = "LATEST (end)";
+    } else if (position instanceof ApacheKafkaOffsetPosition) {
+      ApacheKafkaOffsetPosition kafkaOffsetPosition = (ApacheKafkaOffsetPosition) position;
+      long seekOffset = calculateSeekOffset(kafkaOffsetPosition.getInternalOffset(), isInclusive);
+      kafkaConsumer.seek(topicPartition, seekOffset);
+      logMessage = String.valueOf(seekOffset);
     } else {
       // N.B. This fallback path allows safe rollbacks where the PubSubPosition was written
       // by a newer PubSubClient (possibly using a non-default PubSubPosition implementation),
       // but is being consumed using the Kafka client.
       // In such cases, we attempt to use getNumericOffset() to preserve compatibility.
       // This behavior is temporary and will be deprecated once full enforcement is feasible.
-      long consumptionStartOffset = lastReadPubSubPosition.getNumericOffset() + 1;
-      kafkaConsumer.seek(topicPartition, consumptionStartOffset);
-      logMessage = "" + consumptionStartOffset + " (last read position: " + lastReadPubSubPosition + ")";
+      long seekOffset = calculateSeekOffset(position.getNumericOffset(), isInclusive);
+      kafkaConsumer.seek(topicPartition, seekOffset);
+      logMessage = String.valueOf(seekOffset);
     }
+
     assignments.put(topicPartition, pubSubTopicPartition);
     LOGGER.info("Subscribed to topic-partition: {} from position: {}", pubSubTopicPartition, logMessage);
   }
@@ -494,33 +507,54 @@ public class ApacheKafkaConsumerAdapter implements PubSubConsumerAdapter {
 
   @Override
   public Long beginningOffset(PubSubTopicPartition pubSubTopicPartition, Duration timeout) {
-    TopicPartition kafkaTp =
-        new TopicPartition(pubSubTopicPartition.getPubSubTopic().getName(), pubSubTopicPartition.getPartitionNumber());
-    try {
-      return this.kafkaConsumer.beginningOffsets(Collections.singleton(kafkaTp), timeout).get(kafkaTp);
-    } catch (TimeoutException e) {
-      throw new PubSubOpTimeoutException("Timed out while getting beginning offset for " + kafkaTp, e);
-    } catch (Exception e) {
-      throw new PubSubClientException("Exception while getting beginning offset for " + kafkaTp, e);
+    ApacheKafkaOffsetPosition beginningPosition =
+        (ApacheKafkaOffsetPosition) beginningPosition(pubSubTopicPartition, timeout);
+    if (beginningPosition == null) {
+      return 0L;
     }
+    return beginningPosition.getInternalOffset();
   }
 
   @Override
   public PubSubPosition beginningPosition(PubSubTopicPartition pubSubTopicPartition, Duration timeout) {
-    Long beginningOffset = beginningOffset(pubSubTopicPartition, timeout);
-    return beginningOffset != null ? new ApacheKafkaOffsetPosition(beginningOffset) : PubSubSymbolicPosition.EARLIEST;
+    return beginningPositions(Collections.singleton(pubSubTopicPartition), timeout).get(pubSubTopicPartition);
   }
 
   @Override
-  public Map<PubSubTopicPartition, Long> endOffsets(Collection<PubSubTopicPartition> partitions, Duration timeout) {
-    Map<TopicPartition, PubSubTopicPartition> pubSubTopicPartitionMapping = new HashMap<>(partitions.size());
-    for (PubSubTopicPartition pubSubTopicPartition: partitions) {
-      pubSubTopicPartitionMapping.put(
+  public Map<PubSubTopicPartition, PubSubPosition> beginningPositions(
+      Collection<PubSubTopicPartition> partitions,
+      Duration timeout) {
+    Map<TopicPartition, PubSubTopicPartition> partitionMapping = toKafkaTopicPartitionMap(partitions);
+    try {
+      Map<TopicPartition, Long> startOffsets = kafkaConsumer.beginningOffsets(partitionMapping.keySet(), timeout);
+      Map<PubSubTopicPartition, PubSubPosition> offsets = new HashMap<>(startOffsets.size());
+      for (Map.Entry<TopicPartition, Long> entry: startOffsets.entrySet()) {
+        offsets.put(partitionMapping.get(entry.getKey()), new ApacheKafkaOffsetPosition(entry.getValue()));
+      }
+      return offsets;
+    } catch (TimeoutException e) {
+      throw new PubSubOpTimeoutException("Timed out while fetching start offsets for " + partitions, e);
+    } catch (Exception e) {
+      throw new PubSubClientException("Failed to fetch start offsets for " + partitions, e);
+    }
+  }
+
+  private static Map<TopicPartition, PubSubTopicPartition> toKafkaTopicPartitionMap(
+      Collection<PubSubTopicPartition> pubSubTopicPartitions) {
+    Map<TopicPartition, PubSubTopicPartition> topicPartitionMap = new HashMap<>(pubSubTopicPartitions.size());
+    for (PubSubTopicPartition pubSubTopicPartition: pubSubTopicPartitions) {
+      topicPartitionMap.put(
           new TopicPartition(
               pubSubTopicPartition.getPubSubTopic().getName(),
               pubSubTopicPartition.getPartitionNumber()),
           pubSubTopicPartition);
     }
+    return topicPartitionMap;
+  }
+
+  @Override
+  public Map<PubSubTopicPartition, Long> endOffsets(Collection<PubSubTopicPartition> partitions, Duration timeout) {
+    Map<TopicPartition, PubSubTopicPartition> pubSubTopicPartitionMapping = toKafkaTopicPartitionMap(partitions);
     try {
       Map<TopicPartition, Long> topicPartitionOffsetMap =
           this.kafkaConsumer.endOffsets(pubSubTopicPartitionMapping.keySet(), timeout);
@@ -687,5 +721,16 @@ public class ApacheKafkaConsumerAdapter implements PubSubConsumerAdapter {
         pubSubMessageHeaders,
         pubSubPosition,
         consumerRecord.timestamp());
+  }
+
+  /**
+   * Calculates the seek offset based on the base offset and inclusiveness flag.
+   *
+   * @param baseOffset the base offset to calculate from
+   * @param isInclusive if true, returns the base offset; if false, returns base offset + 1
+   * @return the calculated seek offset
+   */
+  private long calculateSeekOffset(long baseOffset, boolean isInclusive) {
+    return isInclusive ? baseOffset : baseOffset + 1;
   }
 }

--- a/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/api/PubSubConsumerAdapter.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/api/PubSubConsumerAdapter.java
@@ -253,7 +253,7 @@ public interface PubSubConsumerAdapter extends AutoCloseable, Closeable {
   PubSubPosition getPositionByTimestamp(PubSubTopicPartition pubSubTopicPartition, long timestamp);
 
   /**
-   * Retrieves the beginning offset for the specified PubSub topic-partition.
+   * Retrieves the beginning position for the specified PubSub topic-partition.
    *
    * @param pubSubTopicPartition The PubSub topic-partition for which to fetch the beginning offset.
    * @param timeout The maximum duration to wait for the operation to complete.
@@ -262,8 +262,6 @@ public interface PubSubConsumerAdapter extends AutoCloseable, Closeable {
    * @throws PubSubOpTimeoutException If the operation times out while fetching the beginning offset.
    * @throws PubSubClientException If there is an error while attempting to fetch the beginning offset.
    */
-  Long beginningOffset(PubSubTopicPartition pubSubTopicPartition, Duration timeout);
-
   PubSubPosition beginningPosition(PubSubTopicPartition pubSubTopicPartition, Duration timeout);
 
   default PubSubPosition beginningPosition(PubSubTopicPartition pubSubTopicPartition) {

--- a/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/manager/TopicMetadataFetcher.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/manager/TopicMetadataFetcher.java
@@ -613,7 +613,8 @@ class TopicMetadataFetcher implements Closeable {
 
       // find the beginning offset
       long earliestOffset =
-          pubSubConsumerAdapter.beginningOffset(pubSubTopicPartition, getPubsubOffsetApiTimeoutDurationDefaultValue());
+          pubSubConsumerAdapter.beginningPosition(pubSubTopicPartition, getPubsubOffsetApiTimeoutDurationDefaultValue())
+              .getNumericOffset();
       if (earliestOffset == latestOffset) {
         return Collections.emptyList(); // no records in this topic partition
       }

--- a/internal/venice-common/src/test/java/com/linkedin/venice/pubsub/PubSubUtilTest.java
+++ b/internal/venice-common/src/test/java/com/linkedin/venice/pubsub/PubSubUtilTest.java
@@ -234,4 +234,13 @@ public class PubSubUtilTest {
     assertTrue(PubSubUtil.comparePubSubPositions(pos2, pos1) > 0);
     assertEquals(PubSubUtil.comparePubSubPositions(pos1, pos1), 0);
   }
+
+  @Test
+  public void testCalculateSeekOffset() {
+    // Case 1: Inclusive = true, should return the same offset
+    assertEquals(PubSubUtil.calculateSeekOffset(100L, true), 100L, "Inclusive seek should return the base offset");
+
+    // Case 2: Inclusive = false, should return base offset + 1
+    assertEquals(PubSubUtil.calculateSeekOffset(100L, false), 101L, "Exclusive seek should return base offset + 1");
+  }
 }

--- a/internal/venice-common/src/test/java/com/linkedin/venice/pubsub/manager/TopicMetadataFetcherTest.java
+++ b/internal/venice-common/src/test/java/com/linkedin/venice/pubsub/manager/TopicMetadataFetcherTest.java
@@ -323,21 +323,22 @@ public class TopicMetadataFetcherTest {
     assertEquals(consumedRecords.size(), 0);
 
     // test when beginningOffset (non-zero) is same as endOffset
-    endOffsetsMap.put(topicPartition, 1L);
+    ApacheKafkaOffsetPosition position = new ApacheKafkaOffsetPosition(1L);
+    endOffsetsMap.put(topicPartition, position.getInternalOffset());
     when(consumerMock.endOffsets(eq(Collections.singletonList(topicPartition)), any(Duration.class)))
         .thenReturn(endOffsetsMap);
-    when(consumerMock.beginningOffset(eq(topicPartition), any(Duration.class))).thenReturn(1L);
+    when(consumerMock.beginningPosition(eq(topicPartition), any(Duration.class))).thenReturn(position);
     consumedRecords = topicMetadataFetcher.consumeLatestRecords(topicPartition, 1);
     assertEquals(consumedRecords.size(), 0);
 
+    ApacheKafkaOffsetPosition startPosition = ApacheKafkaOffsetPosition.of(3);
     long endOffset = 10;
-    long startOffset = 3;
     int numRecordsToRead = 5; // read records at offsets 5, 6, 7, 8, 9
     long consumePastOffset = 4; // subscribe at offset
     endOffsetsMap.put(topicPartition, endOffset);
     when(consumerMock.endOffsets(eq(Collections.singletonList(topicPartition)), any(Duration.class)))
         .thenReturn(endOffsetsMap);
-    when(consumerMock.beginningOffset(eq(topicPartition), any(Duration.class))).thenReturn(startOffset);
+    when(consumerMock.beginningPosition(eq(topicPartition), any(Duration.class))).thenReturn(startPosition);
     verify(consumerMock, never()).subscribe(topicPartition, consumePastOffset);
     verify(consumerMock, never()).poll(anyLong());
     verify(consumerMock, never()).unSubscribe(eq(topicPartition));

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/pubsub/api/consumer/PubSubConsumerAdapterTest.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/pubsub/api/consumer/PubSubConsumerAdapterTest.java
@@ -335,7 +335,7 @@ public class PubSubConsumerAdapterTest {
     long startTime = System.currentTimeMillis();
     assertThrows(
         PubSubOpTimeoutException.class,
-        () -> pubSubConsumerAdapter.beginningOffset(partition, PUBSUB_OP_TIMEOUT));
+        () -> pubSubConsumerAdapter.beginningPosition(partition, PUBSUB_OP_TIMEOUT));
     long elapsedTime = System.currentTimeMillis() - startTime;
     assertTrue(
         elapsedTime <= PUBSUB_OP_TIMEOUT_WITH_VARIANCE,
@@ -354,21 +354,21 @@ public class PubSubConsumerAdapterTest {
 
     PubSubTopicPartition partition = new PubSubTopicPartitionImpl(existingPubSubTopic, 0);
     long startTime = System.currentTimeMillis();
-    long beginningOffset = pubSubConsumerAdapter.beginningOffset(partition, PUBSUB_OP_TIMEOUT);
+    long beginningOffset = pubSubConsumerAdapter.beginningPosition(partition, PUBSUB_OP_TIMEOUT).getNumericOffset();
     long elapsedTime = System.currentTimeMillis() - startTime;
     assertEquals(beginningOffset, 0, "Beginning offset should be 0 for an existing topic");
     assertTrue(elapsedTime <= PUBSUB_CONSUMER_API_DEFAULT_TIMEOUT_MS_WITH_VARIANCE, "beginningOffset should not block");
 
     partition = new PubSubTopicPartitionImpl(existingPubSubTopic, 1);
     startTime = System.currentTimeMillis();
-    beginningOffset = pubSubConsumerAdapter.beginningOffset(partition, PUBSUB_OP_TIMEOUT);
+    beginningOffset = pubSubConsumerAdapter.beginningPosition(partition, PUBSUB_OP_TIMEOUT).getNumericOffset();
     elapsedTime = System.currentTimeMillis() - startTime;
     assertEquals(beginningOffset, 0, "Beginning offset should be 0 for an existing topic");
     assertTrue(elapsedTime <= PUBSUB_OP_TIMEOUT_WITH_VARIANCE, "beginningOffset should not block");
 
     partition = new PubSubTopicPartitionImpl(existingPubSubTopic, 2);
     startTime = System.currentTimeMillis();
-    beginningOffset = pubSubConsumerAdapter.beginningOffset(partition, PUBSUB_OP_TIMEOUT);
+    beginningOffset = pubSubConsumerAdapter.beginningPosition(partition, PUBSUB_OP_TIMEOUT).getNumericOffset();
     elapsedTime = System.currentTimeMillis() - startTime;
     assertEquals(beginningOffset, 0, "Beginning offset should be 0 for an existing topic");
     assertTrue(elapsedTime <= PUBSUB_OP_TIMEOUT_WITH_VARIANCE, "beginningOffset should not block");
@@ -390,14 +390,14 @@ public class PubSubConsumerAdapterTest {
         "Topic should have only 1 partition");
 
     PubSubTopicPartition partition = new PubSubTopicPartitionImpl(existingPubSubTopic, 0);
-    long beginningOffset = pubSubConsumerAdapter.beginningOffset(partition, PUBSUB_OP_TIMEOUT);
+    long beginningOffset = pubSubConsumerAdapter.beginningPosition(partition, PUBSUB_OP_TIMEOUT).getNumericOffset();
     assertEquals(beginningOffset, 0, "Beginning offset should be 0 for an existing topic");
 
     PubSubTopicPartition nonExistentPartition = new PubSubTopicPartitionImpl(existingPubSubTopic, 1);
     long startTime = System.currentTimeMillis();
     assertThrows(
         PubSubOpTimeoutException.class,
-        () -> pubSubConsumerAdapter.beginningOffset(nonExistentPartition, PUBSUB_OP_TIMEOUT));
+        () -> pubSubConsumerAdapter.beginningPosition(nonExistentPartition, PUBSUB_OP_TIMEOUT));
     long elapsedTime = System.currentTimeMillis() - startTime;
     assertTrue(
         elapsedTime <= PUBSUB_OP_TIMEOUT_WITH_VARIANCE,

--- a/internal/venice-test-common/src/main/java/com/linkedin/venice/pubsub/mock/adapter/consumer/MockInMemoryConsumerAdapter.java
+++ b/internal/venice-test-common/src/main/java/com/linkedin/venice/pubsub/mock/adapter/consumer/MockInMemoryConsumerAdapter.java
@@ -95,11 +95,10 @@ public class MockInMemoryConsumerAdapter implements PubSubConsumerAdapter {
         throw new IllegalStateException(
             "endPosition returned unsupported type: " + resolved.getClass().getSimpleName());
       }
-      long endOffset = ((InMemoryPubSubPosition) resolved).getInternalOffset();
-      seekOffset = isInclusive ? endOffset : endOffset + 1;
+      seekOffset = ((InMemoryPubSubPosition) resolved).getInternalOffset();
     } else if (position instanceof InMemoryPubSubPosition) {
       long inputOffset = ((InMemoryPubSubPosition) position).getInternalOffset();
-      seekOffset = isInclusive ? inputOffset : inputOffset + 1;
+      seekOffset = PubSubUtil.calculateSeekOffset(inputOffset, isInclusive);
     } else {
       throw new IllegalArgumentException("Unsupported PubSubPosition type: " + position.getClass());
     }

--- a/internal/venice-test-common/src/main/java/com/linkedin/venice/pubsub/mock/adapter/consumer/MockInMemoryConsumerAdapter.java
+++ b/internal/venice-test-common/src/main/java/com/linkedin/venice/pubsub/mock/adapter/consumer/MockInMemoryConsumerAdapter.java
@@ -22,6 +22,9 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import javax.annotation.Nonnull;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 
 /**
@@ -37,8 +40,10 @@ import java.util.Set;
  *
  */
 public class MockInMemoryConsumerAdapter implements PubSubConsumerAdapter {
+  private static final Logger LOGGER = LogManager.getLogger(MockInMemoryConsumerAdapter.class);
+
   private final InMemoryPubSubBroker broker;
-  private final Map<PubSubTopicPartition, InMemoryPubSubPosition> offsets = new VeniceConcurrentHashMap<>();
+  private final Map<PubSubTopicPartition, InMemoryPubSubPosition> lastReadPositions = new VeniceConcurrentHashMap<>();
   private final PollStrategy pollStrategy;
   private final PubSubConsumerAdapter delegate;
   private final Set<PubSubTopicPartition> pausedTopicPartitions = VeniceConcurrentHashMap.newKeySet();
@@ -66,26 +71,57 @@ public class MockInMemoryConsumerAdapter implements PubSubConsumerAdapter {
 
   @Override
   public synchronized void subscribe(PubSubTopicPartition pubSubTopicPartition, PubSubPosition lastReadPubSubPosition) {
-    InMemoryPubSubPosition lastReadPosition;
-    if (lastReadPubSubPosition == PubSubSymbolicPosition.EARLIEST) {
-      lastReadPosition = InMemoryPubSubPosition.of(-1L);
-    } else if (lastReadPubSubPosition == PubSubSymbolicPosition.LATEST) {
-      lastReadPosition = (InMemoryPubSubPosition) endPosition(pubSubTopicPartition);
-    } else if (lastReadPubSubPosition instanceof InMemoryPubSubPosition) {
-      lastReadPosition = (InMemoryPubSubPosition) lastReadPubSubPosition;
+    subscribe(pubSubTopicPartition, lastReadPubSubPosition, false);
+  }
+
+  @Override
+  public synchronized void subscribe(
+      @Nonnull PubSubTopicPartition pubSubTopicPartition,
+      @Nonnull PubSubPosition position,
+      boolean isInclusive) {
+    LOGGER.info(
+        "Requested subscription to topic-partition: {} with position: {} isInclusive: {}",
+        pubSubTopicPartition,
+        position,
+        isInclusive);
+
+    long seekOffset;
+
+    if (position == PubSubSymbolicPosition.EARLIEST) {
+      seekOffset = 0L; // start from first available record
+    } else if (position == PubSubSymbolicPosition.LATEST) {
+      PubSubPosition resolved = endPosition(pubSubTopicPartition);
+      if (!(resolved instanceof InMemoryPubSubPosition)) {
+        throw new IllegalStateException(
+            "endPosition returned unsupported type: " + resolved.getClass().getSimpleName());
+      }
+      long endOffset = ((InMemoryPubSubPosition) resolved).getInternalOffset();
+      seekOffset = isInclusive ? endOffset : endOffset + 1;
+    } else if (position instanceof InMemoryPubSubPosition) {
+      long inputOffset = ((InMemoryPubSubPosition) position).getInternalOffset();
+      seekOffset = isInclusive ? inputOffset : inputOffset + 1;
     } else {
-      throw new IllegalArgumentException("Unsupported PubSubPosition type: " + lastReadPubSubPosition.getClass());
+      throw new IllegalArgumentException("Unsupported PubSubPosition type: " + position.getClass());
     }
 
+    InMemoryPubSubPosition seekToPosition = InMemoryPubSubPosition.of(seekOffset);
+    InMemoryPubSubPosition lastReadPosition = InMemoryPubSubPosition.of(seekOffset - 1);
+
     pausedTopicPartitions.remove(pubSubTopicPartition);
-    delegate.subscribe(pubSubTopicPartition, lastReadPosition);
-    offsets.put(pubSubTopicPartition, lastReadPosition);
+    delegate.subscribe(pubSubTopicPartition, seekToPosition);
+    lastReadPositions.put(pubSubTopicPartition, lastReadPosition);
+
+    LOGGER.info(
+        "Subscribed to topic-partition: {} from position: {} (last read set to {})",
+        pubSubTopicPartition,
+        seekToPosition,
+        lastReadPosition);
   }
 
   @Override
   public synchronized void unSubscribe(PubSubTopicPartition pubSubTopicPartition) {
     delegate.unSubscribe(pubSubTopicPartition);
-    offsets.remove(pubSubTopicPartition);
+    lastReadPositions.remove(pubSubTopicPartition);
     pausedTopicPartitions.remove(pubSubTopicPartition);
   }
 
@@ -93,7 +129,7 @@ public class MockInMemoryConsumerAdapter implements PubSubConsumerAdapter {
   public synchronized void batchUnsubscribe(Set<PubSubTopicPartition> pubSubTopicPartitionSet) {
     delegate.batchUnsubscribe(pubSubTopicPartitionSet);
     for (PubSubTopicPartition topicPartition: pubSubTopicPartitionSet) {
-      offsets.remove(topicPartition);
+      lastReadPositions.remove(topicPartition);
       pausedTopicPartitions.remove(topicPartition);
     }
   }
@@ -104,14 +140,14 @@ public class MockInMemoryConsumerAdapter implements PubSubConsumerAdapter {
       throw new PubSubUnsubscribedTopicPartitionException(pubSubTopicPartition);
     }
     delegate.resetOffset(pubSubTopicPartition);
-    offsets.put(pubSubTopicPartition, InMemoryPubSubPosition.of(-1L));
+    lastReadPositions.put(pubSubTopicPartition, InMemoryPubSubPosition.of(-1L));
   }
 
   @Override
   public synchronized void close() {
     delegate.close();
     pausedTopicPartitions.clear();
-    offsets.clear();
+    lastReadPositions.clear();
   }
 
   @Override
@@ -123,7 +159,7 @@ public class MockInMemoryConsumerAdapter implements PubSubConsumerAdapter {
     }
 
     Map<PubSubTopicPartition, InMemoryPubSubPosition> offsetsToPoll = new HashMap<>();
-    for (Map.Entry<PubSubTopicPartition, InMemoryPubSubPosition> entry: offsets.entrySet()) {
+    for (Map.Entry<PubSubTopicPartition, InMemoryPubSubPosition> entry: lastReadPositions.entrySet()) {
       PubSubTopicPartition topicPartition = entry.getKey();
       InMemoryPubSubPosition offset = entry.getValue();
       if (!pausedTopicPartitions.contains(entry.getKey())) {
@@ -136,8 +172,8 @@ public class MockInMemoryConsumerAdapter implements PubSubConsumerAdapter {
     for (Map.Entry<PubSubTopicPartition, InMemoryPubSubPosition> entry: offsetsToPoll.entrySet()) {
       PubSubTopicPartition topicPartition = entry.getKey();
       InMemoryPubSubPosition offsetToPoll = entry.getValue();
-      if (offsets.containsKey(topicPartition)) {
-        offsets.put(topicPartition, offsetToPoll);
+      if (lastReadPositions.containsKey(topicPartition)) {
+        lastReadPositions.put(topicPartition, offsetToPoll);
       }
     }
     return pubSubMessages;
@@ -145,16 +181,16 @@ public class MockInMemoryConsumerAdapter implements PubSubConsumerAdapter {
 
   @Override
   public synchronized boolean hasAnySubscription() {
-    return !offsets.isEmpty();
+    return !lastReadPositions.isEmpty();
   }
 
   @Override
   public synchronized boolean hasSubscription(PubSubTopicPartition pubSubTopicPartition) {
-    return offsets.containsKey(pubSubTopicPartition);
+    return lastReadPositions.containsKey(pubSubTopicPartition);
   }
 
-  public synchronized Map<PubSubTopicPartition, InMemoryPubSubPosition> getOffsets() {
-    return offsets;
+  public synchronized Map<PubSubTopicPartition, InMemoryPubSubPosition> getLastReadPositions() {
+    return lastReadPositions;
   }
 
   @Override
@@ -173,7 +209,7 @@ public class MockInMemoryConsumerAdapter implements PubSubConsumerAdapter {
 
   @Override
   public synchronized Set<PubSubTopicPartition> getAssignment() {
-    return offsets.keySet();
+    return lastReadPositions.keySet();
   }
 
   @Override
@@ -207,6 +243,17 @@ public class MockInMemoryConsumerAdapter implements PubSubConsumerAdapter {
   @Override
   public synchronized PubSubPosition beginningPosition(PubSubTopicPartition pubSubTopicPartition, Duration timeout) {
     return InMemoryPubSubPosition.of(0);
+  }
+
+  @Override
+  public Map<PubSubTopicPartition, PubSubPosition> beginningPositions(
+      Collection<PubSubTopicPartition> partitions,
+      Duration timeout) {
+    Map<PubSubTopicPartition, PubSubPosition> retPositions = new HashMap<>(partitions.size());
+    for (PubSubTopicPartition pubSubTopicPartition: partitions) {
+      retPositions.put(pubSubTopicPartition, beginningPosition(pubSubTopicPartition, timeout));
+    }
+    return retPositions;
   }
 
   @Override

--- a/internal/venice-test-common/src/main/java/com/linkedin/venice/pubsub/mock/adapter/consumer/MockInMemoryConsumerAdapter.java
+++ b/internal/venice-test-common/src/main/java/com/linkedin/venice/pubsub/mock/adapter/consumer/MockInMemoryConsumerAdapter.java
@@ -236,11 +236,6 @@ public class MockInMemoryConsumerAdapter implements PubSubConsumerAdapter {
   }
 
   @Override
-  public synchronized Long beginningOffset(PubSubTopicPartition partition, Duration timeout) {
-    return 0L;
-  }
-
-  @Override
   public synchronized PubSubPosition beginningPosition(PubSubTopicPartition pubSubTopicPartition, Duration timeout) {
     return InMemoryPubSubPosition.of(0);
   }


### PR DESCRIPTION
## Add subscribe API with inclusive flag; use beginningPosition  

- Added a new `subscribe` API to `PubSubConsumerAdapter` that supports inclusive or  
  exclusive subscription. This is necessary because the current API only supports  
  exclusive mode, which forces us to manually adjust positions (e.g., subtract 1).  
  Such arithmetic is not allowed with generic `PubSubPosition`, so native support  
  for inclusive/exclusive behavior is required.  

- Replaced `PubSubConsumerAdapter.beginningOffset` with `beginningPosition` to support  
  non-Kafka `PubSubPosition` implementations and symbolic positions.  
  
###  Code changes
- [ ] Added new code behind **a config**. If so list the config names and their default values in the PR description.
- [ ] Introduced new **log lines**. 
  - [ ] Confirmed if logs need to be **rate limited** to avoid excessive logging.

###  **Concurrency-Specific Checks**
Both reviewer and PR author to verify
- [ ] Code has **no race conditions** or **thread safety issues**.
- [ ] Proper **synchronization mechanisms** (e.g., `synchronized`, `RWLock`) are used where needed.
- [ ] No **blocking calls** inside critical sections that could lead to deadlocks or performance degradation.
- [ ] Verified **thread-safe collections** are used (e.g., `ConcurrentHashMap`, `CopyOnWriteArrayList`).
- [ ] Validated proper exception handling in multi-threaded code to avoid silent thread termination.


## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->

- [ ] New unit tests added.
- [ ] New integration tests added.
- [ ] Modified or extended existing tests.
- [ ] Verified backward compatibility (if applicable).

## Does this PR introduce any user-facing or breaking changes?
<!--  
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [ ] No. You can skip the rest of this section.
- [ ] Yes. Clearly explain the behavior change and its impact.