### PR TITLE
[test] Implement parallel shutdown for Venice test infrastructure to improve performance

### DIFF
--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/store/rocksdb/RocksDBStoragePartitionTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/store/rocksdb/RocksDBStoragePartitionTest.java
@@ -274,13 +274,13 @@ public class RocksDBStoragePartitionTest {
 
     int padding = 100;
     // TODO: decide if we really need this many records? this might be the cause of the slowness...
-    int numberOfRecords = 101000;
+    int numberOfRecords = 10000;
     Map<String, String> inputRecords = generateInput(numberOfRecords, sorted, padding);
     Properties extraProps = new Properties();
     if (enableBlobFile) {
       extraProps.put(ROCKSDB_BLOB_FILES_ENABLED, "true");
       extraProps.put(ROCKSDB_MIN_BLOB_SIZE_IN_BYTES, "10");
-      extraProps.put(ROCKSDB_BLOB_FILE_SIZE_IN_BYTES, "2097152");
+      extraProps.put(ROCKSDB_BLOB_FILE_SIZE_IN_BYTES, "102400");
       extraProps.put(ROCKSDB_BLOB_FILE_STARTING_LEVEL, "0");
     }
     if (enablePlainTable) {

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/integration/utils/TimingUtils.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/integration/utils/TimingUtils.java
@@ -1,0 +1,79 @@
+package com.linkedin.venice.integration.utils;
+
+import org.apache.logging.log4j.Logger;
+
+
+/**
+ * Utility class for timing operations with consistent start/end logging.
+ * This eliminates the repeated pattern of logging start time, end time, and duration
+ * across Venice integration test wrapper classes.
+ */
+public class TimingUtils {
+  /**
+   * Times a Runnable operation with start and completion logging.
+   *
+   * @param logger the logger to use for timing messages
+   * @param operationDescription description of the operation being timed (e.g., "Step 1: Shutting down routers")
+   * @param operation the operation to execute and time
+   * @return the duration in milliseconds
+   */
+  public static long timeOperation(Logger logger, String operationDescription, Runnable operation) {
+    long startTime = System.currentTimeMillis();
+    logger.info(operationDescription);
+
+    try {
+      operation.run();
+    } finally {
+      long duration = System.currentTimeMillis() - startTime;
+      logger.info("Completed {} in {} ms", getCompletionDescription(operationDescription), duration);
+    }
+
+    return System.currentTimeMillis() - startTime;
+  }
+
+  /**
+   * Times a Runnable operation with start and completion logging, returning the duration.
+   *
+   * @param logger the logger to use for timing messages
+   * @param operationDescription description of the operation being timed (e.g., "Step 1: Shutting down routers")
+   * @param operation the operation to execute and time
+   * @return the duration in milliseconds
+   */
+  public static long timeOperationAndReturnDuration(Logger logger, String operationDescription, Runnable operation) {
+    long startTime = System.currentTimeMillis();
+    logger.info(operationDescription);
+
+    try {
+      operation.run();
+    } finally {
+      long duration = System.currentTimeMillis() - startTime;
+      logger.info("Completed {} in {} ms", getCompletionDescription(operationDescription), duration);
+    }
+
+    return System.currentTimeMillis() - startTime;
+  }
+
+  /**
+   * Converts an operation description to a completion description.
+   * Examples:
+   * - "Step 1: Shutting down routers" -> "shutdown of routers"
+   * - "Shutting down 5 controllers in parallel" -> "shutdown of 5 controllers in parallel"
+   * - "Step 3: Starting service" -> "startup of service"
+   */
+  private static String getCompletionDescription(String operationDescription) {
+    String description = operationDescription;
+
+    // Remove step prefixes like "Step 1: ", "Step 2: ", etc.
+    description = description.replaceFirst("^Step \\d+: ", "");
+
+    // Convert common operation verbs to completion forms
+    description = description.replaceFirst("^Shutting down", "shutdown of");
+    description = description.replaceFirst("^Starting", "startup of");
+    description = description.replaceFirst("^Stopping", "shutdown of");
+    description = description.replaceFirst("^Destroying", "destruction of");
+    description = description.replaceFirst("^Creating", "creation of");
+    description = description.replaceFirst("^Initializing", "initialization of");
+
+    return description;
+  }
+}

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/integration/utils/VeniceClusterWrapper.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/integration/utils/VeniceClusterWrapper.java
@@ -76,6 +76,7 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.Properties;
 import java.util.Set;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
 import java.util.function.Function;
@@ -471,17 +472,140 @@ public class VeniceClusterWrapper extends ProcessWrapper {
 
   @Override
   protected void internalStop() throws Exception {
+    LOGGER.info("Starting sequential shutdown of VeniceClusterWrapper");
+    long overallStartTime = System.currentTimeMillis();
+
+    // Step 1: Stop controller client
+    long controllerClientStartTime = System.currentTimeMillis();
+    LOGGER.info("Step 1: Shutting down controller client");
     controllerClient.ifPresent(Utils::closeQuietlyWithErrorLogged);
-    veniceRouterWrappers.values().forEach(Utils::closeQuietlyWithErrorLogged);
-    veniceServerWrappers.values().forEach(Utils::closeQuietlyWithErrorLogged);
-    veniceControllerWrappers.values().forEach(Utils::closeQuietlyWithErrorLogged);
-    if (options.isStandalone()) {
-      Utils.closeQuietlyWithErrorLogged(pubSubBrokerWrapper);
-      Utils.closeQuietlyWithErrorLogged(zkServerWrapper);
+    long controllerClientTime = System.currentTimeMillis() - controllerClientStartTime;
+    LOGGER.info("Completed shutdown of controller client in {} ms", controllerClientTime);
+
+    // Step 2: Stop routers in parallel
+    long routersStartTime = System.currentTimeMillis();
+    LOGGER.info("Step 2: Shutting down {} routers in parallel", veniceRouterWrappers.size());
+
+    List<CompletableFuture<Void>> routerShutdownTasks = new ArrayList<>();
+    int routerIndex = 0;
+    for (VeniceRouterWrapper router: veniceRouterWrappers.values()) {
+      final int currentIndex = routerIndex++;
+      CompletableFuture<Void> routerShutdownTask = CompletableFuture.runAsync(() -> {
+        long routerStartTime = System.currentTimeMillis();
+        LOGGER.debug("Shutting down router {}", currentIndex);
+        Utils.closeQuietlyWithErrorLogged(router);
+        long routerDuration = System.currentTimeMillis() - routerStartTime;
+        LOGGER.debug("Completed shutdown of router {} in {} ms", currentIndex, routerDuration);
+      });
+      routerShutdownTasks.add(routerShutdownTask);
     }
 
+    CompletableFuture.allOf(routerShutdownTasks.toArray(new CompletableFuture[0])).join();
+    long routersTime = System.currentTimeMillis() - routersStartTime;
+    LOGGER.info("Completed parallel shutdown of {} routers in {} ms", veniceRouterWrappers.size(), routersTime);
+
+    // Step 3: Stop servers in parallel
+    long serversStartTime = System.currentTimeMillis();
+    LOGGER.info("Step 3: Shutting down {} servers in parallel", veniceServerWrappers.size());
+
+    List<CompletableFuture<Void>> serverShutdownTasks = new ArrayList<>();
+    int serverIndex = 0;
+    for (VeniceServerWrapper server: veniceServerWrappers.values()) {
+      final int currentIndex = serverIndex++;
+      CompletableFuture<Void> serverShutdownTask = CompletableFuture.runAsync(() -> {
+        long serverStartTime = System.currentTimeMillis();
+        LOGGER.debug("Shutting down server {}", currentIndex);
+        Utils.closeQuietlyWithErrorLogged(server);
+        long serverDuration = System.currentTimeMillis() - serverStartTime;
+        LOGGER.debug("Completed shutdown of server {} in {} ms", currentIndex, serverDuration);
+      });
+      serverShutdownTasks.add(serverShutdownTask);
+    }
+
+    CompletableFuture.allOf(serverShutdownTasks.toArray(new CompletableFuture[0])).join();
+    long serversTime = System.currentTimeMillis() - serversStartTime;
+    LOGGER.info("Completed parallel shutdown of {} servers in {} ms", veniceServerWrappers.size(), serversTime);
+
+    // Step 4: Stop controllers in parallel
+    long controllersStartTime = System.currentTimeMillis();
+    LOGGER.info("Step 4: Shutting down {} controllers in parallel", veniceControllerWrappers.size());
+
+    List<CompletableFuture<Void>> controllerShutdownTasks = new ArrayList<>();
+    int controllerIndex = 0;
+    for (VeniceControllerWrapper controller: veniceControllerWrappers.values()) {
+      final int currentIndex = controllerIndex++;
+      CompletableFuture<Void> controllerShutdownTask = CompletableFuture.runAsync(() -> {
+        long controllerStartTime = System.currentTimeMillis();
+        LOGGER.debug("Shutting down controller {}", currentIndex);
+        Utils.closeQuietlyWithErrorLogged(controller);
+        long controllerDuration = System.currentTimeMillis() - controllerStartTime;
+        LOGGER.debug("Completed shutdown of controller {} in {} ms", currentIndex, controllerDuration);
+      });
+      controllerShutdownTasks.add(controllerShutdownTask);
+    }
+
+    CompletableFuture.allOf(controllerShutdownTasks.toArray(new CompletableFuture[0])).join();
+    long controllersTime = System.currentTimeMillis() - controllersStartTime;
+    LOGGER.info(
+        "Completed parallel shutdown of {} controllers in {} ms",
+        veniceControllerWrappers.size(),
+        controllersTime);
+
+    // Step 5: Stop infrastructure components if standalone
+    long infrastructureTime = 0;
+    if (options.isStandalone()) {
+      long infrastructureStartTime = System.currentTimeMillis();
+      LOGGER.info("Step 5: Shutting down infrastructure components (standalone mode)");
+
+      long pubSubStartTime = System.currentTimeMillis();
+      Utils.closeQuietlyWithErrorLogged(pubSubBrokerWrapper);
+      long pubSubTime = System.currentTimeMillis() - pubSubStartTime;
+      LOGGER.info("Completed shutdown of PubSub broker in {} ms", pubSubTime);
+
+      long zkStartTime = System.currentTimeMillis();
+      Utils.closeQuietlyWithErrorLogged(zkServerWrapper);
+      long zkTime = System.currentTimeMillis() - zkStartTime;
+      LOGGER.info("Completed shutdown of ZooKeeper server in {} ms", zkTime);
+
+      infrastructureTime = System.currentTimeMillis() - infrastructureStartTime;
+      LOGGER.info("Completed shutdown of infrastructure components in {} ms", infrastructureTime);
+    }
+
+    // Step 6: Stop forked process if exists
+    long processTime = 0;
     if (veniceClusterProcess != null) {
+      long processStartTime = System.currentTimeMillis();
+      LOGGER.info("Step 6: Destroying forked Venice cluster process");
       veniceClusterProcess.destroy();
+      processTime = System.currentTimeMillis() - processStartTime;
+      LOGGER.info("Completed destruction of forked process in {} ms", processTime);
+    }
+
+    long totalShutdownTime = System.currentTimeMillis() - overallStartTime;
+
+    // Log comprehensive timing summary
+    if (options.isStandalone()) {
+      LOGGER.info(
+          "Sequential shutdown timing summary - Total: {} ms, "
+              + "Controller client: {} ms, Routers: {} ms, Servers: {} ms, Controllers: {} ms, "
+              + "Infrastructure: {} ms, Process: {} ms",
+          totalShutdownTime,
+          controllerClientTime,
+          routersTime,
+          serversTime,
+          controllersTime,
+          infrastructureTime,
+          processTime);
+    } else {
+      LOGGER.info(
+          "Sequential shutdown timing summary - Total: {} ms, "
+              + "Controller client: {} ms, Routers: {} ms, Servers: {} ms, Controllers: {} ms, Process: {} ms",
+          totalShutdownTime,
+          controllerClientTime,
+          routersTime,
+          serversTime,
+          controllersTime,
+          processTime);
     }
   }
 

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/integration/utils/VeniceMultiClusterWrapper.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/integration/utils/VeniceMultiClusterWrapper.java
@@ -14,16 +14,22 @@ import com.linkedin.venice.utils.SslUtils;
 import com.linkedin.venice.utils.Time;
 import com.linkedin.venice.utils.Utils;
 import java.io.File;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Properties;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import org.apache.commons.io.IOUtils;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 
 public class VeniceMultiClusterWrapper extends ProcessWrapper {
+  private static final Logger LOGGER = LogManager.getLogger(VeniceMultiClusterWrapper.class);
   public static final String SERVICE_NAME = "VeniceMultiCluster";
   private final Map<String, VeniceClusterWrapper> clusters;
   private final Map<Integer, VeniceControllerWrapper> controllers;
@@ -234,13 +240,90 @@ public class VeniceMultiClusterWrapper extends ProcessWrapper {
 
   @Override
   protected void internalStop() throws Exception {
-    controllers.values().forEach(IOUtils::closeQuietly);
-    clusters.values().forEach(IOUtils::closeQuietly);
+    LOGGER.info("Starting sequential shutdown of VeniceMultiClusterWrapper");
+    long overallStartTime = System.currentTimeMillis();
+
+    // Step 1: Stop controllers in parallel
+    long controllersStartTime = System.currentTimeMillis();
+    LOGGER.info("Step 1: Shutting down {} controllers in parallel", controllers.size());
+
+    List<CompletableFuture<Void>> controllerShutdownTasks = new ArrayList<>();
+    int controllerIndex = 0;
+    for (VeniceControllerWrapper controller: controllers.values()) {
+      final int currentIndex = controllerIndex++;
+      CompletableFuture<Void> controllerShutdownTask = CompletableFuture.runAsync(() -> {
+        long controllerStartTime = System.currentTimeMillis();
+        LOGGER.debug("Shutting down controller {}", currentIndex);
+        IOUtils.closeQuietly(controller);
+        long controllerDuration = System.currentTimeMillis() - controllerStartTime;
+        LOGGER.debug("Completed shutdown of controller {} in {} ms", currentIndex, controllerDuration);
+      });
+      controllerShutdownTasks.add(controllerShutdownTask);
+    }
+
+    CompletableFuture.allOf(controllerShutdownTasks.toArray(new CompletableFuture[0])).join();
+    long controllersTime = System.currentTimeMillis() - controllersStartTime;
+    LOGGER.info("Completed parallel shutdown of {} controllers in {} ms", controllers.size(), controllersTime);
+
+    // Step 2: Stop clusters in parallel
+    long clustersStartTime = System.currentTimeMillis();
+    LOGGER.info("Step 2: Shutting down {} clusters in parallel", clusters.size());
+
+    List<CompletableFuture<Void>> clusterShutdownTasks = new ArrayList<>();
+    int clusterIndex = 0;
+    for (Map.Entry<String, VeniceClusterWrapper> clusterEntry: clusters.entrySet()) {
+      final int currentIndex = clusterIndex++;
+      final String clusterName = clusterEntry.getKey();
+      final VeniceClusterWrapper cluster = clusterEntry.getValue();
+      CompletableFuture<Void> clusterShutdownTask = CompletableFuture.runAsync(() -> {
+        long clusterStartTime = System.currentTimeMillis();
+        LOGGER.debug("Shutting down cluster {} ({})", currentIndex, clusterName);
+        IOUtils.closeQuietly(cluster);
+        long clusterDuration = System.currentTimeMillis() - clusterStartTime;
+        LOGGER.debug("Completed shutdown of cluster {} ({}) in {} ms", currentIndex, clusterName, clusterDuration);
+      });
+      clusterShutdownTasks.add(clusterShutdownTask);
+    }
+
+    CompletableFuture.allOf(clusterShutdownTasks.toArray(new CompletableFuture[0])).join();
+    long clustersTime = System.currentTimeMillis() - clustersStartTime;
+    LOGGER.info("Completed parallel shutdown of {} clusters in {} ms", clusters.size(), clustersTime);
+
+    // Step 3: Stop D2 client
+    long d2StartTime = System.currentTimeMillis();
+    LOGGER.info("Step 3: Shutting down D2 client");
     if (clientConfigD2Client != null) {
       D2ClientUtils.shutdownClient(clientConfigD2Client);
     }
+    long d2Time = System.currentTimeMillis() - d2StartTime;
+    LOGGER.info("Completed shutdown of D2 client in {} ms", d2Time);
+
+    // Step 4: Stop PubSub broker
+    long pubSubStartTime = System.currentTimeMillis();
+    LOGGER.info("Step 4: Shutting down PubSub broker");
     IOUtils.closeQuietly(pubSubBrokerWrapper);
+    long pubSubTime = System.currentTimeMillis() - pubSubStartTime;
+    LOGGER.info("Completed shutdown of PubSub broker in {} ms", pubSubTime);
+
+    // Step 5: Stop ZooKeeper last
+    long zkStartTime = System.currentTimeMillis();
+    LOGGER.info("Step 5: Shutting down ZooKeeper server");
     IOUtils.closeQuietly(zkServerWrapper);
+    long zkTime = System.currentTimeMillis() - zkStartTime;
+    LOGGER.info("Completed shutdown of ZooKeeper server in {} ms", zkTime);
+
+    long totalShutdownTime = System.currentTimeMillis() - overallStartTime;
+
+    // Log comprehensive timing summary
+    LOGGER.info(
+        "Sequential shutdown timing summary - Total: {} ms, "
+            + "Controllers: {} ms, Clusters: {} ms, D2 client: {} ms, PubSub broker: {} ms, ZooKeeper: {} ms",
+        totalShutdownTime,
+        controllersTime,
+        clustersTime,
+        d2Time,
+        pubSubTime,
+        zkTime);
   }
 
   @Override

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/integration/utils/VeniceTwoLayerMultiRegionMultiClusterWrapper.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/integration/utils/VeniceTwoLayerMultiRegionMultiClusterWrapper.java
@@ -37,6 +37,7 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.Properties;
 import java.util.Set;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import org.apache.commons.io.IOUtils;
@@ -361,10 +362,85 @@ public class VeniceTwoLayerMultiRegionMultiClusterWrapper extends ProcessWrapper
 
   @Override
   protected void internalStop() throws Exception {
-    parentControllers.forEach(IOUtils::closeQuietly);
-    childRegions.forEach(IOUtils::closeQuietly);
+    LOGGER.info("Starting sequential shutdown of VeniceTwoLayerMultiRegionMultiClusterWrapper");
+    long overallStartTime = System.currentTimeMillis();
+
+    // Step 1: Stop parent controllers first (in parallel)
+    long parentControllersStartTime = System.currentTimeMillis();
+    LOGGER.info("Step 1: Shutting down {} parent controllers in parallel", parentControllers.size());
+
+    // Create individual shutdown tasks for each parent controller
+    List<CompletableFuture<Void>> parentControllerShutdownTasks = new ArrayList<>();
+    for (int i = 0; i < parentControllers.size(); i++) {
+      final int controllerIndex = i;
+      final VeniceControllerWrapper parentController = parentControllers.get(i);
+      CompletableFuture<Void> controllerShutdownTask = CompletableFuture.runAsync(() -> {
+        long controllerStartTime = System.currentTimeMillis();
+        LOGGER.debug("Shutting down parent controller {}", controllerIndex);
+        IOUtils.closeQuietly(parentController);
+        long controllerDuration = System.currentTimeMillis() - controllerStartTime;
+        LOGGER.debug("Completed shutdown of parent controller {} in {} ms", controllerIndex, controllerDuration);
+      });
+      parentControllerShutdownTasks.add(controllerShutdownTask);
+    }
+
+    // Wait for all parent controllers to complete shutdown
+    CompletableFuture.allOf(parentControllerShutdownTasks.toArray(new CompletableFuture[0])).join();
+    long parentControllersTime = System.currentTimeMillis() - parentControllersStartTime;
+    LOGGER.info(
+        "Completed parallel shutdown of {} parent controllers in {} ms",
+        parentControllers.size(),
+        parentControllersTime);
+
+    // Step 2: Stop child regions in parallel
+    long childRegionsStartTime = System.currentTimeMillis();
+    LOGGER.info("Step 2: Shutting down {} child regions in parallel", childRegions.size());
+
+    // Create individual shutdown tasks for each child region
+    List<CompletableFuture<Void>> childRegionShutdownTasks = new ArrayList<>();
+    for (int i = 0; i < childRegions.size(); i++) {
+      final int regionIndex = i;
+      final VeniceMultiClusterWrapper childRegion = childRegions.get(i);
+      CompletableFuture<Void> regionShutdownTask = CompletableFuture.runAsync(() -> {
+        long regionStartTime = System.currentTimeMillis();
+        LOGGER.debug("Shutting down child region {}", regionIndex);
+        IOUtils.closeQuietly(childRegion);
+        long regionDuration = System.currentTimeMillis() - regionStartTime;
+        LOGGER.debug("Completed shutdown of child region {} in {} ms", regionIndex, regionDuration);
+      });
+      childRegionShutdownTasks.add(regionShutdownTask);
+    }
+
+    // Wait for all child regions to complete shutdown
+    CompletableFuture.allOf(childRegionShutdownTasks.toArray(new CompletableFuture[0])).join();
+    long childRegionsTime = System.currentTimeMillis() - childRegionsStartTime;
+    LOGGER.info("Completed parallel shutdown of {} child regions in {} ms", childRegions.size(), childRegionsTime);
+
+    // Step 3: Stop parent PubSub broker
+    long pubSubBrokerStartTime = System.currentTimeMillis();
+    LOGGER.info("Step 3: Shutting down parent PubSub broker");
     IOUtils.closeQuietly(parentPubSubBrokerWrapper);
+    long pubSubBrokerTime = System.currentTimeMillis() - pubSubBrokerStartTime;
+    LOGGER.info("Completed shutdown of parent PubSub broker in {} ms", pubSubBrokerTime);
+
+    // Step 4: Stop parent ZooKeeper last
+    long zkStartTime = System.currentTimeMillis();
+    LOGGER.info("Step 4: Shutting down ZooKeeper server");
     IOUtils.closeQuietly(zkServerWrapper);
+    long zkShutdownTime = System.currentTimeMillis() - zkStartTime;
+    LOGGER.info("Completed shutdown of ZooKeeper server in {} ms", zkShutdownTime);
+
+    long totalShutdownTime = System.currentTimeMillis() - overallStartTime;
+
+    // Log comprehensive timing summary
+    LOGGER.info(
+        "Sequential shutdown timing summary - Total: {} ms, "
+            + "Parent controllers: {} ms, Child regions: {} ms, PubSub broker: {} ms, ZooKeeper: {} ms",
+        totalShutdownTime,
+        parentControllersTime,
+        childRegionsTime,
+        pubSubBrokerTime,
+        zkShutdownTime);
   }
 
   @Override

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/integration/utils/VeniceTwoLayerMultiRegionMultiClusterWrapper.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/integration/utils/VeniceTwoLayerMultiRegionMultiClusterWrapper.java
@@ -366,69 +366,62 @@ public class VeniceTwoLayerMultiRegionMultiClusterWrapper extends ProcessWrapper
     long overallStartTime = System.currentTimeMillis();
 
     // Step 1: Stop parent controllers first (in parallel)
-    long parentControllersStartTime = System.currentTimeMillis();
-    LOGGER.info("Step 1: Shutting down {} parent controllers in parallel", parentControllers.size());
-
-    // Create individual shutdown tasks for each parent controller
-    List<CompletableFuture<Void>> parentControllerShutdownTasks = new ArrayList<>();
-    for (int i = 0; i < parentControllers.size(); i++) {
-      final int controllerIndex = i;
-      final VeniceControllerWrapper parentController = parentControllers.get(i);
-      CompletableFuture<Void> controllerShutdownTask = CompletableFuture.runAsync(() -> {
-        long controllerStartTime = System.currentTimeMillis();
-        LOGGER.debug("Shutting down parent controller {}", controllerIndex);
-        IOUtils.closeQuietly(parentController);
-        long controllerDuration = System.currentTimeMillis() - controllerStartTime;
-        LOGGER.debug("Completed shutdown of parent controller {} in {} ms", controllerIndex, controllerDuration);
-      });
-      parentControllerShutdownTasks.add(controllerShutdownTask);
-    }
-
-    // Wait for all parent controllers to complete shutdown
-    CompletableFuture.allOf(parentControllerShutdownTasks.toArray(new CompletableFuture[0])).join();
-    long parentControllersTime = System.currentTimeMillis() - parentControllersStartTime;
-    LOGGER.info(
-        "Completed parallel shutdown of {} parent controllers in {} ms",
-        parentControllers.size(),
-        parentControllersTime);
+    long parentControllersTime = TimingUtils.timeOperationAndReturnDuration(
+        LOGGER,
+        "Step 1: Shutting down " + parentControllers.size() + " parent controllers in parallel",
+        () -> {
+          // Create individual shutdown tasks for each parent controller
+          List<CompletableFuture<Void>> parentControllerShutdownTasks = new ArrayList<>();
+          for (int i = 0; i < parentControllers.size(); i++) {
+            final int controllerIndex = i;
+            final VeniceControllerWrapper parentController = parentControllers.get(i);
+            CompletableFuture<Void> controllerShutdownTask = CompletableFuture.runAsync(() -> {
+              long controllerStartTime = System.currentTimeMillis();
+              LOGGER.debug("Shutting down parent controller {}", controllerIndex);
+              IOUtils.closeQuietly(parentController);
+              long controllerDuration = System.currentTimeMillis() - controllerStartTime;
+              LOGGER.debug("Completed shutdown of parent controller {} in {} ms", controllerIndex, controllerDuration);
+            });
+            parentControllerShutdownTasks.add(controllerShutdownTask);
+          }
+          // Wait for all parent controllers to complete shutdown
+          CompletableFuture.allOf(parentControllerShutdownTasks.toArray(new CompletableFuture[0])).join();
+        });
 
     // Step 2: Stop child regions in parallel
-    long childRegionsStartTime = System.currentTimeMillis();
-    LOGGER.info("Step 2: Shutting down {} child regions in parallel", childRegions.size());
-
-    // Create individual shutdown tasks for each child region
-    List<CompletableFuture<Void>> childRegionShutdownTasks = new ArrayList<>();
-    for (int i = 0; i < childRegions.size(); i++) {
-      final int regionIndex = i;
-      final VeniceMultiClusterWrapper childRegion = childRegions.get(i);
-      CompletableFuture<Void> regionShutdownTask = CompletableFuture.runAsync(() -> {
-        long regionStartTime = System.currentTimeMillis();
-        LOGGER.debug("Shutting down child region {}", regionIndex);
-        IOUtils.closeQuietly(childRegion);
-        long regionDuration = System.currentTimeMillis() - regionStartTime;
-        LOGGER.debug("Completed shutdown of child region {} in {} ms", regionIndex, regionDuration);
-      });
-      childRegionShutdownTasks.add(regionShutdownTask);
-    }
-
-    // Wait for all child regions to complete shutdown
-    CompletableFuture.allOf(childRegionShutdownTasks.toArray(new CompletableFuture[0])).join();
-    long childRegionsTime = System.currentTimeMillis() - childRegionsStartTime;
-    LOGGER.info("Completed parallel shutdown of {} child regions in {} ms", childRegions.size(), childRegionsTime);
+    long childRegionsTime = TimingUtils.timeOperationAndReturnDuration(
+        LOGGER,
+        "Step 2: Shutting down " + childRegions.size() + " child regions in parallel",
+        () -> {
+          // Create individual shutdown tasks for each child region
+          List<CompletableFuture<Void>> childRegionShutdownTasks = new ArrayList<>();
+          for (int i = 0; i < childRegions.size(); i++) {
+            final int regionIndex = i;
+            final VeniceMultiClusterWrapper childRegion = childRegions.get(i);
+            CompletableFuture<Void> regionShutdownTask = CompletableFuture.runAsync(() -> {
+              long regionStartTime = System.currentTimeMillis();
+              LOGGER.debug("Shutting down child region {}", regionIndex);
+              IOUtils.closeQuietly(childRegion);
+              long regionDuration = System.currentTimeMillis() - regionStartTime;
+              LOGGER.debug("Completed shutdown of child region {} in {} ms", regionIndex, regionDuration);
+            });
+            childRegionShutdownTasks.add(regionShutdownTask);
+          }
+          // Wait for all child regions to complete shutdown
+          CompletableFuture.allOf(childRegionShutdownTasks.toArray(new CompletableFuture[0])).join();
+        });
 
     // Step 3: Stop parent PubSub broker
-    long pubSubBrokerStartTime = System.currentTimeMillis();
-    LOGGER.info("Step 3: Shutting down parent PubSub broker");
-    IOUtils.closeQuietly(parentPubSubBrokerWrapper);
-    long pubSubBrokerTime = System.currentTimeMillis() - pubSubBrokerStartTime;
-    LOGGER.info("Completed shutdown of parent PubSub broker in {} ms", pubSubBrokerTime);
+    long pubSubBrokerTime = TimingUtils.timeOperationAndReturnDuration(
+        LOGGER,
+        "Step 3: Shutting down parent PubSub broker",
+        () -> IOUtils.closeQuietly(parentPubSubBrokerWrapper));
 
     // Step 4: Stop parent ZooKeeper last
-    long zkStartTime = System.currentTimeMillis();
-    LOGGER.info("Step 4: Shutting down ZooKeeper server");
-    IOUtils.closeQuietly(zkServerWrapper);
-    long zkShutdownTime = System.currentTimeMillis() - zkStartTime;
-    LOGGER.info("Completed shutdown of ZooKeeper server in {} ms", zkShutdownTime);
+    long zkShutdownTime = TimingUtils.timeOperationAndReturnDuration(
+        LOGGER,
+        "Step 4: Shutting down ZooKeeper server",
+        () -> IOUtils.closeQuietly(zkServerWrapper));
 
     long totalShutdownTime = System.currentTimeMillis() - overallStartTime;
 

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/restart/TestRestartServerAfterDeletingSstFilesWithActiveActiveIngestion.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/restart/TestRestartServerAfterDeletingSstFilesWithActiveActiveIngestion.java
@@ -78,7 +78,6 @@ import org.apache.logging.log4j.Logger;
 import org.rocksdb.ComparatorOptions;
 import org.rocksdb.util.BytewiseComparator;
 import org.testng.annotations.AfterClass;
-import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -168,12 +167,6 @@ public class TestRestartServerAfterDeletingSstFilesWithActiveActiveIngestion {
         .setPartitionCount(NUMBER_OF_PARTITIONS)
         .setReplicationFactor(NUMBER_OF_REPLICAS);
     createStoreForJob(clusterName, keySchemaStr, valueSchemaStr, props, storeParms).close();
-  }
-
-  @AfterMethod(alwaysRun = true)
-  public void cleanUpAfterMethod() {
-    // Force garbage collection to help release resources
-    System.gc();
   }
 
   @AfterClass(alwaysRun = true)

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/restart/TestRestartServerAfterDeletingSstFilesWithActiveActiveIngestion.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/restart/TestRestartServerAfterDeletingSstFilesWithActiveActiveIngestion.java
@@ -14,6 +14,7 @@ import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertTrue;
 
 import com.linkedin.avroutil1.compatibility.AvroCompatibilityHelper;
 import com.linkedin.d2.balancer.D2Client;
@@ -76,7 +77,6 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.rocksdb.ComparatorOptions;
 import org.rocksdb.util.BytewiseComparator;
-import org.testng.Assert;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
@@ -395,7 +395,7 @@ public class TestRestartServerAfterDeletingSstFilesWithActiveActiveIngestion {
             .getStore(clusterWrappers.get(colo).getClusterName(), STORE_NAME)
             .getCurrentVersion();
         LOGGER.info("colo {} currentVersion {}, pushVersion {}", colo, currentVersion, newVersion);
-        Assert.assertTrue(
+        assertTrue(
             currentVersion >= newVersion,
             "Version is not activated in colo " + colo + ". Current version: " + currentVersion);
       }

--- a/internal/venice-test-common/src/main/java/com/linkedin/venice/utils/DataProviderUtils.java
+++ b/internal/venice-test-common/src/main/java/com/linkedin/venice/utils/DataProviderUtils.java
@@ -72,7 +72,7 @@ public class DataProviderUtils {
     return allPermutationGenerator(BOOLEAN, BOOLEAN, BOOLEAN, BOOLEAN, BOOLEAN);
   }
 
-  @DataProvider(name = "Six-True-and-False")
+  @DataProvider(name = "Six-True-and-False", parallel = true)
   public static Object[][] sixBoolean() {
     return allPermutationGenerator(BOOLEAN, BOOLEAN, BOOLEAN, BOOLEAN, BOOLEAN, BOOLEAN);
   }


### PR DESCRIPTION
## [test] Implement parallel shutdown for Venice test infrastructure to improve performance

Optimized shutdown performance across all levels of Venice test cluster wrappers by  
parallelizing independent service shutdowns while preserving proper dependency ordering.  

Changes:  
- VeniceTwoLayerMultiRegionMultiClusterWrapper: Parallelize parent controller and  
  child region shutdowns independently, keeping sequential order  
  (controllers → regions → pubsub → zk).  
- VeniceMultiClusterWrapper: Parallelize individual controller and cluster shutdowns  
  with dependency management (controllers → clusters → d2 → pubsub → zk).  
- VeniceClusterWrapper: Parallelize router, server, and controller shutdowns within  
  each cluster while preserving order (client → routers → servers → controllers →  
  infrastructure → process).  


###  Code changes
- [ ] Added new code behind **a config**. If so list the config names and their default values in the PR description.
- [ ] Introduced new **log lines**. 
  - [ ] Confirmed if logs need to be **rate limited** to avoid excessive logging.

###  **Concurrency-Specific Checks**
Both reviewer and PR author to verify
- [ ] Code has **no race conditions** or **thread safety issues**.
- [ ] Proper **synchronization mechanisms** (e.g., `synchronized`, `RWLock`) are used where needed.
- [ ] No **blocking calls** inside critical sections that could lead to deadlocks or performance degradation.
- [ ] Verified **thread-safe collections** are used (e.g., `ConcurrentHashMap`, `CopyOnWriteArrayList`).
- [ ] Validated proper exception handling in multi-threaded code to avoid silent thread termination.


## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->

- [ ] New unit tests added.
- [ ] New integration tests added.
- [ ] Modified or extended existing tests.
- [ ] Verified backward compatibility (if applicable).

## Does this PR introduce any user-facing or breaking changes?
<!--  
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [ ] No. You can skip the rest of this section.
- [ ] Yes. Clearly explain the behavior change and its impact.