### PR TITLE
[da-vinci] Add OTel metrics to AggVersionedDaVinciRecordTransformerStats

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/AggVersionedDaVinciRecordTransformerStats.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/AggVersionedDaVinciRecordTransformerStats.java
@@ -24,12 +24,13 @@ import java.util.Map;
  */
 public class AggVersionedDaVinciRecordTransformerStats
     extends AbstractVeniceAggVersionedStats<DaVinciRecordTransformerStats, DaVinciRecordTransformerStatsReporter> {
+  private final boolean emitOtelMetrics;
   private final VeniceOpenTelemetryMetricsRepository otelRepository;
   private final Map<VeniceMetricsDimensions, String> baseDimensionsMap;
 
   /**
    * Per-store OTel metric state for latency. Bounded by the number of stores on this host.
-   * Entries created lazily via {@link #getOrCreateLatencyMetric}, removed in
+   * Entries created lazily via {@link #getOrCreateMetric}, removed in
    * {@link #handleStoreDeleted(String)}.
    */
   private final Map<String, MetricEntityStateOneEnum<VeniceRecordTransformerOperation>> latencyPerStore =
@@ -54,6 +55,7 @@ public class AggVersionedDaVinciRecordTransformerStats
 
     OpenTelemetryMetricsSetup.OpenTelemetryMetricsSetupInfo otelData =
         OpenTelemetryMetricsSetup.builder(metricsRepository).setClusterName(serverConfig.getClusterName()).build();
+    this.emitOtelMetrics = otelData.emitOpenTelemetryMetrics();
     this.otelRepository = otelData.getOtelRepository();
     this.baseDimensionsMap = otelData.getBaseDimensionsMap();
   }
@@ -70,30 +72,41 @@ public class AggVersionedDaVinciRecordTransformerStats
 
   public void recordPutLatency(String storeName, int version, double value, long timestamp) {
     recordVersionedAndTotalStat(storeName, version, stat -> stat.recordPutLatency(value, timestamp));
-    getOrCreateLatencyMetric(storeName).record(value, VeniceRecordTransformerOperation.PUT);
+    if (emitOtelMetrics) {
+      getOrCreateMetric(latencyPerStore, storeName, RECORD_TRANSFORMER_LATENCY)
+          .record(value, VeniceRecordTransformerOperation.PUT);
+    }
   }
 
   public void recordDeleteLatency(String storeName, int version, double value, long timestamp) {
     recordVersionedAndTotalStat(storeName, version, stat -> stat.recordDeleteLatency(value, timestamp));
-    getOrCreateLatencyMetric(storeName).record(value, VeniceRecordTransformerOperation.DELETE);
+    if (emitOtelMetrics) {
+      getOrCreateMetric(latencyPerStore, storeName, RECORD_TRANSFORMER_LATENCY)
+          .record(value, VeniceRecordTransformerOperation.DELETE);
+    }
   }
 
   public void recordPutError(String storeName, int version, long timestamp) {
     recordVersionedAndTotalStat(storeName, version, stat -> stat.recordPutError(timestamp));
-    getOrCreateErrorCountMetric(storeName).record(1, VeniceRecordTransformerOperation.PUT);
+    if (emitOtelMetrics) {
+      getOrCreateMetric(errorCountPerStore, storeName, RECORD_TRANSFORMER_ERROR_COUNT)
+          .record(1, VeniceRecordTransformerOperation.PUT);
+    }
   }
 
   public void recordDeleteError(String storeName, int version, long timestamp) {
     recordVersionedAndTotalStat(storeName, version, stat -> stat.recordDeleteError(timestamp));
-    getOrCreateErrorCountMetric(storeName).record(1, VeniceRecordTransformerOperation.DELETE);
+    if (emitOtelMetrics) {
+      getOrCreateMetric(errorCountPerStore, storeName, RECORD_TRANSFORMER_ERROR_COUNT)
+          .record(1, VeniceRecordTransformerOperation.DELETE);
+    }
   }
 
-  private MetricEntityStateOneEnum<VeniceRecordTransformerOperation> getOrCreateLatencyMetric(String storeName) {
-    return latencyPerStore.computeIfAbsent(storeName, k -> createPerStoreMetric(k, RECORD_TRANSFORMER_LATENCY));
-  }
-
-  private MetricEntityStateOneEnum<VeniceRecordTransformerOperation> getOrCreateErrorCountMetric(String storeName) {
-    return errorCountPerStore.computeIfAbsent(storeName, k -> createPerStoreMetric(k, RECORD_TRANSFORMER_ERROR_COUNT));
+  private MetricEntityStateOneEnum<VeniceRecordTransformerOperation> getOrCreateMetric(
+      Map<String, MetricEntityStateOneEnum<VeniceRecordTransformerOperation>> perStoreMap,
+      String storeName,
+      DaVinciRecordTransformerOtelMetricEntity metricEntity) {
+    return perStoreMap.computeIfAbsent(storeName, k -> createPerStoreMetric(k, metricEntity));
   }
 
   private MetricEntityStateOneEnum<VeniceRecordTransformerOperation> createPerStoreMetric(

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/AggVersionedDaVinciRecordTransformerStats.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/AggVersionedDaVinciRecordTransformerStats.java
@@ -24,7 +24,6 @@ import java.util.Map;
  */
 public class AggVersionedDaVinciRecordTransformerStats
     extends AbstractVeniceAggVersionedStats<DaVinciRecordTransformerStats, DaVinciRecordTransformerStatsReporter> {
-  private final boolean emitOtelMetrics;
   private final VeniceOpenTelemetryMetricsRepository otelRepository;
   private final Map<VeniceMetricsDimensions, String> baseDimensionsMap;
 
@@ -55,7 +54,6 @@ public class AggVersionedDaVinciRecordTransformerStats
 
     OpenTelemetryMetricsSetup.OpenTelemetryMetricsSetupInfo otelData =
         OpenTelemetryMetricsSetup.builder(metricsRepository).setClusterName(serverConfig.getClusterName()).build();
-    this.emitOtelMetrics = otelData.emitOpenTelemetryMetrics();
     this.otelRepository = otelData.getOtelRepository();
     this.baseDimensionsMap = otelData.getBaseDimensionsMap();
   }
@@ -72,34 +70,26 @@ public class AggVersionedDaVinciRecordTransformerStats
 
   public void recordPutLatency(String storeName, int version, double value, long timestamp) {
     recordVersionedAndTotalStat(storeName, version, stat -> stat.recordPutLatency(value, timestamp));
-    if (emitOtelMetrics) {
-      getOrCreateMetric(latencyPerStore, storeName, RECORD_TRANSFORMER_LATENCY)
-          .record(value, VeniceRecordTransformerOperation.PUT);
-    }
+    getOrCreateMetric(latencyPerStore, storeName, RECORD_TRANSFORMER_LATENCY)
+        .record(value, VeniceRecordTransformerOperation.PUT);
   }
 
   public void recordDeleteLatency(String storeName, int version, double value, long timestamp) {
     recordVersionedAndTotalStat(storeName, version, stat -> stat.recordDeleteLatency(value, timestamp));
-    if (emitOtelMetrics) {
-      getOrCreateMetric(latencyPerStore, storeName, RECORD_TRANSFORMER_LATENCY)
-          .record(value, VeniceRecordTransformerOperation.DELETE);
-    }
+    getOrCreateMetric(latencyPerStore, storeName, RECORD_TRANSFORMER_LATENCY)
+        .record(value, VeniceRecordTransformerOperation.DELETE);
   }
 
   public void recordPutError(String storeName, int version, long timestamp) {
     recordVersionedAndTotalStat(storeName, version, stat -> stat.recordPutError(timestamp));
-    if (emitOtelMetrics) {
-      getOrCreateMetric(errorCountPerStore, storeName, RECORD_TRANSFORMER_ERROR_COUNT)
-          .record(1, VeniceRecordTransformerOperation.PUT);
-    }
+    getOrCreateMetric(errorCountPerStore, storeName, RECORD_TRANSFORMER_ERROR_COUNT)
+        .record(1, VeniceRecordTransformerOperation.PUT);
   }
 
   public void recordDeleteError(String storeName, int version, long timestamp) {
     recordVersionedAndTotalStat(storeName, version, stat -> stat.recordDeleteError(timestamp));
-    if (emitOtelMetrics) {
-      getOrCreateMetric(errorCountPerStore, storeName, RECORD_TRANSFORMER_ERROR_COUNT)
-          .record(1, VeniceRecordTransformerOperation.DELETE);
-    }
+    getOrCreateMetric(errorCountPerStore, storeName, RECORD_TRANSFORMER_ERROR_COUNT)
+        .record(1, VeniceRecordTransformerOperation.DELETE);
   }
 
   private MetricEntityStateOneEnum<VeniceRecordTransformerOperation> getOrCreateMetric(

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/AggVersionedDaVinciRecordTransformerStats.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/AggVersionedDaVinciRecordTransformerStats.java
@@ -1,15 +1,46 @@
 package com.linkedin.davinci.stats;
 
+import static com.linkedin.davinci.stats.DaVinciRecordTransformerOtelMetricEntity.RECORD_TRANSFORMER_ERROR_COUNT;
+import static com.linkedin.davinci.stats.DaVinciRecordTransformerOtelMetricEntity.RECORD_TRANSFORMER_LATENCY;
+
 import com.linkedin.davinci.config.VeniceServerConfig;
 import com.linkedin.venice.meta.ReadOnlyStoreRepository;
+import com.linkedin.venice.stats.OpenTelemetryMetricsSetup;
+import com.linkedin.venice.stats.VeniceOpenTelemetryMetricsRepository;
+import com.linkedin.venice.stats.dimensions.VeniceMetricsDimensions;
+import com.linkedin.venice.stats.dimensions.VeniceRecordTransformerOperation;
+import com.linkedin.venice.stats.metrics.MetricEntityStateOneEnum;
+import com.linkedin.venice.utils.concurrent.VeniceConcurrentHashMap;
 import io.tehuti.metrics.MetricsRepository;
+import java.util.HashMap;
+import java.util.Map;
 
 
 /**
- * The store level stats for {@link com.linkedin.davinci.client.DaVinciRecordTransformer}
+ * The store level stats for {@link com.linkedin.davinci.client.DaVinciRecordTransformer}.
+ * OTel metrics are recorded directly here (separate API) because Tehuti uses the Reporter
+ * layer ({@link DaVinciRecordTransformerStatsReporter}) with AsyncGauge polling, while OTel
+ * records at the point of the call.
  */
 public class AggVersionedDaVinciRecordTransformerStats
     extends AbstractVeniceAggVersionedStats<DaVinciRecordTransformerStats, DaVinciRecordTransformerStatsReporter> {
+  private final VeniceOpenTelemetryMetricsRepository otelRepository;
+  private final Map<VeniceMetricsDimensions, String> baseDimensionsMap;
+
+  /**
+   * Per-store OTel metric state for latency. Bounded by the number of stores on this host.
+   * Entries created lazily via {@link #getOrCreateLatencyMetric}, removed in
+   * {@link #handleStoreDeleted(String)}.
+   */
+  private final Map<String, MetricEntityStateOneEnum<VeniceRecordTransformerOperation>> latencyPerStore =
+      new VeniceConcurrentHashMap<>();
+
+  /**
+   * Per-store OTel metric state for error count. Same bounding and lifecycle as latencyPerStore.
+   */
+  private final Map<String, MetricEntityStateOneEnum<VeniceRecordTransformerOperation>> errorCountPerStore =
+      new VeniceConcurrentHashMap<>();
+
   public AggVersionedDaVinciRecordTransformerStats(
       MetricsRepository metricsRepository,
       ReadOnlyStoreRepository metadataRepository,
@@ -20,21 +51,61 @@ public class AggVersionedDaVinciRecordTransformerStats
         DaVinciRecordTransformerStats::new,
         DaVinciRecordTransformerStatsReporter::new,
         serverConfig.isUnregisterMetricForDeletedStoreEnabled());
+
+    OpenTelemetryMetricsSetup.OpenTelemetryMetricsSetupInfo otelData =
+        OpenTelemetryMetricsSetup.builder(metricsRepository).setClusterName(serverConfig.getClusterName()).build();
+    this.otelRepository = otelData.getOtelRepository();
+    this.baseDimensionsMap = otelData.getBaseDimensionsMap();
+  }
+
+  @Override
+  public void handleStoreDeleted(String storeName) {
+    try {
+      super.handleStoreDeleted(storeName);
+    } finally {
+      latencyPerStore.remove(storeName);
+      errorCountPerStore.remove(storeName);
+    }
   }
 
   public void recordPutLatency(String storeName, int version, double value, long timestamp) {
     recordVersionedAndTotalStat(storeName, version, stat -> stat.recordPutLatency(value, timestamp));
+    getOrCreateLatencyMetric(storeName).record(value, VeniceRecordTransformerOperation.PUT);
   }
 
   public void recordDeleteLatency(String storeName, int version, double value, long timestamp) {
     recordVersionedAndTotalStat(storeName, version, stat -> stat.recordDeleteLatency(value, timestamp));
+    getOrCreateLatencyMetric(storeName).record(value, VeniceRecordTransformerOperation.DELETE);
   }
 
   public void recordPutError(String storeName, int version, long timestamp) {
     recordVersionedAndTotalStat(storeName, version, stat -> stat.recordPutError(timestamp));
+    getOrCreateErrorCountMetric(storeName).record(1, VeniceRecordTransformerOperation.PUT);
   }
 
   public void recordDeleteError(String storeName, int version, long timestamp) {
     recordVersionedAndTotalStat(storeName, version, stat -> stat.recordDeleteError(timestamp));
+    getOrCreateErrorCountMetric(storeName).record(1, VeniceRecordTransformerOperation.DELETE);
+  }
+
+  private MetricEntityStateOneEnum<VeniceRecordTransformerOperation> getOrCreateLatencyMetric(String storeName) {
+    return latencyPerStore.computeIfAbsent(storeName, k -> createPerStoreMetric(k, RECORD_TRANSFORMER_LATENCY));
+  }
+
+  private MetricEntityStateOneEnum<VeniceRecordTransformerOperation> getOrCreateErrorCountMetric(String storeName) {
+    return errorCountPerStore.computeIfAbsent(storeName, k -> createPerStoreMetric(k, RECORD_TRANSFORMER_ERROR_COUNT));
+  }
+
+  private MetricEntityStateOneEnum<VeniceRecordTransformerOperation> createPerStoreMetric(
+      String storeName,
+      DaVinciRecordTransformerOtelMetricEntity metricEntity) {
+    Map<VeniceMetricsDimensions, String> storeDimensionsMap = new HashMap<>(baseDimensionsMap);
+    storeDimensionsMap
+        .put(VeniceMetricsDimensions.VENICE_STORE_NAME, OpenTelemetryMetricsSetup.sanitizeStoreName(storeName));
+    return MetricEntityStateOneEnum.create(
+        metricEntity.getMetricEntity(),
+        otelRepository,
+        storeDimensionsMap,
+        VeniceRecordTransformerOperation.class);
   }
 }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/AggVersionedDaVinciRecordTransformerStats.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/AggVersionedDaVinciRecordTransformerStats.java
@@ -3,6 +3,7 @@ package com.linkedin.davinci.stats;
 import static com.linkedin.davinci.stats.DaVinciRecordTransformerOtelMetricEntity.RECORD_TRANSFORMER_ERROR_COUNT;
 import static com.linkedin.davinci.stats.DaVinciRecordTransformerOtelMetricEntity.RECORD_TRANSFORMER_LATENCY;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.linkedin.davinci.config.VeniceServerConfig;
 import com.linkedin.venice.meta.ReadOnlyStoreRepository;
 import com.linkedin.venice.stats.OpenTelemetryMetricsSetup;
@@ -26,10 +27,11 @@ public class AggVersionedDaVinciRecordTransformerStats
     extends AbstractVeniceAggVersionedStats<DaVinciRecordTransformerStats, DaVinciRecordTransformerStatsReporter> {
   private final VeniceOpenTelemetryMetricsRepository otelRepository;
   private final Map<VeniceMetricsDimensions, String> baseDimensionsMap;
+  private final boolean emitOtelMetrics;
 
   /**
    * Per-store OTel metric state for latency. Bounded by the number of stores on this host.
-   * Entries created lazily via {@link #getOrCreateMetric}, removed in
+   * Entries created lazily inside {@link #recordOtelLatency}, removed in
    * {@link #handleStoreDeleted(String)}.
    */
   private final Map<String, MetricEntityStateOneEnum<VeniceRecordTransformerOperation>> latencyPerStore =
@@ -56,6 +58,7 @@ public class AggVersionedDaVinciRecordTransformerStats
         OpenTelemetryMetricsSetup.builder(metricsRepository).setClusterName(serverConfig.getClusterName()).build();
     this.otelRepository = otelData.getOtelRepository();
     this.baseDimensionsMap = otelData.getBaseDimensionsMap();
+    this.emitOtelMetrics = otelData.emitOpenTelemetryMetrics();
   }
 
   @Override
@@ -70,33 +73,58 @@ public class AggVersionedDaVinciRecordTransformerStats
 
   public void recordPutLatency(String storeName, int version, double value, long timestamp) {
     recordVersionedAndTotalStat(storeName, version, stat -> stat.recordPutLatency(value, timestamp));
-    getOrCreateMetric(latencyPerStore, storeName, RECORD_TRANSFORMER_LATENCY)
-        .record(value, VeniceRecordTransformerOperation.PUT);
+    recordOtelLatency(storeName, value, VeniceRecordTransformerOperation.PUT);
   }
 
   public void recordDeleteLatency(String storeName, int version, double value, long timestamp) {
     recordVersionedAndTotalStat(storeName, version, stat -> stat.recordDeleteLatency(value, timestamp));
-    getOrCreateMetric(latencyPerStore, storeName, RECORD_TRANSFORMER_LATENCY)
-        .record(value, VeniceRecordTransformerOperation.DELETE);
+    recordOtelLatency(storeName, value, VeniceRecordTransformerOperation.DELETE);
   }
 
   public void recordPutError(String storeName, int version, long timestamp) {
     recordVersionedAndTotalStat(storeName, version, stat -> stat.recordPutError(timestamp));
-    getOrCreateMetric(errorCountPerStore, storeName, RECORD_TRANSFORMER_ERROR_COUNT)
-        .record(1, VeniceRecordTransformerOperation.PUT);
+    recordOtelErrorCount(storeName, VeniceRecordTransformerOperation.PUT);
   }
 
   public void recordDeleteError(String storeName, int version, long timestamp) {
     recordVersionedAndTotalStat(storeName, version, stat -> stat.recordDeleteError(timestamp));
-    getOrCreateMetric(errorCountPerStore, storeName, RECORD_TRANSFORMER_ERROR_COUNT)
-        .record(1, VeniceRecordTransformerOperation.DELETE);
+    recordOtelErrorCount(storeName, VeniceRecordTransformerOperation.DELETE);
   }
 
-  private MetricEntityStateOneEnum<VeniceRecordTransformerOperation> getOrCreateMetric(
-      Map<String, MetricEntityStateOneEnum<VeniceRecordTransformerOperation>> perStoreMap,
-      String storeName,
-      DaVinciRecordTransformerOtelMetricEntity metricEntity) {
-    return perStoreMap.computeIfAbsent(storeName, k -> createPerStoreMetric(k, metricEntity));
+  private void recordOtelLatency(String storeName, double value, VeniceRecordTransformerOperation operation) {
+    if (!emitOtelMetrics) {
+      return;
+    }
+    latencyPerStore.computeIfAbsent(storeName, k -> createPerStoreMetric(k, RECORD_TRANSFORMER_LATENCY))
+        .record(value, operation);
+  }
+
+  private void recordOtelErrorCount(String storeName, VeniceRecordTransformerOperation operation) {
+    if (!emitOtelMetrics) {
+      return;
+    }
+    errorCountPerStore.computeIfAbsent(storeName, k -> createPerStoreMetric(k, RECORD_TRANSFORMER_ERROR_COUNT))
+        .record(1, operation);
+  }
+
+  @VisibleForTesting
+  boolean hasLatencyMetricFor(String storeName) {
+    return latencyPerStore.containsKey(storeName);
+  }
+
+  @VisibleForTesting
+  boolean hasErrorCountMetricFor(String storeName) {
+    return errorCountPerStore.containsKey(storeName);
+  }
+
+  @VisibleForTesting
+  int latencyStoreCount() {
+    return latencyPerStore.size();
+  }
+
+  @VisibleForTesting
+  int errorCountStoreCount() {
+    return errorCountPerStore.size();
   }
 
   private MetricEntityStateOneEnum<VeniceRecordTransformerOperation> createPerStoreMetric(

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/DaVinciRecordTransformerOtelMetricEntity.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/DaVinciRecordTransformerOtelMetricEntity.java
@@ -14,7 +14,7 @@ import java.util.Set;
 
 
 /**
- * OTel metric entity definitions for {@link DaVinciRecordTransformerStats}.
+ * OTel metric entity definitions recorded from {@link AggVersionedDaVinciRecordTransformerStats}.
  * Tracks DaVinci record transformer latency and error counts by operation (put/delete).
  */
 public enum DaVinciRecordTransformerOtelMetricEntity implements ModuleMetricEntityInterface {

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/DaVinciRecordTransformerOtelMetricEntity.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/DaVinciRecordTransformerOtelMetricEntity.java
@@ -1,0 +1,48 @@
+package com.linkedin.davinci.stats;
+
+import static com.linkedin.venice.stats.dimensions.VeniceMetricsDimensions.VENICE_CLUSTER_NAME;
+import static com.linkedin.venice.stats.dimensions.VeniceMetricsDimensions.VENICE_RECORD_TRANSFORMER_OPERATION;
+import static com.linkedin.venice.stats.dimensions.VeniceMetricsDimensions.VENICE_STORE_NAME;
+import static com.linkedin.venice.utils.Utils.setOf;
+
+import com.linkedin.venice.stats.dimensions.VeniceMetricsDimensions;
+import com.linkedin.venice.stats.metrics.MetricEntity;
+import com.linkedin.venice.stats.metrics.MetricType;
+import com.linkedin.venice.stats.metrics.MetricUnit;
+import com.linkedin.venice.stats.metrics.ModuleMetricEntityInterface;
+import java.util.Set;
+
+
+/**
+ * OTel metric entity definitions for {@link DaVinciRecordTransformerStats}.
+ * Tracks DaVinci record transformer latency and error counts by operation (put/delete).
+ */
+public enum DaVinciRecordTransformerOtelMetricEntity implements ModuleMetricEntityInterface {
+  RECORD_TRANSFORMER_LATENCY(
+      "record_transformer.latency", MetricType.HISTOGRAM, MetricUnit.MILLISECOND,
+      "DaVinci record transformer operation latency",
+      setOf(VENICE_CLUSTER_NAME, VENICE_STORE_NAME, VENICE_RECORD_TRANSFORMER_OPERATION)
+  ),
+
+  RECORD_TRANSFORMER_ERROR_COUNT(
+      "record_transformer.error_count", MetricType.COUNTER, MetricUnit.NUMBER,
+      "DaVinci record transformer operation error count",
+      setOf(VENICE_CLUSTER_NAME, VENICE_STORE_NAME, VENICE_RECORD_TRANSFORMER_OPERATION)
+  );
+
+  private final MetricEntity metricEntity;
+
+  DaVinciRecordTransformerOtelMetricEntity(
+      String metricName,
+      MetricType metricType,
+      MetricUnit unit,
+      String description,
+      Set<VeniceMetricsDimensions> dimensions) {
+    this.metricEntity = new MetricEntity(metricName, metricType, unit, description, dimensions);
+  }
+
+  @Override
+  public MetricEntity getMetricEntity() {
+    return metricEntity;
+  }
+}

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/ServerMetricEntity.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/ServerMetricEntity.java
@@ -43,7 +43,8 @@ public final class ServerMetricEntity {
         ServerReadQuotaOtelMetricEntity.class,
         ServerConnectionOtelMetricEntity.class,
         StoreBufferServiceOtelMetricEntity.class,
-        StorageEngineOtelMetricEntity.class);
+        StorageEngineOtelMetricEntity.class,
+        DaVinciRecordTransformerOtelMetricEntity.class);
   }
 
   public static final Collection<MetricEntity> SERVER_METRIC_ENTITIES =

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/stats/AggVersionedDaVinciRecordTransformerStatsOtelTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/stats/AggVersionedDaVinciRecordTransformerStatsOtelTest.java
@@ -1,0 +1,187 @@
+package com.linkedin.davinci.stats;
+
+import static com.linkedin.davinci.stats.DaVinciRecordTransformerOtelMetricEntity.RECORD_TRANSFORMER_ERROR_COUNT;
+import static com.linkedin.davinci.stats.DaVinciRecordTransformerOtelMetricEntity.RECORD_TRANSFORMER_LATENCY;
+import static com.linkedin.davinci.stats.ServerMetricEntity.SERVER_METRIC_ENTITIES;
+import static com.linkedin.venice.stats.dimensions.VeniceMetricsDimensions.VENICE_CLUSTER_NAME;
+import static com.linkedin.venice.stats.dimensions.VeniceMetricsDimensions.VENICE_RECORD_TRANSFORMER_OPERATION;
+import static com.linkedin.venice.stats.dimensions.VeniceMetricsDimensions.VENICE_STORE_NAME;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+
+import com.linkedin.davinci.config.VeniceServerConfig;
+import com.linkedin.venice.meta.ReadOnlyStoreRepository;
+import com.linkedin.venice.meta.Store;
+import com.linkedin.venice.stats.VeniceMetricsConfig;
+import com.linkedin.venice.stats.VeniceMetricsRepository;
+import com.linkedin.venice.stats.dimensions.VeniceRecordTransformerOperation;
+import com.linkedin.venice.utils.OpenTelemetryDataTestUtils;
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.sdk.testing.exporter.InMemoryMetricReader;
+import io.tehuti.metrics.MetricsRepository;
+import java.util.Collections;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+
+public class AggVersionedDaVinciRecordTransformerStatsOtelTest {
+  private static final String TEST_METRIC_PREFIX = "davinci_client";
+  private static final String TEST_CLUSTER_NAME = "test-cluster";
+  private static final String TEST_STORE_NAME = "test-store";
+
+  private InMemoryMetricReader inMemoryMetricReader;
+  private VeniceMetricsRepository metricsRepository;
+  private AggVersionedDaVinciRecordTransformerStats aggStats;
+
+  @BeforeMethod
+  public void setUp() {
+    inMemoryMetricReader = InMemoryMetricReader.create();
+    metricsRepository = new VeniceMetricsRepository(
+        new VeniceMetricsConfig.Builder().setMetricPrefix(TEST_METRIC_PREFIX)
+            .setMetricEntities(SERVER_METRIC_ENTITIES)
+            .setEmitOtelMetrics(true)
+            .setOtelAdditionalMetricsReader(inMemoryMetricReader)
+            .build());
+    aggStats = createAggStats(metricsRepository);
+  }
+
+  @AfterMethod
+  public void tearDown() {
+    if (metricsRepository != null) {
+      metricsRepository.close();
+    }
+  }
+
+  @Test
+  public void testRecordPutLatency() {
+    long timestamp = System.currentTimeMillis();
+    aggStats.recordPutLatency(TEST_STORE_NAME, 1, 50.0, timestamp);
+    aggStats.recordPutLatency(TEST_STORE_NAME, 1, 100.0, timestamp);
+
+    OpenTelemetryDataTestUtils.validateExponentialHistogramPointData(
+        inMemoryMetricReader,
+        50.0,
+        100.0,
+        2,
+        150.0,
+        buildAttributes(VeniceRecordTransformerOperation.PUT),
+        RECORD_TRANSFORMER_LATENCY.getMetricEntity().getMetricName(),
+        TEST_METRIC_PREFIX);
+  }
+
+  @Test
+  public void testRecordDeleteLatency() {
+    long timestamp = System.currentTimeMillis();
+    aggStats.recordDeleteLatency(TEST_STORE_NAME, 1, 25.0, timestamp);
+
+    OpenTelemetryDataTestUtils.validateExponentialHistogramPointData(
+        inMemoryMetricReader,
+        25.0,
+        25.0,
+        1,
+        25.0,
+        buildAttributes(VeniceRecordTransformerOperation.DELETE),
+        RECORD_TRANSFORMER_LATENCY.getMetricEntity().getMetricName(),
+        TEST_METRIC_PREFIX);
+  }
+
+  @Test
+  public void testRecordPutError() {
+    long timestamp = System.currentTimeMillis();
+    aggStats.recordPutError(TEST_STORE_NAME, 1, timestamp);
+    aggStats.recordPutError(TEST_STORE_NAME, 1, timestamp);
+
+    OpenTelemetryDataTestUtils.validateLongPointDataFromCounter(
+        inMemoryMetricReader,
+        2,
+        buildAttributes(VeniceRecordTransformerOperation.PUT),
+        RECORD_TRANSFORMER_ERROR_COUNT.getMetricEntity().getMetricName(),
+        TEST_METRIC_PREFIX);
+  }
+
+  @Test
+  public void testRecordDeleteError() {
+    long timestamp = System.currentTimeMillis();
+    aggStats.recordDeleteError(TEST_STORE_NAME, 1, timestamp);
+
+    OpenTelemetryDataTestUtils.validateLongPointDataFromCounter(
+        inMemoryMetricReader,
+        1,
+        buildAttributes(VeniceRecordTransformerOperation.DELETE),
+        RECORD_TRANSFORMER_ERROR_COUNT.getMetricEntity().getMetricName(),
+        TEST_METRIC_PREFIX);
+  }
+
+  @Test
+  public void testOperationDimensionIsolation() {
+    long timestamp = System.currentTimeMillis();
+    aggStats.recordPutError(TEST_STORE_NAME, 1, timestamp);
+    aggStats.recordPutError(TEST_STORE_NAME, 1, timestamp);
+    aggStats.recordDeleteError(TEST_STORE_NAME, 1, timestamp);
+
+    OpenTelemetryDataTestUtils.validateLongPointDataFromCounter(
+        inMemoryMetricReader,
+        2,
+        buildAttributes(VeniceRecordTransformerOperation.PUT),
+        RECORD_TRANSFORMER_ERROR_COUNT.getMetricEntity().getMetricName(),
+        TEST_METRIC_PREFIX);
+
+    OpenTelemetryDataTestUtils.validateLongPointDataFromCounter(
+        inMemoryMetricReader,
+        1,
+        buildAttributes(VeniceRecordTransformerOperation.DELETE),
+        RECORD_TRANSFORMER_ERROR_COUNT.getMetricEntity().getMetricName(),
+        TEST_METRIC_PREFIX);
+  }
+
+  // --- NPE prevention tests ---
+
+  @Test
+  public void testNoNpeWhenOtelDisabled() {
+    try (VeniceMetricsRepository disabledRepo = new VeniceMetricsRepository(
+        new VeniceMetricsConfig.Builder().setMetricPrefix(TEST_METRIC_PREFIX).setEmitOtelMetrics(false).build())) {
+      exerciseAllRecordingPaths(disabledRepo);
+    }
+  }
+
+  @Test
+  public void testNoNpeWhenPlainMetricsRepository() {
+    exerciseAllRecordingPaths(new MetricsRepository());
+  }
+
+  private void exerciseAllRecordingPaths(MetricsRepository repo) {
+    AggVersionedDaVinciRecordTransformerStats safeStats = createAggStats(repo);
+    long ts = System.currentTimeMillis();
+    safeStats.recordPutLatency(TEST_STORE_NAME, 1, 10.0, ts);
+    safeStats.recordDeleteLatency(TEST_STORE_NAME, 1, 10.0, ts);
+    safeStats.recordPutError(TEST_STORE_NAME, 1, ts);
+    safeStats.recordDeleteError(TEST_STORE_NAME, 1, ts);
+  }
+
+  // --- Helpers ---
+
+  private static AggVersionedDaVinciRecordTransformerStats createAggStats(MetricsRepository repo) {
+    ReadOnlyStoreRepository metadataRepository = mock(ReadOnlyStoreRepository.class);
+    Store mockStore = mock(Store.class);
+    doReturn(TEST_STORE_NAME).when(mockStore).getName();
+    doReturn(Collections.emptyList()).when(mockStore).getVersions();
+    doReturn(0).when(mockStore).getCurrentVersion();
+    doReturn(mockStore).when(metadataRepository).getStoreOrThrow(anyString());
+
+    VeniceServerConfig serverConfig = mock(VeniceServerConfig.class);
+    doReturn(false).when(serverConfig).isUnregisterMetricForDeletedStoreEnabled();
+    doReturn(TEST_CLUSTER_NAME).when(serverConfig).getClusterName();
+
+    return new AggVersionedDaVinciRecordTransformerStats(repo, metadataRepository, serverConfig);
+  }
+
+  private Attributes buildAttributes(VeniceRecordTransformerOperation operation) {
+    return Attributes.builder()
+        .put(VENICE_CLUSTER_NAME.getDimensionNameInDefaultFormat(), TEST_CLUSTER_NAME)
+        .put(VENICE_STORE_NAME.getDimensionNameInDefaultFormat(), TEST_STORE_NAME)
+        .put(VENICE_RECORD_TRANSFORMER_OPERATION.getDimensionNameInDefaultFormat(), operation.getDimensionValue())
+        .build();
+  }
+}

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/stats/AggVersionedDaVinciRecordTransformerStatsOtelTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/stats/AggVersionedDaVinciRecordTransformerStatsOtelTest.java
@@ -7,8 +7,11 @@ import static com.linkedin.venice.stats.dimensions.VeniceMetricsDimensions.VENIC
 import static com.linkedin.venice.stats.dimensions.VeniceMetricsDimensions.VENICE_RECORD_TRANSFORMER_OPERATION;
 import static com.linkedin.venice.stats.dimensions.VeniceMetricsDimensions.VENICE_STORE_NAME;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
 
 import com.linkedin.davinci.config.VeniceServerConfig;
 import com.linkedin.venice.meta.ReadOnlyStoreRepository;
@@ -167,6 +170,9 @@ public class AggVersionedDaVinciRecordTransformerStatsOtelTest {
         buildAttributes(storeB, VeniceRecordTransformerOperation.PUT),
         RECORD_TRANSFORMER_ERROR_COUNT.getMetricEntity().getMetricName(),
         TEST_METRIC_PREFIX);
+
+    assertTrue(aggStats.hasErrorCountMetricFor(storeA), "Per-store error map must have an entry for " + storeA);
+    assertTrue(aggStats.hasErrorCountMetricFor(storeB), "Per-store error map must have an entry for " + storeB);
   }
 
   @Test
@@ -174,12 +180,18 @@ public class AggVersionedDaVinciRecordTransformerStatsOtelTest {
     long timestamp = System.currentTimeMillis();
     aggStats.recordPutLatency(TEST_STORE_NAME, 1, 10.0, timestamp);
     aggStats.recordPutError(TEST_STORE_NAME, 1, timestamp);
+    assertEquals(aggStats.latencyStoreCount(), 1, "Latency map should have one entry after recording");
+    assertEquals(aggStats.errorCountStoreCount(), 1, "Error map should have one entry after recording");
 
     aggStats.handleStoreDeleted(TEST_STORE_NAME);
 
-    // Recording after deletion must not NPE; per-store entries should be re-created lazily.
+    assertEquals(aggStats.latencyStoreCount(), 0, "Latency map should be empty after store deletion");
+    assertEquals(aggStats.errorCountStoreCount(), 0, "Error map should be empty after store deletion");
+
     aggStats.recordPutLatency(TEST_STORE_NAME, 1, 25.0, timestamp);
     aggStats.recordPutError(TEST_STORE_NAME, 1, timestamp);
+    assertEquals(aggStats.latencyStoreCount(), 1, "Latency map should have exactly one entry after re-record");
+    assertEquals(aggStats.errorCountStoreCount(), 1, "Error map should have exactly one entry after re-record");
   }
 
   // --- NPE prevention tests ---
@@ -214,11 +226,15 @@ public class AggVersionedDaVinciRecordTransformerStatsOtelTest {
 
   private static AggVersionedDaVinciRecordTransformerStats createAggStats(MetricsRepository repo) {
     ReadOnlyStoreRepository metadataRepository = mock(ReadOnlyStoreRepository.class);
-    Store mockStore = mock(Store.class);
-    doReturn(TEST_STORE_NAME).when(mockStore).getName();
-    doReturn(Collections.emptyList()).when(mockStore).getVersions();
-    doReturn(0).when(mockStore).getCurrentVersion();
-    doReturn(mockStore).when(metadataRepository).getStoreOrThrow(anyString());
+    // Return a Store whose getName() matches the requested arg so AbstractVeniceAggVersionedStats
+    // keeps per-store entries distinct (otherwise multi-store tests collapse into one Tehuti entry).
+    doAnswer(invocation -> {
+      Store mockStore = mock(Store.class);
+      doReturn(invocation.<String>getArgument(0)).when(mockStore).getName();
+      doReturn(Collections.emptyList()).when(mockStore).getVersions();
+      doReturn(0).when(mockStore).getCurrentVersion();
+      return mockStore;
+    }).when(metadataRepository).getStoreOrThrow(anyString());
 
     VeniceServerConfig serverConfig = mock(VeniceServerConfig.class);
     doReturn(false).when(serverConfig).isUnregisterMetricForDeletedStoreEnabled();

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/stats/AggVersionedDaVinciRecordTransformerStatsOtelTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/stats/AggVersionedDaVinciRecordTransformerStatsOtelTest.java
@@ -19,7 +19,9 @@ import com.linkedin.venice.stats.dimensions.VeniceRecordTransformerOperation;
 import com.linkedin.venice.utils.OpenTelemetryDataTestUtils;
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.sdk.testing.exporter.InMemoryMetricReader;
+import io.tehuti.metrics.MetricConfig;
 import io.tehuti.metrics.MetricsRepository;
+import io.tehuti.metrics.stats.AsyncGauge;
 import java.util.Collections;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
@@ -34,21 +36,28 @@ public class AggVersionedDaVinciRecordTransformerStatsOtelTest {
   private InMemoryMetricReader inMemoryMetricReader;
   private VeniceMetricsRepository metricsRepository;
   private AggVersionedDaVinciRecordTransformerStats aggStats;
+  // Dedicated executor avoids shutting down Tehuti's static DEFAULT_ASYNC_GAUGE_EXECUTOR singleton when this
+  // repository is closed in tearDown(). Closing the static executor would break AsyncGauge measurements
+  // for any subsequent test running in the same JVM.
+  private AsyncGauge.AsyncGaugeExecutor asyncGaugeExecutor;
 
   @BeforeMethod
   public void setUp() {
     inMemoryMetricReader = InMemoryMetricReader.create();
+    asyncGaugeExecutor = new AsyncGauge.AsyncGaugeExecutor.Builder().build();
     metricsRepository = new VeniceMetricsRepository(
         new VeniceMetricsConfig.Builder().setMetricPrefix(TEST_METRIC_PREFIX)
             .setMetricEntities(SERVER_METRIC_ENTITIES)
             .setEmitOtelMetrics(true)
             .setOtelAdditionalMetricsReader(inMemoryMetricReader)
+            .setTehutiMetricConfig(new MetricConfig(asyncGaugeExecutor))
             .build());
     aggStats = createAggStats(metricsRepository);
   }
 
   @AfterMethod
   public void tearDown() {
+    // Closes only the dedicated executor; the JVM-wide static executor stays alive for other tests.
     if (metricsRepository != null) {
       metricsRepository.close();
     }
@@ -136,12 +145,53 @@ public class AggVersionedDaVinciRecordTransformerStatsOtelTest {
         TEST_METRIC_PREFIX);
   }
 
+  @Test
+  public void testMultiStoreIsolation() {
+    String storeA = "store-a";
+    String storeB = "store-b";
+    long timestamp = System.currentTimeMillis();
+    aggStats.recordPutError(storeA, 1, timestamp);
+    aggStats.recordPutError(storeA, 1, timestamp);
+    aggStats.recordPutError(storeB, 1, timestamp);
+
+    OpenTelemetryDataTestUtils.validateLongPointDataFromCounter(
+        inMemoryMetricReader,
+        2,
+        buildAttributes(storeA, VeniceRecordTransformerOperation.PUT),
+        RECORD_TRANSFORMER_ERROR_COUNT.getMetricEntity().getMetricName(),
+        TEST_METRIC_PREFIX);
+
+    OpenTelemetryDataTestUtils.validateLongPointDataFromCounter(
+        inMemoryMetricReader,
+        1,
+        buildAttributes(storeB, VeniceRecordTransformerOperation.PUT),
+        RECORD_TRANSFORMER_ERROR_COUNT.getMetricEntity().getMetricName(),
+        TEST_METRIC_PREFIX);
+  }
+
+  @Test
+  public void testHandleStoreDeletedClearsPerStoreEntries() {
+    long timestamp = System.currentTimeMillis();
+    aggStats.recordPutLatency(TEST_STORE_NAME, 1, 10.0, timestamp);
+    aggStats.recordPutError(TEST_STORE_NAME, 1, timestamp);
+
+    aggStats.handleStoreDeleted(TEST_STORE_NAME);
+
+    // Recording after deletion must not NPE; per-store entries should be re-created lazily.
+    aggStats.recordPutLatency(TEST_STORE_NAME, 1, 25.0, timestamp);
+    aggStats.recordPutError(TEST_STORE_NAME, 1, timestamp);
+  }
+
   // --- NPE prevention tests ---
 
   @Test
   public void testNoNpeWhenOtelDisabled() {
+    AsyncGauge.AsyncGaugeExecutor localExecutor = new AsyncGauge.AsyncGaugeExecutor.Builder().build();
     try (VeniceMetricsRepository disabledRepo = new VeniceMetricsRepository(
-        new VeniceMetricsConfig.Builder().setMetricPrefix(TEST_METRIC_PREFIX).setEmitOtelMetrics(false).build())) {
+        new VeniceMetricsConfig.Builder().setMetricPrefix(TEST_METRIC_PREFIX)
+            .setEmitOtelMetrics(false)
+            .setTehutiMetricConfig(new MetricConfig(localExecutor))
+            .build())) {
       exerciseAllRecordingPaths(disabledRepo);
     }
   }
@@ -178,9 +228,13 @@ public class AggVersionedDaVinciRecordTransformerStatsOtelTest {
   }
 
   private Attributes buildAttributes(VeniceRecordTransformerOperation operation) {
+    return buildAttributes(TEST_STORE_NAME, operation);
+  }
+
+  private Attributes buildAttributes(String storeName, VeniceRecordTransformerOperation operation) {
     return Attributes.builder()
         .put(VENICE_CLUSTER_NAME.getDimensionNameInDefaultFormat(), TEST_CLUSTER_NAME)
-        .put(VENICE_STORE_NAME.getDimensionNameInDefaultFormat(), TEST_STORE_NAME)
+        .put(VENICE_STORE_NAME.getDimensionNameInDefaultFormat(), storeName)
         .put(VENICE_RECORD_TRANSFORMER_OPERATION.getDimensionNameInDefaultFormat(), operation.getDimensionValue())
         .build();
   }

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/stats/DaVinciRecordTransformerOtelMetricEntityTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/stats/DaVinciRecordTransformerOtelMetricEntityTest.java
@@ -1,0 +1,46 @@
+package com.linkedin.davinci.stats;
+
+import static com.linkedin.davinci.stats.DaVinciRecordTransformerOtelMetricEntity.RECORD_TRANSFORMER_ERROR_COUNT;
+import static com.linkedin.davinci.stats.DaVinciRecordTransformerOtelMetricEntity.RECORD_TRANSFORMER_LATENCY;
+import static com.linkedin.venice.stats.dimensions.VeniceMetricsDimensions.VENICE_CLUSTER_NAME;
+import static com.linkedin.venice.stats.dimensions.VeniceMetricsDimensions.VENICE_RECORD_TRANSFORMER_OPERATION;
+import static com.linkedin.venice.stats.dimensions.VeniceMetricsDimensions.VENICE_STORE_NAME;
+import static com.linkedin.venice.utils.Utils.setOf;
+
+import com.linkedin.venice.stats.metrics.MetricType;
+import com.linkedin.venice.stats.metrics.MetricUnit;
+import com.linkedin.venice.stats.metrics.ModuleMetricEntityTestFixture;
+import com.linkedin.venice.stats.metrics.ModuleMetricEntityTestFixture.MetricEntityExpectation;
+import java.util.HashMap;
+import java.util.Map;
+import org.testng.annotations.Test;
+
+
+public class DaVinciRecordTransformerOtelMetricEntityTest {
+  @Test
+  public void testMetricEntities() {
+    new ModuleMetricEntityTestFixture<>(DaVinciRecordTransformerOtelMetricEntity.class, expectedDefinitions())
+        .assertAll();
+  }
+
+  private static Map<DaVinciRecordTransformerOtelMetricEntity, MetricEntityExpectation> expectedDefinitions() {
+    Map<DaVinciRecordTransformerOtelMetricEntity, MetricEntityExpectation> map = new HashMap<>();
+    map.put(
+        RECORD_TRANSFORMER_LATENCY,
+        new MetricEntityExpectation(
+            "record_transformer.latency",
+            MetricType.HISTOGRAM,
+            MetricUnit.MILLISECOND,
+            "DaVinci record transformer operation latency",
+            setOf(VENICE_CLUSTER_NAME, VENICE_STORE_NAME, VENICE_RECORD_TRANSFORMER_OPERATION)));
+    map.put(
+        RECORD_TRANSFORMER_ERROR_COUNT,
+        new MetricEntityExpectation(
+            "record_transformer.error_count",
+            MetricType.COUNTER,
+            MetricUnit.NUMBER,
+            "DaVinci record transformer operation error count",
+            setOf(VENICE_CLUSTER_NAME, VENICE_STORE_NAME, VENICE_RECORD_TRANSFORMER_OPERATION)));
+    return map;
+  }
+}

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/stats/ServerMetricEntityTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/stats/ServerMetricEntityTest.java
@@ -22,7 +22,7 @@ import org.testng.annotations.Test;
 public class ServerMetricEntityTest {
   @Test
   public void testServerMetricEntitiesCount() {
-    assertEquals(SERVER_METRIC_ENTITIES.size(), 153, "Expected 153 unique metric entities");
+    assertEquals(SERVER_METRIC_ENTITIES.size(), 155, "Expected 155 unique metric entities");
   }
 
   /**

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/stats/ServerMetricEntityTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/stats/ServerMetricEntityTest.java
@@ -22,7 +22,7 @@ import org.testng.annotations.Test;
 public class ServerMetricEntityTest {
   @Test
   public void testServerMetricEntitiesCount() {
-    assertEquals(SERVER_METRIC_ENTITIES.size(), 155, "Expected 155 unique metric entities");
+    assertEquals(SERVER_METRIC_ENTITIES.size(), 157, "Expected 157 unique metric entities");
   }
 
   /**

--- a/internal/venice-client-common/src/main/java/com/linkedin/venice/stats/dimensions/VeniceMetricsDimensions.java
+++ b/internal/venice-client-common/src/main/java/com/linkedin/venice/stats/dimensions/VeniceMetricsDimensions.java
@@ -153,7 +153,10 @@ public enum VeniceMetricsDimensions {
   VENICE_CONNECTION_SOURCE("venice.connection.source"),
 
   /** {@link VeniceDrainerType} Drainer type: sorted or unsorted. */
-  VENICE_DRAINER_TYPE("venice.drainer.type");
+  VENICE_DRAINER_TYPE("venice.drainer.type"),
+
+  /** {@link VeniceRecordTransformerOperation} Record transformer operation: put or delete. */
+  VENICE_RECORD_TRANSFORMER_OPERATION("venice.record_transformer.operation");
 
   private final String[] dimensionName = new String[VeniceOpenTelemetryMetricNamingFormat.SIZE];
 

--- a/internal/venice-client-common/src/main/java/com/linkedin/venice/stats/dimensions/VeniceMetricsDimensions.java
+++ b/internal/venice-client-common/src/main/java/com/linkedin/venice/stats/dimensions/VeniceMetricsDimensions.java
@@ -156,7 +156,10 @@ public enum VeniceMetricsDimensions {
   VENICE_DRAINER_TYPE("venice.drainer.type"),
 
   /** {@link VeniceRequestKeyCountBucket} Coarse key-count bucket for request batches. */
-  VENICE_REQUEST_KEY_COUNT_BUCKET("venice.request.key_count_bucket");
+  VENICE_REQUEST_KEY_COUNT_BUCKET("venice.request.key_count_bucket"),
+
+  /** {@link VeniceRecordTransformerOperation} Record transformer operation: put or delete. */
+  VENICE_RECORD_TRANSFORMER_OPERATION("venice.record_transformer.operation");
 
   private final String[] dimensionName = new String[VeniceOpenTelemetryMetricNamingFormat.SIZE];
 

--- a/internal/venice-client-common/src/main/java/com/linkedin/venice/stats/dimensions/VeniceRecordTransformerOperation.java
+++ b/internal/venice-client-common/src/main/java/com/linkedin/venice/stats/dimensions/VeniceRecordTransformerOperation.java
@@ -1,0 +1,14 @@
+package com.linkedin.venice.stats.dimensions;
+
+/** DaVinci record transformer operation type. */
+public enum VeniceRecordTransformerOperation implements VeniceDimensionInterface {
+  /** Record put (insert/update) operation. */
+  PUT,
+  /** Record delete operation. */
+  DELETE;
+
+  @Override
+  public VeniceMetricsDimensions getDimensionName() {
+    return VeniceMetricsDimensions.VENICE_RECORD_TRANSFORMER_OPERATION;
+  }
+}

--- a/internal/venice-client-common/src/test/java/com/linkedin/venice/stats/dimensions/VeniceMetricsDimensionsTest.java
+++ b/internal/venice-client-common/src/test/java/com/linkedin/venice/stats/dimensions/VeniceMetricsDimensionsTest.java
@@ -157,6 +157,9 @@ public class VeniceMetricsDimensionsTest {
         case VENICE_DRAINER_TYPE:
           assertEquals(dimension.getDimensionName(format), "venice.drainer.type");
           break;
+        case VENICE_RECORD_TRANSFORMER_OPERATION:
+          assertEquals(dimension.getDimensionName(format), "venice.record_transformer.operation");
+          break;
         default:
           throw new IllegalArgumentException("Unknown dimension: " + dimension);
       }
@@ -312,6 +315,9 @@ public class VeniceMetricsDimensionsTest {
         case VENICE_DRAINER_TYPE:
           assertEquals(dimension.getDimensionName(format), "venice.drainer.type");
           break;
+        case VENICE_RECORD_TRANSFORMER_OPERATION:
+          assertEquals(dimension.getDimensionName(format), "venice.recordTransformer.operation");
+          break;
         default:
           throw new IllegalArgumentException("Unknown dimension: " + dimension);
       }
@@ -466,6 +472,9 @@ public class VeniceMetricsDimensionsTest {
           break;
         case VENICE_DRAINER_TYPE:
           assertEquals(dimension.getDimensionName(format), "Venice.Drainer.Type");
+          break;
+        case VENICE_RECORD_TRANSFORMER_OPERATION:
+          assertEquals(dimension.getDimensionName(format), "Venice.RecordTransformer.Operation");
           break;
         default:
           throw new IllegalArgumentException("Unknown dimension: " + dimension);

--- a/internal/venice-client-common/src/test/java/com/linkedin/venice/stats/dimensions/VeniceMetricsDimensionsTest.java
+++ b/internal/venice-client-common/src/test/java/com/linkedin/venice/stats/dimensions/VeniceMetricsDimensionsTest.java
@@ -160,6 +160,9 @@ public class VeniceMetricsDimensionsTest {
         case VENICE_REQUEST_KEY_COUNT_BUCKET:
           assertEquals(dimension.getDimensionName(format), "venice.request.key_count_bucket");
           break;
+        case VENICE_RECORD_TRANSFORMER_OPERATION:
+          assertEquals(dimension.getDimensionName(format), "venice.record_transformer.operation");
+          break;
         default:
           throw new IllegalArgumentException("Unknown dimension: " + dimension);
       }
@@ -318,6 +321,9 @@ public class VeniceMetricsDimensionsTest {
         case VENICE_REQUEST_KEY_COUNT_BUCKET:
           assertEquals(dimension.getDimensionName(format), "venice.request.keyCountBucket");
           break;
+        case VENICE_RECORD_TRANSFORMER_OPERATION:
+          assertEquals(dimension.getDimensionName(format), "venice.recordTransformer.operation");
+          break;
         default:
           throw new IllegalArgumentException("Unknown dimension: " + dimension);
       }
@@ -475,6 +481,9 @@ public class VeniceMetricsDimensionsTest {
           break;
         case VENICE_REQUEST_KEY_COUNT_BUCKET:
           assertEquals(dimension.getDimensionName(format), "Venice.Request.KeyCountBucket");
+          break;
+        case VENICE_RECORD_TRANSFORMER_OPERATION:
+          assertEquals(dimension.getDimensionName(format), "Venice.RecordTransformer.Operation");
           break;
         default:
           throw new IllegalArgumentException("Unknown dimension: " + dimension);

--- a/internal/venice-client-common/src/test/java/com/linkedin/venice/stats/dimensions/VeniceRecordTransformerOperationTest.java
+++ b/internal/venice-client-common/src/test/java/com/linkedin/venice/stats/dimensions/VeniceRecordTransformerOperationTest.java
@@ -1,0 +1,21 @@
+package com.linkedin.venice.stats.dimensions;
+
+import com.linkedin.venice.utils.CollectionUtils;
+import java.util.Map;
+import org.testng.annotations.Test;
+
+
+public class VeniceRecordTransformerOperationTest {
+  @Test
+  public void testDimensionInterface() {
+    Map<VeniceRecordTransformerOperation, String> expectedValues =
+        CollectionUtils.<VeniceRecordTransformerOperation, String>mapBuilder()
+            .put(VeniceRecordTransformerOperation.PUT, "put")
+            .put(VeniceRecordTransformerOperation.DELETE, "delete")
+            .build();
+    new VeniceDimensionTestFixture<>(
+        VeniceRecordTransformerOperation.class,
+        VeniceMetricsDimensions.VENICE_RECORD_TRANSFORMER_OPERATION,
+        expectedValues).assertAll();
+  }
+}


### PR DESCRIPTION
## Problem Statement

`DaVinciRecordTransformerStats` has 4 Tehuti sensors for record transformer operations (put/delete latency and error counts) but no OTel counterparts, making these metrics unavailable in OTel-based monitoring dashboards.

## Solution

Add 2 OTel metrics to `AggVersionedDaVinciRecordTransformerStats` with a `VENICE_RECORD_TRANSFORMER_OPERATION` dimension (PUT/DELETE):

- `record_transformer.latency` (HISTOGRAM) — DaVinci record transformer operation latency
- `record_transformer.error_count` (COUNTER) — DaVinci record transformer operation error count

Uses the **separate Tehuti+OTel API**: Tehuti metrics are managed by the Reporter layer (`DaVinciRecordTransformerStatsReporter`) with AsyncGauge polling, while OTel records directly at the call point in `AggVersionedDaVinciRecordTransformerStats`. This follows the established pattern for versioned stats where Tehuti and OTel have fundamentally different recording paths.

**Key design decisions:**
- Per-store `VeniceConcurrentHashMap` maps for latency and error count metrics, cleaned up in `handleStoreDeleted`.
- `private final boolean emitOtelMetrics` cached at construction; `recordOtelLatency` and `recordOtelErrorCount` early-return when OTel is disabled, so the per-store maps are never populated in non-OTel deployments. Mirrors the established `AggVersionedDIVStats` pattern.
- `@VisibleForTesting` accessors (`hasLatencyMetricFor`, `latencyStoreCount`, etc.) let tests pin the cleanup contract on `handleStoreDeleted` without exposing the internal maps.

###  Code changes
- [ ] Added new code behind **a config**.
- [ ] Introduced new **log lines**.
  - [ ] Confirmed if logs need to be **rate limited** to avoid excessive logging.

###  **Concurrency-Specific Checks**
Both reviewer and PR author to verify
- [x] Code has **no race conditions** or **thread safety issues**.
- [x] Proper **synchronization mechanisms** (e.g., `synchronized`, `RWLock`) are used where needed.
- [x] No **blocking calls** inside critical sections that could lead to deadlocks or performance degradation.
- [x] Verified **thread-safe collections** are used (e.g., `ConcurrentHashMap`, `CopyOnWriteArrayList`).
- [x] Validated proper exception handling in multi-threaded code to avoid silent thread termination.

## How was this PR tested?

- [x] New unit tests added.
- [ ] New integration tests added.
- [ ] Modified or extended existing tests.
- [x] Verified backward compatibility (if applicable).

New tests:
- `AggVersionedDaVinciRecordTransformerStatsOtelTest` (9 tests): OTel histogram for put/delete latency, OTel counter for put/delete errors, operation dimension isolation, multi-store isolation (validates per-store entries stay distinct via the `doAnswer` Store mock so `AbstractVeniceAggVersionedStats` doesn't collapse them), `handleStoreDeleted` cleanup contract (asserts per-store maps go from 1 entry → 0 → 1 across record/delete/re-record), NPE prevention with OTel disabled and plain MetricsRepository.
- `DaVinciRecordTransformerOtelMetricEntityTest`: metric entity validation for both metrics.
- `VeniceRecordTransformerOperationTest`: dimension value validation (PUT/DELETE).

## Does this PR introduce any user-facing or breaking changes?
- [x] No. You can skip the rest of this section.
- [ ] Yes. Clearly explain the behavior change and its impact.
