### PR TITLE
[server] Remove unused replica progress reporting in ReplicaStatus  

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/notifier/PushStatusNotifier.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/notifier/PushStatusNotifier.java
@@ -69,7 +69,7 @@ public class PushStatusNotifier implements VeniceNotifier {
   @Override
   public void restarted(String topic, int partitionId, PubSubPosition position, String message) {
     helixPartitionStatusAccessor.updateReplicaStatus(topic, partitionId, STARTED);
-    offLinePushAccessor.updateReplicaStatus(topic, partitionId, instanceId, STARTED, NO_PROGRESS, "");
+    offLinePushAccessor.updateReplicaStatus(topic, partitionId, instanceId, STARTED, "");
   }
 
   @Override
@@ -84,7 +84,7 @@ public class PushStatusNotifier implements VeniceNotifier {
       LOGGER.error("Could not update CV update to COMPLETED, skipping to update OfflinePushStatus for {}", topic, e);
       return;
     }
-    offLinePushAccessor.updateReplicaStatus(topic, partitionId, instanceId, COMPLETED, NO_PROGRESS, "");
+    offLinePushAccessor.updateReplicaStatus(topic, partitionId, instanceId, COMPLETED, "");
   }
 
   @Override
@@ -102,23 +102,22 @@ public class PushStatusNotifier implements VeniceNotifier {
   @Override
   public void progress(String topic, int partitionId, PubSubPosition position, String message) {
     helixPartitionStatusAccessor.updateReplicaStatus(topic, partitionId, PROGRESS);
-    offLinePushAccessor.updateReplicaStatus(topic, partitionId, instanceId, PROGRESS, NO_PROGRESS, "");
+    offLinePushAccessor.updateReplicaStatus(topic, partitionId, instanceId, PROGRESS, "");
   }
 
   @Override
   public void endOfPushReceived(String topic, int partitionId, PubSubPosition position, String message) {
-    offLinePushAccessor.updateReplicaStatus(topic, partitionId, instanceId, END_OF_PUSH_RECEIVED, NO_PROGRESS, "");
+    offLinePushAccessor.updateReplicaStatus(topic, partitionId, instanceId, END_OF_PUSH_RECEIVED, "");
   }
 
   @Override
   public void topicSwitchReceived(String topic, int partitionId, PubSubPosition position, String message) {
-    offLinePushAccessor.updateReplicaStatus(topic, partitionId, instanceId, TOPIC_SWITCH_RECEIVED, NO_PROGRESS, "");
+    offLinePushAccessor.updateReplicaStatus(topic, partitionId, instanceId, TOPIC_SWITCH_RECEIVED, "");
   }
 
   @Override
   public void dataRecoveryCompleted(String kafkaTopic, int partitionId, PubSubPosition position, String message) {
-    offLinePushAccessor
-        .updateReplicaStatus(kafkaTopic, partitionId, instanceId, DATA_RECOVERY_COMPLETED, NO_PROGRESS, message);
+    offLinePushAccessor.updateReplicaStatus(kafkaTopic, partitionId, instanceId, DATA_RECOVERY_COMPLETED, message);
   }
 
   @Override
@@ -139,7 +138,7 @@ public class PushStatusNotifier implements VeniceNotifier {
       ExecutionStatus status) {
     if (incrementalPushStatusWriteMode == IncrementalPushStatusWriteMode.ZOOKEEPER_ONLY
         || incrementalPushStatusWriteMode == IncrementalPushStatusWriteMode.DUAL) {
-      offLinePushAccessor.updateReplicaStatus(topic, partitionId, instanceId, status, offset, message);
+      offLinePushAccessor.updateReplicaStatus(topic, partitionId, instanceId, status, message);
     }
     if (incrementalPushStatusWriteMode == IncrementalPushStatusWriteMode.PUSH_STATUS_SYSTEM_STORE_ONLY
         || incrementalPushStatusWriteMode == IncrementalPushStatusWriteMode.DUAL) {
@@ -156,12 +155,8 @@ public class PushStatusNotifier implements VeniceNotifier {
 
     if (incrementalPushStatusWriteMode == IncrementalPushStatusWriteMode.ZOOKEEPER_ONLY
         || incrementalPushStatusWriteMode == IncrementalPushStatusWriteMode.DUAL) {
-      offLinePushAccessor.batchUpdateReplicaIncPushStatus(
-          topic,
-          partitionId,
-          instanceId,
-          NO_PROGRESS,
-          pendingReportIncPushVersionList);
+      offLinePushAccessor
+          .batchUpdateReplicaIncPushStatus(topic, partitionId, instanceId, pendingReportIncPushVersionList);
     }
     if (incrementalPushStatusWriteMode == IncrementalPushStatusWriteMode.PUSH_STATUS_SYSTEM_STORE_ONLY
         || incrementalPushStatusWriteMode == IncrementalPushStatusWriteMode.DUAL) {

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/notifier/PushStatusNotifier.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/notifier/PushStatusNotifier.java
@@ -9,6 +9,7 @@ import static com.linkedin.venice.pushmonitor.ExecutionStatus.PROGRESS;
 import static com.linkedin.venice.pushmonitor.ExecutionStatus.STARTED;
 import static com.linkedin.venice.pushmonitor.ExecutionStatus.START_OF_INCREMENTAL_PUSH_RECEIVED;
 import static com.linkedin.venice.pushmonitor.ExecutionStatus.TOPIC_SWITCH_RECEIVED;
+import static com.linkedin.venice.pushmonitor.ReplicaStatus.NO_PROGRESS;
 
 import com.linkedin.davinci.config.VeniceServerConfig.IncrementalPushStatusWriteMode;
 import com.linkedin.venice.common.PushStatusStoreUtils;
@@ -68,7 +69,7 @@ public class PushStatusNotifier implements VeniceNotifier {
   @Override
   public void restarted(String topic, int partitionId, PubSubPosition position, String message) {
     helixPartitionStatusAccessor.updateReplicaStatus(topic, partitionId, STARTED);
-    offLinePushAccessor.updateReplicaStatus(topic, partitionId, instanceId, STARTED, position.getNumericOffset(), "");
+    offLinePushAccessor.updateReplicaStatus(topic, partitionId, instanceId, STARTED, NO_PROGRESS, "");
   }
 
   @Override
@@ -83,7 +84,7 @@ public class PushStatusNotifier implements VeniceNotifier {
       LOGGER.error("Could not update CV update to COMPLETED, skipping to update OfflinePushStatus for {}", topic, e);
       return;
     }
-    offLinePushAccessor.updateReplicaStatus(topic, partitionId, instanceId, COMPLETED, position.getNumericOffset(), "");
+    offLinePushAccessor.updateReplicaStatus(topic, partitionId, instanceId, COMPLETED, NO_PROGRESS, "");
   }
 
   @Override
@@ -101,50 +102,33 @@ public class PushStatusNotifier implements VeniceNotifier {
   @Override
   public void progress(String topic, int partitionId, PubSubPosition position, String message) {
     helixPartitionStatusAccessor.updateReplicaStatus(topic, partitionId, PROGRESS);
-    offLinePushAccessor.updateReplicaStatus(topic, partitionId, instanceId, PROGRESS, position.getNumericOffset(), "");
+    offLinePushAccessor.updateReplicaStatus(topic, partitionId, instanceId, PROGRESS, NO_PROGRESS, "");
   }
 
   @Override
   public void endOfPushReceived(String topic, int partitionId, PubSubPosition position, String message) {
-    offLinePushAccessor
-        .updateReplicaStatus(topic, partitionId, instanceId, END_OF_PUSH_RECEIVED, position.getNumericOffset(), "");
+    offLinePushAccessor.updateReplicaStatus(topic, partitionId, instanceId, END_OF_PUSH_RECEIVED, NO_PROGRESS, "");
   }
 
   @Override
   public void topicSwitchReceived(String topic, int partitionId, PubSubPosition position, String message) {
-    offLinePushAccessor
-        .updateReplicaStatus(topic, partitionId, instanceId, TOPIC_SWITCH_RECEIVED, position.getNumericOffset(), "");
+    offLinePushAccessor.updateReplicaStatus(topic, partitionId, instanceId, TOPIC_SWITCH_RECEIVED, NO_PROGRESS, "");
   }
 
   @Override
   public void dataRecoveryCompleted(String kafkaTopic, int partitionId, PubSubPosition position, String message) {
-    offLinePushAccessor.updateReplicaStatus(
-        kafkaTopic,
-        partitionId,
-        instanceId,
-        DATA_RECOVERY_COMPLETED,
-        position.getNumericOffset(),
-        message);
+    offLinePushAccessor
+        .updateReplicaStatus(kafkaTopic, partitionId, instanceId, DATA_RECOVERY_COMPLETED, NO_PROGRESS, message);
   }
 
   @Override
   public void startOfIncrementalPushReceived(String topic, int partitionId, PubSubPosition position, String message) {
-    updateIncrementalPushStatus(
-        topic,
-        partitionId,
-        position.getNumericOffset(),
-        message,
-        START_OF_INCREMENTAL_PUSH_RECEIVED);
+    updateIncrementalPushStatus(topic, partitionId, NO_PROGRESS, message, START_OF_INCREMENTAL_PUSH_RECEIVED);
   }
 
   @Override
   public void endOfIncrementalPushReceived(String topic, int partitionId, PubSubPosition position, String message) {
-    updateIncrementalPushStatus(
-        topic,
-        partitionId,
-        position.getNumericOffset(),
-        message,
-        END_OF_INCREMENTAL_PUSH_RECEIVED);
+    updateIncrementalPushStatus(topic, partitionId, NO_PROGRESS, message, END_OF_INCREMENTAL_PUSH_RECEIVED);
   }
 
   private void updateIncrementalPushStatus(
@@ -176,7 +160,7 @@ public class PushStatusNotifier implements VeniceNotifier {
           topic,
           partitionId,
           instanceId,
-          position.getNumericOffset(),
+          NO_PROGRESS,
           pendingReportIncPushVersionList);
     }
     if (incrementalPushStatusWriteMode == IncrementalPushStatusWriteMode.PUSH_STATUS_SYSTEM_STORE_ONLY

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/notifier/TestPushStatusNotifier.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/notifier/TestPushStatusNotifier.java
@@ -8,7 +8,6 @@ import static com.linkedin.venice.pushmonitor.ExecutionStatus.START_OF_INCREMENT
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.anyLong;
 import static org.mockito.Mockito.anyString;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;
@@ -77,12 +76,12 @@ public class TestPushStatusNotifier {
     PubSubPosition p1 = ApacheKafkaOffsetPosition.of(1L);
 
     statusNotifier.completed(topic, 1, p1, "");
-    verify(offlinePushAccessor, times(1)).updateReplicaStatus(topic, 1, host, ExecutionStatus.COMPLETED, 1, "");
+    verify(offlinePushAccessor, times(1)).updateReplicaStatus(topic, 1, host, ExecutionStatus.COMPLETED, "");
 
     doThrow(HelixException.class).when(helixPartitionStatusAccessor)
         .updateReplicaStatus(any(), anyInt(), eq(ExecutionStatus.COMPLETED));
     statusNotifier.completed(topic, 1, p1, "");
-    verify(offlinePushAccessor, never()).updateReplicaStatus(topic, 1, "host", ExecutionStatus.COMPLETED, 1, "");
+    verify(offlinePushAccessor, never()).updateReplicaStatus(topic, 1, "host", ExecutionStatus.COMPLETED, "");
 
     doReturn(mock(Store.class)).when(storeRepository).getStoreOrThrow(any());
     statusNotifier.startOfIncrementalPushReceived(topic, 1, p1, "");
@@ -119,16 +118,11 @@ public class TestPushStatusNotifier {
     notifier.startOfIncrementalPushReceived(TOPIC, PARTITION_ID, POSITION_12345, MESSAGE);
 
     if (expectZookeeper) {
-      verify(offlinePushAccessor, times(1)).updateReplicaStatus(
-          TOPIC,
-          PARTITION_ID,
-          INSTANCE_ID,
-          START_OF_INCREMENTAL_PUSH_RECEIVED,
-          POSITION_12345.getInternalOffset(),
-          MESSAGE);
+      verify(offlinePushAccessor, times(1))
+          .updateReplicaStatus(TOPIC, PARTITION_ID, INSTANCE_ID, START_OF_INCREMENTAL_PUSH_RECEIVED, MESSAGE);
     } else {
       verify(offlinePushAccessor, never())
-          .updateReplicaStatus(anyString(), anyInt(), anyString(), any(ExecutionStatus.class), anyLong(), anyString());
+          .updateReplicaStatus(anyString(), anyInt(), anyString(), any(ExecutionStatus.class), anyString());
     }
 
     if (expectPushStatusStore) {
@@ -162,16 +156,11 @@ public class TestPushStatusNotifier {
     notifier.endOfIncrementalPushReceived(TOPIC, PARTITION_ID, POSITION_12345, MESSAGE);
 
     if (expectZookeeper) {
-      verify(offlinePushAccessor, times(1)).updateReplicaStatus(
-          TOPIC,
-          PARTITION_ID,
-          INSTANCE_ID,
-          END_OF_INCREMENTAL_PUSH_RECEIVED,
-          POSITION_12345.getInternalOffset(),
-          MESSAGE);
+      verify(offlinePushAccessor, times(1))
+          .updateReplicaStatus(TOPIC, PARTITION_ID, INSTANCE_ID, END_OF_INCREMENTAL_PUSH_RECEIVED, MESSAGE);
     } else {
       verify(offlinePushAccessor, never())
-          .updateReplicaStatus(anyString(), anyInt(), anyString(), any(ExecutionStatus.class), anyLong(), anyString());
+          .updateReplicaStatus(anyString(), anyInt(), anyString(), any(ExecutionStatus.class), anyString());
     }
 
     if (expectPushStatusStore) {
@@ -211,15 +200,10 @@ public class TestPushStatusNotifier {
     notifier.batchEndOfIncrementalPushReceived(TOPIC, PARTITION_ID, POSITION_12345, incPushVersions);
 
     if (expectZookeeper) {
-      verify(offlinePushAccessor, times(1)).batchUpdateReplicaIncPushStatus(
-          TOPIC,
-          PARTITION_ID,
-          INSTANCE_ID,
-          POSITION_12345.getInternalOffset(),
-          incPushVersions);
+      verify(offlinePushAccessor, times(1))
+          .batchUpdateReplicaIncPushStatus(TOPIC, PARTITION_ID, INSTANCE_ID, incPushVersions);
     } else {
-      verify(offlinePushAccessor, never())
-          .batchUpdateReplicaIncPushStatus(anyString(), anyInt(), anyString(), anyLong(), any());
+      verify(offlinePushAccessor, never()).batchUpdateReplicaIncPushStatus(anyString(), anyInt(), anyString(), any());
     }
 
     if (expectPushStatusStore) {

--- a/internal/venice-common/src/main/java/com/linkedin/venice/helix/VeniceOfflinePushMonitorAccessor.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/helix/VeniceOfflinePushMonitorAccessor.java
@@ -10,7 +10,6 @@ import com.linkedin.venice.pushmonitor.OfflinePushStatus;
 import com.linkedin.venice.pushmonitor.PartitionStatus;
 import com.linkedin.venice.pushmonitor.PartitionStatusListener;
 import com.linkedin.venice.pushmonitor.ReadOnlyPartitionStatus;
-import com.linkedin.venice.pushmonitor.ReplicaStatus;
 import com.linkedin.venice.utils.HelixUtils;
 import com.linkedin.venice.utils.LogContext;
 import com.linkedin.venice.utils.PathResourceRegistry;
@@ -227,25 +226,8 @@ public class VeniceOfflinePushMonitorAccessor implements OfflinePushAccessor {
       int partitionId,
       String instanceId,
       ExecutionStatus status,
-      long progress,
       String incrementalPushVersion) {
-    compareAndUpdateReplicaStatus(topic, partitionId, instanceId, status, progress, incrementalPushVersion);
-  }
-
-  @Override
-  public void updateReplicaStatus(
-      String topic,
-      int partitionId,
-      String instanceId,
-      ExecutionStatus status,
-      String incrementalPushVersion) {
-    compareAndUpdateReplicaStatus(
-        topic,
-        partitionId,
-        instanceId,
-        status,
-        ReplicaStatus.NO_PROGRESS,
-        incrementalPushVersion);
+    compareAndUpdateReplicaStatus(topic, partitionId, instanceId, status, incrementalPushVersion);
   }
 
   @Override
@@ -253,9 +235,8 @@ public class VeniceOfflinePushMonitorAccessor implements OfflinePushAccessor {
       String kafkaTopic,
       int partitionId,
       String instanceId,
-      long progress,
       List<String> pendingReportIncPushVersionList) {
-    compareAndBatchUpdateReplicaStatus(kafkaTopic, partitionId, instanceId, progress, pendingReportIncPushVersionList);
+    compareAndBatchUpdateReplicaStatus(kafkaTopic, partitionId, instanceId, pendingReportIncPushVersionList);
   }
 
   /**
@@ -274,7 +255,6 @@ public class VeniceOfflinePushMonitorAccessor implements OfflinePushAccessor {
       int partitionId,
       String instanceId,
       ExecutionStatus status,
-      long progress,
       String incrementalPushVersion) {
     // If a version was created prior to the deployment of this new push monitor, an exception would be thrown while
     // upgrading venice server.
@@ -296,7 +276,7 @@ public class VeniceOfflinePushMonitorAccessor implements OfflinePushAccessor {
         currentData = new PartitionStatus(partitionId);
       }
 
-      currentData.updateReplicaStatus(instanceId, status, incrementalPushVersion, progress);
+      currentData.updateReplicaStatus(instanceId, status, incrementalPushVersion);
       return currentData;
     });
     LOGGER.info("Updated replica status for replica: {} status: {} in cluster: {}.", replicaId, status, clusterName);
@@ -306,7 +286,6 @@ public class VeniceOfflinePushMonitorAccessor implements OfflinePushAccessor {
       String topic,
       int partitionId,
       String instanceId,
-      long progress,
       List<String> incPushBatchStatus) {
     if (!pushStatusExists(topic)) {
       return;
@@ -317,7 +296,7 @@ public class VeniceOfflinePushMonitorAccessor implements OfflinePushAccessor {
       if (currentData == null) {
         currentData = new PartitionStatus(partitionId);
       }
-      currentData.batchUpdateReplicaIncPushStatus(instanceId, incPushBatchStatus, progress);
+      currentData.batchUpdateReplicaIncPushStatus(instanceId, incPushBatchStatus);
       return currentData;
     });
     LOGGER.info(

--- a/internal/venice-common/src/main/java/com/linkedin/venice/pushmonitor/OfflinePushAccessor.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/pushmonitor/OfflinePushAccessor.java
@@ -49,18 +49,7 @@ public interface OfflinePushAccessor {
   void deleteOfflinePushStatusAndItsPartitionStatuses(String kafkaTopic);
 
   /**
-   * Update one particular replica status and progress by given topic, partition and instanceId to the persistent storage.
-   */
-  void updateReplicaStatus(
-      String kafkaTopic,
-      int partitionId,
-      String instanceId,
-      ExecutionStatus status,
-      long progress,
-      String message);
-
-  /**
-   * Update one particular replica status only by given topic, partition and instanceId to the persistent storage.
+   * Update one particular replica status by given topic, partition and instanceId to the persistent storage.
    */
   void updateReplicaStatus(
       String kafkaTopic,
@@ -73,7 +62,6 @@ public interface OfflinePushAccessor {
       String kafkaTopic,
       int partitionId,
       String instanceId,
-      long progress,
       List<String> pendingReportIncPushVersionList) {
   }
 

--- a/internal/venice-common/src/main/java/com/linkedin/venice/pushmonitor/PartitionStatus.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/pushmonitor/PartitionStatus.java
@@ -38,26 +38,13 @@ public class PartitionStatus implements Comparable<PartitionStatus> {
     updateReplicaStatus(instanceId, newStatus, "", enableStatusHistory);
   }
 
-  public void updateReplicaStatus(
-      String instanceId,
-      ExecutionStatus newStatus,
-      String incrementalPushVersion,
-      long progress) {
-    ReplicaStatus replicaStatus = updateReplicaStatus(instanceId, newStatus, incrementalPushVersion, true);
-    replicaStatus.setCurrentProgress(progress);
+  public void updateReplicaStatus(String instanceId, ExecutionStatus newStatus, String incrementalPushVersion) {
+    updateReplicaStatus(instanceId, newStatus, incrementalPushVersion, true);
   }
 
-  public void batchUpdateReplicaIncPushStatus(String instanceId, List<String> incPushVersionList, long progress) {
-    ReplicaStatus replicaStatus = null;
+  public void batchUpdateReplicaIncPushStatus(String instanceId, List<String> incPushVersionList) {
     for (String incrementalPushVersion: incPushVersionList) {
-      replicaStatus = updateReplicaStatus(
-          instanceId,
-          ExecutionStatus.END_OF_INCREMENTAL_PUSH_RECEIVED,
-          incrementalPushVersion,
-          true);
-    }
-    if (replicaStatus != null) {
-      replicaStatus.setCurrentProgress(progress);
+      updateReplicaStatus(instanceId, ExecutionStatus.END_OF_INCREMENTAL_PUSH_RECEIVED, incrementalPushVersion, true);
     }
   }
 

--- a/internal/venice-common/src/main/java/com/linkedin/venice/pushmonitor/ReadOnlyPartitionStatus.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/pushmonitor/ReadOnlyPartitionStatus.java
@@ -17,16 +17,17 @@ public class ReadOnlyPartitionStatus extends PartitionStatus {
 
   @Override
   public void updateReplicaStatus(String instanceId, ExecutionStatus newStatus, boolean enableStatusHistory) {
-    throw new VeniceException("Unsupported operation in ReadonlyPartition status: updateProgress.");
+    throw new VeniceException("Unsupported operation in ReadonlyPartition status: updateReplicaStatus.");
   }
 
   @Override
-  public void updateReplicaStatus(
-      String instanceId,
-      ExecutionStatus newStatus,
-      String incrementalPushVersion,
-      long progress) {
-    throw new VeniceException("Unsupported operation in ReadonlyPartition status: updateProgress.");
+  public void updateReplicaStatus(String instanceId, ExecutionStatus newStatus, String incrementalPushVersion) {
+    throw new VeniceException("Unsupported operation in ReadonlyPartition status: updateReplicaStatus.");
+  }
+
+  @Override
+  public void batchUpdateReplicaIncPushStatus(String instanceId, java.util.List<String> incPushVersionList) {
+    throw new VeniceException("Unsupported operation in ReadonlyPartition status: batchUpdateReplicaIncPushStatus.");
   }
 
   public static ReadOnlyPartitionStatus fromPartitionStatus(PartitionStatus partitionStatus) {

--- a/internal/venice-common/src/main/java/com/linkedin/venice/pushmonitor/ReplicaStatus.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/pushmonitor/ReplicaStatus.java
@@ -8,6 +8,7 @@ import static com.linkedin.venice.pushmonitor.ExecutionStatus.TOPIC_SWITCH_RECEI
 import static com.linkedin.venice.pushmonitor.ExecutionStatus.isIncrementalPushStatus;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.linkedin.venice.utils.Pair;
 import java.time.LocalDateTime;
@@ -26,7 +27,6 @@ public class ReplicaStatus {
   public static final long NO_PROGRESS = -1;
   private final String instanceId;
   private ExecutionStatus currentStatus = STARTED;
-  private long currentProgress = 0;
   /**
    *  This field is only used by incremental push status
    *  Check out {@link ExecutionStatus#START_OF_INCREMENTAL_PUSH_RECEIVED} and
@@ -71,14 +71,24 @@ public class ReplicaStatus {
     this.currentStatus = currentStatus;
   }
 
+  /**
+   * @deprecated This field has been removed. Always returns 0 for backward compatibility.
+   * @return 0 (for backward compatibility)
+   */
+  @Deprecated
+  @JsonIgnore
   public long getCurrentProgress() {
-    return currentProgress;
+    return 0;
   }
 
+  /**
+   * @deprecated This field has been removed. This method is kept for JSON deserialization compatibility.
+   * @param currentProgress ignored parameter
+   */
+  @Deprecated
+  @JsonProperty("currentProgress")
   public void setCurrentProgress(long currentProgress) {
-    if (currentProgress != NO_PROGRESS) {
-      this.currentProgress = currentProgress;
-    }
+    // No-op: field has been removed but setter kept for backward compatibility during deserialization
   }
 
   public String getIncrementalPushVersion() {
@@ -205,9 +215,6 @@ public class ReplicaStatus {
 
     ReplicaStatus that = (ReplicaStatus) o;
 
-    if (currentProgress != that.currentProgress) {
-      return false;
-    }
     if (!instanceId.equals(that.instanceId)) {
       return false;
     }
@@ -225,7 +232,6 @@ public class ReplicaStatus {
     int result = instanceId.hashCode();
     result = 31 * result + currentStatus.hashCode();
     result = 31 * result + incrementalPushVersion.hashCode();
-    result = 31 * result + (int) (currentProgress ^ (currentProgress >>> 32));
     result = 31 * result + Objects.hashCode(statusHistory);
     return result;
   }

--- a/internal/venice-common/src/test/java/com/linkedin/venice/helix/OfflinePushMonitorAccessorTest.java
+++ b/internal/venice-common/src/test/java/com/linkedin/venice/helix/OfflinePushMonitorAccessorTest.java
@@ -58,7 +58,7 @@ public class OfflinePushMonitorAccessorTest {
         LogContext.EMPTY);
     when(mockPartitionStatusAccessor.exists(anyString(), anyInt())).thenReturn(true);
     when(mockPartitionStatusAccessor.update(anyString(), any(), anyInt())).thenReturn(true);
-    accessor.batchUpdateReplicaIncPushStatus("test_topic", 0, "test_instance_id", 100L, Arrays.asList("a", "b"));
+    accessor.batchUpdateReplicaIncPushStatus("test_topic", 0, "test_instance_id", Arrays.asList("a", "b"));
     Mockito.verify(mockPartitionStatusAccessor, Mockito.times(1)).update(anyString(), any(), anyInt());
   }
 }

--- a/internal/venice-common/src/test/java/com/linkedin/venice/pushmonitor/PartitionStatusTest.java
+++ b/internal/venice-common/src/test/java/com/linkedin/venice/pushmonitor/PartitionStatusTest.java
@@ -37,7 +37,7 @@ public class PartitionStatusTest {
         () -> readonlyPartitionStatus.updateReplicaStatus(instanceId, ExecutionStatus.COMPLETED, false));
     assertThrows(
         VeniceException.class,
-        () -> readonlyPartitionStatus.updateReplicaStatus(instanceId, ExecutionStatus.COMPLETED, "inc push", 1));
+        () -> readonlyPartitionStatus.updateReplicaStatus(instanceId, ExecutionStatus.COMPLETED, "inc push"));
   }
 
   @Test
@@ -51,11 +51,11 @@ public class PartitionStatusTest {
     partitionStatus.updateReplicaStatus("testInstance2", ExecutionStatus.ERROR);
     Assert.assertFalse(partitionStatus.hasFatalDataValidationError());
 
-    partitionStatus.updateReplicaStatus("testInstance3", ExecutionStatus.ERROR, null, 10);
+    partitionStatus.updateReplicaStatus("testInstance3", ExecutionStatus.ERROR, null);
     Assert.assertFalse(partitionStatus.hasFatalDataValidationError());
 
     partitionStatus
-        .updateReplicaStatus("testInstance4", ExecutionStatus.ERROR, FATAL_DATA_VALIDATION_ERROR + " for replica", 10);
+        .updateReplicaStatus("testInstance4", ExecutionStatus.ERROR, FATAL_DATA_VALIDATION_ERROR + " for replica");
     Assert.assertTrue(partitionStatus.hasFatalDataValidationError());
   }
 
@@ -64,11 +64,12 @@ public class PartitionStatusTest {
     PartitionStatus partitionStatus = new PartitionStatus(PARTITION_ID);
     Assert.assertFalse(partitionStatus.hasFatalDataValidationError());
 
-    partitionStatus.batchUpdateReplicaIncPushStatus("testInstance1", Arrays.asList("a", "b", "c"), 100L);
+    partitionStatus.batchUpdateReplicaIncPushStatus("testInstance1", Arrays.asList("a", "b", "c"));
     Assert.assertFalse(partitionStatus.hasFatalDataValidationError());
     Assert.assertEquals(partitionStatus.getReplicaStatus("testInstance1"), ExecutionStatus.STARTED);
     ReplicaStatus replicaStatus = partitionStatus.getReplicaStatuses().iterator().next();
-    Assert.assertEquals(replicaStatus.getCurrentProgress(), 100L);
+    Assert.assertEquals(replicaStatus.getCurrentProgress(), 0L); // getCurrentProgress() is deprecated and always
+                                                                 // returns 0
     Assert.assertEquals(replicaStatus.getStatusHistory().get(0).getIncrementalPushVersion(), "a");
     Assert.assertEquals(
         replicaStatus.getStatusHistory().get(0).getStatus(),

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/davinci/notifier/LeaderErrorNotifier.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/davinci/notifier/LeaderErrorNotifier.java
@@ -43,7 +43,7 @@ public class LeaderErrorNotifier extends PushStatusNotifier {
       accessor.updateReplicaStatus(topic, partitionId, instanceId, ERROR, "");
       doOne = false;
     } else {
-      accessor.updateReplicaStatus(topic, partitionId, instanceId, COMPLETED, position.getNumericOffset(), "");
+      accessor.updateReplicaStatus(topic, partitionId, instanceId, COMPLETED, "");
     }
   }
 

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/helix/HelixOfflinePushMonitorAccessorTest.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/helix/HelixOfflinePushMonitorAccessorTest.java
@@ -81,8 +81,8 @@ public class HelixOfflinePushMonitorAccessorTest {
   public void testUpdateReplicaStatus() {
     accessor.createOfflinePushStatusAndItsPartitionStatuses(offlinePushStatus);
     int partitionId = 1;
-    accessor.updateReplicaStatus(topic, partitionId, "i1", ExecutionStatus.COMPLETED, 0, "");
-    accessor.updateReplicaStatus(topic, partitionId, "i2", ExecutionStatus.PROGRESS, 1000, "");
+    accessor.updateReplicaStatus(topic, partitionId, "i1", ExecutionStatus.COMPLETED, "");
+    accessor.updateReplicaStatus(topic, partitionId, "i2", ExecutionStatus.PROGRESS, "");
     offlinePushStatus.setPartitionStatus(
         ReadOnlyPartitionStatus.fromPartitionStatus(accessor.getPartitionStatus(topic, partitionId)));
     OfflinePushStatus remoteOfflinePushStatus = accessor.getOfflinePushStatusAndItsPartitionStatuses(topic);
@@ -93,7 +93,7 @@ public class HelixOfflinePushMonitorAccessorTest {
   public void testUpdateReplicaStatusThatDoesNotExist() {
     int partitionId = 1;
     try {
-      accessor.updateReplicaStatus(topic, partitionId, "i1", ExecutionStatus.COMPLETED, 0, "");
+      accessor.updateReplicaStatus(topic, partitionId, "i1", ExecutionStatus.COMPLETED, "");
       Assert.assertNull(accessor.getPartitionStatus(topic, partitionId));
     } catch (ZkDataAccessException e) {
       Assert.fail("Should skip the update instead of throw a exception here.");
@@ -116,13 +116,7 @@ public class HelixOfflinePushMonitorAccessorTest {
       accessor.createOfflinePushStatusAndItsPartitionStatuses(push);
       for (int j = 0; j < partitionCount; j++) {
         for (int k = 0; k < replicationFactor; k++) {
-          accessor.updateReplicaStatus(
-              topic + i,
-              j,
-              "i" + k,
-              ExecutionStatus.COMPLETED,
-              (long) (Math.random() * 10000),
-              "");
+          accessor.updateReplicaStatus(topic + i, j, "i" + k, ExecutionStatus.COMPLETED, "");
         }
         push.setPartitionStatus(ReadOnlyPartitionStatus.fromPartitionStatus(accessor.getPartitionStatus(topic + i, j)));
       }

--- a/services/venice-controller/src/test/java/com/linkedin/venice/pushmonitor/PartitionStatusBasedPushMonitorTest.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/pushmonitor/PartitionStatusBasedPushMonitorTest.java
@@ -307,7 +307,7 @@ public class PartitionStatusBasedPushMonitorTest extends AbstractPushMonitorTest
     snapshot.setIncrementalPushVersion(KILLED_JOB_MESSAGE + store.getName());
     replicaStatuses1.get(2).setStatusHistory(Arrays.asList(snapshot));
     PartitionStatus partitionStatus1 = new PartitionStatus(0);
-    partitionStatus1.updateReplicaStatus(disabledHostName, ERROR, KILLED_JOB_MESSAGE + store.getName(), 1);
+    partitionStatus1.updateReplicaStatus(disabledHostName, ERROR, KILLED_JOB_MESSAGE + store.getName());
     offlinePushStatus.setPartitionStatus(partitionStatus1);
 
     offlinePushStatus.getStrategy()


### PR DESCRIPTION
## Remove unused replica progress reporting in ReplicaStatus  


Progress was previously reported as a numeric offset. While this was easy to  
interpret, it was rarely, if ever, used in practice. With the new PubSubPosition,  
progress is represented as raw bytes, which are not meaningful or helpful for  
troubleshooting. Instead of adding extra code to report this unused information,  
the reporting logic is removed.  

###  Code changes
- [ ] Added new code behind **a config**. If so list the config names and their default values in the PR description.
- [ ] Introduced new **log lines**. 
  - [ ] Confirmed if logs need to be **rate limited** to avoid excessive logging.

###  **Concurrency-Specific Checks**
Both reviewer and PR author to verify
- [ ] Code has **no race conditions** or **thread safety issues**.
- [ ] Proper **synchronization mechanisms** (e.g., `synchronized`, `RWLock`) are used where needed.
- [ ] No **blocking calls** inside critical sections that could lead to deadlocks or performance degradation.
- [ ] Verified **thread-safe collections** are used (e.g., `ConcurrentHashMap`, `CopyOnWriteArrayList`).
- [ ] Validated proper exception handling in multi-threaded code to avoid silent thread termination.


## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->

- [ ] New unit tests added.
- [ ] New integration tests added.
- [ ] Modified or extended existing tests.
- [ ] Verified backward compatibility (if applicable).

## Does this PR introduce any user-facing or breaking changes?
<!--  
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [ ] No. You can skip the rest of this section.
- [ ] Yes. Clearly explain the behavior change and its impact.