### PR TITLE
[vpj] Auto-resolve latest version from store name in VT consistency checker

### DIFF
--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/spark/consistency/VTConsistencyCheckerJob.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/spark/consistency/VTConsistencyCheckerJob.java
@@ -4,13 +4,19 @@ import static com.linkedin.venice.ConfigKeys.KAFKA_BOOTSTRAP_SERVERS;
 import static com.linkedin.venice.spark.SparkConstants.SPARK_CLUSTER_CONFIG;
 import static com.linkedin.venice.spark.SparkConstants.SPARK_SESSION_CONF_PREFIX;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.SSL_CONFIGURATOR_CLASS_CONFIG;
+import static com.linkedin.venice.vpj.VenicePushJobConstants.VENICE_DISCOVER_URL_PROP;
 
 import com.linkedin.venice.acl.VeniceComponent;
+import com.linkedin.venice.controllerapi.ControllerClient;
+import com.linkedin.venice.controllerapi.ControllerClientFactory;
+import com.linkedin.venice.controllerapi.StoreResponse;
+import com.linkedin.venice.exceptions.VeniceException;
 import com.linkedin.venice.hadoop.utils.VPJSSLUtils;
 import com.linkedin.venice.kafka.protocol.ControlMessage;
 import com.linkedin.venice.kafka.protocol.KafkaMessageEnvelope;
 import com.linkedin.venice.kafka.protocol.enums.ControlMessageType;
 import com.linkedin.venice.kafka.protocol.enums.MessageType;
+import com.linkedin.venice.meta.Version;
 import com.linkedin.venice.pubsub.PubSubClientsFactory;
 import com.linkedin.venice.pubsub.PubSubConsumerAdapterContext;
 import com.linkedin.venice.pubsub.PubSubPositionDeserializer;
@@ -37,6 +43,7 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Properties;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
@@ -79,7 +86,8 @@ import org.apache.spark.util.LongAccumulator;
  * <ul>
  *   <li>{@value #DC0_BROKER_URL} — PubSub broker address for DC-0</li>
  *   <li>{@value #DC1_BROKER_URL} — PubSub broker address for DC-1</li>
- *   <li>{@value #VERSION_TOPIC} — version topic name to scan (e.g. {@code my-store_v3})</li>
+ *   <li>{@value #STORE_NAME} — store name; the version topic is resolved to the store's current version via the controller</li>
+ *   <li>{@code venice.discover.urls} — controller discovery URLs (HTTP or {@code d2://<serviceName>}) used to look up the current version</li>
  *   <li>{@value #OUTPUT_PATH} — output path to write Parquet results</li>
  *   <li>{@value #NUMBER_OF_REGIONS} — total number of regions in the AA topology</li>
  * </ul>
@@ -98,9 +106,10 @@ public class VTConsistencyCheckerJob {
 
   public static final String DC0_BROKER_URL = "dc0.broker.url";
   public static final String DC1_BROKER_URL = "dc1.broker.url";
-  public static final String VERSION_TOPIC = "version.topic";
+  public static final String STORE_NAME = "store.name";
   public static final String OUTPUT_PATH = "output.path";
   public static final String NUMBER_OF_REGIONS = "number.of.regions";
+  private static final int CONTROLLER_REQUEST_RETRIES = 3;
 
   /**
    * Schema of each output row. One row per detected inconsistency.
@@ -146,11 +155,14 @@ public class VTConsistencyCheckerJob {
   public static void run(Properties jobProps) {
     String dc0BrokerUrl = jobProps.getProperty(DC0_BROKER_URL);
     String dc1BrokerUrl = jobProps.getProperty(DC1_BROKER_URL);
-    String versionTopic = jobProps.getProperty(VERSION_TOPIC);
+    String storeName = jobProps.getProperty(STORE_NAME);
+    String discoveryUrls = jobProps.getProperty(VENICE_DISCOVER_URL_PROP);
     String outputPath = jobProps.getProperty(OUTPUT_PATH);
     int numberOfRegions = Integer.parseInt(jobProps.getProperty(NUMBER_OF_REGIONS));
+    String versionTopic = resolveCurrentVersionTopic(storeName, discoveryUrls);
     LOGGER.info(
-        "VT consistency check starting. topic={} dc0={} dc1={} regions={}",
+        "VT consistency check starting. store={} topic={} dc0={} dc1={} regions={}",
+        storeName,
         versionTopic,
         dc0BrokerUrl,
         dc1BrokerUrl,
@@ -487,11 +499,40 @@ public class VTConsistencyCheckerJob {
   }
 
   private static void validateRequiredProps(Properties props) {
-    for (String required: new String[] { DC0_BROKER_URL, DC1_BROKER_URL, VERSION_TOPIC, OUTPUT_PATH,
-        NUMBER_OF_REGIONS }) {
+    for (String required: new String[] { DC0_BROKER_URL, DC1_BROKER_URL, STORE_NAME, VENICE_DISCOVER_URL_PROP,
+        OUTPUT_PATH, NUMBER_OF_REGIONS }) {
       if (!props.containsKey(required)) {
         Utils.exit("Missing required config: " + required);
       }
     }
+  }
+
+  /**
+   * Looks up the store's current version via the controller and returns the corresponding version topic name.
+   * Throws if the store cannot be found or has no current version assigned.
+   */
+  static String resolveCurrentVersionTopic(String storeName, String discoveryUrls) {
+    try (ControllerClient controllerClient = ControllerClientFactory
+        .discoverAndConstructControllerClient(storeName, discoveryUrls, Optional.empty(), CONTROLLER_REQUEST_RETRIES)) {
+      return versionTopicFromStoreResponse(storeName, discoveryUrls, controllerClient.getStore(storeName));
+    }
+  }
+
+  /**
+   * Package-private for unit testing. Derives the version topic name from a {@link StoreResponse},
+   * validating that the response is not an error and that the store has a valid current version.
+   */
+  static String versionTopicFromStoreResponse(String storeName, String discoveryUrls, StoreResponse response) {
+    if (response.isError()) {
+      throw new VeniceException(
+          "Failed to fetch store metadata for " + storeName + " via " + discoveryUrls + ": " + response.getError());
+    }
+    int currentVersion = response.getStore().getCurrentVersion();
+    if (currentVersion <= 0) {
+      throw new VeniceException(
+          "Store " + storeName + " has no current version (getCurrentVersion=" + currentVersion
+              + "); cannot run VT consistency check.");
+    }
+    return Version.composeKafkaTopic(storeName, currentVersion);
   }
 }

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/spark/consistency/VTConsistencyCheckerJob.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/spark/consistency/VTConsistencyCheckerJob.java
@@ -1,8 +1,12 @@
 package com.linkedin.venice.spark.consistency;
 
+import static com.linkedin.venice.CommonConfigKeys.SSL_FACTORY_CLASS_NAME;
 import static com.linkedin.venice.ConfigKeys.KAFKA_BOOTSTRAP_SERVERS;
+import static com.linkedin.venice.VeniceConstants.DEFAULT_SSL_FACTORY_CLASS_NAME;
 import static com.linkedin.venice.spark.SparkConstants.SPARK_CLUSTER_CONFIG;
 import static com.linkedin.venice.spark.SparkConstants.SPARK_SESSION_CONF_PREFIX;
+import static com.linkedin.venice.vpj.VenicePushJobConstants.DEFAULT_SSL_ENABLED;
+import static com.linkedin.venice.vpj.VenicePushJobConstants.ENABLE_SSL;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.SSL_CONFIGURATOR_CLASS_CONFIG;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.VENICE_DISCOVER_URL_PROP;
 
@@ -32,8 +36,10 @@ import com.linkedin.venice.pubsub.api.PubSubTopicPartition;
 import com.linkedin.venice.pubsub.manager.TopicManager;
 import com.linkedin.venice.pubsub.manager.TopicManagerContext;
 import com.linkedin.venice.pubsub.manager.TopicManagerRepository;
+import com.linkedin.venice.security.SSLFactory;
 import com.linkedin.venice.utils.Utils;
 import com.linkedin.venice.utils.VeniceProperties;
+import com.linkedin.venice.utils.lazy.Lazy;
 import com.linkedin.venice.vpj.pubsub.input.PubSubPartitionSplit;
 import com.linkedin.venice.vpj.pubsub.input.PubSubSplitIterator;
 import java.io.FileReader;
@@ -87,7 +93,7 @@ import org.apache.spark.util.LongAccumulator;
  *   <li>{@value #DC0_BROKER_URL} — PubSub broker address for DC-0</li>
  *   <li>{@value #DC1_BROKER_URL} — PubSub broker address for DC-1</li>
  *   <li>{@value #STORE_NAME} — store name; the version topic is resolved to the store's current version via the controller</li>
- *   <li>{@code venice.discover.urls} — controller discovery URLs (HTTP or {@code d2://<serviceName>}) used to look up the current version</li>
+ *   <li>{@code venice.discover.urls} — comma-separated HTTP controller URLs used to look up the current version. D2-based discovery is not supported here; use HTTP URLs.</li>
  *   <li>{@value #OUTPUT_PATH} — output path to write Parquet results</li>
  *   <li>{@value #NUMBER_OF_REGIONS} — total number of regions in the AA topology</li>
  * </ul>
@@ -159,7 +165,8 @@ public class VTConsistencyCheckerJob {
     String discoveryUrls = jobProps.getProperty(VENICE_DISCOVER_URL_PROP);
     String outputPath = jobProps.getProperty(OUTPUT_PATH);
     int numberOfRegions = Integer.parseInt(jobProps.getProperty(NUMBER_OF_REGIONS));
-    String versionTopic = resolveCurrentVersionTopic(storeName, discoveryUrls);
+    Optional<SSLFactory> sslFactory = buildControllerSSLFactory(jobProps);
+    String versionTopic = resolveCurrentVersionTopic(storeName, discoveryUrls, sslFactory);
     LOGGER.info(
         "VT consistency check starting. store={} topic={} dc0={} dc1={} regions={}",
         storeName,
@@ -508,14 +515,44 @@ public class VTConsistencyCheckerJob {
   }
 
   /**
-   * Looks up the store's current version via the controller and returns the corresponding version topic name.
-   * Throws if the store cannot be found or has no current version assigned.
+   * Looks up the store's current version via the controller and returns the corresponding version
+   * topic name. Throws if the store cannot be found or has no current version assigned.
+   * <p>
+   * The {@code currentVersion} is resolved against the supplied discovery URL's view only. In a
+   * cross-DC setup where DCs may disagree on current version (e.g. mid-rollout), point the
+   * discovery URL at the DC whose view should drive the scan.
+   * <p>
+   * The supplied {@link SSLFactory} is threaded into controller discovery so the lookup honors
+   * the job's SSL/ACL configuration — mirrors the mainline pattern in
+   * {@code VenicePushJob#getControllerClient}. Pass {@link Optional#empty()} for plain HTTP.
    */
-  static String resolveCurrentVersionTopic(String storeName, String discoveryUrls) {
+  static String resolveCurrentVersionTopic(String storeName, String discoveryUrls, Optional<SSLFactory> sslFactory) {
     try (ControllerClient controllerClient = ControllerClientFactory
-        .discoverAndConstructControllerClient(storeName, discoveryUrls, Optional.empty(), CONTROLLER_REQUEST_RETRIES)) {
+        .discoverAndConstructControllerClient(storeName, discoveryUrls, sslFactory, CONTROLLER_REQUEST_RETRIES)) {
       return versionTopicFromStoreResponse(storeName, discoveryUrls, controllerClient.getStore(storeName));
     }
+  }
+
+  /**
+   * Builds the {@link SSLFactory} used for the driver-side controller lookup from the job's own
+   * SSL config ({@code venice.ssl.enable}, {@code ssl.factory.class.name}, and the SSL-
+   * configurator-derived properties loaded via {@link VPJSSLUtils#getSslProperties}). Returns
+   * {@link Optional#empty()} when SSL is disabled — the integration-test path. Mirrors the
+   * mainline VPJ pattern so the driver-side controller lookup has the same SSL posture as the
+   * executor-side PubSub consumers.
+   */
+  static Optional<SSLFactory> buildControllerSSLFactory(Properties jobProps) {
+    VeniceProperties veniceProps = new VeniceProperties(jobProps);
+    return VPJSSLUtils.createSSLFactory(
+        veniceProps.getBoolean(ENABLE_SSL, DEFAULT_SSL_ENABLED),
+        veniceProps.getString(SSL_FACTORY_CLASS_NAME, DEFAULT_SSL_FACTORY_CLASS_NAME),
+        Lazy.of(() -> {
+          try {
+            return VPJSSLUtils.getSslProperties(veniceProps);
+          } catch (IOException e) {
+            throw new VeniceException("Failed to load SSL properties for controller discovery", e);
+          }
+        }));
   }
 
   /**
@@ -526,6 +563,9 @@ public class VTConsistencyCheckerJob {
     if (response.isError()) {
       throw new VeniceException(
           "Failed to fetch store metadata for " + storeName + " via " + discoveryUrls + ": " + response.getError());
+    }
+    if (response.getStore() == null) {
+      throw new VeniceException("Controller returned no store payload for " + storeName + " via " + discoveryUrls);
     }
     int currentVersion = response.getStore().getCurrentVersion();
     if (currentVersion <= 0) {

--- a/clients/venice-push-job/src/test/java/com/linkedin/venice/spark/consistency/VTConsistencyCheckerJobTest.java
+++ b/clients/venice-push-job/src/test/java/com/linkedin/venice/spark/consistency/VTConsistencyCheckerJobTest.java
@@ -11,7 +11,11 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.expectThrows;
 
+import com.linkedin.venice.controllerapi.StoreResponse;
+import com.linkedin.venice.exceptions.VeniceException;
 import com.linkedin.venice.kafka.protocol.ControlMessage;
 import com.linkedin.venice.kafka.protocol.EndOfPush;
 import com.linkedin.venice.kafka.protocol.KafkaMessageEnvelope;
@@ -19,6 +23,7 @@ import com.linkedin.venice.kafka.protocol.ProducerMetadata;
 import com.linkedin.venice.kafka.protocol.Put;
 import com.linkedin.venice.kafka.protocol.enums.ControlMessageType;
 import com.linkedin.venice.kafka.protocol.enums.MessageType;
+import com.linkedin.venice.meta.StoreInfo;
 import com.linkedin.venice.pubsub.PubSubTopicPartitionImpl;
 import com.linkedin.venice.pubsub.PubSubTopicRepository;
 import com.linkedin.venice.pubsub.adapter.kafka.common.ApacheKafkaOffsetPosition;
@@ -345,5 +350,58 @@ public class VTConsistencyCheckerJobTest {
     assertEquals(OUTPUT_SCHEMA.fields()[idx].name(), name, "field[" + idx + "] name");
     assertEquals(OUTPUT_SCHEMA.fields()[idx].dataType(), type, "field[" + idx + "] dataType");
     assertEquals(OUTPUT_SCHEMA.fields()[idx].nullable(), nullable, "field[" + idx + "] nullable");
+  }
+
+  // ── versionTopicFromStoreResponse ─────────────────────────────────────────
+
+  /**
+   * Happy path: a successful {@link StoreResponse} with a positive current version yields a
+   * version topic composed as {@code storeName_v<currentVersion>}.
+   */
+  @Test
+  public void testVersionTopicFromStoreResponseComposesTopicFromCurrentVersion() {
+    StoreInfo storeInfo = new StoreInfo();
+    storeInfo.setCurrentVersion(7);
+    StoreResponse response = new StoreResponse();
+    response.setStore(storeInfo);
+
+    String versionTopic =
+        VTConsistencyCheckerJob.versionTopicFromStoreResponse("my-store", "http://controller.example:1234", response);
+    assertEquals(versionTopic, "my-store_v7");
+  }
+
+  /**
+   * If the controller response is an error, the helper must throw a VeniceException that
+   * includes the store name and the controller-reported error.
+   */
+  @Test
+  public void testVersionTopicFromStoreResponseThrowsOnErrorResponse() {
+    StoreResponse response = new StoreResponse();
+    response.setError("store does not exist");
+
+    VeniceException ex = expectThrows(
+        VeniceException.class,
+        () -> VTConsistencyCheckerJob
+            .versionTopicFromStoreResponse("missing-store", "http://controller.example:1234", response));
+    assertTrue(ex.getMessage().contains("missing-store"), "error message should contain store name");
+    assertTrue(ex.getMessage().contains("store does not exist"), "error message should contain controller error");
+  }
+
+  /**
+   * If the store exists but has no current version yet (e.g. never pushed), the helper must
+   * fail fast rather than construct an invalid version topic like {@code store_v0}.
+   */
+  @Test
+  public void testVersionTopicFromStoreResponseThrowsWhenNoCurrentVersion() {
+    StoreInfo storeInfo = new StoreInfo();
+    storeInfo.setCurrentVersion(0);
+    StoreResponse response = new StoreResponse();
+    response.setStore(storeInfo);
+
+    VeniceException ex = expectThrows(
+        VeniceException.class,
+        () -> VTConsistencyCheckerJob
+            .versionTopicFromStoreResponse("never-pushed", "http://controller.example:1234", response));
+    assertTrue(ex.getMessage().contains("no current version"), "error message should mention missing version");
   }
 }

--- a/clients/venice-push-job/src/test/java/com/linkedin/venice/spark/consistency/VTConsistencyCheckerJobTest.java
+++ b/clients/venice-push-job/src/test/java/com/linkedin/venice/spark/consistency/VTConsistencyCheckerJobTest.java
@@ -1,6 +1,7 @@
 package com.linkedin.venice.spark.consistency;
 
 import static com.linkedin.venice.spark.consistency.VTConsistencyCheckerJob.OUTPUT_SCHEMA;
+import static com.linkedin.venice.vpj.VenicePushJobConstants.ENABLE_SSL;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyLong;
@@ -10,6 +11,7 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.expectThrows;
@@ -403,5 +405,71 @@ public class VTConsistencyCheckerJobTest {
         () -> VTConsistencyCheckerJob
             .versionTopicFromStoreResponse("never-pushed", "http://controller.example:1234", response));
     assertTrue(ex.getMessage().contains("no current version"), "error message should mention missing version");
+  }
+
+  /**
+   * If the controller returns a non-error response but with a null store payload, the helper must
+   * fail with a clear message rather than NPE when dereferencing {@code getStore()}.
+   */
+  @Test
+  public void testVersionTopicFromStoreResponseThrowsOnNullStorePayload() {
+    StoreResponse response = new StoreResponse();
+    // no setStore(...) call → getStore() returns null
+
+    VeniceException ex = expectThrows(
+        VeniceException.class,
+        () -> VTConsistencyCheckerJob
+            .versionTopicFromStoreResponse("null-payload-store", "http://controller.example:1234", response));
+    assertTrue(ex.getMessage().contains("null-payload-store"), "error message should contain store name");
+    assertTrue(ex.getMessage().contains("no store payload"), "error message should describe the missing payload");
+  }
+
+  /**
+   * A negative {@code currentVersion} (e.g. a disabled or deleted store reported with a sentinel
+   * value) must also trip the guard. Covers the negative branch of the {@code <= 0} check that
+   * the zero-version test cannot exercise on its own.
+   */
+  @Test
+  public void testVersionTopicFromStoreResponseThrowsWhenCurrentVersionIsNegative() {
+    StoreInfo storeInfo = new StoreInfo();
+    storeInfo.setCurrentVersion(-1);
+    StoreResponse response = new StoreResponse();
+    response.setStore(storeInfo);
+
+    VeniceException ex = expectThrows(
+        VeniceException.class,
+        () -> VTConsistencyCheckerJob
+            .versionTopicFromStoreResponse("disabled-store", "http://controller.example:1234", response));
+    assertTrue(ex.getMessage().contains("no current version"), "error message should mention missing version");
+    assertTrue(ex.getMessage().contains("-1"), "error message should include the negative sentinel value");
+  }
+
+  // ── buildControllerSSLFactory ────────────────────────────────────────────
+
+  /**
+   * SSL explicitly disabled: the factory must be absent so the controller lookup falls back to
+   * plain HTTP. Guards against accidentally enabling SSL and reading Hadoop token files in
+   * non-SSL deployments (integration test path).
+   */
+  @Test
+  public void testBuildControllerSSLFactoryReturnsEmptyWhenSslDisabledExplicitly() {
+    Properties props = new Properties();
+    props.setProperty(ENABLE_SSL, "false");
+    assertFalse(
+        VTConsistencyCheckerJob.buildControllerSSLFactory(props).isPresent(),
+        "factory should be empty when SSL is explicitly disabled");
+  }
+
+  /**
+   * SSL key absent altogether: defaults must resolve to "disabled" so the helper doesn't attempt
+   * to read Hadoop tokens that don't exist in most test and local setups.
+   */
+  @Test
+  public void testBuildControllerSSLFactoryReturnsEmptyWhenSslEnableKeyAbsent() {
+    Properties props = new Properties();
+    // Intentionally no ENABLE_SSL key — must fall back to DEFAULT_SSL_ENABLED (false).
+    assertFalse(
+        VTConsistencyCheckerJob.buildControllerSSLFactory(props).isPresent(),
+        "factory should be empty when the ENABLE_SSL key is absent");
   }
 }

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestVTConsistencyCheckerJob.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestVTConsistencyCheckerJob.java
@@ -9,6 +9,7 @@ import static com.linkedin.venice.utils.TestWriteUtils.STRING_SCHEMA;
 import static com.linkedin.venice.utils.TestWriteUtils.getTempDataDirectory;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.DEFAULT_KEY_FIELD_PROP;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.DEFAULT_VALUE_FIELD_PROP;
+import static com.linkedin.venice.vpj.VenicePushJobConstants.VENICE_DISCOVER_URL_PROP;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNotNull;
@@ -237,7 +238,8 @@ public class TestVTConsistencyCheckerJob extends AbstractMultiRegionTest {
         jobProps.setProperty(
             VTConsistencyCheckerJob.DC1_BROKER_URL,
             childDatacenters.get(1).getPubSubBrokerWrapper().getAddress());
-        jobProps.setProperty(VTConsistencyCheckerJob.VERSION_TOPIC, versionTopic);
+        jobProps.setProperty(VTConsistencyCheckerJob.STORE_NAME, storeName);
+        jobProps.setProperty(VENICE_DISCOVER_URL_PROP, childDatacenters.get(0).getControllerConnectString());
         jobProps.setProperty(VTConsistencyCheckerJob.OUTPUT_PATH, outputDir.getAbsolutePath());
         jobProps.setProperty(VTConsistencyCheckerJob.NUMBER_OF_REGIONS, "2");
 


### PR DESCRIPTION
## Problem Statement

The VTConsistencyCheckerJob required operators to pass the exact version topic name (e.g. my-store_v3) via the version.topic config. This forced a manual lookup step before every run: the operator had to know or query the store's current version number, then hand-assemble the VT name. This will also block us from automatically integrating this job in the certification DAG. 


## Solution

Replace version.topic with store.name + venice.discover.urls. At job start, the driver uses ControllerClient to:                                         
  1. Discover the cluster that owns the store (discoverCluster).                                                                                           
  2. Fetch the store metadata (getStore(storeName)).
  3. Read StoreInfo.getCurrentVersion() — the version currently serving reads.                                                                             
  4. Compose the VT name via Version.composeKafkaTopic(storeName, currentVersion).   


###  Code changes
- [ ] Added new code behind **a config**. If so list the config names and their default values in the PR description.
- [ ] Introduced new **log lines**. 
  - [ ] Confirmed if logs need to be **rate limited** to avoid excessive logging.

###  **Concurrency-Specific Checks**
Both reviewer and PR author to verify
- [x] Code has **no race conditions** or **thread safety issues**.
- [x] Proper **synchronization mechanisms** (e.g., `synchronized`, `RWLock`) are used where needed.
- [x] No **blocking calls** inside critical sections that could lead to deadlocks or performance degradation.
- [x] Verified **thread-safe collections** are used (e.g., `ConcurrentHashMap`, `CopyOnWriteArrayList`).
- [x] Validated proper exception handling in multi-threaded code to avoid silent thread termination.


## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->

- [ ] New unit tests added.
- [ ] New integration tests added.
- [x] Modified or extended existing tests.
- [x] Verified backward compatibility (if applicable).

## Does this PR introduce any user-facing or breaking changes?
<!--  
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Clearly explain the behavior change and its impact.