### PR TITLE
[server][controller][common] Add merged value-RMD column family for A/A ingestion

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/ActiveActiveStoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/ActiveActiveStoreIngestionTask.java
@@ -22,6 +22,8 @@ import com.linkedin.davinci.storage.chunking.ChunkedValueManifestContainer;
 import com.linkedin.davinci.storage.chunking.ChunkingUtils;
 import com.linkedin.davinci.storage.chunking.RawBytesChunkingAdapter;
 import com.linkedin.davinci.storage.chunking.SingleGetChunkingAdapter;
+import com.linkedin.davinci.store.MergedValueRmdReadOptimizingStorageEngine;
+import com.linkedin.davinci.store.StorageEngine;
 import com.linkedin.davinci.store.cache.backend.ObjectCacheBackend;
 import com.linkedin.davinci.store.record.ByteBufferValueRecord;
 import com.linkedin.davinci.store.record.ValueRecord;
@@ -438,6 +440,7 @@ public class ActiveActiveStoreIngestionTask extends LeaderFollowerStoreIngestion
    * @return The object containing RMD and value schema id. If nothing is found, return null
    */
   RmdWithValueSchemaId getReplicationMetadataAndSchemaId(
+      StorageEngine readStorageEngine,
       PartitionConsumptionState partitionConsumptionState,
       byte[] key,
       int partition,
@@ -455,8 +458,12 @@ public class ActiveActiveStoreIngestionTask extends LeaderFollowerStoreIngestion
           cachedRecord.getRmdManifest());
     }
     ChunkedValueManifestContainer rmdManifestContainer = new ChunkedValueManifestContainer();
-    byte[] replicationMetadataWithValueSchemaBytes =
-        getRmdWithValueSchemaByteBufferFromStorage(partition, key, rmdManifestContainer, currentTimeForMetricsMs);
+    byte[] replicationMetadataWithValueSchemaBytes = getRmdWithValueSchemaByteBufferFromStorage(
+        readStorageEngine,
+        partition,
+        key,
+        rmdManifestContainer,
+        currentTimeForMetricsMs);
     if (replicationMetadataWithValueSchemaBytes == null) {
       return null; // No RMD for this key
     }
@@ -477,13 +484,18 @@ public class ActiveActiveStoreIngestionTask extends LeaderFollowerStoreIngestion
    * RMD manifest into passed-in {@link ChunkedValueManifestContainer} container object if current RMD value is chunked.
    */
   byte[] getRmdWithValueSchemaByteBufferFromStorage(
+      StorageEngine readStorageEngine,
       int partition,
       byte[] key,
       ChunkedValueManifestContainer rmdManifestContainer,
       long currentTimeForMetricsMs) {
     final long lookupStartTimeInNS = System.nanoTime();
     ValueRecord result = databaseLookupWithConcurrencyLimit(
-        () -> getRmdWithValueSchemaByteBufferFromStorageInternal(partition, key, rmdManifestContainer));
+        () -> getRmdWithValueSchemaByteBufferFromStorageInternal(
+            readStorageEngine,
+            partition,
+            key,
+            rmdManifestContainer));
     long rmdLookupElapsedNs = System.nanoTime() - lookupStartTimeInNS;
     double rmdLookupLatency = rmdLookupElapsedNs / 1_000_000.0;
     getHostLevelIngestionStats()
@@ -508,8 +520,16 @@ public class ActiveActiveStoreIngestionTask extends LeaderFollowerStoreIngestion
       int partition,
       byte[] key,
       ChunkedValueManifestContainer rmdManifestContainer) {
+    return getRmdWithValueSchemaByteBufferFromStorageInternal(getStorageEngine(), partition, key, rmdManifestContainer);
+  }
+
+  ValueRecord getRmdWithValueSchemaByteBufferFromStorageInternal(
+      StorageEngine readStorageEngine,
+      int partition,
+      byte[] key,
+      ChunkedValueManifestContainer rmdManifestContainer) {
     return SingleGetChunkingAdapter
-        .getReplicationMetadata(getStorageEngine(), partition, key, isChunked(), rmdManifestContainer);
+        .getReplicationMetadata(readStorageEngine, partition, key, isChunked(), rmdManifestContainer);
   }
 
   @Override
@@ -553,8 +573,14 @@ public class ActiveActiveStoreIngestionTask extends LeaderFollowerStoreIngestion
             ingestionTaskName + " : Invalid/Unrecognized operation type submitted: " + kafkaValue.messageType);
     }
     final ChunkedValueManifestContainer valueManifestContainer = new ChunkedValueManifestContainer();
+    // When the merged value-RMD column family is enabled, the value and RMD live in the same record, so the value
+    // and RMD top-level reads are served from a single storage lookup during conflict resolution instead of two.
+    final StorageEngine dcrReadStorageEngine = isMergedValueRmdColumnFamilyEnabled
+        ? new MergedValueRmdReadOptimizingStorageEngine(getStorageEngine(), partition)
+        : getStorageEngine();
     Lazy<ByteBufferValueRecord<ByteBuffer>> oldValueProvider = Lazy.of(
         () -> getValueBytesForKey(
+            dcrReadStorageEngine,
             partitionConsumptionState,
             keyBytes,
             consumerRecord.getTopicPartition(),
@@ -567,6 +593,7 @@ public class ActiveActiveStoreIngestionTask extends LeaderFollowerStoreIngestion
     }
 
     final RmdWithValueSchemaId rmdWithValueSchemaID = getReplicationMetadataAndSchemaId(
+        dcrReadStorageEngine,
         partitionConsumptionState,
         keyBytes,
         partition,
@@ -854,6 +881,7 @@ public class ActiveActiveStoreIngestionTask extends LeaderFollowerStoreIngestion
    * @return
    */
   private ByteBufferValueRecord<ByteBuffer> getValueBytesForKey(
+      StorageEngine readStorageEngine,
       PartitionConsumptionState partitionConsumptionState,
       byte[] key,
       PubSubTopicPartition topicPartition,
@@ -872,7 +900,7 @@ public class ActiveActiveStoreIngestionTask extends LeaderFollowerStoreIngestion
 
       originalValue = databaseLookupWithConcurrencyLimit(
           () -> RawBytesChunkingAdapter.INSTANCE.getWithSchemaId(
-              storageEngine,
+              readStorageEngine,
               topicPartition.getPartitionNumber(),
               ByteBuffer.wrap(key),
               isChunked,

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
@@ -398,6 +398,7 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
   private final boolean suppressLiveUpdates;
 
   private final boolean isActiveActiveReplicationEnabled;
+  protected final boolean isMergedValueRmdColumnFamilyEnabled;
 
   /**
    * This would be the number of partitions in the StorageEngine and in version topics
@@ -733,6 +734,7 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
     this.localKafkaServer = this.kafkaProps.getProperty(KAFKA_BOOTSTRAP_SERVERS);
     this.localKafkaServerSingletonSet = Collections.singleton(localKafkaServer);
     this.isActiveActiveReplicationEnabled = version.isActiveActiveReplicationEnabled();
+    this.isMergedValueRmdColumnFamilyEnabled = version.isMergedValueRmdColumnFamilyEnabled();
     this.offsetLagDeltaRelaxEnabled = serverConfig.getOffsetLagDeltaRelaxFactorForFastOnlineTransitionInRestart() > 0;
     this.timeLagRelaxEnabled = serverConfig.getTimeLagThresholdForFastOnlineTransitionInRestartMinutes() > 0;
     this.metaStoreWriter = builder.getMetaStoreWriter();

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/storage/StorageService.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/storage/StorageService.java
@@ -393,8 +393,10 @@ public class StorageService extends AbstractVeniceService {
 
     LOGGER.info("Creating/Opening Storage Engine {} with type: {}", topicName, storeConfig.getStorePersistenceType());
     StorageEngineFactory factory = getInternalStorageEngineFactory(storeConfig);
-    StorageEngine newEngine =
-        factory.getStorageEngine(storeConfig, isReplicationMetadataEnabled(topicName, factory.getPersistenceType()));
+    PersistenceType persistenceType = factory.getPersistenceType();
+    boolean replicationMetadataEnabled = isReplicationMetadataEnabled(topicName, persistenceType);
+    boolean mergedCfEnabled = isMergedValueRmdColumnFamilyEnabled(topicName, persistenceType);
+    StorageEngine newEngine = factory.getStorageEngine(storeConfig, replicationMetadataEnabled, mergedCfEnabled);
     newEngine.updateStoreVersionStateCache(initialStoreVersionStateSupplier.get());
 
     // Let's check if a previous incarnation of the storage engine existed earlier
@@ -678,6 +680,32 @@ public class StorageService extends AbstractVeniceService {
 
     if (lastException != null) {
       throw lastException;
+    }
+  }
+
+  private boolean isMergedValueRmdColumnFamilyEnabled(String topicName, PersistenceType persistenceType) {
+    if (serverConfig.isDaVinciClient() || !Objects.equals(persistenceType, ROCKS_DB)) {
+      return false;
+    }
+    String storeName;
+    int versionNum;
+    try {
+      storeName = Version.parseStoreFromVersionTopic(topicName);
+      versionNum = Version.parseVersionFromKafkaTopicName(topicName);
+    } catch (IllegalArgumentException e) {
+      return false;
+    }
+    try {
+      Version version = storeRepository.getStoreOrThrow(storeName).getVersion(versionNum);
+      if (version != null) {
+        return version.isActiveActiveReplicationEnabled() && version.isMergedValueRmdColumnFamilyEnabled();
+      } else {
+        LOGGER.warn("Version {} of store {} does not exist in storeRepository.", versionNum, storeName);
+        return false;
+      }
+    } catch (VeniceNoStoreException e) {
+      LOGGER.warn("Store {} does not exist in storeRepository.", storeName);
+      return false;
     }
   }
 

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/store/AbstractStorageEngine.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/store/AbstractStorageEngine.java
@@ -632,6 +632,14 @@ public abstract class AbstractStorageEngine<Partition extends AbstractStoragePar
     });
   }
 
+  @Override
+  public byte[][] getValueAndReplicationMetadata(int partitionId, ByteBuffer key) {
+    return executeWithSafeGuard(partitionId, () -> {
+      AbstractStoragePartition partition = getPartitionOrThrow(partitionId);
+      return partition.getValueAndReplicationMetadata(key);
+    });
+  }
+
   /**
    * Put the offset associated with the partitionId into the metadata partition.
    */

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/store/AbstractStoragePartition.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/store/AbstractStoragePartition.java
@@ -181,6 +181,15 @@ public abstract class AbstractStoragePartition {
   }
 
   /**
+   * Reads the value and replication metadata for a key in a single storage lookup. Returns {@code [value, rmd]}.
+   * Only {@link MergedValueRmdRocksDBStoragePartition}, which co-locates value and RMD in one column family,
+   * supports this; other partitions throw {@link VeniceUnsupportedOperationException}.
+   */
+  public byte[][] getValueAndReplicationMetadata(ByteBuffer key) {
+    throw new VeniceUnsupportedOperationException("getValueAndReplicationMetadata");
+  }
+
+  /**
    * This API deletes a record from RocksDB but updates the metadata in ByteBuffer format and puts it into RocksDB.
    * Only {@link ReplicationMetadataRocksDBStoragePartition} will execute this method,
    * other storage partition implementation will VeniceUnsupportedOperationException.

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/store/DelegatingStorageEngine.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/store/DelegatingStorageEngine.java
@@ -188,6 +188,11 @@ public class DelegatingStorageEngine<P extends AbstractStoragePartition> impleme
   }
 
   @Override
+  public byte[][] getValueAndReplicationMetadata(int partitionId, ByteBuffer key) {
+    return this.delegate.getValueAndReplicationMetadata(partitionId, key);
+  }
+
+  @Override
   public void putPartitionOffset(int partitionId, OffsetRecord offsetRecord) {
     this.delegate.putPartitionOffset(partitionId, offsetRecord);
   }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/store/MergedValueRmdReadOptimizingStorageEngine.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/store/MergedValueRmdReadOptimizingStorageEngine.java
@@ -1,0 +1,79 @@
+package com.linkedin.davinci.store;
+
+import java.nio.ByteBuffer;
+import java.util.Arrays;
+
+
+/**
+ * A {@link DelegatingStorageEngine} used during active-active conflict resolution for stores backed by the
+ * merged value-RMD column family. For a given key, the value top-level read and the RMD top-level read both
+ * resolve to the same merged record, so this wrapper serves both of them from a single
+ * {@link StorageEngine#getValueAndReplicationMetadata} lookup instead of two separate
+ * {@link StorageEngine#get}/{@link StorageEngine#getReplicationMetadata} reads.
+ *
+ * <p>Only the first top-level read of the record triggers the merged lookup; both value and RMD reads use the
+ * identical (chunking-suffixed, when chunking is enabled) top-level key, so the second one is served from the
+ * cached result. Chunk reads use different keys and therefore fall through to the delegate unchanged, so chunked
+ * value/RMD reassembly behaves exactly as it does without this wrapper.
+ *
+ * <p>Not thread-safe: an instance is created per record and used by a single ingestion thread.
+ */
+public class MergedValueRmdReadOptimizingStorageEngine extends DelegatingStorageEngine {
+  private final int targetPartition;
+  private byte[] primaryKey;
+  private byte[] cachedValue;
+  private byte[] cachedRmd;
+  private boolean loaded;
+
+  public MergedValueRmdReadOptimizingStorageEngine(StorageEngine delegate, int targetPartition) {
+    super(delegate);
+    this.targetPartition = targetPartition;
+  }
+
+  @Override
+  public byte[] get(int partitionId, ByteBuffer keyBuffer) {
+    if (isTopLevelRead(partitionId, keyBuffer)) {
+      return cachedValue;
+    }
+    return super.get(partitionId, keyBuffer);
+  }
+
+  @Override
+  public byte[] getReplicationMetadata(int partitionId, ByteBuffer key) {
+    if (isTopLevelRead(partitionId, key)) {
+      return cachedRmd;
+    }
+    return super.getReplicationMetadata(partitionId, key);
+  }
+
+  /**
+   * Returns true if {@code (partitionId, key)} is the record's top-level read, loading the merged record once on
+   * the first such access. Chunk reads (which use different keys) return false and are delegated. The first
+   * top-level access in conflict resolution is always the value or RMD top-level read; chunk reads only happen
+   * afterwards, during reassembly, so the first key seen for the target partition is the primary key.
+   */
+  private boolean isTopLevelRead(int partitionId, ByteBuffer key) {
+    if (partitionId != targetPartition) {
+      return false;
+    }
+    byte[] keyBytes = toBytes(key);
+    if (!loaded) {
+      primaryKey = keyBytes;
+      byte[][] valueAndRmd = getDelegate().getValueAndReplicationMetadata(partitionId, key);
+      if (valueAndRmd != null) {
+        cachedValue = valueAndRmd[0];
+        cachedRmd = valueAndRmd[1];
+      }
+      loaded = true;
+      return true;
+    }
+    return Arrays.equals(keyBytes, primaryKey);
+  }
+
+  private static byte[] toBytes(ByteBuffer key) {
+    ByteBuffer duplicate = key.duplicate();
+    byte[] bytes = new byte[duplicate.remaining()];
+    duplicate.get(bytes);
+    return bytes;
+  }
+}

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/store/StorageEngine.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/store/StorageEngine.java
@@ -130,6 +130,16 @@ public interface StorageEngine<Partition extends AbstractStoragePartition> exten
   byte[] getReplicationMetadata(int partitionId, ByteBuffer key);
 
   /**
+   * Reads the value and replication metadata for a key in a single storage lookup, for storage formats that
+   * co-locate them in one column family. Returns {@code [value, rmd]} (the array, or either element, may be
+   * null when absent). The default is unsupported; only partitions that store value and RMD together (the
+   * merged value-RMD column family) support this.
+   */
+  default byte[][] getValueAndReplicationMetadata(int partitionId, ByteBuffer key) {
+    throw new UnsupportedOperationException("getValueAndReplicationMetadata");
+  }
+
+  /**
    * Put the offset associated with the partitionId into the metadata partition.
    */
   void putPartitionOffset(int partitionId, OffsetRecord offsetRecord);

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/store/StorageEngineFactory.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/store/StorageEngineFactory.java
@@ -29,8 +29,16 @@ public abstract class StorageEngineFactory {
    * throw VeniceException here.
    */
   public StorageEngine getStorageEngine(VeniceStoreVersionConfig storeDef, boolean replicationMetadataEnabled) {
-    if (replicationMetadataEnabled) {
-      throw new VeniceException("Replication metadata is only supported in RocksDB storage engine!");
+    return getStorageEngine(storeDef, replicationMetadataEnabled, false);
+  }
+
+  public StorageEngine getStorageEngine(
+      VeniceStoreVersionConfig storeDef,
+      boolean replicationMetadataEnabled,
+      boolean mergedValueRmdColumnFamilyEnabled) {
+    if (replicationMetadataEnabled || mergedValueRmdColumnFamilyEnabled) {
+      throw new VeniceException(
+          "Replication metadata and merged value/RMD column-family mode are only supported in RocksDB storage engine!");
     }
     return getStorageEngine(storeDef);
   }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/store/rocksdb/MergedValueRmdRocksDBStoragePartition.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/store/rocksdb/MergedValueRmdRocksDBStoragePartition.java
@@ -1,0 +1,331 @@
+package com.linkedin.davinci.store.rocksdb;
+
+import com.linkedin.davinci.stats.RocksDBMemoryStats;
+import com.linkedin.davinci.store.StoragePartitionConfig;
+import com.linkedin.venice.exceptions.VeniceException;
+import com.linkedin.venice.utils.ByteUtils;
+import java.nio.ByteBuffer;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.Supplier;
+import org.rocksdb.RocksDB;
+
+
+/**
+ * A storage partition that stores both value and replication metadata (RMD) in a single
+ * RocksDB column family. This reduces read amplification during A/A ingestion by eliminating
+ * the need for two separate RocksDB get() calls.
+ *
+ * Storage format for each record:
+ * <pre>
+ * +------------------+-------------+------------+-----------+
+ * | valueSchemaId 4B | valueLen 4B | valueBytes | rmdBytes  |
+ * +------------------+-------------+------------+-----------+
+ * </pre>
+ *
+ * - Client reads: Read first 8 bytes (schemaId + valueLen), then extract valueBytes. RMD is ignored.
+ * - A/A ingestion reads: Parse all fields to get both value and RMD.
+ * - RMD length is implicit: totalLength - 8 - valueLen.
+ * - When RMD is empty (deleted key or non-A/A): rmdBytes section is empty.
+ */
+public class MergedValueRmdRocksDBStoragePartition extends RocksDBStoragePartition {
+  /** Size of the header: 4 bytes for valueSchemaId + 4 bytes for valueLen */
+  public static final int HEADER_SIZE = Integer.BYTES + Integer.BYTES;
+
+  private static final byte[] EMPTY_RMD = new byte[0];
+
+  public MergedValueRmdRocksDBStoragePartition(
+      StoragePartitionConfig storagePartitionConfig,
+      RocksDBStorageEngineFactory factory,
+      String dbDir,
+      RocksDBMemoryStats rocksDBMemoryStats,
+      RocksDBThrottler rocksDbThrottler,
+      RocksDBServerConfig rocksDBServerConfig) {
+    super(
+        storagePartitionConfig,
+        factory,
+        dbDir,
+        rocksDBMemoryStats,
+        rocksDbThrottler,
+        rocksDBServerConfig,
+        Collections.singletonList(RocksDB.DEFAULT_COLUMN_FAMILY));
+  }
+
+  /**
+   * The merged value-RMD format rewrites each record as {@code [schemaId][valueLen][value][rmd]}, so the
+   * bytes persisted to the SST file intentionally differ from the producer's original value bytes. The
+   * push-time SST checksum is computed by the producer over those original value bytes, so it can never
+   * match the merged SST contents. Skip it by passing an empty checksum supplier, analogous to how the
+   * separate replication-metadata column family is excluded from SST checksum verification.
+   */
+  @Override
+  public synchronized void beginBatchWrite(
+      Map<String, String> checkpointedInfo,
+      Optional<Supplier<byte[]>> expectedChecksumSupplier) {
+    super.beginBatchWrite(checkpointedInfo, Optional.empty());
+  }
+
+  /**
+   * Overrides the standard put() to store value in the merged format with empty RMD.
+   * This ensures that data written during batch push (which uses put() instead of
+   * putWithReplicationMetadata()) is stored in the correct merged format so that
+   * subsequent get() calls can correctly parse it.
+   */
+  @Override
+  public synchronized void put(byte[] key, byte[] value) {
+    putMergedRecord(key, mergeValueAndRmd(value, EMPTY_RMD));
+  }
+
+  @Override
+  public synchronized void put(byte[] key, ByteBuffer valueBuffer) {
+    put(key, ByteUtils.extractByteArray(valueBuffer));
+  }
+
+  /**
+   * Writes a key with both value and replication metadata in the merged format.
+   */
+  @Override
+  public synchronized void putWithReplicationMetadata(byte[] key, byte[] value, byte[] metadata) {
+    putMergedRecord(key, mergeValueAndRmd(value, metadata));
+  }
+
+  /**
+   * Writes an already-merged record to storage. Delegates to the superclass {@link ByteBuffer} write,
+   * which honors deferred-write (SST) vs direct RocksDB mode along with the read/close lifecycle guards.
+   * Routing through {@code super.put} (a non-virtual call) is required to avoid re-entering this class's
+   * overridden {@link #put(byte[], byte[])} / {@link #put(byte[], ByteBuffer)} methods, which would
+   * otherwise recurse infinitely in deferred-write (batch) mode.
+   */
+  private void putMergedRecord(byte[] key, byte[] mergedRecord) {
+    super.put(key, ByteBuffer.wrap(mergedRecord));
+  }
+
+  @Override
+  public synchronized void putWithReplicationMetadata(byte[] key, ByteBuffer value, byte[] metadata) {
+    byte[] valueBytes = ByteUtils.extractByteArray(value);
+    putWithReplicationMetadata(key, valueBytes, metadata);
+  }
+
+  /**
+   * Writes only replication metadata for a key. In merged mode, we need to read the existing
+   * value (if any) and re-write with the new RMD.
+   */
+  @Override
+  public synchronized void putReplicationMetadata(byte[] key, byte[] metadata) {
+    if (deferredWrite) {
+      // putReplicationMetadata performs a read-modify-write to preserve the existing value, which
+      // cannot observe records still buffered in the SST writer during deferred-write (batch) mode.
+      throw new VeniceException(
+          "putReplicationMetadata is not supported in deferred-write mode for the merged value-RMD column family, replica: "
+              + replicaId);
+    }
+    // Read the existing merged record to preserve its value portion, then re-write it with the new RMD.
+    byte[] existingRecord = withOpenDatabase(db -> db.get(key));
+    byte[] valueBytes = extractValueHeaderAndBytes(existingRecord);
+    byte[] mergedRecord = new byte[valueBytes.length + metadata.length];
+    System.arraycopy(valueBytes, 0, mergedRecord, 0, valueBytes.length);
+    System.arraycopy(metadata, 0, mergedRecord, valueBytes.length, metadata.length);
+    putMergedRecord(key, mergedRecord);
+  }
+
+  /**
+   * Returns the {@code [schemaId 4B][valueLen 4B][valueBytes]} prefix of an existing merged record,
+   * with the RMD section stripped off. If the record is null, shorter than the header, or its declared
+   * value length is inconsistent with the stored bytes, an empty tombstone header
+   * (schemaId=0, valueLen=0) is returned instead of throwing.
+   */
+  private static byte[] extractValueHeaderAndBytes(byte[] mergedRecord) {
+    if (mergedRecord != null && mergedRecord.length >= HEADER_SIZE) {
+      int valueLen = ByteUtils.readInt(mergedRecord, Integer.BYTES);
+      if (valueLen >= 0 && HEADER_SIZE + valueLen <= mergedRecord.length) {
+        byte[] valueBytes = new byte[HEADER_SIZE + valueLen];
+        System.arraycopy(mergedRecord, 0, valueBytes, 0, valueBytes.length);
+        return valueBytes;
+      }
+    }
+    byte[] valueBytes = new byte[HEADER_SIZE];
+    ByteUtils.writeInt(valueBytes, 0, 0);
+    ByteUtils.writeInt(valueBytes, 0, Integer.BYTES);
+    return valueBytes;
+  }
+
+  /**
+   * Retrieves only the replication metadata portion from the merged record.
+   */
+  @Override
+  public byte[] getReplicationMetadata(ByteBuffer key) {
+    return withOpenDatabase(db -> {
+      byte[] mergedRecord = db.get(READ_OPTIONS_DEFAULT, key.array(), key.position(), key.remaining());
+      return mergedRecord == null ? null : extractRmd(mergedRecord);
+    });
+  }
+
+  /**
+   * Retrieves both value and replication metadata from a single read.
+   * Returns an array of two byte arrays: [value, rmd].
+   * Returns null if the key does not exist.
+   */
+  @Override
+  public byte[][] getValueAndReplicationMetadata(ByteBuffer key) {
+    return withOpenDatabase(db -> {
+      byte[] mergedRecord = db.get(READ_OPTIONS_DEFAULT, key.array(), key.position(), key.remaining());
+      return mergedRecord == null ? null : splitMergedRecord(mergedRecord);
+    });
+  }
+
+  /**
+   * For client reads, the get() method returns the value portion only (including the schema ID prefix).
+   * Since the first 4 bytes are already the valueSchemaId and the next 4 bytes are valueLen,
+   * we extract [valueSchemaId][valueBytes] which is what client reads expect.
+   *
+   * However, for the ingestion path which uses get() to read the full value (with schemaId prefix),
+   * the merged format already has schemaId as the first 4 bytes.
+   * The value portion is: bytes[0..HEADER_SIZE+valueLen-1], but we need to strip out the valueLen field
+   * and return [schemaId 4B][valueBytes].
+   */
+  @Override
+  public byte[] get(byte[] key) {
+    return withOpenDatabase(db -> {
+      byte[] mergedRecord = db.get(key);
+      return mergedRecord == null ? null : extractValue(mergedRecord);
+    });
+  }
+
+  @Override
+  public byte[] get(ByteBuffer keyBuffer) {
+    return withOpenDatabase(db -> {
+      byte[] mergedRecord = db.get(keyBuffer.array(), keyBuffer.position(), keyBuffer.remaining());
+      return mergedRecord == null ? null : extractValue(mergedRecord);
+    });
+  }
+
+  /**
+   * The reuse-buffer read path (used by {@link com.linkedin.davinci.storage.chunking.AbstractAvroChunkingAdapter},
+   * e.g. server-side single-get/compute) calls this overload. The parent copies the raw stored bytes verbatim; for
+   * the merged format those bytes carry the extra {@code [valueLen][rmdBytes]}, so the header must be stripped to
+   * the standard {@code [schemaId][value]} format before populating the buffer, otherwise schema-id parsing and
+   * value deserialization break.
+   */
+  @Override
+  public ByteBuffer get(byte[] key, ByteBuffer valueToBePopulated) {
+    byte[] value = get(key);
+    if (value == null) {
+      return null;
+    }
+    ByteBuffer target =
+        valueToBePopulated.capacity() >= value.length ? valueToBePopulated : ByteBuffer.allocate(value.length);
+    target.clear();
+    target.put(value);
+    target.flip();
+    return target;
+  }
+
+  /**
+   * Deletes the value but preserves the RMD. In merged mode, this means writing
+   * just the RMD with an empty value portion.
+   */
+  @Override
+  public synchronized void deleteWithReplicationMetadata(byte[] key, byte[] replicationMetadata) {
+    // Write a tombstone (schemaId=0, valueLen=0) that preserves the RMD bytes.
+    putMergedRecord(key, mergeValueAndRmd(null, replicationMetadata));
+  }
+
+  /**
+   * Merges value bytes and RMD bytes into the combined format.
+   * Value bytes are expected to already contain the schemaId prefix (first 4 bytes).
+   *
+   * Input value format: [valueSchemaId 4B][actualValueBytes...]
+   * Output merged format: [valueSchemaId 4B][valueLen 4B][actualValueBytes...][rmdBytes...]
+   *
+   * where valueLen = length of actualValueBytes (i.e., value.length - 4)
+   */
+  static byte[] mergeValueAndRmd(byte[] value, byte[] rmd) {
+    if (value == null || value.length < Integer.BYTES) {
+      // No value or invalid value: write header + RMD only
+      byte[] result = new byte[HEADER_SIZE + (rmd != null ? rmd.length : 0)];
+      ByteUtils.writeInt(result, 0, 0); // schemaId = 0
+      ByteUtils.writeInt(result, 0, Integer.BYTES); // valueLen = 0
+      if (rmd != null && rmd.length > 0) {
+        System.arraycopy(rmd, 0, result, HEADER_SIZE, rmd.length);
+      }
+      return result;
+    }
+
+    int schemaId = ByteUtils.readInt(value, 0);
+    int actualValueLen = value.length - Integer.BYTES;
+    int rmdLen = (rmd != null) ? rmd.length : 0;
+    byte[] result = new byte[HEADER_SIZE + actualValueLen + rmdLen];
+
+    ByteUtils.writeInt(result, schemaId, 0);
+    ByteUtils.writeInt(result, actualValueLen, Integer.BYTES);
+    if (actualValueLen > 0) {
+      System.arraycopy(value, Integer.BYTES, result, HEADER_SIZE, actualValueLen);
+    }
+    if (rmdLen > 0) {
+      System.arraycopy(rmd, 0, result, HEADER_SIZE + actualValueLen, rmdLen);
+    }
+    return result;
+  }
+
+  /**
+   * Extracts the value portion from a merged record.
+   * Returns [valueSchemaId 4B][actualValueBytes...] which is the standard value format.
+   */
+  static byte[] extractValue(byte[] mergedRecord) {
+    if (mergedRecord == null || mergedRecord.length < HEADER_SIZE) {
+      return null;
+    }
+    int schemaId = ByteUtils.readInt(mergedRecord, 0);
+    int valueLen = ByteUtils.readInt(mergedRecord, Integer.BYTES);
+    // A corrupt or out-of-bounds length is treated as missing.
+    if (valueLen < 0 || HEADER_SIZE + valueLen > mergedRecord.length) {
+      return null;
+    }
+    // A delete tombstone is the sentinel header schemaId==0 && valueLen==0 (written by deleteWithReplicationMetadata);
+    // it reads back as null even when RMD bytes follow. A legitimate value with an empty payload (schemaId>0,
+    // valueLen==0) still round-trips as a 4-byte [schemaId].
+    if (valueLen == 0 && schemaId == 0) {
+      return null;
+    }
+    // Reconstruct the standard value format: [schemaId 4B][actualValueBytes]
+    byte[] value = new byte[Integer.BYTES + valueLen];
+    ByteUtils.writeInt(value, schemaId, 0);
+    if (valueLen > 0) {
+      System.arraycopy(mergedRecord, HEADER_SIZE, value, Integer.BYTES, valueLen);
+    }
+    return value;
+  }
+
+  /**
+   * Extracts the RMD portion from a merged record.
+   */
+  static byte[] extractRmd(byte[] mergedRecord) {
+    if (mergedRecord == null || mergedRecord.length < HEADER_SIZE) {
+      return null;
+    }
+    int valueLen = ByteUtils.readInt(mergedRecord, Integer.BYTES);
+    if (valueLen < 0 || HEADER_SIZE + valueLen > mergedRecord.length) {
+      // Corrupt length, or a value-only record with no RMD section.
+      return null;
+    }
+    int rmdOffset = HEADER_SIZE + valueLen;
+    int rmdLen = mergedRecord.length - rmdOffset;
+    if (rmdLen <= 0) {
+      return null;
+    }
+    byte[] rmd = new byte[rmdLen];
+    System.arraycopy(mergedRecord, rmdOffset, rmd, 0, rmdLen);
+    return rmd;
+  }
+
+  /**
+   * Splits a merged record into [value, rmd].
+   * Value is in standard format: [schemaId 4B][actualValueBytes]
+   */
+  static byte[][] splitMergedRecord(byte[] mergedRecord) {
+    byte[] value = extractValue(mergedRecord);
+    byte[] rmd = extractRmd(mergedRecord);
+    return new byte[][] { value, rmd };
+  }
+}

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/store/rocksdb/RocksDBStorageEngine.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/store/rocksdb/RocksDBStorageEngine.java
@@ -45,6 +45,7 @@ public class RocksDBStorageEngine extends AbstractStorageEngine<RocksDBStoragePa
   private final RocksDBStorageEngineFactory factory;
   private final VeniceStoreVersionConfig storeConfig;
   private final boolean replicationMetadataEnabled;
+  private final boolean mergedValueRmdColumnFamilyEnabled;
   private final StorageEngineStats stats;
 
   public RocksDBStorageEngine(
@@ -57,6 +58,30 @@ public class RocksDBStorageEngine extends AbstractStorageEngine<RocksDBStoragePa
       InternalAvroSpecificSerializer<StoreVersionState> storeVersionStateSerializer,
       InternalAvroSpecificSerializer<PartitionState> partitionStateSerializer,
       boolean replicationMetadataEnabled) {
+    this(
+        storeConfig,
+        factory,
+        rocksDbPath,
+        rocksDBMemoryStats,
+        rocksDbThrottler,
+        rocksDBServerConfig,
+        storeVersionStateSerializer,
+        partitionStateSerializer,
+        replicationMetadataEnabled,
+        false);
+  }
+
+  public RocksDBStorageEngine(
+      VeniceStoreVersionConfig storeConfig,
+      RocksDBStorageEngineFactory factory,
+      String rocksDbPath,
+      RocksDBMemoryStats rocksDBMemoryStats,
+      RocksDBThrottler rocksDbThrottler,
+      RocksDBServerConfig rocksDBServerConfig,
+      InternalAvroSpecificSerializer<StoreVersionState> storeVersionStateSerializer,
+      InternalAvroSpecificSerializer<PartitionState> partitionStateSerializer,
+      boolean replicationMetadataEnabled,
+      boolean mergedValueRmdColumnFamilyEnabled) {
     super(storeConfig.getStoreVersionName(), storeVersionStateSerializer, partitionStateSerializer);
     this.storeConfig = storeConfig;
     this.rocksDbPath = rocksDbPath;
@@ -65,6 +90,7 @@ public class RocksDBStorageEngine extends AbstractStorageEngine<RocksDBStoragePa
     this.rocksDBServerConfig = rocksDBServerConfig;
     this.factory = factory;
     this.replicationMetadataEnabled = replicationMetadataEnabled;
+    this.mergedValueRmdColumnFamilyEnabled = mergedValueRmdColumnFamilyEnabled;
 
     // Create store folder if it doesn't exist
     storeDbPath = RocksDBUtils.composeStoreDbDir(this.rocksDbPath, getStoreVersionName());
@@ -147,8 +173,8 @@ public class RocksDBStorageEngine extends AbstractStorageEngine<RocksDBStoragePa
 
   @Override
   public RocksDBStoragePartition createStoragePartition(StoragePartitionConfig storagePartitionConfig) {
-    // Metadata partition should not enable replication metadata column family.
-    if (storagePartitionConfig.getPartitionId() == METADATA_PARTITION_ID || !replicationMetadataEnabled) {
+    // Metadata partition should not enable replication metadata column family or merged mode.
+    if (storagePartitionConfig.getPartitionId() == METADATA_PARTITION_ID) {
       return new RocksDBStoragePartition(
           storagePartitionConfig,
           factory,
@@ -156,7 +182,17 @@ public class RocksDBStorageEngine extends AbstractStorageEngine<RocksDBStoragePa
           memoryStats,
           rocksDbThrottler,
           rocksDBServerConfig);
-    } else {
+    }
+    if (mergedValueRmdColumnFamilyEnabled) {
+      return new MergedValueRmdRocksDBStoragePartition(
+          storagePartitionConfig,
+          factory,
+          rocksDbPath,
+          memoryStats,
+          rocksDbThrottler,
+          rocksDBServerConfig);
+    }
+    if (replicationMetadataEnabled) {
       return new ReplicationMetadataRocksDBStoragePartition(
           storagePartitionConfig,
           factory,
@@ -165,6 +201,13 @@ public class RocksDBStorageEngine extends AbstractStorageEngine<RocksDBStoragePa
           rocksDbThrottler,
           rocksDBServerConfig);
     }
+    return new RocksDBStoragePartition(
+        storagePartitionConfig,
+        factory,
+        rocksDbPath,
+        memoryStats,
+        rocksDbThrottler,
+        rocksDBServerConfig);
   }
 
   private long getRMDSizeInBytes() {

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/store/rocksdb/RocksDBStorageEngineFactory.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/store/rocksdb/RocksDBStorageEngineFactory.java
@@ -261,6 +261,14 @@ public class RocksDBStorageEngineFactory extends StorageEngineFactory {
   public synchronized StorageEngine getStorageEngine(
       VeniceStoreVersionConfig storeConfig,
       boolean replicationMetadataEnabled) throws StorageInitializationException {
+    return getStorageEngine(storeConfig, replicationMetadataEnabled, false);
+  }
+
+  @Override
+  public synchronized StorageEngine getStorageEngine(
+      VeniceStoreVersionConfig storeConfig,
+      boolean replicationMetadataEnabled,
+      boolean mergedValueRmdColumnFamilyEnabled) throws StorageInitializationException {
     verifyPersistenceType(storeConfig);
     final String storeName = storeConfig.getStoreVersionName();
     try {
@@ -275,7 +283,8 @@ public class RocksDBStorageEngineFactory extends StorageEngineFactory {
               rocksDBServerConfig,
               storeVersionStateSerializer,
               partitionStateSerializer,
-              replicationMetadataEnabled));
+              replicationMetadataEnabled,
+              mergedValueRmdColumnFamilyEnabled));
     } catch (Exception e) {
       throw new StorageInitializationException(e);
     }

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/ActiveActiveStoreIngestionTaskTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/ActiveActiveStoreIngestionTaskTest.java
@@ -417,6 +417,8 @@ public class ActiveActiveStoreIngestionTaskTest {
     when(ingestionTask.getSchemaRepo()).thenReturn(schemaRepository);
     when(ingestionTask.getServerConfig()).thenReturn(serverConfig);
     when(ingestionTask.getRmdWithValueSchemaByteBufferFromStorageInternal(anyInt(), any(), any())).thenCallRealMethod();
+    when(ingestionTask.getRmdWithValueSchemaByteBufferFromStorageInternal(any(), anyInt(), any(), any()))
+        .thenCallRealMethod();
     when(ingestionTask.isChunked()).thenReturn(true);
     when(ingestionTask.getHostLevelIngestionStats()).thenReturn(mock(HostLevelIngestionStats.class));
     ChunkedValueManifestContainer container = new ChunkedValueManifestContainer();

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/storage/StorageServiceTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/storage/StorageServiceTest.java
@@ -1,6 +1,7 @@
 package com.linkedin.davinci.storage;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doAnswer;
@@ -112,7 +113,7 @@ public class StorageServiceTest {
     when(configLoader.getStoreConfig(eq(resourceName), eq(PersistenceType.BLACK_HOLE))).thenReturn(storeVersionConfig);
 
     StorageEngine mockStorageEngine = mock(StorageEngine.class);
-    when(mockStorageEngineFactory.getStorageEngine(storeVersionConfig, false)).thenReturn(mockStorageEngine);
+    when(mockStorageEngineFactory.getStorageEngine(storeVersionConfig, false, false)).thenReturn(mockStorageEngine);
     Set<Integer> partitionSet = new HashSet<>(Arrays.asList(1, 2, 3));
     when(mockStorageEngine.getPersistedPartitionIds()).thenReturn(partitionSet);
     when(mockStorageEngine.getStoreVersionName()).thenReturn(resourceName);
@@ -294,7 +295,8 @@ public class StorageServiceTest {
 
     // Capture the boolean argument to verify RMD is enabled
     ArgumentCaptor<Boolean> rmdCaptor = ArgumentCaptor.forClass(Boolean.class);
-    when(mockFactory.getStorageEngine(eq(mockStoreVersionConfig), rmdCaptor.capture())).thenReturn(mockEngine);
+    when(mockFactory.getStorageEngine(eq(mockStoreVersionConfig), rmdCaptor.capture(), anyBoolean()))
+        .thenReturn(mockEngine);
 
     StorageService storageService =
         createStorageServiceForRmdTest(mockStoreRepo, mockServerConfig, mockFactory, mockStoreVersionConfig);
@@ -336,7 +338,8 @@ public class StorageServiceTest {
     when(mockEngine.getStoreVersionName()).thenReturn(topicName);
 
     ArgumentCaptor<Boolean> rmdCaptor = ArgumentCaptor.forClass(Boolean.class);
-    when(mockFactory.getStorageEngine(eq(mockStoreVersionConfig), rmdCaptor.capture())).thenReturn(mockEngine);
+    when(mockFactory.getStorageEngine(eq(mockStoreVersionConfig), rmdCaptor.capture(), anyBoolean()))
+        .thenReturn(mockEngine);
 
     StorageService storageService =
         createStorageServiceForRmdTest(mockStoreRepo, mockServerConfig, mockFactory, mockStoreVersionConfig);
@@ -378,7 +381,8 @@ public class StorageServiceTest {
     when(mockEngine.getStoreVersionName()).thenReturn(topicName);
 
     ArgumentCaptor<Boolean> rmdCaptor = ArgumentCaptor.forClass(Boolean.class);
-    when(mockFactory.getStorageEngine(eq(mockStoreVersionConfig), rmdCaptor.capture())).thenReturn(mockEngine);
+    when(mockFactory.getStorageEngine(eq(mockStoreVersionConfig), rmdCaptor.capture(), anyBoolean()))
+        .thenReturn(mockEngine);
 
     StorageService storageService =
         createStorageServiceForRmdTest(mockStoreRepo, mockServerConfig, mockFactory, mockStoreVersionConfig);

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/store/MergedValueRmdReadOptimizingStorageEngineTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/store/MergedValueRmdReadOptimizingStorageEngineTest.java
@@ -1,0 +1,86 @@
+package com.linkedin.davinci.store;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNull;
+
+import java.nio.ByteBuffer;
+import org.testng.annotations.Test;
+
+
+public class MergedValueRmdReadOptimizingStorageEngineTest {
+  private static final int PARTITION = 3;
+
+  @Test
+  public void testValueAndRmdServedFromSingleMergedRead() {
+    StorageEngine delegate = mock(StorageEngine.class);
+    byte[] value = "value-bytes".getBytes();
+    byte[] rmd = "rmd-bytes".getBytes();
+    when(delegate.getValueAndReplicationMetadata(eq(PARTITION), any(ByteBuffer.class)))
+        .thenReturn(new byte[][] { value, rmd });
+
+    MergedValueRmdReadOptimizingStorageEngine engine =
+        new MergedValueRmdReadOptimizingStorageEngine(delegate, PARTITION);
+
+    byte[] key = "the-key".getBytes();
+    // RMD top-level read happens first (eager during conflict resolution).
+    assertEquals(engine.getReplicationMetadata(PARTITION, ByteBuffer.wrap(key)), rmd);
+    // Value top-level read happens next, for the same key, and must be served from the cached merged read.
+    assertEquals(engine.get(PARTITION, ByteBuffer.wrap(key)), value);
+
+    // Exactly one merged lookup for both, and neither single-column read hit the delegate for the primary key.
+    verify(delegate, times(1)).getValueAndReplicationMetadata(eq(PARTITION), any(ByteBuffer.class));
+    verify(delegate, never()).get(eq(PARTITION), any(ByteBuffer.class));
+    verify(delegate, never()).getReplicationMetadata(eq(PARTITION), any(ByteBuffer.class));
+  }
+
+  @Test
+  public void testChunkReadsAndOtherPartitionsAreDelegated() {
+    StorageEngine delegate = mock(StorageEngine.class);
+    byte[] primaryKey = "manifest-key".getBytes();
+    byte[] chunkKey = "chunk-key".getBytes();
+    byte[] rmdChunkKey = "rmd-chunk-key".getBytes();
+    byte[] chunkBytes = "chunk".getBytes();
+    byte[] rmdChunkBytes = "rmd-chunk".getBytes();
+    when(delegate.getValueAndReplicationMetadata(eq(PARTITION), any(ByteBuffer.class)))
+        .thenReturn(new byte[][] { "manifest".getBytes(), "rmd-manifest".getBytes() });
+    when(delegate.get(eq(PARTITION), eq(ByteBuffer.wrap(chunkKey)))).thenReturn(chunkBytes);
+    when(delegate.getReplicationMetadata(eq(PARTITION), eq(ByteBuffer.wrap(rmdChunkKey)))).thenReturn(rmdChunkBytes);
+    when(delegate.get(eq(7), eq(ByteBuffer.wrap(primaryKey)))).thenReturn("other-partition".getBytes());
+
+    MergedValueRmdReadOptimizingStorageEngine engine =
+        new MergedValueRmdReadOptimizingStorageEngine(delegate, PARTITION);
+
+    // Prime the merged read with the primary key.
+    engine.getReplicationMetadata(PARTITION, ByteBuffer.wrap(primaryKey));
+    // Chunk reads (different keys) fall through to the delegate unchanged.
+    assertEquals(engine.get(PARTITION, ByteBuffer.wrap(chunkKey)), chunkBytes);
+    assertEquals(engine.getReplicationMetadata(PARTITION, ByteBuffer.wrap(rmdChunkKey)), rmdChunkBytes);
+    // A read for a different partition is delegated and never served from the cached merged read.
+    assertEquals(engine.get(7, ByteBuffer.wrap(primaryKey)), "other-partition".getBytes());
+
+    verify(delegate, times(1)).get(eq(PARTITION), eq(ByteBuffer.wrap(chunkKey)));
+    verify(delegate, times(1)).getReplicationMetadata(eq(PARTITION), eq(ByteBuffer.wrap(rmdChunkKey)));
+    verify(delegate, times(1)).get(eq(7), eq(ByteBuffer.wrap(primaryKey)));
+  }
+
+  @Test
+  public void testMissingRecordYieldsNullValueAndRmd() {
+    StorageEngine delegate = mock(StorageEngine.class);
+    when(delegate.getValueAndReplicationMetadata(eq(PARTITION), any(ByteBuffer.class))).thenReturn(null);
+
+    MergedValueRmdReadOptimizingStorageEngine engine =
+        new MergedValueRmdReadOptimizingStorageEngine(delegate, PARTITION);
+
+    byte[] key = "missing".getBytes();
+    assertNull(engine.getReplicationMetadata(PARTITION, ByteBuffer.wrap(key)));
+    assertNull(engine.get(PARTITION, ByteBuffer.wrap(key)));
+    verify(delegate, times(1)).getValueAndReplicationMetadata(eq(PARTITION), any(ByteBuffer.class));
+  }
+}

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/store/rocksdb/MergedValueRmdRocksDBStoragePartitionTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/store/rocksdb/MergedValueRmdRocksDBStoragePartitionTest.java
@@ -1,0 +1,189 @@
+package com.linkedin.davinci.store.rocksdb;
+
+import static com.linkedin.davinci.store.rocksdb.MergedValueRmdRocksDBStoragePartition.HEADER_SIZE;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertNull;
+
+import com.linkedin.davinci.config.VeniceServerConfig;
+import com.linkedin.davinci.store.AbstractStorageEngineTest;
+import com.linkedin.davinci.store.StoragePartitionConfig;
+import com.linkedin.venice.meta.PersistenceType;
+import com.linkedin.venice.meta.Version;
+import com.linkedin.venice.utils.ByteUtils;
+import com.linkedin.venice.utils.Utils;
+import com.linkedin.venice.utils.VeniceProperties;
+import java.io.File;
+import java.nio.ByteBuffer;
+import org.rocksdb.RocksDB;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+
+/**
+ * Unit tests for the merged value-RMD record format used by {@link MergedValueRmdRocksDBStoragePartition}.
+ * The merged layout is {@code [schemaId 4B][valueLen 4B][valueBytes][rmdBytes]}. These tests exercise the
+ * pure split/merge helpers, including the tombstone and corrupt-record edge cases.
+ */
+public class MergedValueRmdRocksDBStoragePartitionTest {
+  private static final String DATA_BASE_DIR = Utils.getUniqueTempPath();
+  private static final RocksDBThrottler ROCKSDB_THROTTLER = new RocksDBThrottler(3);
+
+  @BeforeClass
+  public void loadRocksDBLibrary() {
+    // The partition class hierarchy initializes RocksDB option handles in its static initializer, which
+    // requires the native library to be loaded before any of the static record-format helpers are touched.
+    RocksDB.loadLibrary();
+  }
+
+  /** Builds a standard value payload: {@code [schemaId 4B][valueBytes]}. */
+  private static byte[] valueWithSchemaId(int schemaId, byte[] valueBytes) {
+    byte[] value = new byte[Integer.BYTES + valueBytes.length];
+    ByteUtils.writeInt(value, schemaId, 0);
+    System.arraycopy(valueBytes, 0, value, Integer.BYTES, valueBytes.length);
+    return value;
+  }
+
+  @Test
+  public void testMergeAndExtractRoundTrip() {
+    byte[] value = valueWithSchemaId(5, "hello".getBytes());
+    byte[] rmd = "metadata".getBytes();
+
+    byte[] merged = MergedValueRmdRocksDBStoragePartition.mergeValueAndRmd(value, rmd);
+
+    assertEquals(MergedValueRmdRocksDBStoragePartition.extractValue(merged), value);
+    assertEquals(MergedValueRmdRocksDBStoragePartition.extractRmd(merged), rmd);
+
+    byte[][] split = MergedValueRmdRocksDBStoragePartition.splitMergedRecord(merged);
+    assertEquals(split[0], value);
+    assertEquals(split[1], rmd);
+  }
+
+  @Test
+  public void testValueOnlyHasNoRmd() {
+    byte[] value = valueWithSchemaId(7, "world".getBytes());
+
+    byte[] merged = MergedValueRmdRocksDBStoragePartition.mergeValueAndRmd(value, new byte[0]);
+
+    assertEquals(MergedValueRmdRocksDBStoragePartition.extractValue(merged), value);
+    assertNull(MergedValueRmdRocksDBStoragePartition.extractRmd(merged), "A value-only record has no RMD section");
+  }
+
+  @Test
+  public void testTombstoneWithRmdReturnsNullValue() {
+    // Mirror what deleteWithReplicationMetadata writes: schemaId=0, valueLen=0, followed by RMD bytes.
+    byte[] rmd = "tombstone-rmd".getBytes();
+    byte[] tombstone = new byte[HEADER_SIZE + rmd.length];
+    ByteUtils.writeInt(tombstone, 0, 0);
+    ByteUtils.writeInt(tombstone, 0, Integer.BYTES);
+    System.arraycopy(rmd, 0, tombstone, HEADER_SIZE, rmd.length);
+
+    assertNull(
+        MergedValueRmdRocksDBStoragePartition.extractValue(tombstone),
+        "A delete tombstone must read back as null even when RMD bytes are present");
+    assertEquals(MergedValueRmdRocksDBStoragePartition.extractRmd(tombstone), rmd);
+  }
+
+  @Test
+  public void testMergeNullValueProducesTombstoneWithRmd() {
+    byte[] rmd = "rmd-only".getBytes();
+
+    byte[] merged = MergedValueRmdRocksDBStoragePartition.mergeValueAndRmd(null, rmd);
+
+    assertNull(MergedValueRmdRocksDBStoragePartition.extractValue(merged));
+    assertEquals(MergedValueRmdRocksDBStoragePartition.extractRmd(merged), rmd);
+  }
+
+  @Test
+  public void testEmptyPayloadValueIsNotTreatedAsTombstone() {
+    // A legitimate value with an empty serialized payload is just [schemaId] (valueLen==0, schemaId>0). Only the
+    // sentinel schemaId==0 && valueLen==0 is a tombstone, so this must round-trip rather than read back as null.
+    byte[] emptyPayloadValue = valueWithSchemaId(7, new byte[0]);
+    byte[] rmd = "rmd-bytes".getBytes();
+
+    byte[] merged = MergedValueRmdRocksDBStoragePartition.mergeValueAndRmd(emptyPayloadValue, rmd);
+
+    assertEquals(MergedValueRmdRocksDBStoragePartition.extractValue(merged), emptyPayloadValue);
+    assertEquals(MergedValueRmdRocksDBStoragePartition.extractRmd(merged), rmd);
+  }
+
+  @Test
+  public void testExtractFromNullOrTruncatedRecord() {
+    assertNull(MergedValueRmdRocksDBStoragePartition.extractValue(null));
+    assertNull(MergedValueRmdRocksDBStoragePartition.extractRmd(null));
+    // Shorter than the 8-byte header.
+    assertNull(MergedValueRmdRocksDBStoragePartition.extractValue(new byte[] { 1, 2, 3 }));
+    assertNull(MergedValueRmdRocksDBStoragePartition.extractRmd(new byte[] { 1, 2, 3 }));
+  }
+
+  @Test
+  public void testCorruptValueLengthIsHandledWithoutThrowing() {
+    // Header declares a value length far larger than the actual record; must not throw.
+    byte[] corrupt = new byte[HEADER_SIZE];
+    ByteUtils.writeInt(corrupt, 1, 0); // schemaId
+    ByteUtils.writeInt(corrupt, 1_000_000, Integer.BYTES); // bogus valueLen
+
+    assertNull(MergedValueRmdRocksDBStoragePartition.extractValue(corrupt));
+    assertNull(MergedValueRmdRocksDBStoragePartition.extractRmd(corrupt));
+
+    // Negative declared value length.
+    byte[] negative = new byte[HEADER_SIZE + 4];
+    ByteUtils.writeInt(negative, 1, 0);
+    ByteUtils.writeInt(negative, -10, Integer.BYTES);
+
+    assertNull(MergedValueRmdRocksDBStoragePartition.extractValue(negative));
+    assertNull(MergedValueRmdRocksDBStoragePartition.extractRmd(negative));
+  }
+
+  /**
+   * The reuse-buffer {@code get(byte[], ByteBuffer)} overload (used by the Avro chunking read path) must return the
+   * stripped value, identical to {@code get(byte[])}, rather than the raw merged record.
+   */
+  @Test
+  public void testReuseBufferGetStripsMergedHeader() {
+    String storeName = Version.composeKafkaTopic(Utils.getUniqueString("merged_cf"), 1);
+    File storeDir = new File(DATA_BASE_DIR, storeName);
+    storeDir.mkdirs();
+    storeDir.deleteOnExit();
+    StoragePartitionConfig partitionConfig = new StoragePartitionConfig(storeName, 0);
+    VeniceProperties serverProps = AbstractStorageEngineTest.getServerProperties(PersistenceType.ROCKS_DB);
+    RocksDBServerConfig rocksDBServerConfig = new RocksDBServerConfig(serverProps);
+    VeniceServerConfig serverConfig = new VeniceServerConfig(serverProps);
+    RocksDBStorageEngineFactory factory = new RocksDBStorageEngineFactory(serverConfig);
+    MergedValueRmdRocksDBStoragePartition partition = new MergedValueRmdRocksDBStoragePartition(
+        partitionConfig,
+        factory,
+        DATA_BASE_DIR,
+        null,
+        ROCKSDB_THROTTLER,
+        rocksDBServerConfig);
+    try {
+      byte[] key = "key1".getBytes();
+      byte[] value = valueWithSchemaId(5, "hello-merged-value".getBytes());
+      partition.putWithReplicationMetadata(key, value, "rmd-bytes".getBytes());
+
+      // Sanity: get(byte[]) strips the merged header to the standard value format.
+      assertEquals(partition.get(key), value);
+
+      // get(byte[], ByteBuffer) must return the SAME stripped value, not the raw merged record.
+      ByteBuffer populated = partition.get(key, ByteBuffer.allocate(value.length));
+      assertNotNull(populated);
+      assertEquals(toBytes(populated), value);
+
+      // A too-small reusable buffer triggers reallocation and still returns the stripped value.
+      assertEquals(toBytes(partition.get(key, ByteBuffer.allocate(1))), value);
+
+      // A missing key returns null.
+      assertNull(partition.get("missing-key".getBytes(), ByteBuffer.allocate(16)));
+    } finally {
+      partition.drop();
+      factory.close();
+    }
+  }
+
+  private static byte[] toBytes(ByteBuffer buffer) {
+    byte[] bytes = new byte[buffer.remaining()];
+    buffer.get(bytes);
+    return bytes;
+  }
+}

--- a/internal/venice-common/src/main/java/com/linkedin/venice/controllerapi/ControllerApiConstants.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/controllerapi/ControllerApiConstants.java
@@ -70,6 +70,7 @@ public class ControllerApiConstants {
   public static final String CLIENT_DECOMPRESSION_ENABLED = "client_decompression_enabled";
   public static final String CHUNKING_ENABLED = "chunking_enabled";
   public static final String RMD_CHUNKING_ENABLED = "rmd_chunking_enabled";
+  public static final String MERGED_VALUE_RMD_COLUMN_FAMILY_ENABLED = "merged_value_rmd_column_family_enabled";
   public static final String INCREMENTAL_PUSH_ENABLED = "incremental_push_enabled";
   public static final String SEPARATE_REAL_TIME_TOPIC_ENABLED = "separate_realtime_topic_enabled";
   public static final String SINGLE_GET_ROUTER_CACHE_ENABLED = "single_get_router_cache_enabled";

--- a/internal/venice-common/src/main/java/com/linkedin/venice/controllerapi/UpdateStoreQueryParams.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/controllerapi/UpdateStoreQueryParams.java
@@ -44,6 +44,7 @@ import static com.linkedin.venice.controllerapi.ControllerApiConstants.LATEST_SU
 import static com.linkedin.venice.controllerapi.ControllerApiConstants.MAX_COMPACTION_LAG_SECONDS;
 import static com.linkedin.venice.controllerapi.ControllerApiConstants.MAX_NEARLINE_RECORD_SIZE_BYTES;
 import static com.linkedin.venice.controllerapi.ControllerApiConstants.MAX_RECORD_SIZE_BYTES;
+import static com.linkedin.venice.controllerapi.ControllerApiConstants.MERGED_VALUE_RMD_COLUMN_FAMILY_ENABLED;
 import static com.linkedin.venice.controllerapi.ControllerApiConstants.MIGRATION_DUPLICATE_STORE;
 import static com.linkedin.venice.controllerapi.ControllerApiConstants.MIN_COMPACTION_LAG_SECONDS;
 import static com.linkedin.venice.controllerapi.ControllerApiConstants.NATIVE_REPLICATION_ENABLED;
@@ -151,6 +152,7 @@ public class UpdateStoreQueryParams extends QueryParams {
             .setBootstrapToOnlineTimeoutInHours(srcStore.getBootstrapToOnlineTimeoutInHours())
             .setChunkingEnabled(srcStore.isChunkingEnabled())
             .setRmdChunkingEnabled(srcStore.isRmdChunkingEnabled())
+            .setMergedValueRmdColumnFamilyEnabled(srcStore.isMergedValueRmdColumnFamilyEnabled())
             .setClientDecompressionEnabled(srcStore.getClientDecompressionEnabled())
             .setCompressionStrategy(srcStore.getCompressionStrategy())
             .setEnableReads(srcStore.isEnableStoreReads())
@@ -472,6 +474,14 @@ public class UpdateStoreQueryParams extends QueryParams {
 
   public Optional<Boolean> getRmdChunkingEnabled() {
     return getBoolean(RMD_CHUNKING_ENABLED);
+  }
+
+  public UpdateStoreQueryParams setMergedValueRmdColumnFamilyEnabled(boolean mergedValueRmdColumnFamilyEnabled) {
+    return putBoolean(MERGED_VALUE_RMD_COLUMN_FAMILY_ENABLED, mergedValueRmdColumnFamilyEnabled);
+  }
+
+  public Optional<Boolean> getMergedValueRmdColumnFamilyEnabled() {
+    return getBoolean(MERGED_VALUE_RMD_COLUMN_FAMILY_ENABLED);
   }
 
   public UpdateStoreQueryParams setIncrementalPushEnabled(boolean incrementalPushEnabled) {

--- a/internal/venice-common/src/main/java/com/linkedin/venice/meta/AbstractStore.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/meta/AbstractStore.java
@@ -146,6 +146,7 @@ public abstract class AbstractStore implements Store {
 
       version.setChunkingEnabled(isChunkingEnabled());
       version.setRmdChunkingEnabled(isRmdChunkingEnabled());
+      version.setMergedValueRmdColumnFamilyEnabled(isMergedValueRmdColumnFamilyEnabled());
 
       PartitionerConfig partitionerConfig = getPartitionerConfig();
       if (partitionerConfig != null) {

--- a/internal/venice-common/src/main/java/com/linkedin/venice/meta/ReadOnlyStore.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/meta/ReadOnlyStore.java
@@ -425,6 +425,16 @@ public class ReadOnlyStore implements Store {
     }
 
     @Override
+    public boolean isMergedValueRmdColumnFamilyEnabled() {
+      return this.delegate.isMergedValueRmdColumnFamilyEnabled();
+    }
+
+    @Override
+    public void setMergedValueRmdColumnFamilyEnabled(boolean mergedValueRmdColumnFamilyEnabled) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
     public String getStoreName() {
       return this.delegate.getStoreName();
     }
@@ -1056,6 +1066,7 @@ public class ReadOnlyStore implements Store {
     storeProperties.setClientDecompressionEnabled(getClientDecompressionEnabled());
     storeProperties.setChunkingEnabled(isChunkingEnabled());
     storeProperties.setRmdChunkingEnabled(isRmdChunkingEnabled());
+    storeProperties.setMergedValueRmdColumnFamilyEnabled(isMergedValueRmdColumnFamilyEnabled());
     storeProperties.setBatchGetLimit(getBatchGetLimit());
     storeProperties.setNumVersionsToPreserve(getNumVersionsToPreserve());
     storeProperties.setIncrementalPushEnabled(isIncrementalPushEnabled());
@@ -1113,7 +1124,6 @@ public class ReadOnlyStore implements Store {
     storeProperties.setStorageMode(getStorageMode().getValue());
     // Set fields to default values - fields exist in schema but not yet exposed via Store interface
     storeProperties.setTransientRecordCacheEnabled(false);
-    storeProperties.setMergedValueRmdColumnFamilyEnabled(false);
 
     return storeProperties;
   }
@@ -1229,6 +1239,16 @@ public class ReadOnlyStore implements Store {
 
   @Override
   public void setRmdChunkingEnabled(boolean rmdChunkingEnabled) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public boolean isMergedValueRmdColumnFamilyEnabled() {
+    return this.delegate.isMergedValueRmdColumnFamilyEnabled();
+  }
+
+  @Override
+  public void setMergedValueRmdColumnFamilyEnabled(boolean mergedValueRmdColumnFamilyEnabled) {
     throw new UnsupportedOperationException();
   }
 
@@ -2028,6 +2048,7 @@ public class ReadOnlyStore implements Store {
     // storeVersion.setBufferReplayEnabledForHybrid();
     storeVersion.setChunkingEnabled(version.isChunkingEnabled());
     storeVersion.setRmdChunkingEnabled(version.isRmdChunkingEnabled());
+    storeVersion.setMergedValueRmdColumnFamilyEnabled(version.isMergedValueRmdColumnFamilyEnabled());
     storeVersion.setPushType(version.getPushType().getValue());
     storeVersion.setPartitionCount(version.getPartitionCount());
     storeVersion.setPartitionerConfig(convertPartitionerConfig(version.getPartitionerConfig()));
@@ -2060,7 +2081,6 @@ public class ReadOnlyStore implements Store {
     // Set fields to default values - fields exist in schema but not yet exposed via Version interface
     storeVersion.setRollbackTrigger("NOT_ROLLED_BACK");
     storeVersion.setTransientRecordCacheEnabled(false);
-    storeVersion.setMergedValueRmdColumnFamilyEnabled(false);
 
     return storeVersion;
   }

--- a/internal/venice-common/src/main/java/com/linkedin/venice/meta/Store.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/meta/Store.java
@@ -138,6 +138,10 @@ public interface Store {
 
   void setRmdChunkingEnabled(boolean rmdChunkingEnabled);
 
+  boolean isMergedValueRmdColumnFamilyEnabled();
+
+  void setMergedValueRmdColumnFamilyEnabled(boolean mergedValueRmdColumnFamilyEnabled);
+
   int getBatchGetLimit();
 
   void setBatchGetLimit(int batchGetLimit);

--- a/internal/venice-common/src/main/java/com/linkedin/venice/meta/StoreInfo.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/meta/StoreInfo.java
@@ -36,6 +36,7 @@ public class StoreInfo {
     storeInfo.setBootstrapToOnlineTimeoutInHours(store.getBootstrapToOnlineTimeoutInHours());
     storeInfo.setChunkingEnabled(store.isChunkingEnabled());
     storeInfo.setRmdChunkingEnabled(store.isRmdChunkingEnabled());
+    storeInfo.setMergedValueRmdColumnFamilyEnabled(store.isMergedValueRmdColumnFamilyEnabled());
     storeInfo.setClientDecompressionEnabled(store.getClientDecompressionEnabled());
     storeInfo.setCompressionStrategy(store.getCompressionStrategy());
     storeInfo.setCurrentVersion(store.getCurrentVersion());
@@ -185,6 +186,11 @@ public class StoreInfo {
    * Whether the replication metadata chunking is enabled for Active/Active replication enabled store.
    */
   private boolean rmdChunkingEnabled = false;
+
+  /**
+   * Whether value and RMD are stored in a single column family for A/A ingestion.
+   */
+  private boolean mergedValueRmdColumnFamilyEnabled = false;
 
   /**
    * Whether cache is enabled in Router.
@@ -584,6 +590,14 @@ public class StoreInfo {
 
   public void setRmdChunkingEnabled(boolean rmdChunkingEnabled) {
     this.rmdChunkingEnabled = rmdChunkingEnabled;
+  }
+
+  public boolean isMergedValueRmdColumnFamilyEnabled() {
+    return mergedValueRmdColumnFamilyEnabled;
+  }
+
+  public void setMergedValueRmdColumnFamilyEnabled(boolean mergedValueRmdColumnFamilyEnabled) {
+    this.mergedValueRmdColumnFamilyEnabled = mergedValueRmdColumnFamilyEnabled;
   }
 
   public boolean isSingleGetRouterCacheEnabled() {

--- a/internal/venice-common/src/main/java/com/linkedin/venice/meta/SystemStore.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/meta/SystemStore.java
@@ -343,6 +343,16 @@ public class SystemStore extends AbstractStore {
   }
 
   @Override
+  public boolean isMergedValueRmdColumnFamilyEnabled() {
+    return zkSharedStore.isMergedValueRmdColumnFamilyEnabled();
+  }
+
+  @Override
+  public void setMergedValueRmdColumnFamilyEnabled(boolean mergedValueRmdColumnFamilyEnabled) {
+    throwUnsupportedOperationException("setMergedValueRmdColumnFamilyEnabled");
+  }
+
+  @Override
   public int getBatchGetLimit() {
     return zkSharedStore.getBatchGetLimit();
   }

--- a/internal/venice-common/src/main/java/com/linkedin/venice/meta/Version.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/meta/Version.java
@@ -185,6 +185,10 @@ public interface Version extends Comparable<Version>, DataModelBackedStructure<S
 
   void setRmdChunkingEnabled(boolean rmdChunkingEnabled);
 
+  boolean isMergedValueRmdColumnFamilyEnabled();
+
+  void setMergedValueRmdColumnFamilyEnabled(boolean mergedValueRmdColumnFamilyEnabled);
+
   String getStoreName();
 
   String getPushJobId();

--- a/internal/venice-common/src/main/java/com/linkedin/venice/meta/VersionImpl.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/meta/VersionImpl.java
@@ -176,6 +176,16 @@ public class VersionImpl implements Version {
   }
 
   @Override
+  public boolean isMergedValueRmdColumnFamilyEnabled() {
+    return this.storeVersion.mergedValueRmdColumnFamilyEnabled;
+  }
+
+  @Override
+  public void setMergedValueRmdColumnFamilyEnabled(boolean mergedValueRmdColumnFamilyEnabled) {
+    this.storeVersion.mergedValueRmdColumnFamilyEnabled = mergedValueRmdColumnFamilyEnabled;
+  }
+
+  @Override
   public final String getStoreName() {
     return this.storeVersion.storeName.toString();
   }
@@ -594,6 +604,7 @@ public class VersionImpl implements Version {
     clonedVersion.setCompressionStrategy(getCompressionStrategy());
     clonedVersion.setChunkingEnabled(isChunkingEnabled());
     clonedVersion.setRmdChunkingEnabled(isRmdChunkingEnabled());
+    clonedVersion.setMergedValueRmdColumnFamilyEnabled(isMergedValueRmdColumnFamilyEnabled());
     clonedVersion.setPushType(getPushType());
     clonedVersion.setNativeReplicationEnabled(isNativeReplicationEnabled());
     clonedVersion.setPushStreamSourceAddress(getPushStreamSourceAddress());

--- a/internal/venice-common/src/main/java/com/linkedin/venice/meta/ZKStore.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/meta/ZKStore.java
@@ -202,6 +202,7 @@ public class ZKStore extends AbstractStore implements DataModelBackedStructure<S
     setClientDecompressionEnabled(store.getClientDecompressionEnabled());
     setChunkingEnabled(store.isChunkingEnabled());
     setRmdChunkingEnabled(store.isRmdChunkingEnabled());
+    setMergedValueRmdColumnFamilyEnabled(store.isMergedValueRmdColumnFamilyEnabled());
     setBatchGetLimit(store.getBatchGetLimit());
     setNumVersionsToPreserve(store.getNumVersionsToPreserve());
     setIncrementalPushEnabled(store.isIncrementalPushEnabled());
@@ -595,6 +596,16 @@ public class ZKStore extends AbstractStore implements DataModelBackedStructure<S
   @Override
   public void setRmdChunkingEnabled(boolean rmdChunkingEnabled) {
     this.storeProperties.rmdChunkingEnabled = rmdChunkingEnabled;
+  }
+
+  @Override
+  public boolean isMergedValueRmdColumnFamilyEnabled() {
+    return this.storeProperties.mergedValueRmdColumnFamilyEnabled;
+  }
+
+  @Override
+  public void setMergedValueRmdColumnFamilyEnabled(boolean mergedValueRmdColumnFamilyEnabled) {
+    this.storeProperties.mergedValueRmdColumnFamilyEnabled = mergedValueRmdColumnFamilyEnabled;
   }
 
   @Override

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/PartialUpdateTest.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/PartialUpdateTest.java
@@ -53,6 +53,7 @@ import com.linkedin.venice.kafka.protocol.KafkaMessageEnvelope;
 import com.linkedin.venice.kafka.protocol.enums.MessageType;
 import com.linkedin.venice.meta.ReadOnlySchemaRepository;
 import com.linkedin.venice.meta.Store;
+import com.linkedin.venice.meta.StoreInfo;
 import com.linkedin.venice.meta.Version;
 import com.linkedin.venice.pubsub.PubSubConsumerAdapterContext;
 import com.linkedin.venice.pubsub.PubSubTopicPartitionImpl;
@@ -941,6 +942,117 @@ public class PartialUpdateTest extends AbstractMultiRegionTest {
             chunkDeleteCount >= m1ChunkCount,
             "Expected chunk DELETE count (" + chunkDeleteCount + ") to be at least M_prev chunk count (" + m1ChunkCount
                 + "). The winning record in the batch should delete old chunks even when preceded by an ignored record.");
+      });
+    }
+  }
+
+  /**
+   * This integration test verifies that in A/A + partial update enabled store with merged value-RMD column family,
+   * batch push followed by streaming partial updates produces correct results. The merged CF stores both value and
+   * RMD in a single RocksDB column family, reducing read amplification during A/A ingestion.
+   */
+  @Test(timeOut = TEST_TIMEOUT_MS * 3)
+  public void testPartialUpdateWithMergedValueRmdColumnFamily() throws IOException {
+    final String storeName = Utils.getUniqueString("mergedCF");
+    String parentControllerUrl = getParentControllerUrl();
+    File inputDir = getTempDataDirectory();
+    Schema recordSchema = writeSimpleAvroFileWithStringToNameRecordV1Schema(inputDir);
+    String keySchemaStr = recordSchema.getField(DEFAULT_KEY_FIELD_PROP).schema().toString();
+    String valueSchemaStr = recordSchema.getField(DEFAULT_VALUE_FIELD_PROP).schema().toString();
+    String inputDirPath = "file://" + inputDir.getAbsolutePath();
+    Properties vpjProperties =
+        IntegrationTestPushUtils.defaultVPJProps(multiRegionMultiClusterWrapper, inputDirPath, storeName);
+
+    Schema valueSchema = AvroCompatibilityHelper.parse(valueSchemaStr);
+    Schema writeComputeSchema = WriteComputeSchemaConverter.getInstance().convertFromValueRecordSchema(valueSchema);
+    Schema rmdSchema = RmdSchemaGenerator.generateMetadataSchema(valueSchema);
+
+    ReadOnlySchemaRepository schemaRepo = mock(ReadOnlySchemaRepository.class);
+    when(schemaRepo.getReplicationMetadataSchema(storeName, 1, 1)).thenReturn(new RmdSchemaEntry(1, 1, rmdSchema));
+    when(schemaRepo.getValueSchema(storeName, 1)).thenReturn(new SchemaEntry(1, valueSchema));
+    StringAnnotatedStoreSchemaCache stringAnnotatedStoreSchemaCache =
+        new StringAnnotatedStoreSchemaCache(storeName, schemaRepo);
+    RmdSerDe rmdSerDe = new RmdSerDe(stringAnnotatedStoreSchemaCache, 1);
+
+    VeniceClusterWrapper veniceClusterWrapper = childDatacenters.get(0).getClusters().get(CLUSTER_NAME);
+
+    try (ControllerClient parentControllerClient = new ControllerClient(CLUSTER_NAME, parentControllerUrl)) {
+      assertCommand(
+          parentControllerClient.createNewStore(storeName, "test_owner", keySchemaStr, valueSchema.toString()));
+      UpdateStoreQueryParams updateStoreParams =
+          new UpdateStoreQueryParams().setStorageQuotaInByte(Store.UNLIMITED_STORAGE_QUOTA)
+              .setPartitionCount(1)
+              .setCompressionStrategy(CompressionStrategy.NO_OP)
+              .setWriteComputationEnabled(true)
+              .setActiveActiveReplicationEnabled(true)
+              .setChunkingEnabled(true)
+              .setRmdChunkingEnabled(true)
+              .setMergedValueRmdColumnFamilyEnabled(true)
+              .setHybridRewindSeconds(10L)
+              .setHybridOffsetLagThreshold(2L);
+      ControllerResponse updateStoreResponse =
+          parentControllerClient.retryableRequest(5, c -> c.updateStore(storeName, updateStoreParams));
+      assertFalse(updateStoreResponse.isError(), "Update store got error: " + updateStoreResponse.getError());
+
+      // Verify the store-level config was set
+      StoreInfo storeInfo = parentControllerClient.getStore(storeName).getStore();
+      assertTrue(storeInfo.isMergedValueRmdColumnFamilyEnabled());
+
+      // VPJ push
+      String childControllerUrl = childDatacenters.get(0).getRandomController().getControllerUrl();
+      try (ControllerClient childControllerClient = new ControllerClient(CLUSTER_NAME, childControllerUrl)) {
+        IntegrationTestPushUtils.runVPJ(vpjProperties, 1, childControllerClient);
+      }
+      veniceClusterWrapper.waitVersion(storeName, 1);
+
+      // Verify the version-level config was propagated
+      storeInfo = parentControllerClient.getStore(storeName).getStore();
+      assertTrue(storeInfo.getVersion(1).get().isMergedValueRmdColumnFamilyEnabled());
+
+      // Produce partial updates on batch pushed keys
+      try (VeniceSystemProducer veniceProducer =
+          getSamzaProducer(veniceClusterWrapper, storeName, Version.PushType.STREAM)) {
+        for (int i = 1; i < 100; i++) {
+          GenericRecord partialUpdateRecord =
+              new UpdateBuilderImpl(writeComputeSchema).setNewFieldValue("firstName", "merged_name_" + i).build();
+          sendStreamingRecord(veniceProducer, storeName, String.valueOf(i), partialUpdateRecord);
+        }
+      }
+
+      // Verify that partial updates are applied correctly via client reads
+      try (AvroGenericStoreClient<Object, Object> storeReader = ClientFactory.getAndStartGenericAvroClient(
+          ClientConfig.defaultGenericClientConfig(storeName).setVeniceURL(veniceClusterWrapper.getRandomRouterURL()))) {
+        TestUtils.waitForNonDeterministicAssertion(30, TimeUnit.SECONDS, true, () -> {
+          try {
+            for (int i = 1; i < 100; i++) {
+              String key = String.valueOf(i);
+              GenericRecord value = readValue(storeReader, key);
+              assertNotNull(value, "Key " + key + " should not be missing!");
+              assertEquals(value.get("firstName").toString(), "merged_name_" + key);
+              assertEquals(value.get("lastName").toString(), "last_name_" + key);
+            }
+          } catch (Exception e) {
+            throw new VeniceException(e);
+          }
+        });
+      }
+
+      // Validate RMD data is correctly stored and retrievable from the merged column family.
+      String kafkaTopic_v1 = Version.composeKafkaTopic(storeName, 1);
+      TestUtils.waitForNonDeterministicAssertion(30, TimeUnit.SECONDS, true, () -> {
+        validateRmdData(
+            multiRegionMultiClusterWrapper,
+            CLUSTER_NAME,
+            rmdSerDe,
+            kafkaTopic_v1,
+            "1",
+            rmdWithValueSchemaId -> {
+              assertNotNull(rmdWithValueSchemaId.getRmdRecord());
+              assertEquals(rmdWithValueSchemaId.getValueSchemaId(), 1);
+              GenericRecord timestampRecord =
+                  (GenericRecord) rmdWithValueSchemaId.getRmdRecord().get(TIMESTAMP_FIELD_NAME);
+              assertNotNull(timestampRecord, "RMD timestamp record should not be null for merged CF");
+            });
       });
     }
   }

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceHelixAdmin.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceHelixAdmin.java
@@ -5372,6 +5372,16 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
     });
   }
 
+  public void setMergedValueRmdColumnFamilyEnabled(
+      String clusterName,
+      String storeName,
+      boolean mergedValueRmdColumnFamilyEnabled) {
+    storeMetadataUpdate(clusterName, storeName, (store, resources) -> {
+      store.setMergedValueRmdColumnFamilyEnabled(mergedValueRmdColumnFamilyEnabled);
+      return store;
+    });
+  }
+
   public void setIncrementalPushEnabled(String clusterName, String storeName, boolean incrementalPushEnabled) {
     storeMetadataUpdate(clusterName, storeName, (store, resources) -> {
       VeniceControllerClusterConfig config = getHelixVeniceClusterResources(clusterName).getConfig();

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/kafka/consumer/AdminExecutionTask.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/kafka/consumer/AdminExecutionTask.java
@@ -553,6 +553,7 @@ public class AdminExecutionTask implements Callable<Void> {
         .setClientDecompressionEnabled(message.clientDecompressionEnabled)
         .setChunkingEnabled(message.chunkingEnabled)
         .setRmdChunkingEnabled(message.rmdChunkingEnabled)
+        .setMergedValueRmdColumnFamilyEnabled(message.mergedValueRmdColumnFamilyEnabled)
         .setBatchGetLimit(message.batchGetLimit)
         .setNumVersionsToPreserve(message.numVersionsToPreserve)
         .setIncrementalPushEnabled(message.incrementalPushEnabled)

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/storeconfig/StoreConfigUpdater.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/storeconfig/StoreConfigUpdater.java
@@ -39,6 +39,7 @@ import static com.linkedin.venice.controllerapi.ControllerApiConstants.LATEST_SU
 import static com.linkedin.venice.controllerapi.ControllerApiConstants.MAX_COMPACTION_LAG_SECONDS;
 import static com.linkedin.venice.controllerapi.ControllerApiConstants.MAX_NEARLINE_RECORD_SIZE_BYTES;
 import static com.linkedin.venice.controllerapi.ControllerApiConstants.MAX_RECORD_SIZE_BYTES;
+import static com.linkedin.venice.controllerapi.ControllerApiConstants.MERGED_VALUE_RMD_COLUMN_FAMILY_ENABLED;
 import static com.linkedin.venice.controllerapi.ControllerApiConstants.MIGRATION_DUPLICATE_STORE;
 import static com.linkedin.venice.controllerapi.ControllerApiConstants.MIN_COMPACTION_LAG_SECONDS;
 import static com.linkedin.venice.controllerapi.ControllerApiConstants.NATIVE_REPLICATION_ENABLED;
@@ -251,6 +252,7 @@ public final class StoreConfigUpdater {
     Optional<Boolean> clientDecompressionEnabled = params.getClientDecompressionEnabled();
     Optional<Boolean> chunkingEnabled = params.getChunkingEnabled();
     Optional<Boolean> rmdChunkingEnabled = params.getRmdChunkingEnabled();
+    Optional<Boolean> mergedValueRmdColumnFamilyEnabled = params.getMergedValueRmdColumnFamilyEnabled();
     Optional<Integer> batchGetLimit = params.getBatchGetLimit();
     Optional<Integer> numVersionsToPreserve = params.getNumVersionsToPreserve();
     Optional<Boolean> incrementalPushEnabled = params.getIncrementalPushEnabled();
@@ -453,6 +455,10 @@ public final class StoreConfigUpdater {
 
       if (rmdChunkingEnabled.isPresent()) {
         admin.setRmdChunkingEnabled(clusterName, storeName, rmdChunkingEnabled.get());
+      }
+
+      if (mergedValueRmdColumnFamilyEnabled.isPresent()) {
+        admin.setMergedValueRmdColumnFamilyEnabled(clusterName, storeName, mergedValueRmdColumnFamilyEnabled.get());
       }
 
       if (batchGetLimit.isPresent()) {
@@ -881,6 +887,7 @@ public final class StoreConfigUpdater {
     Optional<Boolean> clientDecompressionEnabled = params.getClientDecompressionEnabled();
     Optional<Boolean> chunkingEnabled = params.getChunkingEnabled();
     Optional<Boolean> rmdChunkingEnabled = params.getRmdChunkingEnabled();
+    Optional<Boolean> mergedValueRmdColumnFamilyEnabled = params.getMergedValueRmdColumnFamilyEnabled();
     Optional<Integer> batchGetLimit = params.getBatchGetLimit();
     Optional<Integer> numVersionsToPreserve = params.getNumVersionsToPreserve();
     Optional<Boolean> incrementalPushEnabled = params.getIncrementalPushEnabled();
@@ -1403,6 +1410,18 @@ public final class StoreConfigUpdater {
         .checkAndMaybeApplyRmdChunkingConfigChange(admin, clusterName, storeName, rmdChunkingEnabled, setStore);
     if (rmdChunkingConfigUpdated) {
       updatedConfigsList.add(RMD_CHUNKING_ENABLED);
+    }
+
+    // Update merged value-RMD column family config (requires active-active replication to be enabled).
+    if (mergedValueRmdColumnFamilyEnabled.isPresent()) {
+      if (mergedValueRmdColumnFamilyEnabled.get() && !setStore.getActiveActiveReplicationEnabled()) {
+        throw new VeniceHttpException(
+            HttpStatus.SC_BAD_REQUEST,
+            "Merged value-RMD column family requires active-active replication to be enabled.",
+            ErrorType.BAD_REQUEST);
+      }
+      setStore.mergedValueRmdColumnFamilyEnabled = mergedValueRmdColumnFamilyEnabled.get();
+      updatedConfigsList.add(MERGED_VALUE_RMD_COLUMN_FAMILY_ENABLED);
     }
 
     // Validate Amplification Factor config based on latest A/A and partial update status.

--- a/services/venice-controller/src/test/java/com/linkedin/venice/controller/StoreConfigUpdaterTest.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/controller/StoreConfigUpdaterTest.java
@@ -12,6 +12,7 @@ import static com.linkedin.venice.controllerapi.ControllerApiConstants.ENABLE_RE
 import static com.linkedin.venice.controllerapi.ControllerApiConstants.ENABLE_WRITES;
 import static com.linkedin.venice.controllerapi.ControllerApiConstants.HYBRID_STORE_DISK_QUOTA_ENABLED;
 import static com.linkedin.venice.controllerapi.ControllerApiConstants.LARGEST_USED_VERSION_NUMBER;
+import static com.linkedin.venice.controllerapi.ControllerApiConstants.MERGED_VALUE_RMD_COLUMN_FAMILY_ENABLED;
 import static com.linkedin.venice.controllerapi.ControllerApiConstants.MIGRATION_DUPLICATE_STORE;
 import static com.linkedin.venice.controllerapi.ControllerApiConstants.NATIVE_REPLICATION_ENABLED;
 import static com.linkedin.venice.controllerapi.ControllerApiConstants.NATIVE_REPLICATION_SOURCE_FABRIC;
@@ -40,6 +41,7 @@ import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertSame;
 import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.expectThrows;
 import static org.testng.Assert.fail;
 
 import com.linkedin.venice.compression.CompressionStrategy;
@@ -504,6 +506,73 @@ public class StoreConfigUpdaterTest extends AbstractTestVeniceParentHelixAdmin {
           "Child setter verification failed for " + failures.size() + " field(s):\n  - "
               + String.join("\n  - ", failures));
     }
+  }
+
+  /**
+   * The merged value-RMD column family is not a trivial field: enabling it on the parent requires active-active
+   * replication, so it is driven explicitly here instead of through {@link #TRIVIAL_FIELDS}.
+   * <ul>
+   *   <li>Parent: enabling it with active-active replication on succeeds and records the config key; enabling it
+   *       with active-active replication off is rejected; disabling it is always allowed.</li>
+   *   <li>Child: the value is applied through the matching {@code VeniceHelixAdmin} setter.</li>
+   * </ul>
+   */
+  @Test
+  public void testMergedValueRmdColumnFamily_ParentRequiresActiveActiveAndChildAppliesSetter() {
+    // Parent: enabling with active-active replication enabled succeeds and records the config.
+    String aaStoreName = Utils.getUniqueString("merged-cf-aa");
+    Store aaStore = TestUtils.createTestStore(aaStoreName, "test-owner", System.currentTimeMillis());
+    aaStore.setActiveActiveReplicationEnabled(true);
+    doReturn(aaStore).when(internalAdmin).getStore(clusterName, aaStoreName);
+    parentAdmin.initStorageCluster(clusterName);
+
+    parentAdmin
+        .updateStore(clusterName, aaStoreName, new UpdateStoreQueryParams().setMergedValueRmdColumnFamilyEnabled(true));
+    UpdateStore enabledMsg = captureLastUpdateStore();
+    assertTrue(enabledMsg.mergedValueRmdColumnFamilyEnabled, "merged value-RMD CF should be enabled in the message");
+    assertTrue(
+        updatedConfigKeys(enabledMsg).contains(MERGED_VALUE_RMD_COLUMN_FAMILY_ENABLED),
+        "updatedConfigsList should contain the merged value-RMD CF key");
+
+    // Parent: disabling it is allowed regardless of active-active replication (short-circuits the validation).
+    String disableStoreName = Utils.getUniqueString("merged-cf-disable");
+    Store disableStore = TestUtils.createTestStore(disableStoreName, "test-owner", System.currentTimeMillis());
+    doReturn(disableStore).when(internalAdmin).getStore(clusterName, disableStoreName);
+    parentAdmin.updateStore(
+        clusterName,
+        disableStoreName,
+        new UpdateStoreQueryParams().setMergedValueRmdColumnFamilyEnabled(false));
+    UpdateStore disabledMsg = captureLastUpdateStore();
+    assertFalse(disabledMsg.mergedValueRmdColumnFamilyEnabled, "merged value-RMD CF should be disabled in the message");
+    assertTrue(updatedConfigKeys(disabledMsg).contains(MERGED_VALUE_RMD_COLUMN_FAMILY_ENABLED));
+
+    // Parent: enabling without active-active replication is rejected.
+    String noAaStoreName = Utils.getUniqueString("merged-cf-no-aa");
+    Store noAaStore = TestUtils.createTestStore(noAaStoreName, "test-owner", System.currentTimeMillis());
+    doReturn(noAaStore).when(internalAdmin).getStore(clusterName, noAaStoreName);
+    VeniceException e = expectThrows(
+        VeniceException.class,
+        () -> parentAdmin.updateStore(
+            clusterName,
+            noAaStoreName,
+            new UpdateStoreQueryParams().setMergedValueRmdColumnFamilyEnabled(true)));
+    assertTrue(
+        e.getMessage().contains("active-active replication"),
+        "rejection should explain the active-active requirement, got: " + e.getMessage());
+
+    // Child: the value is applied through the matching VeniceHelixAdmin setter.
+    String childStoreName = Utils.getUniqueString("merged-cf-child");
+    VeniceHelixAdmin childAdmin = newChildAdminMock(childStoreName);
+    StoreConfigUpdater.applyOnChild(
+        childAdmin,
+        clusterName,
+        childStoreName,
+        new UpdateStoreQueryParams().setMergedValueRmdColumnFamilyEnabled(true));
+    verify(childAdmin).setMergedValueRmdColumnFamilyEnabled(clusterName, childStoreName, true);
+  }
+
+  private static Set<String> updatedConfigKeys(UpdateStore msg) {
+    return msg.updatedConfigsList.stream().map(CharSequence::toString).collect(Collectors.toSet());
   }
 
   /**


### PR DESCRIPTION
## Problem Statement

During active-active (A/A) partial-update ingestion, each message triggers **two separate RocksDB lookups** — one for the value (DEFAULT column family) and one for the replication metadata (RMD column family) — doubling read amplification on the hot ingestion path.

## Solution

Introduce a version-level config `mergedValueRmdColumnFamilyEnabled` (default `false`) that stores the value and RMD together in a **single** RocksDB column family, so A/A conflict resolution can read both in one lookup.

Record layout: `[valueSchemaId 4B][valueLen 4B][valueBytes][rmdBytes]`.

> **The protocol/schema is already on `main`.** The `mergedValueRmdColumnFamilyEnabled` Avro field was staged separately in #2703 and is now carried to **StoreMetaValue v45** and **AdminOperation v100**. **This PR therefore contains only the implementation — no `.avsc` / `AvroProtocolDefinition` / `build.gradle` changes.**

Implementation highlights:
- **`MergedValueRmdRocksDBStoragePartition`** — single-CF partition built on the parent's lifecycle-safe RocksDB accessors. All merged writes route through one `super.put()` path so deferred-write (batch) mode does not recurse through the `put()` overrides. Batch records are stored in merged form; the push-time SST checksum is skipped for this partition because the persisted bytes intentionally differ from the producer's original value bytes (the same reason the separate RMD column family is excluded from checksum verification).
- **Single-read optimization** — during A/A conflict resolution the value and RMD top-level reads are served from one merged lookup via `MergedValueRmdReadOptimizingStorageEngine` (a `DelegatingStorageEngine`); chunk reads pass through unchanged, so chunking/compression logic is reused as-is.
- **Config propagation** — `UpdateStoreQueryParams` → `StoreConfigUpdater` (child + parent paths) → `AdminExecutionTask` → `Store`/`Version` → `StorageService` → `RocksDBStorageEngine`. Enabling the merged CF requires active-active replication, validated in the parent controller.
- **`StorageService`** creates the merged partition only when both active-active replication and the merged CF are enabled for the version.

**Config:** `mergedValueRmdColumnFamilyEnabled` — default `false` (backward compatible). Enable per-store via the controller API; the next push writes the merged format. Existing versions stay in separate CFs until retired; disabling reverts on the next version.

### Code changes

- [x] Added new code behind **a config**: `mergedValueRmdColumnFamilyEnabled` (default `false`).
- [x] Introduced new **log lines**: two `LOGGER.warn` in `StorageService`'s flag-resolution fallback (store / version absent).
  - [x] These are cold error-handling paths (not the per-record hot path), so no rate limiting is needed.

### **Concurrency-Specific Checks**

- [x] Code has **no race conditions** or **thread safety issues** — partition writes are `synchronized`; the read-optimizing engine is created per record and used by a single ingestion thread.
- [x] Proper **synchronization mechanisms** are used — reuses the parent partition's lifecycle-safe accessors (`withSynchronizedDatabase*` / `withOpenDatabase`) and `synchronized` write methods.
- [x] No **blocking calls** inside critical sections were introduced.
- [x] No new shared mutable collections were introduced.
- [x] Exception handling validated in the ingestion path (writes throw `VeniceException` on closed / read-only DB).

## How was this PR tested?

- [x] New unit tests added: `MergedValueRmdRocksDBStoragePartitionTest` (merge/split round-trip, tombstone, corrupt-record bounds), `MergedValueRmdReadOptimizingStorageEngineTest` (one merged lookup serves both value + RMD; chunk reads delegate), `StoreConfigUpdaterTest` (merged CF requires active-active validation).
- [x] New integration test added: `PartialUpdateTest.testPartialUpdateWithMergedValueRmdColumnFamily` — A/A batch push + streaming partial updates with the merged CF enabled; verifies values and RMD read back correctly.
- [x] Modified or extended existing tests: `StorageServiceTest`, `ActiveActiveStoreIngestionTaskTest`.
- [x] Verified backward compatibility — default `false`; non-merged stores take the unchanged code path.

## Does this PR introduce any user-facing or breaking changes?

- [x] No. New opt-in store config that defaults to `false`; no behavior change unless explicitly enabled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
