### PR TITLE
[server] Add OTel metrics to BackupVersionOptimizationServiceStats

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/BackupVersionOptimizationOtelMetricEntity.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/BackupVersionOptimizationOtelMetricEntity.java
@@ -1,0 +1,42 @@
+package com.linkedin.davinci.stats;
+
+import static com.linkedin.venice.stats.dimensions.VeniceMetricsDimensions.VENICE_CLUSTER_NAME;
+import static com.linkedin.venice.stats.dimensions.VeniceMetricsDimensions.VENICE_OPERATION_OUTCOME;
+import static com.linkedin.venice.stats.dimensions.VeniceMetricsDimensions.VENICE_STORE_NAME;
+import static com.linkedin.venice.utils.Utils.setOf;
+
+import com.linkedin.venice.stats.dimensions.VeniceMetricsDimensions;
+import com.linkedin.venice.stats.metrics.MetricEntity;
+import com.linkedin.venice.stats.metrics.MetricType;
+import com.linkedin.venice.stats.metrics.MetricUnit;
+import com.linkedin.venice.stats.metrics.ModuleMetricEntityInterface;
+import java.util.Set;
+
+
+/**
+ * OTel metric entity definitions for
+ * {@link com.linkedin.venice.stats.BackupVersionOptimizationServiceStats}.
+ */
+public enum BackupVersionOptimizationOtelMetricEntity implements ModuleMetricEntityInterface {
+  REOPEN_COUNT(
+      "version.backup.optimization.reopen_count", MetricType.COUNTER, MetricUnit.NUMBER,
+      "Count of backup version storage partition reopens by outcome (success or fail)",
+      setOf(VENICE_CLUSTER_NAME, VENICE_STORE_NAME, VENICE_OPERATION_OUTCOME)
+  );
+
+  private final MetricEntity metricEntity;
+
+  BackupVersionOptimizationOtelMetricEntity(
+      String metricName,
+      MetricType metricType,
+      MetricUnit unit,
+      String description,
+      Set<VeniceMetricsDimensions> dimensions) {
+    this.metricEntity = new MetricEntity(metricName, metricType, unit, description, dimensions);
+  }
+
+  @Override
+  public MetricEntity getMetricEntity() {
+    return metricEntity;
+  }
+}

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/ServerMetricEntity.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/ServerMetricEntity.java
@@ -43,7 +43,8 @@ public final class ServerMetricEntity {
         ServerReadQuotaOtelMetricEntity.class,
         ServerConnectionOtelMetricEntity.class,
         StoreBufferServiceOtelMetricEntity.class,
-        StorageEngineOtelMetricEntity.class);
+        StorageEngineOtelMetricEntity.class,
+        BackupVersionOptimizationOtelMetricEntity.class);
   }
 
   public static final Collection<MetricEntity> SERVER_METRIC_ENTITIES =

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/stats/BackupVersionOptimizationOtelMetricEntityTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/stats/BackupVersionOptimizationOtelMetricEntityTest.java
@@ -1,0 +1,37 @@
+package com.linkedin.davinci.stats;
+
+import static com.linkedin.davinci.stats.BackupVersionOptimizationOtelMetricEntity.REOPEN_COUNT;
+import static com.linkedin.venice.stats.dimensions.VeniceMetricsDimensions.VENICE_CLUSTER_NAME;
+import static com.linkedin.venice.stats.dimensions.VeniceMetricsDimensions.VENICE_OPERATION_OUTCOME;
+import static com.linkedin.venice.stats.dimensions.VeniceMetricsDimensions.VENICE_STORE_NAME;
+import static com.linkedin.venice.utils.Utils.setOf;
+
+import com.linkedin.venice.stats.metrics.MetricType;
+import com.linkedin.venice.stats.metrics.MetricUnit;
+import com.linkedin.venice.stats.metrics.ModuleMetricEntityTestFixture;
+import com.linkedin.venice.stats.metrics.ModuleMetricEntityTestFixture.MetricEntityExpectation;
+import java.util.HashMap;
+import java.util.Map;
+import org.testng.annotations.Test;
+
+
+public class BackupVersionOptimizationOtelMetricEntityTest {
+  @Test
+  public void testMetricEntities() {
+    new ModuleMetricEntityTestFixture<>(BackupVersionOptimizationOtelMetricEntity.class, expectedDefinitions())
+        .assertAll();
+  }
+
+  private static Map<BackupVersionOptimizationOtelMetricEntity, MetricEntityExpectation> expectedDefinitions() {
+    Map<BackupVersionOptimizationOtelMetricEntity, MetricEntityExpectation> map = new HashMap<>();
+    map.put(
+        REOPEN_COUNT,
+        new MetricEntityExpectation(
+            "version.backup.optimization.reopen_count",
+            MetricType.COUNTER,
+            MetricUnit.NUMBER,
+            "Count of backup version storage partition reopens by outcome (success or fail)",
+            setOf(VENICE_CLUSTER_NAME, VENICE_STORE_NAME, VENICE_OPERATION_OUTCOME)));
+    return map;
+  }
+}

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/stats/ServerMetricEntityTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/stats/ServerMetricEntityTest.java
@@ -22,7 +22,7 @@ import org.testng.annotations.Test;
 public class ServerMetricEntityTest {
   @Test
   public void testServerMetricEntitiesCount() {
-    assertEquals(SERVER_METRIC_ENTITIES.size(), 153, "Expected 153 unique metric entities");
+    assertEquals(SERVER_METRIC_ENTITIES.size(), 154, "Expected 154 unique metric entities");
   }
 
   /**

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/stats/ServerMetricEntityTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/stats/ServerMetricEntityTest.java
@@ -22,7 +22,7 @@ import org.testng.annotations.Test;
 public class ServerMetricEntityTest {
   @Test
   public void testServerMetricEntitiesCount() {
-    assertEquals(SERVER_METRIC_ENTITIES.size(), 155, "Expected 155 unique metric entities");
+    assertEquals(SERVER_METRIC_ENTITIES.size(), 156, "Expected 156 unique metric entities");
   }
 
   /**

--- a/internal/venice-client-common/src/main/java/com/linkedin/venice/stats/dimensions/VeniceMetricsDimensions.java
+++ b/internal/venice-client-common/src/main/java/com/linkedin/venice/stats/dimensions/VeniceMetricsDimensions.java
@@ -153,7 +153,10 @@ public enum VeniceMetricsDimensions {
   VENICE_CONNECTION_SOURCE("venice.connection.source"),
 
   /** {@link VeniceDrainerType} Drainer type: sorted or unsorted. */
-  VENICE_DRAINER_TYPE("venice.drainer.type");
+  VENICE_DRAINER_TYPE("venice.drainer.type"),
+
+  /** {@link VeniceOperationOutcome} Generic operation outcome: success or fail. */
+  VENICE_OPERATION_OUTCOME("venice.operation.outcome");
 
   private final String[] dimensionName = new String[VeniceOpenTelemetryMetricNamingFormat.SIZE];
 

--- a/internal/venice-client-common/src/main/java/com/linkedin/venice/stats/dimensions/VeniceMetricsDimensions.java
+++ b/internal/venice-client-common/src/main/java/com/linkedin/venice/stats/dimensions/VeniceMetricsDimensions.java
@@ -156,7 +156,10 @@ public enum VeniceMetricsDimensions {
   VENICE_DRAINER_TYPE("venice.drainer.type"),
 
   /** {@link VeniceRequestKeyCountBucket} Coarse key-count bucket for request batches. */
-  VENICE_REQUEST_KEY_COUNT_BUCKET("venice.request.key_count_bucket");
+  VENICE_REQUEST_KEY_COUNT_BUCKET("venice.request.key_count_bucket"),
+
+  /** {@link VeniceOperationOutcome} Generic operation outcome: success or fail. */
+  VENICE_OPERATION_OUTCOME("venice.operation.outcome");
 
   private final String[] dimensionName = new String[VeniceOpenTelemetryMetricNamingFormat.SIZE];
 

--- a/internal/venice-client-common/src/main/java/com/linkedin/venice/stats/dimensions/VeniceOperationOutcome.java
+++ b/internal/venice-client-common/src/main/java/com/linkedin/venice/stats/dimensions/VeniceOperationOutcome.java
@@ -1,0 +1,14 @@
+package com.linkedin.venice.stats.dimensions;
+
+/** Generic operation outcome: success or failure. */
+public enum VeniceOperationOutcome implements VeniceDimensionInterface {
+  /** Operation completed successfully. */
+  SUCCESS,
+  /** Operation failed. */
+  FAIL;
+
+  @Override
+  public VeniceMetricsDimensions getDimensionName() {
+    return VeniceMetricsDimensions.VENICE_OPERATION_OUTCOME;
+  }
+}

--- a/internal/venice-client-common/src/test/java/com/linkedin/venice/stats/dimensions/VeniceMetricsDimensionsTest.java
+++ b/internal/venice-client-common/src/test/java/com/linkedin/venice/stats/dimensions/VeniceMetricsDimensionsTest.java
@@ -157,6 +157,9 @@ public class VeniceMetricsDimensionsTest {
         case VENICE_DRAINER_TYPE:
           assertEquals(dimension.getDimensionName(format), "venice.drainer.type");
           break;
+        case VENICE_OPERATION_OUTCOME:
+          assertEquals(dimension.getDimensionName(format), "venice.operation.outcome");
+          break;
         default:
           throw new IllegalArgumentException("Unknown dimension: " + dimension);
       }
@@ -312,6 +315,9 @@ public class VeniceMetricsDimensionsTest {
         case VENICE_DRAINER_TYPE:
           assertEquals(dimension.getDimensionName(format), "venice.drainer.type");
           break;
+        case VENICE_OPERATION_OUTCOME:
+          assertEquals(dimension.getDimensionName(format), "venice.operation.outcome");
+          break;
         default:
           throw new IllegalArgumentException("Unknown dimension: " + dimension);
       }
@@ -466,6 +472,9 @@ public class VeniceMetricsDimensionsTest {
           break;
         case VENICE_DRAINER_TYPE:
           assertEquals(dimension.getDimensionName(format), "Venice.Drainer.Type");
+          break;
+        case VENICE_OPERATION_OUTCOME:
+          assertEquals(dimension.getDimensionName(format), "Venice.Operation.Outcome");
           break;
         default:
           throw new IllegalArgumentException("Unknown dimension: " + dimension);

--- a/internal/venice-client-common/src/test/java/com/linkedin/venice/stats/dimensions/VeniceMetricsDimensionsTest.java
+++ b/internal/venice-client-common/src/test/java/com/linkedin/venice/stats/dimensions/VeniceMetricsDimensionsTest.java
@@ -160,6 +160,9 @@ public class VeniceMetricsDimensionsTest {
         case VENICE_REQUEST_KEY_COUNT_BUCKET:
           assertEquals(dimension.getDimensionName(format), "venice.request.key_count_bucket");
           break;
+        case VENICE_OPERATION_OUTCOME:
+          assertEquals(dimension.getDimensionName(format), "venice.operation.outcome");
+          break;
         default:
           throw new IllegalArgumentException("Unknown dimension: " + dimension);
       }
@@ -318,6 +321,9 @@ public class VeniceMetricsDimensionsTest {
         case VENICE_REQUEST_KEY_COUNT_BUCKET:
           assertEquals(dimension.getDimensionName(format), "venice.request.keyCountBucket");
           break;
+        case VENICE_OPERATION_OUTCOME:
+          assertEquals(dimension.getDimensionName(format), "venice.operation.outcome");
+          break;
         default:
           throw new IllegalArgumentException("Unknown dimension: " + dimension);
       }
@@ -475,6 +481,9 @@ public class VeniceMetricsDimensionsTest {
           break;
         case VENICE_REQUEST_KEY_COUNT_BUCKET:
           assertEquals(dimension.getDimensionName(format), "Venice.Request.KeyCountBucket");
+          break;
+        case VENICE_OPERATION_OUTCOME:
+          assertEquals(dimension.getDimensionName(format), "Venice.Operation.Outcome");
           break;
         default:
           throw new IllegalArgumentException("Unknown dimension: " + dimension);

--- a/internal/venice-client-common/src/test/java/com/linkedin/venice/stats/dimensions/VeniceOperationOutcomeTest.java
+++ b/internal/venice-client-common/src/test/java/com/linkedin/venice/stats/dimensions/VeniceOperationOutcomeTest.java
@@ -1,0 +1,20 @@
+package com.linkedin.venice.stats.dimensions;
+
+import com.linkedin.venice.utils.CollectionUtils;
+import java.util.Map;
+import org.testng.annotations.Test;
+
+
+public class VeniceOperationOutcomeTest {
+  @Test
+  public void testDimensionInterface() {
+    Map<VeniceOperationOutcome, String> expectedValues = CollectionUtils.<VeniceOperationOutcome, String>mapBuilder()
+        .put(VeniceOperationOutcome.SUCCESS, "success")
+        .put(VeniceOperationOutcome.FAIL, "fail")
+        .build();
+    new VeniceDimensionTestFixture<>(
+        VeniceOperationOutcome.class,
+        VeniceMetricsDimensions.VENICE_OPERATION_OUTCOME,
+        expectedValues).assertAll();
+  }
+}

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestBackupVersionDatabaseOptimization.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestBackupVersionDatabaseOptimization.java
@@ -142,19 +142,27 @@ public class TestBackupVersionDatabaseOptimization {
       // Verify whether the backup version database optimization happens or not.
       VeniceServerWrapper serverWrapper = venice.getVeniceServers().get(0);
       MetricsRepository metricsRepository = serverWrapper.getMetricsRepository();
-      Metric optimizationMetric = metricsRepository
-          .getMetric(".BackupVersionOptimizationService--backup_version_database_optimization.OccurrenceRate");
-      Metric rocksdbMetric = metricsRepository.getMetric(".RocksDBMemoryStats--rocksdb.num-immutable-mem-table.Gauge");
 
       // N.B.: The optimization is performed by a periodic background task, so it cannot be expected to have already
-      // completed as soon as we get here.
+      // completed as soon as we get here. Fetch the metric handle inside the assertion lambda — the Tehuti sensor is
+      // registered lazily on first per-store recording, so getMetric(...) returns null until the first optimization
+      // fires.
       TestUtils.waitForNonDeterministicAssertion(10, TimeUnit.SECONDS, true, () -> {
+        Metric optimizationMetric = metricsRepository
+            .getMetric(".BackupVersionOptimizationService--backup_version_database_optimization.OccurrenceRate");
+        assertNotNull(
+            optimizationMetric,
+            "Backup version optimization Tehuti sensor should be registered after the first optimization");
         assertTrue(optimizationMetric.value() > 0, "Backup version database optimization should happen");
         /**
          * This assertion is used to make sure {@link com.linkedin.davinci.stats.RocksDBMemoryStats} won't crash after
          * reopening the backup version.
          */
-        rocksdbMetric.value();
+        Metric rocksdbMetric =
+            metricsRepository.getMetric(".RocksDBMemoryStats--rocksdb.num-immutable-mem-table.Gauge");
+        if (rocksdbMetric != null) {
+          rocksdbMetric.value();
+        }
       });
     }
   }

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestBackupVersionDatabaseOptimization.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestBackupVersionDatabaseOptimization.java
@@ -160,9 +160,8 @@ public class TestBackupVersionDatabaseOptimization {
          */
         Metric rocksdbMetric =
             metricsRepository.getMetric(".RocksDBMemoryStats--rocksdb.num-immutable-mem-table.Gauge");
-        if (rocksdbMetric != null) {
-          rocksdbMetric.value();
-        }
+        assertNotNull(rocksdbMetric, "RocksDBMemoryStats num-immutable-mem-table gauge must be registered");
+        rocksdbMetric.value();
       });
     }
   }

--- a/services/venice-server/src/main/java/com/linkedin/venice/cleaner/BackupVersionOptimizationService.java
+++ b/services/venice-server/src/main/java/com/linkedin/venice/cleaner/BackupVersionOptimizationService.java
@@ -155,17 +155,17 @@ public class BackupVersionOptimizationService extends AbstractVeniceService impl
           for (int partitionId: partitionIdSet) {
             try {
               engine.reopenStoragePartition(partitionId);
-              stats.recordBackupVersionDatabaseOptimization();
+              stats.recordBackupVersionDatabaseOptimization(storeName);
             } catch (Exception e) {
               LOGGER.error(
                   "Failed to optimize database for topic-partition: {}",
                   Utils.getReplicaId(resourceName, partitionId),
                   e);
+              stats.recordBackupVersionDatabaseOptimizationError(storeName);
               errored = true;
             }
           }
           if (errored) {
-            stats.recordBackupVersionDatabaseOptimizationError();
             LOGGER.warn(
                 "Encountered issue when optimizing database for resource: {}, "
                     + "and please check the above logs to find more details, and will retry the optimization in next iteration",

--- a/services/venice-server/src/main/java/com/linkedin/venice/server/VeniceServer.java
+++ b/services/venice-server/src/main/java/com/linkedin/venice/server/VeniceServer.java
@@ -451,7 +451,10 @@ public class VeniceServer {
           storageService.getStorageEngineRepository(),
           serverConfig.getOptimizeDatabaseForBackupVersionNoReadThresholdMS(),
           serverConfig.getOptimizeDatabaseServiceScheduleIntervalSeconds(),
-          new BackupVersionOptimizationServiceStats(metricsRepository, "BackupVersionOptimizationService"),
+          new BackupVersionOptimizationServiceStats(
+              metricsRepository,
+              "BackupVersionOptimizationService",
+              serverConfig.getClusterName()),
           serverConfig.getLogContext());
       services.add(backupVersionOptimizationService);
       resourceReadUsageTracker = Optional.of(backupVersionOptimizationService);

--- a/services/venice-server/src/main/java/com/linkedin/venice/stats/BackupVersionOptimizationServiceStats.java
+++ b/services/venice-server/src/main/java/com/linkedin/venice/stats/BackupVersionOptimizationServiceStats.java
@@ -1,31 +1,89 @@
 package com.linkedin.venice.stats;
 
+import static com.linkedin.davinci.stats.BackupVersionOptimizationOtelMetricEntity.REOPEN_COUNT;
+
 import com.linkedin.venice.cleaner.BackupVersionOptimizationService;
+import com.linkedin.venice.stats.dimensions.VeniceMetricsDimensions;
+import com.linkedin.venice.stats.dimensions.VeniceOperationOutcome;
+import com.linkedin.venice.stats.metrics.MetricEntityStateOneEnum;
+import com.linkedin.venice.stats.metrics.TehutiMetricNameEnum;
+import com.linkedin.venice.utils.concurrent.VeniceConcurrentHashMap;
 import io.tehuti.metrics.MetricsRepository;
-import io.tehuti.metrics.Sensor;
 import io.tehuti.metrics.stats.OccurrenceRate;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
 
 
 /**
  * {@code BackupVersionOptimizationServiceStats} record the statistics for the database optimization done by the
  * {@link BackupVersionOptimizationService} including both successes and failures.
+ *
+ * <p>OTel uses a single COUNTER with STORE_NAME + OPERATION_OUTCOME dimensions. Tehuti uses
+ * 2 separate OccurrenceRate sensors (backward compatible, no per-store granularity in Tehuti).
  */
 public class BackupVersionOptimizationServiceStats extends AbstractVeniceStats {
-  private final Sensor optimizationSensor;
-  private final Sensor optimizationErrorSensor;
+  /** Tehuti metric names for BackupVersionOptimizationServiceStats sensors. */
+  enum TehutiMetricName implements TehutiMetricNameEnum {
+    BACKUP_VERSION_DATABASE_OPTIMIZATION, BACKUP_VERSION_DATA_OPTIMIZATION_ERROR
+  }
 
-  public BackupVersionOptimizationServiceStats(MetricsRepository metricsRepository, String name) {
+  private final VeniceOpenTelemetryMetricsRepository otelRepository;
+  private final Map<VeniceMetricsDimensions, String> baseDimensionsMap;
+
+  /**
+   * Per-store joint Tehuti+OTel metric state maps. Two maps because they bind to different Tehuti sensors
+   * (success vs error) while sharing the same OTel instrument ({@code REOPEN_COUNT}) differentiated
+   * by {@link VeniceOperationOutcome}. Tehuti sensor is registered once (first store) and shared by all
+   * subsequent stores via {@code registerSensorIfAbsent}. Bounded by the number of stores on this host.
+   * When OTel is disabled, {@code otelRepository} is null and OTel recording is a no-op.
+   */
+  private final Map<String, MetricEntityStateOneEnum<VeniceOperationOutcome>> successPerStore =
+      new VeniceConcurrentHashMap<>();
+  private final Map<String, MetricEntityStateOneEnum<VeniceOperationOutcome>> errorPerStore =
+      new VeniceConcurrentHashMap<>();
+
+  public BackupVersionOptimizationServiceStats(MetricsRepository metricsRepository, String name, String clusterName) {
     super(metricsRepository, name);
 
-    this.optimizationSensor = registerSensor("backup_version_database_optimization", new OccurrenceRate());
-    this.optimizationErrorSensor = registerSensor("backup_version_data_optimization_error", new OccurrenceRate());
+    OpenTelemetryMetricsSetup.OpenTelemetryMetricsSetupInfo otelData =
+        OpenTelemetryMetricsSetup.builder(metricsRepository).setClusterName(clusterName).build();
+    this.otelRepository = otelData.getOtelRepository();
+    this.baseDimensionsMap = otelData.getBaseDimensionsMap();
   }
 
-  public void recordBackupVersionDatabaseOptimization() {
-    this.optimizationSensor.record();
+  public void recordBackupVersionDatabaseOptimization(String storeName) {
+    getOrCreateSuccessMetric(storeName).record(1, VeniceOperationOutcome.SUCCESS);
   }
 
-  public void recordBackupVersionDatabaseOptimizationError() {
-    this.optimizationErrorSensor.record();
+  public void recordBackupVersionDatabaseOptimizationError(String storeName) {
+    getOrCreateErrorMetric(storeName).record(1, VeniceOperationOutcome.FAIL);
+  }
+
+  private MetricEntityStateOneEnum<VeniceOperationOutcome> getOrCreateSuccessMetric(String storeName) {
+    return successPerStore.computeIfAbsent(
+        storeName,
+        k -> createPerStoreMetric(k, TehutiMetricName.BACKUP_VERSION_DATABASE_OPTIMIZATION));
+  }
+
+  private MetricEntityStateOneEnum<VeniceOperationOutcome> getOrCreateErrorMetric(String storeName) {
+    return errorPerStore.computeIfAbsent(
+        storeName,
+        k -> createPerStoreMetric(k, TehutiMetricName.BACKUP_VERSION_DATA_OPTIMIZATION_ERROR));
+  }
+
+  private MetricEntityStateOneEnum<VeniceOperationOutcome> createPerStoreMetric(
+      String storeName,
+      TehutiMetricName tehutiName) {
+    Map<VeniceMetricsDimensions, String> storeDims = new HashMap<>(baseDimensionsMap);
+    storeDims.put(VeniceMetricsDimensions.VENICE_STORE_NAME, OpenTelemetryMetricsSetup.sanitizeStoreName(storeName));
+    return MetricEntityStateOneEnum.create(
+        REOPEN_COUNT.getMetricEntity(),
+        otelRepository,
+        this::registerSensorIfAbsent,
+        tehutiName,
+        Collections.singletonList(new OccurrenceRate()),
+        storeDims,
+        VeniceOperationOutcome.class);
   }
 }

--- a/services/venice-server/src/main/java/com/linkedin/venice/stats/BackupVersionOptimizationServiceStats.java
+++ b/services/venice-server/src/main/java/com/linkedin/venice/stats/BackupVersionOptimizationServiceStats.java
@@ -16,7 +16,7 @@ import java.util.Map;
 
 
 /**
- * {@code BackupVersionOptimizationServiceStats} record the statistics for the database optimization done by the
+ * {@code BackupVersionOptimizationServiceStats} records the statistics for the database optimization done by the
  * {@link BackupVersionOptimizationService} including both successes and failures.
  *
  * <p>OTel uses a single COUNTER with STORE_NAME + OPERATION_OUTCOME dimensions. Tehuti uses
@@ -53,23 +53,20 @@ public class BackupVersionOptimizationServiceStats extends AbstractVeniceStats {
   }
 
   public void recordBackupVersionDatabaseOptimization(String storeName) {
-    getOrCreateSuccessMetric(storeName).record(1, VeniceOperationOutcome.SUCCESS);
+    getOrCreateMetric(successPerStore, storeName, TehutiMetricName.BACKUP_VERSION_DATABASE_OPTIMIZATION)
+        .record(1, VeniceOperationOutcome.SUCCESS);
   }
 
   public void recordBackupVersionDatabaseOptimizationError(String storeName) {
-    getOrCreateErrorMetric(storeName).record(1, VeniceOperationOutcome.FAIL);
+    getOrCreateMetric(errorPerStore, storeName, TehutiMetricName.BACKUP_VERSION_DATA_OPTIMIZATION_ERROR)
+        .record(1, VeniceOperationOutcome.FAIL);
   }
 
-  private MetricEntityStateOneEnum<VeniceOperationOutcome> getOrCreateSuccessMetric(String storeName) {
-    return successPerStore.computeIfAbsent(
-        storeName,
-        k -> createPerStoreMetric(k, TehutiMetricName.BACKUP_VERSION_DATABASE_OPTIMIZATION));
-  }
-
-  private MetricEntityStateOneEnum<VeniceOperationOutcome> getOrCreateErrorMetric(String storeName) {
-    return errorPerStore.computeIfAbsent(
-        storeName,
-        k -> createPerStoreMetric(k, TehutiMetricName.BACKUP_VERSION_DATA_OPTIMIZATION_ERROR));
+  private MetricEntityStateOneEnum<VeniceOperationOutcome> getOrCreateMetric(
+      Map<String, MetricEntityStateOneEnum<VeniceOperationOutcome>> perStoreMap,
+      String storeName,
+      TehutiMetricName tehutiName) {
+    return perStoreMap.computeIfAbsent(storeName, k -> createPerStoreMetric(k, tehutiName));
   }
 
   private MetricEntityStateOneEnum<VeniceOperationOutcome> createPerStoreMetric(

--- a/services/venice-server/src/test/java/com/linkedin/venice/cleaner/BackupVersionOptimizationServiceTest.java
+++ b/services/venice-server/src/test/java/com/linkedin/venice/cleaner/BackupVersionOptimizationServiceTest.java
@@ -276,13 +276,18 @@ public class BackupVersionOptimizationServiceTest {
 
     optimizationService.start();
     try {
-      // Wait until reopen has been attempted on every partition.
+      // Wait until exactly one cycle has run all 4 partition reopens. We stop the service AS PART
+      // of the wait condition so the strict times(4) verify below isn't racing against the next
+      // cycle: the all-partitions-throw path never calls resourceState.recordDatabaseOptimization,
+      // so whetherToOptimize stays true and a short scheduleIntervalSeconds would let the cycle
+      // re-fire and inflate the recorded counts.
       TestUtils.waitForNonDeterministicAssertion(10, TimeUnit.SECONDS, () -> {
         verify(backupEngine).reopenStoragePartition(0);
         verify(backupEngine).reopenStoragePartition(1);
         verify(backupEngine).reopenStoragePartition(2);
         verify(backupEngine).reopenStoragePartition(3);
       });
+      optimizationService.stop();
 
       // Per-partition error recording: 4 partitions all fail → 4 error calls (NOT 1 per store).
       verify(stats, times(4)).recordBackupVersionDatabaseOptimizationError(storeName);

--- a/services/venice-server/src/test/java/com/linkedin/venice/cleaner/BackupVersionOptimizationServiceTest.java
+++ b/services/venice-server/src/test/java/com/linkedin/venice/cleaner/BackupVersionOptimizationServiceTest.java
@@ -5,6 +5,7 @@ import static com.linkedin.venice.meta.VersionStatus.STARTED;
 import static org.mockito.Mockito.after;
 import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
@@ -211,6 +212,82 @@ public class BackupVersionOptimizationServiceTest {
           () -> verify(backupStorageEngine, times(2)).reopenStoragePartition(PARTITION_ID_0));
 
       verify(newStorageEngine, never()).reopenStoragePartition(PARTITION_ID_0);
+    } finally {
+      optimizationService.stop();
+    }
+  }
+
+  /**
+   * Pins per-partition error scaling: N partition failures must produce N
+   * {@code recordBackupVersionDatabaseOptimizationError} calls. Catches a regression that hoists
+   * the error-recording out of the partition loop (pre-PR behavior) — that would silently scale
+   * the error counter at 1 per store-cycle instead of 1 per failing partition.
+   */
+  @Test
+  public void testPerPartitionErrorRecordingScalesWithFailingPartitions() throws Exception {
+    String storeName = Utils.getUniqueString();
+    int backupVersion = 1;
+    int currentVersion = 2;
+    String backupResourceName = Version.composeKafkaTopic(storeName, backupVersion);
+
+    // Build a store with 4 partitions on the backup version, ALL of which throw on reopen.
+    Set<Integer> partitionIds = new HashSet<>();
+    partitionIds.add(0);
+    partitionIds.add(1);
+    partitionIds.add(2);
+    partitionIds.add(3);
+
+    StorageEngineRepository storageEngineRepository = mock(StorageEngineRepository.class);
+    StorageEngine backupEngine = mock(StorageEngine.class);
+    doReturn(backupResourceName).when(backupEngine).getStoreVersionName();
+    doReturn(partitionIds).when(backupEngine).getPartitionIds();
+    doThrow(new RuntimeException("simulated reopen failure")).when(backupEngine).reopenStoragePartition(0);
+    doThrow(new RuntimeException("simulated reopen failure")).when(backupEngine).reopenStoragePartition(1);
+    doThrow(new RuntimeException("simulated reopen failure")).when(backupEngine).reopenStoragePartition(2);
+    doThrow(new RuntimeException("simulated reopen failure")).when(backupEngine).reopenStoragePartition(3);
+
+    // Current-version engine: real but empty (won't be optimized; only the backup is read-active).
+    String currentResourceName = Version.composeKafkaTopic(storeName, currentVersion);
+    StorageEngine currentEngine = mock(StorageEngine.class);
+    doReturn(currentResourceName).when(currentEngine).getStoreVersionName();
+    doReturn(new HashSet<Integer>()).when(currentEngine).getPartitionIds();
+
+    List<StorageEngine> engineList = new ArrayList<>();
+    engineList.add(backupEngine);
+    engineList.add(currentEngine);
+    doReturn(engineList).when(storageEngineRepository).getAllLocalStorageEngines();
+    doReturn(backupEngine).when(storageEngineRepository).getLocalStorageEngine(backupResourceName);
+    doReturn(currentEngine).when(storageEngineRepository).getLocalStorageEngine(currentResourceName);
+
+    Map<Integer, VersionStatus> versionStatusMap = new HashMap<>();
+    versionStatusMap.put(backupVersion, ONLINE);
+    versionStatusMap.put(currentVersion, ONLINE);
+    ReadOnlyStoreRepository storeRepository = mockStoreRepository(storeName, currentVersion, versionStatusMap);
+
+    BackupVersionOptimizationServiceStats stats = mock(BackupVersionOptimizationServiceStats.class);
+    BackupVersionOptimizationService optimizationService = new BackupVersionOptimizationService(
+        storeRepository,
+        storageEngineRepository,
+        NO_READ_THRESHOLD_MS_FOR_DATABASE_OPTIMIZATION,
+        1,
+        stats,
+        LogContext.forTests(VeniceComponent.SERVER.name()));
+    optimizationService.recordReadUsage(backupResourceName);
+
+    optimizationService.start();
+    try {
+      // Wait until reopen has been attempted on every partition.
+      TestUtils.waitForNonDeterministicAssertion(10, TimeUnit.SECONDS, () -> {
+        verify(backupEngine).reopenStoragePartition(0);
+        verify(backupEngine).reopenStoragePartition(1);
+        verify(backupEngine).reopenStoragePartition(2);
+        verify(backupEngine).reopenStoragePartition(3);
+      });
+
+      // Per-partition error recording: 4 partitions all fail → 4 error calls (NOT 1 per store).
+      verify(stats, times(4)).recordBackupVersionDatabaseOptimizationError(storeName);
+      // No success recordings since every partition threw.
+      verify(stats, never()).recordBackupVersionDatabaseOptimization(storeName);
     } finally {
       optimizationService.stop();
     }

--- a/services/venice-server/src/test/java/com/linkedin/venice/stats/BackupVersionOptimizationServiceStatsTest.java
+++ b/services/venice-server/src/test/java/com/linkedin/venice/stats/BackupVersionOptimizationServiceStatsTest.java
@@ -1,0 +1,163 @@
+package com.linkedin.venice.stats;
+
+import static com.linkedin.davinci.stats.BackupVersionOptimizationOtelMetricEntity.REOPEN_COUNT;
+import static com.linkedin.davinci.stats.ServerMetricEntity.SERVER_METRIC_ENTITIES;
+import static com.linkedin.venice.stats.dimensions.VeniceMetricsDimensions.VENICE_CLUSTER_NAME;
+import static com.linkedin.venice.stats.dimensions.VeniceMetricsDimensions.VENICE_OPERATION_OUTCOME;
+import static com.linkedin.venice.stats.dimensions.VeniceMetricsDimensions.VENICE_STORE_NAME;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
+
+import com.linkedin.venice.stats.dimensions.VeniceOperationOutcome;
+import com.linkedin.venice.utils.OpenTelemetryDataTestUtils;
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.sdk.testing.exporter.InMemoryMetricReader;
+import io.tehuti.metrics.MetricsRepository;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+
+public class BackupVersionOptimizationServiceStatsTest {
+  private static final String TEST_METRIC_PREFIX = "server";
+  private static final String TEST_CLUSTER_NAME = "test-cluster";
+  private static final String TEST_STORE_NAME = "test-store";
+
+  private InMemoryMetricReader inMemoryMetricReader;
+  private VeniceMetricsRepository metricsRepository;
+  private BackupVersionOptimizationServiceStats stats;
+
+  @BeforeMethod
+  public void setUp() {
+    inMemoryMetricReader = InMemoryMetricReader.create();
+    metricsRepository = new VeniceMetricsRepository(
+        new VeniceMetricsConfig.Builder().setMetricPrefix(TEST_METRIC_PREFIX)
+            .setMetricEntities(SERVER_METRIC_ENTITIES)
+            .setEmitOtelMetrics(true)
+            .setOtelAdditionalMetricsReader(inMemoryMetricReader)
+            .build());
+    stats = new BackupVersionOptimizationServiceStats(
+        metricsRepository,
+        "BackupVersionOptimizationService",
+        TEST_CLUSTER_NAME);
+  }
+
+  @AfterMethod
+  public void tearDown() {
+    if (metricsRepository != null) {
+      metricsRepository.close();
+    }
+  }
+
+  @Test
+  public void testRecordOptimizationSuccess() {
+    stats.recordBackupVersionDatabaseOptimization(TEST_STORE_NAME);
+    stats.recordBackupVersionDatabaseOptimization(TEST_STORE_NAME);
+
+    OpenTelemetryDataTestUtils.validateLongPointDataFromCounter(
+        inMemoryMetricReader,
+        2,
+        buildAttributes(TEST_STORE_NAME, VeniceOperationOutcome.SUCCESS),
+        REOPEN_COUNT.getMetricEntity().getMetricName(),
+        TEST_METRIC_PREFIX);
+  }
+
+  @Test
+  public void testRecordOptimizationError() {
+    stats.recordBackupVersionDatabaseOptimizationError(TEST_STORE_NAME);
+
+    OpenTelemetryDataTestUtils.validateLongPointDataFromCounter(
+        inMemoryMetricReader,
+        1,
+        buildAttributes(TEST_STORE_NAME, VeniceOperationOutcome.FAIL),
+        REOPEN_COUNT.getMetricEntity().getMetricName(),
+        TEST_METRIC_PREFIX);
+  }
+
+  @Test
+  public void testOutcomeDimensionIsolation() {
+    stats.recordBackupVersionDatabaseOptimization(TEST_STORE_NAME);
+    stats.recordBackupVersionDatabaseOptimization(TEST_STORE_NAME);
+    stats.recordBackupVersionDatabaseOptimizationError(TEST_STORE_NAME);
+
+    OpenTelemetryDataTestUtils.validateLongPointDataFromCounter(
+        inMemoryMetricReader,
+        2,
+        buildAttributes(TEST_STORE_NAME, VeniceOperationOutcome.SUCCESS),
+        REOPEN_COUNT.getMetricEntity().getMetricName(),
+        TEST_METRIC_PREFIX);
+
+    OpenTelemetryDataTestUtils.validateLongPointDataFromCounter(
+        inMemoryMetricReader,
+        1,
+        buildAttributes(TEST_STORE_NAME, VeniceOperationOutcome.FAIL),
+        REOPEN_COUNT.getMetricEntity().getMetricName(),
+        TEST_METRIC_PREFIX);
+  }
+
+  @Test
+  public void testMultiStoreIsolation() {
+    String storeA = "store-a";
+    String storeB = "store-b";
+    stats.recordBackupVersionDatabaseOptimization(storeA);
+    stats.recordBackupVersionDatabaseOptimization(storeA);
+    stats.recordBackupVersionDatabaseOptimization(storeB);
+
+    OpenTelemetryDataTestUtils.validateLongPointDataFromCounter(
+        inMemoryMetricReader,
+        2,
+        buildAttributes(storeA, VeniceOperationOutcome.SUCCESS),
+        REOPEN_COUNT.getMetricEntity().getMetricName(),
+        TEST_METRIC_PREFIX);
+
+    OpenTelemetryDataTestUtils.validateLongPointDataFromCounter(
+        inMemoryMetricReader,
+        1,
+        buildAttributes(storeB, VeniceOperationOutcome.SUCCESS),
+        REOPEN_COUNT.getMetricEntity().getMetricName(),
+        TEST_METRIC_PREFIX);
+  }
+
+  @Test
+  public void testTehutiSensorsRegisteredAndRecorded() {
+    String successSensor = ".BackupVersionOptimizationService--backup_version_database_optimization.OccurrenceRate";
+    String errorSensor = ".BackupVersionOptimizationService--backup_version_data_optimization_error.OccurrenceRate";
+
+    // Sensors are registered lazily on first recording (per-store computeIfAbsent)
+    stats.recordBackupVersionDatabaseOptimization(TEST_STORE_NAME);
+    stats.recordBackupVersionDatabaseOptimizationError(TEST_STORE_NAME);
+
+    assertNotNull(metricsRepository.getMetric(successSensor), "optimization sensor should exist after recording");
+    assertNotNull(metricsRepository.getMetric(errorSensor), "optimization error sensor should exist after recording");
+    assertTrue(metricsRepository.getMetric(successSensor).value() > 0, "optimization rate should be > 0");
+    assertTrue(metricsRepository.getMetric(errorSensor).value() > 0, "optimization error rate should be > 0");
+  }
+
+  @Test
+  public void testNoNpeWhenOtelDisabled() {
+    try (VeniceMetricsRepository disabledRepo = new VeniceMetricsRepository(
+        new VeniceMetricsConfig.Builder().setMetricPrefix(TEST_METRIC_PREFIX).setEmitOtelMetrics(false).build())) {
+      exerciseAllRecordingPaths(disabledRepo);
+    }
+  }
+
+  @Test
+  public void testNoNpeWhenPlainMetricsRepository() {
+    exerciseAllRecordingPaths(new MetricsRepository());
+  }
+
+  private void exerciseAllRecordingPaths(MetricsRepository repo) {
+    BackupVersionOptimizationServiceStats safeStats =
+        new BackupVersionOptimizationServiceStats(repo, "BackupVersionOptimizationService", TEST_CLUSTER_NAME);
+    safeStats.recordBackupVersionDatabaseOptimization(TEST_STORE_NAME);
+    safeStats.recordBackupVersionDatabaseOptimizationError(TEST_STORE_NAME);
+  }
+
+  private Attributes buildAttributes(String storeName, VeniceOperationOutcome outcome) {
+    return Attributes.builder()
+        .put(VENICE_CLUSTER_NAME.getDimensionNameInDefaultFormat(), TEST_CLUSTER_NAME)
+        .put(VENICE_STORE_NAME.getDimensionNameInDefaultFormat(), storeName)
+        .put(VENICE_OPERATION_OUTCOME.getDimensionNameInDefaultFormat(), outcome.getDimensionValue())
+        .build();
+  }
+}

--- a/services/venice-server/src/test/java/com/linkedin/venice/stats/BackupVersionOptimizationServiceStatsTest.java
+++ b/services/venice-server/src/test/java/com/linkedin/venice/stats/BackupVersionOptimizationServiceStatsTest.java
@@ -133,7 +133,6 @@ public class BackupVersionOptimizationServiceStatsTest {
     String successSensor = ".BackupVersionOptimizationService--backup_version_database_optimization.OccurrenceRate";
     String errorSensor = ".BackupVersionOptimizationService--backup_version_data_optimization_error.OccurrenceRate";
 
-    // Sensors are registered lazily on first recording (per-store computeIfAbsent)
     stats.recordBackupVersionDatabaseOptimization(TEST_STORE_NAME);
     stats.recordBackupVersionDatabaseOptimizationError(TEST_STORE_NAME);
 
@@ -171,6 +170,44 @@ public class BackupVersionOptimizationServiceStatsTest {
         metricsRepository.getMetric(successSensor).value(),
         successBeforeAdditionalErrors,
         "Success Tehuti sensor should not be incremented by error recordings (two-map split invariant)");
+  }
+
+  /**
+   * Verifies the cluster-name constructor argument actually propagates into the OTel
+   * {@code baseDimensionsMap} (and thus into emitted attributes). The other tests all use the
+   * same {@code TEST_CLUSTER_NAME} for both setup and assertion, which is tautological — a
+   * future bug that hardcoded a wrong cluster name in the dimensions map would still pass them.
+   */
+  @Test
+  public void testClusterNameArgumentPropagatesToOtelAttributes() {
+    String differentCluster = "another-cluster";
+    AsyncGauge.AsyncGaugeExecutor localExecutor = new AsyncGauge.AsyncGaugeExecutor.Builder().build();
+    InMemoryMetricReader localReader = InMemoryMetricReader.create();
+    try (VeniceMetricsRepository localRepo = new VeniceMetricsRepository(
+        new VeniceMetricsConfig.Builder().setMetricPrefix(TEST_METRIC_PREFIX)
+            .setMetricEntities(SERVER_METRIC_ENTITIES)
+            .setEmitOtelMetrics(true)
+            .setOtelAdditionalMetricsReader(localReader)
+            .setTehutiMetricConfig(new MetricConfig(localExecutor))
+            .build())) {
+      BackupVersionOptimizationServiceStats localStats =
+          new BackupVersionOptimizationServiceStats(localRepo, "BackupVersionOptimizationService", differentCluster);
+      localStats.recordBackupVersionDatabaseOptimization(TEST_STORE_NAME);
+
+      Attributes expected = Attributes.builder()
+          .put(VENICE_CLUSTER_NAME.getDimensionNameInDefaultFormat(), differentCluster)
+          .put(VENICE_STORE_NAME.getDimensionNameInDefaultFormat(), TEST_STORE_NAME)
+          .put(
+              VENICE_OPERATION_OUTCOME.getDimensionNameInDefaultFormat(),
+              VeniceOperationOutcome.SUCCESS.getDimensionValue())
+          .build();
+      OpenTelemetryDataTestUtils.validateLongPointDataFromCounter(
+          localReader,
+          1,
+          expected,
+          REOPEN_COUNT.getMetricEntity().getMetricName(),
+          TEST_METRIC_PREFIX);
+    }
   }
 
   @Test

--- a/services/venice-server/src/test/java/com/linkedin/venice/stats/BackupVersionOptimizationServiceStatsTest.java
+++ b/services/venice-server/src/test/java/com/linkedin/venice/stats/BackupVersionOptimizationServiceStatsTest.java
@@ -5,6 +5,7 @@ import static com.linkedin.davinci.stats.ServerMetricEntity.SERVER_METRIC_ENTITI
 import static com.linkedin.venice.stats.dimensions.VeniceMetricsDimensions.VENICE_CLUSTER_NAME;
 import static com.linkedin.venice.stats.dimensions.VeniceMetricsDimensions.VENICE_OPERATION_OUTCOME;
 import static com.linkedin.venice.stats.dimensions.VeniceMetricsDimensions.VENICE_STORE_NAME;
+import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertTrue;
 
@@ -12,7 +13,9 @@ import com.linkedin.venice.stats.dimensions.VeniceOperationOutcome;
 import com.linkedin.venice.utils.OpenTelemetryDataTestUtils;
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.sdk.testing.exporter.InMemoryMetricReader;
+import io.tehuti.metrics.MetricConfig;
 import io.tehuti.metrics.MetricsRepository;
+import io.tehuti.metrics.stats.AsyncGauge;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
@@ -26,15 +29,21 @@ public class BackupVersionOptimizationServiceStatsTest {
   private InMemoryMetricReader inMemoryMetricReader;
   private VeniceMetricsRepository metricsRepository;
   private BackupVersionOptimizationServiceStats stats;
+  // Dedicated executor avoids shutting down Tehuti's static DEFAULT_ASYNC_GAUGE_EXECUTOR singleton when this
+  // repository is closed in tearDown(). Closing the static executor would break AsyncGauge measurements
+  // for any subsequent test running in the same JVM.
+  private AsyncGauge.AsyncGaugeExecutor asyncGaugeExecutor;
 
   @BeforeMethod
   public void setUp() {
     inMemoryMetricReader = InMemoryMetricReader.create();
+    asyncGaugeExecutor = new AsyncGauge.AsyncGaugeExecutor.Builder().build();
     metricsRepository = new VeniceMetricsRepository(
         new VeniceMetricsConfig.Builder().setMetricPrefix(TEST_METRIC_PREFIX)
             .setMetricEntities(SERVER_METRIC_ENTITIES)
             .setEmitOtelMetrics(true)
             .setOtelAdditionalMetricsReader(inMemoryMetricReader)
+            .setTehutiMetricConfig(new MetricConfig(asyncGaugeExecutor))
             .build());
     stats = new BackupVersionOptimizationServiceStats(
         metricsRepository,
@@ -44,6 +53,7 @@ public class BackupVersionOptimizationServiceStatsTest {
 
   @AfterMethod
   public void tearDown() {
+    // Closes only the dedicated executor; the JVM-wide static executor stays alive for other tests.
     if (metricsRepository != null) {
       metricsRepository.close();
     }
@@ -134,9 +144,43 @@ public class BackupVersionOptimizationServiceStatsTest {
   }
 
   @Test
+  public void testTehutiTwoMapSplitNoCrossContamination() {
+    String successSensor = ".BackupVersionOptimizationService--backup_version_database_optimization.OccurrenceRate";
+    String errorSensor = ".BackupVersionOptimizationService--backup_version_data_optimization_error.OccurrenceRate";
+
+    // Register both Tehuti sensors by exercising each path once.
+    stats.recordBackupVersionDatabaseOptimization(TEST_STORE_NAME);
+    stats.recordBackupVersionDatabaseOptimizationError(TEST_STORE_NAME);
+
+    double errorBeforeAdditionalSuccesses = metricsRepository.getMetric(errorSensor).value();
+    // Recording success many times via the success path must not increment the error sensor.
+    for (int i = 0; i < 10; i++) {
+      stats.recordBackupVersionDatabaseOptimization(TEST_STORE_NAME);
+    }
+    assertEquals(
+        metricsRepository.getMetric(errorSensor).value(),
+        errorBeforeAdditionalSuccesses,
+        "Error Tehuti sensor should not be incremented by success recordings (two-map split invariant)");
+
+    // Symmetrically, recording errors must not increment the success sensor.
+    double successBeforeAdditionalErrors = metricsRepository.getMetric(successSensor).value();
+    for (int i = 0; i < 10; i++) {
+      stats.recordBackupVersionDatabaseOptimizationError(TEST_STORE_NAME);
+    }
+    assertEquals(
+        metricsRepository.getMetric(successSensor).value(),
+        successBeforeAdditionalErrors,
+        "Success Tehuti sensor should not be incremented by error recordings (two-map split invariant)");
+  }
+
+  @Test
   public void testNoNpeWhenOtelDisabled() {
+    AsyncGauge.AsyncGaugeExecutor localExecutor = new AsyncGauge.AsyncGaugeExecutor.Builder().build();
     try (VeniceMetricsRepository disabledRepo = new VeniceMetricsRepository(
-        new VeniceMetricsConfig.Builder().setMetricPrefix(TEST_METRIC_PREFIX).setEmitOtelMetrics(false).build())) {
+        new VeniceMetricsConfig.Builder().setMetricPrefix(TEST_METRIC_PREFIX)
+            .setEmitOtelMetrics(false)
+            .setTehutiMetricConfig(new MetricConfig(localExecutor))
+            .build())) {
       exerciseAllRecordingPaths(disabledRepo);
     }
   }

--- a/services/venice-server/src/test/java/com/linkedin/venice/stats/BackupVersionOptimizationServiceStatsTest.java
+++ b/services/venice-server/src/test/java/com/linkedin/venice/stats/BackupVersionOptimizationServiceStatsTest.java
@@ -156,9 +156,13 @@ public class BackupVersionOptimizationServiceStatsTest {
     for (int i = 0; i < 10; i++) {
       stats.recordBackupVersionDatabaseOptimization(TEST_STORE_NAME);
     }
+    // OccurrenceRate is a sliding-window rate; values can drift in the lowest decimals between
+    // reads as the clock advances. Tolerate that drift here — the assertion targets cross-sensor
+    // contamination, not exact rate values.
     assertEquals(
         metricsRepository.getMetric(errorSensor).value(),
         errorBeforeAdditionalSuccesses,
+        1e-3,
         "Error Tehuti sensor should not be incremented by success recordings (two-map split invariant)");
 
     // Symmetrically, recording errors must not increment the success sensor.
@@ -169,6 +173,7 @@ public class BackupVersionOptimizationServiceStatsTest {
     assertEquals(
         metricsRepository.getMetric(successSensor).value(),
         successBeforeAdditionalErrors,
+        1e-3,
         "Success Tehuti sensor should not be incremented by error recordings (two-map split invariant)");
   }
 

--- a/services/venice-server/src/test/java/com/linkedin/venice/stats/BackupVersionOptimizationTehutiMetricNameTest.java
+++ b/services/venice-server/src/test/java/com/linkedin/venice/stats/BackupVersionOptimizationTehutiMetricNameTest.java
@@ -1,0 +1,27 @@
+package com.linkedin.venice.stats;
+
+import com.linkedin.venice.stats.metrics.TehutiMetricNameEnumTestFixture;
+import java.util.HashMap;
+import java.util.Map;
+import org.testng.annotations.Test;
+
+
+public class BackupVersionOptimizationTehutiMetricNameTest {
+  @Test
+  public void testTehutiMetricNames() {
+    new TehutiMetricNameEnumTestFixture<>(
+        BackupVersionOptimizationServiceStats.TehutiMetricName.class,
+        expectedMetricNames()).assertAll();
+  }
+
+  private static Map<BackupVersionOptimizationServiceStats.TehutiMetricName, String> expectedMetricNames() {
+    Map<BackupVersionOptimizationServiceStats.TehutiMetricName, String> map = new HashMap<>();
+    map.put(
+        BackupVersionOptimizationServiceStats.TehutiMetricName.BACKUP_VERSION_DATABASE_OPTIMIZATION,
+        "backup_version_database_optimization");
+    map.put(
+        BackupVersionOptimizationServiceStats.TehutiMetricName.BACKUP_VERSION_DATA_OPTIMIZATION_ERROR,
+        "backup_version_data_optimization_error");
+    return map;
+  }
+}


### PR DESCRIPTION
## Problem Statement

`BackupVersionOptimizationServiceStats` has 2 Tehuti OccurrenceRate sensors for tracking backup version database optimization (success + error) but no OTel counterparts, making these metrics unavailable in OTel-based monitoring dashboards.

## Solution

Add 1 OTel COUNTER metric `version.backup.optimization.reopen_count` with `STORE_NAME` + `OPERATION_OUTCOME` (SUCCESS/FAIL) dimensions using the joint Tehuti+OTel API.

**Design:** Two per-store `VeniceConcurrentHashMap` maps (`successPerStore`, `errorPerStore`) because they bind to different Tehuti sensors (success vs error) while sharing the same OTel instrument differentiated by `VeniceOperationOutcome`. Single `getOrCreateMetric(map, storeName, tehutiName)` helper shared by both maps. Tehuti sensor is registered once (first store) and shared by all subsequent stores via `registerSensorIfAbsent`. When OTel is disabled, `otelRepository` is null and OTel recording is a no-op — the maps still populate for Tehuti.

**Behavioral change 1 (affects both Tehuti and OTel):** Error recording moved from per-store (once after the partition loop when `errored == true`) to per-partition (inside the catch block). This gives finer granularity and matches the success path, which already records per-partition. If 50 of 100 partitions fail, the old code recorded 1 error; the new code records 50. This is intentional — the old per-store granularity made success count (partitions) and error count (stores) an apples-to-oranges comparison.

**Behavioral change 2 (Tehuti registration timing):** Pre-PR the constructor eagerly registered both Tehuti sensors (`backup_version_database_optimization`, `backup_version_data_optimization_error`) at server startup, so `metricsRepository.getMetric(...)` returned a non-null handle from process start. Post-PR these sensors are registered lazily on the first per-store recording (the standard pattern used by every other joint Tehuti+OTel stats class — keeps the per-store maps as the single source of truth). Impact: between server startup and the first backup-version optimization, `getMetric(...)` returns null and the sensor is absent from JMX. Per-scrape consumers (Grafana / InGraphs / dashboards that look up by metric name each poll cycle) are unaffected — once the first event fires, the metric appears and reports normally. Consumers that capture the metric handle at startup and reuse it across a wait loop must move the lookup inside the lambda; the in-tree integration test (`TestBackupVersionDatabaseOptimization`) is updated accordingly.

###  Code changes
- [ ] Added new code behind **a config**.
- [ ] Introduced new **log lines**.
  - [ ] Confirmed if logs need to be **rate limited** to avoid excessive logging.

###  **Concurrency-Specific Checks**
Both reviewer and PR author to verify
- [x] Code has **no race conditions** or **thread safety issues**.
- [x] Proper **synchronization mechanisms** (e.g., `synchronized`, `RWLock`) are used where needed.
- [x] No **blocking calls** inside critical sections that could lead to deadlocks or performance degradation.
- [x] Verified **thread-safe collections** are used (e.g., `ConcurrentHashMap`, `CopyOnWriteArrayList`).
- [x] Validated proper exception handling in multi-threaded code to avoid silent thread termination.

## How was this PR tested?

- [x] New unit tests added.
- [ ] New integration tests added.
- [ ] Modified or extended existing tests.
- [x] Verified backward compatibility (if applicable).

New tests:
- `BackupVersionOptimizationServiceStatsTest` (9 tests): OTel counter accumulation for success/error, outcome dimension isolation, multi-store isolation, Tehuti lazy sensor registration + recording, two-map split no-cross-contamination invariant, cluster-name argument propagation into OTel attributes (catches dimension hardcoding regressions), NPE prevention with OTel disabled and plain MetricsRepository.
- `BackupVersionOptimizationServiceTest.testPerPartitionErrorRecordingScalesWithFailingPartitions`: pins per-partition error scaling — mocks 4 partitions with all `reopenStoragePartition` calls throwing, asserts `recordBackupVersionDatabaseOptimizationError` was called 4 times and `recordBackupVersionDatabaseOptimization` was never called. Catches a regression that hoists the error recording back outside the partition loop.
- `BackupVersionOptimizationOtelMetricEntityTest`: metric entity validation.
- `BackupVersionOptimizationTehutiMetricNameTest`: Tehuti name validation.
- `VeniceOperationOutcomeTest`: dimension value validation (SUCCESS/FAIL).

Modified:
- `TestBackupVersionDatabaseOptimization` (integration test): moved `metricsRepository.getMetric(...)` for the optimization Tehuti sensor inside the `waitForNonDeterministicAssertion` lambda + added an `assertNotNull` guard, since Tehuti sensors are now registered lazily on first per-store recording (see Behavioral change 2).

## Does this PR introduce any user-facing or breaking changes?
- [ ] No. You can skip the rest of this section.
- [x] Yes. Clearly explain the behavior change and its impact.

- The Tehuti `backup_version_data_optimization_error` OccurrenceRate now records per-partition instead of per-store. Dashboards showing error rate will see higher values when multiple partitions fail in the same optimization cycle. This aligns error counting with the existing success counting granularity (already per-partition).
- Tehuti sensors `backup_version_database_optimization` and `backup_version_data_optimization_error` are now registered lazily on first per-store recording rather than eagerly at server startup. Per-scrape monitoring consumers (Grafana / InGraphs) are unaffected. Consumers that capture the Tehuti metric handle once at startup must do the lookup per-scrape (or post-first-event) — the in-tree integration test was updated accordingly.
