### PR TITLE
[da-vinci][server] Guard version-role-change resubscribe against in-flight blob transfer

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
@@ -793,11 +793,13 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
   void resubscribeForAllPartitions() throws InterruptedException {
     throwIfNotRunning();
     for (PartitionConsumptionState partitionConsumptionState: partitionConsumptionStateMap.values()) {
-      // Skip partitions with an in-flight blob transfer. Resubscribing reopens RocksDB on the final
-      // partition directory while blob transfer is still receiving files into the temp directory,
-      // causing the post-transfer rename to fail with "Final partition directory is not empty".
-      // completeBlobTransferAndSubscribe will subscribe once the transfer finishes, using the
-      // already-updated versionRole/workloadType.
+      /**
+       * Skip partitions with an in-flight blob transfer. Resubscribing reopens RocksDB on the final
+       * partition directory while blob transfer is still receiving files into the temp directory,
+       * causing the post-transfer rename to fail with "Final partition directory is not empty".
+       * completeBlobTransferAndSubscribe will subscribe once the transfer finishes, using the
+       * already-updated versionRole/workloadType.
+       */
       if (partitionConsumptionState.isBlobTransferInProgress()) {
         LOGGER.info(
             "Skipping version-role-change resubscribe for replica: {} because blob transfer is in progress.",
@@ -5894,6 +5896,20 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
             getReplicaId(versionTopic, partition));
         continue;
       }
+
+      /**
+       * Skip partitions with an in-flight blob transfer. Resubscribing reopens RocksDB on the final
+       * partition directory while blob transfer is still receiving files into the temp directory,
+       * causing the post-transfer rename to fail. completeBlobTransferAndSubscribe will subscribe
+       * once the transfer finishes.
+       */
+      if (pcs.isBlobTransferInProgress()) {
+        LOGGER.info(
+            "Skipping lag-based resubscribe for replica: {} because blob transfer is in progress.",
+            pcs.getReplicaId());
+        continue;
+      }
+
       /**
        * As of now, this feature intends to resolve ingestion performance issue introduced by consumer. We will rely on
        * the error reset feature to handle the error replica properly.

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
@@ -792,7 +792,18 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
 
   void resubscribeForAllPartitions() throws InterruptedException {
     throwIfNotRunning();
-    for (PartitionConsumptionState partitionConsumptionState: partitionConsumptionStateMap.values()) {
+    for (PartitionConsumptionState partitionConsumptionState: getPartitionConsumptionStateMap().values()) {
+      // Skip partitions with an in-flight blob transfer. Resubscribing reopens RocksDB on the final
+      // partition directory while blob transfer is still receiving files into the temp directory,
+      // causing the post-transfer rename to fail with "Final partition directory is not empty".
+      // completeBlobTransferAndSubscribe will subscribe once the transfer finishes, using the
+      // already-updated versionRole/workloadType.
+      if (partitionConsumptionState.isBlobTransferInProgress()) {
+        LOGGER.info(
+            "Skipping version-role-change resubscribe for replica: {} because blob transfer is in progress.",
+            partitionConsumptionState.getReplicaId());
+        continue;
+      }
       /**
        * For completed current version replica, if we resubscribe during version role change, it will be resubscribed to
        * correct high priority pool. We will mark {@link PartitionConsumptionState#hasResubscribedAfterBootstrapAsCurrentVersion}

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
@@ -792,7 +792,7 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
 
   void resubscribeForAllPartitions() throws InterruptedException {
     throwIfNotRunning();
-    for (PartitionConsumptionState partitionConsumptionState: getPartitionConsumptionStateMap().values()) {
+    for (PartitionConsumptionState partitionConsumptionState: partitionConsumptionStateMap.values()) {
       // Skip partitions with an in-flight blob transfer. Resubscribing reopens RocksDB on the final
       // partition directory while blob transfer is still receiving files into the temp directory,
       // causing the post-transfer rename to fail with "Final partition directory is not empty".

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTaskTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTaskTest.java
@@ -270,6 +270,7 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
+import java.util.concurrent.PriorityBlockingQueue;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
@@ -4770,6 +4771,56 @@ public abstract class StoreIngestionTaskTest {
     verify(storeIngestionTask, times(1)).resubscribe(pcsNotComplete);
     verify(storeIngestionTask, times(1)).resubscribe(pcsCompleteNotFlipped);
     verify(pcsCompleteNotFlipped, times(1)).setHasResubscribedAfterBootstrapAsCurrentVersion(eq(true));
+  }
+
+  /**
+   * Verifies that {@link StoreIngestionTask#maybeProcessResubscribeRequest()} (the lag-based
+   * auto-resubscribe path fed by {@code HeartbeatMonitoringService}) skips partitions whose blob
+   * transfer is still in flight. Same race as the version-role-change path: resubscribing would
+   * reopen RocksDB on the final partition directory mid-transfer and break the post-transfer rename.
+   */
+  @Test
+  public void testMaybeProcessResubscribeRequestSkipsBlobTransferInProgress() throws Exception {
+    StoreIngestionTask storeIngestionTask = mock(StoreIngestionTask.class);
+    doCallRealMethod().when(storeIngestionTask).maybeProcessResubscribeRequest();
+
+    VeniceServerConfig serverConfig = mock(VeniceServerConfig.class);
+    doReturn(serverConfig).when(storeIngestionTask).getServerConfig();
+    doReturn(10).when(serverConfig).getLagBasedReplicaAutoResubscribeMaxReplicaCount();
+    doReturn(60).when(serverConfig).getLagBasedReplicaAutoResubscribeIntervalInSeconds();
+
+    // pcs0: blob transfer in progress -- MUST be skipped.
+    PartitionConsumptionState pcsBlobInProgress = mock(PartitionConsumptionState.class);
+    doReturn(true).when(pcsBlobInProgress).isBlobTransferInProgress();
+    doReturn("store_v1-0").when(pcsBlobInProgress).getReplicaId();
+
+    // pcs1: no blob transfer -- should be resubscribed.
+    PartitionConsumptionState pcsReady = mock(PartitionConsumptionState.class);
+    doReturn(false).when(pcsReady).isBlobTransferInProgress();
+    doReturn(false).when(pcsReady).isErrorReported();
+    doReturn("store_v1-1").when(pcsReady).getReplicaId();
+
+    VeniceConcurrentHashMap<Integer, PartitionConsumptionState> pcsMap = new VeniceConcurrentHashMap<>();
+    pcsMap.put(0, pcsBlobInProgress);
+    pcsMap.put(1, pcsReady);
+    doReturn(pcsMap).when(storeIngestionTask).getPartitionConsumptionStateMap();
+
+    PriorityBlockingQueue<Integer> resubscribeQueue = new PriorityBlockingQueue<>();
+    resubscribeQueue.add(0);
+    resubscribeQueue.add(1);
+    doReturn(resubscribeQueue).when(storeIngestionTask).getResubscribeRequestQueue();
+
+    // Empty previous-resubscribe-time map means no rate-limiting will trigger.
+    doReturn(new VeniceConcurrentHashMap<Integer, Long>()).when(storeIngestionTask)
+        .getPartitionToPreviousResubscribeTimeMap();
+
+    storeIngestionTask.maybeProcessResubscribeRequest();
+
+    // Blob-transfer-in-progress partition is skipped entirely.
+    verify(storeIngestionTask, never()).resubscribe(pcsBlobInProgress);
+
+    // Ready partition is resubscribed as usual.
+    verify(storeIngestionTask, times(1)).resubscribe(pcsReady);
   }
 
   @Test(dataProvider = "aaConfigProvider")

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTaskTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTaskTest.java
@@ -4728,11 +4728,9 @@ public abstract class StoreIngestionTaskTest {
    * the post-transfer rename and drives the replica to Helix ERROR.
    */
   @Test
-  public void testResubscribeForAllPartitionsSkipsBlobTransferInProgress() throws InterruptedException {
+  public void testResubscribeForAllPartitionsSkipsBlobTransferInProgress() throws Exception {
     StoreIngestionTask storeIngestionTask = mock(StoreIngestionTask.class);
     doCallRealMethod().when(storeIngestionTask).resubscribeForAllPartitions();
-    Map<Integer, PartitionConsumptionState> partitionConsumptionStateMap = new HashMap<>();
-    doReturn(partitionConsumptionStateMap).when(storeIngestionTask).getPartitionConsumptionStateMap();
 
     // pcs0: blob transfer in progress -- MUST be skipped.
     PartitionConsumptionState pcsBlobInProgress = mock(PartitionConsumptionState.class);
@@ -4750,9 +4748,15 @@ public abstract class StoreIngestionTaskTest {
     doReturn(true).when(pcsCompleteNotFlipped).isComplete();
     doReturn(false).when(pcsCompleteNotFlipped).hasResubscribedAfterBootstrapAsCurrentVersion();
 
-    partitionConsumptionStateMap.put(0, pcsBlobInProgress);
-    partitionConsumptionStateMap.put(1, pcsNotComplete);
-    partitionConsumptionStateMap.put(2, pcsCompleteNotFlipped);
+    VeniceConcurrentHashMap<Integer, PartitionConsumptionState> pcsMap = new VeniceConcurrentHashMap<>();
+    pcsMap.put(0, pcsBlobInProgress);
+    pcsMap.put(1, pcsNotComplete);
+    pcsMap.put(2, pcsCompleteNotFlipped);
+
+    // Inject into the protected final partitionConsumptionStateMap field on the mock.
+    Field pcsMapField = StoreIngestionTask.class.getDeclaredField("partitionConsumptionStateMap");
+    pcsMapField.setAccessible(true);
+    pcsMapField.set(storeIngestionTask, pcsMap);
 
     doReturn(true).when(storeIngestionTask).isCurrentVersion();
 

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTaskTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTaskTest.java
@@ -4720,6 +4720,54 @@ public abstract class StoreIngestionTaskTest {
 
   }
 
+  /**
+   * Verifies that {@link StoreIngestionTask#resubscribeForAllPartitions()} skips partitions whose
+   * blob transfer is still in flight. Without this guard, a version-role change (e.g. FUTURE->CURRENT)
+   * would unsubscribe + resubscribe the partition, causing RocksDB to reopen on the final partition
+   * directory while the blob transfer was still streaming into the temp directory -- which breaks
+   * the post-transfer rename and drives the replica to Helix ERROR.
+   */
+  @Test
+  public void testResubscribeForAllPartitionsSkipsBlobTransferInProgress() throws InterruptedException {
+    StoreIngestionTask storeIngestionTask = mock(StoreIngestionTask.class);
+    doCallRealMethod().when(storeIngestionTask).resubscribeForAllPartitions();
+    Map<Integer, PartitionConsumptionState> partitionConsumptionStateMap = new HashMap<>();
+    doReturn(partitionConsumptionStateMap).when(storeIngestionTask).getPartitionConsumptionStateMap();
+
+    // pcs0: blob transfer in progress -- MUST be skipped.
+    PartitionConsumptionState pcsBlobInProgress = mock(PartitionConsumptionState.class);
+    doReturn(true).when(pcsBlobInProgress).isBlobTransferInProgress();
+    doReturn("store_v1-0").when(pcsBlobInProgress).getReplicaId();
+
+    // pcs1: no blob transfer, not complete -- should be resubscribed.
+    PartitionConsumptionState pcsNotComplete = mock(PartitionConsumptionState.class);
+    doReturn(false).when(pcsNotComplete).isBlobTransferInProgress();
+    doReturn(false).when(pcsNotComplete).isComplete();
+
+    // pcs2: no blob transfer, complete, not yet flipped -- should be resubscribed AND flipped.
+    PartitionConsumptionState pcsCompleteNotFlipped = mock(PartitionConsumptionState.class);
+    doReturn(false).when(pcsCompleteNotFlipped).isBlobTransferInProgress();
+    doReturn(true).when(pcsCompleteNotFlipped).isComplete();
+    doReturn(false).when(pcsCompleteNotFlipped).hasResubscribedAfterBootstrapAsCurrentVersion();
+
+    partitionConsumptionStateMap.put(0, pcsBlobInProgress);
+    partitionConsumptionStateMap.put(1, pcsNotComplete);
+    partitionConsumptionStateMap.put(2, pcsCompleteNotFlipped);
+
+    doReturn(true).when(storeIngestionTask).isCurrentVersion();
+
+    storeIngestionTask.resubscribeForAllPartitions();
+
+    // Blob-transfer-in-progress partition is skipped entirely.
+    verify(storeIngestionTask, never()).resubscribe(pcsBlobInProgress);
+    verify(pcsBlobInProgress, never()).setHasResubscribedAfterBootstrapAsCurrentVersion(anyBoolean());
+
+    // Other partitions are resubscribed as usual.
+    verify(storeIngestionTask, times(1)).resubscribe(pcsNotComplete);
+    verify(storeIngestionTask, times(1)).resubscribe(pcsCompleteNotFlipped);
+    verify(pcsCompleteNotFlipped, times(1)).setHasResubscribedAfterBootstrapAsCurrentVersion(eq(true));
+  }
+
   @Test(dataProvider = "aaConfigProvider")
   public void testWrappedInterruptExceptionDuringGracefulShutdown(AAConfig aaConfig) throws Exception {
     hybridStoreConfig = Optional.of(


### PR DESCRIPTION
 ## Summary                                                                                                                                                                                                                                                                                                            
                                                                                                                                                                                                                                                                                                                        
  - Adds `isBlobTransferInProgress()` guard in `StoreIngestionTask.resubscribeForAllPartitions()` so that a FUTURE→CURRENT (or any version-role) change does not unsubscribe + resubscribe a partition whose blob transfer is still in flight. Mirrors the `canSwitchToLeaderTopic()` gate that #2601 added for the     
  STANDBY→LEADER path.                                                                                                                                                                                                                                                                                                  
  - Switches the loop in `resubscribeForAllPartitions()` to use `getPartitionConsumptionStateMap()` for consistency with the sibling `resubscribeForCompletedCurrentVersionPartition()` and to enable mock-based unit testing.                                                                                          
  - Adds `testResubscribeForAllPartitionsSkipsBlobTransferInProgress` to validate the guard.                                                                                                                                                                                                                            
                                                                                                                                                                                                                                                                                                                        
  ## Problem                                                                                                                                                                                                                                                                                                            
                                                                                                                                                                                                                                                                                                                        
  #2601 moved blob transfer orchestration into the SIT thread with async completion and added `canSwitchToLeaderTopic()` to block STANDBY→LEADER promotion during a blob transfer. It did not add a similar gate to the version-role-change resubscribe path (`resubscribeForAllPartitions`, introduced in #1034).      
   
  On a straggler replica, when the version becomes CURRENT cluster-wide while its local blob transfer is still receiving files, `resubscribeForAllPartitions` calls `resubscribeAsFollower` → `unsubscribeFromTopic` + `consumerSubscribe(...EARLIEST)`. Processing `START_OF_PUSH` on the resubscribed consumer calls  
  `AbstractStorageEngine.reopenDatabase`, which opens RocksDB on the **final partition directory** while blob transfer is still streaming SSTs into the **temp** directory. The post-transfer rename then fails:
                                                                                                                                                                                                                                                                                                                        
  ```                                                       
  VeniceException: Final partition directory is not empty:
    /mnt/u001/venice/data/rocksdb/<store>/<store>_<partition>,                                                                                                                                                                                                                                                          
    cannot rename temp directory: temp_transferred_<store>_<partition>                                                                                                                                                                                                                                                  
      at RocksDBUtils.renameTempTransferredPartitionDirToPartitionDir:170                                                                                                                                                                                                                                               
      at P2PFileTransferClientHandler.handleEndOfTransfer:325                                                                                                                                                                                                                                                           
  ```                                                                                                                                                                                                                                                                                                                   
                                                                                                                                                                                                                                                                                                                        
  The fallback path (`completeBlobTransferAndSubscribe` → `adjustStoragePartitionWhenBlobTransferComplete`) also fails because the RocksDB handle is already held by the parallel Kafka ingestion — which drives the replica to Helix ERROR.                                                                            
                                                            
  ## Evidence                                                                                                                                                                                                                                                                                                           
                                                            
  Observed on host for `cert-write-compute_v1303` on 2026-04-22. 7 partitions (18, 29, 42, 57, 58, 82, 92) on this one host transitioned to Helix ERROR. Other replicas on other hosts (the non-stragglers) were fine and drove the push to SUCCESS, which is why v1303 was promoted to CURRENT cluster-wide despite these local stragglers.      
                                                                                                                                                                                                                                                                                                                        
  Key log sequence for partition 92:                                                                                                                                                                                                                                                                                    
   
  | Time (UTC) | Thread | Event |                                                                                                                                                                                                                                                                                       
  |---|---|---|                                             
  | 22:41:43.996 | `venice-SIT` | `Dropped existing partition 92 before blob transfer` + `Skip initializing and opening RocksDB` |                                                                                                                                                                                      
  | 22:41:44.043 | `nioEventLoopGroup-8-41` | Blob transfer begins streaming SSTs into temp dir |                                                                                                                                                                                                                       
  | 22:42:21.454 | `venice-SIT` | `STANDBY_TO_LEADER` consumer action dequeued, **finishes in 0ms** (existing `canSwitchToLeaderTopic` gate from #2601 correctly blocked leader promotion) |                                                                                                                            
  | **22:42:40.405** | `venice-SIT` | **`Trigger for version topic cert-write-compute_v1303: FUTURE -> CURRENT, AA_OR_WRITE_COMPUTE`** — no blob-transfer guard on this path |                                                                                                                                          
  | 22:42:40.598 | `venice-shared-consumer-t30` | `Opening RocksDB database: .../cert-write-compute_v1303_92` on the final partition dir, mid-transfer |                                                                                                                                                                
  | 22:42:45.029 | `nioEventLoopGroup-8-41` | `Failed to rename temp partition dir to partition dir ... Final partition directory is not empty` |                                                                                                                                                                       
  | 22:42:46.054 | `venice-SIT` | `Marking current version replica status to ERROR for replica: cert-write-compute_v1303-92` |                                                                                                                                                                                          
                                                                       
## Solution
 `completeBlobTransferAndSubscribe` runs later on the SIT thread with the **already-updated** `versionRole`/`workloadType` (since `processStoreVersionRoleChange` mutates those fields *before* calling `resubscribeForAllPartitions`), so the deferred partitions land in the correct consumer pool when their        
  transfer finishes — no extra deferred-resubscribe bookkeeping required.


###  Code changes
- [ ] Added new code behind **a config**. If so list the config names and their default values in the PR description.
- [ ] Introduced new **log lines**. 
  - [ ] Confirmed if logs need to be **rate limited** to avoid excessive logging.

###  **Concurrency-Specific Checks**
Both reviewer and PR author to verify
- [ ] Code has **no race conditions** or **thread safety issues**.
- [ ] Proper **synchronization mechanisms** (e.g., `synchronized`, `RWLock`) are used where needed.
- [ ] No **blocking calls** inside critical sections that could lead to deadlocks or performance degradation.
- [ ] Verified **thread-safe collections** are used (e.g., `ConcurrentHashMap`, `CopyOnWriteArrayList`).
- [ ] Validated proper exception handling in multi-threaded code to avoid silent thread termination.


## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->

- [ ] New unit tests added.
- [ ] New integration tests added.
- [ ] Modified or extended existing tests.
- [ ] Verified backward compatibility (if applicable).

## Does this PR introduce any user-facing or breaking changes?
<!--  
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [ ] No. You can skip the rest of this section.
- [ ] Yes. Clearly explain the behavior change and its impact.