### PR TITLE
[Server] Add ingestion context logging when heartbeat lag happened.

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/AggKafkaConsumerService.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/AggKafkaConsumerService.java
@@ -531,4 +531,31 @@ public class AggKafkaConsumerService extends AbstractVeniceService {
     }
     return topicPartitionIngestionContextJsonSerializer.serialize(topicPartitionIngestionContext, "");
   }
+
+  public String getIngestionInfoFor(
+      PubSubTopic versionTopic,
+      PubSubTopicPartition pubSubTopicPartition,
+      String regionName) {
+    String kafkaUrl = getKafkaUrlFromRegionName(regionName);
+    if (kafkaUrl == null) {
+      return "kafkaUrl is not found for region: " + regionName;
+    }
+    AbstractKafkaConsumerService consumerService = getKafkaConsumerService(kafkaUrl);
+    if (consumerService == null) {
+      return "Kafka consumer service is not found for kafkaUrl: " + kafkaUrl + ", region: " + regionName;
+    }
+    Map<PubSubTopicPartition, TopicPartitionIngestionInfo> topicPartitionIngestionInfoMap =
+        consumerService.getIngestionInfoFor(versionTopic, pubSubTopicPartition);
+    return KafkaConsumerService.convertTopicPartitionIngestionInfoMapToStr(topicPartitionIngestionInfoMap);
+  }
+
+  private String getKafkaUrlFromRegionName(String regionName) {
+    for (Map.Entry<String, String> entry: kafkaClusterUrlToAliasMap.entrySet()) {
+      if (entry.getValue().equals(regionName)) {
+        return entry.getKey();
+      }
+    }
+    return null;
+  }
+
 }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/KafkaConsumerService.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/KafkaConsumerService.java
@@ -407,12 +407,7 @@ public abstract class KafkaConsumerService extends AbstractKafkaConsumerService 
         SharedKafkaConsumer consumer = consumerToConsumptionTask.getByIndex(slowestTaskId).getKey();
         Map<PubSubTopicPartition, TopicPartitionIngestionInfo> topicPartitionIngestionInfoMap =
             getIngestionInfoFromConsumer(consumer);
-        // Convert Map of ingestion info for this consumer to String for logging with each partition line by line
-        StringBuilder sb = new StringBuilder();
-        for (Map.Entry<PubSubTopicPartition, TopicPartitionIngestionInfo> entry: topicPartitionIngestionInfoMap
-            .entrySet()) {
-          sb.append(entry.getKey().toString()).append(": ").append(entry.getValue().toString()).append("\n");
-        }
+        String consumerIngestionInfoStr = convertTopicPartitionIngestionInfoMapToStr(topicPartitionIngestionInfoMap);
         // log the slowest consumer id if it couldn't make any progress in a minute!
         LOGGER.warn(
             "Shared consumer ({} - task {}) couldn't make any progress for over {} ms, thread name: {}, stack trace:\n{}, consumer info:\n{}",
@@ -421,10 +416,21 @@ public abstract class KafkaConsumerService extends AbstractKafkaConsumerService 
             maxElapsedTimeSinceLastPollInConsumerPool,
             slowestThread != null ? slowestThread.getName() : null,
             ExceptionUtils.threadToThrowableToString(slowestThread),
-            sb.toString());
+            consumerIngestionInfoStr);
       }
     }
     return maxElapsedTimeSinceLastPollInConsumerPool;
+  }
+
+  public static String convertTopicPartitionIngestionInfoMapToStr(
+      // Convert Map of ingestion info for this consumer to String for logging with each partition line by line
+      Map<PubSubTopicPartition, TopicPartitionIngestionInfo> topicPartitionIngestionInfoMap) {
+    StringBuilder sb = new StringBuilder();
+    for (Map.Entry<PubSubTopicPartition, TopicPartitionIngestionInfo> entry: topicPartitionIngestionInfoMap
+        .entrySet()) {
+      sb.append(entry.getKey().toString()).append(": ").append(entry.getValue().toString()).append("\n");
+    }
+    return sb.toString();
   }
 
   @Override

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/KafkaStoreIngestionService.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/KafkaStoreIngestionService.java
@@ -215,6 +215,8 @@ public class KafkaStoreIngestionService extends AbstractVeniceService implements
   private final VeniceWriterFactory veniceWriterFactory;
   private final MetricsRepository metricsRepository;
 
+  private final HeartbeatMonitoringService heartbeatMonitoringService;
+
   public KafkaStoreIngestionService(
       StorageService storageService,
       VeniceConfigLoader veniceConfigLoader,
@@ -252,6 +254,7 @@ public class KafkaStoreIngestionService extends AbstractVeniceService implements
     this.partitionStateSerializer = partitionStateSerializer;
     this.compressorFactory = compressorFactory;
     this.zkHelixAdmin = zkHelixAdmin;
+    this.heartbeatMonitoringService = heartbeatMonitoringService;
     // Each topic that has any partition ingested by this class has its own lock.
     this.topicLockManager = new ResourceAutoClosableLockManager<>(ReentrantLock::new);
     this.serverConfig = veniceConfigLoader.getVeniceServerConfig();
@@ -550,6 +553,9 @@ public class KafkaStoreIngestionService extends AbstractVeniceService implements
    */
   @Override
   public boolean startInner() {
+    if (heartbeatMonitoringService != null) {
+      heartbeatMonitoringService.setKafkaStoreIngestionService(this);
+    }
     ingestionExecutorService = Executors.newCachedThreadPool();
     topicNameToIngestionTaskMap.values().forEach(ingestionExecutorService::submit);
 
@@ -1438,4 +1444,33 @@ public class KafkaStoreIngestionService extends AbstractVeniceService implements
   public InternalDaVinciRecordTransformerConfig getInternalRecordTransformerConfig(String storeName) {
     return storeNameToInternalRecordTransformerConfig.get(storeName);
   }
+
+  public String prepareIngestionInfoFor(String storeName, Integer version, Integer partition, String regionName) {
+    try {
+      PubSubTopic versionTopic = pubSubTopicRepository.getTopic(Version.composeKafkaTopic(storeName, version));
+      StoreIngestionTask storeIngestionTask = getStoreIngestionTask(versionTopic.getName());
+      PartitionConsumptionState partitionConsumptionState = storeIngestionTask.getPartitionConsumptionState(partition);
+      if (partitionConsumptionState == null) {
+        return "PartitionConsumptionState is not available.";
+      }
+      PubSubTopic ingestingTopic = versionTopic;
+      String infoPrefix = "isCurrentVersion: " + (storeIngestionTask.isCurrentVersion()) + "\n";
+      if (storeIngestionTask.isHybridMode() && partitionConsumptionState.isEndOfPushReceived()
+          && partitionConsumptionState.getLeaderFollowerState() == LeaderFollowerStateType.LEADER) {
+        ingestingTopic = pubSubTopicRepository.getTopic(Utils.composeRealTimeTopic(storeName));
+      }
+      PubSubTopicPartition ingestingTopicPartition = new PubSubTopicPartitionImpl(ingestingTopic, partition);
+      return infoPrefix
+          + aggKafkaConsumerService.getIngestionInfoFor(versionTopic, ingestingTopicPartition, regionName);
+    } catch (Exception e) {
+      LOGGER.error(
+          "Error on preparing ingestion info for store: {}, version: {}, partition: {}",
+          storeName,
+          version,
+          partition,
+          e);
+      return "Error on preparing ingestion info: " + e.getMessage();
+    }
+  }
+
 }

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/KafkaStoreIngestionServiceTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/KafkaStoreIngestionServiceTest.java
@@ -28,6 +28,7 @@ import com.linkedin.davinci.config.VeniceServerConfig;
 import com.linkedin.davinci.config.VeniceStoreVersionConfig;
 import com.linkedin.davinci.helix.LeaderFollowerPartitionStateModel;
 import com.linkedin.davinci.ingestion.utils.IngestionTaskReusableObjects;
+import com.linkedin.davinci.stats.ingestion.heartbeat.HeartbeatMonitoringService;
 import com.linkedin.davinci.storage.StorageMetadataService;
 import com.linkedin.davinci.storage.StorageService;
 import com.linkedin.davinci.store.AbstractStorageEngineTest;
@@ -130,6 +131,8 @@ public abstract class KafkaStoreIngestionServiceTest {
 
     setupMockConfig();
 
+    HeartbeatMonitoringService mockHeartbeatMonitoringService = mock(HeartbeatMonitoringService.class);
+
     kafkaStoreIngestionService = new KafkaStoreIngestionService(
         mockStorageService,
         mockVeniceConfigLoader,
@@ -151,7 +154,7 @@ public abstract class KafkaStoreIngestionServiceTest {
         null,
         mockPubSubClientsFactory,
         Optional.empty(),
-        null,
+        mockHeartbeatMonitoringService,
         null,
         null,
         Optional.empty());
@@ -388,6 +391,7 @@ public abstract class KafkaStoreIngestionServiceTest {
 
   @Test(dataProvider = "True-and-False", dataProviderClass = DataProviderUtils.class)
   public void testStoreIngestionTaskShutdownLastPartition(boolean isIsolatedIngestion) {
+    HeartbeatMonitoringService mockHeartbeatMonitoringService = mock(HeartbeatMonitoringService.class);
     kafkaStoreIngestionService = new KafkaStoreIngestionService(
         mockStorageService,
         mockVeniceConfigLoader,
@@ -409,7 +413,7 @@ public abstract class KafkaStoreIngestionServiceTest {
         null,
         mockPubSubClientsFactory,
         Optional.empty(),
-        null,
+        mockHeartbeatMonitoringService,
         null,
         null,
         Optional.empty());


### PR DESCRIPTION
<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat], [protocol]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## Problem Statement
<!--
Describe
- What problem are you trying to solve
- What issues or limitations exist in the current code
- Why this change is necessary 
-->
Enhanced heartbeat monitoring with detailed ingestion context logging when lag is detected, improving debugging capabilities for consumer performance issues.

 Key Changes
- **New [getIngestionInfoFor()](cci:1://file:///Users/xhao/Projects/venice_os/venice/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/AggKafkaConsumerService.java:517:2-532:3) method** in [AggKafkaConsumerService](cci:2://file:///Users/xhao/Projects/venice_os/venice/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/AggKafkaConsumerService.java:51:0-560:1) for region-based ingestion info retrieval
- **Enhanced `HeartbeatMonitoringService`** with context logging when heartbeat lag occurs
- **Updated ingestion services** to integrate heartbeat monitoring

Provides detailed consumer metrics (offset lag, message rates, consumer health) when heartbeat lag is detected, making it easier to identify and resolve ingestion bottlenecks.

## Solution
<!--
Describe
- What changes you are making and why. 
- How these changes solve the problem.
- Any performance considerations or trade-offs. 
- Describe what testings you have done, for example, performance testing etc.
-->


###  Code changes
- [ ] Added new code behind **a config**. If so list the config names and their default values in the PR description.
- [ ] Introduced new **log lines**. 
  - [ ] Confirmed if logs need to be **rate limited** to avoid excessive logging.

###  **Concurrency-Specific Checks**
Both reviewer and PR author to verify
- [ ] Code has **no race conditions** or **thread safety issues**.
- [ ] Proper **synchronization mechanisms** (e.g., `synchronized`, `RWLock`) are used where needed.
- [ ] No **blocking calls** inside critical sections that could lead to deadlocks or performance degradation.
- [ ] Verified **thread-safe collections** are used (e.g., `ConcurrentHashMap`, `CopyOnWriteArrayList`).
- [ ] Validated proper exception handling in multi-threaded code to avoid silent thread termination.


## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->

- [ ] New unit tests added.
- [ ] New integration tests added.
- [ ] Modified or extended existing tests.
- [ ] Verified backward compatibility (if applicable).

## Does this PR introduce any user-facing or breaking changes?
<!--  
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [ ] No. You can skip the rest of this section.
- [ ] Yes. Clearly explain the behavior change and its impact.