### PR TITLE
[controller] Register PARTITION_STATE and STORE_VERSION_STATE schemas at startup

### DIFF
--- a/internal/venice-common/src/main/java/com/linkedin/venice/ConfigKeys.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/ConfigKeys.java
@@ -716,6 +716,15 @@ public class ConfigKeys {
   public static final String SYSTEM_SCHEMA_INITIALIZATION_AT_START_TIME_ENABLED =
       "system.schema.initialization.at.start.time.enabled";
 
+  /**
+   * Whether to register PARTITION_STATE and STORE_VERSION_STATE schemas via
+   * ControllerClientBackedSystemSchemaInitializer at controller startup.
+   * Requires {@link #SYSTEM_SCHEMA_INITIALIZATION_AT_START_TIME_ENABLED} to also be true.
+   * Default: false.
+   */
+  public static final String CONTROLLER_STATE_PROTOCOL_SCHEMA_STARTUP_REGISTRATION_ENABLED =
+      "controller.state.protocol.schema.startup.registration.enabled";
+
   public static final String KME_REGISTRATION_FROM_MESSAGE_HEADER_ENABLED =
       "kme.registration.from.message.header.enabled";
 

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/helix/TestControllerStateProtocolSchemaStartupRegistration.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/helix/TestControllerStateProtocolSchemaStartupRegistration.java
@@ -76,20 +76,19 @@ public class TestControllerStateProtocolSchemaStartupRegistration {
     HelixReadWriteSchemaRepository repo =
         (HelixReadWriteSchemaRepository) adapter.getReadWriteRegularStoreSchemaRepository();
 
-    // With the flag enabled, every child controller startup runs ControllerClientBackedSystemSchemaInitializer
-    // for PARTITION_STATE and STORE_VERSION_STATE. The current protocol version of each schema must be
-    // registered in the system schema cluster.
+    // Every child controller startup runs ControllerClientBackedSystemSchemaInitializer for
+    // KAFKA_MESSAGE_ENVELOPE and METADATA_SYSTEM_SCHEMA_STORE, plus (when the flag is on) PARTITION_STATE
+    // and STORE_VERSION_STATE. The current protocol version of each schema must be registered in the
+    // system schema cluster.
+    AvroProtocolDefinition[] expectedSchemas =
+        { AvroProtocolDefinition.KAFKA_MESSAGE_ENVELOPE, AvroProtocolDefinition.METADATA_SYSTEM_SCHEMA_STORE,
+            AvroProtocolDefinition.PARTITION_STATE, AvroProtocolDefinition.STORE_VERSION_STATE };
     TestUtils.waitForNonDeterministicAssertion(30, TimeUnit.SECONDS, true, true, () -> {
-      Assert.assertNotNull(
-          repo.getValueSchema(
-              AvroProtocolDefinition.PARTITION_STATE.getSystemStoreName(),
-              AvroProtocolDefinition.PARTITION_STATE.getCurrentProtocolVersion()),
-          "PARTITION_STATE current schema should be registered after child controller startup");
-      Assert.assertNotNull(
-          repo.getValueSchema(
-              AvroProtocolDefinition.STORE_VERSION_STATE.getSystemStoreName(),
-              AvroProtocolDefinition.STORE_VERSION_STATE.getCurrentProtocolVersion()),
-          "STORE_VERSION_STATE current schema should be registered after child controller startup");
+      for (AvroProtocolDefinition protocol: expectedSchemas) {
+        Assert.assertNotNull(
+            repo.getValueSchema(protocol.getSystemStoreName(), protocol.getCurrentProtocolVersion()),
+            protocol.name() + " current schema should be registered after child controller startup");
+      }
     });
   }
 }

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/helix/TestControllerStateProtocolSchemaStartupRegistration.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/helix/TestControllerStateProtocolSchemaStartupRegistration.java
@@ -1,0 +1,95 @@
+package com.linkedin.venice.helix;
+
+import static com.linkedin.venice.ConfigKeys.CONTROLLER_STATE_PROTOCOL_SCHEMA_STARTUP_REGISTRATION_ENABLED;
+import static com.linkedin.venice.ConfigKeys.DEFAULT_MAX_NUMBER_OF_PARTITIONS;
+import static com.linkedin.venice.ConfigKeys.DEFAULT_NUMBER_OF_PARTITION_FOR_HYBRID;
+import static com.linkedin.venice.ConfigKeys.DEFAULT_PARTITION_SIZE;
+
+import com.linkedin.venice.integration.utils.ServiceFactory;
+import com.linkedin.venice.integration.utils.VeniceControllerWrapper;
+import com.linkedin.venice.integration.utils.VeniceMultiClusterWrapper;
+import com.linkedin.venice.integration.utils.VeniceMultiRegionClusterCreateOptions;
+import com.linkedin.venice.integration.utils.VeniceTwoLayerMultiRegionMultiClusterWrapper;
+import com.linkedin.venice.serialization.avro.AvroProtocolDefinition;
+import com.linkedin.venice.utils.TestUtils;
+import com.linkedin.venice.utils.Utils;
+import java.util.List;
+import java.util.Properties;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.IntStream;
+import org.testng.Assert;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+
+public class TestControllerStateProtocolSchemaStartupRegistration {
+  private static final int TEST_TIMEOUT = 90_000; // ms
+  private static final int NUMBER_OF_CHILD_DATACENTERS = 1;
+  private static final int NUMBER_OF_CLUSTERS = 1;
+
+  private static final String[] CLUSTER_NAMES =
+      IntStream.range(0, NUMBER_OF_CLUSTERS).mapToObj(i -> "venice-cluster" + i).toArray(String[]::new);
+
+  private List<VeniceMultiClusterWrapper> childDatacenters;
+  private VeniceTwoLayerMultiRegionMultiClusterWrapper multiRegionMultiClusterWrapper;
+
+  @BeforeClass
+  public void setUp() {
+    Properties controllerProps = new Properties();
+    controllerProps.put(DEFAULT_NUMBER_OF_PARTITION_FOR_HYBRID, 2);
+    controllerProps.put(DEFAULT_MAX_NUMBER_OF_PARTITIONS, 3);
+    controllerProps.put(DEFAULT_PARTITION_SIZE, 1024);
+    controllerProps.put(CONTROLLER_STATE_PROTOCOL_SCHEMA_STARTUP_REGISTRATION_ENABLED, true);
+    VeniceMultiRegionClusterCreateOptions.Builder optionsBuilder =
+        new VeniceMultiRegionClusterCreateOptions.Builder().numberOfRegions(NUMBER_OF_CHILD_DATACENTERS)
+            .numberOfClusters(NUMBER_OF_CLUSTERS)
+            .numberOfParentControllers(1)
+            .numberOfChildControllers(3)
+            .numberOfServers(1)
+            .numberOfRouters(1)
+            .replicationFactor(1)
+            .forkServer(false)
+            .parentControllerProperties(controllerProps)
+            .childControllerProperties(controllerProps);
+    multiRegionMultiClusterWrapper =
+        ServiceFactory.getVeniceTwoLayerMultiRegionMultiClusterWrapper(optionsBuilder.build());
+
+    childDatacenters = multiRegionMultiClusterWrapper.getChildRegions();
+  }
+
+  @AfterClass(alwaysRun = true)
+  public void cleanUp() {
+    Utils.closeQuietlyWithErrorLogged(multiRegionMultiClusterWrapper);
+  }
+
+  @Test(timeOut = TEST_TIMEOUT)
+  public void testStateProtocolSchemasRegisteredAtChildControllerStartup() {
+    String systemSchemaCluster = CLUSTER_NAMES[0];
+    VeniceMultiClusterWrapper child = childDatacenters.get(0);
+    VeniceControllerWrapper systemSchemaLeader = child.getLeaderController(systemSchemaCluster);
+
+    HelixReadWriteSchemaRepositoryAdapter adapter =
+        (HelixReadWriteSchemaRepositoryAdapter) systemSchemaLeader.getVeniceHelixAdmin()
+            .getHelixVeniceClusterResources(systemSchemaCluster)
+            .getSchemaRepository();
+    HelixReadWriteSchemaRepository repo =
+        (HelixReadWriteSchemaRepository) adapter.getReadWriteRegularStoreSchemaRepository();
+
+    // With the flag enabled, every child controller startup runs ControllerClientBackedSystemSchemaInitializer
+    // for PARTITION_STATE and STORE_VERSION_STATE. The current protocol version of each schema must be
+    // registered in the system schema cluster.
+    TestUtils.waitForNonDeterministicAssertion(30, TimeUnit.SECONDS, true, true, () -> {
+      Assert.assertNotNull(
+          repo.getValueSchema(
+              AvroProtocolDefinition.PARTITION_STATE.getSystemStoreName(),
+              AvroProtocolDefinition.PARTITION_STATE.getCurrentProtocolVersion()),
+          "PARTITION_STATE current schema should be registered after child controller startup");
+      Assert.assertNotNull(
+          repo.getValueSchema(
+              AvroProtocolDefinition.STORE_VERSION_STATE.getSystemStoreName(),
+              AvroProtocolDefinition.STORE_VERSION_STATE.getCurrentProtocolVersion()),
+          "STORE_VERSION_STATE current schema should be registered after child controller startup");
+    });
+  }
+}

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceController.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceController.java
@@ -515,6 +515,38 @@ public class VeniceController {
               d2ZkHost,
               sslOnly);
       kmeSchemaInitializer.execute();
+
+      if (systemStoreClusterConfig.isStateProtocolSchemaStartupRegistrationEnabled()) {
+        ControllerClientBackedSystemSchemaInitializer partitionStateSchemaInitializer =
+            new ControllerClientBackedSystemSchemaInitializer(
+                AvroProtocolDefinition.PARTITION_STATE,
+                systemStoreCluster,
+                null,
+                null,
+                false,
+                ((VeniceHelixAdmin) admin).getSslFactory(),
+                childControllerUrl,
+                d2ServiceName,
+                regionD2Client,
+                d2ZkHost,
+                sslOnly);
+        partitionStateSchemaInitializer.execute();
+
+        ControllerClientBackedSystemSchemaInitializer storeVersionStateSchemaInitializer =
+            new ControllerClientBackedSystemSchemaInitializer(
+                AvroProtocolDefinition.STORE_VERSION_STATE,
+                systemStoreCluster,
+                null,
+                null,
+                false,
+                ((VeniceHelixAdmin) admin).getSslFactory(),
+                childControllerUrl,
+                d2ServiceName,
+                regionD2Client,
+                d2ZkHost,
+                sslOnly);
+        storeVersionStateSchemaInitializer.execute();
+      }
     }
   }
 

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceController.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceController.java
@@ -1,6 +1,6 @@
 package com.linkedin.venice.controller;
 
-import static com.linkedin.venice.ConfigKeys.ZOOKEEPER_ADDRESS;
+import static com.linkedin.venice.ConfigKeys.*;
 
 import com.linkedin.d2.balancer.D2Client;
 import com.linkedin.venice.SSLConfig;
@@ -487,6 +487,7 @@ public class VeniceController {
       String d2ZkHost = systemStoreClusterConfig.getChildControllerD2ZkHost(regionName);
       Optional<D2Client> regionD2Client = Optional.ofNullable(d2Clients == null ? null : d2Clients.get(regionName));
       boolean sslOnly = systemStoreClusterConfig.isControllerEnforceSSLOnly();
+      Optional<SSLFactory> sslFactory = ((VeniceHelixAdmin) admin).getSslFactory();
       if (multiClusterConfigs.isZkSharedMetaSystemSchemaStoreAutoCreationEnabled()) {
         createAndExecuteSchemaInitializer(
             AvroProtocolDefinition.METADATA_SYSTEM_SCHEMA_STORE,
@@ -494,7 +495,7 @@ public class VeniceController {
             AvroProtocolDefinition.METADATA_SYSTEM_SCHEMA_STORE_KEY.getCurrentProtocolVersionSchema(),
             VeniceSystemStoreUtils.DEFAULT_USER_SYSTEM_STORE_UPDATE_QUERY_PARAMS,
             true,
-            admin,
+            sslFactory,
             childControllerUrl,
             d2ServiceName,
             regionD2Client,
@@ -504,7 +505,10 @@ public class VeniceController {
       createAndExecuteSchemaInitializer(
           AvroProtocolDefinition.KAFKA_MESSAGE_ENVELOPE,
           systemStoreCluster,
-          admin,
+          null,
+          null,
+          false,
+          sslFactory,
           childControllerUrl,
           d2ServiceName,
           regionD2Client,
@@ -515,7 +519,10 @@ public class VeniceController {
         createAndExecuteSchemaInitializer(
             AvroProtocolDefinition.PARTITION_STATE,
             systemStoreCluster,
-            admin,
+            null,
+            null,
+            false,
+            sslFactory,
             childControllerUrl,
             d2ServiceName,
             regionD2Client,
@@ -524,7 +531,10 @@ public class VeniceController {
         createAndExecuteSchemaInitializer(
             AvroProtocolDefinition.STORE_VERSION_STATE,
             systemStoreCluster,
-            admin,
+            null,
+            null,
+            false,
+            sslFactory,
             childControllerUrl,
             d2ServiceName,
             regionD2Client,
@@ -537,33 +547,10 @@ public class VeniceController {
   private static void createAndExecuteSchemaInitializer(
       AvroProtocolDefinition protocolDefinition,
       String systemStoreCluster,
-      Admin admin,
-      String childControllerUrl,
-      String d2ServiceName,
-      Optional<D2Client> regionD2Client,
-      String d2ZkHost,
-      boolean sslOnly) {
-    createAndExecuteSchemaInitializer(
-        protocolDefinition,
-        systemStoreCluster,
-        null,
-        null,
-        false,
-        admin,
-        childControllerUrl,
-        d2ServiceName,
-        regionD2Client,
-        d2ZkHost,
-        sslOnly);
-  }
-
-  private static void createAndExecuteSchemaInitializer(
-      AvroProtocolDefinition protocolDefinition,
-      String systemStoreCluster,
       Schema keySchema,
       UpdateStoreQueryParams storeMetadataUpdate,
       boolean autoRegisterDerivedSchema,
-      Admin admin,
+      Optional<SSLFactory> sslFactory,
       String childControllerUrl,
       String d2ServiceName,
       Optional<D2Client> regionD2Client,
@@ -575,7 +562,7 @@ public class VeniceController {
         keySchema,
         storeMetadataUpdate,
         autoRegisterDerivedSchema,
-        ((VeniceHelixAdmin) admin).getSslFactory(),
+        sslFactory,
         childControllerUrl,
         d2ServiceName,
         regionD2Client,

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceController.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceController.java
@@ -1,6 +1,6 @@
 package com.linkedin.venice.controller;
 
-import static com.linkedin.venice.ConfigKeys.*;
+import static com.linkedin.venice.ConfigKeys.ZOOKEEPER_ADDRESS;
 
 import com.linkedin.d2.balancer.D2Client;
 import com.linkedin.venice.SSLConfig;

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceController.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceController.java
@@ -501,53 +501,60 @@ public class VeniceController {
                 sslOnly);
         metaSystemStoreSchemaInitializer.execute();
       }
-      ControllerClientBackedSystemSchemaInitializer kmeSchemaInitializer =
-          new ControllerClientBackedSystemSchemaInitializer(
-              AvroProtocolDefinition.KAFKA_MESSAGE_ENVELOPE,
-              systemStoreCluster,
-              null,
-              null,
-              false,
-              ((VeniceHelixAdmin) admin).getSslFactory(),
-              childControllerUrl,
-              d2ServiceName,
-              regionD2Client,
-              d2ZkHost,
-              sslOnly);
-      kmeSchemaInitializer.execute();
+      createAndExecuteSchemaInitializer(
+          AvroProtocolDefinition.KAFKA_MESSAGE_ENVELOPE,
+          systemStoreCluster,
+          admin,
+          childControllerUrl,
+          d2ServiceName,
+          regionD2Client,
+          d2ZkHost,
+          sslOnly);
 
       if (systemStoreClusterConfig.isStateProtocolSchemaStartupRegistrationEnabled()) {
-        ControllerClientBackedSystemSchemaInitializer partitionStateSchemaInitializer =
-            new ControllerClientBackedSystemSchemaInitializer(
-                AvroProtocolDefinition.PARTITION_STATE,
-                systemStoreCluster,
-                null,
-                null,
-                false,
-                ((VeniceHelixAdmin) admin).getSslFactory(),
-                childControllerUrl,
-                d2ServiceName,
-                regionD2Client,
-                d2ZkHost,
-                sslOnly);
-        partitionStateSchemaInitializer.execute();
-
-        ControllerClientBackedSystemSchemaInitializer storeVersionStateSchemaInitializer =
-            new ControllerClientBackedSystemSchemaInitializer(
-                AvroProtocolDefinition.STORE_VERSION_STATE,
-                systemStoreCluster,
-                null,
-                null,
-                false,
-                ((VeniceHelixAdmin) admin).getSslFactory(),
-                childControllerUrl,
-                d2ServiceName,
-                regionD2Client,
-                d2ZkHost,
-                sslOnly);
-        storeVersionStateSchemaInitializer.execute();
+        createAndExecuteSchemaInitializer(
+            AvroProtocolDefinition.PARTITION_STATE,
+            systemStoreCluster,
+            admin,
+            childControllerUrl,
+            d2ServiceName,
+            regionD2Client,
+            d2ZkHost,
+            sslOnly);
+        createAndExecuteSchemaInitializer(
+            AvroProtocolDefinition.STORE_VERSION_STATE,
+            systemStoreCluster,
+            admin,
+            childControllerUrl,
+            d2ServiceName,
+            regionD2Client,
+            d2ZkHost,
+            sslOnly);
       }
     }
+  }
+
+  private static void createAndExecuteSchemaInitializer(
+      AvroProtocolDefinition protocolDefinition,
+      String systemStoreCluster,
+      Admin admin,
+      String childControllerUrl,
+      String d2ServiceName,
+      Optional<D2Client> regionD2Client,
+      String d2ZkHost,
+      boolean sslOnly) {
+    new ControllerClientBackedSystemSchemaInitializer(
+        protocolDefinition,
+        systemStoreCluster,
+        null,
+        null,
+        false,
+        ((VeniceHelixAdmin) admin).getSslFactory(),
+        childControllerUrl,
+        d2ServiceName,
+        regionD2Client,
+        d2ZkHost,
+        sslOnly).execute();
   }
 
   /**

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceController.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceController.java
@@ -569,7 +569,7 @@ public class VeniceController {
       Optional<D2Client> regionD2Client,
       String d2ZkHost,
       boolean sslOnly) {
-    new ControllerClientBackedSystemSchemaInitializer(
+    try (ControllerClientBackedSystemSchemaInitializer initializer = new ControllerClientBackedSystemSchemaInitializer(
         protocolDefinition,
         systemStoreCluster,
         keySchema,
@@ -580,7 +580,9 @@ public class VeniceController {
         d2ServiceName,
         regionD2Client,
         d2ZkHost,
-        sslOnly).execute();
+        sslOnly)) {
+      initializer.execute();
+    }
   }
 
   /**

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceController.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceController.java
@@ -36,6 +36,7 @@ import com.linkedin.venice.controller.stats.TopicCleanupServiceStats;
 import com.linkedin.venice.controller.stats.VeniceAdminStats;
 import com.linkedin.venice.controller.supersetschema.SupersetSchemaGenerator;
 import com.linkedin.venice.controller.systemstore.SystemStoreRepairService;
+import com.linkedin.venice.controllerapi.UpdateStoreQueryParams;
 import com.linkedin.venice.d2.D2ClientFactory;
 import com.linkedin.venice.exceptions.VeniceException;
 import com.linkedin.venice.grpc.VeniceGrpcServer;
@@ -71,6 +72,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.ThreadPoolExecutor;
+import org.apache.avro.Schema;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -486,20 +488,18 @@ public class VeniceController {
       Optional<D2Client> regionD2Client = Optional.ofNullable(d2Clients == null ? null : d2Clients.get(regionName));
       boolean sslOnly = systemStoreClusterConfig.isControllerEnforceSSLOnly();
       if (multiClusterConfigs.isZkSharedMetaSystemSchemaStoreAutoCreationEnabled()) {
-        ControllerClientBackedSystemSchemaInitializer metaSystemStoreSchemaInitializer =
-            new ControllerClientBackedSystemSchemaInitializer(
-                AvroProtocolDefinition.METADATA_SYSTEM_SCHEMA_STORE,
-                systemStoreCluster,
-                AvroProtocolDefinition.METADATA_SYSTEM_SCHEMA_STORE_KEY.getCurrentProtocolVersionSchema(),
-                VeniceSystemStoreUtils.DEFAULT_USER_SYSTEM_STORE_UPDATE_QUERY_PARAMS,
-                true,
-                ((VeniceHelixAdmin) admin).getSslFactory(),
-                childControllerUrl,
-                d2ServiceName,
-                regionD2Client,
-                d2ZkHost,
-                sslOnly);
-        metaSystemStoreSchemaInitializer.execute();
+        createAndExecuteSchemaInitializer(
+            AvroProtocolDefinition.METADATA_SYSTEM_SCHEMA_STORE,
+            systemStoreCluster,
+            AvroProtocolDefinition.METADATA_SYSTEM_SCHEMA_STORE_KEY.getCurrentProtocolVersionSchema(),
+            VeniceSystemStoreUtils.DEFAULT_USER_SYSTEM_STORE_UPDATE_QUERY_PARAMS,
+            true,
+            admin,
+            childControllerUrl,
+            d2ServiceName,
+            regionD2Client,
+            d2ZkHost,
+            sslOnly);
       }
       createAndExecuteSchemaInitializer(
           AvroProtocolDefinition.KAFKA_MESSAGE_ENVELOPE,
@@ -543,12 +543,38 @@ public class VeniceController {
       Optional<D2Client> regionD2Client,
       String d2ZkHost,
       boolean sslOnly) {
-    new ControllerClientBackedSystemSchemaInitializer(
+    createAndExecuteSchemaInitializer(
         protocolDefinition,
         systemStoreCluster,
         null,
         null,
         false,
+        admin,
+        childControllerUrl,
+        d2ServiceName,
+        regionD2Client,
+        d2ZkHost,
+        sslOnly);
+  }
+
+  private static void createAndExecuteSchemaInitializer(
+      AvroProtocolDefinition protocolDefinition,
+      String systemStoreCluster,
+      Schema keySchema,
+      UpdateStoreQueryParams storeMetadataUpdate,
+      boolean autoRegisterDerivedSchema,
+      Admin admin,
+      String childControllerUrl,
+      String d2ServiceName,
+      Optional<D2Client> regionD2Client,
+      String d2ZkHost,
+      boolean sslOnly) {
+    new ControllerClientBackedSystemSchemaInitializer(
+        protocolDefinition,
+        systemStoreCluster,
+        keySchema,
+        storeMetadataUpdate,
+        autoRegisterDerivedSchema,
         ((VeniceHelixAdmin) admin).getSslFactory(),
         childControllerUrl,
         d2ServiceName,

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceControllerClusterConfig.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceControllerClusterConfig.java
@@ -100,6 +100,7 @@ import static com.linkedin.venice.ConfigKeys.CONTROLLER_REPUSH_PREFIX;
 import static com.linkedin.venice.ConfigKeys.CONTROLLER_RESOURCE_INSTANCE_GROUP_TAG;
 import static com.linkedin.venice.ConfigKeys.CONTROLLER_SCHEMA_VALIDATION_ENABLED;
 import static com.linkedin.venice.ConfigKeys.CONTROLLER_SSL_ENABLED;
+import static com.linkedin.venice.ConfigKeys.CONTROLLER_STATE_PROTOCOL_SCHEMA_STARTUP_REGISTRATION_ENABLED;
 import static com.linkedin.venice.ConfigKeys.CONTROLLER_STORAGE_CLUSTER_HELIX_CLOUD_ENABLED;
 import static com.linkedin.venice.ConfigKeys.CONTROLLER_STORE_GRAVEYARD_CLEANUP_DELAY_MINUTES;
 import static com.linkedin.venice.ConfigKeys.CONTROLLER_STORE_GRAVEYARD_CLEANUP_ENABLED;
@@ -480,6 +481,8 @@ public class VeniceControllerClusterConfig {
   private final boolean parentExternalSupersetSchemaGenerationEnabled;
 
   private final boolean systemSchemaInitializationAtStartTimeEnabled;
+
+  private final boolean stateProtocolSchemaStartupRegistrationEnabled;
 
   private final boolean isKMERegistrationFromMessageHeaderEnabled;
   private final boolean producerTimestampFallbackEnabled;
@@ -1194,6 +1197,8 @@ public class VeniceControllerClusterConfig {
         props.getBoolean(CONTROLLER_PARENT_EXTERNAL_SUPERSET_SCHEMA_GENERATION_ENABLED, false);
     this.systemSchemaInitializationAtStartTimeEnabled =
         props.getBoolean(SYSTEM_SCHEMA_INITIALIZATION_AT_START_TIME_ENABLED, false);
+    this.stateProtocolSchemaStartupRegistrationEnabled =
+        props.getBoolean(CONTROLLER_STATE_PROTOCOL_SCHEMA_STARTUP_REGISTRATION_ENABLED, false);
     this.isKMERegistrationFromMessageHeaderEnabled =
         props.getBoolean(KME_REGISTRATION_FROM_MESSAGE_HEADER_ENABLED, false);
     this.producerTimestampFallbackEnabled = props.getBoolean(PUBSUB_PRODUCER_TIMESTAMP_FALLBACK_ENABLED, true);
@@ -2204,6 +2209,10 @@ public class VeniceControllerClusterConfig {
 
   public boolean isSystemSchemaInitializationAtStartTimeEnabled() {
     return systemSchemaInitializationAtStartTimeEnabled;
+  }
+
+  public boolean isStateProtocolSchemaStartupRegistrationEnabled() {
+    return stateProtocolSchemaStartupRegistrationEnabled;
   }
 
   public boolean isKMERegistrationFromMessageHeaderEnabled() {

--- a/services/venice-controller/src/test/java/com/linkedin/venice/controller/TestVeniceControllerClusterConfig.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/controller/TestVeniceControllerClusterConfig.java
@@ -697,4 +697,19 @@ public class TestVeniceControllerClusterConfig {
     assertTrue(config.getUncleanLeaderElectionEnableRealTimeTopics().isPresent());
     assertTrue(config.getUncleanLeaderElectionEnableRealTimeTopics().get());
   }
+
+  @Test
+  public void testStateProtocolSchemaStartupRegistrationDefaultsToFalse() {
+    Properties baseProps = getBaseSingleRegionProperties(false);
+    VeniceControllerClusterConfig config = new VeniceControllerClusterConfig(new VeniceProperties(baseProps));
+    assertFalse(config.isStateProtocolSchemaStartupRegistrationEnabled());
+  }
+
+  @Test
+  public void testStateProtocolSchemaStartupRegistrationEnabled() {
+    Properties baseProps = getBaseSingleRegionProperties(false);
+    baseProps.put(ConfigKeys.CONTROLLER_STATE_PROTOCOL_SCHEMA_STARTUP_REGISTRATION_ENABLED, "true");
+    VeniceControllerClusterConfig config = new VeniceControllerClusterConfig(new VeniceProperties(baseProps));
+    assertTrue(config.isStateProtocolSchemaStartupRegistrationEnabled());
+  }
 }


### PR DESCRIPTION
## Problem Statement

During rolling deployments, servers deployed before the system schema cluster controller
crash-loop when attempting to fetch new PartitionState or StoreVersionState schema versions.
The schemas are only registered by SystemSchemaInitializationRoutine, which runs exclusively
on the leader of the designated system schema cluster.
If that controller hasn't been deployed yet, the schema is missing and servers fail.

KAFKA_MESSAGE_ENVELOPE already has a ControllerClientBackedSystemSchemaInitializer that runs
on any child controller at startup, avoiding this deployment ordering issue. PARTITION_STATE
and STORE_VERSION_STATE do not.

## Solution

Add ControllerClientBackedSystemSchemaInitializer for PARTITION_STATE and STORE_VERSION_STATE
alongside the existing KME initializer in VeniceController.java. Any child controller that
starts up will now register missing schema versions via the controller REST API.

### Code changes
- [x] New config flag `controller.state.protocol.schema.startup.registration.enabled` gates
      PARTITION_STATE and STORE_VERSION_STATE registration. Defaults to `false` for safe rollout.
      Requires `system.schema.initialization.at.start.time.enabled=true` to take effect.
- [x] No new log lines (ControllerClientBackedSystemSchemaInitializer already logs).

### Rollout
- [x] Default `false` — no behavior change on merge.
- [x] Enable per-region by setting `controller.state.protocol.schema.startup.registration.enabled=true`
      on child controllers (alongside the existing system schema init startup gate).
- [x] Roll out to EI first, monitor controller startup logs for schema registration, then prod.

### Concurrency-Specific Checks
- [x] N/A — runs at startup before serving traffic. Schema registration is idempotent.

## How was this PR tested?
- [x] Compilation verified locally.
- [x] The ControllerClientBackedSystemSchemaInitializer is already tested for KME — same code path.
- [x] Unit tests added for the new config flag (default `false` and enabled cases).
- [x] Verified the issue in EI: venice_system_store_PARTITION_STATE only had v1-v20, missing v21.

## Does this PR introduce any user-facing or breaking changes?
- [x] No. Schema registration is additive and idempotent. New flag defaults to off.