### PR TITLE
[server][dvc] Support blob transfer using temporary staging and restore cleanup

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/blobtransfer/BlobTransferPayload.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/blobtransfer/BlobTransferPayload.java
@@ -2,6 +2,7 @@ package com.linkedin.davinci.blobtransfer;
 
 import static com.linkedin.venice.store.rocksdb.RocksDBUtils.composePartitionDbDir;
 import static com.linkedin.venice.store.rocksdb.RocksDBUtils.composeSnapshotDir;
+import static com.linkedin.venice.store.rocksdb.RocksDBUtils.composeTempPartitionDir;
 
 import com.linkedin.davinci.blobtransfer.BlobTransferUtils.BlobTransferTableFormat;
 import com.linkedin.venice.utils.Utils;
@@ -13,7 +14,9 @@ import com.linkedin.venice.utils.Utils;
 public class BlobTransferPayload {
   private final int partition;
   private final String topicName;
+  private final String baseDir;
   private final String partitionDir;
+  private final String tempPartitionDir;
   private final String storeName;
   private final BlobTransferTableFormat requestTableFormat;
 
@@ -23,15 +26,25 @@ public class BlobTransferPayload {
       int version,
       int partition,
       BlobTransferTableFormat requestTableFormat) {
+    this.baseDir = baseDir;
     this.partition = partition;
     this.storeName = storeName;
     this.topicName = storeName + "_v" + version;
     this.partitionDir = composePartitionDbDir(baseDir, topicName, partition);
+    this.tempPartitionDir = composeTempPartitionDir(baseDir, topicName, partition);
     this.requestTableFormat = requestTableFormat;
+  }
+
+  public String getBaseDir() {
+    return baseDir;
   }
 
   public String getPartitionDir() {
     return partitionDir;
+  }
+
+  public String getTempPartitionDir() {
+    return tempPartitionDir;
   }
 
   public String getSnapshotDir() {

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/blobtransfer/NettyP2PBlobTransferManager.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/blobtransfer/NettyP2PBlobTransferManager.java
@@ -209,7 +209,7 @@ public class NettyP2PBlobTransferManager implements P2PBlobTransferManager<Void>
     } else {
       // error case 5: other exceptions (InterruptedException, ExecutionException, TimeoutException) that are not
       // expected, move to the next possible host
-      RocksDBUtils.deletePartitionDir(baseDir, storeName, version, partition);
+      RocksDBUtils.cleanupBothPartitionDirAndTempTransferredDir(storeName, version, partition, baseDir);
       LOGGER.error(FAILED_TO_FETCH_BLOB_MSG, replicaId, chosenHost, ex.getMessage());
     }
   }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/blobtransfer/client/P2PFileTransferClientHandler.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/blobtransfer/client/P2PFileTransferClientHandler.java
@@ -7,6 +7,7 @@ import com.linkedin.davinci.blobtransfer.BlobTransferPayload;
 import com.linkedin.davinci.blobtransfer.BlobTransferUtils;
 import com.linkedin.venice.exceptions.VeniceBlobTransferFileNotFoundException;
 import com.linkedin.venice.exceptions.VeniceException;
+import com.linkedin.venice.store.rocksdb.RocksDBUtils;
 import com.linkedin.venice.utils.Utils;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufInputStream;
@@ -108,19 +109,19 @@ public class P2PFileTransferClientHandler extends SimpleChannelInboundHandler<Ht
           Utils.getReplicaId(payload.getTopicName(), payload.getPartition()));
       this.fileContentLength = Long.parseLong(response.headers().get(HttpHeaderNames.CONTENT_LENGTH));
 
-      // Create the directory
-      Path partitionDir = Paths.get(payload.getPartitionDir());
-      Files.createDirectories(partitionDir);
+      // Create a temp directory
+      Path tempPartitionDir = Paths.get(payload.getTempPartitionDir());
+      Files.createDirectories(tempPartitionDir);
 
       // Prepare the file, remove it if it exists
-      if (Files.deleteIfExists(partitionDir.resolve(fileName))) {
+      if (Files.deleteIfExists(tempPartitionDir.resolve(fileName))) {
         LOGGER.warn(
             "File {} already exists for {}. Overwriting it.",
             fileName,
             Utils.getReplicaId(payload.getTopicName(), payload.getPartition()));
       }
 
-      this.file = Files.createFile(partitionDir.resolve(fileName));
+      this.file = Files.createFile(tempPartitionDir.resolve(fileName));
 
       outputFileChannel = FileChannel.open(file, StandardOpenOption.WRITE, StandardOpenOption.APPEND);
 
@@ -176,6 +177,16 @@ public class P2PFileTransferClientHandler extends SimpleChannelInboundHandler<Ht
                   + receivedFileChecksum);
         }
 
+        // One file transfer completed, reset the state for the next file transfer
+        try {
+          outputFileChannel.close();
+        } catch (Exception e) {
+          LOGGER.warn(
+              "Failed to close file channel for file {} for replica {} : {}",
+              fileName,
+              Utils.getReplicaId(payload.getTopicName(), payload.getPartition()),
+              e.getMessage());
+        }
         resetState();
       }
     } else {
@@ -199,11 +210,6 @@ public class P2PFileTransferClientHandler extends SimpleChannelInboundHandler<Ht
   @Override
   public void channelInactive(ChannelHandlerContext ctx) throws Exception {
     super.channelInactive(ctx);
-    if (outputFileChannel != null) {
-      outputFileChannel.force(true);
-      outputFileChannel.close();
-    }
-    resetState();
     fastFailoverIncompleteTransfer(
         "Channel close before completing transfer, might due to server graceful shutdown.",
         ctx);
@@ -240,11 +246,14 @@ public class P2PFileTransferClientHandler extends SimpleChannelInboundHandler<Ht
 
   @Override
   public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
-    LOGGER.error(
-        "Exception caught in when receiving files for {} with cause {}",
-        Utils.getReplicaId(payload.getTopicName(), payload.getPartition()),
-        cause);
-    inputStreamFuture.toCompletableFuture().completeExceptionally(cause);
+    if (!inputStreamFuture.toCompletableFuture().isDone()) {
+      LOGGER.error(
+          "Exception caught in when receiving files for {} with cause {}",
+          Utils.getReplicaId(payload.getTopicName(), payload.getPartition()),
+          cause);
+      cleanupResources();
+      inputStreamFuture.toCompletableFuture().completeExceptionally(cause);
+    }
     ctx.close();
   }
 
@@ -261,16 +270,65 @@ public class P2PFileTransferClientHandler extends SimpleChannelInboundHandler<Ht
 
   private void handleEndOfTransfer(ChannelHandlerContext ctx) {
     LOGGER.info("All files received successfully for {}", payload.getFullResourceName());
-    // In the short term, we decided to let the netty client handle writing files to the disk, so
-    // the future completes with a null. It's subject to change.
-    inputStreamFuture.toCompletableFuture().complete(null);
-    ctx.close();
+
+    try {
+      RocksDBUtils.renameTempTransferredPartitionDirToPartitionDir(
+          payload.getBaseDir(),
+          payload.getTopicName(),
+          payload.getPartition());
+      LOGGER.info(
+          "Renamed temp partition dir to partition dir for {}",
+          Utils.getReplicaId(payload.getTopicName(), payload.getPartition()));
+      inputStreamFuture.toCompletableFuture().complete(null);
+    } catch (Exception e) {
+      LOGGER.error(
+          "Failed to rename temp partition dir to partition dir for {}. Even all the files are received, "
+              + "the transfer future will be completed exceptionally. ",
+          Utils.getReplicaId(payload.getTopicName(), payload.getPartition()),
+          e);
+      // Even the NettyP2PBlobTransferManager#handlePeerFetchException will do dir cleanup for all done with exception
+      // case per host,
+      // but we still immediate cleanup on rename failure
+      cleanupTempDirectoryOnRenameFail();
+      // Complete future exceptionally
+      inputStreamFuture.toCompletableFuture().completeExceptionally(e);
+    } finally {
+      ctx.close();
+    }
+  }
+
+  private void cleanupResources() {
+    String replicaId = Utils.getReplicaId(payload.getTopicName(), payload.getPartition());
+
+    // 1. Close file channel safely by ensuring data is flushed to disk.
+    if (outputFileChannel != null) {
+      try {
+        outputFileChannel.force(true);
+        outputFileChannel.close();
+      } catch (Exception e) {
+        LOGGER.warn("Failed to close file channel for {}: {}", replicaId, e.getMessage());
+      }
+    }
+    // 2. clean up partial transferred file if exists,
+    // because file will be reset if one cycle of file transfer is completed successfully,
+    // then if file != null means the transfer is incomplete.
+    if (file != null) {
+      try {
+        Files.delete(file);
+      } catch (Exception e) {
+        LOGGER.warn("Failed to cleanup partial file {} for {}: {}", file.getFileName(), replicaId, e.getMessage());
+      }
+    }
+    // 3. reset states only
+    resetState();
   }
 
   private void resetState() {
     outputFileChannel = null;
     fileName = null;
     fileContentLength = 0;
+    file = null;
+    fileChecksum = null;
   }
 
   private void fastFailoverIncompleteTransfer(String causeForFailPendingTransfer, ChannelHandlerContext ctx) {
@@ -283,7 +341,27 @@ public class P2PFileTransferClientHandler extends SimpleChannelInboundHandler<Ht
           ctx.channel().isActive());
 
       LOGGER.error(errorMessage);
+      cleanupResources();
       inputStreamFuture.toCompletableFuture().completeExceptionally(new VeniceException(errorMessage));
+    }
+  }
+
+  private void cleanupTempDirectoryOnRenameFail() {
+    try {
+      String tempPartitionDir = payload.getTempPartitionDir();
+      Path tempDir = Paths.get(tempPartitionDir);
+
+      if (Files.exists(tempDir)) {
+        RocksDBUtils.deleteDirectory(tempPartitionDir);
+        LOGGER.info(
+            "Cleaned up temp directory after rename failure for {}",
+            Utils.getReplicaId(payload.getTopicName(), payload.getPartition()));
+      }
+    } catch (Exception cleanupEx) {
+      LOGGER.error(
+          "Failed to cleanup temp directory after rename failure for {}: {}",
+          Utils.getReplicaId(payload.getTopicName(), payload.getPartition()),
+          cleanupEx.getMessage());
     }
   }
 }

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/blobtransfer/TestP2PFileTransferClientHandler.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/blobtransfer/TestP2PFileTransferClientHandler.java
@@ -231,6 +231,10 @@ public class TestP2PFileTransferClientHandler {
     Path file1 = dest.resolve("test_file.txt");
     Assert.assertTrue(Files.exists(file1));
     Assert.assertEquals(Files.size(file1), 5);
+
+    // Verify the temp directory is cleaned up
+    Path tempDir = Paths.get(payload.getTempPartitionDir());
+    Assert.assertFalse(Files.exists(tempDir), "Temporary directory should be cleaned up after transfer.");
   }
 
   @Test
@@ -420,6 +424,10 @@ public class TestP2PFileTransferClientHandler {
     Assert.assertEquals(actualMetadata.getTopicName(), expectMetadata.getTopicName());
     Assert.assertEquals(actualMetadata.getPartitionId(), expectMetadata.getPartitionId());
     Assert.assertEquals(actualMetadata.getOffsetRecord(), expectMetadata.getOffsetRecord());
+
+    // Verify the temp directory is cleaned up
+    Path tempDir = Paths.get(payload.getTempPartitionDir());
+    Assert.assertFalse(Files.exists(tempDir), "Temporary directory should be cleaned up after transfer.");
 
     // Ensure the future is completed
     Assert.assertTrue(inputStreamFuture.toCompletableFuture().isDone());

--- a/internal/venice-common/src/main/java/com/linkedin/venice/store/rocksdb/RocksDBUtils.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/store/rocksdb/RocksDBUtils.java
@@ -1,11 +1,17 @@
 package com.linkedin.venice.store.rocksdb;
 
 import com.linkedin.venice.exceptions.VeniceException;
+import com.linkedin.venice.meta.Version;
+import com.linkedin.venice.utils.Utils;
 import java.io.File;
+import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.nio.file.StandardCopyOption;
 import java.util.Comparator;
+import java.util.stream.Stream;
 
 
 public class RocksDBUtils {
@@ -23,6 +29,7 @@ public class RocksDBUtils {
   private static final String TEMP_SST_FILE_PREFIX = "sst_file_";
   private static final String TEMP_RMD_SST_FILE_PREFIX = "sst_rmd_file_";
   private static final String TEMP_SNAPSHOT_DIR = ".snapshot_files";
+  private static final String TEMP_TRANSFERRED_PARTITION_DIR_PREFIX = "temp_transferred_";
 
   public static String getPartitionDbName(String storeName, int partitionId) {
     return String.format(PARTITION_DB_NAME, storeName, partitionId);
@@ -51,6 +58,16 @@ public class RocksDBUtils {
   // ex. /db/directory/myStore_v3/myStore_v3_3/
   public static String composePartitionDbDir(String dbDir, String topicName, int partitionId) {
     return dbDir + File.separator + topicName + File.separator + getPartitionDbName(topicName, partitionId);
+  }
+
+  // ex. /db/directory/myStore_v3/temp_transferred_myStore_v3_3/
+  public static String composeTempPartitionDir(String dbDir, String topicName, int partitionId) {
+    return dbDir + File.separator + topicName + File.separator + TEMP_TRANSFERRED_PARTITION_DIR_PREFIX
+        + getPartitionDbName(topicName, partitionId);
+  }
+
+  public static boolean isTempPartitionDir(String partitionDir) {
+    return partitionDir.contains(TEMP_TRANSFERRED_PARTITION_DIR_PREFIX);
   }
 
   // ex. /db/directory/storeName_v3/storeName_v3_3/.snapshot_files
@@ -101,25 +118,117 @@ public class RocksDBUtils {
   }
 
   /**
-   * Deletes the files associated with the specified store, version, and partition.
+   * Deletes the files associated with the specified partition directory.
    *
-   * @param storeName the name of the store
-   * @param version the version number of the store
-   * @param partition the partition ID
    */
-  public static void deletePartitionDir(String baseDir, String storeName, int version, int partition) {
-    String topicName = storeName + "_v" + version;
-    String partitionDir = composePartitionDbDir(baseDir, topicName, partition);
-
-    Path path = null;
-    try {
-      path = Paths.get(partitionDir);
-      if (Files.exists(path)) {
-        Files.walk(path).sorted(Comparator.reverseOrder()).map(Path::toFile).forEach(File::delete);
-      }
+  public static void deleteDirectory(String directoryPathStr) {
+    Path path = Paths.get(directoryPathStr);
+    if (!Files.exists(path)) {
+      return;
+    }
+    try (Stream<Path> walk = Files.walk(path)) {
+      // Sort the paths in reverse order so files are deleted before their parent directories
+      walk.sorted(Comparator.reverseOrder()).forEach(p -> {
+        try {
+          Files.delete(p);
+        } catch (IOException e) {
+          throw new UncheckedIOException(e);
+        }
+      });
     } catch (Exception e) {
       throw new VeniceException(
-          String.format("Error occurred while deleting blobs at path: %s. %s ", path, e.getMessage()));
+          String.format("Error occurred while deleting directory: %s. %s", path, e.getMessage()),
+          e);
+    }
+  }
+
+  /**
+   * Rename the temporary transferred partition directory to the final partition directory.
+   * example of temp partition dir: /db/directory/myStore_v3/temp_transferred_myStore_v3_3/
+   * example of final partition dir: /db/directory/myStore_v3/myStore_v3_3/
+   *
+   *
+   * @param dbDir the base directory where the partition directories are located
+   * @param topicName the topic name
+   * @param partitionId the partition id
+   */
+  public static void renameTempTransferredPartitionDirToPartitionDir(String dbDir, String topicName, int partitionId) {
+    String tempPartitionPathStr = composeTempPartitionDir(dbDir, topicName, partitionId);
+    String partitionPathStr = composePartitionDbDir(dbDir, topicName, partitionId);
+
+    Path tempPartitionDir = Paths.get(tempPartitionPathStr);
+    Path finalPartitionDir = Paths.get(partitionPathStr);
+
+    // If the partition folder already exists and is not empty, we should not rename the temp folder to it.
+    if (Files.exists(finalPartitionDir) && Files.isDirectory(finalPartitionDir)
+        && finalPartitionDir.toFile().list().length > 0) {
+      throw new VeniceException(
+          "Final partition directory is not empty: " + finalPartitionDir + ", cannot rename temp directory: "
+              + tempPartitionDir);
+    }
+
+    if (Files.exists(tempPartitionDir)) {
+      try {
+        Files.move(tempPartitionDir, finalPartitionDir, StandardCopyOption.REPLACE_EXISTING);
+      } catch (Exception e) {
+        deleteDirectory(tempPartitionPathStr);
+        throw new VeniceException("Failed to move temp directory to final directory: " + tempPartitionDir, e);
+      }
+    }
+  }
+
+  /**
+   * Cleans up both the partition directory and the temporary transferred directory for a given store, version, and partition.
+   * temp directory example: /db/directory/myStore_v3/temp_transferred_myStore_v3_3/
+   * partition directory example: /db/directory/myStore_v3/myStore_v3_3/
+   * @param storeName
+   * @param versionNumber
+   * @param partitionId
+   * @param basePath
+   */
+  public static void cleanupBothPartitionDirAndTempTransferredDir(
+      String storeName,
+      int versionNumber,
+      int partitionId,
+      String basePath) {
+    String kafkaTopic = Version.composeKafkaTopic(storeName, versionNumber);
+    String partitionDir = RocksDBUtils.composePartitionDbDir(basePath, kafkaTopic, partitionId);
+    String tempPartitionDir = RocksDBUtils.composeTempPartitionDir(basePath, kafkaTopic, partitionId);
+
+    // Clean partition directory
+    File partitionDirFile = new File(partitionDir);
+    if (partitionDirFile.exists()) {
+      try {
+        RocksDBUtils.deleteDirectory(partitionDir);
+      } catch (Exception e) {
+        throw new VeniceException("Cannot clean up partition directory ", e);
+      }
+    }
+
+    // Clean temp directory
+    File tempPartitionDirFile = new File(tempPartitionDir);
+    if (tempPartitionDirFile.exists()) {
+      try {
+        RocksDBUtils.deleteDirectory(tempPartitionDir);
+      } catch (Exception e) {
+        throw new VeniceException("Cannot clean up temp directory ", e);
+      }
+    }
+
+    if (partitionDirFile.exists()) {
+      throw new VeniceException(
+          String.format(
+              "Partition directory %s still exists after cleanup for %s",
+              partitionDir,
+              Utils.getReplicaId(kafkaTopic, partitionId)));
+    }
+
+    if (tempPartitionDirFile.exists()) {
+      throw new VeniceException(
+          String.format(
+              "Temp partition directory %s still exists after cleanup for %s",
+              tempPartitionDir,
+              Utils.getReplicaId(kafkaTopic, partitionId)));
     }
   }
 }

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/DaVinciClientP2PBlobTransferTest.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/DaVinciClientP2PBlobTransferTest.java
@@ -528,6 +528,150 @@ public class DaVinciClientP2PBlobTransferTest {
     }
   }
 
+  @Test
+  public void testBlobP2PinDVCWithRestoreTempFolderSuccessfully() throws Exception {
+    String dvcPath1 = Utils.getTempDataDirectory().getAbsolutePath();
+    String zkHosts = cluster.getZk().getAddress();
+    int port1 = TestUtils.getFreePort();
+    int port2 = TestUtils.getFreePort();
+    while (port1 == port2) {
+      port2 = TestUtils.getFreePort();
+    }
+    Consumer<UpdateStoreQueryParams> paramsConsumer = params -> params.setBlobTransferEnabled(true);
+    String storeName = Utils.getUniqueString("test-store");
+    setUpStore(storeName, paramsConsumer, properties -> {}, true);
+
+    // Start the first DaVinci Client using DaVinciUserApp
+    File configDir = Utils.getTempDataDirectory();
+    File configFile = new File(configDir, "dvc-config.properties");
+    Properties props = new Properties();
+    props.setProperty("zk.hosts", zkHosts);
+    props.setProperty("base.data.path", dvcPath1);
+    props.setProperty("store.name", storeName);
+    props.setProperty("sleep.seconds", "100");
+    props.setProperty("heartbeat.timeout.seconds", "10");
+    props.setProperty("ingestion.isolation", "false");
+    props.setProperty("blob.transfer.server.port", Integer.toString(port1));
+    props.setProperty("blob.transfer.client.port", Integer.toString(port2));
+    props.setProperty("storage.class", StorageClass.DISK.toString());
+    props.setProperty("record.transformer.enabled", "false");
+    props.setProperty("blob.transfer.manager.enabled", "true");
+    props.setProperty("batch.push.report.enabled", "false");
+
+    // Write properties to file
+    try (FileWriter writer = new FileWriter(configFile)) {
+      props.store(writer, null);
+    }
+
+    ForkedJavaProcess.exec(DaVinciUserApp.class, configFile.getAbsolutePath());
+
+    // Wait for the first DaVinci Client to complete ingestion
+    Thread.sleep(60000);
+
+    // Start the second DaVinci Client using settings for blob transfer
+    String dvcPath2 = Utils.getTempDataDirectory().getAbsolutePath();
+
+    PropertyBuilder configBuilder = new PropertyBuilder().put(PERSISTENCE_TYPE, ROCKS_DB)
+        .put(ROCKSDB_PLAIN_TABLE_FORMAT_ENABLED, "false")
+        .put(SERVER_DATABASE_CHECKSUM_VERIFICATION_ENABLED, "true")
+        .put(SERVER_DATABASE_SYNC_BYTES_INTERNAL_FOR_DEFERRED_WRITE_MODE, "3000")
+        .put(CLIENT_USE_SYSTEM_STORE_REPOSITORY, true)
+        .put(CLIENT_SYSTEM_STORE_REPOSITORY_REFRESH_INTERVAL_SECONDS, 1)
+        .put(DATA_BASE_PATH, dvcPath2)
+        .put(DAVINCI_P2P_BLOB_TRANSFER_SERVER_PORT, port2)
+        .put(DAVINCI_P2P_BLOB_TRANSFER_CLIENT_PORT, port1)
+        .put(PUSH_STATUS_STORE_ENABLED, true)
+        .put(ROCKSDB_BLOCK_CACHE_SIZE_IN_BYTES, 2 * 1024 * 1024L)
+        .put(DAVINCI_PUSH_STATUS_SCAN_INTERVAL_IN_SECONDS, 1)
+        .put(BLOB_TRANSFER_MANAGER_ENABLED, true)
+        .put(BLOB_TRANSFER_SSL_ENABLED, true)
+        .put(BLOB_TRANSFER_ACL_ENABLED, true)
+        .put(BLOB_TRANSFER_DISABLED_OFFSET_LAG_THRESHOLD, -1000000)
+        .put(SSL_KEYSTORE_TYPE, "JKS")
+        .put(SSL_KEYSTORE_LOCATION, SslUtils.getPathForResource(LOCAL_KEYSTORE_JKS))
+        .put(SSL_KEYSTORE_PASSWORD, LOCAL_PASSWORD)
+        .put(SSL_TRUSTSTORE_TYPE, "JKS")
+        .put(SSL_TRUSTSTORE_LOCATION, SslUtils.getPathForResource(LOCAL_KEYSTORE_JKS))
+        .put(SSL_TRUSTSTORE_PASSWORD, LOCAL_PASSWORD)
+        .put(SSL_KEY_PASSWORD, LOCAL_PASSWORD)
+        .put(SSL_KEYMANAGER_ALGORITHM, "SunX509")
+        .put(SSL_TRUSTMANAGER_ALGORITHM, "SunX509")
+        .put(SSL_SECURE_RANDOM_IMPLEMENTATION, "SHA1PRNG")
+        .put(DAVINCI_PUSH_STATUS_CHECK_INTERVAL_IN_MS, "10");
+
+    VeniceProperties backendConfig2 = configBuilder.build();
+    DaVinciConfig dvcConfig = new DaVinciConfig().setIsolated(true);
+
+    try (CachingDaVinciClientFactory factory2 = getCachingDaVinciClientFactory(
+        d2Client,
+        VeniceRouterWrapper.CLUSTER_DISCOVERY_D2_SERVICE_NAME,
+        new MetricsRepository(),
+        backendConfig2,
+        cluster)) {
+      // Case 1: Start a fresh client, and see if it can bootstrap from the first one
+      DaVinciClient<Integer, Object> client2 = factory2.getAndStartGenericAvroClient(storeName, dvcConfig);
+      client2.subscribeAll().get();
+
+      // verify that the DVC 1 is started.
+      for (int i = 0; i < 3; i++) {
+        String partitionPath = RocksDBUtils.composePartitionDbDir(dvcPath1 + "/rocksdb", storeName + "_v1", i);
+        Assert.assertTrue(Files.exists(Paths.get(partitionPath)));
+      }
+
+      // verify that the DVC 2 is also start and get files from DVC 1, DVC 1 should have snapshots folder
+      for (int i = 0; i < 3; i++) {
+        String partitionPath2 = RocksDBUtils.composePartitionDbDir(dvcPath2 + "/rocksdb", storeName + "_v1", i);
+        Assert.assertTrue(Files.exists(Paths.get(partitionPath2)));
+        String snapshotPath2 = RocksDBUtils.composeSnapshotDir(dvcPath2 + "/rocksdb", storeName + "_v1", i);
+        Assert.assertFalse(Files.exists(Paths.get(snapshotPath2)));
+
+        // path 1 (dvc1) should have snapshot which they are transfer to path 2 (dvc2)
+        String snapshotPath1 = RocksDBUtils.composeSnapshotDir(dvcPath1 + "/rocksdb", storeName + "_v1", i);
+        Assert.assertTrue(Files.exists(Paths.get(snapshotPath1)));
+      }
+      LOGGER.info("Completed verification for case 1.");
+
+      // Case 2: Restart the second Da Vinci client to see if it can re-bootstrap from the first one with retained old
+      // temp folder data.
+      client2.close();
+      // wait and restart, and verify old data is retained before subscribing
+      Thread.sleep(3000);
+      // Close DVC2 to prepare the temp partition folders
+      // 1. Verify that the folder is not clean up.
+      for (int i = 0; i < 3; i++) {
+        String partitionPath2 = RocksDBUtils.composePartitionDbDir(dvcPath2 + "/rocksdb", storeName + "_v1", i);
+        Assert.assertTrue(Files.exists(Paths.get(partitionPath2)));
+        String snapshotPath2 = RocksDBUtils.composeSnapshotDir(dvcPath2 + "/rocksdb", storeName + "_v1", i);
+        Assert.assertFalse(Files.exists(Paths.get(snapshotPath2)));
+      }
+      // 2. relocate this partition folder to a temporary partition folder to mimic a scenario
+      // where the transferred temporary folder is not renamed to the final partition folder
+      // to verifying that the restore process will clean up the temporary folder
+      for (int i = 0; i < 3; i++) {
+        String partitionPath2 = RocksDBUtils.composePartitionDbDir(dvcPath2 + "/rocksdb", storeName + "_v1", i);
+        String tempPartitionPath2 = RocksDBUtils.composeTempPartitionDir(dvcPath2 + "/rocksdb", storeName + "_v1", i);
+        Files.move(Paths.get(partitionPath2), Paths.get(tempPartitionPath2));
+        Assert.assertTrue(Files.exists(Paths.get(tempPartitionPath2)));
+      }
+
+      client2.start();
+      client2.subscribeAll().get();
+      // Verification:
+      // 1. dvc2 have new partition folders, and do not have snapshot folder.
+      for (int i = 0; i < 3; i++) {
+        String partitionPath2 = RocksDBUtils.composePartitionDbDir(dvcPath2 + "/rocksdb", storeName + "_v1", i);
+        Assert.assertTrue(Files.exists(Paths.get(partitionPath2)));
+        String snapshotPath2 = RocksDBUtils.composeSnapshotDir(dvcPath2 + "/rocksdb", storeName + "_v1", i);
+        Assert.assertFalse(Files.exists(Paths.get(snapshotPath2)));
+      }
+      // 2. validate that the temporary partition folder is removed.
+      for (int i = 0; i < 3; i++) {
+        String tempPartitionPath2 = RocksDBUtils.composeTempPartitionDir(dvcPath2 + "/rocksdb", storeName + "_v1", i);
+        Assert.assertFalse(Files.exists(Paths.get(tempPartitionPath2)));
+      }
+    }
+  }
+
   /*
    * Batch data schema:
    * Key: Integer


### PR DESCRIPTION
<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat], [protocol]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## Problem Statement
In the existing blob transfer logic, the sender host sends files directly to the receiver host, which writes them into the partition folder path like`/db/directory/myStore_v0/myStore_v0_0/`. However, if the receiver host shuts down unexpectedly, partially transferred files may be left behind at the partition directory. During restore, the RocksDBStorageEngine will attempt to open this partition. Because folder contains incomplete files, this can result in a corrupted RocksDB instance.

## Solution
**1. Client Handler (Receiver Handler): Temporary Transfer Directory**
1. All incoming files are first written to a temporary folder: `/db/directory/myStore_v0/temp_transferred_myStore_v0_0/`
2. Only if received `EndOfTransfer`, `rename` this temp folder to partition folder for preventing the backend from using incomplete or corrupted data in partition folder. 

**2. RocksDBStorageEngine Restore: Cleanup Temporary Folders if Present**
1. During restore, RocksDB relies on getPersistedPartitionIds, which derives partition IDs from folder names.
2. If a subfolder contains temp_transferred, it indicates a partially transferred (and not properly cleaned up) folder. In this case, we perform cleanup by dropping that folder instead of attempting to restore it.

**3. Blob Transfer Reliability & Cleanup Enhancements**

Previously, blob transfer in the server reported many errors related to failed transfers. Logs showed successful cleanup, but in reality, some files were not properly deleted. To address this, we strengthened both cleanup and file validation logic:
1. P2PFileTransferClientHandler improvements:
(1) Ensure `outputFileChannel.close()` is called after each file transfer to avoid resource leaks. Previously, only `outputFileChannel = null` was set. 
 (2) Invoke `cleanupResources()` in `channelInactive`, `userEventTriggered`, or `exceptionCaught` if inputStreamFuture is not complete (indicating an error mid-transfer). In the successful case, explicit cleanup is not needed, since each completed transfer already closes the file channel and resets the state every time.
 (3) Remove the partially transferred file immediately if errors occur, even though the entire directory will be cleaned up later. This ensures problematic file is not left behind during intermediate states.

2. File integrity checks in bootstrapFromBlobs:
(1) Before blob transfer, verify that neither the partition folder nor the temp folder exists. 
(2) After blob transfer, verify that only the partition folder exists.




###  Code changes
- [ ] Added new code behind **a config**. If so list the config names and their default values in the PR description.
- [ ] Introduced new **log lines**. 
  - [ ] Confirmed if logs need to be **rate limited** to avoid excessive logging.

###  **Concurrency-Specific Checks**
Both reviewer and PR author to verify
- [ ] Code has **no race conditions** or **thread safety issues**.
- [ ] Proper **synchronization mechanisms** (e.g., `synchronized`, `RWLock`) are used where needed.
- [ ] No **blocking calls** inside critical sections that could lead to deadlocks or performance degradation.
- [ ] Verified **thread-safe collections** are used (e.g., `ConcurrentHashMap`, `CopyOnWriteArrayList`).
- [ ] Validated proper exception handling in multi-threaded code to avoid silent thread termination.


## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->

- [ ] New unit tests added.
- [ ] New integration tests added.
- [ ] Modified or extended existing tests.
- [ ] Verified backward compatibility (if applicable).

## Does this PR introduce any user-facing or breaking changes?
<!--  
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [ ] No. You can skip the rest of this section.
- [ ] Yes. Clearly explain the behavior change and its impact.