### PR TITLE
[vpj] Reduce default job status poll interval from 5 min to 1 min

### DIFF
--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/vpj/VenicePushJobConstants.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/vpj/VenicePushJobConstants.java
@@ -473,7 +473,7 @@ public final class VenicePushJobConstants {
    * Placeholder for version number that is yet to be created.
    */
   public static final int UNCREATED_VERSION_NUMBER = -1;
-  public static final long DEFAULT_POLL_STATUS_INTERVAL_MS = 5 * Time.MS_PER_MINUTE;
+  public static final long DEFAULT_POLL_STATUS_INTERVAL_MS = Time.MS_PER_MINUTE;
 
   /**
    * The default total time we wait before failing a job if the job status stays in UNKNOWN state.


### PR DESCRIPTION
## Summary
- Reduce `DEFAULT_POLL_STATUS_INTERVAL_MS` from 5 minutes to 1 minute
- This eliminates up to 10 minutes of idle waiting per push job (two poll gaps: one after ingestion, one after version swap)
- Especially impactful for heartbeat push jobs, where YARN scheduling delay + poll gaps push total wall clock to ~47 min, causing Airflow task timeouts

## Motivation
Heartbeat hybrid push jobs on the `war` Airflow cluster are hitting Airflow's 47-minute task timeout. Phase-by-phase analysis shows:

| Phase | Duration | % |
|-------|----------|---|
| YARN scheduling delay | ~23 min | 47-51% |
| VPJ init + Spark + data write | ~7 min | 15% |
| Ingestion + buffer replay | ~10 min | 22% |
| **Poll gap waste (idle waiting)** | **~8 min** | **15-22%** |
| Version swap | ~5 min | 11% |

The poll gap waste is entirely avoidable. After ingestion completes, the VPJ sleeps for up to 5 minutes before discovering it. Same after version swap completes.

## Why this is safe
Each poll is a lightweight in-memory lookup on the controller (`OfflinePushStatus` backed by ZK watches, not on-demand ZK reads). Even at 1-minute intervals with 50 concurrent pushes across 7 regions, the load is ~4,200 requests/hour — trivial.

Docker sample configs already use `poll.job.status.interval.ms=1000` (1 second). The property remains overridable per-job for anyone needing a different interval.

## Testing Done
- Verified no tests depend on the 5-minute default value
- Existing test (`VenicePushJobTest`) already overrides to 10ms
- Docker integration tests use 1s interval
- The property is already used in production heartbeat jobs with custom overrides