### PR TITLE
[da-vinci] Store uncompressed values in AA transient cache to skip recompression

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/ActiveActiveStoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/ActiveActiveStoreIngestionTask.java
@@ -575,13 +575,14 @@ public class ActiveActiveStoreIngestionTask extends LeaderFollowerStoreIngestion
       }
       validatePostOperationResultsAndRecord(mergeConflictResult, offsetSumPreOperation, recordTimestampsPreOperation);
 
-      // Save uncompressed (serialized) value before compression may advance the ByteBuffer position.
+      // Save uncompressed (serialized) value before calling maybeCompressData.
       // The transient cache stores uncompressed bytes so that subsequent reads for the same key
       // skip the decompress-deserialize-reserialize-recompress round-trip.
       final ByteBuffer uncompressedNewValue = mergeConflictResult.getNewValue();
-      final byte[] uncompressedArray = uncompressedNewValue != null ? uncompressedNewValue.array() : null;
-      final int uncompressedOffset = uncompressedNewValue != null ? uncompressedNewValue.position() : 0;
-      final int uncompressedLen = uncompressedNewValue != null ? uncompressedNewValue.remaining() : 0;
+      final byte[] uncompressedArray =
+          uncompressedNewValue != null ? ByteUtils.extractByteArray(uncompressedNewValue) : null;
+      final int uncompressedOffset = 0;
+      final int uncompressedLen = uncompressedArray != null ? uncompressedArray.length : 0;
 
       final ByteBuffer updatedValueBytes = maybeCompressData(
           consumerRecord.getTopicPartition().getPartitionNumber(),

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/PartitionConsumptionState.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/PartitionConsumptionState.java
@@ -742,6 +742,14 @@ public class PartitionConsumptionState {
     return transientRecordMap.size();
   }
 
+  /**
+   * Clears all entries from the transient record map. This is used defensively when transitioning out of data recovery
+   * in AA stores to avoid stale compressed transient records being interpreted as uncompressed by the AA merge path.
+   */
+  public void clearTransientRecordMap() {
+    transientRecordMap.clear();
+  }
+
   public boolean skipKafkaMessage() {
     return this.skipKafkaMessage;
   }

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/ActiveActiveStoreIngestionTaskTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/ActiveActiveStoreIngestionTaskTest.java
@@ -56,9 +56,11 @@ import com.linkedin.venice.pubsub.api.PubSubProducerCallback;
 import com.linkedin.venice.pubsub.api.PubSubTopicPartition;
 import com.linkedin.venice.pubsub.mock.InMemoryPubSubPosition;
 import com.linkedin.venice.schema.SchemaEntry;
+import com.linkedin.venice.serialization.AvroStoreDeserializerCache;
 import com.linkedin.venice.serialization.KeyWithChunkingSuffixSerializer;
 import com.linkedin.venice.serialization.avro.AvroProtocolDefinition;
 import com.linkedin.venice.serialization.avro.ChunkedValueManifestSerializer;
+import com.linkedin.venice.serializer.SerializerDeserializerFactory;
 import com.linkedin.venice.storage.protocol.ChunkId;
 import com.linkedin.venice.storage.protocol.ChunkedKeySuffix;
 import com.linkedin.venice.storage.protocol.ChunkedValueManifest;
@@ -75,7 +77,9 @@ import it.unimi.dsi.fastutil.ints.Int2ObjectMap;
 import it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap;
 import it.unimi.dsi.fastutil.objects.Object2IntMap;
 import it.unimi.dsi.fastutil.objects.Object2IntMaps;
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.lang.reflect.Field;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -83,6 +87,11 @@ import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Future;
 import java.util.concurrent.atomic.AtomicLong;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericData;
+import org.apache.avro.generic.GenericDatumWriter;
+import org.apache.avro.generic.GenericRecord;
+import org.apache.avro.io.EncoderFactory;
 import org.apache.log4j.LogManager;
 import org.apache.log4j.Logger;
 import org.mockito.ArgumentCaptor;
@@ -809,6 +818,75 @@ public class ActiveActiveStoreIngestionTaskTest {
     Assert.assertEquals(
         ingestionTask.getStorageOperationTypeForPut(1, putWithPayloadAndWithRmd),
         ActiveActiveStoreIngestionTask.StorageOperationType.VALUE_AND_RMD);
+  }
+
+  @Test
+  public void testReadStoredValueRecordUsesNoopCompressorForTransientRecords() throws Exception {
+    ActiveActiveStoreIngestionTask ingestionTask = mock(ActiveActiveStoreIngestionTask.class);
+    doCallRealMethod().when(ingestionTask).readStoredValueRecord(any(), any(), anyInt(), any(), any());
+
+    // Set hostLevelIngestionStats via reflection (protected final field in StoreIngestionTask)
+    HostLevelIngestionStats stats = mock(HostLevelIngestionStats.class);
+    Field statsField = StoreIngestionTask.class.getDeclaredField("hostLevelIngestionStats");
+    statsField.setAccessible(true);
+    statsField.set(ingestionTask, stats);
+
+    // Create a real AvroStoreDeserializerCache backed by a simple record schema
+    Schema schema = new Schema.Parser()
+        .parse("{\"type\":\"record\",\"name\":\"TestRecord\",\"fields\":[{\"name\":\"f1\",\"type\":\"string\"}]}");
+    AvroStoreDeserializerCache<GenericRecord> deserializerCache = new AvroStoreDeserializerCache<>(
+        id -> schema,
+        (writer, reader) -> SerializerDeserializerFactory.getAvroGenericDeserializer(writer, reader));
+
+    // Set storeDeserializerCache via reflection (protected final field in LeaderFollowerStoreIngestionTask)
+    Field cacheField = LeaderFollowerStoreIngestionTask.class.getDeclaredField("storeDeserializerCache");
+    cacheField.setAccessible(true);
+    cacheField.set(ingestionTask, deserializerCache);
+
+    PartitionConsumptionState pcs = mock(PartitionConsumptionState.class);
+    PubSubTopicPartition topicPartition = mock(PubSubTopicPartition.class);
+    byte[] keyBytes = "testKey".getBytes();
+    int readerSchemaId = 1;
+
+    // ---- Case 1: Transient record with null value → return null ----
+    PubSubPosition position = mock(PubSubPosition.class);
+    PartitionConsumptionState.TransientRecord nullValueRecord =
+        new PartitionConsumptionState.TransientRecord(null, 0, 0, 1, 0, position);
+    when(pcs.getTransientRecord(keyBytes)).thenReturn(nullValueRecord);
+
+    GenericRecord result = ingestionTask.readStoredValueRecord(pcs, keyBytes, readerSchemaId, topicPartition, null);
+    assertNull(result);
+    verify(stats, times(1)).recordWriteComputeCacheHitCount();
+
+    // ---- Case 2: Transient record with real value + manifest container ----
+    // Serialize a test GenericRecord to Avro binary
+    GenericRecord testRecord = new GenericData.Record(schema);
+    testRecord.put("f1", "hello");
+    ByteArrayOutputStream baos = new ByteArrayOutputStream();
+    org.apache.avro.io.BinaryEncoder encoder = EncoderFactory.get().binaryEncoder(baos, null);
+    new GenericDatumWriter<GenericRecord>(schema).write(testRecord, encoder);
+    encoder.flush();
+    byte[] serializedBytes = baos.toByteArray();
+
+    PartitionConsumptionState.TransientRecord valueRecord =
+        new PartitionConsumptionState.TransientRecord(serializedBytes, 0, serializedBytes.length, 1, 0, position);
+    ChunkedValueManifest testManifest = new ChunkedValueManifest();
+    valueRecord.setValueManifest(testManifest);
+    when(pcs.getTransientRecord(keyBytes)).thenReturn(valueRecord);
+
+    ChunkedValueManifestContainer manifestContainer = new ChunkedValueManifestContainer();
+    result = ingestionTask.readStoredValueRecord(pcs, keyBytes, readerSchemaId, topicPartition, manifestContainer);
+
+    assertNotNull(result);
+    assertEquals(result.get("f1").toString(), "hello");
+    assertEquals(manifestContainer.getManifest(), testManifest);
+    verify(stats, times(2)).recordWriteComputeCacheHitCount();
+
+    // ---- Case 3: Same transient record but null manifest container → should not NPE ----
+    result = ingestionTask.readStoredValueRecord(pcs, keyBytes, readerSchemaId, topicPartition, null);
+    assertNotNull(result);
+    assertEquals(result.get("f1").toString(), "hello");
+    verify(stats, times(3)).recordWriteComputeCacheHitCount();
   }
 
 }

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/ActiveActiveStoreIngestionTaskTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/ActiveActiveStoreIngestionTaskTest.java
@@ -20,7 +20,6 @@ import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.expectThrows;
 
-import com.github.luben.zstd.Zstd;
 import com.linkedin.davinci.config.VeniceServerConfig;
 import com.linkedin.davinci.stats.AggVersionedDIVStats;
 import com.linkedin.davinci.stats.AggVersionedIngestionStats;
@@ -30,10 +29,8 @@ import com.linkedin.davinci.storage.chunking.ChunkingUtils;
 import com.linkedin.davinci.store.StorageEngine;
 import com.linkedin.davinci.store.record.ByteBufferValueRecord;
 import com.linkedin.venice.compression.CompressionStrategy;
-import com.linkedin.venice.compression.CompressorFactory;
 import com.linkedin.venice.compression.NoopCompressor;
 import com.linkedin.venice.compression.VeniceCompressor;
-import com.linkedin.venice.compression.ZstdWithDictCompressor;
 import com.linkedin.venice.exceptions.VeniceException;
 import com.linkedin.venice.kafka.protocol.ControlMessage;
 import com.linkedin.venice.kafka.protocol.Delete;
@@ -83,7 +80,6 @@ import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Map;
-import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Future;
 import java.util.concurrent.atomic.AtomicLong;
@@ -583,14 +579,6 @@ public class ActiveActiveStoreIngestionTaskTest {
     assertEquals(
         ActiveActiveStoreIngestionTask.getUpstreamKafkaUrlFromKafkaValue(validMsg, sourceKafka, kafkaClusterIdToUrlMap),
         "url0");
-  }
-
-  private VeniceCompressor getCompressor(CompressionStrategy strategy) {
-    if (Objects.requireNonNull(strategy) == CompressionStrategy.ZSTD_WITH_DICT) {
-      byte[] dictionary = ZstdWithDictCompressor.buildDictionaryOnSyntheticAvroData();
-      return new CompressorFactory().createCompressorWithDictionary(dictionary, Zstd.maxCompressionLevel());
-    }
-    return new CompressorFactory().getCompressor(strategy);
   }
 
   @Test


### PR DESCRIPTION
## Summary

- For Active-Active stores with compression enabled, consecutive updates to the same key previously incurred a **compress → decompress → recompress** cycle through the transient record cache
- The transient cache now stores **uncompressed (serialized) value bytes** instead of compressed bytes
- `getCurrentValueFromTransientRecord()` no longer needs to decompress, eliminating redundant compression work on the AA/WC hot path
- The produce path is unaffected — it reads compressed bytes from `MergeConflictResultWrapper` independently

## How it was before

For consecutive same-key updates with compression enabled:

```
Update #1:
  merge → serialize → compress → store COMPRESSED in transient cache → produce compressed to VT

Update #2:
  read from transient cache → DECOMPRESS → deserialize → merge → serialize → COMPRESS → store → produce
```

Every consecutive same-key update paid for a full decompress + recompress cycle.

## How it is now

```
Update #1:
  merge → serialize → save uncompressed bytes
                    → compress → produce compressed to VT
                    → store UNCOMPRESSED in transient cache

Update #2:
  read from transient cache (already uncompressed) → deserialize → merge → serialize → ...
```

The decompress step is eliminated entirely. The compress step for the produce path is unchanged.

## Why this is safe

1. The transient cache is **only read by** `getValueBytesForKey()` → `getCurrentValueFromTransientRecord()` in the AA merge path, which needs deserialized Avro records (not compressed bytes)
2. The **produce path** reads from `MergeConflictResultWrapper.getUpdatedValueBytes()` which holds the compressed bytes independently
3. The transient cache is only populated **after EOP** (end of push), and the AA path is the only writer after EOP
4. Key-level locking ensures no concurrent read/write conflicts for the same key

## Test plan

- [x] `ActiveActiveStoreIngestionTaskTest` — all tests pass (updated `testGetValueBytesFromTransientRecords` to match new uncompressed storage)
- [x] `LeaderFollowerStoreIngestionTaskTest` — all tests pass
- [x] `StoreIngestionTaskTest` — all tests pass
- [x] Full `com.linkedin.davinci.replication.merge.*` test suite passes
- [x] Compilation clean