### PR TITLE
[client] Add Otel 'granularity_call_time' metrics for clients

### DIFF
--- a/clients/venice-thin-client/src/main/java/com/linkedin/venice/client/stats/ClientMetricEntity.java
+++ b/clients/venice-thin-client/src/main/java/com/linkedin/venice/client/stats/ClientMetricEntity.java
@@ -1,6 +1,7 @@
 package com.linkedin.venice.client.stats;
 
 import static com.linkedin.venice.stats.dimensions.VeniceMetricsDimensions.VENICE_MESSAGE_TYPE;
+import static com.linkedin.venice.stats.dimensions.VeniceMetricsDimensions.VENICE_REQUEST_GRANULARITY;
 import static com.linkedin.venice.stats.dimensions.VeniceMetricsDimensions.VENICE_REQUEST_METHOD;
 import static com.linkedin.venice.stats.dimensions.VeniceMetricsDimensions.VENICE_REQUEST_RETRY_TYPE;
 import static com.linkedin.venice.stats.dimensions.VeniceMetricsDimensions.VENICE_STORE_NAME;
@@ -29,6 +30,14 @@ public enum ClientMetricEntity implements ModuleMetricEntityInterface {
   RETRY_KEY_COUNT(
       MetricType.MIN_MAX_COUNT_SUM_AGGREGATIONS, MetricUnit.NUMBER, "Key count of retry requests for client",
       setOf(VENICE_STORE_NAME, VENICE_REQUEST_METHOD, VENICE_MESSAGE_TYPE)
+  ),
+
+  /**
+   *  Time taken for each granularity call.
+   */
+  GRANULARITY_CALL_TIME(
+      MetricType.MIN_MAX_COUNT_SUM_AGGREGATIONS, MetricUnit.MILLISECOND, "Time taken for each granularity call",
+      setOf(VENICE_STORE_NAME, VENICE_REQUEST_METHOD, VENICE_REQUEST_GRANULARITY, VENICE_MESSAGE_TYPE)
   );
 
   private final MetricEntity entity;

--- a/internal/venice-client-common/src/main/java/com/linkedin/venice/stats/dimensions/Granularity.java
+++ b/internal/venice-client-common/src/main/java/com/linkedin/venice/stats/dimensions/Granularity.java
@@ -1,0 +1,29 @@
+package com.linkedin.venice.stats.dimensions;
+
+import static com.linkedin.venice.stats.dimensions.VeniceMetricsDimensions.VENICE_REQUEST_GRANULARITY;
+
+
+public enum Granularity implements VeniceDimensionInterface {
+  SERIALIZATION, DESERIALIZATION, DECOMPRESSION, SUBMISSION_TO_RESPONSE, FIRST_RECORD, PCT_50_RECORD, PCT_90_RECORD,
+  PCT_95_RECORD, PCT_99_RECORD;
+
+  private final String type;
+
+  Granularity() {
+    this.type = name().toLowerCase();
+  }
+
+  /**
+   * All the instances of this Enum should have the same dimension name.
+   * Refer {@link VeniceDimensionInterface#getDimensionName()} for more details.
+   */
+  @Override
+  public VeniceMetricsDimensions getDimensionName() {
+    return VENICE_REQUEST_GRANULARITY;
+  }
+
+  @Override
+  public String getDimensionValue() {
+    return type;
+  }
+}

--- a/internal/venice-client-common/src/main/java/com/linkedin/venice/stats/dimensions/VeniceMetricsDimensions.java
+++ b/internal/venice-client-common/src/main/java/com/linkedin/venice/stats/dimensions/VeniceMetricsDimensions.java
@@ -30,6 +30,9 @@ public enum VeniceMetricsDimensions {
   /** {@link com.linkedin.venice.stats.dimensions.MessageType} */
   VENICE_MESSAGE_TYPE("venice.message.type"),
 
+  /** {@link com.linkedin.venice.stats.dimensions.Granularity} */
+  VENICE_REQUEST_GRANULARITY("venice.request.granularity"),
+
   /** {@link RequestRetryAbortReason} */
   VENICE_REQUEST_RETRY_ABORT_REASON("venice.request.retry_abort_reason"),
 

--- a/internal/venice-client-common/src/test/java/com/linkedin/venice/stats/dimensions/VeniceMetricsDimensionsTest.java
+++ b/internal/venice-client-common/src/test/java/com/linkedin/venice/stats/dimensions/VeniceMetricsDimensionsTest.java
@@ -43,6 +43,9 @@ public class VeniceMetricsDimensionsTest {
         case REPUSH_TRIGGER_SOURCE:
           assertEquals(dimension.getDimensionName(format), "repush.trigger.source");
           break;
+        case VENICE_REQUEST_GRANULARITY:
+          assertEquals(dimension.getDimensionName(format), "venice.request.granularity");
+          break;
         default:
           throw new IllegalArgumentException("Unknown dimension: " + dimension);
       }
@@ -84,6 +87,9 @@ public class VeniceMetricsDimensionsTest {
         case REPUSH_TRIGGER_SOURCE:
           assertEquals(dimension.getDimensionName(format), "repush.trigger.source");
           break;
+        case VENICE_REQUEST_GRANULARITY:
+          assertEquals(dimension.getDimensionName(format), "venice.request.granularity");
+          break;
         default:
           throw new IllegalArgumentException("Unknown dimension: " + dimension);
       }
@@ -124,6 +130,9 @@ public class VeniceMetricsDimensionsTest {
           break;
         case REPUSH_TRIGGER_SOURCE:
           assertEquals(dimension.getDimensionName(format), "Repush.Trigger.Source");
+          break;
+        case VENICE_REQUEST_GRANULARITY:
+          assertEquals(dimension.getDimensionName(format), "Venice.Request.Granularity");
           break;
         default:
           throw new IllegalArgumentException("Unknown dimension: " + dimension);


### PR DESCRIPTION
## Problem Statement

Add `granularity_call_time` in OTEL metrics.

## Solution

In this PR, we support the following tehuti metrics to `granularity_call_time` in OTEL. 

```
request_serialization_time
request_submission_to_response_handling_time
response_deserialization_time
response_decompression_time
response_ttfr
response_tt50pr
response_tt90pr
response_tt95pr
response_tt99pr
```

###  Code changes
- [ ] Added new code behind **a config**. If so list the config names and their default values in the PR description.
- [ ] Introduced new **log lines**. 
  - [ ] Confirmed if logs need to be **rate limited** to avoid excessive logging.

###  **Concurrency-Specific Checks**
Both reviewer and PR author to verify
- [ ] Code has **no race conditions** or **thread safety issues**.
- [ ] Proper **synchronization mechanisms** (e.g., `synchronized`, `RWLock`) are used where needed.
- [ ] No **blocking calls** inside critical sections that could lead to deadlocks or performance degradation.
- [ ] Verified **thread-safe collections** are used (e.g., `ConcurrentHashMap`, `CopyOnWriteArrayList`).
- [ ] Validated proper exception handling in multi-threaded code to avoid silent thread termination.


## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->

- [ ] New unit tests added.
- [ ] New integration tests added.
- [ ] Modified or extended existing tests.
- [ ] Verified backward compatibility (if applicable).

## Does this PR introduce any user-facing or breaking changes?
<!--  
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [ ] No. You can skip the rest of this section.
- [ ] Yes. Clearly explain the behavior change and its impact.