### PR TITLE
[vpj] Support rmd field as part of VenicePushJob

### DIFF
--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/DefaultInputDataInfoProvider.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/DefaultInputDataInfoProvider.java
@@ -7,7 +7,7 @@ import static com.linkedin.venice.vpj.VenicePushJobConstants.FILE_VALUE_SCHEMA;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.KEY_FIELD_PROP;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.MINIMUM_NUMBER_OF_SAMPLES_REQUIRED_TO_BUILD_ZSTD_DICTIONARY;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.PATH_FILTER;
-import static com.linkedin.venice.vpj.VenicePushJobConstants.TIMESTAMP_FIELD_PROP;
+import static com.linkedin.venice.vpj.VenicePushJobConstants.RMD_FIELD_PROP;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.VALUE_FIELD_PROP;
 
 import com.linkedin.venice.compression.ZstdWithDictCompressor;
@@ -139,7 +139,7 @@ public class DefaultInputDataInfoProvider implements InputDataInfoProvider {
       // key / value fields are optional for Vson input
       pushJobSetting.keyField = props.getString(KEY_FIELD_PROP, "");
       pushJobSetting.valueField = props.getString(VALUE_FIELD_PROP, "");
-      pushJobSetting.timestampField = props.getString(TIMESTAMP_FIELD_PROP, "");
+      pushJobSetting.rmdField = props.getString(RMD_FIELD_PROP, "");
 
       Pair<VsonSchema, VsonSchema> vsonSchema = checkVsonSchemaConsistency(fs, fileStatuses, inputFileDataSize);
 
@@ -365,7 +365,7 @@ public class DefaultInputDataInfoProvider implements InputDataInfoProvider {
   private VeniceAvroRecordReader getVeniceAvroRecordReader(FileSystem fs, Path path) {
     String keyField = props.getString(KEY_FIELD_PROP, DEFAULT_KEY_FIELD_PROP);
     String valueField = props.getString(VALUE_FIELD_PROP, DEFAULT_VALUE_FIELD_PROP);
-    String timestampField = props.getOrDefault(TIMESTAMP_FIELD_PROP, "");
+    String timestampField = props.getOrDefault(RMD_FIELD_PROP, "");
     return new VeniceAvroRecordReader(
         HdfsAvroUtils.getFileSchema(fs, path),
         keyField,

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/PushJobSetting.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/PushJobSetting.java
@@ -123,10 +123,11 @@ public class PushJobSetting implements Serializable {
   // Schema-properties
   public boolean isAvro = true;
   public int valueSchemaId; // Value schema id retrieved from backend for valueSchemaString
+  public int rmdSchemaId; // Replication metadata schema id retrieved from backend for replicationMetadataSchemaString
   public int derivedSchemaId = -1;
   public String keyField;
   public String valueField;
-  public String timestampField;
+  public String rmdField;
 
   public Schema inputDataSchema;
   public String inputDataSchemaString;

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/VenicePushJob.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/VenicePushJob.java
@@ -64,6 +64,7 @@ import static com.linkedin.venice.vpj.VenicePushJobConstants.REPUSH_TTL_START_TI
 import static com.linkedin.venice.vpj.VenicePushJobConstants.REWIND_EPOCH_TIME_BUFFER_IN_SECONDS_OVERRIDE;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.REWIND_EPOCH_TIME_IN_SECONDS_OVERRIDE;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.REWIND_TIME_IN_SECONDS_OVERRIDE;
+import static com.linkedin.venice.vpj.VenicePushJobConstants.RMD_FIELD_PROP;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.SEND_CONTROL_MESSAGES_DIRECTLY;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.SOURCE_ETL;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.SOURCE_GRID_FABRIC;
@@ -74,7 +75,6 @@ import static com.linkedin.venice.vpj.VenicePushJobConstants.TARGETED_REGION_PUS
 import static com.linkedin.venice.vpj.VenicePushJobConstants.TARGETED_REGION_PUSH_LIST;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.TARGETED_REGION_PUSH_WITH_DEFERRED_SWAP;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.TEMP_DIR_PREFIX;
-import static com.linkedin.venice.vpj.VenicePushJobConstants.TIMESTAMP_FIELD_PROP;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.UNCREATED_VERSION_NUMBER;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.VALUE_FIELD_PROP;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.VENICE_DISCOVER_URL_PROP;
@@ -337,7 +337,7 @@ public class VenicePushJob implements AutoCloseable {
     pushJobSettingToReturn.jobServerName = props.getString(JOB_SERVER_NAME, "unknown_job_server");
     pushJobSettingToReturn.veniceControllerUrl = props.getString(VENICE_DISCOVER_URL_PROP);
     pushJobSettingToReturn.enableSSL = props.getBoolean(ENABLE_SSL, DEFAULT_SSL_ENABLED);
-    pushJobSettingToReturn.timestampField = props.getOrDefault(TIMESTAMP_FIELD_PROP, "");
+    pushJobSettingToReturn.rmdField = props.getOrDefault(RMD_FIELD_PROP, "");
     if (pushJobSettingToReturn.enableSSL) {
       VPJSSLUtils.validateSslProperties(props);
     }
@@ -2056,13 +2056,28 @@ public class VenicePushJob implements AutoCloseable {
     if (replicationSchemasResponse.isError()) {
       LOGGER.error("Failed to fetch replication metadata schemas!" + replicationSchemasResponse.getError());
     } else {
-      // We only need a single valid schema, so getting the first one is good enough.
       if (replicationSchemasResponse.getSchemas() != null && replicationSchemasResponse.getSchemas().length > 0) {
-        pushJobSetting.replicationMetadataSchemaString = replicationSchemasResponse.getSchemas()[0].getSchemaStr();
-        LOGGER.info(
-            "Retrieved and using schema with id: {}, and string: {}",
-            replicationSchemasResponse.getSchemas()[0].getId(),
-            pushJobSetting.replicationMetadataSchemaString);
+        boolean foundRmdSchema = false;
+        for (MultiSchemaResponse.Schema schema: replicationSchemasResponse.getSchemas()) {
+          if (schema.getRmdValueSchemaId() == pushJobSetting.valueSchemaId
+              && schema.getId() > pushJobSetting.rmdSchemaId) {
+            pushJobSetting.rmdSchemaId = schema.getId();
+            pushJobSetting.replicationMetadataSchemaString = schema.getSchemaStr();
+            foundRmdSchema = true;
+          }
+        }
+
+        if (foundRmdSchema) {
+          LOGGER.info(
+              "Retrieved and using schema with id: {}, and string: {}",
+              pushJobSetting.rmdSchemaId,
+              pushJobSetting.replicationMetadataSchemaString);
+        } else {
+          LOGGER.info(
+              "No replication schema found for value schema id: {} in store: {}",
+              pushJobSetting.valueSchemaId,
+              setting.storeName);
+        }
       } else {
         LOGGER.info("No replication schemas associated with the store!");
       }
@@ -2086,7 +2101,7 @@ public class VenicePushJob implements AutoCloseable {
       return;
     }
     // Also allow batch push that will provide the row level timestamp field (compatible with TTL re-push)
-    if (setting.timestampField != null && !setting.timestampField.isEmpty()) {
+    if (setting.rmdField != null && !setting.rmdField.isEmpty()) {
       return;
     }
     StoreResponse storeResponse = ControllerClient

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/input/kafka/VeniceKafkaInputMapper.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/input/kafka/VeniceKafkaInputMapper.java
@@ -60,10 +60,10 @@ public class VeniceKafkaInputMapper extends AbstractVeniceMapper<KafkaInputMappe
   protected boolean process(
       KafkaInputMapperKey inputKey,
       KafkaInputMapperValue inputValue,
-      Long timestamp,
+      byte[] rmd,
       AtomicReference<byte[]> keyRef,
       AtomicReference<byte[]> valueRef,
-      AtomicReference<Long> timestampRef,
+      AtomicReference<byte[]> rmdRef,
       DataWriterTaskTracker dataWriterTaskTracker) {
     if (veniceFilterChain != null && veniceFilterChain.apply(inputValue)) {
       dataWriterTaskTracker.trackRepushTtlFilteredRecord();
@@ -73,7 +73,7 @@ public class VeniceKafkaInputMapper extends AbstractVeniceMapper<KafkaInputMappe
     keyRef.set(serializedKey);
     byte[] serializedValue = KAFKA_INPUT_MAPPER_VALUE_SERIALIZER.serialize(inputValue);
     valueRef.set(serializedValue);
-    timestampRef.set(timestamp);
+    rmdRef.set(rmd);
     return true;
   }
 

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/input/kafka/VeniceKafkaInputReducer.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/input/kafka/VeniceKafkaInputReducer.java
@@ -7,7 +7,6 @@ import static com.linkedin.venice.vpj.VenicePushJobConstants.KAFKA_INPUT_SOURCE_
 import static com.linkedin.venice.vpj.VenicePushJobConstants.KAFKA_INPUT_TOPIC;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.REPUSH_TTL_ENABLE;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.TOPIC_PROP;
-import static com.linkedin.venice.writer.VeniceWriter.APP_DEFAULT_LOGICAL_TS;
 
 import com.linkedin.venice.compression.CompressionStrategy;
 import com.linkedin.venice.compression.CompressorFactory;
@@ -29,9 +28,10 @@ import com.linkedin.venice.utils.Utils;
 import com.linkedin.venice.utils.VeniceProperties;
 import java.io.IOException;
 import java.nio.ByteBuffer;
+import java.util.ArrayList;
 import java.util.Iterator;
+import java.util.List;
 import javax.annotation.Nonnull;
-import org.apache.avro.Schema;
 import org.apache.avro.io.OptimizedBinaryDecoderFactory;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -127,18 +127,16 @@ public class VeniceKafkaInputReducer extends VeniceReducer {
   @Override
   protected AbstractPartitionWriter.VeniceWriterMessage extract(
       byte[] key,
-      Iterator<byte[]> valueIterator,
-      Iterator<Long> timestampIterator,
-      Schema valueSchema,
+      Iterator<VeniceRecordWithMetadata> values,
       DataWriterTaskTracker dataWriterTaskTracker) {
     KafkaInputMapperKey mapperKey = KAFKA_INPUT_MAPPER_KEY_AVRO_SPECIFIC_DESERIALIZER.deserialize(key);
     byte[] keyBytes = ByteUtils.extractByteArray(mapperKey.key);
-    if (!valueIterator.hasNext()) {
+    if (!values.hasNext()) {
       throw new VeniceException("There is no value corresponding to key bytes: " + ByteUtils.toHexString(keyBytes));
     }
 
-    // We don't support a field override in KIF today, so we don't need to pass the timestampIterator
-    return extractor.extract(keyBytes, valueIterator, dataWriterTaskTracker);
+    // We don't support a field override in KIF today, so we don't need to pass the rmdIterator
+    return extractor.extract(keyBytes, getValueOnlyIterator(values), dataWriterTaskTracker);
   }
 
   @Override
@@ -190,15 +188,19 @@ public class VeniceKafkaInputReducer extends VeniceReducer {
       return new AbstractPartitionWriter.VeniceWriterMessage(
           keyBytes,
           compress(value.getBytes()),
-          APP_DEFAULT_LOGICAL_TS,
           value.getSchemaID(),
           value.getReplicationMetadataVersionId(),
           value.getReplicationMetadataPayload(),
           getCallback(),
           isEnableWriteCompute(),
-          null,
           getDerivedValueSchemaId());
     }
+  }
+
+  private Iterator<byte[]> getValueOnlyIterator(Iterator<VeniceRecordWithMetadata> valueRecordIterator) {
+    List<byte[]> values = new ArrayList<>();
+    valueRecordIterator.forEachRemaining(valueRecord -> values.add(valueRecord.getValue()));
+    return values.iterator();
   }
 
   private AbstractPartitionWriter.VeniceWriterMessage extractNonChunkedMessage(
@@ -218,13 +220,11 @@ public class VeniceKafkaInputReducer extends VeniceReducer {
         return new AbstractPartitionWriter.VeniceWriterMessage(
             keyBytes,
             null,
-            APP_DEFAULT_LOGICAL_TS,
             latestMapperValue.schemaId,
             latestMapperValue.replicationMetadataVersionId,
             latestMapperValue.replicationMetadataPayload,
             getCallback(),
             isEnableWriteCompute(),
-            null,
             getDerivedValueSchemaId());
       }
       return null;
@@ -234,13 +234,11 @@ public class VeniceKafkaInputReducer extends VeniceReducer {
       return new AbstractPartitionWriter.VeniceWriterMessage(
           keyBytes,
           compress(valueBytes),
-          APP_DEFAULT_LOGICAL_TS,
           latestMapperValue.schemaId,
           latestMapperValue.replicationMetadataVersionId,
           latestMapperValue.replicationMetadataPayload,
           getCallback(),
           isEnableWriteCompute(),
-          null,
           getDerivedValueSchemaId());
     }
     return new AbstractPartitionWriter.VeniceWriterMessage(

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/input/recordreader/AbstractVeniceRecordReader.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/input/recordreader/AbstractVeniceRecordReader.java
@@ -12,11 +12,16 @@ import org.apache.avro.Schema;
  * @param <INPUT_VALUE> The format of the value as controlled by the input format
  */
 public abstract class AbstractVeniceRecordReader<INPUT_KEY, INPUT_VALUE> {
+  public static final byte[] EMPTY_RMD_BYTES = new byte[0];
   private Schema keySchema;
   private Schema valueSchema;
 
+  private Schema rmdSchema;
+
   private RecordSerializer<Object> keySerializer;
   private RecordSerializer<Object> valueSerializer;
+
+  private RecordSerializer<Object> rmdSerializer;
 
   public Schema getKeySchema() {
     return keySchema;
@@ -26,14 +31,28 @@ public abstract class AbstractVeniceRecordReader<INPUT_KEY, INPUT_VALUE> {
     return valueSchema;
   }
 
+  public Schema getRmdSchema() {
+    return rmdSchema;
+  }
+
+  Schema getDefaultRmdSchema() {
+    return Schema.create(Schema.Type.LONG);
+  }
+
   /**
    * Configure the record serializers
    */
   protected void configure(Schema keySchema, Schema valueSchema) {
+    configure(keySchema, valueSchema, getDefaultRmdSchema());
+  }
+
+  protected void configure(Schema keySchema, Schema valueSchema, Schema rmdSchema) {
     this.keySchema = keySchema;
     this.valueSchema = valueSchema;
+    this.rmdSchema = rmdSchema;
     keySerializer = FastSerializerDeserializerFactory.getFastAvroGenericSerializer(keySchema);
     valueSerializer = FastSerializerDeserializerFactory.getFastAvroGenericSerializer(valueSchema);
+    rmdSerializer = FastSerializerDeserializerFactory.getFastAvroGenericSerializer(rmdSchema);
   }
 
   /**
@@ -46,7 +65,7 @@ public abstract class AbstractVeniceRecordReader<INPUT_KEY, INPUT_VALUE> {
    */
   public abstract Object getAvroValue(INPUT_KEY inputKey, INPUT_VALUE inputValue);
 
-  public abstract Long getRecordTimestamp(INPUT_KEY inputKey, INPUT_VALUE inputValue);
+  public abstract Object getRmdValue(INPUT_KEY inputKey, INPUT_VALUE inputValue);
 
   /**
    * Return a serialized output key
@@ -80,5 +99,19 @@ public abstract class AbstractVeniceRecordReader<INPUT_KEY, INPUT_VALUE> {
     }
 
     return valueSerializer.serialize(avroValue);
+  }
+
+  public byte[] getRmdBytes(INPUT_KEY inputKey, INPUT_VALUE inputValue) {
+    if (rmdSerializer == null) {
+      return EMPTY_RMD_BYTES;
+    }
+
+    Object rmdValue = getRmdValue(inputKey, inputValue);
+
+    if (rmdValue == null) {
+      return EMPTY_RMD_BYTES;
+    }
+
+    return rmdSerializer.serialize(rmdValue);
   }
 }

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/input/recordreader/VeniceRecordIterator.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/input/recordreader/VeniceRecordIterator.java
@@ -20,9 +20,8 @@ public interface VeniceRecordIterator extends Closeable {
   byte[] getCurrentValue();
 
   /**
-   * Return the timestamp associated with the current record. This method will either return the timestamp of the record
-   * or -1L if a timestamp was not specified with the given record
-   * @return
+   * Return the timestamp associated with the current record. This method will either return the top level timestamp
+   * of the record or rmd of the record or -1L if a rmd was not specified with the given record
    */
-  long getTimeStamp();
+  byte[] getCurrentRmd();
 }

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/input/recordreader/avro/AbstractAvroRecordReader.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/input/recordreader/avro/AbstractAvroRecordReader.java
@@ -5,7 +5,6 @@ import com.linkedin.avroutil1.compatibility.AvroSchemaUtil;
 import com.linkedin.venice.etl.ETLUtils;
 import com.linkedin.venice.etl.ETLValueSchemaTransformation;
 import com.linkedin.venice.exceptions.VeniceException;
-import com.linkedin.venice.hadoop.exceptions.VeniceInvalidInputException;
 import com.linkedin.venice.hadoop.exceptions.VeniceSchemaFieldNotFoundException;
 import com.linkedin.venice.hadoop.input.recordreader.AbstractVeniceRecordReader;
 import com.linkedin.venice.writer.update.UpdateBuilder;
@@ -27,7 +26,7 @@ public abstract class AbstractAvroRecordReader<INPUT_KEY, INPUT_VALUE>
 
   private final int keyFieldPos;
   private final int valueFieldPos;
-  private int timestampFieldPos;
+  private int rmdFieldPos;
   private final Schema valueSchema;
 
   private final boolean generatePartialUpdateRecordFromInput;
@@ -43,7 +42,7 @@ public abstract class AbstractAvroRecordReader<INPUT_KEY, INPUT_VALUE>
       Schema dataSchema,
       String keyFieldStr,
       String valueFieldStr,
-      String timestampFieldStr,
+      String rmdFieldStr,
       ETLValueSchemaTransformation etlValueSchemaTransformation,
       Schema updateSchema) {
     this.dataSchema = dataSchema;
@@ -52,15 +51,15 @@ public abstract class AbstractAvroRecordReader<INPUT_KEY, INPUT_VALUE>
     Schema keySchema = keyField.schema();
 
     // The timestamp field is optional
-    if (!timestampFieldStr.isEmpty()) {
+    if (!rmdFieldStr.isEmpty()) {
       try {
-        Schema.Field timestampField = getField(dataSchema, timestampFieldStr);
-        timestampFieldPos = timestampField.pos();
+        Schema.Field rmdField = getField(dataSchema, rmdFieldStr);
+        rmdFieldPos = rmdField.pos();
       } catch (VeniceSchemaFieldNotFoundException e) {
-        timestampFieldPos = -1;
+        rmdFieldPos = -1;
       }
     } else {
-      timestampFieldPos = -1;
+      rmdFieldPos = -1;
     }
 
     Schema outputSchema;
@@ -145,18 +144,12 @@ public abstract class AbstractAvroRecordReader<INPUT_KEY, INPUT_VALUE>
   }
 
   @Override
-  public Long getRecordTimestamp(INPUT_KEY inputKey, INPUT_VALUE inputValue) {
-    if (timestampFieldPos == -1) {
-      return -1L;
+  public Object getRmdValue(INPUT_KEY inputKey, INPUT_VALUE inputValue) {
+    if (rmdFieldPos == -1) {
+      return EMPTY_RMD_BYTES;
     }
 
-    Object timestampDatum = getRecordDatum(inputKey, inputValue).get(timestampFieldPos);
-    if (!(timestampDatum instanceof Long)) {
-      throw new VeniceInvalidInputException(
-          "Timestamp must be non null and of type long!!  Instead got:" + timestampDatum);
-    }
-
-    return (Long) timestampDatum;
+    return getRecordDatum(inputKey, inputValue).get(rmdFieldPos);
   }
 
   @Override

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/input/recordreader/avro/IdentityVeniceRecordReader.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/input/recordreader/avro/IdentityVeniceRecordReader.java
@@ -38,8 +38,8 @@ public class IdentityVeniceRecordReader extends AbstractVeniceRecordReader<ByteB
   }
 
   @Override
-  public Long getRecordTimestamp(ByteBuffer inputKey, ByteBuffer inputValue) {
-    return -1L;
+  public Object getRmdValue(ByteBuffer inputKey, ByteBuffer inputValue) {
+    return EMPTY_RMD_BYTES;
   }
 
   @Override

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/input/recordreader/avro/VeniceAvroFileIterator.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/input/recordreader/avro/VeniceAvroFileIterator.java
@@ -21,7 +21,7 @@ public class VeniceAvroFileIterator implements VeniceRecordIterator {
 
   private byte[] currentKey = null;
   private byte[] currentValue = null;
-  private long timestamp = -1L;
+  private byte[] currentRmd = null;
 
   public VeniceAvroFileIterator(
       FileSystem fs,
@@ -54,8 +54,8 @@ public class VeniceAvroFileIterator implements VeniceRecordIterator {
   }
 
   @Override
-  public long getTimeStamp() {
-    return timestamp;
+  public byte[] getCurrentRmd() {
+    return currentRmd;
   }
 
   @Override
@@ -67,7 +67,7 @@ public class VeniceAvroFileIterator implements VeniceRecordIterator {
     AvroWrapper<IndexedRecord> avroObject = new AvroWrapper<>((IndexedRecord) avroDataFileStream.next());
     currentKey = recordReader.getKeyBytes(avroObject, null);
     currentValue = recordReader.getValueBytes(avroObject, null);
-    timestamp = recordReader.getRecordTimestamp(avroObject, null);
+    currentRmd = recordReader.getRmdBytes(avroObject, null);
     return true;
   }
 

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/input/recordreader/avro/VeniceAvroRecordReader.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/input/recordreader/avro/VeniceAvroRecordReader.java
@@ -5,8 +5,8 @@ import static com.linkedin.venice.vpj.VenicePushJobConstants.ETL_VALUE_SCHEMA_TR
 import static com.linkedin.venice.vpj.VenicePushJobConstants.EXTENDED_SCHEMA_VALIDITY_CHECK_ENABLED;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.GENERATE_PARTIAL_UPDATE_RECORD_FROM_INPUT;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.KEY_FIELD_PROP;
+import static com.linkedin.venice.vpj.VenicePushJobConstants.RMD_FIELD_PROP;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.SCHEMA_STRING_PROP;
-import static com.linkedin.venice.vpj.VenicePushJobConstants.TIMESTAMP_FIELD_PROP;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.UPDATE_SCHEMA_STRING_PROP;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.VALUE_FIELD_PROP;
 
@@ -47,7 +47,7 @@ public class VeniceAvroRecordReader extends AbstractAvroRecordReader<AvroWrapper
 
     String keyFieldStr = props.getString(KEY_FIELD_PROP);
     String valueFieldStr = props.getString(VALUE_FIELD_PROP);
-    String timestampFieldStr = props.getOrDefault(TIMESTAMP_FIELD_PROP, "");
+    String timestampFieldStr = props.getOrDefault(RMD_FIELD_PROP, "");
 
     ETLValueSchemaTransformation etlValueSchemaTransformation = ETLValueSchemaTransformation
         .valueOf(props.getString(ETL_VALUE_SCHEMA_TRANSFORMATION, ETLValueSchemaTransformation.NONE.name()));

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/input/recordreader/vson/VeniceVsonFileIterator.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/input/recordreader/vson/VeniceVsonFileIterator.java
@@ -47,8 +47,8 @@ public class VeniceVsonFileIterator implements VeniceRecordIterator {
   }
 
   @Override
-  public long getTimeStamp() {
-    return recordReader.getRecordTimestamp(currentKey, currentValue);
+  public byte[] getCurrentRmd() {
+    return recordReader.getRmdBytes(currentKey, currentValue);
   }
 
   @Override

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/input/recordreader/vson/VeniceVsonRecordReader.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/input/recordreader/vson/VeniceVsonRecordReader.java
@@ -95,8 +95,8 @@ public class VeniceVsonRecordReader extends AbstractVeniceRecordReader<BytesWrit
   }
 
   @Override
-  public Long getRecordTimestamp(BytesWritable inputKey, BytesWritable inputValue) {
-    return -1L;
+  public Object getRmdValue(BytesWritable inputKey, BytesWritable inputValue) {
+    return EMPTY_RMD_BYTES;
   }
 
   public Map<String, String> getMetadataMap() {

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/mapreduce/datawriter/jobs/DataWriterMRJob.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/mapreduce/datawriter/jobs/DataWriterMRJob.java
@@ -35,6 +35,7 @@ import static com.linkedin.venice.vpj.VenicePushJobConstants.REDUCER_SPECULATIVE
 import static com.linkedin.venice.vpj.VenicePushJobConstants.REPUSH_TTL_ENABLE;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.REPUSH_TTL_POLICY;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.REPUSH_TTL_START_TIMESTAMP;
+import static com.linkedin.venice.vpj.VenicePushJobConstants.RMD_FIELD_PROP;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.RMD_SCHEMA_DIR;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.SCHEMA_STRING_PROP;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.SSL_PREFIX;
@@ -43,7 +44,6 @@ import static com.linkedin.venice.vpj.VenicePushJobConstants.SYSTEM_SCHEMA_CLUST
 import static com.linkedin.venice.vpj.VenicePushJobConstants.SYSTEM_SCHEMA_CLUSTER_D2_ZK_HOST;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.SYSTEM_SCHEMA_READER_ENABLED;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.TELEMETRY_MESSAGE_INTERVAL;
-import static com.linkedin.venice.vpj.VenicePushJobConstants.TIMESTAMP_FIELD_PROP;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.TOPIC_PROP;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.UPDATE_SCHEMA_STRING_PROP;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.VALUE_FIELD_PROP;
@@ -257,7 +257,7 @@ public class DataWriterMRJob extends DataWriterComputeJob {
 
       jobConf.set(KEY_FIELD_PROP, pushJobSetting.keyField);
       jobConf.set(VALUE_FIELD_PROP, pushJobSetting.valueField);
-      jobConf.set(TIMESTAMP_FIELD_PROP, pushJobSetting.timestampField);
+      jobConf.set(RMD_FIELD_PROP, pushJobSetting.rmdField);
       if (pushJobSetting.etlValueSchemaTransformation != null) {
         jobConf.set(ETL_VALUE_SCHEMA_TRANSFORMATION, pushJobSetting.etlValueSchemaTransformation.name());
       }

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/mapreduce/datawriter/map/AbstractVeniceMapper.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/mapreduce/datawriter/map/AbstractVeniceMapper.java
@@ -37,7 +37,7 @@ public abstract class AbstractVeniceMapper<INPUT_KEY, INPUT_VALUE>
     if (updatePreviousReporter(reporter)) {
       dataWriterTaskTracker = new ReporterBackedMapReduceDataWriterTaskTracker(reporter);
     }
-    super.processRecord(inputKey, inputValue, -1L, getRecordEmitter(output), dataWriterTaskTracker);
+    super.processRecord(inputKey, inputValue, EMPTY_BYTES, getRecordEmitter(output), dataWriterTaskTracker);
   }
 
   private boolean updatePreviousReporter(Reporter reporter) {
@@ -63,10 +63,10 @@ public abstract class AbstractVeniceMapper<INPUT_KEY, INPUT_VALUE>
     return bw;
   }
 
-  private TriConsumer<byte[], byte[], Long> getRecordEmitter(
+  private TriConsumer<byte[], byte[], byte[]> getRecordEmitter(
       OutputCollector<BytesWritable, BytesWritable> outputCollector) {
     // TODO: We don't support passing the timestamp in MR yet, so this ignored the timestamp input
-    return (key, value, Long) -> {
+    return (key, value, rmd) -> {
       BytesWritable keyBW = wrapBytes(key);
       BytesWritable valueBW = wrapBytes(value);
       try {

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/mapreduce/datawriter/reduce/VeniceReducer.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/mapreduce/datawriter/reduce/VeniceReducer.java
@@ -15,7 +15,6 @@ import com.linkedin.venice.utils.VeniceProperties;
 import com.linkedin.venice.writer.AbstractVeniceWriter;
 import com.linkedin.venice.writer.VeniceWriterFactory;
 import java.io.IOException;
-import java.util.Collections;
 import java.util.Iterator;
 import org.apache.hadoop.io.BytesWritable;
 import org.apache.hadoop.mapred.Counters;
@@ -72,8 +71,8 @@ public class VeniceReducer extends AbstractPartitionWriter
 
     processValuesForKey(
         key.copyBytes(),
-        IteratorUtils.mapIterator(values, BytesWritable::copyBytes),
-        Collections.emptyIterator(),
+        IteratorUtils
+            .mapIterator(values, x -> new VeniceRecordWithMetadata(key.copyBytes(), x.copyBytes(), new byte[0])),
         dataWriterTaskTracker);
   }
 

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/task/datawriter/AbstractInputRecordProcessor.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/task/datawriter/AbstractInputRecordProcessor.java
@@ -45,6 +45,7 @@ public abstract class AbstractInputRecordProcessor<INPUT_KEY, INPUT_VALUE> exten
     implements Closeable {
   private static final Logger LOGGER = LogManager.getLogger(AbstractInputRecordProcessor.class);
   private static final int TASK_ID_WHICH_SHOULD_SPRAY_ALL_PARTITIONS = 0;
+  public static final byte[] EMPTY_BYTES = new byte[0];
 
   // Compression related
   private CompressionStrategy compressionStrategy;
@@ -53,10 +54,9 @@ public abstract class AbstractInputRecordProcessor<INPUT_KEY, INPUT_VALUE> exten
   private VeniceCompressor[] compressors;
 
   protected AbstractVeniceRecordReader<INPUT_KEY, INPUT_VALUE> veniceRecordReader;
-  private static final byte[] EMPTY_BYTES = new byte[0];
   private final AtomicReference<byte[]> processedKey = new AtomicReference<>();
   private final AtomicReference<byte[]> processedValue = new AtomicReference<>();
-  private final AtomicReference<Long> processedTimestamp = new AtomicReference<>();
+  private final AtomicReference<byte[]> processedRmd = new AtomicReference<>();
   private boolean firstRecord = true;
   private boolean enableUncompressedMaxRecordSizeLimit = false;
   private int maxRecordSizeBytes = VeniceWriter.UNLIMITED_MAX_RECORD_SIZE;
@@ -64,28 +64,21 @@ public abstract class AbstractInputRecordProcessor<INPUT_KEY, INPUT_VALUE> exten
   protected final void processRecord(
       INPUT_KEY inputKey,
       INPUT_VALUE inputValue,
-      Long timestamp,
-      TriConsumer<byte[], byte[], Long> recordEmitter,
+      byte[] inputRmd,
+      TriConsumer<byte[], byte[], byte[]> recordEmitter,
       DataWriterTaskTracker dataWriterTaskTracker) {
     if (firstRecord) {
       maybeSprayAllPartitions(recordEmitter, dataWriterTaskTracker);
     }
     firstRecord = false;
-    if (process(
-        inputKey,
-        inputValue,
-        timestamp,
-        processedKey,
-        processedValue,
-        processedTimestamp,
-        dataWriterTaskTracker)) {
+    if (process(inputKey, inputValue, inputRmd, processedKey, processedValue, processedRmd, dataWriterTaskTracker)) {
       // key/value pair is valid.
-      recordEmitter.accept(processedKey.get(), processedValue.get(), processedTimestamp.get());
+      recordEmitter.accept(processedKey.get(), processedValue.get(), processedRmd.get());
     }
   }
 
   private void maybeSprayAllPartitions(
-      TriConsumer<byte[], byte[], Long> recordEmitter,
+      TriConsumer<byte[], byte[], byte[]> recordEmitter,
       DataWriterTaskTracker dataWriterTaskTracker) {
     /** First map invocation, since the {@link recordKey} will be set after this. */
     if (getTaskId() == TASK_ID_NOT_SET) {
@@ -97,7 +90,7 @@ public abstract class AbstractInputRecordProcessor<INPUT_KEY, INPUT_VALUE> exten
     for (int i = 0; i < getPartitionCount(); i++) {
       byte[] recordValue = new byte[Integer.BYTES];
       ByteUtils.writeInt(recordValue, i, 0);
-      recordEmitter.accept(EMPTY_BYTES, recordValue, -1L);
+      recordEmitter.accept(EMPTY_BYTES, recordValue, EMPTY_BYTES);
     }
     dataWriterTaskTracker.trackSprayAllPartitions();
     LOGGER.info(
@@ -125,14 +118,14 @@ public abstract class AbstractInputRecordProcessor<INPUT_KEY, INPUT_VALUE> exten
   protected boolean process(
       INPUT_KEY inputKey,
       INPUT_VALUE inputValue,
-      Long timestamp,
+      byte[] rmd,
       AtomicReference<byte[]> keyRef,
       AtomicReference<byte[]> valueRef,
-      AtomicReference<Long> timestampRef,
+      AtomicReference<byte[]> rmdRef,
       DataWriterTaskTracker dataWriterTaskTracker) {
     byte[] recordKey = veniceRecordReader.getKeyBytes(inputKey, inputValue);
     byte[] recordValue = veniceRecordReader.getValueBytes(inputKey, inputValue);
-    Long recordTimestamp = timestamp;
+    byte[] recordRmd = rmd;
     if (recordKey == null) {
       throw new VeniceException("Mapper received a empty key record");
     }
@@ -170,7 +163,7 @@ public abstract class AbstractInputRecordProcessor<INPUT_KEY, INPUT_VALUE> exten
     dataWriterTaskTracker.trackCompressedValueSize(finalRecordValue.length);
     keyRef.set(recordKey);
     valueRef.set(finalRecordValue);
-    timestampRef.set(recordTimestamp);
+    rmdRef.set(recordRmd);
 
     if (compressionMetricCollectionEnabled) {
       // Compress based on all compression strategies to collect metrics

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/task/datawriter/AbstractPartitionWriter.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/task/datawriter/AbstractPartitionWriter.java
@@ -19,7 +19,6 @@ import static com.linkedin.venice.vpj.VenicePushJobConstants.TELEMETRY_MESSAGE_I
 import static com.linkedin.venice.vpj.VenicePushJobConstants.TOPIC_PROP;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.VALUE_SCHEMA_DIR;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.VALUE_SCHEMA_ID_PROP;
-import static com.linkedin.venice.writer.VeniceWriter.APP_DEFAULT_LOGICAL_TS;
 
 import com.linkedin.avroutil1.compatibility.AvroCompatibilityHelper;
 import com.linkedin.venice.ConfigKeys;
@@ -43,7 +42,6 @@ import com.linkedin.venice.meta.ViewConfig;
 import com.linkedin.venice.partitioner.VenicePartitioner;
 import com.linkedin.venice.pubsub.api.PubSubProduceResult;
 import com.linkedin.venice.pubsub.api.PubSubProducerCallback;
-import com.linkedin.venice.schema.rmd.RmdSchemaGenerator;
 import com.linkedin.venice.serialization.DefaultSerializer;
 import com.linkedin.venice.serializer.FastSerializerDeserializerFactory;
 import com.linkedin.venice.serializer.RecordDeserializer;
@@ -93,10 +91,39 @@ import org.apache.logging.log4j.Logger;
 public abstract class AbstractPartitionWriter extends AbstractDataWriterTask implements Closeable {
   private static final Logger LOGGER = LogManager.getLogger(AbstractPartitionWriter.class);
 
+  /*
+   * A model class to hold multiple attributes passed from the reducers of VPJ to the writer class. Ideally, we can extract
+   * this class even higher and use it higher up in the call chain to avoid leaking spark abstractions into the code
+   * through vanilla spark rows. However, that is tabled for a separate refactoring effort.
+   */
+  public static class VeniceRecordWithMetadata {
+    private final byte[] key;
+    private final byte[] value;
+
+    private final byte[] rmd;
+
+    public VeniceRecordWithMetadata(byte[] key, byte[] value, byte[] rmd) {
+      this.key = key;
+      this.value = value;
+      this.rmd = rmd;
+    }
+
+    public byte[] getKey() {
+      return key;
+    }
+
+    public byte[] getValue() {
+      return value;
+    }
+
+    public byte[] getRmd() {
+      return rmd;
+    }
+  }
+
   public static class VeniceWriterMessage {
     private final byte[] keyBytes;
     private final byte[] valueBytes;
-    private final long logicalTimestamp;
     private final int valueSchemaId;
     private final int rmdVersionId;
     private final Consumer<AbstractVeniceWriter<byte[], byte[], byte[]>> consumer;
@@ -108,35 +135,22 @@ public abstract class AbstractPartitionWriter extends AbstractDataWriterTask imp
         PubSubProducerCallback callback,
         boolean enableWriteCompute,
         int derivedValueSchemaId) {
-      this(
-          keyBytes,
-          valueBytes,
-          APP_DEFAULT_LOGICAL_TS,
-          valueSchemaId,
-          -1,
-          null,
-          callback,
-          enableWriteCompute,
-          null,
-          derivedValueSchemaId);
+      this(keyBytes, valueBytes, valueSchemaId, -1, null, callback, enableWriteCompute, derivedValueSchemaId);
     }
 
     public VeniceWriterMessage(
         byte[] keyBytes,
         byte[] valueBytes,
-        long logicalTimestamp,
         int valueSchemaId,
         int rmdVersionId,
         ByteBuffer rmdPayload,
         PubSubProducerCallback callback,
         boolean enableWriteCompute,
-        Schema rmdSchema,
         int derivedValueSchemaId) {
       this.keyBytes = keyBytes;
       this.valueBytes = valueBytes;
       this.valueSchemaId = valueSchemaId;
       this.rmdVersionId = rmdVersionId;
-      this.logicalTimestamp = logicalTimestamp;
       this.consumer = writer -> {
         if (rmdPayload != null) {
           if (rmdPayload.remaining() == 0) {
@@ -152,14 +166,7 @@ public abstract class AbstractPartitionWriter extends AbstractDataWriterTask imp
         } else if (enableWriteCompute && derivedValueSchemaId > 0) {
           writer.update(keyBytes, valueBytes, valueSchemaId, derivedValueSchemaId, callback);
         } else {
-          if (this.logicalTimestamp > 0) {
-            PutMetadata putMetadata = new PutMetadata(
-                rmdVersionId,
-                RmdSchemaGenerator.generateRecordLevelTimestampMetadata(rmdSchema, this.logicalTimestamp));
-            writer.put(keyBytes, valueBytes, valueSchemaId, this.logicalTimestamp, callback, putMetadata);
-          } else {
-            writer.put(keyBytes, valueBytes, valueSchemaId, callback, null);
-          }
+          writer.put(keyBytes, valueBytes, valueSchemaId, callback, null);
         }
       };
     }
@@ -240,10 +247,13 @@ public abstract class AbstractPartitionWriter extends AbstractDataWriterTask imp
    */
   private final ScheduledExecutorService taskProgressHeartbeatScheduler = Executors.newScheduledThreadPool(1);
 
+  public VeniceRecordWithMetadata createVeniceValueRecord(byte[] keyBytes, byte[] valueBytes, byte[] rmdBytes) {
+    return new VeniceRecordWithMetadata(keyBytes, valueBytes, rmdBytes);
+  }
+
   public void processValuesForKey(
       byte[] key,
-      Iterator<byte[]> values,
-      Iterator<Long> timestampIterator,
+      Iterator<VeniceRecordWithMetadata> values,
       DataWriterTaskTracker dataWriterTaskTracker) {
     this.dataWriterTaskTracker = dataWriterTaskTracker;
     final long timeOfLastReduceFunctionStartInNS = System.nanoTime();
@@ -253,7 +263,7 @@ public abstract class AbstractPartitionWriter extends AbstractDataWriterTask imp
           (timeOfLastReduceFunctionStartInNS - timeOfLastReduceFunctionEndInNS);
     }
     if (key.length > 0 && (!hasReportedFailure(dataWriterTaskTracker, this.isDuplicateKeyAllowed))) {
-      VeniceWriterMessage message = extract(key, values, timestampIterator, rmdSchema, dataWriterTaskTracker);
+      VeniceWriterMessage message = extract(key, values, dataWriterTaskTracker);
       if (message != null) {
         try {
           sendMessageToKafka(dataWriterTaskTracker, message.getConsumer());
@@ -299,11 +309,13 @@ public abstract class AbstractPartitionWriter extends AbstractDataWriterTask imp
     return enableWriteCompute;
   }
 
+  protected Schema getRmdSchema() {
+    return rmdSchema;
+  }
+
   protected VeniceWriterMessage extract(
       byte[] keyBytes,
-      Iterator<byte[]> values,
-      Iterator<Long> timestampIterator,
-      Schema valueSchema,
+      Iterator<VeniceRecordWithMetadata> values,
       DataWriterTaskTracker dataWriterTaskTracker) {
     /**
      * Don't use {@link BytesWritable#getBytes()} since it could be padded or modified by some other records later on.
@@ -311,11 +323,11 @@ public abstract class AbstractPartitionWriter extends AbstractDataWriterTask imp
     if (!values.hasNext()) {
       throw new VeniceException("There is no value corresponding to key bytes: " + ByteUtils.toHexString(keyBytes));
     }
-    byte[] valueBytes = values.next();
-    long timestamp = -1L;
-    if (timestampIterator.hasNext()) {
-      timestamp = timestampIterator.next();
-    }
+
+    VeniceRecordWithMetadata valueRecord = values.next();
+    byte[] valueBytes = valueRecord.getValue();
+    ByteBuffer rmd = ByteBuffer.wrap(valueRecord.getRmd());
+
     if (duplicateKeyPrinter == null) {
       throw new VeniceException("'DuplicateKeyPrinter' is not initialized properly");
     }
@@ -324,13 +336,11 @@ public abstract class AbstractPartitionWriter extends AbstractDataWriterTask imp
     return new VeniceWriterMessage(
         keyBytes,
         valueBytes,
-        timestamp,
         valueSchemaId,
         -1,
-        null,
+        rmd,
         getCallback(),
         isEnableWriteCompute(),
-        valueSchema,
         getDerivedValueSchemaId());
   }
 
@@ -786,7 +796,7 @@ public abstract class AbstractPartitionWriter extends AbstractDataWriterTask imp
 
     protected void detectAndHandleDuplicateKeys(
         byte[] valueBytes,
-        Iterator<byte[]> values,
+        Iterator<VeniceRecordWithMetadata> values,
         DataWriterTaskTracker dataWriterTaskTracker) {
       if (numOfDupKey > MAX_NUM_OF_LOG) {
         return;
@@ -796,7 +806,7 @@ public abstract class AbstractPartitionWriter extends AbstractDataWriterTask imp
       int identicalValuesToKeyCount = 0;
 
       while (values.hasNext()) {
-        if (Arrays.equals(values.next(), valueBytes)) {
+        if (Arrays.equals(values.next().getValue(), valueBytes)) {
           // Identical values map to the same key. E.g. key:[ value_1, value_1]
           identicalValuesToKeyCount++;
           if (shouldPrint) {

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/spark/SparkConstants.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/spark/SparkConstants.java
@@ -14,7 +14,7 @@ public class SparkConstants {
   // Required column names for input dataframes
   public static final String KEY_COLUMN_NAME = "key";
   public static final String VALUE_COLUMN_NAME = "value";
-  public static final String TIMESTAMP_COLUMN_NAME = "timestamp";
+  public static final String RMD_COLUMN_NAME = "timestamp";
 
   // Internal column names, hence begins with "_"
   public static final String PARTITION_COLUMN_NAME = "__partition__";
@@ -22,12 +22,12 @@ public class SparkConstants {
   public static final StructType DEFAULT_SCHEMA = new StructType(
       new StructField[] { new StructField(KEY_COLUMN_NAME, BinaryType, false, Metadata.empty()),
           new StructField(VALUE_COLUMN_NAME, BinaryType, true, Metadata.empty()),
-          new StructField(TIMESTAMP_COLUMN_NAME, LongType, true, Metadata.empty()) });
+          new StructField(RMD_COLUMN_NAME, BinaryType, true, Metadata.empty()) });
 
   public static final StructType DEFAULT_SCHEMA_WITH_PARTITION = new StructType(
       new StructField[] { new StructField(KEY_COLUMN_NAME, BinaryType, false, Metadata.empty()),
           new StructField(VALUE_COLUMN_NAME, BinaryType, true, Metadata.empty()),
-          new StructField(TIMESTAMP_COLUMN_NAME, LongType, true, Metadata.empty()),
+          new StructField(RMD_COLUMN_NAME, BinaryType, true, Metadata.empty()),
           new StructField(PARTITION_COLUMN_NAME, IntegerType, false, Metadata.empty()) });
 
   /**

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/spark/datawriter/jobs/AbstractDataWriterSparkJob.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/spark/datawriter/jobs/AbstractDataWriterSparkJob.java
@@ -37,6 +37,7 @@ import static com.linkedin.venice.vpj.VenicePushJobConstants.REPUSH_TTL_ENABLE;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.REPUSH_TTL_POLICY;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.REPUSH_TTL_START_TIMESTAMP;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.RMD_SCHEMA_DIR;
+import static com.linkedin.venice.vpj.VenicePushJobConstants.RMD_SCHEMA_ID_PROP;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.RMD_SCHEMA_PROP;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.SSL_CONFIGURATOR_CLASS_CONFIG;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.SSL_KEY_PASSWORD_PROPERTY_NAME;
@@ -221,6 +222,7 @@ public abstract class AbstractDataWriterSparkJob extends DataWriterComputeJob {
     } else {
       jobConf.set(VALUE_SCHEMA_ID_PROP, pushJobSetting.valueSchemaId);
       jobConf.set(DERIVED_SCHEMA_ID_PROP, pushJobSetting.derivedSchemaId);
+      jobConf.set(RMD_SCHEMA_ID_PROP, pushJobSetting.rmdSchemaId);
     }
     jobConf.set(ENABLE_WRITE_COMPUTE, pushJobSetting.enableWriteCompute);
     if (pushJobSetting.replicationMetadataSchemaString != null) {

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/spark/datawriter/jobs/DataWriterSparkJob.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/spark/datawriter/jobs/DataWriterSparkJob.java
@@ -8,10 +8,10 @@ import static com.linkedin.venice.vpj.VenicePushJobConstants.GENERATE_PARTIAL_UP
 import static com.linkedin.venice.vpj.VenicePushJobConstants.GLOB_FILTER_PATTERN;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.INPUT_PATH_PROP;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.KEY_FIELD_PROP;
+import static com.linkedin.venice.vpj.VenicePushJobConstants.RMD_FIELD_PROP;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.RMD_SCHEMA_PROP;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.SCHEMA_STRING_PROP;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.SPARK_NATIVE_INPUT_FORMAT_ENABLED;
-import static com.linkedin.venice.vpj.VenicePushJobConstants.TIMESTAMP_FIELD_PROP;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.UPDATE_SCHEMA_STRING_PROP;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.VALUE_FIELD_PROP;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.VSON_PUSH;
@@ -69,8 +69,8 @@ public class DataWriterSparkJob extends AbstractDataWriterSparkJob {
     if (pushJobSetting.replicationMetadataSchemaString != null) {
       setInputConf(sparkSession, dataFrameReader, RMD_SCHEMA_PROP, pushJobSetting.replicationMetadataSchemaString);
     }
-    if (pushJobSetting.timestampField != null && !pushJobSetting.timestampField.isEmpty()) {
-      setInputConf(sparkSession, dataFrameReader, TIMESTAMP_FIELD_PROP, pushJobSetting.timestampField);
+    if (pushJobSetting.rmdField != null && !pushJobSetting.rmdField.isEmpty()) {
+      setInputConf(sparkSession, dataFrameReader, RMD_FIELD_PROP, pushJobSetting.rmdField);
     }
     if (pushJobSetting.etlValueSchemaTransformation != null) {
       setInputConf(
@@ -109,14 +109,14 @@ public class DataWriterSparkJob extends AbstractDataWriterSparkJob {
           pushJobSetting.inputDataSchema,
           pushJobSetting.keyField,
           pushJobSetting.valueField,
-          pushJobSetting.timestampField,
+          pushJobSetting.rmdField,
           pushJobSetting.etlValueSchemaTransformation,
           updateSchema);
 
       AvroWrapper<IndexedRecord> recordAvroWrapper = new AvroWrapper<>(rowRecord);
       final byte[] inputKeyBytes = recordReader.getKeyBytes(recordAvroWrapper, null);
       final byte[] inputValueBytes = recordReader.getValueBytes(recordAvroWrapper, null);
-      final Long timestamp = recordReader.getRecordTimestamp(recordAvroWrapper, null);
+      final byte[] timestamp = recordReader.getRmdBytes(recordAvroWrapper, null);
       return new GenericRowWithSchema(new Object[] { inputKeyBytes, inputValueBytes, timestamp }, DEFAULT_SCHEMA);
     }, RowEncoder.apply(DEFAULT_SCHEMA));
 
@@ -137,8 +137,12 @@ public class DataWriterSparkJob extends AbstractDataWriterSparkJob {
 
           final byte[] inputKeyBytes = recordReader.getKeyBytes(record._1, record._2);
           final byte[] inputValueBytes = recordReader.getValueBytes(record._1, record._2);
+          final byte[] inputRmdBytes = recordReader.getRmdBytes(record._1, record._2);
+
           // timestamp isn't supported for vson
-          return new GenericRowWithSchema(new Object[] { inputKeyBytes, inputValueBytes, -1L }, DEFAULT_SCHEMA);
+          return new GenericRowWithSchema(
+              new Object[] { inputKeyBytes, inputValueBytes, inputRmdBytes },
+              DEFAULT_SCHEMA);
         });
     return sparkSession.createDataFrame(rdd, DEFAULT_SCHEMA);
   }

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/spark/datawriter/recordprocessor/SparkInputRecordProcessor.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/spark/datawriter/recordprocessor/SparkInputRecordProcessor.java
@@ -35,9 +35,9 @@ public class SparkInputRecordProcessor extends AbstractInputRecordProcessor<Byte
     List<Row> outputRows = new ArrayList<>();
     ByteBuffer keyBB = ByteBuffer.wrap(record.getAs(SparkConstants.KEY_COLUMN_NAME));
     byte[] value = record.getAs(SparkConstants.VALUE_COLUMN_NAME);
-    Long timestamp = record.getAs(SparkConstants.TIMESTAMP_COLUMN_NAME);
+    byte[] rmd = record.getAs(SparkConstants.RMD_COLUMN_NAME);
     ByteBuffer valueBB = value == null ? null : ByteBuffer.wrap(value);
-    super.processRecord(keyBB, valueBB, timestamp, getRecordEmitter(outputRows), dataWriterTaskTracker);
+    super.processRecord(keyBB, valueBB, rmd, getRecordEmitter(outputRows), dataWriterTaskTracker);
     return outputRows.iterator();
   }
 
@@ -46,9 +46,9 @@ public class SparkInputRecordProcessor extends AbstractInputRecordProcessor<Byte
     return IdentityVeniceRecordReader.getInstance();
   }
 
-  private TriConsumer<byte[], byte[], Long> getRecordEmitter(List<Row> rows) {
-    return (key, value, timestamp) -> {
-      rows.add(new GenericRowWithSchema(new Object[] { key, value, timestamp }, SparkConstants.DEFAULT_SCHEMA));
+  private TriConsumer<byte[], byte[], byte[]> getRecordEmitter(List<Row> rows) {
+    return (key, value, rmd) -> {
+      rows.add(new GenericRowWithSchema(new Object[] { key, value, rmd }, SparkConstants.DEFAULT_SCHEMA));
     };
   }
 }

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/spark/datawriter/writer/SparkPartitionWriter.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/spark/datawriter/writer/SparkPartitionWriter.java
@@ -1,11 +1,11 @@
 package com.linkedin.venice.spark.datawriter.writer;
 
 import static com.linkedin.venice.spark.SparkConstants.KEY_COLUMN_NAME;
-import static com.linkedin.venice.spark.SparkConstants.TIMESTAMP_COLUMN_NAME;
+import static com.linkedin.venice.spark.SparkConstants.RMD_COLUMN_NAME;
 import static com.linkedin.venice.spark.SparkConstants.VALUE_COLUMN_NAME;
 
-import com.linkedin.venice.exceptions.VeniceException;
 import com.linkedin.venice.hadoop.task.datawriter.AbstractPartitionWriter;
+import com.linkedin.venice.schema.rmd.RmdSchemaGenerator;
 import com.linkedin.venice.spark.datawriter.task.DataWriterAccumulators;
 import com.linkedin.venice.spark.datawriter.task.SparkDataWriterTaskTracker;
 import com.linkedin.venice.spark.engine.SparkEngineTaskConfigProvider;
@@ -37,44 +37,42 @@ public class SparkPartitionWriter extends AbstractPartitionWriter {
   }
 
   void processRows(Iterator<Row> rows) {
+    List<VeniceRecordWithMetadata> valueRecordsForKey = new ArrayList<>();
     byte[] key = null;
-    List<byte[]> valuesForKey = null;
-    List<Long> logicalTimestamps = null;
-    Long logicalTimestamp;
+
     while (rows.hasNext()) {
       Row row = rows.next();
       byte[] incomingKey = Objects.requireNonNull(row.getAs(KEY_COLUMN_NAME), "Key cannot be null");
 
-      logicalTimestamp = -1L;
+      byte[] rmd = new byte[0];
       try {
-        logicalTimestamp = row.getAs(TIMESTAMP_COLUMN_NAME);
+        rmd = row.getAs(RMD_COLUMN_NAME);
       } catch (IllegalArgumentException e) {
         // Ignore if timestamp is not present
-      } catch (ClassCastException e) {
-        LOGGER.error("Passed timestamp column is not of type long!!!");
-        throw e;
       }
 
       if (!Arrays.equals(incomingKey, key)) {
         if (key != null) {
-          if (!logicalTimestamps.isEmpty() && valuesForKey.size() != logicalTimestamps.size()) {
-            throw new VeniceException("Count mismatch between logical timestamps and input records, aborting!!");
-          }
           // Key is different from the prev one and is not null. Write it out to PubSub.
-          super.processValuesForKey(key, valuesForKey.iterator(), logicalTimestamps.iterator(), dataWriterTaskTracker);
+          super.processValuesForKey(key, valueRecordsForKey.iterator(), dataWriterTaskTracker);
         }
         key = incomingKey;
-        valuesForKey = new ArrayList<>();
-        logicalTimestamps = new ArrayList<>();
+        valueRecordsForKey = new ArrayList<>();
       }
 
       byte[] incomingValue = row.getAs(VALUE_COLUMN_NAME);
-      valuesForKey.add(incomingValue);
-      logicalTimestamps.add(logicalTimestamp);
+      valueRecordsForKey.add(createVeniceValueRecord(key, incomingValue, rmd));
     }
 
     if (key != null) {
-      super.processValuesForKey(key, valuesForKey.iterator(), logicalTimestamps.iterator(), dataWriterTaskTracker);
+      super.processValuesForKey(key, valueRecordsForKey.iterator(), dataWriterTaskTracker);
     }
+  }
+
+  private byte[] convertLogicalTimestampToRmd(Long logicalTimestamp) {
+    if (logicalTimestamp == -1L) {
+      return new byte[0];
+    }
+    return RmdSchemaGenerator.generateRecordLevelTimestampMetadata(getRmdSchema(), logicalTimestamp);
   }
 }

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/spark/input/VeniceAbstractPartitionReader.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/spark/input/VeniceAbstractPartitionReader.java
@@ -28,7 +28,7 @@ public abstract class VeniceAbstractPartitionReader implements PartitionReader<I
   public InternalRow get() {
     return new GenericInternalRow(
         new Object[] { recordIterator.getCurrentKey(), recordIterator.getCurrentValue(),
-            recordIterator.getTimeStamp() });
+            recordIterator.getCurrentRmd() });
   }
 
   @Override

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/vpj/VenicePushJobConstants.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/vpj/VenicePushJobConstants.java
@@ -23,10 +23,10 @@ public final class VenicePushJobConstants {
 
   public static final String KEY_FIELD_PROP = "key.field";
   public static final String VALUE_FIELD_PROP = "value.field";
-  public static final String TIMESTAMP_FIELD_PROP = "timestamp.field";
+  public static final String RMD_FIELD_PROP = "timestamp.field";
   public static final String DEFAULT_KEY_FIELD_PROP = "key";
   public static final String DEFAULT_VALUE_FIELD_PROP = "value";
-  public static final String DEFAULT_TIMESTAMP_FIELD_PROP = "timestamp";
+  public static final String DEFAULT_RMD_FIELD_PROP = "timestamp";
   public static final boolean DEFAULT_SSL_ENABLED = false;
   public static final String SCHEMA_STRING_PROP = "schema";
   public static final String KAFKA_SOURCE_KEY_SCHEMA_STRING_PROP = "kafka.source.key.schema";
@@ -214,6 +214,8 @@ public final class VenicePushJobConstants {
   public static final FsPermission PERMISSION_700 = FsPermission.createImmutable((short) 0700);
 
   public static final String VALUE_SCHEMA_ID_PROP = "value.schema.id";
+
+  public static final String RMD_SCHEMA_ID_PROP = "rmd.schema.id";
   public static final String DERIVED_SCHEMA_ID_PROP = "derived.schema.id";
   public static final String TOPIC_PROP = "venice.kafka.topic";
   public static final String HADOOP_VALIDATE_SCHEMA_AND_BUILD_DICT_PREFIX = "hadoop-dict-build-conf.";

--- a/clients/venice-push-job/src/test/java/com/linkedin/venice/hadoop/input/kafka/TestVeniceKafkaInputMapper.java
+++ b/clients/venice-push-job/src/test/java/com/linkedin/venice/hadoop/input/kafka/TestVeniceKafkaInputMapper.java
@@ -127,10 +127,10 @@ public class TestVeniceKafkaInputMapper extends AbstractTestVeniceMapper<VeniceK
       if (mapper.process(
           EMPTY_KEY,
           generateKIFRecord(),
-          -1L,
+          new byte[0],
           EMPTY_BYTE_REF,
           EMPTY_BYTE_REF,
-          EMPTY_LONG_REF,
+          EMPTY_BYTE_REF,
           mock(DataWriterTaskTracker.class))) {
         validCount++;
       } else {
@@ -152,7 +152,7 @@ public class TestVeniceKafkaInputMapper extends AbstractTestVeniceMapper<VeniceK
     // Trigger manually to set the dummy filterChain
     mapper.configureTask(any());
 
-    Assert.assertFalse(mapper.process(null, null, -1L, null, null, null, mock(DataWriterTaskTracker.class)));
+    Assert.assertFalse(mapper.process(null, null, null, null, null, null, mock(DataWriterTaskTracker.class)));
   }
 
   private KafkaInputMapperValue generateKIFRecord() {

--- a/clients/venice-push-job/src/test/java/com/linkedin/venice/hadoop/input/kafka/TestVeniceKafkaInputReducer.java
+++ b/clients/venice-push-job/src/test/java/com/linkedin/venice/hadoop/input/kafka/TestVeniceKafkaInputReducer.java
@@ -79,15 +79,14 @@ public class TestVeniceKafkaInputReducer {
     /**
      * Construct a list of values, which contain only 'PUT'.
      */
-    List<byte[]> values = getValues(
+    List<AbstractPartitionWriter.VeniceRecordWithMetadata> values = getValues(
+        keyBytes,
         Arrays.asList(MapperValueType.PUT, MapperValueType.PUT, MapperValueType.PUT),
         valueContainsRmdPayload);
 
     AbstractPartitionWriter.VeniceWriterMessage message = reducer.extract(
         serializedMapperKey,
         values.iterator(),
-        Collections.emptyIterator(),
-        null,
         new ReporterBackedMapReduceDataWriterTaskTracker(Mockito.mock(Reporter.class)));
     Assert.assertNotNull(message);
     Assert.assertEquals(message.getKeyBytes(), keyBytes);
@@ -99,14 +98,13 @@ public class TestVeniceKafkaInputReducer {
      * Construct a list of values, which contains both 'PUT' and 'DELETE', but 'DELETE' is the last one.
      */
     values = getValues(
+        keyBytes,
         Arrays.asList(MapperValueType.PUT, MapperValueType.PUT, MapperValueType.DELETE),
         valueContainsRmdPayload);
 
     message = reducer.extract(
         serializedMapperKey,
         values.iterator(),
-        Collections.emptyIterator(),
-        null,
         new ReporterBackedMapReduceDataWriterTaskTracker(Mockito.mock(Reporter.class)));
     // If DELETE contains RMD, it should be kept.
     if (valueContainsRmdPayload) {
@@ -119,14 +117,13 @@ public class TestVeniceKafkaInputReducer {
      * Construct a list of values, which contains both 'PUT' and 'DELETE', but 'DELETE' is in the middle.
      */
     values = getValues(
+        keyBytes,
         Arrays.asList(MapperValueType.PUT, MapperValueType.DELETE, MapperValueType.PUT),
         valueContainsRmdPayload);
 
     message = reducer.extract(
         serializedMapperKey,
         values.iterator(),
-        Collections.emptyIterator(),
-        null,
         new ReporterBackedMapReduceDataWriterTaskTracker(Mockito.mock(Reporter.class)));
     Assert.assertNotNull(message);
     Assert.assertEquals(message.getKeyBytes(), keyBytes);
@@ -157,13 +154,12 @@ public class TestVeniceKafkaInputReducer {
     /**
      * Construct a list of values, which contain only 'PUT'.
      */
-    List<byte[]> values = getValues(Arrays.asList(MapperValueType.PUT, MapperValueType.PUT, MapperValueType.PUT), true);
+    List<AbstractPartitionWriter.VeniceRecordWithMetadata> values =
+        getValues(keyBytes, Arrays.asList(MapperValueType.PUT, MapperValueType.PUT, MapperValueType.PUT), true);
 
     AbstractPartitionWriter.VeniceWriterMessage message = reducer.extract(
         serializedMapperKey,
         values.iterator(),
-        Collections.emptyIterator(),
-        null,
         new ReporterBackedMapReduceDataWriterTaskTracker(Mockito.mock(Reporter.class)));
 
     if (isChunkingEnabled) {
@@ -175,8 +171,11 @@ public class TestVeniceKafkaInputReducer {
     }
   }
 
-  public List<byte[]> getValues(List<MapperValueType> valueTypes, boolean hasRmdPayload) {
-    List<byte[]> values = new ArrayList<>();
+  public List<AbstractPartitionWriter.VeniceRecordWithMetadata> getValues(
+      byte[] keyBytes,
+      List<MapperValueType> valueTypes,
+      boolean hasRmdPayload) {
+    List<AbstractPartitionWriter.VeniceRecordWithMetadata> values = new ArrayList<>();
     long offset = 0;
     for (MapperValueType valueType: valueTypes) {
       KafkaInputMapperValue value = new KafkaInputMapperValue();
@@ -192,7 +191,11 @@ public class TestVeniceKafkaInputReducer {
         value.value = ByteBuffer.wrap((VALUE_PREFIX + value.offset).getBytes());
       }
       byte[] serializedValue = KAFKA_INPUT_MAPPER_VALUE_SERIALIZER.serialize(value);
-      values.add(serializedValue);
+      values.add(
+          new AbstractPartitionWriter.VeniceRecordWithMetadata(
+              keyBytes,
+              serializedValue,
+              value.replicationMetadataPayload.array()));
     }
     Collections.reverse(values);
     return values;

--- a/clients/venice-push-job/src/test/java/com/linkedin/venice/hadoop/recordreader/avro/TestVeniceAvroRecordReader.java
+++ b/clients/venice-push-job/src/test/java/com/linkedin/venice/hadoop/recordreader/avro/TestVeniceAvroRecordReader.java
@@ -10,7 +10,7 @@ import static com.linkedin.venice.utils.TestWriteUtils.STRING_SCHEMA;
 import static com.linkedin.venice.utils.TestWriteUtils.STRING_TO_NAME_RECORD_V1_SCHEMA;
 import static com.linkedin.venice.utils.TestWriteUtils.STRING_TO_NAME_WITH_TIMESTAMP_RECORD_V1_SCHEMA;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.DEFAULT_KEY_FIELD_PROP;
-import static com.linkedin.venice.vpj.VenicePushJobConstants.DEFAULT_TIMESTAMP_FIELD_PROP;
+import static com.linkedin.venice.vpj.VenicePushJobConstants.DEFAULT_RMD_FIELD_PROP;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.DEFAULT_VALUE_FIELD_PROP;
 
 import com.linkedin.avroutil1.compatibility.AvroCompatibilityHelper;
@@ -51,7 +51,7 @@ public class TestVeniceAvroRecordReader {
         STRING_TO_NAME_RECORD_V1_SCHEMA,
         "key",
         "value",
-        DEFAULT_TIMESTAMP_FIELD_PROP,
+        DEFAULT_RMD_FIELD_PROP,
         NONE,
         updateSchema);
 
@@ -79,7 +79,7 @@ public class TestVeniceAvroRecordReader {
         STRING_TO_NAME_WITH_TIMESTAMP_RECORD_V1_SCHEMA,
         "key",
         "value",
-        DEFAULT_TIMESTAMP_FIELD_PROP,
+        DEFAULT_RMD_FIELD_PROP,
         NONE,
         updateSchema);
 
@@ -91,7 +91,7 @@ public class TestVeniceAvroRecordReader {
     valueRecord.put("lastName", "LN");
     record.put("value", valueRecord);
     Object result = recordReader.getAvroValue(new AvroWrapper<>(record), NullWritable.get());
-    Assert.assertEquals(recordReader.getRecordTimestamp(new AvroWrapper<>(record), NullWritable.get()), timestamp);
+    Assert.assertEquals(recordReader.getRmdValue(new AvroWrapper<>(record), NullWritable.get()), timestamp);
     Assert.assertTrue(result instanceof IndexedRecord);
 
     Assert.assertEquals(((IndexedRecord) result).get(updateSchema.getField("firstName").pos()), "FN");
@@ -102,7 +102,7 @@ public class TestVeniceAvroRecordReader {
 
     // Test the exceptional case
     record.put("timestamp", null);
-    Assert.assertThrows(() -> recordReader.getRecordTimestamp(new AvroWrapper<>(record), NullWritable.get()));
+    Assert.assertThrows(() -> recordReader.getRmdValue(new AvroWrapper<>(record), NullWritable.get()));
   }
 
   @Test(dataProvider = "Boolean-and-EtlTransformations")
@@ -139,7 +139,7 @@ public class TestVeniceAvroRecordReader {
         fileSchema,
         DEFAULT_KEY_FIELD_PROP,
         DEFAULT_VALUE_FIELD_PROP,
-        DEFAULT_TIMESTAMP_FIELD_PROP,
+        DEFAULT_RMD_FIELD_PROP,
         etlValueSchemaTransformation,
         null);
 

--- a/clients/venice-push-job/src/test/java/com/linkedin/venice/spark/input/hdfs/TestSparkInputFromHdfs.java
+++ b/clients/venice-push-job/src/test/java/com/linkedin/venice/spark/input/hdfs/TestSparkInputFromHdfs.java
@@ -71,7 +71,7 @@ public class TestSparkInputFromHdfs {
     config.put(VALUE_FIELD_PROP, DEFAULT_VALUE_FIELD_PROP);
     if (useRecordLevelTimestamp) {
       config.put(SCHEMA_STRING_PROP, AVRO_FILE_WITH_TIMESTAMPS_SCHEMA.toString());
-      config.put(TIMESTAMP_FIELD_PROP, "timestamp");
+      config.put(RMD_FIELD_PROP, "timestamp");
     } else {
       config.put(SCHEMA_STRING_PROP, AVRO_FILE_SCHEMA.toString());
     }
@@ -269,7 +269,7 @@ public class TestSparkInputFromHdfs {
         user.put(DEFAULT_KEY_FIELD_PROP, Integer.toString(i));
         user.put(DEFAULT_VALUE_FIELD_PROP, DEFAULT_USER_DATA_VALUE_PREFIX + i);
         if (includeTimestamps) {
-          user.put(DEFAULT_TIMESTAMP_FIELD_PROP, timestamp);
+          user.put(DEFAULT_RMD_FIELD_PROP, timestamp);
         }
         dataFileWriter.append(user);
       }

--- a/clients/venice-push-job/src/test/java/com/linkedin/venice/zstd/TestZstdLibrary.java
+++ b/clients/venice-push-job/src/test/java/com/linkedin/venice/zstd/TestZstdLibrary.java
@@ -5,7 +5,7 @@ import static com.linkedin.venice.utils.ByteUtils.BYTES_PER_MB;
 import static com.linkedin.venice.utils.TestWriteUtils.writeSimpleAvroFileWithStringToStringSchema;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.COMPRESSION_DICTIONARY_SAMPLE_SIZE;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.COMPRESSION_DICTIONARY_SIZE_LIMIT;
-import static com.linkedin.venice.vpj.VenicePushJobConstants.DEFAULT_TIMESTAMP_FIELD_PROP;
+import static com.linkedin.venice.vpj.VenicePushJobConstants.DEFAULT_RMD_FIELD_PROP;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.PATH_FILTER;
 
 import com.github.luben.zstd.ZstdDictTrainer;
@@ -58,7 +58,7 @@ public class TestZstdLibrary {
             HdfsAvroUtils.getFileSchema(fs, fileStatus.getPath()),
             "key",
             "value",
-            DEFAULT_TIMESTAMP_FIELD_PROP,
+            DEFAULT_RMD_FIELD_PROP,
             ETLValueSchemaTransformation.NONE,
             null);
         VeniceAvroFileIterator avroFileIterator = new VeniceAvroFileIterator(fs, fileStatus.getPath(), recordReader);

--- a/internal/venice-client-common/src/main/java/com/linkedin/venice/schema/rmd/RmdSchemaGenerator.java
+++ b/internal/venice-client-common/src/main/java/com/linkedin/venice/schema/rmd/RmdSchemaGenerator.java
@@ -5,7 +5,6 @@ import com.linkedin.venice.exceptions.VeniceException;
 import com.linkedin.venice.schema.rmd.v1.RmdSchemaGeneratorV1;
 import com.linkedin.venice.serializer.FastSerializerDeserializerFactory;
 import io.tehuti.utils.Utils;
-import java.nio.ByteBuffer;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -54,12 +53,12 @@ public class RmdSchemaGenerator {
    *
    * @param schema metadata schema.  This schema MUST contain a root level timestamp field
    * @param timestamp the timestamp to place in the record
-   * @return a bytebuffer containing the serialized metadata payload with the passed timestamp
+   * @return a byte array containing the serialized metadata payload with the passed timestamp
    */
-  public static ByteBuffer generateRecordLevelTimestampMetadata(Schema schema, Long timestamp) {
+  public static byte[] generateRecordLevelTimestampMetadata(Schema schema, Long timestamp) {
     GenericRecord record = new GenericData.Record(schema);
     record.put(RmdConstants.TIMESTAMP_FIELD_NAME, timestamp);
-    return ByteBuffer.wrap(FastSerializerDeserializerFactory.getFastAvroGenericSerializer(schema).serialize(record));
+    return FastSerializerDeserializerFactory.getFastAvroGenericSerializer(schema).serialize(record);
   }
 
   public static int getLatestVersion() {

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestActiveActiveIngestion.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestActiveActiveIngestion.java
@@ -21,10 +21,10 @@ import static com.linkedin.venice.vpj.VenicePushJobConstants.KAFKA_INPUT_BROKER_
 import static com.linkedin.venice.vpj.VenicePushJobConstants.KAFKA_INPUT_MAX_RECORDS_PER_MAPPER;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.REPUSH_TTL_ENABLE;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.REWIND_TIME_IN_SECONDS_OVERRIDE;
+import static com.linkedin.venice.vpj.VenicePushJobConstants.RMD_FIELD_PROP;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.SOURCE_KAFKA;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.SPARK_NATIVE_INPUT_FORMAT_ENABLED;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.TARGETED_REGION_PUSH_ENABLED;
-import static com.linkedin.venice.vpj.VenicePushJobConstants.TIMESTAMP_FIELD_PROP;
 
 import com.linkedin.davinci.kafka.consumer.KafkaConsumerServiceDelegator;
 import com.linkedin.venice.client.store.AvroGenericStoreClient;
@@ -269,7 +269,7 @@ public class TestActiveActiveIngestion {
         .writeSimpleAvroFileWithStringToStringAndTimestampSchema(inputDir, 100, "string2string.avro", oldTimestamp);
     props.setProperty(DATA_WRITER_COMPUTE_JOB_CLASS, DataWriterSparkJob.class.getCanonicalName());
     props.setProperty(SPARK_NATIVE_INPUT_FORMAT_ENABLED, String.valueOf(true));
-    props.setProperty(TIMESTAMP_FIELD_PROP, "timestamp");
+    props.setProperty(RMD_FIELD_PROP, "timestamp");
     IntegrationTestPushUtils.runVPJ(props);
 
     // All streaming writes should succeed

--- a/internal/venice-test-common/src/main/java/com/linkedin/venice/utils/TestWriteUtils.java
+++ b/internal/venice-test-common/src/main/java/com/linkedin/venice/utils/TestWriteUtils.java
@@ -4,7 +4,7 @@ import static com.linkedin.venice.ConfigKeys.MULTI_REGION;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.CONTROLLER_REQUEST_RETRY_ATTEMPTS;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.D2_ZK_HOSTS_PREFIX;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.DEFAULT_KEY_FIELD_PROP;
-import static com.linkedin.venice.vpj.VenicePushJobConstants.DEFAULT_TIMESTAMP_FIELD_PROP;
+import static com.linkedin.venice.vpj.VenicePushJobConstants.DEFAULT_RMD_FIELD_PROP;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.DEFAULT_VALUE_FIELD_PROP;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.INPUT_PATH_PROP;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.KEY_INPUT_FILE_DATA_SIZE;
@@ -152,13 +152,13 @@ public class TestWriteUtils {
       new PushInputSchemaBuilder().setKeySchema(STRING_SCHEMA).setValueSchema(STRING_SCHEMA).build();
   public static final Schema STRING_TO_STRING_WITH_TIMESTAMP = new PushInputSchemaBuilder().setKeySchema(STRING_SCHEMA)
       .setValueSchema(STRING_SCHEMA)
-      .setFieldSchema(DEFAULT_TIMESTAMP_FIELD_PROP, Schema.create(Schema.Type.LONG))
+      .setFieldSchema(DEFAULT_RMD_FIELD_PROP, Schema.create(Schema.Type.LONG))
       .build();
 
   public static final Schema STRING_TO_NAME_WITH_TIMESTAMP_RECORD_V1_SCHEMA =
       new PushInputSchemaBuilder().setKeySchema(STRING_SCHEMA)
           .setValueSchema(NAME_RECORD_V1_SCHEMA)
-          .setFieldSchema(DEFAULT_TIMESTAMP_FIELD_PROP, Schema.create(Schema.Type.LONG))
+          .setFieldSchema(DEFAULT_RMD_FIELD_PROP, Schema.create(Schema.Type.LONG))
           .build();
 
   public static final Schema STRING_TO_NAME_RECORD_V1_SCHEMA =
@@ -260,7 +260,7 @@ public class TestWriteUtils {
         GenericRecord user = new GenericData.Record(recordSchema);
         user.put(DEFAULT_KEY_FIELD_PROP, Integer.toString(i));
         user.put(DEFAULT_VALUE_FIELD_PROP, DEFAULT_USER_DATA_VALUE_PREFIX + i);
-        user.put(DEFAULT_TIMESTAMP_FIELD_PROP, timestamp);
+        user.put(DEFAULT_RMD_FIELD_PROP, timestamp);
         writer.append(user);
       }
     });


### PR DESCRIPTION
## Problem Statement
Certain types of pushes orchestrated by the framework/platform does not carry forward metadata that is used for deterministic conflict resolution. Often times, the framework orchestrated pushes belong to compliance, compaction and other types. 

In this PR, we make changes to support the ground work for including RMD (replication metadata) as part of VPJ.

###  Code changes
- Expand the existing timestamp field to also take in RMD object
- Modify existing timestamp property schema type and validation related code
- Pull out logic to convert the incoming logic timestamp to RMD object higher up in the call chain to clean up interfaces
- Introduce a model class to hold `K,V,RMD` instead of expanding existing consumers from bi -> tri to more.

## How was this PR tested?

In progress.
Testing it internally with a spark push job. 

## Does this PR introduce any user-facing or breaking changes?
- [x] No. You can skip the rest of this section.
- [ ] Yes. Clearly explain the behavior change and its impact.