### PR TITLE
[da-vinci][server] Global RT DIV: Fix Missing OffsetRecord Sync for Remote VT Leaders

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTask.java
@@ -2082,27 +2082,23 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
   }
 
   /**
-   * Mirrors {@link #sendGlobalRtDivMessage}'s LCVP-sync callback for leaders consuming from a VT source
-   * (in practice: remote VT under NR). VT consumption has no RT DIV state to propagate, so
-   * {@code sendGlobalRtDivMessage} — the normal path that hands the VT DIV from the consumer to the
-   * drainer — is never invoked. Without this callback, the OffsetRecord's latestConsumedVtPosition stays
-   * at EARLIEST and ingestion rewinds to the start of VT on the next leader restart.
+   * Mirrors {@link #sendGlobalRtDivMessage}'s LCVP-sync callback for leaders consuming from a remote VT source in NR
+   * VT consumption has no RT DIV state to propagate, so {@link #sendGlobalRtDivMessage} — the normal path that hands
+   * the VT DIV to the drainer — is never invoked. Without this callback, the OffsetRecord's latestConsumedVtPosition
+   * stays at EARLIEST and ingestion rewinds to the start of VT on the next leader restart.
    *
-   * <p>Why {@code !isRealTime()} is the right gate, even though {@link com.linkedin.venice.pubsub.api.PubSubTopic}
-   * cannot distinguish local VT from remote VT (the topic name is identical across regions):
-   * <ul>
-   *   <li>{@link #produceToLocalKafka} is only invoked on the leader replica
-   *       ({@link #shouldProduceToVersionTopic} is true), and a leader does not consume its own local VT.
-   *   <li>Leader consuming RT (local or remote) → {@code isRealTime()} is true → early return; the LCVP
-   *       sync is handled by {@code sendGlobalRtDivMessage}.
-   *   <li>Leader consuming remote VT (NR) → {@code isRealTime()} is false → proceeds to install the
-   *       on-completion VT DIV sync.
-   * </ul>
+   * Why {@code !isRealTime()} is the right gate, even though PubSubTopic cannot distinguish local VT
+   * from remote VT (the topic name is identical across regions):
+   *   - {@link #produceToLocalKafka} is only called on the leader ({@link #shouldProduceToVersionTopic}
+   *     is true), and a leader does not consume its own local VT.
+   *   - Leader consuming RT (local or remote): {@code isRealTime()} is true → early return; LCVP sync
+   *     is handled by {@code sendGlobalRtDivMessage}.
+   *   - Leader consuming remote VT (NR): {@code isRealTime()} is false → installs the on-completion
+   *     VT DIV sync.
    *
-   * <p>No-op unless Global RT DIV is enabled, the consumed source is non-RT, and the byte threshold for
-   * a Global RT DIV sync has been reached. The same predicate gates {@code sendGlobalRtDivMessage}, but
-   * keyed on the local VT name — VT-source bytes (local or remote) share the VT-name counter and are
-   * tracked separately from per-broker RT bytes.
+   * No-op unless Global RT DIV is enabled, the consumed source is non-RT, and the byte threshold for a
+   * Global RT DIV sync has been reached. The same predicate gates {@code sendGlobalRtDivMessage}, keyed
+   * on the local VT name — VT-source bytes share the VT-name counter, tracked separately from RT bytes.
    */
   void addVtDivToProducerCallbackIfNeeded(
       DefaultPubSubMessage consumerRecord,
@@ -2124,9 +2120,8 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
    * Installs an onCompletion callback on {@code callback} that, when the produce to local VT completes,
    * updates {@code vtDiv}'s LCVP to the produced position and queues a drainer-side OffsetRecord sync.
    * Restores the thread interrupt flag if the drainer rejects with {@link InterruptedException}.
-   *
-   * <p>Shared by the leader-RT-source path ({@link #createGlobalRtDivCallback}) and the leader-VT-source
-   * path ({@link #addVtDivToProducerCallbackIfNeeded}).
+   * Shared by {@link #createGlobalRtDivCallback} (leader-RT-source) and
+   * {@link #addVtDivToProducerCallbackIfNeeded} (leader-VT-source).
    */
   private void sendVtDivSnapshotOnCompletion(
       LeaderProducerCallback callback,

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTask.java
@@ -2055,11 +2055,10 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
     /* Leaders consuming from remote VT will produce records to local VT but do not send Global RT DIV messages, since
      * VT consumption has no RT DIV state to propagate. The VT DIV is normally passed from the consumer to the drainer
      * in {@link #sendGlobalRtDivMessage} which is never called, so install a post-completion callback on the regular
-     * callback in order for the LCVP and OffsetRecord to be synced.
+     * callback in order for the LCVP and OffsetRecord to be synced. The install is gated internally by
+     * {@link #addVtDivToProducerCallback} on the same conditions {@code sendGlobalRtDivMessage} is gated on.
      */
-    if (shouldProducerCallbackSendVtDiv(consumerRecord, partitionConsumptionState)) {
-      addVtDivToProducerCallback(callback, partitionConsumptionState, leaderProducedRecordContext);
-    }
+    addVtDivToProducerCallback(consumerRecord, callback, partitionConsumptionState, leaderProducedRecordContext);
 
     PubSubPosition consumedPosition = consumerRecord.getPosition();
     LeaderMetadataWrapper leaderMetadataWrapper =
@@ -2086,21 +2085,24 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
     }
   }
 
-  boolean shouldProducerCallbackSendVtDiv(DefaultPubSubMessage consumerRecord, PartitionConsumptionState pcs) {
-    return isGlobalRtDivEnabled() && !consumerRecord.getTopicPartition().getPubSubTopic().isRealTime()
-        && shouldSendGlobalRtDiv(consumerRecord, pcs, getVersionTopic().getName());
-  }
-
   /**
    * Mirrors {@link #sendGlobalRtDivMessage}'s LCVP-sync callback for leaders consuming from a VT source.
-   * Snapshots the VT producer states from {@link #consumerDiv}, installs an onCompletionCallback that updates LCVP
-   * with the produced-local-VT position and triggers
+   * No-op unless Global RT DIV is enabled, the consumed source is a non-RT topic (e.g., remote VT), and the
+   * byte threshold for a Global RT DIV sync has been reached.
+   *
+   * <p>When the gate passes, snapshots the VT producer states from {@link #consumerDiv} and installs an
+   * onCompletionCallback that updates LCVP with the produced-local-VT position and triggers
    * {@link com.linkedin.davinci.kafka.consumer.StoreBufferService#execSyncOffsetFromSnapshotAsync} via the drainer.
    */
   void addVtDivToProducerCallback(
+      DefaultPubSubMessage consumerRecord,
       LeaderProducerCallback callback,
       PartitionConsumptionState pcs,
       LeaderProducedRecordContext leaderProducedRecordContext) {
+    if (!isGlobalRtDivEnabled() || consumerRecord.getTopicPartition().getPubSubTopic().isRealTime()
+        || !shouldSendGlobalRtDiv(consumerRecord, pcs, getVersionTopic().getName())) {
+      return;
+    }
     PubSubTopicPartition topicPartition = pcs.getReplicaTopicPartition();
     PartitionTracker vtDiv =
         consumerDiv.cloneVtProducerStates(pcs.getPartition(), true, pcs.getLatestMessageTimeInMs());

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTask.java
@@ -2052,12 +2052,6 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
         kafkaUrl,
         beforeProcessingRecordTimestampNs);
 
-    /* Leaders consuming from remote VT will produce records to local VT but do not send Global RT DIV messages, since
-     * VT consumption has no RT DIV state to propagate. The VT DIV is normally passed from the consumer to the drainer
-     * in {@link #sendGlobalRtDivMessage} which is never called, so install a post-completion callback on the regular
-     * callback in order for the LCVP and OffsetRecord to be synced. The install is gated internally by
-     * {@link #addVtDivToProducerCallback} on the same conditions {@code sendGlobalRtDivMessage} is gated on.
-     */
     addVtDivToProducerCallbackIfNeeded(consumerRecord, callback, pcs, leaderProducedRecordContext);
 
     PubSubPosition consumedPosition = consumerRecord.getPosition();
@@ -2086,13 +2080,15 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
   }
 
   /**
-   * Mirrors {@link #sendGlobalRtDivMessage}'s LCVP-sync callback for leaders consuming from a VT source.
-   * No-op unless Global RT DIV is enabled, the consumed source is a non-RT topic (e.g., remote VT), and the
-   * byte threshold for a Global RT DIV sync has been reached.
+   * Mirrors {@link #sendGlobalRtDivMessage}'s LCVP-sync callback for leaders consuming from a VT source
+   * (e.g., remote VT under NR). VT consumption has no RT DIV state to propagate, so
+   * {@code sendGlobalRtDivMessage} — the normal path that hands the VT DIV from the consumer to the
+   * drainer — is never invoked. Without this callback, the OffsetRecord's latestConsumedVtPosition stays
+   * at EARLIEST and ingestion rewinds to the start of VT on the next leader restart.
    *
-   * <p>When the gate passes, snapshots the VT producer states from {@link #consumerDiv} and installs an
-   * onCompletionCallback that updates LCVP with the produced-local-VT position and triggers
-   * {@link com.linkedin.davinci.kafka.consumer.StoreBufferService#execSyncOffsetFromSnapshotAsync} via the drainer.
+   * <p>No-op unless Global RT DIV is enabled, the consumed source is a non-RT topic, and the byte threshold
+   * for a Global RT DIV sync has been reached. The same predicate gates {@code sendGlobalRtDivMessage},
+   * but keyed on the local VT name so VT-source bytes are tracked separately from per-broker RT bytes.
    */
   void addVtDivToProducerCallbackIfNeeded(
       DefaultPubSubMessage consumerRecord,
@@ -2106,26 +2102,33 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
     PubSubTopicPartition topicPartition = pcs.getReplicaTopicPartition();
     PartitionTracker vtDiv =
         consumerDiv.cloneVtProducerStates(pcs.getPartition(), true, pcs.getLatestMessageTimeInMs());
+    sendVtDivSnapshotOnCompletion(callback, topicPartition, vtDiv, leaderProducedRecordContext);
+    pcs.resetConsumedBytesSinceLastGlobalRtDivSync(getVersionTopic().getName());
+  }
+
+  /**
+   * Installs an onCompletion callback on {@code callback} that, when the produce to local VT completes,
+   * updates {@code vtDiv}'s LCVP to the produced position and queues a drainer-side OffsetRecord sync.
+   * Restores the thread interrupt flag if the drainer rejects with {@link InterruptedException}.
+   *
+   * <p>Shared by the leader-RT-source path ({@link #createGlobalRtDivCallback}) and the leader-VT-source
+   * path ({@link #addVtDivToProducerCallbackIfNeeded}).
+   */
+  private void sendVtDivSnapshotOnCompletion(
+      LeaderProducerCallback callback,
+      PubSubTopicPartition topicPartition,
+      PartitionTracker vtDiv,
+      LeaderProducedRecordContext context) {
     callback.setOnCompletionCallback(produceResult -> {
       try {
-        CompletableFuture<Void> lastRecordPersistedFuture = leaderProducedRecordContext.getPersistedToDBFuture();
-        // LCVP = produced position in local VT (matches the leader-RT pattern in sendGlobalRtDivMessage)
+        CompletableFuture<Void> persistedFuture = context.getPersistedToDBFuture();
         vtDiv.updateLatestConsumedVtPosition(produceResult.getPubSubPosition());
-        storeBufferService.execSyncOffsetFromSnapshotAsync(topicPartition, vtDiv, lastRecordPersistedFuture, this);
-        // TODO: remove. this is a temporary log for debugging while the feature is in its infancy
-        LOGGER.info(
-            "event=globalRtDiv Syncing LCVP from VT-source produce callback topic-partition: {} producedPosition: {}",
-            topicPartition,
-            produceResult.getPubSubPosition());
+        storeBufferService.execSyncOffsetFromSnapshotAsync(topicPartition, vtDiv, persistedFuture, this);
       } catch (InterruptedException e) {
-        LOGGER.error(
-            "event=globalRtDiv Failed to sync VT LCVP for VT-source leader on topic-partition: {}",
-            topicPartition,
-            e);
+        LOGGER.error("event=globalRtDiv Failed to async VT DIV OffsetRecord sync for replica: {}", topicPartition, e);
         Thread.currentThread().interrupt();
       }
     });
-    pcs.resetConsumedBytesSinceLastGlobalRtDivSync(getVersionTopic().getName());
   }
 
   @Override
@@ -3224,18 +3227,17 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
 
       CompletableFuture<Void> lastFuture = pcs.getLastQueuedRecordPersistedFuture();
       storeBufferService.execSyncOffsetFromSnapshotAsync(topicPartition, vtDiv, lastFuture, this);
-      // Reset consumer-side VT bytes so the size-based condition in shouldSyncOffsetFromSnapshot does not keep
-      // firing for every subsequent record.
+      // Reset consumer-side VT bytes so shouldSyncOffsetFromSnapshot does not keep firing for every subsequent record
       pcs.resetConsumedBytesSinceLastGlobalRtDivSync(getVersionTopic().getName());
 
       // TODO: remove. this is a temporary log for debugging while the feature is in its infancy
       LOGGER.info(
-          "event=globalRtDiv Syncing LCVP for OffsetRecord topic-partition: {} position: {} size: {}",
+          "event=globalRtDiv Sending LCVP for OffsetRecord topic-partition: {} position: {} size: {}",
           topicPartition,
           record.getPosition(),
           vtDiv.getPartitionStates(PartitionTracker.VERSION_TOPIC).size());
     } catch (InterruptedException e) {
-      LOGGER.error("event=globalRtDiv Unable to sync Offset Record to update the latest consumed vt position", e);
+      LOGGER.error("event=globalRtDiv Unable to send OffsetRecord to update the latest consumed vt position", e);
     }
   }
 
@@ -4098,17 +4100,8 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
     LeaderProducerCallback divCallback =
         createProducerCallback(divMessage, pcs, context, partition, brokerUrl, beforeProcessingRecordTimestampNs);
 
-    // After producing the RT DIV to local VT and LeaderProducerCallback.onCompletion() enqueuing RT DIV in the drainer,
-    // the VT DIV should be sent to the drainer to persist the LCVP onto disk by syncing the OffsetRecord
-    divCallback.setOnCompletionCallback(produceResult -> {
-      try {
-        CompletableFuture<Void> lastRecordPersistedFuture = context.getPersistedToDBFuture();
-        vtDiv.updateLatestConsumedVtPosition(produceResult.getPubSubPosition()); // LCVP = produced position in local VT
-        storeBufferService.execSyncOffsetFromSnapshotAsync(topicPartition, vtDiv, lastRecordPersistedFuture, this);
-      } catch (InterruptedException e) {
-        LOGGER.error("event=globalRtDiv Failed to sync VT DIV to OffsetRecord for replica: {}", topicPartition, e);
-      }
-    });
+    // After producing the RT DIV to local VT, the drainer should sync the VT DIV + LCVP within the OffsetRecord
+    sendVtDivSnapshotOnCompletion(divCallback, topicPartition, vtDiv, context);
 
     return divCallback;
   }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTask.java
@@ -3199,9 +3199,9 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
     }
   }
 
-  void syncOffsetFromSnapshotIfNeeded(DefaultPubSubMessage record, PubSubTopicPartition topicPartition) {
+  void sendVtDivSnapshotIfNeeded(DefaultPubSubMessage record, PubSubTopicPartition topicPartition) {
     int partition = topicPartition.getPartitionNumber();
-    if (!isGlobalRtDivEnabled() || !shouldSyncOffsetFromSnapshot(record, getPartitionConsumptionState(partition))) {
+    if (!isGlobalRtDivEnabled() || !shouldSendVtDivSnapshot(record, getPartitionConsumptionState(partition))) {
       return; // without Global RT DIV enabled, the offset record is synced in the drainer in syncOffset()
     }
 
@@ -3209,7 +3209,7 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
     if (pcs == null || pcs.getLastQueuedRecordPersistedFuture() == null) {
       LOGGER.warn(
           "event=globalRtDiv No PCS or lastRecordPersistedFuture found for topic-partition: {}. "
-              + "Will not sync OffsetRecord without waiting for any record to be persisted",
+              + "Will not send VT DIV snapshot without waiting for any record to be persisted",
           topicPartition);
       return;
     }
@@ -3219,7 +3219,7 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
       long latestMessageTimeInMs = pcs.getLatestMessageTimeInMs();
       PartitionTracker vtDiv = getConsumerDiv().cloneVtProducerStates(partition, true, latestMessageTimeInMs);
 
-      // Skip sync if no real VT progress has been made yet. Syncing with EARLIEST would persist
+      // Skip send if no real VT progress has been made yet. Syncing with EARLIEST would persist
       // EARLIEST to the OffsetRecord, causing the consumer to re-subscribe from EARLIEST on retry.
       if (PubSubSymbolicPosition.EARLIEST.equals(vtDiv.getLatestConsumedVtPosition())) {
         return;
@@ -3227,7 +3227,7 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
 
       CompletableFuture<Void> lastFuture = pcs.getLastQueuedRecordPersistedFuture();
       storeBufferService.execSyncOffsetFromSnapshotAsync(topicPartition, vtDiv, lastFuture, this);
-      // Reset consumer-side VT bytes so shouldSyncOffsetFromSnapshot does not keep firing for every subsequent record
+      // Reset consumer-side VT bytes so shouldSendVtDivSnapshot does not keep firing for every subsequent record
       pcs.resetConsumedBytesSinceLastGlobalRtDivSync(getVersionTopic().getName());
 
       // TODO: remove. this is a temporary log for debugging while the feature is in its infancy
@@ -3242,28 +3242,28 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
   }
 
   /**
-   * Followers should sync the VT DIV to the OffsetRecord if the consumer sees a non-segment control message or a
+   * Followers should send the VT DIV to the OffsetRecord if the consumer sees a non-segment control message or a
    * Global RT DIV message.
-   * Each Global RT DIV sync will create one singular Put or multiple Puts (chunks + one manifest + Deletes). Thus
-   * if we want to sync only once, checking if it's a singular Put or the manifest Put should only trigger once.
+   * Each Global RT DIV replication will create one singular Put or multiple Puts (chunks + one manifest + Deletes).
+   * Thus, if we want to send only once, checking if it's a singular Put or the manifest Put should only trigger once.
    */
-  boolean shouldSyncOffsetFromSnapshot(DefaultPubSubMessage consumerRecord, PartitionConsumptionState pcs) {
+  boolean shouldSendVtDivSnapshot(DefaultPubSubMessage consumerRecord, PartitionConsumptionState pcs) {
     if (consumerRecord.getKey().isGlobalRtDiv()) {
       Object payloadUnion = consumerRecord.getValue().getPayloadUnion();
       if (payloadUnion instanceof Put && ((Put) payloadUnion).getSchemaId() != CHUNK_SCHEMA_ID) {
-        return true; // Global RT DIV message can be multiple chunks + deletes, only sync on one Put (manifest or value)
+        return true; // Global RT DIV message can be multiple chunks + deletes, only send on one Put (manifest or value)
       }
     } else if (isNonSegmentControlMessage(consumerRecord, null)) {
-      return true; // sync when processing most control messages
+      return true; // send when processing most control messages
     }
 
     if (pcs == null) {
-      LOGGER.warn("event=globalRtDiv No PCS found for: {} Will not sync VT DIV", consumerRecord.getTopicPartition());
+      LOGGER.warn("event=globalRtDiv No PCS found for: {} Will not send VT DIV", consumerRecord.getTopicPartition());
       return false;
     }
 
     // must be greater than the interval in shouldSendGlobalRtDiv() to not interfere
-    final long syncBytesInterval = getSyncBytesInterval(pcs); // size-based sync condition
+    final long syncBytesInterval = getSyncBytesInterval(pcs); // size-based send condition
     long vtConsumedBytesSinceLastSync = pcs.getConsumedBytesSinceLastGlobalRtDivSync(getVersionTopic().getName());
     return syncBytesInterval > 0 && (vtConsumedBytesSinceLastSync >= 2 * syncBytesInterval);
   }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTask.java
@@ -2060,8 +2060,7 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
      * the produce. The callback fires after the produce completes; it sets LCVP to the produced
      * position in local VT and asynchronously syncs the OffsetRecord via the drainer.
      */
-    if (isGlobalRtDivEnabled() && !consumerRecord.getTopicPartition().getPubSubTopic().isRealTime()
-        && shouldSendGlobalRtDiv(consumerRecord, partitionConsumptionState, getVersionTopic().getName())) {
+    if (shouldInstallVtLcvpSyncCallback(consumerRecord, partitionConsumptionState)) {
       installVtLcvpSyncCallback(callback, partitionConsumptionState, partition, leaderProducedRecordContext);
     }
 
@@ -2088,6 +2087,17 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
     } catch (Exception e) {
       LOGGER.error("Failed to send Global RT DIV message", e);
     }
+  }
+
+  /**
+   * Predicate gating {@link #installVtLcvpSyncCallback}: only install the LCVP-sync callback when
+   * the Global RT DIV feature is enabled, the consumed source is non-RT (i.e., VT), and the
+   * configured byte-threshold for a Global RT DIV sync has been reached. Extracted into a helper
+   * so the gate's three branches can be exercised directly in unit tests.
+   */
+  boolean shouldInstallVtLcvpSyncCallback(DefaultPubSubMessage consumerRecord, PartitionConsumptionState pcs) {
+    return isGlobalRtDivEnabled() && !consumerRecord.getTopicPartition().getPubSubTopic().isRealTime()
+        && shouldSendGlobalRtDiv(consumerRecord, pcs, getVersionTopic().getName());
   }
 
   /**
@@ -2122,6 +2132,7 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
             "event=globalRtDiv Failed to sync VT LCVP for VT-source leader on topic-partition: {}",
             topicPartition,
             e);
+        Thread.currentThread().interrupt();
       }
     });
     pcs.resetConsumedBytesSinceLastGlobalRtDivSync(getVersionTopic().getName());

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTask.java
@@ -2037,7 +2037,7 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
 
   protected void produceToLocalKafka(
       DefaultPubSubMessage consumerRecord,
-      PartitionConsumptionState partitionConsumptionState,
+      PartitionConsumptionState pcs,
       LeaderProducedRecordContext leaderProducedRecordContext,
       BiConsumer<ChunkAwareCallback, LeaderMetadataWrapper> produceFunction,
       int partition,
@@ -2046,7 +2046,7 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
       long beforeProcessingRecordTimestampNs) {
     LeaderProducerCallback callback = createProducerCallback(
         consumerRecord,
-        partitionConsumptionState,
+        pcs,
         leaderProducedRecordContext,
         partition,
         kafkaUrl,
@@ -2058,12 +2058,12 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
      * callback in order for the LCVP and OffsetRecord to be synced. The install is gated internally by
      * {@link #addVtDivToProducerCallback} on the same conditions {@code sendGlobalRtDivMessage} is gated on.
      */
-    addVtDivToProducerCallback(consumerRecord, callback, partitionConsumptionState, leaderProducedRecordContext);
+    addVtDivToProducerCallbackIfNeeded(consumerRecord, callback, pcs, leaderProducedRecordContext);
 
     PubSubPosition consumedPosition = consumerRecord.getPosition();
     LeaderMetadataWrapper leaderMetadataWrapper =
         new LeaderMetadataWrapper(consumedPosition, kafkaClusterId, DEFAULT_TERM_ID);
-    partitionConsumptionState.setLastLeaderPersistFuture(leaderProducedRecordContext.getPersistedToDBFuture());
+    pcs.setLastLeaderPersistFuture(leaderProducedRecordContext.getPersistedToDBFuture());
     long beforeProduceTimestampNS = System.nanoTime();
     produceFunction.accept(callback, leaderMetadataWrapper);
     double enqueueLatency = LatencyUtils.getElapsedTimeFromNSToMS(beforeProduceTimestampNS);
@@ -2071,10 +2071,10 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
     getVersionIngestionStats().recordProducerEnqueueTime(storeName, versionNumber, enqueueLatency);
 
     try {
-      if (shouldSendGlobalRtDiv(consumerRecord, partitionConsumptionState, kafkaUrl)) {
+      if (shouldSendGlobalRtDiv(consumerRecord, pcs, kafkaUrl)) {
         sendGlobalRtDivMessage(
             consumerRecord,
-            partitionConsumptionState,
+            pcs,
             partition,
             kafkaUrl,
             beforeProcessingRecordTimestampNs,
@@ -2094,7 +2094,7 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
    * onCompletionCallback that updates LCVP with the produced-local-VT position and triggers
    * {@link com.linkedin.davinci.kafka.consumer.StoreBufferService#execSyncOffsetFromSnapshotAsync} via the drainer.
    */
-  void addVtDivToProducerCallback(
+  void addVtDivToProducerCallbackIfNeeded(
       DefaultPubSubMessage consumerRecord,
       LeaderProducerCallback callback,
       PartitionConsumptionState pcs,

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTask.java
@@ -2105,7 +2105,7 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
     }
     PubSubTopicPartition topicPartition = pcs.getReplicaTopicPartition();
     PartitionTracker vtDiv =
-        consumerDiv.cloneVtProducerStates(pcs.getPartition(), true, pcs.getLatestMessageTimeInMs());
+        getConsumerDiv().cloneVtProducerStates(pcs.getPartition(), true, pcs.getLatestMessageTimeInMs());
     sendVtDivSnapshotOnCompletion(callback, topicPartition, vtDiv, persistedToDBFuture);
     pcs.resetConsumedBytesSinceLastGlobalRtDivSync(getVersionTopic().getName());
   }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTask.java
@@ -2061,7 +2061,7 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
      * position in local VT and asynchronously syncs the OffsetRecord via the drainer.
      */
     if (shouldInstallVtLcvpSyncCallback(consumerRecord, partitionConsumptionState)) {
-      installVtLcvpSyncCallback(callback, partitionConsumptionState, partition, leaderProducedRecordContext);
+      installVtLcvpSyncCallback(callback, partitionConsumptionState, leaderProducedRecordContext);
     }
 
     PubSubPosition consumedPosition = consumerRecord.getPosition();
@@ -2111,11 +2111,10 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
   void installVtLcvpSyncCallback(
       LeaderProducerCallback callback,
       PartitionConsumptionState pcs,
-      int partition,
       LeaderProducedRecordContext leaderProducedRecordContext) {
     PubSubTopicPartition topicPartition = pcs.getReplicaTopicPartition();
-    long latestMessageTimeInMs = pcs.getLatestMessageTimeInMs();
-    PartitionTracker vtDiv = consumerDiv.cloneVtProducerStates(partition, true, latestMessageTimeInMs);
+    PartitionTracker vtDiv =
+        consumerDiv.cloneVtProducerStates(pcs.getPartition(), true, pcs.getLatestMessageTimeInMs());
     callback.setOnCompletionCallback(produceResult -> {
       try {
         CompletableFuture<Void> lastRecordPersistedFuture = leaderProducedRecordContext.getPersistedToDBFuture();

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTask.java
@@ -2083,23 +2083,33 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
 
   /**
    * Mirrors {@link #sendGlobalRtDivMessage}'s LCVP-sync callback for leaders consuming from a VT source
-   * (i.e., remote VT under NR — same topic name as the local VT, so {@code getVersionTopic().equals(...)}
-   * matches both). VT consumption has no RT DIV state to propagate, so {@code sendGlobalRtDivMessage} —
-   * the normal path that hands the VT DIV from the consumer to the drainer — is never invoked. Without
-   * this callback, the OffsetRecord's latestConsumedVtPosition stays at EARLIEST and ingestion rewinds
-   * to the start of VT on the next leader restart.
+   * (in practice: remote VT under NR). VT consumption has no RT DIV state to propagate, so
+   * {@code sendGlobalRtDivMessage} — the normal path that hands the VT DIV from the consumer to the
+   * drainer — is never invoked. Without this callback, the OffsetRecord's latestConsumedVtPosition stays
+   * at EARLIEST and ingestion rewinds to the start of VT on the next leader restart.
    *
-   * <p>No-op unless Global RT DIV is enabled, the consumed source is the version topic, and the byte
-   * threshold for a Global RT DIV sync has been reached. The same predicate gates
-   * {@code sendGlobalRtDivMessage}, but keyed on the local VT name — so VT-source bytes (local or remote)
-   * are tracked under the VT-name counter and counted separately from per-broker RT bytes.
+   * <p>Why {@code !isRealTime()} is the right gate, even though {@link com.linkedin.venice.pubsub.api.PubSubTopic}
+   * cannot distinguish local VT from remote VT (the topic name is identical across regions):
+   * <ul>
+   *   <li>{@link #produceToLocalKafka} is only invoked on the leader replica
+   *       ({@link #shouldProduceToVersionTopic} is true), and a leader does not consume its own local VT.
+   *   <li>Leader consuming RT (local or remote) → {@code isRealTime()} is true → early return; the LCVP
+   *       sync is handled by {@code sendGlobalRtDivMessage}.
+   *   <li>Leader consuming remote VT (NR) → {@code isRealTime()} is false → proceeds to install the
+   *       on-completion VT DIV sync.
+   * </ul>
+   *
+   * <p>No-op unless Global RT DIV is enabled, the consumed source is non-RT, and the byte threshold for
+   * a Global RT DIV sync has been reached. The same predicate gates {@code sendGlobalRtDivMessage}, but
+   * keyed on the local VT name — VT-source bytes (local or remote) share the VT-name counter and are
+   * tracked separately from per-broker RT bytes.
    */
   void addVtDivToProducerCallbackIfNeeded(
       DefaultPubSubMessage consumerRecord,
       LeaderProducerCallback callback,
       PartitionConsumptionState pcs,
       CompletableFuture<Void> persistedToDBFuture) {
-    if (!isGlobalRtDivEnabled() || !getVersionTopic().equals(consumerRecord.getTopicPartition().getPubSubTopic())
+    if (!isGlobalRtDivEnabled() || consumerRecord.getTopicPartition().getPubSubTopic().isRealTime()
         || !shouldSendGlobalRtDiv(consumerRecord, pcs, getVersionTopic().getName())) {
       return;
     }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTask.java
@@ -2051,6 +2051,20 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
         partition,
         kafkaUrl,
         beforeProcessingRecordTimestampNs);
+
+    /**
+     * Leaders consuming from a VT source (e.g., remote VT) produce records to local VT but do not
+     * send Global RT DIV messages, since VT consumption has no RT DIV state to propagate. To ensure
+     * the latest consumed VT position (LCVP) is still persisted to the OffsetRecord on disk for
+     * those leaders, install a sync callback on the regular producer callback before dispatching
+     * the produce. The callback fires after the produce completes; it sets LCVP to the produced
+     * position in local VT and asynchronously syncs the OffsetRecord via the drainer.
+     */
+    if (isGlobalRtDivEnabled() && !consumerRecord.getTopicPartition().getPubSubTopic().isRealTime()
+        && shouldSendGlobalRtDiv(consumerRecord, partitionConsumptionState, getVersionTopic().getName())) {
+      installVtLcvpSyncCallback(callback, partitionConsumptionState, partition, leaderProducedRecordContext);
+    }
+
     PubSubPosition consumedPosition = consumerRecord.getPosition();
     LeaderMetadataWrapper leaderMetadataWrapper =
         new LeaderMetadataWrapper(consumedPosition, kafkaClusterId, DEFAULT_TERM_ID);
@@ -2074,6 +2088,43 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
     } catch (Exception e) {
       LOGGER.error("Failed to send Global RT DIV message", e);
     }
+  }
+
+  /**
+   * Mirrors {@link #sendGlobalRtDivMessage}'s LCVP-sync callback for leaders consuming from a VT
+   * source. Snapshots the VT producer states from {@link #consumerDiv}, installs an
+   * onCompletionCallback that updates LCVP with the produced-local-VT position and triggers
+   * {@link com.linkedin.davinci.kafka.consumer.StoreBufferService#execSyncOffsetFromSnapshotAsync}
+   * via the drainer. The byte counter is reset synchronously, matching the RT path's behavior, so
+   * subsequent threshold checks gate correctly.
+   */
+  void installVtLcvpSyncCallback(
+      LeaderProducerCallback callback,
+      PartitionConsumptionState pcs,
+      int partition,
+      LeaderProducedRecordContext leaderProducedRecordContext) {
+    PubSubTopicPartition topicPartition = pcs.getReplicaTopicPartition();
+    long latestMessageTimeInMs = pcs.getLatestMessageTimeInMs();
+    PartitionTracker vtDiv = consumerDiv.cloneVtProducerStates(partition, true, latestMessageTimeInMs);
+    callback.setOnCompletionCallback(produceResult -> {
+      try {
+        CompletableFuture<Void> lastRecordPersistedFuture = leaderProducedRecordContext.getPersistedToDBFuture();
+        // LCVP = produced position in local VT (matches the leader-RT pattern in sendGlobalRtDivMessage)
+        vtDiv.updateLatestConsumedVtPosition(produceResult.getPubSubPosition());
+        storeBufferService.execSyncOffsetFromSnapshotAsync(topicPartition, vtDiv, lastRecordPersistedFuture, this);
+        // TODO: remove. this is a temporary log for debugging while the feature is in its infancy
+        LOGGER.info(
+            "event=globalRtDiv Syncing LCVP from VT-source produce callback topic-partition: {} producedPosition: {}",
+            topicPartition,
+            produceResult.getPubSubPosition());
+      } catch (InterruptedException e) {
+        LOGGER.error(
+            "event=globalRtDiv Failed to sync VT LCVP for VT-source leader on topic-partition: {}",
+            topicPartition,
+            e);
+      }
+    });
+    pcs.resetConsumedBytesSinceLastGlobalRtDivSync(getVersionTopic().getName());
   }
 
   @Override

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTask.java
@@ -2052,12 +2052,14 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
         kafkaUrl,
         beforeProcessingRecordTimestampNs);
 
-    addVtDivToProducerCallbackIfNeeded(consumerRecord, callback, pcs, leaderProducedRecordContext);
-
     PubSubPosition consumedPosition = consumerRecord.getPosition();
     LeaderMetadataWrapper leaderMetadataWrapper =
         new LeaderMetadataWrapper(consumedPosition, kafkaClusterId, DEFAULT_TERM_ID);
-    pcs.setLastLeaderPersistFuture(leaderProducedRecordContext.getPersistedToDBFuture());
+    CompletableFuture<Void> persistedToDBFuture = leaderProducedRecordContext.getPersistedToDBFuture();
+    pcs.setLastLeaderPersistFuture(persistedToDBFuture);
+
+    addVtDivToProducerCallbackIfNeeded(consumerRecord, callback, pcs, persistedToDBFuture);
+
     long beforeProduceTimestampNS = System.nanoTime();
     produceFunction.accept(callback, leaderMetadataWrapper);
     double enqueueLatency = LatencyUtils.getElapsedTimeFromNSToMS(beforeProduceTimestampNS);
@@ -2081,28 +2083,30 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
 
   /**
    * Mirrors {@link #sendGlobalRtDivMessage}'s LCVP-sync callback for leaders consuming from a VT source
-   * (e.g., remote VT under NR). VT consumption has no RT DIV state to propagate, so
-   * {@code sendGlobalRtDivMessage} — the normal path that hands the VT DIV from the consumer to the
-   * drainer — is never invoked. Without this callback, the OffsetRecord's latestConsumedVtPosition stays
-   * at EARLIEST and ingestion rewinds to the start of VT on the next leader restart.
+   * (i.e., remote VT under NR — same topic name as the local VT, so {@code getVersionTopic().equals(...)}
+   * matches both). VT consumption has no RT DIV state to propagate, so {@code sendGlobalRtDivMessage} —
+   * the normal path that hands the VT DIV from the consumer to the drainer — is never invoked. Without
+   * this callback, the OffsetRecord's latestConsumedVtPosition stays at EARLIEST and ingestion rewinds
+   * to the start of VT on the next leader restart.
    *
-   * <p>No-op unless Global RT DIV is enabled, the consumed source is a non-RT topic, and the byte threshold
-   * for a Global RT DIV sync has been reached. The same predicate gates {@code sendGlobalRtDivMessage},
-   * but keyed on the local VT name so VT-source bytes are tracked separately from per-broker RT bytes.
+   * <p>No-op unless Global RT DIV is enabled, the consumed source is the version topic, and the byte
+   * threshold for a Global RT DIV sync has been reached. The same predicate gates
+   * {@code sendGlobalRtDivMessage}, but keyed on the local VT name — so VT-source bytes (local or remote)
+   * are tracked under the VT-name counter and counted separately from per-broker RT bytes.
    */
   void addVtDivToProducerCallbackIfNeeded(
       DefaultPubSubMessage consumerRecord,
       LeaderProducerCallback callback,
       PartitionConsumptionState pcs,
-      LeaderProducedRecordContext leaderProducedRecordContext) {
-    if (!isGlobalRtDivEnabled() || consumerRecord.getTopicPartition().getPubSubTopic().isRealTime()
+      CompletableFuture<Void> persistedToDBFuture) {
+    if (!isGlobalRtDivEnabled() || !getVersionTopic().equals(consumerRecord.getTopicPartition().getPubSubTopic())
         || !shouldSendGlobalRtDiv(consumerRecord, pcs, getVersionTopic().getName())) {
       return;
     }
     PubSubTopicPartition topicPartition = pcs.getReplicaTopicPartition();
     PartitionTracker vtDiv =
         consumerDiv.cloneVtProducerStates(pcs.getPartition(), true, pcs.getLatestMessageTimeInMs());
-    sendVtDivSnapshotOnCompletion(callback, topicPartition, vtDiv, leaderProducedRecordContext);
+    sendVtDivSnapshotOnCompletion(callback, topicPartition, vtDiv, persistedToDBFuture);
     pcs.resetConsumedBytesSinceLastGlobalRtDivSync(getVersionTopic().getName());
   }
 
@@ -2118,12 +2122,11 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
       LeaderProducerCallback callback,
       PubSubTopicPartition topicPartition,
       PartitionTracker vtDiv,
-      LeaderProducedRecordContext context) {
+      CompletableFuture<Void> persistedToDBFuture) {
     callback.setOnCompletionCallback(produceResult -> {
       try {
-        CompletableFuture<Void> persistedFuture = context.getPersistedToDBFuture();
         vtDiv.updateLatestConsumedVtPosition(produceResult.getPubSubPosition());
-        storeBufferService.execSyncOffsetFromSnapshotAsync(topicPartition, vtDiv, persistedFuture, this);
+        storeBufferService.execSyncOffsetFromSnapshotAsync(topicPartition, vtDiv, persistedToDBFuture, this);
       } catch (InterruptedException e) {
         LOGGER.error("event=globalRtDiv Failed to async VT DIV OffsetRecord sync for replica: {}", topicPartition, e);
         Thread.currentThread().interrupt();
@@ -4102,7 +4105,7 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
         createProducerCallback(divMessage, pcs, context, partition, brokerUrl, beforeProcessingRecordTimestampNs);
 
     // After producing the RT DIV to local VT, the drainer should sync the VT DIV + LCVP within the OffsetRecord
-    sendVtDivSnapshotOnCompletion(divCallback, topicPartition, vtDiv, context);
+    sendVtDivSnapshotOnCompletion(divCallback, topicPartition, vtDiv, context.getPersistedToDBFuture());
 
     return divCallback;
   }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTask.java
@@ -3238,6 +3238,7 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
           vtDiv.getPartitionStates(PartitionTracker.VERSION_TOPIC).size());
     } catch (InterruptedException e) {
       LOGGER.error("event=globalRtDiv Unable to send OffsetRecord to update the latest consumed vt position", e);
+      Thread.currentThread().interrupt();
     }
   }
 

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTask.java
@@ -2052,16 +2052,13 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
         kafkaUrl,
         beforeProcessingRecordTimestampNs);
 
-    /**
-     * Leaders consuming from a VT source (e.g., remote VT) produce records to local VT but do not
-     * send Global RT DIV messages, since VT consumption has no RT DIV state to propagate. To ensure
-     * the latest consumed VT position (LCVP) is still persisted to the OffsetRecord on disk for
-     * those leaders, install a sync callback on the regular producer callback before dispatching
-     * the produce. The callback fires after the produce completes; it sets LCVP to the produced
-     * position in local VT and asynchronously syncs the OffsetRecord via the drainer.
+    /* Leaders consuming from remote VT will produce records to local VT but do not send Global RT DIV messages, since
+     * VT consumption has no RT DIV state to propagate. The VT DIV is normally passed from the consumer to the drainer
+     * in {@link #sendGlobalRtDivMessage} which is never called, so install a post-completion callback on the regular
+     * callback in order for the LCVP and OffsetRecord to be synced.
      */
-    if (shouldInstallVtLcvpSyncCallback(consumerRecord, partitionConsumptionState)) {
-      installVtLcvpSyncCallback(callback, partitionConsumptionState, leaderProducedRecordContext);
+    if (shouldProducerCallbackSendVtDiv(consumerRecord, partitionConsumptionState)) {
+      addVtDivToProducerCallback(callback, partitionConsumptionState, leaderProducedRecordContext);
     }
 
     PubSubPosition consumedPosition = consumerRecord.getPosition();
@@ -2085,30 +2082,22 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
             kafkaClusterId);
       }
     } catch (Exception e) {
-      LOGGER.error("Failed to send Global RT DIV message", e);
+      LOGGER.error("event=globalRtDiv Failed to send Global RT DIV message", e);
     }
   }
 
-  /**
-   * Predicate gating {@link #installVtLcvpSyncCallback}: only install the LCVP-sync callback when
-   * the Global RT DIV feature is enabled, the consumed source is non-RT (i.e., VT), and the
-   * configured byte-threshold for a Global RT DIV sync has been reached. Extracted into a helper
-   * so the gate's three branches can be exercised directly in unit tests.
-   */
-  boolean shouldInstallVtLcvpSyncCallback(DefaultPubSubMessage consumerRecord, PartitionConsumptionState pcs) {
+  boolean shouldProducerCallbackSendVtDiv(DefaultPubSubMessage consumerRecord, PartitionConsumptionState pcs) {
     return isGlobalRtDivEnabled() && !consumerRecord.getTopicPartition().getPubSubTopic().isRealTime()
         && shouldSendGlobalRtDiv(consumerRecord, pcs, getVersionTopic().getName());
   }
 
   /**
-   * Mirrors {@link #sendGlobalRtDivMessage}'s LCVP-sync callback for leaders consuming from a VT
-   * source. Snapshots the VT producer states from {@link #consumerDiv}, installs an
-   * onCompletionCallback that updates LCVP with the produced-local-VT position and triggers
-   * {@link com.linkedin.davinci.kafka.consumer.StoreBufferService#execSyncOffsetFromSnapshotAsync}
-   * via the drainer. The byte counter is reset synchronously, matching the RT path's behavior, so
-   * subsequent threshold checks gate correctly.
+   * Mirrors {@link #sendGlobalRtDivMessage}'s LCVP-sync callback for leaders consuming from a VT source.
+   * Snapshots the VT producer states from {@link #consumerDiv}, installs an onCompletionCallback that updates LCVP
+   * with the produced-local-VT position and triggers
+   * {@link com.linkedin.davinci.kafka.consumer.StoreBufferService#execSyncOffsetFromSnapshotAsync} via the drainer.
    */
-  void installVtLcvpSyncCallback(
+  void addVtDivToProducerCallback(
       LeaderProducerCallback callback,
       PartitionConsumptionState pcs,
       LeaderProducedRecordContext leaderProducedRecordContext) {

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
@@ -1533,7 +1533,6 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
           elapsedTimeForPuttingIntoQueue);
       totalBytesRead += recordSize;
       // Key by version topic name when consuming from local VT, by RT broker URL when consuming from RT.
-      // Remote VTs are excluded from tracking.
       PubSubTopic topic = topicPartition.getPubSubTopic();
       if (isGlobalRtDivEnabled() && (versionTopic.equals(topic) || topic.isRealTime())) {
         String consumedBytesKey = versionTopic.equals(topic) ? versionTopic.getName() : kafkaUrl;

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
@@ -3416,18 +3416,19 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
 
   /**
    * Returns true when enough bytes have been consumed from the given source to warrant producing a new Global RT DIV
-   * message to the local VT. {@code brokerUrl} is the consumed-bytes tracking key: a broker URL for the RT path, or
-   * the VT name for the remote-VT (NR) path.
+   * message to the local VT. {@code consumedBytesKey} is the consumed-bytes tracking key: a broker URL for the RT
+   * path, or the VT name for the remote-VT (NR) path.
    *
    * NOTE: Also used for remote VT (NR): the leader's ingestion pattern for remote VT mirrors RT
    *     (it consumes externally and produces to local VT) so the byte-threshold logic applies identically.
    */
-  boolean shouldSendGlobalRtDiv(DefaultPubSubMessage record, PartitionConsumptionState pcs, String brokerUrl) {
+  boolean shouldSendGlobalRtDiv(DefaultPubSubMessage record, PartitionConsumptionState pcs, String consumedBytesKey) {
     if (!isGlobalRtDivEnabled() || record.getKey().isControlMessage()) {
       return false;
     }
     final long syncBytesInterval = getSyncBytesInterval(pcs);
-    return syncBytesInterval > 0 && (pcs.getConsumedBytesSinceLastGlobalRtDivSync(brokerUrl) >= syncBytesInterval);
+    return syncBytesInterval > 0
+        && (pcs.getConsumedBytesSinceLastGlobalRtDivSync(consumedBytesKey) >= syncBytesInterval);
   }
 
   abstract void sendVtDivSnapshotIfNeeded(DefaultPubSubMessage record, PubSubTopicPartition topicPartition);

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
@@ -1532,7 +1532,7 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
           beforeProcessingBatchRecordsTimestampMs,
           elapsedTimeForPuttingIntoQueue);
       totalBytesRead += recordSize;
-      // Key by version topic name when consuming from local VT, by RT broker URL when consuming from RT.
+      // Key VT bytes (local or remote) by version topic name, and key RT bytes by broker URL.
       PubSubTopic topic = topicPartition.getPubSubTopic();
       if (isGlobalRtDivEnabled() && (versionTopic.equals(topic) || topic.isRealTime())) {
         String consumedBytesKey = versionTopic.equals(topic) ? versionTopic.getName() : kafkaUrl;

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
@@ -3414,6 +3414,14 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
     // No Op
   }
 
+  /**
+   * Returns true when enough bytes have been consumed from the given source to warrant producing a new Global RT DIV
+   * message to the local VT. {@code brokerUrl} is the consumed-bytes tracking key: a broker URL for the RT path, or
+   * the VT name for the remote-VT (NR) path.
+   *
+   * NOTE: Also used for remote VT (NR): the leader's ingestion pattern for remote VT mirrors RT
+   *     (it consumes externally and produces to local VT) so the byte-threshold logic applies identically.
+   */
   boolean shouldSendGlobalRtDiv(DefaultPubSubMessage record, PartitionConsumptionState pcs, String brokerUrl) {
     if (!isGlobalRtDivEnabled() || record.getKey().isControlMessage()) {
       return false;

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
@@ -1451,8 +1451,8 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
         }
 
         // Intentionally not protecting against exceptions thrown by putConsumerRecord()
-        // Only sync OffsetRecord if the message that triggered the sync was successfully enqueued into the drainer
-        sendOffsetFromSnapshotIfNeeded(record, topicPartition); // latest consumed VT position (LCVP) in offset record
+        // Only send VT DIV snapshot if the message that triggered the sync was successfully enqueued into the drainer
+        sendVtDivSnapshotIfNeeded(record, topicPartition); // latest consumed VT position (LCVP) in offset record
         break;
       case PRODUCED_TO_KAFKA:
       case SKIPPED_MESSAGE:
@@ -3422,7 +3422,7 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
     return syncBytesInterval > 0 && (pcs.getConsumedBytesSinceLastGlobalRtDivSync(brokerUrl) >= syncBytesInterval);
   }
 
-  abstract void sendOffsetFromSnapshotIfNeeded(DefaultPubSubMessage record, PubSubTopicPartition topicPartition);
+  abstract void sendVtDivSnapshotIfNeeded(DefaultPubSubMessage record, PubSubTopicPartition topicPartition);
 
   /**
    * Update the offset metadata in OffsetRecord in the following cases:

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
@@ -1452,7 +1452,7 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
 
         // Intentionally not protecting against exceptions thrown by putConsumerRecord()
         // Only sync OffsetRecord if the message that triggered the sync was successfully enqueued into the drainer
-        syncOffsetFromSnapshotIfNeeded(record, topicPartition); // latest consumed VT position (LCVP) in offset record
+        sendOffsetFromSnapshotIfNeeded(record, topicPartition); // latest consumed VT position (LCVP) in offset record
         break;
       case PRODUCED_TO_KAFKA:
       case SKIPPED_MESSAGE:
@@ -3422,7 +3422,7 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
     return syncBytesInterval > 0 && (pcs.getConsumedBytesSinceLastGlobalRtDivSync(brokerUrl) >= syncBytesInterval);
   }
 
-  abstract void syncOffsetFromSnapshotIfNeeded(DefaultPubSubMessage record, PubSubTopicPartition topicPartition);
+  abstract void sendOffsetFromSnapshotIfNeeded(DefaultPubSubMessage record, PubSubTopicPartition topicPartition);
 
   /**
    * Update the offset metadata in OffsetRecord in the following cases:

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTaskTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTaskTest.java
@@ -1101,95 +1101,52 @@ public class LeaderFollowerStoreIngestionTaskTest {
   }
 
   /**
-   * Regression test for the early-exit guard added to syncOffsetFromSnapshotIfNeeded.
-   *
-   * <p>When Global RT DIV is enabled, SyncVtDivNode fires for non-segment control messages. If no VT
-   * record has been processed yet — i.e., the partition tracker has not recorded any VT progress —
-   * the snapshot's LCVP will still be EARLIEST. Allowing the sync to proceed in this state would stamp
-   * EARLIEST into the OffsetRecord, causing the follower to re-subscribe from EARLIEST on the next
-   * Helix OFFLINE→STANDBY retry — leading to out-of-order SST key writes and a RocksDBException during
-   * batch push.
-   *
-   * <p>Guard: Skip if the snapshot's LCVP equals EARLIEST (no meaningful VT progress yet).
+   * EARLIEST LCVP (no VT progress yet) must skip the sync — otherwise EARLIEST gets stamped into the
+   * OffsetRecord and the follower re-subscribes from EARLIEST on the next OFFLINE→STANDBY retry,
+   * causing out-of-order SST writes during batch push. Non-EARLIEST LCVP must proceed.
    */
   @Test
   public void testSendVtDivSnapshotIfNeededSkipsWhenLcvpIsEarliest() throws InterruptedException {
     setUp();
-
-    // isGlobalRtDivEnabled must be true and shouldSyncOffsetFromSnapshot must pass so we reach the new guard
-    doReturn(true).when(leaderFollowerStoreIngestionTask).isGlobalRtDivEnabled();
-    doReturn(true).when(leaderFollowerStoreIngestionTask).shouldSendVtDivSnapshot(any(), any());
-    CompletableFuture<Void> mockFuture = new CompletableFuture<>();
-    doReturn(mockFuture).when(mockPartitionConsumptionState).getLastQueuedRecordPersistedFuture();
-
-    // Route consumerDiv through a mock so we can control the returned snapshot
-    DataIntegrityValidator mockConsumerDiv = mock(DataIntegrityValidator.class);
-    doReturn(mockConsumerDiv).when(leaderFollowerStoreIngestionTask).getConsumerDiv();
-
-    // The task was set up with partition 0 → mockPartitionConsumptionState in setUp()
-    PubSubTopicPartition versionTopicPartition =
-        new PubSubTopicPartitionImpl(TOPIC_REPOSITORY.getTopic("test-topic_v1"), 0);
-    DefaultPubSubMessage mockRecord = getMockMessage(1).getMessage();
-
-    // --- Case 1: LCVP = EARLIEST (no VT record processed yet) → sync must be skipped ---
-    PartitionTracker snapshotEarliestLcvp = mock(PartitionTracker.class);
-    doReturn(PubSubSymbolicPosition.EARLIEST).when(snapshotEarliestLcvp).getLatestConsumedVtPosition();
-    doReturn(snapshotEarliestLcvp).when(mockConsumerDiv).cloneVtProducerStates(anyInt(), anyBoolean(), anyLong());
-
-    leaderFollowerStoreIngestionTask.sendVtDivSnapshotIfNeeded(mockRecord, versionTopicPartition);
+    invokeSendVtDivSnapshotIfNeeded(mockVtSnapshot(PubSubSymbolicPosition.EARLIEST));
     verify(mockStoreBufferService, never()).execSyncOffsetFromSnapshotAsync(any(), any(), any(), any());
 
-    // --- Case 2: LCVP is non-EARLIEST (VT progress recorded) → sync must proceed, even with empty segments ---
-    PartitionTracker snapshotReady = mock(PartitionTracker.class);
-    doReturn(ApacheKafkaOffsetPosition.of(10L)).when(snapshotReady).getLatestConsumedVtPosition();
-    doReturn(Collections.singletonMap("producerGuid", new Object())).when(snapshotReady).getPartitionStates(any());
-    doReturn(snapshotReady).when(mockConsumerDiv).cloneVtProducerStates(anyInt(), anyBoolean(), anyLong());
-
-    leaderFollowerStoreIngestionTask.sendVtDivSnapshotIfNeeded(mockRecord, versionTopicPartition);
+    invokeSendVtDivSnapshotIfNeeded(mockVtSnapshot(ApacheKafkaOffsetPosition.of(10L)));
     verify(mockStoreBufferService, times(1)).execSyncOffsetFromSnapshotAsync(any(), any(), any(), any());
   }
 
   /**
-   * Verifies that {@link LeaderFollowerStoreIngestionTask#sendVtDivSnapshotIfNeeded} restores the
-   * thread's interrupt flag when the drainer throws {@link InterruptedException}, so that shutdown
-   * and cancellation signals are not silently swallowed.
+   * When the drainer throws InterruptedException from inside the sync, the thread's interrupt flag
+   * must be restored so shutdown/cancellation signals are not silently swallowed.
    */
   @Test
   public void testSendVtDivSnapshotIfNeededRestoresInterruptOnInterruptedException() throws InterruptedException {
     setUp();
-
-    doReturn(true).when(leaderFollowerStoreIngestionTask).isGlobalRtDivEnabled();
-    doReturn(true).when(leaderFollowerStoreIngestionTask).shouldSendVtDivSnapshot(any(), any());
-    CompletableFuture<Void> mockFuture = new CompletableFuture<>();
-    doReturn(mockFuture).when(mockPartitionConsumptionState).getLastQueuedRecordPersistedFuture();
-
-    DataIntegrityValidator mockConsumerDiv = mock(DataIntegrityValidator.class);
-    doReturn(mockConsumerDiv).when(leaderFollowerStoreIngestionTask).getConsumerDiv();
-
-    PartitionTracker snapshotReady = mock(PartitionTracker.class);
-    doReturn(ApacheKafkaOffsetPosition.of(10L)).when(snapshotReady).getLatestConsumedVtPosition();
-    doReturn(Collections.singletonMap("producerGuid", new Object())).when(snapshotReady).getPartitionStates(any());
-    doReturn(snapshotReady).when(mockConsumerDiv).cloneVtProducerStates(anyInt(), anyBoolean(), anyLong());
-
-    PubSubTopicPartition versionTopicPartition =
-        new PubSubTopicPartitionImpl(TOPIC_REPOSITORY.getTopic("test-topic_v1"), 0);
-    DefaultPubSubMessage mockRecord = getMockMessage(1).getMessage();
-
-    doThrow(new InterruptedException("simulated drainer interrupt")).when(mockStoreBufferService)
+    doThrow(new InterruptedException()).when(mockStoreBufferService)
         .execSyncOffsetFromSnapshotAsync(any(), any(), any(), any());
 
-    // Sanity: make sure the test thread is not already interrupted before the call
-    assertFalse(Thread.interrupted(), "Thread should not be interrupted before invocation");
-    try {
-      leaderFollowerStoreIngestionTask.sendVtDivSnapshotIfNeeded(mockRecord, versionTopicPartition);
-      // The catch block must restore the interrupt flag.
-      assertTrue(
-          Thread.currentThread().isInterrupted(),
-          "Thread interrupt flag should be restored after catching InterruptedException");
-    } finally {
-      // Clear the interrupt flag so subsequent tests on this thread are not affected.
-      Thread.interrupted();
-    }
+    Thread.interrupted(); // clear any pre-existing flag
+    invokeSendVtDivSnapshotIfNeeded(mockVtSnapshot(ApacheKafkaOffsetPosition.of(10L)));
+    assertTrue(Thread.interrupted(), "Interrupt flag should be restored after InterruptedException"); // also clears
+  }
+
+  /** Opens the gate for {@code sendVtDivSnapshotIfNeeded} and routes consumerDiv to return {@code snapshot}. */
+  private void invokeSendVtDivSnapshotIfNeeded(PartitionTracker snapshot) throws InterruptedException {
+    doReturn(true).when(leaderFollowerStoreIngestionTask).isGlobalRtDivEnabled();
+    doReturn(true).when(leaderFollowerStoreIngestionTask).shouldSendVtDivSnapshot(any(), any());
+    doReturn(new CompletableFuture<Void>()).when(mockPartitionConsumptionState).getLastQueuedRecordPersistedFuture();
+    DataIntegrityValidator mockConsumerDiv = mock(DataIntegrityValidator.class);
+    doReturn(mockConsumerDiv).when(leaderFollowerStoreIngestionTask).getConsumerDiv();
+    doReturn(snapshot).when(mockConsumerDiv).cloneVtProducerStates(anyInt(), anyBoolean(), anyLong());
+    PubSubTopicPartition tp = new PubSubTopicPartitionImpl(TOPIC_REPOSITORY.getTopic("test-topic_v1"), 0);
+    leaderFollowerStoreIngestionTask.sendVtDivSnapshotIfNeeded(getMockMessage(1).getMessage(), tp);
+  }
+
+  private static PartitionTracker mockVtSnapshot(PubSubPosition lcvp) {
+    PartitionTracker snapshot = mock(PartitionTracker.class);
+    doReturn(lcvp).when(snapshot).getLatestConsumedVtPosition();
+    doReturn(Collections.singletonMap("producerGuid", new Object())).when(snapshot).getPartitionStates(any());
+    return snapshot;
   }
 
   @Test

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTaskTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTaskTest.java
@@ -771,13 +771,13 @@ public class LeaderFollowerStoreIngestionTaskTest {
   }
 
   /**
-   * Data provider covering every branch of {@link LeaderFollowerStoreIngestionTask#addVtDivToProducerCallback}'s
+   * Data provider covering every branch of {@link LeaderFollowerStoreIngestionTask#addVtDivToProducerCallbackIfNeeded}'s
    * install gate: the callback is installed only when Global RT DIV is enabled, the consumed source is
    * non-RT, AND the byte threshold for a Global RT DIV sync has been reached. Each tuple shifts exactly
    * one input from the previous "install" baseline.
    */
   @DataProvider(name = "addVtDivToProducerCallbackGatingParams")
-  public Object[][] addVtDivToProducerCallbackGatingParams() {
+  public Object[][] addVtDivToProducerCallbackIfNeededGatingParams() {
     return new Object[][] {
         // {globalRtDivEnabled, sourceIsRealTime, shouldSendGlobalRtDiv, expectedInstall}
         { false, false, true, false }, // Global RT DIV disabled — skip regardless.
@@ -787,8 +787,8 @@ public class LeaderFollowerStoreIngestionTaskTest {
     };
   }
 
-  @Test(dataProvider = "addVtDivToProducerCallbackGatingParams")
-  public void testAddVtDivToProducerCallbackGating(
+  @Test(dataProvider = "addVtDivToProducerCallbackIfNeededGatingParams")
+  public void testAddVtDivToProducerCallbackIfNeededGating(
       boolean globalRtDivEnabled,
       boolean sourceIsRealTime,
       boolean shouldSendGlobalRtDiv,
@@ -815,7 +815,7 @@ public class LeaderFollowerStoreIngestionTaskTest {
     LeaderProducedRecordContext mockCtx = mock(LeaderProducedRecordContext.class);
 
     leaderFollowerStoreIngestionTask
-        .addVtDivToProducerCallback(mockSourceRecord, mockCallback, mockPartitionConsumptionState, mockCtx);
+        .addVtDivToProducerCallbackIfNeeded(mockSourceRecord, mockCallback, mockPartitionConsumptionState, mockCtx);
 
     // Both side effects fire iff the install gate accepts.
     int expectedTimes = expectedInstall ? 1 : 0;
@@ -825,7 +825,7 @@ public class LeaderFollowerStoreIngestionTaskTest {
   }
 
   /**
-   * Verifies that {@link LeaderFollowerStoreIngestionTask#addVtDivToProducerCallback} installs an
+   * Verifies that {@link LeaderFollowerStoreIngestionTask#addVtDivToProducerCallbackIfNeeded} installs an
    * onCompletionCallback on the regular {@link LeaderProducerCallback} that, when fired, asynchronously
    * syncs the OffsetRecord with LCVP set to the produced-local-VT position. This covers the leader
    * consuming from a VT source (e.g., remote VT), whose LCVP would otherwise never be persisted —
@@ -835,11 +835,11 @@ public class LeaderFollowerStoreIngestionTaskTest {
    * in {@link LeaderFollowerStoreIngestionTask#sendGlobalRtDivMessage}.
    */
   @Test
-  public void testAddVtDivToProducerCallback() throws InterruptedException {
+  public void testAddVtDivToProducerCallbackIfNeeded() throws InterruptedException {
     setUp();
     PubSubTopicPartition mockTp = mock(PubSubTopicPartition.class);
     CompletableFuture<Void> persistedFuture = CompletableFuture.completedFuture(null);
-    LeaderProducerCallback callback = addVtDivToProducerCallbackWithMocks(mockTp, persistedFuture);
+    LeaderProducerCallback callback = addVtDivToProducerCallbackIfNeededWithMocks(mockTp, persistedFuture);
 
     String versionTopicName = leaderFollowerStoreIngestionTask.getVersionTopic().getName();
     // Byte counter is reset synchronously when the callback is installed (mirrors the RT path).
@@ -859,14 +859,15 @@ public class LeaderFollowerStoreIngestionTaskTest {
    * is restored, preserving shutdown/cancellation semantics.
    */
   @Test
-  public void testAddVtDivToProducerCallbackHandlesInterruptedException() throws InterruptedException {
+  public void testAddVtDivToProducerCallbackIfNeededHandlesInterruptedException() throws InterruptedException {
     setUp();
     // Simulate drainer rejecting the snapshot with InterruptedException (e.g., shutdown).
     doThrow(new InterruptedException("simulated shutdown")).when(mockStoreBufferService)
         .execSyncOffsetFromSnapshotAsync(any(), any(), any(), any());
 
-    LeaderProducerCallback callback =
-        addVtDivToProducerCallbackWithMocks(mock(PubSubTopicPartition.class), CompletableFuture.completedFuture(null));
+    LeaderProducerCallback callback = addVtDivToProducerCallbackIfNeededWithMocks(
+        mock(PubSubTopicPartition.class),
+        CompletableFuture.completedFuture(null));
 
     PubSubProduceResult produceResult = mock(PubSubProduceResult.class);
     doReturn(InMemoryPubSubPosition.of(7L)).when(produceResult).getPubSubPosition();
@@ -887,7 +888,7 @@ public class LeaderFollowerStoreIngestionTaskTest {
    * {@link PartitionTracker} so callers can layer additional assertions.
    *
    * <p>Shared by {@link #testSendGlobalRtDivMessage} (RT-source path) and
-   * {@link #testAddVtDivToProducerCallback} (VT-source path) — both rely on the same
+   * {@link #testAddVtDivToProducerCallbackIfNeeded} (VT-source path) — both rely on the same
    * "produce completes → drainer syncs OffsetRecord with produced VT position" contract.
    */
   private PartitionTracker fireProduceCallbackAndAssertLcvpSynced(
@@ -906,13 +907,13 @@ public class LeaderFollowerStoreIngestionTaskTest {
   }
 
   /**
-   * Wires up shared mocks for {@link #testAddVtDivToProducerCallback} and
-   * {@link #testAddVtDivToProducerCallbackHandlesInterruptedException}, opens
-   * {@link LeaderFollowerStoreIngestionTask#addVtDivToProducerCallback}'s install gate (Global RT DIV
+   * Wires up shared mocks for {@link #testAddVtDivToProducerCallbackIfNeeded} and
+   * {@link #testAddVtDivToProducerCallbackIfNeededHandlesInterruptedException}, opens
+   * {@link LeaderFollowerStoreIngestionTask#addVtDivToProducerCallbackIfNeeded}'s install gate (Global RT DIV
    * enabled, non-RT source, byte threshold reached), builds a real {@link LeaderProducerCallback},
    * and installs the VT LCVP sync callback on it.
    */
-  private LeaderProducerCallback addVtDivToProducerCallbackWithMocks(
+  private LeaderProducerCallback addVtDivToProducerCallbackIfNeededWithMocks(
       PubSubTopicPartition mockReplicaTp,
       CompletableFuture<Void> persistedFuture) {
     int partition = 1;
@@ -946,7 +947,7 @@ public class LeaderFollowerStoreIngestionTaskTest {
         "remote-broker-url",
         0L);
     leaderFollowerStoreIngestionTask
-        .addVtDivToProducerCallback(mockConsumerRecord, callback, mockPartitionConsumptionState, mockContext);
+        .addVtDivToProducerCallbackIfNeeded(mockConsumerRecord, callback, mockPartitionConsumptionState, mockContext);
     return callback;
   }
 

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTaskTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTaskTest.java
@@ -767,29 +767,19 @@ public class LeaderFollowerStoreIngestionTaskTest {
 
     // Verify that completing the future from put() causes execSyncOffsetFromSnapshotAsync to be called
     // and that produceResult should override the LCVP of the VT DIV sent to the drainer
-    verify(mockStoreBufferService, never()).execSyncOffsetFromSnapshotAsync(any(), any(), any(), any());
-    PubSubProduceResult produceResult = mock(PubSubProduceResult.class);
-    PubSubPosition specificPosition = InMemoryPubSubPosition.of(11L);
-    when(produceResult.getPubSubPosition()).thenReturn(specificPosition);
-    when(produceResult.getSerializedSize()).thenReturn(keyBytes.length + put.putValue.remaining());
-    callback.onCompletion(produceResult, null);
-    ArgumentCaptor<PartitionTracker> vtDivCaptor = ArgumentCaptor.forClass(PartitionTracker.class);
-    verify(mockStoreBufferService, times(1))
-        .execSyncOffsetFromSnapshotAsync(any(), vtDivCaptor.capture(), any(), any());
-    assertEquals(vtDivCaptor.getValue().getLatestConsumedVtPosition(), specificPosition);
+    fireProduceCallbackAndAssertLcvpSynced(callback, InMemoryPubSubPosition.of(11L));
   }
 
   /**
-   * Data provider covering every branch outcome of
-   * {@link LeaderFollowerStoreIngestionTask#shouldProducerCallbackSendVtDiv}: the predicate returns
-   * true only when Global RT DIV is enabled, the consumed source is non-RT, and the byte threshold
-   * for a Global RT DIV sync has been reached. Each tuple shifts exactly one input from the
-   * previous "expected=true" baseline.
+   * Data provider covering every branch of {@link LeaderFollowerStoreIngestionTask#addVtDivToProducerCallback}'s
+   * install gate: the callback is installed only when Global RT DIV is enabled, the consumed source is
+   * non-RT, AND the byte threshold for a Global RT DIV sync has been reached. Each tuple shifts exactly
+   * one input from the previous "install" baseline.
    */
-  @DataProvider(name = "shouldInstallVtLcvpSyncCallbackParams")
-  public Object[][] shouldProducerCallbackSendVtDivParams() {
+  @DataProvider(name = "addVtDivToProducerCallbackGatingParams")
+  public Object[][] addVtDivToProducerCallbackGatingParams() {
     return new Object[][] {
-        // {globalRtDivEnabled, sourceIsRealTime, shouldSendGlobalRtDiv, expected}
+        // {globalRtDivEnabled, sourceIsRealTime, shouldSendGlobalRtDiv, expectedInstall}
         { false, false, true, false }, // Global RT DIV disabled — skip regardless.
         { true, true, true, false }, // Source is RT — handled by sendGlobalRtDivMessage path instead.
         { true, false, false, false }, // VT source but byte threshold not yet reached.
@@ -797,29 +787,41 @@ public class LeaderFollowerStoreIngestionTaskTest {
     };
   }
 
-  @Test(dataProvider = "shouldProducerCallbackSendVtDivParams")
-  public void testShouldProducerCallbackSendVtDiv(
+  @Test(dataProvider = "addVtDivToProducerCallbackGatingParams")
+  public void testAddVtDivToProducerCallbackGating(
       boolean globalRtDivEnabled,
       boolean sourceIsRealTime,
       boolean shouldSendGlobalRtDiv,
-      boolean expected) throws InterruptedException {
+      boolean expectedInstall) throws InterruptedException {
     setUp();
     DefaultPubSubMessage mockSourceRecord = mock(DefaultPubSubMessage.class);
-    PubSubTopicPartition mockTp = mock(PubSubTopicPartition.class);
-    PubSubTopic mockTopic = mock(PubSubTopic.class);
-    doReturn(mockTp).when(mockSourceRecord).getTopicPartition();
-    doReturn(mockTopic).when(mockTp).getPubSubTopic();
-    doReturn(sourceIsRealTime).when(mockTopic).isRealTime();
+    PubSubTopicPartition mockSourceTp = mock(PubSubTopicPartition.class);
+    PubSubTopic mockSourceTopic = mock(PubSubTopic.class);
+    doReturn(mockSourceTp).when(mockSourceRecord).getTopicPartition();
+    doReturn(mockSourceTopic).when(mockSourceTp).getPubSubTopic();
+    doReturn(sourceIsRealTime).when(mockSourceTopic).isRealTime();
 
     doReturn(globalRtDivEnabled).when(leaderFollowerStoreIngestionTask).isGlobalRtDivEnabled();
     String versionTopicName = leaderFollowerStoreIngestionTask.getVersionTopic().getName();
     doReturn(shouldSendGlobalRtDiv).when(leaderFollowerStoreIngestionTask)
         .shouldSendGlobalRtDiv(eq(mockSourceRecord), eq(mockPartitionConsumptionState), eq(versionTopicName));
 
-    assertEquals(
-        leaderFollowerStoreIngestionTask
-            .shouldProducerCallbackSendVtDiv(mockSourceRecord, mockPartitionConsumptionState),
-        expected);
+    // Wire pcs basics so the install path doesn't NPE if the gate accepts.
+    doReturn(mock(PubSubTopicPartition.class)).when(mockPartitionConsumptionState).getReplicaTopicPartition();
+    doReturn(0L).when(mockPartitionConsumptionState).getLatestMessageTimeInMs();
+    doReturn(1).when(mockPartitionConsumptionState).getPartition();
+
+    LeaderProducerCallback mockCallback = mock(LeaderProducerCallback.class);
+    LeaderProducedRecordContext mockCtx = mock(LeaderProducedRecordContext.class);
+
+    leaderFollowerStoreIngestionTask
+        .addVtDivToProducerCallback(mockSourceRecord, mockCallback, mockPartitionConsumptionState, mockCtx);
+
+    // Both side effects fire iff the install gate accepts.
+    int expectedTimes = expectedInstall ? 1 : 0;
+    verify(mockCallback, times(expectedTimes)).setOnCompletionCallback(any());
+    verify(mockPartitionConsumptionState, times(expectedTimes))
+        .resetConsumedBytesSinceLastGlobalRtDivSync(versionTopicName);
   }
 
   /**
@@ -842,18 +844,12 @@ public class LeaderFollowerStoreIngestionTaskTest {
     String versionTopicName = leaderFollowerStoreIngestionTask.getVersionTopic().getName();
     // Byte counter is reset synchronously when the callback is installed (mirrors the RT path).
     verify(mockPartitionConsumptionState, times(1)).resetConsumedBytesSinceLastGlobalRtDivSync(versionTopicName);
-    // Sync is not triggered until the produce actually completes.
-    verify(mockStoreBufferService, never()).execSyncOffsetFromSnapshotAsync(any(), any(), any(), any());
 
-    PubSubProduceResult produceResult = mock(PubSubProduceResult.class);
-    PubSubPosition producedPosition = InMemoryPubSubPosition.of(42L);
-    doReturn(producedPosition).when(produceResult).getPubSubPosition();
-    callback.onCompletion(produceResult, null);
-
-    ArgumentCaptor<PartitionTracker> vtDivCaptor = ArgumentCaptor.forClass(PartitionTracker.class);
+    fireProduceCallbackAndAssertLcvpSynced(callback, InMemoryPubSubPosition.of(42L));
+    // Confirm the sync was routed to the leader's replica topic-partition with the correct
+    // persisted-to-DB future from the leaderProducedRecordContext.
     verify(mockStoreBufferService, times(1))
-        .execSyncOffsetFromSnapshotAsync(eq(mockTp), vtDivCaptor.capture(), eq(persistedFuture), any());
-    assertEquals(vtDivCaptor.getValue().getLatestConsumedVtPosition(), producedPosition);
+        .execSyncOffsetFromSnapshotAsync(eq(mockTp), any(), eq(persistedFuture), any());
   }
 
   /**
@@ -885,29 +881,72 @@ public class LeaderFollowerStoreIngestionTaskTest {
   }
 
   /**
-   * Wires up shared mocks for both {@code testInstallVtLcvpSyncCallback*} tests, builds a real
-   * {@link LeaderProducerCallback}, and installs the VT LCVP sync callback on it.
+   * Asserts the LCVP sync was not triggered yet, then fires the produce-completion callback with
+   * the given position and verifies that {@link StoreBufferService#execSyncOffsetFromSnapshotAsync}
+   * was invoked exactly once with LCVP set to the produced position. Returns the captured
+   * {@link PartitionTracker} so callers can layer additional assertions.
+   *
+   * <p>Shared by {@link #testSendGlobalRtDivMessage} (RT-source path) and
+   * {@link #testAddVtDivToProducerCallback} (VT-source path) — both rely on the same
+   * "produce completes → drainer syncs OffsetRecord with produced VT position" contract.
+   */
+  private PartitionTracker fireProduceCallbackAndAssertLcvpSynced(
+      LeaderProducerCallback callback,
+      PubSubPosition producedPosition) throws InterruptedException {
+    verify(mockStoreBufferService, never()).execSyncOffsetFromSnapshotAsync(any(), any(), any(), any());
+    PubSubProduceResult produceResult = mock(PubSubProduceResult.class);
+    doReturn(producedPosition).when(produceResult).getPubSubPosition();
+    callback.onCompletion(produceResult, null);
+    ArgumentCaptor<PartitionTracker> vtDivCaptor = ArgumentCaptor.forClass(PartitionTracker.class);
+    verify(mockStoreBufferService, times(1))
+        .execSyncOffsetFromSnapshotAsync(any(), vtDivCaptor.capture(), any(), any());
+    PartitionTracker captured = vtDivCaptor.getValue();
+    assertEquals(captured.getLatestConsumedVtPosition(), producedPosition);
+    return captured;
+  }
+
+  /**
+   * Wires up shared mocks for {@link #testAddVtDivToProducerCallback} and
+   * {@link #testAddVtDivToProducerCallbackHandlesInterruptedException}, opens
+   * {@link LeaderFollowerStoreIngestionTask#addVtDivToProducerCallback}'s install gate (Global RT DIV
+   * enabled, non-RT source, byte threshold reached), builds a real {@link LeaderProducerCallback},
+   * and installs the VT LCVP sync callback on it.
    */
   private LeaderProducerCallback addVtDivToProducerCallbackWithMocks(
-      PubSubTopicPartition mockTp,
+      PubSubTopicPartition mockReplicaTp,
       CompletableFuture<Void> persistedFuture) {
     int partition = 1;
-    doReturn(mockTp).when(mockPartitionConsumptionState).getReplicaTopicPartition();
+    doReturn(mockReplicaTp).when(mockPartitionConsumptionState).getReplicaTopicPartition();
     doReturn(0L).when(mockPartitionConsumptionState).getLatestMessageTimeInMs();
     doReturn(partition).when(mockPartitionConsumptionState).getPartition();
 
     LeaderProducedRecordContext mockContext = mock(LeaderProducedRecordContext.class);
     doReturn(persistedFuture).when(mockContext).getPersistedToDBFuture();
 
+    // Build a consumer record on a non-RT topic so the install gate accepts it.
+    DefaultPubSubMessage mockConsumerRecord = mock(DefaultPubSubMessage.class);
+    PubSubTopicPartition mockSourceTp = mock(PubSubTopicPartition.class);
+    PubSubTopic mockSourceTopic = mock(PubSubTopic.class);
+    doReturn(mockSourceTp).when(mockConsumerRecord).getTopicPartition();
+    doReturn(mockSourceTopic).when(mockSourceTp).getPubSubTopic();
+    doReturn(false).when(mockSourceTopic).isRealTime();
+
+    // Open the install gate.
+    doReturn(true).when(leaderFollowerStoreIngestionTask).isGlobalRtDivEnabled();
+    String versionTopicName = leaderFollowerStoreIngestionTask.getVersionTopic().getName();
+    doReturn(true).when(leaderFollowerStoreIngestionTask)
+        .shouldSendGlobalRtDiv(eq(mockConsumerRecord), eq(mockPartitionConsumptionState), eq(versionTopicName));
+
     LeaderProducerCallback callback = new LeaderProducerCallback(
         leaderFollowerStoreIngestionTask,
-        mock(DefaultPubSubMessage.class),
+        mockConsumerRecord,
         mockPartitionConsumptionState,
         mockContext,
         partition,
         "remote-broker-url",
         0L);
-    leaderFollowerStoreIngestionTask.addVtDivToProducerCallback(callback, mockPartitionConsumptionState, mockContext);
+    leaderFollowerStoreIngestionTask
+        .addVtDivToProducerCallback(mockConsumerRecord, callback, mockPartitionConsumptionState, mockContext);
     return callback;
   }
 

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTaskTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTaskTest.java
@@ -772,40 +772,39 @@ public class LeaderFollowerStoreIngestionTaskTest {
 
   /**
    * Data provider covering every branch of {@link LeaderFollowerStoreIngestionTask#addVtDivToProducerCallbackIfNeeded}'s
-   * install gate: the callback is installed only when Global RT DIV is enabled, the consumed source IS
-   * the version topic (i.e., remote VT under NR — same topic name as local VT), AND the byte threshold
-   * for a Global RT DIV sync has been reached. Each tuple shifts exactly one input from the
-   * "install" baseline.
+   * install gate: the callback is installed only when Global RT DIV is enabled, the consumed source is
+   * non-RT, AND the byte threshold for a Global RT DIV sync has been reached. Each tuple shifts exactly
+   * one input from the "install" baseline.
    */
   @DataProvider
   public Object[][] addVtDivToProducerCallbackIfNeededGatingParams() {
     return new Object[][] {
-        // {globalRtDivEnabled, sourceIsVersionTopic, shouldSendGlobalRtDiv, expectedInstall}
-        { false, true, true, false }, // Global RT DIV disabled — skip regardless.
-        { true, false, true, false }, // Source is not the VT (e.g. RT) — handled by sendGlobalRtDivMessage path.
-        { true, true, false, false }, // VT source but byte threshold not yet reached.
-        { true, true, true, true } // VT source and threshold reached — install the callback.
+        // {globalRtDivEnabled, sourceIsRealTime, shouldSendGlobalRtDiv, expectedInstall}
+        { false, false, true, false }, // Global RT DIV disabled — skip regardless.
+        { true, true, true, false }, // Source is RT — handled by sendGlobalRtDivMessage path instead.
+        { true, false, false, false }, // VT source but byte threshold not yet reached.
+        { true, false, true, true } // VT source and threshold reached — install the callback.
     };
   }
 
   @Test(dataProvider = "addVtDivToProducerCallbackIfNeededGatingParams")
   public void testAddVtDivToProducerCallbackIfNeededGating(
       boolean globalRtDivEnabled,
-      boolean sourceIsVersionTopic,
+      boolean sourceIsRealTime,
       boolean shouldSendGlobalRtDiv,
       boolean expectedInstall) throws InterruptedException {
     setUp();
-    PubSubTopic versionTopic = leaderFollowerStoreIngestionTask.getVersionTopic();
-    PubSubTopic sourceTopic = sourceIsVersionTopic ? versionTopic : mock(PubSubTopic.class);
-
     DefaultPubSubMessage mockSourceRecord = mock(DefaultPubSubMessage.class);
     PubSubTopicPartition mockSourceTp = mock(PubSubTopicPartition.class);
+    PubSubTopic mockSourceTopic = mock(PubSubTopic.class);
     doReturn(mockSourceTp).when(mockSourceRecord).getTopicPartition();
-    doReturn(sourceTopic).when(mockSourceTp).getPubSubTopic();
+    doReturn(mockSourceTopic).when(mockSourceTp).getPubSubTopic();
+    doReturn(sourceIsRealTime).when(mockSourceTopic).isRealTime();
 
     doReturn(globalRtDivEnabled).when(leaderFollowerStoreIngestionTask).isGlobalRtDivEnabled();
+    String versionTopicName = leaderFollowerStoreIngestionTask.getVersionTopic().getName();
     doReturn(shouldSendGlobalRtDiv).when(leaderFollowerStoreIngestionTask)
-        .shouldSendGlobalRtDiv(eq(mockSourceRecord), eq(mockPartitionConsumptionState), eq(versionTopic.getName()));
+        .shouldSendGlobalRtDiv(eq(mockSourceRecord), eq(mockPartitionConsumptionState), eq(versionTopicName));
 
     // Wire pcs basics so the install path doesn't NPE if the gate accepts.
     doReturn(mock(PubSubTopicPartition.class)).when(mockPartitionConsumptionState).getReplicaTopicPartition();
@@ -823,7 +822,7 @@ public class LeaderFollowerStoreIngestionTaskTest {
     int expectedTimes = expectedInstall ? 1 : 0;
     verify(mockCallback, times(expectedTimes)).setOnCompletionCallback(any());
     verify(mockPartitionConsumptionState, times(expectedTimes))
-        .resetConsumedBytesSinceLastGlobalRtDivSync(versionTopic.getName());
+        .resetConsumedBytesSinceLastGlobalRtDivSync(versionTopicName);
   }
 
   /**
@@ -926,17 +925,19 @@ public class LeaderFollowerStoreIngestionTaskTest {
     LeaderProducedRecordContext mockContext = mock(LeaderProducedRecordContext.class);
     doReturn(persistedFuture).when(mockContext).getPersistedToDBFuture();
 
-    // Build a consumer record whose source topic IS the version topic, so the install gate accepts it.
-    PubSubTopic versionTopic = leaderFollowerStoreIngestionTask.getVersionTopic();
+    // Build a consumer record on a non-RT topic so the install gate accepts it.
     DefaultPubSubMessage mockConsumerRecord = mock(DefaultPubSubMessage.class);
     PubSubTopicPartition mockSourceTp = mock(PubSubTopicPartition.class);
+    PubSubTopic mockSourceTopic = mock(PubSubTopic.class);
     doReturn(mockSourceTp).when(mockConsumerRecord).getTopicPartition();
-    doReturn(versionTopic).when(mockSourceTp).getPubSubTopic();
+    doReturn(mockSourceTopic).when(mockSourceTp).getPubSubTopic();
+    doReturn(false).when(mockSourceTopic).isRealTime();
 
     // Open the install gate.
     doReturn(true).when(leaderFollowerStoreIngestionTask).isGlobalRtDivEnabled();
+    String versionTopicName = leaderFollowerStoreIngestionTask.getVersionTopic().getName();
     doReturn(true).when(leaderFollowerStoreIngestionTask)
-        .shouldSendGlobalRtDiv(eq(mockConsumerRecord), eq(mockPartitionConsumptionState), eq(versionTopic.getName()));
+        .shouldSendGlobalRtDiv(eq(mockConsumerRecord), eq(mockPartitionConsumptionState), eq(versionTopicName));
 
     LeaderProducerCallback callback = new LeaderProducerCallback(
         leaderFollowerStoreIngestionTask,

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTaskTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTaskTest.java
@@ -835,37 +835,16 @@ public class LeaderFollowerStoreIngestionTaskTest {
   @Test
   public void testInstallVtLcvpSyncCallback() throws InterruptedException {
     setUp();
-    int partition = 1;
-    DefaultPubSubMessage mockSourceRecord = mock(DefaultPubSubMessage.class);
     PubSubTopicPartition mockTp = mock(PubSubTopicPartition.class);
-    doReturn(partition).when(mockTp).getPartitionNumber();
-    doReturn(mockTp).when(mockPartitionConsumptionState).getReplicaTopicPartition();
-    doReturn(0L).when(mockPartitionConsumptionState).getLatestMessageTimeInMs();
-
-    LeaderProducedRecordContext mockContext = mock(LeaderProducedRecordContext.class);
-    CompletableFuture<Void> persistedFuture = new CompletableFuture<>();
-    persistedFuture.complete(null);
-    doReturn(persistedFuture).when(mockContext).getPersistedToDBFuture();
-
-    LeaderProducerCallback callback = new LeaderProducerCallback(
-        leaderFollowerStoreIngestionTask,
-        mockSourceRecord,
-        mockPartitionConsumptionState,
-        mockContext,
-        partition,
-        "remote-broker-url",
-        0L);
+    CompletableFuture<Void> persistedFuture = CompletableFuture.completedFuture(null);
+    LeaderProducerCallback callback = installVtLcvpSyncCallbackWithMocks(mockTp, persistedFuture);
 
     String versionTopicName = leaderFollowerStoreIngestionTask.getVersionTopic().getName();
-    leaderFollowerStoreIngestionTask
-        .installVtLcvpSyncCallback(callback, mockPartitionConsumptionState, partition, mockContext);
-
     // Byte counter is reset synchronously when the callback is installed (mirrors the RT path).
     verify(mockPartitionConsumptionState, times(1)).resetConsumedBytesSinceLastGlobalRtDivSync(versionTopicName);
     // Sync is not triggered until the produce actually completes.
     verify(mockStoreBufferService, never()).execSyncOffsetFromSnapshotAsync(any(), any(), any(), any());
 
-    // Simulate produce completion; verify the snapshot's LCVP is overridden with the produced position.
     PubSubProduceResult produceResult = mock(PubSubProduceResult.class);
     PubSubPosition producedPosition = InMemoryPubSubPosition.of(42L);
     doReturn(producedPosition).when(produceResult).getPubSubPosition();
@@ -886,33 +865,12 @@ public class LeaderFollowerStoreIngestionTaskTest {
   @Test
   public void testInstallVtLcvpSyncCallbackHandlesInterruptedException() throws InterruptedException {
     setUp();
-    int partition = 1;
-    DefaultPubSubMessage mockSourceRecord = mock(DefaultPubSubMessage.class);
-    PubSubTopicPartition mockTp = mock(PubSubTopicPartition.class);
-    doReturn(partition).when(mockTp).getPartitionNumber();
-    doReturn(mockTp).when(mockPartitionConsumptionState).getReplicaTopicPartition();
-    doReturn(0L).when(mockPartitionConsumptionState).getLatestMessageTimeInMs();
-
-    LeaderProducedRecordContext mockContext = mock(LeaderProducedRecordContext.class);
-    CompletableFuture<Void> persistedFuture = new CompletableFuture<>();
-    persistedFuture.complete(null);
-    doReturn(persistedFuture).when(mockContext).getPersistedToDBFuture();
-
-    LeaderProducerCallback callback = new LeaderProducerCallback(
-        leaderFollowerStoreIngestionTask,
-        mockSourceRecord,
-        mockPartitionConsumptionState,
-        mockContext,
-        partition,
-        "remote-broker-url",
-        0L);
-
     // Simulate drainer rejecting the snapshot with InterruptedException (e.g., shutdown).
     doThrow(new InterruptedException("simulated shutdown")).when(mockStoreBufferService)
         .execSyncOffsetFromSnapshotAsync(any(), any(), any(), any());
 
-    leaderFollowerStoreIngestionTask
-        .installVtLcvpSyncCallback(callback, mockPartitionConsumptionState, partition, mockContext);
+    LeaderProducerCallback callback =
+        installVtLcvpSyncCallbackWithMocks(mock(PubSubTopicPartition.class), CompletableFuture.completedFuture(null));
 
     PubSubProduceResult produceResult = mock(PubSubProduceResult.class);
     doReturn(InMemoryPubSubPosition.of(7L)).when(produceResult).getPubSubPosition();
@@ -924,6 +882,33 @@ public class LeaderFollowerStoreIngestionTaskTest {
     assertTrue(
         Thread.interrupted(), // also clears the flag for subsequent tests
         "Thread interrupt flag should be restored after InterruptedException is caught in the callback");
+  }
+
+  /**
+   * Wires up shared mocks for both {@code testInstallVtLcvpSyncCallback*} tests, builds a real
+   * {@link LeaderProducerCallback}, and installs the VT LCVP sync callback on it.
+   */
+  private LeaderProducerCallback installVtLcvpSyncCallbackWithMocks(
+      PubSubTopicPartition mockTp,
+      CompletableFuture<Void> persistedFuture) {
+    int partition = 1;
+    doReturn(mockTp).when(mockPartitionConsumptionState).getReplicaTopicPartition();
+    doReturn(0L).when(mockPartitionConsumptionState).getLatestMessageTimeInMs();
+    doReturn(partition).when(mockPartitionConsumptionState).getPartition();
+
+    LeaderProducedRecordContext mockContext = mock(LeaderProducedRecordContext.class);
+    doReturn(persistedFuture).when(mockContext).getPersistedToDBFuture();
+
+    LeaderProducerCallback callback = new LeaderProducerCallback(
+        leaderFollowerStoreIngestionTask,
+        mock(DefaultPubSubMessage.class),
+        mockPartitionConsumptionState,
+        mockContext,
+        partition,
+        "remote-broker-url",
+        0L);
+    leaderFollowerStoreIngestionTask.installVtLcvpSyncCallback(callback, mockPartitionConsumptionState, mockContext);
+    return callback;
   }
 
   /**

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTaskTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTaskTest.java
@@ -772,39 +772,40 @@ public class LeaderFollowerStoreIngestionTaskTest {
 
   /**
    * Data provider covering every branch of {@link LeaderFollowerStoreIngestionTask#addVtDivToProducerCallbackIfNeeded}'s
-   * install gate: the callback is installed only when Global RT DIV is enabled, the consumed source is
-   * non-RT, AND the byte threshold for a Global RT DIV sync has been reached. Each tuple shifts exactly
-   * one input from the previous "install" baseline.
+   * install gate: the callback is installed only when Global RT DIV is enabled, the consumed source IS
+   * the version topic (i.e., remote VT under NR — same topic name as local VT), AND the byte threshold
+   * for a Global RT DIV sync has been reached. Each tuple shifts exactly one input from the
+   * "install" baseline.
    */
   @DataProvider
   public Object[][] addVtDivToProducerCallbackIfNeededGatingParams() {
     return new Object[][] {
-        // {globalRtDivEnabled, sourceIsRealTime, shouldSendGlobalRtDiv, expectedInstall}
-        { false, false, true, false }, // Global RT DIV disabled — skip regardless.
-        { true, true, true, false }, // Source is RT — handled by sendGlobalRtDivMessage path instead.
-        { true, false, false, false }, // VT source but byte threshold not yet reached.
-        { true, false, true, true } // VT source and threshold reached — install the callback.
+        // {globalRtDivEnabled, sourceIsVersionTopic, shouldSendGlobalRtDiv, expectedInstall}
+        { false, true, true, false }, // Global RT DIV disabled — skip regardless.
+        { true, false, true, false }, // Source is not the VT (e.g. RT) — handled by sendGlobalRtDivMessage path.
+        { true, true, false, false }, // VT source but byte threshold not yet reached.
+        { true, true, true, true } // VT source and threshold reached — install the callback.
     };
   }
 
   @Test(dataProvider = "addVtDivToProducerCallbackIfNeededGatingParams")
   public void testAddVtDivToProducerCallbackIfNeededGating(
       boolean globalRtDivEnabled,
-      boolean sourceIsRealTime,
+      boolean sourceIsVersionTopic,
       boolean shouldSendGlobalRtDiv,
       boolean expectedInstall) throws InterruptedException {
     setUp();
+    PubSubTopic versionTopic = leaderFollowerStoreIngestionTask.getVersionTopic();
+    PubSubTopic sourceTopic = sourceIsVersionTopic ? versionTopic : mock(PubSubTopic.class);
+
     DefaultPubSubMessage mockSourceRecord = mock(DefaultPubSubMessage.class);
     PubSubTopicPartition mockSourceTp = mock(PubSubTopicPartition.class);
-    PubSubTopic mockSourceTopic = mock(PubSubTopic.class);
     doReturn(mockSourceTp).when(mockSourceRecord).getTopicPartition();
-    doReturn(mockSourceTopic).when(mockSourceTp).getPubSubTopic();
-    doReturn(sourceIsRealTime).when(mockSourceTopic).isRealTime();
+    doReturn(sourceTopic).when(mockSourceTp).getPubSubTopic();
 
     doReturn(globalRtDivEnabled).when(leaderFollowerStoreIngestionTask).isGlobalRtDivEnabled();
-    String versionTopicName = leaderFollowerStoreIngestionTask.getVersionTopic().getName();
     doReturn(shouldSendGlobalRtDiv).when(leaderFollowerStoreIngestionTask)
-        .shouldSendGlobalRtDiv(eq(mockSourceRecord), eq(mockPartitionConsumptionState), eq(versionTopicName));
+        .shouldSendGlobalRtDiv(eq(mockSourceRecord), eq(mockPartitionConsumptionState), eq(versionTopic.getName()));
 
     // Wire pcs basics so the install path doesn't NPE if the gate accepts.
     doReturn(mock(PubSubTopicPartition.class)).when(mockPartitionConsumptionState).getReplicaTopicPartition();
@@ -812,16 +813,17 @@ public class LeaderFollowerStoreIngestionTaskTest {
     doReturn(1).when(mockPartitionConsumptionState).getPartition();
 
     LeaderProducerCallback mockCallback = mock(LeaderProducerCallback.class);
-    LeaderProducedRecordContext mockCtx = mock(LeaderProducedRecordContext.class);
-
-    leaderFollowerStoreIngestionTask
-        .addVtDivToProducerCallbackIfNeeded(mockSourceRecord, mockCallback, mockPartitionConsumptionState, mockCtx);
+    leaderFollowerStoreIngestionTask.addVtDivToProducerCallbackIfNeeded(
+        mockSourceRecord,
+        mockCallback,
+        mockPartitionConsumptionState,
+        new CompletableFuture<>());
 
     // Both side effects fire iff the install gate accepts.
     int expectedTimes = expectedInstall ? 1 : 0;
     verify(mockCallback, times(expectedTimes)).setOnCompletionCallback(any());
     verify(mockPartitionConsumptionState, times(expectedTimes))
-        .resetConsumedBytesSinceLastGlobalRtDivSync(versionTopicName);
+        .resetConsumedBytesSinceLastGlobalRtDivSync(versionTopic.getName());
   }
 
   /**
@@ -924,19 +926,17 @@ public class LeaderFollowerStoreIngestionTaskTest {
     LeaderProducedRecordContext mockContext = mock(LeaderProducedRecordContext.class);
     doReturn(persistedFuture).when(mockContext).getPersistedToDBFuture();
 
-    // Build a consumer record on a non-RT topic so the install gate accepts it.
+    // Build a consumer record whose source topic IS the version topic, so the install gate accepts it.
+    PubSubTopic versionTopic = leaderFollowerStoreIngestionTask.getVersionTopic();
     DefaultPubSubMessage mockConsumerRecord = mock(DefaultPubSubMessage.class);
     PubSubTopicPartition mockSourceTp = mock(PubSubTopicPartition.class);
-    PubSubTopic mockSourceTopic = mock(PubSubTopic.class);
     doReturn(mockSourceTp).when(mockConsumerRecord).getTopicPartition();
-    doReturn(mockSourceTopic).when(mockSourceTp).getPubSubTopic();
-    doReturn(false).when(mockSourceTopic).isRealTime();
+    doReturn(versionTopic).when(mockSourceTp).getPubSubTopic();
 
     // Open the install gate.
     doReturn(true).when(leaderFollowerStoreIngestionTask).isGlobalRtDivEnabled();
-    String versionTopicName = leaderFollowerStoreIngestionTask.getVersionTopic().getName();
     doReturn(true).when(leaderFollowerStoreIngestionTask)
-        .shouldSendGlobalRtDiv(eq(mockConsumerRecord), eq(mockPartitionConsumptionState), eq(versionTopicName));
+        .shouldSendGlobalRtDiv(eq(mockConsumerRecord), eq(mockPartitionConsumptionState), eq(versionTopic.getName()));
 
     LeaderProducerCallback callback = new LeaderProducerCallback(
         leaderFollowerStoreIngestionTask,
@@ -946,8 +946,11 @@ public class LeaderFollowerStoreIngestionTaskTest {
         partition,
         "remote-broker-url",
         0L);
-    leaderFollowerStoreIngestionTask
-        .addVtDivToProducerCallbackIfNeeded(mockConsumerRecord, callback, mockPartitionConsumptionState, mockContext);
+    leaderFollowerStoreIngestionTask.addVtDivToProducerCallbackIfNeeded(
+        mockConsumerRecord,
+        callback,
+        mockPartitionConsumptionState,
+        persistedFuture);
     return callback;
   }
 

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTaskTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTaskTest.java
@@ -780,6 +780,49 @@ public class LeaderFollowerStoreIngestionTaskTest {
   }
 
   /**
+   * Data provider covering every branch outcome of
+   * {@link LeaderFollowerStoreIngestionTask#shouldInstallVtLcvpSyncCallback}: the predicate returns
+   * true only when Global RT DIV is enabled, the consumed source is non-RT, and the byte threshold
+   * for a Global RT DIV sync has been reached. Each tuple shifts exactly one input from the
+   * previous "expected=true" baseline.
+   */
+  @DataProvider(name = "shouldInstallVtLcvpSyncCallbackParams")
+  public Object[][] shouldInstallVtLcvpSyncCallbackParams() {
+    return new Object[][] {
+        // {globalRtDivEnabled, sourceIsRealTime, shouldSendGlobalRtDiv, expected}
+        { false, false, true, false }, // Global RT DIV disabled — skip regardless.
+        { true, true, true, false }, // Source is RT — handled by sendGlobalRtDivMessage path instead.
+        { true, false, false, false }, // VT source but byte threshold not yet reached.
+        { true, false, true, true } // VT source and threshold reached — install the callback.
+    };
+  }
+
+  @Test(dataProvider = "shouldInstallVtLcvpSyncCallbackParams")
+  public void testShouldInstallVtLcvpSyncCallback(
+      boolean globalRtDivEnabled,
+      boolean sourceIsRealTime,
+      boolean shouldSendGlobalRtDiv,
+      boolean expected) throws InterruptedException {
+    setUp();
+    DefaultPubSubMessage mockSourceRecord = mock(DefaultPubSubMessage.class);
+    PubSubTopicPartition mockTp = mock(PubSubTopicPartition.class);
+    PubSubTopic mockTopic = mock(PubSubTopic.class);
+    doReturn(mockTp).when(mockSourceRecord).getTopicPartition();
+    doReturn(mockTopic).when(mockTp).getPubSubTopic();
+    doReturn(sourceIsRealTime).when(mockTopic).isRealTime();
+
+    doReturn(globalRtDivEnabled).when(leaderFollowerStoreIngestionTask).isGlobalRtDivEnabled();
+    String versionTopicName = leaderFollowerStoreIngestionTask.getVersionTopic().getName();
+    doReturn(shouldSendGlobalRtDiv).when(leaderFollowerStoreIngestionTask)
+        .shouldSendGlobalRtDiv(eq(mockSourceRecord), eq(mockPartitionConsumptionState), eq(versionTopicName));
+
+    assertEquals(
+        leaderFollowerStoreIngestionTask
+            .shouldInstallVtLcvpSyncCallback(mockSourceRecord, mockPartitionConsumptionState),
+        expected);
+  }
+
+  /**
    * Verifies that {@link LeaderFollowerStoreIngestionTask#installVtLcvpSyncCallback} installs an
    * onCompletionCallback on the regular {@link LeaderProducerCallback} that, when fired, asynchronously
    * syncs the OffsetRecord with LCVP set to the produced-local-VT position. This covers the leader
@@ -832,6 +875,55 @@ public class LeaderFollowerStoreIngestionTaskTest {
     verify(mockStoreBufferService, times(1))
         .execSyncOffsetFromSnapshotAsync(eq(mockTp), vtDivCaptor.capture(), eq(persistedFuture), any());
     assertEquals(vtDivCaptor.getValue().getLatestConsumedVtPosition(), producedPosition);
+  }
+
+  /**
+   * Verifies that when {@link StoreBufferService#execSyncOffsetFromSnapshotAsync} throws
+   * {@link InterruptedException} from inside the produce-completion callback, the exception is
+   * caught (so it doesn't propagate up to the producer) and the current thread's interrupt flag
+   * is restored, preserving shutdown/cancellation semantics.
+   */
+  @Test
+  public void testInstallVtLcvpSyncCallbackHandlesInterruptedException() throws InterruptedException {
+    setUp();
+    int partition = 1;
+    DefaultPubSubMessage mockSourceRecord = mock(DefaultPubSubMessage.class);
+    PubSubTopicPartition mockTp = mock(PubSubTopicPartition.class);
+    doReturn(partition).when(mockTp).getPartitionNumber();
+    doReturn(mockTp).when(mockPartitionConsumptionState).getReplicaTopicPartition();
+    doReturn(0L).when(mockPartitionConsumptionState).getLatestMessageTimeInMs();
+
+    LeaderProducedRecordContext mockContext = mock(LeaderProducedRecordContext.class);
+    CompletableFuture<Void> persistedFuture = new CompletableFuture<>();
+    persistedFuture.complete(null);
+    doReturn(persistedFuture).when(mockContext).getPersistedToDBFuture();
+
+    LeaderProducerCallback callback = new LeaderProducerCallback(
+        leaderFollowerStoreIngestionTask,
+        mockSourceRecord,
+        mockPartitionConsumptionState,
+        mockContext,
+        partition,
+        "remote-broker-url",
+        0L);
+
+    // Simulate drainer rejecting the snapshot with InterruptedException (e.g., shutdown).
+    doThrow(new InterruptedException("simulated shutdown")).when(mockStoreBufferService)
+        .execSyncOffsetFromSnapshotAsync(any(), any(), any(), any());
+
+    leaderFollowerStoreIngestionTask
+        .installVtLcvpSyncCallback(callback, mockPartitionConsumptionState, partition, mockContext);
+
+    PubSubProduceResult produceResult = mock(PubSubProduceResult.class);
+    doReturn(InMemoryPubSubPosition.of(7L)).when(produceResult).getPubSubPosition();
+
+    // Clear any pre-existing interrupt state on the test thread, then trigger the callback.
+    // The InterruptedException must be caught (no propagation) and the interrupt flag restored.
+    Thread.interrupted();
+    callback.onCompletion(produceResult, null);
+    assertTrue(
+        Thread.interrupted(), // also clears the flag for subsequent tests
+        "Thread interrupt flag should be restored after InterruptedException is caught in the callback");
   }
 
   /**

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTaskTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTaskTest.java
@@ -780,6 +780,61 @@ public class LeaderFollowerStoreIngestionTaskTest {
   }
 
   /**
+   * Verifies that {@link LeaderFollowerStoreIngestionTask#installVtLcvpSyncCallback} installs an
+   * onCompletionCallback on the regular {@link LeaderProducerCallback} that, when fired, asynchronously
+   * syncs the OffsetRecord with LCVP set to the produced-local-VT position. This covers the leader
+   * consuming from a VT source (e.g., remote VT), whose LCVP would otherwise never be persisted —
+   * causing restart from EARLIEST.
+   *
+   * Also verifies the byte counter is reset synchronously, mirroring the leader-RT path's behavior
+   * in {@link LeaderFollowerStoreIngestionTask#sendGlobalRtDivMessage}.
+   */
+  @Test
+  public void testInstallVtLcvpSyncCallback() throws InterruptedException {
+    setUp();
+    int partition = 1;
+    DefaultPubSubMessage mockSourceRecord = mock(DefaultPubSubMessage.class);
+    PubSubTopicPartition mockTp = mock(PubSubTopicPartition.class);
+    doReturn(partition).when(mockTp).getPartitionNumber();
+    doReturn(mockTp).when(mockPartitionConsumptionState).getReplicaTopicPartition();
+    doReturn(0L).when(mockPartitionConsumptionState).getLatestMessageTimeInMs();
+
+    LeaderProducedRecordContext mockContext = mock(LeaderProducedRecordContext.class);
+    CompletableFuture<Void> persistedFuture = new CompletableFuture<>();
+    persistedFuture.complete(null);
+    doReturn(persistedFuture).when(mockContext).getPersistedToDBFuture();
+
+    LeaderProducerCallback callback = new LeaderProducerCallback(
+        leaderFollowerStoreIngestionTask,
+        mockSourceRecord,
+        mockPartitionConsumptionState,
+        mockContext,
+        partition,
+        "remote-broker-url",
+        0L);
+
+    String versionTopicName = leaderFollowerStoreIngestionTask.getVersionTopic().getName();
+    leaderFollowerStoreIngestionTask
+        .installVtLcvpSyncCallback(callback, mockPartitionConsumptionState, partition, mockContext);
+
+    // Byte counter is reset synchronously when the callback is installed (mirrors the RT path).
+    verify(mockPartitionConsumptionState, times(1)).resetConsumedBytesSinceLastGlobalRtDivSync(versionTopicName);
+    // Sync is not triggered until the produce actually completes.
+    verify(mockStoreBufferService, never()).execSyncOffsetFromSnapshotAsync(any(), any(), any(), any());
+
+    // Simulate produce completion; verify the snapshot's LCVP is overridden with the produced position.
+    PubSubProduceResult produceResult = mock(PubSubProduceResult.class);
+    PubSubPosition producedPosition = InMemoryPubSubPosition.of(42L);
+    doReturn(producedPosition).when(produceResult).getPubSubPosition();
+    callback.onCompletion(produceResult, null);
+
+    ArgumentCaptor<PartitionTracker> vtDivCaptor = ArgumentCaptor.forClass(PartitionTracker.class);
+    verify(mockStoreBufferService, times(1))
+        .execSyncOffsetFromSnapshotAsync(eq(mockTp), vtDivCaptor.capture(), eq(persistedFuture), any());
+    assertEquals(vtDivCaptor.getValue().getLatestConsumedVtPosition(), producedPosition);
+  }
+
+  /**
    * Verifies that validateAndFilterOutDuplicateMessagesFromLeaderTopic selects the correct TopicType
    * based on whether the consumed topic is an RT topic or a remote VT (NR mode).
    *

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTaskTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTaskTest.java
@@ -1149,6 +1149,49 @@ public class LeaderFollowerStoreIngestionTaskTest {
     verify(mockStoreBufferService, times(1)).execSyncOffsetFromSnapshotAsync(any(), any(), any(), any());
   }
 
+  /**
+   * Verifies that {@link LeaderFollowerStoreIngestionTask#sendVtDivSnapshotIfNeeded} restores the
+   * thread's interrupt flag when the drainer throws {@link InterruptedException}, so that shutdown
+   * and cancellation signals are not silently swallowed.
+   */
+  @Test
+  public void testSendVtDivSnapshotIfNeededRestoresInterruptOnInterruptedException() throws InterruptedException {
+    setUp();
+
+    doReturn(true).when(leaderFollowerStoreIngestionTask).isGlobalRtDivEnabled();
+    doReturn(true).when(leaderFollowerStoreIngestionTask).shouldSendVtDivSnapshot(any(), any());
+    CompletableFuture<Void> mockFuture = new CompletableFuture<>();
+    doReturn(mockFuture).when(mockPartitionConsumptionState).getLastQueuedRecordPersistedFuture();
+
+    DataIntegrityValidator mockConsumerDiv = mock(DataIntegrityValidator.class);
+    doReturn(mockConsumerDiv).when(leaderFollowerStoreIngestionTask).getConsumerDiv();
+
+    PartitionTracker snapshotReady = mock(PartitionTracker.class);
+    doReturn(ApacheKafkaOffsetPosition.of(10L)).when(snapshotReady).getLatestConsumedVtPosition();
+    doReturn(Collections.singletonMap("producerGuid", new Object())).when(snapshotReady).getPartitionStates(any());
+    doReturn(snapshotReady).when(mockConsumerDiv).cloneVtProducerStates(anyInt(), anyBoolean(), anyLong());
+
+    PubSubTopicPartition versionTopicPartition =
+        new PubSubTopicPartitionImpl(TOPIC_REPOSITORY.getTopic("test-topic_v1"), 0);
+    DefaultPubSubMessage mockRecord = getMockMessage(1).getMessage();
+
+    doThrow(new InterruptedException("simulated drainer interrupt")).when(mockStoreBufferService)
+        .execSyncOffsetFromSnapshotAsync(any(), any(), any(), any());
+
+    // Sanity: make sure the test thread is not already interrupted before the call
+    assertFalse(Thread.interrupted(), "Thread should not be interrupted before invocation");
+    try {
+      leaderFollowerStoreIngestionTask.sendVtDivSnapshotIfNeeded(mockRecord, versionTopicPartition);
+      // The catch block must restore the interrupt flag.
+      assertTrue(
+          Thread.currentThread().isInterrupted(),
+          "Thread interrupt flag should be restored after catching InterruptedException");
+    } finally {
+      // Clear the interrupt flag so subsequent tests on this thread are not affected.
+      Thread.interrupted();
+    }
+  }
+
   @Test
   public void testFutureVersionLatchStatus() throws InterruptedException {
     setUp(true);

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTaskTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTaskTest.java
@@ -781,13 +781,13 @@ public class LeaderFollowerStoreIngestionTaskTest {
 
   /**
    * Data provider covering every branch outcome of
-   * {@link LeaderFollowerStoreIngestionTask#shouldInstallVtLcvpSyncCallback}: the predicate returns
+   * {@link LeaderFollowerStoreIngestionTask#shouldProducerCallbackSendVtDiv}: the predicate returns
    * true only when Global RT DIV is enabled, the consumed source is non-RT, and the byte threshold
    * for a Global RT DIV sync has been reached. Each tuple shifts exactly one input from the
    * previous "expected=true" baseline.
    */
   @DataProvider(name = "shouldInstallVtLcvpSyncCallbackParams")
-  public Object[][] shouldInstallVtLcvpSyncCallbackParams() {
+  public Object[][] shouldProducerCallbackSendVtDivParams() {
     return new Object[][] {
         // {globalRtDivEnabled, sourceIsRealTime, shouldSendGlobalRtDiv, expected}
         { false, false, true, false }, // Global RT DIV disabled — skip regardless.
@@ -797,8 +797,8 @@ public class LeaderFollowerStoreIngestionTaskTest {
     };
   }
 
-  @Test(dataProvider = "shouldInstallVtLcvpSyncCallbackParams")
-  public void testShouldInstallVtLcvpSyncCallback(
+  @Test(dataProvider = "shouldProducerCallbackSendVtDivParams")
+  public void testShouldProducerCallbackSendVtDiv(
       boolean globalRtDivEnabled,
       boolean sourceIsRealTime,
       boolean shouldSendGlobalRtDiv,
@@ -818,12 +818,12 @@ public class LeaderFollowerStoreIngestionTaskTest {
 
     assertEquals(
         leaderFollowerStoreIngestionTask
-            .shouldInstallVtLcvpSyncCallback(mockSourceRecord, mockPartitionConsumptionState),
+            .shouldProducerCallbackSendVtDiv(mockSourceRecord, mockPartitionConsumptionState),
         expected);
   }
 
   /**
-   * Verifies that {@link LeaderFollowerStoreIngestionTask#installVtLcvpSyncCallback} installs an
+   * Verifies that {@link LeaderFollowerStoreIngestionTask#addVtDivToProducerCallback} installs an
    * onCompletionCallback on the regular {@link LeaderProducerCallback} that, when fired, asynchronously
    * syncs the OffsetRecord with LCVP set to the produced-local-VT position. This covers the leader
    * consuming from a VT source (e.g., remote VT), whose LCVP would otherwise never be persisted —
@@ -833,11 +833,11 @@ public class LeaderFollowerStoreIngestionTaskTest {
    * in {@link LeaderFollowerStoreIngestionTask#sendGlobalRtDivMessage}.
    */
   @Test
-  public void testInstallVtLcvpSyncCallback() throws InterruptedException {
+  public void testAddVtDivToProducerCallback() throws InterruptedException {
     setUp();
     PubSubTopicPartition mockTp = mock(PubSubTopicPartition.class);
     CompletableFuture<Void> persistedFuture = CompletableFuture.completedFuture(null);
-    LeaderProducerCallback callback = installVtLcvpSyncCallbackWithMocks(mockTp, persistedFuture);
+    LeaderProducerCallback callback = addVtDivToProducerCallbackWithMocks(mockTp, persistedFuture);
 
     String versionTopicName = leaderFollowerStoreIngestionTask.getVersionTopic().getName();
     // Byte counter is reset synchronously when the callback is installed (mirrors the RT path).
@@ -863,14 +863,14 @@ public class LeaderFollowerStoreIngestionTaskTest {
    * is restored, preserving shutdown/cancellation semantics.
    */
   @Test
-  public void testInstallVtLcvpSyncCallbackHandlesInterruptedException() throws InterruptedException {
+  public void testAddVtDivToProducerCallbackHandlesInterruptedException() throws InterruptedException {
     setUp();
     // Simulate drainer rejecting the snapshot with InterruptedException (e.g., shutdown).
     doThrow(new InterruptedException("simulated shutdown")).when(mockStoreBufferService)
         .execSyncOffsetFromSnapshotAsync(any(), any(), any(), any());
 
     LeaderProducerCallback callback =
-        installVtLcvpSyncCallbackWithMocks(mock(PubSubTopicPartition.class), CompletableFuture.completedFuture(null));
+        addVtDivToProducerCallbackWithMocks(mock(PubSubTopicPartition.class), CompletableFuture.completedFuture(null));
 
     PubSubProduceResult produceResult = mock(PubSubProduceResult.class);
     doReturn(InMemoryPubSubPosition.of(7L)).when(produceResult).getPubSubPosition();
@@ -888,7 +888,7 @@ public class LeaderFollowerStoreIngestionTaskTest {
    * Wires up shared mocks for both {@code testInstallVtLcvpSyncCallback*} tests, builds a real
    * {@link LeaderProducerCallback}, and installs the VT LCVP sync callback on it.
    */
-  private LeaderProducerCallback installVtLcvpSyncCallbackWithMocks(
+  private LeaderProducerCallback addVtDivToProducerCallbackWithMocks(
       PubSubTopicPartition mockTp,
       CompletableFuture<Void> persistedFuture) {
     int partition = 1;
@@ -907,7 +907,7 @@ public class LeaderFollowerStoreIngestionTaskTest {
         partition,
         "remote-broker-url",
         0L);
-    leaderFollowerStoreIngestionTask.installVtLcvpSyncCallback(callback, mockPartitionConsumptionState, mockContext);
+    leaderFollowerStoreIngestionTask.addVtDivToProducerCallback(callback, mockPartitionConsumptionState, mockContext);
     return callback;
   }
 

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTaskTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTaskTest.java
@@ -1023,10 +1023,10 @@ public class LeaderFollowerStoreIngestionTaskTest {
   }
 
   @Test
-  public void testShouldSyncOffsetFromSnapshot() throws InterruptedException {
+  public void testShouldSendVtDivSnapshot() throws InterruptedException {
     setUp();
     LeaderFollowerStoreIngestionTask mockIngestionTask = mock(LeaderFollowerStoreIngestionTask.class);
-    doCallRealMethod().when(mockIngestionTask).shouldSyncOffsetFromSnapshot(any(), any());
+    doCallRealMethod().when(mockIngestionTask).shouldSendVtDivSnapshot(any(), any());
     doCallRealMethod().when(mockIngestionTask).shouldSyncOffset(any(), any(), any());
     // Stub early so size-based branch can call getVersionTopic().getName()
     PubSubTopic versionTopic = TOPIC_REPOSITORY.getTopic("test-topic_v1");
@@ -1040,20 +1040,20 @@ public class LeaderFollowerStoreIngestionTaskTest {
     KafkaMessageEnvelope mockKme = globalRtDivMessage.getValue();
 
     // The method should only return true for non-chunked Global RT DIV messages
-    assertFalse(mockIngestionTask.shouldSyncOffsetFromSnapshot(globalRtDivMessage, mockPartitionConsumptionState));
+    assertFalse(mockIngestionTask.shouldSendVtDivSnapshot(globalRtDivMessage, mockPartitionConsumptionState));
     doReturn(true).when(mockKey).isGlobalRtDiv();
     doReturn(mockPut).when(mockKme).getPayloadUnion();
     doReturn(GLOBAL_RT_DIV_VERSION).when(mockPut).getSchemaId();
-    assertTrue(mockIngestionTask.shouldSyncOffsetFromSnapshot(globalRtDivMessage, mockPartitionConsumptionState));
+    assertTrue(mockIngestionTask.shouldSendVtDivSnapshot(globalRtDivMessage, mockPartitionConsumptionState));
     doReturn(AvroProtocolDefinition.CHUNK.getCurrentProtocolVersion()).when(mockPut).getSchemaId();
-    assertFalse(mockIngestionTask.shouldSyncOffsetFromSnapshot(globalRtDivMessage, mockPartitionConsumptionState));
+    assertFalse(mockIngestionTask.shouldSendVtDivSnapshot(globalRtDivMessage, mockPartitionConsumptionState));
     doReturn(AvroProtocolDefinition.CHUNKED_VALUE_MANIFEST.getCurrentProtocolVersion()).when(mockPut).getSchemaId();
-    assertTrue(mockIngestionTask.shouldSyncOffsetFromSnapshot(globalRtDivMessage, mockPartitionConsumptionState));
+    assertTrue(mockIngestionTask.shouldSendVtDivSnapshot(globalRtDivMessage, mockPartitionConsumptionState));
 
     // The method should not error when a non-Put value is passed in
     Delete mockDelete = mock(Delete.class);
     doReturn(mockDelete).when(mockKme).getPayloadUnion();
-    assertFalse(mockIngestionTask.shouldSyncOffsetFromSnapshot(globalRtDivMessage, mockPartitionConsumptionState));
+    assertFalse(mockIngestionTask.shouldSendVtDivSnapshot(globalRtDivMessage, mockPartitionConsumptionState));
 
     // Set up Control Message
     final DefaultPubSubMessage nonSegmentControlMessage = getMockMessage(2).getMessage();
@@ -1063,15 +1063,13 @@ public class LeaderFollowerStoreIngestionTaskTest {
     ControlMessage mockControlMessage = mock(ControlMessage.class);
 
     // The method should only return true for non-segment control messages
-    assertFalse(
-        mockIngestionTask.shouldSyncOffsetFromSnapshot(nonSegmentControlMessage, mockPartitionConsumptionState));
+    assertFalse(mockIngestionTask.shouldSendVtDivSnapshot(nonSegmentControlMessage, mockPartitionConsumptionState));
     doReturn(ControlMessageType.START_OF_PUSH.getValue()).when(mockControlMessage).getControlMessageType();
     doReturn(true).when(mockKey).isControlMessage();
     doReturn(mockControlMessage).when(mockKme).getPayloadUnion();
-    assertTrue(mockIngestionTask.shouldSyncOffsetFromSnapshot(nonSegmentControlMessage, mockPartitionConsumptionState));
+    assertTrue(mockIngestionTask.shouldSendVtDivSnapshot(nonSegmentControlMessage, mockPartitionConsumptionState));
     doReturn(ControlMessageType.START_OF_SEGMENT.getValue()).when(mockControlMessage).getControlMessageType();
-    assertFalse(
-        mockIngestionTask.shouldSyncOffsetFromSnapshot(nonSegmentControlMessage, mockPartitionConsumptionState));
+    assertFalse(mockIngestionTask.shouldSendVtDivSnapshot(nonSegmentControlMessage, mockPartitionConsumptionState));
 
     // Mock the getSyncBytesInterval method to return a specific value
     doReturn(1000L).when(mockIngestionTask).getSyncBytesInterval(any());
@@ -1085,21 +1083,21 @@ public class LeaderFollowerStoreIngestionTaskTest {
     // Test case 1: When VT consumed bytes since last sync is less than 2*syncBytesInterval
     doReturn(1500L).when(mockPartitionConsumptionState)
         .getConsumedBytesSinceLastGlobalRtDivSync(versionTopic.getName());
-    assertFalse(mockIngestionTask.shouldSyncOffsetFromSnapshot(regularMessage, mockPartitionConsumptionState));
+    assertFalse(mockIngestionTask.shouldSendVtDivSnapshot(regularMessage, mockPartitionConsumptionState));
 
     // Test case 2: When VT consumed bytes since last sync is equal to 2*syncBytesInterval
     doReturn(2000L).when(mockPartitionConsumptionState)
         .getConsumedBytesSinceLastGlobalRtDivSync(versionTopic.getName());
-    assertTrue(mockIngestionTask.shouldSyncOffsetFromSnapshot(regularMessage, mockPartitionConsumptionState));
+    assertTrue(mockIngestionTask.shouldSendVtDivSnapshot(regularMessage, mockPartitionConsumptionState));
 
     // Test case 3: When VT consumed bytes since last sync is greater than 2*syncBytesInterval
     doReturn(2500L).when(mockPartitionConsumptionState)
         .getConsumedBytesSinceLastGlobalRtDivSync(versionTopic.getName());
-    assertTrue(mockIngestionTask.shouldSyncOffsetFromSnapshot(regularMessage, mockPartitionConsumptionState));
+    assertTrue(mockIngestionTask.shouldSendVtDivSnapshot(regularMessage, mockPartitionConsumptionState));
 
     // Test case 4: When syncBytesInterval is 0 (disabled)
     doReturn(0L).when(mockIngestionTask).getSyncBytesInterval(any());
-    assertFalse(mockIngestionTask.shouldSyncOffsetFromSnapshot(regularMessage, mockPartitionConsumptionState));
+    assertFalse(mockIngestionTask.shouldSendVtDivSnapshot(regularMessage, mockPartitionConsumptionState));
   }
 
   /**
@@ -1115,12 +1113,12 @@ public class LeaderFollowerStoreIngestionTaskTest {
    * <p>Guard: Skip if the snapshot's LCVP equals EARLIEST (no meaningful VT progress yet).
    */
   @Test
-  public void testSyncOffsetFromSnapshotIfNeededSkipsWhenLcvpIsEarliest() throws InterruptedException {
+  public void testSendVtDivSnapshotIfNeededSkipsWhenLcvpIsEarliest() throws InterruptedException {
     setUp();
 
     // isGlobalRtDivEnabled must be true and shouldSyncOffsetFromSnapshot must pass so we reach the new guard
     doReturn(true).when(leaderFollowerStoreIngestionTask).isGlobalRtDivEnabled();
-    doReturn(true).when(leaderFollowerStoreIngestionTask).shouldSyncOffsetFromSnapshot(any(), any());
+    doReturn(true).when(leaderFollowerStoreIngestionTask).shouldSendVtDivSnapshot(any(), any());
     CompletableFuture<Void> mockFuture = new CompletableFuture<>();
     doReturn(mockFuture).when(mockPartitionConsumptionState).getLastQueuedRecordPersistedFuture();
 
@@ -1138,7 +1136,7 @@ public class LeaderFollowerStoreIngestionTaskTest {
     doReturn(PubSubSymbolicPosition.EARLIEST).when(snapshotEarliestLcvp).getLatestConsumedVtPosition();
     doReturn(snapshotEarliestLcvp).when(mockConsumerDiv).cloneVtProducerStates(anyInt(), anyBoolean(), anyLong());
 
-    leaderFollowerStoreIngestionTask.syncOffsetFromSnapshotIfNeeded(mockRecord, versionTopicPartition);
+    leaderFollowerStoreIngestionTask.sendVtDivSnapshotIfNeeded(mockRecord, versionTopicPartition);
     verify(mockStoreBufferService, never()).execSyncOffsetFromSnapshotAsync(any(), any(), any(), any());
 
     // --- Case 2: LCVP is non-EARLIEST (VT progress recorded) → sync must proceed, even with empty segments ---
@@ -1147,7 +1145,7 @@ public class LeaderFollowerStoreIngestionTaskTest {
     doReturn(Collections.singletonMap("producerGuid", new Object())).when(snapshotReady).getPartitionStates(any());
     doReturn(snapshotReady).when(mockConsumerDiv).cloneVtProducerStates(anyInt(), anyBoolean(), anyLong());
 
-    leaderFollowerStoreIngestionTask.syncOffsetFromSnapshotIfNeeded(mockRecord, versionTopicPartition);
+    leaderFollowerStoreIngestionTask.sendVtDivSnapshotIfNeeded(mockRecord, versionTopicPartition);
     verify(mockStoreBufferService, times(1)).execSyncOffsetFromSnapshotAsync(any(), any(), any(), any());
   }
 

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTaskTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTaskTest.java
@@ -776,7 +776,7 @@ public class LeaderFollowerStoreIngestionTaskTest {
    * non-RT, AND the byte threshold for a Global RT DIV sync has been reached. Each tuple shifts exactly
    * one input from the previous "install" baseline.
    */
-  @DataProvider(name = "addVtDivToProducerCallbackGatingParams")
+  @DataProvider
   public Object[][] addVtDivToProducerCallbackIfNeededGatingParams() {
     return new Object[][] {
         // {globalRtDivEnabled, sourceIsRealTime, shouldSendGlobalRtDiv, expectedInstall}

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestGlobalRtDiv.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestGlobalRtDiv.java
@@ -1377,7 +1377,7 @@ public class TestGlobalRtDiv {
    * Owns the multi-region cluster wrapper and shuts it down on {@link #close()}.
    */
   private static final class NRGlobalRtDivBatchEnv implements AutoCloseable {
-    final VeniceTwoLayerMultiRegionMultiClusterWrapper multiRegion;
+    private final VeniceTwoLayerMultiRegionMultiClusterWrapper multiRegion;
     final VeniceClusterWrapper remoteDcCluster;
     final VeniceServerWrapper leaderServer;
     final String topicName;

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestGlobalRtDiv.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestGlobalRtDiv.java
@@ -1400,9 +1400,13 @@ public class TestGlobalRtDiv {
           topicName,
           storeName,
           routingDataRepo);
-    } catch (Exception e) {
-      multiRegion.close();
-      throw e;
+    } catch (Throwable t) {
+      try {
+        multiRegion.close();
+      } catch (Throwable closeFailure) {
+        t.addSuppressed(closeFailure);
+      }
+      throw t;
     }
   }
 

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestGlobalRtDiv.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestGlobalRtDiv.java
@@ -1250,6 +1250,16 @@ public class TestGlobalRtDiv {
                 + "). A lower post-restart value indicates the leader rewound to EARLIEST and re-synced.");
       });
 
+      // The previous (restarted) leader's partition must reach a completed state — End-Of-Push received,
+      // confirming the replica is caught up regardless of whether it is currently leader or follower.
+      TestUtils.waitForNonDeterministicAssertion(60, TimeUnit.SECONDS, true, true, () -> {
+        OffsetRecord previousLeaderRecord = getRemoteDcLeaderOffsetRecord(leaderServer, topicName, PARTITION);
+        assertTrue(
+            previousLeaderRecord.isEndOfPushReceived(),
+            "Previous leader " + leaderServer.getAddress()
+                + " should have endOfPushReceived=true after restart, indicating partition is fully ingested.");
+      });
+
       // Sanity: ingestion remains healthy after restart — version is still current and data is queryable.
       try (AvroGenericStoreClient<Object, Object> client = ClientFactory.getAndStartGenericAvroClient(
           ClientConfig.defaultGenericClientConfig(env.storeName).setVeniceURL(remoteDcCluster.getRandomRouterURL()))) {

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestGlobalRtDiv.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestGlobalRtDiv.java
@@ -1125,18 +1125,169 @@ public class TestGlobalRtDiv {
   @Test(timeOut = 180 * Time.MS_PER_SECOND)
   public void testBatchOnlyNRStoreWithGlobalRtDiv() throws Exception {
     int PARTITION = 0;
-    int recordCount = 100;
-    int partitionCount = 1;
-    String clusterName = "venice-cluster0";
+    try (NRGlobalRtDivBatchEnv env =
+        setUpNRGlobalRtDivBatchPushed("venice-cluster0", "batchOnlyNrGlobalRtDiv", 100, 1, PARTITION, null)) {
 
+      // The non-source dc's leader consumes from the source dc's VT (consumeRemotely=true).
+      // Verify VT state is correctly populated in vtSegments (not misrouted to rtSegments).
+      TestUtils.waitForNonDeterministicAssertion(30, TimeUnit.SECONDS, true, true, () -> {
+        env.remoteDcCluster.getVeniceServers().forEach(server -> {
+          if (!server.isRunning()) {
+            return;
+          }
+          StoreIngestionTask sit =
+              server.getVeniceServer().getKafkaStoreIngestionService().getStoreIngestionTask(env.topicName);
+          assertNotNull(sit, "StoreIngestionTask should exist on server: " + server.getAddress());
+
+          DataIntegrityValidator div = sit.getDataIntegrityValidator();
+          assertNotNull(div, "DIV should be initialized on server: " + server.getAddress());
+
+          boolean isLeader = server.getPort() == env.leaderServer.getPort();
+          LOGGER.info(
+              "remote-dc {} ({}): hasVtDivState={}, hasGlobalRtDivState={}",
+              server.getAddress(),
+              isLeader ? "leader" : "follower",
+              div.hasVtDivState(PARTITION),
+              div.hasGlobalRtDivState(PARTITION));
+
+          if (isLeader) {
+            assertTrue(
+                div.hasVtDivState(PARTITION),
+                "VT DIV state should exist on dc-1 leader after topicType fix. Server: " + server.getAddress());
+          }
+          assertFalse(
+              div.hasGlobalRtDivState(PARTITION),
+              "Global RT DIV state should NOT exist on " + server.getAddress() + " (no RT writers)");
+        });
+      });
+    }
+  }
+
+  /**
+   * Verifies that under native replication with Global RT DIV enabled, the remote-DC leader (which
+   * consumes from the source DC's VT) persists the latest consumed VT position (LCVP) to its
+   * OffsetRecord during ingestion, and that the LCVP survives a leader restart so that ingestion
+   * does not rewind to {@link PubSubSymbolicPosition#EARLIEST} on the second startup.
+   */
+  @Test(timeOut = 240 * Time.MS_PER_SECOND)
+  public void testBatchOnlyNRRemoteVTLeaderRestartDoesNotRewindToEarliest() throws Exception {
+    int PARTITION = 0;
+    // Lower the deferred-write sync threshold so LCVP is persisted during the small batch push.
+    // Batch ingestion runs in deferred-write mode, so this threshold gates shouldSendGlobalRtDiv()
+    // for the remote-VT leader. (The transactional-mode threshold is already lowered by the helper.)
+    Properties extraServerProps = new Properties();
+    extraServerProps.setProperty(SERVER_DATABASE_SYNC_BYTES_INTERNAL_FOR_DEFERRED_WRITE_MODE, "500");
+
+    try (NRGlobalRtDivBatchEnv env = setUpNRGlobalRtDivBatchPushed(
+        "venice-cluster0",
+        "nrRemoteVtLeaderRestart",
+        100,
+        1,
+        PARTITION,
+        extraServerProps)) {
+      VeniceServerWrapper leaderServer = env.leaderServer;
+      VeniceClusterWrapper remoteDcCluster = env.remoteDcCluster;
+      String topicName = env.topicName;
+
+      // Pre-restart: assert LCVP was synced to OffsetRecord while ingesting remote VT.
+      // Without the fix, this remains EARLIEST and the post-restart leader rewinds.
+      AtomicReference<PubSubPosition> preRestartLcvpRef = new AtomicReference<>();
+      TestUtils.waitForNonDeterministicAssertion(60, TimeUnit.SECONDS, true, true, () -> {
+        OffsetRecord offsetRecord = getRemoteDcLeaderOffsetRecord(leaderServer, topicName, PARTITION);
+        PubSubPosition lcvp = offsetRecord.getLatestConsumedVtPosition();
+        LOGGER.info("event=globalRtDiv pre-restart LCVP on dc-1 leader {}: {}", leaderServer.getAddress(), lcvp);
+        assertNotEquals(
+            lcvp,
+            PubSubSymbolicPosition.EARLIEST,
+            "LCVP should be persisted (non-EARLIEST) on dc-1 leader after batch push completes. "
+                + "Without the LCVP-sync fix on the remote-VT path, the OffsetRecord's "
+                + "latestConsumedVtPosition stays at EARLIEST and ingestion rewinds on restart.");
+        preRestartLcvpRef.set(lcvp);
+      });
+      PubSubPosition preRestartLcvp = preRestartLcvpRef.get();
+
+      LOGGER.info("Stopping dc-1 leader server: {}", leaderServer.getAddress());
+      remoteDcCluster.stopVeniceServer(leaderServer.getPort());
+
+      LOGGER.info("Restarting dc-1 leader server: {}", leaderServer.getAddress());
+      remoteDcCluster.restartVeniceServer(leaderServer.getPort());
+
+      TestUtils.waitForNonDeterministicAssertion(60, TimeUnit.SECONDS, true, true, () -> {
+        VeniceServerWrapper restarted = remoteDcCluster.getVeniceServerByPort(leaderServer.getPort());
+        assertNotNull(restarted, "Restarted server wrapper should be found");
+        assertTrue(restarted.isRunning(), "Restarted server should be running");
+      });
+
+      // Post-restart: LCVP must not rewind below the pre-restart value. A strict >= comparison
+      // (rather than just "non-EARLIEST") catches the bug even if the leader rewound to EARLIEST
+      // and quickly re-consumed enough records to advance the LCVP within the retry window.
+      TestUtils.waitForNonDeterministicAssertion(60, TimeUnit.SECONDS, true, true, () -> {
+        OffsetRecord offsetRecord = getRemoteDcLeaderOffsetRecord(leaderServer, topicName, PARTITION);
+        PubSubPosition lcvp = offsetRecord.getLatestConsumedVtPosition();
+        LOGGER.info("event=globalRtDiv post-restart LCVP on dc-1 leader {}: {}", leaderServer.getAddress(), lcvp);
+        assertTrue(
+            lcvp.getNumericOffset() >= preRestartLcvp.getNumericOffset(),
+            "LCVP must not rewind on restart: post-restart LCVP " + lcvp + " (offset " + lcvp.getNumericOffset()
+                + ") should be >= pre-restart LCVP " + preRestartLcvp + " (offset " + preRestartLcvp.getNumericOffset()
+                + "). A lower post-restart value indicates the leader rewound to EARLIEST and re-synced.");
+      });
+
+      // Sanity: ingestion remains healthy after restart — version is still current and data is queryable.
+      try (AvroGenericStoreClient<Object, Object> client = ClientFactory.getAndStartGenericAvroClient(
+          ClientConfig.defaultGenericClientConfig(env.storeName).setVeniceURL(remoteDcCluster.getRandomRouterURL()))) {
+        TestUtils.waitForNonDeterministicAssertion(60, TimeUnit.SECONDS, true, true, () -> {
+          for (int i = 1; i <= 10; i++) {
+            Object value = client.get(Integer.toString(i)).get();
+            assertNotNull(value, "Key " + i + " should be readable after dc-1 leader restart");
+          }
+        });
+      }
+    }
+  }
+
+  /**
+   * Reads OffsetRecord directly from the given server's storage metadata service. Throws an
+   * AssertionError if the record is not yet available, so callers inside
+   * {@link TestUtils#waitForNonDeterministicAssertion} retry on the AssertionError.
+   */
+  private OffsetRecord getRemoteDcLeaderOffsetRecord(VeniceServerWrapper server, String topicName, int partitionId) {
+    OffsetRecord offsetRecord = server.getVeniceServer()
+        .getStorageMetadataService()
+        .getLastOffset(
+            topicName,
+            partitionId,
+            server.getVeniceServer().getKafkaStoreIngestionService().getPubSubContext());
+    assertNotNull(offsetRecord, "OffsetRecord not yet available for " + topicName + " partition " + partitionId);
+    return offsetRecord;
+  }
+
+  /**
+   * Spins up a 2-region NR cluster with Global RT DIV enabled, runs a batch push, and resolves
+   * the dc-1 (remote) leader. dc-0 is pinned as the source fabric so dc-1 is deterministically
+   * the remote consumer (consumeRemotely=true on the dc-1 leader).
+   *
+   * <p>Returned env is {@link AutoCloseable} — callers wrap it in try-with-resources to ensure
+   * the underlying multi-region cluster is shut down. Pass {@code extraServerProperties} to
+   * override or extend the default low-sync-threshold / fast-promotion server config.
+   */
+  private static NRGlobalRtDivBatchEnv setUpNRGlobalRtDivBatchPushed(
+      String clusterName,
+      String storeNamePrefix,
+      int recordCount,
+      int partitionCount,
+      int partition,
+      Properties extraServerProperties) throws Exception {
     Properties serverProperties = new Properties();
     serverProperties.setProperty(SERVER_DATABASE_SYNC_BYTES_INTERNAL_FOR_TRANSACTIONAL_MODE, "500");
     serverProperties.setProperty(SERVER_PROMOTION_TO_LEADER_REPLICA_DELAY_SECONDS, Long.toString(1L));
+    if (extraServerProperties != null) {
+      serverProperties.putAll(extraServerProperties);
+    }
 
     Properties controllerProps = new Properties();
     controllerProps.put(DEFAULT_MAX_NUMBER_OF_PARTITIONS, 4);
 
-    try (VeniceTwoLayerMultiRegionMultiClusterWrapper multiRegion =
+    VeniceTwoLayerMultiRegionMultiClusterWrapper multiRegion =
         ServiceFactory.getVeniceTwoLayerMultiRegionMultiClusterWrapper(
             new VeniceMultiRegionClusterCreateOptions.Builder().numberOfRegions(2)
                 .numberOfClusters(1)
@@ -1148,13 +1299,13 @@ public class TestGlobalRtDiv {
                 .serverProperties(serverProperties)
                 .childControllerProperties(controllerProps)
                 .parentControllerProperties(controllerProps)
-                .build())) {
-
+                .build());
+    try {
       List<VeniceMultiClusterWrapper> childDatacenters = multiRegion.getChildRegions();
 
       File inputDir = getTempDataDirectory();
       String inputDirPath = "file://" + inputDir.getAbsolutePath();
-      String storeName = Utils.getUniqueString("batchOnlyNrGlobalRtDiv");
+      String storeName = Utils.getUniqueString(storeNamePrefix);
       String topicName = Version.composeKafkaTopic(storeName, 1);
 
       Properties vpjProps = IntegrationTestPushUtils.defaultVPJProps(multiRegion, inputDirPath, storeName);
@@ -1178,8 +1329,6 @@ public class TestGlobalRtDiv {
 
       try (ControllerClient parentControllerClient =
           createStoreForJob(clusterName, keySchemaStr, valueSchemaStr, vpjProps, updateStoreParams)) {
-
-        // Verify store config propagated to child DCs
         TestUtils.waitForNonDeterministicAssertion(30, TimeUnit.SECONDS, true, () -> {
           for (VeniceMultiClusterWrapper dc: childDatacenters) {
             dc.getClusters().get(clusterName).useControllerClient(cc -> {
@@ -1195,221 +1344,61 @@ public class TestGlobalRtDiv {
         }
 
         TestUtils.waitForNonDeterministicAssertion(60, TimeUnit.SECONDS, true, () -> {
-          for (int version: parentControllerClient.getStore(storeName).getStore().getColoToCurrentVersions().values()) {
-            assertTrue(version == 1, "Version should be 1, got: " + version);
+          for (int v: parentControllerClient.getStore(storeName).getStore().getColoToCurrentVersions().values()) {
+            assertEquals(v, 1, "Version should be 1 in all DCs, got: " + v);
           }
         });
-
-        // The non-source dc's leader consumes from the source dc's VT (consumeRemotely=true).
-        // Verify VT state is correctly populated in vtSegments (not misrouted to rtSegments).
-        VeniceClusterWrapper remoteDcCluster = childDatacenters.get(1).getClusters().get(clusterName);
-        HelixExternalViewRepository routingDataRepo = remoteDcCluster.getLeaderVeniceController()
-            .getVeniceHelixAdmin()
-            .getHelixVeniceClusterResources(clusterName)
-            .getRoutingDataRepository();
-
-        TestUtils.waitForNonDeterministicAssertion(30, TimeUnit.SECONDS, true, true, () -> {
-          Instance leaderNode = routingDataRepo.getLeaderInstance(topicName, PARTITION);
-          assertNotNull(leaderNode, "Leader should be assigned in remote dc for partition " + PARTITION);
-
-          remoteDcCluster.getVeniceServers().forEach(server -> {
-            if (!server.isRunning()) {
-              return;
-            }
-            StoreIngestionTask sit =
-                server.getVeniceServer().getKafkaStoreIngestionService().getStoreIngestionTask(topicName);
-            assertNotNull(sit, "StoreIngestionTask should exist on server: " + server.getAddress());
-
-            DataIntegrityValidator div = sit.getDataIntegrityValidator();
-            assertNotNull(div, "DIV should be initialized on server: " + server.getAddress());
-
-            boolean isLeader = server.getPort() == leaderNode.getPort();
-            LOGGER.info(
-                "remote-dc {} ({}): hasVtDivState={}, hasGlobalRtDivState={}",
-                server.getAddress(),
-                isLeader ? "leader" : "follower",
-                div.hasVtDivState(PARTITION),
-                div.hasGlobalRtDivState(PARTITION));
-
-            if (isLeader) {
-              assertTrue(
-                  div.hasVtDivState(PARTITION),
-                  "VT DIV state should exist on dc-1 leader after topicType fix. Server: " + server.getAddress());
-            }
-            assertFalse(
-                div.hasGlobalRtDivState(PARTITION),
-                "Global RT DIV state should NOT exist on " + server.getAddress() + " (no RT writers)");
-          });
-        });
       }
+
+      VeniceClusterWrapper remoteDcCluster = childDatacenters.get(1).getClusters().get(clusterName);
+      HelixExternalViewRepository routingDataRepo = remoteDcCluster.getLeaderVeniceController()
+          .getVeniceHelixAdmin()
+          .getHelixVeniceClusterResources(clusterName)
+          .getRoutingDataRepository();
+
+      AtomicReference<Instance> leaderRef = new AtomicReference<>();
+      TestUtils.waitForNonDeterministicAssertion(30, TimeUnit.SECONDS, true, true, () -> {
+        Instance leaderNode = routingDataRepo.getLeaderInstance(topicName, partition);
+        assertNotNull(leaderNode, "Leader should be assigned in remote dc for partition " + partition);
+        leaderRef.set(leaderNode);
+      });
+      VeniceServerWrapper leaderServer = remoteDcCluster.getVeniceServerByPort(leaderRef.get().getPort());
+      assertNotNull(leaderServer, "Leader server wrapper not found");
+
+      return new NRGlobalRtDivBatchEnv(multiRegion, remoteDcCluster, leaderServer, topicName, storeName);
+    } catch (Exception e) {
+      multiRegion.close();
+      throw e;
     }
   }
 
   /**
-   * Verifies that under native replication with Global RT DIV enabled, the remote-DC leader (which
-   * consumes from the source DC's VT) persists the latest consumed VT position (LCVP) to its
-   * OffsetRecord during ingestion, and that the LCVP survives a leader restart so that ingestion
-   * does not rewind to {@link PubSubSymbolicPosition#EARLIEST} on the second startup.
+   * Holder for a fully set-up NR + Global RT DIV cluster after a batch push has completed.
+   * Owns the multi-region cluster wrapper and shuts it down on {@link #close()}.
    */
-  @Test(timeOut = 240 * Time.MS_PER_SECOND)
-  public void testBatchOnlyNRRemoteVTLeaderRestartDoesNotRewindToEarliest() throws Exception {
-    int PARTITION = 0;
-    int recordCount = 100;
-    int partitionCount = 1;
-    String clusterName = "venice-cluster0";
+  private static final class NRGlobalRtDivBatchEnv implements AutoCloseable {
+    final VeniceTwoLayerMultiRegionMultiClusterWrapper multiRegion;
+    final VeniceClusterWrapper remoteDcCluster;
+    final VeniceServerWrapper leaderServer;
+    final String topicName;
+    final String storeName;
 
-    Properties serverProperties = new Properties();
-    // Low sync thresholds so LCVP is persisted to disk during the small batch push. Batch ingestion
-    // runs in deferred-write mode, so the deferred-write threshold gates shouldSendGlobalRtDiv()
-    // for the remote-VT leader. Both modes are lowered to keep the test robust to mode transitions.
-    serverProperties.setProperty(SERVER_DATABASE_SYNC_BYTES_INTERNAL_FOR_TRANSACTIONAL_MODE, "500");
-    serverProperties.setProperty(SERVER_DATABASE_SYNC_BYTES_INTERNAL_FOR_DEFERRED_WRITE_MODE, "500");
-    serverProperties.setProperty(SERVER_PROMOTION_TO_LEADER_REPLICA_DELAY_SECONDS, Long.toString(1L));
-
-    Properties controllerProps = new Properties();
-    controllerProps.put(DEFAULT_MAX_NUMBER_OF_PARTITIONS, 4);
-
-    try (VeniceTwoLayerMultiRegionMultiClusterWrapper multiRegion =
-        ServiceFactory.getVeniceTwoLayerMultiRegionMultiClusterWrapper(
-            new VeniceMultiRegionClusterCreateOptions.Builder().numberOfRegions(2)
-                .numberOfClusters(1)
-                .numberOfParentControllers(1)
-                .numberOfChildControllers(1)
-                .numberOfServers(2)
-                .numberOfRouters(1)
-                .replicationFactor(2)
-                .serverProperties(serverProperties)
-                .childControllerProperties(controllerProps)
-                .parentControllerProperties(controllerProps)
-                .build())) {
-
-      List<VeniceMultiClusterWrapper> childDatacenters = multiRegion.getChildRegions();
-
-      File inputDir = getTempDataDirectory();
-      String inputDirPath = "file://" + inputDir.getAbsolutePath();
-      String storeName = Utils.getUniqueString("nrRemoteVtLeaderRestart");
-      String topicName = Version.composeKafkaTopic(storeName, 1);
-
-      Properties vpjProps = IntegrationTestPushUtils.defaultVPJProps(multiRegion, inputDirPath, storeName);
-      vpjProps.put(SEND_CONTROL_MESSAGES_DIRECTLY, true);
-      // Pin dc-0 as source so dc-1 is deterministically the remote consumer.
-      String sourceFabric = childDatacenters.get(0).getRegionName();
-      vpjProps.put(SOURCE_GRID_FABRIC, sourceFabric);
-
-      Schema recordSchema = TestWriteUtils.writeSimpleAvroFileWithStringToStringSchema(inputDir, recordCount);
-      String keySchemaStr = recordSchema.getField(DEFAULT_KEY_FIELD_PROP).schema().toString();
-      String valueSchemaStr = recordSchema.getField(DEFAULT_VALUE_FIELD_PROP).schema().toString();
-
-      UpdateStoreQueryParams updateStoreParams =
-          new UpdateStoreQueryParams().setStorageQuotaInByte(Store.UNLIMITED_STORAGE_QUOTA)
-              .setGlobalRtDivEnabled(true)
-              .setNativeReplicationEnabled(true)
-              .setNativeReplicationSourceFabric(sourceFabric)
-              .setPartitionCount(partitionCount);
-
-      try (ControllerClient parentControllerClient =
-          createStoreForJob(clusterName, keySchemaStr, valueSchemaStr, vpjProps, updateStoreParams)) {
-
-        TestUtils.waitForNonDeterministicAssertion(30, TimeUnit.SECONDS, true, () -> {
-          for (VeniceMultiClusterWrapper dc: childDatacenters) {
-            dc.getClusters().get(clusterName).useControllerClient(cc -> {
-              ControllerResponse resp = cc.getStore(storeName);
-              assertFalse(resp.isError(), "Failed to get store: " + resp.getError());
-            });
-          }
-        });
-
-        try (VenicePushJob job = new VenicePushJob("Test push job", vpjProps)) {
-          job.run();
-        }
-
-        TestUtils.waitForNonDeterministicAssertion(60, TimeUnit.SECONDS, true, () -> {
-          for (int version: parentControllerClient.getStore(storeName).getStore().getColoToCurrentVersions().values()) {
-            assertEquals(version, 1, "Version should be 1 in all DCs");
-          }
-        });
-
-        VeniceClusterWrapper remoteDcCluster = childDatacenters.get(1).getClusters().get(clusterName);
-        HelixExternalViewRepository routingDataRepo = remoteDcCluster.getLeaderVeniceController()
-            .getVeniceHelixAdmin()
-            .getHelixVeniceClusterResources(clusterName)
-            .getRoutingDataRepository();
-
-        AtomicReference<Instance> leaderInstanceRef = new AtomicReference<>();
-        TestUtils.waitForNonDeterministicAssertion(30, TimeUnit.SECONDS, true, true, () -> {
-          Instance leaderNode = routingDataRepo.getLeaderInstance(topicName, PARTITION);
-          assertNotNull(leaderNode, "Leader should be assigned in remote dc for partition " + PARTITION);
-          leaderInstanceRef.set(leaderNode);
-        });
-        VeniceServerWrapper leaderServer = remoteDcCluster.getVeniceServerByPort(leaderInstanceRef.get().getPort());
-        assertNotNull(leaderServer, "Leader server wrapper not found");
-
-        // Pre-restart: assert LCVP was synced to OffsetRecord while ingesting remote VT.
-        // Without the fix, this remains EARLIEST and the post-restart leader rewinds.
-        TestUtils.waitForNonDeterministicAssertion(60, TimeUnit.SECONDS, true, true, () -> {
-          OffsetRecord offsetRecord = getRemoteDcLeaderOffsetRecord(leaderServer, topicName, PARTITION);
-          PubSubPosition lcvp = offsetRecord.getLatestConsumedVtPosition();
-          LOGGER.info("event=globalRtDiv pre-restart LCVP on dc-1 leader {}: {}", leaderServer.getAddress(), lcvp);
-          assertNotEquals(
-              lcvp,
-              PubSubSymbolicPosition.EARLIEST,
-              "LCVP should be persisted (non-EARLIEST) on dc-1 leader after batch push completes. "
-                  + "Without the LCVP-sync fix on the remote-VT path, the OffsetRecord's "
-                  + "latestConsumedVtPosition stays at EARLIEST and ingestion rewinds on restart.");
-        });
-
-        LOGGER.info("Stopping dc-1 leader server: {}", leaderServer.getAddress());
-        remoteDcCluster.stopVeniceServer(leaderServer.getPort());
-
-        LOGGER.info("Restarting dc-1 leader server: {}", leaderServer.getAddress());
-        remoteDcCluster.restartVeniceServer(leaderServer.getPort());
-
-        TestUtils.waitForNonDeterministicAssertion(60, TimeUnit.SECONDS, true, true, () -> {
-          VeniceServerWrapper restarted = remoteDcCluster.getVeniceServerByPort(leaderServer.getPort());
-          assertNotNull(restarted, "Restarted server wrapper should be found");
-          assertTrue(restarted.isRunning(), "Restarted server should be running");
-        });
-
-        // Post-restart: LCVP read from disk must still be non-EARLIEST. This confirms ingestion
-        // resumes from the previously synced position rather than rewinding to EARLIEST.
-        TestUtils.waitForNonDeterministicAssertion(60, TimeUnit.SECONDS, true, true, () -> {
-          OffsetRecord offsetRecord = getRemoteDcLeaderOffsetRecord(leaderServer, topicName, PARTITION);
-          PubSubPosition lcvp = offsetRecord.getLatestConsumedVtPosition();
-          LOGGER.info("event=globalRtDiv post-restart LCVP on dc-1 leader {}: {}", leaderServer.getAddress(), lcvp);
-          assertNotEquals(
-              lcvp,
-              PubSubSymbolicPosition.EARLIEST,
-              "LCVP must survive restart and remain non-EARLIEST. If EARLIEST after restart, the leader "
-                  + "would rewind to the start of VT on the second ingestion attempt.");
-        });
-
-        // Sanity: ingestion remains healthy after restart — version is still current and data is queryable.
-        try (AvroGenericStoreClient<Object, Object> client = ClientFactory.getAndStartGenericAvroClient(
-            ClientConfig.defaultGenericClientConfig(storeName).setVeniceURL(remoteDcCluster.getRandomRouterURL()))) {
-          TestUtils.waitForNonDeterministicAssertion(60, TimeUnit.SECONDS, true, true, () -> {
-            for (int i = 1; i <= 10; i++) {
-              Object value = client.get(Integer.toString(i)).get();
-              assertNotNull(value, "Key " + i + " should be readable after dc-1 leader restart");
-            }
-          });
-        }
-      }
+    NRGlobalRtDivBatchEnv(
+        VeniceTwoLayerMultiRegionMultiClusterWrapper multiRegion,
+        VeniceClusterWrapper remoteDcCluster,
+        VeniceServerWrapper leaderServer,
+        String topicName,
+        String storeName) {
+      this.multiRegion = multiRegion;
+      this.remoteDcCluster = remoteDcCluster;
+      this.leaderServer = leaderServer;
+      this.topicName = topicName;
+      this.storeName = storeName;
     }
-  }
 
-  /**
-   * Reads OffsetRecord directly from the given server's storage metadata service. Throws an
-   * AssertionError if the record is not yet available, so callers inside
-   * {@link TestUtils#waitForNonDeterministicAssertion} retry on the AssertionError.
-   */
-  private OffsetRecord getRemoteDcLeaderOffsetRecord(VeniceServerWrapper server, String topicName, int partitionId) {
-    OffsetRecord offsetRecord = server.getVeniceServer()
-        .getStorageMetadataService()
-        .getLastOffset(
-            topicName,
-            partitionId,
-            server.getVeniceServer().getKafkaStoreIngestionService().getPubSubContext());
-    assertNotNull(offsetRecord, "OffsetRecord not yet available for " + topicName + " partition " + partitionId);
-    return offsetRecord;
+    @Override
+    public void close() {
+      multiRegion.close();
+    }
   }
 }

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestGlobalRtDiv.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestGlobalRtDiv.java
@@ -1191,11 +1191,18 @@ public class TestGlobalRtDiv {
 
       // Pre-restart: assert LCVP was synced to OffsetRecord while ingesting remote VT.
       // Without the fix, this remains EARLIEST and the post-restart leader rewinds.
+      // Re-resolve the current leader inside the retry loop so that leadership drift during the wait
+      // does not cause us to read a follower's OffsetRecord.
       AtomicReference<PubSubPosition> preRestartLcvpRef = new AtomicReference<>();
       TestUtils.waitForNonDeterministicAssertion(60, TimeUnit.SECONDS, true, true, () -> {
-        OffsetRecord offsetRecord = getRemoteDcLeaderOffsetRecord(leaderServer, topicName, PARTITION);
+        Instance currentLeader = env.routingDataRepo.getLeaderInstance(topicName, PARTITION);
+        assertNotNull(currentLeader, "Leader should be assigned in remote dc for partition " + PARTITION);
+        VeniceServerWrapper currentLeaderWrapper = remoteDcCluster.getVeniceServerByPort(currentLeader.getPort());
+        assertNotNull(currentLeaderWrapper, "Leader server wrapper not found");
+        OffsetRecord offsetRecord = getRemoteDcLeaderOffsetRecord(currentLeaderWrapper, topicName, PARTITION);
         PubSubPosition lcvp = offsetRecord.getLatestConsumedVtPosition();
-        LOGGER.info("event=globalRtDiv pre-restart LCVP on dc-1 leader {}: {}", leaderServer.getAddress(), lcvp);
+        LOGGER
+            .info("event=globalRtDiv pre-restart LCVP on dc-1 leader {}: {}", currentLeaderWrapper.getAddress(), lcvp);
         assertNotEquals(
             lcvp,
             PubSubSymbolicPosition.EARLIEST,

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestGlobalRtDiv.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestGlobalRtDiv.java
@@ -6,6 +6,7 @@ import static com.linkedin.venice.ConfigKeys.KAFKA_BOOTSTRAP_SERVERS;
 import static com.linkedin.venice.ConfigKeys.KAFKA_OVER_SSL;
 import static com.linkedin.venice.ConfigKeys.PERSISTENCE_TYPE;
 import static com.linkedin.venice.ConfigKeys.SERVER_CONSUMER_POOL_SIZE_PER_KAFKA_CLUSTER;
+import static com.linkedin.venice.ConfigKeys.SERVER_DATABASE_SYNC_BYTES_INTERNAL_FOR_DEFERRED_WRITE_MODE;
 import static com.linkedin.venice.ConfigKeys.SERVER_DATABASE_SYNC_BYTES_INTERNAL_FOR_TRANSACTIONAL_MODE;
 import static com.linkedin.venice.ConfigKeys.SERVER_PROMOTION_TO_LEADER_REPLICA_DELAY_SECONDS;
 import static com.linkedin.venice.ConfigKeys.SERVER_SHARED_CONSUMER_ASSIGNMENT_STRATEGY;
@@ -65,7 +66,10 @@ import com.linkedin.venice.meta.PersistenceType;
 import com.linkedin.venice.meta.Store;
 import com.linkedin.venice.meta.StoreInfo;
 import com.linkedin.venice.meta.Version;
+import com.linkedin.venice.offsets.OffsetRecord;
 import com.linkedin.venice.pubsub.PubSubProducerAdapterFactory;
+import com.linkedin.venice.pubsub.api.PubSubPosition;
+import com.linkedin.venice.pubsub.api.PubSubSymbolicPosition;
 import com.linkedin.venice.serialization.RawBytesStoreDeserializerCache;
 import com.linkedin.venice.serialization.avro.AvroProtocolDefinition;
 import com.linkedin.venice.serialization.avro.InternalAvroSpecificSerializer;
@@ -1239,5 +1243,190 @@ public class TestGlobalRtDiv {
         });
       }
     }
+  }
+
+  /**
+   * Verifies that under native replication with Global RT DIV enabled, the remote-DC leader (which
+   * consumes from the source DC's VT) persists the latest consumed VT position (LCVP) to its
+   * OffsetRecord during ingestion, and that the LCVP survives a leader restart so that ingestion
+   * does not rewind to EARLIEST on the second startup.
+   *
+   * <p>Without the fix, leaders on the VT-source path never call
+   * {@code updateAndSyncOffsetFromSnapshot}, so the OffsetRecord's
+   * {@code latestConsumedVtPosition} stays at {@link PubSubSymbolicPosition#EARLIEST}. On restart,
+   * the consumer's seek position (gated by {@code getLocalVtSubscribePosition}) falls back to
+   * EARLIEST and the leader re-ingests the entire VT. With the fix, the produce callback for
+   * VT-source leaders updates LCVP to the produced-local-VT position and asynchronously syncs the
+   * OffsetRecord, so the persisted LCVP is non-EARLIEST both before and after restart.
+   */
+  @Test(timeOut = 240 * Time.MS_PER_SECOND)
+  public void testBatchOnlyNRRemoteVTLeaderRestartDoesNotRewindToEarliest() throws Exception {
+    int PARTITION = 0;
+    int recordCount = 100;
+    int partitionCount = 1;
+    String clusterName = "venice-cluster0";
+
+    Properties serverProperties = new Properties();
+    // Low sync thresholds so LCVP is persisted to disk during the small batch push. Batch ingestion
+    // runs in deferred-write mode, so the deferred-write threshold gates shouldSendGlobalRtDiv()
+    // for the remote-VT leader. Both modes are lowered to keep the test robust to mode transitions.
+    serverProperties.setProperty(SERVER_DATABASE_SYNC_BYTES_INTERNAL_FOR_TRANSACTIONAL_MODE, "500");
+    serverProperties.setProperty(SERVER_DATABASE_SYNC_BYTES_INTERNAL_FOR_DEFERRED_WRITE_MODE, "500");
+    serverProperties.setProperty(SERVER_PROMOTION_TO_LEADER_REPLICA_DELAY_SECONDS, Long.toString(1L));
+
+    Properties controllerProps = new Properties();
+    controllerProps.put(DEFAULT_MAX_NUMBER_OF_PARTITIONS, 4);
+
+    try (VeniceTwoLayerMultiRegionMultiClusterWrapper multiRegion =
+        ServiceFactory.getVeniceTwoLayerMultiRegionMultiClusterWrapper(
+            new VeniceMultiRegionClusterCreateOptions.Builder().numberOfRegions(2)
+                .numberOfClusters(1)
+                .numberOfParentControllers(1)
+                .numberOfChildControllers(1)
+                .numberOfServers(2)
+                .numberOfRouters(1)
+                .replicationFactor(2)
+                .serverProperties(serverProperties)
+                .childControllerProperties(controllerProps)
+                .parentControllerProperties(controllerProps)
+                .build())) {
+
+      List<VeniceMultiClusterWrapper> childDatacenters = multiRegion.getChildRegions();
+
+      File inputDir = getTempDataDirectory();
+      String inputDirPath = "file://" + inputDir.getAbsolutePath();
+      String storeName = Utils.getUniqueString("nrRemoteVtLeaderRestart");
+      String topicName = Version.composeKafkaTopic(storeName, 1);
+
+      Properties vpjProps = IntegrationTestPushUtils.defaultVPJProps(multiRegion, inputDirPath, storeName);
+      vpjProps.put(SEND_CONTROL_MESSAGES_DIRECTLY, true);
+      // Pin dc-0 as source so dc-1 is deterministically the remote consumer.
+      String sourceFabric = childDatacenters.get(0).getRegionName();
+      vpjProps.put(SOURCE_GRID_FABRIC, sourceFabric);
+
+      Schema recordSchema = TestWriteUtils.writeSimpleAvroFileWithStringToStringSchema(inputDir, recordCount);
+      String keySchemaStr = recordSchema.getField(DEFAULT_KEY_FIELD_PROP).schema().toString();
+      String valueSchemaStr = recordSchema.getField(DEFAULT_VALUE_FIELD_PROP).schema().toString();
+
+      UpdateStoreQueryParams updateStoreParams =
+          new UpdateStoreQueryParams().setStorageQuotaInByte(Store.UNLIMITED_STORAGE_QUOTA)
+              .setGlobalRtDivEnabled(true)
+              .setNativeReplicationEnabled(true)
+              .setNativeReplicationSourceFabric(sourceFabric)
+              .setPartitionCount(partitionCount);
+
+      try (ControllerClient parentControllerClient =
+          createStoreForJob(clusterName, keySchemaStr, valueSchemaStr, vpjProps, updateStoreParams)) {
+
+        TestUtils.waitForNonDeterministicAssertion(30, TimeUnit.SECONDS, true, () -> {
+          for (VeniceMultiClusterWrapper dc: childDatacenters) {
+            dc.getClusters().get(clusterName).useControllerClient(cc -> {
+              ControllerResponse resp = cc.getStore(storeName);
+              assertFalse(resp.isError(), "Failed to get store: " + resp.getError());
+            });
+          }
+        });
+
+        try (VenicePushJob job = new VenicePushJob("Test push job", vpjProps)) {
+          job.run();
+        }
+
+        TestUtils.waitForNonDeterministicAssertion(60, TimeUnit.SECONDS, true, () -> {
+          for (int version: parentControllerClient.getStore(storeName).getStore().getColoToCurrentVersions().values()) {
+            assertEquals(version, 1, "Version should be 1 in all DCs");
+          }
+        });
+
+        VeniceClusterWrapper remoteDcCluster = childDatacenters.get(1).getClusters().get(clusterName);
+        HelixExternalViewRepository routingDataRepo = remoteDcCluster.getLeaderVeniceController()
+            .getVeniceHelixAdmin()
+            .getHelixVeniceClusterResources(clusterName)
+            .getRoutingDataRepository();
+
+        AtomicReference<Instance> leaderInstanceRef = new AtomicReference<>();
+        TestUtils.waitForNonDeterministicAssertion(30, TimeUnit.SECONDS, true, true, () -> {
+          Instance leaderNode = routingDataRepo.getLeaderInstance(topicName, PARTITION);
+          assertNotNull(leaderNode, "Leader should be assigned in remote dc for partition " + PARTITION);
+          leaderInstanceRef.set(leaderNode);
+        });
+        Instance leaderInstance = leaderInstanceRef.get();
+        VeniceServerWrapper leaderServer = remoteDcCluster.getVeniceServers()
+            .stream()
+            .filter(s -> s.getPort() == leaderInstance.getPort())
+            .findFirst()
+            .orElseThrow(
+                () -> new AssertionError("Leader server wrapper not found for port " + leaderInstance.getPort()));
+
+        // Pre-restart: assert LCVP was synced to OffsetRecord while ingesting remote VT.
+        // Without the fix, this remains EARLIEST and the post-restart leader rewinds.
+        TestUtils.waitForNonDeterministicAssertion(60, TimeUnit.SECONDS, true, true, () -> {
+          OffsetRecord offsetRecord = getRemoteDcLeaderOffsetRecord(leaderServer, topicName, PARTITION);
+          PubSubPosition lcvp = offsetRecord.getLatestConsumedVtPosition();
+          LOGGER.info("event=globalRtDiv pre-restart LCVP on dc-1 leader {}: {}", leaderServer.getAddress(), lcvp);
+          assertNotEquals(
+              lcvp,
+              PubSubSymbolicPosition.EARLIEST,
+              "LCVP should be persisted (non-EARLIEST) on dc-1 leader after batch push completes. "
+                  + "Without the LCVP-sync fix on the remote-VT path, the OffsetRecord's "
+                  + "latestConsumedVtPosition stays at EARLIEST and ingestion rewinds on restart.");
+        });
+
+        LOGGER.info("Stopping dc-1 leader server: {}", leaderServer.getAddress());
+        remoteDcCluster.stopVeniceServer(leaderServer.getPort());
+
+        LOGGER.info("Restarting dc-1 leader server: {}", leaderServer.getAddress());
+        remoteDcCluster.restartVeniceServer(leaderServer.getPort());
+
+        TestUtils.waitForNonDeterministicAssertion(60, TimeUnit.SECONDS, true, true, () -> {
+          VeniceServerWrapper restarted = remoteDcCluster.getVeniceServers()
+              .stream()
+              .filter(s -> s.getPort() == leaderServer.getPort())
+              .findFirst()
+              .orElse(null);
+          assertNotNull(restarted, "Restarted server wrapper should be found");
+          assertTrue(restarted.isRunning(), "Restarted server should be running");
+        });
+
+        // Post-restart: LCVP read from disk must still be non-EARLIEST. This confirms ingestion
+        // resumes from the previously synced position rather than rewinding to EARLIEST.
+        TestUtils.waitForNonDeterministicAssertion(60, TimeUnit.SECONDS, true, true, () -> {
+          OffsetRecord offsetRecord = getRemoteDcLeaderOffsetRecord(leaderServer, topicName, PARTITION);
+          PubSubPosition lcvp = offsetRecord.getLatestConsumedVtPosition();
+          LOGGER.info("event=globalRtDiv post-restart LCVP on dc-1 leader {}: {}", leaderServer.getAddress(), lcvp);
+          assertNotEquals(
+              lcvp,
+              PubSubSymbolicPosition.EARLIEST,
+              "LCVP must survive restart and remain non-EARLIEST. If EARLIEST after restart, the leader "
+                  + "would rewind to the start of VT on the second ingestion attempt.");
+        });
+
+        // Sanity: ingestion remains healthy after restart — version is still current and data is queryable.
+        try (AvroGenericStoreClient<Object, Object> client = ClientFactory.getAndStartGenericAvroClient(
+            ClientConfig.defaultGenericClientConfig(storeName).setVeniceURL(remoteDcCluster.getRandomRouterURL()))) {
+          TestUtils.waitForNonDeterministicAssertion(60, TimeUnit.SECONDS, true, true, () -> {
+            for (int i = 1; i <= 10; i++) {
+              Object value = client.get(Integer.toString(i)).get();
+              assertNotNull(value, "Key " + i + " should be readable after dc-1 leader restart");
+            }
+          });
+        }
+      }
+    }
+  }
+
+  /**
+   * Reads OffsetRecord directly from the given server's storage metadata service. Throws an
+   * AssertionError if the record is not yet available, so callers inside
+   * {@link TestUtils#waitForNonDeterministicAssertion} retry on the AssertionError.
+   */
+  private OffsetRecord getRemoteDcLeaderOffsetRecord(VeniceServerWrapper server, String topicName, int partitionId) {
+    OffsetRecord offsetRecord = server.getVeniceServer()
+        .getStorageMetadataService()
+        .getLastOffset(
+            topicName,
+            partitionId,
+            server.getVeniceServer().getKafkaStoreIngestionService().getPubSubContext());
+    assertNotNull(offsetRecord, "OffsetRecord not yet available for " + topicName + " partition " + partitionId);
+    return offsetRecord;
   }
 }

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestGlobalRtDiv.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestGlobalRtDiv.java
@@ -1218,13 +1218,31 @@ public class TestGlobalRtDiv {
         assertTrue(restarted.isRunning(), "Restarted server should be running");
       });
 
+      // Re-resolve the current leader: with RF=2 in a 2-node cluster, leadership may move to the
+      // other server during restart. Read the post-restart OffsetRecord from whichever server is
+      // currently the leader, not from the cached pre-restart wrapper.
+      AtomicReference<VeniceServerWrapper> postRestartLeaderRef = new AtomicReference<>();
+      TestUtils.waitForNonDeterministicAssertion(60, TimeUnit.SECONDS, true, true, () -> {
+        Instance currentLeader = env.routingDataRepo.getLeaderInstance(topicName, PARTITION);
+        assertNotNull(currentLeader, "Leader should be re-assigned after restart for partition " + PARTITION);
+        VeniceServerWrapper leaderWrapper = remoteDcCluster.getVeniceServerByPort(currentLeader.getPort());
+        assertNotNull(leaderWrapper, "Post-restart leader wrapper not found for " + currentLeader);
+        assertTrue(leaderWrapper.isRunning(), "Post-restart leader server should be running");
+        postRestartLeaderRef.set(leaderWrapper);
+      });
+      VeniceServerWrapper postRestartLeader = postRestartLeaderRef.get();
+      LOGGER.info(
+          "event=globalRtDiv post-restart leader resolved to {} (pre-restart was {})",
+          postRestartLeader.getAddress(),
+          leaderServer.getAddress());
+
       // Post-restart: LCVP must not rewind below the pre-restart value. A strict >= comparison
       // (rather than just "non-EARLIEST") catches the bug even if the leader rewound to EARLIEST
       // and quickly re-consumed enough records to advance the LCVP within the retry window.
       TestUtils.waitForNonDeterministicAssertion(60, TimeUnit.SECONDS, true, true, () -> {
-        OffsetRecord offsetRecord = getRemoteDcLeaderOffsetRecord(leaderServer, topicName, PARTITION);
+        OffsetRecord offsetRecord = getRemoteDcLeaderOffsetRecord(postRestartLeader, topicName, PARTITION);
         PubSubPosition lcvp = offsetRecord.getLatestConsumedVtPosition();
-        LOGGER.info("event=globalRtDiv post-restart LCVP on dc-1 leader {}: {}", leaderServer.getAddress(), lcvp);
+        LOGGER.info("event=globalRtDiv post-restart LCVP on dc-1 leader {}: {}", postRestartLeader.getAddress(), lcvp);
         assertTrue(
             lcvp.getNumericOffset() >= preRestartLcvp.getNumericOffset(),
             "LCVP must not rewind on restart: post-restart LCVP " + lcvp + " (offset " + lcvp.getNumericOffset()
@@ -1365,7 +1383,14 @@ public class TestGlobalRtDiv {
       VeniceServerWrapper leaderServer = remoteDcCluster.getVeniceServerByPort(leaderRef.get().getPort());
       assertNotNull(leaderServer, "Leader server wrapper not found");
 
-      return new NRGlobalRtDivBatchEnv(multiRegion, remoteDcCluster, leaderServer, topicName, storeName);
+      return new NRGlobalRtDivBatchEnv(
+          multiRegion,
+          remoteDcCluster,
+          leaderServer,
+          topicName,
+          storeName,
+          routingDataRepo,
+          partition);
     } catch (Exception e) {
       multiRegion.close();
       throw e;
@@ -1382,18 +1407,24 @@ public class TestGlobalRtDiv {
     final VeniceServerWrapper leaderServer;
     final String topicName;
     final String storeName;
+    final HelixExternalViewRepository routingDataRepo;
+    final int partition;
 
     NRGlobalRtDivBatchEnv(
         VeniceTwoLayerMultiRegionMultiClusterWrapper multiRegion,
         VeniceClusterWrapper remoteDcCluster,
         VeniceServerWrapper leaderServer,
         String topicName,
-        String storeName) {
+        String storeName,
+        HelixExternalViewRepository routingDataRepo,
+        int partition) {
       this.multiRegion = multiRegion;
       this.remoteDcCluster = remoteDcCluster;
       this.leaderServer = leaderServer;
       this.topicName = topicName;
       this.storeName = storeName;
+      this.routingDataRepo = routingDataRepo;
+      this.partition = partition;
     }
 
     @Override

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestGlobalRtDiv.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestGlobalRtDiv.java
@@ -1389,8 +1389,7 @@ public class TestGlobalRtDiv {
           leaderServer,
           topicName,
           storeName,
-          routingDataRepo,
-          partition);
+          routingDataRepo);
     } catch (Exception e) {
       multiRegion.close();
       throw e;
@@ -1408,7 +1407,6 @@ public class TestGlobalRtDiv {
     final String topicName;
     final String storeName;
     final HelixExternalViewRepository routingDataRepo;
-    final int partition;
 
     NRGlobalRtDivBatchEnv(
         VeniceTwoLayerMultiRegionMultiClusterWrapper multiRegion,
@@ -1416,15 +1414,13 @@ public class TestGlobalRtDiv {
         VeniceServerWrapper leaderServer,
         String topicName,
         String storeName,
-        HelixExternalViewRepository routingDataRepo,
-        int partition) {
+        HelixExternalViewRepository routingDataRepo) {
       this.multiRegion = multiRegion;
       this.remoteDcCluster = remoteDcCluster;
       this.leaderServer = leaderServer;
       this.topicName = topicName;
       this.storeName = storeName;
       this.routingDataRepo = routingDataRepo;
-      this.partition = partition;
     }
 
     @Override

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestGlobalRtDiv.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestGlobalRtDiv.java
@@ -1249,15 +1249,7 @@ public class TestGlobalRtDiv {
    * Verifies that under native replication with Global RT DIV enabled, the remote-DC leader (which
    * consumes from the source DC's VT) persists the latest consumed VT position (LCVP) to its
    * OffsetRecord during ingestion, and that the LCVP survives a leader restart so that ingestion
-   * does not rewind to EARLIEST on the second startup.
-   *
-   * <p>Without the fix, leaders on the VT-source path never call
-   * {@code updateAndSyncOffsetFromSnapshot}, so the OffsetRecord's
-   * {@code latestConsumedVtPosition} stays at {@link PubSubSymbolicPosition#EARLIEST}. On restart,
-   * the consumer's seek position (gated by {@code getLocalVtSubscribePosition}) falls back to
-   * EARLIEST and the leader re-ingests the entire VT. With the fix, the produce callback for
-   * VT-source leaders updates LCVP to the produced-local-VT position and asynchronously syncs the
-   * OffsetRecord, so the persisted LCVP is non-EARLIEST both before and after restart.
+   * does not rewind to {@link PubSubSymbolicPosition#EARLIEST} on the second startup.
    */
   @Test(timeOut = 240 * Time.MS_PER_SECOND)
   public void testBatchOnlyNRRemoteVTLeaderRestartDoesNotRewindToEarliest() throws Exception {
@@ -1349,13 +1341,8 @@ public class TestGlobalRtDiv {
           assertNotNull(leaderNode, "Leader should be assigned in remote dc for partition " + PARTITION);
           leaderInstanceRef.set(leaderNode);
         });
-        Instance leaderInstance = leaderInstanceRef.get();
-        VeniceServerWrapper leaderServer = remoteDcCluster.getVeniceServers()
-            .stream()
-            .filter(s -> s.getPort() == leaderInstance.getPort())
-            .findFirst()
-            .orElseThrow(
-                () -> new AssertionError("Leader server wrapper not found for port " + leaderInstance.getPort()));
+        VeniceServerWrapper leaderServer = remoteDcCluster.getVeniceServerByPort(leaderInstanceRef.get().getPort());
+        assertNotNull(leaderServer, "Leader server wrapper not found");
 
         // Pre-restart: assert LCVP was synced to OffsetRecord while ingesting remote VT.
         // Without the fix, this remains EARLIEST and the post-restart leader rewinds.
@@ -1378,11 +1365,7 @@ public class TestGlobalRtDiv {
         remoteDcCluster.restartVeniceServer(leaderServer.getPort());
 
         TestUtils.waitForNonDeterministicAssertion(60, TimeUnit.SECONDS, true, true, () -> {
-          VeniceServerWrapper restarted = remoteDcCluster.getVeniceServers()
-              .stream()
-              .filter(s -> s.getPort() == leaderServer.getPort())
-              .findFirst()
-              .orElse(null);
+          VeniceServerWrapper restarted = remoteDcCluster.getVeniceServerByPort(leaderServer.getPort());
           assertNotNull(restarted, "Restarted server wrapper should be found");
           assertTrue(restarted.isRunning(), "Restarted server should be running");
         });


### PR DESCRIPTION
## Problem Statement

Under native replication with the Global RT DIV feature enabled, a leader in the remote DC (which consumes from the source DC's VT) was never persisting the latest consumed VT position (LCVP) to its `OffsetRecord` on disk.

The two existing LCVP-sync paths only fire for:
- **Followers** — via `sendVtDivSnapshotIfNeeded` from the `QUEUED_TO_DRAINER` branch.
- **Leaders consuming RT** — via the produce callback in `sendGlobalRtDivMessage`.

A third case — **leaders consuming a remote VT** — falls through both: it goes down the `PRODUCED_TO_KAFKA` branch but does not send a Global RT DIV message (VT consumption has no RT DIV state to propagate). As a result, `latestConsumedVtPosition` in the persisted `OffsetRecord` stayed at `EARLIEST`. On server restart, the consumer's seek position (gated by `getLocalVtSubscribePosition` when Global RT DIV is on) fell back to `EARLIEST` and the leader re-ingested the entire VT from the beginning.

This was observed in production: 1/3 servers in the ei4 fabric was repeatedly re-ingesting from EARLIEST after restarts.

## Solution

For VT-source leaders, install an `onCompletionCallback` on the regular `LeaderProducerCallback` that mirrors the leader-RT pattern in `sendGlobalRtDivMessage`. The callback fires after the local-VT produce completes; it sets LCVP to the produced-local-VT position on a snapshotted `PartitionTracker` and asynchronously syncs the `OffsetRecord` via the drainer. The byte counter is reset synchronously on install, matching the RT path's behavior.

The gate and snapshot logic live in `addVtDivToProducerCallbackIfNeeded`, called unconditionally from `produceToLocalKafka`:

```java
// in produceToLocalKafka (LeaderFollowerStoreIngestionTask)
addVtDivToProducerCallbackIfNeeded(consumerRecord, callback, pcs, leaderProducedRecordContext);
```

```java
// in addVtDivToProducerCallbackIfNeeded
if (!isGlobalRtDivEnabled()
    || consumerRecord.getTopicPartition().getPubSubTopic().isRealTime()
    || !shouldSendGlobalRtDiv(consumerRecord, pcs, getVersionTopic().getName())) {
  return;
}
// snapshot VT producer states, install onCompletionCallback that updates LCVP and syncs OffsetRecord
```

The on-completion sync is shared with the leader-RT path via a new private helper `sendVtDivSnapshotOnCompletion`, so both paths converge on the same "produce completes → drainer syncs OffsetRecord with produced VT position" contract.

This piggybacks on the existing byte-counter / threshold logic (keyed by version-topic name for VT bytes, by broker URL for RT bytes) — no new config or knob. The fix is scoped to leaders whose source topic is non-RT (i.e., VT) and only activates when Global RT DIV is enabled.

###  Code changes
- [ ] Added new code behind **a config**. (Gated by the existing `Version.isGlobalRtDivEnabled()` store-level flag.)
- [ ] Introduced new **log lines**.

###  **Concurrency-Specific Checks**
- [x] No race conditions or thread safety issues. The snapshot-based sync uses `cloneVtProducerStates` (same pattern as `sendGlobalRtDivMessage`), and `consumerDiv` is owned by a single `ConsumptionTask` thread.
- [x] No new locks introduced; uses the existing `StoreBufferService` async sync path.
- [x] No blocking calls in the produce callback.
- [x] Uses existing thread-safe collections in `PartitionConsumptionState` and `PartitionTracker`.
- [x] Exception handling: `InterruptedException` is logged via the existing `event=globalRtDiv` error path **and the thread's interrupt flag is restored** (`Thread.currentThread().interrupt()`) so shutdown/cancellation signals are not silently swallowed — both in `sendVtDivSnapshotOnCompletion` and `sendVtDivSnapshotIfNeeded`.

## How was this PR tested?

- [x] New unit tests added in `LeaderFollowerStoreIngestionTaskTest`:
  - `testAddVtDivToProducerCallbackIfNeededGating` — data-driven, covers all four branches of the install gate (Global RT DIV enabled, source non-RT, byte threshold reached).
  - `testAddVtDivToProducerCallbackIfNeeded` — verifies the callback is installed, the byte counter is reset synchronously on install, and on produce-completion overrides the snapshot's LCVP with the produced position before triggering an async OffsetRecord sync.
  - `testAddVtDivToProducerCallbackIfNeededHandlesInterruptedException` — asserts the interrupt flag is restored when the drainer throws `InterruptedException` from the produce callback.
  - `testSendVtDivSnapshotIfNeededSkipsWhenLcvpIsEarliest` — guard test: an EARLIEST snapshot must not be persisted.
  - `testSendVtDivSnapshotIfNeededRestoresInterruptOnInterruptedException` — asserts the interrupt flag is restored on the follower path when the drainer throws.
- [x] New integration test added — `TestGlobalRtDiv.testBatchOnlyNRRemoteVTLeaderRestartDoesNotRewindToEarliest` runs a 2-region NR setup with Global RT DIV enabled, pushes a batch, and asserts on the dc-1 leader: (1) LCVP is non-EARLIEST after the push, (2) the leader is restarted, (3) the post-restart LCVP (read from whichever node is currently leader, since RF=2 may flip leadership) is **strictly `>=` the pre-restart value** — a rewind to EARLIEST is caught even if the leader quickly re-consumes enough records to advance the LCVP within the retry window. Sanity-checked by temporarily disabling the fix locally — the test fails with the expected assertion before the fix and passes (~60s) with it.
- [x] Modified or extended existing tests.
- [x] Verified backward compatibility — the new path is only entered when `isGlobalRtDivEnabled()` is true.

## Does this PR introduce any user-facing or breaking changes?

- [x] No. You can skip the rest of this section.
