### PR TITLE
[server][dvc] Dropping a partition also removes the blob transfer temp staging folder.

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/store/rocksdb/RocksDBStoragePartition.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/store/rocksdb/RocksDBStoragePartition.java
@@ -80,6 +80,7 @@ public class RocksDBStoragePartition extends AbstractStoragePartition {
   protected final WriteOptions writeOptions;
   protected final ReadOptions iteratorReadOptions;
   private final String fullPathForTempSSTFileDir;
+  private final String fullPathForTempTransferredDir;
   private final String fullPathForPartitionDBSnapshot;
 
   private final EnvOptions envOptions;
@@ -227,6 +228,7 @@ public class RocksDBStoragePartition extends AbstractStoragePartition {
     this.rocksDBThrottler = rocksDbThrottler;
     this.fullPathForTempSSTFileDir = RocksDBUtils.composeTempSSTFileDir(dbDir, storeNameAndVersion, partitionId);
     this.fullPathForPartitionDBSnapshot = RocksDBUtils.composeSnapshotDir(dbDir, storeNameAndVersion, partitionId);
+    this.fullPathForTempTransferredDir = RocksDBUtils.composeTempPartitionDir(dbDir, storeNameAndVersion, partitionId);
 
     if (deferredWrite) {
       this.rocksDBSstFileWriter = new RocksDBSstFileWriter(
@@ -814,6 +816,7 @@ public class RocksDBStoragePartition extends AbstractStoragePartition {
     // remove snapshots files
     deleteFilesInDirectory(fullPathForPartitionDBSnapshot);
     // Remove partition directory
+    deleteDirectory(fullPathForTempTransferredDir);
     deleteDirectory(fullPathForPartitionDB);
     LOGGER.info("RocksDB for replica:{} was dropped.", replicaId);
   }


### PR DESCRIPTION

<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat], [protocol]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## Problem Statement
During blob transfer, files are first written to a temporary staging folder. (/db/directory/myStore_v3/temp_transferred_myStore_v3_3/)

Once all files are received, they are moved from the staging folder to the partition folder (/db/directory/myStore_v3/myStore_v3_3/). 

However, we found that in some error cases, the staging folder is not fully cleaned up. To address this, we added a step to drop the entire temp folder when a partition is dropped.

```
venice/data/rocksdb/cert-histogram-dataset_v1095 ]$ tree
.
├── temp_transferred_cert-histogram-dataset_v1095_149
│   └── 000043.sst
├── temp_transferred_cert-histogram-dataset_v1095_6
│   └── 000044.sst
└── temp_transferred_cert-histogram-dataset_v1095_7
    └── 000042.sst
```

<!--
Describe
- What problem are you trying to solve
- What issues or limitations exist in the current code
- Why this change is necessary 
-->


## Solution
When dropping partitions, also check the temporary folder and clean it up.
<!--
Describe
- What changes you are making and why. 
- How these changes solve the problem.
- Any performance considerations or trade-offs. 
- Describe what testings you have done, for example, performance testing etc.
-->


###  Code changes
- [ ] Added new code behind **a config**. If so list the config names and their default values in the PR description.
- [ ] Introduced new **log lines**. 
  - [ ] Confirmed if logs need to be **rate limited** to avoid excessive logging.

###  **Concurrency-Specific Checks**
Both reviewer and PR author to verify
- [ ] Code has **no race conditions** or **thread safety issues**.
- [ ] Proper **synchronization mechanisms** (e.g., `synchronized`, `RWLock`) are used where needed.
- [ ] No **blocking calls** inside critical sections that could lead to deadlocks or performance degradation.
- [ ] Verified **thread-safe collections** are used (e.g., `ConcurrentHashMap`, `CopyOnWriteArrayList`).
- [ ] Validated proper exception handling in multi-threaded code to avoid silent thread termination.


## How was this PR tested?
Unit test. 
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->

- [ ] New unit tests added.
- [ ] New integration tests added.
- [ ] Modified or extended existing tests.
- [ ] Verified backward compatibility (if applicable).

## Does this PR introduce any user-facing or breaking changes?
<!--  
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [ ] No. You can skip the rest of this section.
- [ ] Yes. Clearly explain the behavior change and its impact.