### PR TITLE
[admin-tool][controller] Add command to update unclean.leader.election.enable on Kafka topics

### DIFF
--- a/clients/venice-admin-tool/src/main/java/com/linkedin/venice/AdminTool.java
+++ b/clients/venice-admin-tool/src/main/java/com/linkedin/venice/AdminTool.java
@@ -560,6 +560,9 @@ public class AdminTool {
         case UPDATE_KAFKA_TOPIC_MIN_IN_SYNC_REPLICA:
           updateKafkaTopicMinInSyncReplica(cmd);
           break;
+        case UPDATE_KAFKA_TOPIC_UNCLEAN_LEADER_ELECTION:
+          updateKafkaTopicUncleanLeaderElection(cmd);
+          break;
         case START_FABRIC_BUILDOUT:
           startFabricBuildout(cmd);
           break;
@@ -3070,17 +3073,17 @@ public class AdminTool {
   private static void updateKafkaTopicMinInSyncReplica(CommandLine cmd) {
     updateKafkaTopicConfig(cmd, client -> {
       String kafkaTopicName = getRequiredArgument(cmd, Arg.KAFKA_TOPIC_NAME);
-      String minISRArg = getOptionalArgument(cmd, Arg.KAFKA_TOPIC_MIN_IN_SYNC_REPLICA);
-      String uleArg = getOptionalArgument(cmd, Arg.KAFKA_TOPIC_UNCLEAN_LEADER_ELECTION_ENABLED);
-      if (minISRArg != null) {
-        int kafkaTopicMinISR = Integer.parseInt(minISRArg);
-        client.updateKafkaTopicMinInSyncReplica(kafkaTopicName, kafkaTopicMinISR);
-      }
-      if (uleArg != null) {
-        boolean uncleanLeaderElectionEnabled = Boolean.parseBoolean(uleArg);
-        client.updateKafkaTopicUncleanLeaderElection(kafkaTopicName, uncleanLeaderElectionEnabled);
-      }
-      return new ControllerResponse();
+      int kafkaTopicMinISR = Integer.parseInt(getRequiredArgument(cmd, Arg.KAFKA_TOPIC_MIN_IN_SYNC_REPLICA));
+      return client.updateKafkaTopicMinInSyncReplica(kafkaTopicName, kafkaTopicMinISR);
+    });
+  }
+
+  private static void updateKafkaTopicUncleanLeaderElection(CommandLine cmd) {
+    updateKafkaTopicConfig(cmd, client -> {
+      String kafkaTopicName = getRequiredArgument(cmd, Arg.KAFKA_TOPIC_NAME);
+      boolean uncleanLeaderElectionEnabled =
+          Boolean.parseBoolean(getRequiredArgument(cmd, Arg.KAFKA_TOPIC_UNCLEAN_LEADER_ELECTION_ENABLED));
+      return client.updateKafkaTopicUncleanLeaderElection(kafkaTopicName, uncleanLeaderElectionEnabled);
     });
   }
 

--- a/clients/venice-admin-tool/src/main/java/com/linkedin/venice/AdminTool.java
+++ b/clients/venice-admin-tool/src/main/java/com/linkedin/venice/AdminTool.java
@@ -560,9 +560,6 @@ public class AdminTool {
         case UPDATE_KAFKA_TOPIC_MIN_IN_SYNC_REPLICA:
           updateKafkaTopicMinInSyncReplica(cmd);
           break;
-        case UPDATE_KAFKA_TOPIC_UNCLEAN_LEADER_ELECTION:
-          updateKafkaTopicUncleanLeaderElection(cmd);
-          break;
         case START_FABRIC_BUILDOUT:
           startFabricBuildout(cmd);
           break;
@@ -3073,17 +3070,17 @@ public class AdminTool {
   private static void updateKafkaTopicMinInSyncReplica(CommandLine cmd) {
     updateKafkaTopicConfig(cmd, client -> {
       String kafkaTopicName = getRequiredArgument(cmd, Arg.KAFKA_TOPIC_NAME);
-      int kafkaTopicMinISR = Integer.parseInt(getRequiredArgument(cmd, Arg.KAFKA_TOPIC_MIN_IN_SYNC_REPLICA));
-      return client.updateKafkaTopicMinInSyncReplica(kafkaTopicName, kafkaTopicMinISR);
-    });
-  }
-
-  private static void updateKafkaTopicUncleanLeaderElection(CommandLine cmd) {
-    updateKafkaTopicConfig(cmd, client -> {
-      String kafkaTopicName = getRequiredArgument(cmd, Arg.KAFKA_TOPIC_NAME);
-      boolean uncleanLeaderElectionEnabled =
-          Boolean.parseBoolean(getRequiredArgument(cmd, Arg.KAFKA_TOPIC_UNCLEAN_LEADER_ELECTION_ENABLED));
-      return client.updateKafkaTopicUncleanLeaderElection(kafkaTopicName, uncleanLeaderElectionEnabled);
+      String minISRArg = getOptionalArgument(cmd, Arg.KAFKA_TOPIC_MIN_IN_SYNC_REPLICA);
+      String uleArg = getOptionalArgument(cmd, Arg.KAFKA_TOPIC_UNCLEAN_LEADER_ELECTION_ENABLED);
+      if (minISRArg != null) {
+        int kafkaTopicMinISR = Integer.parseInt(minISRArg);
+        client.updateKafkaTopicMinInSyncReplica(kafkaTopicName, kafkaTopicMinISR);
+      }
+      if (uleArg != null) {
+        boolean uncleanLeaderElectionEnabled = Boolean.parseBoolean(uleArg);
+        client.updateKafkaTopicUncleanLeaderElection(kafkaTopicName, uncleanLeaderElectionEnabled);
+      }
+      return new ControllerResponse();
     });
   }
 

--- a/clients/venice-admin-tool/src/main/java/com/linkedin/venice/AdminTool.java
+++ b/clients/venice-admin-tool/src/main/java/com/linkedin/venice/AdminTool.java
@@ -560,6 +560,9 @@ public class AdminTool {
         case UPDATE_KAFKA_TOPIC_MIN_IN_SYNC_REPLICA:
           updateKafkaTopicMinInSyncReplica(cmd);
           break;
+        case UPDATE_KAFKA_TOPIC_UNCLEAN_LEADER_ELECTION:
+          updateKafkaTopicUncleanLeaderElection(cmd);
+          break;
         case START_FABRIC_BUILDOUT:
           startFabricBuildout(cmd);
           break;
@@ -3072,6 +3075,15 @@ public class AdminTool {
       String kafkaTopicName = getRequiredArgument(cmd, Arg.KAFKA_TOPIC_NAME);
       int kafkaTopicMinISR = Integer.parseInt(getRequiredArgument(cmd, Arg.KAFKA_TOPIC_MIN_IN_SYNC_REPLICA));
       return client.updateKafkaTopicMinInSyncReplica(kafkaTopicName, kafkaTopicMinISR);
+    });
+  }
+
+  private static void updateKafkaTopicUncleanLeaderElection(CommandLine cmd) {
+    updateKafkaTopicConfig(cmd, client -> {
+      String kafkaTopicName = getRequiredArgument(cmd, Arg.KAFKA_TOPIC_NAME);
+      boolean uncleanLeaderElectionEnabled =
+          Boolean.parseBoolean(getRequiredArgument(cmd, Arg.KAFKA_TOPIC_UNCLEAN_LEADER_ELECTION_ENABLED));
+      return client.updateKafkaTopicUncleanLeaderElection(kafkaTopicName, uncleanLeaderElectionEnabled);
     });
   }
 

--- a/clients/venice-admin-tool/src/main/java/com/linkedin/venice/Arg.java
+++ b/clients/venice-admin-tool/src/main/java/com/linkedin/venice/Arg.java
@@ -234,6 +234,10 @@ public enum Arg {
   KAFKA_RT_TOPICS_MIN_IN_SYNC_REPLICAS(
       "kafka-rt-topic-min-in-sync-replica", "krtmisr", true, "Kafka topic rt minISR config"
   ),
+  KAFKA_TOPIC_UNCLEAN_LEADER_ELECTION_ENABLED(
+      "kafka-topic-unclean-leader-election-enabled", "ktulee", true,
+      "Enable/disable Kafka unclean leader election for a topic"
+  ),
   CHILD_CONTROLLER_ADMIN_TOPIC_CONSUMPTION_ENABLED(
       ConfigKeys.CHILD_CONTROLLER_ADMIN_TOPIC_CONSUMPTION_ENABLED, "atc", true,
       "whether child controller consumes admin topic"

--- a/clients/venice-admin-tool/src/main/java/com/linkedin/venice/Command.java
+++ b/clients/venice-admin-tool/src/main/java/com/linkedin/venice/Command.java
@@ -75,6 +75,7 @@ import static com.linkedin.venice.Arg.KAFKA_TOPIC_MIN_IN_SYNC_REPLICA;
 import static com.linkedin.venice.Arg.KAFKA_TOPIC_NAME;
 import static com.linkedin.venice.Arg.KAFKA_TOPIC_PARTITION;
 import static com.linkedin.venice.Arg.KAFKA_TOPIC_RETENTION_IN_MS;
+import static com.linkedin.venice.Arg.KAFKA_TOPIC_UNCLEAN_LEADER_ELECTION_ENABLED;
 import static com.linkedin.venice.Arg.KEY;
 import static com.linkedin.venice.Arg.KEY_SCHEMA;
 import static com.linkedin.venice.Arg.KEY_URN_COMPRESSION_EANBLED;
@@ -519,6 +520,11 @@ public enum Command {
   UPDATE_KAFKA_TOPIC_MIN_IN_SYNC_REPLICA(
       "update-kafka-topic-min-in-sync-replica", "Update minISR of a topic through controllers",
       new Arg[] { URL, KAFKA_TOPIC_NAME, KAFKA_TOPIC_MIN_IN_SYNC_REPLICA }, new Arg[] { CLUSTER }
+  ),
+  UPDATE_KAFKA_TOPIC_UNCLEAN_LEADER_ELECTION(
+      "update-kafka-topic-unclean-leader-election",
+      "Update unclean leader election config of a topic through controllers",
+      new Arg[] { URL, KAFKA_TOPIC_NAME, KAFKA_TOPIC_UNCLEAN_LEADER_ELECTION_ENABLED }, new Arg[] { CLUSTER }
   ),
   START_FABRIC_BUILDOUT(
       "start-fabric-buildout",

--- a/clients/venice-admin-tool/src/main/java/com/linkedin/venice/Command.java
+++ b/clients/venice-admin-tool/src/main/java/com/linkedin/venice/Command.java
@@ -518,9 +518,13 @@ public enum Command {
       new Arg[] { URL, KAFKA_TOPIC_NAME, KAFKA_TOPIC_RETENTION_IN_MS }, new Arg[] { CLUSTER }
   ),
   UPDATE_KAFKA_TOPIC_MIN_IN_SYNC_REPLICA(
-      "update-kafka-topic-min-in-sync-replica", "Update minISR and/or unclean leader election config of a topic",
-      new Arg[] { URL, KAFKA_TOPIC_NAME },
-      new Arg[] { CLUSTER, KAFKA_TOPIC_MIN_IN_SYNC_REPLICA, KAFKA_TOPIC_UNCLEAN_LEADER_ELECTION_ENABLED }
+      "update-kafka-topic-min-in-sync-replica", "Update minISR of a topic through controllers",
+      new Arg[] { URL, KAFKA_TOPIC_NAME, KAFKA_TOPIC_MIN_IN_SYNC_REPLICA }, new Arg[] { CLUSTER }
+  ),
+  UPDATE_KAFKA_TOPIC_UNCLEAN_LEADER_ELECTION(
+      "update-kafka-topic-unclean-leader-election",
+      "Update unclean leader election config of a topic through controllers",
+      new Arg[] { URL, KAFKA_TOPIC_NAME, KAFKA_TOPIC_UNCLEAN_LEADER_ELECTION_ENABLED }, new Arg[] { CLUSTER }
   ),
   START_FABRIC_BUILDOUT(
       "start-fabric-buildout",

--- a/clients/venice-admin-tool/src/main/java/com/linkedin/venice/Command.java
+++ b/clients/venice-admin-tool/src/main/java/com/linkedin/venice/Command.java
@@ -518,13 +518,9 @@ public enum Command {
       new Arg[] { URL, KAFKA_TOPIC_NAME, KAFKA_TOPIC_RETENTION_IN_MS }, new Arg[] { CLUSTER }
   ),
   UPDATE_KAFKA_TOPIC_MIN_IN_SYNC_REPLICA(
-      "update-kafka-topic-min-in-sync-replica", "Update minISR of a topic through controllers",
-      new Arg[] { URL, KAFKA_TOPIC_NAME, KAFKA_TOPIC_MIN_IN_SYNC_REPLICA }, new Arg[] { CLUSTER }
-  ),
-  UPDATE_KAFKA_TOPIC_UNCLEAN_LEADER_ELECTION(
-      "update-kafka-topic-unclean-leader-election",
-      "Update unclean leader election config of a topic through controllers",
-      new Arg[] { URL, KAFKA_TOPIC_NAME, KAFKA_TOPIC_UNCLEAN_LEADER_ELECTION_ENABLED }, new Arg[] { CLUSTER }
+      "update-kafka-topic-min-in-sync-replica", "Update minISR and/or unclean leader election config of a topic",
+      new Arg[] { URL, KAFKA_TOPIC_NAME },
+      new Arg[] { CLUSTER, KAFKA_TOPIC_MIN_IN_SYNC_REPLICA, KAFKA_TOPIC_UNCLEAN_LEADER_ELECTION_ENABLED }
   ),
   START_FABRIC_BUILDOUT(
       "start-fabric-buildout",

--- a/internal/venice-common/src/main/java/com/linkedin/venice/controllerapi/ControllerApiConstants.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/controllerapi/ControllerApiConstants.java
@@ -236,6 +236,8 @@ public class ControllerApiConstants {
   public static final String KAFKA_TOPIC_LOG_COMPACTION_ENABLED = "kafka.topic.log.compaction.enabled";
   public static final String KAFKA_TOPIC_RETENTION_IN_MS = "kafka.topic.retention.in.ms";
   public static final String KAFKA_TOPIC_MIN_IN_SYNC_REPLICA = "kafka.topic.min.in.sync.replica";
+  public static final String KAFKA_TOPIC_UNCLEAN_LEADER_ELECTION_ENABLED =
+      "kafka.topic.unclean.leader.election.enabled";
   public static final String UPSTREAM_POSITION = "upstream_position";
   public static final String ADMIN_OPERATION_PROTOCOL_VERSION = "admin_operation_protocol_version";
 

--- a/internal/venice-common/src/main/java/com/linkedin/venice/controllerapi/ControllerClient.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/controllerapi/ControllerClient.java
@@ -30,6 +30,7 @@ import static com.linkedin.venice.controllerapi.ControllerApiConstants.IS_WRITE_
 import static com.linkedin.venice.controllerapi.ControllerApiConstants.KAFKA_TOPIC_LOG_COMPACTION_ENABLED;
 import static com.linkedin.venice.controllerapi.ControllerApiConstants.KAFKA_TOPIC_MIN_IN_SYNC_REPLICA;
 import static com.linkedin.venice.controllerapi.ControllerApiConstants.KAFKA_TOPIC_RETENTION_IN_MS;
+import static com.linkedin.venice.controllerapi.ControllerApiConstants.KAFKA_TOPIC_UNCLEAN_LEADER_ELECTION_ENABLED;
 import static com.linkedin.venice.controllerapi.ControllerApiConstants.KEY_SCHEMA;
 import static com.linkedin.venice.controllerapi.ControllerApiConstants.LOOK_BACK_MS;
 import static com.linkedin.venice.controllerapi.ControllerApiConstants.NAME;
@@ -751,6 +752,14 @@ public class ControllerClient implements Closeable {
   public ControllerResponse updateKafkaTopicMinInSyncReplica(String kafkaTopicName, int minISR) {
     QueryParams params = newParams().add(TOPIC, kafkaTopicName).add(KAFKA_TOPIC_MIN_IN_SYNC_REPLICA, minISR);
     return request(ControllerRoute.UPDATE_KAFKA_TOPIC_MIN_IN_SYNC_REPLICA, params, ControllerResponse.class);
+  }
+
+  public ControllerResponse updateKafkaTopicUncleanLeaderElection(
+      String kafkaTopicName,
+      boolean uncleanLeaderElectionEnabled) {
+    QueryParams params = newParams().add(TOPIC, kafkaTopicName)
+        .add(KAFKA_TOPIC_UNCLEAN_LEADER_ELECTION_ENABLED, uncleanLeaderElectionEnabled);
+    return request(ControllerRoute.UPDATE_KAFKA_TOPIC_UNCLEAN_LEADER_ELECTION, params, ControllerResponse.class);
   }
 
   public <R extends ControllerResponse> R retryableRequest(int totalAttempts, Function<ControllerClient, R> request) {

--- a/internal/venice-common/src/main/java/com/linkedin/venice/controllerapi/ControllerClient.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/controllerapi/ControllerClient.java
@@ -759,7 +759,7 @@ public class ControllerClient implements Closeable {
       boolean uncleanLeaderElectionEnabled) {
     QueryParams params = newParams().add(TOPIC, kafkaTopicName)
         .add(KAFKA_TOPIC_UNCLEAN_LEADER_ELECTION_ENABLED, uncleanLeaderElectionEnabled);
-    return request(ControllerRoute.UPDATE_KAFKA_TOPIC_UNCLEAN_LEADER_ELECTION, params, ControllerResponse.class);
+    return request(ControllerRoute.UPDATE_KAFKA_TOPIC_MIN_IN_SYNC_REPLICA, params, ControllerResponse.class);
   }
 
   public <R extends ControllerResponse> R retryableRequest(int totalAttempts, Function<ControllerClient, R> request) {

--- a/internal/venice-common/src/main/java/com/linkedin/venice/controllerapi/ControllerClient.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/controllerapi/ControllerClient.java
@@ -759,7 +759,7 @@ public class ControllerClient implements Closeable {
       boolean uncleanLeaderElectionEnabled) {
     QueryParams params = newParams().add(TOPIC, kafkaTopicName)
         .add(KAFKA_TOPIC_UNCLEAN_LEADER_ELECTION_ENABLED, uncleanLeaderElectionEnabled);
-    return request(ControllerRoute.UPDATE_KAFKA_TOPIC_MIN_IN_SYNC_REPLICA, params, ControllerResponse.class);
+    return request(ControllerRoute.UPDATE_KAFKA_TOPIC_UNCLEAN_LEADER_ELECTION, params, ControllerResponse.class);
   }
 
   public <R extends ControllerResponse> R retryableRequest(int totalAttempts, Function<ControllerClient, R> request) {

--- a/internal/venice-common/src/main/java/com/linkedin/venice/controllerapi/ControllerRoute.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/controllerapi/ControllerRoute.java
@@ -295,11 +295,8 @@ public enum ControllerRoute implements VeniceDimensionInterface {
       "/update_kafka_topic_retention", HttpMethod.POST, Arrays.asList(TOPIC, KAFKA_TOPIC_RETENTION_IN_MS)
   ),
   UPDATE_KAFKA_TOPIC_MIN_IN_SYNC_REPLICA(
-      "/update_kafka_topic_min_in_sync_replica", HttpMethod.POST, Arrays.asList(TOPIC, KAFKA_TOPIC_MIN_IN_SYNC_REPLICA)
-  ),
-  UPDATE_KAFKA_TOPIC_UNCLEAN_LEADER_ELECTION(
-      "/update_kafka_topic_unclean_leader_election", HttpMethod.POST,
-      Arrays.asList(TOPIC, KAFKA_TOPIC_UNCLEAN_LEADER_ELECTION_ENABLED)
+      "/update_kafka_topic_min_in_sync_replica", HttpMethod.POST, Collections.singletonList(TOPIC),
+      KAFKA_TOPIC_MIN_IN_SYNC_REPLICA, KAFKA_TOPIC_UNCLEAN_LEADER_ELECTION_ENABLED
   ), GET_ADMIN_TOPIC_METADATA("/get_admin_topic_metadata", HttpMethod.GET, Collections.singletonList(CLUSTER), NAME),
   UPDATE_ADMIN_TOPIC_METADATA(
       "/update_admin_topic_metadata", HttpMethod.POST, Arrays.asList(CLUSTER, EXECUTION_ID), NAME, POSITION,

--- a/internal/venice-common/src/main/java/com/linkedin/venice/controllerapi/ControllerRoute.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/controllerapi/ControllerRoute.java
@@ -40,6 +40,7 @@ import static com.linkedin.venice.controllerapi.ControllerApiConstants.IS_SYSTEM
 import static com.linkedin.venice.controllerapi.ControllerApiConstants.KAFKA_TOPIC_LOG_COMPACTION_ENABLED;
 import static com.linkedin.venice.controllerapi.ControllerApiConstants.KAFKA_TOPIC_MIN_IN_SYNC_REPLICA;
 import static com.linkedin.venice.controllerapi.ControllerApiConstants.KAFKA_TOPIC_RETENTION_IN_MS;
+import static com.linkedin.venice.controllerapi.ControllerApiConstants.KAFKA_TOPIC_UNCLEAN_LEADER_ELECTION_ENABLED;
 import static com.linkedin.venice.controllerapi.ControllerApiConstants.KEY_SCHEMA;
 import static com.linkedin.venice.controllerapi.ControllerApiConstants.LARGEST_USED_RT_VERSION_NUMBER;
 import static com.linkedin.venice.controllerapi.ControllerApiConstants.LARGEST_USED_VERSION_NUMBER;
@@ -295,6 +296,10 @@ public enum ControllerRoute implements VeniceDimensionInterface {
   ),
   UPDATE_KAFKA_TOPIC_MIN_IN_SYNC_REPLICA(
       "/update_kafka_topic_min_in_sync_replica", HttpMethod.POST, Arrays.asList(TOPIC, KAFKA_TOPIC_MIN_IN_SYNC_REPLICA)
+  ),
+  UPDATE_KAFKA_TOPIC_UNCLEAN_LEADER_ELECTION(
+      "/update_kafka_topic_unclean_leader_election", HttpMethod.POST,
+      Arrays.asList(TOPIC, KAFKA_TOPIC_UNCLEAN_LEADER_ELECTION_ENABLED)
   ), GET_ADMIN_TOPIC_METADATA("/get_admin_topic_metadata", HttpMethod.GET, Collections.singletonList(CLUSTER), NAME),
   UPDATE_ADMIN_TOPIC_METADATA(
       "/update_admin_topic_metadata", HttpMethod.POST, Arrays.asList(CLUSTER, EXECUTION_ID), NAME, POSITION,

--- a/internal/venice-common/src/main/java/com/linkedin/venice/controllerapi/ControllerRoute.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/controllerapi/ControllerRoute.java
@@ -295,8 +295,11 @@ public enum ControllerRoute implements VeniceDimensionInterface {
       "/update_kafka_topic_retention", HttpMethod.POST, Arrays.asList(TOPIC, KAFKA_TOPIC_RETENTION_IN_MS)
   ),
   UPDATE_KAFKA_TOPIC_MIN_IN_SYNC_REPLICA(
-      "/update_kafka_topic_min_in_sync_replica", HttpMethod.POST, Collections.singletonList(TOPIC),
-      KAFKA_TOPIC_MIN_IN_SYNC_REPLICA, KAFKA_TOPIC_UNCLEAN_LEADER_ELECTION_ENABLED
+      "/update_kafka_topic_min_in_sync_replica", HttpMethod.POST, Arrays.asList(TOPIC, KAFKA_TOPIC_MIN_IN_SYNC_REPLICA)
+  ),
+  UPDATE_KAFKA_TOPIC_UNCLEAN_LEADER_ELECTION(
+      "/update_kafka_topic_unclean_leader_election", HttpMethod.POST,
+      Arrays.asList(TOPIC, KAFKA_TOPIC_UNCLEAN_LEADER_ELECTION_ENABLED)
   ), GET_ADMIN_TOPIC_METADATA("/get_admin_topic_metadata", HttpMethod.GET, Collections.singletonList(CLUSTER), NAME),
   UPDATE_ADMIN_TOPIC_METADATA(
       "/update_admin_topic_metadata", HttpMethod.POST, Arrays.asList(CLUSTER, EXECUTION_ID), NAME, POSITION,

--- a/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/manager/TopicManager.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/manager/TopicManager.java
@@ -472,6 +472,19 @@ public class TopicManager implements Closeable {
     return false;
   }
 
+  public boolean updateTopicUncleanLeaderElection(PubSubTopic topicName, boolean uncleanLeaderElectionEnabled)
+      throws PubSubTopicDoesNotExistException {
+    PubSubTopicConfiguration pubSubTopicConfiguration = getTopicConfig(topicName);
+    Optional<Boolean> currentULE = pubSubTopicConfiguration.getUncleanLeaderElectionEnable();
+    if (!currentULE.isPresent() || !currentULE.get().equals(uncleanLeaderElectionEnabled)) {
+      pubSubTopicConfiguration.setUncleanLeaderElectionEnable(Optional.of(uncleanLeaderElectionEnabled));
+      setTopicConfig(topicName, pubSubTopicConfiguration);
+      logger.info("Updated topic: {} with unclean.leader.election.enable: {}", topicName, uncleanLeaderElectionEnabled);
+      return true;
+    }
+    return false;
+  }
+
   /**
    * Get retention time for all topics in the pubsub cluster.
    * @return a map of topic name to retention time in MS.

--- a/internal/venice-common/src/test/java/com/linkedin/venice/controllerapi/ControllerRouteDimensionTest.java
+++ b/internal/venice-common/src/test/java/com/linkedin/venice/controllerapi/ControllerRouteDimensionTest.java
@@ -108,7 +108,6 @@ public class ControllerRouteDimensionTest {
         .put(ControllerRoute.UPDATE_KAFKA_TOPIC_LOG_COMPACTION, "update_kafka_topic_log_compaction")
         .put(ControllerRoute.UPDATE_KAFKA_TOPIC_RETENTION, "update_kafka_topic_retention")
         .put(ControllerRoute.UPDATE_KAFKA_TOPIC_MIN_IN_SYNC_REPLICA, "update_kafka_topic_min_in_sync_replica")
-        .put(ControllerRoute.UPDATE_KAFKA_TOPIC_UNCLEAN_LEADER_ELECTION, "update_kafka_topic_unclean_leader_election")
         .put(ControllerRoute.GET_ADMIN_TOPIC_METADATA, "get_admin_topic_metadata")
         .put(ControllerRoute.UPDATE_ADMIN_TOPIC_METADATA, "update_admin_topic_metadata")
         .put(ControllerRoute.UPDATE_ADMIN_OPERATION_PROTOCOL_VERSION, "update_admin_operation_protocol_version")

--- a/internal/venice-common/src/test/java/com/linkedin/venice/controllerapi/ControllerRouteDimensionTest.java
+++ b/internal/venice-common/src/test/java/com/linkedin/venice/controllerapi/ControllerRouteDimensionTest.java
@@ -108,6 +108,7 @@ public class ControllerRouteDimensionTest {
         .put(ControllerRoute.UPDATE_KAFKA_TOPIC_LOG_COMPACTION, "update_kafka_topic_log_compaction")
         .put(ControllerRoute.UPDATE_KAFKA_TOPIC_RETENTION, "update_kafka_topic_retention")
         .put(ControllerRoute.UPDATE_KAFKA_TOPIC_MIN_IN_SYNC_REPLICA, "update_kafka_topic_min_in_sync_replica")
+        .put(ControllerRoute.UPDATE_KAFKA_TOPIC_UNCLEAN_LEADER_ELECTION, "update_kafka_topic_unclean_leader_election")
         .put(ControllerRoute.GET_ADMIN_TOPIC_METADATA, "get_admin_topic_metadata")
         .put(ControllerRoute.UPDATE_ADMIN_TOPIC_METADATA, "update_admin_topic_metadata")
         .put(ControllerRoute.UPDATE_ADMIN_OPERATION_PROTOCOL_VERSION, "update_admin_operation_protocol_version")

--- a/internal/venice-common/src/test/java/com/linkedin/venice/pubsub/manager/TopicManagerTest.java
+++ b/internal/venice-common/src/test/java/com/linkedin/venice/pubsub/manager/TopicManagerTest.java
@@ -10,6 +10,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertTrue;
 
 import com.github.benmanes.caffeine.cache.Cache;
@@ -689,6 +690,22 @@ public class TopicManagerTest {
     topicManager.updateTopicMinInSyncReplica(topic, 2);
     pubSubTopicConfiguration = topicManager.getTopicConfig(topic);
     assertTrue(pubSubTopicConfiguration.minInSyncReplicas().get() == 2);
+  }
+
+  @Test
+  public void testUpdateTopicUncleanLeaderElection() {
+    PubSubTopic topic = pubSubTopicRepository.getTopic(TestUtils.getUniqueTopicString("topic"));
+    topicManager.createTopic(topic, 1, 1, true);
+    // Disable unclean leader election
+    assertTrue(topicManager.updateTopicUncleanLeaderElection(topic, false));
+    PubSubTopicConfiguration pubSubTopicConfiguration = topicManager.getTopicConfig(topic);
+    assertFalse(pubSubTopicConfiguration.getUncleanLeaderElectionEnable().get());
+    // No-op when value is the same
+    assertFalse(topicManager.updateTopicUncleanLeaderElection(topic, false));
+    // Enable unclean leader election
+    assertTrue(topicManager.updateTopicUncleanLeaderElection(topic, true));
+    pubSubTopicConfiguration = topicManager.getTopicConfig(topic);
+    assertTrue(pubSubTopicConfiguration.getUncleanLeaderElectionEnable().get());
   }
 
   @Test

--- a/internal/venice-common/src/test/java/com/linkedin/venice/pubsub/manager/TopicManagerTest.java
+++ b/internal/venice-common/src/test/java/com/linkedin/venice/pubsub/manager/TopicManagerTest.java
@@ -696,16 +696,16 @@ public class TopicManagerTest {
   public void testUpdateTopicUncleanLeaderElection() {
     PubSubTopic topic = pubSubTopicRepository.getTopic(TestUtils.getUniqueTopicString("topic"));
     topicManager.createTopic(topic, 1, 1, true);
+    // Enable unclean leader election (explicit set regardless of default)
+    assertTrue(topicManager.updateTopicUncleanLeaderElection(topic, true));
+    PubSubTopicConfiguration pubSubTopicConfiguration = topicManager.getTopicConfig(topic);
+    assertTrue(pubSubTopicConfiguration.getUncleanLeaderElectionEnable().get());
+    // No-op when value is the same
+    assertFalse(topicManager.updateTopicUncleanLeaderElection(topic, true));
     // Disable unclean leader election
     assertTrue(topicManager.updateTopicUncleanLeaderElection(topic, false));
-    PubSubTopicConfiguration pubSubTopicConfiguration = topicManager.getTopicConfig(topic);
-    assertFalse(pubSubTopicConfiguration.getUncleanLeaderElectionEnable().get());
-    // No-op when value is the same
-    assertFalse(topicManager.updateTopicUncleanLeaderElection(topic, false));
-    // Enable unclean leader election
-    assertTrue(topicManager.updateTopicUncleanLeaderElection(topic, true));
     pubSubTopicConfiguration = topicManager.getTopicConfig(topic);
-    assertTrue(pubSubTopicConfiguration.getUncleanLeaderElectionEnable().get());
+    assertFalse(pubSubTopicConfiguration.getUncleanLeaderElectionEnable().get());
   }
 
   @Test

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/server/AdminSparkServer.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/server/AdminSparkServer.java
@@ -108,6 +108,7 @@ import static com.linkedin.venice.controllerapi.ControllerRoute.UPDATE_DARK_CLUS
 import static com.linkedin.venice.controllerapi.ControllerRoute.UPDATE_KAFKA_TOPIC_LOG_COMPACTION;
 import static com.linkedin.venice.controllerapi.ControllerRoute.UPDATE_KAFKA_TOPIC_MIN_IN_SYNC_REPLICA;
 import static com.linkedin.venice.controllerapi.ControllerRoute.UPDATE_KAFKA_TOPIC_RETENTION;
+import static com.linkedin.venice.controllerapi.ControllerRoute.UPDATE_KAFKA_TOPIC_UNCLEAN_LEADER_ELECTION;
 import static com.linkedin.venice.controllerapi.ControllerRoute.UPDATE_STORAGE_PERSONA;
 import static com.linkedin.venice.controllerapi.ControllerRoute.UPDATE_STORE;
 import static com.linkedin.venice.controllerapi.ControllerRoute.UPLOAD_PUSH_JOB_STATUS;
@@ -653,6 +654,11 @@ public class AdminSparkServer extends AbstractVeniceService {
     httpService.post(
         UPDATE_KAFKA_TOPIC_MIN_IN_SYNC_REPLICA.getPath(),
         new VeniceParentControllerRegionStateHandler(admin, controllerRoutes.updateKafkaTopicMinInSyncReplica(admin)));
+    httpService.post(
+        UPDATE_KAFKA_TOPIC_UNCLEAN_LEADER_ELECTION.getPath(),
+        new VeniceParentControllerRegionStateHandler(
+            admin,
+            controllerRoutes.updateKafkaTopicUncleanLeaderElection(admin)));
 
     httpService.get(
         GET_ADMIN_TOPIC_METADATA.getPath(),

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/server/AdminSparkServer.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/server/AdminSparkServer.java
@@ -108,7 +108,6 @@ import static com.linkedin.venice.controllerapi.ControllerRoute.UPDATE_DARK_CLUS
 import static com.linkedin.venice.controllerapi.ControllerRoute.UPDATE_KAFKA_TOPIC_LOG_COMPACTION;
 import static com.linkedin.venice.controllerapi.ControllerRoute.UPDATE_KAFKA_TOPIC_MIN_IN_SYNC_REPLICA;
 import static com.linkedin.venice.controllerapi.ControllerRoute.UPDATE_KAFKA_TOPIC_RETENTION;
-import static com.linkedin.venice.controllerapi.ControllerRoute.UPDATE_KAFKA_TOPIC_UNCLEAN_LEADER_ELECTION;
 import static com.linkedin.venice.controllerapi.ControllerRoute.UPDATE_STORAGE_PERSONA;
 import static com.linkedin.venice.controllerapi.ControllerRoute.UPDATE_STORE;
 import static com.linkedin.venice.controllerapi.ControllerRoute.UPLOAD_PUSH_JOB_STATUS;
@@ -654,11 +653,6 @@ public class AdminSparkServer extends AbstractVeniceService {
     httpService.post(
         UPDATE_KAFKA_TOPIC_MIN_IN_SYNC_REPLICA.getPath(),
         new VeniceParentControllerRegionStateHandler(admin, controllerRoutes.updateKafkaTopicMinInSyncReplica(admin)));
-    httpService.post(
-        UPDATE_KAFKA_TOPIC_UNCLEAN_LEADER_ELECTION.getPath(),
-        new VeniceParentControllerRegionStateHandler(
-            admin,
-            controllerRoutes.updateKafkaTopicUncleanLeaderElection(admin)));
 
     httpService.get(
         GET_ADMIN_TOPIC_METADATA.getPath(),

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/server/ControllerRoutes.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/server/ControllerRoutes.java
@@ -12,7 +12,6 @@ import static com.linkedin.venice.controllerapi.ControllerRoute.LIST_CHILD_CLUST
 import static com.linkedin.venice.controllerapi.ControllerRoute.UPDATE_KAFKA_TOPIC_LOG_COMPACTION;
 import static com.linkedin.venice.controllerapi.ControllerRoute.UPDATE_KAFKA_TOPIC_MIN_IN_SYNC_REPLICA;
 import static com.linkedin.venice.controllerapi.ControllerRoute.UPDATE_KAFKA_TOPIC_RETENTION;
-import static com.linkedin.venice.controllerapi.ControllerRoute.UPDATE_KAFKA_TOPIC_UNCLEAN_LEADER_ELECTION;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.linkedin.venice.HttpConstants;
@@ -175,23 +174,18 @@ public class ControllerRoutes extends AbstractRoute {
     return updateKafkaTopicConfig(admin, adminRequest -> {
       AdminSparkServer.validateParams(adminRequest, UPDATE_KAFKA_TOPIC_MIN_IN_SYNC_REPLICA.getParams(), admin);
       PubSubTopic topicName = pubSubTopicRepository.getTopic(adminRequest.queryParams(TOPIC));
-      int kafkaTopicMinISR = Utils.parseIntFromString(
-          adminRequest.queryParams(KAFKA_TOPIC_MIN_IN_SYNC_REPLICA),
-          KAFKA_TOPIC_MIN_IN_SYNC_REPLICA);
       TopicManager topicManager = admin.getTopicManager();
-      topicManager.updateTopicMinInSyncReplica(topicName, kafkaTopicMinISR);
-    });
-  }
-
-  public Route updateKafkaTopicUncleanLeaderElection(Admin admin) {
-    return updateKafkaTopicConfig(admin, adminRequest -> {
-      AdminSparkServer.validateParams(adminRequest, UPDATE_KAFKA_TOPIC_UNCLEAN_LEADER_ELECTION.getParams(), admin);
-      PubSubTopic topicName = pubSubTopicRepository.getTopic(adminRequest.queryParams(TOPIC));
-      boolean uncleanLeaderElectionEnabled = Utils.parseBooleanOrThrow(
-          adminRequest.queryParams(KAFKA_TOPIC_UNCLEAN_LEADER_ELECTION_ENABLED),
-          KAFKA_TOPIC_UNCLEAN_LEADER_ELECTION_ENABLED);
-      TopicManager topicManager = admin.getTopicManager();
-      topicManager.updateTopicUncleanLeaderElection(topicName, uncleanLeaderElectionEnabled);
+      String minISRParam = adminRequest.queryParams(KAFKA_TOPIC_MIN_IN_SYNC_REPLICA);
+      if (minISRParam != null) {
+        int kafkaTopicMinISR = Utils.parseIntFromString(minISRParam, KAFKA_TOPIC_MIN_IN_SYNC_REPLICA);
+        topicManager.updateTopicMinInSyncReplica(topicName, kafkaTopicMinISR);
+      }
+      String uleParam = adminRequest.queryParams(KAFKA_TOPIC_UNCLEAN_LEADER_ELECTION_ENABLED);
+      if (uleParam != null) {
+        boolean uncleanLeaderElectionEnabled =
+            Utils.parseBooleanOrThrow(uleParam, KAFKA_TOPIC_UNCLEAN_LEADER_ELECTION_ENABLED);
+        topicManager.updateTopicUncleanLeaderElection(topicName, uncleanLeaderElectionEnabled);
+      }
     });
   }
 

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/server/ControllerRoutes.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/server/ControllerRoutes.java
@@ -4,6 +4,7 @@ import static com.linkedin.venice.controllerapi.ControllerApiConstants.CLUSTER;
 import static com.linkedin.venice.controllerapi.ControllerApiConstants.KAFKA_TOPIC_LOG_COMPACTION_ENABLED;
 import static com.linkedin.venice.controllerapi.ControllerApiConstants.KAFKA_TOPIC_MIN_IN_SYNC_REPLICA;
 import static com.linkedin.venice.controllerapi.ControllerApiConstants.KAFKA_TOPIC_RETENTION_IN_MS;
+import static com.linkedin.venice.controllerapi.ControllerApiConstants.KAFKA_TOPIC_UNCLEAN_LEADER_ELECTION_ENABLED;
 import static com.linkedin.venice.controllerapi.ControllerApiConstants.TOPIC;
 import static com.linkedin.venice.controllerapi.ControllerRoute.AGGREGATED_HEALTH_STATUS;
 import static com.linkedin.venice.controllerapi.ControllerRoute.LEADER_CONTROLLER;
@@ -11,6 +12,7 @@ import static com.linkedin.venice.controllerapi.ControllerRoute.LIST_CHILD_CLUST
 import static com.linkedin.venice.controllerapi.ControllerRoute.UPDATE_KAFKA_TOPIC_LOG_COMPACTION;
 import static com.linkedin.venice.controllerapi.ControllerRoute.UPDATE_KAFKA_TOPIC_MIN_IN_SYNC_REPLICA;
 import static com.linkedin.venice.controllerapi.ControllerRoute.UPDATE_KAFKA_TOPIC_RETENTION;
+import static com.linkedin.venice.controllerapi.ControllerRoute.UPDATE_KAFKA_TOPIC_UNCLEAN_LEADER_ELECTION;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.linkedin.venice.HttpConstants;
@@ -178,6 +180,18 @@ public class ControllerRoutes extends AbstractRoute {
           KAFKA_TOPIC_MIN_IN_SYNC_REPLICA);
       TopicManager topicManager = admin.getTopicManager();
       topicManager.updateTopicMinInSyncReplica(topicName, kafkaTopicMinISR);
+    });
+  }
+
+  public Route updateKafkaTopicUncleanLeaderElection(Admin admin) {
+    return updateKafkaTopicConfig(admin, adminRequest -> {
+      AdminSparkServer.validateParams(adminRequest, UPDATE_KAFKA_TOPIC_UNCLEAN_LEADER_ELECTION.getParams(), admin);
+      PubSubTopic topicName = pubSubTopicRepository.getTopic(adminRequest.queryParams(TOPIC));
+      boolean uncleanLeaderElectionEnabled = Utils.parseBooleanOrThrow(
+          adminRequest.queryParams(KAFKA_TOPIC_UNCLEAN_LEADER_ELECTION_ENABLED),
+          KAFKA_TOPIC_UNCLEAN_LEADER_ELECTION_ENABLED);
+      TopicManager topicManager = admin.getTopicManager();
+      topicManager.updateTopicUncleanLeaderElection(topicName, uncleanLeaderElectionEnabled);
     });
   }
 

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/server/ControllerRoutes.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/server/ControllerRoutes.java
@@ -12,6 +12,7 @@ import static com.linkedin.venice.controllerapi.ControllerRoute.LIST_CHILD_CLUST
 import static com.linkedin.venice.controllerapi.ControllerRoute.UPDATE_KAFKA_TOPIC_LOG_COMPACTION;
 import static com.linkedin.venice.controllerapi.ControllerRoute.UPDATE_KAFKA_TOPIC_MIN_IN_SYNC_REPLICA;
 import static com.linkedin.venice.controllerapi.ControllerRoute.UPDATE_KAFKA_TOPIC_RETENTION;
+import static com.linkedin.venice.controllerapi.ControllerRoute.UPDATE_KAFKA_TOPIC_UNCLEAN_LEADER_ELECTION;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.linkedin.venice.HttpConstants;
@@ -174,18 +175,23 @@ public class ControllerRoutes extends AbstractRoute {
     return updateKafkaTopicConfig(admin, adminRequest -> {
       AdminSparkServer.validateParams(adminRequest, UPDATE_KAFKA_TOPIC_MIN_IN_SYNC_REPLICA.getParams(), admin);
       PubSubTopic topicName = pubSubTopicRepository.getTopic(adminRequest.queryParams(TOPIC));
+      int kafkaTopicMinISR = Utils.parseIntFromString(
+          adminRequest.queryParams(KAFKA_TOPIC_MIN_IN_SYNC_REPLICA),
+          KAFKA_TOPIC_MIN_IN_SYNC_REPLICA);
       TopicManager topicManager = admin.getTopicManager();
-      String minISRParam = adminRequest.queryParams(KAFKA_TOPIC_MIN_IN_SYNC_REPLICA);
-      if (minISRParam != null) {
-        int kafkaTopicMinISR = Utils.parseIntFromString(minISRParam, KAFKA_TOPIC_MIN_IN_SYNC_REPLICA);
-        topicManager.updateTopicMinInSyncReplica(topicName, kafkaTopicMinISR);
-      }
-      String uleParam = adminRequest.queryParams(KAFKA_TOPIC_UNCLEAN_LEADER_ELECTION_ENABLED);
-      if (uleParam != null) {
-        boolean uncleanLeaderElectionEnabled =
-            Utils.parseBooleanOrThrow(uleParam, KAFKA_TOPIC_UNCLEAN_LEADER_ELECTION_ENABLED);
-        topicManager.updateTopicUncleanLeaderElection(topicName, uncleanLeaderElectionEnabled);
-      }
+      topicManager.updateTopicMinInSyncReplica(topicName, kafkaTopicMinISR);
+    });
+  }
+
+  public Route updateKafkaTopicUncleanLeaderElection(Admin admin) {
+    return updateKafkaTopicConfig(admin, adminRequest -> {
+      AdminSparkServer.validateParams(adminRequest, UPDATE_KAFKA_TOPIC_UNCLEAN_LEADER_ELECTION.getParams(), admin);
+      PubSubTopic topicName = pubSubTopicRepository.getTopic(adminRequest.queryParams(TOPIC));
+      boolean uncleanLeaderElectionEnabled = Utils.parseBooleanOrThrow(
+          adminRequest.queryParams(KAFKA_TOPIC_UNCLEAN_LEADER_ELECTION_ENABLED),
+          KAFKA_TOPIC_UNCLEAN_LEADER_ELECTION_ENABLED);
+      TopicManager topicManager = admin.getTopicManager();
+      topicManager.updateTopicUncleanLeaderElection(topicName, uncleanLeaderElectionEnabled);
     });
   }
 


### PR DESCRIPTION
<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat], [protocol]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## Problem Statement

[PR #2599](https://github.com/linkedin/venice/pull/2599) added cluster-level configuration for `unclean.leader.election.enable` on **new** RT topics, but there is no way to update this setting on **existing** RT topics. Operators need the ability to disable unclean leader election on existing topics to prevent data loss from out-of-sync replicas becoming partition leaders.

## Solution

Add a new admin tool command `--update-kafka-topic-unclean-leader-election` following the existing pattern used by `--update-kafka-topic-log-compaction` and `--update-kafka-topic-min-in-sync-replica`. The command flows through the full admin tool → controller client → controller route → TopicManager chain.

**Usage:**
```bash
admin_tool.sh --update-kafka-topic-unclean-leader-election \
  --url <controller-url> \
  --kafka-topic-name <store_name>_rt \
  --kafka-topic-unclean-leader-election-enabled false
```

**Files changed:**
- `Arg.java` — New arg `--kafka-topic-unclean-leader-election-enabled`
- `Command.java` — New command enum entry
- `AdminTool.java` — Switch case + handler method
- `ControllerApiConstants.java` — New constant for the param name
- `ControllerClient.java` — New client method
- `ControllerRoute.java` — New route `POST /update_kafka_topic_unclean_leader_election`
- `AdminSparkServer.java` — Route registration
- `ControllerRoutes.java` — Route handler calling `TopicManager`
- `TopicManager.java` — New `updateTopicUncleanLeaderElection()` method
- `TopicManagerTest.java` — Unit test covering set, no-op, and toggle

###  Code changes
- [x] Added new code behind **a config**. If so list the config names and their default values in the PR description.
  - No new config keys — this is an on-demand admin operation, not a default behavior change.
- [ ] Introduced new **log lines**.
  - [x] Confirmed if logs need to be **rate limited** to avoid excessive logging.
  - Single log line per invocation in `TopicManager`, no rate limiting needed.

###  **Concurrency-Specific Checks**
Both reviewer and PR author to verify
- [x] Code has **no race conditions** or **thread safety issues**.
- [x] Proper **synchronization mechanisms** (e.g., `synchronized`, `RWLock`) are used where needed.
- [x] No **blocking calls** inside critical sections that could lead to deadlocks or performance degradation.
- [x] Verified **thread-safe collections** are used (e.g., `ConcurrentHashMap`, `CopyOnWriteArrayList`).
- [x] Validated proper exception handling in multi-threaded code to avoid silent thread termination.

N/A — follows the same stateless request-response pattern as existing topic config update commands. No new concurrency.

## How was this PR tested?

- [x] New unit tests added.
- [ ] New integration tests added.
- [ ] Modified or extended existing tests.
- [x] Verified backward compatibility (if applicable).

`TopicManagerTest.testUpdateTopicUncleanLeaderElection` — verifies disable, no-op on same value, and re-enable.

No behavior change for existing commands. Zero behavior change when the new command is not invoked.

## Does this PR introduce any user-facing or breaking changes?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Clearly explain the behavior change and its impact.