### PR TITLE
[all] add config to enable/disable tehuti metrics

### DIFF
--- a/clients/venice-client/src/test/java/com/linkedin/venice/fastclient/ClientConfigTest.java
+++ b/clients/venice-client/src/test/java/com/linkedin/venice/fastclient/ClientConfigTest.java
@@ -9,11 +9,6 @@ import com.linkedin.venice.client.store.AvroGenericStoreClient;
 import org.testng.annotations.Test;
 
 
-/**
- * TODO:
- *  Add tests for options like setMaxAllowedKeyCntInBatchGetReq
- */
-
 public class ClientConfigTest {
   private ClientConfig.ClientConfigBuilder getClientConfigWithMinimumRequiredInputs() {
     return new ClientConfig.ClientConfigBuilder<>().setStoreName("test_store")

--- a/internal/venice-client-common/src/main/java/com/linkedin/venice/stats/VeniceMetricsConfig.java
+++ b/internal/venice-client-common/src/main/java/com/linkedin/venice/stats/VeniceMetricsConfig.java
@@ -35,6 +35,11 @@ public class VeniceMetricsConfig {
   public static final String OTEL_VENICE_METRICS_ENABLED = "otel.venice.metrics.enabled";
 
   /**
+   * Config to enable Tehuti metrics
+   */
+  public static final String TEHUTI_VENICE_METRICS_ENABLED = "tehuti.venice.metrics.enabled";
+
+  /**
    * Configuration to reuse the {@link io.opentelemetry.api.OpenTelemetry} instance
    * already initialized by the application or other libraries and registered as
    * {@link io.opentelemetry.api.GlobalOpenTelemetry}, instead of creating a new one.
@@ -181,6 +186,9 @@ public class VeniceMetricsConfig {
   /** Feature flag to use OpenTelemetry instrumentation for metrics or not */
   private final boolean emitOTelMetrics;
 
+  /** Feature flag to emit Tehuti metrics or not */
+  private final boolean emitTehutiMetrics;
+
   /**
    * Feature flag to use OpenTelemetry initialized by the application or not.
    * If true, it will use the GlobalOpenTelemetry instance. It could be initialized
@@ -241,6 +249,7 @@ public class VeniceMetricsConfig {
     this.metricPrefix = builder.metricPrefix;
     this.metricEntities = builder.metricEntities;
     this.emitOTelMetrics = builder.emitOtelMetrics;
+    this.emitTehutiMetrics = builder.emitTehutiMetrics;
     this.useOpenTelemetryInitializedByApplication = builder.useOpenTelemetryInitializedByApplication;
     this.otelCustomDescriptionForHistogramMetrics = builder.otelCustomDescriptionForHistogramMetrics;
     this.exportOtelMetricsToEndpoint = builder.exportOtelMetricsToEndpoint;
@@ -265,6 +274,7 @@ public class VeniceMetricsConfig {
     private String metricPrefix = null;
     private Collection<MetricEntity> metricEntities = new ArrayList<>();
     private boolean emitOtelMetrics = false;
+    private boolean emitTehutiMetrics = true;
     private boolean useOpenTelemetryInitializedByApplication = false;
     private String otelCustomDescriptionForHistogramMetrics = null;
     private boolean exportOtelMetricsToEndpoint = false;
@@ -301,6 +311,11 @@ public class VeniceMetricsConfig {
 
     public Builder setEmitOtelMetrics(boolean emitOtelMetrics) {
       this.emitOtelMetrics = emitOtelMetrics;
+      return this;
+    }
+
+    public Builder emitTehutiMetrics(boolean emitTehutiMetrics) {
+      this.emitTehutiMetrics = emitTehutiMetrics;
       return this;
     }
 
@@ -393,6 +408,10 @@ public class VeniceMetricsConfig {
       String configValue;
       if ((configValue = configs.get(OTEL_VENICE_METRICS_ENABLED)) != null) {
         setEmitOtelMetrics(Boolean.parseBoolean(configValue));
+      }
+
+      if ((configValue = configs.get(TEHUTI_VENICE_METRICS_ENABLED)) != null) {
+        emitTehutiMetrics = Boolean.parseBoolean(configValue);
       }
 
       if (!emitOtelMetrics) {
@@ -566,6 +585,10 @@ public class VeniceMetricsConfig {
     return emitOTelMetrics;
   }
 
+  public boolean emitTehutiMetrics() {
+    return emitTehutiMetrics;
+  }
+
   public boolean useOpenTelemetryInitializedByApplication() {
     return useOpenTelemetryInitializedByApplication;
   }
@@ -637,15 +660,19 @@ public class VeniceMetricsConfig {
   @Override
   public String toString() {
     return "VeniceMetricsConfig{" + "serviceName='" + serviceName + '\'' + ", metricPrefix='" + metricPrefix + '\''
-        + ", metricEntities=" + metricEntities + ", emitOTelMetrics=" + emitOTelMetrics
+        + ", emitOTelMetrics=" + emitOTelMetrics + ", emitTehutiMetrics=" + emitTehutiMetrics
+        + ", useOpenTelemetryInitializedByApplication=" + useOpenTelemetryInitializedByApplication
+        + ", otelCustomDescriptionForHistogramMetrics='" + otelCustomDescriptionForHistogramMetrics + '\''
         + ", exportOtelMetricsToEndpoint=" + exportOtelMetricsToEndpoint + ", exportOtelMetricsIntervalInSeconds="
         + exportOtelMetricsIntervalInSeconds + ", otelCustomDimensionsMap=" + otelCustomDimensionsMap
         + ", otelExportProtocol='" + otelExportProtocol + '\'' + ", otelEndpoint='" + otelEndpoint + '\''
-        + ", otelHeaders=" + otelHeaders + ", metricNamingFormat=" + metricNamingFormat
-        + ", otelAggregationTemporalitySelector=" + otelAggregationTemporalitySelector
-        + ", useOtelExponentialHistogram=" + useOtelExponentialHistogram + ", otelExponentialHistogramMaxScale="
-        + otelExponentialHistogramMaxScale + ", otelExponentialHistogramMaxBuckets="
-        + otelExponentialHistogramMaxBuckets + ", tehutiMetricConfig=" + tehutiMetricConfig + '}';
+        + ", otelHeaders=" + otelHeaders + ", exportOtelMetricsToLog=" + exportOtelMetricsToLog
+        + ", metricNamingFormat=" + metricNamingFormat + ", exportLastRecordedValueForSynchronousGauge="
+        + exportLastRecordedValueForSynchronousGauge + ", otelAggregationTemporalitySelector="
+        + otelAggregationTemporalitySelector + ", useOtelExponentialHistogram=" + useOtelExponentialHistogram
+        + ", otelExponentialHistogramMaxScale=" + otelExponentialHistogramMaxScale
+        + ", otelExponentialHistogramMaxBuckets=" + otelExponentialHistogramMaxBuckets + ", tehutiMetricConfig="
+        + tehutiMetricConfig + '}';
   }
 
   /**

--- a/internal/venice-client-common/src/main/java/com/linkedin/venice/stats/VeniceOpenTelemetryMetricsRepository.java
+++ b/internal/venice-client-common/src/main/java/com/linkedin/venice/stats/VeniceOpenTelemetryMetricsRepository.java
@@ -65,6 +65,7 @@ public class VeniceOpenTelemetryMetricsRepository {
   private SdkMeterProvider sdkMeterProvider = null;
   private final OpenTelemetry openTelemetry;
   private final boolean emitOpenTelemetryMetrics;
+  private final boolean emitTehutiMetrics;
   private final VeniceOpenTelemetryMetricNamingFormat metricFormat;
   private Meter meter;
   private String metricPrefix;
@@ -78,6 +79,7 @@ public class VeniceOpenTelemetryMetricsRepository {
   public VeniceOpenTelemetryMetricsRepository(VeniceMetricsConfig metricsConfig) {
     this.metricsConfig = metricsConfig;
     emitOpenTelemetryMetrics = metricsConfig.emitOtelMetrics();
+    emitTehutiMetrics = metricsConfig.emitTehutiMetrics();
     metricFormat = metricsConfig.getMetricNamingFormat();
     if (!emitOpenTelemetryMetrics) {
       LOGGER.info("OpenTelemetry metrics are disabled");
@@ -503,6 +505,10 @@ public class VeniceOpenTelemetryMetricsRepository {
 
   public boolean emitOpenTelemetryMetrics() {
     return emitOpenTelemetryMetrics;
+  }
+
+  public boolean emitTehutiMetrics() {
+    return emitTehutiMetrics;
   }
 
   public VeniceMetricsConfig getMetricsConfig() {

--- a/internal/venice-client-common/src/test/java/com/linkedin/venice/stats/VeniceMetricsConfigTest.java
+++ b/internal/venice-client-common/src/test/java/com/linkedin/venice/stats/VeniceMetricsConfigTest.java
@@ -12,6 +12,7 @@ import static com.linkedin.venice.stats.VeniceMetricsConfig.OTEL_VENICE_METRICS_
 import static com.linkedin.venice.stats.VeniceMetricsConfig.OTEL_VENICE_METRICS_EXPORT_TO_ENDPOINT;
 import static com.linkedin.venice.stats.VeniceMetricsConfig.OTEL_VENICE_METRICS_EXPORT_TO_LOG;
 import static com.linkedin.venice.stats.VeniceMetricsConfig.OTEL_VENICE_METRICS_NAMING_FORMAT;
+import static com.linkedin.venice.stats.VeniceMetricsConfig.TEHUTI_VENICE_METRICS_ENABLED;
 import static com.linkedin.venice.stats.VeniceOpenTelemetryMetricNamingFormat.SNAKE_CASE;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
@@ -31,6 +32,9 @@ import java.util.Map;
 import org.testng.annotations.Test;
 
 
+/**
+ * Unit tests for {@link VeniceMetricsConfig}.
+ */
 public class VeniceMetricsConfigTest {
   @Test
   public void testDefaultValues() {
@@ -43,6 +47,7 @@ public class VeniceMetricsConfigTest {
     assertEquals(config.getServiceName(), "noop_service");
     assertEquals(config.getMetricPrefix(), "service");
     assertFalse(config.emitOtelMetrics());
+    assertTrue(config.emitTehutiMetrics());
     assertFalse(config.exportOtelMetricsToEndpoint());
     assertEquals(config.getExportOtelMetricsIntervalInSeconds(), 60);
     assertEquals(config.getOtelExportProtocol(), OtlpConfigUtil.PROTOCOL_HTTP_PROTOBUF);
@@ -277,5 +282,34 @@ public class VeniceMetricsConfigTest {
         .setUseOpenTelemetryInitializedByApplication(true)
         .build();
     assertTrue(config.useOpenTelemetryInitializedByApplication());
+  }
+
+  @Test
+  public void testEmitTehutiMetricsBuilder() {
+    VeniceMetricsConfig config =
+        new Builder().setServiceName("TestService").setMetricPrefix("TestPrefix").emitTehutiMetrics(false).build();
+    assertFalse(config.emitTehutiMetrics(), "Tehuti metrics should be disabled when set to false");
+
+    config = new Builder().setServiceName("TestService").setMetricPrefix("TestPrefix").emitTehutiMetrics(true).build();
+    assertTrue(config.emitTehutiMetrics(), "Tehuti metrics should be enabled when set to true");
+  }
+
+  @Test
+  public void testEmitTehutiMetricsFromConfig() {
+    Map<String, String> configs = new HashMap<>();
+    configs.put(TEHUTI_VENICE_METRICS_ENABLED, "false");
+
+    VeniceMetricsConfig config = new Builder().setServiceName("TestService")
+        .setMetricPrefix("TestPrefix")
+        .extractAndSetOtelConfigs(configs)
+        .build();
+    assertFalse(config.emitTehutiMetrics(), "Tehuti metrics should be disabled when config is false");
+
+    configs.put(TEHUTI_VENICE_METRICS_ENABLED, "true");
+    config = new Builder().setServiceName("TestService")
+        .setMetricPrefix("TestPrefix")
+        .extractAndSetOtelConfigs(configs)
+        .build();
+    assertTrue(config.emitTehutiMetrics(), "Tehuti metrics should be enabled when config is true");
   }
 }

--- a/internal/venice-client-common/src/test/java/com/linkedin/venice/stats/metrics/MetricEntityStateTest.java
+++ b/internal/venice-client-common/src/test/java/com/linkedin/venice/stats/metrics/MetricEntityStateTest.java
@@ -149,7 +149,8 @@ public class MetricEntityStateTest {
       Assert.assertTrue(e.getMessage().contains("Base attributes cannot be null for MetricEntityStateBase"));
     }
 
-    // with tehuti sensor
+    // with tehuti enabled and provided sensor details
+    when(mockOtelRepository.emitTehutiMetrics()).thenReturn(true);
     metricEntityState = MetricEntityStateBase.create(
         mockMetricEntity,
         mockOtelRepository,
@@ -162,6 +163,22 @@ public class MetricEntityStateTest {
     Assert.assertNotNull(metricEntityState.getOtelMetric());
     Assert.assertNotNull(metricEntityState.getTehutiSensor());
     Assert.assertEquals(((MetricEntityStateBase) metricEntityState).getAttributes(), baseAttributes);
+
+    // with tehuti disabled and provided sensor details
+    when(mockOtelRepository.emitTehutiMetrics()).thenReturn(false);
+    metricEntityState = MetricEntityStateBase.create(
+        mockMetricEntity,
+        mockOtelRepository,
+        sensorRegistrationFunction,
+        TestTehutiMetricNameEnum.TEST_METRIC,
+        singletonList(new Count()),
+        baseDimensionsMap,
+        baseAttributes);
+    Assert.assertNotNull(metricEntityState);
+    Assert.assertNotNull(metricEntityState.getOtelMetric());
+    Assert.assertNull(metricEntityState.getTehutiSensor());
+    Assert.assertEquals(((MetricEntityStateBase) metricEntityState).getAttributes(), baseAttributes);
+
   }
 
   @Test


### PR DESCRIPTION
## Problem Statement
Otel can be enabled/disabled, but tehuti metrics are enabled always.

## Solution
1.  Add config to enable/disable tehuti metrics that are created via new Otel `MetricEntityState` APIs.
2. The metrics created directly without use these APIs will still be enabled.

new config: `tehuti.venice.metrics.enabled`
new setter: `emitTehutiMetrics(Boolean)`

###  Code changes
- [ ] Added new code behind **a config**. If so list the config names and their default values in the PR description.
- [ ] Introduced new **log lines**. 
  - [ ] Confirmed if logs need to be **rate limited** to avoid excessive logging.

###  **Concurrency-Specific Checks**
Both reviewer and PR author to verify
- [ ] Code has **no race conditions** or **thread safety issues**.
- [ ] Proper **synchronization mechanisms** (e.g., `synchronized`, `RWLock`) are used where needed.
- [ ] No **blocking calls** inside critical sections that could lead to deadlocks or performance degradation.
- [ ] Verified **thread-safe collections** are used (e.g., `ConcurrentHashMap`, `CopyOnWriteArrayList`).
- [ ] Validated proper exception handling in multi-threaded code to avoid silent thread termination.


## How was this PR tested?
- [ ] New unit tests added.
- [ ] New integration tests added.
- [ ] Modified or extended existing tests.
- [ ] Verified backward compatibility (if applicable).

## Does this PR introduce any user-facing or breaking changes?
- [ ] No. You can skip the rest of this section.
- [ ] Yes. Clearly explain the behavior change and its impact.