### PR TITLE
[server] Add OTel metrics to DiskHealthStats

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/DiskHealthOtelMetricEntity.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/DiskHealthOtelMetricEntity.java
@@ -1,0 +1,38 @@
+package com.linkedin.davinci.stats;
+
+import static com.linkedin.venice.stats.dimensions.VeniceMetricsDimensions.VENICE_CLUSTER_NAME;
+import static com.linkedin.venice.utils.Utils.setOf;
+
+import com.linkedin.venice.stats.dimensions.VeniceMetricsDimensions;
+import com.linkedin.venice.stats.metrics.MetricEntity;
+import com.linkedin.venice.stats.metrics.MetricType;
+import com.linkedin.venice.stats.metrics.MetricUnit;
+import com.linkedin.venice.stats.metrics.ModuleMetricEntityInterface;
+import java.util.Set;
+
+
+/**
+ * OTel metric entity definitions for {@link com.linkedin.venice.stats.DiskHealthStats}.
+ */
+public enum DiskHealthOtelMetricEntity implements ModuleMetricEntityInterface {
+  DISK_HEALTH_STATUS(
+      "disk.health.status", MetricType.ASYNC_GAUGE, MetricUnit.NUMBER,
+      "Disk health status: 1 if healthy, 0 if unhealthy", setOf(VENICE_CLUSTER_NAME)
+  );
+
+  private final MetricEntity metricEntity;
+
+  DiskHealthOtelMetricEntity(
+      String metricName,
+      MetricType metricType,
+      MetricUnit unit,
+      String description,
+      Set<VeniceMetricsDimensions> dimensions) {
+    this.metricEntity = new MetricEntity(metricName, metricType, unit, description, dimensions);
+  }
+
+  @Override
+  public MetricEntity getMetricEntity() {
+    return metricEntity;
+  }
+}

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/ServerMetricEntity.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/ServerMetricEntity.java
@@ -43,7 +43,8 @@ public final class ServerMetricEntity {
         ServerReadQuotaOtelMetricEntity.class,
         ServerConnectionOtelMetricEntity.class,
         StoreBufferServiceOtelMetricEntity.class,
-        StorageEngineOtelMetricEntity.class);
+        StorageEngineOtelMetricEntity.class,
+        DiskHealthOtelMetricEntity.class);
   }
 
   public static final Collection<MetricEntity> SERVER_METRIC_ENTITIES =

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/stats/DiskHealthOtelMetricEntityTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/stats/DiskHealthOtelMetricEntityTest.java
@@ -1,0 +1,34 @@
+package com.linkedin.davinci.stats;
+
+import static com.linkedin.davinci.stats.DiskHealthOtelMetricEntity.DISK_HEALTH_STATUS;
+import static com.linkedin.venice.stats.dimensions.VeniceMetricsDimensions.VENICE_CLUSTER_NAME;
+import static com.linkedin.venice.utils.Utils.setOf;
+
+import com.linkedin.venice.stats.metrics.MetricType;
+import com.linkedin.venice.stats.metrics.MetricUnit;
+import com.linkedin.venice.stats.metrics.ModuleMetricEntityTestFixture;
+import com.linkedin.venice.stats.metrics.ModuleMetricEntityTestFixture.MetricEntityExpectation;
+import java.util.HashMap;
+import java.util.Map;
+import org.testng.annotations.Test;
+
+
+public class DiskHealthOtelMetricEntityTest {
+  @Test
+  public void testMetricEntities() {
+    new ModuleMetricEntityTestFixture<>(DiskHealthOtelMetricEntity.class, expectedDefinitions()).assertAll();
+  }
+
+  private static Map<DiskHealthOtelMetricEntity, MetricEntityExpectation> expectedDefinitions() {
+    Map<DiskHealthOtelMetricEntity, MetricEntityExpectation> map = new HashMap<>();
+    map.put(
+        DISK_HEALTH_STATUS,
+        new MetricEntityExpectation(
+            "disk.health.status",
+            MetricType.ASYNC_GAUGE,
+            MetricUnit.NUMBER,
+            "Disk health status: 1 if healthy, 0 if unhealthy",
+            setOf(VENICE_CLUSTER_NAME)));
+    return map;
+  }
+}

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/stats/ServerMetricEntityTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/stats/ServerMetricEntityTest.java
@@ -22,7 +22,7 @@ import org.testng.annotations.Test;
 public class ServerMetricEntityTest {
   @Test
   public void testServerMetricEntitiesCount() {
-    assertEquals(SERVER_METRIC_ENTITIES.size(), 153, "Expected 153 unique metric entities");
+    assertEquals(SERVER_METRIC_ENTITIES.size(), 154, "Expected 154 unique metric entities");
   }
 
   /**

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/stats/ServerMetricEntityTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/stats/ServerMetricEntityTest.java
@@ -22,7 +22,7 @@ import org.testng.annotations.Test;
 public class ServerMetricEntityTest {
   @Test
   public void testServerMetricEntitiesCount() {
-    assertEquals(SERVER_METRIC_ENTITIES.size(), 155, "Expected 155 unique metric entities");
+    assertEquals(SERVER_METRIC_ENTITIES.size(), 156, "Expected 156 unique metric entities");
   }
 
   /**

--- a/services/venice-server/src/main/java/com/linkedin/venice/server/VeniceServer.java
+++ b/services/venice-server/src/main/java/com/linkedin/venice/server/VeniceServer.java
@@ -442,7 +442,11 @@ public class VeniceServer {
         serverConfig.getLogContext());
     services.add(diskHealthCheckService);
     // create stats for disk health check service
-    new DiskHealthStats(metricsRepository, diskHealthCheckService, "disk_health_check_service");
+    new DiskHealthStats(
+        metricsRepository,
+        diskHealthCheckService,
+        "disk_health_check_service",
+        clusterConfig.getClusterName());
 
     final Optional<ResourceReadUsageTracker> resourceReadUsageTracker;
     if (serverConfig.isOptimizeDatabaseForBackupVersionEnabled()) {

--- a/services/venice-server/src/main/java/com/linkedin/venice/stats/DiskHealthStats.java
+++ b/services/venice-server/src/main/java/com/linkedin/venice/stats/DiskHealthStats.java
@@ -1,33 +1,50 @@
 package com.linkedin.venice.stats;
 
+import static com.linkedin.davinci.stats.DiskHealthOtelMetricEntity.DISK_HEALTH_STATUS;
+
 import com.linkedin.davinci.storage.DiskHealthCheckService;
+import com.linkedin.venice.stats.dimensions.VeniceMetricsDimensions;
+import com.linkedin.venice.stats.metrics.AsyncMetricEntityStateBase;
+import io.opentelemetry.api.common.Attributes;
 import io.tehuti.metrics.MetricsRepository;
-import io.tehuti.metrics.Sensor;
 import io.tehuti.metrics.stats.AsyncGauge;
+import java.util.Map;
+import java.util.function.LongSupplier;
 
 
 /**
- * {@code DiskHealthStats} measures the disk health conditions based on the periodic tests ran by the {@link DiskHealthCheckService}.
+ * {@code DiskHealthStats} measures the disk health conditions based on the periodic tests ran by
+ * the {@link DiskHealthCheckService}. Reports 1 if healthy, 0 if unhealthy.
+ *
+ * <p>Tehuti and OTel both poll the same {@link DiskHealthCheckService#isDiskHealthy()} method.
+ * They cannot share a single registration because Tehuti uses {@link AsyncGauge} (polled by
+ * Tehuti's async executor) while OTel uses {@link AsyncMetricEntityStateBase} (polled by the
+ * OTel SDK's PeriodicMetricReader).
  */
 public class DiskHealthStats extends AbstractVeniceStats {
-  private DiskHealthCheckService diskHealthCheckService;
-
-  private Sensor diskHealthSensor;
-
   public DiskHealthStats(
       MetricsRepository metricsRepository,
       DiskHealthCheckService diskHealthCheckService,
-      String name) {
+      String name,
+      String clusterName) {
     super(metricsRepository, name);
-    this.diskHealthCheckService = diskHealthCheckService;
 
-    diskHealthSensor = registerSensor(new AsyncGauge((ignored, ignored2) -> {
-      if (this.diskHealthCheckService.isDiskHealthy()) {
-        // report 1 if the disk in this host is healthy; otherwise, report 0.
-        return 1;
-      } else {
-        return 0;
-      }
-    }, "disk_healthy"));
+    // Shared callback: 1 = healthy, 0 = unhealthy
+    LongSupplier healthCallback = () -> diskHealthCheckService.isDiskHealthy() ? 1 : 0;
+
+    // Tehuti: AsyncGauge
+    registerSensor(new AsyncGauge((ignored, ignored2) -> healthCallback.getAsLong(), "disk_healthy"));
+
+    // OTel: ASYNC_GAUGE with CLUSTER_NAME
+    OpenTelemetryMetricsSetup.OpenTelemetryMetricsSetupInfo otelData =
+        OpenTelemetryMetricsSetup.builder(metricsRepository).setClusterName(clusterName).build();
+    Map<VeniceMetricsDimensions, String> baseDimensionsMap = otelData.getBaseDimensionsMap();
+    Attributes baseAttributes = otelData.getBaseAttributes();
+    AsyncMetricEntityStateBase.create(
+        DISK_HEALTH_STATUS.getMetricEntity(),
+        otelData.getOtelRepository(),
+        baseDimensionsMap,
+        baseAttributes,
+        healthCallback);
   }
 }

--- a/services/venice-server/src/main/java/com/linkedin/venice/stats/DiskHealthStats.java
+++ b/services/venice-server/src/main/java/com/linkedin/venice/stats/DiskHealthStats.java
@@ -5,9 +5,11 @@ import static com.linkedin.davinci.stats.DiskHealthOtelMetricEntity.DISK_HEALTH_
 import com.linkedin.davinci.storage.DiskHealthCheckService;
 import com.linkedin.venice.stats.dimensions.VeniceMetricsDimensions;
 import com.linkedin.venice.stats.metrics.AsyncMetricEntityStateBase;
+import com.linkedin.venice.stats.metrics.TehutiMetricNameEnum;
 import io.opentelemetry.api.common.Attributes;
 import io.tehuti.metrics.MetricsRepository;
 import io.tehuti.metrics.stats.AsyncGauge;
+import java.util.Collections;
 import java.util.Map;
 import java.util.function.LongSupplier;
 
@@ -16,12 +18,16 @@ import java.util.function.LongSupplier;
  * {@code DiskHealthStats} measures the disk health conditions based on the periodic tests ran by
  * the {@link DiskHealthCheckService}. Reports 1 if healthy, 0 if unhealthy.
  *
- * <p>Tehuti and OTel both poll the same {@link DiskHealthCheckService#isDiskHealthy()} method.
- * They cannot share a single registration because Tehuti uses {@link AsyncGauge} (polled by
- * Tehuti's async executor) while OTel uses {@link AsyncMetricEntityStateBase} (polled by the
- * OTel SDK's PeriodicMetricReader).
+ * <p>Uses the joint Tehuti+OTel API: a single {@link AsyncMetricEntityStateBase} registration
+ * binds both the Tehuti {@link AsyncGauge} and the OTel ASYNC_GAUGE to the same
+ * {@link DiskHealthCheckService#isDiskHealthy()} callback.
  */
 public class DiskHealthStats extends AbstractVeniceStats {
+  /** Tehuti metric name for the disk health sensor. */
+  enum TehutiMetricName implements TehutiMetricNameEnum {
+    DISK_HEALTHY
+  }
+
   public DiskHealthStats(
       MetricsRepository metricsRepository,
       DiskHealthCheckService diskHealthCheckService,
@@ -29,20 +35,19 @@ public class DiskHealthStats extends AbstractVeniceStats {
       String clusterName) {
     super(metricsRepository, name);
 
-    // Shared callback: 1 = healthy, 0 = unhealthy
-    LongSupplier healthCallback = () -> diskHealthCheckService.isDiskHealthy() ? 1 : 0;
-
-    // Tehuti: AsyncGauge
-    registerSensor(new AsyncGauge((ignored, ignored2) -> healthCallback.getAsLong(), "disk_healthy"));
-
-    // OTel: ASYNC_GAUGE with CLUSTER_NAME
     OpenTelemetryMetricsSetup.OpenTelemetryMetricsSetupInfo otelData =
         OpenTelemetryMetricsSetup.builder(metricsRepository).setClusterName(clusterName).build();
     Map<VeniceMetricsDimensions, String> baseDimensionsMap = otelData.getBaseDimensionsMap();
     Attributes baseAttributes = otelData.getBaseAttributes();
+
+    LongSupplier healthCallback = () -> diskHealthCheckService.isDiskHealthy() ? 1 : 0;
     AsyncMetricEntityStateBase.create(
         DISK_HEALTH_STATUS.getMetricEntity(),
         otelData.getOtelRepository(),
+        this::registerSensorIfAbsent,
+        TehutiMetricName.DISK_HEALTHY,
+        Collections.singletonList(
+            new AsyncGauge((ig, ig2) -> healthCallback.getAsLong(), TehutiMetricName.DISK_HEALTHY.getMetricName())),
         baseDimensionsMap,
         baseAttributes,
         healthCallback);

--- a/services/venice-server/src/test/java/com/linkedin/venice/stats/DiskHealthStatsTest.java
+++ b/services/venice-server/src/test/java/com/linkedin/venice/stats/DiskHealthStatsTest.java
@@ -1,0 +1,91 @@
+package com.linkedin.venice.stats;
+
+import static com.linkedin.davinci.stats.DiskHealthOtelMetricEntity.DISK_HEALTH_STATUS;
+import static com.linkedin.davinci.stats.ServerMetricEntity.SERVER_METRIC_ENTITIES;
+import static com.linkedin.venice.stats.dimensions.VeniceMetricsDimensions.VENICE_CLUSTER_NAME;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+
+import com.linkedin.davinci.storage.DiskHealthCheckService;
+import com.linkedin.venice.utils.OpenTelemetryDataTestUtils;
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.sdk.testing.exporter.InMemoryMetricReader;
+import io.tehuti.metrics.MetricsRepository;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+
+public class DiskHealthStatsTest {
+  private static final String TEST_METRIC_PREFIX = "server";
+  private static final String TEST_CLUSTER_NAME = "test-cluster";
+  private static final String METRIC_NAME = DISK_HEALTH_STATUS.getMetricEntity().getMetricName();
+
+  private InMemoryMetricReader inMemoryMetricReader;
+  private VeniceMetricsRepository metricsRepository;
+  private DiskHealthCheckService mockService;
+
+  @BeforeMethod
+  public void setUp() {
+    inMemoryMetricReader = InMemoryMetricReader.create();
+    metricsRepository = new VeniceMetricsRepository(
+        new VeniceMetricsConfig.Builder().setMetricPrefix(TEST_METRIC_PREFIX)
+            .setMetricEntities(SERVER_METRIC_ENTITIES)
+            .setEmitOtelMetrics(true)
+            .setOtelAdditionalMetricsReader(inMemoryMetricReader)
+            .build());
+    mockService = mock(DiskHealthCheckService.class);
+    doReturn(true).when(mockService).isDiskHealthy();
+    new DiskHealthStats(metricsRepository, mockService, "disk_health", TEST_CLUSTER_NAME);
+  }
+
+  @AfterMethod
+  public void tearDown() {
+    if (metricsRepository != null) {
+      metricsRepository.close();
+    }
+  }
+
+  @Test
+  public void testHealthyDiskReportsOne() {
+    OpenTelemetryDataTestUtils
+        .validateLongPointDataFromGauge(inMemoryMetricReader, 1, buildAttributes(), METRIC_NAME, TEST_METRIC_PREFIX);
+  }
+
+  @Test
+  public void testUnhealthyDiskReportsZero() {
+    doReturn(false).when(mockService).isDiskHealthy();
+
+    OpenTelemetryDataTestUtils
+        .validateLongPointDataFromGauge(inMemoryMetricReader, 0, buildAttributes(), METRIC_NAME, TEST_METRIC_PREFIX);
+  }
+
+  @Test
+  public void testGaugeUpdatesOnHealthChange() {
+    OpenTelemetryDataTestUtils
+        .validateLongPointDataFromGauge(inMemoryMetricReader, 1, buildAttributes(), METRIC_NAME, TEST_METRIC_PREFIX);
+
+    // Disk becomes unhealthy
+    doReturn(false).when(mockService).isDiskHealthy();
+
+    OpenTelemetryDataTestUtils
+        .validateLongPointDataFromGauge(inMemoryMetricReader, 0, buildAttributes(), METRIC_NAME, TEST_METRIC_PREFIX);
+  }
+
+  @Test
+  public void testNoNpeWhenOtelDisabled() {
+    try (VeniceMetricsRepository disabledRepo = new VeniceMetricsRepository(
+        new VeniceMetricsConfig.Builder().setMetricPrefix(TEST_METRIC_PREFIX).setEmitOtelMetrics(false).build())) {
+      new DiskHealthStats(disabledRepo, mockService, "disk_health", TEST_CLUSTER_NAME);
+    }
+  }
+
+  @Test
+  public void testNoNpeWhenPlainMetricsRepository() {
+    new DiskHealthStats(new MetricsRepository(), mockService, "disk_health", TEST_CLUSTER_NAME);
+  }
+
+  private static Attributes buildAttributes() {
+    return Attributes.builder().put(VENICE_CLUSTER_NAME.getDimensionNameInDefaultFormat(), TEST_CLUSTER_NAME).build();
+  }
+}

--- a/services/venice-server/src/test/java/com/linkedin/venice/stats/DiskHealthStatsTest.java
+++ b/services/venice-server/src/test/java/com/linkedin/venice/stats/DiskHealthStatsTest.java
@@ -5,12 +5,15 @@ import static com.linkedin.davinci.stats.ServerMetricEntity.SERVER_METRIC_ENTITI
 import static com.linkedin.venice.stats.dimensions.VeniceMetricsDimensions.VENICE_CLUSTER_NAME;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
+import static org.testng.Assert.assertEquals;
 
 import com.linkedin.davinci.storage.DiskHealthCheckService;
 import com.linkedin.venice.utils.OpenTelemetryDataTestUtils;
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.sdk.testing.exporter.InMemoryMetricReader;
+import io.tehuti.metrics.MetricConfig;
 import io.tehuti.metrics.MetricsRepository;
+import io.tehuti.metrics.stats.AsyncGauge;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
@@ -19,29 +22,40 @@ import org.testng.annotations.Test;
 public class DiskHealthStatsTest {
   private static final String TEST_METRIC_PREFIX = "server";
   private static final String TEST_CLUSTER_NAME = "test-cluster";
+  private static final String STATS_NAME = "disk_health";
   private static final String METRIC_NAME = DISK_HEALTH_STATUS.getMetricEntity().getMetricName();
+  /** Tehuti metric path: .{statsName}--{tehutiMetricName}.{StatTypeSuffix}. */
+  private static final String TEHUTI_DISK_HEALTHY = "." + STATS_NAME + "--disk_healthy.Gauge";
 
   private InMemoryMetricReader inMemoryMetricReader;
   private VeniceMetricsRepository metricsRepository;
+  // Dedicated AsyncGauge executor: another test class calling MetricsRepository.close()
+  // in the same JVM shuts down the static default executor, which would make
+  // AsyncGauge.measure() return 0.0 in this test forever.
+  private AsyncGauge.AsyncGaugeExecutor asyncGaugeExecutor;
   private DiskHealthCheckService mockService;
 
   @BeforeMethod
   public void setUp() {
     inMemoryMetricReader = InMemoryMetricReader.create();
+    asyncGaugeExecutor = new AsyncGauge.AsyncGaugeExecutor.Builder().build();
     metricsRepository = new VeniceMetricsRepository(
         new VeniceMetricsConfig.Builder().setMetricPrefix(TEST_METRIC_PREFIX)
             .setMetricEntities(SERVER_METRIC_ENTITIES)
             .setEmitOtelMetrics(true)
             .setOtelAdditionalMetricsReader(inMemoryMetricReader)
+            .setTehutiMetricConfig(new MetricConfig(asyncGaugeExecutor))
             .build());
     mockService = mock(DiskHealthCheckService.class);
     doReturn(true).when(mockService).isDiskHealthy();
-    new DiskHealthStats(metricsRepository, mockService, "disk_health", TEST_CLUSTER_NAME);
+    new DiskHealthStats(metricsRepository, mockService, STATS_NAME, TEST_CLUSTER_NAME);
   }
 
   @AfterMethod
   public void tearDown() {
     if (metricsRepository != null) {
+      // Closes the dedicated executor we injected via setTehutiMetricConfig — does NOT touch
+      // the static AsyncGauge.DEFAULT_ASYNC_GAUGE_EXECUTOR shared with other test classes.
       metricsRepository.close();
     }
   }
@@ -73,16 +87,30 @@ public class DiskHealthStatsTest {
   }
 
   @Test
+  public void testTehutiSensorReportsHealth() {
+    // Joint Tehuti+OTel API regression: ensures the Tehuti AsyncGauge binding stays wired so a
+    // future refactor can't accidentally drop the Tehuti side and only leave OTel emitting.
+    assertEquals(metricsRepository.getMetric(TEHUTI_DISK_HEALTHY).value(), 1.0);
+
+    doReturn(false).when(mockService).isDiskHealthy();
+    assertEquals(metricsRepository.getMetric(TEHUTI_DISK_HEALTHY).value(), 0.0);
+  }
+
+  @Test
   public void testNoNpeWhenOtelDisabled() {
+    AsyncGauge.AsyncGaugeExecutor dedicatedExecutor = new AsyncGauge.AsyncGaugeExecutor.Builder().build();
     try (VeniceMetricsRepository disabledRepo = new VeniceMetricsRepository(
-        new VeniceMetricsConfig.Builder().setMetricPrefix(TEST_METRIC_PREFIX).setEmitOtelMetrics(false).build())) {
-      new DiskHealthStats(disabledRepo, mockService, "disk_health", TEST_CLUSTER_NAME);
+        new VeniceMetricsConfig.Builder().setMetricPrefix(TEST_METRIC_PREFIX)
+            .setEmitOtelMetrics(false)
+            .setTehutiMetricConfig(new MetricConfig(dedicatedExecutor))
+            .build())) {
+      new DiskHealthStats(disabledRepo, mockService, STATS_NAME, TEST_CLUSTER_NAME);
     }
   }
 
   @Test
   public void testNoNpeWhenPlainMetricsRepository() {
-    new DiskHealthStats(new MetricsRepository(), mockService, "disk_health", TEST_CLUSTER_NAME);
+    new DiskHealthStats(new MetricsRepository(), mockService, STATS_NAME, TEST_CLUSTER_NAME);
   }
 
   private static Attributes buildAttributes() {


### PR DESCRIPTION
## Problem Statement

`DiskHealthStats` has a single Tehuti AsyncGauge for disk health (1=healthy, 0=unhealthy) but no OTel counterpart, making this metric unavailable in OTel-based monitoring dashboards.

## Solution

Add 1 OTel ASYNC_GAUGE metric `disk.health.status` with `CLUSTER_NAME` dimension. Reports 1 if disk is healthy, 0 if unhealthy — same semantics as the Tehuti sensor.

Uses the joint Tehuti+OTel API (`AsyncMetricEntityStateBase.create()`) — a single registration binds both the Tehuti `AsyncGauge` and the OTel ASYNC_GAUGE to the same `DiskHealthCheckService.isDiskHealthy()` callback. The two systems are still polled by separate executors at runtime (Tehuti's async executor vs OTel's `PeriodicMetricReader`), but registration and the callback are shared. `clusterName` added to the constructor, passed from `VeniceServer`.

###  Code changes
- [ ] Added new code behind **a config**.
- [ ] Introduced new **log lines**.
  - [ ] Confirmed if logs need to be **rate limited** to avoid excessive logging.

###  **Concurrency-Specific Checks**
Both reviewer and PR author to verify
- [x] Code has **no race conditions** or **thread safety issues**.
- [ ] Proper **synchronization mechanisms** (e.g., `synchronized`, `RWLock`) are used where needed.
- [ ] No **blocking calls** inside critical sections that could lead to deadlocks or performance degradation.
- [ ] Verified **thread-safe collections** are used (e.g., `ConcurrentHashMap`, `CopyOnWriteArrayList`).
- [ ] Validated proper exception handling in multi-threaded code to avoid silent thread termination.

## How was this PR tested?

- [x] New unit tests added.
- [ ] New integration tests added.
- [ ] Modified or extended existing tests.
- [x] Verified backward compatibility (if applicable).

New tests:
- `DiskHealthStatsTest` (6 tests): healthy=1, unhealthy=0, live health change, Tehuti sensor regression (locks in that the joint API keeps the Tehuti AsyncGauge binding wired), NPE prevention with OTel disabled and plain MetricsRepository.
- `DiskHealthOtelMetricEntityTest`: metric entity validation.

## Does this PR introduce any user-facing or breaking changes?
- [x] No. You can skip the rest of this section.
- [ ] Yes. Clearly explain the behavior change and its impact.
