### PR TITLE
[server] Add OTel metrics to ServerLoadStats

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/ServerLoadOtelMetricEntity.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/ServerLoadOtelMetricEntity.java
@@ -1,0 +1,46 @@
+package com.linkedin.davinci.stats;
+
+import static com.linkedin.venice.stats.dimensions.VeniceMetricsDimensions.VENICE_CLUSTER_NAME;
+import static com.linkedin.venice.stats.dimensions.VeniceMetricsDimensions.VENICE_SERVER_LOAD_REQUEST_OUTCOME;
+import static com.linkedin.venice.utils.Utils.setOf;
+
+import com.linkedin.venice.stats.dimensions.VeniceMetricsDimensions;
+import com.linkedin.venice.stats.metrics.MetricEntity;
+import com.linkedin.venice.stats.metrics.MetricType;
+import com.linkedin.venice.stats.metrics.MetricUnit;
+import com.linkedin.venice.stats.metrics.ModuleMetricEntityInterface;
+import java.util.Set;
+
+
+/**
+ * OTel metric entity definitions for {@link com.linkedin.venice.stats.ServerLoadStats}.
+ * Tracks server load control: request outcomes and rejection ratio.
+ */
+public enum ServerLoadOtelMetricEntity implements ModuleMetricEntityInterface {
+  REQUEST_COUNT(
+      "load_controller.request.count", MetricType.COUNTER, MetricUnit.NUMBER,
+      "Count of requests by load control outcome (accepted or rejected)",
+      setOf(VENICE_CLUSTER_NAME, VENICE_SERVER_LOAD_REQUEST_OUTCOME)
+  ),
+
+  REJECTION_RATIO(
+      "load_controller.request.rejection_ratio", MetricType.MIN_MAX_COUNT_SUM_AGGREGATIONS, MetricUnit.RATIO,
+      "Server load rejection ratio (fraction of requests being rejected)", setOf(VENICE_CLUSTER_NAME)
+  );
+
+  private final MetricEntity metricEntity;
+
+  ServerLoadOtelMetricEntity(
+      String metricName,
+      MetricType metricType,
+      MetricUnit unit,
+      String description,
+      Set<VeniceMetricsDimensions> dimensions) {
+    this.metricEntity = new MetricEntity(metricName, metricType, unit, description, dimensions);
+  }
+
+  @Override
+  public MetricEntity getMetricEntity() {
+    return metricEntity;
+  }
+}

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/ServerMetricEntity.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/ServerMetricEntity.java
@@ -43,7 +43,8 @@ public final class ServerMetricEntity {
         ServerReadQuotaOtelMetricEntity.class,
         ServerConnectionOtelMetricEntity.class,
         StoreBufferServiceOtelMetricEntity.class,
-        StorageEngineOtelMetricEntity.class);
+        StorageEngineOtelMetricEntity.class,
+        ServerLoadOtelMetricEntity.class);
   }
 
   public static final Collection<MetricEntity> SERVER_METRIC_ENTITIES =

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/ServerMetricEntity.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/ServerMetricEntity.java
@@ -45,7 +45,8 @@ public final class ServerMetricEntity {
         StoreBufferServiceOtelMetricEntity.class,
         StorageEngineOtelMetricEntity.class,
         DiskHealthOtelMetricEntity.class,
-        NativeMetadataRepositoryOtelMetricEntity.class);
+        NativeMetadataRepositoryOtelMetricEntity.class,
+        ServerLoadOtelMetricEntity.class);
   }
 
   public static final Collection<MetricEntity> SERVER_METRIC_ENTITIES =

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/stats/ServerLoadOtelMetricEntityTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/stats/ServerLoadOtelMetricEntityTest.java
@@ -1,0 +1,44 @@
+package com.linkedin.davinci.stats;
+
+import static com.linkedin.davinci.stats.ServerLoadOtelMetricEntity.REJECTION_RATIO;
+import static com.linkedin.davinci.stats.ServerLoadOtelMetricEntity.REQUEST_COUNT;
+import static com.linkedin.venice.stats.dimensions.VeniceMetricsDimensions.VENICE_CLUSTER_NAME;
+import static com.linkedin.venice.stats.dimensions.VeniceMetricsDimensions.VENICE_SERVER_LOAD_REQUEST_OUTCOME;
+import static com.linkedin.venice.utils.Utils.setOf;
+
+import com.linkedin.venice.stats.metrics.MetricType;
+import com.linkedin.venice.stats.metrics.MetricUnit;
+import com.linkedin.venice.stats.metrics.ModuleMetricEntityTestFixture;
+import com.linkedin.venice.stats.metrics.ModuleMetricEntityTestFixture.MetricEntityExpectation;
+import java.util.HashMap;
+import java.util.Map;
+import org.testng.annotations.Test;
+
+
+public class ServerLoadOtelMetricEntityTest {
+  @Test
+  public void testMetricEntities() {
+    new ModuleMetricEntityTestFixture<>(ServerLoadOtelMetricEntity.class, expectedDefinitions()).assertAll();
+  }
+
+  private static Map<ServerLoadOtelMetricEntity, MetricEntityExpectation> expectedDefinitions() {
+    Map<ServerLoadOtelMetricEntity, MetricEntityExpectation> map = new HashMap<>();
+    map.put(
+        REQUEST_COUNT,
+        new MetricEntityExpectation(
+            "load_controller.request.count",
+            MetricType.COUNTER,
+            MetricUnit.NUMBER,
+            "Count of requests by load control outcome (accepted or rejected)",
+            setOf(VENICE_CLUSTER_NAME, VENICE_SERVER_LOAD_REQUEST_OUTCOME)));
+    map.put(
+        REJECTION_RATIO,
+        new MetricEntityExpectation(
+            "load_controller.request.rejection_ratio",
+            MetricType.MIN_MAX_COUNT_SUM_AGGREGATIONS,
+            MetricUnit.RATIO,
+            "Server load rejection ratio (fraction of requests being rejected)",
+            setOf(VENICE_CLUSTER_NAME)));
+    return map;
+  }
+}

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/stats/ServerMetricEntityTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/stats/ServerMetricEntityTest.java
@@ -22,7 +22,7 @@ import org.testng.annotations.Test;
 public class ServerMetricEntityTest {
   @Test
   public void testServerMetricEntitiesCount() {
-    assertEquals(SERVER_METRIC_ENTITIES.size(), 153, "Expected 153 unique metric entities");
+    assertEquals(SERVER_METRIC_ENTITIES.size(), 155, "Expected 155 unique metric entities");
   }
 
   /**

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/stats/ServerMetricEntityTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/stats/ServerMetricEntityTest.java
@@ -22,7 +22,7 @@ import org.testng.annotations.Test;
 public class ServerMetricEntityTest {
   @Test
   public void testServerMetricEntitiesCount() {
-    assertEquals(SERVER_METRIC_ENTITIES.size(), 157, "Expected 157 unique metric entities");
+    assertEquals(SERVER_METRIC_ENTITIES.size(), 159, "Expected 159 unique metric entities");
   }
 
   /**

--- a/internal/venice-client-common/src/main/java/com/linkedin/venice/stats/dimensions/VeniceMetricsDimensions.java
+++ b/internal/venice-client-common/src/main/java/com/linkedin/venice/stats/dimensions/VeniceMetricsDimensions.java
@@ -153,7 +153,10 @@ public enum VeniceMetricsDimensions {
   VENICE_CONNECTION_SOURCE("venice.connection.source"),
 
   /** {@link VeniceDrainerType} Drainer type: sorted or unsorted. */
-  VENICE_DRAINER_TYPE("venice.drainer.type");
+  VENICE_DRAINER_TYPE("venice.drainer.type"),
+
+  /** {@link VeniceServerLoadRequestOutcome} Server load request outcome: accepted or rejected. */
+  VENICE_SERVER_LOAD_REQUEST_OUTCOME("venice.server.load_controller.request_outcome");
 
   private final String[] dimensionName = new String[VeniceOpenTelemetryMetricNamingFormat.SIZE];
 

--- a/internal/venice-client-common/src/main/java/com/linkedin/venice/stats/dimensions/VeniceMetricsDimensions.java
+++ b/internal/venice-client-common/src/main/java/com/linkedin/venice/stats/dimensions/VeniceMetricsDimensions.java
@@ -159,7 +159,10 @@ public enum VeniceMetricsDimensions {
   VENICE_REQUEST_KEY_COUNT_BUCKET("venice.request.key_count_bucket"),
 
   /** Name of the metric being recorded; used for per-metric attribution on internal failure counters. */
-  VENICE_METRIC_NAME("venice.metric.name");
+  VENICE_METRIC_NAME("venice.metric.name"),
+
+  /** {@link VeniceServerLoadRequestOutcome} Server load request outcome: accepted or rejected. */
+  VENICE_SERVER_LOAD_REQUEST_OUTCOME("venice.server.load_controller.request_outcome");
 
   private final String[] dimensionName = new String[VeniceOpenTelemetryMetricNamingFormat.SIZE];
 

--- a/internal/venice-client-common/src/main/java/com/linkedin/venice/stats/dimensions/VeniceServerLoadRequestOutcome.java
+++ b/internal/venice-client-common/src/main/java/com/linkedin/venice/stats/dimensions/VeniceServerLoadRequestOutcome.java
@@ -2,9 +2,9 @@ package com.linkedin.venice.stats.dimensions;
 
 /** Request outcome for server load control metrics. */
 public enum VeniceServerLoadRequestOutcome implements VeniceDimensionInterface {
-  /** Request processed by the server (not load-shedded). */
+  /** Request processed by the server (not load-shed). */
   ACCEPTED,
-  /** Request load-shedded before processing due to server overload. */
+  /** Request load-shed before processing due to server overload. */
   REJECTED;
 
   @Override

--- a/internal/venice-client-common/src/main/java/com/linkedin/venice/stats/dimensions/VeniceServerLoadRequestOutcome.java
+++ b/internal/venice-client-common/src/main/java/com/linkedin/venice/stats/dimensions/VeniceServerLoadRequestOutcome.java
@@ -1,0 +1,14 @@
+package com.linkedin.venice.stats.dimensions;
+
+/** Request outcome for server load control metrics. */
+public enum VeniceServerLoadRequestOutcome implements VeniceDimensionInterface {
+  /** Request processed by the server (not load-shedded). */
+  ACCEPTED,
+  /** Request load-shedded before processing due to server overload. */
+  REJECTED;
+
+  @Override
+  public VeniceMetricsDimensions getDimensionName() {
+    return VeniceMetricsDimensions.VENICE_SERVER_LOAD_REQUEST_OUTCOME;
+  }
+}

--- a/internal/venice-client-common/src/test/java/com/linkedin/venice/stats/dimensions/VeniceMetricsDimensionsTest.java
+++ b/internal/venice-client-common/src/test/java/com/linkedin/venice/stats/dimensions/VeniceMetricsDimensionsTest.java
@@ -157,6 +157,9 @@ public class VeniceMetricsDimensionsTest {
         case VENICE_DRAINER_TYPE:
           assertEquals(dimension.getDimensionName(format), "venice.drainer.type");
           break;
+        case VENICE_SERVER_LOAD_REQUEST_OUTCOME:
+          assertEquals(dimension.getDimensionName(format), "venice.server.load_controller.request_outcome");
+          break;
         default:
           throw new IllegalArgumentException("Unknown dimension: " + dimension);
       }
@@ -312,6 +315,9 @@ public class VeniceMetricsDimensionsTest {
         case VENICE_DRAINER_TYPE:
           assertEquals(dimension.getDimensionName(format), "venice.drainer.type");
           break;
+        case VENICE_SERVER_LOAD_REQUEST_OUTCOME:
+          assertEquals(dimension.getDimensionName(format), "venice.server.loadController.requestOutcome");
+          break;
         default:
           throw new IllegalArgumentException("Unknown dimension: " + dimension);
       }
@@ -466,6 +472,9 @@ public class VeniceMetricsDimensionsTest {
           break;
         case VENICE_DRAINER_TYPE:
           assertEquals(dimension.getDimensionName(format), "Venice.Drainer.Type");
+          break;
+        case VENICE_SERVER_LOAD_REQUEST_OUTCOME:
+          assertEquals(dimension.getDimensionName(format), "Venice.Server.LoadController.RequestOutcome");
           break;
         default:
           throw new IllegalArgumentException("Unknown dimension: " + dimension);

--- a/internal/venice-client-common/src/test/java/com/linkedin/venice/stats/dimensions/VeniceMetricsDimensionsTest.java
+++ b/internal/venice-client-common/src/test/java/com/linkedin/venice/stats/dimensions/VeniceMetricsDimensionsTest.java
@@ -163,6 +163,9 @@ public class VeniceMetricsDimensionsTest {
         case VENICE_METRIC_NAME:
           assertEquals(dimension.getDimensionName(format), "venice.metric.name");
           break;
+        case VENICE_SERVER_LOAD_REQUEST_OUTCOME:
+          assertEquals(dimension.getDimensionName(format), "venice.server.load_controller.request_outcome");
+          break;
         default:
           throw new IllegalArgumentException("Unknown dimension: " + dimension);
       }
@@ -324,6 +327,9 @@ public class VeniceMetricsDimensionsTest {
         case VENICE_METRIC_NAME:
           assertEquals(dimension.getDimensionName(format), "venice.metric.name");
           break;
+        case VENICE_SERVER_LOAD_REQUEST_OUTCOME:
+          assertEquals(dimension.getDimensionName(format), "venice.server.loadController.requestOutcome");
+          break;
         default:
           throw new IllegalArgumentException("Unknown dimension: " + dimension);
       }
@@ -484,6 +490,9 @@ public class VeniceMetricsDimensionsTest {
           break;
         case VENICE_METRIC_NAME:
           assertEquals(dimension.getDimensionName(format), "Venice.Metric.Name");
+          break;
+        case VENICE_SERVER_LOAD_REQUEST_OUTCOME:
+          assertEquals(dimension.getDimensionName(format), "Venice.Server.LoadController.RequestOutcome");
           break;
         default:
           throw new IllegalArgumentException("Unknown dimension: " + dimension);

--- a/internal/venice-client-common/src/test/java/com/linkedin/venice/stats/dimensions/VeniceServerLoadRequestOutcomeTest.java
+++ b/internal/venice-client-common/src/test/java/com/linkedin/venice/stats/dimensions/VeniceServerLoadRequestOutcomeTest.java
@@ -1,0 +1,21 @@
+package com.linkedin.venice.stats.dimensions;
+
+import com.linkedin.venice.utils.CollectionUtils;
+import java.util.Map;
+import org.testng.annotations.Test;
+
+
+public class VeniceServerLoadRequestOutcomeTest {
+  @Test
+  public void testDimensionInterface() {
+    Map<VeniceServerLoadRequestOutcome, String> expectedValues =
+        CollectionUtils.<VeniceServerLoadRequestOutcome, String>mapBuilder()
+            .put(VeniceServerLoadRequestOutcome.ACCEPTED, "accepted")
+            .put(VeniceServerLoadRequestOutcome.REJECTED, "rejected")
+            .build();
+    new VeniceDimensionTestFixture<>(
+        VeniceServerLoadRequestOutcome.class,
+        VeniceMetricsDimensions.VENICE_SERVER_LOAD_REQUEST_OUTCOME,
+        expectedValues).assertAll();
+  }
+}

--- a/services/venice-server/src/main/java/com/linkedin/venice/listener/HttpChannelInitializer.java
+++ b/services/venice-server/src/main/java/com/linkedin/venice/listener/HttpChannelInitializer.java
@@ -182,8 +182,9 @@ public class HttpChannelInitializer extends ChannelInitializer<SocketChannel> {
       this.serverConnectionStatsHandler = null;
     }
     if (serverConfig.isLoadControllerEnabled()) {
-      this.loadControllerHandler =
-          new ServerLoadControllerHandler(serverConfig, new ServerLoadStats(metricsRepository, "server_load"));
+      this.loadControllerHandler = new ServerLoadControllerHandler(
+          serverConfig,
+          new ServerLoadStats(metricsRepository, "server_load", serverConfig.getClusterName()));
       LOGGER.info("Server load controller is enabled");
     } else {
       this.loadControllerHandler = null;

--- a/services/venice-server/src/main/java/com/linkedin/venice/listener/ServerLoadControllerHandler.java
+++ b/services/venice-server/src/main/java/com/linkedin/venice/listener/ServerLoadControllerHandler.java
@@ -91,8 +91,10 @@ public class ServerLoadControllerHandler extends SimpleChannelInboundHandler<Htt
         latencyThreshold = serverConfig.getLoadControllerComputeLatencyAcceptThresholdMs();
         break;
     }
+    // Metrics: count this request as ACCEPTED (served, not load-shedded)
+    loadStats.recordAcceptedRequest();
     if (latency <= latencyThreshold) {
-      loadStats.recordAcceptedRequest();
+      // Load controller internal: fast-enough request feeds the admission ratio algorithm
       loadController.recordAccept();
     }
 

--- a/services/venice-server/src/main/java/com/linkedin/venice/listener/ServerLoadControllerHandler.java
+++ b/services/venice-server/src/main/java/com/linkedin/venice/listener/ServerLoadControllerHandler.java
@@ -91,7 +91,7 @@ public class ServerLoadControllerHandler extends SimpleChannelInboundHandler<Htt
         latencyThreshold = serverConfig.getLoadControllerComputeLatencyAcceptThresholdMs();
         break;
     }
-    // Metrics: count this request as ACCEPTED (served, not load-shedded)
+    // Metrics: count this request as ACCEPTED (served, not load-shed)
     loadStats.recordAcceptedRequest();
     if (latency <= latencyThreshold) {
       // Load controller internal: fast-enough request feeds the admission ratio algorithm

--- a/services/venice-server/src/main/java/com/linkedin/venice/stats/ServerLoadStats.java
+++ b/services/venice-server/src/main/java/com/linkedin/venice/stats/ServerLoadStats.java
@@ -1,40 +1,97 @@
 package com.linkedin.venice.stats;
 
+import static com.linkedin.davinci.stats.ServerLoadOtelMetricEntity.REJECTION_RATIO;
+import static com.linkedin.davinci.stats.ServerLoadOtelMetricEntity.REQUEST_COUNT;
+
+import com.linkedin.venice.stats.dimensions.VeniceMetricsDimensions;
+import com.linkedin.venice.stats.dimensions.VeniceServerLoadRequestOutcome;
+import com.linkedin.venice.stats.metrics.MetricEntityStateBase;
+import com.linkedin.venice.stats.metrics.MetricEntityStateOneEnum;
+import com.linkedin.venice.stats.metrics.TehutiMetricNameEnum;
+import io.opentelemetry.api.common.Attributes;
 import io.tehuti.metrics.MetricsRepository;
 import io.tehuti.metrics.Sensor;
 import io.tehuti.metrics.stats.Avg;
 import io.tehuti.metrics.stats.Max;
 import io.tehuti.metrics.stats.OccurrenceRate;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Map;
 
 
 public class ServerLoadStats extends AbstractVeniceStats {
-  private final Sensor totalRequestSensor;
-  private final Sensor rejectedRequestSensor;
-  private final Sensor acceptedRequestSensor;
-  private final Sensor rejectionRatioSensor;
-
-  public ServerLoadStats(MetricsRepository metricsRepository, String name) {
-    super(metricsRepository, name);
-
-    totalRequestSensor = registerSensorIfAbsent("total_request", new OccurrenceRate());
-    rejectedRequestSensor = registerSensorIfAbsent("rejected_request", new OccurrenceRate());
-    acceptedRequestSensor = registerSensorIfAbsent("accepted_request", new OccurrenceRate());
-    rejectionRatioSensor = registerSensorIfAbsent("rejection_ratio", new Avg(), new Max());
+  /** Tehuti metric names for sensors managed via joint API or plain Sensor. */
+  enum TehutiMetricName implements TehutiMetricNameEnum {
+    REJECTED_REQUEST, ACCEPTED_REQUEST, REJECTION_RATIO
   }
 
+  // Tehuti-only: total request count (OTel derives total from sum of ACCEPTED + REJECTED)
+  private final Sensor totalRequestSensor;
+
+  // Joint Tehuti+OTel: rejected requests (Tehuti OccurrenceRate + OTel COUNTER with REJECTED dimension)
+  private final MetricEntityStateOneEnum<VeniceServerLoadRequestOutcome> rejectedRequestMetric;
+
+  // Joint Tehuti+OTel: accepted requests (Tehuti OccurrenceRate + OTel COUNTER with ACCEPTED dimension)
+  private final MetricEntityStateOneEnum<VeniceServerLoadRequestOutcome> acceptedRequestMetric;
+
+  // Joint Tehuti+OTel: rejection ratio (Tehuti Avg/Max + OTel MIN_MAX_COUNT_SUM_AGGREGATIONS)
+  private final MetricEntityStateBase rejectionRatioMetric;
+
+  public ServerLoadStats(MetricsRepository metricsRepository, String name, String clusterName) {
+    super(metricsRepository, name);
+
+    // Tehuti-only: OTel total is derived at query time from sum(ACCEPTED + REJECTED)
+    totalRequestSensor = registerSensorIfAbsent("total_request", new OccurrenceRate());
+
+    OpenTelemetryMetricsSetup.OpenTelemetryMetricsSetupInfo otelData =
+        OpenTelemetryMetricsSetup.builder(metricsRepository).setClusterName(clusterName).build();
+    Map<VeniceMetricsDimensions, String> baseDimensionsMap = otelData.getBaseDimensionsMap();
+    Attributes baseAttributes = otelData.getBaseAttributes();
+
+    // Two MetricEntityStateOneEnum instances sharing the same OTel metric (REQUEST_COUNT),
+    // each bound to its own Tehuti sensor. OTel deduplicates by metric name internally.
+    rejectedRequestMetric = MetricEntityStateOneEnum.create(
+        REQUEST_COUNT.getMetricEntity(),
+        otelData.getOtelRepository(),
+        this::registerSensorIfAbsent,
+        TehutiMetricName.REJECTED_REQUEST,
+        Collections.singletonList(new OccurrenceRate()),
+        baseDimensionsMap,
+        VeniceServerLoadRequestOutcome.class);
+
+    acceptedRequestMetric = MetricEntityStateOneEnum.create(
+        REQUEST_COUNT.getMetricEntity(),
+        otelData.getOtelRepository(),
+        this::registerSensorIfAbsent,
+        TehutiMetricName.ACCEPTED_REQUEST,
+        Collections.singletonList(new OccurrenceRate()),
+        baseDimensionsMap,
+        VeniceServerLoadRequestOutcome.class);
+
+    rejectionRatioMetric = MetricEntityStateBase.create(
+        REJECTION_RATIO.getMetricEntity(),
+        otelData.getOtelRepository(),
+        this::registerSensorIfAbsent,
+        TehutiMetricName.REJECTION_RATIO,
+        Arrays.asList(new Avg(), new Max()),
+        baseDimensionsMap,
+        baseAttributes);
+  }
+
+  /** Tehuti-only: total request count. OTel derives total from sum(ACCEPTED + REJECTED). */
   public void recordTotalRequest() {
     totalRequestSensor.record();
   }
 
   public void recordRejectedRequest() {
-    rejectedRequestSensor.record();
+    rejectedRequestMetric.record(1, VeniceServerLoadRequestOutcome.REJECTED);
   }
 
   public void recordAcceptedRequest() {
-    acceptedRequestSensor.record();
+    acceptedRequestMetric.record(1, VeniceServerLoadRequestOutcome.ACCEPTED);
   }
 
   public void recordRejectionRatio(double rejectionRatio) {
-    rejectionRatioSensor.record(rejectionRatio);
+    rejectionRatioMetric.record(rejectionRatio);
   }
 }

--- a/services/venice-server/src/test/java/com/linkedin/venice/listener/ServerLoadControllerHandlerTest.java
+++ b/services/venice-server/src/test/java/com/linkedin/venice/listener/ServerLoadControllerHandlerTest.java
@@ -59,10 +59,12 @@ public class ServerLoadControllerHandlerTest {
     LoadController loadController = serverLoadControllerHandler.getLoadController();
     assertEquals(loadController.getRejectionRatio(), 0.0d);
 
-    // Record slow requests
+    // Record slow requests (latency above threshold — still ACCEPTED in OTel, just not in loadController)
     serverLoadControllerHandler.recordLatency(RequestType.SINGLE_GET, 20, 200);
     serverLoadControllerHandler.recordLatency(RequestType.MULTI_GET, 200, 200);
     serverLoadControllerHandler.recordLatency(RequestType.COMPUTE, 200, 200);
+    // All 6 requests (3 fast + 3 slow) recorded as accepted
+    verify(loadStats, times(6)).recordAcceptedRequest();
     TestUtils.waitForNonDeterministicAssertion(
         10,
         TimeUnit.SECONDS,
@@ -78,7 +80,7 @@ public class ServerLoadControllerHandlerTest {
     serverLoadControllerHandler.recordLatency(RequestType.SINGLE_GET, 5, 529);
     serverLoadControllerHandler.recordLatency(RequestType.SINGLE_GET, 5, 529);
 
-    verify(loadStats, times(3)).recordAcceptedRequest();
+    verify(loadStats, times(6)).recordAcceptedRequest();
     verify(loadStats, times(8)).recordTotalRequest();
 
   }

--- a/services/venice-server/src/test/java/com/linkedin/venice/stats/ServerLoadStatsTest.java
+++ b/services/venice-server/src/test/java/com/linkedin/venice/stats/ServerLoadStatsTest.java
@@ -1,0 +1,196 @@
+package com.linkedin.venice.stats;
+
+import static com.linkedin.davinci.stats.ServerLoadOtelMetricEntity.REJECTION_RATIO;
+import static com.linkedin.davinci.stats.ServerLoadOtelMetricEntity.REQUEST_COUNT;
+import static com.linkedin.davinci.stats.ServerMetricEntity.SERVER_METRIC_ENTITIES;
+import static com.linkedin.venice.stats.dimensions.VeniceMetricsDimensions.VENICE_CLUSTER_NAME;
+import static com.linkedin.venice.stats.dimensions.VeniceMetricsDimensions.VENICE_SERVER_LOAD_REQUEST_OUTCOME;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
+
+import com.linkedin.venice.stats.dimensions.VeniceServerLoadRequestOutcome;
+import com.linkedin.venice.utils.OpenTelemetryDataTestUtils;
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.sdk.testing.exporter.InMemoryMetricReader;
+import io.tehuti.metrics.MetricsRepository;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+
+public class ServerLoadStatsTest {
+  private static final String TEST_METRIC_PREFIX = "server";
+  private static final String TEST_CLUSTER_NAME = "test-cluster";
+
+  private InMemoryMetricReader inMemoryMetricReader;
+  private VeniceMetricsRepository metricsRepository;
+  private ServerLoadStats stats;
+
+  @BeforeMethod
+  public void setUp() {
+    inMemoryMetricReader = InMemoryMetricReader.create();
+    metricsRepository = new VeniceMetricsRepository(
+        new VeniceMetricsConfig.Builder().setMetricPrefix(TEST_METRIC_PREFIX)
+            .setMetricEntities(SERVER_METRIC_ENTITIES)
+            .setEmitOtelMetrics(true)
+            .setOtelAdditionalMetricsReader(inMemoryMetricReader)
+            .build());
+    stats = new ServerLoadStats(metricsRepository, "server_load", TEST_CLUSTER_NAME);
+  }
+
+  @AfterMethod
+  public void tearDown() {
+    if (metricsRepository != null) {
+      metricsRepository.close();
+    }
+  }
+
+  // --- OTel counter tests with request outcome dimension ---
+
+  @Test
+  public void testRecordAcceptedRequest() {
+    stats.recordAcceptedRequest();
+    stats.recordAcceptedRequest();
+
+    OpenTelemetryDataTestUtils.validateLongPointDataFromCounter(
+        inMemoryMetricReader,
+        2,
+        buildRequestAttributes(VeniceServerLoadRequestOutcome.ACCEPTED),
+        REQUEST_COUNT.getMetricEntity().getMetricName(),
+        TEST_METRIC_PREFIX);
+  }
+
+  @Test
+  public void testRecordRejectedRequest() {
+    stats.recordRejectedRequest();
+
+    OpenTelemetryDataTestUtils.validateLongPointDataFromCounter(
+        inMemoryMetricReader,
+        1,
+        buildRequestAttributes(VeniceServerLoadRequestOutcome.REJECTED),
+        REQUEST_COUNT.getMetricEntity().getMetricName(),
+        TEST_METRIC_PREFIX);
+  }
+
+  @Test
+  public void testRequestOutcomeDimensionIsolation() {
+    stats.recordAcceptedRequest();
+    stats.recordAcceptedRequest();
+    stats.recordRejectedRequest();
+
+    OpenTelemetryDataTestUtils.validateLongPointDataFromCounter(
+        inMemoryMetricReader,
+        2,
+        buildRequestAttributes(VeniceServerLoadRequestOutcome.ACCEPTED),
+        REQUEST_COUNT.getMetricEntity().getMetricName(),
+        TEST_METRIC_PREFIX);
+
+    OpenTelemetryDataTestUtils.validateLongPointDataFromCounter(
+        inMemoryMetricReader,
+        1,
+        buildRequestAttributes(VeniceServerLoadRequestOutcome.REJECTED),
+        REQUEST_COUNT.getMetricEntity().getMetricName(),
+        TEST_METRIC_PREFIX);
+  }
+
+  // --- OTel MIN_MAX_COUNT_SUM test for rejection ratio ---
+
+  @Test
+  public void testRecordRejectionRatio() {
+    stats.recordRejectionRatio(0.25);
+    stats.recordRejectionRatio(0.75);
+
+    OpenTelemetryDataTestUtils.validateHistogramPointData(
+        inMemoryMetricReader,
+        0.25,
+        0.75,
+        2,
+        1.0,
+        buildClusterAttributes(),
+        REJECTION_RATIO.getMetricEntity().getMetricName(),
+        TEST_METRIC_PREFIX);
+  }
+
+  // --- Tehuti sensor tests ---
+
+  @Test
+  public void testTehutiSensorsRegisteredAndRecorded() {
+    String totalSensor = ".server_load--total_request.OccurrenceRate";
+    String rejectedSensor = ".server_load--rejected_request.OccurrenceRate";
+    String acceptedSensor = ".server_load--accepted_request.OccurrenceRate";
+    String ratioAvgSensor = ".server_load--rejection_ratio.Avg";
+    String ratioMaxSensor = ".server_load--rejection_ratio.Max";
+
+    assertNotNull(metricsRepository.getMetric(totalSensor), "total_request sensor should exist");
+    assertNotNull(metricsRepository.getMetric(rejectedSensor), "rejected_request sensor should exist");
+    assertNotNull(metricsRepository.getMetric(acceptedSensor), "accepted_request sensor should exist");
+    assertNotNull(metricsRepository.getMetric(ratioAvgSensor), "rejection_ratio Avg sensor should exist");
+    assertNotNull(metricsRepository.getMetric(ratioMaxSensor), "rejection_ratio Max sensor should exist");
+
+    stats.recordTotalRequest();
+    stats.recordRejectedRequest();
+    stats.recordAcceptedRequest();
+    stats.recordRejectionRatio(0.5);
+
+    assertTrue(metricsRepository.getMetric(totalSensor).value() > 0, "total_request rate should be > 0");
+    assertTrue(metricsRepository.getMetric(rejectedSensor).value() > 0, "rejected_request rate should be > 0");
+    assertTrue(metricsRepository.getMetric(acceptedSensor).value() > 0, "accepted_request rate should be > 0");
+    assertTrue(metricsRepository.getMetric(ratioAvgSensor).value() > 0, "rejection_ratio Avg should be > 0");
+    assertTrue(metricsRepository.getMetric(ratioMaxSensor).value() > 0, "rejection_ratio Max should be > 0");
+  }
+
+  // --- Double-counting prevention: recordTotalRequest() must NOT produce OTel data ---
+
+  @Test
+  public void testTotalRequestDoesNotProduceOtelData() {
+    stats.recordTotalRequest();
+    stats.recordTotalRequest();
+
+    // OTel should have NO data for request count (total is Tehuti-only)
+    OpenTelemetryDataTestUtils.assertNoLongSumDataForAttributes(
+        inMemoryMetricReader.collectAllMetrics(),
+        REQUEST_COUNT.getMetricEntity().getMetricName(),
+        TEST_METRIC_PREFIX,
+        buildRequestAttributes(VeniceServerLoadRequestOutcome.ACCEPTED));
+    OpenTelemetryDataTestUtils.assertNoLongSumDataForAttributes(
+        inMemoryMetricReader.collectAllMetrics(),
+        REQUEST_COUNT.getMetricEntity().getMetricName(),
+        TEST_METRIC_PREFIX,
+        buildRequestAttributes(VeniceServerLoadRequestOutcome.REJECTED));
+  }
+
+  // --- NPE prevention tests ---
+
+  @Test
+  public void testNoNpeWhenOtelDisabled() {
+    try (VeniceMetricsRepository disabledRepo = new VeniceMetricsRepository(
+        new VeniceMetricsConfig.Builder().setMetricPrefix(TEST_METRIC_PREFIX).setEmitOtelMetrics(false).build())) {
+      exerciseAllRecordingPaths(disabledRepo);
+    }
+  }
+
+  @Test
+  public void testNoNpeWhenPlainMetricsRepository() {
+    exerciseAllRecordingPaths(new MetricsRepository());
+  }
+
+  private void exerciseAllRecordingPaths(MetricsRepository repo) {
+    ServerLoadStats safeStats = new ServerLoadStats(repo, "server_load", TEST_CLUSTER_NAME);
+    safeStats.recordTotalRequest();
+    safeStats.recordRejectedRequest();
+    safeStats.recordAcceptedRequest();
+    safeStats.recordRejectionRatio(0.5);
+  }
+
+  // --- Helpers ---
+
+  private Attributes buildClusterAttributes() {
+    return Attributes.builder().put(VENICE_CLUSTER_NAME.getDimensionNameInDefaultFormat(), TEST_CLUSTER_NAME).build();
+  }
+
+  private Attributes buildRequestAttributes(VeniceServerLoadRequestOutcome outcome) {
+    return buildClusterAttributes().toBuilder()
+        .put(VENICE_SERVER_LOAD_REQUEST_OUTCOME.getDimensionNameInDefaultFormat(), outcome.getDimensionValue())
+        .build();
+  }
+}

--- a/services/venice-server/src/test/java/com/linkedin/venice/stats/ServerLoadStatsTest.java
+++ b/services/venice-server/src/test/java/com/linkedin/venice/stats/ServerLoadStatsTest.java
@@ -5,6 +5,7 @@ import static com.linkedin.davinci.stats.ServerLoadOtelMetricEntity.REQUEST_COUN
 import static com.linkedin.davinci.stats.ServerMetricEntity.SERVER_METRIC_ENTITIES;
 import static com.linkedin.venice.stats.dimensions.VeniceMetricsDimensions.VENICE_CLUSTER_NAME;
 import static com.linkedin.venice.stats.dimensions.VeniceMetricsDimensions.VENICE_SERVER_LOAD_REQUEST_OUTCOME;
+import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertTrue;
 
@@ -12,7 +13,9 @@ import com.linkedin.venice.stats.dimensions.VeniceServerLoadRequestOutcome;
 import com.linkedin.venice.utils.OpenTelemetryDataTestUtils;
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.sdk.testing.exporter.InMemoryMetricReader;
+import io.tehuti.metrics.MetricConfig;
 import io.tehuti.metrics.MetricsRepository;
+import io.tehuti.metrics.stats.AsyncGauge;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
@@ -25,21 +28,28 @@ public class ServerLoadStatsTest {
   private InMemoryMetricReader inMemoryMetricReader;
   private VeniceMetricsRepository metricsRepository;
   private ServerLoadStats stats;
+  // Dedicated executor avoids shutting down Tehuti's static DEFAULT_ASYNC_GAUGE_EXECUTOR singleton when this
+  // repository is closed in tearDown(). Closing the static executor would break AsyncGauge measurements
+  // for any subsequent test running in the same JVM.
+  private AsyncGauge.AsyncGaugeExecutor asyncGaugeExecutor;
 
   @BeforeMethod
   public void setUp() {
     inMemoryMetricReader = InMemoryMetricReader.create();
+    asyncGaugeExecutor = new AsyncGauge.AsyncGaugeExecutor.Builder().build();
     metricsRepository = new VeniceMetricsRepository(
         new VeniceMetricsConfig.Builder().setMetricPrefix(TEST_METRIC_PREFIX)
             .setMetricEntities(SERVER_METRIC_ENTITIES)
             .setEmitOtelMetrics(true)
             .setOtelAdditionalMetricsReader(inMemoryMetricReader)
+            .setTehutiMetricConfig(new MetricConfig(asyncGaugeExecutor))
             .build());
     stats = new ServerLoadStats(metricsRepository, "server_load", TEST_CLUSTER_NAME);
   }
 
   @AfterMethod
   public void tearDown() {
+    // Closes only the dedicated executor; the JVM-wide static executor stays alive for other tests.
     if (metricsRepository != null) {
       metricsRepository.close();
     }
@@ -159,12 +169,50 @@ public class ServerLoadStatsTest {
         buildRequestAttributes(VeniceServerLoadRequestOutcome.REJECTED));
   }
 
+  // --- Tehuti dimension cross-contamination regression test ---
+
+  @Test
+  public void testTehutiSensorsNoCrossContamination() {
+    String rejectedSensor = ".server_load--rejected_request.OccurrenceRate";
+    String acceptedSensor = ".server_load--accepted_request.OccurrenceRate";
+
+    // Direction 1: recording rejected requests must not increment the accepted Tehuti sensor.
+    for (int i = 0; i < 5; i++) {
+      stats.recordRejectedRequest();
+    }
+    assertTrue(
+        metricsRepository.getMetric(rejectedSensor).value() > 0,
+        "rejected_request sensor should be incremented by recordRejectedRequest");
+    assertEquals(
+        metricsRepository.getMetric(acceptedSensor).value(),
+        0.0,
+        "accepted_request sensor must remain 0 when only rejected requests are recorded "
+            + "(rejected and accepted share the OTel REQUEST_COUNT instrument but bind to separate Tehuti sensors)");
+
+    // Direction 2: recording accepted requests must not increment the rejected Tehuti sensor.
+    double rejectedBeforeAccepted = metricsRepository.getMetric(rejectedSensor).value();
+    for (int i = 0; i < 5; i++) {
+      stats.recordAcceptedRequest();
+    }
+    assertTrue(
+        metricsRepository.getMetric(acceptedSensor).value() > 0,
+        "accepted_request sensor should be incremented by recordAcceptedRequest");
+    assertEquals(
+        metricsRepository.getMetric(rejectedSensor).value(),
+        rejectedBeforeAccepted,
+        "rejected_request sensor must not be incremented by recordAcceptedRequest");
+  }
+
   // --- NPE prevention tests ---
 
   @Test
   public void testNoNpeWhenOtelDisabled() {
+    AsyncGauge.AsyncGaugeExecutor localExecutor = new AsyncGauge.AsyncGaugeExecutor.Builder().build();
     try (VeniceMetricsRepository disabledRepo = new VeniceMetricsRepository(
-        new VeniceMetricsConfig.Builder().setMetricPrefix(TEST_METRIC_PREFIX).setEmitOtelMetrics(false).build())) {
+        new VeniceMetricsConfig.Builder().setMetricPrefix(TEST_METRIC_PREFIX)
+            .setEmitOtelMetrics(false)
+            .setTehutiMetricConfig(new MetricConfig(localExecutor))
+            .build())) {
       exerciseAllRecordingPaths(disabledRepo);
     }
   }

--- a/services/venice-server/src/test/java/com/linkedin/venice/stats/ServerLoadTehutiMetricNameTest.java
+++ b/services/venice-server/src/test/java/com/linkedin/venice/stats/ServerLoadTehutiMetricNameTest.java
@@ -1,0 +1,22 @@
+package com.linkedin.venice.stats;
+
+import com.linkedin.venice.stats.metrics.TehutiMetricNameEnumTestFixture;
+import java.util.HashMap;
+import java.util.Map;
+import org.testng.annotations.Test;
+
+
+public class ServerLoadTehutiMetricNameTest {
+  @Test
+  public void testTehutiMetricNames() {
+    new TehutiMetricNameEnumTestFixture<>(ServerLoadStats.TehutiMetricName.class, expectedMetricNames()).assertAll();
+  }
+
+  private static Map<ServerLoadStats.TehutiMetricName, String> expectedMetricNames() {
+    Map<ServerLoadStats.TehutiMetricName, String> map = new HashMap<>();
+    map.put(ServerLoadStats.TehutiMetricName.REJECTED_REQUEST, "rejected_request");
+    map.put(ServerLoadStats.TehutiMetricName.ACCEPTED_REQUEST, "accepted_request");
+    map.put(ServerLoadStats.TehutiMetricName.REJECTION_RATIO, "rejection_ratio");
+    return map;
+  }
+}


### PR DESCRIPTION
## Problem Statement

`ServerLoadStats` has 4 Tehuti sensors for server load control (total/rejected/accepted request rates + rejection ratio) but no OTel counterparts, making these metrics unavailable in OTel-based monitoring dashboards.

## Solution

Add 2 OTel metrics for server load control using the joint Tehuti+OTel API:

- `load_controller.request.count` (COUNTER) — count of requests by load control outcome, with `VENICE_SERVER_LOAD_REQUEST_OUTCOME` dimension (ACCEPTED/REJECTED). Uses the shared OTel instrument pattern: two `MetricEntityStateOneEnum` instances share the same OTel counter, each bound to its own Tehuti sensor.
- `load_controller.request.rejection_ratio` (MIN_MAX_COUNT_SUM_AGGREGATIONS) — server load rejection ratio as a fraction.

The Tehuti `total_request` sensor remains Tehuti-only — OTel derives total at query time from `sum(ACCEPTED + REJECTED)`.

**Behavioral fix:** `recordAcceptedRequest()` is now called for ALL non-rejected requests in `ServerLoadControllerHandler.recordLatency()`, not just those below the latency threshold. Previously, requests above the threshold but not rejected were uncounted. `loadController.recordAccept()` (the internal admission algorithm feed) still only fires for below-threshold requests.

###  Code changes
- [ ] Added new code behind **a config**.
- [ ] Introduced new **log lines**.
  - [ ] Confirmed if logs need to be **rate limited** to avoid excessive logging.

###  **Concurrency-Specific Checks**
Both reviewer and PR author to verify
- [x] Code has **no race conditions** or **thread safety issues**.
- [ ] Proper **synchronization mechanisms** (e.g., `synchronized`, `RWLock`) are used where needed.
- [ ] No **blocking calls** inside critical sections that could lead to deadlocks or performance degradation.
- [ ] Verified **thread-safe collections** are used (e.g., `ConcurrentHashMap`, `CopyOnWriteArrayList`).
- [ ] Validated proper exception handling in multi-threaded code to avoid silent thread termination.

## How was this PR tested?

- [x] New unit tests added.
- [ ] New integration tests added.
- [x] Modified or extended existing tests.
- [x] Verified backward compatibility (if applicable).

New tests:
- `ServerLoadStatsTest` (9 tests): OTel counter accumulation for accepted/rejected, dimension isolation, rejection ratio histogram (min/max/count/sum), all Tehuti sensors, double-counting prevention (total doesn't produce OTel data), NPE prevention with OTel disabled and plain MetricsRepository.
- `ServerLoadOtelMetricEntityTest`: metric entity validation for both metrics.
- `ServerLoadTehutiMetricNameTest`: Tehuti name validation for 3 enum values.
- `VeniceServerLoadRequestOutcomeTest`: dimension value validation.
- `ServerLoadControllerHandlerTest`: updated to verify all 6 requests (3 fast + 3 slow) are recorded as accepted.

## Does this PR introduce any user-facing or breaking changes?
- [x] No. You can skip the rest of this section.
- [ ] Yes. Clearly explain the behavior change and its impact.