### PR TITLE
[server] Global RT DIV: Fixed `toPartitionState()` NPE

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/validation/PartitionTracker.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/validation/PartitionTracker.java
@@ -245,6 +245,8 @@ public class PartitionTracker {
 
     if (state == null) {
       state = segment.toProducerPartitionState();
+    } else {
+      segment.populateProducerPartitionState(state);
     }
 
     setProducerState(offsetRecord, type, guid, state);

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/validation/PartitionTracker.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/validation/PartitionTracker.java
@@ -244,35 +244,8 @@ public class PartitionTracker {
     }
 
     if (state == null) {
-      state = new ProducerPartitionState();
-
-      /**
-       * The aggregates and debugInfo being stored in the {@link ProducerPartitionState} will add a bit
-       * of overhead when we checkpoint this metadata to disk, so we should be careful not to add a very
-       * large number of elements to these arbitrary collections.
-       * <p>
-       * In the case of the debugInfo, it is expected (at the time of writing this comment) that all
-       * partitions produced by the same producer GUID would have the same debug values (though nothing
-       * precludes us from having per-partition debug values in the future if there is a use case for
-       * that). It is redundant that we store the same debug values once per partition. In the future,
-       * if we want to eliminate this redundancy, we could move the per-producer debug info to another
-       * data structure, though that would increase bookkeeping complexity. This is expected to be a
-       * minor overhead, and therefore it appears to be premature to optimize this now.
-       */
-      state.aggregates = CollectionUtils.substituteEmptyMap(segment.getAggregates());
-      state.debugInfo = CollectionUtils.substituteEmptyMap(segment.getDebugInfo());
+      state = segment.toProducerPartitionState();
     }
-    state.checksumType = segment.getCheckSumType().getValue();
-    /**
-     * {@link MD5Digest#getEncodedState()} is allocating a byte array to contain the intermediate state,
-     * which is expensive. We should only invoke this closure when necessary.
-     */
-    state.checksumState = ByteBuffer.wrap(segment.getCheckSumState());
-    state.segmentNumber = segment.getSegmentNumber();
-    state.messageSequenceNumber = segment.getSequenceNumber();
-    state.messageTimestamp = segment.getLastRecordProducerTimestamp();
-    state.segmentStatus = segment.getStatus().getValue();
-    state.isRegistered = segment.isRegistered();
 
     setProducerState(offsetRecord, type, guid, state);
   }

--- a/internal/venice-common/src/main/java/com/linkedin/venice/kafka/validation/Segment.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/kafka/validation/Segment.java
@@ -416,8 +416,8 @@ public class Segment {
     pps.segmentNumber = segmentNumber;
     pps.segmentStatus = getStatus().getValue();
     pps.messageSequenceNumber = sequenceNumber;
-    pps.checksumState = ByteBuffer.wrap(checkSum.getEncodedState());
-    pps.checksumType = checkSum.getType().getValue();
+    pps.checksumState = ByteBuffer.wrap(getCheckSumState());
+    pps.checksumType = getCheckSumType().getValue();
     pps.aggregates = aggregates;
     pps.debugInfo = debugInfo;
     pps.messageTimestamp = lastRecordProducerTimestamp;

--- a/internal/venice-common/src/main/java/com/linkedin/venice/kafka/validation/Segment.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/kafka/validation/Segment.java
@@ -429,6 +429,11 @@ public class Segment {
     pps.aggregates = CollectionUtils.substituteEmptyMap(getAggregates());
     pps.debugInfo = CollectionUtils.substituteEmptyMap(getDebugInfo());
     pps.checksumType = getCheckSumType().getValue();
+    populateProducerPartitionState(pps);
+    return pps;
+  }
+
+  public void populateProducerPartitionState(ProducerPartitionState pps) {
     /**
      * {@link MD5Digest#getEncodedState()} is allocating a byte array to contain the intermediate,
      * which is expensive. We should only invoke this closure when necessary.
@@ -439,8 +444,6 @@ public class Segment {
     pps.messageTimestamp = getLastRecordProducerTimestamp();
     pps.segmentStatus = getStatus().getValue();
     pps.isRegistered = isRegistered();
-
-    return pps;
   }
 
   // Only for testing.

--- a/internal/venice-common/src/main/java/com/linkedin/venice/kafka/validation/Segment.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/kafka/validation/Segment.java
@@ -428,7 +428,6 @@ public class Segment {
      */
     pps.aggregates = CollectionUtils.substituteEmptyMap(getAggregates());
     pps.debugInfo = CollectionUtils.substituteEmptyMap(getDebugInfo());
-    pps.checksumType = getCheckSumType().getValue();
     populateProducerPartitionState(pps);
     return pps;
   }
@@ -439,6 +438,7 @@ public class Segment {
      * which is expensive. We should only invoke this closure when necessary.
      */
     pps.checksumState = ByteBuffer.wrap(getCheckSumState());
+    pps.checksumType = getCheckSumType().getValue();
     pps.segmentNumber = getSegmentNumber();
     pps.messageSequenceNumber = getSequenceNumber();
     pps.messageTimestamp = getLastRecordProducerTimestamp();

--- a/internal/venice-common/src/main/java/com/linkedin/venice/kafka/validation/Segment.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/kafka/validation/Segment.java
@@ -413,15 +413,33 @@ public class Segment {
 
   public ProducerPartitionState toProducerPartitionState() {
     ProducerPartitionState pps = new ProducerPartitionState();
-    pps.segmentNumber = segmentNumber;
-    pps.segmentStatus = getStatus().getValue();
-    pps.messageSequenceNumber = sequenceNumber;
-    pps.checksumState = ByteBuffer.wrap(getCheckSumState());
+    /**
+     * The aggregates and debugInfo being stored in the {@link ProducerPartitionState} will add a bit
+     * of overhead when we checkpoint this metadata to disk, so we should be careful not to add a very
+     * large number of elements to these arbitrary collections.
+     * <p>
+     * In the case of the debugInfo, it is expected (at the time of writing this comment) that all
+     * partitions produced by the same producer GUID would have the same debug values (though nothing
+     * precludes us from having per-partition debug values in the future if there is a use case for
+     * that). It is redundant that we store the same debug values once per partition. In the future,
+     * if we want to eliminate this redundancy, we could move the per-producer debug info to another
+     * data structure, though that would increase bookkeeping complexity. This is expected to be a
+     * minor overhead, and therefore it appears to be premature to optimize this now.
+     */
+    pps.aggregates = CollectionUtils.substituteEmptyMap(getAggregates());
+    pps.debugInfo = CollectionUtils.substituteEmptyMap(getDebugInfo());
     pps.checksumType = getCheckSumType().getValue();
-    pps.aggregates = aggregates;
-    pps.debugInfo = debugInfo;
-    pps.messageTimestamp = lastRecordProducerTimestamp;
-    pps.isRegistered = registered;
+    /**
+     * {@link MD5Digest#getEncodedState()} is allocating a byte array to contain the intermediate,
+     * which is expensive. We should only invoke this closure when necessary.
+     */
+    pps.checksumState = ByteBuffer.wrap(getCheckSumState());
+    pps.segmentNumber = getSegmentNumber();
+    pps.messageSequenceNumber = getSequenceNumber();
+    pps.messageTimestamp = getLastRecordProducerTimestamp();
+    pps.segmentStatus = getStatus().getValue();
+    pps.isRegistered = isRegistered();
+
     return pps;
   }
 

--- a/internal/venice-common/src/test/java/com/linkedin/venice/kafka/validation/SegmentTest.java
+++ b/internal/venice-common/src/test/java/com/linkedin/venice/kafka/validation/SegmentTest.java
@@ -202,4 +202,10 @@ public class SegmentTest {
     assertEquals(pps.getMessageTimestamp(), segment.getLastRecordProducerTimestamp());
     assertEquals(pps.getIsRegistered(), segment.isRegistered());
   }
+
+  @Test
+  public void testToProducerPartitionState_NoCheckSum() {
+    Segment segment = new Segment(1, 1, 1, CheckSumType.NONE, new HashMap<>(), new HashMap<>());
+    ProducerPartitionState pps = segment.toProducerPartitionState(); // assert does not throw with checksumtype NONE
+  }
 }

--- a/internal/venice-common/src/test/java/com/linkedin/venice/kafka/validation/SegmentTest.java
+++ b/internal/venice-common/src/test/java/com/linkedin/venice/kafka/validation/SegmentTest.java
@@ -206,6 +206,6 @@ public class SegmentTest {
   @Test
   public void testToProducerPartitionState_NoCheckSum() {
     Segment segment = new Segment(1, 1, 1, CheckSumType.NONE, new HashMap<>(), new HashMap<>());
-    ProducerPartitionState pps = segment.toProducerPartitionState(); // assert does not throw with checksumtype NONE
+    segment.toProducerPartitionState(); // assert that a NullPointerException is not thrown with checksumtype NONE
   }
 }


### PR DESCRIPTION
<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat], [protocol]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## Summary
<!--
Describe
- What problem are you trying to solve
- What issues or limitations exist in the current code
- Why this change is necessary 
-->

Fixed `NullPointerException` in `Segment.toProducerPartitionState()` when the `checkSum` is `null`.

###  Code changes
- [x] Added new code behind **a config**. If so list the config names and their default values in the PR description.

###  **Concurrency-Specific Checks**
Both reviewer and PR author to verify
- [X] Code has **no race conditions** or **thread safety issues**.
- [X] Proper **synchronization mechanisms** (e.g., `synchronized`, `RWLock`) are used where needed.
- [X] No **blocking calls** inside critical sections that could lead to deadlocks or performance degradation.
- [X] Verified **thread-safe collections** are used (e.g., `ConcurrentHashMap`, `CopyOnWriteArrayList`).
- [X] Validated proper exception handling in multi-threaded code to avoid silent thread termination.

## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
- [X] New unit tests added.

## Does this PR introduce any user-facing or breaking changes?
<!--  
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [X] No. You can skip the rest of this section.