### PR TITLE
[cc] Use PubSubPosition instead of numeric offsets in changelog code

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/consumer/BootstrappingVeniceChangelogConsumerDaVinciRecordTransformerImpl.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/consumer/BootstrappingVeniceChangelogConsumerDaVinciRecordTransformerImpl.java
@@ -24,8 +24,8 @@ import com.linkedin.venice.exceptions.VeniceException;
 import com.linkedin.venice.meta.Version;
 import com.linkedin.venice.pubsub.PubSubTopicImpl;
 import com.linkedin.venice.pubsub.PubSubTopicPartitionImpl;
-import com.linkedin.venice.pubsub.adapter.kafka.common.ApacheKafkaOffsetPosition;
 import com.linkedin.venice.pubsub.api.PubSubMessage;
+import com.linkedin.venice.pubsub.api.PubSubSymbolicPosition;
 import com.linkedin.venice.pubsub.api.PubSubTopicPartition;
 import com.linkedin.venice.utils.PropertyBuilder;
 import com.linkedin.venice.utils.VeniceProperties;
@@ -79,7 +79,6 @@ public class BootstrappingVeniceChangelogConsumerDaVinciRecordTransformerImpl<K,
   private final ExecutorService completableFutureThreadPool = Executors.newFixedThreadPool(1);
 
   private final Set<Integer> subscribedPartitions = new HashSet<>();
-  private final ApacheKafkaOffsetPosition placeHolderOffset = ApacheKafkaOffsetPosition.of(0);
   private final ReentrantLock bufferLock = new ReentrantLock();
   private final Condition bufferIsFullCondition = bufferLock.newCondition();
   private BackgroundReporterThread backgroundReporterThread;
@@ -388,7 +387,7 @@ public class BootstrappingVeniceChangelogConsumerDaVinciRecordTransformerImpl<K,
                   key,
                   changeEvent,
                   pubSubTopicPartitionMap.get(partitionId),
-                  placeHolderOffset,
+                  PubSubSymbolicPosition.EARLIEST,
                   0,
                   0,
                   false));

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/consumer/InternalLocalBootstrappingVeniceChangelogConsumer.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/consumer/InternalLocalBootstrappingVeniceChangelogConsumer.java
@@ -39,6 +39,7 @@ import com.linkedin.venice.pubsub.adapter.kafka.common.ApacheKafkaOffsetPosition
 import com.linkedin.venice.pubsub.api.PubSubConsumerAdapter;
 import com.linkedin.venice.pubsub.api.PubSubMessage;
 import com.linkedin.venice.pubsub.api.PubSubPosition;
+import com.linkedin.venice.pubsub.api.PubSubSymbolicPosition;
 import com.linkedin.venice.pubsub.api.PubSubTopicPartition;
 import com.linkedin.venice.schema.SchemaReader;
 import com.linkedin.venice.serialization.avro.AvroProtocolDefinition;
@@ -317,7 +318,7 @@ class InternalLocalBootstrappingVeniceChangelogConsumer<K, V> extends VeniceAfte
       LOGGER.info(
           "Update checkpoint for partition: {}, new offset: {}",
           partitionId,
-          getOffset(bootstrapState.currentPubSubPosition));
+          bootstrapState.currentPubSubPosition);
     } catch (IOException e) {
       LOGGER.error("Failed to update change capture coordinate position: {}", bootstrapState.currentPubSubPosition);
     }
@@ -348,11 +349,7 @@ class InternalLocalBootstrappingVeniceChangelogConsumer<K, V> extends VeniceAfte
         keyDeserializer.deserialize(key),
         changeEvent,
         getTopicPartition(partition),
-        /**
-         * TODO: Should we introduce a magic position to handle the zero-offset case?
-         * Or use {@link com.linkedin.venice.pubsub.api.PubSubPosition.EARLIEST} as an alternative.
-         */
-        ApacheKafkaOffsetPosition.of(0),
+        PubSubSymbolicPosition.EARLIEST,
         0,
         value.length * 8,
         false);
@@ -375,7 +372,7 @@ class InternalLocalBootstrappingVeniceChangelogConsumer<K, V> extends VeniceAfte
               null,
               null,
               getTopicPartition(partition),
-              ApacheKafkaOffsetPosition.of(0),
+              PubSubSymbolicPosition.EARLIEST,
               0,
               0,
               true));
@@ -413,7 +410,7 @@ class InternalLocalBootstrappingVeniceChangelogConsumer<K, V> extends VeniceAfte
           LOGGER.info(
               "pollAndCatchup completed for partition: {} with offset: {}, put message: {}, delete message: {}",
               record.getPartition(),
-              getOffset(record.getOffset()),
+              record.getOffset(),
               partitionToPutMessageCount.getOrDefault(record.getPartition(), new AtomicLong(0)).get(),
               partitionToDeleteMessageCount.getOrDefault(record.getPartition(), new AtomicLong(0)).get());
           currentPartitionState.bootstrapState = PollState.BOOTSTRAPPING;
@@ -430,7 +427,7 @@ class InternalLocalBootstrappingVeniceChangelogConsumer<K, V> extends VeniceAfte
       ByteBuffer value,
       PubSubTopicPartition partition,
       int readerSchemaId,
-      long recordOffset) {
+      PubSubPosition recordOffset) {
     if (deserializedValue instanceof RecordChangeEvent) {
       RecordChangeEvent recordChangeEvent = (RecordChangeEvent) deserializedValue;
       if (recordChangeEvent.currentValue == null) {
@@ -455,7 +452,7 @@ class InternalLocalBootstrappingVeniceChangelogConsumer<K, V> extends VeniceAfte
     VeniceChangeCoordinate currentPubSubPosition = bootstrapState.currentPubSubPosition;
     bootstrapState.currentPubSubPosition = new VeniceChangeCoordinate(
         currentPubSubPosition.getTopic(),
-        new ApacheKafkaOffsetPosition(recordOffset),
+        recordOffset,
         currentPubSubPosition.getPartition());
 
     bootstrapState.incrementProcessedRecordSizeSinceLastSync(value.array().length);
@@ -494,7 +491,10 @@ class InternalLocalBootstrappingVeniceChangelogConsumer<K, V> extends VeniceAfte
                 offsetRecord.getLocalVersionTopicOffset());
             localCheckpoint = new VeniceChangeCoordinate(
                 getTopicPartition(partition).getPubSubTopic().getName(),
-                new ApacheKafkaOffsetPosition(offsetRecord.getLocalVersionTopicOffset()),
+                offsetRecord.getLocalVersionTopicOffset() == -1
+                    ? PubSubSymbolicPosition.EARLIEST
+                    // TODO: Remove once we populate PubSubPosition for local version topic offset
+                    : ApacheKafkaOffsetPosition.of(offsetRecord.getLocalVersionTopicOffset()),
                 partition);
           } else {
             localCheckpoint = VeniceChangeCoordinate
@@ -507,7 +507,7 @@ class InternalLocalBootstrappingVeniceChangelogConsumer<K, V> extends VeniceAfte
                       partition));
             }
 
-            LOGGER.info("Got local checkpoint for partition: {}, offset: {}", partition, getOffset(localCheckpoint));
+            LOGGER.info("Got local checkpoint for partition: {}, offset: {}", partition, localCheckpoint);
           }
         } catch (IOException | ClassNotFoundException e) {
           throw new VeniceException("Failed to decode local change capture coordinate checkpoint with exception: ", e);
@@ -515,7 +515,7 @@ class InternalLocalBootstrappingVeniceChangelogConsumer<K, V> extends VeniceAfte
 
         // Where we need to catch up to
         VeniceChangeCoordinate targetCheckpoint = this.getLatestCoordinate(partition);
-        LOGGER.info("Got latest offset: {} for partition: {}", getOffset(targetCheckpoint), partition);
+        LOGGER.info("Got latest offset: {} for partition: {}", targetCheckpoint, partition);
 
         synchronized (bootstrapStateMap) {
           BootstrapState newState = new BootstrapState();
@@ -595,13 +595,6 @@ class InternalLocalBootstrappingVeniceChangelogConsumer<K, V> extends VeniceAfte
   void setStorageAndMetadataService(StorageService storageService, StorageMetadataService storageMetadataService) {
     this.storageService = storageService;
     this.storageMetadataService = storageMetadataService;
-  }
-
-  /**
-   * Helper method to get offset in long value from VeniceChangeCoordinate.
-   */
-  private long getOffset(VeniceChangeCoordinate veniceChangeCoordinate) {
-    return veniceChangeCoordinate.getPosition().getNumericOffset();
   }
 
   enum PollState {

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/consumer/VeniceAfterImageConsumerImpl.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/consumer/VeniceAfterImageConsumerImpl.java
@@ -6,12 +6,12 @@ import com.linkedin.davinci.repository.NativeMetadataRepositoryViewAdapter;
 import com.linkedin.venice.exceptions.VeniceException;
 import com.linkedin.venice.kafka.protocol.ControlMessage;
 import com.linkedin.venice.kafka.protocol.enums.ControlMessageType;
-import com.linkedin.venice.offsets.OffsetRecord;
 import com.linkedin.venice.pubsub.PubSubUtil;
 import com.linkedin.venice.pubsub.api.DefaultPubSubMessage;
 import com.linkedin.venice.pubsub.api.PubSubConsumerAdapter;
 import com.linkedin.venice.pubsub.api.PubSubMessage;
 import com.linkedin.venice.pubsub.api.PubSubPosition;
+import com.linkedin.venice.pubsub.api.PubSubSymbolicPosition;
 import com.linkedin.venice.pubsub.api.PubSubTopic;
 import com.linkedin.venice.pubsub.api.PubSubTopicPartition;
 import com.linkedin.venice.utils.lazy.Lazy;
@@ -181,7 +181,7 @@ public class VeniceAfterImageConsumerImpl<K, V> extends VeniceChangelogConsumerI
               getPartitionListToSubscribe(partitions, Collections.EMPTY_SET, targetTopic);
 
           for (PubSubTopicPartition topicPartition: topicPartitionList) {
-            consumerAdapter.subscribe(topicPartition, OffsetRecord.LOWEST_OFFSET_LAG);
+            consumerAdapter.subscribe(topicPartition, PubSubSymbolicPosition.EARLIEST);
           }
           Map<PubSubTopicPartition, List<DefaultPubSubMessage>> polledResults;
           Map<Integer, Boolean> endOfPushConsumedPerPartitionMap = new HashMap<>();

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
@@ -3880,7 +3880,7 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
               put.getSchemaId(),
               keyBytes,
               put.getPutValue(),
-              consumerRecord.getPosition().getNumericOffset(),
+              consumerRecord.getPosition(),
               compressor.get());
 
           // Current record is a chunk. We only write to the storage engine for fully assembled records

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/utils/ChunkAssembler.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/utils/ChunkAssembler.java
@@ -7,6 +7,7 @@ import com.linkedin.davinci.store.record.ByteBufferValueRecord;
 import com.linkedin.davinci.store.record.ValueRecord;
 import com.linkedin.venice.compression.VeniceCompressor;
 import com.linkedin.venice.exceptions.VeniceException;
+import com.linkedin.venice.pubsub.api.PubSubPosition;
 import com.linkedin.venice.pubsub.api.PubSubTopicPartition;
 import com.linkedin.venice.serialization.RawBytesStoreDeserializerCache;
 import com.linkedin.venice.serialization.avro.AvroProtocolDefinition;
@@ -39,7 +40,7 @@ public abstract class ChunkAssembler {
       int schemaId,
       byte[] keyBytes,
       ByteBuffer valueBytes,
-      long recordOffset,
+      PubSubPosition recordOffset,
       VeniceCompressor compressor) {
     ByteBufferValueRecord<ByteBuffer> assembledRecord = null;
     bufferStorageEngine.addStoragePartitionIfAbsent(pubSubTopicPartition.getPartitionNumber());


### PR DESCRIPTION
## [cc] Use PubSubPosition instead of numeric offsets in changelog code
Update changelog consumer to adopt `PubSubPosition` (including  
`PubSubSymbolicPosition.EARLIEST`) in place of numeric offsets and  
Kafka-specific types. Improves abstraction, flexibility, and compatibility  
with non-numeric position types.  

Key changes:  
- Replace `ApacheKafkaOffsetPosition.of(0)` / `OffsetRecord.LOWEST_OFFSET` with  
  `PubSubSymbolicPosition.EARLIEST`.  
- Update subscription and seeking logic to use `PubSubPosition`.  
- Remove legacy helpers for numeric offset conversions.  
- Update logging to print `PubSubPosition` directly.  
- Drop unused legacy offset imports.  
- Default `-1` offsets to `PubSubSymbolicPosition.EARLIEST`.  

### AI Generated Summary of Changes
This pull request updates the Da Vinci client consumer code to consistently use the new `PubSubSymbolicPosition.EARLIEST` and the generic `PubSubPosition` interface instead of numeric offsets and legacy classes like `ApacheKafkaOffsetPosition` and `OffsetRecord`. This refactor improves abstraction and flexibility for offset management across the consumer implementations, reducing direct dependency on Kafka-specific offset representations.

**Offset Management Refactor**

* Replaced usage of `ApacheKafkaOffsetPosition.of(0)` and `OffsetRecord.LOWEST_OFFSET` with `PubSubSymbolicPosition.EARLIEST` throughout consumer classes, standardizing how the "beginning" of a topic is referenced. [[1]](diffhunk://#diff-6d492ea0727f34431fa564cf199e0489b974ea0e78bd04e7bf1f92f41fc8e7a8L27-R28) [[2]](diffhunk://#diff-6d492ea0727f34431fa564cf199e0489b974ea0e78bd04e7bf1f92f41fc8e7a8L391-R390) [[3]](diffhunk://#diff-ec3b7dbc9ac5840597a40d9015244b5aaa31566b75c125c7000ad704b2dea923L351-R352) [[4]](diffhunk://#diff-ec3b7dbc9ac5840597a40d9015244b5aaa31566b75c125c7000ad704b2dea923L378-R375) [[5]](diffhunk://#diff-9b8671d68eab23391851382672c5e3b1fa28d8d46065aa12171c7c73d22290f7L184-R184) [[6]](diffhunk://#diff-b614d346dad850587acc1f51ebcbdbc42c04dd8e531730b17d5b2bbe7cc17965L344-R343) [[7]](diffhunk://#diff-b614d346dad850587acc1f51ebcbdbc42c04dd8e531730b17d5b2bbe7cc17965L384-R383) [[8]](diffhunk://#diff-b614d346dad850587acc1f51ebcbdbc42c04dd8e531730b17d5b2bbe7cc17965L403-R402)
* Updated consumer subscription and seeking logic to use `PubSubPosition` objects instead of raw long offsets, including changes to method signatures and internal logic for seeking and processing records. [[1]](diffhunk://#diff-b614d346dad850587acc1f51ebcbdbc42c04dd8e531730b17d5b2bbe7cc17965L474-R473) [[2]](diffhunk://#diff-b614d346dad850587acc1f51ebcbdbc42c04dd8e531730b17d5b2bbe7cc17965L512-R511) [[3]](diffhunk://#diff-b614d346dad850587acc1f51ebcbdbc42c04dd8e531730b17d5b2bbe7cc17965L528-R529) [[4]](diffhunk://#diff-b614d346dad850587acc1f51ebcbdbc42c04dd8e531730b17d5b2bbe7cc17965L545-R539) [[5]](diffhunk://#diff-b614d346dad850587acc1f51ebcbdbc42c04dd8e531730b17d5b2bbe7cc17965L578-R575)

**Code Simplification and Cleanup**

* Removed helper methods and code paths that converted between `VeniceChangeCoordinate` and numeric offsets, since offset management is now abstracted by `PubSubPosition`. [[1]](diffhunk://#diff-ec3b7dbc9ac5840597a40d9015244b5aaa31566b75c125c7000ad704b2dea923L416-R413) [[2]](diffhunk://#diff-ec3b7dbc9ac5840597a40d9015244b5aaa31566b75c125c7000ad704b2dea923L510-R518) [[3]](diffhunk://#diff-ec3b7dbc9ac5840597a40d9015244b5aaa31566b75c125c7000ad704b2dea923L600-L606)
* Updated logging statements to print `PubSubPosition` objects directly instead of converting them to numeric offsets. [[1]](diffhunk://#diff-ec3b7dbc9ac5840597a40d9015244b5aaa31566b75c125c7000ad704b2dea923L320-R321) [[2]](diffhunk://#diff-ec3b7dbc9ac5840597a40d9015244b5aaa31566b75c125c7000ad704b2dea923L510-R518) [[3]](diffhunk://#diff-b614d346dad850587acc1f51ebcbdbc42c04dd8e531730b17d5b2bbe7cc17965L545-R539)

**Type and API Updates**

* Changed method signatures and internal references to accept and propagate `PubSubPosition` instead of `long` for record offsets, improving type safety and future compatibility with non-numeric position types. [[1]](diffhunk://#diff-ec3b7dbc9ac5840597a40d9015244b5aaa31566b75c125c7000ad704b2dea923L433-R430) [[2]](diffhunk://#diff-ec3b7dbc9ac5840597a40d9015244b5aaa31566b75c125c7000ad704b2dea923L458-R455) [[3]](diffhunk://#diff-b614d346dad850587acc1f51ebcbdbc42c04dd8e531730b17d5b2bbe7cc17965L884-R878) [[4]](diffhunk://#diff-b614d346dad850587acc1f51ebcbdbc42c04dd8e531730b17d5b2bbe7cc17965L956-R950)

**Dependency Updates**

* Updated import statements to remove unused legacy offset classes and consistently import `PubSubSymbolicPosition` and `PubSubPosition`. [[1]](diffhunk://#diff-6d492ea0727f34431fa564cf199e0489b974ea0e78bd04e7bf1f92f41fc8e7a8L27-R28) [[2]](diffhunk://#diff-ec3b7dbc9ac5840597a40d9015244b5aaa31566b75c125c7000ad704b2dea923R42) [[3]](diffhunk://#diff-9b8671d68eab23391851382672c5e3b1fa28d8d46065aa12171c7c73d22290f7L9-R14) [[4]](diffhunk://#diff-b614d346dad850587acc1f51ebcbdbc42c04dd8e531730b17d5b2bbe7cc17965L49-R56)

**Backward Compatibility Handling**

* Added logic to handle cases where a local version topic offset is not available (`-1`), defaulting to `PubSubSymbolicPosition.EARLIEST` for bootstrapping.



###  Code changes
- [ ] Added new code behind **a config**. If so list the config names and their default values in the PR description.
- [ ] Introduced new **log lines**. 
  - [ ] Confirmed if logs need to be **rate limited** to avoid excessive logging.

###  **Concurrency-Specific Checks**
Both reviewer and PR author to verify
- [ ] Code has **no race conditions** or **thread safety issues**.
- [ ] Proper **synchronization mechanisms** (e.g., `synchronized`, `RWLock`) are used where needed.
- [ ] No **blocking calls** inside critical sections that could lead to deadlocks or performance degradation.
- [ ] Verified **thread-safe collections** are used (e.g., `ConcurrentHashMap`, `CopyOnWriteArrayList`).
- [ ] Validated proper exception handling in multi-threaded code to avoid silent thread termination.


## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->

- [ ] New unit tests added.
- [ ] New integration tests added.
- [ ] Modified or extended existing tests.
- [ ] Verified backward compatibility (if applicable).

## Does this PR introduce any user-facing or breaking changes?
<!--  
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [ ] No. You can skip the rest of this section.
- [ ] Yes. Clearly explain the behavior change and its impact.