### PR TITLE
[server][da-vinci] Fix negative OTel counters in async high-perf types

### DIFF
--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/stats/DIVStatsOtelTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/stats/DIVStatsOtelTest.java
@@ -577,7 +577,7 @@ public class DIVStatsOtelTest {
         repo -> {
           AggVersionedDIVStats s = createDIVStatsWithStore(repo, TEST_STORE_NAME);
           return n -> {
-            for (int i = 0; i < n; i++)
+            for (long i = 0; i < n; i++)
               s.recordSuccessMsg(TEST_STORE_NAME, 1);
           };
         },

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/stats/DIVStatsOtelTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/stats/DIVStatsOtelTest.java
@@ -214,7 +214,7 @@ public class DIVStatsOtelTest {
     stats.recordSuccessMsg(TEST_STORE_NAME, 1);
     stats.recordDuplicateMsg(TEST_STORE_NAME, 1);
 
-    // Collect once — ASYNC_COUNTER uses sumThenReset, so subsequent collections would see 0.
+    // Collect once to snapshot all dimension values from a single collection interval.
     Collection<MetricData> metrics = inMemoryMetricReader.collectAllMetrics();
     validateAsyncCounterFromCollection(
         metrics,
@@ -549,9 +549,7 @@ public class DIVStatsOtelTest {
 
   /**
    * Validates an async counter value from a pre-collected metrics snapshot. Use this when
-   * validating multiple dimension values of the same ASYNC_COUNTER metric in a single test —
-   * each {@code collectAllMetrics()} call resets the LongAdder via {@code sumThenReset()},
-   * so only the first collection returns the accumulated values.
+   * validating multiple dimension values of the same ASYNC_COUNTER metric in a single test.
    */
   private static void validateAsyncCounterFromCollection(
       Collection<MetricData> metricsData,
@@ -562,6 +560,43 @@ public class DIVStatsOtelTest {
         .getLongPointDataFromSum(metricsData, metricName, TEST_METRIC_PREFIX, expectedAttributes);
     assertNotNull(point, "LongPointData should not be null for " + metricName + " with " + expectedAttributes);
     assertEquals(point.getValue(), expectedValue);
+  }
+
+  /**
+   * Verifies that DIV MESSAGE_COUNT (ASYNC_COUNTER_FOR_HIGH_PERF_CASES) produces correct data
+   * across multiple collection intervals under both DELTA and CUMULATIVE temporality.
+   */
+  @Test
+  public void testMessageCountMultiCollection() {
+    Attributes attrs = buildMessageAttributes(TEST_STORE_NAME, VersionRole.CURRENT, VeniceDIVResult.SUCCESS);
+    OpenTelemetryDataTestUtils.validateAsyncCounterMultiCollection(
+        TEST_METRIC_PREFIX,
+        SERVER_METRIC_ENTITIES,
+        OTEL_MESSAGE_COUNT,
+        attrs,
+        repo -> {
+          AggVersionedDIVStats s = createDIVStatsWithStore(repo, TEST_STORE_NAME);
+          return n -> {
+            for (int i = 0; i < n; i++)
+              s.recordSuccessMsg(TEST_STORE_NAME, 1);
+          };
+        },
+        new long[] { 5, 2, 8 });
+  }
+
+  /** Creates an AggVersionedDIVStats with a single store set up (version 1=CURRENT). */
+  private AggVersionedDIVStats createDIVStatsWithStore(VeniceMetricsRepository repo, String storeName) {
+    ReadOnlyStoreRepository mockRepo = mock(ReadOnlyStoreRepository.class);
+    doReturn(Collections.emptyList()).when(mockRepo).getAllStores();
+    AggVersionedDIVStats divStats = new AggVersionedDIVStats(repo, mockRepo, true, TEST_CLUSTER_NAME);
+    Store mockStore = mock(Store.class);
+    doReturn(storeName).when(mockStore).getName();
+    doReturn(1).when(mockStore).getCurrentVersion();
+    Version v1 = new VersionImpl(storeName, 1, "push-1");
+    v1.setStatus(VersionStatus.ONLINE);
+    doReturn(Collections.singletonList(v1)).when(mockStore).getVersions();
+    divStats.handleStoreCreated(mockStore);
+    return divStats;
   }
 
 }

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/stats/KafkaConsumerServiceStatsOtelTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/stats/KafkaConsumerServiceStatsOtelTest.java
@@ -792,7 +792,7 @@ public class KafkaConsumerServiceStatsOtelTest {
               TEST_REGION_NAME,
               TEST_POOL_TYPE);
           return n -> {
-            for (int i = 0; i < n; i++)
+            for (long i = 0; i < n; i++)
               s.recordPollRequestLatency(5.0);
           };
         },

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/stats/KafkaConsumerServiceStatsOtelTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/stats/KafkaConsumerServiceStatsOtelTest.java
@@ -769,4 +769,33 @@ public class KafkaConsumerServiceStatsOtelTest {
     assertNotNull(metric, "Tehuti metric should exist: " + metricName);
     return metric.value();
   }
+
+  /**
+   * Verifies that POLL_COUNT (ASYNC_COUNTER_FOR_HIGH_PERF_CASES) produces correct data
+   * across multiple collection intervals under both DELTA and CUMULATIVE temporality.
+   */
+  @Test
+  public void testPollCountMultiCollection() {
+    OpenTelemetryDataTestUtils.validateAsyncCounterMultiCollection(
+        TEST_METRIC_PREFIX,
+        SERVER_METRIC_ENTITIES,
+        POLL_COUNT.getMetricName(),
+        buildNonStoreAttributes(),
+        repo -> {
+          KafkaConsumerServiceStats s = new KafkaConsumerServiceStats(
+              repo,
+              TOTAL_STORE_NAME,
+              () -> 42L,
+              null,
+              SystemTime.INSTANCE,
+              TEST_CLUSTER_NAME,
+              TEST_REGION_NAME,
+              TEST_POOL_TYPE);
+          return n -> {
+            for (int i = 0; i < n; i++)
+              s.recordPollRequestLatency(5.0);
+          };
+        },
+        new long[] { 10, 4, 15 });
+  }
 }

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/stats/ingestion/IngestionOtelStatsTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/stats/ingestion/IngestionOtelStatsTest.java
@@ -88,6 +88,7 @@ import com.linkedin.venice.stats.dimensions.VeniceMetricsDimensions;
 import com.linkedin.venice.stats.dimensions.VenicePartialUpdateOperation;
 import com.linkedin.venice.stats.dimensions.VeniceRecordType;
 import com.linkedin.venice.stats.dimensions.VeniceRegionLocality;
+import com.linkedin.venice.utils.OpenTelemetryDataTestUtils;
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.sdk.testing.exporter.InMemoryMetricReader;
 import io.tehuti.metrics.MetricsRepository;
@@ -1366,5 +1367,24 @@ public class IngestionOtelStatsTest {
   @FunctionalInterface
   private interface ReflectiveResolveBackup {
     int resolve() throws Exception;
+  }
+
+  /**
+   * Verifies that ingestion ASYNC_COUNTER_FOR_HIGH_PERF_CASES metrics produce correct data
+   * across multiple collection intervals under both DELTA and CUMULATIVE temporality.
+   */
+  @Test
+  public void testRecordsConsumedMultiCollection() {
+    OpenTelemetryDataTestUtils.validateAsyncCounterMultiCollection(
+        TEST_PREFIX,
+        SERVER_METRIC_ENTITIES,
+        INGESTION_RECORDS_CONSUMED.getMetricEntity().getMetricName(),
+        buildAttributesWithVersionRoleAndReplicaType(VersionRole.CURRENT, ReplicaType.LEADER),
+        repo -> {
+          IngestionOtelStats s = createStats(repo);
+          s.updateVersionInfo(CURRENT_VERSION, FUTURE_VERSION);
+          return n -> s.recordRecordsConsumed(CURRENT_VERSION, ReplicaType.LEADER, (int) n);
+        },
+        new long[] { 500, 100, 800 });
   }
 }

--- a/internal/venice-client-common/src/main/java/com/linkedin/venice/stats/metrics/MetricAttributesData.java
+++ b/internal/venice-client-common/src/main/java/com/linkedin/venice/stats/metrics/MetricAttributesData.java
@@ -15,7 +15,7 @@ import java.util.concurrent.atomic.LongAdder;
  *
  * <p>The {@link LongAdder} provides high-throughput recording capability by minimizing contention
  * across threads. The accumulated value is read during OpenTelemetry's metric collection callback
- * via {@link #sumThenReset()}.
+ * via {@link #sum()} (for ObservableLongCounter/UpDownCounter callbacks that must report cumulative values).
  */
 public class MetricAttributesData {
   private final Attributes attributes;
@@ -67,13 +67,20 @@ public class MetricAttributesData {
   }
 
   /**
-   * Returns the current sum and resets the adder to zero.
-   * This is typically called during OpenTelemetry's metric collection callback.
-   * Only call this for observable counter metrics where adder is guaranteed non-null.
+   * Returns the current cumulative sum without resetting.
+   * This is the correct method to use in OpenTelemetry's ObservableLongCounter/UpDownCounter callbacks,
+   * which must report <b>cumulative</b> values per the OTel spec. The SDK handles delta computation
+   * internally based on the configured aggregation temporality.
    *
-   * @return the sum before reset
+   * <p>Using {@code sumThenReset()} in observable counter callbacks causes the SDK to compute
+   * delta-of-delta (because it subtracts the previous observation from the current one, but
+   * {@code sumThenReset()} already returns a delta), producing negative counter values when
+   * traffic varies between collection intervals.
+   *
+   * @return the current cumulative sum
    */
-  public long sumThenReset() {
-    return adder.sumThenReset();
+  public long sum() {
+    return adder.sum();
   }
+
 }

--- a/internal/venice-client-common/src/main/java/com/linkedin/venice/stats/metrics/MetricEntityState.java
+++ b/internal/venice-client-common/src/main/java/com/linkedin/venice/stats/metrics/MetricEntityState.java
@@ -27,7 +27,6 @@ import java.util.function.ObjLongConsumer;
  */
 public abstract class MetricEntityState extends AsyncMetricEntityState {
   private final boolean isObservableCounter;
-  private final boolean isMonotonicCounter;
   /** define both long and double consumer to avoid unnecessary conversions **/
   private final ObjDoubleConsumer<MetricAttributesData> otelDoubleRecordingStrategy;
   private final ObjLongConsumer<MetricAttributesData> otelLongRecordingStrategy;
@@ -50,7 +49,6 @@ public abstract class MetricEntityState extends AsyncMetricEntityState {
         null);
     MetricType metricType = metricEntity.getMetricType();
     this.isObservableCounter = metricType.isObservableCounterType();
-    this.isMonotonicCounter = metricType == MetricType.ASYNC_COUNTER_FOR_HIGH_PERF_CASES;
     this.otelDoubleRecordingStrategy = createOtelDoubleRecordingStrategy(metricType);
     this.otelLongRecordingStrategy = createOtelLongRecordingStrategy(metricType);
   }
@@ -103,17 +101,7 @@ public abstract class MetricEntityState extends AsyncMetricEntityState {
 
     for (MetricAttributesData holder: allData) {
       if (holder.hasAdder()) {
-        long value = holder.sum();
-        // For monotonic counters (ASYNC_COUNTER), skip attribute combinations that were never
-        // recorded (cumulative sum == 0, since values are always non-negative). For stale
-        // combinations (e.g., deleted stores), the cumulative sum stays constant and the SDK
-        // correctly computes delta=0.
-        // For up-down counters (ASYNC_UP_DOWN_COUNTER), always report — a cumulative sum of 0
-        // is a legitimate value (e.g., all connections opened have been closed) and must be
-        // observed by the SDK to compute the correct delta.
-        if (value != 0 || !isMonotonicCounter) {
-          measurement.record(value, holder.getAttributes());
-        }
+        measurement.record(holder.sum(), holder.getAttributes());
       }
     }
   }

--- a/internal/venice-client-common/src/main/java/com/linkedin/venice/stats/metrics/MetricEntityState.java
+++ b/internal/venice-client-common/src/main/java/com/linkedin/venice/stats/metrics/MetricEntityState.java
@@ -27,6 +27,7 @@ import java.util.function.ObjLongConsumer;
  */
 public abstract class MetricEntityState extends AsyncMetricEntityState {
   private final boolean isObservableCounter;
+  private final boolean isMonotonicCounter;
   /** define both long and double consumer to avoid unnecessary conversions **/
   private final ObjDoubleConsumer<MetricAttributesData> otelDoubleRecordingStrategy;
   private final ObjLongConsumer<MetricAttributesData> otelLongRecordingStrategy;
@@ -49,6 +50,7 @@ public abstract class MetricEntityState extends AsyncMetricEntityState {
         null);
     MetricType metricType = metricEntity.getMetricType();
     this.isObservableCounter = metricType.isObservableCounterType();
+    this.isMonotonicCounter = metricType == MetricType.ASYNC_COUNTER_FOR_HIGH_PERF_CASES;
     this.otelDoubleRecordingStrategy = createOtelDoubleRecordingStrategy(metricType);
     this.otelLongRecordingStrategy = createOtelLongRecordingStrategy(metricType);
   }
@@ -86,6 +88,12 @@ public abstract class MetricEntityState extends AsyncMetricEntityState {
   /**
    * Reports all accumulated values to the OpenTelemetry measurement.
    * This is the callback invoked by OTel during metric collection.
+   *
+   * <p>Uses {@link MetricAttributesData#sum()} (not {@code sumThenReset()}) because the OTel spec
+   * requires ObservableLongCounter/UpDownCounter callbacks to report <b>cumulative</b> values. The
+   * SDK handles delta computation internally based on the configured aggregation temporality.
+   * Using {@code sumThenReset()} caused the SDK to compute delta-of-delta, producing negative
+   * counter values when traffic varied between collection intervals.
    */
   private void reportToMeasurement(ObservableLongMeasurement measurement) {
     Iterable<MetricAttributesData> allData = getAllMetricAttributesData();
@@ -95,12 +103,15 @@ public abstract class MetricEntityState extends AsyncMetricEntityState {
 
     for (MetricAttributesData holder: allData) {
       if (holder.hasAdder()) {
-        long value = holder.sumThenReset();
-        // Skip zero values to avoid polluting metrics with stale attribute combinations
-        // (e.g., from deleted stores) rather than trying to clean up all the registered
-        // callbacks which could be complex. For delta-temporality async counters, omitting
-        // a zero report correctly means "no change in this period."
-        if (value != 0) {
+        long value = holder.sum();
+        // For monotonic counters (ASYNC_COUNTER), skip attribute combinations that were never
+        // recorded (cumulative sum == 0, since values are always non-negative). For stale
+        // combinations (e.g., deleted stores), the cumulative sum stays constant and the SDK
+        // correctly computes delta=0.
+        // For up-down counters (ASYNC_UP_DOWN_COUNTER), always report — a cumulative sum of 0
+        // is a legitimate value (e.g., all connections opened have been closed) and must be
+        // observed by the SDK to compute the correct delta.
+        if (value != 0 || !isMonotonicCounter) {
           measurement.record(value, holder.getAttributes());
         }
       }
@@ -132,6 +143,11 @@ public abstract class MetricEntityState extends AsyncMetricEntityState {
   private ObjLongConsumer<MetricAttributesData> createOtelLongRecordingStrategy(MetricType metricType) {
     switch (metricType) {
       case ASYNC_COUNTER_FOR_HIGH_PERF_CASES:
+        return (holder, value) -> {
+          if (value >= 0) {
+            holder.add(value);
+          }
+        };
       case ASYNC_UP_DOWN_COUNTER_FOR_HIGH_PERF_CASES:
         return (holder, value) -> holder.add(value);
       case COUNTER:

--- a/internal/venice-client-common/src/test/java/com/linkedin/venice/stats/VeniceOpenTelemetryMetricsRepositoryTest.java
+++ b/internal/venice-client-common/src/test/java/com/linkedin/venice/stats/VeniceOpenTelemetryMetricsRepositoryTest.java
@@ -1282,6 +1282,31 @@ public class VeniceOpenTelemetryMetricsRepositoryTest {
   }
 
   /**
+   * Verifies that a monotonic async counter correctly reports when cumulative sum is zero
+   * (no events recorded yet). Zero is a valid cumulative value and must be observed by the SDK
+   * so it can compute correct deltas when events start arriving in later periods.
+   */
+  @Test
+  public void testAsyncCounterReportsZeroCumulativeSum() {
+    // Pattern: 0 (no events), 5, 0 (no new events), 3
+    // Cumulative sums: 0, 5, 5, 8
+    String metricName = "test_counter_zero";
+    MetricEntity entity = createAsyncCounterMetricEntity(metricName);
+    OpenTelemetryDataTestUtils.validateAsyncCounterMultiCollection(
+        TEST_PREFIX,
+        singletonList(entity),
+        metricName,
+        buildOkSingleGetAttributes(),
+        repo -> {
+          MetricEntityStateThreeEnums<HttpResponseStatusEnum, HttpResponseStatusCodeCategory, RequestType> state =
+              createAsyncCounterMetricState(entity, repo.getOpenTelemetryMetricsRepository());
+          return n -> state
+              .record(n, HttpResponseStatusEnum.OK, HttpResponseStatusCodeCategory.SUCCESS, RequestType.SINGLE_GET);
+        },
+        new long[] { 0, 5, 0, 3 });
+  }
+
+  /**
    * Verifies that an up-down counter correctly reports when cumulative sum returns to zero.
    * A cumulative sum of 0 is a legitimate value (e.g., all increments cancelled by decrements)
    * and must be reported so the SDK computes the correct delta.

--- a/internal/venice-client-common/src/test/java/com/linkedin/venice/stats/VeniceOpenTelemetryMetricsRepositoryTest.java
+++ b/internal/venice-client-common/src/test/java/com/linkedin/venice/stats/VeniceOpenTelemetryMetricsRepositoryTest.java
@@ -696,13 +696,47 @@ public class VeniceOpenTelemetryMetricsRepositoryTest {
     assertNotNull(data1.getAttributes(), "MetricAttributesData should have Attributes");
     assertTrue(data2.hasAdder(), "MetricAttributesData should have a LongAdder for ASYNC_COUNTER_FOR_HIGH_PERF_CASES");
 
-    // Verify accumulated values (30 for first combination, 5 for second)
-    assertEquals(data1.sumThenReset(), 30L, "Should have accumulated 10 + 20 = 30");
-    assertEquals(data2.sumThenReset(), 5L, "Should have accumulated 5");
+    // Verify accumulated values via sum() (cumulative, non-destructive)
+    assertEquals(data1.sum(), 30L, "Should have accumulated 10 + 20 = 30");
+    assertEquals(data2.sum(), 5L, "Should have accumulated 5");
 
-    // After sumThenReset, values should be 0
-    assertEquals(data1.sumThenReset(), 0L, "Should be 0 after reset");
-    assertEquals(data2.sumThenReset(), 0L, "Should be 0 after reset");
+    // sum() is non-destructive — calling it again returns the same value
+    assertEquals(data1.sum(), 30L, "sum() should be non-destructive");
+    assertEquals(data2.sum(), 5L, "sum() should be non-destructive");
+  }
+
+  /** Verifies that recording a negative value to a monotonic async counter is silently dropped. */
+  @Test
+  public void testAsyncCounterDropsNegativeValue() {
+    MetricEntity metricEntity = createAsyncCounterMetricEntity("test_async_counter_negative");
+    MetricEntityStateThreeEnums<HttpResponseStatusEnum, HttpResponseStatusCodeCategory, RequestType> metricState =
+        createAsyncCounterMetricState(metricEntity, metricsRepository);
+
+    // Record a positive value first
+    metricState.record(10L, HttpResponseStatusEnum.OK, HttpResponseStatusCodeCategory.SUCCESS, RequestType.SINGLE_GET);
+    // Attempt a negative recording — should be dropped, not accumulated
+    metricState.record(-5L, HttpResponseStatusEnum.OK, HttpResponseStatusCodeCategory.SUCCESS, RequestType.SINGLE_GET);
+
+    MetricAttributesData data = metricState.getMetricAttributesDataEnumMap()
+        .get(HttpResponseStatusEnum.OK)
+        .get(HttpResponseStatusCodeCategory.SUCCESS)
+        .get(RequestType.SINGLE_GET);
+    assertEquals(data.sum(), 10L, "Negative recording should be dropped; sum should remain 10");
+  }
+
+  /** Verifies that recording a negative value to an up-down counter is allowed. */
+  @Test
+  public void testAsyncUpDownCounterAllowsNegativeValue() {
+    MetricEntity metricEntity = createAsyncUpDownCounterMetricEntity("test_async_updown_negative");
+    MetricEntityStateThreeEnums<HttpResponseStatusEnum, HttpResponseStatusCodeCategory, RequestType> metricState =
+        createAsyncUpDownCounterMetricState(metricEntity, metricsRepository);
+    // Should not throw
+    metricState.record(-5L, HttpResponseStatusEnum.OK, HttpResponseStatusCodeCategory.SUCCESS, RequestType.SINGLE_GET);
+    MetricAttributesData data = metricState.getMetricAttributesDataEnumMap()
+        .get(HttpResponseStatusEnum.OK)
+        .get(HttpResponseStatusCodeCategory.SUCCESS)
+        .get(RequestType.SINGLE_GET);
+    assertEquals(data.sum(), -5L, "Up-down counter should accept negative values");
   }
 
   /**
@@ -745,7 +779,6 @@ public class VeniceOpenTelemetryMetricsRepositoryTest {
               .build();
 
       // Record and validate OK/SUCCESS/SINGLE_GET combination (100 + 50 = 150)
-      // Note: Each collectAllMetrics() call triggers sumThenReset(), so we validate one combination at a time
       metricState
           .record(100L, HttpResponseStatusEnum.OK, HttpResponseStatusCodeCategory.SUCCESS, RequestType.SINGLE_GET);
       metricState
@@ -759,17 +792,18 @@ public class VeniceOpenTelemetryMetricsRepositoryTest {
           HttpResponseStatusEnum.INTERNAL_SERVER_ERROR,
           HttpResponseStatusCodeCategory.SERVER_ERROR,
           RequestType.MULTI_GET);
+      // Cumulative: error=25, okSuccess still=150 from previous recordings
       OpenTelemetryDataTestUtils
           .validateObservableCounterValue(inMemoryMetricReader, 25L, errorAttributes, metricName, TEST_PREFIX);
 
-      // Record more values and validate again to verify reset behavior
+      // Record more values and validate cumulative behavior
       metricState
           .record(200L, HttpResponseStatusEnum.OK, HttpResponseStatusCodeCategory.SUCCESS, RequestType.SINGLE_GET);
 
-      // After collection, the value should reflect only the new recording (200)
-      // because sumThenReset() resets the LongAdder after each collection
+      // Cumulative total for OK/SUCCESS/SINGLE_GET: 100 + 50 + 200 = 350
+      // (sum() reports running total, not just the latest recording)
       OpenTelemetryDataTestUtils
-          .validateObservableCounterValue(inMemoryMetricReader, 200L, okSuccessAttributes, metricName, TEST_PREFIX);
+          .validateObservableCounterValue(inMemoryMetricReader, 350L, okSuccessAttributes, metricName, TEST_PREFIX);
 
     } finally {
       otelRepo.close();
@@ -844,16 +878,16 @@ public class VeniceOpenTelemetryMetricsRepositoryTest {
         data1.hasAdder(),
         "MetricAttributesData should have a LongAdder for ASYNC_UP_DOWN_COUNTER_FOR_HIGH_PERF_CASES");
 
-    // Verify accumulated values (10 + 20 - 5 = 25)
-    assertEquals(data1.sumThenReset(), 25L, "Should have accumulated 10 + 20 - 5 = 25");
+    // Verify accumulated value via sum() (cumulative, non-destructive)
+    assertEquals(data1.sum(), 25L, "Should have accumulated 10 + 20 - 5 = 25");
 
-    // After sumThenReset, values should be 0
-    assertEquals(data1.sumThenReset(), 0L, "Should be 0 after reset");
+    // sum() is non-destructive — calling it again returns the same value
+    assertEquals(data1.sum(), 25L, "sum() should be non-destructive");
 
-    // Test negative-only accumulation
+    // Test negative accumulation: 25 + (-100) = -75
     metricState
         .record(-100L, HttpResponseStatusEnum.OK, HttpResponseStatusCodeCategory.SUCCESS, RequestType.SINGLE_GET);
-    assertEquals(data1.sumThenReset(), -100L, "Should support negative accumulation");
+    assertEquals(data1.sum(), -75L, "Should support negative accumulation: 25 + (-100) = -75");
   }
 
   /**
@@ -1173,6 +1207,171 @@ public class VeniceOpenTelemetryMetricsRepositoryTest {
           baseAttributes,
           "test_async_double_gauge",
           TEST_PREFIX);
+    } finally {
+      otelRepo.close();
+    }
+  }
+
+  /** Creates a VeniceOpenTelemetryMetricsRepository with the given reader for test use. */
+  private static VeniceOpenTelemetryMetricsRepository createOtelRepoForTest(InMemoryMetricReader reader) {
+    VeniceMetricsConfig config = new VeniceMetricsConfig.Builder().setServiceName("test_service")
+        .setMetricPrefix(TEST_PREFIX)
+        .setEmitOtelMetrics(true)
+        .setExportOtelMetricsToEndpoint(false)
+        .setUseOtelExponentialHistogram(false)
+        .setOtelAdditionalMetricsReader(reader)
+        .build();
+    return new VeniceOpenTelemetryMetricsRepository(config);
+  }
+
+  /** Builds the standard OK/SUCCESS/SINGLE_GET test attributes with the default store name. */
+  private static Attributes buildOkSingleGetAttributes() {
+    return new OpenTelemetryDataTestUtils.OpenTelemetryAttributesBuilder().setStoreName(TEST_STORE_NAME)
+        .setHttpStatus(HttpResponseStatusEnum.OK)
+        .setRequestType(RequestType.SINGLE_GET)
+        .build();
+  }
+
+  /**
+   * Verifies ASYNC_COUNTER_FOR_HIGH_PERF_CASES produces correct data under both DELTA and
+   * CUMULATIVE temporality across multiple collection intervals with varying traffic.
+   *
+   * <p>Production uses {@code deltaPreferred()} temporality. Before the fix (using
+   * {@code sumThenReset()} in the {@code ObservableLongCounter} callback), the OTel SDK computed
+   * delta-of-delta, producing negative counter values when traffic varied between intervals.
+   * The fix ({@code sum()}) reports cumulative observations so the SDK correctly computes deltas.
+   */
+  @Test
+  public void testAsyncCounterMultiCollection() {
+    String metricName = "test_counter_multi";
+    MetricEntity entity = createAsyncCounterMetricEntity(metricName);
+    OpenTelemetryDataTestUtils.validateAsyncCounterMultiCollection(
+        TEST_PREFIX,
+        singletonList(entity),
+        metricName,
+        buildOkSingleGetAttributes(),
+        repo -> {
+          MetricEntityStateThreeEnums<HttpResponseStatusEnum, HttpResponseStatusCodeCategory, RequestType> state =
+              createAsyncCounterMetricState(entity, repo.getOpenTelemetryMetricsRepository());
+          return n -> state
+              .record(n, HttpResponseStatusEnum.OK, HttpResponseStatusCodeCategory.SUCCESS, RequestType.SINGLE_GET);
+        },
+        new long[] { 500, 200, 800, 100, 300 });
+  }
+
+  /**
+   * Verifies ASYNC_UP_DOWN_COUNTER_FOR_HIGH_PERF_CASES produces correct data under both DELTA
+   * and CUMULATIVE temporality, including net-negative periods.
+   */
+  @Test
+  public void testAsyncUpDownCounterMultiCollection() {
+    String metricName = "test_updown_multi";
+    MetricEntity entity = createAsyncUpDownCounterMetricEntity(metricName);
+    OpenTelemetryDataTestUtils.validateAsyncUpDownCounterMultiCollection(
+        TEST_PREFIX,
+        singletonList(entity),
+        metricName,
+        buildOkSingleGetAttributes(),
+        repo -> {
+          MetricEntityStateThreeEnums<HttpResponseStatusEnum, HttpResponseStatusCodeCategory, RequestType> state =
+              createAsyncUpDownCounterMetricState(entity, repo.getOpenTelemetryMetricsRepository());
+          return n -> state
+              .record(n, HttpResponseStatusEnum.OK, HttpResponseStatusCodeCategory.SUCCESS, RequestType.SINGLE_GET);
+        },
+        new long[] { 10, -7, 5, -3, 12 });
+  }
+
+  /**
+   * Verifies that an up-down counter correctly reports when cumulative sum returns to zero.
+   * This is the edge case that distinguishes monotonic counters (skip zero = never recorded)
+   * from up-down counters (zero is a legitimate value after +N/-N that must be reported).
+   */
+  @Test
+  public void testAsyncUpDownCounterReportsZeroCumulativeSum() {
+    // Pattern: +10, -10 → cumulative sum is 0 after period 2, then +5 → cumulative is 5
+    String metricName = "test_updown_zero";
+    MetricEntity entity = createAsyncUpDownCounterMetricEntity(metricName);
+    OpenTelemetryDataTestUtils.validateAsyncUpDownCounterMultiCollection(
+        TEST_PREFIX,
+        singletonList(entity),
+        metricName,
+        buildOkSingleGetAttributes(),
+        repo -> {
+          MetricEntityStateThreeEnums<HttpResponseStatusEnum, HttpResponseStatusCodeCategory, RequestType> state =
+              createAsyncUpDownCounterMetricState(entity, repo.getOpenTelemetryMetricsRepository());
+          return n -> state
+              .record(n, HttpResponseStatusEnum.OK, HttpResponseStatusCodeCategory.SUCCESS, RequestType.SINGLE_GET);
+        },
+        new long[] { 10, -10, 5 });
+  }
+
+  /**
+   * Verifies that multiple stores sharing the same ASYNC_COUNTER metric name produce correct
+   * independent deltas under DELTA temporality, with no cross-contamination between stores.
+   */
+  @Test
+  public void testMultipleCallbacksDeltaTemporalityIsolation() {
+    InMemoryMetricReader deltaReader = InMemoryMetricReader.createDelta();
+    VeniceOpenTelemetryMetricsRepository otelRepo = createOtelRepoForTest(deltaReader);
+
+    try {
+      String metricName = "test_multi_store_delta";
+      MetricEntity metricEntity = createAsyncCounterMetricEntity(metricName);
+
+      // Create two stores with separate metric states
+      Map<VeniceMetricsDimensions, String> storeADims = new HashMap<>();
+      storeADims.put(VeniceMetricsDimensions.VENICE_STORE_NAME, "store_A");
+      MetricEntityStateThreeEnums<HttpResponseStatusEnum, HttpResponseStatusCodeCategory, RequestType> stateA =
+          MetricEntityStateThreeEnums.create(
+              metricEntity,
+              otelRepo,
+              storeADims,
+              HttpResponseStatusEnum.class,
+              HttpResponseStatusCodeCategory.class,
+              RequestType.class);
+
+      Map<VeniceMetricsDimensions, String> storeBDims = new HashMap<>();
+      storeBDims.put(VeniceMetricsDimensions.VENICE_STORE_NAME, "store_B");
+      MetricEntityStateThreeEnums<HttpResponseStatusEnum, HttpResponseStatusCodeCategory, RequestType> stateB =
+          MetricEntityStateThreeEnums.create(
+              metricEntity,
+              otelRepo,
+              storeBDims,
+              HttpResponseStatusEnum.class,
+              HttpResponseStatusCodeCategory.class,
+              RequestType.class);
+
+      Attributes storeAAttrs = new OpenTelemetryDataTestUtils.OpenTelemetryAttributesBuilder().setStoreName("store_A")
+          .setHttpStatus(HttpResponseStatusEnum.OK)
+          .setRequestType(RequestType.SINGLE_GET)
+          .build();
+      Attributes storeBAttrs = new OpenTelemetryDataTestUtils.OpenTelemetryAttributesBuilder().setStoreName("store_B")
+          .setHttpStatus(HttpResponseStatusEnum.OK)
+          .setRequestType(RequestType.SINGLE_GET)
+          .build();
+
+      // Period 1: store A=300, store B=100
+      stateA.record(300L, HttpResponseStatusEnum.OK, HttpResponseStatusCodeCategory.SUCCESS, RequestType.SINGLE_GET);
+      stateB.record(100L, HttpResponseStatusEnum.OK, HttpResponseStatusCodeCategory.SUCCESS, RequestType.SINGLE_GET);
+      Collection<MetricData> p1 = deltaReader.collectAllMetrics();
+      assertEquals(
+          OpenTelemetryDataTestUtils.getLongPointDataFromSum(p1, metricName, TEST_PREFIX, storeAAttrs).getValue(),
+          300L);
+      assertEquals(
+          OpenTelemetryDataTestUtils.getLongPointDataFromSum(p1, metricName, TEST_PREFIX, storeBAttrs).getValue(),
+          100L);
+
+      // Period 2: store A=50 (decreased), store B=400 (increased) — both should have correct positive deltas
+      stateA.record(50L, HttpResponseStatusEnum.OK, HttpResponseStatusCodeCategory.SUCCESS, RequestType.SINGLE_GET);
+      stateB.record(400L, HttpResponseStatusEnum.OK, HttpResponseStatusCodeCategory.SUCCESS, RequestType.SINGLE_GET);
+      Collection<MetricData> p2 = deltaReader.collectAllMetrics();
+      LongPointData p2a = OpenTelemetryDataTestUtils.getLongPointDataFromSum(p2, metricName, TEST_PREFIX, storeAAttrs);
+      LongPointData p2b = OpenTelemetryDataTestUtils.getLongPointDataFromSum(p2, metricName, TEST_PREFIX, storeBAttrs);
+      assertNotNull(p2a);
+      assertNotNull(p2b);
+      assertTrue(p2a.getValue() > 0, "Store A delta must be positive, got: " + p2a.getValue());
+      assertEquals(p2a.getValue(), 50L, "Store A period 2 delta should be 50");
+      assertEquals(p2b.getValue(), 400L, "Store B period 2 delta should be 400");
     } finally {
       otelRepo.close();
     }

--- a/internal/venice-client-common/src/test/java/com/linkedin/venice/stats/VeniceOpenTelemetryMetricsRepositoryTest.java
+++ b/internal/venice-client-common/src/test/java/com/linkedin/venice/stats/VeniceOpenTelemetryMetricsRepositoryTest.java
@@ -1283,8 +1283,8 @@ public class VeniceOpenTelemetryMetricsRepositoryTest {
 
   /**
    * Verifies that an up-down counter correctly reports when cumulative sum returns to zero.
-   * This is the edge case that distinguishes monotonic counters (skip zero = never recorded)
-   * from up-down counters (zero is a legitimate value after +N/-N that must be reported).
+   * A cumulative sum of 0 is a legitimate value (e.g., all increments cancelled by decrements)
+   * and must be reported so the SDK computes the correct delta.
    */
   @Test
   public void testAsyncUpDownCounterReportsZeroCumulativeSum() {

--- a/internal/venice-test-common/src/main/java/com/linkedin/venice/utils/OpenTelemetryDataTestUtils.java
+++ b/internal/venice-test-common/src/main/java/com/linkedin/venice/utils/OpenTelemetryDataTestUtils.java
@@ -15,10 +15,13 @@ import static org.testng.Assert.assertTrue;
 import static org.testng.AssertJUnit.assertFalse;
 
 import com.linkedin.venice.read.RequestType;
+import com.linkedin.venice.stats.VeniceMetricsConfig;
+import com.linkedin.venice.stats.VeniceMetricsRepository;
 import com.linkedin.venice.stats.dimensions.HttpResponseStatusEnum;
 import com.linkedin.venice.stats.dimensions.RequestRetryType;
 import com.linkedin.venice.stats.dimensions.VeniceMetricsDimensions;
 import com.linkedin.venice.stats.dimensions.VeniceResponseStatusCategory;
+import com.linkedin.venice.stats.metrics.MetricEntity;
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.common.AttributesBuilder;
 import io.opentelemetry.sdk.metrics.data.DoublePointData;
@@ -28,6 +31,8 @@ import io.opentelemetry.sdk.metrics.data.LongPointData;
 import io.opentelemetry.sdk.metrics.data.MetricData;
 import io.opentelemetry.sdk.testing.exporter.InMemoryMetricReader;
 import java.util.Collection;
+import java.util.function.Function;
+import java.util.function.LongConsumer;
 import org.testng.annotations.Test;
 
 
@@ -532,5 +537,261 @@ public abstract class OpenTelemetryDataTestUtils {
       point = data.getLongSumData().getPoints().stream().findFirst().orElse(null);
     }
     assertNull(point, "Expected no counter data for " + fullMetricName);
+  }
+
+  /**
+   * Validates that a <b>monotonic</b> async counter ({@code ASYNC_COUNTER_FOR_HIGH_PERF_CASES})
+   * produces correct strictly-positive deltas under DELTA temporality across multiple collection
+   * intervals. All {@code valuesPerPeriod} must be strictly positive.
+   *
+   * <p>This is the key regression test for the {@code sumThenReset()} to {@code sum()} fix. With
+   * DELTA temporality, the OTel SDK computes {@code currentObservation - lastObservation}. If the
+   * callback reports deltas ({@code sumThenReset()}), the SDK computes delta-of-delta which goes
+   * negative when traffic decreases. With cumulative observations ({@code sum()}), the SDK
+   * correctly computes the real delta for each period.
+   *
+   * <p>For {@code ASYNC_UP_DOWN_COUNTER_FOR_HIGH_PERF_CASES}, use
+   * {@link #validateAsyncUpDownCounterDeltaMultiCollection} instead.
+   */
+  public static void validateAsyncCounterDeltaMultiCollection(
+      InMemoryMetricReader deltaReader,
+      String metricName,
+      String metricPrefix,
+      Attributes expectedAttributes,
+      LongConsumer recordFn,
+      long[] valuesPerPeriod) {
+    validateDeltaMultiCollection(
+        deltaReader,
+        metricName,
+        metricPrefix,
+        expectedAttributes,
+        recordFn,
+        valuesPerPeriod,
+        true);
+  }
+
+  /**
+   * Validates that an {@code ASYNC_UP_DOWN_COUNTER_FOR_HIGH_PERF_CASES} metric produces correct
+   * deltas under DELTA temporality. Unlike monotonic counters, deltas can be negative.
+   */
+  public static void validateAsyncUpDownCounterDeltaMultiCollection(
+      InMemoryMetricReader deltaReader,
+      String metricName,
+      String metricPrefix,
+      Attributes expectedAttributes,
+      LongConsumer recordFn,
+      long[] valuesPerPeriod) {
+    validateDeltaMultiCollection(
+        deltaReader,
+        metricName,
+        metricPrefix,
+        expectedAttributes,
+        recordFn,
+        valuesPerPeriod,
+        false);
+  }
+
+  /**
+   * Validates that a <b>monotonic</b> async counter ({@code ASYNC_COUNTER_FOR_HIGH_PERF_CASES})
+   * produces monotonically non-decreasing cumulative values across multiple collection intervals.
+   *
+   * <p>For {@code ASYNC_UP_DOWN_COUNTER_FOR_HIGH_PERF_CASES}, use
+   * {@link #validateAsyncUpDownCounterCumulativeMultiCollection} instead.
+   */
+  public static void validateAsyncCounterCumulativeMultiCollection(
+      InMemoryMetricReader cumulativeReader,
+      String metricName,
+      String metricPrefix,
+      Attributes expectedAttributes,
+      LongConsumer recordFn,
+      long[] valuesPerPeriod) {
+    validateCumulativeMultiCollection(
+        cumulativeReader,
+        metricName,
+        metricPrefix,
+        expectedAttributes,
+        recordFn,
+        valuesPerPeriod,
+        true);
+  }
+
+  /**
+   * Validates that an {@code ASYNC_UP_DOWN_COUNTER_FOR_HIGH_PERF_CASES} metric produces correct
+   * cumulative values. Unlike monotonic counters, the cumulative value can decrease.
+   */
+  public static void validateAsyncUpDownCounterCumulativeMultiCollection(
+      InMemoryMetricReader cumulativeReader,
+      String metricName,
+      String metricPrefix,
+      Attributes expectedAttributes,
+      LongConsumer recordFn,
+      long[] valuesPerPeriod) {
+    validateCumulativeMultiCollection(
+        cumulativeReader,
+        metricName,
+        metricPrefix,
+        expectedAttributes,
+        recordFn,
+        valuesPerPeriod,
+        false);
+  }
+
+  /**
+   * Convenience overload for <b>monotonic</b> async counters ({@code ASYNC_COUNTER_FOR_HIGH_PERF_CASES})
+   * that handles reader and repository lifecycle. Validates both DELTA and CUMULATIVE temporality.
+   *
+   * <p>For {@code ASYNC_UP_DOWN_COUNTER_FOR_HIGH_PERF_CASES}, use
+   * {@link #validateAsyncUpDownCounterMultiCollection} instead.
+   */
+  public static void validateAsyncCounterMultiCollection(
+      String metricPrefix,
+      Collection<MetricEntity> metricEntities,
+      String metricName,
+      Attributes expectedAttributes,
+      Function<VeniceMetricsRepository, LongConsumer> statsFactory,
+      long[] valuesPerPeriod) {
+    validateBothTemporalities(
+        metricPrefix,
+        metricEntities,
+        metricName,
+        expectedAttributes,
+        statsFactory,
+        valuesPerPeriod,
+        true);
+  }
+
+  /**
+   * Convenience overload for {@code ASYNC_UP_DOWN_COUNTER_FOR_HIGH_PERF_CASES} that handles
+   * reader and repository lifecycle. Validates both DELTA and CUMULATIVE temporality.
+   * Values can be positive or negative.
+   */
+  public static void validateAsyncUpDownCounterMultiCollection(
+      String metricPrefix,
+      Collection<MetricEntity> metricEntities,
+      String metricName,
+      Attributes expectedAttributes,
+      Function<VeniceMetricsRepository, LongConsumer> statsFactory,
+      long[] valuesPerPeriod) {
+    validateBothTemporalities(
+        metricPrefix,
+        metricEntities,
+        metricName,
+        expectedAttributes,
+        statsFactory,
+        valuesPerPeriod,
+        false);
+  }
+
+  /** Validates DELTA temporality across multiple collections. When {@code monotonic}, asserts each delta is strictly positive. */
+  private static void validateDeltaMultiCollection(
+      InMemoryMetricReader deltaReader,
+      String metricName,
+      String metricPrefix,
+      Attributes expectedAttributes,
+      LongConsumer recordFn,
+      long[] valuesPerPeriod,
+      boolean monotonic) {
+    for (int i = 0; i < valuesPerPeriod.length; i++) {
+      recordFn.accept(valuesPerPeriod[i]);
+      Collection<MetricData> metrics = deltaReader.collectAllMetrics();
+      LongPointData point = getLongPointDataFromSum(metrics, metricName, metricPrefix, expectedAttributes);
+      assertNotNull(point, "Period " + (i + 1) + " should have data for " + metricName);
+      if (monotonic) {
+        assertTrue(
+            point.getValue() > 0,
+            "Monotonic counter delta must be strictly positive in period " + (i + 1) + ", but got: " + point.getValue()
+                + " for " + metricName);
+      }
+      assertEquals(
+          point.getValue(),
+          valuesPerPeriod[i],
+          "Period " + (i + 1) + " delta should be " + valuesPerPeriod[i] + " for " + metricName);
+    }
+  }
+
+  /** Validates CUMULATIVE temporality across multiple collections. When {@code monotonic}, asserts values are non-decreasing. */
+  private static void validateCumulativeMultiCollection(
+      InMemoryMetricReader cumulativeReader,
+      String metricName,
+      String metricPrefix,
+      Attributes expectedAttributes,
+      LongConsumer recordFn,
+      long[] valuesPerPeriod,
+      boolean monotonic) {
+    long previousValue = 0;
+    long expectedCumulative = 0;
+    for (int i = 0; i < valuesPerPeriod.length; i++) {
+      recordFn.accept(valuesPerPeriod[i]);
+      expectedCumulative += valuesPerPeriod[i];
+      Collection<MetricData> metrics = cumulativeReader.collectAllMetrics();
+      LongPointData point = getLongPointDataFromSum(metrics, metricName, metricPrefix, expectedAttributes);
+      assertNotNull(point, "Period " + (i + 1) + " should have data for " + metricName);
+      if (monotonic) {
+        assertTrue(
+            point.getValue() >= previousValue,
+            "Cumulative counter must be non-decreasing in period " + (i + 1) + ": was " + previousValue + ", now "
+                + point.getValue() + " for " + metricName);
+      }
+      assertEquals(
+          point.getValue(),
+          expectedCumulative,
+          "Cumulative value after period " + (i + 1) + " should be " + expectedCumulative + " for " + metricName);
+      previousValue = point.getValue();
+    }
+  }
+
+  /** Runs both DELTA and CUMULATIVE validation with reader/repo lifecycle management. */
+  private static void validateBothTemporalities(
+      String metricPrefix,
+      Collection<MetricEntity> metricEntities,
+      String metricName,
+      Attributes expectedAttributes,
+      Function<VeniceMetricsRepository, LongConsumer> statsFactory,
+      long[] valuesPerPeriod,
+      boolean monotonic) {
+    InMemoryMetricReader deltaReader = InMemoryMetricReader.createDelta();
+    VeniceMetricsRepository deltaRepo = createOtelRepo(metricPrefix, metricEntities, deltaReader);
+    try {
+      LongConsumer recordFn = statsFactory.apply(deltaRepo);
+      validateDeltaMultiCollection(
+          deltaReader,
+          metricName,
+          metricPrefix,
+          expectedAttributes,
+          recordFn,
+          valuesPerPeriod,
+          monotonic);
+    } finally {
+      deltaRepo.close();
+    }
+
+    InMemoryMetricReader cumulativeReader = InMemoryMetricReader.create();
+    VeniceMetricsRepository cumulativeRepo = createOtelRepo(metricPrefix, metricEntities, cumulativeReader);
+    try {
+      LongConsumer recordFn = statsFactory.apply(cumulativeRepo);
+      validateCumulativeMultiCollection(
+          cumulativeReader,
+          metricName,
+          metricPrefix,
+          expectedAttributes,
+          recordFn,
+          valuesPerPeriod,
+          monotonic);
+    } finally {
+      cumulativeRepo.close();
+    }
+  }
+
+  /** Creates a VeniceMetricsRepository with OTel enabled and the given reader. */
+  private static VeniceMetricsRepository createOtelRepo(
+      String metricPrefix,
+      Collection<MetricEntity> metricEntities,
+      InMemoryMetricReader reader) {
+    return new VeniceMetricsRepository(
+        new VeniceMetricsConfig.Builder().setMetricPrefix(metricPrefix)
+            .setMetricEntities(metricEntities)
+            .setEmitOtelMetrics(true)
+            .setOtelAdditionalMetricsReader(reader)
+            .build());
   }
 }

--- a/internal/venice-test-common/src/main/java/com/linkedin/venice/utils/OpenTelemetryDataTestUtils.java
+++ b/internal/venice-test-common/src/main/java/com/linkedin/venice/utils/OpenTelemetryDataTestUtils.java
@@ -698,8 +698,8 @@ public abstract class OpenTelemetryDataTestUtils {
       assertNotNull(point, "Period " + (i + 1) + " should have data for " + metricName);
       if (monotonic) {
         assertTrue(
-            point.getValue() > 0,
-            "Monotonic counter delta must be strictly positive in period " + (i + 1) + ", but got: " + point.getValue()
+            point.getValue() >= 0,
+            "Monotonic counter delta must be non-negative in period " + (i + 1) + ", but got: " + point.getValue()
                 + " for " + metricName);
       }
       assertEquals(

--- a/services/venice-server/src/test/java/com/linkedin/venice/stats/ServerReadQuotaUsageStatsOtelTest.java
+++ b/services/venice-server/src/test/java/com/linkedin/venice/stats/ServerReadQuotaUsageStatsOtelTest.java
@@ -96,7 +96,6 @@ public class ServerReadQuotaUsageStatsOtelTest {
     stats.recordAllowed(2, 200);
     stats.recordAllowed(1, 50);
 
-    // Collect once — sumThenReset drains adders
     Collection<MetricData> metricsData = inMemoryMetricReader.collectAllMetrics();
 
     // CURRENT: 2 requests, 300 keys
@@ -345,7 +344,7 @@ public class ServerReadQuotaUsageStatsOtelTest {
     stats.recordAllowed(2, 100);
     stats.recordAllowed(1, 50);
 
-    // Drain first collection
+    // First collection (CUMULATIVE reader): reports cumulative sums
     inMemoryMetricReader.collectAllMetrics();
 
     // Transition: version 3 becomes current, version 2 becomes backup
@@ -355,13 +354,15 @@ public class ServerReadQuotaUsageStatsOtelTest {
     // Record on new current version
     stats.recordAllowed(3, 200);
 
-    // Second collection: only the delta since the first drain
+    // Second collection: cumulative total for CURRENT/ALLOWED = 100 (recorded in period 1 while v2 was
+    // CURRENT) + 200 (recorded in period 2 while v3 is CURRENT) = 300. The CURRENT-role LongAdder is
+    // cumulative across collections, so period-1 recordings remain even after v2 transitions to BACKUP.
     Collection<MetricData> metricsData = inMemoryMetricReader.collectAllMetrics();
     assertCounterValue(
         metricsData,
         "read.quota.key.count",
         buildAttributes(VersionRole.CURRENT, QuotaRequestOutcome.ALLOWED),
-        200L);
+        300L);
   }
 
   @Test
@@ -399,6 +400,26 @@ public class ServerReadQuotaUsageStatsOtelTest {
     stats.recordAllowedUnintentionally(1, 25);
     stats.setNodeQuotaResponsibility(1, 1000);
     stats.removeVersion(1);
+  }
+
+  /**
+   * Verifies that READ_QUOTA_KEY_COUNT (ASYNC_COUNTER_FOR_HIGH_PERF_CASES) produces correct data
+   * across multiple collection intervals under both DELTA and CUMULATIVE temporality.
+   */
+  @Test
+  public void testKeyCountMultiCollection() {
+    OpenTelemetryDataTestUtils.validateAsyncCounterMultiCollection(
+        TEST_METRIC_PREFIX,
+        SERVER_METRIC_ENTITIES,
+        "read.quota.key.count",
+        buildAttributes(VersionRole.CURRENT, QuotaRequestOutcome.ALLOWED),
+        repo -> {
+          ServerReadQuotaUsageStats s =
+              new ServerReadQuotaUsageStats(repo, TEST_STORE_NAME, new TestMockTime(), TEST_CLUSTER_NAME);
+          s.updateVersionInfo(1, 0);
+          return n -> s.recordAllowed(1, n);
+        },
+        new long[] { 200_000, 100_000, 300_000 });
   }
 
   private static String fullMetricName(String metricName) {


### PR DESCRIPTION
## Problem Statement

All `ASYNC_COUNTER_FOR_HIGH_PERF_CASES` and `ASYNC_UP_DOWN_COUNTER_FOR_HIGH_PERF_CASES` OTel metrics (READ_QUOTA_KEY_COUNT,
MESSAGE_COUNT, POLL_COUNT, RECORDS_CONSUMED, etc.) produce negative counter
values on dashboards.

Root cause: These use LongAdder for better performance. `MetricEntityState.reportToMeasurement()` used
`LongAdder.sumThenReset()` in the `ObservableLongCounter` callback => reports deltas. The OTel SDK spec requires async counter callbacks to report cumulative values and they internally computes `delta = currentObservation - previousObservation`, so it computed delta-of-delta, producing negative values.

Confirmed by reading the OTel Java SDK 1.47.0 source:
`AsynchronousMetricStorage.collect()` calls `aggregator.diff(lastPoint, currentPoint)` which is `currentPoint.getValue() - previousPoint.getValue()`.

## Solution
- `MetricAttributesData`: Replace `sumThenReset()` with `sum()` so the callback reports cumulative values. Remove `sumThenReset()` entirely.
- `MetricEntityState.reportToMeasurement()`: Call `sum()` instead of `sumThenReset()`. Remove the zero-skip optimization — zero is a valid cumulative value for both monotonic counters (never recorded) and up-down counters (all increments cancelled by decrements). Remove the now-unused `isMonotonicCounter` field.
- Add negative-value guard for `ASYNC_COUNTER_FOR_HIGH_PERF_CASES` (silently dropped, matching OTel SDK behavior for synchronous `LongCounter`).

### Code changes
- [ ] Added new code behind **a config**.
- [ ] Introduced new **log lines**.

### Concurrency-Specific Checks
- [x] Code has **no race conditions** or **thread safety issues**.
  `LongAdder.sum()` and `LongAdder.add()` are designed for concurrent
  read/write. EnumMap iteration uses snapshot copy.
- [x] Proper **synchronization mechanisms** are used where needed.
- [x] No **blocking calls** inside critical sections.
- [x] Verified **thread-safe collections** are used.
- [x] Validated proper exception handling in multi-threaded code.

## How was this PR tested?

- [x] New unit tests added.
- [ ] New integration tests added.
- [x] Modified or extended existing tests.
- [x] Verified backward compatibility (if applicable).

## Does this PR introduce any user-facing or breaking changes?
- [x] Yes.

**Before:** `ASYNC_COUNTER_FOR_HIGH_PERF_CASES` and `ASYNC_UP_DOWN_COUNTER_FOR_HIGH_PERF_CASES` metrics produced incorrect counter values. Monotonic counters oscillated between positive and negative values on dashboards. Rate aggregation showed negative counters.

**After:** Monotonic counters are always non-negative. Up-down counters report correct deltas. Zero cumulative values are always reported (not skipped).