### PR TITLE
[server][dvc] Optimize P2P file transfer by increasing thread pool and chunk size

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/blobtransfer/client/NettyFileTransferClient.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/blobtransfer/client/NettyFileTransferClient.java
@@ -298,7 +298,7 @@ public class NettyFileTransferClient {
       String replicaId = Utils.getReplicaId(Version.composeKafkaTopic(storeName, version), partition);
       requestFuture.addListener(f -> {
         if (f.isSuccess()) {
-          LOGGER.debug("Request successfully sent to the server for replica {} to remove host {}", replicaId, host);
+          LOGGER.info("Request successfully sent to the server for replica {} to remove host {}", replicaId, host);
         } else {
           LOGGER.error("Failed to send request for replica {} to host {}", replicaId, host, f.cause());
         }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/blobtransfer/client/NettyFileTransferClient.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/blobtransfer/client/NettyFileTransferClient.java
@@ -298,7 +298,7 @@ public class NettyFileTransferClient {
       String replicaId = Utils.getReplicaId(Version.composeKafkaTopic(storeName, version), partition);
       requestFuture.addListener(f -> {
         if (f.isSuccess()) {
-          LOGGER.info("Request successfully sent to the server for replica {} to remove host {}", replicaId, host);
+          LOGGER.info("Request successfully sent to the server for replica {} to remote host {}", replicaId, host);
         } else {
           LOGGER.error("Failed to send request for replica {} to host {}", replicaId, host, f.cause());
         }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/blobtransfer/client/NettyFileTransferClient.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/blobtransfer/client/NettyFileTransferClient.java
@@ -6,8 +6,10 @@ import com.linkedin.davinci.blobtransfer.BlobTransferUtils.BlobTransferTableForm
 import com.linkedin.davinci.storage.StorageMetadataService;
 import com.linkedin.venice.exceptions.VenicePeersConnectionException;
 import com.linkedin.venice.listener.VerifySslHandler;
+import com.linkedin.venice.meta.Version;
 import com.linkedin.venice.security.SSLFactory;
 import com.linkedin.venice.utils.DaemonThreadFactory;
+import com.linkedin.venice.utils.Utils;
 import com.linkedin.venice.utils.concurrent.VeniceConcurrentHashMap;
 import io.netty.bootstrap.Bootstrap;
 import io.netty.channel.Channel;
@@ -290,7 +292,17 @@ public class NettyFileTransferClient {
                   partition,
                   requestedTableFormat));
       // Send a GET request
-      ch.writeAndFlush(prepareRequest(storeName, version, partition, requestedTableFormat));
+      ChannelFuture requestFuture =
+          ch.writeAndFlush(prepareRequest(storeName, version, partition, requestedTableFormat));
+
+      String replicaId = Utils.getReplicaId(Version.composeKafkaTopic(storeName, version), partition);
+      requestFuture.addListener(f -> {
+        if (f.isSuccess()) {
+          LOGGER.debug("Request successfully sent to the server for replica {} to remove host {}", replicaId, host);
+        } else {
+          LOGGER.error("Failed to send request for replica {} to host {}", replicaId, host, f.cause());
+        }
+      });
 
       // Set a timeout, otherwise if the host is not responding, the future will never complete
       connectTimeoutScheduler.schedule(() -> {

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/blobtransfer/server/P2PBlobTransferService.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/blobtransfer/server/P2PBlobTransferService.java
@@ -50,11 +50,11 @@ public class P2PBlobTransferService extends AbstractVeniceService {
     Class<? extends ServerChannel> socketChannelClass = NioServerSocketChannel.class;
 
     if (Epoll.isAvailable()) {
-      bossGroup = new EpollEventLoopGroup(4);
+      bossGroup = new EpollEventLoopGroup(1);
       workerGroup = new EpollEventLoopGroup(32);
       socketChannelClass = EpollServerSocketChannel.class;
     } else {
-      bossGroup = new NioEventLoopGroup(4);
+      bossGroup = new NioEventLoopGroup(1);
       workerGroup = new NioEventLoopGroup(32);
     }
 

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/blobtransfer/server/P2PBlobTransferService.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/blobtransfer/server/P2PBlobTransferService.java
@@ -50,12 +50,12 @@ public class P2PBlobTransferService extends AbstractVeniceService {
     Class<? extends ServerChannel> socketChannelClass = NioServerSocketChannel.class;
 
     if (Epoll.isAvailable()) {
-      bossGroup = new EpollEventLoopGroup(1);
-      workerGroup = new EpollEventLoopGroup(6);
+      bossGroup = new EpollEventLoopGroup(4);
+      workerGroup = new EpollEventLoopGroup(32);
       socketChannelClass = EpollServerSocketChannel.class;
     } else {
-      bossGroup = new NioEventLoopGroup(1);
-      workerGroup = new NioEventLoopGroup(6);
+      bossGroup = new NioEventLoopGroup(4);
+      workerGroup = new NioEventLoopGroup(32);
     }
 
     serverBootstrap.group(bossGroup, workerGroup)

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/blobtransfer/server/P2PFileTransferServerHandler.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/blobtransfer/server/P2PFileTransferServerHandler.java
@@ -40,6 +40,7 @@ import io.netty.util.AttributeKey;
 import java.io.File;
 import java.io.IOException;
 import java.io.RandomAccessFile;
+import java.net.InetSocketAddress;
 import java.net.URI;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -177,11 +178,8 @@ public class P2PFileTransferServerHandler extends SimpleChannelInboundHandler<Fu
     // Set up the time limitation for the transfer
     long startTime = System.currentTimeMillis();
     String replicaInfo = Utils.getReplicaId(blobTransferRequest.getTopicName(), blobTransferRequest.getPartition());
-    LOGGER.info(
-        "Start transferring {} files for replica {} to remote host {}.",
-        files.length,
-        replicaInfo,
-        ctx.channel().remoteAddress());
+    String hostName = ((InetSocketAddress) ctx.channel().remoteAddress()).getHostString();
+    LOGGER.info("Start transferring {} files for replica {} to remote host {}.", files.length, replicaInfo, hostName);
     // transfer files
     for (File file: files) {
       // check if the transfer for all files is timed out for this partition
@@ -193,7 +191,7 @@ public class P2PFileTransferServerHandler extends SimpleChannelInboundHandler<Fu
         return;
       }
       // send file
-      sendFile(file, ctx, replicaInfo);
+      sendFile(file, ctx, replicaInfo, hostName);
     }
 
     sendMetadata(ctx, transferPartitionMetadata);
@@ -201,15 +199,12 @@ public class P2PFileTransferServerHandler extends SimpleChannelInboundHandler<Fu
     // end of transfer
     HttpResponse endOfTransfer = new DefaultFullHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.OK);
     endOfTransfer.headers().set(BLOB_TRANSFER_STATUS, BLOB_TRANSFER_COMPLETED);
+
     ctx.writeAndFlush(endOfTransfer).addListener(future -> {
       if (future.isSuccess()) {
-        LOGGER.info("All files sent successfully for {} to host {}", replicaInfo, ctx.channel().remoteAddress());
+        LOGGER.info("All files sent successfully for {} to host {}", replicaInfo, hostName);
       } else {
-        LOGGER.error(
-            "Failed to send all files for {} to host {}",
-            replicaInfo,
-            ctx.channel().remoteAddress(),
-            future.cause());
+        LOGGER.error("Failed to send all files for {} to host {}", replicaInfo, hostName, future.cause());
       }
     });
   }
@@ -261,12 +256,9 @@ public class P2PFileTransferServerHandler extends SimpleChannelInboundHandler<Fu
     ctx.close();
   }
 
-  private void sendFile(File file, ChannelHandlerContext ctx, String replicaInfo) throws IOException {
-    LOGGER.info(
-        "Sending file: {} for replica {} to host {}.",
-        file.getName(),
-        replicaInfo,
-        ctx.channel().remoteAddress());
+  private void sendFile(File file, ChannelHandlerContext ctx, String replicaInfo, String hostName) throws IOException {
+    LOGGER.info("Sending file: {} for replica {} to host {}.", file.getName(), replicaInfo, hostName);
+
     RandomAccessFile raf = new RandomAccessFile(file, "r");
     ChannelFuture sendFileFuture;
     long length = raf.length();
@@ -288,17 +280,13 @@ public class P2PFileTransferServerHandler extends SimpleChannelInboundHandler<Fu
 
     sendFileFuture.addListener(future -> {
       if (future.isSuccess()) {
-        LOGGER.info(
-            "Sent file: {} successfully for replica {} to host {}",
-            file.getName(),
-            replicaInfo,
-            ctx.channel().remoteAddress());
+        LOGGER.info("Sent file: {} successfully for replica {} to host {}", file.getName(), replicaInfo, hostName);
       } else {
         LOGGER.error(
             "Failed to send file {} for replica {} to host {}",
             file.getName(),
             replicaInfo,
-            ctx.channel().remoteAddress(),
+            hostName,
             future.cause());
       }
     });

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/blobtransfer/server/P2PFileTransferServerHandler.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/blobtransfer/server/P2PFileTransferServerHandler.java
@@ -274,8 +274,8 @@ public class P2PFileTransferServerHandler extends SimpleChannelInboundHandler<Fu
     ctx.write(response);
 
     // Use ChunkedFile with adaptive chunk size
-    // It means minimum chunk size: 8 KB (8192 bytes), maximum chunk size: 1 MB (1024 * 1024 bytes)
-    int chunkSize = Math.min(1024 * 1024, (int) Math.max(8192, length / 4));
+    // It means minimum chunk size: 8 KB (8192 bytes), maximum chunk size: 2 MB (1024 * 1024 bytes)
+    int chunkSize = Math.min(2 * 1024 * 1024, (int) Math.max(8192, length / 4));
     sendFileFuture = ctx.writeAndFlush(new HttpChunkedInput(new ChunkedFile(raf, 0, length, chunkSize)));
 
     sendFileFuture.addListener(future -> {

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/blobtransfer/server/P2PFileTransferServerHandler.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/blobtransfer/server/P2PFileTransferServerHandler.java
@@ -281,7 +281,10 @@ public class P2PFileTransferServerHandler extends SimpleChannelInboundHandler<Fu
 
     ctx.write(response);
 
-    sendFileFuture = ctx.writeAndFlush(new HttpChunkedInput(new ChunkedFile(raf)));
+    // Use ChunkedFile with adaptive chunk size
+    // It means minimum chunk size: 8 KB (8192 bytes), maximum chunk size: 1 MB (1024 * 1024 bytes)
+    int chunkSize = Math.min(1024 * 1024, (int) Math.max(8192, length / 4));
+    sendFileFuture = ctx.writeAndFlush(new HttpChunkedInput(new ChunkedFile(raf, 0, length, chunkSize)));
 
     sendFileFuture.addListener(future -> {
       if (future.isSuccess()) {

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/blobtransfer/server/P2PFileTransferServerHandler.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/blobtransfer/server/P2PFileTransferServerHandler.java
@@ -282,8 +282,8 @@ public class P2PFileTransferServerHandler extends SimpleChannelInboundHandler<Fu
     ctx.write(response);
 
     // Use ChunkedFile with adaptive chunk size
-    // It means minimum chunk size: 8 KB (8192 bytes), maximum chunk size: 2 MB (1024 * 1024 bytes)
-    int chunkSize = Math.min(2 * 1024 * 1024, (int) Math.max(8192, length / 4));
+    // It means minimum chunk size: 16 KB (16384 bytes), maximum chunk size: 2 MB (1024 * 1024 bytes)
+    int chunkSize = Math.min(2 * 1024 * 1024, (int) Math.max(16384, length / 4));
     sendFileFuture = ctx.writeAndFlush(new HttpChunkedInput(new ChunkedFile(raf, 0, length, chunkSize)));
 
     sendFileFuture.addListener(future -> {

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/blobtransfer/server/P2PFileTransferServerHandler.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/blobtransfer/server/P2PFileTransferServerHandler.java
@@ -176,7 +176,12 @@ public class P2PFileTransferServerHandler extends SimpleChannelInboundHandler<Fu
 
     // Set up the time limitation for the transfer
     long startTime = System.currentTimeMillis();
-
+    String replicaInfo = Utils.getReplicaId(blobTransferRequest.getTopicName(), blobTransferRequest.getPartition());
+    LOGGER.info(
+        "Start transferring {} files for replica {} to remote host {}.",
+        files.length,
+        replicaInfo,
+        ctx.channel().remoteAddress());
     // transfer files
     for (File file: files) {
       // check if the transfer for all files is timed out for this partition
@@ -188,7 +193,7 @@ public class P2PFileTransferServerHandler extends SimpleChannelInboundHandler<Fu
         return;
       }
       // send file
-      sendFile(file, ctx);
+      sendFile(file, ctx, replicaInfo);
     }
 
     sendMetadata(ctx, transferPartitionMetadata);
@@ -196,12 +201,15 @@ public class P2PFileTransferServerHandler extends SimpleChannelInboundHandler<Fu
     // end of transfer
     HttpResponse endOfTransfer = new DefaultFullHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.OK);
     endOfTransfer.headers().set(BLOB_TRANSFER_STATUS, BLOB_TRANSFER_COMPLETED);
-    String replicaInfo = Utils.getReplicaId(blobTransferRequest.getTopicName(), blobTransferRequest.getPartition());
     ctx.writeAndFlush(endOfTransfer).addListener(future -> {
       if (future.isSuccess()) {
-        LOGGER.info("All files sent successfully for {}", replicaInfo);
+        LOGGER.info("All files sent successfully for {} to host {}", replicaInfo, ctx.channel().remoteAddress());
       } else {
-        LOGGER.error("Failed to send all files for {}", replicaInfo, future.cause());
+        LOGGER.error(
+            "Failed to send all files for {} to host {}",
+            replicaInfo,
+            ctx.channel().remoteAddress(),
+            future.cause());
       }
     });
   }
@@ -253,11 +261,14 @@ public class P2PFileTransferServerHandler extends SimpleChannelInboundHandler<Fu
     ctx.close();
   }
 
-  private void sendFile(File file, ChannelHandlerContext ctx) throws IOException {
-    LOGGER.info("Sending file: {} at path {}. ", file.getName(), file.getAbsolutePath());
+  private void sendFile(File file, ChannelHandlerContext ctx, String replicaInfo) throws IOException {
+    LOGGER.info(
+        "Sending file: {} for replica {} to host {}.",
+        file.getName(),
+        replicaInfo,
+        ctx.channel().remoteAddress());
     RandomAccessFile raf = new RandomAccessFile(file, "r");
     ChannelFuture sendFileFuture;
-    ChannelFuture lastContentFuture;
     long length = raf.length();
     String fileChecksum = BlobTransferUtils.generateFileChecksum(file.toPath());
 
@@ -271,21 +282,21 @@ public class P2PFileTransferServerHandler extends SimpleChannelInboundHandler<Fu
     ctx.write(response);
 
     sendFileFuture = ctx.writeAndFlush(new HttpChunkedInput(new ChunkedFile(raf)));
-    lastContentFuture = sendFileFuture;
 
     sendFileFuture.addListener(future -> {
       if (future.isSuccess()) {
-        LOGGER.info("File {} sent successfully", file.getName());
+        LOGGER.info(
+            "Sent file: {} successfully for replica {} to host {}",
+            file.getName(),
+            replicaInfo,
+            ctx.channel().remoteAddress());
       } else {
-        LOGGER.error("Failed to send file {}", file.getName());
-      }
-    });
-
-    lastContentFuture.addListener(future -> {
-      if (future.isSuccess()) {
-        LOGGER.info("Last content sent successfully for {}", file.getName());
-      } else {
-        LOGGER.error("Failed to send last content for {}", file.getName());
+        LOGGER.error(
+            "Failed to send file {} for replica {} to host {}",
+            file.getName(),
+            replicaInfo,
+            ctx.channel().remoteAddress(),
+            future.cause());
       }
     });
   }


### PR DESCRIPTION
<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat], [protocol]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## Problem Statement
The P2P blob transfer server was experiencing severe performance bottlenecks that limited throughput to ~200 MB/s on enterprise NVMe hardware capable of 3,000+ MB/s. Analysis revealed multiple issues:
1. Thread pool starvation: Only 6 worker threads couldn't generate sufficient concurrent I/O operations to utilize enterprise NVMe's 8+ controller cores. 
2. Low queue depth: Server iostat showed queue depth of only ~4, indicating massive underutilization of NVMe parallel processing capability. 
```
Device            r/s     rkB/s   rrqm/s  %rrqm r_await rareq-sz     w/s     wkB/s   wrqm/s  %wrqm w_await wareq-sz     d/s     dkB/s   drqm/s  %drqm d_await dareq-sz     f/s f_await  aqu-sz  %util
nvme0n1       13193.00 377560.00     0.00   0.00    0.14    28.62    3.00     48.00     0.00   0.00    0.00    16.00    0.00      0.00     0.00   0.00    0.00     0.00    0.00    0.00    1.82 100.00
sda              0.00      0.00     0.00   0.00    0.00     0.00    6.00     36.00     0.00   0.00    0.17     6.00    0.00      0.00     0.00   0.00    0.00     0.00    5.00    0.00    0.00   0.40
```
3. `ctx.writeAndFlush(new HttpChunkedInput(new ChunkedFile(raf))); `always uses default 8 KB per chunk for every file. In our tests, each SST file can reach up to 250 MB/s, which results in significant I/O overhead for large files.


## Solution
1. Scaled thread pools: Increased worker threads from 6 to 32 to generate more concurrent I/O operations
2. Added more logging for replica send operations.
3. Added request send logs to debug client thread hangs.
4. Instead of using fixed chunks for all files (which was incorrect), it now properly shows the adaptive approach that:
Uses 8KB chunks for small files (≤32KB), Uses proportional chunks for medium files (32KB-4MB), Caps at 1MB chunks for large files (>4MB)

<!--
Describe
- What changes you are making and why. 
- How these changes solve the problem.
- Any performance considerations or trade-offs. 
- Describe what testings you have done, for example, performance testing etc.
-->


###  Code changes
- [ ] Added new code behind **a config**. If so list the config names and their default values in the PR description.
- [ ] Introduced new **log lines**. 
  - [ ] Confirmed if logs need to be **rate limited** to avoid excessive logging.

###  **Concurrency-Specific Checks**
Both reviewer and PR author to verify
- [ ] Code has **no race conditions** or **thread safety issues**.
- [ ] Proper **synchronization mechanisms** (e.g., `synchronized`, `RWLock`) are used where needed.
- [ ] No **blocking calls** inside critical sections that could lead to deadlocks or performance degradation.
- [ ] Verified **thread-safe collections** are used (e.g., `ConcurrentHashMap`, `CopyOnWriteArrayList`).
- [ ] Validated proper exception handling in multi-threaded code to avoid silent thread termination.


## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->

- [ ] New unit tests added.
- [ ] New integration tests added.
- [ ] Modified or extended existing tests.
- [ ] Verified backward compatibility (if applicable).

## Does this PR introduce any user-facing or breaking changes?
<!--  
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [ ] No. You can skip the rest of this section.
- [ ] Yes. Clearly explain the behavior change and its impact.