### PR TITLE
[controller] Check cluster specific multi-region configs for batch push eligibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,10 @@
 *.ipr
 *.iws
 *.log
+
+# Binary directories and files
+**/bin/
+
 *.project
 *.swp
 *.class

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/controller/server/TestAdminSparkWithMocks.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/controller/server/TestAdminSparkWithMocks.java
@@ -2,7 +2,6 @@ package com.linkedin.venice.controller.server;
 
 import static com.linkedin.venice.meta.Store.NON_EXISTING_VERSION;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.anyBoolean;
 import static org.mockito.Mockito.anyString;
 import static org.mockito.Mockito.doReturn;
@@ -233,7 +232,7 @@ public class TestAdminSparkWithMocks {
     doReturn(1).when(admin).getReplicationFactor(anyString(), anyString());
     doReturn(1).when(admin).calculateNumberOfPartitions(anyString(), anyString());
     doReturn(corpRegionKafka).when(admin).getKafkaBootstrapServers(anyBoolean());
-    doReturn(true).when(admin).whetherEnableBatchPushFromAdmin(anyString());
+    doReturn(true).when(admin).whetherEnableBatchPushFromAdmin(anyString(), anyString());
     doReturn(true).when(admin).isActiveActiveReplicationEnabledInAllRegion(clusterName, storeName, false);
     doReturn(corpRegionKafka).when(admin).getNativeReplicationKafkaBootstrapServerAddress(corpRegion);
     doReturn(emergencySourceRegionKafka).when(admin)

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/Admin.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/Admin.java
@@ -749,7 +749,7 @@ public interface Admin extends AutoCloseable, Closeable {
 
   void writeEndOfPush(String clusterName, String storeName, int versionNumber, boolean alsoWriteStartOfPush);
 
-  boolean whetherEnableBatchPushFromAdmin(String storeName);
+  boolean whetherEnableBatchPushFromAdmin(String clusterName, String storeName);
 
   /**
    * Provision a new set of ACL for a venice store and its associated kafka topic.

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceHelixAdmin.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceHelixAdmin.java
@@ -1648,12 +1648,13 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
    * @return {@code true} is the store is a participant system store or if Venice is running in single-region mode
    */
   @Override
-  public boolean whetherEnableBatchPushFromAdmin(String storeName) {
+  public boolean whetherEnableBatchPushFromAdmin(String clusterName, String storeName) {
     /*
      * Allow (empty) push to participant system store from child controller directly since participant stores are
      * independent in different fabrics (different data).
      */
-    return VeniceSystemStoreUtils.isParticipantStore(storeName) || !multiClusterConfigs.isMultiRegion();
+    return VeniceSystemStoreUtils.isParticipantStore(storeName)
+        || !multiClusterConfigs.getControllerConfig(clusterName).isMultiRegion();
   }
 
   /**

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceParentHelixAdmin.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceParentHelixAdmin.java
@@ -5114,7 +5114,7 @@ public class VeniceParentHelixAdmin implements Admin {
   }
 
   @Override
-  public boolean whetherEnableBatchPushFromAdmin(String storeName) {
+  public boolean whetherEnableBatchPushFromAdmin(String clusterName, String storeName) {
     /**
      * Batch push to Parent Cluster is always enabled.
      */

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/server/CreateVersion.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/server/CreateVersion.java
@@ -276,7 +276,7 @@ public class CreateVersion extends AbstractRoute {
     String storeName = request.getStoreName();
     PushType pushType = request.getPushType();
     // Check if requestTopicForPush can be handled by child controllers for the given store
-    if (!admin.whetherEnableBatchPushFromAdmin(storeName)) {
+    if (!admin.whetherEnableBatchPushFromAdmin(clusterName, storeName)) {
       throw new VeniceUnsupportedOperationException(
           request.getPushType().name(),
           "Please push data to Venice Parent Colo instead");
@@ -725,13 +725,13 @@ public class CreateVersion extends AbstractRoute {
         AdminSparkServer.validateParams(request, EMPTY_PUSH.getParams(), admin);
 
         String storeName = request.queryParams(NAME);
-        if (!admin.whetherEnableBatchPushFromAdmin(storeName)) {
+        clusterName = request.queryParams(CLUSTER);
+        if (!admin.whetherEnableBatchPushFromAdmin(clusterName, storeName)) {
           throw new VeniceUnsupportedOperationException(
               "EMPTY PUSH",
               "Please push data to Venice Parent Colo instead or use Aggregate mode if you are running Samza GF Job.");
         }
 
-        clusterName = request.queryParams(CLUSTER);
         String pushJobId = request.queryParams(PUSH_JOB_ID);
         int partitionNum = admin.calculateNumberOfPartitions(clusterName, storeName);
         int replicationFactor = admin.getReplicationFactor(clusterName, storeName);

--- a/services/venice-controller/src/test/java/com/linkedin/venice/controller/server/CreateVersionTest.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/controller/server/CreateVersionTest.java
@@ -184,7 +184,7 @@ public class CreateVersionTest {
   public void testRequestTopicForHybridIncPushEnabled(
       boolean isSeparateTopicEnabled,
       boolean pushToSeparateTopicEnabled) throws Exception {
-    doReturn(true).when(admin).whetherEnableBatchPushFromAdmin(STORE_NAME);
+    doReturn(true).when(admin).whetherEnableBatchPushFromAdmin(CLUSTER_NAME, STORE_NAME);
     doCallRealMethod().when(request).queryParamOrDefault(any(), any());
     doReturn(true).when(accessClient).isAllowlistUsers(certificate, STORE_NAME, HTTP_GET);
 
@@ -236,7 +236,7 @@ public class CreateVersionTest {
   // if it happens an ERROR should be returned on requestTopicForPushing with inc-push job type.
   @Test(description = "requestTopicForPushing should an ERROR when store is not in hybrid but inc-push is enabled")
   public void testRequestTopicForIncPushReturnsErrorWhenStoreIsNotHybridAndIncPushIsEnabled() throws Exception {
-    doReturn(true).when(admin).whetherEnableBatchPushFromAdmin(STORE_NAME);
+    doReturn(true).when(admin).whetherEnableBatchPushFromAdmin(CLUSTER_NAME, STORE_NAME);
     doCallRealMethod().when(request).queryParamOrDefault(any(), any());
     doReturn(true).when(accessClient).isAllowlistUsers(certificate, STORE_NAME, HTTP_GET);
 
@@ -298,7 +298,7 @@ public class CreateVersionTest {
     Optional<String> emergencySrcRegion = Optional.of("dc-1");
 
     doReturn("dc-0").when(admin).getRegionName();
-    doReturn(true).when(admin).whetherEnableBatchPushFromAdmin(STORE_NAME);
+    doReturn(true).when(admin).whetherEnableBatchPushFromAdmin(CLUSTER_NAME, STORE_NAME);
     doReturn(true).when(admin).isParent();
     doReturn(true).when(admin).isActiveActiveReplicationEnabledInAllRegion(any(), any(), anyBoolean());
     doReturn(store).when(admin).getStore(CLUSTER_NAME, STORE_NAME);
@@ -936,7 +936,7 @@ public class CreateVersionTest {
     Lazy<Boolean> isActiveActiveReplicationEnabledInAllRegions = Lazy.of(() -> true);
 
     // Mock admin methods
-    when(admin.whetherEnableBatchPushFromAdmin(storeName)).thenReturn(true);
+    when(admin.whetherEnableBatchPushFromAdmin(clusterName, storeName)).thenReturn(true);
     when(admin.calculateNumberOfPartitions(clusterName, storeName)).thenReturn(computedPartitionCount);
 
     Version version = mock(Version.class);
@@ -977,7 +977,7 @@ public class CreateVersionTest {
         "Expected compression strategy to be NO_OP.");
 
     // Case 2: Batch push is not enabled
-    when(admin.whetherEnableBatchPushFromAdmin(storeName)).thenReturn(false);
+    when(admin.whetherEnableBatchPushFromAdmin(clusterName, storeName)).thenReturn(false);
     VeniceUnsupportedOperationException ex1 = expectThrows(
         VeniceUnsupportedOperationException.class,
         () -> createVersion
@@ -1004,7 +1004,7 @@ public class CreateVersionTest {
             request.getTargetedRegions(),
             request.getRepushSourceVersion());
 
-    when(admin.whetherEnableBatchPushFromAdmin(storeName)).thenReturn(true);
+    when(admin.whetherEnableBatchPushFromAdmin(clusterName, storeName)).thenReturn(true);
     VeniceException ex2 = expectThrows(
         VeniceException.class,
         () -> createVersion
@@ -1020,7 +1020,7 @@ public class CreateVersionTest {
     when(request.queryParams(NAME)).thenReturn(STORE_NAME);
     when(request.queryParams(CLUSTER)).thenReturn(CLUSTER_NAME);
     when(request.queryParams(PUSH_JOB_ID)).thenReturn("pushJobId");
-    when(admin.whetherEnableBatchPushFromAdmin(STORE_NAME)).thenReturn(true);
+    when(admin.whetherEnableBatchPushFromAdmin(CLUSTER_NAME, STORE_NAME)).thenReturn(true);
     when(admin.getStore(CLUSTER_NAME, STORE_NAME)).thenReturn(null); // simulate missing store
 
     Object result = emptyPushRoute.handle(request, response);
@@ -1044,7 +1044,7 @@ public class CreateVersionTest {
     when(request.queryParams(PUSH_JOB_ID)).thenReturn("pushJobId");
 
     // Admin behavior
-    when(admin.whetherEnableBatchPushFromAdmin(STORE_NAME)).thenReturn(true);
+    when(admin.whetherEnableBatchPushFromAdmin(CLUSTER_NAME, STORE_NAME)).thenReturn(true);
     when(admin.calculateNumberOfPartitions(CLUSTER_NAME, STORE_NAME)).thenReturn(2);
     when(admin.getReplicationFactor(CLUSTER_NAME, STORE_NAME)).thenReturn(3);
 
@@ -1083,7 +1083,7 @@ public class CreateVersionTest {
     when(request.queryParams(PUSH_JOB_ID)).thenReturn("pushJobId");
 
     // Admin config
-    when(admin.whetherEnableBatchPushFromAdmin(STORE_NAME)).thenReturn(true);
+    when(admin.whetherEnableBatchPushFromAdmin(CLUSTER_NAME, STORE_NAME)).thenReturn(true);
     when(admin.calculateNumberOfPartitions(CLUSTER_NAME, STORE_NAME)).thenReturn(2);
     when(admin.getReplicationFactor(CLUSTER_NAME, STORE_NAME)).thenReturn(3);
 


### PR DESCRIPTION
## Problem Statement
Currently controller is picking configs from a random cluster when checking push job eligibility.


## Solution
This PR fixed the issue by specifying the right cluster name when retrieving configs.


###  Code changes
- [ ] Added new code behind **a config**. If so list the config names and their default values in the PR description.
- [ ] Introduced new **log lines**. 
  - [ ] Confirmed if logs need to be **rate limited** to avoid excessive logging.

###  **Concurrency-Specific Checks**
Both reviewer and PR author to verify
- [ ] Code has **no race conditions** or **thread safety issues**.
- [ ] Proper **synchronization mechanisms** (e.g., `synchronized`, `RWLock`) are used where needed.
- [ ] No **blocking calls** inside critical sections that could lead to deadlocks or performance degradation.
- [ ] Verified **thread-safe collections** are used (e.g., `ConcurrentHashMap`, `CopyOnWriteArrayList`).
- [ ] Validated proper exception handling in multi-threaded code to avoid silent thread termination.


## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->

- [ ] New unit tests added.
- [ ] New integration tests added.
- [x] Modified or extended existing tests.
- [ ] Verified backward compatibility (if applicable).

## Does this PR introduce any user-facing or breaking changes?
<!--  
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [ ] No. You can skip the rest of this section.
- [ ] Yes. Clearly explain the behavior change and its impact.