### PR TITLE
Minor fix

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/config/VeniceServerConfig.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/config/VeniceServerConfig.java
@@ -221,6 +221,7 @@ import static com.linkedin.venice.ConfigKeys.SERVER_USE_CHECKPOINTED_PUBSUB_POSI
 import static com.linkedin.venice.ConfigKeys.SERVER_USE_HEARTBEAT_LAG_FOR_READY_TO_SERVE_CHECK_ENABLED;
 import static com.linkedin.venice.ConfigKeys.SERVER_USE_METRICS_BASED_POSITION_IN_LAG_COMPUTATION;
 import static com.linkedin.venice.ConfigKeys.SERVER_USE_UPSTREAM_PUBSUB_POSITIONS;
+import static com.linkedin.venice.ConfigKeys.SERVER_VERSION_SWAP_DISK_SIZE_DROP_ALERT_THRESHOLD;
 import static com.linkedin.venice.ConfigKeys.SERVER_ZSTD_DICT_COMPRESSION_LEVEL;
 import static com.linkedin.venice.ConfigKeys.SEVER_CALCULATE_QUOTA_USAGE_BASED_ON_PARTITIONS_ASSIGNMENT_ENABLED;
 import static com.linkedin.venice.ConfigKeys.SORTED_INPUT_DRAINER_SIZE;
@@ -424,6 +425,8 @@ public class VeniceServerConfig extends VeniceClusterConfig {
   private final long databaseSyncBytesIntervalForDeferredWriteMode;
 
   private final double diskFullThreshold;
+
+  private final double versionSwapDiskSizeDropAlertThreshold;
 
   private final int partitionGracefulDropDelaySeconds;
 
@@ -858,6 +861,8 @@ public class VeniceServerConfig extends VeniceClusterConfig {
     databaseSyncBytesIntervalForDeferredWriteMode =
         serverProperties.getSizeInBytes(SERVER_DATABASE_SYNC_BYTES_INTERNAL_FOR_DEFERRED_WRITE_MODE, 60 * 1024 * 1024);
     diskFullThreshold = serverProperties.getDouble(SERVER_DISK_FULL_THRESHOLD, 0.95);
+    versionSwapDiskSizeDropAlertThreshold =
+        serverProperties.getDouble(SERVER_VERSION_SWAP_DISK_SIZE_DROP_ALERT_THRESHOLD, 0.5);
     partitionGracefulDropDelaySeconds = serverProperties.getInt(SERVER_PARTITION_GRACEFUL_DROP_DELAY_IN_SECONDS, 30);
     stopConsumptionTimeoutInSeconds = serverProperties.getInt(SERVER_STOP_CONSUMPTION_TIMEOUT_IN_SECONDS, 180);
     leakedResourceCleanUpIntervalInMS =
@@ -1428,6 +1433,10 @@ public class VeniceServerConfig extends VeniceClusterConfig {
 
   public double getDiskFullThreshold() {
     return diskFullThreshold;
+  }
+
+  public double getVersionSwapDiskSizeDropAlertThreshold() {
+    return versionSwapDiskSizeDropAlertThreshold;
   }
 
   public int getPartitionGracefulDropDelaySeconds() {

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/PartitionConsumptionState.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/PartitionConsumptionState.java
@@ -829,6 +829,14 @@ public class PartitionConsumptionState {
   }
 
   /**
+   * Clears the previouslyReadyToServe flag from the offset record. This should be called after blob transfer
+   * completes to prevent the fast RTS check from triggering based on state inherited from a different host.
+   */
+  public void clearPreviouslyReadyToServeInOffsetRecord() {
+    offsetRecord.clearPreviousStatusesEntry(PREVIOUSLY_READY_TO_SERVE);
+  }
+
+  /**
    * This immutable class holds a association between a key and value and the source offset of the consumed message.
    * The value could be either as received in kafka ConsumerRecord or it could be a write computed value.
    */

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
@@ -2996,6 +2996,13 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
 
     PartitionConsumptionState newPcs = reinitializePartitionConsumptionStateFromStorage(topicPartition, partition);
 
+    // Clear the previouslyReadyToServe flag inherited from the blob transfer source host.
+    // This flag gates fast RTS (ready-to-serve) checks, which use (currentTime - checkpointTime)
+    // to decide if a replica can skip normal lag catch-up. After blob transfer, the checkpoint time
+    // is from a different host and does not reflect this replica's actual ingestion state, so
+    // fast RTS should not be triggered based on inherited state.
+    newPcs.clearPreviouslyReadyToServeInOffsetRecord();
+
     LOGGER.info(
         "Post-blob-transfer Kafka subscribe for replica: {} at position: {}",
         pcs.getReplicaId(),

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/AggVersionedStorageEngineStats.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/AggVersionedStorageEngineStats.java
@@ -1,11 +1,19 @@
 package com.linkedin.davinci.stats;
 
+import static com.linkedin.venice.meta.Store.NON_EXISTING_VERSION;
+
 import com.linkedin.davinci.store.StorageEngine;
 import com.linkedin.venice.meta.ReadOnlyStoreRepository;
+import com.linkedin.venice.meta.Store;
 import com.linkedin.venice.meta.Version;
+import com.linkedin.venice.stats.AbstractVeniceStats;
 import com.linkedin.venice.stats.StatsErrorCode;
+import com.linkedin.venice.utils.concurrent.VeniceConcurrentHashMap;
 import io.tehuti.metrics.MetricsRepository;
+import io.tehuti.metrics.Sensor;
 import io.tehuti.metrics.stats.AsyncGauge;
+import io.tehuti.metrics.stats.Gauge;
+import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -14,17 +22,35 @@ import org.apache.logging.log4j.Logger;
 public class AggVersionedStorageEngineStats extends
     AbstractVeniceAggVersionedStats<AggVersionedStorageEngineStats.StorageEngineStatsWrapper, AggVersionedStorageEngineStats.StorageEngineStatsReporter> {
   private static final Logger LOGGER = LogManager.getLogger(AggVersionedStorageEngineStats.class);
+  private static final double DEFAULT_DISK_SIZE_DROP_ALERT_THRESHOLD = 0.5;
+  private static final String DISK_SIZE_DROP_ALERT_METRIC = "version_swap_disk_size_drop_alert";
+
+  private final double diskSizeDropAlertThreshold;
+  private final Map<String, Sensor> diskSizeDropAlertSensors = new VeniceConcurrentHashMap<>();
 
   public AggVersionedStorageEngineStats(
       MetricsRepository metricsRepository,
       ReadOnlyStoreRepository metadataRepository,
       boolean unregisterMetricForDeletedStoreEnabled) {
+    this(
+        metricsRepository,
+        metadataRepository,
+        unregisterMetricForDeletedStoreEnabled,
+        DEFAULT_DISK_SIZE_DROP_ALERT_THRESHOLD);
+  }
+
+  public AggVersionedStorageEngineStats(
+      MetricsRepository metricsRepository,
+      ReadOnlyStoreRepository metadataRepository,
+      boolean unregisterMetricForDeletedStoreEnabled,
+      double diskSizeDropAlertThreshold) {
     super(
         metricsRepository,
         metadataRepository,
         StorageEngineStatsWrapper::new,
         StorageEngineStatsReporter::new,
         unregisterMetricForDeletedStoreEnabled);
+    this.diskSizeDropAlertThreshold = diskSizeDropAlertThreshold;
   }
 
   public void setStorageEngine(String topicName, StorageEngine storageEngine) {
@@ -53,6 +79,88 @@ public class AggVersionedStorageEngineStats extends
     } catch (Exception e) {
       LOGGER.warn("Failed to record open failure for store: {}, version: {}", storeName, version);
     }
+  }
+
+  /**
+   * Called when a store's version info changes (the version swap method).
+   * After the parent updates version info, actively compares the current version's disk size
+   * with the future version's disk size. Records 1 in the alert metric if the future version
+   * is significantly smaller, or 0 otherwise.
+   */
+  @Override
+  public void handleStoreChanged(Store store) {
+    super.handleStoreChanged(store);
+    checkAndRecordDiskSizeAlert(store.getName());
+  }
+
+  @Override
+  public void handleStoreDeleted(String storeName) {
+    try {
+      super.handleStoreDeleted(storeName);
+    } finally {
+      diskSizeDropAlertSensors.remove(storeName);
+    }
+  }
+
+  /**
+   * Compares current vs future version disk sizes and actively records the alert metric.
+   * Called at the moment of version swap, not lazily.
+   */
+  void checkAndRecordDiskSizeAlert(String storeName) {
+    int currentVersion = getCurrentVersion(storeName);
+    int futureVersion = getFutureVersion(storeName);
+
+    Sensor sensor = getOrCreateDiskSizeDropAlertSensor(storeName);
+
+    if (currentVersion == NON_EXISTING_VERSION || futureVersion == NON_EXISTING_VERSION) {
+      sensor.record(0);
+      return;
+    }
+
+    try {
+      StorageEngineStatsWrapper currentStats = getStats(storeName, currentVersion);
+      StorageEngineStatsWrapper futureStats = getStats(storeName, futureVersion);
+      long currentSize = currentStats.getDiskUsageInBytes();
+      long futureSize = futureStats.getDiskUsageInBytes();
+
+      // Only alert if both versions have meaningful data (future version done ingesting)
+      if (currentSize <= 0 || futureSize <= 0) {
+        sensor.record(0);
+        return;
+      }
+
+      if (futureSize < currentSize * diskSizeDropAlertThreshold) {
+        LOGGER.warn(
+            "Disk size drop detected for store {}: current version {} size = {} bytes, "
+                + "future version {} size = {} bytes, threshold = {}",
+            storeName,
+            currentVersion,
+            currentSize,
+            futureVersion,
+            futureSize,
+            diskSizeDropAlertThreshold);
+        sensor.record(1);
+      } else {
+        sensor.record(0);
+      }
+    } catch (Exception e) {
+      LOGGER.debug("Unable to compute disk size drop alert for store: {}", storeName, e);
+      sensor.record(0);
+    }
+  }
+
+  private Sensor getOrCreateDiskSizeDropAlertSensor(String storeName) {
+    return diskSizeDropAlertSensors.computeIfAbsent(storeName, s -> {
+      String sensorFullName = AbstractVeniceStats.getSensorFullName(s, DISK_SIZE_DROP_ALERT_METRIC);
+      Sensor sensor = getMetricsRepository().sensor(sensorFullName);
+      sensor.add(sensorFullName + ".Gauge", new Gauge());
+      return sensor;
+    });
+  }
+
+  // Visible for testing
+  double getDiskSizeDropAlertThreshold() {
+    return diskSizeDropAlertThreshold;
   }
 
   static class StorageEngineStatsWrapper {

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/AggVersionedStorageEngineStats.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/AggVersionedStorageEngineStats.java
@@ -6,6 +6,7 @@ import com.linkedin.davinci.store.StorageEngine;
 import com.linkedin.venice.meta.ReadOnlyStoreRepository;
 import com.linkedin.venice.meta.Store;
 import com.linkedin.venice.meta.Version;
+import com.linkedin.venice.meta.VersionStatus;
 import com.linkedin.venice.stats.AbstractVeniceStats;
 import com.linkedin.venice.stats.StatsErrorCode;
 import com.linkedin.venice.utils.concurrent.VeniceConcurrentHashMap;
@@ -82,15 +83,16 @@ public class AggVersionedStorageEngineStats extends
   }
 
   /**
-   * Called when a store's version info changes (the version swap method).
-   * After the parent updates version info, actively compares the current version's disk size
-   * with the future version's disk size. Records 1 in the alert metric if the future version
-   * is significantly smaller, or 0 otherwise.
+   * Called when a store's version info changes.
+   * After the parent updates version info, compares the current version's disk size
+   * with the future version's disk size when the future version has completed ingestion
+   * (PUSHED status). Records 1 in the alert metric if the future version is significantly
+   * smaller, or 0 otherwise.
    */
   @Override
   public void handleStoreChanged(Store store) {
     super.handleStoreChanged(store);
-    checkAndRecordDiskSizeAlert(store.getName());
+    checkAndRecordDiskSizeAlert(store);
   }
 
   @Override
@@ -98,15 +100,20 @@ public class AggVersionedStorageEngineStats extends
     try {
       super.handleStoreDeleted(storeName);
     } finally {
-      diskSizeDropAlertSensors.remove(storeName);
+      Sensor removed = diskSizeDropAlertSensors.remove(storeName);
+      if (removed != null) {
+        getMetricsRepository().removeSensor(removed.name());
+      }
     }
   }
 
   /**
    * Compares current vs future version disk sizes and actively records the alert metric.
-   * Called at the moment of version swap, not lazily.
+   * Only performs the comparison when the future version has status PUSHED (ingestion complete),
+   * to avoid false positives from partial data during STARTED status.
    */
-  void checkAndRecordDiskSizeAlert(String storeName) {
+  void checkAndRecordDiskSizeAlert(Store store) {
+    String storeName = store.getName();
     int currentVersion = getCurrentVersion(storeName);
     int futureVersion = getFutureVersion(storeName);
 
@@ -117,13 +124,21 @@ public class AggVersionedStorageEngineStats extends
       return;
     }
 
+    // Only check when the future version has completed ingestion (PUSHED status).
+    // During STARTED, disk data is partial and would cause false positive alerts.
+    Version futureVersionObj = store.getVersion(futureVersion);
+    if (futureVersionObj == null || futureVersionObj.getStatus() != VersionStatus.PUSHED) {
+      sensor.record(0);
+      return;
+    }
+
     try {
       StorageEngineStatsWrapper currentStats = getStats(storeName, currentVersion);
       StorageEngineStatsWrapper futureStats = getStats(storeName, futureVersion);
       long currentSize = currentStats.getDiskUsageInBytes();
       long futureSize = futureStats.getDiskUsageInBytes();
 
-      // Only alert if both versions have meaningful data (future version done ingesting)
+      // Only alert if both versions have meaningful data
       if (currentSize <= 0 || futureSize <= 0) {
         sensor.record(0);
         return;
@@ -144,7 +159,7 @@ public class AggVersionedStorageEngineStats extends
         sensor.record(0);
       }
     } catch (Exception e) {
-      LOGGER.debug("Unable to compute disk size drop alert for store: {}", storeName, e);
+      LOGGER.warn("Unable to compute disk size drop alert for store: {}", storeName, e);
       sensor.record(0);
     }
   }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/AggVersionedStorageEngineStats.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/AggVersionedStorageEngineStats.java
@@ -138,12 +138,14 @@ public class AggVersionedStorageEngineStats extends
       long currentSize = currentStats.getDiskUsageInBytes();
       long futureSize = futureStats.getDiskUsageInBytes();
 
-      // Only alert if both versions have meaningful data
-      if (currentSize <= 0 || futureSize <= 0) {
+      // Skip if current version has no data (e.g., first version of a store)
+      if (currentSize <= 0) {
         sensor.record(0);
         return;
       }
 
+      // Since we already guard on PUSHED status (ingestion complete), futureSize == 0
+      // is a real data loss signal, not an incomplete ingestion artifact.
       if (futureSize < currentSize * diskSizeDropAlertThreshold) {
         LOGGER.warn(
             "Disk size drop detected for store {}: current version {} size = {} bytes, "

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/stats/AggVersionedStorageEngineStatsTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/stats/AggVersionedStorageEngineStatsTest.java
@@ -15,6 +15,7 @@ import com.linkedin.venice.meta.VersionStatus;
 import io.tehuti.Metric;
 import io.tehuti.metrics.MetricsRepository;
 import java.util.Arrays;
+import java.util.Collections;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
@@ -91,13 +92,15 @@ public class AggVersionedStorageEngineStatsTest {
     Store mockStore = mock(Store.class);
     doReturn(storeName).when(mockStore).getName();
     doReturn(1).when(mockStore).getCurrentVersion();
+    // Explicitly return empty versions list — no future version exists
+    doReturn(Collections.emptyList()).when(mockStore).getVersions();
     doReturn(mockStore).when(metadataRepository).getStoreOrThrow(anyString());
 
     AggVersionedStorageEngineStats stats =
         new AggVersionedStorageEngineStats(metricsRepository, metadataRepository, false, 0.5);
     stats.addStore(mockStore);
 
-    // Simulate version swap with no future version
+    // Simulate store change with no future version
     stats.handleStoreChanged(mockStore);
 
     Metric alertMetric = metricsRepository.getMetric(".testStore--version_swap_disk_size_drop_alert.Gauge");
@@ -127,7 +130,129 @@ public class AggVersionedStorageEngineStatsTest {
     Assert.assertEquals(alertMetric.value(), 0.0, "Alert should record 0 when future version size is 0");
   }
 
+  @Test
+  public void testDiskSizeDropAlertSkipsStartedVersion() {
+    String storeName = "testStore";
+    MetricsRepository metricsRepository = new MetricsRepository();
+    ReadOnlyStoreRepository metadataRepository = mock(ReadOnlyStoreRepository.class);
+    // Future version is STARTED (still ingesting), not PUSHED
+    Store mockStore = createMockStoreWithVersions(storeName, 1, 2, VersionStatus.STARTED);
+    doReturn(mockStore).when(metadataRepository).getStoreOrThrow(anyString());
+
+    AggVersionedStorageEngineStats stats =
+        new AggVersionedStorageEngineStats(metricsRepository, metadataRepository, false, 0.5);
+    stats.addStore(mockStore);
+
+    // Even though sizes show a huge drop, the STARTED guard should prevent the alert
+    setStorageEngineSize(stats, storeName, 1, 40L * 1024 * 1024 * 1024);
+    setStorageEngineSize(stats, storeName, 2, 1L * 1024 * 1024);
+
+    stats.handleStoreChanged(mockStore);
+
+    Metric alertMetric = metricsRepository.getMetric(".testStore--version_swap_disk_size_drop_alert.Gauge");
+    Assert.assertNotNull(alertMetric);
+    Assert.assertEquals(alertMetric.value(), 0.0, "Alert should not fire when future version is still STARTED");
+  }
+
+  @Test
+  public void testDiskSizeDropAlertSensorCleanedUpOnStoreDelete() {
+    String storeName = "testStore";
+    MetricsRepository metricsRepository = new MetricsRepository();
+    ReadOnlyStoreRepository metadataRepository = mock(ReadOnlyStoreRepository.class);
+    Store mockStore = createMockStoreWithVersions(storeName, 1, 2);
+    doReturn(mockStore).when(metadataRepository).getStoreOrThrow(anyString());
+
+    AggVersionedStorageEngineStats stats =
+        new AggVersionedStorageEngineStats(metricsRepository, metadataRepository, true, 0.5);
+    stats.addStore(mockStore);
+
+    setStorageEngineSize(stats, storeName, 1, 40L * 1024 * 1024 * 1024);
+    setStorageEngineSize(stats, storeName, 2, 1L * 1024 * 1024);
+
+    // Trigger alert to create the sensor
+    stats.handleStoreChanged(mockStore);
+    Metric alertMetric = metricsRepository.getMetric(".testStore--version_swap_disk_size_drop_alert.Gauge");
+    Assert.assertNotNull(alertMetric, "Sensor should exist before deletion");
+
+    // Delete the store
+    stats.handleStoreDeleted(storeName);
+
+    // Verify the sensor is removed from MetricsRepository
+    Metric removedMetric = metricsRepository.getMetric(".testStore--version_swap_disk_size_drop_alert.Gauge");
+    Assert.assertNull(removedMetric, "Sensor should be removed from MetricsRepository after store deletion");
+  }
+
+  @Test
+  public void testDiskSizeDropAlertRecordsZeroOnException() {
+    String storeName = "testStore";
+    MetricsRepository metricsRepository = new MetricsRepository();
+    ReadOnlyStoreRepository metadataRepository = mock(ReadOnlyStoreRepository.class);
+    Store mockStore = createMockStoreWithVersions(storeName, 1, 2);
+    doReturn(mockStore).when(metadataRepository).getStoreOrThrow(anyString());
+
+    AggVersionedStorageEngineStats stats =
+        new AggVersionedStorageEngineStats(metricsRepository, metadataRepository, false, 0.5);
+    stats.addStore(mockStore);
+
+    // Set current version with a storage engine that throws on getStats()
+    StorageEngine throwingEngine = mock(StorageEngine.class);
+    StorageEngineStats throwingStats = mock(StorageEngineStats.class);
+    when(throwingEngine.getStats()).thenReturn(throwingStats);
+    when(throwingStats.getStoreSizeInBytes()).thenThrow(new RuntimeException("RocksDB error"));
+    stats.getStats(storeName, 1).setStorageEngine(throwingEngine);
+
+    setStorageEngineSize(stats, storeName, 2, 1L * 1024 * 1024);
+
+    stats.handleStoreChanged(mockStore);
+
+    Metric alertMetric = metricsRepository.getMetric(".testStore--version_swap_disk_size_drop_alert.Gauge");
+    Assert.assertNotNull(alertMetric);
+    Assert.assertEquals(alertMetric.value(), 0.0, "Alert should record 0 when exception occurs");
+  }
+
+  @Test
+  public void testDiskSizeDropAlertFiresThenResetsOnNextVersionSwap() {
+    String storeName = "testStore";
+    MetricsRepository metricsRepository = new MetricsRepository();
+    ReadOnlyStoreRepository metadataRepository = mock(ReadOnlyStoreRepository.class);
+
+    // First: version 2 is PUSHED with a huge drop — alert should fire
+    Store mockStore1 = createMockStoreWithVersions(storeName, 1, 2);
+    doReturn(mockStore1).when(metadataRepository).getStoreOrThrow(anyString());
+
+    AggVersionedStorageEngineStats stats =
+        new AggVersionedStorageEngineStats(metricsRepository, metadataRepository, false, 0.5);
+    stats.addStore(mockStore1);
+
+    setStorageEngineSize(stats, storeName, 1, 40L * 1024 * 1024 * 1024);
+    setStorageEngineSize(stats, storeName, 2, 1L * 1024 * 1024);
+
+    stats.handleStoreChanged(mockStore1);
+    Metric alertMetric = metricsRepository.getMetric(".testStore--version_swap_disk_size_drop_alert.Gauge");
+    Assert.assertEquals(alertMetric.value(), 1.0, "Alert should fire on bad version swap");
+
+    // Second: version swap completes — version 2 is now current, no future version
+    Store mockStore2 = mock(Store.class);
+    doReturn(storeName).when(mockStore2).getName();
+    doReturn(2).when(mockStore2).getCurrentVersion();
+    Version onlineVersion = new VersionImpl(storeName, 2, "push-job-2");
+    onlineVersion.setStatus(VersionStatus.ONLINE);
+    doReturn(Collections.singletonList(onlineVersion)).when(mockStore2).getVersions();
+    doReturn(mockStore2).when(metadataRepository).getStoreOrThrow(anyString());
+
+    stats.handleStoreChanged(mockStore2);
+    Assert.assertEquals(alertMetric.value(), 0.0, "Alert should reset to 0 after version swap completes");
+  }
+
   private Store createMockStoreWithVersions(String storeName, int currentVersionNum, int futureVersionNum) {
+    return createMockStoreWithVersions(storeName, currentVersionNum, futureVersionNum, VersionStatus.PUSHED);
+  }
+
+  private Store createMockStoreWithVersions(
+      String storeName,
+      int currentVersionNum,
+      int futureVersionNum,
+      VersionStatus futureStatus) {
     Store mockStore = mock(Store.class);
     doReturn(storeName).when(mockStore).getName();
     doReturn(currentVersionNum).when(mockStore).getCurrentVersion();
@@ -136,9 +261,11 @@ public class AggVersionedStorageEngineStatsTest {
     currentVersion.setStatus(VersionStatus.ONLINE);
 
     Version futureVersion = new VersionImpl(storeName, futureVersionNum, "push-job-2");
-    futureVersion.setStatus(VersionStatus.PUSHED);
+    futureVersion.setStatus(futureStatus);
 
     doReturn(Arrays.asList(currentVersion, futureVersion)).when(mockStore).getVersions();
+    doReturn(currentVersion).when(mockStore).getVersion(currentVersionNum);
+    doReturn(futureVersion).when(mockStore).getVersion(futureVersionNum);
     return mockStore;
   }
 

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/stats/AggVersionedStorageEngineStatsTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/stats/AggVersionedStorageEngineStatsTest.java
@@ -3,11 +3,18 @@ package com.linkedin.davinci.stats;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
+import com.linkedin.davinci.store.StorageEngine;
+import com.linkedin.davinci.store.StorageEngineStats;
 import com.linkedin.venice.meta.ReadOnlyStoreRepository;
 import com.linkedin.venice.meta.Store;
+import com.linkedin.venice.meta.Version;
+import com.linkedin.venice.meta.VersionImpl;
+import com.linkedin.venice.meta.VersionStatus;
 import io.tehuti.Metric;
 import io.tehuti.metrics.MetricsRepository;
+import java.util.Arrays;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
@@ -27,5 +34,123 @@ public class AggVersionedStorageEngineStatsTest {
     stats.getStats(storeName, 1).getKeyCountEstimate();
     Metric metric = metricsRepository.getMetric(".testStore_total--rocksdb_key_count_estimate.Gauge");
     Assert.assertEquals(metric.value(), 0.0);
+  }
+
+  @Test
+  public void testDiskSizeDropAlertFiresOnVersionSwap() {
+    String storeName = "testStore";
+    MetricsRepository metricsRepository = new MetricsRepository();
+    ReadOnlyStoreRepository metadataRepository = mock(ReadOnlyStoreRepository.class);
+    Store mockStore = createMockStoreWithVersions(storeName, 1, 2);
+    doReturn(mockStore).when(metadataRepository).getStoreOrThrow(anyString());
+
+    AggVersionedStorageEngineStats stats =
+        new AggVersionedStorageEngineStats(metricsRepository, metadataRepository, false, 0.5);
+    stats.addStore(mockStore);
+
+    // Set up storage engines: current version = 40GB, future version = 1MB (huge drop)
+    setStorageEngineSize(stats, storeName, 1, 40L * 1024 * 1024 * 1024);
+    setStorageEngineSize(stats, storeName, 2, 1L * 1024 * 1024);
+
+    // Simulate version swap event - this is where the check happens
+    stats.handleStoreChanged(mockStore);
+
+    Metric alertMetric = metricsRepository.getMetric(".testStore--version_swap_disk_size_drop_alert.Gauge");
+    Assert.assertNotNull(alertMetric, "Alert gauge should be registered");
+    Assert.assertEquals(alertMetric.value(), 1.0, "Alert should record 1 when future version is much smaller");
+  }
+
+  @Test
+  public void testDiskSizeDropAlertResetsWhenSizesSimilar() {
+    String storeName = "testStore";
+    MetricsRepository metricsRepository = new MetricsRepository();
+    ReadOnlyStoreRepository metadataRepository = mock(ReadOnlyStoreRepository.class);
+    Store mockStore = createMockStoreWithVersions(storeName, 1, 2);
+    doReturn(mockStore).when(metadataRepository).getStoreOrThrow(anyString());
+
+    AggVersionedStorageEngineStats stats =
+        new AggVersionedStorageEngineStats(metricsRepository, metadataRepository, false, 0.5);
+    stats.addStore(mockStore);
+
+    // Set up storage engines: current version = 40GB, future version = 38GB (similar)
+    setStorageEngineSize(stats, storeName, 1, 40L * 1024 * 1024 * 1024);
+    setStorageEngineSize(stats, storeName, 2, 38L * 1024 * 1024 * 1024);
+
+    stats.handleStoreChanged(mockStore);
+
+    Metric alertMetric = metricsRepository.getMetric(".testStore--version_swap_disk_size_drop_alert.Gauge");
+    Assert.assertNotNull(alertMetric);
+    Assert.assertEquals(alertMetric.value(), 0.0, "Alert should record 0 when sizes are similar");
+  }
+
+  @Test
+  public void testDiskSizeDropAlertRecordsZeroWithNoFutureVersion() {
+    String storeName = "testStore";
+    MetricsRepository metricsRepository = new MetricsRepository();
+    ReadOnlyStoreRepository metadataRepository = mock(ReadOnlyStoreRepository.class);
+    Store mockStore = mock(Store.class);
+    doReturn(storeName).when(mockStore).getName();
+    doReturn(1).when(mockStore).getCurrentVersion();
+    doReturn(mockStore).when(metadataRepository).getStoreOrThrow(anyString());
+
+    AggVersionedStorageEngineStats stats =
+        new AggVersionedStorageEngineStats(metricsRepository, metadataRepository, false, 0.5);
+    stats.addStore(mockStore);
+
+    // Simulate version swap with no future version
+    stats.handleStoreChanged(mockStore);
+
+    Metric alertMetric = metricsRepository.getMetric(".testStore--version_swap_disk_size_drop_alert.Gauge");
+    Assert.assertNotNull(alertMetric);
+    Assert.assertEquals(alertMetric.value(), 0.0, "Alert should record 0 without future version");
+  }
+
+  @Test
+  public void testDiskSizeDropAlertRecordsZeroWhenFutureSizeIsZero() {
+    String storeName = "testStore";
+    MetricsRepository metricsRepository = new MetricsRepository();
+    ReadOnlyStoreRepository metadataRepository = mock(ReadOnlyStoreRepository.class);
+    Store mockStore = createMockStoreWithVersions(storeName, 1, 2);
+    doReturn(mockStore).when(metadataRepository).getStoreOrThrow(anyString());
+
+    AggVersionedStorageEngineStats stats =
+        new AggVersionedStorageEngineStats(metricsRepository, metadataRepository, false, 0.5);
+    stats.addStore(mockStore);
+
+    // Current version has data, future version has 0 (still ingesting)
+    setStorageEngineSize(stats, storeName, 1, 40L * 1024 * 1024 * 1024);
+
+    stats.handleStoreChanged(mockStore);
+
+    Metric alertMetric = metricsRepository.getMetric(".testStore--version_swap_disk_size_drop_alert.Gauge");
+    Assert.assertNotNull(alertMetric);
+    Assert.assertEquals(alertMetric.value(), 0.0, "Alert should record 0 when future version size is 0");
+  }
+
+  private Store createMockStoreWithVersions(String storeName, int currentVersionNum, int futureVersionNum) {
+    Store mockStore = mock(Store.class);
+    doReturn(storeName).when(mockStore).getName();
+    doReturn(currentVersionNum).when(mockStore).getCurrentVersion();
+
+    Version currentVersion = new VersionImpl(storeName, currentVersionNum, "push-job-1");
+    currentVersion.setStatus(VersionStatus.ONLINE);
+
+    Version futureVersion = new VersionImpl(storeName, futureVersionNum, "push-job-2");
+    futureVersion.setStatus(VersionStatus.PUSHED);
+
+    doReturn(Arrays.asList(currentVersion, futureVersion)).when(mockStore).getVersions();
+    return mockStore;
+  }
+
+  private void setStorageEngineSize(
+      AggVersionedStorageEngineStats stats,
+      String storeName,
+      int version,
+      long sizeInBytes) {
+    StorageEngine mockEngine = mock(StorageEngine.class);
+    StorageEngineStats mockEngineStats = mock(StorageEngineStats.class);
+    when(mockEngine.getStats()).thenReturn(mockEngineStats);
+    when(mockEngineStats.getStoreSizeInBytes()).thenReturn(sizeInBytes);
+    stats.getStats(storeName, version).setStorageEngine(mockEngine);
   }
 }

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/stats/AggVersionedStorageEngineStatsTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/stats/AggVersionedStorageEngineStatsTest.java
@@ -109,7 +109,7 @@ public class AggVersionedStorageEngineStatsTest {
   }
 
   @Test
-  public void testDiskSizeDropAlertRecordsZeroWhenFutureSizeIsZero() {
+  public void testDiskSizeDropAlertFiresWhenFutureSizeIsZero() {
     String storeName = "testStore";
     MetricsRepository metricsRepository = new MetricsRepository();
     ReadOnlyStoreRepository metadataRepository = mock(ReadOnlyStoreRepository.class);
@@ -120,14 +120,38 @@ public class AggVersionedStorageEngineStatsTest {
         new AggVersionedStorageEngineStats(metricsRepository, metadataRepository, false, 0.5);
     stats.addStore(mockStore);
 
-    // Current version has data, future version has 0 (still ingesting)
+    // Current version has data, future version has 0 bytes — total data loss.
+    // Since future version is PUSHED (ingestion complete), this is a real alert.
     setStorageEngineSize(stats, storeName, 1, 40L * 1024 * 1024 * 1024);
 
     stats.handleStoreChanged(mockStore);
 
     Metric alertMetric = metricsRepository.getMetric(".testStore--version_swap_disk_size_drop_alert.Gauge");
     Assert.assertNotNull(alertMetric);
-    Assert.assertEquals(alertMetric.value(), 0.0, "Alert should record 0 when future version size is 0");
+    Assert
+        .assertEquals(alertMetric.value(), 1.0, "Alert should fire when PUSHED future version has 0 bytes (data loss)");
+  }
+
+  @Test
+  public void testDiskSizeDropAlertRecordsZeroWhenCurrentSizeIsZero() {
+    String storeName = "testStore";
+    MetricsRepository metricsRepository = new MetricsRepository();
+    ReadOnlyStoreRepository metadataRepository = mock(ReadOnlyStoreRepository.class);
+    Store mockStore = createMockStoreWithVersions(storeName, 1, 2);
+    doReturn(mockStore).when(metadataRepository).getStoreOrThrow(anyString());
+
+    AggVersionedStorageEngineStats stats =
+        new AggVersionedStorageEngineStats(metricsRepository, metadataRepository, false, 0.5);
+    stats.addStore(mockStore);
+
+    // Current version has no data (e.g., first version of a store), future has data
+    setStorageEngineSize(stats, storeName, 2, 40L * 1024 * 1024 * 1024);
+
+    stats.handleStoreChanged(mockStore);
+
+    Metric alertMetric = metricsRepository.getMetric(".testStore--version_swap_disk_size_drop_alert.Gauge");
+    Assert.assertNotNull(alertMetric);
+    Assert.assertEquals(alertMetric.value(), 0.0, "Alert should record 0 when current version has no data");
   }
 
   @Test

--- a/internal/venice-common/src/main/java/com/linkedin/venice/ConfigKeys.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/ConfigKeys.java
@@ -1757,6 +1757,16 @@ public class ConfigKeys {
   public static final String SERVER_DISK_FULL_THRESHOLD = "disk.full.threshold";
 
   /**
+   * The minimum ratio of future version disk size to current version disk size.
+   * If the future version's disk usage drops below this ratio of the current version's disk usage,
+   * an alert metric will be emitted. For example, a value of 0.5 means an alert fires when the
+   * future version is less than 50% of the current version's size.
+   * Default value is 0.5 (50%).
+   */
+  public static final String SERVER_VERSION_SWAP_DISK_SIZE_DROP_ALERT_THRESHOLD =
+      "server.version.swap.disk.size.drop.alert.threshold";
+
+  /**
    * If a request is slower than this, it will be reported as tardy in the router metrics
    */
   public static final String ROUTER_SINGLEGET_TARDY_LATENCY_MS = "router.singleget.tardy.latency.ms";

--- a/internal/venice-common/src/main/java/com/linkedin/venice/offsets/OffsetRecord.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/offsets/OffsetRecord.java
@@ -126,6 +126,10 @@ public class OffsetRecord {
     return partitionState.getPreviousStatuses().getOrDefault(key, NULL_STRING).toString();
   }
 
+  public void clearPreviousStatusesEntry(CharSequence key) {
+    partitionState.getPreviousStatuses().remove(key);
+  }
+
   public PubSubPosition getCheckpointedLocalVtPosition() {
     return deserializePositionWithOffsetFallback(
         this.partitionState.lastProcessedVersionTopicPubSubPosition,

--- a/services/venice-server/src/main/java/com/linkedin/venice/server/VeniceServer.java
+++ b/services/venice-server/src/main/java/com/linkedin/venice/server/VeniceServer.java
@@ -325,7 +325,8 @@ public class VeniceServer {
     AggVersionedStorageEngineStats storageEngineStats = new AggVersionedStorageEngineStats(
         metricsRepository,
         metadataRepo,
-        serverConfig.isUnregisterMetricForDeletedStoreEnabled());
+        serverConfig.isUnregisterMetricForDeletedStoreEnabled(),
+        serverConfig.getVersionSwapDiskSizeDropAlertThreshold());
     boolean plainTableEnabled =
         veniceConfigLoader.getVeniceServerConfig().getRocksDBServerConfig().isRocksDBPlainTableFormatEnabled();
     RocksDBMemoryStats rocksDBMemoryStats = veniceConfigLoader.getVeniceServerConfig().isDatabaseMemoryStatsEnabled()


### PR DESCRIPTION
## Problem Statement
After blob transfer, the previouslyReadyToServe flag in OffsetRecord is inherited from the source host. This flag gates the fast RTS (ready-to-serve) check, which allows a replica to skip normal lag catch-up and come online immediately if the time since last checkpoint is within a threshold (default 10 minutes).                                                                                            
                                                                                                                                                                                                                
The fast RTS calculation in checkFastReadyToServeWithPreviousTimeLag simplifies to:                                                                                                                           
                                                                                                                                                                                                                
timeLagIncrease = (currentTime - hbTimestamp) - (checkpointTime - hbTimestamp)                                                                                                                              = currentTime - checkpointTime                                                                                                                                                                
   
The heartbeat lag cancels out, so the decision depends only on how recently the checkpoint was updated — not on actual ingestion lag.                                                                         
                                                            
When multiple hosts bootstrap via blob transfer in sequence (e.g., host A → host B → host C), the flag propagates through the chain. If host B catches up and updates its checkpoint time shortly before host C bootstraps from it, host C will see previouslyReadyToServe=true with a recent checkpoint, causing fast RTS to trigger incorrectly — even though host C has not caught up on its own.
                                                                                                                                                                                                                
Observed impact: Partition 281 was declared ready-to-serve with ~700k record delay because fast RTS bypassed normal lag verification. The actual records to process were only ~12k, but the replica started serving before ingestion completed.



## Solution
Clear the previouslyReadyToServe flag from the OffsetRecord in completePostTransferPSCUpdated after blob transfer completes. This ensures fast RTS is only used for same-host restarts (its intended use case) and not triggered by state inherited from a different host via blob transfer.



###  Code changes
- [ ] Added new code behind **a config**. If so list the config names and their default values in the PR description.
- [ ] Introduced new **log lines**. 
  - [ ] Confirmed if logs need to be **rate limited** to avoid excessive logging.

###  **Concurrency-Specific Checks**
Both reviewer and PR author to verify
- [ ] Code has **no race conditions** or **thread safety issues**.
- [ ] Proper **synchronization mechanisms** (e.g., `synchronized`, `RWLock`) are used where needed.
- [ ] No **blocking calls** inside critical sections that could lead to deadlocks or performance degradation.
- [ ] Verified **thread-safe collections** are used (e.g., `ConcurrentHashMap`, `CopyOnWriteArrayList`).
- [ ] Validated proper exception handling in multi-threaded code to avoid silent thread termination.


## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->

- [ ] New unit tests added.
- [ ] New integration tests added.
- [ ] Modified or extended existing tests.
- [ ] Verified backward compatibility (if applicable).

## Does this PR introduce any user-facing or breaking changes?
<!--  
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [ ] No. You can skip the rest of this section.
- [ ] Yes. Clearly explain the behavior change and its impact.