### PR TITLE
[controller] Separate cluster discovery and d2 service discovery for VeniceHelixAdmin

### DIFF
--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/Admin.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/Admin.java
@@ -669,7 +669,12 @@ public interface Admin extends AutoCloseable, Closeable {
    *
    * @throws com.linkedin.venice.exceptions.VeniceException if not cluster is found.
    */
-  Pair<String, String> discoverCluster(String storeName);
+  String discoverCluster(String storeName);
+
+  /**
+   * Find the router d2 service associated with a given cluster name.
+   */
+  String getRouterD2Service(String clusterName);
 
   /**
    * Find the server d2 service associated with a given cluster name.

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceHelixAdmin.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceHelixAdmin.java
@@ -1539,7 +1539,7 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
     Validate.notNull(key);
     ConcurrencyUtils.executeUnderConditionalLock(() -> {
       String storeName = VeniceSystemStoreUtils.getPushJobDetailsStoreName();
-      String d2Service = discoverCluster(storeName).getSecond();
+      String d2Service = getRouterD2Service(discoverCluster(storeName));
       pushJobDetailsStoreClient = ClientFactory.getAndStartSpecificAvroClient(
           ClientConfig.defaultSpecificClientConfig(storeName, PushJobDetails.class)
               .setD2ServiceName(d2Service)
@@ -1560,7 +1560,7 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
     Validate.notNull(batchJobHeartbeatKey);
     ConcurrencyUtils.executeUnderConditionalLock(() -> {
       String storeName = VeniceSystemStoreType.BATCH_JOB_HEARTBEAT_STORE.getPrefix();
-      String d2Service = discoverCluster(storeName).getSecond();
+      String d2Service = getRouterD2Service(discoverCluster(storeName));
       livenessHeartbeatStoreClient = ClientFactory.getAndStartSpecificAvroClient(
           ClientConfig.defaultSpecificClientConfig(storeName, BatchJobHeartbeatValue.class)
               .setD2ServiceName(d2Service)
@@ -2031,7 +2031,7 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
      * Force update cluster discovery so that it will always point to the source cluster.
      * Whichever cluster it currently belongs to do not matter.
      */
-    String clusterDiscovered = this.discoverCluster(storeName).getFirst();
+    String clusterDiscovered = this.discoverCluster(storeName);
     this.updateClusterDiscovery(storeName, clusterDiscovered, srcClusterName, srcClusterName);
   }
 
@@ -5063,7 +5063,7 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
   @Override
   public StoreMetaValue getMetaStoreValue(StoreMetaKey metaKey, String storeName) {
     String metaStoreName = VeniceSystemStoreType.META_STORE.getSystemStoreName(storeName);
-    String d2Service = discoverCluster(storeName).getSecond();
+    String d2Service = getRouterD2Service(discoverCluster(storeName));
 
     try (AvroSpecificStoreClient<StoreMetaKey, StoreMetaValue> client = ClientFactory.getAndStartSpecificAvroClient(
         ClientConfig.defaultSpecificClientConfig(metaStoreName, StoreMetaValue.class)
@@ -8084,7 +8084,7 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
    * @see Admin#discoverCluster(String)
    */
   @Override
-  public Pair<String, String> discoverCluster(String storeName) {
+  public String discoverCluster(String storeName) {
     StoreConfig config = storeConfigRepo.getStoreConfigOrThrow(storeName);
     if (config == null || StringUtils.isEmpty(config.getCluster())) {
       throw new VeniceNoStoreException(
@@ -8092,12 +8092,20 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
           null,
           "Make sure the store is created and the provided store name is correct");
     }
-    String clusterName = config.getCluster();
+    return config.getCluster();
+  }
+
+  /**
+   * @see Admin#getRouterD2Service(String)
+   */
+  @Override
+  public String getRouterD2Service(String clusterName) {
     String d2Service = multiClusterConfigs.getClusterToD2Map().get(clusterName);
     if (d2Service == null) {
       throw new VeniceException("Could not find d2 service by given cluster: " + clusterName);
     }
-    return new Pair<>(clusterName, d2Service);
+
+    return d2Service;
   }
 
   /**

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceParentHelixAdmin.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceParentHelixAdmin.java
@@ -4849,8 +4849,16 @@ public class VeniceParentHelixAdmin implements Admin {
    * @see Admin#discoverCluster(String)
    */
   @Override
-  public Pair<String, String> discoverCluster(String storeName) {
+  public String discoverCluster(String storeName) {
     return getVeniceHelixAdmin().discoverCluster(storeName);
+  }
+
+  /**
+   * @see Admin#getRouterD2Service(String)
+   */
+  @Override
+  public String getRouterD2Service(String clusterName) {
+    return getVeniceHelixAdmin().getRouterD2Service(clusterName);
   }
 
   /**

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/init/SystemSchemaInitializationRoutine.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/init/SystemSchemaInitializationRoutine.java
@@ -14,7 +14,6 @@ import com.linkedin.venice.schema.SchemaEntry;
 import com.linkedin.venice.schema.avro.DirectionalSchemaCompatibilityType;
 import com.linkedin.venice.schema.writecompute.WriteComputeSchemaConverter;
 import com.linkedin.venice.serialization.avro.AvroProtocolDefinition;
-import com.linkedin.venice.utils.Pair;
 import com.linkedin.venice.utils.Utils;
 import java.util.Collection;
 import java.util.HashMap;
@@ -70,8 +69,7 @@ public class SystemSchemaInitializationRoutine implements ClusterLeaderInitializ
 
       // Sanity check to make sure the store is not already created in another cluster.
       try {
-        Pair<String, String> clusterNameAndD2 = admin.discoverCluster(systemStoreName);
-        String currSystemStoreCluster = clusterNameAndD2.getFirst();
+        String currSystemStoreCluster = admin.discoverCluster(systemStoreName);
         if (!currSystemStoreCluster.equals(intendedCluster)) {
           LOGGER.warn(
               "The system store for '{}' already exists in cluster '{}', "

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/kafka/TopicCleanupService.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/kafka/TopicCleanupService.java
@@ -239,7 +239,7 @@ public class TopicCleanupService extends AbstractVeniceService {
       String storeName = topic.getStoreName();
       String clusterDiscovered;
       try {
-        clusterDiscovered = admin.discoverCluster(storeName).getFirst();
+        clusterDiscovered = admin.discoverCluster(storeName);
       } catch (VeniceNoStoreException e) {
         LOGGER.warn(
             "Expected store: {} not found corresponding to topic: {} in Venice. Will delete the topic without running any safety checks. Error: {}",
@@ -438,7 +438,7 @@ public class TopicCleanupService extends AbstractVeniceService {
             LOGGER.error("Skip dangling admin topic {}.", pubSubTopic);
             continue;
           }
-          String clusterDiscovered = admin.discoverCluster(storeName).getFirst();
+          String clusterDiscovered = admin.discoverCluster(storeName);
           Store store = admin.getStore(clusterDiscovered, storeName);
           LOGGER.warn("Find topic discrepancy case: {}", pubSubTopic);
           if (!isStillValidPubSubTopic(pubSubTopic, store)) {

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/server/StoresRoutes.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/server/StoresRoutes.java
@@ -450,7 +450,7 @@ public class StoresRoutes extends AbstractRoute {
         veniceResponse.setCluster(destClusterName);
         veniceResponse.setName(storeName);
 
-        String clusterDiscovered = admin.discoverCluster(storeName).getFirst();
+        String clusterDiscovered = admin.discoverCluster(storeName);
         // Store should belong to src cluster already
         if (!clusterDiscovered.equals(srcClusterName)) {
           veniceResponse.setError(
@@ -505,7 +505,7 @@ public class StoresRoutes extends AbstractRoute {
         veniceResponse.setCluster(destClusterName);
         veniceResponse.setName(storeName);
 
-        String clusterDiscovered = admin.discoverCluster(storeName).getFirst();
+        String clusterDiscovered = admin.discoverCluster(storeName);
         // Store should belong to src cluster already
         if (!clusterDiscovered.equals(srcClusterName)) {
           veniceResponse.setError(
@@ -545,12 +545,12 @@ public class StoresRoutes extends AbstractRoute {
 
           veniceResponse.setName(storeName);
 
-          String clusterDiscovered = admin.discoverCluster(storeName).getFirst();
+          String clusterDiscovered = admin.discoverCluster(storeName);
           veniceResponse.setSrcClusterName(clusterDiscovered);
 
           admin.abortMigration(srcClusterName, destClusterName, storeName);
 
-          clusterDiscovered = admin.discoverCluster(storeName).getFirst();
+          clusterDiscovered = admin.discoverCluster(storeName);
           veniceResponse.setCluster(clusterDiscovered);
         } catch (Throwable e) {
           veniceResponse.setError(e);
@@ -586,7 +586,7 @@ public class StoresRoutes extends AbstractRoute {
           storeMigrationResponse.setCluster(destClusterName);
           storeMigrationResponse.setName(storeName);
 
-          String clusterDiscovered = admin.discoverCluster(storeName).getFirst();
+          String clusterDiscovered = admin.discoverCluster(storeName);
           // Store should not belong to dest cluster already
           if (clusterDiscovered.equals(destClusterName)) {
             storeMigrationResponse
@@ -996,7 +996,7 @@ public class StoresRoutes extends AbstractRoute {
           allStoreTopics.forEach((storeName, topicsWithRetention) -> {
             String cluster;
             try {
-              cluster = admin.discoverCluster(storeName).getFirst();
+              cluster = admin.discoverCluster(storeName);
             } catch (VeniceNoStoreException e) {
               LOGGER.warn("Store " + storeName + " does not exist. Skipping it.");
               return;

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/server/VeniceControllerRequestHandler.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/server/VeniceControllerRequestHandler.java
@@ -7,7 +7,6 @@ import com.linkedin.venice.protocols.controller.DiscoverClusterGrpcRequest;
 import com.linkedin.venice.protocols.controller.DiscoverClusterGrpcResponse;
 import com.linkedin.venice.protocols.controller.LeaderControllerGrpcRequest;
 import com.linkedin.venice.protocols.controller.LeaderControllerGrpcResponse;
-import com.linkedin.venice.utils.Pair;
 import org.apache.commons.lang.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -93,17 +92,18 @@ public class VeniceControllerRequestHandler {
       throw new IllegalArgumentException("Store name is required for cluster discovery");
     }
     LOGGER.info("Discovering cluster for store: {}", storeName);
-    Pair<String, String> clusterToD2Pair = admin.discoverCluster(storeName);
+    String clusterName = admin.discoverCluster(storeName);
 
     DiscoverClusterGrpcResponse.Builder responseBuilder =
         DiscoverClusterGrpcResponse.newBuilder().setStoreName(storeName);
-    if (clusterToD2Pair.getFirst() != null) {
-      responseBuilder.setClusterName(clusterToD2Pair.getFirst());
+    if (clusterName != null) {
+      responseBuilder.setClusterName(clusterName);
     }
-    if (clusterToD2Pair.getSecond() != null) {
-      responseBuilder.setD2Service(clusterToD2Pair.getSecond());
+    String routerD2Service = admin.getRouterD2Service(clusterName);
+    if (routerD2Service != null) {
+      responseBuilder.setD2Service(routerD2Service);
     }
-    String serverD2Service = admin.getServerD2Service(clusterToD2Pair.getFirst());
+    String serverD2Service = admin.getServerD2Service(clusterName);
     if (serverD2Service != null) {
       responseBuilder.setServerD2Service(serverD2Service);
     }

--- a/services/venice-controller/src/test/java/com/linkedin/venice/controller/kafka/TestTopicCleanupService.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/controller/kafka/TestTopicCleanupService.java
@@ -35,7 +35,6 @@ import com.linkedin.venice.pubsub.adapter.kafka.admin.ApacheKafkaAdminAdapterFac
 import com.linkedin.venice.pubsub.api.PubSubTopic;
 import com.linkedin.venice.pubsub.api.PubSubTopicType;
 import com.linkedin.venice.pubsub.manager.TopicManager;
-import com.linkedin.venice.utils.Pair;
 import com.linkedin.venice.utils.TestUtils;
 import com.linkedin.venice.utils.Utils;
 import java.util.Arrays;
@@ -248,7 +247,7 @@ public class TestTopicCleanupService {
     doReturn(true).when(admin).isTopicTruncatedBasedOnRetention(1000L);
     doReturn(false).when(admin).isTopicTruncatedBasedOnRetention(any(), eq(Long.MAX_VALUE));
     doReturn(true).when(admin).isTopicTruncatedBasedOnRetention(any(), eq(1000L));
-    doReturn(Pair.create(clusterName, null)).when(admin).discoverCluster(anyString());
+    doReturn(clusterName).when(admin).discoverCluster(anyString());
     doReturn(true).when(admin).isRTTopicDeletionPermittedByAllControllers(anyString(), any());
     doReturn(Optional.of(new StoreConfig(storeName1))).when(storeConfigRepository).getStoreConfig(storeName1);
 
@@ -264,8 +263,7 @@ public class TestTopicCleanupService {
     doReturn(apacheKafkaAdminAdapter).when(apacheKafkaAdminAdapterFactory).create(any(PubSubAdminAdapterContext.class));
 
     topicCleanupService.setSourceOfTruthPubSubAdminAdapter(apacheKafkaAdminAdapter);
-    Pair<String, String> pair = new Pair<>(clusterName, "");
-    doReturn(pair).when(admin).discoverCluster(anyString());
+    doReturn(clusterName).when(admin).discoverCluster(anyString());
     doThrow(new VeniceNoStoreException(storeName5)).when(admin).discoverCluster(storeName5);
 
     Store store2 = mock(Store.class);
@@ -392,7 +390,7 @@ public class TestTopicCleanupService {
     doReturn(false).when(admin).isTopicTruncatedBasedOnRetention(any(), eq(Long.MAX_VALUE));
     doReturn(true).when(admin).isTopicTruncatedBasedOnRetention(any(), eq(1000L));
     doReturn(true).when(admin).isLeaderControllerOfControllerCluster();
-    doReturn(Pair.create("cluster0", null)).when(admin).discoverCluster(any());
+    doReturn("cluster0").when(admin).discoverCluster(any());
     // Resource is still alive
     doReturn(true).when(admin).isResourceStillAlive(storeName2 + "_v2");
 
@@ -453,7 +451,7 @@ public class TestTopicCleanupService {
   public void testRunWhenCurrentControllerChangeFromFollowerToLeader() {
     String storeName1 = Utils.getUniqueString("store1");
     doReturn(Optional.of(new StoreConfig(storeName1))).when(storeConfigRepository).getStoreConfig(storeName1);
-    doReturn(new Pair<>("clusterName", "")).when(admin).discoverCluster(anyString());
+    doReturn("clusterName").when(admin).discoverCluster(anyString());
     Map<PubSubTopic, Long> storeTopics1 = new HashMap<>();
     storeTopics1.put(getPubSubTopic(storeName1, "_v1"), 1000L);
     storeTopics1.put(getPubSubTopic(storeName1, "_v2"), 1000L);
@@ -511,7 +509,7 @@ public class TestTopicCleanupService {
     String storeName = Utils.getUniqueString("testStore");
     Map<PubSubTopic, Long> storeTopics = new HashMap<>();
     storeTopics.put(getPubSubTopic(storeName, "_rt"), 1000L);
-    doReturn(Pair.create("cluster0", null)).when(admin).discoverCluster(any());
+    doReturn("cluster0").when(admin).discoverCluster(any());
     doReturn(false).when(admin).isTopicTruncatedBasedOnRetention(Long.MAX_VALUE);
     doReturn(true).when(admin).isTopicTruncatedBasedOnRetention(1000L);
     doReturn(false).when(admin).isTopicTruncatedBasedOnRetention(any(), eq(Long.MAX_VALUE));
@@ -545,7 +543,7 @@ public class TestTopicCleanupService {
     doReturn(true).when(admin).isTopicTruncatedBasedOnRetention(1000L);
     doReturn(false).when(admin).isTopicTruncatedBasedOnRetention(any(), eq(Long.MAX_VALUE));
     doReturn(true).when(admin).isTopicTruncatedBasedOnRetention(any(), eq(1000L));
-    doReturn(Pair.create("cluster0", null)).when(admin).discoverCluster(any());
+    doReturn("cluster0").when(admin).discoverCluster(any());
     doReturn(true).when(admin).isRTTopicDeletionPermittedByAllControllers(anyString(), any());
     when(topicManager.getAllTopicRetentions()).thenReturn(storeTopics1).thenReturn(storeTopics2);
     doReturn(storeTopics2).when(remoteTopicManager).getAllTopicRetentions();

--- a/services/venice-controller/src/test/java/com/linkedin/venice/controller/server/StoresRoutesTest.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/controller/server/StoresRoutesTest.java
@@ -144,7 +144,7 @@ public class StoresRoutesTest {
   public void testMigrateStore() throws Exception {
     Admin mockAdmin = mock(VeniceParentHelixAdmin.class, RETURNS_DEEP_STUBS);
     String DEST_CLUSTER = "dest_cluster";
-    when(mockAdmin.discoverCluster(TEST_STORE_NAME).getFirst()).thenReturn(TEST_CLUSTER);
+    when(mockAdmin.discoverCluster(TEST_STORE_NAME)).thenReturn(TEST_CLUSTER);
     Request request = mock(Request.class);
     doReturn(LEADER_CONTROLLER.getPath()).when(request).pathInfo();
     doReturn(TEST_CLUSTER).when(request).queryParams(eq(ControllerApiConstants.CLUSTER));
@@ -189,7 +189,7 @@ public class StoresRoutesTest {
   public void testCleanExecutionIds() throws Exception {
     Admin mockAdmin = mock(VeniceParentHelixAdmin.class, RETURNS_DEEP_STUBS);
     String DEST_CLUSTER = "dest_cluster";
-    when(mockAdmin.discoverCluster(TEST_STORE_NAME).getFirst()).thenReturn(TEST_CLUSTER);
+    when(mockAdmin.discoverCluster(TEST_STORE_NAME)).thenReturn(TEST_CLUSTER);
     Request request = mock(Request.class);
     doReturn(LEADER_CONTROLLER.getPath()).when(request).pathInfo();
     doReturn(TEST_CLUSTER).when(request).queryParams(eq(ControllerApiConstants.CLUSTER));
@@ -361,7 +361,7 @@ public class StoresRoutesTest {
   public void testAutoMigrateStore() throws Exception {
     Admin mockAdmin = mock(VeniceParentHelixAdmin.class, RETURNS_DEEP_STUBS);
     String DEST_CLUSTER = "dest_cluster";
-    when(mockAdmin.discoverCluster(TEST_STORE_NAME).getFirst()).thenReturn(TEST_CLUSTER);
+    when(mockAdmin.discoverCluster(TEST_STORE_NAME)).thenReturn(TEST_CLUSTER);
     Request request = mock(Request.class);
     doReturn(LEADER_CONTROLLER.getPath()).when(request).pathInfo();
     doReturn(TEST_CLUSTER).when(request).queryParams(eq(ControllerApiConstants.CLUSTER));
@@ -385,7 +385,7 @@ public class StoresRoutesTest {
 
     // Bad Request Path:
     // 1. Store belongs to destination cluster
-    when(mockAdmin.discoverCluster(TEST_STORE_NAME).getFirst()).thenReturn(DEST_CLUSTER);
+    when(mockAdmin.discoverCluster(TEST_STORE_NAME)).thenReturn(DEST_CLUSTER);
 
     trackableControllerResponse = ObjectMapperFactory.getInstance()
         .readValue(migrateStoreRoute.handle(request, mock(Response.class)).toString(), StoreMigrationResponse.class);
@@ -397,7 +397,7 @@ public class StoresRoutesTest {
 
     // 2. Store doesn't belong to the source cluster
     String EXTRA_CLUSTER = "extra_cluster";
-    when(mockAdmin.discoverCluster(TEST_STORE_NAME).getFirst()).thenReturn(EXTRA_CLUSTER);
+    when(mockAdmin.discoverCluster(TEST_STORE_NAME)).thenReturn(EXTRA_CLUSTER);
     trackableControllerResponse = ObjectMapperFactory.getInstance()
         .readValue(migrateStoreRoute.handle(request, mock(Response.class)).toString(), StoreMigrationResponse.class);
     Assert.assertTrue(trackableControllerResponse.isError());

--- a/services/venice-controller/src/test/java/com/linkedin/venice/controller/server/VeniceControllerRequestHandlerTest.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/controller/server/VeniceControllerRequestHandlerTest.java
@@ -12,7 +12,6 @@ import com.linkedin.venice.protocols.controller.DiscoverClusterGrpcRequest;
 import com.linkedin.venice.protocols.controller.DiscoverClusterGrpcResponse;
 import com.linkedin.venice.protocols.controller.LeaderControllerGrpcRequest;
 import com.linkedin.venice.protocols.controller.LeaderControllerGrpcResponse;
-import com.linkedin.venice.utils.Pair;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
@@ -68,8 +67,8 @@ public class VeniceControllerRequestHandlerTest {
   public void testDiscoverCluster() {
     String storeName = "testStore";
     DiscoverClusterGrpcRequest request = DiscoverClusterGrpcRequest.newBuilder().setStoreName(storeName).build();
-    Pair<String, String> clusterToD2Pair = Pair.create("testCluster", "testD2Service");
-    when(admin.discoverCluster(storeName)).thenReturn(clusterToD2Pair);
+    when(admin.discoverCluster(storeName)).thenReturn("testCluster");
+    when(admin.getRouterD2Service("testCluster")).thenReturn("testD2Service");
     when(admin.getServerD2Service("testCluster")).thenReturn("testServerD2Service");
 
     DiscoverClusterGrpcResponse response = requestHandler.discoverCluster(request);


### PR DESCRIPTION
<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat], [protocol]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## Problem Statement
<!--
Describe
- What problem are you trying to solve
- What issues or limitations exist in the current code
- Why this change is necessary 
-->
Today, `Admin#discoverCluster` does cluster discovery, and d2 service resolution for the cluster.Most cases only need the cluster discovery, though.

## Solution
<!--
Describe
- What changes you are making and why. 
- How these changes solve the problem.
- Any performance considerations or trade-offs. 
- Describe what testings you have done, for example, performance testing etc.
-->
This change extracts the d2 service resolution out of `Admin#discoverCluster` into a new function `Admin#getRouterD2Service`

###  Code changes
- [ ] Added new code behind **a config**. If so list the config names and their default values in the PR description.
- [ ] Introduced new **log lines**. 
  - [ ] Confirmed if logs need to be **rate limited** to avoid excessive logging.

###  **Concurrency-Specific Checks**
Both reviewer and PR author to verify
- [x] Code has **no race conditions** or **thread safety issues**.
- [x] Proper **synchronization mechanisms** (e.g., `synchronized`, `RWLock`) are used where needed.
- [x] No **blocking calls** inside critical sections that could lead to deadlocks or performance degradation.
- [x] Verified **thread-safe collections** are used (e.g., `ConcurrentHashMap`, `CopyOnWriteArrayList`).
- [x] Validated proper exception handling in multi-threaded code to avoid silent thread termination.


## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->

- [ ] New unit tests added.
- [ ] New integration tests added.
- [x] Modified or extended existing tests.
- [x] Verified backward compatibility (if applicable).

## Does this PR introduce any user-facing or breaking changes?
<!--  
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Clearly explain the behavior change and its impact.