### PR TITLE
[controller] Update the ProtocolVersionAutoDetectionService metrics to reflect the current status

### DIFF
--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/ProtocolVersionAutoDetectionService.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/ProtocolVersionAutoDetectionService.java
@@ -143,20 +143,18 @@ public class ProtocolVersionAutoDetectionService extends AbstractVeniceService {
         }
         long elapsedTimeInMs = LatencyUtils.getElapsedTimeFromMsToMs(startTime);
         stats.recordProtocolVersionAutoDetectionLatencySensor(elapsedTimeInMs);
-        stats.recordProtocolVersionAutoDetectionErrorSensor(decreaseFailureCount());
+        stats.recordProtocolVersionAutoDetectionErrorSensor(resetFailureCount());
       } catch (Exception e) {
-        LOGGER.error("Received an exception while running " + taskName, e);
+        LOGGER.error("Received an exception while running {}", taskName, e);
         stats.recordProtocolVersionAutoDetectionErrorSensor(increaseFailureCount());
       }
       LOGGER.info("Finished running task {}", taskName);
     };
   }
 
-  private int decreaseFailureCount() {
-    if (failureCount > 0) {
-      return --failureCount;
-    }
-    return failureCount; // Ensure failureCount does not go below zero
+  private int resetFailureCount() {
+    failureCount = 0;
+    return failureCount;
   }
 
   private int increaseFailureCount() {

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/stats/ProtocolVersionAutoDetectionStats.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/stats/ProtocolVersionAutoDetectionStats.java
@@ -3,6 +3,7 @@ package com.linkedin.venice.controller.stats;
 import com.linkedin.venice.stats.AbstractVeniceStats;
 import io.tehuti.metrics.MetricsRepository;
 import io.tehuti.metrics.Sensor;
+import io.tehuti.metrics.stats.Avg;
 import io.tehuti.metrics.stats.Gauge;
 
 
@@ -17,7 +18,7 @@ public class ProtocolVersionAutoDetectionStats extends AbstractVeniceStats {
     protocolVersionAutoDetectionErrorSensor =
         registerSensorIfAbsent(PROTOCOL_VERSION_AUTO_DETECTION_ERROR, new Gauge());
     protocolVersionAutoDetectionLatencySensor =
-        registerSensorIfAbsent(PROTOCOL_VERSION_AUTO_DETECTION_LATENCY, new Gauge());
+        registerSensorIfAbsent(PROTOCOL_VERSION_AUTO_DETECTION_LATENCY, new Avg());
   }
 
   public void recordProtocolVersionAutoDetectionErrorSensor(int count) {


### PR DESCRIPTION
## Problem Statement
There are 2 issues with ProtocolVersionAutoDetectionStats:
1. The failure count always increase when it fails. While the failure count is good, we want to see whether the service is recovering or not.
2. The latency timestamp does not need Avg and Max since we run every 10 mins. Hence, we can use purely Gauge.

## Solution
1. Increase and Decrease the failure count based on the status of task run
2. Remove Max metrics, keep Avg to keep track of the latency itself.


###  Code changes
- [ ] Added new code behind **a config**. If so list the config names and their default values in the PR description.
- [ ] Introduced new **log lines**. 
  - [ ] Confirmed if logs need to be **rate limited** to avoid excessive logging.

###  **Concurrency-Specific Checks**
Both reviewer and PR author to verify
- [x] Code has **no race conditions** or **thread safety issues**.
- [x] Proper **synchronization mechanisms** (e.g., `synchronized`, `RWLock`) are used where needed.
- [x] No **blocking calls** inside critical sections that could lead to deadlocks or performance degradation.
- [x] Verified **thread-safe collections** are used (e.g., `ConcurrentHashMap`, `CopyOnWriteArrayList`).
- [x] Validated proper exception handling in multi-threaded code to avoid silent thread termination.


## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->

- [ ] New unit tests added.
- [ ] New integration tests added.
- [ ] Modified or extended existing tests.
- [ ] Verified backward compatibility (if applicable).

## Does this PR introduce any user-facing or breaking changes?
<!--  
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Clearly explain the behavior change and its impact.