### PR TITLE
[router] Added threadPoolStats to the io worker threads.

### DIFF
--- a/services/venice-router/src/main/java/com/linkedin/venice/router/RouterServer.java
+++ b/services/venice-router/src/main/java/com/linkedin/venice/router/RouterServer.java
@@ -469,6 +469,10 @@ public class RouterServer extends AbstractVeniceService {
     registry = new ResourceRegistry();
     workerExecutor = registry.factory(ShutdownableExecutors.class)
         .newCachedThreadPool(new DefaultThreadFactory("RouterThread", true, Thread.MAX_PRIORITY));
+
+    // Register thread pool stats for workerExecutor
+    new ThreadPoolStats(metricsRepository, (ThreadPoolExecutor) workerExecutor, "router_worker_executor");
+
     /**
      * Use TreeMap inside TimeoutProcessor; the other option ConcurrentSkipList has performance issue.
      *


### PR DESCRIPTION

## Problem Statement
We don't have any visibility into the state of router worker threads and their activity/utilization, this PR enables default threadpool stats for these worker threads.

## Solution
Add threadPoolStats for the worker threads.


###  Code changes
- [ ] Added new code behind **a config**. If so list the config names and their default values in the PR description.
- [ ] Introduced new **log lines**. 
  - [ ] Confirmed if logs need to be **rate limited** to avoid excessive logging.

###  **Concurrency-Specific Checks**
Both reviewer and PR author to verify
- [ ] Code has **no race conditions** or **thread safety issues**.
- [ ] Proper **synchronization mechanisms** (e.g., `synchronized`, `RWLock`) are used where needed.
- [ ] No **blocking calls** inside critical sections that could lead to deadlocks or performance degradation.
- [ ] Verified **thread-safe collections** are used (e.g., `ConcurrentHashMap`, `CopyOnWriteArrayList`).
- [ ] Validated proper exception handling in multi-threaded code to avoid silent thread termination.


## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->

- [ ] New unit tests added.
- [ ] New integration tests added.
- [ ] Modified or extended existing tests.
- [ ] Verified backward compatibility (if applicable).

## Does this PR introduce any user-facing or breaking changes?
<!--  
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [ ] No. You can skip the rest of this section.
- [ ] Yes. Clearly explain the behavior change and its impact.