### PR TITLE
[controller] fix to decide correctly if the offset for admin topic exist

### DIFF
--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/kafka/consumer/AdminConsumptionTask.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/kafka/consumer/AdminConsumptionTask.java
@@ -436,7 +436,10 @@ public class AdminConsumptionTask implements Runnable, Closeable {
 
   private void subscribe() {
     AdminMetadata metaData = adminTopicMetadataAccessor.getMetadata(clusterName);
-    if (!PubSubSymbolicPosition.EARLIEST.equals(metaData.getPosition())) {
+    boolean hasCheckpoint = remoteConsumptionEnabled
+        ? !PubSubSymbolicPosition.EARLIEST.equals(metaData.getUpstreamPosition())
+        : !PubSubSymbolicPosition.EARLIEST.equals(metaData.getPosition());
+    if (hasCheckpoint) {
       localPositionCheckpointAtStartTime = metaData.getPosition();
       upstreamPositionCheckpointAtStartTime = metaData.getUpstreamPosition();
       lastPersistedPosition =


### PR DESCRIPTION
<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat], [protocol]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## Problem Statement
<!--
Describe
- What problem are you trying to solve
- What issues or limitations exist in the current code
- Why this change is necessary 
-->
This pull request updates the logic for subscribing to Kafka topics in `AdminConsumptionTask` and adds targeted tests to verify the new behavior. The main improvement is that the subscription logic now correctly distinguishes between local and upstream checkpoint positions depending on whether remote consumption is enabled, ensuring more reliable recovery and consumption behavior.

**Subscription logic improvements:**

* Updated the `subscribe()` method in `AdminConsumptionTask` to use the upstream checkpoint position when remote consumption is enabled, and the local checkpoint position otherwise. This avoids incorrectly using the local checkpoint when remote consumption should use the upstream checkpoint.

**Test coverage enhancements:**

* Added `testSubscribeUsesLocalPositionWhenRemoteDisabled` to verify that the subscription uses the local checkpoint position when remote consumption is disabled.
* Added `testSubscribeUsesUpstreamPositionWhenRemoteEnabled` to verify that the subscription uses the upstream checkpoint position when remote consumption is enabled.

**Test setup improvements:**

* Added necessary imports for symbolic and numeric position types to support the new tests in `AdminConsumptionTaskTest`.
## Solution
<!--
Describe
- What changes you are making and why. 
- How these changes solve the problem.
- Any performance considerations or trade-offs. 
- Describe what testings you have done, for example, performance testing etc.
-->


###  Code changes
- [ ] Added new code behind **a config**. If so list the config names and their default values in the PR description.
- [ ] Introduced new **log lines**. 
  - [ ] Confirmed if logs need to be **rate limited** to avoid excessive logging.

###  **Concurrency-Specific Checks**
Both reviewer and PR author to verify
- [ ] Code has **no race conditions** or **thread safety issues**.
- [ ] Proper **synchronization mechanisms** (e.g., `synchronized`, `RWLock`) are used where needed.
- [ ] No **blocking calls** inside critical sections that could lead to deadlocks or performance degradation.
- [ ] Verified **thread-safe collections** are used (e.g., `ConcurrentHashMap`, `CopyOnWriteArrayList`).
- [ ] Validated proper exception handling in multi-threaded code to avoid silent thread termination.


## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->

- [ ] New unit tests added.
- [ ] New integration tests added.
- [ ] Modified or extended existing tests.
- [ ] Verified backward compatibility (if applicable).

## Does this PR introduce any user-facing or breaking changes?
<!--  
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [ ] No. You can skip the rest of this section.
- [ ] Yes. Clearly explain the behavior change and its impact.