### PR TITLE
[da-vinci][server] Add OTel store.version ASYNC_GAUGE for current/future version numbers

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/DaVinciBackend.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/DaVinciBackend.java
@@ -28,6 +28,7 @@ import com.linkedin.davinci.stats.AggVersionedBlobTransferStats;
 import com.linkedin.davinci.stats.AggVersionedStorageEngineStats;
 import com.linkedin.davinci.stats.HeartbeatMonitoringServiceStats;
 import com.linkedin.davinci.stats.RocksDBMemoryStats;
+import com.linkedin.davinci.stats.StoreVersionOtelStats;
 import com.linkedin.davinci.stats.ingestion.heartbeat.HeartbeatMonitoringService;
 import com.linkedin.davinci.storage.StorageEngineMetadataService;
 import com.linkedin.davinci.storage.StorageMetadataService;
@@ -185,6 +186,11 @@ public class DaVinciBackend implements Closeable {
           storeRepository,
           backendConfig.isUnregisterMetricForDeletedStoreEnabled(),
           configLoader.getVeniceClusterConfig().getClusterName());
+
+      // OTel per-store version gauge
+      storeRepository.registerStoreDataChangedListener(
+          new StoreVersionOtelStats(metricsRepository, configLoader.getVeniceClusterConfig().getClusterName()));
+
       rocksDBMemoryStats = backendConfig.isDatabaseMemoryStatsEnabled()
           ? new RocksDBMemoryStats(
               metricsRepository,

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/DaVinciBackend.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/DaVinciBackend.java
@@ -188,8 +188,8 @@ public class DaVinciBackend implements Closeable {
           configLoader.getVeniceClusterConfig().getClusterName());
 
       // OTel per-store version gauge
-      storeRepository.registerStoreDataChangedListener(
-          new StoreVersionOtelStats(metricsRepository, configLoader.getVeniceClusterConfig().getClusterName()));
+      StoreVersionOtelStats
+          .create(metricsRepository, configLoader.getVeniceClusterConfig().getClusterName(), storeRepository);
 
       rocksDBMemoryStats = backendConfig.isDatabaseMemoryStatsEnabled()
           ? new RocksDBMemoryStats(

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/DaVinciBackend.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/DaVinciBackend.java
@@ -117,6 +117,7 @@ public class DaVinciBackend implements Closeable {
   private final ReadOnlySchemaRepository schemaRepository;
   private final MetricsRepository metricsRepository;
   private final RocksDBMemoryStats rocksDBMemoryStats;
+  private final StoreVersionOtelStats storeVersionOtelStats;
   private StorageService storageService;
   private final KafkaStoreIngestionService ingestionService;
   private final ScheduledExecutorService executor;
@@ -188,7 +189,7 @@ public class DaVinciBackend implements Closeable {
           configLoader.getVeniceClusterConfig().getClusterName());
 
       // OTel per-store version gauge
-      StoreVersionOtelStats
+      storeVersionOtelStats = StoreVersionOtelStats
           .create(metricsRepository, configLoader.getVeniceClusterConfig().getClusterName(), storeRepository);
 
       rocksDBMemoryStats = backendConfig.isDatabaseMemoryStatsEnabled()
@@ -433,6 +434,9 @@ public class DaVinciBackend implements Closeable {
     cacheBackend.ifPresent(
         objectCacheBackend -> storeRepository
             .unregisterStoreDataChangedListener(objectCacheBackend.getCacheInvalidatingStoreChangeListener()));
+    if (storeVersionOtelStats != null) {
+      storeVersionOtelStats.close();
+    }
     ExecutorService storeBackendCloseExecutor = Executors.newCachedThreadPool(
         new DaemonThreadFactory(
             "DaVinciBackend-StoreBackend-Close",

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/AbstractVeniceAggVersionedStats.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/AbstractVeniceAggVersionedStats.java
@@ -6,7 +6,6 @@ import com.linkedin.venice.meta.ReadOnlyStoreRepository;
 import com.linkedin.venice.meta.Store;
 import com.linkedin.venice.meta.StoreDataChangedListener;
 import com.linkedin.venice.meta.Version;
-import com.linkedin.venice.meta.VersionStatus;
 import com.linkedin.venice.stats.StatsSupplier;
 import com.linkedin.venice.utils.Utils;
 import com.linkedin.venice.utils.concurrent.VeniceConcurrentHashMap;
@@ -123,15 +122,10 @@ public abstract class AbstractVeniceAggVersionedStats<STATS, STATS_REPORTER exte
           cleanupVersionResources(storeName, versionNum);
         });
 
-    int futureVersion = NON_EXISTING_VERSION;
     for (Version version: existingVersions) {
       versionedStats.addVersion(version.getNumber());
-
-      VersionStatus status = version.getStatus();
-      if (status == VersionStatus.STARTED || status == VersionStatus.PUSHED) {
-        futureVersion = Math.max(futureVersion, version.getNumber());
-      }
     }
+    int futureVersion = OtelVersionedStatsUtils.computeFutureVersion(existingVersions);
 
     if (futureVersion != versionedStats.getFutureVersion()) {
       versionedStats.setFutureVersion(futureVersion);

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/BlobTransferOtelStats.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/BlobTransferOtelStats.java
@@ -4,7 +4,6 @@ import static com.linkedin.davinci.stats.BlobTransferOtelMetricEntity.BYTES_RECE
 import static com.linkedin.davinci.stats.BlobTransferOtelMetricEntity.BYTES_SENT;
 import static com.linkedin.davinci.stats.BlobTransferOtelMetricEntity.RESPONSE_COUNT;
 import static com.linkedin.davinci.stats.BlobTransferOtelMetricEntity.TIME;
-import static com.linkedin.venice.meta.Store.NON_EXISTING_VERSION;
 
 import com.linkedin.davinci.stats.OtelVersionedStatsUtils.VersionInfo;
 import com.linkedin.venice.server.VersionRole;
@@ -32,7 +31,7 @@ import java.util.Map;
 public class BlobTransferOtelStats {
   private final boolean emitOtelMetrics;
 
-  private volatile VersionInfo versionInfo = new VersionInfo(NON_EXISTING_VERSION, NON_EXISTING_VERSION);
+  private volatile VersionInfo versionInfo = VersionInfo.NON_EXISTING;
 
   /** Response count with VersionRole + VeniceResponseStatusCategory dimensions. */
   private final MetricEntityStateTwoEnums<VersionRole, VeniceResponseStatusCategory> responseCountMetric;

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/OtelVersionedStatsUtils.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/OtelVersionedStatsUtils.java
@@ -2,7 +2,10 @@ package com.linkedin.davinci.stats;
 
 import static com.linkedin.venice.meta.Store.NON_EXISTING_VERSION;
 
+import com.linkedin.venice.meta.Version;
+import com.linkedin.venice.meta.VersionStatus;
 import com.linkedin.venice.server.VersionRole;
+import java.util.List;
 import java.util.Set;
 
 
@@ -18,6 +21,9 @@ public class OtelVersionedStatsUtils {
    * Used to classify versions as CURRENT, FUTURE, or BACKUP.
    */
   public static class VersionInfo {
+    /** Sentinel for stores with no version assigned yet. */
+    public static final VersionInfo NON_EXISTING = new VersionInfo(NON_EXISTING_VERSION, NON_EXISTING_VERSION);
+
     private final int currentVersion;
     private final int futureVersion;
 
@@ -33,6 +39,22 @@ public class OtelVersionedStatsUtils {
     public int getFutureVersion() {
       return futureVersion;
     }
+  }
+
+  /**
+   * Computes the future version from a list of versions. A version is considered "future"
+   * if its status is {@link VersionStatus#STARTED} or {@link VersionStatus#PUSHED}.
+   * Returns the highest such version number, or {@link com.linkedin.venice.meta.Store#NON_EXISTING_VERSION} if none.
+   */
+  public static int computeFutureVersion(List<Version> versions) {
+    int futureVersion = NON_EXISTING_VERSION;
+    for (Version version: versions) {
+      VersionStatus status = version.getStatus();
+      if (status == VersionStatus.STARTED || status == VersionStatus.PUSHED) {
+        futureVersion = Math.max(futureVersion, version.getNumber());
+      }
+    }
+    return futureVersion;
   }
 
   /**

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/OtelVersionedStatsUtils.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/OtelVersionedStatsUtils.java
@@ -20,8 +20,8 @@ public class OtelVersionedStatsUtils {
    * Immutable holder for current and future version numbers.
    * Used to classify versions as CURRENT, FUTURE, or BACKUP.
    */
-  public static class VersionInfo {
-    /** Sentinel for stores with no version assigned yet. */
+  public static final class VersionInfo {
+    /** Sentinel for stores with no version assigned yet or whose version info has been reset (e.g., after deletion). */
     public static final VersionInfo NON_EXISTING = new VersionInfo(NON_EXISTING_VERSION, NON_EXISTING_VERSION);
 
     private final int currentVersion;
@@ -47,6 +47,9 @@ public class OtelVersionedStatsUtils {
    * Returns the highest such version number, or {@link com.linkedin.venice.meta.Store#NON_EXISTING_VERSION} if none.
    */
   public static int computeFutureVersion(List<Version> versions) {
+    if (versions == null) {
+      return NON_EXISTING_VERSION;
+    }
     int futureVersion = NON_EXISTING_VERSION;
     for (Version version: versions) {
       VersionStatus status = version.getStatus();

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/OtelVersionedStatsUtils.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/OtelVersionedStatsUtils.java
@@ -45,11 +45,10 @@ public class OtelVersionedStatsUtils {
    * Computes the future version from a list of versions. A version is considered "future"
    * if its status is {@link VersionStatus#STARTED} or {@link VersionStatus#PUSHED}.
    * Returns the highest such version number, or {@link com.linkedin.venice.meta.Store#NON_EXISTING_VERSION} if none.
+   *
+   * <p>Caller is responsible for passing a non-null list.
    */
   public static int computeFutureVersion(List<Version> versions) {
-    if (versions == null) {
-      return NON_EXISTING_VERSION;
-    }
     int futureVersion = NON_EXISTING_VERSION;
     for (Version version: versions) {
       VersionStatus status = version.getStatus();

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/ServerMetricEntity.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/ServerMetricEntity.java
@@ -43,7 +43,8 @@ public final class ServerMetricEntity {
         ServerReadQuotaOtelMetricEntity.class,
         ServerConnectionOtelMetricEntity.class,
         StoreBufferServiceOtelMetricEntity.class,
-        StorageEngineOtelMetricEntity.class);
+        StorageEngineOtelMetricEntity.class,
+        VeniceVersionedStatsOtelMetricEntity.class);
   }
 
   public static final Collection<MetricEntity> SERVER_METRIC_ENTITIES =

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/ServerMetricEntity.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/ServerMetricEntity.java
@@ -44,7 +44,8 @@ public final class ServerMetricEntity {
         ServerConnectionOtelMetricEntity.class,
         StoreBufferServiceOtelMetricEntity.class,
         StorageEngineOtelMetricEntity.class,
-        DiskHealthOtelMetricEntity.class);
+        DiskHealthOtelMetricEntity.class,
+        VeniceVersionedStatsOtelMetricEntity.class);
   }
 
   public static final Collection<MetricEntity> SERVER_METRIC_ENTITIES =

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/StorageEngineOtelStats.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/StorageEngineOtelStats.java
@@ -46,7 +46,7 @@ public class StorageEngineOtelStats implements Closeable {
    * {@code (NON_EXISTING_VERSION, NON_EXISTING_VERSION)} means ASYNC_GAUGE callbacks return 0
    * before the first {@link #updateVersionInfo} call.
    */
-  private volatile VersionInfo versionInfo = new VersionInfo(NON_EXISTING_VERSION, NON_EXISTING_VERSION);
+  private volatile VersionInfo versionInfo = VersionInfo.NON_EXISTING;
 
   /**
    * Per-version wrapper map, keyed by version number. Bounded by the number of active versions

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/StorageEngineOtelStats.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/StorageEngineOtelStats.java
@@ -46,7 +46,7 @@ public class StorageEngineOtelStats implements Closeable {
    * {@code (NON_EXISTING_VERSION, NON_EXISTING_VERSION)} means no role has a version backing it, so
    * each async-gauge's {@code liveStateResolver} returns {@code null} and no data points are emitted.
    */
-  private volatile VersionInfo versionInfo = new VersionInfo(NON_EXISTING_VERSION, NON_EXISTING_VERSION);
+  private volatile VersionInfo versionInfo = VersionInfo.NON_EXISTING;
 
   /**
    * Per-version wrapper map, keyed by version number. Bounded by the number of active versions

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/StoreVersionOtelStats.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/StoreVersionOtelStats.java
@@ -1,0 +1,108 @@
+package com.linkedin.davinci.stats;
+
+import static com.linkedin.davinci.stats.VeniceVersionedStatsOtelMetricEntity.STORE_VERSION;
+
+import com.linkedin.davinci.stats.OtelVersionedStatsUtils.VersionInfo;
+import com.linkedin.venice.meta.Store;
+import com.linkedin.venice.meta.StoreDataChangedListener;
+import com.linkedin.venice.server.VersionRole;
+import com.linkedin.venice.stats.OpenTelemetryMetricsSetup;
+import com.linkedin.venice.stats.VeniceOpenTelemetryMetricsRepository;
+import com.linkedin.venice.stats.dimensions.VeniceMetricsDimensions;
+import com.linkedin.venice.stats.metrics.AsyncMetricEntityStateBase;
+import com.linkedin.venice.utils.concurrent.VeniceConcurrentHashMap;
+import io.opentelemetry.api.common.Attributes;
+import io.tehuti.metrics.MetricsRepository;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.LongSupplier;
+
+
+/**
+ * Emits a single OTel {@code ASYNC_GAUGE} per store for the current and future version numbers.
+ *
+ * <p>Metric: {@code store.version} with dimensions {@code CLUSTER_NAME}, {@code STORE_NAME},
+ * and {@code VERSION_ROLE}. Only {@link VersionRole#CURRENT CURRENT} and {@link VersionRole#FUTURE FUTURE}
+ * are emitted — backup version number is not tracked.
+ *
+ * <p>This class implements {@link StoreDataChangedListener} and is registered once per process
+ * on the metadata repository. Per-store state is created lazily on first store change
+ * and bounded by the number of stores on the host.
+ *
+ * <p><b>Cleanup limitation:</b> OTel async gauge callbacks cannot be deregistered (OTel SDK
+ * limitation). On store deletion, version info is reset to {@link VersionInfo#NON_EXISTING}
+ * rather than removed — this avoids duplicate callback registration if the store is re-created.
+ * Callbacks remain registered until the {@link MetricsRepository} is closed.
+ */
+public class StoreVersionOtelStats implements StoreDataChangedListener {
+  private final VeniceOpenTelemetryMetricsRepository otelRepository;
+  private final Map<VeniceMetricsDimensions, String> baseDimensionsMap;
+
+  /** Per-store version info. Written by metadata-change thread, read by OTel collection thread. */
+  private final Map<String, AtomicReference<VersionInfo>> perStoreVersions = new VeniceConcurrentHashMap<>();
+
+  public StoreVersionOtelStats(MetricsRepository metricsRepository, String clusterName) {
+    OpenTelemetryMetricsSetup.OpenTelemetryMetricsSetupInfo otelData =
+        OpenTelemetryMetricsSetup.builder(metricsRepository).setClusterName(clusterName).build();
+    this.otelRepository = otelData.getOtelRepository();
+    this.baseDimensionsMap = otelData.getBaseDimensionsMap();
+  }
+
+  @Override
+  public void handleStoreCreated(Store store) {
+    handleStoreChanged(store);
+  }
+
+  @Override
+  public void handleStoreChanged(Store store) {
+    String storeName = store.getName();
+    int currentVersion = store.getCurrentVersion();
+    int futureVersion = OtelVersionedStatsUtils.computeFutureVersion(store.getVersions());
+
+    AtomicReference<VersionInfo> versionInfoRef = perStoreVersions.computeIfAbsent(storeName, k -> {
+      AtomicReference<VersionInfo> newVersionInfoRef = new AtomicReference<>(VersionInfo.NON_EXISTING);
+      registerOtelGauge(k, newVersionInfoRef);
+      return newVersionInfoRef;
+    });
+    versionInfoRef.set(new VersionInfo(currentVersion, futureVersion));
+  }
+
+  /**
+   * Resets version info to {@link VersionInfo#NON_EXISTING} rather than removing the map entry.
+   * OTel async gauge callbacks cannot be deregistered, so removing and re-creating the entry
+   * on store re-creation would produce duplicate callbacks. Keeping the entry with reset values
+   * ensures the gauge reports 0 for deleted stores and reuses the same callback on re-creation.
+   */
+  @Override
+  public void handleStoreDeleted(String storeName) {
+    AtomicReference<VersionInfo> versionInfoRef = perStoreVersions.get(storeName);
+    if (versionInfoRef != null) {
+      versionInfoRef.set(VersionInfo.NON_EXISTING);
+    }
+  }
+
+  /**
+   * Registers two ASYNC_GAUGE callbacks: one for CURRENT and one for FUTURE.
+   * Only these two roles are tracked — backup version number is not tracked.
+   */
+  private void registerOtelGauge(String storeName, AtomicReference<VersionInfo> versionInfoRef) {
+    if (otelRepository == null) {
+      return;
+    }
+    Map<VeniceMetricsDimensions, String> storeDims = new HashMap<>(baseDimensionsMap);
+    storeDims.put(VeniceMetricsDimensions.VENICE_STORE_NAME, OpenTelemetryMetricsSetup.sanitizeStoreName(storeName));
+    registerRoleGauge(storeDims, VersionRole.CURRENT, () -> versionInfoRef.get().getCurrentVersion());
+    registerRoleGauge(storeDims, VersionRole.FUTURE, () -> versionInfoRef.get().getFutureVersion());
+  }
+
+  private void registerRoleGauge(
+      Map<VeniceMetricsDimensions, String> storeDims,
+      VersionRole role,
+      LongSupplier callback) {
+    Map<VeniceMetricsDimensions, String> dims = new HashMap<>(storeDims);
+    dims.put(VeniceMetricsDimensions.VENICE_VERSION_ROLE, role.getDimensionValue());
+    Attributes attrs = otelRepository.createAttributes(STORE_VERSION.getMetricEntity(), dims);
+    AsyncMetricEntityStateBase.create(STORE_VERSION.getMetricEntity(), otelRepository, dims, attrs, callback);
+  }
+}

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/StoreVersionOtelStats.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/StoreVersionOtelStats.java
@@ -3,6 +3,7 @@ package com.linkedin.davinci.stats;
 import static com.linkedin.davinci.stats.VeniceVersionedStatsOtelMetricEntity.STORE_VERSION;
 
 import com.linkedin.davinci.stats.OtelVersionedStatsUtils.VersionInfo;
+import com.linkedin.venice.meta.ReadOnlyStoreRepository;
 import com.linkedin.venice.meta.Store;
 import com.linkedin.venice.meta.StoreDataChangedListener;
 import com.linkedin.venice.server.VersionRole;
@@ -20,15 +21,16 @@ import java.util.function.LongSupplier;
 
 
 /**
- * Emits a single OTel {@code ASYNC_GAUGE} per store for the current and future version numbers.
+ * Registers OTel {@code ASYNC_GAUGE} callbacks per store for the current and future version numbers.
  *
  * <p>Metric: {@code store.version} with dimensions {@code CLUSTER_NAME}, {@code STORE_NAME},
  * and {@code VERSION_ROLE}. Only {@link VersionRole#CURRENT CURRENT} and {@link VersionRole#FUTURE FUTURE}
  * are emitted — backup version number is not tracked.
  *
- * <p>This class implements {@link StoreDataChangedListener} and is registered once per process
- * on the metadata repository. Per-store state is created lazily on first store change
- * and bounded by the number of stores on the host.
+ * <p>This class implements {@link StoreDataChangedListener} and should be registered once per process
+ * on the metadata repository via {@link #register(ReadOnlyStoreRepository)}. Per-store state is
+ * created lazily on first store change and bounded by the number of distinct store names ever
+ * observed by the process (entries are not removed on deletion — see cleanup limitation below).
  *
  * <p><b>Cleanup limitation:</b> OTel async gauge callbacks cannot be deregistered (OTel SDK
  * limitation). On store deletion, version info is reset to {@link VersionInfo#NON_EXISTING}
@@ -42,11 +44,39 @@ public class StoreVersionOtelStats implements StoreDataChangedListener {
   /** Per-store version info. Written by metadata-change thread, read by OTel collection thread. */
   private final Map<String, AtomicReference<VersionInfo>> perStoreVersions = new VeniceConcurrentHashMap<>();
 
-  public StoreVersionOtelStats(MetricsRepository metricsRepository, String clusterName) {
+  /**
+   * Creates and registers a {@link StoreVersionOtelStats} listener on the given metadata repository.
+   * Initializes gauges for all pre-existing stores. This is the preferred entry point — it combines
+   * construction and registration to prevent the listener from existing in an unregistered state.
+   */
+  public static StoreVersionOtelStats create(
+      MetricsRepository metricsRepository,
+      String clusterName,
+      ReadOnlyStoreRepository metadataRepository) {
+    StoreVersionOtelStats stats = new StoreVersionOtelStats(metricsRepository, clusterName);
+    stats.register(metadataRepository);
+    return stats;
+  }
+
+  StoreVersionOtelStats(MetricsRepository metricsRepository, String clusterName) {
     OpenTelemetryMetricsSetup.OpenTelemetryMetricsSetupInfo otelData =
         OpenTelemetryMetricsSetup.builder(metricsRepository).setClusterName(clusterName).build();
     this.otelRepository = otelData.getOtelRepository();
     this.baseDimensionsMap = otelData.getBaseDimensionsMap();
+  }
+
+  /**
+   * Registers this listener on the metadata repository and initializes gauges for all
+   * pre-existing stores. Prefer {@link #create} which combines construction and registration.
+   */
+  void register(ReadOnlyStoreRepository metadataRepository) {
+    metadataRepository.registerStoreDataChangedListener(this);
+    if (otelRepository == null) {
+      return;
+    }
+    // Initialize gauges for pre-existing stores. Uses computeIfAbsent only (no unconditional
+    // set) so that a concurrent ZK event with newer data is never overwritten by the snapshot.
+    metadataRepository.getAllStores().forEach(this::initializeStoreIfAbsent);
   }
 
   @Override
@@ -56,26 +86,52 @@ public class StoreVersionOtelStats implements StoreDataChangedListener {
 
   @Override
   public void handleStoreChanged(Store store) {
+    if (otelRepository == null) {
+      return;
+    }
     String storeName = store.getName();
-    int currentVersion = store.getCurrentVersion();
-    int futureVersion = OtelVersionedStatsUtils.computeFutureVersion(store.getVersions());
+    VersionInfo newInfo = computeVersionInfo(store);
 
-    AtomicReference<VersionInfo> versionInfoRef = perStoreVersions.computeIfAbsent(storeName, k -> {
-      AtomicReference<VersionInfo> newVersionInfoRef = new AtomicReference<>(VersionInfo.NON_EXISTING);
-      registerOtelGauge(k, newVersionInfoRef);
-      return newVersionInfoRef;
+    // computeIfAbsent for first-time gauge registration (matches the pattern in other OTel stats
+    // classes like ParticipantStoreConsumptionStats, AggVersionedDIVStats). The unconditional
+    // set() after updates existing entries with the latest data from the ZK event.
+    perStoreVersions.computeIfAbsent(storeName, k -> {
+      AtomicReference<VersionInfo> newRef = new AtomicReference<>(newInfo);
+      registerOtelGauge(k, newRef);
+      return newRef;
+    }).set(newInfo);
+  }
+
+  /** Initializes a store entry if absent. Does NOT update existing entries — avoids overwriting
+   *  concurrent ZK events with stale snapshot data during {@link #register} initialization. */
+  private void initializeStoreIfAbsent(Store store) {
+    String storeName = store.getName();
+    VersionInfo newInfo = computeVersionInfo(store);
+    perStoreVersions.computeIfAbsent(storeName, k -> {
+      AtomicReference<VersionInfo> newRef = new AtomicReference<>(newInfo);
+      registerOtelGauge(k, newRef);
+      return newRef;
     });
-    versionInfoRef.set(new VersionInfo(currentVersion, futureVersion));
+  }
+
+  private static VersionInfo computeVersionInfo(Store store) {
+    return new VersionInfo(
+        store.getCurrentVersion(),
+        OtelVersionedStatsUtils.computeFutureVersion(store.getVersions()));
   }
 
   /**
    * Resets version info to {@link VersionInfo#NON_EXISTING} rather than removing the map entry.
    * OTel async gauge callbacks cannot be deregistered, so removing and re-creating the entry
    * on store re-creation would produce duplicate callbacks. Keeping the entry with reset values
-   * ensures the gauge reports 0 for deleted stores and reuses the same callback on re-creation.
+   * ensures the gauge reports NON_EXISTING_VERSION for deleted stores and reuses the same
+   * callback on re-creation.
    */
   @Override
   public void handleStoreDeleted(String storeName) {
+    if (otelRepository == null) {
+      return;
+    }
     AtomicReference<VersionInfo> versionInfoRef = perStoreVersions.get(storeName);
     if (versionInfoRef != null) {
       versionInfoRef.set(VersionInfo.NON_EXISTING);
@@ -87,9 +143,6 @@ public class StoreVersionOtelStats implements StoreDataChangedListener {
    * Only these two roles are tracked — backup version number is not tracked.
    */
   private void registerOtelGauge(String storeName, AtomicReference<VersionInfo> versionInfoRef) {
-    if (otelRepository == null) {
-      return;
-    }
     Map<VeniceMetricsDimensions, String> storeDims = new HashMap<>(baseDimensionsMap);
     storeDims.put(VeniceMetricsDimensions.VENICE_STORE_NAME, OpenTelemetryMetricsSetup.sanitizeStoreName(storeName));
     registerRoleGauge(storeDims, VersionRole.CURRENT, () -> versionInfoRef.get().getCurrentVersion());

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/StoreVersionOtelStats.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/StoreVersionOtelStats.java
@@ -14,6 +14,7 @@ import com.linkedin.venice.stats.metrics.AsyncMetricEntityStateBase;
 import com.linkedin.venice.utils.concurrent.VeniceConcurrentHashMap;
 import io.opentelemetry.api.common.Attributes;
 import io.tehuti.metrics.MetricsRepository;
+import java.io.Closeable;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicReference;
@@ -41,13 +42,20 @@ import org.apache.logging.log4j.Logger;
  * info is reset to {@link VersionInfo#NON_EXISTING} rather than removed — see
  * {@link #handleStoreDeleted} for why removing the map entry is unsafe given the current wrapper.
  */
-public class StoreVersionOtelStats implements StoreDataChangedListener {
+public class StoreVersionOtelStats implements StoreDataChangedListener, Closeable {
   private static final Logger LOGGER = LogManager.getLogger(StoreVersionOtelStats.class);
   private final VeniceOpenTelemetryMetricsRepository otelRepository;
   private final Map<VeniceMetricsDimensions, String> baseDimensionsMap;
 
   /** Per-store version info. Written by metadata-change thread, read by OTel collection thread. */
   private final Map<String, AtomicReference<VersionInfo>> perStoreVersions = new VeniceConcurrentHashMap<>();
+
+  /**
+   * Tracks the metadata repository this OTel listener is registered on. Set when
+   * {@link #register} succeeds; null otherwise (OTel disabled or never registered). Used by
+   * {@link #close} to deregister the OTel listener.
+   */
+  private ReadOnlyStoreRepository registeredMetadataRepository;
 
   /**
    * Creates and registers a {@link StoreVersionOtelStats} listener on the given metadata repository.
@@ -82,10 +90,20 @@ public class StoreVersionOtelStats implements StoreDataChangedListener {
       LOGGER.info("OTel metrics disabled; skipping StoreVersionOtelStats listener registration.");
       return;
     }
+    this.registeredMetadataRepository = metadataRepository;
     metadataRepository.registerStoreDataChangedListener(this);
     // Initialize gauges for pre-existing stores. Uses computeIfAbsent only (no unconditional
     // set) so that a concurrent ZK event with newer data is never overwritten by the snapshot.
     metadataRepository.getAllStores().forEach(this::initializeStoreIfAbsent);
+  }
+
+  /** Unregisters this OTel listener from the metadata repository. Idempotent. */
+  @Override
+  public void close() {
+    if (registeredMetadataRepository != null) {
+      registeredMetadataRepository.unregisterStoreDataChangedListener(this);
+      registeredMetadataRepository = null;
+    }
   }
 
   @Override

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/StoreVersionOtelStats.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/StoreVersionOtelStats.java
@@ -18,6 +18,8 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.LongSupplier;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 
 /**
@@ -32,12 +34,15 @@ import java.util.function.LongSupplier;
  * created lazily on first store change and bounded by the number of distinct store names ever
  * observed by the process (entries are not removed on deletion — see cleanup limitation below).
  *
- * <p><b>Cleanup limitation:</b> OTel async gauge callbacks cannot be deregistered (OTel SDK
- * limitation). On store deletion, version info is reset to {@link VersionInfo#NON_EXISTING}
- * rather than removed — this avoids duplicate callback registration if the store is re-created.
- * Callbacks remain registered until the {@link MetricsRepository} is closed.
+ * <p><b>Cleanup limitation:</b> the OTel SDK does support per-instrument deregistration via
+ * {@code ObservableLongGauge.close()}, but the current Venice wrapper
+ * ({@link AsyncMetricEntityStateBase}) doesn't surface the SDK instrument handle, so callbacks
+ * remain registered until the {@link MetricsRepository} is closed. On store deletion, version
+ * info is reset to {@link VersionInfo#NON_EXISTING} rather than removed — see
+ * {@link #handleStoreDeleted} for why removing the map entry is unsafe given the current wrapper.
  */
 public class StoreVersionOtelStats implements StoreDataChangedListener {
+  private static final Logger LOGGER = LogManager.getLogger(StoreVersionOtelStats.class);
   private final VeniceOpenTelemetryMetricsRepository otelRepository;
   private final Map<VeniceMetricsDimensions, String> baseDimensionsMap;
 
@@ -68,12 +73,16 @@ public class StoreVersionOtelStats implements StoreDataChangedListener {
   /**
    * Registers this listener on the metadata repository and initializes gauges for all
    * pre-existing stores. Prefer {@link #create} which combines construction and registration.
+   *
+   * <p>When OTel is disabled the listener is NOT registered — every event handler would early-return
+   * anyway, so registering would just add no-op dispatch overhead on every store create/change/delete.
    */
   void register(ReadOnlyStoreRepository metadataRepository) {
-    metadataRepository.registerStoreDataChangedListener(this);
     if (otelRepository == null) {
+      LOGGER.info("OTel metrics disabled; skipping StoreVersionOtelStats listener registration.");
       return;
     }
+    metadataRepository.registerStoreDataChangedListener(this);
     // Initialize gauges for pre-existing stores. Uses computeIfAbsent only (no unconditional
     // set) so that a concurrent ZK event with newer data is never overwritten by the snapshot.
     metadataRepository.getAllStores().forEach(this::initializeStoreIfAbsent);
@@ -122,10 +131,11 @@ public class StoreVersionOtelStats implements StoreDataChangedListener {
 
   /**
    * Resets version info to {@link VersionInfo#NON_EXISTING} rather than removing the map entry.
-   * OTel async gauge callbacks cannot be deregistered, so removing and re-creating the entry
-   * on store re-creation would produce duplicate callbacks. Keeping the entry with reset values
-   * ensures the gauge reports NON_EXISTING_VERSION for deleted stores and reuses the same
-   * callback on re-creation.
+   * The async-gauge callback closes over the {@link AtomicReference}, which the Venice wrapper
+   * doesn't currently surface for de-registration. Removing the map entry would orphan the live
+   * callback (SDK keeps polling stale data); a subsequent re-create would register a second
+   * callback emitting under the same attributes. Resetting keeps one live callback pointed at
+   * the right state across delete→re-create cycles.
    */
   @Override
   public void handleStoreDeleted(String storeName) {

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/VeniceVersionedStatsOtelMetricEntity.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/VeniceVersionedStatsOtelMetricEntity.java
@@ -1,0 +1,41 @@
+package com.linkedin.davinci.stats;
+
+import static com.linkedin.venice.stats.dimensions.VeniceMetricsDimensions.VENICE_CLUSTER_NAME;
+import static com.linkedin.venice.stats.dimensions.VeniceMetricsDimensions.VENICE_STORE_NAME;
+import static com.linkedin.venice.stats.dimensions.VeniceMetricsDimensions.VENICE_VERSION_ROLE;
+import static com.linkedin.venice.utils.Utils.setOf;
+
+import com.linkedin.venice.stats.dimensions.VeniceMetricsDimensions;
+import com.linkedin.venice.stats.metrics.MetricEntity;
+import com.linkedin.venice.stats.metrics.MetricType;
+import com.linkedin.venice.stats.metrics.MetricUnit;
+import com.linkedin.venice.stats.metrics.ModuleMetricEntityInterface;
+import java.util.Set;
+
+
+/**
+ * OTel metric entity definitions for {@link StoreVersionOtelStats}.
+ */
+public enum VeniceVersionedStatsOtelMetricEntity implements ModuleMetricEntityInterface {
+  STORE_VERSION(
+      "store.version", MetricType.ASYNC_GAUGE, MetricUnit.NUMBER,
+      "Version number serving a given role (current or future) for a store",
+      setOf(VENICE_CLUSTER_NAME, VENICE_STORE_NAME, VENICE_VERSION_ROLE)
+  );
+
+  private final MetricEntity metricEntity;
+
+  VeniceVersionedStatsOtelMetricEntity(
+      String metricName,
+      MetricType metricType,
+      MetricUnit unit,
+      String description,
+      Set<VeniceMetricsDimensions> dimensions) {
+    this.metricEntity = new MetricEntity(metricName, metricType, unit, description, dimensions);
+  }
+
+  @Override
+  public MetricEntity getMetricEntity() {
+    return metricEntity;
+  }
+}

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/ingestion/IngestionOtelStats.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/ingestion/IngestionOtelStats.java
@@ -97,7 +97,7 @@ public class IngestionOtelStats {
   private final VeniceOpenTelemetryMetricsRepository otelRepository;
   private final Map<VeniceMetricsDimensions, String> baseDimensionsMap;
 
-  private volatile VersionInfo versionInfo = new VersionInfo(NON_EXISTING_VERSION, NON_EXISTING_VERSION);
+  private volatile VersionInfo versionInfo = VersionInfo.NON_EXISTING;
 
   // Store ingestion tasks by version for ASYNC_GAUGE callbacks
   private final Map<Integer, StoreIngestionTask> ingestionTasksByVersion;

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/ingestion/IngestionOtelStats.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/ingestion/IngestionOtelStats.java
@@ -102,7 +102,7 @@ public class IngestionOtelStats {
   private final VeniceOpenTelemetryMetricsRepository otelRepository;
   private final Map<VeniceMetricsDimensions, String> baseDimensionsMap;
 
-  private volatile VersionInfo versionInfo = new VersionInfo(NON_EXISTING_VERSION, NON_EXISTING_VERSION);
+  private volatile VersionInfo versionInfo = VersionInfo.NON_EXISTING;
 
   // Store ingestion tasks by version for ASYNC_GAUGE callbacks
   private final Map<Integer, StoreIngestionTask> ingestionTasksByVersion;

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/ingestion/heartbeat/HeartbeatOtelStats.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/ingestion/heartbeat/HeartbeatOtelStats.java
@@ -1,7 +1,6 @@
 package com.linkedin.davinci.stats.ingestion.heartbeat;
 
 import static com.linkedin.davinci.stats.ingestion.heartbeat.HeartbeatOtelMetricEntity.INGESTION_HEARTBEAT_DELAY;
-import static com.linkedin.venice.meta.Store.NON_EXISTING_VERSION;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.linkedin.davinci.stats.OtelVersionedStatsUtils;
@@ -35,7 +34,7 @@ public class HeartbeatOtelStats {
   private final Map<String, MetricEntityStateThreeEnums<VersionRole, ReplicaType, ReplicaState>> metricsByRegion;
 
   // Version info cache for classifying versions as CURRENT/FUTURE/BACKUP
-  private volatile VersionInfo versionInfo = new VersionInfo(NON_EXISTING_VERSION, NON_EXISTING_VERSION);
+  private volatile VersionInfo versionInfo = VersionInfo.NON_EXISTING;
 
   public HeartbeatOtelStats(MetricsRepository metricsRepository, String storeName, String clusterName) {
     this.metricsByRegion = new VeniceConcurrentHashMap<>();

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/ingestion/heartbeat/RecordLevelDelayOtelStats.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/ingestion/heartbeat/RecordLevelDelayOtelStats.java
@@ -1,7 +1,6 @@
 package com.linkedin.davinci.stats.ingestion.heartbeat;
 
 import static com.linkedin.davinci.stats.ingestion.heartbeat.RecordLevelDelayOtelMetricEntity.INGESTION_RECORD_DELAY;
-import static com.linkedin.venice.meta.Store.NON_EXISTING_VERSION;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.linkedin.davinci.stats.OtelVersionedStatsUtils;
@@ -36,7 +35,7 @@ public class RecordLevelDelayOtelStats {
   private final Map<String, MetricEntityStateThreeEnums<VersionRole, ReplicaType, ReplicaState>> metricsByRegion;
 
   // Version info cache for classifying versions as CURRENT/FUTURE/BACKUP
-  private volatile VersionInfo versionInfo = new VersionInfo(NON_EXISTING_VERSION, NON_EXISTING_VERSION);
+  private volatile VersionInfo versionInfo = VersionInfo.NON_EXISTING;
 
   public RecordLevelDelayOtelStats(MetricsRepository metricsRepository, String storeName, String clusterName) {
     this.metricsByRegion = new VeniceConcurrentHashMap<>();

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/stats/OtelVersionedStatsUtilsTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/stats/OtelVersionedStatsUtilsTest.java
@@ -4,10 +4,14 @@ import static com.linkedin.venice.meta.Store.NON_EXISTING_VERSION;
 import static org.testng.Assert.assertEquals;
 
 import com.linkedin.davinci.stats.OtelVersionedStatsUtils.VersionInfo;
+import com.linkedin.venice.meta.Version;
+import com.linkedin.venice.meta.VersionImpl;
+import com.linkedin.venice.meta.VersionStatus;
 import com.linkedin.venice.server.VersionRole;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 import org.testng.annotations.Test;
 
@@ -80,6 +84,57 @@ public class OtelVersionedStatsUtilsTest {
     // Edge case: current equals future (should classify as CURRENT due to if-else order)
     VersionInfo versionInfo = new VersionInfo(5, 5);
     assertEquals(OtelVersionedStatsUtils.classifyVersion(5, versionInfo), VersionRole.CURRENT);
+  }
+
+  // --- computeFutureVersion tests ---
+
+  @Test
+  public void testComputeFutureVersionEmptyList() {
+    assertEquals(OtelVersionedStatsUtils.computeFutureVersion(Collections.emptyList()), NON_EXISTING_VERSION);
+  }
+
+  @Test
+  public void testComputeFutureVersionAllOnline() {
+    List<Version> versions =
+        Arrays.asList(createVersion(1, VersionStatus.ONLINE), createVersion(2, VersionStatus.ONLINE));
+    assertEquals(OtelVersionedStatsUtils.computeFutureVersion(versions), NON_EXISTING_VERSION);
+  }
+
+  @Test
+  public void testComputeFutureVersionStartedOnly() {
+    List<Version> versions =
+        Arrays.asList(createVersion(1, VersionStatus.ONLINE), createVersion(2, VersionStatus.STARTED));
+    assertEquals(OtelVersionedStatsUtils.computeFutureVersion(versions), 2);
+  }
+
+  @Test
+  public void testComputeFutureVersionPushedOnly() {
+    List<Version> versions =
+        Arrays.asList(createVersion(1, VersionStatus.ONLINE), createVersion(3, VersionStatus.PUSHED));
+    assertEquals(OtelVersionedStatsUtils.computeFutureVersion(versions), 3);
+  }
+
+  @Test
+  public void testComputeFutureVersionMixedReturnsMax() {
+    List<Version> versions = Arrays.asList(
+        createVersion(1, VersionStatus.ONLINE),
+        createVersion(2, VersionStatus.STARTED),
+        createVersion(4, VersionStatus.PUSHED),
+        createVersion(3, VersionStatus.STARTED));
+    assertEquals(OtelVersionedStatsUtils.computeFutureVersion(versions), 4);
+  }
+
+  @Test
+  public void testComputeFutureVersionIgnoresErrorStatus() {
+    List<Version> versions =
+        Arrays.asList(createVersion(1, VersionStatus.ONLINE), createVersion(5, VersionStatus.ERROR));
+    assertEquals(OtelVersionedStatsUtils.computeFutureVersion(versions), NON_EXISTING_VERSION);
+  }
+
+  private static Version createVersion(int number, VersionStatus status) {
+    VersionImpl version = new VersionImpl("test-store", number);
+    version.setStatus(status);
+    return version;
   }
 
   // --- getVersionForRole tests ---

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/stats/OtelVersionedStatsUtilsTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/stats/OtelVersionedStatsUtilsTest.java
@@ -13,6 +13,7 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 
@@ -124,11 +125,30 @@ public class OtelVersionedStatsUtilsTest {
     assertEquals(OtelVersionedStatsUtils.computeFutureVersion(versions), 4);
   }
 
-  @Test
-  public void testComputeFutureVersionIgnoresErrorStatus() {
-    List<Version> versions =
-        Arrays.asList(createVersion(1, VersionStatus.ONLINE), createVersion(5, VersionStatus.ERROR));
-    assertEquals(OtelVersionedStatsUtils.computeFutureVersion(versions), NON_EXISTING_VERSION);
+  /**
+   * Data provider for {@link #testComputeFutureVersionIgnoresNonFutureStatus} — every
+   * {@link VersionStatus} except STARTED and PUSHED, which are the only two statuses that
+   * count as "future". Catches a regression if someone widens the future-set
+   * (e.g., adds PARTIALLY_ONLINE).
+   */
+  @DataProvider(name = "nonFutureStatuses")
+  public Object[][] nonFutureStatuses() {
+    List<Object[]> rows = new java.util.ArrayList<>();
+    for (VersionStatus status: VersionStatus.values()) {
+      if (status != VersionStatus.STARTED && status != VersionStatus.PUSHED) {
+        rows.add(new Object[] { status });
+      }
+    }
+    return rows.toArray(new Object[0][]);
+  }
+
+  @Test(dataProvider = "nonFutureStatuses")
+  public void testComputeFutureVersionIgnoresNonFutureStatus(VersionStatus status) {
+    List<Version> versions = Collections.singletonList(createVersion(5, status));
+    assertEquals(
+        OtelVersionedStatsUtils.computeFutureVersion(versions),
+        NON_EXISTING_VERSION,
+        "VersionStatus." + status + " must be ignored by computeFutureVersion (only STARTED/PUSHED count)");
   }
 
   private static Version createVersion(int number, VersionStatus status) {

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/stats/ServerMetricEntityTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/stats/ServerMetricEntityTest.java
@@ -22,7 +22,7 @@ import org.testng.annotations.Test;
 public class ServerMetricEntityTest {
   @Test
   public void testServerMetricEntitiesCount() {
-    assertEquals(SERVER_METRIC_ENTITIES.size(), 153, "Expected 153 unique metric entities");
+    assertEquals(SERVER_METRIC_ENTITIES.size(), 154, "Expected 154 unique metric entities");
   }
 
   /**

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/stats/ServerMetricEntityTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/stats/ServerMetricEntityTest.java
@@ -22,7 +22,7 @@ import org.testng.annotations.Test;
 public class ServerMetricEntityTest {
   @Test
   public void testServerMetricEntitiesCount() {
-    assertEquals(SERVER_METRIC_ENTITIES.size(), 156, "Expected 156 unique metric entities");
+    assertEquals(SERVER_METRIC_ENTITIES.size(), 157, "Expected 157 unique metric entities");
   }
 
   /**

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/stats/StoreVersionOtelStatsTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/stats/StoreVersionOtelStatsTest.java
@@ -1,0 +1,189 @@
+package com.linkedin.davinci.stats;
+
+import static com.linkedin.davinci.stats.ServerMetricEntity.SERVER_METRIC_ENTITIES;
+import static com.linkedin.davinci.stats.VeniceVersionedStatsOtelMetricEntity.STORE_VERSION;
+import static com.linkedin.venice.meta.Store.NON_EXISTING_VERSION;
+import static com.linkedin.venice.stats.dimensions.VeniceMetricsDimensions.VENICE_CLUSTER_NAME;
+import static com.linkedin.venice.stats.dimensions.VeniceMetricsDimensions.VENICE_STORE_NAME;
+import static com.linkedin.venice.stats.dimensions.VeniceMetricsDimensions.VENICE_VERSION_ROLE;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.linkedin.venice.meta.Store;
+import com.linkedin.venice.meta.Version;
+import com.linkedin.venice.meta.VersionImpl;
+import com.linkedin.venice.meta.VersionStatus;
+import com.linkedin.venice.server.VersionRole;
+import com.linkedin.venice.stats.VeniceMetricsConfig;
+import com.linkedin.venice.stats.VeniceMetricsRepository;
+import com.linkedin.venice.utils.OpenTelemetryDataTestUtils;
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.sdk.testing.exporter.InMemoryMetricReader;
+import io.tehuti.metrics.MetricsRepository;
+import java.util.Arrays;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+
+public class StoreVersionOtelStatsTest {
+  private static final String TEST_METRIC_PREFIX = "server";
+  private static final String TEST_CLUSTER_NAME = "test-cluster";
+  private static final String TEST_STORE_NAME = "test-store";
+  private static final String STORE_VERSION_METRIC_NAME = STORE_VERSION.getMetricEntity().getMetricName();
+
+  private InMemoryMetricReader inMemoryMetricReader;
+  private VeniceMetricsRepository metricsRepository;
+  private StoreVersionOtelStats stats;
+
+  @BeforeMethod
+  public void setUp() {
+    inMemoryMetricReader = InMemoryMetricReader.create();
+    metricsRepository = new VeniceMetricsRepository(
+        new VeniceMetricsConfig.Builder().setMetricPrefix(TEST_METRIC_PREFIX)
+            .setMetricEntities(SERVER_METRIC_ENTITIES)
+            .setEmitOtelMetrics(true)
+            .setOtelAdditionalMetricsReader(inMemoryMetricReader)
+            .build());
+    stats = new StoreVersionOtelStats(metricsRepository, TEST_CLUSTER_NAME);
+  }
+
+  @AfterMethod
+  public void tearDown() {
+    if (metricsRepository != null) {
+      metricsRepository.close();
+    }
+  }
+
+  @Test
+  public void testReportsCurrentAndFutureVersion() {
+    Store store = createMockStore(
+        TEST_STORE_NAME,
+        5,
+        createVersion(5, VersionStatus.ONLINE),
+        createVersion(6, VersionStatus.STARTED));
+    stats.handleStoreChanged(store);
+
+    validateGauge(5, TEST_STORE_NAME, VersionRole.CURRENT);
+    validateGauge(6, TEST_STORE_NAME, VersionRole.FUTURE);
+  }
+
+  @Test
+  public void testGaugeUpdatesOnVersionChange() {
+    Store store = createMockStore(TEST_STORE_NAME, 3, createVersion(3, VersionStatus.ONLINE));
+    stats.handleStoreChanged(store);
+    validateGauge(3, TEST_STORE_NAME, VersionRole.CURRENT);
+
+    // Version swap: 3 → 7
+    Store updated = createMockStore(TEST_STORE_NAME, 7, createVersion(7, VersionStatus.ONLINE));
+    stats.handleStoreChanged(updated);
+    validateGauge(7, TEST_STORE_NAME, VersionRole.CURRENT);
+  }
+
+  @Test
+  public void testMultiStoreIsolation() {
+    String storeA = "store-a";
+    String storeB = "store-b";
+
+    stats.handleStoreChanged(createMockStore(storeA, 5, createVersion(5, VersionStatus.ONLINE)));
+    stats.handleStoreChanged(createMockStore(storeB, 10, createVersion(10, VersionStatus.ONLINE)));
+
+    validateGauge(5, storeA, VersionRole.CURRENT);
+    validateGauge(10, storeB, VersionRole.CURRENT);
+  }
+
+  @Test
+  public void testStoreDeletedResetsToNonExistingVersion() {
+    Store store = createMockStore(TEST_STORE_NAME, 5, createVersion(5, VersionStatus.ONLINE));
+    stats.handleStoreChanged(store);
+    validateGauge(5, TEST_STORE_NAME, VersionRole.CURRENT);
+
+    // Deletion resets versions to NON_EXISTING_VERSION (state kept for callback reuse)
+    stats.handleStoreDeleted(TEST_STORE_NAME);
+    validateGauge(NON_EXISTING_VERSION, TEST_STORE_NAME, VersionRole.CURRENT);
+    validateGauge(NON_EXISTING_VERSION, TEST_STORE_NAME, VersionRole.FUTURE);
+
+    // Re-creation reuses the existing callback — no duplicate registration
+    Store reCreated = createMockStore(TEST_STORE_NAME, 8, createVersion(8, VersionStatus.ONLINE));
+    stats.handleStoreChanged(reCreated);
+    validateGauge(8, TEST_STORE_NAME, VersionRole.CURRENT);
+  }
+
+  @Test
+  public void testNoNpeWhenOtelDisabled() {
+    try (VeniceMetricsRepository disabledRepo = new VeniceMetricsRepository(
+        new VeniceMetricsConfig.Builder().setMetricPrefix(TEST_METRIC_PREFIX).setEmitOtelMetrics(false).build())) {
+      StoreVersionOtelStats disabledStats = new StoreVersionOtelStats(disabledRepo, TEST_CLUSTER_NAME);
+      Store store = createMockStore(TEST_STORE_NAME, 1, createVersion(1, VersionStatus.ONLINE));
+      disabledStats.handleStoreChanged(store);
+      disabledStats.handleStoreDeleted(TEST_STORE_NAME);
+    }
+  }
+
+  @Test
+  public void testNoNpeWhenPlainMetricsRepository() {
+    StoreVersionOtelStats plainStats = new StoreVersionOtelStats(new MetricsRepository(), TEST_CLUSTER_NAME);
+    Store store = createMockStore(TEST_STORE_NAME, 1, createVersion(1, VersionStatus.ONLINE));
+    plainStats.handleStoreChanged(store);
+    plainStats.handleStoreDeleted(TEST_STORE_NAME);
+  }
+
+  @Test
+  public void testFutureVersionComputedFromPushedStatus() {
+    Store store = createMockStore(
+        TEST_STORE_NAME,
+        3,
+        createVersion(3, VersionStatus.ONLINE),
+        createVersion(4, VersionStatus.PUSHED),
+        createVersion(5, VersionStatus.STARTED));
+    stats.handleStoreChanged(store);
+
+    // Future is the max of STARTED/PUSHED versions
+    validateGauge(3, TEST_STORE_NAME, VersionRole.CURRENT);
+    validateGauge(5, TEST_STORE_NAME, VersionRole.FUTURE);
+  }
+
+  @Test
+  public void testNoFutureVersionWhenAllOnline() {
+    Store store = createMockStore(
+        TEST_STORE_NAME,
+        3,
+        createVersion(2, VersionStatus.ONLINE),
+        createVersion(3, VersionStatus.ONLINE));
+    stats.handleStoreChanged(store);
+
+    validateGauge(3, TEST_STORE_NAME, VersionRole.CURRENT);
+    validateGauge(NON_EXISTING_VERSION, TEST_STORE_NAME, VersionRole.FUTURE);
+  }
+
+  private void validateGauge(long expectedValue, String storeName, VersionRole role) {
+    OpenTelemetryDataTestUtils.validateLongPointDataFromGauge(
+        inMemoryMetricReader,
+        expectedValue,
+        buildAttributes(storeName, role),
+        STORE_VERSION_METRIC_NAME,
+        TEST_METRIC_PREFIX);
+  }
+
+  private static Attributes buildAttributes(String storeName, VersionRole role) {
+    return Attributes.builder()
+        .put(VENICE_CLUSTER_NAME.getDimensionNameInDefaultFormat(), TEST_CLUSTER_NAME)
+        .put(VENICE_STORE_NAME.getDimensionNameInDefaultFormat(), storeName)
+        .put(VENICE_VERSION_ROLE.getDimensionNameInDefaultFormat(), role.getDimensionValue())
+        .build();
+  }
+
+  private static Store createMockStore(String storeName, int currentVersion, Version... versions) {
+    Store store = mock(Store.class);
+    when(store.getName()).thenReturn(storeName);
+    when(store.getCurrentVersion()).thenReturn(currentVersion);
+    when(store.getVersions()).thenReturn(Arrays.asList(versions));
+    return store;
+  }
+
+  private static Version createVersion(int number, VersionStatus status) {
+    VersionImpl version = new VersionImpl(TEST_STORE_NAME, number);
+    version.setStatus(status);
+    return version;
+  }
+}

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/stats/StoreVersionOtelStatsTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/stats/StoreVersionOtelStatsTest.java
@@ -9,6 +9,7 @@ import static com.linkedin.venice.stats.dimensions.VeniceMetricsDimensions.VENIC
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import com.linkedin.venice.meta.ReadOnlyStoreRepository;
 import com.linkedin.venice.meta.Store;
 import com.linkedin.venice.meta.Version;
 import com.linkedin.venice.meta.VersionImpl;
@@ -21,6 +22,7 @@ import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.sdk.testing.exporter.InMemoryMetricReader;
 import io.tehuti.metrics.MetricsRepository;
 import java.util.Arrays;
+import java.util.Collections;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
@@ -129,6 +131,15 @@ public class StoreVersionOtelStatsTest {
   }
 
   @Test
+  public void testHandleStoreCreatedInitializesGauge() {
+    Store store = createMockStore(TEST_STORE_NAME, 3, createVersion(3, VersionStatus.ONLINE));
+    stats.handleStoreCreated(store);
+
+    validateGauge(3, TEST_STORE_NAME, VersionRole.CURRENT);
+    validateGauge(NON_EXISTING_VERSION, TEST_STORE_NAME, VersionRole.FUTURE);
+  }
+
+  @Test
   public void testFutureVersionComputedFromPushedStatus() {
     Store store = createMockStore(
         TEST_STORE_NAME,
@@ -154,6 +165,40 @@ public class StoreVersionOtelStatsTest {
 
     validateGauge(3, TEST_STORE_NAME, VersionRole.CURRENT);
     validateGauge(NON_EXISTING_VERSION, TEST_STORE_NAME, VersionRole.FUTURE);
+  }
+
+  @Test
+  public void testRegisterInitializesPreExistingStores() {
+    ReadOnlyStoreRepository mockRepo = mock(ReadOnlyStoreRepository.class);
+    Store preExisting = createMockStore(TEST_STORE_NAME, 5, createVersion(5, VersionStatus.ONLINE));
+    when(mockRepo.getAllStores()).thenReturn(Collections.singletonList(preExisting));
+
+    stats.register(mockRepo);
+
+    validateGauge(5, TEST_STORE_NAME, VersionRole.CURRENT);
+    validateGauge(NON_EXISTING_VERSION, TEST_STORE_NAME, VersionRole.FUTURE);
+  }
+
+  @Test
+  public void testRegisterDoesNotOverwriteConcurrentEvent() {
+    ReadOnlyStoreRepository mockRepo = mock(ReadOnlyStoreRepository.class);
+    // Snapshot has stale version 3
+    Store snapshot = createMockStore(TEST_STORE_NAME, 3, createVersion(3, VersionStatus.ONLINE));
+    when(mockRepo.getAllStores()).thenReturn(Collections.singletonList(snapshot));
+
+    // Simulate a concurrent ZK event with newer version 5 arriving before register() scans
+    stats.handleStoreChanged(createMockStore(TEST_STORE_NAME, 5, createVersion(5, VersionStatus.ONLINE)));
+
+    // register() should NOT overwrite v5 with stale v3 from the snapshot
+    stats.register(mockRepo);
+
+    validateGauge(5, TEST_STORE_NAME, VersionRole.CURRENT);
+  }
+
+  @Test
+  public void testDeleteForNeverSeenStoreIsNoOp() {
+    // handleStoreDeleted for a store that was never created should not throw
+    stats.handleStoreDeleted("never-seen-store");
   }
 
   private void validateGauge(long expectedValue, String storeName, VersionRole role) {

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/stats/StoreVersionOtelStatsTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/stats/StoreVersionOtelStatsTest.java
@@ -9,6 +9,7 @@ import static com.linkedin.venice.stats.dimensions.VeniceMetricsDimensions.VENIC
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -28,6 +29,8 @@ import io.tehuti.metrics.MetricsRepository;
 import io.tehuti.metrics.stats.AsyncGauge;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
@@ -201,11 +204,6 @@ public class StoreVersionOtelStatsTest {
    * for a store, {@code register()} must not overwrite it with snapshot data. This is the
    * invariant {@link StoreVersionOtelStats#initializeStoreIfAbsent} relies on to make the
    * register-then-snapshot path safe against races with ZK events.
-   *
-   * <p>Note: this test is single-threaded — it pre-populates an entry via
-   * {@code handleStoreChanged} before calling {@code register()}. A real concurrency test
-   * with latched threads racing the snapshot against the listener-dispatch path would be a
-   * stronger guard; left as a follow-up.
    */
   @Test
   public void testRegisterDoesNotOverwriteExistingEntry() {
@@ -219,6 +217,58 @@ public class StoreVersionOtelStatsTest {
 
     // register() should NOT overwrite v5 with stale v3 from the snapshot
     stats.register(mockRepo);
+
+    validateGauge(5, TEST_STORE_NAME, VersionRole.CURRENT);
+  }
+
+  /**
+   * Real concurrency test for the production race: a ZK event arrives during
+   * {@link StoreVersionOtelStats#register} between the listener registration and the snapshot
+   * iteration. The fresher value from the ZK event must win.
+   *
+   * <p>Two threads, latched: thread A enters {@code register()} and blocks inside
+   * {@code mockRepo.getAllStores()}; thread B (test thread) calls {@code handleStoreChanged}
+   * with a newer version while thread A is paused; latch releases, thread A resumes the
+   * snapshot iteration which calls {@code initializeStoreIfAbsent} (computeIfAbsent only — no
+   * unconditional set), so the existing fresh entry is preserved.
+   */
+  @Test
+  public void testRegisterRaceWithConcurrentZkEvent() throws Exception {
+    ReadOnlyStoreRepository mockRepo = mock(ReadOnlyStoreRepository.class);
+    Store staleSnapshot = createMockStore(TEST_STORE_NAME, 3, createVersion(3, VersionStatus.ONLINE));
+
+    CountDownLatch snapshotEntered = new CountDownLatch(1);
+    CountDownLatch zkEventApplied = new CountDownLatch(1);
+    when(mockRepo.getAllStores()).thenAnswer(inv -> {
+      snapshotEntered.countDown();
+      // Block until the test thread has applied the concurrent ZK event.
+      if (!zkEventApplied.await(5, TimeUnit.SECONDS)) {
+        throw new AssertionError("Test thread did not apply ZK event within 5s");
+      }
+      return Collections.singletonList(staleSnapshot);
+    });
+
+    Thread registerThread = new Thread(() -> stats.register(mockRepo), "register-thread");
+    registerThread.start();
+
+    // Wait until register() has reached getAllStores() — at this point the listener IS
+    // registered (registerStoreDataChangedListener was called before getAllStores), so a real
+    // ZK event could now reach handleStoreChanged.
+    if (!snapshotEntered.await(5, TimeUnit.SECONDS)) {
+      throw new AssertionError("register() did not reach getAllStores() within 5s");
+    }
+
+    // Simulate the concurrent ZK event with the fresher version.
+    Store fresh = createMockStore(TEST_STORE_NAME, 5, createVersion(5, VersionStatus.ONLINE));
+    stats.handleStoreChanged(fresh);
+
+    // Release register()'s snapshot iteration. initializeStoreIfAbsent will find the existing
+    // entry (fresh v5) and not allocate a new one — no overwrite.
+    zkEventApplied.countDown();
+    registerThread.join(5_000);
+    if (registerThread.isAlive()) {
+      throw new AssertionError("register() did not complete within 5s");
+    }
 
     validateGauge(5, TEST_STORE_NAME, VersionRole.CURRENT);
   }
@@ -258,6 +308,39 @@ public class StoreVersionOtelStatsTest {
       ReadOnlyStoreRepository mockRepo = mock(ReadOnlyStoreRepository.class);
       StoreVersionOtelStats.create(disabledRepo, TEST_CLUSTER_NAME, mockRepo);
       verify(mockRepo, never()).registerStoreDataChangedListener(any());
+    }
+  }
+
+  @Test
+  public void testCloseUnregistersListener() throws Exception {
+    ReadOnlyStoreRepository mockRepo = mock(ReadOnlyStoreRepository.class);
+    when(mockRepo.getAllStores()).thenReturn(Collections.emptyList());
+
+    StoreVersionOtelStats created = StoreVersionOtelStats.create(metricsRepository, TEST_CLUSTER_NAME, mockRepo);
+    verify(mockRepo).registerStoreDataChangedListener(created);
+
+    created.close();
+    verify(mockRepo).unregisterStoreDataChangedListener(created);
+
+    // Idempotent — second close() must not double-unregister.
+    created.close();
+    verify(mockRepo, times(1)).unregisterStoreDataChangedListener(created);
+  }
+
+  @Test
+  public void testCloseIsNoOpWhenOtelDisabled() throws Exception {
+    // When OTel is disabled, register() never registered the listener, so close() must not
+    // call unregisterStoreDataChangedListener.
+    AsyncGauge.AsyncGaugeExecutor dedicatedExecutor = new AsyncGauge.AsyncGaugeExecutor.Builder().build();
+    try (VeniceMetricsRepository disabledRepo = new VeniceMetricsRepository(
+        new VeniceMetricsConfig.Builder().setMetricPrefix(TEST_METRIC_PREFIX)
+            .setEmitOtelMetrics(false)
+            .setTehutiMetricConfig(new MetricConfig(dedicatedExecutor))
+            .build())) {
+      ReadOnlyStoreRepository mockRepo = mock(ReadOnlyStoreRepository.class);
+      StoreVersionOtelStats created = StoreVersionOtelStats.create(disabledRepo, TEST_CLUSTER_NAME, mockRepo);
+      created.close();
+      verify(mockRepo, never()).unregisterStoreDataChangedListener(any());
     }
   }
 

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/stats/StoreVersionOtelStatsTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/stats/StoreVersionOtelStatsTest.java
@@ -6,7 +6,9 @@ import static com.linkedin.venice.meta.Store.NON_EXISTING_VERSION;
 import static com.linkedin.venice.stats.dimensions.VeniceMetricsDimensions.VENICE_CLUSTER_NAME;
 import static com.linkedin.venice.stats.dimensions.VeniceMetricsDimensions.VENICE_STORE_NAME;
 import static com.linkedin.venice.stats.dimensions.VeniceMetricsDimensions.VENICE_VERSION_ROLE;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -194,14 +196,25 @@ public class StoreVersionOtelStatsTest {
     validateGauge(NON_EXISTING_VERSION, TEST_STORE_NAME, VersionRole.FUTURE);
   }
 
+  /**
+   * Sequential test of the {@code computeIfAbsent}-only semantic: if an entry already exists
+   * for a store, {@code register()} must not overwrite it with snapshot data. This is the
+   * invariant {@link StoreVersionOtelStats#initializeStoreIfAbsent} relies on to make the
+   * register-then-snapshot path safe against races with ZK events.
+   *
+   * <p>Note: this test is single-threaded — it pre-populates an entry via
+   * {@code handleStoreChanged} before calling {@code register()}. A real concurrency test
+   * with latched threads racing the snapshot against the listener-dispatch path would be a
+   * stronger guard; left as a follow-up.
+   */
   @Test
-  public void testRegisterDoesNotOverwriteConcurrentEvent() {
+  public void testRegisterDoesNotOverwriteExistingEntry() {
     ReadOnlyStoreRepository mockRepo = mock(ReadOnlyStoreRepository.class);
     // Snapshot has stale version 3
     Store snapshot = createMockStore(TEST_STORE_NAME, 3, createVersion(3, VersionStatus.ONLINE));
     when(mockRepo.getAllStores()).thenReturn(Collections.singletonList(snapshot));
 
-    // Simulate a concurrent ZK event with newer version 5 arriving before register() scans
+    // Pre-populate the entry with version 5 (simulating a ZK event that arrived earlier)
     stats.handleStoreChanged(createMockStore(TEST_STORE_NAME, 5, createVersion(5, VersionStatus.ONLINE)));
 
     // register() should NOT overwrite v5 with stale v3 from the snapshot
@@ -230,6 +243,22 @@ public class StoreVersionOtelStatsTest {
     verify(mockRepo).registerStoreDataChangedListener(created);
     validateGauge(7, TEST_STORE_NAME, VersionRole.CURRENT);
     validateGauge(NON_EXISTING_VERSION, TEST_STORE_NAME, VersionRole.FUTURE);
+  }
+
+  @Test
+  public void testCreateFactoryDoesNotRegisterListenerWhenOtelDisabled() throws Exception {
+    // When OTel is disabled, registering the listener would only add no-op dispatch overhead
+    // for every store create/change/delete event. Verify the optimization holds.
+    AsyncGauge.AsyncGaugeExecutor dedicatedExecutor = new AsyncGauge.AsyncGaugeExecutor.Builder().build();
+    try (VeniceMetricsRepository disabledRepo = new VeniceMetricsRepository(
+        new VeniceMetricsConfig.Builder().setMetricPrefix(TEST_METRIC_PREFIX)
+            .setEmitOtelMetrics(false)
+            .setTehutiMetricConfig(new MetricConfig(dedicatedExecutor))
+            .build())) {
+      ReadOnlyStoreRepository mockRepo = mock(ReadOnlyStoreRepository.class);
+      StoreVersionOtelStats.create(disabledRepo, TEST_CLUSTER_NAME, mockRepo);
+      verify(mockRepo, never()).registerStoreDataChangedListener(any());
+    }
   }
 
   private void validateGauge(long expectedValue, String storeName, VersionRole role) {

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/stats/StoreVersionOtelStatsTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/stats/StoreVersionOtelStatsTest.java
@@ -7,6 +7,7 @@ import static com.linkedin.venice.stats.dimensions.VeniceMetricsDimensions.VENIC
 import static com.linkedin.venice.stats.dimensions.VeniceMetricsDimensions.VENICE_STORE_NAME;
 import static com.linkedin.venice.stats.dimensions.VeniceMetricsDimensions.VENICE_VERSION_ROLE;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.linkedin.venice.meta.ReadOnlyStoreRepository;
@@ -20,7 +21,9 @@ import com.linkedin.venice.stats.VeniceMetricsRepository;
 import com.linkedin.venice.utils.OpenTelemetryDataTestUtils;
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.sdk.testing.exporter.InMemoryMetricReader;
+import io.tehuti.metrics.MetricConfig;
 import io.tehuti.metrics.MetricsRepository;
+import io.tehuti.metrics.stats.AsyncGauge;
 import java.util.Arrays;
 import java.util.Collections;
 import org.testng.annotations.AfterMethod;
@@ -36,16 +39,22 @@ public class StoreVersionOtelStatsTest {
 
   private InMemoryMetricReader inMemoryMetricReader;
   private VeniceMetricsRepository metricsRepository;
+  // Dedicated AsyncGauge executor: another test class calling MetricsRepository.close()
+  // in the same JVM shuts down the static default executor, which would make
+  // AsyncGauge.measure() return 0.0 in this test forever.
+  private AsyncGauge.AsyncGaugeExecutor asyncGaugeExecutor;
   private StoreVersionOtelStats stats;
 
   @BeforeMethod
   public void setUp() {
     inMemoryMetricReader = InMemoryMetricReader.create();
+    asyncGaugeExecutor = new AsyncGauge.AsyncGaugeExecutor.Builder().build();
     metricsRepository = new VeniceMetricsRepository(
         new VeniceMetricsConfig.Builder().setMetricPrefix(TEST_METRIC_PREFIX)
             .setMetricEntities(SERVER_METRIC_ENTITIES)
             .setEmitOtelMetrics(true)
             .setOtelAdditionalMetricsReader(inMemoryMetricReader)
+            .setTehutiMetricConfig(new MetricConfig(asyncGaugeExecutor))
             .build());
     stats = new StoreVersionOtelStats(metricsRepository, TEST_CLUSTER_NAME);
   }
@@ -53,6 +62,8 @@ public class StoreVersionOtelStatsTest {
   @AfterMethod
   public void tearDown() {
     if (metricsRepository != null) {
+      // Closes the dedicated executor we injected via setTehutiMetricConfig — does NOT touch
+      // the static AsyncGauge.DEFAULT_ASYNC_GAUGE_EXECUTOR shared with other test classes.
       metricsRepository.close();
     }
   }
@@ -113,8 +124,12 @@ public class StoreVersionOtelStatsTest {
 
   @Test
   public void testNoNpeWhenOtelDisabled() {
+    AsyncGauge.AsyncGaugeExecutor dedicatedExecutor = new AsyncGauge.AsyncGaugeExecutor.Builder().build();
     try (VeniceMetricsRepository disabledRepo = new VeniceMetricsRepository(
-        new VeniceMetricsConfig.Builder().setMetricPrefix(TEST_METRIC_PREFIX).setEmitOtelMetrics(false).build())) {
+        new VeniceMetricsConfig.Builder().setMetricPrefix(TEST_METRIC_PREFIX)
+            .setEmitOtelMetrics(false)
+            .setTehutiMetricConfig(new MetricConfig(dedicatedExecutor))
+            .build())) {
       StoreVersionOtelStats disabledStats = new StoreVersionOtelStats(disabledRepo, TEST_CLUSTER_NAME);
       Store store = createMockStore(TEST_STORE_NAME, 1, createVersion(1, VersionStatus.ONLINE));
       disabledStats.handleStoreChanged(store);
@@ -199,6 +214,22 @@ public class StoreVersionOtelStatsTest {
   public void testDeleteForNeverSeenStoreIsNoOp() {
     // handleStoreDeleted for a store that was never created should not throw
     stats.handleStoreDeleted("never-seen-store");
+  }
+
+  @Test
+  public void testCreateFactoryRegistersListenerAndInitializesPreExistingStores() {
+    // Exercises the production entry point: StoreVersionOtelStats.create(repo, cluster, metadataRepo).
+    // Verifies (1) the listener is registered on the metadata repository and (2) gauges are
+    // initialized for stores already present at registration time.
+    ReadOnlyStoreRepository mockRepo = mock(ReadOnlyStoreRepository.class);
+    Store preExisting = createMockStore(TEST_STORE_NAME, 7, createVersion(7, VersionStatus.ONLINE));
+    when(mockRepo.getAllStores()).thenReturn(Collections.singletonList(preExisting));
+
+    StoreVersionOtelStats created = StoreVersionOtelStats.create(metricsRepository, TEST_CLUSTER_NAME, mockRepo);
+
+    verify(mockRepo).registerStoreDataChangedListener(created);
+    validateGauge(7, TEST_STORE_NAME, VersionRole.CURRENT);
+    validateGauge(NON_EXISTING_VERSION, TEST_STORE_NAME, VersionRole.FUTURE);
   }
 
   private void validateGauge(long expectedValue, String storeName, VersionRole role) {

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/stats/VeniceVersionedStatsOtelMetricEntityTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/stats/VeniceVersionedStatsOtelMetricEntityTest.java
@@ -1,0 +1,36 @@
+package com.linkedin.davinci.stats;
+
+import static com.linkedin.davinci.stats.VeniceVersionedStatsOtelMetricEntity.STORE_VERSION;
+import static com.linkedin.venice.stats.dimensions.VeniceMetricsDimensions.VENICE_CLUSTER_NAME;
+import static com.linkedin.venice.stats.dimensions.VeniceMetricsDimensions.VENICE_STORE_NAME;
+import static com.linkedin.venice.stats.dimensions.VeniceMetricsDimensions.VENICE_VERSION_ROLE;
+import static com.linkedin.venice.utils.Utils.setOf;
+
+import com.linkedin.venice.stats.metrics.MetricType;
+import com.linkedin.venice.stats.metrics.MetricUnit;
+import com.linkedin.venice.stats.metrics.ModuleMetricEntityTestFixture;
+import com.linkedin.venice.stats.metrics.ModuleMetricEntityTestFixture.MetricEntityExpectation;
+import java.util.HashMap;
+import java.util.Map;
+import org.testng.annotations.Test;
+
+
+public class VeniceVersionedStatsOtelMetricEntityTest {
+  @Test
+  public void testMetricEntities() {
+    new ModuleMetricEntityTestFixture<>(VeniceVersionedStatsOtelMetricEntity.class, expectedDefinitions()).assertAll();
+  }
+
+  private static Map<VeniceVersionedStatsOtelMetricEntity, MetricEntityExpectation> expectedDefinitions() {
+    Map<VeniceVersionedStatsOtelMetricEntity, MetricEntityExpectation> map = new HashMap<>();
+    map.put(
+        STORE_VERSION,
+        new MetricEntityExpectation(
+            "store.version",
+            MetricType.ASYNC_GAUGE,
+            MetricUnit.NUMBER,
+            "Version number serving a given role (current or future) for a store",
+            setOf(VENICE_CLUSTER_NAME, VENICE_STORE_NAME, VENICE_VERSION_ROLE)));
+    return map;
+  }
+}

--- a/services/venice-server/src/main/java/com/linkedin/venice/server/VeniceServer.java
+++ b/services/venice-server/src/main/java/com/linkedin/venice/server/VeniceServer.java
@@ -22,6 +22,7 @@ import com.linkedin.davinci.stats.AggVersionedBlobTransferStats;
 import com.linkedin.davinci.stats.AggVersionedStorageEngineStats;
 import com.linkedin.davinci.stats.HeartbeatMonitoringServiceStats;
 import com.linkedin.davinci.stats.RocksDBMemoryStats;
+import com.linkedin.davinci.stats.StoreVersionOtelStats;
 import com.linkedin.davinci.stats.ingestion.heartbeat.HeartbeatMonitoringService;
 import com.linkedin.davinci.storage.DiskHealthCheckService;
 import com.linkedin.davinci.storage.IngestionMetadataRetriever;
@@ -328,6 +329,11 @@ public class VeniceServer {
         serverConfig.isUnregisterMetricForDeletedStoreEnabled(),
         serverConfig.getVersionSwapDiskSizeDropAlertThreshold(),
         clusterConfig.getClusterName());
+
+    // OTel per-store version gauge
+    metadataRepo
+        .registerStoreDataChangedListener(new StoreVersionOtelStats(metricsRepository, clusterConfig.getClusterName()));
+
     boolean plainTableEnabled =
         veniceConfigLoader.getVeniceServerConfig().getRocksDBServerConfig().isRocksDBPlainTableFormatEnabled();
     RocksDBMemoryStats rocksDBMemoryStats = veniceConfigLoader.getVeniceServerConfig().isDatabaseMemoryStatsEnabled()

--- a/services/venice-server/src/main/java/com/linkedin/venice/server/VeniceServer.java
+++ b/services/venice-server/src/main/java/com/linkedin/venice/server/VeniceServer.java
@@ -331,8 +331,7 @@ public class VeniceServer {
         clusterConfig.getClusterName());
 
     // OTel per-store version gauge
-    metadataRepo
-        .registerStoreDataChangedListener(new StoreVersionOtelStats(metricsRepository, clusterConfig.getClusterName()));
+    StoreVersionOtelStats.create(metricsRepository, clusterConfig.getClusterName(), metadataRepo);
 
     boolean plainTableEnabled =
         veniceConfigLoader.getVeniceServerConfig().getRocksDBServerConfig().isRocksDBPlainTableFormatEnabled();

--- a/services/venice-server/src/main/java/com/linkedin/venice/server/VeniceServer.java
+++ b/services/venice-server/src/main/java/com/linkedin/venice/server/VeniceServer.java
@@ -129,6 +129,7 @@ public class VeniceServer {
   private VeniceJVMStats jvmStats;
   private ICProvider icProvider;
   StorageEngineBackedCompressorFactory compressorFactory;
+  private StoreVersionOtelStats storeVersionOtelStats;
   private HeartbeatMonitoringService heartbeatMonitoringService;
   private AdaptiveThrottlerSignalService adaptiveThrottlerSignalService;
   private ServerReadMetadataRepository serverReadMetadataRepository;
@@ -331,7 +332,8 @@ public class VeniceServer {
         clusterConfig.getClusterName());
 
     // OTel per-store version gauge
-    StoreVersionOtelStats.create(metricsRepository, clusterConfig.getClusterName(), metadataRepo);
+    storeVersionOtelStats =
+        StoreVersionOtelStats.create(metricsRepository, clusterConfig.getClusterName(), metadataRepo);
 
     boolean plainTableEnabled =
         veniceConfigLoader.getVeniceServerConfig().getRocksDBServerConfig().isRocksDBPlainTableFormatEnabled();
@@ -759,6 +761,15 @@ public class VeniceServer {
       }
       LOGGER.info("All services have been stopped");
       compressorFactory.close();
+
+      if (storeVersionOtelStats != null) {
+        try {
+          storeVersionOtelStats.close();
+        } catch (Exception e) {
+          exceptions.add(e);
+          LOGGER.error("Exception while closing StoreVersionOtelStats", e);
+        }
+      }
 
       try {
         metricsRepository.close();


### PR DESCRIPTION
## Problem Statement

Venice stores track which version number is current and which is future for each store via Tehuti `current_version` and `future_version` AsyncGauge sensors in `VeniceVersionedStatsReporter`. These metrics have no OTel counterpart, making them unavailable in OTel-based monitoring dashboards.

## Solution

Add `StoreVersionOtelStats` — a standalone `StoreDataChangedListener` that registers OTel ASYNC_GAUGE callbacks per store for current and future version numbers, with `VERSION_ROLE` dimension (CURRENT/FUTURE). Created via `StoreVersionOtelStats.create()` factory method in both `VeniceServer` and `DaVinciBackend`.

**Design choice:** A standalone listener was chosen over adding OTel to `VeniceVersionedStatsReporter` because each store has 6 `VeniceVersionedStatsReporter` instances (one per `AbstractVeniceAggVersionedStats` subclass). Putting OTel in the reporter would create 6 duplicate ASYNC_GAUGE registrations per store. The standalone listener ensures exactly one registration per store.

**Key design decisions:**
- `create()` factory method combines construction + registration to eliminate temporal coupling (cannot forget to call `register()`).
- `register()` both adds the listener and initializes gauges for pre-existing stores via `getAllStores()` — the metadata repository does not replay existing stores to newly registered listeners.
- `initializeStoreIfAbsent()` uses `computeIfAbsent` only (no unconditional `.set()`) to avoid overwriting concurrent ZK events with stale snapshot data during startup initialization.
- Store deletion resets `AtomicReference<VersionInfo>` to `NON_EXISTING` rather than removing the map entry — OTel async gauge callbacks cannot be deregistered, so this avoids duplicate callback registration on store re-creation.
- Early return in `handleStoreChanged`/`handleStoreDeleted` when `otelRepository == null` skips all computation for non-OTel deployments.
- Implements `Closeable` so `DaVinciBackend`/`VeniceServer` can unregister the `StoreDataChangedListener` from the metadata repository on shutdown. OTel async gauge callbacks are intentionally not deregistered because the SDK does not support it; the `versionInfoMap` remains as the source of truth and continues returning `NON_EXISTING` for closed stores.

**Additional cleanup:**
- Extract `computeFutureVersion` into `OtelVersionedStatsUtils` — shared by `AbstractVeniceAggVersionedStats.applyVersionInfo()` and `StoreVersionOtelStats`, eliminating duplicated STARTED/PUSHED version logic. Caller is responsible for passing a non-null list (both current callers — `Store.getVersions()` and the existing-versions list in `applyVersionInfo` — are non-null by contract).
- Add `VersionInfo.NON_EXISTING` sentinel constant, replacing 5 inline `new VersionInfo(NON_EXISTING_VERSION, NON_EXISTING_VERSION)` duplicates across OTel stats classes.
- Make `VersionInfo` a `final` class to prevent subclassing that could break the shared sentinel pattern.
- Clean up 3 unused `NON_EXISTING_VERSION` imports.

###  Code changes
- [ ] Added new code behind **a config**. If so list the config names and their default values in the PR description.
- [ ] Introduced new **log lines**.
  - [ ] Confirmed if logs need to be **rate limited** to avoid excessive logging.

###  **Concurrency-Specific Checks**
Both reviewer and PR author to verify
- [x] Code has **no race conditions** or **thread safety issues**.
- [x] Proper **synchronization mechanisms** (e.g., `synchronized`, `RWLock`) are used where needed.
- [x] No **blocking calls** inside critical sections that could lead to deadlocks or performance degradation.
- [x] Verified **thread-safe collections** are used (e.g., `ConcurrentHashMap`, `CopyOnWriteArrayList`).
- [x] Validated proper exception handling in multi-threaded code to avoid silent thread termination.

## How was this PR tested?

- [x] New unit tests added.
- [ ] New integration tests added.
- [ ] Modified or extended existing tests.
- [x] Verified backward compatibility (if applicable).

New tests:
- `StoreVersionOtelStatsTest` (17 tests): CURRENT/FUTURE gauge values, version change updates, multi-store isolation, store delete/recreate lifecycle, `handleStoreCreated` delegation, future version computation (STARTED/PUSHED), no future when all ONLINE, NPE prevention (OTel disabled + plain MetricsRepository), `register()` initializes pre-existing stores, `register()` does not overwrite existing entries, latched-thread race with concurrent ZK events, delete for never-seen store is no-op, `create()` factory wires listener + initializes pre-existing stores, `create()` does not register the listener when OTel is disabled, `close()` unregisters the metadata listener, `close()` is a no-op when OTel is disabled.
- `VeniceVersionedStatsOtelMetricEntityTest`: metric entity validation via `ModuleMetricEntityTestFixture`.
- `OtelVersionedStatsUtilsTest` (6 new tests): `computeFutureVersion` — empty list, all ONLINE, STARTED only, PUSHED only, mixed returns max, ERROR ignored.

## Does this PR introduce any user-facing or breaking changes?
- [x] No. You can skip the rest of this section.
- [ ] Yes. Clearly explain the behavior change and its impact.

