### PR TITLE
[server] Remove ready_to_serve_with_rt_lag metric

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/ActiveActiveStoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/ActiveActiveStoreIngestionTask.java
@@ -1364,30 +1364,6 @@ public class ActiveActiveStoreIngestionTask extends LeaderFollowerStoreIngestion
     return maxLag;
   }
 
-  /** used for metric purposes **/
-  @Override
-  public boolean isReadyToServeAnnouncedWithRTLag() {
-    if (!hybridStoreConfig.isPresent() || partitionConsumptionStateMap.isEmpty()) {
-      return false;
-    }
-    long offsetLagThreshold = hybridStoreConfig.get().getOffsetLagThresholdToGoOnline();
-    for (PartitionConsumptionState pcs: partitionConsumptionStateMap.values()) {
-      if (pcs.hasLagCaughtUp() && offsetLagThreshold >= 0) {
-        // If pcs is marked as having caught up, but we're not ready to serve, that means we're lagging
-        // after having announced that we are ready to serve.
-        try {
-          if (!this.isReadyToServe(pcs)) {
-            return true;
-          }
-        } catch (Exception e) {
-          // Something wasn't reachable, we'll report that something is amiss.
-          return true;
-        }
-      }
-    }
-    return false;
-  }
-
   Runnable buildRepairTask(
       String sourceKafkaUrl,
       PubSubTopicPartition sourceTopicPartition,

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTask.java
@@ -1811,31 +1811,6 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
   }
 
   @Override
-  public boolean isReadyToServeAnnouncedWithRTLag() {
-    if (!hybridStoreConfig.isPresent() || partitionConsumptionStateMap.isEmpty()) {
-      return false;
-    }
-    long offsetLagThreshold = hybridStoreConfig.get().getOffsetLagThresholdToGoOnline();
-    for (PartitionConsumptionState pcs: partitionConsumptionStateMap.values()) {
-      if (pcs.hasLagCaughtUp() && offsetLagThreshold >= 0) {
-        Set<String> sourceRealTimeTopicKafkaURLs = getRealTimeDataSourceKafkaAddress(pcs);
-        if (sourceRealTimeTopicKafkaURLs.isEmpty()) {
-          return true;
-        }
-        String sourceRealTimeTopicKafkaURL = sourceRealTimeTopicKafkaURLs.iterator().next();
-        try {
-          if (measureRTOffsetLagForSingleRegion(sourceRealTimeTopicKafkaURL, pcs, false) > offsetLagThreshold) {
-            return true;
-          }
-        } catch (Exception e) {
-          return true;
-        }
-      }
-    }
-    return false;
-  }
-
-  @Override
   protected void reportIfCatchUpVersionTopicOffset(PartitionConsumptionState pcs) {
     int partition = pcs.getPartition();
 

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
@@ -1095,10 +1095,6 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
     return isLagAcceptable;
   }
 
-  public boolean isReadyToServeAnnouncedWithRTLag() {
-    return false;
-  }
-
   IngestionNotificationDispatcher getIngestionNotificationDispatcher() {
     return ingestionNotificationDispatcher;
   }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/IngestionStats.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/IngestionStats.java
@@ -44,7 +44,6 @@ public class IngestionStats {
   protected static final String TIMESTAMP_REGRESSION_DCR_ERROR = "timestamp_regression_dcr_error";
   protected static final String OFFSET_REGRESSION_DCR_ERROR = "offset_regression_dcr_error";
   protected static final String TOMBSTONE_CREATION_DCR = "tombstone_creation_dcr";
-  protected static final String READY_TO_SERVE_WITH_RT_LAG_METRIC_NAME = "ready_to_serve_with_rt_lag";
   public static final String NEARLINE_PRODUCER_TO_LOCAL_BROKER_LATENCY = "nearline_producer_to_local_broker_latency";
   public static final String NEARLINE_LOCAL_BROKER_TO_READY_TO_SERVE_LATENCY =
       "nearline_local_broker_to_ready_to_serve_latency";
@@ -230,16 +229,6 @@ public class IngestionStats {
       return INACTIVE_STORE_INGESTION_TASK.code;
     }
     return ingestionTask.getWriteComputeErrorCode();
-  }
-
-  public double getReadyToServeWithRTLag() {
-    if (!hasActiveIngestionTask()) {
-      return 0;
-    }
-    if (ingestionTask.isReadyToServeAnnouncedWithRTLag()) {
-      return 1;
-    }
-    return 0;
   }
 
   public double getSubscribePrepLatencyAvg() {

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/IngestionStatsReporter.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/IngestionStatsReporter.java
@@ -22,7 +22,6 @@ import static com.linkedin.davinci.stats.IngestionStats.NEARLINE_LOCAL_BROKER_TO
 import static com.linkedin.davinci.stats.IngestionStats.NEARLINE_PRODUCER_TO_LOCAL_BROKER_LATENCY;
 import static com.linkedin.davinci.stats.IngestionStats.OFFSET_REGRESSION_DCR_ERROR;
 import static com.linkedin.davinci.stats.IngestionStats.PRODUCER_CALLBACK_LATENCY;
-import static com.linkedin.davinci.stats.IngestionStats.READY_TO_SERVE_WITH_RT_LAG_METRIC_NAME;
 import static com.linkedin.davinci.stats.IngestionStats.RECORDS_CONSUMED_METRIC_NAME;
 import static com.linkedin.davinci.stats.IngestionStats.STORAGE_QUOTA_USED;
 import static com.linkedin.davinci.stats.IngestionStats.SUBSCRIBE_ACTION_PREP_LATENCY;
@@ -232,13 +231,6 @@ public class IngestionStatsReporter extends AbstractVeniceStatsReporter<Ingestio
   // Only register these stats if the store is hybrid.
   @Override
   protected void registerConditionalStats() {
-    registerSensor(
-        new IngestionStatsGauge(
-            this,
-            () -> getStats().getReadyToServeWithRTLag(),
-            0,
-            READY_TO_SERVE_WITH_RT_LAG_METRIC_NAME));
-
     if (!VeniceSystemStoreUtils.isSystemStore(storeName)) {
       registerSensor(
           new IngestionStatsGauge(

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/ActiveActiveStoreIngestionTaskTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/ActiveActiveStoreIngestionTaskTest.java
@@ -1,8 +1,5 @@
 package com.linkedin.davinci.kafka.consumer;
 
-import static com.linkedin.venice.ConfigKeys.CLUSTER_NAME;
-import static com.linkedin.venice.ConfigKeys.KAFKA_BOOTSTRAP_SERVERS;
-import static com.linkedin.venice.ConfigKeys.ZOOKEEPER_ADDRESS;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyDouble;
@@ -25,18 +22,12 @@ import static org.testng.Assert.expectThrows;
 
 import com.github.luben.zstd.Zstd;
 import com.linkedin.davinci.config.VeniceServerConfig;
-import com.linkedin.davinci.config.VeniceStoreVersionConfig;
-import com.linkedin.davinci.ingestion.utils.IngestionTaskReusableObjects;
-import com.linkedin.davinci.stats.AggHostLevelIngestionStats;
 import com.linkedin.davinci.stats.AggVersionedDIVStats;
 import com.linkedin.davinci.stats.AggVersionedIngestionStats;
 import com.linkedin.davinci.stats.HostLevelIngestionStats;
-import com.linkedin.davinci.storage.StorageEngineRepository;
-import com.linkedin.davinci.storage.StorageService;
 import com.linkedin.davinci.storage.chunking.ChunkedValueManifestContainer;
 import com.linkedin.davinci.storage.chunking.ChunkingUtils;
 import com.linkedin.davinci.store.StorageEngine;
-import com.linkedin.davinci.store.blackhole.BlackHoleStorageEngine;
 import com.linkedin.davinci.store.record.ByteBufferValueRecord;
 import com.linkedin.venice.compression.CompressionStrategy;
 import com.linkedin.venice.compression.CompressorFactory;
@@ -54,22 +45,9 @@ import com.linkedin.venice.kafka.protocol.Put;
 import com.linkedin.venice.kafka.protocol.enums.ControlMessageType;
 import com.linkedin.venice.kafka.protocol.enums.MessageType;
 import com.linkedin.venice.message.KafkaKey;
-import com.linkedin.venice.meta.BufferReplayPolicy;
-import com.linkedin.venice.meta.HybridStoreConfig;
-import com.linkedin.venice.meta.HybridStoreConfigImpl;
-import com.linkedin.venice.meta.OfflinePushStrategy;
-import com.linkedin.venice.meta.PersistenceType;
 import com.linkedin.venice.meta.ReadOnlySchemaRepository;
-import com.linkedin.venice.meta.ReadOnlyStoreRepository;
-import com.linkedin.venice.meta.ReadStrategy;
-import com.linkedin.venice.meta.RoutingStrategy;
-import com.linkedin.venice.meta.Store;
-import com.linkedin.venice.meta.Version;
-import com.linkedin.venice.meta.VersionImpl;
-import com.linkedin.venice.meta.ZKStore;
 import com.linkedin.venice.partitioner.DefaultVenicePartitioner;
 import com.linkedin.venice.pubsub.ImmutablePubSubMessage;
-import com.linkedin.venice.pubsub.PubSubContext;
 import com.linkedin.venice.pubsub.PubSubTopicPartitionImpl;
 import com.linkedin.venice.pubsub.PubSubTopicRepository;
 import com.linkedin.venice.pubsub.adapter.kafka.common.ApacheKafkaOffsetPosition;
@@ -88,7 +66,6 @@ import com.linkedin.venice.storage.protocol.ChunkedKeySuffix;
 import com.linkedin.venice.storage.protocol.ChunkedValueManifest;
 import com.linkedin.venice.utils.ByteUtils;
 import com.linkedin.venice.utils.DataProviderUtils;
-import com.linkedin.venice.utils.ReferenceCounted;
 import com.linkedin.venice.utils.SystemTime;
 import com.linkedin.venice.utils.VeniceProperties;
 import com.linkedin.venice.utils.concurrent.VeniceConcurrentHashMap;
@@ -98,7 +75,6 @@ import com.linkedin.venice.writer.VeniceWriterOptions;
 import it.unimi.dsi.fastutil.ints.Int2ObjectArrayMap;
 import it.unimi.dsi.fastutil.ints.Int2ObjectMap;
 import it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap;
-import it.unimi.dsi.fastutil.objects.Object2IntArrayMap;
 import it.unimi.dsi.fastutil.objects.Object2IntMap;
 import it.unimi.dsi.fastutil.objects.Object2IntMaps;
 import java.io.IOException;
@@ -107,8 +83,6 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Map;
 import java.util.Objects;
-import java.util.Optional;
-import java.util.Properties;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Future;
 import java.util.concurrent.atomic.AtomicLong;
@@ -200,96 +174,6 @@ public class ActiveActiveStoreIngestionTaskTest {
     byte[] resultByteArray = new byte[result.remaining()];
     result.get(resultByteArray);
     Assert.assertEquals("Hello World", new String(resultByteArray));
-  }
-
-  @Test(dataProviderClass = DataProviderUtils.class, dataProvider = "ingestionTaskReusableObjectsStrategy")
-  public void testisReadyToServeAnnouncedWithRTLag(IngestionTaskReusableObjects.Strategy itroStrategy) {
-    // Setup store/schema/storage repository
-    ReadOnlyStoreRepository readOnlyStoreRepository = mock(ReadOnlyStoreRepository.class);
-    ReadOnlySchemaRepository readOnlySchemaRepository = mock(ReadOnlySchemaRepository.class);
-    StorageEngineRepository storageEngineRepository = mock(StorageEngineRepository.class);
-    when(storageEngineRepository.getLocalStorageEngine(any())).thenReturn(new BlackHoleStorageEngine(STORE_NAME));
-
-    // Setup server config
-    VeniceServerConfig serverConfig = mock(VeniceServerConfig.class);
-    when(serverConfig.freezeIngestionIfReadyToServeOrLocalDataExists()).thenReturn(false);
-    when(serverConfig.getKafkaClusterUrlResolver()).thenReturn(null);
-    when(serverConfig.getKafkaClusterUrlToIdMap()).thenReturn(new Object2IntArrayMap<>());
-    when(serverConfig.getKafkaClusterIdToUrlMap()).thenReturn(new Int2ObjectArrayMap<>());
-    when(serverConfig.getConsumerPoolSizePerKafkaCluster()).thenReturn(1);
-
-    // Set up IngestionTask Builder
-    StoreIngestionTaskFactory.Builder builder = new StoreIngestionTaskFactory.Builder();
-    builder.setPubSubContext(new PubSubContext.Builder().setPubSubTopicRepository(TOPIC_REPOSITORY).build());
-    builder.setHostLevelIngestionStats(mock(AggHostLevelIngestionStats.class));
-    builder.setAggKafkaConsumerService(mock(AggKafkaConsumerService.class));
-    builder.setMetadataRepository(readOnlyStoreRepository);
-    builder.setServerConfig(serverConfig);
-    builder.setSchemaRepository(readOnlySchemaRepository);
-    builder.setReusableObjectsSupplier(itroStrategy.supplier());
-
-    // Set up version config and store config
-    HybridStoreConfig hybridStoreConfig =
-        new HybridStoreConfigImpl(100L, 100L, 100L, BufferReplayPolicy.REWIND_FROM_EOP);
-
-    StorageService storageService = mock(StorageService.class);
-    doReturn(new ReferenceCounted<>(mock(StorageEngine.class), se -> {})).when(storageService)
-        .getRefCountedStorageEngine(anyString());
-
-    Store store = new ZKStore(
-        STORE_NAME,
-        "Felix",
-        100L,
-        PersistenceType.BLACK_HOLE,
-        RoutingStrategy.CONSISTENT_HASH,
-        ReadStrategy.ANY_OF_ONLINE,
-        OfflinePushStrategy.WAIT_ALL_REPLICAS,
-        1);
-    store.setHybridStoreConfig(hybridStoreConfig);
-    Version mockVersion = new VersionImpl(STORE_NAME, 1, PUSH_JOB_ID);
-    mockVersion.setHybridStoreConfig(hybridStoreConfig);
-    store.setVersions(Collections.singletonList(mockVersion));
-
-    Properties kafkaConsumerProperties = new Properties();
-    kafkaConsumerProperties.put(KAFKA_BOOTSTRAP_SERVERS, BOOTSTRAP_SERVER);
-    kafkaConsumerProperties.put(CLUSTER_NAME, TEST_CLUSTER_NAME);
-    kafkaConsumerProperties.put(ZOOKEEPER_ADDRESS, BOOTSTRAP_SERVER);
-    VeniceStoreVersionConfig storeVersionConfig =
-        new VeniceStoreVersionConfig(STORE_NAME + "_v1", new VeniceProperties(kafkaConsumerProperties));
-    int port = 123;
-    ActiveActiveStoreIngestionTask ingestionTask = new ActiveActiveStoreIngestionTask(
-        storageService,
-        builder,
-        store,
-        mockVersion,
-        kafkaConsumerProperties,
-        () -> true,
-        storeVersionConfig,
-        1,
-        false,
-        Optional.empty(),
-        null,
-        null);
-
-    PartitionConsumptionState badPartitionConsumptionState = mock(PartitionConsumptionState.class);
-    when(badPartitionConsumptionState.hasLagCaughtUp()).thenReturn(true);
-    // short circuit isReadyToServe
-    when(badPartitionConsumptionState.isEndOfPushReceived()).thenReturn(false);
-    ingestionTask.addPartitionConsumptionState(1, badPartitionConsumptionState);
-
-    Assert.assertTrue(ingestionTask.isReadyToServeAnnouncedWithRTLag());
-
-    PartitionConsumptionState goodPartitionConsumptionState = mock(PartitionConsumptionState.class);
-    when(goodPartitionConsumptionState.hasLagCaughtUp()).thenReturn(true);
-    when(goodPartitionConsumptionState.isEndOfPushReceived()).thenReturn(true);
-    when(goodPartitionConsumptionState.isWaitingForReplicationLag()).thenReturn(false);
-    ingestionTask.addPartitionConsumptionState(1, goodPartitionConsumptionState);
-
-    Assert.assertFalse(ingestionTask.isReadyToServeAnnouncedWithRTLag());
-
-    ingestionTask.addPartitionConsumptionState(2, badPartitionConsumptionState);
-
-    Assert.assertTrue(ingestionTask.isReadyToServeAnnouncedWithRTLag());
   }
 
   @Test


### PR DESCRIPTION
# [server] Remove ready_to_serve_with_rt_lag metric
This metric does not provide meaningful value and adds unnecessary clutter.  
Removing it simplifies metrics and reduces noise in monitoring.  

###  Code changes
- [ ] Added new code behind **a config**. If so list the config names and their default values in the PR description.
- [ ] Introduced new **log lines**. 
  - [ ] Confirmed if logs need to be **rate limited** to avoid excessive logging.

###  **Concurrency-Specific Checks**
Both reviewer and PR author to verify
- [ ] Code has **no race conditions** or **thread safety issues**.
- [ ] Proper **synchronization mechanisms** (e.g., `synchronized`, `RWLock`) are used where needed.
- [ ] No **blocking calls** inside critical sections that could lead to deadlocks or performance degradation.
- [ ] Verified **thread-safe collections** are used (e.g., `ConcurrentHashMap`, `CopyOnWriteArrayList`).
- [ ] Validated proper exception handling in multi-threaded code to avoid silent thread termination.


## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->

- [ ] New unit tests added.
- [ ] New integration tests added.
- [ ] Modified or extended existing tests.
- [ ] Verified backward compatibility (if applicable).

## Does this PR introduce any user-facing or breaking changes?
<!--  
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [ ] No. You can skip the rest of this section.
- [ ] Yes. Clearly explain the behavior change and its impact.