### PR TITLE
[server][da-vinci] Honor IngestionPauseMode by unsubscribing Kafka consumers

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTask.java
@@ -906,7 +906,13 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
     boolean transitioned = false;
     for (PartitionConsumptionState pcs: getPartitionConsumptionStateMap().values()) {
       PauseStateTransition transition = decidePauseTransition(pcs, shouldPause);
-      if (transition == PauseStateTransition.NO_CHANGE) {
+      // Idempotent reconcile: even when the PCS flag already says "paused" (transition ==
+      // NO_CHANGE under shouldPause), a subscription may have crept back via a leader/follower
+      // transition or a topic switch that ran after the initial pause unsubscribe. Force a
+      // re-unsubscribe in that case so ingestion can't resume while shouldPause is still true.
+      boolean forceUnsubscribe = transition == PauseStateTransition.NO_CHANGE && shouldPause && pcs != null
+          && pcs.isStoreLevelPaused() && partitionHasAnyActiveSubscription(pcs);
+      if (transition == PauseStateTransition.NO_CHANGE && !forceUnsubscribe) {
         continue;
       }
       try {
@@ -917,6 +923,11 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
           consumerUnSubscribeAllTopics(pcs);
           LOGGER.info(
               "Store-level pause activated for replica: {} — unsubscribed from Kafka",
+              Utils.getReplicaId(getKafkaVersionTopic(), pcs.getPartition()));
+        } else if (forceUnsubscribe) {
+          consumerUnSubscribeAllTopics(pcs);
+          LOGGER.info(
+              "Store-level pause re-applied for replica: {} — subscription was reattached, unsubscribed again",
               Utils.getReplicaId(getKafkaVersionTopic(), pcs.getPartition()));
         } else { // EXIT_PAUSE
           // Resubscribe BEFORE clearing the flag so quota callbacks stay no-op until the consumer
@@ -3492,21 +3503,27 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
    */
   @Override
   public void consumerUnSubscribeAllTopics(PartitionConsumptionState partitionConsumptionState) {
-    PubSubTopic leaderTopic = partitionConsumptionState.getOffsetRecord().getLeaderTopic(pubSubTopicRepository);
     int partitionId = partitionConsumptionState.getPartition();
-    PubSubTopic primaryTopic;
-    if (partitionConsumptionState.getLeaderFollowerState().equals(LEADER) && leaderTopic != null) {
-      primaryTopic = leaderTopic;
-    } else {
-      primaryTopic = versionTopic;
-    }
-    aggKafkaConsumerService
-        .unsubscribeConsumerFor(versionTopic, new PubSubTopicPartitionImpl(primaryTopic, partitionId));
-    // If the primary topic is a RT and sep-RT is enabled, the leader is also subscribed to the
-    // sep-RT — drop it too so the consumer is fully detached. Mirrors unsubscribeFromTopic.
-    if (isSeparatedRealtimeTopicEnabled() && primaryTopic.isRealTime()) {
+    PubSubTopic leaderTopic = partitionConsumptionState.getOffsetRecord().getLeaderTopic(pubSubTopicRepository);
+
+    // During leader/follower transitions or bootstrap a partition can be transiently subscribed
+    // to BOTH the version topic and a separate leader topic (e.g., RT). Unsubscribe each that is
+    // currently subscribed; consumerHasSubscription() avoids redundant work when a topic isn't
+    // attached.
+    if (consumerHasSubscription(versionTopic, partitionConsumptionState)) {
       aggKafkaConsumerService
-          .unsubscribeConsumerFor(versionTopic, new PubSubTopicPartitionImpl(separateRealTimeTopic, partitionId));
+          .unsubscribeConsumerFor(versionTopic, new PubSubTopicPartitionImpl(versionTopic, partitionId));
+    }
+    if (leaderTopic != null && !leaderTopic.equals(versionTopic)
+        && consumerHasSubscription(leaderTopic, partitionConsumptionState)) {
+      aggKafkaConsumerService
+          .unsubscribeConsumerFor(versionTopic, new PubSubTopicPartitionImpl(leaderTopic, partitionId));
+      // If the leader topic is a RT and sep-RT is enabled, the leader is also subscribed to the
+      // sep-RT — drop it too so the consumer is fully detached. Mirrors unsubscribeFromTopic.
+      if (isSeparatedRealtimeTopicEnabled() && leaderTopic.isRealTime()) {
+        aggKafkaConsumerService
+            .unsubscribeConsumerFor(versionTopic, new PubSubTopicPartitionImpl(separateRealTimeTopic, partitionId));
+      }
     }
 
     /**
@@ -3515,6 +3532,27 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
     if (partitionConsumptionState.getVeniceWriterLazyRef() != null) {
       partitionConsumptionState.getVeniceWriterLazyRef().ifPresent(vw -> vw.closePartition(partitionId));
     }
+  }
+
+  /**
+   * True when this partition has any active Kafka subscription (VT, leader topic, or sep-RT).
+   * Used by {@link #maybeTransitionPauseState} to detect cases where a paused partition has had
+   * a subscription crept back (e.g., a leader/follower transition or a topic switch ran after
+   * the initial pause unsubscribe and re-attached the consumer).
+   */
+  private boolean partitionHasAnyActiveSubscription(PartitionConsumptionState pcs) {
+    if (consumerHasSubscription(versionTopic, pcs)) {
+      return true;
+    }
+    PubSubTopic leaderTopic = pcs.getOffsetRecord().getLeaderTopic(pubSubTopicRepository);
+    if (leaderTopic != null && !leaderTopic.equals(versionTopic) && consumerHasSubscription(leaderTopic, pcs)) {
+      return true;
+    }
+    if (isSeparatedRealtimeTopicEnabled() && separateRealTimeTopic != null
+        && consumerHasSubscription(separateRealTimeTopic, pcs)) {
+      return true;
+    }
+    return false;
   }
 
   @Override

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTask.java
@@ -3494,12 +3494,19 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
   public void consumerUnSubscribeAllTopics(PartitionConsumptionState partitionConsumptionState) {
     PubSubTopic leaderTopic = partitionConsumptionState.getOffsetRecord().getLeaderTopic(pubSubTopicRepository);
     int partitionId = partitionConsumptionState.getPartition();
+    PubSubTopic primaryTopic;
     if (partitionConsumptionState.getLeaderFollowerState().equals(LEADER) && leaderTopic != null) {
-      aggKafkaConsumerService
-          .unsubscribeConsumerFor(versionTopic, new PubSubTopicPartitionImpl(leaderTopic, partitionId));
+      primaryTopic = leaderTopic;
     } else {
+      primaryTopic = versionTopic;
+    }
+    aggKafkaConsumerService
+        .unsubscribeConsumerFor(versionTopic, new PubSubTopicPartitionImpl(primaryTopic, partitionId));
+    // If the primary topic is a RT and sep-RT is enabled, the leader is also subscribed to the
+    // sep-RT — drop it too so the consumer is fully detached. Mirrors unsubscribeFromTopic.
+    if (isSeparatedRealtimeTopicEnabled() && primaryTopic.isRealTime()) {
       aggKafkaConsumerService
-          .unsubscribeConsumerFor(versionTopic, new PubSubTopicPartitionImpl(versionTopic, partitionId));
+          .unsubscribeConsumerFor(versionTopic, new PubSubTopicPartitionImpl(separateRealTimeTopic, partitionId));
     }
 
     /**

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTask.java
@@ -97,6 +97,7 @@ import com.linkedin.venice.storage.protocol.ChunkedValueManifest;
 import com.linkedin.venice.utils.ByteUtils;
 import com.linkedin.venice.utils.LatencyUtils;
 import com.linkedin.venice.utils.PartitionUtils;
+import com.linkedin.venice.utils.RedundantExceptionFilter;
 import com.linkedin.venice.utils.RegionUtils;
 import com.linkedin.venice.utils.SystemTime;
 import com.linkedin.venice.utils.Time;
@@ -212,10 +213,6 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
   private final int localRegionKafkaClusterId;
   protected final Map<String, byte[]> globalRtDivKeyBytesCache;
   private volatile long dataRecoveryCompletionTimeLagThresholdInMs = 0;
-
-  // Edge-triggered: avoids spamming WARN every iteration while store metadata lookup is failing.
-  // Only mutated from the SIT thread (inside maybeTransitionPauseState).
-  private boolean storeRepoLookupFailureLogged = false;
 
   protected final Map<String, VeniceViewWriter> viewWriters;
   protected final boolean hasComplexVenicePartitionerMaterializedView;
@@ -890,19 +887,16 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
     Store store;
     try {
       store = storeRepository.getStoreOrThrow(storeName);
-      if (storeRepoLookupFailureLogged) {
-        LOGGER.info("Store metadata lookup recovered for store: {}", storeName);
-        storeRepoLookupFailureLogged = false;
-      }
     } catch (Exception e) {
-      // Leave pause state as-is and retry next iteration. Log only on the failing-edge so
-      // operators see one WARN when lookups start failing instead of one per iteration.
-      if (!storeRepoLookupFailureLogged) {
+      // Leave pause state as-is and retry next iteration. Throttle the WARN via the shared
+      // RedundantExceptionFilter (default 60s window) so a continuously-failing lookup logs at
+      // most once per window instead of once per SIT iteration.
+      if (!RedundantExceptionFilter.getRedundantExceptionFilter()
+          .isRedundantException(storeName + "-maybeTransitionPauseState-lookup-failure")) {
         LOGGER.warn(
             "Failed to look up store metadata for store: {}; pause/resume transitions will be skipped until the repo recovers",
             storeName,
             e);
-        storeRepoLookupFailureLogged = true;
       }
       return;
     }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTask.java
@@ -46,6 +46,7 @@ import com.linkedin.venice.annotation.VisibleForTesting;
 import com.linkedin.venice.compression.CompressionStrategy;
 import com.linkedin.venice.exceptions.VeniceException;
 import com.linkedin.venice.exceptions.VeniceMessageException;
+import com.linkedin.venice.exceptions.VeniceNoStoreException;
 import com.linkedin.venice.exceptions.VeniceTimeoutException;
 import com.linkedin.venice.exceptions.validation.DuplicateDataException;
 import com.linkedin.venice.exceptions.validation.FatalDataValidationException;
@@ -97,7 +98,6 @@ import com.linkedin.venice.storage.protocol.ChunkedValueManifest;
 import com.linkedin.venice.utils.ByteUtils;
 import com.linkedin.venice.utils.LatencyUtils;
 import com.linkedin.venice.utils.PartitionUtils;
-import com.linkedin.venice.utils.RedundantExceptionFilter;
 import com.linkedin.venice.utils.RegionUtils;
 import com.linkedin.venice.utils.SystemTime;
 import com.linkedin.venice.utils.Time;
@@ -876,27 +876,29 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
   /**
    * Reconciles each PCS's store-level pause state against the current store metadata.
    * <p>
-   * On a transition into paused: fully unsubscribes the Kafka consumer for the current leader
-   * topic (or VT for followers), which covers all Kafka clusters for AA/NR setups. The PCS is
-   * kept alive so observability and the disk-quota no-op guard still work.
-   * On a transition out of paused: clears the flag and resubscribes, reusing the existing
-   * {@link #resubscribe} machinery that rewinds from the persisted offset and handles
-   * leader/follower-specific subscription (local VT for followers, all leader RTs for leaders).
+   * On a transition into paused: removes the partition's current leader topic (or VT for
+   * followers) from every per-broker consumer service via {@link #consumerUnSubscribeAllTopics}.
+   * Note: cross-region RT subscriptions for an A/A leader are managed by the leader's normal A/A
+   * code path, not by this hook — only the topic in the OffsetRecord is dropped here.
+   * On a transition out of paused: resubscribes via {@link #resubscribe}, which rewinds from the
+   * persisted offset to the leader topic recorded in the OffsetRecord (followers: local VT;
+   * leaders: the recorded leader topic).
+   * <p>
+   * The PCS pause flag is set to its target value <em>before</em> the long-running unsubscribe /
+   * resubscribe so the disk-quota no-op guard covers the entire transition window. Each PCS is
+   * processed inside a try/catch so a failure on one partition does not abandon the others.
    */
   void maybeTransitionPauseState() throws InterruptedException {
     Store store;
     try {
       store = storeRepository.getStoreOrThrow(storeName);
-    } catch (Exception e) {
-      // Leave pause state as-is and retry next iteration. Throttle the WARN via the shared
-      // RedundantExceptionFilter (default 60s window) so a continuously-failing lookup logs at
-      // most once per window instead of once per SIT iteration.
-      if (!RedundantExceptionFilter.getRedundantExceptionFilter()
-          .isRedundantException(storeName + "-maybeTransitionPauseState-lookup-failure")) {
-        LOGGER.warn(
-            "Failed to look up store metadata for store: {}; pause/resume transitions will be skipped until the repo recovers",
-            storeName,
-            e);
+    } catch (VeniceNoStoreException e) {
+      // Store metadata is genuinely unavailable (deleted, not yet propagated, etc.). Leave pause
+      // state as-is and retry next iteration. Throttle WARN via the inherited filter so a
+      // continuously-failing lookup logs at most once per window instead of once per SIT
+      // iteration. Other RuntimeExceptions propagate so real bugs surface.
+      if (!REDUNDANT_LOGGING_FILTER.isRedundantException(storeName + "-maybeTransitionPauseState-store-not-found")) {
+        LOGGER.warn("Store {} not found while reconciling pause state; skipping transition.", storeName);
       }
       return;
     }
@@ -904,20 +906,38 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
     boolean transitioned = false;
     for (PartitionConsumptionState pcs: getPartitionConsumptionStateMap().values()) {
       PauseStateTransition transition = decidePauseTransition(pcs, shouldPause);
-      if (transition == PauseStateTransition.ENTER_PAUSE) {
-        consumerUnSubscribeAllTopics(pcs);
-        pcs.setStoreLevelPaused(true);
+      if (transition == PauseStateTransition.NO_CHANGE) {
+        continue;
+      }
+      try {
+        if (transition == PauseStateTransition.ENTER_PAUSE) {
+          // Flip the flag BEFORE the long-running unsubscribe so concurrent disk-quota callbacks
+          // see the new state and no-op for the entire window.
+          pcs.setStoreLevelPaused(true);
+          consumerUnSubscribeAllTopics(pcs);
+          LOGGER.info(
+              "Store-level pause activated for replica: {} — unsubscribed from Kafka",
+              Utils.getReplicaId(getKafkaVersionTopic(), pcs.getPartition()));
+        } else { // EXIT_PAUSE
+          // Resubscribe BEFORE clearing the flag so quota callbacks stay no-op until the consumer
+          // is back online; if resubscribe throws we leave the flag set so the next iteration
+          // retries instead of leaving the partition dark.
+          resubscribe(pcs);
+          pcs.setStoreLevelPaused(false);
+          LOGGER.info(
+              "Store-level pause deactivated for replica: {} — resubscribed from persisted offset",
+              Utils.getReplicaId(getKafkaVersionTopic(), pcs.getPartition()));
+        }
         transitioned = true;
-        LOGGER.info(
-            "Store-level pause activated for replica: {} — unsubscribed from Kafka",
-            Utils.getReplicaId(getKafkaVersionTopic(), pcs.getPartition()));
-      } else if (transition == PauseStateTransition.EXIT_PAUSE) {
-        pcs.setStoreLevelPaused(false);
-        resubscribe(pcs);
-        transitioned = true;
-        LOGGER.info(
-            "Store-level pause deactivated for replica: {} — resubscribed from persisted offset",
-            Utils.getReplicaId(getKafkaVersionTopic(), pcs.getPartition()));
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+        throw e;
+      } catch (Exception e) {
+        LOGGER.error(
+            "Failed to apply pause transition {} for replica: {}; will retry next iteration.",
+            transition,
+            Utils.getReplicaId(getKafkaVersionTopic(), pcs.getPartition()),
+            e);
       }
     }
     if (transitioned) {
@@ -933,8 +953,13 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
   /**
    * Pure decision function: given the current PCS pause flag and the desired pause state, return
    * the transition that needs to happen (if any). Side-effect-free and trivially unit-testable.
+   * Returns NO_CHANGE for a {@code null} PCS — defensive guard mirroring
+   * {@link StoreIngestionTask#shouldSkipQuotaCallbackForStoreLevelPause}.
    */
   static PauseStateTransition decidePauseTransition(PartitionConsumptionState pcs, boolean shouldPause) {
+    if (pcs == null) {
+      return PauseStateTransition.NO_CHANGE;
+    }
     if (shouldPause && !pcs.isStoreLevelPaused()) {
       return PauseStateTransition.ENTER_PAUSE;
     }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTask.java
@@ -905,14 +905,10 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
     boolean shouldPause = shouldPauseForStore(store);
     boolean transitioned = false;
     for (PartitionConsumptionState pcs: getPartitionConsumptionStateMap().values()) {
-      PauseStateTransition transition = decidePauseTransition(pcs, shouldPause);
-      // Idempotent reconcile: even when the PCS flag already says "paused" (transition ==
-      // NO_CHANGE under shouldPause), a subscription may have crept back via a leader/follower
-      // transition or a topic switch that ran after the initial pause unsubscribe. Force a
-      // re-unsubscribe in that case so ingestion can't resume while shouldPause is still true.
-      boolean forceUnsubscribe = transition == PauseStateTransition.NO_CHANGE && shouldPause && pcs != null
-          && pcs.isStoreLevelPaused() && partitionHasAnyActiveSubscription(pcs);
-      if (transition == PauseStateTransition.NO_CHANGE && !forceUnsubscribe) {
+      // Cheap pre-checks (cache the active-subscription probe so it isn't called for null PCS).
+      boolean hasAnyActiveSubscription = pcs != null && partitionHasAnyActiveSubscription(pcs);
+      PauseStateTransition transition = decidePauseTransition(pcs, shouldPause, hasAnyActiveSubscription);
+      if (transition == PauseStateTransition.NO_CHANGE) {
         continue;
       }
       try {
@@ -924,7 +920,7 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
           LOGGER.info(
               "Store-level pause activated for replica: {} — unsubscribed from Kafka",
               Utils.getReplicaId(getKafkaVersionTopic(), pcs.getPartition()));
-        } else if (forceUnsubscribe) {
+        } else if (transition == PauseStateTransition.RECONCILE_FORCE_UNSUBSCRIBE) {
           consumerUnSubscribeAllTopics(pcs);
           LOGGER.info(
               "Store-level pause re-applied for replica: {} — subscription was reattached, unsubscribed again",
@@ -956,23 +952,43 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
     }
   }
 
-  /** Result of evaluating a single PCS against the desired pause state. */
+  /**
+   * Result of evaluating a single PCS against the desired pause state.
+   * {@code RECONCILE_FORCE_UNSUBSCRIBE} fires when the PCS is already flagged paused but a
+   * subscription has crept back (e.g., a leader/follower transition or topic switch reattached
+   * the consumer); the reconcile loop force-unsubscribes again so ingestion can't resume while
+   * shouldPause is still true.
+   */
   enum PauseStateTransition {
-    ENTER_PAUSE, EXIT_PAUSE, NO_CHANGE
+    ENTER_PAUSE, EXIT_PAUSE, RECONCILE_FORCE_UNSUBSCRIBE, NO_CHANGE
   }
 
   /**
-   * Pure decision function: given the current PCS pause flag and the desired pause state, return
-   * the transition that needs to happen (if any). Side-effect-free and trivially unit-testable.
-   * Returns NO_CHANGE for a {@code null} PCS — defensive guard mirroring
+   * Pure decision function: given the current PCS pause flag, the desired pause state, and
+   * whether the partition still has any active Kafka subscription, return the transition that
+   * needs to happen (if any). Side-effect-free and trivially unit-testable.
+   *
+   * <p>{@code RECONCILE_FORCE_UNSUBSCRIBE} fires when {@code shouldPause} is true and the PCS is
+   * already flagged paused but {@code hasAnyActiveSubscription} reports a live subscription —
+   * makes the reconcile loop idempotent against out-of-band re-subscriptions (L/F transitions,
+   * topic switches) that would otherwise leave a paused store ingesting.
+   *
+   * <p>Returns NO_CHANGE for a {@code null} PCS — defensive guard mirroring
    * {@link StoreIngestionTask#shouldSkipQuotaCallbackForStoreLevelPause}.
    */
-  static PauseStateTransition decidePauseTransition(PartitionConsumptionState pcs, boolean shouldPause) {
+  static PauseStateTransition decidePauseTransition(
+      PartitionConsumptionState pcs,
+      boolean shouldPause,
+      boolean hasAnyActiveSubscription) {
     if (pcs == null) {
       return PauseStateTransition.NO_CHANGE;
     }
-    if (shouldPause && !pcs.isStoreLevelPaused()) {
+    boolean isPaused = pcs.isStoreLevelPaused();
+    if (shouldPause && !isPaused) {
       return PauseStateTransition.ENTER_PAUSE;
+    }
+    if (shouldPause && isPaused && hasAnyActiveSubscription) {
+      return PauseStateTransition.RECONCILE_FORCE_UNSUBSCRIBE;
     }
     if (!shouldPause && pcs.isStoreLevelPaused()) {
       return PauseStateTransition.EXIT_PAUSE;

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTask.java
@@ -617,6 +617,7 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
    */
   @Override
   protected void checkLongRunningTaskState() throws InterruptedException {
+    maybeTransitionPauseState();
     boolean pushTimeout = false;
     Set<Integer> timeoutPartitions = null;
     long checkStartTimeInNS = System.nanoTime();
@@ -869,6 +870,49 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
         () -> veniceWriter =
             Lazy.of(() -> constructVeniceWriter(veniceWriterFactory, getVersionTopic().getName(), version, true, 1)),
         getVersionTopic().getName());
+  }
+
+  /**
+   * Reconciles each PCS's store-level pause state against the current store metadata.
+   * <p>
+   * On a transition into paused: fully unsubscribes the Kafka consumer for the current leader
+   * topic (or VT for followers), which covers all Kafka clusters for AA/NR setups. The PCS is
+   * kept alive so observability and the disk-quota no-op guard still work.
+   * On a transition out of paused: clears the flag and resubscribes, reusing the existing
+   * {@link #resubscribe} machinery that rewinds from the persisted offset and handles
+   * leader/follower-specific subscription (local VT for followers, all leader RTs for leaders).
+   */
+  void maybeTransitionPauseState() throws InterruptedException {
+    Store store;
+    try {
+      store = storeRepository.getStoreOrThrow(storeName);
+    } catch (Exception e) {
+      // If the store metadata isn't available, leave pause state as-is and let the next
+      // iteration retry. Don't crash the SIT thread on a transient repo lookup failure.
+      return;
+    }
+    boolean shouldPause = shouldPauseForStore(store);
+    boolean transitioned = false;
+    for (PartitionConsumptionState pcs: getPartitionConsumptionStateMap().values()) {
+      if (shouldPause && !pcs.isStoreLevelPaused()) {
+        consumerUnSubscribeAllTopics(pcs);
+        pcs.setStoreLevelPaused(true);
+        transitioned = true;
+        LOGGER.info(
+            "Store-level pause activated for replica: {} — unsubscribed from Kafka",
+            Utils.getReplicaId(getKafkaVersionTopic(), pcs.getPartition()));
+      } else if (!shouldPause && pcs.isStoreLevelPaused()) {
+        pcs.setStoreLevelPaused(false);
+        resubscribe(pcs);
+        transitioned = true;
+        LOGGER.info(
+            "Store-level pause deactivated for replica: {} — resubscribed from persisted offset",
+            Utils.getReplicaId(getKafkaVersionTopic(), pcs.getPartition()));
+      }
+    }
+    if (transitioned) {
+      versionedIngestionStats.setStoreLevelPausedGauge(storeName, versionNumber, shouldPause);
+    }
   }
 
   protected static boolean checkWhetherToCloseUnusedVeniceWriter(

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTask.java
@@ -904,14 +904,14 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
     }
     boolean shouldPause = shouldPauseForStore(store);
     boolean transitioned = false;
+    // Lazily probe the consumer subscription state once per loop (SIT-wide), only when a
+    // RECONCILE_FORCE_UNSUBSCRIBE could fire (shouldPause is set). consumerHasAnySubscription is
+    // a single fast call against aggKafkaConsumerService; consumerUnSubscribeAllTopics itself is
+    // self-gating per topic, so triggering reconcile when only some partitions are subscribed is
+    // benign (no-ops for the others).
+    boolean anySubscriptionForSit = shouldPause && consumerHasAnySubscription();
     for (PartitionConsumptionState pcs: getPartitionConsumptionStateMap().values()) {
-      // Lazily probe the consumer subscription only when it could change the decision (i.e., the
-      // RECONCILE_FORCE_UNSUBSCRIBE case: shouldPause + already-paused). For ENTER_PAUSE,
-      // EXIT_PAUSE, and NO_CHANGE the probe's value is irrelevant — avoid the per-loop
-      // consumerHasSubscription scans on every partition for large stores.
-      boolean canReconcileForceUnsubscribe = shouldPause && pcs != null && pcs.isStoreLevelPaused();
-      boolean hasAnyActiveSubscription = canReconcileForceUnsubscribe && partitionHasAnyActiveSubscription(pcs);
-      PauseStateTransition transition = decidePauseTransition(pcs, shouldPause, hasAnyActiveSubscription);
+      PauseStateTransition transition = decidePauseTransition(pcs, shouldPause, anySubscriptionForSit);
       if (transition == PauseStateTransition.NO_CHANGE) {
         continue;
       }
@@ -3552,27 +3552,6 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
     if (partitionConsumptionState.getVeniceWriterLazyRef() != null) {
       partitionConsumptionState.getVeniceWriterLazyRef().ifPresent(vw -> vw.closePartition(partitionId));
     }
-  }
-
-  /**
-   * True when this partition has any active Kafka subscription (VT, leader topic, or sep-RT).
-   * Used by {@link #maybeTransitionPauseState} to detect cases where a paused partition has had
-   * a subscription crept back (e.g., a leader/follower transition or a topic switch ran after
-   * the initial pause unsubscribe and re-attached the consumer).
-   */
-  private boolean partitionHasAnyActiveSubscription(PartitionConsumptionState pcs) {
-    if (consumerHasSubscription(versionTopic, pcs)) {
-      return true;
-    }
-    PubSubTopic leaderTopic = pcs.getOffsetRecord().getLeaderTopic(pubSubTopicRepository);
-    if (leaderTopic != null && !leaderTopic.equals(versionTopic) && consumerHasSubscription(leaderTopic, pcs)) {
-      return true;
-    }
-    if (isSeparatedRealtimeTopicEnabled() && separateRealTimeTopic != null
-        && consumerHasSubscription(separateRealTimeTopic, pcs)) {
-      return true;
-    }
-    return false;
   }
 
   @Override

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTask.java
@@ -905,8 +905,12 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
     boolean shouldPause = shouldPauseForStore(store);
     boolean transitioned = false;
     for (PartitionConsumptionState pcs: getPartitionConsumptionStateMap().values()) {
-      // Cheap pre-checks (cache the active-subscription probe so it isn't called for null PCS).
-      boolean hasAnyActiveSubscription = pcs != null && partitionHasAnyActiveSubscription(pcs);
+      // Lazily probe the consumer subscription only when it could change the decision (i.e., the
+      // RECONCILE_FORCE_UNSUBSCRIBE case: shouldPause + already-paused). For ENTER_PAUSE,
+      // EXIT_PAUSE, and NO_CHANGE the probe's value is irrelevant — avoid the per-loop
+      // consumerHasSubscription scans on every partition for large stores.
+      boolean canReconcileForceUnsubscribe = shouldPause && pcs != null && pcs.isStoreLevelPaused();
+      boolean hasAnyActiveSubscription = canReconcileForceUnsubscribe && partitionHasAnyActiveSubscription(pcs);
       PauseStateTransition transition = decidePauseTransition(pcs, shouldPause, hasAnyActiveSubscription);
       if (transition == PauseStateTransition.NO_CHANGE) {
         continue;

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTask.java
@@ -974,7 +974,7 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
    * topic switches) that would otherwise leave a paused store ingesting.
    *
    * <p>Returns NO_CHANGE for a {@code null} PCS — defensive guard mirroring
-   * {@link StoreIngestionTask#shouldSkipQuotaCallbackForStoreLevelPause}.
+   * {@link StoreIngestionTask#shouldSkipQuotaCallbackForStoreLevelPause(PartitionConsumptionState)}.
    */
   static PauseStateTransition decidePauseTransition(
       PartitionConsumptionState pcs,

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTask.java
@@ -618,10 +618,10 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
    */
   @Override
   protected void checkLongRunningTaskState() throws InterruptedException {
-    maybeTransitionPauseState();
     boolean pushTimeout = false;
     Set<Integer> timeoutPartitions = null;
     long checkStartTimeInNS = System.nanoTime();
+    maybeTransitionPauseState();
     for (PartitionConsumptionState partitionConsumptionState: getPartitionConsumptionStateMap().values()) {
       final int partition = partitionConsumptionState.getPartition();
 
@@ -677,7 +677,7 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
        * online replica continue serving and do not close ingestion task.
        */
       if (!partitionConsumptionState.isComplete() && !partitionConsumptionState.isErrorReported()
-          && LatencyUtils.getElapsedTimeFromMsToMs(
+          && !partitionConsumptionState.isStoreLevelPaused() && LatencyUtils.getElapsedTimeFromMsToMs(
               partitionConsumptionState.getConsumptionStartTimeInMs()) > getBootstrapTimeoutInMs()) {
         if (!pushTimeout) {
           pushTimeout = true;
@@ -935,6 +935,7 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
           // retries instead of leaving the partition dark.
           resubscribe(pcs);
           pcs.setStoreLevelPaused(false);
+          pcs.resetConsumptionStartTimeInMs();
           LOGGER.info(
               "Store-level pause deactivated for replica: {} — resubscribed from persisted offset",
               Utils.getReplicaId(getKafkaVersionTopic(), pcs.getPartition()));
@@ -952,7 +953,16 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
       }
     }
     if (transitioned) {
-      versionedIngestionStats.setStoreLevelPausedGauge(storeName, versionNumber, shouldPause);
+      // Reflect actual post-loop state, not intent — partial-failure cases shouldn't flip the
+      // gauge to 0 while some PCSes remain paused.
+      boolean anyPcsPaused = false;
+      for (PartitionConsumptionState pcs: getPartitionConsumptionStateMap().values()) {
+        if (pcs != null && pcs.isStoreLevelPaused()) {
+          anyPcsPaused = true;
+          break;
+        }
+      }
+      versionedIngestionStats.setStoreLevelPausedGauge(storeName, versionNumber, anyPcsPaused);
     }
   }
 
@@ -3538,9 +3548,10 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
         && consumerHasSubscription(leaderTopic, partitionConsumptionState)) {
       aggKafkaConsumerService
           .unsubscribeConsumerFor(versionTopic, new PubSubTopicPartitionImpl(leaderTopic, partitionId));
-      // If the leader topic is a RT and sep-RT is enabled, the leader is also subscribed to the
-      // sep-RT — drop it too so the consumer is fully detached. Mirrors unsubscribeFromTopic.
-      if (isSeparatedRealtimeTopicEnabled() && leaderTopic.isRealTime()) {
+      // Gate sep-RT unsubscribe on actual subscription to avoid WARN spam from the consumer
+      // delegator when sep-RT isn't currently attached (common during transitions).
+      if (isSeparatedRealtimeTopicEnabled() && leaderTopic.isRealTime() && separateRealTimeTopic != null
+          && consumerHasSubscription(separateRealTimeTopic, partitionConsumptionState)) {
         aggKafkaConsumerService
             .unsubscribeConsumerFor(versionTopic, new PubSubTopicPartitionImpl(separateRealTimeTopic, partitionId));
       }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTask.java
@@ -213,6 +213,10 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
   protected final Map<String, byte[]> globalRtDivKeyBytesCache;
   private volatile long dataRecoveryCompletionTimeLagThresholdInMs = 0;
 
+  // Edge-triggered: avoids spamming WARN every iteration while store metadata lookup is failing.
+  // Only mutated from the SIT thread (inside maybeTransitionPauseState).
+  private boolean storeRepoLookupFailureLogged = false;
+
   protected final Map<String, VeniceViewWriter> viewWriters;
   protected final boolean hasComplexVenicePartitionerMaterializedView;
 
@@ -886,22 +890,34 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
     Store store;
     try {
       store = storeRepository.getStoreOrThrow(storeName);
+      if (storeRepoLookupFailureLogged) {
+        LOGGER.info("Store metadata lookup recovered for store: {}", storeName);
+        storeRepoLookupFailureLogged = false;
+      }
     } catch (Exception e) {
-      // If the store metadata isn't available, leave pause state as-is and let the next
-      // iteration retry. Don't crash the SIT thread on a transient repo lookup failure.
+      // Leave pause state as-is and retry next iteration. Log only on the failing-edge so
+      // operators see one WARN when lookups start failing instead of one per iteration.
+      if (!storeRepoLookupFailureLogged) {
+        LOGGER.warn(
+            "Failed to look up store metadata for store: {}; pause/resume transitions will be skipped until the repo recovers",
+            storeName,
+            e);
+        storeRepoLookupFailureLogged = true;
+      }
       return;
     }
     boolean shouldPause = shouldPauseForStore(store);
     boolean transitioned = false;
     for (PartitionConsumptionState pcs: getPartitionConsumptionStateMap().values()) {
-      if (shouldPause && !pcs.isStoreLevelPaused()) {
+      PauseStateTransition transition = decidePauseTransition(pcs, shouldPause);
+      if (transition == PauseStateTransition.ENTER_PAUSE) {
         consumerUnSubscribeAllTopics(pcs);
         pcs.setStoreLevelPaused(true);
         transitioned = true;
         LOGGER.info(
             "Store-level pause activated for replica: {} — unsubscribed from Kafka",
             Utils.getReplicaId(getKafkaVersionTopic(), pcs.getPartition()));
-      } else if (!shouldPause && pcs.isStoreLevelPaused()) {
+      } else if (transition == PauseStateTransition.EXIT_PAUSE) {
         pcs.setStoreLevelPaused(false);
         resubscribe(pcs);
         transitioned = true;
@@ -913,6 +929,25 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
     if (transitioned) {
       versionedIngestionStats.setStoreLevelPausedGauge(storeName, versionNumber, shouldPause);
     }
+  }
+
+  /** Result of evaluating a single PCS against the desired pause state. */
+  enum PauseStateTransition {
+    ENTER_PAUSE, EXIT_PAUSE, NO_CHANGE
+  }
+
+  /**
+   * Pure decision function: given the current PCS pause flag and the desired pause state, return
+   * the transition that needs to happen (if any). Side-effect-free and trivially unit-testable.
+   */
+  static PauseStateTransition decidePauseTransition(PartitionConsumptionState pcs, boolean shouldPause) {
+    if (shouldPause && !pcs.isStoreLevelPaused()) {
+      return PauseStateTransition.ENTER_PAUSE;
+    }
+    if (!shouldPause && pcs.isStoreLevelPaused()) {
+      return PauseStateTransition.EXIT_PAUSE;
+    }
+    return PauseStateTransition.NO_CHANGE;
   }
 
   protected static boolean checkWhetherToCloseUnusedVeniceWriter(

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/PartitionConsumptionState.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/PartitionConsumptionState.java
@@ -223,8 +223,11 @@ public class PartitionConsumptionState {
    * {@link com.linkedin.venice.meta.IngestionPauseMode} other than NOT_PAUSED. Distinct from the
    * disk-quota pause managed by {@link StorageUtilizationManager} — when this flag is true, quota
    * resume callbacks must no-op so they don't fight the store-level pause.
+   * <p>
+   * Written by the SIT thread but read by disk-quota callbacks invoked from other threads, so it
+   * is {@code volatile} for cross-thread visibility.
    */
-  private boolean storeLevelPaused = false;
+  private volatile boolean storeLevelPaused = false;
 
   /**
    * This hash map will keep a temporary mapping between a key and it's value.

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/PartitionConsumptionState.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/PartitionConsumptionState.java
@@ -216,7 +216,7 @@ public class PartitionConsumptionState {
    * and check timeout in the consumption state check function which runs regularly:
    * {@link LeaderFollowerStoreIngestionTask#checkLongRunningTaskState()}
    */
-  private final long consumptionStartTimeInMs;
+  private long consumptionStartTimeInMs;
 
   /**
    * Tracks whether this partition is currently paused due to a store-level
@@ -965,6 +965,11 @@ public class PartitionConsumptionState {
 
   public long getConsumptionStartTimeInMs() {
     return consumptionStartTimeInMs;
+  }
+
+  /** Resets the bootstrap-timeout clock so paused time isn't counted against the window. */
+  public void resetConsumptionStartTimeInMs() {
+    this.consumptionStartTimeInMs = System.currentTimeMillis();
   }
 
   public boolean isStoreLevelPaused() {

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/PartitionConsumptionState.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/PartitionConsumptionState.java
@@ -219,6 +219,14 @@ public class PartitionConsumptionState {
   private final long consumptionStartTimeInMs;
 
   /**
+   * Tracks whether this partition is currently paused due to a store-level
+   * {@link com.linkedin.venice.meta.IngestionPauseMode} other than NOT_PAUSED. Distinct from the
+   * disk-quota pause managed by {@link StorageUtilizationManager} — when this flag is true, quota
+   * resume callbacks must no-op so they don't fight the store-level pause.
+   */
+  private boolean storeLevelPaused = false;
+
+  /**
    * This hash map will keep a temporary mapping between a key and it's value.
    * get {@link #getTransientRecord(byte[])} and put {@link #setTransientRecord(int, PubSubPosition, byte[], int, GenericRecord)}
    * operation on this map will be invoked from kafka consumer thread.
@@ -954,6 +962,14 @@ public class PartitionConsumptionState {
 
   public long getConsumptionStartTimeInMs() {
     return consumptionStartTimeInMs;
+  }
+
+  public boolean isStoreLevelPaused() {
+    return storeLevelPaused;
+  }
+
+  public void setStoreLevelPaused(boolean storeLevelPaused) {
+    this.storeLevelPaused = storeLevelPaused;
   }
 
   public void setTransientRecord(

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StorageUtilizationManager.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StorageUtilizationManager.java
@@ -343,13 +343,19 @@ public class StorageUtilizationManager implements StoreDataChangedListener {
    * partition without affecting partition subscription
    */
   private void pausePartition(int partition, String consumingTopic) {
-    pausePartition.execute(consumingTopic, partition);
-    this.pausedPartitions.add(partition);
+    // Only record the partition as quota-paused if the underlying consumer was actually paused.
+    // The lambda may no-op if a higher-priority pause source (e.g. store-level IngestionPauseMode)
+    // already owns the consumer; recording it as paused anyway would desynchronize this manager
+    // from real consumer state.
+    if (pausePartition.execute(consumingTopic, partition)) {
+      this.pausedPartitions.add(partition);
+    }
   }
 
   private void resumePartition(int partition, String consumingTopic) {
-    resumePartition.execute(consumingTopic, partition);
-    this.pausedPartitions.remove(partition);
+    if (resumePartition.execute(consumingTopic, partition)) {
+      this.pausedPartitions.remove(partition);
+    }
   }
 
   private void resumeAllPartitions() {

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
@@ -93,6 +93,7 @@ import com.linkedin.venice.kafka.protocol.state.PartitionState;
 import com.linkedin.venice.kafka.protocol.state.StoreVersionState;
 import com.linkedin.venice.message.KafkaKey;
 import com.linkedin.venice.meta.HybridStoreConfig;
+import com.linkedin.venice.meta.IngestionPauseMode;
 import com.linkedin.venice.meta.ReadOnlySchemaRepository;
 import com.linkedin.venice.meta.ReadOnlyStoreRepository;
 import com.linkedin.venice.meta.Store;
@@ -2912,6 +2913,22 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
       LOGGER.info("Subscribed to: {} position: {}", topicPartition, subscribePosition);
     }
     storageUtilizationManager.initPartition(partition);
+
+    // Restart-while-paused: if the store is currently paused, unsubscribe this just-subscribed
+    // partition's Kafka consumer immediately and mark the PCS so the disk-quota callbacks no-op.
+    // Blob transfer was allowed to run normally (so the replica comes up populated) and the
+    // Kafka consumer subscribed so state is initialized — we then fully unsubscribe until
+    // resume, at which point maybeTransitionPauseState will resubscribe from the persisted
+    // offset.
+    PartitionConsumptionState newlySubscribedPcs = partitionConsumptionStateMap.get(partition);
+    if (newlySubscribedPcs != null && shouldPauseForStore(storeRepository.getStoreOrThrow(storeName))
+        && !newlySubscribedPcs.isStoreLevelPaused()) {
+      consumerUnSubscribeAllTopics(newlySubscribedPcs);
+      newlySubscribedPcs.setStoreLevelPaused(true);
+      versionedIngestionStats.setStoreLevelPausedGauge(storeName, versionNumber, true);
+      LOGGER
+          .info("Subscribed partition is store-level paused on startup, unsubscribing immediately: {}", topicPartition);
+    }
   }
 
   /**
@@ -4662,12 +4679,22 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
   }
 
   private void pauseConsumption(String topic, int partitionId) {
+    // Store-level pause takes precedence; no-op here so the two pause sources don't race.
+    PartitionConsumptionState pcs = partitionConsumptionStateMap.get(partitionId);
+    if (pcs != null && pcs.isStoreLevelPaused()) {
+      return;
+    }
     aggKafkaConsumerService.pauseConsumerFor(
         versionTopic,
         new PubSubTopicPartitionImpl(pubSubTopicRepository.getTopic(topic), partitionId));
   }
 
   private void resumeConsumption(String topic, int partitionId) {
+    // Store-level pause takes precedence; no-op here so a quota resume doesn't un-pause us.
+    PartitionConsumptionState pcs = partitionConsumptionStateMap.get(partitionId);
+    if (pcs != null && pcs.isStoreLevelPaused()) {
+      return;
+    }
     aggKafkaConsumerService.resumeConsumerFor(
         versionTopic,
         new PubSubTopicPartitionImpl(pubSubTopicRepository.getTopic(topic), partitionId));
@@ -4737,6 +4764,32 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
     partitionConsumptionState.setActiveKeyCount(ACTIVE_KEY_COUNT_NOT_TRACKED);
     versionedIngestionStats.recordActiveKeyCountInvalidation(storeName, versionNumber);
     hostLevelIngestionStats.recordActiveKeyCountInvalidation();
+  }
+
+  /**
+   * Returns true if this SIT should pause based on the store's current pause mode and this version's role.
+   * Applies uniformly to both Venice servers and DaVinci clients.
+   */
+  boolean shouldPauseForStore(Store store) {
+    return shouldPauseForStore(store, versionNumber);
+  }
+
+  /**
+   * Static, side-effect-free pause decision. Exposed package-private for unit testing.
+   * @param store store metadata (must be non-null)
+   * @param sitVersionNumber the version of the SIT making the decision
+   * @return true if this SIT should pause Kafka consumption
+   */
+  static boolean shouldPauseForStore(Store store, int sitVersionNumber) {
+    IngestionPauseMode mode = store.getIngestionPauseMode();
+    if (mode == null || mode == IngestionPauseMode.NOT_PAUSED) {
+      return false;
+    }
+    if (mode == IngestionPauseMode.ALL_VERSIONS) {
+      return true;
+    }
+    // CURRENT_VERSION: pause only if this SIT's version is the current one
+    return sitVersionNumber == store.getCurrentVersion();
   }
 
   /**

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
@@ -2914,21 +2914,56 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
     }
     storageUtilizationManager.initPartition(partition);
 
-    // Restart-while-paused: if the store is currently paused, unsubscribe this just-subscribed
-    // partition's Kafka consumer immediately and mark the PCS so the disk-quota callbacks no-op.
-    // Blob transfer was allowed to run normally (so the replica comes up populated) and the
-    // Kafka consumer subscribed so state is initialized — we then fully unsubscribe until
-    // resume, at which point maybeTransitionPauseState will resubscribe from the persisted
-    // offset.
+    maybeUnsubscribeOnStartupIfStorePaused(partition, topicPartition);
+  }
+
+  /**
+   * Restart-while-paused hook: if the store is currently paused, unsubscribe this just-subscribed
+   * partition's Kafka consumer immediately and mark the PCS so disk-quota callbacks no-op. Blob
+   * transfer was allowed to run normally (so the replica comes up populated) and the Kafka
+   * consumer subscribed so state is initialized — we then fully unsubscribe until resume, at
+   * which point {@code maybeTransitionPauseState} will resubscribe from the persisted offset.
+   * <p>
+   * Failures (a transient lookup miss, a consumer-pool error mid-unsubscribe) are caught and
+   * logged; the next {@code maybeTransitionPauseState} iteration reconciles the actual state.
+   * Ordering: flag is set before the unsubscribe so quota callbacks see the new state for the
+   * entire window.
+   */
+  private void maybeUnsubscribeOnStartupIfStorePaused(int partition, PubSubTopicPartition topicPartition) {
     PartitionConsumptionState newlySubscribedPcs = partitionConsumptionStateMap.get(partition);
-    if (newlySubscribedPcs != null && shouldPauseForStore(storeRepository.getStoreOrThrow(storeName))
-        && !newlySubscribedPcs.isStoreLevelPaused()) {
-      consumerUnSubscribeAllTopics(newlySubscribedPcs);
+    try {
+      Store store = storeRepository.getStoreOrThrow(storeName);
+      if (!shouldUnsubscribeOnStartup(newlySubscribedPcs, store, versionNumber)) {
+        return;
+      }
       newlySubscribedPcs.setStoreLevelPaused(true);
+      consumerUnSubscribeAllTopics(newlySubscribedPcs);
       versionedIngestionStats.setStoreLevelPausedGauge(storeName, versionNumber, true);
       LOGGER
-          .info("Subscribed partition is store-level paused on startup, unsubscribing immediately: {}", topicPartition);
+          .info("Subscribed partition is store-level paused on startup, unsubscribed immediately: {}", topicPartition);
+    } catch (Exception e) {
+      // Don't fail SUBSCRIBE processing — leave the flag/gauge unset so the next
+      // maybeTransitionPauseState iteration reconciles.
+      if (newlySubscribedPcs != null) {
+        newlySubscribedPcs.setStoreLevelPaused(false);
+      }
+      LOGGER.warn(
+          "Failed to apply restart-while-paused unsubscribe for {}; deferring to next reconcile iteration.",
+          topicPartition,
+          e);
     }
+  }
+
+  /**
+   * Pure decision helper: should the restart-while-paused hook unsubscribe this newly-subscribed
+   * partition? Returns false for null PCS, already-paused PCS, null store, or non-paused store.
+   * Side-effect-free and unit-testable.
+   */
+  static boolean shouldUnsubscribeOnStartup(PartitionConsumptionState pcs, Store store, int sitVersionNumber) {
+    if (pcs == null || pcs.isStoreLevelPaused() || store == null) {
+      return false;
+    }
+    return shouldPauseForStore(store, sitVersionNumber);
   }
 
   /**
@@ -4678,24 +4713,39 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
     aggKafkaConsumerService.resetOffsetFor(versionTopic, new PubSubTopicPartitionImpl(topic, partitionId));
   }
 
-  private void pauseConsumption(String topic, int partitionId) {
+  private boolean pauseConsumption(String topic, int partitionId) {
     // Store-level pause takes precedence; no-op here so the two pause sources don't race.
     if (shouldSkipQuotaCallbackForStoreLevelPause(partitionConsumptionStateMap.get(partitionId))) {
-      return;
+      logQuotaCallbackSuppressed("pauseConsumption", topic, partitionId);
+      return false;
     }
     aggKafkaConsumerService.pauseConsumerFor(
         versionTopic,
         new PubSubTopicPartitionImpl(pubSubTopicRepository.getTopic(topic), partitionId));
+    return true;
   }
 
-  private void resumeConsumption(String topic, int partitionId) {
+  private boolean resumeConsumption(String topic, int partitionId) {
     // Store-level pause takes precedence; no-op here so a quota resume doesn't un-pause us.
     if (shouldSkipQuotaCallbackForStoreLevelPause(partitionConsumptionStateMap.get(partitionId))) {
-      return;
+      logQuotaCallbackSuppressed("resumeConsumption", topic, partitionId);
+      return false;
     }
     aggKafkaConsumerService.resumeConsumerFor(
         versionTopic,
         new PubSubTopicPartitionImpl(pubSubTopicRepository.getTopic(topic), partitionId));
+    return true;
+  }
+
+  private void logQuotaCallbackSuppressed(String callbackName, String topic, int partitionId) {
+    String key = storeName + "-" + callbackName + "-storeLevelPauseSuppressed";
+    if (!REDUNDANT_LOGGING_FILTER.isRedundantException(key)) {
+      LOGGER.info(
+          "Disk-quota {} suppressed for {}-{} because partition is store-level paused.",
+          callbackName,
+          topic,
+          partitionId);
+    }
   }
 
   /**

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
@@ -6103,6 +6103,20 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
       }
 
       /**
+       * Skip partitions whose store is currently paused. Resubscribing here would re-attach the
+       * Kafka consumer that the store-level pause has deliberately torn down; maybeTransitionPauseState
+       * would then re-unsubscribe it on the next reconcile tick, but the brief window allows
+       * records to leak through. The reconcile loop will resubscribe via {@link #resubscribe} on
+       * resume, so this lag-based path can safely defer.
+       */
+      if (pcs.isStoreLevelPaused()) {
+        LOGGER.info(
+            "Skipping lag-based resubscribe for replica: {} because store-level pause is active.",
+            pcs.getReplicaId());
+        continue;
+      }
+
+      /**
        * Skip partitions with an in-flight blob transfer. Resubscribing reopens RocksDB on the final
        * partition directory while blob transfer is still receiving files into the temp directory,
        * causing the post-transfer rename to fail. completeBlobTransferAndSubscribe will subscribe

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
@@ -6110,9 +6110,15 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
        * resume, so this lag-based path can safely defer.
        */
       if (pcs.isStoreLevelPaused()) {
-        LOGGER.info(
-            "Skipping lag-based resubscribe for replica: {} because store-level pause is active.",
-            pcs.getReplicaId());
+        // Throttle via the shared filter — during an operational pause every lagging partition
+        // gets enqueued each heartbeat cycle (~60s), so without throttling a paused store with
+        // N partitions emits N log lines per cycle. Key on storeName so we get one signal per
+        // paused store per filter window instead of one per replica.
+        if (!REDUNDANT_LOGGING_FILTER.isRedundantException(storeName + "-skip-lag-resubscribe-store-paused")) {
+          LOGGER.info(
+              "Skipping lag-based resubscribe for replica: {} because store-level pause is active.",
+              pcs.getReplicaId());
+        }
         continue;
       }
 

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
@@ -2913,57 +2913,6 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
       LOGGER.info("Subscribed to: {} position: {}", topicPartition, subscribePosition);
     }
     storageUtilizationManager.initPartition(partition);
-
-    maybeUnsubscribeOnStartupIfStorePaused(partition, topicPartition);
-  }
-
-  /**
-   * Restart-while-paused hook: if the store is currently paused, unsubscribe this just-subscribed
-   * partition's Kafka consumer immediately and mark the PCS so disk-quota callbacks no-op. Blob
-   * transfer was allowed to run normally (so the replica comes up populated) and the Kafka
-   * consumer subscribed so state is initialized — we then fully unsubscribe until resume, at
-   * which point {@code maybeTransitionPauseState} will resubscribe from the persisted offset.
-   * <p>
-   * Failures (a transient lookup miss, a consumer-pool error mid-unsubscribe) are caught and
-   * logged; the next {@code maybeTransitionPauseState} iteration reconciles the actual state.
-   * Ordering: flag is set before the unsubscribe so quota callbacks see the new state for the
-   * entire window.
-   */
-  private void maybeUnsubscribeOnStartupIfStorePaused(int partition, PubSubTopicPartition topicPartition) {
-    PartitionConsumptionState newlySubscribedPcs = partitionConsumptionStateMap.get(partition);
-    try {
-      Store store = storeRepository.getStoreOrThrow(storeName);
-      if (!shouldUnsubscribeOnStartup(newlySubscribedPcs, store, versionNumber)) {
-        return;
-      }
-      newlySubscribedPcs.setStoreLevelPaused(true);
-      consumerUnSubscribeAllTopics(newlySubscribedPcs);
-      versionedIngestionStats.setStoreLevelPausedGauge(storeName, versionNumber, true);
-      LOGGER
-          .info("Subscribed partition is store-level paused on startup, unsubscribed immediately: {}", topicPartition);
-    } catch (Exception e) {
-      // Don't fail SUBSCRIBE processing — leave the flag/gauge unset so the next
-      // maybeTransitionPauseState iteration reconciles.
-      if (newlySubscribedPcs != null) {
-        newlySubscribedPcs.setStoreLevelPaused(false);
-      }
-      LOGGER.warn(
-          "Failed to apply restart-while-paused unsubscribe for {}; deferring to next reconcile iteration.",
-          topicPartition,
-          e);
-    }
-  }
-
-  /**
-   * Pure decision helper: should the restart-while-paused hook unsubscribe this newly-subscribed
-   * partition? Returns false for null PCS, already-paused PCS, null store, or non-paused store.
-   * Side-effect-free and unit-testable.
-   */
-  static boolean shouldUnsubscribeOnStartup(PartitionConsumptionState pcs, Store store, int sitVersionNumber) {
-    if (pcs == null || pcs.isStoreLevelPaused() || store == null) {
-      return false;
-    }
-    return shouldPauseForStore(store, sitVersionNumber);
   }
 
   /**

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
@@ -4680,8 +4680,7 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
 
   private void pauseConsumption(String topic, int partitionId) {
     // Store-level pause takes precedence; no-op here so the two pause sources don't race.
-    PartitionConsumptionState pcs = partitionConsumptionStateMap.get(partitionId);
-    if (pcs != null && pcs.isStoreLevelPaused()) {
+    if (shouldSkipQuotaCallbackForStoreLevelPause(partitionConsumptionStateMap.get(partitionId))) {
       return;
     }
     aggKafkaConsumerService.pauseConsumerFor(
@@ -4691,8 +4690,7 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
 
   private void resumeConsumption(String topic, int partitionId) {
     // Store-level pause takes precedence; no-op here so a quota resume doesn't un-pause us.
-    PartitionConsumptionState pcs = partitionConsumptionStateMap.get(partitionId);
-    if (pcs != null && pcs.isStoreLevelPaused()) {
+    if (shouldSkipQuotaCallbackForStoreLevelPause(partitionConsumptionStateMap.get(partitionId))) {
       return;
     }
     aggKafkaConsumerService.resumeConsumerFor(
@@ -4764,6 +4762,14 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
     partitionConsumptionState.setActiveKeyCount(ACTIVE_KEY_COUNT_NOT_TRACKED);
     versionedIngestionStats.recordActiveKeyCountInvalidation(storeName, versionNumber);
     hostLevelIngestionStats.recordActiveKeyCountInvalidation();
+  }
+
+  /**
+   * Returns true when a disk-quota pause/resume callback must no-op because the partition is
+   * currently store-level paused. Pure helper to keep the branch unit-testable.
+   */
+  static boolean shouldSkipQuotaCallbackForStoreLevelPause(PartitionConsumptionState pcs) {
+    return pcs != null && pcs.isStoreLevelPaused();
   }
 
   /**

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
@@ -4772,8 +4772,10 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
   }
 
   /**
-   * Returns true if this SIT should pause based on the store's current pause mode and this version's role.
-   * Applies uniformly to both Venice servers and DaVinci clients.
+   * Returns true if this SIT should pause based on the store's current pause mode and, for
+   * {@link IngestionPauseMode#CURRENT_VERSION}, whether this SIT's version number equals
+   * {@link Store#getCurrentVersion()}. Applies uniformly to both Venice servers and DaVinci
+   * clients.
    */
   boolean shouldPauseForStore(Store store) {
     return shouldPauseForStore(store, versionNumber);

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/TopicPartitionConsumerFunction.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/TopicPartitionConsumerFunction.java
@@ -1,5 +1,14 @@
 package com.linkedin.davinci.kafka.consumer;
 
 public interface TopicPartitionConsumerFunction {
-  void execute(String topic, int partition);
+  /**
+   * Apply a pause/resume action on the given topic-partition.
+   *
+   * @return {@code true} if the action was applied to the underlying consumer; {@code false} if
+   *     the implementation chose to no-op (e.g. because a higher-priority pause source — such as
+   *     a store-level {@code IngestionPauseMode} — already owns the consumer state). Callers
+   *     that maintain their own bookkeeping should gate updates on this value to avoid
+   *     desynchronizing from real consumer state.
+   */
+  boolean execute(String topic, int partition);
 }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/AggVersionedIngestionStats.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/AggVersionedIngestionStats.java
@@ -292,6 +292,15 @@ public class AggVersionedIngestionStats
     getIngestionOtelStats(storeName).setIngestionTaskPushTimeoutGauge(version, 0);
   }
 
+  /**
+   * Sets the store-level-paused gauge to 1 (paused) or 0 (not paused) for a store-version.
+   * Driven by {@code StoreIngestionTask.run()} on every transition into/out of the paused state,
+   * so operators can see via dashboards whether the pause took effect across the fleet.
+   */
+  public void setStoreLevelPausedGauge(String storeName, int version, boolean paused) {
+    getStats(storeName, version).setStoreLevelPausedGauge(paused ? 1 : 0);
+  }
+
   public void recordSubscribePrepLatency(String storeName, int version, double value) {
     long currentTimeMs = System.currentTimeMillis();
     // Tehuti metrics

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/IngestionStats.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/IngestionStats.java
@@ -21,6 +21,7 @@ import it.unimi.dsi.fastutil.ints.Int2ObjectMap;
 public class IngestionStats {
   protected static final String INGESTION_TASK_ERROR_GAUGE = "ingestion_task_errored_gauge";
   protected static final String INGESTION_TASK_PUSH_TIMEOUT_GAUGE = "ingestion_task_push_timeout_gauge";
+  protected static final String STORE_LEVEL_PAUSED_GAUGE = "store_level_paused_gauge";
   protected static final String WRITE_COMPUTE_OPERATION_FAILURE = "write_compute_operation_failure";
   protected static final String RECORDS_CONSUMED_METRIC_NAME = "records_consumed";
   protected static final String BYTES_CONSUMED_METRIC_NAME = "bytes_consumed";
@@ -115,6 +116,7 @@ public class IngestionStats {
   private static final MetricConfig METRIC_CONFIG = new MetricConfig();
   private StoreIngestionTask ingestionTask;
   private int ingestionTaskPushTimeoutGauge = 0;
+  private int storeLevelPausedGauge = 0;
   private final Int2ObjectMap<Rate> regionIdToHybridBytesConsumedRateMap;
   private final Int2ObjectMap<Rate> regionIdToHybridRecordsConsumedRateMap;
   private final LongAdderRateGauge recordsConsumedSensor = new LongAdderRateGauge();
@@ -465,6 +467,14 @@ public class IngestionStats {
 
   public int getIngestionTaskPushTimeoutGauge() {
     return ingestionTaskPushTimeoutGauge;
+  }
+
+  public void setStoreLevelPausedGauge(int value) {
+    storeLevelPausedGauge = value;
+  }
+
+  public int getStoreLevelPausedGauge() {
+    return storeLevelPausedGauge;
   }
 
   public double getNearlineProducerToLocalBrokerLatencyAvg() {

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/IngestionStatsReporter.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/IngestionStatsReporter.java
@@ -28,6 +28,7 @@ import static com.linkedin.davinci.stats.IngestionStats.PRODUCER_TO_SOURCE_BROKE
 import static com.linkedin.davinci.stats.IngestionStats.RECORDS_CONSUMED_METRIC_NAME;
 import static com.linkedin.davinci.stats.IngestionStats.SOURCE_BROKER_TO_LEADER_CONSUMER_LATENCY;
 import static com.linkedin.davinci.stats.IngestionStats.STORAGE_QUOTA_USED;
+import static com.linkedin.davinci.stats.IngestionStats.STORE_LEVEL_PAUSED_GAUGE;
 import static com.linkedin.davinci.stats.IngestionStats.SUBSCRIBE_ACTION_PREP_LATENCY;
 import static com.linkedin.davinci.stats.IngestionStats.TIMESTAMP_REGRESSION_DCR_ERROR;
 import static com.linkedin.davinci.stats.IngestionStats.TOMBSTONE_CREATION_DCR;
@@ -74,6 +75,8 @@ public class IngestionStatsReporter extends AbstractVeniceStatsReporter<Ingestio
             this,
             () -> (double) getStats().getIngestionTaskPushTimeoutGauge(),
             INGESTION_TASK_PUSH_TIMEOUT_GAUGE));
+    registerSensor(
+        new IngestionStatsGauge(this, () -> (double) getStats().getStoreLevelPausedGauge(), STORE_LEVEL_PAUSED_GAUGE));
     registerSensor(
         new IngestionStatsGauge(
             this,

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTaskPauseTransitionTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTaskPauseTransitionTest.java
@@ -1,0 +1,44 @@
+package com.linkedin.davinci.kafka.consumer;
+
+import static com.linkedin.davinci.kafka.consumer.LeaderFollowerStoreIngestionTask.PauseStateTransition.ENTER_PAUSE;
+import static com.linkedin.davinci.kafka.consumer.LeaderFollowerStoreIngestionTask.PauseStateTransition.EXIT_PAUSE;
+import static com.linkedin.davinci.kafka.consumer.LeaderFollowerStoreIngestionTask.PauseStateTransition.NO_CHANGE;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertEquals;
+
+import org.testng.annotations.Test;
+
+
+/**
+ * Unit tests for {@link LeaderFollowerStoreIngestionTask#decidePauseTransition} — the pure
+ * decision function that drives {@code maybeTransitionPauseState}'s per-PCS state machine.
+ * Covers all four (shouldPause × isStoreLevelPaused) combinations.
+ */
+public class LeaderFollowerStoreIngestionTaskPauseTransitionTest {
+  private PartitionConsumptionState pcsWithPauseFlag(boolean storeLevelPaused) {
+    PartitionConsumptionState pcs = mock(PartitionConsumptionState.class);
+    when(pcs.isStoreLevelPaused()).thenReturn(storeLevelPaused);
+    return pcs;
+  }
+
+  @Test
+  public void enterPauseWhenShouldPauseAndNotYetPaused() {
+    assertEquals(LeaderFollowerStoreIngestionTask.decidePauseTransition(pcsWithPauseFlag(false), true), ENTER_PAUSE);
+  }
+
+  @Test
+  public void exitPauseWhenShouldNotPauseAndCurrentlyPaused() {
+    assertEquals(LeaderFollowerStoreIngestionTask.decidePauseTransition(pcsWithPauseFlag(true), false), EXIT_PAUSE);
+  }
+
+  @Test
+  public void noChangeWhenAlreadyPausedAndShouldStayPaused() {
+    assertEquals(LeaderFollowerStoreIngestionTask.decidePauseTransition(pcsWithPauseFlag(true), true), NO_CHANGE);
+  }
+
+  @Test
+  public void noChangeWhenNotPausedAndShouldStayUnpaused() {
+    assertEquals(LeaderFollowerStoreIngestionTask.decidePauseTransition(pcsWithPauseFlag(false), false), NO_CHANGE);
+  }
+}

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTaskPauseTransitionTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTaskPauseTransitionTest.java
@@ -7,38 +7,46 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertEquals;
 
+import com.linkedin.davinci.kafka.consumer.LeaderFollowerStoreIngestionTask.PauseStateTransition;
+import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 
 /**
  * Unit tests for {@link LeaderFollowerStoreIngestionTask#decidePauseTransition} — the pure
  * decision function that drives {@code maybeTransitionPauseState}'s per-PCS state machine.
- * Covers all four (shouldPause × isStoreLevelPaused) combinations.
+ * Covers the full (PCS state × shouldPause) truth table, including the null-PCS guard.
  */
 public class LeaderFollowerStoreIngestionTaskPauseTransitionTest {
-  private PartitionConsumptionState pcsWithPauseFlag(boolean storeLevelPaused) {
-    PartitionConsumptionState pcs = mock(PartitionConsumptionState.class);
-    when(pcs.isStoreLevelPaused()).thenReturn(storeLevelPaused);
-    return pcs;
+  /**
+   * Truth table for decidePauseTransition.
+   * Columns: pcsAlreadyPaused (Boolean, null = pass null PCS), shouldPause, expectedTransition, label.
+   */
+  @DataProvider(name = "transitionCases")
+  public Object[][] transitionCases() {
+    return new Object[][] {
+        // Active transitions
+        { Boolean.FALSE, true, ENTER_PAUSE, "fresh PCS + shouldPause -> ENTER" },
+        { Boolean.TRUE, false, EXIT_PAUSE, "paused PCS + !shouldPause -> EXIT" },
+        // Steady-state no-ops
+        { Boolean.TRUE, true, NO_CHANGE, "already paused + still shouldPause -> NO_CHANGE" },
+        { Boolean.FALSE, false, NO_CHANGE, "not paused + !shouldPause -> NO_CHANGE" },
+        // Defensive null-PCS guard (mirrors shouldSkipQuotaCallbackForStoreLevelPause)
+        { null, true, NO_CHANGE, "null PCS + shouldPause -> NO_CHANGE" },
+        { null, false, NO_CHANGE, "null PCS + !shouldPause -> NO_CHANGE" } };
   }
 
-  @Test
-  public void enterPauseWhenShouldPauseAndNotYetPaused() {
-    assertEquals(LeaderFollowerStoreIngestionTask.decidePauseTransition(pcsWithPauseFlag(false), true), ENTER_PAUSE);
-  }
-
-  @Test
-  public void exitPauseWhenShouldNotPauseAndCurrentlyPaused() {
-    assertEquals(LeaderFollowerStoreIngestionTask.decidePauseTransition(pcsWithPauseFlag(true), false), EXIT_PAUSE);
-  }
-
-  @Test
-  public void noChangeWhenAlreadyPausedAndShouldStayPaused() {
-    assertEquals(LeaderFollowerStoreIngestionTask.decidePauseTransition(pcsWithPauseFlag(true), true), NO_CHANGE);
-  }
-
-  @Test
-  public void noChangeWhenNotPausedAndShouldStayUnpaused() {
-    assertEquals(LeaderFollowerStoreIngestionTask.decidePauseTransition(pcsWithPauseFlag(false), false), NO_CHANGE);
+  @Test(dataProvider = "transitionCases")
+  public void decidePauseTransitionTruthTable(
+      Boolean pcsAlreadyPaused,
+      boolean shouldPause,
+      PauseStateTransition expected,
+      String label) {
+    PartitionConsumptionState pcs = null;
+    if (pcsAlreadyPaused != null) {
+      pcs = mock(PartitionConsumptionState.class);
+      when(pcs.isStoreLevelPaused()).thenReturn(pcsAlreadyPaused);
+    }
+    assertEquals(LeaderFollowerStoreIngestionTask.decidePauseTransition(pcs, shouldPause), expected, label);
   }
 }

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTaskPauseTransitionTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTaskPauseTransitionTest.java
@@ -3,6 +3,7 @@ package com.linkedin.davinci.kafka.consumer;
 import static com.linkedin.davinci.kafka.consumer.LeaderFollowerStoreIngestionTask.PauseStateTransition.ENTER_PAUSE;
 import static com.linkedin.davinci.kafka.consumer.LeaderFollowerStoreIngestionTask.PauseStateTransition.EXIT_PAUSE;
 import static com.linkedin.davinci.kafka.consumer.LeaderFollowerStoreIngestionTask.PauseStateTransition.NO_CHANGE;
+import static com.linkedin.davinci.kafka.consumer.LeaderFollowerStoreIngestionTask.PauseStateTransition.RECONCILE_FORCE_UNSUBSCRIBE;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertEquals;
@@ -15,31 +16,45 @@ import org.testng.annotations.Test;
 /**
  * Unit tests for {@link LeaderFollowerStoreIngestionTask#decidePauseTransition} — the pure
  * decision function that drives {@code maybeTransitionPauseState}'s per-PCS state machine.
- * Covers the full (PCS state × shouldPause) truth table, including the null-PCS guard.
+ * Covers the full (PCS state × shouldPause × hasAnyActiveSubscription) truth table including
+ * the null-PCS guard and the {@code RECONCILE_FORCE_UNSUBSCRIBE} branch (paused PCS with a
+ * subscription that crept back).
  */
 public class LeaderFollowerStoreIngestionTaskPauseTransitionTest {
   /**
    * Truth table for decidePauseTransition.
-   * Columns: pcsAlreadyPaused (Boolean, null = pass null PCS), shouldPause, expectedTransition, label.
+   * Columns: pcsAlreadyPaused (Boolean, null = pass null PCS), shouldPause,
+   *          hasAnyActiveSubscription, expectedTransition, label.
    */
   @DataProvider(name = "transitionCases")
   public Object[][] transitionCases() {
     return new Object[][] {
         // Active transitions
-        { Boolean.FALSE, true, ENTER_PAUSE, "fresh PCS + shouldPause -> ENTER" },
-        { Boolean.TRUE, false, EXIT_PAUSE, "paused PCS + !shouldPause -> EXIT" },
+        { Boolean.FALSE, true, false, ENTER_PAUSE, "fresh PCS + shouldPause -> ENTER" },
+        { Boolean.FALSE, true, true, ENTER_PAUSE,
+            "fresh PCS + shouldPause + sub already exists (won't yet, but covers ordering) -> ENTER" },
+        { Boolean.TRUE, false, false, EXIT_PAUSE, "paused PCS + !shouldPause -> EXIT" },
+        { Boolean.TRUE, false, true, EXIT_PAUSE,
+            "paused PCS + !shouldPause + crept-back sub -> EXIT (resume reattaches anyway)" },
+        // Reconcile path: paused flag + still subscribed under shouldPause
+        { Boolean.TRUE, true, true, RECONCILE_FORCE_UNSUBSCRIBE,
+            "paused PCS + shouldPause + sub crept back -> RECONCILE_FORCE_UNSUBSCRIBE" },
         // Steady-state no-ops
-        { Boolean.TRUE, true, NO_CHANGE, "already paused + still shouldPause -> NO_CHANGE" },
-        { Boolean.FALSE, false, NO_CHANGE, "not paused + !shouldPause -> NO_CHANGE" },
-        // Defensive null-PCS guard (mirrors shouldSkipQuotaCallbackForStoreLevelPause)
-        { null, true, NO_CHANGE, "null PCS + shouldPause -> NO_CHANGE" },
-        { null, false, NO_CHANGE, "null PCS + !shouldPause -> NO_CHANGE" } };
+        { Boolean.TRUE, true, false, NO_CHANGE, "already paused, no sub crept back -> NO_CHANGE" },
+        { Boolean.FALSE, false, false, NO_CHANGE, "not paused + !shouldPause -> NO_CHANGE" },
+        { Boolean.FALSE, false, true, NO_CHANGE,
+            "not paused + !shouldPause + dangling sub (won't happen normally) -> NO_CHANGE" },
+        // Defensive null-PCS guard
+        { null, true, true, NO_CHANGE, "null PCS + shouldPause + sub -> NO_CHANGE" },
+        { null, true, false, NO_CHANGE, "null PCS + shouldPause + no sub -> NO_CHANGE" },
+        { null, false, false, NO_CHANGE, "null PCS + !shouldPause + no sub -> NO_CHANGE" } };
   }
 
   @Test(dataProvider = "transitionCases")
   public void decidePauseTransitionTruthTable(
       Boolean pcsAlreadyPaused,
       boolean shouldPause,
+      boolean hasAnyActiveSubscription,
       PauseStateTransition expected,
       String label) {
     PartitionConsumptionState pcs = null;
@@ -47,6 +62,9 @@ public class LeaderFollowerStoreIngestionTaskPauseTransitionTest {
       pcs = mock(PartitionConsumptionState.class);
       when(pcs.isStoreLevelPaused()).thenReturn(pcsAlreadyPaused);
     }
-    assertEquals(LeaderFollowerStoreIngestionTask.decidePauseTransition(pcs, shouldPause), expected, label);
+    assertEquals(
+        LeaderFollowerStoreIngestionTask.decidePauseTransition(pcs, shouldPause, hasAnyActiveSubscription),
+        expected,
+        label);
   }
 }

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/PartitionConsumptionStateTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/PartitionConsumptionStateTest.java
@@ -452,4 +452,21 @@ public class PartitionConsumptionStateTest {
     pcs.initializeUniqueKeyCountHll(lgK);
     return pcs;
   }
+
+  @Test
+  public void testStoreLevelPausedDefaultsToFalse() {
+    PartitionConsumptionState pcs =
+        new PartitionConsumptionState(TOPIC_PARTITION, mock(OffsetRecord.class), pubSubContext, false);
+    assertFalse(pcs.isStoreLevelPaused());
+  }
+
+  @Test
+  public void testSetAndGetStoreLevelPaused() {
+    PartitionConsumptionState pcs =
+        new PartitionConsumptionState(TOPIC_PARTITION, mock(OffsetRecord.class), pubSubContext, false);
+    pcs.setStoreLevelPaused(true);
+    assertTrue(pcs.isStoreLevelPaused());
+    pcs.setStoreLevelPaused(false);
+    assertFalse(pcs.isStoreLevelPaused());
+  }
 }

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/StorageUtilizationManagerTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/StorageUtilizationManagerTest.java
@@ -102,8 +102,8 @@ public class StorageUtilizationManagerTest {
         true,
         false,
         ingestionNotificationDispatcher,
-        (t, p) -> {},
-        (t, p) -> {});
+        (t, p) -> true,
+        (t, p) -> true);
 
     hybridQuotaEnforcer = new StorageUtilizationManager(
         storageEngine,
@@ -115,8 +115,8 @@ public class StorageUtilizationManagerTest {
         true,
         true,
         ingestionNotificationDispatcher,
-        (t, p) -> {},
-        (t, p) -> {});
+        (t, p) -> true,
+        (t, p) -> true);
   }
 
   @Test

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTaskShouldPauseTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTaskShouldPauseTest.java
@@ -98,7 +98,7 @@ public class StoreIngestionTaskShouldPauseTest {
   public Object[][] quotaCallbackCases() {
     return new Object[][] { { Boolean.TRUE, true, "store-level paused -> skip" },
         { Boolean.FALSE, false, "not store-level paused -> proceed" },
-        // PCS can be null if UNSUBSCRIBE tore it down before the quota callback fires.
+        // PCS can be null if an UNSUBSCRIBE has already removed it before the quota callback fires.
         { null, false, "null PCS -> proceed" } };
   }
 

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTaskShouldPauseTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTaskShouldPauseTest.java
@@ -2,19 +2,24 @@ package com.linkedin.davinci.kafka.consumer;
 
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
-import static org.testng.Assert.assertFalse;
-import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.assertEquals;
 
 import com.linkedin.venice.meta.IngestionPauseMode;
 import com.linkedin.venice.meta.Store;
+import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 
 /**
- * Targeted unit tests for {@link StoreIngestionTask#shouldPauseForStore(Store, int)} —
- * the static decision helper used by both the run-time pause transition (in
- * {@code LeaderFollowerStoreIngestionTask.maybeTransitionPauseState}) and the post-subscribe
- * restart-while-paused hook in {@code StoreIngestionTask.validateAndSubscribePartition}.
+ * Targeted unit tests for the static decision helpers on {@link StoreIngestionTask} that drive
+ * the run-time pause transition in {@code LeaderFollowerStoreIngestionTask.maybeTransitionPauseState}
+ * and the post-subscribe restart-while-paused hook in {@code validateAndSubscribePartition}.
+ * Helpers under test:
+ * <ul>
+ *   <li>{@link StoreIngestionTask#shouldPauseForStore(Store, int)}</li>
+ *   <li>{@link StoreIngestionTask#shouldSkipQuotaCallbackForStoreLevelPause}</li>
+ *   <li>{@link StoreIngestionTask#shouldUnsubscribeOnStartup}</li>
+ * </ul>
  */
 public class StoreIngestionTaskShouldPauseTest {
   private static final int CURRENT_VERSION = 5;
@@ -27,51 +32,117 @@ public class StoreIngestionTaskShouldPauseTest {
     return store;
   }
 
-  @Test
-  public void notPausedReturnsFalse() {
-    Store store = storeWithPauseMode(IngestionPauseMode.NOT_PAUSED, CURRENT_VERSION);
-    assertFalse(StoreIngestionTask.shouldPauseForStore(store, CURRENT_VERSION));
-  }
-
-  @Test
-  public void nullModeReturnsFalse() {
-    // Defensive: a store metadata fetch on an older schema could return null.
-    Store store = storeWithPauseMode(null, CURRENT_VERSION);
-    assertFalse(StoreIngestionTask.shouldPauseForStore(store, CURRENT_VERSION));
-  }
-
-  @Test
-  public void allVersionsAlwaysPauses() {
-    Store store = storeWithPauseMode(IngestionPauseMode.ALL_VERSIONS, CURRENT_VERSION);
-    assertTrue(StoreIngestionTask.shouldPauseForStore(store, CURRENT_VERSION));
-    assertTrue(StoreIngestionTask.shouldPauseForStore(store, NON_CURRENT_VERSION));
-  }
-
-  @Test
-  public void currentVersionPausesOnlyCurrent() {
-    Store store = storeWithPauseMode(IngestionPauseMode.CURRENT_VERSION, CURRENT_VERSION);
-    assertTrue(StoreIngestionTask.shouldPauseForStore(store, CURRENT_VERSION));
-    assertFalse(StoreIngestionTask.shouldPauseForStore(store, NON_CURRENT_VERSION));
-  }
-
-  @Test
-  public void quotaCallbackSkipsWhenStoreLevelPaused() {
+  private PartitionConsumptionState pcsAlreadyPaused(boolean alreadyPaused) {
     PartitionConsumptionState pcs = mock(PartitionConsumptionState.class);
-    when(pcs.isStoreLevelPaused()).thenReturn(true);
-    assertTrue(StoreIngestionTask.shouldSkipQuotaCallbackForStoreLevelPause(pcs));
+    when(pcs.isStoreLevelPaused()).thenReturn(alreadyPaused);
+    return pcs;
+  }
+
+  // ----- shouldPauseForStore -----
+
+  /**
+   * Truth table for shouldPauseForStore.
+   * Columns: pauseMode, currentVersion, sitVersion, expected, label.
+   */
+  @DataProvider(name = "shouldPauseCases")
+  public Object[][] shouldPauseCases() {
+    return new Object[][] {
+        // NOT_PAUSED / null -> never pause
+        { IngestionPauseMode.NOT_PAUSED, CURRENT_VERSION, CURRENT_VERSION, false, "NOT_PAUSED" },
+        { null, CURRENT_VERSION, CURRENT_VERSION, false, "null mode (older schema)" },
+        // ALL_VERSIONS -> always pause
+        { IngestionPauseMode.ALL_VERSIONS, CURRENT_VERSION, CURRENT_VERSION, true, "ALL_VERSIONS, current" },
+        { IngestionPauseMode.ALL_VERSIONS, CURRENT_VERSION, NON_CURRENT_VERSION, true, "ALL_VERSIONS, non-current" },
+        // CURRENT_VERSION -> only when SIT version matches
+        { IngestionPauseMode.CURRENT_VERSION, CURRENT_VERSION, CURRENT_VERSION, true, "CURRENT_VERSION, current" },
+        { IngestionPauseMode.CURRENT_VERSION, CURRENT_VERSION, NON_CURRENT_VERSION, false,
+            "CURRENT_VERSION, non-current" } };
+  }
+
+  @Test(dataProvider = "shouldPauseCases")
+  public void shouldPauseForStoreTruthTable(
+      IngestionPauseMode mode,
+      int currentVersion,
+      int sitVersion,
+      boolean expected,
+      String label) {
+    Store store = storeWithPauseMode(mode, currentVersion);
+    assertEquals(StoreIngestionTask.shouldPauseForStore(store, sitVersion), expected, label);
   }
 
   @Test
-  public void quotaCallbackProceedsWhenNotStoreLevelPaused() {
-    PartitionConsumptionState pcs = mock(PartitionConsumptionState.class);
-    when(pcs.isStoreLevelPaused()).thenReturn(false);
-    assertFalse(StoreIngestionTask.shouldSkipQuotaCallbackForStoreLevelPause(pcs));
+  public void currentVersionSwapPausesNewCurrentResumesOldCurrent() {
+    // Simulates a current-version swap (V4 -> V5) under CURRENT_VERSION mode. After the swap,
+    // the now-backup V4's SIT should no longer be paused and the newly-current V5's SIT should
+    // start pausing. Codifies dynamic-rebalance behavior — the static truth table above only
+    // covers a single snapshot, so this test mutates the mocked currentVersion to verify the
+    // decision flips on swap.
+    Store store = mock(Store.class);
+    when(store.getIngestionPauseMode()).thenReturn(IngestionPauseMode.CURRENT_VERSION);
+
+    when(store.getCurrentVersion()).thenReturn(4);
+    assertEquals(StoreIngestionTask.shouldPauseForStore(store, 4), true, "V4 (current) -> paused");
+    assertEquals(StoreIngestionTask.shouldPauseForStore(store, 5), false, "V5 (future) -> not paused");
+
+    when(store.getCurrentVersion()).thenReturn(5);
+    assertEquals(StoreIngestionTask.shouldPauseForStore(store, 4), false, "V4 (backup after swap) -> not paused");
+    assertEquals(StoreIngestionTask.shouldPauseForStore(store, 5), true, "V5 (current after swap) -> paused");
   }
 
-  @Test
-  public void quotaCallbackProceedsWhenPcsIsNull() {
-    // Defensive: partitionConsumptionStateMap.get(partitionId) can return null if a UNSUBSCRIBE
-    // has already torn down the PCS by the time the quota callback fires.
-    assertFalse(StoreIngestionTask.shouldSkipQuotaCallbackForStoreLevelPause(null));
+  // ----- shouldSkipQuotaCallbackForStoreLevelPause -----
+
+  /**
+   * Truth table for the disk-quota callback no-op guard.
+   * Columns: pcsState (Boolean, null = pass null PCS), expected, label.
+   */
+  @DataProvider(name = "quotaCallbackCases")
+  public Object[][] quotaCallbackCases() {
+    return new Object[][] { { Boolean.TRUE, true, "store-level paused -> skip" },
+        { Boolean.FALSE, false, "not store-level paused -> proceed" },
+        // PCS can be null if UNSUBSCRIBE tore it down before the quota callback fires.
+        { null, false, "null PCS -> proceed" } };
+  }
+
+  @Test(dataProvider = "quotaCallbackCases")
+  public void shouldSkipQuotaCallbackTruthTable(Boolean pcsPaused, boolean expected, String label) {
+    PartitionConsumptionState pcs = pcsPaused == null ? null : pcsAlreadyPaused(pcsPaused);
+    assertEquals(StoreIngestionTask.shouldSkipQuotaCallbackForStoreLevelPause(pcs), expected, label);
+  }
+
+  // ----- shouldUnsubscribeOnStartup (restart-while-paused decision) -----
+
+  /**
+   * Truth table for the restart-while-paused decision.
+   * Columns: pcsState (Boolean, null = pass null PCS), pauseMode (null = pass null Store),
+   *          sitVersion, expected, label.
+   */
+  @DataProvider(name = "unsubscribeOnStartupCases")
+  public Object[][] unsubscribeOnStartupCases() {
+    return new Object[][] {
+        // Happy path: store paused, PCS fresh
+        { Boolean.FALSE, IngestionPauseMode.ALL_VERSIONS, CURRENT_VERSION, true, "fresh PCS + ALL_VERSIONS" },
+        // Already paused -> don't double-unsubscribe
+        { Boolean.TRUE, IngestionPauseMode.ALL_VERSIONS, CURRENT_VERSION, false, "already paused PCS" },
+        // Store not paused -> nothing to do
+        { Boolean.FALSE, IngestionPauseMode.NOT_PAUSED, CURRENT_VERSION, false, "store NOT_PAUSED" },
+        // Defensive null guards
+        { null, IngestionPauseMode.ALL_VERSIONS, CURRENT_VERSION, false, "null PCS" },
+        { Boolean.FALSE, null, CURRENT_VERSION, false, "null Store (transient lookup miss)" },
+        // CURRENT_VERSION mode interacts with sitVersion
+        { Boolean.FALSE, IngestionPauseMode.CURRENT_VERSION, CURRENT_VERSION, true, "CURRENT_VERSION mode, current" },
+        { Boolean.FALSE, IngestionPauseMode.CURRENT_VERSION, NON_CURRENT_VERSION, false,
+            "CURRENT_VERSION mode, future version" } };
+  }
+
+  @Test(dataProvider = "unsubscribeOnStartupCases")
+  public void shouldUnsubscribeOnStartupTruthTable(
+      Boolean pcsState,
+      IngestionPauseMode mode,
+      int sitVersion,
+      boolean expected,
+      String label) {
+    PartitionConsumptionState pcs = pcsState == null ? null : pcsAlreadyPaused(pcsState);
+    Store store = mode == null ? null : storeWithPauseMode(mode, CURRENT_VERSION);
+    assertEquals(StoreIngestionTask.shouldUnsubscribeOnStartup(pcs, store, sitVersion), expected, label);
   }
 }

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTaskShouldPauseTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTaskShouldPauseTest.java
@@ -1,0 +1,56 @@
+package com.linkedin.davinci.kafka.consumer;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+
+import com.linkedin.venice.meta.IngestionPauseMode;
+import com.linkedin.venice.meta.Store;
+import org.testng.annotations.Test;
+
+
+/**
+ * Targeted unit tests for {@link StoreIngestionTask#shouldPauseForStore(Store, boolean, int)} —
+ * the static decision helper used by both the run-time pause transition (in
+ * {@code LeaderFollowerStoreIngestionTask.maybeTransitionPauseState}) and the post-subscribe
+ * restart-while-paused hook in {@code StoreIngestionTask.validateAndSubscribePartition}.
+ */
+public class StoreIngestionTaskShouldPauseTest {
+  private static final int CURRENT_VERSION = 5;
+  private static final int NON_CURRENT_VERSION = 4;
+
+  private Store storeWithPauseMode(IngestionPauseMode mode, int currentVersion) {
+    Store store = mock(Store.class);
+    when(store.getIngestionPauseMode()).thenReturn(mode);
+    when(store.getCurrentVersion()).thenReturn(currentVersion);
+    return store;
+  }
+
+  @Test
+  public void notPausedReturnsFalse() {
+    Store store = storeWithPauseMode(IngestionPauseMode.NOT_PAUSED, CURRENT_VERSION);
+    assertFalse(StoreIngestionTask.shouldPauseForStore(store, CURRENT_VERSION));
+  }
+
+  @Test
+  public void nullModeReturnsFalse() {
+    // Defensive: a store metadata fetch on an older schema could return null.
+    Store store = storeWithPauseMode(null, CURRENT_VERSION);
+    assertFalse(StoreIngestionTask.shouldPauseForStore(store, CURRENT_VERSION));
+  }
+
+  @Test
+  public void allVersionsAlwaysPauses() {
+    Store store = storeWithPauseMode(IngestionPauseMode.ALL_VERSIONS, CURRENT_VERSION);
+    assertTrue(StoreIngestionTask.shouldPauseForStore(store, CURRENT_VERSION));
+    assertTrue(StoreIngestionTask.shouldPauseForStore(store, NON_CURRENT_VERSION));
+  }
+
+  @Test
+  public void currentVersionPausesOnlyCurrent() {
+    Store store = storeWithPauseMode(IngestionPauseMode.CURRENT_VERSION, CURRENT_VERSION);
+    assertTrue(StoreIngestionTask.shouldPauseForStore(store, CURRENT_VERSION));
+    assertFalse(StoreIngestionTask.shouldPauseForStore(store, NON_CURRENT_VERSION));
+  }
+}

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTaskShouldPauseTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTaskShouldPauseTest.java
@@ -12,13 +12,12 @@ import org.testng.annotations.Test;
 
 /**
  * Targeted unit tests for the static decision helpers on {@link StoreIngestionTask} that drive
- * the run-time pause transition in {@code LeaderFollowerStoreIngestionTask.maybeTransitionPauseState}
- * and the post-subscribe restart-while-paused hook in {@code validateAndSubscribePartition}.
+ * the run-time pause transition in
+ * {@link LeaderFollowerStoreIngestionTask#maybeTransitionPauseState()}.
  * Helpers under test:
  * <ul>
  *   <li>{@link StoreIngestionTask#shouldPauseForStore(Store, int)}</li>
- *   <li>{@link StoreIngestionTask#shouldSkipQuotaCallbackForStoreLevelPause}</li>
- *   <li>{@link StoreIngestionTask#shouldUnsubscribeOnStartup}</li>
+ *   <li>{@link StoreIngestionTask#shouldSkipQuotaCallbackForStoreLevelPause(PartitionConsumptionState)}</li>
  * </ul>
  */
 public class StoreIngestionTaskShouldPauseTest {
@@ -107,42 +106,5 @@ public class StoreIngestionTaskShouldPauseTest {
   public void shouldSkipQuotaCallbackTruthTable(Boolean pcsPaused, boolean expected, String label) {
     PartitionConsumptionState pcs = pcsPaused == null ? null : pcsAlreadyPaused(pcsPaused);
     assertEquals(StoreIngestionTask.shouldSkipQuotaCallbackForStoreLevelPause(pcs), expected, label);
-  }
-
-  // ----- shouldUnsubscribeOnStartup (restart-while-paused decision) -----
-
-  /**
-   * Truth table for the restart-while-paused decision.
-   * Columns: pcsState (Boolean, null = pass null PCS), pauseMode (null = pass null Store),
-   *          sitVersion, expected, label.
-   */
-  @DataProvider(name = "unsubscribeOnStartupCases")
-  public Object[][] unsubscribeOnStartupCases() {
-    return new Object[][] {
-        // Happy path: store paused, PCS fresh
-        { Boolean.FALSE, IngestionPauseMode.ALL_VERSIONS, CURRENT_VERSION, true, "fresh PCS + ALL_VERSIONS" },
-        // Already paused -> don't double-unsubscribe
-        { Boolean.TRUE, IngestionPauseMode.ALL_VERSIONS, CURRENT_VERSION, false, "already paused PCS" },
-        // Store not paused -> nothing to do
-        { Boolean.FALSE, IngestionPauseMode.NOT_PAUSED, CURRENT_VERSION, false, "store NOT_PAUSED" },
-        // Defensive null guards
-        { null, IngestionPauseMode.ALL_VERSIONS, CURRENT_VERSION, false, "null PCS" },
-        { Boolean.FALSE, null, CURRENT_VERSION, false, "null Store (transient lookup miss)" },
-        // CURRENT_VERSION mode interacts with sitVersion
-        { Boolean.FALSE, IngestionPauseMode.CURRENT_VERSION, CURRENT_VERSION, true, "CURRENT_VERSION mode, current" },
-        { Boolean.FALSE, IngestionPauseMode.CURRENT_VERSION, NON_CURRENT_VERSION, false,
-            "CURRENT_VERSION mode, future version" } };
-  }
-
-  @Test(dataProvider = "unsubscribeOnStartupCases")
-  public void shouldUnsubscribeOnStartupTruthTable(
-      Boolean pcsState,
-      IngestionPauseMode mode,
-      int sitVersion,
-      boolean expected,
-      String label) {
-    PartitionConsumptionState pcs = pcsState == null ? null : pcsAlreadyPaused(pcsState);
-    Store store = mode == null ? null : storeWithPauseMode(mode, CURRENT_VERSION);
-    assertEquals(StoreIngestionTask.shouldUnsubscribeOnStartup(pcs, store, sitVersion), expected, label);
   }
 }

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTaskShouldPauseTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTaskShouldPauseTest.java
@@ -11,7 +11,7 @@ import org.testng.annotations.Test;
 
 
 /**
- * Targeted unit tests for {@link StoreIngestionTask#shouldPauseForStore(Store, boolean, int)} —
+ * Targeted unit tests for {@link StoreIngestionTask#shouldPauseForStore(Store, int)} —
  * the static decision helper used by both the run-time pause transition (in
  * {@code LeaderFollowerStoreIngestionTask.maybeTransitionPauseState}) and the post-subscribe
  * restart-while-paused hook in {@code StoreIngestionTask.validateAndSubscribePartition}.
@@ -52,5 +52,26 @@ public class StoreIngestionTaskShouldPauseTest {
     Store store = storeWithPauseMode(IngestionPauseMode.CURRENT_VERSION, CURRENT_VERSION);
     assertTrue(StoreIngestionTask.shouldPauseForStore(store, CURRENT_VERSION));
     assertFalse(StoreIngestionTask.shouldPauseForStore(store, NON_CURRENT_VERSION));
+  }
+
+  @Test
+  public void quotaCallbackSkipsWhenStoreLevelPaused() {
+    PartitionConsumptionState pcs = mock(PartitionConsumptionState.class);
+    when(pcs.isStoreLevelPaused()).thenReturn(true);
+    assertTrue(StoreIngestionTask.shouldSkipQuotaCallbackForStoreLevelPause(pcs));
+  }
+
+  @Test
+  public void quotaCallbackProceedsWhenNotStoreLevelPaused() {
+    PartitionConsumptionState pcs = mock(PartitionConsumptionState.class);
+    when(pcs.isStoreLevelPaused()).thenReturn(false);
+    assertFalse(StoreIngestionTask.shouldSkipQuotaCallbackForStoreLevelPause(pcs));
+  }
+
+  @Test
+  public void quotaCallbackProceedsWhenPcsIsNull() {
+    // Defensive: partitionConsumptionStateMap.get(partitionId) can return null if a UNSUBSCRIBE
+    // has already torn down the PCS by the time the quota callback fires.
+    assertFalse(StoreIngestionTask.shouldSkipQuotaCallbackForStoreLevelPause(null));
   }
 }

--- a/internal/venice-common/src/main/java/com/linkedin/venice/meta/IngestionPauseMode.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/meta/IngestionPauseMode.java
@@ -14,11 +14,14 @@ import java.util.Map;
 public enum IngestionPauseMode implements VeniceEnumValue {
   /** Default. All ingestion runs normally. */
   NOT_PAUSED(0),
-  /** Pause ingestion for the current serving version's RT consumption only.
-   * Non-current versions (future pushes, backup versions) are not affected.
+  /** Pause ingestion for the current serving version only — fully unsubscribes the SIT's
+   * Kafka consumer for whatever topic it is currently consuming (RT for a post-EOP leader, the
+   * relevant remote RT for an A/A leader, local VT for a follower or pre-EOP leader). Non-current
+   * versions (future pushes, backup versions) are not affected.
    */
   CURRENT_VERSION(1),
-  /** Pause ingestion for ALL versions, including the current serving version's RT and VT consumption. */
+  /** Pause ingestion for ALL versions — fully unsubscribes every SIT's Kafka consumer regardless
+   * of role or current topic (VT, RT, sep-RT, or remote RT for A/A leaders). */
   ALL_VERSIONS(2);
 
   private final int value;

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestServerIngestionPauseResume.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestServerIngestionPauseResume.java
@@ -121,7 +121,9 @@ public class TestServerIngestionPauseResume extends AbstractMultiRegionTest {
               storeName,
               new UpdateStoreQueryParams().setStorageQuotaInByte(Store.UNLIMITED_STORAGE_QUOTA)
                   .setHybridRewindSeconds(HYBRID_REWIND_SECONDS)
-                  .setHybridOffsetLagThreshold(HYBRID_OFFSET_LAG_THRESHOLD)));
+                  .setHybridOffsetLagThreshold(HYBRID_OFFSET_LAG_THRESHOLD)
+                  .setNativeReplicationEnabled(true)
+                  .setActiveActiveReplicationEnabled(true)));
       assertCommand(parentClient.emptyPush(storeName, "push-1", 1000));
       TestUtils.waitForNonDeterministicPushCompletion(
           Version.composeKafkaTopic(storeName, 1),
@@ -131,9 +133,14 @@ public class TestServerIngestionPauseResume extends AbstractMultiRegionTest {
     }
 
     VeniceClusterWrapper dc0 = childDatacenters.get(0).getClusters().get(CLUSTER_NAME);
+    VeniceClusterWrapper dc1 = childDatacenters.get(1).getClusters().get(CLUSTER_NAME);
     VeniceSystemProducer producer = getSamzaProducerForStream(multiRegionMultiClusterWrapper, 0, storeName);
-    try (AvroGenericStoreClient<String, Object> dc0Client = ClientFactory.getAndStartGenericAvroClient(
-        ClientConfig.<String, Object>defaultGenericClientConfig(storeName).setVeniceURL(dc0.getRandomRouterURL()))) {
+    try (
+        AvroGenericStoreClient<String, Object> dc0Client = ClientFactory.getAndStartGenericAvroClient(
+            ClientConfig.<String, Object>defaultGenericClientConfig(storeName).setVeniceURL(dc0.getRandomRouterURL()));
+        AvroGenericStoreClient<String, Object> dc1Client = ClientFactory.getAndStartGenericAvroClient(
+            ClientConfig.<String, Object>defaultGenericClientConfig(storeName)
+                .setVeniceURL(dc1.getRandomRouterURL()))) {
 
       // Pause ONLY dc1 via the region filter. dc0 should remain unaffected.
       try (ControllerClient parentClient = new ControllerClient(CLUSTER_NAME, parentController.getControllerUrl())) {
@@ -171,14 +178,25 @@ public class TestServerIngestionPauseResume extends AbstractMultiRegionTest {
         assertEquals(v.toString(), "value1");
       });
 
-      // Resume (clears pause on dc1 — no assertion on dc1 itself since its Samza/read path
-      // is out of scope for this test).
+      // dc1 should NOT see key1 while its ingestion is paused. Wait longer than the hybrid
+      // offset-lag threshold so a passing consumer would have already made it visible.
+      Thread.sleep(15_000);
+      assertNull(dc1Client.get("key1").get(), "key1 should NOT be readable in dc1 while its ingestion is paused");
+
+      // Resume.
       try (ControllerClient parentClient = new ControllerClient(CLUSTER_NAME, parentController.getControllerUrl())) {
         assertCommand(
             parentClient.updateStore(
                 storeName,
                 new UpdateStoreQueryParams().setIngestionPauseMode(IngestionPauseMode.NOT_PAUSED)));
       }
+
+      // After resume, dc1 should eventually catch up and expose key1.
+      TestUtils.waitForNonDeterministicAssertion(60, TimeUnit.SECONDS, () -> {
+        Object v = dc1Client.get("key1").get();
+        assertNotNull(v, "key1 should be readable in dc1 after resume");
+        assertEquals(v.toString(), "value1");
+      });
     } finally {
       producer.stop();
     }

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestServerIngestionPauseResume.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestServerIngestionPauseResume.java
@@ -1,0 +1,186 @@
+package com.linkedin.venice.endToEnd;
+
+import static com.linkedin.venice.utils.IntegrationTestPushUtils.getSamzaProducerForStream;
+import static com.linkedin.venice.utils.IntegrationTestPushUtils.sendStreamingRecord;
+import static com.linkedin.venice.utils.TestUtils.assertCommand;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertNull;
+
+import com.linkedin.venice.client.store.AvroGenericStoreClient;
+import com.linkedin.venice.client.store.ClientConfig;
+import com.linkedin.venice.client.store.ClientFactory;
+import com.linkedin.venice.controllerapi.ControllerClient;
+import com.linkedin.venice.controllerapi.UpdateStoreQueryParams;
+import com.linkedin.venice.integration.utils.VeniceClusterWrapper;
+import com.linkedin.venice.meta.IngestionPauseMode;
+import com.linkedin.venice.meta.Store;
+import com.linkedin.venice.meta.Version;
+import com.linkedin.venice.samza.VeniceSystemProducer;
+import com.linkedin.venice.utils.TestUtils;
+import com.linkedin.venice.utils.Time;
+import com.linkedin.venice.utils.Utils;
+import java.util.concurrent.TimeUnit;
+import org.testng.annotations.Test;
+
+
+public class TestServerIngestionPauseResume extends AbstractMultiRegionTest {
+  private static final long HYBRID_REWIND_SECONDS = 10L;
+  private static final long HYBRID_OFFSET_LAG_THRESHOLD = 2L;
+
+  @Test(timeOut = 300 * Time.MS_PER_SECOND)
+  public void testRealTimeConsumptionPausesAndResumesOnServer() throws Exception {
+    String storeName = Utils.getUniqueString("test_server_ingestion_pause");
+
+    try (ControllerClient parentClient = new ControllerClient(CLUSTER_NAME, parentController.getControllerUrl())) {
+      assertCommand(parentClient.createNewStore(storeName, "owner", "\"string\"", "\"string\""));
+      assertCommand(
+          parentClient.updateStore(
+              storeName,
+              new UpdateStoreQueryParams().setStorageQuotaInByte(Store.UNLIMITED_STORAGE_QUOTA)
+                  .setHybridRewindSeconds(HYBRID_REWIND_SECONDS)
+                  .setHybridOffsetLagThreshold(HYBRID_OFFSET_LAG_THRESHOLD)));
+
+      // Initial batch push (version 1) and wait for it to complete.
+      assertCommand(parentClient.emptyPush(storeName, "push-1", 1000));
+      TestUtils.waitForNonDeterministicPushCompletion(
+          Version.composeKafkaTopic(storeName, 1),
+          parentClient,
+          60,
+          TimeUnit.SECONDS);
+    }
+
+    VeniceClusterWrapper dc0 = childDatacenters.get(0).getClusters().get(CLUSTER_NAME);
+    VeniceSystemProducer producer = getSamzaProducerForStream(multiRegionMultiClusterWrapper, 0, storeName);
+    try (AvroGenericStoreClient<String, Object> dc0Client = ClientFactory.getAndStartGenericAvroClient(
+        ClientConfig.<String, Object>defaultGenericClientConfig(storeName).setVeniceURL(dc0.getRandomRouterURL()))) {
+
+      // Send key1 and confirm dc0 reads it back — baseline that hybrid ingestion is working.
+      sendStreamingRecord(producer, storeName, "key1", "value1");
+      TestUtils.waitForNonDeterministicAssertion(30, TimeUnit.SECONDS, () -> {
+        Object v = dc0Client.get("key1").get();
+        assertNotNull(v, "key1 should be readable before pause");
+        assertEquals(v.toString(), "value1");
+      });
+
+      // Pause ingestion globally (all regions, all versions).
+      try (ControllerClient parentClient = new ControllerClient(CLUSTER_NAME, parentController.getControllerUrl())) {
+        assertCommand(
+            parentClient.updateStore(
+                storeName,
+                new UpdateStoreQueryParams().setIngestionPauseMode(IngestionPauseMode.ALL_VERSIONS)));
+      }
+
+      // Send key2 while paused. It will land in the RT topic but dc0's SIT should not consume it.
+      sendStreamingRecord(producer, storeName, "key2", "value2");
+
+      // Assert key2 stays invisible in dc0 for a meaningful window. We wait longer than the hybrid
+      // offset lag threshold / rewind window so a passing consumer would have made it visible.
+      Thread.sleep(15_000);
+      assertNull(dc0Client.get("key2").get(), "key2 should NOT be readable while ingestion is paused in dc0");
+
+      // Resume ingestion.
+      try (ControllerClient parentClient = new ControllerClient(CLUSTER_NAME, parentController.getControllerUrl())) {
+        assertCommand(
+            parentClient.updateStore(
+                storeName,
+                new UpdateStoreQueryParams().setIngestionPauseMode(IngestionPauseMode.NOT_PAUSED)));
+      }
+
+      // After resume, dc0 should eventually catch up and expose key2.
+      TestUtils.waitForNonDeterministicAssertion(60, TimeUnit.SECONDS, () -> {
+        Object v = dc0Client.get("key2").get();
+        assertNotNull(v, "key2 should be readable after resume");
+        assertEquals(v.toString(), "value2");
+      });
+
+      // key1 should still be readable (sanity: resume didn't blow away prior state).
+      assertEquals(dc0Client.get("key1").get().toString(), "value1");
+    } finally {
+      producer.stop();
+    }
+  }
+
+  /**
+   * Verifies that the {@code ingestionPausedRegions} filter isolates the pause effect to the
+   * named region(s): when only dc1 is listed, dc0 continues to ingest as normal.
+   *
+   * <p>Uses a non-AA hybrid store to keep the write/read path in-region (dc0 Samza -> dc0 RT
+   * -> dc0 server). This avoids cross-region RT consumption, which is orthogonal to what the
+   * region filter is supposed to verify.
+   */
+  @Test(timeOut = 300 * Time.MS_PER_SECOND)
+  public void testRegionScopedPauseOnlyAffectsTargetedRegion() throws Exception {
+    String storeName = Utils.getUniqueString("test_region_scoped_pause");
+    String dc1Name = multiRegionMultiClusterWrapper.getChildRegionNames().get(1);
+
+    try (ControllerClient parentClient = new ControllerClient(CLUSTER_NAME, parentController.getControllerUrl())) {
+      assertCommand(parentClient.createNewStore(storeName, "owner", "\"string\"", "\"string\""));
+      assertCommand(
+          parentClient.updateStore(
+              storeName,
+              new UpdateStoreQueryParams().setStorageQuotaInByte(Store.UNLIMITED_STORAGE_QUOTA)
+                  .setHybridRewindSeconds(HYBRID_REWIND_SECONDS)
+                  .setHybridOffsetLagThreshold(HYBRID_OFFSET_LAG_THRESHOLD)));
+      assertCommand(parentClient.emptyPush(storeName, "push-1", 1000));
+      TestUtils.waitForNonDeterministicPushCompletion(
+          Version.composeKafkaTopic(storeName, 1),
+          parentClient,
+          60,
+          TimeUnit.SECONDS);
+    }
+
+    VeniceClusterWrapper dc0 = childDatacenters.get(0).getClusters().get(CLUSTER_NAME);
+    VeniceSystemProducer producer = getSamzaProducerForStream(multiRegionMultiClusterWrapper, 0, storeName);
+    try (AvroGenericStoreClient<String, Object> dc0Client = ClientFactory.getAndStartGenericAvroClient(
+        ClientConfig.<String, Object>defaultGenericClientConfig(storeName).setVeniceURL(dc0.getRandomRouterURL()))) {
+
+      // Pause ONLY dc1 via the region filter. dc0 should remain unaffected.
+      try (ControllerClient parentClient = new ControllerClient(CLUSTER_NAME, parentController.getControllerUrl())) {
+        assertCommand(
+            parentClient.updateStore(
+                storeName,
+                new UpdateStoreQueryParams().setIngestionPauseMode(IngestionPauseMode.ALL_VERSIONS)
+                    .setIngestionPausedRegions(java.util.Arrays.asList(dc1Name))));
+      }
+
+      // Wait for child controllers to apply the filtered mode: dc0 stays NOT_PAUSED, dc1 sees
+      // ALL_VERSIONS. This confirms the region filter in AdminExecutionTask runs end-to-end.
+      try (
+          ControllerClient dc0Controller =
+              new ControllerClient(CLUSTER_NAME, childDatacenters.get(0).getControllerConnectString());
+          ControllerClient dc1Controller =
+              new ControllerClient(CLUSTER_NAME, childDatacenters.get(1).getControllerConnectString())) {
+        TestUtils.waitForNonDeterministicAssertion(30, TimeUnit.SECONDS, () -> {
+          assertEquals(
+              assertCommand(dc0Controller.getStore(storeName)).getStore().getIngestionPauseMode(),
+              IngestionPauseMode.NOT_PAUSED,
+              "dc0 should stay NOT_PAUSED because it was excluded from the region filter");
+          assertEquals(
+              assertCommand(dc1Controller.getStore(storeName)).getStore().getIngestionPauseMode(),
+              IngestionPauseMode.ALL_VERSIONS,
+              "dc1 should see ALL_VERSIONS because it was named in the region filter");
+        });
+      }
+
+      // dc0 should continue ingesting normally even while dc1 is paused.
+      sendStreamingRecord(producer, storeName, "key1", "value1");
+      TestUtils.waitForNonDeterministicAssertion(30, TimeUnit.SECONDS, () -> {
+        Object v = dc0Client.get("key1").get();
+        assertNotNull(v, "key1 should be readable in dc0 while only dc1 is paused");
+        assertEquals(v.toString(), "value1");
+      });
+
+      // Resume (clears pause on dc1 — no assertion on dc1 itself since its Samza/read path
+      // is out of scope for this test).
+      try (ControllerClient parentClient = new ControllerClient(CLUSTER_NAME, parentController.getControllerUrl())) {
+        assertCommand(
+            parentClient.updateStore(
+                storeName,
+                new UpdateStoreQueryParams().setIngestionPauseMode(IngestionPauseMode.NOT_PAUSED)));
+      }
+    } finally {
+      producer.stop();
+    }
+  }
+}

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestServerIngestionPauseResume.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestServerIngestionPauseResume.java
@@ -71,6 +71,19 @@ public class TestServerIngestionPauseResume extends AbstractMultiRegionTest {
                 new UpdateStoreQueryParams().setIngestionPauseMode(IngestionPauseMode.ALL_VERSIONS)));
       }
 
+      // Wait for the pause mode to propagate parent -> child controller -> server's
+      // storeRepository before producing — otherwise a fast write could land before the SIT
+      // observes the new mode and would be ingested under the old (NOT_PAUSED) state.
+      try (ControllerClient dc0Controller =
+          new ControllerClient(CLUSTER_NAME, childDatacenters.get(0).getControllerConnectString())) {
+        TestUtils.waitForNonDeterministicAssertion(
+            30,
+            TimeUnit.SECONDS,
+            () -> assertEquals(
+                assertCommand(dc0Controller.getStore(storeName)).getStore().getIngestionPauseMode(),
+                IngestionPauseMode.ALL_VERSIONS));
+      }
+
       // Send key2 while paused. It will land in the RT topic but dc0's SIT should not consume it.
       sendStreamingRecord(producer, storeName, "key2", "value2");
 
@@ -105,9 +118,9 @@ public class TestServerIngestionPauseResume extends AbstractMultiRegionTest {
    * Verifies that the {@code ingestionPausedRegions} filter isolates the pause effect to the
    * named region(s): when only dc1 is listed, dc0 continues to ingest as normal.
    *
-   * <p>Uses a non-AA hybrid store to keep the write/read path in-region (dc0 Samza -> dc0 RT
-   * -> dc0 server). This avoids cross-region RT consumption, which is orthogonal to what the
-   * region filter is supposed to verify.
+   * <p>Uses a native-replication + active-active hybrid store so dc1 leaders pull dc0's RT —
+   * which is what makes the post-resume catch-up assertion meaningful (a paused dc1 would
+   * otherwise have nothing to catch up on).
    */
   @Test(timeOut = 300 * Time.MS_PER_SECOND)
   public void testRegionScopedPauseOnlyAffectsTargetedRegion() throws Exception {

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestServerIngestionPauseResume.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestServerIngestionPauseResume.java
@@ -13,6 +13,7 @@ import com.linkedin.venice.client.store.ClientFactory;
 import com.linkedin.venice.controllerapi.ControllerClient;
 import com.linkedin.venice.controllerapi.UpdateStoreQueryParams;
 import com.linkedin.venice.integration.utils.VeniceClusterWrapper;
+import com.linkedin.venice.integration.utils.VeniceServerWrapper;
 import com.linkedin.venice.meta.IngestionPauseMode;
 import com.linkedin.venice.meta.Store;
 import com.linkedin.venice.meta.Version;
@@ -20,6 +21,8 @@ import com.linkedin.venice.samza.VeniceSystemProducer;
 import com.linkedin.venice.utils.TestUtils;
 import com.linkedin.venice.utils.Time;
 import com.linkedin.venice.utils.Utils;
+import io.tehuti.Metric;
+import io.tehuti.metrics.MetricsRepository;
 import java.util.concurrent.TimeUnit;
 import org.testng.annotations.Test;
 
@@ -83,11 +86,10 @@ public class TestServerIngestionPauseResume extends AbstractMultiRegionTest {
                 assertCommand(dc0Controller.getStore(storeName)).getStore().getIngestionPauseMode(),
                 IngestionPauseMode.ALL_VERSIONS));
       }
-      // Additional buffer for the server-side SIT to observe the new mode and apply the
-      // unsubscribe in maybeTransitionPauseState (runs once per checkLongRunningTaskState loop).
-      // Without this, a fast produce can land in RT before SIT reacts and get ingested under
-      // the old NOT_PAUSED state.
-      Thread.sleep(10_000);
+      // Wait for the server-side SIT to actually apply the pause (set the gauge). This signals
+      // that maybeTransitionPauseState has unsubscribed the consumer, so any record produced
+      // after this point cannot leak through. More robust than a fixed sleep.
+      waitForStoreLevelPausedGauge(dc0, storeName, 1.0);
 
       // Send key2 while paused. It will land in the RT topic but dc0's SIT should not consume it.
       sendStreamingRecord(producer, storeName, "key2", "value2");
@@ -187,9 +189,9 @@ public class TestServerIngestionPauseResume extends AbstractMultiRegionTest {
               "dc1 should see ALL_VERSIONS because it was named in the region filter");
         });
       }
-      // Buffer for dc1's SIT to actually apply the unsubscribe — checkLongRunningTaskState
-      // runs once per loop and ZK->server propagation isn't instantaneous.
-      Thread.sleep(10_000);
+      // Wait for dc1's SIT to actually apply the pause (gauge=1) before producing — direct
+      // signal that the consumer has been unsubscribed.
+      waitForStoreLevelPausedGauge(dc1, storeName, 1.0);
 
       // dc0 should continue ingesting normally even while dc1 is paused.
       sendStreamingRecord(producer, storeName, "key1", "value1");
@@ -224,6 +226,32 @@ public class TestServerIngestionPauseResume extends AbstractMultiRegionTest {
     } finally {
       producer.stop();
     }
+  }
+
+  /**
+   * Polls every server in the cluster until at least one reports
+   * {@code store_level_paused_gauge == expected} for the current version of the given store.
+   * Direct signal that {@code maybeTransitionPauseState} has run and applied the requested
+   * transition — replaces fixed-duration buffer waits between updateStore and the next
+   * test action.
+   */
+  private void waitForStoreLevelPausedGauge(VeniceClusterWrapper cluster, String storeName, double expected) {
+    String metricName = "." + storeName + "_current--store_level_paused_gauge.IngestionStatsGauge";
+    TestUtils.waitForNonDeterministicAssertion(30, TimeUnit.SECONDS, () -> {
+      double observed = -1.0;
+      for (VeniceServerWrapper server: cluster.getVeniceServers()) {
+        MetricsRepository repo = server.getMetricsRepository();
+        Metric metric = repo.getMetric(metricName);
+        if (metric != null) {
+          observed = Math.max(observed, metric.value());
+          if (metric.value() == expected) {
+            return; // at least one server has reached the desired state
+          }
+        }
+      }
+      throw new AssertionError(
+          "Expected " + metricName + " == " + expected + " on at least one server; max observed: " + observed);
+    });
   }
 
   /**

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestServerIngestionPauseResume.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestServerIngestionPauseResume.java
@@ -83,14 +83,19 @@ public class TestServerIngestionPauseResume extends AbstractMultiRegionTest {
                 assertCommand(dc0Controller.getStore(storeName)).getStore().getIngestionPauseMode(),
                 IngestionPauseMode.ALL_VERSIONS));
       }
+      // Additional buffer for the server-side SIT to observe the new mode and apply the
+      // unsubscribe in maybeTransitionPauseState (runs once per checkLongRunningTaskState loop).
+      // Without this, a fast produce can land in RT before SIT reacts and get ingested under
+      // the old NOT_PAUSED state.
+      Thread.sleep(10_000);
 
       // Send key2 while paused. It will land in the RT topic but dc0's SIT should not consume it.
       sendStreamingRecord(producer, storeName, "key2", "value2");
 
-      // Assert key2 stays invisible in dc0 for a meaningful window. We wait longer than the hybrid
-      // offset lag threshold / rewind window so a passing consumer would have made it visible.
-      Thread.sleep(15_000);
-      assertNull(dc0Client.get("key2").get(), "key2 should NOT be readable while ingestion is paused in dc0");
+      // Assert key2 stays invisible in dc0 for the entire 15s window. Polls and fails fast if the
+      // key ever appears (rather than sleeping and checking once, which can miss a brief
+      // ingestion window or pass on slow propagation).
+      assertKeyRemainsAbsent(dc0Client, "key2", 15_000, "key2 should NOT be readable while ingestion is paused in dc0");
 
       // Resume ingestion.
       try (ControllerClient parentClient = new ControllerClient(CLUSTER_NAME, parentController.getControllerUrl())) {
@@ -182,6 +187,9 @@ public class TestServerIngestionPauseResume extends AbstractMultiRegionTest {
               "dc1 should see ALL_VERSIONS because it was named in the region filter");
         });
       }
+      // Buffer for dc1's SIT to actually apply the unsubscribe — checkLongRunningTaskState
+      // runs once per loop and ZK->server propagation isn't instantaneous.
+      Thread.sleep(10_000);
 
       // dc0 should continue ingesting normally even while dc1 is paused.
       sendStreamingRecord(producer, storeName, "key1", "value1");
@@ -191,10 +199,13 @@ public class TestServerIngestionPauseResume extends AbstractMultiRegionTest {
         assertEquals(v.toString(), "value1");
       });
 
-      // dc1 should NOT see key1 while its ingestion is paused. Wait longer than the hybrid
-      // offset-lag threshold so a passing consumer would have already made it visible.
-      Thread.sleep(15_000);
-      assertNull(dc1Client.get("key1").get(), "key1 should NOT be readable in dc1 while its ingestion is paused");
+      // dc1 should NOT see key1 for the entire 15s window. Polls and fails fast if the key ever
+      // appears (rather than sleeping and checking once, which can pass on slow propagation).
+      assertKeyRemainsAbsent(
+          dc1Client,
+          "key1",
+          15_000,
+          "key1 should NOT be readable in dc1 while its ingestion is paused");
 
       // Resume.
       try (ControllerClient parentClient = new ControllerClient(CLUSTER_NAME, parentController.getControllerUrl())) {
@@ -212,6 +223,25 @@ public class TestServerIngestionPauseResume extends AbstractMultiRegionTest {
       });
     } finally {
       producer.stop();
+    }
+  }
+
+  /**
+   * Polls the store client over a window, failing fast if the key ever becomes visible. Replaces
+   * the {@code Thread.sleep + assertNull} pattern, which can pass on slow propagation (the key
+   * arrives just after the single check) or fail on a brief ingestion window. Here we check
+   * every 250ms for the entire window, so a single positive read fails the assertion.
+   */
+  private void assertKeyRemainsAbsent(
+      AvroGenericStoreClient<String, Object> client,
+      String key,
+      long windowMs,
+      String message) throws Exception {
+    long deadlineNanos = System.nanoTime() + TimeUnit.MILLISECONDS.toNanos(windowMs);
+    while (System.nanoTime() < deadlineNanos) {
+      Object value = client.get(key).get();
+      assertNull(value, message + " (observed: " + value + ")");
+      Thread.sleep(250);
     }
   }
 }


### PR DESCRIPTION
## Problem Statement

Phase 1 (#2754) added the `IngestionPauseMode` store-metadata field, region filter, admin-tool flags, and a parent-side push guard, but Venice servers and DaVinci clients still ignore the mode at runtime — they keep consuming Kafka regardless of what the controller has stored. We need the actual server-side mechanism that observes the pause mode and stops/resumes ingestion.

## Solution

Servers and DaVinci `StoreIngestionTask`s now honor the store-level `IngestionPauseMode` by fully unsubscribing their Kafka consumers when paused, and resubscribing from the persisted offset on resume.

- `LeaderFollowerStoreIngestionTask.maybeTransitionPauseState()` runs at the top of `checkLongRunningTaskState()` every iteration. On enter: `consumerUnSubscribeAllTopics(pcs)` (covers leader topic across all Kafka clusters for AA/NR setups). On exit: `resubscribe(pcs)`, reusing the existing leader/follower-aware machinery to rewind from the persisted offset.
- `StoreIngestionTask.shouldPauseForStore` is the static decision helper:
  - `NOT_PAUSED` / null -> false
  - `ALL_VERSIONS` -> true
  - `CURRENT_VERSION` -> true only when `sitVersionNumber == store.getCurrentVersion()`
  - Applies uniformly to both Venice servers and DaVinci clients.
- Restart-while-paused: `validateAndSubscribePartition` unsubscribes immediately after subscribe if the store is already paused. Blob transfer still runs so the replica comes up populated; only Kafka fetching is suppressed until resume.
- Disk-quota `pauseConsumption` / `resumeConsumption` callbacks no-op when the PCS is store-level paused, so quota logic and store-level pause don't fight.
- New `store_level_paused_gauge` metric exposed via `IngestionStats` / `AggVersionedIngestionStats`.

### Code changes

- [ ] Added new code behind **a config**.
- [ ] Introduced new **log lines** (info-level transition logs in `maybeTransitionPauseState` and the restart hook; not rate-limited because they only fire on state transitions, not per record).

### **Concurrency-Specific Checks**

- [x] Code has **no race conditions** or **thread safety issues**. `maybeTransitionPauseState` runs only on the SIT thread; the PCS `storeLevelPaused` flag is mutated only from that thread.
- [x] Proper **synchronization mechanisms** are used where needed.
- [x] No **blocking calls** inside critical sections.
- [x] Verified **thread-safe collections** are used.
- [x] Validated proper exception handling — repo lookup wrapped in try/catch so a transient failure doesn't crash the SIT thread.

## How was this PR tested?

- [x] New unit tests added: `StoreIngestionTaskShouldPauseTest` (4 cases for the static decision helper); `PartitionConsumptionStateTest` (storeLevelPaused default + setter).
- [x] New integration tests added: `TestServerIngestionPauseResume`:
  - `testRealTimeConsumptionPausesAndResumesOnServer` — hybrid store, pause globally, verify dc0 doesn't see new RT writes for >15s, resume, verify catch-up.
  - `testRegionScopedPauseOnlyAffectsTargetedRegion` — pause only dc1 via region filter, verify dc0 controller stays `NOT_PAUSED` while dc1 sees `ALL_VERSIONS`, and dc0 continues ingesting.
- [x] Modified or extended existing tests.
- [x] Verified backward compatibility — default `NOT_PAUSED` mode results in zero behavior change.

## Does this PR introduce any user-facing or breaking changes?

- [x] No.