### PR TITLE
[build][ci] Remap E2E test buckets to lower overall CI runtime

### DIFF
--- a/.github/workflows/VeniceCI-E2ETests.yml
+++ b/.github/workflows/VeniceCI-E2ETests.yml
@@ -13,8 +13,8 @@ name: E2ETests
 on: [push, pull_request, workflow_dispatch]
 
 jobs:
-  IntegrationTests_1000:
-    name: IntegrationTests_1000
+  IntegrationTests_1:
+    name: IntegrationTests_1
     strategy:
       fail-fast: false
     runs-on: ubuntu-latest
@@ -24,9 +24,9 @@ jobs:
      checks: write
      pull-requests: write
      issues: write
-    timeout-minutes: 120
+    timeout-minutes: 30
     concurrency:
-     group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-jdk17-IntegrationTests_1000
+     group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-jdk17-IntegrationTests_1
      cancel-in-progress: ${{ github.event_name == 'pull_request' }}
     steps:
       - uses: actions/checkout@v4
@@ -48,7 +48,7 @@ jobs:
         with:
           add-job-summary: never
       - name: Run Integration Tests
-        run: ./gradlew --continue --no-daemon -DforkEvery=1 -DmaxParallelForks=1 integrationTests_1000
+        run: ./gradlew --continue --no-daemon -DforkEvery=1 -DmaxParallelForks=1 integrationTests_1
       - name: Package Build Artifacts
         if: success() || failure()
         shell: bash
@@ -107,8 +107,8 @@ jobs:
           key: ${{ secrets.BUILDPULSE_ACCESS_KEY_ID }}
           secret: ${{ secrets.BUILDPULSE_SECRET_ACCESS_KEY }}
 
-  IntegrationTests_1010:
-    name: IntegrationTests_1010
+  IntegrationTests_2:
+    name: IntegrationTests_2
     strategy:
       fail-fast: false
     runs-on: ubuntu-latest
@@ -118,9 +118,9 @@ jobs:
      checks: write
      pull-requests: write
      issues: write
-    timeout-minutes: 120
+    timeout-minutes: 30
     concurrency:
-     group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-jdk17-IntegrationTests_1010
+     group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-jdk17-IntegrationTests_2
      cancel-in-progress: ${{ github.event_name == 'pull_request' }}
     steps:
       - uses: actions/checkout@v4
@@ -142,7 +142,7 @@ jobs:
         with:
           add-job-summary: never
       - name: Run Integration Tests
-        run: ./gradlew --continue --no-daemon -DforkEvery=1 -DmaxParallelForks=1 integrationTests_1010
+        run: ./gradlew --continue --no-daemon -DforkEvery=1 -DmaxParallelForks=1 integrationTests_2
       - name: Package Build Artifacts
         if: success() || failure()
         shell: bash
@@ -201,8 +201,8 @@ jobs:
           key: ${{ secrets.BUILDPULSE_ACCESS_KEY_ID }}
           secret: ${{ secrets.BUILDPULSE_SECRET_ACCESS_KEY }}
 
-  IntegrationTests_1020:
-    name: IntegrationTests_1020
+  IntegrationTests_3:
+    name: IntegrationTests_3
     strategy:
       fail-fast: false
     runs-on: ubuntu-latest
@@ -212,9 +212,9 @@ jobs:
      checks: write
      pull-requests: write
      issues: write
-    timeout-minutes: 120
+    timeout-minutes: 30
     concurrency:
-     group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-jdk17-IntegrationTests_1020
+     group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-jdk17-IntegrationTests_3
      cancel-in-progress: ${{ github.event_name == 'pull_request' }}
     steps:
       - uses: actions/checkout@v4
@@ -236,7 +236,7 @@ jobs:
         with:
           add-job-summary: never
       - name: Run Integration Tests
-        run: ./gradlew --continue --no-daemon -DforkEvery=1 -DmaxParallelForks=1 integrationTests_1020
+        run: ./gradlew --continue --no-daemon -DforkEvery=1 -DmaxParallelForks=1 integrationTests_3
       - name: Package Build Artifacts
         if: success() || failure()
         shell: bash
@@ -295,8 +295,8 @@ jobs:
           key: ${{ secrets.BUILDPULSE_ACCESS_KEY_ID }}
           secret: ${{ secrets.BUILDPULSE_SECRET_ACCESS_KEY }}
 
-  IntegrationTests_1030:
-    name: IntegrationTests_1030
+  IntegrationTests_4:
+    name: IntegrationTests_4
     strategy:
       fail-fast: false
     runs-on: ubuntu-latest
@@ -306,9 +306,9 @@ jobs:
      checks: write
      pull-requests: write
      issues: write
-    timeout-minutes: 120
+    timeout-minutes: 30
     concurrency:
-     group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-jdk17-IntegrationTests_1030
+     group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-jdk17-IntegrationTests_4
      cancel-in-progress: ${{ github.event_name == 'pull_request' }}
     steps:
       - uses: actions/checkout@v4
@@ -330,7 +330,7 @@ jobs:
         with:
           add-job-summary: never
       - name: Run Integration Tests
-        run: ./gradlew --continue --no-daemon -DforkEvery=1 -DmaxParallelForks=1 integrationTests_1030
+        run: ./gradlew --continue --no-daemon -DforkEvery=1 -DmaxParallelForks=1 integrationTests_4
       - name: Package Build Artifacts
         if: success() || failure()
         shell: bash
@@ -389,8 +389,8 @@ jobs:
           key: ${{ secrets.BUILDPULSE_ACCESS_KEY_ID }}
           secret: ${{ secrets.BUILDPULSE_SECRET_ACCESS_KEY }}
 
-  IntegrationTests_1040:
-    name: IntegrationTests_1040
+  IntegrationTests_5:
+    name: IntegrationTests_5
     strategy:
       fail-fast: false
     runs-on: ubuntu-latest
@@ -400,9 +400,9 @@ jobs:
      checks: write
      pull-requests: write
      issues: write
-    timeout-minutes: 120
+    timeout-minutes: 30
     concurrency:
-     group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-jdk17-IntegrationTests_1040
+     group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-jdk17-IntegrationTests_5
      cancel-in-progress: ${{ github.event_name == 'pull_request' }}
     steps:
       - uses: actions/checkout@v4
@@ -424,7 +424,7 @@ jobs:
         with:
           add-job-summary: never
       - name: Run Integration Tests
-        run: ./gradlew --continue --no-daemon -DforkEvery=1 -DmaxParallelForks=1 integrationTests_1040
+        run: ./gradlew --continue --no-daemon -DforkEvery=1 -DmaxParallelForks=1 integrationTests_5
       - name: Package Build Artifacts
         if: success() || failure()
         shell: bash
@@ -483,8 +483,8 @@ jobs:
           key: ${{ secrets.BUILDPULSE_ACCESS_KEY_ID }}
           secret: ${{ secrets.BUILDPULSE_SECRET_ACCESS_KEY }}
 
-  IntegrationTests_1050:
-    name: IntegrationTests_1050
+  IntegrationTests_6:
+    name: IntegrationTests_6
     strategy:
       fail-fast: false
     runs-on: ubuntu-latest
@@ -494,9 +494,9 @@ jobs:
      checks: write
      pull-requests: write
      issues: write
-    timeout-minutes: 120
+    timeout-minutes: 30
     concurrency:
-     group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-jdk17-IntegrationTests_1050
+     group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-jdk17-IntegrationTests_6
      cancel-in-progress: ${{ github.event_name == 'pull_request' }}
     steps:
       - uses: actions/checkout@v4
@@ -518,7 +518,7 @@ jobs:
         with:
           add-job-summary: never
       - name: Run Integration Tests
-        run: ./gradlew --continue --no-daemon -DforkEvery=1 -DmaxParallelForks=1 integrationTests_1050
+        run: ./gradlew --continue --no-daemon -DforkEvery=1 -DmaxParallelForks=1 integrationTests_6
       - name: Package Build Artifacts
         if: success() || failure()
         shell: bash
@@ -577,8 +577,8 @@ jobs:
           key: ${{ secrets.BUILDPULSE_ACCESS_KEY_ID }}
           secret: ${{ secrets.BUILDPULSE_SECRET_ACCESS_KEY }}
 
-  IntegrationTests_1060:
-    name: IntegrationTests_1060
+  IntegrationTests_7:
+    name: IntegrationTests_7
     strategy:
       fail-fast: false
     runs-on: ubuntu-latest
@@ -588,9 +588,9 @@ jobs:
      checks: write
      pull-requests: write
      issues: write
-    timeout-minutes: 120
+    timeout-minutes: 30
     concurrency:
-     group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-jdk17-IntegrationTests_1060
+     group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-jdk17-IntegrationTests_7
      cancel-in-progress: ${{ github.event_name == 'pull_request' }}
     steps:
       - uses: actions/checkout@v4
@@ -612,7 +612,7 @@ jobs:
         with:
           add-job-summary: never
       - name: Run Integration Tests
-        run: ./gradlew --continue --no-daemon -DforkEvery=1 -DmaxParallelForks=1 integrationTests_1060
+        run: ./gradlew --continue --no-daemon -DforkEvery=1 -DmaxParallelForks=1 integrationTests_7
       - name: Package Build Artifacts
         if: success() || failure()
         shell: bash
@@ -671,8 +671,8 @@ jobs:
           key: ${{ secrets.BUILDPULSE_ACCESS_KEY_ID }}
           secret: ${{ secrets.BUILDPULSE_SECRET_ACCESS_KEY }}
 
-  IntegrationTests_1070:
-    name: IntegrationTests_1070
+  IntegrationTests_8:
+    name: IntegrationTests_8
     strategy:
       fail-fast: false
     runs-on: ubuntu-latest
@@ -682,9 +682,9 @@ jobs:
      checks: write
      pull-requests: write
      issues: write
-    timeout-minutes: 120
+    timeout-minutes: 30
     concurrency:
-     group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-jdk17-IntegrationTests_1070
+     group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-jdk17-IntegrationTests_8
      cancel-in-progress: ${{ github.event_name == 'pull_request' }}
     steps:
       - uses: actions/checkout@v4
@@ -706,7 +706,7 @@ jobs:
         with:
           add-job-summary: never
       - name: Run Integration Tests
-        run: ./gradlew --continue --no-daemon -DforkEvery=1 -DmaxParallelForks=1 integrationTests_1070
+        run: ./gradlew --continue --no-daemon -DforkEvery=1 -DmaxParallelForks=1 integrationTests_8
       - name: Package Build Artifacts
         if: success() || failure()
         shell: bash
@@ -765,8 +765,8 @@ jobs:
           key: ${{ secrets.BUILDPULSE_ACCESS_KEY_ID }}
           secret: ${{ secrets.BUILDPULSE_SECRET_ACCESS_KEY }}
 
-  IntegrationTests_1080:
-    name: IntegrationTests_1080
+  IntegrationTests_9:
+    name: IntegrationTests_9
     strategy:
       fail-fast: false
     runs-on: ubuntu-latest
@@ -776,9 +776,9 @@ jobs:
      checks: write
      pull-requests: write
      issues: write
-    timeout-minutes: 120
+    timeout-minutes: 30
     concurrency:
-     group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-jdk17-IntegrationTests_1080
+     group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-jdk17-IntegrationTests_9
      cancel-in-progress: ${{ github.event_name == 'pull_request' }}
     steps:
       - uses: actions/checkout@v4
@@ -800,7 +800,7 @@ jobs:
         with:
           add-job-summary: never
       - name: Run Integration Tests
-        run: ./gradlew --continue --no-daemon -DforkEvery=1 -DmaxParallelForks=1 integrationTests_1080
+        run: ./gradlew --continue --no-daemon -DforkEvery=1 -DmaxParallelForks=1 integrationTests_9
       - name: Package Build Artifacts
         if: success() || failure()
         shell: bash
@@ -859,8 +859,8 @@ jobs:
           key: ${{ secrets.BUILDPULSE_ACCESS_KEY_ID }}
           secret: ${{ secrets.BUILDPULSE_SECRET_ACCESS_KEY }}
 
-  IntegrationTests_1090:
-    name: IntegrationTests_1090
+  IntegrationTests_10:
+    name: IntegrationTests_10
     strategy:
       fail-fast: false
     runs-on: ubuntu-latest
@@ -870,9 +870,9 @@ jobs:
      checks: write
      pull-requests: write
      issues: write
-    timeout-minutes: 120
+    timeout-minutes: 30
     concurrency:
-     group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-jdk17-IntegrationTests_1090
+     group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-jdk17-IntegrationTests_10
      cancel-in-progress: ${{ github.event_name == 'pull_request' }}
     steps:
       - uses: actions/checkout@v4
@@ -894,7 +894,7 @@ jobs:
         with:
           add-job-summary: never
       - name: Run Integration Tests
-        run: ./gradlew --continue --no-daemon -DforkEvery=1 -DmaxParallelForks=1 integrationTests_1090
+        run: ./gradlew --continue --no-daemon -DforkEvery=1 -DmaxParallelForks=1 integrationTests_10
       - name: Package Build Artifacts
         if: success() || failure()
         shell: bash
@@ -953,8 +953,8 @@ jobs:
           key: ${{ secrets.BUILDPULSE_ACCESS_KEY_ID }}
           secret: ${{ secrets.BUILDPULSE_SECRET_ACCESS_KEY }}
 
-  IntegrationTests_1100:
-    name: IntegrationTests_1100
+  IntegrationTests_11:
+    name: IntegrationTests_11
     strategy:
       fail-fast: false
     runs-on: ubuntu-latest
@@ -964,9 +964,9 @@ jobs:
      checks: write
      pull-requests: write
      issues: write
-    timeout-minutes: 120
+    timeout-minutes: 30
     concurrency:
-     group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-jdk17-IntegrationTests_1100
+     group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-jdk17-IntegrationTests_11
      cancel-in-progress: ${{ github.event_name == 'pull_request' }}
     steps:
       - uses: actions/checkout@v4
@@ -988,7 +988,7 @@ jobs:
         with:
           add-job-summary: never
       - name: Run Integration Tests
-        run: ./gradlew --continue --no-daemon -DforkEvery=1 -DmaxParallelForks=1 integrationTests_1100
+        run: ./gradlew --continue --no-daemon -DforkEvery=1 -DmaxParallelForks=1 integrationTests_11
       - name: Package Build Artifacts
         if: success() || failure()
         shell: bash
@@ -1047,8 +1047,8 @@ jobs:
           key: ${{ secrets.BUILDPULSE_ACCESS_KEY_ID }}
           secret: ${{ secrets.BUILDPULSE_SECRET_ACCESS_KEY }}
 
-  IntegrationTests_1110:
-    name: IntegrationTests_1110
+  IntegrationTests_12:
+    name: IntegrationTests_12
     strategy:
       fail-fast: false
     runs-on: ubuntu-latest
@@ -1058,9 +1058,9 @@ jobs:
      checks: write
      pull-requests: write
      issues: write
-    timeout-minutes: 120
+    timeout-minutes: 30
     concurrency:
-     group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-jdk17-IntegrationTests_1110
+     group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-jdk17-IntegrationTests_12
      cancel-in-progress: ${{ github.event_name == 'pull_request' }}
     steps:
       - uses: actions/checkout@v4
@@ -1082,7 +1082,7 @@ jobs:
         with:
           add-job-summary: never
       - name: Run Integration Tests
-        run: ./gradlew --continue --no-daemon -DforkEvery=1 -DmaxParallelForks=1 integrationTests_1110
+        run: ./gradlew --continue --no-daemon -DforkEvery=1 -DmaxParallelForks=1 integrationTests_12
       - name: Package Build Artifacts
         if: success() || failure()
         shell: bash
@@ -1141,8 +1141,8 @@ jobs:
           key: ${{ secrets.BUILDPULSE_ACCESS_KEY_ID }}
           secret: ${{ secrets.BUILDPULSE_SECRET_ACCESS_KEY }}
 
-  IntegrationTests_1120:
-    name: IntegrationTests_1120
+  IntegrationTests_13:
+    name: IntegrationTests_13
     strategy:
       fail-fast: false
     runs-on: ubuntu-latest
@@ -1152,9 +1152,9 @@ jobs:
      checks: write
      pull-requests: write
      issues: write
-    timeout-minutes: 120
+    timeout-minutes: 30
     concurrency:
-     group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-jdk17-IntegrationTests_1120
+     group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-jdk17-IntegrationTests_13
      cancel-in-progress: ${{ github.event_name == 'pull_request' }}
     steps:
       - uses: actions/checkout@v4
@@ -1176,7 +1176,7 @@ jobs:
         with:
           add-job-summary: never
       - name: Run Integration Tests
-        run: ./gradlew --continue --no-daemon -DforkEvery=1 -DmaxParallelForks=1 integrationTests_1120
+        run: ./gradlew --continue --no-daemon -DforkEvery=1 -DmaxParallelForks=1 integrationTests_13
       - name: Package Build Artifacts
         if: success() || failure()
         shell: bash
@@ -1235,8 +1235,8 @@ jobs:
           key: ${{ secrets.BUILDPULSE_ACCESS_KEY_ID }}
           secret: ${{ secrets.BUILDPULSE_SECRET_ACCESS_KEY }}
 
-  IntegrationTests_1130:
-    name: IntegrationTests_1130
+  IntegrationTests_14:
+    name: IntegrationTests_14
     strategy:
       fail-fast: false
     runs-on: ubuntu-latest
@@ -1246,9 +1246,9 @@ jobs:
      checks: write
      pull-requests: write
      issues: write
-    timeout-minutes: 120
+    timeout-minutes: 30
     concurrency:
-     group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-jdk17-IntegrationTests_1130
+     group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-jdk17-IntegrationTests_14
      cancel-in-progress: ${{ github.event_name == 'pull_request' }}
     steps:
       - uses: actions/checkout@v4
@@ -1270,7 +1270,7 @@ jobs:
         with:
           add-job-summary: never
       - name: Run Integration Tests
-        run: ./gradlew --continue --no-daemon -DforkEvery=1 -DmaxParallelForks=1 integrationTests_1130
+        run: ./gradlew --continue --no-daemon -DforkEvery=1 -DmaxParallelForks=1 integrationTests_14
       - name: Package Build Artifacts
         if: success() || failure()
         shell: bash
@@ -1329,8 +1329,8 @@ jobs:
           key: ${{ secrets.BUILDPULSE_ACCESS_KEY_ID }}
           secret: ${{ secrets.BUILDPULSE_SECRET_ACCESS_KEY }}
 
-  IntegrationTests_1200:
-    name: IntegrationTests_1200
+  IntegrationTests_15:
+    name: IntegrationTests_15
     strategy:
       fail-fast: false
     runs-on: ubuntu-latest
@@ -1340,9 +1340,9 @@ jobs:
      checks: write
      pull-requests: write
      issues: write
-    timeout-minutes: 120
+    timeout-minutes: 30
     concurrency:
-     group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-jdk17-IntegrationTests_1200
+     group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-jdk17-IntegrationTests_15
      cancel-in-progress: ${{ github.event_name == 'pull_request' }}
     steps:
       - uses: actions/checkout@v4
@@ -1364,7 +1364,7 @@ jobs:
         with:
           add-job-summary: never
       - name: Run Integration Tests
-        run: ./gradlew --continue --no-daemon -DforkEvery=1 -DmaxParallelForks=1 integrationTests_1200
+        run: ./gradlew --continue --no-daemon -DforkEvery=1 -DmaxParallelForks=1 integrationTests_15
       - name: Package Build Artifacts
         if: success() || failure()
         shell: bash
@@ -1423,8 +1423,8 @@ jobs:
           key: ${{ secrets.BUILDPULSE_ACCESS_KEY_ID }}
           secret: ${{ secrets.BUILDPULSE_SECRET_ACCESS_KEY }}
 
-  IntegrationTests_1210:
-    name: IntegrationTests_1210
+  IntegrationTests_16:
+    name: IntegrationTests_16
     strategy:
       fail-fast: false
     runs-on: ubuntu-latest
@@ -1434,9 +1434,9 @@ jobs:
      checks: write
      pull-requests: write
      issues: write
-    timeout-minutes: 120
+    timeout-minutes: 30
     concurrency:
-     group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-jdk17-IntegrationTests_1210
+     group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-jdk17-IntegrationTests_16
      cancel-in-progress: ${{ github.event_name == 'pull_request' }}
     steps:
       - uses: actions/checkout@v4
@@ -1458,7 +1458,7 @@ jobs:
         with:
           add-job-summary: never
       - name: Run Integration Tests
-        run: ./gradlew --continue --no-daemon -DforkEvery=1 -DmaxParallelForks=1 integrationTests_1210
+        run: ./gradlew --continue --no-daemon -DforkEvery=1 -DmaxParallelForks=1 integrationTests_16
       - name: Package Build Artifacts
         if: success() || failure()
         shell: bash
@@ -1517,8 +1517,8 @@ jobs:
           key: ${{ secrets.BUILDPULSE_ACCESS_KEY_ID }}
           secret: ${{ secrets.BUILDPULSE_SECRET_ACCESS_KEY }}
 
-  IntegrationTests_1220:
-    name: IntegrationTests_1220
+  IntegrationTests_17:
+    name: IntegrationTests_17
     strategy:
       fail-fast: false
     runs-on: ubuntu-latest
@@ -1528,9 +1528,9 @@ jobs:
      checks: write
      pull-requests: write
      issues: write
-    timeout-minutes: 120
+    timeout-minutes: 30
     concurrency:
-     group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-jdk17-IntegrationTests_1220
+     group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-jdk17-IntegrationTests_17
      cancel-in-progress: ${{ github.event_name == 'pull_request' }}
     steps:
       - uses: actions/checkout@v4
@@ -1552,7 +1552,7 @@ jobs:
         with:
           add-job-summary: never
       - name: Run Integration Tests
-        run: ./gradlew --continue --no-daemon -DforkEvery=1 -DmaxParallelForks=1 integrationTests_1220
+        run: ./gradlew --continue --no-daemon -DforkEvery=1 -DmaxParallelForks=1 integrationTests_17
       - name: Package Build Artifacts
         if: success() || failure()
         shell: bash
@@ -1611,8 +1611,8 @@ jobs:
           key: ${{ secrets.BUILDPULSE_ACCESS_KEY_ID }}
           secret: ${{ secrets.BUILDPULSE_SECRET_ACCESS_KEY }}
 
-  IntegrationTests_1230:
-    name: IntegrationTests_1230
+  IntegrationTests_18:
+    name: IntegrationTests_18
     strategy:
       fail-fast: false
     runs-on: ubuntu-latest
@@ -1622,9 +1622,9 @@ jobs:
      checks: write
      pull-requests: write
      issues: write
-    timeout-minutes: 120
+    timeout-minutes: 30
     concurrency:
-     group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-jdk17-IntegrationTests_1230
+     group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-jdk17-IntegrationTests_18
      cancel-in-progress: ${{ github.event_name == 'pull_request' }}
     steps:
       - uses: actions/checkout@v4
@@ -1646,7 +1646,7 @@ jobs:
         with:
           add-job-summary: never
       - name: Run Integration Tests
-        run: ./gradlew --continue --no-daemon -DforkEvery=1 -DmaxParallelForks=1 integrationTests_1230
+        run: ./gradlew --continue --no-daemon -DforkEvery=1 -DmaxParallelForks=1 integrationTests_18
       - name: Package Build Artifacts
         if: success() || failure()
         shell: bash
@@ -1705,8 +1705,8 @@ jobs:
           key: ${{ secrets.BUILDPULSE_ACCESS_KEY_ID }}
           secret: ${{ secrets.BUILDPULSE_SECRET_ACCESS_KEY }}
 
-  IntegrationTests_1240:
-    name: IntegrationTests_1240
+  IntegrationTests_19:
+    name: IntegrationTests_19
     strategy:
       fail-fast: false
     runs-on: ubuntu-latest
@@ -1716,9 +1716,9 @@ jobs:
      checks: write
      pull-requests: write
      issues: write
-    timeout-minutes: 120
+    timeout-minutes: 30
     concurrency:
-     group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-jdk17-IntegrationTests_1240
+     group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-jdk17-IntegrationTests_19
      cancel-in-progress: ${{ github.event_name == 'pull_request' }}
     steps:
       - uses: actions/checkout@v4
@@ -1740,7 +1740,7 @@ jobs:
         with:
           add-job-summary: never
       - name: Run Integration Tests
-        run: ./gradlew --continue --no-daemon -DforkEvery=1 -DmaxParallelForks=1 integrationTests_1240
+        run: ./gradlew --continue --no-daemon -DforkEvery=1 -DmaxParallelForks=1 integrationTests_19
       - name: Package Build Artifacts
         if: success() || failure()
         shell: bash
@@ -1799,8 +1799,8 @@ jobs:
           key: ${{ secrets.BUILDPULSE_ACCESS_KEY_ID }}
           secret: ${{ secrets.BUILDPULSE_SECRET_ACCESS_KEY }}
 
-  IntegrationTests_1250:
-    name: IntegrationTests_1250
+  IntegrationTests_20:
+    name: IntegrationTests_20
     strategy:
       fail-fast: false
     runs-on: ubuntu-latest
@@ -1810,9 +1810,9 @@ jobs:
      checks: write
      pull-requests: write
      issues: write
-    timeout-minutes: 120
+    timeout-minutes: 30
     concurrency:
-     group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-jdk17-IntegrationTests_1250
+     group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-jdk17-IntegrationTests_20
      cancel-in-progress: ${{ github.event_name == 'pull_request' }}
     steps:
       - uses: actions/checkout@v4
@@ -1834,7 +1834,7 @@ jobs:
         with:
           add-job-summary: never
       - name: Run Integration Tests
-        run: ./gradlew --continue --no-daemon -DforkEvery=1 -DmaxParallelForks=1 integrationTests_1250
+        run: ./gradlew --continue --no-daemon -DforkEvery=1 -DmaxParallelForks=1 integrationTests_20
       - name: Package Build Artifacts
         if: success() || failure()
         shell: bash
@@ -1893,8 +1893,8 @@ jobs:
           key: ${{ secrets.BUILDPULSE_ACCESS_KEY_ID }}
           secret: ${{ secrets.BUILDPULSE_SECRET_ACCESS_KEY }}
 
-  IntegrationTests_1260:
-    name: IntegrationTests_1260
+  IntegrationTests_21:
+    name: IntegrationTests_21
     strategy:
       fail-fast: false
     runs-on: ubuntu-latest
@@ -1904,9 +1904,9 @@ jobs:
      checks: write
      pull-requests: write
      issues: write
-    timeout-minutes: 120
+    timeout-minutes: 30
     concurrency:
-     group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-jdk17-IntegrationTests_1260
+     group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-jdk17-IntegrationTests_21
      cancel-in-progress: ${{ github.event_name == 'pull_request' }}
     steps:
       - uses: actions/checkout@v4
@@ -1928,7 +1928,7 @@ jobs:
         with:
           add-job-summary: never
       - name: Run Integration Tests
-        run: ./gradlew --continue --no-daemon -DforkEvery=1 -DmaxParallelForks=1 integrationTests_1260
+        run: ./gradlew --continue --no-daemon -DforkEvery=1 -DmaxParallelForks=1 integrationTests_21
       - name: Package Build Artifacts
         if: success() || failure()
         shell: bash
@@ -1987,8 +1987,8 @@ jobs:
           key: ${{ secrets.BUILDPULSE_ACCESS_KEY_ID }}
           secret: ${{ secrets.BUILDPULSE_SECRET_ACCESS_KEY }}
 
-  IntegrationTests_1270:
-    name: IntegrationTests_1270
+  IntegrationTests_22:
+    name: IntegrationTests_22
     strategy:
       fail-fast: false
     runs-on: ubuntu-latest
@@ -1998,9 +1998,9 @@ jobs:
      checks: write
      pull-requests: write
      issues: write
-    timeout-minutes: 120
+    timeout-minutes: 30
     concurrency:
-     group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-jdk17-IntegrationTests_1270
+     group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-jdk17-IntegrationTests_22
      cancel-in-progress: ${{ github.event_name == 'pull_request' }}
     steps:
       - uses: actions/checkout@v4
@@ -2022,7 +2022,7 @@ jobs:
         with:
           add-job-summary: never
       - name: Run Integration Tests
-        run: ./gradlew --continue --no-daemon -DforkEvery=1 -DmaxParallelForks=1 integrationTests_1270
+        run: ./gradlew --continue --no-daemon -DforkEvery=1 -DmaxParallelForks=1 integrationTests_22
       - name: Package Build Artifacts
         if: success() || failure()
         shell: bash
@@ -2081,8 +2081,8 @@ jobs:
           key: ${{ secrets.BUILDPULSE_ACCESS_KEY_ID }}
           secret: ${{ secrets.BUILDPULSE_SECRET_ACCESS_KEY }}
 
-  IntegrationTests_1280:
-    name: IntegrationTests_1280
+  IntegrationTests_23:
+    name: IntegrationTests_23
     strategy:
       fail-fast: false
     runs-on: ubuntu-latest
@@ -2092,9 +2092,9 @@ jobs:
      checks: write
      pull-requests: write
      issues: write
-    timeout-minutes: 120
+    timeout-minutes: 30
     concurrency:
-     group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-jdk17-IntegrationTests_1280
+     group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-jdk17-IntegrationTests_23
      cancel-in-progress: ${{ github.event_name == 'pull_request' }}
     steps:
       - uses: actions/checkout@v4
@@ -2116,7 +2116,7 @@ jobs:
         with:
           add-job-summary: never
       - name: Run Integration Tests
-        run: ./gradlew --continue --no-daemon -DforkEvery=1 -DmaxParallelForks=1 integrationTests_1280
+        run: ./gradlew --continue --no-daemon -DforkEvery=1 -DmaxParallelForks=1 integrationTests_23
       - name: Package Build Artifacts
         if: success() || failure()
         shell: bash
@@ -2175,8 +2175,8 @@ jobs:
           key: ${{ secrets.BUILDPULSE_ACCESS_KEY_ID }}
           secret: ${{ secrets.BUILDPULSE_SECRET_ACCESS_KEY }}
 
-  IntegrationTests_1400:
-    name: IntegrationTests_1400
+  integrationTests_99:
+    name: integrationTests_99
     strategy:
       fail-fast: false
     runs-on: ubuntu-latest
@@ -2186,9 +2186,9 @@ jobs:
      checks: write
      pull-requests: write
      issues: write
-    timeout-minutes: 120
+    timeout-minutes: 30
     concurrency:
-     group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-jdk17-IntegrationTests_1400
+     group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-jdk17-integrationTests_99
      cancel-in-progress: ${{ github.event_name == 'pull_request' }}
     steps:
       - uses: actions/checkout@v4
@@ -2210,665 +2210,7 @@ jobs:
         with:
           add-job-summary: never
       - name: Run Integration Tests
-        run: ./gradlew --continue --no-daemon -DforkEvery=1 -DmaxParallelForks=1 integrationTests_1400
-      - name: Package Build Artifacts
-        if: success() || failure()
-        shell: bash
-        run: |
-          mkdir ${{ github.job }}-artifacts
-          echo "Repository owner: ${{ github.repository_owner }}"
-          echo "Repository name: ${{ github.repository }}"
-          echo "event name: ${{ github.event_name }}"
-          find . -path "**/build/reports/*" -or -path "**/build/test-results/*" > artifacts.list
-          find . -type f \( -name 'core.*' -o -name 'hs_err_pid*.log' \) -exec xz -9 {} \; -exec echo "{}.xz" \; >> artifacts.list
-          rsync -R --files-from=artifacts.list . ${{ github.job }}-artifacts
-          tar -zcvf ${{ github.job }}-jdk17-logs.tar.gz ${{ github.job }}-artifacts
-      - name: Generate Fork Repo Test Reports
-        if: ${{ (github.repository_owner != 'linkedin') && (success() || failure()) }}
-        uses: dorny/test-reporter@v1.9.1
-        env:
-         NODE_OPTIONS: --max-old-space-size=9182
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          name: ${{ github.job }} Test Reports       # Name where it report the test results
-          path: '**/TEST-*.xml'
-          fail-on-error: 'false'
-          max-annotations: '10'
-          list-tests: 'all'
-          list-suites: 'all'
-          reporter: java-junit
-      - name: Publish Test Report
-        continue-on-error: true
-        env:
-          NODE_OPTIONS: "--max_old_space_size=8192"
-        uses: mikepenz/action-junit-report@v5
-        if: always()
-        with:
-          check_name: ${{ github.job }}-jdk17 Report
-          comment: false
-          annotate_only: true
-          flaky_summary: true
-          commit: ${{github.event.workflow_run.head_sha}}
-          detailed_summary: true
-          report_paths: '**/build/test-results/test/TEST-*.xml'
-      - name: Upload Build Artifacts
-        if: success() || failure()
-        uses: actions/upload-artifact@v4
-        with:
-          name: ${{ github.job }}
-          path: ${{ github.job }}-jdk17-logs.tar.gz
-          retention-days: 30
-      - name: Upload test results to BuildPulse for flaky test detection
-        if: ${{ !cancelled() }}
-        uses: buildpulse/buildpulse-action@main
-        with:
-          account: 357098
-          repository: 349172057
-          path: |
-            **/TEST-*.xml
-          key: ${{ secrets.BUILDPULSE_ACCESS_KEY_ID }}
-          secret: ${{ secrets.BUILDPULSE_SECRET_ACCESS_KEY }}
-
-  IntegrationTests_1410:
-    name: IntegrationTests_1410
-    strategy:
-      fail-fast: false
-    runs-on: ubuntu-latest
-    permissions:
-     id-token: write
-     contents: read
-     checks: write
-     pull-requests: write
-     issues: write
-    timeout-minutes: 120
-    concurrency:
-     group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-jdk17-IntegrationTests_1410
-     cancel-in-progress: ${{ github.event_name == 'pull_request' }}
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-      - name: Set up JDK
-        uses: actions/setup-java@v4
-        with:
-          java-version: 17
-          distribution: 'temurin'
-          cache: 'gradle'
-      - shell: bash
-        run: |
-          git remote set-head origin --auto
-          git remote add upstream https://github.com/linkedin/venice
-          git fetch upstream
-      - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v4
-        with:
-          add-job-summary: never
-      - name: Run Integration Tests
-        run: ./gradlew --continue --no-daemon -DforkEvery=1 -DmaxParallelForks=1 integrationTests_1410
-      - name: Package Build Artifacts
-        if: success() || failure()
-        shell: bash
-        run: |
-          mkdir ${{ github.job }}-artifacts
-          echo "Repository owner: ${{ github.repository_owner }}"
-          echo "Repository name: ${{ github.repository }}"
-          echo "event name: ${{ github.event_name }}"
-          find . -path "**/build/reports/*" -or -path "**/build/test-results/*" > artifacts.list
-          find . -type f \( -name 'core.*' -o -name 'hs_err_pid*.log' \) -exec xz -9 {} \; -exec echo "{}.xz" \; >> artifacts.list
-          rsync -R --files-from=artifacts.list . ${{ github.job }}-artifacts
-          tar -zcvf ${{ github.job }}-jdk17-logs.tar.gz ${{ github.job }}-artifacts
-      - name: Generate Fork Repo Test Reports
-        if: ${{ (github.repository_owner != 'linkedin') && (success() || failure()) }}
-        uses: dorny/test-reporter@v1.9.1
-        env:
-         NODE_OPTIONS: --max-old-space-size=9182
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          name: ${{ github.job }} Test Reports       # Name where it report the test results
-          path: '**/TEST-*.xml'
-          fail-on-error: 'false'
-          max-annotations: '10'
-          list-tests: 'all'
-          list-suites: 'all'
-          reporter: java-junit
-      - name: Publish Test Report
-        continue-on-error: true
-        env:
-          NODE_OPTIONS: "--max_old_space_size=8192"
-        uses: mikepenz/action-junit-report@v5
-        if: always()
-        with:
-          check_name: ${{ github.job }}-jdk17 Report
-          comment: false
-          annotate_only: true
-          flaky_summary: true
-          commit: ${{github.event.workflow_run.head_sha}}
-          detailed_summary: true
-          report_paths: '**/build/test-results/test/TEST-*.xml'
-      - name: Upload Build Artifacts
-        if: success() || failure()
-        uses: actions/upload-artifact@v4
-        with:
-          name: ${{ github.job }}
-          path: ${{ github.job }}-jdk17-logs.tar.gz
-          retention-days: 30
-      - name: Upload test results to BuildPulse for flaky test detection
-        if: ${{ !cancelled() }}
-        uses: buildpulse/buildpulse-action@main
-        with:
-          account: 357098
-          repository: 349172057
-          path: |
-            **/TEST-*.xml
-          key: ${{ secrets.BUILDPULSE_ACCESS_KEY_ID }}
-          secret: ${{ secrets.BUILDPULSE_SECRET_ACCESS_KEY }}
-
-  IntegrationTests_1420:
-    name: IntegrationTests_1420
-    strategy:
-      fail-fast: false
-    runs-on: ubuntu-latest
-    permissions:
-     id-token: write
-     contents: read
-     checks: write
-     pull-requests: write
-     issues: write
-    timeout-minutes: 120
-    concurrency:
-     group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-jdk17-IntegrationTests_1420
-     cancel-in-progress: ${{ github.event_name == 'pull_request' }}
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-      - name: Set up JDK
-        uses: actions/setup-java@v4
-        with:
-          java-version: 17
-          distribution: 'temurin'
-          cache: 'gradle'
-      - shell: bash
-        run: |
-          git remote set-head origin --auto
-          git remote add upstream https://github.com/linkedin/venice
-          git fetch upstream
-      - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v4
-        with:
-          add-job-summary: never
-      - name: Run Integration Tests
-        run: ./gradlew --continue --no-daemon -DforkEvery=1 -DmaxParallelForks=1 integrationTests_1420
-      - name: Package Build Artifacts
-        if: success() || failure()
-        shell: bash
-        run: |
-          mkdir ${{ github.job }}-artifacts
-          echo "Repository owner: ${{ github.repository_owner }}"
-          echo "Repository name: ${{ github.repository }}"
-          echo "event name: ${{ github.event_name }}"
-          find . -path "**/build/reports/*" -or -path "**/build/test-results/*" > artifacts.list
-          find . -type f \( -name 'core.*' -o -name 'hs_err_pid*.log' \) -exec xz -9 {} \; -exec echo "{}.xz" \; >> artifacts.list
-          rsync -R --files-from=artifacts.list . ${{ github.job }}-artifacts
-          tar -zcvf ${{ github.job }}-jdk17-logs.tar.gz ${{ github.job }}-artifacts
-      - name: Generate Fork Repo Test Reports
-        if: ${{ (github.repository_owner != 'linkedin') && (success() || failure()) }}
-        uses: dorny/test-reporter@v1.9.1
-        env:
-         NODE_OPTIONS: --max-old-space-size=9182
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          name: ${{ github.job }} Test Reports       # Name where it report the test results
-          path: '**/TEST-*.xml'
-          fail-on-error: 'false'
-          max-annotations: '10'
-          list-tests: 'all'
-          list-suites: 'all'
-          reporter: java-junit
-      - name: Publish Test Report
-        continue-on-error: true
-        env:
-          NODE_OPTIONS: "--max_old_space_size=8192"
-        uses: mikepenz/action-junit-report@v5
-        if: always()
-        with:
-          check_name: ${{ github.job }}-jdk17 Report
-          comment: false
-          annotate_only: true
-          flaky_summary: true
-          commit: ${{github.event.workflow_run.head_sha}}
-          detailed_summary: true
-          report_paths: '**/build/test-results/test/TEST-*.xml'
-      - name: Upload Build Artifacts
-        if: success() || failure()
-        uses: actions/upload-artifact@v4
-        with:
-          name: ${{ github.job }}
-          path: ${{ github.job }}-jdk17-logs.tar.gz
-          retention-days: 30
-      - name: Upload test results to BuildPulse for flaky test detection
-        if: ${{ !cancelled() }}
-        uses: buildpulse/buildpulse-action@main
-        with:
-          account: 357098
-          repository: 349172057
-          path: |
-            **/TEST-*.xml
-          key: ${{ secrets.BUILDPULSE_ACCESS_KEY_ID }}
-          secret: ${{ secrets.BUILDPULSE_SECRET_ACCESS_KEY }}
-
-  IntegrationTests_1430:
-    name: IntegrationTests_1430
-    strategy:
-      fail-fast: false
-    runs-on: ubuntu-latest
-    permissions:
-     id-token: write
-     contents: read
-     checks: write
-     pull-requests: write
-     issues: write
-    timeout-minutes: 120
-    concurrency:
-     group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-jdk17-IntegrationTests_1430
-     cancel-in-progress: ${{ github.event_name == 'pull_request' }}
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-      - name: Set up JDK
-        uses: actions/setup-java@v4
-        with:
-          java-version: 17
-          distribution: 'temurin'
-          cache: 'gradle'
-      - shell: bash
-        run: |
-          git remote set-head origin --auto
-          git remote add upstream https://github.com/linkedin/venice
-          git fetch upstream
-      - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v4
-        with:
-          add-job-summary: never
-      - name: Run Integration Tests
-        run: ./gradlew --continue --no-daemon -DforkEvery=1 -DmaxParallelForks=1 integrationTests_1430
-      - name: Package Build Artifacts
-        if: success() || failure()
-        shell: bash
-        run: |
-          mkdir ${{ github.job }}-artifacts
-          echo "Repository owner: ${{ github.repository_owner }}"
-          echo "Repository name: ${{ github.repository }}"
-          echo "event name: ${{ github.event_name }}"
-          find . -path "**/build/reports/*" -or -path "**/build/test-results/*" > artifacts.list
-          find . -type f \( -name 'core.*' -o -name 'hs_err_pid*.log' \) -exec xz -9 {} \; -exec echo "{}.xz" \; >> artifacts.list
-          rsync -R --files-from=artifacts.list . ${{ github.job }}-artifacts
-          tar -zcvf ${{ github.job }}-jdk17-logs.tar.gz ${{ github.job }}-artifacts
-      - name: Generate Fork Repo Test Reports
-        if: ${{ (github.repository_owner != 'linkedin') && (success() || failure()) }}
-        uses: dorny/test-reporter@v1.9.1
-        env:
-         NODE_OPTIONS: --max-old-space-size=9182
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          name: ${{ github.job }} Test Reports       # Name where it report the test results
-          path: '**/TEST-*.xml'
-          fail-on-error: 'false'
-          max-annotations: '10'
-          list-tests: 'all'
-          list-suites: 'all'
-          reporter: java-junit
-      - name: Publish Test Report
-        continue-on-error: true
-        env:
-          NODE_OPTIONS: "--max_old_space_size=8192"
-        uses: mikepenz/action-junit-report@v5
-        if: always()
-        with:
-          check_name: ${{ github.job }}-jdk17 Report
-          comment: false
-          annotate_only: true
-          flaky_summary: true
-          commit: ${{github.event.workflow_run.head_sha}}
-          detailed_summary: true
-          report_paths: '**/build/test-results/test/TEST-*.xml'
-      - name: Upload Build Artifacts
-        if: success() || failure()
-        uses: actions/upload-artifact@v4
-        with:
-          name: ${{ github.job }}
-          path: ${{ github.job }}-jdk17-logs.tar.gz
-          retention-days: 30
-      - name: Upload test results to BuildPulse for flaky test detection
-        if: ${{ !cancelled() }}
-        uses: buildpulse/buildpulse-action@main
-        with:
-          account: 357098
-          repository: 349172057
-          path: |
-            **/TEST-*.xml
-          key: ${{ secrets.BUILDPULSE_ACCESS_KEY_ID }}
-          secret: ${{ secrets.BUILDPULSE_SECRET_ACCESS_KEY }}
-
-  IntegrationTests_1440:
-    name: IntegrationTests_1440
-    strategy:
-      fail-fast: false
-    runs-on: ubuntu-latest
-    permissions:
-     id-token: write
-     contents: read
-     checks: write
-     pull-requests: write
-     issues: write
-    timeout-minutes: 120
-    concurrency:
-     group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-jdk17-IntegrationTests_1440
-     cancel-in-progress: ${{ github.event_name == 'pull_request' }}
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-      - name: Set up JDK
-        uses: actions/setup-java@v4
-        with:
-          java-version: 17
-          distribution: 'temurin'
-          cache: 'gradle'
-      - shell: bash
-        run: |
-          git remote set-head origin --auto
-          git remote add upstream https://github.com/linkedin/venice
-          git fetch upstream
-      - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v4
-        with:
-          add-job-summary: never
-      - name: Run Integration Tests
-        run: ./gradlew --continue --no-daemon -DforkEvery=1 -DmaxParallelForks=1 integrationTests_1440
-      - name: Package Build Artifacts
-        if: success() || failure()
-        shell: bash
-        run: |
-          mkdir ${{ github.job }}-artifacts
-          echo "Repository owner: ${{ github.repository_owner }}"
-          echo "Repository name: ${{ github.repository }}"
-          echo "event name: ${{ github.event_name }}"
-          find . -path "**/build/reports/*" -or -path "**/build/test-results/*" > artifacts.list
-          find . -type f \( -name 'core.*' -o -name 'hs_err_pid*.log' \) -exec xz -9 {} \; -exec echo "{}.xz" \; >> artifacts.list
-          rsync -R --files-from=artifacts.list . ${{ github.job }}-artifacts
-          tar -zcvf ${{ github.job }}-jdk17-logs.tar.gz ${{ github.job }}-artifacts
-      - name: Generate Fork Repo Test Reports
-        if: ${{ (github.repository_owner != 'linkedin') && (success() || failure()) }}
-        uses: dorny/test-reporter@v1.9.1
-        env:
-         NODE_OPTIONS: --max-old-space-size=9182
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          name: ${{ github.job }} Test Reports       # Name where it report the test results
-          path: '**/TEST-*.xml'
-          fail-on-error: 'false'
-          max-annotations: '10'
-          list-tests: 'all'
-          list-suites: 'all'
-          reporter: java-junit
-      - name: Publish Test Report
-        continue-on-error: true
-        env:
-          NODE_OPTIONS: "--max_old_space_size=8192"
-        uses: mikepenz/action-junit-report@v5
-        if: always()
-        with:
-          check_name: ${{ github.job }}-jdk17 Report
-          comment: false
-          annotate_only: true
-          flaky_summary: true
-          commit: ${{github.event.workflow_run.head_sha}}
-          detailed_summary: true
-          report_paths: '**/build/test-results/test/TEST-*.xml'
-      - name: Upload Build Artifacts
-        if: success() || failure()
-        uses: actions/upload-artifact@v4
-        with:
-          name: ${{ github.job }}
-          path: ${{ github.job }}-jdk17-logs.tar.gz
-          retention-days: 30
-      - name: Upload test results to BuildPulse for flaky test detection
-        if: ${{ !cancelled() }}
-        uses: buildpulse/buildpulse-action@main
-        with:
-          account: 357098
-          repository: 349172057
-          path: |
-            **/TEST-*.xml
-          key: ${{ secrets.BUILDPULSE_ACCESS_KEY_ID }}
-          secret: ${{ secrets.BUILDPULSE_SECRET_ACCESS_KEY }}
-
-  IntegrationTests_1500:
-    name: IntegrationTests_1500
-    strategy:
-      fail-fast: false
-    runs-on: ubuntu-latest
-    permissions:
-     id-token: write
-     contents: read
-     checks: write
-     pull-requests: write
-     issues: write
-    timeout-minutes: 120
-    concurrency:
-     group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-jdk17-IntegrationTests_1500
-     cancel-in-progress: ${{ github.event_name == 'pull_request' }}
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-      - name: Set up JDK
-        uses: actions/setup-java@v4
-        with:
-          java-version: 17
-          distribution: 'temurin'
-          cache: 'gradle'
-      - shell: bash
-        run: |
-          git remote set-head origin --auto
-          git remote add upstream https://github.com/linkedin/venice
-          git fetch upstream
-      - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v4
-        with:
-          add-job-summary: never
-      - name: Run Integration Tests
-        run: ./gradlew --continue --no-daemon -DforkEvery=1 -DmaxParallelForks=1 integrationTests_1500
-      - name: Package Build Artifacts
-        if: success() || failure()
-        shell: bash
-        run: |
-          mkdir ${{ github.job }}-artifacts
-          echo "Repository owner: ${{ github.repository_owner }}"
-          echo "Repository name: ${{ github.repository }}"
-          echo "event name: ${{ github.event_name }}"
-          find . -path "**/build/reports/*" -or -path "**/build/test-results/*" > artifacts.list
-          find . -type f \( -name 'core.*' -o -name 'hs_err_pid*.log' \) -exec xz -9 {} \; -exec echo "{}.xz" \; >> artifacts.list
-          rsync -R --files-from=artifacts.list . ${{ github.job }}-artifacts
-          tar -zcvf ${{ github.job }}-jdk17-logs.tar.gz ${{ github.job }}-artifacts
-      - name: Generate Fork Repo Test Reports
-        if: ${{ (github.repository_owner != 'linkedin') && (success() || failure()) }}
-        uses: dorny/test-reporter@v1.9.1
-        env:
-         NODE_OPTIONS: --max-old-space-size=9182
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          name: ${{ github.job }} Test Reports       # Name where it report the test results
-          path: '**/TEST-*.xml'
-          fail-on-error: 'false'
-          max-annotations: '10'
-          list-tests: 'all'
-          list-suites: 'all'
-          reporter: java-junit
-      - name: Publish Test Report
-        continue-on-error: true
-        env:
-          NODE_OPTIONS: "--max_old_space_size=8192"
-        uses: mikepenz/action-junit-report@v5
-        if: always()
-        with:
-          check_name: ${{ github.job }}-jdk17 Report
-          comment: false
-          annotate_only: true
-          flaky_summary: true
-          commit: ${{github.event.workflow_run.head_sha}}
-          detailed_summary: true
-          report_paths: '**/build/test-results/test/TEST-*.xml'
-      - name: Upload Build Artifacts
-        if: success() || failure()
-        uses: actions/upload-artifact@v4
-        with:
-          name: ${{ github.job }}
-          path: ${{ github.job }}-jdk17-logs.tar.gz
-          retention-days: 30
-      - name: Upload test results to BuildPulse for flaky test detection
-        if: ${{ !cancelled() }}
-        uses: buildpulse/buildpulse-action@main
-        with:
-          account: 357098
-          repository: 349172057
-          path: |
-            **/TEST-*.xml
-          key: ${{ secrets.BUILDPULSE_ACCESS_KEY_ID }}
-          secret: ${{ secrets.BUILDPULSE_SECRET_ACCESS_KEY }}
-
-  IntegrationTests_1550:
-    name: IntegrationTests_1550
-    strategy:
-      fail-fast: false
-    runs-on: ubuntu-latest
-    permissions:
-     id-token: write
-     contents: read
-     checks: write
-     pull-requests: write
-     issues: write
-    timeout-minutes: 120
-    concurrency:
-     group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-jdk17-IntegrationTests_1550
-     cancel-in-progress: ${{ github.event_name == 'pull_request' }}
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-      - name: Set up JDK
-        uses: actions/setup-java@v4
-        with:
-          java-version: 17
-          distribution: 'temurin'
-          cache: 'gradle'
-      - shell: bash
-        run: |
-          git remote set-head origin --auto
-          git remote add upstream https://github.com/linkedin/venice
-          git fetch upstream
-      - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v4
-        with:
-          add-job-summary: never
-      - name: Run Integration Tests
-        run: ./gradlew --continue --no-daemon -DforkEvery=1 -DmaxParallelForks=1 integrationTests_1550
-      - name: Package Build Artifacts
-        if: success() || failure()
-        shell: bash
-        run: |
-          mkdir ${{ github.job }}-artifacts
-          echo "Repository owner: ${{ github.repository_owner }}"
-          echo "Repository name: ${{ github.repository }}"
-          echo "event name: ${{ github.event_name }}"
-          find . -path "**/build/reports/*" -or -path "**/build/test-results/*" > artifacts.list
-          find . -type f \( -name 'core.*' -o -name 'hs_err_pid*.log' \) -exec xz -9 {} \; -exec echo "{}.xz" \; >> artifacts.list
-          rsync -R --files-from=artifacts.list . ${{ github.job }}-artifacts
-          tar -zcvf ${{ github.job }}-jdk17-logs.tar.gz ${{ github.job }}-artifacts
-      - name: Generate Fork Repo Test Reports
-        if: ${{ (github.repository_owner != 'linkedin') && (success() || failure()) }}
-        uses: dorny/test-reporter@v1.9.1
-        env:
-         NODE_OPTIONS: --max-old-space-size=9182
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          name: ${{ github.job }} Test Reports       # Name where it report the test results
-          path: '**/TEST-*.xml'
-          fail-on-error: 'false'
-          max-annotations: '10'
-          list-tests: 'all'
-          list-suites: 'all'
-          reporter: java-junit
-      - name: Publish Test Report
-        continue-on-error: true
-        env:
-          NODE_OPTIONS: "--max_old_space_size=8192"
-        uses: mikepenz/action-junit-report@v5
-        if: always()
-        with:
-          check_name: ${{ github.job }}-jdk17 Report
-          comment: false
-          annotate_only: true
-          flaky_summary: true
-          commit: ${{github.event.workflow_run.head_sha}}
-          detailed_summary: true
-          report_paths: '**/build/test-results/test/TEST-*.xml'
-      - name: Upload Build Artifacts
-        if: success() || failure()
-        uses: actions/upload-artifact@v4
-        with:
-          name: ${{ github.job }}
-          path: ${{ github.job }}-jdk17-logs.tar.gz
-          retention-days: 30
-      - name: Upload test results to BuildPulse for flaky test detection
-        if: ${{ !cancelled() }}
-        uses: buildpulse/buildpulse-action@main
-        with:
-          account: 357098
-          repository: 349172057
-          path: |
-            **/TEST-*.xml
-          key: ${{ secrets.BUILDPULSE_ACCESS_KEY_ID }}
-          secret: ${{ secrets.BUILDPULSE_SECRET_ACCESS_KEY }}
-
-  IntegrationTests_9999:
-    name: IntegrationTests_9999
-    strategy:
-      fail-fast: false
-    runs-on: ubuntu-latest
-    permissions:
-     id-token: write
-     contents: read
-     checks: write
-     pull-requests: write
-     issues: write
-    timeout-minutes: 120
-    concurrency:
-     group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-jdk17-IntegrationTests_9999
-     cancel-in-progress: ${{ github.event_name == 'pull_request' }}
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-      - name: Set up JDK
-        uses: actions/setup-java@v4
-        with:
-          java-version: 17
-          distribution: 'temurin'
-          cache: 'gradle'
-      - shell: bash
-        run: |
-          git remote set-head origin --auto
-          git remote add upstream https://github.com/linkedin/venice
-          git fetch upstream
-      - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v4
-        with:
-          add-job-summary: never
-      - name: Run Integration Tests
-        run: ./gradlew --continue --no-daemon -DforkEvery=1 -DmaxParallelForks=1 integrationTests_9999
+        run: ./gradlew --continue --no-daemon -DforkEvery=1 -DmaxParallelForks=1 integrationTests_99
       - name: Package Build Artifacts
         if: success() || failure()
         shell: bash
@@ -2933,7 +2275,7 @@ jobs:
     strategy:
       fail-fast: false
     runs-on: ubuntu-latest
-    needs: [IntegrationTests_1000, IntegrationTests_1010, IntegrationTests_1020, IntegrationTests_1030, IntegrationTests_1040, IntegrationTests_1050, IntegrationTests_1060, IntegrationTests_1070, IntegrationTests_1080, IntegrationTests_1090, IntegrationTests_1100, IntegrationTests_1110, IntegrationTests_1120, IntegrationTests_1130, IntegrationTests_1200, IntegrationTests_1210, IntegrationTests_1220, IntegrationTests_1230, IntegrationTests_1240, IntegrationTests_1250, IntegrationTests_1260, IntegrationTests_1270, IntegrationTests_1280, IntegrationTests_1400, IntegrationTests_1410, IntegrationTests_1420, IntegrationTests_1430, IntegrationTests_1440, IntegrationTests_1500, IntegrationTests_1550, IntegrationTests_9999]
+    needs: [IntegrationTests_1, IntegrationTests_2, IntegrationTests_3, IntegrationTests_4, IntegrationTests_5, IntegrationTests_6, IntegrationTests_7, IntegrationTests_8, IntegrationTests_9, IntegrationTests_10, IntegrationTests_11, IntegrationTests_12, IntegrationTests_13, IntegrationTests_14, IntegrationTests_15, IntegrationTests_16, IntegrationTests_17, IntegrationTests_18, IntegrationTests_19, IntegrationTests_20, IntegrationTests_21, IntegrationTests_22, IntegrationTests_23, integrationTests_99]
     timeout-minutes: 20
     if: ${{ cancelled() || contains(needs.*.result, 'cancelled') || contains(needs.*.result, 'failure') }}
     steps:

--- a/internal/venice-test-common/build.gradle
+++ b/internal/venice-test-common/build.gradle
@@ -214,11 +214,9 @@ def integrationTestBuckets = [
     ],
     "14": [
         "com.linkedin.venice.pubsub.manager.TopicManagerE2ETest",
-        "com.linkedin.venice.endToEnd.DataRecoveryTest",
         "com.linkedin.venice.helixrebalance.LeaderFollowerThreadPoolTest",
         "com.linkedin.venice.ingestionHeartbeat.IngestionHeartBeatTest",
         "com.linkedin.venice.endToEnd.TestPartialUpdateWithActiveActiveReplication",
-        "com.linkedin.venice.endToEnd.StoragePersonaTest",
         "com.linkedin.venice.controller.kafka.consumer.AdminConsumptionTaskIntegrationTest",
         "com.linkedin.venice.helix.TestHelixReadOnlyStorageEngineRepository",
         "com.linkedin.venice.helix.TestHelixReadWriteStorageEngineRepository"
@@ -252,7 +250,6 @@ def integrationTestBuckets = [
     "17": [
         "com.linkedin.venice.endToEnd.TestProducerBatching",
         "com.linkedin.venice.hadoop.TestVenicePushJob",
-        "com.linkedin.venice.endToEnd.TestEmptyPush",
         "com.linkedin.venice.router.TestRouterRetry",
         "com.linkedin.venice.endToEnd.TestBatchReportIncrementalPush",
         "com.linkedin.venice.multicluster.TestMetadataOperationInMultiCluster",
@@ -260,7 +257,6 @@ def integrationTestBuckets = [
         "com.linkedin.venice.endToEnd.ParticipantStoreTest",
         "com.linkedin.venice.endToEnd.DaVinciClientDiskFullTest",
         "com.linkedin.venice.endToEnd.TestVsonStoreBatch",
-        "com.linkedin.venice.endToEnd.SystemStoreMultiColoTest",
         "com.linkedin.venice.restart.TestRestartController",
         "com.linkedin.venice.endToEnd.TestPushJobWithSourceGridFabricSelection",
         "com.linkedin.venice.endToEnd.NearlineE2ELatencyTest",
@@ -308,8 +304,6 @@ def integrationTestBuckets = [
         "com.linkedin.venice.endToEnd.TestHelixCustomizedView"
     ],
     "20": [
-        "com.linkedin.venice.endToEnd.CheckSumTest",
-        "com.linkedin.venice.endToEnd.TestStuckConsumerRepair",
         "com.linkedin.venice.controller.TestClusterLevelConfigForActiveActiveReplication",
         "com.linkedin.venice.helix.TestControllerKMERegistrationFromMessageHeader",
         "com.linkedin.venice.controller.TestAdminOperationVersionDetection",
@@ -345,6 +339,8 @@ def integrationTestBuckets = [
         "com.linkedin.venice.helix.TestHelixReadWriteStoreRepositoryAdapter"
     ],
     "21": [
+        "com.linkedin.venice.endToEnd.StoragePersonaTest",
+        "com.linkedin.venice.endToEnd.DataRecoveryTest",
         "com.linkedin.venice.endToEnd.RocksDBPlainTableTest",
         "com.linkedin.venice.endToEnd.TestFatalDataValidationExceptionHandling",
         "com.linkedin.venice.endToEnd.TestControllerGrpcEndpoints",
@@ -382,6 +378,10 @@ def integrationTestBuckets = [
         "com.linkedin.venice.consumer.BootstrappingChangelogConsumerTest"
     ],
     "23": [
+        "com.linkedin.venice.endToEnd.TestEmptyPush",
+        "com.linkedin.venice.endToEnd.SystemStoreMultiColoTest",
+        "com.linkedin.venice.endToEnd.CheckSumTest",
+        "com.linkedin.venice.endToEnd.TestStuckConsumerRepair",
         "com.linkedin.venice.fastclient.FastClientGrpcServerReadQuotaTest",
         "com.linkedin.venice.fastclient.StoreOverloadTest",
         "com.linkedin.venice.fastclient.meta.RequestBasedMetadataIntegrationTest",

--- a/internal/venice-test-common/build.gradle
+++ b/internal/venice-test-common/build.gradle
@@ -135,103 +135,262 @@ def integrationTestConfigs = {
 }
 
 def integrationTestBuckets = [
-  "1000": [
-      "com.linkedin.davinci.*",
-      "com.linkedin.venice.endToEnd.DaVinciClientDiskFullTest",
-      "com.linkedin.venice.endToEnd.DaVinciClientMemoryLimitTest",
-      "com.linkedin.venice.endToEnd.DaVinciClientRecordTransformerTest"],
-  "1010": [
-       "com.linkedin.venice.endToEnd.DaVinciClientTest"],
-  "1020": [
-      "com.linkedin.venice.endToEnd.DaVinciCluster*",
-      "com.linkedin.venice.endToEnd.DaVinciCompute*",
-      "com.linkedin.venice.endToEnd.DaVinciLive*"],
-  "1030": [
-      "com.linkedin.venice.consumer.*"],
-  "1040": [
-      "com.linkedin.venice.endToEnd.ActiveActive*"],
-  "1050": [
-      "com.linkedin.venice.endToEnd.TestActiveActive*"],
-  "1060": [
-      "com.linkedin.venice.helix.*",
-      "com.linkedin.venice.helixrebalance.*"],
-  "1070": [
-      "com.linkedin.venice.fastclient.*"],
-  "1080": [
-      "com.linkedin.venice.endToEnd.TestEmptyPush",
-      "com.linkedin.venice.ingestionHeartbeat.*"],
-  "1090": [
-      "com.linkedin.venice.router.*"
-        ],
-  "1100": [
-      "com.linkedin.venice.server.*"],
-  "1110": [
-      "com.linkedin.venice.restart.*"],
-  "1120": [
-      "com.linkedin.venice.storagenode.*"],
-  "1130": [
-      "com.linkedin.venice.endToEnd.TestStoreMigration",
-      "com.linkedin.venice.endToEnd.TestStuckConsumerRepair",
-      "com.linkedin.venice.endToEnd.TestSuperSetSchemaRegistration",
-      "com.linkedin.venice.endToEnd.TestTopicWiseSharedConsumerPoolResilience",
-      "com.linkedin.venice.endToEnd.TestUnusedValueSchemaCleanup",
-      "com.linkedin.venice.endToEnd.BlobP2PTransferAmongServersTest"],
-  "1200":[
-      "com.linkedin.venice.endToEnd.TestVson*",
-      "com.linkedin.venice.endToEnd.Push*"],
-  "1210": [
-      "com.linkedin.venice.hadoop.*"],
-  "1220": [
-      "com.linkedin.venice.endToEnd.TestPushJob*"],
-  "1230": [
-      "com.linkedin.venice.endToEnd.TestBatch*"],
-  "1240": [
-      "com.linkedin.venice.kafka.*",
-      "com.linkedin.venice.samza.*",
-      "com.linkedin.venice.writer.*"],
-  "1250": [
-      "com.linkedin.venice.endToEnd.PartialUpdateTest", "com.linkedin.venice.endToEnd.PartialUpdateWithHeartbeatReadyToServeCheckTest"],
-  "1260": [
-      "com.linkedin.venice.endToEnd.PartialUpdateWithParallelProcessingTest"],
-  "1270": [
-      "com.linkedin.venice.endToEnd.TestWritePathComputation",
-      "com.linkedin.venice.endToEnd.WriteComputeWithActiveActiveReplicationTest",
-      "com.linkedin.venice.endToEnd.StoragePersona*",
-      "com.linkedin.venice.endToEnd.TestStoreUpdateStoragePersona",
-      "com.linkedin.venice.persona.*"],
-  "1280": [
-      "com.linkedin.venice.pubsub.*"],
-  "1400": [
-      "com.linkedin.venice.endToEnd.TestHybrid*"],
-  "1410": [
-      "com.linkedin.venice.controller.server.*",
-      "com.linkedin.venice.controller.kafka.consumer.*",
-      "com.linkedin.venice.controller.migration.*"],
-  "1420": [
-      "com.linkedin.venice.controller.AdminTool*",
-      "com.linkedin.venice.controller.VeniceParentHelixAdminTest"],
-  "1430": [
-      "com.linkedin.venice.controller.Test*"],
-  "1440": [
-      "com.linkedin.venice.endToEnd.DataRecoveryTest",
-      "com.linkedin.venice.controllerapi.TestControllerClient",
-      "com.linkedin.venice.endToEnd.TestAdminOperationWithPreviousVersion",
-      "com.linkedin.venice.endToEnd.TestMaterializedViewEndToEnd",
-      "com.linkedin.venice.endToEnd.TestDeferredVersionSwap*",
-  ],
-  "1500":[
-      "com.linkedin.venice.multicluster.TestMetadataOperationInMultiCluster",
-      "com.linkedin.venice.endToEnd.MetaSystemStoreTest",
-      "com.linkedin.venice.zk.TestMigrateVeniceZKPaths",
-      "com.linkedin.venice.throttle.TestRouterReadQuotaThrottler"],
-  "1550": [
-        "com.linkedin.venice.stats.TestZkClientStatusStats",
+    "1": [
+        "com.linkedin.venice.endToEnd.PartialUpdateWithHeartbeatReadyToServeCheckTest"
+    ],
+    "2": [
+        "com.linkedin.venice.endToEnd.PartialUpdateTest"
+    ],
+    "3": [
+        "com.linkedin.venice.endToEnd.PartialUpdateWithParallelProcessingTest",
+        "com.linkedin.venice.client.store.TestD2ServiceDiscovery"
+    ],
+    "4": [
+        "com.linkedin.venice.endToEnd.TestDeferredVersionSwap",
+        "com.linkedin.venice.helix.ZkRoutersClusterManagerTest",
+        "com.linkedin.venice.pubsub.adapter.kafka.consumer.ApacheKafkaConsumerTest",
+        "com.linkedin.venice.helix.TestHelixReadOnlyZKSharedSystemStoreRepository"
+    ],
+    "5": [
+        "com.linkedin.venice.endToEnd.DaVinciClientSubscribeTest",
+        "com.linkedin.venice.endToEnd.DaVinciClientRecordTransformerTest",
+        "com.linkedin.venice.router.TestRouterAsyncStart"
+    ],
+    "6": [
+        "com.linkedin.venice.endToEnd.DaVinciClientP2PBlobTransferTest",
+        "com.linkedin.venice.controller.VeniceParentHelixAdminTest",
+        "com.linkedin.venice.controller.TestParentControllerWithMultiDataCenter",
+        "com.linkedin.venice.integration.utils.SystemExitPrevention"
+    ],
+    "7": [
+        "com.linkedin.venice.endToEnd.PushJobDetailsTest",
+        "com.linkedin.venice.endToEnd.DaVinciClientIsolatedAndHybridStoreTest",
+        "com.linkedin.venice.consumer.TestChangelogConsumerWithParallelProcessing",
+        "com.linkedin.venice.kafka.KafkaConsumptionTest"
+    ],
+    "8": [
+        "com.linkedin.venice.endToEnd.PushStatusStoreTest",
+        "com.linkedin.venice.consumer.TestChangelogConsumer",
+        "com.linkedin.venice.endToEnd.TestPushJobWithNativeReplication",
+        "com.linkedin.venice.zk.TestMigrateVeniceZKPaths"
+    ],
+    "9": [
+        "com.linkedin.venice.endToEnd.TestDeferredVersionSwapWithFailingRegions",
+        "com.linkedin.venice.endToEnd.TestStoreMigration",
+        "com.linkedin.venice.controller.TestVeniceHelixAdminWithIsolatedEnvironment",
+        "com.linkedin.venice.helix.TestHelixExternalViewRepository",
+        "com.linkedin.venice.fastclient.BatchGetAvroStoreClientTest"
+    ],
+    "10": [
+        "com.linkedin.venice.endToEnd.TestHybridQuota",
+        "com.linkedin.venice.endToEnd.TestAdminOperationWithPreviousVersion",
+        "com.linkedin.venice.endToEnd.ActiveActiveReplicationForHybridTest",
+        "com.linkedin.venice.endToEnd.TestMultiDataCenterAdminOperations",
+        "com.linkedin.venice.router.api.TestHostFinder"
+    ],
+    "11": [
+        "com.linkedin.venice.endToEnd.DaVinciClientMemoryLimitTest",
+        "com.linkedin.venice.endToEnd.TestHybrid",
+        "com.linkedin.venice.controller.server.TestAdminSparkServer",
+        "com.linkedin.venice.controller.TestDelayedRebalance",
+        "com.linkedin.venice.client.store.TestSslTransportClient",
+        "com.linkedin.venice.helix.TestHelixReadOnlyStoreRepositoryAdapter"
+    ],
+    "12": [
+        "com.linkedin.venice.endToEnd.DaVinciClientTest",
+        "com.linkedin.venice.endToEnd.TestBatchForRocksDB",
+        "com.linkedin.venice.controller.TestHAASController",
+        "com.linkedin.venice.server.VeniceServerTest",
+        "com.linkedin.venice.endToEnd.TestTopicWiseSharedConsumerPoolResilience"
+    ],
+    "13": [
+        "com.linkedin.venice.endToEnd.DaVinciComputeTest",
+        "com.linkedin.venice.endToEnd.TestMaterializedViewEndToEnd",
+        "com.linkedin.venice.endToEnd.TestActiveActiveIngestion",
+        "com.linkedin.venice.endToEnd.TestActiveActiveIngestionWithReadWriteLeaderCompactionTuningAndParallelProcessing",
+        "com.linkedin.venice.pubsub.api.admin.PubSubAdminAdapterTest",
+        "com.linkedin.venice.router.ReplicaFailoverTest",
+        "com.linkedin.venice.helix.ZkStoreConfigAccessorTest"
+    ],
+    "14": [
+        "com.linkedin.venice.pubsub.manager.TopicManagerE2ETest",
+        "com.linkedin.venice.endToEnd.DataRecoveryTest",
+        "com.linkedin.venice.helixrebalance.LeaderFollowerThreadPoolTest",
+        "com.linkedin.venice.ingestionHeartbeat.IngestionHeartBeatTest",
+        "com.linkedin.venice.endToEnd.TestPartialUpdateWithActiveActiveReplication",
+        "com.linkedin.venice.endToEnd.StoragePersonaTest",
+        "com.linkedin.venice.controller.kafka.consumer.AdminConsumptionTaskIntegrationTest",
+        "com.linkedin.venice.helix.TestHelixReadOnlyStorageEngineRepository",
+        "com.linkedin.venice.helix.TestHelixReadWriteStorageEngineRepository"
+    ],
+    "15": [
+        "com.linkedin.venice.endToEnd.DaVinciClusterAgnosticTest",
+        "com.linkedin.venice.controllerapi.TestControllerClient",
+        "com.linkedin.venice.pubsub.api.consumer.PubSubConsumerAdapterTest",
+        "com.linkedin.venice.endToEnd.TestActiveActiveReplicationForIncPush",
+        "com.linkedin.venice.controller.TestHybridStoreRepartitioningWithMultiDataCenter",
+        "com.linkedin.venice.endToEnd.TestStoreMigrationMultiRegion",
+        "com.linkedin.venice.restart.TestRestartServerAfterDeletingSstFilesWithActiveActiveIngestion",
+        "com.linkedin.venice.endToEnd.MetaSystemStoreTest",
+        "com.linkedin.venice.helix.StoragePersonaRepositoryTest",
+        "com.linkedin.venice.pubsub.adapter.kafka.producer.ApacheKafkaProducerAdapterITest"
+    ],
+    "16": [
+        "com.linkedin.venice.endToEnd.BlobP2PTransferAmongServersTest",
+        "com.linkedin.venice.endToEnd.TestDaVinciRequestBasedMetaRepository",
+        "com.linkedin.venice.endToEnd.TestStoreUpdateStoragePersona",
+        "com.linkedin.venice.controller.TestInstanceRemovable",
+        "com.linkedin.venice.endToEnd.DaVinciLiveUpdateSuppressionTest",
+        "com.linkedin.venice.fastclient.AvroStoreClientEndToEndTest",
+        "com.linkedin.venice.endToEnd.TestDeferredVersionSwapWithoutTargetedRegionPush",
+        "com.linkedin.venice.controller.AdminToolE2ETest",
+        "com.linkedin.venice.router.TestStreaming",
+        "com.linkedin.venice.endToEnd.TestSeparateRealtimeTopicIngestion",
+        "com.linkedin.venice.fastclient.AvroStoreClientZstdEndToEndTest",
+        "com.linkedin.venice.persona.StoragePersonaAccessorTest"
+    ],
+    "17": [
+        "com.linkedin.venice.endToEnd.TestProducerBatching",
+        "com.linkedin.venice.hadoop.TestVenicePushJob",
+        "com.linkedin.venice.endToEnd.TestEmptyPush",
+        "com.linkedin.venice.router.TestRouterRetry",
+        "com.linkedin.venice.endToEnd.TestBatchReportIncrementalPush",
         "com.linkedin.venice.multicluster.TestMetadataOperationInMultiCluster",
-        "com.linkedin.venice.integration.utils.SystemExitPrevention",
-        "com.linkedin.venice.integration.StorageNodeServiceTest",
-        "com.linkedin.venice.endToEnd.TestStoreGraveyardCleanupService",
+        "com.linkedin.venice.endToEnd.TestMultiDatacenterVenicePushJob",
+        "com.linkedin.venice.endToEnd.ParticipantStoreTest",
+        "com.linkedin.venice.endToEnd.DaVinciClientDiskFullTest",
+        "com.linkedin.venice.endToEnd.TestVsonStoreBatch",
+        "com.linkedin.venice.endToEnd.SystemStoreMultiColoTest",
+        "com.linkedin.venice.restart.TestRestartController",
+        "com.linkedin.venice.endToEnd.TestPushJobWithSourceGridFabricSelection",
+        "com.linkedin.venice.endToEnd.NearlineE2ELatencyTest",
+        "com.linkedin.venice.fastclient.grpc.VeniceGrpcEndToEndTest"
+    ],
+    "18": [
+        "com.linkedin.venice.router.TestBlobDiscovery",
+        "com.linkedin.venice.helix.TestHelixCustomizedViewOfflinePushRepository",
+        "com.linkedin.venice.restart.TestRestartRouter",
+        "com.linkedin.venice.controller.TestEnablingSSLPushInVeniceHelixAdminWithIsolatedEnvironment",
+        "com.linkedin.venice.endToEnd.TestWritePathComputation",
+        "com.linkedin.venice.endToEnd.TestDumpIngestionContext",
+        "com.linkedin.venice.controller.TestAdminToolEndToEnd",
+        "com.linkedin.venice.endToEnd.TestPushJobWithEmergencySourceRegionSelection",
+        "com.linkedin.venice.controller.TestVeniceHelixAdminWithSharedEnvironment",
+        "com.linkedin.venice.endToEnd.TestPushJobVersionCleanup",
+        "com.linkedin.venice.controller.TestTopicRequestOnHybridDelete",
+        "com.linkedin.venice.endToEnd.TestStaleDataVisibility",
+        "com.linkedin.venice.writer.VeniceWriterTest",
+        "com.linkedin.venice.endToEnd.OneTouchDataRecoveryTest",
+        "com.linkedin.venice.helix.TestHelixStatusMessageChannel",
+        "com.linkedin.venice.samza.VeniceSystemFactoryTest",
+        "com.linkedin.venice.kafka.EndToEndKafkaWithSASLTest",
+        "com.linkedin.venice.router.TestReadForHttpClient5"
+    ],
+    "19": [
+        "com.linkedin.venice.endToEnd.TestActiveActiveReplicationWithDelayedLeaderPromotion",
+        "com.linkedin.venice.storagenode.ReadComputeValidationTest",
+        "com.linkedin.venice.restart.TestRestartServerWithChecksumVerification",
+        "com.linkedin.venice.endToEnd.StoreMetadataRecoveryTest",
+        "com.linkedin.venice.controller.TestClusterLevelConfigForNativeReplication",
+        "com.linkedin.venice.pubsub.manager.TopicManagerIntegrationTest",
+        "com.linkedin.venice.controller.TestTopicRequestOnHybridDeleteWithHMC",
+        "com.linkedin.venice.restart.TestRestartServerDuringIngestionForRocksDB",
+        "com.linkedin.venice.helix.HelixPartitionPushStatusAccessorTest",
+        "com.linkedin.venice.endToEnd.TestHybridMultiRegion",
+        "com.linkedin.venice.endToEnd.PartialUpdateClusterConfigTest",
         "com.linkedin.venice.endToEnd.TestStoreBackupVersionDeletion",
-        "com.linkedin.venice.endToEnd.TestStaleDataVisibility"]
+        "com.linkedin.venice.kafka.ssl.AdminChannelWithSSLTest",
+        "com.linkedin.venice.endToEnd.TestStoreGraveyardCleanupService",
+        "com.linkedin.venice.controller.server.TestAdminSparkServerWithMultiServers",
+        "com.linkedin.venice.endToEnd.TestUnusedValueSchemaCleanup",
+        "com.linkedin.venice.helixrebalance.TestRebalanceByDefaultStrategy",
+        "com.linkedin.venice.storagenode.StorageNodeComputeTest",
+        "com.linkedin.venice.endToEnd.TestHelixCustomizedView"
+    ],
+    "20": [
+        "com.linkedin.venice.endToEnd.CheckSumTest",
+        "com.linkedin.venice.endToEnd.TestStuckConsumerRepair",
+        "com.linkedin.venice.controller.TestClusterLevelConfigForActiveActiveReplication",
+        "com.linkedin.venice.helix.TestControllerKMERegistrationFromMessageHeader",
+        "com.linkedin.venice.controller.TestAdminOperationVersionDetection",
+        "com.linkedin.venice.controller.TestIncrementalPush",
+        "com.linkedin.venice.router.TestReadForApacheAsyncClient",
+        "com.linkedin.venice.kafka.ssl.TestProduceWithSSL",
+        "com.linkedin.venice.storagenode.StorageNodeReadTest",
+        "com.linkedin.venice.endToEnd.TestGlobalRtDiv",
+        "com.linkedin.venice.consumer.ConsumerIntegrationTestWithSchemaReader",
+        "com.linkedin.venice.endToEnd.TestHybridStoreDeletion",
+        "com.linkedin.venice.restart.TestRestartServerAfterDeletingSstFiles",
+        "com.linkedin.venice.endToEnd.TestBackupVersionDatabaseOptimization",
+        "com.linkedin.venice.endToEnd.TestLeaderReplicaFailover",
+        "com.linkedin.venice.endToEnd.TestProtocolVersionAutoDetection",
+        "com.linkedin.venice.controller.server.TestBackupControllerResponse",
+        "com.linkedin.venice.endToEnd.TestSuperSetSchemaRegistration",
+        "com.linkedin.venice.endToEnd.TestServerStorePropertiesEndpoint",
+        "com.linkedin.davinci.ingestion.IsolatedIngestionServerTest",
+        "com.linkedin.venice.controller.TestHolisticSeverHealthCheck",
+        "com.linkedin.venice.consumer.ConsumerIntegrationTestWithProtocolHeader",
+        "com.linkedin.venice.controller.TestStartMultiControllers",
+        "com.linkedin.venice.restart.TestRestartServer",
+        "com.linkedin.venice.controller.TestDeleteStoreDeletesRealtimeTopic",
+        "com.linkedin.venice.router.TestRouter",
+        "com.linkedin.venice.router.TestConnectionWarmingForApacheAsyncClient",
+        "com.linkedin.venice.throttle.TestRouterReadQuotaThrottler",
+        "com.linkedin.venice.endToEnd.ParentControllerMetadataSystemStoreTest",
+        "com.linkedin.venice.router.TestRetryQuotaRejection",
+        "com.linkedin.venice.endToEnd.TestRocksDBOffsetStore",
+        "com.linkedin.venice.controller.server.TestAdminSparkServerAcl",
+        "com.linkedin.venice.storagenode.TestEarlyTermination",
+        "com.linkedin.venice.client.store.AvroSpecificStoreClientImplTest",
+        "com.linkedin.venice.helix.TestHelixReadWriteStoreRepositoryAdapter"
+    ],
+    "21": [
+        "com.linkedin.venice.endToEnd.RocksDBPlainTableTest",
+        "com.linkedin.venice.endToEnd.TestFatalDataValidationExceptionHandling",
+        "com.linkedin.venice.endToEnd.TestControllerGrpcEndpoints",
+        "com.linkedin.venice.client.store.AvroGenericStoreClientImplTest",
+        "com.linkedin.venice.integration.StorageNodeServiceTest",
+        "com.linkedin.venice.helix.TestServerKMERegistrationFromMessageHeader",
+        "com.linkedin.venice.controller.TestD2ControllerClient",
+        "com.linkedin.venice.controller.TestControllerEnforceSSL",
+        "com.linkedin.venice.controller.server.TestAdminSparkServerGetLeader",
+        "com.linkedin.venice.helix.TestHelixReadOnlySchemaRepository",
+        "com.linkedin.venice.hadoop.input.kafka.TestKafkaInputRecordReader",
+        "com.linkedin.venice.helix.TestHelixReadWriteSchemaRepository",
+        "com.linkedin.venice.controller.TestVeniceHelixResources",
+        "com.linkedin.venice.hadoop.input.kafka.TestKafkaInputFormat",
+        "com.linkedin.venice.router.api.TestVeniceDispatcher",
+        "com.linkedin.venice.helix.HelixLiveInstanceMonitorIntegrationTest",
+        "com.linkedin.venice.router.api.TestRouterHeartbeat",
+        "com.linkedin.venice.stats.TestZkClientStatusStats",
+        "com.linkedin.venice.helix.ControllerInstanceTagRefresherTest",
+        "com.linkedin.venice.helix.HelixOfflinePushMonitorAccessorTest",
+        "com.linkedin.venice.controller.server.TestAdminSparkWithMocks",
+        "com.linkedin.venice.helix.CachedResourceZKStateListenerTest",
+        "com.linkedin.venice.controller.TestControllerSecureGrpcServer",
+        "com.linkedin.venice.helix.TestHelixReadOnlyLiveClusterConfigRepository",
+        "com.linkedin.venice.helix.HelixStoreGraveyardTest",
+        "com.linkedin.venice.helix.TestHelixReadWriteLiveClusterConfigRepository",
+        "com.linkedin.venice.helix.ZkAllowlistAccessorTest",
+        "com.linkedin.venice.controller.multitaskscheduler.StoreMigrationManagerIntegrationTest",
+        "com.linkedin.venice.consumer.ConsumerTest",
+        "com.linkedin.venice.controller.TestZkExecutionIdAccessor",
+        "com.linkedin.venice.controller.migration.TestMigrationPushStrategyZKAccessor",
+        "com.linkedin.venice.helix.StoragePersonaStoreDataListenerTest"
+    ],
+    "22": [
+        "com.linkedin.venice.consumer.BootstrappingChangelogConsumerTest"
+    ],
+    "23": [
+        "com.linkedin.venice.fastclient.FastClientGrpcServerReadQuotaTest",
+        "com.linkedin.venice.fastclient.StoreOverloadTest",
+        "com.linkedin.venice.fastclient.meta.RequestBasedMetadataIntegrationTest",
+        "com.linkedin.venice.fastclient.BatchGetAvroStoreClientZstdTest",
+        "com.linkedin.venice.fastclient.BatchGetAvroStoreClientGzipTest",
+        "com.linkedin.venice.fastclient.FastClientIndividualFeatureConfigurationTest",
+        "com.linkedin.venice.fastclient.FastClientDaVinciClientCompatTest",
+        "com.linkedin.venice.fastclient.AvroStoreClientGzipEndToEndTest",
+    ],
 ]
 
 integrationTestBuckets.each { name, patterns ->
@@ -260,7 +419,7 @@ integrationTestBuckets.each { name, patterns ->
   }
 }
 
-task integrationTests_9999(type: Test) {
+task integrationTests_99(type: Test) {
   ext {
     suiteStartTime = 0
   }
@@ -316,13 +475,14 @@ task generateGHCI() {
   def common = "--continue --no-daemon "
 
   def integTestGradleArgs = common + "-DforkEvery=1 -DmaxParallelForks=1 integrationTests_"
+  def integrationTestTimeout = 30 // minutes
   integrationTestBuckets.each { name, patterns ->
     def flowName = "IntegrationTests_" + name
     jobs << flowName
-    appendToGHCI(paramFileContent, targetFilePath, flowName, 120, integTestGradleArgs + name)
+    appendToGHCI(paramFileContent, targetFilePath, flowName, integrationTestTimeout, integTestGradleArgs + name)
   }
-  def otherTest = "IntegrationTests_9999"
-  appendToGHCI(paramFileContent, targetFilePath, otherTest, 120, integTestGradleArgs + "9999")
+  def otherTest = "integrationTests_99"
+  appendToGHCI(paramFileContent, targetFilePath, otherTest, integrationTestTimeout, integTestGradleArgs + "99")
   jobs << otherTest
 
   // define a job that depends others to manage the status check


### PR DESCRIPTION
## [build][ci] Remap E2E test buckets to lower overall CI runtime  

- Rebalanced E2E test buckets to distribute load evenly and reduce total CI runtime  
- Reduced per-bucket timeout from 120 mins to 30 mins, which will force developers  
  to adjust buckets when changes impact runtime and prevent test accumulation that  
  can make CI slow and unpredictable  

###  Code changes
- [ ] Added new code behind **a config**. If so list the config names and their default values in the PR description.
- [ ] Introduced new **log lines**. 
  - [ ] Confirmed if logs need to be **rate limited** to avoid excessive logging.

###  **Concurrency-Specific Checks**
Both reviewer and PR author to verify
- [ ] Code has **no race conditions** or **thread safety issues**.
- [ ] Proper **synchronization mechanisms** (e.g., `synchronized`, `RWLock`) are used where needed.
- [ ] No **blocking calls** inside critical sections that could lead to deadlocks or performance degradation.
- [ ] Verified **thread-safe collections** are used (e.g., `ConcurrentHashMap`, `CopyOnWriteArrayList`).
- [ ] Validated proper exception handling in multi-threaded code to avoid silent thread termination.


## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->

- [ ] New unit tests added.
- [ ] New integration tests added.
- [ ] Modified or extended existing tests.
- [ ] Verified backward compatibility (if applicable).

## Does this PR introduce any user-facing or breaking changes?
<!--  
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [ ] No. You can skip the rest of this section.
- [ ] Yes. Clearly explain the behavior change and its impact.