### PR TITLE
[server][controller][dvc][cc] Make PubSubConsumerAdapter implementations thread-safe

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/consumer/VeniceChangelogConsumerClientFactory.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/consumer/VeniceChangelogConsumerClientFactory.java
@@ -33,7 +33,6 @@ public class VeniceChangelogConsumerClientFactory {
 
   protected ViewClassGetter viewClassGetter;
 
-  // TODO: Add PubSubConsumerFactory into the constructor, so that client can choose specific Pub Sub system's consumer.
   public VeniceChangelogConsumerClientFactory(
       ChangelogClientConfig globalChangelogClientConfig,
       MetricsRepository metricsRepository) {

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/consumer/VeniceChangelogConsumerImpl.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/consumer/VeniceChangelogConsumerImpl.java
@@ -734,13 +734,13 @@ public class VeniceChangelogConsumerImpl<K, V> implements VeniceChangelogConsume
 
     try {
       try {
-        // the pubsubconsumer internally is completely unthreadsafe, so we need an exclusive lock to poll (ugh)
+        // we need an exclusive lock to coordinate multi-step subscription operations and maintain state consistency
         lockAcquired = subscriptionLock.writeLock().tryLock(timeoutInMs, TimeUnit.MILLISECONDS);
 
         /*
          * If the lock acquisition fails, don't invoke poll on the pubSubConsumer.
-         * Invoking poll without acquiring the lock can lead to a KafkaConsumer multi-threaded access exception
-         * if multiple threads attempt to use this function concurrently.
+         * The lock ensures atomic coordination of subscription state changes and prevents
+         * inconsistent state if multiple threads attempt to use this function concurrently.
          */
         if (!lockAcquired) {
           return Collections.emptyList();

--- a/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/api/PubSubConsumerAdapter.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/api/PubSubConsumerAdapter.java
@@ -21,8 +21,8 @@ import javax.annotation.Nonnull;
 
 /**
  * An adapter for consuming messages from a Pub-Sub topic.
- * Implementations of this interface are not expected to be thread safe. However, they are expected
- * to provide the following guarantees:
+ * Implementations of this interface are expected to be thread safe to allow concurrent access
+ * from multiple threads. They are also expected to provide the following guarantees:
  * 1) Honor the timeout parameter for all methods that have one.
  * 2) Non-blocking behavior for methods that do not have an explicit timeout parameter. In other words, they should
  *  timeout after the default timeout period: {@link PubSubConstants#PUBSUB_CONSUMER_API_DEFAULT_TIMEOUT_MS}.

--- a/internal/venice-common/src/test/java/com/linkedin/venice/pubsub/adapter/kafka/consumer/ApacheKafkaConsumerAdapterTest.java
+++ b/internal/venice-common/src/test/java/com/linkedin/venice/pubsub/adapter/kafka/consumer/ApacheKafkaConsumerAdapterTest.java
@@ -109,6 +109,7 @@ public class ApacheKafkaConsumerAdapterTest {
     when(apacheKafkaConsumerConfig.getTopicPartitionsOffsetsTracker()).thenReturn(topicPartitionsOffsetsTracker);
     when(apacheKafkaConsumerConfig.getPubSubMessageDeserializer()).thenReturn(pubSubMessageDeserializer);
     when(apacheKafkaConsumerConfig.getPubSubPositionTypeRegistry()).thenReturn(pubSubPositionTypeRegistry);
+    when(apacheKafkaConsumerConfig.getDefaultApiTimeout()).thenReturn(Duration.ofSeconds(30));
     kafkaConsumerAdapter = new ApacheKafkaConsumerAdapter(internalKafkaConsumer, apacheKafkaConsumerConfig);
   }
 

--- a/internal/venice-test-common/src/main/java/com/linkedin/venice/pubsub/mock/adapter/consumer/MockInMemoryConsumerAdapter.java
+++ b/internal/venice-test-common/src/main/java/com/linkedin/venice/pubsub/mock/adapter/consumer/MockInMemoryConsumerAdapter.java
@@ -229,7 +229,7 @@ public class MockInMemoryConsumerAdapter implements PubSubConsumerAdapter {
   }
 
   @Override
-  public Map<PubSubTopicPartition, PubSubPosition> beginningPositions(
+  public synchronized Map<PubSubTopicPartition, PubSubPosition> beginningPositions(
       Collection<PubSubTopicPartition> partitions,
       Duration timeout) {
     Map<PubSubTopicPartition, PubSubPosition> retPositions = new HashMap<>(partitions.size());
@@ -266,17 +266,26 @@ public class MockInMemoryConsumerAdapter implements PubSubConsumerAdapter {
   }
 
   @Override
-  public long comparePositions(PubSubTopicPartition partition, PubSubPosition position1, PubSubPosition position2) {
+  public synchronized long comparePositions(
+      PubSubTopicPartition partition,
+      PubSubPosition position1,
+      PubSubPosition position2) {
     return positionDifference(partition, position1, position2);
   }
 
   @Override
-  public long positionDifference(PubSubTopicPartition partition, PubSubPosition position1, PubSubPosition position2) {
+  public synchronized long positionDifference(
+      PubSubTopicPartition partition,
+      PubSubPosition position1,
+      PubSubPosition position2) {
     return PubSubUtil.computeOffsetDelta(partition, position1, position2, this);
   }
 
   @Override
-  public PubSubPosition decodePosition(PubSubTopicPartition partition, int positionTypeId, ByteBuffer buffer) {
+  public synchronized PubSubPosition decodePosition(
+      PubSubTopicPartition partition,
+      int positionTypeId,
+      ByteBuffer buffer) {
     try {
       if (buffer.remaining() < Long.BYTES) {
         throw new VeniceException("Buffer too short to decode InMemoryPubSubPosition: " + buffer);


### PR DESCRIPTION
## Make PubSubConsumerAdapter implementations thread-safe
This commit makes all PubSubConsumerAdapter implementations thread-safe to  
support concurrent access from multiple threads, addressing potential race  
conditions in consumer operations.  

###  Code changes
- [ ] Added new code behind **a config**. If so list the config names and their default values in the PR description.
- [ ] Introduced new **log lines**. 
  - [ ] Confirmed if logs need to be **rate limited** to avoid excessive logging.

###  **Concurrency-Specific Checks**
Both reviewer and PR author to verify
- [ ] Code has **no race conditions** or **thread safety issues**.
- [ ] Proper **synchronization mechanisms** (e.g., `synchronized`, `RWLock`) are used where needed.
- [ ] No **blocking calls** inside critical sections that could lead to deadlocks or performance degradation.
- [ ] Verified **thread-safe collections** are used (e.g., `ConcurrentHashMap`, `CopyOnWriteArrayList`).
- [ ] Validated proper exception handling in multi-threaded code to avoid silent thread termination.


## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->

- [ ] New unit tests added.
- [ ] New integration tests added.
- [ ] Modified or extended existing tests.
- [ ] Verified backward compatibility (if applicable).

## Does this PR introduce any user-facing or breaking changes?
<!--  
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [ ] No. You can skip the rest of this section.
- [ ] Yes. Clearly explain the behavior change and its impact.