### PR TITLE
[vpj] Fix issues with mis-categorization of invalid inputs and dataset changes for VPJ

### DIFF
--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/DefaultInputDataInfoProvider.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/DefaultInputDataInfoProvider.java
@@ -78,90 +78,96 @@ public class DefaultInputDataInfoProvider implements InputDataInfoProvider {
    */
   @Override
   public InputDataInfo validateInputAndGetInfo(String inputUri) throws Exception {
-    long inputModificationTime = getInputLastModificationTime(inputUri);
     Path srcPath = new Path(inputUri);
-    FileSystem fs = srcPath.getFileSystem(new Configuration());
-    FileStatus[] fileStatuses = fs.listStatus(srcPath, PATH_FILTER);
-
-    if (fileStatuses == null || fileStatuses.length == 0) {
-      /*
-       * In order to avoid introducing new checkpoint, we resort to using the existing checkpoint
-       * to categorize no data at the source as invalid input. Venice supports multiple InputDataInfoProvider
-       * and currently other implementations do not adhere to same contract and input validation mechanisms like
-       * throwing same type of exceptions and error categorization. We need to revisit this as this might be a larger
-       * scope of change for the current issue.
-       */
-      throw new VeniceInvalidInputException("No data found at source path: " + srcPath);
-    }
-
-    if (pushJobSetting.isZstdDictCreationRequired) {
-      initZstdConfig(fileStatuses.length);
-    }
-
-    // Check the first file type prior to check schema consistency to make sure a schema can be obtained from it.
-    if (fileStatuses[0].isDirectory()) {
-      throw new VeniceException(
-          "Input directory: " + fileStatuses[0].getPath().getParent().getName() + " should not have sub directory: "
-              + fileStatuses[0].getPath().getName());
-    }
-
-    pushJobSetting.isAvro = !HadoopUtils.isSequenceFile(fs, fileStatuses[0].getPath());
-
-    final AtomicLong inputFileDataSize = new AtomicLong(0);
-    if (pushJobSetting.isAvro) {
-      LOGGER.info("Detected Avro input format.");
-      pushJobSetting.keyField = props.getString(KEY_FIELD_PROP, DEFAULT_KEY_FIELD_PROP);
-      pushJobSetting.valueField = props.getString(VALUE_FIELD_PROP, DEFAULT_VALUE_FIELD_PROP);
-
-      Pair<Schema, Schema> fileAndOutputValueSchema = checkAvroSchemaConsistency(fs, fileStatuses, inputFileDataSize);
-
-      pushJobSetting.inputDataSchema = fileAndOutputValueSchema.getFirst();
-      pushJobSetting.valueSchema = fileAndOutputValueSchema.getSecond();
-
-      pushJobSetting.inputDataSchemaString = pushJobSetting.inputDataSchema.toString();
-      pushJobSetting.keySchema = extractAvroSubSchema(pushJobSetting.inputDataSchema, pushJobSetting.keyField);
-    } else {
-      // try reading the file via sequence file reader. It indicates Vson input if it is succeeded.
-      Path firstFilePath = fileStatuses[0].getPath();
-      Map<String, String> fileMetadata = getMetadataFromSequenceFile(fs, firstFilePath, false);
-
-      if (!fileMetadata.containsKey(FILE_KEY_SCHEMA) || !fileMetadata.containsKey(FILE_VALUE_SCHEMA)) {
-        throw new VeniceException("Input file " + firstFilePath.getName() + " is a SequenceFile but not a Vson file.");
+    try {
+      FileSystem fs = srcPath.getFileSystem(new Configuration());
+      FileStatus[] fileStatuses = fs.listStatus(srcPath, PATH_FILTER);
+      if (fileStatuses == null || fileStatuses.length == 0) {
+        /*
+         * In order to avoid introducing new checkpoint, we resort to using the existing checkpoint
+         * to categorize no data at the source as invalid input. Venice supports multiple InputDataInfoProvider
+         * and currently other implementations do not adhere to same contract and input validation mechanisms like
+         * throwing same type of exceptions and error categorization. We need to revisit this as this might be a larger
+         * scope of change for the current issue.
+         */
+        throw new VeniceInvalidInputException("No data found at source path: " + srcPath);
       }
 
-      LOGGER.info("Detected Vson input format, will convert to Avro automatically.");
+      long inputModificationTime = getInputLastModificationTime(inputUri);
 
-      pushJobSetting.vsonInputKeySchemaString = fileMetadata.get(FILE_KEY_SCHEMA);
-      pushJobSetting.vsonInputKeySchema = VsonSchema.parse(pushJobSetting.vsonInputKeySchemaString);
-      pushJobSetting.vsonInputValueSchemaString = fileMetadata.get(FILE_VALUE_SCHEMA);
-      pushJobSetting.vsonInputValueSchema = VsonSchema.parse(pushJobSetting.vsonInputValueSchemaString);
+      if (pushJobSetting.isZstdDictCreationRequired) {
+        initZstdConfig(fileStatuses.length);
+      }
 
-      // key / value fields are optional for Vson input
-      pushJobSetting.keyField = props.getString(KEY_FIELD_PROP, "");
-      pushJobSetting.valueField = props.getString(VALUE_FIELD_PROP, "");
-      pushJobSetting.rmdField = props.getString(RMD_FIELD_PROP, "");
+      // Check the first file type prior to check schema consistency to make sure a schema can be obtained from it.
+      if (fileStatuses[0].isDirectory()) {
+        throw new VeniceException(
+            "Input directory: " + fileStatuses[0].getPath().getParent().getName() + " should not have sub directory: "
+                + fileStatuses[0].getPath().getName());
+      }
 
-      Pair<VsonSchema, VsonSchema> vsonSchema = checkVsonSchemaConsistency(fs, fileStatuses, inputFileDataSize);
+      pushJobSetting.isAvro = !HadoopUtils.isSequenceFile(fs, fileStatuses[0].getPath());
 
-      VsonSchema vsonKeySchema = StringUtils.isEmpty(pushJobSetting.keyField)
-          ? vsonSchema.getFirst()
-          : vsonSchema.getFirst().recordSubtype(pushJobSetting.keyField);
-      VsonSchema vsonValueSchema = StringUtils.isEmpty(pushJobSetting.valueField)
-          ? vsonSchema.getSecond()
-          : vsonSchema.getSecond().recordSubtype(pushJobSetting.valueField);
+      final AtomicLong inputFileDataSize = new AtomicLong(0);
+      if (pushJobSetting.isAvro) {
+        LOGGER.info("Detected Avro input format.");
+        pushJobSetting.keyField = props.getString(KEY_FIELD_PROP, DEFAULT_KEY_FIELD_PROP);
+        pushJobSetting.valueField = props.getString(VALUE_FIELD_PROP, DEFAULT_VALUE_FIELD_PROP);
+        pushJobSetting.rmdField = props.getString(RMD_FIELD_PROP, "");
 
-      pushJobSetting.keySchema = VsonAvroSchemaAdapter.parse(vsonKeySchema.toString());
-      pushJobSetting.valueSchema = VsonAvroSchemaAdapter.parse(vsonValueSchema.toString());
+        Pair<Schema, Schema> fileAndOutputValueSchema = checkAvroSchemaConsistency(fs, fileStatuses, inputFileDataSize);
+
+        pushJobSetting.inputDataSchema = fileAndOutputValueSchema.getFirst();
+        pushJobSetting.valueSchema = fileAndOutputValueSchema.getSecond();
+
+        pushJobSetting.inputDataSchemaString = pushJobSetting.inputDataSchema.toString();
+        pushJobSetting.keySchema = extractAvroSubSchema(pushJobSetting.inputDataSchema, pushJobSetting.keyField);
+      } else {
+        // try reading the file via sequence file reader. It indicates Vson input if it is succeeded.
+        Path firstFilePath = fileStatuses[0].getPath();
+        Map<String, String> fileMetadata = getMetadataFromSequenceFile(fs, firstFilePath, false);
+
+        if (!fileMetadata.containsKey(FILE_KEY_SCHEMA) || !fileMetadata.containsKey(FILE_VALUE_SCHEMA)) {
+          throw new VeniceException(
+              "Input file " + firstFilePath.getName() + " is a SequenceFile but not a Vson file.");
+        }
+
+        LOGGER.info("Detected Vson input format, will convert to Avro automatically.");
+
+        pushJobSetting.vsonInputKeySchemaString = fileMetadata.get(FILE_KEY_SCHEMA);
+        pushJobSetting.vsonInputKeySchema = VsonSchema.parse(pushJobSetting.vsonInputKeySchemaString);
+        pushJobSetting.vsonInputValueSchemaString = fileMetadata.get(FILE_VALUE_SCHEMA);
+        pushJobSetting.vsonInputValueSchema = VsonSchema.parse(pushJobSetting.vsonInputValueSchemaString);
+
+        // key / value fields are optional for Vson input
+        pushJobSetting.keyField = props.getString(KEY_FIELD_PROP, "");
+        pushJobSetting.valueField = props.getString(VALUE_FIELD_PROP, "");
+        pushJobSetting.rmdField = props.getString(RMD_FIELD_PROP, "");
+
+        Pair<VsonSchema, VsonSchema> vsonSchema = checkVsonSchemaConsistency(fs, fileStatuses, inputFileDataSize);
+
+        VsonSchema vsonKeySchema = StringUtils.isEmpty(pushJobSetting.keyField)
+            ? vsonSchema.getFirst()
+            : vsonSchema.getFirst().recordSubtype(pushJobSetting.keyField);
+        VsonSchema vsonValueSchema = StringUtils.isEmpty(pushJobSetting.valueField)
+            ? vsonSchema.getSecond()
+            : vsonSchema.getSecond().recordSubtype(pushJobSetting.valueField);
+
+        pushJobSetting.keySchema = VsonAvroSchemaAdapter.parse(vsonKeySchema.toString());
+        pushJobSetting.valueSchema = VsonAvroSchemaAdapter.parse(vsonValueSchema.toString());
+      }
+
+      pushJobSetting.keySchemaString = pushJobSetting.keySchema.toString();
+      pushJobSetting.valueSchemaString = pushJobSetting.valueSchema.toString();
+
+      return new InputDataInfo(
+          inputFileDataSize.get(),
+          fileStatuses.length,
+          hasRecords(pushJobSetting.isAvro, fs, fileStatuses),
+          inputModificationTime);
+    } catch (FileNotFoundException e) {
+      throw new VeniceInvalidInputException("No data found at source path: " + srcPath);
     }
-
-    pushJobSetting.keySchemaString = pushJobSetting.keySchema.toString();
-    pushJobSetting.valueSchemaString = pushJobSetting.valueSchema.toString();
-
-    return new InputDataInfo(
-        inputFileDataSize.get(),
-        fileStatuses.length,
-        hasRecords(pushJobSetting.isAvro, fs, fileStatuses),
-        inputModificationTime);
   }
 
   private boolean hasRecords(boolean isAvroFile, FileSystem fs, FileStatus[] fileStatusList) {
@@ -313,11 +319,11 @@ public class DefaultInputDataInfoProvider implements InputDataInfoProvider {
   @Override
   public long getInputLastModificationTime(String inputUri) throws IOException {
     Path srcPath = new Path(inputUri);
-    FileSystem fs = srcPath.getFileSystem(new Configuration());
     try {
+      FileSystem fs = srcPath.getFileSystem(new Configuration());
       return fs.getFileStatus(srcPath).getModificationTime();
     } catch (FileNotFoundException e) {
-      throw new RuntimeException("No data found at source path: " + srcPath);
+      throw new VeniceInvalidInputException("No data found at source path: " + srcPath);
     }
   }
 

--- a/clients/venice-push-job/src/test/java/com/linkedin/venice/hadoop/TestDefaultInputDataInfoProvider.java
+++ b/clients/venice-push-job/src/test/java/com/linkedin/venice/hadoop/TestDefaultInputDataInfoProvider.java
@@ -7,6 +7,7 @@ import static org.testng.Assert.assertNotEquals;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.fail;
 
 import com.linkedin.venice.etl.ETLValueSchemaTransformation;
 import com.linkedin.venice.hadoop.exceptions.VeniceInvalidInputException;
@@ -14,11 +15,56 @@ import com.linkedin.venice.utils.KeyAndValueSchemas;
 import com.linkedin.venice.utils.TestWriteUtils;
 import com.linkedin.venice.utils.VeniceProperties;
 import java.io.File;
+import java.nio.file.Files;
 import org.apache.avro.Schema;
 import org.testng.annotations.Test;
 
 
 public class TestDefaultInputDataInfoProvider {
+  @Test
+  public void testValidInputAtTheBeginningAndModifiedAfter() throws Exception {
+    PushJobSetting pushJobSetting = new PushJobSetting();
+    pushJobSetting.isZstdDictCreationRequired = false;
+    pushJobSetting.etlValueSchemaTransformation = ETLValueSchemaTransformation.NONE;
+    VeniceProperties props = VeniceProperties.empty();
+
+    try (DefaultInputDataInfoProvider provider = new DefaultInputDataInfoProvider(pushJobSetting, props)) {
+      File inputDir = getTempDataDirectory();
+      String inputUri = "file://" + inputDir.getAbsolutePath();
+      TestWriteUtils.writeSimpleAvroFileWithStringToStringSchema(inputDir);
+
+      InputDataInfoProvider.InputDataInfo inputDataInfo = provider.validateInputAndGetInfo(inputUri);
+      assertTrue(inputDataInfo.hasRecords());
+      assertEquals(inputDataInfo.getNumInputFiles(), 1);
+
+      try {
+        for (File file: inputDir.listFiles()) {
+          Files.delete(file.toPath());
+        }
+        Files.delete(inputDir.toPath());
+        provider.getInputLastModificationTime(inputUri);
+        fail("Expected VeniceInvalidInputException to be thrown when input directory is deleted.");
+      } catch (VeniceInvalidInputException ignored) {
+        // not using the default test expectedExceptions to just make sure the test doesn't run into false positive
+        // in case the exception is encountered in the first attempt
+      }
+    }
+  }
+
+  @Test(expectedExceptions = VeniceInvalidInputException.class)
+  public void testEmptyInputDirectory() throws Exception {
+    PushJobSetting pushJobSetting = new PushJobSetting();
+    pushJobSetting.isZstdDictCreationRequired = false;
+    pushJobSetting.etlValueSchemaTransformation = ETLValueSchemaTransformation.NONE;
+    VeniceProperties props = VeniceProperties.empty();
+
+    try (DefaultInputDataInfoProvider provider = new DefaultInputDataInfoProvider(pushJobSetting, props)) {
+      File inputDir = getTempDataDirectory();
+      String inputUri = "file://" + inputDir.getAbsolutePath();
+      provider.validateInputAndGetInfo(inputUri);
+    }
+  }
+
   @Test
   public void testValidateAvroInput() throws Exception {
     PushJobSetting pushJobSetting = new PushJobSetting();

--- a/clients/venice-push-job/src/test/java/com/linkedin/venice/hadoop/VenicePushJobTest.java
+++ b/clients/venice-push-job/src/test/java/com/linkedin/venice/hadoop/VenicePushJobTest.java
@@ -99,6 +99,7 @@ import com.linkedin.venice.views.ChangeCaptureView;
 import com.linkedin.venice.views.MaterializedView;
 import com.linkedin.venice.views.ViewUtils;
 import com.linkedin.venice.writer.VeniceWriter;
+import java.io.File;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -157,6 +158,38 @@ public class VenicePushJobTest {
       + "      { \"name\": \"id\", \"type\": \"string\" },\n" + "      { \"name\": \"name\", \"type\": \"string\" },\n"
       + "      { \"name\": \"age\", \"type\": \"int\" },\n" + "      { \"name\": \"company\", \"type\": \"string\" }\n"
       + "    ]\n" + "  }";
+
+  @Test
+  public void testCheckLastModifiedTimestamp() throws Exception {
+    File inputDir = TestWriteUtils.getTempDataDirectory();
+    TestWriteUtils.writeSimpleAvroFileWithStringToStringSchema(inputDir);
+    String inputUri = "file://" + inputDir.getAbsolutePath();
+
+    PushJobSetting pushJobSetting = new PushJobSetting();
+    pushJobSetting.inputURI = inputUri;
+    VeniceProperties props = VeniceProperties.empty();
+
+    try (DefaultInputDataInfoProvider provider = new DefaultInputDataInfoProvider(pushJobSetting, props);
+        VenicePushJob mockJob = getSpyVenicePushJob(new Properties(), null)) {
+      InputDataInfoProvider.InputDataInfo inputDataInfo = provider.validateInputAndGetInfo(inputUri);
+
+      when(mockJob.getInputDataInfo()).thenReturn(inputDataInfo);
+      when(mockJob.getInputDataInfo()).thenReturn(inputDataInfo);
+      when(mockJob.getPushJobSetting()).thenReturn(pushJobSetting);
+      when(mockJob.getPushJobSetting()).thenReturn(pushJobSetting);
+      when(mockJob.getInputDataInfoProvider()).thenReturn(provider);
+      when(mockJob.getInputDataInfoProvider()).thenReturn(provider);
+
+      // No modifications to input and no interactions expected with mockJob
+      mockJob.checkLastModificationTimeAndLog();
+      verify(mockJob, never()).updatePushJobDetailsWithCheckpoint(any(PushJobCheckpoints.class));
+
+      // Write a new file to the input directory
+      TestWriteUtils.writeSimpleAvroFileWithStringToStringWithExtraSchema(inputDir);
+      mockJob.checkLastModificationTimeAndLog();
+      verify(mockJob, times(1)).updatePushJobDetailsWithCheckpoint(PushJobCheckpoints.DATASET_CHANGED);
+    }
+  }
 
   @Test
   public void testVPJCheckInputUpdateSchema() {

--- a/clients/venice-push-job/src/test/java/com/linkedin/venice/hadoop/VenicePushJobTest.java
+++ b/clients/venice-push-job/src/test/java/com/linkedin/venice/hadoop/VenicePushJobTest.java
@@ -69,6 +69,7 @@ import com.linkedin.venice.controllerapi.MultiSchemaResponse;
 import com.linkedin.venice.controllerapi.SchemaResponse;
 import com.linkedin.venice.controllerapi.StoreResponse;
 import com.linkedin.venice.controllerapi.VersionCreationResponse;
+import com.linkedin.venice.etl.ETLValueSchemaTransformation;
 import com.linkedin.venice.exceptions.UndefinedPropertyException;
 import com.linkedin.venice.exceptions.VeniceException;
 import com.linkedin.venice.hadoop.exceptions.VeniceValidationException;
@@ -167,6 +168,8 @@ public class VenicePushJobTest {
 
     PushJobSetting pushJobSetting = new PushJobSetting();
     pushJobSetting.inputURI = inputUri;
+    pushJobSetting.etlValueSchemaTransformation = ETLValueSchemaTransformation.NONE;
+    pushJobSetting.isZstdDictCreationRequired = false;
     VeniceProperties props = VeniceProperties.empty();
 
     try (DefaultInputDataInfoProvider provider = new DefaultInputDataInfoProvider(pushJobSetting, props);


### PR DESCRIPTION
## Problem Statement
VPJ failures due to invalid input source or dataset changes are mis-categorized as non-user errors.

###  Code changes
- Make the exception thrown consistent in case of input data not present
- Move `checkForLastModificationTime` after input validations
- Cascade `FileNotFoundExceptions` as `VeniceInputInvalidException` to report it as user errors
- Added few getters for unit testing
- Added both unit and partly integration tests to validate the flow

## How was this PR tested?
- [x] New unit tests added.
- [x] New integration tests added.
- [x] Modified or extended existing tests.

## Does this PR introduce any user-facing or breaking changes?
- [x] No. You can skip the rest of this section.
- [ ] Yes. Clearly explain the behavior change and its impact.