### PR TITLE
[all] make otel sync gauge emit last recorded metrics in every export interval

### DIFF
--- a/internal/venice-client-common/src/test/java/com/linkedin/venice/stats/VeniceMetricsConfigTest.java
+++ b/internal/venice-client-common/src/test/java/com/linkedin/venice/stats/VeniceMetricsConfigTest.java
@@ -6,6 +6,7 @@ import static com.linkedin.venice.stats.VeniceMetricsConfig.OTEL_EXPORTER_OTLP_M
 import static com.linkedin.venice.stats.VeniceMetricsConfig.OTEL_EXPORTER_OTLP_METRICS_ENDPOINT;
 import static com.linkedin.venice.stats.VeniceMetricsConfig.OTEL_EXPORTER_OTLP_METRICS_PROTOCOL;
 import static com.linkedin.venice.stats.VeniceMetricsConfig.OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE;
+import static com.linkedin.venice.stats.VeniceMetricsConfig.OTEL_VENICE_EXPORT_LAST_RECORDED_VALUE_FOR_SYNCHRONOUS_GAUGE;
 import static com.linkedin.venice.stats.VeniceMetricsConfig.OTEL_VENICE_METRICS_CUSTOM_DIMENSIONS_MAP;
 import static com.linkedin.venice.stats.VeniceMetricsConfig.OTEL_VENICE_METRICS_ENABLED;
 import static com.linkedin.venice.stats.VeniceMetricsConfig.OTEL_VENICE_METRICS_EXPORT_TO_ENDPOINT;
@@ -19,7 +20,10 @@ import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertTrue;
 
 import com.linkedin.venice.stats.VeniceMetricsConfig.Builder;
+import com.linkedin.venice.utils.DataProviderUtils;
 import io.opentelemetry.exporter.otlp.internal.OtlpConfigUtil;
+import io.opentelemetry.sdk.metrics.InstrumentType;
+import io.opentelemetry.sdk.metrics.data.AggregationTemporality;
 import io.opentelemetry.sdk.metrics.export.AggregationTemporalitySelector;
 import io.tehuti.metrics.MetricConfig;
 import java.util.HashMap;
@@ -46,7 +50,15 @@ public class VeniceMetricsConfigTest {
     assertTrue(config.getOtelHeaders().isEmpty());
     assertFalse(config.exportOtelMetricsToLog());
     assertEquals(config.getMetricNamingFormat(), SNAKE_CASE);
-    assertEquals(config.getOtelAggregationTemporalitySelector(), AggregationTemporalitySelector.deltaPreferred());
+    assertEquals(config.exportLastRecordedValueForSynchronousGauge(), true);
+    AggregationTemporalitySelector defaultSelector =
+        VeniceMetricsConfig.getTemporalitySelector(true, AggregationTemporalitySelector.deltaPreferred());
+    for (InstrumentType type: InstrumentType.values()) {
+      assertEquals(
+          config.getOtelAggregationTemporalitySelector().getAggregationTemporality(type),
+          defaultSelector.getAggregationTemporality(type),
+          type.name());
+    }
     assertEquals(config.useOtelExponentialHistogram(), true);
     assertEquals(config.getOtelExponentialHistogramMaxScale(), 3);
     assertEquals(config.getOtelExponentialHistogramMaxBuckets(), 250);
@@ -132,20 +144,50 @@ public class VeniceMetricsConfigTest {
     assertEquals(config.getOtelEndpoint(), "http://localhost");
   }
 
-  @Test
-  public void testSetAggregationTemporalitySelector() {
+  @Test(dataProvider = "True-and-False", dataProviderClass = DataProviderUtils.class)
+  public void testSetAggregationTemporalitySelector(boolean useLastRecordedValueForSynchronousGauge) {
     Map<String, String> otelConfigs = new HashMap<>();
     otelConfigs.put(OTEL_VENICE_METRICS_ENABLED, "true");
     otelConfigs.put(OTEL_VENICE_METRICS_EXPORT_TO_ENDPOINT, "true");
     otelConfigs.put(OTEL_EXPORTER_OTLP_METRICS_PROTOCOL, OtlpConfigUtil.PROTOCOL_HTTP_PROTOBUF);
     otelConfigs.put(OTEL_EXPORTER_OTLP_METRICS_ENDPOINT, "http://localhost");
+    otelConfigs.put(
+        OTEL_VENICE_EXPORT_LAST_RECORDED_VALUE_FOR_SYNCHRONOUS_GAUGE,
+        Boolean.toString(useLastRecordedValueForSynchronousGauge));
     otelConfigs.put(OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE, "delta");
 
     VeniceMetricsConfig config = new Builder().setServiceName("TestService")
         .setMetricPrefix("TestPrefix")
         .extractAndSetOtelConfigs(otelConfigs)
         .build();
-    assertEquals(config.getOtelAggregationTemporalitySelector(), AggregationTemporalitySelector.deltaPreferred());
+    AggregationTemporalitySelector defaultSelector = VeniceMetricsConfig.getTemporalitySelector(
+        useLastRecordedValueForSynchronousGauge,
+        AggregationTemporalitySelector.deltaPreferred());
+    for (InstrumentType type: InstrumentType.values()) {
+      assertEquals(
+          config.getOtelAggregationTemporalitySelector().getAggregationTemporality(type),
+          defaultSelector.getAggregationTemporality(type));
+    }
+  }
+
+  @Test(dataProvider = "True-and-False", dataProviderClass = DataProviderUtils.class)
+  public void testGetTemporalitySelector(boolean useLastRecordedValueForSynchronousGauge) {
+    AggregationTemporalitySelector[] selectors =
+        new AggregationTemporalitySelector[] { AggregationTemporalitySelector.deltaPreferred(),
+            AggregationTemporalitySelector.alwaysCumulative(), AggregationTemporalitySelector.lowMemory() };
+    for (AggregationTemporalitySelector baseSelector: selectors) {
+      AggregationTemporalitySelector selector =
+          VeniceMetricsConfig.getTemporalitySelector(useLastRecordedValueForSynchronousGauge, baseSelector);
+      for (InstrumentType type: InstrumentType.values()) {
+        if (useLastRecordedValueForSynchronousGauge && type == InstrumentType.GAUGE) {
+          // If exportLastRecordedValue and type is GAUGE, must be CUMULATIVE
+          assertEquals(selector.getAggregationTemporality(type), AggregationTemporality.CUMULATIVE);
+        } else {
+          // Otherwise, should be same as baseSelector
+          assertEquals(selector.getAggregationTemporality(type), baseSelector.getAggregationTemporality(type));
+        }
+      }
+    }
   }
 
   @Test(expectedExceptions = IllegalArgumentException.class)


### PR DESCRIPTION
## Problem Statement
In `AggregationTemporalitySelector#deltaPreferred()` : `GAUGE` falls back to default i,e `DELTA`, which results in no data getting exported if a  synchronous`GAUGE` instrument is not recorded in that export interval, resulting in patches of data only whenever the metric is recorded.

## Solution
Raised an issue with OSS OTel https://github.com/open-telemetry/opentelemetry-java/pull/7634 and it was concluded that its intentionally kept that way by design as an instrument should not emit old recorded data unless its recorded in that export interval. 
This PR makes `GAUGE` to be `CUMULATIVE` based on the below config which is enabled by default.
`otel.venice.export.last.recorded.value.for.synchronous.gauge`

###  Code changes
- [x] Added new code behind **a config**. If so list the config names and their default values in the PR description.
- [ ] Introduced new **log lines**. 
  - [ ] Confirmed if logs need to be **rate limited** to avoid excessive logging.

###  **Concurrency-Specific Checks**
Both reviewer and PR author to verify
- [ ] Code has **no race conditions** or **thread safety issues**.
- [ ] Proper **synchronization mechanisms** (e.g., `synchronized`, `RWLock`) are used where needed.
- [ ] No **blocking calls** inside critical sections that could lead to deadlocks or performance degradation.
- [ ] Verified **thread-safe collections** are used (e.g., `ConcurrentHashMap`, `CopyOnWriteArrayList`).
- [ ] Validated proper exception handling in multi-threaded code to avoid silent thread termination.


## How was this PR tested?
- [x] New unit tests added.
- [ ] New integration tests added.
- [ ] Modified or extended existing tests.
- [ ] Verified backward compatibility (if applicable).

## Does this PR introduce any user-facing or breaking changes?
- [ ] No. You can skip the rest of this section.
- [x] Yes. Clearly explain the behavior change and its impact.
Otel Sync Gauge metrics will always export the last recorded value unless this config is disabled.