### PR TITLE
[server][dvc][test] Delete deprecated PubSubPositionDeserializer::getPositionFromWireFormat API

### DIFF
--- a/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/PubSubPositionDeserializer.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/PubSubPositionDeserializer.java
@@ -28,7 +28,11 @@ public class PubSubPositionDeserializer {
   /**
    * Note: The following default instance is only for convenience purposes until we've updated all the code to use
    * pass the registry and resolver explicitly.
+   *
+   * @deprecated Use explicit instances of {@link PubSubPositionDeserializer} with a custom
+   *             {@link PubSubPositionTypeRegistry} instead of relying on this static default.
    */
+  @Deprecated
   public static final PubSubPositionDeserializer DEFAULT_DESERIALIZER =
       new PubSubPositionDeserializer(PubSubPositionTypeRegistry.RESERVED_POSITION_TYPE_REGISTRY);
 
@@ -73,39 +77,6 @@ public class PubSubPositionDeserializer {
       throw new IllegalArgumentException("Cannot deserialize null wire format position");
     }
     return toPosition(deserializeWireFormat(positionWireFormatBytes));
-  }
-
-  /**
-   * Convenience method for converting a serialized byte array representing a
-   * {@link PubSubPositionWireFormat} into a concrete {@link PubSubPosition} instance.
-   *
-   * <p>This uses the {@link #DEFAULT_DESERIALIZER} with the reserved position type registry.
-   * Recommended only for use in non-critical paths or tests where custom registries are not required.</p>
-   *
-   * @param positionWireFormatBytes the serialized bytes of {@link PubSubPositionWireFormat}
-   * @return deserialized {@link PubSubPosition} object
-   * @throws VeniceException if deserialization fails or type ID is unrecognized
-   */
-  public static PubSubPosition getPositionFromWireFormat(byte[] positionWireFormatBytes) {
-    return DEFAULT_DESERIALIZER.toPosition(positionWireFormatBytes);
-  }
-
-  public static PubSubPosition getPositionFromWireFormat(ByteBuffer positionWireFormatBuffer) {
-    return DEFAULT_DESERIALIZER.toPosition(positionWireFormatBuffer);
-  }
-
-  /**
-   * Convenience method for converting a {@link PubSubPositionWireFormat} record into a concrete {@link PubSubPosition}.
-   *
-   * <p>This uses the {@link #DEFAULT_DESERIALIZER} with the reserved position type registry.
-   * Prefer constructing your own {@link PubSubPositionDeserializer} with a custom registry if needed.</p>
-   *
-   * @param positionWireFormat the wire format record to convert
-   * @return deserialized {@link PubSubPosition} object
-   * @throws VeniceException if the type ID in the wire format is unrecognized
-   */
-  public static PubSubPosition getPositionFromWireFormat(PubSubPositionWireFormat positionWireFormat) {
-    return DEFAULT_DESERIALIZER.toPosition(positionWireFormat);
   }
 
   /**

--- a/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/PubSubUtil.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/PubSubUtil.java
@@ -257,17 +257,6 @@ public final class PubSubUtil {
     return isInclusive ? baseOffset : baseOffset + 1;
   }
 
-  /**
-   * Get the Kafka offset position buffer for the given offset.
-   * This is temporarily used to convert the offset to a buffer during the transition to using
-   * {@link com.linkedin.venice.pubsub.api.PubSubPosition} in the OffsetRecord.
-   * @param offset the offset to convert
-   * @return a ByteBuffer representing the Kafka offset position
-   */
-  public static ByteBuffer toKafkaPositionWf(long offset) {
-    return ApacheKafkaOffsetPosition.of(offset).toWireFormatBuffer();
-  }
-
   public static PubSubPosition fromKafkaOffset(long offset) {
     if (offset == -1) {
       return PubSubSymbolicPosition.EARLIEST; // -1 is start offset

--- a/internal/venice-common/src/test/java/com/linkedin/venice/pubsub/adapter/kafka/consumer/ApacheKafkaConsumerAdapterTest.java
+++ b/internal/venice-common/src/test/java/com/linkedin/venice/pubsub/adapter/kafka/consumer/ApacheKafkaConsumerAdapterTest.java
@@ -28,7 +28,6 @@ import com.linkedin.venice.kafka.protocol.ProducerMetadata;
 import com.linkedin.venice.kafka.protocol.Put;
 import com.linkedin.venice.kafka.protocol.enums.MessageType;
 import com.linkedin.venice.message.KafkaKey;
-import com.linkedin.venice.pubsub.PubSubPositionDeserializer;
 import com.linkedin.venice.pubsub.PubSubPositionTypeRegistry;
 import com.linkedin.venice.pubsub.PubSubTopicPartitionImpl;
 import com.linkedin.venice.pubsub.PubSubTopicPartitionInfo;
@@ -844,10 +843,6 @@ public class ApacheKafkaConsumerAdapterTest {
   public void testDecodePositionFromBuffer() {
     long expectedOffset = 12345L;
     ApacheKafkaOffsetPosition original = new ApacheKafkaOffsetPosition(expectedOffset);
-    byte[] wireBytes = original.toWireFormatBytes();
-    PubSubPosition resolvedPos = PubSubPositionDeserializer.getPositionFromWireFormat(wireBytes);
-    assertTrue(resolvedPos instanceof ApacheKafkaOffsetPosition);
-    assertEquals(((ApacheKafkaOffsetPosition) resolvedPos).getInternalOffset(), expectedOffset);
 
     PubSubPositionWireFormat wireFormat = original.getPositionWireFormat();
     PubSubPosition decoded =


### PR DESCRIPTION
## [server][dvc][test] Delete deprecated PubSubPositionDeserializer::getPositionFromWireFormat API

Remove the deprecated static `PubSubPositionDeserializer::getPositionFromWireFormat`
method to avoid accidental usage. This API only supported a limited set of default
position types, which could lead to incorrect behavior. Callers should instead use
a custom `PubSubPositionDeserializer` to handle all position types properly.

###  Code changes
- [ ] Added new code behind **a config**. If so list the config names and their default values in the PR description.
- [ ] Introduced new **log lines**. 
  - [ ] Confirmed if logs need to be **rate limited** to avoid excessive logging.

###  **Concurrency-Specific Checks**
Both reviewer and PR author to verify
- [ ] Code has **no race conditions** or **thread safety issues**.
- [ ] Proper **synchronization mechanisms** (e.g., `synchronized`, `RWLock`) are used where needed.
- [ ] No **blocking calls** inside critical sections that could lead to deadlocks or performance degradation.
- [ ] Verified **thread-safe collections** are used (e.g., `ConcurrentHashMap`, `CopyOnWriteArrayList`).
- [ ] Validated proper exception handling in multi-threaded code to avoid silent thread termination.


## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->

- [ ] New unit tests added.
- [ ] New integration tests added.
- [ ] Modified or extended existing tests.
- [ ] Verified backward compatibility (if applicable).

## Does this PR introduce any user-facing or breaking changes?
<!--  
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [ ] No. You can skip the rest of this section.
- [ ] Yes. Clearly explain the behavior change and its impact.