### PR TITLE
[server] [dvc] Noisy Log Removal

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/store/rocksdb/RocksDBServerConfig.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/store/rocksdb/RocksDBServerConfig.java
@@ -460,9 +460,6 @@ public class RocksDBServerConfig {
      *  https://github.com/facebook/rocksdb/wiki/BlobDB
      */
     this.blobFilesEnabled = props.getBoolean(ROCKSDB_BLOB_FILES_ENABLED, false);
-    if (this.blobFilesEnabled) {
-      LOGGER.info("RocksDB Blob files feature is enabled");
-    }
     this.minBlobSizeInBytes = props.getSizeInBytes(ROCKSDB_MIN_BLOB_SIZE_IN_BYTES, 4 * 1024); // default: 4KB
     this.blobFileSizeInBytes = props.getSizeInBytes(ROCKSDB_BLOB_FILE_SIZE_IN_BYTES, 256 * 1024 * 1024); // default:
                                                                                                          // 256MB

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/validation/PartitionTracker.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/validation/PartitionTracker.java
@@ -909,6 +909,7 @@ public class PartitionTracker {
             .append(" }");
       }
       if (segment != null) {
+        sb.append("; unregisteredProducer: ").append(!segment.isRegistered());
         if (!CollectionUtils.isEmpty(segment.getAggregates())) {
           sb.append("; aggregates: ");
           printMap(segment.getAggregates(), sb);

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/validation/PartitionTracker.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/validation/PartitionTracker.java
@@ -437,7 +437,7 @@ public class PartitionTracker {
     if (endOfPushReceived && tolerateAnyMessageType) {
       String errorMsgIdentifier = consumerRecord.getTopicPartition() + "-" + DataFaultType.UNREGISTERED_PRODUCER;
       if (!REDUNDANT_LOGGING_FILTER.isRedundantException(errorMsgIdentifier)) {
-        logger.warn("Will {}, endOfPushReceived=true, tolerateAnyMessageType=true", scenario);
+        logger.debug("Will {}, endOfPushReceived=true, tolerateAnyMessageType=true", scenario);
       }
     } else {
       throw DataFaultType.UNREGISTERED_PRODUCER.getNewException(

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTaskTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTaskTest.java
@@ -4837,6 +4837,7 @@ public abstract class StoreIngestionTaskTest {
     when(storeIngestionTask.getIsRunning()).thenReturn(result);
     doCallRealMethod().when(storeIngestionTask).close();
     doCallRealMethod().when(storeIngestionTask).isRunning();
+    doCallRealMethod().when(storeIngestionTask).isIdleOverThreshold();
 
     // Case 1: idle time pass, close(), then startConsumption(), SIT should be closed
     when(storeIngestionTask.getMaxIdleCounter()).thenReturn(10);

--- a/internal/alpini/netty4/alpini-netty4-base/src/main/java/com/linkedin/alpini/netty4/http2/SSLContextBuilder.java
+++ b/internal/alpini/netty4/alpini-netty4-base/src/main/java/com/linkedin/alpini/netty4/http2/SSLContextBuilder.java
@@ -606,8 +606,6 @@ public final class SSLContextBuilder {
     final TrustManagerFactory trustFact = TrustManagerFactory.getInstance(DEFAULT_ALGORITHM);
     trustFact.init(trustStore);
 
-    LOG.info("setupContext provider={} sslContextProvider={}", provider, sslContextProvider);
-
     return builder -> builder.apply(kmf)
         .sslProvider(provider)
         .sslContextProvider(sslContextProvider)

--- a/internal/alpini/netty4/alpini-netty4-base/src/main/java/com/linkedin/alpini/netty4/ssl/SslInitializer.java
+++ b/internal/alpini/netty4/alpini-netty4-base/src/main/java/com/linkedin/alpini/netty4/ssl/SslInitializer.java
@@ -137,11 +137,6 @@ public class SslInitializer extends ChannelInitializer<Channel> {
     if (_sslEnabled) {
       _sslFactory = sslFactory;
       SSLSessionContext sessionContext = _sslFactory.sessionContext(true);
-      LOG.info(
-          "factory={} sessionTimeout={} sessionCacheSize={}",
-          _sslFactory,
-          sessionContext.getSessionTimeout(),
-          sessionContext.getSessionCacheSize());
       _postHandshakeHandler = postHandshakeHandler;
     } else {
       _sslFactory = null;

--- a/services/venice-server/src/main/java/com/linkedin/venice/listener/VeniceHttp2PipelineInitializerBuilder.java
+++ b/services/venice-server/src/main/java/com/linkedin/venice/listener/VeniceHttp2PipelineInitializerBuilder.java
@@ -26,7 +26,7 @@ public class VeniceHttp2PipelineInitializerBuilder {
 
   private static final ActiveStreamsCountHandler ACTIVE_STREAMS_COUNT_HANDLER = new ActiveStreamsCountHandler();
   private static final Http2SettingsFrameLogger HTTP2_SETTINGS_FRAME_LOGGER =
-      new Http2SettingsFrameLogger(LogLevel.INFO);
+      new Http2SettingsFrameLogger(LogLevel.WARN);
 
   public VeniceHttp2PipelineInitializerBuilder(VeniceServerConfig serverConfig) {
     this.serverConfig = serverConfig;


### PR DESCRIPTION
<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat], [protocol]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## Summary
<!--
Describe
- What problem are you trying to solve
- What issues or limitations exist in the current code
- Why this change is necessary 
-->

Some logs to consider removing as a stretch goal. 🤷

### Unregistered Producer in DataIntegrityValidator
```
PartitionTracker(topic: StoreName_v10, partition: 739) Will initialize new segment with a non-START_OF_SEGMENT message, endOfPushReceived=true, tolerateAnyMessageType=true
```

* Removed the warning log in `handleUnregisteredProducer()` if the segment can be initialized without `START_OF_SEGMENT`.
* This log message is very noisy at **250M+ logs / day** and does not provide much value other than being possibly indicative of a problem.
* To compensate, whether the segment was registered is included in the actual error when the actual error is reported.

### Not Subscribed Message

```
StoreIngestionTask SIT-StoreName_v928 Not subscribed to any partitions
StoreIngestionTask SIT-StoreName_v928 Going back to sleep as consumption has finished and topics are unsubscribed
```

* Removed the log message when a `StoreIngestionTask` is not subscribed to any partitions, and when it goes back to sleep after consumption finishes and topics are unsubscribed.
* This can be extremely frequent at **600M+ logs / day**, combined, and in a 15 minute window on 1 host on 1 thread and 1 replica, it logged 20 times. It flips back and forth too frequently, so I feel we would be better off without them.

### Http2Framelogger
They look like connection logs, and are **100M+ logs / day**.

### SSL Factory Initializer & Context
```
factory={factoryName} sessionTimeout=86400 sessionCacheSize=20480
setupContext provider=JDK sslContextProvider=null
```
**50M+ logs / day**, combined, just logging the same `sessionTimeout` and `sessionCacheSize` and `setupContext`.

### RocksDB Blob Feature
```
RocksDB Blob files feature is enabled
```
* **3M logs / day** and all it does is inform us that a feature is enabled.

###  Code changes
- [X] ~~Introduced new **log lines**.~~
  - [X] Removed old log lines. 😘

###  **Concurrency-Specific Checks**
Both reviewer and PR author to verify
- [X] Code has **no race conditions** or **thread safety issues**.
- [X] Proper **synchronization mechanisms** (e.g., `synchronized`, `RWLock`) are used where needed.
- [X] No **blocking calls** inside critical sections that could lead to deadlocks or performance degradation.
- [X] Verified **thread-safe collections** are used (e.g., `ConcurrentHashMap`, `CopyOnWriteArrayList`).
- [X] Validated proper exception handling in multi-threaded code to avoid silent thread termination.

## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
CI

## Does this PR introduce any user-facing or breaking changes?
<!--  
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [X] Yes. Clearly explain the behavior change and its impact.
Many old log messages removed. Anything relying on the old messages will break.