### PR TITLE
[server] Improve HeartbeatMonitoringService cleanup

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/helix/LeaderFollowerPartitionStateModel.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/helix/LeaderFollowerPartitionStateModel.java
@@ -159,6 +159,8 @@ public class LeaderFollowerPartitionStateModel extends AbstractPartitionStateMod
 
   @Transition(to = HelixState.DROPPED_STATE, from = HelixState.OFFLINE_STATE)
   public void onBecomeDroppedFromOffline(Message message, NotificationContext context) {
+    heartbeatMonitoringService
+        .updateLagMonitor(message.getResourceName(), getPartition(), HeartbeatLagMonitorAction.REMOVE_MONITOR);
     executeStateTransition(message, context, () -> {
       boolean isCurrentVersion = false;
       try {

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/helix/LeaderFollowerParticipantModelFactoryTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/helix/LeaderFollowerParticipantModelFactoryTest.java
@@ -10,6 +10,7 @@ import com.linkedin.davinci.ingestion.IngestionBackend;
 import com.linkedin.davinci.stats.ParticipantStateTransitionStats;
 import com.linkedin.davinci.stats.ingestion.heartbeat.HeartbeatMonitoringService;
 import com.linkedin.venice.exceptions.VeniceException;
+import com.linkedin.venice.helix.HelixCustomizedViewOfflinePushRepository;
 import com.linkedin.venice.meta.ReadOnlyStoreRepository;
 import com.linkedin.venice.meta.Store;
 import com.linkedin.venice.meta.Version;
@@ -19,6 +20,7 @@ import com.linkedin.venice.utils.TestUtils;
 import io.tehuti.metrics.MetricsRepository;
 import java.time.Duration;
 import java.util.HashSet;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import org.apache.helix.model.Message;
@@ -35,6 +37,7 @@ public class LeaderFollowerParticipantModelFactoryTest {
   private VeniceServerConfig mockServerConfig;
   private VeniceStoreVersionConfig mockStoreConfig;
   private ReadOnlyStoreRepository mockReadOnlyStoreRepository;
+  private HelixCustomizedViewOfflinePushRepository mockCustomizedViewRepository;
   private Store mockStore;
   private int testPartition = 0;
   private String resourceName = Version.composeKafkaTopic("testStore", 1);
@@ -61,6 +64,7 @@ public class LeaderFollowerParticipantModelFactoryTest {
     mockServerConfig = mock(VeniceServerConfig.class);
     mockStoreConfig = mock(VeniceStoreVersionConfig.class);
     mockReadOnlyStoreRepository = mock(ReadOnlyStoreRepository.class);
+    mockCustomizedViewRepository = mock(HelixCustomizedViewOfflinePushRepository.class);
     mockStore = mock(Store.class);
     Mockito.when(mockConfigLoader.getVeniceServerConfig()).thenReturn(mockServerConfig);
     Mockito.when(mockConfigLoader.getStoreConfig(resourceName)).thenReturn(mockStoreConfig);
@@ -83,7 +87,12 @@ public class LeaderFollowerParticipantModelFactoryTest {
         mockReadOnlyStoreRepository,
         null,
         null,
-        new HeartbeatMonitoringService(new MetricsRepository(), mockReadOnlyStoreRepository, veniceServerConfig, null));
+        new HeartbeatMonitoringService(
+            new MetricsRepository(),
+            mockReadOnlyStoreRepository,
+            veniceServerConfig,
+            null,
+            CompletableFuture.completedFuture(mockCustomizedViewRepository)));
   }
 
   @Test

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/helix/VeniceLeaderFollowerStateModelTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/helix/VeniceLeaderFollowerStateModelTest.java
@@ -19,6 +19,7 @@ import com.linkedin.davinci.config.VeniceServerConfig;
 import com.linkedin.davinci.config.VeniceStoreVersionConfig;
 import com.linkedin.davinci.stats.ingestion.heartbeat.HeartbeatLagMonitorAction;
 import com.linkedin.davinci.stats.ingestion.heartbeat.HeartbeatMonitoringService;
+import com.linkedin.venice.helix.HelixCustomizedViewOfflinePushRepository;
 import com.linkedin.venice.meta.Store;
 import com.linkedin.venice.meta.StoreVersionInfo;
 import com.linkedin.venice.meta.Version;
@@ -38,6 +39,7 @@ import org.testng.annotations.Test;
 public class VeniceLeaderFollowerStateModelTest extends
     AbstractVenicePartitionStateModelTest<LeaderFollowerPartitionStateModel, LeaderFollowerIngestionProgressNotifier> {
   private HeartbeatMonitoringService spyHeartbeatMonitoringService;
+  private HelixCustomizedViewOfflinePushRepository mockCustomizedViewRepository;
 
   @Override
   protected LeaderFollowerPartitionStateModel getParticipantStateModel() {
@@ -45,8 +47,13 @@ public class VeniceLeaderFollowerStateModelTest extends
     doReturn(new HashSet<>()).when(serverConfig).getRegionNames();
     doReturn("local").when(serverConfig).getRegionName();
     doReturn(Duration.ofSeconds(5)).when(serverConfig).getServerMaxWaitForVersionInfo();
-    HeartbeatMonitoringService heartbeatMonitoringService =
-        new HeartbeatMonitoringService(new MetricsRepository(), mockReadOnlyStoreRepository, serverConfig, null);
+    mockCustomizedViewRepository = mock(HelixCustomizedViewOfflinePushRepository.class);
+    HeartbeatMonitoringService heartbeatMonitoringService = new HeartbeatMonitoringService(
+        new MetricsRepository(),
+        mockReadOnlyStoreRepository,
+        serverConfig,
+        null,
+        CompletableFuture.completedFuture(mockCustomizedViewRepository));
     spyHeartbeatMonitoringService = spy(heartbeatMonitoringService);
     return new LeaderFollowerPartitionStateModel(
         mockIngestionBackend,

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/stats/ingestion/heartbeat/HeartbeatMonitoringServiceTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/stats/ingestion/heartbeat/HeartbeatMonitoringServiceTest.java
@@ -23,21 +23,27 @@ import static org.mockito.Mockito.when;
 import com.linkedin.davinci.config.VeniceServerConfig;
 import com.linkedin.davinci.kafka.consumer.LeaderFollowerStateType;
 import com.linkedin.davinci.kafka.consumer.PartitionConsumptionState;
+import com.linkedin.venice.helix.HelixCustomizedViewOfflinePushRepository;
 import com.linkedin.venice.meta.BufferReplayPolicy;
 import com.linkedin.venice.meta.HybridStoreConfig;
 import com.linkedin.venice.meta.HybridStoreConfigImpl;
+import com.linkedin.venice.meta.Instance;
+import com.linkedin.venice.meta.Partition;
+import com.linkedin.venice.meta.PartitionAssignment;
 import com.linkedin.venice.meta.ReadOnlyStoreRepository;
 import com.linkedin.venice.meta.Store;
 import com.linkedin.venice.meta.StoreVersionInfo;
 import com.linkedin.venice.meta.Version;
 import com.linkedin.venice.meta.VersionImpl;
 import com.linkedin.venice.utils.DataProviderUtils;
+import com.linkedin.venice.utils.Utils;
 import com.linkedin.venice.utils.concurrent.VeniceConcurrentHashMap;
 import io.tehuti.metrics.MetricsRepository;
 import java.time.Duration;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 import org.mockito.Mockito;
 import org.testng.Assert;
@@ -283,6 +289,8 @@ public class HeartbeatMonitoringServiceTest {
     Mockito.when(mockStore.getVersion(3)).thenReturn(futureVersion);
 
     MetricsRepository mockMetricsRepository = new MetricsRepository();
+    HelixCustomizedViewOfflinePushRepository mockCustomizedViewOfflinePushRepository =
+        mock(HelixCustomizedViewOfflinePushRepository.class);
     ReadOnlyStoreRepository mockReadOnlyRepository = mock(ReadOnlyStoreRepository.class);
     Mockito.when(mockReadOnlyRepository.getStoreOrThrow(TEST_STORE)).thenReturn(mockStore);
     Set<String> regions = new HashSet<>();
@@ -294,8 +302,12 @@ public class HeartbeatMonitoringServiceTest {
     doReturn(LOCAL_FABRIC).when(serverConfig).getRegionName();
     doReturn(Duration.ofSeconds(5)).when(serverConfig).getServerMaxWaitForVersionInfo();
 
-    HeartbeatMonitoringService heartbeatMonitoringService =
-        new HeartbeatMonitoringService(mockMetricsRepository, mockReadOnlyRepository, serverConfig, null);
+    HeartbeatMonitoringService heartbeatMonitoringService = new HeartbeatMonitoringService(
+        mockMetricsRepository,
+        mockReadOnlyRepository,
+        serverConfig,
+        null,
+        CompletableFuture.completedFuture(mockCustomizedViewOfflinePushRepository));
 
     // Let's emit some heartbeats that don't exist in the registry yet
     heartbeatMonitoringService.recordLeaderHeartbeat(TEST_STORE, 1, 0, LOCAL_FABRIC, 1000L, true);
@@ -588,5 +600,125 @@ public class HeartbeatMonitoringServiceTest {
     heartbeatMonitoringService.updateLagMonitor(resourceName, partition, HeartbeatLagMonitorAction.REMOVE_MONITOR);
     verify(metadataRepo, times(9)).waitVersion(eq(storeName), eq(storeVersion), any(Duration.class), anyLong());
     verify(heartbeatMonitoringService, times(2)).removeLagMonitor(any(Version.class), anyInt());
+  }
+
+  @Test
+  public void testCleanupLagMonitor() {
+    // Default hybrid store config
+    HybridStoreConfig hybridStoreConfig = new HybridStoreConfigImpl(1L, 1L, 1L, BufferReplayPolicy.REWIND_FROM_SOP);
+    // Version configs
+    Version backupVersion = new VersionImpl(TEST_STORE, 1, "1");
+    backupVersion.setHybridStoreConfig(hybridStoreConfig);
+    backupVersion.setActiveActiveReplicationEnabled(true);
+    Version currentVersion = new VersionImpl(TEST_STORE, 2, "2");
+    currentVersion.setHybridStoreConfig(hybridStoreConfig);
+    currentVersion.setActiveActiveReplicationEnabled(true);
+
+    Store mockStore = mock(Store.class);
+    Mockito.when(mockStore.getName()).thenReturn(TEST_STORE);
+    Mockito.when(mockStore.getCurrentVersion()).thenReturn(currentVersion.getNumber());
+    Mockito.when(mockStore.getHybridStoreConfig()).thenReturn(hybridStoreConfig);
+    Mockito.when(mockStore.getVersion(1)).thenReturn(backupVersion);
+    Mockito.when(mockStore.getVersion(2)).thenReturn(currentVersion);
+
+    MetricsRepository mockMetricsRepository = new MetricsRepository();
+    ReadOnlyStoreRepository mockReadOnlyRepository = mock(ReadOnlyStoreRepository.class);
+    Mockito.when(mockReadOnlyRepository.getStoreOrThrow(TEST_STORE)).thenReturn(mockStore);
+    doReturn(new StoreVersionInfo(mockStore, backupVersion)).when(mockReadOnlyRepository)
+        .waitVersion(eq(TEST_STORE), eq(1), any(), anyLong());
+    doReturn(new StoreVersionInfo(mockStore, currentVersion)).when(mockReadOnlyRepository)
+        .waitVersion(eq(TEST_STORE), eq(2), any(), anyLong());
+    Set<String> regions = new HashSet<>();
+    regions.add(LOCAL_FABRIC);
+    regions.add(REMOTE_FABRIC);
+    regions.add(REMOTE_FABRIC + SEPARATE_TOPIC_SUFFIX);
+    String hostname = "localhost";
+    int port = 123;
+    VeniceServerConfig serverConfig = mock(VeniceServerConfig.class);
+    doReturn(regions).when(serverConfig).getRegionNames();
+    doReturn(LOCAL_FABRIC).when(serverConfig).getRegionName();
+    doReturn(Duration.ofSeconds(5)).when(serverConfig).getServerMaxWaitForVersionInfo();
+    doReturn(hostname).when(serverConfig).getListenerHostname();
+    doReturn(port).when(serverConfig).getListenerPort();
+    String backupVersionTopic = Version.composeKafkaTopic(mockStore.getName(), 1);
+    String currentVersionTopic = Version.composeKafkaTopic(mockStore.getName(), 2);
+
+    HelixCustomizedViewOfflinePushRepository mockCustomizedViewOfflinePushRepository =
+        mock(HelixCustomizedViewOfflinePushRepository.class);
+    // Mock CV repository so that the test node has assignment for all partitions except p1 of v1 and p1 of v2
+    Instance thisInstance = Instance.fromNodeId(hostname + "_" + port);
+    Instance otherInstance = Instance.fromNodeId("otherInstance_321");
+    Set<Instance> instancesWithThisNode = new HashSet<>();
+    instancesWithThisNode.add(thisInstance);
+    instancesWithThisNode.add(otherInstance);
+    Set<Instance> instancesWithoutThisNode = new HashSet<>();
+    instancesWithoutThisNode.add(otherInstance);
+    PartitionAssignment mockPartitionAssignment = mock(PartitionAssignment.class);
+    Partition mockPartition1 = mock(Partition.class);
+    doReturn(instancesWithoutThisNode).when(mockPartition1).getAllInstancesSet();
+    Partition mockPartition0And2 = mock(Partition.class);
+    doReturn(instancesWithThisNode).when(mockPartition0And2).getAllInstancesSet();
+    doReturn(mockPartition0And2).when(mockPartitionAssignment).getPartition(0);
+    doReturn(mockPartition1).when(mockPartitionAssignment).getPartition(1);
+    doReturn(mockPartition0And2).when(mockPartitionAssignment).getPartition(2);
+    doReturn(mockPartitionAssignment).when(mockCustomizedViewOfflinePushRepository)
+        .getPartitionAssignments(backupVersionTopic);
+    doReturn(mockPartitionAssignment).when(mockCustomizedViewOfflinePushRepository)
+        .getPartitionAssignments(currentVersionTopic);
+
+    CompletableFuture<HelixCustomizedViewOfflinePushRepository> mockCVRepositoryFuture = new CompletableFuture<>();
+
+    HeartbeatMonitoringService heartbeatMonitoringService = new HeartbeatMonitoringService(
+        mockMetricsRepository,
+        mockReadOnlyRepository,
+        serverConfig,
+        null,
+        mockCVRepositoryFuture);
+    // Initialize lag monitor for leader of p0 and follower of p1 and p2 for v1
+    heartbeatMonitoringService.updateLagMonitor(backupVersionTopic, 0, HeartbeatLagMonitorAction.SET_LEADER_MONITOR);
+    heartbeatMonitoringService.updateLagMonitor(backupVersionTopic, 1, HeartbeatLagMonitorAction.SET_FOLLOWER_MONITOR);
+    heartbeatMonitoringService.updateLagMonitor(backupVersionTopic, 2, HeartbeatLagMonitorAction.SET_FOLLOWER_MONITOR);
+    // Initialize lag monitor for leader of p1 and follower of p0 and p2 for v2
+    heartbeatMonitoringService.updateLagMonitor(currentVersionTopic, 0, HeartbeatLagMonitorAction.SET_FOLLOWER_MONITOR);
+    heartbeatMonitoringService.updateLagMonitor(currentVersionTopic, 1, HeartbeatLagMonitorAction.SET_LEADER_MONITOR);
+    heartbeatMonitoringService.updateLagMonitor(currentVersionTopic, 2, HeartbeatLagMonitorAction.SET_FOLLOWER_MONITOR);
+    // No-op before cv repository is ready
+    heartbeatMonitoringService.checkAndMaybeCleanupLagMonitor();
+    Mockito.verify(mockCustomizedViewOfflinePushRepository, never()).getPartitionAssignments(anyString());
+    Assert.assertTrue(heartbeatMonitoringService.getCleanupHeartbeatMap().isEmpty());
+    mockCVRepositoryFuture.complete(mockCustomizedViewOfflinePushRepository);
+    Assert.assertEquals(heartbeatMonitoringService.getLeaderHeartbeatTimeStamps().get(TEST_STORE).get(1).size(), 1);
+    Assert.assertEquals(heartbeatMonitoringService.getLeaderHeartbeatTimeStamps().get(TEST_STORE).get(2).size(), 1);
+    Assert.assertEquals(heartbeatMonitoringService.getFollowerHeartbeatTimeStamps().get(TEST_STORE).get(1).size(), 2);
+    Assert.assertEquals(heartbeatMonitoringService.getFollowerHeartbeatTimeStamps().get(TEST_STORE).get(1).size(), 2);
+    // 2 topic partitions should be marked for cleanup
+    heartbeatMonitoringService.checkAndMaybeCleanupLagMonitor();
+    Assert.assertEquals(heartbeatMonitoringService.getCleanupHeartbeatMap().size(), 2);
+    Assert.assertEquals(
+        heartbeatMonitoringService.getCleanupHeartbeatMap().get(Utils.getReplicaId(backupVersionTopic, 1)).intValue(),
+        1);
+    Assert.assertEquals(
+        heartbeatMonitoringService.getCleanupHeartbeatMap().get(Utils.getReplicaId(currentVersionTopic, 1)).intValue(),
+        1);
+    // Mimic the cleanup cycle 3 more times and a new assignment for p1 of v1
+    heartbeatMonitoringService.checkAndMaybeCleanupLagMonitor();
+    heartbeatMonitoringService.checkAndMaybeCleanupLagMonitor();
+    heartbeatMonitoringService.checkAndMaybeCleanupLagMonitor();
+    heartbeatMonitoringService.updateLagMonitor(backupVersionTopic, 1, HeartbeatLagMonitorAction.SET_FOLLOWER_MONITOR);
+    Assert.assertEquals(heartbeatMonitoringService.getCleanupHeartbeatMap().size(), 1);
+    Assert.assertEquals(
+        heartbeatMonitoringService.getCleanupHeartbeatMap().get(Utils.getReplicaId(currentVersionTopic, 1)).intValue(),
+        4);
+    // One more cycle and p1 of v2 should be cleaned up. p1 of v1 will is marked again since it's still absent from CV
+    heartbeatMonitoringService.checkAndMaybeCleanupLagMonitor();
+    Assert.assertEquals(heartbeatMonitoringService.getCleanupHeartbeatMap().size(), 1);
+    Assert.assertEquals(
+        heartbeatMonitoringService.getCleanupHeartbeatMap().get(Utils.getReplicaId(backupVersionTopic, 1)).intValue(),
+        1);
+    Assert.assertEquals(heartbeatMonitoringService.getLeaderHeartbeatTimeStamps().get(TEST_STORE).get(2).size(), 0);
+    // Mimic the CV is in-sync again and the marked p1 of v1 should be removed from cleanup map
+    doReturn(mockPartition0And2).when(mockPartitionAssignment).getPartition(1);
+    heartbeatMonitoringService.checkAndMaybeCleanupLagMonitor();
+    Assert.assertEquals(heartbeatMonitoringService.getCleanupHeartbeatMap().size(), 0);
   }
 }

--- a/services/venice-server/src/main/java/com/linkedin/venice/server/VeniceServer.java
+++ b/services/venice-server/src/main/java/com/linkedin/venice/server/VeniceServer.java
@@ -381,8 +381,12 @@ public class VeniceServer {
     HeartbeatMonitoringServiceStats heartbeatMonitoringServiceStats =
         new HeartbeatMonitoringServiceStats(metricsRepository, clusterConfig.getClusterName());
 
-    heartbeatMonitoringService =
-        new HeartbeatMonitoringService(metricsRepository, metadataRepo, serverConfig, heartbeatMonitoringServiceStats);
+    heartbeatMonitoringService = new HeartbeatMonitoringService(
+        metricsRepository,
+        metadataRepo,
+        serverConfig,
+        heartbeatMonitoringServiceStats,
+        customizedViewFuture);
     services.add(heartbeatMonitoringService);
 
     this.zkHelixAdmin = Lazy.of(() -> new ZKHelixAdmin(serverConfig.getZookeeperAddress()));


### PR DESCRIPTION
## Problem Statement
Problem: Due to network issue or other gaps in the Helix state transition we found that the HeartbeatMonitoringService is still monitoring resources that are no longer assigned to the node. e.g. A replica that went from STANDBY->ERROR->DROPPED or a network disruption causing a replica going from STANDBY resetting to OFFLINE and then going from OFFLINE->DROPPED without gracefully transitioning from STANDBY->OFFLINE



## Solution
Solution: Added the cleanup logic from OFFLINE->DROPPED to cover more scenarios since removeLagMonitor is relatively cheap. Added new mechanism in HeartbeatMonitoringService's logging thread to also perform cleanup by checking against existing monitors with the customized view. To deal with potential races and staleness of the CV repository we will collect the replicas and only actually clean them after DEFAULT_LAG_MONITOR_CLEANUP_CYCLE cycles (DEFAULT_LAG_MONITOR_CLEANUP_CYCLE is set to 5 or 5 minutes).


###  Code changes
- [ ] Added new code behind **a config**. If so list the config names and their default values in the PR description.
- [ ] Introduced new **log lines**. 
  - [ ] Confirmed if logs need to be **rate limited** to avoid excessive logging.

###  **Concurrency-Specific Checks**
Both reviewer and PR author to verify
- [ ] Code has **no race conditions** or **thread safety issues**.
- [ ] Proper **synchronization mechanisms** (e.g., `synchronized`, `RWLock`) are used where needed.
- [ ] No **blocking calls** inside critical sections that could lead to deadlocks or performance degradation.
- [ ] Verified **thread-safe collections** are used (e.g., `ConcurrentHashMap`, `CopyOnWriteArrayList`).
- [ ] Validated proper exception handling in multi-threaded code to avoid silent thread termination.


## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->

- [ ] New unit tests added.
- [ ] New integration tests added.
- [ ] Modified or extended existing tests.
- [ ] Verified backward compatibility (if applicable).

## Does this PR introduce any user-facing or breaking changes?
<!--  
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [ ] No. You can skip the rest of this section.
- [ ] Yes. Clearly explain the behavior change and its impact.