### PR TITLE
[server][dvc][controller][test] Replace endOffset with endPosition API

### DIFF
--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/consumer/InternalLocalBootstrappingVeniceChangelogConsumerTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/consumer/InternalLocalBootstrappingVeniceChangelogConsumerTest.java
@@ -3,7 +3,6 @@ package com.linkedin.davinci.consumer;
 import static com.linkedin.venice.ConfigKeys.CLUSTER_NAME;
 import static com.linkedin.venice.ConfigKeys.KAFKA_BOOTSTRAP_SERVERS;
 import static com.linkedin.venice.ConfigKeys.ZOOKEEPER_ADDRESS;
-import static com.linkedin.venice.offsets.OffsetRecord.LOWEST_OFFSET;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyLong;
@@ -154,13 +153,12 @@ public class InternalLocalBootstrappingVeniceChangelogConsumerTest {
         pubSubTopicRepository.getTopic(versionTopic.getName() + ChangeCaptureView.CHANGE_CAPTURE_TOPIC_SUFFIX);
     PubSubTopicPartition topicPartition_0 = new PubSubTopicPartitionImpl(changeCaptureTopic, 0);
     PubSubTopicPartition topicPartition_1 = new PubSubTopicPartitionImpl(changeCaptureTopic, 1);
+    ApacheKafkaOffsetPosition position0 = ApacheKafkaOffsetPosition.of(0L);
     Set<PubSubTopicPartition> assignments = ImmutableSet.of(topicPartition_0, topicPartition_1);
     pubSubConsumer = mock(PubSubConsumerAdapter.class);
     doReturn(assignments).when(pubSubConsumer).getAssignment();
-    doReturn(LOWEST_OFFSET).when(pubSubConsumer).getLatestOffset(topicPartition_0);
-    doReturn(LOWEST_OFFSET).when(pubSubConsumer).getLatestOffset(topicPartition_1);
-    doReturn(0L).when(pubSubConsumer).endOffset(topicPartition_0);
-    doReturn(0L).when(pubSubConsumer).endOffset(topicPartition_1);
+    doReturn(position0).when(pubSubConsumer).endPosition(topicPartition_0);
+    doReturn(position0).when(pubSubConsumer).endPosition(topicPartition_1);
     when(pubSubConsumer.poll(anyLong())).thenReturn(new HashMap<>());
 
     Properties consumerProperties = new Properties();
@@ -406,10 +404,9 @@ public class InternalLocalBootstrappingVeniceChangelogConsumerTest {
     PubSubTopicPartition topicPartition_1 = new PubSubTopicPartitionImpl(changeCaptureTopic, TEST_PARTITION_ID_1);
     Set<PubSubTopicPartition> assignments = ImmutableSet.of(topicPartition_0, topicPartition_1);
     doReturn(assignments).when(pubSubConsumer).getAssignment();
-    doReturn(0L).when(pubSubConsumer).getLatestOffset(topicPartition_0);
-    doReturn(0L).when(pubSubConsumer).getLatestOffset(topicPartition_1);
-    doReturn(1L).when(pubSubConsumer).endOffset(topicPartition_0);
-    doReturn(1L).when(pubSubConsumer).endOffset(topicPartition_1);
+    ApacheKafkaOffsetPosition position1 = ApacheKafkaOffsetPosition.of(1L);
+    doReturn(position1).when(pubSubConsumer).endPosition(topicPartition_0);
+    doReturn(position1).when(pubSubConsumer).endPosition(topicPartition_1);
     when(pubSubConsumer.poll(anyLong())).thenReturn(new HashMap<>());
 
     StorageService mockStorageService = mock(StorageService.class);

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTaskTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTaskTest.java
@@ -695,7 +695,6 @@ public class LeaderFollowerStoreIngestionTaskTest {
     doReturn(mockTopicManager).when(mockTopicManagerRepository).getTopicManager(anyString());
     doReturn(PubSubSymbolicPosition.LATEST).when(mockTopicManager).getLatestPositionCached(any(), anyInt());
     ApacheKafkaOffsetPosition p10 = ApacheKafkaOffsetPosition.of(10L);
-    doReturn(p0).when(mockTopicManager).getLatestPositionCached(any(), anyInt());
     doReturn(p10).when(mockTopicManager).getLatestPositionCached(any(), anyInt());
 
     // Run SIT to process the mock consumer action

--- a/clients/venice-admin-tool/src/main/java/com/linkedin/venice/TopicMessageFinder.java
+++ b/clients/venice-admin-tool/src/main/java/com/linkedin/venice/TopicMessageFinder.java
@@ -16,6 +16,7 @@ import com.linkedin.venice.pubsub.PubSubTopicPartitionImpl;
 import com.linkedin.venice.pubsub.PubSubTopicRepository;
 import com.linkedin.venice.pubsub.api.DefaultPubSubMessage;
 import com.linkedin.venice.pubsub.api.PubSubConsumerAdapter;
+import com.linkedin.venice.pubsub.api.PubSubPosition;
 import com.linkedin.venice.pubsub.api.PubSubTopicPartition;
 import com.linkedin.venice.serialization.KeyWithChunkingSuffixSerializer;
 import com.linkedin.venice.serializer.RecordSerializer;
@@ -82,35 +83,34 @@ public class TopicMessageFinder {
     }
     LOGGER.info("Got partition count: {}", partitionCount);
 
-    long startOffset;
-    long endOffset;
+    PubSubPosition startPosition;
+    PubSubPosition endPosition;
 
     PubSubTopicRepository pubSubTopicRepository = new PubSubTopicRepository();
     PubSubTopicPartition assignedPubSubTopicPartition =
         new PubSubTopicPartitionImpl(pubSubTopicRepository.getTopic(topic), assignedPartition);
 
     // fetch start and end offset
-    startOffset =
-        consumer.getPositionByTimestamp(assignedPubSubTopicPartition, startTimestampEpochMs).getNumericOffset();
+    startPosition = consumer.getPositionByTimestamp(assignedPubSubTopicPartition, startTimestampEpochMs);
     if (endTimestampEpochMs == Long.MAX_VALUE || endTimestampEpochMs > System.currentTimeMillis()) {
-      endOffset = consumer.endOffset(assignedPubSubTopicPartition);
+      endPosition = consumer.endPosition(assignedPubSubTopicPartition);
     } else {
-      endOffset = consumer.getPositionByTimestamp(assignedPubSubTopicPartition, endTimestampEpochMs).getNumericOffset();
+      endPosition = consumer.getPositionByTimestamp(assignedPubSubTopicPartition, endTimestampEpochMs);
     }
-    LOGGER.info("Got start offset: {} and end offset: {} for the specified time range", startOffset, endOffset);
-    return consume(consumer, assignedPubSubTopicPartition, startOffset, endOffset, progressInterval, serializedKey);
+    LOGGER.info("Got start offset: {} and end offset: {} for the specified time range", startPosition, endPosition);
+    return consume(consumer, assignedPubSubTopicPartition, startPosition, endPosition, progressInterval, serializedKey);
   }
 
   static long consume(
       PubSubConsumerAdapter consumer,
       PubSubTopicPartition assignedPubSubTopicPartition,
-      long startOffset,
-      long endOffset,
+      PubSubPosition startPosition,
+      PubSubPosition endPosition,
       long progressInterval,
       byte[] serializedKey) {
     long recordCnt = 0;
     long lastReportRecordCnt = 0;
-    consumer.subscribe(assignedPubSubTopicPartition, startOffset);
+    consumer.subscribe(assignedPubSubTopicPartition, startPosition, true);
     boolean done = false;
     while (!done) {
       Map<PubSubTopicPartition, List<DefaultPubSubMessage>> messages = consumer.poll(10000);
@@ -119,14 +119,14 @@ public class TopicMessageFinder {
       }
       long lastRecordTimestamp = 0;
       for (DefaultPubSubMessage record: messages.get(assignedPubSubTopicPartition)) {
-        if (record.getPosition().getNumericOffset() >= endOffset) {
+        if (consumer.positionDifference(assignedPubSubTopicPartition, record.getPosition(), endPosition) >= 0) {
           done = true;
           break;
         }
         KafkaKey kafkaKey = record.getKey();
         if (Arrays.equals(kafkaKey.getKey(), serializedKey)) {
           KafkaMessageEnvelope value = record.getValue();
-          LOGGER.info("Offset: {}, Value: {}", record.getPosition(), value.toString());
+          LOGGER.info("Position: {}, Value: {}", record.getPosition(), value.toString());
         }
         lastRecordTimestamp = record.getPubSubMessageTime();
         recordCnt++;

--- a/clients/venice-admin-tool/src/main/java/com/linkedin/venice/TopicMessageFinder.java
+++ b/clients/venice-admin-tool/src/main/java/com/linkedin/venice/TopicMessageFinder.java
@@ -97,7 +97,7 @@ public class TopicMessageFinder {
     } else {
       endPosition = consumer.getPositionByTimestamp(assignedPubSubTopicPartition, endTimestampEpochMs);
     }
-    LOGGER.info("Got start offset: {} and end offset: {} for the specified time range", startPosition, endPosition);
+    LOGGER.info("Got start position: {} and end position: {} for the specified time range", startPosition, endPosition);
     return consume(consumer, assignedPubSubTopicPartition, startPosition, endPosition, progressInterval, serializedKey);
   }
 

--- a/clients/venice-admin-tool/src/test/java/com/linkedin/venice/TestAdminToolConsumption.java
+++ b/clients/venice-admin-tool/src/test/java/com/linkedin/venice/TestAdminToolConsumption.java
@@ -3,6 +3,7 @@ package com.linkedin.venice;
 import static com.linkedin.venice.kafka.protocol.enums.MessageType.PUT;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -31,9 +32,11 @@ import com.linkedin.venice.partitioner.DefaultVenicePartitioner;
 import com.linkedin.venice.pubsub.ImmutablePubSubMessage;
 import com.linkedin.venice.pubsub.PubSubTopicPartitionImpl;
 import com.linkedin.venice.pubsub.PubSubTopicRepository;
+import com.linkedin.venice.pubsub.PubSubUtil;
 import com.linkedin.venice.pubsub.adapter.kafka.common.ApacheKafkaOffsetPosition;
 import com.linkedin.venice.pubsub.adapter.kafka.consumer.ApacheKafkaConsumerAdapter;
 import com.linkedin.venice.pubsub.api.DefaultPubSubMessage;
+import com.linkedin.venice.pubsub.api.PubSubPosition;
 import com.linkedin.venice.pubsub.api.PubSubTopicPartition;
 import com.linkedin.venice.utils.Utils;
 import java.nio.ByteBuffer;
@@ -213,12 +216,19 @@ public class TestAdminToolConsumption {
     long endTimestamp = 20;
     when(apacheKafkaConsumer.getPositionByTimestamp(pubSubTopicPartition, startTimestamp)).thenReturn(startPosition);
     when(apacheKafkaConsumer.getPositionByTimestamp(pubSubTopicPartition, endTimestamp)).thenReturn(endPosition);
+    doAnswer(invocation -> {
+      PubSubTopicPartition partition = invocation.getArgument(0);
+      PubSubPosition position1 = invocation.getArgument(1);
+      PubSubPosition position2 = invocation.getArgument(2);
+      return PubSubUtil.computeOffsetDelta(partition, position1, position2, apacheKafkaConsumer);
+    }).when(apacheKafkaConsumer).positionDifference(pubSubTopicPartition, startPosition, endPosition);
+
     long messageCount = TopicMessageFinder
         .find(controllerClient, apacheKafkaConsumer, topic, keyString, startTimestamp, endTimestamp, progressInterval);
     Assert.assertEquals(messageCount, endPosition.getInternalOffset() - startPosition.getInternalOffset());
 
     when(apacheKafkaConsumer.poll(anyLong())).thenReturn(messagesMap, Collections.EMPTY_MAP);
-    when(apacheKafkaConsumer.endOffset(pubSubTopicPartition)).thenReturn(endPosition.getInternalOffset());
+    when(apacheKafkaConsumer.endPosition(pubSubTopicPartition)).thenReturn(endPosition);
     long messageCountNoEndOffset = TopicMessageFinder.find(
         controllerClient,
         apacheKafkaConsumer,
@@ -246,6 +256,8 @@ public class TestAdminToolConsumption {
         false,
         false,
         false);
-    Assert.assertEquals(kafkaTopicDumper.fetchAndProcess(0, 1, 2), consumedMessageCount);
+    ApacheKafkaOffsetPosition p0 = ApacheKafkaOffsetPosition.of(0);
+    ApacheKafkaOffsetPosition p1 = ApacheKafkaOffsetPosition.of(1);
+    Assert.assertEquals(kafkaTopicDumper.fetchAndProcess(p0, p1, 2), consumedMessageCount - 1);
   }
 }

--- a/clients/venice-admin-tool/src/test/java/com/linkedin/venice/TestKafkaTopicDumper.java
+++ b/clients/venice-admin-tool/src/test/java/com/linkedin/venice/TestKafkaTopicDumper.java
@@ -3,6 +3,7 @@ package com.linkedin.venice;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -33,6 +34,7 @@ import com.linkedin.venice.meta.Version;
 import com.linkedin.venice.pubsub.ImmutablePubSubMessage;
 import com.linkedin.venice.pubsub.PubSubTopicPartitionImpl;
 import com.linkedin.venice.pubsub.PubSubTopicRepository;
+import com.linkedin.venice.pubsub.PubSubUtil;
 import com.linkedin.venice.pubsub.adapter.kafka.common.ApacheKafkaOffsetPosition;
 import com.linkedin.venice.pubsub.adapter.kafka.consumer.ApacheKafkaConsumerAdapter;
 import com.linkedin.venice.pubsub.api.DefaultPubSubMessage;
@@ -101,7 +103,7 @@ public class TestKafkaTopicDumper {
     long endTimestamp = 20;
     when(apacheKafkaConsumer.getPositionByTimestamp(pubSubTopicPartition, startTimestamp)).thenReturn(startPosition);
     when(apacheKafkaConsumer.getPositionByTimestamp(pubSubTopicPartition, endTimestamp)).thenReturn(endPosition);
-    when(apacheKafkaConsumer.endOffset(pubSubTopicPartition)).thenReturn(endPosition.getInternalOffset());
+    when(apacheKafkaConsumer.endPosition(pubSubTopicPartition)).thenReturn(endPosition);
 
     KafkaTopicDumper kafkaTopicDumper = new KafkaTopicDumper(
         controllerClient,
@@ -206,7 +208,7 @@ public class TestKafkaTopicDumper {
     long endTimestamp = 20;
     when(apacheKafkaConsumer.getPositionByTimestamp(pubSubTopicPartition, startTimestamp)).thenReturn(startPosition);
     when(apacheKafkaConsumer.getPositionByTimestamp(pubSubTopicPartition, endTimestamp)).thenReturn(endPosition);
-    when(apacheKafkaConsumer.endOffset(pubSubTopicPartition)).thenReturn(endPosition.getInternalOffset());
+    when(apacheKafkaConsumer.endPosition(pubSubTopicPartition)).thenReturn(endPosition);
 
     KafkaTopicDumper kafkaTopicDumper = new KafkaTopicDumper(
         controllerClient,
@@ -330,82 +332,90 @@ public class TestKafkaTopicDumper {
   }
 
   @Test
-  public void testCalculateStartingOffset() {
+  public void testCalculateStartingPosition() {
     PubSubConsumerAdapter consumerAdapter = mock(PubSubConsumerAdapter.class);
     PubSubTopicPartition topicPartition = new PubSubTopicPartitionImpl(TOPIC_REPOSITORY.getTopic("test_topic_rt"), 0);
-    // Case 1: When start timestamp is non-negative and start offset is non-negative; positionForTime is
-    // non-null then it should be used as the start offset.
-    long startOffset = -1;
+    // Case 1: When start timestamp is non-negative and start position is non-negative; positionForTime is
+    // non-null then it should be used as the start position.
+    PubSubPosition userProvideStartPosition = PubSubSymbolicPosition.EARLIEST;
     long startTimestamp = 123456789L;
     ApacheKafkaOffsetPosition positionForTime = ApacheKafkaOffsetPosition.of(1234L);
     ApacheKafkaOffsetPosition startPosition = ApacheKafkaOffsetPosition.of(0L);
     when(consumerAdapter.getPositionByTimestamp(topicPartition, startTimestamp)).thenReturn(positionForTime);
-    when(consumerAdapter.beginningPosition(eq(topicPartition), any())).thenReturn(startPosition);
-    long actualStartOffset =
-        KafkaTopicDumper.calculateStartingOffset(consumerAdapter, topicPartition, startOffset, startTimestamp);
-    assertEquals(actualStartOffset, positionForTime.getInternalOffset());
+    when(consumerAdapter.beginningPosition(eq(topicPartition))).thenReturn(startPosition);
+    doAnswer(invocation -> {
+      PubSubPosition p1 = invocation.getArgument(1);
+      PubSubPosition p2 = invocation.getArgument(2);
+      return PubSubUtil.computeOffsetDelta(topicPartition, p1, p2, consumerAdapter);
+    }).when(consumerAdapter)
+        .positionDifference(any(PubSubTopicPartition.class), any(PubSubPosition.class), any(PubSubPosition.class));
 
-    // Case 2: When start timestamp is non-negative and start offset is non-negative; but positionForTime is null,
-    // beginning offset should be used as the start offset.
+    PubSubPosition actualStartPosition = KafkaTopicDumper
+        .calculateStartingPosition(consumerAdapter, topicPartition, userProvideStartPosition, startTimestamp);
+    assertEquals(actualStartPosition, positionForTime);
+
+    // Case 2: When start timestamp is non-negative and start position is non-negative; but positionForTime is null,
+    // beginning position should be used as the start position.
     when(consumerAdapter.getPositionByTimestamp(topicPartition, startTimestamp)).thenReturn(null);
-    long finalStartOffset = -1;
+    PubSubPosition finalStartOffset = PubSubSymbolicPosition.EARLIEST;
     long finalStartTimestamp = 123456789L;
     PubSubClientException e = expectThrows(
         PubSubClientException.class,
         () -> KafkaTopicDumper
-            .calculateStartingOffset(consumerAdapter, topicPartition, finalStartOffset, finalStartTimestamp));
-    assertTrue(e.getMessage().contains("Failed to find an offset"), "Actual error message: " + e.getMessage());
+            .calculateStartingPosition(consumerAdapter, topicPartition, finalStartOffset, finalStartTimestamp));
+    assertTrue(e.getMessage().contains("Failed to find an position"), "Actual error message: " + e.getMessage());
 
-    // Case 3: When start timestamp is non-negative and start offset is non-negative; but beginning offset is higher
-    // than positionForTime, beginning offset should be used as the start offset.
+    // Case 3: When start timestamp is non-negative and start position is non-negative; but beginning position is higher
+    // than positionForTime, beginning position should be used as the start position.
     startPosition = ApacheKafkaOffsetPosition.of(12356L);
     when(consumerAdapter.getPositionByTimestamp(topicPartition, startTimestamp))
         .thenReturn(PubSubSymbolicPosition.EARLIEST);
-    when(consumerAdapter.beginningPosition(eq(topicPartition), any())).thenReturn(startPosition);
-    actualStartOffset =
-        KafkaTopicDumper.calculateStartingOffset(consumerAdapter, topicPartition, startOffset, startTimestamp);
-    assertEquals(actualStartOffset, startPosition.getInternalOffset());
+    when(consumerAdapter.beginningPosition(eq(topicPartition))).thenReturn(startPosition);
+    actualStartPosition =
+        KafkaTopicDumper.calculateStartingPosition(consumerAdapter, topicPartition, startPosition, startTimestamp);
+    assertEquals(actualStartPosition, startPosition);
 
-    // Case 4: When start timestamp is negative and start offset > beginning offset, start offset should be used.
-    startOffset = 1234L;
+    // Case 4: When start timestamp is negative and start position > beginning position, start position should be used.
+    startPosition = ApacheKafkaOffsetPosition.of(1234L);
     startTimestamp = -1;
     when(consumerAdapter.getPositionByTimestamp(topicPartition, startTimestamp)).thenReturn(null);
-    when(consumerAdapter.beginningPosition(eq(topicPartition), any())).thenReturn(ApacheKafkaOffsetPosition.of(0L));
-    actualStartOffset =
-        KafkaTopicDumper.calculateStartingOffset(consumerAdapter, topicPartition, startOffset, startTimestamp);
-    assertEquals(actualStartOffset, startOffset);
+    when(consumerAdapter.beginningPosition(eq(topicPartition))).thenReturn(ApacheKafkaOffsetPosition.of(0L));
+    actualStartPosition =
+        KafkaTopicDumper.calculateStartingPosition(consumerAdapter, topicPartition, startPosition, startTimestamp);
+    assertEquals(actualStartPosition, startPosition);
   }
 
   @Test
-  public void testCalculateEndingOffset() {
+  public void testCalculateEndingPosition() {
     PubSubTopicPartition partition = new PubSubTopicPartitionImpl(TOPIC_REPOSITORY.getTopic("test-topic"), 0);
 
-    // Test Case 1: endTimestamp is -1, should return endOffset
+    // Test Case 1: endTimestamp is -1, should return endPosition
     PubSubConsumerAdapter mockConsumer = mock(PubSubConsumerAdapter.class);
-    when(mockConsumer.endOffset(partition)).thenReturn(100L);
-    long endOffset = KafkaTopicDumper.calculateEndingOffset(mockConsumer, partition, -1);
-    assertEquals(endOffset, 99L, "Should return the `endOffset - 1` when endTimestamp is -1");
-    verify(mockConsumer).endOffset(partition);
+    ApacheKafkaOffsetPosition endPos = ApacheKafkaOffsetPosition.of(100L);
+    when(mockConsumer.endPosition(partition)).thenReturn(endPos);
+    PubSubPosition endPosition = KafkaTopicDumper.calculateEndingPosition(mockConsumer, partition, -1);
+    assertEquals(endPosition, endPos, "Should return the endPosition when endTimestamp is -1");
+    verify(mockConsumer).endPosition(partition);
     verify(mockConsumer, never()).getPositionByTimestamp(partition, -1L);
 
-    // Test Case 2: Valid endTimestamp` with offsetForTime returning a value
+    // Test Case 2: Valid endTimestamp with positionForTime returning a value
     mockConsumer = mock(PubSubConsumerAdapter.class);
     ApacheKafkaOffsetPosition p80 = ApacheKafkaOffsetPosition.of(80L);
     when(mockConsumer.getPositionByTimestamp(partition, 200L)).thenReturn(p80);
-    endOffset = KafkaTopicDumper.calculateEndingOffset(mockConsumer, partition, 200L);
-    assertEquals(endOffset, p80.getInternalOffset(), "Should return the offset for the specified timestamp");
+    endPosition = KafkaTopicDumper.calculateEndingPosition(mockConsumer, partition, 200L);
+    assertEquals(endPosition, p80, "Should return the position for the specified timestamp");
     verify(mockConsumer).getPositionByTimestamp(partition, 200L);
-    verify(mockConsumer).endOffset(partition);
+    verify(mockConsumer).endPosition(partition);
 
-    // Test Case 3: Valid endTimestamp but offsetForTime returns null
+    // Test Case 3: Valid endTimestamp but positionForTime returns null
     mockConsumer = mock(PubSubConsumerAdapter.class);
-    when(mockConsumer.endOffset(partition)).thenReturn(100L);
+    ApacheKafkaOffsetPosition endPos3 = ApacheKafkaOffsetPosition.of(100L);
+    when(mockConsumer.endPosition(partition)).thenReturn(endPos3);
     when(mockConsumer.getPositionByTimestamp(partition, 300L)).thenReturn(null);
-    endOffset = KafkaTopicDumper.calculateEndingOffset(mockConsumer, partition, 300L);
-    assertEquals(endOffset, 99L, "Should return the `endOffset - 1` when no offset is found for the timestamp");
+    endPosition = KafkaTopicDumper.calculateEndingPosition(mockConsumer, partition, 300L);
+    assertEquals(endPosition, endPos3, "Should return the endPosition when no position is found for the timestamp");
     verify(mockConsumer).getPositionByTimestamp(partition, 300L);
-    verify(mockConsumer).getPositionByTimestamp(partition, 300L);
-    verify(mockConsumer).endOffset(partition);
+    verify(mockConsumer).endPosition(partition);
   }
 
   @Test
@@ -415,14 +425,27 @@ public class TestKafkaTopicDumper {
     KafkaTopicDumper dumper = new KafkaTopicDumper(mockConsumer, topicPartition, 3);
 
     KafkaTopicDumper spyDumper = spy(dumper);
+    ApacheKafkaOffsetPosition p0 = ApacheKafkaOffsetPosition.of(0L);
+    ApacheKafkaOffsetPosition p10 = ApacheKafkaOffsetPosition.of(10L);
+
+    // Mock positionDifference for the dumper's consumer
+    doAnswer(invocation -> {
+      PubSubPosition pos1 = invocation.getArgument(1);
+      PubSubPosition pos2 = invocation.getArgument(2);
+      return PubSubUtil.computeOffsetDelta(topicPartition, pos1, pos2, mockConsumer);
+    }).when(mockConsumer)
+        .positionDifference(any(PubSubTopicPartition.class), any(PubSubPosition.class), any(PubSubPosition.class));
 
     // Case 1: Invalid message count
-    Exception e = expectThrows(IllegalArgumentException.class, () -> spyDumper.fetchAndProcess(0, 10, -1));
+    Exception e = expectThrows(IllegalArgumentException.class, () -> spyDumper.fetchAndProcess(p0, p10, -1));
     assertTrue(e.getMessage().contains("Invalid message count"), "Actual error message: " + e.getMessage());
 
-    // Case 2: Invalid offset range
-    e = expectThrows(IllegalArgumentException.class, () -> spyDumper.fetchAndProcess(10, 0, 5));
-    assertTrue(e.getMessage().contains("Invalid offset range"), "Actual error message: " + e.getMessage());
+    // Case 2: Invalid position range
+    e = expectThrows(IllegalArgumentException.class, () -> spyDumper.fetchAndProcess(p10, p0, 5));
+    assertTrue(
+        e.getMessage().contains("Start position")
+            && e.getMessage().contains("is greater than or equal to end position"),
+        "Actual error message: " + e.getMessage());
 
     // Case 3: Valid range with 5 records to process
     List<DefaultPubSubMessage> mockMessages = createMockMessages(15, 0);
@@ -430,31 +453,31 @@ public class TestKafkaTopicDumper {
     mockPollResult.put(topicPartition, mockMessages);
     when(mockConsumer.poll(5000L)).thenReturn(mockPollResult);
     doNothing().when(spyDumper).processRecord(any());
-    int processedCount = spyDumper.fetchAndProcess(0, 10, 5);
+    int processedCount = spyDumper.fetchAndProcess(p0, p10, 5);
     assertEquals(processedCount, 5, "Should process all 5 messages in range");
 
     // Case 4: Poll returns no records
     when(mockConsumer.poll(5000L)).thenReturn(Collections.emptyMap());
-    processedCount = spyDumper.fetchAndProcess(0, 10, 5);
+    processedCount = spyDumper.fetchAndProcess(p0, p10, 5);
     assertEquals(processedCount, 0, "Should process no messages when poll returns empty");
 
-    // Case 5: endOffset is reached before messageCount is reached
+    // Case 5: endPosition is reached before messageCount is reached
     mockMessages = createMockMessages(4, 0);
     mockPollResult.put(topicPartition, mockMessages);
     when(mockConsumer.poll(5000L)).thenReturn(mockPollResult);
-    processedCount = spyDumper.fetchAndProcess(0, 2, 5);
-    assertEquals(processedCount, 3, "Should stop processing when endOffset is reached");
+    ApacheKafkaOffsetPosition p3 = ApacheKafkaOffsetPosition.of(3L);
+    processedCount = spyDumper.fetchAndProcess(p0, p3, 5);
+    assertEquals(processedCount, 3, "Should process all messages up to endPosition (positions 0,1,2,3)");
 
     // Verify unsubscription
     verify(mockConsumer, atLeastOnce()).unSubscribe(topicPartition);
   }
 
-  private List<DefaultPubSubMessage> createMockMessages(int count, long startOffset) {
+  private List<DefaultPubSubMessage> createMockMessages(int count, long startPosition) {
     List<DefaultPubSubMessage> messages = new ArrayList<>();
     for (int i = 0; i < count; i++) {
       DefaultPubSubMessage message = mock(DefaultPubSubMessage.class);
-      PubSubPosition pubSubPosition = mock(PubSubPosition.class);
-      when(pubSubPosition.getNumericOffset()).thenReturn(startOffset + i);
+      PubSubPosition pubSubPosition = ApacheKafkaOffsetPosition.of(startPosition + i);
       when(message.getPosition()).thenReturn(pubSubPosition);
       messages.add(message);
     }

--- a/clients/venice-admin-tool/src/test/java/com/linkedin/venice/TopicMessageFinderTest.java
+++ b/clients/venice-admin-tool/src/test/java/com/linkedin/venice/TopicMessageFinderTest.java
@@ -1,7 +1,9 @@
 package com.linkedin.venice;
 
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.anyInt;
 import static org.mockito.Mockito.anyLong;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertEquals;
@@ -19,8 +21,11 @@ import com.linkedin.venice.meta.StoreInfo;
 import com.linkedin.venice.meta.Version;
 import com.linkedin.venice.partitioner.DefaultVenicePartitioner;
 import com.linkedin.venice.pubsub.PubSubTopicPartitionImpl;
+import com.linkedin.venice.pubsub.PubSubUtil;
+import com.linkedin.venice.pubsub.adapter.kafka.common.ApacheKafkaOffsetPosition;
 import com.linkedin.venice.pubsub.api.DefaultPubSubMessage;
 import com.linkedin.venice.pubsub.api.PubSubConsumerAdapter;
+import com.linkedin.venice.pubsub.api.PubSubPosition;
 import com.linkedin.venice.pubsub.api.PubSubTopicPartition;
 import com.linkedin.venice.pubsub.mock.SimplePartitioner;
 import java.util.Arrays;
@@ -45,6 +50,9 @@ public class TopicMessageFinderTest {
   private static final int VERSION_NUMBER = 1;
   private static final int PARTITION_COUNT = 3;
   private static final String KEY_SCHEMA_STR = "\"string\"";
+  private static final ApacheKafkaOffsetPosition POSITION_0 = ApacheKafkaOffsetPosition.of(0L);
+  private static final ApacheKafkaOffsetPosition POSITION_10 = ApacheKafkaOffsetPosition.of(10L);
+  private static final ApacheKafkaOffsetPosition POSITION_20 = ApacheKafkaOffsetPosition.of(20L);
 
   @BeforeMethod
   public void setUp() {
@@ -122,12 +130,19 @@ public class TopicMessageFinderTest {
     PubSubTopicPartition mockPartition = mock(PubSubTopicPartitionImpl.class);
     when(mockConsumer.poll(anyLong())).thenReturn(Collections.singletonMap(mockPartition, Arrays.asList(mockMessage)))
         .thenReturn(Collections.emptyMap());
-    when(mockMessage.getPosition().getNumericOffset()).thenReturn(10L);
+    when(mockMessage.getPosition()).thenReturn(POSITION_10);
     when(mockMessage.getKey()).thenReturn(new KafkaKey((byte) 0, KEY.getBytes()));
-    when(mockMessage.getPosition().getNumericOffset()).thenReturn(10L);
+    when(mockMessage.getPosition()).thenReturn(POSITION_10);
+    doAnswer(invocation -> {
+      PubSubTopicPartition tp = invocation.getArgument(0);
+      PubSubPosition p1 = invocation.getArgument(1);
+      PubSubPosition p2 = invocation.getArgument(2);
+      return PubSubUtil.computeOffsetDelta(tp, p1, p2, mockConsumer);
+    }).when(mockConsumer)
+        .positionDifference(any(PubSubTopicPartition.class), any(PubSubPosition.class), any(PubSubPosition.class));
 
-    long recordsConsumed =
-        TopicMessageFinder.consume(mockConsumer, mockPartition, 0L, 20L, 5L, mockMessage.getKey().getKey());
+    long recordsConsumed = TopicMessageFinder
+        .consume(mockConsumer, mockPartition, POSITION_0, POSITION_20, 5L, mockMessage.getKey().getKey());
 
     assertTrue(recordsConsumed > 0);
   }
@@ -138,7 +153,8 @@ public class TopicMessageFinderTest {
     when(mockConsumer.poll(anyInt())).thenReturn(Collections.singletonMap(mockPartition, Arrays.asList(mockMessage)));
     when(mockMessage.getKey()).thenReturn(new KafkaKey((byte) 0, "different_key".getBytes()));
 
-    long recordsConsumed = TopicMessageFinder.consume(mockConsumer, mockPartition, 0L, 20L, 5L, KEY.getBytes());
+    long recordsConsumed =
+        TopicMessageFinder.consume(mockConsumer, mockPartition, POSITION_0, POSITION_20, 5L, KEY.getBytes());
 
     assertEquals(recordsConsumed, 0);
   }
@@ -147,9 +163,19 @@ public class TopicMessageFinderTest {
   public void testConsumeExceedsEndOffset() {
     PubSubTopicPartition mockPartition = mock(PubSubTopicPartitionImpl.class);
     when(mockConsumer.poll(anyInt())).thenReturn(Collections.singletonMap(mockPartition, Arrays.asList(mockMessage)));
-    when(mockMessage.getPosition().getNumericOffset()).thenReturn(30L);
+    ApacheKafkaOffsetPosition position30 = ApacheKafkaOffsetPosition.of(30L);
+    when(mockMessage.getPosition()).thenReturn(position30);
 
-    long recordsConsumed = TopicMessageFinder.consume(mockConsumer, mockPartition, 0L, 20L, 5L, KEY.getBytes());
+    doAnswer(invocation -> {
+      PubSubTopicPartition tp = invocation.getArgument(0);
+      PubSubPosition p1 = invocation.getArgument(1);
+      PubSubPosition p2 = invocation.getArgument(2);
+      return PubSubUtil.computeOffsetDelta(tp, p1, p2, mockConsumer);
+    }).when(mockConsumer)
+        .positionDifference(any(PubSubTopicPartition.class), any(PubSubPosition.class), any(PubSubPosition.class));
+
+    long recordsConsumed =
+        TopicMessageFinder.consume(mockConsumer, mockPartition, POSITION_0, POSITION_20, 5L, KEY.getBytes());
 
     assertEquals(recordsConsumed, 0);
   }

--- a/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/PubSubConstants.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/PubSubConstants.java
@@ -82,7 +82,6 @@ public class PubSubConstants {
    * Default value of sleep interval for polling topic deletion status from ZK.
    */
   public static final int PUBSUB_TOPIC_DELETION_STATUS_POLL_INTERVAL_MS_DEFAULT_VALUE = 2 * Time.MS_PER_SECOND;
-  public static final long UNKNOWN_LATEST_OFFSET = -1L;
 
   private static final Duration PUBSUB_OFFSET_API_TIMEOUT_DURATION_DEFAULT_VALUE_DEFAULT = Duration.ofMinutes(1);
   private static Duration PUBSUB_OFFSET_API_TIMEOUT_DURATION_DEFAULT_VALUE =

--- a/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/api/PubSubConsumerAdapter.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/api/PubSubConsumerAdapter.java
@@ -292,6 +292,7 @@ public interface PubSubConsumerAdapter extends AutoCloseable, Closeable {
    * @throws PubSubOpTimeoutException If the operation times out while fetching the end offsets.
    * @throws PubSubClientException If there is an error while attempting to fetch the end offsets.
    */
+  @Deprecated
   Map<PubSubTopicPartition, Long> endOffsets(Collection<PubSubTopicPartition> partitions, Duration timeout);
 
   Map<PubSubTopicPartition, PubSubPosition> endPositions(Collection<PubSubTopicPartition> partitions, Duration timeout);
@@ -306,6 +307,7 @@ public interface PubSubConsumerAdapter extends AutoCloseable, Closeable {
    * @throws PubSubOpTimeoutException If the operation times out while fetching the end offset.
    * @throws PubSubClientException If there is an error while attempting to fetch the end offset.
    */
+  @Deprecated
   Long endOffset(PubSubTopicPartition pubSubTopicPartition);
 
   PubSubPosition endPosition(PubSubTopicPartition pubSubTopicPartition);

--- a/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/api/PubSubConsumerAdapter.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/api/PubSubConsumerAdapter.java
@@ -293,7 +293,12 @@ public interface PubSubConsumerAdapter extends AutoCloseable, Closeable {
    * @throws PubSubClientException If there is an error while attempting to fetch the end offsets.
    */
   @Deprecated
-  Map<PubSubTopicPartition, Long> endOffsets(Collection<PubSubTopicPartition> partitions, Duration timeout);
+  default Map<PubSubTopicPartition, Long> endOffsets(Collection<PubSubTopicPartition> partitions, Duration timeout) {
+    Map<PubSubTopicPartition, PubSubPosition> positionMap = endPositions(partitions, timeout);
+    return positionMap.entrySet()
+        .stream()
+        .collect(java.util.stream.Collectors.toMap(Map.Entry::getKey, e -> e.getValue().getNumericOffset()));
+  }
 
   Map<PubSubTopicPartition, PubSubPosition> endPositions(Collection<PubSubTopicPartition> partitions, Duration timeout);
 
@@ -308,7 +313,9 @@ public interface PubSubConsumerAdapter extends AutoCloseable, Closeable {
    * @throws PubSubClientException If there is an error while attempting to fetch the end offset.
    */
   @Deprecated
-  Long endOffset(PubSubTopicPartition pubSubTopicPartition);
+  default Long endOffset(PubSubTopicPartition pubSubTopicPartition) {
+    return endPosition(pubSubTopicPartition).getNumericOffset();
+  }
 
   PubSubPosition endPosition(PubSubTopicPartition pubSubTopicPartition);
 

--- a/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/manager/TopicManager.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/manager/TopicManager.java
@@ -764,7 +764,7 @@ public class TopicManager implements Closeable {
 
   public PubSubPosition getEndPositionsForPartitionWithRetries(PubSubTopicPartition pubSubTopicPartition) {
     return RetryUtils.executeWithMaxAttempt(
-        () -> topicMetadataFetcher.getEndPositionsForPartition(pubSubTopicPartition),
+        () -> topicMetadataFetcher.getEndPositionForPartition(pubSubTopicPartition),
         10,
         Duration.ofMinutes(1),
         Collections.singletonList(Exception.class));
@@ -802,17 +802,17 @@ public class TopicManager implements Closeable {
     return topicMetadataFetcher.containsTopicWithRetries(pubSubTopic, retries);
   }
 
-  public long getLatestOffsetWithRetries(PubSubTopicPartition pubSubTopicPartition, int retries) {
-    return topicMetadataFetcher.getLatestOffsetWithRetries(pubSubTopicPartition, retries);
+  public PubSubPosition getLatestPositionWithRetries(PubSubTopicPartition pubSubTopicPartition, int retries) {
+    return topicMetadataFetcher.getLatestPositionWithRetries(pubSubTopicPartition, retries);
   }
 
-  public long getLatestOffsetCached(PubSubTopic pubSubTopic, int partitionId) {
-    return topicMetadataFetcher.getLatestOffsetCached(new PubSubTopicPartitionImpl(pubSubTopic, partitionId));
+  public PubSubPosition getLatestPositionCached(PubSubTopic pubSubTopic, int partitionId) {
+    return topicMetadataFetcher.getLatestPositionCached(new PubSubTopicPartitionImpl(pubSubTopic, partitionId));
   }
 
-  public long getLatestOffsetCachedNonBlocking(PubSubTopic pubSubTopic, int partitionId) {
+  public PubSubPosition getLatestPositionCachedNonBlocking(PubSubTopic pubSubTopic, int partitionId) {
     return topicMetadataFetcher
-        .getLatestOffsetCachedNonBlocking(new PubSubTopicPartitionImpl(pubSubTopic, partitionId));
+        .getLatestPositionCachedNonBlocking(new PubSubTopicPartitionImpl(pubSubTopic, partitionId));
   }
 
   /**

--- a/internal/venice-common/src/test/java/com/linkedin/venice/pubsub/manager/TopicManagerTest.java
+++ b/internal/venice-common/src/test/java/com/linkedin/venice/pubsub/manager/TopicManagerTest.java
@@ -478,7 +478,7 @@ public class TopicManagerTest {
     PubSubTopic nonExistingTopic = pubSubTopicRepository.getTopic(TestUtils.getUniqueTopicString("non-existing-topic"));
     Assert.assertThrows(
         PubSubTopicDoesNotExistException.class,
-        () -> topicManager.getLatestOffsetWithRetries(new PubSubTopicPartitionImpl(nonExistingTopic, 0), 10));
+        () -> topicManager.getLatestPositionWithRetries(new PubSubTopicPartitionImpl(nonExistingTopic, 0), 10));
   }
 
   @Test
@@ -584,7 +584,7 @@ public class TopicManagerTest {
         new TopicManagerRepository(topicManagerContext, localPubSubBrokerAddress).getLocalTopicManager()) {
       Assert.assertThrows(
           PubSubOpTimeoutException.class,
-          () -> topicManagerForThisTest.getLatestOffsetWithRetries(pubSubTopicPartition, 10));
+          () -> topicManagerForThisTest.getLatestPositionWithRetries(pubSubTopicPartition, 10));
     }
   }
 

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestPushJobWithNativeReplication.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestPushJobWithNativeReplication.java
@@ -30,6 +30,7 @@ import static com.linkedin.venice.vpj.VenicePushJobConstants.TARGETED_REGION_PUS
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
 
 import com.linkedin.d2.balancer.D2Client;
 import com.linkedin.d2.balancer.D2ClientBuilder;
@@ -39,6 +40,7 @@ import com.linkedin.davinci.client.StorageClass;
 import com.linkedin.davinci.client.factory.CachingDaVinciClientFactory;
 import com.linkedin.davinci.storage.StorageMetadataService;
 import com.linkedin.venice.D2.D2ClientUtils;
+import com.linkedin.venice.annotation.PubSubAgnosticTest;
 import com.linkedin.venice.client.store.AvroGenericStoreClient;
 import com.linkedin.venice.client.store.ClientConfig;
 import com.linkedin.venice.client.store.ClientFactory;
@@ -72,7 +74,9 @@ import com.linkedin.venice.meta.VersionStatus;
 import com.linkedin.venice.offsets.OffsetRecord;
 import com.linkedin.venice.pubsub.PubSubTopicPartitionImpl;
 import com.linkedin.venice.pubsub.PubSubTopicRepository;
+import com.linkedin.venice.pubsub.api.PubSubPosition;
 import com.linkedin.venice.pubsub.api.PubSubTopicPartition;
+import com.linkedin.venice.pubsub.manager.TopicManager;
 import com.linkedin.venice.pushmonitor.ExecutionStatus;
 import com.linkedin.venice.samza.VeniceSystemProducer;
 import com.linkedin.venice.serialization.avro.AvroProtocolDefinition;
@@ -119,6 +123,7 @@ import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 
+@PubSubAgnosticTest
 public class TestPushJobWithNativeReplication {
   private static final Logger LOGGER = LogManager.getLogger(TestPushJobWithNativeReplication.class);
   private static final int TEST_TIMEOUT = 2 * Time.MS_PER_MINUTE;
@@ -211,7 +216,7 @@ public class TestPushJobWithNativeReplication {
             job.run();
 
             // Verify the kafka URL being returned to the push job is the same as dc-0 kafka url.
-            Assert.assertEquals(job.getKafkaUrl(), childDatacenters.get(0).getKafkaBrokerWrapper().getAddress());
+            Assert.assertEquals(job.getKafkaUrl(), childDatacenters.get(0).getPubSubBrokerWrapper().getAddress());
           }
 
           TestUtils.waitForNonDeterministicAssertion(30, TimeUnit.SECONDS, () -> {
@@ -253,8 +258,10 @@ public class TestPushJobWithNativeReplication {
               PushJobStatusRecordKey key = new PushJobStatusRecordKey();
               key.setStoreName(storeName);
               key.setVersionNumber(1);
-              Object value = client.get(key).get();
-              Assert.assertNotNull(value);
+              waitForNonDeterministicAssertion(30, TimeUnit.SECONDS, () -> {
+                Object value = client.get(key).get();
+                Assert.assertNotNull(value);
+              });
             }
 
             /**
@@ -269,19 +276,26 @@ public class TestPushJobWithNativeReplication {
                 .getPartitionIds();
             Assert.assertFalse(partitionIds.isEmpty());
             int partitionId = partitionIds.iterator().next();
-            // Get the end offset of the selected partition from version topic
+            // Get the end position of the selected partition from version topic
             PubSubTopicPartition versionTopicPartition =
                 new PubSubTopicPartitionImpl(pubSubTopicRepository.getTopic(versionTopic), partitionId);
-            long latestOffsetInVersionTopic = childDataCenter.getRandomController()
-                .getVeniceAdmin()
-                .getTopicManager()
-                .getLatestOffsetWithRetries(versionTopicPartition, 5);
+
+            TopicManager tmInChildRegion = childDataCenter.getRandomController().getVeniceAdmin().getTopicManager();
+            PubSubPosition latestPositionInVersionTopic =
+                tmInChildRegion.getLatestPositionWithRetries(versionTopicPartition, 5);
             // Get the offset metadata of the selected partition from storage node
             StorageMetadataService metadataService = serverInRemoteFabric.getStorageMetadataService();
             OffsetRecord offsetRecord = metadataService.getLastOffset(versionTopic, partitionId);
 
-            Assert.assertTrue(
-                offsetRecord.getCheckpointedLocalVtPosition().getNumericOffset() <= latestOffsetInVersionTopic);
+            assertTrue(
+                tmInChildRegion.diffPosition(
+                    versionTopicPartition,
+                    latestPositionInVersionTopic,
+                    offsetRecord.getCheckpointedLocalVtPosition()) >= 0,
+                "The offset recorded in storage node is larger than the end offset of version topic. "
+                    + "versionTopic: " + versionTopic + ", partitionId: " + partitionId
+                    + ", latestPositionInVersionTopic: " + latestPositionInVersionTopic + ", offsetRecord: "
+                    + offsetRecord);
           });
         });
   }
@@ -359,7 +373,7 @@ public class TestPushJobWithNativeReplication {
           try (VenicePushJob job = new VenicePushJob("Test push job", props)) {
             job.run();
             // Verify the kafka URL being returned to the push job is the same as dc-0 kafka url.
-            Assert.assertEquals(job.getKafkaUrl(), childDatacenters.get(0).getKafkaBrokerWrapper().getAddress());
+            Assert.assertEquals(job.getKafkaUrl(), childDatacenters.get(0).getPubSubBrokerWrapper().getAddress());
           }
 
           // Test Da-vinci client is able to consume from NR region which is consuming remotely
@@ -452,7 +466,7 @@ public class TestPushJobWithNativeReplication {
           try (VenicePushJob job = new VenicePushJob("Batch Push", props)) {
             job.run();
             // Verify the kafka URL being returned to the push job is the same as dc-0 kafka url.
-            Assert.assertEquals(job.getKafkaUrl(), childDatacenters.get(0).getKafkaBrokerWrapper().getAddress());
+            Assert.assertEquals(job.getKafkaUrl(), childDatacenters.get(0).getPubSubBrokerWrapper().getAddress());
           }
 
           props.setProperty(INCREMENTAL_PUSH, "true");
@@ -495,7 +509,7 @@ public class TestPushJobWithNativeReplication {
             job.run();
 
             // Verify the kafka URL being returned to the push job is the same as dc-0 kafka url.
-            Assert.assertEquals(job.getKafkaUrl(), childDatacenters.get(0).getKafkaBrokerWrapper().getAddress());
+            Assert.assertEquals(job.getKafkaUrl(), childDatacenters.get(0).getPubSubBrokerWrapper().getAddress());
           }
 
           TestUtils.waitForNonDeterministicAssertion(10, TimeUnit.SECONDS, () -> {
@@ -755,7 +769,7 @@ public class TestPushJobWithNativeReplication {
             job.run();
 
             // Verify the kafka URL being returned to the push job is the same as dc-0 kafka url.
-            Assert.assertEquals(job.getKafkaUrl(), childDatacenters.get(0).getKafkaBrokerWrapper().getAddress());
+            Assert.assertEquals(job.getKafkaUrl(), childDatacenters.get(0).getPubSubBrokerWrapper().getAddress());
 
             TestUtils.waitForNonDeterministicAssertion(30, TimeUnit.SECONDS, () -> {
               // Current version should become 1 all data centers

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/pubsub/api/consumer/PubSubConsumerAdapterTest.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/pubsub/api/consumer/PubSubConsumerAdapterTest.java
@@ -32,6 +32,7 @@ import com.linkedin.venice.pubsub.api.PubSubMessageDeserializer;
 import com.linkedin.venice.pubsub.api.PubSubPosition;
 import com.linkedin.venice.pubsub.api.PubSubProduceResult;
 import com.linkedin.venice.pubsub.api.PubSubProducerAdapter;
+import com.linkedin.venice.pubsub.api.PubSubSymbolicPosition;
 import com.linkedin.venice.pubsub.api.PubSubTopic;
 import com.linkedin.venice.pubsub.api.PubSubTopicPartition;
 import com.linkedin.venice.pubsub.api.exceptions.PubSubOpTimeoutException;
@@ -145,6 +146,36 @@ public class PubSubConsumerAdapterTest {
                     .build()));
   }
 
+  /**
+   * Helper method to assert that the position difference from earliest equals the expected number of messages
+   */
+  private void assertPositionDifferenceFromEarliest(
+      PubSubTopicPartition partition,
+      PubSubPosition endPosition,
+      long expectedMessages,
+      String message) {
+    assertEquals(
+        pubSubConsumerAdapter.positionDifference(partition, endPosition, PubSubSymbolicPosition.EARLIEST),
+        expectedMessages,
+        message);
+  }
+
+  private void assertBeginningPositionForPartition(
+      PubSubTopic topic,
+      int partitionNumber,
+      long expectedTimeoutVariance) {
+    PubSubTopicPartition partition = new PubSubTopicPartitionImpl(topic, partitionNumber);
+    long startTime = System.currentTimeMillis();
+    PubSubPosition beginningPosition = pubSubConsumerAdapter.beginningPosition(partition, PUBSUB_OP_TIMEOUT);
+    PubSubPosition endPosition = pubSubConsumerAdapter.endPosition(partition);
+    long elapsedTime = System.currentTimeMillis() - startTime;
+    assertEquals(
+        pubSubConsumerAdapter.positionDifference(partition, endPosition, beginningPosition),
+        0,
+        "Beginning position should be equal to end position for an existing topic with no messages");
+    assertTrue(elapsedTime <= expectedTimeoutVariance, "beginningPosition should not block");
+  }
+
   protected Properties getPubSubProperties() {
     Properties properties = new Properties();
     properties.setProperty(ConfigKeys.KAFKA_BOOTSTRAP_SERVERS, pubSubBrokerWrapper.getAddress());
@@ -199,9 +230,9 @@ public class PubSubConsumerAdapterTest {
     assertTrue(elapsedTime <= PUBSUB_CONSUMER_API_DEFAULT_TIMEOUT_MS_WITH_VARIANCE, "PartitionsFor should not block");
   }
 
-  // Test: When endOffsets is called on a non-existent topic, it should throw PubSubOpTimeoutException
+  // Test: When endPositions is called on a non-existent topic, it should throw PubSubOpTimeoutException
   @Test(timeOut = 3 * Time.MS_PER_MINUTE)
-  public void testEndOffsetsForNonExistentTopic() {
+  public void testEndPositionsForNonExistentTopic() {
     PubSubTopic nonExistentPubSubTopic = pubSubTopicRepository.getTopic(Utils.getUniqueString("non-existent-topic-"));
     List<PubSubTopicPartition> partitions = new ArrayList<>(2);
     partitions.add(new PubSubTopicPartitionImpl(nonExistentPubSubTopic, 0));
@@ -209,16 +240,18 @@ public class PubSubConsumerAdapterTest {
 
     assertFalse(pubSubAdminAdapterLazy.get().containsTopic(nonExistentPubSubTopic), "Topic should not exist");
     long startTime = System.currentTimeMillis();
-    assertThrows(PubSubOpTimeoutException.class, () -> pubSubConsumerAdapter.endOffsets(partitions, PUBSUB_OP_TIMEOUT));
+    assertThrows(
+        PubSubOpTimeoutException.class,
+        () -> pubSubConsumerAdapter.endPositions(partitions, PUBSUB_OP_TIMEOUT));
     long elapsedTime = System.currentTimeMillis() - startTime;
     assertTrue(
         elapsedTime <= PUBSUB_OP_TIMEOUT_WITH_VARIANCE,
         "Timeout should be around the specified timeout but not too much greater");
   }
 
-  // Test: When endOffsets is called on an existing topic, it should return a map of partition to end offset
+  // Test: When endPositions is called on an existing topic, it should return a map of partition to end offset
   @Test(timeOut = 3 * Time.MS_PER_MINUTE)
-  public void testEndOffsetsForExistingTopic() {
+  public void testEndPositionsForExistingTopic() {
     PubSubTopic existingPubSubTopic = pubSubTopicRepository.getTopic(Utils.getUniqueString("existing-topic-"));
     int numPartitions = 3;
 
@@ -230,21 +263,30 @@ public class PubSubConsumerAdapterTest {
     partitions.add(new PubSubTopicPartitionImpl(existingPubSubTopic, 0));
     partitions.add(new PubSubTopicPartitionImpl(existingPubSubTopic, 1));
     long startTime = System.currentTimeMillis();
-    Map<PubSubTopicPartition, Long> endOffsets = pubSubConsumerAdapter.endOffsets(partitions, PUBSUB_OP_TIMEOUT);
+    Map<PubSubTopicPartition, PubSubPosition> endPositions =
+        pubSubConsumerAdapter.endPositions(partitions, PUBSUB_OP_TIMEOUT);
     long elapsedTime = System.currentTimeMillis() - startTime;
-    assertNotNull(endOffsets, "End offsets should not be null for an existing topic");
-    assertFalse(endOffsets.isEmpty(), "End offsets should not be empty for an existing topic");
-    assertEquals(endOffsets.size(), partitions.size(), "Number of end offsets does not match");
-    assertTrue(endOffsets.values().stream().allMatch(offset -> offset == 0), "End offsets should be 0 for a new topic");
+    assertNotNull(endPositions, "End offsets should not be null for an existing topic");
+    assertFalse(endPositions.isEmpty(), "End offsets should not be empty for an existing topic");
+    assertEquals(endPositions.size(), partitions.size(), "Number of end offsets does not match");
+    for (PubSubTopicPartition partition: partitions) {
+      assertTrue(endPositions.containsKey(partition), "End offsets should contain all requested partitions");
+      assertNotNull(endPositions.get(partition), "End offset should not be null for a partition");
+      assertEquals(
+          pubSubConsumerAdapter
+              .positionDifference(partition, endPositions.get(partition), PubSubSymbolicPosition.EARLIEST),
+          0,
+          "End position should be equal to beginning position for an empty topic");
+    }
     assertTrue(
         elapsedTime <= PUBSUB_OP_TIMEOUT_WITH_VARIANCE,
         "Timeout should be around the specified timeout but not too much greater");
   }
 
-  // Test: When endOffsets is called for a non-existent and existing topic in the same API call,
+  // Test: When endPositions is called for a non-existent and existing topic in the same API call,
   // it should throw a PubSubOpTimeoutException.
   @Test(timeOut = 3 * Time.MS_PER_MINUTE)
-  public void testEndOffsetsForNonExistentAndExistingTopic() {
+  public void testEndPositionsForNonExistentAndExistingTopic() {
     PubSubTopic nonExistentPubSubTopic = pubSubTopicRepository.getTopic(Utils.getUniqueString("non-existent-topic-"));
     PubSubTopic existingPubSubTopic = pubSubTopicRepository.getTopic(Utils.getUniqueString("existing-topic-"));
     int numPartitions = 3;
@@ -259,17 +301,19 @@ public class PubSubConsumerAdapterTest {
     partitions.add(new PubSubTopicPartitionImpl(existingPubSubTopic, 1));
 
     long startTime = System.currentTimeMillis();
-    assertThrows(PubSubOpTimeoutException.class, () -> pubSubConsumerAdapter.endOffsets(partitions, PUBSUB_OP_TIMEOUT));
+    assertThrows(
+        PubSubOpTimeoutException.class,
+        () -> pubSubConsumerAdapter.endPositions(partitions, PUBSUB_OP_TIMEOUT));
     long elapsedTime = System.currentTimeMillis() - startTime;
     assertTrue(
         elapsedTime <= PUBSUB_OP_TIMEOUT_WITH_VARIANCE,
         "Timeout should be around the specified timeout but not too much greater");
   }
 
-  // Test: When endOffsets is called on an existing topic with a non-existent partition, it should throw
+  // Test: When endPositions is called on an existing topic with a non-existent partition, it should throw
   // PubSubOpTimeoutException
   @Test(timeOut = 3 * Time.MS_PER_MINUTE)
-  public void testEndOffsetsForExistingTopicWithNonExistentPartition() {
+  public void testEndPositionsForExistingTopicWithNonExistentPartition() {
     PubSubTopic existingPubSubTopic = pubSubTopicRepository.getTopic(Utils.getUniqueString("existing-topic-"));
     int numPartitions = 1;
 
@@ -286,7 +330,9 @@ public class PubSubConsumerAdapterTest {
     partitions.add(new PubSubTopicPartitionImpl(existingPubSubTopic, 1));
 
     long startTime = System.currentTimeMillis();
-    assertThrows(PubSubOpTimeoutException.class, () -> pubSubConsumerAdapter.endOffsets(partitions, PUBSUB_OP_TIMEOUT));
+    assertThrows(
+        PubSubOpTimeoutException.class,
+        () -> pubSubConsumerAdapter.endPositions(partitions, PUBSUB_OP_TIMEOUT));
     long elapsedTime = System.currentTimeMillis() - startTime;
     assertTrue(
         elapsedTime <= PUBSUB_OP_TIMEOUT_WITH_VARIANCE,
@@ -296,7 +342,7 @@ public class PubSubConsumerAdapterTest {
   // Test: When endOffset (without explicit timeout) is called on a non-existent partition,
   // it should throw PubSubOpTimeoutException after the default API timeout.
   @Test(timeOut = 3 * Time.MS_PER_MINUTE)
-  public void testEndOffsetWithoutExplicitTimeoutForNonExistentPartition() {
+  public void testEndPositionWithoutExplicitTimeoutForNonExistentPartition() {
     PubSubTopic existingPubSubTopic = pubSubTopicRepository.getTopic(Utils.getUniqueString("existing-topic-"));
     int numPartitions = 1;
 
@@ -314,18 +360,21 @@ public class PubSubConsumerAdapterTest {
 
     // try to get the end offset for an existing topic with a valid partition but no messages
     long startTime = System.currentTimeMillis();
-    Long endOffset = pubSubConsumerAdapter.endOffset(partitions.get(0));
+    PubSubPosition endPosition = pubSubConsumerAdapter.endPosition(partitions.get(0));
     long elapsedTime = System.currentTimeMillis() - startTime;
-    assertNotNull(endOffset, "End offset should not be null for an existing topic partition");
-    assertEquals(endOffset, Long.valueOf(0), "End offset should be 0 for an existing topic partition");
-    assertTrue(elapsedTime <= PUBSUB_CONSUMER_API_DEFAULT_TIMEOUT_MS_WITH_VARIANCE, "endOffset should not block");
+    assertNotNull(endPosition, "End offset should not be null for an existing topic partition");
+    assertEquals(
+        pubSubConsumerAdapter.positionDifference(partitions.get(0), endPosition, PubSubSymbolicPosition.EARLIEST),
+        0,
+        "Position difference should be 0 for an existing topic partition with no messages");
+    assertTrue(elapsedTime <= PUBSUB_CONSUMER_API_DEFAULT_TIMEOUT_MS_WITH_VARIANCE, "endPosition should not block");
 
     // try to get the end offset for a non-existent topic partition
     startTime = System.currentTimeMillis();
-    assertThrows(PubSubOpTimeoutException.class, () -> pubSubConsumerAdapter.endOffset(partitions.get(1)));
+    assertThrows(PubSubOpTimeoutException.class, () -> pubSubConsumerAdapter.endPosition(partitions.get(1)));
     elapsedTime = System.currentTimeMillis() - startTime;
     // elapsed time should be around PUBSUB_OP_TIMEOUT but not too much greater
-    assertTrue(elapsedTime <= 2 * PUBSUB_CONSUMER_API_DEFAULT_TIMEOUT_MS_WITH_VARIANCE, "endOffset should not block");
+    assertTrue(elapsedTime <= 2 * PUBSUB_CONSUMER_API_DEFAULT_TIMEOUT_MS_WITH_VARIANCE, "endPosition should not block");
   }
 
   // Test: When beginningOffset is called on a non-existent topic, it should throw PubSubOpTimeoutException
@@ -347,7 +396,7 @@ public class PubSubConsumerAdapterTest {
 
   // Test: When beginningOffset is called on an existing topic, it should return an offset
   @Test(timeOut = 3 * Time.MS_PER_MINUTE)
-  public void testBeginningOffsetForExistingTopic() {
+  public void testBeginningPositionForExistingTopic() {
     PubSubTopic existingPubSubTopic = pubSubTopicRepository.getTopic(Utils.getUniqueString("existing-topic-"));
     int numPartitions = 3;
 
@@ -355,32 +404,16 @@ public class PubSubConsumerAdapterTest {
         .createTopic(existingPubSubTopic, numPartitions, REPLICATION_FACTOR, TOPIC_CONFIGURATION);
     assertTrue(pubSubAdminAdapterLazy.get().containsTopic(existingPubSubTopic), "Topic should exist");
 
-    PubSubTopicPartition partition = new PubSubTopicPartitionImpl(existingPubSubTopic, 0);
-    long startTime = System.currentTimeMillis();
-    long beginningOffset = pubSubConsumerAdapter.beginningPosition(partition, PUBSUB_OP_TIMEOUT).getNumericOffset();
-    long elapsedTime = System.currentTimeMillis() - startTime;
-    assertEquals(beginningOffset, 0, "Beginning offset should be 0 for an existing topic");
-    assertTrue(elapsedTime <= PUBSUB_CONSUMER_API_DEFAULT_TIMEOUT_MS_WITH_VARIANCE, "beginningOffset should not block");
-
-    partition = new PubSubTopicPartitionImpl(existingPubSubTopic, 1);
-    startTime = System.currentTimeMillis();
-    beginningOffset = pubSubConsumerAdapter.beginningPosition(partition, PUBSUB_OP_TIMEOUT).getNumericOffset();
-    elapsedTime = System.currentTimeMillis() - startTime;
-    assertEquals(beginningOffset, 0, "Beginning offset should be 0 for an existing topic");
-    assertTrue(elapsedTime <= PUBSUB_OP_TIMEOUT_WITH_VARIANCE, "beginningOffset should not block");
-
-    partition = new PubSubTopicPartitionImpl(existingPubSubTopic, 2);
-    startTime = System.currentTimeMillis();
-    beginningOffset = pubSubConsumerAdapter.beginningPosition(partition, PUBSUB_OP_TIMEOUT).getNumericOffset();
-    elapsedTime = System.currentTimeMillis() - startTime;
-    assertEquals(beginningOffset, 0, "Beginning offset should be 0 for an existing topic");
-    assertTrue(elapsedTime <= PUBSUB_OP_TIMEOUT_WITH_VARIANCE, "beginningOffset should not block");
+    // Test all three partitions using the helper method
+    assertBeginningPositionForPartition(existingPubSubTopic, 0, PUBSUB_CONSUMER_API_DEFAULT_TIMEOUT_MS_WITH_VARIANCE);
+    assertBeginningPositionForPartition(existingPubSubTopic, 1, PUBSUB_CONSUMER_API_DEFAULT_TIMEOUT_MS_WITH_VARIANCE);
+    assertBeginningPositionForPartition(existingPubSubTopic, 2, PUBSUB_CONSUMER_API_DEFAULT_TIMEOUT_MS_WITH_VARIANCE);
   }
 
   // Test: When beginningOffset is called on an existing topic with a non-existent partition, it should throw
   // PubSubOpTimeoutException
   @Test(timeOut = 3 * Time.MS_PER_MINUTE)
-  public void testBeginningOffsetForExistingTopicWithNonExistentPartition() {
+  public void testBeginningPositionForExistingTopicWithNonExistentPartition() {
     PubSubTopic existingPubSubTopic = pubSubTopicRepository.getTopic(Utils.getUniqueString("existing-topic-"));
     int numPartitions = 1;
 
@@ -392,9 +425,7 @@ public class PubSubConsumerAdapterTest {
         1,
         "Topic should have only 1 partition");
 
-    PubSubTopicPartition partition = new PubSubTopicPartitionImpl(existingPubSubTopic, 0);
-    long beginningOffset = pubSubConsumerAdapter.beginningPosition(partition, PUBSUB_OP_TIMEOUT).getNumericOffset();
-    assertEquals(beginningOffset, 0, "Beginning offset should be 0 for an existing topic");
+    assertBeginningPositionForPartition(existingPubSubTopic, 0, PUBSUB_CONSUMER_API_DEFAULT_TIMEOUT_MS_WITH_VARIANCE);
 
     PubSubTopicPartition nonExistentPartition = new PubSubTopicPartitionImpl(existingPubSubTopic, 1);
     long startTime = System.currentTimeMillis();
@@ -670,7 +701,9 @@ public class PubSubConsumerAdapterTest {
 
     assertFalse(pubSubAdminAdapterLazy.get().containsTopic(nonExistentPubSubTopic), "Topic should not exist");
     long startTime = System.currentTimeMillis();
-    assertThrows(PubSubTopicDoesNotExistException.class, () -> pubSubConsumerAdapter.subscribe(partition, 0));
+    assertThrows(
+        PubSubTopicDoesNotExistException.class,
+        () -> pubSubConsumerAdapter.subscribe(partition, PubSubSymbolicPosition.EARLIEST));
     long elapsedTime = System.currentTimeMillis() - startTime;
     assertTrue(
         elapsedTime <= PUBSUB_CONSUMER_API_DEFAULT_TIMEOUT_MS_WITH_VARIANCE,
@@ -695,7 +728,9 @@ public class PubSubConsumerAdapterTest {
 
     PubSubTopicPartition invalidPartition = new PubSubTopicPartitionImpl(existingPubSubTopic, 2);
     long startTime = System.currentTimeMillis();
-    assertThrows(PubSubTopicDoesNotExistException.class, () -> pubSubConsumerAdapter.subscribe(invalidPartition, 0));
+    assertThrows(
+        PubSubTopicDoesNotExistException.class,
+        () -> pubSubConsumerAdapter.subscribe(invalidPartition, PubSubSymbolicPosition.EARLIEST));
     long elapsedTime = System.currentTimeMillis() - startTime;
     assertTrue(
         elapsedTime <= PUBSUB_CONSUMER_API_DEFAULT_TIMEOUT_MS_WITH_VARIANCE,
@@ -718,7 +753,7 @@ public class PubSubConsumerAdapterTest {
         "Topic should have only 1 partition");
 
     long startTime = System.currentTimeMillis();
-    pubSubConsumerAdapter.subscribe(partition, 0);
+    pubSubConsumerAdapter.subscribe(partition, PubSubSymbolicPosition.EARLIEST);
     long elapsedTime = System.currentTimeMillis() - startTime;
     assertTrue(
         elapsedTime <= PUBSUB_CONSUMER_API_DEFAULT_TIMEOUT_MS_WITH_VARIANCE,
@@ -726,7 +761,7 @@ public class PubSubConsumerAdapterTest {
 
     // re-subscribe to the same topic and partition; this should not take longer than the default timeout
     startTime = System.currentTimeMillis();
-    pubSubConsumerAdapter.subscribe(partition, 0);
+    pubSubConsumerAdapter.subscribe(partition, PubSubSymbolicPosition.EARLIEST);
     elapsedTime = System.currentTimeMillis() - startTime;
     assertTrue(
         elapsedTime <= PUBSUB_CONSUMER_API_DEFAULT_TIMEOUT_MS_WITH_VARIANCE,
@@ -767,7 +802,7 @@ public class PubSubConsumerAdapterTest {
         "Topic should have only 1 partition");
 
     // subscribe to an existing topic and partition
-    pubSubConsumerAdapter.subscribe(partition, 0);
+    pubSubConsumerAdapter.subscribe(partition, PubSubSymbolicPosition.EARLIEST);
 
     // unsubscribe from an existing topic and partition
     long startTime = System.currentTimeMillis();
@@ -811,7 +846,7 @@ public class PubSubConsumerAdapterTest {
     assertFalse(pubSubConsumerAdapter.hasAnySubscription(), "Should not be subscribed to any topic");
 
     // subscribe to an existing topic and partition
-    pubSubConsumerAdapter.subscribe(validPartition, 0);
+    pubSubConsumerAdapter.subscribe(validPartition, PubSubSymbolicPosition.EARLIEST);
     assertTrue(pubSubConsumerAdapter.hasAnySubscription(), "Should be subscribed to the topic and partition");
     assertTrue(
         pubSubConsumerAdapter.hasSubscription(validPartition),
@@ -863,26 +898,28 @@ public class PubSubConsumerAdapterTest {
     lastMessageFuture.get(10, TimeUnit.SECONDS);
 
     // subscribe to the topic and partition
-    pubSubConsumerAdapter.subscribe(partition, 0);
+    pubSubConsumerAdapter.subscribe(partition, PubSubSymbolicPosition.EARLIEST);
     assertTrue(pubSubConsumerAdapter.hasAnySubscription(), "Should be subscribed to the topic and partition");
     assertTrue(pubSubConsumerAdapter.hasSubscription(partition), "Should be subscribed to the topic and partition");
 
     // consume 5 messages
     int minRecordsToConsume = 5;
-    long offsetOfLastConsumedMessage = -1;
+    PubSubPosition positionOfLastConsumedMessage = PubSubSymbolicPosition.EARLIEST;
     while (minRecordsToConsume > 0) {
       Map<PubSubTopicPartition, List<DefaultPubSubMessage>> messages = pubSubConsumerAdapter.poll(15);
       assertNotNull(messages, "Messages should not be null");
       List<DefaultPubSubMessage> partitionMessages = messages.get(partition);
       if (partitionMessages != null && !partitionMessages.isEmpty()) {
         minRecordsToConsume -= partitionMessages.size();
-        offsetOfLastConsumedMessage =
-            partitionMessages.get(partitionMessages.size() - 1).getPosition().getNumericOffset();
+        positionOfLastConsumedMessage = partitionMessages.get(partitionMessages.size() - 1).getPosition();
       }
     }
-    assertTrue(offsetOfLastConsumedMessage > 0, "Offset of last consumed message should be greater than 0");
+    assertTrue(
+        pubSubConsumerAdapter
+            .positionDifference(partition, positionOfLastConsumedMessage, PubSubSymbolicPosition.EARLIEST) >= 4,
+        "Should have consumed at least 5 messages");
 
-    // reset offset to the beginning
+    // reset position to the beginning
     long startTime = System.currentTimeMillis();
     pubSubConsumerAdapter.resetOffset(partition);
     long elapsedTime = System.currentTimeMillis() - startTime;
@@ -891,17 +928,21 @@ public class PubSubConsumerAdapterTest {
         "Timeout should be less than the default timeout");
 
     minRecordsToConsume = 1;
-    long offsetOfFirstConsumedMessage = -1L;
+    PubSubPosition offsetOfFirstConsumedMessage = PubSubSymbolicPosition.LATEST;
     while (minRecordsToConsume > 0) {
       Map<PubSubTopicPartition, List<DefaultPubSubMessage>> messages = pubSubConsumerAdapter.poll(15);
       List<DefaultPubSubMessage> partitionMessages = messages.get(partition);
       if (partitionMessages != null && !partitionMessages.isEmpty()) {
-        offsetOfFirstConsumedMessage = partitionMessages.get(0).getPosition().getNumericOffset();
+        offsetOfFirstConsumedMessage = partitionMessages.get(0).getPosition();
         minRecordsToConsume--;
       }
     }
     // verify that the offset of the first consumed message is 0
-    assertEquals(offsetOfFirstConsumedMessage, 0, "Offset of first consumed message should be 0 after resetOffset");
+    assertEquals(
+        pubSubConsumerAdapter
+            .positionDifference(partition, offsetOfFirstConsumedMessage, PubSubSymbolicPosition.EARLIEST),
+        0,
+        "Offset of first consumed message should be 0 after resetOffset");
   }
 
   // Test: resetOffset should throw PubSubUnsubscribedTopicPartitionException when called on an existing topic with a
@@ -952,10 +993,10 @@ public class PubSubConsumerAdapterTest {
     assertTrue(pubSubAdminAdapterLazy.get().containsTopic(topicB), "Topic should exist");
 
     // subscribe to the topic and partition
-    pubSubConsumerAdapter.subscribe(partitionA0, -1);
-    pubSubConsumerAdapter.subscribe(partitionA1, -1);
-    pubSubConsumerAdapter.subscribe(partitionB0, -1);
-    pubSubConsumerAdapter.subscribe(partitionB1, -1);
+    pubSubConsumerAdapter.subscribe(partitionA0, PubSubSymbolicPosition.EARLIEST);
+    pubSubConsumerAdapter.subscribe(partitionA1, PubSubSymbolicPosition.EARLIEST);
+    pubSubConsumerAdapter.subscribe(partitionB0, PubSubSymbolicPosition.EARLIEST);
+    pubSubConsumerAdapter.subscribe(partitionB1, PubSubSymbolicPosition.EARLIEST);
     assertTrue(pubSubConsumerAdapter.hasAnySubscription(), "Should be subscribed to the topic and partition");
     assertTrue(pubSubConsumerAdapter.hasSubscription(partitionA0), "Should be subscribed to the topic and partition");
     assertTrue(pubSubConsumerAdapter.hasSubscription(partitionA1), "Should be subscribed to the topic and partition");
@@ -987,16 +1028,32 @@ public class PubSubConsumerAdapterTest {
     CompletableFuture.allOf(lastMessageFutures.values().toArray(new CompletableFuture[0])).get(60, TimeUnit.SECONDS);
     // check end offsets
     long startTime = System.currentTimeMillis();
-    Map<PubSubTopicPartition, Long> endOffsets = pubSubConsumerAdapter.endOffsets(
+    Map<PubSubTopicPartition, PubSubPosition> endPositions = pubSubConsumerAdapter.endPositions(
         new HashSet<>(Arrays.asList(partitionA0, partitionA1, partitionB0, partitionB1)),
         PUBSUB_OP_TIMEOUT);
     long elapsedTime = System.currentTimeMillis() - startTime;
-    assertTrue(elapsedTime <= PUBSUB_OP_TIMEOUT_WITH_VARIANCE, "endOffsets should not block");
+    assertTrue(elapsedTime <= PUBSUB_OP_TIMEOUT_WITH_VARIANCE, "endPositions should not block");
 
-    assertEquals(endOffsets.get(partitionA0), Long.valueOf(numMessages), "End offset should match");
-    assertEquals(endOffsets.get(partitionA1), Long.valueOf(numMessages), "End offset should match");
-    assertEquals(endOffsets.get(partitionB0), Long.valueOf(numMessages), "End offset should match");
-    assertEquals(endOffsets.get(partitionB1), Long.valueOf(numMessages), "End offset should match");
+    assertPositionDifferenceFromEarliest(
+        partitionA0,
+        endPositions.get(partitionA0),
+        numMessages,
+        "End position difference from start should match number of messages");
+    assertPositionDifferenceFromEarliest(
+        partitionA1,
+        endPositions.get(partitionA1),
+        numMessages,
+        "End position difference from start should match number of messages");
+    assertPositionDifferenceFromEarliest(
+        partitionB0,
+        endPositions.get(partitionB0),
+        numMessages,
+        "End position difference from start should match number of messages");
+    assertPositionDifferenceFromEarliest(
+        partitionB1,
+        endPositions.get(partitionB1),
+        numMessages,
+        "End position difference from start should match number of messages");
 
     // poll at lest "minRecordsToConsume" messages per topic-partition; since poll does not guarantee even distribution
     // of messages across topic-partitions, we poll until we get at least "minRecordsToConsume" messages per
@@ -1004,12 +1061,12 @@ public class PubSubConsumerAdapterTest {
     int minRecordsToConsume = 2;
     long pollTimeout = 1;
     long pollTimeoutWithVariance = pollTimeout + 3000;
-    // keep track of the last consumed offset for each topic-partition
-    Map<PubSubTopicPartition, Long> lastConsumedOffsetMap = new HashMap<>(4);
+    // keep track of the last consumed position for each topic-partition
+    Map<PubSubTopicPartition, PubSubPosition> lastConsumedPositionMap = new HashMap<>(4);
     // keep track of the number of messages consumed for each topic-partition
     Map<PubSubTopicPartition, Integer> numMessagesConsumedMap = new HashMap<>(4);
-    // first consumed message offset map
-    Map<PubSubTopicPartition, Long> firstConsumedOffsetMap = new HashMap<>(4);
+    // first consumed message position map
+    Map<PubSubTopicPartition, PubSubPosition> firstConsumedPositionMap = new HashMap<>(4);
 
     Map<PubSubTopicPartition, List<DefaultPubSubMessage>> messages = null;
     Set<PubSubTopicPartition> consumptionBarMet = new HashSet<>();
@@ -1028,25 +1085,32 @@ public class PubSubConsumerAdapterTest {
           continue;
         }
         // update first consumed offset
-        Long oldVal =
-            firstConsumedOffsetMap.putIfAbsent(partition, partitionMessages.get(0).getPosition().getNumericOffset());
+        PubSubPosition oldVal = firstConsumedPositionMap.putIfAbsent(partition, partitionMessages.get(0).getPosition());
         if (oldVal == null) {
-          // assert offset is zero since this is the first time we are consuming from this topic-partition and
-          // and we started consuming from the beginning (-1 last consumed offset)
-          assertEquals(firstConsumedOffsetMap.get(partition), Long.valueOf(0), "First consumed offset should be 0");
+          // assert position is zero since this is the first time we are consuming from this topic-partition and
+          // and we started consuming from the beginning
+          assertEquals(
+              pubSubConsumerAdapter.positionDifference(
+                  partition,
+                  firstConsumedPositionMap.get(partition),
+                  pubSubConsumerAdapter.beginningPosition(partition, PUBSUB_OP_TIMEOUT)),
+              0,
+              "First consumed position should be 0");
         }
         // update last consumed offset
-        lastConsumedOffsetMap
-            .put(partition, partitionMessages.get(partitionMessages.size() - 1).getPosition().getNumericOffset());
+        lastConsumedPositionMap.put(partition, partitionMessages.get(partitionMessages.size() - 1).getPosition());
         // update number of messages consumed so far
         numMessagesConsumedMap
             .compute(partition, (k, v) -> v == null ? partitionMessages.size() : v + partitionMessages.size());
         long consumedCountSoFar = numMessagesConsumedMap.get(partition);
         // verify lastConsumedOffset matches records consumed so far
+        PubSubPosition lastConsumedPosition = lastConsumedPositionMap.get(partition);
+        long delta = pubSubConsumerAdapter
+            .positionDifference(partition, lastConsumedPosition, firstConsumedPositionMap.get(partition));
         assertEquals(
-            lastConsumedOffsetMap.get(partition),
-            Long.valueOf(consumedCountSoFar - 1),
-            "Last consumed offset should match records consumed so far");
+            delta + 1,
+            consumedCountSoFar,
+            "Position difference + 1 should match records consumed so far for partition " + partition);
         if (consumedCountSoFar >= minRecordsToConsume) {
           consumptionBarMet.add(partition);
         }
@@ -1073,9 +1137,10 @@ public class PubSubConsumerAdapterTest {
     assertTrue(pubSubConsumerAdapter.hasSubscription(partitionB1), "Should be subscribed to the topic-partition: B1");
 
     // consume all messages for A1; and check that no messages are consumed for A0, B0, and B1
-    long endOffsetOfA1 = endOffsets.get(partitionA1);
-    while (lastConsumedOffsetMap.get(partitionA1) != (endOffsetOfA1 - 1)) {
-      System.out.println(lastConsumedOffsetMap);
+    PubSubPosition endPositionOfA1 = endPositions.get(partitionA1);
+    while (pubSubConsumerAdapter
+        .positionDifference(partitionA1, endPositionOfA1, lastConsumedPositionMap.get(partitionA1)) != 1) {
+      System.out.println(lastConsumedPositionMap);
       startTime = System.currentTimeMillis();
       messages = pubSubConsumerAdapter.poll(pollTimeout);
       elapsedTime = System.currentTimeMillis() - startTime;
@@ -1094,14 +1159,14 @@ public class PubSubConsumerAdapterTest {
           continue;
         }
         // update last consumed offset
-        lastConsumedOffsetMap
-            .put(partition, partitionMessages.get(partitionMessages.size() - 1).getPosition().getNumericOffset());
+        lastConsumedPositionMap.put(partition, partitionMessages.get(partitionMessages.size() - 1).getPosition());
         int consumedCountSoFar = numMessagesConsumedMap.getOrDefault(partition, 0) + partitionMessages.size();
         // verify lastConsumedOffset matches records consumed so far
-        assertEquals(
-            lastConsumedOffsetMap.get(partition),
-            Long.valueOf(consumedCountSoFar - 1),
-            "Last consumed offset should match records consumed so far");
+        long delta = pubSubConsumerAdapter.positionDifference(
+            partition,
+            lastConsumedPositionMap.get(partition),
+            firstConsumedPositionMap.get(partition));
+        assertEquals(delta, consumedCountSoFar - 1, "Last consumed offset should match records consumed so far");
 
         numMessagesConsumedMap.put(partition, consumedCountSoFar);
       }
@@ -1109,12 +1174,13 @@ public class PubSubConsumerAdapterTest {
 
     // check A1's last consumed offset and consumed count
     assertEquals(
-        lastConsumedOffsetMap.get(partitionA1),
-        Long.valueOf(numMessages - 1),
-        "Last consumed offset should match number of messages");
-    lastConsumedOffsetMap.remove(partitionA1);
+        pubSubConsumerAdapter
+            .positionDifference(partitionA1, lastConsumedPositionMap.get(partitionA1), PubSubSymbolicPosition.EARLIEST),
+        numMessages - 1,
+        "Position difference from beginning should match number of messages");
+    lastConsumedPositionMap.remove(partitionA1);
     numMessagesConsumedMap.remove(partitionA1);
-    firstConsumedOffsetMap.remove(partitionA1);
+    firstConsumedPositionMap.remove(partitionA1);
     pubSubConsumerAdapter.resetOffset(partitionA1);
 
     // resume subscription to A0
@@ -1146,35 +1212,42 @@ public class PubSubConsumerAdapterTest {
           continue;
         }
         // check A1 starts from 0
-        Long oldVal =
-            firstConsumedOffsetMap.putIfAbsent(partition, partitionMessages.get(0).getPosition().getNumericOffset());
+        PubSubPosition oldVal = firstConsumedPositionMap.putIfAbsent(partition, partitionMessages.get(0).getPosition());
         if (oldVal == null) {
           // we reset the offset for A1 to beginning; so the first consumed offset should be 0
-          assertEquals(firstConsumedOffsetMap.get(partition), Long.valueOf(0), "First consumed offset should be 0");
+          assertEquals(
+              pubSubConsumerAdapter.positionDifference(
+                  partition,
+                  firstConsumedPositionMap.get(partition),
+                  pubSubConsumerAdapter.beginningPosition(partition, PUBSUB_OP_TIMEOUT)),
+              0,
+              "First consumed position should be 0 since we reset the position for A1 to beginning");
         }
 
-        // update last consumed offset
-        lastConsumedOffsetMap
-            .put(partition, partitionMessages.get(partitionMessages.size() - 1).getPosition().getNumericOffset());
+        // update last consumed position
+        lastConsumedPositionMap.put(partition, partitionMessages.get(partitionMessages.size() - 1).getPosition());
         int consumedCountSoFar = numMessagesConsumedMap.getOrDefault(partition, 0) + partitionMessages.size();
         // verify lastConsumedOffset matches records consumed so far
         assertEquals(
-            lastConsumedOffsetMap.get(partition),
-            Long.valueOf(consumedCountSoFar - 1),
+            pubSubConsumerAdapter.positionDifference(
+                partition,
+                lastConsumedPositionMap.get(partition),
+                firstConsumedPositionMap.get(partition)) + 1,
+            consumedCountSoFar,
             "Last consumed offset should match records consumed so far");
         numMessagesConsumedMap.put(partition, consumedCountSoFar);
       }
 
       // loop through all topic-partitions and check if consumption bar is met
-      for (PubSubTopicPartition partition: lastConsumedOffsetMap.keySet()) {
+      for (PubSubTopicPartition partition: lastConsumedPositionMap.keySet()) {
         if (numMessagesConsumedMap.get(partition) >= numMessages) {
           consumptionBarMet.add(partition);
         }
       }
     }
 
-    firstConsumedOffsetMap.clear();
-    lastConsumedOffsetMap.clear();
+    firstConsumedPositionMap.clear();
+    lastConsumedPositionMap.clear();
     numMessagesConsumedMap.clear();
     consumptionBarMet.clear();
 
@@ -1225,14 +1298,14 @@ public class PubSubConsumerAdapterTest {
           continue;
         }
         // update last consumed offset
-        lastConsumedOffsetMap
-            .put(partition, partitionMessages.get(partitionMessages.size() - 1).getPosition().getNumericOffset());
+        lastConsumedPositionMap.put(partition, partitionMessages.get(partitionMessages.size() - 1).getPosition());
         int consumedCountSoFar = numMessagesConsumedMap.getOrDefault(partition, 0) + partitionMessages.size();
         // verify lastConsumedOffset matches records consumed so far
         assertEquals(
-            lastConsumedOffsetMap.get(partition),
-            Long.valueOf(consumedCountSoFar - 1),
-            "Last consumed offset should match records consumed so far");
+            pubSubConsumerAdapter
+                .positionDifference(partition, lastConsumedPositionMap.get(partition), PubSubSymbolicPosition.EARLIEST),
+            consumedCountSoFar - 1,
+            "Last consumed position should match records consumed so far");
 
         numMessagesConsumedMap.put(partition, consumedCountSoFar);
       }
@@ -1266,7 +1339,7 @@ public class PubSubConsumerAdapterTest {
     // greater than the end offset, the consumer will seek to the beginning of the partition. Subsequent polls
     // will return the first message in the partition.
     assertFalse(pubSubConsumerAdapter.hasAnySubscription(), "Should be subscribed to the topic and partition");
-    pubSubConsumerAdapter.subscribe(partitionA0, endOffsets.get(partitionA0)); // sub will add +1 to the offset
+    pubSubConsumerAdapter.subscribe(partitionA0, endPositions.get(partitionA0)); // sub will add +1 to the offset
     messages = Collections.emptyMap();
     while (messages.isEmpty()) {
       messages = pubSubConsumerAdapter.poll(pollTimeout);
@@ -1277,10 +1350,12 @@ public class PubSubConsumerAdapterTest {
     assertTrue(messages.containsKey(partitionA0), "Should have messages for A0");
     assertTrue(messages.get(partitionA0).size() > 0, "Should have messages for A0");
     // offset should be at the first message
+
+    PubSubPosition firstPosition = messages.get(partitionA0).get(0).getPosition();
     assertEquals(
-        messages.get(partitionA0).get(0).getPosition().getNumericOffset(),
+        pubSubConsumerAdapter.positionDifference(partitionA0, firstPosition, PubSubSymbolicPosition.EARLIEST),
         0,
-        "Poll should start from the beginning");
+        "First consumed position should be 0 since we reset the position for A0 to beginning");
   }
 
   // Note: The following test may not work for non-Kafka PubSub implementations.
@@ -1309,10 +1384,10 @@ public class PubSubConsumerAdapterTest {
     assertTrue(pubSubAdminAdapterLazy.get().containsTopic(topicB), "Topic should exist");
 
     // subscribe to the topic and partition
-    pubSubConsumerAdapter.subscribe(partitionA0, -1);
-    pubSubConsumerAdapter.subscribe(partitionA1, -1);
-    pubSubConsumerAdapter.subscribe(partitionB0, -1);
-    pubSubConsumerAdapter.subscribe(partitionB1, -1);
+    pubSubConsumerAdapter.subscribe(partitionA0, PubSubSymbolicPosition.EARLIEST);
+    pubSubConsumerAdapter.subscribe(partitionA1, PubSubSymbolicPosition.EARLIEST);
+    pubSubConsumerAdapter.subscribe(partitionB0, PubSubSymbolicPosition.EARLIEST);
+    pubSubConsumerAdapter.subscribe(partitionB1, PubSubSymbolicPosition.EARLIEST);
     assertTrue(pubSubConsumerAdapter.hasAnySubscription(), "Should be subscribed to the topic and partition");
     assertTrue(pubSubConsumerAdapter.hasSubscription(partitionA0), "Should be subscribed to the topic and partition");
     assertTrue(pubSubConsumerAdapter.hasSubscription(partitionA1), "Should be subscribed to the topic and partition");
@@ -1344,16 +1419,24 @@ public class PubSubConsumerAdapterTest {
     CompletableFuture.allOf(lastMessageFutures.values().toArray(new CompletableFuture[0])).get(60, TimeUnit.SECONDS);
     // check end offsets
     long startTime = System.currentTimeMillis();
-    Map<PubSubTopicPartition, Long> endOffsets = pubSubConsumerAdapter.endOffsets(
+    Map<PubSubTopicPartition, PubSubPosition> endPositions = pubSubConsumerAdapter.endPositions(
         new HashSet<>(Arrays.asList(partitionA0, partitionA1, partitionB0, partitionB1)),
         PUBSUB_OP_TIMEOUT);
     long elapsedTime = System.currentTimeMillis() - startTime;
-    assertTrue(elapsedTime <= PUBSUB_OP_TIMEOUT_WITH_VARIANCE, "endOffsets should not block");
+    assertTrue(elapsedTime <= PUBSUB_OP_TIMEOUT_WITH_VARIANCE, "endPositions should not block");
 
-    assertEquals(endOffsets.get(partitionA0), Long.valueOf(numMessages), "End offset should match");
-    assertEquals(endOffsets.get(partitionA1), Long.valueOf(numMessages), "End offset should match");
-    assertEquals(endOffsets.get(partitionB0), Long.valueOf(numMessages), "End offset should match");
-    assertEquals(endOffsets.get(partitionB1), Long.valueOf(numMessages), "End offset should match");
+    long delta = pubSubConsumerAdapter
+        .positionDifference(partitionA0, endPositions.get(partitionA0), PubSubSymbolicPosition.EARLIEST);
+    assertEquals(delta, numMessages, "End position difference from start should match number of messages");
+    delta = pubSubConsumerAdapter
+        .positionDifference(partitionA1, endPositions.get(partitionA1), PubSubSymbolicPosition.EARLIEST);
+    assertEquals(delta, numMessages, "End position difference from start should match number of messages");
+    delta = pubSubConsumerAdapter
+        .positionDifference(partitionB0, endPositions.get(partitionB0), PubSubSymbolicPosition.EARLIEST);
+    assertEquals(delta, numMessages, "End position difference from  start should match number of messages");
+    delta = pubSubConsumerAdapter
+        .positionDifference(partitionB1, endPositions.get(partitionB1), PubSubSymbolicPosition.EARLIEST);
+    assertEquals(delta, numMessages, "End position difference from start should match number of messages");
 
     Set<PubSubTopicPartition> consumptionBarMet = new HashSet<>();
     while (consumptionBarMet.size() != 4) {
@@ -1371,9 +1454,10 @@ public class PubSubConsumerAdapterTest {
           continue;
         }
         // check offset of the last consumed message and see if it is one less than the end offset; if yes bar is met
-        if (partitionMessages.get(partitionMessages.size() - 1)
-            .getPosition()
-            .getNumericOffset() == endOffsets.get(partition) - 1) {
+        PubSubPosition lastMessagePosition = partitionMessages.get(partitionMessages.size() - 1).getPosition();
+        PubSubPosition endPosition = endPositions.get(partition);
+        delta = pubSubConsumerAdapter.positionDifference(partition, endPosition, lastMessagePosition);
+        if (delta == 1) {
           consumptionBarMet.add(partition);
         }
       }
@@ -1415,9 +1499,10 @@ public class PubSubConsumerAdapterTest {
           continue;
         }
         // check offset of the last consumed message and see if it is one less than the end offset; if yes bar is met
-        if (partitionMessages.get(partitionMessages.size() - 1)
-            .getPosition()
-            .getNumericOffset() == endOffsets.get(partition) - 1) {
+        PubSubPosition lastMessagePosition = partitionMessages.get(partitionMessages.size() - 1).getPosition();
+        PubSubPosition endPosition = endPositions.get(partition);
+        delta = pubSubConsumerAdapter.positionDifference(partition, endPosition, lastMessagePosition);
+        if (delta == 1) {
           consumptionBarMet.add(partition);
         }
       }
@@ -1442,16 +1527,24 @@ public class PubSubConsumerAdapterTest {
     CompletableFuture.allOf(lastMessageFutures.values().toArray(new CompletableFuture[0])).get(60, TimeUnit.SECONDS);
     // check end offsets
     startTime = System.currentTimeMillis();
-    endOffsets = pubSubConsumerAdapter.endOffsets(
+    endPositions = pubSubConsumerAdapter.endPositions(
         new HashSet<>(Arrays.asList(partitionA0, partitionA1, partitionB0, partitionB1)),
         PUBSUB_OP_TIMEOUT);
     elapsedTime = System.currentTimeMillis() - startTime;
-    assertTrue(elapsedTime <= PUBSUB_OP_TIMEOUT_WITH_VARIANCE, "endOffsets should not block");
+    assertTrue(elapsedTime <= PUBSUB_OP_TIMEOUT_WITH_VARIANCE, "endPositions should not block");
 
-    assertEquals(endOffsets.get(partitionA0), Long.valueOf(numMessages), "End offset should match");
-    assertEquals(endOffsets.get(partitionA1), Long.valueOf(numMessages), "End offset should match");
-    assertEquals(endOffsets.get(partitionB0), Long.valueOf(numMessages), "End offset should match");
-    assertEquals(endOffsets.get(partitionB1), Long.valueOf(numMessages), "End offset should match");
+    delta = pubSubConsumerAdapter
+        .positionDifference(partitionA0, endPositions.get(partitionA0), PubSubSymbolicPosition.EARLIEST);
+    assertEquals(delta, numMessages, "End position difference from start should match number of messages");
+    delta = pubSubConsumerAdapter
+        .positionDifference(partitionA1, endPositions.get(partitionA1), PubSubSymbolicPosition.EARLIEST);
+    assertEquals(delta, numMessages, "End position difference from start should match number of messages");
+    delta = pubSubConsumerAdapter
+        .positionDifference(partitionB0, endPositions.get(partitionB0), PubSubSymbolicPosition.EARLIEST);
+    assertEquals(delta, numMessages, "End position difference from  start should match number of messages");
+    delta = pubSubConsumerAdapter
+        .positionDifference(partitionB1, endPositions.get(partitionB1), PubSubSymbolicPosition.EARLIEST);
+    assertEquals(delta, numMessages, "End position difference from start should match number of messages");
 
     // only messages for B0 should be consumed as B1 reached end offset before deletion and recreation; A0 and A1
     // should not consume any messages as they already consumed all messages
@@ -1475,9 +1568,10 @@ public class PubSubConsumerAdapterTest {
           continue;
         }
         // check offset of the last consumed message and see if it is one less than the end offset; if yes bar is met
-        if (partitionMessages.get(partitionMessages.size() - 1)
-            .getPosition()
-            .getNumericOffset() == endOffsets.get(partition) - 1) {
+        PubSubPosition lastMessagePosition = partitionMessages.get(partitionMessages.size() - 1).getPosition();
+        PubSubPosition endPosition = endPositions.get(partition);
+        delta = pubSubConsumerAdapter.positionDifference(partition, endPosition, lastMessagePosition);
+        if (delta == 1) {
           consumptionBarMet.add(partition);
         }
       }

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/pubsub/manager/TopicManagerE2ETest.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/pubsub/manager/TopicManagerE2ETest.java
@@ -27,7 +27,6 @@ import com.linkedin.venice.pubsub.api.PubSubSymbolicPosition;
 import com.linkedin.venice.pubsub.api.PubSubTopic;
 import com.linkedin.venice.pubsub.api.PubSubTopicPartition;
 import com.linkedin.venice.pubsub.api.exceptions.PubSubTopicDoesNotExistException;
-import com.linkedin.venice.stats.StatsErrorCode;
 import com.linkedin.venice.utils.PubSubHelper;
 import com.linkedin.venice.utils.PubSubHelper.MutableDefaultPubSubMessage;
 import com.linkedin.venice.utils.Time;
@@ -195,20 +194,27 @@ public class TopicManagerE2ETest {
     Runnable t6 = () -> assertFalse(topicManager.containsTopicCached(nonExistentTopic));
 
     // get latest offset with retries for an existing topic
-    Runnable t7 = () -> assertEquals(topicManager.getLatestOffsetWithRetries(topicPartition, 1), numMessages);
+    Runnable t7 = () -> {
+      PubSubPosition endPosition = topicManager.getEndPositionsForTopicWithRetries(testTopic).get(topicPartition);
+      long delta = topicManager.diffPosition(topicPartition, endPosition, PubSubSymbolicPosition.EARLIEST);
+      assertEquals(delta, numMessages, "End position should be " + numMessages + " positions away from EARLIEST");
+    };
 
     // get latest offset with retries for a non-existent topic
     Runnable t8 = () -> assertThrows(
         PubSubTopicDoesNotExistException.class,
-        () -> topicManager.getLatestOffsetWithRetries(nonExistentTopicPartition, 1));
+        () -> topicManager.getLatestPositionWithRetries(nonExistentTopicPartition, 1));
 
     // get latest offset cached for an existing topic
-    Runnable t9 = () -> assertEquals(topicManager.getLatestOffsetCached(testTopic, 0), numMessages);
+    Runnable t9 = () -> {
+      PubSubPosition endPosition = topicManager.getEndPositionsForTopicWithRetries(testTopic).get(topicPartition);
+      long delta = topicManager.diffPosition(topicPartition, endPosition, PubSubSymbolicPosition.EARLIEST);
+      assertEquals(delta, numMessages, "End position should be " + numMessages + " positions away from EARLIEST");
+    };
 
     // get latest offset cached for a non-existent topic
-    Runnable t10 = () -> assertEquals(
-        topicManager.getLatestOffsetCached(nonExistentTopic, 0),
-        StatsErrorCode.LAG_MEASUREMENT_FAILURE.code);
+    Runnable t10 =
+        () -> assertEquals(topicManager.getLatestPositionCached(nonExistentTopic, 0), PubSubSymbolicPosition.LATEST);
 
     // get offset by time for an existing topic
     Runnable t15 = () -> assertEquals(
@@ -272,8 +278,8 @@ public class TopicManagerE2ETest {
     topicManager.invalidateCache(nonExistentTopic).get(1, TimeUnit.MINUTES); // should not throw an exception
     assertThrows(
         PubSubTopicDoesNotExistException.class,
-        () -> topicManager.getLatestOffsetWithRetries(new PubSubTopicPartitionImpl(nonExistentTopic, 0), 1));
-    assertEquals(topicManager.getLatestOffsetCached(nonExistentTopic, 1), StatsErrorCode.LAG_MEASUREMENT_FAILURE.code);
+        () -> topicManager.getLatestPositionWithRetries(new PubSubTopicPartitionImpl(nonExistentTopic, 0), 1));
+    assertEquals(topicManager.getLatestPositionCached(nonExistentTopic, 1), PubSubSymbolicPosition.LATEST);
   }
 
   @Test(timeOut = 3 * Time.MS_PER_MINUTE)
@@ -355,8 +361,19 @@ public class TopicManagerE2ETest {
         p0Messages.size(),
         "Number of records in partition p0 should match produced messages size. " + "Expected: " + p0Messages.size()
             + ", Actual: " + numRecordsInP0);
-    assertEquals(topicManager.getLatestOffsetWithRetries(p0, 5), p0Messages.size());
-    assertEquals(topicManager.getLatestOffsetCached(p0.getPubSubTopic(), 0), p0Messages.size());
+    PubSubPosition p0EndPosition = topicManager.getLatestPositionWithRetries(p0, 5);
+    long delta = topicManager.diffPosition(p0, p0EndPosition, PubSubSymbolicPosition.EARLIEST);
+    assertEquals(
+        delta,
+        p0Messages.size(),
+        "End position should be " + p0Messages.size() + " positions away from EARLIEST");
+
+    PubSubPosition p0EndPositionCached = topicManager.getLatestPositionCached(p0.getPubSubTopic(), 0);
+    long deltaCached = topicManager.diffPosition(p0, p0EndPositionCached, PubSubSymbolicPosition.EARLIEST);
+    assertEquals(
+        deltaCached,
+        p0Messages.size(),
+        "End position from cache should be " + p0Messages.size() + " positions away from EARLIEST");
 
     long numRecordsInP1 = topicManager.getNumRecordsInPartition(p1);
     assertEquals(
@@ -364,8 +381,20 @@ public class TopicManagerE2ETest {
         p1Messages.size(),
         "Number of records in partition p1 should match produced messages size. " + "Expected: " + p1Messages.size()
             + ", Actual: " + numRecordsInP1);
-    assertEquals(topicManager.getLatestOffsetWithRetries(p1, 5), p1Messages.size());
-    assertEquals(topicManager.getLatestOffsetCached(p1.getPubSubTopic(), 1), p1Messages.size());
+
+    PubSubPosition p1EndPosition = topicManager.getLatestPositionWithRetries(p1, 5);
+    long delta1 = topicManager.diffPosition(p1, p1EndPosition, PubSubSymbolicPosition.EARLIEST);
+    assertEquals(
+        delta1,
+        p1Messages.size(),
+        "End position should be " + p1Messages.size() + " positions away from EARLIEST");
+
+    PubSubPosition p1EndPositionCached = topicManager.getLatestPositionCached(p1.getPubSubTopic(), 1);
+    long delta1Cached = topicManager.diffPosition(p1, p1EndPositionCached, PubSubSymbolicPosition.EARLIEST);
+    assertEquals(
+        delta1Cached,
+        p1Messages.size(),
+        "End position from cache should be " + p1Messages.size() + " positions away from EARLIEST");
 
     long numRecordsInP2 = topicManager.getNumRecordsInPartition(p2);
     assertEquals(
@@ -373,8 +402,19 @@ public class TopicManagerE2ETest {
         p2Messages.size(),
         "Number of records in partition p2 should match produced messages size. " + "Expected: " + p2Messages.size()
             + ", Actual: " + numRecordsInP2);
-    assertEquals(topicManager.getLatestOffsetWithRetries(p2, 5), p2Messages.size());
-    assertEquals(topicManager.getLatestOffsetCached(p2.getPubSubTopic(), 2), p2Messages.size());
+
+    PubSubPosition p2EndPosition = topicManager.getLatestPositionWithRetries(p2, 5);
+    long delta2 = topicManager.diffPosition(p2, p2EndPosition, PubSubSymbolicPosition.EARLIEST);
+    assertEquals(
+        delta2,
+        p2Messages.size(),
+        "End position should be " + p2Messages.size() + " positions away from EARLIEST");
+    PubSubPosition p2EndPositionCached = topicManager.getLatestPositionCached(p2.getPubSubTopic(), 2);
+    long delta2Cached = topicManager.diffPosition(p2, p2EndPositionCached, PubSubSymbolicPosition.EARLIEST);
+    assertEquals(
+        delta2Cached,
+        p2Messages.size(),
+        "End position from cache should be " + p2Messages.size() + " positions away from EARLIEST");
 
     // except for the first 3 partitions, the latest offset should be 0
     for (int i = 3; i < numPartitions; i++) {
@@ -384,8 +424,21 @@ public class TopicManagerE2ETest {
           numRecordsInPartition,
           0L,
           "Number of records in partition " + partition + " should be 0. Actual: " + numRecordsInPartition);
-      assertEquals(topicManager.getLatestOffsetWithRetries(new PubSubTopicPartitionImpl(existingTopic, i), 5), 0L);
-      assertEquals(topicManager.getLatestOffsetCached(existingTopic, i), 0L);
+      PubSubPosition endPosition =
+          topicManager.getLatestPositionWithRetries(new PubSubTopicPartitionImpl(existingTopic, i), 5);
+      long diff = topicManager.diffPosition(partition, PubSubSymbolicPosition.EARLIEST, endPosition);
+      assertEquals(
+          diff,
+          0L,
+          "End position for partition " + partition + " should be equal to EARLIEST. Actual: " + endPosition);
+      // the cached latest position should also
+      PubSubPosition cachedEndPosition = topicManager.getLatestPositionCached(existingTopic, i);
+      long cachedDiff = topicManager.diffPosition(partition, PubSubSymbolicPosition.EARLIEST, cachedEndPosition);
+      assertEquals(
+          cachedDiff,
+          0L,
+          "Cached end position for partition " + partition + " should be equal to EARLIEST. Actual: "
+              + cachedEndPosition);
     }
 
     // if timestamp is greater than the latest message timestamp, the offset returned should be the latest offset
@@ -423,10 +476,10 @@ public class TopicManagerE2ETest {
     CountDownLatch latch = new CountDownLatch(1);
     Runnable[] tasks = { () -> {
       latch.countDown();
-      topicManager.getLatestOffsetCached(nonExistentTopic, 1);
+      topicManager.getLatestPositionCached(nonExistentTopic, 1);
     }, () -> {
       latch.countDown();
-      topicManager.getLatestOffsetWithRetries(new PubSubTopicPartitionImpl(nonExistentTopic, 0), 1);
+      topicManager.getLatestPositionWithRetries(new PubSubTopicPartitionImpl(nonExistentTopic, 0), 1);
     } };
 
     ExecutorService executorService = Executors.newFixedThreadPool(5);

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/pubsub/manager/TopicManagerIntegrationTest.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/pubsub/manager/TopicManagerIntegrationTest.java
@@ -77,7 +77,7 @@ public class TopicManagerIntegrationTest extends TopicManagerTest {
     // Put all topic manager calls related to partition offset fetcher with admin and consumer here.
     Runnable[] tasks = { () -> topicManager.getPositionByTime(pubSubTopicPartition, checkTimestamp),
         () -> topicManager.getPartitionCount(topic),
-        () -> topicManager.getLatestOffsetWithRetries(pubSubTopicPartition, 1),
+        () -> topicManager.getLatestPositionWithRetries(pubSubTopicPartition, 1),
         () -> topicManager.getEndPositionsForTopicWithRetries(topic) };
 
     for (int i = 0; i < numberOfThreads; i++) {

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/kafka/consumer/AdminConsumptionTask.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/kafka/consumer/AdminConsumptionTask.java
@@ -1230,16 +1230,27 @@ public class AdminConsumptionTask implements Runnable, Closeable {
        *  In the default read_uncommitted isolation level, the end offset is the high watermark (that is, the offset of
        *  the last successfully replicated message plus one), so subtract 1 from the max offset result.
        */
-      long sourceAdminTopicEndOffset =
-          sourceKafkaClusterTopicManager.getLatestOffsetWithRetries(adminTopicPartition, 10) - 1;
+
+      PubSubPosition latestPosition =
+          sourceKafkaClusterTopicManager.getLatestPositionWithRetries(adminTopicPartition, 10);
+      if (PubSubSymbolicPosition.LATEST.equals(latestPosition)) {
+        LOGGER.debug(
+            "Cannot get latest position for admin topic: {}, skip this round of lag metrics emission",
+            adminTopicPartition);
+        stats.setAdminConsumptionOffsetLag(Long.MAX_VALUE);
+        return;
+      }
+
       /**
        * If the first consumer poll returns nothing, "lastConsumedOffset" will remain as {@link #UNASSIGNED_VALUE}, so a
        * huge lag will be reported, but actually that's not case since consumer is subscribed to the last checkpoint offset.
        */
       if (!PubSubSymbolicPosition.EARLIEST.equals(lastConsumedPosition)) {
-        stats.setAdminConsumptionOffsetLag(sourceAdminTopicEndOffset - lastConsumedPosition.getNumericOffset());
+        stats.setAdminConsumptionOffsetLag(
+            sourceKafkaClusterTopicManager.diffPosition(adminTopicPartition, latestPosition, lastConsumedPosition) - 1);
       }
-      stats.setMaxAdminConsumptionOffsetLag(sourceAdminTopicEndOffset - lastPersistedPosition.getNumericOffset());
+      stats.setMaxAdminConsumptionOffsetLag(
+          sourceKafkaClusterTopicManager.diffPosition(adminTopicPartition, latestPosition, lastPersistedPosition) - 1);
     } catch (Exception e) {
       LOGGER.error(
           "Error when emitting admin consumption lag metrics; only log for warning; admin channel will continue to work.");

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/kafka/consumer/AdminConsumptionTask.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/kafka/consumer/AdminConsumptionTask.java
@@ -1227,8 +1227,8 @@ public class AdminConsumptionTask implements Runnable, Closeable {
   void recordConsumptionLag() {
     try {
       /**
-       *  In the default read_uncommitted isolation level, the end offset is the high watermark (that is, the offset of
-       *  the last successfully replicated message plus one), so subtract 1 from the max offset result.
+       *  In the default read_uncommitted isolation level, the end position is the high watermark (that is, the position
+       *  of the last successfully replicated message plus one), so subtract 1 from the max position result.
        */
 
       PubSubPosition latestPosition =


### PR DESCRIPTION
<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat], [protocol]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## Replace endOffset with endPosition API 
This change updates all code paths to use the new endPosition API instead of relying  
on topic manager and consumer endOffset calls. Tests are updated accordingly.  
 

###  Code changes
- [ ] Added new code behind **a config**. If so list the config names and their default values in the PR description.
- [ ] Introduced new **log lines**. 
  - [ ] Confirmed if logs need to be **rate limited** to avoid excessive logging.

###  **Concurrency-Specific Checks**
Both reviewer and PR author to verify
- [ ] Code has **no race conditions** or **thread safety issues**.
- [ ] Proper **synchronization mechanisms** (e.g., `synchronized`, `RWLock`) are used where needed.
- [ ] No **blocking calls** inside critical sections that could lead to deadlocks or performance degradation.
- [ ] Verified **thread-safe collections** are used (e.g., `ConcurrentHashMap`, `CopyOnWriteArrayList`).
- [ ] Validated proper exception handling in multi-threaded code to avoid silent thread termination.


## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->

- [ ] New unit tests added.
- [ ] New integration tests added.
- [ ] Modified or extended existing tests.
- [ ] Verified backward compatibility (if applicable).

## Does this PR introduce any user-facing or breaking changes?
<!--  
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [ ] No. You can skip the rest of this section.
- [ ] Yes. Clearly explain the behavior change and its impact.