### PR TITLE
[controller][client] Do not track stats for system store readers used in controller

### DIFF
--- a/clients/venice-thin-client/src/main/java/com/linkedin/venice/client/store/ClientConfig.java
+++ b/clients/venice-thin-client/src/main/java/com/linkedin/venice/client/store/ClientConfig.java
@@ -35,6 +35,7 @@ public class ClientConfig<T extends SpecificRecord> {
   private Class<T> specificValueClass = null;
   private Schema specificValueSchema = null;
   private boolean isVsonClient = false;
+  private boolean isStatTrackingEnabled = true;
 
   // D2 specific settings
   private boolean isD2Routing = false;
@@ -102,6 +103,7 @@ public class ClientConfig<T extends SpecificRecord> {
         .setSpecificValueClass(config.getSpecificValueClass())
         .setSpecificValueSchema(config.getSpecificValueSchema())
         .setVsonClient(config.isVsonClient())
+        .setStatTrackingEnabled(config.isStatTrackingEnabled())
 
         // D2 specific settings
         .setD2ServiceName(config.getD2ServiceName())
@@ -246,6 +248,15 @@ public class ClientConfig<T extends SpecificRecord> {
       setD2Routing(false);
     }
 
+    return this;
+  }
+
+  public boolean isStatTrackingEnabled() {
+    return isStatTrackingEnabled;
+  }
+
+  public ClientConfig<T> setStatTrackingEnabled(boolean statTrackingEnabled) {
+    this.isStatTrackingEnabled = statTrackingEnabled;
     return this;
   }
 

--- a/clients/venice-thin-client/src/main/java/com/linkedin/venice/client/store/SpecificRetriableStoreClient.java
+++ b/clients/venice-thin-client/src/main/java/com/linkedin/venice/client/store/SpecificRetriableStoreClient.java
@@ -9,9 +9,7 @@ import org.apache.avro.specific.SpecificRecord;
  */
 public class SpecificRetriableStoreClient<K, V extends SpecificRecord> extends RetriableStoreClient<K, V>
     implements AvroSpecificStoreClient<K, V> {
-  public SpecificRetriableStoreClient(
-      SpecificStatTrackingStoreClient<K, V> innerStoreClient,
-      ClientConfig clientConfig) {
+  public SpecificRetriableStoreClient(InternalAvroStoreClient<K, V> innerStoreClient, ClientConfig clientConfig) {
     super(innerStoreClient, clientConfig);
   }
 }

--- a/internal/venice-common/src/main/java/com/linkedin/venice/controllerapi/ControllerClient.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/controllerapi/ControllerClient.java
@@ -125,6 +125,7 @@ public class ControllerClient implements Closeable {
 
   private static final int DEFAULT_MAX_ATTEMPTS = 10;
   private static final int QUERY_JOB_STATUS_TIMEOUT = 60 * Time.MS_PER_SECOND;
+  private static final int QUERY_HEARTBEAT_TIMEOUT = 10 * Time.MS_PER_SECOND;
   private static final int DEFAULT_REQUEST_TIMEOUT_MS = 600 * Time.MS_PER_SECOND;
   private final Optional<SSLFactory> sslFactory;
   private final String clusterName;
@@ -1177,7 +1178,11 @@ public class ControllerClient implements Closeable {
     return request(
         ControllerRoute.GET_HEARTBEAT_TIMESTAMP_FROM_SYSTEM_STORE,
         params,
-        SystemStoreHeartbeatResponse.class);
+        SystemStoreHeartbeatResponse.class,
+        QUERY_HEARTBEAT_TIMEOUT,
+        DEFAULT_MAX_ATTEMPTS,
+        null,
+        null);
   }
 
   public ControllerResponse configureActiveActiveReplicationForCluster(

--- a/internal/venice-common/src/main/java/com/linkedin/venice/pushstatushelper/PushStatusStoreReader.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/pushstatushelper/PushStatusStoreReader.java
@@ -349,6 +349,7 @@ public class PushStatusStoreReader implements Closeable {
           ClientConfig.defaultGenericClientConfig(VeniceSystemStoreUtils.getDaVinciPushStatusStoreName(storeName))
               .setD2Client(d2Client)
               .setD2ServiceName(clusterDiscoveryD2ServiceName)
+              .setStatTrackingEnabled(false)
               .setSpecificValueClass(PushStatusValue.class);
       return ClientFactory.getAndStartSpecificAvroClient(clientConfig);
     });

--- a/internal/venice-common/src/main/java/com/linkedin/venice/system/store/MetaStoreReader.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/system/store/MetaStoreReader.java
@@ -54,6 +54,7 @@ public class MetaStoreReader implements Closeable {
           ClientConfig.defaultGenericClientConfig(VeniceSystemStoreUtils.getMetaStoreName(storeName))
               .setD2Client(d2Client)
               .setD2ServiceName(clusterDiscoveryD2ServiceName)
+              .setStatTrackingEnabled(false)
               .setSpecificValueClass(StoreMetaValue.class);
       return ClientFactory.getAndStartSpecificAvroClient(clientConfig);
     });


### PR DESCRIPTION


<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat], [protocol]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## [controller][client] Do not track stats for system store readers used in controller

In test environment large cluster testing, controller went OOM when system store repair service is enabled.
After checking with heapdump, we identified that every system store reader created inside child controller (for heartbeat retrieval) will create a full thin-client. Each thin-client will internally create a stat tracking client that will register metrics for single / batch get and compute operation that's not used and consume huge amount of memory (e.g. Histogram Tehuti metric). 
<!--
Describe
- What problem are you trying to solve
- What issues or limitations exist in the current code
- Why this change is necessary 
-->


## Solution

This PR solves the issue by introduce a knob in ClientConfig to control whether a StatTrackingClient is created to wrap around the internal Avro generic or specific client. For controller system store repair service, this is set to false as we don't need to track metrics for them. The default config value is still true to maintain backward compatibility.

This PR also set a timeout for controller client API for heartbeat retrieval (default 10 min per API call). This is to make sure any issue in the client initialization in child controller will not greatly slowdown the check process.

This PR also adds more logging in the SystemStoreRepairTask to make it easier for each step's progress tracking. It is useful for analyzing performance bottleneck when iterating over large scale cluster.


<!--
Describe
- What changes you are making and why. 
- How these changes solve the problem.
- Any performance considerations or trade-offs. 
- Describe what testings you have done, for example, performance testing etc.
-->


###  Code changes
- [ ] Added new code behind **a config**. If so list the config names and their default values in the PR description.
- [ ] Introduced new **log lines**. 
  - [ ] Confirmed if logs need to be **rate limited** to avoid excessive logging.

###  **Concurrency-Specific Checks**
Both reviewer and PR author to verify
- [ ] Code has **no race conditions** or **thread safety issues**.
- [ ] Proper **synchronization mechanisms** (e.g., `synchronized`, `RWLock`) are used where needed.
- [ ] No **blocking calls** inside critical sections that could lead to deadlocks or performance degradation.
- [ ] Verified **thread-safe collections** are used (e.g., `ConcurrentHashMap`, `CopyOnWriteArrayList`).
- [ ] Validated proper exception handling in multi-threaded code to avoid silent thread termination.


## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->

- [ ] New unit tests added.
- [ ] New integration tests added.
- [ ] Modified or extended existing tests.
- [ ] Verified backward compatibility (if applicable).

## Does this PR introduce any user-facing or breaking changes?
<!--  
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Clearly explain the behavior change and its impact.