### PR TITLE
[controller] Recheck topic truncation in skipMigratingVersion to absorb broker-metadata race

### DIFF
--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceHelixAdmin.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceHelixAdmin.java
@@ -3739,7 +3739,13 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
    * @param versionNumber version number
    * @return whether to skip adding the version
    */
-  private boolean skipMigratingVersion(String clusterName, String storeName, int versionNumber) {
+  // Visible for testing.
+  static final int MIGRATION_TRUNCATION_RECHECK_MAX_ATTEMPTS = 3;
+  static final long MIGRATION_TRUNCATION_RECHECK_INITIAL_BACKOFF_MS = 500;
+  static final long MIGRATION_TRUNCATION_RECHECK_MAX_BACKOFF_MS = 2000;
+
+  // Visible for testing.
+  boolean skipMigratingVersion(String clusterName, String storeName, int versionNumber) {
     if (multiClusterConfigs.isParent()) {
       return false;
     }
@@ -3776,19 +3782,55 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
       // If the topic does not exist it is deleted, If source cluster topic creation is slown during new push
       // its captured in earlier check storeInfo.getLargestUsedVersionNumber() < versionNumber
       // or if the topic is truncated, skip it
-      boolean topicExists = getTopicManager().containsTopicWithRetries(versionTopic, 5);
-      if (!topicExists || isTopicTruncated(versionTopic.getName())) {
+      if (!getTopicManager().containsTopicWithRetries(versionTopic, 5)) {
+        LOGGER.warn(
+            "Skip adding version: {} for store: {} in cluster: {} because the corresponding VT does not exist",
+            versionNumber,
+            storeName,
+            clusterName);
+        return true;
+      }
+      // Truncation check: re-check on a positive ("truncated") result with exponential backoff to
+      // distinguish a genuinely truncated topic from a transient broker-metadata race on a freshly
+      // created topic during migration mirroring (e.g., describeConfigs throwing
+      // PubSubTopicDoesNotExistException for a topic that listTopics already sees). Only treat a
+      // stable truncated result as authoritative.
+      if (isVersionTopicTruncatedWithRecheck(versionTopic)) {
         LOGGER.error(
-            "Skip adding version: {} for store: {} in cluster: {} because the corresponding VT is truncated and version status is {} or topic doesn't exist : {}",
+            "Skip adding version: {} for store: {} in cluster: {} because the corresponding VT is truncated; version status: {}",
             versionNumber,
             storeName,
             clusterName,
-            storeInfo.getVersion(versionNumber).get().getStatus(),
-            topicExists);
+            storeInfo.getVersion(versionNumber).get().getStatus());
         return true;
       }
     }
     return false;
+  }
+
+  // Visible for testing.
+  boolean isVersionTopicTruncatedWithRecheck(PubSubTopic versionTopic) {
+    long backoffMs = MIGRATION_TRUNCATION_RECHECK_INITIAL_BACKOFF_MS;
+    for (int attempt = 0; attempt < MIGRATION_TRUNCATION_RECHECK_MAX_ATTEMPTS; attempt++) {
+      if (!isTopicTruncated(versionTopic.getName())) {
+        return false;
+      }
+      // Truncated == true. If the topic vanished, accept the result. Otherwise the positive result
+      // is likely a transient broker-metadata race; back off and retry.
+      if (!getTopicManager().containsTopicWithRetries(versionTopic, 5)) {
+        return true;
+      }
+      if (attempt < MIGRATION_TRUNCATION_RECHECK_MAX_ATTEMPTS - 1) {
+        try {
+          Thread.sleep(backoffMs);
+        } catch (InterruptedException e) {
+          Thread.currentThread().interrupt();
+          return true;
+        }
+        backoffMs = Math.min(backoffMs * 2, MIGRATION_TRUNCATION_RECHECK_MAX_BACKOFF_MS);
+      }
+    }
+    return true;
   }
 
   void handleVersionCreationFailure(String clusterName, String storeName, int versionNumber, String statusDetails) {

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceHelixAdmin.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceHelixAdmin.java
@@ -3739,12 +3739,14 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
    * @param versionNumber version number
    * @return whether to skip adding the version
    */
-  // Visible for testing.
+  @VisibleForTesting
   static final int MIGRATION_TRUNCATION_RECHECK_MAX_ATTEMPTS = 3;
+  @VisibleForTesting
   static final long MIGRATION_TRUNCATION_RECHECK_INITIAL_BACKOFF_MS = 500;
+  @VisibleForTesting
   static final long MIGRATION_TRUNCATION_RECHECK_MAX_BACKOFF_MS = 2000;
 
-  // Visible for testing.
+  @VisibleForTesting
   boolean skipMigratingVersion(String clusterName, String storeName, int versionNumber) {
     if (multiClusterConfigs.isParent()) {
       return false;
@@ -3779,7 +3781,7 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
             storeInfo.getVersion(versionNumber).get().getStatus());
         return true;
       }
-      // If the topic does not exist it is deleted, If source cluster topic creation is slown during new push
+      // If the topic does not exist it is deleted, If source cluster topic creation is slow during new push
       // its captured in earlier check storeInfo.getLargestUsedVersionNumber() < versionNumber
       // or if the topic is truncated, skip it
       if (!getTopicManager().containsTopicWithRetries(versionTopic, 5)) {
@@ -3808,7 +3810,7 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
     return false;
   }
 
-  // Visible for testing.
+  @VisibleForTesting
   boolean isVersionTopicTruncatedWithRecheck(PubSubTopic versionTopic) {
     long backoffMs = MIGRATION_TRUNCATION_RECHECK_INITIAL_BACKOFF_MS;
     for (int attempt = 0; attempt < MIGRATION_TRUNCATION_RECHECK_MAX_ATTEMPTS; attempt++) {
@@ -3830,6 +3832,15 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
         backoffMs = Math.min(backoffMs * 2, MIGRATION_TRUNCATION_RECHECK_MAX_BACKOFF_MS);
       }
     }
+    // All attempts exhausted with isTopicTruncated == true && topic still exists. Treat as authoritative
+    // truncation and skip, but log a WARN so we can detect if the broker-metadata race ever outlives the
+    // recheck budget in production. If this fires repeatedly, MIGRATION_TRUNCATION_RECHECK_MAX_ATTEMPTS
+    // or the backoff cap should be increased.
+    LOGGER.warn(
+        "Migration truncation recheck exhausted {} attempts for topic: {}; topic still exists "
+            + "but reports truncated. Treating as authoritative and skipping version.",
+        MIGRATION_TRUNCATION_RECHECK_MAX_ATTEMPTS,
+        versionTopic.getName());
     return true;
   }
 

--- a/services/venice-controller/src/test/java/com/linkedin/venice/controller/TestVeniceHelixAdminWithoutCluster.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/controller/TestVeniceHelixAdminWithoutCluster.java
@@ -1,11 +1,16 @@
 package com.linkedin.venice.controller;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.anyBoolean;
 import static org.mockito.Mockito.anyString;
 import static org.mockito.Mockito.doCallRealMethod;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import com.linkedin.venice.common.VeniceSystemStoreType;
 import com.linkedin.venice.exceptions.VeniceException;
@@ -312,5 +317,65 @@ public class TestVeniceHelixAdminWithoutCluster {
             Optional.empty(),
             "dc-99, dc-0, dc-4, dc-2"),
         "dc-4");
+  }
+
+  @Test
+  public void isVersionTopicTruncatedWithRecheckReturnsFalseWhenNotTruncated() {
+    PubSubTopic versionTopic = pubSubTopicRepository.getTopic("foo_v1");
+    VeniceHelixAdmin admin = mock(VeniceHelixAdmin.class);
+    TopicManager topicManager = mock(TopicManager.class);
+    doReturn(topicManager).when(admin).getTopicManager();
+    doReturn(false).when(admin).isTopicTruncated(versionTopic.getName());
+    doCallRealMethod().when(admin).isVersionTopicTruncatedWithRecheck(versionTopic);
+
+    Assert.assertFalse(admin.isVersionTopicTruncatedWithRecheck(versionTopic));
+    // No retries; containsTopicWithRetries should not have been consulted.
+    verify(topicManager, times(0)).containsTopicWithRetries(eq(versionTopic), anyInt());
+  }
+
+  @Test
+  public void isVersionTopicTruncatedWithRecheckReturnsTrueWhenTopicVanished() {
+    PubSubTopic versionTopic = pubSubTopicRepository.getTopic("foo_v1");
+    VeniceHelixAdmin admin = mock(VeniceHelixAdmin.class);
+    TopicManager topicManager = mock(TopicManager.class);
+    doReturn(topicManager).when(admin).getTopicManager();
+    doReturn(true).when(admin).isTopicTruncated(versionTopic.getName());
+    doReturn(false).when(topicManager).containsTopicWithRetries(eq(versionTopic), anyInt());
+    doCallRealMethod().when(admin).isVersionTopicTruncatedWithRecheck(versionTopic);
+
+    Assert.assertTrue(admin.isVersionTopicTruncatedWithRecheck(versionTopic));
+    // Single attempt; topic vanished -> accept truncated result without further retries.
+    verify(admin, times(1)).isTopicTruncated(versionTopic.getName());
+  }
+
+  @Test
+  public void isVersionTopicTruncatedWithRecheckReturnsFalseAfterTransientRace() {
+    PubSubTopic versionTopic = pubSubTopicRepository.getTopic("foo_v1");
+    VeniceHelixAdmin admin = mock(VeniceHelixAdmin.class);
+    TopicManager topicManager = mock(TopicManager.class);
+    doReturn(topicManager).when(admin).getTopicManager();
+    // First attempt: truncated==true (transient race). Second attempt: truncated==false.
+    when(admin.isTopicTruncated(versionTopic.getName())).thenReturn(true, false);
+    doReturn(true).when(topicManager).containsTopicWithRetries(eq(versionTopic), anyInt());
+    doCallRealMethod().when(admin).isVersionTopicTruncatedWithRecheck(versionTopic);
+
+    Assert.assertFalse(admin.isVersionTopicTruncatedWithRecheck(versionTopic));
+    verify(admin, times(2)).isTopicTruncated(versionTopic.getName());
+  }
+
+  @Test
+  public void isVersionTopicTruncatedWithRecheckReturnsTrueAfterMaxAttempts() {
+    PubSubTopic versionTopic = pubSubTopicRepository.getTopic("foo_v1");
+    VeniceHelixAdmin admin = mock(VeniceHelixAdmin.class);
+    TopicManager topicManager = mock(TopicManager.class);
+    doReturn(topicManager).when(admin).getTopicManager();
+    // Truncated stays true and topic continues to exist for the entire retry window.
+    doReturn(true).when(admin).isTopicTruncated(versionTopic.getName());
+    doReturn(true).when(topicManager).containsTopicWithRetries(eq(versionTopic), anyInt());
+    doCallRealMethod().when(admin).isVersionTopicTruncatedWithRecheck(versionTopic);
+
+    Assert.assertTrue(admin.isVersionTopicTruncatedWithRecheck(versionTopic));
+    verify(admin, times(VeniceHelixAdmin.MIGRATION_TRUNCATION_RECHECK_MAX_ATTEMPTS))
+        .isTopicTruncated(versionTopic.getName());
   }
 }


### PR DESCRIPTION
## Problem Statement

During Venice store migration, the parent admin channel mirrors `addVersion` messages to both the source and destination clusters so the destination can ingest in lockstep. The destination-side child controller calls `VeniceHelixAdmin.skipMigratingVersion` to decide whether to honor the addVersion. The current check short-circuits as follows:

```java
boolean topicExists = getTopicManager().containsTopicWithRetries(versionTopic, 5);
if (!topicExists || isTopicTruncated(versionTopic.getName())) {
  // ERROR log + return true (skip the addVersion)
}
```

`isTopicTruncated` defensively returns `true` whenever it catches `PubSubTopicDoesNotExistException` (`TopicManager.java` ~ line 527). That exception is thrown transiently right after topic creation: `containsTopic` already sees the topic via `listTopics` metadata, while `describeConfigs` (used by `getTopicConfig` / `getTopicRetention`) momentarily returns `UNKNOWN_TOPIC_OR_PARTITION`. The destination-side mirror is then dropped silently (a single `pub_sub_admin_op_failure_count` is recorded; the companion log is at DEBUG), and the destination cluster permanently lacks the version even though the source cluster has the topic and the version is healthy.

This was observed in a real prod migration: the destination cluster was stuck at `current=4` in one fabric while the source had `current=5` and the same fabric's destination cluster in the other two fabrics had successfully mirrored to `v5`. The skip log was:

```
ERROR Skip adding version: 5 for store: <store> in cluster: <dest> because the corresponding VT is truncated and version status is STARTED or topic doesn't exist : true
```

`topicExists=true` while `isTopicTruncated=true` — the contradiction is the signature of the race. No `Updated topic ... with retention.ms` log fired against the version topic in that window, confirming the topic was never actually truncated.

## Solution

Split the existing short-circuit so the topic-missing case is handled explicitly with a dedicated log, then re-check `isTopicTruncated` up to 3 attempts with exponential backoff (500ms / 1000ms / max 2000ms) when it reports truncated. On each attempt:
- If `isTopicTruncated` returns `false` → not truncated, return immediately.
- If `isTopicTruncated` returns `true` and `containsTopicWithRetries` confirms the topic vanished → accept the truncated result without further retries.
- If `isTopicTruncated` returns `true` but the topic still exists → treat as a transient broker-metadata race, back off and retry.
- After max attempts with stable truncated == true → treat as genuinely truncated.

This preserves the original protective intent (genuinely truncated topics still skip) while making the destination-side mirror robust against the broker-metadata race. Worst case adds 1.5s on a rare race; typical case is unchanged. The fix is scoped to `skipMigratingVersion` rather than the shared `TopicManager.isTopicTruncated` method to keep blast radius small (other callers of `isTopicTruncated` may rely on the existing fast-fail semantics for already-truncated topics).

###  Code changes
- [ ] Added new code behind **a config**. _No config; new constants are class-private with sensible defaults (`MIGRATION_TRUNCATION_RECHECK_MAX_ATTEMPTS=3`, `..._INITIAL_BACKOFF_MS=500`, `..._MAX_BACKOFF_MS=2000`)._
- [x] Introduced new **log lines**.
  - [x] Confirmed if logs need to be **rate limited** to avoid excessive logging. _Logs only fire on the skip path (existing rate); replaced one ERROR with two distinct ERROR/WARN, no new per-iteration logging._

###  **Concurrency-Specific Checks**
- [x] Code has **no race conditions** or **thread safety issues**. _Method-local state only; no shared mutable state introduced._
- [x] Proper **synchronization mechanisms** are used where needed. _Not applicable — no shared state._
- [x] No **blocking calls** inside critical sections that could lead to deadlocks or performance degradation. _Method does not hold locks; the existing caller path already tolerates blocking I/O against the broker._
- [x] Verified **thread-safe collections** are used. _No new collections._
- [x] Validated proper exception handling in multi-threaded code. _`InterruptedException` from `Thread.sleep` is propagated by re-setting the interrupt flag and conservatively returning `true`._

## How was this PR tested?

- [x] New unit tests added. (4 new tests in `TestVeniceHelixAdminWithoutCluster`)
  - `isVersionTopicTruncatedWithRecheckReturnsFalseWhenNotTruncated`
  - `isVersionTopicTruncatedWithRecheckReturnsTrueWhenTopicVanished`
  - `isVersionTopicTruncatedWithRecheckReturnsFalseAfterTransientRace`
  - `isVersionTopicTruncatedWithRecheckReturnsTrueAfterMaxAttempts`
- [ ] New integration tests added.
- [ ] Modified or extended existing tests.
- [x] Verified backward compatibility. _Behavior is unchanged when the topic is genuinely truncated or genuinely missing; only the transient-race path now recovers instead of silently skipping._

Local test run:

\`\`\`
BUILD SUCCESSFUL
12 tests in TestVeniceHelixAdminWithoutCluster passed (4 new + 8 existing)
\`\`\`

## Does this PR introduce any user-facing or breaking changes?

- [x] No. You can skip the rest of this section.