### PR TITLE
[server] Delete version_topic_end_offset_rewind_count metric

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/AggVersionedIngestionStats.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/AggVersionedIngestionStats.java
@@ -194,10 +194,6 @@ public class AggVersionedIngestionStats
         stat -> stat.recordConsumedRecordEndToEndProcessingLatency(value, currentTimeMs));
   }
 
-  public void recordVersionTopicEndOffsetRewind(String storeName, int version) {
-    recordVersionedAndTotalStat(storeName, version, IngestionStats::recordVersionTopicEndOffsetRewind);
-  }
-
   public void recordNearlineProducerToLocalBrokerLatency(String storeName, int version, double value, long timestamp) {
     recordVersionedAndTotalStat(
         storeName,

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/IngestionStats.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/IngestionStats.java
@@ -45,7 +45,6 @@ public class IngestionStats {
   protected static final String OFFSET_REGRESSION_DCR_ERROR = "offset_regression_dcr_error";
   protected static final String TOMBSTONE_CREATION_DCR = "tombstone_creation_dcr";
   protected static final String READY_TO_SERVE_WITH_RT_LAG_METRIC_NAME = "ready_to_serve_with_rt_lag";
-  public static final String VERSION_TOPIC_END_OFFSET_REWIND_COUNT = "version_topic_end_offset_rewind_count";
   public static final String NEARLINE_PRODUCER_TO_LOCAL_BROKER_LATENCY = "nearline_producer_to_local_broker_latency";
   public static final String NEARLINE_LOCAL_BROKER_TO_READY_TO_SERVE_LATENCY =
       "nearline_local_broker_to_ready_to_serve_latency";
@@ -101,9 +100,6 @@ public class IngestionStats {
   private final Count totalDuplicateKeyUpdateCount = new Count();
   private final Sensor totalDuplicateKeyUpdateCountSensor;
 
-  /** Record a version-level offset rewind events for VTs across all stores. */
-  private final Count versionTopicEndOffsetRewindCount = new Count();
-  private final Sensor versionTopicEndOffsetRewindSensor;
   private final MetricsRepository localMetricRepository;
 
   // Measure the max idle time among partitions for a given the store on this host
@@ -155,8 +151,6 @@ public class IngestionStats {
     registerSensor(localMetricRepository, LEADER_RECORDS_PRODUCED_METRIC_NAME, leaderRecordsProducedSensor);
     registerSensor(localMetricRepository, LEADER_BYTES_PRODUCED_METRIC_NAME, leaderBytesProducedSensor);
 
-    versionTopicEndOffsetRewindSensor = localMetricRepository.sensor(VERSION_TOPIC_END_OFFSET_REWIND_COUNT);
-    versionTopicEndOffsetRewindSensor.add(VERSION_TOPIC_END_OFFSET_REWIND_COUNT, versionTopicEndOffsetRewindCount);
     totalDuplicateKeyUpdateCountSensor = localMetricRepository.sensor(TOTAL_DUPLICATE_KEY_UPDATE_COUNT);
     totalDuplicateKeyUpdateCountSensor.add(TOTAL_DUPLICATE_KEY_UPDATE_COUNT, totalDuplicateKeyUpdateCount);
 
@@ -290,14 +284,6 @@ public class IngestionStats {
 
   public void recordInternalPreprocessingLatency(double value, long currentTimeMs) {
     internalPreprocessingLatency.record(value, currentTimeMs);
-  }
-
-  public void recordVersionTopicEndOffsetRewind() {
-    versionTopicEndOffsetRewindSensor.record();
-  }
-
-  public double getVersionTopicEndOffsetRewindCount() {
-    return versionTopicEndOffsetRewindCount.measure(METRIC_CONFIG, System.currentTimeMillis());
   }
 
   public double getConsumedRecordEndToEndProcessingLatencyAvg() {

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/IngestionStatsReporter.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/IngestionStatsReporter.java
@@ -31,7 +31,6 @@ import static com.linkedin.davinci.stats.IngestionStats.TOMBSTONE_CREATION_DCR;
 import static com.linkedin.davinci.stats.IngestionStats.TOTAL_DCR;
 import static com.linkedin.davinci.stats.IngestionStats.TOTAL_DUPLICATE_KEY_UPDATE_COUNT;
 import static com.linkedin.davinci.stats.IngestionStats.UPDATE_IGNORED_DCR;
-import static com.linkedin.davinci.stats.IngestionStats.VERSION_TOPIC_END_OFFSET_REWIND_COUNT;
 import static com.linkedin.davinci.stats.IngestionStats.WRITE_COMPUTE_OPERATION_FAILURE;
 import static com.linkedin.venice.stats.StatsErrorCode.NULL_INGESTION_STATS;
 
@@ -78,13 +77,6 @@ public class IngestionStatsReporter extends AbstractVeniceStatsReporter<Ingestio
             WRITE_COMPUTE_OPERATION_FAILURE));
 
     registerSensor(new IngestionStatsGauge(this, () -> getStats().getStorageQuotaUsed(), 0, STORAGE_QUOTA_USED));
-
-    registerSensor(
-        new IngestionStatsGauge(
-            this,
-            () -> getStats().getVersionTopicEndOffsetRewindCount(),
-            0,
-            VERSION_TOPIC_END_OFFSET_REWIND_COUNT));
 
     registerSensor(
         new IngestionStatsGauge(this, () -> getStats().getRecordsConsumed(), 0, RECORDS_CONSUMED_METRIC_NAME));


### PR DESCRIPTION
## [server] Delete version_topic_end_offset_rewind_count metric

Deleted metric version_topic_end_offset_rewind_count. The metric captures  
a rare case and not really actionable since Kafka drops data anyways. Rewinds  
should still be visible through HB alerts, which makes this metric redundant.  


###  Code changes
- [ ] Added new code behind **a config**. If so list the config names and their default values in the PR description.
- [ ] Introduced new **log lines**. 
  - [ ] Confirmed if logs need to be **rate limited** to avoid excessive logging.

###  **Concurrency-Specific Checks**
Both reviewer and PR author to verify
- [ ] Code has **no race conditions** or **thread safety issues**.
- [ ] Proper **synchronization mechanisms** (e.g., `synchronized`, `RWLock`) are used where needed.
- [ ] No **blocking calls** inside critical sections that could lead to deadlocks or performance degradation.
- [ ] Verified **thread-safe collections** are used (e.g., `ConcurrentHashMap`, `CopyOnWriteArrayList`).
- [ ] Validated proper exception handling in multi-threaded code to avoid silent thread termination.


## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->

- [ ] New unit tests added.
- [ ] New integration tests added.
- [ ] Modified or extended existing tests.
- [ ] Verified backward compatibility (if applicable).

## Does this PR introduce any user-facing or breaking changes?
<!--  
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [ ] No. You can skip the rest of this section.
- [ ] Yes. Clearly explain the behavior change and its impact.