### PR TITLE
[common][vpj] Tag EOP with per-partition record counts for batch push verification

### DIFF
--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/VenicePushJob.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/VenicePushJob.java
@@ -917,7 +917,8 @@ public class VenicePushJob implements AutoCloseable {
 
         if (!pushJobSetting.suppressEndOfPushMessage) {
           if (pushJobSetting.sendControlMessagesDirectly) {
-            getVeniceWriter(pushJobSetting).broadcastEndOfPush(Collections.emptyMap());
+            Map<Integer, Long> partitionRecordCounts = getPerPartitionRecordCounts();
+            getVeniceWriter(pushJobSetting).broadcastEndOfPush(Collections.emptyMap(), partitionRecordCounts);
           } else {
             controllerClient.writeEndOfPush(pushJobSetting.storeName, pushJobSetting.version);
           }
@@ -1740,6 +1741,17 @@ public class VenicePushJob implements AutoCloseable {
   @VisibleForTesting
   void updatePushJobDetailsWithCheckpoint(PushJobCheckpoints checkpoint) {
     pushJobDetails.pushJobLatestCheckpoint = checkpoint.getValue();
+  }
+
+  private Map<Integer, Long> getPerPartitionRecordCounts() {
+    if (dataWriterComputeJob == null) {
+      return Collections.emptyMap();
+    }
+    DataWriterTaskTracker tracker = dataWriterComputeJob.getTaskTracker();
+    if (tracker == null) {
+      return Collections.emptyMap();
+    }
+    return tracker.getPerPartitionRecordCounts();
   }
 
   private void updatePushJobDetailsWithDataWriterTracker() {

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/mapreduce/counter/MRJobCounterHelper.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/mapreduce/counter/MRJobCounterHelper.java
@@ -285,13 +285,13 @@ public class MRJobCounterHelper {
     incrAmountWithGroupCounterName(reporter, REPUSH_TTL_FILTER_COUNT_GROUP_COUNTER_NAME, amount);
   }
 
-  public static void incrPartitionRecordCount(Reporter reporter, int partition, long amount) {
-    if (reporter == null || reporter.equals(Reporter.NULL) || amount == 0) {
+  public static void setPartitionRecordCount(Reporter reporter, int partition, long count) {
+    if (reporter == null || reporter.equals(Reporter.NULL)) {
       return;
     }
     Counters.Counter counter = reporter.getCounter(PER_PARTITION_RECORD_COUNT_GROUP, String.valueOf(partition));
     if (counter != null) {
-      counter.increment(amount);
+      counter.increment(count); // Counter API only has increment; called once per partition so 0 + count = count
     }
   }
 

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/mapreduce/counter/MRJobCounterHelper.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/mapreduce/counter/MRJobCounterHelper.java
@@ -1,5 +1,7 @@
 package com.linkedin.venice.hadoop.mapreduce.counter;
 
+import java.util.HashMap;
+import java.util.Map;
 import org.apache.hadoop.mapred.Counters;
 import org.apache.hadoop.mapred.Reporter;
 
@@ -38,6 +40,8 @@ public class MRJobCounterHelper {
       "Mapper spray all partitions triggered count";
   private static final String COUNTER_GROUP_KAFKA_INPUT_FORMAT = "KafkaInputFormat";
   private static final String COUNTER_PUT_OR_DELETE_RECORDS = "put or delete records";
+
+  private static final String PER_PARTITION_RECORD_COUNT_GROUP = "Per Partition Record Count";
 
   private static final String REPUSH_TTL_FILTERED_COUNT = "Repush ttl filtered count";
 
@@ -278,6 +282,29 @@ public class MRJobCounterHelper {
 
   public static void incrRepushTtlFilterCount(Reporter reporter, long amount) {
     incrAmountWithGroupCounterName(reporter, REPUSH_TTL_FILTER_COUNT_GROUP_COUNTER_NAME, amount);
+  }
+
+  public static void incrPartitionRecordCount(Reporter reporter, int partition, long amount) {
+    if (reporter == null || reporter.equals(Reporter.NULL) || amount == 0) {
+      return;
+    }
+    Counters.Counter counter = reporter.getCounter(PER_PARTITION_RECORD_COUNT_GROUP, String.valueOf(partition));
+    if (counter != null) {
+      counter.increment(amount);
+    }
+  }
+
+  public static Map<Integer, Long> getPerPartitionRecordCounts(Counters counters) {
+    Map<Integer, Long> result = new HashMap<>();
+    for (Counters.Group group: counters) {
+      if (group.getName().equals(PER_PARTITION_RECORD_COUNT_GROUP)) {
+        for (Counters.Counter counter: group) {
+          result.put(Integer.parseInt(counter.getName()), counter.getValue());
+        }
+        break;
+      }
+    }
+    return result;
   }
 
   /**

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/mapreduce/counter/MRJobCounterHelper.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/mapreduce/counter/MRJobCounterHelper.java
@@ -1,5 +1,6 @@
 package com.linkedin.venice.hadoop.mapreduce.counter;
 
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import org.apache.hadoop.mapred.Counters;
@@ -295,6 +296,9 @@ public class MRJobCounterHelper {
   }
 
   public static Map<Integer, Long> getPerPartitionRecordCounts(Counters counters) {
+    if (counters == null) {
+      return Collections.emptyMap();
+    }
     Map<Integer, Long> result = new HashMap<>();
     for (Counters.Group group: counters) {
       if (group.getName().equals(PER_PARTITION_RECORD_COUNT_GROUP)) {

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/mapreduce/datawriter/task/CounterBackedMapReduceDataWriterTaskTracker.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/mapreduce/datawriter/task/CounterBackedMapReduceDataWriterTaskTracker.java
@@ -2,6 +2,7 @@ package com.linkedin.venice.hadoop.mapreduce.datawriter.task;
 
 import com.linkedin.venice.hadoop.mapreduce.counter.MRJobCounterHelper;
 import com.linkedin.venice.hadoop.task.datawriter.DataWriterTaskTracker;
+import java.util.Map;
 import org.apache.hadoop.mapred.Counters;
 
 
@@ -88,5 +89,10 @@ public class CounterBackedMapReduceDataWriterTaskTracker implements DataWriterTa
   @Override
   public long getIncrementalPushThrottledTimeMs() {
     return MRJobCounterHelper.getIncrementalPushThrottleTimeMs(counters);
+  }
+
+  @Override
+  public Map<Integer, Long> getPerPartitionRecordCounts() {
+    return MRJobCounterHelper.getPerPartitionRecordCounts(this.counters);
   }
 }

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/mapreduce/datawriter/task/ReporterBackedMapReduceDataWriterTaskTracker.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/mapreduce/datawriter/task/ReporterBackedMapReduceDataWriterTaskTracker.java
@@ -89,6 +89,11 @@ public class ReporterBackedMapReduceDataWriterTaskTracker implements DataWriterT
   }
 
   @Override
+  public void trackRecordSentToPubSubForPartition(int partition) {
+    MRJobCounterHelper.incrPartitionRecordCount(this.reporter, partition, 1);
+  }
+
+  @Override
   public void trackDuplicateKeyWithDistinctValue(int count) {
     MRJobCounterHelper.incrDuplicateKeyWithDistinctValue(reporter, count);
   }

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/mapreduce/datawriter/task/ReporterBackedMapReduceDataWriterTaskTracker.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/mapreduce/datawriter/task/ReporterBackedMapReduceDataWriterTaskTracker.java
@@ -90,7 +90,7 @@ public class ReporterBackedMapReduceDataWriterTaskTracker implements DataWriterT
 
   @Override
   public void trackRecordSentToPubSubForPartition(int partition, long count) {
-    MRJobCounterHelper.incrPartitionRecordCount(this.reporter, partition, count);
+    MRJobCounterHelper.setPartitionRecordCount(this.reporter, partition, count);
   }
 
   @Override

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/mapreduce/datawriter/task/ReporterBackedMapReduceDataWriterTaskTracker.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/mapreduce/datawriter/task/ReporterBackedMapReduceDataWriterTaskTracker.java
@@ -89,8 +89,8 @@ public class ReporterBackedMapReduceDataWriterTaskTracker implements DataWriterT
   }
 
   @Override
-  public void trackRecordSentToPubSubForPartition(int partition) {
-    MRJobCounterHelper.incrPartitionRecordCount(this.reporter, partition, 1);
+  public void trackRecordSentToPubSubForPartition(int partition, long count) {
+    MRJobCounterHelper.incrPartitionRecordCount(this.reporter, partition, count);
   }
 
   @Override

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/task/datawriter/AbstractPartitionWriter.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/task/datawriter/AbstractPartitionWriter.java
@@ -498,7 +498,6 @@ public abstract class AbstractPartitionWriter extends AbstractDataWriterTask imp
     messageSent++;
     telemetry();
     dataWriterTaskTracker.trackRecordSentToPubSub();
-    dataWriterTaskTracker.trackRecordSentToPubSubForPartition(getTaskId());
   }
 
   /**
@@ -745,6 +744,8 @@ public abstract class AbstractPartitionWriter extends AbstractDataWriterTask imp
     if (dataWriterTaskTracker == null) {
       LOGGER.warn("No TaskTracker set");
     } else {
+      // Flush per-partition record count once at close instead of per-record
+      dataWriterTaskTracker.trackRecordSentToPubSubForPartition(getTaskId(), messageSent);
       dataWriterTaskTracker.trackPartitionWriterClose();
     }
   }

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/task/datawriter/AbstractPartitionWriter.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/task/datawriter/AbstractPartitionWriter.java
@@ -498,6 +498,7 @@ public abstract class AbstractPartitionWriter extends AbstractDataWriterTask imp
     messageSent++;
     telemetry();
     dataWriterTaskTracker.trackRecordSentToPubSub();
+    dataWriterTaskTracker.trackRecordSentToPubSubForPartition(getTaskId());
   }
 
   /**

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/task/datawriter/DataWriterTaskTracker.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/task/datawriter/DataWriterTaskTracker.java
@@ -1,6 +1,8 @@
 package com.linkedin.venice.hadoop.task.datawriter;
 
 import com.linkedin.venice.hadoop.task.TaskTracker;
+import java.util.Collections;
+import java.util.Map;
 
 
 /**
@@ -45,6 +47,9 @@ public interface DataWriterTaskTracker extends TaskTracker {
   }
 
   default void trackRecordSentToPubSub() {
+  }
+
+  default void trackRecordSentToPubSubForPartition(int partition) {
   }
 
   default void trackDuplicateKeyWithDistinctValue(int count) {
@@ -131,5 +136,9 @@ public interface DataWriterTaskTracker extends TaskTracker {
 
   default long getIncrementalPushThrottledTimeMs() {
     return 0;
+  }
+
+  default Map<Integer, Long> getPerPartitionRecordCounts() {
+    return Collections.emptyMap();
   }
 }

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/task/datawriter/DataWriterTaskTracker.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/task/datawriter/DataWriterTaskTracker.java
@@ -49,7 +49,7 @@ public interface DataWriterTaskTracker extends TaskTracker {
   default void trackRecordSentToPubSub() {
   }
 
-  default void trackRecordSentToPubSubForPartition(int partition) {
+  default void trackRecordSentToPubSubForPartition(int partition, long count) {
   }
 
   default void trackDuplicateKeyWithDistinctValue(int count) {

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/spark/datawriter/task/DataWriterAccumulators.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/spark/datawriter/task/DataWriterAccumulators.java
@@ -30,6 +30,7 @@ public class DataWriterAccumulators implements Serializable {
   public final LongAccumulator repushTtlFilteredRecordCounter;
   public final LongAccumulator incrementalPushThrottleTimeCounter;
   public final LongAccumulator totalDuplicateKeyCounter;
+  public final MapLongAccumulator perPartitionRecordCounts;
 
   public DataWriterAccumulators(SparkSession session) {
     SparkContext sparkContext = session.sparkContext();
@@ -52,5 +53,7 @@ public class DataWriterAccumulators implements Serializable {
     duplicateKeyWithIdenticalValueCounter = sparkContext.longAccumulator("Duplicate Key With Identical Value");
     duplicateKeyWithDistinctValueCounter = sparkContext.longAccumulator("Duplicate Key With Distinct Value");
     totalDuplicateKeyCounter = sparkContext.longAccumulator("Total Duplicate Keys (Compaction)");
+    this.perPartitionRecordCounts = new MapLongAccumulator();
+    sparkContext.register(perPartitionRecordCounts, "perPartitionRecordCounts");
   }
 }

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/spark/datawriter/task/DataWriterAccumulators.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/spark/datawriter/task/DataWriterAccumulators.java
@@ -53,7 +53,7 @@ public class DataWriterAccumulators implements Serializable {
     duplicateKeyWithIdenticalValueCounter = sparkContext.longAccumulator("Duplicate Key With Identical Value");
     duplicateKeyWithDistinctValueCounter = sparkContext.longAccumulator("Duplicate Key With Distinct Value");
     totalDuplicateKeyCounter = sparkContext.longAccumulator("Total Duplicate Keys (Compaction)");
-    this.perPartitionRecordCounts = new MapLongAccumulator();
-    sparkContext.register(perPartitionRecordCounts, "perPartitionRecordCounts");
+    perPartitionRecordCounts = new MapLongAccumulator();
+    sparkContext.register(perPartitionRecordCounts, "Per Partition Record Counts");
   }
 }

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/spark/datawriter/task/DataWriterAccumulators.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/spark/datawriter/task/DataWriterAccumulators.java
@@ -53,7 +53,6 @@ public class DataWriterAccumulators implements Serializable {
     duplicateKeyWithIdenticalValueCounter = sparkContext.longAccumulator("Duplicate Key With Identical Value");
     duplicateKeyWithDistinctValueCounter = sparkContext.longAccumulator("Duplicate Key With Distinct Value");
     totalDuplicateKeyCounter = sparkContext.longAccumulator("Total Duplicate Keys (Compaction)");
-    perPartitionRecordCounts = new MapLongAccumulator();
-    sparkContext.register(perPartitionRecordCounts, "Per Partition Record Counts");
+    perPartitionRecordCounts = new MapLongAccumulator(sparkContext, "Per Partition Record Counts");
   }
 }

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/spark/datawriter/task/MapLongAccumulator.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/spark/datawriter/task/MapLongAccumulator.java
@@ -50,8 +50,11 @@ public class MapLongAccumulator extends AccumulatorV2<scala.Tuple2<Integer, Long
 
   @Override
   public void merge(AccumulatorV2<scala.Tuple2<Integer, Long>, Map<Integer, Long>> other) {
-    MapLongAccumulator otherAcc = (MapLongAccumulator) other;
-    otherAcc.map.forEach((key, value) -> map.merge(key, value, Long::sum));
+    if (!(other instanceof MapLongAccumulator)) {
+      throw new IllegalArgumentException(
+          "Cannot merge " + other.getClass().getSimpleName() + " into MapLongAccumulator");
+    }
+    ((MapLongAccumulator) other).map.forEach((key, value) -> map.merge(key, value, Long::sum));
   }
 
   @Override

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/spark/datawriter/task/MapLongAccumulator.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/spark/datawriter/task/MapLongAccumulator.java
@@ -1,8 +1,8 @@
 package com.linkedin.venice.spark.datawriter.task;
 
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
 import org.apache.spark.SparkContext;
 import org.apache.spark.util.AccumulatorV2;
 
@@ -10,11 +10,14 @@ import org.apache.spark.util.AccumulatorV2;
 /**
  * A Spark accumulator that maintains per-key long counters, merging by summing values per key.
  * Used for tracking per-partition record counts during Spark-based push jobs.
+ *
+ * Thread safety: Spark creates a fresh copy per task via {@link #copy()}, so each task's
+ * instance is single-threaded. A plain HashMap suffices — no concurrent access occurs.
  */
 public class MapLongAccumulator extends AccumulatorV2<scala.Tuple2<Integer, Long>, Map<Integer, Long>> {
   private static final long serialVersionUID = 1L;
 
-  private final ConcurrentHashMap<Integer, Long> map = new ConcurrentHashMap<>();
+  private final HashMap<Integer, Long> map = new HashMap<>();
 
   MapLongAccumulator() {
   }

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/spark/datawriter/task/MapLongAccumulator.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/spark/datawriter/task/MapLongAccumulator.java
@@ -1,0 +1,50 @@
+package com.linkedin.venice.spark.datawriter.task;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import org.apache.spark.util.AccumulatorV2;
+
+
+/**
+ * A Spark accumulator that maintains per-key long counters, merging by summing values per key.
+ * Used for tracking per-partition record counts during Spark-based push jobs.
+ */
+public class MapLongAccumulator extends AccumulatorV2<scala.Tuple2<Integer, Long>, Map<Integer, Long>> {
+  private static final long serialVersionUID = 1L;
+
+  private final ConcurrentHashMap<Integer, Long> map = new ConcurrentHashMap<>();
+
+  @Override
+  public boolean isZero() {
+    return map.isEmpty();
+  }
+
+  @Override
+  public AccumulatorV2<scala.Tuple2<Integer, Long>, Map<Integer, Long>> copy() {
+    MapLongAccumulator newAcc = new MapLongAccumulator();
+    newAcc.map.putAll(this.map);
+    return newAcc;
+  }
+
+  @Override
+  public void reset() {
+    map.clear();
+  }
+
+  @Override
+  public void add(scala.Tuple2<Integer, Long> v) {
+    map.merge(v._1(), v._2(), Long::sum);
+  }
+
+  @Override
+  public void merge(AccumulatorV2<scala.Tuple2<Integer, Long>, Map<Integer, Long>> other) {
+    MapLongAccumulator otherAcc = (MapLongAccumulator) other;
+    otherAcc.map.forEach((key, value) -> map.merge(key, value, Long::sum));
+  }
+
+  @Override
+  public Map<Integer, Long> value() {
+    return Collections.unmodifiableMap(map);
+  }
+}

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/spark/datawriter/task/MapLongAccumulator.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/spark/datawriter/task/MapLongAccumulator.java
@@ -3,6 +3,7 @@ package com.linkedin.venice.spark.datawriter.task;
 import java.util.Collections;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
+import org.apache.spark.SparkContext;
 import org.apache.spark.util.AccumulatorV2;
 
 
@@ -14,6 +15,13 @@ public class MapLongAccumulator extends AccumulatorV2<scala.Tuple2<Integer, Long
   private static final long serialVersionUID = 1L;
 
   private final ConcurrentHashMap<Integer, Long> map = new ConcurrentHashMap<>();
+
+  MapLongAccumulator() {
+  }
+
+  MapLongAccumulator(SparkContext sparkContext, String name) {
+    sparkContext.register(this, name);
+  }
 
   @Override
   public boolean isZero() {

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/spark/datawriter/task/SparkDataWriterTaskTracker.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/spark/datawriter/task/SparkDataWriterTaskTracker.java
@@ -1,6 +1,7 @@
 package com.linkedin.venice.spark.datawriter.task;
 
 import com.linkedin.venice.hadoop.task.datawriter.DataWriterTaskTracker;
+import java.util.Map;
 
 
 /**
@@ -71,6 +72,11 @@ public class SparkDataWriterTaskTracker implements DataWriterTaskTracker {
   @Override
   public void trackRecordSentToPubSub() {
     accumulators.outputRecordCounter.add(1);
+  }
+
+  @Override
+  public void trackRecordSentToPubSubForPartition(int partition) {
+    accumulators.perPartitionRecordCounts.add(new scala.Tuple2<>(partition, 1L));
   }
 
   @Override
@@ -171,5 +177,10 @@ public class SparkDataWriterTaskTracker implements DataWriterTaskTracker {
   @Override
   public long getIncrementalPushThrottledTimeMs() {
     return accumulators.incrementalPushThrottleTimeCounter.value();
+  }
+
+  @Override
+  public Map<Integer, Long> getPerPartitionRecordCounts() {
+    return accumulators.perPartitionRecordCounts.value();
   }
 }

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/spark/datawriter/task/SparkDataWriterTaskTracker.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/spark/datawriter/task/SparkDataWriterTaskTracker.java
@@ -75,8 +75,8 @@ public class SparkDataWriterTaskTracker implements DataWriterTaskTracker {
   }
 
   @Override
-  public void trackRecordSentToPubSubForPartition(int partition) {
-    accumulators.perPartitionRecordCounts.add(new scala.Tuple2<>(partition, 1L));
+  public void trackRecordSentToPubSubForPartition(int partition, long count) {
+    accumulators.perPartitionRecordCounts.add(new scala.Tuple2<>(partition, count));
   }
 
   @Override

--- a/clients/venice-push-job/src/test/java/com/linkedin/venice/hadoop/mapreduce/counter/MRJobCounterHelperTest.java
+++ b/clients/venice-push-job/src/test/java/com/linkedin/venice/hadoop/mapreduce/counter/MRJobCounterHelperTest.java
@@ -1,0 +1,54 @@
+package com.linkedin.venice.hadoop.mapreduce.counter;
+
+import java.util.Map;
+import org.apache.hadoop.mapred.Counters;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+
+public class MRJobCounterHelperTest {
+  @Test
+  public void testGetPerPartitionRecordCounts() {
+    Counters counters = new Counters();
+    // Simulate per-partition record counts by incrementing counters in the expected group
+    Counters.Counter counter0 = counters.findCounter("Per Partition Record Count", "0");
+    counter0.increment(100);
+    Counters.Counter counter1 = counters.findCounter("Per Partition Record Count", "1");
+    counter1.increment(200);
+    Counters.Counter counter5 = counters.findCounter("Per Partition Record Count", "5");
+    counter5.increment(50);
+
+    Map<Integer, Long> result = MRJobCounterHelper.getPerPartitionRecordCounts(counters);
+    Assert.assertEquals(result.size(), 3);
+    Assert.assertEquals((long) result.get(0), 100L);
+    Assert.assertEquals((long) result.get(1), 200L);
+    Assert.assertEquals((long) result.get(5), 50L);
+  }
+
+  @Test
+  public void testGetPerPartitionRecordCountsEmpty() {
+    Counters counters = new Counters();
+    Map<Integer, Long> result = MRJobCounterHelper.getPerPartitionRecordCounts(counters);
+    Assert.assertTrue(result.isEmpty());
+  }
+
+  @Test
+  public void testIncrPartitionRecordCountWithMockReporter() {
+    // Use a Counters-based approach to verify the increment path indirectly:
+    // Increment via Reporter, then read back via Counters
+    Counters counters = new Counters();
+    Counters.Counter counter = counters.findCounter("Per Partition Record Count", "3");
+    counter.increment(10);
+    counter.increment(5);
+
+    Map<Integer, Long> result = MRJobCounterHelper.getPerPartitionRecordCounts(counters);
+    Assert.assertEquals(result.size(), 1);
+    Assert.assertEquals((long) result.get(3), 15L);
+  }
+
+  @Test
+  public void testIncrPartitionRecordCountWithNullReporter() {
+    // Passing null reporter should not throw
+    MRJobCounterHelper.incrPartitionRecordCount(null, 0, 1);
+  }
+}

--- a/clients/venice-push-job/src/test/java/com/linkedin/venice/hadoop/mapreduce/counter/MRJobCounterHelperTest.java
+++ b/clients/venice-push-job/src/test/java/com/linkedin/venice/hadoop/mapreduce/counter/MRJobCounterHelperTest.java
@@ -45,8 +45,8 @@ public class MRJobCounterHelperTest {
   }
 
   @Test
-  public void testIncrPartitionRecordCountWithNullReporter() {
+  public void testSetPartitionRecordCountWithNullReporter() {
     // Passing null reporter should not throw
-    MRJobCounterHelper.incrPartitionRecordCount(null, 0, 1);
+    MRJobCounterHelper.setPartitionRecordCount(null, 0, 1);
   }
 }

--- a/clients/venice-push-job/src/test/java/com/linkedin/venice/hadoop/mapreduce/counter/MRJobCounterHelperTest.java
+++ b/clients/venice-push-job/src/test/java/com/linkedin/venice/hadoop/mapreduce/counter/MRJobCounterHelperTest.java
@@ -33,9 +33,7 @@ public class MRJobCounterHelperTest {
   }
 
   @Test
-  public void testIncrPartitionRecordCountWithMockReporter() {
-    // Use a Counters-based approach to verify the increment path indirectly:
-    // Increment via Reporter, then read back via Counters
+  public void testGetPerPartitionRecordCountsWithMultipleIncrements() {
     Counters counters = new Counters();
     Counters.Counter counter = counters.findCounter("Per Partition Record Count", "3");
     counter.increment(10);

--- a/clients/venice-push-job/src/test/java/com/linkedin/venice/spark/datawriter/task/MapLongAccumulatorTest.java
+++ b/clients/venice-push-job/src/test/java/com/linkedin/venice/spark/datawriter/task/MapLongAccumulatorTest.java
@@ -1,0 +1,85 @@
+package com.linkedin.venice.spark.datawriter.task;
+
+import java.util.Map;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+
+public class MapLongAccumulatorTest {
+  @Test
+  public void testIsZero() {
+    MapLongAccumulator accumulator = new MapLongAccumulator();
+    Assert.assertTrue(accumulator.isZero());
+
+    accumulator.add(new scala.Tuple2<>(0, 10L));
+    Assert.assertFalse(accumulator.isZero());
+  }
+
+  @Test
+  public void testAddAndValue() {
+    MapLongAccumulator accumulator = new MapLongAccumulator();
+    accumulator.add(new scala.Tuple2<>(0, 10L));
+    accumulator.add(new scala.Tuple2<>(1, 20L));
+    accumulator.add(new scala.Tuple2<>(0, 5L));
+
+    Map<Integer, Long> value = accumulator.value();
+    Assert.assertEquals(value.size(), 2);
+    Assert.assertEquals((long) value.get(0), 15L);
+    Assert.assertEquals((long) value.get(1), 20L);
+  }
+
+  @Test
+  public void testMerge() {
+    MapLongAccumulator accA = new MapLongAccumulator();
+    accA.add(new scala.Tuple2<>(0, 10L));
+    accA.add(new scala.Tuple2<>(1, 20L));
+
+    MapLongAccumulator accB = new MapLongAccumulator();
+    accB.add(new scala.Tuple2<>(1, 5L));
+    accB.add(new scala.Tuple2<>(2, 30L));
+
+    accA.merge(accB);
+
+    Map<Integer, Long> value = accA.value();
+    Assert.assertEquals(value.size(), 3);
+    Assert.assertEquals((long) value.get(0), 10L);
+    Assert.assertEquals((long) value.get(1), 25L);
+    Assert.assertEquals((long) value.get(2), 30L);
+  }
+
+  @Test
+  public void testReset() {
+    MapLongAccumulator accumulator = new MapLongAccumulator();
+    accumulator.add(new scala.Tuple2<>(0, 10L));
+    accumulator.add(new scala.Tuple2<>(1, 20L));
+    Assert.assertFalse(accumulator.isZero());
+
+    accumulator.reset();
+    Assert.assertTrue(accumulator.isZero());
+    Assert.assertTrue(accumulator.value().isEmpty());
+  }
+
+  @Test
+  public void testCopy() {
+    MapLongAccumulator original = new MapLongAccumulator();
+    original.add(new scala.Tuple2<>(0, 10L));
+    original.add(new scala.Tuple2<>(1, 20L));
+
+    MapLongAccumulator copy = (MapLongAccumulator) original.copy();
+
+    Assert.assertNotNull(copy);
+    Assert.assertEquals(copy.value(), original.value());
+
+    // Verify independence: modifying copy should not affect original
+    copy.add(new scala.Tuple2<>(0, 5L));
+    Assert.assertEquals((long) original.value().get(0), 10L);
+    Assert.assertEquals((long) copy.value().get(0), 15L);
+  }
+
+  @Test(expectedExceptions = UnsupportedOperationException.class)
+  public void testValueIsUnmodifiable() {
+    MapLongAccumulator accumulator = new MapLongAccumulator();
+    accumulator.add(new scala.Tuple2<>(0, 10L));
+    accumulator.value().put(1, 20L);
+  }
+}

--- a/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/api/PubSubMessageHeaders.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/api/PubSubMessageHeaders.java
@@ -33,6 +33,8 @@ public class PubSubMessageHeaders implements Measurable, Iterable<PubSubMessageH
    * further processing. In the example, this chunk should be sent to view1's partition 0 and view2's partitions 1 & 2.
    */
   public static final String VENICE_VIEW_PARTITIONS_MAP_HEADER = "vpm";
+  /** Header to carry per-partition record count for batch push record count verification */
+  public static final String VENICE_PARTITION_RECORD_COUNT_HEADER = "prc";
 
   public PubSubMessageHeaders add(PubSubMessageHeader header) {
     headers.put(header.key(), header);

--- a/internal/venice-common/src/main/java/com/linkedin/venice/writer/VeniceWriter.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/writer/VeniceWriter.java
@@ -2277,23 +2277,7 @@ public class VeniceWriter<K, V, U> extends AbstractVeniceWriter<K, V, U> {
       Map<String, String> debugInfo,
       PubSubProducerCallback callback,
       LeaderMetadataWrapper leaderMetadataWrapper) {
-    // Work around until we upgrade to a more modern Avro version which supports overriding the
-    // String implementation.
-    controlMessage.debugInfo = getDebugInfo(debugInfo);
-    boolean isEndOfSegment = ControlMessageType.valueOf(controlMessage).equals(ControlMessageType.END_OF_SEGMENT);
-    synchronized (this.partitionLocks[partition]) {
-      return sendMessage(
-          this::getControlMessageKey,
-          MessageType.CONTROL_MESSAGE,
-          controlMessage,
-          isEndOfSegment,
-          partition,
-          callback,
-          true,
-          leaderMetadataWrapper,
-          VENICE_DEFAULT_LOGICAL_TS,
-          EmptyPubSubMessageHeaders.SINGLETON);
-    }
+    return sendControlMessage(controlMessage, partition, debugInfo, callback, leaderMetadataWrapper, null);
   }
 
   public CompletableFuture<PubSubProduceResult> sendControlMessage(
@@ -2303,6 +2287,8 @@ public class VeniceWriter<K, V, U> extends AbstractVeniceWriter<K, V, U> {
       PubSubProducerCallback callback,
       LeaderMetadataWrapper leaderMetadataWrapper,
       PubSubMessageHeaders headers) {
+    // Work around until we upgrade to a more modern Avro version which supports overriding the
+    // String implementation.
     controlMessage.debugInfo = getDebugInfo(debugInfo);
     boolean isEndOfSegment = ControlMessageType.valueOf(controlMessage).equals(ControlMessageType.END_OF_SEGMENT);
     synchronized (this.partitionLocks[partition]) {

--- a/internal/venice-common/src/main/java/com/linkedin/venice/writer/VeniceWriter.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/writer/VeniceWriter.java
@@ -1441,7 +1441,17 @@ public class VeniceWriter<K, V, U> extends AbstractVeniceWriter<K, V, U> {
    * @param debugInfo arbitrary key/value pairs of information that will be propagated alongside the control message.
    */
   public void broadcastEndOfPush(Map<String, String> debugInfo) {
-    broadcastControlMessage(getEmptyControlMessage(ControlMessageType.END_OF_PUSH), debugInfo);
+    broadcastEndOfPush(debugInfo, null);
+  }
+
+  /**
+   * Broadcast end of push with per-partition record counts for verification.
+   *
+   * @param debugInfo arbitrary key/value pairs of information that will be propagated alongside the control message.
+   * @param partitionRecordCounts per-partition record counts. If null or empty, no record count header is sent.
+   */
+  public void broadcastEndOfPush(Map<String, String> debugInfo, Map<Integer, Long> partitionRecordCounts) {
+    broadcastControlMessage(getEmptyControlMessage(ControlMessageType.END_OF_PUSH), debugInfo, partitionRecordCounts);
     endAllSegments(true);
   }
 
@@ -2110,6 +2120,38 @@ public class VeniceWriter<K, V, U> extends AbstractVeniceWriter<K, V, U> {
     return partitionWriteFuture;
   }
 
+  /**
+   * Broadcast a control message with per-partition record counts embedded as PubSub headers.
+   */
+  private List<CompletableFuture<PubSubProduceResult>> broadcastControlMessage(
+      ControlMessage controlMessage,
+      Map<String, String> debugInfo,
+      Map<Integer, Long> partitionRecordCounts) {
+    if (partitionRecordCounts == null || partitionRecordCounts.isEmpty()) {
+      return broadcastControlMessage(controlMessage, debugInfo);
+    }
+    List<CompletableFuture<PubSubProduceResult>> partitionWriteFuture = new ArrayList<>();
+    for (int partition = 0; partition < numberOfPartitions; partition++) {
+      Long recordCount = partitionRecordCounts.get(partition);
+      if (recordCount != null) {
+        PubSubMessageHeaders headers = new PubSubMessageHeaders();
+        headers.add(
+            PubSubMessageHeaders.VENICE_PARTITION_RECORD_COUNT_HEADER,
+            ByteBuffer.allocate(Long.BYTES).putLong(recordCount).array());
+        partitionWriteFuture.add(
+            sendControlMessage(controlMessage, partition, debugInfo, null, DEFAULT_LEADER_METADATA_WRAPPER, headers));
+      } else {
+        partitionWriteFuture
+            .add(sendControlMessage(controlMessage, partition, debugInfo, null, DEFAULT_LEADER_METADATA_WRAPPER));
+      }
+    }
+    logger.info(
+        "Successfully broadcast {} Control Message with record counts for topic: {}",
+        ControlMessageType.valueOf(controlMessage),
+        topicName);
+    return partitionWriteFuture;
+  }
+
   private Map<CharSequence, CharSequence> getDebugInfo(Map<String, String> debugInfoToAdd) {
     if (debugInfoToAdd == null || debugInfoToAdd.isEmpty()) {
       return defaultDebugInfo;
@@ -2251,6 +2293,30 @@ public class VeniceWriter<K, V, U> extends AbstractVeniceWriter<K, V, U> {
           leaderMetadataWrapper,
           VENICE_DEFAULT_LOGICAL_TS,
           EmptyPubSubMessageHeaders.SINGLETON);
+    }
+  }
+
+  public CompletableFuture<PubSubProduceResult> sendControlMessage(
+      ControlMessage controlMessage,
+      int partition,
+      Map<String, String> debugInfo,
+      PubSubProducerCallback callback,
+      LeaderMetadataWrapper leaderMetadataWrapper,
+      PubSubMessageHeaders headers) {
+    controlMessage.debugInfo = getDebugInfo(debugInfo);
+    boolean isEndOfSegment = ControlMessageType.valueOf(controlMessage).equals(ControlMessageType.END_OF_SEGMENT);
+    synchronized (this.partitionLocks[partition]) {
+      return sendMessage(
+          this::getControlMessageKey,
+          MessageType.CONTROL_MESSAGE,
+          controlMessage,
+          isEndOfSegment,
+          partition,
+          callback,
+          true,
+          leaderMetadataWrapper,
+          VENICE_DEFAULT_LOGICAL_TS,
+          headers == null ? EmptyPubSubMessageHeaders.SINGLETON : headers);
     }
   }
 

--- a/internal/venice-common/src/test/java/com/linkedin/venice/writer/VeniceWriterUnitTest.java
+++ b/internal/venice-common/src/test/java/com/linkedin/venice/writer/VeniceWriterUnitTest.java
@@ -76,7 +76,9 @@ import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Properties;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
@@ -1345,5 +1347,113 @@ public class VeniceWriterUnitTest {
       // expected
     }
     verify(mockHook, never()).onBeforeProduce(any(VeniceWriterHook.OperationType.class), anyInt(), anyInt());
+  }
+
+  @Test(timeOut = TIMEOUT)
+  public void testBroadcastEndOfPushWithPartitionRecordCounts() {
+    PubSubProducerAdapter mockedProducer = mock(PubSubProducerAdapter.class);
+    when(mockedProducer.sendMessage(any(), any(), any(), any(), any(), any()))
+        .thenReturn(CompletableFuture.completedFuture(null));
+
+    int partitionCount = 3;
+    String testTopic = "test_v1";
+    VeniceWriterOptions veniceWriterOptions =
+        new VeniceWriterOptions.Builder(testTopic).setPartitioner(new DefaultVenicePartitioner())
+            .setPartitionCount(partitionCount)
+            .build();
+    VeniceWriter<KafkaKey, byte[], byte[]> writer =
+        new VeniceWriter(veniceWriterOptions, VeniceProperties.empty(), mockedProducer);
+
+    Map<Integer, Long> partitionRecordCounts = new HashMap<>();
+    partitionRecordCounts.put(0, 100L);
+    partitionRecordCounts.put(1, 200L);
+    partitionRecordCounts.put(2, 300L);
+
+    writer.broadcastEndOfPush(new HashMap<>(), partitionRecordCounts);
+
+    // Capture all sendMessage calls (SOS + EOP + EOS for each partition)
+    ArgumentCaptor<Integer> partitionCaptor = ArgumentCaptor.forClass(Integer.class);
+    ArgumentCaptor<KafkaMessageEnvelope> kmeCaptor = ArgumentCaptor.forClass(KafkaMessageEnvelope.class);
+    ArgumentCaptor<PubSubMessageHeaders> headersCaptor = ArgumentCaptor.forClass(PubSubMessageHeaders.class);
+    verify(mockedProducer, atLeast(6)).sendMessage(
+        anyString(),
+        partitionCaptor.capture(),
+        any(),
+        kmeCaptor.capture(),
+        headersCaptor.capture(),
+        any());
+
+    // Filter only EOP messages and verify they carry the correct prc header
+    List<Integer> allPartitions = partitionCaptor.getAllValues();
+    List<KafkaMessageEnvelope> allKmes = kmeCaptor.getAllValues();
+    List<PubSubMessageHeaders> allHeaders = headersCaptor.getAllValues();
+
+    Map<Integer, Long> observedCounts = new HashMap<>();
+    for (int i = 0; i < allKmes.size(); i++) {
+      KafkaMessageEnvelope kme = allKmes.get(i);
+      if (kme.messageType == MessageType.CONTROL_MESSAGE.getValue()) {
+        ControlMessage cm = (ControlMessage) kme.payloadUnion;
+        if (ControlMessageType.valueOf(cm) == ControlMessageType.END_OF_PUSH) {
+          int partition = allPartitions.get(i);
+          PubSubMessageHeaders headers = allHeaders.get(i);
+          PubSubMessageHeader prcHeader = headers.get(PubSubMessageHeaders.VENICE_PARTITION_RECORD_COUNT_HEADER);
+          Assert.assertNotNull(prcHeader, "Partition " + partition + " should have prc header");
+          long actualCount = ByteBuffer.wrap(prcHeader.value()).getLong();
+          observedCounts.put(partition, actualCount);
+        }
+      }
+    }
+
+    assertEquals(observedCounts.size(), 3, "Should have EOP for all 3 partitions");
+    for (Map.Entry<Integer, Long> entry: partitionRecordCounts.entrySet()) {
+      assertEquals(
+          observedCounts.get(entry.getKey()),
+          entry.getValue(),
+          "Record count mismatch for partition " + entry.getKey());
+    }
+  }
+
+  @Test(timeOut = TIMEOUT)
+  public void testBroadcastEndOfPushWithNullCounts() {
+    PubSubProducerAdapter mockedProducer = mock(PubSubProducerAdapter.class);
+    when(mockedProducer.sendMessage(any(), any(), any(), any(), any(), any()))
+        .thenReturn(CompletableFuture.completedFuture(null));
+
+    int partitionCount = 2;
+    String testTopic = "test_v2";
+    VeniceWriterOptions veniceWriterOptions =
+        new VeniceWriterOptions.Builder(testTopic).setPartitioner(new DefaultVenicePartitioner())
+            .setPartitionCount(partitionCount)
+            .build();
+    VeniceWriter<KafkaKey, byte[], byte[]> writer =
+        new VeniceWriter(veniceWriterOptions, VeniceProperties.empty(), mockedProducer);
+
+    // Call with null partitionRecordCounts for backward compatibility
+    writer.broadcastEndOfPush(new HashMap<>(), null);
+
+    // Capture all sendMessage calls
+    ArgumentCaptor<PubSubMessageHeaders> headersCaptor = ArgumentCaptor.forClass(PubSubMessageHeaders.class);
+    ArgumentCaptor<KafkaMessageEnvelope> kmeCaptor = ArgumentCaptor.forClass(KafkaMessageEnvelope.class);
+    verify(mockedProducer, atLeast(4))
+        .sendMessage(anyString(), any(), any(), kmeCaptor.capture(), headersCaptor.capture(), any());
+
+    // Filter only EOP messages and verify they have no prc header
+    List<KafkaMessageEnvelope> allKmes = kmeCaptor.getAllValues();
+    List<PubSubMessageHeaders> allHeaders = headersCaptor.getAllValues();
+
+    int eopCount = 0;
+    for (int i = 0; i < allKmes.size(); i++) {
+      KafkaMessageEnvelope kme = allKmes.get(i);
+      if (kme.messageType == MessageType.CONTROL_MESSAGE.getValue()) {
+        ControlMessage cm = (ControlMessage) kme.payloadUnion;
+        if (ControlMessageType.valueOf(cm) == ControlMessageType.END_OF_PUSH) {
+          eopCount++;
+          PubSubMessageHeaders headers = allHeaders.get(i);
+          PubSubMessageHeader prcHeader = headers.get(PubSubMessageHeaders.VENICE_PARTITION_RECORD_COUNT_HEADER);
+          Assert.assertNull(prcHeader, "EOP with null counts should not have prc header");
+        }
+      }
+    }
+    assertEquals(eopCount, partitionCount, "Should have EOP for all partitions");
   }
 }

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestBatchPushEopRecordCount.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestBatchPushEopRecordCount.java
@@ -1,0 +1,132 @@
+package com.linkedin.venice.endToEnd;
+
+import static com.linkedin.venice.utils.IntegrationTestPushUtils.createStoreForJob;
+import static com.linkedin.venice.utils.IntegrationTestPushUtils.defaultVPJProps;
+import static com.linkedin.venice.utils.TestWriteUtils.DEFAULT_USER_DATA_RECORD_COUNT;
+import static com.linkedin.venice.utils.TestWriteUtils.getTempDataDirectory;
+import static com.linkedin.venice.utils.TestWriteUtils.writeSimpleAvroFileWithStringToStringSchema;
+import static com.linkedin.venice.vpj.VenicePushJobConstants.SEND_CONTROL_MESSAGES_DIRECTLY;
+
+import com.linkedin.venice.controllerapi.UpdateStoreQueryParams;
+import com.linkedin.venice.hadoop.VenicePushJob;
+import com.linkedin.venice.integration.utils.ServiceFactory;
+import com.linkedin.venice.integration.utils.VeniceClusterCreateOptions;
+import com.linkedin.venice.integration.utils.VeniceClusterWrapper;
+import com.linkedin.venice.utils.KeyAndValueSchemas;
+import com.linkedin.venice.utils.TestUtils;
+import com.linkedin.venice.utils.Time;
+import com.linkedin.venice.utils.Utils;
+import java.io.File;
+import java.util.Map;
+import java.util.Properties;
+import java.util.concurrent.TimeUnit;
+import org.testng.Assert;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+
+/**
+ * Verifies that per-partition record counts are correctly tracked and passed to broadcastEndOfPush.
+ *
+ * This test runs a batch push with SEND_CONTROL_MESSAGES_DIRECTLY=true and verifies:
+ * 1. The push completes successfully (records are readable)
+ * 2. Per-partition record counts sum to the total records pushed
+ */
+@Test(singleThreaded = true)
+public class TestBatchPushEopRecordCount {
+  private static final int TEST_TIMEOUT = 120 * Time.MS_PER_SECOND;
+  private VeniceClusterWrapper veniceCluster;
+
+  @BeforeClass(alwaysRun = true)
+  public void setUp() {
+    VeniceClusterCreateOptions options =
+        new VeniceClusterCreateOptions.Builder().numberOfControllers(1).numberOfServers(1).numberOfRouters(1).build();
+    veniceCluster = ServiceFactory.getVeniceCluster(options);
+  }
+
+  @AfterClass(alwaysRun = true)
+  public void cleanUp() {
+    Utils.closeQuietlyWithErrorLogged(veniceCluster);
+  }
+
+  @Test(timeOut = TEST_TIMEOUT)
+  public void testPerPartitionRecordCountsMatchTotalPushed() throws Exception {
+    File inputDir = getTempDataDirectory();
+    KeyAndValueSchemas schemas = new KeyAndValueSchemas(writeSimpleAvroFileWithStringToStringSchema(inputDir));
+    String storeName = Utils.getUniqueString("eop-record-count-store");
+    String inputDirPath = "file://" + inputDir.getAbsolutePath();
+
+    Properties props = defaultVPJProps(veniceCluster, inputDirPath, storeName);
+    props.setProperty(SEND_CONTROL_MESSAGES_DIRECTLY, "true");
+
+    createStoreForJob(
+        veniceCluster.getClusterName(),
+        schemas.getKey().toString(),
+        schemas.getValue().toString(),
+        props,
+        new UpdateStoreQueryParams()).close();
+
+    // Run push job and capture per-partition counts via a subclass that exposes them
+    VerifiableVenicePushJob pushJob = new VerifiableVenicePushJob("test-job", props);
+    pushJob.run();
+    Map<Integer, Long> perPartitionCounts = pushJob.getCapturedPerPartitionRecordCounts();
+
+    // Verify per-partition counts are populated
+    Assert.assertNotNull(perPartitionCounts, "Per-partition record counts should not be null");
+    Assert.assertFalse(perPartitionCounts.isEmpty(), "Per-partition record counts should not be empty");
+
+    // Verify sum matches total records
+    long totalFromPartitions = perPartitionCounts.values().stream().mapToLong(Long::longValue).sum();
+    Assert.assertEquals(
+        totalFromPartitions,
+        DEFAULT_USER_DATA_RECORD_COUNT,
+        "Sum of per-partition record counts (" + perPartitionCounts + ") should equal total records pushed ("
+            + DEFAULT_USER_DATA_RECORD_COUNT + ")");
+
+    // Verify each partition has a non-negative count
+    for (Map.Entry<Integer, Long> entry: perPartitionCounts.entrySet()) {
+      Assert.assertTrue(
+          entry.getValue() >= 0,
+          "Partition " + entry.getKey() + " should have non-negative count, got " + entry.getValue());
+    }
+
+    // Verify push actually succeeded — data is readable
+    veniceCluster.useControllerClient(controllerClient -> {
+      TestUtils.waitForNonDeterministicAssertion(30, TimeUnit.SECONDS, true, true, () -> {
+        int currentVersion = controllerClient.getStore(storeName).getStore().getCurrentVersion();
+        Assert.assertTrue(currentVersion > 0, "Store should have a current version");
+      });
+    });
+
+    pushJob.close();
+  }
+
+  /**
+   * A VenicePushJob subclass that captures per-partition record counts for test verification.
+   */
+  private static class VerifiableVenicePushJob extends VenicePushJob {
+    private Map<Integer, Long> capturedCounts;
+
+    VerifiableVenicePushJob(String jobId, Properties vanillaProps) {
+      super(jobId, vanillaProps);
+    }
+
+    Map<Integer, Long> getCapturedPerPartitionRecordCounts() {
+      return capturedCounts;
+    }
+
+    @Override
+    public void run() {
+      super.run();
+      // Capture the counts after the job completes but before close
+      try {
+        java.lang.reflect.Method method = VenicePushJob.class.getDeclaredMethod("getPerPartitionRecordCounts");
+        method.setAccessible(true);
+        capturedCounts = (Map<Integer, Long>) method.invoke(this);
+      } catch (Exception e) {
+        throw new RuntimeException("Failed to capture per-partition record counts", e);
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary
Track per-partition record counts during batch push and embed them as PubSub message headers on the End-of-Push control message. This enables server-side verification (in a follow-up PR) without requiring changes to the EOP Avro schema.

**Part 1 of 4** in the batch push record count verification series.

### Changes
- `PubSubMessageHeaders`: new `prc` header constant
- `VeniceWriter`: new `broadcastEndOfPush`/`sendControlMessage` overloads with per-partition headers (8-byte long per partition)
- `DataWriterTaskTracker`: per-partition tracking interface (`trackRecordSentToPubSubForPartition`, `getPerPartitionRecordCounts`)
- MR path: counter group in `MRJobCounterHelper` + tracker implementations
- Spark path: new `MapLongAccumulator` + tracker implementations
- `VenicePushJob`: collect per-partition counts, pass to `broadcastEndOfPush`

### Backward compatibility
Old servers ignore unknown PubSub headers — no impact.

## Test plan
- [x] `VeniceWriterUnitTest` — broadcastEndOfPush with/without counts
- [x] `MRJobCounterHelperTest` — per-partition counter round-trip
- [x] `MapLongAccumulatorTest` — add, merge, reset, copy