### PR TITLE
[server] Avoid checking keyUrnCompressor in server

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
@@ -503,6 +503,10 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
     if ((this.storageEngine instanceof DelegatingStorageEngine)) {
       DelegatingStorageEngine delegatingStorageEngine = (DelegatingStorageEngine) this.storageEngine;
       delegatingStorageEngine.setKeyDictCompressionFunction(p -> {
+        // Key Compression is only enabled in Venice Server.
+        if (!isDaVinciClient()) {
+          return null;
+        }
         PartitionConsumptionState pcs = partitionConsumptionStateMap.get(p);
         if (pcs == null) {
           throw new VeniceException("Partition " + p + " not found in partitionConsumptionStateMap");

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/store/DelegatingStorageEngine.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/store/DelegatingStorageEngine.java
@@ -57,9 +57,7 @@ public class DelegatingStorageEngine<P extends AbstractStoragePartition> impleme
     }
     KeyUrnCompressor keyUrnCompressor = keyDictCompressionFunction.apply(partitionId);
     if (keyUrnCompressor != null) {
-      byte[] compressedKey = keyUrnCompressor.compressKey(key, updateDictionary);
-      return compressedKey;
-
+      return keyUrnCompressor.compressKey(key, updateDictionary);
     }
 
     return key;


### PR DESCRIPTION
<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat], [protocol]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## [server] Avoid checking keyUrnCompressor in server
We observed high error requests in Venice Server shutdown between PartitionConsumptionState (PCS) is cleared and storage service is shutdown (which happens after listener service shutdown). This is because the newly added logic in storage engine tries to look up PCS's keyUrnCompressor when performing read/write operations.

A small fix in keyUrnCompressor logic that:
(1) Avoid checking PartitionConsumptionState (PCS) in server when performing operation against storage engine.
(2) Da Vinci should not be impacted because it will not take request the moment it is closed.


## Solution
<!--
Describe
- What changes you are making and why. 
- How these changes solve the problem.
- Any performance considerations or trade-offs. 
- Describe what testings you have done, for example, performance testing etc.
-->


###  Code changes
- [ ] Added new code behind **a config**. If so list the config names and their default values in the PR description.
- [ ] Introduced new **log lines**. 
  - [ ] Confirmed if logs need to be **rate limited** to avoid excessive logging.

###  **Concurrency-Specific Checks**
Both reviewer and PR author to verify
- [ ] Code has **no race conditions** or **thread safety issues**.
- [ ] Proper **synchronization mechanisms** (e.g., `synchronized`, `RWLock`) are used where needed.
- [ ] No **blocking calls** inside critical sections that could lead to deadlocks or performance degradation.
- [ ] Verified **thread-safe collections** are used (e.g., `ConcurrentHashMap`, `CopyOnWriteArrayList`).
- [ ] Validated proper exception handling in multi-threaded code to avoid silent thread termination.


## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->

- [ ] New unit tests added.
- [ ] New integration tests added.
- [ ] Modified or extended existing tests.
- [ ] Verified backward compatibility (if applicable).

## Does this PR introduce any user-facing or breaking changes?
<!--  
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [ ] No. You can skip the rest of this section.
- [ ] Yes. Clearly explain the behavior change and its impact.