### PR TITLE
[server][test] Fix flaky testTehutiCrossIsolation

### DIFF
--- a/services/venice-server/src/test/java/com/linkedin/venice/stats/AggServerReadQuotaUsageStatsTest.java
+++ b/services/venice-server/src/test/java/com/linkedin/venice/stats/AggServerReadQuotaUsageStatsTest.java
@@ -97,20 +97,20 @@ public class AggServerReadQuotaUsageStatsTest {
     String rejectedQPS = "." + storeName + "--quota_rejected_request.Rate";
     String rejectedKPS = "." + storeName + "--quota_rejected_key_count.Rate";
     String unintentionalKPS = "." + storeName + "--quota_unintentionally_allowed_key_count.Count";
-    Assert.assertEquals(metricsRepository.getMetric(rejectedQPS).value(), 0d);
-    Assert.assertEquals(metricsRepository.getMetric(rejectedKPS).value(), 0d);
+    Assert.assertEquals(metricsRepository.getMetric(rejectedQPS).value(), 0d, 1e-6);
+    Assert.assertEquals(metricsRepository.getMetric(rejectedKPS).value(), 0d, 1e-6);
     // All sensors registered at construction time; unintentional count should be 0
-    Assert.assertEquals(metricsRepository.getMetric(unintentionalKPS).value(), 0d);
+    Assert.assertEquals(metricsRepository.getMetric(unintentionalKPS).value(), 0d, 1e-6);
 
     // Record only rejected — unintentional count should still be 0
     aggStats.recordRejected(storeName, 1, 50);
-    Assert.assertEquals(metricsRepository.getMetric(unintentionalKPS).value(), 0d);
+    Assert.assertEquals(metricsRepository.getMetric(unintentionalKPS).value(), 0d, 1e-6);
 
     // Now record unintentionally — rejected sensors should not change
     double rejectedQPSBefore = metricsRepository.getMetric(rejectedQPS).value();
     double rejectedKPSBefore = metricsRepository.getMetric(rejectedKPS).value();
     aggStats.recordAllowedUnintentionally(storeName, 1, 75);
-    Assert.assertEquals(metricsRepository.getMetric(rejectedQPS).value(), rejectedQPSBefore);
-    Assert.assertEquals(metricsRepository.getMetric(rejectedKPS).value(), rejectedKPSBefore);
+    Assert.assertEquals(metricsRepository.getMetric(rejectedQPS).value(), rejectedQPSBefore, 1e-6);
+    Assert.assertEquals(metricsRepository.getMetric(rejectedKPS).value(), rejectedKPSBefore, 1e-6);
   }
 }


### PR DESCRIPTION

## Problem Statement
AggServerReadQuotaUsageStatsTest.testTehutiCrossIsolation is flaky in CI. The test compares Rate metric values using exact assertEquals(double, double) with no delta tolerance.

## Solution
Add 1e-6 delta tolerance to all six exact double comparisons in testTehutiCrossIsolation.

###  Code changes
- [ ] Added new code behind **a config**. If so list the config names and their default values in the PR description.
- [ ] Introduced new **log lines**. 
  - [ ] Confirmed if logs need to be **rate limited** to avoid excessive logging.

###  **Concurrency-Specific Checks**
Both reviewer and PR author to verify
- [ ] Code has **no race conditions** or **thread safety issues**.
- [ ] Proper **synchronization mechanisms** (e.g., `synchronized`, `RWLock`) are used where needed.
- [ ] No **blocking calls** inside critical sections that could lead to deadlocks or performance degradation.
- [ ] Verified **thread-safe collections** are used (e.g., `ConcurrentHashMap`, `CopyOnWriteArrayList`).
- [ ] Validated proper exception handling in multi-threaded code to avoid silent thread termination.


## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->

- [ ] New unit tests added.
- [ ] New integration tests added.
- [ ] Modified or extended existing tests.
- [ ] Verified backward compatibility (if applicable).

## Does this PR introduce any user-facing or breaking changes?
<!--  
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [ ] No. You can skip the rest of this section.
- [ ] Yes. Clearly explain the behavior change and its impact.