### PR TITLE
[da-vinci] Add OTel metrics to ParticipantStateTransitionStats

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/helix/AbstractPartitionStateModel.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/helix/AbstractPartitionStateModel.java
@@ -126,7 +126,12 @@ public abstract class AbstractPartitionStateModel extends StateModel {
     try {
       LogContext.setLogContext(storeAndServerConfigs.getLogContext());
       stateTransitionStats.trackStateTransitionStarted(from, to);
-      handler.run();
+      try {
+        handler.run();
+      } catch (Throwable t) {
+        stateTransitionStats.trackStateTransitionFailed(from, to);
+        throw t;
+      }
       stateTransitionStats.trackStateTransitionCompleted(from, to);
       logCompletion(from, to, message, context, rollback);
     } finally {

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/ParticipantStateTransitionOtelMetricEntity.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/ParticipantStateTransitionOtelMetricEntity.java
@@ -1,0 +1,54 @@
+package com.linkedin.davinci.stats;
+
+import static com.linkedin.venice.stats.dimensions.VeniceMetricsDimensions.VENICE_HELIX_FROM_STATE;
+import static com.linkedin.venice.stats.dimensions.VeniceMetricsDimensions.VENICE_HELIX_STATE;
+import static com.linkedin.venice.stats.dimensions.VeniceMetricsDimensions.VENICE_HELIX_TO_STATE;
+import static com.linkedin.venice.stats.dimensions.VeniceMetricsDimensions.VENICE_THREAD_POOL_NAME;
+import static com.linkedin.venice.utils.Utils.setOf;
+
+import com.linkedin.venice.stats.dimensions.VeniceMetricsDimensions;
+import com.linkedin.venice.stats.metrics.MetricEntity;
+import com.linkedin.venice.stats.metrics.MetricType;
+import com.linkedin.venice.stats.metrics.MetricUnit;
+import com.linkedin.venice.stats.metrics.ModuleMetricEntityInterface;
+import java.util.Set;
+
+
+/**
+ * OTel metric entity definitions for {@link ParticipantStateTransitionStats}.
+ * Tracks partition state transition lifecycle and active partition counts per Helix state.
+ */
+public enum ParticipantStateTransitionOtelMetricEntity implements ModuleMetricEntityInterface {
+  BLOCKED_THREAD_COUNT(
+      "partition.state.transition.blocked_thread_count", MetricType.UP_DOWN_COUNTER, MetricUnit.NUMBER,
+      "Number of threads currently blocked on a state transition",
+      setOf(VENICE_THREAD_POOL_NAME, VENICE_HELIX_FROM_STATE, VENICE_HELIX_TO_STATE)
+  ),
+
+  IN_PROGRESS_COUNT(
+      "partition.state.transition.in_progress_count", MetricType.UP_DOWN_COUNTER, MetricUnit.NUMBER,
+      "Number of partitions currently transitioning between Helix states",
+      setOf(VENICE_THREAD_POOL_NAME, VENICE_HELIX_FROM_STATE, VENICE_HELIX_TO_STATE)
+  ),
+
+  STEADY_STATE_COUNT(
+      "partition.state.active_count", MetricType.UP_DOWN_COUNTER, MetricUnit.NUMBER,
+      "Number of partitions currently in a given Helix state", setOf(VENICE_THREAD_POOL_NAME, VENICE_HELIX_STATE)
+  );
+
+  private final MetricEntity metricEntity;
+
+  ParticipantStateTransitionOtelMetricEntity(
+      String metricName,
+      MetricType metricType,
+      MetricUnit unit,
+      String description,
+      Set<VeniceMetricsDimensions> dimensions) {
+    this.metricEntity = new MetricEntity(metricName, metricType, unit, description, dimensions);
+  }
+
+  @Override
+  public MetricEntity getMetricEntity() {
+    return metricEntity;
+  }
+}

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/ParticipantStateTransitionStats.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/ParticipantStateTransitionStats.java
@@ -1,13 +1,23 @@
 package com.linkedin.davinci.stats;
 
+import static com.linkedin.davinci.stats.ParticipantStateTransitionOtelMetricEntity.BLOCKED_THREAD_COUNT;
+import static com.linkedin.davinci.stats.ParticipantStateTransitionOtelMetricEntity.IN_PROGRESS_COUNT;
+import static com.linkedin.davinci.stats.ParticipantStateTransitionOtelMetricEntity.STEADY_STATE_COUNT;
+
 import com.linkedin.venice.helix.HelixState;
+import com.linkedin.venice.stats.OpenTelemetryMetricsSetup;
 import com.linkedin.venice.stats.ThreadPoolStats;
+import com.linkedin.venice.stats.VeniceOpenTelemetryMetricsRepository;
+import com.linkedin.venice.stats.dimensions.VeniceHelixFromState;
+import com.linkedin.venice.stats.dimensions.VeniceHelixSteadyState;
+import com.linkedin.venice.stats.dimensions.VeniceHelixToState;
+import com.linkedin.venice.stats.dimensions.VeniceMetricsDimensions;
+import com.linkedin.venice.stats.metrics.MetricEntityStateOneEnum;
+import com.linkedin.venice.stats.metrics.MetricEntityStateTwoEnums;
+import com.linkedin.venice.utils.Utils;
 import com.linkedin.venice.utils.concurrent.VeniceConcurrentHashMap;
 import io.tehuti.metrics.MetricsRepository;
-import io.tehuti.metrics.Sensor;
 import io.tehuti.metrics.stats.AsyncGauge;
-import java.util.Arrays;
-import java.util.HashSet;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
@@ -16,49 +26,126 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 
 /**
- * This class is used to track the thread pool stats for the state transitions of the participant.
- * Besides the thread pool stats, it also tracks the number of threads that are blocked on the state transition
- * from OFFLINE to DROPPED.
+ * Tracks partition state transition metrics for the Helix participant. Extends {@link ThreadPoolStats}
+ * (which already has OTel for thread pool metrics) and adds:
+ * <ul>
+ *   <li>Blocked thread count per (from, to) state pair (currently only OFFLINE→DROPPED)</li>
+ *   <li>In-progress partition counts per (from, to) state pair</li>
+ *   <li>Active partition counts per Helix state: ERROR, STANDBY, LEADER</li>
+ * </ul>
+ *
+ * <p>All three OTel metrics use UP_DOWN_COUNTER (+1/-1 at call sites). Tehuti uses AsyncGauge
+ * polling AtomicInteger trackers. The AtomicIntegers are Tehuti-only artifacts — they will be
+ * removed when Tehuti is retired.
  */
 public class ParticipantStateTransitionStats extends ThreadPoolStats {
-  private Sensor threadBlockedOnOfflineToDroppedTransitionSensor;
-  private AtomicInteger threadBlockedOnOfflineToDroppedTransitionCount = new AtomicInteger(0);
+  // Tehuti-only: blocked thread count for OFFLINE→DROPPED (AsyncGauge polls this)
+  private final AtomicInteger threadBlockedOnOfflineToDroppedTransitionCount = new AtomicInteger(0);
 
+  /**
+   * OTel: blocked thread count with FROM/TO state dimensions (UP_DOWN_COUNTER, records +1/-1).
+   * Currently only OFFLINE→DROPPED transitions block threads (waiting for ingestion to stop
+   * before dropping a partition). The FROM/TO dimensions allow future transitions to record
+   * blocked threads without changing the metric schema.
+   */
+  private final MetricEntityStateTwoEnums<VeniceHelixFromState, VeniceHelixToState> blockedThreadMetric;
+
+  /** OTel: in-progress transition count with FROM/TO state dimensions (UP_DOWN_COUNTER). */
+  private final MetricEntityStateTwoEnums<VeniceHelixFromState, VeniceHelixToState> inProgressMetric;
+
+  /** OTel: active partition count per Helix state with STATE dimension (UP_DOWN_COUNTER). */
+  private final MetricEntityStateOneEnum<VeniceHelixSteadyState> steadyStateMetric;
+
+  // Tehuti-only: dynamic AtomicInteger trackers polled by AsyncGauge sensors
   private final Map<StateTransition, AtomicInteger> inProgressStateTransitionTrackers = new VeniceConcurrentHashMap<>();
   private final Map<String, AtomicInteger> completedStateTransitionTrackers = new VeniceConcurrentHashMap<>();
-  private static final Set<String> ENABLED_STEADY_STATES =
-      new HashSet<>(Arrays.asList(HelixState.ERROR_STATE, HelixState.STANDBY_STATE, HelixState.LEADER_STATE));
+  static final Set<String> ENABLED_STEADY_STATES =
+      Utils.setOf(HelixState.ERROR_STATE, HelixState.STANDBY_STATE, HelixState.LEADER_STATE);
 
   public ParticipantStateTransitionStats(
       MetricsRepository metricsRepository,
       ThreadPoolExecutor threadPoolExecutor,
       String name) {
     super(metricsRepository, threadPoolExecutor, name);
-    threadBlockedOnOfflineToDroppedTransitionSensor = registerSensor(
+
+    // Tehuti: fixed AsyncGauge for blocked thread count (OFFLINE→DROPPED only)
+    registerSensor(
         new AsyncGauge(
             (ignored, ignored2) -> this.threadBlockedOnOfflineToDroppedTransitionCount.get(),
             "thread_blocked_on_offline_to_dropped_transition"));
+
+    // OTel setup
+    OpenTelemetryMetricsSetup.OpenTelemetryMetricsSetupInfo otelData =
+        OpenTelemetryMetricsSetup.builder(metricsRepository).setThreadPoolName(name).build();
+    VeniceOpenTelemetryMetricsRepository otelRepository = otelData.getOtelRepository();
+    Map<VeniceMetricsDimensions, String> baseDimensionsMap = otelData.getBaseDimensionsMap();
+
+    blockedThreadMetric = MetricEntityStateTwoEnums.create(
+        BLOCKED_THREAD_COUNT.getMetricEntity(),
+        otelRepository,
+        baseDimensionsMap,
+        VeniceHelixFromState.class,
+        VeniceHelixToState.class);
+
+    inProgressMetric = MetricEntityStateTwoEnums.create(
+        IN_PROGRESS_COUNT.getMetricEntity(),
+        otelRepository,
+        baseDimensionsMap,
+        VeniceHelixFromState.class,
+        VeniceHelixToState.class);
+
+    steadyStateMetric = MetricEntityStateOneEnum
+        .create(STEADY_STATE_COUNT.getMetricEntity(), otelRepository, baseDimensionsMap, VeniceHelixSteadyState.class);
   }
 
+  /** Currently only OFFLINE→DROPPED blocks threads; pass different enum values for future transitions. */
   public void incrementThreadBlockedOnOfflineToDroppedTransitionCount() {
     threadBlockedOnOfflineToDroppedTransitionCount.incrementAndGet();
+    blockedThreadMetric.record(1, VeniceHelixFromState.OFFLINE, VeniceHelixToState.DROPPED);
   }
 
+  /** Currently only OFFLINE→DROPPED blocks threads; pass different enum values for future transitions. */
   public void decrementThreadBlockedOnOfflineToDroppedTransitionCount() {
     threadBlockedOnOfflineToDroppedTransitionCount.decrementAndGet();
+    blockedThreadMetric.record(-1, VeniceHelixFromState.OFFLINE, VeniceHelixToState.DROPPED);
   }
 
   public void trackStateTransitionStarted(String fromState, String toState) {
     if (ENABLED_STEADY_STATES.contains(fromState)) {
       getSteadyStateTracker(fromState).decrementAndGet();
+      recordSteadyStateOtel(-1, fromState);
     }
     getInProgressStateTransitionTracker(fromState, toState).incrementAndGet();
+    recordInProgressOtel(1, fromState, toState);
   }
 
   public void trackStateTransitionCompleted(String fromState, String toState) {
     getInProgressStateTransitionTracker(fromState, toState).decrementAndGet();
+    recordInProgressOtel(-1, fromState, toState);
     if (ENABLED_STEADY_STATES.contains(toState)) {
       getSteadyStateTracker(toState).incrementAndGet();
+      recordSteadyStateOtel(1, toState);
+    }
+  }
+
+  private void recordInProgressOtel(long delta, String fromState, String toState) {
+    try {
+      VeniceHelixFromState from = VeniceHelixFromState.valueOf(fromState);
+      VeniceHelixToState to = VeniceHelixToState.valueOf(toState);
+      inProgressMetric.record(delta, from, to);
+    } catch (IllegalArgumentException e) {
+      // Defensive: in practice unreachable because Helix dispatches state transitions via
+      // explicitly named handler methods (e.g., onBecomeStandbyFromOffline). A new Helix state
+      // without a handler would fail before reaching this code. Kept as a safety net.
+    }
+  }
+
+  private void recordSteadyStateOtel(long delta, String state) {
+    try {
+      VeniceHelixSteadyState steadyState = VeniceHelixSteadyState.valueOf(state);
+      steadyStateMetric.record(delta, steadyState);
+    } catch (IllegalArgumentException e) {
+      // Defensive: same reasoning as recordInProgressOtel — unreachable in practice.
     }
   }
 

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/ParticipantStateTransitionStats.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/ParticipantStateTransitionStats.java
@@ -101,13 +101,19 @@ public class ParticipantStateTransitionStats extends ThreadPoolStats {
         .create(STEADY_STATE_COUNT.getMetricEntity(), otelRepository, baseDimensionsMap, VeniceHelixSteadyState.class);
   }
 
-  /** Increments the blocked-thread count for the OFFLINE→DROPPED transition. */
+  /**
+   * Increments the blocked-thread count for the OFFLINE→DROPPED transition. Only call from
+   * OFFLINE→DROPPED transitions — the OTel dimensions are hardcoded to that pair.
+   */
   public void incrementThreadBlockedOnOfflineToDroppedTransitionCount() {
     threadBlockedOnOfflineToDroppedTransitionCount.incrementAndGet();
     blockedThreadMetric.record(1, VeniceHelixFromState.OFFLINE, VeniceHelixToState.DROPPED);
   }
 
-  /** Decrements the blocked-thread count for the OFFLINE→DROPPED transition. */
+  /**
+   * Decrements the blocked-thread count for the OFFLINE→DROPPED transition. Only call from
+   * OFFLINE→DROPPED transitions — the OTel dimensions are hardcoded to that pair.
+   */
   public void decrementThreadBlockedOnOfflineToDroppedTransitionCount() {
     threadBlockedOnOfflineToDroppedTransitionCount.decrementAndGet();
     blockedThreadMetric.record(-1, VeniceHelixFromState.OFFLINE, VeniceHelixToState.DROPPED);
@@ -129,6 +135,19 @@ public class ParticipantStateTransitionStats extends ThreadPoolStats {
       getSteadyStateTracker(toState).incrementAndGet();
       recordSteadyStateOtel(1, toState);
     }
+  }
+
+  /**
+   * Called when a state transition handler throws. Decrements the in-progress counter to avoid
+   * leaking +1 forever for {@code (fromState, toState)}. Steady-state for {@code toState} is NOT
+   * incremented because the partition did not reach {@code toState}; steady-state for
+   * {@code fromState} was already decremented in {@link #trackStateTransitionStarted} and stays
+   * decremented because the partition has left {@code fromState} (Helix typically marks it ERROR
+   * and a follow-up transition will track that).
+   */
+  public void trackStateTransitionFailed(String fromState, String toState) {
+    getInProgressStateTransitionTracker(fromState, toState).decrementAndGet();
+    recordInProgressOtel(-1, fromState, toState);
   }
 
   private void recordInProgressOtel(long delta, String fromState, String toState) {

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/ParticipantStateTransitionStats.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/ParticipantStateTransitionStats.java
@@ -56,6 +56,9 @@ public class ParticipantStateTransitionStats extends ThreadPoolStats {
   /** OTel: active partition count per Helix state with STATE dimension (UP_DOWN_COUNTER). */
   private final MetricEntityStateOneEnum<VeniceHelixSteadyState> steadyStateMetric;
 
+  /** Retained for {@link VeniceOpenTelemetryMetricsRepository#recordFailureMetric} on the otherwise-defensive valueOf catches. */
+  private final VeniceOpenTelemetryMetricsRepository otelRepository;
+
   // Tehuti-only: dynamic AtomicInteger trackers polled by AsyncGauge sensors
   private final Map<StateTransition, AtomicInteger> inProgressStateTransitionTrackers = new VeniceConcurrentHashMap<>();
   private final Map<String, AtomicInteger> completedStateTransitionTrackers = new VeniceConcurrentHashMap<>();
@@ -77,7 +80,7 @@ public class ParticipantStateTransitionStats extends ThreadPoolStats {
     // OTel setup
     OpenTelemetryMetricsSetup.OpenTelemetryMetricsSetupInfo otelData =
         OpenTelemetryMetricsSetup.builder(metricsRepository).setThreadPoolName(name).build();
-    VeniceOpenTelemetryMetricsRepository otelRepository = otelData.getOtelRepository();
+    this.otelRepository = otelData.getOtelRepository();
     Map<VeniceMetricsDimensions, String> baseDimensionsMap = otelData.getBaseDimensionsMap();
 
     blockedThreadMetric = MetricEntityStateTwoEnums.create(
@@ -136,7 +139,12 @@ public class ParticipantStateTransitionStats extends ThreadPoolStats {
     } catch (IllegalArgumentException e) {
       // Defensive: in practice unreachable because Helix dispatches state transitions via
       // explicitly named handler methods (e.g., onBecomeStandbyFromOffline). A new Helix state
-      // without a handler would fail before reaching this code. Kept as a safety net.
+      // without a handler would fail before reaching this code. Surface via the internal
+      // metric_record_failure counter (rate-limited log) so the case is diagnosable if it ever
+      // does happen.
+      if (otelRepository != null) {
+        otelRepository.recordFailureMetric(IN_PROGRESS_COUNT.getMetricEntity(), e);
+      }
     }
   }
 
@@ -145,7 +153,11 @@ public class ParticipantStateTransitionStats extends ThreadPoolStats {
       VeniceHelixSteadyState steadyState = VeniceHelixSteadyState.valueOf(state);
       steadyStateMetric.record(delta, steadyState);
     } catch (IllegalArgumentException e) {
-      // Defensive: same reasoning as recordInProgressOtel — unreachable in practice.
+      // Defensive: same reasoning as recordInProgressOtel — unreachable in practice. Surface via
+      // the internal metric_record_failure counter (rate-limited log) so the case is diagnosable.
+      if (otelRepository != null) {
+        otelRepository.recordFailureMetric(STEADY_STATE_COUNT.getMetricEntity(), e);
+      }
     }
   }
 

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/ParticipantStateTransitionStats.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/ParticipantStateTransitionStats.java
@@ -98,13 +98,13 @@ public class ParticipantStateTransitionStats extends ThreadPoolStats {
         .create(STEADY_STATE_COUNT.getMetricEntity(), otelRepository, baseDimensionsMap, VeniceHelixSteadyState.class);
   }
 
-  /** Currently only OFFLINE→DROPPED blocks threads; pass different enum values for future transitions. */
+  /** Increments the blocked-thread count for the OFFLINE→DROPPED transition. */
   public void incrementThreadBlockedOnOfflineToDroppedTransitionCount() {
     threadBlockedOnOfflineToDroppedTransitionCount.incrementAndGet();
     blockedThreadMetric.record(1, VeniceHelixFromState.OFFLINE, VeniceHelixToState.DROPPED);
   }
 
-  /** Currently only OFFLINE→DROPPED blocks threads; pass different enum values for future transitions. */
+  /** Decrements the blocked-thread count for the OFFLINE→DROPPED transition. */
   public void decrementThreadBlockedOnOfflineToDroppedTransitionCount() {
     threadBlockedOnOfflineToDroppedTransitionCount.decrementAndGet();
     blockedThreadMetric.record(-1, VeniceHelixFromState.OFFLINE, VeniceHelixToState.DROPPED);

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/ServerMetricEntity.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/ServerMetricEntity.java
@@ -43,7 +43,8 @@ public final class ServerMetricEntity {
         ServerReadQuotaOtelMetricEntity.class,
         ServerConnectionOtelMetricEntity.class,
         StoreBufferServiceOtelMetricEntity.class,
-        StorageEngineOtelMetricEntity.class);
+        StorageEngineOtelMetricEntity.class,
+        ParticipantStateTransitionOtelMetricEntity.class);
   }
 
   public static final Collection<MetricEntity> SERVER_METRIC_ENTITIES =

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/ServerMetricEntity.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/ServerMetricEntity.java
@@ -44,7 +44,8 @@ public final class ServerMetricEntity {
         ServerConnectionOtelMetricEntity.class,
         StoreBufferServiceOtelMetricEntity.class,
         StorageEngineOtelMetricEntity.class,
-        DiskHealthOtelMetricEntity.class);
+        DiskHealthOtelMetricEntity.class,
+        ParticipantStateTransitionOtelMetricEntity.class);
   }
 
   public static final Collection<MetricEntity> SERVER_METRIC_ENTITIES =

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/helix/LeaderFollowerPartitionStateModelTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/helix/LeaderFollowerPartitionStateModelTest.java
@@ -9,6 +9,7 @@ import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
@@ -20,6 +21,7 @@ import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.fail;
 
 import com.linkedin.davinci.config.VeniceServerConfig;
 import com.linkedin.davinci.config.VeniceStoreVersionConfig;
@@ -202,6 +204,36 @@ public class LeaderFollowerPartitionStateModelTest {
     leaderFollowerPartitionStateModelSpy.onBecomeDroppedFromOffline(message, context);
     verify(stateTransitionStats).trackStateTransitionStarted(OFFLINE_STATE, DROPPED_STATE);
     verify(stateTransitionStats).trackStateTransitionCompleted(OFFLINE_STATE, DROPPED_STATE);
+  }
+
+  /**
+   * When the transition handler throws, {@code executeStateTransition} must call
+   * {@link ParticipantStateTransitionStats#trackStateTransitionFailed} (not
+   * {@link ParticipantStateTransitionStats#trackStateTransitionCompleted}) so the in-progress
+   * counter does not leak +1, and the exception must still propagate.
+   */
+  @Test
+  public void testStateTransitionFailureRecordedOnHandlerException() {
+    Message message = mock(Message.class);
+    NotificationContext context = mock(NotificationContext.class);
+    when(message.getResourceName()).thenReturn(resourceName);
+    doReturn(STANDBY_STATE).when(message).getFromState();
+    doReturn(LEADER_STATE).when(message).getToState();
+
+    // The STANDBY->LEADER handler invokes promoteToLeader; force it to throw.
+    doThrow(new RuntimeException("simulated handler failure")).when(storeIngestionService)
+        .promoteToLeader(any(), anyInt(), any());
+
+    try {
+      leaderFollowerPartitionStateModel.onBecomeLeaderFromStandby(message, context);
+      fail("Expected handler exception to propagate");
+    } catch (RuntimeException expected) {
+      assertEquals(expected.getMessage(), "simulated handler failure");
+    }
+
+    verify(stateTransitionStats).trackStateTransitionStarted(STANDBY_STATE, LEADER_STATE);
+    verify(stateTransitionStats).trackStateTransitionFailed(STANDBY_STATE, LEADER_STATE);
+    verify(stateTransitionStats, never()).trackStateTransitionCompleted(STANDBY_STATE, LEADER_STATE);
   }
 
   /**

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/stats/ParticipantStateTransitionOtelMetricEntityTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/stats/ParticipantStateTransitionOtelMetricEntityTest.java
@@ -1,0 +1,56 @@
+package com.linkedin.davinci.stats;
+
+import static com.linkedin.davinci.stats.ParticipantStateTransitionOtelMetricEntity.BLOCKED_THREAD_COUNT;
+import static com.linkedin.davinci.stats.ParticipantStateTransitionOtelMetricEntity.IN_PROGRESS_COUNT;
+import static com.linkedin.davinci.stats.ParticipantStateTransitionOtelMetricEntity.STEADY_STATE_COUNT;
+import static com.linkedin.venice.stats.dimensions.VeniceMetricsDimensions.VENICE_HELIX_FROM_STATE;
+import static com.linkedin.venice.stats.dimensions.VeniceMetricsDimensions.VENICE_HELIX_STATE;
+import static com.linkedin.venice.stats.dimensions.VeniceMetricsDimensions.VENICE_HELIX_TO_STATE;
+import static com.linkedin.venice.stats.dimensions.VeniceMetricsDimensions.VENICE_THREAD_POOL_NAME;
+import static com.linkedin.venice.utils.Utils.setOf;
+
+import com.linkedin.venice.stats.metrics.MetricType;
+import com.linkedin.venice.stats.metrics.MetricUnit;
+import com.linkedin.venice.stats.metrics.ModuleMetricEntityTestFixture;
+import com.linkedin.venice.stats.metrics.ModuleMetricEntityTestFixture.MetricEntityExpectation;
+import java.util.HashMap;
+import java.util.Map;
+import org.testng.annotations.Test;
+
+
+public class ParticipantStateTransitionOtelMetricEntityTest {
+  @Test
+  public void testMetricEntities() {
+    new ModuleMetricEntityTestFixture<>(ParticipantStateTransitionOtelMetricEntity.class, expectedDefinitions())
+        .assertAll();
+  }
+
+  private static Map<ParticipantStateTransitionOtelMetricEntity, MetricEntityExpectation> expectedDefinitions() {
+    Map<ParticipantStateTransitionOtelMetricEntity, MetricEntityExpectation> map = new HashMap<>();
+    map.put(
+        BLOCKED_THREAD_COUNT,
+        new MetricEntityExpectation(
+            "partition.state.transition.blocked_thread_count",
+            MetricType.UP_DOWN_COUNTER,
+            MetricUnit.NUMBER,
+            "Number of threads currently blocked on a state transition",
+            setOf(VENICE_THREAD_POOL_NAME, VENICE_HELIX_FROM_STATE, VENICE_HELIX_TO_STATE)));
+    map.put(
+        IN_PROGRESS_COUNT,
+        new MetricEntityExpectation(
+            "partition.state.transition.in_progress_count",
+            MetricType.UP_DOWN_COUNTER,
+            MetricUnit.NUMBER,
+            "Number of partitions currently transitioning between Helix states",
+            setOf(VENICE_THREAD_POOL_NAME, VENICE_HELIX_FROM_STATE, VENICE_HELIX_TO_STATE)));
+    map.put(
+        STEADY_STATE_COUNT,
+        new MetricEntityExpectation(
+            "partition.state.active_count",
+            MetricType.UP_DOWN_COUNTER,
+            MetricUnit.NUMBER,
+            "Number of partitions currently in a given Helix state",
+            setOf(VENICE_THREAD_POOL_NAME, VENICE_HELIX_STATE)));
+    return map;
+  }
+}

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/stats/ParticipantStateTransitionStatsOtelTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/stats/ParticipantStateTransitionStatsOtelTest.java
@@ -1,0 +1,202 @@
+package com.linkedin.davinci.stats;
+
+import static com.linkedin.davinci.stats.ParticipantStateTransitionOtelMetricEntity.BLOCKED_THREAD_COUNT;
+import static com.linkedin.davinci.stats.ParticipantStateTransitionOtelMetricEntity.IN_PROGRESS_COUNT;
+import static com.linkedin.davinci.stats.ParticipantStateTransitionOtelMetricEntity.STEADY_STATE_COUNT;
+import static com.linkedin.davinci.stats.ServerMetricEntity.SERVER_METRIC_ENTITIES;
+import static com.linkedin.venice.helix.HelixState.DROPPED_STATE;
+import static com.linkedin.venice.helix.HelixState.ERROR_STATE;
+import static com.linkedin.venice.helix.HelixState.LEADER_STATE;
+import static com.linkedin.venice.helix.HelixState.OFFLINE_STATE;
+import static com.linkedin.venice.helix.HelixState.STANDBY_STATE;
+import static com.linkedin.venice.stats.dimensions.VeniceMetricsDimensions.VENICE_HELIX_FROM_STATE;
+import static com.linkedin.venice.stats.dimensions.VeniceMetricsDimensions.VENICE_HELIX_STATE;
+import static com.linkedin.venice.stats.dimensions.VeniceMetricsDimensions.VENICE_HELIX_TO_STATE;
+import static com.linkedin.venice.stats.dimensions.VeniceMetricsDimensions.VENICE_THREAD_POOL_NAME;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+
+import com.linkedin.venice.stats.VeniceMetricsConfig;
+import com.linkedin.venice.stats.VeniceMetricsRepository;
+import com.linkedin.venice.stats.dimensions.VeniceHelixSteadyState;
+import com.linkedin.venice.utils.OpenTelemetryDataTestUtils;
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.sdk.testing.exporter.InMemoryMetricReader;
+import io.tehuti.metrics.MetricsRepository;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+
+public class ParticipantStateTransitionStatsOtelTest {
+  private static final String TEST_METRIC_PREFIX = "server";
+  private static final String TEST_POOL_NAME = "test_pool";
+
+  private InMemoryMetricReader inMemoryMetricReader;
+  private VeniceMetricsRepository metricsRepository;
+  private ParticipantStateTransitionStats stats;
+  private ThreadPoolExecutor executor;
+
+  @BeforeMethod
+  public void setUp() {
+    inMemoryMetricReader = InMemoryMetricReader.create();
+    metricsRepository = new VeniceMetricsRepository(
+        new VeniceMetricsConfig.Builder().setMetricPrefix(TEST_METRIC_PREFIX)
+            .setMetricEntities(SERVER_METRIC_ENTITIES)
+            .setEmitOtelMetrics(true)
+            .setOtelAdditionalMetricsReader(inMemoryMetricReader)
+            .build());
+    executor = new ThreadPoolExecutor(1, 1, 0L, TimeUnit.MILLISECONDS, new LinkedBlockingQueue<>());
+    stats = new ParticipantStateTransitionStats(metricsRepository, executor, TEST_POOL_NAME);
+  }
+
+  @AfterMethod
+  public void tearDown() {
+    if (metricsRepository != null) {
+      metricsRepository.close();
+    }
+    if (executor != null) {
+      executor.shutdownNow();
+    }
+  }
+
+  @Test
+  public void testBlockedThreadCount() {
+    stats.incrementThreadBlockedOnOfflineToDroppedTransitionCount();
+    stats.incrementThreadBlockedOnOfflineToDroppedTransitionCount();
+    stats.decrementThreadBlockedOnOfflineToDroppedTransitionCount();
+
+    // UP_DOWN_COUNTER: cumulative value = +1 +1 -1 = 1
+    OpenTelemetryDataTestUtils.validateLongPointDataFromCounter(
+        inMemoryMetricReader,
+        1,
+        buildTransitionAttributes(OFFLINE_STATE, DROPPED_STATE),
+        BLOCKED_THREAD_COUNT.getMetricEntity().getMetricName(),
+        TEST_METRIC_PREFIX);
+  }
+
+  @Test
+  public void testInProgressTransitionCount() {
+    stats.trackStateTransitionStarted(OFFLINE_STATE, STANDBY_STATE);
+    stats.trackStateTransitionStarted(OFFLINE_STATE, STANDBY_STATE);
+
+    // UP_DOWN_COUNTER: 2 starts = +2
+    OpenTelemetryDataTestUtils.validateLongPointDataFromCounter(
+        inMemoryMetricReader,
+        2,
+        buildTransitionAttributes(OFFLINE_STATE, STANDBY_STATE),
+        IN_PROGRESS_COUNT.getMetricEntity().getMetricName(),
+        TEST_METRIC_PREFIX);
+
+    stats.trackStateTransitionCompleted(OFFLINE_STATE, STANDBY_STATE);
+
+    // UP_DOWN_COUNTER: +2 -1 = 1
+    OpenTelemetryDataTestUtils.validateLongPointDataFromCounter(
+        inMemoryMetricReader,
+        1,
+        buildTransitionAttributes(OFFLINE_STATE, STANDBY_STATE),
+        IN_PROGRESS_COUNT.getMetricEntity().getMetricName(),
+        TEST_METRIC_PREFIX);
+  }
+
+  @Test
+  public void testSteadyStateCount() {
+    // Complete a transition to STANDBY — steady state count should increment
+    stats.trackStateTransitionStarted(OFFLINE_STATE, STANDBY_STATE);
+    stats.trackStateTransitionCompleted(OFFLINE_STATE, STANDBY_STATE);
+
+    // UP_DOWN_COUNTER: +1 for STANDBY
+    OpenTelemetryDataTestUtils.validateLongPointDataFromCounter(
+        inMemoryMetricReader,
+        1,
+        buildSteadyStateAttributes(STANDBY_STATE),
+        STEADY_STATE_COUNT.getMetricEntity().getMetricName(),
+        TEST_METRIC_PREFIX);
+
+    // Start transition from STANDBY to LEADER — STANDBY count decrements
+    stats.trackStateTransitionStarted(STANDBY_STATE, LEADER_STATE);
+    stats.trackStateTransitionCompleted(STANDBY_STATE, LEADER_STATE);
+
+    // UP_DOWN_COUNTER: STANDBY = +1 -1 = 0, LEADER = +1
+    OpenTelemetryDataTestUtils.validateLongPointDataFromCounter(
+        inMemoryMetricReader,
+        0,
+        buildSteadyStateAttributes(STANDBY_STATE),
+        STEADY_STATE_COUNT.getMetricEntity().getMetricName(),
+        TEST_METRIC_PREFIX);
+
+    OpenTelemetryDataTestUtils.validateLongPointDataFromCounter(
+        inMemoryMetricReader,
+        1,
+        buildSteadyStateAttributes(LEADER_STATE),
+        STEADY_STATE_COUNT.getMetricEntity().getMetricName(),
+        TEST_METRIC_PREFIX);
+  }
+
+  @Test
+  public void testErrorSteadyStateCount() {
+    stats.trackStateTransitionStarted(OFFLINE_STATE, ERROR_STATE);
+    stats.trackStateTransitionCompleted(OFFLINE_STATE, ERROR_STATE);
+
+    OpenTelemetryDataTestUtils.validateLongPointDataFromCounter(
+        inMemoryMetricReader,
+        1,
+        buildSteadyStateAttributes(ERROR_STATE),
+        STEADY_STATE_COUNT.getMetricEntity().getMetricName(),
+        TEST_METRIC_PREFIX);
+  }
+
+  @Test
+  public void testVeniceHelixSteadyStateEnumMatchesEnabledSteadyStates() {
+    // Guard: if someone adds/removes a state from ENABLED_STEADY_STATES, VeniceHelixSteadyState must be updated
+    assertEquals(
+        VeniceHelixSteadyState.values().length,
+        ParticipantStateTransitionStats.ENABLED_STEADY_STATES.size(),
+        "VeniceHelixSteadyState enum values must match ENABLED_STEADY_STATES. "
+            + "Update VeniceHelixSteadyState when changing ENABLED_STEADY_STATES.");
+    for (VeniceHelixSteadyState state: VeniceHelixSteadyState.values()) {
+      assertTrue(
+          ParticipantStateTransitionStats.ENABLED_STEADY_STATES.contains(state.name()),
+          "VeniceHelixSteadyState." + state.name() + " is not in ENABLED_STEADY_STATES");
+    }
+  }
+
+  @Test
+  public void testNoNpeWhenOtelDisabled() {
+    try (VeniceMetricsRepository disabledRepo = new VeniceMetricsRepository(
+        new VeniceMetricsConfig.Builder().setMetricPrefix(TEST_METRIC_PREFIX).setEmitOtelMetrics(false).build())) {
+      exerciseAllRecordingPaths(disabledRepo);
+    }
+  }
+
+  @Test
+  public void testNoNpeWhenPlainMetricsRepository() {
+    exerciseAllRecordingPaths(new MetricsRepository());
+  }
+
+  private void exerciseAllRecordingPaths(MetricsRepository repo) {
+    ParticipantStateTransitionStats safeStats = new ParticipantStateTransitionStats(repo, executor, TEST_POOL_NAME);
+    safeStats.incrementThreadBlockedOnOfflineToDroppedTransitionCount();
+    safeStats.decrementThreadBlockedOnOfflineToDroppedTransitionCount();
+    safeStats.trackStateTransitionStarted(OFFLINE_STATE, STANDBY_STATE);
+    safeStats.trackStateTransitionCompleted(OFFLINE_STATE, STANDBY_STATE);
+  }
+
+  private static Attributes buildTransitionAttributes(String fromState, String toState) {
+    return Attributes.builder()
+        .put(VENICE_THREAD_POOL_NAME.getDimensionNameInDefaultFormat(), TEST_POOL_NAME)
+        .put(VENICE_HELIX_FROM_STATE.getDimensionNameInDefaultFormat(), fromState.toLowerCase())
+        .put(VENICE_HELIX_TO_STATE.getDimensionNameInDefaultFormat(), toState.toLowerCase())
+        .build();
+  }
+
+  private static Attributes buildSteadyStateAttributes(String state) {
+    return Attributes.builder()
+        .put(VENICE_THREAD_POOL_NAME.getDimensionNameInDefaultFormat(), TEST_POOL_NAME)
+        .put(VENICE_HELIX_STATE.getDimensionNameInDefaultFormat(), state.toLowerCase())
+        .build();
+  }
+}

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/stats/ParticipantStateTransitionStatsOtelTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/stats/ParticipantStateTransitionStatsOtelTest.java
@@ -20,11 +20,15 @@ import com.linkedin.venice.stats.VeniceMetricsConfig;
 import com.linkedin.venice.stats.VeniceMetricsRepository;
 import com.linkedin.venice.stats.dimensions.VeniceHelixSteadyState;
 import com.linkedin.venice.utils.OpenTelemetryDataTestUtils;
+import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.sdk.metrics.data.LongPointData;
+import io.opentelemetry.sdk.metrics.data.MetricData;
 import io.opentelemetry.sdk.testing.exporter.InMemoryMetricReader;
 import io.tehuti.metrics.MetricConfig;
 import io.tehuti.metrics.MetricsRepository;
 import io.tehuti.metrics.stats.AsyncGauge;
+import java.util.Collection;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
@@ -126,8 +130,24 @@ public class ParticipantStateTransitionStatsOtelTest {
         STEADY_STATE_COUNT.getMetricEntity().getMetricName(),
         TEST_METRIC_PREFIX);
 
-    // Start transition from STANDBY to LEADER — STANDBY count decrements
+    // Start transition from STANDBY to LEADER — STANDBY count must decrement on started(), not completed()
     stats.trackStateTransitionStarted(STANDBY_STATE, LEADER_STATE);
+
+    // Mid-transition: pin the ordering contract — STANDBY decrement fires on started(), and LEADER
+    // is not yet present in the OTel snapshot (that happens on completed()). A regression that
+    // moved either side would fail here.
+    OpenTelemetryDataTestUtils.validateLongPointDataFromCounter(
+        inMemoryMetricReader,
+        0,
+        buildSteadyStateAttributes(STANDBY_STATE),
+        STEADY_STATE_COUNT.getMetricEntity().getMetricName(),
+        TEST_METRIC_PREFIX);
+    OpenTelemetryDataTestUtils.assertNoLongSumDataForAttributes(
+        inMemoryMetricReader.collectAllMetrics(),
+        STEADY_STATE_COUNT.getMetricEntity().getMetricName(),
+        TEST_METRIC_PREFIX,
+        buildSteadyStateAttributes(LEADER_STATE));
+
     stats.trackStateTransitionCompleted(STANDBY_STATE, LEADER_STATE);
 
     // UP_DOWN_COUNTER: STANDBY = +1 -1 = 0, LEADER = +1
@@ -172,6 +192,33 @@ public class ParticipantStateTransitionStatsOtelTest {
           ParticipantStateTransitionStats.ENABLED_STEADY_STATES.contains(state.name()),
           "VeniceHelixSteadyState." + state.name() + " is not in ENABLED_STEADY_STATES");
     }
+  }
+
+  /**
+   * Pins the contract for the defensive {@code catch (IllegalArgumentException)} in
+   * {@code recordInProgressOtel}: when an unknown Helix state string reaches it (e.g. a future
+   * state added without updating {@link com.linkedin.venice.stats.dimensions.VeniceHelixFromState}/
+   * {@code ToState}), the failure is surfaced via the internal {@code metric_record_failure}
+   * counter tagged with the failing metric name, instead of silently dropped.
+   */
+  @Test
+  public void testInvalidStateIncrementsMetricRecordFailure() {
+    String bogusFrom = "BOGUS_FROM";
+    String bogusTo = "BOGUS_TO";
+
+    // Public API path: trackStateTransitionStarted -> recordInProgressOtel -> valueOf throws.
+    // bogusFrom is not in ENABLED_STEADY_STATES, so recordSteadyStateOtel is not called here.
+    stats.trackStateTransitionStarted(bogusFrom, bogusTo);
+    stats.trackStateTransitionStarted(bogusFrom, bogusTo);
+
+    Collection<MetricData> metricsData = inMemoryMetricReader.collectAllMetrics();
+    LongPointData failurePoint = OpenTelemetryDataTestUtils.getLongPointDataFromSum(
+        metricsData,
+        "metric_record_failure",
+        "internal",
+        Attributes
+            .of(AttributeKey.stringKey("venice.metric.name"), IN_PROGRESS_COUNT.getMetricEntity().getMetricName()));
+    assertEquals(failurePoint.getValue(), 2, "metric_record_failure should accumulate per invalid recording");
   }
 
   @Test

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/stats/ParticipantStateTransitionStatsOtelTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/stats/ParticipantStateTransitionStatsOtelTest.java
@@ -244,6 +244,12 @@ public class ParticipantStateTransitionStatsOtelTest {
     safeStats.decrementThreadBlockedOnOfflineToDroppedTransitionCount();
     safeStats.trackStateTransitionStarted(OFFLINE_STATE, STANDBY_STATE);
     safeStats.trackStateTransitionCompleted(OFFLINE_STATE, STANDBY_STATE);
+    safeStats.trackStateTransitionFailed(OFFLINE_STATE, STANDBY_STATE);
+    // Also exercise the defensive catches in recordInProgressOtel/recordSteadyStateOtel with a
+    // null otelRepository: when OTel is disabled (or with a plain MetricsRepository),
+    // otelRepository is null, and the catch block must skip the failure-counter call without NPE.
+    safeStats.trackStateTransitionStarted("BOGUS_FROM", "BOGUS_TO");
+    safeStats.trackStateTransitionCompleted("BOGUS_FROM", "BOGUS_TO");
   }
 
   private static Attributes buildTransitionAttributes(String fromState, String toState) {

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/stats/ParticipantStateTransitionStatsOtelTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/stats/ParticipantStateTransitionStatsOtelTest.java
@@ -22,7 +22,9 @@ import com.linkedin.venice.stats.dimensions.VeniceHelixSteadyState;
 import com.linkedin.venice.utils.OpenTelemetryDataTestUtils;
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.sdk.testing.exporter.InMemoryMetricReader;
+import io.tehuti.metrics.MetricConfig;
 import io.tehuti.metrics.MetricsRepository;
+import io.tehuti.metrics.stats.AsyncGauge;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
@@ -37,17 +39,23 @@ public class ParticipantStateTransitionStatsOtelTest {
 
   private InMemoryMetricReader inMemoryMetricReader;
   private VeniceMetricsRepository metricsRepository;
+  // Dedicated AsyncGauge executor: another test class calling MetricsRepository.close()
+  // in the same JVM shuts down the static default executor, which would make
+  // AsyncGauge.measure() return 0.0 in this test forever.
+  private AsyncGauge.AsyncGaugeExecutor asyncGaugeExecutor;
   private ParticipantStateTransitionStats stats;
   private ThreadPoolExecutor executor;
 
   @BeforeMethod
   public void setUp() {
     inMemoryMetricReader = InMemoryMetricReader.create();
+    asyncGaugeExecutor = new AsyncGauge.AsyncGaugeExecutor.Builder().build();
     metricsRepository = new VeniceMetricsRepository(
         new VeniceMetricsConfig.Builder().setMetricPrefix(TEST_METRIC_PREFIX)
             .setMetricEntities(SERVER_METRIC_ENTITIES)
             .setEmitOtelMetrics(true)
             .setOtelAdditionalMetricsReader(inMemoryMetricReader)
+            .setTehutiMetricConfig(new MetricConfig(asyncGaugeExecutor))
             .build());
     executor = new ThreadPoolExecutor(1, 1, 0L, TimeUnit.MILLISECONDS, new LinkedBlockingQueue<>());
     stats = new ParticipantStateTransitionStats(metricsRepository, executor, TEST_POOL_NAME);
@@ -56,6 +64,8 @@ public class ParticipantStateTransitionStatsOtelTest {
   @AfterMethod
   public void tearDown() {
     if (metricsRepository != null) {
+      // Closes the dedicated executor we injected via setTehutiMetricConfig — does NOT touch
+      // the static AsyncGauge.DEFAULT_ASYNC_GAUGE_EXECUTOR shared with other test classes.
       metricsRepository.close();
     }
     if (executor != null) {
@@ -166,8 +176,12 @@ public class ParticipantStateTransitionStatsOtelTest {
 
   @Test
   public void testNoNpeWhenOtelDisabled() {
+    AsyncGauge.AsyncGaugeExecutor dedicatedExecutor = new AsyncGauge.AsyncGaugeExecutor.Builder().build();
     try (VeniceMetricsRepository disabledRepo = new VeniceMetricsRepository(
-        new VeniceMetricsConfig.Builder().setMetricPrefix(TEST_METRIC_PREFIX).setEmitOtelMetrics(false).build())) {
+        new VeniceMetricsConfig.Builder().setMetricPrefix(TEST_METRIC_PREFIX)
+            .setEmitOtelMetrics(false)
+            .setTehutiMetricConfig(new MetricConfig(dedicatedExecutor))
+            .build())) {
       exerciseAllRecordingPaths(disabledRepo);
     }
   }

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/stats/ParticipantStateTransitionStatsTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/stats/ParticipantStateTransitionStatsTest.java
@@ -102,6 +102,51 @@ public class ParticipantStateTransitionStatsTest {
     assertEquals(steadyStateLeader.value(), 1.0, "LEADER state should be incremented after transition from STANDBY");
   }
 
+  /**
+   * Pins the contract for the failure path: in-progress decrements, no steady-state side effect
+   * for {@code toState}, and the {@code fromState} steady-state stays at the value left by
+   * {@link ParticipantStateTransitionStats#trackStateTransitionStarted} (already decremented).
+   */
+  @Test
+  public void testTrackStateTransitionFailedDecrementsInProgressOnly() {
+    String localPrefix = "S_T_Failed_Test";
+    AsyncGauge.AsyncGaugeExecutor localExecutor = new AsyncGauge.AsyncGaugeExecutor.Builder().build();
+    MetricsRepository localRepo = new MetricsRepository(new MetricConfig(localExecutor));
+    ThreadPoolExecutor executor = new ThreadPoolExecutor(1, 1, 0L, TimeUnit.MILLISECONDS, new LinkedBlockingQueue<>());
+    try {
+      ParticipantStateTransitionStats localStats =
+          new ParticipantStateTransitionStats(localRepo, executor, localPrefix);
+
+      // Seed STANDBY at +1 by completing OFFLINE->STANDBY
+      localStats.trackStateTransitionStarted(OFFLINE_STATE, STANDBY_STATE);
+      localStats.trackStateTransitionCompleted(OFFLINE_STATE, STANDBY_STATE);
+
+      String standbyToLeaderInProgress = String
+          .format(".%s--num_partition_in_transition_from_%s_to_%s.Gauge", localPrefix, STANDBY_STATE, LEADER_STATE);
+      String standbySteady = String.format(".%s--num_partition_in_%s_state.Gauge", localPrefix, STANDBY_STATE);
+      String leaderSteady = String.format(".%s--num_partition_in_%s_state.Gauge", localPrefix, LEADER_STATE);
+
+      // Start STANDBY->LEADER, then fail before completion.
+      localStats.trackStateTransitionStarted(STANDBY_STATE, LEADER_STATE);
+      assertEquals(localRepo.getMetric(standbyToLeaderInProgress).value(), 1.0);
+      assertEquals(localRepo.getMetric(standbySteady).value(), 0.0, "STANDBY decremented in started()");
+
+      localStats.trackStateTransitionFailed(STANDBY_STATE, LEADER_STATE);
+
+      // In-progress returns to 0 — no leak.
+      assertEquals(localRepo.getMetric(standbyToLeaderInProgress).value(), 0.0);
+      // STANDBY stays at 0 (partition has left STANDBY); LEADER never registered (not entered).
+      assertEquals(localRepo.getMetric(standbySteady).value(), 0.0);
+      assertNull(localRepo.getMetric(leaderSteady), "LEADER steady-state must not be touched on failure");
+    } finally {
+      executor.shutdownNow();
+      try {
+        localExecutor.close();
+      } catch (IOException ignored) {
+      }
+    }
+  }
+
   private String getInProgressTransitionMetricName(String fromState, String toState) {
     return String.format(".%s--num_partition_in_transition_from_%s_to_%s.Gauge", METRIC_PREFIX, fromState, toState);
   }

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/stats/ServerMetricEntityTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/stats/ServerMetricEntityTest.java
@@ -22,7 +22,7 @@ import org.testng.annotations.Test;
 public class ServerMetricEntityTest {
   @Test
   public void testServerMetricEntitiesCount() {
-    assertEquals(SERVER_METRIC_ENTITIES.size(), 153, "Expected 153 unique metric entities");
+    assertEquals(SERVER_METRIC_ENTITIES.size(), 156, "Expected 156 unique metric entities");
   }
 
   /**

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/stats/ServerMetricEntityTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/stats/ServerMetricEntityTest.java
@@ -22,7 +22,7 @@ import org.testng.annotations.Test;
 public class ServerMetricEntityTest {
   @Test
   public void testServerMetricEntitiesCount() {
-    assertEquals(SERVER_METRIC_ENTITIES.size(), 156, "Expected 156 unique metric entities");
+    assertEquals(SERVER_METRIC_ENTITIES.size(), 159, "Expected 159 unique metric entities");
   }
 
   /**

--- a/internal/venice-client-common/src/main/java/com/linkedin/venice/stats/dimensions/VeniceHelixFromState.java
+++ b/internal/venice-client-common/src/main/java/com/linkedin/venice/stats/dimensions/VeniceHelixFromState.java
@@ -1,0 +1,16 @@
+package com.linkedin.venice.stats.dimensions;
+
+/**
+ * Helix "from" state for partition state transition metrics.
+ * Same values as {@link VeniceHelixToState} but maps to a different dimension key
+ * ({@link VeniceMetricsDimensions#VENICE_HELIX_FROM_STATE}).
+ * Values match {@link com.linkedin.venice.helix.HelixState} constants.
+ */
+public enum VeniceHelixFromState implements VeniceDimensionInterface {
+  OFFLINE, STANDBY, LEADER, ERROR, DROPPED;
+
+  @Override
+  public VeniceMetricsDimensions getDimensionName() {
+    return VeniceMetricsDimensions.VENICE_HELIX_FROM_STATE;
+  }
+}

--- a/internal/venice-client-common/src/main/java/com/linkedin/venice/stats/dimensions/VeniceHelixFromState.java
+++ b/internal/venice-client-common/src/main/java/com/linkedin/venice/stats/dimensions/VeniceHelixFromState.java
@@ -4,7 +4,8 @@ package com.linkedin.venice.stats.dimensions;
  * Helix "from" state for partition state transition metrics.
  * Same values as {@link VeniceHelixToState} but maps to a different dimension key
  * ({@link VeniceMetricsDimensions#VENICE_HELIX_FROM_STATE}).
- * Values match {@link com.linkedin.venice.helix.HelixState} constants.
+ * Values are a subset of {@link com.linkedin.venice.helix.HelixState} constants,
+ * excluding {@code UNKNOWN}.
  */
 public enum VeniceHelixFromState implements VeniceDimensionInterface {
   OFFLINE, STANDBY, LEADER, ERROR, DROPPED;

--- a/internal/venice-client-common/src/main/java/com/linkedin/venice/stats/dimensions/VeniceHelixSteadyState.java
+++ b/internal/venice-client-common/src/main/java/com/linkedin/venice/stats/dimensions/VeniceHelixSteadyState.java
@@ -1,0 +1,15 @@
+package com.linkedin.venice.stats.dimensions;
+
+/**
+ * Helix steady states for partition state metrics. Values must match
+ * {@code ParticipantStateTransitionStats.ENABLED_STEADY_STATES} — a guard test
+ * in {@code ParticipantStateTransitionStatsOtelTest} enforces this.
+ */
+public enum VeniceHelixSteadyState implements VeniceDimensionInterface {
+  ERROR, STANDBY, LEADER;
+
+  @Override
+  public VeniceMetricsDimensions getDimensionName() {
+    return VeniceMetricsDimensions.VENICE_HELIX_STATE;
+  }
+}

--- a/internal/venice-client-common/src/main/java/com/linkedin/venice/stats/dimensions/VeniceHelixToState.java
+++ b/internal/venice-client-common/src/main/java/com/linkedin/venice/stats/dimensions/VeniceHelixToState.java
@@ -1,0 +1,16 @@
+package com.linkedin.venice.stats.dimensions;
+
+/**
+ * Helix "to" state for partition state transition metrics.
+ * Same values as {@link VeniceHelixFromState} but maps to a different dimension key
+ * ({@link VeniceMetricsDimensions#VENICE_HELIX_TO_STATE}).
+ * Values match {@link com.linkedin.venice.helix.HelixState} constants.
+ */
+public enum VeniceHelixToState implements VeniceDimensionInterface {
+  OFFLINE, STANDBY, LEADER, ERROR, DROPPED;
+
+  @Override
+  public VeniceMetricsDimensions getDimensionName() {
+    return VeniceMetricsDimensions.VENICE_HELIX_TO_STATE;
+  }
+}

--- a/internal/venice-client-common/src/main/java/com/linkedin/venice/stats/dimensions/VeniceHelixToState.java
+++ b/internal/venice-client-common/src/main/java/com/linkedin/venice/stats/dimensions/VeniceHelixToState.java
@@ -4,7 +4,8 @@ package com.linkedin.venice.stats.dimensions;
  * Helix "to" state for partition state transition metrics.
  * Same values as {@link VeniceHelixFromState} but maps to a different dimension key
  * ({@link VeniceMetricsDimensions#VENICE_HELIX_TO_STATE}).
- * Values match {@link com.linkedin.venice.helix.HelixState} constants.
+ * Values are a subset of {@link com.linkedin.venice.helix.HelixState} constants,
+ * excluding {@code UNKNOWN}.
  */
 public enum VeniceHelixToState implements VeniceDimensionInterface {
   OFFLINE, STANDBY, LEADER, ERROR, DROPPED;

--- a/internal/venice-client-common/src/main/java/com/linkedin/venice/stats/dimensions/VeniceMetricsDimensions.java
+++ b/internal/venice-client-common/src/main/java/com/linkedin/venice/stats/dimensions/VeniceMetricsDimensions.java
@@ -153,7 +153,16 @@ public enum VeniceMetricsDimensions {
   VENICE_CONNECTION_SOURCE("venice.connection.source"),
 
   /** {@link VeniceDrainerType} Drainer type: sorted or unsorted. */
-  VENICE_DRAINER_TYPE("venice.drainer.type");
+  VENICE_DRAINER_TYPE("venice.drainer.type"),
+
+  /** {@link VeniceHelixFromState} Helix state a partition is transitioning from. */
+  VENICE_HELIX_FROM_STATE("venice.helix.from_state"),
+
+  /** {@link VeniceHelixToState} Helix state a partition is transitioning to. */
+  VENICE_HELIX_TO_STATE("venice.helix.to_state"),
+
+  /** Helix state a partition is currently in (steady state). */
+  VENICE_HELIX_STATE("venice.helix.state");
 
   private final String[] dimensionName = new String[VeniceOpenTelemetryMetricNamingFormat.SIZE];
 

--- a/internal/venice-client-common/src/main/java/com/linkedin/venice/stats/dimensions/VeniceMetricsDimensions.java
+++ b/internal/venice-client-common/src/main/java/com/linkedin/venice/stats/dimensions/VeniceMetricsDimensions.java
@@ -156,7 +156,16 @@ public enum VeniceMetricsDimensions {
   VENICE_DRAINER_TYPE("venice.drainer.type"),
 
   /** {@link VeniceRequestKeyCountBucket} Coarse key-count bucket for request batches. */
-  VENICE_REQUEST_KEY_COUNT_BUCKET("venice.request.key_count_bucket");
+  VENICE_REQUEST_KEY_COUNT_BUCKET("venice.request.key_count_bucket"),
+
+  /** {@link VeniceHelixFromState} Helix state a partition is transitioning from. */
+  VENICE_HELIX_FROM_STATE("venice.helix.from_state"),
+
+  /** {@link VeniceHelixToState} Helix state a partition is transitioning to. */
+  VENICE_HELIX_TO_STATE("venice.helix.to_state"),
+
+  /** Helix state a partition is currently in (steady state). */
+  VENICE_HELIX_STATE("venice.helix.state");
 
   private final String[] dimensionName = new String[VeniceOpenTelemetryMetricNamingFormat.SIZE];
 

--- a/internal/venice-client-common/src/test/java/com/linkedin/venice/stats/dimensions/VeniceHelixFromStateTest.java
+++ b/internal/venice-client-common/src/test/java/com/linkedin/venice/stats/dimensions/VeniceHelixFromStateTest.java
@@ -1,0 +1,23 @@
+package com.linkedin.venice.stats.dimensions;
+
+import com.linkedin.venice.utils.CollectionUtils;
+import java.util.Map;
+import org.testng.annotations.Test;
+
+
+public class VeniceHelixFromStateTest {
+  @Test
+  public void testDimensionInterface() {
+    Map<VeniceHelixFromState, String> expectedValues = CollectionUtils.<VeniceHelixFromState, String>mapBuilder()
+        .put(VeniceHelixFromState.OFFLINE, "offline")
+        .put(VeniceHelixFromState.STANDBY, "standby")
+        .put(VeniceHelixFromState.LEADER, "leader")
+        .put(VeniceHelixFromState.ERROR, "error")
+        .put(VeniceHelixFromState.DROPPED, "dropped")
+        .build();
+    new VeniceDimensionTestFixture<>(
+        VeniceHelixFromState.class,
+        VeniceMetricsDimensions.VENICE_HELIX_FROM_STATE,
+        expectedValues).assertAll();
+  }
+}

--- a/internal/venice-client-common/src/test/java/com/linkedin/venice/stats/dimensions/VeniceHelixFromStateTest.java
+++ b/internal/venice-client-common/src/test/java/com/linkedin/venice/stats/dimensions/VeniceHelixFromStateTest.java
@@ -1,5 +1,6 @@
 package com.linkedin.venice.stats.dimensions;
 
+import com.linkedin.venice.helix.HelixState;
 import com.linkedin.venice.utils.CollectionUtils;
 import java.util.Map;
 import org.testng.annotations.Test;
@@ -19,5 +20,22 @@ public class VeniceHelixFromStateTest {
         VeniceHelixFromState.class,
         VeniceMetricsDimensions.VENICE_HELIX_FROM_STATE,
         expectedValues).assertAll();
+  }
+
+  /**
+   * Guards against drift between {@link HelixState} and this enum: every Helix state that can
+   * appear as a transition source must be representable here so the defensive {@code valueOf}
+   * catch in {@code ParticipantStateTransitionStats#recordInProgressOtel} stays unreachable in
+   * practice. {@link HelixState#UNKNOWN} is excluded — Helix never dispatches transitions
+   * from/to it.
+   */
+  @Test
+  public void testCoversAllHelixStatesExceptUnknown() {
+    for (HelixState helixState: HelixState.values()) {
+      if (helixState == HelixState.UNKNOWN) {
+        continue;
+      }
+      VeniceHelixFromState.valueOf(helixState.name());
+    }
   }
 }

--- a/internal/venice-client-common/src/test/java/com/linkedin/venice/stats/dimensions/VeniceHelixSteadyStateTest.java
+++ b/internal/venice-client-common/src/test/java/com/linkedin/venice/stats/dimensions/VeniceHelixSteadyStateTest.java
@@ -1,0 +1,21 @@
+package com.linkedin.venice.stats.dimensions;
+
+import com.linkedin.venice.utils.CollectionUtils;
+import java.util.Map;
+import org.testng.annotations.Test;
+
+
+public class VeniceHelixSteadyStateTest {
+  @Test
+  public void testDimensionInterface() {
+    Map<VeniceHelixSteadyState, String> expectedValues = CollectionUtils.<VeniceHelixSteadyState, String>mapBuilder()
+        .put(VeniceHelixSteadyState.ERROR, "error")
+        .put(VeniceHelixSteadyState.STANDBY, "standby")
+        .put(VeniceHelixSteadyState.LEADER, "leader")
+        .build();
+    new VeniceDimensionTestFixture<>(
+        VeniceHelixSteadyState.class,
+        VeniceMetricsDimensions.VENICE_HELIX_STATE,
+        expectedValues).assertAll();
+  }
+}

--- a/internal/venice-client-common/src/test/java/com/linkedin/venice/stats/dimensions/VeniceHelixToStateTest.java
+++ b/internal/venice-client-common/src/test/java/com/linkedin/venice/stats/dimensions/VeniceHelixToStateTest.java
@@ -1,0 +1,23 @@
+package com.linkedin.venice.stats.dimensions;
+
+import com.linkedin.venice.utils.CollectionUtils;
+import java.util.Map;
+import org.testng.annotations.Test;
+
+
+public class VeniceHelixToStateTest {
+  @Test
+  public void testDimensionInterface() {
+    Map<VeniceHelixToState, String> expectedValues = CollectionUtils.<VeniceHelixToState, String>mapBuilder()
+        .put(VeniceHelixToState.OFFLINE, "offline")
+        .put(VeniceHelixToState.STANDBY, "standby")
+        .put(VeniceHelixToState.LEADER, "leader")
+        .put(VeniceHelixToState.ERROR, "error")
+        .put(VeniceHelixToState.DROPPED, "dropped")
+        .build();
+    new VeniceDimensionTestFixture<>(
+        VeniceHelixToState.class,
+        VeniceMetricsDimensions.VENICE_HELIX_TO_STATE,
+        expectedValues).assertAll();
+  }
+}

--- a/internal/venice-client-common/src/test/java/com/linkedin/venice/stats/dimensions/VeniceHelixToStateTest.java
+++ b/internal/venice-client-common/src/test/java/com/linkedin/venice/stats/dimensions/VeniceHelixToStateTest.java
@@ -1,5 +1,6 @@
 package com.linkedin.venice.stats.dimensions;
 
+import com.linkedin.venice.helix.HelixState;
 import com.linkedin.venice.utils.CollectionUtils;
 import java.util.Map;
 import org.testng.annotations.Test;
@@ -19,5 +20,22 @@ public class VeniceHelixToStateTest {
         VeniceHelixToState.class,
         VeniceMetricsDimensions.VENICE_HELIX_TO_STATE,
         expectedValues).assertAll();
+  }
+
+  /**
+   * Guards against drift between {@link HelixState} and this enum: every Helix state that can
+   * appear as a transition destination must be representable here so the defensive
+   * {@code valueOf} catch in {@code ParticipantStateTransitionStats#recordInProgressOtel} stays
+   * unreachable in practice. {@link HelixState#UNKNOWN} is excluded — Helix never dispatches
+   * transitions from/to it.
+   */
+  @Test
+  public void testCoversAllHelixStatesExceptUnknown() {
+    for (HelixState helixState: HelixState.values()) {
+      if (helixState == HelixState.UNKNOWN) {
+        continue;
+      }
+      VeniceHelixToState.valueOf(helixState.name());
+    }
   }
 }

--- a/internal/venice-client-common/src/test/java/com/linkedin/venice/stats/dimensions/VeniceMetricsDimensionsTest.java
+++ b/internal/venice-client-common/src/test/java/com/linkedin/venice/stats/dimensions/VeniceMetricsDimensionsTest.java
@@ -157,6 +157,15 @@ public class VeniceMetricsDimensionsTest {
         case VENICE_DRAINER_TYPE:
           assertEquals(dimension.getDimensionName(format), "venice.drainer.type");
           break;
+        case VENICE_HELIX_FROM_STATE:
+          assertEquals(dimension.getDimensionName(format), "venice.helix.from_state");
+          break;
+        case VENICE_HELIX_TO_STATE:
+          assertEquals(dimension.getDimensionName(format), "venice.helix.to_state");
+          break;
+        case VENICE_HELIX_STATE:
+          assertEquals(dimension.getDimensionName(format), "venice.helix.state");
+          break;
         default:
           throw new IllegalArgumentException("Unknown dimension: " + dimension);
       }
@@ -312,6 +321,15 @@ public class VeniceMetricsDimensionsTest {
         case VENICE_DRAINER_TYPE:
           assertEquals(dimension.getDimensionName(format), "venice.drainer.type");
           break;
+        case VENICE_HELIX_FROM_STATE:
+          assertEquals(dimension.getDimensionName(format), "venice.helix.fromState");
+          break;
+        case VENICE_HELIX_TO_STATE:
+          assertEquals(dimension.getDimensionName(format), "venice.helix.toState");
+          break;
+        case VENICE_HELIX_STATE:
+          assertEquals(dimension.getDimensionName(format), "venice.helix.state");
+          break;
         default:
           throw new IllegalArgumentException("Unknown dimension: " + dimension);
       }
@@ -466,6 +484,15 @@ public class VeniceMetricsDimensionsTest {
           break;
         case VENICE_DRAINER_TYPE:
           assertEquals(dimension.getDimensionName(format), "Venice.Drainer.Type");
+          break;
+        case VENICE_HELIX_FROM_STATE:
+          assertEquals(dimension.getDimensionName(format), "Venice.Helix.FromState");
+          break;
+        case VENICE_HELIX_TO_STATE:
+          assertEquals(dimension.getDimensionName(format), "Venice.Helix.ToState");
+          break;
+        case VENICE_HELIX_STATE:
+          assertEquals(dimension.getDimensionName(format), "Venice.Helix.State");
           break;
         default:
           throw new IllegalArgumentException("Unknown dimension: " + dimension);

--- a/internal/venice-client-common/src/test/java/com/linkedin/venice/stats/dimensions/VeniceMetricsDimensionsTest.java
+++ b/internal/venice-client-common/src/test/java/com/linkedin/venice/stats/dimensions/VeniceMetricsDimensionsTest.java
@@ -160,6 +160,15 @@ public class VeniceMetricsDimensionsTest {
         case VENICE_REQUEST_KEY_COUNT_BUCKET:
           assertEquals(dimension.getDimensionName(format), "venice.request.key_count_bucket");
           break;
+        case VENICE_HELIX_FROM_STATE:
+          assertEquals(dimension.getDimensionName(format), "venice.helix.from_state");
+          break;
+        case VENICE_HELIX_TO_STATE:
+          assertEquals(dimension.getDimensionName(format), "venice.helix.to_state");
+          break;
+        case VENICE_HELIX_STATE:
+          assertEquals(dimension.getDimensionName(format), "venice.helix.state");
+          break;
         default:
           throw new IllegalArgumentException("Unknown dimension: " + dimension);
       }
@@ -318,6 +327,15 @@ public class VeniceMetricsDimensionsTest {
         case VENICE_REQUEST_KEY_COUNT_BUCKET:
           assertEquals(dimension.getDimensionName(format), "venice.request.keyCountBucket");
           break;
+        case VENICE_HELIX_FROM_STATE:
+          assertEquals(dimension.getDimensionName(format), "venice.helix.fromState");
+          break;
+        case VENICE_HELIX_TO_STATE:
+          assertEquals(dimension.getDimensionName(format), "venice.helix.toState");
+          break;
+        case VENICE_HELIX_STATE:
+          assertEquals(dimension.getDimensionName(format), "venice.helix.state");
+          break;
         default:
           throw new IllegalArgumentException("Unknown dimension: " + dimension);
       }
@@ -475,6 +493,15 @@ public class VeniceMetricsDimensionsTest {
           break;
         case VENICE_REQUEST_KEY_COUNT_BUCKET:
           assertEquals(dimension.getDimensionName(format), "Venice.Request.KeyCountBucket");
+          break;
+        case VENICE_HELIX_FROM_STATE:
+          assertEquals(dimension.getDimensionName(format), "Venice.Helix.FromState");
+          break;
+        case VENICE_HELIX_TO_STATE:
+          assertEquals(dimension.getDimensionName(format), "Venice.Helix.ToState");
+          break;
+        case VENICE_HELIX_STATE:
+          assertEquals(dimension.getDimensionName(format), "Venice.Helix.State");
           break;
         default:
           throw new IllegalArgumentException("Unknown dimension: " + dimension);

--- a/services/venice-server/src/test/java/com/linkedin/venice/stats/ServerLoadStatsTest.java
+++ b/services/venice-server/src/test/java/com/linkedin/venice/stats/ServerLoadStatsTest.java
@@ -183,9 +183,13 @@ public class ServerLoadStatsTest {
     assertTrue(
         metricsRepository.getMetric(rejectedSensor).value() > 0,
         "rejected_request sensor should be incremented by recordRejectedRequest");
+    // OccurrenceRate is a sliding-window rate; values can drift in the lowest decimals between
+    // reads as the clock advances. Tolerate that drift here — the assertion targets cross-sensor
+    // contamination, not exact rate values.
     assertEquals(
         metricsRepository.getMetric(acceptedSensor).value(),
         0.0,
+        1e-6,
         "accepted_request sensor must remain 0 when only rejected requests are recorded "
             + "(rejected and accepted share the OTel REQUEST_COUNT instrument but bind to separate Tehuti sensors)");
 
@@ -200,6 +204,7 @@ public class ServerLoadStatsTest {
     assertEquals(
         metricsRepository.getMetric(rejectedSensor).value(),
         rejectedBeforeAccepted,
+        1e-6,
         "rejected_request sensor must not be incremented by recordAcceptedRequest");
   }
 


### PR DESCRIPTION
## Problem Statement

`ParticipantStateTransitionStats` has dynamic Tehuti AsyncGauge sensors for tracking partition state transitions (blocked threads, in-progress transitions, steady-state counts) but no OTel counterparts, making these metrics unavailable in OTel-based monitoring dashboards.

## Solution

Add 3 OTel UP_DOWN_COUNTER metrics for partition state transition lifecycle:

- `partition.state.transition.blocked_thread_count` — threads currently blocked on a state transition (FROM/TO state dimensions). Currently only OFFLINE→DROPPED blocks threads; the FROM/TO dimensions allow future transitions to use this metric without schema changes.
- `partition.state.transition.in_progress_count` — partitions currently transitioning between Helix states (FROM/TO state dimensions). Records +1 on transition start, -1 on completion.
- `partition.state.active_count` — partitions currently in a given Helix state: ERROR, STANDBY, LEADER (STATE dimension). Records -1 when a partition leaves a state, +1 when it enters.

All three use UP_DOWN_COUNTER (+1/-1 at call sites). Tehuti AsyncGauge sensors remain backed by AtomicInteger trackers — these are Tehuti-only artifacts that will be removed when Tehuti is retired.

**Exception-safety fix in `AbstractPartitionStateModel.executeStateTransition`:** wraps `handler.run()` in a try/catch — on exception calls a new `trackStateTransitionFailed(from, to)` method (decrements in-progress, leaves the already-decremented `from` steady-state alone, does NOT increment the `to` steady-state since the partition never reached it) and rethrows. Without this, a throwing transition handler would leak +1 on `partition.state.transition.in_progress_count` forever and drift the `from` steady-state monotonically down. Pre-existing bug in the Tehuti AsyncGauges; this PR widens it into OTel dashboards, so fixing it as part of the same change.

**New dimension enums:**
- `VeniceHelixFromState` / `VeniceHelixToState` — 5 values each (OFFLINE, STANDBY, LEADER, ERROR, DROPPED) for transition metrics. Same values but different dimension keys.
- `VeniceHelixSteadyState` — 3 values (ERROR, STANDBY, LEADER) for active partition count. Synced with `ENABLED_STEADY_STATES` via a guard test.

###  Code changes
- [ ] Added new code behind **a config**.
- [ ] Introduced new **log lines**.
  - [ ] Confirmed if logs need to be **rate limited** to avoid excessive logging.

###  **Concurrency-Specific Checks**
Both reviewer and PR author to verify
- [x] Code has **no race conditions** or **thread safety issues**.
- [ ] Proper **synchronization mechanisms** (e.g., `synchronized`, `RWLock`) are used where needed.
- [ ] No **blocking calls** inside critical sections that could lead to deadlocks or performance degradation.
- [x] Verified **thread-safe collections** are used (e.g., `ConcurrentHashMap`, `CopyOnWriteArrayList`).
- [ ] Validated proper exception handling in multi-threaded code to avoid silent thread termination.

## How was this PR tested?

- [x] New unit tests added.
- [ ] New integration tests added.
- [ ] Modified or extended existing tests.
- [x] Verified backward compatibility (if applicable).

New tests:
- `ParticipantStateTransitionStatsOtelTest` (8 tests): blocked thread UP_DOWN_COUNTER, in-progress transition lifecycle, steady-state lifecycle (STANDBY→LEADER) with mid-transition ordering assertion, ERROR steady state, guard test syncing `VeniceHelixSteadyState` with `ENABLED_STEADY_STATES`, defensive `IllegalArgumentException` catch in `recordInProgressOtel` surfaces via `metric_record_failure`, NPE prevention with OTel disabled and plain `MetricsRepository`.
- `ParticipantStateTransitionStatsTest` (2 tests): existing started/completed Tehuti gauge updates + new `trackStateTransitionFailed` decrements in-progress only (no steady-state side effect for `to`).
- `ParticipantStateTransitionOtelMetricEntityTest`: metric entity validation for all 3 metrics.
- `LeaderFollowerPartitionStateModelTest.testStateTransitionFailureRecordedOnHandlerException`: verifies `executeStateTransition` calls `trackStateTransitionFailed` on handler exception (not `trackStateTransitionCompleted`) and the original exception propagates.
- `VeniceHelixFromStateTest`, `VeniceHelixToStateTest`, `VeniceHelixSteadyStateTest`: dimension value validation. `From`/`To` also include a guard test asserting every `HelixState` value (except `UNKNOWN`) is representable, so the defensive `valueOf` catch stays unreachable in practice.

Drive-by stability fix:
- `ServerLoadStatsTest.testTehutiSensorsNoCrossContamination`: added `1e-6` delta to two `assertEquals` calls on `OccurrenceRate` snapshots. Same flake pattern Yug fixed in #2746 — clock advances between snapshot and re-read cause sub-microscopic drift on the rate value.

## Does this PR introduce any user-facing or breaking changes?
- [x] No. You can skip the rest of this section.
- [ ] Yes. Clearly explain the behavior change and its impact.
