### PR TITLE
[protocol] Add ROLLED_BACK to VersionStatusGrpc enum

### DIFF
--- a/internal/venice-common/src/main/proto/controller/ControllerGrpcRequestContext.proto
+++ b/internal/venice-common/src/main/proto/controller/ControllerGrpcRequestContext.proto
@@ -45,6 +45,7 @@ enum VersionStatusGrpc {
   CREATED = 5;
   PARTIALLY_ONLINE = 6;
   KILLED = 7;
+  ROLLED_BACK = 8;
 }
 
 message VersionGrpc {


### PR DESCRIPTION
## Problem Statement

Mirror of the Java `VersionStatus.ROLLED_BACK(8)` enum addition (see #2688) in the gRPC controller protocol so clients using the gRPC controller path can receive this status.

## Solution

Add `ROLLED_BACK = 8` to `VersionStatusGrpc` in `ControllerGrpcRequestContext.proto`, matching the Java enum value.

This is split out from #2688 so the rollback-origin Java changes there don't trip the `enforce-lines-added` CI check which fails when a PR mixes schema (.proto/.avsc) and Java source changes.

### Code changes

- [x] Added new code behind **a config**. N/A (protocol addition only)
- [ ] Introduced new **log lines**.

## How was this PR tested?

- [x] Modified or extended existing tests. N/A — additive enum value only, no behavior change.
- [x] Verified backward compatibility — new enum value appended to existing list, does not reorder or remove any existing values.

## Does this PR introduce any user-facing or breaking changes?

- [x] No. You can skip the rest of this section.