### PR TITLE
[vpj] Fix serialization issue in logical timestamp to RMD conversion

### DIFF
--- a/internal/venice-client-common/src/main/java/com/linkedin/venice/schema/rmd/RmdSchemaGenerator.java
+++ b/internal/venice-client-common/src/main/java/com/linkedin/venice/schema/rmd/RmdSchemaGenerator.java
@@ -59,6 +59,7 @@ public class RmdSchemaGenerator {
   public static ByteBuffer generateRecordLevelTimestampMetadata(Schema schema, Long timestamp) {
     GenericRecord record = new GenericData.Record(schema);
     record.put(RmdConstants.TIMESTAMP_FIELD_NAME, timestamp);
+    record.put(RmdConstants.REPLICATION_CHECKPOINT_VECTOR_FIELD_NAME, Collections.emptyList());
     return ByteBuffer.wrap(FastSerializerDeserializerFactory.getFastAvroGenericSerializer(schema).serialize(record));
   }
 


### PR DESCRIPTION
## Problem Statement

We introduced support for logical timestamp in VPJ. However, the conversion of logical timestamp to RMD has an issue with replication checkpoint vector not specified.

## Solution
Add the field with empty collection as the default.

###  Code changes
- Add the missing field in conversion with default as empty collection

###  **Concurrency-Specific Checks**
Both reviewer and PR author to verify
- [x ] Code has **no race conditions** or **thread safety issues**.
- [x ] Proper **synchronization mechanisms** (e.g., `synchronized`, `RWLock`) are used where needed.
- [ x] No **blocking calls** inside critical sections that could lead to deadlocks or performance degradation.
- [x ] Verified **thread-safe collections** are used (e.g., `ConcurrentHashMap`, `CopyOnWriteArrayList`).
- [x ] Validated proper exception handling in multi-threaded code to avoid silent thread termination.


## How was this PR tested?
It is validated as part of https://github.com/linkedin/venice/pull/2044 but pulled it out to separate PR to expedite the fix

## Does this PR introduce any user-facing or breaking changes?
- [x] No. You can skip the rest of this section.
- [ ] Yes. Clearly explain the behavior change and its impact.