### PR TITLE
[server][controller] Delete TMF::getProducerTimestampOfLastDataRecord API

### DIFF
--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTaskTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTaskTest.java
@@ -37,7 +37,6 @@ import static com.linkedin.venice.schema.rmd.RmdConstants.TIMESTAMP_FIELD_NAME;
 import static com.linkedin.venice.utils.TestUtils.getOffsetRecord;
 import static com.linkedin.venice.utils.TestUtils.waitForNonDeterministicAssertion;
 import static com.linkedin.venice.utils.TestUtils.waitForNonDeterministicCompletion;
-import static com.linkedin.venice.utils.Time.MS_PER_DAY;
 import static com.linkedin.venice.utils.Time.MS_PER_HOUR;
 import static com.linkedin.venice.writer.LeaderCompleteState.LEADER_COMPLETED;
 import static com.linkedin.venice.writer.LeaderCompleteState.LEADER_NOT_COMPLETED;
@@ -3450,10 +3449,6 @@ public abstract class StoreIngestionTaskTest {
         .getOffsetRecord();
     doReturn(5L).when(mockTopicManager).getLatestOffsetCached(any(), anyInt());
     doReturn(5L).when(mockTopicManagerRemoteKafka).getLatestOffsetCached(any(), anyInt());
-    doReturn(System.currentTimeMillis() - 2 * MS_PER_DAY).when(mockTopicManager)
-        .getProducerTimestampOfLastDataMessageCached(any());
-    doReturn(System.currentTimeMillis()).when(mockTopicManagerRemoteKafka)
-        .getProducerTimestampOfLastDataMessageCached(any());
     if (nodeType == NodeType.LEADER) {
       // case 7a: leader replica => partition is not ready to serve
       doReturn(LeaderFollowerStateType.LEADER).when(mockPcsOffsetLagCaughtUpTimestampLagging).getLeaderFollowerState();

--- a/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/manager/TopicManager.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/manager/TopicManager.java
@@ -776,14 +776,6 @@ public class TopicManager implements Closeable {
         .getLatestOffsetCachedNonBlocking(new PubSubTopicPartitionImpl(pubSubTopic, partitionId));
   }
 
-  public long getProducerTimestampOfLastDataMessageWithRetries(PubSubTopicPartition pubSubTopicPartition, int retries) {
-    return topicMetadataFetcher.getProducerTimestampOfLastDataMessageWithRetries(pubSubTopicPartition, retries);
-  }
-
-  public long getProducerTimestampOfLastDataMessageCached(PubSubTopicPartition pubSubTopicPartition) {
-    return topicMetadataFetcher.getProducerTimestampOfLastDataMessageCached(pubSubTopicPartition);
-  }
-
   /**
    * Get offsets for only one partition with a specific timestamp.
    */

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/pubsub/manager/TopicManagerIntegrationTest.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/pubsub/manager/TopicManagerIntegrationTest.java
@@ -18,7 +18,6 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
-import org.testng.Assert;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.Test;
 
@@ -62,9 +61,6 @@ public class TopicManagerIntegrationTest extends TopicManagerTest {
     produceRandomPubSubMessage(topic, true, timestamp); // This timestamp is expected to be retrieved
     produceRandomPubSubMessage(topic, false, timestamp + 1000L); // produce a control message
 
-    long retrievedTimestamp = topicManager.getProducerTimestampOfLastDataMessageWithRetries(pubSubTopicPartition, 1);
-    Assert.assertEquals(retrievedTimestamp, timestamp);
-
     // Produce more data records to this topic partition
     for (int i = 0; i < 100; i++) {
       timestamp += 1000L;
@@ -80,7 +76,6 @@ public class TopicManagerIntegrationTest extends TopicManagerTest {
     Future[] vwFutures = new Future[numberOfThreads];
     // Put all topic manager calls related to partition offset fetcher with admin and consumer here.
     Runnable[] tasks = { () -> topicManager.getOffsetByTime(pubSubTopicPartition, checkTimestamp),
-        () -> topicManager.getProducerTimestampOfLastDataMessageWithRetries(pubSubTopicPartition, 1),
         () -> topicManager.getPartitionCount(topic),
         () -> topicManager.getLatestOffsetWithRetries(pubSubTopicPartition, 1),
         () -> topicManager.getTopicLatestOffsets(topic) };


### PR DESCRIPTION
## Remove unused getProducerTimestampOfLastDataMessage

TM::getProducerTimestampOfLastDataMessage is no longer used anywhere in the  
codebase. The current implementation also performs arithmetic operations on offsets,  
which are not supported. Removing this method for now; it can be reintroduced later  
with a different implementation if needed.  

###  Code changes
- [ ] Added new code behind **a config**. If so list the config names and their default values in the PR description.
- [ ] Introduced new **log lines**. 
  - [ ] Confirmed if logs need to be **rate limited** to avoid excessive logging.

###  **Concurrency-Specific Checks**
Both reviewer and PR author to verify
- [ ] Code has **no race conditions** or **thread safety issues**.
- [ ] Proper **synchronization mechanisms** (e.g., `synchronized`, `RWLock`) are used where needed.
- [ ] No **blocking calls** inside critical sections that could lead to deadlocks or performance degradation.
- [ ] Verified **thread-safe collections** are used (e.g., `ConcurrentHashMap`, `CopyOnWriteArrayList`).
- [ ] Validated proper exception handling in multi-threaded code to avoid silent thread termination.


## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->

- [ ] New unit tests added.
- [ ] New integration tests added.
- [ ] Modified or extended existing tests.
- [ ] Verified backward compatibility (if applicable).

## Does this PR introduce any user-facing or breaking changes?
<!--  
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [ ] No. You can skip the rest of this section.
- [ ] Yes. Clearly explain the behavior change and its impact.