### PR TITLE
[server][ci][build] Replace offsetForTime with getPositionByTimestamp API

### DIFF
--- a/.github/workflows/VeniceCI-E2ETests.yml
+++ b/.github/workflows/VeniceCI-E2ETests.yml
@@ -2147,103 +2147,6 @@ jobs:
           key: ${{ secrets.BUILDPULSE_ACCESS_KEY_ID }}
           secret: ${{ secrets.BUILDPULSE_SECRET_ACCESS_KEY }}
 
-  IntegrationTests_23:
-    name: IntegrationTests_23
-    strategy:
-      fail-fast: false
-    runs-on: ubuntu-latest
-    permissions:
-     id-token: write
-     contents: read
-     checks: write
-     pull-requests: write
-     issues: write
-    timeout-minutes: 30
-    concurrency:
-     group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-jdk17-IntegrationTests_23
-     cancel-in-progress: ${{ github.event_name == 'pull_request' }}
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-      - name: Set up JDK
-        uses: actions/setup-java@v4
-        with:
-          java-version: 17
-          distribution: 'temurin'
-          cache: 'gradle'
-      - shell: bash
-        run: |
-          git remote set-head origin --auto
-          git remote add upstream https://github.com/linkedin/venice
-          git fetch upstream
-      - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v4
-        with:
-          add-job-summary: never
-      - name: Free up disk space in the background
-        run: |
-          bash scripts/ci/util_free_space.sh > background_cleanup.log 2>&1 &
-      - name: Run Integration Tests
-        run: ./gradlew --continue --no-daemon -DforkEvery=1 -DmaxParallelForks=1 integrationTests_23
-      - name: Package Build Artifacts
-        if: always()
-        shell: bash
-        run: |
-          mkdir ${{ github.job }}-artifacts
-          echo "Repository owner: ${{ github.repository_owner }}"
-          echo "Repository name: ${{ github.repository }}"
-          echo "event name: ${{ github.event_name }}"
-          find . -path "**/build/reports/*" -or -path "**/build/test-results/*" > artifacts.list
-          find . -type f \( -name 'core.*' -o -name 'hs_err_pid*.log' \) -exec xz -9 {} \; -exec echo "{}.xz" \; >> artifacts.list
-          rsync -R --files-from=artifacts.list . ${{ github.job }}-artifacts
-          tar -zcvf ${{ github.job }}-jdk17-logs.tar.gz ${{ github.job }}-artifacts
-      - name: Generate Fork Repo Test Reports
-        if: ${{ (github.repository_owner != 'linkedin') && (success() || failure()) }}
-        uses: dorny/test-reporter@v1.9.1
-        env:
-         NODE_OPTIONS: --max-old-space-size=9182
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          name: ${{ github.job }} Test Reports       # Name where it report the test results
-          path: '**/TEST-*.xml'
-          fail-on-error: 'false'
-          max-annotations: '10'
-          list-tests: 'all'
-          list-suites: 'all'
-          reporter: java-junit
-      - name: Publish Test Report
-        continue-on-error: true
-        env:
-          NODE_OPTIONS: "--max_old_space_size=8192"
-        uses: mikepenz/action-junit-report@v5
-        if: always()
-        with:
-          check_name: ${{ github.job }}-jdk17 Report
-          comment: false
-          annotate_only: true
-          flaky_summary: true
-          commit: ${{github.event.workflow_run.head_sha}}
-          detailed_summary: true
-          report_paths: '**/build/test-results/test/TEST-*.xml'
-      - name: Upload Build Artifacts
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: ${{ github.job }}
-          path: ${{ github.job }}-jdk17-logs.tar.gz
-          retention-days: 30
-      - name: Upload test results to BuildPulse for flaky test detection
-        if: ${{ !cancelled() }}
-        uses: buildpulse/buildpulse-action@main
-        with:
-          account: 357098
-          repository: 349172057
-          path: |
-            **/TEST-*.xml
-          key: ${{ secrets.BUILDPULSE_ACCESS_KEY_ID }}
-          secret: ${{ secrets.BUILDPULSE_SECRET_ACCESS_KEY }}
-
   integrationTests_99:
     name: integrationTests_99
     strategy:
@@ -2347,7 +2250,7 @@ jobs:
     strategy:
       fail-fast: false
     runs-on: ubuntu-latest
-    needs: [IntegrationTests_1, IntegrationTests_2, IntegrationTests_3, IntegrationTests_4, IntegrationTests_5, IntegrationTests_6, IntegrationTests_7, IntegrationTests_8, IntegrationTests_9, IntegrationTests_10, IntegrationTests_11, IntegrationTests_12, IntegrationTests_13, IntegrationTests_14, IntegrationTests_15, IntegrationTests_16, IntegrationTests_17, IntegrationTests_18, IntegrationTests_19, IntegrationTests_20, IntegrationTests_21, IntegrationTests_22, IntegrationTests_23, integrationTests_99]
+    needs: [IntegrationTests_1, IntegrationTests_2, IntegrationTests_3, IntegrationTests_4, IntegrationTests_5, IntegrationTests_6, IntegrationTests_7, IntegrationTests_8, IntegrationTests_9, IntegrationTests_10, IntegrationTests_11, IntegrationTests_12, IntegrationTests_13, IntegrationTests_14, IntegrationTests_15, IntegrationTests_16, IntegrationTests_17, IntegrationTests_18, IntegrationTests_19, IntegrationTests_20, IntegrationTests_21, IntegrationTests_22, integrationTests_99]
     timeout-minutes: 20
     if: ${{ cancelled() || contains(needs.*.result, 'cancelled') || contains(needs.*.result, 'failure') }}
     steps:

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/ActiveActiveStoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/ActiveActiveStoreIngestionTask.java
@@ -951,109 +951,129 @@ public class ActiveActiveStoreIngestionTask extends LeaderFollowerStoreIngestion
     }
   }
 
+  /**
+   * Calculates real-time start positions for each PubSub broker during a topic switch in Active-Active replication.
+   *
+   * <p>For each broker, determines the appropriate starting position by either using the latest processed position
+   * or rewinding to a specific timestamp. Handles broker failures gracefully by adding unreachable brokers to a
+   * repair queue and requires a quorum of reachable brokers to proceed.</p>
+   *
+   * @param pcs the partition consumption state containing topic switch information
+   * @param newSourceTopic the new real-time topic to switch to
+   * @param unreachableBrokerList output list populated with brokers that couldn't be contacted
+   * @return map of PubSub broker addresses to their calculated start positions
+   * @throws VeniceException if no topic switch is configured or insufficient brokers are reachable
+   */
   @Override
-  protected Map<String, PubSubPosition> calculateLeaderUpstreamOffsetWithTopicSwitch(
-      PartitionConsumptionState partitionConsumptionState,
+  protected Map<String, PubSubPosition> calculateRtConsumptionStartPositions(
+      PartitionConsumptionState pcs,
       PubSubTopic newSourceTopic,
       List<CharSequence> unreachableBrokerList) {
-    TopicSwitch topicSwitch = partitionConsumptionState.getTopicSwitch().getTopicSwitch();
+    TopicSwitch topicSwitch = pcs.getTopicSwitch().getTopicSwitch();
     if (topicSwitch == null) {
       throw new VeniceException(
           "New leader does not have topic switch, unable to switch to realtime leader topic: " + newSourceTopic);
     }
-    final PubSubTopicPartition sourceTopicPartition = partitionConsumptionState.getSourceTopicPartition(newSourceTopic);
+    final PubSubTopicPartition sourceTopicPartition = pcs.getSourceTopicPartition(newSourceTopic);
     long rewindStartTimestamp;
     // calculate the rewind start time here if controller asked to do so by using this sentinel value.
     if (topicSwitch.rewindStartTimestamp == REWIND_TIME_DECIDED_BY_SERVER) {
-      rewindStartTimestamp = calculateRewindStartTime(partitionConsumptionState);
+      rewindStartTimestamp = calculateRewindStartTime(pcs);
       LOGGER.info(
           "{} leader calculated rewindStartTimestamp: {} for topic-partition: {}",
-          partitionConsumptionState.getReplicaId(),
+          pcs.getReplicaId(),
           rewindStartTimestamp,
           sourceTopicPartition);
     } else {
       rewindStartTimestamp = topicSwitch.rewindStartTimestamp;
     }
-    Set<String> sourceKafkaServers = getKafkaUrlSetFromTopicSwitch(partitionConsumptionState.getTopicSwitch());
-    Map<String, PubSubPosition> rtPositionsByPubSubAddress = new HashMap<>(sourceKafkaServers.size());
-    sourceKafkaServers.forEach(sourceKafkaURL -> {
-      PubSubPosition rtStartPosition = partitionConsumptionState.getLatestProcessedRtPosition(sourceKafkaURL);
+    Set<String> rtPubSubAddresses = getPubSubBrokerAddressesFromTopicSwitch(pcs.getTopicSwitch());
+    Map<String, PubSubPosition> rtPositionsByPubSubAddress = new HashMap<>(rtPubSubAddresses.size());
+    rtPubSubAddresses.forEach(pubSubAddress -> {
+      // Get the latest processed position for this PubSub address.
+      PubSubPosition rtStartPosition = pcs.getLatestProcessedRtPosition(pubSubAddress);
+
+      // If the latest processed position is at the earliest point, it means we haven't consumed
+      // from the RT topic of this PubSub address before. In that case, we rewind to the timestamp specified
+      // in the TopicSwitch (if rewindStartTimestamp > 0); otherwise, we start from the beginning of the topic.
       if (PubSubSymbolicPosition.EARLIEST.equals(rtStartPosition)) {
         if (rewindStartTimestamp > 0) {
+          LOGGER.info(
+              "{} needs to rewind to timestamp: {} for source URL: {}, topic-partition: {} since no prior position found",
+              pcs.getReplicaId(),
+              rewindStartTimestamp,
+              pubSubAddress,
+              sourceTopicPartition);
           PubSubTopicPartition newSourceTopicPartition =
-              resolveTopicPartitionWithKafkaURL(newSourceTopic, partitionConsumptionState, sourceKafkaURL);
+              resolveRtTopicPartitionWithPubSubBrokerAddress(newSourceTopic, pcs, pubSubAddress);
           try {
             rtStartPosition =
-                getTopicPartitionOffsetByKafkaURL(sourceKafkaURL, newSourceTopicPartition, rewindStartTimestamp);
+                getRewindStartPositionForRealTimeTopic(pubSubAddress, newSourceTopicPartition, rewindStartTimestamp);
             LOGGER.info(
                 "{} get rtStartPosition: {} for source URL: {}, topic-partition: {}, rewind timestamp: {}",
-                partitionConsumptionState.getReplicaId(),
+                pcs.getReplicaId(),
                 rtStartPosition,
-                sourceKafkaURL,
+                pubSubAddress,
                 newSourceTopicPartition,
                 rewindStartTimestamp);
-            rtPositionsByPubSubAddress.put(sourceKafkaURL, rtStartPosition);
+            rtPositionsByPubSubAddress.put(pubSubAddress, rtStartPosition);
           } catch (Exception e) {
             /**
              * This is actually tricky. Potentially we could return a -1 value here, but this has the gotcha that if we
              * have a non-symmetrical failure (like, region1 can't talk to the region2 broker) this will result in a remote
-             * colo rewinding to a potentially non-deterministic offset when the remote becomes available again. So
+             * colo rewinding to a potentially non-deterministic position when the remote becomes available again. So
              * instead, we record the context of this call and commit it to a repair queue to rewind to a
              * consistent place on the RT
              *
              * NOTE: It is possible that the outage is so long and the rewind so large that we fall off retention. If
              * this happens we can detect and repair the inconsistency from the offline DCR validator.
              */
-            unreachableBrokerList.add(sourceKafkaURL);
+            unreachableBrokerList.add(pubSubAddress);
             rtStartPosition = PubSubSymbolicPosition.EARLIEST;
             LOGGER.error(
-                "Failed contacting {}/{} when processing topic switch for replica {}. Setting upstream start offset to {}",
-                sourceKafkaURL,
+                "Failed contacting {}/{} when processing topic switch for replica {}. Setting upstream start position to {}",
+                pubSubAddress,
                 sourceTopicPartition,
-                partitionConsumptionState.getReplicaId(),
+                pcs.getReplicaId(),
                 rtStartPosition);
             hostLevelIngestionStats.recordIngestionFailure();
             /**
              *  Add to repair queue. We won't attempt to resubscribe for brokers we couldn't compute an upstream offset
-             *  accurately for. We will not persist the wrong offset into OffsetRecord, we'll reattempt subscription later.
+             *  accurately for. We will not persist the wrong position into OffsetRecord, we'll reattempt subscription later.
              */
             if (remoteIngestionRepairService != null) {
               this.remoteIngestionRepairService.registerRepairTask(
                   this,
-                  buildRepairTask(
-                      sourceKafkaURL,
-                      sourceTopicPartition,
-                      rewindStartTimestamp,
-                      partitionConsumptionState));
+                  buildRepairTask(pubSubAddress, sourceTopicPartition, rewindStartTimestamp, pcs));
             } else {
               // If there isn't an available repair service, then we need to abort in order to make sure the error is
               // propagated up
               throw new VeniceException(
                   String.format(
-                      "Failed contacting (%s/%s) and no repair service available!  Aborting topic switch processing for %s. Setting upstream start offset to %s",
-                      sourceKafkaURL,
+                      "Failed contacting (%s/%s) and no repair service available. Aborting topic switch processing for %s. Setting upstream start position to %s",
+                      pubSubAddress,
                       sourceTopicPartition,
-                      partitionConsumptionState.getReplicaId(),
+                      pcs.getReplicaId(),
                       rtStartPosition));
             }
           }
         } else {
           LOGGER.warn(
               "Got unexpected rewind time: {} for: {}/{}, will start ingesting upstream from the beginning for replica: {}",
-              sourceKafkaURL,
+              pubSubAddress,
               sourceTopicPartition,
               rewindStartTimestamp,
-              partitionConsumptionState.getReplicaId());
+              pcs.getReplicaId());
           rtStartPosition = PubSubSymbolicPosition.EARLIEST;
-          rtPositionsByPubSubAddress.put(sourceKafkaURL, rtStartPosition);
+          rtPositionsByPubSubAddress.put(pubSubAddress, rtStartPosition);
         }
       } else {
-        rtPositionsByPubSubAddress.put(sourceKafkaURL, rtStartPosition);
+        rtPositionsByPubSubAddress.put(pubSubAddress, rtStartPosition);
       }
     });
-    if (unreachableBrokerList.size() >= ((sourceKafkaServers.size() + 1) / 2)) {
+    if (unreachableBrokerList.size() >= ((rtPubSubAddresses.size() + 1) / 2)) {
       // We couldn't reach a quorum of brokers and that's a red flag, so throw exception and abort!
-      throw new VeniceException("Couldn't reach any broker!!  Aborting topic switch triggered consumer subscription!");
+      throw new VeniceException("Couldn't reach any broker!! Aborting topic switch triggered consumer subscription!");
     }
     return rtPositionsByPubSubAddress;
   }
@@ -1075,7 +1095,7 @@ public class ActiveActiveStoreIngestionTask extends LeaderFollowerStoreIngestion
           .info("{} enabled remote consumption from topic {} partition {}", ingestionTaskName, leaderTopic, partition);
     }
     partitionConsumptionState.setLeaderFollowerState(LEADER);
-    prepareOffsetCheckpointAndStartConsumptionAsLeader(leaderTopic, partitionConsumptionState, true);
+    preparePositionCheckpointAndStartRtConsumptionAsLeader(leaderTopic, partitionConsumptionState, true);
   }
 
   /**
@@ -1142,7 +1162,7 @@ public class ActiveActiveStoreIngestionTask extends LeaderFollowerStoreIngestion
     // Update leader topic.
     partitionConsumptionState.getOffsetRecord().setLeaderTopic(newSourceTopic);
     // Calculate leader offset and start consumption
-    prepareOffsetCheckpointAndStartConsumptionAsLeader(newSourceTopic, partitionConsumptionState, false);
+    preparePositionCheckpointAndStartRtConsumptionAsLeader(newSourceTopic, partitionConsumptionState, false);
   }
 
   /**
@@ -1371,10 +1391,11 @@ public class ActiveActiveStoreIngestionTask extends LeaderFollowerStoreIngestion
       PartitionConsumptionState pcs) {
     return () -> {
       PubSubTopic pubSubTopic = sourceTopicPartition.getPubSubTopic();
-      PubSubTopicPartition resolvedTopicPartition = resolveTopicPartitionWithKafkaURL(pubSubTopic, pcs, sourceKafkaUrl);
+      PubSubTopicPartition resolvedTopicPartition =
+          resolveRtTopicPartitionWithPubSubBrokerAddress(pubSubTopic, pcs, sourceKafkaUrl);
       // Calculate upstream offset
       PubSubPosition upstreamOffset =
-          getTopicPartitionOffsetByKafkaURL(sourceKafkaUrl, resolvedTopicPartition, rewindStartTimestamp);
+          getRewindStartPositionForRealTimeTopic(sourceKafkaUrl, resolvedTopicPartition, rewindStartTimestamp);
       // Subscribe (unsubscribe should have processed correctly regardless of remote broker state)
       consumerSubscribe(pubSubTopic, pcs, upstreamOffset, sourceKafkaUrl);
       // syncConsumedUpstreamRTOffsetMapIfNeeded
@@ -1443,43 +1464,48 @@ public class ActiveActiveStoreIngestionTask extends LeaderFollowerStoreIngestion
         beforeProcessingRecordTimestampNs);
   }
 
+  /**
+   * Initializes leader consumption from real-time topics across multiple upstream brokers.
+   * Retrieves or calculates starting positions for each broker, handles topic switching
+   * for missing positions, and subscribes to all upstream sources.
+   *
+   * @param leaderTopic the leader topic to consume from
+   * @param pcs the partition consumption state
+   * @param isTransition true if this is a leader transition, false for initial setup
+   */
   @Override
-  void prepareOffsetCheckpointAndStartConsumptionAsLeader(
+  void preparePositionCheckpointAndStartRtConsumptionAsLeader(
       PubSubTopic leaderTopic,
-      PartitionConsumptionState partitionConsumptionState,
+      PartitionConsumptionState pcs,
       boolean isTransition) {
-    Set<String> leaderSourceKafkaURLs = getConsumptionSourceKafkaAddress(partitionConsumptionState);
-    Map<String, PubSubPosition> leaderOffsetByKafkaURL = new HashMap<>(leaderSourceKafkaURLs.size());
-    List<CharSequence> unreachableBrokerList = new ArrayList<>();
+    Set<String> leaderSourceBrokerAddresses = getConsumptionSourceKafkaAddress(pcs);
+    Map<String, PubSubPosition> rtPositionsByBroker = new HashMap<>(leaderSourceBrokerAddresses.size());
+    List<CharSequence> unreachableBrokers = new ArrayList<>();
     boolean shouldUseDivRtPosition = isTransition && isGlobalRtDivEnabled();
     // Read previously checkpointed offset and maybe fallback to TopicSwitch if any of upstream offset is missing.
-    for (String kafkaURL: leaderSourceKafkaURLs) {
-      leaderOffsetByKafkaURL
-          .put(kafkaURL, partitionConsumptionState.getLeaderPosition(kafkaURL, shouldUseDivRtPosition));
+    for (String broker: leaderSourceBrokerAddresses) {
+      rtPositionsByBroker.put(broker, pcs.getLeaderPosition(broker, shouldUseDivRtPosition));
     }
-    if (leaderTopic.isRealTime() && leaderOffsetByKafkaURL.containsValue(PubSubSymbolicPosition.EARLIEST)) {
-      leaderOffsetByKafkaURL =
-          calculateLeaderUpstreamOffsetWithTopicSwitch(partitionConsumptionState, leaderTopic, unreachableBrokerList);
+    if (leaderTopic.isRealTime() && rtPositionsByBroker.containsValue(PubSubSymbolicPosition.EARLIEST)) {
+      rtPositionsByBroker = calculateRtConsumptionStartPositions(pcs, leaderTopic, unreachableBrokers);
     }
-
-    if (!unreachableBrokerList.isEmpty()) {
+    if (!unreachableBrokers.isEmpty()) {
       LOGGER.warn(
-          "Failed to reach broker urls {}, will schedule retry to compute upstream offset and resubscribe!",
-          unreachableBrokerList.toString());
+          "Failed to reach broker urls: {}, will schedule retry to compute upstream position and resubscribe!",
+          unreachableBrokers);
     }
     // subscribe to the new upstream
-    leaderOffsetByKafkaURL.forEach((kafkaURL, leaderStartOffset) -> {
-      consumerSubscribe(leaderTopic, partitionConsumptionState, leaderStartOffset, kafkaURL);
+    rtPositionsByBroker.forEach((brokerAddress, rtStartPosition) -> {
+      consumerSubscribe(leaderTopic, pcs, rtStartPosition, brokerAddress);
     });
 
-    syncConsumedUpstreamRTOffsetMapIfNeeded(partitionConsumptionState, leaderOffsetByKafkaURL);
+    syncConsumedUpstreamRTOffsetMapIfNeeded(pcs, rtPositionsByBroker);
 
     LOGGER.info(
-        "{}, as a leader, started consuming from topic-partition: {} replica: {}: with offset by Kafka URL mapping: {}",
-        ingestionTaskName,
-        Utils.getReplicaId(leaderTopic, partitionConsumptionState.getPartition()),
-        partitionConsumptionState.getReplicaId(),
-        leaderOffsetByKafkaURL);
+        "Leader replica: {} started consuming from topic-partition: {} with rtPositionsByBroker: {}",
+        pcs.getReplicaId(),
+        Utils.getReplicaId(leaderTopic, pcs.getPartition()),
+        rtPositionsByBroker);
   }
 
   private long calculateRewindStartTime(PartitionConsumptionState partitionConsumptionState) {

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/ActiveActiveStoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/ActiveActiveStoreIngestionTask.java
@@ -980,7 +980,7 @@ public class ActiveActiveStoreIngestionTask extends LeaderFollowerStoreIngestion
     if (topicSwitch.rewindStartTimestamp == REWIND_TIME_DECIDED_BY_SERVER) {
       rewindStartTimestamp = calculateRewindStartTime(pcs);
       LOGGER.info(
-          "{} leader calculated rewindStartTimestamp: {} for topic-partition: {}",
+          "Leader replica: {} calculated rewind timestamp: {} for tp: {}",
           pcs.getReplicaId(),
           rewindStartTimestamp,
           sourceTopicPartition);
@@ -999,7 +999,7 @@ public class ActiveActiveStoreIngestionTask extends LeaderFollowerStoreIngestion
       if (PubSubSymbolicPosition.EARLIEST.equals(rtStartPosition)) {
         if (rewindStartTimestamp > 0) {
           LOGGER.info(
-              "{} needs to rewind to timestamp: {} for source URL: {}, topic-partition: {} since no prior position found",
+              "Leader replica: {} needs to rewind to timestamp: {} for pubSubAddress: {}, tp: {} since no prior position found",
               pcs.getReplicaId(),
               rewindStartTimestamp,
               pubSubAddress,
@@ -1010,12 +1010,12 @@ public class ActiveActiveStoreIngestionTask extends LeaderFollowerStoreIngestion
             rtStartPosition =
                 getRewindStartPositionForRealTimeTopic(pubSubAddress, newSourceTopicPartition, rewindStartTimestamp);
             LOGGER.info(
-                "{} get rtStartPosition: {} for source URL: {}, topic-partition: {}, rewind timestamp: {}",
+                "Leader replica: {} got rtPosition: {} for rewindTime: {} from pubSubAddress: {}/{}",
                 pcs.getReplicaId(),
                 rtStartPosition,
+                rewindStartTimestamp,
                 pubSubAddress,
-                newSourceTopicPartition,
-                rewindStartTimestamp);
+                newSourceTopicPartition);
             rtPositionsByPubSubAddress.put(pubSubAddress, rtStartPosition);
           } catch (Exception e) {
             /**
@@ -1031,10 +1031,10 @@ public class ActiveActiveStoreIngestionTask extends LeaderFollowerStoreIngestion
             unreachableBrokerList.add(pubSubAddress);
             rtStartPosition = PubSubSymbolicPosition.EARLIEST;
             LOGGER.error(
-                "Failed contacting {}/{} when processing topic switch for replica {}. Setting upstream start position to {}",
+                "Leader replica: {} failed contacting {}/{} when processing topic switch. Setting upstream start position to: {}",
+                pcs.getReplicaId(),
                 pubSubAddress,
                 sourceTopicPartition,
-                pcs.getReplicaId(),
                 rtStartPosition);
             hostLevelIngestionStats.recordIngestionFailure();
             /**
@@ -1059,11 +1059,11 @@ public class ActiveActiveStoreIngestionTask extends LeaderFollowerStoreIngestion
           }
         } else {
           LOGGER.warn(
-              "Got unexpected rewind time: {} for: {}/{}, will start ingesting upstream from the beginning for replica: {}",
-              pubSubAddress,
-              sourceTopicPartition,
+              "Leader replica: {} got unexpected rewind time: {} for: {}/{}, will start ingesting upstream from the beginning",
+              pcs.getReplicaId(),
               rewindStartTimestamp,
-              pcs.getReplicaId());
+              pubSubAddress,
+              sourceTopicPartition);
           rtStartPosition = PubSubSymbolicPosition.EARLIEST;
           rtPositionsByPubSubAddress.put(pubSubAddress, rtStartPosition);
         }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTask.java
@@ -910,12 +910,12 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
           newSourceTopicPartition,
           topicSwitch.rewindStartTimestamp);
       LOGGER.info(
-          "UpstreamStartPosition: {} for source URL: {}, tp: {}, rewind timestamp: {}. Replica: {}",
+          "Leader replica: {} got rtPosition: {} for rewindTime: {} from pubSubAddress: {}/{}",
+          partitionConsumptionState.getReplicaId(),
           upstreamStartPosition,
-          rtPubSubAddress,
-          Utils.getReplicaId(newSourceTopic, partitionConsumptionState.getPartition()),
           topicSwitch.rewindStartTimestamp,
-          partitionConsumptionState.getReplicaId());
+          rtPubSubAddress,
+          newSourceTopicPartition);
     }
     return Collections.singletonMap(NON_AA_REPLICATION_UPSTREAM_OFFSET_MAP_KEY, upstreamStartPosition);
   }
@@ -1091,10 +1091,6 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
       CharSequence pubSubAddress,
       PubSubTopicPartition rtTopicPartition,
       long rewindStartTimestamp) {
-    LOGGER.info(
-        "Getting rewind start position for RT topic-partition: {} at timestamp: {}",
-        rtTopicPartition,
-        rewindStartTimestamp);
     TopicManager topicManager = getTopicManager(pubSubAddress.toString());
     return topicManager.getPositionByTime(rtTopicPartition, rewindStartTimestamp);
   }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTask.java
@@ -11,6 +11,7 @@ import static com.linkedin.davinci.validation.PartitionTracker.TopicType.VERSION
 import static com.linkedin.venice.kafka.protocol.enums.ControlMessageType.END_OF_PUSH;
 import static com.linkedin.venice.kafka.protocol.enums.ControlMessageType.START_OF_SEGMENT;
 import static com.linkedin.venice.kafka.protocol.enums.MessageType.UPDATE;
+import static com.linkedin.venice.offsets.OffsetRecord.NON_AA_REPLICATION_UPSTREAM_OFFSET_MAP_KEY;
 import static com.linkedin.venice.pubsub.api.PubSubMessageHeaders.VENICE_LEADER_COMPLETION_STATE_HEADER;
 import static com.linkedin.venice.writer.VeniceWriter.APP_DEFAULT_LOGICAL_TS;
 import static com.linkedin.venice.writer.VeniceWriter.DEFAULT_LEADER_METADATA_WRAPPER;
@@ -80,6 +81,7 @@ import com.linkedin.venice.pubsub.api.PubSubProducerCallback;
 import com.linkedin.venice.pubsub.api.PubSubSymbolicPosition;
 import com.linkedin.venice.pubsub.api.PubSubTopic;
 import com.linkedin.venice.pubsub.api.PubSubTopicPartition;
+import com.linkedin.venice.pubsub.manager.TopicManager;
 import com.linkedin.venice.schema.SchemaEntry;
 import com.linkedin.venice.schema.writecompute.DerivedSchemaEntry;
 import com.linkedin.venice.serialization.AvroStoreDeserializerCache;
@@ -884,7 +886,7 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
     return localVtPos.getNumericOffset() + 1 >= localVTEndOffset;
   }
 
-  protected Map<String, PubSubPosition> calculateLeaderUpstreamOffsetWithTopicSwitch(
+  protected Map<String, PubSubPosition> calculateRtConsumptionStartPositions(
       PartitionConsumptionState partitionConsumptionState,
       PubSubTopic newSourceTopic,
       List<CharSequence> unreachableBrokerList) {
@@ -897,25 +899,25 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
       throw new VeniceException(
           "New leader does not have topic switch, unable to switch to realtime leader topic: " + newSourceTopic);
     }
-    final String newSourceKafkaServer = topicSwitch.sourceKafkaServers.get(0).toString();
+    final String rtPubSubAddress = topicSwitch.sourceKafkaServers.get(0).toString();
     final PubSubTopicPartition newSourceTopicPartition =
         partitionConsumptionState.getSourceTopicPartition(newSourceTopic);
 
     PubSubPosition upstreamStartPosition = PubSubSymbolicPosition.EARLIEST;
     if (topicSwitch.rewindStartTimestamp > 0) {
-      upstreamStartPosition = getTopicPartitionOffsetByKafkaURL(
-          newSourceKafkaServer,
+      upstreamStartPosition = getRewindStartPositionForRealTimeTopic(
+          rtPubSubAddress,
           newSourceTopicPartition,
           topicSwitch.rewindStartTimestamp);
       LOGGER.info(
           "UpstreamStartPosition: {} for source URL: {}, tp: {}, rewind timestamp: {}. Replica: {}",
           upstreamStartPosition,
-          newSourceKafkaServer,
+          rtPubSubAddress,
           Utils.getReplicaId(newSourceTopic, partitionConsumptionState.getPartition()),
           topicSwitch.rewindStartTimestamp,
           partitionConsumptionState.getReplicaId());
     }
-    return Collections.singletonMap(OffsetRecord.NON_AA_REPLICATION_UPSTREAM_OFFSET_MAP_KEY, upstreamStartPosition);
+    return Collections.singletonMap(NON_AA_REPLICATION_UPSTREAM_OFFSET_MAP_KEY, upstreamStartPosition);
   }
 
   @Override
@@ -961,7 +963,7 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
     }
     partitionConsumptionState.setLeaderFollowerState(LEADER);
     final PubSubTopic leaderTopic = offsetRecord.getLeaderTopic(pubSubTopicRepository);
-    prepareOffsetCheckpointAndStartConsumptionAsLeader(leaderTopic, partitionConsumptionState, true);
+    preparePositionCheckpointAndStartRtConsumptionAsLeader(leaderTopic, partitionConsumptionState, true);
   }
 
   private boolean switchAwayFromStreamReprocessingTopic(PubSubTopic currentLeaderTopic, PubSubTopic topicSwitchTopic) {
@@ -1008,7 +1010,7 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
     }
     partitionConsumptionState.getOffsetRecord().setLeaderTopic(newSourceTopic);
 
-    prepareOffsetCheckpointAndStartConsumptionAsLeader(newSourceTopic, partitionConsumptionState, false);
+    preparePositionCheckpointAndStartRtConsumptionAsLeader(newSourceTopic, partitionConsumptionState, false);
   }
 
   /**
@@ -1017,34 +1019,30 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
    * (2) Subscribe to all the Kafka upstream.
    * (3) Potentially sync offset to PartitionConsumptionState map if needed.
    */
-  void prepareOffsetCheckpointAndStartConsumptionAsLeader(
+  void preparePositionCheckpointAndStartRtConsumptionAsLeader(
       PubSubTopic leaderTopic,
-      PartitionConsumptionState partitionConsumptionState,
+      PartitionConsumptionState pcs,
       boolean isTransition) {
-    Set<String> leaderSourceKafkaURLs = getConsumptionSourceKafkaAddress(partitionConsumptionState);
-    if (leaderSourceKafkaURLs.size() != 1) {
-      throw new VeniceException("In L/F mode, expect only one leader source Kafka URL. Got: " + leaderSourceKafkaURLs);
+    Set<String> leaderSourceBrokers = getConsumptionSourceKafkaAddress(pcs);
+    if (leaderSourceBrokers.size() != 1) {
+      throw new VeniceException(
+          "In L/F mode, expect only one leader source pubsub address. Got: " + leaderSourceBrokers);
     }
     boolean shouldUseDivRtPosition = isTransition && isGlobalRtDivEnabled();
-    PubSubPosition upstreamStartPosition = partitionConsumptionState
-        .getLeaderPosition(OffsetRecord.NON_AA_REPLICATION_UPSTREAM_OFFSET_MAP_KEY, shouldUseDivRtPosition);
-    String leaderSourceKafkaURL = leaderSourceKafkaURLs.iterator().next();
-    if (PubSubSymbolicPosition.EARLIEST.equals(upstreamStartPosition) && leaderTopic.isRealTime()) {
-      upstreamStartPosition =
-          calculateLeaderUpstreamOffsetWithTopicSwitch(partitionConsumptionState, leaderTopic, Collections.emptyList())
-              .getOrDefault(OffsetRecord.NON_AA_REPLICATION_UPSTREAM_OFFSET_MAP_KEY, PubSubSymbolicPosition.EARLIEST);
+    PubSubPosition startPos = pcs.getLeaderPosition(NON_AA_REPLICATION_UPSTREAM_OFFSET_MAP_KEY, shouldUseDivRtPosition);
+    String pubSubAddress = leaderSourceBrokers.iterator().next();
+    if (PubSubSymbolicPosition.EARLIEST.equals(startPos) && leaderTopic.isRealTime()) {
+      startPos = calculateRtConsumptionStartPositions(pcs, leaderTopic, Collections.emptyList())
+          .getOrDefault(NON_AA_REPLICATION_UPSTREAM_OFFSET_MAP_KEY, PubSubSymbolicPosition.EARLIEST);
     }
-
-    consumerSubscribe(leaderTopic, partitionConsumptionState, upstreamStartPosition, leaderSourceKafkaURL);
+    consumerSubscribe(leaderTopic, pcs, startPos, pubSubAddress);
     // TODO: clear the LCRO map in the PCS after subscribing and set the value for this brokerUrl as null?
-    syncConsumedUpstreamRTOffsetMapIfNeeded(
-        partitionConsumptionState,
-        Collections.singletonMap(leaderSourceKafkaURL, upstreamStartPosition));
+    syncConsumedUpstreamRTOffsetMapIfNeeded(pcs, Collections.singletonMap(pubSubAddress, startPos));
     LOGGER.info(
-        "{}, as a leader, started consuming from replica: {} with offset: {}",
-        partitionConsumptionState.getReplicaId(),
-        Utils.getReplicaId(leaderTopic, partitionConsumptionState.getPartition()),
-        upstreamStartPosition);
+        "Leader replica: {} started consuming: {} from: {}",
+        pcs.getReplicaId(),
+        Utils.getReplicaId(leaderTopic, pcs.getPartition()),
+        startPos);
   }
 
   protected void syncConsumedUpstreamRTOffsetMapIfNeeded(
@@ -1077,19 +1075,28 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
     }
   }
 
-  protected PubSubPosition getTopicPartitionOffsetByKafkaURL(
-      CharSequence kafkaURL,
-      PubSubTopicPartition pubSubTopicPartition,
+  /**
+   * Returns the rewind start position in the real-time topic based on the given timestamp.
+   *
+   * <p>This is used during a future version push when the system begins replaying
+   * real-time data from a configured rewind point (e.g., 24 hours in the past)
+   * into the new version topic.</p>
+   *
+   * @param pubSubAddress        the PubSub endpoint or address
+   * @param rtTopicPartition     the real-time topic partition
+   * @param rewindStartTimestamp the rewind start time (epoch ms)
+   * @return the corresponding PubSubPosition to start replaying from
+   */
+  protected PubSubPosition getRewindStartPositionForRealTimeTopic(
+      CharSequence pubSubAddress,
+      PubSubTopicPartition rtTopicPartition,
       long rewindStartTimestamp) {
-    long topicPartitionOffset =
-        getTopicManager(kafkaURL.toString()).getOffsetByTime(pubSubTopicPartition, rewindStartTimestamp);
-    /**
-     * {@link com.linkedin.venice.pubsub.manager.TopicManager#getOffsetByTime} will always
-     * return the next offset to consume, but {@link ApacheKafkaConsumer#subscribe} is always
-     * seeking the next offset, so we will deduct 1 from the returned offset here.
-     */
-    // TODO(sushantmane): We need inclusive and exclusive subscriptions
-    return PubSubUtil.fromKafkaOffset(topicPartitionOffset - 1);
+    LOGGER.info(
+        "Getting rewind start position for RT topic-partition: {} at timestamp: {}",
+        rtTopicPartition,
+        rewindStartTimestamp);
+    TopicManager topicManager = getTopicManager(pubSubAddress.toString());
+    return topicManager.getPositionByTime(rtTopicPartition, rewindStartTimestamp);
   }
 
   @Override
@@ -1119,7 +1126,7 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
     if (topicSwitchWrapper == null) {
       return Collections.emptySet();
     }
-    return getKafkaUrlSetFromTopicSwitch(topicSwitchWrapper);
+    return getPubSubBrokerAddressesFromTopicSwitch(topicSwitchWrapper);
   }
 
   /**
@@ -1513,7 +1520,7 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
         (sourceKafkaUrl, upstreamTopic) -> upstreamTopic.isRealTime()
             ? partitionConsumptionState.getLatestProcessedRtPosition(sourceKafkaUrl)
             : partitionConsumptionState.getLatestProcessedRemoteVtPosition(),
-        () -> OffsetRecord.NON_AA_REPLICATION_UPSTREAM_OFFSET_MAP_KEY,
+        () -> NON_AA_REPLICATION_UPSTREAM_OFFSET_MAP_KEY,
         dryRun);
   }
 
@@ -2829,7 +2836,7 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
   protected PubSubPosition getLatestPersistedUpstreamOffsetForHybridOffsetLagMeasurement(
       PartitionConsumptionState pcs,
       String ignoredUpstreamKafkaUrl) {
-    return pcs.getLatestProcessedRtPosition(OffsetRecord.NON_AA_REPLICATION_UPSTREAM_OFFSET_MAP_KEY);
+    return pcs.getLatestProcessedRtPosition(NON_AA_REPLICATION_UPSTREAM_OFFSET_MAP_KEY);
   }
 
   /**
@@ -2838,14 +2845,14 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
   protected PubSubPosition getLatestConsumedUpstreamOffsetForHybridOffsetLagMeasurement(
       PartitionConsumptionState pcs,
       String ignoredKafkaUrl) {
-    return pcs.getLatestConsumedRtPosition(OffsetRecord.NON_AA_REPLICATION_UPSTREAM_OFFSET_MAP_KEY);
+    return pcs.getLatestConsumedRtPosition(NON_AA_REPLICATION_UPSTREAM_OFFSET_MAP_KEY);
   }
 
   protected void updateLatestConsumedRtPositions(
       PartitionConsumptionState pcs,
       String ignoredPubSubBrokerAddress,
       PubSubPosition pubSubPosition) {
-    pcs.setLatestConsumedRtPosition(OffsetRecord.NON_AA_REPLICATION_UPSTREAM_OFFSET_MAP_KEY, pubSubPosition);
+    pcs.setLatestConsumedRtPosition(NON_AA_REPLICATION_UPSTREAM_OFFSET_MAP_KEY, pubSubPosition);
   }
 
   /**
@@ -3657,7 +3664,7 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
     PubSubTopic leaderTopic = pcs.getOffsetRecord().getLeaderTopic(pubSubTopicRepository);
     long lastOffsetInRealTimeTopic = getTopicPartitionEndOffSet(
         sourceRealTimeTopicKafkaURL,
-        resolveTopicWithKafkaURL(leaderTopic, sourceRealTimeTopicKafkaURL),
+        resolveRtTopicWithPubSubBrokerAddress(leaderTopic, sourceRealTimeTopicKafkaURL),
         partition);
 
     if (lastOffsetInRealTimeTopic < 0) {
@@ -3976,7 +3983,7 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
     LOGGER.info(
         "Leader replica: {} unsubscribe finished for future resubscribe.",
         partitionConsumptionState.getReplicaId());
-    prepareOffsetCheckpointAndStartConsumptionAsLeader(leaderTopic, partitionConsumptionState, false);
+    preparePositionCheckpointAndStartRtConsumptionAsLeader(leaderTopic, partitionConsumptionState, false);
   }
 
   protected void queueUpVersionTopicWritesWithViewWriters(
@@ -4031,7 +4038,7 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
     }
   }
 
-  Set<String> getKafkaUrlSetFromTopicSwitch(TopicSwitchWrapper topicSwitchWrapper) {
+  Set<String> getPubSubBrokerAddressesFromTopicSwitch(TopicSwitchWrapper topicSwitchWrapper) {
     if (isSeparatedRealtimeTopicEnabled()) {
       Set<String> result = new HashSet<>();
       for (String server: topicSwitchWrapper.getSourceServers()) {

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/SharedKafkaConsumer.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/SharedKafkaConsumer.java
@@ -361,21 +361,11 @@ class SharedKafkaConsumer implements PubSubConsumerAdapter {
   }
 
   @Override
-  public Long offsetForTime(PubSubTopicPartition pubSubTopicPartition, long timestamp, Duration timeout) {
-    throw new UnsupportedOperationException("offsetForTime is not supported in SharedKafkaConsumer");
-  }
-
-  @Override
   public PubSubPosition getPositionByTimestamp(
       PubSubTopicPartition pubSubTopicPartition,
       long timestamp,
       Duration timeout) {
     throw new UnsupportedOperationException("getPositionByTimestamp is not supported in SharedKafkaConsumer");
-  }
-
-  @Override
-  public Long offsetForTime(PubSubTopicPartition pubSubTopicPartition, long timestamp) {
-    throw new UnsupportedOperationException("offsetForTime is not supported in SharedKafkaConsumer");
   }
 
   @Override

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTaskTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTaskTest.java
@@ -254,6 +254,7 @@ import java.util.Queue;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -4034,7 +4035,7 @@ public abstract class StoreIngestionTaskTest {
     doReturn(PARTITION_FOO).when(mockPcs).getPartition();
     PubSubPosition p10 = InMemoryPubSubPosition.of(10L);
     storeIngestionTaskUnderTest.processTopicSwitch(controlMessage, PARTITION_FOO, p10, mockPcs);
-    verify(mockTopicManagerRemoteKafka, never()).getOffsetByTime(any(), anyLong());
+    verify(mockTopicManagerRemoteKafka, never()).getPositionByTime(any(), anyLong());
     verify(mockOffsetRecord, never()).checkpointRtPosition(anyString(), any(PubSubPosition.class));
   }
 
@@ -4147,12 +4148,17 @@ public abstract class StoreIngestionTaskTest {
     // Test alternative branch of the code
     Supplier<PartitionConsumptionState> mockPcsSupplier2 = () -> {
       PartitionConsumptionState mock = mockPcsSupplier.get();
+      doReturn(versionTopic + "-0").when(mock).getReplicaId();
       doReturn(PubSubSymbolicPosition.EARLIEST).when(mock).getLeaderPosition(anyString(), anyBoolean());
       doReturn(PubSubSymbolicPosition.EARLIEST).when(mock).getLatestProcessedRtPosition(anyString());
       doReturn(new PubSubTopicPartitionImpl(rtTopic, 0)).when(mock).getSourceTopicPartition(any());
       return mock;
     };
     mockPcs = mockPcsSupplier2.get();
+
+    when(mockTopicManagerRepository.getTopicManager("localhost")).thenReturn(mockTopicManager);
+    doReturn(PubSubSymbolicPosition.EARLIEST).when(mockTopicManager).getPositionByTime(any(), anyLong());
+
     ingestionTask.leaderExecuteTopicSwitch(mockPcs, topicSwitch, newSourceTopic);
     verify(mockPcs, never()).setLatestConsumedRtPosition(anyString(), any());
 
@@ -4225,7 +4231,8 @@ public abstract class StoreIngestionTaskTest {
     // Run the actual codes inside function "startConsumingAsLeader"
     doCallRealMethod().when(leaderFollowerStoreIngestionTask).startConsumingAsLeader(any());
 
-    doCallRealMethod().when(leaderFollowerStoreIngestionTask).resolveTopicPartitionWithKafkaURL(any(), any(), any());
+    doCallRealMethod().when(leaderFollowerStoreIngestionTask)
+        .resolveRtTopicPartitionWithPubSubBrokerAddress(any(), any(), any());
     doReturn(false).when(leaderFollowerStoreIngestionTask).shouldNewLeaderSwitchToRemoteConsumption(any());
     Set<String> kafkaServerSet = new HashSet<>();
     kafkaServerSet.add("localhost");
@@ -4262,7 +4269,8 @@ public abstract class StoreIngestionTaskTest {
 
   private Consumer<MockInMemoryPartitionPosition> getObserver(
       List<InMemoryPubSubPosition> resubscriptionOffsetForVT,
-      List<InMemoryPubSubPosition> resubscriptionOffsetForRT) {
+      List<InMemoryPubSubPosition> resubscriptionOffsetForRT,
+      CountDownLatch resubscriptionLatch) {
     return topicPartitionOffset -> {
 
       if (topicPartitionOffset == null || topicPartitionOffset.getPubSubPosition() == null) {
@@ -4276,12 +4284,14 @@ public abstract class StoreIngestionTaskTest {
             topicPartitionOffset.getPubSubPosition());
         if (pubSubTopicPartition.getPubSubTopic().isVersionTopic() && resubscriptionOffsetForVT.contains(offset)) {
           storeIngestionTaskUnderTest.setVersionRole(PartitionReplicaIngestionContext.VersionRole.BACKUP);
+          resubscriptionLatch.countDown();
           LOGGER.info(
               "Trigger re-subscription after consuming message for {} at offset {} ",
               pubSubTopicPartition,
               offset);
         } else if (pubSubTopicPartition.getPubSubTopic().isRealTime() && resubscriptionOffsetForRT.contains(offset)) {
           storeIngestionTaskUnderTest.setVersionRole(PartitionReplicaIngestionContext.VersionRole.BACKUP);
+          resubscriptionLatch.countDown();
           LOGGER.info(
               "Trigger re-subscription after consuming message for {} at offset {}.",
               pubSubTopicPartition,
@@ -4291,7 +4301,7 @@ public abstract class StoreIngestionTaskTest {
     };
   }
 
-  @Test(timeOut = 60000)
+  @Test(timeOut = 120000)
   public void testResubscribeAfterRoleChange() throws Exception {
     String realTimeTopicName = Utils.composeRealTimeTopic(storeNameWithoutVersionInfo);
     PubSubTopic realTimeTopic = pubSubTopicRepository.getTopic(realTimeTopicName);
@@ -4337,6 +4347,9 @@ public abstract class StoreIngestionTaskTest {
     int totalRemoteRtResubscriptionTriggered =
         resubscriptionOffsetForRemoteRT.size() + resubscriptionOffsetForLocalRT.size();
 
+    // Create CountDownLatch for synchronization between observer threads and main test thread
+    CountDownLatch resubscriptionLatch = new CountDownLatch(totalResubscriptionTriggered);
+
     vtWriter.broadcastStartOfPush(new HashMap<>());
 
     // Produce batchMessagesNum messages to local Venice version topic
@@ -4346,13 +4359,17 @@ public abstract class StoreIngestionTaskTest {
     // setting
     // the version role to Backup when the offset reaches the specified value.
     Consumer<MockInMemoryPartitionPosition> localObserver =
-        getObserver(resubscriptionOffsetForLocalVT, resubscriptionOffsetForLocalRT);
+        getObserver(resubscriptionOffsetForLocalVT, resubscriptionOffsetForLocalRT, resubscriptionLatch);
     Consumer<MockInMemoryPartitionPosition> remoteObserver =
-        getObserver(Collections.emptyList(), resubscriptionOffsetForRemoteRT);
+        getObserver(Collections.emptyList(), resubscriptionOffsetForRemoteRT, resubscriptionLatch);
     PollStrategy localPollStrategy = new BlockingObserverPollStrategy(new RandomPollStrategy(false), localObserver);
     remotePollStrategy = Optional.of(new BlockingObserverPollStrategy(new RandomPollStrategy(false), remoteObserver));
 
+    doReturn(PubSubSymbolicPosition.EARLIEST).when(mockTopicManager)
+        .getPositionByTime(any(PubSubTopicPartition.class), anyLong());
     TopicManager mockTopicManagerRemoteKafka = mock(TopicManager.class);
+    doReturn(PubSubSymbolicPosition.EARLIEST).when(mockTopicManagerRemoteKafka)
+        .getPositionByTime(any(PubSubTopicPartition.class), anyLong());
     doReturn(mockTopicManagerRemoteKafka).when(mockTopicManagerRepository)
         .getTopicManager(inMemoryRemoteKafkaBroker.getPubSubBrokerAddress());
 
@@ -4385,25 +4402,61 @@ public abstract class StoreIngestionTaskTest {
 
           verify(mockAbstractStorageEngine, timeout(10000).times(batchMessagesNum * 2))
               .putWithReplicationMetadata(eq(PARTITION_FOO), any(), any(), any());
+
+          // Wait for all resubscriptions to complete before verifying mock interactions
           try {
-            verify(storeIngestionTaskUnderTest, times(totalResubscriptionTriggered)).resubscribeForAllPartitions();
+            assertTrue(
+                resubscriptionLatch.await(30, TimeUnit.SECONDS),
+                "Timed out waiting for all resubscriptions to complete");
           } catch (InterruptedException e) {
             throw new RuntimeException(e);
           }
-          verify(mockLocalKafkaConsumer, atLeast(totalLocalVtResubscriptionTriggered))
-              .unSubscribe(eq(fooTopicPartition));
-          verify(mockLocalKafkaConsumer, atLeast(totalLocalVtResubscriptionTriggered))
-              .unSubscribe(eq(barTopicPartition));
+
+          // Use waitForNonDeterministicAssertion with atLeast() for all mock verifications
+          waitForNonDeterministicAssertion(30, TimeUnit.SECONDS, () -> {
+            try {
+              verify(storeIngestionTaskUnderTest, atLeast(totalResubscriptionTriggered)).resubscribeForAllPartitions();
+            } catch (InterruptedException e) {
+              throw new RuntimeException(e);
+            }
+          });
+
           PubSubTopicPartition fooRtTopicPartition = new PubSubTopicPartitionImpl(realTimeTopic, PARTITION_FOO);
-          verify(mockLocalKafkaConsumer, atLeast(totalLocalRtResubscriptionTriggered)).unSubscribe(fooRtTopicPartition);
-          verify(mockRemoteKafkaConsumer, atLeast(totalRemoteRtResubscriptionTriggered))
-              .unSubscribe(fooRtTopicPartition);
-          verify(mockLocalKafkaConsumer, atLeast(totalLocalVtResubscriptionTriggered))
-              .subscribe(eq(fooTopicPartition), any(PubSubPosition.class));
-          verify(mockLocalKafkaConsumer, atLeast(totalLocalRtResubscriptionTriggered))
-              .subscribe(eq(fooRtTopicPartition), any(PubSubPosition.class));
-          verify(mockRemoteKafkaConsumer, atLeast(totalRemoteRtResubscriptionTriggered))
-              .subscribe(eq(fooRtTopicPartition), any(PubSubPosition.class));
+
+          waitForNonDeterministicAssertion(30, TimeUnit.SECONDS, () -> {
+            verify(mockLocalKafkaConsumer, atLeast(totalLocalVtResubscriptionTriggered))
+                .unSubscribe(eq(fooTopicPartition));
+          });
+
+          waitForNonDeterministicAssertion(30, TimeUnit.SECONDS, () -> {
+            verify(mockLocalKafkaConsumer, atLeast(totalLocalVtResubscriptionTriggered))
+                .unSubscribe(eq(barTopicPartition));
+          });
+
+          waitForNonDeterministicAssertion(30, TimeUnit.SECONDS, () -> {
+            verify(mockLocalKafkaConsumer, atLeast(totalLocalRtResubscriptionTriggered))
+                .unSubscribe(fooRtTopicPartition);
+          });
+
+          waitForNonDeterministicAssertion(30, TimeUnit.SECONDS, () -> {
+            verify(mockRemoteKafkaConsumer, atLeast(totalRemoteRtResubscriptionTriggered))
+                .unSubscribe(fooRtTopicPartition);
+          });
+
+          waitForNonDeterministicAssertion(30, TimeUnit.SECONDS, () -> {
+            verify(mockLocalKafkaConsumer, atLeast(totalLocalVtResubscriptionTriggered))
+                .subscribe(eq(fooTopicPartition), any(PubSubPosition.class));
+          });
+
+          waitForNonDeterministicAssertion(30, TimeUnit.SECONDS, () -> {
+            verify(mockLocalKafkaConsumer, atLeast(totalLocalRtResubscriptionTriggered))
+                .subscribe(eq(fooRtTopicPartition), any(PubSubPosition.class));
+          });
+
+          waitForNonDeterministicAssertion(30, TimeUnit.SECONDS, () -> {
+            verify(mockRemoteKafkaConsumer, atLeast(totalRemoteRtResubscriptionTriggered))
+                .subscribe(eq(fooRtTopicPartition), any(PubSubPosition.class));
+          });
         }, AA_ON);
     config.setPollStrategy(localPollStrategy)
         .setHybridStoreConfig(Optional.of(hybridStoreConfig))
@@ -5839,12 +5892,13 @@ public abstract class StoreIngestionTaskTest {
   }
 
   @Test
-  public void testResolveTopicPartitionWithKafkaURL() throws NoSuchFieldException, IllegalAccessException {
+  public void testResolveRtTopicPartitionWithPubSubBrokerAddress() throws NoSuchFieldException, IllegalAccessException {
     StoreIngestionTask storeIngestionTask = mock(StoreIngestionTask.class);
     Function<String, String> resolver = Utils::resolveKafkaUrlForSepTopic;
     PubSubTopicRepository pubSubTopicRepository = new PubSubTopicRepository();
-    doCallRealMethod().when(storeIngestionTask).resolveTopicPartitionWithKafkaURL(any(), any(), anyString());
-    doCallRealMethod().when(storeIngestionTask).resolveTopicWithKafkaURL(any(), anyString());
+    doCallRealMethod().when(storeIngestionTask)
+        .resolveRtTopicPartitionWithPubSubBrokerAddress(any(), any(), anyString());
+    doCallRealMethod().when(storeIngestionTask).resolveRtTopicWithPubSubBrokerAddress(any(), anyString());
     doReturn(pubSubTopicRepository).when(storeIngestionTask).getPubSubTopicRepository();
     doReturn(resolver).when(storeIngestionTask).getKafkaClusterUrlResolver();
     PartitionConsumptionState pcs = mock(PartitionConsumptionState.class);
@@ -5861,13 +5915,15 @@ public abstract class StoreIngestionTaskTest {
     field.set(storeIngestionTask, separateRealTimeTopic);
 
     Assert.assertEquals(
-        storeIngestionTask.resolveTopicPartitionWithKafkaURL(realTimeTopic, pcs, kafkaUrl).getPubSubTopic(),
+        storeIngestionTask.resolveRtTopicPartitionWithPubSubBrokerAddress(realTimeTopic, pcs, kafkaUrl)
+            .getPubSubTopic(),
         realTimeTopic);
     Assert.assertEquals(
-        storeIngestionTask.resolveTopicPartitionWithKafkaURL(versionTopic, pcs, kafkaUrl).getPubSubTopic(),
+        storeIngestionTask.resolveRtTopicPartitionWithPubSubBrokerAddress(versionTopic, pcs, kafkaUrl).getPubSubTopic(),
         versionTopic);
     Assert.assertEquals(
-        storeIngestionTask.resolveTopicPartitionWithKafkaURL(realTimeTopic, pcs, kafkaUrl + Utils.SEPARATE_TOPIC_SUFFIX)
+        storeIngestionTask
+            .resolveRtTopicPartitionWithPubSubBrokerAddress(realTimeTopic, pcs, kafkaUrl + Utils.SEPARATE_TOPIC_SUFFIX)
             .getPubSubTopic(),
         separateRealTimeTopic);
   }
@@ -5972,7 +6028,7 @@ public abstract class StoreIngestionTaskTest {
         aaEnabled ? mock(ActiveActiveStoreIngestionTask.class) : mock(LeaderFollowerStoreIngestionTask.class);
     doCallRealMethod().when(ingestionTask).resubscribeAsLeader(any());
     doCallRealMethod().when(ingestionTask)
-        .prepareOffsetCheckpointAndStartConsumptionAsLeader(any(), any(), anyBoolean());
+        .preparePositionCheckpointAndStartRtConsumptionAsLeader(any(), any(), anyBoolean());
     PubSubTopicRepository topicRepository = new PubSubTopicRepository();
     when(ingestionTask.getPubSubTopicRepository()).thenReturn(topicRepository);
     OffsetRecord offsetRecord = mock(OffsetRecord.class);
@@ -6034,7 +6090,7 @@ public abstract class StoreIngestionTaskTest {
     LeaderFollowerStoreIngestionTask ingestionTask =
         aaEnabled ? mock(ActiveActiveStoreIngestionTask.class) : mock(LeaderFollowerStoreIngestionTask.class);
     doCallRealMethod().when(ingestionTask)
-        .prepareOffsetCheckpointAndStartConsumptionAsLeader(any(), any(), anyBoolean());
+        .preparePositionCheckpointAndStartRtConsumptionAsLeader(any(), any(), anyBoolean());
     PubSubTopicRepository topicRepository = new PubSubTopicRepository();
     when(ingestionTask.getPubSubTopicRepository()).thenReturn(topicRepository);
     InternalAvroSpecificSerializer<PartitionState> partitionStateSerializer =
@@ -6060,7 +6116,7 @@ public abstract class StoreIngestionTaskTest {
     PubSubPosition p100 = InMemoryPubSubPosition.of(100L);
     when(pcs.getLatestProcessedRemoteVtPosition()).thenReturn(p100);
     when(pcs.consumeRemotely()).thenReturn(true);
-    ingestionTask.prepareOffsetCheckpointAndStartConsumptionAsLeader(pubSubTopic, pcs, false);
+    ingestionTask.preparePositionCheckpointAndStartRtConsumptionAsLeader(pubSubTopic, pcs, false);
 
     if (aaEnabled) {
       Assert.assertEquals(offsetRecord.getCheckpointedRtPosition("dc-1"), PubSubSymbolicPosition.EARLIEST);

--- a/clients/venice-admin-tool/src/main/java/com/linkedin/venice/KafkaTopicDumper.java
+++ b/clients/venice-admin-tool/src/main/java/com/linkedin/venice/KafkaTopicDumper.java
@@ -34,6 +34,7 @@ import com.linkedin.venice.meta.Version;
 import com.linkedin.venice.pubsub.PubSubTopicRepository;
 import com.linkedin.venice.pubsub.api.DefaultPubSubMessage;
 import com.linkedin.venice.pubsub.api.PubSubConsumerAdapter;
+import com.linkedin.venice.pubsub.api.PubSubPosition;
 import com.linkedin.venice.pubsub.api.PubSubTopicPartition;
 import com.linkedin.venice.pubsub.api.exceptions.PubSubClientException;
 import com.linkedin.venice.schema.AvroSchemaParseUtils;
@@ -278,8 +279,8 @@ public class KafkaTopicDumper implements AutoCloseable {
       long startingTimestamp) {
     if (startingTimestamp != -1) {
       LOGGER.info("Searching for offset for timestamp: {} in topic-partition: {}", partition, startingTimestamp);
-      Long offsetForTime = consumer.offsetForTime(partition, startingTimestamp);
-      if (offsetForTime == null) {
+      PubSubPosition position = consumer.getPositionByTimestamp(partition, startingTimestamp);
+      if (position == null) {
         LOGGER.error(
             "No offset found for the requested timestamp: {} in topic-partition: {}. "
                 + "This indicates that there are no messages in the topic-partition with a timestamp "
@@ -291,12 +292,8 @@ public class KafkaTopicDumper implements AutoCloseable {
             "Failed to find an offset for the requested timestamp: " + startingTimestamp + " in topic-partition: "
                 + partition + ". Ensure that messages exist in the specified time range.");
       }
-      LOGGER.info(
-          "Found offset: {} for timestamp: {} in topic-partition: {}",
-          offsetForTime,
-          startingTimestamp,
-          partition);
-      startingOffset = offsetForTime;
+      LOGGER.info("Found offset: {} for timestamp: {} in topic-partition: {}", position, startingTimestamp, partition);
+      startingOffset = position.getNumericOffset();
     }
     return Math.max(
         startingOffset,
@@ -322,9 +319,9 @@ public class KafkaTopicDumper implements AutoCloseable {
     if (endTimestamp == -1) {
       return endOffset;
     }
-    Long offsetForTime = consumer.offsetForTime(partition, endTimestamp);
-    if (offsetForTime != null) {
-      return offsetForTime;
+    PubSubPosition positionForTime = consumer.getPositionByTimestamp(partition, endTimestamp);
+    if (positionForTime != null) {
+      return positionForTime.getNumericOffset();
     }
     // if offsetForTime returns null, it means there is no message with timestamp >= endTimestamp;
     // In this case we will use the endOffset

--- a/clients/venice-admin-tool/src/main/java/com/linkedin/venice/KafkaTopicDumper.java
+++ b/clients/venice-admin-tool/src/main/java/com/linkedin/venice/KafkaTopicDumper.java
@@ -292,7 +292,8 @@ public class KafkaTopicDumper implements AutoCloseable {
             "Failed to find an offset for the requested timestamp: " + startingTimestamp + " in topic-partition: "
                 + partition + ". Ensure that messages exist in the specified time range.");
       }
-      LOGGER.info("Found offset: {} for timestamp: {} in topic-partition: {}", position, startingTimestamp, partition);
+      LOGGER
+          .info("Found position: {} for timestamp: {} in topic-partition: {}", position, startingTimestamp, partition);
       startingOffset = position.getNumericOffset();
     }
     return Math.max(

--- a/clients/venice-admin-tool/src/main/java/com/linkedin/venice/TopicMessageFinder.java
+++ b/clients/venice-admin-tool/src/main/java/com/linkedin/venice/TopicMessageFinder.java
@@ -90,11 +90,12 @@ public class TopicMessageFinder {
         new PubSubTopicPartitionImpl(pubSubTopicRepository.getTopic(topic), assignedPartition);
 
     // fetch start and end offset
-    startOffset = consumer.offsetForTime(assignedPubSubTopicPartition, startTimestampEpochMs);
+    startOffset =
+        consumer.getPositionByTimestamp(assignedPubSubTopicPartition, startTimestampEpochMs).getNumericOffset();
     if (endTimestampEpochMs == Long.MAX_VALUE || endTimestampEpochMs > System.currentTimeMillis()) {
       endOffset = consumer.endOffset(assignedPubSubTopicPartition);
     } else {
-      endOffset = consumer.offsetForTime(assignedPubSubTopicPartition, endTimestampEpochMs);
+      endOffset = consumer.getPositionByTimestamp(assignedPubSubTopicPartition, endTimestampEpochMs).getNumericOffset();
     }
     LOGGER.info("Got start offset: {} and end offset: {} for the specified time range", startOffset, endOffset);
     return consume(consumer, assignedPubSubTopicPartition, startOffset, endOffset, progressInterval, serializedKey);

--- a/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/adapter/kafka/consumer/ApacheKafkaConsumerAdapter.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/adapter/kafka/consumer/ApacheKafkaConsumerAdapter.java
@@ -427,84 +427,53 @@ public class ApacheKafkaConsumerAdapter implements PubSubConsumerAdapter {
     return topicPartitionsOffsetsTracker != null ? topicPartitionsOffsetsTracker.getEndOffset(topic, partition) : -1;
   }
 
-  /**
-   * @return get the offset of the first message with timestamp greater than or equal to the target timestamp.
-   *          {@code null} will be returned for the partition if there is no such message.
-   */
-  @Override
-  public Long offsetForTime(PubSubTopicPartition pubSubTopicPartition, long timestamp, Duration timeout) {
-    try {
-      TopicPartition topicPartition =
-          new TopicPartition(pubSubTopicPartition.getTopicName(), pubSubTopicPartition.getPartitionNumber());
-      Map<TopicPartition, OffsetAndTimestamp> topicPartitionOffsetMap =
-          this.kafkaConsumer.offsetsForTimes(Collections.singletonMap(topicPartition, timestamp), timeout);
-      if (topicPartitionOffsetMap == null || topicPartitionOffsetMap.isEmpty()) {
-        return null;
-      }
-      OffsetAndTimestamp offsetAndTimestamp = topicPartitionOffsetMap.get(topicPartition);
-      if (offsetAndTimestamp == null) {
-        return null;
-      }
-      return offsetAndTimestamp.offset();
-    } catch (TimeoutException e) {
-      throw new PubSubOpTimeoutException(
-          "Timed out while getting offset for time: " + timestamp + " for: " + pubSubTopicPartition + " with timeout: "
-              + timeout,
-          e);
-    } catch (Exception e) {
-      throw new PubSubClientException(
-          "Failed to fetch offset for time: " + timestamp + " for: " + pubSubTopicPartition + " with timeout: "
-              + timeout,
-          e);
-    }
-  }
-
-  @Override
-  public Long offsetForTime(PubSubTopicPartition pubSubTopicPartition, long timestamp) {
-    try {
-      TopicPartition topicPartition = new TopicPartition(
-          pubSubTopicPartition.getPubSubTopic().getName(),
-          pubSubTopicPartition.getPartitionNumber());
-      Map<TopicPartition, OffsetAndTimestamp> topicPartitionOffsetMap =
-          this.kafkaConsumer.offsetsForTimes(Collections.singletonMap(topicPartition, timestamp));
-      if (topicPartitionOffsetMap == null || topicPartitionOffsetMap.isEmpty()) {
-        return null;
-      }
-      OffsetAndTimestamp offsetAndTimestamp = topicPartitionOffsetMap.get(topicPartition);
-      if (offsetAndTimestamp == null) {
-        return null;
-      }
-      return offsetAndTimestamp.offset();
-    } catch (TimeoutException e) {
-      throw new PubSubOpTimeoutException(
-          "Timed out while getting offset for time: " + timestamp + " for: " + pubSubTopicPartition,
-          e);
-    } catch (Exception e) {
-      throw new PubSubClientException(
-          "Failed to fetch offset for time: " + timestamp + " for: " + pubSubTopicPartition,
-          e);
-    }
-  }
-
   @Override
   public PubSubPosition getPositionByTimestamp(
       PubSubTopicPartition pubSubTopicPartition,
       long timestamp,
       Duration timeout) {
-    Long offset = offsetForTime(pubSubTopicPartition, timestamp, timeout);
-    if (offset == null) {
-      return null;
-    }
-    return new ApacheKafkaOffsetPosition(offset);
+    return getPositionByTimestampInternal(pubSubTopicPartition, timestamp, timeout);
   }
 
   @Override
   public PubSubPosition getPositionByTimestamp(PubSubTopicPartition pubSubTopicPartition, long timestamp) {
-    Long offset = offsetForTime(pubSubTopicPartition, timestamp);
-    if (offset == null) {
-      return null;
+    return getPositionByTimestampInternal(pubSubTopicPartition, timestamp, null);
+  }
+
+  private PubSubPosition getPositionByTimestampInternal(
+      PubSubTopicPartition pubSubTopicPartition,
+      long timestamp,
+      Duration timeout) {
+    try {
+      TopicPartition topicPartition =
+          new TopicPartition(pubSubTopicPartition.getTopicName(), pubSubTopicPartition.getPartitionNumber());
+      Map<TopicPartition, OffsetAndTimestamp> topicPartitionOffsetMap;
+      if (timeout != null) {
+        topicPartitionOffsetMap =
+            this.kafkaConsumer.offsetsForTimes(Collections.singletonMap(topicPartition, timestamp), timeout);
+      } else {
+        topicPartitionOffsetMap =
+            this.kafkaConsumer.offsetsForTimes(Collections.singletonMap(topicPartition, timestamp));
+      }
+      if (topicPartitionOffsetMap == null || topicPartitionOffsetMap.isEmpty()) {
+        return null;
+      }
+      OffsetAndTimestamp offsetAndTimestamp = topicPartitionOffsetMap.get(topicPartition);
+      if (offsetAndTimestamp == null) {
+        return null;
+      }
+      return new ApacheKafkaOffsetPosition(offsetAndTimestamp.offset());
+    } catch (TimeoutException e) {
+      String timeoutMsg = timeout != null ? " with timeout: " + timeout : "";
+      throw new PubSubOpTimeoutException(
+          "Timed out while getting offset for time: " + timestamp + " for: " + pubSubTopicPartition + timeoutMsg,
+          e);
+    } catch (Exception e) {
+      String timeoutMsg = timeout != null ? " with timeout: " + timeout : "";
+      throw new PubSubClientException(
+          "Failed to fetch offset for time: " + timestamp + " for: " + pubSubTopicPartition + timeoutMsg,
+          e);
     }
-    return new ApacheKafkaOffsetPosition(offset);
   }
 
   @Override

--- a/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/api/PubSubConsumerAdapter.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/api/PubSubConsumerAdapter.java
@@ -207,7 +207,10 @@ public interface PubSubConsumerAdapter extends AutoCloseable, Closeable {
    * @throws PubSubOpTimeoutException If the operation times out while fetching the offset.
    * @throws PubSubClientException If there is an error while attempting to fetch the offset.
    */
-  Long offsetForTime(PubSubTopicPartition pubSubTopicPartition, long timestamp, Duration timeout);
+  @Deprecated
+  default Long offsetForTime(PubSubTopicPartition pubSubTopicPartition, long timestamp, Duration timeout) {
+    return getPositionByTimestamp(pubSubTopicPartition, timestamp, timeout).getNumericOffset();
+  }
 
   /**
    * Retrieves the offset of the first message with a timestamp greater than or equal to the target
@@ -236,7 +239,10 @@ public interface PubSubConsumerAdapter extends AutoCloseable, Closeable {
    * @throws PubSubOpTimeoutException If the operation times out while fetching the offset.
    * @throws PubSubClientException If there is an error while attempting to fetch the offset.
    */
-  Long offsetForTime(PubSubTopicPartition pubSubTopicPartition, long timestamp);
+  @Deprecated
+  default Long offsetForTime(PubSubTopicPartition pubSubTopicPartition, long timestamp) {
+    return getPositionByTimestamp(pubSubTopicPartition, timestamp).getNumericOffset();
+  }
 
   /**
    * Retrieves the offset of the first message with a timestamp greater than or equal to the target

--- a/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/manager/TopicManager.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/manager/TopicManager.java
@@ -816,10 +816,10 @@ public class TopicManager implements Closeable {
   }
 
   /**
-   * Get offsets for only one partition with a specific timestamp.
+   * Get position for only one partition with a specific timestamp.
    */
-  public long getOffsetByTime(PubSubTopicPartition pubSubTopicPartition, long timestamp) {
-    return topicMetadataFetcher.getOffsetForTimeWithRetries(pubSubTopicPartition, timestamp, 25);
+  public PubSubPosition getPositionByTime(PubSubTopicPartition pubSubTopicPartition, long timestamp) {
+    return topicMetadataFetcher.getPositionForTimeWithRetries(pubSubTopicPartition, timestamp, 25);
   }
 
   /**

--- a/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/manager/TopicMetadataFetcher.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/manager/TopicMetadataFetcher.java
@@ -462,52 +462,57 @@ class TopicMetadataFetcher implements Closeable {
   }
 
   /**
-   * Get the offset for a given timestamp. This is a blocking call.
-   * @param pubSubTopicPartition topic partition to get the offset for
-   * @param timestamp timestamp to get the offset for
-   * @return the offset for the given timestamp
+   * Get the position for a given timestamp. This is a blocking call.
+   * @param pubSubTopicPartition topic partition to get the position for
+   * @param timestamp timestamp to get the position for
+   * @return the position for the given timestamp
    */
-  long getOffsetForTime(PubSubTopicPartition pubSubTopicPartition, long timestamp) {
+  PubSubPosition getPositionForTime(PubSubTopicPartition pubSubTopicPartition, long timestamp) {
     validateTopicPartition(pubSubTopicPartition);
-    // We start by retrieving the latest offset. If the provided timestamp is out of range,
-    // we return the latest offset. This ensures that we don't miss any records produced
-    // after the 'offsetForTime' call when the latest offset is obtained after timestamp checking.
-    long latestOffset = getLatestOffset(pubSubTopicPartition);
+    // We start by retrieving the latest position. If the provided timestamp is out of range,
+    // we return the latest position. This ensures that we don't miss any records produced
+    // after the 'getPositionByTimestamp' call when the latest position is obtained after timestamp checking.
+    PubSubPosition latestPosition = getEndPositionsForPartition(pubSubTopicPartition);
 
     PubSubConsumerAdapter pubSubConsumerAdapter = acquireConsumer();
     try {
       long startTime = System.nanoTime();
-      Long result = pubSubConsumerAdapter
-          .offsetForTime(pubSubTopicPartition, timestamp, getPubsubOffsetApiTimeoutDurationDefaultValue());
+      PubSubPosition result = pubSubConsumerAdapter
+          .getPositionByTimestamp(pubSubTopicPartition, timestamp, getPubsubOffsetApiTimeoutDurationDefaultValue());
       stats.recordLatency(GET_OFFSET_FOR_TIME, startTime);
       if (result != null) {
         return result;
       }
-      // When the offset is null, it indicates that the provided timestamp is either out of range
+      // When the position is null, it indicates that the provided timestamp is either out of range
       // or the topic does not contain any messages. In such cases, we log a warning and return
-      // the offset of the last message available for the topic-partition.
+      // the position of the last message available for the topic-partition.
       LOGGER.warn(
-          "Received null offset for timestamp: {} on topic-partition: {}. This may occur if the timestamp is beyond "
-              + "the latest message timestamp or if the topic has no messages. Returning the latest offset: {}",
+          "Received null position for timestamp: {} on topic-partition: {}. This may occur if the timestamp "
+              + "is beyond the latest message timestamp or if the topic has no messages. Returning the latest position: {}",
           timestamp,
           pubSubTopicPartition,
-          latestOffset);
-      return latestOffset;
+          latestPosition);
+      return latestPosition;
     } finally {
       releaseConsumer(pubSubConsumerAdapter);
     }
   }
 
   /**
-   * Get the offset for a given timestamp with retries. This is a blocking call.
-   * @param pubSubTopicPartition topic partition to get the offset for
-   * @param timestamp timestamp to get the offset for
-   * @param retries number of retries
-   * @return the offset for the given timestamp
+   * Retrieves the position for a given timestamp in the specified topic partition, with retry logic.
+   * <p>
+   * This is a blocking call that attempts to find the position corresponding to the provided timestamp,
+   * retrying the operation up to the specified number of times in case of retriable failures.
+   * </p>
+   *
+   * @param pubSubTopicPartition the topic partition for which to retrieve the position
+   * @param timestamp the timestamp (in milliseconds) to find the corresponding position for
+   * @param retries the maximum number of retry attempts for retriable errors
+   * @return the offset corresponding to the given timestamp, or the latest position if the timestamp is out of range
    */
-  long getOffsetForTimeWithRetries(PubSubTopicPartition pubSubTopicPartition, long timestamp, int retries) {
+  PubSubPosition getPositionForTimeWithRetries(PubSubTopicPartition pubSubTopicPartition, long timestamp, int retries) {
     return RetryUtils.executeWithMaxAttemptAndExponentialBackoff(
-        () -> getOffsetForTime(pubSubTopicPartition, timestamp),
+        () -> getPositionForTime(pubSubTopicPartition, timestamp),
         retries,
         INITIAL_RETRY_DELAY,
         Duration.ofSeconds(5),

--- a/internal/venice-common/src/test/java/com/linkedin/venice/pubsub/adapter/kafka/consumer/ApacheKafkaConsumerAdapterTest.java
+++ b/internal/venice-common/src/test/java/com/linkedin/venice/pubsub/adapter/kafka/consumer/ApacheKafkaConsumerAdapterTest.java
@@ -599,8 +599,8 @@ public class ApacheKafkaConsumerAdapterTest {
     TopicPartition topicPartition =
         new TopicPartition(pubSubTopicPartition.getTopicName(), pubSubTopicPartition.getPartitionNumber());
     long timestamp = 1000000L;
-    Long expectedOffset = 500L;
-    OffsetAndTimestamp offsetAndTimestamp = new OffsetAndTimestamp(expectedOffset, timestamp);
+    ApacheKafkaOffsetPosition expectedPosition = ApacheKafkaOffsetPosition.of(500L);
+    OffsetAndTimestamp offsetAndTimestamp = new OffsetAndTimestamp(expectedPosition.getInternalOffset(), timestamp);
     Map<TopicPartition, OffsetAndTimestamp> mockResponse = Collections.singletonMap(topicPartition, offsetAndTimestamp);
 
     when(
@@ -608,8 +608,9 @@ public class ApacheKafkaConsumerAdapterTest {
             .offsetsForTimes(Collections.singletonMap(topicPartition, timestamp), Duration.ofMillis(500)))
                 .thenReturn(mockResponse);
 
-    Long actualOffset = kafkaConsumerAdapter.offsetForTime(pubSubTopicPartition, timestamp, Duration.ofMillis(500));
-    assertEquals(actualOffset, expectedOffset);
+    PubSubPosition actualPosition =
+        kafkaConsumerAdapter.getPositionByTimestamp(pubSubTopicPartition, timestamp, Duration.ofMillis(500));
+    assertEquals(actualPosition, expectedPosition);
   }
 
   @Test
@@ -625,8 +626,9 @@ public class ApacheKafkaConsumerAdapterTest {
             .offsetsForTimes(Collections.singletonMap(topicPartition, timestamp), Duration.ofMillis(500)))
                 .thenReturn(mockResponse);
 
-    Long actualOffset = kafkaConsumerAdapter.offsetForTime(pubSubTopicPartition, timestamp, Duration.ofMillis(500));
-    assertNull(actualOffset);
+    assertNull(
+        kafkaConsumerAdapter.getPositionByTimestamp(pubSubTopicPartition, timestamp, Duration.ofMillis(500)),
+        "Should return null when no offset found for the given timestamp");
   }
 
   @Test(expectedExceptions = PubSubOpTimeoutException.class)
@@ -641,7 +643,7 @@ public class ApacheKafkaConsumerAdapterTest {
             .offsetsForTimes(Collections.singletonMap(topicPartition, timestamp), Duration.ofMillis(500)))
                 .thenThrow(new TimeoutException("Test timeout"));
 
-    kafkaConsumerAdapter.offsetForTime(pubSubTopicPartition, timestamp, Duration.ofMillis(500));
+    kafkaConsumerAdapter.getPositionByTimestamp(pubSubTopicPartition, timestamp, Duration.ofMillis(500));
   }
 
   @Test
@@ -650,15 +652,15 @@ public class ApacheKafkaConsumerAdapterTest {
     TopicPartition topicPartition =
         new TopicPartition(pubSubTopicPartition.getTopicName(), pubSubTopicPartition.getPartitionNumber());
     long timestamp = 1000000L;
-    Long expectedOffset = 500L;
-    OffsetAndTimestamp offsetAndTimestamp = new OffsetAndTimestamp(expectedOffset, timestamp);
+    ApacheKafkaOffsetPosition expectedPosition = ApacheKafkaOffsetPosition.of(500L);
+    OffsetAndTimestamp offsetAndTimestamp = new OffsetAndTimestamp(expectedPosition.getInternalOffset(), timestamp);
     Map<TopicPartition, OffsetAndTimestamp> mockResponse = Collections.singletonMap(topicPartition, offsetAndTimestamp);
 
     when(internalKafkaConsumer.offsetsForTimes(Collections.singletonMap(topicPartition, timestamp)))
         .thenReturn(mockResponse);
 
-    Long actualOffset = kafkaConsumerAdapter.offsetForTime(pubSubTopicPartition, timestamp);
-    assertEquals(actualOffset, expectedOffset);
+    PubSubPosition actualPosition = kafkaConsumerAdapter.getPositionByTimestamp(pubSubTopicPartition, timestamp);
+    assertEquals(actualPosition, expectedPosition);
   }
 
   @Test

--- a/internal/venice-common/src/test/java/com/linkedin/venice/pubsub/manager/TopicMetadataFetcherTest.java
+++ b/internal/venice-common/src/test/java/com/linkedin/venice/pubsub/manager/TopicMetadataFetcherTest.java
@@ -381,21 +381,22 @@ public class TopicMetadataFetcherTest {
   }
 
   @Test
-  public void testGetOffsetForTime() {
+  public void testGetPositionForTime() {
     PubSubTopicPartition tp0 = new PubSubTopicPartitionImpl(pubSubTopic, 0);
     when(adminMock.containsTopic(pubSubTopic)).thenReturn(true);
-    long latestOffset = 12321L;
     TopicMetadataFetcher topicMetadataFetcherSpy = spy(topicMetadataFetcher);
-    doReturn(latestOffset).when(topicMetadataFetcherSpy).getLatestOffset(tp0);
+    ApacheKafkaOffsetPosition endPosition = ApacheKafkaOffsetPosition.of(1234L);
+    doReturn(endPosition).when(topicMetadataFetcherSpy).getEndPositionsForPartition(tp0);
 
     long ts = System.currentTimeMillis();
-    when(consumerMock.offsetForTime(eq(tp0), eq(ts), any(Duration.class))).thenReturn(9988L);
-    assertEquals(topicMetadataFetcherSpy.getOffsetForTime(tp0, ts), 9988L);
+    ApacheKafkaOffsetPosition p9988 = ApacheKafkaOffsetPosition.of(9988L);
+    when(consumerMock.getPositionByTimestamp(eq(tp0), eq(ts), any(Duration.class))).thenReturn(p9988);
+    assertEquals(topicMetadataFetcherSpy.getPositionForTime(tp0, ts), p9988);
     assertEquals(pubSubConsumerPool.size(), 1);
 
     // test when offsetForTime returns null
-    when(consumerMock.offsetForTime(eq(tp0), eq(ts), any(Duration.class))).thenReturn(null);
-    assertEquals(topicMetadataFetcherSpy.getOffsetForTime(tp0, ts), latestOffset);
+    when(consumerMock.getPositionByTimestamp(eq(tp0), eq(ts), any(Duration.class))).thenReturn(null);
+    assertEquals(topicMetadataFetcherSpy.getPositionForTime(tp0, ts), endPosition);
     assertEquals(pubSubConsumerPool.size(), 1);
   }
 

--- a/internal/venice-test-common/build.gradle
+++ b/internal/venice-test-common/build.gradle
@@ -145,14 +145,15 @@ def integrationTestConfigs = {
 
 def integrationTestBuckets = [
     "1": [
-        "com.linkedin.venice.endToEnd.PartialUpdateWithHeartbeatReadyToServeCheckTest"
+        "com.linkedin.venice.endToEnd.PartialUpdateWithHeartbeatReadyToServeCheckTest",
+        "com.linkedin.venice.endToEnd.TestIncrementalPush"
     ],
     "2": [
-        "com.linkedin.venice.endToEnd.PartialUpdateTest"
+        "com.linkedin.venice.endToEnd.PartialUpdateTest",
+        "com.linkedin.venice.endToEnd.TestRepush"
     ],
     "3": [
-        "com.linkedin.venice.endToEnd.TestRepush",
-        "com.linkedin.venice.endToEnd.TestIncrementalPush"
+        "com.linkedin.venice.consumer.BootstrappingChangelogConsumerTest"
     ],
     "4": [
         "com.linkedin.venice.endToEnd.TestDeferredVersionSwap",
@@ -384,9 +385,6 @@ def integrationTestBuckets = [
         "com.linkedin.venice.endToEnd.PushStatusStoreTest"
     ],
     "22": [
-        "com.linkedin.venice.consumer.BootstrappingChangelogConsumerTest"
-    ],
-    "23": [
         "com.linkedin.venice.endToEnd.TestEmptyPush",
         "com.linkedin.venice.endToEnd.SystemStoreMultiColoTest",
         "com.linkedin.venice.endToEnd.CheckSumTest",

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/pubsub/manager/TopicManagerIntegrationTest.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/pubsub/manager/TopicManagerIntegrationTest.java
@@ -75,7 +75,7 @@ public class TopicManagerIntegrationTest extends TopicManagerTest {
     ExecutorService executorService = Executors.newFixedThreadPool(numberOfThreads);
     Future[] vwFutures = new Future[numberOfThreads];
     // Put all topic manager calls related to partition offset fetcher with admin and consumer here.
-    Runnable[] tasks = { () -> topicManager.getOffsetByTime(pubSubTopicPartition, checkTimestamp),
+    Runnable[] tasks = { () -> topicManager.getPositionByTime(pubSubTopicPartition, checkTimestamp),
         () -> topicManager.getPartitionCount(topic),
         () -> topicManager.getLatestOffsetWithRetries(pubSubTopicPartition, 1),
         () -> topicManager.getEndPositionsForTopicWithRetries(topic) };

--- a/internal/venice-test-common/src/main/java/com/linkedin/venice/pubsub/mock/adapter/consumer/MockInMemoryConsumerAdapter.java
+++ b/internal/venice-test-common/src/main/java/com/linkedin/venice/pubsub/mock/adapter/consumer/MockInMemoryConsumerAdapter.java
@@ -216,20 +216,10 @@ public class MockInMemoryConsumerAdapter implements PubSubConsumerAdapter {
   }
 
   @Override
-  public synchronized Long offsetForTime(PubSubTopicPartition pubSubTopicPartition, long timestamp, Duration timeout) {
-    return null;
-  }
-
-  @Override
   public synchronized PubSubPosition getPositionByTimestamp(
       PubSubTopicPartition pubSubTopicPartition,
       long timestamp,
       Duration timeout) {
-    return null;
-  }
-
-  @Override
-  public synchronized Long offsetForTime(PubSubTopicPartition pubSubTopicPartition, long timestamp) {
     return null;
   }
 


### PR DESCRIPTION
## [server] Replace offsetForTime with getPositionByTimestamp API

- Replace offsetForTime with getPositionByTimestamp API across ingestion tasks
- Update ApacheKafkaConsumerAdapter and TopicManager interfaces  
- Standardize logging patterns in ingestion task implementations



###  Code changes
- [ ] Added new code behind **a config**. If so list the config names and their default values in the PR description.
- [ ] Introduced new **log lines**. 
  - [ ] Confirmed if logs need to be **rate limited** to avoid excessive logging.

###  **Concurrency-Specific Checks**
Both reviewer and PR author to verify
- [ ] Code has **no race conditions** or **thread safety issues**.
- [ ] Proper **synchronization mechanisms** (e.g., `synchronized`, `RWLock`) are used where needed.
- [ ] No **blocking calls** inside critical sections that could lead to deadlocks or performance degradation.
- [ ] Verified **thread-safe collections** are used (e.g., `ConcurrentHashMap`, `CopyOnWriteArrayList`).
- [ ] Validated proper exception handling in multi-threaded code to avoid silent thread termination.


## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->

- [ ] New unit tests added.
- [ ] New integration tests added.
- [ ] Modified or extended existing tests.
- [ ] Verified backward compatibility (if applicable).

## Does this PR introduce any user-facing or breaking changes?
<!--  
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [ ] No. You can skip the rest of this section.
- [ ] Yes. Clearly explain the behavior change and its impact.