### PR TITLE
[controller] Preserve partitionCount=0 sentinel and enforce hybrid floor on conversion

### DIFF
--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/controller/TestPartitionCountResetToZero.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/controller/TestPartitionCountResetToZero.java
@@ -1,0 +1,117 @@
+package com.linkedin.venice.controller;
+
+import com.linkedin.venice.controllerapi.UpdateStoreQueryParams;
+import com.linkedin.venice.meta.Store;
+import com.linkedin.venice.utils.Utils;
+import io.tehuti.metrics.MetricsRepository;
+import org.testng.Assert;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+
+/**
+ * Regression tests for the partition-count auto-calc behavior on update-store.
+ *
+ * <p>{@link com.linkedin.venice.utils.PartitionUtils#calculatePartitionCount} auto-calcs the
+ * partition count for a new push from storage quota when the persisted
+ * {@code store.getPartitionCount() == 0}. Reaching that branch requires the store record to
+ * actually carry a zero, so {@link VeniceHelixAdmin#setStorePartitionCount} must preserve a
+ * caller-supplied 0 verbatim instead of substituting a cluster-level minimum.
+ *
+ * <p>Earlier versions of {@code setStorePartitionCount} clamped {@code 0} to
+ * {@code clusterConfig.getMinNumberOfPartitions()}, which silently defeated both the auto-calc
+ * branch in {@code PartitionUtils.calculatePartitionCount} and the parent-side hybrid-conversion
+ * floor enforcement in {@link VeniceParentHelixAdmin#updateStore}.
+ */
+public class TestPartitionCountResetToZero extends AbstractTestVeniceHelixAdmin {
+  private final MetricsRepository metricsRepository = new MetricsRepository();
+
+  @BeforeClass(alwaysRun = true)
+  public void setUp() throws Exception {
+    setupCluster(metricsRepository);
+  }
+
+  @AfterClass(alwaysRun = true)
+  public void cleanUp() {
+    super.cleanUp();
+  }
+
+  /**
+   * Baseline: a freshly created store carries {@code partitionCount == 0} (from the {@code ZKStore}
+   * constructor) and {@code calculateNumberOfPartitions} returns the quota-derived auto-calc value.
+   */
+  @Test(timeOut = TOTAL_TIMEOUT_FOR_SHORT_TEST_MS)
+  public void testFreshStoreAutoCalcsPartitionCountFromStorageQuota() {
+    String storeName = Utils.getUniqueString("auto-calc-fresh");
+    veniceAdmin.createStore(clusterName, storeName, storeOwner, KEY_SCHEMA, VALUE_SCHEMA);
+
+    long partitionSize = controllerConfig.getPartitionSize();
+    int minPartitions = controllerConfig.getMinNumberOfPartitions();
+    int maxPartitions = controllerConfig.getMaxNumberOfPartitions();
+    int expectedAutoCalc = Math.min(maxPartitions, Math.max(minPartitions, 5));
+    long storageQuota = partitionSize * expectedAutoCalc;
+
+    veniceAdmin.updateStore(clusterName, storeName, new UpdateStoreQueryParams().setStorageQuotaInByte(storageQuota));
+
+    Store store = veniceAdmin.getStore(clusterName, storeName);
+    Assert.assertEquals(
+        store.getPartitionCount(),
+        0,
+        "Fresh store record must carry partitionCount=0 so calculatePartitionCount can run on push.");
+
+    int calculated = veniceAdmin.calculateNumberOfPartitions(clusterName, storeName);
+    Assert.assertEquals(
+        calculated,
+        expectedAutoCalc,
+        "calculateNumberOfPartitions on a fresh store should auto-calc from storage quota, "
+            + "since storePartitionCount==0 falls through to PartitionUtils.calculatePartitionCount.");
+  }
+
+  /**
+   * Setting {@code partitionCount=0} via {@code update-store} is the documented "use auto-calc"
+   * sentinel. The persisted store record must keep that zero so the next push triggers
+   * {@link com.linkedin.venice.utils.PartitionUtils#calculatePartitionCount} against quota, just
+   * like a freshly-created store.
+   */
+  @Test(timeOut = TOTAL_TIMEOUT_FOR_SHORT_TEST_MS)
+  public void testUpdateStorePartitionCountToZeroPersistsAsZero() {
+    String storeName = Utils.getUniqueString("auto-calc-reset");
+    veniceAdmin.createStore(clusterName, storeName, storeOwner, KEY_SCHEMA, VALUE_SCHEMA);
+
+    long partitionSize = controllerConfig.getPartitionSize();
+    int minPartitions = controllerConfig.getMinNumberOfPartitions();
+    int maxPartitions = controllerConfig.getMaxNumberOfPartitions();
+    int explicitNonZeroCount = Math.min(maxPartitions, minPartitions + 3);
+    int expectedAutoCalc = Math.min(maxPartitions, Math.max(minPartitions, 5));
+    long storageQuota = partitionSize * expectedAutoCalc;
+
+    veniceAdmin.updateStore(
+        clusterName,
+        storeName,
+        new UpdateStoreQueryParams().setStorageQuotaInByte(storageQuota).setPartitionCount(explicitNonZeroCount));
+
+    Store afterExplicit = veniceAdmin.getStore(clusterName, storeName);
+    Assert.assertEquals(
+        afterExplicit.getPartitionCount(),
+        explicitNonZeroCount,
+        "Explicit non-zero partition count should persist verbatim.");
+
+    veniceAdmin.updateStore(clusterName, storeName, new UpdateStoreQueryParams().setPartitionCount(0));
+
+    Store afterReset = veniceAdmin.getStore(clusterName, storeName);
+    Assert.assertEquals(
+        afterReset.getPartitionCount(),
+        0,
+        "update-store partitionCount=0 must persist as the auto-calc sentinel. "
+            + "If this assert fires, setStorePartitionCount is clamping 0 to the cluster minimum "
+            + "and defeating the auto-calc-on-push branch.");
+
+    int calculated = veniceAdmin.calculateNumberOfPartitions(clusterName, storeName);
+    Assert.assertEquals(
+        calculated,
+        expectedAutoCalc,
+        "After reset to 0, calculateNumberOfPartitions must return the quota-derived value, "
+            + "not the previously-set explicit count and not the cluster minimum.");
+  }
+}

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceHelixAdmin.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceHelixAdmin.java
@@ -5419,7 +5419,6 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
    */
   @Override
   public void setStorePartitionCount(String clusterName, String storeName, int partitionCount) {
-    VeniceControllerClusterConfig clusterConfig = getHelixVeniceClusterResources(clusterName).getConfig();
     storeMetadataUpdate(clusterName, storeName, (store, resources) -> {
       preCheckStorePartitionCountUpdate(clusterName, store, partitionCount);
       // Do not update the partitionCount on the store.version as version config is immutable. The
@@ -5436,11 +5435,13 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
             storeName,
             clusterName);
       }
-      if (partitionCount != 0) {
-        store.setPartitionCount(partitionCount);
-      } else {
-        store.setPartitionCount(clusterConfig.getMinNumberOfPartitions());
-      }
+      // Preserve a caller-supplied 0 as the documented "use auto-calc" sentinel. The push path
+      // (CreateVersion#handleNonStreamPushType -> calculateNumberOfPartitions ->
+      // PartitionUtils#calculatePartitionCount) auto-calculates the partition count from storage
+      // quota whenever store.getPartitionCount() == 0. Clamping to a cluster-level minimum here
+      // would defeat that branch and also bypass the parent-side hybrid-conversion enforcement
+      // in VeniceParentHelixAdmin, which is gated on partitionNum being below the hybrid floor.
+      store.setPartitionCount(partitionCount);
 
       return store;
     });

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceParentHelixAdmin.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceParentHelixAdmin.java
@@ -3532,25 +3532,30 @@ public class VeniceParentHelixAdmin implements Admin {
       }
 
       if (!getVeniceHelixAdmin().isHybrid(currStore.getHybridStoreConfig())
-          && getVeniceHelixAdmin().isHybrid(setStore.getHybridStoreConfig()) && setStore.getPartitionNum() == 0) {
-        // This is a new hybrid store and partition count is not specified.
+          && getVeniceHelixAdmin().isHybrid(setStore.getHybridStoreConfig())) {
+        // Batch-to-hybrid conversion. Enforce the hybrid floor whenever the store is below it,
+        // not only when partitionNum == 0. A non-hybrid store may carry a small explicit count
+        // (e.g. set during creation, or carried over from a prior cluster default) that is too
+        // low for hybrid serving; in that case we still need to bump it to the hybrid minimum.
         VeniceControllerClusterConfig config =
             getVeniceHelixAdmin().getHelixVeniceClusterResources(clusterName).getConfig();
-        setStore.setPartitionNum(
-            PartitionUtils.calculatePartitionCount(
-                storeName,
-                setStore.getStorageQuotaInByte(),
-                0,
-                config.getPartitionSize(),
-                config.getMinNumberOfPartitionsForHybrid(),
-                config.getMaxNumberOfPartitions(),
-                config.isPartitionCountRoundUpEnabled(),
-                config.getPartitionCountRoundUpSize()));
-        LOGGER.info(
-            "Enforcing default hybrid partition count:{} for a new hybrid store:{}.",
-            setStore.getPartitionNum(),
-            storeName);
-        updatedConfigsList.add(PARTITION_COUNT);
+        if (setStore.getPartitionNum() < config.getMinNumberOfPartitionsForHybrid()) {
+          setStore.setPartitionNum(
+              PartitionUtils.calculatePartitionCount(
+                  storeName,
+                  setStore.getStorageQuotaInByte(),
+                  0,
+                  config.getPartitionSize(),
+                  config.getMinNumberOfPartitionsForHybrid(),
+                  config.getMaxNumberOfPartitions(),
+                  config.isPartitionCountRoundUpEnabled(),
+                  config.getPartitionCountRoundUpSize()));
+          LOGGER.info(
+              "Enforcing default hybrid partition count:{} for a new hybrid store:{}.",
+              setStore.getPartitionNum(),
+              storeName);
+          updatedConfigsList.add(PARTITION_COUNT);
+        }
       }
 
       /**


### PR DESCRIPTION
## What's broken

When an operator runs:

```
admin-tool update-store --store my-store --partition-count 0
```

…they expect the controller to mark the store as "use auto-calc" — meaning Venice will compute the right number of partitions from storage quota on the next push. That's the documented contract everywhere else in the code: a stored `partitionCount` of `0` is the sentinel for "auto-calc later."

Today, that contract is silently broken. The controller overwrites `0` with whatever `default.partition.count` is set to in cluster config (e.g. `20` in many clusters). After the update, the store record says `partitionCount = 20`, not `0`, and the auto-calc branch on the push path becomes unreachable.

This causes two visible problems:

1. **Operators can't reset a store back to auto-calc.** Once a partition count is explicitly set, there's no way to clear it. `--partition-count 0` looks like it works (the controller responds `success`) but the value lands at the cluster default.

2. **Batch-to-hybrid conversion silently skips the hybrid floor.** When a non-hybrid store is converted to hybrid, the controller is supposed to enforce a minimum partition count suitable for hybrid serving (e.g. `200`). That enforcement only triggers when `partitionCount == 0`. Because of (1), promoted/explicitly-set batch stores arrive at conversion with a small non-zero count (e.g. `20`), the `== 0` check fails, and the floor is skipped. The store becomes hybrid with too few partitions for its workload.

## What this PR does

Two small changes in the controller, both restoring intended behavior:

**1. Stop overwriting `partitionCount = 0`.** In `VeniceHelixAdmin.setStorePartitionCount`, just persist the caller's value as-is. The existing precheck already rejects negative values, so no new guards are needed. After this change, `update-store --partition-count 0` does what it says.

```java
// Before
if (partitionCount != 0) {
  store.setPartitionCount(partitionCount);
} else {
  store.setPartitionCount(clusterConfig.getMinNumberOfPartitions());  // ← silently rewrites 0
}

// After
store.setPartitionCount(partitionCount);
```

**2. Make the hybrid-conversion floor robust.** In `VeniceParentHelixAdmin.updateStore`, change the trigger for hybrid floor enforcement from `partitionNum == 0` to `partitionNum < minNumberOfPartitionsForHybrid`. Now any batch-to-hybrid conversion that would land below the hybrid floor gets bumped, regardless of whether the existing count was `0` or some small non-zero value carried over from the batch state.

## Why this is safe

- A `partitionCount = 0` in steady state is **already** a valid store state — every freshly-created store has it (the `ZKStore` constructor leaves `partitionCount = 0` until the first push runs auto-calc). The fix just lets that state survive an explicit `update-store` call too.
- The push path already handles `partitionCount = 0` correctly: `CreateVersion#handleNonStreamPushType` calls `calculateNumberOfPartitions`, which calls `PartitionUtils.calculatePartitionCount`. That utility already auto-calcs from quota when `storePartitionCount == 0`. We're not adding new logic — we're letting an unreachable branch become reachable again.
- No existing test asserts the clamp behavior. Only `setStorePartitionCount` reject-paths are tested (negative values rejected, max+1 rejected). Those still pass.

## Testing Done

New integration test `TestPartitionCountResetToZero` with two assertions:

- **Baseline (already worked, now pinned):** A freshly created store has `partitionCount = 0`, and `calculateNumberOfPartitions` returns the quota-derived value.
- **The fix (broken before, now works):** After `update-store --partition-count 5` followed by `update-store --partition-count 0`, the persisted value is `0` (not the cluster minimum), and the next `calculateNumberOfPartitions` auto-calcs from quota.

I verified the second test fails at exactly the `store.getPartitionCount()` assertion when the controller change is reverted (`expected [0] but found [<cluster min>]`), so it's a real regression guard.

Existing tests still pass:

- `TestVeniceHelixAdminWithSharedEnvironment.testGetNumberOfPartition`
- `TestVeniceHelixAdminWithSharedEnvironment.testGetNumberOfPartitionsFromStoreLevelConfig`
- `TestVeniceHelixAdminWithSharedEnvironment` `setStorePartitionCount` reject paths (negative, max+1)
- `TestVeniceParentHelixAdmin` full suite (87 tests)
