### PR TITLE
[vpj] Fix AbstractPartitionWriter to pass the correct rmdSchemaId

### DIFF
--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/task/datawriter/AbstractPartitionWriter.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/task/datawriter/AbstractPartitionWriter.java
@@ -151,6 +151,11 @@ public abstract class AbstractPartitionWriter extends AbstractDataWriterTask imp
           if (rmdPayload.remaining() == 0) {
             throw new VeniceException("Found empty replication metadata");
           }
+
+          if (rmdVersionId < 0) {
+            throw new VeniceException("Found replication metadata without a valid schema id");
+          }
+
           if (valueBytes == null) {
             DeleteMetadata deleteMetadata = new DeleteMetadata(valueSchemaId, rmdVersionId, rmdPayload);
             writer.delete(keyBytes, callback, deleteMetadata);

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/task/datawriter/AbstractPartitionWriter.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/task/datawriter/AbstractPartitionWriter.java
@@ -24,6 +24,7 @@ import static com.linkedin.venice.vpj.VenicePushJobConstants.VALUE_SCHEMA_ID_PRO
 import com.linkedin.avroutil1.compatibility.AvroCompatibilityHelper;
 import com.linkedin.venice.ConfigKeys;
 import com.linkedin.venice.annotation.NotThreadsafe;
+import com.linkedin.venice.annotation.VisibleForTesting;
 import com.linkedin.venice.compression.CompressionStrategy;
 import com.linkedin.venice.compression.CompressorFactory;
 import com.linkedin.venice.compression.VeniceCompressor;
@@ -152,7 +153,7 @@ public abstract class AbstractPartitionWriter extends AbstractDataWriterTask imp
             throw new VeniceException("Found empty replication metadata");
           }
 
-          if (rmdVersionId < 0) {
+          if (rmdVersionId <= 0) {
             throw new VeniceException("Found replication metadata without a valid schema id");
           }
 
@@ -171,7 +172,8 @@ public abstract class AbstractPartitionWriter extends AbstractDataWriterTask imp
       };
     }
 
-    private Consumer<AbstractVeniceWriter<byte[], byte[], byte[]>> getConsumer() {
+    @VisibleForTesting
+    Consumer<AbstractVeniceWriter<byte[], byte[], byte[]>> getConsumer() {
       return consumer;
     }
 

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/task/datawriter/AbstractPartitionWriter.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/task/datawriter/AbstractPartitionWriter.java
@@ -13,6 +13,7 @@ import static com.linkedin.venice.vpj.VenicePushJobConstants.KAFKA_INPUT_BROKER_
 import static com.linkedin.venice.vpj.VenicePushJobConstants.KAFKA_INPUT_SOURCE_COMPRESSION_STRATEGY;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.KAFKA_INPUT_TOPIC;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.RMD_SCHEMA_DIR;
+import static com.linkedin.venice.vpj.VenicePushJobConstants.RMD_SCHEMA_ID_PROP;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.RMD_SCHEMA_PROP;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.STORAGE_QUOTA_PROP;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.TELEMETRY_MESSAGE_INTERVAL;
@@ -194,6 +195,8 @@ public abstract class AbstractPartitionWriter extends AbstractDataWriterTask imp
   private VeniceWriter<byte[], byte[], byte[]> mainWriter = null;
   private ComplexVeniceWriter[] childWriters = null;
   private int valueSchemaId = -1;
+
+  private int rmdSchemaId = -1;
   private Schema rmdSchema = null;
   private int derivedValueSchemaId = -1;
   private boolean enableWriteCompute = false;
@@ -327,7 +330,7 @@ public abstract class AbstractPartitionWriter extends AbstractDataWriterTask imp
         keyBytes,
         valueBytes,
         valueSchemaId,
-        -1,
+        rmdSchemaId,
         rmd,
         getCallback(),
         isEnableWriteCompute(),
@@ -646,6 +649,7 @@ public abstract class AbstractPartitionWriter extends AbstractDataWriterTask imp
     if (rmdSchemaProp.isEmpty()) {
       this.rmdSchema = null;
     } else {
+      this.rmdSchemaId = props.getInt(RMD_SCHEMA_ID_PROP);
       this.rmdSchema = AvroCompatibilityHelper.parse(props.getString(RMD_SCHEMA_PROP));
     }
     initStorageQuotaFields(props);

--- a/clients/venice-push-job/src/test/java/com/linkedin/venice/hadoop/task/datawriter/AbstractPartitionWriterTest.java
+++ b/clients/venice-push-job/src/test/java/com/linkedin/venice/hadoop/task/datawriter/AbstractPartitionWriterTest.java
@@ -1,0 +1,46 @@
+package com.linkedin.venice.hadoop.task.datawriter;
+
+import static org.mockito.Mockito.mock;
+
+import com.linkedin.venice.exceptions.VeniceException;
+import com.linkedin.venice.pubsub.api.PubSubProducerCallback;
+import com.linkedin.venice.writer.VeniceWriter;
+import java.nio.ByteBuffer;
+import org.testng.annotations.Test;
+
+
+public class AbstractPartitionWriterTest {
+  @Test(expectedExceptions = VeniceException.class, expectedExceptionsMessageRegExp = "Found replication metadata without a valid schema id")
+  public void testInvalidRmdSchemaWithValidRmdPayload() {
+    final byte[] keys = new byte[] { 0, 1, 2 };
+    final byte[] value = new byte[] { 0, 1, 2 };
+    final byte[] rmd = new byte[] { 0, 1, 2 };
+    AbstractPartitionWriter.VeniceWriterMessage message = new AbstractPartitionWriter.VeniceWriterMessage(
+        keys,
+        value,
+        1,
+        -1,
+        ByteBuffer.wrap(rmd),
+        mock(PubSubProducerCallback.class),
+        false,
+        1);
+    message.getConsumer().accept(mock(VeniceWriter.class));
+  }
+
+  @Test(expectedExceptions = VeniceException.class, expectedExceptionsMessageRegExp = "Found empty replication metadata")
+  public void testInvalidRmdSchemaWithInvalidRmdPayload() {
+    final byte[] keys = new byte[] { 0, 1, 2 };
+    final byte[] value = new byte[] { 0, 1, 2 };
+    final byte[] rmd = new byte[0];
+    AbstractPartitionWriter.VeniceWriterMessage message = new AbstractPartitionWriter.VeniceWriterMessage(
+        keys,
+        value,
+        1,
+        -1,
+        ByteBuffer.wrap(rmd),
+        mock(PubSubProducerCallback.class),
+        false,
+        1);
+    message.getConsumer().accept(mock(VeniceWriter.class));
+  }
+}

--- a/clients/venice-push-job/src/test/java/com/linkedin/venice/hadoop/task/datawriter/AbstractPartitionWriterTest.java
+++ b/clients/venice-push-job/src/test/java/com/linkedin/venice/hadoop/task/datawriter/AbstractPartitionWriterTest.java
@@ -10,17 +10,17 @@ import org.testng.annotations.Test;
 
 
 public class AbstractPartitionWriterTest {
+  private static final byte[] DUMMY_DATA = new byte[] { 0, 1, 2 };
+  private static final byte[] EMPTY_BYTES = new byte[0];
+
   @Test(expectedExceptions = VeniceException.class, expectedExceptionsMessageRegExp = "Found replication metadata without a valid schema id")
   public void testInvalidRmdSchemaWithValidRmdPayload() {
-    final byte[] keys = new byte[] { 0, 1, 2 };
-    final byte[] value = new byte[] { 0, 1, 2 };
-    final byte[] rmd = new byte[] { 0, 1, 2 };
     AbstractPartitionWriter.VeniceWriterMessage message = new AbstractPartitionWriter.VeniceWriterMessage(
-        keys,
-        value,
+        DUMMY_DATA,
+        DUMMY_DATA,
         1,
         -1,
-        ByteBuffer.wrap(rmd),
+        ByteBuffer.wrap(DUMMY_DATA),
         mock(PubSubProducerCallback.class),
         false,
         1);
@@ -29,15 +29,12 @@ public class AbstractPartitionWriterTest {
 
   @Test(expectedExceptions = VeniceException.class, expectedExceptionsMessageRegExp = "Found empty replication metadata")
   public void testInvalidRmdSchemaWithInvalidRmdPayload() {
-    final byte[] keys = new byte[] { 0, 1, 2 };
-    final byte[] value = new byte[] { 0, 1, 2 };
-    final byte[] rmd = new byte[0];
     AbstractPartitionWriter.VeniceWriterMessage message = new AbstractPartitionWriter.VeniceWriterMessage(
-        keys,
-        value,
+        DUMMY_DATA,
+        DUMMY_DATA,
         1,
         -1,
-        ByteBuffer.wrap(rmd),
+        ByteBuffer.wrap(EMPTY_BYTES),
         mock(PubSubProducerCallback.class),
         false,
         1);

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestHybridMultiRegion.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestHybridMultiRegion.java
@@ -16,7 +16,15 @@ import static com.linkedin.venice.pubsub.PubSubConstants.PUBSUB_OPERATION_TIMEOU
 import static com.linkedin.venice.utils.IntegrationTestPushUtils.defaultVPJProps;
 import static com.linkedin.venice.utils.TestWriteUtils.STRING_SCHEMA;
 import static com.linkedin.venice.utils.TestWriteUtils.getTempDataDirectory;
-import static com.linkedin.venice.vpj.VenicePushJobConstants.*;
+import static com.linkedin.venice.vpj.VenicePushJobConstants.DATA_WRITER_COMPUTE_JOB_CLASS;
+import static com.linkedin.venice.vpj.VenicePushJobConstants.KAFKA_INPUT_BROKER_URL;
+import static com.linkedin.venice.vpj.VenicePushJobConstants.KAFKA_INPUT_MAX_RECORDS_PER_MAPPER;
+import static com.linkedin.venice.vpj.VenicePushJobConstants.REPUSH_TTL_ENABLE;
+import static com.linkedin.venice.vpj.VenicePushJobConstants.REPUSH_TTL_START_TIMESTAMP;
+import static com.linkedin.venice.vpj.VenicePushJobConstants.REWIND_TIME_IN_SECONDS_OVERRIDE;
+import static com.linkedin.venice.vpj.VenicePushJobConstants.RMD_FIELD_PROP;
+import static com.linkedin.venice.vpj.VenicePushJobConstants.SOURCE_KAFKA;
+import static com.linkedin.venice.vpj.VenicePushJobConstants.SPARK_NATIVE_INPUT_FORMAT_ENABLED;
 import static com.linkedin.venice.writer.VeniceWriter.DEFAULT_TERM_ID;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;


### PR DESCRIPTION
## Problem Statement

As part of support for logical timestamp and RMD support for VPJ, we did not pass the right rmd schema id to the Writer and as a result the payload written to the server did not carry any writer schema information. As a result, any subsequent consumption of the RMD data would result in NPE due to lack of writer schema id.

This is was noticed in our testing RMD pushes E2E and here is the stacktrace
```
ava.lang.Exception: java.lang.NullPointerException: Cannot invoke "org.apache.avro.Schema.hashCode()" because "this.writer" is null
	at org.apache.hadoop.mapred.LocalJobRunner$Job.runTasks(LocalJobRunner.java:491) ~[hadoop-mapreduce-client-common-2.10.2.jar:?]
	at org.apache.hadoop.mapred.LocalJobRunner$Job.run(LocalJobRunner.java:551) [hadoop-mapreduce-client-common-2.10.2.jar:?]
Caused by: java.lang.NullPointerException: Cannot invoke "org.apache.avro.Schema.hashCode()" because "this.writer" is null
	at com.linkedin.venice.serializer.SerializerDeserializerFactory$SchemaPairAndClassContainer.hashCode(SerializerDeserializerFactory.java:54) ~[venice-client-common.jar:?]
	at java.util.concurrent.ConcurrentHashMap.get(ConcurrentHashMap.java:936) ~[?:?]
	at com.linkedin.venice.utils.concurrent.VeniceConcurrentHashMap.computeIfAbsent(VeniceConcurrentHashMap.java:37) ~[venice-client-common.jar:?]
	at com.linkedin.davinci.serializer.avro.MapOrderPreservingSerDeFa
```

###  Code changes
- Pass the rmd schema id as part of processing input records prior to writing to Kafka
- Add a check to `AbstractPartitionWriterMessage` to ensure version id cannot be < 0 in case of non-null RMD payloads

## How was this PR tested?
- [x] Modified or extended existing tests.

## Does this PR introduce any user-facing or breaking changes?
- [x] No. You can skip the rest of this section.
- [ ] Yes. Clearly explain the behavior change and its impact.