### PR TITLE
[controller] Add configs to tune replication factor based on current/future/backup version status

### DIFF
--- a/internal/venice-common/src/main/java/com/linkedin/venice/ConfigKeys.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/ConfigKeys.java
@@ -3269,6 +3269,22 @@ public class ConfigKeys {
   public static final String CONTROLLER_BACKUP_VERSION_REPLICA_REDUCTION_ENABLED =
       "controller.backup.version.replica.reduction.enabled";
 
+  /**
+   * Feature flag to enable per-cluster RF tuning on child controllers. When enabled, the controller uses
+   * configurable RF and MinActiveReplicas values for each version lifecycle stage (future, current, backup)
+   * instead of deriving them from the store-level replicationFactor.
+   */
+  public static final String CONTROLLER_RF_TUNING_ENABLED = "controller.rf.tuning.enabled";
+  public static final String CONTROLLER_CURRENT_VERSION_RF_COUNT = "controller.current.version.rf.count";
+  public static final String CONTROLLER_CURRENT_VERSION_MIN_ACTIVE_REPLICA_COUNT =
+      "controller.current.version.min.active.replica.count";
+  public static final String CONTROLLER_BACKUP_VERSION_RF_COUNT = "controller.backup.version.rf.count";
+  public static final String CONTROLLER_BACKUP_VERSION_MIN_ACTIVE_REPLICA_COUNT =
+      "controller.backup.version.min.active.replica.count";
+  public static final String CONTROLLER_FUTURE_VERSION_RF_COUNT = "controller.future.version.rf.count";
+  public static final String CONTROLLER_FUTURE_VERSION_MIN_ACTIVE_REPLICA_COUNT =
+      "controller.future.version.min.active.replica.count";
+
   public static final String DAVINCI_VALIDATE_SPECIFIC_SCHEMA_ENABLED = "davinci.validate.specific.schema.enabled";
 
   /**

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/HelixAdminClient.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/HelixAdminClient.java
@@ -163,4 +163,13 @@ public interface HelixAdminClient {
   IdealState getResourceIdealState(String clusterName, String resourceName);
 
   void updateIdealState(String clusterName, String resourceName, IdealState idealState);
+
+  /**
+   * Update the IdealState for a resource with the specified MinActiveReplicas and numReplicas.
+   * Only writes to ZK if values actually changed. Validates that numReplicas >= 1 and
+   * 1 &lt;= minActiveReplicas &lt;= numReplicas.
+   *
+   * @return true if the IdealState was updated, false if no changes were needed or resource not found.
+   */
+  boolean updateIdealState(String clusterName, String resourceName, int minActiveReplicas, int numReplicas);
 }

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/StoreBackupVersionCleanupService.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/StoreBackupVersionCleanupService.java
@@ -55,7 +55,6 @@ import org.apache.logging.log4j.Logger;
  * to accommodate the delay between Controller and Router.
  */
 public class StoreBackupVersionCleanupService extends AbstractVeniceService {
-  private static final int MIN_REPLICA = 2;
   public static final String TYPE_CURRENT_VERSION = "current_version";
   private static final Logger LOGGER = LogManager.getLogger(StoreBackupVersionCleanupService.class);
   private static final ObjectMapper OBJECT_MAPPER = ObjectMapperFactory.getInstance();
@@ -271,46 +270,6 @@ public class StoreBackupVersionCleanupService extends AbstractVeniceService {
         time,
         currentVersion,
         this.minBackupVersionCleanupDelay)) {
-      // not ready to clean up backup versions yet, reduce backup version replicas if configured
-      VeniceControllerClusterConfig clusterConfig = multiClusterConfig.getControllerConfig(clusterName);
-      if (clusterConfig.isRfTuningEnabled()) {
-        int backupRf = clusterConfig.getBackupVersionRfCount();
-        int backupMinActive = clusterConfig.getBackupVersionMinActiveReplicaCount();
-        for (Version version: versions) {
-          if (version.getNumber() >= currentVersion) {
-            continue;
-          }
-          if (admin.updateIdealState(
-              clusterName,
-              Version.composeKafkaTopic(store.getName(), version.getNumber()),
-              backupMinActive,
-              backupRf)) {
-            LOGGER.info(
-                "Store {} version {} ideal state updated to {} replicas with minActiveReplicas={}",
-                store.getName(),
-                version.getNumber(),
-                backupRf,
-                backupMinActive);
-          }
-        }
-      } else if (clusterConfig.isBackupVersionReplicaReductionEnabled()) {
-        // Legacy fallback: only sets MinActiveReplicas (does not reduce actual replica count)
-        for (Version version: versions) {
-          if (version.getNumber() >= currentVersion) {
-            continue;
-          }
-          if (admin.updateIdealState(
-              clusterName,
-              Version.composeKafkaTopic(store.getName(), version.getNumber()),
-              MIN_REPLICA)) {
-            LOGGER.info(
-                "Store {} version {} is updated to ideal state to use {} minActiveReplicas",
-                store.getName(),
-                version.getNumber(),
-                MIN_REPLICA);
-          }
-        }
-      }
       return false;
     }
 

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/StoreBackupVersionCleanupService.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/StoreBackupVersionCleanupService.java
@@ -55,6 +55,7 @@ import org.apache.logging.log4j.Logger;
  * to accommodate the delay between Controller and Router.
  */
 public class StoreBackupVersionCleanupService extends AbstractVeniceService {
+  private static final int MIN_REPLICA = 2;
   public static final String TYPE_CURRENT_VERSION = "current_version";
   private static final Logger LOGGER = LogManager.getLogger(StoreBackupVersionCleanupService.class);
   private static final ObjectMapper OBJECT_MAPPER = ObjectMapperFactory.getInstance();
@@ -279,7 +280,6 @@ public class StoreBackupVersionCleanupService extends AbstractVeniceService {
           if (version.getNumber() >= currentVersion) {
             continue;
           }
-
           if (admin.updateIdealState(
               clusterName,
               Version.composeKafkaTopic(store.getName(), version.getNumber()),
@@ -291,6 +291,23 @@ public class StoreBackupVersionCleanupService extends AbstractVeniceService {
                 version.getNumber(),
                 backupRf,
                 backupMinActive);
+          }
+        }
+      } else if (clusterConfig.isBackupVersionReplicaReductionEnabled()) {
+        // Legacy fallback: only sets MinActiveReplicas (does not reduce actual replica count)
+        for (Version version: versions) {
+          if (version.getNumber() >= currentVersion) {
+            continue;
+          }
+          if (admin.updateIdealState(
+              clusterName,
+              Version.composeKafkaTopic(store.getName(), version.getNumber()),
+              MIN_REPLICA)) {
+            LOGGER.info(
+                "Store {} version {} is updated to ideal state to use {} minActiveReplicas",
+                store.getName(),
+                version.getNumber(),
+                MIN_REPLICA);
           }
         }
       }

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/StoreBackupVersionCleanupService.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/StoreBackupVersionCleanupService.java
@@ -55,7 +55,6 @@ import org.apache.logging.log4j.Logger;
  * to accommodate the delay between Controller and Router.
  */
 public class StoreBackupVersionCleanupService extends AbstractVeniceService {
-  private static final int MIN_REPLICA = 2;
   public static final String TYPE_CURRENT_VERSION = "current_version";
   private static final Logger LOGGER = LogManager.getLogger(StoreBackupVersionCleanupService.class);
   private static final ObjectMapper OBJECT_MAPPER = ObjectMapperFactory.getInstance();
@@ -271,9 +270,11 @@ public class StoreBackupVersionCleanupService extends AbstractVeniceService {
         time,
         currentVersion,
         this.minBackupVersionCleanupDelay)) {
-      // not ready to clean up backup versions yet, update the backup version ideal state to use 2 replicas after
-      // minimal delay
-      if (multiClusterConfig.getControllerConfig(clusterName).isBackupVersionReplicaReductionEnabled()) {
+      // not ready to clean up backup versions yet, reduce backup version replicas if configured
+      VeniceControllerClusterConfig clusterConfig = multiClusterConfig.getControllerConfig(clusterName);
+      if (clusterConfig.isRfTuningEnabled()) {
+        int backupRf = clusterConfig.getBackupVersionRfCount();
+        int backupMinActive = clusterConfig.getBackupVersionMinActiveReplicaCount();
         for (Version version: versions) {
           if (version.getNumber() >= currentVersion) {
             continue;
@@ -282,12 +283,14 @@ public class StoreBackupVersionCleanupService extends AbstractVeniceService {
           if (admin.updateIdealState(
               clusterName,
               Version.composeKafkaTopic(store.getName(), version.getNumber()),
-              MIN_REPLICA)) {
+              backupMinActive,
+              backupRf)) {
             LOGGER.info(
-                "Store {} version {} is updated to ideal state to use {} replicas",
+                "Store {} version {} ideal state updated to {} replicas with minActiveReplicas={}",
                 store.getName(),
                 version.getNumber(),
-                MIN_REPLICA);
+                backupRf,
+                backupMinActive);
           }
         }
       }

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceControllerClusterConfig.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceControllerClusterConfig.java
@@ -694,6 +694,15 @@ public class VeniceControllerClusterConfig {
   private final int storeChangeNotifierThreadPoolSize;
 
   private final boolean backupVersionReplicaReductionEnabled;
+
+  private final boolean rfTuningEnabled;
+  private final int currentVersionRfCount;
+  private final int currentVersionMinActiveReplicaCount;
+  private final int backupVersionRfCount;
+  private final int backupVersionMinActiveReplicaCount;
+  private final int futureVersionRfCount;
+  private final int futureVersionMinActiveReplicaCount;
+
   private final boolean useMultiRegionRealTimeTopicSwitcher;
   private final Set<String> activeActiveRealTimeSourceFabrics;
 
@@ -1341,6 +1350,18 @@ public class VeniceControllerClusterConfig {
     }
     this.backupVersionReplicaReductionEnabled =
         props.getBoolean(CONTROLLER_BACKUP_VERSION_REPLICA_REDUCTION_ENABLED, false);
+
+    this.rfTuningEnabled = props.getBoolean(ConfigKeys.CONTROLLER_RF_TUNING_ENABLED, false);
+    this.currentVersionRfCount = props.getInt(ConfigKeys.CONTROLLER_CURRENT_VERSION_RF_COUNT, replicationFactor);
+    this.currentVersionMinActiveReplicaCount =
+        props.getInt(ConfigKeys.CONTROLLER_CURRENT_VERSION_MIN_ACTIVE_REPLICA_COUNT, currentVersionRfCount - 1);
+    this.backupVersionRfCount = props.getInt(ConfigKeys.CONTROLLER_BACKUP_VERSION_RF_COUNT, replicationFactor);
+    this.backupVersionMinActiveReplicaCount =
+        props.getInt(ConfigKeys.CONTROLLER_BACKUP_VERSION_MIN_ACTIVE_REPLICA_COUNT, backupVersionRfCount - 1);
+    this.futureVersionRfCount = props.getInt(ConfigKeys.CONTROLLER_FUTURE_VERSION_RF_COUNT, replicationFactor);
+    this.futureVersionMinActiveReplicaCount =
+        props.getInt(ConfigKeys.CONTROLLER_FUTURE_VERSION_MIN_ACTIVE_REPLICA_COUNT, futureVersionRfCount - 1);
+
     this.useMultiRegionRealTimeTopicSwitcher =
         props.getBoolean(ConfigKeys.CONTROLLER_USE_MULTI_REGION_REAL_TIME_TOPIC_SWITCHER_ENABLED, false);
     this.isAdminOperationSystemStoreEnabled =
@@ -1756,6 +1777,34 @@ public class VeniceControllerClusterConfig {
 
   public boolean isBackupVersionReplicaReductionEnabled() {
     return backupVersionReplicaReductionEnabled;
+  }
+
+  public boolean isRfTuningEnabled() {
+    return rfTuningEnabled;
+  }
+
+  public int getCurrentVersionRfCount() {
+    return currentVersionRfCount;
+  }
+
+  public int getCurrentVersionMinActiveReplicaCount() {
+    return currentVersionMinActiveReplicaCount;
+  }
+
+  public int getBackupVersionRfCount() {
+    return backupVersionRfCount;
+  }
+
+  public int getBackupVersionMinActiveReplicaCount() {
+    return backupVersionMinActiveReplicaCount;
+  }
+
+  public int getFutureVersionRfCount() {
+    return futureVersionRfCount;
+  }
+
+  public int getFutureVersionMinActiveReplicaCount() {
+    return futureVersionMinActiveReplicaCount;
   }
 
   public double getDaVinciPushStatusScanMaxOfflineInstanceRatio() {

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceControllerClusterConfig.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceControllerClusterConfig.java
@@ -1352,15 +1352,33 @@ public class VeniceControllerClusterConfig {
         props.getBoolean(CONTROLLER_BACKUP_VERSION_REPLICA_REDUCTION_ENABLED, false);
 
     this.rfTuningEnabled = props.getBoolean(ConfigKeys.CONTROLLER_RF_TUNING_ENABLED, false);
-    this.currentVersionRfCount = props.getInt(ConfigKeys.CONTROLLER_CURRENT_VERSION_RF_COUNT, replicationFactor);
-    this.currentVersionMinActiveReplicaCount =
-        props.getInt(ConfigKeys.CONTROLLER_CURRENT_VERSION_MIN_ACTIVE_REPLICA_COUNT, currentVersionRfCount - 1);
-    this.backupVersionRfCount = props.getInt(ConfigKeys.CONTROLLER_BACKUP_VERSION_RF_COUNT, replicationFactor);
-    this.backupVersionMinActiveReplicaCount =
-        props.getInt(ConfigKeys.CONTROLLER_BACKUP_VERSION_MIN_ACTIVE_REPLICA_COUNT, backupVersionRfCount - 1);
-    this.futureVersionRfCount = props.getInt(ConfigKeys.CONTROLLER_FUTURE_VERSION_RF_COUNT, replicationFactor);
-    this.futureVersionMinActiveReplicaCount =
-        props.getInt(ConfigKeys.CONTROLLER_FUTURE_VERSION_MIN_ACTIVE_REPLICA_COUNT, futureVersionRfCount - 1);
+    this.currentVersionRfCount =
+        Math.max(1, props.getInt(ConfigKeys.CONTROLLER_CURRENT_VERSION_RF_COUNT, replicationFactor));
+    this.currentVersionMinActiveReplicaCount = Math.min(
+        currentVersionRfCount,
+        Math.max(
+            1,
+            props.getInt(
+                ConfigKeys.CONTROLLER_CURRENT_VERSION_MIN_ACTIVE_REPLICA_COUNT,
+                Math.max(currentVersionRfCount - 1, 1))));
+    this.backupVersionRfCount =
+        Math.max(1, props.getInt(ConfigKeys.CONTROLLER_BACKUP_VERSION_RF_COUNT, replicationFactor));
+    this.backupVersionMinActiveReplicaCount = Math.min(
+        backupVersionRfCount,
+        Math.max(
+            1,
+            props.getInt(
+                ConfigKeys.CONTROLLER_BACKUP_VERSION_MIN_ACTIVE_REPLICA_COUNT,
+                Math.max(backupVersionRfCount - 1, 1))));
+    this.futureVersionRfCount =
+        Math.max(1, props.getInt(ConfigKeys.CONTROLLER_FUTURE_VERSION_RF_COUNT, replicationFactor));
+    this.futureVersionMinActiveReplicaCount = Math.min(
+        futureVersionRfCount,
+        Math.max(
+            1,
+            props.getInt(
+                ConfigKeys.CONTROLLER_FUTURE_VERSION_MIN_ACTIVE_REPLICA_COUNT,
+                Math.max(futureVersionRfCount - 1, 1))));
 
     this.useMultiRegionRealTimeTopicSwitcher =
         props.getBoolean(ConfigKeys.CONTROLLER_USE_MULTI_REGION_REAL_TIME_TOPIC_SWITCHER_ENABLED, false);

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceHelixAdmin.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceHelixAdmin.java
@@ -7834,8 +7834,11 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
       String storeName,
       int newCurrentVersion,
       int previousVersion) {
+    if (multiClusterConfigs == null) {
+      return;
+    }
     VeniceControllerClusterConfig clusterConfig = multiClusterConfigs.getControllerConfig(clusterName);
-    if (!clusterConfig.isRfTuningEnabled() || newCurrentVersion == NON_EXISTING_VERSION) {
+    if (clusterConfig == null || !clusterConfig.isRfTuningEnabled() || newCurrentVersion == NON_EXISTING_VERSION) {
       return;
     }
 

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceHelixAdmin.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceHelixAdmin.java
@@ -5229,7 +5229,7 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
       realTimeTopicSwitcher.transmitVersionSwapMessage(store, previousVersion, backupVersion);
       store.updateVersionStatus(previousVersion, ERROR);
 
-      applyRfTuningOnVersionSwap(store, clusterName, storeName, backupVersion, NON_EXISTING_VERSION);
+      applyRfTuningOnVersionSwap(store, clusterName, storeName, backupVersion, previousVersion);
 
       return store;
     });
@@ -7793,35 +7793,8 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
     return true;
   }
 
-  /**
-   * Update the IdealState for a resource with the specified MinActiveReplicas and numReplicas.
-   * Both fields are updated in-memory and persisted together with a single
-   * {@code updateIdealState} call when an update is needed.
-   */
   public boolean updateIdealState(String clusterName, String resourceName, int minActiveReplicas, int numReplicas) {
-    if (numReplicas < 1 || minActiveReplicas < 1 || minActiveReplicas > numReplicas) {
-      throw new VeniceException(
-          "Invalid RF tuning params for resource " + resourceName + ": numReplicas=" + numReplicas
-              + ", minActiveReplicas=" + minActiveReplicas
-              + ". Require: numReplicas >= 1, 1 <= minActiveReplicas <= numReplicas");
-    }
-    IdealState idealState = helixAdminClient.getResourceIdealState(clusterName, resourceName);
-    if (idealState == null) {
-      return false;
-    }
-    boolean changed = false;
-    if (idealState.getMinActiveReplicas() != minActiveReplicas) {
-      idealState.setMinActiveReplicas(minActiveReplicas);
-      changed = true;
-    }
-    if (!idealState.getReplicas().equals(String.valueOf(numReplicas))) {
-      idealState.setReplicas(String.valueOf(numReplicas));
-      changed = true;
-    }
-    if (changed) {
-      helixAdminClient.updateIdealState(clusterName, resourceName, idealState);
-    }
-    return changed;
+    return helixAdminClient.updateIdealState(clusterName, resourceName, minActiveReplicas, numReplicas);
   }
 
   /**

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceHelixAdmin.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceHelixAdmin.java
@@ -5050,6 +5050,7 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
       return;
     }
 
+    int[] prevVersionHolder = new int[] { NON_EXISTING_VERSION };
     storeMetadataUpdate(clusterName, storeName, (store, resources) -> {
       if (store.getCurrentVersion() != NON_EXISTING_VERSION) {
         if (versionNumber != NON_EXISTING_VERSION && !store.containsVersion(versionNumber)) {
@@ -5062,6 +5063,7 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
         }
       }
       int previousVersion = store.getCurrentVersion();
+      prevVersionHolder[0] = previousVersion;
       store.setCurrentVersion(versionNumber);
       // Current usage of this code path is only when we are rolling backward to a backup version. Even in the case
       // when we roll back from v2 -> v1, and roll forward to v2 from v1. The roll forward from v1 to v2 via this method
@@ -5078,13 +5080,15 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
           resources::isSourceCluster);
       if (!isParent()) {
         // Parent controller should not transmit the version swap message
-        realTimeTopicSwitcher.transmitVersionSwapMessage(store, previousVersion, versionNumber);
+        getRealTimeTopicSwitcher().transmitVersionSwapMessage(store, previousVersion, versionNumber);
       }
 
-      applyRfTuningOnVersionSwap(store, clusterName, storeName, versionNumber, previousVersion);
+      applyRfTuningMetadataUpdate(store, clusterName, versionNumber, previousVersion);
 
       return store;
     });
+
+    applyRfTuningIdealStateUpdate(clusterName, storeName, versionNumber, prevVersionHolder[0]);
   }
 
   @Override
@@ -5111,6 +5115,7 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
     }
 
     int futureVersion = onlineFutureVersion == Store.NON_EXISTING_VERSION ? pushedFutureVersion : onlineFutureVersion;
+    int[] prevVersionHolder = new int[] { NON_EXISTING_VERSION };
     storeMetadataUpdate(clusterName, storeName, (store, resources) -> {
       if (!store.isEnableWrites()) {
         throw new VeniceException(
@@ -5120,6 +5125,7 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
       // deferred version swap. it is safe to skip this for automatic deferred version swap as ST is stalled until
       // the future version replica is ready
       int previousVersion = store.getCurrentVersion();
+      prevVersionHolder[0] = previousVersion;
       Version futureVersionObj = store.getVersion(futureVersion);
       if (futureVersionObj.isVersionSwapDeferred() && StringUtils.isEmpty(futureVersionObj.getTargetSwapRegion())) {
         int partitionCount = futureVersionObj.getPartitionCount();
@@ -5175,10 +5181,12 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
           storeName);
       getRealTimeTopicSwitcher().transmitVersionSwapMessage(store, previousVersion, futureVersion);
 
-      applyRfTuningOnVersionSwap(store, clusterName, storeName, futureVersion, previousVersion);
+      applyRfTuningMetadataUpdate(store, clusterName, futureVersion, previousVersion);
 
       return store;
     });
+
+    applyRfTuningIdealStateUpdate(clusterName, storeName, futureVersion, prevVersionHolder[0]);
   }
 
   /**
@@ -5200,6 +5208,7 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
       }
     }
 
+    int[] versionHolder = new int[] { NON_EXISTING_VERSION, NON_EXISTING_VERSION };
     storeMetadataUpdate(clusterName, storeName, (store, resources) -> {
       if (!store.isEnableWrites()) {
         throw new VeniceException(
@@ -5210,6 +5219,8 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
         return store;
       }
       int previousVersion = store.getCurrentVersion();
+      versionHolder[0] = backupVersion;
+      versionHolder[1] = previousVersion;
       store.setCurrentVersion(backupVersion);
       LOGGER.info(
           "Rolling back current version {} to version {} in store {}. Updating previous version {} status to ERROR",
@@ -5226,13 +5237,15 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
           false,
           store.isMigrating(),
           resources::isSourceCluster);
-      realTimeTopicSwitcher.transmitVersionSwapMessage(store, previousVersion, backupVersion);
+      getRealTimeTopicSwitcher().transmitVersionSwapMessage(store, previousVersion, backupVersion);
       store.updateVersionStatus(previousVersion, ERROR);
 
-      applyRfTuningOnVersionSwap(store, clusterName, storeName, backupVersion, previousVersion);
+      applyRfTuningMetadataUpdate(store, clusterName, backupVersion, previousVersion);
 
       return store;
     });
+
+    applyRfTuningIdealStateUpdate(clusterName, storeName, versionHolder[0], versionHolder[1]);
   }
 
   /**
@@ -7794,34 +7807,58 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
   }
 
   public boolean updateIdealState(String clusterName, String resourceName, int minActiveReplicas, int numReplicas) {
-    return helixAdminClient.updateIdealState(clusterName, resourceName, minActiveReplicas, numReplicas);
+    return getHelixAdminClient().updateIdealState(clusterName, resourceName, minActiveReplicas, numReplicas);
   }
 
   /**
-   * Apply RF tuning configs during a version swap: update version metadata RF and Helix IdealState
-   * for the new current version and (if present) the demoted backup version.
+   * Update version metadata RF during version swap. Called inside the store write lock.
+   * Only applies on child controllers — parent controllers do not manage Helix IdealState.
    */
-  private void applyRfTuningOnVersionSwap(
+  private void applyRfTuningMetadataUpdate(
       Store store,
       String clusterName,
-      String storeName,
       int newCurrentVersion,
       int previousVersion) {
-    if (multiClusterConfigs == null) {
+    if (isParent()) {
       return;
     }
-    VeniceControllerClusterConfig clusterConfig = multiClusterConfigs.getControllerConfig(clusterName);
+    VeniceControllerMultiClusterConfig configs = getMultiClusterConfigs();
+    if (configs == null) {
+      return;
+    }
+    VeniceControllerClusterConfig clusterConfig = configs.getControllerConfig(clusterName);
     if (clusterConfig == null || !clusterConfig.isRfTuningEnabled() || newCurrentVersion == NON_EXISTING_VERSION) {
       return;
     }
 
-    // Update version metadata RF to match Helix IdealState
     store.getVersion(newCurrentVersion).setReplicationFactor(clusterConfig.getCurrentVersionRfCount());
     if (previousVersion != NON_EXISTING_VERSION && store.containsVersion(previousVersion)) {
       store.getVersion(previousVersion).setReplicationFactor(clusterConfig.getBackupVersionRfCount());
     }
+  }
 
-    // Update Helix IdealState
+  /**
+   * Update Helix IdealState RF and MinActiveReplicas during version swap.
+   * Called outside the store write lock to avoid prolonged lock hold time on ZK writes.
+   * Only applies on child controllers.
+   */
+  private void applyRfTuningIdealStateUpdate(
+      String clusterName,
+      String storeName,
+      int newCurrentVersion,
+      int previousVersion) {
+    if (isParent()) {
+      return;
+    }
+    VeniceControllerMultiClusterConfig configs = getMultiClusterConfigs();
+    if (configs == null) {
+      return;
+    }
+    VeniceControllerClusterConfig clusterConfig = configs.getControllerConfig(clusterName);
+    if (clusterConfig == null || !clusterConfig.isRfTuningEnabled() || newCurrentVersion == NON_EXISTING_VERSION) {
+      return;
+    }
+
     String currentVersionTopic = Version.composeKafkaTopic(storeName, newCurrentVersion);
     updateIdealState(
         clusterName,

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceHelixAdmin.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceHelixAdmin.java
@@ -2906,13 +2906,13 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
           clusterName,
           version.kafkaTopicName(),
           version.getPartitionCount(),
-          store.getReplicationFactor(),
+          version.getReplicationFactor(),
           store.getOffLinePushStrategy());
       helixAdminClient.createVeniceStorageClusterResources(
           clusterName,
           version.kafkaTopicName(),
           version.getPartitionCount(),
-          store.getReplicationFactor());
+          version.getReplicationFactor());
       try {
         retireOldStoreVersions(clusterName, storeName, true, store.getCurrentVersion());
       } catch (Throwable t) {
@@ -3263,6 +3263,11 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
             }
             // Update ZK with the new version
             store.addVersion(version, true, currentRTVersionNumber);
+            // Override version RF with tuning config if enabled
+            VeniceControllerClusterConfig migrationClusterConfig = multiClusterConfigs.getControllerConfig(clusterName);
+            if (migrationClusterConfig.isRfTuningEnabled()) {
+              version.setReplicationFactor(migrationClusterConfig.getFutureVersionRfCount());
+            }
             repository.updateStore(store);
 
             addVersionLatencyStats.recordExistingSourceVersionHandlingLatency(
@@ -3297,6 +3302,12 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
             if (!store.containsVersion(version.getNumber())) {
               version.setPushType(pushType);
               store.addVersion(version, false, currentRTVersionNumber);
+            }
+
+            // Override version RF with tuning config if enabled
+            VeniceControllerClusterConfig rfTuningConfig = multiClusterConfigs.getControllerConfig(clusterName);
+            if (rfTuningConfig.isRfTuningEnabled()) {
+              version.setReplicationFactor(rfTuningConfig.getFutureVersionRfCount());
             }
 
             version.setNativeReplicationEnabled(store.isNativeReplicationEnabled());
@@ -5069,6 +5080,34 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
         // Parent controller should not transmit the version swap message
         realTimeTopicSwitcher.transmitVersionSwapMessage(store, previousVersion, versionNumber);
       }
+
+      // Apply RF tuning configs for the new current version and the demoted backup version
+      VeniceControllerClusterConfig clusterConfig = multiClusterConfigs.getControllerConfig(clusterName);
+      if (clusterConfig.isRfTuningEnabled() && versionNumber != NON_EXISTING_VERSION) {
+        // Update version metadata RF to match Helix IdealState
+        store.getVersion(versionNumber).setReplicationFactor(clusterConfig.getCurrentVersionRfCount());
+        if (previousVersion != NON_EXISTING_VERSION && store.containsVersion(previousVersion)) {
+          store.getVersion(previousVersion).setReplicationFactor(clusterConfig.getBackupVersionRfCount());
+        }
+
+        // Update Helix IdealState
+        String currentVersionTopic = Version.composeKafkaTopic(storeName, versionNumber);
+        updateIdealState(
+            clusterName,
+            currentVersionTopic,
+            clusterConfig.getCurrentVersionMinActiveReplicaCount(),
+            clusterConfig.getCurrentVersionRfCount());
+
+        if (previousVersion != NON_EXISTING_VERSION) {
+          String backupVersionTopic = Version.composeKafkaTopic(storeName, previousVersion);
+          updateIdealState(
+              clusterName,
+              backupVersionTopic,
+              clusterConfig.getBackupVersionMinActiveReplicaCount(),
+              clusterConfig.getBackupVersionRfCount());
+        }
+      }
+
       return store;
     });
   }
@@ -5160,6 +5199,34 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
           futureVersion,
           storeName);
       getRealTimeTopicSwitcher().transmitVersionSwapMessage(store, previousVersion, futureVersion);
+
+      // Apply RF tuning configs for the new current version and the demoted backup version
+      VeniceControllerClusterConfig clusterConfig = multiClusterConfigs.getControllerConfig(clusterName);
+      if (clusterConfig.isRfTuningEnabled()) {
+        // Update version metadata RF to match Helix IdealState
+        store.getVersion(futureVersion).setReplicationFactor(clusterConfig.getCurrentVersionRfCount());
+        if (previousVersion != Store.NON_EXISTING_VERSION && store.containsVersion(previousVersion)) {
+          store.getVersion(previousVersion).setReplicationFactor(clusterConfig.getBackupVersionRfCount());
+        }
+
+        // Update Helix IdealState
+        String currentVersionTopic = Version.composeKafkaTopic(storeName, futureVersion);
+        updateIdealState(
+            clusterName,
+            currentVersionTopic,
+            clusterConfig.getCurrentVersionMinActiveReplicaCount(),
+            clusterConfig.getCurrentVersionRfCount());
+
+        if (previousVersion != Store.NON_EXISTING_VERSION) {
+          String backupVersionTopic = Version.composeKafkaTopic(storeName, previousVersion);
+          updateIdealState(
+              clusterName,
+              backupVersionTopic,
+              clusterConfig.getBackupVersionMinActiveReplicaCount(),
+              clusterConfig.getBackupVersionRfCount());
+        }
+      }
+
       return store;
     });
   }
@@ -5211,6 +5278,21 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
           resources::isSourceCluster);
       realTimeTopicSwitcher.transmitVersionSwapMessage(store, previousVersion, backupVersion);
       store.updateVersionStatus(previousVersion, ERROR);
+
+      // Apply RF tuning configs for the new current version (restored from backup)
+      VeniceControllerClusterConfig clusterConfig = multiClusterConfigs.getControllerConfig(clusterName);
+      if (clusterConfig.isRfTuningEnabled()) {
+        // Update version metadata RF to match Helix IdealState
+        store.getVersion(backupVersion).setReplicationFactor(clusterConfig.getCurrentVersionRfCount());
+
+        // Update Helix IdealState
+        String currentVersionTopic = Version.composeKafkaTopic(storeName, backupVersion);
+        updateIdealState(
+            clusterName,
+            currentVersionTopic,
+            clusterConfig.getCurrentVersionMinActiveReplicaCount(),
+            clusterConfig.getCurrentVersionRfCount());
+      }
 
       return store;
     });
@@ -7772,6 +7854,31 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
     idealState.setMinActiveReplicas(minReplica);
     helixAdminClient.updateIdealState(clusterName, resourceName, idealState);
     return true;
+  }
+
+  /**
+   * Update the IdealState for a resource with the specified MinActiveReplicas and numReplicas.
+   * MinActiveReplicas is updated first to prevent Helix from triggering immediate rebalance
+   * when numReplicas is being reduced.
+   */
+  public boolean updateIdealState(String clusterName, String resourceName, int minActiveReplicas, int numReplicas) {
+    IdealState idealState = helixAdminClient.getResourceIdealState(clusterName, resourceName);
+    if (idealState == null) {
+      return false;
+    }
+    boolean changed = false;
+    if (idealState.getMinActiveReplicas() != minActiveReplicas) {
+      idealState.setMinActiveReplicas(minActiveReplicas);
+      changed = true;
+    }
+    if (!idealState.getReplicas().equals(String.valueOf(numReplicas))) {
+      idealState.setReplicas(String.valueOf(numReplicas));
+      changed = true;
+    }
+    if (changed) {
+      helixAdminClient.updateIdealState(clusterName, resourceName, idealState);
+    }
+    return changed;
   }
 
   public IdealState getIdealState(String clusterName, String resourceName) {

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceHelixAdmin.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceHelixAdmin.java
@@ -3264,9 +3264,9 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
             // Update ZK with the new version
             store.addVersion(version, true, currentRTVersionNumber);
             // Override version RF with tuning config if enabled
-            VeniceControllerClusterConfig migrationClusterConfig = multiClusterConfigs.getControllerConfig(clusterName);
-            if (migrationClusterConfig.isRfTuningEnabled()) {
-              version.setReplicationFactor(migrationClusterConfig.getFutureVersionRfCount());
+            VeniceControllerClusterConfig destClusterConfig = multiClusterConfigs.getControllerConfig(clusterName);
+            if (destClusterConfig.isRfTuningEnabled()) {
+              version.setReplicationFactor(destClusterConfig.getFutureVersionRfCount());
             }
             repository.updateStore(store);
 
@@ -5081,32 +5081,7 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
         realTimeTopicSwitcher.transmitVersionSwapMessage(store, previousVersion, versionNumber);
       }
 
-      // Apply RF tuning configs for the new current version and the demoted backup version
-      VeniceControllerClusterConfig clusterConfig = multiClusterConfigs.getControllerConfig(clusterName);
-      if (clusterConfig.isRfTuningEnabled() && versionNumber != NON_EXISTING_VERSION) {
-        // Update version metadata RF to match Helix IdealState
-        store.getVersion(versionNumber).setReplicationFactor(clusterConfig.getCurrentVersionRfCount());
-        if (previousVersion != NON_EXISTING_VERSION && store.containsVersion(previousVersion)) {
-          store.getVersion(previousVersion).setReplicationFactor(clusterConfig.getBackupVersionRfCount());
-        }
-
-        // Update Helix IdealState
-        String currentVersionTopic = Version.composeKafkaTopic(storeName, versionNumber);
-        updateIdealState(
-            clusterName,
-            currentVersionTopic,
-            clusterConfig.getCurrentVersionMinActiveReplicaCount(),
-            clusterConfig.getCurrentVersionRfCount());
-
-        if (previousVersion != NON_EXISTING_VERSION) {
-          String backupVersionTopic = Version.composeKafkaTopic(storeName, previousVersion);
-          updateIdealState(
-              clusterName,
-              backupVersionTopic,
-              clusterConfig.getBackupVersionMinActiveReplicaCount(),
-              clusterConfig.getBackupVersionRfCount());
-        }
-      }
+      applyRfTuningOnVersionSwap(store, clusterName, storeName, versionNumber, previousVersion);
 
       return store;
     });
@@ -5200,32 +5175,7 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
           storeName);
       getRealTimeTopicSwitcher().transmitVersionSwapMessage(store, previousVersion, futureVersion);
 
-      // Apply RF tuning configs for the new current version and the demoted backup version
-      VeniceControllerClusterConfig clusterConfig = multiClusterConfigs.getControllerConfig(clusterName);
-      if (clusterConfig.isRfTuningEnabled()) {
-        // Update version metadata RF to match Helix IdealState
-        store.getVersion(futureVersion).setReplicationFactor(clusterConfig.getCurrentVersionRfCount());
-        if (previousVersion != Store.NON_EXISTING_VERSION && store.containsVersion(previousVersion)) {
-          store.getVersion(previousVersion).setReplicationFactor(clusterConfig.getBackupVersionRfCount());
-        }
-
-        // Update Helix IdealState
-        String currentVersionTopic = Version.composeKafkaTopic(storeName, futureVersion);
-        updateIdealState(
-            clusterName,
-            currentVersionTopic,
-            clusterConfig.getCurrentVersionMinActiveReplicaCount(),
-            clusterConfig.getCurrentVersionRfCount());
-
-        if (previousVersion != Store.NON_EXISTING_VERSION) {
-          String backupVersionTopic = Version.composeKafkaTopic(storeName, previousVersion);
-          updateIdealState(
-              clusterName,
-              backupVersionTopic,
-              clusterConfig.getBackupVersionMinActiveReplicaCount(),
-              clusterConfig.getBackupVersionRfCount());
-        }
-      }
+      applyRfTuningOnVersionSwap(store, clusterName, storeName, futureVersion, previousVersion);
 
       return store;
     });
@@ -5279,20 +5229,7 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
       realTimeTopicSwitcher.transmitVersionSwapMessage(store, previousVersion, backupVersion);
       store.updateVersionStatus(previousVersion, ERROR);
 
-      // Apply RF tuning configs for the new current version (restored from backup)
-      VeniceControllerClusterConfig clusterConfig = multiClusterConfigs.getControllerConfig(clusterName);
-      if (clusterConfig.isRfTuningEnabled()) {
-        // Update version metadata RF to match Helix IdealState
-        store.getVersion(backupVersion).setReplicationFactor(clusterConfig.getCurrentVersionRfCount());
-
-        // Update Helix IdealState
-        String currentVersionTopic = Version.composeKafkaTopic(storeName, backupVersion);
-        updateIdealState(
-            clusterName,
-            currentVersionTopic,
-            clusterConfig.getCurrentVersionMinActiveReplicaCount(),
-            clusterConfig.getCurrentVersionRfCount());
-      }
+      applyRfTuningOnVersionSwap(store, clusterName, storeName, backupVersion, NON_EXISTING_VERSION);
 
       return store;
     });
@@ -7858,10 +7795,16 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
 
   /**
    * Update the IdealState for a resource with the specified MinActiveReplicas and numReplicas.
-   * MinActiveReplicas is updated first to prevent Helix from triggering immediate rebalance
-   * when numReplicas is being reduced.
+   * Both fields are updated in-memory and persisted together with a single
+   * {@code updateIdealState} call when an update is needed.
    */
   public boolean updateIdealState(String clusterName, String resourceName, int minActiveReplicas, int numReplicas) {
+    if (numReplicas < 1 || minActiveReplicas < 1 || minActiveReplicas > numReplicas) {
+      throw new VeniceException(
+          "Invalid RF tuning params for resource " + resourceName + ": numReplicas=" + numReplicas
+              + ", minActiveReplicas=" + minActiveReplicas
+              + ". Require: numReplicas >= 1, 1 <= minActiveReplicas <= numReplicas");
+    }
     IdealState idealState = helixAdminClient.getResourceIdealState(clusterName, resourceName);
     if (idealState == null) {
       return false;
@@ -7879,6 +7822,45 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
       helixAdminClient.updateIdealState(clusterName, resourceName, idealState);
     }
     return changed;
+  }
+
+  /**
+   * Apply RF tuning configs during a version swap: update version metadata RF and Helix IdealState
+   * for the new current version and (if present) the demoted backup version.
+   */
+  private void applyRfTuningOnVersionSwap(
+      Store store,
+      String clusterName,
+      String storeName,
+      int newCurrentVersion,
+      int previousVersion) {
+    VeniceControllerClusterConfig clusterConfig = multiClusterConfigs.getControllerConfig(clusterName);
+    if (!clusterConfig.isRfTuningEnabled() || newCurrentVersion == NON_EXISTING_VERSION) {
+      return;
+    }
+
+    // Update version metadata RF to match Helix IdealState
+    store.getVersion(newCurrentVersion).setReplicationFactor(clusterConfig.getCurrentVersionRfCount());
+    if (previousVersion != NON_EXISTING_VERSION && store.containsVersion(previousVersion)) {
+      store.getVersion(previousVersion).setReplicationFactor(clusterConfig.getBackupVersionRfCount());
+    }
+
+    // Update Helix IdealState
+    String currentVersionTopic = Version.composeKafkaTopic(storeName, newCurrentVersion);
+    updateIdealState(
+        clusterName,
+        currentVersionTopic,
+        clusterConfig.getCurrentVersionMinActiveReplicaCount(),
+        clusterConfig.getCurrentVersionRfCount());
+
+    if (previousVersion != NON_EXISTING_VERSION) {
+      String backupVersionTopic = Version.composeKafkaTopic(storeName, previousVersion);
+      updateIdealState(
+          clusterName,
+          backupVersionTopic,
+          clusterConfig.getBackupVersionMinActiveReplicaCount(),
+          clusterConfig.getBackupVersionRfCount());
+    }
   }
 
   public IdealState getIdealState(String clusterName, String resourceName) {

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/ZkHelixAdminClient.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/ZkHelixAdminClient.java
@@ -406,4 +406,31 @@ public class ZkHelixAdminClient implements HelixAdminClient {
   public void updateIdealState(String clusterName, String resourceName, IdealState idealState) {
     helixAdmin.updateIdealState(clusterName, resourceName, idealState);
   }
+
+  @Override
+  public boolean updateIdealState(String clusterName, String resourceName, int minActiveReplicas, int numReplicas) {
+    if (numReplicas < 1 || minActiveReplicas < 1 || minActiveReplicas > numReplicas) {
+      throw new VeniceException(
+          "Invalid RF tuning params for resource " + resourceName + ": numReplicas=" + numReplicas
+              + ", minActiveReplicas=" + minActiveReplicas
+              + ". Require: numReplicas >= 1, 1 <= minActiveReplicas <= numReplicas");
+    }
+    IdealState idealState = getResourceIdealState(clusterName, resourceName);
+    if (idealState == null) {
+      return false;
+    }
+    boolean changed = false;
+    if (idealState.getMinActiveReplicas() != minActiveReplicas) {
+      idealState.setMinActiveReplicas(minActiveReplicas);
+      changed = true;
+    }
+    if (!idealState.getReplicas().equals(String.valueOf(numReplicas))) {
+      idealState.setReplicas(String.valueOf(numReplicas));
+      changed = true;
+    }
+    if (changed) {
+      updateIdealState(clusterName, resourceName, idealState);
+    }
+    return changed;
+  }
 }

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/ZkHelixAdminClient.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/ZkHelixAdminClient.java
@@ -303,11 +303,20 @@ public class ZkHelixAdminClient implements HelixAdminClient {
       // We don't set the delayed time per resource, we will use the cluster level helix config to decide
       // the delayed rebalance time
       idealState.setRebalancerClassName(DelayedAutoRebalancer.class.getName());
-      idealState.setMinActiveReplicas(Math.max(replicationFactor - 1, 1));
+      int effectiveRf;
+      int effectiveMinActive;
+      if (config.isRfTuningEnabled()) {
+        effectiveRf = config.getFutureVersionRfCount();
+        effectiveMinActive = config.getFutureVersionMinActiveReplicaCount();
+      } else {
+        effectiveRf = replicationFactor;
+        effectiveMinActive = Math.max(replicationFactor - 1, 1);
+      }
+      idealState.setMinActiveReplicas(effectiveMinActive);
       idealState.setRebalanceStrategy(config.getHelixRebalanceAlg());
       helixAdmin.setResourceIdealState(clusterName, kafkaTopic, idealState);
       LOGGER.info("Enabled delayed re-balance for resource: {}", kafkaTopic);
-      helixAdmin.rebalance(clusterName, kafkaTopic, replicationFactor);
+      helixAdmin.rebalance(clusterName, kafkaTopic, effectiveRf);
       LOGGER.info("Added {} as a resource to cluster: {}", kafkaTopic, clusterName);
     } else {
       String errorMessage = "Resource:" + kafkaTopic + " already exists, Can not add it to Helix.";

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/ZkHelixAdminClient.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/ZkHelixAdminClient.java
@@ -312,6 +312,11 @@ public class ZkHelixAdminClient implements HelixAdminClient {
         effectiveRf = replicationFactor;
         effectiveMinActive = Math.max(replicationFactor - 1, 1);
       }
+      if (effectiveRf < 1 || effectiveMinActive < 1 || effectiveMinActive > effectiveRf) {
+        throw new VeniceException(
+            "Invalid RF tuning params for resource " + kafkaTopic + ": rf=" + effectiveRf + ", minActive="
+                + effectiveMinActive + ". Require: rf >= 1, 1 <= minActive <= rf");
+      }
       idealState.setMinActiveReplicas(effectiveMinActive);
       idealState.setRebalanceStrategy(config.getHelixRebalanceAlg());
       helixAdmin.setResourceIdealState(clusterName, kafkaTopic, idealState);

--- a/services/venice-controller/src/main/java/com/linkedin/venice/pushmonitor/AbstractPushMonitor.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/pushmonitor/AbstractPushMonitor.java
@@ -1169,6 +1169,8 @@ public abstract class AbstractPushMonitor
 
   private void updateStoreVersionStatus(String storeName, int versionNumber, VersionStatus status) {
     VersionStatus newStatus = status;
+    int[] rfTuningPrevVersionHolder = new int[] { Store.NON_EXISTING_VERSION };
+    boolean rfTuningSwapOccurred = false;
     try (AutoCloseableLock ignore = clusterLockManager.createStoreWriteLock(storeName)) {
       Store store = metadataRepository.getStore(storeName);
       if (store == null) {
@@ -1254,7 +1256,9 @@ public abstract class AbstractPushMonitor
             store.setCurrentVersion(versionNumber);
             currentVersionChangeNotifier.onCurrentVersionChange(store, clusterName, versionNumber, previousVersion);
             realTimeTopicSwitcher.transmitVersionSwapMessage(store, previousVersion, versionNumber);
-            applyRfTuningOnVersionSwap(store, storeName, versionNumber, previousVersion);
+            applyRfTuningMetadataUpdate(store, versionNumber, previousVersion);
+            rfTuningPrevVersionHolder[0] = previousVersion;
+            rfTuningSwapOccurred = true;
           } else if (isTargetRegionPushWithDeferredSwap || isNormalPush) {
             LOGGER.info(
                 "Swapping to version {} for store {} in region {} during "
@@ -1268,7 +1272,9 @@ public abstract class AbstractPushMonitor
             store.setCurrentVersion(versionNumber);
             currentVersionChangeNotifier.onCurrentVersionChange(store, clusterName, versionNumber, previousVersion);
             realTimeTopicSwitcher.transmitVersionSwapMessage(store, previousVersion, versionNumber);
-            applyRfTuningOnVersionSwap(store, storeName, versionNumber, previousVersion);
+            applyRfTuningMetadataUpdate(store, versionNumber, previousVersion);
+            rfTuningPrevVersionHolder[0] = previousVersion;
+            rfTuningSwapOccurred = true;
           } else {
             LOGGER.info(
                 "Version swap is deferred for store {} on version {} in region {} because "
@@ -1304,6 +1310,11 @@ public abstract class AbstractPushMonitor
       metadataRepository.updateStore(store);
       LOGGER.info("Updated store: {} version: {} to status: {}", store.getName(), versionNumber, newStatus.toString());
     }
+
+    // Update Helix IdealState outside the store write lock to avoid prolonged lock hold time on ZK writes
+    if (rfTuningSwapOccurred) {
+      applyRfTuningIdealStateUpdate(storeName, versionNumber, rfTuningPrevVersionHolder[0]);
+    }
   }
 
   private Integer getStoreCurrentVersion(String storeName) {
@@ -1337,21 +1348,26 @@ public abstract class AbstractPushMonitor
   }
 
   /**
-   * Apply RF tuning on version swap: update version metadata RF and Helix IdealState
-   * for the new current version and the demoted backup version.
+   * Update version metadata RF during version swap. Called inside the store write lock.
    */
-  private void applyRfTuningOnVersionSwap(Store store, String storeName, int newCurrentVersion, int previousVersion) {
+  private void applyRfTuningMetadataUpdate(Store store, int newCurrentVersion, int previousVersion) {
     if (!rfTuningEnabled) {
       return;
     }
-
-    // Update version metadata RF
     store.getVersion(newCurrentVersion).setReplicationFactor(currentVersionRfCount);
     if (previousVersion != Store.NON_EXISTING_VERSION && store.containsVersion(previousVersion)) {
       store.getVersion(previousVersion).setReplicationFactor(backupVersionRfCount);
     }
+  }
 
-    // Update Helix IdealState
+  /**
+   * Update Helix IdealState RF and MinActiveReplicas during version swap.
+   * Called outside the store write lock to avoid prolonged lock hold time on ZK writes.
+   */
+  private void applyRfTuningIdealStateUpdate(String storeName, int newCurrentVersion, int previousVersion) {
+    if (!rfTuningEnabled) {
+      return;
+    }
     String currentVersionTopic = Version.composeKafkaTopic(storeName, newCurrentVersion);
     helixAdminClient
         .updateIdealState(clusterName, currentVersionTopic, currentVersionMinActiveReplicaCount, currentVersionRfCount);

--- a/services/venice-controller/src/main/java/com/linkedin/venice/pushmonitor/AbstractPushMonitor.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/pushmonitor/AbstractPushMonitor.java
@@ -107,6 +107,12 @@ public abstract class AbstractPushMonitor
   private String sequentialRollForwardFirstRegion = null;
   private final CurrentVersionChangeNotifier currentVersionChangeNotifier;
 
+  private final boolean rfTuningEnabled;
+  private final int currentVersionRfCount;
+  private final int currentVersionMinActiveReplicaCount;
+  private final int backupVersionRfCount;
+  private final int backupVersionMinActiveReplicaCount;
+
   public interface CurrentVersionChangeNotifier {
     void onCurrentVersionChange(Store store, String clusterName, int currentVersion, int previousVersion);
   }
@@ -160,6 +166,11 @@ public abstract class AbstractPushMonitor
         controllerConfig.getLogContext());
     this.isOfflinePushMonitorDaVinciPushStatusEnabled = controllerConfig.isDaVinciPushStatusEnabled();
     this.regionName = controllerConfig.getRegionName();
+    this.rfTuningEnabled = controllerConfig.isRfTuningEnabled();
+    this.currentVersionRfCount = controllerConfig.getCurrentVersionRfCount();
+    this.currentVersionMinActiveReplicaCount = controllerConfig.getCurrentVersionMinActiveReplicaCount();
+    this.backupVersionRfCount = controllerConfig.getBackupVersionRfCount();
+    this.backupVersionMinActiveReplicaCount = controllerConfig.getBackupVersionMinActiveReplicaCount();
     this.veniceWriterFactory = veniceWriterFactory;
     if (StringUtils.isNotEmpty(controllerConfig.getDeferredVersionSwapRegionRollforwardOrder())) {
       List<String> rolloutOrderList =
@@ -1243,6 +1254,7 @@ public abstract class AbstractPushMonitor
             store.setCurrentVersion(versionNumber);
             currentVersionChangeNotifier.onCurrentVersionChange(store, clusterName, versionNumber, previousVersion);
             realTimeTopicSwitcher.transmitVersionSwapMessage(store, previousVersion, versionNumber);
+            applyRfTuningOnVersionSwap(store, storeName, versionNumber, previousVersion);
           } else if (isTargetRegionPushWithDeferredSwap || isNormalPush) {
             LOGGER.info(
                 "Swapping to version {} for store {} in region {} during "
@@ -1256,6 +1268,7 @@ public abstract class AbstractPushMonitor
             store.setCurrentVersion(versionNumber);
             currentVersionChangeNotifier.onCurrentVersionChange(store, clusterName, versionNumber, previousVersion);
             realTimeTopicSwitcher.transmitVersionSwapMessage(store, previousVersion, versionNumber);
+            applyRfTuningOnVersionSwap(store, storeName, versionNumber, previousVersion);
           } else {
             LOGGER.info(
                 "Version swap is deferred for store {} on version {} in region {} because "
@@ -1321,5 +1334,32 @@ public abstract class AbstractPushMonitor
   @Override
   public boolean isOfflinePushMonitorDaVinciPushStatusEnabled() {
     return isOfflinePushMonitorDaVinciPushStatusEnabled;
+  }
+
+  /**
+   * Apply RF tuning on version swap: update version metadata RF and Helix IdealState
+   * for the new current version and the demoted backup version.
+   */
+  private void applyRfTuningOnVersionSwap(Store store, String storeName, int newCurrentVersion, int previousVersion) {
+    if (!rfTuningEnabled) {
+      return;
+    }
+
+    // Update version metadata RF
+    store.getVersion(newCurrentVersion).setReplicationFactor(currentVersionRfCount);
+    if (previousVersion != Store.NON_EXISTING_VERSION && store.containsVersion(previousVersion)) {
+      store.getVersion(previousVersion).setReplicationFactor(backupVersionRfCount);
+    }
+
+    // Update Helix IdealState
+    String currentVersionTopic = Version.composeKafkaTopic(storeName, newCurrentVersion);
+    helixAdminClient
+        .updateIdealState(clusterName, currentVersionTopic, currentVersionMinActiveReplicaCount, currentVersionRfCount);
+
+    if (previousVersion != Store.NON_EXISTING_VERSION) {
+      String backupVersionTopic = Version.composeKafkaTopic(storeName, previousVersion);
+      helixAdminClient
+          .updateIdealState(clusterName, backupVersionTopic, backupVersionMinActiveReplicaCount, backupVersionRfCount);
+    }
   }
 }

--- a/services/venice-controller/src/test/java/com/linkedin/venice/controller/TestStoreBackupVersionCleanupService.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/controller/TestStoreBackupVersionCleanupService.java
@@ -321,10 +321,6 @@ public class TestStoreBackupVersionCleanupService {
     Map<Integer, VersionStatus> versions = new HashMap<>();
     versions.put(1, VersionStatus.ONLINE);
     versions.put(2, VersionStatus.ONLINE);
-    doReturn(true).when(controllerConfig).isRfTuningEnabled();
-    doReturn(2).when(controllerConfig).getBackupVersionRfCount();
-    doReturn(2).when(controllerConfig).getBackupVersionMinActiveReplicaCount();
-
     // Create a store with two versions (one backup, one current)
     Store storeWithOneBackup = mockStore(360000, System.currentTimeMillis() - DEFAULT_RETENTION_MS * 2, versions, 2);
     doReturn(System.currentTimeMillis()).when(storeWithOneBackup).getLatestVersionPromoteToCurrentTimestamp();
@@ -342,50 +338,6 @@ public class TestStoreBackupVersionCleanupService {
     // Should still not clean up the only backup version
     Assert.assertFalse(service.cleanupBackupVersion(storeWithOneBackup, CLUSTER_NAME));
     verify(admin, never()).deleteOldVersionInStore(CLUSTER_NAME, storeWithOneBackup.getName(), 1);
-    verify(admin).updateIdealState(CLUSTER_NAME, Version.composeKafkaTopic(storeWithOneBackup.getName(), 1), 2, 2);
-  }
-
-  @Test
-  public void testCleanupBackupVersion_RfTuningReducesBackupReplicas() {
-    // When RF tuning is enabled, backup versions should be reduced to configured RF and MinActiveReplicas
-    Map<Integer, VersionStatus> versions = new HashMap<>();
-    versions.put(1, VersionStatus.ONLINE);
-    versions.put(2, VersionStatus.ONLINE);
-
-    doReturn(true).when(controllerConfig).isRfTuningEnabled();
-    doReturn(2).when(controllerConfig).getBackupVersionRfCount();
-    doReturn(1).when(controllerConfig).getBackupVersionMinActiveReplicaCount();
-
-    // Same pattern as testCleanupBackupVersion_OnlyOneBackupVersion — triggers the not-ready-to-cleanup path
-    // which enters the backup reduction block. Use 3 versions with a STARTED push to have only one backup.
-    versions.put(3, VersionStatus.STARTED);
-    Store store = mockStore(360000, System.currentTimeMillis(), versions, 2);
-
-    Assert.assertFalse(service.cleanupBackupVersion(store, CLUSTER_NAME));
-
-    // Verify backup version (1) was reduced with configured values (minActive=1, rf=2)
-    String backupTopic = Version.composeKafkaTopic(store.getName(), 1);
-    verify(admin).updateIdealState(CLUSTER_NAME, backupTopic, 1, 2);
-  }
-
-  @Test
-  public void testCleanupBackupVersion_RfTuningDisabledNoReduction() {
-    // When RF tuning is disabled, no backup reduction should happen (even if old flag is off too)
-    Map<Integer, VersionStatus> versions = new HashMap<>();
-    versions.put(1, VersionStatus.ONLINE);
-    versions.put(2, VersionStatus.ONLINE);
-
-    doReturn(false).when(controllerConfig).isRfTuningEnabled();
-    doReturn(false).when(controllerConfig).isBackupVersionReplicaReductionEnabled();
-
-    Store store = mockStore(360000, System.currentTimeMillis() - DEFAULT_RETENTION_MS * 2, versions, 2);
-    doReturn(System.currentTimeMillis()).when(store).getLatestVersionPromoteToCurrentTimestamp();
-
-    Assert.assertFalse(service.cleanupBackupVersion(store, CLUSTER_NAME));
-
-    // No ideal state updates should happen for the backup version
-    String backupTopic = Version.composeKafkaTopic(store.getName(), 1);
-    verify(admin, never()).updateIdealState(CLUSTER_NAME, backupTopic, 2);
   }
 
   @Test

--- a/services/venice-controller/src/test/java/com/linkedin/venice/controller/TestStoreBackupVersionCleanupService.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/controller/TestStoreBackupVersionCleanupService.java
@@ -321,7 +321,9 @@ public class TestStoreBackupVersionCleanupService {
     Map<Integer, VersionStatus> versions = new HashMap<>();
     versions.put(1, VersionStatus.ONLINE);
     versions.put(2, VersionStatus.ONLINE);
-    doReturn(true).when(controllerConfig).isBackupVersionReplicaReductionEnabled();
+    doReturn(true).when(controllerConfig).isRfTuningEnabled();
+    doReturn(2).when(controllerConfig).getBackupVersionRfCount();
+    doReturn(2).when(controllerConfig).getBackupVersionMinActiveReplicaCount();
 
     // Create a store with two versions (one backup, one current)
     Store storeWithOneBackup = mockStore(360000, System.currentTimeMillis() - DEFAULT_RETENTION_MS * 2, versions, 2);
@@ -340,7 +342,50 @@ public class TestStoreBackupVersionCleanupService {
     // Should still not clean up the only backup version
     Assert.assertFalse(service.cleanupBackupVersion(storeWithOneBackup, CLUSTER_NAME));
     verify(admin, never()).deleteOldVersionInStore(CLUSTER_NAME, storeWithOneBackup.getName(), 1);
-    verify(admin).updateIdealState(CLUSTER_NAME, Version.composeKafkaTopic(storeWithOneBackup.getName(), 1), 2);
+    verify(admin).updateIdealState(CLUSTER_NAME, Version.composeKafkaTopic(storeWithOneBackup.getName(), 1), 2, 2);
+  }
+
+  @Test
+  public void testCleanupBackupVersion_RfTuningReducesBackupReplicas() {
+    // When RF tuning is enabled, backup versions should be reduced to configured RF and MinActiveReplicas
+    Map<Integer, VersionStatus> versions = new HashMap<>();
+    versions.put(1, VersionStatus.ONLINE);
+    versions.put(2, VersionStatus.ONLINE);
+
+    doReturn(true).when(controllerConfig).isRfTuningEnabled();
+    doReturn(2).when(controllerConfig).getBackupVersionRfCount();
+    doReturn(1).when(controllerConfig).getBackupVersionMinActiveReplicaCount();
+
+    // Same pattern as testCleanupBackupVersion_OnlyOneBackupVersion — triggers the not-ready-to-cleanup path
+    // which enters the backup reduction block. Use 3 versions with a STARTED push to have only one backup.
+    versions.put(3, VersionStatus.STARTED);
+    Store store = mockStore(360000, System.currentTimeMillis(), versions, 2);
+
+    Assert.assertFalse(service.cleanupBackupVersion(store, CLUSTER_NAME));
+
+    // Verify backup version (1) was reduced with configured values (minActive=1, rf=2)
+    String backupTopic = Version.composeKafkaTopic(store.getName(), 1);
+    verify(admin).updateIdealState(CLUSTER_NAME, backupTopic, 1, 2);
+  }
+
+  @Test
+  public void testCleanupBackupVersion_RfTuningDisabledNoReduction() {
+    // When RF tuning is disabled, no backup reduction should happen (even if old flag is off too)
+    Map<Integer, VersionStatus> versions = new HashMap<>();
+    versions.put(1, VersionStatus.ONLINE);
+    versions.put(2, VersionStatus.ONLINE);
+
+    doReturn(false).when(controllerConfig).isRfTuningEnabled();
+    doReturn(false).when(controllerConfig).isBackupVersionReplicaReductionEnabled();
+
+    Store store = mockStore(360000, System.currentTimeMillis() - DEFAULT_RETENTION_MS * 2, versions, 2);
+    doReturn(System.currentTimeMillis()).when(store).getLatestVersionPromoteToCurrentTimestamp();
+
+    Assert.assertFalse(service.cleanupBackupVersion(store, CLUSTER_NAME));
+
+    // No ideal state updates should happen for the backup version
+    String backupTopic = Version.composeKafkaTopic(store.getName(), 1);
+    verify(admin, never()).updateIdealState(CLUSTER_NAME, backupTopic, 2);
   }
 
   @Test

--- a/services/venice-controller/src/test/java/com/linkedin/venice/controller/TestVeniceControllerClusterConfig.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/controller/TestVeniceControllerClusterConfig.java
@@ -697,4 +697,59 @@ public class TestVeniceControllerClusterConfig {
     assertTrue(config.getUncleanLeaderElectionEnableRealTimeTopics().isPresent());
     assertTrue(config.getUncleanLeaderElectionEnableRealTimeTopics().get());
   }
+
+  /**
+   * RF tuning clamping tests: verify minActiveReplicas is properly clamped.
+   */
+  @DataProvider(name = "rfTuningClampingCases")
+  public Object[][] rfTuningClampingCases() {
+    // { rfTuningEnabled, configuredRf, configuredMinActive (null = use default), expectedRf, expectedMinActive }
+    return new Object[][] {
+        // When RF=1, minActive is clamped to 1 (not 0, since default would be RF-1=0)
+        { true, 1, null, 1, 1 },
+        // When configured minActive > RF, it's clamped to RF
+        { true, 3, 5, 3, 3 },
+        // Normal case: RF=4, minActive defaults to 3 (RF-1)
+        { true, 4, null, 4, 3 },
+        // When RF tuning is disabled, getters still return defaults matching store RF (which is
+        // DEFAULT_REPLICA_FACTOR=1)
+        { false, null, null, 1, 1 }, };
+  }
+
+  @Test(dataProvider = "rfTuningClampingCases")
+  public void testRfTuningClamping(
+      boolean rfTuningEnabled,
+      Integer configuredRf,
+      Integer configuredMinActive,
+      int expectedRf,
+      int expectedMinActive) {
+    Properties props = getBaseSingleRegionProperties(false);
+    props.put(ConfigKeys.CONTROLLER_RF_TUNING_ENABLED, String.valueOf(rfTuningEnabled));
+    if (configuredRf != null) {
+      props.put(ConfigKeys.CONTROLLER_FUTURE_VERSION_RF_COUNT, String.valueOf(configuredRf));
+      props.put(ConfigKeys.CONTROLLER_CURRENT_VERSION_RF_COUNT, String.valueOf(configuredRf));
+      props.put(ConfigKeys.CONTROLLER_BACKUP_VERSION_RF_COUNT, String.valueOf(configuredRf));
+    }
+    if (configuredMinActive != null) {
+      props.put(ConfigKeys.CONTROLLER_FUTURE_VERSION_MIN_ACTIVE_REPLICA_COUNT, String.valueOf(configuredMinActive));
+      props.put(ConfigKeys.CONTROLLER_CURRENT_VERSION_MIN_ACTIVE_REPLICA_COUNT, String.valueOf(configuredMinActive));
+      props.put(ConfigKeys.CONTROLLER_BACKUP_VERSION_MIN_ACTIVE_REPLICA_COUNT, String.valueOf(configuredMinActive));
+    }
+
+    VeniceControllerClusterConfig config = new VeniceControllerClusterConfig(new VeniceProperties(props));
+
+    assertEquals(config.isRfTuningEnabled(), rfTuningEnabled);
+
+    // Verify future version
+    assertEquals(config.getFutureVersionRfCount(), expectedRf);
+    assertEquals(config.getFutureVersionMinActiveReplicaCount(), expectedMinActive);
+
+    // Verify current version
+    assertEquals(config.getCurrentVersionRfCount(), expectedRf);
+    assertEquals(config.getCurrentVersionMinActiveReplicaCount(), expectedMinActive);
+
+    // Verify backup version
+    assertEquals(config.getBackupVersionRfCount(), expectedRf);
+    assertEquals(config.getBackupVersionMinActiveReplicaCount(), expectedMinActive);
+  }
 }

--- a/services/venice-controller/src/test/java/com/linkedin/venice/controller/TestVeniceHelixAdmin.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/controller/TestVeniceHelixAdmin.java
@@ -1378,6 +1378,124 @@ public class TestVeniceHelixAdmin {
     }
   }
 
+  /**
+   * Tests RF tuning behavior during version swap (rollForwardToFutureVersion).
+   * When enabled: version RF metadata and Helix IdealState are updated at each lifecycle transition.
+   * When disabled: no RF changes occur.
+   */
+  @Test(dataProvider = "True-and-False", dataProviderClass = DataProviderUtils.class)
+  public void testRfTuningVersionLifecycleTransitions(boolean rfTuningEnabled) {
+    VeniceHelixAdmin mockVeniceHelixAdmin = mock(VeniceHelixAdmin.class);
+
+    VeniceControllerClusterConfig mockClusterConfig = mock(VeniceControllerClusterConfig.class);
+    when(mockClusterConfig.isRfTuningEnabled()).thenReturn(rfTuningEnabled);
+    if (rfTuningEnabled) {
+      when(mockClusterConfig.getCurrentVersionRfCount()).thenReturn(4);
+      when(mockClusterConfig.getCurrentVersionMinActiveReplicaCount()).thenReturn(3);
+      when(mockClusterConfig.getBackupVersionRfCount()).thenReturn(2);
+      when(mockClusterConfig.getBackupVersionMinActiveReplicaCount()).thenReturn(1);
+    }
+
+    VeniceControllerMultiClusterConfig mockMultiClusterConfig = mock(VeniceControllerMultiClusterConfig.class);
+    when(mockMultiClusterConfig.getControllerConfig(clusterName)).thenReturn(mockClusterConfig);
+
+    // Inject multiClusterConfigs and helixAdminClient
+    HelixAdminClient mockHelixAdminClient = mock(HelixAdminClient.class);
+    try {
+      java.lang.reflect.Field configField = VeniceHelixAdmin.class.getDeclaredField("multiClusterConfigs");
+      configField.setAccessible(true);
+      configField.set(mockVeniceHelixAdmin, mockMultiClusterConfig);
+
+      java.lang.reflect.Field helixField = VeniceHelixAdmin.class.getDeclaredField("helixAdminClient");
+      helixField.setAccessible(true);
+      helixField.set(mockVeniceHelixAdmin, mockHelixAdminClient);
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
+
+    // Build mock store: v1 (current), v2 (future being promoted)
+    Store mockStore = mock(Store.class);
+    when(mockStore.isEnableWrites()).thenReturn(true);
+    when(mockStore.getCurrentVersion()).thenReturn(1);
+    when(mockStore.isMigrating()).thenReturn(false);
+    when(mockStore.getName()).thenReturn(storeName);
+
+    Version v1 = mock(Version.class);
+    when(v1.getNumber()).thenReturn(1);
+    when(v1.getReplicationFactor()).thenReturn(3);
+
+    Version v2 = mock(Version.class);
+    when(v2.getNumber()).thenReturn(2);
+    when(v2.isVersionSwapDeferred()).thenReturn(false);
+    when(v2.getReplicationFactor()).thenReturn(rfTuningEnabled ? 4 : 3);
+
+    when(mockStore.getVersion(1)).thenReturn(v1);
+    when(mockStore.getVersion(2)).thenReturn(v2);
+    when(mockStore.containsVersion(1)).thenReturn(true);
+    when(mockStore.containsVersion(2)).thenReturn(true);
+
+    HelixVeniceClusterResources mockClusterResources = mock(HelixVeniceClusterResources.class);
+    doReturn(mock(VeniceVersionLifecycleEventManager.class)).when(mockClusterResources)
+        .getVeniceVersionLifecycleEventManager();
+    doReturn(mockClusterResources).when(mockVeniceHelixAdmin).getHelixVeniceClusterResources(clusterName);
+
+    RealTimeTopicSwitcher mockTopicSwitcher = mock(RealTimeTopicSwitcher.class);
+    doReturn(mockTopicSwitcher).when(mockVeniceHelixAdmin).getRealTimeTopicSwitcher();
+
+    doReturn(2).when(mockVeniceHelixAdmin).getFutureVersionWithStatus(clusterName, storeName, VersionStatus.ONLINE);
+    doReturn(0).when(mockVeniceHelixAdmin).getFutureVersionWithStatus(clusterName, storeName, VersionStatus.PUSHED);
+
+    // Intercept storeMetadataUpdate and execute the lambda on our mock store
+    doAnswer(inv -> {
+      VeniceHelixAdmin.StoreMetadataOperation updater = inv.getArgument(2);
+      updater.update(mockStore, mockClusterResources);
+      return null;
+    }).when(mockVeniceHelixAdmin).storeMetadataUpdate(eq(clusterName), eq(storeName), any());
+
+    // Wire up updateIdealState to execute real logic
+    doCallRealMethod().when(mockVeniceHelixAdmin).updateIdealState(anyString(), anyString(), anyInt(), anyInt());
+
+    if (rfTuningEnabled) {
+      // Mock IdealState for backup version (v1 being demoted from RF=3 to RF=2)
+      org.apache.helix.model.IdealState mockIdealStateV1 = mock(org.apache.helix.model.IdealState.class);
+      when(mockIdealStateV1.getMinActiveReplicas()).thenReturn(2);
+      when(mockIdealStateV1.getReplicas()).thenReturn("3");
+      when(mockHelixAdminClient.getResourceIdealState(clusterName, Version.composeKafkaTopic(storeName, 1)))
+          .thenReturn(mockIdealStateV1);
+
+      // Mock IdealState for current version (v2, already at RF=4 from creation)
+      org.apache.helix.model.IdealState mockIdealStateV2 = mock(org.apache.helix.model.IdealState.class);
+      when(mockIdealStateV2.getMinActiveReplicas()).thenReturn(3);
+      when(mockIdealStateV2.getReplicas()).thenReturn("4");
+      when(mockHelixAdminClient.getResourceIdealState(clusterName, Version.composeKafkaTopic(storeName, 2)))
+          .thenReturn(mockIdealStateV2);
+    }
+
+    doCallRealMethod().when(mockVeniceHelixAdmin).rollForwardToFutureVersion(anyString(), anyString(), anyString());
+    doReturn("test").when(mockVeniceHelixAdmin).getRegionName();
+
+    try (MockedStatic<RegionUtils> utilities = mockStatic(RegionUtils.class)) {
+      utilities.when(() -> RegionUtils.isRegionPartOfRegionsFilterList(anyString(), anyString())).thenReturn(true);
+      mockVeniceHelixAdmin.rollForwardToFutureVersion(clusterName, storeName, "test");
+    }
+
+    if (rfTuningEnabled) {
+      // Version 2 (new current) RF metadata set to currentVersionRfCount=4
+      verify(v2).setReplicationFactor(4);
+      // Version 1 (demoted to backup) RF metadata set to backupVersionRfCount=2
+      verify(v1).setReplicationFactor(2);
+      // Helix IdealState updated for backup version (v1: RF 3→2, minActive 2→1)
+      verify(mockHelixAdminClient)
+          .updateIdealState(eq(clusterName), eq(Version.composeKafkaTopic(storeName, 1)), any());
+      // v2 IdealState is a no-op (already RF=4/minActive=3 from creation as future version)
+    } else {
+      // No RF changes when tuning is disabled
+      verify(v1, never()).setReplicationFactor(anyInt());
+      verify(v2, never()).setReplicationFactor(anyInt());
+      verify(mockVeniceHelixAdmin, never()).updateIdealState(anyString(), anyString(), anyInt(), anyInt());
+    }
+  }
+
   @Test(dataProvider = "Three-True-and-False", dataProviderClass = DataProviderUtils.class)
   public void testRepushStore(boolean manualRepush, boolean responseFailure, boolean responseException)
       throws Exception {

--- a/services/venice-controller/src/test/java/com/linkedin/venice/controller/TestVeniceHelixAdmin.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/controller/TestVeniceHelixAdmin.java
@@ -1399,19 +1399,10 @@ public class TestVeniceHelixAdmin {
     VeniceControllerMultiClusterConfig mockMultiClusterConfig = mock(VeniceControllerMultiClusterConfig.class);
     when(mockMultiClusterConfig.getControllerConfig(clusterName)).thenReturn(mockClusterConfig);
 
-    // Inject multiClusterConfigs and helixAdminClient
+    // Wire up getters for RF tuning
     HelixAdminClient mockHelixAdminClient = mock(HelixAdminClient.class);
-    try {
-      java.lang.reflect.Field configField = VeniceHelixAdmin.class.getDeclaredField("multiClusterConfigs");
-      configField.setAccessible(true);
-      configField.set(mockVeniceHelixAdmin, mockMultiClusterConfig);
-
-      java.lang.reflect.Field helixField = VeniceHelixAdmin.class.getDeclaredField("helixAdminClient");
-      helixField.setAccessible(true);
-      helixField.set(mockVeniceHelixAdmin, mockHelixAdminClient);
-    } catch (Exception e) {
-      throw new RuntimeException(e);
-    }
+    doReturn(mockMultiClusterConfig).when(mockVeniceHelixAdmin).getMultiClusterConfigs();
+    doReturn(mockHelixAdminClient).when(mockVeniceHelixAdmin).getHelixAdminClient();
 
     // Build mock store: v1 (current), v2 (future being promoted)
     Store mockStore = mock(Store.class);
@@ -1521,21 +1512,9 @@ public class TestVeniceHelixAdmin {
     HelixAdminClient mockHelixAdminClient = mock(HelixAdminClient.class);
     RealTimeTopicSwitcher mockTopicSwitcher = mock(RealTimeTopicSwitcher.class);
 
-    try {
-      java.lang.reflect.Field configField = VeniceHelixAdmin.class.getDeclaredField("multiClusterConfigs");
-      configField.setAccessible(true);
-      configField.set(mockVeniceHelixAdmin, mockMultiClusterConfig);
-
-      java.lang.reflect.Field helixField = VeniceHelixAdmin.class.getDeclaredField("helixAdminClient");
-      helixField.setAccessible(true);
-      helixField.set(mockVeniceHelixAdmin, mockHelixAdminClient);
-
-      java.lang.reflect.Field rtsField = VeniceHelixAdmin.class.getDeclaredField("realTimeTopicSwitcher");
-      rtsField.setAccessible(true);
-      rtsField.set(mockVeniceHelixAdmin, mockTopicSwitcher);
-    } catch (Exception e) {
-      throw new RuntimeException(e);
-    }
+    doReturn(mockMultiClusterConfig).when(mockVeniceHelixAdmin).getMultiClusterConfigs();
+    doReturn(mockHelixAdminClient).when(mockVeniceHelixAdmin).getHelixAdminClient();
+    doReturn(mockTopicSwitcher).when(mockVeniceHelixAdmin).getRealTimeTopicSwitcher();
 
     // Build mock store: v1 (backup, ONLINE), v2 (current)
     Store mockStore = mock(Store.class);
@@ -1635,21 +1614,9 @@ public class TestVeniceHelixAdmin {
 
     HelixAdminClient mockHelixAdminClient = mock(HelixAdminClient.class);
 
-    try {
-      java.lang.reflect.Field configField = VeniceHelixAdmin.class.getDeclaredField("multiClusterConfigs");
-      configField.setAccessible(true);
-      configField.set(mockVeniceHelixAdmin, mockMultiClusterConfig);
-
-      java.lang.reflect.Field helixField = VeniceHelixAdmin.class.getDeclaredField("helixAdminClient");
-      helixField.setAccessible(true);
-      helixField.set(mockVeniceHelixAdmin, mockHelixAdminClient);
-
-      java.lang.reflect.Field rtsField = VeniceHelixAdmin.class.getDeclaredField("realTimeTopicSwitcher");
-      rtsField.setAccessible(true);
-      rtsField.set(mockVeniceHelixAdmin, mock(RealTimeTopicSwitcher.class));
-    } catch (Exception e) {
-      throw new RuntimeException(e);
-    }
+    doReturn(mockMultiClusterConfig).when(mockVeniceHelixAdmin).getMultiClusterConfigs();
+    doReturn(mockHelixAdminClient).when(mockVeniceHelixAdmin).getHelixAdminClient();
+    doReturn(mock(RealTimeTopicSwitcher.class)).when(mockVeniceHelixAdmin).getRealTimeTopicSwitcher();
 
     // Build mock store: v1 (current), setting v2 as new current
     Store mockStore = mock(Store.class);

--- a/services/venice-controller/src/test/java/com/linkedin/venice/controller/TestVeniceHelixAdmin.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/controller/TestVeniceHelixAdmin.java
@@ -1452,7 +1452,7 @@ public class TestVeniceHelixAdmin {
       return null;
     }).when(mockVeniceHelixAdmin).storeMetadataUpdate(eq(clusterName), eq(storeName), any());
 
-    // Wire up updateIdealState to execute real logic
+    // Wire up updateIdealState to delegate to helixAdminClient
     doCallRealMethod().when(mockVeniceHelixAdmin).updateIdealState(anyString(), anyString(), anyInt(), anyInt());
 
     if (rfTuningEnabled) {
@@ -1485,11 +1485,233 @@ public class TestVeniceHelixAdmin {
       // Version 1 (demoted to backup) RF metadata set to backupVersionRfCount=2
       verify(v1).setReplicationFactor(2);
       // Helix IdealState updated for backup version (v1: RF 3→2, minActive 2→1)
-      verify(mockHelixAdminClient)
-          .updateIdealState(eq(clusterName), eq(Version.composeKafkaTopic(storeName, 1)), any());
+      verify(mockHelixAdminClient).updateIdealState(clusterName, Version.composeKafkaTopic(storeName, 1), 1, 2);
       // v2 IdealState is a no-op (already RF=4/minActive=3 from creation as future version)
     } else {
       // No RF changes when tuning is disabled
+      verify(v1, never()).setReplicationFactor(anyInt());
+      verify(v2, never()).setReplicationFactor(anyInt());
+      verify(mockVeniceHelixAdmin, never()).updateIdealState(anyString(), anyString(), anyInt(), anyInt());
+    }
+  }
+
+  /**
+   * Tests RF tuning behavior during rollbackToBackupVersion.
+   * When enabled: the restored backup version gets currentVersionRfCount,
+   * the demoted previous version gets backupVersionRfCount.
+   * When disabled: no RF changes occur.
+   */
+  @Test(dataProvider = "True-and-False", dataProviderClass = DataProviderUtils.class)
+  public void testRfTuningRollbackToBackupVersion(boolean rfTuningEnabled) {
+    VeniceHelixAdmin mockVeniceHelixAdmin = mock(VeniceHelixAdmin.class);
+
+    VeniceControllerClusterConfig mockClusterConfig = mock(VeniceControllerClusterConfig.class);
+    when(mockClusterConfig.isRfTuningEnabled()).thenReturn(rfTuningEnabled);
+    if (rfTuningEnabled) {
+      when(mockClusterConfig.getCurrentVersionRfCount()).thenReturn(4);
+      when(mockClusterConfig.getCurrentVersionMinActiveReplicaCount()).thenReturn(3);
+      when(mockClusterConfig.getBackupVersionRfCount()).thenReturn(2);
+      when(mockClusterConfig.getBackupVersionMinActiveReplicaCount()).thenReturn(1);
+    }
+
+    VeniceControllerMultiClusterConfig mockMultiClusterConfig = mock(VeniceControllerMultiClusterConfig.class);
+    when(mockMultiClusterConfig.getControllerConfig(clusterName)).thenReturn(mockClusterConfig);
+    when(mockMultiClusterConfig.getRegionName()).thenReturn("test-region");
+
+    HelixAdminClient mockHelixAdminClient = mock(HelixAdminClient.class);
+    RealTimeTopicSwitcher mockTopicSwitcher = mock(RealTimeTopicSwitcher.class);
+
+    try {
+      java.lang.reflect.Field configField = VeniceHelixAdmin.class.getDeclaredField("multiClusterConfigs");
+      configField.setAccessible(true);
+      configField.set(mockVeniceHelixAdmin, mockMultiClusterConfig);
+
+      java.lang.reflect.Field helixField = VeniceHelixAdmin.class.getDeclaredField("helixAdminClient");
+      helixField.setAccessible(true);
+      helixField.set(mockVeniceHelixAdmin, mockHelixAdminClient);
+
+      java.lang.reflect.Field rtsField = VeniceHelixAdmin.class.getDeclaredField("realTimeTopicSwitcher");
+      rtsField.setAccessible(true);
+      rtsField.set(mockVeniceHelixAdmin, mockTopicSwitcher);
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
+
+    // Build mock store: v1 (backup, ONLINE), v2 (current)
+    Store mockStore = mock(Store.class);
+    when(mockStore.isEnableWrites()).thenReturn(true);
+    when(mockStore.getCurrentVersion()).thenReturn(2);
+    when(mockStore.getName()).thenReturn(storeName);
+
+    Version v1 = mock(Version.class);
+    when(v1.getNumber()).thenReturn(1);
+    when(v1.getStatus()).thenReturn(VersionStatus.ONLINE);
+    when(v1.getReplicationFactor()).thenReturn(rfTuningEnabled ? 2 : 3);
+
+    Version v2 = mock(Version.class);
+    when(v2.getNumber()).thenReturn(2);
+    when(v2.getReplicationFactor()).thenReturn(rfTuningEnabled ? 4 : 3);
+
+    when(mockStore.getVersion(1)).thenReturn(v1);
+    when(mockStore.getVersion(2)).thenReturn(v2);
+    when(mockStore.containsVersion(1)).thenReturn(true);
+    when(mockStore.containsVersion(2)).thenReturn(true);
+    when(mockStore.getVersions()).thenReturn(Arrays.asList(v1, v2));
+
+    HelixVeniceClusterResources mockClusterResources = mock(HelixVeniceClusterResources.class);
+    doReturn(mock(VeniceVersionLifecycleEventManager.class)).when(mockClusterResources)
+        .getVeniceVersionLifecycleEventManager();
+    doReturn(mockClusterResources).when(mockVeniceHelixAdmin).getHelixVeniceClusterResources(clusterName);
+
+    // getBackupVersionNumber returns 1 (highest ONLINE version < current=2)
+    doCallRealMethod().when(mockVeniceHelixAdmin).getBackupVersionNumber(any(), anyInt());
+
+    // Intercept storeMetadataUpdate and execute the lambda
+    doAnswer(inv -> {
+      VeniceHelixAdmin.StoreMetadataOperation updater = inv.getArgument(2);
+      updater.update(mockStore, mockClusterResources);
+      return null;
+    }).when(mockVeniceHelixAdmin).storeMetadataUpdate(eq(clusterName), eq(storeName), any());
+
+    doCallRealMethod().when(mockVeniceHelixAdmin).updateIdealState(anyString(), anyString(), anyInt(), anyInt());
+    doReturn(false).when(mockVeniceHelixAdmin).isParent();
+
+    if (rfTuningEnabled) {
+      org.apache.helix.model.IdealState mockIdealStateV1 = mock(org.apache.helix.model.IdealState.class);
+      when(mockIdealStateV1.getMinActiveReplicas()).thenReturn(1);
+      when(mockIdealStateV1.getReplicas()).thenReturn("2");
+      when(mockHelixAdminClient.getResourceIdealState(clusterName, Version.composeKafkaTopic(storeName, 1)))
+          .thenReturn(mockIdealStateV1);
+
+      org.apache.helix.model.IdealState mockIdealStateV2 = mock(org.apache.helix.model.IdealState.class);
+      when(mockIdealStateV2.getMinActiveReplicas()).thenReturn(3);
+      when(mockIdealStateV2.getReplicas()).thenReturn("4");
+      when(mockHelixAdminClient.getResourceIdealState(clusterName, Version.composeKafkaTopic(storeName, 2)))
+          .thenReturn(mockIdealStateV2);
+    }
+
+    doCallRealMethod().when(mockVeniceHelixAdmin).rollbackToBackupVersion(anyString(), anyString(), anyString());
+
+    mockVeniceHelixAdmin.rollbackToBackupVersion(clusterName, storeName, "");
+
+    // Verify version swap happened: backup v1 becomes current
+    verify(mockStore).setCurrentVersion(1);
+
+    if (rfTuningEnabled) {
+      // v1 (restored as current) gets currentVersionRfCount=4
+      verify(v1).setReplicationFactor(4);
+      // v2 (demoted to backup) gets backupVersionRfCount=2
+      verify(v2).setReplicationFactor(2);
+      // IdealState updates
+      verify(mockHelixAdminClient).updateIdealState(clusterName, Version.composeKafkaTopic(storeName, 1), 3, 4);
+      verify(mockHelixAdminClient).updateIdealState(clusterName, Version.composeKafkaTopic(storeName, 2), 1, 2);
+    } else {
+      verify(v1, never()).setReplicationFactor(anyInt());
+      verify(v2, never()).setReplicationFactor(anyInt());
+      verify(mockVeniceHelixAdmin, never()).updateIdealState(anyString(), anyString(), anyInt(), anyInt());
+    }
+  }
+
+  /**
+   * Tests RF tuning behavior during setStoreCurrentVersion (API-driven version swap).
+   * When enabled: RF tuning is applied to the new current and old backup.
+   * When disabled: no RF changes.
+   */
+  @Test(dataProvider = "True-and-False", dataProviderClass = DataProviderUtils.class)
+  public void testRfTuningSetStoreCurrentVersion(boolean rfTuningEnabled) {
+    VeniceHelixAdmin mockVeniceHelixAdmin = mock(VeniceHelixAdmin.class);
+
+    VeniceControllerClusterConfig mockClusterConfig = mock(VeniceControllerClusterConfig.class);
+    when(mockClusterConfig.isRfTuningEnabled()).thenReturn(rfTuningEnabled);
+    if (rfTuningEnabled) {
+      when(mockClusterConfig.getCurrentVersionRfCount()).thenReturn(4);
+      when(mockClusterConfig.getCurrentVersionMinActiveReplicaCount()).thenReturn(3);
+      when(mockClusterConfig.getBackupVersionRfCount()).thenReturn(2);
+      when(mockClusterConfig.getBackupVersionMinActiveReplicaCount()).thenReturn(1);
+    }
+
+    VeniceControllerMultiClusterConfig mockMultiClusterConfig = mock(VeniceControllerMultiClusterConfig.class);
+    when(mockMultiClusterConfig.getControllerConfig(clusterName)).thenReturn(mockClusterConfig);
+
+    HelixAdminClient mockHelixAdminClient = mock(HelixAdminClient.class);
+
+    try {
+      java.lang.reflect.Field configField = VeniceHelixAdmin.class.getDeclaredField("multiClusterConfigs");
+      configField.setAccessible(true);
+      configField.set(mockVeniceHelixAdmin, mockMultiClusterConfig);
+
+      java.lang.reflect.Field helixField = VeniceHelixAdmin.class.getDeclaredField("helixAdminClient");
+      helixField.setAccessible(true);
+      helixField.set(mockVeniceHelixAdmin, mockHelixAdminClient);
+
+      java.lang.reflect.Field rtsField = VeniceHelixAdmin.class.getDeclaredField("realTimeTopicSwitcher");
+      rtsField.setAccessible(true);
+      rtsField.set(mockVeniceHelixAdmin, mock(RealTimeTopicSwitcher.class));
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
+
+    // Build mock store: v1 (current), setting v2 as new current
+    Store mockStore = mock(Store.class);
+    when(mockStore.isEnableWrites()).thenReturn(true);
+    when(mockStore.getCurrentVersion()).thenReturn(1);
+    when(mockStore.getName()).thenReturn(storeName);
+
+    Version v1 = mock(Version.class);
+    when(v1.getNumber()).thenReturn(1);
+    when(v1.getReplicationFactor()).thenReturn(3);
+
+    Version v2 = mock(Version.class);
+    when(v2.getNumber()).thenReturn(2);
+    when(v2.getReplicationFactor()).thenReturn(3);
+
+    when(mockStore.getVersion(1)).thenReturn(v1);
+    when(mockStore.getVersion(2)).thenReturn(v2);
+    when(mockStore.containsVersion(1)).thenReturn(true);
+    when(mockStore.containsVersion(2)).thenReturn(true);
+
+    HelixVeniceClusterResources mockClusterResources = mock(HelixVeniceClusterResources.class);
+    doReturn(mock(VeniceVersionLifecycleEventManager.class)).when(mockClusterResources)
+        .getVeniceVersionLifecycleEventManager();
+    doReturn(mockClusterResources).when(mockVeniceHelixAdmin).getHelixVeniceClusterResources(clusterName);
+
+    // Intercept storeMetadataUpdate and execute the lambda
+    doAnswer(inv -> {
+      VeniceHelixAdmin.StoreMetadataOperation updater = inv.getArgument(2);
+      updater.update(mockStore, mockClusterResources);
+      return null;
+    }).when(mockVeniceHelixAdmin).storeMetadataUpdate(eq(clusterName), eq(storeName), any());
+
+    doCallRealMethod().when(mockVeniceHelixAdmin).updateIdealState(anyString(), anyString(), anyInt(), anyInt());
+    doCallRealMethod().when(mockVeniceHelixAdmin).setStoreCurrentVersion(anyString(), anyString(), anyInt());
+    doReturn(false).when(mockVeniceHelixAdmin).isParent();
+
+    if (rfTuningEnabled) {
+      org.apache.helix.model.IdealState mockIdealStateV1 = mock(org.apache.helix.model.IdealState.class);
+      when(mockIdealStateV1.getMinActiveReplicas()).thenReturn(2);
+      when(mockIdealStateV1.getReplicas()).thenReturn("3");
+      when(mockHelixAdminClient.getResourceIdealState(clusterName, Version.composeKafkaTopic(storeName, 1)))
+          .thenReturn(mockIdealStateV1);
+
+      org.apache.helix.model.IdealState mockIdealStateV2 = mock(org.apache.helix.model.IdealState.class);
+      when(mockIdealStateV2.getMinActiveReplicas()).thenReturn(2);
+      when(mockIdealStateV2.getReplicas()).thenReturn("3");
+      when(mockHelixAdminClient.getResourceIdealState(clusterName, Version.composeKafkaTopic(storeName, 2)))
+          .thenReturn(mockIdealStateV2);
+    }
+
+    mockVeniceHelixAdmin.setStoreCurrentVersion(clusterName, storeName, 2);
+
+    verify(mockStore).setCurrentVersion(2);
+
+    if (rfTuningEnabled) {
+      // v2 (new current) gets currentVersionRfCount=4
+      verify(v2).setReplicationFactor(4);
+      // v1 (demoted to backup) gets backupVersionRfCount=2
+      verify(v1).setReplicationFactor(2);
+      verify(mockHelixAdminClient).updateIdealState(clusterName, Version.composeKafkaTopic(storeName, 2), 3, 4);
+      verify(mockHelixAdminClient).updateIdealState(clusterName, Version.composeKafkaTopic(storeName, 1), 1, 2);
+    } else {
       verify(v1, never()).setReplicationFactor(anyInt());
       verify(v2, never()).setReplicationFactor(anyInt());
       verify(mockVeniceHelixAdmin, never()).updateIdealState(anyString(), anyString(), anyInt(), anyInt());

--- a/services/venice-controller/src/test/java/com/linkedin/venice/controller/TestZkHelixAdminClient.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/controller/TestZkHelixAdminClient.java
@@ -137,6 +137,62 @@ public class TestZkHelixAdminClient {
   }
 
   @Test
+  public void testCreateVeniceStorageClusterResources_RfTuningEnabled() {
+    String clusterName = "test-cluster";
+    String kafkaTopic = "test-store_v1";
+    int partitions = 10;
+    int storeRf = 3; // store-level RF passed by caller
+
+    VeniceControllerClusterConfig mockClusterConfig = mock(VeniceControllerClusterConfig.class);
+    when(mockClusterConfig.isRfTuningEnabled()).thenReturn(true);
+    when(mockClusterConfig.getFutureVersionRfCount()).thenReturn(4);
+    when(mockClusterConfig.getFutureVersionMinActiveReplicaCount()).thenReturn(3);
+    when(mockClusterConfig.getHelixRebalanceAlg())
+        .thenReturn("org.apache.helix.controller.rebalancer.strategy.CrushRebalanceStrategy");
+    when(mockMultiClusterConfigs.getControllerConfig(clusterName)).thenReturn(mockClusterConfig);
+
+    IdealState mockIdealState = mock(IdealState.class);
+    when(mockHelixAdmin.getResourcesInCluster(clusterName)).thenReturn(Collections.emptyList());
+    when(mockHelixAdmin.getResourceIdealState(clusterName, kafkaTopic)).thenReturn(mockIdealState);
+
+    doCallRealMethod().when(zkHelixAdminClient)
+        .createVeniceStorageClusterResources(anyString(), anyString(), anyInt(), anyInt());
+
+    zkHelixAdminClient.createVeniceStorageClusterResources(clusterName, kafkaTopic, partitions, storeRf);
+
+    // Should use tuning config values (RF=4, minActive=3), NOT store-level RF (3)
+    verify(mockIdealState).setMinActiveReplicas(3);
+    verify(mockHelixAdmin).rebalance(clusterName, kafkaTopic, 4);
+  }
+
+  @Test
+  public void testCreateVeniceStorageClusterResources_RfTuningDisabled() {
+    String clusterName = "test-cluster";
+    String kafkaTopic = "test-store_v1";
+    int partitions = 10;
+    int storeRf = 3;
+
+    VeniceControllerClusterConfig mockClusterConfig = mock(VeniceControllerClusterConfig.class);
+    when(mockClusterConfig.isRfTuningEnabled()).thenReturn(false);
+    when(mockClusterConfig.getHelixRebalanceAlg())
+        .thenReturn("org.apache.helix.controller.rebalancer.strategy.CrushRebalanceStrategy");
+    when(mockMultiClusterConfigs.getControllerConfig(clusterName)).thenReturn(mockClusterConfig);
+
+    IdealState mockIdealState = mock(IdealState.class);
+    when(mockHelixAdmin.getResourcesInCluster(clusterName)).thenReturn(Collections.emptyList());
+    when(mockHelixAdmin.getResourceIdealState(clusterName, kafkaTopic)).thenReturn(mockIdealState);
+
+    doCallRealMethod().when(zkHelixAdminClient)
+        .createVeniceStorageClusterResources(anyString(), anyString(), anyInt(), anyInt());
+
+    zkHelixAdminClient.createVeniceStorageClusterResources(clusterName, kafkaTopic, partitions, storeRf);
+
+    // Should use store-level RF (3) and derive minActive as RF-1=2
+    verify(mockIdealState).setMinActiveReplicas(2);
+    verify(mockHelixAdmin).rebalance(clusterName, kafkaTopic, 3);
+  }
+
+  @Test
   public void testCreateVeniceControllerCluster() {
     doReturn(true).when(mockHelixAdmin).addCluster(VENICE_CONTROLLER_CLUSTER, false);
     doReturn(true).when(mockMultiClusterConfigs).isControllerClusterHelixCloudEnabled();

--- a/services/venice-controller/src/test/java/com/linkedin/venice/controller/TestZkHelixAdminClient.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/controller/TestZkHelixAdminClient.java
@@ -21,6 +21,7 @@ import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.expectThrows;
 
 import com.linkedin.venice.controller.helix.HelixCapacityConfig;
+import com.linkedin.venice.exceptions.VeniceException;
 import java.lang.reflect.Field;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
@@ -583,5 +584,78 @@ public class TestZkHelixAdminClient {
 
     doCallRealMethod().when(zkHelixAdminClient).createVeniceControllerCluster();
     zkHelixAdminClient.createVeniceControllerCluster();
+  }
+
+  @Test
+  public void testUpdateIdealState4Arg_NormalUpdate() {
+    String clusterName = "test-cluster";
+    String resource = "test-store_v1";
+
+    IdealState mockIdealState = mock(IdealState.class);
+    when(mockIdealState.getMinActiveReplicas()).thenReturn(2);
+    when(mockIdealState.getReplicas()).thenReturn("3");
+    doReturn(mockIdealState).when(zkHelixAdminClient).getResourceIdealState(clusterName, resource);
+
+    doCallRealMethod().when(zkHelixAdminClient).updateIdealState(clusterName, resource, 1, 2);
+
+    boolean result = zkHelixAdminClient.updateIdealState(clusterName, resource, 1, 2);
+
+    assertTrue(result);
+    verify(mockIdealState).setMinActiveReplicas(1);
+    verify(mockIdealState).setReplicas("2");
+    verify(zkHelixAdminClient).updateIdealState(clusterName, resource, mockIdealState);
+  }
+
+  @Test
+  public void testUpdateIdealState4Arg_NoOp() {
+    String clusterName = "test-cluster";
+    String resource = "test-store_v1";
+
+    IdealState mockIdealState = mock(IdealState.class);
+    when(mockIdealState.getMinActiveReplicas()).thenReturn(3);
+    when(mockIdealState.getReplicas()).thenReturn("4");
+    doReturn(mockIdealState).when(zkHelixAdminClient).getResourceIdealState(clusterName, resource);
+
+    doCallRealMethod().when(zkHelixAdminClient).updateIdealState(clusterName, resource, 3, 4);
+
+    boolean result = zkHelixAdminClient.updateIdealState(clusterName, resource, 3, 4);
+
+    assertFalse(result);
+    verify(mockIdealState, never()).setMinActiveReplicas(anyInt());
+    verify(mockIdealState, never()).setReplicas(anyString());
+    verify(zkHelixAdminClient, never()).updateIdealState(eq(clusterName), eq(resource), any(IdealState.class));
+  }
+
+  @Test
+  public void testUpdateIdealState4Arg_NullIdealState() {
+    String clusterName = "test-cluster";
+    String resource = "test-store_v1";
+
+    doReturn(null).when(zkHelixAdminClient).getResourceIdealState(clusterName, resource);
+
+    doCallRealMethod().when(zkHelixAdminClient).updateIdealState(clusterName, resource, 3, 4);
+
+    boolean result = zkHelixAdminClient.updateIdealState(clusterName, resource, 3, 4);
+
+    assertFalse(result);
+    verify(zkHelixAdminClient, never()).updateIdealState(eq(clusterName), eq(resource), any(IdealState.class));
+  }
+
+  @Test
+  public void testUpdateIdealState4Arg_InvalidNumReplicasZero() {
+    doCallRealMethod().when(zkHelixAdminClient).updateIdealState(anyString(), anyString(), anyInt(), anyInt());
+
+    VeniceException e =
+        expectThrows(VeniceException.class, () -> zkHelixAdminClient.updateIdealState("cluster", "resource", 1, 0));
+    assertTrue(e.getMessage().contains("Invalid RF tuning params"));
+  }
+
+  @Test
+  public void testUpdateIdealState4Arg_InvalidMinActiveGreaterThanReplicas() {
+    doCallRealMethod().when(zkHelixAdminClient).updateIdealState(anyString(), anyString(), anyInt(), anyInt());
+
+    VeniceException e =
+        expectThrows(VeniceException.class, () -> zkHelixAdminClient.updateIdealState("cluster", "resource", 5, 3));
+    assertTrue(e.getMessage().contains("Invalid RF tuning params"));
   }
 }

--- a/services/venice-controller/src/test/java/com/linkedin/venice/pushmonitor/PartitionStatusBasedPushMonitorTest.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/pushmonitor/PartitionStatusBasedPushMonitorTest.java
@@ -34,6 +34,7 @@ import com.linkedin.venice.meta.StoreCleaner;
 import com.linkedin.venice.meta.Version;
 import com.linkedin.venice.meta.VersionImpl;
 import com.linkedin.venice.meta.VersionStatus;
+import com.linkedin.venice.utils.DataProviderUtils;
 import com.linkedin.venice.utils.HelixUtils;
 import com.linkedin.venice.utils.TestUtils;
 import com.linkedin.venice.utils.Time;
@@ -394,5 +395,101 @@ public class PartitionStatusBasedPushMonitorTest extends AbstractPushMonitorTest
     store.addVersion(new VersionImpl(store.getName(), 1, "", 3));
     store.setCurrentVersion(1);
     return store;
+  }
+
+  /**
+   * Tests that RF tuning is applied during version swap in the push monitor's handleCompletedPush path.
+   * When enabled: version RF metadata and Helix IdealState are updated for both current and backup.
+   * When disabled: no RF changes occur.
+   */
+  @Test(dataProvider = "True-and-False", dataProviderClass = DataProviderUtils.class)
+  public void testRfTuningOnVersionSwap(boolean rfTuningEnabled) {
+    // Configure RF tuning on the mock controller config
+    when(getMockControllerConfig().isRfTuningEnabled()).thenReturn(rfTuningEnabled);
+    if (rfTuningEnabled) {
+      when(getMockControllerConfig().getCurrentVersionRfCount()).thenReturn(4);
+      when(getMockControllerConfig().getCurrentVersionMinActiveReplicaCount()).thenReturn(3);
+      when(getMockControllerConfig().getBackupVersionRfCount()).thenReturn(2);
+      when(getMockControllerConfig().getBackupVersionMinActiveReplicaCount()).thenReturn(1);
+    }
+
+    // Create a fresh helixAdminClient mock for this test to isolate verification
+    HelixAdminClient testHelixAdminClient = mock(HelixAdminClient.class);
+
+    // Create a monitor with the updated config
+    AbstractPushMonitor testMonitor = new PartitionStatusBasedPushMonitor(
+        getClusterName(),
+        getMockAccessor(),
+        getMockStoreCleaner(),
+        getMockStoreRepo(),
+        getMockRoutingDataRepo(),
+        getMockPushHealthStats(),
+        mock(RealTimeTopicSwitcher.class),
+        getClusterLockManager(),
+        getAggregateRealTimeSourceKafkaUrl(),
+        Collections.emptyList(),
+        testHelixAdminClient,
+        getMockControllerConfig(),
+        null,
+        mock(DisabledPartitionStats.class),
+        getMockVeniceWriterFactory(),
+        getCurrentVersionChangeNotifier());
+
+    // Prepare mock store with v1 (current) and v2 (new push completing)
+    // Use mock versions to avoid ReadOnlyStore wrapper issues
+    String storeName = getStoreName();
+    String topicV2 = Version.composeKafkaTopic(storeName, 2);
+
+    Store store = mock(Store.class);
+    when(store.getName()).thenReturn(storeName);
+    when(store.getCurrentVersion()).thenReturn(1); // v1 is current
+    when(store.isEnableWrites()).thenReturn(true);
+
+    Version v1 = mock(Version.class);
+    when(v1.getNumber()).thenReturn(1);
+    when(v1.getStatus()).thenReturn(VersionStatus.ONLINE);
+    when(v1.kafkaTopicName()).thenReturn(Version.composeKafkaTopic(storeName, 1));
+
+    Version v2 = mock(Version.class);
+    when(v2.getNumber()).thenReturn(2);
+    when(v2.getStatus()).thenReturn(VersionStatus.STARTED);
+    when(v2.kafkaTopicName()).thenReturn(topicV2);
+    when(v2.isVersionSwapDeferred()).thenReturn(false);
+    when(v2.getTargetSwapRegion()).thenReturn("");
+
+    when(store.getVersion(1)).thenReturn(v1);
+    when(store.getVersion(2)).thenReturn(v2);
+    when(store.containsVersion(1)).thenReturn(true);
+    when(store.containsVersion(2)).thenReturn(true);
+    when(store.getVersions()).thenReturn(Arrays.asList(v1, v2));
+
+    // setCurrentVersion needs to update the return value
+    Mockito.doAnswer(inv -> {
+      when(store.getCurrentVersion()).thenReturn(inv.getArgument(0));
+      return null;
+    }).when(store).setCurrentVersion(anyInt());
+
+    doReturn(store).when(getMockStoreRepo()).getStore(storeName);
+
+    // Start monitoring the push for v2
+    testMonitor.startMonitorOfflinePush(topicV2, 1, 3, OfflinePushStrategy.WAIT_N_MINUS_ONE_REPLCIA_PER_PARTITION);
+
+    // Trigger completed push which invokes version swap + RF tuning
+    testMonitor.handleCompletedPush(topicV2);
+
+    if (rfTuningEnabled) {
+      // Verify version metadata RF was updated
+      verify(v2).setReplicationFactor(4);
+      verify(v1).setReplicationFactor(2);
+
+      // Verify Helix IdealState updates
+      verify(testHelixAdminClient).updateIdealState(getClusterName(), Version.composeKafkaTopic(storeName, 2), 3, 4);
+      verify(testHelixAdminClient).updateIdealState(getClusterName(), Version.composeKafkaTopic(storeName, 1), 1, 2);
+    } else {
+      // Verify no RF changes when disabled
+      verify(v1, never()).setReplicationFactor(anyInt());
+      verify(v2, never()).setReplicationFactor(anyInt());
+      verify(testHelixAdminClient, never()).updateIdealState(anyString(), anyString(), anyInt(), anyInt());
+    }
   }
 }


### PR DESCRIPTION
## Problem Statement

  Today, replication factor (RF) and MinActiveReplicas are tightly coupled — MinActiveReplicas is always derived as `RF - 1` (hardcoded in `VersionImpl.getMinActiveReplicas()`), and neither can be tuned per version lifecycle stage (future, current, backup).

  This makes it impossible to:
  - Run current versions at a higher RF (e.g., 4) for better fault tolerance while reducing backup versions to a lower RF (e.g., 2) to keep capacity neutral
  - Independently configure RF and MinActiveReplicas per version lifecycle stage
  - Tune these values per cluster via config without code changes

  ## Solution

  Introduces a configurable RF tuning framework behind a per-cluster feature flag (`controller.rf.tuning.enabled`) on child controllers. When enabled, the controller uses configurable RF and
  MinActiveReplicas values for each version lifecycle stage instead of deriving them from the store-level `replicationFactor`.

  **New config properties:**

  | Config key | Default | Description |
  |------------|---------|-------------|
  | `controller.rf.tuning.enabled` | `false` | Feature flag (per-cluster, child controller) |
  | `controller.future.version.rf.count` | `default.replica.factor` | RF for versions being ingested |
  | `controller.future.version.min.active.replica.count` | `future RF - 1` | MinActiveReplicas for future versions |
  | `controller.current.version.rf.count` | `default.replica.factor` | RF for the current serving version |
  | `controller.current.version.min.active.replica.count` | `current RF - 1` | MinActiveReplicas for current versions |
  | `controller.backup.version.rf.count` | `default.replica.factor` | RF for backup versions |
  | `controller.backup.version.min.active.replica.count` | `backup RF - 1` | MinActiveReplicas for backup versions |

  **Behavior when enabled:**

  At each version lifecycle transition, the controller updates both the version metadata RF (persisted to ZK) and the Helix IdealState:

  - **Version created (future):** RF set to `future.version.rf.count`, Helix resource created with configured RF/MinActiveReplicas
  - **Version promoted to current:** Version RF updated to `current.version.rf.count`, Helix IdealState updated
  - **Version demoted to backup:** Version RF updated to `backup.version.rf.count`, Helix IdealState updated (MinActiveReplicas lowered first, then numReplicas reduced)

  **When disabled:** All defaults fall back to the existing `default.replica.factor` value, making this a complete no-op. The existing `controller.backup.version.replica.reduction.enabled` behavior
   is preserved as a fallback.

**NOTE:** While the `min.active.replica.count` configs are accepted and applied to the Helix IdealState, `VersionImpl.getMinActiveReplicas()` still returns `RF - 1`. This means push monitoring, version swap readiness checks, and other controller-side decision logic always derive MinActiveReplicas from the version's RF rather than using the independently configured value. _This will be addressed in a followup pr_

  ### Code changes
  - [x] Added new code behind **a config**. Config names and defaults listed in the table above. All configs default to existing behavior (store-level RF and RF-1 for MinActiveReplicas) so enabling
   the flag alone with no other config changes is a no-op.
  - [x] Introduced new **log lines**.
    - [x] Confirmed logs are within existing per-store per-version iteration — not a new hot path, no rate limiting needed.

  ### Concurrency-Specific Checks
  - [x] Code has **no race conditions** or **thread safety issues**. All version RF updates happen inside existing `storeMetadataUpdate` lambdas which hold the store write lock. Helix IdealState
  updates are atomic ZK writes.
  - [x] Proper **synchronization mechanisms** are used — leverages existing `storeMetadataUpdate` store write lock pattern.
  - [x] No **blocking calls** inside critical sections.
  - [x] No new collections introduced — uses existing config loading and version metadata patterns.
  - [x] Exception handling follows existing patterns in all modified methods.

  ## How was this PR tested?

  - [x] New unit tests added.
    - `TestStoreBackupVersionCleanupService`: 2 new tests — verifies backup reduction uses configured RF/MinActiveReplicas when tuning enabled, and no reduction when disabled
    - `TestZkHelixAdminClient`: 2 new tests — verifies Helix resource creation uses `futureVersionRfCount` when tuning enabled, and store-level RF when disabled
    - `TestVeniceHelixAdmin`: 1 parameterized test (2 cases) — verifies full version lifecycle RF transitions during `rollForwardToFutureVersion` with tuning enabled/disabled
  - [ ] New integration tests added.
  - [x] Modified or extended existing tests. Updated `testCleanupBackupVersion_OnlyOneBackupVersion` to use RF tuning path.
  - [x] Verified backward compatibility — all defaults match existing behavior; feature flag defaults to `false`.

  ## Does this PR introduce any user-facing or breaking changes?

  - [x] No. You can skip the rest of this section.