### PR TITLE
[server] Fix AvroCollectionElementComparator to handle records with nested map fields

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/schema/merge/AvroCollectionElementComparator.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/schema/merge/AvroCollectionElementComparator.java
@@ -1,12 +1,13 @@
 package com.linkedin.davinci.schema.merge;
 
 import com.linkedin.davinci.utils.IndexedHashMap;
-import com.linkedin.venice.utils.AvroSchemaUtils;
+import java.util.List;
 import java.util.Map;
 import javax.annotation.concurrent.ThreadSafe;
 import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericContainer;
 import org.apache.avro.generic.GenericData;
+import org.apache.avro.generic.GenericRecord;
 import org.apache.commons.lang.Validate;
 
 
@@ -35,27 +36,66 @@ public class AvroCollectionElementComparator {
    */
   public int compare(Object o1, Object o2, Schema schema) {
     Validate.notNull(schema);
-    if (isMapOrNullableMap(schema)) {
-      return compareMaps(validateAndCastToMapType(o1), validateAndCastToMapType(o2));
+    if (o1 == o2) {
+      return 0;
     }
-    return GenericData.get().compare(o1, o2, schema);
+    switch (schema.getType()) {
+      case MAP:
+        return compareMaps(validateAndCastToMapType(o1), validateAndCastToMapType(o2), schema);
+      case RECORD:
+        return compareRecords((GenericRecord) o1, (GenericRecord) o2, schema);
+      case ARRAY:
+        return compareArrays((List<?>) o1, (List<?>) o2, schema);
+      case UNION:
+        return compareUnion(o1, o2, schema);
+      default:
+        return GenericData.get().compare(o1, o2, schema);
+    }
   }
 
-  private boolean isMapOrNullableMap(Schema schema) {
-    if (schema.getType() == Schema.Type.MAP) {
-      return true;
+  private int compareRecords(GenericRecord r1, GenericRecord r2, Schema schema) {
+    for (Schema.Field field: schema.getFields()) {
+      if (field.order() == Schema.Field.Order.IGNORE) {
+        continue;
+      }
+      int pos = field.pos();
+      int cmp = compare(r1.get(pos), r2.get(pos), field.schema());
+      if (cmp != 0) {
+        return field.order() == Schema.Field.Order.DESCENDING ? -cmp : cmp;
+      }
     }
-    return AvroSchemaUtils.isNullableUnionPair(schema) && (schema.getTypes().get(0).getType() == Schema.Type.MAP
-        || schema.getTypes().get(1).getType() == Schema.Type.MAP);
+    return 0;
   }
 
-  private int compareMaps(IndexedHashMap<String, Object> map1, IndexedHashMap<String, Object> map2) {
+  private int compareArrays(List<?> a1, List<?> a2, Schema arraySchema) {
+    Schema elementSchema = arraySchema.getElementType();
+    int minSize = Math.min(a1.size(), a2.size());
+    for (int i = 0; i < minSize; i++) {
+      int cmp = compare(a1.get(i), a2.get(i), elementSchema);
+      if (cmp != 0) {
+        return cmp;
+      }
+    }
+    return Integer.compare(a1.size(), a2.size());
+  }
+
+  private int compareUnion(Object o1, Object o2, Schema unionSchema) {
+    int index1 = GenericData.get().resolveUnion(unionSchema, o1);
+    int index2 = GenericData.get().resolveUnion(unionSchema, o2);
+    if (index1 != index2) {
+      return Integer.compare(index1, index2);
+    }
+    return compare(o1, o2, unionSchema.getTypes().get(index1));
+  }
+
+  private int compareMaps(IndexedHashMap<String, Object> map1, IndexedHashMap<String, Object> map2, Schema mapSchema) {
     if (map1 == map2) {
       return 0;
     }
     if (map1.size() != map2.size()) {
       return map1.size() > map2.size() ? 1 : -1;
     }
+    Schema valueSchema = mapSchema.getValueType();
     boolean schemaCompared = false;
 
     // Same size
@@ -68,19 +108,24 @@ public class AvroCollectionElementComparator {
         return keyCompareResult;
       }
       // Same key. So compare values and assume that every value has the same schema in a map.
-      Schema schema = ((GenericContainer) entry1.getValue()).getSchema();
-      if (!schemaCompared) {
-        Schema otherEntrySchema = ((GenericContainer) entry2.getValue()).getSchema();
-        final int schemaCompareResult = compareSchemas(schema, otherEntrySchema);
-        if (schemaCompareResult == 0) {
-          schemaCompared = true;
-        } else {
-          // Schemas are different in two maps.
-          return schemaCompareResult;
+      // For GenericContainer values, use the actual value schema to handle schema evolution.
+      // For primitive values, use the map schema's value type.
+      Schema effectiveValueSchema = valueSchema;
+      if (entry1.getValue() instanceof GenericContainer) {
+        effectiveValueSchema = ((GenericContainer) entry1.getValue()).getSchema();
+        if (!schemaCompared) {
+          Schema otherEntrySchema = ((GenericContainer) entry2.getValue()).getSchema();
+          final int schemaCompareResult = compareSchemas(effectiveValueSchema, otherEntrySchema);
+          if (schemaCompareResult == 0) {
+            schemaCompared = true;
+          } else {
+            // Schemas are different in two maps.
+            return schemaCompareResult;
+          }
         }
       }
 
-      final int compareValueResult = compare(entry1.getValue(), entry2.getValue(), schema);
+      final int compareValueResult = compare(entry1.getValue(), entry2.getValue(), effectiveValueSchema);
       if (compareValueResult != 0) {
         return compareValueResult;
       }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/schema/merge/AvroCollectionElementComparator.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/schema/merge/AvroCollectionElementComparator.java
@@ -61,7 +61,7 @@ public class AvroCollectionElementComparator {
       int pos = field.pos();
       int cmp = compare(r1.get(pos), r2.get(pos), field.schema());
       if (cmp != 0) {
-        return field.order() == Schema.Field.Order.DESCENDING ? -cmp : cmp;
+        return field.order() == Schema.Field.Order.DESCENDING ? Integer.compare(0, cmp) : cmp;
       }
     }
     return 0;
@@ -109,9 +109,9 @@ public class AvroCollectionElementComparator {
       }
       // Same key. So compare values and assume that every value has the same schema in a map.
       // For GenericContainer values, use the actual value schema to handle schema evolution.
-      // For primitive values, use the map schema's value type.
+      // For primitive/null values, use the map schema's declared value type.
       Schema effectiveValueSchema = valueSchema;
-      if (entry1.getValue() instanceof GenericContainer) {
+      if (entry1.getValue() instanceof GenericContainer && entry2.getValue() instanceof GenericContainer) {
         effectiveValueSchema = ((GenericContainer) entry1.getValue()).getSchema();
         if (!schemaCompared) {
           Schema otherEntrySchema = ((GenericContainer) entry2.getValue()).getSchema();

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/schema/merge/AvroCollectionElementComparatorTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/schema/merge/AvroCollectionElementComparatorTest.java
@@ -7,6 +7,7 @@ import static org.testng.Assert.assertTrue;
 
 import com.linkedin.avroutil1.compatibility.AvroCompatibilityHelper;
 import com.linkedin.davinci.utils.IndexedHashMap;
+import java.util.Arrays;
 import java.util.Collections;
 import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericData;
@@ -109,6 +110,66 @@ public class AvroCollectionElementComparatorTest {
     map1.put("k1", genericRecord);
     map1.put("k2", genericRecord);
     assertEquals(INSTANCE.compare(map, map1, Schema.createMap(schema)), 0);
+  }
+
+  @Test
+  public void testCompareRecordWithNestedMapField() {
+    // This reproduces the "Can't compare maps!" error from GenericData.compare() when
+    // list elements are records containing map fields.
+    Schema mapFieldSchema = Schema.createMap(Schema.create(Schema.Type.STRING));
+    Schema.Field intField =
+        AvroCompatibilityHelper.newField(null).setSchema(Schema.create(Schema.Type.INT)).setName("id").build();
+    Schema.Field mapField =
+        AvroCompatibilityHelper.newField(null).setSchema(mapFieldSchema).setName("attributes").build();
+    Schema recordSchema = Schema.createRecord("RecordWithMap", "test", "com.linkedin.venice.test", false);
+    recordSchema.setFields(Arrays.asList(intField, mapField));
+
+    IndexedHashMap<String, Object> map1 = new IndexedHashMap<>();
+    map1.put("key1", "value1");
+    GenericRecord r1 = new GenericData.Record(recordSchema);
+    r1.put("id", 1);
+    r1.put("attributes", map1);
+
+    IndexedHashMap<String, Object> map2 = new IndexedHashMap<>();
+    map2.put("key1", "value1");
+    GenericRecord r2 = new GenericData.Record(recordSchema);
+    r2.put("id", 1);
+    r2.put("attributes", map2);
+
+    // Same content should be equal
+    assertEquals(INSTANCE.compare(r1, r2, recordSchema), 0);
+
+    // Different id field should produce non-zero
+    r2.put("id", 2);
+    assertTrue(INSTANCE.compare(r1, r2, recordSchema) < 0);
+
+    // Same id, different map content
+    r2.put("id", 1);
+    IndexedHashMap<String, Object> map3 = new IndexedHashMap<>();
+    map3.put("key2", "value2");
+    r2.put("attributes", map3);
+    assertNotEquals(INSTANCE.compare(r1, r2, recordSchema), 0);
+  }
+
+  @Test
+  public void testCompareRecordWithNestedNullableMapField() {
+    Schema mapSchema = Schema.createMap(Schema.create(Schema.Type.STRING));
+    Schema nullableMapSchema = Schema.createUnion(Schema.create(Schema.Type.NULL), mapSchema);
+    Schema.Field nullableMapField =
+        AvroCompatibilityHelper.newField(null).setSchema(nullableMapSchema).setName("attributes").build();
+    Schema recordSchema = Schema.createRecord("RecordWithNullableMap", "test", "com.linkedin.venice.test", false);
+    recordSchema.setFields(Collections.singletonList(nullableMapField));
+
+    IndexedHashMap<String, Object> map1 = new IndexedHashMap<>();
+    map1.put("k", "v");
+    GenericRecord r1 = new GenericData.Record(recordSchema);
+    r1.put("attributes", map1);
+
+    GenericRecord r2 = new GenericData.Record(recordSchema);
+    r2.put("attributes", null);
+
+    // Non-null vs null: null branch (index 0) < map branch (index 1)
+    assertTrue(INSTANCE.compare(r1, r2, recordSchema) > 0);
   }
 
   @Test

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/schema/merge/AvroCollectionElementComparatorTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/schema/merge/AvroCollectionElementComparatorTest.java
@@ -218,8 +218,8 @@ public class AvroCollectionElementComparatorTest {
 
   @Test
   public void testCompareMapWithNullableUnionValues() {
-    // Tests the fix for Copilot's review: when map value schema is a union and one value is null
-    // while the other is a GenericContainer, the old code would NPE on the entry2 cast.
+    // Regression: when map value schema is a union (e.g. ["null", "record"]) and one entry value is null
+    // while the other is a GenericContainer, compareMaps must not cast entry2 unconditionally.
     Schema recordSchema = Schema.createRecord("Inner", "test", "com.linkedin.venice.test", false);
     Schema.Field intField =
         AvroCompatibilityHelper.newField(null).setSchema(Schema.create(Schema.Type.INT)).setName("val").build();

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/schema/merge/AvroCollectionElementComparatorTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/schema/merge/AvroCollectionElementComparatorTest.java
@@ -173,6 +173,81 @@ public class AvroCollectionElementComparatorTest {
   }
 
   @Test
+  public void testCompareMapWithPrimitiveValuesSameKeysDifferentValues() {
+    // Regression test: old code would ClassCastException (Integer cannot be cast to GenericContainer)
+    // when comparing maps with primitive values that share the same keys.
+    IndexedHashMap<String, Integer> map1 = new IndexedHashMap<>();
+    map1.put("k1", 1);
+    IndexedHashMap<String, Integer> map2 = new IndexedHashMap<>();
+    map2.put("k1", 2);
+    assertTrue(INSTANCE.compare(map1, map2, Schema.createMap(Schema.create(Schema.Type.INT))) < 0);
+    assertTrue(INSTANCE.compare(map2, map1, Schema.createMap(Schema.create(Schema.Type.INT))) > 0);
+
+    // Equal values
+    IndexedHashMap<String, Integer> map3 = new IndexedHashMap<>();
+    map3.put("k1", 1);
+    assertEquals(INSTANCE.compare(map1, map3, Schema.createMap(Schema.create(Schema.Type.INT))), 0);
+  }
+
+  @Test
+  public void testCompareRecordWithNestedArrayField() {
+    Schema arraySchema = Schema.createArray(Schema.create(Schema.Type.STRING));
+    Schema.Field arrayField = AvroCompatibilityHelper.newField(null).setSchema(arraySchema).setName("tags").build();
+    Schema recordSchema = Schema.createRecord("RecordWithArray", "test", "com.linkedin.venice.test", false);
+    recordSchema.setFields(Collections.singletonList(arrayField));
+
+    GenericRecord r1 = new GenericData.Record(recordSchema);
+    r1.put("tags", Arrays.asList("a", "b"));
+    GenericRecord r2 = new GenericData.Record(recordSchema);
+    r2.put("tags", Arrays.asList("a", "c"));
+
+    // "b" < "c"
+    assertTrue(INSTANCE.compare(r1, r2, recordSchema) < 0);
+
+    // Equal arrays
+    GenericRecord r3 = new GenericData.Record(recordSchema);
+    r3.put("tags", Arrays.asList("a", "b"));
+    assertEquals(INSTANCE.compare(r1, r3, recordSchema), 0);
+
+    // Different lengths: [a, b] vs [a, b, c]
+    GenericRecord r4 = new GenericData.Record(recordSchema);
+    r4.put("tags", Arrays.asList("a", "b", "c"));
+    assertTrue(INSTANCE.compare(r1, r4, recordSchema) < 0);
+    assertTrue(INSTANCE.compare(r4, r1, recordSchema) > 0);
+  }
+
+  @Test
+  public void testCompareMapWithNullableUnionValues() {
+    // Tests the fix for Copilot's review: when map value schema is a union and one value is null
+    // while the other is a GenericContainer, the old code would NPE on the entry2 cast.
+    Schema recordSchema = Schema.createRecord("Inner", "test", "com.linkedin.venice.test", false);
+    Schema.Field intField =
+        AvroCompatibilityHelper.newField(null).setSchema(Schema.create(Schema.Type.INT)).setName("val").build();
+    recordSchema.setFields(Collections.singletonList(intField));
+
+    Schema nullableRecordSchema = Schema.createUnion(Schema.create(Schema.Type.NULL), recordSchema);
+    Schema mapSchema = Schema.createMap(nullableRecordSchema);
+
+    GenericRecord inner = new GenericData.Record(recordSchema);
+    inner.put("val", 42);
+
+    // map1 has a non-null value, map2 has a null value for the same key
+    IndexedHashMap<String, Object> map1 = new IndexedHashMap<>();
+    map1.put("k1", inner);
+    IndexedHashMap<String, Object> map2 = new IndexedHashMap<>();
+    map2.put("k1", null);
+
+    // null branch (index 0) < record branch (index 1), so map2 < map1
+    assertTrue(INSTANCE.compare(map1, map2, mapSchema) > 0);
+    assertTrue(INSTANCE.compare(map2, map1, mapSchema) < 0);
+
+    // Both null
+    IndexedHashMap<String, Object> map3 = new IndexedHashMap<>();
+    map3.put("k1", null);
+    assertEquals(INSTANCE.compare(map2, map3, mapSchema), 0);
+  }
+
+  @Test
   public void testCompareWhenSchemaIsMapAndObjectsAreIndexedHashMaps() {
     IndexedHashMap<String, Integer> map1 = new IndexedHashMap<>();
     map1.put("k1", 1);

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/schema/merge/AvroCollectionElementComparatorTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/schema/merge/AvroCollectionElementComparatorTest.java
@@ -248,6 +248,116 @@ public class AvroCollectionElementComparatorTest {
   }
 
   @Test
+  public void testCompareArrayOfRecordsWithMapFields() {
+    // 3-level recursion: ARRAY -> RECORD -> MAP -> primitive
+    // This is the real-world scenario: collection list elements are records containing map fields.
+    Schema mapFieldSchema = Schema.createMap(Schema.create(Schema.Type.STRING));
+    Schema.Field idField =
+        AvroCompatibilityHelper.newField(null).setSchema(Schema.create(Schema.Type.INT)).setName("id").build();
+    Schema.Field attrField = AvroCompatibilityHelper.newField(null).setSchema(mapFieldSchema).setName("attrs").build();
+    Schema elemSchema = Schema.createRecord("Element", "test", "com.linkedin.venice.test", false);
+    elemSchema.setFields(Arrays.asList(idField, attrField));
+    Schema arraySchema = Schema.createArray(elemSchema);
+
+    IndexedHashMap<String, Object> m1 = new IndexedHashMap<>();
+    m1.put("color", "red");
+    GenericRecord e1 = new GenericData.Record(elemSchema);
+    e1.put("id", 1);
+    e1.put("attrs", m1);
+
+    IndexedHashMap<String, Object> m2 = new IndexedHashMap<>();
+    m2.put("color", "red");
+    GenericRecord e2 = new GenericData.Record(elemSchema);
+    e2.put("id", 1);
+    e2.put("attrs", m2);
+
+    // Equal arrays of records
+    assertEquals(INSTANCE.compare(Arrays.asList(e1), Arrays.asList(e2), arraySchema), 0);
+
+    // Differ at record primitive field
+    GenericRecord e3 = new GenericData.Record(elemSchema);
+    e3.put("id", 2);
+    e3.put("attrs", m2);
+    assertTrue(INSTANCE.compare(Arrays.asList(e1), Arrays.asList(e3), arraySchema) < 0);
+
+    // Same id, differ at nested map value
+    IndexedHashMap<String, Object> m3 = new IndexedHashMap<>();
+    m3.put("color", "blue");
+    GenericRecord e4 = new GenericData.Record(elemSchema);
+    e4.put("id", 1);
+    e4.put("attrs", m3);
+    assertNotEquals(INSTANCE.compare(Arrays.asList(e1), Arrays.asList(e4), arraySchema), 0);
+
+    // Multiple elements: first equal, second differs
+    assertTrue(INSTANCE.compare(Arrays.asList(e1, e1), Arrays.asList(e1, e3), arraySchema) < 0);
+  }
+
+  @Test
+  public void testCompareNestedRecords() {
+    // 2-level record recursion: RECORD -> RECORD -> primitive
+    Schema innerSchema = Schema.createRecord("Inner", "test", "com.linkedin.venice.test", false);
+    Schema.Field valField =
+        AvroCompatibilityHelper.newField(null).setSchema(Schema.create(Schema.Type.INT)).setName("val").build();
+    innerSchema.setFields(Collections.singletonList(valField));
+
+    Schema outerSchema = Schema.createRecord("Outer", "test", "com.linkedin.venice.test", false);
+    Schema.Field nameField =
+        AvroCompatibilityHelper.newField(null).setSchema(Schema.create(Schema.Type.STRING)).setName("name").build();
+    Schema.Field nestedField = AvroCompatibilityHelper.newField(null).setSchema(innerSchema).setName("nested").build();
+    outerSchema.setFields(Arrays.asList(nameField, nestedField));
+
+    GenericRecord inner1 = new GenericData.Record(innerSchema);
+    inner1.put("val", 10);
+    GenericRecord outer1 = new GenericData.Record(outerSchema);
+    outer1.put("name", "a");
+    outer1.put("nested", inner1);
+
+    GenericRecord inner2 = new GenericData.Record(innerSchema);
+    inner2.put("val", 10);
+    GenericRecord outer2 = new GenericData.Record(outerSchema);
+    outer2.put("name", "a");
+    outer2.put("nested", inner2);
+
+    // Equal
+    assertEquals(INSTANCE.compare(outer1, outer2, outerSchema), 0);
+
+    // Differ at inner record field
+    inner2.put("val", 20);
+    assertTrue(INSTANCE.compare(outer1, outer2, outerSchema) < 0);
+
+    // Differ at outer field (short-circuits before reaching inner)
+    outer2.put("name", "b");
+    assertTrue(INSTANCE.compare(outer1, outer2, outerSchema) < 0);
+  }
+
+  @Test
+  public void testCompareNestedMaps() {
+    // MAP -> MAP -> primitive (map whose values are maps)
+    Schema innerMapSchema = Schema.createMap(Schema.create(Schema.Type.INT));
+    Schema outerMapSchema = Schema.createMap(innerMapSchema);
+
+    IndexedHashMap<String, Object> innerMap1 = new IndexedHashMap<>();
+    innerMap1.put("x", 1);
+    IndexedHashMap<String, Object> outerMap1 = new IndexedHashMap<>();
+    outerMap1.put("k", innerMap1);
+
+    IndexedHashMap<String, Object> innerMap2 = new IndexedHashMap<>();
+    innerMap2.put("x", 1);
+    IndexedHashMap<String, Object> outerMap2 = new IndexedHashMap<>();
+    outerMap2.put("k", innerMap2);
+
+    // Equal
+    assertEquals(INSTANCE.compare(outerMap1, outerMap2, outerMapSchema), 0);
+
+    // Differ at inner map value
+    IndexedHashMap<String, Object> innerMap3 = new IndexedHashMap<>();
+    innerMap3.put("x", 2);
+    IndexedHashMap<String, Object> outerMap3 = new IndexedHashMap<>();
+    outerMap3.put("k", innerMap3);
+    assertTrue(INSTANCE.compare(outerMap1, outerMap3, outerMapSchema) < 0);
+  }
+
+  @Test
   public void testCompareWhenSchemaIsMapAndObjectsAreIndexedHashMaps() {
     IndexedHashMap<String, Integer> map1 = new IndexedHashMap<>();
     map1.put("k1", 1);


### PR DESCRIPTION
## Problem Statement

During Active-Active ingestion, `SortBasedCollectionFieldOpHandler` sorts list elements using `AvroCollectionElementComparator` when timestamps are equal. The comparator only handled direct MAP schemas (and nullable MAP unions) — for all other types, it delegated to Avro's `GenericData.compare()`.

However, `GenericData.compare()` throws `AvroRuntimeException: Can't compare maps!` when it encounters a MAP field at **any nesting depth**. This means when a list element is a **RECORD containing MAP fields**, the sort crashes and kills ingestion for the entire partition:

```
org.apache.avro.AvroRuntimeException: Can't compare maps!
    at org.apache.avro.generic.GenericData.compare(GenericData.java:1146)
    at com.linkedin.davinci.schema.merge.AvroCollectionElementComparator.compare(AvroCollectionElementComparator.java:41)
    at com.linkedin.davinci.schema.merge.SortBasedCollectionFieldOpHandler.lambda$sortElementAndTimestampList$5(...)
```

## Solution

Replace the two-branch comparison (map vs. everything-else) in `AvroCollectionElementComparator.compare()` with a recursive comparator that handles all container types natively, so `GenericData.compare()` is only ever called on primitive/leaf types where it is safe.

### Recursive dispatch structure

`compare()` is the central dispatch hub. Each container handler recurses back through it:

| Schema type | Handler | Recurses via |
|---|---|---|
| `RECORD` | `compareRecords` | `compare(r1.get(pos), r2.get(pos), field.schema())` per field |
| `ARRAY` | `compareArrays` | `compare(a1.get(i), a2.get(i), elementSchema)` per element |
| `UNION` | `compareUnion` | `compare(o1, o2, resolvedBranchSchema)` after resolving the union branch |
| `MAP` | `compareMaps` | `compare(entry1.getValue(), entry2.getValue(), effectiveValueSchema)` per entry |
| primitives | (base case) | `GenericData.get().compare()` — safe for non-container types |

Handler details:
- **RECORD** — compares field-by-field recursively, respecting field sort order (`ASCENDING`/`DESCENDING`/`IGNORE`), mirroring `GenericData.compare()` logic but routing each field through our own `compare()`. Uses `Integer.compare(0, cmp)` for safe negation (avoids `Integer.MIN_VALUE` overflow flagged by SpotBugs).
- **ARRAY** — compares element-by-element recursively, then by length.
- **UNION** — resolves the actual union branch via `GenericData.resolveUnion()` and recurses. This generalizes the old hardcoded `isMapOrNullableMap` check to handle all union types (e.g., nullable records, nullable arrays).
- **MAP** — refactored `compareMaps` to accept the map schema. For `GenericContainer` values, preserves existing schema-evolution detection. For primitive/null values, uses the declared `valueType` from the map schema. **Fix:** checks that **both** entry values are `GenericContainer` before casting, preventing NPE/ClassCastException when values are null or primitive (e.g., union value types).
- **Primitives** — still delegates to `GenericData.get().compare()` (safe for non-container types).

### Code changes
- [x] No new config flags — this is a bug fix in existing comparison logic.
- [x] No new log lines.

### Concurrency-Specific Checks
- [x] `AvroCollectionElementComparator` is annotated `@ThreadSafe` and remains stateless/singleton — no concurrency concerns.

## How was this PR tested?

### Test coverage matrix

All recursive paths through `compare()` are tested:

| Test | Recursive path | Depth |
|---|---|---|
| `testCompareRecordWithNestedMapField` | RECORD → INT (primitive), RECORD → MAP → STRING | 2 |
| `testCompareRecordWithNestedNullableMapField` | RECORD → UNION → MAP/NULL | 2 |
| `testCompareRecordWithNestedArrayField` | RECORD → ARRAY → STRING | 2 |
| `testCompareMapWithPrimitiveValuesSameKeysDifferentValues` | MAP → INT (primitive) | 1 |
| `testCompareMapWithNullableUnionValues` | MAP → UNION → RECORD/NULL | 2 |
| `testCompareWhenSchemaIsNullableUnionPair` | UNION → MAP → RECORD → INT | 3 |
| `testCompareArrayOfRecordsWithMapFields` | ARRAY → RECORD → MAP → STRING | 3 |
| `testCompareNestedRecords` | RECORD → RECORD → INT | 2 |
| `testCompareNestedMaps` | MAP → MAP → INT | 2 |

### Regression tests
- `testCompareMapWithPrimitiveValuesSameKeysDifferentValues` — old code would `ClassCastException: Integer cannot be cast to GenericContainer` when map values are primitives with same keys.
- `testCompareMapWithNullableUnionValues` — old code would NPE when one map entry is `null` and the other is a `GenericContainer`.
- `testCompareArrayOfRecordsWithMapFields` — the exact real-world scenario: array elements are records containing map fields.

### Existing tests
- [x] All existing `AvroCollectionElementComparatorTest` tests pass unchanged.
- [x] All `com.linkedin.davinci.schema.merge.*` tests pass.

## Does this PR introduce any user-facing or breaking changes?
- [x] No.