### PR TITLE
Global RT DIV: Fix SST Key-Ordering Error on OFFLINE→STANDBY Retry

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,4 @@ Gemfile.lock
 docs/vendor/
 docs/_site/
 
+.worktrees/

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTask.java
@@ -3165,7 +3165,7 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
 
     try {
       // VT DIV contains the latest consumed VT position (LCVP)
-      PartitionTracker vtDiv = consumerDiv.cloneVtProducerStates(partition, true);
+      PartitionTracker vtDiv = getConsumerDiv().cloneVtProducerStates(partition, true);
 
       // Skip sync if no real VT progress has been made yet. Syncing with EARLIEST would persist
       // EARLIEST to the OffsetRecord, causing the consumer to re-subscribe from EARLIEST on retry.

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTask.java
@@ -3173,12 +3173,6 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
         return;
       }
 
-      // Skip sync if no VT producer segments have been tracked yet. There is nothing meaningful
-      // to persist — the segment state is empty and writing it would be a no-op at best.
-      if (vtDiv.getPartitionStates(PartitionTracker.VERSION_TOPIC).isEmpty()) {
-        return;
-      }
-
       CompletableFuture<Void> lastFuture = pcs.getLastQueuedRecordPersistedFuture();
       storeBufferService.execSyncOffsetFromSnapshotAsync(topicPartition, vtDiv, lastFuture, this);
       // Reset consumer-side VT bytes so the size-based condition in shouldSyncOffsetFromSnapshot does not keep

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTask.java
@@ -3166,6 +3166,19 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
     try {
       // VT DIV contains the latest consumed VT position (LCVP)
       PartitionTracker vtDiv = consumerDiv.cloneVtProducerStates(partition, true);
+
+      // Skip sync if no real VT progress has been made yet. Syncing with EARLIEST would persist
+      // EARLIEST to the OffsetRecord, causing the consumer to re-subscribe from EARLIEST on retry.
+      if (PubSubSymbolicPosition.EARLIEST.equals(vtDiv.getLatestConsumedVtPosition())) {
+        return;
+      }
+
+      // Skip sync if no VT producer segments have been tracked yet. There is nothing meaningful
+      // to persist — the segment state is empty and writing it would be a no-op at best.
+      if (vtDiv.getPartitionStates(PartitionTracker.VERSION_TOPIC).isEmpty()) {
+        return;
+      }
+
       CompletableFuture<Void> lastFuture = pcs.getLastQueuedRecordPersistedFuture();
       storeBufferService.execSyncOffsetFromSnapshotAsync(topicPartition, vtDiv, lastFuture, this);
       // Reset consumer-side VT bytes so the size-based condition in shouldSyncOffsetFromSnapshot does not keep

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
@@ -5635,7 +5635,7 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
   }
 
   boolean isGlobalRtDivEnabled() {
-    return isGlobalRtDivEnabled;
+    return isGlobalRtDivEnabled && isHybridMode();
   }
 
   /** When Global RT DIV is enabled the ConsumptionTask's DIV is exclusively used to validate data integrity. */

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
@@ -5635,7 +5635,7 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
   }
 
   boolean isGlobalRtDivEnabled() {
-    return isGlobalRtDivEnabled && isHybridMode();
+    return isGlobalRtDivEnabled;
   }
 
   /** When Global RT DIV is enabled the ConsumptionTask's DIV is exclusively used to validate data integrity. */

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/validation/PartitionTracker.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/validation/PartitionTracker.java
@@ -287,7 +287,6 @@ public class PartitionTracker {
     ProducerPartitionState state;
     if (TopicType.isVersionTopic(type)) {
       state = offsetRecord.getProducerPartitionState(guid);
-      offsetRecord.setLatestConsumedVtPosition(getLatestConsumedVtPosition());
     } else {
       state = offsetRecord.getRealTimeProducerState(type.getKafkaUrl(), guid);
     }
@@ -314,6 +313,13 @@ public class PartitionTracker {
   }
 
   public void updateOffsetRecord(TopicType type, OffsetRecord offsetRecord) {
+    if (TopicType.isVersionTopic(type)) {
+      // Always persist the latest consumed VT position, even when there are no segments yet
+      // (e.g. at SOP before any VT producer segment has been tracked). Without this, the
+      // OffsetRecord keeps latestConsumedVtPosition=EARLIEST, which causes the consumer to
+      // re-subscribe from EARLIEST on the next retry, leading to out-of-order SST keys.
+      offsetRecord.setLatestConsumedVtPosition(getLatestConsumedVtPosition());
+    }
     for (Map.Entry<GUID, Segment> entry: getSegments(type).entrySet()) {
       updateOffsetRecord(type, entry.getKey(), entry.getValue(), offsetRecord);
     }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/validation/PartitionTracker.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/validation/PartitionTracker.java
@@ -314,10 +314,7 @@ public class PartitionTracker {
 
   public void updateOffsetRecord(TopicType type, OffsetRecord offsetRecord) {
     if (TopicType.isVersionTopic(type)) {
-      // Always persist the latest consumed VT position, even when there are no segments yet
-      // (e.g. at SOP before any VT producer segment has been tracked). Without this, the
-      // OffsetRecord keeps latestConsumedVtPosition=EARLIEST, which causes the consumer to
-      // re-subscribe from EARLIEST on the next retry, leading to out-of-order SST keys.
+      // Without this, the OffsetRecord keeps latestConsumedVtPosition=EARLIEST
       offsetRecord.setLatestConsumedVtPosition(getLatestConsumedVtPosition());
     }
     for (Map.Entry<GUID, Segment> entry: getSegments(type).entrySet()) {

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTaskTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTaskTest.java
@@ -73,6 +73,7 @@ import com.linkedin.venice.kafka.protocol.enums.ControlMessageType;
 import com.linkedin.venice.kafka.protocol.enums.MessageType;
 import com.linkedin.venice.kafka.protocol.state.GlobalRtDivState;
 import com.linkedin.venice.message.KafkaKey;
+import com.linkedin.venice.meta.HybridStoreConfigImpl;
 import com.linkedin.venice.meta.MaterializedViewParameters;
 import com.linkedin.venice.meta.ReadOnlyStoreRepository;
 import com.linkedin.venice.meta.Store;
@@ -938,6 +939,62 @@ public class LeaderFollowerStoreIngestionTaskTest {
 
     leaderFollowerStoreIngestionTask.syncOffsetFromSnapshotIfNeeded(mockRecord, versionTopicPartition);
     verify(mockStoreBufferService, times(1)).execSyncOffsetFromSnapshotAsync(any(), any(), any(), any());
+  }
+
+  /**
+   * Verifies that {@link StoreIngestionTask#isGlobalRtDivEnabled()} returns false when the store is not in hybrid mode,
+   * even if the store-level flag is set to true. Global RT DIV tracks RT producer state, so it is meaningless for
+   * batch-only stores that never receive real-time writes.
+   */
+  @Test
+  public void testIsGlobalRtDivEnabledRequiresHybridMode() throws InterruptedException {
+    setUp(); // initializes mockStorageService, mockProperties, mockBooleanSupplier, mockVeniceStoreVersionConfig
+    String storeName = Utils.getUniqueString("store");
+
+    // Build a task with globalRtDivEnabled=true but NO hybrid config
+    StoreIngestionTaskFactory.Builder nonHybridBuilder = TestUtils.getStoreIngestionTaskBuilder(storeName, false);
+    doReturn(Object2IntMaps.emptyMap()).when(nonHybridBuilder.getServerConfig()).getKafkaClusterUrlToIdMap();
+    Version nonHybridVersion = nonHybridBuilder.getMetadataRepo().getStoreOrThrow(storeName).getVersion(1);
+    nonHybridVersion.setGlobalRtDivEnabled(true);
+    Store nonHybridStore = nonHybridBuilder.getMetadataRepo().getStoreOrThrow(storeName);
+    LeaderFollowerStoreIngestionTask nonHybridTask = (LeaderFollowerStoreIngestionTask) nonHybridBuilder.build()
+        .getNewIngestionTask(
+            mockStorageService,
+            nonHybridStore,
+            nonHybridVersion,
+            mockProperties,
+            mockBooleanSupplier,
+            mockVeniceStoreVersionConfig,
+            0,
+            Optional.empty(),
+            null,
+            null);
+    assertFalse(
+        nonHybridTask.isGlobalRtDivEnabled(),
+        "isGlobalRtDivEnabled() must return false for non-hybrid stores even if the flag is set");
+
+    // Build a task with globalRtDivEnabled=true AND a hybrid config
+    StoreIngestionTaskFactory.Builder hybridBuilder = TestUtils.getStoreIngestionTaskBuilder(storeName, true);
+    doReturn(Object2IntMaps.emptyMap()).when(hybridBuilder.getServerConfig()).getKafkaClusterUrlToIdMap();
+    Version hybridVersion = hybridBuilder.getMetadataRepo().getStoreOrThrow(storeName).getVersion(1);
+    hybridVersion.setGlobalRtDivEnabled(true);
+    hybridVersion.setHybridStoreConfig(new HybridStoreConfigImpl(0, 0, 0, null, null, null));
+    Store hybridStore = hybridBuilder.getMetadataRepo().getStoreOrThrow(storeName);
+    LeaderFollowerStoreIngestionTask hybridTask = (LeaderFollowerStoreIngestionTask) hybridBuilder.build()
+        .getNewIngestionTask(
+            mockStorageService,
+            hybridStore,
+            hybridVersion,
+            mockProperties,
+            mockBooleanSupplier,
+            mockVeniceStoreVersionConfig,
+            0,
+            Optional.empty(),
+            null,
+            null);
+    assertTrue(
+        hybridTask.isGlobalRtDivEnabled(),
+        "isGlobalRtDivEnabled() must return true for hybrid stores with the flag set");
   }
 
   @Test

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTaskTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTaskTest.java
@@ -877,6 +877,69 @@ public class LeaderFollowerStoreIngestionTaskTest {
     assertFalse(mockIngestionTask.shouldSyncOffsetFromSnapshot(regularMessage, mockPartitionConsumptionState));
   }
 
+  /**
+   * Regression test for the two early-exit guards added to syncOffsetFromSnapshotIfNeeded.
+   *
+   * <p>When Global RT DIV is enabled, SyncVtDivNode fires for non-segment control messages such as START_OF_PUSH.
+   * At that point no VT producer segment has been opened yet, so the snapshot has LCVP=EARLIEST and an empty segment
+   * map. Allowing the sync to proceed in this state would stamp EARLIEST into the OffsetRecord, causing the follower
+   * to re-subscribe from VT offset 0 on the next Helix OFFLINE→STANDBY retry — leading to out-of-order SST key
+   * writes and a RocksDBException during batch push.
+   *
+   * <p>Guards:
+   * <ol>
+   *   <li>Skip if the snapshot's LCVP equals EARLIEST (no meaningful VT progress yet).</li>
+   *   <li>Skip if the snapshot's VT segment map is empty (no producer state to persist).</li>
+   * </ol>
+   */
+  @Test
+  public void testSyncOffsetFromSnapshotIfNeededSkipsWhenLcvpIsEarliestOrNoSegments() throws InterruptedException {
+    setUp();
+
+    // isGlobalRtDivEnabled must be true and shouldSyncOffsetFromSnapshot must pass so we reach the new guards
+    doReturn(true).when(leaderFollowerStoreIngestionTask).isGlobalRtDivEnabled();
+    doReturn(true).when(leaderFollowerStoreIngestionTask).shouldSyncOffsetFromSnapshot(any(), any());
+    CompletableFuture<Void> mockFuture = new CompletableFuture<>();
+    doReturn(mockFuture).when(mockPartitionConsumptionState).getLastQueuedRecordPersistedFuture();
+
+    // Route consumerDiv through a mock so we can control the returned snapshot
+    DataIntegrityValidator mockConsumerDiv = mock(DataIntegrityValidator.class);
+    doReturn(mockConsumerDiv).when(leaderFollowerStoreIngestionTask).getConsumerDiv();
+
+    // The task was set up with partition 0 → mockPartitionConsumptionState in setUp()
+    PubSubTopicPartition versionTopicPartition =
+        new PubSubTopicPartitionImpl(TOPIC_REPOSITORY.getTopic("test-topic_v1"), 0);
+    DefaultPubSubMessage mockRecord = getMockMessage(1).getMessage();
+
+    // --- Case 1: LCVP = EARLIEST (default for a fresh tracker) → sync must be skipped ---
+    PartitionTracker snapshotEarliestLcvp = mock(PartitionTracker.class);
+    doReturn(PubSubSymbolicPosition.EARLIEST).when(snapshotEarliestLcvp).getLatestConsumedVtPosition();
+    doReturn(snapshotEarliestLcvp).when(mockConsumerDiv).cloneVtProducerStates(anyInt(), anyBoolean());
+
+    leaderFollowerStoreIngestionTask.syncOffsetFromSnapshotIfNeeded(mockRecord, versionTopicPartition);
+    verify(mockStoreBufferService, never()).execSyncOffsetFromSnapshotAsync(any(), any(), any(), any());
+
+    // --- Case 2: LCVP is non-EARLIEST but segment map is empty → sync must still be skipped ---
+    PartitionTracker snapshotNoSegments = mock(PartitionTracker.class);
+    doReturn(ApacheKafkaOffsetPosition.of(10L)).when(snapshotNoSegments).getLatestConsumedVtPosition();
+    doReturn(Collections.emptyMap()).when(snapshotNoSegments).getPartitionStates(any());
+    doReturn(snapshotNoSegments).when(mockConsumerDiv).cloneVtProducerStates(anyInt(), anyBoolean());
+
+    leaderFollowerStoreIngestionTask.syncOffsetFromSnapshotIfNeeded(mockRecord, versionTopicPartition);
+    verify(mockStoreBufferService, never()).execSyncOffsetFromSnapshotAsync(any(), any(), any(), any());
+
+    // --- Case 3: LCVP is non-EARLIEST and segments are non-empty → sync must proceed ---
+    PartitionTracker snapshotReady = mock(PartitionTracker.class);
+    doReturn(ApacheKafkaOffsetPosition.of(10L)).when(snapshotReady).getLatestConsumedVtPosition();
+    doReturn(Collections.singletonMap("producerGuid", new Object())).when(snapshotReady).getPartitionStates(any());
+    doReturn(snapshotReady).when(mockConsumerDiv).cloneVtProducerStates(anyInt(), anyBoolean());
+    VeniceConcurrentHashMap<String, Long> consumedBytes = new VeniceConcurrentHashMap<>();
+    doReturn(consumedBytes).when(leaderFollowerStoreIngestionTask).getConsumedBytesSinceLastSync();
+
+    leaderFollowerStoreIngestionTask.syncOffsetFromSnapshotIfNeeded(mockRecord, versionTopicPartition);
+    verify(mockStoreBufferService, times(1)).execSyncOffsetFromSnapshotAsync(any(), any(), any(), any());
+  }
+
   @Test
   public void testFutureVersionLatchStatus() throws InterruptedException {
     setUp(true);

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTaskTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTaskTest.java
@@ -879,25 +879,22 @@ public class LeaderFollowerStoreIngestionTaskTest {
   }
 
   /**
-   * Regression test for the two early-exit guards added to syncOffsetFromSnapshotIfNeeded.
+   * Regression test for the early-exit guard added to syncOffsetFromSnapshotIfNeeded.
    *
-   * <p>When Global RT DIV is enabled, SyncVtDivNode fires for non-segment control messages such as START_OF_PUSH.
-   * At that point no VT producer segment has been opened yet, so the snapshot has LCVP=EARLIEST and an empty segment
-   * map. Allowing the sync to proceed in this state would stamp EARLIEST into the OffsetRecord, causing the follower
-   * to re-subscribe from VT offset 0 on the next Helix OFFLINE→STANDBY retry — leading to out-of-order SST key
-   * writes and a RocksDBException during batch push.
+   * <p>When Global RT DIV is enabled, SyncVtDivNode fires for non-segment control messages. If no VT
+   * record has been processed yet — i.e., the partition tracker has not recorded any VT progress —
+   * the snapshot's LCVP will still be EARLIEST. Allowing the sync to proceed in this state would stamp
+   * EARLIEST into the OffsetRecord, causing the follower to re-subscribe from EARLIEST on the next
+   * Helix OFFLINE→STANDBY retry — leading to out-of-order SST key writes and a RocksDBException during
+   * batch push.
    *
-   * <p>Guards:
-   * <ol>
-   *   <li>Skip if the snapshot's LCVP equals EARLIEST (no meaningful VT progress yet).</li>
-   *   <li>Skip if the snapshot's VT segment map is empty (no producer state to persist).</li>
-   * </ol>
+   * <p>Guard: Skip if the snapshot's LCVP equals EARLIEST (no meaningful VT progress yet).
    */
   @Test
-  public void testSyncOffsetFromSnapshotIfNeededSkipsWhenLcvpIsEarliestOrNoSegments() throws InterruptedException {
+  public void testSyncOffsetFromSnapshotIfNeededSkipsWhenLcvpIsEarliest() throws InterruptedException {
     setUp();
 
-    // isGlobalRtDivEnabled must be true and shouldSyncOffsetFromSnapshot must pass so we reach the new guards
+    // isGlobalRtDivEnabled must be true and shouldSyncOffsetFromSnapshot must pass so we reach the new guard
     doReturn(true).when(leaderFollowerStoreIngestionTask).isGlobalRtDivEnabled();
     doReturn(true).when(leaderFollowerStoreIngestionTask).shouldSyncOffsetFromSnapshot(any(), any());
     CompletableFuture<Void> mockFuture = new CompletableFuture<>();
@@ -912,7 +909,7 @@ public class LeaderFollowerStoreIngestionTaskTest {
         new PubSubTopicPartitionImpl(TOPIC_REPOSITORY.getTopic("test-topic_v1"), 0);
     DefaultPubSubMessage mockRecord = getMockMessage(1).getMessage();
 
-    // --- Case 1: LCVP = EARLIEST (default for a fresh tracker) → sync must be skipped ---
+    // --- Case 1: LCVP = EARLIEST (no VT record processed yet) → sync must be skipped ---
     PartitionTracker snapshotEarliestLcvp = mock(PartitionTracker.class);
     doReturn(PubSubSymbolicPosition.EARLIEST).when(snapshotEarliestLcvp).getLatestConsumedVtPosition();
     doReturn(snapshotEarliestLcvp).when(mockConsumerDiv).cloneVtProducerStates(anyInt(), anyBoolean());
@@ -920,16 +917,7 @@ public class LeaderFollowerStoreIngestionTaskTest {
     leaderFollowerStoreIngestionTask.syncOffsetFromSnapshotIfNeeded(mockRecord, versionTopicPartition);
     verify(mockStoreBufferService, never()).execSyncOffsetFromSnapshotAsync(any(), any(), any(), any());
 
-    // --- Case 2: LCVP is non-EARLIEST but segment map is empty → sync must still be skipped ---
-    PartitionTracker snapshotNoSegments = mock(PartitionTracker.class);
-    doReturn(ApacheKafkaOffsetPosition.of(10L)).when(snapshotNoSegments).getLatestConsumedVtPosition();
-    doReturn(Collections.emptyMap()).when(snapshotNoSegments).getPartitionStates(any());
-    doReturn(snapshotNoSegments).when(mockConsumerDiv).cloneVtProducerStates(anyInt(), anyBoolean());
-
-    leaderFollowerStoreIngestionTask.syncOffsetFromSnapshotIfNeeded(mockRecord, versionTopicPartition);
-    verify(mockStoreBufferService, never()).execSyncOffsetFromSnapshotAsync(any(), any(), any(), any());
-
-    // --- Case 3: LCVP is non-EARLIEST and segments are non-empty → sync must proceed ---
+    // --- Case 2: LCVP is non-EARLIEST (VT progress recorded) → sync must proceed, even with empty segments ---
     PartitionTracker snapshotReady = mock(PartitionTracker.class);
     doReturn(ApacheKafkaOffsetPosition.of(10L)).when(snapshotReady).getLatestConsumedVtPosition();
     doReturn(Collections.singletonMap("producerGuid", new Object())).when(snapshotReady).getPartitionStates(any());

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTaskTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTaskTest.java
@@ -73,7 +73,6 @@ import com.linkedin.venice.kafka.protocol.enums.ControlMessageType;
 import com.linkedin.venice.kafka.protocol.enums.MessageType;
 import com.linkedin.venice.kafka.protocol.state.GlobalRtDivState;
 import com.linkedin.venice.message.KafkaKey;
-import com.linkedin.venice.meta.HybridStoreConfigImpl;
 import com.linkedin.venice.meta.MaterializedViewParameters;
 import com.linkedin.venice.meta.ReadOnlyStoreRepository;
 import com.linkedin.venice.meta.Store;
@@ -927,62 +926,6 @@ public class LeaderFollowerStoreIngestionTaskTest {
 
     leaderFollowerStoreIngestionTask.syncOffsetFromSnapshotIfNeeded(mockRecord, versionTopicPartition);
     verify(mockStoreBufferService, times(1)).execSyncOffsetFromSnapshotAsync(any(), any(), any(), any());
-  }
-
-  /**
-   * Verifies that {@link StoreIngestionTask#isGlobalRtDivEnabled()} returns false when the store is not in hybrid mode,
-   * even if the store-level flag is set to true. Global RT DIV tracks RT producer state, so it is meaningless for
-   * batch-only stores that never receive real-time writes.
-   */
-  @Test
-  public void testIsGlobalRtDivEnabledRequiresHybridMode() throws InterruptedException {
-    setUp(); // initializes mockStorageService, mockProperties, mockBooleanSupplier, mockVeniceStoreVersionConfig
-    String storeName = Utils.getUniqueString("store");
-
-    // Build a task with globalRtDivEnabled=true but NO hybrid config
-    StoreIngestionTaskFactory.Builder nonHybridBuilder = TestUtils.getStoreIngestionTaskBuilder(storeName, false);
-    doReturn(Object2IntMaps.emptyMap()).when(nonHybridBuilder.getServerConfig()).getKafkaClusterUrlToIdMap();
-    Version nonHybridVersion = nonHybridBuilder.getMetadataRepo().getStoreOrThrow(storeName).getVersion(1);
-    nonHybridVersion.setGlobalRtDivEnabled(true);
-    Store nonHybridStore = nonHybridBuilder.getMetadataRepo().getStoreOrThrow(storeName);
-    LeaderFollowerStoreIngestionTask nonHybridTask = (LeaderFollowerStoreIngestionTask) nonHybridBuilder.build()
-        .getNewIngestionTask(
-            mockStorageService,
-            nonHybridStore,
-            nonHybridVersion,
-            mockProperties,
-            mockBooleanSupplier,
-            mockVeniceStoreVersionConfig,
-            0,
-            Optional.empty(),
-            null,
-            null);
-    assertFalse(
-        nonHybridTask.isGlobalRtDivEnabled(),
-        "isGlobalRtDivEnabled() must return false for non-hybrid stores even if the flag is set");
-
-    // Build a task with globalRtDivEnabled=true AND a hybrid config
-    StoreIngestionTaskFactory.Builder hybridBuilder = TestUtils.getStoreIngestionTaskBuilder(storeName, true);
-    doReturn(Object2IntMaps.emptyMap()).when(hybridBuilder.getServerConfig()).getKafkaClusterUrlToIdMap();
-    Version hybridVersion = hybridBuilder.getMetadataRepo().getStoreOrThrow(storeName).getVersion(1);
-    hybridVersion.setGlobalRtDivEnabled(true);
-    hybridVersion.setHybridStoreConfig(new HybridStoreConfigImpl(0, 0, 0, null, null, null));
-    Store hybridStore = hybridBuilder.getMetadataRepo().getStoreOrThrow(storeName);
-    LeaderFollowerStoreIngestionTask hybridTask = (LeaderFollowerStoreIngestionTask) hybridBuilder.build()
-        .getNewIngestionTask(
-            mockStorageService,
-            hybridStore,
-            hybridVersion,
-            mockProperties,
-            mockBooleanSupplier,
-            mockVeniceStoreVersionConfig,
-            0,
-            Optional.empty(),
-            null,
-            null);
-    assertTrue(
-        hybridTask.isGlobalRtDivEnabled(),
-        "isGlobalRtDivEnabled() must return true for hybrid stores with the flag set");
   }
 
   @Test

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/validation/TestPartitionTracker.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/validation/TestPartitionTracker.java
@@ -719,6 +719,35 @@ public class TestPartitionTracker {
   }
 
   /**
+   * Regression test for a bug where updateOffsetRecord only called setLatestConsumedVtPosition inside the per-segment
+   * loop. When no VT producer segments exist yet (e.g. at SOP before the first data record arrives), the loop body
+   * never executed, leaving latestConsumedVtPosition=EARLIEST in the OffsetRecord. On the next OFFLINE→STANDBY retry
+   * the consumer would re-subscribe from EARLIEST, causing out-of-order SST key writes during batch push.
+   */
+  @Test(timeOut = 10 * Time.MS_PER_SECOND)
+  public void testUpdateOffsetRecordPersistsLcvpWithNoSegments() {
+    // A freshly constructed PartitionTracker has no VT segments
+    assertTrue(
+        partitionTracker.getPartitionStates(vt).isEmpty(),
+        "Precondition: tracker should start with no VT segments");
+
+    // Simulate the consumer having advanced past SOP (LCVP is now a real offset, not EARLIEST)
+    PubSubPosition sopPosition = ApacheKafkaOffsetPosition.of(0L);
+    partitionTracker.updateLatestConsumedVtPosition(sopPosition);
+
+    OffsetRecord offsetRecord =
+        TestUtils.getOffsetRecord(sopPosition, Optional.empty(), DEFAULT_PUBSUB_CONTEXT_FOR_UNIT_TESTING);
+
+    // updateOffsetRecord must persist LCVP even though no segments exist yet
+    partitionTracker.updateOffsetRecord(vt, offsetRecord);
+
+    assertEquals(
+        offsetRecord.getLatestConsumedVtPosition(),
+        sopPosition,
+        "LCVP must be written to OffsetRecord even when no VT producer segments have been tracked yet");
+  }
+
+  /**
    * Test that cloneVtProducerStates removes old entries from the source tracker when maxAgeInMs threshold is exceeded.
    */
   @Test(timeOut = 10 * Time.MS_PER_SECOND)


### PR DESCRIPTION
## Summary

Fixes a bug where enabling Global RT DIV causes batch push to fail with:

```
org.rocksdb.RocksDBException: Keys must be added in strict ascending order
```

### Background

When Global RT DIV is enabled, a follower tracks its latest consumed VT position (LCVP) and periodically persists it to the OffsetRecord via `SyncVtDivNode`. On each OFFLINE→STANDBY transition (including Helix retries with `RETRY_COUNT=3`), `getLocalVtSubscribePosition()` reads LCVP from the OffsetRecord and uses it as the starting consume position for the VT. This lets the follower resume from where it left off rather than re-reading from the beginning of the topic.

With Global RT DIV **off**, the analogous field is `latestProcessedVtPosition`, which is checkpointed via `updateOffsetMetadataInOffsetRecord` inside the normal `syncOffset` drainer path. Critically, `latestProcessedVtPosition` and the RocksDB SST checkpoint are always written together in the same `syncOffset` call — so they are always consistent on disk. A crash or failed push just rolls both back to the last sync point, and re-subscribing from that point writes new SST data cleanly in order.

With Global RT DIV **on**, `shouldSyncOffset` always returns `false` — the drainer sync path is completely disabled. LCVP is only persisted through `SyncVtDivNode`, which calls `updateAndSyncOffsetFromSnapshot` → `PartitionTracker.updateOffsetRecord` → `syncOffset`. This separation introduced two bugs that caused LCVP to be stamped as `EARLIEST` even after real VT progress had been made.

### Bug 1: `PartitionTracker.updateOffsetRecord` — LCVP not written when segment count is zero

`SyncVtDivNode` fires for every non-segment control message, including `START_OF_PUSH`. At SOP time, the VT producer has not yet sent any user data, so no VT producer segment has been opened yet. The call chain was:

```
SyncVtDivNode.execute()
  → updateAndSyncOffsetFromSnapshot(vtDivSnapshot, topicPartition)
      → vtDivSnapshot.updateOffsetRecord(VERSION_TOPIC, pcs.getOffsetRecord())
```

Inside `updateOffsetRecord`, `setLatestConsumedVtPosition` was called only inside the per-segment loop (private overload):

```java
// BEFORE (private overload — BUG)
for (Map.Entry<GUID, Segment> entry : getSegments(type).entrySet()) {
    // only reached when a segment exists
    offsetRecord.setLatestConsumedVtPosition(getLatestConsumedVtPosition());
    ...
}
```

With zero segments the loop body never executes, so LCVP is never written to the OffsetRecord. `cloneVtProducerStates` does copy the LCVP into the snapshot (`destProducerTracker.updateLatestConsumedVtPosition(...)`), but that LCVP value never makes it into the OffsetRecord when segments are absent.

`syncOffset` then persists the OffsetRecord with `LCVP = EARLIEST` to disk.

**Fix:** move `setLatestConsumedVtPosition` to the public `updateOffsetRecord(TopicType, OffsetRecord)` method, unconditionally before the loop:

```java
// AFTER (public method — FIXED)
public void updateOffsetRecord(TopicType type, OffsetRecord offsetRecord) {
    if (TopicType.isVersionTopic(type)) {
        // Always persist LCVP even when no segments exist yet (e.g. at SOP)
        offsetRecord.setLatestConsumedVtPosition(getLatestConsumedVtPosition());
    }
    for (Map.Entry<GUID, Segment> entry : getSegments(type).entrySet()) {
        updateOffsetRecord(type, entry.getKey(), entry.getValue(), offsetRecord);
    }
}
```

### Bug 2: `syncOffsetFromSnapshotIfNeeded` — syncing when LCVP is EARLIEST or segments are empty

Even with Bug 1 fixed, `consumerDiv` starts with `latestConsumedVtPosition = EARLIEST` and no VT segments. If `shouldSyncOffsetFromSnapshot` returns `true` before the consumer has made any meaningful VT progress (e.g. SOP triggers `isNonSegmentControlMessage`), `cloneVtProducerStates` produces a snapshot whose LCVP is EARLIEST and whose segment map is empty. Enqueueing that snapshot as a `SyncVtDivNode` is either harmful (persisting EARLIEST to disk) or a no-op (empty segment map).

**Fix:** return early from `syncOffsetFromSnapshotIfNeeded` after cloning if either condition holds:

```java
PartitionTracker vtDiv = consumerDiv.cloneVtProducerStates(partition, true);

if (PubSubSymbolicPosition.EARLIEST.equals(vtDiv.getLatestConsumedVtPosition())) {
    return; // no real VT progress yet; persisting EARLIEST would break re-subscription
}
if (vtDiv.getPartitionStates(PartitionTracker.VERSION_TOPIC).isEmpty()) {
    return; // no segments tracked; nothing meaningful to persist
}
```

### How the SST ordering error manifests

With both bugs in place, the failure chain during batch push is:

1. Follower subscribes to VT from EARLIEST (first attempt, or LCVP = EARLIEST from a prior failed attempt).
2. SOP is consumed. `shouldSyncOffsetFromSnapshot` returns `true` (SOP is a non-segment control message). `SyncVtDivNode` is enqueued.
3. `SyncVtDivNode.execute()` runs. vtDiv has 0 segments → Bug 1 means LCVP is never written → OffsetRecord is persisted with `LCVP = EARLIEST`.
4. User data records are written into the RocksDB SST file. If a record in the drainer fails (or one from a prior retry's data is re-consumed), the `lastRecordPersistedFuture` completes exceptionally.
5. Subsequent `SyncVtDivNode` instances are skipped (`isCompletedExceptionally()` check in `SyncVtDivNode.execute()`), so the SST file is never closed/synced.
6. The Helix OFFLINE→STANDBY transition fails and is retried.
7. On retry, `getLocalVtSubscribePosition()` reads LCVP = EARLIEST from disk. The consumer re-subscribes from VT offset 0.
8. Records from the beginning of the VT are re-consumed and written into the **same open SST file** that already contains data from further into the push (because the SST was never closed after step 5).
9. The earlier records' RocksDB keys are smaller than the keys already in the SST → `SstFileWriter.put()` throws `RocksDBException: Keys must be added in strict ascending order`.

The two fixes together eliminate the root cause (Bug 1) and add a defensive early-exit guard (Bug 2) to prevent the useless/harmful sync in the first place.

### Why the same issue doesn't occur with Global RT DIV off

With Global RT DIV off:

- `getLocalVtSubscribePosition()` uses `latestProcessedVtPosition` (not LCVP).
- `latestProcessedVtPosition` is checkpointed via `updateOffsetMetadataInOffsetRecord` inside `syncOffset`.
- The SST checkpoint and `latestProcessedVtPosition` are always written in the same `syncOffset` call, so they are always consistent on disk.
- `checkDatabaseIntegrity` uses the SST checkpoint to remove any uncommitted SST data, then re-subscription from the matching VT position writes new SST data cleanly in order.

With Global RT DIV on (pre-fix), LCVP and the SST checkpoint were written via separate code paths that could disagree: the SOP `SyncVtDivNode` wrote an empty SST checkpoint (correct — no user data yet) but stamped EARLIEST as LCVP (wrong — should reflect the SOP offset). This inconsistency is what allowed the consumer to re-subscribe from the beginning of the topic while the SST was in a mid-push state.

## Testing Done

- `PartitionTrackerTest` — existing tests pass; the LCVP-is-always-written invariant is exercised by tests that call `updateOffsetRecord` with an empty segment map.
- `LeaderFollowerStoreIngestionTaskTest` — all 56 tests pass after adding the early-exit guards.
- Manually traced the full failure chain against the production logs that triggered this investigation (`cert-chunking_v1366-5`).