### PR TITLE
[vpj] Add HLL-based repush pipeline integrity verification

### DIFF
--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/PushJobSetting.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/PushJobSetting.java
@@ -80,6 +80,8 @@ public class PushJobSetting implements Serializable {
   public boolean extendedSchemaValidityCheckEnabled;
   /** Refer {@link VenicePushJobConstants#COMPRESSION_METRIC_COLLECTION_ENABLED} **/
   public boolean compressionMetricCollectionEnabled;
+  public boolean repushHllVerificationEnabled;
+  public double repushHllErrorTolerance;
   public boolean repushTTLEnabled;
   public boolean isCompliancePush;
   // specify time to drop stale records.

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/VenicePushJob.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/VenicePushJob.java
@@ -917,7 +917,8 @@ public class VenicePushJob implements AutoCloseable {
 
         if (!pushJobSetting.suppressEndOfPushMessage) {
           if (pushJobSetting.sendControlMessagesDirectly) {
-            getVeniceWriter(pushJobSetting).broadcastEndOfPush(Collections.emptyMap());
+            Map<Integer, Long> partitionRecordCounts = getPerPartitionRecordCounts();
+            getVeniceWriter(pushJobSetting).broadcastEndOfPush(Collections.emptyMap(), partitionRecordCounts);
           } else {
             controllerClient.writeEndOfPush(pushJobSetting.storeName, pushJobSetting.version);
           }
@@ -1740,6 +1741,17 @@ public class VenicePushJob implements AutoCloseable {
   @VisibleForTesting
   void updatePushJobDetailsWithCheckpoint(PushJobCheckpoints checkpoint) {
     pushJobDetails.pushJobLatestCheckpoint = checkpoint.getValue();
+  }
+
+  private Map<Integer, Long> getPerPartitionRecordCounts() {
+    if (dataWriterComputeJob == null) {
+      return Collections.emptyMap();
+    }
+    DataWriterTaskTracker tracker = dataWriterComputeJob.getTaskTracker();
+    if (tracker == null) {
+      return Collections.emptyMap();
+    }
+    return tracker.getPerPartitionRecordCounts();
   }
 
   private void updatePushJobDetailsWithDataWriterTracker() {

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/VenicePushJob.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/VenicePushJob.java
@@ -28,6 +28,7 @@ import static com.linkedin.venice.vpj.VenicePushJobConstants.DEFAULT_COMPRESSION
 import static com.linkedin.venice.vpj.VenicePushJobConstants.DEFAULT_EXTENDED_SCHEMA_VALIDITY_CHECK_ENABLED;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.DEFAULT_JOB_STATUS_IN_UNKNOWN_STATE_TIMEOUT_MS;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.DEFAULT_POLL_STATUS_INTERVAL_MS;
+import static com.linkedin.venice.vpj.VenicePushJobConstants.DEFAULT_REPUSH_HLL_ERROR_TOLERANCE;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.DEFAULT_RE_PUSH_REWIND_IN_SECONDS_OVERRIDE;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.DEFAULT_SSL_ENABLED;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.DEFER_VERSION_SWAP;
@@ -63,6 +64,8 @@ import static com.linkedin.venice.vpj.VenicePushJobConstants.POLL_JOB_STATUS_INT
 import static com.linkedin.venice.vpj.VenicePushJobConstants.POLL_STATUS_RETRY_ATTEMPTS;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.PUSH_JOB_TIMEOUT_OVERRIDE_MS;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.PUSH_TO_SEPARATE_REALTIME_TOPIC;
+import static com.linkedin.venice.vpj.VenicePushJobConstants.REPUSH_HLL_ERROR_TOLERANCE;
+import static com.linkedin.venice.vpj.VenicePushJobConstants.REPUSH_HLL_VERIFICATION_ENABLED;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.REPUSH_TTL_ENABLE;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.REPUSH_TTL_SECONDS;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.REPUSH_TTL_START_TIMESTAMP;
@@ -418,6 +421,9 @@ public class VenicePushJob implements AutoCloseable {
         props.getBoolean(KAFKA_INPUT_COMPRESSION_BUILD_NEW_DICT_ENABLED, true);
     pushJobSettingToReturn.suppressEndOfPushMessage = props.getBoolean(SUPPRESS_END_OF_PUSH_MESSAGE, false);
     pushJobSettingToReturn.deferVersionSwap = props.getBoolean(DEFER_VERSION_SWAP, false);
+    pushJobSettingToReturn.repushHllVerificationEnabled = props.getBoolean(REPUSH_HLL_VERIFICATION_ENABLED, true);
+    pushJobSettingToReturn.repushHllErrorTolerance =
+        props.getDouble(REPUSH_HLL_ERROR_TOLERANCE, DEFAULT_REPUSH_HLL_ERROR_TOLERANCE);
     pushJobSettingToReturn.repushTTLEnabled = props.getBoolean(REPUSH_TTL_ENABLE, false);
     pushJobSettingToReturn.repushUseFallbackValueSchemaId =
         props.getBoolean(REPUSH_USE_FALLBACK_VALUE_SCHEMA_ID, false);

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/mapreduce/counter/MRJobCounterHelper.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/mapreduce/counter/MRJobCounterHelper.java
@@ -1,5 +1,7 @@
 package com.linkedin.venice.hadoop.mapreduce.counter;
 
+import java.util.HashMap;
+import java.util.Map;
 import org.apache.hadoop.mapred.Counters;
 import org.apache.hadoop.mapred.Reporter;
 
@@ -38,6 +40,8 @@ public class MRJobCounterHelper {
       "Mapper spray all partitions triggered count";
   private static final String COUNTER_GROUP_KAFKA_INPUT_FORMAT = "KafkaInputFormat";
   private static final String COUNTER_PUT_OR_DELETE_RECORDS = "put or delete records";
+
+  private static final String PER_PARTITION_RECORD_COUNT_GROUP = "Per Partition Record Count";
 
   private static final String REPUSH_TTL_FILTERED_COUNT = "Repush ttl filtered count";
 
@@ -278,6 +282,29 @@ public class MRJobCounterHelper {
 
   public static void incrRepushTtlFilterCount(Reporter reporter, long amount) {
     incrAmountWithGroupCounterName(reporter, REPUSH_TTL_FILTER_COUNT_GROUP_COUNTER_NAME, amount);
+  }
+
+  public static void incrPartitionRecordCount(Reporter reporter, int partition, long amount) {
+    if (reporter == null || reporter.equals(Reporter.NULL) || amount == 0) {
+      return;
+    }
+    Counters.Counter counter = reporter.getCounter(PER_PARTITION_RECORD_COUNT_GROUP, String.valueOf(partition));
+    if (counter != null) {
+      counter.increment(amount);
+    }
+  }
+
+  public static Map<Integer, Long> getPerPartitionRecordCounts(Counters counters) {
+    Map<Integer, Long> result = new HashMap<>();
+    for (Counters.Group group: counters) {
+      if (group.getName().equals(PER_PARTITION_RECORD_COUNT_GROUP)) {
+        for (Counters.Counter counter: group) {
+          result.put(Integer.parseInt(counter.getName()), counter.getValue());
+        }
+        break;
+      }
+    }
+    return result;
   }
 
   /**

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/mapreduce/counter/MRJobCounterHelper.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/mapreduce/counter/MRJobCounterHelper.java
@@ -1,5 +1,6 @@
 package com.linkedin.venice.hadoop.mapreduce.counter;
 
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import org.apache.hadoop.mapred.Counters;
@@ -295,6 +296,9 @@ public class MRJobCounterHelper {
   }
 
   public static Map<Integer, Long> getPerPartitionRecordCounts(Counters counters) {
+    if (counters == null) {
+      return Collections.emptyMap();
+    }
     Map<Integer, Long> result = new HashMap<>();
     for (Counters.Group group: counters) {
       if (group.getName().equals(PER_PARTITION_RECORD_COUNT_GROUP)) {

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/mapreduce/datawriter/task/CounterBackedMapReduceDataWriterTaskTracker.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/mapreduce/datawriter/task/CounterBackedMapReduceDataWriterTaskTracker.java
@@ -2,6 +2,7 @@ package com.linkedin.venice.hadoop.mapreduce.datawriter.task;
 
 import com.linkedin.venice.hadoop.mapreduce.counter.MRJobCounterHelper;
 import com.linkedin.venice.hadoop.task.datawriter.DataWriterTaskTracker;
+import java.util.Map;
 import org.apache.hadoop.mapred.Counters;
 
 
@@ -88,5 +89,10 @@ public class CounterBackedMapReduceDataWriterTaskTracker implements DataWriterTa
   @Override
   public long getIncrementalPushThrottledTimeMs() {
     return MRJobCounterHelper.getIncrementalPushThrottleTimeMs(counters);
+  }
+
+  @Override
+  public Map<Integer, Long> getPerPartitionRecordCounts() {
+    return MRJobCounterHelper.getPerPartitionRecordCounts(this.counters);
   }
 }

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/mapreduce/datawriter/task/ReporterBackedMapReduceDataWriterTaskTracker.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/mapreduce/datawriter/task/ReporterBackedMapReduceDataWriterTaskTracker.java
@@ -89,6 +89,11 @@ public class ReporterBackedMapReduceDataWriterTaskTracker implements DataWriterT
   }
 
   @Override
+  public void trackRecordSentToPubSubForPartition(int partition) {
+    MRJobCounterHelper.incrPartitionRecordCount(this.reporter, partition, 1);
+  }
+
+  @Override
   public void trackDuplicateKeyWithDistinctValue(int count) {
     MRJobCounterHelper.incrDuplicateKeyWithDistinctValue(reporter, count);
   }

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/task/datawriter/AbstractPartitionWriter.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/task/datawriter/AbstractPartitionWriter.java
@@ -498,6 +498,7 @@ public abstract class AbstractPartitionWriter extends AbstractDataWriterTask imp
     messageSent++;
     telemetry();
     dataWriterTaskTracker.trackRecordSentToPubSub();
+    dataWriterTaskTracker.trackRecordSentToPubSubForPartition(getTaskId());
   }
 
   /**

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/task/datawriter/DataWriterTaskTracker.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/task/datawriter/DataWriterTaskTracker.java
@@ -1,6 +1,8 @@
 package com.linkedin.venice.hadoop.task.datawriter;
 
 import com.linkedin.venice.hadoop.task.TaskTracker;
+import java.util.Collections;
+import java.util.Map;
 
 
 /**
@@ -45,6 +47,9 @@ public interface DataWriterTaskTracker extends TaskTracker {
   }
 
   default void trackRecordSentToPubSub() {
+  }
+
+  default void trackRecordSentToPubSubForPartition(int partition) {
   }
 
   default void trackDuplicateKeyWithDistinctValue(int count) {
@@ -131,5 +136,9 @@ public interface DataWriterTaskTracker extends TaskTracker {
 
   default long getIncrementalPushThrottledTimeMs() {
     return 0;
+  }
+
+  default Map<Integer, Long> getPerPartitionRecordCounts() {
+    return Collections.emptyMap();
   }
 }

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/task/datawriter/DataWriterTaskTracker.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/task/datawriter/DataWriterTaskTracker.java
@@ -141,4 +141,19 @@ public interface DataWriterTaskTracker extends TaskTracker {
   default Map<Integer, Long> getPerPartitionRecordCounts() {
     return Collections.emptyMap();
   }
+
+  default void trackReadSideUniqueKey(byte[] key) {
+  }
+
+  default void trackReadSideUniqueKeyForPartition(int partition, byte[] key) {
+  }
+
+  default long getReadSideUniqueKeyCountEstimate() {
+    return -1;
+  }
+
+  default Map<Integer, Long> getPerPartitionReadSideUniqueKeyCountEstimates() {
+    return Collections.emptyMap();
+  }
+
 }

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/jobs/DataWriterComputeJob.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/jobs/DataWriterComputeJob.java
@@ -14,6 +14,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -159,6 +160,62 @@ public abstract class DataWriterComputeJob implements ComputeJob {
       }
     } else {
       verifyTaskWithZeroValues(dataWriterTaskTracker);
+    }
+
+    // Repush HLL verification: compare read-side unique key estimate with write-side output count
+    if (pushJobSetting.isSourceKafka && pushJobSetting.repushHllVerificationEnabled) {
+      long hllEstimate = dataWriterTaskTracker.getReadSideUniqueKeyCountEstimate();
+      if (hllEstimate > 0) {
+        long outputRecords = dataWriterTaskTracker.getOutputRecordsCount();
+        long ttlFiltered = dataWriterTaskTracker.getRepushTtlFilterCount();
+        // N.B.: ttlFiltered counts rows, not unique keys. This is valid because the source VT
+        // (after compaction) has one record per unique key, so row count == unique key count.
+        // The 5% default tolerance absorbs any imprecision from edge cases.
+        long expectedUniqueKeys = outputRecords + ttlFiltered;
+        double errorRate = Math.abs((double) (hllEstimate - expectedUniqueKeys)) / Math.max(hllEstimate, 1);
+
+        LOGGER.info(
+            "Repush HLL verification: HLL estimate={}, output={}, TTL filtered={}, "
+                + "expected={}, error={}, tolerance={}",
+            hllEstimate,
+            outputRecords,
+            ttlFiltered,
+            expectedUniqueKeys,
+            errorRate,
+            pushJobSetting.repushHllErrorTolerance);
+
+        if (errorRate > pushJobSetting.repushHllErrorTolerance) {
+          throw new VeniceException(
+              String.format(
+                  "Repush HLL verification failed: HLL estimate (%d) diverges from expected (%d) "
+                      + "by %.2f%%, exceeding tolerance %.2f%%",
+                  hllEstimate,
+                  expectedUniqueKeys,
+                  errorRate * 100,
+                  pushJobSetting.repushHllErrorTolerance * 100));
+        }
+
+        // Per-partition HLL check (diagnostic only, does not fail — higher variance per partition)
+        Map<Integer, Long> perPartitionHllEstimates =
+            dataWriterTaskTracker.getPerPartitionReadSideUniqueKeyCountEstimates();
+        Map<Integer, Long> perPartitionWriteCounts = dataWriterTaskTracker.getPerPartitionRecordCounts();
+        if (!perPartitionHllEstimates.isEmpty() && !perPartitionWriteCounts.isEmpty()) {
+          for (Map.Entry<Integer, Long> entry: perPartitionHllEstimates.entrySet()) {
+            int partition = entry.getKey();
+            long partHllEstimate = entry.getValue();
+            long partWriteCount = perPartitionWriteCounts.getOrDefault(partition, 0L);
+            double partErrorRate = Math.abs((double) (partHllEstimate - partWriteCount)) / Math.max(partHllEstimate, 1);
+            if (partErrorRate > pushJobSetting.repushHllErrorTolerance) {
+              LOGGER.error(
+                  "Per-partition HLL mismatch for partition {}: HLL estimate={}, write count={}, error={}",
+                  partition,
+                  partHllEstimate,
+                  partWriteCount,
+                  partErrorRate);
+            }
+          }
+        }
+      }
     }
   }
 

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/spark/datawriter/jobs/AbstractDataWriterSparkJob.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/spark/datawriter/jobs/AbstractDataWriterSparkJob.java
@@ -93,6 +93,8 @@ import com.linkedin.venice.spark.datawriter.partition.VeniceSparkPartitioner;
 import com.linkedin.venice.spark.datawriter.recordprocessor.SparkInputRecordProcessorFactory;
 import com.linkedin.venice.spark.datawriter.recordprocessor.SparkLogicalTimestampProcessor;
 import com.linkedin.venice.spark.datawriter.task.DataWriterAccumulators;
+import com.linkedin.venice.spark.datawriter.task.HyperLogLogAccumulator;
+import com.linkedin.venice.spark.datawriter.task.MapHyperLogLogAccumulator;
 import com.linkedin.venice.spark.datawriter.task.SparkDataWriterTaskTracker;
 import com.linkedin.venice.spark.datawriter.writer.SparkPartitionWriterFactory;
 import com.linkedin.venice.spark.input.kafka.ttl.SparkKafkaInputTTLFilter;
@@ -156,6 +158,8 @@ public abstract class AbstractDataWriterSparkJob extends DataWriterComputeJob {
   private SparkSession sparkSession;
   private DataWriterAccumulators accumulatorsForDataWriterJob;
   private SparkDataWriterTaskTracker taskTracker;
+  private HyperLogLogAccumulator readSideHllAccumulator;
+  private MapHyperLogLogAccumulator perPartitionReadSideHllAccumulator;
 
   @Override
   public void configure(VeniceProperties props, PushJobSetting pushJobSetting) {
@@ -166,7 +170,17 @@ public abstract class AbstractDataWriterSparkJob extends DataWriterComputeJob {
     Properties jobProps = new Properties();
     sparkSession.conf().getAll().foreach(entry -> jobProps.setProperty(entry._1, entry._2));
     accumulatorsForDataWriterJob = new DataWriterAccumulators(sparkSession);
-    taskTracker = new SparkDataWriterTaskTracker(accumulatorsForDataWriterJob);
+    if (pushJobSetting.repushHllVerificationEnabled && pushJobSetting.isSourceKafka) {
+      SparkContext sparkContext = sparkSession.sparkContext();
+      readSideHllAccumulator = new HyperLogLogAccumulator();
+      sparkContext.register(readSideHllAccumulator, "Repush Read-Side HLL Unique Key Count");
+      perPartitionReadSideHllAccumulator = new MapHyperLogLogAccumulator();
+      sparkContext.register(perPartitionReadSideHllAccumulator, "Repush Per-Partition Read-Side HLL");
+    }
+    taskTracker = new SparkDataWriterTaskTracker(
+        accumulatorsForDataWriterJob,
+        readSideHllAccumulator,
+        perPartitionReadSideHllAccumulator);
   }
 
   /**
@@ -387,6 +401,33 @@ public abstract class AbstractDataWriterSparkJob extends DataWriterComputeJob {
   private Dataset<Row> getInputDataFrame() {
     if (pushJobSetting.isSourceKafka) {
       Dataset<Row> rawKafkaInput = getKafkaInputDataFrame();
+
+      // Track read-side unique key cardinality via HLL for repush verification
+      if (pushJobSetting.repushHllVerificationEnabled && readSideHllAccumulator != null) {
+        final HyperLogLogAccumulator hllAcc = readSideHllAccumulator;
+        final MapHyperLogLogAccumulator perPartHllAcc = perPartitionReadSideHllAccumulator;
+        rawKafkaInput = rawKafkaInput
+            .mapPartitions((org.apache.spark.api.java.function.MapPartitionsFunction<Row, Row>) iterator -> {
+              return new java.util.Iterator<Row>() {
+                @Override
+                public boolean hasNext() {
+                  return iterator.hasNext();
+                }
+
+                @Override
+                public Row next() {
+                  Row row = iterator.next();
+                  byte[] key = row.getAs(KEY_COLUMN_NAME);
+                  if (key != null) {
+                    hllAcc.add(key);
+                    int partition = row.getAs(PARTITION_COLUMN_NAME);
+                    perPartHllAcc.add(new scala.Tuple2<>(partition, key));
+                  }
+                  return row;
+                }
+              };
+            }, org.apache.spark.sql.catalyst.encoders.RowEncoder.apply(rawKafkaInput.schema()));
+      }
 
       // Apply TTL filter first on RAW_PUBSUB_INPUT_TABLE_SCHEMA (if enabled)
       Dataset<Row> filteredInput = applyTTLFilter(rawKafkaInput);

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/spark/datawriter/task/DataWriterAccumulators.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/spark/datawriter/task/DataWriterAccumulators.java
@@ -30,6 +30,7 @@ public class DataWriterAccumulators implements Serializable {
   public final LongAccumulator repushTtlFilteredRecordCounter;
   public final LongAccumulator incrementalPushThrottleTimeCounter;
   public final LongAccumulator totalDuplicateKeyCounter;
+  public final MapLongAccumulator perPartitionRecordCounts;
 
   public DataWriterAccumulators(SparkSession session) {
     SparkContext sparkContext = session.sparkContext();
@@ -52,5 +53,7 @@ public class DataWriterAccumulators implements Serializable {
     duplicateKeyWithIdenticalValueCounter = sparkContext.longAccumulator("Duplicate Key With Identical Value");
     duplicateKeyWithDistinctValueCounter = sparkContext.longAccumulator("Duplicate Key With Distinct Value");
     totalDuplicateKeyCounter = sparkContext.longAccumulator("Total Duplicate Keys (Compaction)");
+    this.perPartitionRecordCounts = new MapLongAccumulator();
+    sparkContext.register(perPartitionRecordCounts, "perPartitionRecordCounts");
   }
 }

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/spark/datawriter/task/DataWriterAccumulators.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/spark/datawriter/task/DataWriterAccumulators.java
@@ -53,7 +53,7 @@ public class DataWriterAccumulators implements Serializable {
     duplicateKeyWithIdenticalValueCounter = sparkContext.longAccumulator("Duplicate Key With Identical Value");
     duplicateKeyWithDistinctValueCounter = sparkContext.longAccumulator("Duplicate Key With Distinct Value");
     totalDuplicateKeyCounter = sparkContext.longAccumulator("Total Duplicate Keys (Compaction)");
-    this.perPartitionRecordCounts = new MapLongAccumulator();
-    sparkContext.register(perPartitionRecordCounts, "perPartitionRecordCounts");
+    perPartitionRecordCounts = new MapLongAccumulator();
+    sparkContext.register(perPartitionRecordCounts, "Per Partition Record Counts");
   }
 }

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/spark/datawriter/task/DataWriterAccumulators.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/spark/datawriter/task/DataWriterAccumulators.java
@@ -53,7 +53,6 @@ public class DataWriterAccumulators implements Serializable {
     duplicateKeyWithIdenticalValueCounter = sparkContext.longAccumulator("Duplicate Key With Identical Value");
     duplicateKeyWithDistinctValueCounter = sparkContext.longAccumulator("Duplicate Key With Distinct Value");
     totalDuplicateKeyCounter = sparkContext.longAccumulator("Total Duplicate Keys (Compaction)");
-    perPartitionRecordCounts = new MapLongAccumulator();
-    sparkContext.register(perPartitionRecordCounts, "Per Partition Record Counts");
+    perPartitionRecordCounts = new MapLongAccumulator(sparkContext, "Per Partition Record Counts");
   }
 }

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/spark/datawriter/task/HyperLogLogAccumulator.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/spark/datawriter/task/HyperLogLogAccumulator.java
@@ -1,0 +1,54 @@
+package com.linkedin.venice.spark.datawriter.task;
+
+import com.linkedin.venice.utils.HyperLogLogSketch;
+import org.apache.spark.util.AccumulatorV2;
+
+
+/**
+ * A Spark {@link AccumulatorV2} that wraps {@link HyperLogLogSketch} for distributed
+ * cardinality estimation across Spark tasks.
+ *
+ * Each task gets a fresh copy via {@link #copy()}, adds keys during processing,
+ * and the driver merges all task-level sketches via {@link #merge(AccumulatorV2)}.
+ */
+public class HyperLogLogAccumulator extends AccumulatorV2<byte[], Long> {
+  private static final long serialVersionUID = 1L;
+
+  private HyperLogLogSketch sketch;
+
+  public HyperLogLogAccumulator() {
+    this.sketch = new HyperLogLogSketch();
+  }
+
+  @Override
+  public boolean isZero() {
+    return sketch.isEmpty();
+  }
+
+  @Override
+  public AccumulatorV2<byte[], Long> copy() {
+    HyperLogLogAccumulator newAcc = new HyperLogLogAccumulator();
+    newAcc.sketch = this.sketch.copy();
+    return newAcc;
+  }
+
+  @Override
+  public void reset() {
+    sketch.reset();
+  }
+
+  @Override
+  public void add(byte[] key) {
+    sketch.add(key);
+  }
+
+  @Override
+  public void merge(AccumulatorV2<byte[], Long> other) {
+    sketch.merge(((HyperLogLogAccumulator) other).sketch);
+  }
+
+  @Override
+  public Long value() {
+    return sketch.estimate();
+  }
+}

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/spark/datawriter/task/MapHyperLogLogAccumulator.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/spark/datawriter/task/MapHyperLogLogAccumulator.java
@@ -1,0 +1,66 @@
+package com.linkedin.venice.spark.datawriter.task;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import org.apache.spark.util.AccumulatorV2;
+import scala.Tuple2;
+
+
+/**
+ * A Spark accumulator that maintains per-partition HyperLogLog sketches for estimating
+ * the unique key cardinality within each partition independently.
+ *
+ * Used during repush when source and destination partition counts match, enabling
+ * per-partition verification that catches partition-level record loss which aggregate
+ * HLL comparison would mask.
+ *
+ * Each partition gets its own HLL sketch (16KB). For 1000 partitions, total memory is ~16MB per task.
+ */
+public class MapHyperLogLogAccumulator extends AccumulatorV2<Tuple2<Integer, byte[]>, Map<Integer, Long>> {
+  private static final long serialVersionUID = 1L;
+
+  private final ConcurrentHashMap<Integer, HyperLogLogAccumulator> hllMap = new ConcurrentHashMap<>();
+
+  @Override
+  public boolean isZero() {
+    return hllMap.isEmpty();
+  }
+
+  @Override
+  public AccumulatorV2<Tuple2<Integer, byte[]>, Map<Integer, Long>> copy() {
+    MapHyperLogLogAccumulator newAcc = new MapHyperLogLogAccumulator();
+    hllMap.forEach((partition, hll) -> {
+      newAcc.hllMap.put(partition, (HyperLogLogAccumulator) hll.copy());
+    });
+    return newAcc;
+  }
+
+  @Override
+  public void reset() {
+    hllMap.clear();
+  }
+
+  @Override
+  public void add(Tuple2<Integer, byte[]> v) {
+    hllMap.computeIfAbsent(v._1(), k -> new HyperLogLogAccumulator()).add(v._2());
+  }
+
+  @Override
+  public void merge(AccumulatorV2<Tuple2<Integer, byte[]>, Map<Integer, Long>> other) {
+    MapHyperLogLogAccumulator otherAcc = (MapHyperLogLogAccumulator) other;
+    otherAcc.hllMap.forEach((partition, otherHll) -> {
+      hllMap.merge(partition, otherHll, (existing, incoming) -> {
+        existing.merge(incoming);
+        return existing;
+      });
+    });
+  }
+
+  @Override
+  public Map<Integer, Long> value() {
+    ConcurrentHashMap<Integer, Long> result = new ConcurrentHashMap<>();
+    hllMap.forEach((partition, hll) -> result.put(partition, hll.value()));
+    return Collections.unmodifiableMap(result);
+  }
+}

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/spark/datawriter/task/MapLongAccumulator.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/spark/datawriter/task/MapLongAccumulator.java
@@ -50,8 +50,11 @@ public class MapLongAccumulator extends AccumulatorV2<scala.Tuple2<Integer, Long
 
   @Override
   public void merge(AccumulatorV2<scala.Tuple2<Integer, Long>, Map<Integer, Long>> other) {
-    MapLongAccumulator otherAcc = (MapLongAccumulator) other;
-    otherAcc.map.forEach((key, value) -> map.merge(key, value, Long::sum));
+    if (!(other instanceof MapLongAccumulator)) {
+      throw new IllegalArgumentException(
+          "Cannot merge " + other.getClass().getSimpleName() + " into MapLongAccumulator");
+    }
+    ((MapLongAccumulator) other).map.forEach((key, value) -> map.merge(key, value, Long::sum));
   }
 
   @Override

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/spark/datawriter/task/MapLongAccumulator.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/spark/datawriter/task/MapLongAccumulator.java
@@ -1,8 +1,8 @@
 package com.linkedin.venice.spark.datawriter.task;
 
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
 import org.apache.spark.SparkContext;
 import org.apache.spark.util.AccumulatorV2;
 
@@ -10,11 +10,14 @@ import org.apache.spark.util.AccumulatorV2;
 /**
  * A Spark accumulator that maintains per-key long counters, merging by summing values per key.
  * Used for tracking per-partition record counts during Spark-based push jobs.
+ *
+ * Thread safety: Spark creates a fresh copy per task via {@link #copy()}, so each task's
+ * instance is single-threaded. A plain HashMap suffices — no concurrent access occurs.
  */
 public class MapLongAccumulator extends AccumulatorV2<scala.Tuple2<Integer, Long>, Map<Integer, Long>> {
   private static final long serialVersionUID = 1L;
 
-  private final ConcurrentHashMap<Integer, Long> map = new ConcurrentHashMap<>();
+  private final HashMap<Integer, Long> map = new HashMap<>();
 
   MapLongAccumulator() {
   }

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/spark/datawriter/task/MapLongAccumulator.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/spark/datawriter/task/MapLongAccumulator.java
@@ -1,0 +1,50 @@
+package com.linkedin.venice.spark.datawriter.task;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import org.apache.spark.util.AccumulatorV2;
+
+
+/**
+ * A Spark accumulator that maintains per-key long counters, merging by summing values per key.
+ * Used for tracking per-partition record counts during Spark-based push jobs.
+ */
+public class MapLongAccumulator extends AccumulatorV2<scala.Tuple2<Integer, Long>, Map<Integer, Long>> {
+  private static final long serialVersionUID = 1L;
+
+  private final ConcurrentHashMap<Integer, Long> map = new ConcurrentHashMap<>();
+
+  @Override
+  public boolean isZero() {
+    return map.isEmpty();
+  }
+
+  @Override
+  public AccumulatorV2<scala.Tuple2<Integer, Long>, Map<Integer, Long>> copy() {
+    MapLongAccumulator newAcc = new MapLongAccumulator();
+    newAcc.map.putAll(this.map);
+    return newAcc;
+  }
+
+  @Override
+  public void reset() {
+    map.clear();
+  }
+
+  @Override
+  public void add(scala.Tuple2<Integer, Long> v) {
+    map.merge(v._1(), v._2(), Long::sum);
+  }
+
+  @Override
+  public void merge(AccumulatorV2<scala.Tuple2<Integer, Long>, Map<Integer, Long>> other) {
+    MapLongAccumulator otherAcc = (MapLongAccumulator) other;
+    otherAcc.map.forEach((key, value) -> map.merge(key, value, Long::sum));
+  }
+
+  @Override
+  public Map<Integer, Long> value() {
+    return Collections.unmodifiableMap(map);
+  }
+}

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/spark/datawriter/task/MapLongAccumulator.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/spark/datawriter/task/MapLongAccumulator.java
@@ -3,6 +3,7 @@ package com.linkedin.venice.spark.datawriter.task;
 import java.util.Collections;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
+import org.apache.spark.SparkContext;
 import org.apache.spark.util.AccumulatorV2;
 
 
@@ -14,6 +15,13 @@ public class MapLongAccumulator extends AccumulatorV2<scala.Tuple2<Integer, Long
   private static final long serialVersionUID = 1L;
 
   private final ConcurrentHashMap<Integer, Long> map = new ConcurrentHashMap<>();
+
+  MapLongAccumulator() {
+  }
+
+  MapLongAccumulator(SparkContext sparkContext, String name) {
+    sparkContext.register(this, name);
+  }
 
   @Override
   public boolean isZero() {

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/spark/datawriter/task/SparkDataWriterTaskTracker.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/spark/datawriter/task/SparkDataWriterTaskTracker.java
@@ -1,6 +1,7 @@
 package com.linkedin.venice.spark.datawriter.task;
 
 import com.linkedin.venice.hadoop.task.datawriter.DataWriterTaskTracker;
+import java.util.Map;
 
 
 /**
@@ -71,6 +72,11 @@ public class SparkDataWriterTaskTracker implements DataWriterTaskTracker {
   @Override
   public void trackRecordSentToPubSub() {
     accumulators.outputRecordCounter.add(1);
+  }
+
+  @Override
+  public void trackRecordSentToPubSubForPartition(int partition) {
+    accumulators.perPartitionRecordCounts.add(new scala.Tuple2<>(partition, 1L));
   }
 
   @Override
@@ -171,5 +177,10 @@ public class SparkDataWriterTaskTracker implements DataWriterTaskTracker {
   @Override
   public long getIncrementalPushThrottledTimeMs() {
     return accumulators.incrementalPushThrottleTimeCounter.value();
+  }
+
+  @Override
+  public Map<Integer, Long> getPerPartitionRecordCounts() {
+    return accumulators.perPartitionRecordCounts.value();
   }
 }

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/spark/datawriter/task/SparkDataWriterTaskTracker.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/spark/datawriter/task/SparkDataWriterTaskTracker.java
@@ -1,6 +1,7 @@
 package com.linkedin.venice.spark.datawriter.task;
 
 import com.linkedin.venice.hadoop.task.datawriter.DataWriterTaskTracker;
+import java.util.Collections;
 import java.util.Map;
 
 
@@ -9,9 +10,20 @@ import java.util.Map;
  */
 public class SparkDataWriterTaskTracker implements DataWriterTaskTracker {
   private final DataWriterAccumulators accumulators;
+  private final HyperLogLogAccumulator readSideHllAccumulator;
+  private final MapHyperLogLogAccumulator perPartitionReadSideHllAccumulator;
 
   public SparkDataWriterTaskTracker(DataWriterAccumulators accumulators) {
+    this(accumulators, null, null);
+  }
+
+  public SparkDataWriterTaskTracker(
+      DataWriterAccumulators accumulators,
+      HyperLogLogAccumulator readSideHllAccumulator,
+      MapHyperLogLogAccumulator perPartitionReadSideHllAccumulator) {
     this.accumulators = accumulators;
+    this.readSideHllAccumulator = readSideHllAccumulator;
+    this.perPartitionReadSideHllAccumulator = perPartitionReadSideHllAccumulator;
   }
 
   @Override
@@ -183,4 +195,31 @@ public class SparkDataWriterTaskTracker implements DataWriterTaskTracker {
   public Map<Integer, Long> getPerPartitionRecordCounts() {
     return accumulators.perPartitionRecordCounts.value();
   }
+
+  @Override
+  public void trackReadSideUniqueKey(byte[] key) {
+    if (readSideHllAccumulator != null) {
+      readSideHllAccumulator.add(key);
+    }
+  }
+
+  @Override
+  public void trackReadSideUniqueKeyForPartition(int partition, byte[] key) {
+    if (perPartitionReadSideHllAccumulator != null) {
+      perPartitionReadSideHllAccumulator.add(new scala.Tuple2<>(partition, key));
+    }
+  }
+
+  @Override
+  public long getReadSideUniqueKeyCountEstimate() {
+    return readSideHllAccumulator != null ? readSideHllAccumulator.value() : -1;
+  }
+
+  @Override
+  public Map<Integer, Long> getPerPartitionReadSideUniqueKeyCountEstimates() {
+    return perPartitionReadSideHllAccumulator != null
+        ? perPartitionReadSideHllAccumulator.value()
+        : Collections.emptyMap();
+  }
+
 }

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/vpj/VenicePushJobConstants.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/vpj/VenicePushJobConstants.java
@@ -406,6 +406,14 @@ public final class VenicePushJobConstants {
    */
   public static final String REPUSH_USE_FALLBACK_VALUE_SCHEMA_ID = "repush.use.fallback.value.schema.id";
 
+  /**
+   * When enabled, repush jobs use HyperLogLog to estimate the unique key cardinality of the source
+   * version topic and compare it against the write-side output count for pipeline integrity verification.
+   */
+  public static final String REPUSH_HLL_VERIFICATION_ENABLED = "repush.hll.verification.enabled";
+  public static final String REPUSH_HLL_ERROR_TOLERANCE = "repush.hll.error.tolerance";
+  public static final double DEFAULT_REPUSH_HLL_ERROR_TOLERANCE = 0.05;
+
   public static final String REPUSH_TTL_ENABLE = "repush.ttl.enable";
   public static final String REPUSH_TTL_POLICY = "repush.ttl.policy";
   public static final String REPUSH_TTL_SECONDS = "repush.ttl.seconds";

--- a/clients/venice-push-job/src/test/java/com/linkedin/venice/hadoop/mapreduce/counter/MRJobCounterHelperTest.java
+++ b/clients/venice-push-job/src/test/java/com/linkedin/venice/hadoop/mapreduce/counter/MRJobCounterHelperTest.java
@@ -1,0 +1,54 @@
+package com.linkedin.venice.hadoop.mapreduce.counter;
+
+import java.util.Map;
+import org.apache.hadoop.mapred.Counters;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+
+public class MRJobCounterHelperTest {
+  @Test
+  public void testGetPerPartitionRecordCounts() {
+    Counters counters = new Counters();
+    // Simulate per-partition record counts by incrementing counters in the expected group
+    Counters.Counter counter0 = counters.findCounter("Per Partition Record Count", "0");
+    counter0.increment(100);
+    Counters.Counter counter1 = counters.findCounter("Per Partition Record Count", "1");
+    counter1.increment(200);
+    Counters.Counter counter5 = counters.findCounter("Per Partition Record Count", "5");
+    counter5.increment(50);
+
+    Map<Integer, Long> result = MRJobCounterHelper.getPerPartitionRecordCounts(counters);
+    Assert.assertEquals(result.size(), 3);
+    Assert.assertEquals((long) result.get(0), 100L);
+    Assert.assertEquals((long) result.get(1), 200L);
+    Assert.assertEquals((long) result.get(5), 50L);
+  }
+
+  @Test
+  public void testGetPerPartitionRecordCountsEmpty() {
+    Counters counters = new Counters();
+    Map<Integer, Long> result = MRJobCounterHelper.getPerPartitionRecordCounts(counters);
+    Assert.assertTrue(result.isEmpty());
+  }
+
+  @Test
+  public void testIncrPartitionRecordCountWithMockReporter() {
+    // Use a Counters-based approach to verify the increment path indirectly:
+    // Increment via Reporter, then read back via Counters
+    Counters counters = new Counters();
+    Counters.Counter counter = counters.findCounter("Per Partition Record Count", "3");
+    counter.increment(10);
+    counter.increment(5);
+
+    Map<Integer, Long> result = MRJobCounterHelper.getPerPartitionRecordCounts(counters);
+    Assert.assertEquals(result.size(), 1);
+    Assert.assertEquals((long) result.get(3), 15L);
+  }
+
+  @Test
+  public void testIncrPartitionRecordCountWithNullReporter() {
+    // Passing null reporter should not throw
+    MRJobCounterHelper.incrPartitionRecordCount(null, 0, 1);
+  }
+}

--- a/clients/venice-push-job/src/test/java/com/linkedin/venice/hadoop/mapreduce/counter/MRJobCounterHelperTest.java
+++ b/clients/venice-push-job/src/test/java/com/linkedin/venice/hadoop/mapreduce/counter/MRJobCounterHelperTest.java
@@ -33,9 +33,7 @@ public class MRJobCounterHelperTest {
   }
 
   @Test
-  public void testIncrPartitionRecordCountWithMockReporter() {
-    // Use a Counters-based approach to verify the increment path indirectly:
-    // Increment via Reporter, then read back via Counters
+  public void testGetPerPartitionRecordCountsWithMultipleIncrements() {
     Counters counters = new Counters();
     Counters.Counter counter = counters.findCounter("Per Partition Record Count", "3");
     counter.increment(10);

--- a/clients/venice-push-job/src/test/java/com/linkedin/venice/spark/datawriter/task/HyperLogLogAccumulatorTest.java
+++ b/clients/venice-push-job/src/test/java/com/linkedin/venice/spark/datawriter/task/HyperLogLogAccumulatorTest.java
@@ -1,0 +1,125 @@
+package com.linkedin.venice.spark.datawriter.task;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+
+import java.nio.charset.StandardCharsets;
+import org.testng.annotations.Test;
+
+
+public class HyperLogLogAccumulatorTest {
+  @Test
+  public void testEmptyHllReturnsZero() {
+    HyperLogLogAccumulator hll = new HyperLogLogAccumulator();
+    assertTrue(hll.isZero());
+    assertEquals(hll.value().longValue(), 0L);
+  }
+
+  @Test
+  public void testSingleKey() {
+    HyperLogLogAccumulator hll = new HyperLogLogAccumulator();
+    hll.add("key1".getBytes(StandardCharsets.UTF_8));
+    assertFalse(hll.isZero());
+    assertEquals(hll.value().longValue(), 1L);
+  }
+
+  @Test
+  public void testDuplicateKeysDoNotInflateCardinality() {
+    HyperLogLogAccumulator hll = new HyperLogLogAccumulator();
+    byte[] key = "same-key".getBytes(StandardCharsets.UTF_8);
+    for (int i = 0; i < 1000; i++) {
+      hll.add(key);
+    }
+    assertEquals(hll.value().longValue(), 1L);
+  }
+
+  @Test
+  public void testManyUniqueKeys() {
+    HyperLogLogAccumulator hll = new HyperLogLogAccumulator();
+    int n = 100_000;
+    for (int i = 0; i < n; i++) {
+      hll.add(("key-" + i).getBytes(StandardCharsets.UTF_8));
+    }
+    long estimate = hll.value();
+    double relativeError = Math.abs((double) (estimate - n)) / n;
+    // HLL with p=14 has ~0.8% standard error; allow 3% for safety
+    assertTrue(relativeError < 0.03, "Relative error " + relativeError + " exceeds 3% for " + n + " unique keys");
+  }
+
+  @Test
+  public void testMergeDisjointSets() {
+    HyperLogLogAccumulator hll1 = new HyperLogLogAccumulator();
+    HyperLogLogAccumulator hll2 = new HyperLogLogAccumulator();
+
+    for (int i = 0; i < 10_000; i++) {
+      hll1.add(("a-" + i).getBytes(StandardCharsets.UTF_8));
+    }
+    for (int i = 0; i < 10_000; i++) {
+      hll2.add(("b-" + i).getBytes(StandardCharsets.UTF_8));
+    }
+
+    hll1.merge(hll2);
+    long estimate = hll1.value();
+    double relativeError = Math.abs((double) (estimate - 20_000)) / 20_000;
+    assertTrue(relativeError < 0.03, "Merged estimate error " + relativeError + " exceeds 3%");
+  }
+
+  @Test
+  public void testMergeWithOverlap() {
+    HyperLogLogAccumulator hll1 = new HyperLogLogAccumulator();
+    HyperLogLogAccumulator hll2 = new HyperLogLogAccumulator();
+
+    // Both add keys 0-9999, hll2 also adds 10000-19999
+    for (int i = 0; i < 10_000; i++) {
+      hll1.add(("key-" + i).getBytes(StandardCharsets.UTF_8));
+      hll2.add(("key-" + i).getBytes(StandardCharsets.UTF_8));
+    }
+    for (int i = 10_000; i < 20_000; i++) {
+      hll2.add(("key-" + i).getBytes(StandardCharsets.UTF_8));
+    }
+
+    hll1.merge(hll2);
+    long estimate = hll1.value();
+    double relativeError = Math.abs((double) (estimate - 20_000)) / 20_000;
+    assertTrue(relativeError < 0.03, "Overlap merged estimate error " + relativeError + " exceeds 3%");
+  }
+
+  @Test
+  public void testCopy() {
+    HyperLogLogAccumulator hll = new HyperLogLogAccumulator();
+    for (int i = 0; i < 1000; i++) {
+      hll.add(("key-" + i).getBytes(StandardCharsets.UTF_8));
+    }
+
+    HyperLogLogAccumulator copy = (HyperLogLogAccumulator) hll.copy();
+    assertEquals(copy.value(), hll.value());
+
+    // Mutating copy should not affect original
+    copy.add("extra-key".getBytes(StandardCharsets.UTF_8));
+    // Values might still be equal due to HLL approximation, but registers should differ
+    copy.reset();
+    assertTrue(copy.isZero());
+    assertFalse(hll.isZero());
+  }
+
+  @Test
+  public void testReset() {
+    HyperLogLogAccumulator hll = new HyperLogLogAccumulator();
+    hll.add("key".getBytes(StandardCharsets.UTF_8));
+    assertFalse(hll.isZero());
+
+    hll.reset();
+    assertTrue(hll.isZero());
+    assertEquals(hll.value().longValue(), 0L);
+  }
+
+  @Test
+  public void testNullAndEmptyKeyIgnored() {
+    HyperLogLogAccumulator hll = new HyperLogLogAccumulator();
+    hll.add(null);
+    hll.add(new byte[0]);
+    assertTrue(hll.isZero());
+    assertEquals(hll.value().longValue(), 0L);
+  }
+}

--- a/clients/venice-push-job/src/test/java/com/linkedin/venice/spark/datawriter/task/MapLongAccumulatorTest.java
+++ b/clients/venice-push-job/src/test/java/com/linkedin/venice/spark/datawriter/task/MapLongAccumulatorTest.java
@@ -1,0 +1,85 @@
+package com.linkedin.venice.spark.datawriter.task;
+
+import java.util.Map;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+
+public class MapLongAccumulatorTest {
+  @Test
+  public void testIsZero() {
+    MapLongAccumulator accumulator = new MapLongAccumulator();
+    Assert.assertTrue(accumulator.isZero());
+
+    accumulator.add(new scala.Tuple2<>(0, 10L));
+    Assert.assertFalse(accumulator.isZero());
+  }
+
+  @Test
+  public void testAddAndValue() {
+    MapLongAccumulator accumulator = new MapLongAccumulator();
+    accumulator.add(new scala.Tuple2<>(0, 10L));
+    accumulator.add(new scala.Tuple2<>(1, 20L));
+    accumulator.add(new scala.Tuple2<>(0, 5L));
+
+    Map<Integer, Long> value = accumulator.value();
+    Assert.assertEquals(value.size(), 2);
+    Assert.assertEquals((long) value.get(0), 15L);
+    Assert.assertEquals((long) value.get(1), 20L);
+  }
+
+  @Test
+  public void testMerge() {
+    MapLongAccumulator accA = new MapLongAccumulator();
+    accA.add(new scala.Tuple2<>(0, 10L));
+    accA.add(new scala.Tuple2<>(1, 20L));
+
+    MapLongAccumulator accB = new MapLongAccumulator();
+    accB.add(new scala.Tuple2<>(1, 5L));
+    accB.add(new scala.Tuple2<>(2, 30L));
+
+    accA.merge(accB);
+
+    Map<Integer, Long> value = accA.value();
+    Assert.assertEquals(value.size(), 3);
+    Assert.assertEquals((long) value.get(0), 10L);
+    Assert.assertEquals((long) value.get(1), 25L);
+    Assert.assertEquals((long) value.get(2), 30L);
+  }
+
+  @Test
+  public void testReset() {
+    MapLongAccumulator accumulator = new MapLongAccumulator();
+    accumulator.add(new scala.Tuple2<>(0, 10L));
+    accumulator.add(new scala.Tuple2<>(1, 20L));
+    Assert.assertFalse(accumulator.isZero());
+
+    accumulator.reset();
+    Assert.assertTrue(accumulator.isZero());
+    Assert.assertTrue(accumulator.value().isEmpty());
+  }
+
+  @Test
+  public void testCopy() {
+    MapLongAccumulator original = new MapLongAccumulator();
+    original.add(new scala.Tuple2<>(0, 10L));
+    original.add(new scala.Tuple2<>(1, 20L));
+
+    MapLongAccumulator copy = (MapLongAccumulator) original.copy();
+
+    Assert.assertNotNull(copy);
+    Assert.assertEquals(copy.value(), original.value());
+
+    // Verify independence: modifying copy should not affect original
+    copy.add(new scala.Tuple2<>(0, 5L));
+    Assert.assertEquals((long) original.value().get(0), 10L);
+    Assert.assertEquals((long) copy.value().get(0), 15L);
+  }
+
+  @Test(expectedExceptions = UnsupportedOperationException.class)
+  public void testValueIsUnmodifiable() {
+    MapLongAccumulator accumulator = new MapLongAccumulator();
+    accumulator.add(new scala.Tuple2<>(0, 10L));
+    accumulator.value().put(1, 20L);
+  }
+}

--- a/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/api/PubSubMessageHeaders.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/api/PubSubMessageHeaders.java
@@ -33,6 +33,8 @@ public class PubSubMessageHeaders implements Measurable, Iterable<PubSubMessageH
    * further processing. In the example, this chunk should be sent to view1's partition 0 and view2's partitions 1 & 2.
    */
   public static final String VENICE_VIEW_PARTITIONS_MAP_HEADER = "vpm";
+  /** Header to carry per-partition record count for batch push record count verification */
+  public static final String VENICE_PARTITION_RECORD_COUNT_HEADER = "prc";
 
   public PubSubMessageHeaders add(PubSubMessageHeader header) {
     headers.put(header.key(), header);

--- a/internal/venice-common/src/main/java/com/linkedin/venice/utils/HyperLogLogSketch.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/utils/HyperLogLogSketch.java
@@ -31,9 +31,9 @@ import java.util.Arrays;
  *
  * <h3>Serialization format</h3>
  * <pre>
- *   [1 byte: precision p] [2^p bytes: registers]
+ *   [1 byte: precision p] [2^p bytes: registers (unsigned, valid range 0..64-p+1)]
  * </pre>
- * Total size = 1 + 2^p bytes (e.g., 16385 bytes for p=14).
+ * Total size = 1 + 2^p bytes (e.g., 16385 bytes for p=14). Always dense — no sparse mode.
  *
  * <h3>Thread safety</h3>
  * Not thread-safe. Callers must synchronize externally if shared across threads.
@@ -75,12 +75,12 @@ public class HyperLogLogSketch {
     this.registers = new byte[m];
   }
 
-  /** Internal constructor for deserialization — takes ownership of the registers array. */
-  private HyperLogLogSketch(int precision, byte[] registers) {
+  /** Internal constructor for deserialization — takes ownership of the provided registers array. */
+  private HyperLogLogSketch(int precision, byte[] ownedRegisters) {
     this.p = precision;
     this.m = 1 << p;
     this.alphaM = computeAlpha(m) * m * m;
-    this.registers = registers;
+    this.registers = ownedRegisters;
   }
 
   /**
@@ -92,13 +92,7 @@ public class HyperLogLogSketch {
     if (key == null || key.length == 0) {
       return;
     }
-    long hash = hash64(key);
-    int registerIndex = (int) (hash >>> (64 - p));
-    long remainingBits = (hash << p) | (1L << (p - 1));
-    int rho = Long.numberOfLeadingZeros(remainingBits) + 1;
-    if (rho > registers[registerIndex]) {
-      registers[registerIndex] = (byte) rho;
-    }
+    updateRegister(hash64(key));
   }
 
   /**
@@ -108,6 +102,10 @@ public class HyperLogLogSketch {
    * @param hash a well-distributed 64-bit hash value
    */
   public void addHash(long hash) {
+    updateRegister(hash);
+  }
+
+  private void updateRegister(long hash) {
     int registerIndex = (int) (hash >>> (64 - p));
     long remainingBits = (hash << p) | (1L << (p - 1));
     int rho = Long.numberOfLeadingZeros(remainingBits) + 1;
@@ -120,10 +118,13 @@ public class HyperLogLogSketch {
    * Merges another sketch into this one. Both sketches must have the same precision.
    * The merge operation is element-wise max of registers — associative, commutative, and idempotent.
    *
-   * @param other the sketch to merge in
-   * @throws IllegalArgumentException if precisions differ
+   * @param other the sketch to merge in (must not be null)
+   * @throws IllegalArgumentException if other is null or precisions differ
    */
   public void merge(HyperLogLogSketch other) {
+    if (other == null) {
+      throw new IllegalArgumentException("Cannot merge null HLL sketch");
+    }
     if (this.p != other.p) {
       throw new IllegalArgumentException(
           "Cannot merge HLL sketches with different precisions: " + p + " vs " + other.p);
@@ -137,6 +138,8 @@ public class HyperLogLogSketch {
 
   /**
    * Returns the estimated cardinality (number of distinct elements added).
+   * Includes small-range (linear counting) and large-range corrections per the original
+   * Flajolet et al. HLL paper.
    *
    * @return estimated cardinality, or 0 if no elements have been added
    */
@@ -144,7 +147,7 @@ public class HyperLogLogSketch {
     double sum = 0.0;
     int zeroCount = 0;
     for (int i = 0; i < m; i++) {
-      sum += 1.0 / (1L << registers[i]);
+      sum += 1.0 / (1L << (registers[i] & 0xFF));
       if (registers[i] == 0) {
         zeroCount++;
       }
@@ -155,6 +158,12 @@ public class HyperLogLogSketch {
     // Small range correction (linear counting)
     if (estimate <= 2.5 * m && zeroCount > 0) {
       estimate = m * Math.log((double) m / zeroCount);
+    }
+
+    // Large range correction (Flajolet et al.)
+    double twoTo32 = 1L << 32;
+    if (estimate > twoTo32 / 30.0) {
+      estimate = -twoTo32 * Math.log(1.0 - estimate / twoTo32);
     }
 
     return Math.round(estimate);
@@ -187,9 +196,9 @@ public class HyperLogLogSketch {
 
   /** Creates a deep copy of this sketch. */
   public HyperLogLogSketch copy() {
-    byte[] registersCopy = new byte[m];
-    System.arraycopy(registers, 0, registersCopy, 0, m);
-    return new HyperLogLogSketch(p, registersCopy);
+    HyperLogLogSketch copySketch = new HyperLogLogSketch(p);
+    System.arraycopy(registers, 0, copySketch.registers, 0, m);
+    return copySketch;
   }
 
   // ---- Serialization ----
@@ -237,8 +246,7 @@ public class HyperLogLogSketch {
       throw new IllegalArgumentException(
           "Invalid HLL bytes length: expected " + expectedLength + " for p=" + precision + ", got " + bytes.length);
     }
-    byte[] registers = new byte[1 << precision];
-    System.arraycopy(bytes, 1, registers, 0, registers.length);
+    byte[] registers = Arrays.copyOfRange(bytes, 1, bytes.length);
     return new HyperLogLogSketch(precision, registers);
   }
 
@@ -265,13 +273,14 @@ public class HyperLogLogSketch {
    * Uses FNV-1a to fold the input bytes into a single long, then applies the
    * MurmurHash3 fmix64 avalanche step for final bit mixing.
    *
-   * This is a public static method so callers can pre-hash keys (e.g., for use with
-   * {@link #addHash(long)}) or for other hashing needs.
-   *
-   * @param key the byte array to hash
+   * @param key the byte array to hash (must not be null)
    * @return a 64-bit hash value
+   * @throws IllegalArgumentException if key is null
    */
   public static long hash64(byte[] key) {
+    if (key == null) {
+      throw new IllegalArgumentException("Key must not be null");
+    }
     // FNV-1a to fold variable-length input into 64 bits
     long h = 0xcbf29ce484222325L; // FNV offset basis
     for (byte b: key) {

--- a/internal/venice-common/src/main/java/com/linkedin/venice/utils/HyperLogLogSketch.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/utils/HyperLogLogSketch.java
@@ -1,0 +1,303 @@
+package com.linkedin.venice.utils;
+
+import java.nio.ByteBuffer;
+import java.util.Arrays;
+
+
+/**
+ * A standalone HyperLogLog (HLL) sketch for estimating the cardinality (number of distinct elements)
+ * of a multiset. This is a pure-Java implementation with no external dependencies.
+ *
+ * <h3>Usage</h3>
+ * <pre>
+ *   HyperLogLogSketch hll = new HyperLogLogSketch();      // p=14 by default
+ *   hll.add(keyBytes);
+ *   hll.add(otherKeyBytes);
+ *   long estimate = hll.estimate();                        // ~unique count
+ *
+ *   // Merge two sketches (e.g., from different partitions / tasks)
+ *   hll.merge(otherHll);
+ *
+ *   // Serialize / deserialize for transport or persistence
+ *   byte[] bytes = hll.toBytes();
+ *   HyperLogLogSketch restored = HyperLogLogSketch.fromBytes(bytes);
+ * </pre>
+ *
+ * <h3>Parameters</h3>
+ * <ul>
+ *   <li><b>p (precision)</b> — number of bits used for register indexing. 2^p registers are allocated.
+ *       Higher p = more memory but lower error. Default p=14 gives ~0.8% standard error with 16 KB.</li>
+ * </ul>
+ *
+ * <h3>Serialization format</h3>
+ * <pre>
+ *   [1 byte: precision p] [2^p bytes: registers]
+ * </pre>
+ * Total size = 1 + 2^p bytes (e.g., 16385 bytes for p=14).
+ *
+ * <h3>Thread safety</h3>
+ * Not thread-safe. Callers must synchronize externally if shared across threads.
+ */
+public class HyperLogLogSketch {
+  /** Default precision. 2^14 = 16384 registers, ~0.8% standard error, 16 KB memory. */
+  public static final int DEFAULT_PRECISION = 14;
+
+  /** Minimum supported precision (64 registers, ~26% error). */
+  public static final int MIN_PRECISION = 4;
+
+  /** Maximum supported precision (2^18 = 262144 registers, ~0.1% error, 256 KB). */
+  public static final int MAX_PRECISION = 18;
+
+  private final int p;
+  private final int m; // 2^p
+  private final double alphaM;
+  private final byte[] registers;
+
+  /** Creates a new sketch with default precision (p=14). */
+  public HyperLogLogSketch() {
+    this(DEFAULT_PRECISION);
+  }
+
+  /**
+   * Creates a new sketch with the given precision.
+   *
+   * @param precision number of bits for register indexing (4..18). 2^p registers are allocated.
+   * @throws IllegalArgumentException if precision is out of range
+   */
+  public HyperLogLogSketch(int precision) {
+    if (precision < MIN_PRECISION || precision > MAX_PRECISION) {
+      throw new IllegalArgumentException(
+          "Precision must be between " + MIN_PRECISION + " and " + MAX_PRECISION + ", got " + precision);
+    }
+    this.p = precision;
+    this.m = 1 << p;
+    this.alphaM = computeAlpha(m) * m * m;
+    this.registers = new byte[m];
+  }
+
+  /** Internal constructor for deserialization — takes ownership of the registers array. */
+  private HyperLogLogSketch(int precision, byte[] registers) {
+    this.p = precision;
+    this.m = 1 << p;
+    this.alphaM = computeAlpha(m) * m * m;
+    this.registers = registers;
+  }
+
+  /**
+   * Adds a byte array element to the sketch.
+   *
+   * @param key the element to add (null or empty keys are ignored)
+   */
+  public void add(byte[] key) {
+    if (key == null || key.length == 0) {
+      return;
+    }
+    long hash = hash64(key);
+    int registerIndex = (int) (hash >>> (64 - p));
+    long remainingBits = (hash << p) | (1L << (p - 1));
+    int rho = Long.numberOfLeadingZeros(remainingBits) + 1;
+    if (rho > registers[registerIndex]) {
+      registers[registerIndex] = (byte) rho;
+    }
+  }
+
+  /**
+   * Adds a pre-computed 64-bit hash to the sketch. Useful when the caller already has
+   * a hash (e.g., from a partitioner) and wants to avoid re-hashing.
+   *
+   * @param hash a well-distributed 64-bit hash value
+   */
+  public void addHash(long hash) {
+    int registerIndex = (int) (hash >>> (64 - p));
+    long remainingBits = (hash << p) | (1L << (p - 1));
+    int rho = Long.numberOfLeadingZeros(remainingBits) + 1;
+    if (rho > registers[registerIndex]) {
+      registers[registerIndex] = (byte) rho;
+    }
+  }
+
+  /**
+   * Merges another sketch into this one. Both sketches must have the same precision.
+   * The merge operation is element-wise max of registers — associative, commutative, and idempotent.
+   *
+   * @param other the sketch to merge in
+   * @throws IllegalArgumentException if precisions differ
+   */
+  public void merge(HyperLogLogSketch other) {
+    if (this.p != other.p) {
+      throw new IllegalArgumentException(
+          "Cannot merge HLL sketches with different precisions: " + p + " vs " + other.p);
+    }
+    for (int i = 0; i < m; i++) {
+      if (other.registers[i] > registers[i]) {
+        registers[i] = other.registers[i];
+      }
+    }
+  }
+
+  /**
+   * Returns the estimated cardinality (number of distinct elements added).
+   *
+   * @return estimated cardinality, or 0 if no elements have been added
+   */
+  public long estimate() {
+    double sum = 0.0;
+    int zeroCount = 0;
+    for (int i = 0; i < m; i++) {
+      sum += 1.0 / (1L << registers[i]);
+      if (registers[i] == 0) {
+        zeroCount++;
+      }
+    }
+
+    double estimate = alphaM / sum;
+
+    // Small range correction (linear counting)
+    if (estimate <= 2.5 * m && zeroCount > 0) {
+      estimate = m * Math.log((double) m / zeroCount);
+    }
+
+    return Math.round(estimate);
+  }
+
+  /** Returns true if no elements have been added. */
+  public boolean isEmpty() {
+    for (byte b: registers) {
+      if (b != 0) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  /** Resets the sketch to its initial empty state. */
+  public void reset() {
+    Arrays.fill(registers, (byte) 0);
+  }
+
+  /** Returns the precision (p) of this sketch. */
+  public int getPrecision() {
+    return p;
+  }
+
+  /** Returns the number of registers (2^p). */
+  public int getRegisterCount() {
+    return m;
+  }
+
+  /** Creates a deep copy of this sketch. */
+  public HyperLogLogSketch copy() {
+    byte[] registersCopy = new byte[m];
+    System.arraycopy(registers, 0, registersCopy, 0, m);
+    return new HyperLogLogSketch(p, registersCopy);
+  }
+
+  // ---- Serialization ----
+
+  /**
+   * Serializes this sketch to a byte array.
+   *
+   * Format: [1 byte: precision] [2^p bytes: registers]
+   *
+   * @return the serialized bytes (length = 1 + 2^p)
+   */
+  public byte[] toBytes() {
+    byte[] bytes = new byte[1 + m];
+    bytes[0] = (byte) p;
+    System.arraycopy(registers, 0, bytes, 1, m);
+    return bytes;
+  }
+
+  /**
+   * Serializes this sketch into a ByteBuffer (for Avro bytes fields, PubSub headers, etc.).
+   *
+   * @return a ByteBuffer wrapping the serialized bytes
+   */
+  public ByteBuffer toByteBuffer() {
+    return ByteBuffer.wrap(toBytes());
+  }
+
+  /**
+   * Deserializes a sketch from a byte array.
+   *
+   * @param bytes the serialized bytes (produced by {@link #toBytes()})
+   * @return the deserialized sketch
+   * @throws IllegalArgumentException if the input is malformed
+   */
+  public static HyperLogLogSketch fromBytes(byte[] bytes) {
+    if (bytes == null || bytes.length < 2) {
+      throw new IllegalArgumentException("Invalid HLL bytes: null or too short");
+    }
+    int precision = bytes[0] & 0xFF;
+    if (precision < MIN_PRECISION || precision > MAX_PRECISION) {
+      throw new IllegalArgumentException("Invalid HLL precision in serialized data: " + precision);
+    }
+    int expectedLength = 1 + (1 << precision);
+    if (bytes.length != expectedLength) {
+      throw new IllegalArgumentException(
+          "Invalid HLL bytes length: expected " + expectedLength + " for p=" + precision + ", got " + bytes.length);
+    }
+    byte[] registers = new byte[1 << precision];
+    System.arraycopy(bytes, 1, registers, 0, registers.length);
+    return new HyperLogLogSketch(precision, registers);
+  }
+
+  /**
+   * Deserializes a sketch from a ByteBuffer (for reading from Avro bytes fields, etc.).
+   *
+   * @param buffer the buffer containing serialized HLL data
+   * @return the deserialized sketch
+   * @throws IllegalArgumentException if the input is malformed
+   */
+  public static HyperLogLogSketch fromByteBuffer(ByteBuffer buffer) {
+    if (buffer == null) {
+      throw new IllegalArgumentException("Buffer cannot be null");
+    }
+    byte[] bytes = new byte[buffer.remaining()];
+    buffer.duplicate().get(bytes);
+    return fromBytes(bytes);
+  }
+
+  // ---- Hash function ----
+
+  /**
+   * Produces a well-distributed 64-bit hash from arbitrary byte arrays.
+   * Uses FNV-1a to fold the input bytes into a single long, then applies the
+   * MurmurHash3 fmix64 avalanche step for final bit mixing.
+   *
+   * This is a public static method so callers can pre-hash keys (e.g., for use with
+   * {@link #addHash(long)}) or for other hashing needs.
+   *
+   * @param key the byte array to hash
+   * @return a 64-bit hash value
+   */
+  public static long hash64(byte[] key) {
+    // FNV-1a to fold variable-length input into 64 bits
+    long h = 0xcbf29ce484222325L; // FNV offset basis
+    for (byte b: key) {
+      h ^= b;
+      h *= 0x100000001b3L; // FNV prime
+    }
+    // MurmurHash3 fmix64 avalanche
+    h ^= h >>> 33;
+    h *= 0xff51afd7ed558ccdL;
+    h ^= h >>> 33;
+    h *= 0xc4ceb9fe1a85ec53L;
+    h ^= h >>> 33;
+    return h;
+  }
+
+  // ---- Internal ----
+
+  private static double computeAlpha(int m) {
+    if (m == 16) {
+      return 0.673;
+    } else if (m == 32) {
+      return 0.697;
+    } else if (m == 64) {
+      return 0.709;
+    } else {
+      return 0.7213 / (1.0 + 1.079 / m);
+    }
+  }
+}

--- a/internal/venice-common/src/main/java/com/linkedin/venice/writer/VeniceWriter.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/writer/VeniceWriter.java
@@ -2277,23 +2277,7 @@ public class VeniceWriter<K, V, U> extends AbstractVeniceWriter<K, V, U> {
       Map<String, String> debugInfo,
       PubSubProducerCallback callback,
       LeaderMetadataWrapper leaderMetadataWrapper) {
-    // Work around until we upgrade to a more modern Avro version which supports overriding the
-    // String implementation.
-    controlMessage.debugInfo = getDebugInfo(debugInfo);
-    boolean isEndOfSegment = ControlMessageType.valueOf(controlMessage).equals(ControlMessageType.END_OF_SEGMENT);
-    synchronized (this.partitionLocks[partition]) {
-      return sendMessage(
-          this::getControlMessageKey,
-          MessageType.CONTROL_MESSAGE,
-          controlMessage,
-          isEndOfSegment,
-          partition,
-          callback,
-          true,
-          leaderMetadataWrapper,
-          VENICE_DEFAULT_LOGICAL_TS,
-          EmptyPubSubMessageHeaders.SINGLETON);
-    }
+    return sendControlMessage(controlMessage, partition, debugInfo, callback, leaderMetadataWrapper, null);
   }
 
   public CompletableFuture<PubSubProduceResult> sendControlMessage(
@@ -2303,6 +2287,8 @@ public class VeniceWriter<K, V, U> extends AbstractVeniceWriter<K, V, U> {
       PubSubProducerCallback callback,
       LeaderMetadataWrapper leaderMetadataWrapper,
       PubSubMessageHeaders headers) {
+    // Work around until we upgrade to a more modern Avro version which supports overriding the
+    // String implementation.
     controlMessage.debugInfo = getDebugInfo(debugInfo);
     boolean isEndOfSegment = ControlMessageType.valueOf(controlMessage).equals(ControlMessageType.END_OF_SEGMENT);
     synchronized (this.partitionLocks[partition]) {

--- a/internal/venice-common/src/main/java/com/linkedin/venice/writer/VeniceWriter.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/writer/VeniceWriter.java
@@ -1441,7 +1441,17 @@ public class VeniceWriter<K, V, U> extends AbstractVeniceWriter<K, V, U> {
    * @param debugInfo arbitrary key/value pairs of information that will be propagated alongside the control message.
    */
   public void broadcastEndOfPush(Map<String, String> debugInfo) {
-    broadcastControlMessage(getEmptyControlMessage(ControlMessageType.END_OF_PUSH), debugInfo);
+    broadcastEndOfPush(debugInfo, null);
+  }
+
+  /**
+   * Broadcast end of push with per-partition record counts for verification.
+   *
+   * @param debugInfo arbitrary key/value pairs of information that will be propagated alongside the control message.
+   * @param partitionRecordCounts per-partition record counts. If null or empty, no record count header is sent.
+   */
+  public void broadcastEndOfPush(Map<String, String> debugInfo, Map<Integer, Long> partitionRecordCounts) {
+    broadcastControlMessage(getEmptyControlMessage(ControlMessageType.END_OF_PUSH), debugInfo, partitionRecordCounts);
     endAllSegments(true);
   }
 
@@ -2110,6 +2120,38 @@ public class VeniceWriter<K, V, U> extends AbstractVeniceWriter<K, V, U> {
     return partitionWriteFuture;
   }
 
+  /**
+   * Broadcast a control message with per-partition record counts embedded as PubSub headers.
+   */
+  private List<CompletableFuture<PubSubProduceResult>> broadcastControlMessage(
+      ControlMessage controlMessage,
+      Map<String, String> debugInfo,
+      Map<Integer, Long> partitionRecordCounts) {
+    if (partitionRecordCounts == null || partitionRecordCounts.isEmpty()) {
+      return broadcastControlMessage(controlMessage, debugInfo);
+    }
+    List<CompletableFuture<PubSubProduceResult>> partitionWriteFuture = new ArrayList<>();
+    for (int partition = 0; partition < numberOfPartitions; partition++) {
+      Long recordCount = partitionRecordCounts.get(partition);
+      if (recordCount != null) {
+        PubSubMessageHeaders headers = new PubSubMessageHeaders();
+        headers.add(
+            PubSubMessageHeaders.VENICE_PARTITION_RECORD_COUNT_HEADER,
+            ByteBuffer.allocate(Long.BYTES).putLong(recordCount).array());
+        partitionWriteFuture.add(
+            sendControlMessage(controlMessage, partition, debugInfo, null, DEFAULT_LEADER_METADATA_WRAPPER, headers));
+      } else {
+        partitionWriteFuture
+            .add(sendControlMessage(controlMessage, partition, debugInfo, null, DEFAULT_LEADER_METADATA_WRAPPER));
+      }
+    }
+    logger.info(
+        "Successfully broadcast {} Control Message with record counts for topic: {}",
+        ControlMessageType.valueOf(controlMessage),
+        topicName);
+    return partitionWriteFuture;
+  }
+
   private Map<CharSequence, CharSequence> getDebugInfo(Map<String, String> debugInfoToAdd) {
     if (debugInfoToAdd == null || debugInfoToAdd.isEmpty()) {
       return defaultDebugInfo;
@@ -2251,6 +2293,30 @@ public class VeniceWriter<K, V, U> extends AbstractVeniceWriter<K, V, U> {
           leaderMetadataWrapper,
           VENICE_DEFAULT_LOGICAL_TS,
           EmptyPubSubMessageHeaders.SINGLETON);
+    }
+  }
+
+  public CompletableFuture<PubSubProduceResult> sendControlMessage(
+      ControlMessage controlMessage,
+      int partition,
+      Map<String, String> debugInfo,
+      PubSubProducerCallback callback,
+      LeaderMetadataWrapper leaderMetadataWrapper,
+      PubSubMessageHeaders headers) {
+    controlMessage.debugInfo = getDebugInfo(debugInfo);
+    boolean isEndOfSegment = ControlMessageType.valueOf(controlMessage).equals(ControlMessageType.END_OF_SEGMENT);
+    synchronized (this.partitionLocks[partition]) {
+      return sendMessage(
+          this::getControlMessageKey,
+          MessageType.CONTROL_MESSAGE,
+          controlMessage,
+          isEndOfSegment,
+          partition,
+          callback,
+          true,
+          leaderMetadataWrapper,
+          VENICE_DEFAULT_LOGICAL_TS,
+          headers == null ? EmptyPubSubMessageHeaders.SINGLETON : headers);
     }
   }
 

--- a/internal/venice-common/src/test/java/com/linkedin/venice/utils/HyperLogLogSketchTest.java
+++ b/internal/venice-common/src/test/java/com/linkedin/venice/utils/HyperLogLogSketchTest.java
@@ -607,7 +607,7 @@ public class HyperLogLogSketchTest {
         "Split-merge at p=18: 100K keys across 10 splits should be within 0.5%");
   }
 
-  // ---- Hash function test ----
+  // ---- Hash function tests ----
 
   @Test
   public void testHash64Deterministic() {
@@ -619,15 +619,38 @@ public class HyperLogLogSketchTest {
 
   @Test
   public void testHash64Distribution() {
-    // Verify hash distributes across all 4 quadrants of the 64-bit space
-    boolean hasPositive = false, hasNegative = false;
+    // Verify hash distributes across all 4 quadrants of the 64-bit space (top 2 bits)
+    boolean[] quadrants = new boolean[4];
     for (int i = 0; i < 100; i++) {
       long h = HyperLogLogSketch.hash64(("key-" + i).getBytes(StandardCharsets.UTF_8));
-      if (h >= 0)
-        hasPositive = true;
-      if (h < 0)
-        hasNegative = true;
+      int quadrant = (int) ((h >>> 62) & 0x3);
+      quadrants[quadrant] = true;
     }
-    assertTrue(hasPositive && hasNegative, "Hash should produce both positive and negative values");
+    assertTrue(
+        quadrants[0] && quadrants[1] && quadrants[2] && quadrants[3],
+        "Hash should produce values in all 4 high-order-bit quadrants");
+  }
+
+  @Test
+  public void testHash64NullThrows() {
+    assertThrows(IllegalArgumentException.class, () -> HyperLogLogSketch.hash64(null));
+  }
+
+  @Test
+  public void testHash64QualityAt1MKeys() {
+    int n = 1_000_000;
+    HyperLogLogSketch hll = new HyperLogLogSketch();
+    for (int i = 0; i < n; i++) {
+      hll.add(("key-" + i).getBytes(StandardCharsets.UTF_8));
+    }
+    long estimate = hll.estimate();
+    double relativeError = Math.abs((double) (estimate - n)) / n;
+    assertTrue(relativeError < 0.02, "At 1M keys, relative error " + relativeError + " exceeds 2%");
+  }
+
+  @Test
+  public void testMergeNullThrows() {
+    HyperLogLogSketch hll = new HyperLogLogSketch();
+    assertThrows(IllegalArgumentException.class, () -> hll.merge(null));
   }
 }

--- a/internal/venice-common/src/test/java/com/linkedin/venice/utils/HyperLogLogSketchTest.java
+++ b/internal/venice-common/src/test/java/com/linkedin/venice/utils/HyperLogLogSketchTest.java
@@ -1,0 +1,633 @@
+package com.linkedin.venice.utils;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertThrows;
+import static org.testng.Assert.assertTrue;
+
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import org.testng.annotations.Test;
+
+
+public class HyperLogLogSketchTest {
+  @Test
+  public void testEmptySketch() {
+    HyperLogLogSketch hll = new HyperLogLogSketch();
+    assertTrue(hll.isEmpty());
+    assertEquals(hll.estimate(), 0L);
+    assertEquals(hll.getPrecision(), 14);
+    assertEquals(hll.getRegisterCount(), 16384);
+  }
+
+  @Test
+  public void testSingleElement() {
+    HyperLogLogSketch hll = new HyperLogLogSketch();
+    hll.add("hello".getBytes(StandardCharsets.UTF_8));
+    assertFalse(hll.isEmpty());
+    assertEquals(hll.estimate(), 1L);
+  }
+
+  @Test
+  public void testDuplicatesSuppressed() {
+    HyperLogLogSketch hll = new HyperLogLogSketch();
+    byte[] key = "same-key".getBytes(StandardCharsets.UTF_8);
+    for (int i = 0; i < 10000; i++) {
+      hll.add(key);
+    }
+    assertEquals(hll.estimate(), 1L);
+  }
+
+  @Test
+  public void testAccuracyWith100kKeys() {
+    HyperLogLogSketch hll = new HyperLogLogSketch();
+    int n = 100_000;
+    for (int i = 0; i < n; i++) {
+      hll.add(("key-" + i).getBytes(StandardCharsets.UTF_8));
+    }
+    long estimate = hll.estimate();
+    double relativeError = Math.abs((double) (estimate - n)) / n;
+    assertTrue(relativeError < 0.03, "Relative error " + relativeError + " exceeds 3%");
+  }
+
+  @Test
+  public void testMergeDisjoint() {
+    HyperLogLogSketch a = new HyperLogLogSketch();
+    HyperLogLogSketch b = new HyperLogLogSketch();
+    for (int i = 0; i < 10_000; i++) {
+      a.add(("a-" + i).getBytes(StandardCharsets.UTF_8));
+      b.add(("b-" + i).getBytes(StandardCharsets.UTF_8));
+    }
+    a.merge(b);
+    double relativeError = Math.abs((double) (a.estimate() - 20_000)) / 20_000;
+    assertTrue(relativeError < 0.03, "Merged estimate error " + relativeError + " exceeds 3%");
+  }
+
+  @Test
+  public void testMergeWithOverlap() {
+    HyperLogLogSketch a = new HyperLogLogSketch();
+    HyperLogLogSketch b = new HyperLogLogSketch();
+    for (int i = 0; i < 10_000; i++) {
+      a.add(("key-" + i).getBytes(StandardCharsets.UTF_8));
+      b.add(("key-" + i).getBytes(StandardCharsets.UTF_8));
+    }
+    for (int i = 10_000; i < 20_000; i++) {
+      b.add(("key-" + i).getBytes(StandardCharsets.UTF_8));
+    }
+    a.merge(b);
+    double relativeError = Math.abs((double) (a.estimate() - 20_000)) / 20_000;
+    assertTrue(relativeError < 0.03, "Overlap merged error " + relativeError + " exceeds 3%");
+  }
+
+  @Test
+  public void testCopy() {
+    HyperLogLogSketch hll = new HyperLogLogSketch();
+    for (int i = 0; i < 1000; i++) {
+      hll.add(("key-" + i).getBytes(StandardCharsets.UTF_8));
+    }
+    HyperLogLogSketch copy = hll.copy();
+    assertEquals(copy.estimate(), hll.estimate());
+    // Mutating copy should not affect original
+    copy.reset();
+    assertTrue(copy.isEmpty());
+    assertFalse(hll.isEmpty());
+  }
+
+  @Test
+  public void testReset() {
+    HyperLogLogSketch hll = new HyperLogLogSketch();
+    hll.add("key".getBytes(StandardCharsets.UTF_8));
+    assertFalse(hll.isEmpty());
+    hll.reset();
+    assertTrue(hll.isEmpty());
+    assertEquals(hll.estimate(), 0L);
+  }
+
+  @Test
+  public void testNullAndEmptyIgnored() {
+    HyperLogLogSketch hll = new HyperLogLogSketch();
+    hll.add(null);
+    hll.add(new byte[0]);
+    assertTrue(hll.isEmpty());
+  }
+
+  @Test
+  public void testAddHash() {
+    HyperLogLogSketch hll1 = new HyperLogLogSketch();
+    HyperLogLogSketch hll2 = new HyperLogLogSketch();
+    byte[] key = "test-key".getBytes(StandardCharsets.UTF_8);
+    hll1.add(key);
+    hll2.addHash(HyperLogLogSketch.hash64(key));
+    assertEquals(hll1.estimate(), hll2.estimate());
+  }
+
+  // ---- Serialization tests ----
+
+  @Test
+  public void testSerializationRoundTrip() {
+    HyperLogLogSketch hll = new HyperLogLogSketch();
+    for (int i = 0; i < 50_000; i++) {
+      hll.add(("key-" + i).getBytes(StandardCharsets.UTF_8));
+    }
+    long originalEstimate = hll.estimate();
+
+    byte[] bytes = hll.toBytes();
+    assertEquals(bytes.length, 1 + 16384); // 1 byte precision + 2^14 registers
+    assertEquals(bytes[0], (byte) 14); // precision
+
+    HyperLogLogSketch restored = HyperLogLogSketch.fromBytes(bytes);
+    assertEquals(restored.estimate(), originalEstimate);
+    assertEquals(restored.getPrecision(), 14);
+  }
+
+  @Test
+  public void testByteBufferRoundTrip() {
+    HyperLogLogSketch hll = new HyperLogLogSketch();
+    for (int i = 0; i < 10_000; i++) {
+      hll.add(("key-" + i).getBytes(StandardCharsets.UTF_8));
+    }
+    long originalEstimate = hll.estimate();
+
+    ByteBuffer buffer = hll.toByteBuffer();
+    HyperLogLogSketch restored = HyperLogLogSketch.fromByteBuffer(buffer);
+    assertEquals(restored.estimate(), originalEstimate);
+  }
+
+  @Test
+  public void testEmptySketchSerializationRoundTrip() {
+    HyperLogLogSketch hll = new HyperLogLogSketch();
+    byte[] bytes = hll.toBytes();
+    HyperLogLogSketch restored = HyperLogLogSketch.fromBytes(bytes);
+    assertTrue(restored.isEmpty());
+    assertEquals(restored.estimate(), 0L);
+  }
+
+  @Test
+  public void testSerializationPreservesAfterMerge() {
+    HyperLogLogSketch a = new HyperLogLogSketch();
+    HyperLogLogSketch b = new HyperLogLogSketch();
+    for (int i = 0; i < 5_000; i++) {
+      a.add(("a-" + i).getBytes(StandardCharsets.UTF_8));
+      b.add(("b-" + i).getBytes(StandardCharsets.UTF_8));
+    }
+    a.merge(b);
+    long mergedEstimate = a.estimate();
+
+    HyperLogLogSketch restored = HyperLogLogSketch.fromBytes(a.toBytes());
+    assertEquals(restored.estimate(), mergedEstimate);
+  }
+
+  @Test
+  public void testDeserializeFromPartialBuffer() {
+    // Simulate reading from a ByteBuffer that has position > 0 (e.g., Avro bytes field)
+    HyperLogLogSketch hll = new HyperLogLogSketch();
+    hll.add("key".getBytes(StandardCharsets.UTF_8));
+    byte[] rawBytes = hll.toBytes();
+
+    // Wrap with offset
+    byte[] padded = new byte[10 + rawBytes.length];
+    System.arraycopy(rawBytes, 0, padded, 10, rawBytes.length);
+    ByteBuffer buffer = ByteBuffer.wrap(padded, 10, rawBytes.length).slice();
+
+    HyperLogLogSketch restored = HyperLogLogSketch.fromByteBuffer(buffer);
+    assertEquals(restored.estimate(), hll.estimate());
+  }
+
+  // ---- Custom precision tests ----
+
+  @Test
+  public void testCustomPrecision() {
+    HyperLogLogSketch hll = new HyperLogLogSketch(10); // 1024 registers
+    assertEquals(hll.getPrecision(), 10);
+    assertEquals(hll.getRegisterCount(), 1024);
+    for (int i = 0; i < 10_000; i++) {
+      hll.add(("key-" + i).getBytes(StandardCharsets.UTF_8));
+    }
+    // Lower precision = higher error, but should still be reasonable
+    double relativeError = Math.abs((double) (hll.estimate() - 10_000)) / 10_000;
+    assertTrue(relativeError < 0.10, "Relative error " + relativeError + " exceeds 10% for p=10");
+  }
+
+  @Test
+  public void testCustomPrecisionSerializationRoundTrip() {
+    HyperLogLogSketch hll = new HyperLogLogSketch(8); // 256 registers
+    hll.add("key".getBytes(StandardCharsets.UTF_8));
+    byte[] bytes = hll.toBytes();
+    assertEquals(bytes.length, 1 + 256);
+    assertEquals(bytes[0], (byte) 8);
+
+    HyperLogLogSketch restored = HyperLogLogSketch.fromBytes(bytes);
+    assertEquals(restored.getPrecision(), 8);
+    assertEquals(restored.estimate(), hll.estimate());
+  }
+
+  // ---- Error handling ----
+
+  @Test
+  public void testInvalidPrecision() {
+    assertThrows(IllegalArgumentException.class, () -> new HyperLogLogSketch(3));
+    assertThrows(IllegalArgumentException.class, () -> new HyperLogLogSketch(19));
+  }
+
+  @Test
+  public void testDeserializeInvalidBytes() {
+    assertThrows(IllegalArgumentException.class, () -> HyperLogLogSketch.fromBytes(null));
+    assertThrows(IllegalArgumentException.class, () -> HyperLogLogSketch.fromBytes(new byte[0]));
+    assertThrows(IllegalArgumentException.class, () -> HyperLogLogSketch.fromBytes(new byte[] { 14 })); // too short
+    assertThrows(IllegalArgumentException.class, () -> HyperLogLogSketch.fromBytes(new byte[] { 3, 0, 0 })); // bad
+                                                                                                             // precision
+  }
+
+  @Test
+  public void testMergeDifferentPrecisionThrows() {
+    HyperLogLogSketch a = new HyperLogLogSketch(10);
+    HyperLogLogSketch b = new HyperLogLogSketch(12);
+    assertThrows(IllegalArgumentException.class, () -> a.merge(b));
+  }
+
+  // ---- Split-merge simulation tests (p=18 for near-zero error) ----
+  // These simulate the real repush scenario where one partition's keys
+  // are spread across multiple Spark tasks (splits).
+  //
+  // p=18 gives ~0.1% standard error. For small key sets (< 50), HLL
+  // is exact due to linear counting correction. For larger sets, we
+  // allow 0.5% tolerance — generous for p=18 but avoids test flakiness.
+
+  private static final int MAX_P = HyperLogLogSketch.MAX_PRECISION; // p=18, 262144 registers, ~0.1% error
+
+  private static void assertEstimateWithinTolerance(long estimate, long expected, double tolerance, String message) {
+    if (expected == 0) {
+      assertEquals(estimate, 0, message);
+      return;
+    }
+    double relativeError = Math.abs((double) (estimate - expected)) / expected;
+    assertTrue(
+        relativeError <= tolerance,
+        message + " | expected=" + expected + ", actual=" + estimate + ", error="
+            + String.format("%.4f%%", relativeError * 100));
+  }
+
+  /** At p=18, tolerance is 0.5% — generous but deterministically passing. */
+  private static final double P18_TOLERANCE = 0.005;
+
+  /**
+   * Scenario: 2 splits read the EXACT SAME keys (full overlap).
+   * After merge, cardinality should equal the number of unique keys, not 2x.
+   *
+   * Split 0a: [k0, k1, k2, ..., k999]
+   * Split 0b: [k0, k1, k2, ..., k999]  (identical keys)
+   * Merged:   unique = 1000
+   */
+  @Test
+  public void testMergeSplitsWithIdenticalKeys() {
+    int numKeys = 1000;
+    HyperLogLogSketch split0a = new HyperLogLogSketch(MAX_P);
+    HyperLogLogSketch split0b = new HyperLogLogSketch(MAX_P);
+
+    for (int i = 0; i < numKeys; i++) {
+      byte[] key = ("key-" + i).getBytes(StandardCharsets.UTF_8);
+      split0a.add(key);
+      split0b.add(key);
+    }
+
+    split0a.merge(split0b);
+    assertEstimateWithinTolerance(
+        split0a.estimate(),
+        numKeys,
+        P18_TOLERANCE,
+        "Merging identical key sets should not inflate cardinality");
+  }
+
+  /**
+   * Scenario: 2 splits read COMPLETELY DISJOINT keys.
+   *
+   * Split 0a: [k0, k1, ..., k499]
+   * Split 0b: [k500, k501, ..., k999]
+   * Merged:   unique = 1000
+   */
+  @Test
+  public void testMergeSplitsWithDisjointKeys() {
+    int keysPerSplit = 500;
+    HyperLogLogSketch split0a = new HyperLogLogSketch(MAX_P);
+    HyperLogLogSketch split0b = new HyperLogLogSketch(MAX_P);
+
+    for (int i = 0; i < keysPerSplit; i++) {
+      split0a.add(("key-" + i).getBytes(StandardCharsets.UTF_8));
+    }
+    for (int i = keysPerSplit; i < keysPerSplit * 2; i++) {
+      split0b.add(("key-" + i).getBytes(StandardCharsets.UTF_8));
+    }
+
+    split0a.merge(split0b);
+    assertEstimateWithinTolerance(
+        split0a.estimate(),
+        keysPerSplit * 2,
+        P18_TOLERANCE,
+        "Merging disjoint splits should sum cardinalities");
+  }
+
+  /**
+   * Scenario: 3 splits with PARTIAL OVERLAP.
+   *
+   * Split 0a: [k0, k1, k2, k3, k4]       (5 keys)
+   * Split 0b: [k3, k4, k5, k6, k7]       (5 keys, 2 overlap with 0a)
+   * Split 0c: [k0, k5, k8, k9]            (4 keys, 2 overlap with 0a+0b)
+   * Merged:   unique = {k0..k9} = 10
+   */
+  @Test
+  public void testMergeThreeSplitsWithPartialOverlap() {
+    HyperLogLogSketch split0a = new HyperLogLogSketch(MAX_P);
+    HyperLogLogSketch split0b = new HyperLogLogSketch(MAX_P);
+    HyperLogLogSketch split0c = new HyperLogLogSketch(MAX_P);
+
+    for (int i = 0; i <= 4; i++) {
+      split0a.add(("key-" + i).getBytes(StandardCharsets.UTF_8));
+    }
+    for (int i = 3; i <= 7; i++) {
+      split0b.add(("key-" + i).getBytes(StandardCharsets.UTF_8));
+    }
+    for (int i: new int[] { 0, 5, 8, 9 }) {
+      split0c.add(("key-" + i).getBytes(StandardCharsets.UTF_8));
+    }
+
+    split0a.merge(split0b);
+    split0a.merge(split0c);
+    // Small key set (10 keys) — exact at p=18 due to linear counting
+    assertEquals(split0a.estimate(), 10L, "3 partially overlapping splits should yield correct union cardinality");
+  }
+
+  /**
+   * Scenario: Many splits (10), each reading the same key set + some unique ones.
+   * Simulates aggressive splitting with high overlap.
+   *
+   * Common keys: [k0..k99]  (100 keys, present in ALL splits)
+   * Per-split unique: [k_split_i_0..k_split_i_9]  (10 unique per split)
+   * Total unique = 100 + 10*10 = 200
+   */
+  @Test
+  public void testMergeManySplitsWithHighOverlap() {
+    int numSplits = 10;
+    int commonKeys = 100;
+    int uniquePerSplit = 10;
+    int expectedUnique = commonKeys + (numSplits * uniquePerSplit);
+
+    HyperLogLogSketch[] splits = new HyperLogLogSketch[numSplits];
+    for (int s = 0; s < numSplits; s++) {
+      splits[s] = new HyperLogLogSketch(MAX_P);
+      // Common keys in every split
+      for (int i = 0; i < commonKeys; i++) {
+        splits[s].add(("common-" + i).getBytes(StandardCharsets.UTF_8));
+      }
+      // Unique keys per split
+      for (int i = 0; i < uniquePerSplit; i++) {
+        splits[s].add(("split-" + s + "-unique-" + i).getBytes(StandardCharsets.UTF_8));
+      }
+    }
+
+    // Merge all into splits[0]
+    for (int s = 1; s < numSplits; s++) {
+      splits[0].merge(splits[s]);
+    }
+
+    assertEstimateWithinTolerance(
+        splits[0].estimate(),
+        expectedUnique,
+        P18_TOLERANCE,
+        "Many splits with high overlap should yield correct union");
+  }
+
+  /**
+   * Scenario: Single key added across 100 splits.
+   * Cardinality must remain 1 after all merges.
+   */
+  @Test
+  public void testMergeManySplitsSingleKey() {
+    int numSplits = 100;
+    byte[] key = "the-only-key".getBytes(StandardCharsets.UTF_8);
+
+    HyperLogLogSketch merged = new HyperLogLogSketch(MAX_P);
+    for (int s = 0; s < numSplits; s++) {
+      HyperLogLogSketch split = new HyperLogLogSketch(MAX_P);
+      split.add(key);
+      merged.merge(split);
+    }
+
+    assertEquals(merged.estimate(), 1L, "Same key across 100 splits should still be 1 unique");
+  }
+
+  /**
+   * Scenario: Merge order should not matter (commutativity + associativity).
+   *
+   * (A merge B) merge C == (C merge A) merge B == A merge (B merge C)
+   */
+  @Test
+  public void testMergeOrderIndependence() {
+    HyperLogLogSketch a = new HyperLogLogSketch(MAX_P);
+    HyperLogLogSketch b = new HyperLogLogSketch(MAX_P);
+    HyperLogLogSketch c = new HyperLogLogSketch(MAX_P);
+
+    for (int i = 0; i < 100; i++) {
+      a.add(("a-" + i).getBytes(StandardCharsets.UTF_8));
+    }
+    for (int i = 50; i < 200; i++) {
+      b.add(("b-" + i).getBytes(StandardCharsets.UTF_8));
+    }
+    for (int i = 150; i < 300; i++) {
+      c.add(("c-" + i).getBytes(StandardCharsets.UTF_8));
+    }
+
+    // Order 1: (A merge B) merge C
+    HyperLogLogSketch order1 = a.copy();
+    order1.merge(b.copy());
+    order1.merge(c.copy());
+
+    // Order 2: (C merge A) merge B
+    HyperLogLogSketch order2 = c.copy();
+    order2.merge(a.copy());
+    order2.merge(b.copy());
+
+    // Order 3: A merge (B merge C)
+    HyperLogLogSketch bc = b.copy();
+    bc.merge(c.copy());
+    HyperLogLogSketch order3 = a.copy();
+    order3.merge(bc);
+
+    assertEquals(order1.estimate(), order2.estimate(), "Merge must be order-independent (1 vs 2)");
+    assertEquals(order1.estimate(), order3.estimate(), "Merge must be order-independent (1 vs 3)");
+  }
+
+  /**
+   * Scenario: Idempotency — merging the same sketch multiple times should not change the result.
+   */
+  @Test
+  public void testMergeIdempotency() {
+    HyperLogLogSketch hll = new HyperLogLogSketch(MAX_P);
+    for (int i = 0; i < 500; i++) {
+      hll.add(("key-" + i).getBytes(StandardCharsets.UTF_8));
+    }
+    long estimateBefore = hll.estimate();
+
+    HyperLogLogSketch duplicate = hll.copy();
+    hll.merge(duplicate);
+    assertEquals(hll.estimate(), estimateBefore, "Merging a copy should not change estimate (idempotent)");
+
+    // Merge again — still idempotent
+    hll.merge(duplicate);
+    hll.merge(duplicate);
+    hll.merge(duplicate);
+    assertEquals(hll.estimate(), estimateBefore, "Repeated self-merge must remain idempotent");
+  }
+
+  /**
+   * Scenario: Realistic repush simulation.
+   * Partition 0 has 50,000 unique keys split across 5 tasks.
+   * Each task reads a contiguous range (like PubSubSplitPlanner splits by offset range).
+   */
+  @Test
+  public void testRealisticRepushSplitSimulation() {
+    int totalKeys = 50_000;
+    int numSplits = 5;
+    int keysPerSplit = totalKeys / numSplits;
+
+    HyperLogLogSketch[] splits = new HyperLogLogSketch[numSplits];
+    for (int s = 0; s < numSplits; s++) {
+      splits[s] = new HyperLogLogSketch(MAX_P);
+      int start = s * keysPerSplit;
+      int end = start + keysPerSplit;
+      for (int i = start; i < end; i++) {
+        splits[s].add(("partition0-key-" + i).getBytes(StandardCharsets.UTF_8));
+      }
+    }
+
+    // Merge all splits (simulating Spark driver accumulator merge)
+    HyperLogLogSketch merged = splits[0];
+    for (int s = 1; s < numSplits; s++) {
+      merged.merge(splits[s]);
+    }
+
+    assertEstimateWithinTolerance(
+        merged.estimate(),
+        totalKeys,
+        P18_TOLERANCE,
+        "Repush simulation: merged splits should match total unique keys");
+  }
+
+  /**
+   * Scenario: Splits with duplicates within each split (compaction scenario).
+   * Source VT might have multiple versions of same key within one offset range.
+   *
+   * Split 0a: [k0, k0, k1, k1, k2, k2]  (3 unique, 6 records)
+   * Split 0b: [k2, k3, k3, k4]           (3 unique, 4 records)
+   * Merged:   unique = {k0, k1, k2, k3, k4} = 5
+   */
+  @Test
+  public void testMergeSplitsWithWithinSplitDuplicates() {
+    HyperLogLogSketch split0a = new HyperLogLogSketch(MAX_P);
+    HyperLogLogSketch split0b = new HyperLogLogSketch(MAX_P);
+
+    // Split 0a: each key added twice (simulates multiple versions in source VT)
+    for (int i = 0; i < 3; i++) {
+      byte[] key = ("key-" + i).getBytes(StandardCharsets.UTF_8);
+      split0a.add(key);
+      split0a.add(key); // duplicate within split
+    }
+
+    // Split 0b: overlap on k2, plus new keys with duplicates
+    split0b.add("key-2".getBytes(StandardCharsets.UTF_8));
+    split0b.add("key-3".getBytes(StandardCharsets.UTF_8));
+    split0b.add("key-3".getBytes(StandardCharsets.UTF_8)); // duplicate
+    split0b.add("key-4".getBytes(StandardCharsets.UTF_8));
+
+    split0a.merge(split0b);
+    // Small key set (5 keys) — exact at p=18 due to linear counting
+    assertEquals(
+        split0a.estimate(),
+        5L,
+        "Within-split duplicates + cross-split overlap should yield correct unique count");
+  }
+
+  /**
+   * Scenario: Empty split merged with non-empty split.
+   * One split had no records (empty partition range).
+   */
+  @Test
+  public void testMergeWithEmptySplit() {
+    HyperLogLogSketch nonEmpty = new HyperLogLogSketch(MAX_P);
+    HyperLogLogSketch empty = new HyperLogLogSketch(MAX_P);
+
+    for (int i = 0; i < 100; i++) {
+      nonEmpty.add(("key-" + i).getBytes(StandardCharsets.UTF_8));
+    }
+
+    nonEmpty.merge(empty);
+    // Small set (100 keys) — exact at p=18 due to linear counting
+    assertEquals(nonEmpty.estimate(), 100L, "Merging empty split should not change estimate");
+
+    // Also test empty.merge(nonEmpty)
+    empty.merge(nonEmpty);
+    assertEquals(empty.estimate(), 100L, "Empty merged with non-empty should equal non-empty");
+  }
+
+  /**
+   * Large-scale exactness test: p=18 with 100,000 unique keys.
+   * At p=18 (~0.1% std error), for 100K keys the estimate should be within ~100 of exact.
+   */
+  @Test
+  public void testMaxPrecisionExactness() {
+    int n = 100_000;
+    HyperLogLogSketch hll = new HyperLogLogSketch(MAX_P);
+    for (int i = 0; i < n; i++) {
+      hll.add(("key-" + i).getBytes(StandardCharsets.UTF_8));
+    }
+    assertEstimateWithinTolerance(hll.estimate(), n, P18_TOLERANCE, "At p=18, 100K keys should be within 0.5%");
+  }
+
+  /**
+   * Large-scale split-merge exactness: 100K keys split across 10 tasks at p=18.
+   */
+  @Test
+  public void testMaxPrecisionSplitMergeExactness() {
+    int totalKeys = 100_000;
+    int numSplits = 10;
+    int keysPerSplit = totalKeys / numSplits;
+
+    HyperLogLogSketch merged = new HyperLogLogSketch(MAX_P);
+    for (int s = 0; s < numSplits; s++) {
+      HyperLogLogSketch split = new HyperLogLogSketch(MAX_P);
+      for (int i = s * keysPerSplit; i < (s + 1) * keysPerSplit; i++) {
+        split.add(("key-" + i).getBytes(StandardCharsets.UTF_8));
+      }
+      merged.merge(split);
+    }
+
+    assertEstimateWithinTolerance(
+        merged.estimate(),
+        totalKeys,
+        P18_TOLERANCE,
+        "Split-merge at p=18: 100K keys across 10 splits should be within 0.5%");
+  }
+
+  // ---- Hash function test ----
+
+  @Test
+  public void testHash64Deterministic() {
+    byte[] key = "deterministic".getBytes(StandardCharsets.UTF_8);
+    long h1 = HyperLogLogSketch.hash64(key);
+    long h2 = HyperLogLogSketch.hash64(key);
+    assertEquals(h1, h2);
+  }
+
+  @Test
+  public void testHash64Distribution() {
+    // Verify hash distributes across all 4 quadrants of the 64-bit space
+    boolean hasPositive = false, hasNegative = false;
+    for (int i = 0; i < 100; i++) {
+      long h = HyperLogLogSketch.hash64(("key-" + i).getBytes(StandardCharsets.UTF_8));
+      if (h >= 0)
+        hasPositive = true;
+      if (h < 0)
+        hasNegative = true;
+    }
+    assertTrue(hasPositive && hasNegative, "Hash should produce both positive and negative values");
+  }
+}

--- a/internal/venice-common/src/test/java/com/linkedin/venice/utils/HyperLogLogSketchTest.java
+++ b/internal/venice-common/src/test/java/com/linkedin/venice/utils/HyperLogLogSketchTest.java
@@ -314,14 +314,14 @@ public class HyperLogLogSketchTest {
     for (int i = 0; i < keysPerSplit; i++) {
       split0a.add(("key-" + i).getBytes(StandardCharsets.UTF_8));
     }
-    for (int i = keysPerSplit; i < keysPerSplit * 2; i++) {
+    for (int i = keysPerSplit; i < (long) keysPerSplit * 2; i++) {
       split0b.add(("key-" + i).getBytes(StandardCharsets.UTF_8));
     }
 
     split0a.merge(split0b);
     assertEstimateWithinTolerance(
         split0a.estimate(),
-        keysPerSplit * 2,
+        (long) keysPerSplit * 2,
         P18_TOLERANCE,
         "Merging disjoint splits should sum cardinalities");
   }

--- a/internal/venice-common/src/test/java/com/linkedin/venice/writer/VeniceWriterUnitTest.java
+++ b/internal/venice-common/src/test/java/com/linkedin/venice/writer/VeniceWriterUnitTest.java
@@ -76,7 +76,9 @@ import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Properties;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
@@ -1345,5 +1347,113 @@ public class VeniceWriterUnitTest {
       // expected
     }
     verify(mockHook, never()).onBeforeProduce(any(VeniceWriterHook.OperationType.class), anyInt(), anyInt());
+  }
+
+  @Test(timeOut = TIMEOUT)
+  public void testBroadcastEndOfPushWithPartitionRecordCounts() {
+    PubSubProducerAdapter mockedProducer = mock(PubSubProducerAdapter.class);
+    when(mockedProducer.sendMessage(any(), any(), any(), any(), any(), any()))
+        .thenReturn(CompletableFuture.completedFuture(null));
+
+    int partitionCount = 3;
+    String testTopic = "test_v1";
+    VeniceWriterOptions veniceWriterOptions =
+        new VeniceWriterOptions.Builder(testTopic).setPartitioner(new DefaultVenicePartitioner())
+            .setPartitionCount(partitionCount)
+            .build();
+    VeniceWriter<KafkaKey, byte[], byte[]> writer =
+        new VeniceWriter(veniceWriterOptions, VeniceProperties.empty(), mockedProducer);
+
+    Map<Integer, Long> partitionRecordCounts = new HashMap<>();
+    partitionRecordCounts.put(0, 100L);
+    partitionRecordCounts.put(1, 200L);
+    partitionRecordCounts.put(2, 300L);
+
+    writer.broadcastEndOfPush(new HashMap<>(), partitionRecordCounts);
+
+    // Capture all sendMessage calls (SOS + EOP + EOS for each partition)
+    ArgumentCaptor<Integer> partitionCaptor = ArgumentCaptor.forClass(Integer.class);
+    ArgumentCaptor<KafkaMessageEnvelope> kmeCaptor = ArgumentCaptor.forClass(KafkaMessageEnvelope.class);
+    ArgumentCaptor<PubSubMessageHeaders> headersCaptor = ArgumentCaptor.forClass(PubSubMessageHeaders.class);
+    verify(mockedProducer, atLeast(6)).sendMessage(
+        anyString(),
+        partitionCaptor.capture(),
+        any(),
+        kmeCaptor.capture(),
+        headersCaptor.capture(),
+        any());
+
+    // Filter only EOP messages and verify they carry the correct prc header
+    List<Integer> allPartitions = partitionCaptor.getAllValues();
+    List<KafkaMessageEnvelope> allKmes = kmeCaptor.getAllValues();
+    List<PubSubMessageHeaders> allHeaders = headersCaptor.getAllValues();
+
+    Map<Integer, Long> observedCounts = new HashMap<>();
+    for (int i = 0; i < allKmes.size(); i++) {
+      KafkaMessageEnvelope kme = allKmes.get(i);
+      if (kme.messageType == MessageType.CONTROL_MESSAGE.getValue()) {
+        ControlMessage cm = (ControlMessage) kme.payloadUnion;
+        if (ControlMessageType.valueOf(cm) == ControlMessageType.END_OF_PUSH) {
+          int partition = allPartitions.get(i);
+          PubSubMessageHeaders headers = allHeaders.get(i);
+          PubSubMessageHeader prcHeader = headers.get(PubSubMessageHeaders.VENICE_PARTITION_RECORD_COUNT_HEADER);
+          Assert.assertNotNull(prcHeader, "Partition " + partition + " should have prc header");
+          long actualCount = ByteBuffer.wrap(prcHeader.value()).getLong();
+          observedCounts.put(partition, actualCount);
+        }
+      }
+    }
+
+    assertEquals(observedCounts.size(), 3, "Should have EOP for all 3 partitions");
+    for (Map.Entry<Integer, Long> entry: partitionRecordCounts.entrySet()) {
+      assertEquals(
+          observedCounts.get(entry.getKey()),
+          entry.getValue(),
+          "Record count mismatch for partition " + entry.getKey());
+    }
+  }
+
+  @Test(timeOut = TIMEOUT)
+  public void testBroadcastEndOfPushWithNullCounts() {
+    PubSubProducerAdapter mockedProducer = mock(PubSubProducerAdapter.class);
+    when(mockedProducer.sendMessage(any(), any(), any(), any(), any(), any()))
+        .thenReturn(CompletableFuture.completedFuture(null));
+
+    int partitionCount = 2;
+    String testTopic = "test_v2";
+    VeniceWriterOptions veniceWriterOptions =
+        new VeniceWriterOptions.Builder(testTopic).setPartitioner(new DefaultVenicePartitioner())
+            .setPartitionCount(partitionCount)
+            .build();
+    VeniceWriter<KafkaKey, byte[], byte[]> writer =
+        new VeniceWriter(veniceWriterOptions, VeniceProperties.empty(), mockedProducer);
+
+    // Call with null partitionRecordCounts for backward compatibility
+    writer.broadcastEndOfPush(new HashMap<>(), null);
+
+    // Capture all sendMessage calls
+    ArgumentCaptor<PubSubMessageHeaders> headersCaptor = ArgumentCaptor.forClass(PubSubMessageHeaders.class);
+    ArgumentCaptor<KafkaMessageEnvelope> kmeCaptor = ArgumentCaptor.forClass(KafkaMessageEnvelope.class);
+    verify(mockedProducer, atLeast(4))
+        .sendMessage(anyString(), any(), any(), kmeCaptor.capture(), headersCaptor.capture(), any());
+
+    // Filter only EOP messages and verify they have no prc header
+    List<KafkaMessageEnvelope> allKmes = kmeCaptor.getAllValues();
+    List<PubSubMessageHeaders> allHeaders = headersCaptor.getAllValues();
+
+    int eopCount = 0;
+    for (int i = 0; i < allKmes.size(); i++) {
+      KafkaMessageEnvelope kme = allKmes.get(i);
+      if (kme.messageType == MessageType.CONTROL_MESSAGE.getValue()) {
+        ControlMessage cm = (ControlMessage) kme.payloadUnion;
+        if (ControlMessageType.valueOf(cm) == ControlMessageType.END_OF_PUSH) {
+          eopCount++;
+          PubSubMessageHeaders headers = allHeaders.get(i);
+          PubSubMessageHeader prcHeader = headers.get(PubSubMessageHeaders.VENICE_PARTITION_RECORD_COUNT_HEADER);
+          Assert.assertNull(prcHeader, "EOP with null counts should not have prc header");
+        }
+      }
+    }
+    assertEquals(eopCount, partitionCount, "Should have EOP for all partitions");
   }
 }


### PR DESCRIPTION
## Summary
During KIF repush, track read-side unique key cardinality via HLL and compare with write-side output count at the driver. Catches silent record loss within the VPJ pipeline.

**Part 4 of 4** — depends on Part 1 (#2663) and Part 2 (#2664).

### Two-tier verification
- **Aggregate HLL** (always runs): `HLL_cardinality ≈ outputCount + ttlFiltered`. Fails push if divergence > tolerance.
- **Per-partition HLL** (diagnostic): when partition counts match, compares per-partition HLL vs write count. Log-only.

### Key design decisions
- HLL accumulators isolated from `DataWriterAccumulators` to prevent Spark task serialization issues
- Only created for KIF repush jobs (`isSourceKafka=true`)
- Multi-split correctness: `MapHyperLogLogAccumulator.merge()` does per-partition HLL union (element-wise max)

### Config
- `repush.hll.verification.enabled` (default true)
- `repush.hll.error.tolerance` (default 5%)
- Spark path only (MR inherits no-op defaults)

## Test plan
- [x] `HyperLogLogAccumulatorTest` — 9 tests