### PR TITLE
[controller][server] Remove usage of PubSubProduceResult::getOffset and deprecate it

### DIFF
--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/ActiveActiveStoreIngestionTaskTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/ActiveActiveStoreIngestionTaskTest.java
@@ -57,6 +57,7 @@ import com.linkedin.venice.pubsub.api.PubSubProduceResult;
 import com.linkedin.venice.pubsub.api.PubSubProducerAdapter;
 import com.linkedin.venice.pubsub.api.PubSubProducerCallback;
 import com.linkedin.venice.pubsub.api.PubSubTopicPartition;
+import com.linkedin.venice.pubsub.mock.InMemoryPubSubPosition;
 import com.linkedin.venice.schema.SchemaEntry;
 import com.linkedin.venice.serialization.KeyWithChunkingSuffixSerializer;
 import com.linkedin.venice.serialization.avro.AvroProtocolDefinition;
@@ -99,10 +100,6 @@ import org.testng.annotations.Test;
 public class ActiveActiveStoreIngestionTaskTest {
   private static final Logger LOGGER = LogManager.getLogger(ActiveActiveStoreIngestionTaskTest.class);
   private static final PubSubTopicRepository TOPIC_REPOSITORY = new PubSubTopicRepository();
-  String STORE_NAME = "Thvorusleikir_store";
-  String PUSH_JOB_ID = "yule";
-  String BOOTSTRAP_SERVER = "Stekkjastaur";
-  String TEST_CLUSTER_NAME = "venice-GRYLA";
 
   @DataProvider(name = "CompressionStrategy")
   public static Object[] compressionStrategyProvider() {
@@ -245,7 +242,7 @@ public class ActiveActiveStoreIngestionTaskTest {
               PubSubProducerCallback callback = invocation.getArgument(5);
               PubSubProduceResult produceResult = mock(PubSubProduceResult.class);
               offset.addAndGet(1);
-              when(produceResult.getOffset()).thenReturn(offset.get());
+              when(produceResult.getPubSubPosition()).thenReturn(InMemoryPubSubPosition.of(offset.get()));
               MessageType messageType = MessageType.valueOf(kafkaMessageEnvelope.messageType);
               when(produceResult.getSerializedSize()).thenReturn(
                   kafkaKey.getKeyLength() + (messageType.equals(MessageType.PUT)

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTaskTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTaskTest.java
@@ -577,7 +577,7 @@ public class LeaderFollowerStoreIngestionTaskTest {
     assertEquals(put.getSchemaId(), AvroProtocolDefinition.GLOBAL_RT_DIV_STATE.getCurrentProtocolVersion());
     assertNotNull(put.getPutValue());
     PubSubProduceResult produceResult = mock(PubSubProduceResult.class);
-    when(produceResult.getOffset()).thenReturn(0L);
+    when(produceResult.getPubSubPosition()).thenReturn(mock(PubSubPosition.class));
     when(produceResult.getSerializedSize()).thenReturn(keyBytes.length + put.putValue.remaining());
     callback.onCompletion(produceResult, null);
     verify(mockStoreBufferService, times(1)).execSyncOffsetFromSnapshotAsync(any(), any(), any());

--- a/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/adapter/SimplePubSubProduceResultImpl.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/adapter/SimplePubSubProduceResultImpl.java
@@ -22,11 +22,6 @@ public class SimplePubSubProduceResultImpl implements PubSubProduceResult {
   }
 
   @Override
-  public long getOffset() {
-    return pubSubPosition.getNumericOffset();
-  }
-
-  @Override
   public PubSubPosition getPubSubPosition() {
     return pubSubPosition;
   }

--- a/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/api/PubSubProduceResult.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/api/PubSubProduceResult.java
@@ -6,8 +6,12 @@ package com.linkedin.venice.pubsub.api;
 public interface PubSubProduceResult {
   /**
    * The offset of the record in the topic/partition.
+   * @deprecated Use {@link #getPubSubPosition()} instead.
    */
-  long getOffset();
+  @Deprecated
+  default long getOffset() {
+    return getPubSubPosition().getNumericOffset();
+  }
 
   /**
    * The position of the record in the topic/partition.

--- a/internal/venice-common/src/main/java/com/linkedin/venice/pushstatushelper/PushStatusStoreWriter.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/pushstatushelper/PushStatusStoreWriter.java
@@ -8,6 +8,7 @@ import com.linkedin.venice.pushstatus.PushStatusKey;
 import com.linkedin.venice.schema.SchemaEntry;
 import com.linkedin.venice.schema.writecompute.DerivedSchemaEntry;
 import com.linkedin.venice.utils.LatencyUtils;
+import com.linkedin.venice.utils.Utils;
 import com.linkedin.venice.writer.VeniceWriter;
 import com.linkedin.venice.writer.VeniceWriterFactory;
 import com.linkedin.venice.writer.update.UpdateBuilder;
@@ -42,9 +43,9 @@ public class PushStatusStoreWriter implements AutoCloseable {
         LOGGER.error("Failed to update push status. Error: ", exception);
       } else {
         LOGGER.info(
-            "Updated push status into topic {} at offset {}.",
-            produceResult.getTopic(),
-            produceResult.getOffset());
+            "Updated push status into topic: {} at position: {}",
+            Utils.getReplicaId(produceResult.getTopic(), produceResult.getPartition()),
+            produceResult.getPubSubPosition());
       }
     }
   };

--- a/internal/venice-common/src/test/java/com/linkedin/venice/pubsub/adapter/kafka/producer/ApacheKafkaProduceResultTest.java
+++ b/internal/venice-common/src/test/java/com/linkedin/venice/pubsub/adapter/kafka/producer/ApacheKafkaProduceResultTest.java
@@ -3,6 +3,7 @@ package com.linkedin.venice.pubsub.adapter.kafka.producer;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
 
+import com.linkedin.venice.pubsub.adapter.kafka.common.ApacheKafkaOffsetPosition;
 import com.linkedin.venice.pubsub.api.PubSubProduceResult;
 import org.apache.kafka.clients.producer.RecordMetadata;
 import org.apache.kafka.common.TopicPartition;
@@ -22,7 +23,7 @@ public class ApacheKafkaProduceResultTest {
     assertNotNull(produceResult);
     assertEquals(produceResult.getTopic(), recordMetadata.topic());
     assertEquals(produceResult.getPartition(), recordMetadata.partition());
-    assertEquals(produceResult.getOffset(), recordMetadata.offset());
+    assertEquals(produceResult.getPubSubPosition(), ApacheKafkaOffsetPosition.of(recordMetadata.offset()));
     assertEquals(
         produceResult.getSerializedSize(),
         recordMetadata.serializedKeySize() + recordMetadata.serializedValueSize());

--- a/internal/venice-common/src/test/java/com/linkedin/venice/pubsub/adapter/kafka/producer/ApacheKafkaProducerCallbackTest.java
+++ b/internal/venice-common/src/test/java/com/linkedin/venice/pubsub/adapter/kafka/producer/ApacheKafkaProducerCallbackTest.java
@@ -6,6 +6,7 @@ import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertTrue;
 
+import com.linkedin.venice.pubsub.adapter.kafka.common.ApacheKafkaOffsetPosition;
 import com.linkedin.venice.pubsub.api.PubSubProduceResult;
 import com.linkedin.venice.pubsub.mock.adapter.PubSubProducerCallbackSimpleImpl;
 import com.linkedin.venice.utils.ExceptionUtils;
@@ -33,7 +34,7 @@ public class ApacheKafkaProducerCallbackTest {
     PubSubProduceResult produceResult = internalCallback.getProduceResult();
     assertEquals(produceResult.getTopic(), recordMetadata.topic());
     assertEquals(produceResult.getPartition(), recordMetadata.partition());
-    assertEquals(produceResult.getOffset(), recordMetadata.offset());
+    assertEquals(produceResult.getPubSubPosition(), ApacheKafkaOffsetPosition.of(recordMetadata.offset()));
   }
 
   @Test

--- a/internal/venice-common/src/test/java/com/linkedin/venice/pushstatushelper/PushStatusStoreWriterTest.java
+++ b/internal/venice-common/src/test/java/com/linkedin/venice/pushstatushelper/PushStatusStoreWriterTest.java
@@ -11,6 +11,7 @@ import static org.mockito.Mockito.when;
 
 import com.linkedin.venice.common.PushStatusStoreUtils;
 import com.linkedin.venice.logger.TestLogAppender;
+import com.linkedin.venice.pubsub.adapter.kafka.common.ApacheKafkaOffsetPosition;
 import com.linkedin.venice.pubsub.api.PubSubProduceResult;
 import com.linkedin.venice.pubsub.api.PubSubProducerCallback;
 import com.linkedin.venice.pushstatus.PushStatusKey;
@@ -181,14 +182,17 @@ public class PushStatusStoreWriterTest {
     // Mock the produce result
     PubSubProduceResult produceResult = Mockito.mock(PubSubProduceResult.class);
     Mockito.when(produceResult.getTopic()).thenReturn("test-topic");
-    Mockito.when(produceResult.getOffset()).thenReturn(12345L);
+    Mockito.when(produceResult.getPubSubPosition()).thenReturn(ApacheKafkaOffsetPosition.of(12345L));
 
     // Test successful completion path
     callback.onCompletion(produceResult, null);
 
     // Verify logging
     String capturedLog = testLogAppender.getLog();
-    Assert.assertTrue(capturedLog.contains("Updated push status into topic test-topic at offset 12345"));
+    Assert.assertTrue(
+        capturedLog.contains("Updated push status into topic: test-topic-0 at position:"),
+        "Got: " + capturedLog);
+    Assert.assertTrue(capturedLog.contains("12345"));
 
     // Test failure path
     Exception exception = new Exception("Test error");

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/controller/kafka/consumer/AdminConsumptionTaskIntegrationTest.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/controller/kafka/consumer/AdminConsumptionTaskIntegrationTest.java
@@ -24,6 +24,7 @@ import com.linkedin.venice.integration.utils.VeniceTwoLayerMultiRegionMultiClust
 import com.linkedin.venice.meta.StoreInfo;
 import com.linkedin.venice.pubsub.PubSubProducerAdapterFactory;
 import com.linkedin.venice.pubsub.PubSubTopicRepository;
+import com.linkedin.venice.pubsub.api.PubSubPosition;
 import com.linkedin.venice.pubsub.api.PubSubTopic;
 import com.linkedin.venice.pubsub.manager.TopicManager;
 import com.linkedin.venice.utils.ConfigCommonUtils;
@@ -120,9 +121,10 @@ public class AdminConsumptionTaskIntegrationTest {
         valueSchema,
         nextExecutionId(),
         AdminOperationSerializer.LATEST_SCHEMA_ID_FOR_ADMIN_OPERATION);
-    long badOffset = writer.put(new byte[0], message, AdminOperationSerializer.LATEST_SCHEMA_ID_FOR_ADMIN_OPERATION)
-        .get()
-        .getOffset();
+    PubSubPosition failingPosition =
+        writer.put(new byte[0], message, AdminOperationSerializer.LATEST_SCHEMA_ID_FOR_ADMIN_OPERATION)
+            .get()
+            .getPubSubPosition();
 
     byte[] goodMessage = getStoreCreationMessage(
         clusterName,
@@ -141,9 +143,9 @@ public class AdminConsumptionTaskIntegrationTest {
     TestUtils.waitForNonDeterministicAssertion(
         TIMEOUT,
         TimeUnit.MILLISECONDS,
-        () -> Assert.assertEquals(adminConsumerService.getFailingPosition().getNumericOffset(), badOffset));
+        () -> Assert.assertEquals(adminConsumerService.getFailingPosition(), failingPosition));
 
-    parentControllerClient.skipAdminMessage(Long.toString(badOffset), false, null);
+    parentControllerClient.skipAdminMessage(Long.toString(failingPosition.getNumericOffset()), false, null);
 
     TestUtils.waitForNonDeterministicAssertion(TIMEOUT, TimeUnit.MILLISECONDS, () -> {
       Assert.assertFalse(parentControllerClient.getStore(storeName).isError());

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/pubsub/adapter/kafka/producer/ApacheKafkaProducerAdapterITest.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/pubsub/adapter/kafka/producer/ApacheKafkaProducerAdapterITest.java
@@ -23,6 +23,7 @@ import com.linkedin.venice.message.KafkaKey;
 import com.linkedin.venice.pubsub.PubSubProducerAdapterContext;
 import com.linkedin.venice.pubsub.api.PubSubProduceResult;
 import com.linkedin.venice.pubsub.api.PubSubProducerCallback;
+import com.linkedin.venice.pubsub.api.PubSubSymbolicPosition;
 import com.linkedin.venice.pubsub.mock.adapter.PubSubProducerCallbackSimpleImpl;
 import com.linkedin.venice.utils.DataProviderUtils;
 import com.linkedin.venice.utils.ExceptionUtils;
@@ -237,7 +238,7 @@ public class ApacheKafkaProducerAdapterITest {
         try {
           PubSubProduceResult produceResult = future.get();
           assertNotNull(produceResult);
-          assertNotEquals(produceResult.getOffset(), -1);
+          assertNotEquals(produceResult.getPubSubPosition(), PubSubSymbolicPosition.EARLIEST);
           assertNull(cb.getException());
         } catch (Exception notExpected) {
           fail("When flush is enabled all messages should be sent to Kafka successfully");

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceParentHelixAdmin.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceParentHelixAdmin.java
@@ -721,7 +721,11 @@ public class VeniceParentHelixAdmin implements Admin {
           veniceWriter.flush();
           PubSubProduceResult produceResult = future.get();
 
-          LOGGER.info("Sent message: {} to kafka, offset: {}", message, produceResult.getOffset());
+          LOGGER.info(
+              "Sent message: {} to: {}, position: {}",
+              message,
+              Utils.getReplicaId(produceResult.getTopic(), produceResult.getPartition()),
+              produceResult.getPubSubPosition());
         } catch (Exception e) {
           throw new VeniceException("Got exception during sending message to Kafka -- " + e.getMessage(), e);
         }

--- a/services/venice-controller/src/test/java/com/linkedin/venice/controller/kafka/consumer/AdminConsumptionTaskTest.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/controller/kafka/consumer/AdminConsumptionTaskTest.java
@@ -78,7 +78,6 @@ import com.linkedin.venice.offsets.OffsetRecord;
 import com.linkedin.venice.pubsub.PubSubTopicPartitionImpl;
 import com.linkedin.venice.pubsub.PubSubTopicRepository;
 import com.linkedin.venice.pubsub.PubSubUtil;
-import com.linkedin.venice.pubsub.adapter.kafka.common.ApacheKafkaOffsetPosition;
 import com.linkedin.venice.pubsub.api.PubSubConsumerAdapter;
 import com.linkedin.venice.pubsub.api.PubSubMessageHeader;
 import com.linkedin.venice.pubsub.api.PubSubMessageHeaders;
@@ -129,6 +128,7 @@ import java.util.Queue;
 import java.util.Set;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CancellationException;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -209,7 +209,7 @@ public class AdminConsumptionTaskTest {
     doReturn(lockManager).when(resources).getClusterLockManager();
     doCallRealMethod().when(resources).getStoreMetadataRepository();
 
-    when(mockKafkaConsumer.beginningPosition(any())).thenReturn(ApacheKafkaOffsetPosition.of(-1L));
+    when(mockKafkaConsumer.beginningPosition(any())).thenReturn(InMemoryPubSubPosition.of(0));
     doAnswer(invocation -> {
       PubSubTopicPartition partition = invocation.getArgument(0);
       PubSubPosition position1 = invocation.getArgument(1);
@@ -291,8 +291,8 @@ public class AdminConsumptionTaskTest {
     return new MockInMemoryPartitionPosition(pubSubTopicPartition, produceResult.getPubSubPosition());
   }
 
-  private long getLastOffset(String clusterName) {
-    return adminTopicMetadataAccessor.getMetadata(clusterName).getOffset();
+  private PubSubPosition getLastPosition(String clusterName) {
+    return adminTopicMetadataAccessor.getMetadata(clusterName).getPosition();
   }
 
   private long getLastExecutionId(String clusterName) {
@@ -303,7 +303,8 @@ public class AdminConsumptionTaskTest {
   public void testSubscribeUsesLocalPositionWhenRemoteDisabled() throws Exception {
     // Arrange: write admin metadata with only local position set
     AdminMetadata adminMetadata = new AdminMetadata();
-    adminMetadata.setPubSubPosition(ApacheKafkaOffsetPosition.of(10L));
+    PubSubPosition p10 = InMemoryPubSubPosition.of(10L);
+    adminMetadata.setPubSubPosition(p10);
     adminMetadata.setUpstreamPubSubPosition(PubSubSymbolicPosition.EARLIEST);
     adminMetadata.setExecutionId(1L);
     adminTopicMetadataAccessor.updateMetadata(clusterName, adminMetadata);
@@ -317,7 +318,7 @@ public class AdminConsumptionTaskTest {
     // Assert: subscribe called with local position (offset 10)
     ArgumentCaptor<PubSubPosition> posCaptor = ArgumentCaptor.forClass(PubSubPosition.class);
     verify(mockKafkaConsumer, timeout(TIMEOUT)).subscribe(any(), posCaptor.capture());
-    Assert.assertEquals(posCaptor.getValue().getNumericOffset(), 10L, "Should subscribe from local checkpoint");
+    Assert.assertEquals(posCaptor.getValue(), p10, "Should subscribe from local checkpoint");
 
     task.close();
     executor.shutdown();
@@ -327,9 +328,10 @@ public class AdminConsumptionTaskTest {
   @Test(timeOut = TIMEOUT)
   public void testSubscribeUsesUpstreamPositionWhenRemoteEnabled() throws Exception {
     // Arrange: write admin metadata with upstream position set
+    InMemoryPubSubPosition p20 = InMemoryPubSubPosition.of(20L);
     AdminMetadata adminMetadata = new AdminMetadata();
     adminMetadata.setPubSubPosition(PubSubSymbolicPosition.EARLIEST);
-    adminMetadata.setUpstreamPubSubPosition(ApacheKafkaOffsetPosition.of(20L));
+    adminMetadata.setUpstreamPubSubPosition(p20);
     adminMetadata.setExecutionId(2L);
     adminTopicMetadataAccessor.updateMetadata(clusterName, adminMetadata);
 
@@ -349,7 +351,7 @@ public class AdminConsumptionTaskTest {
     // Assert: subscribe called with upstream position (offset 20)
     ArgumentCaptor<PubSubPosition> posCaptor = ArgumentCaptor.forClass(PubSubPosition.class);
     verify(mockKafkaConsumer, timeout(TIMEOUT)).subscribe(any(), posCaptor.capture());
-    Assert.assertEquals(posCaptor.getValue().getNumericOffset(), 20L, "Should subscribe from upstream checkpoint");
+    Assert.assertEquals(posCaptor.getValue(), p20, "Should subscribe from upstream checkpoint");
 
     task.close();
     executor.shutdown();
@@ -414,7 +416,7 @@ public class AdminConsumptionTaskTest {
   }
 
   @Test(timeOut = TIMEOUT)
-  public void testRun() throws InterruptedException, IOException {
+  public void testRun() throws InterruptedException, IOException, ExecutionException {
     // The store doesn't exist
     doReturn(false).when(admin).hasStore(clusterName, storeName);
 
@@ -422,17 +424,19 @@ public class AdminConsumptionTaskTest {
         emptyKeyBytes,
         getStoreCreationMessage(clusterName, storeName, owner, keySchema, valueSchema, 1),
         AdminOperationSerializer.LATEST_SCHEMA_ID_FOR_ADMIN_OPERATION);
-    veniceWriter.put(
-        emptyKeyBytes,
-        getKillOfflinePushJobMessage(clusterName, storeTopicName, 2),
-        AdminOperationSerializer.LATEST_SCHEMA_ID_FOR_ADMIN_OPERATION);
+    InMemoryPubSubPosition position2 = getPosition(
+        veniceWriter.put(
+            emptyKeyBytes,
+            getKillOfflinePushJobMessage(clusterName, storeTopicName, 2),
+            AdminOperationSerializer.LATEST_SCHEMA_ID_FOR_ADMIN_OPERATION));
 
     AdminConsumptionTask task = getAdminConsumptionTask(new RandomPollStrategy(), false);
     executor.submit(task);
 
-    TestUtils.waitForNonDeterministicAssertion(TIMEOUT, TimeUnit.MILLISECONDS, () -> {
-      Assert.assertEquals(getLastOffset(clusterName), 2L);
-    });
+    TestUtils.waitForNonDeterministicAssertion(
+        TIMEOUT,
+        TimeUnit.MILLISECONDS,
+        () -> Assert.assertEquals(getLastPosition(clusterName), position2));
 
     task.close();
     executor.shutdown();
@@ -470,11 +474,13 @@ public class AdminConsumptionTaskTest {
   }
 
   @Test(timeOut = TIMEOUT)
-  public void testRunWhenStoreCreationGotExceptionForTheFirstTime() throws InterruptedException, IOException {
-    veniceWriter.put(
-        emptyKeyBytes,
-        getStoreCreationMessage(clusterName, storeName, owner, keySchema, valueSchema, 1),
-        AdminOperationSerializer.LATEST_SCHEMA_ID_FOR_ADMIN_OPERATION);
+  public void testRunWhenStoreCreationGotExceptionForTheFirstTime()
+      throws InterruptedException, IOException, ExecutionException {
+    InMemoryPubSubPosition position1 = getPosition(
+        veniceWriter.put(
+            emptyKeyBytes,
+            getStoreCreationMessage(clusterName, storeName, owner, keySchema, valueSchema, 1),
+            AdminOperationSerializer.LATEST_SCHEMA_ID_FOR_ADMIN_OPERATION));
     // The store doesn't exist
     doReturn(false).when(admin).hasStore(clusterName, storeName);
     doThrow(new VeniceException("Mock store creation exception")).doNothing()
@@ -487,7 +493,7 @@ public class AdminConsumptionTaskTest {
     TestUtils.waitForNonDeterministicAssertion(
         TIMEOUT,
         TimeUnit.MILLISECONDS,
-        () -> Assert.assertEquals(getLastOffset(clusterName), 1L));
+        () -> Assert.assertEquals(getLastPosition(clusterName), position1));
 
     task.close();
     executor.shutdown();
@@ -501,20 +507,20 @@ public class AdminConsumptionTaskTest {
 
   @Test(timeOut = TIMEOUT)
   public void testDelegateExceptionSetsFailingOffset() throws ExecutionException, InterruptedException, IOException {
-    long failingOffset =
+    PubSubPosition failingPosition =
         ((PubSubProduceResult) veniceWriter
             .put(
                 emptyKeyBytes,
                 getStoreCreationMessage(clusterName, storeName, owner, keySchema, valueSchema, 1),
                 AdminOperationSerializer.LATEST_SCHEMA_ID_FOR_ADMIN_OPERATION)
-            .get()).getOffset();
+            .get()).getPubSubPosition();
     AdminConsumptionStats mockStats = mock(AdminConsumptionStats.class);
     doThrow(StringIndexOutOfBoundsException.class).when(mockStats).recordAdminMessageDelegateLatency(anyDouble());
     AdminConsumptionTask task = getAdminConsumptionTask(new RandomPollStrategy(), false, mockStats, 10000);
     executor.submit(task);
 
     TestUtils.waitForNonDeterministicAssertion(TIMEOUT, TimeUnit.MILLISECONDS, () -> {
-      Assert.assertEquals(task.getFailingPosition().getNumericOffset(), failingOffset);
+      Assert.assertEquals(task.getFailingPosition(), failingPosition);
     });
 
     task.close();
@@ -541,7 +547,7 @@ public class AdminConsumptionTaskTest {
     executor.submit(task);
 
     TestUtils.waitForNonDeterministicAssertion(TIMEOUT, TimeUnit.MILLISECONDS, () -> {
-      Assert.assertEquals(task.getFailingPosition().getNumericOffset(), 1L);
+      Assert.assertEquals(task.getFailingPosition(), InMemoryPubSubPosition.of(1L));
     });
 
     verify(mockStats, timeout(100).atLeastOnce()).setAdminConsumptionFailedPosition(any());
@@ -552,15 +558,16 @@ public class AdminConsumptionTaskTest {
     task.close();
     executor.shutdown();
     executor.awaitTermination(TIMEOUT, TimeUnit.MILLISECONDS);
-    Assert.assertEquals(getLastOffset(clusterName), -1L);
+    Assert.assertEquals(getLastPosition(clusterName), PubSubSymbolicPosition.EARLIEST);
   }
 
   @Test(timeOut = TIMEOUT)
-  public void testSkipMessageCommand() throws IOException, InterruptedException {
-    veniceWriter.put(
-        emptyKeyBytes,
-        getStoreCreationMessage(clusterName, storeName, owner, keySchema, valueSchema, 1),
-        AdminOperationSerializer.LATEST_SCHEMA_ID_FOR_ADMIN_OPERATION);
+  public void testSkipMessageCommand() throws IOException, InterruptedException, ExecutionException {
+    InMemoryPubSubPosition position1 = getPosition(
+        veniceWriter.put(
+            emptyKeyBytes,
+            getStoreCreationMessage(clusterName, storeName, owner, keySchema, valueSchema, 1),
+            AdminOperationSerializer.LATEST_SCHEMA_ID_FOR_ADMIN_OPERATION));
     // The store doesn't exist
     doReturn(false).when(admin).hasStore(clusterName, storeName);
     doThrow(new VeniceException("Mock store creation exception")).when(admin)
@@ -579,7 +586,7 @@ public class AdminConsumptionTaskTest {
 
     // admin throws errors, so record offset means we skipped the message
     TestUtils.waitForNonDeterministicAssertion(TIMEOUT, TimeUnit.MILLISECONDS, () -> {
-      Assert.assertEquals(getLastOffset(clusterName), 1L);
+      Assert.assertEquals(getLastPosition(clusterName), position1);
     });
 
     task.close();
@@ -628,12 +635,11 @@ public class AdminConsumptionTaskTest {
                 getKillOfflinePushJobMessage(clusterName, storeTopicName, 1),
                 AdminOperationSerializer.LATEST_SCHEMA_ID_FOR_ADMIN_OPERATION)
             .get();
-    veniceWriter
-        .put(
+    InMemoryPubSubPosition position2 = getPosition(
+        veniceWriter.put(
             emptyKeyBytes,
             getStoreCreationMessage(clusterName, storeName, owner, keySchema, valueSchema, 2),
-            AdminOperationSerializer.LATEST_SCHEMA_ID_FOR_ADMIN_OPERATION)
-        .get();
+            AdminOperationSerializer.LATEST_SCHEMA_ID_FOR_ADMIN_OPERATION));
 
     Queue<AbstractPollStrategy> pollStrategies = new LinkedList<>();
     pollStrategies.add(new RandomPollStrategy());
@@ -647,9 +653,10 @@ public class AdminConsumptionTaskTest {
     AdminConsumptionTask task = getAdminConsumptionTask(pollStrategy, false);
     executor.submit(task);
 
-    TestUtils.waitForNonDeterministicAssertion(TIMEOUT, TimeUnit.MILLISECONDS, () -> {
-      Assert.assertEquals(getLastOffset(clusterName), 2L);
-    });
+    TestUtils.waitForNonDeterministicAssertion(
+        TIMEOUT,
+        TimeUnit.MILLISECONDS,
+        () -> Assert.assertEquals(getLastPosition(clusterName), position2));
 
     Utils.sleep(1000); // TODO: find a better to wait for AdminConsumptionTask consume the last message.
     task.close();
@@ -667,23 +674,21 @@ public class AdminConsumptionTaskTest {
     String storeName1 = "test_store1";
     String storeName2 = "test_store2";
     String storeName3 = "test_store3";
-    InMemoryPubSubPosition offset1 = getPosition(
+    InMemoryPubSubPosition position1 = getPosition(
         veniceWriter.put(
             emptyKeyBytes,
             getStoreCreationMessage(clusterName, storeName1, owner, keySchema, valueSchema, 1),
             AdminOperationSerializer.LATEST_SCHEMA_ID_FOR_ADMIN_OPERATION));
-    System.out.println("Offset for store creation message 1: " + offset1);
-    InMemoryPubSubPosition offsetToSkip = getPosition(
+    InMemoryPubSubPosition position2ToSkip = getPosition(
         veniceWriter.put(
             emptyKeyBytes,
             getStoreCreationMessage(clusterName, storeName2, owner, keySchema, valueSchema, 2),
             AdminOperationSerializer.LATEST_SCHEMA_ID_FOR_ADMIN_OPERATION));
-    InMemoryPubSubPosition offset3 = getPosition(
+    InMemoryPubSubPosition position3 = getPosition(
         veniceWriter.put(
             emptyKeyBytes,
             getStoreCreationMessage(clusterName, storeName3, owner, keySchema, valueSchema, 3),
             AdminOperationSerializer.LATEST_SCHEMA_ID_FOR_ADMIN_OPERATION));
-    System.out.println("Offset for store creation message 3: " + offset3);
 
     Set<MockInMemoryPartitionPosition> topicPartitionOffsetsToFilterOut = new HashSet<>();
     topicPartitionOffsetsToFilterOut.add(
@@ -691,7 +696,7 @@ public class AdminConsumptionTaskTest {
             new PubSubTopicPartitionImpl(
                 pubSubTopicRepository.getTopic(topicName),
                 AdminTopicUtils.ADMIN_TOPIC_PARTITION_ID),
-            offsetToSkip.getPreviousPosition()));
+            position2ToSkip.getPreviousPosition()));
     PollStrategy pollStrategy =
         new FilteringPollStrategy(new RandomPollStrategy(false), topicPartitionOffsetsToFilterOut);
 
@@ -707,16 +712,16 @@ public class AdminConsumptionTaskTest {
     TestUtils.waitForNonDeterministicAssertion(
         TIMEOUT,
         TimeUnit.MILLISECONDS,
-        () -> Assert.assertEquals(getLastOffset(clusterName), 1L));
+        () -> Assert.assertEquals(getLastPosition(clusterName), position1));
     TestUtils.waitForNonDeterministicAssertion(
         TIMEOUT,
         TimeUnit.MILLISECONDS,
-        () -> Assert.assertEquals(task.getFailingPosition().getNumericOffset(), 3L));
+        () -> Assert.assertEquals(task.getFailingPosition(), position3));
     task.skipMessageWithOffset(3L);
     TestUtils.waitForNonDeterministicAssertion(
         TIMEOUT,
         TimeUnit.MILLISECONDS,
-        () -> Assert.assertEquals(getLastOffset(clusterName), 3L));
+        () -> Assert.assertEquals(getLastPosition(clusterName), position3));
     task.close();
     executor.shutdownNow();
     executor.awaitTermination(TIMEOUT, TimeUnit.MILLISECONDS);
@@ -815,10 +820,11 @@ public class AdminConsumptionTaskTest {
         emptyKeyBytes,
         getStoreCreationMessage(clusterName, storeName2, owner, keySchema, valueSchema, 3),
         AdminOperationSerializer.LATEST_SCHEMA_ID_FOR_ADMIN_OPERATION);
-    veniceWriter.put(
-        emptyKeyBytes,
-        getStoreCreationMessage(clusterName, storeName3, owner, keySchema, valueSchema, 4),
-        AdminOperationSerializer.LATEST_SCHEMA_ID_FOR_ADMIN_OPERATION);
+    InMemoryPubSubPosition position3 = getPosition(
+        veniceWriter.put(
+            emptyKeyBytes,
+            getStoreCreationMessage(clusterName, storeName3, owner, keySchema, valueSchema, 4),
+            AdminOperationSerializer.LATEST_SCHEMA_ID_FOR_ADMIN_OPERATION));
     // The stores don't exist yet.
     doReturn(false).when(admin).hasStore(clusterName, storeName1);
     doReturn(false).when(admin).hasStore(clusterName, storeName2);
@@ -830,8 +836,8 @@ public class AdminConsumptionTaskTest {
     TestUtils.waitForNonDeterministicAssertion(
         TIMEOUT,
         TimeUnit.MILLISECONDS,
-        () -> Assert.assertEquals(getLastOffset(clusterName), 3L));
-    Assert.assertEquals(task.getFailingPosition().getNumericOffset(), -1);
+        () -> Assert.assertEquals(getLastPosition(clusterName), position3));
+    Assert.assertEquals(task.getFailingPosition(), PubSubSymbolicPosition.EARLIEST);
     task.close();
     verify(stats, never()).recordAdminTopicDIVErrorReportCount();
     verify(admin, atLeastOnce()).createStore(clusterName, storeName1, owner, keySchema, valueSchema, false);
@@ -854,7 +860,7 @@ public class AdminConsumptionTaskTest {
         AdminOperationSerializer.LATEST_SCHEMA_ID_FOR_ADMIN_OPERATION);
     AdminMetadata adminMetadata = new AdminMetadata();
     PubSubProduceResult pubSubProduceResult = metadataForStoreName0Future.get();
-    adminMetadata.setOffset(pubSubProduceResult.getOffset());
+    adminMetadata.setOffset(((InMemoryPubSubPosition) pubSubProduceResult.getPubSubPosition()).getInternalOffset());
     adminMetadata.setPubSubPosition(pubSubProduceResult.getPubSubPosition());
     adminMetadata.setExecutionId(1L);
     adminTopicMetadataAccessor.updateMetadata(clusterName, adminMetadata);
@@ -869,10 +875,11 @@ public class AdminConsumptionTaskTest {
         emptyKeyBytes,
         getStoreCreationMessage(clusterName, storeName2, owner, keySchema, valueSchema, 4),
         AdminOperationSerializer.LATEST_SCHEMA_ID_FOR_ADMIN_OPERATION);
-    veniceWriter.put(
-        emptyKeyBytes,
-        getStoreCreationMessage(clusterName, storeName3, owner, keySchema, valueSchema, 5),
-        AdminOperationSerializer.LATEST_SCHEMA_ID_FOR_ADMIN_OPERATION);
+    InMemoryPubSubPosition position5 = getPosition(
+        veniceWriter.put(
+            emptyKeyBytes,
+            getStoreCreationMessage(clusterName, storeName3, owner, keySchema, valueSchema, 5),
+            AdminOperationSerializer.LATEST_SCHEMA_ID_FOR_ADMIN_OPERATION));
     // The stores don't exist yet.
     doReturn(false).when(admin).hasStore(clusterName, storeName0);
     doReturn(false).when(admin).hasStore(clusterName, storeName1);
@@ -885,8 +892,8 @@ public class AdminConsumptionTaskTest {
     TestUtils.waitForNonDeterministicAssertion(
         TIMEOUT,
         TimeUnit.MILLISECONDS,
-        () -> Assert.assertEquals(getLastOffset(clusterName), 5L));
-    Assert.assertEquals(task.getFailingPosition().getNumericOffset(), -1);
+        () -> Assert.assertEquals(getLastPosition(clusterName), position5));
+    Assert.assertEquals(task.getFailingPosition(), PubSubSymbolicPosition.EARLIEST);
     task.close();
     verify(stats, never()).recordAdminTopicDIVErrorReportCount();
     verify(admin, atLeastOnce()).createStore(clusterName, storeName1, owner, keySchema, valueSchema, false);
@@ -897,24 +904,27 @@ public class AdminConsumptionTaskTest {
   }
 
   @Test(timeOut = TIMEOUT)
-  public void testRunWithDuplicateMessagesWithDifferentOffset() throws InterruptedException, IOException {
+  public void testRunWithDuplicateMessagesWithDifferentOffset()
+      throws InterruptedException, IOException, ExecutionException {
     veniceWriter.put(
         emptyKeyBytes,
         getStoreCreationMessage(clusterName, storeName, owner, keySchema, valueSchema, 1),
         AdminOperationSerializer.LATEST_SCHEMA_ID_FOR_ADMIN_OPERATION);
-    veniceWriter.put(
-        emptyKeyBytes,
-        getStoreCreationMessage(clusterName, storeName, owner, keySchema, valueSchema, 1),
-        AdminOperationSerializer.LATEST_SCHEMA_ID_FOR_ADMIN_OPERATION);
+    InMemoryPubSubPosition position2 = getPosition(
+        veniceWriter.put(
+            emptyKeyBytes,
+            getStoreCreationMessage(clusterName, storeName, owner, keySchema, valueSchema, 1),
+            AdminOperationSerializer.LATEST_SCHEMA_ID_FOR_ADMIN_OPERATION));
     // The store doesn't exist for the first time, and exist for the second time
     when(admin.hasStore(clusterName, storeName)).thenReturn(false).thenReturn(true);
 
     AdminConsumptionTask task = getAdminConsumptionTask(new RandomPollStrategy(), false);
     executor.submit(task);
 
-    TestUtils.waitForNonDeterministicAssertion(TIMEOUT, TimeUnit.MILLISECONDS, () -> {
-      Assert.assertEquals(getLastOffset(clusterName), 2L);
-    });
+    TestUtils.waitForNonDeterministicAssertion(
+        TIMEOUT,
+        TimeUnit.MILLISECONDS,
+        () -> Assert.assertEquals(getLastPosition(clusterName), position2));
 
     task.close();
     executor.shutdown();
@@ -927,7 +937,7 @@ public class AdminConsumptionTaskTest {
   }
 
   @Test(timeOut = 2 * TIMEOUT)
-  public void testRunWithBiggerStartingOffset() throws InterruptedException, IOException {
+  public void testRunWithBiggerStartingOffset() throws InterruptedException, IOException, ExecutionException {
     String storeName1 = "test_store1";
     String storeName2 = "test_store2";
     veniceWriter.put(
@@ -936,10 +946,11 @@ public class AdminConsumptionTaskTest {
         AdminOperationSerializer.LATEST_SCHEMA_ID_FOR_ADMIN_OPERATION);
     // This scenario mostly happens when leader controller fails over
     veniceWriter = getVeniceWriter(inMemoryPubSubBroker);
-    veniceWriter.put(
-        emptyKeyBytes,
-        getStoreCreationMessage(clusterName, storeName2, owner, keySchema, valueSchema, 2),
-        AdminOperationSerializer.LATEST_SCHEMA_ID_FOR_ADMIN_OPERATION);
+    InMemoryPubSubPosition position3 = getPosition(
+        veniceWriter.put(
+            emptyKeyBytes,
+            getStoreCreationMessage(clusterName, storeName2, owner, keySchema, valueSchema, 2),
+            AdminOperationSerializer.LATEST_SCHEMA_ID_FOR_ADMIN_OPERATION));
     // The store doesn't exist
     doReturn(false).when(admin).hasStore(clusterName, storeName1);
     doReturn(false).when(admin).hasStore(clusterName, storeName2);
@@ -950,9 +961,10 @@ public class AdminConsumptionTaskTest {
 
     AdminConsumptionTask task = getAdminConsumptionTask(new RandomPollStrategy(), false);
     executor.submit(task);
-    TestUtils.waitForNonDeterministicAssertion(TIMEOUT, TimeUnit.MILLISECONDS, () -> {
-      Assert.assertEquals(getLastOffset(clusterName), 3L);
-    });
+    TestUtils.waitForNonDeterministicAssertion(
+        TIMEOUT,
+        TimeUnit.MILLISECONDS,
+        () -> Assert.assertEquals(getLastPosition(clusterName), position3));
     task.close();
     executor.shutdown();
     executor.awaitTermination(TIMEOUT, TimeUnit.MILLISECONDS);
@@ -966,18 +978,21 @@ public class AdminConsumptionTaskTest {
   }
 
   @Test(timeOut = TIMEOUT)
-  public void testParentControllerSkipKillOfflinePushJobMessage() throws InterruptedException, IOException {
-    veniceWriter.put(
-        emptyKeyBytes,
-        getKillOfflinePushJobMessage(clusterName, storeTopicName, 1),
-        AdminOperationSerializer.LATEST_SCHEMA_ID_FOR_ADMIN_OPERATION);
+  public void testParentControllerSkipKillOfflinePushJobMessage()
+      throws InterruptedException, IOException, ExecutionException {
+    InMemoryPubSubPosition position1 = getPosition(
+        veniceWriter.put(
+            emptyKeyBytes,
+            getKillOfflinePushJobMessage(clusterName, storeTopicName, 1),
+            AdminOperationSerializer.LATEST_SCHEMA_ID_FOR_ADMIN_OPERATION));
 
     AdminConsumptionTask task = getAdminConsumptionTask(new RandomPollStrategy(), true);
     executor.submit(task);
 
-    TestUtils.waitForNonDeterministicAssertion(TIMEOUT, TimeUnit.MILLISECONDS, () -> {
-      Assert.assertEquals(getLastOffset(clusterName), 1L);
-    });
+    TestUtils.waitForNonDeterministicAssertion(
+        TIMEOUT,
+        TimeUnit.MILLISECONDS,
+        () -> Assert.assertEquals(getLastPosition(clusterName), position1));
 
     task.close();
     executor.shutdown();
@@ -1146,11 +1161,12 @@ public class AdminConsumptionTaskTest {
     byte[] message =
         adminOperationSerializer.serialize(adminMessage, AdminOperationSerializer.LATEST_SCHEMA_ID_FOR_ADMIN_OPERATION);
 
-    veniceWriter.put(emptyKeyBytes, message, AdminOperationSerializer.LATEST_SCHEMA_ID_FOR_ADMIN_OPERATION);
-
-    TestUtils.waitForNonDeterministicAssertion(TIMEOUT, TimeUnit.MILLISECONDS, () -> {
-      Assert.assertEquals(getLastOffset(clusterName), 2L);
-    });
+    InMemoryPubSubPosition position2 = getPosition(
+        veniceWriter.put(emptyKeyBytes, message, AdminOperationSerializer.LATEST_SCHEMA_ID_FOR_ADMIN_OPERATION));
+    TestUtils.waitForNonDeterministicAssertion(
+        TIMEOUT,
+        TimeUnit.MILLISECONDS,
+        () -> Assert.assertEquals(getLastPosition(clusterName), position2));
 
     task.close();
     executor.shutdown();
@@ -1174,15 +1190,16 @@ public class AdminConsumptionTaskTest {
   }
 
   @Test(timeOut = TIMEOUT * 2)
-  public void testRetryLimitForNoStoreException() throws InterruptedException, IOException {
+  public void testRetryLimitForNoStoreException() throws InterruptedException, IOException, ExecutionException {
     // Use a store name that doesn't exist to trigger VeniceNoStoreException
     String nonExistentStoreName = Utils.getUniqueString("non_existent_store");
 
     // Create a delete-store operation for a store that doesn't exist
-    veniceWriter.put(
-        emptyKeyBytes,
-        getDeleteStoreMessage(clusterName, nonExistentStoreName, 1),
-        AdminOperationSerializer.LATEST_SCHEMA_ID_FOR_ADMIN_OPERATION);
+    InMemoryPubSubPosition position1 = getPosition(
+        veniceWriter.put(
+            emptyKeyBytes,
+            getDeleteStoreMessage(clusterName, nonExistentStoreName, 1),
+            AdminOperationSerializer.LATEST_SCHEMA_ID_FOR_ADMIN_OPERATION));
 
     // Simulate the store not existing by throwing VeniceNoStoreException
     doThrow(new VeniceNoStoreException(nonExistentStoreName, clusterName)).when(admin)
@@ -1203,7 +1220,7 @@ public class AdminConsumptionTaskTest {
 
     // Wait for the message to be processed and moved past (skipped after max retries)
     TestUtils.waitForNonDeterministicAssertion(TIMEOUT * 2, TimeUnit.MILLISECONDS, () -> {
-      Assert.assertEquals(getLastOffset(clusterName), 1L);
+      Assert.assertEquals(getLastPosition(clusterName), position1);
       // After max retries, the exception should be cleared from problematic stores
       Assert.assertNull(task.getLastExceptionForStore(nonExistentStoreName));
     });
@@ -1219,10 +1236,11 @@ public class AdminConsumptionTaskTest {
     String storeName2 = "test_store2";
     String storeTopicName1 = storeName1 + "_v1";
     String storeTopicName2 = storeName2 + "_v1";
-    veniceWriter.put(
-        emptyKeyBytes,
-        getStoreCreationMessage(clusterName, storeName1, owner, keySchema, valueSchema, 1),
-        AdminOperationSerializer.LATEST_SCHEMA_ID_FOR_ADMIN_OPERATION);
+    InMemoryPubSubPosition position1 = getPosition(
+        veniceWriter.put(
+            emptyKeyBytes,
+            getStoreCreationMessage(clusterName, storeName1, owner, keySchema, valueSchema, 1),
+            AdminOperationSerializer.LATEST_SCHEMA_ID_FOR_ADMIN_OPERATION));
     veniceWriter.put(
         emptyKeyBytes,
         getStoreCreationMessage(clusterName, storeName2, owner, keySchema, valueSchema, 2),
@@ -1231,10 +1249,11 @@ public class AdminConsumptionTaskTest {
         emptyKeyBytes,
         getKillOfflinePushJobMessage(clusterName, storeTopicName1, 3),
         AdminOperationSerializer.LATEST_SCHEMA_ID_FOR_ADMIN_OPERATION);
-    veniceWriter.put(
-        emptyKeyBytes,
-        getKillOfflinePushJobMessage(clusterName, storeTopicName2, 4),
-        AdminOperationSerializer.LATEST_SCHEMA_ID_FOR_ADMIN_OPERATION);
+    InMemoryPubSubPosition position4 = getPosition(
+        veniceWriter.put(
+            emptyKeyBytes,
+            getKillOfflinePushJobMessage(clusterName, storeTopicName2, 4),
+            AdminOperationSerializer.LATEST_SCHEMA_ID_FOR_ADMIN_OPERATION));
 
     // The store doesn't exist
     when(admin.hasStore(clusterName, storeName1)).thenReturn(false);
@@ -1248,7 +1267,7 @@ public class AdminConsumptionTaskTest {
     TestUtils.waitForNonDeterministicAssertion(
         TIMEOUT,
         TimeUnit.MILLISECONDS,
-        () -> Assert.assertEquals(task.getFailingPosition().getNumericOffset(), 1L));
+        () -> Assert.assertEquals(task.getFailingPosition(), position1));
     TestUtils.waitForNonDeterministicAssertion(
         TIMEOUT,
         TimeUnit.MILLISECONDS,
@@ -1261,7 +1280,7 @@ public class AdminConsumptionTaskTest {
     Assert.assertEquals(
         executionIdAccessor.getLastSucceededExecutionIdMap(clusterName).getOrDefault(storeName1, -1L).longValue(),
         -1L);
-    Assert.assertEquals(getLastOffset(clusterName), -1L);
+    Assert.assertEquals(getLastPosition(clusterName), PubSubSymbolicPosition.EARLIEST);
     Assert.assertEquals(getLastExecutionId(clusterName), -1L);
 
     // skip the blocking message
@@ -1269,13 +1288,13 @@ public class AdminConsumptionTaskTest {
     TestUtils.waitForNonDeterministicAssertion(
         TIMEOUT,
         TimeUnit.MILLISECONDS,
-        () -> Assert.assertEquals(getLastOffset(clusterName), 4L));
+        () -> Assert.assertEquals(getLastPosition(clusterName), position4));
 
     Assert.assertEquals(getLastExecutionId(clusterName), 4L);
     Assert.assertEquals(
         executionIdAccessor.getLastSucceededExecutionIdMap(clusterName).getOrDefault(storeName1, -1L).longValue(),
         3L);
-    Assert.assertEquals(task.getFailingPosition().getNumericOffset(), -1L);
+    Assert.assertEquals(task.getFailingPosition(), PubSubSymbolicPosition.EARLIEST);
     task.close();
     executor.shutdown();
     executor.awaitTermination(TIMEOUT, TimeUnit.MILLISECONDS);
@@ -1320,9 +1339,9 @@ public class AdminConsumptionTaskTest {
         emptyKeyBytes,
         getKillOfflinePushJobMessage(clusterName, storeTopicName, 4L),
         AdminOperationSerializer.LATEST_SCHEMA_ID_FOR_ADMIN_OPERATION);
-    long offset = future.get(TIMEOUT, TimeUnit.MILLISECONDS).getOffset();
+    PubSubPosition position = future.get(TIMEOUT, TimeUnit.MILLISECONDS).getPubSubPosition();
     AdminMetadata newMetadata = new AdminMetadata();
-    newMetadata.setOffset(offset);
+    newMetadata.setOffset(((InMemoryPubSubPosition) position).getInternalOffset());
     newMetadata.setExecutionId(4L);
     adminTopicMetadataAccessor.updateMetadata(clusterName, newMetadata);
     executionIdAccessor.updateLastSucceededExecutionIdMap(clusterName, storeName, 4L);
@@ -1351,13 +1370,13 @@ public class AdminConsumptionTaskTest {
         emptyKeyBytes,
         getStoreCreationMessage(clusterName, storeName, owner, keySchema, valueSchema, 1L),
         AdminOperationSerializer.LATEST_SCHEMA_ID_FOR_ADMIN_OPERATION);
-    long failingOffset =
+    PubSubPosition failingPosition =
         ((PubSubProduceResult) veniceWriter
             .put(
                 emptyKeyBytes,
                 getAddVersionMessage(clusterName, storeName, mockPushJobId, 1, 1, 2L),
                 AdminOperationSerializer.LATEST_SCHEMA_ID_FOR_ADMIN_OPERATION)
-            .get()).getOffset();
+            .get()).getPubSubPosition();
     veniceWriter.put(
         emptyKeyBytes,
         getKillOfflinePushJobMessage(clusterName, storeTopicName, 3L),
@@ -1383,19 +1402,20 @@ public class AdminConsumptionTaskTest {
     // while stuck on a failing message.
     when(admin.isLeaderControllerFor(clusterName)).thenReturn(true, true, true, true, true, false, false, false, true);
     executor.submit(task);
-    TestUtils.waitForNonDeterministicAssertion(TIMEOUT, TimeUnit.MILLISECONDS, () -> {
-      Assert.assertEquals(task.getFailingPosition().getNumericOffset(), failingOffset);
-    });
+    TestUtils.waitForNonDeterministicAssertion(
+        TIMEOUT,
+        TimeUnit.MILLISECONDS,
+        () -> Assert.assertEquals(task.getFailingPosition(), failingPosition));
     // Failing offset should be set to -1 once the consumption task unsubscribed.
     TestUtils.waitForNonDeterministicAssertion(
         TIMEOUT,
         TimeUnit.MILLISECONDS,
-        () -> Assert.assertEquals(task.getFailingPosition().getNumericOffset(), -1));
+        () -> Assert.assertEquals(task.getFailingPosition(), PubSubSymbolicPosition.EARLIEST));
     // The consumption task will eventually resubscribe and should be stuck on the same admin message.
     TestUtils.waitForNonDeterministicAssertion(
         TIMEOUT,
         TimeUnit.MILLISECONDS,
-        () -> Assert.assertEquals(task.getFailingPosition().getNumericOffset(), failingOffset));
+        () -> Assert.assertEquals(task.getFailingPosition(), failingPosition));
     task.close();
     executor.shutdown();
     ;
@@ -1431,7 +1451,7 @@ public class AdminConsumptionTaskTest {
     TestUtils.waitForNonDeterministicAssertion(
         TIMEOUT,
         TimeUnit.MILLISECONDS,
-        () -> Assert.assertEquals(InMemoryPubSubPosition.of(getLastOffset(clusterName)), position));
+        () -> Assert.assertEquals(getLastPosition(clusterName), position));
     TestUtils.waitForNonDeterministicAssertion(
         TIMEOUT,
         TimeUnit.MILLISECONDS,
@@ -1440,17 +1460,17 @@ public class AdminConsumptionTaskTest {
         emptyKeyBytes,
         getKillOfflinePushJobMessage(clusterName, storeTopicName, 4L),
         AdminOperationSerializer.LATEST_SCHEMA_ID_FOR_ADMIN_OPERATION);
-    future = veniceWriter.put(
-        emptyKeyBytes,
-        getKillOfflinePushJobMessage(clusterName, storeTopicName, 5L),
-        AdminOperationSerializer.LATEST_SCHEMA_ID_FOR_ADMIN_OPERATION);
-    final long latestOffset = future.get(TIMEOUT, TimeUnit.MILLISECONDS).getOffset();
+    InMemoryPubSubPosition position5 = getPosition(
+        veniceWriter.put(
+            emptyKeyBytes,
+            getKillOfflinePushJobMessage(clusterName, storeTopicName, 5L),
+            AdminOperationSerializer.LATEST_SCHEMA_ID_FOR_ADMIN_OPERATION));
     TestUtils.waitForNonDeterministicAssertion(
         TIMEOUT,
         TimeUnit.MILLISECONDS,
         () -> Assert.assertEquals(getLastExecutionId(clusterName), 5L));
     Assert.assertEquals(executionIdAccessor.getLastSucceededExecutionIdMap(clusterName).get(storeName).longValue(), 5L);
-    Assert.assertEquals(getLastOffset(clusterName), latestOffset);
+    Assert.assertEquals(getLastPosition(clusterName), position5);
     task.close();
     executor.shutdown();
     executor.awaitTermination(TIMEOUT, TimeUnit.MILLISECONDS);
@@ -1476,7 +1496,7 @@ public class AdminConsumptionTaskTest {
         emptyKeyBytes,
         getKillOfflinePushJobMessage(clusterName, storeTopicName, 4L),
         AdminOperationSerializer.LATEST_SCHEMA_ID_FOR_ADMIN_OPERATION);
-    long offset = future.get(TIMEOUT, TimeUnit.MILLISECONDS).getOffset();
+    PubSubPosition position = future.get(TIMEOUT, TimeUnit.MILLISECONDS).getPubSubPosition();
     veniceWriter.put(
         emptyKeyBytes,
         getKillOfflinePushJobMessage(clusterName, storeTopicName, 5L),
@@ -1499,9 +1519,9 @@ public class AdminConsumptionTaskTest {
     TestUtils.waitForNonDeterministicAssertion(
         TIMEOUT,
         TimeUnit.MILLISECONDS,
-        () -> Assert.assertEquals(task.getFailingPosition().getNumericOffset(), offset));
+        () -> Assert.assertEquals(task.getFailingPosition(), position));
     // Skip the DIV check, make sure the sequence number is updated and new admin messages can also be processed
-    task.skipMessageDIVWithOffset(offset);
+    task.skipMessageDIVWithOffset(((InMemoryPubSubPosition) position).getInternalOffset());
     TestUtils.waitForNonDeterministicAssertion(
         TIMEOUT,
         TimeUnit.MILLISECONDS,
@@ -1532,7 +1552,7 @@ public class AdminConsumptionTaskTest {
         emptyKeyBytes,
         getKillOfflinePushJobMessage(clusterName, storeTopicName, 4L),
         AdminOperationSerializer.LATEST_SCHEMA_ID_FOR_ADMIN_OPERATION);
-    long offset = future.get(TIMEOUT, TimeUnit.MILLISECONDS).getOffset();
+    PubSubPosition position = future.get(TIMEOUT, TimeUnit.MILLISECONDS).getPubSubPosition();
     veniceWriter.put(
         emptyKeyBytes,
         getKillOfflinePushJobMessage(clusterName, storeTopicName, 5L),
@@ -1557,7 +1577,7 @@ public class AdminConsumptionTaskTest {
     TestUtils.waitForNonDeterministicAssertion(
         TIMEOUT,
         TimeUnit.MILLISECONDS,
-        () -> Assert.assertEquals(task.getFailingPosition().getNumericOffset(), offset));
+        () -> Assert.assertEquals(task.getFailingPosition(), position));
 
     // Skip the DIV check, make sure the sequence number is updated and new admin messages can also be processed
     task.skipMessageDIVWithExecutionId(4L);
@@ -1599,11 +1619,11 @@ public class AdminConsumptionTaskTest {
         emptyKeyBytes,
         getAddVersionMessage(clusterName, storeName, mockPushJobId, versionNumber, numberOfPartitions, 1L),
         AdminOperationSerializer.LATEST_SCHEMA_ID_FOR_ADMIN_OPERATION);
-    long offset = future.get(TIMEOUT, TimeUnit.MILLISECONDS).getOffset();
+    PubSubPosition position = future.get(TIMEOUT, TimeUnit.MILLISECONDS).getPubSubPosition();
     TestUtils.waitForNonDeterministicAssertion(
         TIMEOUT,
         TimeUnit.MILLISECONDS,
-        () -> Assert.assertEquals(task.getFailingPosition().getNumericOffset(), offset));
+        () -> Assert.assertEquals(task.getFailingPosition(), position));
     // The add version message is expected to fail with retriable VeniceOperationAgainstKafkaTimeOut exception and the
     // corresponding code path for handling retriable exceptions should have been executed.
     verify(stats, atLeastOnce()).recordFailedRetriableAdminConsumption();
@@ -1670,10 +1690,12 @@ public class AdminConsumptionTaskTest {
     byte[] message =
         adminOperationSerializer.serialize(adminMessage, AdminOperationSerializer.LATEST_SCHEMA_ID_FOR_ADMIN_OPERATION);
 
-    veniceWriter.put(emptyKeyBytes, message, AdminOperationSerializer.LATEST_SCHEMA_ID_FOR_ADMIN_OPERATION);
+    CompletableFuture<PubSubProduceResult> future =
+        veniceWriter.put(emptyKeyBytes, message, AdminOperationSerializer.LATEST_SCHEMA_ID_FOR_ADMIN_OPERATION);
+    PubSubPosition position2 = future.get().getPubSubPosition();
 
     TestUtils.waitForNonDeterministicAssertion(TIMEOUT, TimeUnit.MILLISECONDS, () -> {
-      Assert.assertEquals(getLastOffset(clusterName), 2L);
+      Assert.assertEquals(getLastPosition(clusterName), position2);
     });
 
     task.close();
@@ -1929,10 +1951,11 @@ public class AdminConsumptionTaskTest {
     String storeName2 = "test_store2";
     String storeTopicName1 = storeName1 + "_v1";
     String storeTopicName2 = storeName2 + "_v1";
-    veniceWriter.put(
-        emptyKeyBytes,
-        getStoreCreationMessage(clusterName, storeName1, owner, keySchema, valueSchema, 1),
-        AdminOperationSerializer.LATEST_SCHEMA_ID_FOR_ADMIN_OPERATION);
+    InMemoryPubSubPosition position1 = getPosition(
+        veniceWriter.put(
+            emptyKeyBytes,
+            getStoreCreationMessage(clusterName, storeName1, owner, keySchema, valueSchema, 1),
+            AdminOperationSerializer.LATEST_SCHEMA_ID_FOR_ADMIN_OPERATION));
     veniceWriter.put(
         emptyKeyBytes,
         getStoreCreationMessage(clusterName, storeName2, owner, keySchema, valueSchema, 2),
@@ -1941,10 +1964,12 @@ public class AdminConsumptionTaskTest {
         emptyKeyBytes,
         getKillOfflinePushJobMessage(clusterName, storeTopicName1, 3),
         AdminOperationSerializer.LATEST_SCHEMA_ID_FOR_ADMIN_OPERATION);
-    veniceWriter.put(
-        emptyKeyBytes,
-        getKillOfflinePushJobMessage(clusterName, storeTopicName2, 4),
-        AdminOperationSerializer.LATEST_SCHEMA_ID_FOR_ADMIN_OPERATION);
+
+    InMemoryPubSubPosition position4 = getPosition(
+        veniceWriter.put(
+            emptyKeyBytes,
+            getKillOfflinePushJobMessage(clusterName, storeTopicName2, 4),
+            AdminOperationSerializer.LATEST_SCHEMA_ID_FOR_ADMIN_OPERATION));
 
     // The store doesn't exist
     when(admin.hasStore(clusterName, storeName1)).thenReturn(false);
@@ -1952,9 +1977,8 @@ public class AdminConsumptionTaskTest {
 
     // Delay by more than the cycle time. This will cause this thread to be interrupted.
     // The task will be retried but will not succeed
-    doAnswer(AdditionalAnswers.answersWithDelay(2000, invocation -> {
-      return null;
-    })).when(admin).createStore(clusterName, storeName1, owner, keySchema, valueSchema, false);
+    doAnswer(AdditionalAnswers.answersWithDelay(2000, invocation -> null)).when(admin)
+        .createStore(clusterName, storeName1, owner, keySchema, valueSchema, false);
 
     AdminConsumptionTask task = getAdminConsumptionTask(
         new RandomPollStrategy(),
@@ -1975,9 +1999,9 @@ public class AdminConsumptionTaskTest {
             executionIdAccessor.getLastSucceededExecutionIdMap(clusterName).getOrDefault(storeName2, -1L).longValue(),
             4L));
 
-    Assert.assertEquals(getLastOffset(clusterName), -1L);
+    Assert.assertEquals(getLastPosition(clusterName), PubSubSymbolicPosition.EARLIEST);
     Assert.assertEquals(getLastExecutionId(clusterName), -1L);
-    Assert.assertEquals(task.getFailingPosition().getNumericOffset(), 1L);
+    Assert.assertEquals(task.getFailingPosition(), position1);
     Assert.assertEquals(task.getLastSucceededExecutionId().longValue(), -1L);
     Assert.assertNull(task.getLastSucceededExecutionId(storeName1));
     Assert.assertEquals(task.getLastSucceededExecutionId(storeName2).longValue(), 4L);
@@ -1988,13 +2012,13 @@ public class AdminConsumptionTaskTest {
     TestUtils.waitForNonDeterministicAssertion(
         TIMEOUT,
         TimeUnit.MILLISECONDS,
-        () -> Assert.assertEquals(getLastOffset(clusterName), 4L));
+        () -> Assert.assertEquals(getLastPosition(clusterName), position4));
 
     Assert.assertEquals(getLastExecutionId(clusterName), 4L);
     Assert.assertEquals(
         executionIdAccessor.getLastSucceededExecutionIdMap(clusterName).getOrDefault(storeName1, -1L).longValue(),
         3L);
-    Assert.assertEquals(task.getFailingPosition().getNumericOffset(), -1L);
+    Assert.assertEquals(task.getFailingPosition(), PubSubSymbolicPosition.EARLIEST);
 
     task.close();
     executor.shutdown();


### PR DESCRIPTION
## [controller][server] Remove usage of PubSubProduceResult::getOffset and deprecate it  

Replaced all remaining call sites of PubSubProduceResult::getOffset with the  
position-based API. This aligns with the ongoing migration away from numeric  
offsets toward PubSubPosition abstractions.  

The getOffset() method is now marked as `@Deprecated` to discourage future use  
and signal its planned removal.  

###  Code changes
- [ ] Added new code behind **a config**. If so list the config names and their default values in the PR description.
- [ ] Introduced new **log lines**. 
  - [ ] Confirmed if logs need to be **rate limited** to avoid excessive logging.

###  **Concurrency-Specific Checks**
Both reviewer and PR author to verify
- [ ] Code has **no race conditions** or **thread safety issues**.
- [ ] Proper **synchronization mechanisms** (e.g., `synchronized`, `RWLock`) are used where needed.
- [ ] No **blocking calls** inside critical sections that could lead to deadlocks or performance degradation.
- [ ] Verified **thread-safe collections** are used (e.g., `ConcurrentHashMap`, `CopyOnWriteArrayList`).
- [ ] Validated proper exception handling in multi-threaded code to avoid silent thread termination.


## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->

- [ ] New unit tests added.
- [ ] New integration tests added.
- [ ] Modified or extended existing tests.
- [ ] Verified backward compatibility (if applicable).

## Does this PR introduce any user-facing or breaking changes?
<!--  
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [ ] No. You can skip the rest of this section.
- [ ] Yes. Clearly explain the behavior change and its impact.