### PR TITLE
[tc][fc][router][server][dvc][test] Add key-count buckets OTel dimension to call_time metrics

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/client/StatsAvroGenericDaVinciClient.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/client/StatsAvroGenericDaVinciClient.java
@@ -11,7 +11,6 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Supplier;
-import org.apache.http.HttpStatus;
 
 
 /**
@@ -65,9 +64,7 @@ public class StatsAvroGenericDaVinciClient<K, V> extends DelegatingAvroGenericDa
         }
       });
     } catch (Exception e) {
-      stats.emitUnhealthyRequestMetrics(
-          LatencyUtils.getElapsedTimeFromNSToMS(startTimeInNS),
-          HttpStatus.SC_INTERNAL_SERVER_ERROR);
+      stats.emitUnhealthyRequestMetricsForDavinciClient(LatencyUtils.getElapsedTimeFromNSToMS(startTimeInNS));
       throw e;
     }
   }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/ServerReadOtelMetricEntity.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/ServerReadOtelMetricEntity.java
@@ -5,6 +5,7 @@ import static com.linkedin.venice.stats.dimensions.VeniceMetricsDimensions.HTTP_
 import static com.linkedin.venice.stats.dimensions.VeniceMetricsDimensions.VENICE_CHUNKING_STATUS;
 import static com.linkedin.venice.stats.dimensions.VeniceMetricsDimensions.VENICE_CLUSTER_NAME;
 import static com.linkedin.venice.stats.dimensions.VeniceMetricsDimensions.VENICE_READ_COMPUTE_OPERATION_TYPE;
+import static com.linkedin.venice.stats.dimensions.VeniceMetricsDimensions.VENICE_REQUEST_KEY_COUNT_BUCKET;
 import static com.linkedin.venice.stats.dimensions.VeniceMetricsDimensions.VENICE_REQUEST_METHOD;
 import static com.linkedin.venice.stats.dimensions.VeniceMetricsDimensions.VENICE_RESPONSE_STATUS_CODE_CATEGORY;
 import static com.linkedin.venice.stats.dimensions.VeniceMetricsDimensions.VENICE_STORE_NAME;
@@ -32,7 +33,8 @@ public enum ServerReadOtelMetricEntity implements ModuleMetricEntityInterface {
           VENICE_REQUEST_METHOD,
           HTTP_RESPONSE_STATUS_CODE,
           HTTP_RESPONSE_STATUS_CODE_CATEGORY,
-          VENICE_RESPONSE_STATUS_CODE_CATEGORY)
+          VENICE_RESPONSE_STATUS_CODE_CATEGORY,
+          VENICE_REQUEST_KEY_COUNT_BUCKET)
   ),
 
   READ_CALL_COUNT(

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/stats/ServerReadOtelMetricEntityTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/stats/ServerReadOtelMetricEntityTest.java
@@ -5,6 +5,7 @@ import static com.linkedin.venice.stats.dimensions.VeniceMetricsDimensions.HTTP_
 import static com.linkedin.venice.stats.dimensions.VeniceMetricsDimensions.VENICE_CHUNKING_STATUS;
 import static com.linkedin.venice.stats.dimensions.VeniceMetricsDimensions.VENICE_CLUSTER_NAME;
 import static com.linkedin.venice.stats.dimensions.VeniceMetricsDimensions.VENICE_READ_COMPUTE_OPERATION_TYPE;
+import static com.linkedin.venice.stats.dimensions.VeniceMetricsDimensions.VENICE_REQUEST_KEY_COUNT_BUCKET;
 import static com.linkedin.venice.stats.dimensions.VeniceMetricsDimensions.VENICE_REQUEST_METHOD;
 import static com.linkedin.venice.stats.dimensions.VeniceMetricsDimensions.VENICE_RESPONSE_STATUS_CODE_CATEGORY;
 import static com.linkedin.venice.stats.dimensions.VeniceMetricsDimensions.VENICE_STORE_NAME;
@@ -47,6 +48,14 @@ public class ServerReadOtelMetricEntityTest {
     Set<VeniceMetricsDimensions> storeClusterComputeOp =
         setOf(VENICE_STORE_NAME, VENICE_CLUSTER_NAME, VENICE_READ_COMPUTE_OPERATION_TYPE);
 
+    Set<VeniceMetricsDimensions> storeClusterRequestTypeHttpStatusKeyBucket = setOf(
+        VENICE_STORE_NAME,
+        VENICE_CLUSTER_NAME,
+        VENICE_REQUEST_METHOD,
+        HTTP_RESPONSE_STATUS_CODE,
+        HTTP_RESPONSE_STATUS_CODE_CATEGORY,
+        VENICE_RESPONSE_STATUS_CODE_CATEGORY,
+        VENICE_REQUEST_KEY_COUNT_BUCKET);
     map.put(
         ServerReadOtelMetricEntity.READ_CALL_TIME,
         new MetricEntityExpectation(
@@ -54,7 +63,7 @@ public class ServerReadOtelMetricEntityTest {
             MetricType.HISTOGRAM,
             MetricUnit.MILLISECOND,
             "Server-side read request latency",
-            storeClusterRequestTypeHttpStatus));
+            storeClusterRequestTypeHttpStatusKeyBucket));
     map.put(
         ServerReadOtelMetricEntity.READ_CALL_COUNT,
         new MetricEntityExpectation(

--- a/clients/venice-client/src/main/java/com/linkedin/venice/fastclient/StatsAvroGenericStoreClient.java
+++ b/clients/venice-client/src/main/java/com/linkedin/venice/fastclient/StatsAvroGenericStoreClient.java
@@ -164,9 +164,12 @@ public class StatsAvroGenericStoreClient<K, V> extends DelegatingAvroStoreClient
       }
 
       if (exceptionReceived) {
-        clientStats.emitUnhealthyRequestMetrics(latency, throwable);
+        clientStats.emitUnhealthyRequestMetricsNonDavinciClient(latency, throwable, numberOfKeys);
       } else {
-        clientStats.emitHealthyRequestMetrics(latency, requestContext.successRequestKeyCount.get());
+        clientStats.emitHealthyRequestMetricsNonDavinciClient(
+            latency,
+            requestContext.successRequestKeyCount.get(),
+            numberOfKeys);
 
         // Record additional metrics
         if (requestContext.requestSerializationTime > 0) {

--- a/clients/venice-thin-client/src/main/java/com/linkedin/venice/client/stats/BasicClientStats.java
+++ b/clients/venice-thin-client/src/main/java/com/linkedin/venice/client/stats/BasicClientStats.java
@@ -288,24 +288,24 @@ public class BasicClientStats extends AbstractVeniceHttpStats {
         healthyLatencyMetric);
   }
 
-  public void emitUnhealthyRequestMetricsNonDavinciClient(double latency, int httpStatus, int keyCount) {
+  public void emitUnhealthyRequestMetricsNonDavinciClient(double latency, int httpStatus, int requestedKeyCount) {
     emitRequestMetricsNonDavinciClient(
         latency,
         httpStatus,
-        keyCount,
+        requestedKeyCount,
         FAIL,
         unhealthyRequestMetric,
         unhealthyLatencyMetric);
   }
 
-  public void emitUnhealthyRequestMetricsNonDavinciClient(double latency, Throwable throwable, int keyCount) {
-    emitUnhealthyRequestMetricsNonDavinciClient(latency, getUnhealthyRequestHttpStatus(throwable), keyCount);
+  public void emitUnhealthyRequestMetricsNonDavinciClient(double latency, Throwable throwable, int requestedKeyCount) {
+    emitUnhealthyRequestMetricsNonDavinciClient(latency, getUnhealthyRequestHttpStatus(throwable), requestedKeyCount);
   }
 
   private void emitRequestMetricsNonDavinciClient(
       double latency,
       int httpStatus,
-      int bucketKeyCount,
+      int requestedKeyCount,
       VeniceResponseStatusCategory veniceCategory,
       MetricEntityStateThreeEnums<HttpResponseStatusEnum, HttpResponseStatusCodeCategory, VeniceResponseStatusCategory> countMetric,
       MetricEntityStateFourEnums<HttpResponseStatusEnum, HttpResponseStatusCodeCategory, VeniceResponseStatusCategory, VeniceRequestKeyCountBucket> latencyMetric) {
@@ -321,7 +321,7 @@ public class BasicClientStats extends AbstractVeniceHttpStats {
         statusEnum,
         httpCategory,
         veniceCategory,
-        VeniceRequestKeyCountBucket.fromKeyCount(bucketKeyCount));
+        VeniceRequestKeyCountBucket.fromKeyCount(requestedKeyCount));
   }
 
   public void emitHealthyRequestMetricsForDavinciClient(double latency) {

--- a/clients/venice-thin-client/src/main/java/com/linkedin/venice/client/stats/BasicClientStats.java
+++ b/clients/venice-thin-client/src/main/java/com/linkedin/venice/client/stats/BasicClientStats.java
@@ -4,6 +4,7 @@ import static com.linkedin.venice.stats.dimensions.HttpResponseStatusCodeCategor
 import static com.linkedin.venice.stats.dimensions.HttpResponseStatusEnum.transformIntToHttpResponseStatusEnum;
 import static com.linkedin.venice.stats.dimensions.VeniceMetricsDimensions.HTTP_RESPONSE_STATUS_CODE;
 import static com.linkedin.venice.stats.dimensions.VeniceMetricsDimensions.HTTP_RESPONSE_STATUS_CODE_CATEGORY;
+import static com.linkedin.venice.stats.dimensions.VeniceMetricsDimensions.VENICE_REQUEST_KEY_COUNT_BUCKET;
 import static com.linkedin.venice.stats.dimensions.VeniceMetricsDimensions.VENICE_REQUEST_METHOD;
 import static com.linkedin.venice.stats.dimensions.VeniceMetricsDimensions.VENICE_RESPONSE_STATUS_CODE_CATEGORY;
 import static com.linkedin.venice.stats.dimensions.VeniceMetricsDimensions.VENICE_STORE_NAME;
@@ -25,9 +26,11 @@ import com.linkedin.venice.stats.VeniceOpenTelemetryMetricsRepository;
 import com.linkedin.venice.stats.dimensions.HttpResponseStatusCodeCategory;
 import com.linkedin.venice.stats.dimensions.HttpResponseStatusEnum;
 import com.linkedin.venice.stats.dimensions.VeniceMetricsDimensions;
+import com.linkedin.venice.stats.dimensions.VeniceRequestKeyCountBucket;
 import com.linkedin.venice.stats.dimensions.VeniceResponseStatusCategory;
 import com.linkedin.venice.stats.metrics.MetricEntity;
 import com.linkedin.venice.stats.metrics.MetricEntityStateBase;
+import com.linkedin.venice.stats.metrics.MetricEntityStateFourEnums;
 import com.linkedin.venice.stats.metrics.MetricEntityStateOneEnum;
 import com.linkedin.venice.stats.metrics.MetricEntityStateThreeEnums;
 import com.linkedin.venice.stats.metrics.MetricType;
@@ -76,8 +79,8 @@ public class BasicClientStats extends AbstractVeniceHttpStats {
   private final Sensor requestSensor; // will be a derived metric in otel: healthy + unhealthy
   private final MetricEntityStateThreeEnums<HttpResponseStatusEnum, HttpResponseStatusCodeCategory, VeniceResponseStatusCategory> healthyRequestMetric;
   private final MetricEntityStateThreeEnums<HttpResponseStatusEnum, HttpResponseStatusCodeCategory, VeniceResponseStatusCategory> unhealthyRequestMetric;
-  private final MetricEntityStateThreeEnums<HttpResponseStatusEnum, HttpResponseStatusCodeCategory, VeniceResponseStatusCategory> healthyLatencyMetric;
-  private final MetricEntityStateThreeEnums<HttpResponseStatusEnum, HttpResponseStatusCodeCategory, VeniceResponseStatusCategory> unhealthyLatencyMetric;
+  private final MetricEntityStateFourEnums<HttpResponseStatusEnum, HttpResponseStatusCodeCategory, VeniceResponseStatusCategory, VeniceRequestKeyCountBucket> healthyLatencyMetric;
+  private final MetricEntityStateFourEnums<HttpResponseStatusEnum, HttpResponseStatusCodeCategory, VeniceResponseStatusCategory, VeniceRequestKeyCountBucket> unhealthyLatencyMetric;
   private final MetricEntityStateOneEnum<VeniceResponseStatusCategory> healthyRequestMetricForDavinciClient;
   private final MetricEntityStateOneEnum<VeniceResponseStatusCategory> unhealthyRequestMetricForDavinciClient;
   private final MetricEntityStateOneEnum<VeniceResponseStatusCategory> healthyLatencyMetricForDavinciClient;
@@ -204,7 +207,7 @@ public class BasicClientStats extends AbstractVeniceHttpStats {
           HttpResponseStatusCodeCategory.class,
           VeniceResponseStatusCategory.class);
       // latency
-      healthyLatencyMetric = MetricEntityStateThreeEnums.create(
+      healthyLatencyMetric = MetricEntityStateFourEnums.create(
           BasicClientMetricEntity.CALL_TIME.getMetricEntity(),
           otelRepository,
           this::registerSensorWithDetailedPercentiles,
@@ -217,8 +220,9 @@ public class BasicClientStats extends AbstractVeniceHttpStats {
           baseDimensionsMap,
           HttpResponseStatusEnum.class,
           HttpResponseStatusCodeCategory.class,
-          VeniceResponseStatusCategory.class);
-      unhealthyLatencyMetric = MetricEntityStateThreeEnums.create(
+          VeniceResponseStatusCategory.class,
+          VeniceRequestKeyCountBucket.class);
+      unhealthyLatencyMetric = MetricEntityStateFourEnums.create(
           BasicClientMetricEntity.CALL_TIME.getMetricEntity(),
           getOtelRepository(),
           this::registerSensorWithDetailedPercentiles,
@@ -231,7 +235,8 @@ public class BasicClientStats extends AbstractVeniceHttpStats {
           getBaseDimensionsMap(),
           HttpResponseStatusEnum.class,
           HttpResponseStatusCodeCategory.class,
-          VeniceResponseStatusCategory.class);
+          VeniceResponseStatusCategory.class,
+          VeniceRequestKeyCountBucket.class);
       healthyRequestMetricForDavinciClient = null;
       unhealthyRequestMetricForDavinciClient = null;
       healthyLatencyMetricForDavinciClient = null;
@@ -269,33 +274,54 @@ public class BasicClientStats extends AbstractVeniceHttpStats {
     requestSensor.record();
   }
 
-  public void emitHealthyRequestMetrics(double latency, int keyCount) {
-    if (!clientType.equals(ClientType.DAVINCI_CLIENT)) {
-      recordRequest();
-      int httpStatus = getHealthyRequestHttpStatus(keyCount);
-      HttpResponseStatusEnum statusEnum = transformIntToHttpResponseStatusEnum(httpStatus);
-      HttpResponseStatusCodeCategory httpCategory = getVeniceHttpResponseStatusCodeCategory(httpStatus);
-      healthyRequestMetric.record(1, statusEnum, httpCategory, SUCCESS);
-      healthyLatencyMetric.record(latency, statusEnum, httpCategory, SUCCESS);
+  /**
+   * Records healthy request metrics, bucketing the {@code call_time} OTel metric by the
+   * originally-requested key count (not the successful count).
+   */
+  public void emitHealthyRequestMetricsNonDavinciClient(double latency, int successfulKeyCount, int requestedKeyCount) {
+    emitRequestMetricsNonDavinciClient(
+        latency,
+        getHealthyRequestHttpStatus(successfulKeyCount),
+        requestedKeyCount,
+        SUCCESS,
+        healthyRequestMetric,
+        healthyLatencyMetric);
+  }
+
+  public void emitUnhealthyRequestMetricsNonDavinciClient(double latency, int httpStatus, int keyCount) {
+    emitRequestMetricsNonDavinciClient(
+        latency,
+        httpStatus,
+        keyCount,
+        FAIL,
+        unhealthyRequestMetric,
+        unhealthyLatencyMetric);
+  }
+
+  public void emitUnhealthyRequestMetricsNonDavinciClient(double latency, Throwable throwable, int keyCount) {
+    emitUnhealthyRequestMetricsNonDavinciClient(latency, getUnhealthyRequestHttpStatus(throwable), keyCount);
+  }
+
+  private void emitRequestMetricsNonDavinciClient(
+      double latency,
+      int httpStatus,
+      int bucketKeyCount,
+      VeniceResponseStatusCategory veniceCategory,
+      MetricEntityStateThreeEnums<HttpResponseStatusEnum, HttpResponseStatusCodeCategory, VeniceResponseStatusCategory> countMetric,
+      MetricEntityStateFourEnums<HttpResponseStatusEnum, HttpResponseStatusCodeCategory, VeniceResponseStatusCategory, VeniceRequestKeyCountBucket> latencyMetric) {
+    if (clientType.equals(ClientType.DAVINCI_CLIENT)) {
+      return;
     }
-  }
-
-  public void emitHealthyRequestMetrics(double latency, Object value) {
-    emitHealthyRequestMetrics(latency, getSuccessfulKeyCount(value));
-  }
-
-  public void emitUnhealthyRequestMetrics(double latency, int httpStatus) {
-    if (!clientType.equals(ClientType.DAVINCI_CLIENT)) {
-      recordRequest();
-      HttpResponseStatusEnum statusEnum = transformIntToHttpResponseStatusEnum(httpStatus);
-      HttpResponseStatusCodeCategory httpCategory = getVeniceHttpResponseStatusCodeCategory(httpStatus);
-      unhealthyRequestMetric.record(1, statusEnum, httpCategory, FAIL);
-      unhealthyLatencyMetric.record(latency, statusEnum, httpCategory, FAIL);
-    }
-  }
-
-  public void emitUnhealthyRequestMetrics(double latency, Throwable throwable) {
-    emitUnhealthyRequestMetrics(latency, getUnhealthyRequestHttpStatus(throwable));
+    recordRequest();
+    HttpResponseStatusEnum statusEnum = transformIntToHttpResponseStatusEnum(httpStatus);
+    HttpResponseStatusCodeCategory httpCategory = getVeniceHttpResponseStatusCodeCategory(httpStatus);
+    countMetric.record(1, statusEnum, httpCategory, veniceCategory);
+    latencyMetric.record(
+        latency,
+        statusEnum,
+        httpCategory,
+        veniceCategory,
+        VeniceRequestKeyCountBucket.fromKeyCount(bucketKeyCount));
   }
 
   public void emitHealthyRequestMetricsForDavinciClient(double latency) {
@@ -416,7 +442,8 @@ public class BasicClientStats extends AbstractVeniceHttpStats {
             VENICE_REQUEST_METHOD,
             HTTP_RESPONSE_STATUS_CODE,
             HTTP_RESPONSE_STATUS_CODE_CATEGORY,
-            VENICE_RESPONSE_STATUS_CODE_CATEGORY)
+            VENICE_RESPONSE_STATUS_CODE_CATEGORY,
+            VENICE_REQUEST_KEY_COUNT_BUCKET)
     ),
     /**
      * Count of keys for venice client request and response.

--- a/clients/venice-thin-client/src/main/java/com/linkedin/venice/client/store/StatTrackingStoreClient.java
+++ b/clients/venice-thin-client/src/main/java/com/linkedin/venice/client/store/StatTrackingStoreClient.java
@@ -97,7 +97,7 @@ public class StatTrackingStoreClient<K, V> extends DelegatingStoreClient<K, V> {
     CompletableFuture<V> innerFuture = super.get(key, Optional.of(singleGetStats), startTimeInNS);
     singleGetStats.recordRequestKeyCount(1);
     CompletableFuture<V> statFuture = innerFuture
-        .handle((BiFunction<? super V, Throwable, ? extends V>) getStatCallback(singleGetStats, startTimeInNS));
+        .handle((BiFunction<? super V, Throwable, ? extends V>) getStatCallback(singleGetStats, startTimeInNS, 1));
     return AppTimeOutTrackingCompletableFuture.track(statFuture, singleGetStats);
   }
 
@@ -107,7 +107,7 @@ public class StatTrackingStoreClient<K, V> extends DelegatingStoreClient<K, V> {
     CompletableFuture<byte[]> innerFuture = super.getRaw(requestPath, Optional.of(schemaReaderStats), startTimeInNS);
     schemaReaderStats.recordRequestKeyCount(1);
     CompletableFuture<byte[]> statFuture = innerFuture.handle(
-        (BiFunction<? super byte[], Throwable, ? extends byte[]>) getStatCallback(schemaReaderStats, startTimeInNS));
+        (BiFunction<? super byte[], Throwable, ? extends byte[]>) getStatCallback(schemaReaderStats, startTimeInNS, 1));
     return statFuture;
   }
 
@@ -144,6 +144,7 @@ public class StatTrackingStoreClient<K, V> extends DelegatingStoreClient<K, V> {
     private final Optional<ClientStats> statsOptional;
     private final long preRequestTimeInNS;
     private final StreamingResponseTracker streamingResponseTracker;
+    private final int requestedKeyCount;
 
     public StatTrackingStreamingCallback(
         StreamingCallback<K, V> callback,
@@ -154,6 +155,7 @@ public class StatTrackingStoreClient<K, V> extends DelegatingStoreClient<K, V> {
       this.stats = stats;
       this.statsOptional = Optional.of(stats);
       this.preRequestTimeInNS = preRequestTimeInNS;
+      this.requestedKeyCount = keyCnt;
       streamingResponseTracker = new StreamingResponseTracker(stats, keyCnt, preRequestTimeInNS);
     }
 
@@ -177,7 +179,8 @@ public class StatTrackingStoreClient<K, V> extends DelegatingStoreClient<K, V> {
           preRequestTimeInNS,
           exception,
           successKeyCount,
-          duplicateEntryCount);
+          duplicateEntryCount,
+          requestedKeyCount);
     }
   }
 
@@ -206,9 +209,13 @@ public class StatTrackingStoreClient<K, V> extends DelegatingStoreClient<K, V> {
         preRequestTimeInNS);
   }
 
-  private static void handleUnhealthyRequest(ClientStats clientStats, Throwable throwable, double latency) {
+  private static void handleUnhealthyRequest(
+      ClientStats clientStats,
+      Throwable throwable,
+      double latency,
+      int requestedKeyCount) {
     int httpStatus = getUnhealthyRequestHttpStatus(throwable);
-    clientStats.emitUnhealthyRequestMetrics(latency, httpStatus);
+    clientStats.emitUnhealthyRequestMetricsNonDavinciClient(latency, httpStatus, requestedKeyCount);
     if (throwable instanceof VeniceClientHttpException) {
       clientStats.recordHttpRequest(httpStatus);
     }
@@ -219,12 +226,13 @@ public class StatTrackingStoreClient<K, V> extends DelegatingStoreClient<K, V> {
       long startTimeInNS,
       Optional<Exception> exception,
       int successKeyCnt,
-      int duplicateEntryCnt) {
+      int duplicateEntryCnt,
+      int requestedKeyCount) {
     double latency = LatencyUtils.getElapsedTimeFromNSToMS(startTimeInNS);
     if (exception.isPresent()) {
-      handleUnhealthyRequest(clientStats, exception.get(), latency);
+      handleUnhealthyRequest(clientStats, exception.get(), latency, requestedKeyCount);
     } else {
-      clientStats.emitHealthyRequestMetrics(latency, successKeyCnt);
+      clientStats.emitHealthyRequestMetricsNonDavinciClient(latency, successKeyCnt, requestedKeyCount);
     }
     clientStats.recordResponseKeyCount(successKeyCnt);
     clientStats.recordSuccessDuplicateRequestKeyCount(duplicateEntryCnt);
@@ -240,18 +248,26 @@ public class StatTrackingStoreClient<K, V> extends DelegatingStoreClient<K, V> {
     return super.compute(Optional.of(computeStreamingStats), this);
   }
 
+  /**
+   * Builds a completion handler that records healthy/unhealthy client metrics. Callers pass the
+   * number of keys originally requested; it feeds the key-count-bucket OTel dimension and the
+   * unhealthy-path recording. {@code T} may be a single value (single-get, getRaw) or a
+   * multi-key result (e.g. {@link Map}) — the caller owns knowing how many keys they asked for.
+   */
   public static <T> BiFunction<? super T, Throwable, ? extends T> getStatCallback(
       ClientStats clientStats,
-      long startTimeInNS) {
+      long startTimeInNS,
+      int requestedKeyCount) {
     return (T value, Throwable throwable) -> {
       double latency = LatencyUtils.getElapsedTimeFromNSToMS(startTimeInNS);
       if (throwable != null) {
-        handleUnhealthyRequest(clientStats, throwable, latency);
+        handleUnhealthyRequest(clientStats, throwable, latency, requestedKeyCount);
         handleStoreExceptionInternally(throwable);
       }
 
-      clientStats.emitHealthyRequestMetrics(latency, value);
-      clientStats.recordResponseKeyCount(getSuccessfulKeyCount(value));
+      int successfulKeyCount = getSuccessfulKeyCount(value);
+      clientStats.emitHealthyRequestMetricsNonDavinciClient(latency, successfulKeyCount, requestedKeyCount);
+      clientStats.recordResponseKeyCount(successfulKeyCount);
       return value;
     };
   }

--- a/clients/venice-thin-client/src/test/java/com/linkedin/venice/client/stats/BasicClientMetricEntityTest.java
+++ b/clients/venice-thin-client/src/test/java/com/linkedin/venice/client/stats/BasicClientMetricEntityTest.java
@@ -2,6 +2,7 @@ package com.linkedin.venice.client.stats;
 
 import static com.linkedin.venice.stats.dimensions.VeniceMetricsDimensions.HTTP_RESPONSE_STATUS_CODE;
 import static com.linkedin.venice.stats.dimensions.VeniceMetricsDimensions.HTTP_RESPONSE_STATUS_CODE_CATEGORY;
+import static com.linkedin.venice.stats.dimensions.VeniceMetricsDimensions.VENICE_REQUEST_KEY_COUNT_BUCKET;
 import static com.linkedin.venice.stats.dimensions.VeniceMetricsDimensions.VENICE_REQUEST_METHOD;
 import static com.linkedin.venice.stats.dimensions.VeniceMetricsDimensions.VENICE_RESPONSE_STATUS_CODE_CATEGORY;
 import static com.linkedin.venice.stats.dimensions.VeniceMetricsDimensions.VENICE_STORE_NAME;
@@ -60,7 +61,8 @@ public class BasicClientMetricEntityTest {
                 VENICE_REQUEST_METHOD,
                 HTTP_RESPONSE_STATUS_CODE,
                 HTTP_RESPONSE_STATUS_CODE_CATEGORY,
-                VENICE_RESPONSE_STATUS_CODE_CATEGORY)));
+                VENICE_RESPONSE_STATUS_CODE_CATEGORY,
+                VENICE_REQUEST_KEY_COUNT_BUCKET)));
     map.put(
         BasicClientMetricEntity.REQUEST_KEY_COUNT,
         new MetricEntityExpectation(

--- a/clients/venice-thin-client/src/test/java/com/linkedin/venice/client/stats/BasicClientStatsTest.java
+++ b/clients/venice-thin-client/src/test/java/com/linkedin/venice/client/stats/BasicClientStatsTest.java
@@ -105,10 +105,12 @@ public class BasicClientStatsTest {
   }
 
   /**
-   * Verifies the partial-success contract: when successfulKeyCount and requestedKeyCount differ
-   * (a multiget returned fewer keys than requested), the {@code call_time} bucket dimension
-   * must reflect the REQUESTED count so dashboards filter on the batch size users actually sent,
-   * not on how many keys came back.
+   * Verifies the partial-success contract at the {@link BasicClientStats#emitHealthyRequestMetricsNonDavinciClient}
+   * layer: when {@code successfulKeyCount} and {@code requestedKeyCount} differ (a multi-key request returned
+   * fewer keys than requested), the {@code call_time} bucket dimension must reflect the REQUESTED count so
+   * dashboards filter on the batch size users actually sent, not on how many keys came back. The fixture uses
+   * {@code SINGLE_GET} because the contract is layer-agnostic — the recording API accepts both counts regardless
+   * of the stats instance's request type.
    */
   @Test
   public void testEmitHealthyMetricsBucketsByRequestedNotSuccessful() {

--- a/clients/venice-thin-client/src/test/java/com/linkedin/venice/client/stats/BasicClientStatsTest.java
+++ b/clients/venice-thin-client/src/test/java/com/linkedin/venice/client/stats/BasicClientStatsTest.java
@@ -13,6 +13,7 @@ import static com.linkedin.venice.stats.VeniceMetricsRepository.getVeniceMetrics
 import static com.linkedin.venice.stats.dimensions.VeniceMetricsDimensions.HTTP_RESPONSE_STATUS_CODE;
 import static com.linkedin.venice.stats.dimensions.VeniceMetricsDimensions.HTTP_RESPONSE_STATUS_CODE_CATEGORY;
 import static com.linkedin.venice.stats.dimensions.VeniceMetricsDimensions.VENICE_CLUSTER_NAME;
+import static com.linkedin.venice.stats.dimensions.VeniceMetricsDimensions.VENICE_REQUEST_KEY_COUNT_BUCKET;
 import static com.linkedin.venice.stats.dimensions.VeniceMetricsDimensions.VENICE_REQUEST_METHOD;
 import static com.linkedin.venice.stats.dimensions.VeniceMetricsDimensions.VENICE_REQUEST_REJECTION_REASON;
 import static com.linkedin.venice.stats.dimensions.VeniceMetricsDimensions.VENICE_REQUEST_RETRY_TYPE;
@@ -34,6 +35,7 @@ import com.linkedin.venice.stats.ClientType;
 import com.linkedin.venice.stats.VeniceMetricsRepository;
 import com.linkedin.venice.stats.dimensions.HttpResponseStatusEnum;
 import com.linkedin.venice.stats.dimensions.RequestRetryType;
+import com.linkedin.venice.stats.dimensions.VeniceRequestKeyCountBucket;
 import com.linkedin.venice.stats.dimensions.VeniceResponseStatusCategory;
 import com.linkedin.venice.stats.metrics.MetricEntity;
 import com.linkedin.venice.stats.metrics.MetricType;
@@ -89,7 +91,7 @@ public class BasicClientStatsTest {
   public void testEmitHealthyMetrics() {
     InMemoryMetricReader inMemoryMetricReader = InMemoryMetricReader.create();
     BasicClientStats stats = createStats(inMemoryMetricReader, THIN_CLIENT);
-    stats.emitHealthyRequestMetrics(90.0, 2);
+    stats.emitHealthyRequestMetricsNonDavinciClient(90.0, 2, 2);
 
     validateTehutiMetrics(stats.getMetricsRepository(), ".test_store", true, 90.0);
     validateOtelMetrics(
@@ -98,6 +100,42 @@ public class BasicClientStatsTest {
         HttpResponseStatusEnum.OK,
         SUCCESS,
         90.0,
+        THIN_CLIENT.getMetricsPrefix(),
+        2);
+  }
+
+  /**
+   * Verifies the partial-success contract: when successfulKeyCount and requestedKeyCount differ
+   * (a multiget returned fewer keys than requested), the {@code call_time} bucket dimension
+   * must reflect the REQUESTED count so dashboards filter on the batch size users actually sent,
+   * not on how many keys came back.
+   */
+  @Test
+  public void testEmitHealthyMetricsBucketsByRequestedNotSuccessful() {
+    InMemoryMetricReader inMemoryMetricReader = InMemoryMetricReader.create();
+    BasicClientStats stats = createStats(inMemoryMetricReader, THIN_CLIENT);
+    // requested=300 (KEYS_151_500), successful=30 (KEYS_2_150) — different buckets
+    int requestedKeyCount = 300;
+    int successfulKeyCount = 30;
+    stats.emitHealthyRequestMetricsNonDavinciClient(90.0, successfulKeyCount, requestedKeyCount);
+
+    Attributes callTimeAttributes =
+        new OpenTelemetryDataTestUtils.OpenTelemetryAttributesBuilder().setStoreName("test_store")
+            .setHttpStatus(HttpResponseStatusEnum.OK)
+            .setVeniceStatusCategory(SUCCESS)
+            .setRequestType(SINGLE_GET)
+            .setKeyCountBucket(VeniceRequestKeyCountBucket.fromKeyCount(requestedKeyCount))
+            .build();
+    // The bucket dim on call_time must match the REQUESTED bucket; assert the histogram point
+    // exists at the requested-key-count bucket attributes (throws if the recording used successful).
+    validateExponentialHistogramPointData(
+        inMemoryMetricReader,
+        90.0,
+        90.0,
+        1,
+        90.0,
+        callTimeAttributes,
+        "call_time",
         THIN_CLIENT.getMetricsPrefix());
   }
 
@@ -124,7 +162,7 @@ public class BasicClientStatsTest {
   public void testEmitUnhealthyMetrics() {
     InMemoryMetricReader inMemoryMetricReader = InMemoryMetricReader.create();
     BasicClientStats stats = createStats(inMemoryMetricReader, THIN_CLIENT);
-    stats.emitUnhealthyRequestMetrics(90.0, HttpStatus.SC_INTERNAL_SERVER_ERROR);
+    stats.emitUnhealthyRequestMetricsNonDavinciClient(90.0, HttpStatus.SC_INTERNAL_SERVER_ERROR, 1);
 
     validateTehutiMetrics(stats.getMetricsRepository(), ".test_store", false, 90.0);
     validateOtelMetrics(
@@ -312,11 +350,30 @@ public class BasicClientStatsTest {
       VeniceResponseStatusCategory category,
       double latency,
       String otelPrefix) {
+    validateOtelMetrics(inMemoryMetricReader, storeName, httpStatus, category, latency, otelPrefix, 1);
+  }
+
+  private void validateOtelMetrics(
+      InMemoryMetricReader inMemoryMetricReader,
+      String storeName,
+      HttpResponseStatusEnum httpStatus,
+      VeniceResponseStatusCategory category,
+      double latency,
+      String otelPrefix,
+      int keyCount) {
     Attributes expectedAttributes =
         new OpenTelemetryDataTestUtils.OpenTelemetryAttributesBuilder().setStoreName(storeName)
             .setHttpStatus(httpStatus)
             .setVeniceStatusCategory(category)
             .setRequestType(SINGLE_GET)
+            .build();
+    // call_time carries the additional key-count-bucket dimension derived from keyCount.
+    Attributes expectedCallTimeAttributes =
+        new OpenTelemetryDataTestUtils.OpenTelemetryAttributesBuilder().setStoreName(storeName)
+            .setHttpStatus(httpStatus)
+            .setVeniceStatusCategory(category)
+            .setRequestType(SINGLE_GET)
+            .setKeyCountBucket(VeniceRequestKeyCountBucket.fromKeyCount(keyCount))
             .build();
     Collection<MetricData> metricsData = inMemoryMetricReader.collectAllMetrics();
     assertEquals(metricsData.size(), 2, "There should be two metrics recorded: call_time and call_count");
@@ -329,7 +386,7 @@ public class BasicClientStatsTest {
         latency,
         1,
         latency,
-        expectedAttributes,
+        expectedCallTimeAttributes,
         "call_time",
         otelPrefix);
   }
@@ -340,8 +397,26 @@ public class BasicClientStatsTest {
       VeniceResponseStatusCategory category,
       double latency,
       String otelPrefix) {
-    // Overload for Davinci client where httpStatus is not applicable
-    validateOtelMetrics(inMemoryMetricReader, storeName, null, category, latency, otelPrefix);
+    // Overload for Davinci client where httpStatus is not applicable. CALL_TIME_DVC does not
+    // carry the key-count-bucket dimension, so we validate against attributes without it.
+    Attributes expectedAttributes =
+        new OpenTelemetryDataTestUtils.OpenTelemetryAttributesBuilder().setStoreName(storeName)
+            .setVeniceStatusCategory(category)
+            .setRequestType(SINGLE_GET)
+            .build();
+    Collection<MetricData> metricsData = inMemoryMetricReader.collectAllMetrics();
+    assertEquals(metricsData.size(), 2, "There should be two metrics recorded: call_time and call_count");
+
+    validateLongPointDataFromCounter(inMemoryMetricReader, 1, expectedAttributes, "call_count", otelPrefix);
+    validateExponentialHistogramPointData(
+        inMemoryMetricReader,
+        latency,
+        latency,
+        1,
+        latency,
+        expectedAttributes,
+        "call_time",
+        otelPrefix);
   }
 
   private void validateOtelMetrics(
@@ -414,7 +489,8 @@ public class BasicClientStatsTest {
                 VENICE_REQUEST_METHOD,
                 HTTP_RESPONSE_STATUS_CODE,
                 HTTP_RESPONSE_STATUS_CODE_CATEGORY,
-                VENICE_RESPONSE_STATUS_CODE_CATEGORY)));
+                VENICE_RESPONSE_STATUS_CODE_CATEGORY,
+                VENICE_REQUEST_KEY_COUNT_BUCKET)));
     expectedMetrics.put(
         BasicClientStats.BasicClientMetricEntity.CALL_COUNT_DVC,
         new MetricEntity(

--- a/internal/venice-client-common/src/main/java/com/linkedin/venice/stats/dimensions/VeniceMetricsDimensions.java
+++ b/internal/venice-client-common/src/main/java/com/linkedin/venice/stats/dimensions/VeniceMetricsDimensions.java
@@ -153,7 +153,10 @@ public enum VeniceMetricsDimensions {
   VENICE_CONNECTION_SOURCE("venice.connection.source"),
 
   /** {@link VeniceDrainerType} Drainer type: sorted or unsorted. */
-  VENICE_DRAINER_TYPE("venice.drainer.type");
+  VENICE_DRAINER_TYPE("venice.drainer.type"),
+
+  /** {@link VeniceRequestKeyCountBucket} Coarse key-count bucket for request batches. */
+  VENICE_REQUEST_KEY_COUNT_BUCKET("venice.request.key_count_bucket");
 
   private final String[] dimensionName = new String[VeniceOpenTelemetryMetricNamingFormat.SIZE];
 

--- a/internal/venice-client-common/src/main/java/com/linkedin/venice/stats/dimensions/VeniceRequestKeyCountBucket.java
+++ b/internal/venice-client-common/src/main/java/com/linkedin/venice/stats/dimensions/VeniceRequestKeyCountBucket.java
@@ -37,31 +37,27 @@ public enum VeniceRequestKeyCountBucket implements VeniceDimensionInterface {
   }
 
   /**
-   * Hot path is the positive-count balanced comparison tree (up to 4 branches). The non-positive
-   * sentinel case falls through to the terminal return so the rare path doesn't cost the common
-   * path anything.
+   * Single-get short-circuits in a single comparison. Multi-key requests fall through to a
+   * balanced comparison tree. The non-positive sentinel falls through to the terminal return.
    */
   public static VeniceRequestKeyCountBucket fromKeyCount(int keyCount) {
-    if (keyCount >= 1) {
+    if (keyCount == 1) {
+      return KEYS_EQ_1;
+    } else if (keyCount > 1) {
       if (keyCount <= 500) {
-        if (keyCount == 1) {
-          return KEYS_EQ_1;
-        } else if (keyCount <= 150) {
+        if (keyCount <= 150) {
           return KEYS_2_150;
-        } else {
-          return KEYS_151_500;
         }
+        return KEYS_151_500;
       } else if (keyCount <= 2000) {
         if (keyCount <= 1000) {
           return KEYS_501_1000;
-        } else {
-          return KEYS_1001_2000;
         }
+        return KEYS_1001_2000;
       } else if (keyCount <= 5000) {
         return KEYS_2001_5000;
-      } else {
-        return KEYS_GT_5000;
       }
+      return KEYS_GT_5000;
     }
     return KEYS_LE_0;
   }

--- a/internal/venice-client-common/src/main/java/com/linkedin/venice/stats/dimensions/VeniceRequestKeyCountBucket.java
+++ b/internal/venice-client-common/src/main/java/com/linkedin/venice/stats/dimensions/VeniceRequestKeyCountBucket.java
@@ -1,0 +1,68 @@
+package com.linkedin.venice.stats.dimensions;
+
+/**
+ * Coarse buckets for request key count, used as an OTel dimension on CallTime metrics so that
+ * SLOs can distinguish latency across batch sizes without blowing up cardinality with raw counts.
+ *
+ * <p>{@link #KEYS_LE_0} captures recordings that carry a non-positive key count — in practice the
+ * {@code -1} sentinel that server-side pre-parse errors emit when the request failed before its
+ * key count could be parsed. Dashboards should filter this bucket out of SLO views since the
+ * latency it represents is not tied to a real batch size.
+ */
+public enum VeniceRequestKeyCountBucket implements VeniceDimensionInterface {
+  /** Key count {@code <= 0}: pre-parse error sentinel (e.g., server {@code requestKeyCount == -1}). */
+  KEYS_LE_0,
+  /** Single-key request (single-get, or a multiget / compute with exactly one key). */
+  KEYS_EQ_1,
+  /** Small batch: 2 to 150 keys inclusive. */
+  KEYS_2_150,
+  /** Medium batch: 151 to 500 keys inclusive. */
+  KEYS_151_500,
+  /** Medium-large batch: 501 to 1000 keys inclusive. */
+  KEYS_501_1000,
+  /** Large batch: 1001 to 2000 keys inclusive. */
+  KEYS_1001_2000,
+  /** Very large batch: 2001 to 5000 keys inclusive. */
+  KEYS_2001_5000,
+  /** Oversized batch: more than 5000 keys. */
+  KEYS_GT_5000;
+
+  /**
+   * All instances of this Enum should have the same dimension name.
+   * Refer {@link VeniceDimensionInterface#getDimensionName()} for more details.
+   */
+  @Override
+  public VeniceMetricsDimensions getDimensionName() {
+    return VeniceMetricsDimensions.VENICE_REQUEST_KEY_COUNT_BUCKET;
+  }
+
+  /**
+   * Hot path is the positive-count balanced comparison tree (up to 4 branches). The non-positive
+   * sentinel case falls through to the terminal return so the rare path doesn't cost the common
+   * path anything.
+   */
+  public static VeniceRequestKeyCountBucket fromKeyCount(int keyCount) {
+    if (keyCount >= 1) {
+      if (keyCount <= 500) {
+        if (keyCount == 1) {
+          return KEYS_EQ_1;
+        } else if (keyCount <= 150) {
+          return KEYS_2_150;
+        } else {
+          return KEYS_151_500;
+        }
+      } else if (keyCount <= 2000) {
+        if (keyCount <= 1000) {
+          return KEYS_501_1000;
+        } else {
+          return KEYS_1001_2000;
+        }
+      } else if (keyCount <= 5000) {
+        return KEYS_2001_5000;
+      } else {
+        return KEYS_GT_5000;
+      }
+    }
+    return KEYS_LE_0;
+  }
+}

--- a/internal/venice-client-common/src/test/java/com/linkedin/venice/stats/dimensions/VeniceMetricsDimensionsTest.java
+++ b/internal/venice-client-common/src/test/java/com/linkedin/venice/stats/dimensions/VeniceMetricsDimensionsTest.java
@@ -157,6 +157,9 @@ public class VeniceMetricsDimensionsTest {
         case VENICE_DRAINER_TYPE:
           assertEquals(dimension.getDimensionName(format), "venice.drainer.type");
           break;
+        case VENICE_REQUEST_KEY_COUNT_BUCKET:
+          assertEquals(dimension.getDimensionName(format), "venice.request.key_count_bucket");
+          break;
         default:
           throw new IllegalArgumentException("Unknown dimension: " + dimension);
       }
@@ -312,6 +315,9 @@ public class VeniceMetricsDimensionsTest {
         case VENICE_DRAINER_TYPE:
           assertEquals(dimension.getDimensionName(format), "venice.drainer.type");
           break;
+        case VENICE_REQUEST_KEY_COUNT_BUCKET:
+          assertEquals(dimension.getDimensionName(format), "venice.request.keyCountBucket");
+          break;
         default:
           throw new IllegalArgumentException("Unknown dimension: " + dimension);
       }
@@ -466,6 +472,9 @@ public class VeniceMetricsDimensionsTest {
           break;
         case VENICE_DRAINER_TYPE:
           assertEquals(dimension.getDimensionName(format), "Venice.Drainer.Type");
+          break;
+        case VENICE_REQUEST_KEY_COUNT_BUCKET:
+          assertEquals(dimension.getDimensionName(format), "Venice.Request.KeyCountBucket");
           break;
         default:
           throw new IllegalArgumentException("Unknown dimension: " + dimension);

--- a/internal/venice-client-common/src/test/java/com/linkedin/venice/stats/dimensions/VeniceRequestKeyCountBucketTest.java
+++ b/internal/venice-client-common/src/test/java/com/linkedin/venice/stats/dimensions/VeniceRequestKeyCountBucketTest.java
@@ -1,0 +1,51 @@
+package com.linkedin.venice.stats.dimensions;
+
+import static com.linkedin.venice.stats.dimensions.VeniceRequestKeyCountBucket.KEYS_1001_2000;
+import static com.linkedin.venice.stats.dimensions.VeniceRequestKeyCountBucket.KEYS_151_500;
+import static com.linkedin.venice.stats.dimensions.VeniceRequestKeyCountBucket.KEYS_2001_5000;
+import static com.linkedin.venice.stats.dimensions.VeniceRequestKeyCountBucket.KEYS_2_150;
+import static com.linkedin.venice.stats.dimensions.VeniceRequestKeyCountBucket.KEYS_501_1000;
+import static com.linkedin.venice.stats.dimensions.VeniceRequestKeyCountBucket.KEYS_EQ_1;
+import static com.linkedin.venice.stats.dimensions.VeniceRequestKeyCountBucket.KEYS_GT_5000;
+import static com.linkedin.venice.stats.dimensions.VeniceRequestKeyCountBucket.KEYS_LE_0;
+import static org.testng.Assert.assertEquals;
+
+import com.linkedin.venice.utils.CollectionUtils;
+import java.util.Map;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+
+public class VeniceRequestKeyCountBucketTest {
+  @Test
+  public void testDimensionInterface() {
+    Map<VeniceRequestKeyCountBucket, String> expectedValues =
+        CollectionUtils.<VeniceRequestKeyCountBucket, String>mapBuilder()
+            .put(KEYS_LE_0, "keys_le_0")
+            .put(KEYS_EQ_1, "keys_eq_1")
+            .put(KEYS_2_150, "keys_2_150")
+            .put(KEYS_151_500, "keys_151_500")
+            .put(KEYS_501_1000, "keys_501_1000")
+            .put(KEYS_1001_2000, "keys_1001_2000")
+            .put(KEYS_2001_5000, "keys_2001_5000")
+            .put(KEYS_GT_5000, "keys_gt_5000")
+            .build();
+    new VeniceDimensionTestFixture<>(
+        VeniceRequestKeyCountBucket.class,
+        VeniceMetricsDimensions.VENICE_REQUEST_KEY_COUNT_BUCKET,
+        expectedValues).assertAll();
+  }
+
+  @DataProvider(name = "boundaries")
+  public Object[][] boundaries() {
+    return new Object[][] { { Integer.MIN_VALUE, KEYS_LE_0 }, { -1, KEYS_LE_0 }, { 0, KEYS_LE_0 }, { 1, KEYS_EQ_1 },
+        { 2, KEYS_2_150 }, { 150, KEYS_2_150 }, { 151, KEYS_151_500 }, { 500, KEYS_151_500 }, { 501, KEYS_501_1000 },
+        { 1000, KEYS_501_1000 }, { 1001, KEYS_1001_2000 }, { 2000, KEYS_1001_2000 }, { 2001, KEYS_2001_5000 },
+        { 5000, KEYS_2001_5000 }, { 5001, KEYS_GT_5000 }, { Integer.MAX_VALUE, KEYS_GT_5000 } };
+  }
+
+  @Test(dataProvider = "boundaries")
+  public void testFromKeyCountBoundaries(int keyCount, VeniceRequestKeyCountBucket expected) {
+    assertEquals(VeniceRequestKeyCountBucket.fromKeyCount(keyCount), expected);
+  }
+}

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/fastclient/utils/AbstractClientEndToEndSetup.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/fastclient/utils/AbstractClientEndToEndSetup.java
@@ -48,6 +48,7 @@ import com.linkedin.venice.serialization.avro.VeniceAvroKafkaSerializer;
 import com.linkedin.venice.stats.VeniceMetricsConfig;
 import com.linkedin.venice.stats.VeniceMetricsRepository;
 import com.linkedin.venice.stats.dimensions.HttpResponseStatusEnum;
+import com.linkedin.venice.stats.dimensions.VeniceRequestKeyCountBucket;
 import com.linkedin.venice.stats.dimensions.VeniceResponseStatusCategory;
 import com.linkedin.venice.utils.DataProviderUtils;
 import com.linkedin.venice.utils.IntegrationTestPushUtils;
@@ -506,6 +507,18 @@ public abstract class AbstractClientEndToEndSetup {
             .setHttpStatus(HttpResponseStatusEnum.OK)
             .setVeniceStatusCategory(VeniceResponseStatusCategory.SUCCESS)
             .build();
+    // call_time carries an additional key-count-bucket dimension. Single-get sends 1 key per
+    // request -> KEYS_EQ_1; multi-get / compute send recordCnt (100) keys per request -> KEYS_2_150.
+    VeniceRequestKeyCountBucket callTimeBucket = requestType == RequestType.SINGLE_GET
+        ? VeniceRequestKeyCountBucket.KEYS_EQ_1
+        : VeniceRequestKeyCountBucket.fromKeyCount(recordCnt);
+    Attributes callTimeExpectedAttributes =
+        new OpenTelemetryDataTestUtils.OpenTelemetryAttributesBuilder().setStoreName(storeName)
+            .setRequestType(updatedRequestType)
+            .setHttpStatus(HttpResponseStatusEnum.OK)
+            .setVeniceStatusCategory(VeniceResponseStatusCategory.SUCCESS)
+            .setKeyCountBucket(callTimeBucket)
+            .build();
     // counters are incremented in an async manner, so adding non-deterministic wait
     TestUtils.waitForNonDeterministicAssertion(5, TimeUnit.SECONDS, () -> {
       validateLongPointDataFromCounter(
@@ -517,7 +530,7 @@ public abstract class AbstractClientEndToEndSetup {
       validateExponentialHistogramPointDataForLatency(
           inMemoryMetricReader,
           numRequests,
-          requestExpectedAttributes,
+          callTimeExpectedAttributes,
           CALL_TIME.getMetricEntity().getMetricName(),
           FAST_CLIENT.getMetricsPrefix());
     });

--- a/internal/venice-test-common/src/main/java/com/linkedin/venice/utils/OpenTelemetryDataTestUtils.java
+++ b/internal/venice-test-common/src/main/java/com/linkedin/venice/utils/OpenTelemetryDataTestUtils.java
@@ -4,6 +4,7 @@ import static com.linkedin.venice.stats.VeniceOpenTelemetryMetricsRepository.DEF
 import static com.linkedin.venice.stats.dimensions.HttpResponseStatusCodeCategory.getVeniceHttpResponseStatusCodeCategory;
 import static com.linkedin.venice.stats.dimensions.VeniceMetricsDimensions.HTTP_RESPONSE_STATUS_CODE;
 import static com.linkedin.venice.stats.dimensions.VeniceMetricsDimensions.HTTP_RESPONSE_STATUS_CODE_CATEGORY;
+import static com.linkedin.venice.stats.dimensions.VeniceMetricsDimensions.VENICE_REQUEST_KEY_COUNT_BUCKET;
 import static com.linkedin.venice.stats.dimensions.VeniceMetricsDimensions.VENICE_REQUEST_METHOD;
 import static com.linkedin.venice.stats.dimensions.VeniceMetricsDimensions.VENICE_REQUEST_RETRY_TYPE;
 import static com.linkedin.venice.stats.dimensions.VeniceMetricsDimensions.VENICE_RESPONSE_STATUS_CODE_CATEGORY;
@@ -20,6 +21,7 @@ import com.linkedin.venice.stats.VeniceMetricsRepository;
 import com.linkedin.venice.stats.dimensions.HttpResponseStatusEnum;
 import com.linkedin.venice.stats.dimensions.RequestRetryType;
 import com.linkedin.venice.stats.dimensions.VeniceMetricsDimensions;
+import com.linkedin.venice.stats.dimensions.VeniceRequestKeyCountBucket;
 import com.linkedin.venice.stats.dimensions.VeniceResponseStatusCategory;
 import com.linkedin.venice.stats.metrics.MetricEntity;
 import io.opentelemetry.api.common.Attributes;
@@ -46,6 +48,7 @@ public abstract class OpenTelemetryDataTestUtils {
     private HttpResponseStatusEnum httpStatus;
     private VeniceResponseStatusCategory veniceStatusCategory;
     private RequestRetryType retryType;
+    private VeniceRequestKeyCountBucket keyCountBucket;
 
     /**
      * Set the store name dimension.
@@ -104,6 +107,14 @@ public abstract class OpenTelemetryDataTestUtils {
     }
 
     /**
+     * Set the request key-count-bucket dimension (OTel-only, used on CallTime metrics).
+     */
+    public OpenTelemetryAttributesBuilder setKeyCountBucket(VeniceRequestKeyCountBucket keyCountBucket) {
+      this.keyCountBucket = keyCountBucket;
+      return this;
+    }
+
+    /**
      * Build: setup base dimensions and attributes, and determine if OTel metrics should be emitted.
      * @return OpenTelemetryMetricsSetupInfo containing this information
      */
@@ -149,6 +160,12 @@ public abstract class OpenTelemetryDataTestUtils {
       // Add retry type if provided
       if (retryType != null) {
         builder.put(VENICE_REQUEST_RETRY_TYPE.getDimensionNameInDefaultFormat(), retryType.getDimensionValue());
+      }
+
+      // Add key count bucket if provided
+      if (keyCountBucket != null) {
+        builder
+            .put(VENICE_REQUEST_KEY_COUNT_BUCKET.getDimensionNameInDefaultFormat(), keyCountBucket.getDimensionValue());
       }
 
       return builder.build();

--- a/services/venice-router/src/main/java/com/linkedin/venice/router/stats/RouterHttpRequestStats.java
+++ b/services/venice-router/src/main/java/com/linkedin/venice/router/stats/RouterHttpRequestStats.java
@@ -34,9 +34,11 @@ import com.linkedin.venice.stats.dimensions.MessageType;
 import com.linkedin.venice.stats.dimensions.RequestRetryAbortReason;
 import com.linkedin.venice.stats.dimensions.RequestRetryType;
 import com.linkedin.venice.stats.dimensions.VeniceMetricsDimensions;
+import com.linkedin.venice.stats.dimensions.VeniceRequestKeyCountBucket;
 import com.linkedin.venice.stats.dimensions.VeniceResponseStatusCategory;
 import com.linkedin.venice.stats.metrics.MetricEntityState;
 import com.linkedin.venice.stats.metrics.MetricEntityStateBase;
+import com.linkedin.venice.stats.metrics.MetricEntityStateFourEnums;
 import com.linkedin.venice.stats.metrics.MetricEntityStateOneEnum;
 import com.linkedin.venice.stats.metrics.MetricEntityStateThreeEnums;
 import com.linkedin.venice.stats.metrics.TehutiMetricNameEnum;
@@ -54,6 +56,7 @@ import io.tehuti.metrics.stats.OccurrenceRate;
 import io.tehuti.metrics.stats.Rate;
 import io.tehuti.metrics.stats.Total;
 import java.util.Arrays;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -74,10 +77,10 @@ public class RouterHttpRequestStats extends AbstractVeniceHttpStats {
 
   /** latency metrics */
   private final Sensor latencyTehutiSensor; // This can be removed while removing tehuti
-  private final MetricEntityStateThreeEnums<HttpResponseStatusEnum, HttpResponseStatusCodeCategory, VeniceResponseStatusCategory> healthyLatencyMetric;
-  private final MetricEntityStateThreeEnums<HttpResponseStatusEnum, HttpResponseStatusCodeCategory, VeniceResponseStatusCategory> unhealthyLatencyMetric;
-  private final MetricEntityStateThreeEnums<HttpResponseStatusEnum, HttpResponseStatusCodeCategory, VeniceResponseStatusCategory> tardyLatencyMetric;
-  private final MetricEntityStateThreeEnums<HttpResponseStatusEnum, HttpResponseStatusCodeCategory, VeniceResponseStatusCategory> throttledLatencyMetric;
+  private final MetricEntityStateFourEnums<HttpResponseStatusEnum, HttpResponseStatusCodeCategory, VeniceResponseStatusCategory, VeniceRequestKeyCountBucket> healthyLatencyMetric;
+  private final MetricEntityStateFourEnums<HttpResponseStatusEnum, HttpResponseStatusCodeCategory, VeniceResponseStatusCategory, VeniceRequestKeyCountBucket> unhealthyLatencyMetric;
+  private final MetricEntityStateFourEnums<HttpResponseStatusEnum, HttpResponseStatusCodeCategory, VeniceResponseStatusCategory, VeniceRequestKeyCountBucket> tardyLatencyMetric;
+  private final MetricEntityStateFourEnums<HttpResponseStatusEnum, HttpResponseStatusCodeCategory, VeniceResponseStatusCategory, VeniceRequestKeyCountBucket> throttledLatencyMetric;
 
   /** retry metrics */
   private final MetricEntityStateOneEnum<RequestRetryType> retryCountMetric;
@@ -253,53 +256,22 @@ public class RouterHttpRequestStats extends AbstractVeniceHttpStats {
         VeniceResponseStatusCategory.class);
 
     latencyTehutiSensor = registerSensorWithDetailedPercentiles("latency", new Avg(), new Max(0));
-    healthyLatencyMetric = MetricEntityStateThreeEnums.create(
-        CALL_TIME.getMetricEntity(),
-        otelRepository,
-        this::registerSensorFinal,
+    healthyLatencyMetric = createCallTimeMetric(
         RouterTehutiMetricNameEnum.HEALTHY_REQUEST_LATENCY,
         Arrays.asList(
             new Avg(),
             new Max(0),
             TehutiUtils.getPercentileStatForNetworkLatency(
                 getName(),
-                getFullMetricName(RouterTehutiMetricNameEnum.HEALTHY_REQUEST_LATENCY.getMetricName()))),
-        baseDimensionsMap,
-        HttpResponseStatusEnum.class,
-        HttpResponseStatusCodeCategory.class,
-        VeniceResponseStatusCategory.class);
-    unhealthyLatencyMetric = MetricEntityStateThreeEnums.create(
-        CALL_TIME.getMetricEntity(),
-        otelRepository,
-        this::registerSensorFinal,
+                getFullMetricName(RouterTehutiMetricNameEnum.HEALTHY_REQUEST_LATENCY.getMetricName()))));
+    unhealthyLatencyMetric = createCallTimeMetric(
         RouterTehutiMetricNameEnum.UNHEALTHY_REQUEST_LATENCY,
-        Arrays.asList(new Avg(), new Max(0)),
-        baseDimensionsMap,
-        HttpResponseStatusEnum.class,
-        HttpResponseStatusCodeCategory.class,
-        VeniceResponseStatusCategory.class);
-
-    tardyLatencyMetric = MetricEntityStateThreeEnums.create(
-        CALL_TIME.getMetricEntity(),
-        otelRepository,
-        this::registerSensorFinal,
-        RouterTehutiMetricNameEnum.TARDY_REQUEST_LATENCY,
-        Arrays.asList(new Avg(), new Max(0)),
-        baseDimensionsMap,
-        HttpResponseStatusEnum.class,
-        HttpResponseStatusCodeCategory.class,
-        VeniceResponseStatusCategory.class);
-
-    throttledLatencyMetric = MetricEntityStateThreeEnums.create(
-        CALL_TIME.getMetricEntity(),
-        otelRepository,
-        this::registerSensorFinal,
+        Arrays.asList(new Avg(), new Max(0)));
+    tardyLatencyMetric =
+        createCallTimeMetric(RouterTehutiMetricNameEnum.TARDY_REQUEST_LATENCY, Arrays.asList(new Avg(), new Max(0)));
+    throttledLatencyMetric = createCallTimeMetric(
         RouterTehutiMetricNameEnum.THROTTLED_REQUEST_LATENCY,
-        Arrays.asList(new Avg(), new Max(0)),
-        baseDimensionsMap,
-        HttpResponseStatusEnum.class,
-        HttpResponseStatusCodeCategory.class,
-        VeniceResponseStatusCategory.class);
+        Arrays.asList(new Avg(), new Max(0)));
 
     retryCountMetric = MetricEntityStateOneEnum.create(
         RETRY_COUNT.getMetricEntity(),
@@ -511,6 +483,22 @@ public class RouterHttpRequestStats extends AbstractVeniceHttpStats {
     this.totalInFlightRequestSensor = totalInFlightRequestSensor;
   }
 
+  private MetricEntityStateFourEnums<HttpResponseStatusEnum, HttpResponseStatusCodeCategory, VeniceResponseStatusCategory, VeniceRequestKeyCountBucket> createCallTimeMetric(
+      RouterTehutiMetricNameEnum tehutiName,
+      List<MeasurableStat> tehutiStats) {
+    return MetricEntityStateFourEnums.create(
+        CALL_TIME.getMetricEntity(),
+        otelRepository,
+        this::registerSensorFinal,
+        tehutiName,
+        tehutiStats,
+        baseDimensionsMap,
+        HttpResponseStatusEnum.class,
+        HttpResponseStatusCodeCategory.class,
+        VeniceResponseStatusCategory.class,
+        VeniceRequestKeyCountBucket.class);
+  }
+
   /**
    * We record this at the beginning of request handling, so we don't know the latency yet... All specific
    * types of requests also have their latencies logged at the same time.
@@ -569,13 +557,18 @@ public class RouterHttpRequestStats extends AbstractVeniceHttpStats {
       HttpResponseStatus responseStatus,
       VeniceResponseStatusCategory veniceResponseStatusCategory,
       MetricEntityStateThreeEnums<HttpResponseStatusEnum, HttpResponseStatusCodeCategory, VeniceResponseStatusCategory> requestMetric,
-      MetricEntityStateThreeEnums<HttpResponseStatusEnum, HttpResponseStatusCodeCategory, VeniceResponseStatusCategory> latencyMetric) {
+      MetricEntityStateFourEnums<HttpResponseStatusEnum, HttpResponseStatusCodeCategory, VeniceResponseStatusCategory, VeniceRequestKeyCountBucket> latencyMetric) {
     HttpResponseStatusEnum httpResponseStatusEnum = transformHttpResponseStatusToHttpResponseStatusEnum(responseStatus);
     HttpResponseStatusCodeCategory httpResponseStatusCodeCategory =
         getVeniceHttpResponseStatusCodeCategory(responseStatus);
     requestMetric.record(1, httpResponseStatusEnum, httpResponseStatusCodeCategory, veniceResponseStatusCategory);
     keyCountMetric.record(keyNum, httpResponseStatusEnum, httpResponseStatusCodeCategory, veniceResponseStatusCategory);
-    latencyMetric.record(latency, httpResponseStatusEnum, httpResponseStatusCodeCategory, veniceResponseStatusCategory);
+    latencyMetric.record(
+        latency,
+        httpResponseStatusEnum,
+        httpResponseStatusCodeCategory,
+        veniceResponseStatusCategory,
+        VeniceRequestKeyCountBucket.fromKeyCount(keyNum));
   }
 
   public void recordUnavailableReplicaStreamingRequest() {

--- a/services/venice-router/src/main/java/com/linkedin/venice/router/stats/RouterMetricEntity.java
+++ b/services/venice-router/src/main/java/com/linkedin/venice/router/stats/RouterMetricEntity.java
@@ -4,6 +4,7 @@ import static com.linkedin.venice.stats.dimensions.VeniceMetricsDimensions.HTTP_
 import static com.linkedin.venice.stats.dimensions.VeniceMetricsDimensions.HTTP_RESPONSE_STATUS_CODE_CATEGORY;
 import static com.linkedin.venice.stats.dimensions.VeniceMetricsDimensions.VENICE_CLUSTER_NAME;
 import static com.linkedin.venice.stats.dimensions.VeniceMetricsDimensions.VENICE_MESSAGE_TYPE;
+import static com.linkedin.venice.stats.dimensions.VeniceMetricsDimensions.VENICE_REQUEST_KEY_COUNT_BUCKET;
 import static com.linkedin.venice.stats.dimensions.VeniceMetricsDimensions.VENICE_REQUEST_METHOD;
 import static com.linkedin.venice.stats.dimensions.VeniceMetricsDimensions.VENICE_REQUEST_RETRY_ABORT_REASON;
 import static com.linkedin.venice.stats.dimensions.VeniceMetricsDimensions.VENICE_REQUEST_RETRY_TYPE;
@@ -47,7 +48,8 @@ public enum RouterMetricEntity implements ModuleMetricEntityInterface {
           VENICE_REQUEST_METHOD,
           HTTP_RESPONSE_STATUS_CODE,
           HTTP_RESPONSE_STATUS_CODE_CATEGORY,
-          VENICE_RESPONSE_STATUS_CODE_CATEGORY)
+          VENICE_RESPONSE_STATUS_CODE_CATEGORY,
+          VENICE_REQUEST_KEY_COUNT_BUCKET)
   ),
   /**
    * Size of request and response in bytes

--- a/services/venice-router/src/test/java/com/linkedin/venice/router/stats/RouterHttpRequestStatsTest.java
+++ b/services/venice-router/src/test/java/com/linkedin/venice/router/stats/RouterHttpRequestStatsTest.java
@@ -24,13 +24,17 @@ import com.linkedin.venice.stats.VeniceMetricsConfig;
 import com.linkedin.venice.stats.VeniceMetricsRepository;
 import com.linkedin.venice.stats.VeniceOpenTelemetryMetricNamingFormat;
 import com.linkedin.venice.stats.VeniceOpenTelemetryMetricsRepository;
+import com.linkedin.venice.stats.dimensions.HttpResponseStatusEnum;
 import com.linkedin.venice.stats.dimensions.MessageType;
 import com.linkedin.venice.stats.dimensions.VeniceMetricsDimensions;
+import com.linkedin.venice.stats.dimensions.VeniceRequestKeyCountBucket;
+import com.linkedin.venice.stats.dimensions.VeniceResponseStatusCategory;
 import com.linkedin.venice.stats.metrics.MetricEntity;
 import com.linkedin.venice.stats.metrics.MetricType;
 import com.linkedin.venice.stats.metrics.MetricUnit;
 import com.linkedin.venice.tehuti.MockTehutiReporter;
 import com.linkedin.venice.utils.DataProviderUtils;
+import com.linkedin.venice.utils.OpenTelemetryDataTestUtils;
 import com.linkedin.venice.utils.Utils;
 import com.linkedin.venice.utils.metrics.MetricsRepositoryUtils;
 import io.netty.handler.codec.http.HttpResponseStatus;
@@ -299,6 +303,80 @@ public class RouterHttpRequestStatsTest {
         reporter.query("." + storeName + "--" + prefix + "body_aggregation_latency" + ".99thPercentile").value();
     assertEquals((int) p50, 50);
     assertEquals((int) p99, 99);
+  }
+
+  /**
+   * Verifies that CALL_TIME OTel histogram carries the {@code venice.request.key_count_bucket}
+   * dimension derived from the recorded keyNum. Covers recordHealthyRequest (KEYS_151_500) and
+   * recordUnhealthyRequest (KEYS_2_150) to ensure different keyNums map to the correct buckets.
+   */
+  @Test
+  public void testCallTimeKeyCountBucketDimension() {
+    String storeName = "test-store";
+    String clusterName = "test-cluster";
+    InMemoryMetricReader inMemoryMetricReader = InMemoryMetricReader.create();
+    VeniceMetricsRepository metricsRepository =
+        getVeniceMetricsRepositoryForRouter(RouterServer.ROUTER_SERVICE_METRIC_ENTITIES, true, inMemoryMetricReader);
+    RouterHttpRequestStats stats = new RouterHttpRequestStats(
+        metricsRepository,
+        storeName,
+        clusterName,
+        RequestType.MULTI_GET_STREAMING,
+        mock(ScatterGatherStats.class),
+        false,
+        null);
+
+    // keyNum=250 -> KEYS_151_500 bucket
+    stats.recordHealthyRequest(1.0, HttpResponseStatus.OK, 250);
+    // keyNum=100 -> KEYS_2_150 bucket
+    stats.recordUnhealthyRequest(2.0, HttpResponseStatus.INTERNAL_SERVER_ERROR, 100);
+
+    validateCallTimeWithBucket(
+        inMemoryMetricReader,
+        storeName,
+        clusterName,
+        RequestType.MULTI_GET_STREAMING,
+        HttpResponseStatusEnum.OK,
+        VeniceResponseStatusCategory.SUCCESS,
+        VeniceRequestKeyCountBucket.KEYS_151_500,
+        1.0);
+    validateCallTimeWithBucket(
+        inMemoryMetricReader,
+        storeName,
+        clusterName,
+        RequestType.MULTI_GET_STREAMING,
+        HttpResponseStatusEnum.INTERNAL_SERVER_ERROR,
+        VeniceResponseStatusCategory.FAIL,
+        VeniceRequestKeyCountBucket.KEYS_2_150,
+        2.0);
+  }
+
+  private void validateCallTimeWithBucket(
+      InMemoryMetricReader inMemoryMetricReader,
+      String storeName,
+      String clusterName,
+      RequestType requestType,
+      HttpResponseStatusEnum httpStatus,
+      VeniceResponseStatusCategory veniceCategory,
+      VeniceRequestKeyCountBucket bucket,
+      double expectedLatency) {
+    Attributes expectedAttributes =
+        new OpenTelemetryDataTestUtils.OpenTelemetryAttributesBuilder().setStoreName(storeName)
+            .setClusterName(clusterName)
+            .setRequestType(requestType)
+            .setHttpStatus(httpStatus)
+            .setVeniceStatusCategory(veniceCategory)
+            .setKeyCountBucket(bucket)
+            .build();
+    validateExponentialHistogramPointData(
+        inMemoryMetricReader,
+        expectedLatency,
+        expectedLatency,
+        1,
+        expectedLatency,
+        expectedAttributes,
+        "call_time",
+        "");
   }
 
 }

--- a/services/venice-router/src/test/java/com/linkedin/venice/router/stats/RouterMetricEntityTest.java
+++ b/services/venice-router/src/test/java/com/linkedin/venice/router/stats/RouterMetricEntityTest.java
@@ -4,6 +4,7 @@ import static com.linkedin.venice.stats.dimensions.VeniceMetricsDimensions.HTTP_
 import static com.linkedin.venice.stats.dimensions.VeniceMetricsDimensions.HTTP_RESPONSE_STATUS_CODE_CATEGORY;
 import static com.linkedin.venice.stats.dimensions.VeniceMetricsDimensions.VENICE_CLUSTER_NAME;
 import static com.linkedin.venice.stats.dimensions.VeniceMetricsDimensions.VENICE_MESSAGE_TYPE;
+import static com.linkedin.venice.stats.dimensions.VeniceMetricsDimensions.VENICE_REQUEST_KEY_COUNT_BUCKET;
 import static com.linkedin.venice.stats.dimensions.VeniceMetricsDimensions.VENICE_REQUEST_METHOD;
 import static com.linkedin.venice.stats.dimensions.VeniceMetricsDimensions.VENICE_REQUEST_RETRY_ABORT_REASON;
 import static com.linkedin.venice.stats.dimensions.VeniceMetricsDimensions.VENICE_REQUEST_RETRY_TYPE;
@@ -58,7 +59,8 @@ public class RouterMetricEntityTest {
                 VENICE_REQUEST_METHOD,
                 HTTP_RESPONSE_STATUS_CODE,
                 HTTP_RESPONSE_STATUS_CODE_CATEGORY,
-                VENICE_RESPONSE_STATUS_CODE_CATEGORY)));
+                VENICE_RESPONSE_STATUS_CODE_CATEGORY,
+                VENICE_REQUEST_KEY_COUNT_BUCKET)));
     map.put(
         RouterMetricEntity.CALL_SIZE,
         new MetricEntityExpectation(

--- a/services/venice-server/src/main/java/com/linkedin/venice/listener/ServerStatsContext.java
+++ b/services/venice-server/src/main/java/com/linkedin/venice/listener/ServerStatsContext.java
@@ -238,7 +238,11 @@ public class ServerStatsContext {
       throw new VeniceException("response status could not be null");
     }
 
-    stats.recordSuccessRequestAndLatency(responseStatus, VeniceResponseStatusCategory.SUCCESS, elapsedTime);
+    stats.recordSuccessRequestAndLatency(
+        responseStatus,
+        VeniceResponseStatusCategory.SUCCESS,
+        elapsedTime,
+        requestKeyCount);
   }
 
   /**
@@ -259,7 +263,7 @@ public class ServerStatsContext {
       throw new VeniceException("response status could not be null");
     }
 
-    stats.recordErrorRequestAndLatency(responseStatus, VeniceResponseStatusCategory.FAIL, elapsedTime);
+    stats.recordErrorRequestAndLatency(responseStatus, VeniceResponseStatusCategory.FAIL, elapsedTime, requestKeyCount);
     if (isMisroutedStoreVersion) {
       // Tehuti-only: OTel captures this via READ_CALL_COUNT with HTTP 500 status dimension
       stats.recordMisroutedStoreVersionRequest();

--- a/services/venice-server/src/main/java/com/linkedin/venice/stats/AggServerHttpRequestStats.java
+++ b/services/venice-server/src/main/java/com/linkedin/venice/stats/AggServerHttpRequestStats.java
@@ -83,14 +83,6 @@ public class AggServerHttpRequestStats extends AbstractVeniceAggStoreStats<Serve
     totalStats.recordErrorRequest(statusEnum, statusCategory, veniceCategory);
   }
 
-  public void recordErrorRequestLatency(
-      HttpResponseStatusEnum statusEnum,
-      HttpResponseStatusCodeCategory statusCategory,
-      VeniceResponseStatusCategory veniceCategory,
-      double latency) {
-    totalStats.recordErrorRequestLatency(statusEnum, statusCategory, veniceCategory, latency);
-  }
-
   public void recordMisroutedStoreVersionRequest() {
     totalStats.recordMisroutedStoreVersionRequest();
   }

--- a/services/venice-server/src/main/java/com/linkedin/venice/stats/ServerHttpRequestStats.java
+++ b/services/venice-server/src/main/java/com/linkedin/venice/stats/ServerHttpRequestStats.java
@@ -24,8 +24,10 @@ import com.linkedin.venice.stats.dimensions.HttpResponseStatusEnum;
 import com.linkedin.venice.stats.dimensions.VeniceChunkingStatus;
 import com.linkedin.venice.stats.dimensions.VeniceComputeOperationType;
 import com.linkedin.venice.stats.dimensions.VeniceMetricsDimensions;
+import com.linkedin.venice.stats.dimensions.VeniceRequestKeyCountBucket;
 import com.linkedin.venice.stats.dimensions.VeniceResponseStatusCategory;
 import com.linkedin.venice.stats.metrics.MetricEntityStateBase;
+import com.linkedin.venice.stats.metrics.MetricEntityStateFourEnums;
 import com.linkedin.venice.stats.metrics.MetricEntityStateOneEnum;
 import com.linkedin.venice.stats.metrics.MetricEntityStateThreeEnums;
 import com.linkedin.venice.stats.metrics.TehutiMetricNameEnum;
@@ -55,8 +57,8 @@ import java.util.function.Supplier;
 public class ServerHttpRequestStats extends AbstractVeniceHttpStats {
   private final MetricEntityStateThreeEnums<HttpResponseStatusEnum, HttpResponseStatusCodeCategory, VeniceResponseStatusCategory> successRequestMetric;
   private final MetricEntityStateThreeEnums<HttpResponseStatusEnum, HttpResponseStatusCodeCategory, VeniceResponseStatusCategory> errorRequestMetric;
-  private final MetricEntityStateThreeEnums<HttpResponseStatusEnum, HttpResponseStatusCodeCategory, VeniceResponseStatusCategory> successRequestLatencyMetric;
-  private final MetricEntityStateThreeEnums<HttpResponseStatusEnum, HttpResponseStatusCodeCategory, VeniceResponseStatusCategory> errorRequestLatencyMetric;
+  private final MetricEntityStateFourEnums<HttpResponseStatusEnum, HttpResponseStatusCodeCategory, VeniceResponseStatusCategory, VeniceRequestKeyCountBucket> successRequestLatencyMetric;
+  private final MetricEntityStateFourEnums<HttpResponseStatusEnum, HttpResponseStatusCodeCategory, VeniceResponseStatusCategory, VeniceRequestKeyCountBucket> errorRequestLatencyMetric;
   private final MetricEntityStateThreeEnums<HttpResponseStatusEnum, HttpResponseStatusCodeCategory, VeniceResponseStatusCategory> responseValueSizeMetric;
   private final MetricEntityStateThreeEnums<HttpResponseStatusEnum, HttpResponseStatusCodeCategory, VeniceResponseStatusCategory> responseSizeMetric;
   private final MetricEntityStateOneEnum<VeniceChunkingStatus> storageEngineQueryTimeMetric;
@@ -159,7 +161,7 @@ public class ServerHttpRequestStats extends AbstractVeniceHttpStats {
         "success_request_ratio",
         new TehutiUtils.RatioStat(successRequest, errorRequest, "success_request_ratio"));
 
-    successRequestLatencyMetric = MetricEntityStateThreeEnums.create(
+    successRequestLatencyMetric = MetricEntityStateFourEnums.create(
         READ_CALL_TIME.getMetricEntity(),
         otelRepository,
         registerPerStoreAndTotal(totalStats != null ? totalStats.successRequestLatencyMetric : null),
@@ -169,9 +171,10 @@ public class ServerHttpRequestStats extends AbstractVeniceHttpStats {
         baseDimensionsMap,
         HttpResponseStatusEnum.class,
         HttpResponseStatusCodeCategory.class,
-        VeniceResponseStatusCategory.class);
+        VeniceResponseStatusCategory.class,
+        VeniceRequestKeyCountBucket.class);
 
-    errorRequestLatencyMetric = MetricEntityStateThreeEnums.create(
+    errorRequestLatencyMetric = MetricEntityStateFourEnums.create(
         READ_CALL_TIME.getMetricEntity(),
         otelRepository,
         registerPerStoreAndTotal(totalStats != null ? totalStats.errorRequestLatencyMetric : null),
@@ -181,7 +184,8 @@ public class ServerHttpRequestStats extends AbstractVeniceHttpStats {
         baseDimensionsMap,
         HttpResponseStatusEnum.class,
         HttpResponseStatusCodeCategory.class,
-        VeniceResponseStatusCategory.class);
+        VeniceResponseStatusCategory.class,
+        VeniceRequestKeyCountBucket.class);
 
     responseSizeMetric = MetricEntityStateThreeEnums.create(
         READ_RESPONSE_SIZE.getMetricEntity(),
@@ -509,40 +513,36 @@ public class ServerHttpRequestStats extends AbstractVeniceHttpStats {
     errorRequestMetric.record(1, statusEnum, statusCategory, veniceCategory);
   }
 
-  public void recordSuccessRequestLatency(
-      HttpResponseStatusEnum statusEnum,
-      HttpResponseStatusCodeCategory statusCategory,
-      VeniceResponseStatusCategory veniceCategory,
-      double latency) {
-    successRequestLatencyMetric.record(latency, statusEnum, statusCategory, veniceCategory);
-  }
-
-  public void recordErrorRequestLatency(
-      HttpResponseStatusEnum statusEnum,
-      HttpResponseStatusCodeCategory statusCategory,
-      VeniceResponseStatusCategory veniceCategory,
-      double latency) {
-    errorRequestLatencyMetric.record(latency, statusEnum, statusCategory, veniceCategory);
-  }
-
   public void recordSuccessRequestAndLatency(
       HttpResponseStatus responseStatus,
       VeniceResponseStatusCategory veniceCategory,
-      double latency) {
+      double latency,
+      int keyCount) {
     HttpResponseStatusEnum statusEnum = resolveStatusEnum(responseStatus);
     HttpResponseStatusCodeCategory statusCategory = resolveStatusCategory(responseStatus);
     successRequestMetric.record(1, statusEnum, statusCategory, veniceCategory);
-    successRequestLatencyMetric.record(latency, statusEnum, statusCategory, veniceCategory);
+    successRequestLatencyMetric.record(
+        latency,
+        statusEnum,
+        statusCategory,
+        veniceCategory,
+        VeniceRequestKeyCountBucket.fromKeyCount(keyCount));
   }
 
   public void recordErrorRequestAndLatency(
       HttpResponseStatus responseStatus,
       VeniceResponseStatusCategory veniceCategory,
-      double latency) {
+      double latency,
+      int keyCount) {
     HttpResponseStatusEnum statusEnum = resolveStatusEnum(responseStatus);
     HttpResponseStatusCodeCategory statusCategory = resolveStatusCategory(responseStatus);
     errorRequestMetric.record(1, statusEnum, statusCategory, veniceCategory);
-    errorRequestLatencyMetric.record(latency, statusEnum, statusCategory, veniceCategory);
+    errorRequestLatencyMetric.record(
+        latency,
+        statusEnum,
+        statusCategory,
+        veniceCategory,
+        VeniceRequestKeyCountBucket.fromKeyCount(keyCount));
   }
 
   private static HttpResponseStatusEnum resolveStatusEnum(HttpResponseStatus responseStatus) {

--- a/services/venice-server/src/main/java/com/linkedin/venice/stats/ServerHttpRequestStats.java
+++ b/services/venice-server/src/main/java/com/linkedin/venice/stats/ServerHttpRequestStats.java
@@ -517,7 +517,7 @@ public class ServerHttpRequestStats extends AbstractVeniceHttpStats {
       HttpResponseStatus responseStatus,
       VeniceResponseStatusCategory veniceCategory,
       double latency,
-      int keyCount) {
+      int requestedKeyCount) {
     HttpResponseStatusEnum statusEnum = resolveStatusEnum(responseStatus);
     HttpResponseStatusCodeCategory statusCategory = resolveStatusCategory(responseStatus);
     successRequestMetric.record(1, statusEnum, statusCategory, veniceCategory);
@@ -526,14 +526,14 @@ public class ServerHttpRequestStats extends AbstractVeniceHttpStats {
         statusEnum,
         statusCategory,
         veniceCategory,
-        VeniceRequestKeyCountBucket.fromKeyCount(keyCount));
+        VeniceRequestKeyCountBucket.fromKeyCount(requestedKeyCount));
   }
 
   public void recordErrorRequestAndLatency(
       HttpResponseStatus responseStatus,
       VeniceResponseStatusCategory veniceCategory,
       double latency,
-      int keyCount) {
+      int requestedKeyCount) {
     HttpResponseStatusEnum statusEnum = resolveStatusEnum(responseStatus);
     HttpResponseStatusCodeCategory statusCategory = resolveStatusCategory(responseStatus);
     errorRequestMetric.record(1, statusEnum, statusCategory, veniceCategory);
@@ -542,7 +542,7 @@ public class ServerHttpRequestStats extends AbstractVeniceHttpStats {
         statusEnum,
         statusCategory,
         veniceCategory,
-        VeniceRequestKeyCountBucket.fromKeyCount(keyCount));
+        VeniceRequestKeyCountBucket.fromKeyCount(requestedKeyCount));
   }
 
   private static HttpResponseStatusEnum resolveStatusEnum(HttpResponseStatus responseStatus) {

--- a/services/venice-server/src/test/java/com/linkedin/venice/grpc/ServerStatsContextTest.java
+++ b/services/venice-server/src/test/java/com/linkedin/venice/grpc/ServerStatsContextTest.java
@@ -106,7 +106,7 @@ public class ServerStatsContextTest {
     ServerHttpRequestStats stats = mock(ServerHttpRequestStats.class);
     context.successRequest(stats, 10.5);
 
-    verify(stats).recordSuccessRequestAndLatency(OK_RESPONSE_STATUS, OK_VENICE_STATUS, 10.5);
+    verify(stats).recordSuccessRequestAndLatency(OK_RESPONSE_STATUS, OK_VENICE_STATUS, 10.5, -1);
   }
 
   @Test
@@ -116,8 +116,45 @@ public class ServerStatsContextTest {
     context.setMisroutedStoreVersion(true);
     context.errorRequest(stats, 12.3);
 
-    verify(stats).recordErrorRequestAndLatency(ERROR_RESPONSE_STATUS, ERROR_VENICE_STATUS, 12.3);
+    verify(stats).recordErrorRequestAndLatency(ERROR_RESPONSE_STATUS, ERROR_VENICE_STATUS, 12.3, -1);
     verify(stats).recordMisroutedStoreVersionRequest();
+  }
+
+  /**
+   * Verifies the requestKeyCount -&gt; CallTime bucket dimension plumbing:
+   *   - setRequestKeyCount(N) is forwarded verbatim to recordSuccessRequestAndLatency / recordErrorRequestAndLatency
+   *     so the downstream stats class can bucket CallTime with the correct {@link com.linkedin.venice.stats.dimensions.VeniceRequestKeyCountBucket}.
+   *   - The default -1 (request never parsed) is forwarded unchanged; VeniceRequestKeyCountBucket#fromKeyCount maps
+   *     non-positive inputs to the dedicated KEYS_LE_0 sentinel bucket, isolated from real single-key traffic.
+   */
+  @Test
+  public void testSuccessRequestForwardsRequestKeyCount() {
+    ServerStatsContext context = createContext(RequestType.MULTI_GET, OK_RESPONSE_STATUS);
+    context.setRequestKeyCount(250);
+    ServerHttpRequestStats stats = mock(ServerHttpRequestStats.class);
+    context.successRequest(stats, 7.5);
+
+    verify(stats).recordSuccessRequestAndLatency(OK_RESPONSE_STATUS, OK_VENICE_STATUS, 7.5, 250);
+  }
+
+  @Test
+  public void testErrorRequestForwardsRequestKeyCount() {
+    ServerStatsContext context = createContext(RequestType.MULTI_GET, ERROR_RESPONSE_STATUS);
+    context.setRequestKeyCount(1500);
+    ServerHttpRequestStats stats = mock(ServerHttpRequestStats.class);
+    context.errorRequest(stats, 42.0);
+
+    verify(stats).recordErrorRequestAndLatency(ERROR_RESPONSE_STATUS, ERROR_VENICE_STATUS, 42.0, 1500);
+  }
+
+  @Test
+  public void testErrorRequestForwardsUnparsedKeyCountSentinel() {
+    // requestKeyCount stays at its -1 default when the request failed before parsing.
+    ServerStatsContext context = createContext(RequestType.SINGLE_GET, ERROR_RESPONSE_STATUS);
+    ServerHttpRequestStats stats = mock(ServerHttpRequestStats.class);
+    context.errorRequest(stats, 3.0);
+
+    verify(stats).recordErrorRequestAndLatency(ERROR_RESPONSE_STATUS, ERROR_VENICE_STATUS, 3.0, -1);
   }
 
   /**
@@ -134,7 +171,7 @@ public class ServerStatsContextTest {
     context.errorRequest(null, 12.3);
 
     verify(singleGetStats).getStoreStats(ServerStatsContext.UNKNOWN_STORE_NAME);
-    verify(unknownStoreStats).recordErrorRequestAndLatency(ERROR_RESPONSE_STATUS, ERROR_VENICE_STATUS, 12.3);
+    verify(unknownStoreStats).recordErrorRequestAndLatency(ERROR_RESPONSE_STATUS, ERROR_VENICE_STATUS, 12.3, -1);
     verify(unknownStoreStats).recordMisroutedStoreVersionRequest();
   }
 
@@ -220,7 +257,7 @@ public class ServerStatsContextTest {
 
     // successRequest only records count and latency (not size)
     context.successRequest(stats, 10.5);
-    verify(stats).recordSuccessRequestAndLatency(OK_RESPONSE_STATUS, OK_VENICE_STATUS, 10.5);
+    verify(stats).recordSuccessRequestAndLatency(OK_RESPONSE_STATUS, OK_VENICE_STATUS, 10.5, -1);
   }
 
   /**
@@ -245,7 +282,7 @@ public class ServerStatsContextTest {
 
     // errorRequest only records count and latency (not size)
     context.errorRequest(stats, 15.0);
-    verify(stats).recordErrorRequestAndLatency(ERROR_RESPONSE_STATUS, ERROR_VENICE_STATUS, 15.0);
+    verify(stats).recordErrorRequestAndLatency(ERROR_RESPONSE_STATUS, ERROR_VENICE_STATUS, 15.0, -1);
   }
 
   @Test
@@ -315,11 +352,13 @@ public class ServerStatsContextTest {
     verify(stats, never()).recordSuccessRequestAndLatency(
         any(HttpResponseStatus.class),
         any(VeniceResponseStatusCategory.class),
-        anyDouble());
+        anyDouble(),
+        anyInt());
     verify(stats, never()).recordErrorRequestAndLatency(
         any(HttpResponseStatus.class),
         any(VeniceResponseStatusCategory.class),
-        anyDouble());
+        anyDouble(),
+        anyInt());
   }
 
   /**
@@ -585,7 +624,7 @@ public class ServerStatsContextTest {
 
     // Error count and latency are still recorded in errorRequest
     context.errorRequest(stats, 8.0);
-    verify(stats).recordErrorRequestAndLatency(ERROR_RESPONSE_STATUS, ERROR_VENICE_STATUS, 8.0);
+    verify(stats).recordErrorRequestAndLatency(ERROR_RESPONSE_STATUS, ERROR_VENICE_STATUS, 8.0, -1);
   }
 
   /**

--- a/services/venice-server/src/test/java/com/linkedin/venice/stats/AggServerHttpRequestStatsTest.java
+++ b/services/venice-server/src/test/java/com/linkedin/venice/stats/AggServerHttpRequestStatsTest.java
@@ -351,8 +351,8 @@ public class AggServerHttpRequestStatsTest {
     // --- Combined recording methods and 3-arg recordResponseSize ---
     // These resolve HttpResponseStatus dimensions internally and record to the same sensors
     // as the individual methods above, verifying the delegation works correctly.
-    singleGetPerStore.recordSuccessRequestAndLatency(HttpResponseStatus.OK, OK_VENICE, 50.0);
-    singleGetPerStore.recordErrorRequestAndLatency(HttpResponseStatus.INTERNAL_SERVER_ERROR, ERROR_VENICE, 100.0);
+    singleGetPerStore.recordSuccessRequestAndLatency(HttpResponseStatus.OK, OK_VENICE, 50.0, 1);
+    singleGetPerStore.recordErrorRequestAndLatency(HttpResponseStatus.INTERNAL_SERVER_ERROR, ERROR_VENICE, 100.0, 1);
     singleGetPerStore.recordResponseSize(HttpResponseStatus.OK, OK_VENICE, 1024);
 
     assertPerStoreAndTotal(store, "response_size.50thPercentile");


### PR DESCRIPTION
## Problem Statement

Venice exposes `call_time` (request latency) OTel metrics at multiple layers. The below 4 are directly used for read path SLAs as these are the direct read path latencies.
1. `venice.thin_client.call_time`
2. `venice.fast_client.call_time`
3. `venice.router.call_time`
4. `venice.server.read.call_time`

For multiget scenarios, its impossible to differentiate the keys sizes for these requests leading up to the latencies as defining SLOs would take the key count as an dimension as larger key counts could drastically affect the long tail.

## Solution
Using the actual key counts will explode the cardinality, so introducing a new OTel dimension `venice.request.key_count_bucket` on the above four `call_time` metrics. Values come from a new `VeniceRequestKeyCountBucket` enum with 8 fixed buckets:

- `KEYS_LE_0` — sentinel for pre-parse error paths (requestKeyCount == -1)
- `KEYS_EQ_1` — single-key requests
- `KEYS_2_150`, `KEYS_151_500`, `KEYS_501_1000`, `KEYS_1001_2000`, `KEYS_2001_5000`, `KEYS_GT_5000`

The bucket resolver `VeniceRequestKeyCountBucket.fromKeyCount(int)`: 4 branches worst case, zero allocation, trivially JIT-inlined, so the hot path cost is negligible.
Bucket uses the **requested** key count (not successful), so partial-success multigets attribute to the batch size the user actually sent.
`CALL_TIME_DVC` intentionally excluded from this PR; DVC batch support can be added as a follow-up.
Dead code removal:
  `ServerHttpRequestStats.record{Success,Error}RequestLatency` (no external callers)
  and `AggServerHttpRequestStats.recordErrorRequestLatency`.

###  Code changes
- [ ] Added new code behind **a config**. If so list the config names and their default values in the PR description.
- [ ] Introduced new **log lines**.
  - [ ] Confirmed if logs need to be **rate limited** to avoid excessive logging.

###  **Concurrency-Specific Checks**
Both reviewer and PR author to verify
- [x] Code has **no race conditions** or **thread safety issues**. The new enum is
      immutable; `fromKeyCount` is pure; `MetricEntityStateFourEnums` uses existing
      thread-safe nested `EnumMap` caching.
- [x] Proper **synchronization mechanisms** (e.g., `synchronized`, `RWLock`) are used where needed.
- [x] No **blocking calls** inside critical sections that could lead to deadlocks or performance degradation.
- [x] Verified **thread-safe collections** are used (e.g., `ConcurrentHashMap`, `CopyOnWriteArrayList`).
- [x] Validated proper exception handling in multi-threaded code to avoid silent thread termination.

## How was this PR tested?

- [x] New unit tests added.
  - `VeniceRequestKeyCountBucketTest` — data-provider-driven boundary coverage across all 8 buckets + dimension interface fixture.
  - `testEmitHealthyMetricsBucketsByRequestedNotSuccessful` in `BasicClientStatsTest` locks the partial-success contract: distinct `successfulKeyCount` and `requestedKeyCount` must produce a CallTime histogram point at the **requested** bucket.
  - `testCallTimeKeyCountBucketDimension` in `RouterHttpRequestStatsTest` asserts the bucket attribute appears on the four latency variants with the correct value per keyNum.
  - `ServerStatsContextTest` extended with `testSuccessRequestForwardsRequestKeyCount`, `testErrorRequestForwardsRequestKeyCount`, and `testErrorRequestForwardsUnparsedKeyCountSentinel` covering explicit and default (-1) forwarding.
- [x] New integration tests added.
  - `AbstractClientEndToEndSetup` validates the bucket attribute on the FastClient CallTime histogram across `SINGLE_GET` / `MULTI_GET_STREAMING` / `COMPUTE_STREAMING` permutations.
- [x] Modified or extended existing tests.
  - `BasicClientMetricEntityTest`, `RouterMetricEntityTest`, `ServerReadOtelMetricEntityTest` updated to expect the new dimension on CALL_TIME / READ_CALL_TIME.
  - `VeniceMetricsDimensionsTest` adds the 3-naming-format cases for `venice.request.key_count_bucket`.
  - `OpenTelemetryAttributesBuilder.setKeyCountBucket(...)` added to `OpenTelemetryDataTestUtils` so the same test fixture is used across all 4 layers.
- [x] Verified backward compatibility (if applicable).
  - Tehuti sensors are unchanged — the dimension is OTel-only. Existing Tehuti dashboards for CallTime continue to report the same latency values.
  - `CALL_TIME_DVC` metric definition unchanged; DVC dashboards unaffected.

## Does this PR introduce any user-facing or breaking changes?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Clearly explain the behavior change and its impact.
New OTel dimension is additive: consumers that don't filter by it see identical aggregates.