### PR TITLE
[server][controller][dvc] Delete deprecated offset APIs from producer and consumer

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/consumer/ImmutableChangeCapturePubSubMessage.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/consumer/ImmutableChangeCapturePubSubMessage.java
@@ -10,7 +10,7 @@ public class ImmutableChangeCapturePubSubMessage<K, V> implements PubSubMessage<
   private final K key;
   private final V value;
   private final PubSubTopicPartition topicPartition;
-  private final VeniceChangeCoordinate offset;
+  private final VeniceChangeCoordinate changeCoordinate;
   private final long timestamp;
   private final int payloadSize;
   private final boolean isEndOfBootstrap;
@@ -29,7 +29,7 @@ public class ImmutableChangeCapturePubSubMessage<K, V> implements PubSubMessage<
     this.topicPartition = Objects.requireNonNull(topicPartition);
     this.timestamp = timestamp;
     this.payloadSize = payloadSize;
-    this.offset = new VeniceChangeCoordinate(
+    this.changeCoordinate = new VeniceChangeCoordinate(
         this.topicPartition.getPubSubTopic().getName(),
         pubSubPosition,
         this.topicPartition.getPartitionNumber(),
@@ -53,8 +53,8 @@ public class ImmutableChangeCapturePubSubMessage<K, V> implements PubSubMessage<
   }
 
   @Override
-  public VeniceChangeCoordinate getOffset() {
-    return offset;
+  public VeniceChangeCoordinate getPosition() {
+    return changeCoordinate;
   }
 
   @Override
@@ -74,8 +74,8 @@ public class ImmutableChangeCapturePubSubMessage<K, V> implements PubSubMessage<
 
   @Override
   public String toString() {
-    return "PubSubMessage{" + topicPartition + ", offset=" + offset + ", timestamp=" + timestamp + ", isEndOfBootstrap="
-        + isEndOfBootstrap + '}';
+    return "PubSubMessage{" + topicPartition + ", changeCoordinate=" + changeCoordinate + ", timestamp=" + timestamp
+        + ", isEndOfBootstrap=" + isEndOfBootstrap + '}';
   }
 
   @Override

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/consumer/InternalLocalBootstrappingVeniceChangelogConsumer.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/consumer/InternalLocalBootstrappingVeniceChangelogConsumer.java
@@ -402,13 +402,13 @@ class InternalLocalBootstrappingVeniceChangelogConsumer<K, V> extends VeniceAfte
         super.internalPoll(timeoutInMs, topicSuffix, true);
     for (PubSubMessage<K, ChangeEvent<V>, VeniceChangeCoordinate> record: polledResults) {
       BootstrapState currentPartitionState = bootstrapStateMap.get(record.getPartition());
-      currentPartitionState.currentChangeCoordinate = record.getOffset();
+      currentPartitionState.currentChangeCoordinate = record.getPosition();
       if (currentPartitionState.bootstrapState.equals(PollState.CATCHING_UP)) {
         if (currentPartitionState.isCaughtUp(pubSubConsumer)) {
           LOGGER.info(
-              "pollAndCatchup completed for partition: {} with offset: {}, put message: {}, delete message: {}",
+              "pollAndCatchup completed for partition: {} with vcc: {}, put message: {}, delete message: {}",
               record.getPartition(),
-              record.getOffset(),
+              record.getPosition(),
               partitionToPutMessageCount.getOrDefault(record.getPartition(), new AtomicLong(0)).get(),
               partitionToDeleteMessageCount.getOrDefault(record.getPartition(), new AtomicLong(0)).get());
           currentPartitionState.bootstrapState = PollState.BOOTSTRAPPING;

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/consumer/VeniceChangelogConsumerImplTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/consumer/VeniceChangelogConsumerImplTest.java
@@ -1058,7 +1058,7 @@ public class VeniceChangelogConsumerImplTest {
       ChangeEvent<Utf8> changeEvent = pubSubMessage.getValue();
       Assert.assertEquals(changeEvent.getCurrentValue().toString(), "newValue" + i);
       Assert.assertEquals(changeEvent.getPreviousValue().toString(), "oldValue" + i);
-      Assert.assertEquals(pubSubMessage.getOffset().getConsumerSequenceId(), expectedSequenceId++);
+      Assert.assertEquals(pubSubMessage.getPosition().getConsumerSequenceId(), expectedSequenceId++);
     }
   }
 

--- a/integrations/venice-beam/src/main/java/com/linkedin/venice/beam/consumer/VeniceChangelogConsumerIO.java
+++ b/integrations/venice-beam/src/main/java/com/linkedin/venice/beam/consumer/VeniceChangelogConsumerIO.java
@@ -480,7 +480,7 @@ public final class VeniceChangelogConsumerIO {
         return;
       }
 
-      VeniceChangeCoordinate veniceChangeCoordinate = pubSubMessage.getOffset();
+      VeniceChangeCoordinate veniceChangeCoordinate = pubSubMessage.getPosition();
       LOG.debug("Revised checkpoint for partition {}", veniceChangeCoordinate.getPartition());
       _partitionToVeniceChangeCoordinates.put(veniceChangeCoordinate.getPartition(), veniceChangeCoordinate);
 

--- a/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/api/DefaultPubSubMessage.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/api/DefaultPubSubMessage.java
@@ -30,12 +30,4 @@ public interface DefaultPubSubMessage extends PubSubMessage<KafkaKey, KafkaMessa
    * @return the {@link PubSubPosition} representing the message offset.
    */
   PubSubPosition getPosition();
-
-  /**
-   * @Deprecated use {@link #getPosition()} instead.
-   * @return position of this message within the underlying topic-partition.
-   */
-  default PubSubPosition getOffset() {
-    return getPosition();
-  }
 }

--- a/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/api/PubSubMessage.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/api/PubSubMessage.java
@@ -3,7 +3,7 @@ package com.linkedin.venice.pubsub.api;
 import com.linkedin.venice.memory.Measurable;
 
 
-public interface PubSubMessage<K, V, OFFSET> extends Measurable {
+public interface PubSubMessage<K, V, POSITION> extends Measurable {
   /**
    * @return the key part of this message
    */
@@ -21,8 +21,13 @@ public interface PubSubMessage<K, V, OFFSET> extends Measurable {
 
   /**
    * @return the offset of this message in the underlying topic-partition
+   * @Deprecated use {@link #getPosition()} instead.
    */
-  OFFSET getOffset();
+  default POSITION getOffset() {
+    return getPosition();
+  }
+
+  POSITION getPosition();
 
   /**
    * @return the timestamp at which the message was persisted in the pub sub system

--- a/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/api/PubSubPosition.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/api/PubSubPosition.java
@@ -17,6 +17,7 @@ public interface PubSubPosition extends Measurable {
 
   @RestrictedApi("This API facilitates the transition from numeric offsets to PubSubPosition. "
       + "It should be removed once the codebase fully adopts PubSubPosition.")
+  @Deprecated
   long getNumericOffset();
 
   boolean equals(Object obj);

--- a/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/api/PubSubProduceResult.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/api/PubSubProduceResult.java
@@ -5,15 +5,6 @@ package com.linkedin.venice.pubsub.api;
  */
 public interface PubSubProduceResult {
   /**
-   * The offset of the record in the topic/partition.
-   * @deprecated Use {@link #getPubSubPosition()} instead.
-   */
-  @Deprecated
-  default long getOffset() {
-    return getPubSubPosition().getNumericOffset();
-  }
-
-  /**
    * The position of the record in the topic/partition.
    */
   PubSubPosition getPubSubPosition();

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/consumer/BootstrappingChangelogConsumerTest.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/consumer/BootstrappingChangelogConsumerTest.java
@@ -316,7 +316,7 @@ public class BootstrappingChangelogConsumerTest {
       verifyDelete(polledChangeEventsMap, 110, 120, 1);
     });
 
-    long startingSequenceId = polledChangeEventsList.iterator().next().getOffset().getConsumerSequenceId();
+    long startingSequenceId = polledChangeEventsList.iterator().next().getPosition().getConsumerSequenceId();
     Map<Integer, Long> partitionSequenceIdMap = new HashMap<>();
     verifyVCCSequenceId(polledChangeEventsList, partitionSequenceIdMap, startingSequenceId);
 
@@ -430,7 +430,7 @@ public class BootstrappingChangelogConsumerTest {
       return;
     }
     long startingSequenceId = knownStartingSequenceId < 0
-        ? polledChangeEventsList.iterator().next().getOffset().getConsumerSequenceId()
+        ? polledChangeEventsList.iterator().next().getPosition().getConsumerSequenceId()
         : knownStartingSequenceId;
     Map<Integer, Long> partitionSequenceIdMap =
         previousPartitionSequenceIdMap == null ? new HashMap<>() : previousPartitionSequenceIdMap;
@@ -438,7 +438,7 @@ public class BootstrappingChangelogConsumerTest {
       int partition = message.getPartition();
       long expectedSequenceId = partitionSequenceIdMap.computeIfAbsent(partition, k -> startingSequenceId);
       Assert.assertEquals(
-          message.getOffset().getConsumerSequenceId(),
+          message.getPosition().getConsumerSequenceId(),
           expectedSequenceId,
           "Unexpected sequence id for partition: " + partition + ", starting sequence id: " + startingSequenceId);
       partitionSequenceIdMap.put(partition, expectedSequenceId + 1);

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/consumer/TestChangelogConsumer.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/consumer/TestChangelogConsumer.java
@@ -693,7 +693,7 @@ public class TestChangelogConsumer {
 
     // Save a checkpoint and clear the map
     Set<VeniceChangeCoordinate> checkpointSet = new HashSet<>();
-    checkpointSet.add(polledChangeEvents.get(Integer.toString(20)).getOffset());
+    checkpointSet.add(polledChangeEvents.get(Integer.toString(20)).getPosition());
     allChangeEvents.putAll(polledChangeEvents);
     polledChangeEvents.clear();
 
@@ -1147,12 +1147,12 @@ public class TestChangelogConsumer {
     });
     // The consumer sequence id should be consecutive and monotonically increasing within the same partition. All
     // partitions should start with the same sequence id (seeded by consumer initialization timestamp).
-    long startingSequenceId = pubSubMessages.iterator().next().getOffset().getConsumerSequenceId();
+    long startingSequenceId = pubSubMessages.iterator().next().getPosition().getConsumerSequenceId();
     HashMap<Integer, Long> partitionSequenceIdMap = new HashMap<>();
     for (PubSubMessage<Utf8, ChangeEvent<Utf8>, VeniceChangeCoordinate> message: pubSubMessages) {
       int partition = message.getPartition();
       long expectedSequenceId = partitionSequenceIdMap.computeIfAbsent(partition, k -> startingSequenceId);
-      Assert.assertEquals(message.getOffset().getConsumerSequenceId(), expectedSequenceId);
+      Assert.assertEquals(message.getPosition().getConsumerSequenceId(), expectedSequenceId);
       partitionSequenceIdMap.put(partition, expectedSequenceId + 1);
     }
     Assert.assertEquals(partitionSequenceIdMap.size(), 3);


### PR DESCRIPTION
## [server][controller][dvc] Delete deprecated offset APIs from producer and consumer

Deprecated and removed offset-based methods in PubSubConsumerAdapter,  
PubSubProduceResult, and related interfaces. Updated PubSubMessage to make  
getPosition() the primary accessor, with getOffset() now deprecated and  
delegating to getPosition(). Refactored implementations and tests to use  
positions consistently, and improved Javadoc and naming to reflect the shift  
from offsets to positions.  


###  Code changes
- [ ] Added new code behind **a config**. If so list the config names and their default values in the PR description.
- [ ] Introduced new **log lines**. 
  - [ ] Confirmed if logs need to be **rate limited** to avoid excessive logging.

###  **Concurrency-Specific Checks**
Both reviewer and PR author to verify
- [ ] Code has **no race conditions** or **thread safety issues**.
- [ ] Proper **synchronization mechanisms** (e.g., `synchronized`, `RWLock`) are used where needed.
- [ ] No **blocking calls** inside critical sections that could lead to deadlocks or performance degradation.
- [ ] Verified **thread-safe collections** are used (e.g., `ConcurrentHashMap`, `CopyOnWriteArrayList`).
- [ ] Validated proper exception handling in multi-threaded code to avoid silent thread termination.


## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->

- [ ] New unit tests added.
- [ ] New integration tests added.
- [ ] Modified or extended existing tests.
- [ ] Verified backward compatibility (if applicable).

## Does this PR introduce any user-facing or breaking changes?
<!--  
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [ ] No. You can skip the rest of this section.
- [ ] Yes. Clearly explain the behavior change and its impact.