### PR TITLE
[controller] Migrate from long offset to PubSubPosition abstraction in admin message consumption

### DIFF
--- a/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/PubSubUtil.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/PubSubUtil.java
@@ -293,7 +293,6 @@ public final class PubSubUtil {
    * @return the calculated seek offset
    */
   public static long calculateSeekOffset(long baseOffset, boolean isInclusive) {
-    // return Math.max(0L, isInclusive ? baseOffset : baseOffset + 1);
     return isInclusive ? baseOffset : baseOffset + 1;
   }
 

--- a/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/PubSubUtil.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/PubSubUtil.java
@@ -293,7 +293,8 @@ public final class PubSubUtil {
    * @return the calculated seek offset
    */
   public static long calculateSeekOffset(long baseOffset, boolean isInclusive) {
-    return Math.max(0L, isInclusive ? baseOffset : baseOffset + 1);
+    // return Math.max(0L, isInclusive ? baseOffset : baseOffset + 1);
+    return isInclusive ? baseOffset : baseOffset + 1;
   }
 
   /**

--- a/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/PubSubUtil.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/PubSubUtil.java
@@ -197,7 +197,9 @@ public final class PubSubUtil {
    * @return A negative integer, zero, or a positive integer if position1 is less than,
    *         equal to, or greater than position2, respectively.
    * @throws IllegalArgumentException if either position is {@code null}.
+   * @Deprecated Use {@link com.linkedin.venice.pubsub.manager.TopicManager#diffPosition(PubSubTopicPartition, PubSubPosition, PubSubPosition)} instead.
    */
+  @Deprecated
   public static int comparePubSubPositions(PubSubPosition position1, PubSubPosition position2) {
     if (position1 == null || position2 == null) {
       throw new IllegalArgumentException("Positions cannot be null");
@@ -291,7 +293,7 @@ public final class PubSubUtil {
    * @return the calculated seek offset
    */
   public static long calculateSeekOffset(long baseOffset, boolean isInclusive) {
-    return isInclusive ? baseOffset : baseOffset + 1;
+    return Math.max(0L, isInclusive ? baseOffset : baseOffset + 1);
   }
 
   /**

--- a/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/manager/TopicMetadataFetcher.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/manager/TopicMetadataFetcher.java
@@ -526,10 +526,10 @@ class TopicMetadataFetcher implements Closeable {
 
   public long diffPosition(PubSubTopicPartition partition, PubSubPosition position1, PubSubPosition position2) {
     PubSubTopic pubSubTopic = partition.getPubSubTopic();
-    PubSubConsumerAdapter pubSubConsumerAdapter = acquireConsumer();
     if (!pubSubAdminAdapter.containsTopic(pubSubTopic)) {
       throw new PubSubTopicDoesNotExistException(pubSubTopic);
     }
+    PubSubConsumerAdapter pubSubConsumerAdapter = acquireConsumer();
     try {
       return pubSubConsumerAdapter.positionDifference(partition, position1, position2);
     } finally {

--- a/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/manager/TopicMetadataFetcher.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/manager/TopicMetadataFetcher.java
@@ -525,7 +525,11 @@ class TopicMetadataFetcher implements Closeable {
   }
 
   public long diffPosition(PubSubTopicPartition partition, PubSubPosition position1, PubSubPosition position2) {
+    PubSubTopic pubSubTopic = partition.getPubSubTopic();
     PubSubConsumerAdapter pubSubConsumerAdapter = acquireConsumer();
+    if (!pubSubAdminAdapter.containsTopic(pubSubTopic)) {
+      throw new PubSubTopicDoesNotExistException(pubSubTopic);
+    }
     try {
       return pubSubConsumerAdapter.positionDifference(partition, position1, position2);
     } finally {

--- a/internal/venice-test-common/src/main/java/com/linkedin/venice/admin/InMemoryAdminTopicMetadataAccessor.java
+++ b/internal/venice-test-common/src/main/java/com/linkedin/venice/admin/InMemoryAdminTopicMetadataAccessor.java
@@ -35,7 +35,7 @@ public class InMemoryAdminTopicMetadataAccessor extends AdminTopicMetadataAccess
       inMemoryMetadata.setPubSubPosition(newPosition);
     }
     if (!newUpstreamPosition.equals(PubSubSymbolicPosition.EARLIEST)) {
-      inMemoryMetadata.setPubSubPosition(newUpstreamPosition);
+      inMemoryMetadata.setUpstreamPubSubPosition(newUpstreamPosition);
     }
 
     LOGGER.info("Persisted admin topic metadata for cluster: {}, metadata: {}", clusterName, metadataDelta);

--- a/internal/venice-test-common/src/main/java/com/linkedin/venice/admin/InMemoryAdminTopicMetadataAccessor.java
+++ b/internal/venice-test-common/src/main/java/com/linkedin/venice/admin/InMemoryAdminTopicMetadataAccessor.java
@@ -31,10 +31,10 @@ public class InMemoryAdminTopicMetadataAccessor extends AdminTopicMetadataAccess
     if (!metadataDelta.getAdminOperationProtocolVersion().equals(UNDEFINED_VALUE)) {
       inMemoryMetadata.setAdminOperationProtocolVersion(metadataDelta.getAdminOperationProtocolVersion());
     }
-    if (!newPosition.equals(PubSubSymbolicPosition.EARLIEST)) {
+    if (!PubSubSymbolicPosition.EARLIEST.equals(newPosition)) {
       inMemoryMetadata.setPubSubPosition(newPosition);
     }
-    if (!newUpstreamPosition.equals(PubSubSymbolicPosition.EARLIEST)) {
+    if (!PubSubSymbolicPosition.EARLIEST.equals(newUpstreamPosition)) {
       inMemoryMetadata.setUpstreamPubSubPosition(newUpstreamPosition);
     }
 

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/AdminTopicMetadataAccessor.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/AdminTopicMetadataAccessor.java
@@ -84,7 +84,7 @@ public abstract class AdminTopicMetadataAccessor {
    * @return the execution ID from the metadata
    */
   public static long getExecutionId(AdminMetadata metadata) {
-    return metadata.getExecutionId() != null ? metadata.getExecutionId() : UNDEFINED_VALUE;
+    return metadata != null && metadata.getExecutionId() != null ? metadata.getExecutionId() : UNDEFINED_VALUE;
   }
 
   /**

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/ZkAdminTopicMetadataAccessor.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/ZkAdminTopicMetadataAccessor.java
@@ -118,13 +118,13 @@ public class ZkAdminTopicMetadataAccessor extends AdminTopicMetadataAccessor {
           metadata);
 
       // Merge the metadata objects
-      if (metadata.getExecutionId() != null) {
+      if (!metadata.getExecutionId().equals(UNDEFINED_VALUE)) {
         currentMetadata.setExecutionId(metadata.getExecutionId());
       }
-      if (metadata.getOffset() != null) {
+      if (!metadata.getOffset().equals(UNDEFINED_VALUE)) {
         currentMetadata.setOffset(metadata.getOffset());
       }
-      if (metadata.getUpstreamOffset() != null) {
+      if (!metadata.getUpstreamOffset().equals(UNDEFINED_VALUE)) {
         currentMetadata.setUpstreamOffset(metadata.getUpstreamOffset());
       }
       if (!metadata.getAdminOperationProtocolVersion().equals(UNDEFINED_VALUE)) {

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/kafka/consumer/AdminConsumptionTask.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/kafka/consumer/AdminConsumptionTask.java
@@ -25,17 +25,19 @@ import com.linkedin.venice.meta.Store;
 import com.linkedin.venice.meta.Version;
 import com.linkedin.venice.pubsub.PubSubTopicPartitionImpl;
 import com.linkedin.venice.pubsub.PubSubTopicRepository;
+import com.linkedin.venice.pubsub.PubSubUtil;
 import com.linkedin.venice.pubsub.api.DefaultPubSubMessage;
 import com.linkedin.venice.pubsub.api.PubSubConsumerAdapter;
 import com.linkedin.venice.pubsub.api.PubSubMessage;
 import com.linkedin.venice.pubsub.api.PubSubMessageHeader;
 import com.linkedin.venice.pubsub.api.PubSubMessageHeaders;
+import com.linkedin.venice.pubsub.api.PubSubPosition;
+import com.linkedin.venice.pubsub.api.PubSubSymbolicPosition;
 import com.linkedin.venice.pubsub.api.PubSubTopic;
 import com.linkedin.venice.pubsub.api.PubSubTopicPartition;
 import com.linkedin.venice.pubsub.manager.TopicManager;
 import com.linkedin.venice.utils.DaemonThreadFactory;
 import com.linkedin.venice.utils.LatencyUtils;
-import com.linkedin.venice.utils.Pair;
 import com.linkedin.venice.utils.Time;
 import com.linkedin.venice.utils.Utils;
 import com.linkedin.venice.utils.locks.AutoCloseableLock;
@@ -75,7 +77,7 @@ public class AdminConsumptionTask implements Runnable, Closeable {
   private static final int MAX_WORKER_QUEUE_SIZE = 10000;
 
   private static class AdminErrorInfo {
-    long offset;
+    PubSubPosition position;
     Exception exception;
   }
 
@@ -158,24 +160,24 @@ public class AdminConsumptionTask implements Runnable, Closeable {
   private volatile long offsetToSkip = UNASSIGNED_VALUE;
   private volatile long offsetToSkipDIV = UNASSIGNED_VALUE;
   /**
-   * The smallest or first failing offset.
+   * The smallest or first failing position.
    */
-  private volatile long failingOffset = UNASSIGNED_VALUE;
+  private volatile PubSubPosition failingPosition = PubSubSymbolicPosition.EARLIEST;
   private boolean topicExists;
   /**
-   * A {@link Map} of stores to admin operations belonging to each store. The corresponding kafka offset and other
+   * A {@link Map} of stores to admin operations belonging to each store. The corresponding pubsub position and other
    * metadata of each admin operation are included in the {@link AdminOperationWrapper}.
    */
-  private final Map<String, Queue<AdminOperationWrapper>> storeAdminOperationsMapWithOffset;
+  private final Map<String, Queue<AdminOperationWrapper>> storeAdminOperationsMapWithPosition;
 
   /**
    * Map of store names that have encountered some sort of exception during consumption to {@link AdminErrorInfo}
-   * that has the details about the exception and the offset of the problematic admin message.
+   * that has the details about the exception and the position of the problematic admin message.
    */
   private final ConcurrentHashMap<String, AdminErrorInfo> problematicStores;
   private final Queue<DefaultPubSubMessage> undelegatedRecords;
 
-  private final Map<String, Map<Long, Integer>> storeRetryCountMap;
+  private final Map<String, Map<PubSubPosition, Integer>> storeRetryCountMap;
 
   private final ExecutionIdAccessor executionIdAccessor;
   private ExecutorService executorService;
@@ -188,44 +190,47 @@ public class AdminConsumptionTask implements Runnable, Closeable {
 
   private final long processingCycleTimeoutInMs;
   /**
-   * Once all admin messages in a cycle is processed successfully, the id would be updated together with the offset.
+   * Once all admin messages in a cycle is processed successfully, the id would be updated together with the position.
    * It represents a kind of comparable progress of admin topic consumption among all controllers.
    */
   private long lastPersistedExecutionId = UNASSIGNED_VALUE;
   /**
-   * The corresponding offset to {@code lastPersistedExecutionId}
+   * The corresponding position to {@code lastPersistedExecutionId}
    */
-  private long lastPersistedOffset = UNASSIGNED_VALUE;
+  private PubSubPosition lastPersistedPosition = PubSubSymbolicPosition.EARLIEST;
   /**
    * The execution id of the last message that was delegated to a store's queue. Used for DIV check when fetching
    * messages from the admin topic.
    */
   private long lastDelegatedExecutionId = UNASSIGNED_VALUE;
   /**
-   * The corresponding offset to {@code lastDelegatedExecutionId}
+   * The corresponding position to {@code lastDelegatedExecutionId}
    */
-  private long lastOffset = UNASSIGNED_VALUE;
+  private PubSubPosition lastPosition = PubSubSymbolicPosition.EARLIEST;
   /**
-   * Track the latest consumed offset; this variable is updated as long as the consumer consumes new messages,
+   * A flag used immediately after subscribe to allow processing (or at least reading) the first
+   * checkpoint record so we can initialize producerInfo, without relying on offset arithmetic.
+   * This is an alternative to the previous approach (see https://github.com/linkedin/venice/pull/84)
+   * which subtracted 1 from the offset to read one older record.
+   * With inclusive subscription at the checkpoint position, the first record may be a duplicate;
+   * we use this flag to handle that case and initialize producerInfo safely, then set it to true.
+   */
+  private boolean isFirstRecordProcessed = false;
+  /**
+   * Track the latest consumed position; this variable is updated as long as the consumer consumes new messages,
    * no matter whether the message has any issue or not.
    */
-  private long lastConsumedOffset = UNASSIGNED_VALUE;
+  private PubSubPosition lastConsumedPosition = PubSubSymbolicPosition.EARLIEST;
   /**
-   * The local offset value in ZK during initialization phase; the value will not be updated during admin topic consumption.
+   * The local position value in ZK during initialization phase; the value will not be updated during admin topic consumption.
    *
-   * Currently, there are two potential offset: local offset and upstream offset, and we only update and
-   * maintain one of them. While persisting the offset to ZK, we would like to keep the original value
+   * Currently, there are two potential position: local position and upstream position, and we only update and
+   * maintain one of them. While persisting the position to ZK, we would like to keep the original value
    * for the other one, so that rollback/roll-forward of the remote consumption feature can be faster.
    */
-  private long localOffsetCheckpointAtStartTime = UNASSIGNED_VALUE;
-  /**
-   * The upstream offset value in ZK during initialization phase; the value will not be updated during admin topic consumption.
-   *
-   * Currently, there are two potential offset: local offset and upstream offset, and we only update and
-   * maintain one of them. While persisting the offset to ZK, we would like to keep the original value
-   * for the other one, so that rollback/roll-forward of the remote consumption feature can be faster.
-   */
-  private long upstreamOffsetCheckpointAtStartTime = UNASSIGNED_VALUE;
+  private PubSubPosition localPositionCheckpointAtStartTime = PubSubSymbolicPosition.EARLIEST;
+  private PubSubPosition upstreamPositionCheckpointAtStartTime = PubSubSymbolicPosition.EARLIEST;
+
   /**
    * Map of store names to their last succeeded execution id
    */
@@ -244,9 +249,9 @@ public class AdminConsumptionTask implements Runnable, Closeable {
   private int consecutiveDuplicateMessageCount = 0;
 
   /**
-   * Timestamp in millisecond: the last time when updating the consumption offset lag metric
+   * Timestamp in millisecond: the last time when updating the consumption position lag metric
    */
-  private long lastUpdateTimeForConsumptionOffsetLag = 0;
+  private long lastUpdateTimeForConsumptionPositionLag = 0;
 
   /**
    * The local region name of the controller.
@@ -289,7 +294,7 @@ public class AdminConsumptionTask implements Runnable, Closeable {
     this.executionIdAccessor = executionIdAccessor;
     this.processingCycleTimeoutInMs = processingCycleTimeoutInMs;
 
-    this.storeAdminOperationsMapWithOffset = new ConcurrentHashMap<>();
+    this.storeAdminOperationsMapWithPosition = new ConcurrentHashMap<>();
     this.problematicStores = new ConcurrentHashMap<>();
     // since we use an unbounded queue the core pool size is really the max pool size
     this.executorService = new ThreadPoolExecutor(
@@ -300,7 +305,7 @@ public class AdminConsumptionTask implements Runnable, Closeable {
         new LinkedBlockingQueue<>(MAX_WORKER_QUEUE_SIZE),
         new DaemonThreadFactory(String.format("Venice-Admin-Execution-Task-%s", clusterName), admin.getLogContext()));
     this.undelegatedRecords = new LinkedList<>();
-    this.stats.setAdminConsumptionFailedOffset(failingOffset);
+    this.stats.setAdminConsumptionFailedPosition(failingPosition);
     this.regionName = regionName;
     this.storeRetryCountMap = new ConcurrentHashMap<>();
 
@@ -373,7 +378,7 @@ public class AdminConsumptionTask implements Runnable, Closeable {
             recordsIterator = Utils.iterateOnMapOfLists(messages);
             while (recordsIterator.hasNext()) {
               DefaultPubSubMessage newRecord = recordsIterator.next();
-              lastConsumedOffset = newRecord.getPosition().getNumericOffset();
+              lastConsumedPosition = newRecord.getPosition();
               undelegatedRecords.add(newRecord);
             }
           }
@@ -392,34 +397,35 @@ public class AdminConsumptionTask implements Runnable, Closeable {
           try {
             long executionId = delegateMessage(record);
             if (executionId == lastDelegatedExecutionId) {
-              updateLastOffset(record.getPosition().getNumericOffset());
+              updateLastPosition(record.getPosition());
             }
             undelegatedRecords.remove();
           } catch (DataValidationException dve) {
             // Very unlikely but DataValidationException could be thrown here.
             LOGGER.error(
-                "Admin consumption task is blocked due to DataValidationException with offset {}",
+                "Admin consumption task is blocked due to DataValidationException with position {}",
                 record.getPosition(),
                 dve);
-            failingOffset = record.getPosition().getNumericOffset();
+            failingPosition = record.getPosition();
             stats.recordFailedAdminConsumption();
             stats.recordAdminTopicDIVErrorReportCount();
             break;
           } catch (Exception e) {
-            LOGGER.error("Admin consumption task is blocked due to Exception with offset {}", record.getPosition(), e);
-            failingOffset = record.getPosition().getNumericOffset();
+            LOGGER
+                .error("Admin consumption task is blocked due to Exception with position {}", record.getPosition(), e);
+            failingPosition = record.getPosition();
             stats.recordFailedAdminConsumption();
             break;
           }
         }
 
-        if (remoteConsumptionEnabled && LatencyUtils
-            .getElapsedTimeFromMsToMs(lastUpdateTimeForConsumptionOffsetLag) > getConsumptionLagUpdateIntervalInMs()) {
+        if (remoteConsumptionEnabled && LatencyUtils.getElapsedTimeFromMsToMs(
+            lastUpdateTimeForConsumptionPositionLag) > getConsumptionLagUpdateIntervalInMs()) {
           recordConsumptionLag();
-          lastUpdateTimeForConsumptionOffsetLag = System.currentTimeMillis();
+          lastUpdateTimeForConsumptionPositionLag = System.currentTimeMillis();
         }
         executeMessagesAndCollectResults();
-        stats.setAdminConsumptionFailedOffset(failingOffset);
+        stats.setAdminConsumptionFailedPosition(failingPosition);
       } catch (Exception e) {
         LOGGER.error("Exception thrown while running admin consumption task", e);
         // Unsubscribe and resubscribe in the next cycle to start over and avoid missing messages from poll.
@@ -431,36 +437,35 @@ public class AdminConsumptionTask implements Runnable, Closeable {
   }
 
   private void subscribe() {
-    Map<String, Long> metaData = adminTopicMetadataAccessor.getMetadata(clusterName).toLegacyMap();
-    if (!metaData.isEmpty()) {
-      Pair<Long, Long> localAndUpstreamOffsets = AdminTopicMetadataAccessor.getOffsets(metaData);
-      localOffsetCheckpointAtStartTime = localAndUpstreamOffsets.getFirst();
-      upstreamOffsetCheckpointAtStartTime = localAndUpstreamOffsets.getSecond();
-      lastPersistedOffset =
-          remoteConsumptionEnabled ? upstreamOffsetCheckpointAtStartTime : localOffsetCheckpointAtStartTime;
-      lastPersistedExecutionId = AdminTopicMetadataAccessor.getExecutionId(metaData);
+    AdminMetadata metaData = adminTopicMetadataAccessor.getMetadata(clusterName);
+    if (!PubSubSymbolicPosition.EARLIEST.equals(metaData.getPosition())) {
+      localPositionCheckpointAtStartTime = metaData.getPosition();
+      upstreamPositionCheckpointAtStartTime = metaData.getUpstreamPosition();
+      lastPersistedPosition =
+          remoteConsumptionEnabled ? upstreamPositionCheckpointAtStartTime : localPositionCheckpointAtStartTime;
+      lastPersistedExecutionId = metaData.getExecutionId();
       /**
-       * For the first poll after subscription, Controller will try to consume one message older than {@link #lastPersistedOffset}
+       * For the first poll after subscription, Controller will try to consume one message older than {@link #lastPersistedPosition}
        * to initialize the {@link #producerInfo}, which will be used to decide whether an execution id gap is a false alarm or not
        * in {@link #checkAndValidateMessage}.
        *
        */
-      lastOffset = lastPersistedOffset - 1;
+      lastPosition = lastPersistedPosition;
       lastDelegatedExecutionId = lastPersistedExecutionId;
     } else {
-      LOGGER.info("Admin topic metadata is empty, will resume consumption from the starting offset");
-      lastOffset = UNASSIGNED_VALUE;
+      LOGGER.info("Admin topic metadata is empty, will resume consumption from the starting position");
+      lastPosition = PubSubSymbolicPosition.EARLIEST;
       lastDelegatedExecutionId = UNASSIGNED_VALUE;
     }
-    stats.setAdminConsumptionCheckpointOffset(lastPersistedOffset);
-    stats.registerAdminConsumptionCheckpointOffset();
+    stats.setAdminConsumptionCheckpointPosition(lastPersistedPosition);
+    stats.registerAdminConsumptionCheckpointPosition();
     // Subscribe the admin topic
-    consumer.subscribe(adminTopicPartition, lastOffset);
+    consumer.subscribe(adminTopicPartition, lastPosition, true);
     isSubscribed = true;
     LOGGER.info(
-        "Subscribed to topic-partition: {}, with offset: {} and execution id: {}. Remote consumption flag: {}",
+        "Subscribed to topic name: {}, with position: {} and execution id: {}. Remote consumption flag: {}",
         adminTopicPartition,
-        lastOffset,
+        lastPosition,
         lastPersistedExecutionId,
         remoteConsumptionEnabled);
   }
@@ -468,21 +473,22 @@ public class AdminConsumptionTask implements Runnable, Closeable {
   private void unSubscribe() {
     if (isSubscribed) {
       consumer.unSubscribe(adminTopicPartition);
-      storeAdminOperationsMapWithOffset.clear();
+      storeAdminOperationsMapWithPosition.clear();
       problematicStores.clear();
       undelegatedRecords.clear();
-      failingOffset = UNASSIGNED_VALUE;
+      failingPosition = PubSubSymbolicPosition.EARLIEST;
       offsetToSkip = UNASSIGNED_VALUE;
       offsetToSkipDIV = UNASSIGNED_VALUE;
       lastDelegatedExecutionId = UNASSIGNED_VALUE;
       lastPersistedExecutionId = UNASSIGNED_VALUE;
-      lastOffset = UNASSIGNED_VALUE;
-      lastPersistedOffset = UNASSIGNED_VALUE;
+      lastPosition = PubSubSymbolicPosition.EARLIEST;
+      lastPersistedPosition = PubSubSymbolicPosition.EARLIEST;
       producerInfo = null;
       stats.recordPendingAdminMessagesCount(UNASSIGNED_VALUE);
       stats.recordStoresWithPendingAdminMessagesCount(UNASSIGNED_VALUE);
       resetConsumptionLag();
       isSubscribed = false;
+      isFirstRecordProcessed = false;
       LOGGER.info(
           "Unsubscribed from topic name: {}. Remote consumption flag before unsubscription: {}",
           adminTopicPartition,
@@ -493,7 +499,7 @@ public class AdminConsumptionTask implements Runnable, Closeable {
   /**
    * Package private for testing purpose
    *
-   * Delegate work from the {@code storeAdminOperationsMapWithOffset} to the worker threads. Wait for the worker threads
+   * Delegate work from the {@link #storeAdminOperationsMapWithPosition} to the worker threads. Wait for the worker threads
    * to complete or when timeout {@code processingCycleTimeoutInMs} is reached. Collect the result of each thread.
    * The result can either be success: all given {@link AdminOperation}s were processed successfully or made progress
    * but couldn't finish processing all of it within the time limit for each cycle. Failure is when either an exception
@@ -514,7 +520,7 @@ public class AdminConsumptionTask implements Runnable, Closeable {
     List<String> stores = new ArrayList<>();
     // Create a task for each store that has admin messages pending to be processed.
     boolean skipOffsetCommandHasBeenProcessed = false;
-    for (Map.Entry<String, Queue<AdminOperationWrapper>> entry: storeAdminOperationsMapWithOffset.entrySet()) {
+    for (Map.Entry<String, Queue<AdminOperationWrapper>> entry: storeAdminOperationsMapWithPosition.entrySet()) {
       String storeName = entry.getKey();
       Queue<AdminOperationWrapper> storeQueue = entry.getValue();
       if (!storeQueue.isEmpty()) {
@@ -522,13 +528,12 @@ public class AdminConsumptionTask implements Runnable, Closeable {
         if (nextOp == null) {
           continue;
         }
-        long adminMessageOffset = nextOp.getOffset();
-        if (checkOffsetToSkip(nextOp.getOffset(), false)) {
+        PubSubPosition adminMessagePosition = nextOp.getPosition();
+        if (checkOffsetToSkip(adminMessagePosition.getNumericOffset(), false)) {
           storeQueue.remove();
           skipOffsetCommandHasBeenProcessed = true;
         }
         AdminExecutionTask newTask = new AdminExecutionTask(
-            LOGGER,
             clusterName,
             storeName,
             lastSucceededExecutionIdMap,
@@ -541,11 +546,11 @@ public class AdminConsumptionTask implements Runnable, Closeable {
             regionName);
         // Check if there is previously created scheduled task still occupying one thread from the pool.
         if (storesWithScheduledTask.add(storeName)) {
-          // Log the store name and the offset of the task being added into the task list
+          // Log the store name and the position of the task being added into the task list
           LOGGER.info(
-              "Adding admin message from store {} with offset {} to the task list",
+              "Adding admin message from store {} with position {} to the task list",
               storeName,
-              adminMessageOffset);
+              adminMessagePosition);
           tasks.add(newTask);
           stores.add(storeName);
         }
@@ -574,7 +579,7 @@ public class AdminConsumptionTask implements Runnable, Closeable {
             result.get();
             problematicStores.remove(storeName);
             if (internalQueuesEmptied) {
-              Queue<AdminOperationWrapper> storeQueue = storeAdminOperationsMapWithOffset.get(storeName);
+              Queue<AdminOperationWrapper> storeQueue = storeAdminOperationsMapWithPosition.get(storeName);
               if (storeQueue != null && !storeQueue.isEmpty()) {
                 internalQueuesEmptied = false;
               }
@@ -582,7 +587,7 @@ public class AdminConsumptionTask implements Runnable, Closeable {
           } catch (ExecutionException | CancellationException e) {
             internalQueuesEmptied = false;
             AdminErrorInfo errorInfo = new AdminErrorInfo();
-            Queue<AdminOperationWrapper> storeQueue = storeAdminOperationsMapWithOffset.get(storeName);
+            Queue<AdminOperationWrapper> storeQueue = storeAdminOperationsMapWithPosition.get(storeName);
             int perStorePendingMessagesCount = storeQueue == null ? 0 : storeQueue.size();
             pendingAdminMessagesCount += perStorePendingMessagesCount;
             storesWithPendingAdminMessagesCount += perStorePendingMessagesCount > 0 ? 1 : 0;
@@ -591,7 +596,7 @@ public class AdminConsumptionTask implements Runnable, Closeable {
             Throwable cause = e.getCause();
             if (cause instanceof VeniceNoStoreException) {
               // Get the retry count for this store and version combination
-              Map<Long, Integer> retryCountMap =
+              Map<PubSubPosition, Integer> retryCountMap =
                   storeRetryCountMap.computeIfAbsent(storeName, s -> new ConcurrentHashMap<>());
               AdminOperationWrapper nextOp = storeQueue != null ? storeQueue.peek() : null;
               boolean allowAutoSkip = false;
@@ -602,8 +607,8 @@ public class AdminConsumptionTask implements Runnable, Closeable {
                     messageType == AdminMessageType.UPDATE_STORE || messageType == AdminMessageType.DELETE_STORE;
               }
 
-              long offset = nextOp != null ? nextOp.getOffset() : UNASSIGNED_VALUE;
-              int currentRetryCount = retryCountMap.getOrDefault(offset, 0);
+              PubSubPosition position = nextOp != null ? nextOp.getPosition() : PubSubSymbolicPosition.EARLIEST;
+              int currentRetryCount = retryCountMap.getOrDefault(position, 0);
 
               if (currentRetryCount >= MAX_RETRIES_FOR_NONEXISTENT_STORE && allowAutoSkip) {
                 // We've reached the maximum retry limit for this store/message, so remove it from the queue
@@ -613,24 +618,24 @@ public class AdminConsumptionTask implements Runnable, Closeable {
                       "Exceeded maximum retry attempts ({}) for store {} that does not exist. Skipping admin message with offset {}.",
                       MAX_RETRIES_FOR_NONEXISTENT_STORE,
                       storeName,
-                      removedOp.getOffset());
-                  retryCountMap.remove(offset);
+                      removedOp.getPosition().getNumericOffset());
+                  retryCountMap.remove(position);
                   problematicStores.remove(storeName);
                   continue;
                 }
               } else {
                 // Increment the retry count
-                retryCountMap.put(offset, currentRetryCount + 1);
+                retryCountMap.put(position, currentRetryCount + 1);
                 LOGGER.warn(
-                    "Store {} does not exist. Retry attempt {}/{}. Will retry admin message with offset {}.",
+                    "Store {} does not exist. Retry attempt {}/{}. Will retry admin message with position {}.",
                     storeName,
                     currentRetryCount + 1,
                     MAX_RETRIES_FOR_NONEXISTENT_STORE,
-                    offset);
+                    position);
 
                 // Add the error info as normal for retry
                 errorInfo.exception = (VeniceNoStoreException) cause;
-                errorInfo.offset = offset;
+                errorInfo.position = position;
                 problematicStores.put(storeName, errorInfo);
               }
             } else if (e instanceof CancellationException) {
@@ -645,25 +650,25 @@ public class AdminConsumptionTask implements Runnable, Closeable {
                 // only mark the store problematic if no progress is made and there are still message(s) in the queue.
                 errorInfo.exception = new VeniceException(
                     "Could not finish processing admin message for store " + storeName + " in time");
-                errorInfo.offset = getNextOperationOffsetIfAvailable(storeName);
+                errorInfo.position = getNextOperationPositionIfAvailable(storeName);
                 problematicStores.put(storeName, errorInfo);
                 LOGGER.warn(errorInfo.exception.getMessage());
               }
             } else {
               errorInfo.exception = e;
-              errorInfo.offset = getNextOperationOffsetIfAvailable(storeName);
+              errorInfo.position = getNextOperationPositionIfAvailable(storeName);
               problematicStores.put(storeName, errorInfo);
             }
           } catch (Throwable e) {
-            long errorMsgOffset = getNextOperationOffsetIfAvailable(storeName);
-            if (errorMsgOffset == UNASSIGNED_VALUE) {
-              LOGGER.error("Could not get the offset of the problematic admin message for store {}", storeName);
+            PubSubPosition errorMsgPosition = getNextOperationPositionIfAvailable(storeName);
+            if (PubSubSymbolicPosition.EARLIEST.equals(errorMsgPosition)) {
+              LOGGER.error("Could not get the position of the problematic admin message for store {}", storeName);
             }
 
             LOGGER.error(
-                "Unexpected exception thrown while processing admin message for store {} at offset {}",
+                "Unexpected exception thrown while processing admin message for store {} at position {}",
                 storeName,
-                errorMsgOffset,
+                errorMsgPosition,
                 e);
             // Throw it above to have the consistent behavior as before
             throw e;
@@ -671,28 +676,29 @@ public class AdminConsumptionTask implements Runnable, Closeable {
         }
         if (problematicStores.isEmpty() && internalQueuesEmptied) {
           // All admin operations were successfully executed or skipped.
-          // 1. Clear the failing offset.
-          // 3. Persist the latest execution id and offset (cluster wide) to ZK.
+          // 1. Clear the failing position.
+          // 3. Persist the latest execution id and position (cluster wide) to ZK.
 
-          // Ensure failingOffset from the delegateMessage is not overwritten.
-          if (failingOffset <= lastOffset) {
-            failingOffset = UNASSIGNED_VALUE;
+          // Ensure failingPosition from the delegateMessage is not overwritten.
+          if (PubSubUtil.comparePubSubPositions(failingPosition, lastPosition) <= 0) {
+            failingPosition = PubSubSymbolicPosition.EARLIEST;
           }
           persistAdminTopicMetadata();
         } else {
           // One or more stores encountered problems while executing their admin operations.
-          // 1. Do not persist the latest offset (cluster wide) to ZK.
-          // 2. Find and set the smallest failing offset amongst the problematic stores.
-          long smallestOffset = UNASSIGNED_VALUE;
+          // 1. Do not persist the latest position (cluster wide) to ZK.
+          // 2. Find and set the smallest failing position amongst the problematic stores.
+          PubSubPosition smallestPosition = PubSubSymbolicPosition.EARLIEST;
 
           for (Map.Entry<String, AdminErrorInfo> problematicStore: problematicStores.entrySet()) {
-            if (smallestOffset == UNASSIGNED_VALUE || problematicStore.getValue().offset < smallestOffset) {
-              smallestOffset = problematicStore.getValue().offset;
+            if (smallestPosition.equals(PubSubSymbolicPosition.EARLIEST)
+                || PubSubUtil.comparePubSubPositions(problematicStore.getValue().position, smallestPosition) < 0) {
+              smallestPosition = problematicStore.getValue().position;
             }
           }
-          // Ensure failingOffset from the delegateMessage is not overwritten.
-          if (failingOffset <= lastOffset) {
-            failingOffset = smallestOffset;
+          // Ensure failingPosition from the delegateMessage is not overwritten.
+          if (PubSubUtil.comparePubSubPositions(failingPosition, lastPosition) <= 0) {
+            failingPosition = smallestPosition;
           }
         }
         stats.recordPendingAdminMessagesCount(pendingAdminMessagesCount);
@@ -705,12 +711,12 @@ public class AdminConsumptionTask implements Runnable, Closeable {
   }
 
   /**
-   * @return the offset of the next enqueued operation for the given store name, or {@link #UNASSIGNED_VALUE} if unavailable.
+   * @return the position of the next enqueued operation for the given store name, or {@link #UNASSIGNED_VALUE} if unavailable.
    */
-  private long getNextOperationOffsetIfAvailable(String storeName) {
-    Queue<AdminOperationWrapper> storeQueue = storeAdminOperationsMapWithOffset.get(storeName);
+  private PubSubPosition getNextOperationPositionIfAvailable(String storeName) {
+    Queue<AdminOperationWrapper> storeQueue = storeAdminOperationsMapWithPosition.get(storeName);
     AdminOperationWrapper nextOperation = storeQueue == null ? null : storeQueue.peek();
-    return nextOperation == null ? UNASSIGNED_VALUE : nextOperation.getOffset();
+    return nextOperation == null ? PubSubSymbolicPosition.EARLIEST : nextOperation.getPosition();
   }
 
   private void internalClose() {
@@ -796,19 +802,21 @@ public class AdminConsumptionTask implements Runnable, Closeable {
     try {
       checkAndValidateMessage(adminOperation, record);
       LOGGER.info(
-          "Received admin operation: {}, message {} offset: {}",
+          "Received admin operation: {}, message {} position: {}",
           AdminMessageType.valueOf(adminOperation).name(),
           adminOperation,
           record.getPosition());
       consecutiveDuplicateMessageCount = 0;
     } catch (DuplicateDataException e) {
       // Previously processed message, safe to skip
+      isFirstRecordProcessed = true;
+      LOGGER.info("Received duplicate message, now setting testRunWithBiggerStartingOffset to false.");
       if (consecutiveDuplicateMessageCount < MAX_DUPLICATE_MESSAGE_LOGS) {
         consecutiveDuplicateMessageCount++;
         LOGGER.info(e.getMessage());
       } else if (consecutiveDuplicateMessageCount == MAX_DUPLICATE_MESSAGE_LOGS) {
         LOGGER.info(
-            "It appears that controller is consuming from a low offset and encounters many admin messages that "
+            "It appears that controller is consuming from a low position and encounters many admin messages that "
                 + "have already been processed. Will stop logging duplicate messages until a fresh admin message.");
       }
       return executionId;
@@ -822,10 +830,10 @@ public class AdminConsumptionTask implements Runnable, Closeable {
       for (Store store: stores) {
         String storeName = store.getName();
         Queue<AdminOperationWrapper> operationQueue =
-            storeAdminOperationsMapWithOffset.computeIfAbsent(storeName, n -> new LinkedList<>());
+            storeAdminOperationsMapWithPosition.computeIfAbsent(storeName, n -> new LinkedList<>());
         AdminOperationWrapper adminOperationWrapper = new AdminOperationWrapper(
             adminOperation,
-            record.getPosition().getNumericOffset(),
+            record.getPosition(),
             producerTimestamp,
             brokerTimestamp,
             System.currentTimeMillis());
@@ -844,7 +852,7 @@ public class AdminConsumptionTask implements Runnable, Closeable {
       long brokerTimestamp = record.getPubSubMessageTime();
       AdminOperationWrapper adminOperationWrapper = new AdminOperationWrapper(
           adminOperation,
-          record.getPosition().getNumericOffset(),
+          record.getPosition(),
           producerTimestamp,
           brokerTimestamp,
           System.currentTimeMillis());
@@ -853,8 +861,8 @@ public class AdminConsumptionTask implements Runnable, Closeable {
       stats.recordAdminMessageDelegateLatency(
           Math.max(0, adminOperationWrapper.getDelegateTimestamp() - adminOperationWrapper.getLocalBrokerTimestamp()));
       String storeName = extractStoreName(adminOperation);
-      storeAdminOperationsMapWithOffset.putIfAbsent(storeName, new LinkedList<>());
-      storeAdminOperationsMapWithOffset.get(storeName).add(adminOperationWrapper);
+      storeAdminOperationsMapWithPosition.putIfAbsent(storeName, new LinkedList<>());
+      storeAdminOperationsMapWithPosition.get(storeName).add(adminOperationWrapper);
 
     }
     return executionId;
@@ -960,53 +968,53 @@ public class AdminConsumptionTask implements Runnable, Closeable {
     return storeName;
   }
 
-  private void updateLastOffset(long offset) {
-    if (offset > lastOffset) {
-      lastOffset = offset;
+  private void updateLastPosition(PubSubPosition position) {
+    if (PubSubUtil.comparePubSubPositions(position, lastPosition) > 0) {
+      lastPosition = position;
     }
   }
 
   private void persistAdminTopicMetadata() {
-    if (lastDelegatedExecutionId == lastPersistedExecutionId && lastOffset == lastPersistedOffset) {
+    if (lastDelegatedExecutionId == lastPersistedExecutionId && lastPosition == lastPersistedPosition) {
       // Skip since there are no new admin messages processed.
       return;
     }
     try (AutoCloseableLock ignore =
         admin.getHelixVeniceClusterResources(clusterName).getClusterLockManager().createClusterWriteLock()) {
-      Map<String, Long> metadata = remoteConsumptionEnabled
-          ? AdminTopicMetadataAccessor.generateMetadataMap(
-              Optional.of(localOffsetCheckpointAtStartTime),
-              Optional.of(lastOffset),
-              Optional.of(lastDelegatedExecutionId),
-              Optional.empty())
-          : AdminTopicMetadataAccessor.generateMetadataMap(
-              Optional.of(lastOffset),
-              Optional.of(upstreamOffsetCheckpointAtStartTime),
-              Optional.of(lastDelegatedExecutionId),
-              Optional.empty());
-      adminTopicMetadataAccessor.updateMetadata(clusterName, AdminMetadata.fromLegacyMap(metadata));
-      lastPersistedOffset = lastOffset;
+      AdminMetadata adminMetadata = new AdminMetadata();
+      adminMetadata.setExecutionId(lastDelegatedExecutionId);
+      if (remoteConsumptionEnabled) {
+        adminMetadata.setPubSubPosition(localPositionCheckpointAtStartTime);
+        adminMetadata.setUpstreamPubSubPosition(lastPosition);
+      } else {
+        adminMetadata.setPubSubPosition(lastPosition);
+        adminMetadata.setUpstreamPubSubPosition(upstreamPositionCheckpointAtStartTime);
+      }
+      adminTopicMetadataAccessor.updateMetadata(clusterName, adminMetadata);
+      lastPersistedPosition = lastPosition;
       lastPersistedExecutionId = lastDelegatedExecutionId;
-      LOGGER.info("Updated lastPersistedOffset to {}", lastPersistedOffset);
-      stats.setAdminConsumptionCheckpointOffset(lastPersistedOffset);
+      LOGGER.info("Updated lastPersistedPosition to {}", lastPersistedPosition);
+      stats.setAdminConsumptionCheckpointPosition(lastPersistedPosition);
     }
   }
 
   void skipMessageWithOffset(long offset) {
-    if (offset == failingOffset) {
+    if (offset == failingPosition.getNumericOffset()) {
       offsetToSkip = offset;
     } else {
       throw new VeniceException(
-          "Cannot skip an offset that isn't the first one failing.  Last failed offset is: " + failingOffset);
+          "Cannot skip an offset that isn't the first one failing.  Last failed offset is: "
+              + failingPosition.getNumericOffset());
     }
   }
 
   void skipMessageDIVWithOffset(long offset) {
-    if (offset == failingOffset) {
+    if (offset == failingPosition.getNumericOffset()) {
       offsetToSkipDIV = offset;
     } else {
       throw new VeniceException(
-          "Cannot skip an offset that isn't the first one failing.  Last failed offset is: " + failingOffset);
+          "Cannot skip an offset that isn't the first one failing.  Last failed offset is: "
+              + failingPosition.getNumericOffset());
     }
   }
 
@@ -1056,8 +1064,8 @@ public class AdminConsumptionTask implements Runnable, Closeable {
     }
   }
 
-  long getFailingOffset() {
-    return failingOffset;
+  PubSubPosition getFailingPosition() {
+    return failingPosition;
   }
 
   private boolean shouldProcessRecord(DefaultPubSubMessage record) {
@@ -1075,13 +1083,13 @@ public class AdminConsumptionTask implements Runnable, Closeable {
           consumerTaskId + " received message from different partition: " + recordPartition + ", expected: "
               + AdminTopicUtils.ADMIN_TOPIC_PARTITION_ID);
     }
-    long recordOffset = record.getPosition().getNumericOffset();
-    // check offset
-    if (lastOffset >= recordOffset) {
+    PubSubPosition recordPosition = record.getPosition();
+    // check position
+    if (isFirstRecordProcessed && PubSubUtil.comparePubSubPositions(lastPosition, recordPosition) >= 0) {
       LOGGER.error(
-          "Current record has been processed, last known offset: {}, current offset: {}",
-          lastOffset,
-          recordOffset);
+          "Current record has been processed, last known position: {}, current position: {}",
+          lastPosition,
+          recordPosition);
       return false;
     }
 
@@ -1103,10 +1111,10 @@ public class AdminConsumptionTask implements Runnable, Closeable {
        * If the first consumer poll returns nothing, "lastConsumedOffset" will remain as {@link #UNASSIGNED_VALUE}, so a
        * huge lag will be reported, but actually that's not case since consumer is subscribed to the last checkpoint offset.
        */
-      if (lastConsumedOffset != UNASSIGNED_VALUE) {
-        stats.setAdminConsumptionOffsetLag(sourceAdminTopicEndOffset - lastConsumedOffset);
+      if (!lastConsumedPosition.equals(PubSubSymbolicPosition.EARLIEST)) {
+        stats.setAdminConsumptionOffsetLag(sourceAdminTopicEndOffset - lastConsumedPosition.getNumericOffset());
       }
-      stats.setMaxAdminConsumptionOffsetLag(sourceAdminTopicEndOffset - lastPersistedOffset);
+      stats.setMaxAdminConsumptionOffsetLag(sourceAdminTopicEndOffset - lastPersistedPosition.getNumericOffset());
     } catch (Exception e) {
       LOGGER.error(
           "Error when emitting admin consumption lag metrics; only log for warning; admin channel will continue to work.");

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/kafka/consumer/AdminConsumptionTask.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/kafka/consumer/AdminConsumptionTask.java
@@ -682,7 +682,7 @@ public class AdminConsumptionTask implements Runnable, Closeable {
           PubSubPosition smallestPosition = PubSubSymbolicPosition.EARLIEST;
 
           for (Map.Entry<String, AdminErrorInfo> problematicStore: problematicStores.entrySet()) {
-            if (smallestPosition.equals(PubSubSymbolicPosition.EARLIEST)
+            if (PubSubSymbolicPosition.EARLIEST.equals(smallestPosition)
                 || PubSubUtil.comparePubSubPositions(problematicStore.getValue().position, smallestPosition) < 0) {
               smallestPosition = problematicStore.getValue().position;
             }
@@ -800,7 +800,6 @@ public class AdminConsumptionTask implements Runnable, Closeable {
       consecutiveDuplicateMessageCount = 0;
     } catch (DuplicateDataException e) {
       // Previously processed message, safe to skip
-      LOGGER.info("Received duplicate message, now setting testRunWithBiggerStartingOffset to false.");
       if (consecutiveDuplicateMessageCount < MAX_DUPLICATE_MESSAGE_LOGS) {
         consecutiveDuplicateMessageCount++;
         LOGGER.info(e.getMessage());

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/kafka/consumer/AdminConsumptionTask.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/kafka/consumer/AdminConsumptionTask.java
@@ -524,6 +524,7 @@ public class AdminConsumptionTask implements Runnable, Closeable {
           skipOffsetCommandHasBeenProcessed = true;
         }
         AdminExecutionTask newTask = new AdminExecutionTask(
+            LOGGER,
             clusterName,
             storeName,
             lastSucceededExecutionIdMap,
@@ -964,7 +965,7 @@ public class AdminConsumptionTask implements Runnable, Closeable {
   }
 
   private void persistAdminTopicMetadata() {
-    if (lastDelegatedExecutionId == lastPersistedExecutionId && lastDelegatedPosition == lastPersistedPosition) {
+    if (lastDelegatedExecutionId == lastPersistedExecutionId && lastDelegatedPosition.equals(lastPersistedPosition)) {
       // Skip since there are no new admin messages processed.
       return;
     }
@@ -1102,7 +1103,7 @@ public class AdminConsumptionTask implements Runnable, Closeable {
        * If the first consumer poll returns nothing, "lastConsumedOffset" will remain as {@link #UNASSIGNED_VALUE}, so a
        * huge lag will be reported, but actually that's not case since consumer is subscribed to the last checkpoint offset.
        */
-      if (!lastConsumedPosition.equals(PubSubSymbolicPosition.EARLIEST)) {
+      if (!PubSubSymbolicPosition.EARLIEST.equals(lastConsumedPosition)) {
         stats.setAdminConsumptionOffsetLag(sourceAdminTopicEndOffset - lastConsumedPosition.getNumericOffset());
       }
       stats.setMaxAdminConsumptionOffsetLag(sourceAdminTopicEndOffset - lastPersistedPosition.getNumericOffset());

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/kafka/consumer/AdminExecutionTask.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/kafka/consumer/AdminExecutionTask.java
@@ -68,7 +68,6 @@ import java.util.Set;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
-import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 
@@ -93,6 +92,7 @@ public class AdminExecutionTask implements Callable<Void> {
   private final long lastPersistedExecutionId;
 
   AdminExecutionTask(
+      Logger LOGGER,
       String clusterName,
       String storeName,
       ConcurrentHashMap<String, Long> lastSucceededExecutionIdMap,
@@ -103,7 +103,7 @@ public class AdminExecutionTask implements Callable<Void> {
       boolean isParentController,
       AdminConsumptionStats stats,
       String regionName) {
-    this.LOGGER = LogManager.getLogger(AdminExecutionTask.class);
+    this.LOGGER = LOGGER;
     this.clusterName = clusterName;
     this.storeName = storeName;
     this.lastSucceededExecutionIdMap = lastSucceededExecutionIdMap;

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/kafka/consumer/AdminExecutionTask.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/kafka/consumer/AdminExecutionTask.java
@@ -68,6 +68,7 @@ import java.util.Set;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
+import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 
@@ -92,7 +93,6 @@ public class AdminExecutionTask implements Callable<Void> {
   private final long lastPersistedExecutionId;
 
   AdminExecutionTask(
-      Logger LOGGER,
       String clusterName,
       String storeName,
       ConcurrentHashMap<String, Long> lastSucceededExecutionIdMap,
@@ -103,7 +103,7 @@ public class AdminExecutionTask implements Callable<Void> {
       boolean isParentController,
       AdminConsumptionStats stats,
       String regionName) {
-    this.LOGGER = LOGGER;
+    this.LOGGER = LogManager.getLogger(AdminExecutionTask.class);
     this.clusterName = clusterName;
     this.storeName = storeName;
     this.lastSucceededExecutionIdMap = lastSucceededExecutionIdMap;
@@ -150,7 +150,7 @@ public class AdminExecutionTask implements Callable<Void> {
       // The queue with the problematic operation will be delegated and retried by the worker thread in the next cycle.
       AdminOperationWrapper adminOperationWrapper = internalTopic.peek();
       String logMessage =
-          "when processing admin message for store " + storeName + " with offset " + adminOperationWrapper.getOffset()
+          "when processing admin message for store " + storeName + " with offset " + adminOperationWrapper.getPosition()
               + " and execution id " + adminOperationWrapper.getAdminOperation().executionId;
       if (e instanceof VeniceRetriableException) {
         // These retriable exceptions are expected, therefore logging at the info level should be sufficient.

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/kafka/consumer/AdminMetadata.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/kafka/consumer/AdminMetadata.java
@@ -119,11 +119,11 @@ public class AdminMetadata {
       metadata.setAdminOperationProtocolVersion(
           legacyMap.get(AdminTopicMetadataAccessor.ADMIN_OPERATION_PROTOCOL_VERSION_KEY));
       metadata.setPubSubPosition(
-          metadata.getOffset() == null
+          metadata.getOffset().longValue() == UNDEFINED_VALUE
               ? PubSubSymbolicPosition.EARLIEST
               : ApacheKafkaOffsetPosition.of(metadata.getOffset()));
       metadata.setUpstreamPubSubPosition(
-          metadata.getUpstreamOffset() == null
+          metadata.getUpstreamOffset().longValue() == UNDEFINED_VALUE
               ? PubSubSymbolicPosition.EARLIEST
               : ApacheKafkaOffsetPosition.of(metadata.getUpstreamOffset()));
     }

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/kafka/consumer/AdminOperationWrapper.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/kafka/consumer/AdminOperationWrapper.java
@@ -1,11 +1,12 @@
 package com.linkedin.venice.controller.kafka.consumer;
 
 import com.linkedin.venice.controller.kafka.protocol.admin.AdminOperation;
+import com.linkedin.venice.pubsub.api.PubSubPosition;
 
 
 public class AdminOperationWrapper {
   private final AdminOperation adminOperation;
-  private final long offset;
+  private final PubSubPosition position;
   private final long producerTimestamp;
   private final long localBrokerTimestamp;
   private final long delegateTimestamp;
@@ -16,19 +17,19 @@ public class AdminOperationWrapper {
    * Constructor for the wrapper of an {@link AdminOperation}, the wrapper includes additional information about the
    * operation that is used for processing and metrics emission.
    * @param adminOperation of this wrapper.
-   * @param offset for the corresponding {@link AdminOperation}.
+   * @param position for the corresponding {@link AdminOperation}.
    * @param producerTimestamp the time when this admin operation was first produced in the parent controller.
    * @param localBrokerTimestamp the time when this admin operation arrived at the local admin kafka topic or broker.
    * @param delegateTimestamp the time when this admin operation was read and placed in the in-memory topics.
    */
   AdminOperationWrapper(
       AdminOperation adminOperation,
-      long offset,
+      PubSubPosition position,
       long producerTimestamp,
       long localBrokerTimestamp,
       long delegateTimestamp) {
     this.adminOperation = adminOperation;
-    this.offset = offset;
+    this.position = position;
     this.producerTimestamp = producerTimestamp;
     this.localBrokerTimestamp = localBrokerTimestamp;
     this.delegateTimestamp = delegateTimestamp;
@@ -38,8 +39,8 @@ public class AdminOperationWrapper {
     return adminOperation;
   }
 
-  public long getOffset() {
-    return offset;
+  public PubSubPosition getPosition() {
+    return position;
   }
 
   public long getProducerTimestamp() {

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/stats/AdminConsumptionStats.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/stats/AdminConsumptionStats.java
@@ -1,5 +1,6 @@
 package com.linkedin.venice.controller.stats;
 
+import com.linkedin.venice.pubsub.api.PubSubPosition;
 import com.linkedin.venice.stats.AbstractVeniceStats;
 import io.tehuti.metrics.MetricsRepository;
 import io.tehuti.metrics.Sensor;
@@ -43,7 +44,7 @@ public class AdminConsumptionStats extends AbstractVeniceStats {
    */
   final private Sensor adminMessageTotalLatencySensor;
 
-  private long adminConsumptionFailedOffset;
+  private PubSubPosition adminConsumptionFailedPosition;
   /**
    * A gauge reporting the total number of pending admin messages remaining in the internal queue at the end of each
    * consumption cycle. Pending messages could be caused by blocked admin operations or insufficient resources.
@@ -58,7 +59,7 @@ public class AdminConsumptionStats extends AbstractVeniceStats {
    * A gauge that represents the consumption offset checkpointed into ZK. If remote consumption is enabled, this is the
    * checkpoint upstream offset; otherwise, it's the checkpoint local consumption offset.
    */
-  private long adminConsumptionCheckpointOffset;
+  private PubSubPosition adminConsumptionCheckpointPosition;
 
   /**
    * adminConsumptionOffsetLag = End offset of the admin topic in the source Kafka cluster - the latest consumed offset
@@ -79,7 +80,12 @@ public class AdminConsumptionStats extends AbstractVeniceStats {
     adminConsumeFailCountSensor = registerSensor("failed_admin_messages", new Count());
     adminConsumeFailRetriableMessageCountSensor = registerSensor("failed_retriable_admin_messages", new Count());
     adminTopicDIVErrorReportCountSensor = registerSensor("admin_message_div_error_report_count", new Count());
-    registerSensor(new AsyncGauge((ignored, ignored2) -> adminConsumptionFailedOffset, "failed_admin_message_offset"));
+    registerSensor(
+        new AsyncGauge(
+            (ignored, ignored2) -> adminConsumptionFailedPosition == null
+                ? 0L
+                : adminConsumptionFailedPosition.getNumericOffset(),
+            "failed_admin_message_offset"));
     adminConsumptionCycleDurationMsSensor =
         registerSensor("admin_consumption_cycle_duration_ms", new Avg(), new Min(), new Max());
     registerSensor(
@@ -131,8 +137,8 @@ public class AdminConsumptionStats extends AbstractVeniceStats {
     this.storesWithPendingAdminMessagesCountGauge = value;
   }
 
-  public void setAdminConsumptionFailedOffset(long adminConsumptionFailedOffset) {
-    this.adminConsumptionFailedOffset = adminConsumptionFailedOffset;
+  public void setAdminConsumptionFailedPosition(PubSubPosition adminConsumptionFailedPosition) {
+    this.adminConsumptionFailedPosition = adminConsumptionFailedPosition;
   }
 
   public void recordAdminMessageMMLatency(double value) {
@@ -159,18 +165,20 @@ public class AdminConsumptionStats extends AbstractVeniceStats {
     adminMessageTotalLatencySensor.record(value);
   }
 
-  public void setAdminConsumptionCheckpointOffset(long adminConsumptionCheckpointOffset) {
-    this.adminConsumptionCheckpointOffset = adminConsumptionCheckpointOffset;
+  public void setAdminConsumptionCheckpointPosition(PubSubPosition adminConsumptionCheckpointPosition) {
+    this.adminConsumptionCheckpointPosition = adminConsumptionCheckpointPosition;
   }
 
   /**
    * Lazily register the checkpoint offset metric after knowing the latest checkpoint offset, so that restarting the
    * controller node will not result in the metric value dipping to 0.
    */
-  public void registerAdminConsumptionCheckpointOffset() {
+  public void registerAdminConsumptionCheckpointPosition() {
     registerSensorIfAbsent(
         new AsyncGauge(
-            (ignored, ignored2) -> this.adminConsumptionCheckpointOffset,
+            (ignored, ignored2) -> this.adminConsumptionCheckpointPosition == null
+                ? 0L
+                : this.adminConsumptionCheckpointPosition.getNumericOffset(),
             "admin_consumption_checkpoint_offset"));
   }
 

--- a/services/venice-controller/src/test/java/com/linkedin/venice/controller/kafka/consumer/AdminConsumptionTaskTest.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/controller/kafka/consumer/AdminConsumptionTaskTest.java
@@ -281,11 +281,11 @@ public class AdminConsumptionTaskTest {
   }
 
   private long getLastOffset(String clusterName) {
-    return AdminTopicMetadataAccessor.getOffsets(adminTopicMetadataAccessor.getMetadata(clusterName)).getFirst();
+    return adminTopicMetadataAccessor.getMetadata(clusterName).getOffset();
   }
 
   private long getLastExecutionId(String clusterName) {
-    return AdminTopicMetadataAccessor.getExecutionId(adminTopicMetadataAccessor.getMetadata(clusterName));
+    return adminTopicMetadataAccessor.getMetadata(clusterName).getExecutionId();
   }
 
   @Test(timeOut = TIMEOUT)
@@ -445,7 +445,7 @@ public class AdminConsumptionTaskTest {
     executor.submit(task);
 
     TestUtils.waitForNonDeterministicAssertion(TIMEOUT, TimeUnit.MILLISECONDS, () -> {
-      Assert.assertEquals(task.getFailingOffset(), failingOffset);
+      Assert.assertEquals(task.getFailingPosition().getNumericOffset(), failingOffset);
     });
 
     task.close();
@@ -472,10 +472,10 @@ public class AdminConsumptionTaskTest {
     executor.submit(task);
 
     TestUtils.waitForNonDeterministicAssertion(TIMEOUT, TimeUnit.MILLISECONDS, () -> {
-      Assert.assertEquals(task.getFailingOffset(), 1L);
+      Assert.assertEquals(task.getFailingPosition().getNumericOffset(), 1L);
     });
 
-    verify(mockStats, timeout(100).atLeastOnce()).setAdminConsumptionFailedOffset(1);
+    verify(mockStats, timeout(100).atLeastOnce()).setAdminConsumptionFailedPosition(any());
     verify(mockStats, timeout(100).atLeastOnce()).recordPendingAdminMessagesCount(2D);
     verify(mockStats, timeout(100).atLeastOnce()).recordStoresWithPendingAdminMessagesCount(1D);
     verify(mockStats, timeout(100).atLeastOnce()).recordAdminConsumptionCycleDurationMs(anyDouble());
@@ -610,7 +610,7 @@ public class AdminConsumptionTaskTest {
     TestUtils.waitForNonDeterministicAssertion(
         TIMEOUT,
         TimeUnit.MILLISECONDS,
-        () -> Assert.assertEquals(task.getFailingOffset(), 3L));
+        () -> Assert.assertEquals(task.getFailingPosition().getNumericOffset(), 3L));
     task.skipMessageWithOffset(3L);
     TestUtils.waitForNonDeterministicAssertion(
         TIMEOUT,
@@ -659,7 +659,7 @@ public class AdminConsumptionTaskTest {
         TIMEOUT,
         TimeUnit.MILLISECONDS,
         () -> Assert.assertEquals(getLastOffset(clusterName), 3L));
-    Assert.assertEquals(task.getFailingOffset(), -1);
+    Assert.assertEquals(task.getFailingPosition().getNumericOffset(), -1);
     task.close();
     verify(stats, never()).recordAdminTopicDIVErrorReportCount();
     verify(admin, atLeastOnce()).createStore(clusterName, storeName1, owner, keySchema, valueSchema, false);
@@ -680,14 +680,13 @@ public class AdminConsumptionTaskTest {
         emptyKeyBytes,
         getStoreCreationMessage(clusterName, storeName0, owner, keySchema, valueSchema, 1),
         AdminOperationSerializer.LATEST_SCHEMA_ID_FOR_ADMIN_OPERATION);
-    adminTopicMetadataAccessor.updateMetadata(
-        clusterName,
-        AdminMetadata.fromLegacyMap(
-            AdminTopicMetadataAccessor.generateMetadataMap(
-                Optional.of(metadataForStoreName0Future.get().getOffset()),
-                Optional.of(-1L),
-                Optional.of(1L),
-                Optional.empty())));
+    AdminMetadata adminMetadata = new AdminMetadata();
+    PubSubProduceResult pubSubProduceResult = metadataForStoreName0Future.get();
+    adminMetadata.setOffset(pubSubProduceResult.getOffset());
+    adminMetadata.setPubSubPosition(pubSubProduceResult.getPubSubPosition());
+    adminMetadata.setExecutionId(1L);
+    adminTopicMetadataAccessor.updateMetadata(clusterName, adminMetadata);
+    adminTopicMetadataAccessor.updateMetadata(clusterName, adminMetadata);
 
     // Write a message with a skipped execution id but a different producer metadata.
     veniceWriter.put(
@@ -716,7 +715,7 @@ public class AdminConsumptionTaskTest {
         TIMEOUT,
         TimeUnit.MILLISECONDS,
         () -> Assert.assertEquals(getLastOffset(clusterName), 5L));
-    Assert.assertEquals(task.getFailingOffset(), -1);
+    Assert.assertEquals(task.getFailingPosition().getNumericOffset(), -1);
     task.close();
     verify(stats, never()).recordAdminTopicDIVErrorReportCount();
     verify(admin, atLeastOnce()).createStore(clusterName, storeName1, owner, keySchema, valueSchema, false);
@@ -773,9 +772,10 @@ public class AdminConsumptionTaskTest {
     // The store doesn't exist
     doReturn(false).when(admin).hasStore(clusterName, storeName1);
     doReturn(false).when(admin).hasStore(clusterName, storeName2);
-    Map<String, Long> newMetadata = AdminTopicMetadataAccessor
-        .generateMetadataMap(Optional.of(1L), Optional.of(-1L), Optional.of(1L), Optional.empty());
-    adminTopicMetadataAccessor.updateMetadata(clusterName, AdminMetadata.fromLegacyMap(newMetadata));
+    AdminMetadata newMetadata = new AdminMetadata();
+    newMetadata.setOffset(1L);
+    newMetadata.setExecutionId(1L);
+    adminTopicMetadataAccessor.updateMetadata(clusterName, newMetadata);
 
     AdminConsumptionTask task = getAdminConsumptionTask(new RandomPollStrategy(), false);
     executor.submit(task);
@@ -1077,7 +1077,7 @@ public class AdminConsumptionTaskTest {
     TestUtils.waitForNonDeterministicAssertion(
         TIMEOUT,
         TimeUnit.MILLISECONDS,
-        () -> Assert.assertEquals(task.getFailingOffset(), 1L));
+        () -> Assert.assertEquals(task.getFailingPosition().getNumericOffset(), 1L));
     TestUtils.waitForNonDeterministicAssertion(
         TIMEOUT,
         TimeUnit.MILLISECONDS,
@@ -1104,7 +1104,7 @@ public class AdminConsumptionTaskTest {
     Assert.assertEquals(
         executionIdAccessor.getLastSucceededExecutionIdMap(clusterName).getOrDefault(storeName1, -1L).longValue(),
         3L);
-    Assert.assertEquals(task.getFailingOffset(), -1L);
+    Assert.assertEquals(task.getFailingPosition().getNumericOffset(), -1L);
     task.close();
     executor.shutdown();
     executor.awaitTermination(TIMEOUT, TimeUnit.MILLISECONDS);
@@ -1150,9 +1150,10 @@ public class AdminConsumptionTaskTest {
         getKillOfflinePushJobMessage(clusterName, storeTopicName, 4L),
         AdminOperationSerializer.LATEST_SCHEMA_ID_FOR_ADMIN_OPERATION);
     long offset = future.get(TIMEOUT, TimeUnit.MILLISECONDS).getOffset();
-    Map<String, Long> newMetadata = AdminTopicMetadataAccessor
-        .generateMetadataMap(Optional.of(offset), Optional.of(-1L), Optional.of(4L), Optional.empty());
-    adminTopicMetadataAccessor.updateMetadata(clusterName, AdminMetadata.fromLegacyMap(newMetadata));
+    AdminMetadata newMetadata = new AdminMetadata();
+    newMetadata.setOffset(offset);
+    newMetadata.setExecutionId(4L);
+    adminTopicMetadataAccessor.updateMetadata(clusterName, newMetadata);
     executionIdAccessor.updateLastSucceededExecutionIdMap(clusterName, storeName, 4L);
     // Resubscribe to the admin topic and make sure it can still process new admin messages
     doReturn(true).when(admin).isLeaderControllerFor(clusterName);
@@ -1212,18 +1213,18 @@ public class AdminConsumptionTaskTest {
     when(admin.isLeaderControllerFor(clusterName)).thenReturn(true, true, true, true, true, false, false, false, true);
     executor.submit(task);
     TestUtils.waitForNonDeterministicAssertion(TIMEOUT, TimeUnit.MILLISECONDS, () -> {
-      Assert.assertEquals(task.getFailingOffset(), failingOffset);
+      Assert.assertEquals(task.getFailingPosition().getNumericOffset(), failingOffset);
     });
     // Failing offset should be set to -1 once the consumption task unsubscribed.
     TestUtils.waitForNonDeterministicAssertion(
         TIMEOUT,
         TimeUnit.MILLISECONDS,
-        () -> Assert.assertEquals(task.getFailingOffset(), -1));
+        () -> Assert.assertEquals(task.getFailingPosition().getNumericOffset(), -1));
     // The consumption task will eventually resubscribe and should be stuck on the same admin message.
     TestUtils.waitForNonDeterministicAssertion(
         TIMEOUT,
         TimeUnit.MILLISECONDS,
-        () -> Assert.assertEquals(task.getFailingOffset(), failingOffset));
+        () -> Assert.assertEquals(task.getFailingPosition().getNumericOffset(), failingOffset));
     task.close();
     executor.shutdown();
     ;
@@ -1327,7 +1328,7 @@ public class AdminConsumptionTaskTest {
     TestUtils.waitForNonDeterministicAssertion(
         TIMEOUT,
         TimeUnit.MILLISECONDS,
-        () -> Assert.assertEquals(task.getFailingOffset(), offset));
+        () -> Assert.assertEquals(task.getFailingPosition().getNumericOffset(), offset));
     // Skip the DIV check, make sure the sequence number is updated and new admin messages can also be processed
     task.skipMessageDIVWithOffset(offset);
     TestUtils.waitForNonDeterministicAssertion(
@@ -1371,7 +1372,7 @@ public class AdminConsumptionTaskTest {
     TestUtils.waitForNonDeterministicAssertion(
         TIMEOUT,
         TimeUnit.MILLISECONDS,
-        () -> Assert.assertEquals(task.getFailingOffset(), offset));
+        () -> Assert.assertEquals(task.getFailingPosition().getNumericOffset(), offset));
     // The add version message is expected to fail with retriable VeniceOperationAgainstKafkaTimeOut exception and the
     // corresponding code path for handling retriable exceptions should have been executed.
     verify(stats, atLeastOnce()).recordFailedRetriableAdminConsumption();
@@ -1744,7 +1745,7 @@ public class AdminConsumptionTaskTest {
 
     Assert.assertEquals(getLastOffset(clusterName), -1L);
     Assert.assertEquals(getLastExecutionId(clusterName), -1L);
-    Assert.assertEquals(task.getFailingOffset(), 1L);
+    Assert.assertEquals(task.getFailingPosition().getNumericOffset(), 1L);
     Assert.assertEquals(task.getLastSucceededExecutionId().longValue(), -1L);
     Assert.assertNull(task.getLastSucceededExecutionId(storeName1));
     Assert.assertEquals(task.getLastSucceededExecutionId(storeName2).longValue(), 4L);
@@ -1761,7 +1762,7 @@ public class AdminConsumptionTaskTest {
     Assert.assertEquals(
         executionIdAccessor.getLastSucceededExecutionIdMap(clusterName).getOrDefault(storeName1, -1L).longValue(),
         3L);
-    Assert.assertEquals(task.getFailingOffset(), -1L);
+    Assert.assertEquals(task.getFailingPosition().getNumericOffset(), -1L);
 
     task.close();
     executor.shutdown();

--- a/services/venice-controller/src/test/java/com/linkedin/venice/controller/kafka/consumer/AdminConsumptionTaskTest.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/controller/kafka/consumer/AdminConsumptionTaskTest.java
@@ -686,7 +686,6 @@ public class AdminConsumptionTaskTest {
     adminMetadata.setPubSubPosition(pubSubProduceResult.getPubSubPosition());
     adminMetadata.setExecutionId(1L);
     adminTopicMetadataAccessor.updateMetadata(clusterName, adminMetadata);
-    adminTopicMetadataAccessor.updateMetadata(clusterName, adminMetadata);
 
     // Write a message with a skipped execution id but a different producer metadata.
     veniceWriter.put(

--- a/services/venice-controller/src/test/java/com/linkedin/venice/controller/kafka/consumer/TestAdminMetadata.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/controller/kafka/consumer/TestAdminMetadata.java
@@ -4,7 +4,6 @@ import static com.linkedin.venice.controller.AdminTopicMetadataAccessor.UNDEFINE
 import static com.linkedin.venice.pubsub.PubSubPositionTypeRegistry.APACHE_KAFKA_OFFSET_POSITION_TYPE_ID;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
-import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertTrue;
 
 import com.linkedin.venice.controller.AdminTopicMetadataAccessor;
@@ -33,13 +32,13 @@ public class TestAdminMetadata {
 
   @Test
   public void testSerializeAndDeserializeAdminMetadata() throws IOException {
-    PubSubPosition originalPosition = PubSubSymbolicPosition.EARLIEST;
+    PubSubPosition originalPosition = ApacheKafkaOffsetPosition.of(12345L);
     PubSubPosition originalUpstreamPosition = ApacheKafkaOffsetPosition.of(67890L);
 
     AdminMetadata originalMetadata = new AdminMetadata();
-    originalMetadata.setExecutionId(12345L);
-    originalMetadata.setOffset(67890L);
-    originalMetadata.setUpstreamOffset(11111L);
+    originalMetadata.setExecutionId(123L);
+    originalMetadata.setOffset(12345L);
+    originalMetadata.setUpstreamOffset(67890L);
     originalMetadata.setAdminOperationProtocolVersion(88L);
     originalMetadata.setPubSubPosition(originalPosition);
     originalMetadata.setUpstreamPubSubPosition(originalUpstreamPosition);
@@ -51,9 +50,9 @@ public class TestAdminMetadata {
 
     // Verify JSON is human-readable
     String jsonString = new String(jsonBytes);
-    assertTrue(jsonString.contains("\"executionId\" : 12345"));
-    assertTrue(jsonString.contains("\"offset\" : 67890"));
-    assertTrue(jsonString.contains("\"upstreamOffset\" : 11111"));
+    assertTrue(jsonString.contains("\"executionId\" : 123"));
+    assertTrue(jsonString.contains("\"offset\" : 12345"));
+    assertTrue(jsonString.contains("\"upstreamOffset\" : 67890"));
     assertTrue(jsonString.contains("\"adminOperationProtocolVersion\" : 88"));
     assertTrue(jsonString.contains("\"pubSubPositionJsonWireFormat\""));
     assertTrue(jsonString.contains("\"pubSubUpstreamPositionJsonWireFormat\""));
@@ -65,9 +64,9 @@ public class TestAdminMetadata {
 
     // Verify all fields
     assertNotNull(deserializedMetadata);
-    assertEquals(deserializedMetadata.getExecutionId(), Long.valueOf(12345L));
-    assertEquals(deserializedMetadata.getOffset(), Long.valueOf(67890L));
-    assertEquals(deserializedMetadata.getUpstreamOffset(), Long.valueOf(11111L));
+    assertEquals(deserializedMetadata.getExecutionId(), Long.valueOf(123L));
+    assertEquals(deserializedMetadata.getOffset(), Long.valueOf(12345L));
+    assertEquals(deserializedMetadata.getUpstreamOffset(), Long.valueOf(67890L));
     assertEquals(deserializedMetadata.getAdminOperationProtocolVersion(), Long.valueOf(88L));
 
     // Verify position objects
@@ -98,7 +97,7 @@ public class TestAdminMetadata {
     assertEquals(deserializedMetadata.getOffset(), Long.valueOf(1234L));
 
     // Verify null fields remain null
-    assertNull(deserializedMetadata.getUpstreamOffset());
+    assertEquals(deserializedMetadata.getUpstreamOffset(), UNDEFINED_VALUE);
     assertEquals(deserializedMetadata.getAdminOperationProtocolVersion(), UNDEFINED_VALUE);
 
     // verify position objects derived from offset
@@ -134,9 +133,11 @@ public class TestAdminMetadata {
     assertNotNull(deserializedMetadata);
 
     // All fields should be null
-    assertNull(deserializedMetadata.getExecutionId());
-    assertNull(deserializedMetadata.getOffset());
-    assertNull(deserializedMetadata.getUpstreamOffset());
+    assertEquals(deserializedMetadata.getExecutionId(), UNDEFINED_VALUE);
+    assertEquals(deserializedMetadata.getOffset().longValue(), PubSubSymbolicPosition.EARLIEST.getNumericOffset());
+    assertEquals(
+        deserializedMetadata.getUpstreamOffset().longValue(),
+        PubSubSymbolicPosition.EARLIEST.getNumericOffset());
     assertEquals(deserializedMetadata.getAdminOperationProtocolVersion(), UNDEFINED_VALUE);
   }
 

--- a/services/venice-controller/src/test/java/com/linkedin/venice/controller/kafka/consumer/TestAdminMetadata.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/controller/kafka/consumer/TestAdminMetadata.java
@@ -96,7 +96,6 @@ public class TestAdminMetadata {
     assertEquals(deserializedMetadata.getExecutionId(), Long.valueOf(999L));
     assertEquals(deserializedMetadata.getOffset(), Long.valueOf(1234L));
 
-    // Verify null fields remain null
     assertEquals(deserializedMetadata.getUpstreamOffset(), UNDEFINED_VALUE);
     assertEquals(deserializedMetadata.getAdminOperationProtocolVersion(), UNDEFINED_VALUE);
 
@@ -132,7 +131,6 @@ public class TestAdminMetadata {
     AdminMetadata deserializedMetadata = serializer.deserialize(jsonBytes, "test-path");
     assertNotNull(deserializedMetadata);
 
-    // All fields should be null
     assertEquals(deserializedMetadata.getExecutionId(), UNDEFINED_VALUE);
     assertEquals(deserializedMetadata.getOffset().longValue(), PubSubSymbolicPosition.EARLIEST.getNumericOffset());
     assertEquals(


### PR DESCRIPTION
<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat], [protocol]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## Problem Statement
<!--
Describe
- What problem are you trying to solve
- What issues or limitations exist in the current code
- Why this change is necessary 
-->
This pull request refactors the admin topic consumption logic to use the generic `PubSubPosition` abstraction instead of raw numeric offsets throughout the codebase. This improves compatibility with different pub/sub systems and makes the code more robust and future-proof. The changes touch several key classes and methods, updating member variables, method signatures, and internal logic to consistently use `PubSubPosition`.

### Refactoring: Offset to Position Abstraction

* Replaced all usages of numeric offsets with `PubSubPosition` in `AdminConsumptionTask`, including member variables such as `failingOffset`, `lastPersistedOffset`, `lastOffset`, and `lastConsumedOffset`, as well as related logic and comments. This includes updating error tracking (`AdminErrorInfo`), store operation queues, retry maps, and checkpoint variables.
* Updated `AdminConsumerService` to expose `getFailingPosition()` instead of `getFailingOffset()`, and updated related method signatures and documentation to use "position" terminology. 
* Updated integration tests (`TestMultiDataCenterAdminOperations`) to use `PubSubPosition` and related utilities for comparisons and skipping failed admin messages, instead of numeric offsets. 

### Documentation and Metrics

* Updated comments and documentation throughout the code to refer to "position" instead of "offset", reflecting the new abstraction. Also updated metric tracking for consumption lag to use position terminology.

### Defensive Programming

* Added null checks to `AdminTopicMetadataAccessor.getExecutionId()` to avoid potential NPEs when metadata is null.

### Handle execution id gap
* using `producerInfo==null` check to decide whether to ingest the duplicate record, which we do for one time when the ingestion start to handle execution id gap, related PR https://github.com/linkedin/venice/pull/84

These changes collectively modernize the admin topic consumption logic, making it more flexible and resilient across different pub/sub implementations.

## Solution
<!--
Describe
- What changes you are making and why. 
- How these changes solve the problem.
- Any performance considerations or trade-offs. 
- Describe what testings you have done, for example, performance testing etc.
-->


###  Code changes
- [ ] Added new code behind **a config**. If so list the config names and their default values in the PR description.
- [ ] Introduced new **log lines**. 
  - [ ] Confirmed if logs need to be **rate limited** to avoid excessive logging.

###  **Concurrency-Specific Checks**
Both reviewer and PR author to verify
- [ ] Code has **no race conditions** or **thread safety issues**.
- [ ] Proper **synchronization mechanisms** (e.g., `synchronized`, `RWLock`) are used where needed.
- [ ] No **blocking calls** inside critical sections that could lead to deadlocks or performance degradation.
- [ ] Verified **thread-safe collections** are used (e.g., `ConcurrentHashMap`, `CopyOnWriteArrayList`).
- [ ] Validated proper exception handling in multi-threaded code to avoid silent thread termination.


## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->

- [ ] New unit tests added.
- [ ] New integration tests added.
- [ ] Modified or extended existing tests.
- [ ] Verified backward compatibility (if applicable).

## Does this PR introduce any user-facing or breaking changes?
<!--  
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [ ] No. You can skip the rest of this section.
- [ ] Yes. Clearly explain the behavior change and its impact.