### PR TITLE
[server][dvc] Stop pinning ~16KB Avro schema header per queued PubSub message

### DIFF
--- a/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/ImmutablePubSubMessage.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/ImmutablePubSubMessage.java
@@ -99,11 +99,13 @@ public class ImmutablePubSubMessage implements DefaultPubSubMessage {
     /** The {@link #topicPartition} is supposed to be a shared instance, and is therefore ignored. */
     int size = SHALLOW_CLASS_OVERHEAD + InstanceSizeEstimator.getObjectSize(key)
         + InstanceSizeEstimator.getObjectSize(value) + InstanceSizeEstimator.getObjectSize(pubSubPosition);
-    // pubSubMessageHeaders can hold non-trivial bytes (e.g. 'vpm' view-partition-map values
-    // or future custom keys). It is captured at construction and not mutated thereafter, so
-    // it is safe to include here. Without this, downstream capacity accounting (e.g.
-    // StoreBufferService.QueueNode.getHeapSize, which delegates to this method) underestimates
-    // per-record retention and the buffer queue can grow well past its byte budget.
+    /*
+     * pubSubMessageHeaders can hold non-trivial bytes (e.g. 'vpm' view-partition-map values
+     * or future custom keys). It is captured at construction and not mutated thereafter, so
+     * it is safe to include here. Without this, downstream capacity accounting (e.g.
+     * StoreBufferService.QueueNode.getHeapSize, which delegates to this method) underestimates
+     * per-record retention and the buffer queue can grow well past its byte budget.
+     */
     if (pubSubMessageHeaders != null) {
       size += pubSubMessageHeaders.getHeapSize();
     }

--- a/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/ImmutablePubSubMessage.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/ImmutablePubSubMessage.java
@@ -97,7 +97,16 @@ public class ImmutablePubSubMessage implements DefaultPubSubMessage {
   @Override
   public int getHeapSize() {
     /** The {@link #topicPartition} is supposed to be a shared instance, and is therefore ignored. */
-    return SHALLOW_CLASS_OVERHEAD + InstanceSizeEstimator.getObjectSize(key)
+    int size = SHALLOW_CLASS_OVERHEAD + InstanceSizeEstimator.getObjectSize(key)
         + InstanceSizeEstimator.getObjectSize(value) + InstanceSizeEstimator.getObjectSize(pubSubPosition);
+    // pubSubMessageHeaders can hold non-trivial bytes (e.g. 'vpm' view-partition-map values
+    // or future custom keys). It is captured at construction and not mutated thereafter, so
+    // it is safe to include here. Without this, downstream capacity accounting (e.g.
+    // StoreBufferService.QueueNode.getHeapSize, which delegates to this method) underestimates
+    // per-record retention and the buffer queue can grow well past its byte budget.
+    if (pubSubMessageHeaders != null) {
+      size += pubSubMessageHeaders.getHeapSize();
+    }
+    return size;
   }
 }

--- a/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/api/PubSubMessageDeserializer.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/api/PubSubMessageDeserializer.java
@@ -92,41 +92,17 @@ public class PubSubMessageDeserializer {
       value = valueSerializer.deserialize(valueBytes, getEnvelope(key.getKeyHeaderByte()));
     }
     /*
-     * Strip the protocol-schema header before constructing ImmutablePubSubMessage. Its sole
-     * purpose is forward-compat schema bootstrap during deserialization (above), and once we
-     * have the value envelope it is dead weight in heap.
-     *
-     * The header value is the entire Avro schema for KafkaMessageEnvelope (~16 KB JSON text).
-     * VeniceWriter#getHeaders attaches it only when both (a) producerMetadata.segmentNumber
-     * == 0 && messageSequenceNumber == 0 and (b) protocolSchemaHeader != null. Even so, in
-     * NR pass-through paths and any other code that copies headers from upstream messages,
-     * 'vtp' can ride along on a substantial fraction of records. With back-pressure on the
-     * StoreBufferService drainer (e.g. during a gzip-Inflater GCLocker stall) a queue with
-     * hundreds of thousands of records can pin its own ~16 KB byte[] copy of identical
-     * schema text per record - upwards of 10 GB of redundant retention has been observed
-     * in production heap dumps. Removing the header here keeps the value (already
-     * deserialized into the KafkaMessageEnvelope above) without the byte[] tail.
-     *
-     * When the header is present, build a new PubSubMessageHeaders that excludes it rather
-     * than mutating the caller's instance. This avoids two failure modes:
-     *   1) EmptyPubSubMessageHeaders.SINGLETON throws on remove() by design.
-     *   2) Any caller-supplied immutable wrapper would also throw on remove().
-     * It also keeps the deserialize() contract free of an undocumented input-mutation
-     * side effect.
-     *
-     * Common case ('vtp' absent) is a single map lookup with no allocation. Allocating
-     * a small replacement headers object only on the rare path is well within the budget
-     * we're trying to recover.
+     * Strip the protocol-schema header ('vtp') before constructing ImmutablePubSubMessage. Its
+     * sole purpose is forward-compat schema bootstrap during deserialization (above), and once
+     * we have the value envelope it is dead weight - the header value is the entire ~16 KB
+     * Avro JSON for KafkaMessageEnvelope. With back-pressure on the StoreBufferService drainer
+     * (e.g. during a gzip-Inflater GCLocker stall) a queue with hundreds of thousands of
+     * records can pin its own ~16 KB byte[] copy of identical schema text per record -
+     * upwards of 10 GB of redundant retention has been observed in production heap dumps.
+     * See PubSubMessageHeaders.stripProtocolSchemaHeader for the precise semantics (input is
+     * never mutated; absent-case is allocation-free).
      */
-    if (headers.get(VENICE_TRANSPORT_PROTOCOL_HEADER) != null) {
-      PubSubMessageHeaders filtered = new PubSubMessageHeaders();
-      for (PubSubMessageHeader h: headers) {
-        if (!VENICE_TRANSPORT_PROTOCOL_HEADER.equals(h.key())) {
-          filtered.add(h);
-        }
-      }
-      headers = filtered;
-    }
+    headers = PubSubMessageHeaders.stripProtocolSchemaHeader(headers);
     // When enabled, prefer Venice's own producer timestamp when the pub-sub system timestamp is
     // missing or zero. Some pub-sub systems do not provide reliable per-message timestamps.
     // Venice always embeds a producer timestamp in the KafkaMessageEnvelope, so we can fall back

--- a/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/api/PubSubMessageDeserializer.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/api/PubSubMessageDeserializer.java
@@ -99,8 +99,10 @@ public class PubSubMessageDeserializer {
      * (e.g. during a gzip-Inflater GCLocker stall) a queue with hundreds of thousands of
      * records can pin its own ~16 KB byte[] copy of identical schema text per record -
      * upwards of 10 GB of redundant retention has been observed in production heap dumps.
-     * See PubSubMessageHeaders.stripProtocolSchemaHeader for the precise semantics (input is
-     * never mutated; absent-case is allocation-free).
+     *
+     * stripProtocolSchemaHeader is best-effort: zero-allocation when 'vtp' is absent, in-place
+     * remove on the production hot path, copy-fallback when the caller hands in an immutable
+     * variant. Never throws. See PubSubMessageHeaders.stripProtocolSchemaHeader for details.
      */
     headers = PubSubMessageHeaders.stripProtocolSchemaHeader(headers);
     // When enabled, prefer Venice's own producer timestamp when the pub-sub system timestamp is

--- a/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/api/PubSubMessageDeserializer.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/api/PubSubMessageDeserializer.java
@@ -96,12 +96,15 @@ public class PubSubMessageDeserializer {
      * purpose is forward-compat schema bootstrap during deserialization (above), and once we
      * have the value envelope it is dead weight in heap.
      *
-     * The header value is the entire Avro schema for KafkaMessageEnvelope (~16 KB JSON text)
-     * and is attached to roughly every message on the wire. With back-pressure on the
-     * StoreBufferService drainer (e.g. during a gzip-Inflater GCLocker stall) the queue can
-     * grow to hundreds of thousands of messages, each pinning its own ~16 KB byte[] copy of
-     * identical schema text - upwards of 10 GB of redundant per-record retention has been
-     * observed in production heap dumps. Removing the header here keeps the value (already
+     * The header value is the entire Avro schema for KafkaMessageEnvelope (~16 KB JSON text).
+     * VeniceWriter#getHeaders attaches it only when both (a) producerMetadata.segmentNumber
+     * == 0 && messageSequenceNumber == 0 and (b) protocolSchemaHeader != null. Even so, in
+     * NR pass-through paths and any other code that copies headers from upstream messages,
+     * 'vtp' can ride along on a substantial fraction of records. With back-pressure on the
+     * StoreBufferService drainer (e.g. during a gzip-Inflater GCLocker stall) a queue with
+     * hundreds of thousands of records can pin its own ~16 KB byte[] copy of identical
+     * schema text per record - upwards of 10 GB of redundant retention has been observed
+     * in production heap dumps. Removing the header here keeps the value (already
      * deserialized into the KafkaMessageEnvelope above) without the byte[] tail.
      *
      * When the header is present, build a new PubSubMessageHeaders that excludes it rather

--- a/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/api/PubSubMessageDeserializer.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/api/PubSubMessageDeserializer.java
@@ -102,7 +102,13 @@ public class PubSubMessageDeserializer {
     // identical schema text - upwards of 10 GB of redundant per-record retention has been
     // observed in production heap dumps. Removing the header here keeps the value (already
     // deserialized into the KafkaMessageEnvelope above) without the byte[] tail.
-    headers.remove(VENICE_TRANSPORT_PROTOCOL_HEADER);
+    //
+    // Guard with a `get` first: EmptyPubSubMessageHeaders.SINGLETON's remove() throws by
+    // design (it is intentionally immutable), and we want this strip to be a no-op rather
+    // than blow up when callers pass the singleton.
+    if (headers.get(VENICE_TRANSPORT_PROTOCOL_HEADER) != null) {
+      headers.remove(VENICE_TRANSPORT_PROTOCOL_HEADER);
+    }
     // When enabled, prefer Venice's own producer timestamp when the pub-sub system timestamp is
     // missing or zero. Some pub-sub systems do not provide reliable per-message timestamps.
     // Venice always embeds a producer timestamp in the KafkaMessageEnvelope, so we can fall back

--- a/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/api/PubSubMessageDeserializer.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/api/PubSubMessageDeserializer.java
@@ -91,6 +91,18 @@ public class PubSubMessageDeserializer {
     if (value == null) {
       value = valueSerializer.deserialize(valueBytes, getEnvelope(key.getKeyHeaderByte()));
     }
+    // Strip the protocol-schema header before constructing ImmutablePubSubMessage. Its sole
+    // purpose is forward-compat schema bootstrap during deserialization (above), and once we
+    // have the value envelope it is dead weight in heap.
+    //
+    // The header value is the entire Avro schema for KafkaMessageEnvelope (~16 KB JSON text)
+    // and is attached to roughly every message on the wire. With back-pressure on the
+    // StoreBufferService drainer (e.g. during a gzip-Inflater GCLocker stall) the queue can
+    // grow to hundreds of thousands of messages, each pinning its own ~16 KB byte[] copy of
+    // identical schema text - upwards of 10 GB of redundant per-record retention has been
+    // observed in production heap dumps. Removing the header here keeps the value (already
+    // deserialized into the KafkaMessageEnvelope above) without the byte[] tail.
+    headers.remove(VENICE_TRANSPORT_PROTOCOL_HEADER);
     // When enabled, prefer Venice's own producer timestamp when the pub-sub system timestamp is
     // missing or zero. Some pub-sub systems do not provide reliable per-message timestamps.
     // Venice always embeds a producer timestamp in the KafkaMessageEnvelope, so we can fall back

--- a/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/api/PubSubMessageDeserializer.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/api/PubSubMessageDeserializer.java
@@ -104,12 +104,25 @@ public class PubSubMessageDeserializer {
      * observed in production heap dumps. Removing the header here keeps the value (already
      * deserialized into the KafkaMessageEnvelope above) without the byte[] tail.
      *
-     * Guard with a `get` first: EmptyPubSubMessageHeaders.SINGLETON's remove() throws by
-     * design (it is intentionally immutable), and we want this strip to be a no-op rather
-     * than blow up when callers pass the singleton.
+     * When the header is present, build a new PubSubMessageHeaders that excludes it rather
+     * than mutating the caller's instance. This avoids two failure modes:
+     *   1) EmptyPubSubMessageHeaders.SINGLETON throws on remove() by design.
+     *   2) Any caller-supplied immutable wrapper would also throw on remove().
+     * It also keeps the deserialize() contract free of an undocumented input-mutation
+     * side effect.
+     *
+     * Common case ('vtp' absent) is a single map lookup with no allocation. Allocating
+     * a small replacement headers object only on the rare path is well within the budget
+     * we're trying to recover.
      */
     if (headers.get(VENICE_TRANSPORT_PROTOCOL_HEADER) != null) {
-      headers.remove(VENICE_TRANSPORT_PROTOCOL_HEADER);
+      PubSubMessageHeaders filtered = new PubSubMessageHeaders();
+      for (PubSubMessageHeader h: headers) {
+        if (!VENICE_TRANSPORT_PROTOCOL_HEADER.equals(h.key())) {
+          filtered.add(h);
+        }
+      }
+      headers = filtered;
     }
     // When enabled, prefer Venice's own producer timestamp when the pub-sub system timestamp is
     // missing or zero. Some pub-sub systems do not provide reliable per-message timestamps.

--- a/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/api/PubSubMessageDeserializer.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/api/PubSubMessageDeserializer.java
@@ -91,21 +91,23 @@ public class PubSubMessageDeserializer {
     if (value == null) {
       value = valueSerializer.deserialize(valueBytes, getEnvelope(key.getKeyHeaderByte()));
     }
-    // Strip the protocol-schema header before constructing ImmutablePubSubMessage. Its sole
-    // purpose is forward-compat schema bootstrap during deserialization (above), and once we
-    // have the value envelope it is dead weight in heap.
-    //
-    // The header value is the entire Avro schema for KafkaMessageEnvelope (~16 KB JSON text)
-    // and is attached to roughly every message on the wire. With back-pressure on the
-    // StoreBufferService drainer (e.g. during a gzip-Inflater GCLocker stall) the queue can
-    // grow to hundreds of thousands of messages, each pinning its own ~16 KB byte[] copy of
-    // identical schema text - upwards of 10 GB of redundant per-record retention has been
-    // observed in production heap dumps. Removing the header here keeps the value (already
-    // deserialized into the KafkaMessageEnvelope above) without the byte[] tail.
-    //
-    // Guard with a `get` first: EmptyPubSubMessageHeaders.SINGLETON's remove() throws by
-    // design (it is intentionally immutable), and we want this strip to be a no-op rather
-    // than blow up when callers pass the singleton.
+    /*
+     * Strip the protocol-schema header before constructing ImmutablePubSubMessage. Its sole
+     * purpose is forward-compat schema bootstrap during deserialization (above), and once we
+     * have the value envelope it is dead weight in heap.
+     *
+     * The header value is the entire Avro schema for KafkaMessageEnvelope (~16 KB JSON text)
+     * and is attached to roughly every message on the wire. With back-pressure on the
+     * StoreBufferService drainer (e.g. during a gzip-Inflater GCLocker stall) the queue can
+     * grow to hundreds of thousands of messages, each pinning its own ~16 KB byte[] copy of
+     * identical schema text - upwards of 10 GB of redundant per-record retention has been
+     * observed in production heap dumps. Removing the header here keeps the value (already
+     * deserialized into the KafkaMessageEnvelope above) without the byte[] tail.
+     *
+     * Guard with a `get` first: EmptyPubSubMessageHeaders.SINGLETON's remove() throws by
+     * design (it is intentionally immutable), and we want this strip to be a no-op rather
+     * than blow up when callers pass the singleton.
+     */
     if (headers.get(VENICE_TRANSPORT_PROTOCOL_HEADER) != null) {
       headers.remove(VENICE_TRANSPORT_PROTOCOL_HEADER);
     }

--- a/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/api/PubSubMessageDeserializer.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/api/PubSubMessageDeserializer.java
@@ -50,10 +50,21 @@ public class PubSubMessageDeserializer {
   /**
    * Deserialize a message from the pubsub specific message format to PubSubMessage.
    *
+   * <p><b>Side effect on {@code headers}:</b> if the input contains
+   * {@link PubSubMessageHeaders#VENICE_TRANSPORT_PROTOCOL_HEADER}, this method strips it via
+   * {@link PubSubMessageHeaders#stripProtocolSchemaHeader} — best-effort in-place when the headers
+   * object is mutable, copy-fallback otherwise. The header carries the entire ~16 KB Avro JSON for
+   * {@code KafkaMessageEnvelope} and is dead weight once the value envelope is built; pinning it
+   * per queued record has been observed to cost upwards of 10 GB on the DaVinci buffer queue
+   * during back-pressure. Callers that need to retain {@code vtp} after this call must pass a
+   * copy. Callers whose {@code headers} reference is shared across reads should pre-strip via
+   * {@link PubSubMessageHeaders#stripProtocolSchemaHeaderCopy} themselves.
+   *
    * @param topicPartition the topic partition from which the message was read
    * @param keyBytes the key bytes of the message
    * @param valueBytes the value bytes of the message
-   * @param headers the headers of the message
+   * @param headers the headers of the message; may be modified in place to remove
+   *                {@link PubSubMessageHeaders#VENICE_TRANSPORT_PROTOCOL_HEADER}
    * @param pubSubPosition the position of the message in the topic partition
    * @param timestamp the timestamp of the message
    * @return the deserialized PubSubMessage

--- a/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/api/PubSubMessageHeader.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/api/PubSubMessageHeader.java
@@ -45,9 +45,13 @@ public class PubSubMessageHeader implements Measurable {
 
   /**
    * TODO: the following estimation doesn't consider the overhead of the internal structure.
+   *
+   * Kafka headers may legally have null values (and {@code ApacheKafkaConsumerAdapter}
+   * passes them through verbatim), so guard the {@code value.length} dereference and
+   * count a null value as zero bytes.
    */
   @Override
   public int getHeapSize() {
-    return key.length() + value.length;
+    return key.length() + (value == null ? 0 : value.length);
   }
 }

--- a/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/api/PubSubMessageHeaders.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/api/PubSubMessageHeaders.java
@@ -67,20 +67,47 @@ public class PubSubMessageHeaders implements Measurable, Iterable<PubSubMessageH
   }
 
   /**
-   * Returns a {@link PubSubMessageHeaders} that does not contain the {@link #VENICE_TRANSPORT_PROTOCOL_HEADER}
-   * (a.k.a. {@code vtp}). The {@code vtp} value is the entire ~16 KB Avro JSON for {@link
-   * com.linkedin.venice.kafka.protocol.KafkaMessageEnvelope}; once the value envelope has been deserialized it
-   * is dead weight and pinning it per queued record has been observed to cost upwards of 10 GB on the DaVinci
-   * ingestion buffer queue during back-pressure.
+   * Returns a {@link PubSubMessageHeaders} without the {@link #VENICE_TRANSPORT_PROTOCOL_HEADER} (a.k.a.
+   * {@code vtp}). The {@code vtp} value is the entire ~16 KB Avro JSON for {@link
+   * com.linkedin.venice.kafka.protocol.KafkaMessageEnvelope}; once the value envelope has been deserialized
+   * it is dead weight and pinning it per queued record has been observed to cost upwards of 10 GB on the
+   * DaVinci ingestion buffer queue during back-pressure.
    *
-   * <p>The input is never mutated. When {@code vtp} is absent the input is returned as-is (no allocation, no
-   * copy). When {@code vtp} is present a new {@link PubSubMessageHeaders} is built containing the remaining
-   * headers; this is safe even for callers that hand in immutable variants whose {@code remove()} throws.
+   * <p>Best-effort: when {@code vtp} is absent the input is returned as-is (no allocation). When present, the
+   * helper attempts an in-place {@code remove} — allocation-free for the production hot path where callers
+   * construct fresh mutable headers per record. If the input is an immutable variant whose {@code remove()}
+   * throws, the helper falls back to building a new headers object without {@code vtp}. Never throws.
+   *
+   * <p>Use {@link #stripProtocolSchemaHeaderCopy} instead when the caller's headers reference is shared
+   * across reads (e.g. an in-memory broker that re-serves the same message), since silent in-place mutation
+   * would corrupt subsequent observers.
    */
   public static PubSubMessageHeaders stripProtocolSchemaHeader(PubSubMessageHeaders headers) {
     if (headers == null || headers.get(VENICE_TRANSPORT_PROTOCOL_HEADER) == null) {
       return headers;
     }
+    try {
+      headers.remove(VENICE_TRANSPORT_PROTOCOL_HEADER);
+      return headers;
+    } catch (UnsupportedOperationException e) {
+      return copyWithoutProtocolSchemaHeader(headers);
+    }
+  }
+
+  /**
+   * Always-copy variant of {@link #stripProtocolSchemaHeader}. Returns the input unchanged when {@code vtp}
+   * is absent (no allocation); otherwise returns a fresh {@link PubSubMessageHeaders} omitting {@code vtp}
+   * and leaves the input untouched. Use this from call sites where the headers reference is shared across
+   * reads.
+   */
+  public static PubSubMessageHeaders stripProtocolSchemaHeaderCopy(PubSubMessageHeaders headers) {
+    if (headers == null || headers.get(VENICE_TRANSPORT_PROTOCOL_HEADER) == null) {
+      return headers;
+    }
+    return copyWithoutProtocolSchemaHeader(headers);
+  }
+
+  private static PubSubMessageHeaders copyWithoutProtocolSchemaHeader(PubSubMessageHeaders headers) {
     PubSubMessageHeaders filtered = new PubSubMessageHeaders();
     for (PubSubMessageHeader h: headers) {
       if (!VENICE_TRANSPORT_PROTOCOL_HEADER.equals(h.key())) {

--- a/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/api/PubSubMessageHeaders.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/api/PubSubMessageHeaders.java
@@ -75,8 +75,10 @@ public class PubSubMessageHeaders implements Measurable, Iterable<PubSubMessageH
    *
    * <p>Best-effort: when {@code vtp} is absent the input is returned as-is (no allocation). When present, the
    * helper attempts an in-place {@code remove} — allocation-free for the production hot path where callers
-   * construct fresh mutable headers per record. If the input is an immutable variant whose {@code remove()}
-   * throws, the helper falls back to building a new headers object without {@code vtp}. Never throws.
+   * construct fresh mutable headers per record. If {@code remove()} throws any {@link RuntimeException}
+   * (e.g. {@code UnsupportedOperationException} from an immutable variant), the helper falls back to
+   * building a new headers object without {@code vtp}. Never throws — the strip is on the deserialization
+   * hot path, where an escaping exception would kill the partition's ingestion thread.
    *
    * <p>Use {@link #stripProtocolSchemaHeaderCopy} instead when the caller's headers reference is shared
    * across reads (e.g. an in-memory broker that re-serves the same message), since silent in-place mutation
@@ -89,7 +91,7 @@ public class PubSubMessageHeaders implements Measurable, Iterable<PubSubMessageH
     try {
       headers.remove(VENICE_TRANSPORT_PROTOCOL_HEADER);
       return headers;
-    } catch (UnsupportedOperationException e) {
+    } catch (RuntimeException e) {
       return copyWithoutProtocolSchemaHeader(headers);
     }
   }

--- a/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/api/PubSubMessageHeaders.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/api/PubSubMessageHeaders.java
@@ -66,6 +66,30 @@ public class PubSubMessageHeaders implements Measurable, Iterable<PubSubMessageH
     return headers.isEmpty();
   }
 
+  /**
+   * Returns a {@link PubSubMessageHeaders} that does not contain the {@link #VENICE_TRANSPORT_PROTOCOL_HEADER}
+   * (a.k.a. {@code vtp}). The {@code vtp} value is the entire ~16 KB Avro JSON for {@link
+   * com.linkedin.venice.kafka.protocol.KafkaMessageEnvelope}; once the value envelope has been deserialized it
+   * is dead weight and pinning it per queued record has been observed to cost upwards of 10 GB on the DaVinci
+   * ingestion buffer queue during back-pressure.
+   *
+   * <p>The input is never mutated. When {@code vtp} is absent the input is returned as-is (no allocation, no
+   * copy). When {@code vtp} is present a new {@link PubSubMessageHeaders} is built containing the remaining
+   * headers; this is safe even for callers that hand in immutable variants whose {@code remove()} throws.
+   */
+  public static PubSubMessageHeaders stripProtocolSchemaHeader(PubSubMessageHeaders headers) {
+    if (headers == null || headers.get(VENICE_TRANSPORT_PROTOCOL_HEADER) == null) {
+      return headers;
+    }
+    PubSubMessageHeaders filtered = new PubSubMessageHeaders();
+    for (PubSubMessageHeader h: headers) {
+      if (!VENICE_TRANSPORT_PROTOCOL_HEADER.equals(h.key())) {
+        filtered.add(h);
+      }
+    }
+    return filtered;
+  }
+
   @Override
   public int getHeapSize() {
     return SHALLOW_CLASS_OVERHEAD + this.headers.getHeapSize();

--- a/internal/venice-common/src/test/java/com/linkedin/venice/pubsub/ImmutablePubSubMessageTest.java
+++ b/internal/venice-common/src/test/java/com/linkedin/venice/pubsub/ImmutablePubSubMessageTest.java
@@ -1,0 +1,87 @@
+package com.linkedin.venice.pubsub;
+
+import static com.linkedin.venice.pubsub.api.PubSubMessageHeaders.VENICE_LEADER_COMPLETION_STATE_HEADER;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
+
+import com.linkedin.venice.kafka.protocol.GUID;
+import com.linkedin.venice.kafka.protocol.KafkaMessageEnvelope;
+import com.linkedin.venice.kafka.protocol.ProducerMetadata;
+import com.linkedin.venice.kafka.protocol.Put;
+import com.linkedin.venice.kafka.protocol.enums.MessageType;
+import com.linkedin.venice.message.KafkaKey;
+import com.linkedin.venice.pubsub.adapter.kafka.common.ApacheKafkaOffsetPosition;
+import com.linkedin.venice.pubsub.api.DefaultPubSubMessage;
+import com.linkedin.venice.pubsub.api.EmptyPubSubMessageHeaders;
+import com.linkedin.venice.pubsub.api.PubSubMessageHeader;
+import com.linkedin.venice.pubsub.api.PubSubMessageHeaders;
+import com.linkedin.venice.pubsub.api.PubSubTopicPartition;
+import java.nio.ByteBuffer;
+import org.testng.annotations.Test;
+
+
+public class ImmutablePubSubMessageTest {
+  private static final PubSubTopicRepository TOPIC_REPOSITORY = new PubSubTopicRepository();
+  private static final PubSubTopicPartition TOPIC_PARTITION =
+      new PubSubTopicPartitionImpl(TOPIC_REPOSITORY.getTopic("test_v1"), 0);
+
+  /**
+   * Capacity accounting in StoreBufferService.QueueNode delegates to
+   * ImmutablePubSubMessage.getHeapSize. If headers are not counted there, queues
+   * can grow well past their byte budget when per-record headers carry payload
+   * (e.g. the 'vpm' view-partition-map or any future custom key).
+   */
+  @Test
+  public void testGetHeapSizeIncludesHeaders() {
+    KafkaKey key = new KafkaKey(MessageType.PUT, "key".getBytes());
+    KafkaMessageEnvelope value = dummyEnvelope();
+
+    DefaultPubSubMessage withoutHeaders = new ImmutablePubSubMessage(
+        key,
+        value,
+        TOPIC_PARTITION,
+        ApacheKafkaOffsetPosition.of(0),
+        0L,
+        0,
+        EmptyPubSubMessageHeaders.SINGLETON);
+
+    PubSubMessageHeaders headers =
+        new PubSubMessageHeaders().add(new PubSubMessageHeader(VENICE_LEADER_COMPLETION_STATE_HEADER, new byte[1024]));
+    DefaultPubSubMessage withHeaders =
+        new ImmutablePubSubMessage(key, value, TOPIC_PARTITION, ApacheKafkaOffsetPosition.of(0), 0L, 0, headers);
+
+    assertTrue(
+        withHeaders.getHeapSize() > withoutHeaders.getHeapSize() + 1024,
+        "getHeapSize() must include the headers payload — saw " + withHeaders.getHeapSize() + " vs "
+            + withoutHeaders.getHeapSize());
+  }
+
+  @Test
+  public void testGetHeapSizeWithNullHeadersDoesNotThrow() {
+    // The 6-arg constructor leaves pubSubMessageHeaders as null. getHeapSize must
+    // tolerate that path (used heavily by tests and the writer code).
+    DefaultPubSubMessage message = new ImmutablePubSubMessage(
+        new KafkaKey(MessageType.PUT, "key".getBytes()),
+        dummyEnvelope(),
+        TOPIC_PARTITION,
+        ApacheKafkaOffsetPosition.of(0),
+        0L,
+        0);
+    assertNotNull(message);
+    assertTrue(message.getHeapSize() > 0, "Heap size must be positive even when headers are null");
+  }
+
+  private static KafkaMessageEnvelope dummyEnvelope() {
+    KafkaMessageEnvelope env = new KafkaMessageEnvelope();
+    env.producerMetadata = new ProducerMetadata();
+    env.producerMetadata.messageTimestamp = 0;
+    env.producerMetadata.messageSequenceNumber = 0;
+    env.producerMetadata.segmentNumber = 0;
+    env.producerMetadata.producerGUID = new GUID();
+    Put put = new Put();
+    put.putValue = ByteBuffer.allocate(8);
+    put.replicationMetadataPayload = ByteBuffer.allocate(0);
+    env.payloadUnion = put;
+    return env;
+  }
+}

--- a/internal/venice-common/src/test/java/com/linkedin/venice/pubsub/ImmutablePubSubMessageTest.java
+++ b/internal/venice-common/src/test/java/com/linkedin/venice/pubsub/ImmutablePubSubMessageTest.java
@@ -57,6 +57,26 @@ public class ImmutablePubSubMessageTest {
   }
 
   @Test
+  public void testGetHeapSizeWithNullHeaderValueDoesNotThrow() {
+    /*
+     * Kafka headers may carry a null value, and ApacheKafkaConsumerAdapter passes them
+     * through to PubSubMessageHeaders.add(key, null). The size accounting must treat
+     * such a header as zero bytes rather than NPE'ing.
+     */
+    PubSubMessageHeaders headersWithNullValue =
+        new PubSubMessageHeaders().add(new PubSubMessageHeader("nullable-key", null));
+    DefaultPubSubMessage message = new ImmutablePubSubMessage(
+        new KafkaKey(MessageType.PUT, "key".getBytes()),
+        dummyEnvelope(),
+        TOPIC_PARTITION,
+        ApacheKafkaOffsetPosition.of(0),
+        0L,
+        0,
+        headersWithNullValue);
+    assertTrue(message.getHeapSize() > 0, "Heap size must be positive even when a header value is null");
+  }
+
+  @Test
   public void testGetHeapSizeWithNullHeadersDoesNotThrow() {
     /*
      * The 6-arg constructor leaves pubSubMessageHeaders as null. getHeapSize must

--- a/internal/venice-common/src/test/java/com/linkedin/venice/pubsub/ImmutablePubSubMessageTest.java
+++ b/internal/venice-common/src/test/java/com/linkedin/venice/pubsub/ImmutablePubSubMessageTest.java
@@ -58,8 +58,10 @@ public class ImmutablePubSubMessageTest {
 
   @Test
   public void testGetHeapSizeWithNullHeadersDoesNotThrow() {
-    // The 6-arg constructor leaves pubSubMessageHeaders as null. getHeapSize must
-    // tolerate that path (used heavily by tests and the writer code).
+    /*
+     * The 6-arg constructor leaves pubSubMessageHeaders as null. getHeapSize must
+     * tolerate that path (used heavily by tests and the writer code).
+     */
     DefaultPubSubMessage message = new ImmutablePubSubMessage(
         new KafkaKey(MessageType.PUT, "key".getBytes()),
         dummyEnvelope(),

--- a/internal/venice-common/src/test/java/com/linkedin/venice/pubsub/api/PubSubMessageDeserializerTest.java
+++ b/internal/venice-common/src/test/java/com/linkedin/venice/pubsub/api/PubSubMessageDeserializerTest.java
@@ -4,7 +4,6 @@ import static com.linkedin.venice.pubsub.api.PubSubMessageHeaders.VENICE_LEADER_
 import static com.linkedin.venice.pubsub.api.PubSubMessageHeaders.VENICE_TRANSPORT_PROTOCOL_HEADER;
 import static org.mockito.Mockito.mock;
 import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertNull;
 
 import com.linkedin.venice.exceptions.VeniceMessageException;
@@ -165,34 +164,6 @@ public class PubSubMessageDeserializerTest {
 
     assertEquals(message.getValue(), value);
     assertEquals(message.getPubSubMessageHeaders(), EmptyPubSubMessageHeaders.SINGLETON);
-  }
-
-  @Test
-  public void testDeserializerDoesNotMutateCallerSuppliedHeaders() {
-    /*
-     * The deserializer must not mutate the headers object the caller passed in: that would
-     * be an undocumented side effect, and in particular it would break callers that hand
-     * in an immutable wrapper. The strip is implemented by building a new headers object
-     * when vtp is present, leaving the caller's headers untouched.
-     */
-    KafkaKey key = new KafkaKey(MessageType.CONTROL_MESSAGE, "key".getBytes());
-    KafkaMessageEnvelope value = getDummyValue();
-    PubSubMessageHeader vtp =
-        new PubSubMessageHeader(VENICE_TRANSPORT_PROTOCOL_HEADER, KafkaMessageEnvelope.SCHEMA$.toString().getBytes());
-    PubSubMessageHeaders input = new PubSubMessageHeaders().add(vtp);
-
-    DefaultPubSubMessage message = messageDeserializer.deserialize(
-        topicPartition,
-        keySerializer.serialize("test", key),
-        valueSerializer.serialize("test", value),
-        input,
-        position,
-        12L);
-
-    assertNotNull(input.get(VENICE_TRANSPORT_PROTOCOL_HEADER), "caller's headers must not be mutated");
-    assertNull(
-        message.getPubSubMessageHeaders().get(VENICE_TRANSPORT_PROTOCOL_HEADER),
-        "the resulting message must not carry vtp");
   }
 
   @Test

--- a/internal/venice-common/src/test/java/com/linkedin/venice/pubsub/api/PubSubMessageDeserializerTest.java
+++ b/internal/venice-common/src/test/java/com/linkedin/venice/pubsub/api/PubSubMessageDeserializerTest.java
@@ -111,8 +111,10 @@ public class PubSubMessageDeserializerTest {
     assertEquals(actualKey.getKey(), key.getKey());
     assertEquals(message.getValue(), value);
     assertEquals(message.getPosition(), position);
-    // The protocol-schema header must not be retained in the resulting message: the schema is
-    // ~16 KB of redundant Avro JSON and queueing it per-record blows up heap during back-pressure.
+    /*
+     * The protocol-schema header must not be retained in the resulting message: the schema is
+     * ~16 KB of redundant Avro JSON and queueing it per-record blows up heap during back-pressure.
+     */
     assertNull(
         message.getPubSubMessageHeaders().get(VENICE_TRANSPORT_PROTOCOL_HEADER),
         "vtp header should be stripped after the protocol schema is consumed");
@@ -120,9 +122,11 @@ public class PubSubMessageDeserializerTest {
 
   @Test
   public void testDeserializerStripsVtpHeaderFromPutMessage() {
-    // Producer attaches the vtp header to the first message of a segment, including PUTs.
-    // The consumer never uses vtp on non-control messages, so it must be stripped to avoid
-    // pinning ~16 KB of schema text per queued record.
+    /*
+     * Producer attaches the vtp header to the first message of a segment, including PUTs.
+     * The consumer never uses vtp on non-control messages, so it must be stripped to avoid
+     * pinning ~16 KB of schema text per queued record.
+     */
     KafkaKey key = new KafkaKey(MessageType.PUT, "key".getBytes());
     KafkaMessageEnvelope value = getDummyValue();
     PubSubMessageHeader vtp =
@@ -143,9 +147,11 @@ public class PubSubMessageDeserializerTest {
 
   @Test
   public void testDeserializerWithEmptyPubSubMessageHeadersSingleton() {
-    // EmptyPubSubMessageHeaders.SINGLETON is intentionally immutable: its remove()
-    // throws UnsupportedOperationException. The vtp strip must be a no-op when the
-    // header isn't present, otherwise it breaks callers passing the singleton.
+    /*
+     * EmptyPubSubMessageHeaders.SINGLETON is intentionally immutable: its remove()
+     * throws UnsupportedOperationException. The vtp strip must be a no-op when the
+     * header isn't present, otherwise it breaks callers passing the singleton.
+     */
     KafkaKey key = new KafkaKey(MessageType.PUT, "key".getBytes());
     KafkaMessageEnvelope value = getDummyValue();
     DefaultPubSubMessage message = messageDeserializer.deserialize(
@@ -162,9 +168,11 @@ public class PubSubMessageDeserializerTest {
 
   @Test
   public void testDeserializerStripsVtpHeaderButPreservesOtherHeaders() {
-    // Stripping vtp must not touch other headers - lcs (leader-complete state), vpm
-    // (view partitions map), or any unknown future header keys must survive deserialization
-    // intact for downstream consumers.
+    /*
+     * Stripping vtp must not touch other headers - lcs (leader-complete state), vpm
+     * (view partitions map), or any unknown future header keys must survive deserialization
+     * intact for downstream consumers.
+     */
     KafkaKey key = new KafkaKey(MessageType.CONTROL_MESSAGE, "key".getBytes());
     KafkaMessageEnvelope value = getDummyValue();
     PubSubMessageHeader vtp =

--- a/internal/venice-common/src/test/java/com/linkedin/venice/pubsub/api/PubSubMessageDeserializerTest.java
+++ b/internal/venice-common/src/test/java/com/linkedin/venice/pubsub/api/PubSubMessageDeserializerTest.java
@@ -142,6 +142,25 @@ public class PubSubMessageDeserializerTest {
   }
 
   @Test
+  public void testDeserializerWithEmptyPubSubMessageHeadersSingleton() {
+    // EmptyPubSubMessageHeaders.SINGLETON is intentionally immutable: its remove()
+    // throws UnsupportedOperationException. The vtp strip must be a no-op when the
+    // header isn't present, otherwise it breaks callers passing the singleton.
+    KafkaKey key = new KafkaKey(MessageType.PUT, "key".getBytes());
+    KafkaMessageEnvelope value = getDummyValue();
+    DefaultPubSubMessage message = messageDeserializer.deserialize(
+        topicPartition,
+        keySerializer.serialize("test", key),
+        valueSerializer.serialize("test", value),
+        EmptyPubSubMessageHeaders.SINGLETON,
+        position,
+        12L);
+
+    assertEquals(message.getValue(), value);
+    assertEquals(message.getPubSubMessageHeaders(), EmptyPubSubMessageHeaders.SINGLETON);
+  }
+
+  @Test
   public void testDeserializerStripsVtpHeaderButPreservesOtherHeaders() {
     // Stripping vtp must not touch other headers - lcs (leader-complete state), vpm
     // (view partitions map), or any unknown future header keys must survive deserialization

--- a/internal/venice-common/src/test/java/com/linkedin/venice/pubsub/api/PubSubMessageDeserializerTest.java
+++ b/internal/venice-common/src/test/java/com/linkedin/venice/pubsub/api/PubSubMessageDeserializerTest.java
@@ -4,6 +4,7 @@ import static com.linkedin.venice.pubsub.api.PubSubMessageHeaders.VENICE_LEADER_
 import static com.linkedin.venice.pubsub.api.PubSubMessageHeaders.VENICE_TRANSPORT_PROTOCOL_HEADER;
 import static org.mockito.Mockito.mock;
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertNull;
 
 import com.linkedin.venice.exceptions.VeniceMessageException;
@@ -164,6 +165,87 @@ public class PubSubMessageDeserializerTest {
 
     assertEquals(message.getValue(), value);
     assertEquals(message.getPubSubMessageHeaders(), EmptyPubSubMessageHeaders.SINGLETON);
+  }
+
+  @Test
+  public void testDeserializerDoesNotMutateCallerSuppliedHeaders() {
+    /*
+     * The deserializer must not mutate the headers object the caller passed in: that would
+     * be an undocumented side effect, and in particular it would break callers that hand
+     * in an immutable wrapper. The strip is implemented by building a new headers object
+     * when vtp is present, leaving the caller's headers untouched.
+     */
+    KafkaKey key = new KafkaKey(MessageType.CONTROL_MESSAGE, "key".getBytes());
+    KafkaMessageEnvelope value = getDummyValue();
+    PubSubMessageHeader vtp =
+        new PubSubMessageHeader(VENICE_TRANSPORT_PROTOCOL_HEADER, KafkaMessageEnvelope.SCHEMA$.toString().getBytes());
+    PubSubMessageHeaders input = new PubSubMessageHeaders().add(vtp);
+
+    DefaultPubSubMessage message = messageDeserializer.deserialize(
+        topicPartition,
+        keySerializer.serialize("test", key),
+        valueSerializer.serialize("test", value),
+        input,
+        position,
+        12L);
+
+    assertNotNull(input.get(VENICE_TRANSPORT_PROTOCOL_HEADER), "caller's headers must not be mutated");
+    assertNull(
+        message.getPubSubMessageHeaders().get(VENICE_TRANSPORT_PROTOCOL_HEADER),
+        "the resulting message must not carry vtp");
+  }
+
+  @Test
+  public void testDeserializerHandlesImmutableNonEmptyHeaders() {
+    /*
+     * Some callers may wrap headers in an immutable variant whose remove() throws even when
+     * the underlying map is non-empty. The strip must work on those without throwing.
+     */
+    KafkaKey key = new KafkaKey(MessageType.CONTROL_MESSAGE, "key".getBytes());
+    KafkaMessageEnvelope value = getDummyValue();
+    PubSubMessageHeader vtp =
+        new PubSubMessageHeader(VENICE_TRANSPORT_PROTOCOL_HEADER, KafkaMessageEnvelope.SCHEMA$.toString().getBytes());
+    PubSubMessageHeader lcs = new PubSubMessageHeader(VENICE_LEADER_COMPLETION_STATE_HEADER, new byte[] { 1 });
+
+    PubSubMessageHeaders immutableNonEmpty = new PubSubMessageHeaders() {
+      private final PubSubMessageHeaders delegate = new PubSubMessageHeaders().add(vtp).add(lcs);
+
+      @Override
+      public PubSubMessageHeader get(String k) {
+        return delegate.get(k);
+      }
+
+      @Override
+      public java.util.Iterator<PubSubMessageHeader> iterator() {
+        return delegate.iterator();
+      }
+
+      @Override
+      public PubSubMessageHeaders remove(String k) {
+        throw new UnsupportedOperationException("immutable");
+      }
+
+      @Override
+      public PubSubMessageHeaders add(PubSubMessageHeader h) {
+        throw new UnsupportedOperationException("immutable");
+      }
+    };
+
+    DefaultPubSubMessage message = messageDeserializer.deserialize(
+        topicPartition,
+        keySerializer.serialize("test", key),
+        valueSerializer.serialize("test", value),
+        immutableNonEmpty,
+        position,
+        12L);
+
+    assertNull(
+        message.getPubSubMessageHeaders().get(VENICE_TRANSPORT_PROTOCOL_HEADER),
+        "vtp must be stripped without mutating the immutable input");
+    assertEquals(
+        message.getPubSubMessageHeaders().get(VENICE_LEADER_COMPLETION_STATE_HEADER).value(),
+        new byte[] { 1 },
+        "non-vtp headers must round-trip via the rebuilt headers");
   }
 
   @Test

--- a/internal/venice-common/src/test/java/com/linkedin/venice/pubsub/api/PubSubMessageDeserializerTest.java
+++ b/internal/venice-common/src/test/java/com/linkedin/venice/pubsub/api/PubSubMessageDeserializerTest.java
@@ -1,8 +1,10 @@
 package com.linkedin.venice.pubsub.api;
 
+import static com.linkedin.venice.pubsub.api.PubSubMessageHeaders.VENICE_LEADER_COMPLETION_STATE_HEADER;
 import static com.linkedin.venice.pubsub.api.PubSubMessageHeaders.VENICE_TRANSPORT_PROTOCOL_HEADER;
 import static org.mockito.Mockito.mock;
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNull;
 
 import com.linkedin.venice.exceptions.VeniceMessageException;
 import com.linkedin.venice.kafka.protocol.GUID;
@@ -109,6 +111,60 @@ public class PubSubMessageDeserializerTest {
     assertEquals(actualKey.getKey(), key.getKey());
     assertEquals(message.getValue(), value);
     assertEquals(message.getPosition(), position);
+    // The protocol-schema header must not be retained in the resulting message: the schema is
+    // ~16 KB of redundant Avro JSON and queueing it per-record blows up heap during back-pressure.
+    assertNull(
+        message.getPubSubMessageHeaders().get(VENICE_TRANSPORT_PROTOCOL_HEADER),
+        "vtp header should be stripped after the protocol schema is consumed");
+  }
+
+  @Test
+  public void testDeserializerStripsVtpHeaderFromPutMessage() {
+    // Producer attaches the vtp header to the first message of a segment, including PUTs.
+    // The consumer never uses vtp on non-control messages, so it must be stripped to avoid
+    // pinning ~16 KB of schema text per queued record.
+    KafkaKey key = new KafkaKey(MessageType.PUT, "key".getBytes());
+    KafkaMessageEnvelope value = getDummyValue();
+    PubSubMessageHeader vtp =
+        new PubSubMessageHeader(VENICE_TRANSPORT_PROTOCOL_HEADER, KafkaMessageEnvelope.SCHEMA$.toString().getBytes());
+    DefaultPubSubMessage message = messageDeserializer.deserialize(
+        topicPartition,
+        keySerializer.serialize("test", key),
+        valueSerializer.serialize("test", value),
+        new PubSubMessageHeaders().add(vtp),
+        position,
+        12L);
+
+    assertNull(
+        message.getPubSubMessageHeaders().get(VENICE_TRANSPORT_PROTOCOL_HEADER),
+        "vtp header should be stripped on non-control messages too");
+    assertEquals(message.getValue(), value);
+  }
+
+  @Test
+  public void testDeserializerStripsVtpHeaderButPreservesOtherHeaders() {
+    // Stripping vtp must not touch other headers - lcs (leader-complete state), vpm
+    // (view partitions map), or any unknown future header keys must survive deserialization
+    // intact for downstream consumers.
+    KafkaKey key = new KafkaKey(MessageType.CONTROL_MESSAGE, "key".getBytes());
+    KafkaMessageEnvelope value = getDummyValue();
+    PubSubMessageHeader vtp =
+        new PubSubMessageHeader(VENICE_TRANSPORT_PROTOCOL_HEADER, KafkaMessageEnvelope.SCHEMA$.toString().getBytes());
+    PubSubMessageHeader lcs = new PubSubMessageHeader(VENICE_LEADER_COMPLETION_STATE_HEADER, new byte[] { 1 });
+    PubSubMessageHeader custom = new PubSubMessageHeader("some-future-header", "payload".getBytes());
+
+    DefaultPubSubMessage message = messageDeserializer.deserialize(
+        topicPartition,
+        keySerializer.serialize("test", key),
+        valueSerializer.serialize("test", value),
+        new PubSubMessageHeaders().add(vtp).add(lcs).add(custom),
+        position,
+        12L);
+
+    PubSubMessageHeaders out = message.getPubSubMessageHeaders();
+    assertNull(out.get(VENICE_TRANSPORT_PROTOCOL_HEADER), "vtp must be stripped");
+    assertEquals(out.get(VENICE_LEADER_COMPLETION_STATE_HEADER).value(), new byte[] { 1 }, "lcs must be preserved");
+    assertEquals(out.get("some-future-header").value(), "payload".getBytes(), "unknown headers must be preserved");
   }
 
   @Test

--- a/internal/venice-common/src/test/java/com/linkedin/venice/pubsub/api/PubSubMessageHeadersTest.java
+++ b/internal/venice-common/src/test/java/com/linkedin/venice/pubsub/api/PubSubMessageHeadersTest.java
@@ -1,7 +1,11 @@
 package com.linkedin.venice.pubsub.api;
 
+import static com.linkedin.venice.pubsub.api.PubSubMessageHeaders.VENICE_LEADER_COMPLETION_STATE_HEADER;
+import static com.linkedin.venice.pubsub.api.PubSubMessageHeaders.VENICE_TRANSPORT_PROTOCOL_HEADER;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertSame;
 import static org.testng.Assert.assertTrue;
 
 import java.util.List;
@@ -25,5 +29,33 @@ public class PubSubMessageHeadersTest {
     assertTrue(headerList.contains(new PubSubMessageHeader("key-1", "val-1".getBytes())));
     assertTrue(headerList.contains(new PubSubMessageHeader("key-0", "val-0-prime".getBytes())));
     assertTrue(headerList.contains(new PubSubMessageHeader("key-3", "val-3".getBytes())));
+  }
+
+  @Test
+  public void testStripProtocolSchemaHeaderReturnsInputWhenVtpAbsent() {
+    // Absent-case must be allocation-free: return the same instance.
+    PubSubMessageHeaders headers =
+        new PubSubMessageHeaders().add(VENICE_LEADER_COMPLETION_STATE_HEADER, new byte[] { 1 });
+    assertSame(PubSubMessageHeaders.stripProtocolSchemaHeader(headers), headers);
+  }
+
+  @Test
+  public void testStripProtocolSchemaHeaderHandlesNullInput() {
+    assertNull(PubSubMessageHeaders.stripProtocolSchemaHeader(null));
+  }
+
+  @Test
+  public void testStripProtocolSchemaHeaderRemovesVtpAndPreservesOthers() {
+    PubSubMessageHeaders input = new PubSubMessageHeaders().add(VENICE_TRANSPORT_PROTOCOL_HEADER, "schema".getBytes())
+        .add(VENICE_LEADER_COMPLETION_STATE_HEADER, new byte[] { 1 })
+        .add("custom", "payload".getBytes());
+
+    PubSubMessageHeaders out = PubSubMessageHeaders.stripProtocolSchemaHeader(input);
+
+    assertNull(out.get(VENICE_TRANSPORT_PROTOCOL_HEADER), "vtp must be stripped");
+    assertEquals(out.get(VENICE_LEADER_COMPLETION_STATE_HEADER).value(), new byte[] { 1 }, "lcs must be preserved");
+    assertEquals(out.get("custom").value(), "payload".getBytes(), "unknown headers must be preserved");
+    // Caller's input must not be mutated.
+    assertNotNull(input.get(VENICE_TRANSPORT_PROTOCOL_HEADER), "input headers must not be mutated");
   }
 }

--- a/internal/venice-common/src/test/java/com/linkedin/venice/pubsub/api/PubSubMessageHeadersTest.java
+++ b/internal/venice-common/src/test/java/com/linkedin/venice/pubsub/api/PubSubMessageHeadersTest.java
@@ -93,6 +93,38 @@ public class PubSubMessageHeadersTest {
   }
 
   @Test
+  public void testStripProtocolSchemaHeaderCatchesAnyRuntimeExceptionFromRemove() {
+    // The Javadoc promises "Never throws" because the strip runs on the ingestion hot path.
+    // A subclass whose remove() throws something other than UnsupportedOperationException
+    // (e.g. IllegalStateException) must still be handled by the copy fallback.
+    PubSubMessageHeader vtp = new PubSubMessageHeader(VENICE_TRANSPORT_PROTOCOL_HEADER, "schema".getBytes());
+    PubSubMessageHeader lcs = new PubSubMessageHeader(VENICE_LEADER_COMPLETION_STATE_HEADER, new byte[] { 1 });
+    PubSubMessageHeaders input = new PubSubMessageHeaders() {
+      private final PubSubMessageHeaders delegate = new PubSubMessageHeaders().add(vtp).add(lcs);
+
+      @Override
+      public PubSubMessageHeader get(String k) {
+        return delegate.get(k);
+      }
+
+      @Override
+      public java.util.Iterator<PubSubMessageHeader> iterator() {
+        return delegate.iterator();
+      }
+
+      @Override
+      public PubSubMessageHeaders remove(String k) {
+        throw new IllegalStateException("simulated invariant violation");
+      }
+    };
+
+    PubSubMessageHeaders out = PubSubMessageHeaders.stripProtocolSchemaHeader(input);
+
+    assertNull(out.get(VENICE_TRANSPORT_PROTOCOL_HEADER), "vtp must be absent after strip");
+    assertEquals(out.get(VENICE_LEADER_COMPLETION_STATE_HEADER).value(), new byte[] { 1 }, "lcs must be preserved");
+  }
+
+  @Test
   public void testStripProtocolSchemaHeaderCopyAlwaysReturnsFreshInstanceWhenVtpPresent() {
     PubSubMessageHeaders input = new PubSubMessageHeaders().add(VENICE_TRANSPORT_PROTOCOL_HEADER, "schema".getBytes())
         .add(VENICE_LEADER_COMPLETION_STATE_HEADER, new byte[] { 1 });

--- a/internal/venice-common/src/test/java/com/linkedin/venice/pubsub/api/PubSubMessageHeadersTest.java
+++ b/internal/venice-common/src/test/java/com/linkedin/venice/pubsub/api/PubSubMessageHeadersTest.java
@@ -45,17 +45,74 @@ public class PubSubMessageHeadersTest {
   }
 
   @Test
-  public void testStripProtocolSchemaHeaderRemovesVtpAndPreservesOthers() {
+  public void testStripProtocolSchemaHeaderMutatesInPlaceForMutableInput() {
+    // Production hot path: mutable headers + vtp present. Helper removes vtp in place
+    // (no allocation) and returns the same instance.
     PubSubMessageHeaders input = new PubSubMessageHeaders().add(VENICE_TRANSPORT_PROTOCOL_HEADER, "schema".getBytes())
         .add(VENICE_LEADER_COMPLETION_STATE_HEADER, new byte[] { 1 })
         .add("custom", "payload".getBytes());
 
     PubSubMessageHeaders out = PubSubMessageHeaders.stripProtocolSchemaHeader(input);
 
+    assertSame(out, input, "mutable input should be modified in place, not copied");
     assertNull(out.get(VENICE_TRANSPORT_PROTOCOL_HEADER), "vtp must be stripped");
     assertEquals(out.get(VENICE_LEADER_COMPLETION_STATE_HEADER).value(), new byte[] { 1 }, "lcs must be preserved");
     assertEquals(out.get("custom").value(), "payload".getBytes(), "unknown headers must be preserved");
-    // Caller's input must not be mutated.
-    assertNotNull(input.get(VENICE_TRANSPORT_PROTOCOL_HEADER), "input headers must not be mutated");
+  }
+
+  @Test
+  public void testStripProtocolSchemaHeaderFallsBackToCopyForImmutableInput() {
+    // Immutable wrapper whose remove() throws: helper must catch and return a fresh copy
+    // without vtp. Input is left untouched.
+    PubSubMessageHeader vtp = new PubSubMessageHeader(VENICE_TRANSPORT_PROTOCOL_HEADER, "schema".getBytes());
+    PubSubMessageHeader lcs = new PubSubMessageHeader(VENICE_LEADER_COMPLETION_STATE_HEADER, new byte[] { 1 });
+    PubSubMessageHeaders input = new PubSubMessageHeaders() {
+      private final PubSubMessageHeaders delegate = new PubSubMessageHeaders().add(vtp).add(lcs);
+
+      @Override
+      public PubSubMessageHeader get(String k) {
+        return delegate.get(k);
+      }
+
+      @Override
+      public java.util.Iterator<PubSubMessageHeader> iterator() {
+        return delegate.iterator();
+      }
+
+      @Override
+      public PubSubMessageHeaders remove(String k) {
+        throw new UnsupportedOperationException("immutable");
+      }
+    };
+
+    PubSubMessageHeaders out = PubSubMessageHeaders.stripProtocolSchemaHeader(input);
+
+    assertNull(out.get(VENICE_TRANSPORT_PROTOCOL_HEADER), "vtp must be absent in output");
+    assertEquals(out.get(VENICE_LEADER_COMPLETION_STATE_HEADER).value(), new byte[] { 1 }, "lcs must be preserved");
+    assertNotNull(input.get(VENICE_TRANSPORT_PROTOCOL_HEADER), "immutable input must not be mutated");
+  }
+
+  @Test
+  public void testStripProtocolSchemaHeaderCopyAlwaysReturnsFreshInstanceWhenVtpPresent() {
+    PubSubMessageHeaders input = new PubSubMessageHeaders().add(VENICE_TRANSPORT_PROTOCOL_HEADER, "schema".getBytes())
+        .add(VENICE_LEADER_COMPLETION_STATE_HEADER, new byte[] { 1 });
+
+    PubSubMessageHeaders out = PubSubMessageHeaders.stripProtocolSchemaHeaderCopy(input);
+
+    assertNull(out.get(VENICE_TRANSPORT_PROTOCOL_HEADER), "vtp must be absent in output");
+    assertEquals(out.get(VENICE_LEADER_COMPLETION_STATE_HEADER).value(), new byte[] { 1 }, "lcs must be preserved");
+    assertNotNull(input.get(VENICE_TRANSPORT_PROTOCOL_HEADER), "shared input must not be mutated");
+  }
+
+  @Test
+  public void testStripProtocolSchemaHeaderCopyReturnsInputWhenVtpAbsent() {
+    PubSubMessageHeaders headers =
+        new PubSubMessageHeaders().add(VENICE_LEADER_COMPLETION_STATE_HEADER, new byte[] { 1 });
+    assertSame(PubSubMessageHeaders.stripProtocolSchemaHeaderCopy(headers), headers);
+  }
+
+  @Test
+  public void testStripProtocolSchemaHeaderCopyHandlesNullInput() {
+    assertNull(PubSubMessageHeaders.stripProtocolSchemaHeaderCopy(null));
   }
 }

--- a/internal/venice-test-common/src/main/java/com/linkedin/venice/pubsub/mock/adapter/consumer/poll/AbstractPollStrategy.java
+++ b/internal/venice-test-common/src/main/java/com/linkedin/venice/pubsub/mock/adapter/consumer/poll/AbstractPollStrategy.java
@@ -1,11 +1,15 @@
 package com.linkedin.venice.pubsub.mock.adapter.consumer.poll;
 
+import static com.linkedin.venice.pubsub.api.PubSubMessageHeaders.VENICE_TRANSPORT_PROTOCOL_HEADER;
+
 import com.linkedin.venice.controller.kafka.AdminTopicUtils;
 import com.linkedin.venice.kafka.protocol.KafkaMessageEnvelope;
 import com.linkedin.venice.kafka.protocol.Put;
 import com.linkedin.venice.kafka.protocol.enums.MessageType;
 import com.linkedin.venice.pubsub.ImmutablePubSubMessage;
 import com.linkedin.venice.pubsub.api.DefaultPubSubMessage;
+import com.linkedin.venice.pubsub.api.PubSubMessageHeader;
+import com.linkedin.venice.pubsub.api.PubSubMessageHeaders;
 import com.linkedin.venice.pubsub.api.PubSubTopicPartition;
 import com.linkedin.venice.pubsub.mock.InMemoryPubSubBroker;
 import com.linkedin.venice.pubsub.mock.InMemoryPubSubMessage;
@@ -93,7 +97,7 @@ public abstract class AbstractPollStrategy implements PollStrategy {
             nextPosition,
             System.currentTimeMillis(),
             -1,
-            message.get().headers);
+            stripProtocolSchemaHeader(message.get().headers));
         if (!records.containsKey(pubSubTopicPartition)) {
           records.put(pubSubTopicPartition, new ArrayList<>());
         }
@@ -116,5 +120,26 @@ public abstract class AbstractPollStrategy implements PollStrategy {
       PubSubTopicPartition topicPartition,
       InMemoryPubSubPosition position) {
     positionMap.put(topicPartition, position.getNextPosition());
+  }
+
+  /*
+   * Mirror the protocol-schema header strip done by PubSubMessageDeserializer.deserialize. The mock poll
+   * path bypasses the real deserializer, so without this the queued ImmutablePubSubMessage would still
+   * carry the ~16 KB Avro schema in 'vtp' that production code already discards once the value envelope
+   * is built. With ImmutablePubSubMessage.getHeapSize now counting headers, retaining 'vtp' here would
+   * push per-record size over the small bufferCapacityPerDrainer used by tests (10 KB), causing
+   * MemoryBoundBlockingQueue.put to block indefinitely.
+   */
+  private static PubSubMessageHeaders stripProtocolSchemaHeader(PubSubMessageHeaders headers) {
+    if (headers == null || headers.get(VENICE_TRANSPORT_PROTOCOL_HEADER) == null) {
+      return headers;
+    }
+    PubSubMessageHeaders filtered = new PubSubMessageHeaders();
+    for (PubSubMessageHeader h: headers) {
+      if (!VENICE_TRANSPORT_PROTOCOL_HEADER.equals(h.key())) {
+        filtered.add(h);
+      }
+    }
+    return filtered;
   }
 }

--- a/internal/venice-test-common/src/main/java/com/linkedin/venice/pubsub/mock/adapter/consumer/poll/AbstractPollStrategy.java
+++ b/internal/venice-test-common/src/main/java/com/linkedin/venice/pubsub/mock/adapter/consumer/poll/AbstractPollStrategy.java
@@ -1,14 +1,11 @@
 package com.linkedin.venice.pubsub.mock.adapter.consumer.poll;
 
-import static com.linkedin.venice.pubsub.api.PubSubMessageHeaders.VENICE_TRANSPORT_PROTOCOL_HEADER;
-
 import com.linkedin.venice.controller.kafka.AdminTopicUtils;
 import com.linkedin.venice.kafka.protocol.KafkaMessageEnvelope;
 import com.linkedin.venice.kafka.protocol.Put;
 import com.linkedin.venice.kafka.protocol.enums.MessageType;
 import com.linkedin.venice.pubsub.ImmutablePubSubMessage;
 import com.linkedin.venice.pubsub.api.DefaultPubSubMessage;
-import com.linkedin.venice.pubsub.api.PubSubMessageHeader;
 import com.linkedin.venice.pubsub.api.PubSubMessageHeaders;
 import com.linkedin.venice.pubsub.api.PubSubTopicPartition;
 import com.linkedin.venice.pubsub.mock.InMemoryPubSubBroker;
@@ -97,7 +94,15 @@ public abstract class AbstractPollStrategy implements PollStrategy {
             nextPosition,
             System.currentTimeMillis(),
             -1,
-            stripProtocolSchemaHeader(message.get().headers));
+            /*
+             * Mirror the protocol-schema header strip done by PubSubMessageDeserializer.deserialize. The mock
+             * poll path bypasses the real deserializer, so without this the queued ImmutablePubSubMessage
+             * would still carry the ~16 KB Avro schema in 'vtp' that production code already discards once
+             * the value envelope is built. With ImmutablePubSubMessage.getHeapSize now counting headers,
+             * retaining 'vtp' here would push per-record size over the small bufferCapacityPerDrainer used
+             * by tests (10 KB), causing MemoryBoundBlockingQueue.put to block indefinitely.
+             */
+            PubSubMessageHeaders.stripProtocolSchemaHeader(message.get().headers));
         if (!records.containsKey(pubSubTopicPartition)) {
           records.put(pubSubTopicPartition, new ArrayList<>());
         }
@@ -120,26 +125,5 @@ public abstract class AbstractPollStrategy implements PollStrategy {
       PubSubTopicPartition topicPartition,
       InMemoryPubSubPosition position) {
     positionMap.put(topicPartition, position.getNextPosition());
-  }
-
-  /*
-   * Mirror the protocol-schema header strip done by PubSubMessageDeserializer.deserialize. The mock poll
-   * path bypasses the real deserializer, so without this the queued ImmutablePubSubMessage would still
-   * carry the ~16 KB Avro schema in 'vtp' that production code already discards once the value envelope
-   * is built. With ImmutablePubSubMessage.getHeapSize now counting headers, retaining 'vtp' here would
-   * push per-record size over the small bufferCapacityPerDrainer used by tests (10 KB), causing
-   * MemoryBoundBlockingQueue.put to block indefinitely.
-   */
-  private static PubSubMessageHeaders stripProtocolSchemaHeader(PubSubMessageHeaders headers) {
-    if (headers == null || headers.get(VENICE_TRANSPORT_PROTOCOL_HEADER) == null) {
-      return headers;
-    }
-    PubSubMessageHeaders filtered = new PubSubMessageHeaders();
-    for (PubSubMessageHeader h: headers) {
-      if (!VENICE_TRANSPORT_PROTOCOL_HEADER.equals(h.key())) {
-        filtered.add(h);
-      }
-    }
-    return filtered;
   }
 }

--- a/internal/venice-test-common/src/main/java/com/linkedin/venice/pubsub/mock/adapter/consumer/poll/AbstractPollStrategy.java
+++ b/internal/venice-test-common/src/main/java/com/linkedin/venice/pubsub/mock/adapter/consumer/poll/AbstractPollStrategy.java
@@ -101,8 +101,11 @@ public abstract class AbstractPollStrategy implements PollStrategy {
              * the value envelope is built. With ImmutablePubSubMessage.getHeapSize now counting headers,
              * retaining 'vtp' here would push per-record size over the small bufferCapacityPerDrainer used
              * by tests (10 KB), causing MemoryBoundBlockingQueue.put to block indefinitely.
+             *
+             * Use the copy variant: InMemoryPubSubMessage.headers is shared across re-consumes of the same
+             * offset, so in-place mutation would corrupt subsequent reads.
              */
-            PubSubMessageHeaders.stripProtocolSchemaHeader(message.get().headers));
+            PubSubMessageHeaders.stripProtocolSchemaHeaderCopy(message.get().headers));
         if (!records.containsKey(pubSubTopicPartition)) {
           records.put(pubSubTopicPartition, new ArrayList<>());
         }


### PR DESCRIPTION
## Summary

Two related changes that together close out a heap-retention path on the DaVinci ingestion buffer queue:

1. **Strip the `vtp` (`VENICE_TRANSPORT_PROTOCOL_HEADER`) byte[] from `PubSubMessageHeaders` inside `PubSubMessageDeserializer`** once the schema has been used. This header carries the entire Avro JSON schema for `KafkaMessageEnvelope` (~16 KB per record) and is dead weight after deserialization.
2. **Include `pubSubMessageHeaders` in `ImmutablePubSubMessage.getHeapSize()`**. `StoreBufferService.QueueNode.getHeapSize()` delegates to it for byte-budget accounting; previously the headers were silently invisible to the budget, so the queue could grow well past it.

## Why

Heap dumps captured from a DaVinci consumer application during recurring OOMs (one of which was an active incident; another was a similar incident the prior year) all show the same signature:

| Source | Inflater threads | Queue depth | `vtp` byte[16482] count | byte[16K-1M] total |
|---|---:|---:|---:|---:|
| OOM dump A | 3 | ~900 K | ~645 K | ~10.4 GB |
| OOM dump B | 1 | ~750 K | ~670 K | ~10.8 GB |
| OOM dump C | 3 | ~770 K | ~650 K | ~10.4 GB |
| Calm baseline | 0 | ~1.3 K | 0 | ~0.6 GB |

Three independent OOMs across two replicas of the application + an 11-day span all show the same shape: ~10 GB of `vtp` byte[16482] held in the `StoreBufferService` queue, alongside SharedKafkaConsumer threads stuck in `java.util.zip.Inflater.inflateBytesBytes` (JNI critical region, GCLocker held → GC blocked).

The mechanism: gzip Kafka batch decompression on the SharedKafkaConsumer thread enters a JNI critical region. While the GCLocker is held, the drainer can't make allocation progress either, so the StoreBufferService queue grows. Every queued `ImmutablePubSubMessage` carries its own deserialized `PubSubMessageHeader` whose `value` is the 16 KB byte[] for `vtp`. The 16 KB byte[]s are not deduplicated by the JVM (each comes from a fresh wire message), so the heap fills with redundant schema text. With ~700 K–900 K queued records pinning their own copies, the JVM exhausts its heap budget.

## Why both fixes

The strip alone removes the current dominant contributor (`vtp`). The `getHeapSize` fix prevents the same retention-undercounting pattern from recurring with any other header (`vpm` view-partitions-map, `lcs`, future custom keys). Without it, the queue's byte budget remains blind to all header payload — anyone adding a fat header in the future would hit the same OOM.

## Safety

**On the strip:**
- `VENICE_TRANSPORT_PROTOCOL_HEADER` has only two references in production code: `VeniceWriter` writes it; `PubSubMessageDeserializer` reads it. Verified via `grep -rn VENICE_TRANSPORT_PROTOCOL_HEADER --include='*.java'`.
- All other downstream callers of `PubSubMessage.getPubSubMessageHeaders()` look up specific keys — `lcs` (`getAndUpdateLeaderCompletedState`, `LeaderFollowerStoreIngestionTask:2556`), `vpm` (`ViewUtils.extractViewPartitionMap`), and `EXECUTION_ID` (`AdminConsumptionTask:921`). None read `vtp`.
- The strip is unconditional w.r.t. message type (applies on PUT/UPDATE/DELETE as well as control messages). Correct because `VeniceWriter.getHeaders` (`writer.java:1786-87`) attaches `vtp` to the first message of every segment regardless of message type.
- The strip is implemented as a shared helper `PubSubMessageHeaders.stripProtocolSchemaHeader(...)` with best-effort, never-throws semantics:
  - **Common case (`vtp` absent):** single map lookup, zero allocation, returns the input unchanged.
  - **Production hot path (mutable headers + `vtp` present):** in-place `remove`, zero allocation — the only production caller (`ApacheKafkaConsumerAdapter`) constructs fresh mutable `PubSubMessageHeaders` per `ConsumerRecord`, so in-place mutation is safe and cheaper than rebuilding a wrapper per record.
  - **Immutable wrapper + `vtp` present (incl. `EmptyPubSubMessageHeaders.SINGLETON`):** `remove()` throws → catch wraps any `RuntimeException` and falls back to building a fresh `PubSubMessageHeaders` without `vtp`. Wide catch is intentional: the strip runs on the deserialization hot path, where any escaping exception kills the partition's ingestion thread.
  - **Side effect documented:** `PubSubMessageDeserializer.deserialize(...)` Javadoc now spells out that the input headers may be modified in place. Callers whose headers reference is shared across reads (e.g. an in-memory broker that re-serves the same message) should pre-strip via the always-copy variant `PubSubMessageHeaders.stripProtocolSchemaHeaderCopy(...)`. `AbstractPollStrategy` does exactly that.

**On the `getHeapSize`:**
- Headers are captured at construction and not mutated thereafter (the strip happens before the `ImmutablePubSubMessage` is built), so including them in the size calculation is safe (snapshot semantics).
- Null-guarded for the existing 6-arg constructor that omits headers.
- `PubSubMessageHeader.getHeapSize` was made null-safe for header values (Kafka headers can legally have null values; `ApacheKafkaConsumerAdapter` passes `header.value()` through).
- The pre-existing `InstanceSizeEstimatorTest` (which empirically measures heap usage by allocating real instances and comparing against `getHeapSize`) continues to pass.

## Testing Done

`PubSubMessageHeadersTest` (8 new cases):
- `testStripProtocolSchemaHeaderReturnsInputWhenVtpAbsent` / `testStripProtocolSchemaHeaderHandlesNullInput`: zero-allocation absent and null cases.
- `testStripProtocolSchemaHeaderMutatesInPlaceForMutableInput`: locks in the production hot-path semantics (same instance returned, `vtp` removed in place).
- `testStripProtocolSchemaHeaderFallsBackToCopyForImmutableInput`: passes an inline immutable wrapper whose `remove()` throws `UnsupportedOperationException`; helper catches and returns a fresh `PubSubMessageHeaders` without `vtp`. Asserts the immutable input is left untouched.
- `testStripProtocolSchemaHeaderCatchesAnyRuntimeExceptionFromRemove`: passes an immutable wrapper whose `remove()` throws `IllegalStateException`; verifies the wide `RuntimeException` catch.
- `testStripProtocolSchemaHeaderCopyAlwaysReturnsFreshInstanceWhenVtpPresent` / `testStripProtocolSchemaHeaderCopyReturnsInputWhenVtpAbsent` / `testStripProtocolSchemaHeaderCopyHandlesNullInput`: covers the always-copy variant used from `AbstractPollStrategy`.

`PubSubMessageDeserializerTest` (existing + new):
- `testDeserializerValueWithSchemaFromPubSubMessageHeaders` (updated): asserts `vtp` is gone after a successful control-message schema bootstrap.
- `testDeserializerStripsVtpHeaderFromPutMessage`: covers the writer-side defensive case where `vtp` lands on a non-control message.
- `testDeserializerStripsVtpHeaderButPreservesOtherHeaders`: confirms only `vtp` is removed; `lcs` and unknown future header keys round-trip intact.
- `testDeserializerWithEmptyPubSubMessageHeadersSingleton`: passes the empty-singleton (whose `remove()` throws) through `deserialize(...)` and confirms it doesn't throw.
- `testDeserializerHandlesImmutableNonEmptyHeaders`: passes an inline `PubSubMessageHeaders` subclass whose `remove()` throws on a non-empty payload, asserts the strip still works (now exercises the catch branch in the helper).

`ImmutablePubSubMessageTest` (new):
- `testGetHeapSizeIncludesHeaders`: constructs two messages differing only in headers; the second (with a 1 KB byte[] payload) reports a proportionally larger heap size.
- `testGetHeapSizeWithNullHeadersDoesNotThrow`: asserts the 6-arg null-headers constructor path is safe.
- `testGetHeapSizeWithNullHeaderValueDoesNotThrow`: covers Kafka headers with null values.

All existing `PubSubMessageDeserializerTest` and `InstanceSizeEstimatorTest` tests continue to pass.
