### PR TITLE
[controller] Disallow store migration actions on child controllers

### DIFF
--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/server/StoresRoutes.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/server/StoresRoutes.java
@@ -351,6 +351,11 @@ public class StoresRoutes extends AbstractRoute {
         if (!checkIsAllowListUser(request, veniceResponse, () -> isAllowListUser(request))) {
           return;
         }
+        if (!admin.isParent()) {
+          veniceResponse.setError("Store migration is only allowed from a parent controller!");
+          veniceResponse.setErrorType(ErrorType.BAD_REQUEST);
+          return;
+        }
         AdminSparkServer.validateParams(request, MIGRATE_STORE.getParams(), admin);
         String srcClusterName = request.queryParams(CLUSTER);
         String destClusterName = request.queryParams(CLUSTER_DEST);
@@ -406,6 +411,11 @@ public class StoresRoutes extends AbstractRoute {
         if (!checkIsAllowListUser(request, veniceResponse, () -> isAllowListUser(request))) {
           return;
         }
+        if (!admin.isParent()) {
+          veniceResponse.setError("Complete migration is only allowed from a parent controller!");
+          veniceResponse.setErrorType(ErrorType.BAD_REQUEST);
+          return;
+        }
         AdminSparkServer.validateParams(request, COMPLETE_MIGRATION.getParams(), admin);
         String srcClusterName = request.queryParams(CLUSTER);
         String destClusterName = request.queryParams(CLUSTER_DEST);
@@ -448,6 +458,11 @@ public class StoresRoutes extends AbstractRoute {
           if (!checkIsAllowListUser(request, veniceResponse, () -> isAllowListUser(request))) {
             return;
           }
+          if (!admin.isParent()) {
+            veniceResponse.setError("Abort migration is only allowed from a parent controller!");
+            veniceResponse.setErrorType(ErrorType.BAD_REQUEST);
+            return;
+          }
           AdminSparkServer.validateParams(request, ABORT_MIGRATION.getParams(), admin);
           String srcClusterName = request.queryParams(CLUSTER);
           String destClusterName = request.queryParams(CLUSTER_DEST);
@@ -482,6 +497,11 @@ public class StoresRoutes extends AbstractRoute {
         try {
           // Only allow allowlist users to run this command
           if (!checkIsAllowListUser(request, storeMigrationResponse, () -> isAllowListUser(request))) {
+            return;
+          }
+          if (!admin.isParent()) {
+            storeMigrationResponse.setError("Auto store migration is only allowed from a parent controller!");
+            storeMigrationResponse.setErrorType(ErrorType.BAD_REQUEST);
             return;
           }
           AdminSparkServer.validateParams(request, MIGRATE_STORE.getParams(), admin);


### PR DESCRIPTION
## Problem Statement
Currently, users can send migration requests to child controllers by mistake which causes the store and its metadata in a weird state resulting in unusable state. 

###  Code changes
Add isParent() guards to migrateStore, completeMigration, abortMigration, and autoMigrateStore route handlers in StoresRoutes so that migration requests sent directly to child controllers are rejected with BAD_REQUEST. Internal admin message consumption (via AdminExecutionTask) is unaffected since it does not go through these HTTP routes.

## How was this PR tested?

- [x] New unit tests added.
- [x] Modified or extended existing tests.

## Does this PR introduce any user-facing or breaking changes?
- [x] No. You can skip the rest of this section.
- [ ] Yes. Clearly explain the behavior change and its impact.