### PR TITLE
[server] Wait for version metadata before creating storage engine on transition

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/config/VeniceServerConfig.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/config/VeniceServerConfig.java
@@ -208,7 +208,7 @@ import static com.linkedin.venice.ConfigKeys.SERVER_SSL_HANDSHAKE_QUEUE_CAPACITY
 import static com.linkedin.venice.ConfigKeys.SERVER_SSL_HANDSHAKE_THREAD_POOL_SIZE;
 import static com.linkedin.venice.ConfigKeys.SERVER_STOP_CONSUMPTION_TIMEOUT_IN_SECONDS;
 import static com.linkedin.venice.ConfigKeys.SERVER_STORE_TO_EARLY_TERMINATION_THRESHOLD_MS_MAP;
-import static com.linkedin.venice.ConfigKeys.SERVER_STORE_VERSION_METADATA_WAIT_TIME_MS;
+import static com.linkedin.venice.ConfigKeys.SERVER_STORE_VERSION_METADATA_WAIT_DURING_STATE_TRANSITION_TIME_MS;
 import static com.linkedin.venice.ConfigKeys.SERVER_STUCK_CONSUMER_REPAIR_ENABLED;
 import static com.linkedin.venice.ConfigKeys.SERVER_STUCK_CONSUMER_REPAIR_INTERVAL_SECOND;
 import static com.linkedin.venice.ConfigKeys.SERVER_STUCK_CONSUMER_REPAIR_THRESHOLD_SECOND;
@@ -466,7 +466,7 @@ public class VeniceServerConfig extends VeniceClusterConfig {
 
   private final Duration serverMaxWaitForVersionInfo;
 
-  private final long storeVersionMetadataWaitTimeMs;
+  private final long storeVersionMetadataWaitDuringStateTransitionTimeMs;
 
   private final boolean computeFastAvroEnabled;
 
@@ -887,7 +887,8 @@ public class VeniceServerConfig extends VeniceClusterConfig {
     diskHealthCheckServiceEnabled = serverProperties.getBoolean(SERVER_DISK_HEALTH_CHECK_SERVICE_ENABLED, true);
     serverMaxWaitForVersionInfo =
         Duration.ofMillis(serverProperties.getLong(SERVER_MAX_WAIT_FOR_VERSION_INFO_MS_CONFIG, 5000));
-    storeVersionMetadataWaitTimeMs = serverProperties.getLong(SERVER_STORE_VERSION_METADATA_WAIT_TIME_MS, 180_000);
+    storeVersionMetadataWaitDuringStateTransitionTimeMs =
+        serverProperties.getLong(SERVER_STORE_VERSION_METADATA_WAIT_DURING_STATE_TRANSITION_TIME_MS, 300_000);
     computeFastAvroEnabled = serverProperties.getBoolean(SERVER_COMPUTE_FAST_AVRO_ENABLED, true);
     participantMessageConsumptionDelayMs = serverProperties.getLong(PARTICIPANT_MESSAGE_CONSUMPTION_DELAY_MS, 60000);
     serverPromotionToLeaderReplicaDelayMs =
@@ -1499,8 +1500,8 @@ public class VeniceServerConfig extends VeniceClusterConfig {
     return serverMaxWaitForVersionInfo;
   }
 
-  public long getStoreVersionMetadataWaitTimeMs() {
-    return storeVersionMetadataWaitTimeMs;
+  public long getStoreVersionMetadataWaitDuringStateTransitionTimeMs() {
+    return storeVersionMetadataWaitDuringStateTransitionTimeMs;
   }
 
   public BlockingQueueType getBlockingQueueType() {

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/config/VeniceServerConfig.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/config/VeniceServerConfig.java
@@ -208,6 +208,7 @@ import static com.linkedin.venice.ConfigKeys.SERVER_SSL_HANDSHAKE_QUEUE_CAPACITY
 import static com.linkedin.venice.ConfigKeys.SERVER_SSL_HANDSHAKE_THREAD_POOL_SIZE;
 import static com.linkedin.venice.ConfigKeys.SERVER_STOP_CONSUMPTION_TIMEOUT_IN_SECONDS;
 import static com.linkedin.venice.ConfigKeys.SERVER_STORE_TO_EARLY_TERMINATION_THRESHOLD_MS_MAP;
+import static com.linkedin.venice.ConfigKeys.SERVER_STORE_VERSION_METADATA_WAIT_TIME_MS;
 import static com.linkedin.venice.ConfigKeys.SERVER_STUCK_CONSUMER_REPAIR_ENABLED;
 import static com.linkedin.venice.ConfigKeys.SERVER_STUCK_CONSUMER_REPAIR_INTERVAL_SECOND;
 import static com.linkedin.venice.ConfigKeys.SERVER_STUCK_CONSUMER_REPAIR_THRESHOLD_SECOND;
@@ -464,6 +465,8 @@ public class VeniceServerConfig extends VeniceClusterConfig {
   private final boolean diskHealthCheckServiceEnabled;
 
   private final Duration serverMaxWaitForVersionInfo;
+
+  private final long storeVersionMetadataWaitTimeMs;
 
   private final boolean computeFastAvroEnabled;
 
@@ -884,6 +887,7 @@ public class VeniceServerConfig extends VeniceClusterConfig {
     diskHealthCheckServiceEnabled = serverProperties.getBoolean(SERVER_DISK_HEALTH_CHECK_SERVICE_ENABLED, true);
     serverMaxWaitForVersionInfo =
         Duration.ofMillis(serverProperties.getLong(SERVER_MAX_WAIT_FOR_VERSION_INFO_MS_CONFIG, 5000));
+    storeVersionMetadataWaitTimeMs = serverProperties.getLong(SERVER_STORE_VERSION_METADATA_WAIT_TIME_MS, 180_000);
     computeFastAvroEnabled = serverProperties.getBoolean(SERVER_COMPUTE_FAST_AVRO_ENABLED, true);
     participantMessageConsumptionDelayMs = serverProperties.getLong(PARTICIPANT_MESSAGE_CONSUMPTION_DELAY_MS, 60000);
     serverPromotionToLeaderReplicaDelayMs =
@@ -1493,6 +1497,10 @@ public class VeniceServerConfig extends VeniceClusterConfig {
 
   public Duration getServerMaxWaitForVersionInfo() {
     return serverMaxWaitForVersionInfo;
+  }
+
+  public long getStoreVersionMetadataWaitTimeMs() {
+    return storeVersionMetadataWaitTimeMs;
   }
 
   public BlockingQueueType getBlockingQueueType() {

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/helix/AbstractPartitionStateModel.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/helix/AbstractPartitionStateModel.java
@@ -233,7 +233,7 @@ public abstract class AbstractPartitionStateModel extends StateModel {
    * (with or without replication metadata) is used.
    */
   protected void waitForVersionToBeAvailable() {
-    long waitTimeMs = storeAndServerConfigs.getStoreVersionMetadataWaitTimeMs();
+    long waitTimeMs = storeAndServerConfigs.getStoreVersionMetadataWaitDuringStateTransitionTimeMs();
     try {
       RetryUtils.executeWithMaxAttemptAndExponentialBackoff(() -> {
         Version version = storeRepository.getStoreOrThrow(storeName).getVersion(versionNumber);
@@ -249,13 +249,10 @@ public abstract class AbstractPartitionStateModel extends StateModel {
           Collections.singletonList(VeniceException.class));
       logger.info("Version {} of store {} is available in store repository.", versionNumber, storeName);
     } catch (Exception e) {
-      logger.error(
-          "Version {} of store {} did not become available within {} ms. "
-              + "StorageService fallback will use store-level AA config.",
-          versionNumber,
-          storeName,
-          waitTimeMs,
-          e);
+      String errorMsg = "Version " + versionNumber + " of store " + storeName
+          + " did not become available in store repository within " + waitTimeMs + " ms.";
+      logger.error(errorMsg, e);
+      throw new VeniceException(errorMsg, e);
     }
   }
 

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/helix/AbstractPartitionStateModel.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/helix/AbstractPartitionStateModel.java
@@ -15,8 +15,11 @@ import com.linkedin.venice.meta.Version;
 import com.linkedin.venice.pushmonitor.ExecutionStatus;
 import com.linkedin.venice.pushmonitor.HybridStoreQuotaStatus;
 import com.linkedin.venice.utils.LogContext;
+import com.linkedin.venice.utils.RetryUtils;
 import com.linkedin.venice.utils.Timer;
 import com.linkedin.venice.utils.Utils;
+import java.time.Duration;
+import java.util.Collections;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
@@ -224,9 +227,49 @@ public abstract class AbstractPartitionStateModel extends StateModel {
   }
 
   /**
+   * Waits for the version metadata to become available in the store repository using exponential backoff.
+   * During OFFLINE->STANDBY transitions, version info may not have propagated from ZK yet.
+   * This must be called before the storage engine is created so that the correct partition type
+   * (with or without replication metadata) is used.
+   */
+  protected void waitForVersionToBeAvailable() {
+    long waitTimeMs = storeAndServerConfigs.getStoreVersionMetadataWaitTimeMs();
+    try {
+      RetryUtils.executeWithMaxAttemptAndExponentialBackoff(() -> {
+        Version version = storeRepository.getStoreOrThrow(storeName).getVersion(versionNumber);
+        if (version == null) {
+          throw new VeniceException(
+              "Version " + versionNumber + " of store " + storeName + " not yet available in store repository");
+        }
+      },
+          Integer.MAX_VALUE,
+          Duration.ofMillis(10),
+          Duration.ofMillis(200),
+          Duration.ofMillis(waitTimeMs),
+          Collections.singletonList(VeniceException.class));
+      logger.info("Version {} of store {} is available in store repository.", versionNumber, storeName);
+    } catch (Exception e) {
+      logger.error(
+          "Version {} of store {} did not become available within {} ms. "
+              + "StorageService fallback will use store-level AA config.",
+          versionNumber,
+          storeName,
+          waitTimeMs,
+          e);
+    }
+  }
+
+  /**
    * set up a new store partition and start the ingestion
    */
   protected void setupNewStorePartition() {
+    /**
+     * Wait for version metadata to become available in the store repository before opening the
+     * storage engine. This ensures the correct partition type (with or without replication metadata)
+     * is determined based on version-level config rather than falling back to store-level config.
+     */
+    waitForVersionToBeAvailable();
+
     /**
      * Waiting for push accessor to get initialized before starting ingestion.
      * Otherwise, it's possible that store ingestion starts without having the

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/helix/AbstractPartitionStateModel.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/helix/AbstractPartitionStateModel.java
@@ -236,9 +236,7 @@ public abstract class AbstractPartitionStateModel extends StateModel {
     String storeVersion = Version.composeKafkaTopic(storeName, versionNumber);
     long waitTimeMs = storeAndServerConfigs.getStoreVersionMetadataWaitDuringStateTransitionTimeMs();
     try {
-      // Suppress per-retry WARN logs — with 10ms-200ms backoff over 5 min, default logging
-      // would emit thousands of WARNs. The final error log on exhaustion provides visibility.
-      RetryUtils.executeWithMaxAttemptAndExponentialBackoffNoIntermediateLog(() -> {
+      RetryUtils.executeWithMaxAttemptAndExponentialBackoff(() -> {
         Version version = storeRepository.getStoreOrThrow(storeName).getVersion(versionNumber);
         if (version == null) {
           throw new VeniceException(storeVersion + " not yet available in store repository");

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/helix/AbstractPartitionStateModel.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/helix/AbstractPartitionStateModel.java
@@ -236,7 +236,9 @@ public abstract class AbstractPartitionStateModel extends StateModel {
     String storeVersion = Version.composeKafkaTopic(storeName, versionNumber);
     long waitTimeMs = storeAndServerConfigs.getStoreVersionMetadataWaitDuringStateTransitionTimeMs();
     try {
-      RetryUtils.executeWithMaxAttemptAndExponentialBackoff(() -> {
+      // Suppress per-retry WARN logs — with 10ms-200ms backoff over 5 min, default logging
+      // would emit thousands of WARNs. The final error log on exhaustion provides visibility.
+      RetryUtils.executeWithMaxAttemptAndExponentialBackoffNoIntermediateLog(() -> {
         Version version = storeRepository.getStoreOrThrow(storeName).getVersion(versionNumber);
         if (version == null) {
           throw new VeniceException(storeVersion + " not yet available in store repository");
@@ -247,7 +249,6 @@ public abstract class AbstractPartitionStateModel extends StateModel {
           Duration.ofMillis(200),
           Duration.ofMillis(waitTimeMs),
           Collections.singletonList(VeniceException.class));
-      logger.info("{} is available in store repository.", storeVersion);
     } catch (Exception e) {
       String errorMsg = storeVersion + " did not become available in store repository within " + waitTimeMs + " ms.";
       logger.error(errorMsg, e);

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/helix/AbstractPartitionStateModel.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/helix/AbstractPartitionStateModel.java
@@ -233,13 +233,13 @@ public abstract class AbstractPartitionStateModel extends StateModel {
    * (with or without replication metadata) is used.
    */
   protected void waitForVersionToBeAvailable() {
+    String storeVersion = Version.composeKafkaTopic(storeName, versionNumber);
     long waitTimeMs = storeAndServerConfigs.getStoreVersionMetadataWaitDuringStateTransitionTimeMs();
     try {
       RetryUtils.executeWithMaxAttemptAndExponentialBackoff(() -> {
         Version version = storeRepository.getStoreOrThrow(storeName).getVersion(versionNumber);
         if (version == null) {
-          throw new VeniceException(
-              "Version " + versionNumber + " of store " + storeName + " not yet available in store repository");
+          throw new VeniceException(storeVersion + " not yet available in store repository");
         }
       },
           Integer.MAX_VALUE,
@@ -247,10 +247,9 @@ public abstract class AbstractPartitionStateModel extends StateModel {
           Duration.ofMillis(200),
           Duration.ofMillis(waitTimeMs),
           Collections.singletonList(VeniceException.class));
-      logger.info("Version {} of store {} is available in store repository.", versionNumber, storeName);
+      logger.info("{} is available in store repository.", storeVersion);
     } catch (Exception e) {
-      String errorMsg = "Version " + versionNumber + " of store " + storeName
-          + " did not become available in store repository within " + waitTimeMs + " ms.";
+      String errorMsg = storeVersion + " did not become available in store repository within " + waitTimeMs + " ms.";
       logger.error(errorMsg, e);
       throw new VeniceException(errorMsg, e);
     }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/storage/StorageService.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/storage/StorageService.java
@@ -706,10 +706,7 @@ public class StorageService extends AbstractVeniceService {
       if (version != null) {
         return version.isActiveActiveReplicationEnabled();
       } else {
-        LOGGER.warn(
-            "Version {} of store {} does not exist in storeRepository, falling back to store-level AA config.",
-            versionNum,
-            storeName);
+        LOGGER.warn("{} does not exist in storeRepository, falling back to store-level AA config.", topicName);
         return store.isActiveActiveReplicationEnabled();
       }
     } catch (VeniceNoStoreException e) {

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/storage/StorageService.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/storage/StorageService.java
@@ -706,11 +706,15 @@ public class StorageService extends AbstractVeniceService {
       if (version != null) {
         return version.isActiveActiveReplicationEnabled();
       } else {
-        LOGGER.warn("{} does not exist in storeRepository, falling back to store-level AA config.", topicName);
-        return store.isActiveActiveReplicationEnabled();
+        boolean storeAA = store.isActiveActiveReplicationEnabled();
+        LOGGER.warn(
+            "{} does not exist in storeRepository, falling back to store-level AA config: {}",
+            topicName,
+            storeAA);
+        return storeAA;
       }
     } catch (VeniceNoStoreException e) {
-      LOGGER.warn("Store {} does not exist in storeRepository.", storeName);
+      LOGGER.warn("{} - store does not exist in storeRepository.", topicName);
       return false;
     }
   }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/storage/StorageService.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/storage/StorageService.java
@@ -701,13 +701,61 @@ public class StorageService extends AbstractVeniceService {
       return false;
     }
     try {
-      Version version = storeRepository.getStoreOrThrow(storeName).getVersion(versionNum);
+      Store store = storeRepository.getStoreOrThrow(storeName);
+      Version version = store.getVersion(versionNum);
       if (version != null) {
         return version.isActiveActiveReplicationEnabled();
-      } else {
-        LOGGER.warn("Version {} of store {} does not exist in storeRepository.", versionNum, storeName);
-        return false;
       }
+      // Version metadata not yet available — retry with exponential backoff.
+      // During OFFLINE->STANDBY transitions, version info may not have propagated from ZK yet.
+      long maxWaitMs = serverConfig.getStoreVersionMetadataWaitTimeMs();
+      long initialDelayMs = 10;
+      long maxDelayMs = 200;
+      long currentDelayMs = initialDelayMs;
+      long elapsedMs = 0;
+      int attempt = 0;
+      while (elapsedMs < maxWaitMs) {
+        attempt++;
+        LOGGER.warn(
+            "Version {} of store {} not yet in storeRepository (attempt {}), retrying in {} ms (elapsed: {} ms / max: {} ms)",
+            versionNum,
+            storeName,
+            attempt,
+            currentDelayMs,
+            elapsedMs,
+            maxWaitMs);
+        try {
+          Thread.sleep(currentDelayMs);
+        } catch (InterruptedException ie) {
+          Thread.currentThread().interrupt();
+          LOGGER.warn(
+              "Interrupted while waiting for version {} of store {} metadata, falling back to store-level AA config",
+              versionNum,
+              storeName);
+          return store.isActiveActiveReplicationEnabled();
+        }
+        elapsedMs += currentDelayMs;
+        currentDelayMs = Math.min(currentDelayMs * 2, maxDelayMs);
+        // Re-fetch the store in case the repository was updated
+        store = storeRepository.getStoreOrThrow(storeName);
+        version = store.getVersion(versionNum);
+        if (version != null) {
+          LOGGER.info(
+              "Version {} of store {} became available after {} ms ({} retries)",
+              versionNum,
+              storeName,
+              elapsedMs,
+              attempt);
+          return version.isActiveActiveReplicationEnabled();
+        }
+      }
+      // Retries exhausted — fall back to store-level Active-Active replication config
+      LOGGER.error(
+          "Version {} of store {} still not in storeRepository after {} ms retries, falling back to store-level AA config",
+          versionNum,
+          storeName,
+          maxWaitMs);
+      return store.isActiveActiveReplicationEnabled();
     } catch (VeniceNoStoreException e) {
       LOGGER.warn("Store {} does not exist in storeRepository.", storeName);
       return false;

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/storage/StorageService.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/storage/StorageService.java
@@ -705,57 +705,13 @@ public class StorageService extends AbstractVeniceService {
       Version version = store.getVersion(versionNum);
       if (version != null) {
         return version.isActiveActiveReplicationEnabled();
-      }
-      // Version metadata not yet available — retry with exponential backoff.
-      // During OFFLINE->STANDBY transitions, version info may not have propagated from ZK yet.
-      long maxWaitMs = serverConfig.getStoreVersionMetadataWaitTimeMs();
-      long initialDelayMs = 10;
-      long maxDelayMs = 200;
-      long currentDelayMs = initialDelayMs;
-      long elapsedMs = 0;
-      int attempt = 0;
-      while (elapsedMs < maxWaitMs) {
-        attempt++;
+      } else {
         LOGGER.warn(
-            "Version {} of store {} not yet in storeRepository (attempt {}), retrying in {} ms (elapsed: {} ms / max: {} ms)",
+            "Version {} of store {} does not exist in storeRepository, falling back to store-level AA config.",
             versionNum,
-            storeName,
-            attempt,
-            currentDelayMs,
-            elapsedMs,
-            maxWaitMs);
-        try {
-          Thread.sleep(currentDelayMs);
-        } catch (InterruptedException ie) {
-          Thread.currentThread().interrupt();
-          LOGGER.warn(
-              "Interrupted while waiting for version {} of store {} metadata, falling back to store-level AA config",
-              versionNum,
-              storeName);
-          return store.isActiveActiveReplicationEnabled();
-        }
-        elapsedMs += currentDelayMs;
-        currentDelayMs = Math.min(currentDelayMs * 2, maxDelayMs);
-        // Re-fetch the store in case the repository was updated
-        store = storeRepository.getStoreOrThrow(storeName);
-        version = store.getVersion(versionNum);
-        if (version != null) {
-          LOGGER.info(
-              "Version {} of store {} became available after {} ms ({} retries)",
-              versionNum,
-              storeName,
-              elapsedMs,
-              attempt);
-          return version.isActiveActiveReplicationEnabled();
-        }
+            storeName);
+        return store.isActiveActiveReplicationEnabled();
       }
-      // Retries exhausted — fall back to store-level Active-Active replication config
-      LOGGER.error(
-          "Version {} of store {} still not in storeRepository after {} ms retries, falling back to store-level AA config",
-          versionNum,
-          storeName,
-          maxWaitMs);
-      return store.isActiveActiveReplicationEnabled();
     } catch (VeniceNoStoreException e) {
       LOGGER.warn("Store {} does not exist in storeRepository.", storeName);
       return false;

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/helix/AbstractVenicePartitionStateModelTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/helix/AbstractVenicePartitionStateModelTest.java
@@ -250,12 +250,13 @@ public abstract class AbstractVenicePartitionStateModelTest<MODEL_TYPE extends A
     // Very short wait time so the test completes quickly
     when(mockStoreConfig.getStoreVersionMetadataWaitDuringStateTransitionTimeMs()).thenReturn(200L);
 
+    String expectedStoreVersion = Version.composeKafkaTopic(storeName, version);
     VeniceException e = Assert.expectThrows(VeniceException.class, () -> testStateModel.waitForVersionToBeAvailable());
     Assert.assertTrue(
         e.getMessage().contains("did not become available in store repository"),
         "Exception message should indicate version metadata unavailability, got: " + e.getMessage());
     Assert.assertTrue(
-        e.getMessage().contains(storeName),
-        "Exception message should contain store name, got: " + e.getMessage());
+        e.getMessage().contains(expectedStoreVersion),
+        "Exception message should contain store version (" + expectedStoreVersion + "), got: " + e.getMessage());
   }
 }

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/helix/AbstractVenicePartitionStateModelTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/helix/AbstractVenicePartitionStateModelTest.java
@@ -11,6 +11,7 @@ import com.linkedin.davinci.kafka.consumer.KafkaStoreIngestionService;
 import com.linkedin.davinci.stats.AggVersionedIngestionStats;
 import com.linkedin.davinci.stats.ParticipantStateTransitionStats;
 import com.linkedin.venice.common.VeniceSystemStoreUtils;
+import com.linkedin.venice.exceptions.VeniceException;
 import com.linkedin.venice.helix.HelixPartitionStatusAccessor;
 import com.linkedin.venice.helix.SafeHelixManager;
 import com.linkedin.venice.meta.ReadOnlyStoreRepository;
@@ -25,6 +26,7 @@ import org.apache.helix.NotificationContext;
 import org.apache.helix.customizedstate.CustomizedStateProvider;
 import org.apache.helix.model.Message;
 import org.mockito.Mockito;
+import org.testng.Assert;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
@@ -102,6 +104,10 @@ public abstract class AbstractVenicePartitionStateModelTest<MODEL_TYPE extends A
     when(mockReadOnlyStoreRepository.getStore(systemStoreName)).thenReturn(mockSystemStore);
     when(mockStore.getBootstrapToOnlineTimeoutInHours()).thenReturn(Store.BOOTSTRAP_TO_ONLINE_TIMEOUT_IN_HOURS);
     when(mockSystemStore.getBootstrapToOnlineTimeoutInHours()).thenReturn(Store.BOOTSTRAP_TO_ONLINE_TIMEOUT_IN_HOURS);
+    // Default: version metadata available immediately so existing tests don't hit the retry/throw path
+    when(mockStore.getVersion(version)).thenReturn(Mockito.mock(Version.class));
+    when(mockSystemStore.getVersion(version)).thenReturn(Mockito.mock(Version.class));
+    when(mockStoreConfig.getStoreVersionMetadataWaitDuringStateTransitionTimeMs()).thenReturn(5000L);
 
     when(mockStoreIngestionService.getAggVersionedIngestionStats()).thenReturn(mockAggVersionedIngestionStats);
 
@@ -208,7 +214,7 @@ public abstract class AbstractVenicePartitionStateModelTest<MODEL_TYPE extends A
   public void testWaitForVersionToBeAvailableHappyPath() {
     Version mockVersion = Mockito.mock(Version.class);
     when(mockStore.getVersion(version)).thenReturn(mockVersion);
-    when(mockStoreConfig.getStoreVersionMetadataWaitTimeMs()).thenReturn(5000L);
+    when(mockStoreConfig.getStoreVersionMetadataWaitDuringStateTransitionTimeMs()).thenReturn(5000L);
 
     // Should return immediately without retries
     testStateModel.waitForVersionToBeAvailable();
@@ -227,7 +233,7 @@ public abstract class AbstractVenicePartitionStateModelTest<MODEL_TYPE extends A
       int count = callCount.incrementAndGet();
       return count >= 3 ? mockVersion : null;
     });
-    when(mockStoreConfig.getStoreVersionMetadataWaitTimeMs()).thenReturn(5000L);
+    when(mockStoreConfig.getStoreVersionMetadataWaitDuringStateTransitionTimeMs()).thenReturn(5000L);
 
     testStateModel.waitForVersionToBeAvailable();
     // Should have retried at least 3 times
@@ -235,16 +241,21 @@ public abstract class AbstractVenicePartitionStateModelTest<MODEL_TYPE extends A
   }
 
   /**
-   * Tests that waitForVersionToBeAvailable() does not throw when version never becomes available
-   * (it logs an error and returns, letting StorageService fallback handle it).
+   * Tests that waitForVersionToBeAvailable() throws VeniceException when version never becomes available,
+   * which causes the state transition to fail and the replica to enter ERROR state.
    */
   @Test(timeOut = 10_000)
   public void testWaitForVersionToBeAvailableExhaustsRetries() {
     when(mockStore.getVersion(version)).thenReturn(null);
     // Very short wait time so the test completes quickly
-    when(mockStoreConfig.getStoreVersionMetadataWaitTimeMs()).thenReturn(200L);
+    when(mockStoreConfig.getStoreVersionMetadataWaitDuringStateTransitionTimeMs()).thenReturn(200L);
 
-    // Should NOT throw — it catches the exception and logs an error
-    testStateModel.waitForVersionToBeAvailable();
+    VeniceException e = Assert.expectThrows(VeniceException.class, () -> testStateModel.waitForVersionToBeAvailable());
+    Assert.assertTrue(
+        e.getMessage().contains("did not become available in store repository"),
+        "Exception message should indicate version metadata unavailability, got: " + e.getMessage());
+    Assert.assertTrue(
+        e.getMessage().contains(storeName),
+        "Exception message should contain store name, got: " + e.getMessage());
   }
 }

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/helix/AbstractVenicePartitionStateModelTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/helix/AbstractVenicePartitionStateModelTest.java
@@ -1,5 +1,7 @@
 package com.linkedin.davinci.helix;
 
+import static org.mockito.Mockito.atLeast;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertEquals;
 
@@ -17,6 +19,7 @@ import com.linkedin.venice.meta.VeniceStoreType;
 import com.linkedin.venice.meta.Version;
 import com.linkedin.venice.utils.Utils;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicInteger;
 import org.apache.helix.HelixManager;
 import org.apache.helix.NotificationContext;
 import org.apache.helix.customizedstate.CustomizedStateProvider;
@@ -196,5 +199,52 @@ public abstract class AbstractVenicePartitionStateModelTest<MODEL_TYPE extends A
     when(mockReadOnlyStoreRepository.getStore(storeName)).thenReturn(null);
     description = freshModel.getReplicaTypeDescription();
     assertEquals(description, "BATCH store", "Case 4: Unknown store");
+  }
+
+  /**
+   * Tests that waitForVersionToBeAvailable() returns immediately when the version is already present.
+   */
+  @Test
+  public void testWaitForVersionToBeAvailableHappyPath() {
+    Version mockVersion = Mockito.mock(Version.class);
+    when(mockStore.getVersion(version)).thenReturn(mockVersion);
+    when(mockStoreConfig.getStoreVersionMetadataWaitTimeMs()).thenReturn(5000L);
+
+    // Should return immediately without retries
+    testStateModel.waitForVersionToBeAvailable();
+    // Verify getStoreOrThrow was called (at least once for the initial check)
+    verify(mockReadOnlyStoreRepository, atLeast(1)).getStoreOrThrow(storeName);
+  }
+
+  /**
+   * Tests that waitForVersionToBeAvailable() retries and succeeds when version appears after a few attempts.
+   */
+  @Test(timeOut = 10_000)
+  public void testWaitForVersionToBeAvailableRetrySuccess() {
+    Version mockVersion = Mockito.mock(Version.class);
+    AtomicInteger callCount = new AtomicInteger(0);
+    when(mockStore.getVersion(version)).thenAnswer(invocation -> {
+      int count = callCount.incrementAndGet();
+      return count >= 3 ? mockVersion : null;
+    });
+    when(mockStoreConfig.getStoreVersionMetadataWaitTimeMs()).thenReturn(5000L);
+
+    testStateModel.waitForVersionToBeAvailable();
+    // Should have retried at least 3 times
+    assertEquals(callCount.get() >= 3, true, "getVersion should have been called at least 3 times");
+  }
+
+  /**
+   * Tests that waitForVersionToBeAvailable() does not throw when version never becomes available
+   * (it logs an error and returns, letting StorageService fallback handle it).
+   */
+  @Test(timeOut = 10_000)
+  public void testWaitForVersionToBeAvailableExhaustsRetries() {
+    when(mockStore.getVersion(version)).thenReturn(null);
+    // Very short wait time so the test completes quickly
+    when(mockStoreConfig.getStoreVersionMetadataWaitTimeMs()).thenReturn(200L);
+
+    // Should NOT throw — it catches the exception and logs an error
+    testStateModel.waitForVersionToBeAvailable();
   }
 }

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/helix/LeaderFollowerPartitionStateModelTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/helix/LeaderFollowerPartitionStateModelTest.java
@@ -83,8 +83,13 @@ public class LeaderFollowerPartitionStateModelTest {
         .dropStoragePartitionGracefully(any(), anyInt(), anyInt(), anyString());
 
     storeAndServerConfigs = mock(VeniceStoreVersionConfig.class);
+    when(storeAndServerConfigs.getStoreVersionMetadataWaitDuringStateTransitionTimeMs()).thenReturn(5000L);
     notifier = mock(LeaderFollowerIngestionProgressNotifier.class);
     metadataRepo = mock(ReadOnlyStoreRepository.class);
+    // Default store mock so waitForVersionToBeAvailable() finds the version immediately
+    Store defaultStore = mock(Store.class);
+    when(defaultStore.getVersion(storeVersion)).thenReturn(mock(Version.class));
+    doReturn(defaultStore).when(metadataRepo).getStoreOrThrow(storeName);
     partitionPushStatusAccessorFuture = CompletableFuture.completedFuture(mock(HelixPartitionStatusAccessor.class));
     stateTransitionStats = mock(ParticipantStateTransitionStats.class);
     heartbeatMonitoringService = mock(HeartbeatMonitoringService.class);
@@ -112,6 +117,9 @@ public class LeaderFollowerPartitionStateModelTest {
     when(message.getResourceName()).thenReturn(resourceName);
     Store store = mock(Store.class);
     when(store.getVersionStatus(anyInt())).thenReturn(VersionStatus.STARTED);
+    Version mockVersion = mock(Version.class);
+    when(mockVersion.getStatus()).thenReturn(VersionStatus.STARTED);
+    when(store.getVersion(storeVersion)).thenReturn(mockVersion);
     doReturn(store).when(metadataRepo).getStoreOrThrow(anyString());
 
     LeaderFollowerPartitionStateModel leaderFollowerPartitionStateModelSpy = spy(leaderFollowerPartitionStateModel);
@@ -153,6 +161,9 @@ public class LeaderFollowerPartitionStateModelTest {
     when(message.getResourceName()).thenReturn(resourceName);
     Store store = mock(Store.class);
     when(store.getVersionStatus(anyInt())).thenReturn(VersionStatus.STARTED);
+    Version mockVersion = mock(Version.class);
+    when(mockVersion.getStatus()).thenReturn(VersionStatus.STARTED);
+    when(store.getVersion(storeVersion)).thenReturn(mockVersion);
     doReturn(store).when(metadataRepo).getStoreOrThrow(anyString());
 
     LeaderFollowerPartitionStateModel leaderFollowerPartitionStateModelSpy = spy(leaderFollowerPartitionStateModel);
@@ -207,6 +218,7 @@ public class LeaderFollowerPartitionStateModelTest {
     Store store = mock(Store.class);
     when(store.getCurrentVersion()).thenReturn(storeVersion);
     doReturn(store).when(metadataRepo).getStoreOrThrow(anyString());
+    when(store.getVersion(storeVersion)).thenReturn(mock(Version.class));
 
     // Case 1: Timestamp captured during STANDBY->OFFLINE transition
     when(storeAndServerConfigs.getPartitionGracefulDropDelaySeconds()).thenReturn(0); // No sleep for speed
@@ -258,6 +270,7 @@ public class LeaderFollowerPartitionStateModelTest {
     Store store = mock(Store.class);
     when(store.getCurrentVersion()).thenReturn(storeVersion); // Current version
     doReturn(store).when(metadataRepo).getStoreOrThrow(anyString());
+    when(store.getVersion(storeVersion)).thenReturn(mock(Version.class));
     NotificationContext context = mock(NotificationContext.class);
 
     // Case 1: Partial wait - partition offline for some time, should wait for remaining delay
@@ -350,6 +363,7 @@ public class LeaderFollowerPartitionStateModelTest {
     Store store = mock(Store.class);
     when(store.getCurrentVersion()).thenReturn(storeVersion + 1); // NOT current version
     doReturn(store).when(metadataRepo).getStoreOrThrow(anyString());
+    when(store.getVersion(storeVersion)).thenReturn(mock(Version.class));
 
     // Transition to OFFLINE first to capture timestamp
     Message offlineMessage = mock(Message.class);
@@ -385,6 +399,7 @@ public class LeaderFollowerPartitionStateModelTest {
     when(store.getCurrentVersion()).thenReturn(storeVersion); // Version starts as current so the latch is created
     when(store.getBootstrapToOnlineTimeoutInHours()).thenReturn(24); // large timeout for latch await
     doReturn(store).when(metadataRepo).getStoreOrThrow(anyString());
+    when(store.getVersion(storeVersion)).thenReturn(mock(Version.class));
     LeaderFollowerIngestionProgressNotifier notifier = new LeaderFollowerIngestionProgressNotifier();
     LeaderFollowerPartitionStateModel model = buildModel(notifier);
 

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/storage/StorageServiceTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/storage/StorageServiceTest.java
@@ -39,9 +39,11 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicInteger;
 import org.apache.helix.PropertyKey;
 import org.apache.helix.model.IdealState;
 import org.apache.helix.zookeeper.datamodel.ZNRecord;
+import org.mockito.ArgumentCaptor;
 import org.mockito.internal.util.collections.Sets;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
@@ -218,5 +220,228 @@ public class StorageServiceTest {
     mockStorageService.checkWhetherStoragePartitionsShouldBeKeptOrNot(manager);
     verify(storageEngine).dropPartition(0);
     Assert.assertFalse(storageEngine.getPartitionIds().contains(0));
+  }
+
+  /**
+   * Helper to build a StorageService with a controllable mock factory for RocksDB persistence type,
+   * used by the isReplicationMetadataEnabled tests.
+   */
+  private StorageService createStorageServiceForRmdTest(
+      ReadOnlyStoreRepository mockStoreRepo,
+      VeniceServerConfig mockServerConfig,
+      StorageEngineFactory mockFactory,
+      VeniceStoreVersionConfig mockStoreVersionConfig) {
+    VeniceConfigLoader configLoader = mock(VeniceConfigLoader.class);
+    when(configLoader.getVeniceServerConfig()).thenReturn(mockServerConfig);
+    when(mockServerConfig.getDataBasePath()).thenReturn("/tmp");
+
+    AggVersionedStorageEngineStats storageEngineStats = mock(AggVersionedStorageEngineStats.class);
+    RocksDBMemoryStats rocksDBMemoryStats = mock(RocksDBMemoryStats.class);
+    InternalAvroSpecificSerializer<StoreVersionState> storeVersionStateSerializer =
+        mock(InternalAvroSpecificSerializer.class);
+    InternalAvroSpecificSerializer<PartitionState> partitionStateSerializer =
+        mock(InternalAvroSpecificSerializer.class);
+
+    when(mockFactory.getPersistenceType()).thenReturn(PersistenceType.ROCKS_DB);
+    when(mockFactory.getPersistedStoreNames()).thenReturn(new HashSet<>());
+
+    Map<PersistenceType, StorageEngineFactory> factoryMap = new HashMap<>();
+    factoryMap.put(PersistenceType.ROCKS_DB, mockFactory);
+
+    return new StorageService(
+        configLoader,
+        storageEngineStats,
+        rocksDBMemoryStats,
+        storeVersionStateSerializer,
+        partitionStateSerializer,
+        mockStoreRepo,
+        false,
+        false,
+        (s) -> true,
+        Optional.of(factoryMap));
+  }
+
+  /**
+   * Tests the happy path: version metadata is available immediately, and the version-level
+   * AA config is used to determine whether RMD is enabled.
+   */
+  @Test
+  public void testIsReplicationMetadataEnabledHappyPath() {
+    String testStore = "test_rmd_store";
+    int versionNum = 1;
+    String topicName = Version.composeKafkaTopic(testStore, versionNum);
+
+    Version mockVersion = mock(Version.class);
+    when(mockVersion.isActiveActiveReplicationEnabled()).thenReturn(true);
+
+    Store mockStore = mock(Store.class);
+    when(mockStore.getVersion(versionNum)).thenReturn(mockVersion);
+
+    ReadOnlyStoreRepository mockStoreRepo = mock(ReadOnlyStoreRepository.class);
+    when(mockStoreRepo.getStoreOrThrow(testStore)).thenReturn(mockStore);
+
+    VeniceServerConfig mockServerConfig = mock(VeniceServerConfig.class);
+    when(mockServerConfig.isDaVinciClient()).thenReturn(false);
+    when(mockServerConfig.getStoreVersionMetadataWaitTimeMs()).thenReturn(1000L);
+
+    StorageEngine mockEngine = mock(StorageEngine.class);
+    StorageEngineFactory mockFactory = mock(StorageEngineFactory.class);
+
+    VeniceStoreVersionConfig mockStoreVersionConfig = mock(VeniceStoreVersionConfig.class);
+    when(mockStoreVersionConfig.getStoreVersionName()).thenReturn(topicName);
+    when(mockStoreVersionConfig.isStorePersistenceTypeKnown()).thenReturn(true);
+    when(mockStoreVersionConfig.getStorePersistenceType()).thenReturn(PersistenceType.ROCKS_DB);
+
+    when(mockEngine.getStoreVersionName()).thenReturn(topicName);
+
+    // Capture the boolean argument to verify RMD is enabled
+    ArgumentCaptor<Boolean> rmdCaptor = ArgumentCaptor.forClass(Boolean.class);
+    when(mockFactory.getStorageEngine(eq(mockStoreVersionConfig), rmdCaptor.capture())).thenReturn(mockEngine);
+
+    StorageService storageService =
+        createStorageServiceForRmdTest(mockStoreRepo, mockServerConfig, mockFactory, mockStoreVersionConfig);
+    storageService.openStore(mockStoreVersionConfig, () -> null);
+
+    Assert.assertTrue(rmdCaptor.getValue(), "RMD should be enabled when version-level AA is true");
+  }
+
+  /**
+   * Tests the retry path: version returns null initially, then becomes available after a few retries.
+   * Verifies that the retry loop correctly detects the version and returns the version-level AA config.
+   */
+  @Test(timeOut = 30_000)
+  public void testIsReplicationMetadataEnabledRetryPath() {
+    String testStore = "test_rmd_retry_store";
+    int versionNum = 1;
+    String topicName = Version.composeKafkaTopic(testStore, versionNum);
+
+    Version mockVersion = mock(Version.class);
+    when(mockVersion.isActiveActiveReplicationEnabled()).thenReturn(true);
+
+    // Version appears after the 3rd call to getVersion
+    AtomicInteger getVersionCallCount = new AtomicInteger(0);
+    Store mockStore = mock(Store.class);
+    when(mockStore.getVersion(versionNum)).thenAnswer(invocation -> {
+      int count = getVersionCallCount.incrementAndGet();
+      return count >= 3 ? mockVersion : null;
+    });
+
+    ReadOnlyStoreRepository mockStoreRepo = mock(ReadOnlyStoreRepository.class);
+    when(mockStoreRepo.getStoreOrThrow(testStore)).thenReturn(mockStore);
+
+    VeniceServerConfig mockServerConfig = mock(VeniceServerConfig.class);
+    when(mockServerConfig.isDaVinciClient()).thenReturn(false);
+    // Short wait time for test speed
+    when(mockServerConfig.getStoreVersionMetadataWaitTimeMs()).thenReturn(5000L);
+
+    StorageEngine mockEngine = mock(StorageEngine.class);
+    StorageEngineFactory mockFactory = mock(StorageEngineFactory.class);
+
+    VeniceStoreVersionConfig mockStoreVersionConfig = mock(VeniceStoreVersionConfig.class);
+    when(mockStoreVersionConfig.getStoreVersionName()).thenReturn(topicName);
+    when(mockStoreVersionConfig.isStorePersistenceTypeKnown()).thenReturn(true);
+    when(mockStoreVersionConfig.getStorePersistenceType()).thenReturn(PersistenceType.ROCKS_DB);
+
+    when(mockEngine.getStoreVersionName()).thenReturn(topicName);
+
+    ArgumentCaptor<Boolean> rmdCaptor = ArgumentCaptor.forClass(Boolean.class);
+    when(mockFactory.getStorageEngine(eq(mockStoreVersionConfig), rmdCaptor.capture())).thenReturn(mockEngine);
+
+    StorageService storageService =
+        createStorageServiceForRmdTest(mockStoreRepo, mockServerConfig, mockFactory, mockStoreVersionConfig);
+    storageService.openStore(mockStoreVersionConfig, () -> null);
+
+    Assert.assertTrue(rmdCaptor.getValue(), "RMD should be enabled after retry when version-level AA is true");
+    // Verify getVersion was called at least 3 times (1 initial + 2 retries in loop)
+    Assert.assertTrue(getVersionCallCount.get() >= 3, "getVersion should have been called at least 3 times");
+  }
+
+  /**
+   * Tests the fallback path: version never becomes available within the retry window,
+   * so the code falls back to the store-level Active-Active config.
+   */
+  @Test(timeOut = 30_000)
+  public void testIsReplicationMetadataEnabledFallbackPath() {
+    String testStore = "test_rmd_fallback_store";
+    int versionNum = 1;
+    String topicName = Version.composeKafkaTopic(testStore, versionNum);
+
+    Store mockStore = mock(Store.class);
+    // Version never becomes available
+    when(mockStore.getVersion(versionNum)).thenReturn(null);
+    // Store-level AA config is the fallback
+    when(mockStore.isActiveActiveReplicationEnabled()).thenReturn(true);
+
+    ReadOnlyStoreRepository mockStoreRepo = mock(ReadOnlyStoreRepository.class);
+    when(mockStoreRepo.getStoreOrThrow(testStore)).thenReturn(mockStore);
+
+    VeniceServerConfig mockServerConfig = mock(VeniceServerConfig.class);
+    when(mockServerConfig.isDaVinciClient()).thenReturn(false);
+    // Very short wait time so the test completes quickly
+    when(mockServerConfig.getStoreVersionMetadataWaitTimeMs()).thenReturn(100L);
+
+    StorageEngine mockEngine = mock(StorageEngine.class);
+    StorageEngineFactory mockFactory = mock(StorageEngineFactory.class);
+
+    VeniceStoreVersionConfig mockStoreVersionConfig = mock(VeniceStoreVersionConfig.class);
+    when(mockStoreVersionConfig.getStoreVersionName()).thenReturn(topicName);
+    when(mockStoreVersionConfig.isStorePersistenceTypeKnown()).thenReturn(true);
+    when(mockStoreVersionConfig.getStorePersistenceType()).thenReturn(PersistenceType.ROCKS_DB);
+
+    when(mockEngine.getStoreVersionName()).thenReturn(topicName);
+
+    ArgumentCaptor<Boolean> rmdCaptor = ArgumentCaptor.forClass(Boolean.class);
+    when(mockFactory.getStorageEngine(eq(mockStoreVersionConfig), rmdCaptor.capture())).thenReturn(mockEngine);
+
+    StorageService storageService =
+        createStorageServiceForRmdTest(mockStoreRepo, mockServerConfig, mockFactory, mockStoreVersionConfig);
+    storageService.openStore(mockStoreVersionConfig, () -> null);
+
+    Assert.assertTrue(
+        rmdCaptor.getValue(),
+        "RMD should be enabled via store-level AA fallback when version never becomes available");
+  }
+
+  /**
+   * Tests that when store-level AA is false and version is never available, the fallback correctly returns false.
+   */
+  @Test(timeOut = 30_000)
+  public void testIsReplicationMetadataEnabledFallbackReturnsFalse() {
+    String testStore = "test_rmd_fallback_false_store";
+    int versionNum = 1;
+    String topicName = Version.composeKafkaTopic(testStore, versionNum);
+
+    Store mockStore = mock(Store.class);
+    when(mockStore.getVersion(versionNum)).thenReturn(null);
+    // Store-level AA is disabled
+    when(mockStore.isActiveActiveReplicationEnabled()).thenReturn(false);
+
+    ReadOnlyStoreRepository mockStoreRepo = mock(ReadOnlyStoreRepository.class);
+    when(mockStoreRepo.getStoreOrThrow(testStore)).thenReturn(mockStore);
+
+    VeniceServerConfig mockServerConfig = mock(VeniceServerConfig.class);
+    when(mockServerConfig.isDaVinciClient()).thenReturn(false);
+    when(mockServerConfig.getStoreVersionMetadataWaitTimeMs()).thenReturn(100L);
+
+    StorageEngine mockEngine = mock(StorageEngine.class);
+    StorageEngineFactory mockFactory = mock(StorageEngineFactory.class);
+
+    VeniceStoreVersionConfig mockStoreVersionConfig = mock(VeniceStoreVersionConfig.class);
+    when(mockStoreVersionConfig.getStoreVersionName()).thenReturn(topicName);
+    when(mockStoreVersionConfig.isStorePersistenceTypeKnown()).thenReturn(true);
+    when(mockStoreVersionConfig.getStorePersistenceType()).thenReturn(PersistenceType.ROCKS_DB);
+
+    when(mockEngine.getStoreVersionName()).thenReturn(topicName);
+
+    ArgumentCaptor<Boolean> rmdCaptor = ArgumentCaptor.forClass(Boolean.class);
+    when(mockFactory.getStorageEngine(eq(mockStoreVersionConfig), rmdCaptor.capture())).thenReturn(mockEngine);
+
+    StorageService storageService =
+        createStorageServiceForRmdTest(mockStoreRepo, mockServerConfig, mockFactory, mockStoreVersionConfig);
+    storageService.openStore(mockStoreVersionConfig, () -> null);
+
+    Assert.assertFalse(
+        rmdCaptor.getValue(),
+        "RMD should be disabled when store-level AA is false and version is never available");
   }
 }

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/storage/StorageServiceTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/storage/StorageServiceTest.java
@@ -39,7 +39,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
-import java.util.concurrent.atomic.AtomicInteger;
 import org.apache.helix.PropertyKey;
 import org.apache.helix.model.IdealState;
 import org.apache.helix.zookeeper.datamodel.ZNRecord;
@@ -282,7 +281,6 @@ public class StorageServiceTest {
 
     VeniceServerConfig mockServerConfig = mock(VeniceServerConfig.class);
     when(mockServerConfig.isDaVinciClient()).thenReturn(false);
-    when(mockServerConfig.getStoreVersionMetadataWaitTimeMs()).thenReturn(1000L);
 
     StorageEngine mockEngine = mock(StorageEngine.class);
     StorageEngineFactory mockFactory = mock(StorageEngineFactory.class);
@@ -306,68 +304,17 @@ public class StorageServiceTest {
   }
 
   /**
-   * Tests the retry path: version returns null initially, then becomes available after a few retries.
-   * Verifies that the retry loop correctly detects the version and returns the version-level AA config.
+   * Tests the fallback path: version is null, so the code falls back to the store-level
+   * Active-Active config immediately (no retry in StorageService).
    */
-  @Test(timeOut = 30_000)
-  public void testIsReplicationMetadataEnabledRetryPath() {
-    String testStore = "test_rmd_retry_store";
-    int versionNum = 1;
-    String topicName = Version.composeKafkaTopic(testStore, versionNum);
-
-    Version mockVersion = mock(Version.class);
-    when(mockVersion.isActiveActiveReplicationEnabled()).thenReturn(true);
-
-    // Version appears after the 3rd call to getVersion
-    AtomicInteger getVersionCallCount = new AtomicInteger(0);
-    Store mockStore = mock(Store.class);
-    when(mockStore.getVersion(versionNum)).thenAnswer(invocation -> {
-      int count = getVersionCallCount.incrementAndGet();
-      return count >= 3 ? mockVersion : null;
-    });
-
-    ReadOnlyStoreRepository mockStoreRepo = mock(ReadOnlyStoreRepository.class);
-    when(mockStoreRepo.getStoreOrThrow(testStore)).thenReturn(mockStore);
-
-    VeniceServerConfig mockServerConfig = mock(VeniceServerConfig.class);
-    when(mockServerConfig.isDaVinciClient()).thenReturn(false);
-    // Short wait time for test speed
-    when(mockServerConfig.getStoreVersionMetadataWaitTimeMs()).thenReturn(5000L);
-
-    StorageEngine mockEngine = mock(StorageEngine.class);
-    StorageEngineFactory mockFactory = mock(StorageEngineFactory.class);
-
-    VeniceStoreVersionConfig mockStoreVersionConfig = mock(VeniceStoreVersionConfig.class);
-    when(mockStoreVersionConfig.getStoreVersionName()).thenReturn(topicName);
-    when(mockStoreVersionConfig.isStorePersistenceTypeKnown()).thenReturn(true);
-    when(mockStoreVersionConfig.getStorePersistenceType()).thenReturn(PersistenceType.ROCKS_DB);
-
-    when(mockEngine.getStoreVersionName()).thenReturn(topicName);
-
-    ArgumentCaptor<Boolean> rmdCaptor = ArgumentCaptor.forClass(Boolean.class);
-    when(mockFactory.getStorageEngine(eq(mockStoreVersionConfig), rmdCaptor.capture())).thenReturn(mockEngine);
-
-    StorageService storageService =
-        createStorageServiceForRmdTest(mockStoreRepo, mockServerConfig, mockFactory, mockStoreVersionConfig);
-    storageService.openStore(mockStoreVersionConfig, () -> null);
-
-    Assert.assertTrue(rmdCaptor.getValue(), "RMD should be enabled after retry when version-level AA is true");
-    // Verify getVersion was called at least 3 times (1 initial + 2 retries in loop)
-    Assert.assertTrue(getVersionCallCount.get() >= 3, "getVersion should have been called at least 3 times");
-  }
-
-  /**
-   * Tests the fallback path: version never becomes available within the retry window,
-   * so the code falls back to the store-level Active-Active config.
-   */
-  @Test(timeOut = 30_000)
-  public void testIsReplicationMetadataEnabledFallbackPath() {
+  @Test
+  public void testIsReplicationMetadataEnabledFallbackToStoreLevel() {
     String testStore = "test_rmd_fallback_store";
     int versionNum = 1;
     String topicName = Version.composeKafkaTopic(testStore, versionNum);
 
     Store mockStore = mock(Store.class);
-    // Version never becomes available
+    // Version is not available
     when(mockStore.getVersion(versionNum)).thenReturn(null);
     // Store-level AA config is the fallback
     when(mockStore.isActiveActiveReplicationEnabled()).thenReturn(true);
@@ -377,8 +324,6 @@ public class StorageServiceTest {
 
     VeniceServerConfig mockServerConfig = mock(VeniceServerConfig.class);
     when(mockServerConfig.isDaVinciClient()).thenReturn(false);
-    // Very short wait time so the test completes quickly
-    when(mockServerConfig.getStoreVersionMetadataWaitTimeMs()).thenReturn(100L);
 
     StorageEngine mockEngine = mock(StorageEngine.class);
     StorageEngineFactory mockFactory = mock(StorageEngineFactory.class);
@@ -399,13 +344,13 @@ public class StorageServiceTest {
 
     Assert.assertTrue(
         rmdCaptor.getValue(),
-        "RMD should be enabled via store-level AA fallback when version never becomes available");
+        "RMD should be enabled via store-level AA fallback when version is not available");
   }
 
   /**
-   * Tests that when store-level AA is false and version is never available, the fallback correctly returns false.
+   * Tests that when store-level AA is false and version is not available, the fallback correctly returns false.
    */
-  @Test(timeOut = 30_000)
+  @Test
   public void testIsReplicationMetadataEnabledFallbackReturnsFalse() {
     String testStore = "test_rmd_fallback_false_store";
     int versionNum = 1;
@@ -421,7 +366,6 @@ public class StorageServiceTest {
 
     VeniceServerConfig mockServerConfig = mock(VeniceServerConfig.class);
     when(mockServerConfig.isDaVinciClient()).thenReturn(false);
-    when(mockServerConfig.getStoreVersionMetadataWaitTimeMs()).thenReturn(100L);
 
     StorageEngine mockEngine = mock(StorageEngine.class);
     StorageEngineFactory mockFactory = mock(StorageEngineFactory.class);
@@ -442,6 +386,6 @@ public class StorageServiceTest {
 
     Assert.assertFalse(
         rmdCaptor.getValue(),
-        "RMD should be disabled when store-level AA is false and version is never available");
+        "RMD should be disabled when store-level AA is false and version is not available");
   }
 }

--- a/internal/venice-client-common/src/main/java/com/linkedin/venice/utils/RetryUtils.java
+++ b/internal/venice-client-common/src/main/java/com/linkedin/venice/utils/RetryUtils.java
@@ -111,6 +111,28 @@ public class RetryUtils {
   }
 
   /**
+   * Same as {@link #executeWithMaxAttemptAndExponentialBackoff(VeniceCheckedRunnable, int, Duration, Duration, Duration, List)}
+   * but suppresses intermediate failure logging. Useful for high-frequency retries where per-attempt WARN
+   * logs would create excessive noise.
+   */
+  public static void executeWithMaxAttemptAndExponentialBackoffNoIntermediateLog(
+      VeniceCheckedRunnable runnable,
+      final int maxAttempt,
+      Duration initialDelay,
+      Duration maxDelay,
+      Duration maxDuration,
+      List<Class<? extends Throwable>> retryFailureTypes) {
+    executeWithMaxAttemptAndExponentialBackoff(
+        runnable,
+        maxAttempt,
+        initialDelay,
+        maxDelay,
+        maxDuration,
+        retryFailureTypes,
+        RetryUtils::doNotLog);
+  }
+
+  /**
    * Execute a {@link Runnable} with exponential backoff. If all attempts are made or the max duration has reached
    * and still no success, the last thrown exception will be thrown.
    *

--- a/internal/venice-client-common/src/main/java/com/linkedin/venice/utils/RetryUtils.java
+++ b/internal/venice-client-common/src/main/java/com/linkedin/venice/utils/RetryUtils.java
@@ -111,28 +111,6 @@ public class RetryUtils {
   }
 
   /**
-   * Same as {@link #executeWithMaxAttemptAndExponentialBackoff(VeniceCheckedRunnable, int, Duration, Duration, Duration, List)}
-   * but suppresses intermediate failure logging. Useful for high-frequency retries where per-attempt WARN
-   * logs would create excessive noise.
-   */
-  public static void executeWithMaxAttemptAndExponentialBackoffNoIntermediateLog(
-      VeniceCheckedRunnable runnable,
-      final int maxAttempt,
-      Duration initialDelay,
-      Duration maxDelay,
-      Duration maxDuration,
-      List<Class<? extends Throwable>> retryFailureTypes) {
-    executeWithMaxAttemptAndExponentialBackoff(
-        runnable,
-        maxAttempt,
-        initialDelay,
-        maxDelay,
-        maxDuration,
-        retryFailureTypes,
-        RetryUtils::doNotLog);
-  }
-
-  /**
    * Execute a {@link Runnable} with exponential backoff. If all attempts are made or the max duration has reached
    * and still no success, the last thrown exception will be thrown.
    *

--- a/internal/venice-common/src/main/java/com/linkedin/venice/ConfigKeys.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/ConfigKeys.java
@@ -1008,12 +1008,12 @@ public class ConfigKeys {
 
   /**
    * Maximum duration (in milliseconds) to wait for version metadata to become available in the store repository
-   * when determining whether replication metadata (RMD) should be enabled for a storage engine. During
-   * OFFLINE-to-STANDBY state transitions, version metadata may not yet be propagated from ZK. This config controls
-   * how long to retry with exponential backoff before falling back to the store-level Active-Active config.
-   * Default: 180000 (3 minutes).
+   * during Helix state transitions. Version metadata may not yet be propagated from ZK when the OFFLINE-to-STANDBY
+   * transition fires. This config controls how long to retry with exponential backoff before failing the state
+   * transition. Default: 300000 (5 minutes).
    */
-  public static final String SERVER_STORE_VERSION_METADATA_WAIT_TIME_MS = "server.store.version.metadata.wait.time.ms";
+  public static final String SERVER_STORE_VERSION_METADATA_WAIT_DURING_STATE_TRANSITION_TIME_MS =
+      "server.store.version.metadata.wait.during.state.transition.time.ms";
 
   /**
    * This config decides the frequency of the disk health check; the disk health check service writes

--- a/internal/venice-common/src/main/java/com/linkedin/venice/ConfigKeys.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/ConfigKeys.java
@@ -1007,6 +1007,15 @@ public class ConfigKeys {
   public static final String SERVER_MAX_WAIT_FOR_VERSION_INFO_MS_CONFIG = "server.max.wait.for.version.info.ms";
 
   /**
+   * Maximum duration (in milliseconds) to wait for version metadata to become available in the store repository
+   * when determining whether replication metadata (RMD) should be enabled for a storage engine. During
+   * OFFLINE-to-STANDBY state transitions, version metadata may not yet be propagated from ZK. This config controls
+   * how long to retry with exponential backoff before falling back to the store-level Active-Active config.
+   * Default: 180000 (3 minutes).
+   */
+  public static final String SERVER_STORE_VERSION_METADATA_WAIT_TIME_MS = "server.store.version.metadata.wait.time.ms";
+
+  /**
    * This config decides the frequency of the disk health check; the disk health check service writes
    * 64KB data to a temporary file in the database directory and read from the file for each health check.
    */

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/integration/utils/VeniceServerWrapper.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/integration/utils/VeniceServerWrapper.java
@@ -224,7 +224,7 @@ public class VeniceServerWrapper extends ProcessWrapper implements MetricsAware 
           .put(SERVER_PARTITION_GRACEFUL_DROP_DELAY_IN_SECONDS, 0)
           .put(PARTICIPANT_MESSAGE_CONSUMPTION_DELAY_MS, 1000)
           .put(SERVER_MAX_WAIT_FOR_VERSION_INFO_MS_CONFIG, 1000)
-          .put(SERVER_STORE_VERSION_METADATA_WAIT_TIME_MS, 1000)
+          .put(SERVER_STORE_VERSION_METADATA_WAIT_DURING_STATE_TRANSITION_TIME_MS, 1000)
           .put(KAFKA_READ_CYCLE_DELAY_MS, 50)
           .put(SERVER_DISK_FULL_THRESHOLD, 0.99) // Minimum free space is required in tests
           .put(SYSTEM_SCHEMA_CLUSTER_NAME, clusterName)

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/integration/utils/VeniceServerWrapper.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/integration/utils/VeniceServerWrapper.java
@@ -224,6 +224,7 @@ public class VeniceServerWrapper extends ProcessWrapper implements MetricsAware 
           .put(SERVER_PARTITION_GRACEFUL_DROP_DELAY_IN_SECONDS, 0)
           .put(PARTICIPANT_MESSAGE_CONSUMPTION_DELAY_MS, 1000)
           .put(SERVER_MAX_WAIT_FOR_VERSION_INFO_MS_CONFIG, 1000)
+          .put(SERVER_STORE_VERSION_METADATA_WAIT_TIME_MS, 1000)
           .put(KAFKA_READ_CYCLE_DELAY_MS, 50)
           .put(SERVER_DISK_FULL_THRESHOLD, 0.99) // Minimum free space is required in tests
           .put(SYSTEM_SCHEMA_CLUSTER_NAME, clusterName)


### PR DESCRIPTION
## Summary

Fixes a race condition where version metadata may not be available in the store repository when a Helix OFFLINE-to-STANDBY state transition fires. This causes the storage engine to be created without RMD (Replication Metadata) support, permanently cached via `computeIfAbsent`, leading to `VeniceUnsupportedOperationException: putWithReplicationMetadata is not supported` when Active-Active records arrive.

**Root cause:** Two independent ZK watch paths race — Helix IdealState watch (triggers state transition) vs Venice StoreRepository watch (updates version metadata). When the Helix watch fires first, `getVersion()` returns null. Observed in production during a Venice ZK ensemble propagation latency spike (15-17s) in prod-lva1.

### Changes

- **`AbstractPartitionStateModel.java`**: Added `waitForVersionToBeAvailable()` using `RetryUtils.executeWithMaxAttemptAndExponentialBackoff` (10ms initial, 200ms max delay, configurable max duration). Called at the start of `setupNewStorePartition()` before the storage engine is created. **Throws `VeniceException`** if version never appears — replica goes to ERROR state rather than silently creating the wrong partition type.
- **`StorageService.java`**: Simplified `isReplicationMetadataEnabled()` — when `getVersion()` returns null, falls back to store-level `activeActiveReplicationEnabled` as a safety net (no retry logic here).
- **`ConfigKeys.java`**: Added `SERVER_STORE_VERSION_METADATA_WAIT_DURING_STATE_TRANSITION_TIME_MS` config key.
- **`VeniceServerConfig.java`**: Added config field (default: 300,000ms / 5 minutes).
- **`VeniceServerWrapper.java`**: Set to 1000ms in integration test defaults for fast tests.

### Tests

- `AbstractVenicePartitionStateModelTest`: 3 new tests — happy path (version available immediately), retry success (version appears after retries), exhaustion (throws VeniceException with message validation via `Assert.expectThrows`)
- `StorageServiceTest`: 3 tests — happy path, fallback to store-level AA (true), fallback (false)
- All existing `LeaderFollowerPartitionStateModelTest` tests updated and passing

## Testing Done

- All unit tests pass (`StorageServiceTest`, `AbstractVenicePartitionStateModelTest`, `LeaderFollowerPartitionStateModelTest`)
- Pre-commit hooks (spotless) pass
- Integration test config uses 1s wait time to avoid test slowdowns