### PR TITLE
[dvc] Add heartbeat monitoring service for Da Vinci

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
@@ -1063,6 +1063,7 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
 
       // Log only once a minute per partition.
       boolean shouldLogLag = !REDUNDANT_LOGGING_FILTER.isRedundantException(msg);
+
       if (serverConfig.isUseHeartbeatLagForReadyToServeCheckEnabled()) {
         // Measure heartbeat lag for ready-to-serve check.
         isLagAcceptable = checkAndLogIfLagIsAcceptableForHybridStore(

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/HeartbeatMonitoringServiceStats.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/HeartbeatMonitoringServiceStats.java
@@ -8,13 +8,13 @@ import io.tehuti.metrics.stats.OccurrenceRate;
 
 
 public class HeartbeatMonitoringServiceStats extends AbstractVeniceStats {
-  private static final String HB_SUFFIX = "-heartbeat-monitor-service";
+  private static final String HEARTBEAT_SUFFIX = "-heartbeat-monitor-service";
   private final Sensor heartbeatExceptionCountSensor;
   private final Sensor heartbeatReporterSensor;
   private final Sensor heartbeatLoggingSensor;
 
-  public HeartbeatMonitoringServiceStats(MetricsRepository metricsRepository, String clusterName) {
-    super(metricsRepository, clusterName + HB_SUFFIX);
+  public HeartbeatMonitoringServiceStats(MetricsRepository metricsRepository, String heartbeatStatPrefix) {
+    super(metricsRepository, heartbeatStatPrefix + HEARTBEAT_SUFFIX);
     heartbeatExceptionCountSensor = registerSensorIfAbsent("heartbeat-monitor-service-exception-count", new Count());
     heartbeatReporterSensor = registerSensorIfAbsent("heartbeat-reporter", new OccurrenceRate());
     heartbeatLoggingSensor = registerSensorIfAbsent("heartbeat-logger", new OccurrenceRate());

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/ingestion/heartbeat/HeartbeatMonitoringService.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/ingestion/heartbeat/HeartbeatMonitoringService.java
@@ -519,16 +519,6 @@ public class HeartbeatMonitoringService extends AbstractVeniceService {
       }
       return Long.MAX_VALUE;
     }
-    LOGGER.info(
-        "DEBUGGING WE ARE HERE storeName: {}, version: {}, partition: {}, currentTimestamp: {}, entry timestamp: {}, entry consumedFromUpstream: {}, local region: {}",
-        storeName,
-        version,
-        partitionConsumptionState.getPartition(),
-        currentTimestamp,
-        followerReplicaTimestamp.timestamp,
-        followerReplicaTimestamp.consumedFromUpstream,
-        getLocalRegionName());
-
     if (!followerReplicaTimestamp.consumedFromUpstream) {
       if (shouldLogLag) {
         LOGGER.info(
@@ -564,15 +554,6 @@ public class HeartbeatMonitoringService extends AbstractVeniceService {
       Map<String, Map<Integer, Map<Integer, Map<String, HeartbeatTimeStampEntry>>>> heartbeatTimestamps,
       boolean isReadyToServe,
       boolean retainHighestTimeStamp) {
-    LOGGER.info(
-        "DEBUGGING: PUT FOLLOWER HB: store: {}, version: {}, partition: {}, region: {}, timestamp: {}, isReadyToServe: {}, retainHighestTimeStamp: {}",
-        store,
-        version,
-        partition,
-        region,
-        timestamp,
-        isReadyToServe,
-        retainHighestTimeStamp);
     if (region != null) {
       heartbeatTimestamps.computeIfPresent(store, (storeKey, perVersionMap) -> {
         perVersionMap.computeIfPresent(version, (versionKey, perPartitionMap) -> {

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/ingestion/heartbeat/HeartbeatMonitoringService.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/ingestion/heartbeat/HeartbeatMonitoringService.java
@@ -135,6 +135,11 @@ public class HeartbeatMonitoringService extends AbstractVeniceService {
           }
           return regionTimestamps;
         });
+    LOGGER.info(
+        "Completed initializing heartbeat timestamps for version: {}, partition: {}, follower: {}",
+        version,
+        partition,
+        isFollower);
   }
 
   private synchronized void removeEntry(
@@ -514,6 +519,16 @@ public class HeartbeatMonitoringService extends AbstractVeniceService {
       }
       return Long.MAX_VALUE;
     }
+    LOGGER.info(
+        "DEBUGGING WE ARE HERE storeName: {}, version: {}, partition: {}, currentTimestamp: {}, entry timestamp: {}, entry consumedFromUpstream: {}, local region: {}",
+        storeName,
+        version,
+        partitionConsumptionState.getPartition(),
+        currentTimestamp,
+        followerReplicaTimestamp.timestamp,
+        followerReplicaTimestamp.consumedFromUpstream,
+        getLocalRegionName());
+
     if (!followerReplicaTimestamp.consumedFromUpstream) {
       if (shouldLogLag) {
         LOGGER.info(
@@ -549,6 +564,15 @@ public class HeartbeatMonitoringService extends AbstractVeniceService {
       Map<String, Map<Integer, Map<Integer, Map<String, HeartbeatTimeStampEntry>>>> heartbeatTimestamps,
       boolean isReadyToServe,
       boolean retainHighestTimeStamp) {
+    LOGGER.info(
+        "DEBUGGING: PUT FOLLOWER HB: store: {}, version: {}, partition: {}, region: {}, timestamp: {}, isReadyToServe: {}, retainHighestTimeStamp: {}",
+        store,
+        version,
+        partition,
+        region,
+        timestamp,
+        isReadyToServe,
+        retainHighestTimeStamp);
     if (region != null) {
       heartbeatTimestamps.computeIfPresent(store, (storeKey, perVersionMap) -> {
         perVersionMap.computeIfPresent(version, (versionKey, perPartitionMap) -> {
@@ -660,7 +684,7 @@ public class HeartbeatMonitoringService extends AbstractVeniceService {
    * This should prevent other race conditions caused by out of sync customized view too.
    */
   void checkAndMaybeCleanupLagMonitor() {
-    if (customizedViewRepository == null) {
+    if (customizedViewRepository == null && customizedViewRepositoryFuture != null) {
       if (customizedViewRepositoryFuture.isDone()) {
         try {
           customizedViewRepository = customizedViewRepositoryFuture.get();

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/StoreBackendTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/StoreBackendTest.java
@@ -22,6 +22,8 @@ import com.linkedin.davinci.compression.StorageEngineBackedCompressorFactory;
 import com.linkedin.davinci.config.VeniceConfigLoader;
 import com.linkedin.davinci.ingestion.IngestionBackend;
 import com.linkedin.davinci.kafka.consumer.StoreIngestionService;
+import com.linkedin.davinci.stats.ingestion.heartbeat.HeartbeatLagMonitorAction;
+import com.linkedin.davinci.stats.ingestion.heartbeat.HeartbeatMonitoringService;
 import com.linkedin.davinci.storage.StorageService;
 import com.linkedin.venice.ConfigKeys;
 import com.linkedin.venice.exceptions.VeniceException;
@@ -70,6 +72,7 @@ public class StoreBackendTest {
   StorageService storageService;
   IngestionBackend ingestionBackend;
   StorageEngineBackedCompressorFactory compressorFactory;
+  HeartbeatMonitoringService heartbeatMonitoringService;
 
   @BeforeMethod
   void setUp() {
@@ -90,6 +93,7 @@ public class StoreBackendTest {
     ingestionBackend = mock(IngestionBackend.class);
     compressorFactory = mock(StorageEngineBackedCompressorFactory.class);
     backend = mock(DaVinciBackend.class);
+    heartbeatMonitoringService = mock(HeartbeatMonitoringService.class);
     when(backend.getExecutor()).thenReturn(executor);
     when(backend.getConfigLoader()).thenReturn(new VeniceConfigLoader(backendConfig));
     when(backend.getMetricsRepository()).thenReturn(metricsRepository);
@@ -102,6 +106,7 @@ public class StoreBackendTest {
     when(backend.getIngestionBackend()).thenReturn(ingestionBackend);
     when(backend.getCompressorFactory()).thenReturn(compressorFactory);
     when(backend.hasCurrentVersionBootstrapping()).thenReturn(false);
+    when(backend.getHeartbeatMonitoringService()).thenReturn(heartbeatMonitoringService);
     doCallRealMethod().when(backend).handleStoreChanged(any());
 
     store = new ZKStore(
@@ -148,6 +153,8 @@ public class StoreBackendTest {
 
     // Expecting to subscribe to version1 and that version2 is a future version.
     CompletableFuture subscribeResult = storeBackend.subscribe(ComplementSet.of(partition));
+    verify(heartbeatMonitoringService, times(1))
+        .updateLagMonitor(version1.kafkaTopicName(), partition, HeartbeatLagMonitorAction.SET_FOLLOWER_MONITOR);
     TimeUnit.MILLISECONDS.sleep(v1SubscribeDurationMs);
     versionMap.get(version1.kafkaTopicName()).completePartition(partition);
     subscribeResult.get(3, TimeUnit.SECONDS);
@@ -328,9 +335,17 @@ public class StoreBackendTest {
   void testSubscribeUnsubscribe() throws Exception {
     // Simulate concurrent unsubscribe while subscribe is pending.
     CompletableFuture subscribeResult = storeBackend.subscribe(ComplementSet.of(0, 1));
+    verify(heartbeatMonitoringService, times(1))
+        .updateLagMonitor(version1.kafkaTopicName(), 0, HeartbeatLagMonitorAction.SET_FOLLOWER_MONITOR);
+    verify(heartbeatMonitoringService, times(1))
+        .updateLagMonitor(version1.kafkaTopicName(), 1, HeartbeatLagMonitorAction.SET_FOLLOWER_MONITOR);
     versionMap.get(version1.kafkaTopicName()).completePartition(0);
     assertFalse(subscribeResult.isDone());
     storeBackend.unsubscribe(ComplementSet.of(1));
+    verify(heartbeatMonitoringService, times(1))
+        .updateLagMonitor(version1.kafkaTopicName(), 1, HeartbeatLagMonitorAction.REMOVE_MONITOR);
+    verify(heartbeatMonitoringService, times(0))
+        .updateLagMonitor(version1.kafkaTopicName(), 0, HeartbeatLagMonitorAction.REMOVE_MONITOR);
     // Verify that unsubscribe completed pending subscribe without failing it.
     subscribeResult.get(3, TimeUnit.SECONDS);
     TestUtils.waitForNonDeterministicAssertion(3, TimeUnit.SECONDS, () -> {

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/VersionBackendTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/VersionBackendTest.java
@@ -19,6 +19,7 @@ import com.linkedin.davinci.client.InternalDaVinciRecordTransformerConfig;
 import com.linkedin.davinci.config.VeniceConfigLoader;
 import com.linkedin.davinci.ingestion.IngestionBackend;
 import com.linkedin.davinci.stats.AggVersionedDaVinciRecordTransformerStats;
+import com.linkedin.davinci.stats.ingestion.heartbeat.HeartbeatMonitoringService;
 import com.linkedin.davinci.storage.StorageService;
 import com.linkedin.davinci.transformer.TestStringRecordTransformer;
 import com.linkedin.venice.ConfigKeys;
@@ -176,6 +177,9 @@ public class VersionBackendTest {
 
     StoreBackend mockStoreBackend = mock(StoreBackend.class);
     when(mockDaVinciBackend.getStoreOrThrow(anyString())).thenReturn(mockStoreBackend);
+
+    HeartbeatMonitoringService mockHeartbeatMonitoringService = mock(HeartbeatMonitoringService.class);
+    when(mockDaVinciBackend.getHeartbeatMonitoringService()).thenReturn(mockHeartbeatMonitoringService);
 
     ZKStore store = TestUtils.populateZKStore(
         (ZKStore) TestUtils.createTestStore(

--- a/internal/venice-common/src/main/java/com/linkedin/venice/ConfigKeys.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/ConfigKeys.java
@@ -2816,9 +2816,6 @@ public class ConfigKeys {
    */
   public static final String SERVER_CONSUMER_POLL_TRACKER_STALE_THRESHOLD_IN_SECONDS =
       "server.consumer.poll.tracker.stale.threshold.in.seconds";
-  public static final String SERVER_USE_HEARTBEAT_LAG_FOR_READY_TO_SERVE_CHECK =
-      "server.use.heartbeat.lag.for.ready.to.serve.check";
-
   /**
    * Use heartbeat lag instead of offset lag for ready-to-serve check.
    */

--- a/internal/venice-test-common/build.gradle
+++ b/internal/venice-test-common/build.gradle
@@ -207,6 +207,7 @@ def integrationTestBuckets = [
     ],
     "12": [
         "com.linkedin.venice.endToEnd.DaVinciClientTest",
+        "com.linkedin.venice.endToEnd.DaVinciClientTestWithHeartbeatReadyToServeCheckTest",
         "com.linkedin.venice.endToEnd.TestBatchForRocksDB",
         "com.linkedin.venice.controller.TestHAASController",
         "com.linkedin.venice.server.VeniceServerTest"

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/DaVinciClientIsolatedAndHybridStoreTest.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/DaVinciClientIsolatedAndHybridStoreTest.java
@@ -77,7 +77,6 @@ import java.io.FileWriter;
 import java.nio.ByteBuffer;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Properties;
@@ -618,21 +617,6 @@ public class DaVinciClientIsolatedAndHybridStoreTest {
         writerFutures[i].get();
       }
       batchProducer.broadcastEndOfIncrementalPush(incrementalPushVersion, Collections.emptyMap());
-    }
-  }
-
-  private void generateHybridData(String storeName, List<Pair<Object, Object>> dataToWrite) {
-    SystemProducer producer = IntegrationTestPushUtils.getSamzaProducer(
-        cluster,
-        storeName,
-        Version.PushType.STREAM,
-        Pair.create(VENICE_PARTITIONERS, ConstantVenicePartitioner.class.getName()));
-    try {
-      for (Pair<Object, Object> record: dataToWrite) {
-        IntegrationTestPushUtils.sendStreamingRecord(producer, storeName, record.getFirst(), record.getSecond());
-      }
-    } finally {
-      producer.stop();
     }
   }
 }

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/DaVinciClientTestWithHeartbeatReadyToServeCheckTest.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/DaVinciClientTestWithHeartbeatReadyToServeCheckTest.java
@@ -1,0 +1,212 @@
+package com.linkedin.venice.endToEnd;
+
+import static com.linkedin.davinci.store.rocksdb.RocksDBServerConfig.ROCKSDB_BLOCK_CACHE_SIZE_IN_BYTES;
+import static com.linkedin.venice.ConfigKeys.CLIENT_SYSTEM_STORE_REPOSITORY_REFRESH_INTERVAL_SECONDS;
+import static com.linkedin.venice.ConfigKeys.CLIENT_USE_SYSTEM_STORE_REPOSITORY;
+import static com.linkedin.venice.ConfigKeys.DATA_BASE_PATH;
+import static com.linkedin.venice.ConfigKeys.DAVINCI_PUSH_STATUS_SCAN_INTERVAL_IN_SECONDS;
+import static com.linkedin.venice.ConfigKeys.PERSISTENCE_TYPE;
+import static com.linkedin.venice.ConfigKeys.PUSH_STATUS_STORE_ENABLED;
+import static com.linkedin.venice.ConfigKeys.SERVER_USE_HEARTBEAT_LAG_FOR_READY_TO_SERVE_CHECK_ENABLED;
+import static com.linkedin.venice.ConfigKeys.VENICE_PARTITIONERS;
+import static com.linkedin.venice.integration.utils.DaVinciTestContext.getCachingDaVinciClientFactory;
+import static com.linkedin.venice.integration.utils.VeniceClusterWrapper.DEFAULT_KEY_SCHEMA;
+import static com.linkedin.venice.integration.utils.VeniceClusterWrapper.DEFAULT_VALUE_SCHEMA;
+import static com.linkedin.venice.meta.PersistenceType.ROCKS_DB;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertThrows;
+
+import com.linkedin.d2.balancer.D2Client;
+import com.linkedin.d2.balancer.D2ClientBuilder;
+import com.linkedin.davinci.client.DaVinciClient;
+import com.linkedin.davinci.client.DaVinciConfig;
+import com.linkedin.davinci.client.NonLocalAccessException;
+import com.linkedin.davinci.client.factory.CachingDaVinciClientFactory;
+import com.linkedin.venice.D2.D2ClientUtils;
+import com.linkedin.venice.controllerapi.UpdateStoreQueryParams;
+import com.linkedin.venice.integration.utils.ServiceFactory;
+import com.linkedin.venice.integration.utils.VeniceClusterCreateOptions;
+import com.linkedin.venice.integration.utils.VeniceClusterWrapper;
+import com.linkedin.venice.integration.utils.VeniceRouterWrapper;
+import com.linkedin.venice.meta.Version;
+import com.linkedin.venice.partitioner.ConstantVenicePartitioner;
+import com.linkedin.venice.utils.DataProviderUtils;
+import com.linkedin.venice.utils.IntegrationTestPushUtils;
+import com.linkedin.venice.utils.Pair;
+import com.linkedin.venice.utils.PropertyBuilder;
+import com.linkedin.venice.utils.TestUtils;
+import com.linkedin.venice.utils.Utils;
+import com.linkedin.venice.utils.VeniceProperties;
+import io.tehuti.metrics.MetricsRepository;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Consumer;
+import java.util.stream.Stream;
+import org.apache.samza.system.SystemProducer;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+
+public class DaVinciClientTestWithHeartbeatReadyToServeCheckTest {
+  private static final int KEY_COUNT = 10;
+  private static final int TEST_TIMEOUT = 120_000;
+  private VeniceClusterWrapper cluster;
+  private D2Client d2Client;
+
+  @BeforeClass
+  public void setUp() {
+    Utils.thisIsLocalhost();
+    Properties clusterConfig = new Properties();
+    clusterConfig.put(PUSH_STATUS_STORE_ENABLED, true);
+    clusterConfig.put(DAVINCI_PUSH_STATUS_SCAN_INTERVAL_IN_SECONDS, 3);
+    VeniceClusterCreateOptions options = new VeniceClusterCreateOptions.Builder().numberOfControllers(1)
+        .numberOfServers(2)
+        .numberOfRouters(1)
+        .replicationFactor(2)
+        .partitionSize(100)
+        .sslToStorageNodes(false)
+        .sslToKafka(false)
+        .extraProperties(clusterConfig)
+        .build();
+    cluster = ServiceFactory.getVeniceCluster(options);
+    d2Client = new D2ClientBuilder().setZkHosts(cluster.getZk().getAddress())
+        .setZkSessionTimeout(3, TimeUnit.SECONDS)
+        .setZkStartupTimeout(3, TimeUnit.SECONDS)
+        .build();
+    D2ClientUtils.startClient(d2Client);
+  }
+
+  @AfterClass
+  public void cleanUp() {
+    if (d2Client != null) {
+      D2ClientUtils.shutdownClient(d2Client);
+    }
+    Utils.closeQuietlyWithErrorLogged(cluster);
+  }
+
+  @Test(dataProvider = "dv-client-config-provider", dataProviderClass = DataProviderUtils.class, timeOut = TEST_TIMEOUT
+      * 2)
+  public void testHybridStore(DaVinciConfig daVinciConfig) throws Exception {
+    // Create store
+    final int partitionCount = 2;
+    final int emptyPartition = 0;
+    final int dataPartition = 1;
+    String storeName = Utils.getUniqueString("hybrid-store");
+
+    // Convert it to hybrid
+    Consumer<UpdateStoreQueryParams> paramsConsumer =
+        params -> params.setPartitionerClass(ConstantVenicePartitioner.class.getName())
+            .setPartitionCount(partitionCount)
+            .setPartitionerParams(
+                Collections.singletonMap(ConstantVenicePartitioner.CONSTANT_PARTITION, String.valueOf(dataPartition)));
+    setupHybridStore(storeName, paramsConsumer);
+
+    VeniceProperties backendConfig = new PropertyBuilder().put(CLIENT_USE_SYSTEM_STORE_REPOSITORY, true)
+        .put(CLIENT_SYSTEM_STORE_REPOSITORY_REFRESH_INTERVAL_SECONDS, 1)
+        .put(SERVER_USE_HEARTBEAT_LAG_FOR_READY_TO_SERVE_CHECK_ENABLED, true)
+        .put(DATA_BASE_PATH, Utils.getTempDataDirectory().getAbsolutePath())
+        .put(ROCKSDB_BLOCK_CACHE_SIZE_IN_BYTES, 2 * 1024 * 1024L)
+        .put(PERSISTENCE_TYPE, ROCKS_DB)
+        .build();
+
+    MetricsRepository metricsRepository = new MetricsRepository();
+
+    try (CachingDaVinciClientFactory factory = getCachingDaVinciClientFactory(
+        d2Client,
+        VeniceRouterWrapper.CLUSTER_DISCOVERY_D2_SERVICE_NAME,
+        metricsRepository,
+        backendConfig,
+        cluster)) {
+      DaVinciClient<Integer, Integer> client = factory.getAndStartGenericAvroClient(storeName, daVinciConfig);
+      // subscribe to a partition without data
+      client.subscribe(Collections.singleton(emptyPartition)).get();
+      for (int i = 0; i < KEY_COUNT; i++) {
+        int key = i;
+        assertThrows(NonLocalAccessException.class, () -> client.get(key).get());
+      }
+      client.unsubscribe(Collections.singleton(emptyPartition));
+
+      // subscribe to a partition with data
+      client.subscribe(Collections.singleton(dataPartition)).get();
+      TestUtils.waitForNonDeterministicAssertion(TEST_TIMEOUT, TimeUnit.MILLISECONDS, () -> {
+
+        Map<Integer, Integer> keyValueMap = new HashMap<>();
+        for (Integer i = 0; i < KEY_COUNT; i++) {
+          assertEquals(client.get(i).get(), i);
+          keyValueMap.put(i, i);
+        }
+
+        Map<Integer, Integer> batchGetResult = client.batchGet(keyValueMap.keySet()).get();
+        assertNotNull(batchGetResult);
+        assertEquals(batchGetResult, keyValueMap);
+      });
+
+      // Write some fresh records to override the old value. Make sure we can read the new value.
+      List<Pair<Object, Object>> dataToPublish = new ArrayList<>();
+      dataToPublish.add(new Pair<>(0, 1));
+      dataToPublish.add(new Pair<>(1, 2));
+      dataToPublish.add(new Pair<>(3, 4));
+
+      generateHybridData(storeName, dataToPublish);
+      TestUtils.waitForNonDeterministicAssertion(TEST_TIMEOUT, TimeUnit.MILLISECONDS, () -> {
+        for (Pair<Object, Object> entry: dataToPublish) {
+          assertEquals(client.get((Integer) entry.getFirst()).get(), entry.getSecond());
+        }
+      });
+    }
+  }
+
+  private void setupHybridStore(String storeName, Consumer<UpdateStoreQueryParams> paramsConsumer) throws Exception {
+    setupHybridStore(storeName, paramsConsumer, KEY_COUNT);
+  }
+
+  private void setupHybridStore(String storeName, Consumer<UpdateStoreQueryParams> paramsConsumer, int keyCount)
+      throws Exception {
+    UpdateStoreQueryParams params = new UpdateStoreQueryParams().setHybridRewindSeconds(10)
+        .setHybridOffsetLagThreshold(10)
+        .setIncrementalPushEnabled(true);
+    paramsConsumer.accept(params);
+    cluster.useControllerClient(client -> {
+      client.createNewStore(storeName, "owner", DEFAULT_KEY_SCHEMA, DEFAULT_VALUE_SCHEMA);
+      cluster.createMetaSystemStore(storeName);
+      client.updateStore(storeName, params);
+      cluster.createVersion(storeName, DEFAULT_KEY_SCHEMA, DEFAULT_VALUE_SCHEMA, Stream.of());
+      if (keyCount > 0) {
+        SystemProducer producer = IntegrationTestPushUtils.getSamzaProducer(
+            cluster,
+            storeName,
+            Version.PushType.STREAM,
+            Pair.create(VENICE_PARTITIONERS, ConstantVenicePartitioner.class.getName()));
+        try {
+          for (int i = 0; i < keyCount; i++) {
+            IntegrationTestPushUtils.sendStreamingRecord(producer, storeName, i, i);
+          }
+        } finally {
+          producer.stop();
+        }
+      }
+    });
+  }
+
+  private void generateHybridData(String storeName, List<Pair<Object, Object>> dataToWrite) {
+    SystemProducer producer = IntegrationTestPushUtils.getSamzaProducer(
+        cluster,
+        storeName,
+        Version.PushType.STREAM,
+        Pair.create(VENICE_PARTITIONERS, ConstantVenicePartitioner.class.getName()));
+    try {
+      for (Pair<Object, Object> record: dataToWrite) {
+        IntegrationTestPushUtils.sendStreamingRecord(producer, storeName, record.getFirst(), record.getSecond());
+      }
+    } finally {
+      producer.stop();
+    }
+  }
+}

--- a/services/venice-controller/src/test/java/com/linkedin/venice/controller/systemstore/SystemStoreRepairTaskTest.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/controller/systemstore/SystemStoreRepairTaskTest.java
@@ -36,7 +36,6 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
-import org.apache.logging.log4j.LogManager;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
@@ -278,7 +277,6 @@ public class SystemStoreRepairTaskTest {
     /**
      * All other stores should have new timestamp sent.
      */
-    LogManager.getLogger().info("DEBUGGING: {}", systemStoreToHeartbeatTimestampMap);
     Assert.assertEquals(systemStoreToHeartbeatTimestampMap.size(), 2);
     Assert.assertNotNull(
         systemStoreToHeartbeatTimestampMap


### PR DESCRIPTION
<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat], [protocol]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## [dvc] Add heartbeat monitoring service for Da Vinci
This PR adds heartbeat monitoring support for Da Vinci. With this support, Da Vinci will be able to switch to measure time lag, instead of offset lag when performing ready-to-serve check.


## Solution


###  Code changes
- [ ] Added new code behind **a config**. If so list the config names and their default values in the PR description.
- [x] Introduced new **log lines**. 
  - [x] Confirmed if logs need to be **rate limited** to avoid excessive logging.

###  **Concurrency-Specific Checks**
Both reviewer and PR author to verify
- [ ] Code has **no race conditions** or **thread safety issues**.
- [ ] Proper **synchronization mechanisms** (e.g., `synchronized`, `RWLock`) are used where needed.
- [ ] No **blocking calls** inside critical sections that could lead to deadlocks or performance degradation.
- [ ] Verified **thread-safe collections** are used (e.g., `ConcurrentHashMap`, `CopyOnWriteArrayList`).
- [ ] Validated proper exception handling in multi-threaded code to avoid silent thread termination.


## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->

- [ ] New unit tests added.
- [x] New integration tests added.
- [ ] Modified or extended existing tests.
- [ ] Verified backward compatibility (if applicable).

## Does this PR introduce any user-facing or breaking changes?
<!--  
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Clearly explain the behavior change and its impact.