### PR TITLE
[da-vinci] Add OTel metrics to StuckConsumerRepairStats

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/AggKafkaConsumerService.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/AggKafkaConsumerService.java
@@ -119,7 +119,7 @@ public class AggKafkaConsumerService extends AbstractVeniceService {
     this.kafkaClusterUrlResolver = serverConfig.getKafkaClusterUrlResolver();
     this.metadataRepository = metadataRepository;
     if (serverConfig.isStuckConsumerRepairEnabled()) {
-      this.stuckConsumerStats = new StuckConsumerRepairStats(metricsRepository);
+      this.stuckConsumerStats = new StuckConsumerRepairStats(metricsRepository, serverConfig.getClusterName());
       this.stuckConsumerRepairExecutorService = Executors.newSingleThreadScheduledExecutor(
           new DaemonThreadFactory(this.getClass().getName() + "-StuckConsumerRepair", serverConfig.getLogContext()));
       int intervalInSeconds = serverConfig.getStuckConsumerRepairIntervalSecond();

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/ServerMetricEntity.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/ServerMetricEntity.java
@@ -43,7 +43,8 @@ public final class ServerMetricEntity {
         ServerReadQuotaOtelMetricEntity.class,
         ServerConnectionOtelMetricEntity.class,
         StoreBufferServiceOtelMetricEntity.class,
-        StorageEngineOtelMetricEntity.class);
+        StorageEngineOtelMetricEntity.class,
+        StuckConsumerRepairOtelMetricEntity.class);
   }
 
   public static final Collection<MetricEntity> SERVER_METRIC_ENTITIES =

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/StuckConsumerRepairOtelMetricEntity.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/StuckConsumerRepairOtelMetricEntity.java
@@ -1,0 +1,50 @@
+package com.linkedin.davinci.stats;
+
+import static com.linkedin.venice.stats.dimensions.VeniceMetricsDimensions.VENICE_CLUSTER_NAME;
+import static com.linkedin.venice.utils.Utils.setOf;
+
+import com.linkedin.venice.stats.dimensions.VeniceMetricsDimensions;
+import com.linkedin.venice.stats.metrics.MetricEntity;
+import com.linkedin.venice.stats.metrics.MetricType;
+import com.linkedin.venice.stats.metrics.MetricUnit;
+import com.linkedin.venice.stats.metrics.ModuleMetricEntityInterface;
+import java.util.Set;
+
+
+/**
+ * OTel metric entity definitions for {@link StuckConsumerRepairStats}.
+ * Metrics track the stuck PubSub consumer detection and repair lifecycle.
+ */
+public enum StuckConsumerRepairOtelMetricEntity implements ModuleMetricEntityInterface {
+  STUCK_CONSUMER_DETECTED_COUNT(
+      "ingestion.pubsub.consumer.stuck.detected_count", MetricType.COUNTER, MetricUnit.NUMBER,
+      "Count of scans that detected a stuck PubSub consumer", setOf(VENICE_CLUSTER_NAME)
+  ),
+
+  STUCK_CONSUMER_TASK_REPAIRED_COUNT(
+      "ingestion.pubsub.consumer.stuck.task_repaired_count", MetricType.COUNTER, MetricUnit.NUMBER,
+      "Count of ingestion tasks killed to unblock a stuck PubSub consumer", setOf(VENICE_CLUSTER_NAME)
+  ),
+
+  STUCK_CONSUMER_UNRESOLVED_COUNT(
+      "ingestion.pubsub.consumer.stuck.unresolved_count", MetricType.COUNTER, MetricUnit.NUMBER,
+      "Count of scans where a stuck PubSub consumer was found but no fixable task identified",
+      setOf(VENICE_CLUSTER_NAME)
+  );
+
+  private final MetricEntity metricEntity;
+
+  StuckConsumerRepairOtelMetricEntity(
+      String metricName,
+      MetricType metricType,
+      MetricUnit unit,
+      String description,
+      Set<VeniceMetricsDimensions> dimensions) {
+    this.metricEntity = new MetricEntity(metricName, metricType, unit, description, dimensions);
+  }
+
+  @Override
+  public MetricEntity getMetricEntity() {
+    return metricEntity;
+  }
+}

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/StuckConsumerRepairStats.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/StuckConsumerRepairStats.java
@@ -1,33 +1,76 @@
 package com.linkedin.davinci.stats;
 
+import static com.linkedin.davinci.stats.StuckConsumerRepairOtelMetricEntity.STUCK_CONSUMER_DETECTED_COUNT;
+import static com.linkedin.davinci.stats.StuckConsumerRepairOtelMetricEntity.STUCK_CONSUMER_TASK_REPAIRED_COUNT;
+import static com.linkedin.davinci.stats.StuckConsumerRepairOtelMetricEntity.STUCK_CONSUMER_UNRESOLVED_COUNT;
+
 import com.linkedin.venice.stats.AbstractVeniceStats;
+import com.linkedin.venice.stats.OpenTelemetryMetricsSetup;
+import com.linkedin.venice.stats.dimensions.VeniceMetricsDimensions;
+import com.linkedin.venice.stats.metrics.MetricEntityStateBase;
+import com.linkedin.venice.stats.metrics.TehutiMetricNameEnum;
+import io.opentelemetry.api.common.Attributes;
 import io.tehuti.metrics.MetricsRepository;
-import io.tehuti.metrics.Sensor;
 import io.tehuti.metrics.stats.OccurrenceRate;
+import java.util.Collections;
+import java.util.Map;
 
 
 public class StuckConsumerRepairStats extends AbstractVeniceStats {
-  private Sensor stuckConsumerFound;
-  private Sensor ingestionTaskRepair;
-  private Sensor repairFailure;
+  /** Tehuti metric names for StuckConsumerRepairStats sensors. */
+  enum TehutiMetricName implements TehutiMetricNameEnum {
+    STUCK_CONSUMER_FOUND, INGESTION_TASK_REPAIR, REPAIR_FAILURE
+  }
 
-  public StuckConsumerRepairStats(MetricsRepository metricsRepository) {
+  private final MetricEntityStateBase stuckConsumerFoundOtel;
+  private final MetricEntityStateBase ingestionTaskRepairOtel;
+  private final MetricEntityStateBase repairFailureOtel;
+
+  public StuckConsumerRepairStats(MetricsRepository metricsRepository, String clusterName) {
     super(metricsRepository, "StuckConsumerRepair");
 
-    this.stuckConsumerFound = registerSensor("stuck_consumer_found", new OccurrenceRate());
-    this.ingestionTaskRepair = registerSensor("ingestion_task_repair", new OccurrenceRate());
-    this.repairFailure = registerSensor("repair_failure", new OccurrenceRate());
+    OpenTelemetryMetricsSetup.OpenTelemetryMetricsSetupInfo otelData =
+        OpenTelemetryMetricsSetup.builder(metricsRepository).setClusterName(clusterName).build();
+    Map<VeniceMetricsDimensions, String> baseDimensionsMap = otelData.getBaseDimensionsMap();
+    Attributes baseAttributes = otelData.getBaseAttributes();
+
+    stuckConsumerFoundOtel = MetricEntityStateBase.create(
+        STUCK_CONSUMER_DETECTED_COUNT.getMetricEntity(),
+        otelData.getOtelRepository(),
+        this::registerSensorIfAbsent,
+        TehutiMetricName.STUCK_CONSUMER_FOUND,
+        Collections.singletonList(new OccurrenceRate()),
+        baseDimensionsMap,
+        baseAttributes);
+
+    ingestionTaskRepairOtel = MetricEntityStateBase.create(
+        STUCK_CONSUMER_TASK_REPAIRED_COUNT.getMetricEntity(),
+        otelData.getOtelRepository(),
+        this::registerSensorIfAbsent,
+        TehutiMetricName.INGESTION_TASK_REPAIR,
+        Collections.singletonList(new OccurrenceRate()),
+        baseDimensionsMap,
+        baseAttributes);
+
+    repairFailureOtel = MetricEntityStateBase.create(
+        STUCK_CONSUMER_UNRESOLVED_COUNT.getMetricEntity(),
+        otelData.getOtelRepository(),
+        this::registerSensorIfAbsent,
+        TehutiMetricName.REPAIR_FAILURE,
+        Collections.singletonList(new OccurrenceRate()),
+        baseDimensionsMap,
+        baseAttributes);
   }
 
   public void recordStuckConsumerFound() {
-    stuckConsumerFound.record();
+    stuckConsumerFoundOtel.record(1);
   }
 
   public void recordIngestionTaskRepair() {
-    ingestionTaskRepair.record();
+    ingestionTaskRepairOtel.record(1);
   }
 
   public void recordRepairFailure() {
-    repairFailure.record();
+    repairFailureOtel.record(1);
   }
 }

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/stats/ServerMetricEntityTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/stats/ServerMetricEntityTest.java
@@ -22,7 +22,7 @@ import org.testng.annotations.Test;
 public class ServerMetricEntityTest {
   @Test
   public void testServerMetricEntitiesCount() {
-    assertEquals(SERVER_METRIC_ENTITIES.size(), 153, "Expected 153 unique metric entities");
+    assertEquals(SERVER_METRIC_ENTITIES.size(), 156, "Expected 156 unique metric entities");
   }
 
   /**

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/stats/ServerMetricEntityTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/stats/ServerMetricEntityTest.java
@@ -22,7 +22,7 @@ import org.testng.annotations.Test;
 public class ServerMetricEntityTest {
   @Test
   public void testServerMetricEntitiesCount() {
-    assertEquals(SERVER_METRIC_ENTITIES.size(), 155, "Expected 155 unique metric entities");
+    assertEquals(SERVER_METRIC_ENTITIES.size(), 158, "Expected 158 unique metric entities");
   }
 
   /**

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/stats/StuckConsumerRepairOtelMetricEntityTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/stats/StuckConsumerRepairOtelMetricEntityTest.java
@@ -1,0 +1,52 @@
+package com.linkedin.davinci.stats;
+
+import static com.linkedin.davinci.stats.StuckConsumerRepairOtelMetricEntity.STUCK_CONSUMER_DETECTED_COUNT;
+import static com.linkedin.davinci.stats.StuckConsumerRepairOtelMetricEntity.STUCK_CONSUMER_TASK_REPAIRED_COUNT;
+import static com.linkedin.davinci.stats.StuckConsumerRepairOtelMetricEntity.STUCK_CONSUMER_UNRESOLVED_COUNT;
+import static com.linkedin.venice.stats.dimensions.VeniceMetricsDimensions.VENICE_CLUSTER_NAME;
+import static com.linkedin.venice.utils.Utils.setOf;
+
+import com.linkedin.venice.stats.metrics.MetricType;
+import com.linkedin.venice.stats.metrics.MetricUnit;
+import com.linkedin.venice.stats.metrics.ModuleMetricEntityTestFixture;
+import com.linkedin.venice.stats.metrics.ModuleMetricEntityTestFixture.MetricEntityExpectation;
+import java.util.HashMap;
+import java.util.Map;
+import org.testng.annotations.Test;
+
+
+public class StuckConsumerRepairOtelMetricEntityTest {
+  @Test
+  public void testMetricEntities() {
+    new ModuleMetricEntityTestFixture<>(StuckConsumerRepairOtelMetricEntity.class, expectedDefinitions()).assertAll();
+  }
+
+  private static Map<StuckConsumerRepairOtelMetricEntity, MetricEntityExpectation> expectedDefinitions() {
+    Map<StuckConsumerRepairOtelMetricEntity, MetricEntityExpectation> map = new HashMap<>();
+    map.put(
+        STUCK_CONSUMER_DETECTED_COUNT,
+        new MetricEntityExpectation(
+            "ingestion.pubsub.consumer.stuck.detected_count",
+            MetricType.COUNTER,
+            MetricUnit.NUMBER,
+            "Count of scans that detected a stuck PubSub consumer",
+            setOf(VENICE_CLUSTER_NAME)));
+    map.put(
+        STUCK_CONSUMER_TASK_REPAIRED_COUNT,
+        new MetricEntityExpectation(
+            "ingestion.pubsub.consumer.stuck.task_repaired_count",
+            MetricType.COUNTER,
+            MetricUnit.NUMBER,
+            "Count of ingestion tasks killed to unblock a stuck PubSub consumer",
+            setOf(VENICE_CLUSTER_NAME)));
+    map.put(
+        STUCK_CONSUMER_UNRESOLVED_COUNT,
+        new MetricEntityExpectation(
+            "ingestion.pubsub.consumer.stuck.unresolved_count",
+            MetricType.COUNTER,
+            MetricUnit.NUMBER,
+            "Count of scans where a stuck PubSub consumer was found but no fixable task identified",
+            setOf(VENICE_CLUSTER_NAME)));
+    return map;
+  }
+}

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/stats/StuckConsumerRepairStatsTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/stats/StuckConsumerRepairStatsTest.java
@@ -1,0 +1,136 @@
+package com.linkedin.davinci.stats;
+
+import static com.linkedin.davinci.stats.ServerMetricEntity.SERVER_METRIC_ENTITIES;
+import static com.linkedin.venice.stats.dimensions.VeniceMetricsDimensions.VENICE_CLUSTER_NAME;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
+
+import com.linkedin.venice.stats.VeniceMetricsConfig;
+import com.linkedin.venice.stats.VeniceMetricsRepository;
+import com.linkedin.venice.utils.OpenTelemetryDataTestUtils;
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.sdk.testing.exporter.InMemoryMetricReader;
+import io.tehuti.metrics.MetricsRepository;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+
+public class StuckConsumerRepairStatsTest {
+  private static final String TEST_METRIC_PREFIX = "server";
+  private static final String TEST_CLUSTER_NAME = "test-cluster";
+
+  private InMemoryMetricReader inMemoryMetricReader;
+  private VeniceMetricsRepository metricsRepository;
+  private StuckConsumerRepairStats stats;
+
+  @BeforeMethod
+  public void setUp() {
+    inMemoryMetricReader = InMemoryMetricReader.create();
+    metricsRepository = new VeniceMetricsRepository(
+        new VeniceMetricsConfig.Builder().setMetricPrefix(TEST_METRIC_PREFIX)
+            .setMetricEntities(SERVER_METRIC_ENTITIES)
+            .setEmitOtelMetrics(true)
+            .setOtelAdditionalMetricsReader(inMemoryMetricReader)
+            .build());
+    stats = new StuckConsumerRepairStats(metricsRepository, TEST_CLUSTER_NAME);
+  }
+
+  @AfterMethod
+  public void tearDown() {
+    if (metricsRepository != null) {
+      metricsRepository.close();
+    }
+  }
+
+  // --- Positive tests: OTel counter accumulation ---
+
+  @Test
+  public void testRecordStuckConsumerFound() {
+    stats.recordStuckConsumerFound();
+    stats.recordStuckConsumerFound();
+
+    OpenTelemetryDataTestUtils.validateLongPointDataFromCounter(
+        inMemoryMetricReader,
+        2,
+        buildAttributes(),
+        StuckConsumerRepairOtelMetricEntity.STUCK_CONSUMER_DETECTED_COUNT.getMetricEntity().getMetricName(),
+        TEST_METRIC_PREFIX);
+  }
+
+  @Test
+  public void testRecordIngestionTaskRepair() {
+    stats.recordIngestionTaskRepair();
+    stats.recordIngestionTaskRepair();
+    stats.recordIngestionTaskRepair();
+
+    OpenTelemetryDataTestUtils.validateLongPointDataFromCounter(
+        inMemoryMetricReader,
+        3,
+        buildAttributes(),
+        StuckConsumerRepairOtelMetricEntity.STUCK_CONSUMER_TASK_REPAIRED_COUNT.getMetricEntity().getMetricName(),
+        TEST_METRIC_PREFIX);
+  }
+
+  @Test
+  public void testRecordRepairFailure() {
+    stats.recordRepairFailure();
+
+    OpenTelemetryDataTestUtils.validateLongPointDataFromCounter(
+        inMemoryMetricReader,
+        1,
+        buildAttributes(),
+        StuckConsumerRepairOtelMetricEntity.STUCK_CONSUMER_UNRESOLVED_COUNT.getMetricEntity().getMetricName(),
+        TEST_METRIC_PREFIX);
+  }
+
+  // --- Positive tests: Tehuti sensor existence and recording ---
+
+  @Test
+  public void testTehutiSensorsRegisteredAndRecorded() {
+    // OccurrenceRate sensors use the ".OccurrenceRate" suffix
+    String foundSensor = ".StuckConsumerRepair--stuck_consumer_found.OccurrenceRate";
+    String repairSensor = ".StuckConsumerRepair--ingestion_task_repair.OccurrenceRate";
+    String failureSensor = ".StuckConsumerRepair--repair_failure.OccurrenceRate";
+
+    assertNotNull(metricsRepository.getMetric(foundSensor), "Tehuti sensor should exist for stuck_consumer_found");
+    assertNotNull(metricsRepository.getMetric(repairSensor), "Tehuti sensor should exist for ingestion_task_repair");
+    assertNotNull(metricsRepository.getMetric(failureSensor), "Tehuti sensor should exist for repair_failure");
+
+    // Record and verify values are non-zero (OccurrenceRate is time-dependent, so just assert > 0)
+    stats.recordStuckConsumerFound();
+    stats.recordIngestionTaskRepair();
+    stats.recordRepairFailure();
+    assertTrue(metricsRepository.getMetric(foundSensor).value() > 0, "stuck_consumer_found rate should be > 0");
+    assertTrue(metricsRepository.getMetric(repairSensor).value() > 0, "ingestion_task_repair rate should be > 0");
+    assertTrue(metricsRepository.getMetric(failureSensor).value() > 0, "repair_failure rate should be > 0");
+  }
+
+  // --- NPE prevention tests ---
+
+  @Test
+  public void testNoNpeWhenOtelDisabled() {
+    try (VeniceMetricsRepository disabledRepo = new VeniceMetricsRepository(
+        new VeniceMetricsConfig.Builder().setMetricPrefix(TEST_METRIC_PREFIX).setEmitOtelMetrics(false).build())) {
+      exerciseAllRecordingPaths(disabledRepo);
+    }
+  }
+
+  @Test
+  public void testNoNpeWhenPlainMetricsRepository() {
+    exerciseAllRecordingPaths(new MetricsRepository());
+  }
+
+  private void exerciseAllRecordingPaths(MetricsRepository repo) {
+    StuckConsumerRepairStats safeStats = new StuckConsumerRepairStats(repo, TEST_CLUSTER_NAME);
+    safeStats.recordStuckConsumerFound();
+    safeStats.recordIngestionTaskRepair();
+    safeStats.recordRepairFailure();
+  }
+
+  // --- Helper ---
+
+  private Attributes buildAttributes() {
+    return Attributes.builder().put(VENICE_CLUSTER_NAME.getDimensionNameInDefaultFormat(), TEST_CLUSTER_NAME).build();
+  }
+}

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/stats/StuckConsumerRepairStatsTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/stats/StuckConsumerRepairStatsTest.java
@@ -10,7 +10,9 @@ import com.linkedin.venice.stats.VeniceMetricsRepository;
 import com.linkedin.venice.utils.OpenTelemetryDataTestUtils;
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.sdk.testing.exporter.InMemoryMetricReader;
+import io.tehuti.metrics.MetricConfig;
 import io.tehuti.metrics.MetricsRepository;
+import io.tehuti.metrics.stats.AsyncGauge;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
@@ -23,21 +25,28 @@ public class StuckConsumerRepairStatsTest {
   private InMemoryMetricReader inMemoryMetricReader;
   private VeniceMetricsRepository metricsRepository;
   private StuckConsumerRepairStats stats;
+  // Dedicated executor avoids shutting down Tehuti's static DEFAULT_ASYNC_GAUGE_EXECUTOR singleton when this
+  // repository is closed in tearDown(). Closing the static executor would break AsyncGauge measurements
+  // for any subsequent test running in the same JVM.
+  private AsyncGauge.AsyncGaugeExecutor asyncGaugeExecutor;
 
   @BeforeMethod
   public void setUp() {
     inMemoryMetricReader = InMemoryMetricReader.create();
+    asyncGaugeExecutor = new AsyncGauge.AsyncGaugeExecutor.Builder().build();
     metricsRepository = new VeniceMetricsRepository(
         new VeniceMetricsConfig.Builder().setMetricPrefix(TEST_METRIC_PREFIX)
             .setMetricEntities(SERVER_METRIC_ENTITIES)
             .setEmitOtelMetrics(true)
             .setOtelAdditionalMetricsReader(inMemoryMetricReader)
+            .setTehutiMetricConfig(new MetricConfig(asyncGaugeExecutor))
             .build());
     stats = new StuckConsumerRepairStats(metricsRepository, TEST_CLUSTER_NAME);
   }
 
   @AfterMethod
   public void tearDown() {
+    // Closes only the dedicated executor; the JVM-wide static executor stays alive for other tests.
     if (metricsRepository != null) {
       metricsRepository.close();
     }
@@ -110,8 +119,12 @@ public class StuckConsumerRepairStatsTest {
 
   @Test
   public void testNoNpeWhenOtelDisabled() {
+    AsyncGauge.AsyncGaugeExecutor localExecutor = new AsyncGauge.AsyncGaugeExecutor.Builder().build();
     try (VeniceMetricsRepository disabledRepo = new VeniceMetricsRepository(
-        new VeniceMetricsConfig.Builder().setMetricPrefix(TEST_METRIC_PREFIX).setEmitOtelMetrics(false).build())) {
+        new VeniceMetricsConfig.Builder().setMetricPrefix(TEST_METRIC_PREFIX)
+            .setEmitOtelMetrics(false)
+            .setTehutiMetricConfig(new MetricConfig(localExecutor))
+            .build())) {
       exerciseAllRecordingPaths(disabledRepo);
     }
   }

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/stats/StuckConsumerRepairTehutiMetricNameTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/stats/StuckConsumerRepairTehutiMetricNameTest.java
@@ -1,0 +1,23 @@
+package com.linkedin.davinci.stats;
+
+import com.linkedin.venice.stats.metrics.TehutiMetricNameEnumTestFixture;
+import java.util.HashMap;
+import java.util.Map;
+import org.testng.annotations.Test;
+
+
+public class StuckConsumerRepairTehutiMetricNameTest {
+  @Test
+  public void testTehutiMetricNames() {
+    new TehutiMetricNameEnumTestFixture<>(StuckConsumerRepairStats.TehutiMetricName.class, expectedMetricNames())
+        .assertAll();
+  }
+
+  private static Map<StuckConsumerRepairStats.TehutiMetricName, String> expectedMetricNames() {
+    Map<StuckConsumerRepairStats.TehutiMetricName, String> map = new HashMap<>();
+    map.put(StuckConsumerRepairStats.TehutiMetricName.STUCK_CONSUMER_FOUND, "stuck_consumer_found");
+    map.put(StuckConsumerRepairStats.TehutiMetricName.INGESTION_TASK_REPAIR, "ingestion_task_repair");
+    map.put(StuckConsumerRepairStats.TehutiMetricName.REPAIR_FAILURE, "repair_failure");
+    return map;
+  }
+}


### PR DESCRIPTION
## Problem Statement

`StuckConsumerRepairStats` has 3 Tehuti OccurrenceRate sensors for the stuck consumer detection and repair lifecycle but no OTel counterparts, making these metrics unavailable in OTel-based monitoring dashboards.

## Solution

Add 3 OTel COUNTER metrics under the `ingestion.pubsub.consumer.stuck.*` namespace using the joint Tehuti+OTel API (`MetricEntityStateBase`):

- `ingestion.pubsub.consumer.stuck.detected_count` — scans that detected a stuck PubSub consumer
- `ingestion.pubsub.consumer.stuck.task_repaired_count` — ingestion tasks killed to unblock a stuck consumer
- `ingestion.pubsub.consumer.stuck.unresolved_count` — stuck consumers found with no fixable task identified

This is a singleton stats class with `CLUSTER_NAME` as the only dimension. `clusterName` was added to the constructor, passed from `AggKafkaConsumerService` via `serverConfig.getClusterName()`.

###  Code changes
- [ ] Added new code behind **a config**.
- [ ] Introduced new **log lines**.
  - [ ] Confirmed if logs need to be **rate limited** to avoid excessive logging.

###  **Concurrency-Specific Checks**
Both reviewer and PR author to verify
- [x] Code has **no race conditions** or **thread safety issues**.
- [ ] Proper **synchronization mechanisms** (e.g., `synchronized`, `RWLock`) are used where needed.
- [ ] No **blocking calls** inside critical sections that could lead to deadlocks or performance degradation.
- [ ] Verified **thread-safe collections** are used (e.g., `ConcurrentHashMap`, `CopyOnWriteArrayList`).
- [ ] Validated proper exception handling in multi-threaded code to avoid silent thread termination.

## How was this PR tested?

- [x] New unit tests added.
- [ ] New integration tests added.
- [ ] Modified or extended existing tests.
- [x] Verified backward compatibility (if applicable).

New tests:
- `StuckConsumerRepairStatsTest` (6 tests): OTel counter accumulation for all 3 metrics, Tehuti sensor registration + recording, NPE prevention with OTel disabled and plain MetricsRepository.
- `StuckConsumerRepairOtelMetricEntityTest`: metric entity validation for all 3 metrics.
- `StuckConsumerRepairTehutiMetricNameTest`: Tehuti name validation for all 3 enum values.

## Does this PR introduce any user-facing or breaking changes?
- [x] No. You can skip the rest of this section.
- [ ] Yes. Clearly explain the behavior change and its impact.