### PR TITLE
[admin-tool][compat] Remove D2 usage from Admin tool

### DIFF
--- a/clients/venice-admin-tool/src/test/java/com/linkedin/venice/TestCheckMigrationStatus.java
+++ b/clients/venice-admin-tool/src/test/java/com/linkedin/venice/TestCheckMigrationStatus.java
@@ -40,7 +40,6 @@ public class TestCheckMigrationStatus {
     mockMultiStoreResponse.setStores(new String[] { SYSTEM_STORE_NAME, STORE_NAME });
     ChildAwareResponse mockChildAwareResponse = Mockito.mock(ChildAwareResponse.class);
     Mockito.when(mockChildAwareResponse.getChildDataCenterControllerUrlMap()).thenReturn(new HashMap<>());
-    Mockito.when(mockChildAwareResponse.getChildDataCenterControllerD2Map()).thenReturn(new HashMap<>());
     Mockito.when(mockSourceControllerClient.listChildControllers(SRC_CLUSTER_NAME)).thenReturn(mockChildAwareResponse);
     Mockito.when(mockStoreResponse.getStore()).thenReturn(mockStoreInfo);
     Mockito.when(mockSourceControllerClient.getStore(STORE_NAME)).thenReturn(mockStoreResponse);


### PR DESCRIPTION
<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat], [protocol]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## Problem Statement
<!--
Describe
- What problem are you trying to solve
- What issues or limitations exist in the current code
- Why this change is necessary 
-->
We are migrating away from using D2 for controller and will rely on URL-routing and DNS-based service discovery. This change removes D2 usage from Admin tool

## Solution
<!--
Describe
- What changes you are making and why. 
- How these changes solve the problem.
- Any performance considerations or trade-offs. 
- Describe what testings you have done, for example, performance testing etc.
-->
This change removes D2 usage from Admin tool

###  Code changes
- [ ] Added new code behind **a config**. If so list the config names and their default values in the PR description.
- [ ] Introduced new **log lines**. 
  - [ ] Confirmed if logs need to be **rate limited** to avoid excessive logging.

###  **Concurrency-Specific Checks**
Both reviewer and PR author to verify
- [x] Code has **no race conditions** or **thread safety issues**.
- [x] Proper **synchronization mechanisms** (e.g., `synchronized`, `RWLock`) are used where needed.
- [x] No **blocking calls** inside critical sections that could lead to deadlocks or performance degradation.
- [x] Verified **thread-safe collections** are used (e.g., `ConcurrentHashMap`, `CopyOnWriteArrayList`).
- [x] Validated proper exception handling in multi-threaded code to avoid silent thread termination.


## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->

- [ ] New unit tests added.
- [ ] New integration tests added.
- [ ] Modified or extended existing tests.
- [x] Verified backward compatibility (if applicable).

## Does this PR introduce any user-facing or breaking changes?
<!--  
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [ ] No. You can skip the rest of this section.
- [X] Yes. Clearly explain the behavior change and its impact.
    - Some admin tool commands will not work with Venice setups that only use D2 to communicate from Parent to Child controllers 