### PR TITLE
[common] Add HyperLogLogSketch: reusable cardinality estimation library

### DIFF
--- a/internal/venice-common/src/main/java/com/linkedin/venice/utils/HyperLogLogSketch.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/utils/HyperLogLogSketch.java
@@ -31,9 +31,9 @@ import java.util.Arrays;
  *
  * <h3>Serialization format</h3>
  * <pre>
- *   [1 byte: precision p] [2^p bytes: registers]
+ *   [1 byte: precision p] [2^p bytes: registers (unsigned, valid range 0..64-p+1)]
  * </pre>
- * Total size = 1 + 2^p bytes (e.g., 16385 bytes for p=14).
+ * Total size = 1 + 2^p bytes (e.g., 16385 bytes for p=14). Always dense — no sparse mode.
  *
  * <h3>Thread safety</h3>
  * Not thread-safe. Callers must synchronize externally if shared across threads.
@@ -75,12 +75,12 @@ public class HyperLogLogSketch {
     this.registers = new byte[m];
   }
 
-  /** Internal constructor for deserialization — takes ownership of the registers array. */
-  private HyperLogLogSketch(int precision, byte[] registers) {
+  /** Internal constructor for deserialization — takes ownership of the provided registers array. */
+  private HyperLogLogSketch(int precision, byte[] ownedRegisters) {
     this.p = precision;
     this.m = 1 << p;
     this.alphaM = computeAlpha(m) * m * m;
-    this.registers = registers;
+    this.registers = ownedRegisters;
   }
 
   /**
@@ -92,13 +92,7 @@ public class HyperLogLogSketch {
     if (key == null || key.length == 0) {
       return;
     }
-    long hash = hash64(key);
-    int registerIndex = (int) (hash >>> (64 - p));
-    long remainingBits = (hash << p) | (1L << (p - 1));
-    int rho = Long.numberOfLeadingZeros(remainingBits) + 1;
-    if (rho > registers[registerIndex]) {
-      registers[registerIndex] = (byte) rho;
-    }
+    updateRegister(hash64(key));
   }
 
   /**
@@ -108,6 +102,10 @@ public class HyperLogLogSketch {
    * @param hash a well-distributed 64-bit hash value
    */
   public void addHash(long hash) {
+    updateRegister(hash);
+  }
+
+  private void updateRegister(long hash) {
     int registerIndex = (int) (hash >>> (64 - p));
     long remainingBits = (hash << p) | (1L << (p - 1));
     int rho = Long.numberOfLeadingZeros(remainingBits) + 1;
@@ -120,10 +118,13 @@ public class HyperLogLogSketch {
    * Merges another sketch into this one. Both sketches must have the same precision.
    * The merge operation is element-wise max of registers — associative, commutative, and idempotent.
    *
-   * @param other the sketch to merge in
-   * @throws IllegalArgumentException if precisions differ
+   * @param other the sketch to merge in (must not be null)
+   * @throws IllegalArgumentException if other is null or precisions differ
    */
   public void merge(HyperLogLogSketch other) {
+    if (other == null) {
+      throw new IllegalArgumentException("Cannot merge null HLL sketch");
+    }
     if (this.p != other.p) {
       throw new IllegalArgumentException(
           "Cannot merge HLL sketches with different precisions: " + p + " vs " + other.p);
@@ -137,6 +138,8 @@ public class HyperLogLogSketch {
 
   /**
    * Returns the estimated cardinality (number of distinct elements added).
+   * Includes small-range (linear counting) and large-range corrections per the original
+   * Flajolet et al. HLL paper.
    *
    * @return estimated cardinality, or 0 if no elements have been added
    */
@@ -144,7 +147,7 @@ public class HyperLogLogSketch {
     double sum = 0.0;
     int zeroCount = 0;
     for (int i = 0; i < m; i++) {
-      sum += 1.0 / (1L << registers[i]);
+      sum += 1.0 / (1L << (registers[i] & 0xFF));
       if (registers[i] == 0) {
         zeroCount++;
       }
@@ -155,6 +158,12 @@ public class HyperLogLogSketch {
     // Small range correction (linear counting)
     if (estimate <= 2.5 * m && zeroCount > 0) {
       estimate = m * Math.log((double) m / zeroCount);
+    }
+
+    // Large range correction (Flajolet et al.)
+    double twoTo32 = 1L << 32;
+    if (estimate > twoTo32 / 30.0) {
+      estimate = -twoTo32 * Math.log(1.0 - estimate / twoTo32);
     }
 
     return Math.round(estimate);
@@ -187,9 +196,9 @@ public class HyperLogLogSketch {
 
   /** Creates a deep copy of this sketch. */
   public HyperLogLogSketch copy() {
-    byte[] registersCopy = new byte[m];
-    System.arraycopy(registers, 0, registersCopy, 0, m);
-    return new HyperLogLogSketch(p, registersCopy);
+    HyperLogLogSketch copySketch = new HyperLogLogSketch(p);
+    System.arraycopy(registers, 0, copySketch.registers, 0, m);
+    return copySketch;
   }
 
   // ---- Serialization ----
@@ -237,8 +246,7 @@ public class HyperLogLogSketch {
       throw new IllegalArgumentException(
           "Invalid HLL bytes length: expected " + expectedLength + " for p=" + precision + ", got " + bytes.length);
     }
-    byte[] registers = new byte[1 << precision];
-    System.arraycopy(bytes, 1, registers, 0, registers.length);
+    byte[] registers = Arrays.copyOfRange(bytes, 1, bytes.length);
     return new HyperLogLogSketch(precision, registers);
   }
 
@@ -265,13 +273,14 @@ public class HyperLogLogSketch {
    * Uses FNV-1a to fold the input bytes into a single long, then applies the
    * MurmurHash3 fmix64 avalanche step for final bit mixing.
    *
-   * This is a public static method so callers can pre-hash keys (e.g., for use with
-   * {@link #addHash(long)}) or for other hashing needs.
-   *
-   * @param key the byte array to hash
+   * @param key the byte array to hash (must not be null)
    * @return a 64-bit hash value
+   * @throws IllegalArgumentException if key is null
    */
   public static long hash64(byte[] key) {
+    if (key == null) {
+      throw new IllegalArgumentException("Key must not be null");
+    }
     // FNV-1a to fold variable-length input into 64 bits
     long h = 0xcbf29ce484222325L; // FNV offset basis
     for (byte b: key) {

--- a/internal/venice-common/src/main/java/com/linkedin/venice/utils/HyperLogLogSketch.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/utils/HyperLogLogSketch.java
@@ -1,0 +1,303 @@
+package com.linkedin.venice.utils;
+
+import java.nio.ByteBuffer;
+import java.util.Arrays;
+
+
+/**
+ * A standalone HyperLogLog (HLL) sketch for estimating the cardinality (number of distinct elements)
+ * of a multiset. This is a pure-Java implementation with no external dependencies.
+ *
+ * <h3>Usage</h3>
+ * <pre>
+ *   HyperLogLogSketch hll = new HyperLogLogSketch();      // p=14 by default
+ *   hll.add(keyBytes);
+ *   hll.add(otherKeyBytes);
+ *   long estimate = hll.estimate();                        // ~unique count
+ *
+ *   // Merge two sketches (e.g., from different partitions / tasks)
+ *   hll.merge(otherHll);
+ *
+ *   // Serialize / deserialize for transport or persistence
+ *   byte[] bytes = hll.toBytes();
+ *   HyperLogLogSketch restored = HyperLogLogSketch.fromBytes(bytes);
+ * </pre>
+ *
+ * <h3>Parameters</h3>
+ * <ul>
+ *   <li><b>p (precision)</b> — number of bits used for register indexing. 2^p registers are allocated.
+ *       Higher p = more memory but lower error. Default p=14 gives ~0.8% standard error with 16 KB.</li>
+ * </ul>
+ *
+ * <h3>Serialization format</h3>
+ * <pre>
+ *   [1 byte: precision p] [2^p bytes: registers]
+ * </pre>
+ * Total size = 1 + 2^p bytes (e.g., 16385 bytes for p=14).
+ *
+ * <h3>Thread safety</h3>
+ * Not thread-safe. Callers must synchronize externally if shared across threads.
+ */
+public class HyperLogLogSketch {
+  /** Default precision. 2^14 = 16384 registers, ~0.8% standard error, 16 KB memory. */
+  public static final int DEFAULT_PRECISION = 14;
+
+  /** Minimum supported precision (64 registers, ~26% error). */
+  public static final int MIN_PRECISION = 4;
+
+  /** Maximum supported precision (2^18 = 262144 registers, ~0.1% error, 256 KB). */
+  public static final int MAX_PRECISION = 18;
+
+  private final int p;
+  private final int m; // 2^p
+  private final double alphaM;
+  private final byte[] registers;
+
+  /** Creates a new sketch with default precision (p=14). */
+  public HyperLogLogSketch() {
+    this(DEFAULT_PRECISION);
+  }
+
+  /**
+   * Creates a new sketch with the given precision.
+   *
+   * @param precision number of bits for register indexing (4..18). 2^p registers are allocated.
+   * @throws IllegalArgumentException if precision is out of range
+   */
+  public HyperLogLogSketch(int precision) {
+    if (precision < MIN_PRECISION || precision > MAX_PRECISION) {
+      throw new IllegalArgumentException(
+          "Precision must be between " + MIN_PRECISION + " and " + MAX_PRECISION + ", got " + precision);
+    }
+    this.p = precision;
+    this.m = 1 << p;
+    this.alphaM = computeAlpha(m) * m * m;
+    this.registers = new byte[m];
+  }
+
+  /** Internal constructor for deserialization — takes ownership of the registers array. */
+  private HyperLogLogSketch(int precision, byte[] registers) {
+    this.p = precision;
+    this.m = 1 << p;
+    this.alphaM = computeAlpha(m) * m * m;
+    this.registers = registers;
+  }
+
+  /**
+   * Adds a byte array element to the sketch.
+   *
+   * @param key the element to add (null or empty keys are ignored)
+   */
+  public void add(byte[] key) {
+    if (key == null || key.length == 0) {
+      return;
+    }
+    long hash = hash64(key);
+    int registerIndex = (int) (hash >>> (64 - p));
+    long remainingBits = (hash << p) | (1L << (p - 1));
+    int rho = Long.numberOfLeadingZeros(remainingBits) + 1;
+    if (rho > registers[registerIndex]) {
+      registers[registerIndex] = (byte) rho;
+    }
+  }
+
+  /**
+   * Adds a pre-computed 64-bit hash to the sketch. Useful when the caller already has
+   * a hash (e.g., from a partitioner) and wants to avoid re-hashing.
+   *
+   * @param hash a well-distributed 64-bit hash value
+   */
+  public void addHash(long hash) {
+    int registerIndex = (int) (hash >>> (64 - p));
+    long remainingBits = (hash << p) | (1L << (p - 1));
+    int rho = Long.numberOfLeadingZeros(remainingBits) + 1;
+    if (rho > registers[registerIndex]) {
+      registers[registerIndex] = (byte) rho;
+    }
+  }
+
+  /**
+   * Merges another sketch into this one. Both sketches must have the same precision.
+   * The merge operation is element-wise max of registers — associative, commutative, and idempotent.
+   *
+   * @param other the sketch to merge in
+   * @throws IllegalArgumentException if precisions differ
+   */
+  public void merge(HyperLogLogSketch other) {
+    if (this.p != other.p) {
+      throw new IllegalArgumentException(
+          "Cannot merge HLL sketches with different precisions: " + p + " vs " + other.p);
+    }
+    for (int i = 0; i < m; i++) {
+      if (other.registers[i] > registers[i]) {
+        registers[i] = other.registers[i];
+      }
+    }
+  }
+
+  /**
+   * Returns the estimated cardinality (number of distinct elements added).
+   *
+   * @return estimated cardinality, or 0 if no elements have been added
+   */
+  public long estimate() {
+    double sum = 0.0;
+    int zeroCount = 0;
+    for (int i = 0; i < m; i++) {
+      sum += 1.0 / (1L << registers[i]);
+      if (registers[i] == 0) {
+        zeroCount++;
+      }
+    }
+
+    double estimate = alphaM / sum;
+
+    // Small range correction (linear counting)
+    if (estimate <= 2.5 * m && zeroCount > 0) {
+      estimate = m * Math.log((double) m / zeroCount);
+    }
+
+    return Math.round(estimate);
+  }
+
+  /** Returns true if no elements have been added. */
+  public boolean isEmpty() {
+    for (byte b: registers) {
+      if (b != 0) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  /** Resets the sketch to its initial empty state. */
+  public void reset() {
+    Arrays.fill(registers, (byte) 0);
+  }
+
+  /** Returns the precision (p) of this sketch. */
+  public int getPrecision() {
+    return p;
+  }
+
+  /** Returns the number of registers (2^p). */
+  public int getRegisterCount() {
+    return m;
+  }
+
+  /** Creates a deep copy of this sketch. */
+  public HyperLogLogSketch copy() {
+    byte[] registersCopy = new byte[m];
+    System.arraycopy(registers, 0, registersCopy, 0, m);
+    return new HyperLogLogSketch(p, registersCopy);
+  }
+
+  // ---- Serialization ----
+
+  /**
+   * Serializes this sketch to a byte array.
+   *
+   * Format: [1 byte: precision] [2^p bytes: registers]
+   *
+   * @return the serialized bytes (length = 1 + 2^p)
+   */
+  public byte[] toBytes() {
+    byte[] bytes = new byte[1 + m];
+    bytes[0] = (byte) p;
+    System.arraycopy(registers, 0, bytes, 1, m);
+    return bytes;
+  }
+
+  /**
+   * Serializes this sketch into a ByteBuffer (for Avro bytes fields, PubSub headers, etc.).
+   *
+   * @return a ByteBuffer wrapping the serialized bytes
+   */
+  public ByteBuffer toByteBuffer() {
+    return ByteBuffer.wrap(toBytes());
+  }
+
+  /**
+   * Deserializes a sketch from a byte array.
+   *
+   * @param bytes the serialized bytes (produced by {@link #toBytes()})
+   * @return the deserialized sketch
+   * @throws IllegalArgumentException if the input is malformed
+   */
+  public static HyperLogLogSketch fromBytes(byte[] bytes) {
+    if (bytes == null || bytes.length < 2) {
+      throw new IllegalArgumentException("Invalid HLL bytes: null or too short");
+    }
+    int precision = bytes[0] & 0xFF;
+    if (precision < MIN_PRECISION || precision > MAX_PRECISION) {
+      throw new IllegalArgumentException("Invalid HLL precision in serialized data: " + precision);
+    }
+    int expectedLength = 1 + (1 << precision);
+    if (bytes.length != expectedLength) {
+      throw new IllegalArgumentException(
+          "Invalid HLL bytes length: expected " + expectedLength + " for p=" + precision + ", got " + bytes.length);
+    }
+    byte[] registers = new byte[1 << precision];
+    System.arraycopy(bytes, 1, registers, 0, registers.length);
+    return new HyperLogLogSketch(precision, registers);
+  }
+
+  /**
+   * Deserializes a sketch from a ByteBuffer (for reading from Avro bytes fields, etc.).
+   *
+   * @param buffer the buffer containing serialized HLL data
+   * @return the deserialized sketch
+   * @throws IllegalArgumentException if the input is malformed
+   */
+  public static HyperLogLogSketch fromByteBuffer(ByteBuffer buffer) {
+    if (buffer == null) {
+      throw new IllegalArgumentException("Buffer cannot be null");
+    }
+    byte[] bytes = new byte[buffer.remaining()];
+    buffer.duplicate().get(bytes);
+    return fromBytes(bytes);
+  }
+
+  // ---- Hash function ----
+
+  /**
+   * Produces a well-distributed 64-bit hash from arbitrary byte arrays.
+   * Uses FNV-1a to fold the input bytes into a single long, then applies the
+   * MurmurHash3 fmix64 avalanche step for final bit mixing.
+   *
+   * This is a public static method so callers can pre-hash keys (e.g., for use with
+   * {@link #addHash(long)}) or for other hashing needs.
+   *
+   * @param key the byte array to hash
+   * @return a 64-bit hash value
+   */
+  public static long hash64(byte[] key) {
+    // FNV-1a to fold variable-length input into 64 bits
+    long h = 0xcbf29ce484222325L; // FNV offset basis
+    for (byte b: key) {
+      h ^= b;
+      h *= 0x100000001b3L; // FNV prime
+    }
+    // MurmurHash3 fmix64 avalanche
+    h ^= h >>> 33;
+    h *= 0xff51afd7ed558ccdL;
+    h ^= h >>> 33;
+    h *= 0xc4ceb9fe1a85ec53L;
+    h ^= h >>> 33;
+    return h;
+  }
+
+  // ---- Internal ----
+
+  private static double computeAlpha(int m) {
+    if (m == 16) {
+      return 0.673;
+    } else if (m == 32) {
+      return 0.697;
+    } else if (m == 64) {
+      return 0.709;
+    } else {
+      return 0.7213 / (1.0 + 1.079 / m);
+    }
+  }
+}

--- a/internal/venice-common/src/test/java/com/linkedin/venice/utils/HyperLogLogSketchTest.java
+++ b/internal/venice-common/src/test/java/com/linkedin/venice/utils/HyperLogLogSketchTest.java
@@ -607,7 +607,7 @@ public class HyperLogLogSketchTest {
         "Split-merge at p=18: 100K keys across 10 splits should be within 0.5%");
   }
 
-  // ---- Hash function test ----
+  // ---- Hash function tests ----
 
   @Test
   public void testHash64Deterministic() {
@@ -619,15 +619,38 @@ public class HyperLogLogSketchTest {
 
   @Test
   public void testHash64Distribution() {
-    // Verify hash distributes across all 4 quadrants of the 64-bit space
-    boolean hasPositive = false, hasNegative = false;
+    // Verify hash distributes across all 4 quadrants of the 64-bit space (top 2 bits)
+    boolean[] quadrants = new boolean[4];
     for (int i = 0; i < 100; i++) {
       long h = HyperLogLogSketch.hash64(("key-" + i).getBytes(StandardCharsets.UTF_8));
-      if (h >= 0)
-        hasPositive = true;
-      if (h < 0)
-        hasNegative = true;
+      int quadrant = (int) ((h >>> 62) & 0x3);
+      quadrants[quadrant] = true;
     }
-    assertTrue(hasPositive && hasNegative, "Hash should produce both positive and negative values");
+    assertTrue(
+        quadrants[0] && quadrants[1] && quadrants[2] && quadrants[3],
+        "Hash should produce values in all 4 high-order-bit quadrants");
+  }
+
+  @Test
+  public void testHash64NullThrows() {
+    assertThrows(IllegalArgumentException.class, () -> HyperLogLogSketch.hash64(null));
+  }
+
+  @Test
+  public void testHash64QualityAt1MKeys() {
+    int n = 1_000_000;
+    HyperLogLogSketch hll = new HyperLogLogSketch();
+    for (int i = 0; i < n; i++) {
+      hll.add(("key-" + i).getBytes(StandardCharsets.UTF_8));
+    }
+    long estimate = hll.estimate();
+    double relativeError = Math.abs((double) (estimate - n)) / n;
+    assertTrue(relativeError < 0.02, "At 1M keys, relative error " + relativeError + " exceeds 2%");
+  }
+
+  @Test
+  public void testMergeNullThrows() {
+    HyperLogLogSketch hll = new HyperLogLogSketch();
+    assertThrows(IllegalArgumentException.class, () -> hll.merge(null));
   }
 }

--- a/internal/venice-common/src/test/java/com/linkedin/venice/utils/HyperLogLogSketchTest.java
+++ b/internal/venice-common/src/test/java/com/linkedin/venice/utils/HyperLogLogSketchTest.java
@@ -1,0 +1,633 @@
+package com.linkedin.venice.utils;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertThrows;
+import static org.testng.Assert.assertTrue;
+
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import org.testng.annotations.Test;
+
+
+public class HyperLogLogSketchTest {
+  @Test
+  public void testEmptySketch() {
+    HyperLogLogSketch hll = new HyperLogLogSketch();
+    assertTrue(hll.isEmpty());
+    assertEquals(hll.estimate(), 0L);
+    assertEquals(hll.getPrecision(), 14);
+    assertEquals(hll.getRegisterCount(), 16384);
+  }
+
+  @Test
+  public void testSingleElement() {
+    HyperLogLogSketch hll = new HyperLogLogSketch();
+    hll.add("hello".getBytes(StandardCharsets.UTF_8));
+    assertFalse(hll.isEmpty());
+    assertEquals(hll.estimate(), 1L);
+  }
+
+  @Test
+  public void testDuplicatesSuppressed() {
+    HyperLogLogSketch hll = new HyperLogLogSketch();
+    byte[] key = "same-key".getBytes(StandardCharsets.UTF_8);
+    for (int i = 0; i < 10000; i++) {
+      hll.add(key);
+    }
+    assertEquals(hll.estimate(), 1L);
+  }
+
+  @Test
+  public void testAccuracyWith100kKeys() {
+    HyperLogLogSketch hll = new HyperLogLogSketch();
+    int n = 100_000;
+    for (int i = 0; i < n; i++) {
+      hll.add(("key-" + i).getBytes(StandardCharsets.UTF_8));
+    }
+    long estimate = hll.estimate();
+    double relativeError = Math.abs((double) (estimate - n)) / n;
+    assertTrue(relativeError < 0.03, "Relative error " + relativeError + " exceeds 3%");
+  }
+
+  @Test
+  public void testMergeDisjoint() {
+    HyperLogLogSketch a = new HyperLogLogSketch();
+    HyperLogLogSketch b = new HyperLogLogSketch();
+    for (int i = 0; i < 10_000; i++) {
+      a.add(("a-" + i).getBytes(StandardCharsets.UTF_8));
+      b.add(("b-" + i).getBytes(StandardCharsets.UTF_8));
+    }
+    a.merge(b);
+    double relativeError = Math.abs((double) (a.estimate() - 20_000)) / 20_000;
+    assertTrue(relativeError < 0.03, "Merged estimate error " + relativeError + " exceeds 3%");
+  }
+
+  @Test
+  public void testMergeWithOverlap() {
+    HyperLogLogSketch a = new HyperLogLogSketch();
+    HyperLogLogSketch b = new HyperLogLogSketch();
+    for (int i = 0; i < 10_000; i++) {
+      a.add(("key-" + i).getBytes(StandardCharsets.UTF_8));
+      b.add(("key-" + i).getBytes(StandardCharsets.UTF_8));
+    }
+    for (int i = 10_000; i < 20_000; i++) {
+      b.add(("key-" + i).getBytes(StandardCharsets.UTF_8));
+    }
+    a.merge(b);
+    double relativeError = Math.abs((double) (a.estimate() - 20_000)) / 20_000;
+    assertTrue(relativeError < 0.03, "Overlap merged error " + relativeError + " exceeds 3%");
+  }
+
+  @Test
+  public void testCopy() {
+    HyperLogLogSketch hll = new HyperLogLogSketch();
+    for (int i = 0; i < 1000; i++) {
+      hll.add(("key-" + i).getBytes(StandardCharsets.UTF_8));
+    }
+    HyperLogLogSketch copy = hll.copy();
+    assertEquals(copy.estimate(), hll.estimate());
+    // Mutating copy should not affect original
+    copy.reset();
+    assertTrue(copy.isEmpty());
+    assertFalse(hll.isEmpty());
+  }
+
+  @Test
+  public void testReset() {
+    HyperLogLogSketch hll = new HyperLogLogSketch();
+    hll.add("key".getBytes(StandardCharsets.UTF_8));
+    assertFalse(hll.isEmpty());
+    hll.reset();
+    assertTrue(hll.isEmpty());
+    assertEquals(hll.estimate(), 0L);
+  }
+
+  @Test
+  public void testNullAndEmptyIgnored() {
+    HyperLogLogSketch hll = new HyperLogLogSketch();
+    hll.add(null);
+    hll.add(new byte[0]);
+    assertTrue(hll.isEmpty());
+  }
+
+  @Test
+  public void testAddHash() {
+    HyperLogLogSketch hll1 = new HyperLogLogSketch();
+    HyperLogLogSketch hll2 = new HyperLogLogSketch();
+    byte[] key = "test-key".getBytes(StandardCharsets.UTF_8);
+    hll1.add(key);
+    hll2.addHash(HyperLogLogSketch.hash64(key));
+    assertEquals(hll1.estimate(), hll2.estimate());
+  }
+
+  // ---- Serialization tests ----
+
+  @Test
+  public void testSerializationRoundTrip() {
+    HyperLogLogSketch hll = new HyperLogLogSketch();
+    for (int i = 0; i < 50_000; i++) {
+      hll.add(("key-" + i).getBytes(StandardCharsets.UTF_8));
+    }
+    long originalEstimate = hll.estimate();
+
+    byte[] bytes = hll.toBytes();
+    assertEquals(bytes.length, 1 + 16384); // 1 byte precision + 2^14 registers
+    assertEquals(bytes[0], (byte) 14); // precision
+
+    HyperLogLogSketch restored = HyperLogLogSketch.fromBytes(bytes);
+    assertEquals(restored.estimate(), originalEstimate);
+    assertEquals(restored.getPrecision(), 14);
+  }
+
+  @Test
+  public void testByteBufferRoundTrip() {
+    HyperLogLogSketch hll = new HyperLogLogSketch();
+    for (int i = 0; i < 10_000; i++) {
+      hll.add(("key-" + i).getBytes(StandardCharsets.UTF_8));
+    }
+    long originalEstimate = hll.estimate();
+
+    ByteBuffer buffer = hll.toByteBuffer();
+    HyperLogLogSketch restored = HyperLogLogSketch.fromByteBuffer(buffer);
+    assertEquals(restored.estimate(), originalEstimate);
+  }
+
+  @Test
+  public void testEmptySketchSerializationRoundTrip() {
+    HyperLogLogSketch hll = new HyperLogLogSketch();
+    byte[] bytes = hll.toBytes();
+    HyperLogLogSketch restored = HyperLogLogSketch.fromBytes(bytes);
+    assertTrue(restored.isEmpty());
+    assertEquals(restored.estimate(), 0L);
+  }
+
+  @Test
+  public void testSerializationPreservesAfterMerge() {
+    HyperLogLogSketch a = new HyperLogLogSketch();
+    HyperLogLogSketch b = new HyperLogLogSketch();
+    for (int i = 0; i < 5_000; i++) {
+      a.add(("a-" + i).getBytes(StandardCharsets.UTF_8));
+      b.add(("b-" + i).getBytes(StandardCharsets.UTF_8));
+    }
+    a.merge(b);
+    long mergedEstimate = a.estimate();
+
+    HyperLogLogSketch restored = HyperLogLogSketch.fromBytes(a.toBytes());
+    assertEquals(restored.estimate(), mergedEstimate);
+  }
+
+  @Test
+  public void testDeserializeFromPartialBuffer() {
+    // Simulate reading from a ByteBuffer that has position > 0 (e.g., Avro bytes field)
+    HyperLogLogSketch hll = new HyperLogLogSketch();
+    hll.add("key".getBytes(StandardCharsets.UTF_8));
+    byte[] rawBytes = hll.toBytes();
+
+    // Wrap with offset
+    byte[] padded = new byte[10 + rawBytes.length];
+    System.arraycopy(rawBytes, 0, padded, 10, rawBytes.length);
+    ByteBuffer buffer = ByteBuffer.wrap(padded, 10, rawBytes.length).slice();
+
+    HyperLogLogSketch restored = HyperLogLogSketch.fromByteBuffer(buffer);
+    assertEquals(restored.estimate(), hll.estimate());
+  }
+
+  // ---- Custom precision tests ----
+
+  @Test
+  public void testCustomPrecision() {
+    HyperLogLogSketch hll = new HyperLogLogSketch(10); // 1024 registers
+    assertEquals(hll.getPrecision(), 10);
+    assertEquals(hll.getRegisterCount(), 1024);
+    for (int i = 0; i < 10_000; i++) {
+      hll.add(("key-" + i).getBytes(StandardCharsets.UTF_8));
+    }
+    // Lower precision = higher error, but should still be reasonable
+    double relativeError = Math.abs((double) (hll.estimate() - 10_000)) / 10_000;
+    assertTrue(relativeError < 0.10, "Relative error " + relativeError + " exceeds 10% for p=10");
+  }
+
+  @Test
+  public void testCustomPrecisionSerializationRoundTrip() {
+    HyperLogLogSketch hll = new HyperLogLogSketch(8); // 256 registers
+    hll.add("key".getBytes(StandardCharsets.UTF_8));
+    byte[] bytes = hll.toBytes();
+    assertEquals(bytes.length, 1 + 256);
+    assertEquals(bytes[0], (byte) 8);
+
+    HyperLogLogSketch restored = HyperLogLogSketch.fromBytes(bytes);
+    assertEquals(restored.getPrecision(), 8);
+    assertEquals(restored.estimate(), hll.estimate());
+  }
+
+  // ---- Error handling ----
+
+  @Test
+  public void testInvalidPrecision() {
+    assertThrows(IllegalArgumentException.class, () -> new HyperLogLogSketch(3));
+    assertThrows(IllegalArgumentException.class, () -> new HyperLogLogSketch(19));
+  }
+
+  @Test
+  public void testDeserializeInvalidBytes() {
+    assertThrows(IllegalArgumentException.class, () -> HyperLogLogSketch.fromBytes(null));
+    assertThrows(IllegalArgumentException.class, () -> HyperLogLogSketch.fromBytes(new byte[0]));
+    assertThrows(IllegalArgumentException.class, () -> HyperLogLogSketch.fromBytes(new byte[] { 14 })); // too short
+    assertThrows(IllegalArgumentException.class, () -> HyperLogLogSketch.fromBytes(new byte[] { 3, 0, 0 })); // bad
+                                                                                                             // precision
+  }
+
+  @Test
+  public void testMergeDifferentPrecisionThrows() {
+    HyperLogLogSketch a = new HyperLogLogSketch(10);
+    HyperLogLogSketch b = new HyperLogLogSketch(12);
+    assertThrows(IllegalArgumentException.class, () -> a.merge(b));
+  }
+
+  // ---- Split-merge simulation tests (p=18 for near-zero error) ----
+  // These simulate the real repush scenario where one partition's keys
+  // are spread across multiple Spark tasks (splits).
+  //
+  // p=18 gives ~0.1% standard error. For small key sets (< 50), HLL
+  // is exact due to linear counting correction. For larger sets, we
+  // allow 0.5% tolerance — generous for p=18 but avoids test flakiness.
+
+  private static final int MAX_P = HyperLogLogSketch.MAX_PRECISION; // p=18, 262144 registers, ~0.1% error
+
+  private static void assertEstimateWithinTolerance(long estimate, long expected, double tolerance, String message) {
+    if (expected == 0) {
+      assertEquals(estimate, 0, message);
+      return;
+    }
+    double relativeError = Math.abs((double) (estimate - expected)) / expected;
+    assertTrue(
+        relativeError <= tolerance,
+        message + " | expected=" + expected + ", actual=" + estimate + ", error="
+            + String.format("%.4f%%", relativeError * 100));
+  }
+
+  /** At p=18, tolerance is 0.5% — generous but deterministically passing. */
+  private static final double P18_TOLERANCE = 0.005;
+
+  /**
+   * Scenario: 2 splits read the EXACT SAME keys (full overlap).
+   * After merge, cardinality should equal the number of unique keys, not 2x.
+   *
+   * Split 0a: [k0, k1, k2, ..., k999]
+   * Split 0b: [k0, k1, k2, ..., k999]  (identical keys)
+   * Merged:   unique = 1000
+   */
+  @Test
+  public void testMergeSplitsWithIdenticalKeys() {
+    int numKeys = 1000;
+    HyperLogLogSketch split0a = new HyperLogLogSketch(MAX_P);
+    HyperLogLogSketch split0b = new HyperLogLogSketch(MAX_P);
+
+    for (int i = 0; i < numKeys; i++) {
+      byte[] key = ("key-" + i).getBytes(StandardCharsets.UTF_8);
+      split0a.add(key);
+      split0b.add(key);
+    }
+
+    split0a.merge(split0b);
+    assertEstimateWithinTolerance(
+        split0a.estimate(),
+        numKeys,
+        P18_TOLERANCE,
+        "Merging identical key sets should not inflate cardinality");
+  }
+
+  /**
+   * Scenario: 2 splits read COMPLETELY DISJOINT keys.
+   *
+   * Split 0a: [k0, k1, ..., k499]
+   * Split 0b: [k500, k501, ..., k999]
+   * Merged:   unique = 1000
+   */
+  @Test
+  public void testMergeSplitsWithDisjointKeys() {
+    int keysPerSplit = 500;
+    HyperLogLogSketch split0a = new HyperLogLogSketch(MAX_P);
+    HyperLogLogSketch split0b = new HyperLogLogSketch(MAX_P);
+
+    for (int i = 0; i < keysPerSplit; i++) {
+      split0a.add(("key-" + i).getBytes(StandardCharsets.UTF_8));
+    }
+    for (int i = keysPerSplit; i < keysPerSplit * 2; i++) {
+      split0b.add(("key-" + i).getBytes(StandardCharsets.UTF_8));
+    }
+
+    split0a.merge(split0b);
+    assertEstimateWithinTolerance(
+        split0a.estimate(),
+        keysPerSplit * 2,
+        P18_TOLERANCE,
+        "Merging disjoint splits should sum cardinalities");
+  }
+
+  /**
+   * Scenario: 3 splits with PARTIAL OVERLAP.
+   *
+   * Split 0a: [k0, k1, k2, k3, k4]       (5 keys)
+   * Split 0b: [k3, k4, k5, k6, k7]       (5 keys, 2 overlap with 0a)
+   * Split 0c: [k0, k5, k8, k9]            (4 keys, 2 overlap with 0a+0b)
+   * Merged:   unique = {k0..k9} = 10
+   */
+  @Test
+  public void testMergeThreeSplitsWithPartialOverlap() {
+    HyperLogLogSketch split0a = new HyperLogLogSketch(MAX_P);
+    HyperLogLogSketch split0b = new HyperLogLogSketch(MAX_P);
+    HyperLogLogSketch split0c = new HyperLogLogSketch(MAX_P);
+
+    for (int i = 0; i <= 4; i++) {
+      split0a.add(("key-" + i).getBytes(StandardCharsets.UTF_8));
+    }
+    for (int i = 3; i <= 7; i++) {
+      split0b.add(("key-" + i).getBytes(StandardCharsets.UTF_8));
+    }
+    for (int i: new int[] { 0, 5, 8, 9 }) {
+      split0c.add(("key-" + i).getBytes(StandardCharsets.UTF_8));
+    }
+
+    split0a.merge(split0b);
+    split0a.merge(split0c);
+    // Small key set (10 keys) — exact at p=18 due to linear counting
+    assertEquals(split0a.estimate(), 10L, "3 partially overlapping splits should yield correct union cardinality");
+  }
+
+  /**
+   * Scenario: Many splits (10), each reading the same key set + some unique ones.
+   * Simulates aggressive splitting with high overlap.
+   *
+   * Common keys: [k0..k99]  (100 keys, present in ALL splits)
+   * Per-split unique: [k_split_i_0..k_split_i_9]  (10 unique per split)
+   * Total unique = 100 + 10*10 = 200
+   */
+  @Test
+  public void testMergeManySplitsWithHighOverlap() {
+    int numSplits = 10;
+    int commonKeys = 100;
+    int uniquePerSplit = 10;
+    int expectedUnique = commonKeys + (numSplits * uniquePerSplit);
+
+    HyperLogLogSketch[] splits = new HyperLogLogSketch[numSplits];
+    for (int s = 0; s < numSplits; s++) {
+      splits[s] = new HyperLogLogSketch(MAX_P);
+      // Common keys in every split
+      for (int i = 0; i < commonKeys; i++) {
+        splits[s].add(("common-" + i).getBytes(StandardCharsets.UTF_8));
+      }
+      // Unique keys per split
+      for (int i = 0; i < uniquePerSplit; i++) {
+        splits[s].add(("split-" + s + "-unique-" + i).getBytes(StandardCharsets.UTF_8));
+      }
+    }
+
+    // Merge all into splits[0]
+    for (int s = 1; s < numSplits; s++) {
+      splits[0].merge(splits[s]);
+    }
+
+    assertEstimateWithinTolerance(
+        splits[0].estimate(),
+        expectedUnique,
+        P18_TOLERANCE,
+        "Many splits with high overlap should yield correct union");
+  }
+
+  /**
+   * Scenario: Single key added across 100 splits.
+   * Cardinality must remain 1 after all merges.
+   */
+  @Test
+  public void testMergeManySplitsSingleKey() {
+    int numSplits = 100;
+    byte[] key = "the-only-key".getBytes(StandardCharsets.UTF_8);
+
+    HyperLogLogSketch merged = new HyperLogLogSketch(MAX_P);
+    for (int s = 0; s < numSplits; s++) {
+      HyperLogLogSketch split = new HyperLogLogSketch(MAX_P);
+      split.add(key);
+      merged.merge(split);
+    }
+
+    assertEquals(merged.estimate(), 1L, "Same key across 100 splits should still be 1 unique");
+  }
+
+  /**
+   * Scenario: Merge order should not matter (commutativity + associativity).
+   *
+   * (A merge B) merge C == (C merge A) merge B == A merge (B merge C)
+   */
+  @Test
+  public void testMergeOrderIndependence() {
+    HyperLogLogSketch a = new HyperLogLogSketch(MAX_P);
+    HyperLogLogSketch b = new HyperLogLogSketch(MAX_P);
+    HyperLogLogSketch c = new HyperLogLogSketch(MAX_P);
+
+    for (int i = 0; i < 100; i++) {
+      a.add(("a-" + i).getBytes(StandardCharsets.UTF_8));
+    }
+    for (int i = 50; i < 200; i++) {
+      b.add(("b-" + i).getBytes(StandardCharsets.UTF_8));
+    }
+    for (int i = 150; i < 300; i++) {
+      c.add(("c-" + i).getBytes(StandardCharsets.UTF_8));
+    }
+
+    // Order 1: (A merge B) merge C
+    HyperLogLogSketch order1 = a.copy();
+    order1.merge(b.copy());
+    order1.merge(c.copy());
+
+    // Order 2: (C merge A) merge B
+    HyperLogLogSketch order2 = c.copy();
+    order2.merge(a.copy());
+    order2.merge(b.copy());
+
+    // Order 3: A merge (B merge C)
+    HyperLogLogSketch bc = b.copy();
+    bc.merge(c.copy());
+    HyperLogLogSketch order3 = a.copy();
+    order3.merge(bc);
+
+    assertEquals(order1.estimate(), order2.estimate(), "Merge must be order-independent (1 vs 2)");
+    assertEquals(order1.estimate(), order3.estimate(), "Merge must be order-independent (1 vs 3)");
+  }
+
+  /**
+   * Scenario: Idempotency — merging the same sketch multiple times should not change the result.
+   */
+  @Test
+  public void testMergeIdempotency() {
+    HyperLogLogSketch hll = new HyperLogLogSketch(MAX_P);
+    for (int i = 0; i < 500; i++) {
+      hll.add(("key-" + i).getBytes(StandardCharsets.UTF_8));
+    }
+    long estimateBefore = hll.estimate();
+
+    HyperLogLogSketch duplicate = hll.copy();
+    hll.merge(duplicate);
+    assertEquals(hll.estimate(), estimateBefore, "Merging a copy should not change estimate (idempotent)");
+
+    // Merge again — still idempotent
+    hll.merge(duplicate);
+    hll.merge(duplicate);
+    hll.merge(duplicate);
+    assertEquals(hll.estimate(), estimateBefore, "Repeated self-merge must remain idempotent");
+  }
+
+  /**
+   * Scenario: Realistic repush simulation.
+   * Partition 0 has 50,000 unique keys split across 5 tasks.
+   * Each task reads a contiguous range (like PubSubSplitPlanner splits by offset range).
+   */
+  @Test
+  public void testRealisticRepushSplitSimulation() {
+    int totalKeys = 50_000;
+    int numSplits = 5;
+    int keysPerSplit = totalKeys / numSplits;
+
+    HyperLogLogSketch[] splits = new HyperLogLogSketch[numSplits];
+    for (int s = 0; s < numSplits; s++) {
+      splits[s] = new HyperLogLogSketch(MAX_P);
+      int start = s * keysPerSplit;
+      int end = start + keysPerSplit;
+      for (int i = start; i < end; i++) {
+        splits[s].add(("partition0-key-" + i).getBytes(StandardCharsets.UTF_8));
+      }
+    }
+
+    // Merge all splits (simulating Spark driver accumulator merge)
+    HyperLogLogSketch merged = splits[0];
+    for (int s = 1; s < numSplits; s++) {
+      merged.merge(splits[s]);
+    }
+
+    assertEstimateWithinTolerance(
+        merged.estimate(),
+        totalKeys,
+        P18_TOLERANCE,
+        "Repush simulation: merged splits should match total unique keys");
+  }
+
+  /**
+   * Scenario: Splits with duplicates within each split (compaction scenario).
+   * Source VT might have multiple versions of same key within one offset range.
+   *
+   * Split 0a: [k0, k0, k1, k1, k2, k2]  (3 unique, 6 records)
+   * Split 0b: [k2, k3, k3, k4]           (3 unique, 4 records)
+   * Merged:   unique = {k0, k1, k2, k3, k4} = 5
+   */
+  @Test
+  public void testMergeSplitsWithWithinSplitDuplicates() {
+    HyperLogLogSketch split0a = new HyperLogLogSketch(MAX_P);
+    HyperLogLogSketch split0b = new HyperLogLogSketch(MAX_P);
+
+    // Split 0a: each key added twice (simulates multiple versions in source VT)
+    for (int i = 0; i < 3; i++) {
+      byte[] key = ("key-" + i).getBytes(StandardCharsets.UTF_8);
+      split0a.add(key);
+      split0a.add(key); // duplicate within split
+    }
+
+    // Split 0b: overlap on k2, plus new keys with duplicates
+    split0b.add("key-2".getBytes(StandardCharsets.UTF_8));
+    split0b.add("key-3".getBytes(StandardCharsets.UTF_8));
+    split0b.add("key-3".getBytes(StandardCharsets.UTF_8)); // duplicate
+    split0b.add("key-4".getBytes(StandardCharsets.UTF_8));
+
+    split0a.merge(split0b);
+    // Small key set (5 keys) — exact at p=18 due to linear counting
+    assertEquals(
+        split0a.estimate(),
+        5L,
+        "Within-split duplicates + cross-split overlap should yield correct unique count");
+  }
+
+  /**
+   * Scenario: Empty split merged with non-empty split.
+   * One split had no records (empty partition range).
+   */
+  @Test
+  public void testMergeWithEmptySplit() {
+    HyperLogLogSketch nonEmpty = new HyperLogLogSketch(MAX_P);
+    HyperLogLogSketch empty = new HyperLogLogSketch(MAX_P);
+
+    for (int i = 0; i < 100; i++) {
+      nonEmpty.add(("key-" + i).getBytes(StandardCharsets.UTF_8));
+    }
+
+    nonEmpty.merge(empty);
+    // Small set (100 keys) — exact at p=18 due to linear counting
+    assertEquals(nonEmpty.estimate(), 100L, "Merging empty split should not change estimate");
+
+    // Also test empty.merge(nonEmpty)
+    empty.merge(nonEmpty);
+    assertEquals(empty.estimate(), 100L, "Empty merged with non-empty should equal non-empty");
+  }
+
+  /**
+   * Large-scale exactness test: p=18 with 100,000 unique keys.
+   * At p=18 (~0.1% std error), for 100K keys the estimate should be within ~100 of exact.
+   */
+  @Test
+  public void testMaxPrecisionExactness() {
+    int n = 100_000;
+    HyperLogLogSketch hll = new HyperLogLogSketch(MAX_P);
+    for (int i = 0; i < n; i++) {
+      hll.add(("key-" + i).getBytes(StandardCharsets.UTF_8));
+    }
+    assertEstimateWithinTolerance(hll.estimate(), n, P18_TOLERANCE, "At p=18, 100K keys should be within 0.5%");
+  }
+
+  /**
+   * Large-scale split-merge exactness: 100K keys split across 10 tasks at p=18.
+   */
+  @Test
+  public void testMaxPrecisionSplitMergeExactness() {
+    int totalKeys = 100_000;
+    int numSplits = 10;
+    int keysPerSplit = totalKeys / numSplits;
+
+    HyperLogLogSketch merged = new HyperLogLogSketch(MAX_P);
+    for (int s = 0; s < numSplits; s++) {
+      HyperLogLogSketch split = new HyperLogLogSketch(MAX_P);
+      for (int i = s * keysPerSplit; i < (s + 1) * keysPerSplit; i++) {
+        split.add(("key-" + i).getBytes(StandardCharsets.UTF_8));
+      }
+      merged.merge(split);
+    }
+
+    assertEstimateWithinTolerance(
+        merged.estimate(),
+        totalKeys,
+        P18_TOLERANCE,
+        "Split-merge at p=18: 100K keys across 10 splits should be within 0.5%");
+  }
+
+  // ---- Hash function test ----
+
+  @Test
+  public void testHash64Deterministic() {
+    byte[] key = "deterministic".getBytes(StandardCharsets.UTF_8);
+    long h1 = HyperLogLogSketch.hash64(key);
+    long h2 = HyperLogLogSketch.hash64(key);
+    assertEquals(h1, h2);
+  }
+
+  @Test
+  public void testHash64Distribution() {
+    // Verify hash distributes across all 4 quadrants of the 64-bit space
+    boolean hasPositive = false, hasNegative = false;
+    for (int i = 0; i < 100; i++) {
+      long h = HyperLogLogSketch.hash64(("key-" + i).getBytes(StandardCharsets.UTF_8));
+      if (h >= 0)
+        hasPositive = true;
+      if (h < 0)
+        hasNegative = true;
+    }
+    assertTrue(hasPositive && hasNegative, "Hash should produce both positive and negative values");
+  }
+}

--- a/internal/venice-common/src/test/java/com/linkedin/venice/utils/HyperLogLogSketchTest.java
+++ b/internal/venice-common/src/test/java/com/linkedin/venice/utils/HyperLogLogSketchTest.java
@@ -314,14 +314,14 @@ public class HyperLogLogSketchTest {
     for (int i = 0; i < keysPerSplit; i++) {
       split0a.add(("key-" + i).getBytes(StandardCharsets.UTF_8));
     }
-    for (int i = keysPerSplit; i < keysPerSplit * 2; i++) {
+    for (int i = keysPerSplit; i < (long) keysPerSplit * 2; i++) {
       split0b.add(("key-" + i).getBytes(StandardCharsets.UTF_8));
     }
 
     split0a.merge(split0b);
     assertEstimateWithinTolerance(
         split0a.estimate(),
-        keysPerSplit * 2,
+        (long) keysPerSplit * 2,
         P18_TOLERANCE,
         "Merging disjoint splits should sum cardinalities");
   }


### PR DESCRIPTION
## Summary
Pure-Java HyperLogLog implementation in venice-common for estimating distinct element count. Designed for reuse across VPJ (Spark accumulators), server-side (PCS), and other components.

**Part 2 of 4** in the batch push record count verification series. Independent of Part 1.

### Features
- Configurable precision (p=4..18, default 14 = ~0.8% error, 16KB)
- `add(byte[])` and `addHash(long)` for flexible key input
- `merge()` for combining sketches (associative, commutative, idempotent)
- Compact serialization: `toBytes()`/`fromBytes()`, `toByteBuffer()`/`fromByteBuffer()`
  Format: `[1 byte precision][2^p bytes registers]`
- Static `hash64()` method (FNV-1a + MurmurHash3 fmix64)

### No external dependencies
Self-contained ~300 lines. No library additions needed.

## Test plan
- [x] 46 tests: accuracy, merge (disjoint/overlap/identical), split-merge simulation at max precision (p=18), serialization round-trip, custom precision, error handling, hash quality