### PR TITLE
[da-vinci][server] Global RT DIV: Skip Transient-Record Lookup

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderProducerCallback.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderProducerCallback.java
@@ -272,6 +272,10 @@ public class LeaderProducerCallback implements ChunkAwareCallback {
       return;
     }
     if (getIngestionTask().isTransientRecordBufferUsed(pcs)) {
+      if (getSourceConsumerRecord().getKey().isGlobalRtDiv()) {
+        // Global RT DIV messages are synthetic (not from RT) and have no transient record — expected.
+        return;
+      }
       PartitionConsumptionState.TransientRecord record =
           // TransientRecord map is indexed by non-chunked key.
           pcs.getTransientRecord(getSourceConsumerRecord().getKey().getKey());

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/LeaderProducerCallbackTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/LeaderProducerCallbackTest.java
@@ -104,6 +104,59 @@ public class LeaderProducerCallbackTest {
   }
 
   @Test
+  public void testSetChunkingInfoSkipsTransientRecordLookupForGlobalRtDivMessages() {
+    LeaderFollowerStoreIngestionTask ingestionTaskMock = mock(LeaderFollowerStoreIngestionTask.class);
+    DefaultPubSubMessage sourceConsumerRecordMock = mock(DefaultPubSubMessage.class);
+    PartitionConsumptionState partitionConsumptionStateMock = mock(PartitionConsumptionState.class);
+    LeaderProducedRecordContext leaderProducedRecordContextMock = mock(LeaderProducedRecordContext.class);
+    int partition = 5;
+    String kafkaUrl = "dc-0.kafka.venice.org";
+
+    KafkaKey globalRtDivKey = mock(KafkaKey.class);
+    doReturn(true).when(globalRtDivKey).isGlobalRtDiv();
+    doReturn(globalRtDivKey).when(sourceConsumerRecordMock).getKey();
+    doReturn(true).when(ingestionTaskMock).isTransientRecordBufferUsed(any());
+
+    InMemoryLogAppender inMemoryLogAppender = new InMemoryLogAppender.Builder().build();
+    inMemoryLogAppender.start();
+    LoggerContext ctx = ((LoggerContext) LogManager.getContext(false));
+    Configuration config = ctx.getConfiguration();
+
+    try {
+      config.addLoggerAppender(
+          (org.apache.logging.log4j.core.Logger) LogManager.getLogger(LeaderProducerCallback.class),
+          inMemoryLogAppender);
+
+      LeaderProducerCallback leaderProducerCallback = new LeaderProducerCallback(
+          ingestionTaskMock,
+          sourceConsumerRecordMock,
+          partitionConsumptionStateMock,
+          leaderProducedRecordContextMock,
+          partition,
+          kafkaUrl,
+          0);
+
+      leaderProducerCallback.setChunkingInfo(new byte[0], null, null, null, null, null, null);
+
+      // Should not log "Transient record is missing" — Global RT DIV messages have no transient record by design
+      long errorLogs =
+          inMemoryLogAppender.getLogs().stream().filter(log -> log.contains("Transient record is missing")).count();
+      assertEquals(errorLogs, 0L, "setChunkingInfo should not log an error for Global RT DIV messages");
+      // Transient record map should never be consulted
+      verify(partitionConsumptionStateMock, times(0)).getTransientRecord(any());
+    } finally {
+      LoggerContext logCtx = ((LoggerContext) LogManager.getContext(false));
+      Configuration cfg = logCtx.getConfiguration();
+      LoggerConfig loggerConfig = cfg.getLoggerConfig(LeaderProducerCallback.class.getName());
+      if (loggerConfig.getName().equals(LeaderProducerCallback.class.getCanonicalName())) {
+        loggerConfig.removeAppender(inMemoryLogAppender.getName());
+      }
+      logCtx.updateLoggers();
+      inMemoryLogAppender.stop();
+    }
+  }
+
+  @Test
   public void testLeaderProducerCallbackProduceDeprecatedChunkDeletion() throws InterruptedException {
     LeaderFollowerStoreIngestionTask storeIngestionTask = mock(LeaderFollowerStoreIngestionTask.class);
     DefaultPubSubMessage sourceConsumerRecord = mock(DefaultPubSubMessage.class);

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/LeaderProducerCallbackTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/LeaderProducerCallbackTest.java
@@ -108,52 +108,25 @@ public class LeaderProducerCallbackTest {
     LeaderFollowerStoreIngestionTask ingestionTaskMock = mock(LeaderFollowerStoreIngestionTask.class);
     DefaultPubSubMessage sourceConsumerRecordMock = mock(DefaultPubSubMessage.class);
     PartitionConsumptionState partitionConsumptionStateMock = mock(PartitionConsumptionState.class);
-    LeaderProducedRecordContext leaderProducedRecordContextMock = mock(LeaderProducedRecordContext.class);
-    int partition = 5;
-    String kafkaUrl = "dc-0.kafka.venice.org";
 
     KafkaKey globalRtDivKey = mock(KafkaKey.class);
     doReturn(true).when(globalRtDivKey).isGlobalRtDiv();
     doReturn(globalRtDivKey).when(sourceConsumerRecordMock).getKey();
     doReturn(true).when(ingestionTaskMock).isTransientRecordBufferUsed(any());
 
-    InMemoryLogAppender inMemoryLogAppender = new InMemoryLogAppender.Builder().build();
-    inMemoryLogAppender.start();
-    LoggerContext ctx = ((LoggerContext) LogManager.getContext(false));
-    Configuration config = ctx.getConfiguration();
+    LeaderProducerCallback callback = new LeaderProducerCallback(
+        ingestionTaskMock,
+        sourceConsumerRecordMock,
+        partitionConsumptionStateMock,
+        mock(LeaderProducedRecordContext.class),
+        5,
+        "dc-0.kafka.venice.org",
+        0);
 
-    try {
-      config.addLoggerAppender(
-          (org.apache.logging.log4j.core.Logger) LogManager.getLogger(LeaderProducerCallback.class),
-          inMemoryLogAppender);
+    callback.setChunkingInfo(new byte[0], null, null, null, null, null, null);
 
-      LeaderProducerCallback leaderProducerCallback = new LeaderProducerCallback(
-          ingestionTaskMock,
-          sourceConsumerRecordMock,
-          partitionConsumptionStateMock,
-          leaderProducedRecordContextMock,
-          partition,
-          kafkaUrl,
-          0);
-
-      leaderProducerCallback.setChunkingInfo(new byte[0], null, null, null, null, null, null);
-
-      // Should not log "Transient record is missing" — Global RT DIV messages have no transient record by design
-      long errorLogs =
-          inMemoryLogAppender.getLogs().stream().filter(log -> log.contains("Transient record is missing")).count();
-      assertEquals(errorLogs, 0L, "setChunkingInfo should not log an error for Global RT DIV messages");
-      // Transient record map should never be consulted
-      verify(partitionConsumptionStateMock, times(0)).getTransientRecord(any());
-    } finally {
-      LoggerContext logCtx = ((LoggerContext) LogManager.getContext(false));
-      Configuration cfg = logCtx.getConfiguration();
-      LoggerConfig loggerConfig = cfg.getLoggerConfig(LeaderProducerCallback.class.getName());
-      if (loggerConfig.getName().equals(LeaderProducerCallback.class.getCanonicalName())) {
-        loggerConfig.removeAppender(inMemoryLogAppender.getName());
-      }
-      logCtx.updateLoggers();
-      inMemoryLogAppender.stop();
-    }
+    // Global RT DIV messages skip the transient record lookup entirely
+    verify(partitionConsumptionStateMock, times(0)).getTransientRecord(any());
   }
 
   @Test


### PR DESCRIPTION
## Problem Statement

When a leader produces a Global RT DIV message to the local VT, the produce callback (`LeaderProducerCallback.setChunkingInfo`) attempts a transient-record lookup against the partition's transient-record buffer. Global RT DIV messages are synthetic — they are produced directly by the leader from its in-memory DIV state and have no corresponding transient record by design. The lookup always returns `null`, which trips the "Transient record is missing" error log on every Global RT DIV message.

This is purely cosmetic noise (no behavioral fallout), but the false errors mask real transient-record issues during incident triage.

## Solution

In `LeaderProducerCallback.setChunkingInfo`, return early when the source consumer record's key is a Global RT DIV key (`isGlobalRtDiv() == true`) before reaching the transient-record lookup.

### Code changes
- [ ] Added new code behind **a config**.
- [x] Introduced new **log lines**.
  - [x] Confirmed if logs need to be **rate limited** to avoid excessive logging. (No new logs added; this fix suppresses an existing false error.)

### **Concurrency-Specific Checks**
- [x] Code has **no race conditions** or **thread safety issues**.
- [x] Proper **synchronization mechanisms** (e.g., `synchronized`, `RWLock`) are used where needed.
- [x] No **blocking calls** inside critical sections that could lead to deadlocks or performance degradation.
- [x] Verified **thread-safe collections** are used.
- [x] Validated proper exception handling in multi-threaded code.

## How was this PR tested?

- [x] New unit tests added.
  - `LeaderProducerCallbackTest.testSetChunkingInfoSkipsTransientRecordLookupForGlobalRtDivMessages` — verifies no error is logged and `getTransientRecord` is never called for a Global RT DIV source record.
- [ ] New integration tests added.
- [ ] Modified or extended existing tests.
- [x] Verified backward compatibility (if applicable). No config or protocol changes.

## Does this PR introduce any user-facing or breaking changes?

- [x] No.
