### PR TITLE
[controller] Enforce min backup version cleanup delay at push start

### DIFF
--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/controller/AbstractTestVeniceHelixAdmin.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/controller/AbstractTestVeniceHelixAdmin.java
@@ -5,6 +5,7 @@ import static com.linkedin.venice.ConfigKeys.CLUSTER_NAME;
 import static com.linkedin.venice.ConfigKeys.CLUSTER_TO_D2;
 import static com.linkedin.venice.ConfigKeys.CLUSTER_TO_SERVER_D2;
 import static com.linkedin.venice.ConfigKeys.CONTROLLER_ADD_VERSION_VIA_ADMIN_PROTOCOL;
+import static com.linkedin.venice.ConfigKeys.CONTROLLER_BACKUP_VERSION_MIN_CLEANUP_DELAY_MS;
 import static com.linkedin.venice.ConfigKeys.CONTROLLER_INSTANCE_TAG_LIST;
 import static com.linkedin.venice.ConfigKeys.CONTROLLER_SSL_ENABLED;
 import static com.linkedin.venice.ConfigKeys.CONTROLLER_STORE_RECREATION_AFTER_DELETION_TIME_WINDOW_SECONDS;
@@ -314,6 +315,9 @@ class AbstractTestVeniceHelixAdmin {
     properties.put(CONTROLLER_SSL_ENABLED, false);
     // Set store recreation time window to 0 seconds by default to allow immediate recreation in tests
     properties.put(CONTROLLER_STORE_RECREATION_AFTER_DELETION_TIME_WINDOW_SECONDS, 0);
+    // Set min backup version cleanup delay to 0 by default so tests can push multiple versions
+    // in rapid succession without tripping the push-start capacity guard in VeniceHelixAdmin.
+    properties.put(CONTROLLER_BACKUP_VERSION_MIN_CLEANUP_DELAY_MS, 0);
     properties.putAll(PubSubBrokerWrapper.getBrokerDetailsForClients(Collections.singletonList(pubSubBrokerWrapper)));
     return properties;
   }

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/controller/TestParentControllerWithMultiDataCenter.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/controller/TestParentControllerWithMultiDataCenter.java
@@ -1,5 +1,6 @@
 package com.linkedin.venice.controller;
 
+import static com.linkedin.venice.ConfigKeys.CONTROLLER_BACKUP_VERSION_MIN_CLEANUP_DELAY_MS;
 import static com.linkedin.venice.ConfigKeys.DEFAULT_MAX_NUMBER_OF_PARTITIONS;
 import static com.linkedin.venice.ConfigKeys.DEFAULT_NUMBER_OF_PARTITION_FOR_HYBRID;
 import static com.linkedin.venice.ConfigKeys.DEFAULT_PARTITION_SIZE;
@@ -103,6 +104,10 @@ public class TestParentControllerWithMultiDataCenter {
     controllerProps.put(DEFAULT_NUMBER_OF_PARTITION_FOR_HYBRID, 2);
     controllerProps.put(DEFAULT_MAX_NUMBER_OF_PARTITIONS, 3);
     controllerProps.put(DEFAULT_PARTITION_SIZE, 1024);
+    // Set min backup version cleanup delay long enough to exercise the push-start capacity guard
+    // in testPushBlockedAfterRollbackWithinMinCleanupDelay. Safe for other tests — they do not
+    // push-then-rollback-then-push-again within this window.
+    controllerProps.put(CONTROLLER_BACKUP_VERSION_MIN_CLEANUP_DELAY_MS, TimeUnit.MINUTES.toMillis(1));
     Properties serverProps = new Properties();
     VeniceMultiRegionClusterCreateOptions.Builder optionsBuilder =
         new VeniceMultiRegionClusterCreateOptions.Builder().numberOfRegions(NUMBER_OF_CHILD_DATACENTERS)
@@ -650,6 +655,99 @@ public class TestParentControllerWithMultiDataCenter {
         });
       }
     }
+  }
+
+  /**
+   * After a rollback, v2 becomes ERROR and v1 becomes current. If an operator starts a new push
+   * within the min backup version cleanup delay window, the controller's capacity guard in
+   * {@link com.linkedin.venice.controller.VeniceHelixAdmin#checkBackupVersionCleanupCapacityForNewPush}
+   * should reject the push fast (not hang / retry indefinitely) so VPJ surfaces a clear error.
+   */
+  @Test(timeOut = TEST_TIMEOUT)
+  public void testPushBlockedAfterRollbackWithinMinCleanupDelay() throws IOException {
+    String clusterName = CLUSTER_NAMES[0];
+    String storeName = Utils.getUniqueString("pushBlockedAfterRollback");
+    String parentControllerURLs = multiRegionMultiClusterWrapper.getControllerConnectString();
+
+    File inputDir = getTempDataDirectory();
+    TestWriteUtils.writeSimpleAvroFileWithStringToV3Schema(inputDir, 100, 100);
+    String inputDirPath = "file://" + inputDir.getAbsolutePath();
+
+    // Create the store with the name-record schema that the VPJ will push.
+    Properties props =
+        IntegrationTestPushUtils.defaultVPJProps(multiRegionMultiClusterWrapper, inputDirPath, storeName);
+    try (
+        ControllerClient parentControllerClient = createStoreForJob(
+            clusterName,
+            "\"string\"",
+            TestWriteUtils.NAME_RECORD_V3_SCHEMA.toString(),
+            props,
+            new UpdateStoreQueryParams());
+        ControllerClient dc0Client =
+            new ControllerClient(clusterName, childDatacenters.get(0).getControllerConnectString());
+        ControllerClient dc1Client =
+            new ControllerClient(clusterName, childDatacenters.get(1).getControllerConnectString())) {
+      List<ControllerClient> childControllerClients = new ArrayList<>();
+      childControllerClients.add(dc0Client);
+      childControllerClients.add(dc1Client);
+
+      // Set up v1 current, v2 current via empty pushes.
+      emptyPushToStore(parentControllerClient, childControllerClients, storeName, 1);
+      emptyPushToStore(parentControllerClient, childControllerClients, storeName, 2);
+
+      // Rollback: v1 becomes current, v2 becomes ERROR. Promotion timestamp resets.
+      ControllerResponse rollbackResponse = parentControllerClient.rollbackToBackupVersion(storeName);
+      Assert.assertFalse(rollbackResponse.isError(), "rollback failed: " + rollbackResponse.getError());
+      for (ControllerClient childControllerClient: childControllerClients) {
+        TestUtils.waitForNonDeterministicAssertion(10, TimeUnit.SECONDS, false, true, () -> {
+          StoreResponse storeResponse = childControllerClient.getStore(storeName);
+          Assert.assertFalse(storeResponse.isError());
+          assertEquals(storeResponse.getStore().getCurrentVersion(), 1);
+        });
+      }
+
+      // Attempt a real VPJ v3 push. The capacity guard should reject it fast because v2 (ERROR)
+      // is pending deletion and latestVersionPromoteToCurrentTimestamp was just reset by the rollback.
+      long startMs = System.currentTimeMillis();
+      try (com.linkedin.venice.hadoop.VenicePushJob job =
+          new com.linkedin.venice.hadoop.VenicePushJob("venice-push-job-v3-" + storeName, props)) {
+        job.run();
+        fail("Expected VPJ to fail — capacity guard should block v3 push after rollback within min delay");
+      } catch (Exception e) {
+        long elapsedMs = System.currentTimeMillis() - startMs;
+        // Fast failure: must be well under TEST_TIMEOUT. 60s is generous but still proves no hang.
+        Assert
+            .assertTrue(elapsedMs < TimeUnit.SECONDS.toMillis(60), "VPJ should fail fast but took " + elapsedMs + "ms");
+        String fullMessage = collectExceptionMessages(e);
+        Assert.assertTrue(
+            fullMessage.contains("pending deletion") && fullMessage.contains("min cleanup delay"),
+            "Expected capacity-guard message in exception chain, got: " + fullMessage);
+      }
+
+      // Sanity: the capacity guard rejected before any v3 version was created.
+      StoreResponse finalStoreResponse = parentControllerClient.getStore(storeName);
+      Assert.assertFalse(finalStoreResponse.isError());
+      Assert.assertFalse(
+          finalStoreResponse.getStore().getVersion(3).isPresent(),
+          "Version 3 should NOT have been created after capacity-guard rejection");
+    }
+  }
+
+  /** Concatenate messages from the full exception cause chain. */
+  private static String collectExceptionMessages(Throwable t) {
+    StringBuilder sb = new StringBuilder();
+    Throwable cur = t;
+    while (cur != null) {
+      if (sb.length() > 0) {
+        sb.append(" | ");
+      }
+      sb.append(cur.getClass().getSimpleName()).append(": ").append(cur.getMessage());
+      if (cur.getCause() == cur) {
+        break;
+      }
+      cur = cur.getCause();
+    }
+    return sb.toString();
   }
 
   @Test

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/controller/TestParentControllerWithMultiDataCenter.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/controller/TestParentControllerWithMultiDataCenter.java
@@ -667,7 +667,6 @@ public class TestParentControllerWithMultiDataCenter {
   public void testPushBlockedAfterRollbackWithinMinCleanupDelay() throws IOException {
     String clusterName = CLUSTER_NAMES[0];
     String storeName = Utils.getUniqueString("pushBlockedAfterRollback");
-    String parentControllerURLs = multiRegionMultiClusterWrapper.getControllerConnectString();
 
     File inputDir = getTempDataDirectory();
     TestWriteUtils.writeSimpleAvroFileWithStringToV3Schema(inputDir, 100, 100);
@@ -712,8 +711,13 @@ public class TestParentControllerWithMultiDataCenter {
           new com.linkedin.venice.hadoop.VenicePushJob("venice-push-job-v3-" + storeName, props)) {
         job.run();
         fail("Expected VPJ to fail — capacity guard should block v3 push after rollback within min delay");
-      } catch (Exception expected) {
-        // Expected: capacity guard rejects the push.
+      } catch (Exception e) {
+        // Verify the failure is specifically from the capacity guard, not some unrelated issue.
+        // VPJ wraps the controller error message into its own exception message verbatim.
+        String message = e.getMessage();
+        Assert.assertTrue(
+            message != null && message.contains("pending deletion") && message.contains("min cleanup delay"),
+            "Expected capacity-guard message, got: " + message);
       }
 
       // Sanity: the capacity guard rejected before any v3 version was created.

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/controller/TestParentControllerWithMultiDataCenter.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/controller/TestParentControllerWithMultiDataCenter.java
@@ -706,22 +706,14 @@ public class TestParentControllerWithMultiDataCenter {
         });
       }
 
-      // Attempt a real VPJ v3 push. The capacity guard should reject it fast because v2 (ERROR)
-      // is pending deletion and latestVersionPromoteToCurrentTimestamp was just reset by the rollback.
-      long startMs = System.currentTimeMillis();
+      // Attempt a real VPJ v3 push. The capacity guard should reject it because v2 (ERROR) is
+      // pending deletion and latestVersionPromoteToCurrentTimestamp was just reset by the rollback.
       try (com.linkedin.venice.hadoop.VenicePushJob job =
           new com.linkedin.venice.hadoop.VenicePushJob("venice-push-job-v3-" + storeName, props)) {
         job.run();
         fail("Expected VPJ to fail — capacity guard should block v3 push after rollback within min delay");
-      } catch (Exception e) {
-        long elapsedMs = System.currentTimeMillis() - startMs;
-        // Fast failure: must be well under TEST_TIMEOUT. 60s is generous but still proves no hang.
-        Assert
-            .assertTrue(elapsedMs < TimeUnit.SECONDS.toMillis(60), "VPJ should fail fast but took " + elapsedMs + "ms");
-        String fullMessage = collectExceptionMessages(e);
-        Assert.assertTrue(
-            fullMessage.contains("pending deletion") && fullMessage.contains("min cleanup delay"),
-            "Expected capacity-guard message in exception chain, got: " + fullMessage);
+      } catch (Exception expected) {
+        // Expected: capacity guard rejects the push.
       }
 
       // Sanity: the capacity guard rejected before any v3 version was created.
@@ -731,23 +723,6 @@ public class TestParentControllerWithMultiDataCenter {
           finalStoreResponse.getStore().getVersion(3).isPresent(),
           "Version 3 should NOT have been created after capacity-guard rejection");
     }
-  }
-
-  /** Concatenate messages from the full exception cause chain. */
-  private static String collectExceptionMessages(Throwable t) {
-    StringBuilder sb = new StringBuilder();
-    Throwable cur = t;
-    while (cur != null) {
-      if (sb.length() > 0) {
-        sb.append(" | ");
-      }
-      sb.append(cur.getClass().getSimpleName()).append(": ").append(cur.getMessage());
-      if (cur.getCause() == cur) {
-        break;
-      }
-      cur = cur.getCause();
-    }
-    return sb.toString();
   }
 
   @Test

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/controller/TestParentControllerWithMultiDataCenter.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/controller/TestParentControllerWithMultiDataCenter.java
@@ -1,6 +1,5 @@
 package com.linkedin.venice.controller;
 
-import static com.linkedin.venice.ConfigKeys.CONTROLLER_BACKUP_VERSION_MIN_CLEANUP_DELAY_MS;
 import static com.linkedin.venice.ConfigKeys.DEFAULT_MAX_NUMBER_OF_PARTITIONS;
 import static com.linkedin.venice.ConfigKeys.DEFAULT_NUMBER_OF_PARTITION_FOR_HYBRID;
 import static com.linkedin.venice.ConfigKeys.DEFAULT_PARTITION_SIZE;
@@ -104,10 +103,6 @@ public class TestParentControllerWithMultiDataCenter {
     controllerProps.put(DEFAULT_NUMBER_OF_PARTITION_FOR_HYBRID, 2);
     controllerProps.put(DEFAULT_MAX_NUMBER_OF_PARTITIONS, 3);
     controllerProps.put(DEFAULT_PARTITION_SIZE, 1024);
-    // Set min backup version cleanup delay long enough to exercise the push-start capacity guard
-    // in testPushBlockedAfterRollbackWithinMinCleanupDelay. Safe for other tests — they do not
-    // push-then-rollback-then-push-again within this window.
-    controllerProps.put(CONTROLLER_BACKUP_VERSION_MIN_CLEANUP_DELAY_MS, TimeUnit.MINUTES.toMillis(1));
     Properties serverProps = new Properties();
     VeniceMultiRegionClusterCreateOptions.Builder optionsBuilder =
         new VeniceMultiRegionClusterCreateOptions.Builder().numberOfRegions(NUMBER_OF_CHILD_DATACENTERS)
@@ -654,78 +649,6 @@ public class TestParentControllerWithMultiDataCenter {
           assertEquals(storeInfo.getCurrentVersion(), 1);
         });
       }
-    }
-  }
-
-  /**
-   * After a rollback, v2 becomes ERROR and v1 becomes current. If an operator starts a new push
-   * within the min backup version cleanup delay window, the controller's capacity guard in
-   * {@link com.linkedin.venice.controller.VeniceHelixAdmin#checkBackupVersionCleanupCapacityForNewPush}
-   * should reject the push fast (not hang / retry indefinitely) so VPJ surfaces a clear error.
-   */
-  @Test(timeOut = TEST_TIMEOUT)
-  public void testPushBlockedAfterRollbackWithinMinCleanupDelay() throws IOException {
-    String clusterName = CLUSTER_NAMES[0];
-    String storeName = Utils.getUniqueString("pushBlockedAfterRollback");
-
-    File inputDir = getTempDataDirectory();
-    TestWriteUtils.writeSimpleAvroFileWithStringToV3Schema(inputDir, 100, 100);
-    String inputDirPath = "file://" + inputDir.getAbsolutePath();
-
-    // Create the store with the name-record schema that the VPJ will push.
-    Properties props =
-        IntegrationTestPushUtils.defaultVPJProps(multiRegionMultiClusterWrapper, inputDirPath, storeName);
-    try (
-        ControllerClient parentControllerClient = createStoreForJob(
-            clusterName,
-            "\"string\"",
-            TestWriteUtils.NAME_RECORD_V3_SCHEMA.toString(),
-            props,
-            new UpdateStoreQueryParams());
-        ControllerClient dc0Client =
-            new ControllerClient(clusterName, childDatacenters.get(0).getControllerConnectString());
-        ControllerClient dc1Client =
-            new ControllerClient(clusterName, childDatacenters.get(1).getControllerConnectString())) {
-      List<ControllerClient> childControllerClients = new ArrayList<>();
-      childControllerClients.add(dc0Client);
-      childControllerClients.add(dc1Client);
-
-      // Set up v1 current, v2 current via empty pushes.
-      emptyPushToStore(parentControllerClient, childControllerClients, storeName, 1);
-      emptyPushToStore(parentControllerClient, childControllerClients, storeName, 2);
-
-      // Rollback: v1 becomes current, v2 becomes ERROR. Promotion timestamp resets.
-      ControllerResponse rollbackResponse = parentControllerClient.rollbackToBackupVersion(storeName);
-      Assert.assertFalse(rollbackResponse.isError(), "rollback failed: " + rollbackResponse.getError());
-      for (ControllerClient childControllerClient: childControllerClients) {
-        TestUtils.waitForNonDeterministicAssertion(10, TimeUnit.SECONDS, false, true, () -> {
-          StoreResponse storeResponse = childControllerClient.getStore(storeName);
-          Assert.assertFalse(storeResponse.isError());
-          assertEquals(storeResponse.getStore().getCurrentVersion(), 1);
-        });
-      }
-
-      // Attempt a real VPJ v3 push. The capacity guard should reject it because v2 (ERROR) is
-      // pending deletion and latestVersionPromoteToCurrentTimestamp was just reset by the rollback.
-      try (com.linkedin.venice.hadoop.VenicePushJob job =
-          new com.linkedin.venice.hadoop.VenicePushJob("venice-push-job-v3-" + storeName, props)) {
-        job.run();
-        fail("Expected VPJ to fail — capacity guard should block v3 push after rollback within min delay");
-      } catch (Exception e) {
-        // Verify the failure is specifically from the capacity guard, not some unrelated issue.
-        // VPJ wraps the controller error message into its own exception message verbatim.
-        String message = e.getMessage();
-        Assert.assertTrue(
-            message != null && message.contains("pending deletion") && message.contains("min cleanup delay"),
-            "Expected capacity-guard message, got: " + message);
-      }
-
-      // Sanity: the capacity guard rejected before any v3 version was created.
-      StoreResponse finalStoreResponse = parentControllerClient.getStore(storeName);
-      Assert.assertFalse(finalStoreResponse.isError());
-      Assert.assertFalse(
-          finalStoreResponse.getStore().getVersion(3).isPresent(),
-          "Version 3 should NOT have been created after capacity-guard rejection");
     }
   }
 

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestPushBlockedWithinMinCleanupDelay.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestPushBlockedWithinMinCleanupDelay.java
@@ -1,0 +1,133 @@
+package com.linkedin.venice.endToEnd;
+
+import static com.linkedin.venice.ConfigKeys.CONTROLLER_BACKUP_VERSION_MIN_CLEANUP_DELAY_MS;
+import static com.linkedin.venice.ConfigKeys.DEFAULT_MAX_NUMBER_OF_PARTITIONS;
+import static com.linkedin.venice.ConfigKeys.DEFAULT_PARTITION_SIZE;
+import static com.linkedin.venice.ConfigKeys.TOPIC_CLEANUP_SLEEP_INTERVAL_BETWEEN_TOPIC_LIST_FETCH_MS;
+import static com.linkedin.venice.utils.IntegrationTestPushUtils.createStoreForJob;
+import static com.linkedin.venice.utils.TestWriteUtils.NAME_RECORD_V3_SCHEMA;
+import static com.linkedin.venice.utils.TestWriteUtils.getTempDataDirectory;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.fail;
+
+import com.linkedin.venice.controllerapi.ControllerClient;
+import com.linkedin.venice.controllerapi.ControllerResponse;
+import com.linkedin.venice.controllerapi.StoreResponse;
+import com.linkedin.venice.controllerapi.UpdateStoreQueryParams;
+import com.linkedin.venice.hadoop.VenicePushJob;
+import com.linkedin.venice.meta.Version;
+import com.linkedin.venice.utils.IntegrationTestPushUtils;
+import com.linkedin.venice.utils.TestUtils;
+import com.linkedin.venice.utils.TestWriteUtils;
+import com.linkedin.venice.utils.Utils;
+import java.io.File;
+import java.io.IOException;
+import java.util.Properties;
+import java.util.concurrent.TimeUnit;
+import org.testng.annotations.Test;
+
+
+/**
+ * Integration test for {@link com.linkedin.venice.controller.VeniceHelixAdmin#checkBackupVersionCleanupCapacityForNewPush}.
+ *
+ * <p>After a rollback, v2 becomes ERROR and v1 becomes current. If an operator starts a new push
+ * within the min backup version cleanup delay, the controller's capacity guard should reject the
+ * push so the VPJ surfaces a clear error instead of hanging.
+ *
+ * <p>The min cleanup delay is set to 1 minute at class level so the guard reliably fires within
+ * the test's lifetime. This is in its own test class so other classes don't inherit the delay.
+ */
+public class TestPushBlockedWithinMinCleanupDelay extends AbstractMultiRegionTest {
+  private static final int TEST_TIMEOUT = 180_000; // ms
+
+  @Override
+  protected int getNumberOfRegions() {
+    return 1;
+  }
+
+  @Override
+  protected int getNumberOfServers() {
+    return 1;
+  }
+
+  @Override
+  protected int getReplicationFactor() {
+    return 1;
+  }
+
+  @Override
+  protected Properties getExtraControllerProperties() {
+    Properties controllerProps = new Properties();
+    controllerProps.put(DEFAULT_MAX_NUMBER_OF_PARTITIONS, 1);
+    controllerProps.put(DEFAULT_PARTITION_SIZE, 10);
+    controllerProps
+        .setProperty(TOPIC_CLEANUP_SLEEP_INTERVAL_BETWEEN_TOPIC_LIST_FETCH_MS, String.valueOf(Long.MAX_VALUE));
+    // Override VeniceControllerWrapper's default (0) with a real value so the capacity guard fires.
+    controllerProps.put(CONTROLLER_BACKUP_VERSION_MIN_CLEANUP_DELAY_MS, TimeUnit.MINUTES.toMillis(1));
+    return controllerProps;
+  }
+
+  @Test(timeOut = TEST_TIMEOUT)
+  public void testPushBlockedAfterRollbackWithinMinCleanupDelay() throws IOException {
+    File inputDir = getTempDataDirectory();
+    TestWriteUtils.writeSimpleAvroFileWithStringToV3Schema(inputDir, 100, 100);
+    String inputDirPath = "file://" + inputDir.getAbsolutePath();
+    String storeName = Utils.getUniqueString("pushBlockedAfterRollback");
+
+    Properties props =
+        IntegrationTestPushUtils.defaultVPJProps(multiRegionMultiClusterWrapper, inputDirPath, storeName);
+    try (ControllerClient parentControllerClient = createStoreForJob(
+        CLUSTER_NAME,
+        "\"string\"",
+        NAME_RECORD_V3_SCHEMA.toString(),
+        props,
+        new UpdateStoreQueryParams())) {
+      // Push v1 and v2 via VPJ so the store has a real current version to roll back from.
+      IntegrationTestPushUtils.runVPJ(props);
+      TestUtils.waitForNonDeterministicPushCompletion(
+          Version.composeKafkaTopic(storeName, 1),
+          parentControllerClient,
+          30,
+          TimeUnit.SECONDS);
+      IntegrationTestPushUtils.runVPJ(props);
+      TestUtils.waitForNonDeterministicPushCompletion(
+          Version.composeKafkaTopic(storeName, 2),
+          parentControllerClient,
+          30,
+          TimeUnit.SECONDS);
+
+      TestUtils.waitForNonDeterministicAssertion(30, TimeUnit.SECONDS, () -> {
+        StoreResponse storeResponse = parentControllerClient.getStore(storeName);
+        assertFalse(storeResponse.isError(), "getStore error: " + storeResponse.getError());
+        assertEquals(storeResponse.getStore().getCurrentVersion(), 2);
+      });
+
+      // Rollback: v1 becomes current, v2 becomes ERROR, latestVersionPromoteToCurrentTimestamp resets.
+      ControllerResponse rollbackResponse = parentControllerClient.rollbackToBackupVersion(storeName);
+      assertFalse(rollbackResponse.isError(), "rollback failed: " + rollbackResponse.getError());
+
+      // Attempt a real VPJ v3 push. The capacity guard should reject it because v2 (ERROR) is
+      // pending deletion and latestVersionPromoteToCurrentTimestamp was just reset by the rollback.
+      try (VenicePushJob job = new VenicePushJob("venice-push-job-v3-" + storeName, props)) {
+        job.run();
+        fail("Expected VPJ to fail — capacity guard should block v3 push after rollback within min delay");
+      } catch (Exception e) {
+        // Verify the failure is specifically from the capacity guard, not some unrelated issue.
+        // VPJ wraps the controller error message into its own exception message verbatim.
+        String message = e.getMessage();
+        assertTrue(
+            message != null && message.contains("pending deletion") && message.contains("min cleanup delay"),
+            "Expected capacity-guard message, got: " + message);
+      }
+
+      // Sanity: the capacity guard rejected before any v3 version was created.
+      StoreResponse finalStoreResponse = parentControllerClient.getStore(storeName);
+      assertFalse(finalStoreResponse.isError());
+      assertFalse(
+          finalStoreResponse.getStore().getVersion(3).isPresent(),
+          "Version 3 should NOT have been created after capacity-guard rejection");
+    }
+  }
+}

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/integration/utils/VeniceControllerWrapper.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/integration/utils/VeniceControllerWrapper.java
@@ -17,6 +17,7 @@ import static com.linkedin.venice.ConfigKeys.CONCURRENT_INIT_ROUTINES_ENABLED;
 import static com.linkedin.venice.ConfigKeys.CONTROLLER_ADD_VERSION_VIA_ADMIN_PROTOCOL;
 import static com.linkedin.venice.ConfigKeys.CONTROLLER_ADMIN_GRPC_PORT;
 import static com.linkedin.venice.ConfigKeys.CONTROLLER_ADMIN_SECURE_GRPC_PORT;
+import static com.linkedin.venice.ConfigKeys.CONTROLLER_BACKUP_VERSION_MIN_CLEANUP_DELAY_MS;
 import static com.linkedin.venice.ConfigKeys.CONTROLLER_NAME;
 import static com.linkedin.venice.ConfigKeys.CONTROLLER_PARENT_MODE;
 import static com.linkedin.venice.ConfigKeys.CONTROLLER_SSL_ENABLED;
@@ -249,7 +250,11 @@ public class VeniceControllerWrapper extends ProcessWrapper {
             .put(extraProps.toProperties())
             // Set store recreation time window to 0 seconds by default to allow immediate recreation in tests
             // This is set after extraProps so tests can override it if needed
-            .putIfAbsent(CONTROLLER_STORE_RECREATION_AFTER_DELETION_TIME_WINDOW_SECONDS, 0);
+            .putIfAbsent(CONTROLLER_STORE_RECREATION_AFTER_DELETION_TIME_WINDOW_SECONDS, 0)
+            // Set min backup version cleanup delay to 0 by default so tests can push multiple versions
+            // in rapid succession without tripping the push-start capacity guard in VeniceHelixAdmin.
+            // Specific tests that exercise the delay can override this via extraProps.
+            .putIfAbsent(CONTROLLER_BACKUP_VERSION_MIN_CLEANUP_DELAY_MS, 0);
 
         if (sslEnabled) {
           builder.put(SslUtils.getVeniceLocalSslProperties());

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceHelixAdmin.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceHelixAdmin.java
@@ -3235,13 +3235,7 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
             return new Pair<>(false, null);
           }
 
-          // Capacity guard: if the current version was promoted within the min cleanup delay (e.g., from a
-          // recent rollback) and there are pending backup versions that cannot be deleted yet, starting a
-          // new push would exceed the hardware capacity provisioned for the store. Block the push.
-          // Behavior differs by backup strategy:
-          // - DELETE_ON_NEW_PUSH_START: hardware provisioned for 2x versions (current + new).
-          // - KEEP_MIN_VERSIONS: hardware provisioned for N+1 where N = store's configured versions to keep.
-          // Runs after the skipMigratingVersion early-return so migration no-ops don't trip the guard.
+          // Block the push if backup versions are pending deletion but still within the min cleanup delay.
           checkBackupVersionCleanupCapacityForNewPush(clusterName, storeName, store, store.getBackupStrategy());
           backupStrategy = store.getBackupStrategy();
           offlinePushStrategy = store.getOffLinePushStrategy();
@@ -4527,22 +4521,9 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
   }
 
   /**
-   * Verify there is capacity to start a new push without exceeding the store's hardware budget.
-   *
-   * <p>If there are backup versions that would normally be cleaned up at push start (or after push completion)
-   * but are still within the min backup version cleanup delay (e.g., the current version was just promoted via
-   * rollback), starting a new push would exceed provisioned capacity. Block the push in that case.
-   *
-   * <p>Behavior differs by backup strategy:
-   * <ul>
-   *   <li>{@code DELETE_ON_NEW_PUSH_START}: hardware provisioned for 2x versions (current + new). Old versions
-   *       are deleted at SOP, so any version beyond current would exceed capacity.</li>
-   *   <li>{@code KEEP_MIN_VERSIONS}: hardware provisioned for N+1 where N is the configured versions to keep
-   *       ({@link Store#getNumVersionsToPreserve()} or cluster default). Any version beyond N would exceed
-   *       capacity once a new push is added.</li>
-   * </ul>
-   *
-   * @throws VeniceException if the store has pending backup versions that cannot be deleted yet.
+   * Throws if starting a new push would exceed the store's version budget because existing backup
+   * versions are pending deletion but still within the min cleanup delay (e.g., after a rollback).
+   * Preserve count is {@code N-1} for {@code DELETE_ON_NEW_PUSH_START}, {@code N} otherwise.
    */
   private void checkBackupVersionCleanupCapacityForNewPush(
       String clusterName,
@@ -4559,10 +4540,7 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
         System.currentTimeMillis());
   }
 
-  /**
-   * Testable variant of {@link #checkBackupVersionCleanupCapacityForNewPush(String, String, Store, BackupStrategy)}
-   * that takes the config values and current time as parameters instead of reading from instance state.
-   */
+  /** Testable variant — config and time passed in. */
   static void checkBackupVersionCleanupCapacityForNewPush(
       String clusterName,
       String storeName,
@@ -4571,15 +4549,7 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
       int minNumberOfStoreVersionsToPreserve,
       long minBackupVersionCleanupDelay,
       long currentTimeMs) {
-    // Preserve count differs by strategy:
-    // - DELETE_ON_NEW_PUSH_START: mirror retireOldStoreVersions(deleteBackupOnStartPush=true) which passes N-1.
-    // The new push effectively "counts" as the Nth version, so at steady state we preserve N-1 non-current
-    // versions plus the current version.
-    // - KEEP_MIN_VERSIONS (and anything else): preserve N at steady state. retrieveVersionsToDelete will use
-    // the store-level override if set (Store.getNumVersionsToPreserve()); the passed value is a fallback.
-    // Clamp the fallback to at least 1 because Store.retrieveVersionsToDelete throws IllegalArgumentException
-    // if the passed value drops below 1 (e.g., when cluster config minNumberOfStoreVersionsToPreserve == 1 and
-    // the strategy decrement would take it to 0).
+    // Clamp to 1: retrieveVersionsToDelete throws if passed < 1 (cluster config can set N == 1).
     int numVersionToPreserve = Math.max(
         1,
         backupStrategy == BackupStrategy.DELETE_ON_NEW_PUSH_START
@@ -4632,11 +4602,7 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
         return;
       }
 
-      // Enforce the min backup version cleanup delay here as well as in StoreBackupVersionCleanupService.
-      // If the current version was just promoted (e.g., via a rollback that marked the ex-current as ERROR),
-      // deleting backup versions immediately can race with routers/servers/clients that haven't switched off
-      // the old current version yet. The periodic cleanup service or a subsequent push will handle deletion
-      // once the min delay has elapsed.
+      // Skip if within min cleanup delay; StoreBackupVersionCleanupService will pick it up later.
       long minBackupVersionCleanupDelay = multiClusterConfigs.getBackupVersionMinCleanupDelayMs();
       long minRetentionThreshold = store.getLatestVersionPromoteToCurrentTimestamp() + minBackupVersionCleanupDelay;
       if (System.currentTimeMillis() <= minRetentionThreshold) {

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceHelixAdmin.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceHelixAdmin.java
@@ -4595,8 +4595,9 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
        * If deleteBackupOnStartPush is true decrement minNumberOfStoreVersionsToPreserve by one
        * as newly started push is considered as another version. The code in retrieveVersionsToDelete
        * will not return any store if we pass minNumberOfStoreVersionsToPreserve during push.
+       * Clamp to at least 1 since retrieveVersionsToDelete rejects values < 1.
        */
-      int numVersionToPreserve = minNumberOfStoreVersionsToPreserve - (deleteBackupOnStartPush ? 1 : 0);
+      int numVersionToPreserve = Math.max(1, minNumberOfStoreVersionsToPreserve - (deleteBackupOnStartPush ? 1 : 0));
       List<Version> versionsToDelete = store.retrieveVersionsToDelete(numVersionToPreserve);
       if (versionsToDelete.isEmpty()) {
         return;

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceHelixAdmin.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceHelixAdmin.java
@@ -3220,14 +3220,6 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
           }
           currentVersionBeforePush = store.getCurrentVersion();
 
-          // Capacity guard: if the current version was promoted within the min cleanup delay (e.g., from a
-          // recent rollback) and there are pending backup versions that cannot be deleted yet, starting a
-          // new push would exceed the hardware capacity provisioned for the store. Block the push.
-          // Behavior differs by backup strategy:
-          // - DELETE_ON_NEW_PUSH_START: hardware provisioned for 2x versions (current + new).
-          // - KEEP_MIN_VERSIONS: hardware provisioned for N+1 where N = store's configured versions to keep.
-          checkBackupVersionCleanupCapacityForNewPush(clusterName, storeName, store, store.getBackupStrategy());
-
           // Dest child controllers skip the version whose kafka topic is truncated
           if (store.isMigrating() && skipMigratingVersion(clusterName, storeName, versionNumber)) {
 
@@ -3242,6 +3234,15 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
                 clusterName);
             return new Pair<>(false, null);
           }
+
+          // Capacity guard: if the current version was promoted within the min cleanup delay (e.g., from a
+          // recent rollback) and there are pending backup versions that cannot be deleted yet, starting a
+          // new push would exceed the hardware capacity provisioned for the store. Block the push.
+          // Behavior differs by backup strategy:
+          // - DELETE_ON_NEW_PUSH_START: hardware provisioned for 2x versions (current + new).
+          // - KEEP_MIN_VERSIONS: hardware provisioned for N+1 where N = store's configured versions to keep.
+          // Runs after the skipMigratingVersion early-return so migration no-ops don't trip the guard.
+          checkBackupVersionCleanupCapacityForNewPush(clusterName, storeName, store, store.getBackupStrategy());
           backupStrategy = store.getBackupStrategy();
           offlinePushStrategy = store.getOffLinePushStrategy();
 
@@ -4576,9 +4577,14 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
     // versions plus the current version.
     // - KEEP_MIN_VERSIONS (and anything else): preserve N at steady state. retrieveVersionsToDelete will use
     // the store-level override if set (Store.getNumVersionsToPreserve()); the passed value is a fallback.
-    int numVersionToPreserve = backupStrategy == BackupStrategy.DELETE_ON_NEW_PUSH_START
-        ? minNumberOfStoreVersionsToPreserve - 1
-        : minNumberOfStoreVersionsToPreserve;
+    // Clamp the fallback to at least 1 because Store.retrieveVersionsToDelete throws IllegalArgumentException
+    // if the passed value drops below 1 (e.g., when cluster config minNumberOfStoreVersionsToPreserve == 1 and
+    // the strategy decrement would take it to 0).
+    int numVersionToPreserve = Math.max(
+        1,
+        backupStrategy == BackupStrategy.DELETE_ON_NEW_PUSH_START
+            ? minNumberOfStoreVersionsToPreserve - 1
+            : minNumberOfStoreVersionsToPreserve);
     List<Version> versionsToDelete = store.retrieveVersionsToDelete(numVersionToPreserve);
     if (versionsToDelete.isEmpty()) {
       return;

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceHelixAdmin.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceHelixAdmin.java
@@ -3220,6 +3220,14 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
           }
           currentVersionBeforePush = store.getCurrentVersion();
 
+          // Capacity guard: if the current version was promoted within the min cleanup delay (e.g., from a
+          // recent rollback) and there are pending backup versions that cannot be deleted yet, starting a
+          // new push would exceed the hardware capacity provisioned for the store. Block the push.
+          // Behavior differs by backup strategy:
+          // - DELETE_ON_NEW_PUSH_START: hardware provisioned for 2x versions (current + new).
+          // - KEEP_MIN_VERSIONS: hardware provisioned for N+1 where N = store's configured versions to keep.
+          checkBackupVersionCleanupCapacityForNewPush(clusterName, storeName, store, store.getBackupStrategy());
+
           // Dest child controllers skip the version whose kafka topic is truncated
           if (store.isMigrating() && skipMigratingVersion(clusterName, storeName, versionNumber)) {
 
@@ -4518,6 +4526,78 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
   }
 
   /**
+   * Verify there is capacity to start a new push without exceeding the store's hardware budget.
+   *
+   * <p>If there are backup versions that would normally be cleaned up at push start (or after push completion)
+   * but are still within the min backup version cleanup delay (e.g., the current version was just promoted via
+   * rollback), starting a new push would exceed provisioned capacity. Block the push in that case.
+   *
+   * <p>Behavior differs by backup strategy:
+   * <ul>
+   *   <li>{@code DELETE_ON_NEW_PUSH_START}: hardware provisioned for 2x versions (current + new). Old versions
+   *       are deleted at SOP, so any version beyond current would exceed capacity.</li>
+   *   <li>{@code KEEP_MIN_VERSIONS}: hardware provisioned for N+1 where N is the configured versions to keep
+   *       ({@link Store#getNumVersionsToPreserve()} or cluster default). Any version beyond N would exceed
+   *       capacity once a new push is added.</li>
+   * </ul>
+   *
+   * @throws VeniceException if the store has pending backup versions that cannot be deleted yet.
+   */
+  private void checkBackupVersionCleanupCapacityForNewPush(
+      String clusterName,
+      String storeName,
+      Store store,
+      BackupStrategy backupStrategy) {
+    checkBackupVersionCleanupCapacityForNewPush(
+        clusterName,
+        storeName,
+        store,
+        backupStrategy,
+        minNumberOfStoreVersionsToPreserve,
+        multiClusterConfigs.getBackupVersionMinCleanupDelayMs(),
+        System.currentTimeMillis());
+  }
+
+  /**
+   * Testable variant of {@link #checkBackupVersionCleanupCapacityForNewPush(String, String, Store, BackupStrategy)}
+   * that takes the config values and current time as parameters instead of reading from instance state.
+   */
+  static void checkBackupVersionCleanupCapacityForNewPush(
+      String clusterName,
+      String storeName,
+      Store store,
+      BackupStrategy backupStrategy,
+      int minNumberOfStoreVersionsToPreserve,
+      long minBackupVersionCleanupDelay,
+      long currentTimeMs) {
+    // Preserve count differs by strategy:
+    // - DELETE_ON_NEW_PUSH_START: mirror retireOldStoreVersions(deleteBackupOnStartPush=true) which passes N-1.
+    // The new push effectively "counts" as the Nth version, so at steady state we preserve N-1 non-current
+    // versions plus the current version.
+    // - KEEP_MIN_VERSIONS (and anything else): preserve N at steady state. retrieveVersionsToDelete will use
+    // the store-level override if set (Store.getNumVersionsToPreserve()); the passed value is a fallback.
+    int numVersionToPreserve = backupStrategy == BackupStrategy.DELETE_ON_NEW_PUSH_START
+        ? minNumberOfStoreVersionsToPreserve - 1
+        : minNumberOfStoreVersionsToPreserve;
+    List<Version> versionsToDelete = store.retrieveVersionsToDelete(numVersionToPreserve);
+    if (versionsToDelete.isEmpty()) {
+      return;
+    }
+    long minRetentionThreshold = store.getLatestVersionPromoteToCurrentTimestamp() + minBackupVersionCleanupDelay;
+    if (currentTimeMs <= minRetentionThreshold) {
+      throw new VeniceException(
+          String.format(
+              "Cannot start new push for store %s in cluster %s: %d backup version(s) pending deletion "
+                  + "but still within min cleanup delay (%dms) of latest version promotion. "
+                  + "Retry after min delay has elapsed.",
+              storeName,
+              clusterName,
+              versionsToDelete.size(),
+              minBackupVersionCleanupDelay));
+    }
+  }
+
+  /**
    * For a given store, determine its versions to delete based on the {@linkplain BackupStrategy} settings and execute
    * the deletion in the cluster (including all its resources). It also truncates Kafka topics and Helix resources.
    * @param clusterName name of a cluster.
@@ -4543,6 +4623,23 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
       int numVersionToPreserve = minNumberOfStoreVersionsToPreserve - (deleteBackupOnStartPush ? 1 : 0);
       List<Version> versionsToDelete = store.retrieveVersionsToDelete(numVersionToPreserve);
       if (versionsToDelete.isEmpty()) {
+        return;
+      }
+
+      // Enforce the min backup version cleanup delay here as well as in StoreBackupVersionCleanupService.
+      // If the current version was just promoted (e.g., via a rollback that marked the ex-current as ERROR),
+      // deleting backup versions immediately can race with routers/servers/clients that haven't switched off
+      // the old current version yet. The periodic cleanup service or a subsequent push will handle deletion
+      // once the min delay has elapsed.
+      long minBackupVersionCleanupDelay = multiClusterConfigs.getBackupVersionMinCleanupDelayMs();
+      long minRetentionThreshold = store.getLatestVersionPromoteToCurrentTimestamp() + minBackupVersionCleanupDelay;
+      if (System.currentTimeMillis() <= minRetentionThreshold) {
+        LOGGER.info(
+            "Skipping retireOldStoreVersions for store {} in cluster {}: within min backup version cleanup delay "
+                + "({}ms) of latest version promotion",
+            storeName,
+            clusterName,
+            minBackupVersionCleanupDelay);
         return;
       }
 

--- a/services/venice-controller/src/test/java/com/linkedin/venice/controller/TestBackupVersionCleanupCapacityCheck.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/controller/TestBackupVersionCleanupCapacityCheck.java
@@ -1,0 +1,193 @@
+package com.linkedin.venice.controller;
+
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.testng.Assert.assertThrows;
+import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.expectThrows;
+
+import com.linkedin.venice.exceptions.VeniceException;
+import com.linkedin.venice.meta.BackupStrategy;
+import com.linkedin.venice.meta.Store;
+import com.linkedin.venice.meta.Version;
+import java.util.Collections;
+import java.util.concurrent.TimeUnit;
+import org.testng.annotations.Test;
+
+
+/**
+ * Unit tests for {@link VeniceHelixAdmin#checkBackupVersionCleanupCapacityForNewPush}.
+ */
+public class TestBackupVersionCleanupCapacityCheck {
+  private static final String CLUSTER_NAME = "test-cluster";
+  private static final String STORE_NAME = "test-store";
+  private static final int MIN_VERSIONS_TO_PRESERVE = 2;
+  private static final long MIN_CLEANUP_DELAY_MS = TimeUnit.HOURS.toMillis(1);
+
+  @Test
+  public void testDeleteOnNewPushStart_UsesNMinusOnePreserveCountAndPassesWhenNoVersionsPending() {
+    // DELETE_ON_NEW_PUSH_START: after SOP cleanup we expect only current + new push.
+    // Preserve count passed to retrieveVersionsToDelete should be N-1 (= 1).
+    Store store = mock(Store.class);
+    doReturn(Collections.emptyList()).when(store).retrieveVersionsToDelete(MIN_VERSIONS_TO_PRESERVE - 1);
+
+    VeniceHelixAdmin.checkBackupVersionCleanupCapacityForNewPush(
+        CLUSTER_NAME,
+        STORE_NAME,
+        store,
+        BackupStrategy.DELETE_ON_NEW_PUSH_START,
+        MIN_VERSIONS_TO_PRESERVE,
+        MIN_CLEANUP_DELAY_MS,
+        System.currentTimeMillis());
+
+    verify(store).retrieveVersionsToDelete(MIN_VERSIONS_TO_PRESERVE - 1);
+    // When nothing is pending, we short-circuit and never check the promotion timestamp.
+    verify(store, never()).getLatestVersionPromoteToCurrentTimestamp();
+  }
+
+  @Test
+  public void testKeepMinVersions_UsesNPreserveCountAndPassesWhenNoVersionsPending() {
+    // KEEP_MIN_VERSIONS: preserve N at steady state, N+1 during push.
+    // Preserve count passed to retrieveVersionsToDelete should be N (= 2), not N-1.
+    Store store = mock(Store.class);
+    doReturn(Collections.emptyList()).when(store).retrieveVersionsToDelete(MIN_VERSIONS_TO_PRESERVE);
+
+    VeniceHelixAdmin.checkBackupVersionCleanupCapacityForNewPush(
+        CLUSTER_NAME,
+        STORE_NAME,
+        store,
+        BackupStrategy.KEEP_MIN_VERSIONS,
+        MIN_VERSIONS_TO_PRESERVE,
+        MIN_CLEANUP_DELAY_MS,
+        System.currentTimeMillis());
+
+    verify(store).retrieveVersionsToDelete(MIN_VERSIONS_TO_PRESERVE);
+    verify(store, never()).retrieveVersionsToDelete(MIN_VERSIONS_TO_PRESERVE - 1);
+    verify(store, never()).getLatestVersionPromoteToCurrentTimestamp();
+  }
+
+  @Test
+  public void testPassesWhenPastMinCleanupDelayEvenWithPendingVersions() {
+    // Pending versions exist but promotion was > min delay ago → push allowed.
+    Store store = mock(Store.class);
+    Version pendingVersion = mock(Version.class);
+    doReturn(Collections.singletonList(pendingVersion)).when(store)
+        .retrieveVersionsToDelete(MIN_VERSIONS_TO_PRESERVE - 1);
+    long now = System.currentTimeMillis();
+    long promotionTime = now - MIN_CLEANUP_DELAY_MS - 1;
+    doReturn(promotionTime).when(store).getLatestVersionPromoteToCurrentTimestamp();
+
+    VeniceHelixAdmin.checkBackupVersionCleanupCapacityForNewPush(
+        CLUSTER_NAME,
+        STORE_NAME,
+        store,
+        BackupStrategy.DELETE_ON_NEW_PUSH_START,
+        MIN_VERSIONS_TO_PRESERVE,
+        MIN_CLEANUP_DELAY_MS,
+        now);
+
+    // Both reads should have happened — we checked versions pending, then checked the timestamp.
+    verify(store).retrieveVersionsToDelete(MIN_VERSIONS_TO_PRESERVE - 1);
+    verify(store).getLatestVersionPromoteToCurrentTimestamp();
+  }
+
+  @Test
+  public void testDeleteOnNewPushStart_BlocksPushWhenWithinMinCleanupDelay() {
+    // Rollback scenario: versions pending AND promotion was 30min ago (< 1h min delay).
+    Store store = mock(Store.class);
+    Version pendingVersion = mock(Version.class);
+    doReturn(Collections.singletonList(pendingVersion)).when(store)
+        .retrieveVersionsToDelete(MIN_VERSIONS_TO_PRESERVE - 1);
+    long now = System.currentTimeMillis();
+    doReturn(now - TimeUnit.MINUTES.toMillis(30)).when(store).getLatestVersionPromoteToCurrentTimestamp();
+
+    VeniceException e = expectThrows(
+        VeniceException.class,
+        () -> VeniceHelixAdmin.checkBackupVersionCleanupCapacityForNewPush(
+            CLUSTER_NAME,
+            STORE_NAME,
+            store,
+            BackupStrategy.DELETE_ON_NEW_PUSH_START,
+            MIN_VERSIONS_TO_PRESERVE,
+            MIN_CLEANUP_DELAY_MS,
+            now));
+    assertTrue(e.getMessage().contains(STORE_NAME), "Error should include store name: " + e.getMessage());
+    assertTrue(e.getMessage().contains(CLUSTER_NAME), "Error should include cluster name: " + e.getMessage());
+    assertTrue(e.getMessage().contains("1"), "Error should include pending version count: " + e.getMessage());
+    assertTrue(
+        e.getMessage().contains(String.valueOf(MIN_CLEANUP_DELAY_MS)),
+        "Error should include the min cleanup delay value: " + e.getMessage());
+  }
+
+  @Test
+  public void testKeepMinVersions_BlocksPushWhenWithinMinCleanupDelay() {
+    // Same rollback scenario but with KEEP_MIN_VERSIONS strategy and multiple pending versions.
+    Store store = mock(Store.class);
+    Version v1 = mock(Version.class);
+    Version v2 = mock(Version.class);
+    doReturn(java.util.Arrays.asList(v1, v2)).when(store).retrieveVersionsToDelete(MIN_VERSIONS_TO_PRESERVE);
+    long now = System.currentTimeMillis();
+    doReturn(now - TimeUnit.MINUTES.toMillis(30)).when(store).getLatestVersionPromoteToCurrentTimestamp();
+
+    VeniceException e = expectThrows(
+        VeniceException.class,
+        () -> VeniceHelixAdmin.checkBackupVersionCleanupCapacityForNewPush(
+            CLUSTER_NAME,
+            STORE_NAME,
+            store,
+            BackupStrategy.KEEP_MIN_VERSIONS,
+            MIN_VERSIONS_TO_PRESERVE,
+            MIN_CLEANUP_DELAY_MS,
+            now));
+    assertTrue(e.getMessage().contains(STORE_NAME));
+    // Pending count (2) should appear in the message.
+    assertTrue(e.getMessage().contains("2"), "Error should report the 2 pending versions: " + e.getMessage());
+  }
+
+  @Test
+  public void testBlocksExactlyAtMinCleanupDelayBoundary() {
+    // At the boundary (currentTime == promotionTime + minDelay), the check is <= so it blocks.
+    Store store = mock(Store.class);
+    Version pendingVersion = mock(Version.class);
+    doReturn(Collections.singletonList(pendingVersion)).when(store)
+        .retrieveVersionsToDelete(MIN_VERSIONS_TO_PRESERVE - 1);
+    long now = System.currentTimeMillis();
+    doReturn(now - MIN_CLEANUP_DELAY_MS).when(store).getLatestVersionPromoteToCurrentTimestamp();
+
+    assertThrows(
+        VeniceException.class,
+        () -> VeniceHelixAdmin.checkBackupVersionCleanupCapacityForNewPush(
+            CLUSTER_NAME,
+            STORE_NAME,
+            store,
+            BackupStrategy.DELETE_ON_NEW_PUSH_START,
+            MIN_VERSIONS_TO_PRESERVE,
+            MIN_CLEANUP_DELAY_MS,
+            now));
+  }
+
+  @Test
+  public void testJustPastBoundaryAllowsPush() {
+    // One ms past the boundary should allow the push.
+    Store store = mock(Store.class);
+    Version pendingVersion = mock(Version.class);
+    doReturn(Collections.singletonList(pendingVersion)).when(store)
+        .retrieveVersionsToDelete(MIN_VERSIONS_TO_PRESERVE - 1);
+    long now = System.currentTimeMillis();
+    doReturn(now - MIN_CLEANUP_DELAY_MS - 1).when(store).getLatestVersionPromoteToCurrentTimestamp();
+
+    // Should not throw
+    VeniceHelixAdmin.checkBackupVersionCleanupCapacityForNewPush(
+        CLUSTER_NAME,
+        STORE_NAME,
+        store,
+        BackupStrategy.DELETE_ON_NEW_PUSH_START,
+        MIN_VERSIONS_TO_PRESERVE,
+        MIN_CLEANUP_DELAY_MS,
+        now);
+    verify(store).retrieveVersionsToDelete(MIN_VERSIONS_TO_PRESERVE - 1);
+    verify(store).getLatestVersionPromoteToCurrentTimestamp();
+  }
+}

--- a/services/venice-controller/src/test/java/com/linkedin/venice/controller/TestBackupVersionCleanupCapacityCheck.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/controller/TestBackupVersionCleanupCapacityCheck.java
@@ -115,7 +115,10 @@ public class TestBackupVersionCleanupCapacityCheck {
             now));
     assertTrue(e.getMessage().contains(STORE_NAME), "Error should include store name: " + e.getMessage());
     assertTrue(e.getMessage().contains(CLUSTER_NAME), "Error should include cluster name: " + e.getMessage());
-    assertTrue(e.getMessage().contains("1"), "Error should include pending version count: " + e.getMessage());
+    // Anchor on "1 backup version(s)" to avoid matching the digit 1 that could appear elsewhere in the message.
+    assertTrue(
+        e.getMessage().contains("1 backup version(s)"),
+        "Error should include pending version count: " + e.getMessage());
     assertTrue(
         e.getMessage().contains(String.valueOf(MIN_CLEANUP_DELAY_MS)),
         "Error should include the min cleanup delay value: " + e.getMessage());
@@ -142,8 +145,10 @@ public class TestBackupVersionCleanupCapacityCheck {
             MIN_CLEANUP_DELAY_MS,
             now));
     assertTrue(e.getMessage().contains(STORE_NAME));
-    // Pending count (2) should appear in the message.
-    assertTrue(e.getMessage().contains("2"), "Error should report the 2 pending versions: " + e.getMessage());
+    // Anchor on "2 backup version(s)" to avoid matching the digit 2 that could appear elsewhere in the message.
+    assertTrue(
+        e.getMessage().contains("2 backup version(s)"),
+        "Error should report the 2 pending versions: " + e.getMessage());
   }
 
   @Test
@@ -189,5 +194,26 @@ public class TestBackupVersionCleanupCapacityCheck {
         now);
     verify(store).retrieveVersionsToDelete(MIN_VERSIONS_TO_PRESERVE - 1);
     verify(store).getLatestVersionPromoteToCurrentTimestamp();
+  }
+
+  @Test
+  public void testDeleteOnNewPushStart_ClampsPreserveCountToAtLeastOneWhenMinIsOne() {
+    // If cluster config sets minNumberOfStoreVersionsToPreserve == 1, the DELETE_ON_NEW_PUSH_START branch
+    // would compute N-1 = 0, which Store.retrieveVersionsToDelete rejects with IllegalArgumentException.
+    // Verify the check clamps to 1 so the push path doesn't break.
+    Store store = mock(Store.class);
+    doReturn(Collections.emptyList()).when(store).retrieveVersionsToDelete(1);
+
+    VeniceHelixAdmin.checkBackupVersionCleanupCapacityForNewPush(
+        CLUSTER_NAME,
+        STORE_NAME,
+        store,
+        BackupStrategy.DELETE_ON_NEW_PUSH_START,
+        1, // cluster config edge case
+        MIN_CLEANUP_DELAY_MS,
+        System.currentTimeMillis());
+
+    verify(store).retrieveVersionsToDelete(1);
+    verify(store, never()).retrieveVersionsToDelete(0);
   }
 }


### PR DESCRIPTION
## Problem Statement

When a version rollback marks the ex-current version as ERROR, a subsequent new push can delete that ERROR version immediately at start of push (SOP), bypassing the min backup version cleanup delay (default 1h) that exists to let routers/servers/clients switch off the old current version. This can also push the store beyond its provisioned hardware capacity if a new push arrives before backup versions can be safely cleaned up.

More generally, any code path that triggers `retireOldStoreVersions` at SOP doesn't currently honor the min cleanup delay, creating an inconsistency with `StoreBackupVersionCleanupService` (which does enforce it).

## Solution

Add a capacity guard in `VeniceHelixAdmin.addVersion` that blocks a new push if backup versions are pending deletion but cannot be cleaned up yet due to the min cleanup delay.

Behavior differs by backup strategy:
- **DELETE_ON_NEW_PUSH_START**: hardware provisioned for 2x versions (current + new push). Preserve count = N-1.
- **KEEP_MIN_VERSIONS** (and others): hardware provisioned for N+1 where N = configured versions to keep. Preserve count = N (store-level `numVersionsToPreserve` takes precedence when set).

When blocked, the caller receives a clear `VeniceException` with the store name, cluster name, pending version count, and the min cleanup delay value, and can retry after the delay has elapsed.

Also adds a silent skip in `retireOldStoreVersions` when within the min delay as defense-in-depth for the post-push-completion path; the periodic `StoreBackupVersionCleanupService` handles eventual deletion.

### Code changes

- [ ] Added new code behind **a config**. _(Uses existing `CONTROLLER_BACKUP_VERSION_MIN_CLEANUP_DELAY_MS`, default 1h.)_
- [x] Introduced new **log lines**.
  - [x] Confirmed if logs need to be **rate limited** to avoid excessive logging. _(Per-push-start, not per-iteration — no rate limiting needed.)_

### **Concurrency-Specific Checks**

- [x] Code has **no race conditions** or **thread safety issues**. _(Check runs inside existing store write lock.)_
- [x] Proper **synchronization mechanisms** used. _(Inherits existing `createStoreWriteLockOnly` in `addVersion`.)_
- [x] No **blocking calls** inside critical sections.
- [x] Verified **thread-safe collections** are used.
- [x] Validated proper exception handling in multi-threaded code.

## How was this PR tested?

- [x] New unit tests added. _(`TestBackupVersionCleanupCapacityCheck` — 7 tests covering both strategies, preserve-count verification, boundary conditions, and error message content.)_
- [ ] New integration tests added.
- [x] Modified or extended existing tests. _(None needed — existing `TestVeniceHelixAdmin` and `TestStoreBackupVersionCleanupService` still pass.)_
- [x] Verified backward compatibility. _(No enum changes, no config changes, no wire protocol changes.)_

## Does this PR introduce any user-facing or breaking changes?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Clearly explain the behavior change and its impact.

**Behavior change**: A new push can now be rejected at SOP with a `VeniceException` if:
1. The store has backup versions that would need to be deleted to make room, AND
2. The current version was promoted within the min cleanup delay window (default 1h).

In practice this will only trigger immediately after a rollback (which promotes the backup version and leaves the ex-current as ERROR). Operators can retry the push after the min cleanup delay has elapsed.