### PR TITLE
[router][server] Fix NPE error in HelixInstanceConfigRepository

### DIFF
--- a/internal/venice-common/src/main/java/com/linkedin/venice/helix/HelixInstanceConfigRepository.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/helix/HelixInstanceConfigRepository.java
@@ -7,6 +7,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 import org.apache.helix.NotificationContext;
@@ -128,10 +129,12 @@ public class HelixInstanceConfigRepository
       // Extract group config
       if (instanceConfig.getInstanceEnabled()) {
         Map<String, String> domainConfigMap = instanceConfig.getDomainAsMap();
-        String groupConfig = domainConfigMap.get(faultZoneType);
-        if (groupConfig == null) {
+        String groupConfig;
+        if (faultZoneType == null || !domainConfigMap.containsKey(faultZoneType)) {
           // Set the default group to be empty if not present
           groupConfig = "";
+        } else {
+          groupConfig = domainConfigMap.get(faultZoneType);
         }
         int currentGroupId = groupIdMapping.computeIfAbsent(groupConfig, gc -> groupIdCnt.getAndIncrement());
         newInstanceGroupIdMapping.put(instanceConfig.getId(), currentGroupId);
@@ -158,7 +161,7 @@ public class HelixInstanceConfigRepository
   @Override
   public void onClusterConfigChange(ClusterConfig clusterConfig, NotificationContext context) {
     String updatedFaultZoneType = clusterConfig.getFaultZoneType();
-    if (faultZoneType.equals(updatedFaultZoneType)) {
+    if (Objects.equals(faultZoneType, updatedFaultZoneType)) {
       return;
     }
     synchronized (this) {

--- a/internal/venice-common/src/test/java/com/linkedin/venice/helix/HelixInstanceConfigRepositoryTest.java
+++ b/internal/venice-common/src/test/java/com/linkedin/venice/helix/HelixInstanceConfigRepositoryTest.java
@@ -39,7 +39,8 @@ public class HelixInstanceConfigRepositoryTest {
     return helixManager;
   }
 
-  private List<InstanceConfig> mockInstanceConfigs(Map<String, InstanceVirtualZone> instanceGroupMapping) {
+  private List<InstanceConfig> mockInstanceConfigsWithVirtualGrouping(
+      Map<String, InstanceVirtualZone> instanceGroupMapping) {
     List<InstanceConfig> instanceConfigs = new ArrayList<>();
     instanceGroupMapping.forEach((instanceId, zoneAndGroup) -> {
       ZNRecord record = new ZNRecord(instanceId);
@@ -47,6 +48,19 @@ public class HelixInstanceConfigRepositoryTest {
           InstanceConfig.InstanceConfigProperty.DOMAIN.name(),
           VENICE_FAULT_ZONE_TYPE_GROUP + "=" + zoneAndGroup.virtualGroup + "," + VENICE_FAULT_ZONE_TYPE_ZONE + "="
               + zoneAndGroup.virtualZone);
+      InstanceConfig instanceConfig = new InstanceConfig(record);
+      instanceConfigs.add(instanceConfig);
+    });
+    return instanceConfigs;
+  }
+
+  private List<InstanceConfig> mockInstanceConfigs(Map<String, String> instanceGroupMapping) {
+    List<InstanceConfig> instanceConfigs = new ArrayList<>();
+    instanceGroupMapping.forEach((instanceId, group) -> {
+      ZNRecord record = new ZNRecord(instanceId);
+      record.setSimpleField(
+          InstanceConfig.InstanceConfigProperty.DOMAIN.name(),
+          VENICE_FAULT_ZONE_TYPE_GROUP + "=" + group);
       InstanceConfig instanceConfig = new InstanceConfig(record);
       instanceConfigs.add(instanceConfig);
     });
@@ -78,7 +92,7 @@ public class HelixInstanceConfigRepositoryTest {
     instanceGroupMapping.put(nodeId5, new InstanceVirtualZone(group1, zone1));
     instanceGroupMapping.put(nodeId6, new InstanceVirtualZone(group3, zone2));
 
-    List<InstanceConfig> instanceConfigs1 = mockInstanceConfigs(instanceGroupMapping);
+    List<InstanceConfig> instanceConfigs1 = mockInstanceConfigsWithVirtualGrouping(instanceGroupMapping);
 
     Collections.shuffle(instanceConfigs1);
 
@@ -113,6 +127,71 @@ public class HelixInstanceConfigRepositoryTest {
     Assert.assertEquals(repo1.getInstanceGroupId(nodeId4), 1);
     Assert.assertEquals(repo1.getInstanceGroupId(nodeId5), 0);
     Assert.assertEquals(repo1.getInstanceGroupId(nodeId6), 1);
+    Assert.assertEquals(repo1.getInstanceGroupId(unknownNodeId), 0);
+
+    PropertyKey.Builder builder = new PropertyKey.Builder(clusterName);
+
+    repo1.clear();
+    verify(manager, times(1)).removeListener(builder.clusterConfig(), repo1);
+    verify(manager, times(1)).removeListener(builder.instanceConfigs(), repo1);
+  }
+
+  @Test
+  public void testTopologyAwareSwitch() {
+    String nodeId1 = "node_id_1_port";
+    String nodeId2 = "node_id_2_port";
+    String nodeId3 = "node_id_3_port";
+    String nodeId4 = "node_id_4_port";
+    String nodeId5 = "node_id_5_port";
+    String nodeId6 = "node_id_6_port";
+    String unknownNodeId = "unknown_node_id_port";
+
+    String group1 = "group_1";
+    String group2 = "group_2";
+    String group3 = "group_3";
+
+    Map<String, String> instanceGroupMapping = new TreeMap<>();
+    instanceGroupMapping.put(nodeId1, group1);
+    instanceGroupMapping.put(nodeId2, group2);
+    instanceGroupMapping.put(nodeId3, group3);
+    instanceGroupMapping.put(nodeId4, group2);
+    instanceGroupMapping.put(nodeId5, group1);
+    instanceGroupMapping.put(nodeId6, group3);
+    List<InstanceConfig> instanceConfigs1 = mockInstanceConfigs(instanceGroupMapping);
+
+    Collections.shuffle(instanceConfigs1);
+
+    SafeHelixManager manager = getMockHelixManager();
+    String clusterName = manager.getClusterName();
+    ClusterConfig clusterConfig = manager.getConfigAccessor().getClusterConfig(clusterName);
+
+    doReturn(null).when(clusterConfig).getFaultZoneType();
+    Mockito.clearInvocations(manager);
+
+    HelixInstanceConfigRepository repo1 = new HelixInstanceConfigRepository(manager);
+    repo1.refresh();
+    repo1.onInstanceConfigChange(instanceConfigs1, null);
+    Assert.assertEquals(repo1.getGroupCount(), 1);
+    Assert.assertEquals(repo1.getInstanceGroupId(nodeId1), 0);
+    Assert.assertEquals(repo1.getInstanceGroupId(nodeId2), 0);
+    Assert.assertEquals(repo1.getInstanceGroupId(nodeId3), 0);
+    Assert.assertEquals(repo1.getInstanceGroupId(nodeId4), 0);
+    Assert.assertEquals(repo1.getInstanceGroupId(nodeId5), 0);
+    Assert.assertEquals(repo1.getInstanceGroupId(nodeId6), 0);
+    Assert.assertEquals(repo1.getInstanceGroupId(unknownNodeId), 0);
+
+    // Cluster becomes TOPLOGY_AWARE
+    doReturn(VENICE_FAULT_ZONE_TYPE_GROUP).when(clusterConfig).getFaultZoneType();
+    Mockito.clearInvocations(manager);
+
+    repo1.onClusterConfigChange(clusterConfig, null);
+    Assert.assertEquals(repo1.getGroupCount(), 3);
+    Assert.assertEquals(repo1.getInstanceGroupId(nodeId1), 0);
+    Assert.assertEquals(repo1.getInstanceGroupId(nodeId2), 1);
+    Assert.assertEquals(repo1.getInstanceGroupId(nodeId3), 2);
+    Assert.assertEquals(repo1.getInstanceGroupId(nodeId4), 1);
+    Assert.assertEquals(repo1.getInstanceGroupId(nodeId5), 0);
+    Assert.assertEquals(repo1.getInstanceGroupId(nodeId6), 2);
     Assert.assertEquals(repo1.getInstanceGroupId(unknownNodeId), 0);
 
     PropertyKey.Builder builder = new PropertyKey.Builder(clusterName);


### PR DESCRIPTION
<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat], [protocol]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## Problem Statement
<!--
Describe
- What problem are you trying to solve
- What issues or limitations exist in the current code
- Why this change is necessary 
-->
If a storage cluster's Helix configuration changes from topology-unaware to topology-aware, `HelixInstanceConfigRepository` runs into an `NullPointerException`.

## Solution
<!--
Describe
- What changes you are making and why. 
- How these changes solve the problem.
- Any performance considerations or trade-offs. 
- Describe what testings you have done, for example, performance testing etc.
-->
Addressed the `NullPointerException` case and added tests for it.

###  Code changes
- [ ] Added new code behind **a config**. If so list the config names and their default values in the PR description.
- [ ] Introduced new **log lines**. 
  - [x] Confirmed if logs need to be **rate limited** to avoid excessive logging.

###  **Concurrency-Specific Checks**
Both reviewer and PR author to verify
- [x] Code has **no race conditions** or **thread safety issues**.
- [x] Proper **synchronization mechanisms** (e.g., `synchronized`, `RWLock`) are used where needed.
- [x] No **blocking calls** inside critical sections that could lead to deadlocks or performance degradation.
- [x] Verified **thread-safe collections** are used (e.g., `ConcurrentHashMap`, `CopyOnWriteArrayList`).
- [x] Validated proper exception handling in multi-threaded code to avoid silent thread termination.


## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->

- [x] New unit tests added.
- [ ] New integration tests added.
- [ ] Modified or extended existing tests.
- [x] Verified backward compatibility (if applicable).

## Does this PR introduce any user-facing or breaking changes?
<!--  
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Clearly explain the behavior change and its impact.