### PR TITLE
[admin-tool] Fix dump-admin-messages and improve UX

### DIFF
--- a/clients/venice-admin-tool/src/main/java/com/linkedin/venice/AdminTool.java
+++ b/clients/venice-admin-tool/src/main/java/com/linkedin/venice/AdminTool.java
@@ -1857,14 +1857,17 @@ public class AdminTool {
 
   private static void dumpAdminMessages(CommandLine cmd, PubSubClientsFactory pubSubClientsFactory) {
     ConsumerContext context = createConsumerContext(cmd);
-    PubSubPosition startingPosition = parsePositionFromArgs(cmd, context.getPositionDeserializer(), true);
-    LOGGER.info("Dump admin messages with starting position: {}", startingPosition);
+    PubSubPosition startingPosition = parsePositionFromArgs(cmd, context.getPositionDeserializer(), false);
+    if (startingPosition == null) {
+      startingPosition = PubSubSymbolicPosition.EARLIEST;
+    }
+    int messageCount = cmd.hasOption(Arg.MESSAGE_COUNT.first())
+        ? Integer.parseInt(cmd.getOptionValue(Arg.MESSAGE_COUNT.first()))
+        : Integer.MAX_VALUE;
+    LOGGER.info("Dump admin messages with starting position: {}, message count: {}", startingPosition, messageCount);
     try (PubSubConsumerAdapter consumer = getConsumer(pubSubClientsFactory, context)) {
-      DumpAdminMessages.dumpAdminMessages(
-          consumer,
-          getRequiredArgument(cmd, Arg.CLUSTER),
-          startingPosition,
-          Integer.parseInt(getRequiredArgument(cmd, Arg.MESSAGE_COUNT)));
+      DumpAdminMessages
+          .dumpAdminMessages(consumer, getRequiredArgument(cmd, Arg.CLUSTER), startingPosition, messageCount);
     }
   }
 
@@ -3763,6 +3766,12 @@ public class AdminTool {
     boolean hasOffset = cmd.hasOption(Arg.STARTING_OFFSET.first());
     boolean hasPosition = cmd.hasOption(Arg.STARTING_POSITION.first());
 
+    if (hasOffset && hasPosition) {
+      printErrAndExit(
+          Arg.STARTING_OFFSET.getArgName() + " and " + Arg.STARTING_POSITION.getArgName()
+              + " are mutually exclusive. Please specify only one.");
+    }
+
     if (required && !hasOffset && !hasPosition) {
       printErrAndExit(
           "At least one of " + Arg.STARTING_OFFSET.getArgName() + " or " + Arg.STARTING_POSITION.getArgName()
@@ -3774,7 +3783,13 @@ public class AdminTool {
     }
 
     if (hasOffset) {
-      return PubSubUtil.fromKafkaOffset(Long.parseLong(cmd.getOptionValue(Arg.STARTING_OFFSET.first())));
+      String offsetValue = cmd.getOptionValue(Arg.STARTING_OFFSET.first()).trim();
+      if ("earliest".equalsIgnoreCase(offsetValue)) {
+        return PubSubSymbolicPosition.EARLIEST;
+      } else if ("latest".equalsIgnoreCase(offsetValue)) {
+        return PubSubSymbolicPosition.LATEST;
+      }
+      return PubSubUtil.fromKafkaOffset(Long.parseLong(offsetValue));
     } else {
       return PubSubUtil
           .parsePositionWireFormat(cmd.getOptionValue(Arg.STARTING_POSITION.first()), pubSubPositionDeserializer);

--- a/clients/venice-admin-tool/src/main/java/com/linkedin/venice/Arg.java
+++ b/clients/venice-admin-tool/src/main/java/com/linkedin/venice/Arg.java
@@ -122,10 +122,12 @@ public enum Arg {
       "venice-client-ssl-config-file", "vcsc", true, "Configuration file for querying key in Venice client through SSL."
   ),
   STARTING_POSITION(
-      "starting_position", "sp", true,
-      "Starting <typeId:base64EncodedPositionWfBytes> when dumping admin messages, inclusive"
-  ), STARTING_OFFSET("starting_offset", "so", true, "Starting offset when dumping admin messages, inclusive"),
-  MESSAGE_COUNT("message_count", "mc", true, "Max message count when dumping admin messages"),
+      "starting_position", "sp", true, "Starting <typeId:base64EncodedPositionWfBytes> when dumping messages, inclusive"
+  ),
+  STARTING_OFFSET(
+      "starting_offset", "so", true,
+      "Starting offset when dumping messages, inclusive. Accepts a numeric offset, 'earliest', or 'latest'"
+  ), MESSAGE_COUNT("message_count", "mc", true, "Max message count when dumping messages"),
   PARENT_DIRECTORY(
       "parent_output_directory", "pod", true,
       "A directory where output can be dumped to.  If dumping a kafka topic, the output will be dumped under this directory."

--- a/clients/venice-admin-tool/src/main/java/com/linkedin/venice/Command.java
+++ b/clients/venice-admin-tool/src/main/java/com/linkedin/venice/Command.java
@@ -401,9 +401,9 @@ public enum Command {
       new Arg[] { KAFKA_OPERATION_TIMEOUT, KAFKA_CONSUMER_CONFIG_FILE }
   ),
   DUMP_ADMIN_MESSAGES(
-      "dump-admin-messages", "Dump admin messages",
-      new Arg[] { CLUSTER, KAFKA_BOOTSTRAP_SERVERS, MESSAGE_COUNT, KAFKA_CONSUMER_CONFIG_FILE },
-      new Arg[] { STARTING_OFFSET, STARTING_POSITION }
+      "dump-admin-messages", "Dump admin messages (defaults: earliest, all messages)",
+      new Arg[] { CLUSTER, KAFKA_BOOTSTRAP_SERVERS, KAFKA_CONSUMER_CONFIG_FILE },
+      new Arg[] { STARTING_OFFSET, STARTING_POSITION, MESSAGE_COUNT }
   ),
   DUMP_CONTROL_MESSAGES(
       "dump-control-messages", "Dump control messages in a partition",

--- a/clients/venice-admin-tool/src/main/java/com/linkedin/venice/DumpAdminMessages.java
+++ b/clients/venice-admin-tool/src/main/java/com/linkedin/venice/DumpAdminMessages.java
@@ -39,6 +39,18 @@ public class DumpAdminMessages {
   private static final Logger LOGGER = LogManager.getLogger(DumpAdminMessages.class);
 
   /**
+   * Max empty polls to tolerate during initial consumer warmup. Xinfra consumers need 2-3 seconds
+   * to connect to conductor, receive assignments, and seek before returning any records.
+   */
+  static final int INITIAL_EMPTY_POLL_RETRIES = 10;
+
+  /**
+   * Max empty polls to tolerate after data has been received, used to detect end-of-topic.
+   * Fewer retries needed since the consumer is already warmed up.
+   */
+  static final int END_OF_DATA_EMPTY_POLL_RETRIES = 3;
+
+  /**
    * Dumps admin messages from the admin topic for the given cluster.
    * Messages are logged as they are received instead of being buffered.
    *
@@ -61,14 +73,19 @@ public class DumpAdminMessages {
     consumer.subscribe(adminTopicPartition, startingPosition, true);
     AdminOperationSerializer deserializer = new AdminOperationSerializer();
     int curMsgCnt = 0;
+    int emptyPollRetries = INITIAL_EMPTY_POLL_RETRIES;
     DateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss z");
     dateFormat.setTimeZone(TimeZone.getTimeZone("UTC"));
     KafkaMessageEnvelope messageEnvelope = null;
     while (curMsgCnt < messageCnt) {
       Map<PubSubTopicPartition, List<DefaultPubSubMessage>> records = consumer.poll(1000); // 1 second
       if (records.isEmpty()) {
+        if (--emptyPollRetries > 0) {
+          continue;
+        }
         break;
       }
+      emptyPollRetries = END_OF_DATA_EMPTY_POLL_RETRIES;
       Iterator<DefaultPubSubMessage> recordsIterator = Utils.iterateOnMapOfLists(records);
       while (recordsIterator.hasNext()) {
         DefaultPubSubMessage record = recordsIterator.next();

--- a/clients/venice-admin-tool/src/test/java/com/linkedin/venice/TestAdminTool.java
+++ b/clients/venice-admin-tool/src/test/java/com/linkedin/venice/TestAdminTool.java
@@ -12,6 +12,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.expectThrows;
 
@@ -50,6 +51,7 @@ import com.linkedin.venice.metadata.response.VersionProperties;
 import com.linkedin.venice.pubsub.PubSubPositionDeserializer;
 import com.linkedin.venice.pubsub.PubSubPositionTypeRegistry;
 import com.linkedin.venice.pubsub.api.PubSubPosition;
+import com.linkedin.venice.pubsub.api.PubSubSymbolicPosition;
 import com.linkedin.venice.serialization.avro.AvroProtocolDefinition;
 import com.linkedin.venice.serializer.FastSerializerDeserializerFactory;
 import com.linkedin.venice.serializer.RecordSerializer;
@@ -610,5 +612,31 @@ public class TestAdminTool {
     when(emptyCmd.hasOption(Arg.STARTING_OFFSET.first())).thenReturn(false);
     when(emptyCmd.hasOption(Arg.STARTING_POSITION.first())).thenReturn(false);
     expectThrows(Exception.class, () -> AdminTool.parsePositionFromArgs(emptyCmd, deserializer, true));
+
+    // Test 5: Verify 'earliest' string maps to PubSubSymbolicPosition.EARLIEST
+    CommandLine earliestCmd = mock(CommandLine.class);
+    when(earliestCmd.hasOption(Arg.STARTING_OFFSET.first())).thenReturn(true);
+    when(earliestCmd.hasOption(Arg.STARTING_POSITION.first())).thenReturn(false);
+    when(earliestCmd.getOptionValue(Arg.STARTING_OFFSET.first())).thenReturn("earliest");
+    PubSubPosition earliestPos = AdminTool.parsePositionFromArgs(earliestCmd, deserializer, true);
+    assertEquals(earliestPos, PubSubSymbolicPosition.EARLIEST, "'earliest' should map to EARLIEST");
+
+    // Test 6: Verify 'latest' string maps to PubSubSymbolicPosition.LATEST
+    CommandLine latestCmd = mock(CommandLine.class);
+    when(latestCmd.hasOption(Arg.STARTING_OFFSET.first())).thenReturn(true);
+    when(latestCmd.hasOption(Arg.STARTING_POSITION.first())).thenReturn(false);
+    when(latestCmd.getOptionValue(Arg.STARTING_OFFSET.first())).thenReturn("LATEST");
+    PubSubPosition latestPos = AdminTool.parsePositionFromArgs(latestCmd, deserializer, true);
+    assertEquals(latestPos, PubSubSymbolicPosition.LATEST, "'LATEST' should map to LATEST (case-insensitive)");
+
+    // Test 7: Verify null returned when neither arg provided and not required
+    PubSubPosition nullPos = AdminTool.parsePositionFromArgs(emptyCmd, deserializer, false);
+    assertNull(nullPos, "Should return null when neither arg provided and not required");
+
+    // Test 8: Verify error when both offset and position are provided
+    CommandLine bothCmd = mock(CommandLine.class);
+    when(bothCmd.hasOption(Arg.STARTING_OFFSET.first())).thenReturn(true);
+    when(bothCmd.hasOption(Arg.STARTING_POSITION.first())).thenReturn(true);
+    expectThrows(Exception.class, () -> AdminTool.parsePositionFromArgs(bothCmd, deserializer, true));
   }
 }

--- a/clients/venice-admin-tool/src/test/java/com/linkedin/venice/TestAdminToolConsumption.java
+++ b/clients/venice-admin-tool/src/test/java/com/linkedin/venice/TestAdminToolConsumption.java
@@ -126,6 +126,40 @@ public class TestAdminToolConsumption {
   }
 
   @Test
+  void testDumpAdminMessagesRetriesOnInitialEmptyPolls() {
+    int assignedPartition = 0;
+    String topic = Utils.composeRealTimeTopic(STORE_NAME);
+    PubSubTopicPartition pubSubTopicPartition =
+        new PubSubTopicPartitionImpl(pubSubTopicRepository.getTopic(topic), assignedPartition);
+    List<DefaultPubSubMessage> pubSubMessageList = prepareAdminPubSubMessageList(STORE_NAME, pubSubTopicPartition, 5);
+    Map<PubSubTopicPartition, List<DefaultPubSubMessage>> messagesMap = new HashMap<>();
+    messagesMap.put(pubSubTopicPartition, pubSubMessageList);
+
+    // Simulate Xinfra consumer warmup: first 3 polls return empty, then data arrives
+    ApacheKafkaConsumerAdapter consumer = mock(ApacheKafkaConsumerAdapter.class);
+    when(consumer.poll(anyLong())).thenReturn(
+        Collections.emptyMap(), // poll 1: empty (warmup)
+        Collections.emptyMap(), // poll 2: empty (warmup)
+        Collections.emptyMap(), // poll 3: empty (warmup)
+        messagesMap, // poll 4: data arrives
+        Collections.emptyMap()); // poll 5: end of topic
+
+    int processedCount = DumpAdminMessages.dumpAdminMessages(consumer, "cluster1", ApacheKafkaOffsetPosition.of(0L), 5);
+    Assert.assertEquals(processedCount, 5, "Should process all messages after initial empty polls during warmup");
+  }
+
+  @Test
+  void testDumpAdminMessagesStopsAfterExhaustingRetries() {
+    // All polls return empty — should stop after INITIAL_EMPTY_POLL_RETRIES
+    ApacheKafkaConsumerAdapter consumer = mock(ApacheKafkaConsumerAdapter.class);
+    when(consumer.poll(anyLong())).thenReturn(Collections.emptyMap());
+
+    int processedCount =
+        DumpAdminMessages.dumpAdminMessages(consumer, "cluster1", ApacheKafkaOffsetPosition.of(0L), 100);
+    Assert.assertEquals(processedCount, 0, "Should process 0 messages when topic is empty");
+  }
+
+  @Test
   public void testAdminToolConsumption() {
     ControllerClient controllerClient = mock(ControllerClient.class);
     SchemaResponse schemaResponse = mock(SchemaResponse.class);

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/controller/AdminToolE2ETest.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/controller/AdminToolE2ETest.java
@@ -482,8 +482,11 @@ public class AdminToolE2ETest {
   @DataProvider(name = "dumpAdminMessageOptions")
   public Object[][] dumpAdminOptions() {
     return new Object[][] { { new String[] { "--starting_offset", "3" }, null },
-        { new String[] { "--starting_position", "0:0twI" }, null }, { new String[] {}, RuntimeException.class },
-        { new String[] { "--starting_offset", "10", "--starting_position", "0:0o1e" },
+        { new String[] { "--starting_position", "0:0twI" }, null },
+        { new String[] { "--starting_offset", "earliest" }, null },
+        { new String[] { "--starting_offset", "LATEST" }, null },
+        // No starting offset/position -> defaults to EARLIEST, should succeed
+        { new String[] {}, null }, { new String[] { "--starting_offset", "10", "--starting_position", "0:0o1e" },
             AlreadySelectedException.class } };
   }
 }


### PR DESCRIPTION
## Summary

- Fix `dump-admin-messages` failing with Xinfra-based consumers due to consumer initialization race condition
- The Xinfra consumer (XcConsumerAdapter) needs 2-3s to initialize (connect to conductor, get assignments, seek), but `DumpAdminMessages` exits on the first empty poll (1s timeout), always returning 0 messages
- Add retry logic: 10 retries during initial warmup, 3 retries after data starts flowing
- Default starting position to `EARLIEST` when `--starting_offset` is not specified
- Accept `earliest` and `latest` as string values for `--starting_offset`
- Make `--message_count` optional (defaults to all messages)

## How was this tested?

Tested against EI cert-1 admin topic (`venice_admin_cert-1` in `venice-feed` namespace):
- Before fix: `Total admin messages processed: 0` (every time)
- After fix: Successfully dumped 12,401+ admin messages
- Verified `--starting_offset earliest`, `--starting_offset latest`, and default (no offset) all work correctly
- Verified `--message_count` omission defaults to dumping all messages