### PR TITLE
[da-vinci] Add OTel metrics to NativeMetadataRepositoryStats

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/repository/NativeMetadataRepository.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/repository/NativeMetadataRepository.java
@@ -185,7 +185,7 @@ public abstract class NativeMetadataRepository
       Store newStore = fetchStoreFromRemote(storeName, storeConfig.getCluster());
       putStore(newStore);
       getAndCacheSchemaData(storeName);
-      nativeMetadataRepositoryStats.updateCacheTimestamp(storeName, clock.millis());
+      nativeMetadataRepositoryStats.updateCacheTimestamp(storeName, storeConfig.getCluster(), clock.millis());
       return newStore;
     } catch (ServiceDiscoveryException | MissingKeyInStoreMetadataException e) {
       throw new VeniceNoStoreException(storeName, e);

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/NativeMetadataRepositoryOtelMetricEntity.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/NativeMetadataRepositoryOtelMetricEntity.java
@@ -1,0 +1,40 @@
+package com.linkedin.davinci.stats;
+
+import static com.linkedin.venice.stats.dimensions.VeniceMetricsDimensions.VENICE_CLUSTER_NAME;
+import static com.linkedin.venice.stats.dimensions.VeniceMetricsDimensions.VENICE_STORE_NAME;
+import static com.linkedin.venice.utils.Utils.setOf;
+
+import com.linkedin.venice.stats.dimensions.VeniceMetricsDimensions;
+import com.linkedin.venice.stats.metrics.MetricEntity;
+import com.linkedin.venice.stats.metrics.MetricType;
+import com.linkedin.venice.stats.metrics.MetricUnit;
+import com.linkedin.venice.stats.metrics.ModuleMetricEntityInterface;
+import java.util.Set;
+
+
+/**
+ * OTel metric entity definitions for {@link NativeMetadataRepositoryStats}.
+ */
+public enum NativeMetadataRepositoryOtelMetricEntity implements ModuleMetricEntityInterface {
+  METADATA_CACHE_STALENESS(
+      "metadata.staleness_duration", MetricType.ASYNC_DOUBLE_GAUGE, MetricUnit.MILLISECOND,
+      "Per-store metadata staleness in ms since the store metadata was last fetched from the meta system store",
+      setOf(VENICE_CLUSTER_NAME, VENICE_STORE_NAME)
+  );
+
+  private final MetricEntity metricEntity;
+
+  NativeMetadataRepositoryOtelMetricEntity(
+      String metricName,
+      MetricType metricType,
+      MetricUnit unit,
+      String description,
+      Set<VeniceMetricsDimensions> dimensions) {
+    this.metricEntity = new MetricEntity(metricName, metricType, unit, description, dimensions);
+  }
+
+  @Override
+  public MetricEntity getMetricEntity() {
+    return metricEntity;
+  }
+}

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/NativeMetadataRepositoryStats.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/NativeMetadataRepositoryStats.java
@@ -1,26 +1,58 @@
 package com.linkedin.davinci.stats;
 
+import static com.linkedin.davinci.stats.NativeMetadataRepositoryOtelMetricEntity.METADATA_CACHE_STALENESS;
+
 import com.linkedin.venice.stats.AbstractVeniceStats;
+import com.linkedin.venice.stats.OpenTelemetryMetricsSetup;
+import com.linkedin.venice.stats.VeniceOpenTelemetryMetricsRepository;
+import com.linkedin.venice.stats.dimensions.VeniceMetricsDimensions;
+import com.linkedin.venice.stats.metrics.AsyncMetricEntityStateBase;
 import com.linkedin.venice.utils.concurrent.VeniceConcurrentHashMap;
+import io.opentelemetry.api.common.Attributes;
 import io.tehuti.metrics.MetricsRepository;
-import io.tehuti.metrics.Sensor;
 import io.tehuti.metrics.stats.AsyncGauge;
 import java.time.Clock;
+import java.util.HashMap;
 import java.util.Map;
+import java.util.function.DoubleSupplier;
 
 
+/**
+ * Tracks metadata cache staleness for {@link com.linkedin.davinci.repository.NativeMetadataRepository}.
+ *
+ * <p>Tehuti emits a single high-watermark gauge (oldest store's staleness across all stores).
+ * OTel emits per-store ASYNC_DOUBLE_GAUGE with STORE_NAME dimension — backends can compute the
+ * high watermark at query time via max aggregation.
+ *
+ * <p>Per-store OTel callbacks are registered lazily on first {@link #updateCacheTimestamp} call
+ * and read from the shared {@link #metadataCacheTimestampMapInMs}. When a store is removed,
+ * the callback returns {@code NaN} (timestamp absent from the map, store no longer tracked). OTel callbacks cannot be deregistered
+ * (SDK limitation), so the per-store entry stays registered until the process exits.
+ */
 public class NativeMetadataRepositoryStats extends AbstractVeniceStats {
-  private final Sensor storeMetadataStalenessSensor;
   private final Map<String, Long> metadataCacheTimestampMapInMs = new VeniceConcurrentHashMap<>();
   private final Clock clock;
+
+  // OTel: per-store ASYNC_GAUGE for staleness. Bounded by number of subscribed stores.
+  private final VeniceOpenTelemetryMetricsRepository otelRepository;
+  private final Map<VeniceMetricsDimensions, String> baseDimensionsMap;
+  private final Map<String, AsyncMetricEntityStateBase> otelPerStore = new VeniceConcurrentHashMap<>();
 
   public NativeMetadataRepositoryStats(MetricsRepository metricsRepository, String name, Clock clock) {
     super(metricsRepository, name);
     this.clock = clock;
-    this.storeMetadataStalenessSensor = registerSensor(
+
+    // Tehuti: single high-watermark gauge across all stores
+    registerSensor(
         new AsyncGauge(
             (ignored1, ignored2) -> getMetadataStalenessHighWatermarkMs(),
             "store_metadata_staleness_high_watermark_ms"));
+
+    // OTel setup
+    OpenTelemetryMetricsSetup.OpenTelemetryMetricsSetupInfo otelData =
+        OpenTelemetryMetricsSetup.builder(metricsRepository).build();
+    this.otelRepository = otelData.getOtelRepository();
+    this.baseDimensionsMap = otelData.getBaseDimensionsMap();
   }
 
   public final double getMetadataStalenessHighWatermarkMs() {
@@ -36,11 +68,32 @@ public class NativeMetadataRepositoryStats extends AbstractVeniceStats {
     return oldest == Long.MAX_VALUE ? Double.NaN : (double) (clock.millis() - oldest);
   }
 
-  public void updateCacheTimestamp(String storeName, long cacheTimeStampInMs) {
+  public void updateCacheTimestamp(String storeName, String clusterName, long cacheTimeStampInMs) {
     metadataCacheTimestampMapInMs.put(storeName, cacheTimeStampInMs);
+    registerOtelGaugeIfAbsent(storeName, clusterName);
   }
 
   public void removeCacheTimestamp(String storeName) {
     metadataCacheTimestampMapInMs.remove(storeName);
+    // OTel callback stays registered but returns NaN (timestamp absent from map, store no longer tracked)
+  }
+
+  private void registerOtelGaugeIfAbsent(String storeName, String clusterName) {
+    if (otelRepository == null) {
+      return;
+    }
+    otelPerStore.computeIfAbsent(storeName, k -> {
+      Map<VeniceMetricsDimensions, String> dims = new HashMap<>(baseDimensionsMap);
+      dims.put(VeniceMetricsDimensions.VENICE_CLUSTER_NAME, clusterName);
+      dims.put(VeniceMetricsDimensions.VENICE_STORE_NAME, OpenTelemetryMetricsSetup.sanitizeStoreName(k));
+      Attributes attrs = otelRepository.createAttributes(METADATA_CACHE_STALENESS.getMetricEntity(), dims);
+      // DoubleSupplier callback: returns NaN when store is removed (no timestamp in map),
+      // consistent with the Tehuti high-watermark gauge behavior.
+      return AsyncMetricEntityStateBase
+          .create(METADATA_CACHE_STALENESS.getMetricEntity(), otelRepository, dims, attrs, (DoubleSupplier) () -> {
+            Long ts = metadataCacheTimestampMapInMs.get(k);
+            return ts == null ? Double.NaN : (double) (clock.millis() - ts);
+          });
+    });
   }
 }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/NativeMetadataRepositoryStats.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/NativeMetadataRepositoryStats.java
@@ -26,14 +26,14 @@ import java.util.function.DoubleSupplier;
  *
  * <p>Per-store OTel callbacks are registered lazily on first {@link #updateCacheTimestamp} call
  * and read from the shared {@link #metadataCacheTimestampMapInMs}. When a store is removed,
- * the callback returns {@code NaN} (timestamp absent from the map, store no longer tracked). OTel callbacks cannot be deregistered
- * (SDK limitation), so the per-store entry stays registered until the process exits.
+ * the callback returns {@code NaN} (timestamp absent from the map, store no longer tracked). OTel callbacks cannot be
+ * deregistered (SDK limitation), so the per-store entry stays registered until the process exits.
  */
 public class NativeMetadataRepositoryStats extends AbstractVeniceStats {
   private final Map<String, Long> metadataCacheTimestampMapInMs = new VeniceConcurrentHashMap<>();
   private final Clock clock;
 
-  // OTel: per-store ASYNC_GAUGE for staleness. Bounded by number of subscribed stores.
+  // OTel: per-store ASYNC_DOUBLE_GAUGE for staleness. Bounded by number of subscribed stores.
   private final VeniceOpenTelemetryMetricsRepository otelRepository;
   private final Map<VeniceMetricsDimensions, String> baseDimensionsMap;
   private final Map<String, AsyncMetricEntityStateBase> otelPerStore = new VeniceConcurrentHashMap<>();
@@ -68,6 +68,14 @@ public class NativeMetadataRepositoryStats extends AbstractVeniceStats {
     return oldest == Long.MAX_VALUE ? Double.NaN : (double) (clock.millis() - oldest);
   }
 
+  /**
+   * Updates the cache timestamp for a store and lazily registers an OTel gauge on first call per store.
+   *
+   * @param clusterName used only on the first call per store to set the CLUSTER_NAME OTel dimension.
+   *                    Subsequent calls for the same store ignore this parameter (the OTel gauge is
+   *                    already registered). This is acceptable because a DaVinci client connects to
+   *                    a single cluster — the cluster name does not change per store.
+   */
   public void updateCacheTimestamp(String storeName, String clusterName, long cacheTimeStampInMs) {
     metadataCacheTimestampMapInMs.put(storeName, cacheTimeStampInMs);
     registerOtelGaugeIfAbsent(storeName, clusterName);

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/NativeMetadataRepositoryStats.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/NativeMetadataRepositoryStats.java
@@ -33,7 +33,9 @@ public class NativeMetadataRepositoryStats extends AbstractVeniceStats {
   private final Map<String, Long> metadataCacheTimestampMapInMs = new VeniceConcurrentHashMap<>();
   private final Clock clock;
 
-  // OTel: per-store ASYNC_DOUBLE_GAUGE for staleness. Bounded by number of subscribed stores.
+  // OTel: per-store ASYNC_DOUBLE_GAUGE for staleness. Effectively bounded by the number of
+  // distinct stores seen during the lifetime of the process, since callbacks cannot be deregistered
+  // (entries in this map are not removed when a store is unsubscribed).
   private final VeniceOpenTelemetryMetricsRepository otelRepository;
   private final Map<VeniceMetricsDimensions, String> baseDimensionsMap;
   private final Map<String, AsyncMetricEntityStateBase> otelPerStore = new VeniceConcurrentHashMap<>();
@@ -72,9 +74,11 @@ public class NativeMetadataRepositoryStats extends AbstractVeniceStats {
    * Updates the cache timestamp for a store and lazily registers an OTel gauge on first call per store.
    *
    * @param clusterName used only on the first call per store to set the CLUSTER_NAME OTel dimension.
-   *                    Subsequent calls for the same store ignore this parameter (the OTel gauge is
-   *                    already registered). This is acceptable because a DaVinci client connects to
-   *                    a single cluster — the cluster name does not change per store.
+   *                    Subsequent calls for the same store ignore this parameter — the OTel gauge is
+   *                    already registered under the first-seen cluster name and OTel callbacks cannot
+   *                    be deregistered. Known limitation: if a store migrates clusters during the
+   *                    lifetime of this process, the gauge will continue to emit under the original
+   *                    cluster name dimension rather than the post-migration cluster.
    */
   public void updateCacheTimestamp(String storeName, String clusterName, long cacheTimeStampInMs) {
     metadataCacheTimestampMapInMs.put(storeName, cacheTimeStampInMs);

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/ServerMetricEntity.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/ServerMetricEntity.java
@@ -43,7 +43,8 @@ public final class ServerMetricEntity {
         ServerReadQuotaOtelMetricEntity.class,
         ServerConnectionOtelMetricEntity.class,
         StoreBufferServiceOtelMetricEntity.class,
-        StorageEngineOtelMetricEntity.class);
+        StorageEngineOtelMetricEntity.class,
+        NativeMetadataRepositoryOtelMetricEntity.class);
   }
 
   public static final Collection<MetricEntity> SERVER_METRIC_ENTITIES =

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/ServerMetricEntity.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/ServerMetricEntity.java
@@ -44,7 +44,8 @@ public final class ServerMetricEntity {
         ServerConnectionOtelMetricEntity.class,
         StoreBufferServiceOtelMetricEntity.class,
         StorageEngineOtelMetricEntity.class,
-        DiskHealthOtelMetricEntity.class);
+        DiskHealthOtelMetricEntity.class,
+        NativeMetadataRepositoryOtelMetricEntity.class);
   }
 
   public static final Collection<MetricEntity> SERVER_METRIC_ENTITIES =

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/stats/NativeMetadataRepositoryOtelMetricEntityTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/stats/NativeMetadataRepositoryOtelMetricEntityTest.java
@@ -1,0 +1,36 @@
+package com.linkedin.davinci.stats;
+
+import static com.linkedin.davinci.stats.NativeMetadataRepositoryOtelMetricEntity.METADATA_CACHE_STALENESS;
+import static com.linkedin.venice.stats.dimensions.VeniceMetricsDimensions.VENICE_CLUSTER_NAME;
+import static com.linkedin.venice.stats.dimensions.VeniceMetricsDimensions.VENICE_STORE_NAME;
+import static com.linkedin.venice.utils.Utils.setOf;
+
+import com.linkedin.venice.stats.metrics.MetricType;
+import com.linkedin.venice.stats.metrics.MetricUnit;
+import com.linkedin.venice.stats.metrics.ModuleMetricEntityTestFixture;
+import com.linkedin.venice.stats.metrics.ModuleMetricEntityTestFixture.MetricEntityExpectation;
+import java.util.HashMap;
+import java.util.Map;
+import org.testng.annotations.Test;
+
+
+public class NativeMetadataRepositoryOtelMetricEntityTest {
+  @Test
+  public void testMetricEntities() {
+    new ModuleMetricEntityTestFixture<>(NativeMetadataRepositoryOtelMetricEntity.class, expectedDefinitions())
+        .assertAll();
+  }
+
+  private static Map<NativeMetadataRepositoryOtelMetricEntity, MetricEntityExpectation> expectedDefinitions() {
+    Map<NativeMetadataRepositoryOtelMetricEntity, MetricEntityExpectation> map = new HashMap<>();
+    map.put(
+        METADATA_CACHE_STALENESS,
+        new MetricEntityExpectation(
+            "metadata.staleness_duration",
+            MetricType.ASYNC_DOUBLE_GAUGE,
+            MetricUnit.MILLISECOND,
+            "Per-store metadata staleness in ms since the store metadata was last fetched from the meta system store",
+            setOf(VENICE_CLUSTER_NAME, VENICE_STORE_NAME)));
+    return map;
+  }
+}

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/stats/NativeMetadataRepositoryStatsOtelTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/stats/NativeMetadataRepositoryStatsOtelTest.java
@@ -1,0 +1,155 @@
+package com.linkedin.davinci.stats;
+
+import static com.linkedin.davinci.stats.NativeMetadataRepositoryOtelMetricEntity.METADATA_CACHE_STALENESS;
+import static com.linkedin.davinci.stats.ServerMetricEntity.SERVER_METRIC_ENTITIES;
+import static com.linkedin.venice.stats.dimensions.VeniceMetricsDimensions.VENICE_CLUSTER_NAME;
+import static com.linkedin.venice.stats.dimensions.VeniceMetricsDimensions.VENICE_STORE_NAME;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.testng.Assert.assertFalse;
+
+import com.linkedin.venice.stats.VeniceMetricsConfig;
+import com.linkedin.venice.stats.VeniceMetricsRepository;
+import com.linkedin.venice.utils.OpenTelemetryDataTestUtils;
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.sdk.metrics.data.MetricData;
+import io.opentelemetry.sdk.testing.exporter.InMemoryMetricReader;
+import io.tehuti.metrics.MetricsRepository;
+import java.time.Clock;
+import java.util.Collection;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+
+public class NativeMetadataRepositoryStatsOtelTest {
+  private static final String TEST_METRIC_PREFIX = "server";
+  private static final String TEST_CLUSTER_NAME = "test-cluster";
+  private static final String METRIC_NAME = METADATA_CACHE_STALENESS.getMetricEntity().getMetricName();
+
+  private InMemoryMetricReader inMemoryMetricReader;
+  private VeniceMetricsRepository metricsRepository;
+  private Clock mockClock;
+  private NativeMetadataRepositoryStats stats;
+
+  @BeforeMethod
+  public void setUp() {
+    inMemoryMetricReader = InMemoryMetricReader.create();
+    metricsRepository = new VeniceMetricsRepository(
+        new VeniceMetricsConfig.Builder().setMetricPrefix(TEST_METRIC_PREFIX)
+            .setMetricEntities(SERVER_METRIC_ENTITIES)
+            .setEmitOtelMetrics(true)
+            .setOtelAdditionalMetricsReader(inMemoryMetricReader)
+            .build());
+    mockClock = mock(Clock.class);
+    doReturn(1000L).when(mockClock).millis();
+    stats = new NativeMetadataRepositoryStats(metricsRepository, "test", mockClock);
+  }
+
+  @AfterMethod
+  public void tearDown() {
+    if (metricsRepository != null) {
+      metricsRepository.close();
+    }
+  }
+
+  @Test
+  public void testPerStoreStaleness() {
+    stats.updateCacheTimestamp("store-a", TEST_CLUSTER_NAME, 500);
+    stats.updateCacheTimestamp("store-b", TEST_CLUSTER_NAME, 800);
+
+    // store-a staleness = 1000 - 500 = 500ms
+    validateGauge(500, "store-a");
+    // store-b staleness = 1000 - 800 = 200ms
+    validateGauge(200, "store-b");
+  }
+
+  @Test
+  public void testStalenessUpdatesOnClockAdvance() {
+    stats.updateCacheTimestamp("store-a", TEST_CLUSTER_NAME, 900);
+
+    validateGauge(100, "store-a");
+
+    // Clock advances
+    doReturn(2000L).when(mockClock).millis();
+    validateGauge(1100, "store-a");
+  }
+
+  @Test
+  public void testStalenessUpdatesOnCacheRefresh() {
+    stats.updateCacheTimestamp("store-a", TEST_CLUSTER_NAME, 500);
+    validateGauge(500, "store-a");
+
+    // Store metadata refreshed — staleness drops
+    stats.updateCacheTimestamp("store-a", TEST_CLUSTER_NAME, 900);
+    validateGauge(100, "store-a");
+  }
+
+  @Test
+  public void testRemovedStoreReportsNaN() {
+    stats.updateCacheTimestamp("store-a", TEST_CLUSTER_NAME, 500);
+    validateGauge(500, "store-a");
+
+    stats.removeCacheTimestamp("store-a");
+    // After removal, callback returns NaN (no data). Validate directly since the
+    // tolerance-based helper doesn't support NaN comparison (NaN != NaN in IEEE 754).
+    validateGaugeAbsent("store-a");
+  }
+
+  @Test
+  public void testMultiStoreIsolation() {
+    stats.updateCacheTimestamp("store-a", TEST_CLUSTER_NAME, 200);
+    stats.updateCacheTimestamp("store-b", TEST_CLUSTER_NAME, 900);
+
+    validateGauge(800, "store-a");
+    validateGauge(100, "store-b");
+  }
+
+  @Test
+  public void testNoNpeWhenOtelDisabled() {
+    try (VeniceMetricsRepository disabledRepo = new VeniceMetricsRepository(
+        new VeniceMetricsConfig.Builder().setMetricPrefix(TEST_METRIC_PREFIX).setEmitOtelMetrics(false).build())) {
+      NativeMetadataRepositoryStats stats = new NativeMetadataRepositoryStats(disabledRepo, "test", mockClock);
+      stats.updateCacheTimestamp("store-a", TEST_CLUSTER_NAME, 500);
+      stats.removeCacheTimestamp("store-a");
+    }
+  }
+
+  @Test
+  public void testNoNpeWhenPlainMetricsRepository() {
+    NativeMetadataRepositoryStats stats = new NativeMetadataRepositoryStats(new MetricsRepository(), "test", mockClock);
+    stats.updateCacheTimestamp("store-a", TEST_CLUSTER_NAME, 500);
+    stats.removeCacheTimestamp("store-a");
+  }
+
+  /**
+   * Verifies that a removed store emits no OTel data point. The callback returns NaN
+   * which the OTel SDK drops entirely — the metric data point disappears from collection.
+   */
+  private void validateGaugeAbsent(String storeName) {
+    Collection<MetricData> metricsData = inMemoryMetricReader.collectAllMetrics();
+    String fullMetricName = "venice." + TEST_METRIC_PREFIX + "." + METRIC_NAME;
+    boolean hasDataPoint = metricsData.stream()
+        .filter(m -> m.getName().equals(fullMetricName))
+        .flatMap(m -> m.getDoubleGaugeData().getPoints().stream())
+        .anyMatch(p -> p.getAttributes().equals(buildAttributes(storeName)));
+    assertFalse(hasDataPoint, "Expected no data point for removed store: " + storeName);
+  }
+
+  private void validateGauge(double expectedValue, String storeName) {
+    OpenTelemetryDataTestUtils.validateDoublePointDataFromGauge(
+        inMemoryMetricReader,
+        expectedValue,
+        0.01,
+        buildAttributes(storeName),
+        METRIC_NAME,
+        TEST_METRIC_PREFIX);
+  }
+
+  private static Attributes buildAttributes(String storeName) {
+    return Attributes.builder()
+        .put(VENICE_CLUSTER_NAME.getDimensionNameInDefaultFormat(), TEST_CLUSTER_NAME)
+        .put(VENICE_STORE_NAME.getDimensionNameInDefaultFormat(), storeName)
+        .build();
+  }
+}

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/stats/NativeMetadataRepositoryStatsOtelTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/stats/NativeMetadataRepositoryStatsOtelTest.java
@@ -14,7 +14,9 @@ import com.linkedin.venice.utils.OpenTelemetryDataTestUtils;
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.sdk.metrics.data.MetricData;
 import io.opentelemetry.sdk.testing.exporter.InMemoryMetricReader;
+import io.tehuti.metrics.MetricConfig;
 import io.tehuti.metrics.MetricsRepository;
+import io.tehuti.metrics.stats.AsyncGauge;
 import java.time.Clock;
 import java.util.Collection;
 import org.testng.annotations.AfterMethod;
@@ -29,17 +31,23 @@ public class NativeMetadataRepositoryStatsOtelTest {
 
   private InMemoryMetricReader inMemoryMetricReader;
   private VeniceMetricsRepository metricsRepository;
+  // Dedicated AsyncGauge executor: another test class calling MetricsRepository.close()
+  // in the same JVM shuts down the static default executor, which would make
+  // AsyncGauge.measure() return 0.0 in this test forever.
+  private AsyncGauge.AsyncGaugeExecutor asyncGaugeExecutor;
   private Clock mockClock;
   private NativeMetadataRepositoryStats stats;
 
   @BeforeMethod
   public void setUp() {
     inMemoryMetricReader = InMemoryMetricReader.create();
+    asyncGaugeExecutor = new AsyncGauge.AsyncGaugeExecutor.Builder().build();
     metricsRepository = new VeniceMetricsRepository(
         new VeniceMetricsConfig.Builder().setMetricPrefix(TEST_METRIC_PREFIX)
             .setMetricEntities(SERVER_METRIC_ENTITIES)
             .setEmitOtelMetrics(true)
             .setOtelAdditionalMetricsReader(inMemoryMetricReader)
+            .setTehutiMetricConfig(new MetricConfig(asyncGaugeExecutor))
             .build());
     mockClock = mock(Clock.class);
     doReturn(1000L).when(mockClock).millis();
@@ -49,6 +57,8 @@ public class NativeMetadataRepositoryStatsOtelTest {
   @AfterMethod
   public void tearDown() {
     if (metricsRepository != null) {
+      // Closes the dedicated executor we injected via setTehutiMetricConfig — does NOT touch
+      // the static AsyncGauge.DEFAULT_ASYNC_GAUGE_EXECUTOR shared with other test classes.
       metricsRepository.close();
     }
   }
@@ -106,9 +116,31 @@ public class NativeMetadataRepositoryStatsOtelTest {
   }
 
   @Test
+  public void testReAddAfterRemoveReusesCallback() {
+    // First registration: gauge reports a real value.
+    stats.updateCacheTimestamp("store-a", TEST_CLUSTER_NAME, 500);
+    validateGauge(500, "store-a");
+
+    // Removal: callback returns NaN (timestamp absent), no data point emitted.
+    stats.removeCacheTimestamp("store-a");
+    validateGaugeAbsent("store-a");
+
+    // Re-add: the existing OTel callback (registered on the first updateCacheTimestamp)
+    // is reused — computeIfAbsent on otelPerStore is a no-op the second time. The gauge
+    // resumes reporting because the callback re-reads from metadataCacheTimestampMapInMs
+    // dynamically each cycle.
+    stats.updateCacheTimestamp("store-a", TEST_CLUSTER_NAME, 700);
+    validateGauge(300, "store-a");
+  }
+
+  @Test
   public void testNoNpeWhenOtelDisabled() {
+    AsyncGauge.AsyncGaugeExecutor dedicatedExecutor = new AsyncGauge.AsyncGaugeExecutor.Builder().build();
     try (VeniceMetricsRepository disabledRepo = new VeniceMetricsRepository(
-        new VeniceMetricsConfig.Builder().setMetricPrefix(TEST_METRIC_PREFIX).setEmitOtelMetrics(false).build())) {
+        new VeniceMetricsConfig.Builder().setMetricPrefix(TEST_METRIC_PREFIX)
+            .setEmitOtelMetrics(false)
+            .setTehutiMetricConfig(new MetricConfig(dedicatedExecutor))
+            .build())) {
       NativeMetadataRepositoryStats stats = new NativeMetadataRepositoryStats(disabledRepo, "test", mockClock);
       stats.updateCacheTimestamp("store-a", TEST_CLUSTER_NAME, 500);
       stats.removeCacheTimestamp("store-a");

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/stats/NativeMetadataRepositoryStatsTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/stats/NativeMetadataRepositoryStatsTest.java
@@ -18,12 +18,12 @@ public class NativeMetadataRepositoryStatsTest {
     String store2 = "testStore2";
     NativeMetadataRepositoryStats stats = new NativeMetadataRepositoryStats(new MetricsRepository(), "test", mockClock);
     Assert.assertEquals(stats.getMetadataStalenessHighWatermarkMs(), Double.NaN);
-    stats.updateCacheTimestamp(store1, 0);
+    stats.updateCacheTimestamp(store1, "test-cluster", 0);
     Assert.assertEquals(stats.getMetadataStalenessHighWatermarkMs(), 1000d);
-    stats.updateCacheTimestamp(store2, 1000);
+    stats.updateCacheTimestamp(store2, "test-cluster", 1000);
     Assert.assertEquals(stats.getMetadataStalenessHighWatermarkMs(), 1000d);
     doReturn(1500L).when(mockClock).millis();
-    stats.updateCacheTimestamp(store1, 1100);
+    stats.updateCacheTimestamp(store1, "test-cluster", 1100);
     Assert.assertEquals(stats.getMetadataStalenessHighWatermarkMs(), 500d);
     stats.removeCacheTimestamp(store2);
     Assert.assertEquals(stats.getMetadataStalenessHighWatermarkMs(), 400d);

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/stats/ServerMetricEntityTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/stats/ServerMetricEntityTest.java
@@ -22,7 +22,7 @@ import org.testng.annotations.Test;
 public class ServerMetricEntityTest {
   @Test
   public void testServerMetricEntitiesCount() {
-    assertEquals(SERVER_METRIC_ENTITIES.size(), 153, "Expected 153 unique metric entities");
+    assertEquals(SERVER_METRIC_ENTITIES.size(), 154, "Expected 154 unique metric entities");
   }
 
   /**

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/stats/ServerMetricEntityTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/stats/ServerMetricEntityTest.java
@@ -22,7 +22,7 @@ import org.testng.annotations.Test;
 public class ServerMetricEntityTest {
   @Test
   public void testServerMetricEntitiesCount() {
-    assertEquals(SERVER_METRIC_ENTITIES.size(), 156, "Expected 156 unique metric entities");
+    assertEquals(SERVER_METRIC_ENTITIES.size(), 157, "Expected 157 unique metric entities");
   }
 
   /**


### PR DESCRIPTION
## Problem Statement

`NativeMetadataRepositoryStats` has a single Tehuti AsyncGauge for metadata staleness (high watermark across all stores) but no OTel counterpart, making this metric unavailable in OTel-based monitoring dashboards.

## Solution

Add a per-store `ASYNC_DOUBLE_GAUGE` OTel metric `metadata.staleness_duration` with `STORE_NAME` dimension. Returns time in milliseconds since the store metadata was last fetched from the meta system store. Uses `DoubleSupplier` callback so removed stores return `Double.NaN` — the OTel SDK drops NaN data points entirely, so removed stores disappear from dashboards (no stale 0 values).

**Design:**
- Tehuti (unchanged): single high-watermark gauge — oldest staleness across all stores, returns `NaN` when empty
- OTel (new): per-store `ASYNC_DOUBLE_GAUGE` — backends can compute max at query time via aggregation
- Metric name `metadata.staleness_duration` matches the fast client's existing metric (different prefix: `venice.server.*` vs `venice.fast_client.*`)
- Per-store callbacks registered lazily in `computeIfAbsent` on first `updateCacheTimestamp` call, bounded by number of subscribed stores

###  Code changes
- [ ] Added new code behind **a config**.
- [ ] Introduced new **log lines**.
  - [ ] Confirmed if logs need to be **rate limited** to avoid excessive logging.

###  **Concurrency-Specific Checks**
Both reviewer and PR author to verify
- [x] Code has **no race conditions** or **thread safety issues**.
- [ ] Proper **synchronization mechanisms** (e.g., `synchronized`, `RWLock`) are used where needed.
- [ ] No **blocking calls** inside critical sections that could lead to deadlocks or performance degradation.
- [x] Verified **thread-safe collections** are used (e.g., `ConcurrentHashMap`, `CopyOnWriteArrayList`).
- [ ] Validated proper exception handling in multi-threaded code to avoid silent thread termination.

## How was this PR tested?

- [x] New unit tests added.
- [ ] New integration tests added.
- [ ] Modified or extended existing tests.
- [x] Verified backward compatibility (if applicable).

New tests:
- `NativeMetadataRepositoryStatsOtelTest` (7 tests): per-store staleness, clock advance, cache refresh, store removal (NaN → absent data point), multi-store isolation, NPE prevention with OTel disabled and plain MetricsRepository.
- `NativeMetadataRepositoryOtelMetricEntityTest`: metric entity validation.

## Does this PR introduce any user-facing or breaking changes?
- [x] No. You can skip the rest of this section.
- [ ] Yes. Clearly explain the behavior change and its impact.