### PR TITLE
[server][dvc] Clear stale previouslyReadyToServe flag when fast-RTS lag check declines

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
@@ -5724,17 +5724,12 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
     long previousCheckpointTimestamp = pcs.getOffsetRecord().getLastCheckpointTimestamp();
     String replicaId = pcs.getReplicaId();
     if (previousMessageTimestamp == HeartbeatMonitoringService.INVALID_MESSAGE_TIMESTAMP) {
-      // Clear the flag: we are declining the fast path, and syncOffset() during the upcoming catch-up will
-      // refresh heartbeatTimestamp/lastCheckpointTimestamp. A crash mid-catch-up with the flag left set could
-      // pass the fast-path delta check on the next restart while the replica is still behind.
-      pcs.clearPreviouslyReadyToServeInOffsetRecord();
       LOGGER.info(
           "Previous message timestamp is invalid for replica: {}, will fallback to regular ready-to-serve check path.",
           replicaId);
       return false;
     }
     if (previousCheckpointTimestamp == HeartbeatMonitoringService.INVALID_MESSAGE_TIMESTAMP) {
-      pcs.clearPreviouslyReadyToServeInOffsetRecord();
       LOGGER.info(
           "Previous checkpoint timestamp is invalid for replica: {}, will fallback to regular ready-to-serve check path.",
           replicaId);
@@ -5755,10 +5750,6 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
       return true;
     } else {
       pcs.setReadyToServeTimeLagThresholdInMs(previousLag + heartbeatRelaxThresholdInMs);
-      // Clear the stale previouslyReadyToServe flag: the replica is not actually caught up, so the flag no longer
-      // reflects truth. Leaving it set would allow a crash during this catch-up to trick a later restart into
-      // passing the fast path via a small delta between two in-flight checkpoints.
-      pcs.clearPreviouslyReadyToServeInOffsetRecord();
       LOGGER.info(
           "Time lag increase since last server checkpoint: {} is greater than configured threshold: {}, will update ready-to-serve time lag threshold to: {} for replica: {}",
           currentLag - previousLag,
@@ -5785,10 +5776,6 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
     long previousOffsetLag = pcs.getOffsetRecord().getOffsetLag();
     long offsetLag = measureHybridOffsetLag(pcs, true);
     if (previousOffsetLag == OffsetRecord.DEFAULT_OFFSET_LAG) {
-      // Clear the flag: we are declining the fast path, and syncOffset() during the upcoming catch-up will
-      // refresh offsetLag. A crash mid-catch-up with the flag left set could pass the fast-path delta check
-      // on the next restart while the replica is still behind.
-      pcs.clearPreviouslyReadyToServeInOffsetRecord();
       LOGGER.info(
           "Previous offset lag is invalid for replica: {}, will fallback to regular ready-to-serve check path.",
           pcs.getReplicaId());
@@ -5805,10 +5792,6 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
       reportCompleted(pcs, true);
       return true;
     } else {
-      // Clear the stale previouslyReadyToServe flag: the replica is not actually caught up, so the flag no longer
-      // reflects truth. Leaving it set would allow a crash during this catch-up to trick a later restart into
-      // passing the fast path via a small delta between two in-flight checkpoints.
-      pcs.clearPreviouslyReadyToServeInOffsetRecord();
       LOGGER.info(
           "Offset lag increase since last server checkpoint: {} is greater than configured threshold: {}, will fallback to regular ready-to-serve check path for replica: {}",
           offsetLag - previousOffsetLag,
@@ -5826,11 +5809,35 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
        * If time lag for ready-to-serve is disabled and offset lag relax check is enabled, we will perform offset lag
        * relax check. It will be fully deprecated when time lag is used everywhere in ready-to-serve check.
        */
+      boolean fastPathPassed;
       if (isTimeLagRelaxEnabled() && getServerConfig().isUseHeartbeatLagForReadyToServeCheckEnabled()) {
-        return checkFastReadyToServeWithPreviousTimeLag(pcs);
+        fastPathPassed = checkFastReadyToServeWithPreviousTimeLag(pcs);
       } else if (isOffsetLagDeltaRelaxEnabled() && !getServerConfig().isUseHeartbeatLagForReadyToServeCheckEnabled()) {
-        return checkFastReadyToServeWithPreviousOffsetLag(pcs);
+        fastPathPassed = checkFastReadyToServeWithPreviousOffsetLag(pcs);
+      } else {
+        fastPathPassed = false;
       }
+      if (!fastPathPassed) {
+        /*
+         * Clear the previouslyReadyToServe flag on every decline, regardless of which inner check (or none) ran.
+         *
+         * Why this is centralized here rather than per-site inside the lag-check methods:
+         * once we decide not to take the fast path, the replica falls through to regular catch-up. During
+         * catch-up, syncOffset() refreshes heartbeatTimestamp / lastCheckpointTimestamp / offsetLag on disk
+         * with fresh-but-still-behind values. If the replica then crashes before actually reaching RTS and
+         * the next restart enters a lag-check method (possibly because a server-level or per-store config
+         * was flipped in between), the check would see flag=true paired with freshly-written checkpoints and
+         * could pass the delta comparison incorrectly — marking the replica RTS while still behind.
+         *
+         * The disk state produced after a decline is the same regardless of *why* we declined (lag exceeds
+         * threshold, invalid prior measurement, unmatched config combo, non-positive per-store threshold),
+         * so clearing must happen on every decline path. Doing it at this boundary covers them all in one
+         * place and makes the flag's invariant unambiguous: "true iff the replica was genuinely caught up
+         * at the last successful shutdown".
+         */
+        pcs.clearPreviouslyReadyToServeInOffsetRecord();
+      }
+      return fastPathPassed;
     }
     return false;
   }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
@@ -5750,6 +5750,10 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
       return true;
     } else {
       pcs.setReadyToServeTimeLagThresholdInMs(previousLag + heartbeatRelaxThresholdInMs);
+      // Clear the stale previouslyReadyToServe flag: the replica is not actually caught up, so the flag no longer
+      // reflects truth. Leaving it set would allow a crash during this catch-up to trick a later restart into
+      // passing the fast path via a small delta between two in-flight checkpoints.
+      pcs.clearPreviouslyReadyToServeInOffsetRecord();
       LOGGER.info(
           "Time lag increase since last server checkpoint: {} is greater than configured threshold: {}, will update ready-to-serve time lag threshold to: {} for replica: {}",
           currentLag - previousLag,
@@ -5792,6 +5796,10 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
       reportCompleted(pcs, true);
       return true;
     } else {
+      // Clear the stale previouslyReadyToServe flag: the replica is not actually caught up, so the flag no longer
+      // reflects truth. Leaving it set would allow a crash during this catch-up to trick a later restart into
+      // passing the fast path via a small delta between two in-flight checkpoints.
+      pcs.clearPreviouslyReadyToServeInOffsetRecord();
       LOGGER.info(
           "Offset lag increase since last server checkpoint: {} is greater than configured threshold: {}, will fallback to regular ready-to-serve check path for replica: {}",
           offsetLag - previousOffsetLag,

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
@@ -5724,12 +5724,17 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
     long previousCheckpointTimestamp = pcs.getOffsetRecord().getLastCheckpointTimestamp();
     String replicaId = pcs.getReplicaId();
     if (previousMessageTimestamp == HeartbeatMonitoringService.INVALID_MESSAGE_TIMESTAMP) {
+      // Clear the flag: we are declining the fast path, and syncOffset() during the upcoming catch-up will
+      // refresh heartbeatTimestamp/lastCheckpointTimestamp. A crash mid-catch-up with the flag left set could
+      // pass the fast-path delta check on the next restart while the replica is still behind.
+      pcs.clearPreviouslyReadyToServeInOffsetRecord();
       LOGGER.info(
           "Previous message timestamp is invalid for replica: {}, will fallback to regular ready-to-serve check path.",
           replicaId);
       return false;
     }
     if (previousCheckpointTimestamp == HeartbeatMonitoringService.INVALID_MESSAGE_TIMESTAMP) {
+      pcs.clearPreviouslyReadyToServeInOffsetRecord();
       LOGGER.info(
           "Previous checkpoint timestamp is invalid for replica: {}, will fallback to regular ready-to-serve check path.",
           replicaId);
@@ -5780,6 +5785,10 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
     long previousOffsetLag = pcs.getOffsetRecord().getOffsetLag();
     long offsetLag = measureHybridOffsetLag(pcs, true);
     if (previousOffsetLag == OffsetRecord.DEFAULT_OFFSET_LAG) {
+      // Clear the flag: we are declining the fast path, and syncOffset() during the upcoming catch-up will
+      // refresh offsetLag. A crash mid-catch-up with the flag left set could pass the fast-path delta check
+      // on the next restart while the replica is still behind.
+      pcs.clearPreviouslyReadyToServeInOffsetRecord();
       LOGGER.info(
           "Previous offset lag is invalid for replica: {}, will fallback to regular ready-to-serve check path.",
           pcs.getReplicaId());

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/SITFastReadyToServeTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/SITFastReadyToServeTest.java
@@ -130,24 +130,12 @@ public class SITFastReadyToServeTest {
   }
 
   /**
-   * Regression test for the stale previouslyReadyToServe flag bug.
-   *
-   * Scenario:
-   *   Run 1: replica genuinely reaches ready-to-serve; previouslyReadyToServe=true is persisted.
-   *   Server is down for a long time (lag exceeds threshold on next restart).
-   *   Run 2: restart. Fast RTS lag check declines (lag too high). Replica starts regular catch-up.
-   *          syncOffset() refreshes heartbeatTimestamp / offsetLag / lastCheckpointTimestamp to fresh,
-   *          still-behind values before the replica ever reaches RTS.
-   *          Server crashes mid-catch-up.
-   *   Run 3: restart. Without the fix, flag is still true, and the checkpoint-vs-heartbeat delta on disk is
-   *          small (because both were written moments apart during Run 2 catch-up), so the fast RTS path
-   *          incorrectly marks the replica ready-to-serve while it is still substantially behind.
-   *
-   * Fix: clear the flag in the decline branch of both lag-check methods so the flag is only ever true when
-   * the replica was actually caught up at last shutdown. This test verifies that behavior directly.
+   * Regression test for the stale previouslyReadyToServe flag bug: when the fast-RTS time-lag check declines,
+   * the flag must be cleared so a later restart cannot mistakenly take the fast path based on two close-in-time
+   * catch-up checkpoints written while the replica was still behind.
    */
   @Test
-  public void testStalePreviouslyReadyToServeFlagIsClearedOnDeclineThenCannotPassOnNextRestart() {
+  public void testStalePreviouslyReadyToServeFlagIsClearedOnTimeLagDecline() {
     StoreIngestionTask storeIngestionTask = mock(StoreIngestionTask.class);
     VeniceServerConfig serverConfig = mock(VeniceServerConfig.class);
     doReturn(5).when(serverConfig).getTimeLagThresholdForFastOnlineTransitionInRestartMinutes();
@@ -159,8 +147,9 @@ public class SITFastReadyToServeTest {
     doCallRealMethod().when(storeIngestionTask).checkFastReadyToServeWithPreviousTimeLag(any());
 
     long currentTimestamp = System.currentTimeMillis();
-    // Run 2 restart: previous heartbeat is 10min behind, checkpoint was 7min ago => growth = 3min > 5min-2min
-    // threshold, lag check declines.
+    // Run 2 restart: previous heartbeat is 10min behind and the last checkpoint was 7min ago.
+    // That makes the previous lag 3min, but the lag growth checked by the code is 7min, which exceeds the
+    // 5min threshold, so the lag check declines.
     doReturn(currentTimestamp - TimeUnit.MINUTES.toMillis(7)).when(record).getLastCheckpointTimestamp();
     doReturn(currentTimestamp - TimeUnit.MINUTES.toMillis(10)).when(record).getHeartbeatTimestamp();
     doReturn(true).when(pcs).getReadyToServeInOffsetRecord();

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/SITFastReadyToServeTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/SITFastReadyToServeTest.java
@@ -10,6 +10,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 import com.linkedin.davinci.config.VeniceServerConfig;
+import com.linkedin.davinci.stats.ingestion.heartbeat.HeartbeatMonitoringService;
 import com.linkedin.venice.kafka.protocol.state.PartitionState;
 import com.linkedin.venice.meta.BufferReplayPolicy;
 import com.linkedin.venice.meta.HybridStoreConfig;
@@ -157,6 +158,94 @@ public class SITFastReadyToServeTest {
     Assert.assertFalse(
         storeIngestionTask.checkFastReadyToServeWithPreviousTimeLag(pcs),
         "Fast RTS should decline when lag growth exceeds threshold");
+    verify(pcs, never()).lagHasCaughtUp();
+    verify(pcs, times(1)).clearPreviouslyReadyToServeInOffsetRecord();
+  }
+
+  /**
+   * When the previous heartbeat timestamp is INVALID on restart (e.g., after a format upgrade or a prior in-memory
+   * clear), the fast-RTS time-lag method returns false without measuring lag. syncOffset() will later refresh
+   * heartbeat/checkpoint during catch-up, so leaving the flag set re-creates the stale-flag vulnerability.
+   */
+  @Test
+  public void testStalePreviouslyReadyToServeFlagIsClearedWhenHeartbeatTimestampInvalid() {
+    StoreIngestionTask storeIngestionTask = mock(StoreIngestionTask.class);
+    VeniceServerConfig serverConfig = mock(VeniceServerConfig.class);
+    doReturn(5).when(serverConfig).getTimeLagThresholdForFastOnlineTransitionInRestartMinutes();
+    doReturn(serverConfig).when(storeIngestionTask).getServerConfig();
+    OffsetRecord record = mock(OffsetRecord.class);
+    PartitionConsumptionState pcs = mock(PartitionConsumptionState.class);
+    doReturn(record).when(pcs).getOffsetRecord();
+    doReturn("test_v1-1").when(pcs).getReplicaId();
+    doCallRealMethod().when(storeIngestionTask).checkFastReadyToServeWithPreviousTimeLag(any());
+
+    doReturn(HeartbeatMonitoringService.INVALID_MESSAGE_TIMESTAMP).when(record).getHeartbeatTimestamp();
+    doReturn(System.currentTimeMillis()).when(record).getLastCheckpointTimestamp();
+    doReturn(true).when(pcs).getReadyToServeInOffsetRecord();
+
+    Assert.assertFalse(
+        storeIngestionTask.checkFastReadyToServeWithPreviousTimeLag(pcs),
+        "Fast RTS should decline when previous heartbeat timestamp is invalid");
+    verify(pcs, never()).lagHasCaughtUp();
+    verify(pcs, times(1)).clearPreviouslyReadyToServeInOffsetRecord();
+  }
+
+  /**
+   * Mirror of {@link #testStalePreviouslyReadyToServeFlagIsClearedWhenHeartbeatTimestampInvalid} for the checkpoint
+   * timestamp fallback path.
+   */
+  @Test
+  public void testStalePreviouslyReadyToServeFlagIsClearedWhenCheckpointTimestampInvalid() {
+    StoreIngestionTask storeIngestionTask = mock(StoreIngestionTask.class);
+    VeniceServerConfig serverConfig = mock(VeniceServerConfig.class);
+    doReturn(5).when(serverConfig).getTimeLagThresholdForFastOnlineTransitionInRestartMinutes();
+    doReturn(serverConfig).when(storeIngestionTask).getServerConfig();
+    OffsetRecord record = mock(OffsetRecord.class);
+    PartitionConsumptionState pcs = mock(PartitionConsumptionState.class);
+    doReturn(record).when(pcs).getOffsetRecord();
+    doReturn("test_v1-1").when(pcs).getReplicaId();
+    doCallRealMethod().when(storeIngestionTask).checkFastReadyToServeWithPreviousTimeLag(any());
+
+    doReturn(System.currentTimeMillis() - TimeUnit.MINUTES.toMillis(1)).when(record).getHeartbeatTimestamp();
+    doReturn(HeartbeatMonitoringService.INVALID_MESSAGE_TIMESTAMP).when(record).getLastCheckpointTimestamp();
+    doReturn(true).when(pcs).getReadyToServeInOffsetRecord();
+
+    Assert.assertFalse(
+        storeIngestionTask.checkFastReadyToServeWithPreviousTimeLag(pcs),
+        "Fast RTS should decline when previous checkpoint timestamp is invalid");
+    verify(pcs, never()).lagHasCaughtUp();
+    verify(pcs, times(1)).clearPreviouslyReadyToServeInOffsetRecord();
+  }
+
+  /**
+   * When the previous offset lag on disk is the DEFAULT sentinel, the fast-RTS offset-lag method returns false
+   * without measuring lag. Same rationale as the heartbeat-invalid case: syncOffset() will refresh the field
+   * during catch-up, so leaving the flag set re-creates the stale-flag vulnerability.
+   */
+  @Test
+  public void testStalePreviouslyReadyToServeFlagIsClearedWhenPreviousOffsetLagDefault() {
+    StoreIngestionTask storeIngestionTask = mock(StoreIngestionTask.class);
+    VeniceServerConfig serverConfig = mock(VeniceServerConfig.class);
+    doReturn(2).when(serverConfig).getOffsetLagDeltaRelaxFactorForFastOnlineTransitionInRestart();
+    doReturn(serverConfig).when(storeIngestionTask).getServerConfig();
+    OffsetRecord record = mock(OffsetRecord.class);
+    PartitionConsumptionState pcs = mock(PartitionConsumptionState.class);
+    doReturn(record).when(pcs).getOffsetRecord();
+    doReturn("test_v1-1").when(pcs).getReplicaId();
+    doCallRealMethod().when(storeIngestionTask).checkFastReadyToServeWithPreviousOffsetLag(any());
+    HybridStoreConfig hybridStoreConfig =
+        new HybridStoreConfigImpl(100L, -100L, -1L, BufferReplayPolicy.REWIND_FROM_SOP);
+    hybridStoreConfig.setOffsetLagThresholdToGoOnline(100);
+    doReturn(Optional.of(hybridStoreConfig)).when(storeIngestionTask).getHybridStoreConfig();
+    doReturn(1).when(storeIngestionTask).getPartitionCount();
+
+    doReturn(200L).when(storeIngestionTask).measureHybridOffsetLag(pcs, true);
+    doReturn(OffsetRecord.DEFAULT_OFFSET_LAG).when(record).getOffsetLag();
+    doReturn(true).when(pcs).getReadyToServeInOffsetRecord();
+
+    Assert.assertFalse(
+        storeIngestionTask.checkFastReadyToServeWithPreviousOffsetLag(pcs),
+        "Fast RTS should decline when previous offset lag is the DEFAULT sentinel");
     verify(pcs, never()).lagHasCaughtUp();
     verify(pcs, times(1)).clearPreviouslyReadyToServeInOffsetRecord();
   }

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/SITFastReadyToServeTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/SITFastReadyToServeTest.java
@@ -10,7 +10,6 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 import com.linkedin.davinci.config.VeniceServerConfig;
-import com.linkedin.davinci.stats.ingestion.heartbeat.HeartbeatMonitoringService;
 import com.linkedin.venice.kafka.protocol.state.PartitionState;
 import com.linkedin.venice.meta.BufferReplayPolicy;
 import com.linkedin.venice.meta.HybridStoreConfig;
@@ -88,10 +87,9 @@ public class SITFastReadyToServeTest {
     storeIngestionTask.checkFastReadyToServeWithPreviousTimeLag(pcs);
     verify(pcs, times(1)).lagHasCaughtUp();
     verify(pcs, times(1)).setReadyToServeTimeLagThresholdInMs(eq(TimeUnit.MINUTES.toMillis(8)));
-    // The stale previouslyReadyToServe flag must be cleared on the decline path so that a crash during catch-up
-    // cannot trick a later restart into passing the fast path via a small checkpoint delta.
-    // Called twice above: Case 1 (default-0 timestamps produce a huge delta) and Case 3 (growth out of bound).
-    verify(pcs, times(2)).clearPreviouslyReadyToServeInOffsetRecord();
+    // Flag clearing is the outer checkFastReadyToServeForReplica's responsibility now; see the
+    // testStale* tests that drive behavior via the outer method.
+    verify(pcs, never()).clearPreviouslyReadyToServeInOffsetRecord();
   }
 
   @Test
@@ -125,15 +123,22 @@ public class SITFastReadyToServeTest {
     doReturn(400L).when(storeIngestionTask).measureHybridOffsetLag(pcs, true);
     storeIngestionTask.checkFastReadyToServeWithPreviousOffsetLag(pcs);
     verify(pcs, times(1)).lagHasCaughtUp();
-    // The stale previouslyReadyToServe flag must be cleared on the decline path so that a crash during catch-up
-    // cannot trick a later restart into passing the fast path via a small checkpoint delta.
-    verify(pcs, times(1)).clearPreviouslyReadyToServeInOffsetRecord();
+    // Flag clearing is the outer checkFastReadyToServeForReplica's responsibility now.
+    verify(pcs, never()).clearPreviouslyReadyToServeInOffsetRecord();
   }
 
   /**
-   * Regression test for the stale previouslyReadyToServe flag bug: when the fast-RTS time-lag check declines,
-   * the flag must be cleared so a later restart cannot mistakenly take the fast path based on two close-in-time
-   * catch-up checkpoints written while the replica was still behind.
+   * The outer {@link StoreIngestionTask#checkFastReadyToServeForReplica} is the single site that clears the stale
+   * {@code previouslyReadyToServe} flag on every decline path. The tests below drive the outer method and cover:
+   *
+   * <ul>
+   *   <li>Time-lag inner check declines → flag cleared.</li>
+   *   <li>Offset-lag inner check declines → flag cleared.</li>
+   *   <li>Outer gate passes (hybrid present, flag=true) but no inner branch matches the current config combo
+   *       → flag cleared. This is the config-fall-through case that was uncovered before the refactor.</li>
+   *   <li>Fast path succeeds → flag preserved.</li>
+   *   <li>Outer gate blocks the fast path (flag already false, or no hybrid config) → no-op; flag untouched.</li>
+   * </ul>
    */
   @Test
   public void testStalePreviouslyReadyToServeFlagIsClearedOnTimeLagDecline() {
@@ -145,107 +150,20 @@ public class SITFastReadyToServeTest {
     PartitionConsumptionState pcs = mock(PartitionConsumptionState.class);
     doReturn(record).when(pcs).getOffsetRecord();
     doReturn("test_v1-1").when(pcs).getReplicaId();
+    doReturn(true).when(pcs).getReadyToServeInOffsetRecord();
+    doReturn(Optional.of(mock(HybridStoreConfig.class))).when(storeIngestionTask).getHybridStoreConfig();
+    doReturn(true).when(storeIngestionTask).isTimeLagRelaxEnabled();
+    doReturn(true).when(serverConfig).isUseHeartbeatLagForReadyToServeCheckEnabled();
+    doCallRealMethod().when(storeIngestionTask).checkFastReadyToServeForReplica(any());
     doCallRealMethod().when(storeIngestionTask).checkFastReadyToServeWithPreviousTimeLag(any());
 
-    long currentTimestamp = System.currentTimeMillis();
-    // Run 2 restart: previous heartbeat is 10min behind and the last checkpoint was 7min ago.
-    // That makes the previous lag 3min, but the lag growth checked by the code is 7min, which exceeds the
-    // 5min threshold, so the lag check declines.
-    doReturn(currentTimestamp - TimeUnit.MINUTES.toMillis(7)).when(record).getLastCheckpointTimestamp();
-    doReturn(currentTimestamp - TimeUnit.MINUTES.toMillis(10)).when(record).getHeartbeatTimestamp();
-    doReturn(true).when(pcs).getReadyToServeInOffsetRecord();
+    long now = System.currentTimeMillis();
+    // Previous heartbeat is 10min behind and the last checkpoint was 7min ago: previous lag is 3min, but
+    // the lag growth (currentLag - previousLag) is 7min, which exceeds the 5min threshold, so decline.
+    doReturn(now - TimeUnit.MINUTES.toMillis(7)).when(record).getLastCheckpointTimestamp();
+    doReturn(now - TimeUnit.MINUTES.toMillis(10)).when(record).getHeartbeatTimestamp();
 
-    Assert.assertFalse(
-        storeIngestionTask.checkFastReadyToServeWithPreviousTimeLag(pcs),
-        "Fast RTS should decline when lag growth exceeds threshold");
-    verify(pcs, never()).lagHasCaughtUp();
-    verify(pcs, times(1)).clearPreviouslyReadyToServeInOffsetRecord();
-  }
-
-  /**
-   * When the previous heartbeat timestamp is INVALID on restart (e.g., after a format upgrade or a prior in-memory
-   * clear), the fast-RTS time-lag method returns false without measuring lag. syncOffset() will later refresh
-   * heartbeat/checkpoint during catch-up, so leaving the flag set re-creates the stale-flag vulnerability.
-   */
-  @Test
-  public void testStalePreviouslyReadyToServeFlagIsClearedWhenHeartbeatTimestampInvalid() {
-    StoreIngestionTask storeIngestionTask = mock(StoreIngestionTask.class);
-    VeniceServerConfig serverConfig = mock(VeniceServerConfig.class);
-    doReturn(5).when(serverConfig).getTimeLagThresholdForFastOnlineTransitionInRestartMinutes();
-    doReturn(serverConfig).when(storeIngestionTask).getServerConfig();
-    OffsetRecord record = mock(OffsetRecord.class);
-    PartitionConsumptionState pcs = mock(PartitionConsumptionState.class);
-    doReturn(record).when(pcs).getOffsetRecord();
-    doReturn("test_v1-1").when(pcs).getReplicaId();
-    doCallRealMethod().when(storeIngestionTask).checkFastReadyToServeWithPreviousTimeLag(any());
-
-    doReturn(HeartbeatMonitoringService.INVALID_MESSAGE_TIMESTAMP).when(record).getHeartbeatTimestamp();
-    doReturn(System.currentTimeMillis()).when(record).getLastCheckpointTimestamp();
-    doReturn(true).when(pcs).getReadyToServeInOffsetRecord();
-
-    Assert.assertFalse(
-        storeIngestionTask.checkFastReadyToServeWithPreviousTimeLag(pcs),
-        "Fast RTS should decline when previous heartbeat timestamp is invalid");
-    verify(pcs, never()).lagHasCaughtUp();
-    verify(pcs, times(1)).clearPreviouslyReadyToServeInOffsetRecord();
-  }
-
-  /**
-   * Mirror of {@link #testStalePreviouslyReadyToServeFlagIsClearedWhenHeartbeatTimestampInvalid} for the checkpoint
-   * timestamp fallback path.
-   */
-  @Test
-  public void testStalePreviouslyReadyToServeFlagIsClearedWhenCheckpointTimestampInvalid() {
-    StoreIngestionTask storeIngestionTask = mock(StoreIngestionTask.class);
-    VeniceServerConfig serverConfig = mock(VeniceServerConfig.class);
-    doReturn(5).when(serverConfig).getTimeLagThresholdForFastOnlineTransitionInRestartMinutes();
-    doReturn(serverConfig).when(storeIngestionTask).getServerConfig();
-    OffsetRecord record = mock(OffsetRecord.class);
-    PartitionConsumptionState pcs = mock(PartitionConsumptionState.class);
-    doReturn(record).when(pcs).getOffsetRecord();
-    doReturn("test_v1-1").when(pcs).getReplicaId();
-    doCallRealMethod().when(storeIngestionTask).checkFastReadyToServeWithPreviousTimeLag(any());
-
-    doReturn(System.currentTimeMillis() - TimeUnit.MINUTES.toMillis(1)).when(record).getHeartbeatTimestamp();
-    doReturn(HeartbeatMonitoringService.INVALID_MESSAGE_TIMESTAMP).when(record).getLastCheckpointTimestamp();
-    doReturn(true).when(pcs).getReadyToServeInOffsetRecord();
-
-    Assert.assertFalse(
-        storeIngestionTask.checkFastReadyToServeWithPreviousTimeLag(pcs),
-        "Fast RTS should decline when previous checkpoint timestamp is invalid");
-    verify(pcs, never()).lagHasCaughtUp();
-    verify(pcs, times(1)).clearPreviouslyReadyToServeInOffsetRecord();
-  }
-
-  /**
-   * When the previous offset lag on disk is the DEFAULT sentinel, the fast-RTS offset-lag method returns false
-   * without measuring lag. Same rationale as the heartbeat-invalid case: syncOffset() will refresh the field
-   * during catch-up, so leaving the flag set re-creates the stale-flag vulnerability.
-   */
-  @Test
-  public void testStalePreviouslyReadyToServeFlagIsClearedWhenPreviousOffsetLagDefault() {
-    StoreIngestionTask storeIngestionTask = mock(StoreIngestionTask.class);
-    VeniceServerConfig serverConfig = mock(VeniceServerConfig.class);
-    doReturn(2).when(serverConfig).getOffsetLagDeltaRelaxFactorForFastOnlineTransitionInRestart();
-    doReturn(serverConfig).when(storeIngestionTask).getServerConfig();
-    OffsetRecord record = mock(OffsetRecord.class);
-    PartitionConsumptionState pcs = mock(PartitionConsumptionState.class);
-    doReturn(record).when(pcs).getOffsetRecord();
-    doReturn("test_v1-1").when(pcs).getReplicaId();
-    doCallRealMethod().when(storeIngestionTask).checkFastReadyToServeWithPreviousOffsetLag(any());
-    HybridStoreConfig hybridStoreConfig =
-        new HybridStoreConfigImpl(100L, -100L, -1L, BufferReplayPolicy.REWIND_FROM_SOP);
-    hybridStoreConfig.setOffsetLagThresholdToGoOnline(100);
-    doReturn(Optional.of(hybridStoreConfig)).when(storeIngestionTask).getHybridStoreConfig();
-    doReturn(1).when(storeIngestionTask).getPartitionCount();
-
-    doReturn(200L).when(storeIngestionTask).measureHybridOffsetLag(pcs, true);
-    doReturn(OffsetRecord.DEFAULT_OFFSET_LAG).when(record).getOffsetLag();
-    doReturn(true).when(pcs).getReadyToServeInOffsetRecord();
-
-    Assert.assertFalse(
-        storeIngestionTask.checkFastReadyToServeWithPreviousOffsetLag(pcs),
-        "Fast RTS should decline when previous offset lag is the DEFAULT sentinel");
+    Assert.assertFalse(storeIngestionTask.checkFastReadyToServeForReplica(pcs));
     verify(pcs, never()).lagHasCaughtUp();
     verify(pcs, times(1)).clearPreviouslyReadyToServeInOffsetRecord();
   }
@@ -260,23 +178,111 @@ public class SITFastReadyToServeTest {
     PartitionConsumptionState pcs = mock(PartitionConsumptionState.class);
     doReturn(record).when(pcs).getOffsetRecord();
     doReturn("test_v1-1").when(pcs).getReplicaId();
-    doCallRealMethod().when(storeIngestionTask).checkFastReadyToServeWithPreviousOffsetLag(any());
+    doReturn(true).when(pcs).getReadyToServeInOffsetRecord();
     HybridStoreConfig hybridStoreConfig =
         new HybridStoreConfigImpl(100L, -100L, -1L, BufferReplayPolicy.REWIND_FROM_SOP);
     hybridStoreConfig.setOffsetLagThresholdToGoOnline(100);
     doReturn(Optional.of(hybridStoreConfig)).when(storeIngestionTask).getHybridStoreConfig();
     doReturn(1).when(storeIngestionTask).getPartitionCount();
+    doReturn(false).when(storeIngestionTask).isTimeLagRelaxEnabled();
+    doReturn(true).when(storeIngestionTask).isOffsetLagDeltaRelaxEnabled();
+    doReturn(false).when(serverConfig).isUseHeartbeatLagForReadyToServeCheckEnabled();
+    doCallRealMethod().when(storeIngestionTask).checkFastReadyToServeForReplica(any());
+    doCallRealMethod().when(storeIngestionTask).checkFastReadyToServeWithPreviousOffsetLag(any());
 
     // Offset lag grew from 100 to 400 => delta 300 > 2 * 100 threshold, decline.
     doReturn(400L).when(storeIngestionTask).measureHybridOffsetLag(pcs, true);
     doReturn(100L).when(record).getOffsetLag();
-    doReturn(true).when(pcs).getReadyToServeInOffsetRecord();
 
-    Assert.assertFalse(
-        storeIngestionTask.checkFastReadyToServeWithPreviousOffsetLag(pcs),
-        "Fast RTS should decline when offset lag growth exceeds threshold");
+    Assert.assertFalse(storeIngestionTask.checkFastReadyToServeForReplica(pcs));
     verify(pcs, never()).lagHasCaughtUp();
     verify(pcs, times(1)).clearPreviouslyReadyToServeInOffsetRecord();
+  }
+
+  /**
+   * Site A from the review: the outer gate passes (hybrid present, flag=true) but the current config combo
+   * matches neither inner branch. The outer method returns false without entering either lag-check method.
+   * The flag must still be cleared here because syncOffset() during the ensuing regular catch-up pollutes the
+   * on-disk lag fields; if the admin later flips a config that makes a lag-check method reachable, a restart
+   * could then pass the delta check with flag=true still set.
+   */
+  @Test
+  public void testStalePreviouslyReadyToServeFlagIsClearedWhenConfigDoesNotMatchAnyInnerBranch() {
+    StoreIngestionTask storeIngestionTask = mock(StoreIngestionTask.class);
+    VeniceServerConfig serverConfig = mock(VeniceServerConfig.class);
+    doReturn(serverConfig).when(storeIngestionTask).getServerConfig();
+    PartitionConsumptionState pcs = mock(PartitionConsumptionState.class);
+    doReturn("test_v1-1").when(pcs).getReplicaId();
+    doReturn(true).when(pcs).getReadyToServeInOffsetRecord();
+    doReturn(Optional.of(mock(HybridStoreConfig.class))).when(storeIngestionTask).getHybridStoreConfig();
+    // Config combo that matches neither inner branch: time-lag needs heartbeat=true, offset-lag needs
+    // heartbeat=false; flipping just isTimeLagRelaxEnabled without the matching heartbeat setting skips
+    // the time-lag branch, and leaving isOffsetLagDeltaRelaxEnabled=false skips the offset-lag branch.
+    doReturn(true).when(storeIngestionTask).isTimeLagRelaxEnabled();
+    doReturn(false).when(serverConfig).isUseHeartbeatLagForReadyToServeCheckEnabled();
+    doReturn(false).when(storeIngestionTask).isOffsetLagDeltaRelaxEnabled();
+    doCallRealMethod().when(storeIngestionTask).checkFastReadyToServeForReplica(any());
+
+    Assert.assertFalse(storeIngestionTask.checkFastReadyToServeForReplica(pcs));
+    verify(storeIngestionTask, never()).checkFastReadyToServeWithPreviousTimeLag(pcs);
+    verify(storeIngestionTask, never()).checkFastReadyToServeWithPreviousOffsetLag(pcs);
+    verify(pcs, times(1)).clearPreviouslyReadyToServeInOffsetRecord();
+  }
+
+  /**
+   * When the fast path succeeds, the flag must stay set — the replica is genuinely ready-to-serve and a clean
+   * shutdown should allow the next restart to take the fast path again.
+   */
+  @Test
+  public void testPreviouslyReadyToServeFlagPreservedWhenFastPathSucceeds() {
+    StoreIngestionTask storeIngestionTask = mock(StoreIngestionTask.class);
+    VeniceServerConfig serverConfig = mock(VeniceServerConfig.class);
+    doReturn(5).when(serverConfig).getTimeLagThresholdForFastOnlineTransitionInRestartMinutes();
+    doReturn(serverConfig).when(storeIngestionTask).getServerConfig();
+    OffsetRecord record = mock(OffsetRecord.class);
+    PartitionConsumptionState pcs = mock(PartitionConsumptionState.class);
+    doReturn(record).when(pcs).getOffsetRecord();
+    doReturn("test_v1-1").when(pcs).getReplicaId();
+    doReturn(true).when(pcs).getReadyToServeInOffsetRecord();
+    doReturn(Optional.of(mock(HybridStoreConfig.class))).when(storeIngestionTask).getHybridStoreConfig();
+    doReturn(true).when(storeIngestionTask).isTimeLagRelaxEnabled();
+    doReturn(true).when(serverConfig).isUseHeartbeatLagForReadyToServeCheckEnabled();
+    doCallRealMethod().when(storeIngestionTask).checkFastReadyToServeForReplica(any());
+    doCallRealMethod().when(storeIngestionTask).checkFastReadyToServeWithPreviousTimeLag(any());
+
+    long now = System.currentTimeMillis();
+    // Growth is 1min, within the 5min threshold -> fast path passes.
+    doReturn(now - TimeUnit.MINUTES.toMillis(1)).when(record).getLastCheckpointTimestamp();
+    doReturn(now - TimeUnit.MINUTES.toMillis(10)).when(record).getHeartbeatTimestamp();
+
+    Assert.assertTrue(storeIngestionTask.checkFastReadyToServeForReplica(pcs));
+    verify(pcs, times(1)).lagHasCaughtUp();
+    verify(pcs, never()).clearPreviouslyReadyToServeInOffsetRecord();
+  }
+
+  /**
+   * When the outer gate blocks (flag already false, or no hybrid config), the outer method must not touch the
+   * flag — clearing a flag that was never set is a harmless no-op but verifying it stays untouched guards
+   * against an accidental side-effect if the routing logic is ever rewritten.
+   */
+  @Test
+  public void testPreviouslyReadyToServeFlagNotTouchedWhenOuterGateBlocks() {
+    StoreIngestionTask storeIngestionTask = mock(StoreIngestionTask.class);
+    PartitionConsumptionState pcs = mock(PartitionConsumptionState.class);
+    doReturn("test_v1-1").when(pcs).getReplicaId();
+    doCallRealMethod().when(storeIngestionTask).checkFastReadyToServeForReplica(any());
+
+    // Case 1: no hybrid config -> outer gate fails.
+    doReturn(Optional.empty()).when(storeIngestionTask).getHybridStoreConfig();
+    doReturn(true).when(pcs).getReadyToServeInOffsetRecord();
+    Assert.assertFalse(storeIngestionTask.checkFastReadyToServeForReplica(pcs));
+
+    // Case 2: flag already false -> outer gate fails.
+    doReturn(Optional.of(mock(HybridStoreConfig.class))).when(storeIngestionTask).getHybridStoreConfig();
+    doReturn(false).when(pcs).getReadyToServeInOffsetRecord();
+    Assert.assertFalse(storeIngestionTask.checkFastReadyToServeForReplica(pcs));
+
+    verify(pcs, never()).clearPreviouslyReadyToServeInOffsetRecord();
   }
 
   @Test

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/SITFastReadyToServeTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/SITFastReadyToServeTest.java
@@ -87,6 +87,10 @@ public class SITFastReadyToServeTest {
     storeIngestionTask.checkFastReadyToServeWithPreviousTimeLag(pcs);
     verify(pcs, times(1)).lagHasCaughtUp();
     verify(pcs, times(1)).setReadyToServeTimeLagThresholdInMs(eq(TimeUnit.MINUTES.toMillis(8)));
+    // The stale previouslyReadyToServe flag must be cleared on the decline path so that a crash during catch-up
+    // cannot trick a later restart into passing the fast path via a small checkpoint delta.
+    // Called twice above: Case 1 (default-0 timestamps produce a huge delta) and Case 3 (growth out of bound).
+    verify(pcs, times(2)).clearPreviouslyReadyToServeInOffsetRecord();
   }
 
   @Test
@@ -120,6 +124,81 @@ public class SITFastReadyToServeTest {
     doReturn(400L).when(storeIngestionTask).measureHybridOffsetLag(pcs, true);
     storeIngestionTask.checkFastReadyToServeWithPreviousOffsetLag(pcs);
     verify(pcs, times(1)).lagHasCaughtUp();
+    // The stale previouslyReadyToServe flag must be cleared on the decline path so that a crash during catch-up
+    // cannot trick a later restart into passing the fast path via a small checkpoint delta.
+    verify(pcs, times(1)).clearPreviouslyReadyToServeInOffsetRecord();
+  }
+
+  /**
+   * Regression test for the stale previouslyReadyToServe flag bug.
+   *
+   * Scenario:
+   *   Run 1: replica genuinely reaches ready-to-serve; previouslyReadyToServe=true is persisted.
+   *   Server is down for a long time (lag exceeds threshold on next restart).
+   *   Run 2: restart. Fast RTS lag check declines (lag too high). Replica starts regular catch-up.
+   *          syncOffset() refreshes heartbeatTimestamp / offsetLag / lastCheckpointTimestamp to fresh,
+   *          still-behind values before the replica ever reaches RTS.
+   *          Server crashes mid-catch-up.
+   *   Run 3: restart. Without the fix, flag is still true, and the checkpoint-vs-heartbeat delta on disk is
+   *          small (because both were written moments apart during Run 2 catch-up), so the fast RTS path
+   *          incorrectly marks the replica ready-to-serve while it is still substantially behind.
+   *
+   * Fix: clear the flag in the decline branch of both lag-check methods so the flag is only ever true when
+   * the replica was actually caught up at last shutdown. This test verifies that behavior directly.
+   */
+  @Test
+  public void testStalePreviouslyReadyToServeFlagIsClearedOnDeclineThenCannotPassOnNextRestart() {
+    StoreIngestionTask storeIngestionTask = mock(StoreIngestionTask.class);
+    VeniceServerConfig serverConfig = mock(VeniceServerConfig.class);
+    doReturn(5).when(serverConfig).getTimeLagThresholdForFastOnlineTransitionInRestartMinutes();
+    doReturn(serverConfig).when(storeIngestionTask).getServerConfig();
+    OffsetRecord record = mock(OffsetRecord.class);
+    PartitionConsumptionState pcs = mock(PartitionConsumptionState.class);
+    doReturn(record).when(pcs).getOffsetRecord();
+    doReturn("test_v1-1").when(pcs).getReplicaId();
+    doCallRealMethod().when(storeIngestionTask).checkFastReadyToServeWithPreviousTimeLag(any());
+
+    long currentTimestamp = System.currentTimeMillis();
+    // Run 2 restart: previous heartbeat is 10min behind, checkpoint was 7min ago => growth = 3min > 5min-2min
+    // threshold, lag check declines.
+    doReturn(currentTimestamp - TimeUnit.MINUTES.toMillis(7)).when(record).getLastCheckpointTimestamp();
+    doReturn(currentTimestamp - TimeUnit.MINUTES.toMillis(10)).when(record).getHeartbeatTimestamp();
+    doReturn(true).when(pcs).getReadyToServeInOffsetRecord();
+
+    Assert.assertFalse(
+        storeIngestionTask.checkFastReadyToServeWithPreviousTimeLag(pcs),
+        "Fast RTS should decline when lag growth exceeds threshold");
+    verify(pcs, never()).lagHasCaughtUp();
+    verify(pcs, times(1)).clearPreviouslyReadyToServeInOffsetRecord();
+  }
+
+  @Test
+  public void testStalePreviouslyReadyToServeFlagIsClearedOnOffsetLagDecline() {
+    StoreIngestionTask storeIngestionTask = mock(StoreIngestionTask.class);
+    VeniceServerConfig serverConfig = mock(VeniceServerConfig.class);
+    doReturn(2).when(serverConfig).getOffsetLagDeltaRelaxFactorForFastOnlineTransitionInRestart();
+    doReturn(serverConfig).when(storeIngestionTask).getServerConfig();
+    OffsetRecord record = mock(OffsetRecord.class);
+    PartitionConsumptionState pcs = mock(PartitionConsumptionState.class);
+    doReturn(record).when(pcs).getOffsetRecord();
+    doReturn("test_v1-1").when(pcs).getReplicaId();
+    doCallRealMethod().when(storeIngestionTask).checkFastReadyToServeWithPreviousOffsetLag(any());
+    HybridStoreConfig hybridStoreConfig =
+        new HybridStoreConfigImpl(100L, -100L, -1L, BufferReplayPolicy.REWIND_FROM_SOP);
+    hybridStoreConfig.setOffsetLagThresholdToGoOnline(100);
+    doReturn(Optional.of(hybridStoreConfig)).when(storeIngestionTask).getHybridStoreConfig();
+    doReturn(1).when(storeIngestionTask).getPartitionCount();
+
+    // Offset lag grew from 100 to 400 => delta 300 > 2 * 100 threshold, decline.
+    doReturn(400L).when(storeIngestionTask).measureHybridOffsetLag(pcs, true);
+    doReturn(100L).when(record).getOffsetLag();
+    doReturn(true).when(pcs).getReadyToServeInOffsetRecord();
+
+    Assert.assertFalse(
+        storeIngestionTask.checkFastReadyToServeWithPreviousOffsetLag(pcs),
+        "Fast RTS should decline when offset lag growth exceeds threshold");
+    verify(pcs, never()).lagHasCaughtUp();
+    verify(pcs, times(1)).clearPreviouslyReadyToServeInOffsetRecord();
   }
 
   @Test


### PR DESCRIPTION
## Problem Statement

The fast ready-to-serve (RTS) restart path uses the `previouslyReadyToServe` flag persisted in the offset record to decide whether a replica may skip normal lag catch-up on restart. When the flag is set, `StoreIngestionTask#checkFastReadyToServeForReplica` runs either `checkFastReadyToServeWithPreviousTimeLag` or `checkFastReadyToServeWithPreviousOffsetLag`; if the lag delta between the last checkpoint and the current measurement is below threshold, the replica is marked ready-to-serve immediately.

The bug: when those checks **decline** (lag delta exceeds threshold), the flag is **not** cleared. Meanwhile, `syncOffset()` refreshes `heartbeatTimestamp`, `offsetLag`, and `lastCheckpointTimestamp` on every checkpoint cycle during regular catch-up — well before the replica reaches RTS. A crash mid-catch-up therefore leaves on disk: stale `previouslyReadyToServe = true` plus fresh-but-still-behind lag values. On the next restart the delta check looks at two close-in-time catch-up checkpoints, computes a small delta, and passes the fast path — marking the replica ready-to-serve while it is still substantially behind the actual tail.

### Reproduction scenario

- **Run 1** — Replica genuinely reaches ready-to-serve. `previouslyReadyToServe = true` is persisted. Server stays up for hours, then is shut down for a long time.
- **Run 2 — restart after long downtime:**
  - Fast RTS time-lag check (`StoreIngestionTask.java:5742`): `delta = currentLag - previousLag` is huge → declines, returns `false`.
  - **Flag NOT cleared** (the bug).
  - Regular catch-up begins. Messages being consumed are from, say, 30 min ago.
  - `syncOffset` fires periodically and overwrites the checkpoint fields: `heartbeatTimestamp` ← producer TS of currently-consumed message (30 min behind wall clock), `lastCheckpointTimestamp` ← now, so `previousLag` on disk ≈ 30 min.
  - Server crashes/restarts before reaching actual RTS.
- **Run 3 — restart shortly after Run 2 crash (say 1 min later):**
  - Flag is still `true` (never cleared).
  - `currentLag = now - previousMessageTimestamp ≈ 31 min`
  - `previousLag ≈ 30 min`
  - `delta = currentLag - previousLag ≈ 1 min` → **within threshold**
  - `pcs.lagHasCaughtUp(); reportCompleted(pcs, true);`
  - **Replica is marked ready-to-serve while still ~31 minutes behind.**

The symmetric bug exists in `checkFastReadyToServeWithPreviousOffsetLag` (`StoreIngestionTask.java:5794-5801`).

## Solution

Clear `previouslyReadyToServe` in both decline branches — `checkFastReadyToServeWithPreviousTimeLag` and `checkFastReadyToServeWithPreviousOffsetLag` — before returning `false`. This restores the invariant implied by `recordReadyToServeInOffsetRecord`'s contract: the flag is only ever set if the replica was actually caught up at last successful shutdown. The decline path already signals "we do not trust the prior RTS state", so clearing the flag on that path is the natural place to express that distrust.

No performance impact — the clear is a single Avro-field mutation on an offset record that is already being read in the same code path.

###  Code changes
- [ ] Added new code behind **a config**. If so list the config names and their default values in the PR description.
- [ ] Introduced new **log lines**.
  - [ ] Confirmed if logs need to be **rate limited** to avoid excessive logging.

###  **Concurrency-Specific Checks**
Both reviewer and PR author to verify
- [x] Code has **no race conditions** or **thread safety issues**. The clear runs on the same SIT thread as the existing reads in the same method.
- [x] Proper **synchronization mechanisms** (e.g., `synchronized`, `RWLock`) are used where needed. No new shared-state access introduced.
- [x] No **blocking calls** inside critical sections that could lead to deadlocks or performance degradation.
- [x] Verified **thread-safe collections** are used (e.g., `ConcurrentHashMap`, `CopyOnWriteArrayList`). N/A — no new collection access.
- [x] Validated proper exception handling in multi-threaded code to avoid silent thread termination.

## How was this PR tested?

- [x] New unit tests added. Two new regression tests in `SITFastReadyToServeTest`:
  - `testStalePreviouslyReadyToServeFlagIsClearedOnDeclineThenCannotPassOnNextRestart` — verifies the time-lag decline path clears the flag.
  - `testStalePreviouslyReadyToServeFlagIsClearedOnOffsetLagDecline` — verifies the offset-lag decline path clears the flag.
- [ ] New integration tests added.
- [x] Modified or extended existing tests. Extended `testReadyToServeWithMessageTimeLag` and `testReadyToServeWithOffsetLag` to assert the flag is cleared on decline.
- [x] Verified backward compatibility. Clearing the flag on decline is strictly safer than leaving it set: the only effect is that a subsequent restart will take the regular RTS path instead of (potentially incorrectly) the fast path. Regular RTS remains correct.

Test run:
```
SITFastReadyToServeTest > testReadyToServeConfigBranch PASSED
SITFastReadyToServeTest > testReadyToServeSerialization PASSED
SITFastReadyToServeTest > testReadyToServeWithMessageTimeLag PASSED
SITFastReadyToServeTest > testReadyToServeWithOffsetLag PASSED
SITFastReadyToServeTest > testStalePreviouslyReadyToServeFlagIsClearedOnDeclineThenCannotPassOnNextRestart PASSED
SITFastReadyToServeTest > testStalePreviouslyReadyToServeFlagIsClearedOnOffsetLagDecline PASSED
```

## Does this PR introduce any user-facing or breaking changes?

- [x] No. You can skip the rest of this section.