### PR TITLE
[CI] Enforce 10-minute max duration per E2E test class

### DIFF
--- a/.github/actions/integration-test-run/action.yml
+++ b/.github/actions/integration-test-run/action.yml
@@ -17,7 +17,7 @@ runs:
       shell: bash
       run: |
         mkdir ${{ github.job }}-artifacts
-        find . -path "**/build/reports/*" -or -path "**/build/test-results/*" > artifacts.list
+        find . -path "**/build/reports/*" -or -path "**/build/test-results/*" -or -path "**/build/test-watchdog-timeouts/*" > artifacts.list
         find . -type f \( -name 'core.*' -o -name 'hs_err_pid*.log' \) -exec xz -9 {} \; -exec echo "{}.xz" \; >> artifacts.list
         rsync -R --files-from=artifacts.list . ${{ github.job }}-artifacts
         tar -zcvf ${{ github.job }}-jdk17-logs.tar.gz ${{ github.job }}-artifacts

--- a/.github/rawWorkflows/gh-ci-completion-flow.txt
+++ b/.github/rawWorkflows/gh-ci-completion-flow.txt
@@ -10,6 +10,20 @@
     timeout-minutes: $TimeOut
     if: ${{ cancelled() || contains(needs.*.result, 'cancelled') || contains(needs.*.result, 'failure') }}
     steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+      - name: Download All Shard Artifacts
+        uses: actions/download-artifact@v6
+        with:
+          path: all-artifacts
+      - name: Check Test Class Duration Limits
+        shell: bash
+        run: |
+          for tarball in all-artifacts/*/IntegrationTests_*-jdk17-logs.tar.gz; do
+            [ -f "$tarball" ] && tar -xzf "$tarball" -C all-artifacts/ 2>/dev/null || true
+          done
+          python3 scripts/ci/check_test_duration.py all-artifacts || true
       - name: NoGood
         shell: bash
         run: |

--- a/.github/workflows/VeniceCI-E2ETests.yml
+++ b/.github/workflows/VeniceCI-E2ETests.yml
@@ -1527,6 +1527,20 @@ jobs:
     timeout-minutes: 20
     if: ${{ cancelled() || contains(needs.*.result, 'cancelled') || contains(needs.*.result, 'failure') }}
     steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+      - name: Download All Shard Artifacts
+        uses: actions/download-artifact@v6
+        with:
+          path: all-artifacts
+      - name: Check Test Class Duration Limits
+        shell: bash
+        run: |
+          for tarball in all-artifacts/*/IntegrationTests_*-jdk17-logs.tar.gz; do
+            [ -f "$tarball" ] && tar -xzf "$tarball" -C all-artifacts/ 2>/dev/null || true
+          done
+          python3 scripts/ci/check_test_duration.py all-artifacts || true
       - name: NoGood
         shell: bash
         run: |

--- a/internal/venice-test-common/build.gradle
+++ b/internal/venice-test-common/build.gradle
@@ -139,9 +139,40 @@ def integrationTestConfigs = {
   minHeapSize = '4g'
   maxHeapSize = '8g'
 
+  // Per-class watchdog timeout: enabled in CI (10 minutes), disabled locally by default.
+  // Set -Dvenice.test.class.timeout.ms=600000 to enable locally.
+  def defaultTimeout = System.getenv('CI') ? '600000' : '0'
+  systemProperty 'venice.test.class.timeout.ms', System.getProperty('venice.test.class.timeout.ms', defaultTimeout)
+  systemProperty 'venice.test.buildDir', buildDir.absolutePath
+
   // Disable JaCoCo for integration tests
   jacoco {
     enabled = false
+  }
+}
+
+gradle.buildFinished {
+  def markerDir = new File(buildDir, "test-watchdog-timeouts")
+  if (markerDir.exists()) {
+    def markers = markerDir.listFiles()?.findAll { it.name.endsWith('.timeout') }
+    if (markers) {
+      println "\n" + "=" * 80
+      println "TEST CLASS TIMEOUT VIOLATIONS"
+      println "=" * 80
+      markers.sort().each { marker ->
+        def parts = marker.text.trim().split('\\|')
+        if (parts.length == 3) {
+          def elapsed = parts[1] as int
+          def limit = parts[2] as int
+          println "  ${parts[0]}: killed after ${elapsed.intdiv(60)}m${elapsed % 60}s (limit: ${limit.intdiv(60)}m${limit % 60}s)"
+        }
+      }
+      println "\nSplit slow test classes or optimize test methods."
+      println "Set -Dvenice.test.class.timeout.ms=0 to disable locally."
+      println "=" * 80 + "\n"
+    }
+    // Clean up markers so stale violations are not reported on subsequent runs
+    markerDir.deleteDir()
   }
 }
 

--- a/internal/venice-test-common/build.gradle
+++ b/internal/venice-test-common/build.gradle
@@ -139,9 +139,10 @@ def integrationTestConfigs = {
   minHeapSize = '4g'
   maxHeapSize = '8g'
 
-  // Per-class watchdog timeout: enabled in CI (10 minutes), disabled locally by default.
-  // Set -Dvenice.test.class.timeout.ms=600000 to enable locally.
-  def defaultTimeout = System.getenv('CI') ? '600000' : '0'
+  // Per-class watchdog timeout: kills the JVM if a test class exceeds this limit.
+  // CI: 6 min (360s shard target). Local: 5 min (tighter feedback loop).
+  // Set -Dvenice.test.class.timeout.ms=0 to disable.
+  def defaultTimeout = System.getenv('CI') ? '360000' : '300000'
   systemProperty 'venice.test.class.timeout.ms', System.getProperty('venice.test.class.timeout.ms', defaultTimeout)
   systemProperty 'venice.test.buildDir', buildDir.absolutePath
 
@@ -168,7 +169,7 @@ gradle.buildFinished {
         }
       }
       println "\nSplit slow test classes or optimize test methods."
-      println "Set -Dvenice.test.class.timeout.ms=0 to disable locally."
+      println "Set -Dvenice.test.class.timeout.ms=0 to disable the watchdog."
       println "=" * 80 + "\n"
     }
     // Clean up markers so stale violations are not reported on subsequent runs

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestPushJobWithNativeReplication.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestPushJobWithNativeReplication.java
@@ -513,7 +513,7 @@ public class TestPushJobWithNativeReplication extends AbstractMultiRegionTest {
                   .getClusters()
                   .get(clusterName)
                   .useControllerClient(
-                      dc1Client -> TestUtils.waitForNonDeterministicAssertion(30, TimeUnit.SECONDS, true, () -> {
+                      dc1Client -> TestUtils.waitForNonDeterministicAssertion(60, TimeUnit.SECONDS, true, () -> {
                         // verify the update store command has taken effect before starting the push job.
                         StoreInfo store = dc0Client.getStore(storeName).getStore();
                         Assert.assertNotNull(store);

--- a/internal/venice-test-common/src/main/java/com/linkedin/venice/testng/VeniceSuiteListener.java
+++ b/internal/venice-test-common/src/main/java/com/linkedin/venice/testng/VeniceSuiteListener.java
@@ -1,23 +1,112 @@
 package com.linkedin.venice.testng;
 
 import com.linkedin.venice.utils.TestUtils;
+import java.io.File;
+import java.io.FileWriter;
+import java.util.Collection;
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.core.config.Configurator;
 import org.testng.ISuite;
 import org.testng.ISuiteListener;
+import org.testng.ITestNGMethod;
 
 
 public class VeniceSuiteListener implements ISuiteListener {
+  private static final String TIMEOUT_PROPERTY = "venice.test.class.timeout.ms";
+  private volatile Thread watchdogThread;
+
   @Override
   public void onStart(ISuite suite) {
     System.out.println("Start suite " + suite.getName());
     TestUtils.preventSystemExit();
     Configurator.setAllLevels("com.linkedin.d2", Level.OFF);
+    startWatchdog(getTestClassName(suite));
   }
 
   @Override
   public void onFinish(ISuite suite) {
+    stopWatchdog();
     System.out.println("Finish suite " + suite.getName());
     TestUtils.restoreSystemExit();
+  }
+
+  private void startWatchdog(String suiteName) {
+    long timeoutMs;
+    try {
+      timeoutMs = Long.parseLong(System.getProperty(TIMEOUT_PROPERTY, "0"));
+    } catch (NumberFormatException e) {
+      System.err.println(
+          "Invalid value for " + TIMEOUT_PROPERTY + "='" + System.getProperty(TIMEOUT_PROPERTY)
+              + "'. Expected numeric milliseconds. Watchdog disabled.");
+      return;
+    }
+    if (timeoutMs <= 0) {
+      return;
+    }
+    long startTime = System.currentTimeMillis();
+    Thread thread = new Thread(() -> {
+      try {
+        Thread.sleep(timeoutMs);
+      } catch (InterruptedException e) {
+        // Test finished before timeout — normal exit
+        return;
+      }
+      long elapsed = System.currentTimeMillis() - startTime;
+      String msg = String.format(
+          "TEST CLASS TIMEOUT: %s exceeded the %d second limit (ran for %d seconds).%n"
+              + "Split this test class into smaller classes or optimize the slow test methods.%n"
+              + "Set -D%s=0 to disable this check locally.",
+          suiteName,
+          timeoutMs / 1000,
+          elapsed / 1000,
+          TIMEOUT_PROPERTY);
+      System.err.println(msg);
+      System.err.flush();
+      writeTimeoutMarker(suiteName, timeoutMs / 1000, elapsed / 1000);
+      // Remove SecurityManager before halt — preventSystemExit() installs one that blocks non-zero exits
+      TestUtils.restoreSystemExit();
+      Runtime.getRuntime().halt(1);
+    }, "venice-test-watchdog-" + suiteName);
+    thread.setDaemon(true);
+    thread.start();
+    watchdogThread = thread;
+  }
+
+  private void stopWatchdog() {
+    Thread thread = watchdogThread;
+    if (thread != null) {
+      thread.interrupt();
+      watchdogThread = null;
+    }
+  }
+
+  /**
+   * Extract the test class name from the suite. TestNG names the suite "Gradle suite" by default,
+   * but the actual class name is available from the test methods.
+   */
+  private static String getTestClassName(ISuite suite) {
+    Collection<ITestNGMethod> methods = suite.getAllMethods();
+    if (methods != null && !methods.isEmpty()) {
+      return methods.iterator().next().getTestClass().getName();
+    }
+    return suite.getName();
+  }
+
+  private static File getMarkerDir() {
+    String buildDir = System.getProperty("venice.test.buildDir", "build");
+    return new File(buildDir, "test-watchdog-timeouts");
+  }
+
+  private static void writeTimeoutMarker(String suiteName, long limitSeconds, long elapsedSeconds) {
+    try {
+      File markerDir = getMarkerDir();
+      markerDir.mkdirs();
+      File marker = new File(markerDir, suiteName + ".timeout");
+      try (FileWriter fw = new FileWriter(marker)) {
+        fw.write(suiteName + "|" + elapsedSeconds + "|" + limitSeconds + "\n");
+      }
+    } catch (Exception e) {
+      // Best effort — don't let marker writing prevent the halt
+    }
   }
 }

--- a/scripts/ci/check_test_duration.py
+++ b/scripts/ci/check_test_duration.py
@@ -13,7 +13,7 @@ import os
 import sys
 import xml.etree.ElementTree as ET
 
-THRESHOLD_SECONDS = int(os.environ.get("TEST_DURATION_THRESHOLD_SECONDS", "600"))
+THRESHOLD_SECONDS = int(os.environ.get("TEST_DURATION_THRESHOLD_SECONDS", "360"))
 
 
 def main():

--- a/scripts/ci/check_test_duration.py
+++ b/scripts/ci/check_test_duration.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+"""Check that no E2E test class exceeds the duration limit.
+
+Reads watchdog marker files (written by VeniceSuiteListener when a test is
+killed) and JUnit XML reports (for tests that completed but were slow).
+
+Exit code 1 if any violations are found, 0 otherwise.
+Output is written to both stdout and $GITHUB_STEP_SUMMARY (if set).
+"""
+
+import glob
+import os
+import sys
+import xml.etree.ElementTree as ET
+
+THRESHOLD_SECONDS = int(os.environ.get("TEST_DURATION_THRESHOLD_SECONDS", "600"))
+
+
+def main():
+    search_root = sys.argv[1] if len(sys.argv) > 1 else "."
+    violations = []
+
+    # Check watchdog marker files (test was killed by the watchdog)
+    for f in sorted(glob.glob(os.path.join(search_root, "**/build/test-watchdog-timeouts/*.timeout"), recursive=True)):
+        with open(f) as fh:
+            parts = fh.read().strip().split("|")
+            if len(parts) == 3:
+                try:
+                    duration = float(parts[1])
+                except (ValueError, IndexError):
+                    print(f"Warning: malformed watchdog marker '{f}': {parts}", file=sys.stderr)
+                    violations.append((parts[0] if parts else f, 0.0, "invalid watchdog marker"))
+                    continue
+                violations.append((parts[0], duration, "killed by watchdog"))
+            else:
+                print(f"Warning: malformed watchdog marker '{f}': expected 3 fields, got {len(parts)}", file=sys.stderr)
+                violations.append((parts[0] if parts else f, 0.0, "invalid watchdog marker"))
+
+    # Check JUnit XML reports (test completed but exceeded the threshold)
+    for f in sorted(glob.glob(os.path.join(search_root, "**/build/test-results/integrationTest*/TEST-*.xml"), recursive=True)):
+        try:
+            root = ET.parse(f).getroot()
+            name = root.get("name", "")
+            time = float(root.get("time", "0"))
+            if time > THRESHOLD_SECONDS:
+                violations.append((name, time, "completed"))
+        except ET.ParseError as e:
+            print(f"Warning: failed to parse JUnit XML report '{f}': {e}", file=sys.stderr)
+            violations.append((f, 0.0, "junit report parse error"))
+
+    if not violations:
+        sys.exit(0)
+
+    lines = [
+        "## Test Class Duration Violations",
+        "",
+        "| Test Class | Duration | Status |",
+        "|------------|----------|--------|",
+    ]
+    for name, time, status in sorted(violations, key=lambda x: -x[1]):
+        mins = int(time // 60)
+        secs = int(time % 60)
+        lines.append(f"| {name} | {mins}m{secs}s | {status} |")
+    lines.append("")
+    lines.append(
+        f"**{len(violations)} test class(es) exceeded the "
+        f"{THRESHOLD_SECONDS // 60}-minute limit.** "
+        f"Split slow test classes or optimize test methods."
+    )
+
+    output = "\n".join(lines)
+    print(output)
+
+    # Write to GitHub Actions step summary if available
+    summary_file = os.environ.get("GITHUB_STEP_SUMMARY")
+    if summary_file:
+        with open(summary_file, "a") as f:
+            f.write(output + "\n")
+
+    sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
Add a JVM watchdog that force-kills E2E test classes exceeding the timeout, preventing slow tests from blowing up CI shard wall-clock times. Enabled everywhere with tighter local limits for faster feedback.

| Environment | Timeout | Rationale |
|-------------|---------|-----------|
| **Local** | 5 min | Tighter feedback — catch slow tests during development |
| **CI** | 6 min | 360s shard target + headroom for CI machine variance |

**Disable:** `-Dvenice.test.class.timeout.ms=0`

## How it works

Since `forkEvery=1`, each test class runs in its own JVM. `VeniceSuiteListener.onStart()` starts a daemon watchdog thread that:
1. Sleeps for the configured timeout
2. On timeout: writes a marker file, logs the violation, and calls `Runtime.halt(1)` to kill the JVM

### CI duration reporting
The `E2ETestsFailureAlert` completion job downloads all shard artifacts, then runs `check_test_duration.py` which:
- Reads watchdog marker files (tests killed by timeout)
- Reads JUnit XML reports (tests that completed but exceeded the threshold)
- Outputs a markdown table to `$GITHUB_STEP_SUMMARY`

### Local reporting
A Gradle `buildFinished` hook prints timeout violations to console output if any markers exist.

## Files changed

| File | Change |
|------|--------|
| `VeniceSuiteListener.java` | Watchdog daemon thread with marker file writing |
| `build.gradle` | System property `venice.test.class.timeout.ms` (CI=360000, local=300000) + `buildFinished` console reporting |
| `action.yml` | Include `test-watchdog-timeouts/` in CI artifacts |
| `gh-ci-completion-flow.txt` | Duration check step in completion job |
| `VeniceCI-E2ETests.yml` | Auto-regenerated |
| `scripts/ci/check_test_duration.py` | Aggregates watchdog markers + JUnit XML to report violations (threshold: 360s) |

## Test plan
- [ ] CI E2E shards pass (no test class currently exceeds 6 min)
- [ ] Verify "Check Test Class Duration Limits" step appears in CI completion job
- [ ] Locally verify watchdog fires: `./gradlew integrationTests_3 --no-daemon -DforkEvery=1 -DmaxParallelForks=1 -Dvenice.test.class.timeout.ms=5000`
- [ ] Locally verify disable flag: `-Dvenice.test.class.timeout.ms=0`