### PR TITLE
[vpj] counting records produced per partition as part of push and adding it to the EOP message

### DIFF
--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/VenicePushJob.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/VenicePushJob.java
@@ -917,10 +917,18 @@ public class VenicePushJob implements AutoCloseable {
         runJobWithKillDetection();
 
         if (!pushJobSetting.suppressEndOfPushMessage) {
+          Map<Integer, Long> partitionRecordCounts = getPerPartitionRecordCounts();
           if (pushJobSetting.sendControlMessagesDirectly) {
-            getVeniceWriter(pushJobSetting).broadcastEndOfPush(Collections.emptyMap());
+            getVeniceWriter(pushJobSetting).broadcastEndOfPush(Collections.emptyMap(), partitionRecordCounts);
           } else {
-            controllerClient.writeEndOfPush(pushJobSetting.storeName, pushJobSetting.version);
+            ControllerResponse eopResponse = controllerClient
+                .writeEndOfPush(pushJobSetting.storeName, pushJobSetting.version, partitionRecordCounts);
+            if (eopResponse.isError()) {
+              throw new VeniceException(
+                  "Failed to write End-of-Push for topic: "
+                      + Version.composeKafkaTopic(pushJobSetting.storeName, pushJobSetting.version) + ": "
+                      + eopResponse.getError());
+            }
           }
         }
       }
@@ -1750,6 +1758,15 @@ public class VenicePushJob implements AutoCloseable {
   @VisibleForTesting
   void updatePushJobDetailsWithCheckpoint(PushJobCheckpoints checkpoint) {
     pushJobDetails.pushJobLatestCheckpoint = checkpoint.getValue();
+  }
+
+  private Map<Integer, Long> getPerPartitionRecordCounts() {
+    String topicName = Version.composeKafkaTopic(pushJobSetting.storeName, pushJobSetting.version);
+    if (dataWriterComputeJob == null || dataWriterComputeJob.getTaskTracker() == null) {
+      LOGGER.warn("Cannot retrieve per-partition record counts for topic: {}: no task tracker available", topicName);
+      return Collections.emptyMap();
+    }
+    return dataWriterComputeJob.getTaskTracker().getPerPartitionRecordCounts();
   }
 
   private void updatePushJobDetailsWithDataWriterTracker() {

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/task/datawriter/AbstractPartitionWriter.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/task/datawriter/AbstractPartitionWriter.java
@@ -267,6 +267,11 @@ public abstract class AbstractPartitionWriter extends AbstractDataWriterTask imp
    * This doesn't need to be atomic since {@link #processValuesForKey(byte[], Iterator, DataWriterTaskTracker)} will be called sequentially.
    */
   private long messageSent = 0;
+
+  protected long getMessageSent() {
+    return messageSent;
+  }
+
   private final AtomicLong messageCompleted = new AtomicLong();
   private final AtomicLong messageErrored = new AtomicLong();
   private long timeOfLastReduceFunctionEndInNS = 0;

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/task/datawriter/DataWriterTaskTracker.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/task/datawriter/DataWriterTaskTracker.java
@@ -1,6 +1,8 @@
 package com.linkedin.venice.hadoop.task.datawriter;
 
 import com.linkedin.venice.hadoop.task.TaskTracker;
+import java.util.Collections;
+import java.util.Map;
 
 
 /**
@@ -131,5 +133,15 @@ public interface DataWriterTaskTracker extends TaskTracker {
 
   default long getIncrementalPushThrottledTimeMs() {
     return 0;
+  }
+
+  /**
+   * Returns per-partition record counts collected during the data writer job.
+   * For the Spark path, these are collected via {@code collect()} on the DAG output
+   *
+   * @return Map of partition ID to record count, or empty map if not available.
+   */
+  default Map<Integer, Long> getPerPartitionRecordCounts() {
+    return Collections.emptyMap();
   }
 }

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/spark/SparkConstants.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/spark/SparkConstants.java
@@ -18,6 +18,7 @@ public class SparkConstants {
 
   // Internal column names, hence begins with "_"
   public static final String PARTITION_COLUMN_NAME = "__partition__";
+  public static final String RECORD_COUNT_COLUMN_NAME = "__record_count__";
   public static final String SCHEMA_ID_COLUMN_NAME = "__schema_id__";
   public static final String RMD_VERSION_ID_COLUMN_NAME = "__replication_metadata_version_id__";
   public static final String OFFSET_COLUMN_NAME = "__offset__";
@@ -28,6 +29,10 @@ public class SparkConstants {
       new StructField[] { new StructField(KEY_COLUMN_NAME, BinaryType, false, Metadata.empty()),
           new StructField(VALUE_COLUMN_NAME, BinaryType, true, Metadata.empty()),
           new StructField(RMD_COLUMN_NAME, BinaryType, true, Metadata.empty()) });
+
+  public static final StructType PARTITION_RECORD_COUNT_SCHEMA = new StructType(
+      new StructField[] { new StructField(PARTITION_COLUMN_NAME, IntegerType, false, Metadata.empty()),
+          new StructField(RECORD_COUNT_COLUMN_NAME, LongType, false, Metadata.empty()) });
 
   public static final StructType DEFAULT_SCHEMA_WITH_PARTITION = new StructType(
       new StructField[] { new StructField(KEY_COLUMN_NAME, BinaryType, false, Metadata.empty()),

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/spark/datawriter/jobs/AbstractDataWriterSparkJob.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/spark/datawriter/jobs/AbstractDataWriterSparkJob.java
@@ -20,6 +20,7 @@ import static com.linkedin.venice.spark.SparkConstants.MESSAGE_TYPE_COLUMN_NAME;
 import static com.linkedin.venice.spark.SparkConstants.OFFSET;
 import static com.linkedin.venice.spark.SparkConstants.OFFSET_COLUMN_NAME;
 import static com.linkedin.venice.spark.SparkConstants.PARTITION_COLUMN_NAME;
+import static com.linkedin.venice.spark.SparkConstants.PARTITION_RECORD_COUNT_SCHEMA;
 import static com.linkedin.venice.spark.SparkConstants.RAW_PUBSUB_INPUT_TABLE_SCHEMA;
 import static com.linkedin.venice.spark.SparkConstants.REPLICATION_METADATA_PAYLOAD;
 import static com.linkedin.venice.spark.SparkConstants.RMD_COLUMN_NAME;
@@ -113,9 +114,11 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Comparator;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Properties;
 import java.util.Set;
@@ -844,7 +847,7 @@ public abstract class AbstractDataWriterSparkJob extends DataWriterComputeJob {
     validateRmdSchema(pushJobSetting);
 
     ExpressionEncoder<Row> rowEncoder = RowEncoder.apply(DEFAULT_SCHEMA);
-    ExpressionEncoder<Row> rowEncoderWithPartition = RowEncoder.apply(DEFAULT_SCHEMA_WITH_PARTITION);
+    ExpressionEncoder<Row> partitionRecordCountEncoder = RowEncoder.apply(PARTITION_RECORD_COUNT_SCHEMA);
     int numOutputPartitions = pushJobSetting.partitionCount;
 
     Properties jobProps = new Properties();
@@ -913,11 +916,30 @@ public abstract class AbstractDataWriterSparkJob extends DataWriterComputeJob {
         } finally {
           kafkaWriteMetrics.timeNs.add(System.nanoTime() - startNs);
         }
-      }, rowEncoderWithPartition);
+      }, partitionRecordCountEncoder);
 
-      // For VPJ, we don't care about the output from the DAG. ".count()" is an action that will trigger execution of
-      // the DAG to completion and will not copy all the rows to the driver to be more memory efficient.
-      dataFrame.count();
+      /*
+       * collect() returns exactly one (partitionId, recordCount) row per Spark partition. With
+       * speculative execution, if the original task and a speculative attempt both finish at the
+       * same time, Spark's TaskScheduler accepts the result from whichever one successfully
+       * communicates completion first and immediately kills the other; the duplicate's work is
+       * discarded to prevent duplicate data processing. So no two rows in the collected list will
+       * ever share the same partition id, and we can populate the map directly via put().
+       *
+       * The collected data volume is bounded by numPartitions (e.g. 10K partitions = ~160KB) so
+       * collectAsList() is safe.
+       */
+      String topicName = pushJobSetting.topic;
+      List<Row> partitionCountRows = dataFrame.collectAsList();
+      Map<Integer, Long> perPartitionRecordCounts = new HashMap<>(partitionCountRows.size());
+      for (Row row: partitionCountRows) {
+        perPartitionRecordCounts.put(row.getInt(0), row.getLong(1));
+      }
+      taskTracker.setPerPartitionRecordCounts(perPartitionRecordCounts);
+      LOGGER.info(
+          "Collected per-partition record counts for topic: {} ({} partitions)",
+          topicName,
+          perPartitionRecordCounts.size());
     } finally {
       // No matter what, always log the final accumulator values
       logAccumulatorValues();

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/spark/datawriter/task/SparkDataWriterTaskTracker.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/spark/datawriter/task/SparkDataWriterTaskTracker.java
@@ -1,6 +1,9 @@
 package com.linkedin.venice.spark.datawriter.task;
 
 import com.linkedin.venice.hadoop.task.datawriter.DataWriterTaskTracker;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
 
 
 /**
@@ -8,6 +11,7 @@ import com.linkedin.venice.hadoop.task.datawriter.DataWriterTaskTracker;
  */
 public class SparkDataWriterTaskTracker implements DataWriterTaskTracker {
   private final DataWriterAccumulators accumulators;
+  private Map<Integer, Long> perPartitionRecordCounts = Collections.emptyMap();
 
   public SparkDataWriterTaskTracker(DataWriterAccumulators accumulators) {
     this.accumulators = accumulators;
@@ -171,5 +175,19 @@ public class SparkDataWriterTaskTracker implements DataWriterTaskTracker {
   @Override
   public long getIncrementalPushThrottledTimeMs() {
     return accumulators.incrementalPushThrottleTimeCounter.value();
+  }
+
+  /**
+   * Sets the per-partition record counts collected from the Spark DAG output via {@code collect()}.
+   */
+  public void setPerPartitionRecordCounts(Map<Integer, Long> counts) {
+    this.perPartitionRecordCounts = (counts == null || counts.isEmpty())
+        ? Collections.emptyMap()
+        : Collections.unmodifiableMap(new HashMap<>(counts));
+  }
+
+  @Override
+  public Map<Integer, Long> getPerPartitionRecordCounts() {
+    return perPartitionRecordCounts;
   }
 }

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/spark/datawriter/writer/SparkPartitionWriter.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/spark/datawriter/writer/SparkPartitionWriter.java
@@ -85,4 +85,11 @@ public class SparkPartitionWriter extends AbstractPartitionWriter {
       super.processValuesForKey(key, valueRecordsForKey.iterator(), dataWriterTaskTracker);
     }
   }
+
+  /**
+   * @return The number of records sent to PubSub by this partition writer.
+   */
+  long getRecordCount() {
+    return getMessageSent();
+  }
 }

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/spark/datawriter/writer/SparkPartitionWriterFactory.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/spark/datawriter/writer/SparkPartitionWriterFactory.java
@@ -1,11 +1,14 @@
 package com.linkedin.venice.spark.datawriter.writer;
 
 import com.linkedin.venice.spark.datawriter.task.DataWriterAccumulators;
+import java.util.Collections;
 import java.util.Iterator;
 import java.util.Properties;
+import org.apache.spark.TaskContext;
 import org.apache.spark.api.java.function.MapPartitionsFunction;
 import org.apache.spark.broadcast.Broadcast;
 import org.apache.spark.sql.Row;
+import org.apache.spark.sql.RowFactory;
 
 
 public class SparkPartitionWriterFactory implements MapPartitionsFunction<Row, Row> {
@@ -20,9 +23,12 @@ public class SparkPartitionWriterFactory implements MapPartitionsFunction<Row, R
 
   @Override
   public Iterator<Row> call(Iterator<Row> rows) throws Exception {
+    long recordCount;
     try (SparkPartitionWriter partitionWriter = new SparkPartitionWriter(jobProps.getValue(), accumulators)) {
       partitionWriter.processRows(rows);
+      recordCount = partitionWriter.getRecordCount();
     }
-    return rows;
+    int partitionId = TaskContext.get().partitionId();
+    return Collections.singletonList(RowFactory.create(partitionId, recordCount)).iterator();
   }
 }

--- a/clients/venice-push-job/src/test/java/com/linkedin/venice/hadoop/TestVenicePushJobCheckpoints.java
+++ b/clients/venice-push-job/src/test/java/com/linkedin/venice/hadoop/TestVenicePushJobCheckpoints.java
@@ -746,6 +746,8 @@ public class TestVenicePushJobCheckpoints {
     ControllerResponse controllerResponse = mock(ControllerResponse.class);
     when(controllerResponse.isError()).thenReturn(false);
     when(controllerClient.sendPushJobDetails(anyString(), anyInt(), any(byte[].class))).thenReturn(controllerResponse);
+    when(controllerClient.writeEndOfPush(anyString(), anyInt())).thenReturn(controllerResponse);
+    when(controllerClient.writeEndOfPush(anyString(), anyInt(), any())).thenReturn(controllerResponse);
   }
 
   private void configureClusterDiscoverControllerClient(ControllerClient controllerClient) {

--- a/clients/venice-push-job/src/test/java/com/linkedin/venice/hadoop/VenicePushJobTest.java
+++ b/clients/venice-push-job/src/test/java/com/linkedin/venice/hadoop/VenicePushJobTest.java
@@ -809,6 +809,7 @@ public class VenicePushJobTest {
 
     ControllerResponse response = new ControllerResponse();
     doReturn(response).when(client).writeEndOfPush(anyString(), anyInt());
+    doReturn(response).when(client).writeEndOfPush(anyString(), anyInt(), any());
     doReturn(response).when(client).sendPushJobDetails(anyString(), anyInt(), any(byte[].class));
     return client;
   }

--- a/clients/venice-push-job/src/test/java/com/linkedin/venice/spark/datawriter/task/SparkDataWriterTaskTrackerTest.java
+++ b/clients/venice-push-job/src/test/java/com/linkedin/venice/spark/datawriter/task/SparkDataWriterTaskTrackerTest.java
@@ -1,6 +1,8 @@
 package com.linkedin.venice.spark.datawriter.task;
 
 import com.linkedin.venice.spark.SparkConstants;
+import java.util.HashMap;
+import java.util.Map;
 import org.apache.spark.sql.SparkSession;
 import org.testng.Assert;
 import org.testng.annotations.AfterClass;
@@ -239,6 +241,45 @@ public class SparkDataWriterTaskTrackerTest {
     expectedAccumulators.partitionWriterCloseCounter.add(2);
 
     verifyAllAccumulators(accumulators, expectedAccumulators);
+  }
+
+  @Test
+  public void testPerPartitionRecordCountsDefaultEmpty() {
+    DataWriterAccumulators accumulators = new DataWriterAccumulators(spark);
+    SparkDataWriterTaskTracker tracker = new SparkDataWriterTaskTracker(accumulators);
+
+    Assert.assertTrue(tracker.getPerPartitionRecordCounts().isEmpty());
+  }
+
+  @Test
+  public void testSetAndGetPerPartitionRecordCounts() {
+    DataWriterAccumulators accumulators = new DataWriterAccumulators(spark);
+    SparkDataWriterTaskTracker tracker = new SparkDataWriterTaskTracker(accumulators);
+
+    Map<Integer, Long> counts = new HashMap<>();
+    counts.put(0, 100L);
+    counts.put(1, 200L);
+    counts.put(2, 50L);
+
+    tracker.setPerPartitionRecordCounts(counts);
+
+    Map<Integer, Long> result = tracker.getPerPartitionRecordCounts();
+    Assert.assertEquals(result.size(), 3);
+    Assert.assertEquals((long) result.get(0), 100L);
+    Assert.assertEquals((long) result.get(1), 200L);
+    Assert.assertEquals((long) result.get(2), 50L);
+  }
+
+  @Test(expectedExceptions = UnsupportedOperationException.class)
+  public void testPerPartitionRecordCountsIsUnmodifiable() {
+    DataWriterAccumulators accumulators = new DataWriterAccumulators(spark);
+    SparkDataWriterTaskTracker tracker = new SparkDataWriterTaskTracker(accumulators);
+
+    Map<Integer, Long> counts = new HashMap<>();
+    counts.put(0, 100L);
+    tracker.setPerPartitionRecordCounts(counts);
+
+    tracker.getPerPartitionRecordCounts().put(1, 200L);
   }
 
   // Verify values of all accumulators to ensure that they don't get updated through side effects

--- a/internal/venice-common/src/main/java/com/linkedin/venice/controllerapi/ControllerApiConstants.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/controllerapi/ControllerApiConstants.java
@@ -52,6 +52,7 @@ public class ControllerApiConstants {
   public static final String READ_OPERATION = "read";
   public static final String WRITE_OPERATION = "write";
   public static final String READ_WRITE_OPERATION = READ_OPERATION + WRITE_OPERATION;
+  public static final String PARTITION_RECORD_COUNTS = "partition_record_counts";
   public static final String EXECUTION_ID = "execution_id";
   public static final String ENABLE_READS = "enable_reads";
   public static final String ENABLE_WRITES = "enable_writes";

--- a/internal/venice-common/src/main/java/com/linkedin/venice/controllerapi/ControllerClient.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/controllerapi/ControllerClient.java
@@ -39,6 +39,7 @@ import static com.linkedin.venice.controllerapi.ControllerApiConstants.OWNER;
 import static com.linkedin.venice.controllerapi.ControllerApiConstants.PARTITIONERS;
 import static com.linkedin.venice.controllerapi.ControllerApiConstants.PARTITION_COUNT;
 import static com.linkedin.venice.controllerapi.ControllerApiConstants.PARTITION_DETAIL_ENABLED;
+import static com.linkedin.venice.controllerapi.ControllerApiConstants.PARTITION_RECORD_COUNTS;
 import static com.linkedin.venice.controllerapi.ControllerApiConstants.PERSONA_NAME;
 import static com.linkedin.venice.controllerapi.ControllerApiConstants.PERSONA_OWNERS;
 import static com.linkedin.venice.controllerapi.ControllerApiConstants.PERSONA_QUOTA;
@@ -472,6 +473,21 @@ public class ControllerClient implements Closeable {
 
   public ControllerResponse writeEndOfPush(String storeName, int version) {
     QueryParams params = newParams().add(NAME, storeName).add(VERSION, version);
+    return request(ControllerRoute.END_OF_PUSH, params, ControllerResponse.class);
+  }
+
+  public ControllerResponse writeEndOfPush(String storeName, int version, Map<Integer, Long> partitionRecordCounts) {
+    QueryParams params = newParams().add(NAME, storeName).add(VERSION, version);
+    if (partitionRecordCounts != null && !partitionRecordCounts.isEmpty()) {
+      try {
+        params
+            .add(PARTITION_RECORD_COUNTS, ObjectMapperFactory.getInstance().writeValueAsString(partitionRecordCounts));
+      } catch (JsonProcessingException e) {
+        throw new VeniceException(
+            "Failed to serialize partitionRecordCounts for store " + storeName + " version " + version,
+            e);
+      }
+    }
     return request(ControllerRoute.END_OF_PUSH, params, ControllerResponse.class);
   }
 

--- a/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/api/PubSubMessageHeaders.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/api/PubSubMessageHeaders.java
@@ -33,6 +33,12 @@ public class PubSubMessageHeaders implements Measurable, Iterable<PubSubMessageH
    * further processing. In the example, this chunk should be sent to view1's partition 0 and view2's partitions 1 & 2.
    */
   public static final String VENICE_VIEW_PARTITIONS_MAP_HEADER = "vpm";
+  /**
+   * Header carrying per-partition record count on End-of-Push control messages.
+   * Value is an 8-byte big-endian encoded long representing the number of records
+   * written to that partition. Used for server-side batch push verification.
+   */
+  public static final String VENICE_PARTITION_RECORD_COUNT_HEADER = "prc";
 
   public PubSubMessageHeaders add(PubSubMessageHeader header) {
     headers.put(header.key(), header);

--- a/internal/venice-common/src/main/java/com/linkedin/venice/writer/VeniceWriter.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/writer/VeniceWriter.java
@@ -1500,6 +1500,76 @@ public class VeniceWriter<K, V, U> extends AbstractVeniceWriter<K, V, U> {
     endAllSegments(true);
   }
 
+  /**
+   * Broadcast End-of-Push control messages with per-partition record counts embedded as PubSub headers.
+   * Each partition's EOP message carries a {@link PubSubMessageHeaders#VENICE_PARTITION_RECORD_COUNT_HEADER}
+   * header containing the 8-byte big-endian encoded record count for that partition.
+   * Partitions not present in the map receive a standard EOP without the header.
+   *
+   * @param debugInfo arbitrary key/value pairs of information propagated alongside the control message.
+   * @param partitionRecordCounts map of partition ID to record count, or null to skip embedding counts.
+   */
+  public void broadcastEndOfPush(Map<String, String> debugInfo, Map<Integer, Long> partitionRecordCounts) {
+    if (partitionRecordCounts == null || partitionRecordCounts.isEmpty()) {
+      broadcastEndOfPush(debugInfo);
+      return;
+    }
+    if (partitionRecordCounts.size() < numberOfPartitions) {
+      logger.warn(
+          "partitionRecordCounts covers {}/{} partitions for topic: {}; "
+              + "partitions without a count will receive an EOP without the prc header",
+          partitionRecordCounts.size(),
+          numberOfPartitions,
+          topicName);
+    }
+    /*
+     * Validate that all keys in partitionRecordCounts fall in [0, numberOfPartitions). Out-of-range
+     * keys are silently dropped by the per-partition lookup below, but logging them up front makes
+     * partition-count mismatches (e.g. amplification-factor changes, bad client input) detectable
+     * without consuming the topic.
+     */
+    for (Integer partitionId: partitionRecordCounts.keySet()) {
+      if (partitionId == null || partitionId < 0 || partitionId >= numberOfPartitions) {
+        logger.warn(
+            "partitionRecordCounts for topic: {} contains out-of-range partition id: {} (valid range: [0, {})); "
+                + "this entry will be ignored",
+            topicName,
+            partitionId,
+            numberOfPartitions);
+      }
+    }
+    /*
+     * The same ControlMessage instance is reused across all per-partition sends below. This is
+     * safe today because sendControlMessage serializes synchronously on the calling thread before
+     * returning, so no partition ever observes a mutated CM. If sendControlMessage ever captures
+     * the CM reference asynchronously (e.g. retry handler or async produce callback), this loop
+     * must construct a fresh ControlMessage per partition instead.
+     */
+    ControlMessage controlMessage = getEmptyControlMessage(ControlMessageType.END_OF_PUSH);
+    for (int partition = 0; partition < numberOfPartitions; partition++) {
+      sendControlMessage(
+          controlMessage,
+          partition,
+          debugInfo,
+          null,
+          DEFAULT_LEADER_METADATA_WRAPPER,
+          buildPartitionRecordCountHeaders(partitionRecordCounts.get(partition)));
+    }
+    logger.info(
+        "Successfully broadcast END_OF_PUSH Control Message with per-partition record counts for topic: {}",
+        topicName);
+    endAllSegments(true);
+  }
+
+  private static PubSubMessageHeaders buildPartitionRecordCountHeaders(Long recordCount) {
+    PubSubMessageHeaders headers = new PubSubMessageHeaders();
+    if (recordCount != null) {
+      byte[] countBytes = ByteBuffer.allocate(Long.BYTES).putLong(recordCount).array();
+      headers.add(PubSubMessageHeaders.VENICE_PARTITION_RECORD_COUNT_HEADER, countBytes);
+    }
+    return headers;
+  }
+
   public void broadcastTopicSwitch(
       @Nonnull List<CharSequence> sourceKafkaCluster,
       @Nonnull String sourceTopicName,
@@ -2299,6 +2369,22 @@ public class VeniceWriter<K, V, U> extends AbstractVeniceWriter<K, V, U> {
       Map<String, String> debugInfo,
       PubSubProducerCallback callback,
       LeaderMetadataWrapper leaderMetadataWrapper) {
+    return sendControlMessage(
+        controlMessage,
+        partition,
+        debugInfo,
+        callback,
+        leaderMetadataWrapper,
+        EmptyPubSubMessageHeaders.SINGLETON);
+  }
+
+  public CompletableFuture<PubSubProduceResult> sendControlMessage(
+      ControlMessage controlMessage,
+      int partition,
+      Map<String, String> debugInfo,
+      PubSubProducerCallback callback,
+      LeaderMetadataWrapper leaderMetadataWrapper,
+      PubSubMessageHeaders pubSubMessageHeaders) {
     // Work around until we upgrade to a more modern Avro version which supports overriding the
     // String implementation.
     controlMessage.debugInfo = getDebugInfo(debugInfo);
@@ -2314,7 +2400,7 @@ public class VeniceWriter<K, V, U> extends AbstractVeniceWriter<K, V, U> {
           true,
           leaderMetadataWrapper,
           VENICE_DEFAULT_LOGICAL_TS,
-          EmptyPubSubMessageHeaders.SINGLETON);
+          pubSubMessageHeaders);
     }
   }
 

--- a/internal/venice-common/src/test/java/com/linkedin/venice/writer/VeniceWriterUnitTest.java
+++ b/internal/venice-common/src/test/java/com/linkedin/venice/writer/VeniceWriterUnitTest.java
@@ -78,7 +78,10 @@ import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Properties;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
@@ -1523,5 +1526,113 @@ public class VeniceWriterUnitTest {
       // expected
     }
     verify(mockHook, never()).onBeforeProduce(any(VeniceWriterHook.OperationType.class), anyInt(), anyInt());
+  }
+
+  @Test
+  public void testBroadcastEndOfPushWithPartitionRecordCounts() {
+    int partitionCount = 4;
+    PubSubProducerAdapter mockedProducer = mock(PubSubProducerAdapter.class);
+    // Use completed futures so endAllSegments doesn't block
+    when(mockedProducer.sendMessage(any(), any(), any(), any(), any(), any()))
+        .thenReturn(CompletableFuture.completedFuture(null));
+
+    String stringSchema = "\"string\"";
+    VeniceKafkaSerializer serializer = new VeniceAvroKafkaSerializer(stringSchema);
+    VeniceWriterOptions veniceWriterOptions =
+        new VeniceWriterOptions.Builder("test_topic").setKeyPayloadSerializer(serializer)
+            .setValuePayloadSerializer(serializer)
+            .setPartitioner(new DefaultVenicePartitioner())
+            .setPartitionCount(partitionCount)
+            .build();
+    VeniceWriter<Object, Object, Object> writer =
+        new VeniceWriter(veniceWriterOptions, VeniceProperties.empty(), mockedProducer);
+
+    Map<Integer, Long> partitionRecordCounts = new HashMap<>();
+    partitionRecordCounts.put(0, 100L);
+    partitionRecordCounts.put(1, 200L);
+    partitionRecordCounts.put(2, 0L);
+    partitionRecordCounts.put(3, 50L);
+
+    writer.broadcastEndOfPush(Collections.emptyMap(), partitionRecordCounts);
+
+    // Capture all sendMessage calls: SOS (start of segment) + EOP + EOS (end of segment) per partition
+    ArgumentCaptor<Integer> partitionCaptor = ArgumentCaptor.forClass(Integer.class);
+    ArgumentCaptor<KafkaMessageEnvelope> kmeCaptor = ArgumentCaptor.forClass(KafkaMessageEnvelope.class);
+    ArgumentCaptor<PubSubMessageHeaders> headersCaptor = ArgumentCaptor.forClass(PubSubMessageHeaders.class);
+    verify(mockedProducer, atLeast(partitionCount)).sendMessage(
+        anyString(),
+        partitionCaptor.capture(),
+        any(),
+        kmeCaptor.capture(),
+        headersCaptor.capture(),
+        any());
+
+    // Find the EOP messages and verify prc headers
+    List<Integer> allPartitions = partitionCaptor.getAllValues();
+    List<KafkaMessageEnvelope> allKmes = kmeCaptor.getAllValues();
+    List<PubSubMessageHeaders> allHeaders = headersCaptor.getAllValues();
+
+    Map<Integer, Long> foundCounts = new HashMap<>();
+    for (int i = 0; i < allKmes.size(); i++) {
+      KafkaMessageEnvelope kme = allKmes.get(i);
+      if (kme.messageType == MessageType.CONTROL_MESSAGE.getValue()) {
+        ControlMessage cm = (ControlMessage) kme.payloadUnion;
+        if (cm.controlMessageType == ControlMessageType.END_OF_PUSH.getValue()) {
+          int partition = allPartitions.get(i);
+          PubSubMessageHeaders headers = allHeaders.get(i);
+          PubSubMessageHeader prcHeader = headers.get(PubSubMessageHeaders.VENICE_PARTITION_RECORD_COUNT_HEADER);
+          if (prcHeader != null) {
+            long count = java.nio.ByteBuffer.wrap(prcHeader.value()).getLong();
+            foundCounts.put(partition, count);
+          }
+        }
+      }
+    }
+
+    assertEquals(foundCounts.size(), partitionCount, "Should have prc header on all partitions with counts");
+    assertEquals((long) foundCounts.get(0), 100L);
+    assertEquals((long) foundCounts.get(1), 200L);
+    assertEquals((long) foundCounts.get(2), 0L);
+    assertEquals((long) foundCounts.get(3), 50L);
+  }
+
+  @Test
+  public void testBroadcastEndOfPushWithNoCountsFallsBackToOriginal() {
+    int partitionCount = 2;
+    PubSubProducerAdapter mockedProducer = mock(PubSubProducerAdapter.class);
+    when(mockedProducer.sendMessage(any(), any(), any(), any(), any(), any()))
+        .thenReturn(CompletableFuture.completedFuture(null));
+
+    String stringSchema = "\"string\"";
+    VeniceKafkaSerializer serializer = new VeniceAvroKafkaSerializer(stringSchema);
+    VeniceWriterOptions veniceWriterOptions =
+        new VeniceWriterOptions.Builder("test_topic").setKeyPayloadSerializer(serializer)
+            .setValuePayloadSerializer(serializer)
+            .setPartitioner(new DefaultVenicePartitioner())
+            .setPartitionCount(partitionCount)
+            .build();
+    VeniceWriter<Object, Object, Object> writer =
+        new VeniceWriter(veniceWriterOptions, VeniceProperties.empty(), mockedProducer);
+
+    // Null counts should fall back to the original broadcastEndOfPush (no prc headers)
+    writer.broadcastEndOfPush(Collections.emptyMap(), null);
+
+    ArgumentCaptor<PubSubMessageHeaders> headersCaptor = ArgumentCaptor.forClass(PubSubMessageHeaders.class);
+    ArgumentCaptor<KafkaMessageEnvelope> kmeCaptor = ArgumentCaptor.forClass(KafkaMessageEnvelope.class);
+    verify(mockedProducer, atLeast(partitionCount))
+        .sendMessage(anyString(), anyInt(), any(), kmeCaptor.capture(), headersCaptor.capture(), any());
+
+    // No EOP message should have a prc header
+    for (int i = 0; i < kmeCaptor.getAllValues().size(); i++) {
+      KafkaMessageEnvelope kme = kmeCaptor.getAllValues().get(i);
+      if (kme.messageType == MessageType.CONTROL_MESSAGE.getValue()) {
+        ControlMessage cm = (ControlMessage) kme.payloadUnion;
+        if (cm.controlMessageType == ControlMessageType.END_OF_PUSH.getValue()) {
+          PubSubMessageHeaders headers = headersCaptor.getAllValues().get(i);
+          PubSubMessageHeader prcHeader = headers.get(PubSubMessageHeaders.VENICE_PARTITION_RECORD_COUNT_HEADER);
+          Assert.assertNull(prcHeader, "No prc header expected when counts are null");
+        }
+      }
+    }
   }
 }

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/AbstractTestRepush.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/AbstractTestRepush.java
@@ -28,6 +28,8 @@ import com.linkedin.venice.utils.IntegrationTestPushUtils;
 import com.linkedin.venice.utils.TestUtils;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.util.Collection;
+import java.util.Map;
 import java.util.Properties;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
@@ -179,6 +181,24 @@ public abstract class AbstractTestRepush extends AbstractMultiRegionTest {
         rmdDataValidationFlow.accept(rmdWithValueSchemaId);
       });
     }
+  }
+
+  /**
+   * Verifies that EOP prc headers match the expected per-partition record distribution
+   * for the given keys. Reads from dc-0's broker.
+   */
+  protected void verifyEopPartitionRecordCounts(
+      String storeName,
+      int version,
+      int partitionCount,
+      Collection<String> keys) {
+    Map<Integer, Long> actualCounts = IntegrationTestPushUtils.getEopPartitionRecordCounts(
+        childDatacenters.get(0).getClusters().get(CLUSTER_NAME).getPubSubBrokerWrapper(),
+        storeName,
+        version,
+        partitionCount);
+
+    IntegrationTestPushUtils.verifyPerPartitionCounts(actualCounts, keys, "\"string\"", partitionCount);
   }
 
   protected byte[] serializeStringKeyToByteArray(String key) {

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestBatch.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestBatch.java
@@ -64,6 +64,7 @@ import com.linkedin.venice.integration.utils.VeniceRouterWrapper;
 import com.linkedin.venice.jobs.StageMetricsSnapshot;
 import com.linkedin.venice.jobs.StageMetricsSnapshot.StageSummary;
 import com.linkedin.venice.meta.BackupStrategy;
+import com.linkedin.venice.meta.StoreInfo;
 import com.linkedin.venice.meta.Version;
 import com.linkedin.venice.read.RequestType;
 import com.linkedin.venice.spark.datawriter.jobs.DataWriterSparkJob;
@@ -695,19 +696,25 @@ public abstract class TestBatch {
 
   @Test(timeOut = TEST_TIMEOUT, dataProvider = "True-and-False", dataProviderClass = DataProviderUtils.class)
   public void testKafkaInputBatchJobWithZstdCompression(boolean sendDirectControlMessage) throws Exception {
+    int numRecords = 100;
     VPJValidator validator = (avroClient, vsonClient, metricsRepository) -> {
       // test single get
-      for (int i = 1; i <= 100; i++) {
+      for (int i = 1; i <= numRecords; i++) {
         Assert.assertEquals(avroClient.get(Integer.toString(i)).get().toString(), "test_name_" + i);
       }
     };
-    testBatchStore(
+    String storeName = testBatchStore(
         inputDir -> new KeyAndValueSchemas(writeSimpleAvroFileWithStringToStringSchema(inputDir)),
         properties -> {
           properties.setProperty(SEND_CONTROL_MESSAGES_DIRECTLY, String.valueOf(sendDirectControlMessage));
         },
         validator,
         new UpdateStoreQueryParams().setCompressionStrategy(CompressionStrategy.ZSTD_WITH_DICT));
+
+    if (sendDirectControlMessage) {
+      // Verify EOP messages carry per-partition record count headers
+      verifyEopPartitionRecordCounts(storeName, numRecords);
+    }
   }
 
   @Test(timeOut = TEST_TIMEOUT)
@@ -992,6 +999,29 @@ public abstract class TestBatch {
     }
 
     return storeName;
+  }
+
+  /**
+   * Verifies that EOP prc headers match the expected per-partition record distribution
+   */
+  private void verifyEopPartitionRecordCounts(String storeName, int numRecords) {
+    List<String> keys = new java.util.ArrayList<>(numRecords);
+    for (int i = 1; i <= numRecords; i++) {
+      keys.add(Integer.toString(i));
+    }
+    veniceCluster.useControllerClient(controllerClient -> {
+      StoreInfo storeInfo = controllerClient.getStore(storeName).getStore();
+      int currentVersion = storeInfo.getCurrentVersion();
+      int partitionCount = storeInfo.getVersion(currentVersion).get().getPartitionCount();
+
+      Map<Integer, Long> actualCounts = IntegrationTestPushUtils.getEopPartitionRecordCounts(
+          veniceCluster.getPubSubBrokerWrapper(),
+          storeName,
+          currentVersion,
+          partitionCount);
+
+      IntegrationTestPushUtils.verifyPerPartitionCounts(actualCounts, keys, "\"string\"", partitionCount);
+    });
   }
 
   interface InputFileWriter {

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestRepushDiagnostics.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestRepushDiagnostics.java
@@ -44,6 +44,8 @@ import com.linkedin.venice.utils.TestUtils;
 import com.linkedin.venice.utils.Utils;
 import com.linkedin.venice.writer.update.UpdateBuilderImpl;
 import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Properties;
 import java.util.concurrent.TimeUnit;
 import org.apache.avro.Schema;
@@ -85,8 +87,20 @@ public class TestRepushDiagnostics extends AbstractTestRepush {
     }
     waitForVersion(storeName, 1);
 
+    // Build key collection for per-partition verification
+    List<String> keys = new ArrayList<>(100);
+    for (int i = 1; i <= 100; i++) {
+      keys.add(Integer.toString(i));
+    }
+
+    // Verify EOP on the initial batch push has per-partition record counts
+    verifyEopPartitionRecordCounts(storeName, 1, 2, keys);
+
     // Repush twice: combiner=true then combiner=false
+    int repushVersion = 1;
     for (String combiner: new String[] { "true", "false" }) {
+      repushVersion++;
+      final int expectedVersion = repushVersion;
       Properties repushProps = buildRepushProps(storeName, inputDirPath);
       repushProps.setProperty(KAFKA_INPUT_COMBINER_ENABLED, combiner);
       try (VenicePushJob repushJob = new VenicePushJob("repush-basic-combiner-" + combiner, repushProps)) {
@@ -100,6 +114,9 @@ public class TestRepushDiagnostics extends AbstractTestRepush {
           LOGGER.info("Repush (combiner={}) metrics:\n{}", combiner, snapshot.getFormattedReport());
         });
       }
+      waitForVersion(storeName, expectedVersion);
+      // Verify EOP on repush version also has per-partition record counts
+      verifyEopPartitionRecordCounts(storeName, expectedVersion, 2, keys);
     }
     verifyBatchData(storeName, 100, 0);
   }

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/utils/IntegrationTestPushUtils.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/utils/IntegrationTestPushUtils.java
@@ -35,6 +35,7 @@ import com.linkedin.davinci.kafka.consumer.ConsumerPoolType;
 import com.linkedin.davinci.kafka.consumer.KafkaStoreIngestionService;
 import com.linkedin.davinci.kafka.consumer.TopicPartitionIngestionInfo;
 import com.linkedin.davinci.listener.response.ReplicaIngestionResponse;
+import com.linkedin.venice.ConfigKeys;
 import com.linkedin.venice.common.VeniceSystemStoreType;
 import com.linkedin.venice.compression.CompressionStrategy;
 import com.linkedin.venice.controllerapi.ControllerClient;
@@ -56,10 +57,22 @@ import com.linkedin.venice.integration.utils.VeniceMultiClusterWrapper;
 import com.linkedin.venice.integration.utils.VeniceServerWrapper;
 import com.linkedin.venice.integration.utils.VeniceTwoLayerMultiRegionMultiClusterWrapper;
 import com.linkedin.venice.jobs.StageMetricsSnapshot;
+import com.linkedin.venice.kafka.protocol.ControlMessage;
+import com.linkedin.venice.kafka.protocol.KafkaMessageEnvelope;
+import com.linkedin.venice.kafka.protocol.enums.ControlMessageType;
 import com.linkedin.venice.meta.Store;
 import com.linkedin.venice.meta.Version;
+import com.linkedin.venice.partitioner.DefaultVenicePartitioner;
+import com.linkedin.venice.pubsub.PubSubConsumerAdapterContext;
 import com.linkedin.venice.pubsub.PubSubProducerAdapterFactory;
+import com.linkedin.venice.pubsub.PubSubTopicPartitionImpl;
 import com.linkedin.venice.pubsub.PubSubTopicRepository;
+import com.linkedin.venice.pubsub.api.DefaultPubSubMessage;
+import com.linkedin.venice.pubsub.api.PubSubConsumerAdapter;
+import com.linkedin.venice.pubsub.api.PubSubMessageDeserializer;
+import com.linkedin.venice.pubsub.api.PubSubMessageHeader;
+import com.linkedin.venice.pubsub.api.PubSubMessageHeaders;
+import com.linkedin.venice.pubsub.api.PubSubSymbolicPosition;
 import com.linkedin.venice.pubsub.api.PubSubTopic;
 import com.linkedin.venice.pubsub.api.PubSubTopicPartition;
 import com.linkedin.venice.pubsub.manager.TopicManagerContext;
@@ -67,9 +80,12 @@ import com.linkedin.venice.pubsub.manager.TopicManagerRepository;
 import com.linkedin.venice.samza.VeniceObjectWithTimestamp;
 import com.linkedin.venice.samza.VeniceSystemFactory;
 import com.linkedin.venice.samza.VeniceSystemProducer;
+import com.linkedin.venice.serialization.avro.VeniceAvroKafkaSerializer;
 import com.linkedin.venice.writer.VeniceWriterFactory;
 import java.io.IOException;
+import java.nio.ByteBuffer;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -662,6 +678,97 @@ public class IntegrationTestPushUtils {
         });
       }
     });
+  }
+
+  /**
+   * Reads EOP messages from all partitions of a store's version topic and returns the per-partition
+   * record counts from the "prc" headers. Asserts that every partition has a prc header.
+   *
+   * @return Map of partition ID to record count extracted from prc headers.
+   */
+  public static Map<Integer, Long> getEopPartitionRecordCounts(
+      PubSubBrokerWrapper pubSubBrokerWrapper,
+      String storeName,
+      int version,
+      int partitionCount) {
+    String versionTopic = Version.composeKafkaTopic(storeName, version);
+    Properties consumerProps = new Properties();
+    consumerProps.setProperty(ConfigKeys.KAFKA_BOOTSTRAP_SERVERS, pubSubBrokerWrapper.getAddress());
+
+    Map<Integer, Long> foundCounts = new HashMap<>();
+    for (int p = 0; p < partitionCount; p++) {
+      final int partition = p;
+      try (PubSubConsumerAdapter consumer = pubSubBrokerWrapper.getPubSubClientsFactory()
+          .getConsumerAdapterFactory()
+          .create(
+              new PubSubConsumerAdapterContext.Builder().setVeniceProperties(new VeniceProperties(consumerProps))
+                  .setPubSubMessageDeserializer(PubSubMessageDeserializer.createDefaultDeserializer())
+                  .setPubSubPositionTypeRegistry(pubSubBrokerWrapper.getPubSubPositionTypeRegistry())
+                  .setConsumerName("eopVerifier-" + partition)
+                  .build())) {
+        consumer.subscribe(
+            new PubSubTopicPartitionImpl(new PubSubTopicRepository().getTopic(versionTopic), partition),
+            PubSubSymbolicPosition.EARLIEST,
+            false);
+
+        TestUtils.waitForNonDeterministicAssertion(30, TimeUnit.SECONDS, () -> {
+          Map<PubSubTopicPartition, List<DefaultPubSubMessage>> messages = consumer.poll(5000);
+          messages.forEach((tp, msgList) -> msgList.forEach(msg -> {
+            if (msg.getKey().isControlMessage()) {
+              KafkaMessageEnvelope kme = msg.getValue();
+              ControlMessage cm = (ControlMessage) kme.payloadUnion;
+              if (cm.getControlMessageType() == ControlMessageType.END_OF_PUSH.getValue()) {
+                PubSubMessageHeader prcHeader =
+                    msg.getPubSubMessageHeaders().get(PubSubMessageHeaders.VENICE_PARTITION_RECORD_COUNT_HEADER);
+                Assert.assertNotNull(prcHeader, "EOP on partition " + partition + " missing prc header");
+                foundCounts.put(partition, ByteBuffer.wrap(prcHeader.value()).getLong());
+              }
+            }
+          }));
+          Assert.assertTrue(foundCounts.containsKey(partition), "No EOP with prc header on partition " + partition);
+        });
+      }
+    }
+
+    Assert.assertEquals(foundCounts.size(), partitionCount, "All partitions should have prc headers");
+    return foundCounts;
+  }
+
+  /**
+   * Verifies that EOP prc headers match the expected per-partition record distribution
+   * computed by running the Venice partitioner against the given keys.
+   *
+   * @param actualCounts per-partition record counts from EOP headers (from {@link #getEopPartitionRecordCounts})
+   * @param keys the keys that were pushed (will be serialized using the string schema)
+   * @param keySchemaStr the Avro schema string for serializing keys (e.g., "\"string\"")
+   * @param partitionCount number of partitions
+   */
+  public static void verifyPerPartitionCounts(
+      Map<Integer, Long> actualCounts,
+      Collection<String> keys,
+      String keySchemaStr,
+      int partitionCount) {
+    DefaultVenicePartitioner partitioner = new DefaultVenicePartitioner();
+    VeniceAvroKafkaSerializer keySerializer = new VeniceAvroKafkaSerializer(keySchemaStr);
+
+    Map<Integer, Long> expectedCounts = new HashMap<>();
+    for (String key: keys) {
+      byte[] keyBytes = keySerializer.serialize(null, key);
+      int partition = partitioner.getPartitionId(keyBytes, partitionCount);
+      expectedCounts.merge(partition, 1L, Long::sum);
+    }
+
+    long actualTotal = actualCounts.values().stream().mapToLong(Long::longValue).sum();
+    long expectedTotal = keys.size();
+    Assert.assertEquals(actualTotal, expectedTotal, "Total record count mismatch");
+
+    for (Map.Entry<Integer, Long> entry: expectedCounts.entrySet()) {
+      int partition = entry.getKey();
+      long expected = entry.getValue();
+      Long actual = actualCounts.get(partition);
+      Assert.assertNotNull(actual, "Missing prc count for partition " + partition);
+      Assert.assertEquals(actual.longValue(), expected, "Record count mismatch on partition " + partition);
+    }
   }
 
   private static void assertStoreHealth(ControllerClient controllerClient, String systemStoreName, String regionName) {

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/Admin.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/Admin.java
@@ -761,6 +761,15 @@ public interface Admin extends AutoCloseable, Closeable {
 
   void writeEndOfPush(String clusterName, String storeName, int versionNumber, boolean alsoWriteStartOfPush);
 
+  default void writeEndOfPush(
+      String clusterName,
+      String storeName,
+      int versionNumber,
+      boolean alsoWriteStartOfPush,
+      Map<Integer, Long> partitionRecordCounts) {
+    writeEndOfPush(clusterName, storeName, versionNumber, alsoWriteStartOfPush);
+  }
+
   boolean whetherEnableBatchPushFromAdmin(String clusterName, String storeName);
 
   /**

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceHelixAdmin.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceHelixAdmin.java
@@ -1796,6 +1796,16 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
    */
   @Override
   public void writeEndOfPush(String clusterName, String storeName, int versionNumber, boolean alsoWriteStartOfPush) {
+    writeEndOfPush(clusterName, storeName, versionNumber, alsoWriteStartOfPush, Collections.emptyMap());
+  }
+
+  @Override
+  public void writeEndOfPush(
+      String clusterName,
+      String storeName,
+      int versionNumber,
+      boolean alsoWriteStartOfPush,
+      Map<Integer, Long> partitionRecordCounts) {
     // validate store and version exist
     Store store = getStore(clusterName, storeName);
 
@@ -1841,7 +1851,7 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
             version.getCompressionStrategy(),
             new HashMap<>());
       }
-      veniceWriter.broadcastEndOfPush(new HashMap<>());
+      veniceWriter.broadcastEndOfPush(new HashMap<>(), partitionRecordCounts);
       veniceWriter.flush();
     }
   }

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceParentHelixAdmin.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceParentHelixAdmin.java
@@ -5581,6 +5581,17 @@ public class VeniceParentHelixAdmin implements Admin {
   }
 
   @Override
+  public void writeEndOfPush(
+      String clusterName,
+      String storeName,
+      int versionNumber,
+      boolean alsoWriteStartOfPush,
+      Map<Integer, Long> partitionRecordCounts) {
+    getVeniceHelixAdmin()
+        .writeEndOfPush(clusterName, storeName, versionNumber, alsoWriteStartOfPush, partitionRecordCounts);
+  }
+
+  @Override
   public boolean whetherEnableBatchPushFromAdmin(String clusterName, String storeName) {
     /**
      * Batch push to Parent Cluster is always enabled.

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/server/CreateVersion.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/server/CreateVersion.java
@@ -8,6 +8,7 @@ import static com.linkedin.venice.controllerapi.ControllerApiConstants.IS_WRITE_
 import static com.linkedin.venice.controllerapi.ControllerApiConstants.NAME;
 import static com.linkedin.venice.controllerapi.ControllerApiConstants.PARTITIONERS;
 import static com.linkedin.venice.controllerapi.ControllerApiConstants.PARTITION_COUNT;
+import static com.linkedin.venice.controllerapi.ControllerApiConstants.PARTITION_RECORD_COUNTS;
 import static com.linkedin.venice.controllerapi.ControllerApiConstants.PUSH_IN_SORTED_ORDER;
 import static com.linkedin.venice.controllerapi.ControllerApiConstants.PUSH_JOB_ID;
 import static com.linkedin.venice.controllerapi.ControllerApiConstants.PUSH_TYPE;
@@ -30,6 +31,7 @@ import static com.linkedin.venice.meta.Version.PushType;
 import static com.linkedin.venice.meta.Version.REPLICATION_METADATA_VERSION_ID_UNSET;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
 import com.linkedin.venice.HttpConstants;
 import com.linkedin.venice.acl.DynamicAccessController;
 import com.linkedin.venice.compression.CompressionStrategy;
@@ -52,6 +54,7 @@ import com.linkedin.venice.utils.Utils;
 import com.linkedin.venice.utils.lazy.Lazy;
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import org.apache.http.HttpStatus;
@@ -755,7 +758,24 @@ public class CreateVersion extends AbstractRoute {
         responseObject.setCluster(clusterName);
         responseObject.setName(storeName);
 
-        admin.writeEndOfPush(clusterName, storeName, versionNumber, false);
+        String partitionRecordCountsJson = request.queryParams(PARTITION_RECORD_COUNTS);
+        Map<Integer, Long> partitionRecordCounts = Collections.emptyMap();
+        if (partitionRecordCountsJson != null && !partitionRecordCountsJson.isEmpty()) {
+          try {
+            partitionRecordCounts = AdminSparkServer.OBJECT_MAPPER
+                .readValue(partitionRecordCountsJson, new TypeReference<Map<Integer, Long>>() {
+                });
+          } catch (JsonProcessingException jpe) {
+            throw new VeniceHttpException(
+                HttpStatus.SC_BAD_REQUEST,
+                "Malformed " + PARTITION_RECORD_COUNTS + " query parameter for store " + storeName + " version "
+                    + versionNumber + ": " + jpe.getOriginalMessage(),
+                ErrorType.BAD_REQUEST);
+          }
+        }
+        // alsoWriteStartOfPush is hardcoded false for this route (current contract). If this route ever needs to
+        // support alsoWriteStartOfPush=true, change this single literal rather than two branches.
+        admin.writeEndOfPush(clusterName, storeName, versionNumber, false, partitionRecordCounts);
 
       } catch (Throwable e) {
         responseObject.setError(e);

--- a/services/venice-controller/src/test/java/com/linkedin/venice/controller/TestVeniceHelixAdminWithoutCluster.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/controller/TestVeniceHelixAdminWithoutCluster.java
@@ -14,11 +14,13 @@ import static org.mockito.Mockito.when;
 
 import com.linkedin.venice.common.VeniceSystemStoreType;
 import com.linkedin.venice.exceptions.VeniceException;
+import com.linkedin.venice.exceptions.VeniceNoStoreException;
 import com.linkedin.venice.helix.ZkStoreConfigAccessor;
 import com.linkedin.venice.meta.BufferReplayPolicy;
 import com.linkedin.venice.meta.DataReplicationPolicy;
 import com.linkedin.venice.meta.HybridStoreConfig;
 import com.linkedin.venice.meta.HybridStoreConfigImpl;
+import com.linkedin.venice.meta.PartitionerConfig;
 import com.linkedin.venice.meta.ReadWriteStoreRepository;
 import com.linkedin.venice.meta.Store;
 import com.linkedin.venice.meta.StoreConfig;
@@ -28,10 +30,16 @@ import com.linkedin.venice.pubsub.api.PubSubTopic;
 import com.linkedin.venice.pubsub.manager.TopicManager;
 import com.linkedin.venice.utils.TestUtils;
 import com.linkedin.venice.utils.Utils;
+import com.linkedin.venice.writer.VeniceWriter;
+import com.linkedin.venice.writer.VeniceWriterFactory;
+import com.linkedin.venice.writer.VeniceWriterOptions;
+import java.lang.reflect.Field;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.Consumer;
@@ -377,5 +385,95 @@ public class TestVeniceHelixAdminWithoutCluster {
     Assert.assertTrue(admin.isVersionTopicTruncatedWithRecheck(versionTopic));
     verify(admin, times(VeniceHelixAdmin.MIGRATION_TRUNCATION_RECHECK_MAX_ATTEMPTS))
         .isTopicTruncated(versionTopic.getName());
+  }
+
+  private VeniceHelixAdmin setupAdminForWriteEndOfPush() throws Exception {
+    VeniceHelixAdmin admin = mock(VeniceHelixAdmin.class);
+    doCallRealMethod().when(admin).writeEndOfPush(anyString(), anyString(), anyInt(), anyBoolean());
+    doCallRealMethod().when(admin).writeEndOfPush(anyString(), anyString(), anyInt(), anyBoolean(), any());
+
+    // Set the private multiClusterConfigs field via reflection since writeEndOfPush accesses it directly
+    VeniceControllerMultiClusterConfig multiClusterConfigs = mock(VeniceControllerMultiClusterConfig.class);
+    doReturn(false).when(multiClusterConfigs).isParent();
+    Field field = VeniceHelixAdmin.class.getDeclaredField("multiClusterConfigs");
+    field.setAccessible(true);
+    field.set(admin, multiClusterConfigs);
+
+    return admin;
+  }
+
+  @Test
+  public void testWriteEndOfPushNoPartitionCounts() throws Exception {
+    String clusterName = "test_cluster";
+    String storeName = "test_store";
+    int versionNumber = 1;
+
+    VeniceHelixAdmin admin = setupAdminForWriteEndOfPush();
+
+    Store store = mock(Store.class);
+    doReturn(0).when(store).getCurrentVersion();
+    Version version = mock(Version.class);
+    doReturn(version).when(store).getVersion(versionNumber);
+    doReturn(Version.PushType.BATCH).when(version).getPushType();
+    doReturn(3).when(version).getPartitionCount();
+    PartitionerConfig partitionerConfig = mock(PartitionerConfig.class);
+    doReturn(1).when(partitionerConfig).getAmplificationFactor();
+    doReturn(partitionerConfig).when(version).getPartitionerConfig();
+    doReturn(store).when(admin).getStore(clusterName, storeName);
+
+    VeniceWriterFactory writerFactory = mock(VeniceWriterFactory.class);
+    VeniceWriter veniceWriter = mock(VeniceWriter.class);
+    doReturn(writerFactory).when(admin).getVeniceWriterFactory();
+    doReturn(veniceWriter).when(writerFactory).createVeniceWriter(any(VeniceWriterOptions.class));
+
+    // Call the original 4-arg overload
+    admin.writeEndOfPush(clusterName, storeName, versionNumber, false);
+
+    // Verify it delegates to the 5-arg overload with empty counts (falls back to no-header EOP in VeniceWriter)
+    verify(veniceWriter).broadcastEndOfPush(any(Map.class), eq(Collections.emptyMap()));
+    verify(veniceWriter).flush();
+  }
+
+  @Test
+  public void testWriteEndOfPushWithPartitionRecordCounts() throws Exception {
+    String clusterName = "test_cluster";
+    String storeName = "test_store";
+    int versionNumber = 1;
+
+    VeniceHelixAdmin admin = setupAdminForWriteEndOfPush();
+
+    Store store = mock(Store.class);
+    doReturn(0).when(store).getCurrentVersion();
+    Version version = mock(Version.class);
+    doReturn(version).when(store).getVersion(versionNumber);
+    doReturn(Version.PushType.BATCH).when(version).getPushType();
+    doReturn(3).when(version).getPartitionCount();
+    PartitionerConfig partitionerConfig = mock(PartitionerConfig.class);
+    doReturn(1).when(partitionerConfig).getAmplificationFactor();
+    doReturn(partitionerConfig).when(version).getPartitionerConfig();
+    doReturn(store).when(admin).getStore(clusterName, storeName);
+
+    VeniceWriterFactory writerFactory = mock(VeniceWriterFactory.class);
+    VeniceWriter veniceWriter = mock(VeniceWriter.class);
+    doReturn(writerFactory).when(admin).getVeniceWriterFactory();
+    doReturn(veniceWriter).when(writerFactory).createVeniceWriter(any(VeniceWriterOptions.class));
+
+    Map<Integer, Long> counts = new HashMap<>();
+    counts.put(0, 100L);
+    counts.put(1, 200L);
+    counts.put(2, 50L);
+
+    admin.writeEndOfPush(clusterName, storeName, versionNumber, false, counts);
+
+    verify(veniceWriter).broadcastEndOfPush(any(Map.class), eq(counts));
+    verify(veniceWriter).flush();
+  }
+
+  @Test(expectedExceptions = VeniceNoStoreException.class)
+  public void testWriteEndOfPushThrowsForNonExistentStore() throws Exception {
+    VeniceHelixAdmin admin = setupAdminForWriteEndOfPush();
+    doReturn(null).when(admin).getStore("cluster", "missing_store");
+
+    admin.writeEndOfPush("cluster", "missing_store", 1, false, null);
   }
 }

--- a/services/venice-controller/src/test/java/com/linkedin/venice/controller/server/CreateVersionTest.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/controller/server/CreateVersionTest.java
@@ -10,6 +10,7 @@ import static com.linkedin.venice.controllerapi.ControllerApiConstants.HOSTNAME;
 import static com.linkedin.venice.controllerapi.ControllerApiConstants.IS_WRITE_COMPUTE_ENABLED;
 import static com.linkedin.venice.controllerapi.ControllerApiConstants.NAME;
 import static com.linkedin.venice.controllerapi.ControllerApiConstants.PARTITIONERS;
+import static com.linkedin.venice.controllerapi.ControllerApiConstants.PARTITION_RECORD_COUNTS;
 import static com.linkedin.venice.controllerapi.ControllerApiConstants.PUSH_IN_SORTED_ORDER;
 import static com.linkedin.venice.controllerapi.ControllerApiConstants.PUSH_JOB_ID;
 import static com.linkedin.venice.controllerapi.ControllerApiConstants.PUSH_TYPE;
@@ -1306,5 +1307,63 @@ public class CreateVersionTest {
 
     // SOP and EOP should NOT be written
     verify(admin, never()).writeEndOfPush(any(), any(), anyInt(), anyBoolean());
+  }
+
+  @Test
+  public void testWriteEndOfPushWithPartitionRecordCounts() throws Exception {
+    CreateVersion createVersion = new CreateVersion(false, Optional.of(NoOpDynamicAccessController.INSTANCE), false);
+    Route writeEopRoute = createVersion.writeEndOfPush(admin);
+
+    when(request.queryParams(NAME)).thenReturn(STORE_NAME);
+    when(request.queryParams(CLUSTER)).thenReturn(CLUSTER_NAME);
+    when(request.queryParams("version")).thenReturn("3");
+    when(request.queryParams(PARTITION_RECORD_COUNTS)).thenReturn("{\"0\":100,\"1\":200,\"2\":50}");
+
+    Object result = writeEopRoute.handle(request, response);
+    assertNotNull(result);
+
+    // Verify the new overload with partition counts was called
+    Map<Integer, Long> expectedCounts = new HashMap<>();
+    expectedCounts.put(0, 100L);
+    expectedCounts.put(1, 200L);
+    expectedCounts.put(2, 50L);
+    verify(admin).writeEndOfPush(CLUSTER_NAME, STORE_NAME, 3, false, expectedCounts);
+    verify(admin, never()).writeEndOfPush(CLUSTER_NAME, STORE_NAME, 3, false);
+  }
+
+  @Test
+  public void testWriteEndOfPushWithoutPartitionRecordCounts() throws Exception {
+    CreateVersion createVersion = new CreateVersion(false, Optional.of(NoOpDynamicAccessController.INSTANCE), false);
+    Route writeEopRoute = createVersion.writeEndOfPush(admin);
+
+    when(request.queryParams(NAME)).thenReturn(STORE_NAME);
+    when(request.queryParams(CLUSTER)).thenReturn(CLUSTER_NAME);
+    when(request.queryParams("version")).thenReturn("3");
+    when(request.queryParams(PARTITION_RECORD_COUNTS)).thenReturn(null);
+
+    Object result = writeEopRoute.handle(request, response);
+    assertNotNull(result);
+
+    // Route always calls the 5-arg overload now; absent partition counts -> empty map
+    verify(admin).writeEndOfPush(CLUSTER_NAME, STORE_NAME, 3, false, Collections.emptyMap());
+    verify(admin, never()).writeEndOfPush(anyString(), anyString(), anyInt(), anyBoolean());
+  }
+
+  @Test
+  public void testWriteEndOfPushWithEmptyPartitionRecordCounts() throws Exception {
+    CreateVersion createVersion = new CreateVersion(false, Optional.of(NoOpDynamicAccessController.INSTANCE), false);
+    Route writeEopRoute = createVersion.writeEndOfPush(admin);
+
+    when(request.queryParams(NAME)).thenReturn(STORE_NAME);
+    when(request.queryParams(CLUSTER)).thenReturn(CLUSTER_NAME);
+    when(request.queryParams("version")).thenReturn("3");
+    when(request.queryParams(PARTITION_RECORD_COUNTS)).thenReturn("");
+
+    Object result = writeEopRoute.handle(request, response);
+    assertNotNull(result);
+
+    // Empty string -> empty map -> still routes through the 5-arg overload
+    verify(admin).writeEndOfPush(CLUSTER_NAME, STORE_NAME, 3, false, Collections.emptyMap());
+    verify(admin, never()).writeEndOfPush(anyString(), anyString(), anyInt(), anyBoolean());
   }
 }


### PR DESCRIPTION
<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat], [protocol]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## Problem Statement
Venice batch pushes (VPJ) currently have no mechanism to verify that the number of records written by the push job matches what the server actually ingested per partition. If records are silently dropped or duplicated during ingestion, there's no detection — the push completes successfully and the version swaps in with incorrect data.                        
   
To enable server-side verification, the EOP (End-of-Push) control message needs to carry the per-partition record count as metadata. The server can then compare its own ingested count against the expected count from the EOP header and flag mismatches.                                                                                                             


## Solution
This PR implements per-partition record counting, which provides exactly-once semantics by piggybacking on Spark's task output guarantees - only the successful task's return value is collected.                                                                                                                              
  
Spark pipeline changes:                                                                                                                                                                                                                                                                                                                                                 
  - `SparkPartitionWriterFactory` now emits a single `(partitionId, recordCount)` summary row per partition after writing all records to Kafka, instead of returning the exhausted input iterator
  - `AbstractDataWriterSparkJob` replaces `dataFrame.count()` with `dataFrame.collectAsList()` to retrieve these summary rows on the driver. Memory overhead is bounded by partition count (~40 bytes per partition)                                                                                                                                                            
  - Per-partition counts are stored on `SparkDataWriterTaskTracker` via a new `getPerPartitionRecordCounts()` method on the `DataWriterTaskTracker` interface                                                       
                                                                                                                                                                                                                                                                                                                                                                          
EOP header encoding:                                                                                                                                                                                                                                                                                                                                                    
  - New PubSub message header `prc` (VENICE_PARTITION_RECORD_COUNT_HEADER) carries the partition size per partition                                                                                                                        
  - `VeniceWriter.broadcastEndOfPush(debugInfo, partitionRecordCounts)` — new overload that attaches the `prc` header to each partition's EOP message. No Avro schema changes needed — headers sit outside the control message payload, so old servers ignore unknown headers (backward compatible)                                                                           
                                                                                                                                                                                                                                                                                                                                                                          
 Both EOP paths covered:                                                                                                                                                                                                                                                                                                                                                 
  - Direct path `(sendControlMessagesDirectly=true)`: VPJ driver passes counts directly to VeniceWriter
  - Controller path `(sendControlMessagesDirectly=false)`: Counts are JSON-serialized as a partition_record_counts query parameter on the `END_OF_PUSH REST POST`. `CreateVersion` route handler deserializes and passes to `VeniceHelixAdmin.writeEndOfPush()`, which was refactored to eliminate code duplication — the 4-arg overload now delegates to the 5-arg overload      


###  Code changes
- [ ] Added new code behind **a config**. If so list the config names and their default values in the PR description.
- [ ] Introduced new **log lines**. 
  - [ ] Confirmed if logs need to be **rate limited** to avoid excessive logging.

###  **Concurrency-Specific Checks**
Both reviewer and PR author to verify
- [ ] Code has **no race conditions** or **thread safety issues**.
- [ ] Proper **synchronization mechanisms** (e.g., `synchronized`, `RWLock`) are used where needed.
- [ ] No **blocking calls** inside critical sections that could lead to deadlocks or performance degradation.
- [ ] Verified **thread-safe collections** are used (e.g., `ConcurrentHashMap`, `CopyOnWriteArrayList`).
- [ ] Validated proper exception handling in multi-threaded code to avoid silent thread termination.


## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->

- [ ] New unit tests added.
- [ ] New integration tests added.
- [ ] Modified or extended existing tests.
- [ ] Verified backward compatibility (if applicable).

## Does this PR introduce any user-facing or breaking changes?
<!--  
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [ ] No. You can skip the rest of this section.
- [ ] Yes. Clearly explain the behavior change and its impact.