### PR TITLE
[controller] Auto-initialize ZK admin protocol version and enable detection service by default

### DIFF
--- a/internal/venice-common/src/main/java/com/linkedin/venice/ConfigKeys.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/ConfigKeys.java
@@ -3194,7 +3194,7 @@ public class ConfigKeys {
   /**
    * Enables / disables protocol version auto-detection service in parent controller.
    * This service is responsible for detecting the admin operation protocol version to serialize message
-   * Default value is disabled (false).
+   * Default value is enabled (true).
    */
   public static final String CONTROLLER_PROTOCOL_VERSION_AUTO_DETECTION_SERVICE_ENABLED =
       "controller.protocol.version.auto.detection.service.enabled";

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestProtocolVersionAutoDetection.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestProtocolVersionAutoDetection.java
@@ -38,7 +38,6 @@ public class TestProtocolVersionAutoDetection {
   @BeforeClass(alwaysRun = true)
   public void setUp() {
     Properties parentControllerProps = new Properties();
-    parentControllerProps.put(CONTROLLER_PROTOCOL_VERSION_AUTO_DETECTION_SERVICE_ENABLED, true);
     parentControllerProps.put(CONTROLLER_PROTOCOL_VERSION_AUTO_DETECTION_SLEEP_MS, SERVICE_INTERVAL_MS);
     parentControllerProps.put(CONTROLLER_SSL_ENABLED, "false");
 

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/ProtocolVersionAutoDetectionService.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/ProtocolVersionAutoDetectionService.java
@@ -25,8 +25,9 @@ import org.apache.logging.log4j.Logger;
  * 1. Get the current admin operation protocol versions from all controllers (parent + child) in the current cluster
  * and find the smallest version - good version to use.
  * 2. Get the admin operation protocol version from ZK.
- * 3. If the version in ZK is different from the current version, update the version in ZK.
- * To disable step 3, set the admin version for the cluster in ZK as -1.
+ * 3. If the version in ZK is different from the current version, update the version in ZK. This includes the case
+ *    where ZK has no recorded version (sentinel -1), which is treated as needing initialization to the current good
+ *    version.
  */
 public class ProtocolVersionAutoDetectionService extends AbstractVeniceService {
   private static final Logger LOGGER = LogManager.getLogger(ProtocolVersionAutoDetectionService.class);
@@ -134,8 +135,7 @@ public class ProtocolVersionAutoDetectionService extends AbstractVeniceService {
             clusterName,
             currentGoodVersion,
             upstreamVersion);
-        if (upstreamVersion != -1 && currentGoodVersion != Long.MAX_VALUE
-            && !Objects.equals(currentGoodVersion, upstreamVersion)) {
+        if (currentGoodVersion != Long.MAX_VALUE && !Objects.equals(currentGoodVersion, upstreamVersion)) {
           admin.updateAdminOperationProtocolVersion(clusterName, currentGoodVersion);
           LOGGER.info(
               "Updated admin operation protocol version in ZK for cluster {} from {} to {}",

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceControllerClusterConfig.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceControllerClusterConfig.java
@@ -1264,7 +1264,7 @@ public class VeniceControllerClusterConfig {
         props.getBoolean(ConfigKeys.CONTROLLER_ENABLE_HYBRID_STORE_PARTITION_COUNT_UPDATE, false);
 
     this.isProtocolVersionAutoDetectionServiceEnabled =
-        props.getBoolean(CONTROLLER_PROTOCOL_VERSION_AUTO_DETECTION_SERVICE_ENABLED, false);
+        props.getBoolean(CONTROLLER_PROTOCOL_VERSION_AUTO_DETECTION_SERVICE_ENABLED, true);
     this.protocolVersionAutoDetectionSleepMS =
         props.getLong(CONTROLLER_PROTOCOL_VERSION_AUTO_DETECTION_SLEEP_MS, TimeUnit.MINUTES.toMillis(10));
 

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceParentHelixAdmin.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceParentHelixAdmin.java
@@ -838,7 +838,7 @@ public class VeniceParentHelixAdmin implements Admin {
 
   /**
    * Fetches the writer schema ID from ZK.
-   * If the upstream protocol version (the one in /adminTopicMetadata) is -1 or larger than latest schema, returns the latest;
+   * If the upstream protocol version (the one in /adminTopicMetadataV2) is -1 or larger than latest schema, returns the latest;
    * otherwise, returns the version in ZK.
    * @param clusterName The name of the cluster for which the writer schema id is to be fetched.
    * @return The writer schema id to be used to serialize the admin operation.

--- a/services/venice-controller/src/test/java/com/linkedin/venice/controller/TestProtocolVersionAutoDetectionService.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/controller/TestProtocolVersionAutoDetectionService.java
@@ -52,8 +52,9 @@ import org.testng.annotations.Test;
  * 1. The protocol version auto-detection service correctly detects the smallest local admin operation protocol version
  *   for all consumers in the cluster.
  * 2. The service correctly updates the admin operation protocol version for the cluster.
- * 3. The service handles the case where the admin operation protocol version is -1, indicating that no update is needed.
- * 4. The service handles the case where the request to get the admin operation protocol version fails.
+ * 3. The service skips the update when the upstream version already matches the smallest good version.
+ * 4. The service updates ZK from the sentinel -1 (undefined) to the smallest good version on first detection.
+ * 5. The service handles the case where the request to get the admin operation protocol version fails.
  */
 public class TestProtocolVersionAutoDetectionService {
   private VeniceHelixAdmin admin;
@@ -192,11 +193,12 @@ public class TestProtocolVersionAutoDetectionService {
   }
 
   @Test
-  public void testProtocolVersionDetectionWithNoUpdate() throws Exception {
-    // When version is -1, no need to update
+  public void testProtocolVersionDetectionWithMatchingUpstreamVersion() throws Exception {
+    // When upstream version equals the smallest good version, no update is needed.
     AdminMetadata adminMetadata = new AdminMetadata();
     adminMetadata.setPubSubPosition(InMemoryPubSubPosition.of(1L));
     adminMetadata.setExecutionId(1L);
+    adminMetadata.setAdminOperationProtocolVersion(1L);
 
     doReturn(adminMetadata).when(admin).getAdminTopicMetadata(clusterName, Optional.empty());
 
@@ -242,6 +244,31 @@ public class TestProtocolVersionAutoDetectionService {
       assertNotNull(histogramData, "OTel detection time histogram should exist");
       assertTrue(histogramData.getCount() >= 1, "Should have at least 1 latency recording");
       assertTrue(histogramData.getSum() > 0, "OTel latency sum should be > 0");
+    });
+
+    localProtocolVersionAutoDetectionService.stopInner();
+  }
+
+  @Test
+  public void testProtocolVersionDetectionUpdatesWhenUpstreamIsUndefined() throws Exception {
+    // When upstream version is undefined (sentinel -1) in ZK, the service should still update ZK to the smallest
+    // good version observed across controllers (1L in this setup).
+    AdminMetadata adminMetadata = new AdminMetadata();
+    adminMetadata.setPubSubPosition(InMemoryPubSubPosition.of(1L));
+    adminMetadata.setExecutionId(1L);
+    // Intentionally do not call setAdminOperationProtocolVersion -> getAdminOperationProtocolVersion() returns -1.
+
+    doReturn(adminMetadata).when(admin).getAdminTopicMetadata(clusterName, Optional.empty());
+
+    ProtocolVersionAutoDetectionStats realStats = createRealStats(clusterName);
+    ProtocolVersionAutoDetectionService localProtocolVersionAutoDetectionService =
+        new ProtocolVersionAutoDetectionService(clusterName, admin, realStats, DEFAULT_SLEEP_INTERVAL_MS);
+
+    localProtocolVersionAutoDetectionService.startInner();
+
+    TestUtils.waitForNonDeterministicAssertion(5, TimeUnit.SECONDS, () -> {
+      verify(admin, atLeastOnce()).getAdminOperationVersionFromControllers(clusterName);
+      verify(adminConsumerService, atLeastOnce()).updateAdminOperationProtocolVersion(clusterName, 1L);
     });
 
     localProtocolVersionAutoDetectionService.stopInner();


### PR DESCRIPTION
## Problem Statement

`ProtocolVersionAutoDetectionService` is a parent-controller background task that reconciles the admin operation protocol version stored in ZK with the smallest version reported by all controllers (parent + child) in a cluster. 

Two issues today:

1. **The service is off by default.** `controller.protocol.version.auto.detection.service.enabled` defaulted to `false`, so parent controllers needed an explicit opt-in to run the service at all. The service has been running for 6 months+ without issue, it's safe to enable it by default.

3.  **Remove the required step to init version for cluster** The previous predicate skipped the update whenever the upstream value in ZK was `-1` (undefined).

   ```java
   if (upstreamVersion != -1 && currentGoodVersion != Long.MAX_VALUE
       && !Objects.equals(currentGoodVersion, upstreamVersion)) {
     admin.updateAdminOperationProtocolVersion(clusterName, currentGoodVersion);
   }
   ```

We will need to manually init the version by using admin-tool. With this new change, the service will auto register the version.

## Solution

1. **`[controller] Enable protocol version auto-detection service by default`**
   - Flip `CONTROLLER_PROTOCOL_VERSION_AUTO_DETECTION_SERVICE_ENABLED` default from `false` to `true` in `VeniceControllerClusterConfig`.
   - Updated the config-key Javadoc in `ConfigKeys.java` to match the new default.

2. **`[controller] Initialize ZK protocol version when undefined (-1)`**
   - Drop the `upstreamVersion != -1` short-circuit in `ProtocolVersionAutoDetectionService`. The remaining `currentGoodVersion != Long.MAX_VALUE` guard still handles the empty-controllers edge case, and the `!Objects.equals(currentGoodVersion, upstreamVersion)` check now distinguishes "needs update" from "already in sync". When ZK is `-1`, the inequality is true and the service initializes ZK to the current good version on the next tick.
   - Updated the class-level Javadoc to remove the obsolete "set ZK to -1 to disable step 3" note.
   - Fixed a stale Javadoc reference in `VeniceParentHelixAdmin#getWriterSchemaIdFromZK` (`/adminTopicMetadata` -> `/adminTopicMetadataV2`) noticed while tracing this code path.

###  Code changes
- [x] Added new code behind **a config**. — Default of `controller.protocol.version.auto.detection.service.enabled` flipped from `false` -> `true`. Listed in the description above.
- [x] Introduced new **log lines**. — N/A; existing log lines retained.

###  **Concurrency-Specific Checks**
- [x] Code has **no race conditions** or **thread safety issues**. — Single-threaded scheduled executor; only the predicate and a default config value change, no new shared state.
- [x] Proper **synchronization mechanisms** are used where needed. — N/A.
- [x] No **blocking calls** inside critical sections.
- [x] Verified **thread-safe collections** are used.
- [x] Validated proper exception handling in multi-threaded code.

## How was this PR tested?

- [x] Modified or extended existing tests.
  - Renamed `testProtocolVersionDetectionWithNoUpdate` -> `testProtocolVersionDetectionWithMatchingUpstreamVersion` and adjusted the setup to use a matching upstream (`1L`) so the no-update assertion remains meaningful under the new behavior.
  - Added `testProtocolVersionDetectionUpdatesWhenUpstreamIsUndefined` to cover the new behavior: when ZK has no recorded version, the service must write `currentGoodVersion` to ZK.
- [x] Verified with: `./gradlew :services:venice-controller:test --tests "com.linkedin.venice.controller.TestProtocolVersionAutoDetectionService"` — 5 tests pass.

## Does this PR introduce any user-facing or breaking changes?

- [x] No. The usage has been running for a while. This is a clean up PR.