### PR TITLE
[cdc] Add KME schema reader in CDC to support schema evolution

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/consumer/ChangelogClientConfig.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/consumer/ChangelogClientConfig.java
@@ -68,7 +68,6 @@ public class ChangelogClientConfig<T extends SpecificRecord> {
    * These are refreshed each time a new set of consumer properties is applied.
    */
   private PubSubConsumerAdapterFactory<? extends PubSubConsumerAdapter> pubSubConsumerAdapterFactory;
-  private PubSubMessageDeserializer pubSubMessageDeserializer;
   private PubSubContext pubSubContext;
 
   public ChangelogClientConfig(String storeName) {
@@ -378,15 +377,10 @@ public class ChangelogClientConfig<T extends SpecificRecord> {
         .setPubSubTopicRepository(pubSubTopicRepository)
         .build();
     this.pubSubConsumerAdapterFactory = PubSubClientsFactory.createConsumerFactory(pubSubProperties);
-    this.pubSubMessageDeserializer = PubSubMessageDeserializer.createOptimizedDeserializer();
   }
 
   protected PubSubConsumerAdapterFactory<? extends PubSubConsumerAdapter> getPubSubConsumerAdapterFactory() {
     return pubSubConsumerAdapterFactory;
-  }
-
-  protected PubSubMessageDeserializer getPubSubMessageDeserializer() {
-    return pubSubMessageDeserializer;
   }
 
   protected PubSubContext getPubSubContext() {

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/consumer/InternalLocalBootstrappingVeniceChangelogConsumer.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/consumer/InternalLocalBootstrappingVeniceChangelogConsumer.java
@@ -38,6 +38,7 @@ import com.linkedin.venice.meta.Store;
 import com.linkedin.venice.offsets.OffsetRecord;
 import com.linkedin.venice.pubsub.api.PubSubConsumerAdapter;
 import com.linkedin.venice.pubsub.api.PubSubMessage;
+import com.linkedin.venice.pubsub.api.PubSubMessageDeserializer;
 import com.linkedin.venice.pubsub.api.PubSubPosition;
 import com.linkedin.venice.pubsub.api.PubSubSymbolicPosition;
 import com.linkedin.venice.pubsub.api.PubSubTopicPartition;
@@ -95,8 +96,9 @@ class InternalLocalBootstrappingVeniceChangelogConsumer<K, V> extends VeniceAfte
   public InternalLocalBootstrappingVeniceChangelogConsumer(
       ChangelogClientConfig changelogClientConfig,
       PubSubConsumerAdapter pubSubConsumer,
+      PubSubMessageDeserializer pubSubMessageDeserializer,
       String consumerId) {
-    super(changelogClientConfig, pubSubConsumer);
+    super(changelogClientConfig, pubSubConsumer, pubSubMessageDeserializer);
     bootstrapStateMap = new VeniceConcurrentHashMap<>();
     syncBytesInterval = changelogClientConfig.getDatabaseSyncBytesInterval();
     metricsRepository = changelogClientConfig.getInnerClientConfig().getMetricsRepository();

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/consumer/LocalBootstrappingVeniceChangelogConsumer.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/consumer/LocalBootstrappingVeniceChangelogConsumer.java
@@ -1,6 +1,7 @@
 package com.linkedin.davinci.consumer;
 
 import com.linkedin.venice.pubsub.api.PubSubConsumerAdapter;
+import com.linkedin.venice.pubsub.api.PubSubMessageDeserializer;
 
 
 /**
@@ -16,7 +17,8 @@ public class LocalBootstrappingVeniceChangelogConsumer<K, V>
   public LocalBootstrappingVeniceChangelogConsumer(
       ChangelogClientConfig changelogClientConfig,
       PubSubConsumerAdapter pubSubConsumer,
+      PubSubMessageDeserializer pubSubMessageDeserializer,
       String consumerId) {
-    super(changelogClientConfig, pubSubConsumer, consumerId);
+    super(changelogClientConfig, pubSubConsumer, pubSubMessageDeserializer, consumerId);
   }
 }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/consumer/VeniceAfterImageConsumerImpl.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/consumer/VeniceAfterImageConsumerImpl.java
@@ -7,6 +7,7 @@ import com.linkedin.venice.kafka.protocol.enums.ControlMessageType;
 import com.linkedin.venice.pubsub.api.DefaultPubSubMessage;
 import com.linkedin.venice.pubsub.api.PubSubConsumerAdapter;
 import com.linkedin.venice.pubsub.api.PubSubMessage;
+import com.linkedin.venice.pubsub.api.PubSubMessageDeserializer;
 import com.linkedin.venice.pubsub.api.PubSubPosition;
 import com.linkedin.venice.pubsub.api.PubSubSymbolicPosition;
 import com.linkedin.venice.pubsub.api.PubSubTopic;
@@ -42,20 +43,27 @@ public class VeniceAfterImageConsumerImpl<K, V> extends VeniceChangelogConsumerI
   private final AtomicReference<Exception> versionSwapThreadException = new AtomicReference<>();
   private final VersionSwapDataChangeListener<K, V> versionSwapListener;
 
-  public VeniceAfterImageConsumerImpl(ChangelogClientConfig changelogClientConfig, PubSubConsumerAdapter consumer) {
+  public VeniceAfterImageConsumerImpl(
+      ChangelogClientConfig changelogClientConfig,
+      PubSubConsumerAdapter consumer,
+      PubSubMessageDeserializer pubSubMessageDeserializer) {
     this(
         changelogClientConfig,
         consumer,
         Lazy.of(
-            () -> VeniceChangelogConsumerClientFactory
-                .getPubSubConsumer(changelogClientConfig, changelogClientConfig.getStoreName() + "-" + "internal")));
+            () -> VeniceChangelogConsumerClientFactory.getPubSubConsumer(
+                changelogClientConfig,
+                pubSubMessageDeserializer,
+                changelogClientConfig.getStoreName() + "-" + "internal")),
+        pubSubMessageDeserializer);
   }
 
   protected VeniceAfterImageConsumerImpl(
       ChangelogClientConfig changelogClientConfig,
       PubSubConsumerAdapter consumer,
-      Lazy<PubSubConsumerAdapter> seekConsumer) {
-    super(changelogClientConfig, consumer);
+      Lazy<PubSubConsumerAdapter> seekConsumer,
+      PubSubMessageDeserializer pubSubMessageDeserializer) {
+    super(changelogClientConfig, consumer, pubSubMessageDeserializer);
     internalSeekConsumer = seekConsumer;
     versionSwapListener = new VersionSwapDataChangeListener<K, V>(
         this,

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/consumer/VeniceChangelogConsumerClientFactory.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/consumer/VeniceChangelogConsumerClientFactory.java
@@ -260,7 +260,6 @@ public class VeniceChangelogConsumerClientFactory {
    *       a KME backed {@link SchemaReader} for schema evolution during message decoding.</li>
    *   <li>Otherwise, fall back to {@link PubSubMessageDeserializer#createDefaultDeserializer()}.</li>
    * </ul>
-   * </pre>
    */
   @VisibleForTesting
   static PubSubMessageDeserializer createPubSubMessageDeserializer(final ChangelogClientConfig changelogClientConfig) {

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/consumer/VeniceChangelogConsumerImpl.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/consumer/VeniceChangelogConsumerImpl.java
@@ -1,5 +1,6 @@
 package com.linkedin.davinci.consumer;
 
+import static com.linkedin.davinci.consumer.VeniceChangelogConsumerClientFactory.getPubSubMessageDeserializer;
 import static com.linkedin.davinci.store.rocksdb.RocksDBServerConfig.ROCKSDB_BLOCK_CACHE_SIZE_IN_BYTES;
 import static com.linkedin.venice.ConfigKeys.CLIENT_SYSTEM_STORE_REPOSITORY_REFRESH_INTERVAL_SECONDS;
 import static com.linkedin.venice.ConfigKeys.CLIENT_USE_REQUEST_BASED_METADATA_REPOSITORY;
@@ -381,8 +382,10 @@ public class VeniceChangelogConsumerImpl<K, V> implements VeniceChangelogConsume
       compressor = compressorFactory.getVersionSpecificCompressor(topicName);
       if (compressor == null) {
         // we need to retrieve the dictionary from the kafka topic
-        ByteBuffer dictionary = DictionaryUtils
-            .readDictionaryFromKafka(topicName, new VeniceProperties(changelogClientConfig.getConsumerProperties()));
+        ByteBuffer dictionary = DictionaryUtils.readDictionaryFromKafka(
+            topicName,
+            new VeniceProperties(changelogClientConfig.getConsumerProperties()),
+            getPubSubMessageDeserializer(changelogClientConfig));
         compressor = compressorFactory
             .createVersionSpecificCompressorIfNotExist(version.getCompressionStrategy(), topicName, dictionary.array());
       }

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/consumer/InternalLocalBootstrappingVeniceChangelogConsumerTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/consumer/InternalLocalBootstrappingVeniceChangelogConsumerTest.java
@@ -51,6 +51,7 @@ import com.linkedin.venice.pubsub.adapter.kafka.common.ApacheKafkaOffsetPosition
 import com.linkedin.venice.pubsub.api.DefaultPubSubMessage;
 import com.linkedin.venice.pubsub.api.PubSubConsumerAdapter;
 import com.linkedin.venice.pubsub.api.PubSubMessage;
+import com.linkedin.venice.pubsub.api.PubSubMessageDeserializer;
 import com.linkedin.venice.pubsub.api.PubSubPosition;
 import com.linkedin.venice.pubsub.api.PubSubSymbolicPosition;
 import com.linkedin.venice.pubsub.api.PubSubTopic;
@@ -182,8 +183,11 @@ public class InternalLocalBootstrappingVeniceChangelogConsumerTest {
             .setDatabaseSyncBytesInterval(TEST_DB_SYNC_BYTES_INTERVAL)
             .setIsBeforeImageView(true);
     changelogClientConfig.getInnerClientConfig().setMetricsRepository(new MetricsRepository());
-    bootstrappingVeniceChangelogConsumer =
-        new InternalLocalBootstrappingVeniceChangelogConsumer<>(changelogClientConfig, pubSubConsumer, null);
+    bootstrappingVeniceChangelogConsumer = new InternalLocalBootstrappingVeniceChangelogConsumer<>(
+        changelogClientConfig,
+        pubSubConsumer,
+        PubSubMessageDeserializer.createDefaultDeserializer(),
+        null);
 
     metadataRepository = mock(NativeMetadataRepositoryViewAdapter.class);
     Store store = mock(Store.class);

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/consumer/VeniceChangelogConsumerClientFactoryTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/consumer/VeniceChangelogConsumerClientFactoryTest.java
@@ -3,10 +3,15 @@ package com.linkedin.davinci.consumer;
 import static com.linkedin.venice.ConfigKeys.CLUSTER_NAME;
 import static com.linkedin.venice.ConfigKeys.KAFKA_BOOTSTRAP_SERVERS;
 import static com.linkedin.venice.ConfigKeys.ZOOKEEPER_ADDRESS;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.expectThrows;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.linkedin.d2.balancer.D2Client;
@@ -14,6 +19,8 @@ import com.linkedin.data.ByteString;
 import com.linkedin.davinci.repository.NativeMetadataRepositoryViewAdapter;
 import com.linkedin.r2.message.rest.RestResponse;
 import com.linkedin.venice.ConfigKeys;
+import com.linkedin.venice.client.store.ClientConfig;
+import com.linkedin.venice.client.store.ClientFactory;
 import com.linkedin.venice.client.store.schemas.TestKeyRecord;
 import com.linkedin.venice.compression.CompressionStrategy;
 import com.linkedin.venice.controllerapi.D2ControllerClient;
@@ -26,6 +33,7 @@ import com.linkedin.venice.meta.VersionImpl;
 import com.linkedin.venice.meta.ViewConfig;
 import com.linkedin.venice.meta.ViewConfigImpl;
 import com.linkedin.venice.pubsub.api.PubSubConsumerAdapter;
+import com.linkedin.venice.pubsub.api.PubSubMessageDeserializer;
 import com.linkedin.venice.schema.SchemaReader;
 import com.linkedin.venice.utils.ObjectMapperFactory;
 import com.linkedin.venice.views.ChangeCaptureView;
@@ -36,8 +44,10 @@ import java.util.Map;
 import java.util.Properties;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
+import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 import org.testng.Assert;
+import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 
@@ -340,5 +350,60 @@ public class VeniceChangelogConsumerClientFactoryTest {
     Mockito.when(mockControllerClient.getStore(STORE_NAME)).thenReturn(mockStoreResponse);
     globalChangelogClientConfig.setViewName(VIEW_NAME);
     Assert.assertThrows(() -> veniceChangelogConsumerClientFactory.getBootstrappingChangelogConsumer(STORE_NAME));
+  }
+
+  @DataProvider(name = "kmeDeserializerScenarios", parallel = true)
+  public Object[][] kmeDeserializerScenarios() {
+    return new Object[][] {
+        // kmeProp, d2Present, expectClientFactoryCall
+        { "true", true, true }, // KME enabled, D2 present => KME evolution path
+        { "true", false, false }, // KME enabled, no D2 => default path
+        { "false", true, false }, // KME disabled, D2 present => default path
+        { "false", false, false }, // KME disabled, no D2 => default path
+        { null, false, false }, // No property, no D2 => default path
+        { null, true, true }, // No property, D2 present => KME defaults to enabled => KME evolution path
+    };
+  }
+
+  @Test(dataProvider = "kmeDeserializerScenarios")
+  public void testCreatePubSubMessageDeserializer(
+      String kmeProp,
+      boolean d2Present,
+      boolean expectKmeWithSchemaReaderCall) {
+    // Build properties
+    Properties props = new Properties();
+    if (kmeProp != null) {
+      props.put(ConfigKeys.KME_SCHEMA_READER_FOR_SCHEMA_EVOLUTION_ENABLED, kmeProp);
+    }
+
+    // Build config
+    D2Client d2 = d2Present ? mock(D2Client.class) : null;
+    ChangelogClientConfig config = new ChangelogClientConfig().setConsumerProperties(props).setD2Client(d2);
+
+    // Static mocking for ClientFactory only when needed. Use try-with-resources to avoid leaks.
+    if (expectKmeWithSchemaReaderCall) {
+      try (MockedStatic<ClientFactory> clientFactoryMock = org.mockito.Mockito.mockStatic(ClientFactory.class)) {
+        SchemaReader mockSchemaReader = mock(SchemaReader.class);
+        clientFactoryMock.when(() -> ClientFactory.getSchemaReader(any(ClientConfig.class), eq(null)))
+            .thenReturn(mockSchemaReader);
+
+        PubSubMessageDeserializer result = VeniceChangelogConsumerClientFactory.createPubSubMessageDeserializer(config);
+        assertNotNull(result, "Deserializer should not be null");
+
+        // Verify KME path taken exactly once
+        clientFactoryMock.verify(() -> ClientFactory.getSchemaReader(any(ClientConfig.class), eq(null)), times(1));
+      }
+    } else {
+      // No KME with schema reader expected. Do not set up static mocking. Just call and assert non-null.
+      PubSubMessageDeserializer result = VeniceChangelogConsumerClientFactory.createPubSubMessageDeserializer(config);
+      assertNotNull(result, "Deserializer should not be null when default path is taken");
+    }
+  }
+
+  @Test
+  public void testCreatePubSubMessageDeserializer_nullConfig() {
+    expectThrows(
+        NullPointerException.class,
+        () -> VeniceChangelogConsumerClientFactory.createPubSubMessageDeserializer(null));
   }
 }

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/consumer/VeniceChangelogConsumerClientFactoryTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/consumer/VeniceChangelogConsumerClientFactoryTest.java
@@ -54,6 +54,7 @@ public class VeniceChangelogConsumerClientFactoryTest {
     Properties consumerProperties = new Properties();
     String localKafkaUrl = "http://www.fooAddress.linkedin.com:16337";
     consumerProperties.put(ConfigKeys.PUBSUB_BROKER_ADDRESS, localKafkaUrl);
+    consumerProperties.put(ConfigKeys.KME_SCHEMA_READER_FOR_SCHEMA_EVOLUTION_ENABLED, false);
 
     SchemaReader mockSchemaReader = Mockito.mock(SchemaReader.class);
     Mockito.when(mockSchemaReader.getKeySchema()).thenReturn(TestKeyRecord.SCHEMA$);

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/consumer/VeniceChangelogConsumerImplTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/consumer/VeniceChangelogConsumerImplTest.java
@@ -64,6 +64,7 @@ import com.linkedin.venice.pubsub.adapter.kafka.common.ApacheKafkaOffsetPosition
 import com.linkedin.venice.pubsub.api.DefaultPubSubMessage;
 import com.linkedin.venice.pubsub.api.PubSubConsumerAdapter;
 import com.linkedin.venice.pubsub.api.PubSubMessage;
+import com.linkedin.venice.pubsub.api.PubSubMessageDeserializer;
 import com.linkedin.venice.pubsub.api.PubSubPosition;
 import com.linkedin.venice.pubsub.api.PubSubSymbolicPosition;
 import com.linkedin.venice.pubsub.api.PubSubTopic;
@@ -225,8 +226,10 @@ public class VeniceChangelogConsumerImplTest {
         false);
     ChangelogClientConfig changelogClientConfig =
         getChangelogClientConfig().setViewName("changeCaptureView").setIsBeforeImageView(true);
-    VeniceChangelogConsumerImpl<String, Utf8> veniceChangelogConsumer =
-        new VeniceChangelogConsumerImpl<>(changelogClientConfig, mockPubSubConsumer);
+    VeniceChangelogConsumerImpl<String, Utf8> veniceChangelogConsumer = new VeniceChangelogConsumerImpl<>(
+        changelogClientConfig,
+        mockPubSubConsumer,
+        PubSubMessageDeserializer.createDefaultDeserializer());
 
     veniceChangelogConsumer.setStoreRepository(mockRepository);
 
@@ -290,7 +293,8 @@ public class VeniceChangelogConsumerImplTest {
     VeniceAfterImageConsumerImpl<String, Utf8> veniceChangelogConsumer = new VeniceAfterImageConsumerImpl<>(
         changelogClientConfig,
         mockPubSubConsumer,
-        Lazy.of(() -> mockInternalSeekConsumer));
+        Lazy.of(() -> mockInternalSeekConsumer),
+        PubSubMessageDeserializer.createDefaultDeserializer());
     NativeMetadataRepositoryViewAdapter mockRepository = mock(NativeMetadataRepositoryViewAdapter.class);
     Store store = mock(Store.class);
     Version mockVersion = new VersionImpl(storeName, 1, "foo");
@@ -451,8 +455,10 @@ public class VeniceChangelogConsumerImplTest {
   public void testConsumeAfterImage()
       throws ExecutionException, InterruptedException, NoSuchFieldException, IllegalAccessException {
     prepareVersionTopicRecordsToBePolled(0L, 5L, mockPubSubConsumer, oldVersionTopic, 0, true);
-    VeniceChangelogConsumerImpl<String, Utf8> veniceChangelogConsumer =
-        new VeniceAfterImageConsumerImpl<>(changelogClientConfig, mockPubSubConsumer);
+    VeniceChangelogConsumerImpl<String, Utf8> veniceChangelogConsumer = new VeniceAfterImageConsumerImpl<>(
+        changelogClientConfig,
+        mockPubSubConsumer,
+        PubSubMessageDeserializer.createDefaultDeserializer());
 
     BasicConsumerStats consumerStats = spy(veniceChangelogConsumer.getChangeCaptureStats());
     Field changeCaptureStatsField = VeniceChangelogConsumerImpl.class.getDeclaredField("changeCaptureStats");
@@ -500,8 +506,10 @@ public class VeniceChangelogConsumerImplTest {
       throws ExecutionException, InterruptedException, NoSuchFieldException, IllegalAccessException {
     prepareVersionTopicRecordsToBePolled(0L, 5L, mockPubSubConsumer, oldVersionTopic, 0, true);
     ChangelogClientConfig changelogClientConfig = getChangelogClientConfig().setShouldCompactMessages(true);
-    VeniceChangelogConsumerImpl<String, Utf8> veniceChangelogConsumer =
-        new VeniceAfterImageConsumerImpl<>(changelogClientConfig, mockPubSubConsumer);
+    VeniceChangelogConsumerImpl<String, Utf8> veniceChangelogConsumer = new VeniceAfterImageConsumerImpl<>(
+        changelogClientConfig,
+        mockPubSubConsumer,
+        PubSubMessageDeserializer.createDefaultDeserializer());
 
     BasicConsumerStats consumerStats = spy(veniceChangelogConsumer.getChangeCaptureStats());
     Field changeCaptureStatsField = VeniceChangelogConsumerImpl.class.getDeclaredField("changeCaptureStats");
@@ -546,8 +554,10 @@ public class VeniceChangelogConsumerImplTest {
   @Test
   public void testPollFailure()
       throws ExecutionException, InterruptedException, NoSuchFieldException, IllegalAccessException {
-    VeniceChangelogConsumerImpl<String, Utf8> veniceChangelogConsumer =
-        new VeniceAfterImageConsumerImpl<>(changelogClientConfig, mockPubSubConsumer);
+    VeniceChangelogConsumerImpl<String, Utf8> veniceChangelogConsumer = new VeniceAfterImageConsumerImpl<>(
+        changelogClientConfig,
+        mockPubSubConsumer,
+        PubSubMessageDeserializer.createDefaultDeserializer());
 
     BasicConsumerStats consumerStats = spy(veniceChangelogConsumer.getChangeCaptureStats());
     Field changeCaptureStatsField = VeniceChangelogConsumerImpl.class.getDeclaredField("changeCaptureStats");
@@ -606,8 +616,11 @@ public class VeniceChangelogConsumerImplTest {
 
   @Test
   public void testVersionSwapDataChangeListenerFailure() {
-    VeniceAfterImageConsumerImpl<String, Utf8> veniceChangelogConsumer =
-        spy(new VeniceAfterImageConsumerImpl<>(changelogClientConfig, mockPubSubConsumer));
+    VeniceAfterImageConsumerImpl<String, Utf8> veniceChangelogConsumer = spy(
+        new VeniceAfterImageConsumerImpl<>(
+            changelogClientConfig,
+            mockPubSubConsumer,
+            PubSubMessageDeserializer.createDefaultDeserializer()));
     when(veniceChangelogConsumer.subscribed()).thenReturn(true);
     PubSubTopicPartition topicPartition = new PubSubTopicPartitionImpl(
         new TestPubSubTopic(storeName + "_v1", storeName, PubSubTopicType.VERSION_TOPIC),
@@ -744,8 +757,10 @@ public class VeniceChangelogConsumerImplTest {
   @Test
   public void testMetricReportingThread() {
     prepareVersionTopicRecordsToBePolled(0L, 5L, mockPubSubConsumer, oldVersionTopic, 0, true);
-    VeniceChangelogConsumerImpl<String, Utf8> veniceChangelogConsumer =
-        new VeniceAfterImageConsumerImpl<>(changelogClientConfig, mockPubSubConsumer);
+    VeniceChangelogConsumerImpl<String, Utf8> veniceChangelogConsumer = new VeniceAfterImageConsumerImpl<>(
+        changelogClientConfig,
+        mockPubSubConsumer,
+        PubSubMessageDeserializer.createDefaultDeserializer());
     veniceChangelogConsumer.setStoreRepository(mockRepository);
 
     Assert.assertEquals(veniceChangelogConsumer.getPartitionCount(), 2);
@@ -956,8 +971,10 @@ public class VeniceChangelogConsumerImplTest {
     doReturn(null).when(nullResponsePubSubConsumer).getPositionByTimestamp(any(), anyLong());
     PubSubPosition mockedPubSubPosition = mock(PubSubPosition.class);
     when(nullResponsePubSubConsumer.endPosition(any())).thenReturn(mockedPubSubPosition);
-    VeniceChangelogConsumerImpl<String, Utf8> veniceChangelogConsumer =
-        new VeniceAfterImageConsumerImpl<>(changelogClientConfig, nullResponsePubSubConsumer);
+    VeniceChangelogConsumerImpl<String, Utf8> veniceChangelogConsumer = new VeniceAfterImageConsumerImpl<>(
+        changelogClientConfig,
+        nullResponsePubSubConsumer,
+        PubSubMessageDeserializer.createDefaultDeserializer());
     veniceChangelogConsumer.setStoreRepository(mockRepository);
     veniceChangelogConsumer.internalSeekToTimestamps(partitionTimestampMap, "").get(10, TimeUnit.SECONDS);
     verify(nullResponsePubSubConsumer, times(1)).endPosition(any());
@@ -967,7 +984,10 @@ public class VeniceChangelogConsumerImplTest {
     PubSubConsumerAdapter mockErrorPubSubConsumer = mock(PubSubConsumerAdapter.class);
     doThrow(new NullPointerException("mock NPE")).when(mockErrorPubSubConsumer)
         .getPositionByTimestamp(any(), anyLong());
-    veniceChangelogConsumer = new VeniceAfterImageConsumerImpl<>(changelogClientConfig, mockErrorPubSubConsumer);
+    veniceChangelogConsumer = new VeniceAfterImageConsumerImpl<>(
+        changelogClientConfig,
+        mockErrorPubSubConsumer,
+        PubSubMessageDeserializer.createDefaultDeserializer());
     veniceChangelogConsumer.setStoreRepository(mockRepository);
     CompletableFuture<Void> seekFuture =
         veniceChangelogConsumer.internalSeekToTimestamps(partitionTimestampMap, "", mockLogger);
@@ -991,8 +1011,10 @@ public class VeniceChangelogConsumerImplTest {
 
   @Test
   public void testConcurrentPolls() throws ExecutionException, InterruptedException {
-    VeniceChangelogConsumerImpl<String, Utf8> veniceChangelogConsumer =
-        new VeniceAfterImageConsumerImpl<>(changelogClientConfig, mockPubSubConsumer);
+    VeniceChangelogConsumerImpl<String, Utf8> veniceChangelogConsumer = new VeniceAfterImageConsumerImpl<>(
+        changelogClientConfig,
+        mockPubSubConsumer,
+        PubSubMessageDeserializer.createDefaultDeserializer());
 
     /*
      * We make this test deterministic by making the first poll hold the lock longer than the second poll, to ensure
@@ -1059,8 +1081,11 @@ public class VeniceChangelogConsumerImplTest {
         false);
     ChangelogClientConfig changelogClientConfig =
         getChangelogClientConfig().setViewName("changeCaptureView").setIsBeforeImageView(true);
-    VeniceChangelogConsumerImpl<String, Utf8> veniceChangelogConsumer =
-        new VeniceChangelogConsumerImpl<>(changelogClientConfig, mockPubSubConsumer, sequenceIdStartingValue);
+    VeniceChangelogConsumerImpl<String, Utf8> veniceChangelogConsumer = new VeniceChangelogConsumerImpl<>(
+        changelogClientConfig,
+        mockPubSubConsumer,
+        PubSubMessageDeserializer.createDefaultDeserializer(),
+        sequenceIdStartingValue);
     veniceChangelogConsumer.setStoreRepository(mockRepository);
     Assert.assertEquals(veniceChangelogConsumer.getPartitionCount(), 2);
     veniceChangelogConsumer.subscribe(new HashSet<>(Collections.singletonList(partition))).get();

--- a/internal/venice-common/src/main/java/com/linkedin/venice/ConfigKeys.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/ConfigKeys.java
@@ -652,6 +652,16 @@ public class ConfigKeys {
       "kme.registration.from.message.header.enabled";
 
   /**
+   * Configuration flag to enable using the KME-based schema reader for schema evolution.
+   * <p>
+   * When set to {@code true}, and if all other prerequisites are satisfied
+   * (e.g., a valid client is available to fetch schemas from the router or controller),
+   * Venice will leverage the KME schema reader to handle schema evolution.
+   */
+  public static final String KME_SCHEMA_READER_FOR_SCHEMA_EVOLUTION_ENABLED =
+      "kme.schema.reader.for.schema.evolution.enabled";
+
+  /**
    * The following config is to control whether to turn on disabled replica enabler service.
    */
   public static final String CONTROLLER_ENABLE_DISABLED_REPLICA_ENABLED = "controller.enable.disabled.replica.enabled";

--- a/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/api/PubSubMessageDeserializer.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/api/PubSubMessageDeserializer.java
@@ -119,8 +119,8 @@ public class PubSubMessageDeserializer {
   }
 
   /**
-   * Do not use the following default deserializer in production code as they do not support schema evolution
-   * properly. They are only provided for convenience in test code.
+   * Do not use the following default deserializer in production code as it does not support schema evolution
+   * properly. It is only provided for convenience in test code.
    */
   public static PubSubMessageDeserializer createDefaultDeserializer() {
     return new PubSubMessageDeserializer(
@@ -130,8 +130,8 @@ public class PubSubMessageDeserializer {
   }
 
   /**
-   * Do not use the following default deserializer in production code as they do not support schema evolution
-   * properly. They are only provided for convenience in test code.
+   * Do not use the following default deserializer in production code as it does not support schema evolution
+   * properly. It is only provided for convenience in test code.
    */
   public static PubSubMessageDeserializer createOptimizedDeserializer() {
     return new PubSubMessageDeserializer(

--- a/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/api/PubSubMessageDeserializer.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/api/PubSubMessageDeserializer.java
@@ -118,6 +118,10 @@ public class PubSubMessageDeserializer {
     return valueSerializer;
   }
 
+  /**
+   * Do not use the following default deserializer in production code as they do not support schema evolution
+   * properly. They are only provided for convenience in test code.
+   */
   public static PubSubMessageDeserializer createDefaultDeserializer() {
     return new PubSubMessageDeserializer(
         new KafkaValueSerializer(),
@@ -125,6 +129,10 @@ public class PubSubMessageDeserializer {
         new LandFillObjectPool<>(KafkaMessageEnvelope::new));
   }
 
+  /**
+   * Do not use the following default deserializer in production code as they do not support schema evolution
+   * properly. They are only provided for convenience in test code.
+   */
   public static PubSubMessageDeserializer createOptimizedDeserializer() {
     return new PubSubMessageDeserializer(
         new OptimizedKafkaValueSerializer(),

--- a/internal/venice-common/src/main/java/com/linkedin/venice/utils/DictionaryUtils.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/utils/DictionaryUtils.java
@@ -39,13 +39,20 @@ public class DictionaryUtils {
   }
 
   public static ByteBuffer readDictionaryFromKafka(String topicName, VeniceProperties props) {
+    return readDictionaryFromKafka(topicName, props, PubSubMessageDeserializer.createDefaultDeserializer());
+  }
+
+  public static ByteBuffer readDictionaryFromKafka(
+      String topicName,
+      VeniceProperties props,
+      PubSubMessageDeserializer pubSubMessageDeserializer) {
     PubSubConsumerAdapterFactory pubSubConsumerAdapterFactory = PubSubClientsFactory.createConsumerFactory(props);
     PubSubTopicRepository pubSubTopicRepository = new PubSubTopicRepository();
     VeniceProperties pubSubProperties = getKafkaConsumerProps(props);
     PubSubConsumerAdapterContext context =
         new PubSubConsumerAdapterContext.Builder().setVeniceProperties(pubSubProperties)
             .setPubSubTopicRepository(pubSubTopicRepository)
-            .setPubSubMessageDeserializer(PubSubMessageDeserializer.createDefaultDeserializer())
+            .setPubSubMessageDeserializer(pubSubMessageDeserializer)
             .setPubSubPositionTypeRegistry(PubSubPositionTypeRegistry.fromPropertiesOrDefault(pubSubProperties))
             .setConsumerName("DictionaryUtilsConsumer")
             .build();


### PR DESCRIPTION
## [cdc] Add KME schema reader in CDC to support schema evolution  

CDC currently fails when KME schema evolves, since records encoded with newer schema  
cannot be deserialized. This change introduces a KME schema reader so that records  
with updated schema versions can be deserialized and processed correctly.  


###  Code changes
- [ ] Added new code behind **a config**. If so list the config names and their default values in the PR description.
- [ ] Introduced new **log lines**. 
  - [ ] Confirmed if logs need to be **rate limited** to avoid excessive logging.

###  **Concurrency-Specific Checks**
Both reviewer and PR author to verify
- [ ] Code has **no race conditions** or **thread safety issues**.
- [ ] Proper **synchronization mechanisms** (e.g., `synchronized`, `RWLock`) are used where needed.
- [ ] No **blocking calls** inside critical sections that could lead to deadlocks or performance degradation.
- [ ] Verified **thread-safe collections** are used (e.g., `ConcurrentHashMap`, `CopyOnWriteArrayList`).
- [ ] Validated proper exception handling in multi-threaded code to avoid silent thread termination.


## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->

- [ ] New unit tests added.
- [ ] New integration tests added.
- [ ] Modified or extended existing tests.
- [ ] Verified backward compatibility (if applicable).

## Does this PR introduce any user-facing or breaking changes?
<!--  
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [ ] No. You can skip the rest of this section.
- [ ] Yes. Clearly explain the behavior change and its impact.