### PR TITLE
[protocol] Add activeKeyCount to PartitionState Avro schema

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -329,6 +329,7 @@ subprojects {
       // when actually using the new protocol. Example to pin KME to v12 when introducing v13:
       // project(':internal:venice-common').file('src/main/resources/avro/KafkaMessageEnvelope/v12', PathValidation.DIRECTORY)
       def versionOverrides = [
+          project(':internal:venice-common').file('src/main/resources/avro/PartitionState/v21', PathValidation.DIRECTORY)
       ]
 
       def schemaDirs = [sourceDir]

--- a/internal/venice-common/src/main/resources/avro/PartitionState/v22/PartitionState.avsc
+++ b/internal/venice-common/src/main/resources/avro/PartitionState/v22/PartitionState.avsc
@@ -49,7 +49,7 @@
               "type": "string"
             }, {
               "name": "error",
-              "doc": "The first error founded during in`gestion",
+              "doc": "The first error found during in`gestion",
               "type": ["null", "string"],
               "default": null
             }

--- a/internal/venice-common/src/main/resources/avro/PartitionState/v22/PartitionState.avsc
+++ b/internal/venice-common/src/main/resources/avro/PartitionState/v22/PartitionState.avsc
@@ -314,7 +314,7 @@
     },
     {
       "name": "activeKeyCount",
-      "doc": "Active unique key count for this partition. -1 means not yet tracked or invalidated. During batch push (SOP to EOP), this is the count of logical PUTs. After EOP for hybrid A/A stores, this is adjusted by +1/-1 deltas based on whether a value existed before and after conflict resolution (leader) or based on VT header deltas from leader (follower).",
+      "doc": "Active unique key count for this partition. -1 means not yet tracked or invalidated.",
       "type": "long",
       "default": -1
     }

--- a/internal/venice-common/src/main/resources/avro/PartitionState/v22/PartitionState.avsc
+++ b/internal/venice-common/src/main/resources/avro/PartitionState/v22/PartitionState.avsc
@@ -49,7 +49,7 @@
               "type": "string"
             }, {
               "name": "error",
-              "doc": "The first error found during in`gestion",
+              "doc": "The first error found during ingestion",
               "type": ["null", "string"],
               "default": null
             }
@@ -113,7 +113,7 @@
     }, {
       "name": "leaderHostId",
       "type": ["null", "string"],
-      "doc": "An unique identifier (such as host name) that stands for each host. It's used to identify if there is a split-brain happened while the leader(s) re-produce records",
+      "doc": "A unique identifier (such as host name) that stands for each host. It's used to identify if there is a split-brain happened while the leader(s) re-produce records",
       "default": null
     }, {
       "name": "producerStates",

--- a/internal/venice-common/src/main/resources/avro/PartitionState/v22/PartitionState.avsc
+++ b/internal/venice-common/src/main/resources/avro/PartitionState/v22/PartitionState.avsc
@@ -1,0 +1,322 @@
+{
+  "name": "PartitionState",
+  "namespace": "com.linkedin.venice.kafka.protocol.state",
+  "doc": "This record holds the state necessary for a consumer to checkpoint its progress when consuming a Venice partition. When provided the state in this record, a consumer should thus be able to resume consuming midway through a stream.",
+  "type": "record",
+  "fields": [
+    {
+      "name": "offset",
+      "doc": "The last Kafka offset processed successfully in this partition from version topic.",
+      "type": "long"
+    }, {
+      "name": "offsetLag",
+      "doc": "The last Kafka offset lag in this partition for fast online transition in server restart.",
+      "type": "long",
+      "default": -1
+    }, {
+      "name": "endOfPush",
+      "doc": "Whether the EndOfPush control message was consumed in this partition.",
+      "type": "boolean"
+    }, {
+      "name": "lastUpdate",
+      "doc": "The last time this PartitionState was updated. Can be compared against the various messageTimestamp in ProducerPartitionState in order to infer lag time between producers and the consumer maintaining this PartitionState.",
+      "type": "long"
+    }, {
+      "name": "startOfBufferReplayDestinationOffset",
+      "doc": "This is the offset at which the StartOfBufferReplay control message was consumed in the current partition of the destination topic. This is not the same value as the source offsets contained in the StartOfBufferReplay control message itself. The source and destination offsets act together as a synchronization marker. N.B.: null means that the SOBR control message was not received yet.",
+      "type": ["null", "long"],
+      "default": null
+    }, {
+      "name": "databaseInfo",
+      "doc": "A map of string -> string to store database related info, which is necessary to checkpoint",
+      "type": {
+        "type": "map",
+        "values": "string"
+      },
+      "default": {}
+    }, {
+      "name": "incrementalPushInfo",
+      "doc": "metadata of ongoing incremental push in the partition",
+      "type": [
+        "null",
+        {
+          "name": "IncrementalPush",
+          "type": "record",
+          "fields": [
+            {
+              "name": "version",
+              "doc": "The version of current incremental push",
+              "type": "string"
+            }, {
+              "name": "error",
+              "doc": "The first error founded during in`gestion",
+              "type": ["null", "string"],
+              "default": null
+            }
+          ]
+        }
+      ],
+      "default": null
+    }, {
+      "name": "leaderTopic",
+      "type": ["null", "string"],
+      "doc": "The topic that leader is consuming from; for leader, leaderTopic can be different from the version topic; for follower, leaderTopic is the same as version topic.",
+      "default": null
+    }, {
+      "name": "leaderOffset",
+      "type": "long",
+      "doc": "The last Kafka offset consumed successfully in this partition from the leader topic. TODO: remove this field once upstreamOffsetMap is used everywhere.",
+      "default": -1
+    }, {
+      "name": "upstreamOffsetMap",
+      "type": {
+        "type": "map",
+        "values": "long",
+        "java-key-class": "java.lang.String",
+        "avro.java.string": "String"
+      },
+      "doc": "A map of upstream Kafka bootstrap server url -> the last Kafka offset consumed from upstream topic.",
+      "default": {}
+    }, {
+      "name": "upstreamRealTimeTopicPubSubPositionMap",
+      "type": {
+        "type": "map",
+        "values": "bytes",
+        "java-key-class": "java.lang.String",
+        "avro.java.string": "String"
+      },
+      "doc": "A map of upstream PubSub bootstrap server url -> the last PubSub position consumed from upstream topic.",
+      "default": {}
+    }, {
+      "name": "upstreamVersionTopicOffset",
+      "type": "long",
+      "doc": "The last upstream version topic offset persisted to disk; if the batch native-replication source is the same as local region, this value will always be -1",
+      "default": -1
+    }, {
+      "name": "upstreamVersionTopicPubSubPosition",
+      "type": "bytes",
+      "doc": "The last upstream version topic PubSub position persisted to disk; if the batch native-replication source is the same as local region, this value will always be null",
+      "default": ""
+    }, {
+      "name": "leaderGUID",
+      "type": [
+        "null",
+        {
+          "namespace": "com.linkedin.venice.kafka.protocol",
+          "name": "GUID",
+          "type": "fixed",
+          "size": 16
+        }
+      ],
+      "doc": "This field is deprecated since GUID is no longer able to identify the split-brain issue once 'pass-through' mode is enabled in venice writer. The field is superseded by leaderHostId and will be removed in the future ",
+      "default": null
+    }, {
+      "name": "leaderHostId",
+      "type": ["null", "string"],
+      "doc": "An unique identifier (such as host name) that stands for each host. It's used to identify if there is a split-brain happened while the leader(s) re-produce records",
+      "default": null
+    }, {
+      "name": "producerStates",
+      "doc": "A map of producer GUID -> producer state.",
+      "type": {
+        "type": "map",
+        "values": {
+          "name": "ProducerPartitionState",
+          "doc": "A record containing the state pertaining to the data sent by one upstream producer into one partition.",
+          "type": "record",
+          "fields": [
+            {
+              "name": "segmentNumber",
+              "doc": "The current segment number corresponds to the last (highest) segment number for which we have seen a StartOfSegment control message.",
+              "type": "int"
+            }, {
+              "name": "segmentStatus",
+              "doc": "The status of the current segment: 0 => NOT_STARTED, 1 => IN_PROGRESS, 2 => END_OF_INTERMEDIATE_SEGMENT, 3 => END_OF_FINAL_SEGMENT.",
+              "type": "int"
+            }, {
+              "name": "isRegistered",
+              "doc": "Whether the segment is registered. i.e. received Start_Of_Segment to initialize the segment.",
+              "type": "boolean",
+              "default": false
+            }, {
+              "name": "messageSequenceNumber",
+              "doc": "The current message sequence number, within the current segment, which we have seen for this partition/producer pair.",
+              "type": "int"
+            }, {
+              "name": "messageTimestamp",
+              "doc": "The timestamp included in the last message we have seen for this partition/producer pair.",
+              "type": "long"
+            }, {
+              "name": "checksumType",
+              "doc": "The current mapping is the following: 0 => None, 1 => MD5, 2 => Adler32, 3 => CRC32.",
+              "type": "int"
+            }, {
+              "name": "checksumState",
+              "doc": "The value of the checksum computed since the last StartOfSegment ControlMessage.",
+              "type": "bytes"
+            }, {
+              "name": "aggregates",
+              "doc": "The aggregates that have been computed so far since the last StartOfSegment ControlMessage.",
+              "type": {
+                "type": "map",
+                "values": "long"
+              }
+            }, {
+              "name": "debugInfo",
+              "doc": "The debug info received as part of the last StartOfSegment ControlMessage.",
+              "type": {
+                "type": "map",
+                "values": "string"
+              }
+            }
+          ]
+        }
+      }
+    }, {
+      "name": "previousStatuses",
+      "doc": "A map of string -> string which stands for previous PartitionStatus",
+      "type": {
+        "type": "map",
+        "values": "string"
+      },
+      "default": {}
+    }, {
+      "name": "pendingReportIncrementalPushVersions",
+      "doc": "A list of string which stands for incremental push versions which have received EOIP but not yet reported prior to lag caught up, they will be reported in batch",
+      "type": {
+        "type":  "array",
+        "items": "string"
+      },
+      "default": []
+    }, {
+      "name": "realtimeTopicProducerStates",
+      "doc": "A map that maps upstream Kafka bootstrap server url -> to a map of producer GUID -> producer state for real-time data.",
+      "type": {
+        "type": "map",
+        "values": {
+          "type": "map",
+          "values": "com.linkedin.venice.kafka.protocol.state.ProducerPartitionState"
+        },
+        "java-key-class": "java.lang.String",
+        "avro.java.string": "String"
+      },
+      "default": {}
+    },
+    {
+      "name": "recordTransformerClassHash",
+      "doc": "An integer hash code used by the DaVinciRecordTransformer to detect changes to the user's class during bootstrapping.",
+      "type": [
+        "null",
+        "int"
+      ],
+      "default": null
+    }, {
+      "name": "lastProcessedVersionTopicPubSubPosition",
+      "doc": "The last PubSub position processed successfully in this partition from version topic",
+      "type": "bytes",
+      "default": ""
+    }, {
+      "name": "lastConsumedVersionTopicPubSubPosition",
+      "doc": "The last PubSub position consumed successfully in this partition from the version topic. This is used during resubscription when the Global RT DIV feature is enabled.",
+      "type": "bytes",
+      "default": ""
+    }, {
+      "name": "latestObservedTermId",
+      "doc": "The most recent termId observed by this replica.",
+      "type": "long",
+      "default": -1
+    }, {
+      "name": "currentTermStartPubSubPosition",
+      "doc": "The pubsub position marking the start of the current leader's term in the version topic.",
+      "type": "bytes",
+      "default": ""
+    }, {
+      "name": "lastConsumedVersionTopicOffset",
+      "doc": "The last offset consumed successfully in this partition from the version topic. This is used during resubscription when the Global RT DIV feature is enabled.",
+      "type": "long",
+      "default": -1
+    }, {
+      "name": "heartbeatTimestamp",
+      "doc": "The most stale heartbeat timestamp among all the regions in this partition for fast online transition during server restart.",
+      "type": "long",
+      "default": -1
+    }, {
+      "name": "lastCheckpointTimestamp",
+      "doc": "The most recent checkpoint timestamp for fast online transition during server restart.",
+      "type": "long",
+      "default": -1
+    },
+    {
+      "name": "keyUrnCompressionDict",
+      "doc": "When key compression is enabled, this field keeps all the related information for key URN compression.",
+      "type": [
+        "null",
+        {
+          "name": "KeyUrnCompressionDict",
+          "namespace": "com.linkedin.venice.server.state",
+          "doc": "The key compression dictionary will be populated at ingestion time.",
+          "type": "record",
+          "fields": [
+            {
+              "name": "keyUrnFields",
+              "doc": "The list of fields to be compressed in the key",
+              "type": {
+                "type": "array",
+                "items": "string"
+              }
+            },
+            {
+              "name": "keyUrnCompressionDictionaryVersion",
+              "doc": "The version of the key compression dictionary used to compress/decompress keys. This is used to ensure that the correct dictionary is applied when decompressing keys.",
+              "type": "int"
+            },
+            {
+              "name": "keyUrnCompressionDictionary",
+              "doc": "The raw bytes of dictionary used to compress/decompress keys.",
+              "type": "bytes"
+            }
+          ]
+        }
+      ],
+      "default": null
+    },
+    {
+      "name": "trackingIncrementalPushStatus",
+      "doc": "A map that maps incremental push job id to the replica status",
+      "type": {
+        "type": "map",
+        "values": {
+          "name": "IncrementalPushReplicaStatus",
+          "doc": "A record containing the incremental push replica status, including timestamp and status.",
+          "type": "record",
+          "fields": [
+            {
+              "name": "status",
+              "doc": "The current push status for the incremental push",
+              "type": "int"
+            }, {
+              "name": "timestamp",
+              "doc": "The broker timestamp of the control message received which can be used to purge stale incremental push entries",
+              "type": "long"
+            }
+          ]
+        },
+        "java-key-class": "java.lang.String",
+        "avro.java.string": "String"
+      },
+      "default": {}
+    },
+    {
+      "name": "uniqueIngestedKeyCountHllSketch",
+      "doc": "Serialized HyperLogLog sketch (Apache DataSketches) tracking unique keys ingested in this partition. Null if HLL tracking is not enabled or not yet initialized.",
+      "type": ["null", "bytes"],
+      "default": null
+    },
+    {
+      "name": "activeKeyCount",
+      "doc": "Active unique key count for this partition. -1 means not yet tracked or invalidated. During batch push (SOP to EOP), this is the count of logical PUTs. After EOP for hybrid A/A stores, this is adjusted by +1/-1 deltas based on whether a value existed before and after conflict resolution (leader) or based on VT header deltas from leader (follower).",
+      "type": "long",
+      "default": -1
+    }
+  ]
+}


### PR DESCRIPTION
## Problem Statement

PR #2676 adds active key count tracking that needs it in the partition checkpoint. This requires a new field in the PartitionState Avro schema. CI policy requires schema changes in a separate PR.

## Solution

Add PartitionState v22 with one new long with default -1 (not tracked)

New field: `activeKeyCount` (long, default -1)

### Code changes
- [x] No new code behind a config. Schema-only change.
- [x] No new log lines.

### Concurrency-Specific Checks
- [x] N/A — schema change only, no runtime code.

## How was this PR tested?

- [x] Compilation verified locally.
- [x] Verified backward compatibility
- [x] Full unit + integration test coverage in PR #2676.

## Does this PR introduce any user-facing or breaking changes?
- [x] No. You can skip the rest of this section.
