### PR TITLE
[server] Fallback to offset if PubSubPosition is lower to avoid duplicate work

### DIFF
--- a/internal/venice-common/src/main/java/com/linkedin/venice/offsets/OffsetRecord.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/offsets/OffsetRecord.java
@@ -2,6 +2,7 @@ package com.linkedin.venice.offsets;
 
 import static com.linkedin.venice.pubsub.PubSubUtil.fromKafkaOffset;
 
+import com.linkedin.venice.annotation.VisibleForTesting;
 import com.linkedin.venice.exceptions.VeniceException;
 import com.linkedin.venice.guid.GuidUtils;
 import com.linkedin.venice.kafka.protocol.GUID;
@@ -492,30 +493,52 @@ public class OffsetRecord {
   }
 
   /**
-   * Deserializes a PubSubPosition from a ByteBuffer with fallback to offset-based position.
+   * Best-effort deserialization of a {@code PubSubPosition} with an explicit offset fallback.
    *
-   * This method attempts to deserialize a PubSubPosition from the provided ByteBuffer using
-   * the configured pubSubPositionDeserializer. If the buffer is null, empty, or deserialization
-   * fails for any reason, it falls back to creating a position based solely on the provided
-   * numeric offset.
+   * <p>Behavior:
+   * <ul>
+   *   <li>If {@code wireFormatBytes} is {@code null} or has no remaining bytes, returns a position from {@code offset}.</li>
+   *   <li>Otherwise, tries to deserialize using {@code pubSubPositionDeserializer}.</li>
+   *   <li>If deserialization throws or yields a position whose numeric offset is less than {@code offset},
+   *       returns a position from {@code offset}.</li>
+   *   <li>On success, returns the deserialized position.</li>
+   * </ul>
    *
-   * @param wireFormatBytes the ByteBuffer containing serialized position data, may be null
-   * @param offset the numeric offset to use as fallback if deserialization fails
-   * @return a PubSubPosition either deserialized from the buffer or created from the offset
+   * <p>The second parameter is required because callers often know a minimum offset that must not be
+   * regressed. Keeping it explicit makes the fallback rule obvious at the call site.</p>
+   *
+   * @param wireFormatBytes byte buffer with serialized position data, may be {@code null}.
+   *                        The buffer is not consumed (a sliced view is used).
+   * @param offset          minimum numeric offset to use if deserialization fails or regresses
+   * @return a {@code PubSubPosition} from the buffer if valid, otherwise derived from {@code offset}
    */
-  private PubSubPosition deserializePositionWithOffsetFallback(ByteBuffer wireFormatBytes, long offset) {
+  @VisibleForTesting
+  PubSubPosition deserializePositionWithOffsetFallback(ByteBuffer wireFormatBytes, long offset) {
+    // Fast path: nothing to deserialize
     if (wireFormatBytes == null || !wireFormatBytes.hasRemaining()) {
       return fromKafkaOffset(offset);
     }
+
     try {
-      return pubSubPositionDeserializer.toPosition(wireFormatBytes);
-    } catch (Exception e) {
+      final PubSubPosition position = pubSubPositionDeserializer.toPosition(wireFormatBytes);
+
+      // Guard against regressions: honor the caller-provided minimum offset.
+      if (position.getNumericOffset() < offset) {
+        LOGGER.info(
+            "Deserialized position: {} is behind the provided offset: {}. Using offset-based position.",
+            position.getNumericOffset(),
+            offset);
+        return fromKafkaOffset(offset);
+      }
+
+      return position;
+    } catch (RuntimeException e) {
       LOGGER.warn(
-          "Failed to deserialize PubSubPosition from buffer. Falling back to offset ({}) only position. Buffer: {}",
+          "Failed to deserialize PubSubPosition. Using offset-based position (offset={}, bufferRem={}, bufferCap={}).",
           offset,
-          wireFormatBytes,
+          wireFormatBytes.remaining(),
+          wireFormatBytes.capacity(),
           e);
-      // Fallback to offset only position
       return fromKafkaOffset(offset);
     }
   }

--- a/internal/venice-common/src/test/java/com/linkedin/venice/offsets/TestOffsetRecord.java
+++ b/internal/venice-common/src/test/java/com/linkedin/venice/offsets/TestOffsetRecord.java
@@ -3,19 +3,25 @@ package com.linkedin.venice.offsets;
 import static com.linkedin.venice.utils.TestUtils.DEFAULT_PUBSUB_CONTEXT_FOR_UNIT_TESTING;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertTrue;
 
 import com.linkedin.venice.kafka.protocol.GUID;
 import com.linkedin.venice.kafka.protocol.state.ProducerPartitionState;
 import com.linkedin.venice.pubsub.adapter.kafka.common.ApacheKafkaOffsetPosition;
 import com.linkedin.venice.pubsub.api.PubSubPosition;
+import com.linkedin.venice.pubsub.api.PubSubSymbolicPosition;
 import com.linkedin.venice.serialization.avro.AvroProtocolDefinition;
 import com.linkedin.venice.utils.TestUtils;
 import com.linkedin.venice.utils.concurrent.VeniceConcurrentHashMap;
+import java.nio.ByteBuffer;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
+import java.util.function.Supplier;
 import org.testng.Assert;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 
@@ -27,7 +33,8 @@ public class TestOffsetRecord {
   private ProducerPartitionState state;
   private String kafkaUrl;
 
-  TestOffsetRecord() {
+  @BeforeClass(alwaysRun = true)
+  public void setUp() {
     offsetRecord = new OffsetRecord(
         AvroProtocolDefinition.PARTITION_STATE.getSerializer(),
         DEFAULT_PUBSUB_CONTEXT_FOR_UNIT_TESTING);
@@ -104,5 +111,68 @@ public class TestOffsetRecord {
     // Verify that the state was removed correctly
     ProducerPartitionState result = offsetRecord.getRealTimeProducerState(kafkaUrl, guid);
     assertNull(result, "The state should be null after removal");
+  }
+
+  private static Supplier<ByteBuffer> buf(long offset) {
+    return () -> ApacheKafkaOffsetPosition.of(offset).toWireFormatBuffer();
+  }
+
+  private static Supplier<ByteBuffer> bytes(byte... arr) {
+    return () -> ByteBuffer.wrap(arr);
+  }
+
+  private static final Supplier<ByteBuffer> NULL_BUF = () -> null;
+  private static final Supplier<ByteBuffer> EMPTY_BUF = () -> ByteBuffer.allocate(0);
+  private static final Supplier<ByteBuffer> NO_REMAINING_BUF = () -> {
+    ByteBuffer b = ByteBuffer.wrap(new byte[] { 1, 2, 3 });
+    b.position(3);
+    return b;
+  };
+  private static final Supplier<ByteBuffer> LATEST_BUF = PubSubSymbolicPosition.LATEST::toWireFormatBuffer;
+  private static final Supplier<ByteBuffer> EARLIEST_BUF = PubSubSymbolicPosition.EARLIEST::toWireFormatBuffer;
+
+  @DataProvider(name = "dpDeserialize", parallel = true)
+  public Object[][] dpDeserialize() {
+    return new Object[][] {
+        // name, bufferSupplier, offset, expectedNumeric, expectApacheKafka
+        { "valid>offset", buf(1000), 500L, 1000L, true }, { "valid==offset", buf(1000), 1000L, 1000L, true },
+        { "valid>offset_2k_vs1.5k", buf(2000), 1500L, 2000L, true }, { "regress_behind", buf(500), 1000L, 1000L, true },
+        { "regress_far", buf(500), 2000L, 2000L, true }, { "zero_vs_100", buf(0), 100L, 100L, true },
+        { "null_bytes", NULL_BUF, 1500L, 1500L, true }, { "empty_bytes", EMPTY_BUF, 2500L, 2500L, true },
+        { "no_remaining", NO_REMAINING_BUF, 3500L, 3500L, true },
+        { "malformed_fffe", bytes((byte) 0xFF, (byte) 0xFE, (byte) 0xFD), 4000L, 4000L, true },
+        { "corrupted_short_seq", bytes((byte) 0xFF, (byte) 0xFE, (byte) 0xFD), 5000L, 5000L, true },
+        { "invalid_length", bytes((byte) 0xFF), 6000L, 6000L, true },
+        { "max_long_offset", NULL_BUF, Long.MAX_VALUE, Long.MAX_VALUE, true },
+        { "zero_offset_valid_pos", buf(1000), 0L, 1000L, true }, { "negative_offset", NULL_BUF, -1L, -1L, false },
+        { "EARLIEST_vs_1000", EARLIEST_BUF, 1000L, 1000L, true },
+        { "LATEST_vs_1000", LATEST_BUF, 1000L, Long.MAX_VALUE, false },
+        { "LATEST_vs_max-1", LATEST_BUF, Long.MAX_VALUE - 1, Long.MAX_VALUE, false },
+        // Consistency checks (same inputs twice)
+        { "consistency_sameA", buf(1000), 500L, 1000L, true }, { "consistency_sameB", buf(1000), 500L, 1000L, true },
+        // Consistency fallback paths equivalence
+        { "consistency_fallback_null", NULL_BUF, 1500L, 1500L, true },
+        { "consistency_fallback_empty", EMPTY_BUF, 1500L, 1500L, true }, };
+  }
+
+  @Test(dataProvider = "dpDeserialize", timeOut = 30_000)
+  public void testDeserializePositionWithOffsetFallback(
+      String name,
+      Supplier<ByteBuffer> bufferSupplier,
+      long offset,
+      long expectedNumeric,
+      boolean expectApacheKafka) {
+    PubSubPosition result = offsetRecord.deserializePositionWithOffsetFallback(bufferSupplier.get(), offset);
+    if (expectApacheKafka) {
+      assertTrue(result instanceof ApacheKafkaOffsetPosition, name + ": expected AK position");
+      assertEquals(
+          ((ApacheKafkaOffsetPosition) result).getInternalOffset(),
+          expectedNumeric,
+          name + ": numeric mismatch");
+    } else if (expectedNumeric == -1L) {
+      assertEquals(result, PubSubSymbolicPosition.EARLIEST, name + ": expected EARLIEST");
+    } else {
+      assertEquals(result, PubSubSymbolicPosition.LATEST, name + ": expected LATEST");
+    }
   }
 }

--- a/internal/venice-common/src/test/java/com/linkedin/venice/offsets/TestOffsetRecord.java
+++ b/internal/venice-common/src/test/java/com/linkedin/venice/offsets/TestOffsetRecord.java
@@ -155,7 +155,7 @@ public class TestOffsetRecord {
         { "consistency_fallback_empty", EMPTY_BUF, 1500L, 1500L, true }, };
   }
 
-  @Test(dataProvider = "dpDeserialize", timeOut = 30_000)
+  @Test(dataProvider = "dpDeserialize", timeOut = 10_000)
   public void testDeserializePositionWithOffsetFallback(
       String name,
       Supplier<ByteBuffer> bufferSupplier,


### PR DESCRIPTION
## [server] Fallback to offset if PubSubPosition is lower to avoid duplicate work  

If a deserialized PubSubPosition is behind the provided offset, fall back to the  
offset value instead. Ideally this situation should not occur, but this is added  
as extremely defensive coding to prevent duplicate processing.  

###  Code changes
- [ ] Added new code behind **a config**. If so list the config names and their default values in the PR description.
- [ ] Introduced new **log lines**. 
  - [ ] Confirmed if logs need to be **rate limited** to avoid excessive logging.

###  **Concurrency-Specific Checks**
Both reviewer and PR author to verify
- [ ] Code has **no race conditions** or **thread safety issues**.
- [ ] Proper **synchronization mechanisms** (e.g., `synchronized`, `RWLock`) are used where needed.
- [ ] No **blocking calls** inside critical sections that could lead to deadlocks or performance degradation.
- [ ] Verified **thread-safe collections** are used (e.g., `ConcurrentHashMap`, `CopyOnWriteArrayList`).
- [ ] Validated proper exception handling in multi-threaded code to avoid silent thread termination.


## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->

- [ ] New unit tests added.
- [ ] New integration tests added.
- [ ] Modified or extended existing tests.
- [ ] Verified backward compatibility (if applicable).

## Does this PR introduce any user-facing or breaking changes?
<!--  
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [ ] No. You can skip the rest of this section.
- [ ] Yes. Clearly explain the behavior change and its impact.