### PR TITLE
[controller] Improve new cluster set up

### DIFF
--- a/internal/venice-common/src/main/java/com/linkedin/venice/ConfigKeys.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/ConfigKeys.java
@@ -566,10 +566,33 @@ public class ConfigKeys {
   public static final String CONTROLLER_HELIX_CLOUD_INFO_PROCESSOR_NAME = "controller.helix.cloud.info.processor.name";
 
   /**
+   * Controller Helix participant deregistration timeout in milliseconds.
+   */
+  public static final String CONTROLLER_HELIX_PARTICIPANT_DEREGISTRATION_TIMEOUT_MS =
+      "controller.helix.participant.deregistration.timeout.ms";
+
+  /**
    * Base URL for customized health checks triggered by Helix. Default is empty string.
    */
   public static final String CONTROLLER_HELIX_REST_CUSTOMIZED_HEALTH_URL =
       "controller.helix.rest.customized.health.url";
+
+  /**
+   * Config that controls whether server cluster in Helix is TOPOLOGY aware or not.
+   */
+  public static final String CONTROLLER_HELIX_SERVER_CLUSTER_TOPOLOGY_AWARE =
+      "controller.helix.server.cluster.topology.aware";
+
+  /**
+   * The TOPOLOGY string to use for the server cluster in Helix.
+   */
+  public static final String CONTROLLER_HELIX_SERVER_CLUSTER_TOPOLOGY = "controller.helix.server.cluster.topology";
+
+  /**
+   * The FAULT_ZONE_TYPE string to use for the server cluster in Helix.
+   */
+  public static final String CONTROLLER_HELIX_SERVER_CLUSTER_FAULT_ZONE_TYPE =
+      "controller.helix.server.cluster.fault.zone.type";
 
   /**
    * Whether to enable graveyard cleanup for batch-only store at cluster level. Default is false.

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/controller/TestHAASController.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/controller/TestHAASController.java
@@ -36,7 +36,6 @@ import com.linkedin.venice.utils.Utils;
 import io.tehuti.metrics.MetricsRepository;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
@@ -51,7 +50,6 @@ import org.apache.helix.HelixAdmin;
 import org.apache.helix.PropertyKey;
 import org.apache.helix.cloud.constants.CloudProvider;
 import org.apache.helix.constants.InstanceConstants;
-import org.apache.helix.manager.zk.ZKHelixManager;
 import org.apache.helix.model.CloudConfig;
 import org.apache.helix.model.ClusterConfig;
 import org.apache.helix.model.InstanceConfig;
@@ -413,12 +411,9 @@ public class TestHAASController {
 
   private static class InitTask implements Callable<Void> {
     private final HelixAdminClient client;
-    private final HashMap<String, String> helixClusterProperties;
 
     public InitTask(HelixAdminClient client) {
       this.client = client;
-      helixClusterProperties = new HashMap<>();
-      helixClusterProperties.put(ZKHelixManager.ALLOW_PARTICIPANT_AUTO_JOIN, String.valueOf(true));
     }
 
     @Override

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceControllerClusterConfig.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceControllerClusterConfig.java
@@ -61,11 +61,15 @@ import static com.linkedin.venice.ConfigKeys.CONTROLLER_HELIX_CLOUD_INFO_PROCESS
 import static com.linkedin.venice.ConfigKeys.CONTROLLER_HELIX_CLOUD_INFO_SOURCES;
 import static com.linkedin.venice.ConfigKeys.CONTROLLER_HELIX_CLOUD_PROVIDER;
 import static com.linkedin.venice.ConfigKeys.CONTROLLER_HELIX_INSTANCE_CAPACITY;
+import static com.linkedin.venice.ConfigKeys.CONTROLLER_HELIX_PARTICIPANT_DEREGISTRATION_TIMEOUT_MS;
 import static com.linkedin.venice.ConfigKeys.CONTROLLER_HELIX_REBALANCE_PREFERENCE_EVENNESS;
 import static com.linkedin.venice.ConfigKeys.CONTROLLER_HELIX_REBALANCE_PREFERENCE_FORCE_BASELINE_CONVERGE;
 import static com.linkedin.venice.ConfigKeys.CONTROLLER_HELIX_REBALANCE_PREFERENCE_LESS_MOVEMENT;
 import static com.linkedin.venice.ConfigKeys.CONTROLLER_HELIX_RESOURCE_CAPACITY_WEIGHT;
 import static com.linkedin.venice.ConfigKeys.CONTROLLER_HELIX_REST_CUSTOMIZED_HEALTH_URL;
+import static com.linkedin.venice.ConfigKeys.CONTROLLER_HELIX_SERVER_CLUSTER_FAULT_ZONE_TYPE;
+import static com.linkedin.venice.ConfigKeys.CONTROLLER_HELIX_SERVER_CLUSTER_TOPOLOGY;
+import static com.linkedin.venice.ConfigKeys.CONTROLLER_HELIX_SERVER_CLUSTER_TOPOLOGY_AWARE;
 import static com.linkedin.venice.ConfigKeys.CONTROLLER_INSTANCE_TAG_LIST;
 import static com.linkedin.venice.ConfigKeys.CONTROLLER_JETTY_CONFIG_OVERRIDE_PREFIX;
 import static com.linkedin.venice.ConfigKeys.CONTROLLER_MIN_SCHEMA_COUNT_TO_KEEP;
@@ -402,8 +406,12 @@ public class VeniceControllerClusterConfig {
   private final boolean controllerClusterHelixCloudEnabled;
   private final boolean storageClusterHelixCloudEnabled;
   private final CloudConfig helixCloudConfig;
+  private final long controllerHelixParticipantDeregistrationTimeoutMs;
 
   private final String helixRestCustomizedHealthUrl;
+  private final boolean serverHelixClusterTopologyAware;
+  private final String serverHelixClusterTopology;
+  private final String serverHelixClusterFaultZoneType;
 
   private final boolean usePushStatusStoreForIncrementalPushStatusReads;
 
@@ -1028,8 +1036,14 @@ public class VeniceControllerClusterConfig {
     } else {
       helixCloudConfig = null;
     }
-
+    this.controllerHelixParticipantDeregistrationTimeoutMs =
+        props.getLong(CONTROLLER_HELIX_PARTICIPANT_DEREGISTRATION_TIMEOUT_MS, -1L);
     this.helixRestCustomizedHealthUrl = props.getString(CONTROLLER_HELIX_REST_CUSTOMIZED_HEALTH_URL, "");
+    this.serverHelixClusterTopologyAware = props.getBoolean(CONTROLLER_HELIX_SERVER_CLUSTER_TOPOLOGY_AWARE, false);
+    this.serverHelixClusterTopology =
+        props.getString(CONTROLLER_HELIX_SERVER_CLUSTER_TOPOLOGY, "/" + HelixUtils.TOPOLOGY_CONSTRAINT);
+    this.serverHelixClusterFaultZoneType =
+        props.getString(CONTROLLER_HELIX_SERVER_CLUSTER_FAULT_ZONE_TYPE, HelixUtils.TOPOLOGY_CONSTRAINT);
 
     this.unregisterMetricForDeletedStoreEnabled = props.getBoolean(UNREGISTER_METRIC_FOR_DELETED_STORE_ENABLED, false);
     this.identityParserClassName = props.getString(IDENTITY_PARSER_CLASS, DefaultIdentityParser.class.getName());
@@ -1817,8 +1831,24 @@ public class VeniceControllerClusterConfig {
     return helixCloudConfig;
   }
 
+  public long getControllerHelixParticipantDeregistrationTimeoutMs() {
+    return controllerHelixParticipantDeregistrationTimeoutMs;
+  }
+
   public String getHelixRestCustomizedHealthUrl() {
     return helixRestCustomizedHealthUrl;
+  }
+
+  public boolean isServerHelixClusterTopologyAware() {
+    return serverHelixClusterTopologyAware;
+  }
+
+  public String getServerHelixClusterTopology() {
+    return serverHelixClusterTopology;
+  }
+
+  public String getServerHelixClusterFaultZoneType() {
+    return serverHelixClusterFaultZoneType;
   }
 
   public boolean usePushStatusStoreForIncrementalPush() {

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceControllerMultiClusterConfig.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceControllerMultiClusterConfig.java
@@ -16,6 +16,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import org.apache.helix.model.CloudConfig;
+import org.apache.helix.model.ClusterConfig;
 
 
 public class VeniceControllerMultiClusterConfig {
@@ -329,6 +331,34 @@ public class VeniceControllerMultiClusterConfig {
 
   public List<String> getControllerInstanceTagList() {
     return getCommonConfig().getControllerInstanceTagList();
+  }
+
+  public Map<ClusterConfig.GlobalRebalancePreferenceKey, Integer> getHelixGlobalRebalancePreference() {
+    return getCommonConfig().getHelixGlobalRebalancePreference();
+  }
+
+  public List<String> getHelixInstanceCapacityKeys() {
+    return getCommonConfig().getHelixInstanceCapacityKeys();
+  }
+
+  public Map<String, Integer> getHelixDefaultInstanceCapacityMap() {
+    return getCommonConfig().getHelixDefaultInstanceCapacityMap();
+  }
+
+  public Map<String, Integer> getHelixDefaultPartitionWeightMap() {
+    return getCommonConfig().getHelixDefaultPartitionWeightMap();
+  }
+
+  public long getControllerHelixParticipantDeregistrationTimeoutMs() {
+    return getCommonConfig().getControllerHelixParticipantDeregistrationTimeoutMs();
+  }
+
+  public boolean isControllerClusterHelixCloudEnabled() {
+    return getCommonConfig().isControllerClusterHelixCloudEnabled();
+  }
+
+  public CloudConfig getHelixCloudConfig() {
+    return getCommonConfig().getHelixCloudConfig();
   }
 
   public String getRepushOrchestratorClassName() {

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceHelixAdmin.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceHelixAdmin.java
@@ -7066,10 +7066,11 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
         helixClusterConfig.setDelayRebalaceEnabled(true);
       }
       helixClusterConfig.setPersistBestPossibleAssignment(true);
-      // Topology and fault zone type fields are used by CRUSH alg. Helix would apply the constraints on CRUSH alg to
-      // choose proper instance to hold the replica.
-      helixClusterConfig.setTopology("/" + HelixUtils.TOPOLOGY_CONSTRAINT);
-      helixClusterConfig.setFaultZoneType(HelixUtils.TOPOLOGY_CONSTRAINT);
+      helixClusterConfig.setTopologyAwareEnabled(clusterConfigs.isServerHelixClusterTopologyAware());
+      if (clusterConfigs.isServerHelixClusterTopologyAware()) {
+        helixClusterConfig.setTopology(clusterConfigs.getServerHelixClusterTopology());
+        helixClusterConfig.setFaultZoneType(clusterConfigs.getServerHelixClusterFaultZoneType());
+      }
 
       RESTConfig restConfig = null;
       if (!StringUtils.isEmpty(clusterConfigs.getHelixRestCustomizedHealthUrl())) {
@@ -7101,7 +7102,7 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
     }
 
     VeniceControllerClusterConfig config = multiClusterConfigs.getControllerConfig(clusterName);
-    HelixConfigScope configScope =
+    HelixConfigScope clusterConfigScope =
         new HelixConfigScopeBuilder(HelixConfigScope.ConfigScopeProperty.CLUSTER).forCluster(clusterName).build();
     Map<String, String> helixClusterProperties = new HashMap<>();
     helixClusterProperties.put(ZKHelixManager.ALLOW_PARTICIPANT_AUTO_JOIN, String.valueOf(true));
@@ -7112,17 +7113,37 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
     }
     helixClusterProperties
         .put(ClusterConfig.ClusterConfigProperty.PERSIST_BEST_POSSIBLE_ASSIGNMENT.name(), String.valueOf(true));
-    // Topology and fault zone type fields are used by CRUSH alg. Helix would apply the constrains on CRUSH alg to
-    // choose proper instance to hold the replica.
-    helixClusterProperties
-        .put(ClusterConfig.ClusterConfigProperty.TOPOLOGY.name(), "/" + HelixUtils.TOPOLOGY_CONSTRAINT);
-    helixClusterProperties
-        .put(ClusterConfig.ClusterConfigProperty.FAULT_ZONE_TYPE.name(), HelixUtils.TOPOLOGY_CONSTRAINT);
-    admin.setConfig(configScope, helixClusterProperties);
+
+    helixClusterProperties.put(
+        ClusterConfig.ClusterConfigProperty.TOPOLOGY_AWARE_ENABLED.name(),
+        String.valueOf(config.isServerHelixClusterTopologyAware()));
+    if (config.isServerHelixClusterTopologyAware()) {
+      helixClusterProperties
+          .put(ClusterConfig.ClusterConfigProperty.TOPOLOGY.name(), config.getServerHelixClusterTopology());
+      helixClusterProperties
+          .put(ClusterConfig.ClusterConfigProperty.FAULT_ZONE_TYPE.name(), config.getServerHelixClusterFaultZoneType());
+    }
+
+    admin.setConfig(clusterConfigScope, helixClusterProperties);
+
     LOGGER.info(
         "Cluster creation: {} completed, auto join to true. Delayed rebalance time: {}ms",
         clusterName,
         delayedTime);
+
+    if (!StringUtils.isEmpty(config.getHelixRestCustomizedHealthUrl())) {
+      HelixConfigScope restConfigScope =
+          new HelixConfigScopeBuilder(HelixConfigScope.ConfigScopeProperty.REST).forCluster(clusterName).build();
+      Map<String, String> helixRestProperties = new HashMap<>();
+      helixRestProperties
+          .put(RESTConfig.SimpleFields.CUSTOMIZED_HEALTH_URL.name(), config.getHelixRestCustomizedHealthUrl());
+      admin.setConfig(restConfigScope, helixRestProperties);
+      LOGGER.info(
+          "REST Config set for cluster {} with customized health url: {}",
+          clusterName,
+          config.getHelixRestCustomizedHealthUrl());
+    }
+
     admin.addStateModelDef(clusterName, LeaderStandbySMD.name, LeaderStandbySMD.build());
 
     admin.addResource(

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/ZkHelixAdminClient.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/ZkHelixAdminClient.java
@@ -40,9 +40,11 @@ public class ZkHelixAdminClient implements HelixAdminClient {
   private static final int CONTROLLER_CLUSTER_PARTITION_COUNT = 1;
   private static final String CONTROLLER_HAAS_ZK_CLIENT_NAME = "controller-zk-client-for-haas-admin";
 
+  // TODO: Replace with config from Helix lib once we pick up a fresher Helix dependency
+  static final String HELIX_PARTICIPANT_DEREGISTRATION_TIMEOUT_CONFIG = "PARTICIPANT_DEREGISTRATION_TIMEOUT";
+
   private final HelixAdmin helixAdmin;
   private final ConfigAccessor helixConfigAccessor;
-  private final VeniceControllerClusterConfig commonConfig;
   private final VeniceControllerMultiClusterConfig multiClusterConfigs;
   private final String haasSuperClusterName;
   private final String controllerClusterName;
@@ -52,7 +54,6 @@ public class ZkHelixAdminClient implements HelixAdminClient {
       VeniceControllerMultiClusterConfig multiClusterConfigs,
       MetricsRepository metricsRepository) {
     this.multiClusterConfigs = multiClusterConfigs;
-    this.commonConfig = multiClusterConfigs.getCommonConfig();
     haasSuperClusterName = multiClusterConfigs.getControllerHAASSuperClusterName();
     controllerClusterName = multiClusterConfigs.getControllerClusterName();
     controllerClusterReplicaCount = multiClusterConfigs.getControllerClusterReplica();
@@ -100,28 +101,35 @@ public class ZkHelixAdminClient implements HelixAdminClient {
         clusterConfig.setTopologyAwareEnabled(false);
         clusterConfig.setPersistBestPossibleAssignment(true);
 
-        if (commonConfig.getHelixGlobalRebalancePreference() != null) {
+        if (multiClusterConfigs.getHelixGlobalRebalancePreference() != null) {
           // We want to prioritize evenness over less movement when it comes to resource assignment, because the cost
           // of rebalancing for the controller is cheap as it is stateless.
-          clusterConfig.setGlobalRebalancePreference(commonConfig.getHelixGlobalRebalancePreference());
+          clusterConfig.setGlobalRebalancePreference(multiClusterConfigs.getHelixGlobalRebalancePreference());
         }
 
-        if (commonConfig.getHelixDefaultInstanceCapacityMap() != null
-            && commonConfig.getHelixDefaultPartitionWeightMap() != null) {
-          clusterConfig.setInstanceCapacityKeys(commonConfig.getHelixInstanceCapacityKeys());
+        if (multiClusterConfigs.getHelixDefaultInstanceCapacityMap() != null
+            && multiClusterConfigs.getHelixDefaultPartitionWeightMap() != null) {
+          clusterConfig.setInstanceCapacityKeys(multiClusterConfigs.getHelixInstanceCapacityKeys());
 
           // This is how much capacity a participant can take. The Helix documentation recommends setting this to a high
           // value to avoid rebalance failures. The primary goal of setting this is to enable a constraint that takes
           // the current top-state distribution into account when rebalancing.
-          clusterConfig.setDefaultInstanceCapacityMap(commonConfig.getHelixDefaultInstanceCapacityMap());
-          clusterConfig.setDefaultPartitionWeightMap(commonConfig.getHelixDefaultPartitionWeightMap());
+          clusterConfig.setDefaultInstanceCapacityMap(multiClusterConfigs.getHelixDefaultInstanceCapacityMap());
+          clusterConfig.setDefaultPartitionWeightMap(multiClusterConfigs.getHelixDefaultPartitionWeightMap());
+        }
+
+        if (multiClusterConfigs.getControllerHelixParticipantDeregistrationTimeoutMs() > 0) {
+          clusterConfig.getRecord()
+              .setLongField(
+                  HELIX_PARTICIPANT_DEREGISTRATION_TIMEOUT_CONFIG,
+                  multiClusterConfigs.getControllerHelixParticipantDeregistrationTimeoutMs());
         }
 
         updateClusterConfigs(controllerClusterName, clusterConfig);
         helixAdmin.addStateModelDef(controllerClusterName, LeaderStandbySMD.name, LeaderStandbySMD.build());
 
-        if (commonConfig.isControllerClusterHelixCloudEnabled()) {
-          helixAdmin.addCloudConfig(controllerClusterName, commonConfig.getHelixCloudConfig());
+        if (multiClusterConfigs.isControllerClusterHelixCloudEnabled()) {
+          helixAdmin.addCloudConfig(controllerClusterName, multiClusterConfigs.getHelixCloudConfig());
         }
       }
       return true;

--- a/services/venice-controller/src/test/java/com/linkedin/venice/controller/TestVeniceControllerClusterConfig.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/controller/TestVeniceControllerClusterConfig.java
@@ -15,7 +15,11 @@ import static com.linkedin.venice.ConfigKeys.CONTROLLER_HELIX_CLOUD_ID;
 import static com.linkedin.venice.ConfigKeys.CONTROLLER_HELIX_CLOUD_INFO_PROCESSOR_NAME;
 import static com.linkedin.venice.ConfigKeys.CONTROLLER_HELIX_CLOUD_INFO_SOURCES;
 import static com.linkedin.venice.ConfigKeys.CONTROLLER_HELIX_CLOUD_PROVIDER;
+import static com.linkedin.venice.ConfigKeys.CONTROLLER_HELIX_PARTICIPANT_DEREGISTRATION_TIMEOUT_MS;
 import static com.linkedin.venice.ConfigKeys.CONTROLLER_HELIX_REST_CUSTOMIZED_HEALTH_URL;
+import static com.linkedin.venice.ConfigKeys.CONTROLLER_HELIX_SERVER_CLUSTER_FAULT_ZONE_TYPE;
+import static com.linkedin.venice.ConfigKeys.CONTROLLER_HELIX_SERVER_CLUSTER_TOPOLOGY;
+import static com.linkedin.venice.ConfigKeys.CONTROLLER_HELIX_SERVER_CLUSTER_TOPOLOGY_AWARE;
 import static com.linkedin.venice.ConfigKeys.CONTROLLER_PARENT_MODE;
 import static com.linkedin.venice.ConfigKeys.CONTROLLER_SSL_ENABLED;
 import static com.linkedin.venice.ConfigKeys.CONTROLLER_STORAGE_CLUSTER_HELIX_CLOUD_ENABLED;
@@ -290,6 +294,34 @@ public class TestVeniceControllerClusterConfig {
     assertEquals(cloudConfig.getCloudID(), cloudId);
     assertEquals(cloudConfig.getCloudInfoProcessorName(), processorName);
     assertEquals(cloudConfig.getCloudInfoSources(), cloudInfoSources);
+  }
+
+  @Test
+  public void testControllerHelixParticipantDeregistrationTimeoutMs() {
+    Properties baseProps = getBaseSingleRegionProperties(false);
+
+    baseProps.setProperty(CONTROLLER_HELIX_PARTICIPANT_DEREGISTRATION_TIMEOUT_MS, "60000");
+
+    VeniceControllerClusterConfig clusterConfig = new VeniceControllerClusterConfig(new VeniceProperties(baseProps));
+    assertEquals(clusterConfig.getControllerHelixParticipantDeregistrationTimeoutMs(), 60000L);
+  }
+
+  @Test
+  public void testServerHelixTopologyAwareConfigs() {
+    Properties baseProps = getBaseSingleRegionProperties(false);
+
+    boolean topologyAware = true;
+    String topology = "/fault_zone_type/instance_id";
+    String faultZoneType = "fault_zone_type";
+
+    baseProps.setProperty(CONTROLLER_HELIX_SERVER_CLUSTER_TOPOLOGY_AWARE, String.valueOf(topologyAware));
+    baseProps.setProperty(CONTROLLER_HELIX_SERVER_CLUSTER_TOPOLOGY, topology);
+    baseProps.setProperty(CONTROLLER_HELIX_SERVER_CLUSTER_FAULT_ZONE_TYPE, faultZoneType);
+
+    VeniceControllerClusterConfig clusterConfig = new VeniceControllerClusterConfig(new VeniceProperties(baseProps));
+    assertEquals(clusterConfig.isServerHelixClusterTopologyAware(), topologyAware);
+    assertEquals(clusterConfig.getServerHelixClusterTopology(), topology);
+    assertEquals(clusterConfig.getServerHelixClusterFaultZoneType(), faultZoneType);
   }
 
   @Test


### PR DESCRIPTION
<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat], [protocol]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## Problem Statement
<!--
Describe
- What problem are you trying to solve
- What issues or limitations exist in the current code
- Why this change is necessary 
-->
When setting up new Helix clusters, we set certain configs. However, there are some configs that we have been operating with in production, and would like to have the ability to control during cluster creation.

## Solution
<!--
Describe
- What changes you are making and why. 
- How these changes solve the problem.
- Any performance considerations or trade-offs. 
- Describe what testings you have done, for example, performance testing etc.
-->
This change adds the following new configs:

For new controller clusters:
* `PARTICIPANT_DEREGISTRATION_TIMEOUT`
  * Helix supports deregistering instances after they have been OFFLINE for this amount of time
  * This is controlled through the controller config: `controller.helix.participant.deregistration.timeout.ms`

For new server clusters:
* `TOPOLOGY_AWARE_ENABLED`
  * This config controls whether the instances in a Helix cluster should follow Topology-Aware Partition Placement
  * This is controlled through the controller config: `controller.helix.server.cluster.topology.aware`
* `FAULT_ZONE_TYPE`
  * The fault zone that Helix should use for it's topology-aware partition placement
  * This is controlled through the controller config: `controller.helix.server.cluster.fault.zone.type`
* `TOPOLOGY`
  * The cluster topology definition as honored by Apache Helix. Example `/zone/rack/host/instance`
  * This is controlled through the controller config: `controller.helix.server.cluster.topology`

In addition to this, also made the following changes:
1. Cleaned up some code in controller cluster creation to avoid using reflection in tests
2. Added extra tests to cover previously missed branches

###  Code changes
- [x] Added new code behind **a config**. If so list the config names and their default values in the PR description.
- [ ] Introduced new **log lines**. 
  - [x] Confirmed if logs need to be **rate limited** to avoid excessive logging.

###  **Concurrency-Specific Checks**
Both reviewer and PR author to verify
- [x] Code has **no race conditions** or **thread safety issues**.
- [x] Proper **synchronization mechanisms** (e.g., `synchronized`, `RWLock`) are used where needed.
- [x] No **blocking calls** inside critical sections that could lead to deadlocks or performance degradation.
- [x] Verified **thread-safe collections** are used (e.g., `ConcurrentHashMap`, `CopyOnWriteArrayList`).
- [x] Validated proper exception handling in multi-threaded code to avoid silent thread termination.


## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
GH CI
- [x] New unit tests added.
- [ ] New integration tests added.
- [x] Modified or extended existing tests.
- [ ] Verified backward compatibility (if applicable).

## Does this PR introduce any user-facing or breaking changes?
<!--  
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [X] No. You can skip the rest of this section.
- [ ] Yes. Clearly explain the behavior change and its impact.