### PR TITLE
[server][dvc] Disable fast RTS after blob transfer by clearing inherited previouslyReadyToServe flag

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/PartitionConsumptionState.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/PartitionConsumptionState.java
@@ -819,6 +819,14 @@ public class PartitionConsumptionState {
   }
 
   /**
+   * Clears the previouslyReadyToServe flag from the offset record. This should be called after blob transfer
+   * completes to prevent the fast RTS check from triggering based on state inherited from a different host.
+   */
+  public void clearPreviouslyReadyToServeInOffsetRecord() {
+    offsetRecord.clearPreviousStatusesEntry(PREVIOUSLY_READY_TO_SERVE);
+  }
+
+  /**
    * This immutable class holds a association between a key and value and the source offset of the consumed message.
    * The value could be either as received in kafka ConsumerRecord or it could be a write computed value.
    */

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
@@ -2965,6 +2965,12 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
   protected void completePostTransferPSCUpdated(PartitionConsumptionState pcs) {
     PartitionConsumptionState newPcs = reinitializePartitionConsumptionStateFromStorage(pcs.getReplicaTopicPartition());
 
+    // Clear the previouslyReadyToServe flag inherited from the blob transfer source host.
+    // This flag gates fast RTS checks, which use (currentTime - checkpointTime) to decide
+    // if a replica can skip normal lag catch-up. After blob transfer, the checkpoint time
+    // is from a different host and does not reflect this replica's actual ingestion state.
+    newPcs.clearPreviouslyReadyToServeInOffsetRecord();
+
     LOGGER.info(
         "Post-blob-transfer PCS reinitialized for replica: {} at position: {}. PCS: {}",
         pcs.getReplicaId(),

--- a/internal/venice-common/src/main/java/com/linkedin/venice/offsets/OffsetRecord.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/offsets/OffsetRecord.java
@@ -125,6 +125,10 @@ public class OffsetRecord {
     return partitionState.getPreviousStatuses().getOrDefault(key, NULL_STRING).toString();
   }
 
+  public void clearPreviousStatusesEntry(CharSequence key) {
+    partitionState.getPreviousStatuses().remove(key);
+  }
+
   public PubSubPosition getCheckpointedLocalVtPosition() {
     return deserializePositionWithOffsetFallback(
         this.partitionState.lastProcessedVersionTopicPubSubPosition,


### PR DESCRIPTION
## Problem Statement

After blob transfer, the previouslyReadyToServe flag in OffsetRecord is inherited from the source host. This flag gates the fast RTS (ready-to-serve) check, which allows a replica to skip normal lag catch-up and come online immediately if the time since last checkpoint is within a threshold (default 10 minutes).

The fast RTS calculation in checkFastReadyToServeWithPreviousTimeLag simplifies to:

timeLagIncrease = (currentTime - hbTimestamp) - (checkpointTime - hbTimestamp) = currentTime - checkpointTime

The heartbeat lag cancels out, so the decision depends only on how recently the checkpoint was updated — not on actual ingestion lag.

When multiple hosts bootstrap via blob transfer in sequence (e.g., host A → host B → host C), the flag propagates through the chain. If host B catches up and updates its checkpoint time shortly before host C bootstraps from it, host C will see previouslyReadyToServe=true with a recent checkpoint, causing fast RTS to trigger incorrectly — even though host C has not caught up on its own.

Observed impact: Partition 281 was declared ready-to-serve with ~700k record delay because fast RTS bypassed normal lag verification. The actual records to process were only ~12k, but the replica started serving before ingestion completed.


## Solution
Clear the previouslyReadyToServe flag from the OffsetRecord in completePostTransferPSCUpdated after blob transfer completes. This ensures fast RTS is only used for same-host restarts (its intended use case) and not triggered by state inherited from a different host via blob transfer.


###  Code changes
- [ ] Added new code behind **a config**. If so list the config names and their default values in the PR description.
- [ ] Introduced new **log lines**. 
  - [ ] Confirmed if logs need to be **rate limited** to avoid excessive logging.

###  **Concurrency-Specific Checks**
Both reviewer and PR author to verify
- [ ] Code has **no race conditions** or **thread safety issues**.
- [ ] Proper **synchronization mechanisms** (e.g., `synchronized`, `RWLock`) are used where needed.
- [ ] No **blocking calls** inside critical sections that could lead to deadlocks or performance degradation.
- [ ] Verified **thread-safe collections** are used (e.g., `ConcurrentHashMap`, `CopyOnWriteArrayList`).
- [ ] Validated proper exception handling in multi-threaded code to avoid silent thread termination.


## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->

- [ ] New unit tests added.
- [ ] New integration tests added.
- [ ] Modified or extended existing tests.
- [ ] Verified backward compatibility (if applicable).

## Does this PR introduce any user-facing or breaking changes?
<!--  
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [ ] No. You can skip the rest of this section.
- [ ] Yes. Clearly explain the behavior change and its impact.