### PR TITLE
[tc][fc][dvc][cdc] Use GlobalOpenTelemetry singleton for clients usecases

### DIFF
--- a/internal/venice-client-common/src/main/java/com/linkedin/venice/stats/VeniceMetricsConfig.java
+++ b/internal/venice-client-common/src/main/java/com/linkedin/venice/stats/VeniceMetricsConfig.java
@@ -33,11 +33,14 @@ public class VeniceMetricsConfig {
   public static final String OTEL_VENICE_METRICS_ENABLED = "otel.venice.metrics.enabled";
 
   /**
-   * Config to reuse the {@link io.opentelemetry.api.OpenTelemetry} initialized by the application
-   * or other libraries and set as {@link io.opentelemetry.api.GlobalOpenTelemetry} rather than
-   * initializing it individually. This is particularly useful for clients use cases where one
-   * application can initialize multiple venice client libraries which would otherwise initialize
-   * OpenTelemetry multiple times, which could take more resources.
+   * Configuration to reuse the {@link io.opentelemetry.api.OpenTelemetry} instance
+   * already initialized by the application or other libraries and registered as
+   * {@link io.opentelemetry.api.GlobalOpenTelemetry}, instead of creating a new one.
+   *
+   * This is especially useful in clients where a single application may use
+   * multiple Venice client libraries. Without this setting, each library would
+   * initialize its own OpenTelemetry instance, leading to redundant initialization
+   * and increased resource usage.
    */
   public static final String OTEL_VENICE_USE_OPENTELEMETRY_INITIALIZED_BY_APPLICATION =
       "otel.venice.use.opentelemetry.initialized.by.application";
@@ -48,7 +51,18 @@ public class VeniceMetricsConfig {
   public static final String OTEL_VENICE_METRICS_PREFIX = "otel.venice.metrics.prefix";
 
   /**
-   * Config to set custom description for all Histogram metrics.
+   * Configuration to define a custom description for all Histogram metrics.
+   *
+   * This option is particularly relevant when
+   * {@link #OTEL_VENICE_USE_OPENTELEMETRY_INITIALIZED_BY_APPLICATION} is enabled,
+   * restricting direct configuration of OpenTelemetry via Venice code and application
+   * code overrides can rely on something else like the description here without
+   * introducing new setters or APIs. When set to a non-empty string, if neeeded,
+   * this description could be used by application-level code overrides to control
+   * Histogram behavior (e.g., exponential vs. explicit aggregation) as done in
+   * {@link VeniceOpenTelemetryMetricsRepository#setExponentialHistogramAggregation}
+   *
+   * If null or unset, this configuration has no effect.
    */
   public static final String OTEL_VENICE_METRICS_CUSTOM_DESCRIPTION_FOR_HISTOGRAM =
       "otel.venice.metrics.custom.description.for.histogram";

--- a/internal/venice-client-common/src/main/java/com/linkedin/venice/stats/VeniceOpenTelemetryMetricsRepository.java
+++ b/internal/venice-client-common/src/main/java/com/linkedin/venice/stats/VeniceOpenTelemetryMetricsRepository.java
@@ -57,7 +57,7 @@ public class VeniceOpenTelemetryMetricsRepository {
   public static final String DEFAULT_METRIC_PREFIX = "venice.";
   private final VeniceMetricsConfig metricsConfig;
   private SdkMeterProvider sdkMeterProvider = null;
-  private OpenTelemetry openTelemetry = null;
+  private final OpenTelemetry openTelemetry;
   private final boolean emitOpenTelemetryMetrics;
   private final VeniceOpenTelemetryMetricNamingFormat metricFormat;
   private Meter meter;
@@ -75,6 +75,7 @@ public class VeniceOpenTelemetryMetricsRepository {
     metricFormat = metricsConfig.getMetricNamingFormat();
     if (!emitOpenTelemetryMetrics) {
       LOGGER.info("OpenTelemetry metrics are disabled");
+      openTelemetry = null;
       return;
     }
     LOGGER.info(
@@ -84,14 +85,13 @@ public class VeniceOpenTelemetryMetricsRepository {
     this.metricPrefix = metricsConfig.getMetricPrefix();
     validateMetricName(getMetricPrefix());
     if (metricsConfig.useOpenTelemetryInitializedByApplication()) {
-      LOGGER.warn("Configured to use GlobalOpenTelemetry set by the application");
+      LOGGER.info("Using globally initialized OpenTelemetry for {}", metricsConfig.getServiceName());
       openTelemetry = GlobalOpenTelemetry.get();
       if (openTelemetry == null) {
         // this is an extra safety check as GlobalOpenTelemetry.get() will return a default noop instance
         // if it was not originally initialized by the application
         throw new VeniceException("OpenTelemetry is not initialized globally, but it is required for metrics.");
       }
-      LOGGER.info("Using globally initialized OpenTelemetry for {}", metricsConfig.getServiceName());
     } else {
       LOGGER.info(
           "OpenTelemetry initialization for {} started with config: {}",

--- a/internal/venice-client-common/src/main/java/com/linkedin/venice/stats/VeniceOpenTelemetryMetricsRepository.java
+++ b/internal/venice-client-common/src/main/java/com/linkedin/venice/stats/VeniceOpenTelemetryMetricsRepository.java
@@ -3,6 +3,7 @@ package com.linkedin.venice.stats;
 import static com.linkedin.venice.stats.VeniceOpenTelemetryMetricNamingFormat.transformMetricName;
 import static com.linkedin.venice.stats.VeniceOpenTelemetryMetricNamingFormat.validateMetricName;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.linkedin.venice.exceptions.VeniceException;
 import com.linkedin.venice.stats.dimensions.VeniceDimensionInterface;
 import com.linkedin.venice.stats.dimensions.VeniceMetricsDimensions;
@@ -11,6 +12,7 @@ import com.linkedin.venice.stats.metrics.MetricEntityStateBase;
 import com.linkedin.venice.stats.metrics.MetricType;
 import com.linkedin.venice.stats.metrics.MetricUnit;
 import com.linkedin.venice.utils.concurrent.VeniceConcurrentHashMap;
+import io.opentelemetry.api.GlobalOpenTelemetry;
 import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.common.AttributesBuilder;
@@ -55,6 +57,7 @@ public class VeniceOpenTelemetryMetricsRepository {
   public static final String DEFAULT_METRIC_PREFIX = "venice.";
   private final VeniceMetricsConfig metricsConfig;
   private SdkMeterProvider sdkMeterProvider = null;
+  private OpenTelemetry openTelemetry = null;
   private final boolean emitOpenTelemetryMetrics;
   private final VeniceOpenTelemetryMetricNamingFormat metricFormat;
   private Meter meter;
@@ -80,62 +83,75 @@ public class VeniceOpenTelemetryMetricsRepository {
         metricsConfig.toString());
     this.metricPrefix = metricsConfig.getMetricPrefix();
     validateMetricName(getMetricPrefix());
-    try {
-      SdkMeterProviderBuilder builder = SdkMeterProvider.builder();
-
-      if (metricsConfig.exportOtelMetricsToEndpoint()) {
-        MetricExporter httpExporter = getOtlpHttpMetricExporter(metricsConfig);
-        builder.registerMetricReader(
-            PeriodicMetricReader.builder(httpExporter)
-                .setInterval(metricsConfig.getExportOtelMetricsIntervalInSeconds(), TimeUnit.SECONDS)
-                .build());
+    if (metricsConfig.useOpenTelemetryInitializedByApplication()) {
+      LOGGER.warn("Configured to use GlobalOpenTelemetry set by the application");
+      openTelemetry = GlobalOpenTelemetry.get();
+      if (openTelemetry == null) {
+        // this is an extra safety check as GlobalOpenTelemetry.get() will return a default noop instance
+        // if it was not originally initialized by the application
+        throw new VeniceException("OpenTelemetry is not initialized globally, but it is required for metrics.");
       }
-
-      if (metricsConfig.exportOtelMetricsToLog()) {
-        // internal to test: Disabled by default
-        builder.registerMetricReader(
-            PeriodicMetricReader.builder(new LogBasedMetricExporter(metricsConfig))
-                .setInterval(metricsConfig.getExportOtelMetricsIntervalInSeconds(), TimeUnit.SECONDS)
-                .build());
-      }
-
-      if (metricsConfig.getOtelAdditionalMetricsReader() != null) {
-        // additional metrics reader apart from the above. For instance,
-        // an in-memory metric reader can be passed in for testing purposes.
-        builder.registerMetricReader(metricsConfig.getOtelAdditionalMetricsReader());
-      }
-
-      if (metricsConfig.useOtelExponentialHistogram()) {
-        setExponentialHistogramAggregation(builder, metricsConfig);
-      }
-
-      // Set resource to empty to avoid adding any default resource attributes. The receiver
-      // pipeline can choose to add the respective resource attributes if needed.
-      builder.setResource(Resource.empty());
-
-      sdkMeterProvider = builder.build();
-
-      // Register MeterProvider with the OpenTelemetry instance
-      OpenTelemetry openTelemetry = OpenTelemetrySdk.builder().setMeterProvider(sdkMeterProvider).build();
-
-      this.meter = openTelemetry.getMeter(transformMetricName(getMetricPrefix(), metricFormat));
-
-      this.recordFailureMetric = MetricEntityStateBase.create(
-          CommonMetricsEntity.METRIC_RECORD_FAILURE.getMetricEntity(),
-          this,
-          Collections.EMPTY_MAP,
-          Attributes.empty());
-
+      LOGGER.info("Using globally initialized OpenTelemetry for {}", metricsConfig.getServiceName());
+    } else {
       LOGGER.info(
-          "OpenTelemetry initialization for {} completed with config: {}",
+          "OpenTelemetry initialization for {} started with config: {}",
           metricsConfig.getServiceName(),
-          metricsConfig);
-    } catch (Exception e) {
-      String err = "OpenTelemetry initialization for " + metricsConfig.getServiceName() + " failed with config: "
-          + metricsConfig;
-      LOGGER.error(err, e);
-      throw new VeniceException(err, e);
+          metricsConfig.toString());
+      try {
+        SdkMeterProviderBuilder builder = SdkMeterProvider.builder();
+
+        if (metricsConfig.exportOtelMetricsToEndpoint()) {
+          MetricExporter httpExporter = getOtlpHttpMetricExporter(metricsConfig);
+          builder.registerMetricReader(
+              PeriodicMetricReader.builder(httpExporter)
+                  .setInterval(metricsConfig.getExportOtelMetricsIntervalInSeconds(), TimeUnit.SECONDS)
+                  .build());
+        }
+
+        if (metricsConfig.exportOtelMetricsToLog()) {
+          // internal to test: Disabled by default
+          builder.registerMetricReader(
+              PeriodicMetricReader.builder(new LogBasedMetricExporter(metricsConfig))
+                  .setInterval(metricsConfig.getExportOtelMetricsIntervalInSeconds(), TimeUnit.SECONDS)
+                  .build());
+        }
+
+        if (metricsConfig.getOtelAdditionalMetricsReader() != null) {
+          // additional metrics reader apart from the above. For instance,
+          // an in-memory metric reader can be passed in for testing purposes.
+          builder.registerMetricReader(metricsConfig.getOtelAdditionalMetricsReader());
+        }
+
+        if (metricsConfig.useOtelExponentialHistogram()) {
+          setExponentialHistogramAggregation(builder, metricsConfig);
+        }
+
+        // Set resource to empty to avoid adding any default resource attributes. The receiver
+        // pipeline can choose to add the respective resource attributes if needed.
+        builder.setResource(Resource.empty());
+
+        sdkMeterProvider = builder.build();
+
+        // Register MeterProvider with the OpenTelemetry instance
+        openTelemetry = OpenTelemetrySdk.builder().setMeterProvider(sdkMeterProvider).build();
+        LOGGER.info(
+            "OpenTelemetry initialization for {} completed with config: {}",
+            metricsConfig.getServiceName(),
+            metricsConfig);
+      } catch (Exception e) {
+        String err = "OpenTelemetry initialization for " + metricsConfig.getServiceName() + " failed with config: "
+            + metricsConfig;
+        LOGGER.error(err, e);
+        throw new VeniceException(err, e);
+      }
     }
+
+    this.meter = openTelemetry.getMeter(transformMetricName(getMetricPrefix(), metricFormat));
+    this.recordFailureMetric = MetricEntityStateBase.create(
+        CommonMetricsEntity.METRIC_RECORD_FAILURE.getMetricEntity(),
+        this,
+        Collections.EMPTY_MAP,
+        Attributes.empty());
   }
 
   /**
@@ -162,14 +178,12 @@ public class VeniceOpenTelemetryMetricsRepository {
   }
 
   /**
-   * Setting Exponential Histogram aggregation for {@link MetricType#HISTOGRAM} by looping through all
-   * the metric entities set for this service to registering the view with exponential histogram aggregation for
-   * all the {@link MetricType#HISTOGRAM} metrics.
+   * Setting Exponential Histogram aggregation for each {@link MetricType#HISTOGRAM} metric by looping through all
+   * the metric entities set for this service using views.
    *
-   * There is a limitation in opentelemetry sdk to configure different histogram aggregation for different
-   * instruments, so {@link OtlpHttpMetricExporterBuilder#setDefaultAggregationSelector} to enable exponential
-   * histogram aggregation is not used here to not convert the histograms of type {@link MetricType#MIN_MAX_COUNT_SUM_AGGREGATIONS}
-   * to exponential histograms to be able to follow explict boundaries.
+   * Because the OpenTelemetry SDK cannot currently assign different histogram aggregations to different histogram
+   * instruments, we deliberately avoid {@link OtlpHttpMetricExporterBuilder#setDefaultAggregationSelector}. Using it
+   * would also convert {@link MetricType#MIN_MAX_COUNT_SUM_AGGREGATIONS} to exponential histograms.
    *
    * If the metric entities are empty, it will throw an exception. Failing fast here as
    * 1. If we configure exponential histogram aggregation for every histogram: it could lead to increased memory usage
@@ -226,6 +240,16 @@ public class VeniceOpenTelemetryMetricsRepository {
         : createFullMetricPrefix(metricEntity.getCustomMetricPrefix()));
   }
 
+  static String getMetricDescription(MetricEntity metricEntity, VeniceMetricsConfig metricsConfig) {
+    String customDescription = metricsConfig.getOtelCustomDescriptionForHistogramMetrics();
+    if (metricEntity.getMetricType() == MetricType.HISTOGRAM && customDescription != null
+        && !customDescription.isEmpty()) {
+      return customDescription;
+    } else {
+      return metricEntity.getDescription();
+    }
+  }
+
   public DoubleHistogram createHistogram(MetricEntity metricEntity) {
     if (!emitOpenTelemetryMetrics()) {
       return null;
@@ -234,10 +258,10 @@ public class VeniceOpenTelemetryMetricsRepository {
       String fullMetricName = getFullMetricName(metricEntity);
       DoubleHistogramBuilder builder = meter.histogramBuilder(fullMetricName)
           .setUnit(metricEntity.getUnit().name())
-          .setDescription(metricEntity.getDescription());
+          .setDescription(getMetricDescription(metricEntity, metricsConfig));
       if (metricEntity.getMetricType() == MetricType.MIN_MAX_COUNT_SUM_AGGREGATIONS) {
         // No buckets needed to get only min/max/count/sum aggregations
-        builder.setExplicitBucketBoundariesAdvice(new ArrayList<>());
+        builder.setExplicitBucketBoundariesAdvice(new ArrayList<>()).setDescription(metricEntity.getDescription());
       }
       return builder.build();
     });
@@ -251,7 +275,7 @@ public class VeniceOpenTelemetryMetricsRepository {
       String fullMetricName = getFullMetricName(metricEntity);
       LongCounterBuilder builder = meter.counterBuilder(fullMetricName)
           .setUnit(metricEntity.getUnit().name())
-          .setDescription(metricEntity.getDescription());
+          .setDescription(getMetricDescription(metricEntity, metricsConfig));
       return builder.build();
     });
   }
@@ -264,7 +288,7 @@ public class VeniceOpenTelemetryMetricsRepository {
       String fullMetricName = getFullMetricName(metricEntity);
       DoubleGaugeBuilder builder = meter.gaugeBuilder(fullMetricName)
           .setUnit(metricEntity.getUnit().name())
-          .setDescription(metricEntity.getDescription());
+          .setDescription(getMetricDescription(metricEntity, metricsConfig));
       return builder.build();
     });
   }
@@ -433,17 +457,22 @@ public class VeniceOpenTelemetryMetricsRepository {
     }
   }
 
-  /** for testing purposes */
+  @VisibleForTesting
   SdkMeterProvider getSdkMeterProvider() {
     return sdkMeterProvider;
   }
 
-  /** for testing purposes */
+  @VisibleForTesting
+  OpenTelemetry getOpenTelemetry() {
+    return openTelemetry;
+  }
+
+  @VisibleForTesting
   Meter getMeter() {
     return meter;
   }
 
-  /** for testing purposes */
+  @VisibleForTesting
   public MetricEntityStateBase getRecordFailureMetric() {
     return this.recordFailureMetric;
   }

--- a/internal/venice-client-common/src/test/java/com/linkedin/venice/stats/VeniceMetricsConfigTest.java
+++ b/internal/venice-client-common/src/test/java/com/linkedin/venice/stats/VeniceMetricsConfigTest.java
@@ -15,6 +15,7 @@ import static com.linkedin.venice.stats.VeniceOpenTelemetryMetricNamingFormat.SN
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertTrue;
 
 import com.linkedin.venice.stats.VeniceMetricsConfig.Builder;
@@ -49,6 +50,9 @@ public class VeniceMetricsConfigTest {
     assertEquals(config.useOtelExponentialHistogram(), true);
     assertEquals(config.getOtelExponentialHistogramMaxScale(), 3);
     assertEquals(config.getOtelExponentialHistogramMaxBuckets(), 250);
+    assertTrue(config.getOtelCustomDimensionsMap().isEmpty());
+    assertFalse(config.useOpenTelemetryInitializedByApplication());
+    assertNull(config.getOtelCustomDescriptionForHistogramMetrics());
     assertNotNull(config.getTehutiMetricConfig());
   }
 
@@ -212,5 +216,24 @@ public class VeniceMetricsConfigTest {
     VeniceMetricsConfig config =
         new Builder().setServiceName("TestService").setMetricPrefix("TestPrefix").setOtelHeaders(otelHeaders).build();
     assertEquals(config.getOtelHeaders().get("key1"), "value1");
+  }
+
+  @Test
+  public void testSetOtelCustomDescription() {
+    String customDescription = "This is a custom description for OpenTelemetry metrics.";
+    VeniceMetricsConfig config = new Builder().setServiceName("TestService")
+        .setMetricPrefix("TestPrefix")
+        .setOtelCustomDescriptionForHistogramMetrics(customDescription)
+        .build();
+    assertEquals(config.getOtelCustomDescriptionForHistogramMetrics(), customDescription);
+  }
+
+  @Test
+  public void testUseOpenTelemetryInitializedByApplication() {
+    VeniceMetricsConfig config = new Builder().setServiceName("TestService")
+        .setMetricPrefix("TestPrefix")
+        .setUseOpenTelemetryInitializedByApplication(true)
+        .build();
+    assertTrue(config.useOpenTelemetryInitializedByApplication());
   }
 }

--- a/internal/venice-client-common/src/test/java/com/linkedin/venice/stats/VeniceOpenTelemetryMetricsRepositoryTest.java
+++ b/internal/venice-client-common/src/test/java/com/linkedin/venice/stats/VeniceOpenTelemetryMetricsRepositoryTest.java
@@ -20,6 +20,8 @@ import com.linkedin.venice.stats.metrics.MetricEntityState;
 import com.linkedin.venice.stats.metrics.MetricEntityStateBase;
 import com.linkedin.venice.stats.metrics.MetricType;
 import com.linkedin.venice.stats.metrics.MetricUnit;
+import io.opentelemetry.api.GlobalOpenTelemetry;
+import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.metrics.DoubleGauge;
 import io.opentelemetry.api.metrics.DoubleHistogram;
@@ -291,5 +293,101 @@ public class VeniceOpenTelemetryMetricsRepositoryTest {
     metricPrefix = metricsRepository.getMetricPrefix(metricEntity);
     assertNotNull(metricPrefix, "Metric prefix should not be null");
     assertEquals(metricPrefix, "venice.test_custom_prefix", "Metric prefix should match the configured value");
+  }
+
+  @Test
+  public void testOtelCustomDescription() {
+    String metricName = "test_metric";
+    String specificMetricDescription = "This is a specific metric description";
+    String customDescriptionInConfig = "Custom description from config";
+
+    assertEquals(
+        VeniceOpenTelemetryMetricsRepository.getMetricDescription(
+            new MetricEntity(
+                metricName,
+                MetricType.HISTOGRAM,
+                MetricUnit.NUMBER,
+                specificMetricDescription,
+                new HashSet<>(singletonList(VeniceMetricsDimensions.VENICE_REQUEST_METHOD))),
+            mockMetricsConfig),
+        specificMetricDescription);
+
+    assertEquals(
+        VeniceOpenTelemetryMetricsRepository.getMetricDescription(
+            new MetricEntity(
+                metricName,
+                MetricType.COUNTER,
+                MetricUnit.NUMBER,
+                specificMetricDescription,
+                new HashSet<>(singletonList(VeniceMetricsDimensions.VENICE_REQUEST_METHOD))),
+            mockMetricsConfig),
+        specificMetricDescription);
+
+    when(mockMetricsConfig.getOtelCustomDescriptionForHistogramMetrics()).thenReturn(customDescriptionInConfig);
+
+    assertEquals(
+        VeniceOpenTelemetryMetricsRepository.getMetricDescription(
+            new MetricEntity(
+                metricName,
+                MetricType.HISTOGRAM,
+                MetricUnit.NUMBER,
+                specificMetricDescription,
+                new HashSet<>(singletonList(VeniceMetricsDimensions.VENICE_REQUEST_METHOD))),
+            mockMetricsConfig),
+        customDescriptionInConfig);
+
+    // Non HISTOGRAM should still be the metric specific description
+    assertEquals(
+        VeniceOpenTelemetryMetricsRepository.getMetricDescription(
+            new MetricEntity(
+                metricName,
+                MetricType.COUNTER,
+                MetricUnit.NUMBER,
+                specificMetricDescription,
+                new HashSet<>(singletonList(VeniceMetricsDimensions.VENICE_REQUEST_METHOD))),
+            mockMetricsConfig),
+        specificMetricDescription);
+
+    // reset
+    when(mockMetricsConfig.getOtelCustomDescriptionForHistogramMetrics()).thenReturn(null);
+  }
+
+  @Test
+  public void testOpenTelemetryCreation() {
+    // case 1: No global set and useOpenTelemetryInitializedByApplication is false: Use newly created one
+    VeniceOpenTelemetryMetricsRepository otelMetricsRepositoryCase1 =
+        new VeniceOpenTelemetryMetricsRepository(mockMetricsConfig);
+
+    assertNotNull(otelMetricsRepositoryCase1.getSdkMeterProvider(), "SdkMeterProvider should not be null");
+    assertNotNull(otelMetricsRepositoryCase1.getOpenTelemetry(), "OpenTelemetry should not be null");
+
+    // case 2: Global is set from case 1 and useOpenTelemetryInitializedByApplication is true: Use the global
+    // OpenTelemetry
+    GlobalOpenTelemetry.set(otelMetricsRepositoryCase1.getOpenTelemetry());
+    when(mockMetricsConfig.useOpenTelemetryInitializedByApplication()).thenReturn(true);
+    VeniceOpenTelemetryMetricsRepository otelMetricsRepositoryCase2 =
+        new VeniceOpenTelemetryMetricsRepository(mockMetricsConfig);
+
+    assertNull(otelMetricsRepositoryCase2.getSdkMeterProvider(), "SdkMeterProvider should be null");
+    // comparing the meter provider rather than comparing the OpenTelemetry instance as setting the GlobalOpenTelemetry
+    // copies the OpenTelemetry instance as a new ObfuscatedOpenTelemetry instance.
+    assertEquals(
+        otelMetricsRepositoryCase2.getOpenTelemetry().getMeterProvider(),
+        otelMetricsRepositoryCase1.getOpenTelemetry().getMeterProvider());
+
+    // case 3: Global is not set and useOpenTelemetryInitializedByApplication is true: use new noop OpenTelemetry
+    GlobalOpenTelemetry.resetForTest();
+    VeniceOpenTelemetryMetricsRepository otelMetricsRepositoryCase3 =
+        new VeniceOpenTelemetryMetricsRepository(mockMetricsConfig);
+
+    assertNull(otelMetricsRepositoryCase3.getSdkMeterProvider(), "SdkMeterProvider should be null");
+    // comparing the meter provider rather than comparing the OpenTelemetry instance as setting the GlobalOpenTelemetry
+    // copies the OpenTelemetry instance as a new ObfuscatedOpenTelemetry instance.
+    assertEquals(
+        otelMetricsRepositoryCase3.getOpenTelemetry().getMeterProvider(),
+        OpenTelemetry.noop().getMeterProvider());
+
+    // reset
+    when(mockMetricsConfig.useOpenTelemetryInitializedByApplication()).thenReturn(false);
   }
 }


### PR DESCRIPTION
## Problem Statement
When applications use multiple Venice client libraries to access different Venice stores, each library may initialize its own `OpenTelemetry` (OTel) instance, in addition to the one already initialized by the application. This duplication can increase resource usage, especially during periodic metric exports with each instance allocating resources to aggregate and export metrics. 

## Solution
This PR introduces an option to reuse the `GlobalOpenTelemetry` singleton instead of creating new ones for each Venice component.

Configs added:
1. `setUseOpenTelemetryInitializedByApplication()` or `otel.venice.use.opentelemetry.initialized.by.application` (Default `false`)
If `true`: `GlobalOpenTelemetry.get()` will return an instance initialized by the applications or throw an exception if its not already initialized. This is Ideal for clients. All the configurations wrt exporters are from the application. This should be used only if the application is initializing OpenTelemetry.
If `false`: Each component will create its own `OpenTelemetry` and use it. Ideal for backend services.

2. `setOtelCustomDescriptionForHistogramMetrics()` or `otel.venice.metrics.custom.description.for.histogram` (Default `null`)
If set to a valid string: This description will be used for all `Histogram` metrics. Can be used by applications to customize `Histogram` aggregation behavior (e.g., exponential vs. explicit) through their own OTel overrides. Has no effect if such customization is not implemented in the application.

###  Code changes
- [x] Added new code behind **a config**. If so list the config names and their default values in the PR description.
- [ ] Introduced new **log lines**. 
  - [ ] Confirmed if logs need to be **rate limited** to avoid excessive logging.

###  **Concurrency-Specific Checks**
Both reviewer and PR author to verify
- [ ] Code has **no race conditions** or **thread safety issues**.
- [ ] Proper **synchronization mechanisms** (e.g., `synchronized`, `RWLock`) are used where needed.
- [ ] No **blocking calls** inside critical sections that could lead to deadlocks or performance degradation.
- [ ] Verified **thread-safe collections** are used (e.g., `ConcurrentHashMap`, `CopyOnWriteArrayList`).
- [ ] Validated proper exception handling in multi-threaded code to avoid silent thread termination.

## How was this PR tested?
- [x] New unit tests added.
- [ ] New integration tests added.
- [x] Modified or extended existing tests.
- [ ] Verified backward compatibility (if applicable).

## Does this PR introduce any user-facing or breaking changes?
- [x] No. You can skip the rest of this section.
- [ ] Yes. Clearly explain the behavior change and its impact.