### PR TITLE
[controller] Support configuring cluster topology when creating storage clusters in Helix

### DIFF
--- a/internal/venice-common/src/main/java/com/linkedin/venice/ConfigKeys.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/ConfigKeys.java
@@ -580,6 +580,23 @@ public class ConfigKeys {
       "controller.helix.rest.customized.health.url";
 
   /**
+   * Config that controls whether server cluster in Helix is TOPOLOGY aware or not.
+   */
+  public static final String CONTROLLER_HELIX_SERVER_CLUSTER_TOPOLOGY_AWARE =
+      "controller.helix.server.cluster.topology.aware";
+
+  /**
+   * The TOPOLOGY string to use for the server cluster in Helix.
+   */
+  public static final String CONTROLLER_HELIX_SERVER_CLUSTER_TOPOLOGY = "controller.helix.server.cluster.topology";
+
+  /**
+   * The FAULT_ZONE_TYPE string to use for the server cluster in Helix.
+   */
+  public static final String CONTROLLER_HELIX_SERVER_CLUSTER_FAULT_ZONE_TYPE =
+      "controller.helix.server.cluster.fault.zone.type";
+
+  /**
    * Whether to enable graveyard cleanup for batch-only store at cluster level. Default is false.
    */
   public static final String CONTROLLER_STORE_GRAVEYARD_CLEANUP_ENABLED = "controller.store.graveyard.cleanup.enabled";

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/controller/AbstractTestVeniceHelixAdmin.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/controller/AbstractTestVeniceHelixAdmin.java
@@ -30,7 +30,6 @@ import com.linkedin.venice.integration.utils.ServiceFactory;
 import com.linkedin.venice.integration.utils.ZkServerWrapper;
 import com.linkedin.venice.pubsub.PubSubTopicRepository;
 import com.linkedin.venice.stats.HelixMessageChannelStats;
-import com.linkedin.venice.utils.HelixUtils;
 import com.linkedin.venice.utils.LogContext;
 import com.linkedin.venice.utils.MockTestStateModelFactory;
 import com.linkedin.venice.utils.TestUtils;
@@ -64,10 +63,10 @@ class AbstractTestVeniceHelixAdmin {
   static final String KEY_SCHEMA = "\"string\"";
   static final String VALUE_SCHEMA = "\"string\"";
   static final int MAX_NUMBER_OF_PARTITION = 16;
-  static String NODE_ID = "localhost_9985";
-  static int SERVER_LISTENING_PORT = 9985;
+  static final String NODE_ID = "localhost_9985";
+  static final int SERVER_LISTENING_PORT = 9985;
 
-  private final static Logger LOGGER = LogManager.getLogger(AbstractTestVeniceHelixAdmin.class);
+  private static final Logger LOGGER = LogManager.getLogger(AbstractTestVeniceHelixAdmin.class);
 
   VeniceHelixAdmin veniceAdmin;
   String clusterName;
@@ -183,7 +182,6 @@ class AbstractTestVeniceHelixAdmin {
         TestUtils.getParticipant(clusterName, nodeId, zkAddress, SERVER_LISTENING_PORT, stateModelFactory, stateModel);
     helixManager.connect();
     helixManagerByNodeID.put(nodeId, helixManager);
-    HelixUtils.setupInstanceConfig(clusterName, nodeId, zkAddress);
   }
 
   void stopAllParticipants() {

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/controller/TestVeniceHelixAdminWithSharedEnvironment.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/controller/TestVeniceHelixAdminWithSharedEnvironment.java
@@ -410,9 +410,12 @@ public class TestVeniceHelixAdminWithSharedEnvironment extends AbstractTestVenic
       return !routingDataRepository.containsKafkaTopic(version.kafkaTopicName());
     });
 
-    stateModelFactoryByNodeID.forEach(
-        (nodeId, stateModelFactory) -> Assert
-            .assertEquals(stateModelFactory.getModelList(version.kafkaTopicName(), 0).size(), 1));
+    TestUtils.waitForNonDeterministicAssertion(3, TimeUnit.SECONDS, () -> {
+      stateModelFactoryByNodeID.forEach(
+          (nodeId, stateModelFactory) -> Assert
+              .assertEquals(stateModelFactory.getModelList(version.kafkaTopicName(), 0).size(), 1));
+    });
+
     // Replica become OFFLINE state
     stateModelFactoryByNodeID.forEach(
         (nodeId, stateModelFactory) -> Assert.assertEquals(


### PR DESCRIPTION
<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat], [protocol]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## Problem Statement
<!--
Describe
- What problem are you trying to solve
- What issues or limitations exist in the current code
- Why this change is necessary 
-->
Helix supports topology-aware partition placement, and it is being widely used in production at LinkedIn. However, configuring this is an operational task, and done after the cluster is created.

## Solution
<!--
Describe
- What changes you are making and why. 
- How these changes solve the problem.
- Any performance considerations or trade-offs. 
- Describe what testings you have done, for example, performance testing etc.
-->
This change allows configuring the topology-aware configs of the Helix cluster at time of cluster creation, so that it can be handled automatically.

Also cleaned up some code and tests that previously configured this incorrectly

###  Code changes
- [x] Added new code behind **a config**. If so list the config names and their default values in the PR description.
- [ ] Introduced new **log lines**. 
  - [x] Confirmed if logs need to be **rate limited** to avoid excessive logging.

###  **Concurrency-Specific Checks**
Both reviewer and PR author to verify
- [x] Code has **no race conditions** or **thread safety issues**.
- [x] Proper **synchronization mechanisms** (e.g., `synchronized`, `RWLock`) are used where needed.
- [x] No **blocking calls** inside critical sections that could lead to deadlocks or performance degradation.
- [x] Verified **thread-safe collections** are used (e.g., `ConcurrentHashMap`, `CopyOnWriteArrayList`).
- [x] Validated proper exception handling in multi-threaded code to avoid silent thread termination.


## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->

- [x] New unit tests added.
- [ ] New integration tests added.
- [x] Modified or extended existing tests.
- [x] Verified backward compatibility (if applicable).

## Does this PR introduce any user-facing or breaking changes?
<!--  
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [ ] No. You can skip the rest of this section.
- [x] Yes. Clearly explain the behavior change and its impact.
  - Previously, new clusters would get created with partial topology-aware configs - `TOPOLOGY = /instance` and `FAULT_ZONE_TYPE = instance`. However, this would not take effect as Helix needs another config `TOPOLOGY_AWARE_ENABLED = true` to enable topology-aware routing
  - Hence, this change doesn't change the behavior of the cluster by itself, but might cause issues for users that just enable `TOPOLOGY_AWARE_ENABLED = true` as an operational task and expect to use `TOPOLOGY = /instance` and `FAULT_ZONE_TYPE = instance`.