### PR TITLE
[controller][admin-tool]  Fixing bug in store migration where RF is misconfigured to source cluster's RF

### DIFF
--- a/internal/venice-common/src/main/java/com/linkedin/venice/controllerapi/UpdateStoreQueryParams.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/controllerapi/UpdateStoreQueryParams.java
@@ -161,6 +161,7 @@ public class UpdateStoreQueryParams extends QueryParams {
             .setPushStreamSourceAddress(srcStore.getPushStreamSourceAddress())
             .setReadComputationEnabled(srcStore.isReadComputationEnabled())
             .setReadQuotaInCU(srcStore.getReadQuotaInCU())
+            // replicationFactor is set conditionally below — see the if (storeMigrating) ... else branch.
             .setAutoSchemaPushJobEnabled(srcStore.isSchemaAutoRegisterFromPushJobEnabled())
             .setStorageQuotaInByte(srcStore.getStorageQuotaInByte())
             .setWriteComputationEnabled(srcStore.isWriteComputationEnabled())

--- a/internal/venice-common/src/main/java/com/linkedin/venice/controllerapi/UpdateStoreQueryParams.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/controllerapi/UpdateStoreQueryParams.java
@@ -200,7 +200,9 @@ public class UpdateStoreQueryParams extends QueryParams {
           .setStoreMigration(true)
           .setMigrationDuplicateStore(true); // Mark as duplicate store, to which L/F SN refers to avoid multi leaders
       // Replication factor is intentionally NOT carried over during cross-cluster migration: the destination
-      // cluster's createNewStore has already applied its own default RF, and the dest cluster's topology
+      // cluster's createNewStore has already applied its own default RF, and the destination cluster's
+      // topology (e.g. number of Helix fault zones / groups under HELIX_ASSISTED_ROUTING, which requires
+      // RF >= num_groups) may require a different RF than the source cluster.
     } else {
       updateStoreQueryParams.setReplicationFactor(srcStore.getReplicationFactor());
     }

--- a/internal/venice-common/src/main/java/com/linkedin/venice/controllerapi/UpdateStoreQueryParams.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/controllerapi/UpdateStoreQueryParams.java
@@ -202,7 +202,7 @@ public class UpdateStoreQueryParams extends QueryParams {
       // Replication factor is intentionally NOT carried over during cross-cluster migration: the destination
       // cluster's createNewStore has already applied its own default RF, and the destination cluster's
       // topology (e.g. number of Helix fault zones / groups under HELIX_ASSISTED_ROUTING, which requires
-      // RF >= num_groups) may require a different RF than the source cluster.
+      // RF = num_groups) may require a different RF than the source cluster.
     } else {
       updateStoreQueryParams.setReplicationFactor(srcStore.getReplicationFactor());
     }

--- a/internal/venice-common/src/main/java/com/linkedin/venice/controllerapi/UpdateStoreQueryParams.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/controllerapi/UpdateStoreQueryParams.java
@@ -161,7 +161,6 @@ public class UpdateStoreQueryParams extends QueryParams {
             .setPushStreamSourceAddress(srcStore.getPushStreamSourceAddress())
             .setReadComputationEnabled(srcStore.isReadComputationEnabled())
             .setReadQuotaInCU(srcStore.getReadQuotaInCU())
-            .setReplicationFactor(srcStore.getReplicationFactor())
             .setAutoSchemaPushJobEnabled(srcStore.isSchemaAutoRegisterFromPushJobEnabled())
             .setStorageQuotaInByte(srcStore.getStorageQuotaInByte())
             .setWriteComputationEnabled(srcStore.isWriteComputationEnabled())
@@ -200,6 +199,10 @@ public class UpdateStoreQueryParams extends QueryParams {
                                                             // bootstrap in dest cluster
           .setStoreMigration(true)
           .setMigrationDuplicateStore(true); // Mark as duplicate store, to which L/F SN refers to avoid multi leaders
+      // Replication factor is intentionally NOT carried over during cross-cluster migration: the destination
+      // cluster's createNewStore has already applied its own default RF, and the dest cluster's topology
+    } else {
+      updateStoreQueryParams.setReplicationFactor(srcStore.getReplicationFactor());
     }
 
     ETLStoreConfig etlStoreConfig = srcStore.getEtlStoreConfig();

--- a/internal/venice-common/src/test/java/com/linkedin/venice/controllerapi/UpdateStoreQueryParamsTest.java
+++ b/internal/venice-common/src/test/java/com/linkedin/venice/controllerapi/UpdateStoreQueryParamsTest.java
@@ -5,6 +5,7 @@ import static com.linkedin.venice.controllerapi.ControllerApiConstants.STORE_MIG
 import static org.testng.Assert.assertEquals;
 
 import com.linkedin.venice.meta.IngestionPauseMode;
+import com.linkedin.venice.meta.StoreInfo;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -53,5 +54,55 @@ public class UpdateStoreQueryParamsTest {
     UpdateStoreQueryParams params = new UpdateStoreQueryParams();
     params.setIngestionPausedRegions(Collections.emptyList());
     Assert.assertTrue(params.getIngestionPausedRegions().get().isEmpty());
+  }
+
+  /**
+   * During cross-cluster store migration the source store's replication factor must NOT be carried
+   * onto the destination — destination's createNewStore has already applied the dest cluster's
+   * default RF, and the dest cluster's topology (e.g. number of Helix fault zones) may require a
+   * different RF than the source. Carrying the source RF would clobber the dest cluster default
+   * via the subsequent updateStore call, leaving the migrated store with the wrong RF.
+   */
+  @Test
+  public void testReplicationFactorOmittedDuringStoreMigration() {
+    StoreInfo srcStore = new StoreInfo();
+    srcStore.setReplicationFactor(3);
+    srcStore.setReplicationMetadataVersionId(-1);
+
+    UpdateStoreQueryParams params = new UpdateStoreQueryParams(srcStore, /*storeMigrating=*/true);
+
+    assertEquals(
+        params.getReplicationFactor(),
+        Optional.empty(),
+        "Replication factor must not be carried over during cross-cluster store migration; "
+            + "the destination cluster's createNewStore default must win.");
+    // Sanity: the migration-specific flags should still be present
+    assertEquals(params.getStoreMigration(), Optional.of(Boolean.TRUE));
+    assertEquals(params.getMigrationDuplicateStore(), Optional.of(Boolean.TRUE));
+    assertEquals(params.getLargestUsedVersionNumber(), Optional.of(0));
+  }
+
+  /**
+   * The non-migration path (within-cluster fabric copy / metadata recovery, e.g. the caller at
+   * VeniceParentHelixAdmin#copyOverStoreMetadataFromSrcFabricToDestFabric) MUST preserve the
+   * source store's replication factor — the source and destination are the same cluster, so the
+   * RF should not change.
+   */
+  @Test
+  public void testReplicationFactorPreservedWhenNotMigrating() {
+    StoreInfo srcStore = new StoreInfo();
+    srcStore.setReplicationFactor(7);
+    srcStore.setReplicationMetadataVersionId(-1);
+
+    UpdateStoreQueryParams params = new UpdateStoreQueryParams(srcStore, /*storeMigrating=*/false);
+
+    assertEquals(
+        params.getReplicationFactor(),
+        Optional.of(7),
+        "Replication factor must be preserved on the non-migration code path "
+            + "(within-cluster fabric copy / metadata recovery).");
+    // Migration-specific flags must NOT be set on this path
+    assertEquals(params.getStoreMigration(), Optional.empty());
+    assertEquals(params.getMigrationDuplicateStore(), Optional.empty());
   }
 }

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestStoreMigrationMultiRegion.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestStoreMigrationMultiRegion.java
@@ -16,6 +16,7 @@ import com.linkedin.venice.client.store.ClientFactory;
 import com.linkedin.venice.client.store.StatTrackingStoreClient;
 import com.linkedin.venice.compression.CompressionStrategy;
 import com.linkedin.venice.controllerapi.ControllerClient;
+import com.linkedin.venice.controllerapi.ControllerResponse;
 import com.linkedin.venice.controllerapi.StoreResponse;
 import com.linkedin.venice.controllerapi.UpdateStoreQueryParams;
 import com.linkedin.venice.exceptions.VeniceException;
@@ -176,6 +177,95 @@ public class TestStoreMigrationMultiRegion {
               destParentControllerClient,
               storeName,
               srcClusterName));
+    }
+  }
+
+  /**
+   * Verifies that after a cross-cluster store migration, the migrated store's replication factor matches the
+   * destination cluster's default RF — NOT the source store's RF. The check is performed at the parent controller
+   * and at every child controller.
+   */
+  @Test(timeOut = TEST_TIMEOUT)
+  public void testStoreMigrationRespectsDestinationClusterRF() throws Exception {
+    String storeName = Utils.getUniqueString("rfMigrationTest");
+    int destClusterDefaultRF = 1; // Matches replicationFactor(1) configured in setUp
+    int sourceStoreRF = 2; // Deliberately different from cluster default to surface the bug
+
+    File inputDir = getTempDataDirectory();
+    String inputDirPath = "file:" + inputDir.getAbsolutePath();
+    Properties props =
+        IntegrationTestPushUtils.defaultVPJProps(twoLayerMultiRegionMultiClusterWrapper, inputDirPath, storeName);
+    Schema recordSchema = TestWriteUtils.writeSimpleAvroFileWithStringToStringSchema(inputDir, RECORD_COUNT);
+    String keySchemaStr = recordSchema.getField(DEFAULT_KEY_FIELD_PROP).schema().toString();
+    String valueSchemaStr = recordSchema.getField(DEFAULT_VALUE_FIELD_PROP).schema().toString();
+
+    IntegrationTestPushUtils
+        .createStoreForJob(
+            srcClusterName,
+            keySchemaStr,
+            valueSchemaStr,
+            props,
+            new UpdateStoreQueryParams().setStorageQuotaInByte(Store.UNLIMITED_STORAGE_QUOTA))
+        .close();
+
+    // Override source store's RF to a value different from the cluster default so the migration result is unambiguous
+    try (ControllerClient srcParentControllerClient = new ControllerClient(srcClusterName, parentControllerUrl)) {
+      ControllerResponse rfResponse = srcParentControllerClient
+          .updateStore(storeName, new UpdateStoreQueryParams().setReplicationFactor(sourceStoreRF));
+      Assert.assertFalse(rfResponse.isError(), "Failed to set source store RF: " + rfResponse.getError());
+    }
+
+    // Verify source store has the non-default RF in parent + both child controllers before migrating.
+    // Wrap in waitForNonDeterministicAssertion since the updateStore admin message takes time to propagate
+    // from parent to children via Kafka.
+    TestUtils.waitForNonDeterministicAssertion(30, TimeUnit.SECONDS, () -> {
+      assertStoreReplicationFactor(srcClusterName, parentControllerUrl, storeName, sourceStoreRF, "src parent");
+      assertStoreReplicationFactor(srcClusterName, childControllerUrl0, storeName, sourceStoreRF, "src child0");
+      assertStoreReplicationFactor(srcClusterName, childControllerUrl1, storeName, sourceStoreRF, "src child1");
+    });
+
+    // Run the migration
+    StoreMigrationTestUtil.startMigration(parentControllerUrl, storeName, srcClusterName, destClusterName);
+    StoreMigrationTestUtil
+        .completeMigration(parentControllerUrl, storeName, srcClusterName, destClusterName, fabricList);
+
+    // After migration, the destination store must reflect the dest cluster's default RF, not the source's RF.
+    // This must hold at the dest parent AND at every dest child controller.
+    TestUtils.waitForNonDeterministicAssertion(60, TimeUnit.SECONDS, () -> {
+      assertStoreReplicationFactor(
+          destClusterName,
+          parentControllerUrl,
+          storeName,
+          destClusterDefaultRF,
+          "dest parent");
+      assertStoreReplicationFactor(
+          destClusterName,
+          childControllerUrl0,
+          storeName,
+          destClusterDefaultRF,
+          "dest child0");
+      assertStoreReplicationFactor(
+          destClusterName,
+          childControllerUrl1,
+          storeName,
+          destClusterDefaultRF,
+          "dest child1");
+    });
+  }
+
+  private void assertStoreReplicationFactor(
+      String clusterName,
+      String controllerUrl,
+      String storeName,
+      int expectedRF,
+      String label) {
+    try (ControllerClient client = new ControllerClient(clusterName, controllerUrl)) {
+      StoreResponse response = client.getStore(storeName);
+      Assert.assertNotNull(response.getStore(), "Store missing on " + label);
+      Assert.assertEquals(
+          response.getStore().getReplicationFactor(),
+          expectedRF,
+          "Replication factor mismatch on " + label + " for store " + storeName);
     }
   }
 

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestStoreMigrationMultiRegion.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestStoreMigrationMultiRegion.java
@@ -261,7 +261,10 @@ public class TestStoreMigrationMultiRegion {
       String label) {
     try (ControllerClient client = new ControllerClient(clusterName, controllerUrl)) {
       StoreResponse response = client.getStore(storeName);
-      Assert.assertNotNull(response.getStore(), "Store missing on " + label);
+      Assert.assertFalse(
+          response.isError(),
+          "Failed to fetch store on " + label + " for store " + storeName + ": " + response.getError());
+      Assert.assertNotNull(response.getStore(), "Store missing on " + label + " for store " + storeName);
       Assert.assertEquals(
           response.getStore().getReplicationFactor(),
           expectedRF,

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestStoreMigrationMultiRegion.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestStoreMigrationMultiRegion.java
@@ -231,6 +231,8 @@ public class TestStoreMigrationMultiRegion {
 
     // After migration, the destination store must reflect the dest cluster's default RF, not the source's RF.
     // This must hold at the dest parent AND at every dest child controller.
+    // Also assert the source store's RF is unchanged (migration must not mutate source-side metadata) — this
+    // catches regressions where the migration code accidentally writes back into the source's storeConfig.
     TestUtils.waitForNonDeterministicAssertion(60, TimeUnit.SECONDS, () -> {
       assertStoreReplicationFactor(
           destClusterName,
@@ -250,6 +252,11 @@ public class TestStoreMigrationMultiRegion {
           storeName,
           destClusterDefaultRF,
           "dest child1");
+      // Source store should still carry its original RF — completeMigration only flips cluster discovery
+      // and does not delete the source store (that happens at endMigration, which this test doesn't run).
+      assertStoreReplicationFactor(srcClusterName, parentControllerUrl, storeName, sourceStoreRF, "src parent (post)");
+      assertStoreReplicationFactor(srcClusterName, childControllerUrl0, storeName, sourceStoreRF, "src child0 (post)");
+      assertStoreReplicationFactor(srcClusterName, childControllerUrl1, storeName, sourceStoreRF, "src child1 (post)");
     });
   }
 


### PR DESCRIPTION

## Problem Statement
When a Venice store is migrated from one cluster to another via migrate-store, the source store's replicationFactor is silently carried onto the destination — overriding the destination cluster's default.replication.factor. The migrated store therefore retains an RF that may be wrong for the destination's topology (e.g., its number of Helix fault zones / groups), and operators have no signal that this happened.

**Root cause**

`VeniceHelixAdmin.migrateStore` does the cross-cluster cloning in two steps:

  1. `destControllerClient.createNewStore(...)` — destination's createNewStore reads `config.getReplicationFactor()` and writes the destination cluster's default RF to the new store ZNode. This step is correct.
  2. Immediately after, new `UpdateStoreQueryParams(srcStore, true)` is sent to the destination via updateStore. The constructor at `UpdateStoreQueryParams` unconditionally calls `.setReplicationFactor(srcStore.getReplicationFactor())`. The destination's updateStore honors the override and overwrites the value step 1 had just written. The override then propagates from the destination's parent to every child via the admin Kafka topic, so all fabrics end up with the source's RF.

## Solution
Drop replicationFactor from the migration-mode constructor of `UpdateStoreQueryParams` so the destination's createNewStore value (step 1) survives. The within-cluster fabric-copy path `storeMigrating == false`, used by `VeniceParentHelixAdmin#copyOverStoreMetadataFromSrcFabricToDestFabric` is unaffected — it still preserves the source RF, which is correct since source and destination are the same cluster there.

###  Code changes
- [ ] Added new code behind **a config**. If so list the config names and their default values in the PR description.
- [ ] Introduced new **log lines**. 
  - [ ] Confirmed if logs need to be **rate limited** to avoid excessive logging.

###  **Concurrency-Specific Checks**
Both reviewer and PR author to verify
- [ ] Code has **no race conditions** or **thread safety issues**.
- [ ] Proper **synchronization mechanisms** (e.g., `synchronized`, `RWLock`) are used where needed.
- [ ] No **blocking calls** inside critical sections that could lead to deadlocks or performance degradation.
- [ ] Verified **thread-safe collections** are used (e.g., `ConcurrentHashMap`, `CopyOnWriteArrayList`).
- [ ] Validated proper exception handling in multi-threaded code to avoid silent thread termination.


## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->

- [ ] New unit tests added.
- [ ] New integration tests added.
- [ ] Modified or extended existing tests.
- [ ] Verified backward compatibility (if applicable).

## Does this PR introduce any user-facing or breaking changes?
<!--  
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [ ] No. You can skip the rest of this section.
- [ ] Yes. Clearly explain the behavior change and its impact.