### PR TITLE
[docker] Use block-based RocksDB format by default in Docker configs and update block cache size

### DIFF
--- a/docker/venice-server/multi-dc-configs/dc-0/server.properties
+++ b/docker/venice-server/multi-dc-configs/dc-0/server.properties
@@ -1,5 +1,5 @@
 rocksdb.options.use.direct.reads=false
-rocksdb.plain.table.format.enabled=true
+rocksdb.plain.table.format.enabled=false
 server.netty.graceful.shutdown.period.seconds=0
 r2d2Client.zkHosts=zookeeper.dc-0.venicedb.io:2181
 server.promotion.to.leader.replica.delay.seconds=1

--- a/docker/venice-server/multi-dc-configs/dc-0/server.properties
+++ b/docker/venice-server/multi-dc-configs/dc-0/server.properties
@@ -15,5 +15,6 @@ server.partition.graceful.drop.time.in.seconds=0
 system.schema.cluster.name=venice-cluster0
 data.base.path=/opt/venice/rocksdb
 persistence.type=ROCKS_DB
+rocksdb.block.cache.size.in.bytes=2147483648
 rocksdb.sst.file.manager.delete.rate.bytes.per.second=524288000
 rocksdb.sst.file.manager.max.trash.db.ratio=0.25

--- a/docker/venice-server/multi-dc-configs/dc-1/server.properties
+++ b/docker/venice-server/multi-dc-configs/dc-1/server.properties
@@ -1,5 +1,5 @@
 rocksdb.options.use.direct.reads=false
-rocksdb.plain.table.format.enabled=true
+rocksdb.plain.table.format.enabled=false
 server.netty.graceful.shutdown.period.seconds=0
 r2d2Client.zkHosts=zookeeper.dc-1.venicedb.io:2181
 server.promotion.to.leader.replica.delay.seconds=1

--- a/docker/venice-server/multi-dc-configs/dc-1/server.properties
+++ b/docker/venice-server/multi-dc-configs/dc-1/server.properties
@@ -15,5 +15,6 @@ server.partition.graceful.drop.time.in.seconds=0
 system.schema.cluster.name=venice-cluster0
 data.base.path=/opt/venice/rocksdb
 persistence.type=ROCKS_DB
+rocksdb.block.cache.size.in.bytes=2147483648
 rocksdb.sst.file.manager.delete.rate.bytes.per.second=524288000
 rocksdb.sst.file.manager.max.trash.db.ratio=0.25

--- a/docker/venice-server/single-dc-configs/server.properties
+++ b/docker/venice-server/single-dc-configs/server.properties
@@ -1,5 +1,5 @@
 rocksdb.options.use.direct.reads=false
-rocksdb.plain.table.format.enabled=true
+rocksdb.plain.table.format.enabled=false
 server.netty.graceful.shutdown.period.seconds=0
 r2d2Client.zkHosts=zookeeper:2181
 server.promotion.to.leader.replica.delay.seconds=1


### PR DESCRIPTION
## Problem Statement

The Docker server config examples have `rocksdb.plain.table.format.enabled=true`, which enables plain table format. Plain table format requires mmap reads and is designed for read-only workloads on memory-mapped filesystems — it is not suitable for members outside of LinkedIn to start off with as it requires more expertise.

Additionally, the multi dc docker configs are using the default block cache size of 16GB which is too much for small docker environments.

## Solution

Set `rocksdb.plain.table.format.enabled=false` in all three Docker server config files to default to block-based table format, which is the standard RocksDB format suitable for general production use.

Set block cache size to 2GB for the multi dc docker configs.

###  Code changes
- [ ] Added new code behind **a config**.
- [ ] Introduced new **log lines**.
  - [ ] Confirmed if logs need to be **rate limited** to avoid excessive logging.

###  **Concurrency-Specific Checks**
Both reviewer and PR author to verify
- [x] Code has **no race conditions** or **thread safety issues**.
- [x] Proper **synchronization mechanisms** (e.g., `synchronized`, `RWLock`) are used where needed.
- [x] No **blocking calls** inside critical sections that could lead to deadlocks or performance degradation.
- [x] Verified **thread-safe collections** are used (e.g., `ConcurrentHashMap`, `CopyOnWriteArrayList`).
- [x] Validated proper exception handling in multi-threaded code to avoid silent thread termination.

## How was this PR tested?

- [ ] New unit tests added.
- [ ] New integration tests added.
- [ ] Modified or extended existing tests.
- [ ] Verified backward compatibility (if applicable).

## Does this PR introduce any user-facing or breaking changes?

- [x] No. You can skip the rest of this section.
