### PR TITLE
[cc][test] Add default metric emission for version swap, and fix OTEL metrics test validation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,8 @@ internal/venice-test-common/src/jmh/generated
 internal/venice-test-common/file:/
 clients/da-vinci-client/classHash*.txt
 integrations/venice-duckdb/classHash*.txt
+.vscode/
+.github/copilot-instructions.md
 
 # Stuff related to running the docs server locally
 .jekyll-cache/

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/consumer/stats/BasicConsumerStats.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/consumer/stats/BasicConsumerStats.java
@@ -2,6 +2,7 @@ package com.linkedin.davinci.consumer.stats;
 
 import static com.linkedin.venice.stats.dimensions.VeniceMetricsDimensions.VENICE_RESPONSE_STATUS_CODE_CATEGORY;
 import static com.linkedin.venice.stats.dimensions.VeniceMetricsDimensions.VENICE_STORE_NAME;
+import static com.linkedin.venice.stats.dimensions.VeniceResponseStatusCategory.FAIL;
 import static com.linkedin.venice.stats.dimensions.VeniceResponseStatusCategory.SUCCESS;
 import static com.linkedin.venice.stats.metrics.ModuleMetricEntityInterface.getUniqueMetricEntities;
 import static com.linkedin.venice.utils.CollectionUtils.setOf;
@@ -177,6 +178,10 @@ public class BasicConsumerStats extends AbstractVeniceStats {
         Collections.singletonList(new Rate()),
         baseDimensionsMap,
         VeniceResponseStatusCategory.class);
+
+    // Record default value for version swap metrics so histograms include initial zero
+    versionSwapSuccessCountMetric.record(0, SUCCESS);
+    versionSwapFailCountMetric.record(0, FAIL);
   }
 
   public void emitCurrentConsumingVersionMetrics(int minVersion, int maxVersion) {

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/stats/BasicConsumerStatsTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/stats/BasicConsumerStatsTest.java
@@ -114,39 +114,40 @@ public class BasicConsumerStatsTest {
   }
 
   @Test
-  public void testEmitVersionSwapSuccessCountMetrics() {
-    VeniceResponseStatusCategory responseStatusCategory = SUCCESS;
-    consumerStats.emitVersionSwapCountMetrics(responseStatusCategory);
-
+  public void testEmitVersionSwapCountMetrics() {
+    int defaultNum = 0;
     int expectedNum = 1;
+
+    // Default Tehuti metrics
+    validateTehutiMetric(tehutiMetricPrefix + "--" + VERSION_SWAP_SUCCESS_COUNT.getMetricName() + ".Gauge", defaultNum);
+    validateTehutiMetric(tehutiMetricPrefix + "--" + VERSION_SWAP_FAIL_COUNT.getMetricName() + ".Gauge", defaultNum);
+
+    consumerStats.emitVersionSwapCountMetrics(SUCCESS);
+    consumerStats.emitVersionSwapCountMetrics(FAIL);
+
+    // Success metrics
     validateTehutiMetric(
         tehutiMetricPrefix + "--" + VERSION_SWAP_SUCCESS_COUNT.getMetricName() + ".Gauge",
         expectedNum);
     validateMinMaxSumAggregationsOtelMetric(
         storeName,
         VERSION_SWAP_COUNT.getMetricEntity().getMetricName(),
-        0, // min includes default 0 recorded at construction
+        defaultNum, // min includes default 0 recorded at construction
         expectedNum, // max after first increment
         2, // count includes default 0 and this increment
         expectedNum, // sum is 1 (0 + 1)
-        responseStatusCategory);
-  }
+        SUCCESS);
 
-  @Test
-  public void testEmitVersionSwapFailCountMetrics() {
-    VeniceResponseStatusCategory responseStatusCategory = FAIL;
-    consumerStats.emitVersionSwapCountMetrics(responseStatusCategory);
-
-    int expectedNum = 1;
+    // Fail metrics
     validateTehutiMetric(tehutiMetricPrefix + "--" + VERSION_SWAP_FAIL_COUNT.getMetricName() + ".Gauge", expectedNum);
     validateMinMaxSumAggregationsOtelMetric(
         storeName,
         VERSION_SWAP_COUNT.getMetricEntity().getMetricName(),
-        0, // min includes default 0 recorded at construction
+        defaultNum, // min includes default 0 recorded at construction
         expectedNum, // max after first increment
         2, // count includes default 0 and this increment
         expectedNum, // sum is 1 (0 + 1)
-        responseStatusCategory);
+        FAIL);
   }
 
   @Test

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/stats/BasicConsumerStatsTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/stats/BasicConsumerStatsTest.java
@@ -125,10 +125,10 @@ public class BasicConsumerStatsTest {
     validateMinMaxSumAggregationsOtelMetric(
         storeName,
         VERSION_SWAP_COUNT.getMetricEntity().getMetricName(),
-        expectedNum,
-        expectedNum,
-        expectedNum,
-        expectedNum,
+        0, // min includes default 0 recorded at construction
+        expectedNum, // max after first increment
+        2, // count includes default 0 and this increment
+        expectedNum, // sum is 1 (0 + 1)
         responseStatusCategory);
   }
 
@@ -142,10 +142,10 @@ public class BasicConsumerStatsTest {
     validateMinMaxSumAggregationsOtelMetric(
         storeName,
         VERSION_SWAP_COUNT.getMetricEntity().getMetricName(),
-        expectedNum,
-        expectedNum,
-        expectedNum,
-        expectedNum,
+        0, // min includes default 0 recorded at construction
+        expectedNum, // max after first increment
+        2, // count includes default 0 and this increment
+        expectedNum, // sum is 1 (0 + 1)
         responseStatusCategory);
   }
 

--- a/internal/venice-test-common/src/main/java/com/linkedin/venice/utils/OpenTelemetryDataPointTestUtils.java
+++ b/internal/venice-test-common/src/main/java/com/linkedin/venice/utils/OpenTelemetryDataPointTestUtils.java
@@ -20,7 +20,8 @@ public abstract class OpenTelemetryDataPointTestUtils {
   public static LongPointData getLongPointDataFromSum(
       Collection<MetricData> metricsData,
       String metricName,
-      String prefix) {
+      String prefix,
+      Attributes expectedAttributes) {
     return metricsData.stream()
         .filter(metricData -> metricData.getName().equals(DEFAULT_METRIC_PREFIX + prefix + "." + metricName))
         .findFirst()
@@ -28,6 +29,7 @@ public abstract class OpenTelemetryDataPointTestUtils {
         .getLongSumData()
         .getPoints()
         .stream()
+        .filter(p -> p.getAttributes().equals(expectedAttributes))
         .findFirst()
         .orElse(null);
   }
@@ -35,7 +37,8 @@ public abstract class OpenTelemetryDataPointTestUtils {
   public static LongPointData getLongPointDataFromGauge(
       Collection<MetricData> metricsData,
       String metricName,
-      String prefix) {
+      String prefix,
+      Attributes expectedAttributes) {
     return metricsData.stream()
         .filter(metricData -> metricData.getName().equals(DEFAULT_METRIC_PREFIX + prefix + "." + metricName))
         .findFirst()
@@ -43,6 +46,7 @@ public abstract class OpenTelemetryDataPointTestUtils {
         .getLongGaugeData()
         .getPoints()
         .stream()
+        .filter(p -> p.getAttributes().equals(expectedAttributes))
         .findFirst()
         .orElse(null);
   }
@@ -50,7 +54,8 @@ public abstract class OpenTelemetryDataPointTestUtils {
   public static ExponentialHistogramPointData getExponentialHistogramPointData(
       Collection<MetricData> metricsData,
       String metricName,
-      String prefix) {
+      String prefix,
+      Attributes expectedAttributes) {
     return metricsData.stream()
         .filter(metricData -> metricData.getName().equals(DEFAULT_METRIC_PREFIX + prefix + "." + metricName))
         .findFirst()
@@ -58,6 +63,7 @@ public abstract class OpenTelemetryDataPointTestUtils {
         .getExponentialHistogramData()
         .getPoints()
         .stream()
+        .filter(p -> p.getAttributes().equals(expectedAttributes))
         .findFirst()
         .orElse(null);
   }
@@ -65,7 +71,8 @@ public abstract class OpenTelemetryDataPointTestUtils {
   public static HistogramPointData getHistogramPointData(
       Collection<MetricData> metricsData,
       String metricName,
-      String prefix) {
+      String prefix,
+      Attributes expectedAttributes) {
     return metricsData.stream()
         .filter(metricData -> metricData.getName().equals(DEFAULT_METRIC_PREFIX + prefix + "." + metricName))
         .findFirst()
@@ -73,6 +80,7 @@ public abstract class OpenTelemetryDataPointTestUtils {
         .getHistogramData()
         .getPoints()
         .stream()
+        .filter(p -> p.getAttributes().equals(expectedAttributes))
         .findFirst()
         .orElse(null);
   }
@@ -86,7 +94,7 @@ public abstract class OpenTelemetryDataPointTestUtils {
     Collection<MetricData> metricsData = inMemoryMetricReader.collectAllMetrics();
     assertFalse(metricsData.isEmpty());
 
-    LongPointData longPointData = getLongPointDataFromSum(metricsData, metricName, metricPrefix);
+    LongPointData longPointData = getLongPointDataFromSum(metricsData, metricName, metricPrefix, expectedAttributes);
     assertNotNull(longPointData, "LongPointData should not be null");
     assertEquals(longPointData.getValue(), expectedValue, "LongPointData value should be " + expectedValue);
     assertEquals(longPointData.getAttributes(), expectedAttributes, "LongPointData attributes should match");
@@ -101,7 +109,7 @@ public abstract class OpenTelemetryDataPointTestUtils {
     Collection<MetricData> metricsData = inMemoryMetricReader.collectAllMetrics();
     assertFalse(metricsData.isEmpty());
 
-    LongPointData longPointData = getLongPointDataFromGauge(metricsData, metricName, metricPrefix);
+    LongPointData longPointData = getLongPointDataFromGauge(metricsData, metricName, metricPrefix, expectedAttributes);
     assertNotNull(longPointData, "LongPointData should not be null");
     assertEquals(longPointData.getValue(), expectedValue, "LongPointData value should be " + expectedValue);
     assertEquals(longPointData.getAttributes(), expectedAttributes, "LongPointData attributes should match");
@@ -119,7 +127,7 @@ public abstract class OpenTelemetryDataPointTestUtils {
     Collection<MetricData> metricsData = inMemoryMetricReader.collectAllMetrics();
     assertFalse(metricsData.isEmpty());
     ExponentialHistogramPointData histogramPointData =
-        getExponentialHistogramPointData(metricsData, metricName, metricPrefix);
+        getExponentialHistogramPointData(metricsData, metricName, metricPrefix, expectedAttributes);
 
     assertNotNull(histogramPointData, "ExponentialHistogramPointData should not be null");
     assertEquals(histogramPointData.getMin(), expectedMin, "Histogram min value should be " + expectedMin);
@@ -144,7 +152,8 @@ public abstract class OpenTelemetryDataPointTestUtils {
       String metricPrefix) {
     Collection<MetricData> metricsData = inMemoryMetricReader.collectAllMetrics();
     assertFalse(metricsData.isEmpty());
-    HistogramPointData histogramPointData = getHistogramPointData(metricsData, metricName, metricPrefix);
+    HistogramPointData histogramPointData =
+        getHistogramPointData(metricsData, metricName, metricPrefix, expectedAttributes);
 
     assertNotNull(histogramPointData, "HistogramPointData should not be null");
     assertEquals(histogramPointData.getMin(), expectedMin, "Histogram min value should be " + expectedMin);


### PR DESCRIPTION
<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat], [protocol]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## Problem Statement
<!--
Describe
- What problem are you trying to solve
- What issues or limitations exist in the current code
- Why this change is necessary 
-->
1. The version swap count metric in CDC will emit a NaN by default, so when you go to query it the data is unavailable.
2. There is an issue where you can't test multiple OTEL metrics in one unit test.


## Solution
<!--
Describe
- What changes you are making and why. 
- How these changes solve the problem.
- Any performance considerations or trade-offs. 
- Describe what testings you have done, for example, performance testing etc.
-->
1. We will emit a default value of 0 for the version swap metrics.
2. The reason why you couldn't test multiple OTEL metrics in one unit test is because the helper functions fetching the metrics didn't filter by the passed in attributes. It would only return the latest metric emitted. Now, it will filter by the expected attributes.

###  Code changes
- [ ] Added new code behind **a config**. If so list the config names and their default values in the PR description.
- [ ] Introduced new **log lines**. 
  - [ ] Confirmed if logs need to be **rate limited** to avoid excessive logging.

###  **Concurrency-Specific Checks**
Both reviewer and PR author to verify
- [X] Code has **no race conditions** or **thread safety issues**.
- [X] Proper **synchronization mechanisms** (e.g., `synchronized`, `RWLock`) are used where needed.
- [X] No **blocking calls** inside critical sections that could lead to deadlocks or performance degradation.
- [X] Verified **thread-safe collections** are used (e.g., `ConcurrentHashMap`, `CopyOnWriteArrayList`).
- [X] Validated proper exception handling in multi-threaded code to avoid silent thread termination.


## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->

- [ ] New unit tests added.
- [ ] New integration tests added.
- [X] Modified or extended existing tests.
- [X] Verified backward compatibility (if applicable).

## Does this PR introduce any user-facing or breaking changes?
<!--  
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [X] No. You can skip the rest of this section.
- [ ] Yes. Clearly explain the behavior change and its impact.