### PR TITLE
[vpj] [controller] Fix Missing ACL Message

### DIFF
--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/server/CreateVersion.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/server/CreateVersion.java
@@ -465,7 +465,7 @@ public class CreateVersion extends AbstractRoute {
     response.status(HttpStatus.SC_FORBIDDEN);
     VersionCreationResponse responseObject = new VersionCreationResponse();
     String userId = getPrincipalId(request);
-    String errorMessage = "Missing [{}] ACLs for user \"" + userId + "\". Please setup ACLs for your store.";
+    String errorMessage = "Missing [%s] ACLs for user \"" + userId + "\". Please setup ACLs for your store.";
     if (missingWriteAccess) {
       errorMessage = String.format(errorMessage, "write");
     }

--- a/services/venice-controller/src/test/java/com/linkedin/venice/controller/server/CreateVersionTest.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/controller/server/CreateVersionTest.java
@@ -159,7 +159,8 @@ public class CreateVersionTest {
      * Create version should fail if user doesn't have "Write" method access to the topic
      */
     doReturn(false).when(accessClient).hasAccessToTopic(certificate, STORE_NAME, "Write");
-    createVersionRoute.handle(request, response);
+    String responseBody = createVersionRoute.handle(request, response).toString();
+    assertTrue(responseBody.contains("Missing [write] ACLs"));
 
     /**
      * Response should be 403 if user doesn't have "Write" method access
@@ -173,7 +174,8 @@ public class CreateVersionTest {
        */
       doReturn(true).when(accessClient).hasAccessToTopic(certificate, STORE_NAME, "Write");
       doReturn(false).when(accessClient).hasAccessToTopic(certificate, STORE_NAME, "Read");
-      createVersionRoute.handle(request, response);
+      responseBody = createVersionRoute.handle(request, response).toString();
+      assertTrue(responseBody.contains("Missing [read] ACLs"));
       verify(response).status(org.apache.http.HttpStatus.SC_FORBIDDEN);
     }
   }


### PR DESCRIPTION
<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat], [protocol]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## Summary
<!--
Describe
- What changes you are making and why. 
- How these changes solve the problem.
- Any performance considerations or trade-offs. 
- Describe what testings you have done, for example, performance testing etc.
-->
fix: update error message formatting and add response validation in CreateVersionTest

###  Code changes
- [X] Added new code behind **a config**. If so list the config names and their default values in the PR description.
- [X] Introduced new **log lines**. 
  - [X] Confirmed if logs need to be **rate limited** to avoid excessive logging.

###  **Concurrency-Specific Checks**
Both reviewer and PR author to verify
- [X] Code has **no race conditions** or **thread safety issues**.
- [X] Proper **synchronization mechanisms** (e.g., `synchronized`, `RWLock`) are used where needed.
- [X] No **blocking calls** inside critical sections that could lead to deadlocks or performance degradation.
- [X] Verified **thread-safe collections** are used (e.g., `ConcurrentHashMap`, `CopyOnWriteArrayList`).
- [X] Validated proper exception handling in multi-threaded code to avoid silent thread termination.


## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
CI

- [X] Modified or extended existing tests.
- [X] Verified backward compatibility (if applicable).

## Does this PR introduce any user-facing or breaking changes?
<!--  
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [X] No. You can skip the rest of this section.