### PR TITLE
[controller] Add pluggable SystemStoreHealthChecker to replace heartbeat write+read cycle

### DIFF
--- a/internal/venice-common/src/main/java/com/linkedin/venice/ConfigKeys.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/ConfigKeys.java
@@ -737,6 +737,22 @@ public class ConfigKeys {
       "controller.parent.system.store.version.refresh.threshold.in.days";
 
   /**
+   * Maximum number of system stores to repair in a single round per cluster. When there are more unhealthy stores
+   * than this limit, the excess stores will be deferred to the next round. A negative value (e.g. -1) means
+   * unlimited. A value of 0 disables repair entirely: health checking still runs and the bad-store metrics are
+   * still updated, but no store is repaired. Default is 50.
+   */
+  public static final String CONTROLLER_PARENT_SYSTEM_STORE_REPAIR_MAX_PER_ROUND =
+      "controller.parent.system.store.repair.max.per.round";
+
+  /**
+   * Fully qualified class name of an optional {@code SystemStoreHealthChecker} override. When set, this checker runs
+   * to check system store health. Default value is empty, will fall back to {@code HeartbeatBasedSystemStoreHealthChecker}.
+   */
+  public static final String CONTROLLER_PARENT_SYSTEM_STORE_HEALTH_CHECK_OVERRIDE_CLASS_NAME =
+      "controller.parent.system.store.health.check.override.class.name";
+
+  /**
    * Whether to initialize system schemas when controller starts. Default is true.
    */
   public static final String SYSTEM_SCHEMA_INITIALIZATION_AT_START_TIME_ENABLED =

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/SystemStoreMultiColoTest.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/SystemStoreMultiColoTest.java
@@ -28,6 +28,7 @@ import com.linkedin.venice.integration.utils.VeniceControllerWrapper;
 import com.linkedin.venice.integration.utils.VeniceMultiClusterWrapper;
 import com.linkedin.venice.integration.utils.VeniceMultiRegionClusterCreateOptions;
 import com.linkedin.venice.integration.utils.VeniceRouterWrapper;
+import com.linkedin.venice.integration.utils.VeniceServerWrapper;
 import com.linkedin.venice.integration.utils.VeniceTwoLayerMultiRegionMultiClusterWrapper;
 import com.linkedin.venice.meta.Store;
 import com.linkedin.venice.meta.Version;
@@ -38,6 +39,7 @@ import com.linkedin.venice.utils.TestUtils;
 import com.linkedin.venice.utils.Utils;
 import java.util.List;
 import java.util.Properties;
+import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import org.testng.Assert;
 import org.testng.annotations.AfterClass;
@@ -150,6 +152,32 @@ public class SystemStoreMultiColoTest {
       }
     }
 
+    // Verify that heartbeat delay metrics are registered in the server's MetricsRepository for system stores.
+    String metaStoreName = VeniceSystemStoreUtils.getMetaStoreName(userStoreName);
+    String pushStatusStoreName = VeniceSystemStoreUtils.getDaVinciPushStatusStoreName(userStoreName);
+    // The versioned stats reporter creates metrics with the format:
+    // .{storeName}_current--heartbeat_delay_ms_leader-{StatType}
+    // We use prefix matching because the StatType suffix (Gauge, Avg, Max, etc.) varies.
+    String metaStoreMetricPrefix = "." + metaStoreName + "_current--heartbeat_delay_ms_leader-";
+    String pushStatusStoreMetricPrefix = "." + pushStatusStoreName + "_current--heartbeat_delay_ms_leader-";
+
+    // Guard against a future config change dropping the server count to zero, which would make the per-server
+    // metric assertions below pass vacuously. Also note getMetricsRepository() assumes in-process servers.
+    Assert.assertFalse(
+        cluster.getVeniceServers().isEmpty(),
+        "expected at least one in-process Venice server to assert heartbeat delay metrics on");
+    for (VeniceServerWrapper serverWrapper: cluster.getVeniceServers()) {
+      Set<String> metricNames = serverWrapper.getMetricsRepository().metrics().keySet();
+
+      Assert.assertTrue(
+          metricNames.stream().anyMatch(name -> name.contains(metaStoreMetricPrefix)),
+          "Expected heartbeat delay metric for meta system store " + metaStoreName
+              + " in server MetricsRepository, but not found. Looked for prefix: " + metaStoreMetricPrefix);
+      Assert.assertTrue(
+          metricNames.stream().anyMatch(name -> name.contains(pushStatusStoreMetricPrefix)),
+          "Expected heartbeat delay metric for push status system store " + pushStatusStoreName
+              + " in server MetricsRepository, but not found. Looked for prefix: " + pushStatusStoreMetricPrefix);
+    }
   }
 
   @Test(timeOut = TEST_TIMEOUT_MS)

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceControllerClusterConfig.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceControllerClusterConfig.java
@@ -81,8 +81,10 @@ import static com.linkedin.venice.ConfigKeys.CONTROLLER_NAME;
 import static com.linkedin.venice.ConfigKeys.CONTROLLER_PARENT_EXTERNAL_SUPERSET_SCHEMA_GENERATION_ENABLED;
 import static com.linkedin.venice.ConfigKeys.CONTROLLER_PARENT_MODE;
 import static com.linkedin.venice.ConfigKeys.CONTROLLER_PARENT_REGION_STATE;
+import static com.linkedin.venice.ConfigKeys.CONTROLLER_PARENT_SYSTEM_STORE_HEALTH_CHECK_OVERRIDE_CLASS_NAME;
 import static com.linkedin.venice.ConfigKeys.CONTROLLER_PARENT_SYSTEM_STORE_HEARTBEAT_CHECK_WAIT_TIME_SECONDS;
 import static com.linkedin.venice.ConfigKeys.CONTROLLER_PARENT_SYSTEM_STORE_REPAIR_CHECK_INTERVAL_SECONDS;
+import static com.linkedin.venice.ConfigKeys.CONTROLLER_PARENT_SYSTEM_STORE_REPAIR_MAX_PER_ROUND;
 import static com.linkedin.venice.ConfigKeys.CONTROLLER_PARENT_SYSTEM_STORE_REPAIR_SERVICE_ENABLED;
 import static com.linkedin.venice.ConfigKeys.CONTROLLER_PARENT_SYSTEM_STORE_VERSION_REFRESH_THRESHOLD_IN_DAYS;
 import static com.linkedin.venice.ConfigKeys.CONTROLLER_PROTOCOL_VERSION_AUTO_DETECTION_SERVICE_ENABLED;
@@ -479,6 +481,10 @@ public class VeniceControllerClusterConfig {
   private final int parentSystemStoreHeartbeatCheckWaitTimeSeconds;
 
   private final int parentSystemStoreVersionRefreshThresholdInDays;
+
+  private final int systemStoreRepairMaxPerRound;
+
+  private final String systemStoreHealthCheckOverrideClassName;
 
   private final boolean parentExternalSupersetSchemaGenerationEnabled;
 
@@ -1199,6 +1205,9 @@ public class VeniceControllerClusterConfig {
         props.getInt(CONTROLLER_PARENT_SYSTEM_STORE_HEARTBEAT_CHECK_WAIT_TIME_SECONDS, 600);
     this.parentSystemStoreVersionRefreshThresholdInDays =
         props.getInt(CONTROLLER_PARENT_SYSTEM_STORE_VERSION_REFRESH_THRESHOLD_IN_DAYS, 30);
+    this.systemStoreRepairMaxPerRound = props.getInt(CONTROLLER_PARENT_SYSTEM_STORE_REPAIR_MAX_PER_ROUND, 50);
+    this.systemStoreHealthCheckOverrideClassName =
+        props.getString(CONTROLLER_PARENT_SYSTEM_STORE_HEALTH_CHECK_OVERRIDE_CLASS_NAME, "");
     this.clusterDiscoveryD2ServiceName =
         props.getString(CLUSTER_DISCOVERY_D2_SERVICE, ClientConfig.DEFAULT_CLUSTER_DISCOVERY_D2_SERVICE_NAME);
     this.parentExternalSupersetSchemaGenerationEnabled =
@@ -2216,6 +2225,14 @@ public class VeniceControllerClusterConfig {
 
   public int getParentSystemStoreVersionRefreshThresholdInDays() {
     return parentSystemStoreVersionRefreshThresholdInDays;
+  }
+
+  public int getSystemStoreRepairMaxPerRound() {
+    return systemStoreRepairMaxPerRound;
+  }
+
+  public String getSystemStoreHealthCheckOverrideClassName() {
+    return systemStoreHealthCheckOverrideClassName;
   }
 
   public boolean isParentExternalSupersetSchemaGenerationEnabled() {

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/stats/SystemStoreHealthCheckStats.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/stats/SystemStoreHealthCheckStats.java
@@ -32,9 +32,11 @@ public class SystemStoreHealthCheckStats extends AbstractVeniceStats {
   private final Sensor badMetaSystemStoreCountSensor;
   private final Sensor badPushStatusSystemStoreCountSensor;
   private final Sensor notRepairableSystemStoreCountSensor;
+  private final Sensor systemStoreHealthCheckErrorCountSensor;
   private final AtomicLong badMetaSystemStoreCounter = new AtomicLong(0);
   private final AtomicLong badPushStatusSystemStoreCounter = new AtomicLong(0);
   private final AtomicLong notRepairableSystemStoreCounter = new AtomicLong(0);
+  private final AtomicLong systemStoreHealthCheckErrorCounter = new AtomicLong(0);
 
   public SystemStoreHealthCheckStats(MetricsRepository metricsRepository, String name) {
     super(metricsRepository, name);
@@ -54,6 +56,10 @@ public class SystemStoreHealthCheckStats extends AbstractVeniceStats {
         new AsyncGauge(
             (ignored, ignored2) -> notRepairableSystemStoreCounter.get(),
             SystemStoreHealthCheckTehutiMetricNameEnum.NOT_REPAIRABLE_SYSTEM_STORE_COUNT.getMetricName()));
+    systemStoreHealthCheckErrorCountSensor = registerSensorIfAbsent(
+        new AsyncGauge(
+            (ignored, ignored2) -> systemStoreHealthCheckErrorCounter.get(),
+            SystemStoreHealthCheckTehutiMetricNameEnum.SYSTEM_STORE_HEALTH_CHECK_ERROR_COUNT.getMetricName()));
 
     // OTel setup
     OpenTelemetryMetricsSetup.OpenTelemetryMetricsSetupInfo otelData =
@@ -93,6 +99,13 @@ public class SystemStoreHealthCheckStats extends AbstractVeniceStats {
         baseDimensionsMap,
         baseAttributes,
         notRepairableSystemStoreCounter::get);
+
+    AsyncMetricEntityStateBase.create(
+        SystemStoreHealthCheckOtelMetricEntity.SYSTEM_STORE_HEALTH_CHECK_ERROR_COUNT.getMetricEntity(),
+        otelRepository,
+        baseDimensionsMap,
+        baseAttributes,
+        systemStoreHealthCheckErrorCounter::get);
   }
 
   public AtomicLong getBadMetaSystemStoreCounter() {
@@ -107,8 +120,13 @@ public class SystemStoreHealthCheckStats extends AbstractVeniceStats {
     return notRepairableSystemStoreCounter;
   }
 
+  public AtomicLong getSystemStoreHealthCheckErrorCounter() {
+    return systemStoreHealthCheckErrorCounter;
+  }
+
   enum SystemStoreHealthCheckTehutiMetricNameEnum implements TehutiMetricNameEnum {
-    BAD_META_SYSTEM_STORE_COUNT, BAD_PUSH_STATUS_SYSTEM_STORE_COUNT, NOT_REPAIRABLE_SYSTEM_STORE_COUNT
+    BAD_META_SYSTEM_STORE_COUNT, BAD_PUSH_STATUS_SYSTEM_STORE_COUNT, NOT_REPAIRABLE_SYSTEM_STORE_COUNT,
+    SYSTEM_STORE_HEALTH_CHECK_ERROR_COUNT
   }
 
   public enum SystemStoreHealthCheckOtelMetricEntity implements ModuleMetricEntityInterface {
@@ -120,6 +138,11 @@ public class SystemStoreHealthCheckStats extends AbstractVeniceStats {
     SYSTEM_STORE_UNREPAIRABLE_COUNT(
         "system_store.health_check.unrepairable_count", MetricType.ASYNC_GAUGE, MetricUnit.NUMBER,
         "System stores that cannot be repaired", setOf(VENICE_CLUSTER_NAME)
+    ),
+    SYSTEM_STORE_HEALTH_CHECK_ERROR_COUNT(
+        "system_store.health_check.error_count", MetricType.ASYNC_GAUGE, MetricUnit.NUMBER,
+        "Cumulative count of system store health-check invocations that failed by throwing or returning null",
+        setOf(VENICE_CLUSTER_NAME)
     );
 
     private final MetricEntity metricEntity;

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/systemstore/HeartbeatBasedSystemStoreHealthChecker.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/systemstore/HeartbeatBasedSystemStoreHealthChecker.java
@@ -1,0 +1,200 @@
+package com.linkedin.venice.controller.systemstore;
+
+import com.linkedin.venice.controller.VeniceParentHelixAdmin;
+import com.linkedin.venice.controllerapi.ControllerClient;
+import com.linkedin.venice.utils.LatencyUtils;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.BooleanSupplier;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+
+/**
+ * Default {@link SystemStoreHealthChecker} implementation that uses the heartbeat write+read cycle to determine
+ * system store health.
+ *
+ * For each store, it sends a heartbeat timestamp to all child regions, then polls periodically until the heartbeat
+ * is read back or a timeout is reached. A store that reads back a fresh heartbeat is marked HEALTHY; a store that
+ * still returns a stale or unreachable heartbeat once the timeout elapses is marked UNHEALTHY. Stores that are
+ * never polled before the check aborts (e.g., leadership loss or shutdown) are omitted from the result and
+ * deferred to the next round, per the {@link SystemStoreHealthChecker} contract.
+ */
+public class HeartbeatBasedSystemStoreHealthChecker implements SystemStoreHealthChecker {
+  private static final Logger LOGGER = LogManager.getLogger(HeartbeatBasedSystemStoreHealthChecker.class);
+  private static final int DEFAULT_HEARTBEAT_CHECK_INTERVAL_IN_SECONDS = 30;
+  private static final int DEFAULT_PER_SYSTEM_STORE_HEARTBEAT_CHECK_INTERVAL_IN_MS = 100;
+  private static final int DEFAULT_CHECK_LOGGING_COUNT = 100;
+
+  private final VeniceParentHelixAdmin parentAdmin;
+  private final int heartbeatWaitTimeInSeconds;
+  private final AtomicBoolean isRunning;
+
+  public HeartbeatBasedSystemStoreHealthChecker(
+      VeniceParentHelixAdmin parentAdmin,
+      int heartbeatWaitTimeInSeconds,
+      AtomicBoolean isRunning) {
+    this.parentAdmin = parentAdmin;
+    this.heartbeatWaitTimeInSeconds = heartbeatWaitTimeInSeconds;
+    this.isRunning = isRunning;
+  }
+
+  @Override
+  public Map<String, HealthCheckResult> checkHealth(String clusterName, Set<String> systemStoreNames) {
+    Map<String, HealthCheckResult> results = new HashMap<>();
+    if (systemStoreNames.isEmpty()) {
+      return Collections.emptyMap();
+    }
+
+    // Phase 1: Send heartbeats to all stores
+    Map<String, Long> storeToHeartbeatTimestamp = new HashMap<>();
+    int count = 0;
+    long startTimestamp = System.currentTimeMillis();
+    for (String storeName: systemStoreNames) {
+      if (!shouldContinue(clusterName)) {
+        return results;
+      }
+      long currentTimestamp = System.currentTimeMillis();
+      sendHeartbeatToSystemStore(clusterName, storeName, currentTimestamp);
+      storeToHeartbeatTimestamp.put(storeName, currentTimestamp);
+      count++;
+      if ((count % DEFAULT_CHECK_LOGGING_COUNT) == 0) {
+        LOGGER.info(
+            "Sent heartbeat to {} system stores, took: {} ms",
+            count,
+            LatencyUtils.getElapsedTimeFromMsToMs(startTimestamp));
+      }
+      LatencyUtils.sleep(DEFAULT_PER_SYSTEM_STORE_HEARTBEAT_CHECK_INTERVAL_IN_MS);
+    }
+
+    // Phase 2: Poll for heartbeat reads. A store that reads back a fresh heartbeat on any poll is marked HEALTHY
+    // immediately; a store that stays stale/unreachable is kept pending and only marked UNHEALTHY after the wait
+    // window elapses (handled inside checkHeartbeatFromSystemStores), so a round aborted mid-poll never records a
+    // speculative UNHEALTHY. Stores never polled before an abort are omitted from the results map entirely, per the
+    // SystemStoreHealthChecker contract — the caller treats missing entries as "deferred" rather than UNHEALTHY.
+    checkHeartbeatFromSystemStores(clusterName, storeToHeartbeatTimestamp, results);
+
+    return Collections.unmodifiableMap(results);
+  }
+
+  void sendHeartbeatToSystemStore(String clusterName, String systemStoreName, long heartbeatTimestamp) {
+    for (Map.Entry<String, ControllerClient> entry: getControllerClientMap(clusterName).entrySet()) {
+      entry.getValue().sendHeartbeatToSystemStore(systemStoreName, heartbeatTimestamp);
+    }
+  }
+
+  long getHeartbeatFromSystemStore(String clusterName, String systemStoreName) {
+    long oldestHeartbeatTimestamp = Long.MAX_VALUE;
+    for (Map.Entry<String, ControllerClient> entry: getControllerClientMap(clusterName).entrySet()) {
+      long timestamp = entry.getValue().getHeartbeatFromSystemStore(systemStoreName).getHeartbeatTimestamp();
+      if (oldestHeartbeatTimestamp > timestamp) {
+        oldestHeartbeatTimestamp = timestamp;
+      }
+    }
+    return oldestHeartbeatTimestamp;
+  }
+
+  Map<String, ControllerClient> getControllerClientMap(String clusterName) {
+    return parentAdmin.getVeniceHelixAdmin().getControllerClientMap(clusterName);
+  }
+
+  void checkHeartbeatFromSystemStores(
+      String clusterName,
+      Map<String, Long> storeToHeartbeatTimestamp,
+      Map<String, HealthCheckResult> results) {
+    // Make a mutable copy for polling
+    Map<String, Long> pendingStores = new HashMap<>(storeToHeartbeatTimestamp);
+
+    periodicCheckTask(clusterName, heartbeatWaitTimeInSeconds, getHeartbeatCheckIntervalInSeconds(), () -> {
+      List<String> listToRemove = new ArrayList<>();
+      int checkCount = 0;
+      long checkStartTimestamp = System.currentTimeMillis();
+      for (Map.Entry<String, Long> entry: pendingStores.entrySet()) {
+        if (!shouldContinue(clusterName)) {
+          return true;
+        }
+
+        long retrievedHeartbeatTimestamp = getHeartbeatFromSystemStore(clusterName, entry.getKey());
+        if (retrievedHeartbeatTimestamp >= entry.getValue()) {
+          // Fresh heartbeat received
+          listToRemove.add(entry.getKey());
+          results.put(entry.getKey(), HealthCheckResult.HEALTHY);
+        } else {
+          // Stale or unreachable on this poll: keep the store pending so a later poll can still flip it to
+          // HEALTHY. The UNHEALTHY decision is deferred until the wait window elapses (handled after the polling
+          // loop) so a round aborted mid-poll does not record a premature, speculative UNHEALTHY result.
+          if (retrievedHeartbeatTimestamp == -1) {
+            LOGGER.warn(
+                "System store: {} in cluster: {} is not reachable for heartbeat request.",
+                entry.getKey(),
+                clusterName);
+          } else {
+            LOGGER.warn(
+                "Expect heartbeat: {} from system store: {} in cluster: {}, got stale heartbeat: {}.",
+                entry.getValue(),
+                entry.getKey(),
+                clusterName,
+                retrievedHeartbeatTimestamp);
+          }
+        }
+        checkCount++;
+        if ((checkCount % DEFAULT_CHECK_LOGGING_COUNT) == 0) {
+          LOGGER.info(
+              "Checked heartbeat for {} system stores, took: {} ms",
+              checkCount,
+              LatencyUtils.getElapsedTimeFromMsToMs(checkStartTimestamp));
+        }
+      }
+      for (String key: listToRemove) {
+        pendingStores.remove(key);
+      }
+      return pendingStores.isEmpty();
+    });
+
+    // Any store still pending never read back a fresh heartbeat. Only mark these UNHEALTHY when the check ran to
+    // completion (the wait window elapsed while still leader/running). If polling aborted early (leadership loss
+    // or shutdown), leave them out of the results so they are deferred to the next round, per the
+    // SystemStoreHealthChecker contract — a store is omitted only when no decision was reached for it.
+    if (shouldContinue(clusterName)) {
+      for (String pendingStore: pendingStores.keySet()) {
+        results.put(pendingStore, HealthCheckResult.UNHEALTHY);
+      }
+    }
+  }
+
+  void periodicCheckTask(
+      String clusterName,
+      int maxWaitTimeInSeconds,
+      int checkIntervalInSeconds,
+      BooleanSupplier checkTask) {
+    long startCheckingTime = System.currentTimeMillis();
+    while ((System.currentTimeMillis() - startCheckingTime) <= TimeUnit.SECONDS.toMillis(maxWaitTimeInSeconds)) {
+      if (!shouldContinue(clusterName)) {
+        return;
+      }
+      boolean result = checkTask.getAsBoolean();
+      if (result) {
+        LOGGER.info("Check task completed for {} ms", System.currentTimeMillis() - startCheckingTime);
+        return;
+      }
+      LatencyUtils.sleep(TimeUnit.SECONDS.toMillis(checkIntervalInSeconds));
+    }
+  }
+
+  boolean shouldContinue(String clusterName) {
+    if (!isRunning.get()) {
+      return false;
+    }
+    return parentAdmin.isLeaderControllerFor(clusterName);
+  }
+
+  int getHeartbeatCheckIntervalInSeconds() {
+    return DEFAULT_HEARTBEAT_CHECK_INTERVAL_IN_SECONDS;
+  }
+}

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/systemstore/SystemStoreHealthChecker.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/systemstore/SystemStoreHealthChecker.java
@@ -1,0 +1,55 @@
+package com.linkedin.venice.controller.systemstore;
+
+import java.util.Map;
+import java.util.Set;
+
+
+/**
+ * Pluggable interface for checking the health of Venice system stores.
+ *
+ * The default implementation ({@link HeartbeatBasedSystemStoreHealthChecker}) uses the existing heartbeat write+read
+ * cycle. Alternative implementations (e.g., metrics-based) can be plugged in via the
+ * {@code controller.parent.system.store.health.check.override.class.name} config.
+ *
+ * <p>Custom implementations must provide a public constructor with the following signature:
+ * <pre>{@code
+ * public MyHealthChecker(VeniceControllerMultiClusterConfig config)
+ * }</pre>
+ * so they can be instantiated reflectively by the controller.
+ *
+ */
+public interface SystemStoreHealthChecker extends AutoCloseable {
+  /**
+   * Result of a system store health check.
+   */
+  enum HealthCheckResult {
+    /** Store is healthy and does not need repair. */
+    HEALTHY,
+    /** Store is unhealthy and should be repaired. */
+    UNHEALTHY
+  }
+
+  /**
+   * Check the health of the given system stores in the specified cluster.
+   *
+   * @param clusterName the Venice cluster name
+   * @param systemStoreNames the set of system store names to check
+   * @return a map from system store name to its health check result. Implementations should return an entry for
+   *         every store they were able to check. Missing entries (e.g., when the checker aborts early due to
+   *         leadership change or shutdown) are treated by the caller as "deferred to next round" — they are
+   *         neither marked HEALTHY nor UNHEALTHY for this round, so a partial result will not inflate unhealthy
+   *         counts. Implementations should therefore omit a store from the result map only when no decision was
+   *         reached for it; an explicit UNHEALTHY entry should be returned for stores that were checked and found
+   *         to be unhealthy.
+   *
+   *         <p>This method is invoked on the repair service's single-threaded scheduler, so a call that blocks
+   *         indefinitely will stall every subsequent repair round. Implementations must bound their own execution
+   *         time and honor thread interruption (the service calls {@code shutdownNow()} on shutdown) rather than
+   *         relying on the caller to time them out.
+   */
+  Map<String, HealthCheckResult> checkHealth(String clusterName, Set<String> systemStoreNames);
+
+  @Override
+  default void close() {
+  }
+}

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/systemstore/SystemStoreRepairService.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/systemstore/SystemStoreRepairService.java
@@ -6,6 +6,7 @@ import com.linkedin.venice.controller.VeniceControllerMultiClusterConfig;
 import com.linkedin.venice.controller.VeniceParentHelixAdmin;
 import com.linkedin.venice.controller.stats.SystemStoreHealthCheckStats;
 import com.linkedin.venice.service.AbstractVeniceService;
+import com.linkedin.venice.utils.ReflectUtils;
 import com.linkedin.venice.utils.concurrent.VeniceConcurrentHashMap;
 import io.tehuti.metrics.MetricsRepository;
 import java.util.Map;
@@ -28,19 +29,24 @@ public class SystemStoreRepairService extends AbstractVeniceService {
   private final AtomicBoolean isRunning = new AtomicBoolean(false);
   private final int heartbeatWaitTimeInSeconds;
   private final int versionRefreshThresholdInDays;
+  private final int maxRepairPerRound;
+  private final VeniceControllerMultiClusterConfig multiClusterConfigs;
   private ScheduledExecutorService checkServiceExecutor;
   private final Map<String, SystemStoreHealthCheckStats> clusterToSystemStoreHealthCheckStatsMap =
       new VeniceConcurrentHashMap<>();
+  private volatile SystemStoreHealthChecker healthChecker;
 
   public SystemStoreRepairService(
       VeniceParentHelixAdmin parentAdmin,
       VeniceControllerMultiClusterConfig multiClusterConfigs,
       MetricsRepository metricsRepository) {
     this.parentAdmin = parentAdmin;
+    this.multiClusterConfigs = multiClusterConfigs;
     this.repairTaskIntervalInSeconds =
         multiClusterConfigs.getCommonConfig().getParentSystemStoreRepairCheckIntervalSeconds();
     this.versionRefreshThresholdInDays =
         multiClusterConfigs.getCommonConfig().getParentSystemStoreVersionRefreshThresholdInDays();
+    this.maxRepairPerRound = multiClusterConfigs.getCommonConfig().getSystemStoreRepairMaxPerRound();
     this.heartbeatWaitTimeInSeconds =
         multiClusterConfigs.getCommonConfig().getParentSystemStoreHeartbeatCheckWaitTimeSeconds();
     for (String clusterName: multiClusterConfigs.getClusters()) {
@@ -55,13 +61,17 @@ public class SystemStoreRepairService extends AbstractVeniceService {
   public boolean startInner() {
     checkServiceExecutor = Executors.newScheduledThreadPool(1);
     isRunning.set(true);
+
+    healthChecker = loadHealthChecker();
+
     checkServiceExecutor.scheduleWithFixedDelay(
         new SystemStoreRepairTask(
             parentAdmin,
             clusterToSystemStoreHealthCheckStatsMap,
-            heartbeatWaitTimeInSeconds,
             versionRefreshThresholdInDays,
-            isRunning),
+            maxRepairPerRound,
+            isRunning,
+            healthChecker),
         repairTaskIntervalInSeconds,
         repairTaskIntervalInSeconds,
         TimeUnit.SECONDS);
@@ -80,10 +90,48 @@ public class SystemStoreRepairService extends AbstractVeniceService {
     } catch (InterruptedException e) {
       currentThread().interrupt();
     }
+    closeChecker(healthChecker);
     LOGGER.info("SystemStoreRepairService is shutdown.");
+  }
+
+  private SystemStoreHealthChecker loadHealthChecker() {
+    String className = multiClusterConfigs.getCommonConfig().getSystemStoreHealthCheckOverrideClassName();
+    if (className != null && !className.isEmpty()) {
+      try {
+        Class<? extends SystemStoreHealthChecker> checkerClass = ReflectUtils.loadClass(className);
+        SystemStoreHealthChecker checker = ReflectUtils.callConstructor(
+            checkerClass,
+            new Class[] { VeniceControllerMultiClusterConfig.class },
+            new Object[] { multiClusterConfigs });
+        LOGGER.info("Loaded system store health checker: {}", className);
+        return checker;
+      } catch (Exception e) {
+        LOGGER.error(
+            "Failed to load configured system store health checker class: {}. Falling back to the default "
+                + "heartbeat checker; the configured override will NOT be used until this is fixed.",
+            className,
+            e);
+      }
+    }
+    LOGGER.info("Using default heartbeat-based system store health checker.");
+    return new HeartbeatBasedSystemStoreHealthChecker(parentAdmin, heartbeatWaitTimeInSeconds, isRunning);
+  }
+
+  private void closeChecker(SystemStoreHealthChecker checker) {
+    if (checker != null) {
+      try {
+        checker.close();
+      } catch (Exception e) {
+        LOGGER.warn("Error closing system store health checker: {}", checker.getClass().getName(), e);
+      }
+    }
   }
 
   final Map<String, SystemStoreHealthCheckStats> getClusterToSystemStoreHealthCheckStatsMap() {
     return clusterToSystemStoreHealthCheckStatsMap;
+  }
+
+  SystemStoreHealthChecker getHealthChecker() {
+    return healthChecker;
   }
 }

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/systemstore/SystemStoreRepairTask.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/systemstore/SystemStoreRepairTask.java
@@ -6,14 +6,14 @@ import com.linkedin.venice.controller.Admin;
 import com.linkedin.venice.controller.UserSystemStoreLifeCycleHelper;
 import com.linkedin.venice.controller.VeniceParentHelixAdmin;
 import com.linkedin.venice.controller.stats.SystemStoreHealthCheckStats;
-import com.linkedin.venice.controllerapi.ControllerClient;
+import com.linkedin.venice.controller.systemstore.SystemStoreHealthChecker.HealthCheckResult;
 import com.linkedin.venice.meta.Store;
 import com.linkedin.venice.meta.Version;
 import com.linkedin.venice.pushmonitor.ExecutionStatus;
 import com.linkedin.venice.utils.LatencyUtils;
 import com.linkedin.venice.utils.LogContext;
-import com.linkedin.venice.utils.concurrent.VeniceConcurrentHashMap;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -28,12 +28,12 @@ import org.apache.logging.log4j.Logger;
 
 
 /**
- * This class tries to scan all cluster which current parent controller is the leader controller.
- * It will perform the following action for each system store of each cluster:
- * 1. Check system store is created.
- * 2. Send heartbeat to system store and check if heartbeat is received after certain wait period.
- * 3. If system store failed any of the check in (1) / (2), it will try to run empty push to repair the system store.
- * It will emit metrics to indicate bad system store counts per cluster and how many stores are not fixable by the task.
+ * This class tries to scan all clusters for which the current parent controller is the leader.
+ * It will perform the following actions for each system store of each cluster:
+ * 1. Pre-filter: check that system stores are created and versions are not stale.
+ * 2. Health check: run the configured {@link SystemStoreHealthChecker} (heartbeat-based by default, but pluggable).
+ * 3. Repair: for any store that fails (1) or (2), run an empty push to repair it.
+ * It emits metrics to indicate bad system store counts per cluster and how many stores are not fixable by the task.
  */
 public class SystemStoreRepairTask implements Runnable {
   public static final Logger LOGGER = LogManager.getLogger(SystemStoreRepairTask.class);
@@ -41,27 +41,27 @@ public class SystemStoreRepairTask implements Runnable {
   private static final int DEFAULT_SKIP_NEWLY_CREATED_STORE_SYSTEM_STORE_HEALTH_CHECK_IN_HOURS = 2;
   private static final int DEFAULT_REPAIR_JOB_CHECK_TIMEOUT_IN_SECONDS = 3600;
   private static final int DEFAULT_REPAIR_JOB_CHECK_INTERVAL_IN_SECONDS = 30;
-  private static final int DEFAULT_HEARTBEAT_CHECK_INTERVAL_IN_SECONDS = 30;
-  private static final int DEFAULT_PER_SYSTEM_STORE_HEARTBEAT_CHECK_INTERVAL_IN_MS = 100;
-  private static final int DEFAULT_CHECK_LOGGING_COUNT = 100;
 
-  private final int heartbeatWaitTimeInSeconds;
   private final int versionRefreshThresholdInDays;
+  private final int maxRepairPerRound;
   private final VeniceParentHelixAdmin parentAdmin;
   private final AtomicBoolean isRunning;
   private final Map<String, SystemStoreHealthCheckStats> clusterToSystemStoreHealthCheckStatsMap;
+  private final SystemStoreHealthChecker healthChecker;
 
   public SystemStoreRepairTask(
       VeniceParentHelixAdmin parentAdmin,
       Map<String, SystemStoreHealthCheckStats> clusterToSystemStoreHealthCheckStatsMap,
-      int heartbeatWaitTimeInSeconds,
       int versionRefreshThresholdInDays,
-      AtomicBoolean isRunning) {
+      int maxRepairPerRound,
+      AtomicBoolean isRunning,
+      SystemStoreHealthChecker healthChecker) {
     this.parentAdmin = parentAdmin;
     this.clusterToSystemStoreHealthCheckStatsMap = clusterToSystemStoreHealthCheckStatsMap;
-    this.heartbeatWaitTimeInSeconds = heartbeatWaitTimeInSeconds;
     this.versionRefreshThresholdInDays = versionRefreshThresholdInDays;
+    this.maxRepairPerRound = maxRepairPerRound;
     this.isRunning = isRunning;
+    this.healthChecker = healthChecker;
   }
 
   @Override
@@ -71,34 +71,60 @@ public class SystemStoreRepairTask implements Runnable {
       if (!getClusterToSystemStoreHealthCheckStatsMap().containsKey(clusterName)) {
         continue;
       }
-      LOGGER.info("Starting system store repair task for cluster: {}", clusterName);
-      Set<String> unhealthySystemStoreSet = new HashSet<>();
-      Set<String> unreachableSystemStoreSet = new HashSet<>();
-      Map<String, Long> systemStoreToHeartbeatTimestampMap = new VeniceConcurrentHashMap<>();
-      // Iterate all system stores and get unhealthy system stores.
-      checkSystemStoresHealth(
-          clusterName,
-          unhealthySystemStoreSet,
-          unreachableSystemStoreSet,
-          systemStoreToHeartbeatTimestampMap);
-      // Try repair all bad system stores.
-      repairBadSystemStore(clusterName, unhealthySystemStoreSet);
-      LOGGER.info("Completed system store repair task for cluster: {}", clusterName);
+      try {
+        LOGGER.info("Starting system store repair task for cluster: {}", clusterName);
+        Set<String> unhealthySystemStoreSet = new HashSet<>();
+        // Iterate all system stores and get unhealthy system stores.
+        checkSystemStoresHealth(clusterName, unhealthySystemStoreSet);
+        // Try repair all bad system stores.
+        repairBadSystemStore(clusterName, unhealthySystemStoreSet);
+        LOGGER.info("Completed system store repair task for cluster: {}", clusterName);
+      } catch (Exception e) {
+        LOGGER.error("System store repair task failed for cluster: {}", clusterName, e);
+      }
     }
   }
 
   void repairBadSystemStore(String clusterName, Set<String> unhealthySystemStoreSet) {
+    int configLimit = getMaxRepairPerRound();
+    boolean unlimited = configLimit < 0;
+    if (!unlimited && unhealthySystemStoreSet.size() > configLimit) {
+      LOGGER.info(
+          "Cluster {} has {} unhealthy system stores but max repair per round is {}. Deferring {} stores to next round.",
+          clusterName,
+          unhealthySystemStoreSet.size(),
+          configLimit,
+          unhealthySystemStoreSet.size() - configLimit);
+    }
     Map<String, Integer> systemStoreToRepairJobVersionMap = new HashMap<>();
-    for (String systemStoreName: unhealthySystemStoreSet) {
+    Set<String> attemptedStores = new HashSet<>();
+    int repairCount = 0;
+    // Shuffle the unhealthy stores before applying maxRepairPerRound so that, when the cap defers some stores,
+    // different stores are picked each round. This avoids two failure modes:
+    // (1) HashSet iteration order is JVM-specific and stable within a JVM, which can consistently deprioritize
+    // the same stores round after round.
+    // (2) A fully deterministic order (e.g., sorted by name) can starve later stores indefinitely if the first
+    // maxRepairPerRound stores remain unhealthy across rounds.
+    List<String> repairOrder = new ArrayList<>(unhealthySystemStoreSet);
+    Collections.shuffle(repairOrder);
+    for (String systemStoreName: repairOrder) {
+      if (!unlimited && repairCount >= configLimit) {
+        break;
+      }
       if (!shouldContinue(clusterName)) {
         return;
       }
+      attemptedStores.add(systemStoreName);
+      // Count the attempt toward the per-round cap regardless of whether materialization succeeds. Otherwise a
+      // burst of stores whose repair fails fast would not consume the limit, letting one round attempt the
+      // entire unhealthy set and defeat the throttle.
+      repairCount++;
       String pushJobId = SYSTEM_STORE_REPAIR_JOB_PREFIX + System.currentTimeMillis();
       try {
         Version version = getNewSystemStoreVersion(clusterName, systemStoreName, pushJobId);
         systemStoreToRepairJobVersionMap.put(systemStoreName, version.getNumber());
         LOGGER.info(
-            "Kick off an repair empty push job for store: {} in cluster: {} with expected version number: {}",
+            "Kick off a repair empty push job for store: {} in cluster: {} with expected version number: {}",
             systemStoreName,
             clusterName,
             version.getNumber());
@@ -114,116 +140,161 @@ public class SystemStoreRepairTask implements Runnable {
         getRepairJobCheckTimeoutInSeconds());
     // After repairing system stores, update stats again.
     updateBadSystemStoreCount(clusterName, unhealthySystemStoreSet);
-    updateNotRepairableSystemStoreCount(clusterName, unhealthySystemStoreSet);
+    // Only count stores that were actually attempted but remain unhealthy as "not repairable".
+    // Stores deferred due to maxRepairPerRound are not counted since they were never attempted.
+    Set<String> notRepairableStores = new HashSet<>(attemptedStores);
+    notRepairableStores.retainAll(unhealthySystemStoreSet);
+    updateNotRepairableSystemStoreCount(clusterName, notRepairableStores);
   }
 
   /**
-   * This method iterates over all system stores in the given cluster by sending heartbeat and validate if heartbeat is
-   * consumed successfully by system store.
-   * At the end, it will update the count of bad meta system stores and bad DaVinci push status stores respectively.
+   * Check health of all system stores in the cluster:
+   * 1. Pre-filter to get candidate stores (stores already known unhealthy are added directly).
+   * 2. Run the health checker on candidates. HEALTHY stores are skipped; UNHEALTHY stores are repaired.
    */
-  void checkSystemStoresHealth(
-      String clusterName,
-      Set<String> unhealthySystemStoreSet,
-      Set<String> unreachableSystemStoreSet,
-      Map<String, Long> systemStoreToHeartbeatTimestampMap) {
-    checkAndSendHeartbeatToSystemStores(clusterName, unhealthySystemStoreSet, systemStoreToHeartbeatTimestampMap);
-    checkHeartbeatFromSystemStores(
+  void checkSystemStoresHealth(String clusterName, Set<String> unhealthySystemStoreSet) {
+    Set<String> candidates = preFilterSystemStores(clusterName, unhealthySystemStoreSet);
+
+    if (candidates.isEmpty()) {
+      updateBadSystemStoreCount(clusterName, unhealthySystemStoreSet);
+      return;
+    }
+
+    Map<String, HealthCheckResult> results;
+    try {
+      results = getHealthChecker().checkHealth(clusterName, candidates);
+    } catch (Exception e) {
+      // Don't let a misbehaving (e.g., pluggable override) checker take down the whole cluster round — stores
+      // already added to unhealthySystemStoreSet via pre-filtering should still be repaired below. The
+      // remaining health-check candidates are deferred to the next round.
+      LOGGER.warn(
+          "Health checker {} threw an exception while checking {} candidates for cluster {}; deferring those candidates to the next round.",
+          getHealthChecker().getClass().getName(),
+          candidates.size(),
+          clusterName,
+          e);
+      getSystemStoreHealthCheckErrorCounter(clusterName).incrementAndGet();
+      updateBadSystemStoreCount(clusterName, unhealthySystemStoreSet);
+      return;
+    }
+    if (results == null) {
+      // A misbehaving checker returned null instead of a (possibly empty) map. Treat it like an aborted check and
+      // defer all candidates to the next round, rather than letting the resulting NPE abort the whole cluster
+      // round and skip repairing stores already flagged by pre-filtering.
+      LOGGER.warn(
+          "Health checker {} returned null for cluster {}; deferring all {} candidates to the next round.",
+          getHealthChecker().getClass().getName(),
+          clusterName,
+          candidates.size());
+      getSystemStoreHealthCheckErrorCounter(clusterName).incrementAndGet();
+      updateBadSystemStoreCount(clusterName, unhealthySystemStoreSet);
+      return;
+    }
+    int healthyCount = 0;
+    int unhealthyCount = 0;
+    // Iterate over returned results only; candidates without a result (e.g., checker aborted mid-run due to
+    // leadership loss) are deferred to the next round rather than being penalized as unhealthy.
+    for (Map.Entry<String, HealthCheckResult> entry: results.entrySet()) {
+      if (!candidates.contains(entry.getKey())) {
+        // A misbehaving (e.g., pluggable override) checker returned a store that was not among the candidates.
+        // Ignore it so it cannot pollute the unhealthy set or the bad-store metric, which assumes system-store
+        // names and would throw on an arbitrary name.
+        LOGGER.warn(
+            "Health checker for cluster {} returned a result for non-candidate store {}; ignoring it.",
+            clusterName,
+            entry.getKey());
+        continue;
+      }
+      if (entry.getValue() == HealthCheckResult.HEALTHY) {
+        healthyCount++;
+      } else {
+        unhealthySystemStoreSet.add(entry.getKey());
+        unhealthyCount++;
+      }
+    }
+    int deferredCount = candidates.size() - healthyCount - unhealthyCount;
+    LOGGER.info(
+        "Health checker for cluster {} returned: {} healthy, {} unhealthy, {} deferred (no result)",
         clusterName,
-        unhealthySystemStoreSet,
-        unreachableSystemStoreSet,
-        systemStoreToHeartbeatTimestampMap,
-        getHeartbeatWaitTimeInSeconds());
+        healthyCount,
+        unhealthyCount,
+        deferredCount);
+
     updateBadSystemStoreCount(clusterName, unhealthySystemStoreSet);
   }
 
   /**
-   *  Here we scan the store repository for two passes:
-   *  1. We check user stores and see if system stores are created or not.
-   *  2. For created system stores, we will check if version needs refresh based on creation time. For stores with stale
-   *  versions, it will directly be added into repair set. It will send heartbeat request to the remaining system stores.
-   *  During the two passes, stores they are undergoing migration will be skipped.
+   * Pre-filter system stores to identify candidates for health checking:
+   * 1. Check user stores and add non-created system stores directly to unhealthySet.
+   * 2. For created system stores, check if version needs refresh; stale versions go directly to unhealthySet.
+   * 3. Remaining stores become candidates for health checking (heartbeat or metrics).
+   *
+   * @param clusterName cluster being filtered.
+   * @param unhealthySystemStoreSet [IN/OUT] mutated as a side effect: any system store identified as already
+   *     unhealthy during pre-filtering (missing system store flag, stale or missing version) is added to this set
+   *     and is NOT included in the returned candidate set.
+   * @return the set of candidate system store names that passed pre-filtering and need further health checking.
    */
-  void checkAndSendHeartbeatToSystemStores(
-      String clusterName,
-      Set<String> newUnhealthySystemStoreSet,
-      Map<String, Long> systemStoreToHeartbeatTimestampMap) {
-
+  Set<String> preFilterSystemStores(String clusterName, Set<String> unhealthySystemStoreSet) {
+    Set<String> candidates = new HashSet<>();
     Map<String, Long> userStoreToCreationTimestampMap = new HashMap<>();
     List<Store> storeList = getParentAdmin().getAllStores(clusterName);
-    // First pass only check user store and directly add non-existed system stores.
+
+    // First pass: check user stores for missing system stores
     for (Store store: storeList) {
       if (!shouldContinue(clusterName)) {
-        return;
+        return candidates;
       }
 
-      // For user store, if corresponding system store flag is not true, it indicates system store is not created.
       if (!VeniceSystemStoreUtils.isSystemStore(store.getName())) {
         userStoreToCreationTimestampMap
             .put(VeniceSystemStoreType.META_STORE.getSystemStoreName(store.getName()), store.getCreatedTime());
         userStoreToCreationTimestampMap.put(
             VeniceSystemStoreType.DAVINCI_PUSH_STATUS_STORE.getSystemStoreName(store.getName()),
             store.getCreatedTime());
-        // We will not check newly created system stores.
         if (isStoreNewlyCreated(store.getCreatedTime())) {
           continue;
         }
-
-        // Skipping migration store.
         if (store.isMigrating()) {
           LOGGER.info("Store: {} is being migrated, will skip it for now.", store.getName());
           continue;
         }
-
         if (!store.isDaVinciPushStatusStoreEnabled()) {
-          newUnhealthySystemStoreSet
+          unhealthySystemStoreSet
               .add(VeniceSystemStoreType.DAVINCI_PUSH_STATUS_STORE.getSystemStoreName(store.getName()));
         }
         if (!store.isStoreMetaSystemStoreEnabled()) {
-          newUnhealthySystemStoreSet.add(VeniceSystemStoreType.META_STORE.getSystemStoreName(store.getName()));
+          unhealthySystemStoreSet.add(VeniceSystemStoreType.META_STORE.getSystemStoreName(store.getName()));
         }
       }
     }
-    // Second pass only check system store and potentially send heartbeat message to validate health.
-    int count = 0;
-    long startTimestamp = System.currentTimeMillis();
+
+    // Second pass: check system stores for version staleness; remaining become candidates
     for (Store store: storeList) {
       if (!shouldContinue(clusterName)) {
-        return;
+        return candidates;
       }
 
-      // This pass we only scan user system store.
       if (!(VeniceSystemStoreUtils.isSystemStore(store.getName())
           && VeniceSystemStoreUtils.isUserSystemStore(store.getName()))) {
         continue;
       }
 
-      // Skipping migration store.
       if (store.isMigrating()) {
         LOGGER.info("Store: {} is being migrated, will skip it for now.", store.getName());
         continue;
       }
 
-      // We will not check newly created system stores.
       if (isStoreNewlyCreated(userStoreToCreationTimestampMap.getOrDefault(store.getName(), 0L))) {
         continue;
       }
 
-      // Skip checking store that is already added in the unhealthy list in the previous scan.
-      if (newUnhealthySystemStoreSet.contains(store.getName())) {
+      if (unhealthySystemStoreSet.contains(store.getName())) {
         continue;
       }
 
-      /**
-       * Checking the largest version's age and add stale version to the repair service. Note that in parent region,
-       * there is no current version information, here we use the latest version by the creation time to compute the
-       * version age.
-       */
       List<Version> storeVersionList = store.getVersions();
-
-      // If no version is found, we will default to 0.
       long latestCreatedTime = storeVersionList.stream().mapToLong(Version::getCreatedTime).max().orElse(0);
-
       boolean versionTooOldOrMissing = LatencyUtils.getElapsedTimeFromMsToMs(latestCreatedTime) > TimeUnit.DAYS
           .toMillis(getVersionRefreshThresholdInDays());
 
@@ -237,145 +308,14 @@ public class SystemStoreRepairTask implements Runnable {
               store.getName(),
               versionAgeInMs);
         }
-        newUnhealthySystemStoreSet.add(store.getName());
+        unhealthySystemStoreSet.add(store.getName());
         continue;
       }
 
-      // Send heartbeat to system store in all child regions.
-      long currentTimestamp = System.currentTimeMillis();
-      sendHeartbeatToSystemStore(clusterName, store.getName(), currentTimestamp);
-      systemStoreToHeartbeatTimestampMap.put(store.getName(), currentTimestamp);
-      count += 1;
-      if ((count % DEFAULT_CHECK_LOGGING_COUNT) == 0) {
-        LOGGER.info(
-            "Sent heartbeat to {} system stores, took: {} ms",
-            count,
-            LatencyUtils.getElapsedTimeFromMsToMs(startTimestamp));
-      }
-
-      // Sleep to throttle heartbeat send rate.
-      LatencyUtils.sleep(DEFAULT_PER_SYSTEM_STORE_HEARTBEAT_CHECK_INTERVAL_IN_MS);
+      candidates.add(store.getName());
     }
-  }
 
-  /**
-   * This method iterates over all system stores and validate if heartbeat has been received.
-   */
-  void checkHeartbeatFromSystemStores(
-      String clusterName,
-      Set<String> newUnhealthySystemStoreSet,
-      Set<String> unreachableSystemStoreSet,
-      Map<String, Long> systemStoreToHeartbeatTimestampMap,
-      int heartbeatCheckWaitTimeoutInSeconds) {
-    periodicCheckTask(clusterName, heartbeatCheckWaitTimeoutInSeconds, getHeartbeatCheckIntervalInSeconds(), () -> {
-      List<String> listToRemove = new ArrayList<>();
-      int count = 0;
-      long startTimestamp = System.currentTimeMillis();
-      for (Map.Entry<String, Long> entry: systemStoreToHeartbeatTimestampMap.entrySet()) {
-        if (!shouldContinue(clusterName)) {
-          return true;
-        }
-
-        long retrievedHeartbeatTimestamp = getHeartbeatFromSystemStore(clusterName, entry.getKey());
-        if (retrievedHeartbeatTimestamp < entry.getValue()) {
-          newUnhealthySystemStoreSet.add(entry.getKey());
-          if (retrievedHeartbeatTimestamp == -1) {
-            unreachableSystemStoreSet.add(entry.getKey());
-            LOGGER.warn(
-                "System store: {} in cluster: {} is not reachable for heartbeat request.",
-                entry.getKey(),
-                clusterName);
-          } else {
-            LOGGER.warn(
-                "Expect heartbeat: {} from system store: {} in cluster: {}, got stale heartbeat: {}.",
-                entry.getValue(),
-                clusterName,
-                entry.getKey(),
-                retrievedHeartbeatTimestamp);
-          }
-        } else {
-          // Retrieved fresh heartbeat message, will not check anymore.
-          listToRemove.add(entry.getKey());
-        }
-        count += 1;
-        if ((count % DEFAULT_CHECK_LOGGING_COUNT) == 0) {
-          LOGGER.info(
-              "Checked heartbeat for {} system stores, took: {} ms",
-              count,
-              LatencyUtils.getElapsedTimeFromMsToMs(startTimestamp));
-        }
-      }
-      for (String key: listToRemove) {
-        systemStoreToHeartbeatTimestampMap.remove(key);
-        newUnhealthySystemStoreSet.remove(key);
-        unreachableSystemStoreSet.remove(key);
-      }
-      return systemStoreToHeartbeatTimestampMap.isEmpty();
-    });
-  }
-
-  void periodicCheckTask(
-      String clusterName,
-      int maxWaitTimeInSeconds,
-      int checkIntervalInSeconds,
-      BooleanSupplier checkTask) {
-    long startCheckingTime = System.currentTimeMillis();
-    while ((System.currentTimeMillis() - startCheckingTime) <= TimeUnit.SECONDS.toMillis(maxWaitTimeInSeconds)) {
-      if (!shouldContinue(clusterName)) {
-        return;
-      }
-      boolean result = checkTask.getAsBoolean();
-      if (result) {
-        LOGGER.info("Check task completed for {} ms", System.currentTimeMillis() - startCheckingTime);
-        return;
-      }
-      // Wait for certain period for next round of check.
-      LatencyUtils.sleep(TimeUnit.SECONDS.toMillis(checkIntervalInSeconds));
-    }
-  }
-
-  void updateBadSystemStoreCount(String clusterName, Set<String> newUnhealthySystemStoreSet) {
-    long newBadMetaSystemStoreCount = newUnhealthySystemStoreSet.stream()
-        .filter(x -> VeniceSystemStoreType.getSystemStoreType(x).equals(VeniceSystemStoreType.META_STORE))
-        .count();
-    getBadMetaStoreCount(clusterName).set(newBadMetaSystemStoreCount);
-    getBadPushStatusStoreCount(clusterName).set(newUnhealthySystemStoreSet.size() - newBadMetaSystemStoreCount);
-    LOGGER.info(
-        "Cluster: {} collected unhealthy system stores: {}. Meta system store count: {}, push status system store count: {}",
-        clusterName,
-        newUnhealthySystemStoreSet.toString(),
-        getBadMetaStoreCount(clusterName).get(),
-        getBadPushStatusStoreCount(clusterName).get());
-  }
-
-  void updateNotRepairableSystemStoreCount(String clusterName, Set<String> notRepairableSystemStoreSet) {
-    getNotRepairableSystemStoreCounter(clusterName).set(notRepairableSystemStoreSet.size());
-    LOGGER.info("Cluster: {} has not repairable system stores: {}", clusterName, notRepairableSystemStoreSet);
-  }
-
-  AtomicBoolean getIsRunning() {
-    return isRunning;
-  }
-
-  public Map<String, ControllerClient> getControllerClientMap(String clusterName) {
-    return getParentAdmin().getVeniceHelixAdmin().getControllerClientMap(clusterName);
-  }
-
-  void sendHeartbeatToSystemStore(String clusterName, String systemStoreName, long heartbeatTimestamp) {
-    for (Map.Entry<String, ControllerClient> entry: getControllerClientMap(clusterName).entrySet()) {
-      entry.getValue().sendHeartbeatToSystemStore(systemStoreName, heartbeatTimestamp);
-    }
-  }
-
-  long getHeartbeatFromSystemStore(String clusterName, String systemStoreName) {
-    long oldestHeartbeatTimestamp = Long.MAX_VALUE;
-    for (Map.Entry<String, ControllerClient> entry: getControllerClientMap(clusterName).entrySet()) {
-      long timestamp = entry.getValue().getHeartbeatFromSystemStore(systemStoreName).getHeartbeatTimestamp();
-      if (oldestHeartbeatTimestamp > timestamp) {
-        oldestHeartbeatTimestamp = timestamp;
-      }
-    }
-    return oldestHeartbeatTimestamp;
+    return candidates;
   }
 
   /**
@@ -428,8 +368,50 @@ public class SystemStoreRepairTask implements Runnable {
     }
   }
 
+  void periodicCheckTask(
+      String clusterName,
+      int maxWaitTimeInSeconds,
+      int checkIntervalInSeconds,
+      BooleanSupplier checkTask) {
+    long startCheckingTime = System.currentTimeMillis();
+    while ((System.currentTimeMillis() - startCheckingTime) <= TimeUnit.SECONDS.toMillis(maxWaitTimeInSeconds)) {
+      if (!shouldContinue(clusterName)) {
+        return;
+      }
+      boolean result = checkTask.getAsBoolean();
+      if (result) {
+        LOGGER.info("Check task completed for {} ms", System.currentTimeMillis() - startCheckingTime);
+        return;
+      }
+      // Wait for certain period for next round of check.
+      LatencyUtils.sleep(TimeUnit.SECONDS.toMillis(checkIntervalInSeconds));
+    }
+  }
+
+  void updateBadSystemStoreCount(String clusterName, Set<String> newUnhealthySystemStoreSet) {
+    long newBadMetaSystemStoreCount = newUnhealthySystemStoreSet.stream()
+        .filter(x -> VeniceSystemStoreType.getSystemStoreType(x).equals(VeniceSystemStoreType.META_STORE))
+        .count();
+    getBadMetaStoreCount(clusterName).set(newBadMetaSystemStoreCount);
+    getBadPushStatusStoreCount(clusterName).set(newUnhealthySystemStoreSet.size() - newBadMetaSystemStoreCount);
+    LOGGER.info(
+        "Cluster: {} collected unhealthy system stores: {}. Meta system store count: {}, push status system store count: {}",
+        clusterName,
+        newUnhealthySystemStoreSet.toString(),
+        getBadMetaStoreCount(clusterName).get(),
+        getBadPushStatusStoreCount(clusterName).get());
+  }
+
+  void updateNotRepairableSystemStoreCount(String clusterName, Set<String> notRepairableSystemStoreSet) {
+    getNotRepairableSystemStoreCounter(clusterName).set(notRepairableSystemStoreSet.size());
+    LOGGER.info("Cluster: {} has not repairable system stores: {}", clusterName, notRepairableSystemStoreSet);
+  }
+
+  AtomicBoolean getIsRunning() {
+    return isRunning;
+  }
+
   boolean isStoreNewlyCreated(long creationTimestamp) {
-    // Since system store is just created, we can skip checking its system store.
     return LatencyUtils.getElapsedTimeFromMsToMs(creationTimestamp) < TimeUnit.HOURS
         .toMillis(DEFAULT_SKIP_NEWLY_CREATED_STORE_SYSTEM_STORE_HEALTH_CHECK_IN_HOURS);
   }
@@ -452,6 +434,10 @@ public class SystemStoreRepairTask implements Runnable {
 
   AtomicLong getNotRepairableSystemStoreCounter(String clusterName) {
     return getClusterSystemStoreHealthCheckStats(clusterName).getNotRepairableSystemStoreCounter();
+  }
+
+  AtomicLong getSystemStoreHealthCheckErrorCounter(String clusterName) {
+    return getClusterSystemStoreHealthCheckStats(clusterName).getSystemStoreHealthCheckErrorCounter();
   }
 
   boolean shouldContinue(String clusterName) {
@@ -478,15 +464,15 @@ public class SystemStoreRepairTask implements Runnable {
     return DEFAULT_REPAIR_JOB_CHECK_INTERVAL_IN_SECONDS;
   }
 
-  int getHeartbeatCheckIntervalInSeconds() {
-    return DEFAULT_HEARTBEAT_CHECK_INTERVAL_IN_SECONDS;
-  }
-
-  int getHeartbeatWaitTimeInSeconds() {
-    return heartbeatWaitTimeInSeconds;
+  int getMaxRepairPerRound() {
+    return maxRepairPerRound;
   }
 
   int getVersionRefreshThresholdInDays() {
     return versionRefreshThresholdInDays;
+  }
+
+  SystemStoreHealthChecker getHealthChecker() {
+    return healthChecker;
   }
 }

--- a/services/venice-controller/src/test/java/com/linkedin/venice/controller/stats/SystemStoreHealthCheckOtelMetricEntityTest.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/controller/stats/SystemStoreHealthCheckOtelMetricEntityTest.java
@@ -33,6 +33,14 @@ public class SystemStoreHealthCheckOtelMetricEntityTest {
             MetricUnit.NUMBER,
             "System stores that cannot be repaired",
             setOf(VENICE_CLUSTER_NAME)));
+    map.put(
+        SystemStoreHealthCheckOtelMetricEntity.SYSTEM_STORE_HEALTH_CHECK_ERROR_COUNT,
+        new MetricEntityExpectation(
+            "system_store.health_check.error_count",
+            MetricType.ASYNC_GAUGE,
+            MetricUnit.NUMBER,
+            "Cumulative count of system store health-check invocations that failed by throwing or returning null",
+            setOf(VENICE_CLUSTER_NAME)));
     return map;
   }
 

--- a/services/venice-controller/src/test/java/com/linkedin/venice/controller/stats/SystemStoreHealthCheckStatsOtelTest.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/controller/stats/SystemStoreHealthCheckStatsOtelTest.java
@@ -91,6 +91,24 @@ public class SystemStoreHealthCheckStatsOtelTest {
   }
 
   @Test
+  public void testHealthCheckErrorCount() {
+    stats.getSystemStoreHealthCheckErrorCounter().set(4);
+
+    // OTel
+    validateGauge(
+        SystemStoreHealthCheckStats.SystemStoreHealthCheckOtelMetricEntity.SYSTEM_STORE_HEALTH_CHECK_ERROR_COUNT
+            .getMetricName(),
+        4,
+        clusterAttributes());
+
+    // Tehuti
+    validateTehutiMetric(
+        SystemStoreHealthCheckStats.SystemStoreHealthCheckTehutiMetricNameEnum.SYSTEM_STORE_HEALTH_CHECK_ERROR_COUNT,
+        "Gauge",
+        4.0);
+  }
+
+  @Test
   public void testCounterResetToZero() {
     stats.getBadMetaSystemStoreCounter().set(5);
     validateGauge(
@@ -149,6 +167,7 @@ public class SystemStoreHealthCheckStatsOtelTest {
     disabledStats.getBadMetaSystemStoreCounter().set(1);
     disabledStats.getBadPushStatusSystemStoreCounter().set(2);
     disabledStats.getNotRepairableSystemStoreCounter().set(3);
+    disabledStats.getSystemStoreHealthCheckErrorCounter().set(4);
   }
 
   @Test
@@ -161,6 +180,7 @@ public class SystemStoreHealthCheckStatsOtelTest {
       plainStats.getBadMetaSystemStoreCounter().set(1);
       plainStats.getBadPushStatusSystemStoreCounter().set(2);
       plainStats.getNotRepairableSystemStoreCounter().set(3);
+      plainStats.getSystemStoreHealthCheckErrorCounter().set(4);
     } finally {
       plainRepo.close();
     }

--- a/services/venice-controller/src/test/java/com/linkedin/venice/controller/stats/SystemStoreHealthCheckTehutiMetricNameEnumTest.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/controller/stats/SystemStoreHealthCheckTehutiMetricNameEnumTest.java
@@ -17,6 +17,9 @@ public class SystemStoreHealthCheckTehutiMetricNameEnumTest {
     map.put(
         SystemStoreHealthCheckTehutiMetricNameEnum.NOT_REPAIRABLE_SYSTEM_STORE_COUNT,
         "not_repairable_system_store_count");
+    map.put(
+        SystemStoreHealthCheckTehutiMetricNameEnum.SYSTEM_STORE_HEALTH_CHECK_ERROR_COUNT,
+        "system_store_health_check_error_count");
     return map;
   }
 

--- a/services/venice-controller/src/test/java/com/linkedin/venice/controller/systemstore/HeartbeatBasedSystemStoreHealthCheckerTest.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/controller/systemstore/HeartbeatBasedSystemStoreHealthCheckerTest.java
@@ -1,0 +1,271 @@
+package com.linkedin.venice.controller.systemstore;
+
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.doCallRealMethod;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.linkedin.venice.common.VeniceSystemStoreType;
+import com.linkedin.venice.controller.VeniceHelixAdmin;
+import com.linkedin.venice.controller.VeniceParentHelixAdmin;
+import com.linkedin.venice.controller.systemstore.SystemStoreHealthChecker.HealthCheckResult;
+import com.linkedin.venice.controllerapi.ControllerClient;
+import com.linkedin.venice.controllerapi.SystemStoreHeartbeatResponse;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicBoolean;
+import org.mockito.ArgumentMatchers;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+
+public class HeartbeatBasedSystemStoreHealthCheckerTest {
+  @Test
+  public void testGetHeartbeatFromSystemStore() {
+    String clusterName = "venice";
+    String userStoreName1 = "testStore";
+    String metaStoreName1 = VeniceSystemStoreType.META_STORE.getSystemStoreName(userStoreName1);
+    String pushStatusStoreName1 = VeniceSystemStoreType.DAVINCI_PUSH_STATUS_STORE.getSystemStoreName(userStoreName1);
+
+    String userStoreName2 = "testStore2";
+    String metaStoreName2 = VeniceSystemStoreType.META_STORE.getSystemStoreName(userStoreName2);
+    String pushStatusStoreName2 = VeniceSystemStoreType.DAVINCI_PUSH_STATUS_STORE.getSystemStoreName(userStoreName2);
+
+    SystemStoreHeartbeatResponse heartbeatResponse1 = new SystemStoreHeartbeatResponse();
+    heartbeatResponse1.setHeartbeatTimestamp(10L);
+    SystemStoreHeartbeatResponse heartbeatResponse2 = new SystemStoreHeartbeatResponse();
+    heartbeatResponse2.setHeartbeatTimestamp(11L);
+    SystemStoreHeartbeatResponse heartbeatResponse3 = new SystemStoreHeartbeatResponse();
+    heartbeatResponse3.setHeartbeatTimestamp(-1L);
+
+    ControllerClient client1 = mock(ControllerClient.class);
+    when(client1.getHeartbeatFromSystemStore(metaStoreName1)).thenReturn(heartbeatResponse1);
+    when(client1.getHeartbeatFromSystemStore(pushStatusStoreName1)).thenReturn(heartbeatResponse1);
+    when(client1.getHeartbeatFromSystemStore(metaStoreName2)).thenReturn(heartbeatResponse1);
+    when(client1.getHeartbeatFromSystemStore(pushStatusStoreName2)).thenReturn(heartbeatResponse1);
+
+    ControllerClient client2 = mock(ControllerClient.class);
+    when(client2.getHeartbeatFromSystemStore(metaStoreName1)).thenReturn(heartbeatResponse2);
+    when(client2.getHeartbeatFromSystemStore(pushStatusStoreName1)).thenReturn(heartbeatResponse3);
+    when(client2.getHeartbeatFromSystemStore(metaStoreName2)).thenReturn(heartbeatResponse1);
+    when(client2.getHeartbeatFromSystemStore(pushStatusStoreName2)).thenReturn(heartbeatResponse1);
+
+    HeartbeatBasedSystemStoreHealthChecker checker = mock(HeartbeatBasedSystemStoreHealthChecker.class);
+    when(checker.getHeartbeatFromSystemStore(anyString(), anyString())).thenCallRealMethod();
+    Map<String, ControllerClient> controllerClientMap = new HashMap<>();
+    controllerClientMap.put("region1", client1);
+    controllerClientMap.put("region2", client2);
+    when(checker.getControllerClientMap(clusterName)).thenReturn(controllerClientMap);
+
+    Assert.assertEquals(checker.getHeartbeatFromSystemStore(clusterName, metaStoreName1), 10L);
+    Assert.assertEquals(checker.getHeartbeatFromSystemStore(clusterName, pushStatusStoreName1), -1L);
+    Assert.assertEquals(checker.getHeartbeatFromSystemStore(clusterName, metaStoreName2), 10L);
+    Assert.assertEquals(checker.getHeartbeatFromSystemStore(clusterName, pushStatusStoreName2), 10L);
+  }
+
+  @Test
+  public void testCheckHealthReturnsCorrectResults() {
+    String clusterName = "venice";
+    String storeName1 = VeniceSystemStoreType.META_STORE.getSystemStoreName("testStore1");
+    String storeName2 = VeniceSystemStoreType.META_STORE.getSystemStoreName("testStore2");
+
+    HeartbeatBasedSystemStoreHealthChecker checker = mock(HeartbeatBasedSystemStoreHealthChecker.class);
+    doCallRealMethod().when(checker).checkHealth(anyString(), ArgumentMatchers.<Set<String>>any());
+    doCallRealMethod().when(checker)
+        .checkHeartbeatFromSystemStores(
+            anyString(),
+            ArgumentMatchers.<Map<String, Long>>any(),
+            ArgumentMatchers.<Map<String, HealthCheckResult>>any());
+    when(checker.shouldContinue(anyString())).thenReturn(true);
+    when(checker.getHeartbeatCheckIntervalInSeconds()).thenReturn(1);
+    doCallRealMethod().when(checker)
+        .periodicCheckTask(anyString(), ArgumentMatchers.anyInt(), ArgumentMatchers.anyInt(), ArgumentMatchers.any());
+
+    // storeName1 returns fresh heartbeat, storeName2 returns stale
+    when(checker.getHeartbeatFromSystemStore(anyString(), anyString())).thenAnswer(invocation -> {
+      String store = invocation.getArgument(1);
+      if (store.equals(storeName1)) {
+        return Long.MAX_VALUE; // fresh heartbeat
+      }
+      return 0L; // stale heartbeat
+    });
+
+    Set<String> storeNames = new HashSet<>();
+    storeNames.add(storeName1);
+    storeNames.add(storeName2);
+
+    Map<String, HealthCheckResult> results = checker.checkHealth(clusterName, storeNames);
+
+    Assert.assertEquals(results.get(storeName1), HealthCheckResult.HEALTHY);
+    Assert.assertEquals(results.get(storeName2), HealthCheckResult.UNHEALTHY);
+  }
+
+  @Test
+  public void testCheckHealthMarksAlwaysStaleStoreUnhealthyAfterWaitWindow() {
+    // A single store that reads stale on every poll and is never aborted must end UNHEALTHY via the post-loop
+    // completion block in checkHeartbeatFromSystemStores. This pins that terminal path directly, decoupled from any
+    // healthy sibling store.
+    String clusterName = "venice";
+    String storeName = VeniceSystemStoreType.META_STORE.getSystemStoreName("testStore1");
+
+    HeartbeatBasedSystemStoreHealthChecker checker = mock(HeartbeatBasedSystemStoreHealthChecker.class);
+    doCallRealMethod().when(checker).checkHealth(anyString(), ArgumentMatchers.<Set<String>>any());
+    doCallRealMethod().when(checker)
+        .checkHeartbeatFromSystemStores(
+            anyString(),
+            ArgumentMatchers.<Map<String, Long>>any(),
+            ArgumentMatchers.<Map<String, HealthCheckResult>>any());
+    when(checker.shouldContinue(anyString())).thenReturn(true);
+    when(checker.getHeartbeatCheckIntervalInSeconds()).thenReturn(1);
+    doCallRealMethod().when(checker)
+        .periodicCheckTask(anyString(), ArgumentMatchers.anyInt(), ArgumentMatchers.anyInt(), ArgumentMatchers.any());
+
+    // Stale on every poll, so the store never resolves to HEALTHY and is still pending when the wait window ends.
+    when(checker.getHeartbeatFromSystemStore(anyString(), anyString())).thenReturn(0L);
+
+    Set<String> storeNames = new HashSet<>();
+    storeNames.add(storeName);
+
+    Map<String, HealthCheckResult> results = checker.checkHealth(clusterName, storeNames);
+
+    verify(checker, atLeastOnce()).getHeartbeatFromSystemStore(clusterName, storeName);
+    Assert.assertEquals(
+        results.get(storeName),
+        HealthCheckResult.UNHEALTHY,
+        "a store stale through the full wait window (never aborted) must be marked UNHEALTHY by the post-loop block");
+  }
+
+  @Test
+  public void testCheckHealthFlipsStaleStoreToHealthyOnLaterPoll() {
+    // A store that is stale on the first poll but reads back a fresh heartbeat on a later polling iteration must
+    // end up HEALTHY. This exercises the multi-iteration polling loop (the core retry-and-recover behavior).
+    String clusterName = "venice";
+    String storeName = VeniceSystemStoreType.META_STORE.getSystemStoreName("testStore1");
+
+    // Wait time is large enough for >= 2 polling iterations; the check interval is 0 so the test runs fast.
+    HeartbeatBasedSystemStoreHealthChecker checker = spy(
+        new HeartbeatBasedSystemStoreHealthChecker(mock(VeniceParentHelixAdmin.class), 60, new AtomicBoolean(true)));
+    doReturn(true).when(checker).shouldContinue(anyString());
+    doReturn(0).when(checker).getHeartbeatCheckIntervalInSeconds();
+    // No regions wired; the send phase is a no-op and reads come from the stub below.
+    doReturn(new HashMap<String, ControllerClient>()).when(checker).getControllerClientMap(anyString());
+    // First poll returns a stale heartbeat (older than the sent timestamp) -> UNHEALTHY; the second poll returns a
+    // fresh heartbeat -> the store flips to HEALTHY.
+    doReturn(0L).doReturn(Long.MAX_VALUE).when(checker).getHeartbeatFromSystemStore(anyString(), anyString());
+
+    Set<String> storeNames = new HashSet<>();
+    storeNames.add(storeName);
+
+    Map<String, HealthCheckResult> results = checker.checkHealth(clusterName, storeNames);
+
+    Assert.assertEquals(
+        results.get(storeName),
+        HealthCheckResult.HEALTHY,
+        "a store stale on the first poll but fresh on a later poll should end HEALTHY");
+  }
+
+  @Test
+  public void testCheckHealthEmptySet() {
+    VeniceParentHelixAdmin parentAdmin = mock(VeniceParentHelixAdmin.class);
+    AtomicBoolean isRunning = new AtomicBoolean(true);
+    HeartbeatBasedSystemStoreHealthChecker checker =
+        new HeartbeatBasedSystemStoreHealthChecker(parentAdmin, 5, isRunning);
+
+    Map<String, HealthCheckResult> results = checker.checkHealth("venice", new HashSet<>());
+    Assert.assertTrue(results.isEmpty());
+  }
+
+  @Test
+  public void testCheckHealthOmitsUnpolledStoresWhenAborted() {
+    // Verify the contract that stores never polled (because the periodic check aborted before reaching them)
+    // are omitted from results, not pre-initialized as UNHEALTHY.
+    String clusterName = "venice";
+    String storeName1 = VeniceSystemStoreType.META_STORE.getSystemStoreName("testStore1");
+    String storeName2 = VeniceSystemStoreType.META_STORE.getSystemStoreName("testStore2");
+
+    HeartbeatBasedSystemStoreHealthChecker checker = mock(HeartbeatBasedSystemStoreHealthChecker.class);
+    doCallRealMethod().when(checker).checkHealth(anyString(), ArgumentMatchers.<Set<String>>any());
+    doCallRealMethod().when(checker)
+        .checkHeartbeatFromSystemStores(
+            anyString(),
+            ArgumentMatchers.<Map<String, Long>>any(),
+            ArgumentMatchers.<Map<String, HealthCheckResult>>any());
+    when(checker.getHeartbeatCheckIntervalInSeconds()).thenReturn(1);
+    doCallRealMethod().when(checker)
+        .periodicCheckTask(anyString(), ArgumentMatchers.anyInt(), ArgumentMatchers.anyInt(), ArgumentMatchers.any());
+
+    // shouldContinue returns true for the two phase-1 sends and the initial periodicCheckTask gate,
+    // then false on the first per-store check inside the polling lambda — so no store is actually polled.
+    when(checker.shouldContinue(anyString())).thenReturn(true, true, true, false);
+
+    Set<String> storeNames = new HashSet<>();
+    storeNames.add(storeName1);
+    storeNames.add(storeName2);
+
+    Map<String, HealthCheckResult> results = checker.checkHealth(clusterName, storeNames);
+
+    Assert.assertTrue(
+        results.isEmpty(),
+        "stores whose heartbeats were sent but never polled should be omitted from results (deferred), not UNHEALTHY");
+  }
+
+  @Test
+  public void testCheckHealthDefersStaleStorePolledThenAborted() {
+    // A store found stale on a poll must NOT be recorded UNHEALTHY if the round aborts before the wait window
+    // elapses — no final decision was reached, so it must be deferred (omitted) per the contract. This differs
+    // from the never-polled case: here the store IS polled (and read stale) before the abort.
+    String clusterName = "venice";
+    String storeName = VeniceSystemStoreType.META_STORE.getSystemStoreName("testStore1");
+
+    HeartbeatBasedSystemStoreHealthChecker checker = spy(
+        new HeartbeatBasedSystemStoreHealthChecker(mock(VeniceParentHelixAdmin.class), 60, new AtomicBoolean(true)));
+    doReturn(0).when(checker).getHeartbeatCheckIntervalInSeconds();
+    // No regions wired; the send phase is a no-op and reads come from the stub below.
+    doReturn(new HashMap<String, ControllerClient>()).when(checker).getControllerClientMap(anyString());
+    // Always stale, so the store never resolves to HEALTHY and stays pending.
+    doReturn(0L).when(checker).getHeartbeatFromSystemStore(anyString(), anyString());
+    // true for the phase-1 send, the periodic-check gate, and the in-loop poll (so the store is polled and read
+    // stale), then false so the round aborts before the wait window and the post-loop completion check defers
+    // the still-pending store instead of marking it UNHEALTHY.
+    doReturn(true, true, true, false).when(checker).shouldContinue(anyString());
+
+    Set<String> storeNames = new HashSet<>();
+    storeNames.add(storeName);
+
+    Map<String, HealthCheckResult> results = checker.checkHealth(clusterName, storeNames);
+
+    verify(checker).getHeartbeatFromSystemStore(clusterName, storeName);
+    Assert.assertTrue(
+        results.isEmpty(),
+        "a store polled stale but aborted before the wait window elapsed should be deferred, not UNHEALTHY");
+  }
+
+  @Test
+  public void testCheckHealthWhenNotRunning() {
+    VeniceParentHelixAdmin parentAdmin = mock(VeniceParentHelixAdmin.class);
+    VeniceHelixAdmin helixAdmin = mock(VeniceHelixAdmin.class);
+    when(parentAdmin.getVeniceHelixAdmin()).thenReturn(helixAdmin);
+    when(parentAdmin.isLeaderControllerFor(anyString())).thenReturn(true);
+    Map<String, ControllerClient> clientMap = new HashMap<>();
+    clientMap.put("region1", mock(ControllerClient.class));
+    when(helixAdmin.getControllerClientMap("venice")).thenReturn(clientMap);
+
+    AtomicBoolean isRunning = new AtomicBoolean(false);
+    HeartbeatBasedSystemStoreHealthChecker checker =
+        new HeartbeatBasedSystemStoreHealthChecker(parentAdmin, 5, isRunning);
+
+    Set<String> storeNames = new HashSet<>();
+    storeNames.add("store1");
+
+    // When not running, shouldContinue returns false immediately, no heartbeats sent
+    Map<String, HealthCheckResult> results = checker.checkHealth("venice", storeNames);
+    // Results should be empty since the send loop broke before any heartbeats were sent
+    Assert.assertTrue(results.isEmpty());
+  }
+}

--- a/services/venice-controller/src/test/java/com/linkedin/venice/controller/systemstore/SystemStoreRepairServiceTest.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/controller/systemstore/SystemStoreRepairServiceTest.java
@@ -7,18 +7,79 @@ import com.linkedin.venice.controller.VeniceControllerClusterConfig;
 import com.linkedin.venice.controller.VeniceControllerMultiClusterConfig;
 import com.linkedin.venice.controller.VeniceParentHelixAdmin;
 import io.tehuti.metrics.MetricsRepository;
+import java.util.Collections;
 import java.util.HashSet;
+import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicBoolean;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
 
 public class SystemStoreRepairServiceTest {
+  /**
+   * Public test-only SystemStoreHealthChecker with the documented {@code (VeniceControllerMultiClusterConfig)}
+   * constructor so it can be loaded reflectively by {@link SystemStoreRepairService#loadHealthChecker()}.
+   */
+  public static class TestOverrideChecker implements SystemStoreHealthChecker {
+    private final VeniceControllerMultiClusterConfig config;
+
+    public TestOverrideChecker(VeniceControllerMultiClusterConfig config) {
+      this.config = config;
+    }
+
+    public VeniceControllerMultiClusterConfig getConfig() {
+      return config;
+    }
+
+    @Override
+    public Map<String, HealthCheckResult> checkHealth(String clusterName, Set<String> systemStoreNames) {
+      return Collections.emptyMap();
+    }
+  }
+
+  /**
+   * Override whose constructor throws — distinct from a class-not-found failure, but it hits the same broad catch
+   * in {@link SystemStoreRepairService#loadHealthChecker()} and must also fall back to the heartbeat checker.
+   */
+  public static class ThrowingConstructorChecker implements SystemStoreHealthChecker {
+    public ThrowingConstructorChecker(VeniceControllerMultiClusterConfig config) {
+      throw new RuntimeException("constructor boom");
+    }
+
+    @Override
+    public Map<String, HealthCheckResult> checkHealth(String clusterName, Set<String> systemStoreNames) {
+      return Collections.emptyMap();
+    }
+  }
+
+  /**
+   * Tracks whether {@code close()} ran via a static flag, because the checker is created reflectively inside
+   * {@link SystemStoreRepairService#loadHealthChecker()} and the test has no other reference to the instance.
+   */
+  private static final AtomicBoolean CLOSE_TRACKING_CHECKER_CLOSED = new AtomicBoolean(false);
+
+  public static class CloseTrackingChecker implements SystemStoreHealthChecker {
+    public CloseTrackingChecker(VeniceControllerMultiClusterConfig config) {
+    }
+
+    @Override
+    public Map<String, HealthCheckResult> checkHealth(String clusterName, Set<String> systemStoreNames) {
+      return Collections.emptyMap();
+    }
+
+    @Override
+    public void close() {
+      CLOSE_TRACKING_CHECKER_CLOSED.set(true);
+    }
+  }
+
   @Test
   public void testInitialization() {
     VeniceControllerClusterConfig commonConfig = mock(VeniceControllerClusterConfig.class);
     VeniceControllerMultiClusterConfig multiClusterConfigs = mock(VeniceControllerMultiClusterConfig.class);
     doReturn(commonConfig).when(multiClusterConfigs).getCommonConfig();
+    doReturn("").when(commonConfig).getSystemStoreHealthCheckOverrideClassName();
     Set<String> clusterSet = new HashSet<>();
     clusterSet.add("venice-1");
     clusterSet.add("venice-2");
@@ -34,5 +95,139 @@ public class SystemStoreRepairServiceTest {
         new SystemStoreRepairService(mock(VeniceParentHelixAdmin.class), multiClusterConfigs, new MetricsRepository());
     Assert.assertFalse(systemStoreRepairService.getClusterToSystemStoreHealthCheckStatsMap().containsKey("venice-1"));
     Assert.assertTrue(systemStoreRepairService.getClusterToSystemStoreHealthCheckStatsMap().containsKey("venice-2"));
+  }
+
+  @Test
+  public void testStartCreatesHeartbeatChecker() {
+    VeniceControllerClusterConfig commonConfig = mock(VeniceControllerClusterConfig.class);
+    doReturn(600).when(commonConfig).getParentSystemStoreHeartbeatCheckWaitTimeSeconds();
+    doReturn(1800).when(commonConfig).getParentSystemStoreRepairCheckIntervalSeconds();
+    doReturn(30).when(commonConfig).getParentSystemStoreVersionRefreshThresholdInDays();
+    doReturn(50).when(commonConfig).getSystemStoreRepairMaxPerRound();
+    doReturn("").when(commonConfig).getSystemStoreHealthCheckOverrideClassName();
+
+    VeniceControllerMultiClusterConfig multiClusterConfigs = mock(VeniceControllerMultiClusterConfig.class);
+    doReturn(commonConfig).when(multiClusterConfigs).getCommonConfig();
+    doReturn(new HashSet<>()).when(multiClusterConfigs).getClusters();
+
+    VeniceParentHelixAdmin parentAdmin = mock(VeniceParentHelixAdmin.class);
+    SystemStoreRepairService service =
+        new SystemStoreRepairService(parentAdmin, multiClusterConfigs, new MetricsRepository());
+    service.startInner();
+
+    Assert.assertNotNull(service.getHealthChecker());
+    Assert.assertTrue(service.getHealthChecker() instanceof HeartbeatBasedSystemStoreHealthChecker);
+
+    service.stopInner();
+  }
+
+  @Test
+  public void testStartWithValidOverrideClassName() {
+    VeniceControllerClusterConfig commonConfig = mock(VeniceControllerClusterConfig.class);
+    doReturn(600).when(commonConfig).getParentSystemStoreHeartbeatCheckWaitTimeSeconds();
+    doReturn(1800).when(commonConfig).getParentSystemStoreRepairCheckIntervalSeconds();
+    doReturn(30).when(commonConfig).getParentSystemStoreVersionRefreshThresholdInDays();
+    doReturn(50).when(commonConfig).getSystemStoreRepairMaxPerRound();
+    doReturn(TestOverrideChecker.class.getName()).when(commonConfig).getSystemStoreHealthCheckOverrideClassName();
+
+    VeniceControllerMultiClusterConfig multiClusterConfigs = mock(VeniceControllerMultiClusterConfig.class);
+    doReturn(commonConfig).when(multiClusterConfigs).getCommonConfig();
+    doReturn(new HashSet<>()).when(multiClusterConfigs).getClusters();
+
+    VeniceParentHelixAdmin parentAdmin = mock(VeniceParentHelixAdmin.class);
+    SystemStoreRepairService service =
+        new SystemStoreRepairService(parentAdmin, multiClusterConfigs, new MetricsRepository());
+    service.startInner();
+
+    // The reflective override path must successfully instantiate the configured class via the documented
+    // (VeniceControllerMultiClusterConfig) constructor and use it instead of the default heartbeat checker.
+    SystemStoreHealthChecker loaded = service.getHealthChecker();
+    Assert.assertNotNull(loaded);
+    Assert.assertTrue(
+        loaded instanceof TestOverrideChecker,
+        "expected TestOverrideChecker to be loaded, got " + loaded.getClass().getName());
+    Assert.assertSame(((TestOverrideChecker) loaded).getConfig(), multiClusterConfigs);
+
+    service.stopInner();
+  }
+
+  @Test
+  public void testStartWithInvalidOverrideClassName() {
+    VeniceControllerClusterConfig commonConfig = mock(VeniceControllerClusterConfig.class);
+    doReturn(600).when(commonConfig).getParentSystemStoreHeartbeatCheckWaitTimeSeconds();
+    doReturn(1800).when(commonConfig).getParentSystemStoreRepairCheckIntervalSeconds();
+    doReturn(30).when(commonConfig).getParentSystemStoreVersionRefreshThresholdInDays();
+    doReturn(50).when(commonConfig).getSystemStoreRepairMaxPerRound();
+    doReturn("com.nonexistent.FakeChecker").when(commonConfig).getSystemStoreHealthCheckOverrideClassName();
+
+    VeniceControllerMultiClusterConfig multiClusterConfigs = mock(VeniceControllerMultiClusterConfig.class);
+    doReturn(commonConfig).when(multiClusterConfigs).getCommonConfig();
+    doReturn(new HashSet<>()).when(multiClusterConfigs).getClusters();
+
+    VeniceParentHelixAdmin parentAdmin = mock(VeniceParentHelixAdmin.class);
+    SystemStoreRepairService service =
+        new SystemStoreRepairService(parentAdmin, multiClusterConfigs, new MetricsRepository());
+    service.startInner();
+
+    // Should fall back to heartbeat checker when override class cannot be loaded
+    Assert.assertNotNull(service.getHealthChecker());
+    Assert.assertTrue(service.getHealthChecker() instanceof HeartbeatBasedSystemStoreHealthChecker);
+
+    service.stopInner();
+  }
+
+  @Test
+  public void testStartWithOverrideConstructorThrowing() {
+    VeniceControllerClusterConfig commonConfig = mock(VeniceControllerClusterConfig.class);
+    doReturn(600).when(commonConfig).getParentSystemStoreHeartbeatCheckWaitTimeSeconds();
+    doReturn(1800).when(commonConfig).getParentSystemStoreRepairCheckIntervalSeconds();
+    doReturn(30).when(commonConfig).getParentSystemStoreVersionRefreshThresholdInDays();
+    doReturn(50).when(commonConfig).getSystemStoreRepairMaxPerRound();
+    doReturn(ThrowingConstructorChecker.class.getName()).when(commonConfig)
+        .getSystemStoreHealthCheckOverrideClassName();
+
+    VeniceControllerMultiClusterConfig multiClusterConfigs = mock(VeniceControllerMultiClusterConfig.class);
+    doReturn(commonConfig).when(multiClusterConfigs).getCommonConfig();
+    doReturn(new HashSet<>()).when(multiClusterConfigs).getClusters();
+
+    VeniceParentHelixAdmin parentAdmin = mock(VeniceParentHelixAdmin.class);
+    SystemStoreRepairService service =
+        new SystemStoreRepairService(parentAdmin, multiClusterConfigs, new MetricsRepository());
+    service.startInner();
+
+    // An override that loads but whose constructor throws must fall back to the heartbeat checker, just like a
+    // class-not-found failure, rather than crashing controller startup.
+    Assert.assertNotNull(service.getHealthChecker());
+    Assert.assertTrue(service.getHealthChecker() instanceof HeartbeatBasedSystemStoreHealthChecker);
+
+    service.stopInner();
+  }
+
+  @Test
+  public void testStopInnerClosesChecker() {
+    CLOSE_TRACKING_CHECKER_CLOSED.set(false);
+
+    VeniceControllerClusterConfig commonConfig = mock(VeniceControllerClusterConfig.class);
+    doReturn(600).when(commonConfig).getParentSystemStoreHeartbeatCheckWaitTimeSeconds();
+    doReturn(1800).when(commonConfig).getParentSystemStoreRepairCheckIntervalSeconds();
+    doReturn(30).when(commonConfig).getParentSystemStoreVersionRefreshThresholdInDays();
+    doReturn(50).when(commonConfig).getSystemStoreRepairMaxPerRound();
+    doReturn(CloseTrackingChecker.class.getName()).when(commonConfig).getSystemStoreHealthCheckOverrideClassName();
+
+    VeniceControllerMultiClusterConfig multiClusterConfigs = mock(VeniceControllerMultiClusterConfig.class);
+    doReturn(commonConfig).when(multiClusterConfigs).getCommonConfig();
+    doReturn(new HashSet<>()).when(multiClusterConfigs).getClusters();
+
+    VeniceParentHelixAdmin parentAdmin = mock(VeniceParentHelixAdmin.class);
+    SystemStoreRepairService service =
+        new SystemStoreRepairService(parentAdmin, multiClusterConfigs, new MetricsRepository());
+    service.startInner();
+    Assert.assertTrue(service.getHealthChecker() instanceof CloseTrackingChecker);
+
+    service.stopInner();
+
+    // stopInner() must close() the loaded checker so a custom checker can release its resources; a regression that
+    // skips close() would leak silently.
+    Assert.assertTrue(CLOSE_TRACKING_CHECKER_CLOSED.get(), "stopInner() should close the loaded health checker");
   }
 }

--- a/services/venice-controller/src/test/java/com/linkedin/venice/controller/systemstore/SystemStoreRepairTaskTest.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/controller/systemstore/SystemStoreRepairTaskTest.java
@@ -11,11 +11,13 @@ import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.ArgumentMatchers.anySet;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doCallRealMethod;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -25,8 +27,7 @@ import com.linkedin.venice.common.VeniceSystemStoreUtils;
 import com.linkedin.venice.controller.Admin;
 import com.linkedin.venice.controller.VeniceParentHelixAdmin;
 import com.linkedin.venice.controller.stats.SystemStoreHealthCheckStats;
-import com.linkedin.venice.controllerapi.ControllerClient;
-import com.linkedin.venice.controllerapi.SystemStoreHeartbeatResponse;
+import com.linkedin.venice.controller.systemstore.SystemStoreHealthChecker.HealthCheckResult;
 import com.linkedin.venice.exceptions.VeniceException;
 import com.linkedin.venice.meta.Store;
 import com.linkedin.venice.meta.Version;
@@ -36,7 +37,6 @@ import com.linkedin.venice.stats.VeniceMetricsConfig;
 import com.linkedin.venice.stats.VeniceMetricsRepository;
 import com.linkedin.venice.utils.LogContext;
 import com.linkedin.venice.utils.OpenTelemetryDataTestUtils;
-import com.linkedin.venice.utils.concurrent.VeniceConcurrentHashMap;
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.sdk.testing.exporter.InMemoryMetricReader;
 import java.util.Arrays;
@@ -48,6 +48,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
@@ -76,121 +77,13 @@ public class SystemStoreRepairTaskTest {
     systemStoreRepairTask.run();
 
     // Only venice-3 is the leader cluster and has system store repair task enabled.
-    verify(systemStoreRepairTask, never()).checkSystemStoresHealth(eq("venice-1"), anySet(), anySet(), anyMap());
-    verify(systemStoreRepairTask, never()).checkSystemStoresHealth(eq("venice-2"), anySet(), anySet(), anyMap());
-    verify(systemStoreRepairTask).checkSystemStoresHealth(eq("venice-3"), anySet(), anySet(), anyMap());
-
+    verify(systemStoreRepairTask, never()).checkSystemStoresHealth(eq("venice-1"), anySet());
+    verify(systemStoreRepairTask, never()).checkSystemStoresHealth(eq("venice-2"), anySet());
+    verify(systemStoreRepairTask).checkSystemStoresHealth(eq("venice-3"), anySet());
   }
 
   @Test
-  public void testPeriodicCheckHeartbeat() {
-
-    SystemStoreRepairTask systemStoreRepairTask = mock(SystemStoreRepairTask.class);
-
-    String clusterName = "venice";
-
-    String userStoreName1 = "testStore";
-    String metaStoreName1 = VeniceSystemStoreType.META_STORE.getSystemStoreName(userStoreName1);
-    String pushStatusStoreName1 = VeniceSystemStoreType.DAVINCI_PUSH_STATUS_STORE.getSystemStoreName(userStoreName1);
-
-    String userStoreName2 = "testStore2";
-    String metaStoreName2 = VeniceSystemStoreType.META_STORE.getSystemStoreName(userStoreName2);
-    String pushStatusStoreName2 = VeniceSystemStoreType.DAVINCI_PUSH_STATUS_STORE.getSystemStoreName(userStoreName2);
-
-    Map<String, Long> systemStoreToHeartbeatTimestampMap = new HashMap<>();
-    systemStoreToHeartbeatTimestampMap.put(metaStoreName1, 100L);
-    systemStoreToHeartbeatTimestampMap.put(pushStatusStoreName1, 100L);
-    systemStoreToHeartbeatTimestampMap.put(metaStoreName2, 100L);
-    systemStoreToHeartbeatTimestampMap.put(pushStatusStoreName2, 100L);
-
-    Set<String> unhealthySystemStoreSet = new HashSet<>();
-    Set<String> unreachableSystemStoreSet = new HashSet<>();
-    doCallRealMethod().when(systemStoreRepairTask)
-        .checkHeartbeatFromSystemStores(anyString(), anySet(), anySet(), anyMap(), anyInt());
-    // Check is not enabled.
-    when(systemStoreRepairTask.shouldContinue(anyString())).thenReturn(false);
-    doCallRealMethod().when(systemStoreRepairTask).periodicCheckTask(anyString(), anyInt(), anyInt(), any());
-    doReturn(1).when(systemStoreRepairTask).getHeartbeatCheckIntervalInSeconds();
-    systemStoreRepairTask.checkHeartbeatFromSystemStores(
-        clusterName,
-        unhealthySystemStoreSet,
-        unreachableSystemStoreSet,
-        systemStoreToHeartbeatTimestampMap,
-        5);
-    Assert.assertEquals(unhealthySystemStoreSet.size(), 0);
-    Assert.assertEquals(unreachableSystemStoreSet.size(), 0);
-
-    // Always stale
-    when(systemStoreRepairTask.getHeartbeatFromSystemStore(clusterName, metaStoreName1)).thenReturn(10L);
-    // First stale, then healthy HB
-    when(systemStoreRepairTask.getHeartbeatFromSystemStore(clusterName, pushStatusStoreName1)).thenReturn(10L)
-        .thenReturn(100L);
-    // Always not reachable
-    when(systemStoreRepairTask.getHeartbeatFromSystemStore(clusterName, metaStoreName2)).thenReturn(-1L);
-    // First not reachable, then healthy HB
-    when(systemStoreRepairTask.getHeartbeatFromSystemStore(clusterName, pushStatusStoreName2)).thenReturn(-1L)
-        .thenReturn(100L);
-
-    // Check is enabled.
-    when(systemStoreRepairTask.shouldContinue(anyString())).thenReturn(true);
-    systemStoreRepairTask.checkHeartbeatFromSystemStores(
-        clusterName,
-        unhealthySystemStoreSet,
-        unreachableSystemStoreSet,
-        systemStoreToHeartbeatTimestampMap,
-        5);
-    Assert.assertEquals(unhealthySystemStoreSet.size(), 2);
-    Assert.assertEquals(unreachableSystemStoreSet.size(), 1);
-  }
-
-  @Test
-  public void testCheckHeartbeat() {
-    SystemStoreRepairTask systemStoreRepairTask = mock(SystemStoreRepairTask.class);
-    String clusterName = "venice";
-    String userStoreName1 = "testStore";
-    String metaStoreName1 = VeniceSystemStoreType.META_STORE.getSystemStoreName(userStoreName1);
-    String pushStatusStoreName1 = VeniceSystemStoreType.DAVINCI_PUSH_STATUS_STORE.getSystemStoreName(userStoreName1);
-
-    String userStoreName2 = "testStore2";
-    String metaStoreName2 = VeniceSystemStoreType.META_STORE.getSystemStoreName(userStoreName2);
-    String pushStatusStoreName2 = VeniceSystemStoreType.DAVINCI_PUSH_STATUS_STORE.getSystemStoreName(userStoreName2);
-
-    SystemStoreHeartbeatResponse heartbeatResponse1 = new SystemStoreHeartbeatResponse();
-    heartbeatResponse1.setHeartbeatTimestamp(10L);
-    SystemStoreHeartbeatResponse heartbeatResponse2 = new SystemStoreHeartbeatResponse();
-    heartbeatResponse2.setHeartbeatTimestamp(11L);
-    SystemStoreHeartbeatResponse heartbeatResponse3 = new SystemStoreHeartbeatResponse();
-    heartbeatResponse3.setHeartbeatTimestamp(-1L);
-
-    ControllerClient client1 = mock(ControllerClient.class);
-    when(client1.getHeartbeatFromSystemStore(metaStoreName1)).thenReturn(heartbeatResponse1);
-    when(client1.getHeartbeatFromSystemStore(pushStatusStoreName1)).thenReturn(heartbeatResponse1);
-    when(client1.getHeartbeatFromSystemStore(metaStoreName2)).thenReturn(heartbeatResponse1);
-    when(client1.getHeartbeatFromSystemStore(pushStatusStoreName2)).thenReturn(heartbeatResponse1);
-
-    ControllerClient client2 = mock(ControllerClient.class);
-    when(client2.getHeartbeatFromSystemStore(metaStoreName1)).thenReturn(heartbeatResponse2);
-    when(client2.getHeartbeatFromSystemStore(pushStatusStoreName1)).thenReturn(heartbeatResponse3);
-    when(client2.getHeartbeatFromSystemStore(metaStoreName2)).thenReturn(heartbeatResponse1);
-    when(client2.getHeartbeatFromSystemStore(pushStatusStoreName2)).thenReturn(heartbeatResponse1);
-
-    when(systemStoreRepairTask.getHeartbeatFromSystemStore(anyString(), anyString())).thenCallRealMethod();
-    doCallRealMethod().when(systemStoreRepairTask)
-        .checkHeartbeatFromSystemStores(anyString(), anySet(), anySet(), anyMap(), anyInt());
-    Map<String, ControllerClient> controllerClientMap = new HashMap<>();
-
-    controllerClientMap.put("region1", client1);
-    controllerClientMap.put("region2", client2);
-    when(systemStoreRepairTask.getControllerClientMap(clusterName)).thenReturn(controllerClientMap);
-
-    Assert.assertEquals(systemStoreRepairTask.getHeartbeatFromSystemStore(clusterName, metaStoreName1), 10L);
-    Assert.assertEquals(systemStoreRepairTask.getHeartbeatFromSystemStore(clusterName, pushStatusStoreName1), -1L);
-    Assert.assertEquals(systemStoreRepairTask.getHeartbeatFromSystemStore(clusterName, metaStoreName2), 10L);
-    Assert.assertEquals(systemStoreRepairTask.getHeartbeatFromSystemStore(clusterName, pushStatusStoreName2), 10L);
-  }
-
-  @Test
-  public void testSendHeartbeat() {
+  public void testPreFilterSystemStores() {
     Version staleVersion = mock(Version.class);
     doReturn(System.currentTimeMillis() - TimeUnit.DAYS.toMillis(100)).when(staleVersion).getCreatedTime();
     Version newVersion = mock(Version.class);
@@ -264,41 +157,233 @@ public class SystemStoreRepairTaskTest {
     SystemStoreRepairTask systemStoreRepairTask = mock(SystemStoreRepairTask.class);
     doReturn(30).when(systemStoreRepairTask).getVersionRefreshThresholdInDays();
     when(systemStoreRepairTask.getParentAdmin()).thenReturn(veniceParentHelixAdmin);
-    doCallRealMethod().when(systemStoreRepairTask).checkAndSendHeartbeatToSystemStores(anyString(), anySet(), anyMap());
+    doCallRealMethod().when(systemStoreRepairTask).preFilterSystemStores(anyString(), anySet());
     when(systemStoreRepairTask.getIsRunning()).thenReturn(isRunning);
 
+    // shouldContinue returns false -> early exit
     when(systemStoreRepairTask.shouldContinue(cluster)).thenReturn(false);
-    Set<String> newUnhealthySystemStoreSet = new HashSet<>();
-    Map<String, Long> systemStoreToHeartbeatTimestampMap = new VeniceConcurrentHashMap<>();
+    Set<String> unhealthySet = new HashSet<>();
+    Set<String> candidates = systemStoreRepairTask.preFilterSystemStores(cluster, unhealthySet);
+    Assert.assertTrue(unhealthySet.isEmpty());
+    Assert.assertTrue(candidates.isEmpty());
 
-    systemStoreRepairTask
-        .checkAndSendHeartbeatToSystemStores(cluster, newUnhealthySystemStoreSet, systemStoreToHeartbeatTimestampMap);
-    Assert.assertTrue(newUnhealthySystemStoreSet.isEmpty());
-    Assert.assertTrue(systemStoreToHeartbeatTimestampMap.isEmpty());
-
+    // shouldContinue returns true -> full filter
     isRunning.set(true);
     when(systemStoreRepairTask.shouldContinue(cluster)).thenReturn(true);
-    systemStoreRepairTask
-        .checkAndSendHeartbeatToSystemStores(cluster, newUnhealthySystemStoreSet, systemStoreToHeartbeatTimestampMap);
-    /**
-     * It is expected to NOT check current version as it is always 0 in parent controller.
-     */
-    Assert.assertEquals(newUnhealthySystemStoreSet.size(), 4);
-    Assert.assertTrue(
-        newUnhealthySystemStoreSet.contains(VeniceSystemStoreType.META_STORE.getSystemStoreName(testStore3)));
-    Assert.assertTrue(
-        newUnhealthySystemStoreSet
-            .contains(VeniceSystemStoreType.DAVINCI_PUSH_STATUS_STORE.getSystemStoreName(testStore3)));
+    unhealthySet = new HashSet<>();
+    candidates = systemStoreRepairTask.preFilterSystemStores(cluster, unhealthySet);
 
-    /**
-     * All other stores should have new timestamp sent.
-     */
-    Assert.assertEquals(systemStoreToHeartbeatTimestampMap.size(), 2);
-    Assert.assertNotNull(
-        systemStoreToHeartbeatTimestampMap
-            .get(VeniceSystemStoreType.DAVINCI_PUSH_STATUS_STORE.getSystemStoreName(testStore1)));
-    Assert.assertNotNull(
-        systemStoreToHeartbeatTimestampMap.get(VeniceSystemStoreType.META_STORE.getSystemStoreName(testStore2)));
+    // testStore3 has system store flags disabled -> 2 unhealthy
+    // metaStore1 has no version -> 1 more unhealthy (stale)
+    // pushStatusStore2 has stale version -> 1 more unhealthy (stale)
+    // Total unhealthy: 4
+    Assert.assertEquals(unhealthySet.size(), 4);
+    Assert.assertTrue(unhealthySet.contains(VeniceSystemStoreType.META_STORE.getSystemStoreName(testStore3)));
+    Assert.assertTrue(
+        unhealthySet.contains(VeniceSystemStoreType.DAVINCI_PUSH_STATUS_STORE.getSystemStoreName(testStore3)));
+
+    // Candidates should be stores that passed all filters (pushStatusStore1 and metaStore2)
+    Assert.assertEquals(candidates.size(), 2);
+    Assert.assertTrue(
+        candidates.contains(VeniceSystemStoreType.DAVINCI_PUSH_STATUS_STORE.getSystemStoreName(testStore1)));
+    Assert.assertTrue(candidates.contains(VeniceSystemStoreType.META_STORE.getSystemStoreName(testStore2)));
+  }
+
+  @Test
+  public void testCheckSystemStoresHealthMixedResults() {
+    // Checker returns HEALTHY and UNHEALTHY for the stores it decided on; candidates missing from the result map
+    // are deferred to the next round (NOT marked unhealthy), so an aborted checker can't inflate unhealthy counts.
+    SystemStoreRepairTask task = mock(SystemStoreRepairTask.class);
+    String cluster = "venice";
+
+    Set<String> candidates = new HashSet<>(Arrays.asList("store_a", "store_b", "store_c"));
+    doCallRealMethod().when(task).checkSystemStoresHealth(anyString(), anySet());
+    doReturn(candidates).when(task).preFilterSystemStores(anyString(), anySet());
+
+    SystemStoreHealthChecker checker = mock(SystemStoreHealthChecker.class);
+    Map<String, HealthCheckResult> results = new HashMap<>();
+    results.put("store_a", HealthCheckResult.HEALTHY);
+    results.put("store_b", HealthCheckResult.UNHEALTHY);
+    // store_c has no result — checker aborted before reaching a decision; should be deferred.
+    doReturn(results).when(checker).checkHealth(eq(cluster), anySet());
+    doReturn(checker).when(task).getHealthChecker();
+
+    SystemStoreHealthCheckStats stats = mock(SystemStoreHealthCheckStats.class);
+    when(stats.getBadMetaSystemStoreCounter()).thenReturn(new AtomicLong(0));
+    when(stats.getBadPushStatusSystemStoreCounter()).thenReturn(new AtomicLong(0));
+    doReturn(stats).when(task).getClusterSystemStoreHealthCheckStats(cluster);
+
+    Set<String> unhealthySet = new HashSet<>();
+    task.checkSystemStoresHealth(cluster, unhealthySet);
+
+    Assert.assertEquals(unhealthySet.size(), 1);
+    Assert.assertFalse(unhealthySet.contains("store_a"));
+    Assert.assertTrue(unhealthySet.contains("store_b"));
+    Assert.assertFalse(unhealthySet.contains("store_c"), "stores missing from checker result should be deferred");
+  }
+
+  @Test
+  public void testCheckSystemStoresHealthEmptyResultsDoesNotInflateUnhealthy() {
+    // When the checker aborts very early (e.g., leadership lost) and returns an empty result map, candidates
+    // should be deferred to the next round instead of all being marked unhealthy.
+    SystemStoreRepairTask task = mock(SystemStoreRepairTask.class);
+    String cluster = "venice";
+
+    Set<String> candidates = new HashSet<>(Arrays.asList("store_a", "store_b", "store_c"));
+    doCallRealMethod().when(task).checkSystemStoresHealth(anyString(), anySet());
+    doReturn(candidates).when(task).preFilterSystemStores(anyString(), anySet());
+
+    SystemStoreHealthChecker checker = mock(SystemStoreHealthChecker.class);
+    doReturn(Collections.emptyMap()).when(checker).checkHealth(eq(cluster), anySet());
+    doReturn(checker).when(task).getHealthChecker();
+
+    SystemStoreHealthCheckStats stats = mock(SystemStoreHealthCheckStats.class);
+    when(stats.getBadMetaSystemStoreCounter()).thenReturn(new AtomicLong(0));
+    when(stats.getBadPushStatusSystemStoreCounter()).thenReturn(new AtomicLong(0));
+    doReturn(stats).when(task).getClusterSystemStoreHealthCheckStats(cluster);
+
+    Set<String> unhealthySet = new HashSet<>();
+    task.checkSystemStoresHealth(cluster, unhealthySet);
+
+    Assert.assertTrue(unhealthySet.isEmpty(), "empty checker result should not flag any store as unhealthy");
+  }
+
+  @Test
+  public void testCheckSystemStoresHealthAllHealthy() {
+    SystemStoreRepairTask task = mock(SystemStoreRepairTask.class);
+    String cluster = "venice";
+
+    Set<String> candidates = new HashSet<>(Arrays.asList("store_a", "store_b"));
+    doCallRealMethod().when(task).checkSystemStoresHealth(anyString(), anySet());
+    doReturn(candidates).when(task).preFilterSystemStores(anyString(), anySet());
+
+    SystemStoreHealthChecker checker = mock(SystemStoreHealthChecker.class);
+    Map<String, HealthCheckResult> results = new HashMap<>();
+    results.put("store_a", HealthCheckResult.HEALTHY);
+    results.put("store_b", HealthCheckResult.HEALTHY);
+    doReturn(results).when(checker).checkHealth(eq(cluster), anySet());
+    doReturn(checker).when(task).getHealthChecker();
+
+    SystemStoreHealthCheckStats stats = mock(SystemStoreHealthCheckStats.class);
+    when(stats.getBadMetaSystemStoreCounter()).thenReturn(new AtomicLong(0));
+    when(stats.getBadPushStatusSystemStoreCounter()).thenReturn(new AtomicLong(0));
+    doReturn(stats).when(task).getClusterSystemStoreHealthCheckStats(cluster);
+
+    Set<String> unhealthySet = new HashSet<>();
+    task.checkSystemStoresHealth(cluster, unhealthySet);
+
+    Assert.assertTrue(unhealthySet.isEmpty());
+  }
+
+  @Test
+  public void testCheckSystemStoresHealthRecoversFromCheckerException() {
+    // A misbehaving (e.g., pluggable override) health checker that throws must not take down the cluster round.
+    // Stores already flagged unhealthy by pre-filtering must still be repairable; only the health-check
+    // candidates are deferred.
+    SystemStoreRepairTask task = mock(SystemStoreRepairTask.class);
+    String cluster = "venice";
+
+    Set<String> candidates = new HashSet<>(Arrays.asList("candidate_a", "candidate_b"));
+    doCallRealMethod().when(task).checkSystemStoresHealth(anyString(), anySet());
+    // Simulate pre-filter already adding one store as unhealthy via the side-effect set.
+    doAnswer(invocation -> {
+      Set<String> unhealthy = invocation.getArgument(1);
+      unhealthy.add("pre_filtered_bad");
+      return candidates;
+    }).when(task).preFilterSystemStores(anyString(), anySet());
+
+    SystemStoreHealthChecker checker = mock(SystemStoreHealthChecker.class);
+    when(checker.checkHealth(eq(cluster), anySet())).thenThrow(new RuntimeException("checker boom"));
+    doReturn(checker).when(task).getHealthChecker();
+
+    SystemStoreHealthCheckStats stats = mock(SystemStoreHealthCheckStats.class);
+    when(stats.getBadMetaSystemStoreCounter()).thenReturn(new AtomicLong(0));
+    when(stats.getBadPushStatusSystemStoreCounter()).thenReturn(new AtomicLong(0));
+    doReturn(stats).when(task).getClusterSystemStoreHealthCheckStats(cluster);
+    AtomicLong errorCounter = new AtomicLong(0);
+    doReturn(errorCounter).when(task).getSystemStoreHealthCheckErrorCounter(cluster);
+
+    Set<String> unhealthySet = new HashSet<>();
+    task.checkSystemStoresHealth(cluster, unhealthySet);
+
+    // Pre-filtered store stays unhealthy (will be repaired); candidates are deferred (not falsely flagged).
+    Assert.assertTrue(unhealthySet.contains("pre_filtered_bad"));
+    Assert.assertFalse(unhealthySet.contains("candidate_a"));
+    Assert.assertFalse(unhealthySet.contains("candidate_b"));
+    Assert.assertEquals(unhealthySet.size(), 1);
+    // A checker that throws must bump the error metric so a persistently broken checker is alertable rather than
+    // silently deferring every round.
+    Assert.assertEquals(errorCounter.get(), 1L, "a thrown checker exception should increment the error counter");
+  }
+
+  @Test
+  public void testCheckSystemStoresHealthIgnoresNonCandidateResults() {
+    // A misbehaving (e.g., pluggable override) checker may return a store that was not among the candidates.
+    // Such entries must be ignored so they cannot pollute the unhealthy set or the bad-store metric (which would
+    // otherwise throw on an arbitrary, non-system-store name).
+    SystemStoreRepairTask task = mock(SystemStoreRepairTask.class);
+    String cluster = "venice";
+
+    Set<String> candidates = new HashSet<>(Collections.singletonList("store_a"));
+    doCallRealMethod().when(task).checkSystemStoresHealth(anyString(), anySet());
+    doReturn(candidates).when(task).preFilterSystemStores(anyString(), anySet());
+
+    SystemStoreHealthChecker checker = mock(SystemStoreHealthChecker.class);
+    Map<String, HealthCheckResult> results = new HashMap<>();
+    results.put("store_a", HealthCheckResult.HEALTHY);
+    // Not a candidate; an arbitrary name a buggy override should never be able to inject into repair.
+    results.put("rogue_non_candidate_store", HealthCheckResult.UNHEALTHY);
+    doReturn(results).when(checker).checkHealth(eq(cluster), anySet());
+    doReturn(checker).when(task).getHealthChecker();
+
+    SystemStoreHealthCheckStats stats = mock(SystemStoreHealthCheckStats.class);
+    when(stats.getBadMetaSystemStoreCounter()).thenReturn(new AtomicLong(0));
+    when(stats.getBadPushStatusSystemStoreCounter()).thenReturn(new AtomicLong(0));
+    doReturn(stats).when(task).getClusterSystemStoreHealthCheckStats(cluster);
+
+    Set<String> unhealthySet = new HashSet<>();
+    task.checkSystemStoresHealth(cluster, unhealthySet);
+
+    Assert.assertTrue(
+        unhealthySet.isEmpty(),
+        "a result for a non-candidate store must be ignored and never added to the unhealthy set");
+  }
+
+  @Test
+  public void testCheckSystemStoresHealthHandlesNullResult() {
+    // A misbehaving checker that returns null (instead of a possibly-empty map) must not abort the cluster round.
+    // Stores already flagged by pre-filtering must still be repairable; the health-check candidates are deferred.
+    SystemStoreRepairTask task = mock(SystemStoreRepairTask.class);
+    String cluster = "venice";
+
+    Set<String> candidates = new HashSet<>(Arrays.asList("candidate_a", "candidate_b"));
+    doCallRealMethod().when(task).checkSystemStoresHealth(anyString(), anySet());
+    doAnswer(invocation -> {
+      Set<String> unhealthy = invocation.getArgument(1);
+      unhealthy.add("pre_filtered_bad");
+      return candidates;
+    }).when(task).preFilterSystemStores(anyString(), anySet());
+
+    SystemStoreHealthChecker checker = mock(SystemStoreHealthChecker.class);
+    doReturn(null).when(checker).checkHealth(eq(cluster), anySet());
+    doReturn(checker).when(task).getHealthChecker();
+
+    SystemStoreHealthCheckStats stats = mock(SystemStoreHealthCheckStats.class);
+    when(stats.getBadMetaSystemStoreCounter()).thenReturn(new AtomicLong(0));
+    when(stats.getBadPushStatusSystemStoreCounter()).thenReturn(new AtomicLong(0));
+    doReturn(stats).when(task).getClusterSystemStoreHealthCheckStats(cluster);
+    AtomicLong errorCounter = new AtomicLong(0);
+    doReturn(errorCounter).when(task).getSystemStoreHealthCheckErrorCounter(cluster);
+
+    Set<String> unhealthySet = new HashSet<>();
+    task.checkSystemStoresHealth(cluster, unhealthySet);
+
+    Assert.assertTrue(unhealthySet.contains("pre_filtered_bad"));
+    Assert.assertFalse(unhealthySet.contains("candidate_a"));
+    Assert.assertFalse(unhealthySet.contains("candidate_b"));
+    Assert.assertEquals(unhealthySet.size(), 1);
+    // A checker that returns null must bump the error metric, same as a thrown exception.
+    Assert.assertEquals(errorCounter.get(), 1L, "a null checker result should increment the error counter");
   }
 
   @Test
@@ -314,8 +399,8 @@ public class SystemStoreRepairTaskTest {
     doReturn(parentHelixAdmin).when(systemStoreRepairTask).getParentAdmin();
 
     doReturn(1).when(systemStoreRepairTask).getRepairJobCheckIntervalInSeconds();
-    doReturn(1).when(systemStoreRepairTask).getHeartbeatWaitTimeInSeconds();
     doReturn(3).when(systemStoreRepairTask).getRepairJobCheckTimeoutInSeconds();
+    doReturn(-1).when(systemStoreRepairTask).getMaxRepairPerRound();
 
     // Real stats for metric verification
     String metricPrefix = "controller";
@@ -455,5 +540,142 @@ public class SystemStoreRepairTaskTest {
         clusterAttrs,
         "system_store.health_check.unrepairable_count",
         metricPrefix);
+  }
+
+  @Test
+  public void testRepairMaxPerRoundLimit() {
+    String clusterName = "test-cluster";
+    SystemStoreRepairTask systemStoreRepairTask = mock(SystemStoreRepairTask.class);
+    doCallRealMethod().when(systemStoreRepairTask).repairBadSystemStore(anyString(), anySet());
+    doCallRealMethod().when(systemStoreRepairTask).pollSystemStorePushStatus(anyString(), anyMap(), anySet(), anyInt());
+    doReturn(true).when(systemStoreRepairTask).shouldContinue(anyString());
+    doCallRealMethod().when(systemStoreRepairTask).periodicCheckTask(anyString(), anyInt(), anyInt(), any());
+
+    VeniceParentHelixAdmin parentHelixAdmin = mock(VeniceParentHelixAdmin.class);
+    doReturn(parentHelixAdmin).when(systemStoreRepairTask).getParentAdmin();
+
+    doReturn(1).when(systemStoreRepairTask).getRepairJobCheckIntervalInSeconds();
+    doReturn(3).when(systemStoreRepairTask).getRepairJobCheckTimeoutInSeconds();
+    // Set limit to 1
+    doReturn(1).when(systemStoreRepairTask).getMaxRepairPerRound();
+
+    String systemStore1 = VeniceSystemStoreUtils.getMetaStoreName("testStore1");
+    String systemStore2 = VeniceSystemStoreUtils.getMetaStoreName("testStore2");
+    String systemStore3 = VeniceSystemStoreUtils.getMetaStoreName("testStore3");
+    Set<String> unhealthySystemStoreSet = new HashSet<>();
+    unhealthySystemStoreSet.add(systemStore1);
+    unhealthySystemStoreSet.add(systemStore2);
+    unhealthySystemStoreSet.add(systemStore3);
+
+    Version version = mock(Version.class);
+    doReturn(5).when(version).getNumber();
+    doReturn(version).when(systemStoreRepairTask).getNewSystemStoreVersion(anyString(), anyString(), anyString());
+
+    Admin.OfflinePushStatusInfo goodPushStatus = mock(Admin.OfflinePushStatusInfo.class);
+    doReturn(ExecutionStatus.COMPLETED).when(goodPushStatus).getExecutionStatus();
+    when(parentHelixAdmin.getOffLinePushStatus(anyString(), anyString())).thenReturn(goodPushStatus);
+
+    systemStoreRepairTask.repairBadSystemStore(clusterName, unhealthySystemStoreSet);
+    // Only 1 store should have been repaired (removed from unhealthy set), 2 remain. The repaired store is
+    // picked randomly from the unhealthy set (we shuffle to avoid both HashSet-order starvation and
+    // sort-order starvation), so we only assert the count, not the identity.
+    Assert.assertEquals(unhealthySystemStoreSet.size(), 2);
+    // Sanity check: exactly one of the original three was repaired (removed) — not zero, not multiple.
+    int remaining = 0;
+    if (unhealthySystemStoreSet.contains(systemStore1)) {
+      remaining++;
+    }
+    if (unhealthySystemStoreSet.contains(systemStore2)) {
+      remaining++;
+    }
+    if (unhealthySystemStoreSet.contains(systemStore3)) {
+      remaining++;
+    }
+    Assert.assertEquals(remaining, 2, "exactly one of the seeded stores should have been repaired");
+  }
+
+  @Test
+  public void testRepairMaxPerRoundCapCountsFailedAttempts() {
+    // Repairs that fail fast (materialization throws) must still consume the per-round cap. Otherwise a burst of
+    // failing stores would let one round attempt the entire unhealthy set and defeat the throttle.
+    String clusterName = "test-cluster";
+    SystemStoreRepairTask systemStoreRepairTask = mock(SystemStoreRepairTask.class);
+    doCallRealMethod().when(systemStoreRepairTask).repairBadSystemStore(anyString(), anySet());
+    doCallRealMethod().when(systemStoreRepairTask).pollSystemStorePushStatus(anyString(), anyMap(), anySet(), anyInt());
+    doReturn(true).when(systemStoreRepairTask).shouldContinue(anyString());
+    doCallRealMethod().when(systemStoreRepairTask).periodicCheckTask(anyString(), anyInt(), anyInt(), any());
+
+    VeniceParentHelixAdmin parentHelixAdmin = mock(VeniceParentHelixAdmin.class);
+    doReturn(parentHelixAdmin).when(systemStoreRepairTask).getParentAdmin();
+    doReturn(1).when(systemStoreRepairTask).getRepairJobCheckIntervalInSeconds();
+    doReturn(3).when(systemStoreRepairTask).getRepairJobCheckTimeoutInSeconds();
+    // Cap of 1 repair per round.
+    doReturn(1).when(systemStoreRepairTask).getMaxRepairPerRound();
+    // Wire the real not-repairable accounting so we can assert the metric, not just the unhealthy-set size.
+    doCallRealMethod().when(systemStoreRepairTask).updateNotRepairableSystemStoreCount(anyString(), anySet());
+    AtomicLong notRepairableCounter = new AtomicLong(0);
+    doReturn(notRepairableCounter).when(systemStoreRepairTask).getNotRepairableSystemStoreCounter(clusterName);
+
+    Set<String> unhealthySystemStoreSet = new HashSet<>();
+    unhealthySystemStoreSet.add(VeniceSystemStoreUtils.getMetaStoreName("testStore1"));
+    unhealthySystemStoreSet.add(VeniceSystemStoreUtils.getMetaStoreName("testStore2"));
+    unhealthySystemStoreSet.add(VeniceSystemStoreUtils.getMetaStoreName("testStore3"));
+
+    // Every materialization fails fast.
+    doThrow(new VeniceException("materialization failed")).when(systemStoreRepairTask)
+        .getNewSystemStoreVersion(anyString(), anyString(), anyString());
+
+    systemStoreRepairTask.repairBadSystemStore(clusterName, unhealthySystemStoreSet);
+
+    // Despite all attempts failing, the cap of 1 must stop the loop after a single attempt.
+    verify(systemStoreRepairTask, times(1)).getNewSystemStoreVersion(anyString(), anyString(), anyString());
+    // No store was repaired, so all three remain unhealthy (the other two were deferred, never attempted).
+    Assert.assertEquals(unhealthySystemStoreSet.size(), 3);
+    // Only the single attempted-but-failed store is "not repairable"; the two cap-deferred stores were never
+    // attempted and must NOT inflate the metric.
+    Assert.assertEquals(
+        notRepairableCounter.get(),
+        1L,
+        "cap-deferred stores (never attempted) must not be counted as not-repairable");
+  }
+
+  @Test
+  public void testRepairMaxPerRoundExactlyAtLimitRepairsAll() {
+    // Boundary: when the cap equals the number of unhealthy stores, every store is repaired and none is deferred.
+    // Guards the `>=` comparison in SystemStoreRepairTask#repairBadSystemStore against an off-by-one regression.
+    String clusterName = "test-cluster";
+    SystemStoreRepairTask systemStoreRepairTask = mock(SystemStoreRepairTask.class);
+    doCallRealMethod().when(systemStoreRepairTask).repairBadSystemStore(anyString(), anySet());
+    doCallRealMethod().when(systemStoreRepairTask).pollSystemStorePushStatus(anyString(), anyMap(), anySet(), anyInt());
+    doReturn(true).when(systemStoreRepairTask).shouldContinue(anyString());
+    doCallRealMethod().when(systemStoreRepairTask).periodicCheckTask(anyString(), anyInt(), anyInt(), any());
+
+    VeniceParentHelixAdmin parentHelixAdmin = mock(VeniceParentHelixAdmin.class);
+    doReturn(parentHelixAdmin).when(systemStoreRepairTask).getParentAdmin();
+    doReturn(1).when(systemStoreRepairTask).getRepairJobCheckIntervalInSeconds();
+    doReturn(3).when(systemStoreRepairTask).getRepairJobCheckTimeoutInSeconds();
+    // Cap exactly equals the unhealthy-store count: all should be repaired, none deferred.
+    doReturn(3).when(systemStoreRepairTask).getMaxRepairPerRound();
+
+    Set<String> unhealthySystemStoreSet = new HashSet<>();
+    unhealthySystemStoreSet.add(VeniceSystemStoreUtils.getMetaStoreName("testStore1"));
+    unhealthySystemStoreSet.add(VeniceSystemStoreUtils.getMetaStoreName("testStore2"));
+    unhealthySystemStoreSet.add(VeniceSystemStoreUtils.getMetaStoreName("testStore3"));
+
+    Version version = mock(Version.class);
+    doReturn(5).when(version).getNumber();
+    doReturn(version).when(systemStoreRepairTask).getNewSystemStoreVersion(anyString(), anyString(), anyString());
+
+    Admin.OfflinePushStatusInfo goodPushStatus = mock(Admin.OfflinePushStatusInfo.class);
+    doReturn(ExecutionStatus.COMPLETED).when(goodPushStatus).getExecutionStatus();
+    when(parentHelixAdmin.getOffLinePushStatus(anyString(), anyString())).thenReturn(goodPushStatus);
+
+    systemStoreRepairTask.repairBadSystemStore(clusterName, unhealthySystemStoreSet);
+
+    // Cap == unhealthy count, so every store is attempted and (push COMPLETED) repaired; none deferred, none left.
+    verify(systemStoreRepairTask, times(3)).getNewSystemStoreVersion(anyString(), anyString(), anyString());
+    Assert.assertTrue(
+        unhealthySystemStoreSet.isEmpty(),
+        "when the cap equals the unhealthy-store count, every store should be repaired and none deferred");
   }
 }


### PR DESCRIPTION
## Problem Statement

The current system store health checking in `SystemStoreRepairTask` is tightly coupled to a heartbeat write+read cycle. This approach:
- Requires sending a heartbeat to every system store and then polling for the response, which is slow for large clusters.

## Solution

  - Introduce a pluggable `SystemStoreHealthChecker` interface to decouple health-check logic from the repair task, allowing custom implementations (e.g., metrics-based) to be loaded via the `controller.parent.system.store.health.check.override.class.name` config
  - Extract the existing heartbeat write+read cycle into `HeartbeatBasedSystemStoreHealthChecker` as the default implementation
  - Simplify `SystemStoreRepairTask` by delegating health checking to the single configured `SystemStoreHealthChecker`. Stores returning `UNHEALTHY` are repaired; stores missing from the result map are treated as "deferred" (neither healthy nor unhealthy) so a partial/aborted check cannot inflate unhealthy counts.
  - Add `controller.parent.system.store.repair.max.per.round` config to limit how many system stores are repaired per round per cluster (default: 50); excess unhealthy stores are deferred to the next round
  - Harden the pluggable-checker boundary so a misbehaving override cannot destabilize the repair loop (see "Hardening from review" below)

### Code changes
- [x] Added new code behind **a config**:
  - `controller.parent.system.store.health.check.override.class.name` — Fully qualified class name of an optional `SystemStoreHealthChecker` override. Default: `""` (empty, falls back to `HeartbeatBasedSystemStoreHealthChecker`).
  - `controller.parent.system.store.repair.max.per.round` — Max system stores repaired per round per cluster. Default: `50`. A negative value means unlimited.
- [x] Introduced new **log lines**.
  - [x] Confirmed if logs need to be **rate limited** to avoid excessive logging. The new log lines are per-cluster-per-round (not per-record), consistent with the existing repair-task logging cadence.

### **Concurrency-Specific Checks**
- [x] Code has **no race conditions** or **thread safety issues**. The `HeartbeatBasedSystemStoreHealthChecker` uses the same `AtomicBoolean isRunning` pattern as before. No new shared mutable state introduced; the repair task runs on a single scheduled-executor thread.
- [x] Proper **synchronization mechanisms** are used where needed. The `isRunning` AtomicBoolean is shared from the service; `healthChecker` is `volatile`.
- [x] No **blocking calls** inside critical sections that could lead to deadlocks or performance degradation.
- [x] Verified **thread-safe collections** are used. N/A — no new concurrent collections introduced.
- [x] Validated proper exception handling in multi-threaded code to avoid silent thread termination. Per-cluster and per-checker failures are caught and isolated; an override-load failure falls back to the heartbeat checker.

## Hardening from review

Addressed reviewer feedback on the pluggable-checker boundary in `SystemStoreRepairTask`:
- **Ignore non-candidate results.** Results whose key is not in the candidate set are skipped (with a warning) so a misbehaving override cannot inject a non-candidate / non-system-store name into the repair set or the bad-store metric (which assumes system-store names).
- **Count attempts toward the per-round cap.** `maxRepairPerRound` now counts each repair *attempt*, not only successes, so a burst of fast-failing materializations cannot attempt the entire unhealthy set in one round and defeat the throttle.
- **Handle a `null` checker result.** A `null` result is treated as an aborted check that defers all candidates, instead of NPE-ing out of the try/catch and aborting the whole cluster round.
- Escalated the override-load failure log to `ERROR` so a misconfigured override that silently falls back to the heartbeat checker is visible.

## How was this PR tested?

- [x] New unit tests added.
  - `HeartbeatBasedSystemStoreHealthCheckerTest` — heartbeat retrieval across regions, healthy/unhealthy results, the stale-then-fresh "flip to HEALTHY" recovery across polling iterations, empty-set handling, omitting unpolled (deferred) stores on abort, and early exit when not running.
  - `SystemStoreRepairServiceTest` — heartbeat checker created on startup when no override is configured, valid override loaded reflectively, and graceful fallback when the override class cannot be loaded.
  - `SystemStoreRepairTaskTest.testCheckSystemStoresHealthMixedResults` — HEALTHY stores are skipped, UNHEALTHY stores are repaired, and candidates missing from the result are deferred (not flagged unhealthy).
  - `SystemStoreRepairTaskTest.testCheckSystemStoresHealthAllHealthy` / `...EmptyResultsDoesNotInflateUnhealthy` / `...RecoversFromCheckerException` — health-check accounting and checker-exception isolation.
  - `SystemStoreRepairTaskTest.testCheckSystemStoresHealthIgnoresNonCandidateResults` / `...HandlesNullResult` — pluggable-checker boundary hardening.
  - `SystemStoreRepairTaskTest.testPreFilterSystemStores` — pre-filtering logic (missing stores, stale versions, migration skips).
  - `SystemStoreRepairTaskTest.testRepairMaxPerRoundLimit` / `testRepairMaxPerRoundCapCountsFailedAttempts` — the per-round cap limits repairs, including when every attempt fails.
- [x] New integration tests added.
  - `SystemStoreMultiColoTest` — verifies heartbeat delay metrics are registered for system stores in the server `MetricsRepository`.
- [x] Modified or extended existing tests.
  - Updated `SystemStoreRepairTaskTest` to use the new method signatures and to exercise health checking via the pluggable checker.
- [x] Verified backward compatibility (if applicable). The default override config is empty, preserving the existing heartbeat-only behavior.

## Does this PR introduce any user-facing or breaking changes?
- [x] No. You can skip the rest of this section.
- [ ] Yes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
