### PR TITLE
[da-vinci][server] Add per-poll record count metric (poll_result_size)

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
@@ -1546,6 +1546,14 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
     if (!ongoingBatch.isEmpty()) {
       batches.add(ongoingBatch);
     }
+    int totalRecordsInPoll = 0;
+    for (List<DefaultPubSubMessage> batch: batches) {
+      totalRecordsInPoll += batch.size();
+    }
+    if (totalRecordsInPoll > 0) {
+      versionedIngestionStats
+          .recordPollResultSize(storeName, versionNumber, totalRecordsInPoll, beforeProcessingBatchRecordsTimestampMs);
+    }
     if (batches.isEmpty()) {
       return;
     }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
@@ -1535,6 +1535,7 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
     int batchSize = serverConfig.getAAWCWorkloadParallelProcessingThreadPoolSize();
     List<List<DefaultPubSubMessage>> batches = new ArrayList<>();
     List<DefaultPubSubMessage> ongoingBatch = new ArrayList<>(batchSize);
+    int totalRecordsInPoll = 0;
     Iterator<DefaultPubSubMessage> iter = records.iterator();
     while (iter.hasNext()) {
       DefaultPubSubMessage record = iter.next();
@@ -1546,6 +1547,7 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
       }
       waitReadyToProcessRecord(record);
       ongoingBatch.add(record);
+      totalRecordsInPoll++;
       if (ongoingBatch.size() == batchSize) {
         batches.add(ongoingBatch);
         ongoingBatch = new ArrayList<>(batchSize);
@@ -1553,10 +1555,6 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
     }
     if (!ongoingBatch.isEmpty()) {
       batches.add(ongoingBatch);
-    }
-    int totalRecordsInPoll = 0;
-    for (List<DefaultPubSubMessage> batch: batches) {
-      totalRecordsInPoll += batch.size();
     }
     if (totalRecordsInPoll > 0) {
       versionedIngestionStats

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
@@ -1468,6 +1468,7 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
     }
 
     long totalBytesRead = 0;
+    int totalRecordsInPoll = 0;
     ValueHolder<Double> elapsedTimeForPuttingIntoQueue = new ValueHolder<>(0d);
     long beforeProcessingBatchRecordsTimestampMs = System.currentTimeMillis();
 
@@ -1478,6 +1479,8 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
       if (!shouldProcessRecord(record)) {
         continue;
       }
+
+      totalRecordsInPoll++;
 
       // Check schema id availability before putting consumer record to drainer queue
       waitReadyToProcessRecord(record);
@@ -1499,6 +1502,11 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
         String consumedBytesKey = versionTopic.equals(topic) ? versionTopic.getName() : kafkaUrl;
         consumedBytesSinceLastSync.compute(consumedBytesKey, (k, v) -> (v == null) ? recordSize : v + recordSize);
       }
+    }
+
+    if (totalRecordsInPoll > 0) {
+      versionedIngestionStats
+          .recordPollResultSize(storeName, versionNumber, totalRecordsInPoll, beforeProcessingBatchRecordsTimestampMs);
     }
 
     /**

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/AggVersionedIngestionStats.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/AggVersionedIngestionStats.java
@@ -418,6 +418,11 @@ public class AggVersionedIngestionStats
     otelStats.recordBatchProcessingRequestRecordCount(version, size);
   }
 
+  public void recordPollResultSize(String storeName, int version, int size, long timestamp) {
+    recordVersionedAndTotalStat(storeName, version, stat -> stat.recordPollResultSize(size, timestamp));
+    getIngestionOtelStats(storeName).recordPollResultSize(version, size);
+  }
+
   public void recordBatchProcessingRequestError(String storeName, int version) {
     // Tehuti metrics
     recordVersionedAndTotalStat(storeName, version, stat -> stat.recordBatchProcessingRequestError());

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/IngestionStats.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/IngestionStats.java
@@ -108,6 +108,7 @@ public class IngestionStats {
   public static final String BATCH_PROCESSING_REQUEST_RECORDS = "batch_processing_request_records";
   public static final String BATCH_PROCESSING_REQUEST_LATENCY = "batch_processing_request_latency";
   public static final String BATCH_PROCESSING_REQUEST_ERROR = "batch_processing_request_error";
+  public static final String POLL_RESULT_SIZE = "poll_result_size";
 
   public static final String STORAGE_QUOTA_USED = "storage_quota_used";
 
@@ -159,6 +160,7 @@ public class IngestionStats {
   private final LongAdderRateGauge batchProcessingRequestRecordsSensor = new LongAdderRateGauge();
   private final WritePathLatencySensor batchProcessingRequestLatencySensor;
   private final LongAdderRateGauge batchProcessingRequestErrorSensor = new LongAdderRateGauge();
+  private final WritePathLatencySensor pollResultSizeSensor;
 
   public IngestionStats(VeniceServerConfig serverConfig) {
 
@@ -241,6 +243,7 @@ public class IngestionStats {
         new WritePathLatencySensor(localMetricRepository, METRIC_CONFIG, BATCH_PROCESSING_REQUEST_SIZE);
     batchProcessingRequestLatencySensor =
         new WritePathLatencySensor(localMetricRepository, METRIC_CONFIG, BATCH_PROCESSING_REQUEST_LATENCY);
+    pollResultSizeSensor = new WritePathLatencySensor(localMetricRepository, METRIC_CONFIG, POLL_RESULT_SIZE);
   }
 
   private void registerSensor(MetricsRepository localMetricRepository, String sensorName, LongAdderRateGauge gauge) {
@@ -558,6 +561,14 @@ public class IngestionStats {
 
   public WritePathLatencySensor getBatchProcessingRequestLatencySensor() {
     return batchProcessingRequestLatencySensor;
+  }
+
+  public void recordPollResultSize(int size, long currentTimeMs) {
+    pollResultSizeSensor.record(size, currentTimeMs);
+  }
+
+  public WritePathLatencySensor getPollResultSizeSensor() {
+    return pollResultSizeSensor;
   }
 
   public static double unAvailableToZero(double value) {

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/ingestion/IngestionOtelMetricEntity.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/ingestion/IngestionOtelMetricEntity.java
@@ -134,6 +134,12 @@ public enum IngestionOtelMetricEntity implements ModuleMetricEntityInterface {
       "Batch processing latency", setOf(VENICE_STORE_NAME, VENICE_CLUSTER_NAME, VENICE_VERSION_ROLE)
   ),
 
+  POLL_RESULT_SIZE(
+      "ingestion.poll_result.size", MetricType.MIN_MAX_COUNT_SUM_AGGREGATIONS, MetricUnit.NUMBER,
+      "Total records per poll per partition before mini-batch splitting (leader AA/WC path)",
+      setOf(VENICE_STORE_NAME, VENICE_CLUSTER_NAME, VENICE_VERSION_ROLE)
+  ),
+
   DCR_EVENT_COUNT(
       "ingestion.dcr.event_count", MetricType.ASYNC_COUNTER_FOR_HIGH_PERF_CASES, MetricUnit.NUMBER,
       "Count of DCR outcomes per event type (e.g., PUT, DELETE, UPDATE)",

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/ingestion/IngestionOtelMetricEntity.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/ingestion/IngestionOtelMetricEntity.java
@@ -136,7 +136,7 @@ public enum IngestionOtelMetricEntity implements ModuleMetricEntityInterface {
 
   POLL_RESULT_SIZE(
       "ingestion.poll_result.size", MetricType.MIN_MAX_COUNT_SUM_AGGREGATIONS, MetricUnit.NUMBER,
-      "Total records per poll per partition before mini-batch splitting (leader AA/WC path)",
+      "Total records per poll per partition before mini-batch splitting, counting only records that pass shouldProcessRecord",
       setOf(VENICE_STORE_NAME, VENICE_CLUSTER_NAME, VENICE_VERSION_ROLE)
   ),
 

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/ingestion/IngestionOtelStats.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/ingestion/IngestionOtelStats.java
@@ -34,6 +34,7 @@ import static com.linkedin.davinci.stats.ingestion.IngestionOtelMetricEntity.ING
 import static com.linkedin.davinci.stats.ingestion.IngestionOtelMetricEntity.LONG_RUNNING_TASK_CHECK_TIME;
 import static com.linkedin.davinci.stats.ingestion.IngestionOtelMetricEntity.PARTIAL_UPDATE_CACHE_HIT_COUNT;
 import static com.linkedin.davinci.stats.ingestion.IngestionOtelMetricEntity.PARTIAL_UPDATE_TIME;
+import static com.linkedin.davinci.stats.ingestion.IngestionOtelMetricEntity.POLL_RESULT_SIZE;
 import static com.linkedin.davinci.stats.ingestion.IngestionOtelMetricEntity.PRODUCER_COMPRESS_TIME;
 import static com.linkedin.davinci.stats.ingestion.IngestionOtelMetricEntity.PRODUCER_ENQUEUE_TIME;
 import static com.linkedin.davinci.stats.ingestion.IngestionOtelMetricEntity.PRODUCER_SYNCHRONIZE_TIME;
@@ -121,6 +122,7 @@ public class IngestionOtelStats {
   private final MetricEntityStateOneEnum<VersionRole> batchProcessingRequestRecordCountMetric;
   private final MetricEntityStateOneEnum<VersionRole> batchProcessingRequestErrorCountMetric;
   private final MetricEntityStateOneEnum<VersionRole> batchProcessingRequestTimeMetric;
+  private final MetricEntityStateOneEnum<VersionRole> pollResultSizeMetric;
   private final MetricEntityStateOneEnum<VersionRole> dcrTotalCountMetric;
   private final MetricEntityStateOneEnum<VersionRole> duplicateKeyUpdateCountMetric;
 
@@ -212,6 +214,7 @@ public class IngestionOtelStats {
     this.batchProcessingRequestRecordCountMetric = null;
     this.batchProcessingRequestErrorCountMetric = null;
     this.batchProcessingRequestTimeMetric = null;
+    this.pollResultSizeMetric = null;
     this.dcrTotalCountMetric = null;
     this.duplicateKeyUpdateCountMetric = null;
     this.recordsConsumedMetric = null;
@@ -315,6 +318,7 @@ public class IngestionOtelStats {
     batchProcessingRequestErrorCountMetric =
         createOneEnumMetric(BATCH_PROCESSING_REQUEST_ERROR_COUNT.getMetricEntity());
     batchProcessingRequestTimeMetric = createOneEnumMetric(BATCH_PROCESSING_REQUEST_TIME.getMetricEntity());
+    pollResultSizeMetric = createOneEnumMetric(POLL_RESULT_SIZE.getMetricEntity());
     dcrTotalCountMetric = createOneEnumMetric(DCR_TOTAL_COUNT.getMetricEntity());
     duplicateKeyUpdateCountMetric = createOneEnumMetric(DUPLICATE_KEY_UPDATE_COUNT.getMetricEntity());
 
@@ -566,6 +570,10 @@ public class IngestionOtelStats {
 
   public void recordBatchProcessingRequestTime(int version, double latencyMs) {
     batchProcessingRequestTimeMetric.record(latencyMs, classifyVersion(version, versionInfo));
+  }
+
+  public void recordPollResultSize(int version, int size) {
+    pollResultSizeMetric.record(size, classifyVersion(version, versionInfo));
   }
 
   public void recordDcrTotalCount(int version, long value) {

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/ingestion/NoOpIngestionOtelStats.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/ingestion/NoOpIngestionOtelStats.java
@@ -94,6 +94,10 @@ public class NoOpIngestionOtelStats extends IngestionOtelStats {
   }
 
   @Override
+  public void recordPollResultSize(int version, int size) {
+  }
+
+  @Override
   public void recordDcrTotalCount(int version, long value) {
   }
 

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTaskTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTaskTest.java
@@ -262,6 +262,7 @@ import java.util.Optional;
 import java.util.Properties;
 import java.util.Queue;
 import java.util.Set;
+import java.util.TreeMap;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.CountDownLatch;
@@ -6215,6 +6216,172 @@ public abstract class StoreIngestionTaskTest {
     consumedBytesMap.clear();
     sit.produceToStoreBufferServiceOrKafka(records, new PubSubTopicPartitionImpl(remoteVt, partition), kafkaUrl, 0);
     assertTrue(consumedBytesMap.isEmpty(), "Remote VT should not be tracked");
+  }
+
+  /**
+   * Verifies that {@link StoreIngestionTask#produceToStoreBufferServiceOrKafka} records the poll_result_size metric
+   * in the non-batch path (AA/WC parallel processing disabled).
+   */
+  @Test
+  public void testPollResultSizeRecordedInNonBatchPath() throws Exception {
+    String storeName = "test-store";
+    int version = 1;
+    PubSubTopic rtTopic = pubSubTopicRepository.getTopic(storeName + "_rt");
+    String kafkaUrl = "broker:9092";
+    int partition = 0;
+
+    StoreIngestionTask sit = mock(StoreIngestionTask.class);
+    doCallRealMethod().when(sit).produceToStoreBufferServiceOrKafka(any(), any(), any(), anyInt());
+    doReturn(false).when(sit).isGlobalRtDivEnabled();
+    doReturn(false).when(sit).isEmitTehutiMetricsEnabled();
+    doReturn(true).when(sit).shouldProcessRecord(any());
+    doReturn(StoreIngestionTask.DelegateConsumerRecordResult.SKIPPED_MESSAGE).when(sit)
+        .delegateConsumerRecord(any(), anyInt(), any(), anyInt(), anyLong(), anyLong());
+
+    AggVersionedIngestionStats mockStats = mock(AggVersionedIngestionStats.class);
+    VeniceConcurrentHashMap<Integer, PartitionConsumptionState> pcsMap = new VeniceConcurrentHashMap<>();
+    pcsMap.put(partition, mock(PartitionConsumptionState.class));
+
+    // Disable AA/WC so we stay on the non-batch path
+    for (String fieldName: new String[] { "isActiveActiveReplicationEnabled", "isWriteComputationEnabled" }) {
+      Field f = StoreIngestionTask.class.getDeclaredField(fieldName);
+      f.setAccessible(true);
+      f.set(sit, false);
+    }
+    for (Object[] entry: new Object[][] { { "versionTopic", rtTopic }, { "storeName", storeName },
+        { "versionNumber", version }, { "versionedIngestionStats", mockStats },
+        { "storageUtilizationManager", mock(StorageUtilizationManager.class) },
+        { "partitionConsumptionStateMap", pcsMap },
+        { "consumedBytesSinceLastSync", new VeniceConcurrentHashMap<>() } }) {
+      Field f = StoreIngestionTask.class.getDeclaredField((String) entry[0]);
+      f.setAccessible(true);
+      f.set(sit, entry[1]);
+    }
+
+    KafkaKey mockKey = mock(KafkaKey.class);
+    doReturn(false).when(mockKey).isControlMessage();
+    DefaultPubSubMessage mockRecord = mock(DefaultPubSubMessage.class);
+    doReturn(mockKey).when(mockRecord).getKey();
+    List<DefaultPubSubMessage> records = Arrays.asList(mockRecord, mockRecord, mockRecord);
+    doReturn(records).when(sit).validateAndFilterOutDuplicateMessagesFromLeaderTopic(any(), any(), any());
+
+    sit.produceToStoreBufferServiceOrKafka(records, new PubSubTopicPartitionImpl(rtTopic, partition), kafkaUrl, 0);
+
+    verify(mockStats).recordPollResultSize(eq(storeName), eq(version), eq(3), anyLong());
+  }
+
+  /**
+   * Verifies that {@link StoreIngestionTask#produceToStoreBufferServiceOrKafka} does NOT record poll_result_size
+   * when all records are filtered out by shouldProcessRecord in the non-batch path.
+   */
+  @Test
+  public void testPollResultSizeNotRecordedWhenAllRecordsFiltered() throws Exception {
+    String storeName = "test-store";
+    int version = 1;
+    PubSubTopic rtTopic = pubSubTopicRepository.getTopic(storeName + "_rt");
+    String kafkaUrl = "broker:9092";
+    int partition = 0;
+
+    StoreIngestionTask sit = mock(StoreIngestionTask.class);
+    doCallRealMethod().when(sit).produceToStoreBufferServiceOrKafka(any(), any(), any(), anyInt());
+    doReturn(false).when(sit).isGlobalRtDivEnabled();
+    doReturn(false).when(sit).isEmitTehutiMetricsEnabled();
+    doReturn(false).when(sit).shouldProcessRecord(any());
+
+    AggVersionedIngestionStats mockStats = mock(AggVersionedIngestionStats.class);
+    VeniceConcurrentHashMap<Integer, PartitionConsumptionState> pcsMap = new VeniceConcurrentHashMap<>();
+    pcsMap.put(partition, mock(PartitionConsumptionState.class));
+
+    for (String fieldName: new String[] { "isActiveActiveReplicationEnabled", "isWriteComputationEnabled" }) {
+      Field f = StoreIngestionTask.class.getDeclaredField(fieldName);
+      f.setAccessible(true);
+      f.set(sit, false);
+    }
+    for (Object[] entry: new Object[][] { { "versionTopic", rtTopic }, { "storeName", storeName },
+        { "versionNumber", version }, { "versionedIngestionStats", mockStats },
+        { "storageUtilizationManager", mock(StorageUtilizationManager.class) },
+        { "partitionConsumptionStateMap", pcsMap },
+        { "consumedBytesSinceLastSync", new VeniceConcurrentHashMap<>() } }) {
+      Field f = StoreIngestionTask.class.getDeclaredField((String) entry[0]);
+      f.setAccessible(true);
+      f.set(sit, entry[1]);
+    }
+
+    KafkaKey mockKey = mock(KafkaKey.class);
+    doReturn(false).when(mockKey).isControlMessage();
+    DefaultPubSubMessage mockRecord = mock(DefaultPubSubMessage.class);
+    doReturn(mockKey).when(mockRecord).getKey();
+    List<DefaultPubSubMessage> records = Arrays.asList(mockRecord, mockRecord);
+    doReturn(records).when(sit).validateAndFilterOutDuplicateMessagesFromLeaderTopic(any(), any(), any());
+
+    sit.produceToStoreBufferServiceOrKafka(records, new PubSubTopicPartitionImpl(rtTopic, partition), kafkaUrl, 0);
+
+    verify(mockStats, never()).recordPollResultSize(anyString(), anyInt(), anyInt(), anyLong());
+  }
+
+  /**
+   * Verifies that {@link StoreIngestionTask#produceToStoreBufferServiceOrKafkaInBatch} records the poll_result_size
+   * metric in the batch path (AA/WC parallel processing enabled with RT records).
+   */
+  @Test
+  public void testPollResultSizeRecordedInBatchPath() throws Exception {
+    String storeName = "test-store";
+    int version = 1;
+    PubSubTopic rtTopic = pubSubTopicRepository.getTopic(storeName + "_rt");
+    PubSubTopicPartition rtTopicPartition = new PubSubTopicPartitionImpl(rtTopic, 0);
+    String kafkaUrl = "broker:9092";
+    int partition = 0;
+
+    StoreIngestionTask sit = mock(StoreIngestionTask.class);
+    doCallRealMethod().when(sit).produceToStoreBufferServiceOrKafka(any(), any(), any(), anyInt());
+    doCallRealMethod().when(sit).produceToStoreBufferServiceOrKafkaInBatch(any(), any(), any(), any(), anyInt());
+    doReturn(false).when(sit).isGlobalRtDivEnabled();
+    doReturn(false).when(sit).isEmitTehutiMetricsEnabled();
+    doReturn(true).when(sit).shouldProcessRecord(any());
+
+    AggVersionedIngestionStats mockStats = mock(AggVersionedIngestionStats.class);
+    VeniceServerConfig mockServerConfig = mock(VeniceServerConfig.class);
+    doReturn(true).when(mockServerConfig).isAAWCWorkloadParallelProcessingEnabled();
+    doReturn(4).when(mockServerConfig).getAAWCWorkloadParallelProcessingThreadPoolSize();
+
+    IngestionBatchProcessor mockBatchProcessor = mock(IngestionBatchProcessor.class);
+    doReturn(new TreeMap<>()).when(mockBatchProcessor).lockKeys(any());
+    doReturn(Collections.emptyList()).when(mockBatchProcessor)
+        .process(any(), any(), anyInt(), any(), anyInt(), anyLong(), anyLong());
+    doReturn(mockBatchProcessor).when(sit).getIngestionBatchProcessor();
+
+    VeniceConcurrentHashMap<Integer, PartitionConsumptionState> pcsMap = new VeniceConcurrentHashMap<>();
+    pcsMap.put(partition, mock(PartitionConsumptionState.class));
+
+    // Enable AA so the batch path is taken
+    Field aaField = StoreIngestionTask.class.getDeclaredField("isActiveActiveReplicationEnabled");
+    aaField.setAccessible(true);
+    aaField.set(sit, true);
+    Field wcField = StoreIngestionTask.class.getDeclaredField("isWriteComputationEnabled");
+    wcField.setAccessible(true);
+    wcField.set(sit, false);
+
+    for (Object[] entry: new Object[][] { { "versionTopic", rtTopic }, { "storeName", storeName },
+        { "versionNumber", version }, { "versionedIngestionStats", mockStats }, { "serverConfig", mockServerConfig },
+        { "storageUtilizationManager", mock(StorageUtilizationManager.class) },
+        { "partitionConsumptionStateMap", pcsMap },
+        { "consumedBytesSinceLastSync", new VeniceConcurrentHashMap<>() } }) {
+      Field f = StoreIngestionTask.class.getDeclaredField((String) entry[0]);
+      f.setAccessible(true);
+      f.set(sit, entry[1]);
+    }
+
+    KafkaKey mockKey = mock(KafkaKey.class);
+    doReturn(false).when(mockKey).isControlMessage();
+    DefaultPubSubMessage mockRecord = mock(DefaultPubSubMessage.class);
+    doReturn(mockKey).when(mockRecord).getKey();
+    doReturn(rtTopicPartition).when(mockRecord).getTopicPartition();
+    List<DefaultPubSubMessage> records = Arrays.asList(mockRecord, mockRecord, mockRecord, mockRecord, mockRecord);
+    doReturn(records).when(sit).validateAndFilterOutDuplicateMessagesFromLeaderTopic(any(), any(), any());
+
+    sit.produceToStoreBufferServiceOrKafka(records, rtTopicPartition, kafkaUrl, 0);
+
+    verify(mockStats).recordPollResultSize(eq(storeName), eq(version), eq(5), anyLong());
   }
 
   /**

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTaskTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTaskTest.java
@@ -6188,7 +6188,8 @@ public abstract class StoreIngestionTaskTest {
     for (Object[] entry: new Object[][] { { "versionTopic", localVt },
         { "consumedBytesSinceLastSync", consumedBytesMap },
         { "storageUtilizationManager", mock(StorageUtilizationManager.class) },
-        { "partitionConsumptionStateMap", pcsMap } }) {
+        { "partitionConsumptionStateMap", pcsMap }, { "storeName", storeName }, { "versionNumber", 1 },
+        { "versionedIngestionStats", mock(AggVersionedIngestionStats.class) } }) {
       Field f = StoreIngestionTask.class.getDeclaredField((String) entry[0]);
       f.setAccessible(true);
       f.set(sit, entry[1]);

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/stats/ServerMetricEntityTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/stats/ServerMetricEntityTest.java
@@ -22,7 +22,7 @@ import org.testng.annotations.Test;
 public class ServerMetricEntityTest {
   @Test
   public void testServerMetricEntitiesCount() {
-    assertEquals(SERVER_METRIC_ENTITIES.size(), 139, "Expected 139 unique metric entities");
+    assertEquals(SERVER_METRIC_ENTITIES.size(), 140, "Expected 140 unique metric entities");
   }
 
   /**

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/stats/ingestion/IngestionOtelMetricEntityTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/stats/ingestion/IngestionOtelMetricEntityTest.java
@@ -181,6 +181,14 @@ public class IngestionOtelMetricEntityTest {
             MetricUnit.MILLISECOND,
             "Batch processing latency",
             storeClusterVersion));
+    map.put(
+        IngestionOtelMetricEntity.POLL_RESULT_SIZE,
+        new MetricEntityExpectation(
+            "ingestion.poll_result.size",
+            MetricType.MIN_MAX_COUNT_SUM_AGGREGATIONS,
+            MetricUnit.NUMBER,
+            "Total records per poll per partition before mini-batch splitting, counting only records that pass shouldProcessRecord",
+            storeClusterVersion));
 
     // MIN_MAX_COUNT_SUM_AGGREGATIONS metric with VersionRole + ReplicaType
     map.put(


### PR DESCRIPTION
## Problem Statement

The existing `batch_processing_request_size` metric is recorded per mini-batch *after* splitting in the leader AA/WC path. This makes it impossible to distinguish genuinely small polls from tail batches of larger polls, obscuring the true per-poll record count.

Additionally, poll size was only tracked in the batch processing path (`produceToStoreBufferServiceOrKafkaInBatch`), meaning any ingestion that goes through the non-batch path (e.g., non-AA/WC stores, VT consumption, or when parallel processing is disabled) had no poll size visibility at all.

## Solution

- Add a new `poll_result_size` metric (Tehuti + OTel) recorded **before** mini-batch splitting to capture the true per-poll record count per partition.
- Record this metric in **both** the batch path (`produceToStoreBufferServiceOrKafkaInBatch`) and the non-batch path (`produceToStoreBufferServiceOrKafka`), so poll sizes are captured regardless of whether AA/WC parallel processing is enabled.
- Only records that pass `shouldProcessRecord` are counted, consistent across both paths.

### Code changes

- `StoreIngestionTask.java`: Add `poll_result_size` recording in both `produceToStoreBufferServiceOrKafka` (non-batch) and `produceToStoreBufferServiceOrKafkaInBatch` (batch) paths.
- `IngestionStats.java`: Add `pollResultSizeSensor` (Tehuti).
- `AggVersionedIngestionStats.java`: Add `recordPollResultSize` delegation to both Tehuti and OTel stats.
- `IngestionOtelStats.java` / `IngestionOtelMetricEntity.java`: Add `POLL_RESULT_SIZE` OTel metric entity and recording method.
- `NoOpIngestionOtelStats.java`: Add no-op override.

- [ ] Added new code behind **a config**. No new config — metric is always emitted.
- [x] Introduced new **log lines**. No new log lines.

### **Concurrency-Specific Checks**

- [x] Code has **no race conditions** or **thread safety issues**. The metric recording is a simple counter increment on an existing stats object within the single-threaded consumer callback path.
- [x] No new synchronization needed.
- [x] No **blocking calls** introduced.
- [x] No new collections introduced.
- [x] No new multi-threaded code introduced.

## How was this PR tested?

- [x] New unit tests added.
  - `testPollResultSizeRecordedInNonBatchPath` — verifies metric is recorded with correct count (3 records) in the non-batch path.
  - `testPollResultSizeNotRecordedWhenAllRecordsFiltered` — verifies metric is NOT recorded when all records are filtered by `shouldProcessRecord`.
  - `testPollResultSizeRecordedInBatchPath` — verifies metric is recorded with correct count (5 records) in the AA/WC batch path.
- [ ] New integration tests added.
- [ ] Modified or extended existing tests.
- [x] Verified backward compatibility (if applicable). No breaking changes — only additive metric.

## Does this PR introduce any user-facing or breaking changes?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Clearly explain the behavior change and its impact.