### PR TITLE
[router] Removed active_ssl_connection metric

### DIFF
--- a/services/venice-router/src/main/java/com/linkedin/venice/router/stats/SecurityStats.java
+++ b/services/venice-router/src/main/java/com/linkedin/venice/router/stats/SecurityStats.java
@@ -80,9 +80,5 @@ public class SecurityStats extends AbstractVeniceStats {
         new AsyncGauge(
             (ignored1, ignored2) -> sslInitializer.getHandshakesFailed(),
             "total_failed_ssl_handshake_count"));
-    registerSensor(
-        new AsyncGauge(
-            (ignored1, ignored2) -> sslInitializer.getHandshakesStarted() - sslInitializer.getHandshakesFailed(),
-            "active_ssl_connection_count"));
   }
 }


### PR DESCRIPTION

## Problem Statement
The active ssl connection count is not working as intended. 


## Solution
Removed the bad metric as it's superseded by connection_count_gauge.

###  Code changes
- [ ] Added new code behind **a config**. If so list the config names and their default values in the PR description.
- [ ] Introduced new **log lines**. 
  - [ ] Confirmed if logs need to be **rate limited** to avoid excessive logging.

###  **Concurrency-Specific Checks**
Both reviewer and PR author to verify
- [ ] Code has **no race conditions** or **thread safety issues**.
- [ ] Proper **synchronization mechanisms** (e.g., `synchronized`, `RWLock`) are used where needed.
- [ ] No **blocking calls** inside critical sections that could lead to deadlocks or performance degradation.
- [ ] Verified **thread-safe collections** are used (e.g., `ConcurrentHashMap`, `CopyOnWriteArrayList`).
- [ ] Validated proper exception handling in multi-threaded code to avoid silent thread termination.


## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->

- [ ] New unit tests added.
- [ ] New integration tests added.
- [ ] Modified or extended existing tests.
- [ ] Verified backward compatibility (if applicable).

## Does this PR introduce any user-facing or breaking changes?
<!--  
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [ ] No. You can skip the rest of this section.
- [ ] Yes. Clearly explain the behavior change and its impact.