### PR TITLE
[server] Add OTel metrics to RocksDBStats

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/RocksDBStatsOtelMetricEntity.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/RocksDBStatsOtelMetricEntity.java
@@ -59,12 +59,12 @@ public enum RocksDBStatsOtelMetricEntity implements ModuleMetricEntityInterface 
   ),
 
   BLOCK_CACHE_READ_BYTES(
-      "rocksdb.block_cache.read.bytes", MetricUnit.BYTES, "Bytes served from block cache on hits",
+      "rocksdb.block_cache.bytes.read", MetricUnit.BYTES, "Bytes served from block cache on hits",
       setOf(VENICE_CLUSTER_NAME)
   ),
 
   BLOCK_CACHE_WRITE_BYTES(
-      "rocksdb.block_cache.write.bytes", MetricUnit.BYTES, "Bytes inserted into block cache on misses",
+      "rocksdb.block_cache.bytes.written", MetricUnit.BYTES, "Bytes written into block cache on misses",
       setOf(VENICE_CLUSTER_NAME)
   ),
 

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/RocksDBStatsOtelMetricEntity.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/RocksDBStatsOtelMetricEntity.java
@@ -1,0 +1,129 @@
+package com.linkedin.davinci.stats;
+
+import static com.linkedin.venice.stats.dimensions.VeniceMetricsDimensions.VENICE_CLUSTER_NAME;
+import static com.linkedin.venice.stats.dimensions.VeniceMetricsDimensions.VENICE_ROCKSDB_BLOCK_CACHE_COMPONENT;
+import static com.linkedin.venice.stats.dimensions.VeniceMetricsDimensions.VENICE_ROCKSDB_LEVEL;
+import static com.linkedin.venice.utils.Utils.setOf;
+
+import com.linkedin.venice.stats.dimensions.VeniceMetricsDimensions;
+import com.linkedin.venice.stats.metrics.MetricEntity;
+import com.linkedin.venice.stats.metrics.MetricType;
+import com.linkedin.venice.stats.metrics.MetricUnit;
+import com.linkedin.venice.stats.metrics.ModuleMetricEntityInterface;
+import java.util.Set;
+
+
+/**
+ * OTel metric entity definitions for {@link com.linkedin.venice.stats.RocksDBStats}.
+ *
+ * <p>Per-component block cache metrics (index, filter, data, compression_dict) are consolidated
+ * into single metrics with a {@code VENICE_ROCKSDB_BLOCK_CACHE_COMPONENT} dimension. Overall
+ * block cache miss/hit/add counters are Tehuti-only — OTel derives totals via
+ * {@code sum by (component)}. Overall-only counters without per-component equivalents
+ * (add failures, bytes read/write) are emitted as joint Tehuti+OTel.
+ *
+ * <p>Get-hit-by-level metrics are consolidated into {@link #GET_HIT_COUNT} with a
+ * {@code VENICE_ROCKSDB_LEVEL} dimension.
+ *
+ * <p>Block cache hit ratio is Tehuti-only (derivable from existing OTel gauge metrics).
+ *
+ * @see com.linkedin.venice.stats.dimensions.VeniceRocksDBBlockCacheComponent
+ * @see com.linkedin.venice.stats.dimensions.VeniceRocksDBLevel
+ */
+public enum RocksDBStatsOtelMetricEntity implements ModuleMetricEntityInterface {
+  // Block Cache — per-component (COMPONENT dimension: INDEX/FILTER/DATA/COMPRESSION_DICT)
+  BLOCK_CACHE_MISS_COUNT(
+      "rocksdb.block_cache.miss.count", MetricUnit.NUMBER, "Block cache misses by component",
+      setOf(VENICE_CLUSTER_NAME, VENICE_ROCKSDB_BLOCK_CACHE_COMPONENT)
+  ),
+
+  BLOCK_CACHE_HIT_COUNT(
+      "rocksdb.block_cache.hit.count", MetricUnit.NUMBER, "Block cache hits by component",
+      setOf(VENICE_CLUSTER_NAME, VENICE_ROCKSDB_BLOCK_CACHE_COMPONENT)
+  ),
+
+  BLOCK_CACHE_ADD_COUNT(
+      "rocksdb.block_cache.add.count", MetricUnit.NUMBER, "Blocks added to cache by component",
+      setOf(VENICE_CLUSTER_NAME, VENICE_ROCKSDB_BLOCK_CACHE_COMPONENT)
+  ),
+
+  BLOCK_CACHE_BYTES_INSERTED(
+      "rocksdb.block_cache.bytes.inserted", MetricUnit.BYTES, "Bytes inserted into cache by component",
+      setOf(VENICE_CLUSTER_NAME, VENICE_ROCKSDB_BLOCK_CACHE_COMPONENT)
+  ),
+
+  // Block Cache — overall (no per-component breakdown available)
+  BLOCK_CACHE_ADD_FAILURE_COUNT(
+      "rocksdb.block_cache.add.failure.count", MetricUnit.NUMBER, "Failed attempts to add blocks to cache",
+      setOf(VENICE_CLUSTER_NAME)
+  ),
+
+  BLOCK_CACHE_READ_BYTES(
+      "rocksdb.block_cache.read.bytes", MetricUnit.BYTES, "Bytes served from block cache on hits",
+      setOf(VENICE_CLUSTER_NAME)
+  ),
+
+  BLOCK_CACHE_WRITE_BYTES(
+      "rocksdb.block_cache.write.bytes", MetricUnit.BYTES, "Bytes inserted into block cache on misses",
+      setOf(VENICE_CLUSTER_NAME)
+  ),
+
+  // Bloom Filter
+  BLOOM_FILTER_USEFUL_COUNT(
+      "rocksdb.bloom_filter.useful_count", MetricUnit.NUMBER, "Bloom filter checks that avoided a disk read",
+      setOf(VENICE_CLUSTER_NAME)
+  ),
+
+  // Memtable
+  MEMTABLE_HIT_COUNT(
+      "rocksdb.memtable.hit.count", MetricUnit.NUMBER, "Get requests served from memtable", setOf(VENICE_CLUSTER_NAME)
+  ),
+
+  MEMTABLE_MISS_COUNT(
+      "rocksdb.memtable.miss.count", MetricUnit.NUMBER, "Get requests not found in memtable", setOf(VENICE_CLUSTER_NAME)
+  ),
+
+  // Get Hit by Level (LEVEL dimension: LEVEL_0/LEVEL_1/LEVEL_2_AND_UP)
+  GET_HIT_COUNT(
+      "rocksdb.get.hit.count", MetricUnit.NUMBER, "Get requests served from SST files by level",
+      setOf(VENICE_CLUSTER_NAME, VENICE_ROCKSDB_LEVEL)
+  ),
+
+  // Compaction
+  COMPACTION_CANCELLED_COUNT(
+      "rocksdb.compaction.cancelled_count", MetricUnit.NUMBER, "Compactions cancelled", setOf(VENICE_CLUSTER_NAME)
+  ),
+
+  // Computed Ratio
+  READ_AMPLIFICATION_FACTOR(
+      "rocksdb.read_amplification_factor", MetricType.ASYNC_DOUBLE_GAUGE, MetricUnit.RATIO,
+      "Read amplification — ratio of total bytes read to useful bytes. Values > 1.0 indicate amplification",
+      setOf(VENICE_CLUSTER_NAME)
+  );
+
+  private final MetricEntity metricEntity;
+
+  /** Constructor for ASYNC_GAUGE metrics (default type). */
+  RocksDBStatsOtelMetricEntity(
+      String metricName,
+      MetricUnit unit,
+      String description,
+      Set<VeniceMetricsDimensions> dimensions) {
+    this(metricName, MetricType.ASYNC_GAUGE, unit, description, dimensions);
+  }
+
+  /** Constructor with explicit MetricType. */
+  RocksDBStatsOtelMetricEntity(
+      String metricName,
+      MetricType metricType,
+      MetricUnit unit,
+      String description,
+      Set<VeniceMetricsDimensions> dimensions) {
+    this.metricEntity = new MetricEntity(metricName, metricType, unit, description, dimensions);
+  }
+
+  @Override
+  public MetricEntity getMetricEntity() {
+    return metricEntity;
+  }
+}

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/ServerMetricEntity.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/ServerMetricEntity.java
@@ -43,7 +43,8 @@ public final class ServerMetricEntity {
         ServerReadQuotaOtelMetricEntity.class,
         ServerConnectionOtelMetricEntity.class,
         StoreBufferServiceOtelMetricEntity.class,
-        StorageEngineOtelMetricEntity.class);
+        StorageEngineOtelMetricEntity.class,
+        RocksDBStatsOtelMetricEntity.class);
   }
 
   public static final Collection<MetricEntity> SERVER_METRIC_ENTITIES =

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/ServerMetricEntity.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/ServerMetricEntity.java
@@ -44,7 +44,8 @@ public final class ServerMetricEntity {
         ServerConnectionOtelMetricEntity.class,
         StoreBufferServiceOtelMetricEntity.class,
         StorageEngineOtelMetricEntity.class,
-        DiskHealthOtelMetricEntity.class);
+        DiskHealthOtelMetricEntity.class,
+        RocksDBStatsOtelMetricEntity.class);
   }
 
   public static final Collection<MetricEntity> SERVER_METRIC_ENTITIES =

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/stats/RocksDBStatsOtelMetricEntityTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/stats/RocksDBStatsOtelMetricEntityTest.java
@@ -69,7 +69,7 @@ public class RocksDBStatsOtelMetricEntityTest {
     map.put(
         RocksDBStatsOtelMetricEntity.BLOCK_CACHE_READ_BYTES,
         new MetricEntityExpectation(
-            "rocksdb.block_cache.read.bytes",
+            "rocksdb.block_cache.bytes.read",
             MetricType.ASYNC_GAUGE,
             MetricUnit.BYTES,
             "Bytes served from block cache on hits",
@@ -77,10 +77,10 @@ public class RocksDBStatsOtelMetricEntityTest {
     map.put(
         RocksDBStatsOtelMetricEntity.BLOCK_CACHE_WRITE_BYTES,
         new MetricEntityExpectation(
-            "rocksdb.block_cache.write.bytes",
+            "rocksdb.block_cache.bytes.written",
             MetricType.ASYNC_GAUGE,
             MetricUnit.BYTES,
-            "Bytes inserted into block cache on misses",
+            "Bytes written into block cache on misses",
             setOf(VENICE_CLUSTER_NAME)));
 
     // Bloom Filter, Memtable, Compaction

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/stats/RocksDBStatsOtelMetricEntityTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/stats/RocksDBStatsOtelMetricEntityTest.java
@@ -1,0 +1,142 @@
+package com.linkedin.davinci.stats;
+
+import static com.linkedin.venice.stats.dimensions.VeniceMetricsDimensions.VENICE_CLUSTER_NAME;
+import static com.linkedin.venice.stats.dimensions.VeniceMetricsDimensions.VENICE_ROCKSDB_BLOCK_CACHE_COMPONENT;
+import static com.linkedin.venice.stats.dimensions.VeniceMetricsDimensions.VENICE_ROCKSDB_LEVEL;
+import static com.linkedin.venice.utils.Utils.setOf;
+
+import com.linkedin.venice.stats.metrics.MetricType;
+import com.linkedin.venice.stats.metrics.MetricUnit;
+import com.linkedin.venice.stats.metrics.ModuleMetricEntityTestFixture;
+import com.linkedin.venice.stats.metrics.ModuleMetricEntityTestFixture.MetricEntityExpectation;
+import java.util.HashMap;
+import java.util.Map;
+import org.testng.annotations.Test;
+
+
+public class RocksDBStatsOtelMetricEntityTest {
+  @Test
+  public void testMetricEntities() {
+    new ModuleMetricEntityTestFixture<>(RocksDBStatsOtelMetricEntity.class, expectedDefinitions()).assertAll();
+  }
+
+  private static Map<RocksDBStatsOtelMetricEntity, MetricEntityExpectation> expectedDefinitions() {
+    Map<RocksDBStatsOtelMetricEntity, MetricEntityExpectation> map = new HashMap<>();
+
+    // Block Cache — per-component (COMPONENT dimension)
+    map.put(
+        RocksDBStatsOtelMetricEntity.BLOCK_CACHE_MISS_COUNT,
+        new MetricEntityExpectation(
+            "rocksdb.block_cache.miss.count",
+            MetricType.ASYNC_GAUGE,
+            MetricUnit.NUMBER,
+            "Block cache misses by component",
+            setOf(VENICE_CLUSTER_NAME, VENICE_ROCKSDB_BLOCK_CACHE_COMPONENT)));
+    map.put(
+        RocksDBStatsOtelMetricEntity.BLOCK_CACHE_HIT_COUNT,
+        new MetricEntityExpectation(
+            "rocksdb.block_cache.hit.count",
+            MetricType.ASYNC_GAUGE,
+            MetricUnit.NUMBER,
+            "Block cache hits by component",
+            setOf(VENICE_CLUSTER_NAME, VENICE_ROCKSDB_BLOCK_CACHE_COMPONENT)));
+    map.put(
+        RocksDBStatsOtelMetricEntity.BLOCK_CACHE_ADD_COUNT,
+        new MetricEntityExpectation(
+            "rocksdb.block_cache.add.count",
+            MetricType.ASYNC_GAUGE,
+            MetricUnit.NUMBER,
+            "Blocks added to cache by component",
+            setOf(VENICE_CLUSTER_NAME, VENICE_ROCKSDB_BLOCK_CACHE_COMPONENT)));
+    map.put(
+        RocksDBStatsOtelMetricEntity.BLOCK_CACHE_BYTES_INSERTED,
+        new MetricEntityExpectation(
+            "rocksdb.block_cache.bytes.inserted",
+            MetricType.ASYNC_GAUGE,
+            MetricUnit.BYTES,
+            "Bytes inserted into cache by component",
+            setOf(VENICE_CLUSTER_NAME, VENICE_ROCKSDB_BLOCK_CACHE_COMPONENT)));
+
+    // Block Cache — overall (no per-component breakdown)
+    map.put(
+        RocksDBStatsOtelMetricEntity.BLOCK_CACHE_ADD_FAILURE_COUNT,
+        new MetricEntityExpectation(
+            "rocksdb.block_cache.add.failure.count",
+            MetricType.ASYNC_GAUGE,
+            MetricUnit.NUMBER,
+            "Failed attempts to add blocks to cache",
+            setOf(VENICE_CLUSTER_NAME)));
+    map.put(
+        RocksDBStatsOtelMetricEntity.BLOCK_CACHE_READ_BYTES,
+        new MetricEntityExpectation(
+            "rocksdb.block_cache.read.bytes",
+            MetricType.ASYNC_GAUGE,
+            MetricUnit.BYTES,
+            "Bytes served from block cache on hits",
+            setOf(VENICE_CLUSTER_NAME)));
+    map.put(
+        RocksDBStatsOtelMetricEntity.BLOCK_CACHE_WRITE_BYTES,
+        new MetricEntityExpectation(
+            "rocksdb.block_cache.write.bytes",
+            MetricType.ASYNC_GAUGE,
+            MetricUnit.BYTES,
+            "Bytes inserted into block cache on misses",
+            setOf(VENICE_CLUSTER_NAME)));
+
+    // Bloom Filter, Memtable, Compaction
+    map.put(
+        RocksDBStatsOtelMetricEntity.BLOOM_FILTER_USEFUL_COUNT,
+        new MetricEntityExpectation(
+            "rocksdb.bloom_filter.useful_count",
+            MetricType.ASYNC_GAUGE,
+            MetricUnit.NUMBER,
+            "Bloom filter checks that avoided a disk read",
+            setOf(VENICE_CLUSTER_NAME)));
+    map.put(
+        RocksDBStatsOtelMetricEntity.MEMTABLE_HIT_COUNT,
+        new MetricEntityExpectation(
+            "rocksdb.memtable.hit.count",
+            MetricType.ASYNC_GAUGE,
+            MetricUnit.NUMBER,
+            "Get requests served from memtable",
+            setOf(VENICE_CLUSTER_NAME)));
+    map.put(
+        RocksDBStatsOtelMetricEntity.MEMTABLE_MISS_COUNT,
+        new MetricEntityExpectation(
+            "rocksdb.memtable.miss.count",
+            MetricType.ASYNC_GAUGE,
+            MetricUnit.NUMBER,
+            "Get requests not found in memtable",
+            setOf(VENICE_CLUSTER_NAME)));
+    map.put(
+        RocksDBStatsOtelMetricEntity.COMPACTION_CANCELLED_COUNT,
+        new MetricEntityExpectation(
+            "rocksdb.compaction.cancelled_count",
+            MetricType.ASYNC_GAUGE,
+            MetricUnit.NUMBER,
+            "Compactions cancelled",
+            setOf(VENICE_CLUSTER_NAME)));
+
+    // Get Hit by Level (SST_LEVEL dimension)
+    map.put(
+        RocksDBStatsOtelMetricEntity.GET_HIT_COUNT,
+        new MetricEntityExpectation(
+            "rocksdb.get.hit.count",
+            MetricType.ASYNC_GAUGE,
+            MetricUnit.NUMBER,
+            "Get requests served from SST files by level",
+            setOf(VENICE_CLUSTER_NAME, VENICE_ROCKSDB_LEVEL)));
+
+    // Computed Ratio
+    map.put(
+        RocksDBStatsOtelMetricEntity.READ_AMPLIFICATION_FACTOR,
+        new MetricEntityExpectation(
+            "rocksdb.read_amplification_factor",
+            MetricType.ASYNC_DOUBLE_GAUGE,
+            MetricUnit.RATIO,
+            "Read amplification — ratio of total bytes read to useful bytes. Values > 1.0 indicate amplification",
+            setOf(VENICE_CLUSTER_NAME)));
+
+    return map;
+  }
+}

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/stats/ServerMetricEntityTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/stats/ServerMetricEntityTest.java
@@ -22,7 +22,7 @@ import org.testng.annotations.Test;
 public class ServerMetricEntityTest {
   @Test
   public void testServerMetricEntitiesCount() {
-    assertEquals(SERVER_METRIC_ENTITIES.size(), 153, "Expected 153 unique metric entities");
+    assertEquals(SERVER_METRIC_ENTITIES.size(), 166, "Expected 166 unique metric entities");
   }
 
   /**

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/stats/ServerMetricEntityTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/stats/ServerMetricEntityTest.java
@@ -22,7 +22,7 @@ import org.testng.annotations.Test;
 public class ServerMetricEntityTest {
   @Test
   public void testServerMetricEntitiesCount() {
-    assertEquals(SERVER_METRIC_ENTITIES.size(), 156, "Expected 156 unique metric entities");
+    assertEquals(SERVER_METRIC_ENTITIES.size(), 168, "Expected 168 unique metric entities");
   }
 
   /**

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/stats/ServerMetricEntityTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/stats/ServerMetricEntityTest.java
@@ -22,7 +22,7 @@ import org.testng.annotations.Test;
 public class ServerMetricEntityTest {
   @Test
   public void testServerMetricEntitiesCount() {
-    assertEquals(SERVER_METRIC_ENTITIES.size(), 168, "Expected 168 unique metric entities");
+    assertEquals(SERVER_METRIC_ENTITIES.size(), 169, "Expected 169 unique metric entities");
   }
 
   /**

--- a/internal/venice-client-common/src/main/java/com/linkedin/venice/stats/dimensions/VeniceMetricsDimensions.java
+++ b/internal/venice-client-common/src/main/java/com/linkedin/venice/stats/dimensions/VeniceMetricsDimensions.java
@@ -153,7 +153,13 @@ public enum VeniceMetricsDimensions {
   VENICE_CONNECTION_SOURCE("venice.connection.source"),
 
   /** {@link VeniceDrainerType} Drainer type: sorted or unsorted. */
-  VENICE_DRAINER_TYPE("venice.drainer.type");
+  VENICE_DRAINER_TYPE("venice.drainer.type"),
+
+  /** {@link VeniceRocksDBLevel} RocksDB level where a Get was served from. */
+  VENICE_ROCKSDB_LEVEL("venice.rocksdb.level"),
+
+  /** {@link VeniceRocksDBBlockCacheComponent} RocksDB block cache component type. */
+  VENICE_ROCKSDB_BLOCK_CACHE_COMPONENT("venice.rocksdb.block_cache_component");
 
   private final String[] dimensionName = new String[VeniceOpenTelemetryMetricNamingFormat.SIZE];
 

--- a/internal/venice-client-common/src/main/java/com/linkedin/venice/stats/dimensions/VeniceMetricsDimensions.java
+++ b/internal/venice-client-common/src/main/java/com/linkedin/venice/stats/dimensions/VeniceMetricsDimensions.java
@@ -159,7 +159,13 @@ public enum VeniceMetricsDimensions {
   VENICE_REQUEST_KEY_COUNT_BUCKET("venice.request.key_count_bucket"),
 
   /** Name of the metric being recorded; used for per-metric attribution on internal failure counters. */
-  VENICE_METRIC_NAME("venice.metric.name");
+  VENICE_METRIC_NAME("venice.metric.name"),
+
+  /** {@link VeniceRocksDBLevel} RocksDB level where a Get was served from. */
+  VENICE_ROCKSDB_LEVEL("venice.rocksdb.level"),
+
+  /** {@link VeniceRocksDBBlockCacheComponent} RocksDB block cache component type. */
+  VENICE_ROCKSDB_BLOCK_CACHE_COMPONENT("venice.rocksdb.block_cache_component");
 
   private final String[] dimensionName = new String[VeniceOpenTelemetryMetricNamingFormat.SIZE];
 

--- a/internal/venice-client-common/src/main/java/com/linkedin/venice/stats/dimensions/VeniceRocksDBBlockCacheComponent.java
+++ b/internal/venice-client-common/src/main/java/com/linkedin/venice/stats/dimensions/VeniceRocksDBBlockCacheComponent.java
@@ -1,0 +1,11 @@
+package com.linkedin.venice.stats.dimensions;
+
+/** RocksDB block cache component type. */
+public enum VeniceRocksDBBlockCacheComponent implements VeniceDimensionInterface {
+  INDEX, FILTER, DATA, COMPRESSION_DICT;
+
+  @Override
+  public VeniceMetricsDimensions getDimensionName() {
+    return VeniceMetricsDimensions.VENICE_ROCKSDB_BLOCK_CACHE_COMPONENT;
+  }
+}

--- a/internal/venice-client-common/src/main/java/com/linkedin/venice/stats/dimensions/VeniceRocksDBLevel.java
+++ b/internal/venice-client-common/src/main/java/com/linkedin/venice/stats/dimensions/VeniceRocksDBLevel.java
@@ -1,0 +1,14 @@
+package com.linkedin.venice.stats.dimensions;
+
+/**
+ * Bucketed RocksDB LSM level where a Get was served from. LEVEL_2_AND_UP covers all
+ * levels >= 2, matching RocksDB's GET_HIT_L2_AND_UP ticker.
+ */
+public enum VeniceRocksDBLevel implements VeniceDimensionInterface {
+  LEVEL_0, LEVEL_1, LEVEL_2_AND_UP;
+
+  @Override
+  public VeniceMetricsDimensions getDimensionName() {
+    return VeniceMetricsDimensions.VENICE_ROCKSDB_LEVEL;
+  }
+}

--- a/internal/venice-client-common/src/test/java/com/linkedin/venice/stats/dimensions/VeniceMetricsDimensionsTest.java
+++ b/internal/venice-client-common/src/test/java/com/linkedin/venice/stats/dimensions/VeniceMetricsDimensionsTest.java
@@ -157,6 +157,12 @@ public class VeniceMetricsDimensionsTest {
         case VENICE_DRAINER_TYPE:
           assertEquals(dimension.getDimensionName(format), "venice.drainer.type");
           break;
+        case VENICE_ROCKSDB_LEVEL:
+          assertEquals(dimension.getDimensionName(format), "venice.rocksdb.level");
+          break;
+        case VENICE_ROCKSDB_BLOCK_CACHE_COMPONENT:
+          assertEquals(dimension.getDimensionName(format), "venice.rocksdb.block_cache_component");
+          break;
         default:
           throw new IllegalArgumentException("Unknown dimension: " + dimension);
       }
@@ -312,6 +318,12 @@ public class VeniceMetricsDimensionsTest {
         case VENICE_DRAINER_TYPE:
           assertEquals(dimension.getDimensionName(format), "venice.drainer.type");
           break;
+        case VENICE_ROCKSDB_LEVEL:
+          assertEquals(dimension.getDimensionName(format), "venice.rocksdb.level");
+          break;
+        case VENICE_ROCKSDB_BLOCK_CACHE_COMPONENT:
+          assertEquals(dimension.getDimensionName(format), "venice.rocksdb.blockCacheComponent");
+          break;
         default:
           throw new IllegalArgumentException("Unknown dimension: " + dimension);
       }
@@ -466,6 +478,12 @@ public class VeniceMetricsDimensionsTest {
           break;
         case VENICE_DRAINER_TYPE:
           assertEquals(dimension.getDimensionName(format), "Venice.Drainer.Type");
+          break;
+        case VENICE_ROCKSDB_LEVEL:
+          assertEquals(dimension.getDimensionName(format), "Venice.Rocksdb.Level");
+          break;
+        case VENICE_ROCKSDB_BLOCK_CACHE_COMPONENT:
+          assertEquals(dimension.getDimensionName(format), "Venice.Rocksdb.BlockCacheComponent");
           break;
         default:
           throw new IllegalArgumentException("Unknown dimension: " + dimension);

--- a/internal/venice-client-common/src/test/java/com/linkedin/venice/stats/dimensions/VeniceMetricsDimensionsTest.java
+++ b/internal/venice-client-common/src/test/java/com/linkedin/venice/stats/dimensions/VeniceMetricsDimensionsTest.java
@@ -163,6 +163,12 @@ public class VeniceMetricsDimensionsTest {
         case VENICE_METRIC_NAME:
           assertEquals(dimension.getDimensionName(format), "venice.metric.name");
           break;
+        case VENICE_ROCKSDB_LEVEL:
+          assertEquals(dimension.getDimensionName(format), "venice.rocksdb.level");
+          break;
+        case VENICE_ROCKSDB_BLOCK_CACHE_COMPONENT:
+          assertEquals(dimension.getDimensionName(format), "venice.rocksdb.block_cache_component");
+          break;
         default:
           throw new IllegalArgumentException("Unknown dimension: " + dimension);
       }
@@ -324,6 +330,12 @@ public class VeniceMetricsDimensionsTest {
         case VENICE_METRIC_NAME:
           assertEquals(dimension.getDimensionName(format), "venice.metric.name");
           break;
+        case VENICE_ROCKSDB_LEVEL:
+          assertEquals(dimension.getDimensionName(format), "venice.rocksdb.level");
+          break;
+        case VENICE_ROCKSDB_BLOCK_CACHE_COMPONENT:
+          assertEquals(dimension.getDimensionName(format), "venice.rocksdb.blockCacheComponent");
+          break;
         default:
           throw new IllegalArgumentException("Unknown dimension: " + dimension);
       }
@@ -484,6 +496,12 @@ public class VeniceMetricsDimensionsTest {
           break;
         case VENICE_METRIC_NAME:
           assertEquals(dimension.getDimensionName(format), "Venice.Metric.Name");
+          break;
+        case VENICE_ROCKSDB_LEVEL:
+          assertEquals(dimension.getDimensionName(format), "Venice.Rocksdb.Level");
+          break;
+        case VENICE_ROCKSDB_BLOCK_CACHE_COMPONENT:
+          assertEquals(dimension.getDimensionName(format), "Venice.Rocksdb.BlockCacheComponent");
           break;
         default:
           throw new IllegalArgumentException("Unknown dimension: " + dimension);

--- a/internal/venice-client-common/src/test/java/com/linkedin/venice/stats/dimensions/VeniceRocksDBBlockCacheComponentTest.java
+++ b/internal/venice-client-common/src/test/java/com/linkedin/venice/stats/dimensions/VeniceRocksDBBlockCacheComponentTest.java
@@ -1,0 +1,23 @@
+package com.linkedin.venice.stats.dimensions;
+
+import com.linkedin.venice.utils.CollectionUtils;
+import java.util.Map;
+import org.testng.annotations.Test;
+
+
+public class VeniceRocksDBBlockCacheComponentTest {
+  @Test
+  public void testDimensionInterface() {
+    Map<VeniceRocksDBBlockCacheComponent, String> expectedValues =
+        CollectionUtils.<VeniceRocksDBBlockCacheComponent, String>mapBuilder()
+            .put(VeniceRocksDBBlockCacheComponent.INDEX, "index")
+            .put(VeniceRocksDBBlockCacheComponent.FILTER, "filter")
+            .put(VeniceRocksDBBlockCacheComponent.DATA, "data")
+            .put(VeniceRocksDBBlockCacheComponent.COMPRESSION_DICT, "compression_dict")
+            .build();
+    new VeniceDimensionTestFixture<>(
+        VeniceRocksDBBlockCacheComponent.class,
+        VeniceMetricsDimensions.VENICE_ROCKSDB_BLOCK_CACHE_COMPONENT,
+        expectedValues).assertAll();
+  }
+}

--- a/internal/venice-client-common/src/test/java/com/linkedin/venice/stats/dimensions/VeniceRocksDBLevelTest.java
+++ b/internal/venice-client-common/src/test/java/com/linkedin/venice/stats/dimensions/VeniceRocksDBLevelTest.java
@@ -1,0 +1,21 @@
+package com.linkedin.venice.stats.dimensions;
+
+import com.linkedin.venice.utils.CollectionUtils;
+import java.util.Map;
+import org.testng.annotations.Test;
+
+
+public class VeniceRocksDBLevelTest {
+  @Test
+  public void testDimensionInterface() {
+    Map<VeniceRocksDBLevel, String> expectedValues = CollectionUtils.<VeniceRocksDBLevel, String>mapBuilder()
+        .put(VeniceRocksDBLevel.LEVEL_0, "level_0")
+        .put(VeniceRocksDBLevel.LEVEL_1, "level_1")
+        .put(VeniceRocksDBLevel.LEVEL_2_AND_UP, "level_2_and_up")
+        .build();
+    new VeniceDimensionTestFixture<>(
+        VeniceRocksDBLevel.class,
+        VeniceMetricsDimensions.VENICE_ROCKSDB_LEVEL,
+        expectedValues).assertAll();
+  }
+}

--- a/services/venice-server/src/main/java/com/linkedin/venice/stats/AggRocksDBStats.java
+++ b/services/venice-server/src/main/java/com/linkedin/venice/stats/AggRocksDBStats.java
@@ -12,7 +12,7 @@ public class AggRocksDBStats extends AbstractVeniceAggStats<RocksDBStats> {
     super(
         cluster,
         metricsRepository,
-        (metricsRepo, storeName, clusterName) -> new RocksDBStats(metricsRepository, storeName),
+        (metricsRepo, storeName, clusterName) -> new RocksDBStats(metricsRepo, storeName, clusterName),
         false);
     totalStats.setRocksDBStat(aggStat);
   }

--- a/services/venice-server/src/main/java/com/linkedin/venice/stats/RocksDBStats.java
+++ b/services/venice-server/src/main/java/com/linkedin/venice/stats/RocksDBStats.java
@@ -1,9 +1,26 @@
 package com.linkedin.venice.stats;
 
+import static com.linkedin.davinci.stats.RocksDBStatsOtelMetricEntity.BLOCK_CACHE_ADD_COUNT;
+import static com.linkedin.davinci.stats.RocksDBStatsOtelMetricEntity.BLOCK_CACHE_ADD_FAILURE_COUNT;
+import static com.linkedin.davinci.stats.RocksDBStatsOtelMetricEntity.BLOCK_CACHE_BYTES_INSERTED;
+import static com.linkedin.davinci.stats.RocksDBStatsOtelMetricEntity.BLOCK_CACHE_HIT_COUNT;
+import static com.linkedin.davinci.stats.RocksDBStatsOtelMetricEntity.BLOCK_CACHE_MISS_COUNT;
+import static com.linkedin.davinci.stats.RocksDBStatsOtelMetricEntity.BLOCK_CACHE_READ_BYTES;
+import static com.linkedin.davinci.stats.RocksDBStatsOtelMetricEntity.BLOCK_CACHE_WRITE_BYTES;
+import static com.linkedin.davinci.stats.RocksDBStatsOtelMetricEntity.BLOOM_FILTER_USEFUL_COUNT;
+import static com.linkedin.davinci.stats.RocksDBStatsOtelMetricEntity.COMPACTION_CANCELLED_COUNT;
+import static com.linkedin.davinci.stats.RocksDBStatsOtelMetricEntity.GET_HIT_COUNT;
+import static com.linkedin.davinci.stats.RocksDBStatsOtelMetricEntity.MEMTABLE_HIT_COUNT;
+import static com.linkedin.davinci.stats.RocksDBStatsOtelMetricEntity.MEMTABLE_MISS_COUNT;
+import static com.linkedin.davinci.stats.RocksDBStatsOtelMetricEntity.READ_AMPLIFICATION_FACTOR;
 import static org.rocksdb.TickerType.BLOCK_CACHE_ADD;
 import static org.rocksdb.TickerType.BLOCK_CACHE_ADD_FAILURES;
 import static org.rocksdb.TickerType.BLOCK_CACHE_BYTES_READ;
 import static org.rocksdb.TickerType.BLOCK_CACHE_BYTES_WRITE;
+import static org.rocksdb.TickerType.BLOCK_CACHE_COMPRESSION_DICT_ADD;
+import static org.rocksdb.TickerType.BLOCK_CACHE_COMPRESSION_DICT_BYTES_INSERT;
+import static org.rocksdb.TickerType.BLOCK_CACHE_COMPRESSION_DICT_HIT;
+import static org.rocksdb.TickerType.BLOCK_CACHE_COMPRESSION_DICT_MISS;
 import static org.rocksdb.TickerType.BLOCK_CACHE_DATA_ADD;
 import static org.rocksdb.TickerType.BLOCK_CACHE_DATA_BYTES_INSERT;
 import static org.rocksdb.TickerType.BLOCK_CACHE_DATA_HIT;
@@ -28,112 +45,273 @@ import static org.rocksdb.TickerType.MEMTABLE_MISS;
 import static org.rocksdb.TickerType.READ_AMP_ESTIMATE_USEFUL_BYTES;
 import static org.rocksdb.TickerType.READ_AMP_TOTAL_READ_BYTES;
 
+import com.linkedin.davinci.stats.RocksDBStatsOtelMetricEntity;
 import com.linkedin.venice.exceptions.VeniceException;
+import com.linkedin.venice.stats.dimensions.VeniceMetricsDimensions;
+import com.linkedin.venice.stats.dimensions.VeniceRocksDBBlockCacheComponent;
+import com.linkedin.venice.stats.dimensions.VeniceRocksDBLevel;
+import com.linkedin.venice.stats.metrics.AsyncMetricEntityStateBase;
+import com.linkedin.venice.stats.metrics.AsyncMetricEntityStateOneEnum;
+import io.opentelemetry.api.common.Attributes;
 import io.tehuti.metrics.MetricsRepository;
-import io.tehuti.metrics.Sensor;
 import io.tehuti.metrics.stats.AsyncGauge;
+import java.util.EnumMap;
+import java.util.Map;
+import java.util.function.DoubleSupplier;
+import java.util.function.LongSupplier;
 import org.rocksdb.Statistics;
 import org.rocksdb.TickerType;
 
 
 /**
- * Check {@link TickerType} to find more details about RocksDB metrics.
+ * RocksDB ticker-based statistics. Gated by {@code rocksdb.statistics.enabled} (default false).
+ *
+ * <p>Per-component block cache metrics use a {@code BLOCK_CACHE_COMPONENT} dimension
+ * (INDEX/FILTER/DATA/COMPRESSION_DICT). Overall block cache miss/hit/add counters are
+ * Tehuti-only — OTel derives totals via {@code sum by (component)}. Overall-only counters
+ * without per-component equivalents (add failures, bytes read/write) are joint Tehuti+OTel.
+ *
+ * <p>Get-hit-by-level uses a {@code LEVEL} dimension (LEVEL_0/LEVEL_1/LEVEL_2_AND_UP).
+ * Block cache hit ratio is Tehuti-only (derivable from per-component OTel gauge metrics).
+ *
+ * @see RocksDBStatsOtelMetricEntity
  */
 public class RocksDBStats extends AbstractVeniceStats {
+  private static final EnumMap<VeniceRocksDBLevel, TickerType> GET_HIT_TICKER_BY_LEVEL =
+      new EnumMap<>(VeniceRocksDBLevel.class);
+  private static final EnumMap<VeniceRocksDBBlockCacheComponent, TickerType> MISS_TICKER_BY_COMPONENT =
+      new EnumMap<>(VeniceRocksDBBlockCacheComponent.class);
+  private static final EnumMap<VeniceRocksDBBlockCacheComponent, TickerType> HIT_TICKER_BY_COMPONENT =
+      new EnumMap<>(VeniceRocksDBBlockCacheComponent.class);
+  private static final EnumMap<VeniceRocksDBBlockCacheComponent, TickerType> ADD_TICKER_BY_COMPONENT =
+      new EnumMap<>(VeniceRocksDBBlockCacheComponent.class);
+  private static final EnumMap<VeniceRocksDBBlockCacheComponent, TickerType> BYTES_INSERT_TICKER_BY_COMPONENT =
+      new EnumMap<>(VeniceRocksDBBlockCacheComponent.class);
+  static {
+    GET_HIT_TICKER_BY_LEVEL.put(VeniceRocksDBLevel.LEVEL_0, GET_HIT_L0);
+    GET_HIT_TICKER_BY_LEVEL.put(VeniceRocksDBLevel.LEVEL_1, GET_HIT_L1);
+    GET_HIT_TICKER_BY_LEVEL.put(VeniceRocksDBLevel.LEVEL_2_AND_UP, GET_HIT_L2_AND_UP);
+
+    MISS_TICKER_BY_COMPONENT.put(VeniceRocksDBBlockCacheComponent.INDEX, BLOCK_CACHE_INDEX_MISS);
+    MISS_TICKER_BY_COMPONENT.put(VeniceRocksDBBlockCacheComponent.FILTER, BLOCK_CACHE_FILTER_MISS);
+    MISS_TICKER_BY_COMPONENT.put(VeniceRocksDBBlockCacheComponent.DATA, BLOCK_CACHE_DATA_MISS);
+    MISS_TICKER_BY_COMPONENT.put(VeniceRocksDBBlockCacheComponent.COMPRESSION_DICT, BLOCK_CACHE_COMPRESSION_DICT_MISS);
+
+    HIT_TICKER_BY_COMPONENT.put(VeniceRocksDBBlockCacheComponent.INDEX, BLOCK_CACHE_INDEX_HIT);
+    HIT_TICKER_BY_COMPONENT.put(VeniceRocksDBBlockCacheComponent.FILTER, BLOCK_CACHE_FILTER_HIT);
+    HIT_TICKER_BY_COMPONENT.put(VeniceRocksDBBlockCacheComponent.DATA, BLOCK_CACHE_DATA_HIT);
+    HIT_TICKER_BY_COMPONENT.put(VeniceRocksDBBlockCacheComponent.COMPRESSION_DICT, BLOCK_CACHE_COMPRESSION_DICT_HIT);
+
+    ADD_TICKER_BY_COMPONENT.put(VeniceRocksDBBlockCacheComponent.INDEX, BLOCK_CACHE_INDEX_ADD);
+    ADD_TICKER_BY_COMPONENT.put(VeniceRocksDBBlockCacheComponent.FILTER, BLOCK_CACHE_FILTER_ADD);
+    ADD_TICKER_BY_COMPONENT.put(VeniceRocksDBBlockCacheComponent.DATA, BLOCK_CACHE_DATA_ADD);
+    ADD_TICKER_BY_COMPONENT.put(VeniceRocksDBBlockCacheComponent.COMPRESSION_DICT, BLOCK_CACHE_COMPRESSION_DICT_ADD);
+
+    BYTES_INSERT_TICKER_BY_COMPONENT.put(VeniceRocksDBBlockCacheComponent.INDEX, BLOCK_CACHE_INDEX_BYTES_INSERT);
+    BYTES_INSERT_TICKER_BY_COMPONENT.put(VeniceRocksDBBlockCacheComponent.FILTER, BLOCK_CACHE_FILTER_BYTES_INSERT);
+    BYTES_INSERT_TICKER_BY_COMPONENT.put(VeniceRocksDBBlockCacheComponent.DATA, BLOCK_CACHE_DATA_BYTES_INSERT);
+    BYTES_INSERT_TICKER_BY_COMPONENT
+        .put(VeniceRocksDBBlockCacheComponent.COMPRESSION_DICT, BLOCK_CACHE_COMPRESSION_DICT_BYTES_INSERT);
+  }
+
   private Statistics rocksDBStat;
 
-  private final Sensor blockCacheMiss;
-  private final Sensor blockCacheHit;
-  private final Sensor blockCacheAdd;
-  private final Sensor blockCacheAddFailures;
-  private final Sensor blockCacheIndexMiss;
-  private final Sensor blockCacheIndexHit;
-  private final Sensor blockCacheIndexAdd;
-  private final Sensor blockCacheIndexBytesInsert;
-  private final Sensor blockCacheFilterMiss;
-  private final Sensor blockCacheFilterHit;
-  private final Sensor blockCacheFilterAdd;
-  private final Sensor blockCacheFilterBytesInsert;
-  private final Sensor blockCacheDataMiss;
-  private final Sensor blockCacheDataHit;
-  private final Sensor blockCacheDataAdd;
-  private final Sensor blockCacheDataBytesInsert;
-  private final Sensor blockCacheBytesRead;
-  private final Sensor blockCacheBytesWrite;
-  private final Sensor bloomFilterUseful;
-  private final Sensor memtableHit;
-  private final Sensor memtableMiss;
-  private final Sensor getHitL0;
-  private final Sensor getHitL1;
-  private final Sensor getHitL2AndUp;
-  private final Sensor blockCacheHitRatio;
-
-  // we'll need to enable read_amp_bytes_per_bit in rocksDB config
-  private final Sensor readAmplificationFactor;
-  private final Sensor compactionCancelled;
-
-  public RocksDBStats(MetricsRepository metricsRepository, String name) {
+  public RocksDBStats(MetricsRepository metricsRepository, String name, String clusterName) {
     super(metricsRepository, name);
 
-    this.blockCacheMiss = registerSensor("rocksdb_block_cache_miss", BLOCK_CACHE_MISS);
-    this.blockCacheHit = registerSensor("rocksdb_block_cache_hit", BLOCK_CACHE_HIT);
-    this.blockCacheAdd = registerSensor("rocksdb_block_cache_add", BLOCK_CACHE_ADD);
-    this.blockCacheAddFailures = registerSensor("rocksdb_block_cache_add_failures", BLOCK_CACHE_ADD_FAILURES);
-    this.blockCacheIndexMiss = registerSensor("rocksdb_block_cache_index_miss", BLOCK_CACHE_INDEX_MISS);
-    this.blockCacheIndexHit = registerSensor("rocksdb_block_cache_index_hit", BLOCK_CACHE_INDEX_HIT);
-    this.blockCacheIndexAdd = registerSensor("rocksdb_block_cache_index_add", BLOCK_CACHE_INDEX_ADD);
-    this.blockCacheIndexBytesInsert =
-        registerSensor("rocksdb_block_cache_index_bytes_insert", BLOCK_CACHE_INDEX_BYTES_INSERT);
-    this.blockCacheFilterMiss = registerSensor("rocksdb_block_cache_filter_miss", BLOCK_CACHE_FILTER_MISS);
-    this.blockCacheFilterHit = registerSensor("rocksdb_block_cache_filter_hit", BLOCK_CACHE_FILTER_HIT);
-    this.blockCacheFilterAdd = registerSensor("rocksdb_block_cache_filter_add", BLOCK_CACHE_FILTER_ADD);
-    this.blockCacheFilterBytesInsert =
-        registerSensor("rocksdb_block_cache_filter_bytes_insert", BLOCK_CACHE_FILTER_BYTES_INSERT);
-    this.blockCacheDataMiss = registerSensor("rocksdb_block_cache_data_miss", BLOCK_CACHE_DATA_MISS);
-    this.blockCacheDataHit = registerSensor("rocksdb_block_cache_data_hit", BLOCK_CACHE_DATA_HIT);
-    this.blockCacheDataAdd = registerSensor("rocksdb_block_cache_data_add", BLOCK_CACHE_DATA_ADD);
-    this.blockCacheDataBytesInsert =
-        registerSensor("rocksdb_block_cache_data_bytes_insert", BLOCK_CACHE_DATA_BYTES_INSERT);
-    this.blockCacheBytesRead = registerSensor("rocksdb_block_cache_bytes_read", BLOCK_CACHE_BYTES_READ);
-    this.blockCacheBytesWrite = registerSensor("rocksdb_block_cache_bytes_write", BLOCK_CACHE_BYTES_WRITE);
-    this.bloomFilterUseful = registerSensor("rocksdb_bloom_filter_useful", BLOOM_FILTER_USEFUL);
-    this.memtableHit = registerSensor("rocksdb_memtable_hit", MEMTABLE_HIT);
-    this.memtableMiss = registerSensor("rocksdb_memtable_miss", MEMTABLE_MISS);
-    this.getHitL0 = registerSensor("rocksdb_get_hit_l0", GET_HIT_L0);
-    this.getHitL1 = registerSensor("rocksdb_get_hit_l1", GET_HIT_L1);
-    this.getHitL2AndUp = registerSensor("rocksdb_get_hit_l2_and_up", GET_HIT_L2_AND_UP);
-    this.compactionCancelled = registerSensor("rocksdb_compaction_cancelled", COMPACTION_CANCELLED);
+    OpenTelemetryMetricsSetup.OpenTelemetryMetricsSetupInfo otelData =
+        OpenTelemetryMetricsSetup.builder(metricsRepository)
+            .setClusterName(clusterName)
+            .isTotalStats(isTotalStats())
+            .build();
+    VeniceOpenTelemetryMetricsRepository otelRepository = otelData.getOtelRepository();
+    Map<VeniceMetricsDimensions, String> baseDimensionsMap = otelData.getBaseDimensionsMap();
+    Attributes baseAttributes = otelData.getBaseAttributes();
 
-    this.blockCacheHitRatio = registerSensor(new AsyncGauge((ignored, ignored2) -> {
+    // --- Block Cache: overall (Tehuti-only, OTel derives from per-component sum) ---
+    registerTickerSensor("rocksdb_block_cache_miss", BLOCK_CACHE_MISS);
+    registerTickerSensor("rocksdb_block_cache_hit", BLOCK_CACHE_HIT);
+    registerTickerSensor("rocksdb_block_cache_add", BLOCK_CACHE_ADD);
+
+    // --- Block Cache: per-component (Tehuti sensors + OTel with COMPONENT dimension) ---
+    // Tehuti: 16 individual sensors (4 components × 4 operations)
+    registerTickerSensor("rocksdb_block_cache_index_miss", BLOCK_CACHE_INDEX_MISS);
+    registerTickerSensor("rocksdb_block_cache_index_hit", BLOCK_CACHE_INDEX_HIT);
+    registerTickerSensor("rocksdb_block_cache_index_add", BLOCK_CACHE_INDEX_ADD);
+    registerTickerSensor("rocksdb_block_cache_index_bytes_insert", BLOCK_CACHE_INDEX_BYTES_INSERT);
+    registerTickerSensor("rocksdb_block_cache_filter_miss", BLOCK_CACHE_FILTER_MISS);
+    registerTickerSensor("rocksdb_block_cache_filter_hit", BLOCK_CACHE_FILTER_HIT);
+    registerTickerSensor("rocksdb_block_cache_filter_add", BLOCK_CACHE_FILTER_ADD);
+    registerTickerSensor("rocksdb_block_cache_filter_bytes_insert", BLOCK_CACHE_FILTER_BYTES_INSERT);
+    registerTickerSensor("rocksdb_block_cache_data_miss", BLOCK_CACHE_DATA_MISS);
+    registerTickerSensor("rocksdb_block_cache_data_hit", BLOCK_CACHE_DATA_HIT);
+    registerTickerSensor("rocksdb_block_cache_data_add", BLOCK_CACHE_DATA_ADD);
+    registerTickerSensor("rocksdb_block_cache_data_bytes_insert", BLOCK_CACHE_DATA_BYTES_INSERT);
+    registerTickerSensor("rocksdb_block_cache_compression_dict_miss", BLOCK_CACHE_COMPRESSION_DICT_MISS);
+    registerTickerSensor("rocksdb_block_cache_compression_dict_hit", BLOCK_CACHE_COMPRESSION_DICT_HIT);
+    registerTickerSensor("rocksdb_block_cache_compression_dict_add", BLOCK_CACHE_COMPRESSION_DICT_ADD);
+    registerTickerSensor(
+        "rocksdb_block_cache_compression_dict_bytes_insert",
+        BLOCK_CACHE_COMPRESSION_DICT_BYTES_INSERT);
+
+    // OTel: 4 metrics with COMPONENT dimension
+    registerComponentMetric(otelRepository, baseDimensionsMap, BLOCK_CACHE_MISS_COUNT, MISS_TICKER_BY_COMPONENT);
+    registerComponentMetric(otelRepository, baseDimensionsMap, BLOCK_CACHE_HIT_COUNT, HIT_TICKER_BY_COMPONENT);
+    registerComponentMetric(otelRepository, baseDimensionsMap, BLOCK_CACHE_ADD_COUNT, ADD_TICKER_BY_COMPONENT);
+    registerComponentMetric(
+        otelRepository,
+        baseDimensionsMap,
+        BLOCK_CACHE_BYTES_INSERTED,
+        BYTES_INSERT_TICKER_BY_COMPONENT);
+
+    // --- Block Cache: overall-only (joint Tehuti+OTel, no per-component breakdown) ---
+    registerJointTickerMetric(
+        "rocksdb_block_cache_add_failures",
+        BLOCK_CACHE_ADD_FAILURES,
+        BLOCK_CACHE_ADD_FAILURE_COUNT,
+        otelRepository,
+        baseDimensionsMap,
+        baseAttributes);
+    registerJointTickerMetric(
+        "rocksdb_block_cache_bytes_read",
+        BLOCK_CACHE_BYTES_READ,
+        BLOCK_CACHE_READ_BYTES,
+        otelRepository,
+        baseDimensionsMap,
+        baseAttributes);
+    registerJointTickerMetric(
+        "rocksdb_block_cache_bytes_write",
+        BLOCK_CACHE_BYTES_WRITE,
+        BLOCK_CACHE_WRITE_BYTES,
+        otelRepository,
+        baseDimensionsMap,
+        baseAttributes);
+
+    // --- Bloom Filter, Memtable, Compaction (joint Tehuti+OTel) ---
+    registerJointTickerMetric(
+        "rocksdb_bloom_filter_useful",
+        BLOOM_FILTER_USEFUL,
+        BLOOM_FILTER_USEFUL_COUNT,
+        otelRepository,
+        baseDimensionsMap,
+        baseAttributes);
+    registerJointTickerMetric(
+        "rocksdb_memtable_hit",
+        MEMTABLE_HIT,
+        MEMTABLE_HIT_COUNT,
+        otelRepository,
+        baseDimensionsMap,
+        baseAttributes);
+    registerJointTickerMetric(
+        "rocksdb_memtable_miss",
+        MEMTABLE_MISS,
+        MEMTABLE_MISS_COUNT,
+        otelRepository,
+        baseDimensionsMap,
+        baseAttributes);
+    registerJointTickerMetric(
+        "rocksdb_compaction_cancelled",
+        COMPACTION_CANCELLED,
+        COMPACTION_CANCELLED_COUNT,
+        otelRepository,
+        baseDimensionsMap,
+        baseAttributes);
+
+    // --- Get Hit by Level: 3 Tehuti sensors + 1 OTel with LEVEL dimension ---
+    registerTickerSensor("rocksdb_get_hit_l0", GET_HIT_L0);
+    registerTickerSensor("rocksdb_get_hit_l1", GET_HIT_L1);
+    registerTickerSensor("rocksdb_get_hit_l2_and_up", GET_HIT_L2_AND_UP);
+    AsyncMetricEntityStateOneEnum
+        .create(GET_HIT_COUNT.getMetricEntity(), otelRepository, baseDimensionsMap, VeniceRocksDBLevel.class, level -> {
+          TickerType ticker = GET_HIT_TICKER_BY_LEVEL.get(level);
+          if (ticker == null) {
+            throw new IllegalStateException("No TickerType mapping for level: " + level);
+          }
+          return () -> rocksDBStat != null ? rocksDBStat.getTickerCount(ticker) : -1;
+        });
+
+    // --- Block Cache Hit Ratio: Tehuti-only (OTel derivable: hit{data} / (hit{data} + sum(miss))) ---
+    registerSensorIfAbsent(new AsyncGauge((ig, ig2) -> {
       if (rocksDBStat != null) {
-        return rocksDBStat.getTickerCount(BLOCK_CACHE_DATA_HIT)
-            / (double) (rocksDBStat.getTickerCount(BLOCK_CACHE_DATA_HIT)
-                + rocksDBStat.getTickerCount(BLOCK_CACHE_MISS));
+        long dataHit = rocksDBStat.getTickerCount(BLOCK_CACHE_DATA_HIT);
+        long miss = rocksDBStat.getTickerCount(BLOCK_CACHE_MISS);
+        long denominator = dataHit + miss;
+        return denominator == 0 ? Double.NaN : dataHit / (double) denominator;
       }
-
       return -1;
     }, "rocksdb_block_cache_hit_ratio"));
 
-    this.readAmplificationFactor = registerSensor(new AsyncGauge((ignored, ignored2) -> {
+    // --- Read Amplification: Tehuti + OTel ASYNC_DOUBLE_GAUGE ---
+    // OTel callback returns NaN when unavailable (SDK drops the data point).
+    // Tehuti callback returns -1 as the established sentinel for uninitialized state.
+    DoubleSupplier readAmpOtelCallback = () -> {
       if (rocksDBStat != null) {
-        return rocksDBStat.getTickerCount(READ_AMP_TOTAL_READ_BYTES)
-            / (double) (rocksDBStat.getTickerCount(READ_AMP_ESTIMATE_USEFUL_BYTES));
+        long total = rocksDBStat.getTickerCount(READ_AMP_TOTAL_READ_BYTES);
+        long useful = rocksDBStat.getTickerCount(READ_AMP_ESTIMATE_USEFUL_BYTES);
+        return useful == 0 ? Double.NaN : total / (double) useful;
       }
-
+      return Double.NaN;
+    };
+    registerSensorIfAbsent(new AsyncGauge((ig, ig2) -> {
+      if (rocksDBStat != null) {
+        long total = rocksDBStat.getTickerCount(READ_AMP_TOTAL_READ_BYTES);
+        long useful = rocksDBStat.getTickerCount(READ_AMP_ESTIMATE_USEFUL_BYTES);
+        return useful == 0 ? -1 : total / (double) useful;
+      }
       return -1;
     }, "rocksdb_read_amplification_factor"));
+    AsyncMetricEntityStateBase.create(
+        READ_AMPLIFICATION_FACTOR.getMetricEntity(),
+        otelRepository,
+        baseDimensionsMap,
+        baseAttributes,
+        readAmpOtelCallback);
   }
 
-  private Sensor registerSensor(String sensorName, TickerType tickerType) {
-    return registerSensor(new AsyncGauge((ignored, ignored2) -> {
-      if (rocksDBStat != null) {
-        return rocksDBStat.getTickerCount(tickerType);
-      }
-      return -1;
-    }, sensorName));
+  /** Registers a Tehuti-only AsyncGauge for a RocksDB TickerType counter. */
+  private void registerTickerSensor(String sensorName, TickerType tickerType) {
+    registerSensorIfAbsent(
+        new AsyncGauge((ig, ig2) -> rocksDBStat != null ? rocksDBStat.getTickerCount(tickerType) : -1, sensorName));
+  }
+
+  /** Registers a joint Tehuti+OTel AsyncGauge for a RocksDB TickerType counter. */
+  private void registerJointTickerMetric(
+      String tehutiSensorName,
+      TickerType tickerType,
+      RocksDBStatsOtelMetricEntity otelEntity,
+      VeniceOpenTelemetryMetricsRepository otelRepository,
+      Map<VeniceMetricsDimensions, String> baseDimensionsMap,
+      Attributes baseAttributes) {
+    LongSupplier callback = () -> rocksDBStat != null ? rocksDBStat.getTickerCount(tickerType) : -1;
+    registerSensorIfAbsent(new AsyncGauge((ig, ig2) -> callback.getAsLong(), tehutiSensorName));
+    AsyncMetricEntityStateBase
+        .create(otelEntity.getMetricEntity(), otelRepository, baseDimensionsMap, baseAttributes, callback);
+  }
+
+  /** Registers an OTel-only AsyncMetricEntityStateOneEnum for per-component block cache metrics. */
+  private void registerComponentMetric(
+      VeniceOpenTelemetryMetricsRepository otelRepository,
+      Map<VeniceMetricsDimensions, String> baseDimensionsMap,
+      RocksDBStatsOtelMetricEntity otelEntity,
+      EnumMap<VeniceRocksDBBlockCacheComponent, TickerType> componentTickers) {
+    AsyncMetricEntityStateOneEnum.create(
+        otelEntity.getMetricEntity(),
+        otelRepository,
+        baseDimensionsMap,
+        VeniceRocksDBBlockCacheComponent.class,
+        component -> {
+          TickerType ticker = componentTickers.get(component);
+          if (ticker == null) {
+            throw new IllegalStateException("No TickerType mapping for component: " + component);
+          }
+          return () -> rocksDBStat != null ? rocksDBStat.getTickerCount(ticker) : -1;
+        });
   }
 
   public void setRocksDBStat(Statistics stat) {
+    if (stat == null) {
+      throw new IllegalArgumentException("'stat' must not be null");
+    }
     if (this.rocksDBStat != null) {
       throw new VeniceException("'rocksDBStat' has already been initialized");
     }

--- a/services/venice-server/src/main/java/com/linkedin/venice/stats/RocksDBStats.java
+++ b/services/venice-server/src/main/java/com/linkedin/venice/stats/RocksDBStats.java
@@ -114,7 +114,7 @@ public class RocksDBStats extends AbstractVeniceStats {
         .put(VeniceRocksDBBlockCacheComponent.COMPRESSION_DICT, BLOCK_CACHE_COMPRESSION_DICT_BYTES_INSERT);
   }
 
-  private Statistics rocksDBStat;
+  private volatile Statistics rocksDBStat;
 
   public RocksDBStats(MetricsRepository metricsRepository, String name, String clusterName) {
     super(metricsRepository, name);

--- a/services/venice-server/src/main/java/com/linkedin/venice/stats/RocksDBStats.java
+++ b/services/venice-server/src/main/java/com/linkedin/venice/stats/RocksDBStats.java
@@ -223,12 +223,12 @@ public class RocksDBStats extends AbstractVeniceStats {
     registerTickerSensor("rocksdb_get_hit_l2_and_up", GET_HIT_L2_AND_UP);
     AsyncMetricEntityStateOneEnum
         .create(GET_HIT_COUNT.getMetricEntity(), otelRepository, baseDimensionsMap, VeniceRocksDBLevel.class, level -> {
-          TickerType ticker = GET_HIT_TICKER_BY_LEVEL.get(level);
-          if (ticker == null) {
-            throw new IllegalStateException("No TickerType mapping for level: " + level);
+          Statistics stat = rocksDBStat;
+          if (stat == null || GET_HIT_TICKER_BY_LEVEL.get(level) == null) {
+            return null;
           }
-          return () -> rocksDBStat != null ? rocksDBStat.getTickerCount(ticker) : -1;
-        });
+          return stat;
+        }, (stat, level) -> stat.getTickerCount(GET_HIT_TICKER_BY_LEVEL.get(level)));
 
     // --- Block Cache Hit Ratio: Tehuti-only (OTel derivable: hit{data} / (hit{data} + sum(miss))) ---
     registerSensorIfAbsent(new AsyncGauge((ig, ig2) -> {
@@ -300,12 +300,13 @@ public class RocksDBStats extends AbstractVeniceStats {
         baseDimensionsMap,
         VeniceRocksDBBlockCacheComponent.class,
         component -> {
-          TickerType ticker = componentTickers.get(component);
-          if (ticker == null) {
-            throw new IllegalStateException("No TickerType mapping for component: " + component);
+          Statistics stat = rocksDBStat;
+          if (stat == null || componentTickers.get(component) == null) {
+            return null;
           }
-          return () -> rocksDBStat != null ? rocksDBStat.getTickerCount(ticker) : -1;
-        });
+          return stat;
+        },
+        (stat, component) -> stat.getTickerCount(componentTickers.get(component)));
   }
 
   public void setRocksDBStat(Statistics stat) {

--- a/services/venice-server/src/main/java/com/linkedin/venice/stats/RocksDBStats.java
+++ b/services/venice-server/src/main/java/com/linkedin/venice/stats/RocksDBStats.java
@@ -119,11 +119,10 @@ public class RocksDBStats extends AbstractVeniceStats {
   public RocksDBStats(MetricsRepository metricsRepository, String name, String clusterName) {
     super(metricsRepository, name);
 
+    // AggRocksDBStats only constructs the "total" stats instance and never per-store stats, so
+    // isTotalStats() must NOT be propagated — it would suppress all OTel emission in production.
     OpenTelemetryMetricsSetup.OpenTelemetryMetricsSetupInfo otelData =
-        OpenTelemetryMetricsSetup.builder(metricsRepository)
-            .setClusterName(clusterName)
-            .isTotalStats(isTotalStats())
-            .build();
+        OpenTelemetryMetricsSetup.builder(metricsRepository).setClusterName(clusterName).build();
     VeniceOpenTelemetryMetricsRepository otelRepository = otelData.getOtelRepository();
     Map<VeniceMetricsDimensions, String> baseDimensionsMap = otelData.getBaseDimensionsMap();
     Attributes baseAttributes = otelData.getBaseAttributes();

--- a/services/venice-server/src/test/java/com/linkedin/venice/stats/RocksDBStatsOtelTest.java
+++ b/services/venice-server/src/test/java/com/linkedin/venice/stats/RocksDBStatsOtelTest.java
@@ -1,0 +1,298 @@
+package com.linkedin.venice.stats;
+
+import static com.linkedin.davinci.stats.RocksDBStatsOtelMetricEntity.BLOCK_CACHE_ADD_COUNT;
+import static com.linkedin.davinci.stats.RocksDBStatsOtelMetricEntity.BLOCK_CACHE_ADD_FAILURE_COUNT;
+import static com.linkedin.davinci.stats.RocksDBStatsOtelMetricEntity.BLOCK_CACHE_BYTES_INSERTED;
+import static com.linkedin.davinci.stats.RocksDBStatsOtelMetricEntity.BLOCK_CACHE_HIT_COUNT;
+import static com.linkedin.davinci.stats.RocksDBStatsOtelMetricEntity.BLOCK_CACHE_MISS_COUNT;
+import static com.linkedin.davinci.stats.RocksDBStatsOtelMetricEntity.BLOCK_CACHE_READ_BYTES;
+import static com.linkedin.davinci.stats.RocksDBStatsOtelMetricEntity.BLOCK_CACHE_WRITE_BYTES;
+import static com.linkedin.davinci.stats.RocksDBStatsOtelMetricEntity.BLOOM_FILTER_USEFUL_COUNT;
+import static com.linkedin.davinci.stats.RocksDBStatsOtelMetricEntity.COMPACTION_CANCELLED_COUNT;
+import static com.linkedin.davinci.stats.RocksDBStatsOtelMetricEntity.GET_HIT_COUNT;
+import static com.linkedin.davinci.stats.RocksDBStatsOtelMetricEntity.MEMTABLE_HIT_COUNT;
+import static com.linkedin.davinci.stats.RocksDBStatsOtelMetricEntity.MEMTABLE_MISS_COUNT;
+import static com.linkedin.davinci.stats.RocksDBStatsOtelMetricEntity.READ_AMPLIFICATION_FACTOR;
+import static com.linkedin.davinci.stats.ServerMetricEntity.SERVER_METRIC_ENTITIES;
+import static com.linkedin.venice.stats.dimensions.VeniceMetricsDimensions.VENICE_CLUSTER_NAME;
+import static com.linkedin.venice.stats.dimensions.VeniceMetricsDimensions.VENICE_ROCKSDB_BLOCK_CACHE_COMPONENT;
+import static com.linkedin.venice.stats.dimensions.VeniceMetricsDimensions.VENICE_ROCKSDB_LEVEL;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertFalse;
+
+import com.linkedin.davinci.stats.RocksDBStatsOtelMetricEntity;
+import com.linkedin.venice.stats.dimensions.VeniceRocksDBBlockCacheComponent;
+import com.linkedin.venice.stats.dimensions.VeniceRocksDBLevel;
+import com.linkedin.venice.utils.OpenTelemetryDataTestUtils;
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.sdk.metrics.data.MetricData;
+import io.opentelemetry.sdk.testing.exporter.InMemoryMetricReader;
+import io.tehuti.metrics.MetricsRepository;
+import java.util.Collection;
+import org.rocksdb.Statistics;
+import org.rocksdb.TickerType;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+
+public class RocksDBStatsOtelTest {
+  private static final String TEST_METRIC_PREFIX = "server";
+  private static final String TEST_CLUSTER_NAME = "test-cluster";
+
+  private InMemoryMetricReader inMemoryMetricReader;
+  private VeniceMetricsRepository metricsRepository;
+  private Statistics mockStats;
+  private RocksDBStats rocksDBStats;
+
+  @BeforeMethod
+  public void setUp() {
+    inMemoryMetricReader = InMemoryMetricReader.create();
+    metricsRepository = new VeniceMetricsRepository(
+        new VeniceMetricsConfig.Builder().setMetricPrefix(TEST_METRIC_PREFIX)
+            .setMetricEntities(SERVER_METRIC_ENTITIES)
+            .setEmitOtelMetrics(true)
+            .setOtelAdditionalMetricsReader(inMemoryMetricReader)
+            .build());
+    mockStats = mock(Statistics.class);
+    rocksDBStats = new RocksDBStats(metricsRepository, "rocksdb_stat", TEST_CLUSTER_NAME);
+    rocksDBStats.setRocksDBStat(mockStats);
+  }
+
+  @AfterMethod
+  public void tearDown() {
+    if (metricsRepository != null) {
+      metricsRepository.close();
+    }
+  }
+
+  // --- Per-component block cache metrics (OTel with COMPONENT dimension) ---
+
+  @Test
+  public void testBlockCacheMissCountByComponent() {
+    when(mockStats.getTickerCount(TickerType.BLOCK_CACHE_INDEX_MISS)).thenReturn(10L);
+    when(mockStats.getTickerCount(TickerType.BLOCK_CACHE_FILTER_MISS)).thenReturn(20L);
+    when(mockStats.getTickerCount(TickerType.BLOCK_CACHE_DATA_MISS)).thenReturn(30L);
+    when(mockStats.getTickerCount(TickerType.BLOCK_CACHE_COMPRESSION_DICT_MISS)).thenReturn(40L);
+
+    validateComponentGauge(10, BLOCK_CACHE_MISS_COUNT, VeniceRocksDBBlockCacheComponent.INDEX);
+    validateComponentGauge(20, BLOCK_CACHE_MISS_COUNT, VeniceRocksDBBlockCacheComponent.FILTER);
+    validateComponentGauge(30, BLOCK_CACHE_MISS_COUNT, VeniceRocksDBBlockCacheComponent.DATA);
+    validateComponentGauge(40, BLOCK_CACHE_MISS_COUNT, VeniceRocksDBBlockCacheComponent.COMPRESSION_DICT);
+  }
+
+  @Test
+  public void testBlockCacheHitCountByComponent() {
+    when(mockStats.getTickerCount(TickerType.BLOCK_CACHE_INDEX_HIT)).thenReturn(100L);
+    when(mockStats.getTickerCount(TickerType.BLOCK_CACHE_FILTER_HIT)).thenReturn(200L);
+    when(mockStats.getTickerCount(TickerType.BLOCK_CACHE_DATA_HIT)).thenReturn(300L);
+    when(mockStats.getTickerCount(TickerType.BLOCK_CACHE_COMPRESSION_DICT_HIT)).thenReturn(400L);
+
+    validateComponentGauge(100, BLOCK_CACHE_HIT_COUNT, VeniceRocksDBBlockCacheComponent.INDEX);
+    validateComponentGauge(200, BLOCK_CACHE_HIT_COUNT, VeniceRocksDBBlockCacheComponent.FILTER);
+    validateComponentGauge(300, BLOCK_CACHE_HIT_COUNT, VeniceRocksDBBlockCacheComponent.DATA);
+    validateComponentGauge(400, BLOCK_CACHE_HIT_COUNT, VeniceRocksDBBlockCacheComponent.COMPRESSION_DICT);
+  }
+
+  @Test
+  public void testBlockCacheAddCountByComponent() {
+    when(mockStats.getTickerCount(TickerType.BLOCK_CACHE_INDEX_ADD)).thenReturn(5L);
+    when(mockStats.getTickerCount(TickerType.BLOCK_CACHE_FILTER_ADD)).thenReturn(6L);
+    when(mockStats.getTickerCount(TickerType.BLOCK_CACHE_DATA_ADD)).thenReturn(7L);
+    when(mockStats.getTickerCount(TickerType.BLOCK_CACHE_COMPRESSION_DICT_ADD)).thenReturn(8L);
+
+    validateComponentGauge(5, BLOCK_CACHE_ADD_COUNT, VeniceRocksDBBlockCacheComponent.INDEX);
+    validateComponentGauge(6, BLOCK_CACHE_ADD_COUNT, VeniceRocksDBBlockCacheComponent.FILTER);
+    validateComponentGauge(7, BLOCK_CACHE_ADD_COUNT, VeniceRocksDBBlockCacheComponent.DATA);
+    validateComponentGauge(8, BLOCK_CACHE_ADD_COUNT, VeniceRocksDBBlockCacheComponent.COMPRESSION_DICT);
+  }
+
+  @Test
+  public void testBlockCacheBytesInsertByComponent() {
+    when(mockStats.getTickerCount(TickerType.BLOCK_CACHE_INDEX_BYTES_INSERT)).thenReturn(1024L);
+    when(mockStats.getTickerCount(TickerType.BLOCK_CACHE_FILTER_BYTES_INSERT)).thenReturn(2048L);
+    when(mockStats.getTickerCount(TickerType.BLOCK_CACHE_DATA_BYTES_INSERT)).thenReturn(4096L);
+    when(mockStats.getTickerCount(TickerType.BLOCK_CACHE_COMPRESSION_DICT_BYTES_INSERT)).thenReturn(512L);
+
+    validateComponentGauge(1024, BLOCK_CACHE_BYTES_INSERTED, VeniceRocksDBBlockCacheComponent.INDEX);
+    validateComponentGauge(2048, BLOCK_CACHE_BYTES_INSERTED, VeniceRocksDBBlockCacheComponent.FILTER);
+    validateComponentGauge(4096, BLOCK_CACHE_BYTES_INSERTED, VeniceRocksDBBlockCacheComponent.DATA);
+    validateComponentGauge(512, BLOCK_CACHE_BYTES_INSERTED, VeniceRocksDBBlockCacheComponent.COMPRESSION_DICT);
+  }
+
+  // --- Joint Tehuti+OTel metrics (cluster-only attributes) ---
+
+  @Test
+  public void testJointBlockCacheMetrics() {
+    when(mockStats.getTickerCount(TickerType.BLOCK_CACHE_ADD_FAILURES)).thenReturn(3L);
+    when(mockStats.getTickerCount(TickerType.BLOCK_CACHE_BYTES_READ)).thenReturn(8192L);
+    when(mockStats.getTickerCount(TickerType.BLOCK_CACHE_BYTES_WRITE)).thenReturn(4096L);
+
+    validateClusterGauge(3, BLOCK_CACHE_ADD_FAILURE_COUNT);
+    validateClusterGauge(8192, BLOCK_CACHE_READ_BYTES);
+    validateClusterGauge(4096, BLOCK_CACHE_WRITE_BYTES);
+  }
+
+  @Test
+  public void testJointBloomFilterMemtableAndCompactionMetrics() {
+    when(mockStats.getTickerCount(TickerType.BLOOM_FILTER_USEFUL)).thenReturn(50L);
+    when(mockStats.getTickerCount(TickerType.MEMTABLE_HIT)).thenReturn(60L);
+    when(mockStats.getTickerCount(TickerType.MEMTABLE_MISS)).thenReturn(70L);
+    when(mockStats.getTickerCount(TickerType.COMPACTION_CANCELLED)).thenReturn(2L);
+
+    validateClusterGauge(50, BLOOM_FILTER_USEFUL_COUNT);
+    validateClusterGauge(60, MEMTABLE_HIT_COUNT);
+    validateClusterGauge(70, MEMTABLE_MISS_COUNT);
+    validateClusterGauge(2, COMPACTION_CANCELLED_COUNT);
+  }
+
+  // --- Get Hit by Level (SST_LEVEL dimension) ---
+
+  @Test
+  public void testGetHitCountWithSstLevelDimension() {
+    when(mockStats.getTickerCount(TickerType.GET_HIT_L0)).thenReturn(10L);
+    when(mockStats.getTickerCount(TickerType.GET_HIT_L1)).thenReturn(20L);
+    when(mockStats.getTickerCount(TickerType.GET_HIT_L2_AND_UP)).thenReturn(30L);
+
+    validateSstLevelGauge(10, VeniceRocksDBLevel.LEVEL_0);
+    validateSstLevelGauge(20, VeniceRocksDBLevel.LEVEL_1);
+    validateSstLevelGauge(30, VeniceRocksDBLevel.LEVEL_2_AND_UP);
+  }
+
+  // --- Read Amplification (ASYNC_DOUBLE_GAUGE) ---
+
+  @Test
+  public void testReadAmplificationFactor() {
+    when(mockStats.getTickerCount(TickerType.READ_AMP_TOTAL_READ_BYTES)).thenReturn(1000L);
+    when(mockStats.getTickerCount(TickerType.READ_AMP_ESTIMATE_USEFUL_BYTES)).thenReturn(500L);
+
+    OpenTelemetryDataTestUtils.validateDoublePointDataFromGauge(
+        inMemoryMetricReader,
+        2.0,
+        0.01,
+        buildClusterAttributes(),
+        READ_AMPLIFICATION_FACTOR.getMetricEntity().getMetricName(),
+        TEST_METRIC_PREFIX);
+  }
+
+  @Test
+  public void testReadAmplificationFactorReturnsNaNWhenUsefulBytesZero() {
+    when(mockStats.getTickerCount(TickerType.READ_AMP_TOTAL_READ_BYTES)).thenReturn(1000L);
+    when(mockStats.getTickerCount(TickerType.READ_AMP_ESTIMATE_USEFUL_BYTES)).thenReturn(0L);
+
+    // NaN causes OTel SDK to drop the data point
+    Collection<MetricData> metricsData = inMemoryMetricReader.collectAllMetrics();
+    String fullName =
+        "venice." + TEST_METRIC_PREFIX + "." + READ_AMPLIFICATION_FACTOR.getMetricEntity().getMetricName();
+    boolean hasDataPoint = metricsData.stream()
+        .filter(m -> m.getName().equals(fullName))
+        .flatMap(m -> m.getDoubleGaugeData().getPoints().stream())
+        .anyMatch(p -> p.getAttributes().equals(buildClusterAttributes()));
+    assertFalse(hasDataPoint, "Expected no data point when useful bytes is 0 (NaN)");
+  }
+
+  // --- Negative tests ---
+
+  @Test
+  public void testMetricsReturnNegativeOneBeforeStatSet() {
+    InMemoryMetricReader uninitReader = InMemoryMetricReader.create();
+    try (VeniceMetricsRepository uninitRepo = new VeniceMetricsRepository(
+        new VeniceMetricsConfig.Builder().setMetricPrefix(TEST_METRIC_PREFIX)
+            .setMetricEntities(SERVER_METRIC_ENTITIES)
+            .setEmitOtelMetrics(true)
+            .setOtelAdditionalMetricsReader(uninitReader)
+            .build())) {
+      new RocksDBStats(uninitRepo, "rocksdb_uninit", TEST_CLUSTER_NAME);
+
+      // Joint metrics return -1 when rocksDBStat is null
+      OpenTelemetryDataTestUtils.validateLongPointDataFromGauge(
+          uninitReader,
+          -1,
+          buildClusterAttributes(),
+          BLOOM_FILTER_USEFUL_COUNT.getMetricEntity().getMetricName(),
+          TEST_METRIC_PREFIX);
+
+      // Per-component metrics also return -1
+      OpenTelemetryDataTestUtils.validateLongPointDataFromGauge(
+          uninitReader,
+          -1,
+          buildComponentAttributes(VeniceRocksDBBlockCacheComponent.DATA),
+          BLOCK_CACHE_MISS_COUNT.getMetricEntity().getMetricName(),
+          TEST_METRIC_PREFIX);
+
+      // SST-level metrics return -1
+      OpenTelemetryDataTestUtils.validateLongPointDataFromGauge(
+          uninitReader,
+          -1,
+          buildSstLevelAttributes(VeniceRocksDBLevel.LEVEL_0),
+          GET_HIT_COUNT.getMetricEntity().getMetricName(),
+          TEST_METRIC_PREFIX);
+    }
+  }
+
+  @Test
+  public void testNoNpeWhenOtelDisabled() {
+    try (VeniceMetricsRepository disabledRepo = new VeniceMetricsRepository(
+        new VeniceMetricsConfig.Builder().setMetricPrefix(TEST_METRIC_PREFIX).setEmitOtelMetrics(false).build())) {
+      RocksDBStats stats = new RocksDBStats(disabledRepo, "rocksdb_stat", TEST_CLUSTER_NAME);
+      stats.setRocksDBStat(mockStats);
+    }
+  }
+
+  @Test
+  public void testNoNpeWhenPlainMetricsRepository() {
+    RocksDBStats stats = new RocksDBStats(new MetricsRepository(), "rocksdb_stat", TEST_CLUSTER_NAME);
+    stats.setRocksDBStat(mockStats);
+  }
+
+  // --- Helpers ---
+
+  private void validateClusterGauge(long expectedValue, RocksDBStatsOtelMetricEntity entity) {
+    OpenTelemetryDataTestUtils.validateLongPointDataFromGauge(
+        inMemoryMetricReader,
+        expectedValue,
+        buildClusterAttributes(),
+        entity.getMetricEntity().getMetricName(),
+        TEST_METRIC_PREFIX);
+  }
+
+  private void validateSstLevelGauge(long expectedValue, VeniceRocksDBLevel level) {
+    OpenTelemetryDataTestUtils.validateLongPointDataFromGauge(
+        inMemoryMetricReader,
+        expectedValue,
+        buildSstLevelAttributes(level),
+        GET_HIT_COUNT.getMetricEntity().getMetricName(),
+        TEST_METRIC_PREFIX);
+  }
+
+  private void validateComponentGauge(
+      long expectedValue,
+      RocksDBStatsOtelMetricEntity entity,
+      VeniceRocksDBBlockCacheComponent component) {
+    OpenTelemetryDataTestUtils.validateLongPointDataFromGauge(
+        inMemoryMetricReader,
+        expectedValue,
+        buildComponentAttributes(component),
+        entity.getMetricEntity().getMetricName(),
+        TEST_METRIC_PREFIX);
+  }
+
+  private static Attributes buildClusterAttributes() {
+    return Attributes.builder().put(VENICE_CLUSTER_NAME.getDimensionNameInDefaultFormat(), TEST_CLUSTER_NAME).build();
+  }
+
+  private static Attributes buildComponentAttributes(VeniceRocksDBBlockCacheComponent component) {
+    return Attributes.builder()
+        .put(VENICE_CLUSTER_NAME.getDimensionNameInDefaultFormat(), TEST_CLUSTER_NAME)
+        .put(VENICE_ROCKSDB_BLOCK_CACHE_COMPONENT.getDimensionNameInDefaultFormat(), component.getDimensionValue())
+        .build();
+  }
+
+  private static Attributes buildSstLevelAttributes(VeniceRocksDBLevel level) {
+    return Attributes.builder()
+        .put(VENICE_CLUSTER_NAME.getDimensionNameInDefaultFormat(), TEST_CLUSTER_NAME)
+        .put(VENICE_ROCKSDB_LEVEL.getDimensionNameInDefaultFormat(), level.getDimensionValue())
+        .build();
+  }
+}

--- a/services/venice-server/src/test/java/com/linkedin/venice/stats/RocksDBStatsOtelTest.java
+++ b/services/venice-server/src/test/java/com/linkedin/venice/stats/RocksDBStatsOtelTest.java
@@ -30,7 +30,10 @@ import com.linkedin.venice.utils.OpenTelemetryDataTestUtils;
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.sdk.metrics.data.MetricData;
 import io.opentelemetry.sdk.testing.exporter.InMemoryMetricReader;
+import io.tehuti.metrics.MetricConfig;
 import io.tehuti.metrics.MetricsRepository;
+import io.tehuti.metrics.stats.AsyncGauge;
+import java.io.IOException;
 import java.util.Collection;
 import org.rocksdb.Statistics;
 import org.rocksdb.TickerType;
@@ -45,17 +48,23 @@ public class RocksDBStatsOtelTest {
 
   private InMemoryMetricReader inMemoryMetricReader;
   private VeniceMetricsRepository metricsRepository;
+  private AsyncGauge.AsyncGaugeExecutor asyncGaugeExecutor;
   private Statistics mockStats;
   private RocksDBStats rocksDBStats;
 
   @BeforeMethod
-  public void setUp() {
+  public void setUp() throws IOException {
     inMemoryMetricReader = InMemoryMetricReader.create();
+    // Dedicated AsyncGauge executor: VeniceMetricsRepository.close() shuts down the Tehuti
+    // executor it was given. Without this, close() in tearDown / try-with-resources would shut
+    // down the static singleton DEFAULT_ASYNC_GAUGE_EXECUTOR JVM-wide and break later tests.
+    asyncGaugeExecutor = new AsyncGauge.AsyncGaugeExecutor.Builder().build();
     metricsRepository = new VeniceMetricsRepository(
         new VeniceMetricsConfig.Builder().setMetricPrefix(TEST_METRIC_PREFIX)
             .setMetricEntities(SERVER_METRIC_ENTITIES)
             .setEmitOtelMetrics(true)
             .setOtelAdditionalMetricsReader(inMemoryMetricReader)
+            .setTehutiMetricConfig(new MetricConfig(asyncGaugeExecutor))
             .build());
     mockStats = mock(Statistics.class);
     rocksDBStats = new RocksDBStats(metricsRepository, "rocksdb_stat", TEST_CLUSTER_NAME);
@@ -63,9 +72,12 @@ public class RocksDBStatsOtelTest {
   }
 
   @AfterMethod
-  public void tearDown() {
+  public void tearDown() throws IOException {
     if (metricsRepository != null) {
       metricsRepository.close();
+    }
+    if (asyncGaugeExecutor != null) {
+      asyncGaugeExecutor.close();
     }
   }
 
@@ -197,14 +209,16 @@ public class RocksDBStatsOtelTest {
   // --- Negative tests ---
 
   @Test
-  public void testMetricsBehaviorBeforeStatSet() {
+  public void testMetricsBehaviorBeforeStatSet() throws IOException {
     InMemoryMetricReader uninitReader = InMemoryMetricReader.create();
-    try (VeniceMetricsRepository uninitRepo = new VeniceMetricsRepository(
-        new VeniceMetricsConfig.Builder().setMetricPrefix(TEST_METRIC_PREFIX)
-            .setMetricEntities(SERVER_METRIC_ENTITIES)
-            .setEmitOtelMetrics(true)
-            .setOtelAdditionalMetricsReader(uninitReader)
-            .build())) {
+    try (AsyncGauge.AsyncGaugeExecutor localExecutor = new AsyncGauge.AsyncGaugeExecutor.Builder().build();
+        VeniceMetricsRepository uninitRepo = new VeniceMetricsRepository(
+            new VeniceMetricsConfig.Builder().setMetricPrefix(TEST_METRIC_PREFIX)
+                .setMetricEntities(SERVER_METRIC_ENTITIES)
+                .setEmitOtelMetrics(true)
+                .setOtelAdditionalMetricsReader(uninitReader)
+                .setTehutiMetricConfig(new MetricConfig(localExecutor))
+                .build())) {
       new RocksDBStats(uninitRepo, "rocksdb_uninit", TEST_CLUSTER_NAME);
 
       // Joint metrics (AsyncMetricEntityStateBase) emit the -1 sentinel pre-init — the base
@@ -278,9 +292,42 @@ public class RocksDBStatsOtelTest {
   }
 
   @Test
-  public void testNoNpeWhenOtelDisabled() {
-    try (VeniceMetricsRepository disabledRepo = new VeniceMetricsRepository(
-        new VeniceMetricsConfig.Builder().setMetricPrefix(TEST_METRIC_PREFIX).setEmitOtelMetrics(false).build())) {
+  public void testOtelEmitsForTotalStatsName() throws IOException {
+    // Regression guard: in production AggRocksDBStats only constructs the totalStats instance
+    // (named "total") and never per-store stats, so the totalStats IS the canonical recorder.
+    // RocksDBStats must not propagate isTotalStats() — otherwise OpenTelemetryMetricsSetup
+    // suppresses every RocksDB OTel emission in production.
+    InMemoryMetricReader totalReader = InMemoryMetricReader.create();
+    try (AsyncGauge.AsyncGaugeExecutor localExecutor = new AsyncGauge.AsyncGaugeExecutor.Builder().build();
+        VeniceMetricsRepository totalRepo = new VeniceMetricsRepository(
+            new VeniceMetricsConfig.Builder().setMetricPrefix(TEST_METRIC_PREFIX)
+                .setMetricEntities(SERVER_METRIC_ENTITIES)
+                .setEmitOtelMetrics(true)
+                .setOtelAdditionalMetricsReader(totalReader)
+                .setTehutiMetricConfig(new MetricConfig(localExecutor))
+                .build())) {
+      Statistics totalMockStats = mock(Statistics.class);
+      when(totalMockStats.getTickerCount(TickerType.GET_HIT_L0)).thenReturn(123L);
+      RocksDBStats totalStats = new RocksDBStats(totalRepo, "total", TEST_CLUSTER_NAME);
+      totalStats.setRocksDBStat(totalMockStats);
+
+      OpenTelemetryDataTestUtils.validateLongPointDataFromGauge(
+          totalReader,
+          123,
+          buildSstLevelAttributes(VeniceRocksDBLevel.LEVEL_0),
+          GET_HIT_COUNT.getMetricEntity().getMetricName(),
+          TEST_METRIC_PREFIX);
+    }
+  }
+
+  @Test
+  public void testNoNpeWhenOtelDisabled() throws IOException {
+    try (AsyncGauge.AsyncGaugeExecutor localExecutor = new AsyncGauge.AsyncGaugeExecutor.Builder().build();
+        VeniceMetricsRepository disabledRepo = new VeniceMetricsRepository(
+            new VeniceMetricsConfig.Builder().setMetricPrefix(TEST_METRIC_PREFIX)
+                .setEmitOtelMetrics(false)
+                .setTehutiMetricConfig(new MetricConfig(localExecutor))
+                .build())) {
       RocksDBStats stats = new RocksDBStats(disabledRepo, "rocksdb_stat", TEST_CLUSTER_NAME);
       stats.setRocksDBStat(mockStats);
     }

--- a/services/venice-server/src/test/java/com/linkedin/venice/stats/RocksDBStatsOtelTest.java
+++ b/services/venice-server/src/test/java/com/linkedin/venice/stats/RocksDBStatsOtelTest.java
@@ -20,6 +20,8 @@ import static com.linkedin.venice.stats.dimensions.VeniceMetricsDimensions.VENIC
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertNull;
 
 import com.linkedin.davinci.stats.RocksDBStatsOtelMetricEntity;
 import com.linkedin.venice.stats.dimensions.VeniceRocksDBBlockCacheComponent;
@@ -195,7 +197,7 @@ public class RocksDBStatsOtelTest {
   // --- Negative tests ---
 
   @Test
-  public void testMetricsReturnNegativeOneBeforeStatSet() {
+  public void testMetricsBehaviorBeforeStatSet() {
     InMemoryMetricReader uninitReader = InMemoryMetricReader.create();
     try (VeniceMetricsRepository uninitRepo = new VeniceMetricsRepository(
         new VeniceMetricsConfig.Builder().setMetricPrefix(TEST_METRIC_PREFIX)
@@ -205,7 +207,9 @@ public class RocksDBStatsOtelTest {
             .build())) {
       new RocksDBStats(uninitRepo, "rocksdb_uninit", TEST_CLUSTER_NAME);
 
-      // Joint metrics return -1 when rocksDBStat is null
+      // Joint metrics (AsyncMetricEntityStateBase) emit the -1 sentinel pre-init — the base
+      // wrapper has no liveness contract, so the LongSupplier callback fires every cycle and
+      // returns -1 when rocksDBStat is null.
       OpenTelemetryDataTestUtils.validateLongPointDataFromGauge(
           uninitReader,
           -1,
@@ -213,21 +217,63 @@ public class RocksDBStatsOtelTest {
           BLOOM_FILTER_USEFUL_COUNT.getMetricEntity().getMetricName(),
           TEST_METRIC_PREFIX);
 
-      // Per-component metrics also return -1
-      OpenTelemetryDataTestUtils.validateLongPointDataFromGauge(
-          uninitReader,
-          -1,
-          buildComponentAttributes(VeniceRocksDBBlockCacheComponent.DATA),
-          BLOCK_CACHE_MISS_COUNT.getMetricEntity().getMetricName(),
-          TEST_METRIC_PREFIX);
+      // Per-component and SST-level metrics (AsyncMetricEntityStateOneEnum) honor the dormant
+      // contract — the liveStateResolver returns null pre-init, so no data point is emitted.
+      Collection<MetricData> metrics = uninitReader.collectAllMetrics();
+      assertNull(
+          OpenTelemetryDataTestUtils.getLongPointDataFromGaugeIfPresent(
+              metrics,
+              BLOCK_CACHE_MISS_COUNT.getMetricEntity().getMetricName(),
+              TEST_METRIC_PREFIX,
+              buildComponentAttributes(VeniceRocksDBBlockCacheComponent.DATA)),
+          "Per-component metric should emit no data point pre-init (dormant contract)");
+      assertNull(
+          OpenTelemetryDataTestUtils.getLongPointDataFromGaugeIfPresent(
+              metrics,
+              GET_HIT_COUNT.getMetricEntity().getMetricName(),
+              TEST_METRIC_PREFIX,
+              buildSstLevelAttributes(VeniceRocksDBLevel.LEVEL_0)),
+          "SST-level metric should emit no data point pre-init (dormant contract)");
+    }
+  }
 
-      // SST-level metrics return -1
-      OpenTelemetryDataTestUtils.validateLongPointDataFromGauge(
-          uninitReader,
-          -1,
-          buildSstLevelAttributes(VeniceRocksDBLevel.LEVEL_0),
-          GET_HIT_COUNT.getMetricEntity().getMetricName(),
-          TEST_METRIC_PREFIX);
+  // --- Completeness guards ---
+  // If a new VeniceRocksDBLevel or VeniceRocksDBBlockCacheComponent value is added without
+  // updating the corresponding ticker map in RocksDBStats, the liveStateResolver returns null
+  // and the new combo silently emits no data point. These tests iterate every enum value and
+  // assert each lands a data point, catching the omission at CI time.
+
+  @Test
+  public void testEveryVeniceRocksDBLevelEmitsForGetHitCount() {
+    Collection<MetricData> metrics = inMemoryMetricReader.collectAllMetrics();
+    String metricName = GET_HIT_COUNT.getMetricEntity().getMetricName();
+    for (VeniceRocksDBLevel level: VeniceRocksDBLevel.values()) {
+      assertNotNull(
+          OpenTelemetryDataTestUtils.getLongPointDataFromGaugeIfPresent(
+              metrics,
+              metricName,
+              TEST_METRIC_PREFIX,
+              buildSstLevelAttributes(level)),
+          "VeniceRocksDBLevel." + level + " must emit a data point — add it to "
+              + "GET_HIT_TICKER_BY_LEVEL in RocksDBStats.");
+    }
+  }
+
+  @Test
+  public void testEveryVeniceRocksDBBlockCacheComponentEmitsForAllPerComponentMetrics() {
+    Collection<MetricData> metrics = inMemoryMetricReader.collectAllMetrics();
+    RocksDBStatsOtelMetricEntity[] perComponentMetrics =
+        { BLOCK_CACHE_MISS_COUNT, BLOCK_CACHE_HIT_COUNT, BLOCK_CACHE_ADD_COUNT, BLOCK_CACHE_BYTES_INSERTED };
+    for (VeniceRocksDBBlockCacheComponent component: VeniceRocksDBBlockCacheComponent.values()) {
+      Attributes attrs = buildComponentAttributes(component);
+      for (RocksDBStatsOtelMetricEntity entity: perComponentMetrics) {
+        String metricName = entity.getMetricEntity().getMetricName();
+        assertNotNull(
+            OpenTelemetryDataTestUtils
+                .getLongPointDataFromGaugeIfPresent(metrics, metricName, TEST_METRIC_PREFIX, attrs),
+            "VeniceRocksDBBlockCacheComponent." + component + " must emit a data point for " + metricName
+                + " — add it to the corresponding ticker map in RocksDBStats.");
+      }
     }
   }
 

--- a/services/venice-server/src/test/java/com/linkedin/venice/stats/RocksDBStatsTehutiTest.java
+++ b/services/venice-server/src/test/java/com/linkedin/venice/stats/RocksDBStatsTehutiTest.java
@@ -1,0 +1,96 @@
+package com.linkedin.venice.stats;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+
+import com.linkedin.venice.exceptions.VeniceException;
+import io.tehuti.metrics.MetricsRepository;
+import org.rocksdb.Statistics;
+import org.rocksdb.TickerType;
+import org.testng.annotations.Test;
+
+
+/**
+ * Tehuti baseline tests for {@link RocksDBStats}. Uses plain {@link MetricsRepository} (not
+ * {@link VeniceMetricsRepository}) to avoid the static AsyncGaugeExecutor shutdown issue
+ * that occurs when VeniceMetricsRepository.close() is called in other test classes.
+ *
+ * <p>Each test creates its own MetricsRepository to stay self-contained.
+ */
+public class RocksDBStatsTehutiTest {
+  private static final String TEST_CLUSTER_NAME = "test-cluster";
+  private static final String STAT_NAME = "rocksdb_stat";
+
+  @Test
+  public void testTickerSensors() {
+    MetricsRepository repo = new MetricsRepository();
+    createAndInit(
+        repo,
+        mockStats(
+            TickerType.BLOCK_CACHE_DATA_HIT,
+            100L,
+            TickerType.BLOCK_CACHE_MISS,
+            50L,
+            TickerType.BLOOM_FILTER_USEFUL,
+            42L,
+            TickerType.BLOCK_CACHE_COMPRESSION_DICT_MISS,
+            7L));
+
+    assertEquals(getGauge(repo, "rocksdb_block_cache_data_hit"), 100.0);
+    assertEquals(getGauge(repo, "rocksdb_block_cache_compression_dict_miss"), 7.0);
+    assertEquals(getGauge(repo, "rocksdb_bloom_filter_useful"), 42.0);
+    // Hit ratio: 100 / (100 + 50) = 0.6667
+    assertEquals(getGauge(repo, "rocksdb_block_cache_hit_ratio"), 100.0 / 150.0, 0.001);
+  }
+
+  @Test
+  public void testReadAmplificationReturnsNegativeOneWhenStatNull() {
+    MetricsRepository repo = new MetricsRepository();
+    new RocksDBStats(repo, STAT_NAME, TEST_CLUSTER_NAME);
+    assertEquals(getGauge(repo, "rocksdb_read_amplification_factor"), -1.0);
+  }
+
+  @Test
+  public void testHitRatioReturnsNaNWhenBothZero() {
+    MetricsRepository repo = new MetricsRepository();
+    createAndInit(repo, mockStats(TickerType.BLOCK_CACHE_DATA_HIT, 0L, TickerType.BLOCK_CACHE_MISS, 0L));
+
+    assertTrue(
+        Double.isNaN(getGauge(repo, "rocksdb_block_cache_hit_ratio")),
+        "Expected NaN when both dataHit and miss are 0");
+  }
+
+  @Test(expectedExceptions = VeniceException.class)
+  public void testSetRocksDBStatThrowsOnDoubleInit() {
+    MetricsRepository repo = new MetricsRepository();
+    RocksDBStats stats = createAndInit(repo, mock(Statistics.class));
+    stats.setRocksDBStat(mock(Statistics.class));
+  }
+
+  @Test(expectedExceptions = IllegalArgumentException.class)
+  public void testSetRocksDBStatThrowsOnNull() {
+    new RocksDBStats(new MetricsRepository(), STAT_NAME, TEST_CLUSTER_NAME).setRocksDBStat(null);
+  }
+
+  // --- Helpers ---
+
+  private RocksDBStats createAndInit(MetricsRepository repo, Statistics mockStat) {
+    RocksDBStats stats = new RocksDBStats(repo, STAT_NAME, TEST_CLUSTER_NAME);
+    stats.setRocksDBStat(mockStat);
+    return stats;
+  }
+
+  private static Statistics mockStats(Object... tickerValuePairs) {
+    Statistics mock = mock(Statistics.class);
+    for (int i = 0; i < tickerValuePairs.length; i += 2) {
+      when(mock.getTickerCount((TickerType) tickerValuePairs[i])).thenReturn((Long) tickerValuePairs[i + 1]);
+    }
+    return mock;
+  }
+
+  private double getGauge(MetricsRepository repo, String sensorName) {
+    return repo.getMetric("." + STAT_NAME + "--" + sensorName + ".Gauge").value();
+  }
+}


### PR DESCRIPTION
## Problem Statement

RocksDBStats (gated by `rocksdb.statistics.enabled`, default false) reports 27 Tehuti AsyncGauge sensors for RocksDB ticker counters but has no OTel metrics. This prevents migration to OTel-based monitoring for RocksDB block cache, memtable, bloom filter, compaction, and read amplification statistics.

## Solution

Add 13 OTel metrics alongside the existing 27 Tehuti sensors, consolidating per-component metrics using dimensions:

- **4 per-component block cache metrics** (`miss.count`, `hit.count`, `add.count`, `bytes.inserted`) with `VENICE_ROCKSDB_BLOCK_CACHE_COMPONENT` dimension (INDEX/FILTER/DATA/COMPRESSION_DICT) — consolidates 16 Tehuti sensors into 4 OTel metrics
- **7 joint Tehuti+OTel metrics** for block cache add failures, bytes read/write, bloom filter, memtable hit/miss, and compaction cancelled
- **1 per-level get-hit metric** (`get.hit.count`) with `VENICE_ROCKSDB_LEVEL` dimension (LEVEL_0/LEVEL_1/LEVEL_2_AND_UP) — consolidates 3 Tehuti sensors into 1 OTel metric
- **1 read amplification factor** using `ASYNC_DOUBLE_GAUGE` with split callbacks (Tehuti returns -1 sentinel, OTel returns NaN when unavailable so SDK drops data point)

Overall block cache miss/hit/add counters remain Tehuti-only — OTel totals are derivable via `sum by (component)`. Block cache hit ratio is also Tehuti-only (derivable from per-component OTel gauges).

<details>
<summary>Tehuti → OTel metric mapping (click to expand)</summary>

| Tehuti Sensor | OTel Metric | OTel Dimensions | Notes |
|---|---|---|---|
| `rocksdb_block_cache_index_miss` | `rocksdb.block_cache.miss.count` | COMPONENT=INDEX | Per-component |
| `rocksdb_block_cache_filter_miss` | `rocksdb.block_cache.miss.count` | COMPONENT=FILTER | Per-component |
| `rocksdb_block_cache_data_miss` | `rocksdb.block_cache.miss.count` | COMPONENT=DATA | Per-component |
| `rocksdb_block_cache_compression_dict_miss` | `rocksdb.block_cache.miss.count` | COMPONENT=COMPRESSION_DICT | Per-component |
| `rocksdb_block_cache_index_hit` | `rocksdb.block_cache.hit.count` | COMPONENT=INDEX | Per-component |
| `rocksdb_block_cache_filter_hit` | `rocksdb.block_cache.hit.count` | COMPONENT=FILTER | Per-component |
| `rocksdb_block_cache_data_hit` | `rocksdb.block_cache.hit.count` | COMPONENT=DATA | Per-component |
| `rocksdb_block_cache_compression_dict_hit` | `rocksdb.block_cache.hit.count` | COMPONENT=COMPRESSION_DICT | Per-component |
| `rocksdb_block_cache_index_add` | `rocksdb.block_cache.add.count` | COMPONENT=INDEX | Per-component |
| `rocksdb_block_cache_filter_add` | `rocksdb.block_cache.add.count` | COMPONENT=FILTER | Per-component |
| `rocksdb_block_cache_data_add` | `rocksdb.block_cache.add.count` | COMPONENT=DATA | Per-component |
| `rocksdb_block_cache_compression_dict_add` | `rocksdb.block_cache.add.count` | COMPONENT=COMPRESSION_DICT | Per-component |
| `rocksdb_block_cache_index_bytes_insert` | `rocksdb.block_cache.bytes.inserted` | COMPONENT=INDEX | Per-component |
| `rocksdb_block_cache_filter_bytes_insert` | `rocksdb.block_cache.bytes.inserted` | COMPONENT=FILTER | Per-component |
| `rocksdb_block_cache_data_bytes_insert` | `rocksdb.block_cache.bytes.inserted` | COMPONENT=DATA | Per-component |
| `rocksdb_block_cache_compression_dict_bytes_insert` | `rocksdb.block_cache.bytes.inserted` | COMPONENT=COMPRESSION_DICT | Per-component |
| `rocksdb_block_cache_add_failures` | `rocksdb.block_cache.add.failure.count` | — | Joint |
| `rocksdb_block_cache_bytes_read` | `rocksdb.block_cache.bytes.read` | — | Joint |
| `rocksdb_block_cache_bytes_write` | `rocksdb.block_cache.bytes.written` | — | Joint |
| `rocksdb_bloom_filter_useful` | `rocksdb.bloom_filter.useful_count` | — | Joint |
| `rocksdb_memtable_hit` | `rocksdb.memtable.hit.count` | — | Joint |
| `rocksdb_memtable_miss` | `rocksdb.memtable.miss.count` | — | Joint |
| `rocksdb_compaction_cancelled` | `rocksdb.compaction.cancelled_count` | — | Joint |
| `rocksdb_get_hit_l0` | `rocksdb.get.hit.count` | LEVEL=LEVEL_0 | Per-level |
| `rocksdb_get_hit_l1` | `rocksdb.get.hit.count` | LEVEL=LEVEL_1 | Per-level |
| `rocksdb_get_hit_l2_and_up` | `rocksdb.get.hit.count` | LEVEL=LEVEL_2_AND_UP | Per-level |
| `rocksdb_read_amplification_factor` | `rocksdb.read_amplification_factor` | — | ASYNC_DOUBLE_GAUGE |
| `rocksdb_block_cache_miss` | — | — | Tehuti-only (OTel derives from sum) |
| `rocksdb_block_cache_hit` | — | — | Tehuti-only (OTel derives from sum) |
| `rocksdb_block_cache_add` | — | — | Tehuti-only (OTel derives from sum) |
| `rocksdb_block_cache_hit_ratio` | — | — | Tehuti-only (derivable from OTel gauges) |

</details>

Dimension-to-TickerType mappings use static `EnumMap`s. A missing mapping causes the `liveStateResolver` to return `null` (dormant — no data point emitted) rather than throwing; completeness is enforced by per-enum CI tests (`testEveryVeniceRocksDBLevelEmitsForGetHitCount`, `testEveryVeniceRocksDBBlockCacheComponentEmitsForAllPerComponentMetrics`) so adding a new `VeniceRocksDBLevel` or `VeniceRocksDBBlockCacheComponent` value without updating the ticker map fails CI rather than spamming failure metrics every collection cycle.

Also fixes: `AggRocksDBStats` lambda was capturing the outer `metricsRepository` constructor parameter instead of the lambda parameter `metricsRepo`, and adds null guard to `setRocksDBStat`. `rocksDBStat` field made `volatile` for JMM correctness. `RocksDBStats` does NOT propagate `isTotalStats()` to `OpenTelemetryMetricsSetup` — `AggRocksDBStats` is fire-and-forget in `VeniceServer.java`, so the `totalStats` instance is the only `RocksDBStats` ever created in production. Propagating `isTotalStats(true)` would suppress every RocksDB OTel emission. This matches the pattern used by `RocksDBMemoryStats` (the closest single-instance analog).

### Code changes
- [ ] Added new code behind **a config**. If so list the config names and their default values in the PR description.
- [ ] Introduced new **log lines**.
  - [ ] Confirmed if logs need to be **rate limited** to avoid excessive logging.

### **Concurrency-Specific Checks**
Both reviewer and PR author to verify
- [x] Code has **no race conditions** or **thread safety issues**.
- [x] Proper **synchronization mechanisms** (e.g., `synchronized`, `RWLock`) are used where needed.
- [x] No **blocking calls** inside critical sections that could lead to deadlocks or performance degradation.
- [x] Verified **thread-safe collections** are used (e.g., `ConcurrentHashMap`, `CopyOnWriteArrayList`).
- [x] Validated proper exception handling in multi-threaded code to avoid silent thread termination.

## How was this PR tested?

- [x] New unit tests added.
- [ ] New integration tests added.
- [ ] Modified or extended existing tests.
- [x] Verified backward compatibility (if applicable).

New test files:
- `RocksDBStatsOtelTest` (15 tests): per-component dimension validation for all 4 block cache metrics × 4 components, joint metrics, SST-level dimensions, read amplification `ASYNC_DOUBLE_GAUGE` with NaN edge case, pre-init behavior (joint `AsyncMetricEntityStateBase` metrics emit `-1` sentinel; per-component / per-level `AsyncMetricEntityStateOneEnum` metrics honor the dormant contract and emit no data point), per-enum completeness guards (`testEveryVeniceRocksDBLevelEmitsForGetHitCount`, `testEveryVeniceRocksDBBlockCacheComponentEmitsForAllPerComponentMetrics`), `isTotalStats` regression guard (`testOtelEmitsForTotalStatsName` constructs `RocksDBStats(repo, "total", ...)` and asserts emission so re-introducing `isTotalStats()` propagation fails CI), NPE prevention (OTel disabled + plain `MetricsRepository`). Tests use a dedicated `AsyncGauge.AsyncGaugeExecutor` per `VeniceMetricsRepository` so `close()` doesn't shut down the JVM-wide singleton executor and break later AsyncGauge tests.
- `RocksDBStatsTehutiTest` (5 tests): Tehuti sensor baseline (ticker values, hit ratio formula, read amplification -1 sentinel, NaN on zero denominator, setRocksDBStat guards)
- `RocksDBStatsOtelMetricEntityTest`: validates all 13 entity definitions via ModuleMetricEntityTestFixture
- `VeniceRocksDBBlockCacheComponentTest` + `VeniceRocksDBLevelTest`: dimension enum validation via VeniceDimensionTestFixture
- `VeniceMetricsDimensionsTest`: updated for both new dimensions across all 3 naming formats
- `ServerMetricEntityTest`: count updated from 159 to 172

## Does this PR introduce any user-facing or breaking changes?
- [x] No. You can skip the rest of this section.
- [ ] Yes. Clearly explain the behavior change and its impact.

