### PR TITLE
[server][da-vinci][test] Optimize Heartbeat Messages by Excluding VTP Headers

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/ingestion/utils/IsolatedIngestionUtils.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/ingestion/utils/IsolatedIngestionUtils.java
@@ -115,8 +115,6 @@ public class IsolatedIngestionUtils {
       AvroProtocolDefinition.INGESTION_STORAGE_METADATA.getSerializer();
   private static final InternalAvroSpecificSerializer<ProcessShutdownCommand> processShutdownCommandSerializer =
       AvroProtocolDefinition.PROCESS_SHUTDOWN_COMMAND.getSerializer();
-  private static final InternalAvroSpecificSerializer<IngestionTaskCommand> ingestionDummyContentSerializer =
-      ingestionTaskCommandSerializer;
   private static final InternalAvroSpecificSerializer<LoadedStoreUserPartitionMapping> storeUserPartitionMappingSerializer =
       AvroProtocolDefinition.LOADED_STORE_USER_PARTITION_MAPPING.getSerializer();
 
@@ -126,17 +124,17 @@ public class IsolatedIngestionUtils {
               new AbstractMap.SimpleEntry<>(COMMAND, ingestionTaskCommandSerializer),
               new AbstractMap.SimpleEntry<>(REPORT, ingestionTaskReportSerializer),
               new AbstractMap.SimpleEntry<>(METRIC, ingestionMetricsReportSerializer),
-              new AbstractMap.SimpleEntry<>(HEARTBEAT, ingestionDummyContentSerializer),
+              new AbstractMap.SimpleEntry<>(HEARTBEAT, ingestionTaskCommandSerializer),
               new AbstractMap.SimpleEntry<>(UPDATE_METADATA, ingestionStorageMetadataSerializer),
               new AbstractMap.SimpleEntry<>(SHUTDOWN_COMPONENT, processShutdownCommandSerializer),
-              new AbstractMap.SimpleEntry<>(GET_LOADED_STORE_USER_PARTITION_MAPPING, ingestionDummyContentSerializer))
+              new AbstractMap.SimpleEntry<>(GET_LOADED_STORE_USER_PARTITION_MAPPING, ingestionTaskCommandSerializer))
           .collect(Collectors.toMap(AbstractMap.SimpleEntry::getKey, AbstractMap.SimpleEntry::getValue));
 
   private static final Map<IngestionAction, InternalAvroSpecificSerializer> ingestionActionToResponseSerializerMap =
       Stream.of(
           new AbstractMap.SimpleEntry<>(COMMAND, ingestionTaskReportSerializer),
-          new AbstractMap.SimpleEntry<>(REPORT, ingestionDummyContentSerializer),
-          new AbstractMap.SimpleEntry<>(METRIC, ingestionDummyContentSerializer),
+          new AbstractMap.SimpleEntry<>(REPORT, ingestionTaskCommandSerializer),
+          new AbstractMap.SimpleEntry<>(METRIC, ingestionTaskCommandSerializer),
           new AbstractMap.SimpleEntry<>(HEARTBEAT, ingestionTaskCommandSerializer),
           new AbstractMap.SimpleEntry<>(UPDATE_METADATA, ingestionTaskReportSerializer),
           new AbstractMap.SimpleEntry<>(SHUTDOWN_COMPONENT, ingestionTaskReportSerializer),

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/KafkaStoreIngestionService.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/KafkaStoreIngestionService.java
@@ -421,7 +421,13 @@ public class KafkaStoreIngestionService extends AbstractVeniceService implements
         ? new OptimizedKafkaValueSerializer(newSchemaEncountered)
         : new OptimizedKafkaValueSerializer();
 
-    kafkaMessageEnvelopeSchemaReader.ifPresent(kafkaValueSerializer::setSchemaReader);
+    kafkaMessageEnvelopeSchemaReader.ifPresent(reader -> {
+      LOGGER.info(
+          "Initialized KME schema reader. Type: {}, Latest value schema ID: {}",
+          reader.getClass().getSimpleName(),
+          reader.getLatestValueSchemaId());
+      kafkaValueSerializer.setSchemaReader(reader);
+    });
     PubSubMessageDeserializer pubSubDeserializer = new PubSubMessageDeserializer(
         kafkaValueSerializer,
         new LandFillObjectPool<>(KafkaMessageEnvelope::new),
@@ -1518,4 +1524,7 @@ public class KafkaStoreIngestionService extends AbstractVeniceService implements
     }
   }
 
+  public boolean isKMESchemeReaderPresent() {
+    return kafkaMessageEnvelopeSchemaReader.isPresent();
+  }
 }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/KafkaStoreIngestionService.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/KafkaStoreIngestionService.java
@@ -1524,7 +1524,7 @@ public class KafkaStoreIngestionService extends AbstractVeniceService implements
     }
   }
 
-  public boolean isKMESchemeReaderPresent() {
+  public boolean isKMESchemaReaderPresent() {
     return kafkaMessageEnvelopeSchemaReader.isPresent();
   }
 }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTask.java
@@ -3943,7 +3943,7 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
         originTimeStampMs);
   }
 
-  private CompletableFuture<PubSubProduceResult> sendIngestionHeartbeat(
+  CompletableFuture<PubSubProduceResult> sendIngestionHeartbeat(
       PartitionConsumptionState partitionConsumptionState,
       PubSubTopicPartition topicPartition,
       PubSubProducerCallback callback,
@@ -3953,6 +3953,8 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
       LeaderCompleteState leaderCompleteState,
       long originTimeStampMs) {
     CompletableFuture<PubSubProduceResult> heartBeatFuture;
+    boolean dependentFeatureEnabled = isSystemSchemaInitializationAtStartTimeEnabled()
+        && getHeartbeatMonitoringService().getKafkaStoreIngestionService().isKMESchemeReaderPresent();
     try {
       heartBeatFuture = partitionConsumptionState.getVeniceWriterLazyRef()
           .get()
@@ -3962,7 +3964,8 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
               leaderMetadataWrapper,
               addLeaderCompleteState,
               leaderCompleteState,
-              originTimeStampMs);
+              originTimeStampMs,
+              dependentFeatureEnabled);
       if (shouldLog) {
         heartBeatFuture
             .whenComplete((ignore, throwable) -> logIngestionHeartbeat(topicPartition, (Exception) throwable));

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTask.java
@@ -3954,7 +3954,7 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
       long originTimeStampMs) {
     CompletableFuture<PubSubProduceResult> heartBeatFuture;
     boolean dependentFeatureEnabled = isSystemSchemaInitializationAtStartTimeEnabled()
-        && getHeartbeatMonitoringService().getKafkaStoreIngestionService().isKMESchemeReaderPresent();
+        && getHeartbeatMonitoringService().getKafkaStoreIngestionService().isKMESchemaReaderPresent();
     try {
       heartBeatFuture = partitionConsumptionState.getVeniceWriterLazyRef()
           .get()

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
@@ -416,6 +416,7 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
   private final Version version;
   private boolean skipValidationForSeekableClientEnabled = false;
   private long lastResubscriptionCheckTimestamp = System.currentTimeMillis();
+  private final boolean isSystemSchemaInitializationAtStartTimeEnabled;
 
   public StoreIngestionTask(
       StorageService storageService,
@@ -682,6 +683,7 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
     this.parallelProcessingThreadPool = builder.getAAWCWorkLoadProcessingThreadPool();
     this.hostName = Utils.getHostName() + "_" + storeVersionConfig.getListenerPort();
     this.zkHelixAdmin = zkHelixAdmin;
+    this.isSystemSchemaInitializationAtStartTimeEnabled = serverConfig.isSystemSchemaInitializationAtStartTimeEnabled();
   }
 
   /** Package-private on purpose, only intended for tests. Do not use for production use cases. */
@@ -5001,6 +5003,10 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
 
   boolean isGlobalRtDivEnabled() {
     return isGlobalRtDivEnabled;
+  }
+
+  boolean isSystemSchemaInitializationAtStartTimeEnabled() {
+    return isSystemSchemaInitializationAtStartTimeEnabled;
   }
 
   /** When Global RT DIV is enabled the ConsumptionTask's DIV is exclusively used to validate data integrity. */

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/ingestion/heartbeat/HeartbeatMonitoringService.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/ingestion/heartbeat/HeartbeatMonitoringService.java
@@ -889,4 +889,8 @@ public class HeartbeatMonitoringService extends AbstractVeniceService {
   public void setKafkaStoreIngestionService(KafkaStoreIngestionService kafkaStoreIngestionService) {
     this.kafkaStoreIngestionService = kafkaStoreIngestionService;
   }
+
+  public KafkaStoreIngestionService getKafkaStoreIngestionService() {
+    return kafkaStoreIngestionService;
+  }
 }

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTaskTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTaskTest.java
@@ -554,7 +554,7 @@ public class LeaderFollowerStoreIngestionTaskTest {
 
     // Test case 1: Both dependent features enabled - should pass true to sendHeartbeat
     doReturn(true).when(leaderFollowerStoreIngestionTask).isSystemSchemaInitializationAtStartTimeEnabled();
-    when(mockKafkaStoreIngestionService.isKMESchemeReaderPresent()).thenReturn(true);
+    when(mockKafkaStoreIngestionService.isKMESchemaReaderPresent()).thenReturn(true);
 
     leaderFollowerStoreIngestionTask.sendIngestionHeartbeat(
         mockPartitionConsumptionState,
@@ -581,7 +581,7 @@ public class LeaderFollowerStoreIngestionTaskTest {
 
     // Test case 2: System schema initialization disabled - should pass false to sendHeartbeat
     doReturn(false).when(leaderFollowerStoreIngestionTask).isSystemSchemaInitializationAtStartTimeEnabled();
-    when(mockKafkaStoreIngestionService.isKMESchemeReaderPresent()).thenReturn(true);
+    when(mockKafkaStoreIngestionService.isKMESchemaReaderPresent()).thenReturn(true);
 
     leaderFollowerStoreIngestionTask.sendIngestionHeartbeat(
         mockPartitionConsumptionState,
@@ -608,7 +608,7 @@ public class LeaderFollowerStoreIngestionTaskTest {
 
     // Test case 3: KME reader disabled - should pass false to sendHeartbeat
     doReturn(true).when(leaderFollowerStoreIngestionTask).isSystemSchemaInitializationAtStartTimeEnabled();
-    when(mockKafkaStoreIngestionService.isKMESchemeReaderPresent()).thenReturn(false);
+    when(mockKafkaStoreIngestionService.isKMESchemaReaderPresent()).thenReturn(false);
 
     leaderFollowerStoreIngestionTask.sendIngestionHeartbeat(
         mockPartitionConsumptionState,

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTaskTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTaskTest.java
@@ -2994,7 +2994,8 @@ public abstract class StoreIngestionTaskTest {
             DEFAULT_LEADER_METADATA_WRAPPER,
             true,
             LeaderCompleteState.getLeaderCompleteState(true),
-            System.currentTimeMillis());
+            System.currentTimeMillis(),
+            true);
         messageCountPerPartition[partition]++;
       }
 
@@ -5134,7 +5135,8 @@ public abstract class StoreIngestionTaskTest {
     VeniceWriterFactory veniceWriterFactory = mock(VeniceWriterFactory.class);
     CompletableFuture heartBeatFuture = new CompletableFuture();
     heartBeatFuture.complete(null);
-    doReturn(heartBeatFuture).when(veniceWriter).sendHeartbeat(any(), any(), any(), anyBoolean(), any(), anyLong());
+    doReturn(heartBeatFuture).when(veniceWriter)
+        .sendHeartbeat(any(), any(), any(), anyBoolean(), any(), anyLong(), anyBoolean());
     doReturn(veniceWriter).when(veniceWriterFactory).createVeniceWriter(any());
 
     doReturn(Lazy.of(() -> veniceWriter)).when(pcs).getVeniceWriterLazyRef();
@@ -5168,9 +5170,9 @@ public abstract class StoreIngestionTaskTest {
     // Second invocation should be skipped since it shouldn't be time for another heartbeat yet.
     ingestionTask.maybeSendIngestionHeartbeat();
     if (hybridConfig == HYBRID && isRealTimeTopic && nodeType == NodeType.LEADER) {
-      verify(veniceWriter, times(1)).sendHeartbeat(any(), any(), any(), anyBoolean(), any(), anyLong());
+      verify(veniceWriter, times(1)).sendHeartbeat(any(), any(), any(), anyBoolean(), any(), anyLong(), anyBoolean());
     } else {
-      verify(veniceWriter, never()).sendHeartbeat(any(), any(), any(), anyBoolean(), any(), anyLong());
+      verify(veniceWriter, never()).sendHeartbeat(any(), any(), any(), anyBoolean(), any(), anyLong(), anyBoolean());
     }
 
     /**
@@ -5272,17 +5274,19 @@ public abstract class StoreIngestionTaskTest {
     PubSubTopicPartition pubSubTopicPartition1sep = new PubSubTopicPartitionImpl(sepRTtopic, 1);
 
     // all succeeded
-    doReturn(heartBeatFuture).when(veniceWriter).sendHeartbeat(any(), any(), any(), anyBoolean(), any(), anyLong());
+    doReturn(heartBeatFuture).when(veniceWriter)
+        .sendHeartbeat(any(), any(), any(), anyBoolean(), any(), anyLong(), anyBoolean());
     AtomicReference<Set<String>> failedPartitions = new AtomicReference<>(null);
     failedPartitions.set(ingestionTask.maybeSendIngestionHeartbeat());
     assertEquals(failedPartitions.get().size(), 0);
 
     // 1 partition throws exception
     doReturn(heartBeatFuture).when(veniceWriter)
-        .sendHeartbeat(eq(pubSubTopicPartition0), any(), any(), anyBoolean(), any(), anyLong());
+        .sendHeartbeat(eq(pubSubTopicPartition0), any(), any(), anyBoolean(), any(), anyLong(), anyBoolean());
     doAnswer(invocation -> {
       throw new Exception("mock exception");
-    }).when(veniceWriter).sendHeartbeat(eq(pubSubTopicPartition1), any(), any(), anyBoolean(), any(), anyLong());
+    }).when(veniceWriter)
+        .sendHeartbeat(eq(pubSubTopicPartition1), any(), any(), anyBoolean(), any(), anyLong(), anyBoolean());
     // wait for SERVER_INGESTION_HEARTBEAT_INTERVAL_MS
     TestUtils.waitForNonDeterministicAssertion(5, TimeUnit.SECONDS, () -> {
       failedPartitions.set(ingestionTask.maybeSendIngestionHeartbeat());
@@ -5297,10 +5301,11 @@ public abstract class StoreIngestionTaskTest {
 
     // 1 partition throws exception
     doReturn(heartBeatFuture).when(veniceWriter)
-        .sendHeartbeat(eq(pubSubTopicPartition0), any(), any(), anyBoolean(), any(), anyLong());
+        .sendHeartbeat(eq(pubSubTopicPartition0), any(), any(), anyBoolean(), any(), anyLong(), anyBoolean());
     doAnswer(invocation -> {
       throw new Exception("mock exception");
-    }).when(veniceWriter).sendHeartbeat(eq(pubSubTopicPartition1sep), any(), any(), anyBoolean(), any(), anyLong());
+    }).when(veniceWriter)
+        .sendHeartbeat(eq(pubSubTopicPartition1sep), any(), any(), anyBoolean(), any(), anyLong(), anyBoolean());
     // wait for SERVER_INGESTION_HEARTBEAT_INTERVAL_MS
     TestUtils.waitForNonDeterministicAssertion(5, TimeUnit.SECONDS, () -> {
       failedPartitions.set(ingestionTask.maybeSendIngestionHeartbeat());
@@ -5316,7 +5321,8 @@ public abstract class StoreIngestionTaskTest {
     // both partition throws exception
     doAnswer(invocation -> {
       throw new Exception("mock exception");
-    }).when(veniceWriter).sendHeartbeat(eq(pubSubTopicPartition0), any(), any(), anyBoolean(), any(), anyLong());
+    }).when(veniceWriter)
+        .sendHeartbeat(eq(pubSubTopicPartition0), any(), any(), anyBoolean(), any(), anyLong(), anyBoolean());
     // wait for SERVER_INGESTION_HEARTBEAT_INTERVAL_MS
     TestUtils.waitForNonDeterministicAssertion(5, TimeUnit.SECONDS, () -> {
       failedPartitions.set(ingestionTask.maybeSendIngestionHeartbeat());

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/store/view/MaterializedViewWriterTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/store/view/MaterializedViewWriterTest.java
@@ -138,16 +138,17 @@ public class MaterializedViewWriterTest {
     KafkaKey kafkaKey = mock(KafkaKey.class);
     doReturn(KafkaKey.HEART_BEAT.getKey()).when(kafkaKey).getKey();
     ComplexVeniceWriter veniceWriter = mock(ComplexVeniceWriter.class);
-    when(veniceWriter.sendHeartbeat(anyString(), anyInt(), any(), any(), anyBoolean(), any(), anyLong()))
+    when(veniceWriter.sendHeartbeat(anyString(), anyInt(), any(), any(), anyBoolean(), any(), anyLong(), anyBoolean()))
         .thenReturn(CompletableFuture.completedFuture(null));
     doReturn(CompletableFuture.completedFuture(null)).when(veniceWriter)
-        .sendHeartbeat(anyString(), anyInt(), any(), any(), anyBoolean(), any(), anyLong());
+        .sendHeartbeat(anyString(), anyInt(), any(), any(), anyBoolean(), any(), anyLong(), anyBoolean());
     materializedViewWriter.setVeniceWriter(veniceWriter);
     KafkaMessageEnvelope kafkaMessageEnvelope = mock(KafkaMessageEnvelope.class);
     PartitionConsumptionState partitionConsumptionState = mock(PartitionConsumptionState.class);
     materializedViewWriter
         .processControlMessage(kafkaKey, kafkaMessageEnvelope, controlMessage, 1, partitionConsumptionState);
-    verify(veniceWriter, never()).sendHeartbeat(anyString(), anyInt(), any(), any(), anyBoolean(), any(), anyLong());
+    verify(veniceWriter, never())
+        .sendHeartbeat(anyString(), anyInt(), any(), any(), anyBoolean(), any(), anyLong(), anyBoolean());
   }
 
   @Test

--- a/internal/venice-common/src/test/java/com/linkedin/venice/writer/VeniceWriterHeartbeatHeaderTest.java
+++ b/internal/venice-common/src/test/java/com/linkedin/venice/writer/VeniceWriterHeartbeatHeaderTest.java
@@ -1,0 +1,142 @@
+package com.linkedin.venice.writer;
+
+import static com.linkedin.venice.ConfigKeys.KAFKA_BOOTSTRAP_SERVERS;
+import static com.linkedin.venice.pubsub.api.PubSubMessageHeaders.VENICE_TRANSPORT_PROTOCOL_HEADER;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertTrue;
+
+import com.linkedin.venice.kafka.protocol.KafkaMessageEnvelope;
+import com.linkedin.venice.message.KafkaKey;
+import com.linkedin.venice.pubsub.PubSubTopicPartitionImpl;
+import com.linkedin.venice.pubsub.PubSubTopicRepository;
+import com.linkedin.venice.pubsub.api.PubSubMessageHeader;
+import com.linkedin.venice.pubsub.api.PubSubMessageHeaders;
+import com.linkedin.venice.pubsub.api.PubSubProducerAdapter;
+import com.linkedin.venice.pubsub.api.PubSubProducerCallback;
+import com.linkedin.venice.pubsub.api.PubSubTopicPartition;
+import com.linkedin.venice.serialization.DefaultSerializer;
+import com.linkedin.venice.serialization.avro.AvroProtocolDefinition;
+import com.linkedin.venice.utils.SystemTime;
+import com.linkedin.venice.utils.VeniceProperties;
+import java.nio.charset.StandardCharsets;
+import java.util.Properties;
+import java.util.concurrent.CompletableFuture;
+import org.apache.avro.Schema;
+import org.mockito.ArgumentCaptor;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+
+public class VeniceWriterHeartbeatHeaderTest {
+  private VeniceWriter<byte[], byte[], byte[]> veniceWriter;
+  private PubSubProducerAdapter mockProducerAdapter;
+  private Schema testSchema;
+  private PubSubTopicPartition topicPartition;
+  private PubSubTopicRepository pubSubTopicRepository;
+
+  @BeforeMethod
+  public void setUp() {
+    mockProducerAdapter = mock(PubSubProducerAdapter.class);
+    testSchema = AvroProtocolDefinition.KAFKA_MESSAGE_ENVELOPE.getCurrentProtocolVersionSchema();
+    pubSubTopicRepository = new PubSubTopicRepository();
+    topicPartition = new PubSubTopicPartitionImpl(pubSubTopicRepository.getTopic("test_topic_v1"), 0);
+
+    // Mock producer adapter to return completed future
+    when(mockProducerAdapter.sendMessage(anyString(), anyInt(), any(), any(), any(), any()))
+        .thenReturn(CompletableFuture.completedFuture(null));
+
+    // Create VeniceWriter with protocol schema override to enable VTP headers
+    VeniceWriterOptions options =
+        new VeniceWriterOptions.Builder("test_topic").setKeyPayloadSerializer(new DefaultSerializer())
+            .setValuePayloadSerializer(new DefaultSerializer())
+            .setWriteComputePayloadSerializer(new DefaultSerializer())
+            .setTime(SystemTime.INSTANCE)
+            .setPartitioner(null)
+            .setPartitionCount(1) // Set partition count to avoid "Invalid number of partitions: 0" error
+            .build();
+
+    // Create test properties for VeniceWriter
+    Properties testProperties = new Properties();
+    testProperties.put(KAFKA_BOOTSTRAP_SERVERS, "localhost:9092");
+
+    // Override protocol schema to enable VTP headers.
+    veniceWriter = new VeniceWriter<>(options, new VeniceProperties(testProperties), mockProducerAdapter, testSchema);
+  }
+
+  @Test
+  public void testHeartbeatMessageDoesNotIncludeVtpHeader() {
+    // Arrange
+    ArgumentCaptor<PubSubMessageHeaders> headersCaptor = ArgumentCaptor.forClass(PubSubMessageHeaders.class);
+
+    // Act - Send heartbeat message
+    veniceWriter.sendHeartbeat(
+        topicPartition,
+        mock(PubSubProducerCallback.class),
+        VeniceWriter.DEFAULT_LEADER_METADATA_WRAPPER,
+        false,
+        LeaderCompleteState.LEADER_NOT_COMPLETED,
+        System.currentTimeMillis(),
+        true);
+
+    // Assert
+    verify(mockProducerAdapter).sendMessage(
+        eq("test_topic_v1"),
+        eq(0),
+        eq(KafkaKey.HEART_BEAT),
+        any(KafkaMessageEnvelope.class),
+        headersCaptor.capture(),
+        any(PubSubProducerCallback.class));
+
+    PubSubMessageHeaders capturedHeaders = headersCaptor.getValue();
+
+    // Verify VTP header is NOT present in heartbeat message
+    PubSubMessageHeader vtpHeader = capturedHeaders.get(VENICE_TRANSPORT_PROTOCOL_HEADER);
+    assertNull(vtpHeader, "Heartbeat messages should not include VTP headers");
+  }
+
+  @Test
+  public void testDataMessageIncludesVtpHeaderWhenFirstMessage() {
+    // Arrange
+    ArgumentCaptor<PubSubMessageHeaders> headersCaptor = ArgumentCaptor.forClass(PubSubMessageHeaders.class);
+
+    // Act - Send first data message (segment=0, sequence=0)
+    veniceWriter.put(
+        "test_key".getBytes(StandardCharsets.UTF_8),
+        "test_value".getBytes(StandardCharsets.UTF_8),
+        1,
+        (PubSubProducerCallback) null,
+        VeniceWriter.DEFAULT_LEADER_METADATA_WRAPPER);
+
+    // Assert - sendMessage may be called multiple times (for views, etc.)
+    verify(mockProducerAdapter, atLeastOnce()).sendMessage(
+        anyString(),
+        anyInt(),
+        any(KafkaKey.class),
+        any(KafkaMessageEnvelope.class),
+        headersCaptor.capture(),
+        any(PubSubProducerCallback.class));
+
+    // Check if any of the captured headers contains VTP header
+    boolean foundVtpHeader = false;
+    for (PubSubMessageHeaders capturedHeaders: headersCaptor.getAllValues()) {
+      PubSubMessageHeader vtpHeader = capturedHeaders.get(VENICE_TRANSPORT_PROTOCOL_HEADER);
+      if (vtpHeader != null) {
+        foundVtpHeader = true;
+        // Verify header contains the protocol schema
+        String schemaString = new String(vtpHeader.value(), StandardCharsets.UTF_8);
+        assertTrue(schemaString.contains("KafkaMessageEnvelope"), "VTP header should contain KME schema");
+        break;
+      }
+    }
+
+    assertTrue(foundVtpHeader, "First data message should include VTP header");
+  }
+}

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/helix/TestServerKMERegistrationFromMessageHeader.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/helix/TestServerKMERegistrationFromMessageHeader.java
@@ -1,7 +1,9 @@
 package com.linkedin.venice.helix;
 
 import static com.linkedin.venice.ConfigKeys.KME_REGISTRATION_FROM_MESSAGE_HEADER_ENABLED;
+import static com.linkedin.venice.integration.utils.VeniceServerWrapper.CLIENT_CONFIG_FOR_CONSUMER;
 
+import com.linkedin.venice.client.store.ClientConfig;
 import com.linkedin.venice.compression.CompressionStrategy;
 import com.linkedin.venice.controllerapi.ControllerClient;
 import com.linkedin.venice.controllerapi.VersionCreationResponse;
@@ -9,16 +11,22 @@ import com.linkedin.venice.integration.utils.ServiceFactory;
 import com.linkedin.venice.integration.utils.VeniceClusterCreateOptions;
 import com.linkedin.venice.integration.utils.VeniceClusterWrapper;
 import com.linkedin.venice.integration.utils.VeniceControllerWrapper;
+import com.linkedin.venice.integration.utils.VeniceRouterWrapper;
 import com.linkedin.venice.integration.utils.VeniceServerWrapper;
 import com.linkedin.venice.meta.Version;
 import com.linkedin.venice.pubsub.PubSubProducerAdapterFactory;
+import com.linkedin.venice.pubsub.PubSubTopicPartitionImpl;
+import com.linkedin.venice.pubsub.PubSubTopicRepository;
+import com.linkedin.venice.pubsub.api.PubSubTopicPartition;
 import com.linkedin.venice.serialization.VeniceKafkaSerializer;
 import com.linkedin.venice.serialization.avro.AvroProtocolDefinition;
 import com.linkedin.venice.serialization.avro.KafkaValueSerializer;
 import com.linkedin.venice.serialization.avro.VeniceAvroKafkaSerializer;
 import com.linkedin.venice.utils.IntegrationTestPushUtils;
+import com.linkedin.venice.utils.SslUtils;
 import com.linkedin.venice.utils.TestUtils;
 import com.linkedin.venice.utils.Utils;
+import com.linkedin.venice.writer.LeaderCompleteState;
 import com.linkedin.venice.writer.VeniceWriter;
 import com.linkedin.venice.writer.VeniceWriterOptions;
 import java.util.HashMap;
@@ -27,8 +35,8 @@ import java.util.concurrent.TimeUnit;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.testng.Assert;
-import org.testng.annotations.AfterClass;
-import org.testng.annotations.BeforeClass;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 
@@ -50,8 +58,11 @@ public class TestServerKMERegistrationFromMessageHeader {
   private VeniceKafkaSerializer keySerializer;
   private VeniceServerWrapper server;
   private String clusterName;
+  private KafkaValueSerializer valueSerializer;
+  private int pushVersion;
+  private HelixReadWriteSchemaRepository repo;
 
-  @BeforeClass
+  @BeforeMethod(alwaysRun = true)
   public void setUp() {
     VeniceClusterCreateOptions options = new VeniceClusterCreateOptions.Builder().numberOfControllers(numOfController)
         .numberOfServers(0)
@@ -66,51 +77,31 @@ public class TestServerKMERegistrationFromMessageHeader {
 
     Properties serverProperties = new Properties();
     Properties serverFeatureProperties = new Properties();
+
+    // Enable KME registration from message header.
     serverProperties.put(KME_REGISTRATION_FROM_MESSAGE_HEADER_ENABLED, true);
+
+    // Create client config for consumer to enable schema readers.
+    ClientConfig clientConfig = new ClientConfig().setVeniceURL(cluster.getZk().getAddress())
+        .setD2ServiceName(VeniceRouterWrapper.CLUSTER_DISCOVERY_D2_SERVICE_NAME)
+        .setSslFactory(SslUtils.getVeniceLocalSslFactory());
+    serverFeatureProperties.put(CLIENT_CONFIG_FOR_CONSUMER, clientConfig);
+
     server = cluster.addVeniceServer(serverFeatureProperties, serverProperties);
   }
 
-  @AfterClass(alwaysRun = true)
+  @AfterMethod(alwaysRun = true)
   public void cleanUp() {
+    repo.clear();
+    valueSerializer.close();
+    veniceWriter.close();
     Utils.closeQuietlyWithErrorLogged(cluster);
   }
 
   @Test(timeOut = TEST_TIMEOUT)
   public void testServerKMERegistrationFromMessageHeader() {
     storeName = Utils.getUniqueString("venice-store");
-    cluster.getNewStore(storeName, KEY_SCHEMA, VALUE_SCHEMA);
-    VersionCreationResponse creationResponse = cluster.getNewVersion(storeName, false);
-
-    storeVersion = creationResponse.getKafkaTopic();
-    int pushVersion = Version.parseVersionFromKafkaTopicName(storeVersion);
-    PubSubProducerAdapterFactory pubSubProducerAdapterFactory =
-        cluster.getPubSubBrokerWrapper().getPubSubClientsFactory().getProducerAdapterFactory();
-    keySerializer = new VeniceAvroKafkaSerializer(KEY_SCHEMA);
-
-    veniceWriter =
-        IntegrationTestPushUtils.getVeniceWriterFactory(cluster.getPubSubBrokerWrapper(), pubSubProducerAdapterFactory)
-            .createVeniceWriter(
-                new VeniceWriterOptions.Builder(storeVersion).setKeyPayloadSerializer(keySerializer).build());
-
-    VeniceControllerWrapper leaderController = cluster.getLeaderVeniceController();
-    KafkaValueSerializer valueSerializer =
-        server.getVeniceServer().getKafkaStoreIngestionService().getKafkaValueSerializer();
-
-    HelixReadWriteSchemaRepositoryAdapter adapter =
-        (HelixReadWriteSchemaRepositoryAdapter) (leaderController.getVeniceHelixAdmin()
-            .getHelixVeniceClusterResources(clusterName)
-            .getSchemaRepository());
-    HelixReadWriteSchemaRepository repo =
-        (HelixReadWriteSchemaRepository) adapter.getReadWriteRegularStoreSchemaRepository();
-
-    // Wait until the latest schema appears in child colo's schema repository (ZK).
-    TestUtils.waitForNonDeterministicAssertion(30, TimeUnit.SECONDS, true, true, () -> {
-      Assert.assertEquals(
-          repo.getValueSchema(
-              AvroProtocolDefinition.KAFKA_MESSAGE_ENVELOPE.getSystemStoreName(),
-              AvroProtocolDefinition.KAFKA_MESSAGE_ENVELOPE.getCurrentProtocolVersion()).getId(),
-          AvroProtocolDefinition.KAFKA_MESSAGE_ENVELOPE.getCurrentProtocolVersion());
-    });
+    commonSetup();
 
     // Remove the latest schema from child controller's local value serializer and remove it from child colo's schema
     // repository (ZK).
@@ -143,6 +134,108 @@ public class TestServerKMERegistrationFromMessageHeader {
       int currentVersion =
           ControllerClient.getStore(controllerUrl, cluster.getClusterName(), storeName).getStore().getCurrentVersion();
       return currentVersion == pushVersion;
+    });
+  }
+
+  /**
+   * Integration test that validates the VTP header optimization for heartbeat messages.
+   *
+   * This test demonstrates that Venice can safely exclude VTP headers from heartbeat messages
+   * while maintaining full schema evolution capabilities through its system-level infrastructure.
+   *
+   * Test Scenario:
+   * 1. Remove all local KME schemas to simulate a server without cached schema knowledge
+   * 2. Send multi-heartbeats with dependentFeatureEnabled=true (excludes VTP headers)
+   * 3. Complete a full push cycle to verify schema evolution works without heartbeat VTP headers
+   *
+   * Key Validation Points:
+   * - Heartbeat messages exclude VTP headers when optimization is enabled
+   * - Schema evolution infrastructure (KME registration + schema reader) handles compatibility
+   * - Push completion succeeds despite heartbeats lacking schema information
+   * - System-level schema management is sufficient for operational needs
+   *
+   * This proves that frequent heartbeat messages can be optimized for performance without
+   * compromising Venice's robust schema evolution capabilities.
+   */
+  @Test(timeOut = TEST_TIMEOUT)
+  public void testServerDoNotIncludeKMESchemaInHeartbeatMessage() {
+    storeName = Utils.getUniqueString("venice-store-do-not-include-kme-schema");
+    commonSetup();
+
+    // Step 1: Remove all local KME schemas to simulate a server without cached schema knowledge
+    // This creates the scenario where schema evolution infrastructure must handle compatibility
+    valueSerializer.removeAllSchemas();
+    LOGGER.info("Server local schemas are removed - simulating schema evolution scenario");
+
+    // Step 2: Send multiple heartbeat messages with VTP header optimization enabled
+    // The last parameter (dependentFeatureEnabled=true) tells VeniceWriter to exclude VTP headers
+    // because we can rely on system-level schema evolution infrastructure
+    PubSubTopicRepository topicRepository = new PubSubTopicRepository();
+    PubSubTopicPartition topicPartition = new PubSubTopicPartitionImpl(topicRepository.getTopic(storeVersion), 0);
+
+    for (int i = 0; i < 10; i++) {
+      veniceWriter.sendHeartbeat(
+          topicPartition,
+          null, // No callback needed for this test
+          VeniceWriter.DEFAULT_LEADER_METADATA_WRAPPER,
+          false, // Don't add leader complete state
+          LeaderCompleteState.LEADER_NOT_COMPLETED,
+          System.currentTimeMillis(),
+          true); // dependentFeatureEnabled=true -> excludes VTP headers
+
+      LOGGER.info(
+          "Sent optimized heartbeat message #{} (no VTP headers) to topic partition: {}",
+          i,
+          topicPartition.getPubSubTopic().getName() + "-" + topicPartition.getPartitionNumber());
+    }
+
+    // Step 3: Execute a complete push cycle to validate that schema evolution works
+    // Even though heartbeats excluded VTP headers, the system should handle schema compatibility
+    // through KME schema registration and RouterBackedSchemaReader
+    veniceWriter.broadcastStartOfPush(false, false, CompressionStrategy.NO_OP, new HashMap<>());
+    veniceWriter.broadcastEndOfPush(new HashMap<>());
+
+    // Step 4: Verify successful push completion despite optimized heartbeats
+    // This proves that excluding VTP headers from heartbeats doesn't break schema evolution
+    String controllerUrl = cluster.getAllControllersURLs();
+    TestUtils.waitForNonDeterministicCompletion(30, TimeUnit.SECONDS, () -> {
+      int currentVersion =
+          ControllerClient.getStore(controllerUrl, cluster.getClusterName(), storeName).getStore().getCurrentVersion();
+      return currentVersion == pushVersion;
+    });
+  }
+
+  private void commonSetup() {
+    cluster.getNewStore(storeName, KEY_SCHEMA, VALUE_SCHEMA);
+    VersionCreationResponse creationResponse = cluster.getNewVersion(storeName, false);
+
+    storeVersion = creationResponse.getKafkaTopic();
+    pushVersion = Version.parseVersionFromKafkaTopicName(storeVersion);
+    PubSubProducerAdapterFactory pubSubProducerAdapterFactory =
+        cluster.getPubSubBrokerWrapper().getPubSubClientsFactory().getProducerAdapterFactory();
+    keySerializer = new VeniceAvroKafkaSerializer(KEY_SCHEMA);
+
+    veniceWriter =
+        IntegrationTestPushUtils.getVeniceWriterFactory(cluster.getPubSubBrokerWrapper(), pubSubProducerAdapterFactory)
+            .createVeniceWriter(
+                new VeniceWriterOptions.Builder(storeVersion).setKeyPayloadSerializer(keySerializer).build());
+
+    VeniceControllerWrapper leaderController = cluster.getLeaderVeniceController();
+    valueSerializer = server.getVeniceServer().getKafkaStoreIngestionService().getKafkaValueSerializer();
+
+    HelixReadWriteSchemaRepositoryAdapter adapter =
+        (HelixReadWriteSchemaRepositoryAdapter) (leaderController.getVeniceHelixAdmin()
+            .getHelixVeniceClusterResources(clusterName)
+            .getSchemaRepository());
+    repo = (HelixReadWriteSchemaRepository) adapter.getReadWriteRegularStoreSchemaRepository();
+
+    // Wait until the latest schema appears in child colo's schema repository (ZK).
+    TestUtils.waitForNonDeterministicAssertion(30, TimeUnit.SECONDS, true, true, () -> {
+      Assert.assertEquals(
+          repo.getValueSchema(
+              AvroProtocolDefinition.KAFKA_MESSAGE_ENVELOPE.getSystemStoreName(),
+              AvroProtocolDefinition.KAFKA_MESSAGE_ENVELOPE.getCurrentProtocolVersion()).getId(),
+          AvroProtocolDefinition.KAFKA_MESSAGE_ENVELOPE.getCurrentProtocolVersion());
     });
   }
 }


### PR DESCRIPTION
## Problem Statement
Heartbeat messages in Venice were including Venice Transport Protocol (VTP) headers unnecessarily, adding overhead to frequent heartbeat communications. Since heartbeats are primarily for liveness detection rather than data transport, this overhead was wasteful.


## Solution
Implemented an optimization to conditionally exclude VTP headers from heartbeat messages when Venice's robust schema evolution infrastructure is available to handle compatibility.

When dependent features are enabled, heartbeat messages skip VTP headers because:
- KME Schema Registration: Servers register schemas during startup via ControllerClientBackedSystemSchemaInitializer
- Schema Reader: RouterBackedSchemaReader automatically fetches unknown schemas from system store
- Graceful Handling: InternalAvroSpecificSerializer handles unknown protocol versions via schema reader

Testing
- Updated existing tests to maintain compatibility
- Add new integration test to validate that optimization works correctly with Venice's KME schema evolution infrastructure (TestServerKMERegistrationFromMessageHeader.java)

###  Code changes
- [ ] Added new code behind **a config**. If so list the config names and their default values in the PR description.
- [x] Introduced new **log lines**. 
  - [x] Confirmed if logs need to be **rate limited** to avoid excessive logging.

###  **Concurrency-Specific Checks**
Both reviewer and PR author to verify
- [x] Code has **no race conditions** or **thread safety issues**.
- [ ] Proper **synchronization mechanisms** (e.g., `synchronized`, `RWLock`) are used where needed.
- [ ] No **blocking calls** inside critical sections that could lead to deadlocks or performance degradation.
- [ ] Verified **thread-safe collections** are used (e.g., `ConcurrentHashMap`, `CopyOnWriteArrayList`).
- [ ] Validated proper exception handling in multi-threaded code to avoid silent thread termination.


## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->

- [x] New unit tests added.
- [x] New integration tests added.
- [ ] Modified or extended existing tests.
- [ ] Verified backward compatibility (if applicable).

## Does this PR introduce any user-facing or breaking changes?
<!--  
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [ ] No. You can skip the rest of this section.
- [ ] Yes. Clearly explain the behavior change and its impact.