### PR TITLE
[da-vinci][server] Add bounded hot transient record cache for large records during ingestion

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/config/VeniceServerConfig.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/config/VeniceServerConfig.java
@@ -139,6 +139,9 @@ import static com.linkedin.venice.ConfigKeys.SERVER_INGESTION_INFO_LOG_LINE_LIMI
 import static com.linkedin.venice.ConfigKeys.SERVER_INGESTION_OTEL_STATS_ENABLED;
 import static com.linkedin.venice.ConfigKeys.SERVER_INGESTION_TASK_MAX_IDLE_COUNT;
 import static com.linkedin.venice.ConfigKeys.SERVER_INGESTION_TASK_REUSABLE_OBJECTS_STRATEGY;
+import static com.linkedin.venice.ConfigKeys.SERVER_INGESTION_TRANSIENT_RECORD_CACHE_ENABLED;
+import static com.linkedin.venice.ConfigKeys.SERVER_INGESTION_TRANSIENT_RECORD_CACHE_MAX_WEIGHT;
+import static com.linkedin.venice.ConfigKeys.SERVER_INGESTION_TRANSIENT_RECORD_CACHE_MIN_VALUE_SIZE;
 import static com.linkedin.venice.ConfigKeys.SERVER_KAFKA_CONSUMER_OFFSET_COLLECTION_ENABLED;
 import static com.linkedin.venice.ConfigKeys.SERVER_KAFKA_MAX_POLL_RECORDS;
 import static com.linkedin.venice.ConfigKeys.SERVER_LAG_BASED_REPLICA_AUTO_RESUBSCRIBE_ENABLED;
@@ -747,6 +750,9 @@ public class VeniceServerConfig extends VeniceClusterConfig {
   private final boolean activeKeyCountForHybridStoreEnabled;
   private final int partialUpdateLargeResultLogThresholdBytes;
   private final long partialUpdateAmplificationReportIntervalMs;
+  private final boolean transientRecordCacheEnabled;
+  private final long transientRecordCacheMaxWeight;
+  private final int transientRecordCacheMinValueSize;
 
   public VeniceServerConfig(VeniceProperties serverProperties) throws ConfigurationException {
     this(serverProperties, Collections.emptyMap());
@@ -1303,6 +1309,12 @@ public class VeniceServerConfig extends VeniceClusterConfig {
         serverProperties.getInt(PARTIAL_UPDATE_LARGE_RESULT_LOG_THRESHOLD_BYTES, 100 * 1024);
     this.partialUpdateAmplificationReportIntervalMs =
         serverProperties.getLong(PARTIAL_UPDATE_AMPLIFICATION_REPORT_INTERVAL_MS, -1);
+    this.transientRecordCacheEnabled =
+        serverProperties.getBoolean(SERVER_INGESTION_TRANSIENT_RECORD_CACHE_ENABLED, true);
+    this.transientRecordCacheMaxWeight =
+        serverProperties.getLong(SERVER_INGESTION_TRANSIENT_RECORD_CACHE_MAX_WEIGHT, 32 * 1024 * 1024L);
+    this.transientRecordCacheMinValueSize =
+        serverProperties.getInt(SERVER_INGESTION_TRANSIENT_RECORD_CACHE_MIN_VALUE_SIZE, 100 * 1024);
   }
 
   List<Double> extractThrottleLimitFactorsFor(VeniceProperties serverProperties, String configKey) {
@@ -2360,5 +2372,17 @@ public class VeniceServerConfig extends VeniceClusterConfig {
 
   public long getPartialUpdateAmplificationReportIntervalMs() {
     return partialUpdateAmplificationReportIntervalMs;
+  }
+
+  public boolean isTransientRecordCacheEnabled() {
+    return transientRecordCacheEnabled;
+  }
+
+  public long getTransientRecordCacheMaxWeight() {
+    return transientRecordCacheMaxWeight;
+  }
+
+  public int getTransientRecordCacheMinValueSize() {
+    return transientRecordCacheMinValueSize;
   }
 }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/PartitionConsumptionState.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/PartitionConsumptionState.java
@@ -2,6 +2,7 @@ package com.linkedin.davinci.kafka.consumer;
 
 import static java.util.concurrent.TimeUnit.MINUTES;
 
+import com.github.benmanes.caffeine.cache.Cache;
 import com.linkedin.davinci.helix.LeaderFollowerPartitionStateModel;
 import com.linkedin.davinci.stats.ingestion.heartbeat.HeartbeatKey;
 import com.linkedin.davinci.utils.ByteArrayKey;
@@ -32,6 +33,7 @@ import com.linkedin.venice.utils.lazy.Lazy;
 import com.linkedin.venice.writer.LeaderCompleteState;
 import com.linkedin.venice.writer.VeniceWriter;
 import java.nio.ByteBuffer;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -249,6 +251,13 @@ public class PartitionConsumptionState {
    */
   private final Map<ByteArrayKey, TransientRecord> transientRecordMap = new VeniceConcurrentHashMap<>();
 
+  /** Shared Caffeine cache across partitions for hot transient records. Nullable when disabled. */
+  private final Cache<HotRecordCacheKey, TransientRecord> hotRecordCache;
+  private final int minValueSizeForHotCache;
+  private final AtomicLong hotRecordCacheHitCount = new AtomicLong(0);
+  /** Records a hot-cache hit to the host-level metric; set after construction, no-op when unset. */
+  private Runnable hotRecordCacheHitRecorder;
+
   /**
    * This field is used to track whether the last queued record has been fully processed or not.
    * For Leader role, it is redundant from {@literal ProducedRecord#persistedToDBFuture} since it is tracking
@@ -416,6 +425,28 @@ public class PartitionConsumptionState {
       boolean isWriteComputationEnabled,
       boolean isChunked,
       String localRegionName) {
+    this(
+        partitionReplica,
+        offsetRecord,
+        pubSubContext,
+        hybrid,
+        isWriteComputationEnabled,
+        isChunked,
+        localRegionName,
+        null,
+        0);
+  }
+
+  public PartitionConsumptionState(
+      PubSubTopicPartition partitionReplica,
+      OffsetRecord offsetRecord,
+      PubSubContext pubSubContext,
+      boolean hybrid,
+      boolean isWriteComputationEnabled,
+      boolean isChunked,
+      String localRegionName,
+      Cache<HotRecordCacheKey, TransientRecord> hotRecordCache,
+      int minValueSizeForHotCache) {
     LOGGER.info("Creating PCS for replica: {}", partitionReplica);
 
     this.partitionReplica = Objects.requireNonNull(partitionReplica, "TopicPartition cannot be null when creating PCS");
@@ -427,6 +458,8 @@ public class PartitionConsumptionState {
     this.hybrid = hybrid;
     this.offsetRecord = offsetRecord;
     this.pubSubContext = pubSubContext;
+    this.hotRecordCache = hotRecordCache;
+    this.minValueSizeForHotCache = minValueSizeForHotCache;
     this.errorReported = false;
     this.lagCaughtUp = false;
     this.lagCaughtUpTimeInMs = 0;
@@ -1062,10 +1095,45 @@ public class PartitionConsumptionState {
     }
 
     transientRecordMap.put(ByteArrayKey.wrap(key), transientRecord);
+
+    if (hotRecordCache != null) {
+      HotRecordCacheKey hotKey = buildHotCacheKey(key);
+      if (valueLen >= minValueSizeForHotCache) {
+        hotRecordCache.put(hotKey, transientRecord);
+      } else {
+        // Invalidate any stale entry when the new record no longer qualifies
+        hotRecordCache.invalidate(hotKey);
+      }
+    }
   }
 
   public TransientRecord getTransientRecord(byte[] key) {
-    return transientRecordMap.get(ByteArrayKey.wrap(key));
+    TransientRecord record = transientRecordMap.get(ByteArrayKey.wrap(key));
+    if (record != null) {
+      return record;
+    }
+    if (hotRecordCache != null) {
+      record = hotRecordCache.getIfPresent(buildHotCacheKey(key));
+      if (record != null) {
+        hotRecordCacheHitCount.incrementAndGet();
+        if (hotRecordCacheHitRecorder != null) {
+          hotRecordCacheHitRecorder.run();
+        }
+      }
+    }
+    return record;
+  }
+
+  private HotRecordCacheKey buildHotCacheKey(byte[] key) {
+    return new HotRecordCacheKey(getPartition(), key);
+  }
+
+  public long getHotRecordCacheHitCount() {
+    return hotRecordCacheHitCount.get();
+  }
+
+  public void setHotRecordCacheHitRecorder(Runnable hotRecordCacheHitRecorder) {
+    this.hotRecordCacheHitRecorder = hotRecordCacheHitRecorder;
   }
 
   /**
@@ -1128,6 +1196,44 @@ public class PartitionConsumptionState {
    */
   public void clearPreviouslyReadyToServeInOffsetRecord() {
     offsetRecord.clearPreviousStatusesEntry(PREVIOUSLY_READY_TO_SERVE);
+  }
+
+  /**
+   * Cache key for the shared (cross-partition) hot record cache. Combines the partition id with the record key
+   * so the same user key in different partitions does not collide. Wraps the key array by reference rather than
+   * copying it into a partition-prefixed array, avoiding a per-lookup allocation on the ingestion hot path.
+   */
+  public static final class HotRecordCacheKey {
+    private final int partition;
+    private final byte[] key;
+    private final int hashCode;
+
+    public HotRecordCacheKey(int partition, byte[] key) {
+      this.partition = partition;
+      this.key = key;
+      this.hashCode = 31 * partition + Arrays.hashCode(key);
+    }
+
+    public byte[] getContent() {
+      return key;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) {
+        return true;
+      }
+      if (o == null || getClass() != o.getClass()) {
+        return false;
+      }
+      HotRecordCacheKey that = (HotRecordCacheKey) o;
+      return partition == that.partition && Arrays.equals(key, that.key);
+    }
+
+    @Override
+    public int hashCode() {
+      return hashCode;
+    }
   }
 
   /**

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
@@ -23,6 +23,8 @@ import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.concurrent.TimeUnit.MINUTES;
 import static java.util.concurrent.TimeUnit.SECONDS;
 
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
 import com.linkedin.davinci.client.DaVinciRecordTransformer;
 import com.linkedin.davinci.client.DaVinciRecordTransformerConfig;
 import com.linkedin.davinci.client.DaVinciRecordTransformerRecordMetadata;
@@ -399,6 +401,10 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
 
   private final boolean isActiveActiveReplicationEnabled;
 
+  /** Shared Caffeine cache for hot transient records across all partitions. Nullable when disabled. */
+  private final Cache<PartitionConsumptionState.HotRecordCacheKey, PartitionConsumptionState.TransientRecord> hotRecordCache;
+  private final int minValueSizeForHotCache;
+
   /**
    * This would be the number of partitions in the StorageEngine and in version topics
    */
@@ -733,6 +739,22 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
     this.localKafkaServer = this.kafkaProps.getProperty(KAFKA_BOOTSTRAP_SERVERS);
     this.localKafkaServerSingletonSet = Collections.singleton(localKafkaServer);
     this.isActiveActiveReplicationEnabled = version.isActiveActiveReplicationEnabled();
+
+    if (serverConfig.isTransientRecordCacheEnabled() && version.isTransientRecordCacheEnabled()
+        && (this.isActiveActiveReplicationEnabled || this.isWriteComputationEnabled)) {
+      long maxWeight = serverConfig.getTransientRecordCacheMaxWeight();
+      this.hotRecordCache = Caffeine.newBuilder()
+          .maximumWeight(maxWeight)
+          .weigher((PartitionConsumptionState.HotRecordCacheKey k, PartitionConsumptionState.TransientRecord v) -> {
+            return k.getContent().length + (v.getValue() != null ? v.getValueLen() : 0);
+          })
+          .build();
+      this.minValueSizeForHotCache = serverConfig.getTransientRecordCacheMinValueSize();
+    } else {
+      this.hotRecordCache = null;
+      this.minValueSizeForHotCache = 0;
+    }
+
     this.offsetLagDeltaRelaxEnabled = serverConfig.getOffsetLagDeltaRelaxFactorForFastOnlineTransitionInRestart() > 0;
     this.timeLagRelaxEnabled = serverConfig.getTimeLagThresholdForFastOnlineTransitionInRestartMinutes() > 0;
     this.metaStoreWriter = builder.getMetaStoreWriter();
@@ -2870,7 +2892,9 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
         hybridStoreConfig.isPresent(),
         isWriteComputationEnabled,
         isChunked,
-        serverConfig.getRegionName());
+        serverConfig.getRegionName(),
+        hotRecordCache,
+        minValueSizeForHotCache);
     if (uniqueIngestedKeyCountHllEnabled) {
       int lgK = serverConfig.getUniqueIngestedKeyCountHllLog2K();
       boolean isNewSubscription = PubSubSymbolicPosition.EARLIEST.equals(offsetRecord.getCheckpointedLocalVtPosition());
@@ -2882,6 +2906,9 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
       // else: pre-deployment version (not new + no HLL bytes) — leave null, no metric emitted
     }
     freshPcs.setCurrentVersionSupplier(isCurrentVersion);
+    if (hotRecordCache != null) {
+      freshPcs.setHotRecordCacheHitRecorder(hostLevelIngestionStats::recordHotRecordCacheHitCount);
+    }
 
     boolean isFutureVersionReady = isFutureVersionReady(kafkaVersionTopic, storeRepository);
     if (isCurrentVersion.getAsBoolean() || isFutureVersionReady) {
@@ -2924,8 +2951,13 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
         hybridStoreConfig.isPresent(),
         isWriteComputationEnabled,
         isChunked,
-        serverConfig.getRegionName());
+        serverConfig.getRegionName(),
+        hotRecordCache,
+        minValueSizeForHotCache);
     pcs.setCurrentVersionSupplier(isCurrentVersion);
+    if (hotRecordCache != null) {
+      pcs.setHotRecordCacheHitRecorder(hostLevelIngestionStats::recordHotRecordCacheHitCount);
+    }
 
     boolean isFutureVersionReady = isFutureVersionReady(kafkaVersionTopic, storeRepository);
     if (isCurrentVersion.getAsBoolean() || isFutureVersionReady) {
@@ -3195,11 +3227,16 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
           hybridStoreConfig.isPresent(),
           isWriteComputationEnabled,
           isChunked,
-          serverConfig.getRegionName());
+          serverConfig.getRegionName(),
+          hotRecordCache,
+          minValueSizeForHotCache);
       if (uniqueIngestedKeyCountHllEnabled) {
         consumptionState.initializeUniqueKeyCountHll(serverConfig.getUniqueIngestedKeyCountHllLog2K());
       }
       consumptionState.setCurrentVersionSupplier(isCurrentVersion);
+      if (hotRecordCache != null) {
+        consumptionState.setHotRecordCacheHitRecorder(hostLevelIngestionStats::recordHotRecordCacheHitCount);
+      }
       partitionConsumptionStateMap.put(partition, consumptionState);
       storageUtilizationManager.initPartition(partition);
       // Reset the error partition tracking

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/HostLevelIngestionStats.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/HostLevelIngestionStats.java
@@ -174,6 +174,8 @@ public class HostLevelIngestionStats extends AbstractVeniceStats {
   private final Sensor batchProcessingRequestLatencySensor;
   private final LongAdderRateGauge batchProcessingRequestErrorSensor;
 
+  private final Sensor hotRecordCacheHitCountSensor;
+
   /**
    * @param totalStats the total stats singleton instance, or null if we are constructing the total stats
    */
@@ -541,6 +543,12 @@ public class HostLevelIngestionStats extends AbstractVeniceStats {
         totalStats,
         () -> totalStats.batchProcessingRequestLatencySensor,
         avgAndMax());
+
+    this.hotRecordCacheHitCountSensor = registerPerStoreAndTotalSensor(
+        "hot_record_cache_hit_count",
+        totalStats,
+        () -> totalStats.hotRecordCacheHitCountSensor,
+        new OccurrenceRate());
   }
 
   private Measurable measurable(
@@ -710,6 +718,10 @@ public class HostLevelIngestionStats extends AbstractVeniceStats {
 
   public void recordWriteComputeCacheHitCount() {
     writeComputeCacheHitCount.record();
+  }
+
+  public void recordHotRecordCacheHitCount() {
+    hotRecordCacheHitCountSensor.record();
   }
 
   public void recordWriteComputeLookupCount() {

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/PartitionConsumptionStateTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/PartitionConsumptionStateTest.java
@@ -9,6 +9,8 @@ import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertTrue;
 
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
 import com.linkedin.davinci.stats.ingestion.heartbeat.HeartbeatKey;
 import com.linkedin.venice.kafka.protocol.Put;
 import com.linkedin.venice.kafka.validation.checksum.CheckSum;
@@ -633,5 +635,233 @@ public class PartitionConsumptionStateTest {
       pcs.incrementBatchPushRecordCount();
     }
     assertEquals(pcs.getBatchPushRecordCount(), expectedFinalCount, description);
+  }
+
+  private static Cache<PartitionConsumptionState.HotRecordCacheKey, PartitionConsumptionState.TransientRecord> newHotCache() {
+    return Caffeine.newBuilder()
+        .maximumWeight(1024 * 1024)
+        .weigher(
+            (
+                PartitionConsumptionState.HotRecordCacheKey k,
+                PartitionConsumptionState.TransientRecord v) -> k.getContent().length
+                    + (v.getValue() != null ? v.getValueLen() : 0))
+        .build();
+  }
+
+  @Test
+  public void testHotRecordCacheRetainsAfterTransientMapRemoval() {
+    Cache<PartitionConsumptionState.HotRecordCacheKey, PartitionConsumptionState.TransientRecord> hotCache =
+        newHotCache();
+
+    int minValueSize = 10;
+    PartitionConsumptionState pcs = new PartitionConsumptionState(
+        TOPIC_PARTITION,
+        mock(OffsetRecord.class),
+        pubSubContext,
+        false,
+        false,
+        false,
+        null,
+        hotCache,
+        minValueSize);
+
+    PubSubPosition pos = mock(PubSubPosition.class);
+    byte[] key = new byte[] { 1, 2, 3 };
+    byte[] value = new byte[100]; // >= minValueSize, so it should be admitted to hot cache
+
+    pcs.setTransientRecord(-1, pos, key, value, 0, value.length, 1, null);
+
+    // Record is in the transient map
+    assertNotNull(pcs.getTransientRecord(key));
+    assertEquals(pcs.getHotRecordCacheHitCount(), 0);
+
+    // Remove from transient map (simulating drainer)
+    pcs.mayRemoveTransientRecord(-1, pos, key);
+    assertEquals(pcs.getTransientRecordMapSize(), 0);
+
+    // Record should still be available via hot cache fallback
+    PartitionConsumptionState.TransientRecord record = pcs.getTransientRecord(key);
+    assertNotNull(record);
+    assertEquals(record.getValue(), value);
+    assertEquals(pcs.getHotRecordCacheHitCount(), 1);
+  }
+
+  @Test
+  public void testHotRecordCacheAdmissionThreshold() {
+    Cache<PartitionConsumptionState.HotRecordCacheKey, PartitionConsumptionState.TransientRecord> hotCache =
+        newHotCache();
+
+    int minValueSize = 50;
+    PartitionConsumptionState pcs = new PartitionConsumptionState(
+        TOPIC_PARTITION,
+        mock(OffsetRecord.class),
+        pubSubContext,
+        false,
+        false,
+        false,
+        null,
+        hotCache,
+        minValueSize);
+
+    PubSubPosition pos = mock(PubSubPosition.class);
+    byte[] key = new byte[] { 1, 2, 3 };
+    byte[] smallValue = new byte[10]; // < minValueSize, should NOT be in hot cache
+
+    pcs.setTransientRecord(-1, pos, key, smallValue, 0, smallValue.length, 1, null);
+
+    // Remove from transient map
+    pcs.mayRemoveTransientRecord(-1, pos, key);
+    assertEquals(pcs.getTransientRecordMapSize(), 0);
+
+    // Should NOT be in hot cache because value is too small
+    assertNull(pcs.getTransientRecord(key));
+    assertEquals(pcs.getHotRecordCacheHitCount(), 0);
+  }
+
+  @Test
+  public void testHotCacheInvalidatedWhenReplacedWithSmallValue() {
+    Cache<PartitionConsumptionState.HotRecordCacheKey, PartitionConsumptionState.TransientRecord> hotCache =
+        newHotCache();
+
+    int minValueSize = 50;
+    PartitionConsumptionState pcs = new PartitionConsumptionState(
+        TOPIC_PARTITION,
+        mock(OffsetRecord.class),
+        pubSubContext,
+        false,
+        false,
+        false,
+        null,
+        hotCache,
+        minValueSize);
+
+    PubSubPosition pos1 = mock(PubSubPosition.class);
+    PubSubPosition pos2 = mock(PubSubPosition.class);
+    byte[] key = new byte[] { 1, 2, 3 };
+    byte[] largeValue = new byte[100]; // >= minValueSize, admitted to hot cache
+    byte[] smallValue = new byte[10]; // < minValueSize
+
+    // First write: large value gets into hot cache
+    pcs.setTransientRecord(-1, pos1, key, largeValue, 0, largeValue.length, 1, null);
+    pcs.mayRemoveTransientRecord(-1, pos1, key);
+    // Verify hot cache serves it
+    assertNotNull(pcs.getTransientRecord(key));
+
+    // Second write: small value replaces it — hot cache entry must be invalidated
+    pcs.setTransientRecord(-1, pos2, key, smallValue, 0, smallValue.length, 2, null);
+    pcs.mayRemoveTransientRecord(-1, pos2, key);
+    // Stale large-value entry should NOT be returned
+    assertNull(pcs.getTransientRecord(key));
+  }
+
+  @Test
+  public void testHotCacheInvalidatedWhenReplacedWithNullValue() {
+    Cache<PartitionConsumptionState.HotRecordCacheKey, PartitionConsumptionState.TransientRecord> hotCache =
+        newHotCache();
+
+    int minValueSize = 50;
+    PartitionConsumptionState pcs = new PartitionConsumptionState(
+        TOPIC_PARTITION,
+        mock(OffsetRecord.class),
+        pubSubContext,
+        false,
+        false,
+        false,
+        null,
+        hotCache,
+        minValueSize);
+
+    PubSubPosition pos1 = mock(PubSubPosition.class);
+    PubSubPosition pos2 = mock(PubSubPosition.class);
+    byte[] key = new byte[] { 1, 2, 3 };
+    byte[] largeValue = new byte[100];
+
+    // First write: large value gets into hot cache
+    pcs.setTransientRecord(-1, pos1, key, largeValue, 0, largeValue.length, 1, null);
+    pcs.mayRemoveTransientRecord(-1, pos1, key);
+    assertNotNull(pcs.getTransientRecord(key));
+
+    // Second write: null-value overload (valueLen = -1) — must invalidate hot cache entry
+    pcs.setTransientRecord(-1, pos2, key, 2, null);
+    pcs.mayRemoveTransientRecord(-1, pos2, key);
+    assertNull(pcs.getTransientRecord(key));
+  }
+
+  @Test
+  public void testNullHotCacheBehavesIdentically() {
+    // Without hot cache (null), behavior should be identical to previous implementation
+    PartitionConsumptionState pcs = new PartitionConsumptionState(
+        TOPIC_PARTITION,
+        mock(OffsetRecord.class),
+        pubSubContext,
+        false,
+        false,
+        false,
+        null);
+
+    PubSubPosition pos = mock(PubSubPosition.class);
+    byte[] key = new byte[] { 1, 2, 3 };
+    byte[] value = new byte[100];
+
+    pcs.setTransientRecord(-1, pos, key, value, 0, value.length, 1, null);
+    assertNotNull(pcs.getTransientRecord(key));
+
+    pcs.mayRemoveTransientRecord(-1, pos, key);
+    assertNull(pcs.getTransientRecord(key));
+    assertEquals(pcs.getHotRecordCacheHitCount(), 0);
+  }
+
+  @Test
+  public void testTwoPartitionsSharingHotCache() {
+    Cache<PartitionConsumptionState.HotRecordCacheKey, PartitionConsumptionState.TransientRecord> hotCache =
+        newHotCache();
+
+    int minValueSize = 10;
+    PubSubTopicPartition tp0 = new PubSubTopicPartitionImpl(TOPIC_REPOSITORY.getTopic("topic1_v1"), 0);
+    PubSubTopicPartition tp1 = new PubSubTopicPartitionImpl(TOPIC_REPOSITORY.getTopic("topic1_v1"), 1);
+
+    PartitionConsumptionState pcs0 = new PartitionConsumptionState(
+        tp0,
+        mock(OffsetRecord.class),
+        pubSubContext,
+        false,
+        false,
+        false,
+        null,
+        hotCache,
+        minValueSize);
+    PartitionConsumptionState pcs1 = new PartitionConsumptionState(
+        tp1,
+        mock(OffsetRecord.class),
+        pubSubContext,
+        false,
+        false,
+        false,
+        null,
+        hotCache,
+        minValueSize);
+
+    PubSubPosition pos = mock(PubSubPosition.class);
+    byte[] sameKey = new byte[] { 10, 20, 30 };
+    byte[] value0 = new byte[50];
+    byte[] value1 = new byte[60];
+    value0[0] = 1;
+    value1[0] = 2;
+
+    // Both partitions set the same key with different values
+    pcs0.setTransientRecord(-1, pos, sameKey, value0, 0, value0.length, 1, null);
+    pcs1.setTransientRecord(-1, pos, sameKey, value1, 0, value1.length, 1, null);
+
+    // Remove from transient maps
+    pcs0.mayRemoveTransientRecord(-1, pos, sameKey);
+    pcs1.mayRemoveTransientRecord(-1, pos, sameKey);
+
+    // Each partition should get its own value from the hot cache (no key collision)
+    PartitionConsumptionState.TransientRecord r0 = pcs0.getTransientRecord(sameKey);
+    PartitionConsumptionState.TransientRecord r1 = pcs1.getTransientRecord(sameKey);
+    assertNotNull(r0);
+    assertNotNull(r1);
+    assertEquals(r0.getValue()[0], 1);
+    assertEquals(r1.getValue()[0], 2);
   }
 }

--- a/internal/venice-common/src/main/java/com/linkedin/venice/ConfigKeys.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/ConfigKeys.java
@@ -3542,4 +3542,28 @@ public class ConfigKeys {
    */
   public static final String PARTIAL_UPDATE_AMPLIFICATION_REPORT_INTERVAL_MS =
       "partial.update.amplification.report.interval.ms";
+
+  /**
+   * Maximum weight in bytes for the per-SIT shared hot transient record cache. This Caffeine cache retains
+   * frequently accessed large records across consumer poll boundaries to avoid expensive DB lookups for
+   * chunked values. Default is 32MB.
+   */
+  public static final String SERVER_INGESTION_TRANSIENT_RECORD_CACHE_MAX_WEIGHT =
+      "server.ingestion.transient.record.cache.max.weight";
+
+  /**
+   * Minimum value size in bytes for a record to be admitted into the hot transient record cache.
+   * Records smaller than this threshold are cheap to fetch from DB and should not occupy cache budget.
+   * Default is 100KB.
+   */
+  public static final String SERVER_INGESTION_TRANSIENT_RECORD_CACHE_MIN_VALUE_SIZE =
+      "server.ingestion.transient.record.cache.min.value.size";
+
+  /**
+   * Host-level kill switch for the transient record cache. When set to false, the cache is disabled
+   * on this node regardless of the version-level setting. This allows operators to quickly disable
+   * the cache without requiring a new push. Default is true (enabled, defers to version-level config).
+   */
+  public static final String SERVER_INGESTION_TRANSIENT_RECORD_CACHE_ENABLED =
+      "server.ingestion.transient.record.cache.enabled";
 }

--- a/internal/venice-common/src/main/java/com/linkedin/venice/meta/ReadOnlyStore.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/meta/ReadOnlyStore.java
@@ -770,6 +770,16 @@ public class ReadOnlyStore implements Store {
     }
 
     @Override
+    public boolean isTransientRecordCacheEnabled() {
+      return this.delegate.isTransientRecordCacheEnabled();
+    }
+
+    @Override
+    public void setTransientRecordCacheEnabled(boolean transientRecordCacheEnabled) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
     public Version cloneVersion() {
       return this.delegate.cloneVersion();
     }

--- a/internal/venice-common/src/main/java/com/linkedin/venice/meta/Version.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/meta/Version.java
@@ -344,6 +344,10 @@ public interface Version extends Comparable<Version>, DataModelBackedStructure<S
 
   void setPreviousCurrentVersion(int previousCurrentVersion);
 
+  boolean isTransientRecordCacheEnabled();
+
+  void setTransientRecordCacheEnabled(boolean transientRecordCacheEnabled);
+
   /**
    * Per-version storage mode controlling where data is persisted relative to the configured external storage system.
    * Defaults to {@link StorageMode#INTERNAL}. Mirrors the {@code storageMode} field staged on {@code StoreVersion}

--- a/internal/venice-common/src/main/java/com/linkedin/venice/meta/VersionImpl.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/meta/VersionImpl.java
@@ -531,6 +531,16 @@ public class VersionImpl implements Version {
   }
 
   @Override
+  public boolean isTransientRecordCacheEnabled() {
+    return this.storeVersion.transientRecordCacheEnabled;
+  }
+
+  @Override
+  public void setTransientRecordCacheEnabled(boolean transientRecordCacheEnabled) {
+    this.storeVersion.transientRecordCacheEnabled = transientRecordCacheEnabled;
+  }
+
+  @Override
   public StoreVersion dataModel() {
     return this.storeVersion;
   }


### PR DESCRIPTION
## Problem Statement

During Active-Active replication and Write Compute ingestion, the transient record map in `PartitionConsumptionState` holds records only until the drainer processes them. For large/chunked values, once evicted from the transient map, the ingestion pipeline must perform expensive RocksDB lookups to re-fetch the record. This is especially costly when the same key is accessed repeatedly across consumer poll boundaries.

## Solution

Introduce a **shared, bounded Caffeine cache** per `StoreIngestionTask` that retains large transient records across consumer poll boundaries, acting as a second-level lookup after the per-partition transient record map.

### Key design:
- **Version-level flag** (`transientRecordCacheEnabled`) controls whether the cache is active for a given store version
- **Host-level kill switch** (`server.ingestion.transient.record.cache.enabled`, default `true`) allows operators to disable the cache on a node immediately without requiring a new push
- **Weight-based eviction** via Caffeine (`server.ingestion.transient.record.cache.max.weight`, default 32MB)
- **Admission gating** — only records with value size >= threshold are admitted (`server.ingestion.transient.record.cache.min.value.size`, default 100KB)
- **Partition-safe** — cache keys are prefixed with partition ID to avoid cross-partition collisions in the shared cache
- **Staleness protection** — when a key is overwritten with a smaller value or null-value update, the stale hot cache entry is invalidated

### Code changes

- [x] Added new code behind **a config**:
  - `transientRecordCacheEnabled` (version-level, default `false`)
  - `server.ingestion.transient.record.cache.enabled` (server-level, default `true`)
  - `server.ingestion.transient.record.cache.max.weight` (server-level, default `33554432` / 32MB)
  - `server.ingestion.transient.record.cache.min.value.size` (server-level, default `102400` / 100KB)
- [ ] Introduced new **log lines**.
  - [ ] Confirmed if logs need to be **rate limited** to avoid excessive logging.

### **Concurrency-Specific Checks**

Both reviewer and PR author to verify

- [x] Code has **no race conditions** or **thread safety issues**. The Caffeine cache is thread-safe; hit counter uses `AtomicLong`.
- [x] Proper **synchronization mechanisms** (e.g., `synchronized`, `RWLock`) are used where needed.
- [x] No **blocking calls** inside critical sections that could lead to deadlocks or performance degradation.
- [x] Verified **thread-safe collections** are used (e.g., `ConcurrentHashMap`, `CopyOnWriteArrayList`).
- [x] Validated proper exception handling in multi-threaded code to avoid silent thread termination.

## How was this PR tested?

- [x] New unit tests added.
  - Hot cache retention after transient map removal
  - Admission threshold filtering (small values excluded)
  - Null hot cache backward compatibility
  - Two-partition shared cache key isolation
  - Cache invalidation on small-value overwrite
  - Cache invalidation on null-value overwrite
- [ ] New integration tests added.
- [ ] Modified or extended existing tests.
- [x] Verified backward compatibility (if applicable). New Avro schema v42 with default values.

## Does this PR introduce any user-facing or breaking changes?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Clearly explain the behavior change and its impact.