### PR TITLE
[common] Handle single-element union in superset schema generation

### DIFF
--- a/internal/venice-client-common/src/main/java/com/linkedin/venice/utils/AvroSupersetSchemaUtils.java
+++ b/internal/venice-client-common/src/main/java/com/linkedin/venice/utils/AvroSupersetSchemaUtils.java
@@ -42,10 +42,14 @@ public class AvroSupersetSchemaUtils {
    * @return super-set schema of rawExistingSchema and rawNewSchema
    */
   public static Schema generateSupersetSchema(Schema rawExistingSchema, Schema rawNewSchema) {
-    // Unwrap single-element unions to their inner type so that [T] is treated
-    // equivalently to T during type comparison and superset generation.
-    final Schema existingSchema = unwrapSingleElementUnion(rawExistingSchema);
-    final Schema newSchema = unwrapSingleElementUnion(rawNewSchema);
+    // Normalize single-element unions [T] to their inner type T so that [T] and T
+    // are treated equivalently. Skip normalization when both inputs are unions —
+    // the multi-element union case is handled by unionSchema() below and must not
+    // be disrupted (e.g. [T] vs ["null", T] must remain a UNION-vs-UNION merge).
+    final boolean bothUnions =
+        rawExistingSchema.getType() == Schema.Type.UNION && rawNewSchema.getType() == Schema.Type.UNION;
+    final Schema existingSchema = bothUnions ? rawExistingSchema : unwrapSingleElementUnion(rawExistingSchema);
+    final Schema newSchema = bothUnions ? rawNewSchema : unwrapSingleElementUnion(rawNewSchema);
 
     if (existingSchema.getType() != newSchema.getType()) {
       throw new VeniceException("Incompatible schema");

--- a/internal/venice-client-common/src/main/java/com/linkedin/venice/utils/AvroSupersetSchemaUtils.java
+++ b/internal/venice-client-common/src/main/java/com/linkedin/venice/utils/AvroSupersetSchemaUtils.java
@@ -37,71 +37,66 @@ public class AvroSupersetSchemaUtils {
    * C/D could be nested record change as well eg, array/map of records, or record of records.
    * Prerequisite: The top-level schema are of type RECORD only and each field have default values. ie they are compatible
    * schemas and the generated schema will pick the default value from new value schema.
-   * @param existingSchema schema existing in the repo
-   * @param newSchema schema to be added.
-   * @return super-set schema of existingSchema abd newSchema
+   * @param rawExistingSchema schema existing in the repo
+   * @param rawNewSchema schema to be added.
+   * @return super-set schema of rawExistingSchema and rawNewSchema
    */
-  public static Schema generateSupersetSchema(Schema existingSchema, Schema newSchema) {
+  public static Schema generateSupersetSchema(Schema rawExistingSchema, Schema rawNewSchema) {
     // Unwrap single-element unions to their inner type so that [T] is treated
     // equivalently to T during type comparison and superset generation.
-    final Schema unwrappedExistingSchema = unwrapSingleElementUnion(existingSchema);
-    final Schema unwrappedNewSchema = unwrapSingleElementUnion(newSchema);
+    final Schema existingSchema = unwrapSingleElementUnion(rawExistingSchema);
+    final Schema newSchema = unwrapSingleElementUnion(rawNewSchema);
 
-    if (unwrappedExistingSchema.getType() != unwrappedNewSchema.getType()) {
+    if (existingSchema.getType() != newSchema.getType()) {
       throw new VeniceException("Incompatible schema");
     }
-    if (Objects.equals(unwrappedExistingSchema, unwrappedNewSchema)) {
-      return unwrappedExistingSchema;
+    if (Objects.equals(existingSchema, newSchema)) {
+      return existingSchema;
     }
 
     // Special handling for String vs Avro string comparison,
     // return the schema with avro.java.string property for string type
-    if (unwrappedExistingSchema.getType() == Schema.Type.STRING) {
-      return AvroCompatibilityHelper.getSchemaPropAsJsonString(unwrappedExistingSchema, "avro.java.string") == null
-          ? unwrappedNewSchema
-          : unwrappedExistingSchema;
+    if (existingSchema.getType() == Schema.Type.STRING) {
+      return AvroCompatibilityHelper.getSchemaPropAsJsonString(existingSchema, "avro.java.string") == null
+          ? newSchema
+          : existingSchema;
     }
 
-    switch (unwrappedExistingSchema.getType()) {
+    switch (existingSchema.getType()) {
       case RECORD:
-        if (!StringUtils.equals(unwrappedExistingSchema.getNamespace(), unwrappedNewSchema.getNamespace())) {
+        if (!StringUtils.equals(existingSchema.getNamespace(), newSchema.getNamespace())) {
           throw new VeniceException(
               String.format(
                   "Trying to merge record schemas with different namespace. "
                       + "Got existing schema namespace: %s and new schema namespace: %s",
-                  unwrappedExistingSchema.getNamespace(),
-                  unwrappedNewSchema.getNamespace()));
+                  existingSchema.getNamespace(),
+                  newSchema.getNamespace()));
         }
-        if (!StringUtils.equals(unwrappedExistingSchema.getName(), unwrappedNewSchema.getName())) {
+        if (!StringUtils.equals(existingSchema.getName(), newSchema.getName())) {
           throw new VeniceException(
               String.format(
                   "Trying to merge record schemas with different name. "
                       + "Got existing schema name: %s and new schema name: %s",
-                  unwrappedExistingSchema.getName(),
-                  unwrappedNewSchema.getName()));
+                  existingSchema.getName(),
+                  newSchema.getName()));
         }
 
-        Schema superSetSchema = Schema.createRecord(
-            unwrappedExistingSchema.getName(),
-            unwrappedExistingSchema.getDoc(),
-            unwrappedExistingSchema.getNamespace(),
-            false);
-        superSetSchema.setFields(mergeFieldSchemas(unwrappedExistingSchema, unwrappedNewSchema));
+        Schema superSetSchema = Schema
+            .createRecord(existingSchema.getName(), existingSchema.getDoc(), existingSchema.getNamespace(), false);
+        superSetSchema.setFields(mergeFieldSchemas(existingSchema, newSchema));
         return superSetSchema;
       case ARRAY:
-        return Schema.createArray(
-            generateSupersetSchema(unwrappedExistingSchema.getElementType(), unwrappedNewSchema.getElementType()));
+        return Schema.createArray(generateSupersetSchema(existingSchema.getElementType(), newSchema.getElementType()));
       case MAP:
-        return Schema.createMap(
-            generateSupersetSchema(unwrappedExistingSchema.getValueType(), unwrappedNewSchema.getValueType()));
+        return Schema.createMap(generateSupersetSchema(existingSchema.getValueType(), newSchema.getValueType()));
       case UNION:
-        return unionSchema(unwrappedExistingSchema, unwrappedNewSchema);
+        return unionSchema(existingSchema, newSchema);
       case ENUM: {
         // Build a superset symbol list: all symbols from existingSchema (preserving their order),
         // followed by any symbols present only in newSchema. This ensures no symbol is lost when
         // the two schemas have diverged (e.g. existing has ["A","B","C"], new has ["A","B","D"]).
-        LinkedHashSet<String> supersetSymbols = new LinkedHashSet<>(unwrappedExistingSchema.getEnumSymbols());
-        supersetSymbols.addAll(unwrappedNewSchema.getEnumSymbols());
+        LinkedHashSet<String> supersetSymbols = new LinkedHashSet<>(existingSchema.getEnumSymbols());
+        supersetSymbols.addAll(newSchema.getEnumSymbols());
         // Always construct a new enum schema so that properties from both schemas are merged
         // consistently, regardless of whether symbols grew or diverged. (Truly-equal schemas are
         // already short-circuited by the Objects.equals check at the top of this method.)
@@ -109,25 +104,25 @@ public class AvroSupersetSchemaUtils {
         // property, so each prop is written exactly once: existingSchema-only props first, then
         // all newSchema props.
         Schema supersetEnum = Schema.createEnum(
-            unwrappedNewSchema.getName(),
-            unwrappedNewSchema.getDoc(),
-            unwrappedNewSchema.getNamespace(),
+            newSchema.getName(),
+            newSchema.getDoc(),
+            newSchema.getNamespace(),
             new ArrayList<>(supersetSymbols),
-            unwrappedNewSchema.getEnumDefault());
-        Set<String> newSchemaPropNames = getSchemaPropNames(unwrappedNewSchema);
-        getSchemaPropNames(unwrappedExistingSchema).stream()
+            newSchema.getEnumDefault());
+        Set<String> newSchemaPropNames = getSchemaPropNames(newSchema);
+        getSchemaPropNames(existingSchema).stream()
             .filter(prop -> !newSchemaPropNames.contains(prop))
             .forEach(
                 prop -> AvroCompatibilityHelper.setSchemaPropFromJsonString(
                     supersetEnum,
                     prop,
-                    AvroCompatibilityHelper.getSchemaPropAsJsonString(unwrappedExistingSchema, prop),
+                    AvroCompatibilityHelper.getSchemaPropAsJsonString(existingSchema, prop),
                     false));
-        getSchemaPropNames(unwrappedNewSchema).forEach(
+        getSchemaPropNames(newSchema).forEach(
             prop -> AvroCompatibilityHelper.setSchemaPropFromJsonString(
                 supersetEnum,
                 prop,
-                AvroCompatibilityHelper.getSchemaPropAsJsonString(unwrappedNewSchema, prop),
+                AvroCompatibilityHelper.getSchemaPropAsJsonString(newSchema, prop),
                 false));
         return supersetEnum;
       }
@@ -135,35 +130,32 @@ public class AvroSupersetSchemaUtils {
         // FIXED schemas are structurally compatible only when their size attributes are identical.
         // A size mismatch is an irreconcilable schema incompatibility — unlike custom properties,
         // the size is part of the binary encoding and cannot be silently promoted.
-        if (unwrappedExistingSchema.getFixedSize() != unwrappedNewSchema.getFixedSize()) {
+        if (existingSchema.getFixedSize() != newSchema.getFixedSize()) {
           throw new VeniceException(
               String.format(
                   "Incompatible FIXED schemas for '%s': existing size %d does not match new size %d",
-                  unwrappedExistingSchema.getFullName(),
-                  unwrappedExistingSchema.getFixedSize(),
-                  unwrappedNewSchema.getFixedSize()));
+                  existingSchema.getFullName(),
+                  existingSchema.getFixedSize(),
+                  newSchema.getFixedSize()));
         }
         // Sizes match — merge properties from both schemas, same convention as ENUM:
         // existingSchema-only props first, then all newSchema props (newSchema wins on conflicts).
-        Schema supersetFixed = Schema.createFixed(
-            unwrappedNewSchema.getName(),
-            unwrappedNewSchema.getDoc(),
-            unwrappedNewSchema.getNamespace(),
-            unwrappedNewSchema.getFixedSize());
-        Set<String> newFixedPropNames = getSchemaPropNames(unwrappedNewSchema);
-        getSchemaPropNames(unwrappedExistingSchema).stream()
+        Schema supersetFixed = Schema
+            .createFixed(newSchema.getName(), newSchema.getDoc(), newSchema.getNamespace(), newSchema.getFixedSize());
+        Set<String> newFixedPropNames = getSchemaPropNames(newSchema);
+        getSchemaPropNames(existingSchema).stream()
             .filter(prop -> !newFixedPropNames.contains(prop))
             .forEach(
                 prop -> AvroCompatibilityHelper.setSchemaPropFromJsonString(
                     supersetFixed,
                     prop,
-                    AvroCompatibilityHelper.getSchemaPropAsJsonString(unwrappedExistingSchema, prop),
+                    AvroCompatibilityHelper.getSchemaPropAsJsonString(existingSchema, prop),
                     false));
-        getSchemaPropNames(unwrappedNewSchema).forEach(
+        getSchemaPropNames(newSchema).forEach(
             prop -> AvroCompatibilityHelper.setSchemaPropFromJsonString(
                 supersetFixed,
                 prop,
-                AvroCompatibilityHelper.getSchemaPropAsJsonString(unwrappedNewSchema, prop),
+                AvroCompatibilityHelper.getSchemaPropAsJsonString(newSchema, prop),
                 false));
         return supersetFixed;
       }
@@ -175,9 +167,9 @@ public class AvroSupersetSchemaUtils {
       case BYTES:
       case NULL:
         // Primitive types cannot differ structurally; schemas are equal in type but differ only in
-        // custom properties (e.g. "li.data.proto.numberFieldType"). Return unwrappedNewSchema so
-        // its properties take priority, consistent with the convention used elsewhere in this method.
-        return unwrappedNewSchema;
+        // custom properties (e.g. "li.data.proto.numberFieldType"). Return newSchema so its
+        // properties take priority, consistent with the convention used elsewhere in this method.
+        return newSchema;
       default:
         throw new VeniceException("Super set schema not supported");
     }

--- a/internal/venice-client-common/src/main/java/com/linkedin/venice/utils/AvroSupersetSchemaUtils.java
+++ b/internal/venice-client-common/src/main/java/com/linkedin/venice/utils/AvroSupersetSchemaUtils.java
@@ -42,82 +42,85 @@ public class AvroSupersetSchemaUtils {
    * @return super-set schema of existingSchema abd newSchema
    */
   public static Schema generateSupersetSchema(Schema existingSchema, Schema newSchema) {
-    if (existingSchema.getType() != newSchema.getType()) {
+    // Unwrap single-element unions to their inner type so that [T] is treated
+    // equivalently to T during type comparison and superset generation.
+    final Schema existing = unwrapSingleElementUnion(existingSchema);
+    final Schema newer = unwrapSingleElementUnion(newSchema);
+
+    if (existing.getType() != newer.getType()) {
       throw new VeniceException("Incompatible schema");
     }
-    if (Objects.equals(existingSchema, newSchema)) {
-      return existingSchema;
+    if (Objects.equals(existing, newer)) {
+      return existing;
     }
 
     // Special handling for String vs Avro string comparison,
     // return the schema with avro.java.string property for string type
-    if (existingSchema.getType() == Schema.Type.STRING) {
-      return AvroCompatibilityHelper.getSchemaPropAsJsonString(existingSchema, "avro.java.string") == null
-          ? newSchema
-          : existingSchema;
+    if (existing.getType() == Schema.Type.STRING) {
+      return AvroCompatibilityHelper.getSchemaPropAsJsonString(existing, "avro.java.string") == null ? newer : existing;
     }
 
-    switch (existingSchema.getType()) {
+    switch (existing.getType()) {
       case RECORD:
-        if (!StringUtils.equals(existingSchema.getNamespace(), newSchema.getNamespace())) {
+        if (!StringUtils.equals(existing.getNamespace(), newer.getNamespace())) {
           throw new VeniceException(
               String.format(
                   "Trying to merge record schemas with different namespace. "
                       + "Got existing schema namespace: %s and new schema namespace: %s",
-                  existingSchema.getNamespace(),
-                  newSchema.getNamespace()));
+                  existing.getNamespace(),
+                  newer.getNamespace()));
         }
-        if (!StringUtils.equals(existingSchema.getName(), newSchema.getName())) {
+        if (!StringUtils.equals(existing.getName(), newer.getName())) {
           throw new VeniceException(
               String.format(
                   "Trying to merge record schemas with different name. "
                       + "Got existing schema name: %s and new schema name: %s",
-                  existingSchema.getName(),
-                  newSchema.getName()));
+                  existing.getName(),
+                  newer.getName()));
         }
 
-        Schema superSetSchema = Schema
-            .createRecord(existingSchema.getName(), existingSchema.getDoc(), existingSchema.getNamespace(), false);
-        superSetSchema.setFields(mergeFieldSchemas(existingSchema, newSchema));
+        Schema superSetSchema =
+            Schema.createRecord(existing.getName(), existing.getDoc(), existing.getNamespace(), false);
+        superSetSchema.setFields(mergeFieldSchemas(existing, newer));
         return superSetSchema;
       case ARRAY:
-        return Schema.createArray(generateSupersetSchema(existingSchema.getElementType(), newSchema.getElementType()));
+        return Schema.createArray(generateSupersetSchema(existing.getElementType(), newer.getElementType()));
       case MAP:
-        return Schema.createMap(generateSupersetSchema(existingSchema.getValueType(), newSchema.getValueType()));
+        return Schema.createMap(generateSupersetSchema(existing.getValueType(), newer.getValueType()));
       case UNION:
-        return unionSchema(existingSchema, newSchema);
+        return unionSchema(existing, newer);
       case ENUM: {
-        // Build a superset symbol list: all symbols from existingSchema (preserving their order),
-        // followed by any symbols present only in newSchema. This ensures no symbol is lost when
+        // Build a superset symbol list: all symbols from existing (preserving their order),
+        // followed by any symbols present only in newer. This ensures no symbol is lost when
         // the two schemas have diverged (e.g. existing has ["A","B","C"], new has ["A","B","D"]).
-        LinkedHashSet<String> supersetSymbols = new LinkedHashSet<>(existingSchema.getEnumSymbols());
-        supersetSymbols.addAll(newSchema.getEnumSymbols());
+        LinkedHashSet<String> supersetSymbols = new LinkedHashSet<>(existing.getEnumSymbols());
+        supersetSymbols.addAll(newer.getEnumSymbols());
         // Always construct a new enum schema so that properties from both schemas are merged
         // consistently, regardless of whether symbols grew or diverged. (Truly-equal schemas are
         // already short-circuited by the Objects.equals check at the top of this method.)
-        // newSchema takes priority on conflicts. Avro 1.10+ forbids overwriting an already-set
-        // property, so each prop is written exactly once: existingSchema-only props first, then
-        // all newSchema props.
+        // newer takes priority on conflicts. Avro 1.10+ forbids overwriting an already-set
+        // property, so each prop is written exactly once: existing-only props first, then
+        // all newer props.
         Schema supersetEnum = Schema.createEnum(
-            newSchema.getName(),
-            newSchema.getDoc(),
-            newSchema.getNamespace(),
+            newer.getName(),
+            newer.getDoc(),
+            newer.getNamespace(),
             new ArrayList<>(supersetSymbols),
-            newSchema.getEnumDefault());
-        Set<String> newSchemaPropNames = getSchemaPropNames(newSchema);
-        getSchemaPropNames(existingSchema).stream()
+            newer.getEnumDefault());
+        Set<String> newSchemaPropNames = getSchemaPropNames(newer);
+        getSchemaPropNames(existing).stream()
             .filter(prop -> !newSchemaPropNames.contains(prop))
             .forEach(
                 prop -> AvroCompatibilityHelper.setSchemaPropFromJsonString(
                     supersetEnum,
                     prop,
-                    AvroCompatibilityHelper.getSchemaPropAsJsonString(existingSchema, prop),
+                    AvroCompatibilityHelper.getSchemaPropAsJsonString(existing, prop),
                     false));
-        getSchemaPropNames(newSchema).forEach(
+        getSchemaPropNames(newer).forEach(
             prop -> AvroCompatibilityHelper.setSchemaPropFromJsonString(
                 supersetEnum,
                 prop,
-                AvroCompatibilityHelper.getSchemaPropAsJsonString(newSchema, prop),
+                AvroCompatibilityHelper.getSchemaPropAsJsonString(newer, prop),
                 false));
         return supersetEnum;
       }
@@ -125,32 +128,32 @@ public class AvroSupersetSchemaUtils {
         // FIXED schemas are structurally compatible only when their size attributes are identical.
         // A size mismatch is an irreconcilable schema incompatibility — unlike custom properties,
         // the size is part of the binary encoding and cannot be silently promoted.
-        if (existingSchema.getFixedSize() != newSchema.getFixedSize()) {
+        if (existing.getFixedSize() != newer.getFixedSize()) {
           throw new VeniceException(
               String.format(
                   "Incompatible FIXED schemas for '%s': existing size %d does not match new size %d",
-                  existingSchema.getFullName(),
-                  existingSchema.getFixedSize(),
-                  newSchema.getFixedSize()));
+                  existing.getFullName(),
+                  existing.getFixedSize(),
+                  newer.getFixedSize()));
         }
         // Sizes match — merge properties from both schemas, same convention as ENUM:
-        // existingSchema-only props first, then all newSchema props (newSchema wins on conflicts).
-        Schema supersetFixed = Schema
-            .createFixed(newSchema.getName(), newSchema.getDoc(), newSchema.getNamespace(), newSchema.getFixedSize());
-        Set<String> newFixedPropNames = getSchemaPropNames(newSchema);
-        getSchemaPropNames(existingSchema).stream()
+        // existing-only props first, then all newer props (newer wins on conflicts).
+        Schema supersetFixed =
+            Schema.createFixed(newer.getName(), newer.getDoc(), newer.getNamespace(), newer.getFixedSize());
+        Set<String> newFixedPropNames = getSchemaPropNames(newer);
+        getSchemaPropNames(existing).stream()
             .filter(prop -> !newFixedPropNames.contains(prop))
             .forEach(
                 prop -> AvroCompatibilityHelper.setSchemaPropFromJsonString(
                     supersetFixed,
                     prop,
-                    AvroCompatibilityHelper.getSchemaPropAsJsonString(existingSchema, prop),
+                    AvroCompatibilityHelper.getSchemaPropAsJsonString(existing, prop),
                     false));
-        getSchemaPropNames(newSchema).forEach(
+        getSchemaPropNames(newer).forEach(
             prop -> AvroCompatibilityHelper.setSchemaPropFromJsonString(
                 supersetFixed,
                 prop,
-                AvroCompatibilityHelper.getSchemaPropAsJsonString(newSchema, prop),
+                AvroCompatibilityHelper.getSchemaPropAsJsonString(newer, prop),
                 false));
         return supersetFixed;
       }
@@ -162,9 +165,9 @@ public class AvroSupersetSchemaUtils {
       case BYTES:
       case NULL:
         // Primitive types cannot differ structurally; schemas are equal in type but differ only in
-        // custom properties (e.g. "li.data.proto.numberFieldType"). Return newSchema so its
+        // custom properties (e.g. "li.data.proto.numberFieldType"). Return newer so its
         // properties take priority, consistent with the convention used elsewhere in this method.
-        return newSchema;
+        return newer;
       default:
         throw new VeniceException("Super set schema not supported");
     }
@@ -191,6 +194,19 @@ public class AvroSupersetSchemaUtils {
     }
     existingSchemaTypeMap.forEach((k, v) -> combinedSchema.add(v));
     return Schema.createUnion(combinedSchema);
+  }
+
+  /**
+   * If the schema is a UNION with exactly one member type, return that inner type.
+   * A single-element union {@code [T]} is semantically equivalent to {@code T} in Avro,
+   * but {@link Schema#getType()} returns {@link Schema.Type#UNION} for the wrapper form.
+   * Unwrapping normalizes both representations so they compare as the same type.
+   */
+  private static Schema unwrapSingleElementUnion(Schema schema) {
+    if (schema.getType() == Schema.Type.UNION && schema.getTypes().size() == 1) {
+      return schema.getTypes().get(0);
+    }
+    return schema;
   }
 
   /**

--- a/internal/venice-client-common/src/main/java/com/linkedin/venice/utils/AvroSupersetSchemaUtils.java
+++ b/internal/venice-client-common/src/main/java/com/linkedin/venice/utils/AvroSupersetSchemaUtils.java
@@ -44,83 +44,90 @@ public class AvroSupersetSchemaUtils {
   public static Schema generateSupersetSchema(Schema existingSchema, Schema newSchema) {
     // Unwrap single-element unions to their inner type so that [T] is treated
     // equivalently to T during type comparison and superset generation.
-    final Schema existing = unwrapSingleElementUnion(existingSchema);
-    final Schema newer = unwrapSingleElementUnion(newSchema);
+    final Schema unwrappedExistingSchema = unwrapSingleElementUnion(existingSchema);
+    final Schema unwrappedNewSchema = unwrapSingleElementUnion(newSchema);
 
-    if (existing.getType() != newer.getType()) {
+    if (unwrappedExistingSchema.getType() != unwrappedNewSchema.getType()) {
       throw new VeniceException("Incompatible schema");
     }
-    if (Objects.equals(existing, newer)) {
-      return existing;
+    if (Objects.equals(unwrappedExistingSchema, unwrappedNewSchema)) {
+      return unwrappedExistingSchema;
     }
 
     // Special handling for String vs Avro string comparison,
     // return the schema with avro.java.string property for string type
-    if (existing.getType() == Schema.Type.STRING) {
-      return AvroCompatibilityHelper.getSchemaPropAsJsonString(existing, "avro.java.string") == null ? newer : existing;
+    if (unwrappedExistingSchema.getType() == Schema.Type.STRING) {
+      return AvroCompatibilityHelper.getSchemaPropAsJsonString(unwrappedExistingSchema, "avro.java.string") == null
+          ? unwrappedNewSchema
+          : unwrappedExistingSchema;
     }
 
-    switch (existing.getType()) {
+    switch (unwrappedExistingSchema.getType()) {
       case RECORD:
-        if (!StringUtils.equals(existing.getNamespace(), newer.getNamespace())) {
+        if (!StringUtils.equals(unwrappedExistingSchema.getNamespace(), unwrappedNewSchema.getNamespace())) {
           throw new VeniceException(
               String.format(
                   "Trying to merge record schemas with different namespace. "
                       + "Got existing schema namespace: %s and new schema namespace: %s",
-                  existing.getNamespace(),
-                  newer.getNamespace()));
+                  unwrappedExistingSchema.getNamespace(),
+                  unwrappedNewSchema.getNamespace()));
         }
-        if (!StringUtils.equals(existing.getName(), newer.getName())) {
+        if (!StringUtils.equals(unwrappedExistingSchema.getName(), unwrappedNewSchema.getName())) {
           throw new VeniceException(
               String.format(
                   "Trying to merge record schemas with different name. "
                       + "Got existing schema name: %s and new schema name: %s",
-                  existing.getName(),
-                  newer.getName()));
+                  unwrappedExistingSchema.getName(),
+                  unwrappedNewSchema.getName()));
         }
 
-        Schema superSetSchema =
-            Schema.createRecord(existing.getName(), existing.getDoc(), existing.getNamespace(), false);
-        superSetSchema.setFields(mergeFieldSchemas(existing, newer));
+        Schema superSetSchema = Schema.createRecord(
+            unwrappedExistingSchema.getName(),
+            unwrappedExistingSchema.getDoc(),
+            unwrappedExistingSchema.getNamespace(),
+            false);
+        superSetSchema.setFields(mergeFieldSchemas(unwrappedExistingSchema, unwrappedNewSchema));
         return superSetSchema;
       case ARRAY:
-        return Schema.createArray(generateSupersetSchema(existing.getElementType(), newer.getElementType()));
+        return Schema.createArray(
+            generateSupersetSchema(unwrappedExistingSchema.getElementType(), unwrappedNewSchema.getElementType()));
       case MAP:
-        return Schema.createMap(generateSupersetSchema(existing.getValueType(), newer.getValueType()));
+        return Schema.createMap(
+            generateSupersetSchema(unwrappedExistingSchema.getValueType(), unwrappedNewSchema.getValueType()));
       case UNION:
-        return unionSchema(existing, newer);
+        return unionSchema(unwrappedExistingSchema, unwrappedNewSchema);
       case ENUM: {
-        // Build a superset symbol list: all symbols from existing (preserving their order),
-        // followed by any symbols present only in newer. This ensures no symbol is lost when
+        // Build a superset symbol list: all symbols from existingSchema (preserving their order),
+        // followed by any symbols present only in newSchema. This ensures no symbol is lost when
         // the two schemas have diverged (e.g. existing has ["A","B","C"], new has ["A","B","D"]).
-        LinkedHashSet<String> supersetSymbols = new LinkedHashSet<>(existing.getEnumSymbols());
-        supersetSymbols.addAll(newer.getEnumSymbols());
+        LinkedHashSet<String> supersetSymbols = new LinkedHashSet<>(unwrappedExistingSchema.getEnumSymbols());
+        supersetSymbols.addAll(unwrappedNewSchema.getEnumSymbols());
         // Always construct a new enum schema so that properties from both schemas are merged
         // consistently, regardless of whether symbols grew or diverged. (Truly-equal schemas are
         // already short-circuited by the Objects.equals check at the top of this method.)
-        // newer takes priority on conflicts. Avro 1.10+ forbids overwriting an already-set
-        // property, so each prop is written exactly once: existing-only props first, then
-        // all newer props.
+        // newSchema takes priority on conflicts. Avro 1.10+ forbids overwriting an already-set
+        // property, so each prop is written exactly once: existingSchema-only props first, then
+        // all newSchema props.
         Schema supersetEnum = Schema.createEnum(
-            newer.getName(),
-            newer.getDoc(),
-            newer.getNamespace(),
+            unwrappedNewSchema.getName(),
+            unwrappedNewSchema.getDoc(),
+            unwrappedNewSchema.getNamespace(),
             new ArrayList<>(supersetSymbols),
-            newer.getEnumDefault());
-        Set<String> newSchemaPropNames = getSchemaPropNames(newer);
-        getSchemaPropNames(existing).stream()
+            unwrappedNewSchema.getEnumDefault());
+        Set<String> newSchemaPropNames = getSchemaPropNames(unwrappedNewSchema);
+        getSchemaPropNames(unwrappedExistingSchema).stream()
             .filter(prop -> !newSchemaPropNames.contains(prop))
             .forEach(
                 prop -> AvroCompatibilityHelper.setSchemaPropFromJsonString(
                     supersetEnum,
                     prop,
-                    AvroCompatibilityHelper.getSchemaPropAsJsonString(existing, prop),
+                    AvroCompatibilityHelper.getSchemaPropAsJsonString(unwrappedExistingSchema, prop),
                     false));
-        getSchemaPropNames(newer).forEach(
+        getSchemaPropNames(unwrappedNewSchema).forEach(
             prop -> AvroCompatibilityHelper.setSchemaPropFromJsonString(
                 supersetEnum,
                 prop,
-                AvroCompatibilityHelper.getSchemaPropAsJsonString(newer, prop),
+                AvroCompatibilityHelper.getSchemaPropAsJsonString(unwrappedNewSchema, prop),
                 false));
         return supersetEnum;
       }
@@ -128,32 +135,35 @@ public class AvroSupersetSchemaUtils {
         // FIXED schemas are structurally compatible only when their size attributes are identical.
         // A size mismatch is an irreconcilable schema incompatibility — unlike custom properties,
         // the size is part of the binary encoding and cannot be silently promoted.
-        if (existing.getFixedSize() != newer.getFixedSize()) {
+        if (unwrappedExistingSchema.getFixedSize() != unwrappedNewSchema.getFixedSize()) {
           throw new VeniceException(
               String.format(
                   "Incompatible FIXED schemas for '%s': existing size %d does not match new size %d",
-                  existing.getFullName(),
-                  existing.getFixedSize(),
-                  newer.getFixedSize()));
+                  unwrappedExistingSchema.getFullName(),
+                  unwrappedExistingSchema.getFixedSize(),
+                  unwrappedNewSchema.getFixedSize()));
         }
         // Sizes match — merge properties from both schemas, same convention as ENUM:
-        // existing-only props first, then all newer props (newer wins on conflicts).
-        Schema supersetFixed =
-            Schema.createFixed(newer.getName(), newer.getDoc(), newer.getNamespace(), newer.getFixedSize());
-        Set<String> newFixedPropNames = getSchemaPropNames(newer);
-        getSchemaPropNames(existing).stream()
+        // existingSchema-only props first, then all newSchema props (newSchema wins on conflicts).
+        Schema supersetFixed = Schema.createFixed(
+            unwrappedNewSchema.getName(),
+            unwrappedNewSchema.getDoc(),
+            unwrappedNewSchema.getNamespace(),
+            unwrappedNewSchema.getFixedSize());
+        Set<String> newFixedPropNames = getSchemaPropNames(unwrappedNewSchema);
+        getSchemaPropNames(unwrappedExistingSchema).stream()
             .filter(prop -> !newFixedPropNames.contains(prop))
             .forEach(
                 prop -> AvroCompatibilityHelper.setSchemaPropFromJsonString(
                     supersetFixed,
                     prop,
-                    AvroCompatibilityHelper.getSchemaPropAsJsonString(existing, prop),
+                    AvroCompatibilityHelper.getSchemaPropAsJsonString(unwrappedExistingSchema, prop),
                     false));
-        getSchemaPropNames(newer).forEach(
+        getSchemaPropNames(unwrappedNewSchema).forEach(
             prop -> AvroCompatibilityHelper.setSchemaPropFromJsonString(
                 supersetFixed,
                 prop,
-                AvroCompatibilityHelper.getSchemaPropAsJsonString(newer, prop),
+                AvroCompatibilityHelper.getSchemaPropAsJsonString(unwrappedNewSchema, prop),
                 false));
         return supersetFixed;
       }
@@ -165,9 +175,9 @@ public class AvroSupersetSchemaUtils {
       case BYTES:
       case NULL:
         // Primitive types cannot differ structurally; schemas are equal in type but differ only in
-        // custom properties (e.g. "li.data.proto.numberFieldType"). Return newer so its
-        // properties take priority, consistent with the convention used elsewhere in this method.
-        return newer;
+        // custom properties (e.g. "li.data.proto.numberFieldType"). Return unwrappedNewSchema so
+        // its properties take priority, consistent with the convention used elsewhere in this method.
+        return unwrappedNewSchema;
       default:
         throw new VeniceException("Super set schema not supported");
     }

--- a/internal/venice-client-common/src/test/java/com/linkedin/venice/schema/TestAvroSupersetSchemaUtils.java
+++ b/internal/venice-client-common/src/test/java/com/linkedin/venice/schema/TestAvroSupersetSchemaUtils.java
@@ -35,18 +35,6 @@ import org.testng.annotations.Test;
 
 
 public class TestAvroSupersetSchemaUtils {
-  // v1: opportunityIds as a single-element union wrapping an array
-  private static final String SINGLE_ELEMENT_UNION_ARRAY_SCHEMA_STR =
-      "{\"type\":\"record\",\"name\":\"TestRecord\",\"namespace\":\"com.example\","
-          + "\"fields\":[{\"name\":\"opportunityIds\"," + "\"type\":[{\"type\":\"array\",\"items\":\"long\"}],"
-          + "\"doc\":\"List of opportunityIds.\"}]}";
-
-  // v2: opportunityIds as a plain array (no union wrapper)
-  private static final String PLAIN_ARRAY_SCHEMA_STR =
-      "{\"type\":\"record\",\"name\":\"TestRecord\",\"namespace\":\"com.example\","
-          + "\"fields\":[{\"name\":\"opportunityIds\"," + "\"type\":{\"type\":\"array\",\"items\":\"long\"},"
-          + "\"doc\":\"List of opportunityIds.\"}]}";
-
   @Test
   public void testGenerateSupersetSchemaFromValueSchemasWithTwoSchemas() {
     String schemaStr1 = "{\"type\":\"record\",\"name\":\"KeyRecord\"," + "\"fields\":" + " ["
@@ -803,8 +791,16 @@ public class TestAvroSupersetSchemaUtils {
    */
   @Test
   public void testSchemaMergeSingleElementUnionVsPlainType() {
-    Schema s1 = AvroSchemaParseUtils.parseSchemaFromJSONStrictValidation(SINGLE_ELEMENT_UNION_ARRAY_SCHEMA_STR);
-    Schema s2 = AvroSchemaParseUtils.parseSchemaFromJSONStrictValidation(PLAIN_ARRAY_SCHEMA_STR);
+    // v1: opportunityIds as a single-element union wrapping an array
+    String schemaStr1 = "{\"type\":\"record\",\"name\":\"TestRecord\",\"namespace\":\"com.example\","
+        + "\"fields\":[{\"name\":\"opportunityIds\"," + "\"type\":[{\"type\":\"array\",\"items\":\"long\"}],"
+        + "\"doc\":\"List of opportunityIds.\"}]}";
+    // v2: opportunityIds as a plain array (no union wrapper)
+    String schemaStr2 = "{\"type\":\"record\",\"name\":\"TestRecord\",\"namespace\":\"com.example\","
+        + "\"fields\":[{\"name\":\"opportunityIds\"," + "\"type\":{\"type\":\"array\",\"items\":\"long\"},"
+        + "\"doc\":\"List of opportunityIds.\"}]}";
+    Schema s1 = AvroSchemaParseUtils.parseSchemaFromJSONStrictValidation(schemaStr1);
+    Schema s2 = AvroSchemaParseUtils.parseSchemaFromJSONStrictValidation(schemaStr2);
 
     // Should not throw — these are semantically equivalent
     Schema superset12 = AvroSupersetSchemaUtils.generateSupersetSchema(s1, s2);

--- a/internal/venice-client-common/src/test/java/com/linkedin/venice/schema/TestAvroSupersetSchemaUtils.java
+++ b/internal/venice-client-common/src/test/java/com/linkedin/venice/schema/TestAvroSupersetSchemaUtils.java
@@ -855,6 +855,24 @@ public class TestAvroSupersetSchemaUtils {
   }
 
   @Test
+  public void testSchemaMergeSingleElementUnionVsMultiElementUnion() {
+    // [T] vs ["null", T] must still merge correctly via the union path.
+    // Unwrapping [T] to T before comparison would produce T vs UNION and throw.
+    String schemaStr1 = "{\"type\":\"record\",\"name\":\"TestRecord\"," + "\"fields\":[{\"name\":\"ids\","
+        + "\"type\":[{\"type\":\"array\",\"items\":\"long\"}]}]}";
+
+    String schemaStr2 = "{\"type\":\"record\",\"name\":\"TestRecord\"," + "\"fields\":[{\"name\":\"ids\","
+        + "\"type\":[\"null\",{\"type\":\"array\",\"items\":\"long\"}],\"default\":null}]}";
+
+    Schema s1 = AvroSchemaParseUtils.parseSchemaFromJSONStrictValidation(schemaStr1);
+    Schema s2 = AvroSchemaParseUtils.parseSchemaFromJSONStrictValidation(schemaStr2);
+
+    Schema superset = AvroSupersetSchemaUtils.generateSupersetSchema(s1, s2);
+    Assert.assertNotNull(superset);
+    Assert.assertEquals(superset.getField("ids").schema().getType(), Schema.Type.UNION);
+  }
+
+  @Test
   public void testValidateSubsetSchema() {
     Assert.assertTrue(
         AvroSupersetSchemaUtils.validateSubsetValueSchema(NAME_RECORD_V1_SCHEMA, NAME_RECORD_V2_SCHEMA.toString()));

--- a/internal/venice-client-common/src/test/java/com/linkedin/venice/schema/TestAvroSupersetSchemaUtils.java
+++ b/internal/venice-client-common/src/test/java/com/linkedin/venice/schema/TestAvroSupersetSchemaUtils.java
@@ -906,12 +906,6 @@ public class TestAvroSupersetSchemaUtils {
     Assert.assertEquals(toStringMap((Map<?, ?>) deserializedV2.get("metadata")), metadata);
   }
 
-  private static Map<String, String> toStringMap(Map<?, ?> map) {
-    Map<String, String> result = new HashMap<>();
-    map.forEach((k, v) -> result.put(k.toString(), v.toString()));
-    return result;
-  }
-
   @Test
   public void testSchemaMergeSingleElementUnionVsMultiElementUnion() {
     // [T] vs ["null", T] must still merge correctly via the union path.
@@ -962,5 +956,11 @@ public class TestAvroSupersetSchemaUtils {
         AvroSupersetSchemaUtils.validateSubsetValueSchema(NAME_RECORD_V5_SCHEMA, supersetSchemaForV5AndV4.toString()));
     Assert.assertTrue(
         AvroSupersetSchemaUtils.validateSubsetValueSchema(NAME_RECORD_V6_SCHEMA, supersetSchemaForV5AndV4.toString()));
+  }
+
+  private static Map<String, String> toStringMap(Map<?, ?> map) {
+    Map<String, String> result = new HashMap<>();
+    map.forEach((k, v) -> result.put(k.toString(), v.toString()));
+    return result;
   }
 }

--- a/internal/venice-client-common/src/test/java/com/linkedin/venice/schema/TestAvroSupersetSchemaUtils.java
+++ b/internal/venice-client-common/src/test/java/com/linkedin/venice/schema/TestAvroSupersetSchemaUtils.java
@@ -16,16 +16,37 @@ import com.linkedin.avroutil1.compatibility.AvroCompatibilityHelper;
 import com.linkedin.venice.controllerapi.MultiSchemaResponse;
 import com.linkedin.venice.exceptions.VeniceException;
 import com.linkedin.venice.schema.avro.DirectionalSchemaCompatibilityType;
+import com.linkedin.venice.serializer.AvroGenericDeserializer;
+import com.linkedin.venice.serializer.AvroSerializer;
 import com.linkedin.venice.utils.AvroSchemaUtils;
 import com.linkedin.venice.utils.AvroSupersetSchemaUtils;
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericData;
+import org.apache.avro.generic.GenericRecord;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
 
 public class TestAvroSupersetSchemaUtils {
+  // v1: opportunityIds as a single-element union wrapping an array
+  private static final String SINGLE_ELEMENT_UNION_ARRAY_SCHEMA_STR =
+      "{\"type\":\"record\",\"name\":\"TestRecord\",\"namespace\":\"com.example\","
+          + "\"fields\":[{\"name\":\"opportunityIds\"," + "\"type\":[{\"type\":\"array\",\"items\":\"long\"}],"
+          + "\"doc\":\"List of opportunityIds.\"}]}";
+
+  // v2: opportunityIds as a plain array (no union wrapper)
+  private static final String PLAIN_ARRAY_SCHEMA_STR =
+      "{\"type\":\"record\",\"name\":\"TestRecord\",\"namespace\":\"com.example\","
+          + "\"fields\":[{\"name\":\"opportunityIds\"," + "\"type\":{\"type\":\"array\",\"items\":\"long\"},"
+          + "\"doc\":\"List of opportunityIds.\"}]}";
+
   @Test
   public void testGenerateSupersetSchemaFromValueSchemasWithTwoSchemas() {
     String schemaStr1 = "{\"type\":\"record\",\"name\":\"KeyRecord\"," + "\"fields\":" + " ["
@@ -782,18 +803,8 @@ public class TestAvroSupersetSchemaUtils {
    */
   @Test
   public void testSchemaMergeSingleElementUnionVsPlainType() {
-    // v1: opportunityIds is a single-element union wrapping an array
-    String schemaStr1 = "{\"type\":\"record\",\"name\":\"TestRecord\"," + "\"namespace\":\"com.example\","
-        + "\"fields\":[{\"name\":\"opportunityIds\"," + "\"type\":[{\"type\":\"array\",\"items\":\"long\"}],"
-        + "\"doc\":\"List of opportunityIds.\"}]}";
-
-    // v2: opportunityIds is a plain array (no union wrapper)
-    String schemaStr2 = "{\"type\":\"record\",\"name\":\"TestRecord\"," + "\"namespace\":\"com.example\","
-        + "\"fields\":[{\"name\":\"opportunityIds\"," + "\"type\":{\"type\":\"array\",\"items\":\"long\"},"
-        + "\"doc\":\"List of opportunityIds.\"}]}";
-
-    Schema s1 = AvroSchemaParseUtils.parseSchemaFromJSONStrictValidation(schemaStr1);
-    Schema s2 = AvroSchemaParseUtils.parseSchemaFromJSONStrictValidation(schemaStr2);
+    Schema s1 = AvroSchemaParseUtils.parseSchemaFromJSONStrictValidation(SINGLE_ELEMENT_UNION_ARRAY_SCHEMA_STR);
+    Schema s2 = AvroSchemaParseUtils.parseSchemaFromJSONStrictValidation(PLAIN_ARRAY_SCHEMA_STR);
 
     // Should not throw — these are semantically equivalent
     Schema superset12 = AvroSupersetSchemaUtils.generateSupersetSchema(s1, s2);
@@ -810,6 +821,21 @@ public class TestAvroSupersetSchemaUtils {
 
     // Both orderings should produce equivalent superset schemas
     Assert.assertTrue(AvroSchemaUtils.compareSchemaIgnoreFieldOrder(superset12, superset21));
+
+    // Verify that the superset schema can deserialize records serialized with either version
+    List<Long> ids = Collections.singletonList(42L);
+
+    GenericRecord recordV1 = new GenericData.Record(s1);
+    recordV1.put("opportunityIds", ids);
+    byte[] bytesV1 = new AvroSerializer<>(s1).serialize(recordV1);
+    GenericRecord deserializedV1 = (GenericRecord) new AvroGenericDeserializer<>(s1, superset12).deserialize(bytesV1);
+    Assert.assertEquals(new ArrayList<>((Collection<?>) deserializedV1.get("opportunityIds")), ids);
+
+    GenericRecord recordV2 = new GenericData.Record(s2);
+    recordV2.put("opportunityIds", ids);
+    byte[] bytesV2 = new AvroSerializer<>(s2).serialize(recordV2);
+    GenericRecord deserializedV2 = (GenericRecord) new AvroGenericDeserializer<>(s2, superset12).deserialize(bytesV2);
+    Assert.assertEquals(new ArrayList<>((Collection<?>) deserializedV2.get("opportunityIds")), ids);
   }
 
   @Test
@@ -829,12 +855,27 @@ public class TestAvroSupersetSchemaUtils {
 
     Schema superset = AvroSupersetSchemaUtils.generateSupersetSchema(s1, s2);
     Assert.assertNotNull(superset);
-    // All fields from both schemas should be present
     Assert.assertNotNull(superset.getField("ids"));
     Assert.assertNotNull(superset.getField("name"));
     Assert.assertNotNull(superset.getField("description"));
-    // The array field should be unwrapped
     Assert.assertEquals(superset.getField("ids").schema().getType(), Schema.Type.ARRAY);
+
+    List<Long> ids = Collections.singletonList(42L);
+
+    GenericRecord recordV1 = new GenericData.Record(s1);
+    recordV1.put("ids", ids);
+    recordV1.put("name", "alice");
+    byte[] bytesV1 = new AvroSerializer<>(s1).serialize(recordV1);
+    GenericRecord deserializedV1 = (GenericRecord) new AvroGenericDeserializer<>(s1, superset).deserialize(bytesV1);
+    // GenericData.Array.equals() only accepts other GenericArray — copy to ArrayList to compare
+    Assert.assertEquals(new ArrayList<>((Collection<?>) deserializedV1.get("ids")), ids);
+
+    GenericRecord recordV2 = new GenericData.Record(s2);
+    recordV2.put("ids", ids);
+    recordV2.put("description", "desc");
+    byte[] bytesV2 = new AvroSerializer<>(s2).serialize(recordV2);
+    GenericRecord deserializedV2 = (GenericRecord) new AvroGenericDeserializer<>(s2, superset).deserialize(bytesV2);
+    Assert.assertEquals(new ArrayList<>((Collection<?>) deserializedV2.get("ids")), ids);
   }
 
   @Test
@@ -852,6 +893,27 @@ public class TestAvroSupersetSchemaUtils {
     Schema superset = AvroSupersetSchemaUtils.generateSupersetSchema(s1, s2);
     Assert.assertNotNull(superset);
     Assert.assertEquals(superset.getField("metadata").schema().getType(), Schema.Type.MAP);
+
+    Map<String, String> metadata = Collections.singletonMap("k", "v");
+
+    GenericRecord recordV1 = new GenericData.Record(s1);
+    recordV1.put("metadata", metadata);
+    byte[] bytesV1 = new AvroSerializer<>(s1).serialize(recordV1);
+    GenericRecord deserializedV1 = (GenericRecord) new AvroGenericDeserializer<>(s1, superset).deserialize(bytesV1);
+    // Avro deserializes string keys/values as Utf8 — convert to String for comparison
+    Assert.assertEquals(toStringMap((Map<?, ?>) deserializedV1.get("metadata")), metadata);
+
+    GenericRecord recordV2 = new GenericData.Record(s2);
+    recordV2.put("metadata", metadata);
+    byte[] bytesV2 = new AvroSerializer<>(s2).serialize(recordV2);
+    GenericRecord deserializedV2 = (GenericRecord) new AvroGenericDeserializer<>(s2, superset).deserialize(bytesV2);
+    Assert.assertEquals(toStringMap((Map<?, ?>) deserializedV2.get("metadata")), metadata);
+  }
+
+  private static Map<String, String> toStringMap(Map<?, ?> map) {
+    Map<String, String> result = new HashMap<>();
+    map.forEach((k, v) -> result.put(k.toString(), v.toString()));
+    return result;
   }
 
   @Test
@@ -870,6 +932,20 @@ public class TestAvroSupersetSchemaUtils {
     Schema superset = AvroSupersetSchemaUtils.generateSupersetSchema(s1, s2);
     Assert.assertNotNull(superset);
     Assert.assertEquals(superset.getField("ids").schema().getType(), Schema.Type.UNION);
+
+    List<Long> ids = Collections.singletonList(42L);
+
+    GenericRecord recordV1 = new GenericData.Record(s1);
+    recordV1.put("ids", ids);
+    byte[] bytesV1 = new AvroSerializer<>(s1).serialize(recordV1);
+    GenericRecord deserializedV1 = (GenericRecord) new AvroGenericDeserializer<>(s1, superset).deserialize(bytesV1);
+    Assert.assertEquals(new ArrayList<>((Collection<?>) deserializedV1.get("ids")), ids);
+
+    GenericRecord recordV2 = new GenericData.Record(s2);
+    recordV2.put("ids", ids);
+    byte[] bytesV2 = new AvroSerializer<>(s2).serialize(recordV2);
+    GenericRecord deserializedV2 = (GenericRecord) new AvroGenericDeserializer<>(s2, superset).deserialize(bytesV2);
+    Assert.assertEquals(new ArrayList<>((Collection<?>) deserializedV2.get("ids")), ids);
   }
 
   @Test

--- a/internal/venice-client-common/src/test/java/com/linkedin/venice/schema/TestAvroSupersetSchemaUtils.java
+++ b/internal/venice-client-common/src/test/java/com/linkedin/venice/schema/TestAvroSupersetSchemaUtils.java
@@ -775,6 +775,85 @@ public class TestAvroSupersetSchemaUtils {
         "Superset schema must retain the 'categoryRef' field from v1");
   }
 
+  /**
+   * Validates that generateSupersetSchema() treats a single-element union wrapping a type
+   * (e.g. {@code [array]}) the same as the bare type ({@code array}), since they are
+   * semantically equivalent in Avro.
+   */
+  @Test
+  public void testSchemaMergeSingleElementUnionVsPlainType() {
+    // v1: opportunityIds is a single-element union wrapping an array
+    String schemaStr1 = "{\"type\":\"record\",\"name\":\"TestRecord\"," + "\"namespace\":\"com.example\","
+        + "\"fields\":[{\"name\":\"opportunityIds\"," + "\"type\":[{\"type\":\"array\",\"items\":\"long\"}],"
+        + "\"doc\":\"List of opportunityIds.\"}]}";
+
+    // v2: opportunityIds is a plain array (no union wrapper)
+    String schemaStr2 = "{\"type\":\"record\",\"name\":\"TestRecord\"," + "\"namespace\":\"com.example\","
+        + "\"fields\":[{\"name\":\"opportunityIds\"," + "\"type\":{\"type\":\"array\",\"items\":\"long\"},"
+        + "\"doc\":\"List of opportunityIds.\"}]}";
+
+    Schema s1 = AvroSchemaParseUtils.parseSchemaFromJSONStrictValidation(schemaStr1);
+    Schema s2 = AvroSchemaParseUtils.parseSchemaFromJSONStrictValidation(schemaStr2);
+
+    // Should not throw — these are semantically equivalent
+    Schema superset12 = AvroSupersetSchemaUtils.generateSupersetSchema(s1, s2);
+    Assert.assertNotNull(superset12);
+    Assert.assertNotNull(superset12.getField("opportunityIds"));
+
+    // The result should be an array type (the unwrapped form)
+    Assert.assertEquals(superset12.getField("opportunityIds").schema().getType(), Schema.Type.ARRAY);
+
+    // Should also work in the reverse direction
+    Schema superset21 = AvroSupersetSchemaUtils.generateSupersetSchema(s2, s1);
+    Assert.assertNotNull(superset21);
+    Assert.assertEquals(superset21.getField("opportunityIds").schema().getType(), Schema.Type.ARRAY);
+
+    // Both orderings should produce equivalent superset schemas
+    Assert.assertTrue(AvroSchemaUtils.compareSchemaIgnoreFieldOrder(superset12, superset21));
+  }
+
+  @Test
+  public void testSchemaMergeSingleElementUnionVsPlainTypeWithAdditionalFields() {
+    // Record with additional fields to test that single-element union unwrapping
+    // doesn't interfere with normal superset field merging
+    String schemaStr1 = "{\"type\":\"record\",\"name\":\"TestRecord\"," + "\"namespace\":\"com.example\","
+        + "\"fields\":[" + "{\"name\":\"ids\",\"type\":[{\"type\":\"array\",\"items\":\"long\"}]},"
+        + "{\"name\":\"name\",\"type\":\"string\",\"default\":\"default\"}" + "]}";
+
+    String schemaStr2 = "{\"type\":\"record\",\"name\":\"TestRecord\"," + "\"namespace\":\"com.example\","
+        + "\"fields\":[" + "{\"name\":\"ids\",\"type\":{\"type\":\"array\",\"items\":\"long\"}},"
+        + "{\"name\":\"description\",\"type\":\"string\",\"default\":\"none\"}" + "]}";
+
+    Schema s1 = AvroSchemaParseUtils.parseSchemaFromJSONStrictValidation(schemaStr1);
+    Schema s2 = AvroSchemaParseUtils.parseSchemaFromJSONStrictValidation(schemaStr2);
+
+    Schema superset = AvroSupersetSchemaUtils.generateSupersetSchema(s1, s2);
+    Assert.assertNotNull(superset);
+    // All fields from both schemas should be present
+    Assert.assertNotNull(superset.getField("ids"));
+    Assert.assertNotNull(superset.getField("name"));
+    Assert.assertNotNull(superset.getField("description"));
+    // The array field should be unwrapped
+    Assert.assertEquals(superset.getField("ids").schema().getType(), Schema.Type.ARRAY);
+  }
+
+  @Test
+  public void testSchemaMergeSingleElementUnionMap() {
+    // Test single-element union wrapping a map type
+    String schemaStr1 = "{\"type\":\"record\",\"name\":\"TestRecord\"," + "\"fields\":[{\"name\":\"metadata\","
+        + "\"type\":[{\"type\":\"map\",\"values\":\"string\"}]}]}";
+
+    String schemaStr2 = "{\"type\":\"record\",\"name\":\"TestRecord\"," + "\"fields\":[{\"name\":\"metadata\","
+        + "\"type\":{\"type\":\"map\",\"values\":\"string\"}}]}";
+
+    Schema s1 = AvroSchemaParseUtils.parseSchemaFromJSONStrictValidation(schemaStr1);
+    Schema s2 = AvroSchemaParseUtils.parseSchemaFromJSONStrictValidation(schemaStr2);
+
+    Schema superset = AvroSupersetSchemaUtils.generateSupersetSchema(s1, s2);
+    Assert.assertNotNull(superset);
+    Assert.assertEquals(superset.getField("metadata").schema().getType(), Schema.Type.MAP);
+  }
+
   @Test
   public void testValidateSubsetSchema() {
     Assert.assertTrue(


### PR DESCRIPTION
## Problem Statement

`generateSupersetSchema()` throws `VeniceException("Incompatible schema")` when a field evolves between a single-element union `[T]` and the bare type `T`. These are semantically equivalent in Avro but have different `Schema.getType()` values (`UNION` vs the inner type), causing a false incompatibility error.

## Solution

Add `unwrapSingleElementUnion()` to normalize `[T]` to `T` before the type comparison. Unwrapping is skipped when both inputs are unions so existing multi-union merge behavior (e.g. `[T]` vs `["null", T]`) is unchanged.

###  Code changes
- [ ] Added new code behind **a config**. If so list the config names and their default values in the PR description.
- [ ] Introduced new **log lines**.
  - [ ] Confirmed if logs need to be **rate limited** to avoid excessive logging.

###  **Concurrency-Specific Checks**
Both reviewer and PR author to verify
- [x] Code has **no race conditions** or **thread safety issues**.
- [ ] Proper **synchronization mechanisms** (e.g., `synchronized`, `RWLock`) are used where needed.
- [ ] No **blocking calls** inside critical sections that could lead to deadlocks or performance degradation.
- [ ] Verified **thread-safe collections** are used (e.g., `ConcurrentHashMap`, `CopyOnWriteArrayList`).
- [ ] Validated proper exception handling in multi-threaded code to avoid silent thread termination.

## How was this PR tested?

- [x] New unit tests added.
- [ ] New integration tests added.
- [ ] Modified or extended existing tests.
- [x] Verified backward compatibility (if applicable).

4 new unit tests covering: single-element union vs plain type (array and map), mixed-field records, and `[T]` vs `["null", T]` to guard against regressions. All 32 `TestAvroSupersetSchemaUtils` tests pass.

Also ran `generateSupersetSchema()` on every consecutive schema pair across all production stores with 2+ value schemas — all pass.

## Does this PR introduce any user-facing or breaking changes?
- [x] No. You can skip the rest of this section.
- [ ] Yes. Clearly explain the behavior change and its impact.