### PR TITLE
[server] [dvc] Replica Id Logging 

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/VersionBackend.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/VersionBackend.java
@@ -485,9 +485,8 @@ public class VersionBackend {
       return;
     }
     LOGGER.info(
-        "Topic: {}, partition: {} batch report END_OF_INCREMENTAL_PUSH for inc push versions: {}",
-        getVersion().kafkaTopicName(),
-        partition,
+        "Replica: {} batch report END_OF_INCREMENTAL_PUSH for inc push versions: {}",
+        Utils.getReplicaId(getVersion().kafkaTopicName(), partition),
         pendingReportIncPushVersionList);
     for (String incPushVersion: pendingReportIncPushVersionList) {
       reportConsumer.accept(incPushVersion);

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/VersionBackend.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/VersionBackend.java
@@ -26,6 +26,7 @@ import com.linkedin.venice.serializer.RecordDeserializer;
 import com.linkedin.venice.utils.ComplementSet;
 import com.linkedin.venice.utils.ExceptionUtils;
 import com.linkedin.venice.utils.PartitionUtils;
+import com.linkedin.venice.utils.Utils;
 import com.linkedin.venice.utils.concurrent.VeniceConcurrentHashMap;
 import com.linkedin.venice.utils.lazy.Lazy;
 import java.nio.ByteBuffer;
@@ -514,10 +515,9 @@ public class VersionBackend {
       return;
     }
     LOGGER.info(
-        "Adding incremental push version: {} to pending report list for topic: {}, partition: {}",
+        "Adding incremental push version: {} to pending report list for replica: {}",
         incrementalPushVersion,
-        getVersion().kafkaTopicName(),
-        partition);
+        Utils.getReplicaId(getVersion().kafkaTopicName(), partition));
     List<String> pendingReportIncPushVersionList =
         getPartitionToPendingReportIncrementalPushList().computeIfAbsent(partition, p -> new ArrayList<>());
     pendingReportIncPushVersionList.add(incrementalPushVersion);

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/consumer/BootstrappingVeniceChangelogConsumerDaVinciRecordTransformerImpl.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/consumer/BootstrappingVeniceChangelogConsumerDaVinciRecordTransformerImpl.java
@@ -28,6 +28,7 @@ import com.linkedin.venice.pubsub.api.PubSubMessage;
 import com.linkedin.venice.pubsub.api.PubSubSymbolicPosition;
 import com.linkedin.venice.pubsub.api.PubSubTopicPartition;
 import com.linkedin.venice.utils.PropertyBuilder;
+import com.linkedin.venice.utils.Utils;
 import com.linkedin.venice.utils.VeniceProperties;
 import com.linkedin.venice.utils.concurrent.VeniceConcurrentHashMap;
 import com.linkedin.venice.utils.lazy.Lazy;
@@ -471,15 +472,11 @@ public class BootstrappingVeniceChangelogConsumerDaVinciRecordTransformerImpl<K,
        * This early swap causes the buffer to fill with records before the EOP, which is undesirable.
        * By only allowing the futureVersion to perform the version swap, we ensure that only nearline events are served.
        */
+      String replicaId = Utils.getReplicaId(storeName, futureVersion, partitionId);
       try {
         if (futureVersion == getStoreVersion()) {
           partitionToVersionToServe.put(partitionId, futureVersion);
-          LOGGER.info(
-              "Swapped from version: {} to version: {} for store: {} for partition: {}",
-              currentVersion,
-              futureVersion,
-              storeName,
-              partitionId);
+          LOGGER.info("Swapped versions from: {} to: {} for replica: {}", currentVersion, futureVersion, replicaId);
 
           if (changeCaptureStats != null) {
             changeCaptureStats.emitVersionSwapCountMetrics(SUCCESS);
@@ -491,11 +488,10 @@ public class BootstrappingVeniceChangelogConsumerDaVinciRecordTransformerImpl<K,
         }
 
         LOGGER.error(
-            "Encountered an exception when processing Version Swap from version: {} to version: {} for store: {} for partition: {}",
+            "Encountered an exception when processing Version Swap from version: {} to version: {} for replica: {}",
             currentVersion,
             futureVersion,
-            storeName,
-            partitionId);
+            replicaId);
         throw exception;
       }
     }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/consumer/InternalLocalBootstrappingVeniceChangelogConsumer.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/consumer/InternalLocalBootstrappingVeniceChangelogConsumer.java
@@ -207,9 +207,8 @@ class InternalLocalBootstrappingVeniceChangelogConsumer<K, V> extends VeniceAfte
           }
 
           LOGGER.info(
-              "Version Swap succeeded when switching to topic: {} for partition: {} after {} attempts",
-              pubSubTopicPartition.getTopicName(),
-              pubSubTopicPartition.getPartitionNumber(),
+              "Version Swap succeeded when switching to replica: {} after {} attempts",
+              Utils.getReplicaId(pubSubTopicPartition),
               attempt);
 
           return true;
@@ -220,16 +219,14 @@ class InternalLocalBootstrappingVeniceChangelogConsumer<K, V> extends VeniceAfte
             }
 
             LOGGER.error(
-                "Version Swap failed when switching to topic: {} for partition: {} after {} attempts",
-                pubSubTopicPartition.getTopicName(),
-                pubSubTopicPartition.getPartitionNumber(),
+                "Version Swap failed when switching to replica: {} after {} attempts",
+                Utils.getReplicaId(pubSubTopicPartition),
                 MAX_VERSION_SWAP_RETRIES);
             throw error;
           } else {
             LOGGER.error(
-                "Version Swap failed when switching to topic: {} for partition: {} on attempt {}/{}. Retrying.",
-                pubSubTopicPartition.getTopicName(),
-                pubSubTopicPartition.getPartitionNumber(),
+                "Version Swap failed when switching to replica: {} on attempt {}/{}. Retrying.",
+                Utils.getReplicaId(pubSubTopicPartition),
                 attempt,
                 MAX_VERSION_SWAP_RETRIES);
 
@@ -299,10 +296,8 @@ class InternalLocalBootstrappingVeniceChangelogConsumer<K, V> extends VeniceAfte
     StorageEngine storageEngineReloadedFromRepo =
         storageService.getStorageEngineRepository().getLocalStorageEngine(localStateTopicName);
     if (storageEngineReloadedFromRepo == null) {
-      LOGGER.warn(
-          "Storage engine has been removed. Could not execute sync offset for topic: {} and partition: {}",
-          localStateTopicName,
-          partitionId);
+      String replicaId = Utils.getReplicaId(localStateTopicName, partitionId);
+      LOGGER.warn("Storage engine has been removed. Could not execute sync offset for replica: {}", replicaId);
       return;
     }
 

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/consumer/VeniceChangelogConsumerImpl.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/consumer/VeniceChangelogConsumerImpl.java
@@ -985,9 +985,8 @@ public class VeniceChangelogConsumerImpl<K, V> implements VeniceChangelogConsume
         }
 
         LOGGER.error(
-            "Encountered an exception when processing a record in ChunkAssembler for topic: {} and partition: {}",
-            pubSubTopicPartition.getTopicName(),
-            pubSubTopicPartition.getPartitionNumber());
+            "Encountered an exception when processing a record in ChunkAssembler for replica: {}",
+            Utils.getReplicaId(pubSubTopicPartition));
         throw exception;
       }
 
@@ -1122,6 +1121,7 @@ public class VeniceChangelogConsumerImpl<K, V> implements VeniceChangelogConsume
       PubSubTopicPartition pubSubTopicPartition,
       String topicSuffix,
       Integer upstreamPartition) {
+    String replicaId = Utils.getReplicaId(pubSubTopicPartition);
     ControlMessageType controlMessageType = ControlMessageType.valueOf(controlMessage);
     if (controlMessageType.equals(ControlMessageType.VERSION_SWAP)) {
       for (int attempt = 1; attempt <= MAX_VERSION_SWAP_RETRIES; attempt++) {
@@ -1164,11 +1164,7 @@ public class VeniceChangelogConsumerImpl<K, V> implements VeniceChangelogConsume
             changeCaptureStats.emitVersionSwapCountMetrics(SUCCESS);
           }
 
-          LOGGER.info(
-              "Version Swap succeeded when switching to topic: {} for partition: {} after {} attempts",
-              pubSubTopicPartition.getTopicName(),
-              pubSubTopicPartition.getPartitionNumber(),
-              attempt);
+          LOGGER.info("Version Swap succeeded when switching to replica: {} after {} attempts", replicaId, attempt);
 
           return true;
         } catch (Exception error) {
@@ -1177,17 +1173,12 @@ public class VeniceChangelogConsumerImpl<K, V> implements VeniceChangelogConsume
               changeCaptureStats.emitVersionSwapCountMetrics(FAIL);
             }
 
-            LOGGER.error(
-                "Version Swap failed when switching to topic: {} for partition: {} after {} attempts",
-                pubSubTopicPartition.getTopicName(),
-                pubSubTopicPartition.getPartitionNumber(),
-                attempt);
+            LOGGER.error("Version Swap failed when switching to replica: {} after {} attempts", replicaId, attempt);
             throw error;
           } else {
             LOGGER.error(
-                "Version Swap failed when switching to topic: {} for partition: {} on attempt {}/{}. Retrying.",
-                pubSubTopicPartition.getTopicName(),
-                pubSubTopicPartition.getPartitionNumber(),
+                "Version Swap failed when switching to replica: {} on attempt {}/{}. Retrying.",
+                replicaId,
                 attempt,
                 MAX_VERSION_SWAP_RETRIES);
 

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/ingestion/IsolatedIngestionBackend.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/ingestion/IsolatedIngestionBackend.java
@@ -306,9 +306,8 @@ public class IsolatedIngestionBackend extends DefaultIngestionBackend implements
           });
         } else {
           LOGGER.error(
-              "Partition: {} of topic: {} is not assigned to this host, will not resume the ingestion on main process.",
-              partition,
-              kafkaTopic);
+              "Replica: {} is not assigned to this host, will not resume the ingestion on main process.",
+              Utils.getReplicaId(kafkaTopic, partition));
         }
       }
     };

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/ingestion/isolated/IsolatedIngestionRequestClient.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/ingestion/isolated/IsolatedIngestionRequestClient.java
@@ -10,6 +10,7 @@ import com.linkedin.venice.ingestion.protocol.IngestionTaskReport;
 import com.linkedin.venice.ingestion.protocol.enums.IngestionAction;
 import com.linkedin.venice.ingestion.protocol.enums.IngestionReportType;
 import com.linkedin.venice.security.SSLFactory;
+import com.linkedin.venice.utils.Utils;
 import java.io.Closeable;
 import java.util.Optional;
 import org.apache.logging.log4j.LogManager;
@@ -35,20 +36,20 @@ public class IsolatedIngestionRequestClient implements Closeable {
   public boolean reportIngestionStatus(IngestionTaskReport report) {
     String topicName = report.topicName.toString();
     int partitionId = report.partitionId;
+    String replicaId = Utils.getReplicaId(topicName, partitionId);
     // Avoid sending binary data in OffsetRecord and pollute logs.
     LOGGER.info(
-        "Sending ingestion report {}, isPositive: {}, message: {} for partition: {} of topic: {} at offset: {}",
+        "Sending ingestion report {}, isPositive: {}, message: {} for replica: {} at offset: {}",
         IngestionReportType.valueOf(report.reportType),
         report.isPositive,
         report.message,
-        partitionId,
-        topicName,
+        replicaId,
         report.offset);
     try {
       httpClientTransport.sendRequest(IngestionAction.REPORT, report);
       return true;
     } catch (Exception e) {
-      LOGGER.warn("Failed to send report with exception for topic: {}, partition: {}", topicName, partitionId, e);
+      LOGGER.warn("Failed to send report with exception for replica: {}", replicaId, e);
       return false;
     }
   }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/ingestion/isolated/IsolatedIngestionServerHandler.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/ingestion/isolated/IsolatedIngestionServerHandler.java
@@ -382,11 +382,8 @@ public class IsolatedIngestionServerHandler extends SimpleChannelInboundHandler<
        * it will be executed inside main process.
        */
       report.isPositive = false;
-      LOGGER.info(
-          "Topic: {}, partition {} is being unsubscribed, will reject command {}",
-          topic,
-          partition,
-          command.name());
+      String replicaId = Utils.getReplicaId(topic, partition);
+      LOGGER.info("Replica: {} is being unsubscribed, will reject command {}", replicaId, command.name());
     }
   }
 }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/ingestion/isolated/IsolatedIngestionServerHandler.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/ingestion/isolated/IsolatedIngestionServerHandler.java
@@ -27,6 +27,7 @@ import com.linkedin.venice.meta.SubscriptionBasedReadOnlyStoreRepository;
 import com.linkedin.venice.meta.Version;
 import com.linkedin.venice.offsets.OffsetRecord;
 import com.linkedin.venice.utils.ExceptionUtils;
+import com.linkedin.venice.utils.Utils;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.SimpleChannelInboundHandler;
 import io.netty.handler.codec.http.FullHttpRequest;
@@ -142,14 +143,14 @@ public class IsolatedIngestionServerHandler extends SimpleChannelInboundHandler<
     String topicName = ingestionTaskCommand.topicName.toString();
     int partitionId = ingestionTaskCommand.partitionId;
     String storeName = Version.parseStoreFromKafkaTopicName(topicName);
+    String replicaId = Utils.getReplicaId(topicName, partitionId);
 
     IngestionTaskReport report = createIngestionTaskReport(topicName, partitionId);
     IngestionCommandType ingestionCommandType = IngestionCommandType.valueOf(ingestionTaskCommand.commandType);
     LOGGER.info(
-        "Received ingestion command {} for topic: {}, partition: {} in timestamp: {}",
+        "Received ingestion command {} for replica: {} in timestamp: {}",
         ingestionCommandType,
-        topicName,
-        partitionId,
+        replicaId,
         startTimeInMs);
     try {
       if (!isolatedIngestionServer.isInitiated()) {
@@ -174,7 +175,7 @@ public class IsolatedIngestionServerHandler extends SimpleChannelInboundHandler<
                 LOGGER.warn("Subscription to store: {} is interrupted. ", storeName);
               }
             }
-            LOGGER.info("Start ingesting partition: {} of topic: {}", partitionId, topicName);
+            LOGGER.info("Start ingesting replica: {}", replicaId);
             isolatedIngestionServer.setResourceToBeSubscribed(topicName, partitionId);
             isolatedIngestionServer.getIngestionBackend().startConsumption(storeConfig, partitionId);
           });
@@ -247,10 +248,9 @@ public class IsolatedIngestionServerHandler extends SimpleChannelInboundHandler<
     }
     long executionTimeInMs = System.currentTimeMillis() - startTimeInMs;
     LOGGER.info(
-        "Completed ingestion command {} for topic: {}, partition: {} in {} ms.",
+        "Completed ingestion command {} for replica: {} in {} ms.",
         ingestionCommandType,
-        topicName,
-        partitionId,
+        replicaId,
         executionTimeInMs);
     return report;
   }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/ingestion/main/MainIngestionReportHandler.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/ingestion/main/MainIngestionReportHandler.java
@@ -18,6 +18,7 @@ import com.linkedin.venice.pubsub.adapter.kafka.common.ApacheKafkaOffsetPosition
 import com.linkedin.venice.pubsub.api.PubSubPosition;
 import com.linkedin.venice.pubsub.api.PubSubSymbolicPosition;
 import com.linkedin.venice.utils.ExceptionUtils;
+import com.linkedin.venice.utils.Utils;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.SimpleChannelInboundHandler;
 import io.netty.handler.codec.http.FullHttpRequest;
@@ -106,10 +107,9 @@ public class MainIngestionReportHandler extends SimpleChannelInboundHandler<Full
     PubSubPosition position = offset == -1 ? PubSubSymbolicPosition.EARLIEST : new ApacheKafkaOffsetPosition(offset);
     String message = report.message.toString();
     LOGGER.info(
-        "Received ingestion report {} for topic: {}, partition: {} position: {} from ingestion service. ",
+        "Received ingestion report {} for replica: {} position: {} from ingestion service. ",
         reportType.name(),
-        topicName,
-        partitionId,
+        Utils.getReplicaId(topicName, partitionId),
         position);
     updateLocalStorageMetadata(report);
     // Relay the notification to parent service's listener.

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/ingestion/main/MainIngestionStorageMetadataService.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/ingestion/main/MainIngestionStorageMetadataService.java
@@ -14,6 +14,7 @@ import com.linkedin.venice.offsets.OffsetRecord;
 import com.linkedin.venice.serialization.avro.InternalAvroSpecificSerializer;
 import com.linkedin.venice.service.AbstractVeniceService;
 import com.linkedin.venice.utils.Time;
+import com.linkedin.venice.utils.Utils;
 import com.linkedin.venice.utils.concurrent.VeniceConcurrentHashMap;
 import java.io.Closeable;
 import java.io.IOException;
@@ -158,7 +159,8 @@ public class MainIngestionStorageMetadataService extends AbstractVeniceService i
    * putOffsetRecord will only put OffsetRecord into in-memory state, without persisting into metadata RocksDB partition.
    */
   public void putOffsetRecord(String topicName, int partitionId, OffsetRecord record) {
-    LOGGER.info("Updating OffsetRecord: {} for topic: {}, partition: {}", record.toString(), topicName, partitionId);
+    String replicaId = Utils.getReplicaId(topicName, partitionId);
+    LOGGER.info("Updating OffsetRecord: {} for replica: {}", record.toString(), replicaId);
     Map<Integer, OffsetRecord> partitionOffsetRecordMap =
         topicPartitionOffsetRecordMap.computeIfAbsent(topicName, k -> new VeniceConcurrentHashMap<>());
     partitionOffsetRecordMap.put(partitionId, record);

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/ActiveActiveStoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/ActiveActiveStoreIngestionTask.java
@@ -1475,10 +1475,9 @@ public class ActiveActiveStoreIngestionTask extends LeaderFollowerStoreIngestion
     syncConsumedUpstreamRTOffsetMapIfNeeded(partitionConsumptionState, leaderOffsetByKafkaURL);
 
     LOGGER.info(
-        "{}, as a leader, started consuming from topic: {}, partition {}: with offset by Kafka URL mapping: {}",
+        "{}, as a leader, started consuming from replica: {}: with offset by Kafka URL mapping: {}",
+        ingestionTaskName,
         partitionConsumptionState.getReplicaId(),
-        leaderTopic,
-        partitionConsumptionState.getPartition(),
         leaderOffsetByKafkaURL);
   }
 

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/ActiveActiveStoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/ActiveActiveStoreIngestionTask.java
@@ -1475,8 +1475,9 @@ public class ActiveActiveStoreIngestionTask extends LeaderFollowerStoreIngestion
     syncConsumedUpstreamRTOffsetMapIfNeeded(partitionConsumptionState, leaderOffsetByKafkaURL);
 
     LOGGER.info(
-        "{}, as a leader, started consuming from replica: {}: with offset by Kafka URL mapping: {}",
+        "{}, as a leader, started consuming from topic-partition: {} replica: {}: with offset by Kafka URL mapping: {}",
         ingestionTaskName,
+        Utils.getReplicaId(leaderTopic, partitionConsumptionState.getPartition()),
         partitionConsumptionState.getReplicaId(),
         leaderOffsetByKafkaURL);
   }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/KafkaStoreIngestionService.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/KafkaStoreIngestionService.java
@@ -750,7 +750,7 @@ public class KafkaStoreIngestionService extends AbstractVeniceService implements
       storeIngestionTask
           .subscribePartition(new PubSubTopicPartitionImpl(pubSubTopicRepository.getTopic(topic), partitionId));
     }
-    LOGGER.info("Started Consuming - Kafka Partition: {}-{}.", topic, partitionId);
+    LOGGER.info("Started Consuming - Replica: {}.", Utils.getReplicaId(topic, partitionId));
   }
 
   /**
@@ -991,9 +991,8 @@ public class KafkaStoreIngestionService extends AbstractVeniceService implements
           sleep((long) sleepSeconds * Time.MS_PER_SECOND);
         }
         LOGGER.warn(
-            "Partition: {} of store: {} is still consuming after waiting for it to stop for {} seconds.",
-            partitionId,
-            topicName,
+            "Replica: {} is still consuming after waiting for it to stop for {} seconds.",
+            Utils.getReplicaId(topicName, partitionId),
             numRetries * sleepSeconds);
       } catch (InterruptedException e) {
         LOGGER.warn("Waiting for partition to stop consumption was interrupted", e);
@@ -1408,7 +1407,7 @@ public class KafkaStoreIngestionService extends AbstractVeniceService implements
       consumerTask.resetPartitionConsumptionOffset(
           new PubSubTopicPartitionImpl(pubSubTopicRepository.getTopic(topic), partitionId));
     }
-    LOGGER.info("Offset reset to beginning - Kafka Partition: {}-{}.", topic, partitionId);
+    LOGGER.info("Offset reset to beginning - Replica: {}.", Utils.getReplicaId(topic, partitionId));
   }
 
   @VisibleForTesting

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTask.java
@@ -2258,10 +2258,8 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
     final PartitionConsumptionState pcs = partitionConsumptionStateMap.get(topicPartition.getPartitionNumber());
     if (pcs == null) {
       // The partition is likely unsubscribed, will skip these messages.
-      LOGGER.warn(
-          "No partition consumption state for store version: {}, partition: {}, will filter out all the messages",
-          kafkaVersionTopic,
-          topicPartition.getPartitionNumber());
+      String replicaId = Utils.getReplicaId(kafkaVersionTopic, topicPartition.getPartitionNumber());
+      LOGGER.warn("No partition consumption state for replica: {}, will filter out all the messages", replicaId);
       return Collections.emptyList();
     }
     boolean isEndOfPushReceived = pcs.isEndOfPushReceived();
@@ -2928,11 +2926,11 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
         return result;
       } catch (IOException e) {
         // throw a loud exception if something goes wrong here
+        PubSubTopic leaderTopic = partitionConsumptionState.getOffsetRecord().getLeaderTopic(pubSubTopicRepository);
         throw new RuntimeException(
             String.format(
-                "Failed to compress value in venice writer! Aborting write! partition: %d, leader topic: %s, compressor: %s",
-                partition,
-                partitionConsumptionState.getOffsetRecord().getLeaderTopic(pubSubTopicRepository),
+                "Failed to compress value in venice writer! Aborting write! replica: %s, compressor: %s",
+                Utils.getReplicaId(leaderTopic, partition),
                 compressor.getClass().getName()),
             e);
       }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
@@ -3631,7 +3631,7 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
   protected void logStorageOperationWhileUnsubscribed(int partition) {
     // TODO Consider if this is going to be too noisy, in which case we could mute it.
     LOGGER.info(
-        "Attempted to interact with the storage engine for partition: {} while the "
+        "Attempted to interact with the storage engine for replica: {} while the "
             + "partitionConsumptionStateMap does not contain this partition. "
             + "Will ignore the operation as it probably indicates the partition was unsubscribed.",
         getReplicaId(versionTopic, partition));

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/notifier/PushStatusNotifier.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/notifier/PushStatusNotifier.java
@@ -212,9 +212,8 @@ public class PushStatusNotifier implements VeniceNotifier {
           e);
     }
     LOGGER.info(
-        "Update server inc push status for topic: {}, partition: {}, inc push version: {}, status: {} to push status store",
-        kafkaTopic,
-        partitionId,
+        "Update server inc push status for replica: {}, inc push version: {}, status: {} to push status store",
+        Utils.getReplicaId(kafkaTopic, partitionId),
         incPushVersion,
         status);
     pushStatusStoreWriter.writePushStatus(

--- a/internal/venice-common/src/main/java/com/linkedin/venice/helix/VeniceOfflinePushMonitorAccessor.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/helix/VeniceOfflinePushMonitorAccessor.java
@@ -14,6 +14,7 @@ import com.linkedin.venice.pushmonitor.ReplicaStatus;
 import com.linkedin.venice.utils.HelixUtils;
 import com.linkedin.venice.utils.LogContext;
 import com.linkedin.venice.utils.PathResourceRegistry;
+import com.linkedin.venice.utils.Utils;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Iterator;
@@ -283,11 +284,8 @@ public class VeniceOfflinePushMonitorAccessor implements OfflinePushAccessor {
     if (!pushStatusExists(topic)) {
       return;
     }
-    LOGGER.info(
-        "Start update replica status for topic: {}, partition: {} in cluster: {}.",
-        topic,
-        partitionId,
-        clusterName);
+    String replicaId = Utils.getReplicaId(topic, partitionId);
+    LOGGER.info("Start update replica status for replica: {} in cluster: {}.", replicaId, clusterName);
     HelixUtils.compareAndUpdate(partitionStatusAccessor, getPartitionStatusPath(topic, partitionId), currentData -> {
 
       // currentData can be null if the path read out of zk is blank to start with (as current data is read and passed
@@ -301,12 +299,7 @@ public class VeniceOfflinePushMonitorAccessor implements OfflinePushAccessor {
       currentData.updateReplicaStatus(instanceId, status, incrementalPushVersion, progress);
       return currentData;
     });
-    LOGGER.info(
-        "Updated replica status for topic: {} partition: {} status: {} in cluster: {}.",
-        topic,
-        partitionId,
-        status,
-        clusterName);
+    LOGGER.info("Updated replica status for replica: {} status: {} in cluster: {}.", replicaId, status, clusterName);
   }
 
   private void compareAndBatchUpdateReplicaStatus(
@@ -318,11 +311,8 @@ public class VeniceOfflinePushMonitorAccessor implements OfflinePushAccessor {
     if (!pushStatusExists(topic)) {
       return;
     }
-    LOGGER.info(
-        "Start batch update replica status for topic: {}, partition: {} in cluster: {}.",
-        topic,
-        partitionId,
-        clusterName);
+    String replicaId = Utils.getReplicaId(topic, partitionId);
+    LOGGER.info("Start batch update replica status for replica: {} in cluster: {}.", replicaId, clusterName);
     HelixUtils.compareAndUpdate(partitionStatusAccessor, getPartitionStatusPath(topic, partitionId), currentData -> {
       if (currentData == null) {
         currentData = new PartitionStatus(partitionId);
@@ -331,9 +321,8 @@ public class VeniceOfflinePushMonitorAccessor implements OfflinePushAccessor {
       return currentData;
     });
     LOGGER.info(
-        "Updated replica status for topic: {} partition: {}, EOIP for incremental push versions: {} in cluster: {}.",
-        topic,
-        partitionId,
+        "Updated replica status for replica: {}, EOIP for incremental push versions: {} in cluster: {}",
+        replicaId,
         incPushBatchStatus,
         clusterName);
   }
@@ -381,8 +370,8 @@ public class VeniceOfflinePushMonitorAccessor implements OfflinePushAccessor {
   protected PartitionStatus getPartitionStatus(String topic, int partitionId) {
     PartitionStatus partitionStatus =
         partitionStatusAccessor.get(getPartitionStatusPath(topic, partitionId), null, AccessOption.PERSISTENT);
-    LOGGER
-        .debug("Read partition status for topic: {} in partition: {} in cluster: {}.", topic, partitionId, clusterName);
+    String replicaId = Utils.getReplicaId(topic, partitionId);
+    LOGGER.debug("Read partition status for replica: {} in cluster: {}.", replicaId, clusterName);
     return partitionStatus;
   }
 

--- a/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/api/PubSubProducerAdapterConcurrentDelegator.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/api/PubSubProducerAdapterConcurrentDelegator.java
@@ -8,6 +8,7 @@ import com.linkedin.venice.memory.InstanceSizeEstimator;
 import com.linkedin.venice.memory.Measurable;
 import com.linkedin.venice.message.KafkaKey;
 import com.linkedin.venice.utils.DaemonThreadFactory;
+import com.linkedin.venice.utils.Utils;
 import com.linkedin.venice.utils.collections.MemoryBoundBlockingQueue;
 import com.linkedin.venice.utils.concurrent.VeniceConcurrentHashMap;
 import it.unimi.dsi.fastutil.objects.Object2DoubleMap;
@@ -199,9 +200,8 @@ public class PubSubProducerAdapterConcurrentDelegator implements PubSubProducerA
                 });
           } catch (Exception ex) {
             LOGGER.error(
-                "Got exception when producing record to topic: {}, partition: {} in drainer: {}",
-                node.topic,
-                node.partition,
+                "Got exception when producing record to replica: {} in drainer: {}",
+                Utils.getReplicaId(node.topic, node.partition),
                 drainerIndex,
                 ex);
             // TODO: do we need to add retry here?

--- a/internal/venice-common/src/main/java/com/linkedin/venice/pushmonitor/OfflinePushStatus.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/pushmonitor/OfflinePushStatus.java
@@ -284,10 +284,8 @@ public class OfflinePushStatus {
   public boolean hasFatalDataValidationError() {
     return partitionIdToStatus.values().stream().anyMatch(partitionStatus -> {
       if (partitionStatus.hasFatalDataValidationError()) {
-        LOGGER.warn(
-            "Fatal data validation error found in topic: {}, partition: {}",
-            kafkaTopic,
-            partitionStatus.getPartitionId());
+        String replicaId = Utils.getReplicaId(kafkaTopic, partitionStatus.getPartitionId());
+        LOGGER.warn("Fatal data validation error found in replica: {}", replicaId);
         return true;
       }
       return false;

--- a/internal/venice-common/src/main/java/com/linkedin/venice/utils/Utils.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/utils/Utils.java
@@ -1151,6 +1151,10 @@ public class Utils {
     return orig.replace('.', '_');
   }
 
+  public static String getReplicaId(String storeName, int version, int partition) {
+    return getReplicaId(Version.composeKafkaTopic(storeName, version), partition);
+  }
+
   /**
    * Standard logging format for TopicPartition
    */

--- a/services/venice-controller/src/main/java/com/linkedin/venice/pushmonitor/AbstractPushMonitor.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/pushmonitor/AbstractPushMonitor.java
@@ -824,11 +824,8 @@ public abstract class AbstractPushMonitor
 
       @Override
       public void disableReplica(String instance, int partitionId) {
-        LOGGER.warn(
-            "Disabling errored out leader replica of {} partition: {} on host {}",
-            kafkaTopic,
-            partitionId,
-            instance);
+        String replicaId = Utils.getReplicaId(kafkaTopic, partitionId);
+        LOGGER.warn("Disabling errored out leader replica: {} on host {}", replicaId, instance);
         helixAdminClient.enablePartition(
             false,
             clusterName,

--- a/services/venice-router/src/main/java/com/linkedin/venice/router/MetaDataHandler.java
+++ b/services/venice-router/src/main/java/com/linkedin/venice/router/MetaDataHandler.java
@@ -588,22 +588,17 @@ public class MetaDataHandler extends SimpleChannelInboundHandler<HttpRequest> {
       partitionStatusFuture.whenComplete((partitionLevelInstances, partitionThrowable) -> {
         try {
           // case 1: partition level throw exception, then query at version level.
+          String replicaId = Utils.getReplicaId(storeName, versionInt, partitionInt);
           if (partitionThrowable != null) {
             LOGGER.error(
-                "Failed to get partition status for store: {} version: {} partition: {}, will try version-level",
-                storeName,
-                storeVersion,
-                storePartition,
+                "Failed to get partition status for replica: {}, will try version-level",
+                replicaId,
                 partitionThrowable);
 
             queryVersionLevelPushStatus(ctx, storeName, storeVersion, storePartition, versionInt, partitionInt);
           } else if (partitionLevelInstances == null || partitionLevelInstances.isEmpty()) {
             // case 2: partition level return empty/null instances, then query at version level.
-            LOGGER.info(
-                "No partition instances found for store: {} version: {} partition: {}, will try version-level",
-                storeName,
-                storeVersion,
-                storePartition);
+            LOGGER.info("No partition instances found for replica: {}, will try version-level", replicaId);
 
             queryVersionLevelPushStatus(ctx, storeName, storeVersion, storePartition, versionInt, partitionInt);
           } else {
@@ -641,6 +636,7 @@ public class MetaDataHandler extends SimpleChannelInboundHandler<HttpRequest> {
       Map<CharSequence, Integer> instances,
       boolean isVersionLevelPushReportResult) throws Exception {
     String pushReportLevelType = isVersionLevelPushReportResult ? "version" : "partition";
+    String replicaId = Utils.getReplicaId(storeName, Integer.parseInt(storeVersion), Integer.parseInt(storePartition));
 
     BlobPeersDiscoveryResponse response = new BlobPeersDiscoveryResponse();
 
@@ -653,18 +649,14 @@ public class MetaDataHandler extends SimpleChannelInboundHandler<HttpRequest> {
 
     if (!readyToServeNodeHostNames.isEmpty()) {
       LOGGER.info(
-          "{} ready to serve nodes were found for store {} version {} partition {} from {} level push report",
+          "{} ready to serve nodes were found for replica: {} from {} level push report",
           readyToServeNodeHostNames.size(),
-          storeName,
-          storeVersion,
-          storePartition,
+          replicaId,
           pushReportLevelType);
     } else {
       LOGGER.info(
-          "No ready to serve nodes found for store: {} version: {} partition: {} from {} level push report",
-          storeName,
-          storeVersion,
-          storePartition,
+          "No ready to serve nodes found for replica: {} from {} level push report",
+          replicaId,
           pushReportLevelType);
     }
 
@@ -692,15 +684,11 @@ public class MetaDataHandler extends SimpleChannelInboundHandler<HttpRequest> {
             Optional.empty(),
             true);
 
+    String replicaId = Utils.getReplicaId(storeName, versionInt, partitionInt);
     versionStatusFuture.whenComplete((versionLevelInstances, throwable) -> {
       try {
         if (throwable != null) {
-          LOGGER.error(
-              "Failed to get version status for store: {} version: {} partition: {}",
-              storeName,
-              storeVersion,
-              storePartition,
-              throwable);
+          LOGGER.error("Failed to get version status for replica: {}", replicaId, throwable);
 
           byte[] errBody =
               (String.format(REQUEST_BLOB_DISCOVERY_ERROR_PUSH_STORE, storeName, storeVersion, storePartition))


### PR DESCRIPTION
<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat], [protocol]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## Problem Statement
<!--
Describe
- What problem are you trying to solve
- What issues or limitations exist in the current code
- Why this change is necessary 
-->
Continuing the effort from #989, standardized logging of `store name` + `version` + `partition` as replica. This will make searching through logs easier as the partition won't be separate from the `store` + `version`.

## Solution
<!--
Describe
- What changes you are making and why. 
- How these changes solve the problem.
- Any performance considerations or trade-offs. 
- Describe what testings you have done, for example, performance testing etc.
-->
Asked Windsurf to refactor and make these changes. Also asked it to address review comments, push changes, and reply to the comments.

###  Code changes
- [X] Introduced new **log lines**. 
  - [X] Confirmed if logs need to be **rate limited** to avoid excessive logging.

###  **Concurrency-Specific Checks**
Both reviewer and PR author to verify
- [X] Code has **no race conditions** or **thread safety issues**.
- [X] Proper **synchronization mechanisms** (e.g., `synchronized`, `RWLock`) are used where needed.
- [X] No **blocking calls** inside critical sections that could lead to deadlocks or performance degradation.
- [X] Verified **thread-safe collections** are used (e.g., `ConcurrentHashMap`, `CopyOnWriteArrayList`).
- [X] Validated proper exception handling in multi-threaded code to avoid silent thread termination.

## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
```mint build```

## Does this PR introduce any user-facing or breaking changes?
<!--  
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [X] Yes. Clearly explain the behavior change and its impact.
Many existing log messages were modified, so anything relying on the previous log message will be breaking.