### PR TITLE
[da-vinci][server] Global RT DIV: RT Subscribe Position Fallback

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,4 @@ Gemfile.lock
 docs/vendor/
 docs/_site/
 
+.worktrees/

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/PartitionConsumptionState.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/PartitionConsumptionState.java
@@ -1049,9 +1049,15 @@ public class PartitionConsumptionState {
     PubSubTopic leaderTopic = getOffsetRecord().getLeaderTopic(getPubSubContext().getPubSubTopicRepository());
     if (leaderTopic != null && !leaderTopic.isVersionTopic()) {
       // consumed corresponds to messages seen by consumer, processed corresponds to messages seen by drainer
-      return (useCheckpointedDivRtPosition)
-          ? getDivRtCheckpointPosition(pubSubBrokerAddress)
-          : getLatestProcessedRtPosition(pubSubBrokerAddress);
+      if (useCheckpointedDivRtPosition) {
+        PubSubPosition lcrp = getDivRtCheckpointPosition(pubSubBrokerAddress);
+        if (!PubSubSymbolicPosition.EARLIEST.equals(lcrp)) {
+          return lcrp;
+        }
+        // LCRP not yet established (e.g. first leader transition after Global RT DIV is enabled);
+        // fall back to the position that would have been used before Global RT DIV.
+      }
+      return getLatestProcessedRtPosition(pubSubBrokerAddress);
     } else {
       return consumeRemotely() ? getLatestProcessedRemoteVtPosition() : getLatestProcessedVtPosition();
     }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
@@ -5635,7 +5635,7 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
   }
 
   boolean isGlobalRtDivEnabled() {
-    return isGlobalRtDivEnabled;
+    return isGlobalRtDivEnabled && isHybridMode();
   }
 
   /** When Global RT DIV is enabled the ConsumptionTask's DIV is exclusively used to validate data integrity. */

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/PartitionConsumptionStateTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/PartitionConsumptionStateTest.java
@@ -1,6 +1,7 @@
 package com.linkedin.davinci.kafka.consumer;
 
 import static com.linkedin.venice.utils.TestUtils.DEFAULT_PUBSUB_CONTEXT_FOR_UNIT_TESTING;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.testng.Assert.assertEquals;
@@ -17,6 +18,8 @@ import com.linkedin.venice.pubsub.PubSubContext;
 import com.linkedin.venice.pubsub.PubSubTopicPartitionImpl;
 import com.linkedin.venice.pubsub.PubSubTopicRepository;
 import com.linkedin.venice.pubsub.api.PubSubPosition;
+import com.linkedin.venice.pubsub.api.PubSubSymbolicPosition;
+import com.linkedin.venice.pubsub.api.PubSubTopic;
 import com.linkedin.venice.pubsub.api.PubSubTopicPartition;
 import com.linkedin.venice.schema.rmd.RmdSchemaGenerator;
 import com.linkedin.venice.serialization.avro.AvroProtocolDefinition;
@@ -240,5 +243,48 @@ public class PartitionConsumptionStateTest {
     // Clear and verify
     pcs.clearDolState();
     assertNull(pcs.getDolState());
+  }
+
+  /**
+   * Tests the fallback behavior of {@link PartitionConsumptionState#getLeaderPosition} when
+   * Global RT DIV is in use (useCheckpointedDivRtPosition=true).
+   *
+   * When LCRP (divRtCheckpointPosition) is present, it should be returned directly.
+   * When LCRP is absent, the method must fall back to {@code getLatestProcessedRtPosition}
+   * rather than returning EARLIEST — preserving the subscribe position that would have
+   * been used before Global RT DIV was introduced.
+   */
+  @Test
+  public void testGetLeaderPositionLcrpFallback() {
+    String broker = "broker1";
+    PubSubTopic rtTopic = TOPIC_REPOSITORY.getTopic("store_rt");
+
+    OffsetRecord offsetRecord = mock(OffsetRecord.class);
+    doReturn(rtTopic).when(offsetRecord).getLeaderTopic(any(PubSubTopicRepository.class));
+    // getCheckpointedRtPosition is consulted by getLatestProcessedRtPosition when in-memory map is EARLIEST
+    doReturn(PubSubSymbolicPosition.EARLIEST).when(offsetRecord).getCheckpointedRtPosition(broker);
+
+    // hybrid=true is required so the RT position maps are allocated as mutable maps
+    PartitionConsumptionState pcs = new PartitionConsumptionState(TOPIC_PARTITION, offsetRecord, pubSubContext, true);
+
+    PubSubPosition lcrpPosition = mock(PubSubPosition.class);
+    PubSubPosition processedPosition = mock(PubSubPosition.class);
+
+    // Case 1: useCheckpointedDivRtPosition=false — always returns latestProcessedRtPosition
+    pcs.setLatestProcessedRtPosition(broker, processedPosition);
+    assertEquals(pcs.getLeaderPosition(broker, false), processedPosition);
+
+    // Case 2: useCheckpointedDivRtPosition=true with LCRP set — returns LCRP
+    pcs.setDivRtCheckpointPosition(broker, lcrpPosition);
+    assertEquals(pcs.getLeaderPosition(broker, true), lcrpPosition);
+
+    // Case 3: useCheckpointedDivRtPosition=true with LCRP absent — falls back to latestProcessedRtPosition,
+    // not EARLIEST. This covers the first leader transition after Global RT DIV is enabled, before any
+    // checkpoint has been persisted.
+    PartitionConsumptionState pcsNoDivCheckpoint =
+        new PartitionConsumptionState(TOPIC_PARTITION, offsetRecord, pubSubContext, true);
+    pcsNoDivCheckpoint.setLatestProcessedRtPosition(broker, processedPosition);
+    PubSubPosition result = pcsNoDivCheckpoint.getLeaderPosition(broker, true);
+    assertEquals(result, processedPosition, "Expected fallback to latestProcessedRtPosition, not EARLIEST");
   }
 }

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTaskTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTaskTest.java
@@ -6121,6 +6121,80 @@ public abstract class StoreIngestionTaskTest {
   }
 
   /**
+   * Verifies that {@link StoreIngestionTask#isGlobalRtDivEnabled()} returns false for batch-only
+   * (non-hybrid) stores, even when the version-level flag is set to true. Global RT DIV only makes
+   * sense for hybrid stores that consume from an RT topic.
+   */
+  @Test(dataProvider = "aaConfigProvider")
+  public void testIsGlobalRtDivEnabledRequiresHybridStore(AAConfig aaConfig) {
+    PartitionerConfig partitionerConfig = new PartitionerConfigImpl();
+    HybridStoreConfig hybridConfig = new HybridStoreConfigImpl(
+        100,
+        100,
+        HybridStoreConfigImpl.DEFAULT_HYBRID_TIME_LAG_THRESHOLD,
+        BufferReplayPolicy.REWIND_FROM_EOP);
+    Properties kafkaProps = new Properties();
+    kafkaProps.put(KAFKA_BOOTSTRAP_SERVERS, inMemoryLocalKafkaBroker.getPubSubBrokerAddress());
+
+    // Non-hybrid store: isGlobalRtDivEnabled() must return false even when version flag is on
+    MockStoreVersionConfigs batchConfigs =
+        setupStoreAndVersionMocks(PARTITION_COUNT, partitionerConfig, Optional.empty(), false, false, aaConfig);
+    batchConfigs.version.setGlobalRtDivEnabled(true);
+    StoreIngestionTaskFactory batchFactory = getIngestionTaskFactoryBuilder(
+        new RandomPollStrategy(),
+        Utils.setOf(PARTITION_FOO),
+        Optional.empty(),
+        new HashMap<>(),
+        true,
+        null,
+        null,
+        this.mockStorageService).build();
+    StoreIngestionTask batchTask = batchFactory.getNewIngestionTask(
+        this.mockStorageService,
+        batchConfigs.store,
+        batchConfigs.version,
+        kafkaProps,
+        isCurrentVersion,
+        batchConfigs.storeVersionConfig,
+        PARTITION_FOO,
+        Optional.empty(),
+        null,
+        null);
+    assertFalse(batchTask.isGlobalRtDivEnabled(), "Non-hybrid store must not enable Global RT DIV");
+
+    // Hybrid store: isGlobalRtDivEnabled() must return true when version flag is on
+    MockStoreVersionConfigs hybridConfigs = setupStoreAndVersionMocks(
+        PARTITION_COUNT,
+        partitionerConfig,
+        Optional.of(hybridConfig),
+        false,
+        false,
+        aaConfig);
+    hybridConfigs.version.setGlobalRtDivEnabled(true);
+    StoreIngestionTaskFactory hybridFactory = getIngestionTaskFactoryBuilder(
+        new RandomPollStrategy(),
+        Utils.setOf(PARTITION_FOO),
+        Optional.empty(),
+        new HashMap<>(),
+        true,
+        null,
+        null,
+        this.mockStorageService).build();
+    StoreIngestionTask hybridTask = hybridFactory.getNewIngestionTask(
+        this.mockStorageService,
+        hybridConfigs.store,
+        hybridConfigs.version,
+        kafkaProps,
+        isCurrentVersion,
+        hybridConfigs.storeVersionConfig,
+        PARTITION_FOO,
+        Optional.empty(),
+        null,
+        null);
+    assertTrue(hybridTask.isGlobalRtDivEnabled(), "Hybrid store with version flag on must enable Global RT DIV");
+  }
+
+  /**
    * Verifies that {@link StoreIngestionTask#produceToStoreBufferServiceOrKafka} populates
    * {@link StoreIngestionTask#consumedBytesSinceLastSync} only for the local VT (keyed by VT name)
    * and RT topics (keyed by broker URL). Remote VTs must be excluded from the map entirely.


### PR DESCRIPTION
## Problem Statement

Two related gaps in Global RT DIV:

1. **LCRP fallback**: When Global RT DIV is enabled and a leader transition occurs, \`getLeaderPosition()\` takes the LCRP path. If no LCRP has been persisted yet (e.g. first F→L transition after the feature is enabled on a store), it falls straight to \`EARLIEST\`, re-consuming the entire RT topic. The correct fallback is \`getLatestProcessedRtPosition()\` — the position the leader would have subscribed at before Global RT DIV existed.

2. **Hybrid guard**: \`isGlobalRtDivEnabled()\` returned \`true\` for batch-only stores if the version flag happened to be set. Global RT DIV only makes sense for hybrid stores (which consume from an RT topic); enabling it on a batch-only store could trigger unexpected behavior in gated code paths.

## Solution

**Commit 1** — \`PartitionConsumptionState.getLeaderPosition()\`: when \`useCheckpointedDivRtPosition=true\` but LCRP is absent, fall through to \`getLatestProcessedRtPosition()\` instead of returning \`EARLIEST\`:

\`\`\`java
if (useCheckpointedDivRtPosition) {
    PubSubPosition lcrp = getDivRtCheckpointPosition(pubSubBrokerAddress);
    if (!PubSubSymbolicPosition.EARLIEST.equals(lcrp)) {
        return lcrp;
    }
    // LCRP not yet established; fall back to the pre-Global-RT-DIV subscribe position
}
return getLatestProcessedRtPosition(pubSubBrokerAddress);
\`\`\`

**Commit 2** — \`StoreIngestionTask.isGlobalRtDivEnabled()\`: add \`&& isHybridMode()\` guard:

\`\`\`java
boolean isGlobalRtDivEnabled() {
    return isGlobalRtDivEnabled && isHybridMode();
}
\`\`\`

###  Code changes
- [ ] Added new code behind **a config**. If so list the config names and their default values in the PR description.
- [ ] Introduced new **log lines**.
  - [ ] Confirmed if logs need to be **rate limited** to avoid excessive logging.

###  **Concurrency-Specific Checks**
Both reviewer and PR author to verify
- [ ] Code has **no race conditions** or **thread safety issues**.
- [ ] Proper **synchronization mechanisms** (e.g., \`synchronized\`, \`RWLock\`) are used where needed.
- [ ] No **blocking calls** inside critical sections that could lead to deadlocks or performance degradation.
- [ ] Verified **thread-safe collections** are used (e.g., \`ConcurrentHashMap\`, \`CopyOnWriteArrayList\`).
- [ ] Validated proper exception handling in multi-threaded code to avoid silent thread termination.

## How was this PR tested?

- [x] New unit tests added:
  - \`PartitionConsumptionStateTest.testGetLeaderPositionLcrpFallback\`: covers LCRP present, LCRP absent (fallback to latestProcessedRtPosition), and flag-off cases
  - \`StoreIngestionTaskTest.testIsGlobalRtDivEnabledRequiresHybridStore\`: verifies non-hybrid stores return false even when version flag is set; hybrid stores return true
- [ ] New integration tests added.
- [ ] Modified or extended existing tests.
- [ ] Verified backward compatibility (if applicable).

## Does this PR introduce any user-facing or breaking changes?

- [x] No. You can skip the rest of this section.