### PR TITLE
[server] Add InactiveTopicPartitionChecker to pause/resume inactive topic partition periodically

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/config/VeniceServerConfig.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/config/VeniceServerConfig.java
@@ -1124,7 +1124,7 @@ public class VeniceServerConfig extends VeniceClusterConfig {
     this.inactiveTopicPartitionCheckerInternalInSeconds =
         serverProperties.getInt(SERVER_INACTIVE_TOPIC_PARTITION_CHECKER_INTERNAL_IN_SECONDS, 60);
     this.inactiveTopicPartitionCheckerThresholdInSeconds =
-        serverProperties.getInt(SERVER_INACTIVE_TOPIC_PARTITION_CHECKER_THRESHOLD_IN_SECONDS, 10);
+        serverProperties.getInt(SERVER_INACTIVE_TOPIC_PARTITION_CHECKER_THRESHOLD_IN_SECONDS, 5);
   }
 
   List<Double> extractThrottleLimitFactorsFor(VeniceProperties serverProperties, String configKey) {

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/config/VeniceServerConfig.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/config/VeniceServerConfig.java
@@ -1121,8 +1121,9 @@ public class VeniceServerConfig extends VeniceClusterConfig {
     this.keyUrnCompressionEnabled = serverProperties.getBoolean(KEY_URN_COMPRESSION_ENABLED, false);
     this.inactiveTopicPartitionCheckerEnabled =
         serverProperties.getBoolean(SERVER_INACTIVE_TOPIC_PARTITION_CHECKER_ENABLED, false);
+    // Default value is 100 seconds to make sure it has different frequency as the heartbeat message frequency.
     this.inactiveTopicPartitionCheckerInternalInSeconds =
-        serverProperties.getInt(SERVER_INACTIVE_TOPIC_PARTITION_CHECKER_INTERNAL_IN_SECONDS, 60);
+        serverProperties.getInt(SERVER_INACTIVE_TOPIC_PARTITION_CHECKER_INTERNAL_IN_SECONDS, 100);
     this.inactiveTopicPartitionCheckerThresholdInSeconds =
         serverProperties.getInt(SERVER_INACTIVE_TOPIC_PARTITION_CHECKER_THRESHOLD_IN_SECONDS, 5);
   }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/config/VeniceServerConfig.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/config/VeniceServerConfig.java
@@ -115,6 +115,9 @@ import static com.linkedin.venice.ConfigKeys.SERVER_HTTP2_MAX_CONCURRENT_STREAMS
 import static com.linkedin.venice.ConfigKeys.SERVER_HTTP2_MAX_FRAME_SIZE;
 import static com.linkedin.venice.ConfigKeys.SERVER_HTTP2_MAX_HEADER_LIST_SIZE;
 import static com.linkedin.venice.ConfigKeys.SERVER_IDLE_INGESTION_TASK_CLEANUP_INTERVAL_IN_SECONDS;
+import static com.linkedin.venice.ConfigKeys.SERVER_INACTIVE_TOPIC_PARTITION_CHECKER_ENABLED;
+import static com.linkedin.venice.ConfigKeys.SERVER_INACTIVE_TOPIC_PARTITION_CHECKER_INTERNAL_IN_SECONDS;
+import static com.linkedin.venice.ConfigKeys.SERVER_INACTIVE_TOPIC_PARTITION_CHECKER_THRESHOLD_IN_SECONDS;
 import static com.linkedin.venice.ConfigKeys.SERVER_INCREMENTAL_PUSH_STATUS_WRITE_MODE;
 import static com.linkedin.venice.ConfigKeys.SERVER_INGESTION_CHECKPOINT_DURING_GRACEFUL_SHUTDOWN_ENABLED;
 import static com.linkedin.venice.ConfigKeys.SERVER_INGESTION_HEARTBEAT_INTERVAL_MS;
@@ -656,6 +659,10 @@ public class VeniceServerConfig extends VeniceClusterConfig {
   private final IngestionTaskReusableObjects.Strategy ingestionTaskReusableObjectsStrategy;
   private final boolean keyUrnCompressionEnabled;
 
+  private final boolean inactiveTopicPartitionCheckerEnabled;
+  private final int inactiveTopicPartitionCheckerInternalInSeconds;
+  private final int inactiveTopicPartitionCheckerThresholdInSeconds;
+
   public VeniceServerConfig(VeniceProperties serverProperties) throws ConfigurationException {
     this(serverProperties, Collections.emptyMap());
   }
@@ -1112,6 +1119,12 @@ public class VeniceServerConfig extends VeniceClusterConfig {
             IngestionTaskReusableObjects.Strategy.THREAD_LOCAL_PER_INGESTION_TASK.name()));
     this.validateSpecificSchemaEnabled = serverProperties.getBoolean(DAVINCI_VALIDATE_SPECIFIC_SCHEMA_ENABLED, true);
     this.keyUrnCompressionEnabled = serverProperties.getBoolean(KEY_URN_COMPRESSION_ENABLED, false);
+    this.inactiveTopicPartitionCheckerEnabled =
+        serverProperties.getBoolean(SERVER_INACTIVE_TOPIC_PARTITION_CHECKER_ENABLED, false);
+    this.inactiveTopicPartitionCheckerInternalInSeconds =
+        serverProperties.getInt(SERVER_INACTIVE_TOPIC_PARTITION_CHECKER_INTERNAL_IN_SECONDS, 60);
+    this.inactiveTopicPartitionCheckerThresholdInSeconds =
+        serverProperties.getInt(SERVER_INACTIVE_TOPIC_PARTITION_CHECKER_THRESHOLD_IN_SECONDS, 10);
   }
 
   List<Double> extractThrottleLimitFactorsFor(VeniceProperties serverProperties, String configKey) {
@@ -2005,5 +2018,17 @@ public class VeniceServerConfig extends VeniceClusterConfig {
 
   public boolean isKeyUrnCompressionEnabled() {
     return keyUrnCompressionEnabled;
+  }
+
+  public int getInactiveTopicPartitionCheckerInternalInSeconds() {
+    return inactiveTopicPartitionCheckerInternalInSeconds;
+  }
+
+  public int getInactiveTopicPartitionCheckerThresholdInSeconds() {
+    return inactiveTopicPartitionCheckerThresholdInSeconds;
+  }
+
+  public boolean isInactiveTopicPartitionCheckerEnabled() {
+    return inactiveTopicPartitionCheckerEnabled;
   }
 }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/InactiveTopicPartitionChecker.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/InactiveTopicPartitionChecker.java
@@ -1,0 +1,200 @@
+package com.linkedin.davinci.kafka.consumer;
+
+import com.linkedin.davinci.utils.IndexedMap;
+import com.linkedin.venice.pubsub.api.PubSubTopicPartition;
+import com.linkedin.venice.service.AbstractVeniceService;
+import com.linkedin.venice.utils.concurrent.VeniceConcurrentHashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+
+/**
+ * A service that monitors Kafka topic partitions for inactivity and automatically pauses/resumes them
+ * to prevent blocking of active topic partitions.
+ *
+ * <p>This checker runs periodically to:
+ * <ul>
+ *   <li>Identify topic partitions that haven't been successfully polled within a configured threshold</li>
+ *   <li>Pause inactive topic partitions to prevent them from blocking consumption of active topic partitions</li>
+ *   <li>Resume previously paused topic partitions that have become active again</li>
+ * </ul>
+ *
+ * <p>The service maintains state about which topic partitions are currently paused for each consumer
+ * and makes intelligent decisions about when to pause/resume based on the current activity status.
+ *
+ * <p>This is particularly useful in scenarios where some topic partitions may become temporarily
+ * unavailable or slow, preventing the consumer from making progress on other healthy topic partitions.
+ *
+ * <p>The checker uses per-topic-partition statistics from {@link ConsumptionTask} to determine activity,
+ * specifically looking at the last successful poll timestamp for each topic partition.
+ */
+public class InactiveTopicPartitionChecker extends AbstractVeniceService {
+  private static final Logger LOGGER = LogManager.getLogger(InactiveTopicPartitionChecker.class);
+
+  /** Map tracking which topic partitions are currently paused for each consumer */
+  private final Map<SharedKafkaConsumer, Set<PubSubTopicPartition>> consumerToPausedTopicPartitionsMap =
+      new VeniceConcurrentHashMap<>();
+
+  /** Map of consumers to their associated consumption tasks */
+  private final IndexedMap<SharedKafkaConsumer, ConsumptionTask> consumerToConsumptionTask;
+
+  /** Interval in milliseconds between inactive topic partition checks */
+  private final long inactiveTopicPartitionCheckIntervalInMs;
+
+  /** Threshold in milliseconds after which a topic partition is considered inactive */
+  private final long inactiveTopicPartitionThresholdInMs;
+
+  /** Executor service for scheduling periodic inactive topic partition checks */
+  private final ScheduledExecutorService executorService;
+
+  /**
+   * Creates a new InactiveTopicPartitionChecker.
+   *
+   * @param consumerToConsumptionTask map of consumers to their consumption tasks,
+   *                                  used to check topic partition activity status
+   * @param inactiveTopicPartitionCheckIntervalInSeconds how often to check for inactive topic partitions (in milliseconds)
+   * @param inactiveTopicPartitionThresholdInSeconds threshold after which a topic partition is considered inactive (in milliseconds)
+   */
+  public InactiveTopicPartitionChecker(
+      IndexedMap<SharedKafkaConsumer, ConsumptionTask> consumerToConsumptionTask,
+      long inactiveTopicPartitionCheckIntervalInSeconds,
+      long inactiveTopicPartitionThresholdInSeconds) {
+    this.consumerToConsumptionTask = consumerToConsumptionTask;
+    this.inactiveTopicPartitionCheckIntervalInMs =
+        TimeUnit.SECONDS.toMillis(inactiveTopicPartitionCheckIntervalInSeconds);
+    this.inactiveTopicPartitionThresholdInMs = TimeUnit.SECONDS.toMillis(inactiveTopicPartitionThresholdInSeconds);
+    this.executorService = Executors.newSingleThreadScheduledExecutor();
+  }
+
+  /**
+   * Starts the inactive topic partition checker service.
+   *
+   * <p>This method schedules a periodic task that will run every
+   * {@code inactiveTopicPartitionCheckIntervalInMs} milliseconds to check for
+   * and handle inactive topic partitions.
+   *
+   * @return true if the service started successfully
+   * @throws Exception if there's an error starting the service
+   */
+  @Override
+  public boolean startInner() throws Exception {
+    // Start the scheduled task to check inactive topic partitions
+    executorService.scheduleWithFixedDelay(
+        this::checkInactiveTopicPartition,
+        inactiveTopicPartitionCheckIntervalInMs,
+        inactiveTopicPartitionCheckIntervalInMs,
+        TimeUnit.MICROSECONDS);
+    return true;
+  }
+
+  /**
+   * Stops the inactive topic partition checker service.
+   *
+   * <p>This method gracefully shuts down the scheduled executor service,
+   * waiting up to 5 seconds for running tasks to complete before forcing shutdown.
+   *
+   * @throws Exception if there's an error stopping the service
+   */
+  @Override
+  public void stopInner() throws Exception {
+    if (executorService != null && !executorService.isShutdown()) {
+      executorService.shutdown();
+      try {
+        if (!executorService.awaitTermination(5, TimeUnit.SECONDS)) {
+          executorService.shutdownNow();
+        }
+      } catch (InterruptedException e) {
+        executorService.shutdownNow();
+        Thread.currentThread().interrupt();
+      }
+    }
+  }
+
+  /**
+   * Checks for inactive topic partitions and handles them appropriately.
+   *
+   * <p>This method is called periodically by the scheduled executor service and performs
+   * the following operations for each consumer:
+   *
+   * <ol>
+   *   <li><b>Detection:</b> Identifies currently inactive topic partitions by comparing
+   *       the per-topic-partition last successful poll timestamp against the configured threshold.
+   *       Skips topic partitions that are already paused to avoid redundant checks.</li>
+   *   <li><b>Resume:</b> Resumes previously paused topic partitions that are no longer inactive</li>
+   *   <li><b>Pause:</b> Pauses newly detected inactive topic partitions and adds them to the tracking set</li>
+   * </ol>
+   *
+   * <p>A topic partition is considered inactive if:
+   * <ul>
+   *   <li>The time since its last successful poll exceeds {@code inactiveTopicPartitionThresholdInMs}</li>
+   *   <li>It has never been successfully polled (lastSuccessfulPollTimestamp == -1)</li>
+   * </ul>
+   *
+   * <p>The method includes comprehensive error handling to ensure that exceptions
+   * don't break the periodic execution schedule.
+   *
+   * <p><b>Note:</b> This implementation uses per-topic-partition statistics from {@link ConsumptionTask#getPartitionStats(PubSubTopicPartition)}
+   * to get accurate activity information for each topic partition individually, rather than using a global
+   * last poll timestamp for the entire consumer.
+   */
+  private void checkInactiveTopicPartition() {
+    try {
+      long currentTime = System.currentTimeMillis();
+
+      // Process each consumer: check for inactive topic-partitions, then pause/resume as needed
+      for (Map.Entry<SharedKafkaConsumer, ConsumptionTask> entry: consumerToConsumptionTask.entrySet()) {
+        SharedKafkaConsumer consumer = entry.getKey();
+        ConsumptionTask task = entry.getValue();
+        Set<PubSubTopicPartition> previouslyPausedTopicPartitions =
+            consumerToPausedTopicPartitionsMap.computeIfAbsent(consumer, x -> new HashSet<>());
+        Set<PubSubTopicPartition> assignedTopicPartitions = consumer.getAssignment();
+        Set<PubSubTopicPartition> currentlyInactiveTopicPartitions = new HashSet<>();
+
+        // Step 1: Check all assigned topic-partitions for inactivity and collect currently inactive ones
+        for (PubSubTopicPartition topicPartition: assignedTopicPartitions) {
+          if (previouslyPausedTopicPartitions.contains(topicPartition)) {
+            continue;
+          }
+          long lastSuccessfulPollTimestamp = task.getPartitionStats(topicPartition).getLastSuccessfulPollTimestamp();
+          long timeSinceLastPoll = currentTime - lastSuccessfulPollTimestamp;
+          if (lastSuccessfulPollTimestamp == -1 || timeSinceLastPoll > inactiveTopicPartitionThresholdInMs) {
+            currentlyInactiveTopicPartitions.add(topicPartition);
+            LOGGER.warn(
+                "Detected inactive topic partition: {} for consumer task: {}. Time since last poll: {} ms, threshold: {} ms",
+                topicPartition,
+                task.getTaskIdStr(),
+                timeSinceLastPoll,
+                inactiveTopicPartitionThresholdInMs);
+          }
+        }
+
+        // Step 2: Resume topic-partitions that are no longer inactive
+        for (PubSubTopicPartition topicPartition: previouslyPausedTopicPartitions) {
+          if (!currentlyInactiveTopicPartitions.contains(topicPartition)) {
+            consumer.resume(topicPartition);
+            LOGGER.info("Resumed previously paused topic partition {} for consumer", topicPartition);
+          }
+        }
+
+        // Step 3: Pause newly inactive topic-partitions
+        for (PubSubTopicPartition topicPartition: currentlyInactiveTopicPartitions) {
+          if (!previouslyPausedTopicPartitions.contains(topicPartition)) {
+            consumer.pause(topicPartition);
+            LOGGER.warn("Paused inactive topic partition {} for consumer", topicPartition);
+          }
+          previouslyPausedTopicPartitions.add(topicPartition);
+        }
+      }
+
+    } catch (Exception e) {
+      // Log the exception to avoid breaking the scheduled execution
+      LOGGER.warn("Error during inactive topic partition check: {}", e.getMessage(), e);
+    }
+  }
+}

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/InactiveTopicPartitionChecker.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/InactiveTopicPartitionChecker.java
@@ -89,7 +89,7 @@ public class InactiveTopicPartitionChecker extends AbstractVeniceService {
         this::checkInactiveTopicPartition,
         getInactiveTopicPartitionCheckIntervalInMs(),
         getInactiveTopicPartitionCheckIntervalInMs(),
-        TimeUnit.MICROSECONDS);
+        TimeUnit.MILLISECONDS);
     return true;
   }
 
@@ -156,6 +156,10 @@ public class InactiveTopicPartitionChecker extends AbstractVeniceService {
         Set<PubSubTopicPartition> assignedTopicPartitions = consumer.getAssignment();
         Set<PubSubTopicPartition> currentlyInactiveTopicPartitions = new HashSet<>();
 
+        LOGGER.info(
+            "Checking inactive topic partition for consumer task: {} with current assignments: {}",
+            task.getTaskIdStr(),
+            assignedTopicPartitions);
         // Step 1: Check all assigned topic-partitions for inactivity and collect currently inactive ones
         for (PubSubTopicPartition topicPartition: assignedTopicPartitions) {
           if (previouslyPausedTopicPartitions.contains(topicPartition)) {

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/KafkaConsumerService.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/KafkaConsumerService.java
@@ -93,6 +93,7 @@ public abstract class KafkaConsumerService extends AbstractKafkaConsumerService 
       new RedundantExceptionFilter(8 * 1024 * 1024 * 4, TimeUnit.MINUTES.toMillis(10));
   private final VeniceServerConfig serverConfig;
   protected final ConsumerPollTracker consumerPollTracker;
+  protected final InactiveTopicPartitionChecker inactiveTopicPartitionChecker;
 
   /**
    * @param statsOverride injection of stats, for test purposes
@@ -189,6 +190,15 @@ public abstract class KafkaConsumerService extends AbstractKafkaConsumerService 
       consumerToLocks.put(pubSubConsumer, new ReentrantLock());
     }
 
+    if (shouldEnableInactiveTopicPartitionChecker(serverConfig, poolType)) {
+      this.inactiveTopicPartitionChecker = new InactiveTopicPartitionChecker(
+          getConsumerToConsumptionTask(),
+          serverConfig.getInactiveTopicPartitionCheckerInternalInSeconds(),
+          serverConfig.getInactiveTopicPartitionCheckerThresholdInSeconds());
+      LOGGER.info("Created InactiveTopicPartitionChecker for consumer pool type: {}", poolType);
+    } else {
+      this.inactiveTopicPartitionChecker = null;
+    }
     LOGGER.info("KafkaConsumerService was initialized with {} consumers.", numOfConsumersPerKafkaCluster);
   }
 
@@ -473,6 +483,14 @@ public abstract class KafkaConsumerService extends AbstractKafkaConsumerService 
   @Override
   public Map<PubSubTopicPartition, Long> getStaleTopicPartitions(long thresholdTimestamp) {
     return consumerPollTracker.getStaleTopicPartitions(thresholdTimestamp);
+  }
+
+  boolean shouldEnableInactiveTopicPartitionChecker(VeniceServerConfig serverConfig, ConsumerPoolType poolType) {
+    if (!serverConfig.isInactiveTopicPartitionCheckerEnabled()) {
+      return false;
+    }
+    return (poolType.equals(ConsumerPoolType.CURRENT_VERSION_NON_AA_WC_LEADER_POOL)
+        || poolType.equals(ConsumerPoolType.CURRENT_VERSION_AA_WC_LEADER_POOL));
   }
 
   interface KCSConstructor {

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/KafkaConsumerService.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/KafkaConsumerService.java
@@ -335,12 +335,18 @@ public abstract class KafkaConsumerService extends AbstractKafkaConsumerService 
   public boolean startInner() {
     consumerToConsumptionTask.values().forEach(consumerExecutor::submit);
     consumerExecutor.shutdown();
+    if (inactiveTopicPartitionChecker != null) {
+      inactiveTopicPartitionChecker.start();
+    }
     LOGGER.info("KafkaConsumerService started for {}", kafkaUrl);
     return true;
   }
 
   @Override
   public void stopInner() throws Exception {
+    if (inactiveTopicPartitionChecker != null) {
+      inactiveTopicPartitionChecker.stop();
+    }
     consumerToConsumptionTask.values().forEach(ConsumptionTask::stop);
     long beginningTime = System.currentTimeMillis();
     boolean gracefulShutdownSuccess = consumerExecutor.awaitTermination(SHUTDOWN_TIMEOUT_IN_SECOND, TimeUnit.SECONDS);

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/InactiveTopicPartitionCheckerTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/InactiveTopicPartitionCheckerTest.java
@@ -22,7 +22,6 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import org.testng.Assert;
-import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
@@ -94,11 +93,6 @@ public class InactiveTopicPartitionCheckerTest {
 
     when(mockChecker.getInactiveTopicPartitionCheckIntervalInMs()).thenReturn(CHECK_INTERVAL_SECONDS);
     when(mockChecker.getInactiveTopicPartitionThresholdInMs()).thenReturn(THRESHOLD_MS);
-  }
-
-  @AfterMethod
-  public void tearDown() throws Exception {
-    // No cleanup needed for mock objects
   }
 
   @Test

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/InactiveTopicPartitionCheckerTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/InactiveTopicPartitionCheckerTest.java
@@ -1,0 +1,338 @@
+package com.linkedin.davinci.kafka.consumer;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doCallRealMethod;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+
+import com.linkedin.davinci.utils.IndexedHashMap;
+import com.linkedin.davinci.utils.IndexedMap;
+import com.linkedin.venice.pubsub.PubSubTopicPartitionImpl;
+import com.linkedin.venice.pubsub.PubSubTopicRepository;
+import com.linkedin.venice.pubsub.api.PubSubTopic;
+import com.linkedin.venice.pubsub.api.PubSubTopicPartition;
+import com.linkedin.venice.utils.concurrent.VeniceConcurrentHashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+import org.testng.Assert;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+
+public class InactiveTopicPartitionCheckerTest {
+  private static final long CHECK_INTERVAL_SECONDS = 1;
+  private static final long THRESHOLD_SECONDS = 5;
+  private static final long THRESHOLD_MS = TimeUnit.SECONDS.toMillis(THRESHOLD_SECONDS);
+
+  private InactiveTopicPartitionChecker mockChecker;
+  private IndexedMap<SharedKafkaConsumer, ConsumptionTask> consumerToTaskMap;
+  private Map<SharedKafkaConsumer, Set<PubSubTopicPartition>> pausedMaps;
+  private SharedKafkaConsumer mockConsumer1;
+  private SharedKafkaConsumer mockConsumer2;
+  private ConsumptionTask mockTask1;
+  private ConsumptionTask mockTask2;
+  private ConsumptionTask.PartitionStats mockPartitionStats1;
+  private ConsumptionTask.PartitionStats mockPartitionStats2;
+  private ConsumptionTask.PartitionStats mockPartitionStats3;
+
+  private PubSubTopicRepository topicRepository;
+  private PubSubTopic testTopic;
+  private PubSubTopicPartition partition1;
+  private PubSubTopicPartition partition2;
+  private PubSubTopicPartition partition3;
+
+  @BeforeMethod
+  public void setUp() {
+    // Initialize topic and partitions
+    topicRepository = new PubSubTopicRepository();
+    testTopic = topicRepository.getTopic("test_store_v1");
+    partition1 = new PubSubTopicPartitionImpl(testTopic, 0);
+    partition2 = new PubSubTopicPartitionImpl(testTopic, 1);
+    partition3 = new PubSubTopicPartitionImpl(testTopic, 2);
+
+    // Create mocks
+    mockConsumer1 = mock(SharedKafkaConsumer.class);
+    mockConsumer2 = mock(SharedKafkaConsumer.class);
+    mockTask1 = mock(ConsumptionTask.class);
+    mockTask2 = mock(ConsumptionTask.class);
+    mockPartitionStats1 = mock(ConsumptionTask.PartitionStats.class);
+    mockPartitionStats2 = mock(ConsumptionTask.PartitionStats.class);
+    mockPartitionStats3 = mock(ConsumptionTask.PartitionStats.class);
+
+    // Set up consumer to task mapping
+    consumerToTaskMap = new IndexedHashMap<>(2);
+    consumerToTaskMap.putByIndex(mockConsumer1, mockTask1, 0);
+    consumerToTaskMap.putByIndex(mockConsumer2, mockTask2, 1);
+
+    // Set up task IDs for logging
+    when(mockTask1.getTaskIdStr()).thenReturn("task-1");
+    when(mockTask2.getTaskIdStr()).thenReturn("task-2");
+
+    // Create a proper mock object using mock() with constructor initialization
+    // This creates a true mock object that has proper internal state and can call real methods
+    mockChecker = mock(InactiveTopicPartitionChecker.class);
+
+    // Configure the mock to call the real checkInactiveTopicPartition method using doCallRealMethod
+    doCallRealMethod().when(mockChecker).checkInactiveTopicPartition();
+
+    // Initialize pausedMaps for use by the mocked object
+    pausedMaps = new VeniceConcurrentHashMap<>();
+
+    // Configure mock to return pausedMaps when getConsumerToPausedTopicPartitionsMap() is called
+    when(mockChecker.getConsumerToPausedTopicPartitionsMap()).thenReturn(pausedMaps);
+
+    // Configure mock to return consumerToTaskMap when getConsumerToConsumptionTask() is called
+    when(mockChecker.getConsumerToConsumptionTask()).thenReturn(consumerToTaskMap);
+
+    when(mockChecker.getInactiveTopicPartitionCheckIntervalInMs()).thenReturn(CHECK_INTERVAL_SECONDS);
+    when(mockChecker.getInactiveTopicPartitionThresholdInMs()).thenReturn(THRESHOLD_MS);
+  }
+
+  @AfterMethod
+  public void tearDown() throws Exception {
+    // No cleanup needed for mock objects
+  }
+
+  @Test
+  public void testServiceStartAndStop() throws Exception {
+    // Create a real instance for lifecycle testing
+    InactiveTopicPartitionChecker realChecker =
+        new InactiveTopicPartitionChecker(consumerToTaskMap, CHECK_INTERVAL_SECONDS, THRESHOLD_SECONDS);
+
+    // Test service can start successfully
+    realChecker.start();
+    assertTrue(realChecker.isRunning());
+
+    // Test service can stop successfully
+    realChecker.stop();
+    assertFalse(realChecker.isRunning());
+  }
+
+  @Test
+  public void testNoPartitionsAssigned() {
+    // Setup: No partitions assigned to any consumer
+    when(mockConsumer1.getAssignment()).thenReturn(new HashSet<>());
+    when(mockConsumer2.getAssignment()).thenReturn(new HashSet<>());
+
+    // Execute the check method directly using spy to test the logic without starting the service
+    invokeCheckMethodDirectly();
+
+    // Verify: No pause or resume calls should be made
+    verify(mockConsumer1, never()).pause(any());
+    verify(mockConsumer1, never()).resume(any());
+    verify(mockConsumer2, never()).pause(any());
+    verify(mockConsumer2, never()).resume(any());
+  }
+
+  @Test
+  public void testActivePartitionsNotPaused() {
+    long currentTime = System.currentTimeMillis();
+    long recentPollTime = currentTime - (THRESHOLD_MS / 2); // Recent poll, should be active
+
+    // Setup: Consumer1 has one active partition
+    Set<PubSubTopicPartition> assignedPartitions = new HashSet<>();
+    assignedPartitions.add(partition1);
+    when(mockConsumer1.getAssignment()).thenReturn(assignedPartitions);
+    when(mockTask1.getPartitionStats(partition1)).thenReturn(mockPartitionStats1);
+    when(mockPartitionStats1.getLastSuccessfulPollTimestamp()).thenReturn(recentPollTime);
+
+    // Setup: Consumer2 has no partitions
+    when(mockConsumer2.getAssignment()).thenReturn(new HashSet<>());
+
+    // Execute
+    invokeCheckMethodDirectly();
+
+    // Verify: No partitions should be paused or resumed
+    verify(mockConsumer1, never()).pause(partition1);
+    verify(mockConsumer1, never()).resume(partition1);
+  }
+
+  @Test
+  public void testInactivePartitionsPaused() {
+    long currentTime = System.currentTimeMillis();
+    long oldPollTime = currentTime - (THRESHOLD_MS * 2); // Old poll, should be inactive
+
+    // Setup: Consumer1 has one inactive partition
+    Set<PubSubTopicPartition> assignedPartitions = new HashSet<>();
+    assignedPartitions.add(partition1);
+    when(mockConsumer1.getAssignment()).thenReturn(assignedPartitions);
+    when(mockTask1.getPartitionStats(partition1)).thenReturn(mockPartitionStats1);
+    when(mockPartitionStats1.getLastSuccessfulPollTimestamp()).thenReturn(oldPollTime);
+
+    // Setup: Consumer2 has no partitions
+    when(mockConsumer2.getAssignment()).thenReturn(new HashSet<>());
+
+    // Execute
+    invokeCheckMethodDirectly();
+
+    // Verify: Inactive partition should be paused
+    verify(mockConsumer1, times(1)).pause(partition1);
+    verify(mockConsumer1, never()).resume(partition1);
+  }
+
+  @Test
+  public void testNeverPolledPartitionsPaused() {
+    // Setup: Consumer1 has one partition that was never polled (timestamp = -1)
+    Set<PubSubTopicPartition> assignedPartitions = new HashSet<>();
+    assignedPartitions.add(partition1);
+    when(mockConsumer1.getAssignment()).thenReturn(assignedPartitions);
+    when(mockTask1.getPartitionStats(partition1)).thenReturn(mockPartitionStats1);
+    when(mockPartitionStats1.getLastSuccessfulPollTimestamp()).thenReturn(-1L);
+
+    // Setup: Consumer2 has no partitions
+    when(mockConsumer2.getAssignment()).thenReturn(new HashSet<>());
+
+    // Execute
+    invokeCheckMethodDirectly();
+
+    // Verify: Never-polled partition should be paused
+    verify(mockConsumer1, times(1)).pause(partition1);
+    verify(mockConsumer1, never()).resume(partition1);
+  }
+
+  @Test
+  public void testPreviouslyPausedPartitionsResumed() {
+    long currentTime = System.currentTimeMillis();
+    long recentPollTime = currentTime - (THRESHOLD_MS / 2); // Recent poll, should be active now
+
+    // Setup: Consumer1 has one partition that was previously paused but is now active
+    Set<PubSubTopicPartition> assignedPartitions = new HashSet<>();
+    assignedPartitions.add(partition1);
+    when(mockConsumer1.getAssignment()).thenReturn(assignedPartitions);
+    when(mockTask1.getPartitionStats(partition1)).thenReturn(mockPartitionStats1);
+    when(mockPartitionStats1.getLastSuccessfulPollTimestamp()).thenReturn(recentPollTime);
+
+    // Setup: Consumer2 has no partitions
+    when(mockConsumer2.getAssignment()).thenReturn(new HashSet<>());
+
+    // First execution: Simulate that partition1 was previously paused
+    // We need to manually add it to the paused partitions map
+    when(mockConsumer1.getAssignment()).thenReturn(assignedPartitions);
+
+    // Simulate the checker having previously paused this partition by calling the check twice
+    // First call: make it inactive to get it paused
+    when(mockPartitionStats1.getLastSuccessfulPollTimestamp()).thenReturn(currentTime - (THRESHOLD_MS * 2));
+    invokeCheckMethodDirectly();
+    verify(mockConsumer1, times(1)).pause(partition1);
+
+    // Second call: make it active again to get it resumed
+    invokeCheckMethodDirectly();
+
+    // Verify: Previously paused partition should be resumed
+    verify(mockConsumer1, times(1)).resume(partition1);
+  }
+
+  @Test
+  public void testMixedPartitionStates() {
+    long currentTime = System.currentTimeMillis();
+    long recentPollTime = currentTime - (THRESHOLD_MS / 2); // Active
+    long oldPollTime = currentTime - (THRESHOLD_MS * 2); // Inactive
+
+    // Setup: Consumer1 has multiple partitions with different states
+    Set<PubSubTopicPartition> assignedPartitions = new HashSet<>();
+    assignedPartitions.add(partition1); // Will be active
+    assignedPartitions.add(partition2); // Will be inactive
+    assignedPartitions.add(partition3); // Will be never polled
+
+    when(mockConsumer1.getAssignment()).thenReturn(assignedPartitions);
+    when(mockTask1.getPartitionStats(partition1)).thenReturn(mockPartitionStats1);
+    when(mockTask1.getPartitionStats(partition2)).thenReturn(mockPartitionStats2);
+    when(mockTask1.getPartitionStats(partition3)).thenReturn(mockPartitionStats3);
+
+    when(mockPartitionStats1.getLastSuccessfulPollTimestamp()).thenReturn(recentPollTime); // Active
+    when(mockPartitionStats2.getLastSuccessfulPollTimestamp()).thenReturn(oldPollTime); // Inactive
+    when(mockPartitionStats3.getLastSuccessfulPollTimestamp()).thenReturn(-1L); // Never polled
+
+    // Setup: Consumer2 has no partitions
+    when(mockConsumer2.getAssignment()).thenReturn(new HashSet<>());
+
+    // Execute
+    invokeCheckMethodDirectly();
+
+    // Verify: Only inactive partitions should be paused
+    verify(mockConsumer1, never()).pause(partition1); // Active, should not be paused
+    verify(mockConsumer1, times(1)).pause(partition2); // Inactive, should be paused
+    verify(mockConsumer1, times(1)).pause(partition3); // Never polled, should be paused
+
+    verify(mockConsumer1, never()).resume(any()); // No previously paused partitions
+  }
+
+  @Test
+  public void testSkipAlreadyPausedPartitions() {
+    long currentTime = System.currentTimeMillis();
+    long oldPollTime = currentTime - (THRESHOLD_MS * 2); // Inactive
+
+    // Setup: Consumer1 has one partition
+    Set<PubSubTopicPartition> assignedPartitions = new HashSet<>();
+    assignedPartitions.add(partition1);
+    when(mockConsumer1.getAssignment()).thenReturn(assignedPartitions);
+    when(mockTask1.getPartitionStats(partition1)).thenReturn(mockPartitionStats1);
+    when(mockPartitionStats1.getLastSuccessfulPollTimestamp()).thenReturn(oldPollTime);
+    Set<PubSubTopicPartition> pausedPartitions = new HashSet<>();
+    pausedPartitions.add(partition1);
+    pausedMaps.put(mockConsumer1, pausedPartitions);
+
+    // Setup: Consumer2 has no partitions
+    when(mockConsumer2.getAssignment()).thenReturn(new HashSet<>());
+
+    // First execution: Partition should be paused
+    invokeCheckMethodDirectly();
+    verify(mockConsumer1, never()).pause(partition1);
+    Assert.assertTrue(pausedPartitions.isEmpty());
+
+    // Second execution: Partition should be skipped (already paused)
+    // The partition stats check should not be called for already paused partitions
+    invokeCheckMethodDirectly();
+
+    // Verify: pause should only be called once (from first execution)
+    verify(mockConsumer1, times(1)).pause(partition1);
+  }
+
+  @Test
+  public void testMultipleConsumers() {
+    long currentTime = System.currentTimeMillis();
+    long recentPollTime = currentTime - (THRESHOLD_MS / 2); // Active
+    long oldPollTime = currentTime - (THRESHOLD_MS * 2); // Inactive
+
+    // Setup: Consumer1 has one active partition
+    Set<PubSubTopicPartition> assignedPartitions1 = new HashSet<>();
+    assignedPartitions1.add(partition1);
+    when(mockConsumer1.getAssignment()).thenReturn(assignedPartitions1);
+    when(mockTask1.getPartitionStats(partition1)).thenReturn(mockPartitionStats1);
+    when(mockPartitionStats1.getLastSuccessfulPollTimestamp()).thenReturn(recentPollTime);
+
+    // Setup: Consumer2 has one inactive partition
+    Set<PubSubTopicPartition> assignedPartitions2 = new HashSet<>();
+    assignedPartitions2.add(partition2);
+    when(mockConsumer2.getAssignment()).thenReturn(assignedPartitions2);
+    when(mockTask2.getPartitionStats(partition2)).thenReturn(mockPartitionStats2);
+    when(mockPartitionStats2.getLastSuccessfulPollTimestamp()).thenReturn(oldPollTime);
+
+    // Execute
+    invokeCheckMethodDirectly();
+
+    // Verify: Only consumer2's inactive partition should be paused
+    verify(mockConsumer1, never()).pause(any());
+    verify(mockConsumer1, never()).resume(any());
+    verify(mockConsumer2, times(1)).pause(partition2);
+    verify(mockConsumer2, never()).resume(any());
+  }
+
+  /**
+   * Helper method to invoke the checkInactiveTopicPartition method directly on the mock object
+   * This calls the real method implementation using doCallRealMethod approach
+   */
+  private void invokeCheckMethodDirectly() {
+    // Since checkInactiveTopicPartition is package-private, we can call it directly
+    // The mock is configured with doCallRealMethod() so it will execute the real logic
+    mockChecker.checkInactiveTopicPartition();
+  }
+}

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/KafkaConsumerServiceTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/KafkaConsumerServiceTest.java
@@ -452,4 +452,21 @@ public class KafkaConsumerServiceTest {
     // Verify that the getStackTrace method was called once for t.
     verify(t, times(1)).getStackTrace();
   }
+
+  @Test
+  public void testInactiveTopicPartitionChecker() {
+    KafkaConsumerService consumerService = mock(KafkaConsumerService.class);
+    doCallRealMethod().when(consumerService).shouldEnableInactiveTopicPartitionChecker(any(), any());
+    VeniceServerConfig serverConfig = mock(VeniceServerConfig.class);
+    for (int i = 0; i < 2; i++) {
+      boolean configEnabled = (i == 0);
+      doReturn(configEnabled).when(serverConfig).isInactiveTopicPartitionCheckerEnabled();
+      for (ConsumerPoolType poolType: ConsumerPoolType.values()) {
+        boolean expected = configEnabled && (poolType.equals(ConsumerPoolType.CURRENT_VERSION_AA_WC_LEADER_POOL)
+            || poolType.equals(ConsumerPoolType.CURRENT_VERSION_NON_AA_WC_LEADER_POOL));
+        Assert
+            .assertEquals(expected, consumerService.shouldEnableInactiveTopicPartitionChecker(serverConfig, poolType));
+      }
+    }
+  }
 }

--- a/internal/venice-common/src/main/java/com/linkedin/venice/ConfigKeys.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/ConfigKeys.java
@@ -2647,6 +2647,15 @@ public class ConfigKeys {
   public static final String SERVER_LOAD_CONTROLLER_COMPUTE_LATENCY_ACCEPT_THRESHOLD_IN_MS =
       "server.load.controller.compute.latency.accept.threshold.in.ms";
 
+  public static final String SERVER_INACTIVE_TOPIC_PARTITION_CHECKER_ENABLED =
+      "server.inactive.topic.partition.checker.enabled";
+
+  public static final String SERVER_INACTIVE_TOPIC_PARTITION_CHECKER_INTERNAL_IN_SECONDS =
+      "server.inactive.topic.partition.checker.internal.in.seconds";
+
+  public static final String SERVER_INACTIVE_TOPIC_PARTITION_CHECKER_THRESHOLD_IN_SECONDS =
+      "server.inactive.topic.partition.checker.threshold.in.seconds";
+
   /**
    * Whether to enable producer throughput optimization for realtime workload or not.
    * Two strategies:


### PR DESCRIPTION
## [server] Add InactiveTopicPartitionChecker to pause/resume inactive topic partition periodically
We observed that when two topic-partitions with the same leader Kafka broker are assigned to the same consumer, if one is idle, it may impact fetch performance of the other topic-partition.

To address this issue, a few ideas have been proposed offline. 
This PR implements one of the solution: Introduce a checker service that periodically check current version pool's consumers and pause idle topic-partition for some times.

For now, the check works as follows:
The check will be scheduled every **server.inactive.topic.partition.checker.internal.in.seconds** seconds.
In the check, it will examine every topic-partition that, if delta between previous message and now is beyond certain threshold "server.inactive.topic.partition.checker.threshold.in.seconds", it will try to add them to the pause set. It will be resumed by the next check cycle and in next check cycle it won't be paused (avoid infinite paused).


## Solution
<!--
Describe
- What changes you are making and why. 
- How these changes solve the problem.
- Any performance considerations or trade-offs. 
- Describe what testings you have done, for example, performance testing etc.
-->


###  Code changes
- [x] Added new code behind **a config**. If so list the config names and their default values in the PR description.
- [x] Introduced new **log lines**. 
  - [x] Confirmed if logs need to be **rate limited** to avoid excessive logging.

###  **Concurrency-Specific Checks**
Both reviewer and PR author to verify
- [ ] Code has **no race conditions** or **thread safety issues**.
- [ ] Proper **synchronization mechanisms** (e.g., `synchronized`, `RWLock`) are used where needed.
- [ ] No **blocking calls** inside critical sections that could lead to deadlocks or performance degradation.
- [ ] Verified **thread-safe collections** are used (e.g., `ConcurrentHashMap`, `CopyOnWriteArrayList`).
- [ ] Validated proper exception handling in multi-threaded code to avoid silent thread termination.


## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->

- [ ] New unit tests added.
- [ ] New integration tests added.
- [ ] Modified or extended existing tests.
- [ ] Verified backward compatibility (if applicable).

## Does this PR introduce any user-facing or breaking changes?
<!--  
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [ ] No. You can skip the rest of this section.
- [ ] Yes. Clearly explain the behavior change and its impact.