### PR TITLE
[common][da-vinci] Server-side record count verification at EOP

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/config/VeniceServerConfig.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/config/VeniceServerConfig.java
@@ -75,6 +75,7 @@ import static com.linkedin.venice.ConfigKeys.SERVER_ADAPTIVE_THROTTLER_READ_COMP
 import static com.linkedin.venice.ConfigKeys.SERVER_ADAPTIVE_THROTTLER_SIGNAL_IDLE_THRESHOLD;
 import static com.linkedin.venice.ConfigKeys.SERVER_ADAPTIVE_THROTTLER_SIGNAL_REFRESH_INTERVAL_IN_SECONDS;
 import static com.linkedin.venice.ConfigKeys.SERVER_ADAPTIVE_THROTTLER_SINGLE_GET_LATENCY_THRESHOLD;
+import static com.linkedin.venice.ConfigKeys.SERVER_BATCH_PUSH_RECORD_COUNT_VERIFICATION_ENABLED;
 import static com.linkedin.venice.ConfigKeys.SERVER_BATCH_REPORT_END_OF_INCREMENTAL_PUSH_STATUS_ENABLED;
 import static com.linkedin.venice.ConfigKeys.SERVER_BLOB_TRANSFER_ADAPTIVE_THROTTLER_ENABLED;
 import static com.linkedin.venice.ConfigKeys.SERVER_BLOB_TRANSFER_ADAPTIVE_THROTTLER_UPDATE_PERCENTAGE;
@@ -724,6 +725,7 @@ public class VeniceServerConfig extends VeniceClusterConfig {
   private final boolean ingestionProgressLoggingEnabled;
   private final int partialUpdateLargeResultLogThresholdBytes;
   private final long partialUpdateAmplificationReportIntervalMs;
+  private final boolean batchPushRecordCountVerificationEnabled;
 
   public VeniceServerConfig(VeniceProperties serverProperties) throws ConfigurationException {
     this(serverProperties, Collections.emptyMap());
@@ -1250,6 +1252,9 @@ public class VeniceServerConfig extends VeniceClusterConfig {
         serverProperties.getInt(PARTIAL_UPDATE_LARGE_RESULT_LOG_THRESHOLD_BYTES, 100 * 1024);
     this.partialUpdateAmplificationReportIntervalMs =
         serverProperties.getLong(PARTIAL_UPDATE_AMPLIFICATION_REPORT_INTERVAL_MS, -1);
+    this.batchPushRecordCountVerificationEnabled =
+        serverProperties.getBoolean(SERVER_BATCH_PUSH_RECORD_COUNT_VERIFICATION_ENABLED, true);
+
   }
 
   List<Double> extractThrottleLimitFactorsFor(VeniceProperties serverProperties, String configKey) {
@@ -2267,5 +2272,9 @@ public class VeniceServerConfig extends VeniceClusterConfig {
 
   public long getPartialUpdateAmplificationReportIntervalMs() {
     return partialUpdateAmplificationReportIntervalMs;
+  }
+
+  public boolean isBatchPushRecordCountVerificationEnabled() {
+    return batchPushRecordCountVerificationEnabled;
   }
 }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/PartitionConsumptionState.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/PartitionConsumptionState.java
@@ -561,6 +561,14 @@ public class PartitionConsumptionState {
     return this.offsetRecord;
   }
 
+  public void incrementBatchPushRecordCount() {
+    offsetRecord.setBatchPushRecordCount(offsetRecord.getBatchPushRecordCount() + 1);
+  }
+
+  public long getBatchPushRecordCount() {
+    return offsetRecord.getBatchPushRecordCount();
+  }
+
   public void setDeferredWrite(boolean deferredWrite) {
     this.deferredWrite = deferredWrite;
   }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
@@ -105,6 +105,8 @@ import com.linkedin.venice.pubsub.PubSubUtil;
 import com.linkedin.venice.pubsub.api.DefaultPubSubMessage;
 import com.linkedin.venice.pubsub.api.PubSubMessage;
 import com.linkedin.venice.pubsub.api.PubSubMessageDeserializer;
+import com.linkedin.venice.pubsub.api.PubSubMessageHeader;
+import com.linkedin.venice.pubsub.api.PubSubMessageHeaders;
 import com.linkedin.venice.pubsub.api.PubSubPosition;
 import com.linkedin.venice.pubsub.api.PubSubSymbolicPosition;
 import com.linkedin.venice.pubsub.api.PubSubTopic;
@@ -3802,7 +3804,8 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
       KafkaMessageEnvelope endOfPushKME,
       PubSubPosition offset,
       PartitionConsumptionState partitionConsumptionState,
-      EndOfPush endOfPush) {
+      EndOfPush endOfPush,
+      PubSubMessageHeaders headers) {
 
     // Do not process duplication EOP messages.
     if (partitionConsumptionState.getOffsetRecord().isEndOfPushReceived()) {
@@ -3856,6 +3859,39 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
     if (isDataRecovery && partitionConsumptionState.isBatchOnly()) {
       partitionConsumptionState.setDataRecoveryCompleted(true);
       ingestionNotificationDispatcher.reportDataRecoveryCompleted(partitionConsumptionState);
+    }
+
+    verifyBatchPushRecordCount(partitionConsumptionState, headers);
+  }
+
+  void verifyBatchPushRecordCount(PartitionConsumptionState pcs, PubSubMessageHeaders headers) {
+    if (headers == null) {
+      return;
+    }
+    PubSubMessageHeader header = headers.get(PubSubMessageHeaders.VENICE_PARTITION_RECORD_COUNT_HEADER);
+    if (header == null || header.value() == null || header.value().length != Long.BYTES) {
+      return;
+    }
+    long expectedCount = ByteBuffer.wrap(header.value()).getLong();
+    if (expectedCount == -1) {
+      return;
+    }
+
+    long actualCount = pcs.getBatchPushRecordCount();
+    if (expectedCount != actualCount) {
+      LOGGER.error(
+          "Record count MISMATCH for replica: {}. Expected: {}, Actual: {}.",
+          pcs.getReplicaId(),
+          expectedCount,
+          actualCount);
+      hostLevelIngestionStats.recordBatchPushRecordCountMismatch();
+      if (serverConfig.isBatchPushRecordCountVerificationEnabled()) {
+        throw new VeniceException(
+            "Record count mismatch for " + pcs.getReplicaId() + ". Expected: " + expectedCount + ", Actual: "
+                + actualCount);
+      }
+    } else {
+      LOGGER.debug("Record count verification passed for replica: {}. Count: {}", pcs.getReplicaId(), actualCount);
     }
   }
 
@@ -3931,7 +3967,8 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
       int partition,
       PubSubPosition offset,
       long pubSubMessageTime,
-      PartitionConsumptionState partitionConsumptionState) {
+      PartitionConsumptionState partitionConsumptionState,
+      PubSubMessageHeaders headers) {
     /**
      * If leader consumes control messages from topics other than version topic, it should produce
      * them to version topic; however, START_OF_SEGMENT and END_OF_SEGMENT should not be forwarded
@@ -3956,7 +3993,7 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
         break;
       case END_OF_PUSH:
         EndOfPush endOfPush = (EndOfPush) controlMessage.controlMessageUnion;
-        processEndOfPush(kafkaMessageEnvelope, offset, partitionConsumptionState, endOfPush);
+        processEndOfPush(kafkaMessageEnvelope, offset, partitionConsumptionState, endOfPush, headers);
         if (recordTransformer != null) {
           recordTransformer.onControlMessage(partition, offset, controlMessage, pubSubMessageTime);
         }
@@ -4086,7 +4123,8 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
             consumerRecord.getTopicPartition().getPartitionNumber(),
             consumerRecord.getPosition(),
             consumerRecord.getPubSubMessageTime(),
-            partitionConsumptionState);
+            partitionConsumptionState,
+            consumerRecord.getPubSubMessageHeaders());
         try {
           if (controlMessage.controlMessageType == START_OF_SEGMENT.getValue()) {
             if (Arrays.equals(consumerRecord.getKey().getKey(), KafkaKey.HEART_BEAT.getKey())) {
@@ -4772,6 +4810,13 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
               keyBytes,
               put);
         }
+        // Count logical records for batch push record count verification
+        if (!partitionConsumptionState.getOffsetRecord().isEndOfPushReceived()) {
+          int schemaId = put.getSchemaId();
+          if (schemaId != CHUNK_SCHEMA_ID) {
+            partitionConsumptionState.incrementBatchPushRecordCount();
+          }
+        }
         // grab the positive schema id (actual value schema id) to be used in schema warm-up value schema id.
         // for hybrid use case in read compute store in future we need revisit this as we can have multiple schemas.
         if (writerSchemaId > 0) {
@@ -4834,6 +4879,10 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
           storageEngine.deleteGlobalRtDivMetadata(keyBytes);
         } else {
           deleteFromStorageEngine(producedPartition, keyBytes, delete);
+        }
+        // Count logical records for batch push record count verification
+        if (!partitionConsumptionState.getOffsetRecord().isEndOfPushReceived()) {
+          partitionConsumptionState.incrementBatchPushRecordCount();
         }
         if (recordMetrics) {
           double deleteLatency = LatencyUtils.getElapsedTimeFromNSToMS(startTimeNs);

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
@@ -3878,20 +3878,27 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
     }
 
     long actualCount = pcs.getBatchPushRecordCount();
-    if (expectedCount != actualCount) {
+    // Kafka provides at-least-once delivery: producer retries may cause the server to consume
+    // duplicate records. So actualCount >= expectedCount is normal. Only flag when actualCount
+    // is LESS than expected, which indicates record loss.
+    if (actualCount < expectedCount) {
       LOGGER.error(
-          "Record count MISMATCH for replica: {}. Expected: {}, Actual: {}.",
+          "Record count DEFICIT for replica: {}. Expected at least: {}, Actual: {}.",
           pcs.getReplicaId(),
           expectedCount,
           actualCount);
       hostLevelIngestionStats.recordBatchPushRecordCountMismatch();
       if (serverConfig.isBatchPushRecordCountVerificationEnabled()) {
         throw new VeniceException(
-            "Record count mismatch for " + pcs.getReplicaId() + ". Expected: " + expectedCount + ", Actual: "
+            "Record count deficit for " + pcs.getReplicaId() + ". Expected at least: " + expectedCount + ", Actual: "
                 + actualCount);
       }
     } else {
-      LOGGER.debug("Record count verification passed for replica: {}. Count: {}", pcs.getReplicaId(), actualCount);
+      LOGGER.debug(
+          "Record count verification passed for replica: {}. Expected: {}, Actual: {}",
+          pcs.getReplicaId(),
+          expectedCount,
+          actualCount);
     }
   }
 

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/HostLevelIngestionStats.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/HostLevelIngestionStats.java
@@ -117,6 +117,7 @@ public class HostLevelIngestionStats extends AbstractVeniceStats {
   private final List<Sensor> totalHybridRecordsConsumedByRegionId;
 
   private final Sensor checksumVerificationFailureSensor;
+  private final Sensor batchPushRecordCountMismatchSensor;
 
   /**
    * Measure the number of times replication metadata was found in {@link PartitionConsumptionState#transientRecordMap}
@@ -435,6 +436,12 @@ public class HostLevelIngestionStats extends AbstractVeniceStats {
         "checksum_verification_failure",
         totalStats,
         () -> totalStats.checksumVerificationFailureSensor,
+        new Count());
+
+    this.batchPushRecordCountMismatchSensor = registerPerStoreAndTotalSensor(
+        "batch_push_record_count_mismatch",
+        totalStats,
+        () -> totalStats.batchPushRecordCountMismatchSensor,
         new Count());
 
     this.leaderIngestionValueBytesLookUpLatencySensor = registerPerStoreAndTotalSensor(
@@ -757,6 +764,10 @@ public class HostLevelIngestionStats extends AbstractVeniceStats {
 
   public void recordChecksumVerificationFailure() {
     checksumVerificationFailureSensor.record();
+  }
+
+  public void recordBatchPushRecordCountMismatch() {
+    batchPushRecordCountMismatchSensor.record();
   }
 
   public void recordTimestampRegressionDCRError() {

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/PartitionConsumptionStateTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/PartitionConsumptionStateTest.java
@@ -20,6 +20,7 @@ import com.linkedin.venice.pubsub.api.PubSubPosition;
 import com.linkedin.venice.pubsub.api.PubSubTopicPartition;
 import com.linkedin.venice.schema.rmd.RmdSchemaGenerator;
 import com.linkedin.venice.serialization.avro.AvroProtocolDefinition;
+import com.linkedin.venice.serialization.avro.InternalAvroSpecificSerializer;
 import com.linkedin.venice.writer.LeaderCompleteState;
 import com.linkedin.venice.writer.WriterChunkingHelper;
 import java.nio.ByteBuffer;
@@ -47,8 +48,12 @@ public class PartitionConsumptionStateTest {
 
   @Test
   public void testUpdateChecksum() {
-    PartitionConsumptionState pcs =
-        new PartitionConsumptionState(TOPIC_PARTITION, mock(OffsetRecord.class), pubSubContext, false);
+    PartitionConsumptionState pcs = new PartitionConsumptionState(
+        TOPIC_PARTITION,
+        mock(OffsetRecord.class),
+        pubSubContext,
+        false,
+        Schema.create(Schema.Type.STRING));
     pcs.initializeExpectedChecksum();
     byte[] rmdPayload = new byte[] { 127 };
     byte[] key1 = new byte[] { 1 };
@@ -103,8 +108,12 @@ public class PartitionConsumptionStateTest {
    */
   @Test
   public void testTransientRecordMap() {
-    PartitionConsumptionState pcs =
-        new PartitionConsumptionState(TOPIC_PARTITION, mock(OffsetRecord.class), pubSubContext, false);
+    PartitionConsumptionState pcs = new PartitionConsumptionState(
+        TOPIC_PARTITION,
+        mock(OffsetRecord.class),
+        pubSubContext,
+        false,
+        Schema.create(Schema.Type.STRING));
     assertEquals(pcs.getPubSubContext(), pubSubContext);
     PubSubPosition consumedPosition1Mock = mock(PubSubPosition.class);
     PubSubPosition consumedPosition2Mock = mock(PubSubPosition.class);
@@ -154,8 +163,12 @@ public class PartitionConsumptionStateTest {
 
   @Test
   public void testIsLeaderCompleted() {
-    PartitionConsumptionState pcs =
-        new PartitionConsumptionState(TOPIC_PARTITION, mock(OffsetRecord.class), pubSubContext, false);
+    PartitionConsumptionState pcs = new PartitionConsumptionState(
+        TOPIC_PARTITION,
+        mock(OffsetRecord.class),
+        pubSubContext,
+        false,
+        Schema.create(Schema.Type.STRING));
     // default is LEADER_NOT_COMPLETED
     assertEquals(pcs.getLeaderCompleteState(), LeaderCompleteState.LEADER_NOT_COMPLETED);
     assertFalse(pcs.isLeaderCompleted());
@@ -170,7 +183,12 @@ public class PartitionConsumptionStateTest {
     List<String> pendingReportIncrementalPush = new ArrayList<>();
     OffsetRecord offsetRecord = mock(OffsetRecord.class);
     doReturn(pendingReportIncrementalPush).when(offsetRecord).getPendingReportIncPushVersionList();
-    PartitionConsumptionState pcs = new PartitionConsumptionState(TOPIC_PARTITION, offsetRecord, pubSubContext, false);
+    PartitionConsumptionState pcs = new PartitionConsumptionState(
+        TOPIC_PARTITION,
+        offsetRecord,
+        pubSubContext,
+        false,
+        Schema.create(Schema.Type.STRING));
     pcs.addIncPushVersionToPendingReportList("a");
     Assert.assertEquals(pcs.getPendingReportIncPushVersionList().size(), 1);
     for (int i = 0; i < 50; i++) {
@@ -182,8 +200,12 @@ public class PartitionConsumptionStateTest {
 
   @Test
   public void testDolStateOperations() {
-    PartitionConsumptionState pcs =
-        new PartitionConsumptionState(TOPIC_PARTITION, mock(OffsetRecord.class), pubSubContext, false);
+    PartitionConsumptionState pcs = new PartitionConsumptionState(
+        TOPIC_PARTITION,
+        mock(OffsetRecord.class),
+        pubSubContext,
+        false,
+        Schema.create(Schema.Type.STRING));
 
     // Initially, DoL state should be null
     assertNull(pcs.getDolState());
@@ -203,8 +225,12 @@ public class PartitionConsumptionStateTest {
 
   @Test
   public void testHighestLeadershipTermOperations() {
-    PartitionConsumptionState pcs =
-        new PartitionConsumptionState(TOPIC_PARTITION, mock(OffsetRecord.class), pubSubContext, false);
+    PartitionConsumptionState pcs = new PartitionConsumptionState(
+        TOPIC_PARTITION,
+        mock(OffsetRecord.class),
+        pubSubContext,
+        false,
+        Schema.create(Schema.Type.STRING));
 
     // Initially, highest leadership term should be -1 (default uninitialized value)
     assertEquals(pcs.getHighestLeadershipTerm(), -1L);
@@ -224,8 +250,12 @@ public class PartitionConsumptionStateTest {
 
   @Test
   public void testDolStateWithMultipleUpdates() {
-    PartitionConsumptionState pcs =
-        new PartitionConsumptionState(TOPIC_PARTITION, mock(OffsetRecord.class), pubSubContext, false);
+    PartitionConsumptionState pcs = new PartitionConsumptionState(
+        TOPIC_PARTITION,
+        mock(OffsetRecord.class),
+        pubSubContext,
+        false,
+        Schema.create(Schema.Type.STRING));
 
     // Set first DolStamp
     DolStamp dolStamp1 = new DolStamp(1L, "host-1");
@@ -451,5 +481,24 @@ public class PartitionConsumptionStateTest {
     PartitionConsumptionState pcs = new PartitionConsumptionState(TOPIC_PARTITION, offsetRecord, pubSubContext, false);
     pcs.initializeUniqueKeyCountHll(lgK);
     return pcs;
+  public void testBatchPushRecordCountIncrement() {
+    InternalAvroSpecificSerializer<com.linkedin.venice.kafka.protocol.state.PartitionState> serializer =
+        AvroProtocolDefinition.PARTITION_STATE.getSerializer();
+    OffsetRecord offsetRecord = new OffsetRecord(serializer, pubSubContext);
+    PartitionConsumptionState pcs = new PartitionConsumptionState(TOPIC_PARTITION, offsetRecord, pubSubContext, false);
+
+    // Initial count should be 0
+    assertEquals(pcs.getBatchPushRecordCount(), 0L);
+
+    // Increment once
+    pcs.incrementBatchPushRecordCount();
+    assertEquals(pcs.getBatchPushRecordCount(), 1L);
+
+    // Increment multiple times
+    for (int i = 0; i < 99; i++) {
+      pcs.incrementBatchPushRecordCount();
+    }
+    assertEquals(pcs.getBatchPushRecordCount(), 100L);
+
   }
 }

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/PartitionConsumptionStateTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/PartitionConsumptionStateTest.java
@@ -48,12 +48,8 @@ public class PartitionConsumptionStateTest {
 
   @Test
   public void testUpdateChecksum() {
-    PartitionConsumptionState pcs = new PartitionConsumptionState(
-        TOPIC_PARTITION,
-        mock(OffsetRecord.class),
-        pubSubContext,
-        false,
-        Schema.create(Schema.Type.STRING));
+    PartitionConsumptionState pcs =
+        new PartitionConsumptionState(TOPIC_PARTITION, mock(OffsetRecord.class), pubSubContext, false);
     pcs.initializeExpectedChecksum();
     byte[] rmdPayload = new byte[] { 127 };
     byte[] key1 = new byte[] { 1 };
@@ -108,12 +104,8 @@ public class PartitionConsumptionStateTest {
    */
   @Test
   public void testTransientRecordMap() {
-    PartitionConsumptionState pcs = new PartitionConsumptionState(
-        TOPIC_PARTITION,
-        mock(OffsetRecord.class),
-        pubSubContext,
-        false,
-        Schema.create(Schema.Type.STRING));
+    PartitionConsumptionState pcs =
+        new PartitionConsumptionState(TOPIC_PARTITION, mock(OffsetRecord.class), pubSubContext, false);
     assertEquals(pcs.getPubSubContext(), pubSubContext);
     PubSubPosition consumedPosition1Mock = mock(PubSubPosition.class);
     PubSubPosition consumedPosition2Mock = mock(PubSubPosition.class);
@@ -163,12 +155,8 @@ public class PartitionConsumptionStateTest {
 
   @Test
   public void testIsLeaderCompleted() {
-    PartitionConsumptionState pcs = new PartitionConsumptionState(
-        TOPIC_PARTITION,
-        mock(OffsetRecord.class),
-        pubSubContext,
-        false,
-        Schema.create(Schema.Type.STRING));
+    PartitionConsumptionState pcs =
+        new PartitionConsumptionState(TOPIC_PARTITION, mock(OffsetRecord.class), pubSubContext, false);
     // default is LEADER_NOT_COMPLETED
     assertEquals(pcs.getLeaderCompleteState(), LeaderCompleteState.LEADER_NOT_COMPLETED);
     assertFalse(pcs.isLeaderCompleted());
@@ -183,12 +171,7 @@ public class PartitionConsumptionStateTest {
     List<String> pendingReportIncrementalPush = new ArrayList<>();
     OffsetRecord offsetRecord = mock(OffsetRecord.class);
     doReturn(pendingReportIncrementalPush).when(offsetRecord).getPendingReportIncPushVersionList();
-    PartitionConsumptionState pcs = new PartitionConsumptionState(
-        TOPIC_PARTITION,
-        offsetRecord,
-        pubSubContext,
-        false,
-        Schema.create(Schema.Type.STRING));
+    PartitionConsumptionState pcs = new PartitionConsumptionState(TOPIC_PARTITION, offsetRecord, pubSubContext, false);
     pcs.addIncPushVersionToPendingReportList("a");
     Assert.assertEquals(pcs.getPendingReportIncPushVersionList().size(), 1);
     for (int i = 0; i < 50; i++) {
@@ -200,12 +183,8 @@ public class PartitionConsumptionStateTest {
 
   @Test
   public void testDolStateOperations() {
-    PartitionConsumptionState pcs = new PartitionConsumptionState(
-        TOPIC_PARTITION,
-        mock(OffsetRecord.class),
-        pubSubContext,
-        false,
-        Schema.create(Schema.Type.STRING));
+    PartitionConsumptionState pcs =
+        new PartitionConsumptionState(TOPIC_PARTITION, mock(OffsetRecord.class), pubSubContext, false);
 
     // Initially, DoL state should be null
     assertNull(pcs.getDolState());
@@ -225,12 +204,8 @@ public class PartitionConsumptionStateTest {
 
   @Test
   public void testHighestLeadershipTermOperations() {
-    PartitionConsumptionState pcs = new PartitionConsumptionState(
-        TOPIC_PARTITION,
-        mock(OffsetRecord.class),
-        pubSubContext,
-        false,
-        Schema.create(Schema.Type.STRING));
+    PartitionConsumptionState pcs =
+        new PartitionConsumptionState(TOPIC_PARTITION, mock(OffsetRecord.class), pubSubContext, false);
 
     // Initially, highest leadership term should be -1 (default uninitialized value)
     assertEquals(pcs.getHighestLeadershipTerm(), -1L);
@@ -250,12 +225,8 @@ public class PartitionConsumptionStateTest {
 
   @Test
   public void testDolStateWithMultipleUpdates() {
-    PartitionConsumptionState pcs = new PartitionConsumptionState(
-        TOPIC_PARTITION,
-        mock(OffsetRecord.class),
-        pubSubContext,
-        false,
-        Schema.create(Schema.Type.STRING));
+    PartitionConsumptionState pcs =
+        new PartitionConsumptionState(TOPIC_PARTITION, mock(OffsetRecord.class), pubSubContext, false);
 
     // Set first DolStamp
     DolStamp dolStamp1 = new DolStamp(1L, "host-1");

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTaskRecordCountTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTaskRecordCountTest.java
@@ -121,8 +121,23 @@ public class StoreIngestionTaskRecordCountTest {
     verify(hostLevelIngestionStats).recordBatchPushRecordCountMismatch();
   }
 
-  @Test(expectedExceptions = VeniceException.class, expectedExceptionsMessageRegExp = ".*Record count mismatch.*")
-  public void testRecordCountMismatchWithVerificationEnabled() {
+  /**
+   * At-least-once: actual > expected is OK (Kafka duplicates). Only actual < expected is a deficit.
+   */
+  @Test
+  public void testRecordCountAboveExpectedIsAccepted() {
+    PartitionConsumptionState pcs = mock(PartitionConsumptionState.class);
+    when(pcs.getBatchPushRecordCount()).thenReturn(150L);
+    when(pcs.getReplicaId()).thenReturn("test-replica");
+    when(serverConfig.isBatchPushRecordCountVerificationEnabled()).thenReturn(true);
+    PubSubMessageHeaders headers = createHeadersWithRecordCount(100);
+
+    task.verifyBatchPushRecordCount(pcs, headers);
+    verify(hostLevelIngestionStats, never()).recordBatchPushRecordCountMismatch();
+  }
+
+  @Test(expectedExceptions = VeniceException.class, expectedExceptionsMessageRegExp = ".*Record count deficit.*")
+  public void testRecordCountDeficitWithVerificationEnabled() {
     PartitionConsumptionState pcs = mock(PartitionConsumptionState.class);
     when(pcs.getBatchPushRecordCount()).thenReturn(50L);
     when(pcs.getReplicaId()).thenReturn("test-replica");

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTaskRecordCountTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTaskRecordCountTest.java
@@ -1,0 +1,145 @@
+package com.linkedin.davinci.kafka.consumer;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.linkedin.davinci.config.VeniceServerConfig;
+import com.linkedin.davinci.stats.HostLevelIngestionStats;
+import com.linkedin.venice.exceptions.VeniceException;
+import com.linkedin.venice.pubsub.api.PubSubMessageHeader;
+import com.linkedin.venice.pubsub.api.PubSubMessageHeaders;
+import java.lang.reflect.Field;
+import java.nio.ByteBuffer;
+import java.security.AccessController;
+import java.security.PrivilegedAction;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+
+public class StoreIngestionTaskRecordCountTest {
+  private StoreIngestionTask task;
+  private HostLevelIngestionStats hostLevelIngestionStats;
+  private VeniceServerConfig serverConfig;
+
+  @BeforeMethod
+  public void setUp() {
+    hostLevelIngestionStats = mock(HostLevelIngestionStats.class);
+    serverConfig = mock(VeniceServerConfig.class);
+
+    task = mock(StoreIngestionTask.class, org.mockito.Mockito.CALLS_REAL_METHODS);
+    AccessController.doPrivileged((PrivilegedAction<Void>) () -> {
+      try {
+        Field statsField = StoreIngestionTask.class.getDeclaredField("hostLevelIngestionStats");
+        statsField.setAccessible(true);
+        statsField.set(task, hostLevelIngestionStats);
+
+        Field configField = StoreIngestionTask.class.getDeclaredField("serverConfig");
+        configField.setAccessible(true);
+        configField.set(task, serverConfig);
+      } catch (Exception e) {
+        throw new RuntimeException(e);
+      }
+      return null;
+    });
+  }
+
+  private PubSubMessageHeaders createHeadersWithRecordCount(long count) {
+    PubSubMessageHeaders headers = new PubSubMessageHeaders();
+    byte[] countBytes = ByteBuffer.allocate(Long.BYTES).putLong(count).array();
+    headers.add(PubSubMessageHeaders.VENICE_PARTITION_RECORD_COUNT_HEADER, countBytes);
+    return headers;
+  }
+
+  @Test
+  public void testNullHeaders() {
+    PartitionConsumptionState pcs = mock(PartitionConsumptionState.class);
+    task.verifyBatchPushRecordCount(pcs, null);
+    verify(pcs, never()).getBatchPushRecordCount();
+    verify(hostLevelIngestionStats, never()).recordBatchPushRecordCountMismatch();
+  }
+
+  @Test
+  public void testMissingRecordCountHeader() {
+    PartitionConsumptionState pcs = mock(PartitionConsumptionState.class);
+    PubSubMessageHeaders headers = new PubSubMessageHeaders();
+    task.verifyBatchPushRecordCount(pcs, headers);
+    verify(pcs, never()).getBatchPushRecordCount();
+    verify(hostLevelIngestionStats, never()).recordBatchPushRecordCountMismatch();
+  }
+
+  @Test
+  public void testNullHeaderValue() {
+    PartitionConsumptionState pcs = mock(PartitionConsumptionState.class);
+    PubSubMessageHeaders headers = new PubSubMessageHeaders();
+    headers.add(new PubSubMessageHeader(PubSubMessageHeaders.VENICE_PARTITION_RECORD_COUNT_HEADER, null));
+    task.verifyBatchPushRecordCount(pcs, headers);
+    verify(pcs, never()).getBatchPushRecordCount();
+    verify(hostLevelIngestionStats, never()).recordBatchPushRecordCountMismatch();
+  }
+
+  @Test
+  public void testWrongHeaderSize() {
+    PartitionConsumptionState pcs = mock(PartitionConsumptionState.class);
+    PubSubMessageHeaders headers = new PubSubMessageHeaders();
+    headers.add(PubSubMessageHeaders.VENICE_PARTITION_RECORD_COUNT_HEADER, new byte[] { 1, 2, 3, 4 });
+    task.verifyBatchPushRecordCount(pcs, headers);
+    verify(pcs, never()).getBatchPushRecordCount();
+    verify(hostLevelIngestionStats, never()).recordBatchPushRecordCountMismatch();
+  }
+
+  @Test
+  public void testSentinelValueMinusOne() {
+    PartitionConsumptionState pcs = mock(PartitionConsumptionState.class);
+    PubSubMessageHeaders headers = createHeadersWithRecordCount(-1);
+    task.verifyBatchPushRecordCount(pcs, headers);
+    verify(pcs, never()).getBatchPushRecordCount();
+    verify(hostLevelIngestionStats, never()).recordBatchPushRecordCountMismatch();
+  }
+
+  @Test
+  public void testRecordCountMatch() {
+    PartitionConsumptionState pcs = mock(PartitionConsumptionState.class);
+    when(pcs.getBatchPushRecordCount()).thenReturn(100L);
+    when(pcs.getReplicaId()).thenReturn("test-replica");
+    PubSubMessageHeaders headers = createHeadersWithRecordCount(100);
+
+    task.verifyBatchPushRecordCount(pcs, headers);
+    verify(hostLevelIngestionStats, never()).recordBatchPushRecordCountMismatch();
+  }
+
+  @Test
+  public void testRecordCountMismatchWithVerificationDisabled() {
+    PartitionConsumptionState pcs = mock(PartitionConsumptionState.class);
+    when(pcs.getBatchPushRecordCount()).thenReturn(50L);
+    when(pcs.getReplicaId()).thenReturn("test-replica");
+    when(serverConfig.isBatchPushRecordCountVerificationEnabled()).thenReturn(false);
+    PubSubMessageHeaders headers = createHeadersWithRecordCount(100);
+
+    task.verifyBatchPushRecordCount(pcs, headers);
+    verify(hostLevelIngestionStats).recordBatchPushRecordCountMismatch();
+  }
+
+  @Test(expectedExceptions = VeniceException.class, expectedExceptionsMessageRegExp = ".*Record count mismatch.*")
+  public void testRecordCountMismatchWithVerificationEnabled() {
+    PartitionConsumptionState pcs = mock(PartitionConsumptionState.class);
+    when(pcs.getBatchPushRecordCount()).thenReturn(50L);
+    when(pcs.getReplicaId()).thenReturn("test-replica");
+    when(serverConfig.isBatchPushRecordCountVerificationEnabled()).thenReturn(true);
+    PubSubMessageHeaders headers = createHeadersWithRecordCount(100);
+
+    task.verifyBatchPushRecordCount(pcs, headers);
+  }
+
+  @Test
+  public void testRecordCountMatchWithZero() {
+    PartitionConsumptionState pcs = mock(PartitionConsumptionState.class);
+    when(pcs.getBatchPushRecordCount()).thenReturn(0L);
+    when(pcs.getReplicaId()).thenReturn("test-replica");
+    PubSubMessageHeaders headers = createHeadersWithRecordCount(0);
+
+    task.verifyBatchPushRecordCount(pcs, headers);
+    verify(hostLevelIngestionStats, never()).recordBatchPushRecordCountMismatch();
+  }
+}

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/VenicePushJob.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/VenicePushJob.java
@@ -917,7 +917,8 @@ public class VenicePushJob implements AutoCloseable {
 
         if (!pushJobSetting.suppressEndOfPushMessage) {
           if (pushJobSetting.sendControlMessagesDirectly) {
-            getVeniceWriter(pushJobSetting).broadcastEndOfPush(Collections.emptyMap());
+            Map<Integer, Long> partitionRecordCounts = getPerPartitionRecordCounts();
+            getVeniceWriter(pushJobSetting).broadcastEndOfPush(Collections.emptyMap(), partitionRecordCounts);
           } else {
             controllerClient.writeEndOfPush(pushJobSetting.storeName, pushJobSetting.version);
           }
@@ -1740,6 +1741,17 @@ public class VenicePushJob implements AutoCloseable {
   @VisibleForTesting
   void updatePushJobDetailsWithCheckpoint(PushJobCheckpoints checkpoint) {
     pushJobDetails.pushJobLatestCheckpoint = checkpoint.getValue();
+  }
+
+  private Map<Integer, Long> getPerPartitionRecordCounts() {
+    if (dataWriterComputeJob == null) {
+      return Collections.emptyMap();
+    }
+    DataWriterTaskTracker tracker = dataWriterComputeJob.getTaskTracker();
+    if (tracker == null) {
+      return Collections.emptyMap();
+    }
+    return tracker.getPerPartitionRecordCounts();
   }
 
   private void updatePushJobDetailsWithDataWriterTracker() {

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/mapreduce/counter/MRJobCounterHelper.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/mapreduce/counter/MRJobCounterHelper.java
@@ -1,5 +1,7 @@
 package com.linkedin.venice.hadoop.mapreduce.counter;
 
+import java.util.HashMap;
+import java.util.Map;
 import org.apache.hadoop.mapred.Counters;
 import org.apache.hadoop.mapred.Reporter;
 
@@ -38,6 +40,8 @@ public class MRJobCounterHelper {
       "Mapper spray all partitions triggered count";
   private static final String COUNTER_GROUP_KAFKA_INPUT_FORMAT = "KafkaInputFormat";
   private static final String COUNTER_PUT_OR_DELETE_RECORDS = "put or delete records";
+
+  private static final String PER_PARTITION_RECORD_COUNT_GROUP = "Per Partition Record Count";
 
   private static final String REPUSH_TTL_FILTERED_COUNT = "Repush ttl filtered count";
 
@@ -278,6 +282,29 @@ public class MRJobCounterHelper {
 
   public static void incrRepushTtlFilterCount(Reporter reporter, long amount) {
     incrAmountWithGroupCounterName(reporter, REPUSH_TTL_FILTER_COUNT_GROUP_COUNTER_NAME, amount);
+  }
+
+  public static void incrPartitionRecordCount(Reporter reporter, int partition, long amount) {
+    if (reporter == null || reporter.equals(Reporter.NULL) || amount == 0) {
+      return;
+    }
+    Counters.Counter counter = reporter.getCounter(PER_PARTITION_RECORD_COUNT_GROUP, String.valueOf(partition));
+    if (counter != null) {
+      counter.increment(amount);
+    }
+  }
+
+  public static Map<Integer, Long> getPerPartitionRecordCounts(Counters counters) {
+    Map<Integer, Long> result = new HashMap<>();
+    for (Counters.Group group: counters) {
+      if (group.getName().equals(PER_PARTITION_RECORD_COUNT_GROUP)) {
+        for (Counters.Counter counter: group) {
+          result.put(Integer.parseInt(counter.getName()), counter.getValue());
+        }
+        break;
+      }
+    }
+    return result;
   }
 
   /**

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/mapreduce/counter/MRJobCounterHelper.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/mapreduce/counter/MRJobCounterHelper.java
@@ -1,5 +1,6 @@
 package com.linkedin.venice.hadoop.mapreduce.counter;
 
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import org.apache.hadoop.mapred.Counters;
@@ -295,6 +296,9 @@ public class MRJobCounterHelper {
   }
 
   public static Map<Integer, Long> getPerPartitionRecordCounts(Counters counters) {
+    if (counters == null) {
+      return Collections.emptyMap();
+    }
     Map<Integer, Long> result = new HashMap<>();
     for (Counters.Group group: counters) {
       if (group.getName().equals(PER_PARTITION_RECORD_COUNT_GROUP)) {

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/mapreduce/datawriter/task/CounterBackedMapReduceDataWriterTaskTracker.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/mapreduce/datawriter/task/CounterBackedMapReduceDataWriterTaskTracker.java
@@ -2,6 +2,7 @@ package com.linkedin.venice.hadoop.mapreduce.datawriter.task;
 
 import com.linkedin.venice.hadoop.mapreduce.counter.MRJobCounterHelper;
 import com.linkedin.venice.hadoop.task.datawriter.DataWriterTaskTracker;
+import java.util.Map;
 import org.apache.hadoop.mapred.Counters;
 
 
@@ -88,5 +89,10 @@ public class CounterBackedMapReduceDataWriterTaskTracker implements DataWriterTa
   @Override
   public long getIncrementalPushThrottledTimeMs() {
     return MRJobCounterHelper.getIncrementalPushThrottleTimeMs(counters);
+  }
+
+  @Override
+  public Map<Integer, Long> getPerPartitionRecordCounts() {
+    return MRJobCounterHelper.getPerPartitionRecordCounts(this.counters);
   }
 }

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/mapreduce/datawriter/task/ReporterBackedMapReduceDataWriterTaskTracker.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/mapreduce/datawriter/task/ReporterBackedMapReduceDataWriterTaskTracker.java
@@ -89,6 +89,11 @@ public class ReporterBackedMapReduceDataWriterTaskTracker implements DataWriterT
   }
 
   @Override
+  public void trackRecordSentToPubSubForPartition(int partition) {
+    MRJobCounterHelper.incrPartitionRecordCount(this.reporter, partition, 1);
+  }
+
+  @Override
   public void trackDuplicateKeyWithDistinctValue(int count) {
     MRJobCounterHelper.incrDuplicateKeyWithDistinctValue(reporter, count);
   }

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/task/datawriter/AbstractPartitionWriter.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/task/datawriter/AbstractPartitionWriter.java
@@ -498,6 +498,7 @@ public abstract class AbstractPartitionWriter extends AbstractDataWriterTask imp
     messageSent++;
     telemetry();
     dataWriterTaskTracker.trackRecordSentToPubSub();
+    dataWriterTaskTracker.trackRecordSentToPubSubForPartition(getTaskId());
   }
 
   /**

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/task/datawriter/DataWriterTaskTracker.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/task/datawriter/DataWriterTaskTracker.java
@@ -1,6 +1,8 @@
 package com.linkedin.venice.hadoop.task.datawriter;
 
 import com.linkedin.venice.hadoop.task.TaskTracker;
+import java.util.Collections;
+import java.util.Map;
 
 
 /**
@@ -45,6 +47,9 @@ public interface DataWriterTaskTracker extends TaskTracker {
   }
 
   default void trackRecordSentToPubSub() {
+  }
+
+  default void trackRecordSentToPubSubForPartition(int partition) {
   }
 
   default void trackDuplicateKeyWithDistinctValue(int count) {
@@ -131,5 +136,9 @@ public interface DataWriterTaskTracker extends TaskTracker {
 
   default long getIncrementalPushThrottledTimeMs() {
     return 0;
+  }
+
+  default Map<Integer, Long> getPerPartitionRecordCounts() {
+    return Collections.emptyMap();
   }
 }

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/spark/datawriter/task/DataWriterAccumulators.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/spark/datawriter/task/DataWriterAccumulators.java
@@ -30,6 +30,7 @@ public class DataWriterAccumulators implements Serializable {
   public final LongAccumulator repushTtlFilteredRecordCounter;
   public final LongAccumulator incrementalPushThrottleTimeCounter;
   public final LongAccumulator totalDuplicateKeyCounter;
+  public final MapLongAccumulator perPartitionRecordCounts;
 
   public DataWriterAccumulators(SparkSession session) {
     SparkContext sparkContext = session.sparkContext();
@@ -52,5 +53,7 @@ public class DataWriterAccumulators implements Serializable {
     duplicateKeyWithIdenticalValueCounter = sparkContext.longAccumulator("Duplicate Key With Identical Value");
     duplicateKeyWithDistinctValueCounter = sparkContext.longAccumulator("Duplicate Key With Distinct Value");
     totalDuplicateKeyCounter = sparkContext.longAccumulator("Total Duplicate Keys (Compaction)");
+    this.perPartitionRecordCounts = new MapLongAccumulator();
+    sparkContext.register(perPartitionRecordCounts, "perPartitionRecordCounts");
   }
 }

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/spark/datawriter/task/DataWriterAccumulators.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/spark/datawriter/task/DataWriterAccumulators.java
@@ -53,7 +53,7 @@ public class DataWriterAccumulators implements Serializable {
     duplicateKeyWithIdenticalValueCounter = sparkContext.longAccumulator("Duplicate Key With Identical Value");
     duplicateKeyWithDistinctValueCounter = sparkContext.longAccumulator("Duplicate Key With Distinct Value");
     totalDuplicateKeyCounter = sparkContext.longAccumulator("Total Duplicate Keys (Compaction)");
-    this.perPartitionRecordCounts = new MapLongAccumulator();
-    sparkContext.register(perPartitionRecordCounts, "perPartitionRecordCounts");
+    perPartitionRecordCounts = new MapLongAccumulator();
+    sparkContext.register(perPartitionRecordCounts, "Per Partition Record Counts");
   }
 }

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/spark/datawriter/task/DataWriterAccumulators.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/spark/datawriter/task/DataWriterAccumulators.java
@@ -53,7 +53,6 @@ public class DataWriterAccumulators implements Serializable {
     duplicateKeyWithIdenticalValueCounter = sparkContext.longAccumulator("Duplicate Key With Identical Value");
     duplicateKeyWithDistinctValueCounter = sparkContext.longAccumulator("Duplicate Key With Distinct Value");
     totalDuplicateKeyCounter = sparkContext.longAccumulator("Total Duplicate Keys (Compaction)");
-    perPartitionRecordCounts = new MapLongAccumulator();
-    sparkContext.register(perPartitionRecordCounts, "Per Partition Record Counts");
+    perPartitionRecordCounts = new MapLongAccumulator(sparkContext, "Per Partition Record Counts");
   }
 }

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/spark/datawriter/task/MapLongAccumulator.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/spark/datawriter/task/MapLongAccumulator.java
@@ -50,8 +50,11 @@ public class MapLongAccumulator extends AccumulatorV2<scala.Tuple2<Integer, Long
 
   @Override
   public void merge(AccumulatorV2<scala.Tuple2<Integer, Long>, Map<Integer, Long>> other) {
-    MapLongAccumulator otherAcc = (MapLongAccumulator) other;
-    otherAcc.map.forEach((key, value) -> map.merge(key, value, Long::sum));
+    if (!(other instanceof MapLongAccumulator)) {
+      throw new IllegalArgumentException(
+          "Cannot merge " + other.getClass().getSimpleName() + " into MapLongAccumulator");
+    }
+    ((MapLongAccumulator) other).map.forEach((key, value) -> map.merge(key, value, Long::sum));
   }
 
   @Override

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/spark/datawriter/task/MapLongAccumulator.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/spark/datawriter/task/MapLongAccumulator.java
@@ -1,8 +1,8 @@
 package com.linkedin.venice.spark.datawriter.task;
 
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
 import org.apache.spark.SparkContext;
 import org.apache.spark.util.AccumulatorV2;
 
@@ -10,11 +10,14 @@ import org.apache.spark.util.AccumulatorV2;
 /**
  * A Spark accumulator that maintains per-key long counters, merging by summing values per key.
  * Used for tracking per-partition record counts during Spark-based push jobs.
+ *
+ * Thread safety: Spark creates a fresh copy per task via {@link #copy()}, so each task's
+ * instance is single-threaded. A plain HashMap suffices — no concurrent access occurs.
  */
 public class MapLongAccumulator extends AccumulatorV2<scala.Tuple2<Integer, Long>, Map<Integer, Long>> {
   private static final long serialVersionUID = 1L;
 
-  private final ConcurrentHashMap<Integer, Long> map = new ConcurrentHashMap<>();
+  private final HashMap<Integer, Long> map = new HashMap<>();
 
   MapLongAccumulator() {
   }

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/spark/datawriter/task/MapLongAccumulator.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/spark/datawriter/task/MapLongAccumulator.java
@@ -1,0 +1,50 @@
+package com.linkedin.venice.spark.datawriter.task;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import org.apache.spark.util.AccumulatorV2;
+
+
+/**
+ * A Spark accumulator that maintains per-key long counters, merging by summing values per key.
+ * Used for tracking per-partition record counts during Spark-based push jobs.
+ */
+public class MapLongAccumulator extends AccumulatorV2<scala.Tuple2<Integer, Long>, Map<Integer, Long>> {
+  private static final long serialVersionUID = 1L;
+
+  private final ConcurrentHashMap<Integer, Long> map = new ConcurrentHashMap<>();
+
+  @Override
+  public boolean isZero() {
+    return map.isEmpty();
+  }
+
+  @Override
+  public AccumulatorV2<scala.Tuple2<Integer, Long>, Map<Integer, Long>> copy() {
+    MapLongAccumulator newAcc = new MapLongAccumulator();
+    newAcc.map.putAll(this.map);
+    return newAcc;
+  }
+
+  @Override
+  public void reset() {
+    map.clear();
+  }
+
+  @Override
+  public void add(scala.Tuple2<Integer, Long> v) {
+    map.merge(v._1(), v._2(), Long::sum);
+  }
+
+  @Override
+  public void merge(AccumulatorV2<scala.Tuple2<Integer, Long>, Map<Integer, Long>> other) {
+    MapLongAccumulator otherAcc = (MapLongAccumulator) other;
+    otherAcc.map.forEach((key, value) -> map.merge(key, value, Long::sum));
+  }
+
+  @Override
+  public Map<Integer, Long> value() {
+    return Collections.unmodifiableMap(map);
+  }
+}

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/spark/datawriter/task/MapLongAccumulator.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/spark/datawriter/task/MapLongAccumulator.java
@@ -3,6 +3,7 @@ package com.linkedin.venice.spark.datawriter.task;
 import java.util.Collections;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
+import org.apache.spark.SparkContext;
 import org.apache.spark.util.AccumulatorV2;
 
 
@@ -14,6 +15,13 @@ public class MapLongAccumulator extends AccumulatorV2<scala.Tuple2<Integer, Long
   private static final long serialVersionUID = 1L;
 
   private final ConcurrentHashMap<Integer, Long> map = new ConcurrentHashMap<>();
+
+  MapLongAccumulator() {
+  }
+
+  MapLongAccumulator(SparkContext sparkContext, String name) {
+    sparkContext.register(this, name);
+  }
 
   @Override
   public boolean isZero() {

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/spark/datawriter/task/SparkDataWriterTaskTracker.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/spark/datawriter/task/SparkDataWriterTaskTracker.java
@@ -1,6 +1,7 @@
 package com.linkedin.venice.spark.datawriter.task;
 
 import com.linkedin.venice.hadoop.task.datawriter.DataWriterTaskTracker;
+import java.util.Map;
 
 
 /**
@@ -71,6 +72,11 @@ public class SparkDataWriterTaskTracker implements DataWriterTaskTracker {
   @Override
   public void trackRecordSentToPubSub() {
     accumulators.outputRecordCounter.add(1);
+  }
+
+  @Override
+  public void trackRecordSentToPubSubForPartition(int partition) {
+    accumulators.perPartitionRecordCounts.add(new scala.Tuple2<>(partition, 1L));
   }
 
   @Override
@@ -171,5 +177,10 @@ public class SparkDataWriterTaskTracker implements DataWriterTaskTracker {
   @Override
   public long getIncrementalPushThrottledTimeMs() {
     return accumulators.incrementalPushThrottleTimeCounter.value();
+  }
+
+  @Override
+  public Map<Integer, Long> getPerPartitionRecordCounts() {
+    return accumulators.perPartitionRecordCounts.value();
   }
 }

--- a/clients/venice-push-job/src/test/java/com/linkedin/venice/hadoop/mapreduce/counter/MRJobCounterHelperTest.java
+++ b/clients/venice-push-job/src/test/java/com/linkedin/venice/hadoop/mapreduce/counter/MRJobCounterHelperTest.java
@@ -1,0 +1,54 @@
+package com.linkedin.venice.hadoop.mapreduce.counter;
+
+import java.util.Map;
+import org.apache.hadoop.mapred.Counters;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+
+public class MRJobCounterHelperTest {
+  @Test
+  public void testGetPerPartitionRecordCounts() {
+    Counters counters = new Counters();
+    // Simulate per-partition record counts by incrementing counters in the expected group
+    Counters.Counter counter0 = counters.findCounter("Per Partition Record Count", "0");
+    counter0.increment(100);
+    Counters.Counter counter1 = counters.findCounter("Per Partition Record Count", "1");
+    counter1.increment(200);
+    Counters.Counter counter5 = counters.findCounter("Per Partition Record Count", "5");
+    counter5.increment(50);
+
+    Map<Integer, Long> result = MRJobCounterHelper.getPerPartitionRecordCounts(counters);
+    Assert.assertEquals(result.size(), 3);
+    Assert.assertEquals((long) result.get(0), 100L);
+    Assert.assertEquals((long) result.get(1), 200L);
+    Assert.assertEquals((long) result.get(5), 50L);
+  }
+
+  @Test
+  public void testGetPerPartitionRecordCountsEmpty() {
+    Counters counters = new Counters();
+    Map<Integer, Long> result = MRJobCounterHelper.getPerPartitionRecordCounts(counters);
+    Assert.assertTrue(result.isEmpty());
+  }
+
+  @Test
+  public void testIncrPartitionRecordCountWithMockReporter() {
+    // Use a Counters-based approach to verify the increment path indirectly:
+    // Increment via Reporter, then read back via Counters
+    Counters counters = new Counters();
+    Counters.Counter counter = counters.findCounter("Per Partition Record Count", "3");
+    counter.increment(10);
+    counter.increment(5);
+
+    Map<Integer, Long> result = MRJobCounterHelper.getPerPartitionRecordCounts(counters);
+    Assert.assertEquals(result.size(), 1);
+    Assert.assertEquals((long) result.get(3), 15L);
+  }
+
+  @Test
+  public void testIncrPartitionRecordCountWithNullReporter() {
+    // Passing null reporter should not throw
+    MRJobCounterHelper.incrPartitionRecordCount(null, 0, 1);
+  }
+}

--- a/clients/venice-push-job/src/test/java/com/linkedin/venice/hadoop/mapreduce/counter/MRJobCounterHelperTest.java
+++ b/clients/venice-push-job/src/test/java/com/linkedin/venice/hadoop/mapreduce/counter/MRJobCounterHelperTest.java
@@ -33,9 +33,7 @@ public class MRJobCounterHelperTest {
   }
 
   @Test
-  public void testIncrPartitionRecordCountWithMockReporter() {
-    // Use a Counters-based approach to verify the increment path indirectly:
-    // Increment via Reporter, then read back via Counters
+  public void testGetPerPartitionRecordCountsWithMultipleIncrements() {
     Counters counters = new Counters();
     Counters.Counter counter = counters.findCounter("Per Partition Record Count", "3");
     counter.increment(10);

--- a/clients/venice-push-job/src/test/java/com/linkedin/venice/spark/datawriter/task/MapLongAccumulatorTest.java
+++ b/clients/venice-push-job/src/test/java/com/linkedin/venice/spark/datawriter/task/MapLongAccumulatorTest.java
@@ -1,0 +1,85 @@
+package com.linkedin.venice.spark.datawriter.task;
+
+import java.util.Map;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+
+public class MapLongAccumulatorTest {
+  @Test
+  public void testIsZero() {
+    MapLongAccumulator accumulator = new MapLongAccumulator();
+    Assert.assertTrue(accumulator.isZero());
+
+    accumulator.add(new scala.Tuple2<>(0, 10L));
+    Assert.assertFalse(accumulator.isZero());
+  }
+
+  @Test
+  public void testAddAndValue() {
+    MapLongAccumulator accumulator = new MapLongAccumulator();
+    accumulator.add(new scala.Tuple2<>(0, 10L));
+    accumulator.add(new scala.Tuple2<>(1, 20L));
+    accumulator.add(new scala.Tuple2<>(0, 5L));
+
+    Map<Integer, Long> value = accumulator.value();
+    Assert.assertEquals(value.size(), 2);
+    Assert.assertEquals((long) value.get(0), 15L);
+    Assert.assertEquals((long) value.get(1), 20L);
+  }
+
+  @Test
+  public void testMerge() {
+    MapLongAccumulator accA = new MapLongAccumulator();
+    accA.add(new scala.Tuple2<>(0, 10L));
+    accA.add(new scala.Tuple2<>(1, 20L));
+
+    MapLongAccumulator accB = new MapLongAccumulator();
+    accB.add(new scala.Tuple2<>(1, 5L));
+    accB.add(new scala.Tuple2<>(2, 30L));
+
+    accA.merge(accB);
+
+    Map<Integer, Long> value = accA.value();
+    Assert.assertEquals(value.size(), 3);
+    Assert.assertEquals((long) value.get(0), 10L);
+    Assert.assertEquals((long) value.get(1), 25L);
+    Assert.assertEquals((long) value.get(2), 30L);
+  }
+
+  @Test
+  public void testReset() {
+    MapLongAccumulator accumulator = new MapLongAccumulator();
+    accumulator.add(new scala.Tuple2<>(0, 10L));
+    accumulator.add(new scala.Tuple2<>(1, 20L));
+    Assert.assertFalse(accumulator.isZero());
+
+    accumulator.reset();
+    Assert.assertTrue(accumulator.isZero());
+    Assert.assertTrue(accumulator.value().isEmpty());
+  }
+
+  @Test
+  public void testCopy() {
+    MapLongAccumulator original = new MapLongAccumulator();
+    original.add(new scala.Tuple2<>(0, 10L));
+    original.add(new scala.Tuple2<>(1, 20L));
+
+    MapLongAccumulator copy = (MapLongAccumulator) original.copy();
+
+    Assert.assertNotNull(copy);
+    Assert.assertEquals(copy.value(), original.value());
+
+    // Verify independence: modifying copy should not affect original
+    copy.add(new scala.Tuple2<>(0, 5L));
+    Assert.assertEquals((long) original.value().get(0), 10L);
+    Assert.assertEquals((long) copy.value().get(0), 15L);
+  }
+
+  @Test(expectedExceptions = UnsupportedOperationException.class)
+  public void testValueIsUnmodifiable() {
+    MapLongAccumulator accumulator = new MapLongAccumulator();
+    accumulator.add(new scala.Tuple2<>(0, 10L));
+    accumulator.value().put(1, 20L);
+  }
+}

--- a/internal/venice-common/src/main/java/com/linkedin/venice/ConfigKeys.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/ConfigKeys.java
@@ -1182,6 +1182,14 @@ public class ConfigKeys {
       "server.batch.report.end.of.incremental.push.status.enabled";
 
   /**
+   * Whether to strictly enforce batch push record count verification by failing ingestion when a mismatch is detected.
+   * Verification itself still occurs whenever the EOP header is present; when this flag is false,
+   * mismatches are only logged and recorded as metrics instead of failing ingestion. Default: true.
+   */
+  public static final String SERVER_BATCH_PUSH_RECORD_COUNT_VERIFICATION_ENABLED =
+      "server.batch.push.record.count.verification.enabled";
+
+  /**
    * This config dictates where the server should write the end of incremental push status.
    */
   public static final String SERVER_INCREMENTAL_PUSH_STATUS_WRITE_MODE = "server.incremental.push.status.write.mode";

--- a/internal/venice-common/src/main/java/com/linkedin/venice/offsets/OffsetRecord.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/offsets/OffsetRecord.java
@@ -110,6 +110,7 @@ public class OffsetRecord {
     emptyPartitionState.lastConsumedVersionTopicPubSubPosition = PubSubSymbolicPosition.EARLIEST.toWireFormatBuffer();
     emptyPartitionState.upstreamVersionTopicPubSubPosition = PubSubSymbolicPosition.EARLIEST.toWireFormatBuffer();
     emptyPartitionState.lastConsumedVersionTopicPubSubPosition = PubSubSymbolicPosition.EARLIEST.toWireFormatBuffer();
+    emptyPartitionState.batchPushRecordCount = 0;
     return emptyPartitionState;
   }
 
@@ -381,6 +382,14 @@ public class OffsetRecord {
 
   public PubSubPosition getLatestConsumedVtPosition() {
     return pubSubPositionDeserializer.toPosition(this.partitionState.getLastConsumedVersionTopicPubSubPosition());
+  }
+
+  public long getBatchPushRecordCount() {
+    return this.partitionState.batchPushRecordCount;
+  }
+
+  public void setBatchPushRecordCount(long count) {
+    this.partitionState.batchPushRecordCount = count;
   }
 
   public Map<String, IncrementalPushReplicaStatus> getTrackingIncrementalPushStatus() {

--- a/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/api/PubSubMessageHeaders.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/api/PubSubMessageHeaders.java
@@ -33,6 +33,8 @@ public class PubSubMessageHeaders implements Measurable, Iterable<PubSubMessageH
    * further processing. In the example, this chunk should be sent to view1's partition 0 and view2's partitions 1 & 2.
    */
   public static final String VENICE_VIEW_PARTITIONS_MAP_HEADER = "vpm";
+  /** Header to carry per-partition record count for batch push record count verification */
+  public static final String VENICE_PARTITION_RECORD_COUNT_HEADER = "prc";
 
   public PubSubMessageHeaders add(PubSubMessageHeader header) {
     headers.put(header.key(), header);

--- a/internal/venice-common/src/main/java/com/linkedin/venice/writer/VeniceWriter.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/writer/VeniceWriter.java
@@ -2277,23 +2277,7 @@ public class VeniceWriter<K, V, U> extends AbstractVeniceWriter<K, V, U> {
       Map<String, String> debugInfo,
       PubSubProducerCallback callback,
       LeaderMetadataWrapper leaderMetadataWrapper) {
-    // Work around until we upgrade to a more modern Avro version which supports overriding the
-    // String implementation.
-    controlMessage.debugInfo = getDebugInfo(debugInfo);
-    boolean isEndOfSegment = ControlMessageType.valueOf(controlMessage).equals(ControlMessageType.END_OF_SEGMENT);
-    synchronized (this.partitionLocks[partition]) {
-      return sendMessage(
-          this::getControlMessageKey,
-          MessageType.CONTROL_MESSAGE,
-          controlMessage,
-          isEndOfSegment,
-          partition,
-          callback,
-          true,
-          leaderMetadataWrapper,
-          VENICE_DEFAULT_LOGICAL_TS,
-          EmptyPubSubMessageHeaders.SINGLETON);
-    }
+    return sendControlMessage(controlMessage, partition, debugInfo, callback, leaderMetadataWrapper, null);
   }
 
   public CompletableFuture<PubSubProduceResult> sendControlMessage(
@@ -2303,6 +2287,8 @@ public class VeniceWriter<K, V, U> extends AbstractVeniceWriter<K, V, U> {
       PubSubProducerCallback callback,
       LeaderMetadataWrapper leaderMetadataWrapper,
       PubSubMessageHeaders headers) {
+    // Work around until we upgrade to a more modern Avro version which supports overriding the
+    // String implementation.
     controlMessage.debugInfo = getDebugInfo(debugInfo);
     boolean isEndOfSegment = ControlMessageType.valueOf(controlMessage).equals(ControlMessageType.END_OF_SEGMENT);
     synchronized (this.partitionLocks[partition]) {

--- a/internal/venice-common/src/main/java/com/linkedin/venice/writer/VeniceWriter.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/writer/VeniceWriter.java
@@ -1441,7 +1441,17 @@ public class VeniceWriter<K, V, U> extends AbstractVeniceWriter<K, V, U> {
    * @param debugInfo arbitrary key/value pairs of information that will be propagated alongside the control message.
    */
   public void broadcastEndOfPush(Map<String, String> debugInfo) {
-    broadcastControlMessage(getEmptyControlMessage(ControlMessageType.END_OF_PUSH), debugInfo);
+    broadcastEndOfPush(debugInfo, null);
+  }
+
+  /**
+   * Broadcast end of push with per-partition record counts for verification.
+   *
+   * @param debugInfo arbitrary key/value pairs of information that will be propagated alongside the control message.
+   * @param partitionRecordCounts per-partition record counts. If null or empty, no record count header is sent.
+   */
+  public void broadcastEndOfPush(Map<String, String> debugInfo, Map<Integer, Long> partitionRecordCounts) {
+    broadcastControlMessage(getEmptyControlMessage(ControlMessageType.END_OF_PUSH), debugInfo, partitionRecordCounts);
     endAllSegments(true);
   }
 
@@ -2110,6 +2120,38 @@ public class VeniceWriter<K, V, U> extends AbstractVeniceWriter<K, V, U> {
     return partitionWriteFuture;
   }
 
+  /**
+   * Broadcast a control message with per-partition record counts embedded as PubSub headers.
+   */
+  private List<CompletableFuture<PubSubProduceResult>> broadcastControlMessage(
+      ControlMessage controlMessage,
+      Map<String, String> debugInfo,
+      Map<Integer, Long> partitionRecordCounts) {
+    if (partitionRecordCounts == null || partitionRecordCounts.isEmpty()) {
+      return broadcastControlMessage(controlMessage, debugInfo);
+    }
+    List<CompletableFuture<PubSubProduceResult>> partitionWriteFuture = new ArrayList<>();
+    for (int partition = 0; partition < numberOfPartitions; partition++) {
+      Long recordCount = partitionRecordCounts.get(partition);
+      if (recordCount != null) {
+        PubSubMessageHeaders headers = new PubSubMessageHeaders();
+        headers.add(
+            PubSubMessageHeaders.VENICE_PARTITION_RECORD_COUNT_HEADER,
+            ByteBuffer.allocate(Long.BYTES).putLong(recordCount).array());
+        partitionWriteFuture.add(
+            sendControlMessage(controlMessage, partition, debugInfo, null, DEFAULT_LEADER_METADATA_WRAPPER, headers));
+      } else {
+        partitionWriteFuture
+            .add(sendControlMessage(controlMessage, partition, debugInfo, null, DEFAULT_LEADER_METADATA_WRAPPER));
+      }
+    }
+    logger.info(
+        "Successfully broadcast {} Control Message with record counts for topic: {}",
+        ControlMessageType.valueOf(controlMessage),
+        topicName);
+    return partitionWriteFuture;
+  }
+
   private Map<CharSequence, CharSequence> getDebugInfo(Map<String, String> debugInfoToAdd) {
     if (debugInfoToAdd == null || debugInfoToAdd.isEmpty()) {
       return defaultDebugInfo;
@@ -2251,6 +2293,30 @@ public class VeniceWriter<K, V, U> extends AbstractVeniceWriter<K, V, U> {
           leaderMetadataWrapper,
           VENICE_DEFAULT_LOGICAL_TS,
           EmptyPubSubMessageHeaders.SINGLETON);
+    }
+  }
+
+  public CompletableFuture<PubSubProduceResult> sendControlMessage(
+      ControlMessage controlMessage,
+      int partition,
+      Map<String, String> debugInfo,
+      PubSubProducerCallback callback,
+      LeaderMetadataWrapper leaderMetadataWrapper,
+      PubSubMessageHeaders headers) {
+    controlMessage.debugInfo = getDebugInfo(debugInfo);
+    boolean isEndOfSegment = ControlMessageType.valueOf(controlMessage).equals(ControlMessageType.END_OF_SEGMENT);
+    synchronized (this.partitionLocks[partition]) {
+      return sendMessage(
+          this::getControlMessageKey,
+          MessageType.CONTROL_MESSAGE,
+          controlMessage,
+          isEndOfSegment,
+          partition,
+          callback,
+          true,
+          leaderMetadataWrapper,
+          VENICE_DEFAULT_LOGICAL_TS,
+          headers == null ? EmptyPubSubMessageHeaders.SINGLETON : headers);
     }
   }
 

--- a/internal/venice-common/src/main/resources/avro/PartitionState/v21/PartitionState.avsc
+++ b/internal/venice-common/src/main/resources/avro/PartitionState/v21/PartitionState.avsc
@@ -49,7 +49,7 @@
               "type": "string"
             }, {
               "name": "error",
-              "doc": "The first error founded during in`gestion",
+              "doc": "The first error found during ingestion",
               "type": ["null", "string"],
               "default": null
             }
@@ -307,10 +307,10 @@
       "default": {}
     },
     {
-      "name": "uniqueIngestedKeyCountHllSketch",
-      "doc": "Serialized HyperLogLog sketch (Apache DataSketches) tracking unique keys ingested in this partition. Null if HLL tracking is not enabled or not yet initialized.",
-      "type": ["null", "bytes"],
-      "default": null
+      "name": "batchPushRecordCount",
+      "doc": "The number of logical data records consumed during batch push, used for record count verification at EOP.",
+      "type": "long",
+      "default": 0
     }
   ]
 }

--- a/internal/venice-common/src/test/java/com/linkedin/venice/offsets/TestOffsetRecord.java
+++ b/internal/venice-common/src/test/java/com/linkedin/venice/offsets/TestOffsetRecord.java
@@ -155,6 +155,45 @@ public class TestOffsetRecord {
         { "consistency_fallback_empty", EMPTY_BUF, 1500L, 1500L, true }, };
   }
 
+  @Test
+  public void testBatchPushRecordCountGetterSetter() {
+    OffsetRecord record = new OffsetRecord(
+        AvroProtocolDefinition.PARTITION_STATE.getSerializer(),
+        DEFAULT_PUBSUB_CONTEXT_FOR_UNIT_TESTING);
+    record.setBatchPushRecordCount(42L);
+    assertEquals(record.getBatchPushRecordCount(), 42L);
+
+    record.setBatchPushRecordCount(Long.MAX_VALUE);
+    assertEquals(record.getBatchPushRecordCount(), Long.MAX_VALUE);
+
+    record.setBatchPushRecordCount(0L);
+    assertEquals(record.getBatchPushRecordCount(), 0L);
+  }
+
+  @Test
+  public void testBatchPushRecordCountDefaultValue() {
+    OffsetRecord record = new OffsetRecord(
+        AvroProtocolDefinition.PARTITION_STATE.getSerializer(),
+        DEFAULT_PUBSUB_CONTEXT_FOR_UNIT_TESTING);
+    assertEquals(record.getBatchPushRecordCount(), 0L);
+  }
+
+  @Test
+  public void testBatchPushRecordCountSerialization() {
+    OffsetRecord original = new OffsetRecord(
+        AvroProtocolDefinition.PARTITION_STATE.getSerializer(),
+        DEFAULT_PUBSUB_CONTEXT_FOR_UNIT_TESTING);
+    original.setBatchPushRecordCount(12345L);
+
+    byte[] serialized = original.toBytes();
+    OffsetRecord deserialized = new OffsetRecord(
+        serialized,
+        AvroProtocolDefinition.PARTITION_STATE.getSerializer(),
+        DEFAULT_PUBSUB_CONTEXT_FOR_UNIT_TESTING);
+
+    assertEquals(deserialized.getBatchPushRecordCount(), 12345L);
+  }
+
   @Test(dataProvider = "dpDeserialize", timeOut = 10_000)
   public void testDeserializePositionWithOffsetFallback(
       String name,

--- a/internal/venice-common/src/test/java/com/linkedin/venice/writer/VeniceWriterUnitTest.java
+++ b/internal/venice-common/src/test/java/com/linkedin/venice/writer/VeniceWriterUnitTest.java
@@ -76,7 +76,9 @@ import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Properties;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
@@ -1345,5 +1347,113 @@ public class VeniceWriterUnitTest {
       // expected
     }
     verify(mockHook, never()).onBeforeProduce(any(VeniceWriterHook.OperationType.class), anyInt(), anyInt());
+  }
+
+  @Test(timeOut = TIMEOUT)
+  public void testBroadcastEndOfPushWithPartitionRecordCounts() {
+    PubSubProducerAdapter mockedProducer = mock(PubSubProducerAdapter.class);
+    when(mockedProducer.sendMessage(any(), any(), any(), any(), any(), any()))
+        .thenReturn(CompletableFuture.completedFuture(null));
+
+    int partitionCount = 3;
+    String testTopic = "test_v1";
+    VeniceWriterOptions veniceWriterOptions =
+        new VeniceWriterOptions.Builder(testTopic).setPartitioner(new DefaultVenicePartitioner())
+            .setPartitionCount(partitionCount)
+            .build();
+    VeniceWriter<KafkaKey, byte[], byte[]> writer =
+        new VeniceWriter(veniceWriterOptions, VeniceProperties.empty(), mockedProducer);
+
+    Map<Integer, Long> partitionRecordCounts = new HashMap<>();
+    partitionRecordCounts.put(0, 100L);
+    partitionRecordCounts.put(1, 200L);
+    partitionRecordCounts.put(2, 300L);
+
+    writer.broadcastEndOfPush(new HashMap<>(), partitionRecordCounts);
+
+    // Capture all sendMessage calls (SOS + EOP + EOS for each partition)
+    ArgumentCaptor<Integer> partitionCaptor = ArgumentCaptor.forClass(Integer.class);
+    ArgumentCaptor<KafkaMessageEnvelope> kmeCaptor = ArgumentCaptor.forClass(KafkaMessageEnvelope.class);
+    ArgumentCaptor<PubSubMessageHeaders> headersCaptor = ArgumentCaptor.forClass(PubSubMessageHeaders.class);
+    verify(mockedProducer, atLeast(6)).sendMessage(
+        anyString(),
+        partitionCaptor.capture(),
+        any(),
+        kmeCaptor.capture(),
+        headersCaptor.capture(),
+        any());
+
+    // Filter only EOP messages and verify they carry the correct prc header
+    List<Integer> allPartitions = partitionCaptor.getAllValues();
+    List<KafkaMessageEnvelope> allKmes = kmeCaptor.getAllValues();
+    List<PubSubMessageHeaders> allHeaders = headersCaptor.getAllValues();
+
+    Map<Integer, Long> observedCounts = new HashMap<>();
+    for (int i = 0; i < allKmes.size(); i++) {
+      KafkaMessageEnvelope kme = allKmes.get(i);
+      if (kme.messageType == MessageType.CONTROL_MESSAGE.getValue()) {
+        ControlMessage cm = (ControlMessage) kme.payloadUnion;
+        if (ControlMessageType.valueOf(cm) == ControlMessageType.END_OF_PUSH) {
+          int partition = allPartitions.get(i);
+          PubSubMessageHeaders headers = allHeaders.get(i);
+          PubSubMessageHeader prcHeader = headers.get(PubSubMessageHeaders.VENICE_PARTITION_RECORD_COUNT_HEADER);
+          Assert.assertNotNull(prcHeader, "Partition " + partition + " should have prc header");
+          long actualCount = ByteBuffer.wrap(prcHeader.value()).getLong();
+          observedCounts.put(partition, actualCount);
+        }
+      }
+    }
+
+    assertEquals(observedCounts.size(), 3, "Should have EOP for all 3 partitions");
+    for (Map.Entry<Integer, Long> entry: partitionRecordCounts.entrySet()) {
+      assertEquals(
+          observedCounts.get(entry.getKey()),
+          entry.getValue(),
+          "Record count mismatch for partition " + entry.getKey());
+    }
+  }
+
+  @Test(timeOut = TIMEOUT)
+  public void testBroadcastEndOfPushWithNullCounts() {
+    PubSubProducerAdapter mockedProducer = mock(PubSubProducerAdapter.class);
+    when(mockedProducer.sendMessage(any(), any(), any(), any(), any(), any()))
+        .thenReturn(CompletableFuture.completedFuture(null));
+
+    int partitionCount = 2;
+    String testTopic = "test_v2";
+    VeniceWriterOptions veniceWriterOptions =
+        new VeniceWriterOptions.Builder(testTopic).setPartitioner(new DefaultVenicePartitioner())
+            .setPartitionCount(partitionCount)
+            .build();
+    VeniceWriter<KafkaKey, byte[], byte[]> writer =
+        new VeniceWriter(veniceWriterOptions, VeniceProperties.empty(), mockedProducer);
+
+    // Call with null partitionRecordCounts for backward compatibility
+    writer.broadcastEndOfPush(new HashMap<>(), null);
+
+    // Capture all sendMessage calls
+    ArgumentCaptor<PubSubMessageHeaders> headersCaptor = ArgumentCaptor.forClass(PubSubMessageHeaders.class);
+    ArgumentCaptor<KafkaMessageEnvelope> kmeCaptor = ArgumentCaptor.forClass(KafkaMessageEnvelope.class);
+    verify(mockedProducer, atLeast(4))
+        .sendMessage(anyString(), any(), any(), kmeCaptor.capture(), headersCaptor.capture(), any());
+
+    // Filter only EOP messages and verify they have no prc header
+    List<KafkaMessageEnvelope> allKmes = kmeCaptor.getAllValues();
+    List<PubSubMessageHeaders> allHeaders = headersCaptor.getAllValues();
+
+    int eopCount = 0;
+    for (int i = 0; i < allKmes.size(); i++) {
+      KafkaMessageEnvelope kme = allKmes.get(i);
+      if (kme.messageType == MessageType.CONTROL_MESSAGE.getValue()) {
+        ControlMessage cm = (ControlMessage) kme.payloadUnion;
+        if (ControlMessageType.valueOf(cm) == ControlMessageType.END_OF_PUSH) {
+          eopCount++;
+          PubSubMessageHeaders headers = allHeaders.get(i);
+          PubSubMessageHeader prcHeader = headers.get(PubSubMessageHeaders.VENICE_PARTITION_RECORD_COUNT_HEADER);
+          Assert.assertNull(prcHeader, "EOP with null counts should not have prc header");
+        }
+      }
+    }
+    assertEquals(eopCount, partitionCount, "Should have EOP for all partitions");
   }
 }

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestBatchPushRecordCountVerification.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestBatchPushRecordCountVerification.java
@@ -1,0 +1,139 @@
+package com.linkedin.venice.endToEnd;
+
+import static com.linkedin.venice.ConfigKeys.SERVER_BATCH_PUSH_RECORD_COUNT_VERIFICATION_ENABLED;
+import static com.linkedin.venice.utils.IntegrationTestPushUtils.createStoreForJob;
+import static com.linkedin.venice.utils.IntegrationTestPushUtils.defaultVPJProps;
+import static com.linkedin.venice.utils.TestWriteUtils.getTempDataDirectory;
+import static com.linkedin.venice.utils.TestWriteUtils.writeSimpleAvroFileWithCustomSize;
+import static com.linkedin.venice.utils.TestWriteUtils.writeSimpleAvroFileWithStringToStringSchema;
+import static com.linkedin.venice.vpj.VenicePushJobConstants.SEND_CONTROL_MESSAGES_DIRECTLY;
+
+import com.linkedin.venice.client.store.AvroGenericStoreClient;
+import com.linkedin.venice.client.store.ClientConfig;
+import com.linkedin.venice.client.store.ClientFactory;
+import com.linkedin.venice.controllerapi.UpdateStoreQueryParams;
+import com.linkedin.venice.integration.utils.ServiceFactory;
+import com.linkedin.venice.integration.utils.VeniceClusterCreateOptions;
+import com.linkedin.venice.integration.utils.VeniceClusterWrapper;
+import com.linkedin.venice.utils.IntegrationTestPushUtils;
+import com.linkedin.venice.utils.KeyAndValueSchemas;
+import com.linkedin.venice.utils.TestUtils;
+import com.linkedin.venice.utils.Time;
+import com.linkedin.venice.utils.Utils;
+import java.io.File;
+import java.util.Properties;
+import java.util.concurrent.TimeUnit;
+import org.apache.avro.Schema;
+import org.testng.Assert;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+
+/**
+ * End-to-end integration test for batch push record count verification.
+ *
+ * This test creates a cluster with {@code SERVER_BATCH_PUSH_RECORD_COUNT_VERIFICATION_ENABLED=true},
+ * runs a batch push with {@code SEND_CONTROL_MESSAGES_DIRECTLY=true} (which embeds per-partition
+ * record counts as PubSub headers on EOP), and verifies the push completes successfully.
+ * If the record counts don't match, the server would throw a VeniceException and the push would fail.
+ */
+@Test(singleThreaded = true)
+public class TestBatchPushRecordCountVerification {
+  private static final int TEST_TIMEOUT = 120 * Time.MS_PER_SECOND;
+  private VeniceClusterWrapper veniceCluster;
+
+  @BeforeClass(alwaysRun = true)
+  public void setUp() {
+    VeniceClusterCreateOptions options =
+        new VeniceClusterCreateOptions.Builder().numberOfControllers(1).numberOfServers(0).numberOfRouters(0).build();
+    veniceCluster = ServiceFactory.getVeniceCluster(options);
+
+    Properties serverProperties = new Properties();
+    serverProperties.setProperty(SERVER_BATCH_PUSH_RECORD_COUNT_VERIFICATION_ENABLED, "true");
+    veniceCluster.addVeniceServer(new Properties(), serverProperties);
+
+    veniceCluster.addVeniceRouter(new Properties());
+  }
+
+  @AfterClass(alwaysRun = true)
+  public void cleanUp() {
+    Utils.closeQuietlyWithErrorLogged(veniceCluster);
+  }
+
+  /**
+   * Tests that a basic batch push with record count verification enabled completes successfully.
+   * The VPJ sends per-partition record counts on EOP, and the server verifies them.
+   * If there's a mismatch, the server throws and the push fails.
+   */
+  @Test(timeOut = TEST_TIMEOUT)
+  public void testBatchPushWithRecordCountVerification() throws Exception {
+    File inputDir = getTempDataDirectory();
+    KeyAndValueSchemas schemas = new KeyAndValueSchemas(writeSimpleAvroFileWithStringToStringSchema(inputDir));
+    String storeName = Utils.getUniqueString("record-count-verification-store");
+    String inputDirPath = "file://" + inputDir.getAbsolutePath();
+
+    Properties props = defaultVPJProps(veniceCluster, inputDirPath, storeName);
+    props.setProperty(SEND_CONTROL_MESSAGES_DIRECTLY, "true");
+
+    createStoreForJob(
+        veniceCluster.getClusterName(),
+        schemas.getKey().toString(),
+        schemas.getValue().toString(),
+        props,
+        new UpdateStoreQueryParams()).close();
+
+    // Run the push job - this will fail if record count verification detects a mismatch
+    IntegrationTestPushUtils.runVPJ(props);
+
+    // Wait for version to become current
+    veniceCluster.useControllerClient(controllerClient -> {
+      TestUtils.waitForNonDeterministicAssertion(30, TimeUnit.SECONDS, true, true, () -> {
+        int currentVersion = controllerClient.getStore(storeName).getStore().getCurrentVersion();
+        Assert.assertTrue(currentVersion > 0, "Store " + storeName + " does not have a current version yet");
+      });
+    });
+
+    // Verify data is readable (push succeeded with record count verification)
+    try (AvroGenericStoreClient avroClient = ClientFactory.getAndStartGenericAvroClient(
+        ClientConfig.defaultGenericClientConfig(storeName).setVeniceURL(veniceCluster.getRandomRouterURL()))) {
+      TestUtils.waitForNonDeterministicAssertion(10, TimeUnit.SECONDS, true, true, () -> {
+        for (int i = 1; i <= 100; i++) {
+          Assert.assertEquals(avroClient.get(Integer.toString(i)).get().toString(), "test_name_" + i);
+        }
+      });
+    }
+  }
+
+  /**
+   * Tests batch push with chunking enabled and record count verification.
+   * Verifies that chunked records are counted correctly (only logical records, not chunk pieces).
+   */
+  @Test(timeOut = TEST_TIMEOUT)
+  public void testChunkedBatchPushWithRecordCountVerification() throws Exception {
+    File inputDir = getTempDataDirectory();
+    Schema recordSchema = writeSimpleAvroFileWithCustomSize(inputDir, 10, 1024 * 1024, 1024 * 1024); // 10 records ~1MB
+    String storeName = Utils.getUniqueString("chunked-record-count-store");
+    String inputDirPath = "file://" + inputDir.getAbsolutePath();
+
+    Properties props = defaultVPJProps(veniceCluster, inputDirPath, storeName);
+    props.setProperty(SEND_CONTROL_MESSAGES_DIRECTLY, "true");
+
+    createStoreForJob(
+        veniceCluster.getClusterName(),
+        recordSchema.getField("key").schema().toString(),
+        recordSchema.getField("value").schema().toString(),
+        props,
+        new UpdateStoreQueryParams().setChunkingEnabled(true)).close();
+
+    // Run the push - should succeed even with chunking because we count logical records, not chunks
+    IntegrationTestPushUtils.runVPJ(props);
+
+    veniceCluster.useControllerClient(controllerClient -> {
+      TestUtils.waitForNonDeterministicAssertion(30, TimeUnit.SECONDS, true, true, () -> {
+        int currentVersion = controllerClient.getStore(storeName).getStore().getCurrentVersion();
+        Assert.assertTrue(currentVersion > 0, "Store " + storeName + " does not have a current version yet");
+      });
+    });
+  }
+}


### PR DESCRIPTION
VALIDATION_OVERRIDE

## Summary
Server counts ingested logical records per partition and verifies against the expected count from the EOP PubSub header. On mismatch: logs error, emits metric, fails ingestion (default enabled).

**Part 3 of 4** — depends on Part 1 (#2663) for the `prc` header.

### Changes
- `PartitionState` v21 schema: `batchPushRecordCount` field (persisted across restarts)
- `AvroProtocolDefinition`: bump PARTITION_STATE 20→21
- `StoreIngestionTask`: count non-chunk PUTs/DELETEs before EOP, verify at EOP
- `VeniceServerConfig`: `server.batch.push.record.count.verification.enabled` (default true)
- `HostLevelIngestionStats`: `batch_push_record_count_mismatch` metric

### Chunking-aware
Only counts logical records (skips `CHUNK_SCHEMA_ID`). Chunk manifests are counted.

## Test plan
- [x] `StoreIngestionTaskRecordCountTest` — 9 tests (all verification branches)
- [x] `PartitionConsumptionStateTest` — increment/get
- [x] `TestOffsetRecord` — serialization round-trip
- [x] `TestBatchPushRecordCountVerification` — E2E basic + chunked with strict verification