### PR TITLE
[protocol] Evolve KME for new version swap CM fields

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -323,7 +323,12 @@ subprojects {
     outputs.cacheIf { true }
 
     doFirst {
-      def versionOverrides = []
+      // Protocol changes should pin the current version via this override and remove the override in a follow-up PR
+      // when actually using the new protocol. Example to pin KME to v12 when introducing v13:
+      // project(':internal:venice-common').file('src/main/resources/avro/KafkaMessageEnvelope/v12', PathValidation.DIRECTORY)
+      def versionOverrides = [
+          project(':internal:venice-common').file('src/main/resources/avro/KafkaMessageEnvelope/v12', PathValidation.DIRECTORY)
+      ]
 
       def schemaDirs = [sourceDir]
       sourceDir.eachDir { typeDir ->

--- a/internal/venice-common/src/main/resources/avro/KafkaMessageEnvelope/v13/KafkaMessageEnvelope.avsc
+++ b/internal/venice-common/src/main/resources/avro/KafkaMessageEnvelope/v13/KafkaMessageEnvelope.avsc
@@ -328,7 +328,7 @@
                       "type": "string",
                       "default": ""
                     }, {
-                      "name": "generation",
+                      "name": "generationId",
                       "doc": "A timestamp-based generation id to differentiate multiple version swaps within the same version topic",
                       "type": "long",
                       "default": -1


### PR DESCRIPTION
## Problem Statement
Current version swap proposal does not work for A/A, deferred version swap and re-pushes.


## Solution
NOTE: schema change only to add v13, not used yet.

Adding 3 new fields to version swap CM to address known version swap issues with A/A, deferred version swap, re-pushes and multiple version swap.

sourceRegion and destinationRegion to address A/A and deferred version swap. To ensure no data gaps in true A/A we need to consume all version swaps with different destinationRegion. For deferred version swap the consumer should only react to version swap where sourceRegion is equal to the consumer's region. i.e. region 1's consumer shouldn't react to version swap messages where sourceRegion != 1. These fields should also work with seperate incremental push topic feature too since we will simply be expecting to consume more version swap messages from more regions. e.g. with 3 regions we will be expecting to consume 3 version swaps where destinationRegion is 1, 2, 3. If separate incremental push topic feature is enabled then we will be expecting to consume 6 version swaps where destinationRegion is 1, 2, 3, 1_sep, 2_sep, 3_sep.

generationId is a timestamp based id to ensure it's monotonically increasing. This can help us differentiate multiple version swap within the same version topic due to repushes or multiple rollback/roll-forward.

```
diff internal/venice-common/src/main/resources/avro/KafkaMessageEnvelope/$VAR1/KafkaMessageEnvelope.avsc \
     internal/venice-common/src/main/resources/avro/KafkaMessageEnvelope/$VAR2/KafkaMessageEnvelope.avsc
319a320,334
>                     }, {
>                       "name": "sourceRegion",
>                       "doc": "The region that initiated this version swap.",
>                       "type": "string",
>                       "default": ""
>                     }, {
>                       "name": "destinationRegion",
>                       "doc": "The real-time topic region that this version swap was written to.",
>                       "type": "string",
>                       "default": ""
>                     }, {
>                       "name": "generationId",
>                       "doc": "A timestamp-based generation id to differentiate multiple version swaps within the same version topic",
>                       "type": "long",
>                       "default": -1
```
###  Code changes
- [ ] Added new code behind **a config**. If so list the config names and their default values in the PR description.
- [ ] Introduced new **log lines**. 
  - [ ] Confirmed if logs need to be **rate limited** to avoid excessive logging.

###  **Concurrency-Specific Checks**
Both reviewer and PR author to verify
- [ ] Code has **no race conditions** or **thread safety issues**.
- [ ] Proper **synchronization mechanisms** (e.g., `synchronized`, `RWLock`) are used where needed.
- [ ] No **blocking calls** inside critical sections that could lead to deadlocks or performance degradation.
- [ ] Verified **thread-safe collections** are used (e.g., `ConcurrentHashMap`, `CopyOnWriteArrayList`).
- [ ] Validated proper exception handling in multi-threaded code to avoid silent thread termination.


## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->

- [ ] New unit tests added.
- [ ] New integration tests added.
- [ ] Modified or extended existing tests.
- [ ] Verified backward compatibility (if applicable).

## Does this PR introduce any user-facing or breaking changes?
<!--  
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [ ] No. You can skip the rest of this section.
- [ ] Yes. Clearly explain the behavior change and its impact.