### PR TITLE
[server] Replace numeric offsets with PubSubPosition in DCR and WC code paths

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/ActiveActiveStoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/ActiveActiveStoreIngestionTask.java
@@ -1293,8 +1293,8 @@ public class ActiveActiveStoreIngestionTask extends LeaderFollowerStoreIngestion
       throw new VeniceException(
           String.format(
               "No PubSub cluster ID found in the cluster ID to PubSub URL map. "
-                  + "Got cluster ID %d and ID to cluster URL map %s. Source PubSub: %s; "
-                  + "%s; Offset: %s; Message type: %s; ProducerMetadata: %s; LeaderMetadataFooter: %s",
+                  + "Got cluster ID %d and ID to cluster URL map %s. Source topic-partition: %s; "
+                  + "%s; Position: %s; Message type: %s; ProducerMetadata: %s; LeaderMetadataFooter: %s",
               kafkaValue.leaderMetadataFooter.upstreamKafkaClusterId,
               kafkaClusterIdToUrlMap,
               recordSourceKafkaUrl,

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/ActiveActiveStoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/ActiveActiveStoreIngestionTask.java
@@ -522,7 +522,7 @@ public class ActiveActiveStoreIngestionTask extends LeaderFollowerStoreIngestion
         : Collections.singletonList(0L);
 
     // get the source offset and the id
-    long sourceOffset = consumerRecord.getPosition().getNumericOffset();
+    PubSubPosition sourcePosition = consumerRecord.getPosition();
     final MergeConflictResult mergeConflictResult;
 
     aggVersionedIngestionStats.recordTotalDCR(storeName, versionNumber);
@@ -538,7 +538,7 @@ public class ActiveActiveStoreIngestionTask extends LeaderFollowerStoreIngestion
             ((Put) kafkaValue.payloadUnion).putValue,
             writeTimestamp,
             incomingValueSchemaId,
-            sourceOffset,
+            sourcePosition,
             kafkaClusterId,
             kafkaClusterId // Use the kafka cluster ID as the colo ID for now because one colo/fabric has only one
         // Kafka cluster. TODO: evaluate whether it is enough this way, or we need to add a new
@@ -553,7 +553,7 @@ public class ActiveActiveStoreIngestionTask extends LeaderFollowerStoreIngestion
             oldValueByteBufferProvider,
             rmdWithValueSchemaID,
             writeTimestamp,
-            sourceOffset,
+            sourcePosition,
             kafkaClusterId,
             kafkaClusterId);
         getHostLevelIngestionStats()
@@ -568,7 +568,7 @@ public class ActiveActiveStoreIngestionTask extends LeaderFollowerStoreIngestion
             incomingValueSchemaId,
             incomingWriteComputeSchemaId,
             writeTimestamp,
-            sourceOffset,
+            sourcePosition,
             kafkaClusterId,
             kafkaClusterId,
             valueManifestContainer);
@@ -1292,14 +1292,14 @@ public class ActiveActiveStoreIngestionTask extends LeaderFollowerStoreIngestion
       MessageType type = MessageType.valueOf(kafkaValue.messageType);
       throw new VeniceException(
           String.format(
-              "No Kafka cluster ID found in the cluster ID to Kafka URL map. "
-                  + "Got cluster ID %d and ID to cluster URL map %s. Source Kafka: %s; "
-                  + "%s; Offset: %d; Message type: %s; ProducerMetadata: %s; LeaderMetadataFooter: %s",
+              "No PubSub cluster ID found in the cluster ID to PubSub URL map. "
+                  + "Got cluster ID %d and ID to cluster URL map %s. Source PubSub: %s; "
+                  + "%s; Offset: %s; Message type: %s; ProducerMetadata: %s; LeaderMetadataFooter: %s",
               kafkaValue.leaderMetadataFooter.upstreamKafkaClusterId,
               kafkaClusterIdToUrlMap,
               recordSourceKafkaUrl,
               consumerRecord.getTopicPartition(),
-              consumerRecord.getPosition().getNumericOffset(),
+              consumerRecord.getPosition(),
               type.toString() + (type == MessageType.CONTROL_MESSAGE
                   ? "/" + ControlMessageType.valueOf((ControlMessage) kafkaValue.getPayloadUnion())
                   : ""),

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTask.java
@@ -3635,7 +3635,7 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
       PartitionTracker.TopicType realTimeTopicType = PartitionTracker.TopicType.of(REALTIME_TOPIC_TYPE, brokerUrl);
       getConsumerDiv().setPartitionState(realTimeTopicType, pcs.getPartition(), producerStates);
       final PubSubPosition divRtCheckpointPosition =
-          getPubSubContext().getPubSubPositionDeserializer().toPosition(globalRtDivState.getLatestPubSubPositionWf());
+          getPubSubContext().getPubSubPositionDeserializer().toPosition(globalRtDivState.getLatestPubSubPosition());
       pcs.setDivRtCheckpointPosition(brokerUrl, divRtCheckpointPosition);
     } else {
       LOGGER.warn(

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
@@ -2210,13 +2210,13 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
         updateLeaderTopicOnFollower(newPartitionConsumptionState);
 
         // Subscribe to local version topic.
-        PubSubPosition subscribeOffset = getLocalVtSubscribePosition(newPartitionConsumptionState);
+        PubSubPosition localVtSubscribePosition = getLocalVtSubscribePosition(newPartitionConsumptionState);
         consumerSubscribe(
             topicPartition.getPubSubTopic(),
             newPartitionConsumptionState,
-            subscribeOffset,
+            localVtSubscribePosition,
             localKafkaServer);
-        LOGGER.info("Subscribed to: {} Offset {}", topicPartition, subscribeOffset);
+        LOGGER.info("Subscribed to: {} position: {}", topicPartition, localVtSubscribePosition);
         storageUtilizationManager.initPartition(partition);
         break;
       case UNSUBSCRIBE:

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
@@ -2210,7 +2210,7 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
         updateLeaderTopicOnFollower(newPartitionConsumptionState);
 
         // Subscribe to local version topic.
-        PubSubPosition subscribeOffset = getLocalVtSubscribeOffset(newPartitionConsumptionState);
+        PubSubPosition subscribeOffset = getLocalVtSubscribePosition(newPartitionConsumptionState);
         consumerSubscribe(
             topicPartition.getPubSubTopic(),
             newPartitionConsumptionState,
@@ -4767,7 +4767,7 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
    * When Global RT DIV is enabled, the latest consumed VT offset (LCVO) should be used during subscription.
    * Otherwise, the drainer's latest processed VT offset is traditionally used.
    */
-  PubSubPosition getLocalVtSubscribeOffset(PartitionConsumptionState pcs) {
+  PubSubPosition getLocalVtSubscribePosition(PartitionConsumptionState pcs) {
     return (isGlobalRtDivEnabled()) ? pcs.getLatestConsumedVtPosition() : pcs.getLatestProcessedVtPosition();
   }
 
@@ -4911,5 +4911,10 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
 
   boolean isOffsetLagDeltaRelaxEnabled() {
     return offsetLagDeltaRelaxEnabled;
+  }
+
+  @VisibleForTesting
+  PubSubContext getPubSubContext() {
+    return pubSubContext;
   }
 }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/replication/merge/Merge.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/replication/merge/Merge.java
@@ -2,6 +2,7 @@ package com.linkedin.davinci.replication.merge;
 
 import com.linkedin.davinci.schema.merge.ValueAndRmd;
 import com.linkedin.venice.annotation.Threadsafe;
+import com.linkedin.venice.pubsub.api.PubSubPosition;
 import com.linkedin.venice.utils.lazy.Lazy;
 import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericRecord;
@@ -47,7 +48,7 @@ public interface Merge<T> {
    * @param newValue a record with all fields populated and with one of the registered value schemas
    * @param putOperationTimestamp the timestamp of the incoming write operation
    * @param putOperationColoID ID of the colo/fabric where this PUT request was originally received.
-   * @param newValueSourceOffset The offset from which the new value originates in the realtime stream.  Used to build
+   * @param newValueSourcePosition The position from which the new value originates in the realtime stream.  Used to build
    *                               the ReplicationMetadata for the newly inserted record.
    * @param newValueSourceBrokerID The ID of the broker from which the new value originates.  ID's should correspond
    *                                 to the kafkaClusterUrlIdMap configured in the LeaderFollowerIngestionTask.  Used to build
@@ -61,12 +62,12 @@ public interface Merge<T> {
       T newValue,
       long putOperationTimestamp,
       int putOperationColoID,
-      long newValueSourceOffset,
+      PubSubPosition newValueSourcePosition,
       int newValueSourceBrokerID);
 
   /**
    * @param oldValueAndRmd the old value and replication metadata which are persisted in the server prior to the write operation
-   * @param newValueSourceOffset The offset from which the new value originates in the realtime stream.  Used to build
+   * @param newValueSourcePosition The position from which the new value originates in the realtime stream.  Used to build
    *                               the ReplicationMetadata for the newly inserted record.
    * @param deleteOperationColoID ID of the colo/fabric where this DELETE request was originally received.
    * @param newValueSourceBrokerID The ID of the broker from which the new value originates.  ID's should correspond
@@ -80,18 +81,16 @@ public interface Merge<T> {
       ValueAndRmd<T> oldValueAndRmd,
       long deleteOperationTimestamp,
       int deleteOperationColoID,
-      long newValueSourceOffset,
+      PubSubPosition newValueSourcePosition,
       int newValueSourceBrokerID);
 
   /**
    * @param oldValueAndRmd the old value and replication metadata which are persisted in the server prior to the write operation
    * @param writeOperation a record with a write compute schema
    * @param currValueSchema Schema of the current value that is to-be-updated here.
-   * @param writeComputeSchema Schema used to generate the write compute record. This schema could be a union and that is
-   *                           why this schema is needed when we already pass in the {@code writeOperation} generic record.
    * @param updateOperationTimestamp the timestamp of the incoming write operation
    * @param updateOperationColoID ID of the colo/fabric where this UPDATE request was originally received.
-   * @param newValueSourceOffset The offset from which the new value originates in the realtime stream.  Used to build
+   * @param newValueSourcePosition The position from which the new value originates in the realtime stream.  Used to build
    *                               the ReplicationMetadata for the newly inserted record.
    * @param newValueSourceBrokerID The ID of the broker from which the new value originates.  ID's should correspond
    *                                 to the kafkaClusterUrlIdMap configured in the LeaderFollowerIngestionTask.  Used to build
@@ -106,6 +105,6 @@ public interface Merge<T> {
       Schema currValueSchema,
       long updateOperationTimestamp,
       int updateOperationColoID,
-      long newValueSourceOffset,
+      PubSubPosition newValueSourcePosition,
       int newValueSourceBrokerID);
 }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/replication/merge/MergeByteBuffer.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/replication/merge/MergeByteBuffer.java
@@ -3,6 +3,7 @@ package com.linkedin.davinci.replication.merge;
 import static com.linkedin.venice.schema.rmd.RmdConstants.TIMESTAMP_FIELD_POS;
 
 import com.linkedin.davinci.schema.merge.ValueAndRmd;
+import com.linkedin.venice.pubsub.api.PubSubPosition;
 import com.linkedin.venice.schema.rmd.RmdTimestampType;
 import com.linkedin.venice.schema.rmd.RmdUtils;
 import com.linkedin.venice.utils.lazy.Lazy;
@@ -22,7 +23,7 @@ public class MergeByteBuffer extends AbstractMerge<ByteBuffer> {
       ByteBuffer newValue,
       long putOperationTimestamp,
       int writeOperationColoID,
-      long sourceOffsetOfNewValue,
+      PubSubPosition sourcePositionOfNewValue,
       int newValueSourceBrokerID) {
     final GenericRecord oldReplicationMetadata = oldValueAndRmd.getRmd();
     final Object tsObject = oldReplicationMetadata.get(TIMESTAMP_FIELD_POS);
@@ -33,7 +34,7 @@ public class MergeByteBuffer extends AbstractMerge<ByteBuffer> {
           (long) tsObject,
           oldValueAndRmd,
           putOperationTimestamp,
-          sourceOffsetOfNewValue,
+          sourcePositionOfNewValue,
           newValueSourceBrokerID,
           newValue);
     } else {
@@ -46,7 +47,7 @@ public class MergeByteBuffer extends AbstractMerge<ByteBuffer> {
       ValueAndRmd<ByteBuffer> oldValueAndRmd,
       long deleteOperationTimestamp,
       int deleteOperationColoID,
-      long newValueSourceOffset,
+      PubSubPosition newValueSourcePosition,
       int newValueSourceBrokerID) {
     final GenericRecord oldReplicationMetadata = oldValueAndRmd.getRmd();
     final Object tsObject = oldReplicationMetadata.get(TIMESTAMP_FIELD_POS);
@@ -55,7 +56,7 @@ public class MergeByteBuffer extends AbstractMerge<ByteBuffer> {
       return deleteWithValueLevelTimestamp(
           (long) tsObject,
           deleteOperationTimestamp,
-          newValueSourceOffset,
+          newValueSourcePosition,
           newValueSourceBrokerID,
           oldValueAndRmd);
     } else {
@@ -70,7 +71,7 @@ public class MergeByteBuffer extends AbstractMerge<ByteBuffer> {
       Schema currValueSchema,
       long updateOperationTimestamp,
       int updateOperationColoID,
-      long newValueSourceOffset,
+      PubSubPosition newValueSourcePosition,
       int newValueSourceBrokerID) {
     throw new IllegalStateException("Update request should not be handled by this class.");
   }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/store/view/ChangeCaptureViewWriter.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/store/view/ChangeCaptureViewWriter.java
@@ -129,9 +129,6 @@ public class ChangeCaptureViewWriter extends VeniceViewWriter {
     Map<String, PubSubPosition> sortedWaterMarkOffsets = partitionConsumptionState.getLatestProcessedRtPositions();
 
     List<Long> highWaterMarkOffsets;
-    /**
-     * TODO(sushantmane): Once we update OffsetRecord to use PubSubPosition, we should pop up this field from the PCS
-     */
     List<ByteBuffer> highWaterMarkPubSubPositions;
     if (maxColoIdValue > -1) {
       highWaterMarkOffsets = new ArrayList<>(Collections.nCopies(maxColoIdValue + 1, 0L));

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/validation/DataIntegrityValidator.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/validation/DataIntegrityValidator.java
@@ -167,9 +167,9 @@ public class DataIntegrityValidator {
         this.logCompactionDelayInMs);
   }
 
-  public void updateLatestConsumedVtOffset(int partition, PubSubPosition offset) {
+  public void updateLatestConsumedVtPosition(int partition, PubSubPosition vtPosition) {
     PartitionTracker partitionTracker = registerPartition(partition);
-    partitionTracker.updateLatestConsumedVtPosition(offset);
+    partitionTracker.updateLatestConsumedVtPosition(vtPosition);
   }
 
   /**

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/validation/PartitionTracker.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/validation/PartitionTracker.java
@@ -878,7 +878,7 @@ public class PartitionTracker {
 
       sb.append("; partition: ").append(consumerRecord.getTopicPartition().getPartitionNumber());
       if (segment != null) {
-        sb.append("; previous successful offset (in same segment): ").append(segment.getLastSuccessfulPosition());
+        sb.append("; previous successful position (in same segment): ").append(segment.getLastSuccessfulPosition());
       }
       sb.append("; incoming offset: ")
           .append(consumerRecord.getPosition())
@@ -900,7 +900,7 @@ public class PartitionTracker {
           .append(new Date(producerMetadata.messageTimestamp))
           .append(")");
       if (consumerRecord.getValue().leaderMetadataFooter != null) {
-        sb.append("; LeaderMetadata { upstream offset: ")
+        sb.append("; LeaderMetadata { upstream position: ")
             .append(consumerRecord.getValue().leaderMetadataFooter.upstreamOffset)
             .append("; upstream pub sub cluster ID: ")
             .append(consumerRecord.getValue().leaderMetadataFooter.upstreamKafkaClusterId)

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/validation/PartitionTracker.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/validation/PartitionTracker.java
@@ -77,7 +77,7 @@ public class PartitionTracker {
   private final int partition;
   // TODO: clear vtSegments
   /**
-   * There should only be one {@link ConsumptionTask} for VT, so there shouldn't need to be any locking.
+   * There should only be one {@code ConsumptionTask} for VT, so there shouldn't need to be any locking.
    */
   private final VeniceConcurrentHashMap<GUID, Segment> vtSegments = new VeniceConcurrentHashMap<>();
   /**
@@ -88,7 +88,7 @@ public class PartitionTracker {
 
   /**
    * rtSegments is a map of source broker URL to a map of GUID to Segment.
-   * There should only be one {@link ConsumptionTask} for each broker URL, so there shouldn't need to be any locking.
+   * There should only be one {@code ConsumptionTask} for each broker URL, so there shouldn't need to be any locking.
    *
    * TODO: Refactor this so the {@link #rtSegments} map is keyed by region ID (numeric), rather than URL. URLs could
    *       change over time but the ID should remain fixed. It is also more compact (and the outer collection could even
@@ -308,7 +308,7 @@ public class PartitionTracker {
     trackSequenceNumber(segment, consumerRecord, endOfPushReceived, tolerateMissingMsgs, hasPreviousSegment);
     // This is the last step, because we want failures in the previous steps to short-circuit execution.
     trackCheckSum(segment, consumerRecord, endOfPushReceived, tolerateMissingMsgs);
-    segment.setLastSuccessfulOffset(consumerRecord.getPosition().getNumericOffset());
+    segment.setLastSuccessfulPosition(consumerRecord.getPosition());
     segment.setNewSegment(false);
   }
 
@@ -878,7 +878,7 @@ public class PartitionTracker {
 
       sb.append("; partition: ").append(consumerRecord.getTopicPartition().getPartitionNumber());
       if (segment != null) {
-        sb.append("; previous successful offset (in same segment): ").append(segment.getLastSuccessfulOffset());
+        sb.append("; previous successful offset (in same segment): ").append(segment.getLastSuccessfulPosition());
       }
       sb.append("; incoming offset: ")
           .append(consumerRecord.getPosition())

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/ActiveActiveStoreIngestionTaskTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/ActiveActiveStoreIngestionTaskTest.java
@@ -668,7 +668,7 @@ public class ActiveActiveStoreIngestionTaskTest {
           .getUpstreamKafkaUrlFromKafkaValue(msgWithAbsentUpstreamCluster, sourceKafka, kafkaClusterIdToUrlMap);
     } catch (VeniceException e) {
       LOGGER.info("kmeWithAbsentUpstreamCluster", e);
-      assertTrue(e.getMessage().startsWith("No Kafka cluster ID found in the cluster ID to Kafka URL map."));
+      assertTrue(e.getMessage().startsWith("No PubSub cluster ID found in the cluster ID to PubSub URL map."));
       assertTrue(e.getMessage().contains("Message type: " + MessageType.PUT));
     }
 
@@ -692,7 +692,7 @@ public class ActiveActiveStoreIngestionTaskTest {
           .getUpstreamKafkaUrlFromKafkaValue(msgForControlMessage, sourceKafka, kafkaClusterIdToUrlMap);
     } catch (VeniceException e) {
       LOGGER.info("kmeForControlMessage", e);
-      assertTrue(e.getMessage().startsWith("No Kafka cluster ID found in the cluster ID to Kafka URL map."));
+      assertTrue(e.getMessage().startsWith("No PubSub cluster ID found in the cluster ID to PubSub URL map."));
       assertTrue(
           e.getMessage()
               .contains("Message type: " + MessageType.CONTROL_MESSAGE + "/" + ControlMessageType.TOPIC_SWITCH));

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTaskTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTaskTest.java
@@ -600,7 +600,7 @@ public class LeaderFollowerStoreIngestionTaskTest {
 
     // delegateConsumerRecord() should cause updateLatestConsumedVtPosition() to be called
     mockIngestionTask.delegateConsumerRecord(cm, 0, "testURL", 0, 0, 0);
-    verify(consumerDiv, times(1)).updateLatestConsumedVtOffset(0, cm.getMessage().getPosition());
+    verify(consumerDiv, times(1)).updateLatestConsumedVtPosition(0, cm.getMessage().getPosition());
   }
 
   @Test

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/replication/merge/MergeGenericRecordTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/replication/merge/MergeGenericRecordTest.java
@@ -11,6 +11,8 @@ import com.linkedin.davinci.schema.merge.MergeRecordHelper;
 import com.linkedin.davinci.schema.merge.ValueAndRmd;
 import com.linkedin.davinci.schema.writecompute.WriteComputeProcessor;
 import com.linkedin.venice.exceptions.VeniceException;
+import com.linkedin.venice.pubsub.adapter.kafka.common.ApacheKafkaOffsetPosition;
+import com.linkedin.venice.pubsub.api.PubSubPosition;
 import com.linkedin.venice.schema.rmd.RmdSchemaGenerator;
 import com.linkedin.venice.schema.writecompute.WriteComputeSchemaConverter;
 import com.linkedin.venice.utils.lazy.Lazy;
@@ -40,6 +42,8 @@ public class MergeGenericRecordTest {
       + "    },\n" + "    \"default\" : [ ]\n" + "  }, {\n" + "    \"name\" : \"hasNext\",\n"
       + "    \"type\" : \"boolean\",\n" + "    \"default\" : false\n" + "  } ]\n" + "}";
 
+  private static final PubSubPosition P1 = new ApacheKafkaOffsetPosition(1L);
+
   @Test
   public void testDelete() {
     Schema schema = AvroCompatibilityHelper.parse(RECORD_SCHEMA_STR);
@@ -58,7 +62,7 @@ public class MergeGenericRecordTest {
     ValueAndRmd<GenericRecord> valueAndRmd = new ValueAndRmd<>(Lazy.of(() -> valueRecord), timestampRecord);
 
     Merge<GenericRecord> genericRecordMerge = createMergeGenericRecord();
-    ValueAndRmd<GenericRecord> deletedValueAndRmd1 = genericRecordMerge.delete(valueAndRmd, 20, -1, 1, 0);
+    ValueAndRmd<GenericRecord> deletedValueAndRmd1 = genericRecordMerge.delete(valueAndRmd, 20, -1, P1, 0);
     // verify id and name fields are default (deleted)
     Assert.assertEquals(deletedValueAndRmd1.getValue().get("id").toString(), "id");
     Assert.assertEquals(deletedValueAndRmd1.getValue().get("name").toString(), "name");
@@ -73,7 +77,7 @@ public class MergeGenericRecordTest {
     // full delete. expect null value
     timestampRecord.put(0, 20L);
     valueAndRmd.setRmd(timestampRecord);
-    ValueAndRmd<GenericRecord> deletedValueAndRmd2 = genericRecordMerge.delete(valueAndRmd, 30, -1, 1, 0);
+    ValueAndRmd<GenericRecord> deletedValueAndRmd2 = genericRecordMerge.delete(valueAndRmd, 30, -1, P1, 0);
     Assert.assertNull(deletedValueAndRmd2.getValue());
     // Verify that the same object is returned
     Assert.assertSame(deletedValueAndRmd2, valueAndRmd);
@@ -85,7 +89,7 @@ public class MergeGenericRecordTest {
     timestampRecord.put(0, ts);
     valueAndRmd.setRmd(timestampRecord);
     valueAndRmd.setValue(valueRecord);
-    valueAndRmd = genericRecordMerge.delete(valueAndRmd, 30, 1, -1, 0);
+    valueAndRmd = genericRecordMerge.delete(valueAndRmd, 30, 1, P1, 0);
     Assert.assertNull(valueAndRmd.getValue());
     Assert.assertTrue(valueAndRmd.getRmd().get(TIMESTAMP_FIELD_NAME) instanceof GenericRecord);
     GenericRecord newTimestampRecord = (GenericRecord) valueAndRmd.getRmd().get(TIMESTAMP_FIELD_NAME);
@@ -97,7 +101,7 @@ public class MergeGenericRecordTest {
     timestampRecord.put(0, ts);
     valueAndRmd.setRmd(timestampRecord);
     valueAndRmd.setValue(valueRecord);
-    ValueAndRmd<GenericRecord> deletedValueAndRmd3 = genericRecordMerge.delete(valueAndRmd, 5, -1, 1, 0);
+    ValueAndRmd<GenericRecord> deletedValueAndRmd3 = genericRecordMerge.delete(valueAndRmd, 5, -1, P1, 0);
 
     Assert.assertEquals(deletedValueAndRmd3.getValue(), valueAndRmd.getValue());
     Assert.assertEquals(
@@ -129,7 +133,7 @@ public class MergeGenericRecordTest {
     newRecord.put("name", "name10");
     newRecord.put("age", 20);
     Merge<GenericRecord> genericRecordMerge = createMergeGenericRecord();
-    ValueAndRmd<GenericRecord> mergedValueAndRmd1 = genericRecordMerge.put(valueAndRmd, newRecord, 30, -1, 1, 0);
+    ValueAndRmd<GenericRecord> mergedValueAndRmd1 = genericRecordMerge.put(valueAndRmd, newRecord, 30, -1, P1, 0);
 
     // verify id and name fields are from new record
     Assert.assertEquals(mergedValueAndRmd1.getValue().get("id"), newRecord.get(0));
@@ -139,7 +143,7 @@ public class MergeGenericRecordTest {
     Assert.assertSame(mergedValueAndRmd1, valueAndRmd);
 
     // verify we reuse the same instance when nothings changed.
-    ValueAndRmd<GenericRecord> mergedValueAndRmd2 = genericRecordMerge.put(valueAndRmd, newRecord, 10, -1, 1, 0);
+    ValueAndRmd<GenericRecord> mergedValueAndRmd2 = genericRecordMerge.put(valueAndRmd, newRecord, 10, -1, P1, 0);
     Assert.assertEquals(mergedValueAndRmd2.getValue(), valueAndRmd.getValue());
     // Verify that the same object is returned
     Assert.assertSame(mergedValueAndRmd2, valueAndRmd);
@@ -151,7 +155,8 @@ public class MergeGenericRecordTest {
             + "   ]," + " \"name\": \"testObject\", \"type\": \"record\"" + "}");
     newRecord = new GenericData.Record(schema2);
     GenericRecord finalNewRecord = newRecord;
-    Assert.assertThrows(VeniceException.class, () -> genericRecordMerge.put(valueAndRmd, finalNewRecord, 10, -1, 1, 0));
+    Assert
+        .assertThrows(VeniceException.class, () -> genericRecordMerge.put(valueAndRmd, finalNewRecord, 10, -1, P1, 0));
   }
 
   @Test
@@ -182,7 +187,7 @@ public class MergeGenericRecordTest {
     wcRecord.put("name", noOpRecord);
     wcRecord.put("age", 20);
     Merge<GenericRecord> genericRecordMerge = createMergeGenericRecord();
-    valueAndRmd = genericRecordMerge.update(valueAndRmd, Lazy.of(() -> wcRecord), wcRecord.getSchema(), 30, -1, 1, 0);
+    valueAndRmd = genericRecordMerge.update(valueAndRmd, Lazy.of(() -> wcRecord), wcRecord.getSchema(), 30, -1, P1, 0);
 
     // verify id and name fields are from new record
     Assert.assertEquals(valueAndRmd.getValue().get("id"), wcRecord.get(0));
@@ -195,12 +200,12 @@ public class MergeGenericRecordTest {
 
     // verify we reuse the same instance when nothing changed.
     ValueAndRmd<GenericRecord> valueAndRmd1 =
-        genericRecordMerge.update(valueAndRmd, Lazy.of(() -> wcRecord), wcRecord.getSchema(), 10, -1, 1, 0);
+        genericRecordMerge.update(valueAndRmd, Lazy.of(() -> wcRecord), wcRecord.getSchema(), 10, -1, P1, 0);
     Assert.assertTrue(valueAndRmd1.getValue() == valueAndRmd.getValue());
 
     // validate ts record change from LONG to GenericRecord.
     // timeStampRecord.put(0, 10L); // N.B. The test fails when this is uncommented. TODO: Figure out if it's important?
-    valueAndRmd = genericRecordMerge.update(valueAndRmd, Lazy.of(() -> wcRecord), wcRecord.getSchema(), 30, -1, 1, 0);
+    valueAndRmd = genericRecordMerge.update(valueAndRmd, Lazy.of(() -> wcRecord), wcRecord.getSchema(), 30, -1, P1, 0);
     ts = (GenericRecord) valueAndRmd.getRmd().get(TIMESTAMP_FIELD_NAME);
     Assert.assertEquals(ts.get("id"), 30L);
     Assert.assertEquals(ts.get("name"), 10L);
@@ -217,7 +222,8 @@ public class MergeGenericRecordTest {
     ValueAndRmd finalValueAndRmd = valueAndRmd;
     Assert.assertThrows(
         IllegalStateException.class,
-        () -> genericRecordMerge.update(finalValueAndRmd, Lazy.of(() -> wcRecord), wcRecord.getSchema(), 10, -1, 1, 0));
+        () -> genericRecordMerge
+            .update(finalValueAndRmd, Lazy.of(() -> wcRecord), wcRecord.getSchema(), 10, -1, P1, 0));
   }
 
   @Test
@@ -252,7 +258,7 @@ public class MergeGenericRecordTest {
     for (int i = 0; i < 100; i++) {
       for (int j = 0; j < 100; j++) {
         valueAndRmd = genericRecordMerge
-            .put(valueAndRmd, GenericData.get().deepCopy(schema, payload.get(j)), writeTs.get(i), -1, 1, 0);
+            .put(valueAndRmd, GenericData.get().deepCopy(schema, payload.get(j)), writeTs.get(i), -1, P1, 0);
       }
     }
     // timestamp record should always contain the latest value
@@ -270,7 +276,7 @@ public class MergeGenericRecordTest {
     for (int i = 0; i < 100; i++) {
       for (int j = 0; j < 100; j++) {
         valueAndRmd = genericRecordMerge
-            .put(valueAndRmd, GenericData.get().deepCopy(schema, payload.get(i)), writeTs.get(j), -1, 1, 0);
+            .put(valueAndRmd, GenericData.get().deepCopy(schema, payload.get(i)), writeTs.get(j), -1, P1, 0);
       }
     }
     // timestamp record should always contain the latest value

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/replication/merge/TestMergeBase.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/replication/merge/TestMergeBase.java
@@ -7,6 +7,8 @@ import com.linkedin.davinci.replication.merge.helper.utils.ValueAndDerivedSchema
 import com.linkedin.davinci.serializer.avro.MapOrderPreservingSerDeFactory;
 import com.linkedin.davinci.utils.IndexedHashMap;
 import com.linkedin.venice.meta.ReadOnlySchemaRepository;
+import com.linkedin.venice.pubsub.adapter.kafka.common.ApacheKafkaOffsetPosition;
+import com.linkedin.venice.pubsub.api.PubSubPosition;
 import com.linkedin.venice.schema.rmd.RmdConstants;
 import com.linkedin.venice.schema.rmd.RmdSchemaGenerator;
 import com.linkedin.venice.serializer.RecordDeserializer;
@@ -23,6 +25,7 @@ import org.testng.annotations.BeforeClass;
 
 public class TestMergeBase {
   protected static final int UPDATE_SCHEMA_PROTOCOL_VERSION = 1;
+  protected static final PubSubPosition P1 = new ApacheKafkaOffsetPosition(1L);
   protected static final int RMD_SCHEMA_PROTOCOL_VERSION = RmdSchemaGenerator.getLatestVersion();
   protected static final String REGULAR_FIELD_NAME = "regularField";
   protected static final String STRING_ARRAY_FIELD_NAME = "stringArrayField";

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/replication/merge/TestMergeConflictResolver.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/replication/merge/TestMergeConflictResolver.java
@@ -11,6 +11,8 @@ import static org.mockito.Mockito.mock;
 import com.linkedin.davinci.replication.merge.helper.utils.ValueAndDerivedSchemas;
 import com.linkedin.davinci.serializer.avro.MapOrderPreservingSerDeFactory;
 import com.linkedin.venice.meta.ReadOnlySchemaRepository;
+import com.linkedin.venice.pubsub.adapter.kafka.common.ApacheKafkaOffsetPosition;
+import com.linkedin.venice.pubsub.api.PubSubPosition;
 import com.linkedin.venice.schema.SchemaEntry;
 import com.linkedin.venice.schema.rmd.RmdConstants;
 import com.linkedin.venice.schema.rmd.RmdSchemaEntry;
@@ -31,6 +33,8 @@ import org.testng.annotations.BeforeClass;
 
 public class TestMergeConflictResolver {
   protected static final int RMD_VERSION_ID = 1;
+  protected static final PubSubPosition P1 = new ApacheKafkaOffsetPosition(1L);
+  protected static final PubSubPosition P2 = new ApacheKafkaOffsetPosition(2L);
 
   protected String storeName;
   protected ReadOnlySchemaRepository schemaRepository;

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/replication/merge/TestMergeDelete.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/replication/merge/TestMergeDelete.java
@@ -48,7 +48,7 @@ public class TestMergeDelete extends TestMergeBase {
         Lazy.of(() -> serializeValueRecord(oldValueRecord)),
         new RmdWithValueSchemaId(schemaSet.getValueSchemaId(), RMD_VERSION_ID, oldRmdRecord),
         2L,
-        1L,
+        P1,
         0,
         0);
 
@@ -97,7 +97,7 @@ public class TestMergeDelete extends TestMergeBase {
         Lazy.of(() -> serializeValueRecord(oldValueRecord)),
         new RmdWithValueSchemaId(schemaSet.getValueSchemaId(), RMD_VERSION_ID, oldRmdRecord),
         2L,
-        1L,
+        P1,
         0,
         0);
 
@@ -121,7 +121,7 @@ public class TestMergeDelete extends TestMergeBase {
         Lazy.of(() -> serializeValueRecord(oldValueRecord)),
         new RmdWithValueSchemaId(schemaSet.getValueSchemaId(), RMD_VERSION_ID, oldRmdRecord),
         4L,
-        1L,
+        P1,
         0,
         -1); // Default colo ID = -1, any coloID >= -1 will be accepted.
     Assert.assertFalse(result.isUpdateIgnored());
@@ -167,7 +167,7 @@ public class TestMergeDelete extends TestMergeBase {
         Lazy.of(() -> serializeValueRecord(oldValueRecord)),
         new RmdWithValueSchemaId(schemaSet.getValueSchemaId(), RMD_VERSION_ID, oldRmdRecord),
         2L,
-        1L,
+        P1,
         0,
         0);
     Assert.assertTrue(result.isUpdateIgnored());
@@ -183,7 +183,7 @@ public class TestMergeDelete extends TestMergeBase {
         Lazy.of(() -> serializeValueRecord(oldValueRecord)),
         new RmdWithValueSchemaId(schemaSet.getValueSchemaId(), RMD_VERSION_ID, oldRmdRecord),
         3L,
-        1L,
+        P1,
         0,
         -2);
     Assert.assertTrue(result.isUpdateIgnored());
@@ -199,7 +199,7 @@ public class TestMergeDelete extends TestMergeBase {
         Lazy.of(() -> serializeValueRecord(oldValueRecord)),
         new RmdWithValueSchemaId(schemaSet.getValueSchemaId(), RMD_VERSION_ID, oldRmdRecord),
         3L,
-        1L,
+        P1,
         0,
         -2);
     Assert.assertTrue(result.isUpdateIgnored());

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/replication/merge/TestMergeDeleteWithFieldLevelTimestamp.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/replication/merge/TestMergeDeleteWithFieldLevelTimestamp.java
@@ -43,7 +43,7 @@ public class TestMergeDeleteWithFieldLevelTimestamp extends TestMergeConflictRes
         Lazy.of(() -> null),
         new RmdWithValueSchemaId(oldValueSchemaID, RMD_VERSION_ID, rmdRecord),
         deleteOperationTimestamp,
-        1L, // Same as the old value schema ID.
+        P1, // Same as the old value schema ID.
         0,
         0);
     Assert.assertTrue(mergeResult.isUpdateIgnored());
@@ -72,7 +72,7 @@ public class TestMergeDeleteWithFieldLevelTimestamp extends TestMergeConflictRes
         Lazy.of(() -> null),
         new RmdWithValueSchemaId(oldValueSchemaID, RMD_VERSION_ID, rmdRecord),
         11L,
-        1L,
+        P1,
         0,
         0);
     Assert.assertFalse(mergeResult.isUpdateIgnored());
@@ -112,7 +112,7 @@ public class TestMergeDeleteWithFieldLevelTimestamp extends TestMergeConflictRes
     // Case 1: Delete one field with the same delete timestamp.
     long deleteOperationTimestamp = 10L;
     MergeConflictResult result = mergeConflictResolver
-        .delete(Lazy.of(() -> oldValueBytes), oldRmdWithValueSchemaID, deleteOperationTimestamp, 1L, 0, 0);
+        .delete(Lazy.of(() -> oldValueBytes), oldRmdWithValueSchemaID, deleteOperationTimestamp, P1, 0, 0);
     Assert.assertFalse(result.isUpdateIgnored());
     GenericRecord updatedRmd = result.getRmdRecord();
     GenericRecord updatedPerFieldTimestampRecord = (GenericRecord) updatedRmd.get(TIMESTAMP_FIELD_NAME);
@@ -130,7 +130,7 @@ public class TestMergeDeleteWithFieldLevelTimestamp extends TestMergeConflictRes
     // Case 2: Delete two fields with the a higher delete timestamp.
     deleteOperationTimestamp = 25L;
     result = mergeConflictResolver
-        .delete(Lazy.of(() -> oldValueBytes), oldRmdWithValueSchemaID, deleteOperationTimestamp, 1L, 0, 0);
+        .delete(Lazy.of(() -> oldValueBytes), oldRmdWithValueSchemaID, deleteOperationTimestamp, P1, 0, 0);
     Assert.assertFalse(result.isUpdateIgnored());
     updatedRmd = result.getRmdRecord();
     updatedPerFieldTimestampRecord = (GenericRecord) updatedRmd.get(TIMESTAMP_FIELD_NAME);
@@ -148,7 +148,7 @@ public class TestMergeDeleteWithFieldLevelTimestamp extends TestMergeConflictRes
     // Case 3: Delete all three fields with the a higher delete timestamp.
     deleteOperationTimestamp = 99L;
     result = mergeConflictResolver
-        .delete(Lazy.of(() -> oldValueBytes), oldRmdWithValueSchemaID, deleteOperationTimestamp, 1L, 0, 0);
+        .delete(Lazy.of(() -> oldValueBytes), oldRmdWithValueSchemaID, deleteOperationTimestamp, P1, 0, 0);
     Assert.assertFalse(result.isUpdateIgnored());
     updatedRmd = result.getRmdRecord();
     Object timestampObj = updatedRmd.get(TIMESTAMP_FIELD_NAME);

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/replication/merge/TestMergePut.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/replication/merge/TestMergePut.java
@@ -51,7 +51,7 @@ public class TestMergePut extends TestMergeBase {
         serializeValueRecord(newValueRecord),
         1L,
         schemaSet.getValueSchemaId(),
-        1L,
+        P1,
         0,
         0);
 
@@ -108,7 +108,7 @@ public class TestMergePut extends TestMergeBase {
         serializeValueRecord(newValueRecord),
         1L,
         schemaSet.getValueSchemaId(),
-        1L,
+        P1,
         0,
         0);
     Assert.assertTrue(result.isUpdateIgnored());
@@ -120,7 +120,7 @@ public class TestMergePut extends TestMergeBase {
         serializeValueRecord(newValueRecord),
         2L,
         schemaSet.getValueSchemaId(),
-        1L,
+        P1,
         0,
         -2);
     Assert.assertTrue(result.isUpdateIgnored());
@@ -158,7 +158,7 @@ public class TestMergePut extends TestMergeBase {
         serializeValueRecord(newValueRecord),
         1L,
         schemaSet.getValueSchemaId(),
-        1L,
+        P1,
         0,
         -1);
 
@@ -192,7 +192,7 @@ public class TestMergePut extends TestMergeBase {
         serializeValueRecord(newValueRecord),
         2L,
         schemaSet.getValueSchemaId(),
-        1L,
+        P1,
         0,
         -2);
     Assert.assertFalse(result.isUpdateIgnored());
@@ -248,7 +248,7 @@ public class TestMergePut extends TestMergeBase {
         serializeValueRecord(newValueRecord),
         2L,
         schemaSet.getValueSchemaId(),
-        1L,
+        P1,
         0,
         -2);
     Assert.assertFalse(result.isUpdateIgnored());
@@ -281,7 +281,7 @@ public class TestMergePut extends TestMergeBase {
         serializeValueRecord(newValueRecord),
         3L,
         schemaSet.getValueSchemaId(),
-        1L,
+        P1,
         0,
         0);
     Assert.assertFalse(result.isUpdateIgnored());

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/replication/merge/TestMergePutWithFieldLevelTimestamp.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/replication/merge/TestMergePutWithFieldLevelTimestamp.java
@@ -55,7 +55,7 @@ public class TestMergePutWithFieldLevelTimestamp extends TestMergeConflictResolv
         null,
         9L,
         1, // Same as the old value schema ID.
-        1L,
+        P1,
         0,
         0);
     Assert.assertTrue(mergeResult.isUpdateIgnored());
@@ -92,7 +92,7 @@ public class TestMergePutWithFieldLevelTimestamp extends TestMergeConflictResolv
         newValueBytes,
         11L,
         1, // Same as the old value schema ID.
-        1L,
+        P1,
         0,
         0);
     Assert.assertFalse(mergeResult.isUpdateIgnored());
@@ -139,7 +139,7 @@ public class TestMergePutWithFieldLevelTimestamp extends TestMergeConflictResolv
         newValueBytes,
         11L,
         1, // Different from the old value schema ID.
-        1L,
+        P1,
         0,
         0);
     Assert.assertFalse(mergeResult.isUpdateIgnored());
@@ -240,7 +240,7 @@ public class TestMergePutWithFieldLevelTimestamp extends TestMergeConflictResolv
         newValueBytes,
         15L,
         3, // same as the old value schema ID.
-        1L,
+        P1,
         0,
         0);
 
@@ -293,7 +293,7 @@ public class TestMergePutWithFieldLevelTimestamp extends TestMergeConflictResolv
         newValueBytes,
         15L,
         4, // new value schema ID is different from the old value schema ID.
-        1L,
+        P1,
         0,
         0);
 
@@ -347,7 +347,7 @@ public class TestMergePutWithFieldLevelTimestamp extends TestMergeConflictResolv
         newValueBytes,
         15L,
         5, // new value schema ID is different from the old value schema ID.
-        1L,
+        P1,
         0,
         0);
 
@@ -401,7 +401,7 @@ public class TestMergePutWithFieldLevelTimestamp extends TestMergeConflictResolv
         newValueBytes,
         25L,
         4, // new value schema ID is different from the old value schema ID.
-        1L,
+        P1,
         0,
         0);
 

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/replication/merge/TestMergeUpdate.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/replication/merge/TestMergeUpdate.java
@@ -1,5 +1,6 @@
 package com.linkedin.davinci.replication.merge;
 
+import static com.linkedin.davinci.replication.merge.TestMergeConflictResolver.P1;
 import static com.linkedin.davinci.replication.merge.TestMergeConflictResolver.RMD_VERSION_ID;
 import static com.linkedin.venice.schema.rmd.v1.CollectionRmdTimestamp.ACTIVE_ELEM_TS_FIELD_NAME;
 import static com.linkedin.venice.schema.rmd.v1.CollectionRmdTimestamp.DELETED_ELEM_FIELD_NAME;
@@ -56,7 +57,7 @@ public class TestMergeUpdate extends TestMergeBase {
         schemaSet.getValueSchemaId(),
         schemaSet.getUpdateSchemaProtocolVersion(),
         updateTs,
-        1L,
+        P1,
         0,
         0,
         null);
@@ -102,7 +103,7 @@ public class TestMergeUpdate extends TestMergeBase {
         schemaSet.getValueSchemaId(),
         schemaSet.getUpdateSchemaProtocolVersion(),
         updateTs,
-        1L,
+        P1,
         0,
         updateColoId,
         null);
@@ -163,7 +164,7 @@ public class TestMergeUpdate extends TestMergeBase {
         schemaSet.getValueSchemaId(),
         schemaSet.getUpdateSchemaProtocolVersion(),
         updateTs,
-        1L,
+        P1,
         0,
         -2,
         null);
@@ -222,7 +223,7 @@ public class TestMergeUpdate extends TestMergeBase {
         schemaSet.getValueSchemaId(),
         schemaSet.getUpdateSchemaProtocolVersion(),
         updateTs,
-        1L,
+        P1,
         0,
         -2,
         null);
@@ -262,7 +263,7 @@ public class TestMergeUpdate extends TestMergeBase {
         schemaSet.getValueSchemaId(),
         schemaSet.getUpdateSchemaProtocolVersion(),
         updateTs,
-        1L,
+        P1,
         0,
         -2,
         null);
@@ -334,7 +335,7 @@ public class TestMergeUpdate extends TestMergeBase {
         schemaSet.getValueSchemaId(),
         schemaSet.getUpdateSchemaProtocolVersion(),
         2L,
-        1L,
+        P1,
         0,
         0,
         null);
@@ -401,7 +402,7 @@ public class TestMergeUpdate extends TestMergeBase {
         schemaSet.getValueSchemaId(),
         schemaSet.getUpdateSchemaProtocolVersion(),
         10L,
-        1L,
+        P1,
         0,
         0,
         null);
@@ -443,7 +444,7 @@ public class TestMergeUpdate extends TestMergeBase {
         schemaSet.getValueSchemaId(),
         schemaSet.getUpdateSchemaProtocolVersion(),
         10L,
-        1L,
+        P1,
         0,
         0,
         container);
@@ -523,7 +524,7 @@ public class TestMergeUpdate extends TestMergeBase {
         schemaSet.getValueSchemaId(),
         schemaSet.getUpdateSchemaProtocolVersion(),
         2L,
-        1L,
+        P1,
         0,
         0,
         null);
@@ -602,7 +603,7 @@ public class TestMergeUpdate extends TestMergeBase {
         schemaSet.getValueSchemaId(),
         schemaSet.getUpdateSchemaProtocolVersion(),
         3L,
-        1L,
+        P1,
         0,
         0,
         null);
@@ -813,7 +814,7 @@ public class TestMergeUpdate extends TestMergeBase {
         schemaSet.getValueSchemaId(),
         schemaSet.getUpdateSchemaProtocolVersion(),
         timestamp,
-        1L,
+        P1,
         0,
         0,
         null);

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/replication/merge/TestMergeUpdateWithFieldLevelTimestamp.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/replication/merge/TestMergeUpdateWithFieldLevelTimestamp.java
@@ -88,7 +88,7 @@ public class TestMergeUpdateWithFieldLevelTimestamp extends TestMergeConflictRes
         incomingValueSchemaId,
         incomingWriteComputeSchemaId,
         valueLevelTimestamp - 1, // Slightly lower than existing timestamp. Thus update should be ignored.
-        1,
+        P1,
         1,
         1,
         null);
@@ -146,7 +146,7 @@ public class TestMergeUpdateWithFieldLevelTimestamp extends TestMergeConflictRes
         incomingValueSchemaId,
         incomingWriteComputeSchemaId,
         valueLevelTimestamp - 1, // Slightly lower than existing timestamp. Thus update should be ignored.
-        1,
+        P1,
         1,
         1,
         null);
@@ -210,7 +210,7 @@ public class TestMergeUpdateWithFieldLevelTimestamp extends TestMergeConflictRes
         incomingValueSchemaId,
         1,
         valueLevelTimestamp + 1, // Slightly higher than existing timestamp. Thus update should be applied.
-        1,
+        P1,
         1,
         1,
         null);
@@ -278,7 +278,7 @@ public class TestMergeUpdateWithFieldLevelTimestamp extends TestMergeConflictRes
         incomingValueSchemaId,
         incomingWriteComputeSchemaId,
         valueLevelTimestamp + 1,
-        1,
+        P1,
         1,
         1,
         null);
@@ -296,7 +296,7 @@ public class TestMergeUpdateWithFieldLevelTimestamp extends TestMergeConflictRes
         incomingValueSchemaId,
         incomingWriteComputeSchemaId,
         valueLevelTimestamp + 2,
-        2,
+        P2,
         0,
         0,
         null);
@@ -402,7 +402,7 @@ public class TestMergeUpdateWithFieldLevelTimestamp extends TestMergeConflictRes
         incomingValueSchemaId,
         incomingWriteComputeSchemaId,
         valueLevelTimestamp + 1, // Slightly higher than existing timestamp. Thus update is NOT ignored.
-        1,
+        P1,
         1,
         newColoID,
         null);

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/replication/merge/TestMergeUpdateWithValueLevelTimestamp.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/replication/merge/TestMergeUpdateWithValueLevelTimestamp.java
@@ -77,7 +77,7 @@ public class TestMergeUpdateWithValueLevelTimestamp extends TestMergeConflictRes
         incomingValueSchemaId,
         incomingWriteComputeSchemaId,
         valueLevelTimestamp - 1, // Slightly lower than existing timestamp. Thus update should be ignored.
-        1,
+        P1,
         1,
         1,
         null);
@@ -131,7 +131,7 @@ public class TestMergeUpdateWithValueLevelTimestamp extends TestMergeConflictRes
         incomingValueSchemaId,
         incomingWriteComputeSchemaId,
         valueLevelTimestamp - 1, // Slightly lower than existing timestamp. Thus update should be ignored.
-        1,
+        P1,
         1,
         1,
         null);
@@ -201,7 +201,7 @@ public class TestMergeUpdateWithValueLevelTimestamp extends TestMergeConflictRes
         incomingValueSchemaId,
         incomingWriteComputeSchemaId,
         valueLevelTimestamp + 1, // Slightly higher than existing timestamp. Thus update is NOT ignored.
-        1,
+        P1,
         1,
         1,
         null);
@@ -314,7 +314,7 @@ public class TestMergeUpdateWithValueLevelTimestamp extends TestMergeConflictRes
         incomingValueSchemaId,
         incomingWriteComputeSchemaId,
         valueLevelTimestamp + 1, // Slightly higher than existing timestamp. Thus update is NOT ignored.
-        1,
+        P1,
         1,
         newColoID,
         null);
@@ -394,7 +394,7 @@ public class TestMergeUpdateWithValueLevelTimestamp extends TestMergeConflictRes
         incomingValueSchemaId,
         incomingWriteComputeSchemaId,
         valueLevelTimestamp + 2,
-        1,
+        P1,
         1,
         newColoID,
         null);
@@ -479,7 +479,7 @@ public class TestMergeUpdateWithValueLevelTimestamp extends TestMergeConflictRes
         incomingValueSchemaId,
         incomingWriteComputeSchemaId,
         valueLevelTimestamp + 1, // Slightly higher than existing timestamp. Thus update is NOT ignored.
-        1,
+        P1,
         1,
         newValueColoID,
         null);
@@ -627,7 +627,7 @@ public class TestMergeUpdateWithValueLevelTimestamp extends TestMergeConflictRes
         incomingValueSchemaId,
         incomingWriteComputeSchemaId,
         valueLevelTimestamp + 1, // Slightly higher than existing timestamp. Thus update is NOT ignored.
-        1,
+        P1,
         1,
         newValueColoID,
         null);

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/replication/merge/TestMergeWithValueLevelTimestamp.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/replication/merge/TestMergeWithValueLevelTimestamp.java
@@ -53,7 +53,7 @@ public class TestMergeWithValueLevelTimestamp extends TestMergeConflictResolver 
         newBB,
         30L,
         1,
-        1L,
+        P1,
         0,
         0);
 
@@ -68,7 +68,7 @@ public class TestMergeWithValueLevelTimestamp extends TestMergeConflictResolver 
         newBB,
         10L,
         1,
-        1L,
+        P1,
         0,
         0);
     Assert.assertTrue(mergeConflictResult.isUpdateIgnored());
@@ -80,7 +80,7 @@ public class TestMergeWithValueLevelTimestamp extends TestMergeConflictResolver 
         newBB,
         20L,
         1,
-        1L,
+        P1,
         0,
         0);
 
@@ -97,7 +97,7 @@ public class TestMergeWithValueLevelTimestamp extends TestMergeConflictResolver 
         newBB,
         30L,
         1,
-        1L,
+        P1,
         0,
         0);
     Assert.assertEquals(mergeConflictResult.getNewValue(), newBB);
@@ -111,7 +111,7 @@ public class TestMergeWithValueLevelTimestamp extends TestMergeConflictResolver 
             newBB,
             30L,
             1,
-            1L,
+            P1,
             0,
             0));
 
@@ -122,7 +122,7 @@ public class TestMergeWithValueLevelTimestamp extends TestMergeConflictResolver 
         newBB,
         30L,
         1,
-        1L,
+        P1,
         0,
         0);
     result = deserializer.deserialize(mergeConflictResult.getNewValue());
@@ -132,11 +132,11 @@ public class TestMergeWithValueLevelTimestamp extends TestMergeConflictResolver 
     // win on a tie, meaning
     // this should get an ignore result
     mergeConflictResult = mergeConflictResolver
-        .put(Lazy.of(() -> null), new RmdWithValueSchemaId(1, RMD_VERSION_ID, rmdRecord), newBB, 20L, 1, 1L, 0, 0);
+        .put(Lazy.of(() -> null), new RmdWithValueSchemaId(1, RMD_VERSION_ID, rmdRecord), newBB, 20L, 1, P1, 0, 0);
     Assert.assertTrue(mergeConflictResult.isUpdateIgnored());
 
     // Validate null RMD for existing old value
-    mergeConflictResult = mergeConflictResolver.put(Lazy.of(() -> oldBB), null, newBB, 30L, 1, 1L, 0, 0);
+    mergeConflictResult = mergeConflictResolver.put(Lazy.of(() -> oldBB), null, newBB, 30L, 1, P1, 0, 0);
     Assert.assertEquals(mergeConflictResult.getNewValue(), newBB);
   }
 
@@ -165,34 +165,34 @@ public class TestMergeWithValueLevelTimestamp extends TestMergeConflictResolver 
     // new MergeConflictResolver(schemaRepository, storeName, valueSchemaID -> new GenericData.Record(rmdSchemaV1));
 
     MergeConflictResult mergeConflictResult = mergeConflictResolver
-        .delete(Lazy.of(() -> null), new RmdWithValueSchemaId(1, RMD_VERSION_ID, timestampRecord), 30L, 1L, 0, 0);
+        .delete(Lazy.of(() -> null), new RmdWithValueSchemaId(1, RMD_VERSION_ID, timestampRecord), 30L, P1, 0, 0);
 
     // verify delete null value
     Assert.assertNull(mergeConflictResult.getNewValue());
 
     // verify update ignored.
     mergeConflictResult = mergeConflictResolver
-        .delete(Lazy.of(() -> null), new RmdWithValueSchemaId(1, RMD_VERSION_ID, timestampRecord), 10L, 1L, 0, 0);
+        .delete(Lazy.of(() -> null), new RmdWithValueSchemaId(1, RMD_VERSION_ID, timestampRecord), 10L, P1, 0, 0);
     Assert.assertTrue(mergeConflictResult.isUpdateIgnored());
 
     // verify same timestamp case
     mergeConflictResult = mergeConflictResolver
-        .delete(Lazy.of(() -> null), new RmdWithValueSchemaId(1, RMD_VERSION_ID, timestampRecord), 30L, 1L, 0, 0);
+        .delete(Lazy.of(() -> null), new RmdWithValueSchemaId(1, RMD_VERSION_ID, timestampRecord), 30L, P1, 0, 0);
     Assert.assertNull(mergeConflictResult.getNewValue());
 
     // Validate null RMD for existing old value
-    mergeConflictResult = mergeConflictResolver.delete(Lazy.of(() -> null), null, 30, 1, 0, 0);
+    mergeConflictResult = mergeConflictResolver.delete(Lazy.of(() -> null), null, 30, P1, 0, 0);
     Assert.assertFalse(mergeConflictResult.isUpdateIgnored());
     Assert.assertNull(mergeConflictResult.getNewValue());
 
     // Validate null RMD for invalid schema id
-    mergeConflictResult = mergeConflictResolver.delete(Lazy.of(() -> null), null, 30, 1, 0, 0);
+    mergeConflictResult = mergeConflictResolver.delete(Lazy.of(() -> null), null, 30, P1, 0, 0);
     Assert.assertFalse(mergeConflictResult.isUpdateIgnored());
     Assert.assertEquals(mergeConflictResult.getValueSchemaId(), 1);
 
     // Validate delete wins on same timestamp
     mergeConflictResult = mergeConflictResolver
-        .delete(Lazy.of(() -> null), new RmdWithValueSchemaId(1, RMD_VERSION_ID, timestampRecord), 30L, 1L, 0, 0);
+        .delete(Lazy.of(() -> null), new RmdWithValueSchemaId(1, RMD_VERSION_ID, timestampRecord), 30L, P1, 0, 0);
     Assert.assertFalse(mergeConflictResult.isUpdateIgnored());
     Assert.assertEquals(mergeConflictResult.getValueSchemaId(), 1);
 
@@ -200,7 +200,7 @@ public class TestMergeWithValueLevelTimestamp extends TestMergeConflictResolver 
     Assert.assertThrows(
         VeniceException.class,
         () -> mergeConflictResolver
-            .delete(Lazy.of(() -> null), new RmdWithValueSchemaId(-1, RMD_VERSION_ID, timestampRecord), 30L, 1L, 0, 0));
+            .delete(Lazy.of(() -> null), new RmdWithValueSchemaId(-1, RMD_VERSION_ID, timestampRecord), 30L, P1, 0, 0));
   }
 
   @Test
@@ -248,7 +248,7 @@ public class TestMergeWithValueLevelTimestamp extends TestMergeConflictResolver 
             newBB,
             writeTs.get(j),
             1,
-            1,
+            P1,
             0,
             0);
       }
@@ -268,7 +268,7 @@ public class TestMergeWithValueLevelTimestamp extends TestMergeConflictResolver 
             newBB,
             writeTs.get(i),
             1,
-            1,
+            P1,
             0,
             0);
       }

--- a/internal/venice-common/src/main/java/com/linkedin/venice/kafka/validation/Segment.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/kafka/validation/Segment.java
@@ -17,6 +17,7 @@ import com.linkedin.venice.kafka.protocol.state.ProducerPartitionState;
 import com.linkedin.venice.kafka.validation.checksum.CheckSum;
 import com.linkedin.venice.kafka.validation.checksum.CheckSumType;
 import com.linkedin.venice.message.KafkaKey;
+import com.linkedin.venice.pubsub.api.PubSubPosition;
 import com.linkedin.venice.utils.CollectionUtils;
 import it.unimi.dsi.fastutil.objects.Object2ObjectArrayMap;
 import java.nio.ByteBuffer;
@@ -70,7 +71,7 @@ public class Segment {
    * after checking incoming message's sequence number.
    */
   private volatile boolean newSegment;
-  private volatile long lastSuccessfulOffset;
+  private volatile PubSubPosition lastSuccessfulPosition;
   // record the last timestamp that a validation for this segment happened and passed.
   private volatile long lastRecordTimestamp = -1;
   // record the last producer message time stamp passed within the ConsumerRecord
@@ -202,12 +203,12 @@ public class Segment {
     return this.registered;
   }
 
-  public long getLastSuccessfulOffset() {
-    return lastSuccessfulOffset;
+  public PubSubPosition getLastSuccessfulPosition() {
+    return lastSuccessfulPosition;
   }
 
-  public void setLastSuccessfulOffset(long lastSuccessfulOffset) {
-    this.lastSuccessfulOffset = lastSuccessfulOffset;
+  public void setLastSuccessfulPosition(PubSubPosition lastSuccessfulPosition) {
+    this.lastSuccessfulPosition = lastSuccessfulPosition;
   }
 
   public long getLastRecordTimestamp() {

--- a/internal/venice-common/src/main/resources/avro/GlobalRtDivState/v1/GlobalRtDivState.avsc
+++ b/internal/venice-common/src/main/resources/avro/GlobalRtDivState/v1/GlobalRtDivState.avsc
@@ -82,14 +82,8 @@
       "default": {}
     },
     {
-      "name": "latestOffset",
-      "doc": "The last Kafka offset consumed successfully in this partition.",
-      "type": "long",
-      "default": -1
-    },
-    {
-      "name": "latestPubSubPosition",
-      "doc": "The last PubSubPosition consumed successfully in this partition. Will be used once offset is deprecated.",
+      "name": "latestPubSubPositionWf",
+      "doc": "The last PubSubPosition consumed successfully in this partition.",
       "type": "bytes",
       "default": ""
     }

--- a/internal/venice-common/src/main/resources/avro/GlobalRtDivState/v1/GlobalRtDivState.avsc
+++ b/internal/venice-common/src/main/resources/avro/GlobalRtDivState/v1/GlobalRtDivState.avsc
@@ -82,7 +82,7 @@
       "default": {}
     },
     {
-      "name": "latestPubSubPositionWf",
+      "name": "latestPubSubPosition",
       "doc": "The last PubSubPosition consumed successfully in this partition.",
       "type": "bytes",
       "default": ""


### PR DESCRIPTION
## [server] Replace numeric offsets with PubSubPosition in DCR and WC code paths
- Change long with PubSubPosition in code as well as tests

VALIDATION_OVERRIDE
###  Code changes
- [ ] Added new code behind **a config**. If so list the config names and their default values in the PR description.
- [ ] Introduced new **log lines**. 
  - [ ] Confirmed if logs need to be **rate limited** to avoid excessive logging.

###  **Concurrency-Specific Checks**
Both reviewer and PR author to verify
- [ ] Code has **no race conditions** or **thread safety issues**.
- [ ] Proper **synchronization mechanisms** (e.g., `synchronized`, `RWLock`) are used where needed.
- [ ] No **blocking calls** inside critical sections that could lead to deadlocks or performance degradation.
- [ ] Verified **thread-safe collections** are used (e.g., `ConcurrentHashMap`, `CopyOnWriteArrayList`).
- [ ] Validated proper exception handling in multi-threaded code to avoid silent thread termination.


## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->

- [ ] New unit tests added.
- [ ] New integration tests added.
- [ ] Modified or extended existing tests.
- [ ] Verified backward compatibility (if applicable).

## Does this PR introduce any user-facing or breaking changes?
<!--  
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [ ] No. You can skip the rest of this section.
- [ ] Yes. Clearly explain the behavior change and its impact.