### PR TITLE
[controller][test] Handle ROLLED_BACK / PARTIALLY_ONLINE in parent push-topic lookup

### DIFF
--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/VenicePushJob.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/VenicePushJob.java
@@ -2904,7 +2904,7 @@ public class VenicePushJob implements AutoCloseable {
           fetchParentVersionRetryCount = 0; // Reset retry counter if we are able to get parent version
           Version parentVersion = parentVersionFromStore.get();
           VersionStatus parentVersionStatus = parentVersion.getStatus();
-          if (VersionStatus.ERROR.equals(parentVersionStatus)
+          if (VersionStatus.ROLLED_BACK.equals(parentVersionStatus)
               && ExecutionStatus.COMPLETED.equals(overallStatus.getRootStatus())) {
             throw new VeniceException(
                 "Version " + pushJobSetting.topic

--- a/clients/venice-push-job/src/test/java/com/linkedin/venice/hadoop/VenicePushJobTest.java
+++ b/clients/venice-push-job/src/test/java/com/linkedin/venice/hadoop/VenicePushJobTest.java
@@ -1875,7 +1875,7 @@ public class VenicePushJobTest {
     extraInfo2.put("dc-0", ExecutionStatus.COMPLETED.toString());
     extraInfo2.put("dc-1", ExecutionStatus.COMPLETED.toString());
 
-    return new Object[][] { { VersionStatus.ONLINE, extraInfo }, { VersionStatus.ERROR, extraInfo2 },
+    return new Object[][] { { VersionStatus.ONLINE, extraInfo }, { VersionStatus.ROLLED_BACK, extraInfo2 },
         { VersionStatus.PARTIALLY_ONLINE, extraInfo }, { VersionStatus.KILLED, extraInfo } };
   }
 

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestPushBlockedByRollbackOriginGuard.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestPushBlockedByRollbackOriginGuard.java
@@ -87,7 +87,7 @@ public class TestPushBlockedByRollbackOriginGuard extends AbstractMultiRegionTes
     // CONTROLLER_BACKUP_VERSION_MIN_CLEANUP_DELAY_MS defaults to 0 in the test harness, which means
     // the other (min-delay) guard does not fire here — ensuring this test exercises the rollback-origin
     // guard and nothing else.
-    controllerProps.put(CONTROLLER_ROLLED_BACK_VERSION_RETENTION_MS, TimeUnit.MINUTES.toMillis(30));
+    controllerProps.put(CONTROLLER_ROLLED_BACK_VERSION_RETENTION_MS, ROLLED_BACK_RETENTION_MS);
     return controllerProps;
   }
 

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestPushBlockedByRollbackOriginGuard.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestPushBlockedByRollbackOriginGuard.java
@@ -11,17 +11,23 @@ import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.fail;
 
+import com.linkedin.venice.controller.HelixVeniceClusterResources;
+import com.linkedin.venice.controller.VeniceParentHelixAdmin;
 import com.linkedin.venice.controllerapi.ControllerClient;
 import com.linkedin.venice.controllerapi.ControllerResponse;
 import com.linkedin.venice.controllerapi.StoreResponse;
 import com.linkedin.venice.controllerapi.UpdateStoreQueryParams;
 import com.linkedin.venice.hadoop.VenicePushJob;
+import com.linkedin.venice.integration.utils.VeniceControllerWrapper;
+import com.linkedin.venice.meta.ReadWriteStoreRepository;
+import com.linkedin.venice.meta.Store;
 import com.linkedin.venice.meta.Version;
 import com.linkedin.venice.meta.VersionStatus;
 import com.linkedin.venice.utils.IntegrationTestPushUtils;
 import com.linkedin.venice.utils.TestUtils;
 import com.linkedin.venice.utils.TestWriteUtils;
 import com.linkedin.venice.utils.Utils;
+import com.linkedin.venice.utils.locks.AutoCloseableLock;
 import java.io.File;
 import java.io.IOException;
 import java.util.Properties;
@@ -33,18 +39,27 @@ import org.testng.annotations.Test;
  * Integration test for {@link com.linkedin.venice.controller.VeniceHelixAdmin#checkRollbackOriginVersionCapacityForNewPush}.
  *
  * <p>After a rollback, v2 becomes ROLLED_BACK (on the parent, once propagated) and v1 becomes
- * current. A new push within the rolled-back retention window should be rejected with a message
- * that tells operators to wait for the rolled-back version to be cleaned up.
+ * current. The test exercises both sides of the rollback-origin retention window:
+ * <ul>
+ *   <li>A push attempted <em>within</em> the retention window is rejected with the guard's
+ *       distinctive message.</li>
+ *   <li>A push attempted <em>after</em> the retention window has elapsed is allowed through
+ *       and produces a new version.</li>
+ * </ul>
  *
  * <p>Config tuning: the min backup version cleanup delay is left at the default (0) so the
- * generic pending-deletion guard does NOT fire first. The rolled-back retention is set to 1 minute
- * so the rollback-origin guard reliably fires within the test lifetime.
+ * generic pending-deletion guard does NOT fire first. The rolled-back retention is set to 30
+ * minutes — long enough that the within-retention block phase isn't time-sensitive. To exercise
+ * the post-retention path, the test rewinds the store's {@code latestVersionPromoteToCurrentTimestamp}
+ * directly via the parent controller's repository so the retention check sees an "elapsed"
+ * window deterministically, without sleeping or relying on wall-clock timing.
  *
  * <p>This test is in its own class (separate from {@link TestPushBlockedWithinMinCleanupDelay}) so
  * the two guards can be exercised in isolation with their respective configs.
  */
 public class TestPushBlockedByRollbackOriginGuard extends AbstractMultiRegionTest {
-  private static final int TEST_TIMEOUT = 180_000; // ms
+  private static final int TEST_TIMEOUT = 240_000; // ms
+  private static final long ROLLED_BACK_RETENTION_MS = TimeUnit.MINUTES.toMillis(30);
 
   @Override
   protected int getNumberOfRegions() {
@@ -121,9 +136,9 @@ public class TestPushBlockedByRollbackOriginGuard extends AbstractMultiRegionTes
             "Expected v2 to be ROLLED_BACK after rollback, got: " + resp.getStore().getVersion(2));
       });
 
-      // Attempt v3 push; the parent-level rollback-origin guard should reject it synchronously
-      // so the VPJ throws with the guard's distinctive message.
-      try (VenicePushJob job = new VenicePushJob("venice-push-job-v3-" + storeName, props)) {
+      // Phase 1: within retention — attempt v3 push; the parent-level rollback-origin guard should
+      // reject it synchronously so the VPJ throws with the guard's distinctive message.
+      try (VenicePushJob job = new VenicePushJob("venice-push-job-v3-blocked-" + storeName, props)) {
         job.run();
         fail("Expected VPJ to fail — rollback-origin guard should block v3 push within retention");
       } catch (Exception e) {
@@ -133,11 +148,63 @@ public class TestPushBlockedByRollbackOriginGuard extends AbstractMultiRegionTes
             "Expected rollback-origin guard message, got: " + message);
       }
 
+      StoreResponse blockedStoreResponse = parentControllerClient.getStore(storeName);
+      assertFalse(blockedStoreResponse.isError());
+      assertFalse(
+          blockedStoreResponse.getStore().getVersion(3).isPresent(),
+          "Version 3 should NOT have been created while v2's retention is active");
+
+      // Phase 2: simulate retention having elapsed by rewinding the store's
+      // latestVersionPromoteToCurrentTimestamp far enough into the past that
+      // (now > latestPromoteTs + retentionMs) holds
+      long rewindTo = System.currentTimeMillis() - ROLLED_BACK_RETENTION_MS - TimeUnit.MINUTES.toMillis(1);
+      VeniceParentHelixAdmin parentAdmin = (VeniceParentHelixAdmin) parentController.getVeniceAdmin();
+      rewindLatestPromoteTimestamp(
+          parentAdmin.getVeniceHelixAdmin().getHelixVeniceClusterResources(CLUSTER_NAME),
+          storeName,
+          rewindTo);
+      for (VeniceControllerWrapper childController: childDatacenters.get(0).getControllers().values()) {
+        rewindLatestPromoteTimestamp(
+            childController.getVeniceHelixAdmin().getHelixVeniceClusterResources(CLUSTER_NAME),
+            storeName,
+            rewindTo);
+      }
+      // Wait for the rewind to be reflected via the parent's getStore API.
+      TestUtils.waitForNonDeterministicAssertion(15, TimeUnit.SECONDS, () -> {
+        StoreResponse resp = parentControllerClient.getStore(storeName);
+        assertFalse(resp.isError(), "getStore error: " + resp.getError());
+        assertTrue(
+            resp.getStore().getLatestVersionPromoteToCurrentTimestamp() <= rewindTo,
+            "Expected latestPromoteTs to be rewound to " + rewindTo + ", got: "
+                + resp.getStore().getLatestVersionPromoteToCurrentTimestamp());
+      });
+
+      // Phase 3: post-retention — the same v3 push should now succeed. The guard's early-return
+      // path fires (currentTimeMs > retentionExpiresAt) and addVersion proceeds normally.
+      IntegrationTestPushUtils.runVPJ(props);
+      TestUtils.waitForNonDeterministicPushCompletion(
+          Version.composeKafkaTopic(storeName, 3),
+          parentControllerClient,
+          60,
+          TimeUnit.SECONDS);
+
       StoreResponse finalStoreResponse = parentControllerClient.getStore(storeName);
       assertFalse(finalStoreResponse.isError());
-      assertFalse(
+      assertTrue(
           finalStoreResponse.getStore().getVersion(3).isPresent(),
-          "Version 3 should NOT have been created after guard rejection");
+          "Version 3 should have been created after retention expired");
+    }
+  }
+
+  private static void rewindLatestPromoteTimestamp(
+      HelixVeniceClusterResources resources,
+      String storeName,
+      long rewindTo) {
+    try (AutoCloseableLock ignore = resources.getClusterLockManager().createStoreWriteLock(storeName)) {
+      ReadWriteStoreRepository repo = resources.getStoreMetadataRepository();
+      Store store = repo.getStore(storeName);
+      store.setLatestVersionPromoteToCurrentTimestamp(rewindTo);
+      repo.updateStore(store);
     }
   }
 }

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestPushBlockedWithinMinCleanupDelay.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestPushBlockedWithinMinCleanupDelay.java
@@ -41,8 +41,9 @@ import org.testng.annotations.Test;
  * <p>The capacity guard rejects a new push when one or more backup versions are in a deletable
  * state (e.g., {@code KILLED} / {@code ERROR}) and the store is still within the configured
  * min backup version cleanup delay. This test sets up that scenario deterministically by
- * marking v2 as {@code KILLED} via direct repository writes (rather than relying on a real
- * push failure or rollback, both of which interact with other guards).
+ * marking the backup version (v1) as {@code KILLED} via direct repository writes (rather than
+ * relying on a real push failure or rollback, both of which interact with other guards). With
+ * v2 as current and v1 as a KILLED backup, the guard fires on v1 as a backup pending deletion.
  *
  * <p>The min cleanup delay is set to 1 minute at class level so the guard reliably fires within
  * the test's lifetime. This is in its own test class so other classes don't inherit the delay.

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestPushBlockedWithinMinCleanupDelay.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestPushBlockedWithinMinCleanupDelay.java
@@ -12,16 +12,22 @@ import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.fail;
 
+import com.linkedin.venice.controller.HelixVeniceClusterResources;
+import com.linkedin.venice.controller.VeniceParentHelixAdmin;
 import com.linkedin.venice.controllerapi.ControllerClient;
-import com.linkedin.venice.controllerapi.ControllerResponse;
 import com.linkedin.venice.controllerapi.StoreResponse;
 import com.linkedin.venice.controllerapi.UpdateStoreQueryParams;
 import com.linkedin.venice.hadoop.VenicePushJob;
+import com.linkedin.venice.integration.utils.VeniceControllerWrapper;
+import com.linkedin.venice.meta.ReadWriteStoreRepository;
+import com.linkedin.venice.meta.Store;
 import com.linkedin.venice.meta.Version;
+import com.linkedin.venice.meta.VersionStatus;
 import com.linkedin.venice.utils.IntegrationTestPushUtils;
 import com.linkedin.venice.utils.TestUtils;
 import com.linkedin.venice.utils.TestWriteUtils;
 import com.linkedin.venice.utils.Utils;
+import com.linkedin.venice.utils.locks.AutoCloseableLock;
 import java.io.File;
 import java.io.IOException;
 import java.util.Properties;
@@ -32,9 +38,11 @@ import org.testng.annotations.Test;
 /**
  * Integration test for {@link com.linkedin.venice.controller.VeniceHelixAdmin#checkBackupVersionCleanupCapacityForNewPush}.
  *
- * <p>After a rollback, v2 becomes ERROR and v1 becomes current. If an operator starts a new push
- * within the min backup version cleanup delay, the controller's capacity guard should reject the
- * push so the VPJ surfaces a clear error instead of hanging.
+ * <p>The capacity guard rejects a new push when one or more backup versions are in a deletable
+ * state (e.g., {@code KILLED} / {@code ERROR}) and the store is still within the configured
+ * min backup version cleanup delay. This test sets up that scenario deterministically by
+ * marking v2 as {@code KILLED} via direct repository writes (rather than relying on a real
+ * push failure or rollback, both of which interact with other guards).
  *
  * <p>The min cleanup delay is set to 1 minute at class level so the guard reliably fires within
  * the test's lifetime. This is in its own test class so other classes don't inherit the delay.
@@ -70,11 +78,11 @@ public class TestPushBlockedWithinMinCleanupDelay extends AbstractMultiRegionTes
   }
 
   @Test(timeOut = TEST_TIMEOUT)
-  public void testPushBlockedAfterRollbackWithinMinCleanupDelay() throws IOException {
+  public void testPushBlockedWhenBackupKilledWithinMinCleanupDelay() throws IOException {
     File inputDir = getTempDataDirectory();
     TestWriteUtils.writeSimpleAvroFileWithStringToV3Schema(inputDir, 100, 100);
     String inputDirPath = "file://" + inputDir.getAbsolutePath();
-    String storeName = Utils.getUniqueString("pushBlockedAfterRollback");
+    String storeName = Utils.getUniqueString("pushBlockedByMinCleanupDelay");
 
     Properties props =
         IntegrationTestPushUtils.defaultVPJProps(multiRegionMultiClusterWrapper, inputDirPath, storeName);
@@ -84,7 +92,7 @@ public class TestPushBlockedWithinMinCleanupDelay extends AbstractMultiRegionTes
         NAME_RECORD_V3_SCHEMA.toString(),
         props,
         new UpdateStoreQueryParams())) {
-      // Push v1 and v2 via VPJ so the store has a real current version to roll back from.
+      // Push v1 and v2 via VPJ so the store has two real versions.
       IntegrationTestPushUtils.runVPJ(props);
       TestUtils.waitForNonDeterministicPushCompletion(
           Version.composeKafkaTopic(storeName, 1),
@@ -104,17 +112,38 @@ public class TestPushBlockedWithinMinCleanupDelay extends AbstractMultiRegionTes
         assertEquals(storeResponse.getStore().getCurrentVersion(), 2);
       });
 
-      // Rollback: v1 becomes current, v2 becomes ERROR, latestVersionPromoteToCurrentTimestamp resets.
-      ControllerResponse rollbackResponse = parentControllerClient.rollbackToBackupVersion(storeName);
-      assertFalse(rollbackResponse.isError(), "rollback failed: " + rollbackResponse.getError());
+      // Mark v1 as KILLED on every controller. KILLED is in canDelete-set, so retrieveVersionsToDelete
+      // returns it, which is what the min-cleanup-delay guard uses to decide whether the store has
+      // any backup version pending deletion. This simulates the operator-killed-the-old-push scenario
+      // without depending on rollback (which produces ROLLED_BACK and is governed by a separate
+      // dedicated retention guard).
+      VeniceParentHelixAdmin parentAdmin = (VeniceParentHelixAdmin) parentController.getVeniceAdmin();
+      markBackupVersionKilled(
+          parentAdmin.getVeniceHelixAdmin().getHelixVeniceClusterResources(CLUSTER_NAME),
+          storeName,
+          1);
+      for (VeniceControllerWrapper childController: childDatacenters.get(0).getControllers().values()) {
+        markBackupVersionKilled(
+            childController.getVeniceHelixAdmin().getHelixVeniceClusterResources(CLUSTER_NAME),
+            storeName,
+            1);
+      }
+      // Wait for the parent's getStore to reflect the KILLED status before triggering the v3 push.
+      TestUtils.waitForNonDeterministicAssertion(15, TimeUnit.SECONDS, () -> {
+        StoreResponse resp = parentControllerClient.getStore(storeName);
+        assertFalse(resp.isError(), "getStore error: " + resp.getError());
+        assertTrue(
+            resp.getStore().getVersion(1).isPresent()
+                && resp.getStore().getVersion(1).get().getStatus() == VersionStatus.KILLED,
+            "Expected v1 to be KILLED, got: " + resp.getStore().getVersion(1));
+      });
 
-      // Attempt a real VPJ v3 push. The capacity guard should reject it because v2 (ERROR) is
-      // pending deletion and latestVersionPromoteToCurrentTimestamp was just reset by the rollback.
+      // Attempt a real VPJ v3 push. The capacity guard should reject it because v1 (KILLED) is
+      // pending deletion and latestVersionPromoteToCurrentTimestamp is recent (v2 was just promoted).
       try (VenicePushJob job = new VenicePushJob("venice-push-job-v3-" + storeName, props)) {
         job.run();
-        fail("Expected VPJ to fail — capacity guard should block v3 push after rollback within min delay");
+        fail("Expected VPJ to fail — capacity guard should block v3 push while a KILLED backup is within min delay");
       } catch (Exception e) {
-        // Verify the failure is specifically from the capacity guard, not some unrelated issue.
         // VPJ wraps the controller error message into its own exception message verbatim.
         String message = e.getMessage();
         assertTrue(
@@ -128,6 +157,18 @@ public class TestPushBlockedWithinMinCleanupDelay extends AbstractMultiRegionTes
       assertFalse(
           finalStoreResponse.getStore().getVersion(3).isPresent(),
           "Version 3 should NOT have been created after capacity-guard rejection");
+    }
+  }
+
+  private static void markBackupVersionKilled(
+      HelixVeniceClusterResources resources,
+      String storeName,
+      int versionNumber) {
+    try (AutoCloseableLock ignore = resources.getClusterLockManager().createStoreWriteLock(storeName)) {
+      ReadWriteStoreRepository repo = resources.getStoreMetadataRepository();
+      Store store = repo.getStore(storeName);
+      store.updateVersionStatus(versionNumber, VersionStatus.KILLED);
+      repo.updateStore(store);
     }
   }
 }

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/DeferredVersionSwapService.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/DeferredVersionSwapService.java
@@ -806,7 +806,8 @@ public class DeferredVersionSwapService extends AbstractVeniceService {
       int targetVersionNum,
       String clusterName,
       String targetRegion,
-      String kafkaTopicName) {
+      String kafkaTopicName,
+      List<String> rolloutOrder) {
     boolean proceed = true;
     List<LifecycleHooksRecord> storeLifecycleHooks = parentStore.getStoreLifecycleHooks();
     for (LifecycleHooksRecord lifecycleHooksRecord: storeLifecycleHooks) {
@@ -852,14 +853,13 @@ public class DeferredVersionSwapService extends AbstractVeniceService {
         logMessageIfNotRedundant(message);
       } else if (StoreVersionLifecycleEventOutcome.ROLLBACK.equals(outcome)
           || StoreVersionLifecycleEventOutcome.ABORT.equals(outcome)) {
+        String regionsToRollback = computeRegionsToRollback(targetRegion, rolloutOrder);
         String message = "Skipping version swap for store: " + parentStore.getName() + " on version: "
-            + targetVersionNum + "as post version swap validations emitted " + outcome;
+            + targetVersionNum + " as post version swap validations emitted " + outcome + "; rolling back regions: "
+            + regionsToRollback;
         logMessageIfNotRedundant(message);
 
-        veniceParentHelixAdmin.rollbackToBackupVersion(clusterName, parentStore.getName(), targetRegion);
-        updateStore(clusterName, parentStore.getName(), ERROR, targetVersionNum);
-        LOGGER.info(
-            "Updating store status to ERROR for store: " + parentStore.getName() + " on version: " + targetVersionNum);
+        veniceParentHelixAdmin.rollbackToBackupVersion(clusterName, parentStore.getName(), regionsToRollback);
       }
 
       if (!StoreVersionLifecycleEventOutcome.PROCEED.equals(outcome)) {
@@ -871,6 +871,28 @@ public class DeferredVersionSwapService extends AbstractVeniceService {
         + " in region" + targetRegion + " is proceed: " + proceed;
     logMessageIfNotRedundant(message);
     return proceed;
+  }
+
+  /**
+   * Returns the comma-separated list of regions to roll back when a post-version-swap validation
+   * fails. For the sequential rollout path, this is every region in {@code rolloutOrder} from the
+   * first one up to and including {@code targetRegion} — i.e., every region that has rolled
+   * forward by this point. For the parallel rollout path (no rolloutOrder), the affected set is
+   * just {@code targetRegion}.
+   *
+   * <p>Rolling back only {@code targetRegion} alone would leave earlier regions on the new version
+   * when the lifecycle hook decided the store shouldn't be on the new version anywhere.
+   */
+  static String computeRegionsToRollback(String targetRegion, List<String> rolloutOrder) {
+    if (rolloutOrder == null || rolloutOrder.isEmpty()) {
+      return targetRegion;
+    }
+    int targetRegionIndex = rolloutOrder.indexOf(targetRegion);
+    if (targetRegionIndex < 0) {
+      // Defensive: targetRegion isn't in rolloutOrder. Roll back only the named region.
+      return targetRegion;
+    }
+    return String.join(",", rolloutOrder.subList(0, targetRegionIndex + 1));
   }
 
   private void handleFailedRollForward(
@@ -1097,7 +1119,8 @@ public class DeferredVersionSwapService extends AbstractVeniceService {
           targetVersionNum,
           cluster,
           priorRegionRolledForward,
-          kafkaTopicName)) {
+          kafkaTopicName,
+          rolloutOrder)) {
         logLatency(startTime, storeName, targetVersionNum);
         return;
       }
@@ -1205,7 +1228,8 @@ public class DeferredVersionSwapService extends AbstractVeniceService {
         targetVersionNum,
         cluster,
         targetVersion.getTargetSwapRegion(),
-        kafkaTopicName)) {
+        kafkaTopicName,
+        Collections.emptyList())) {
       logLatency(startTime, storeName, targetVersionNum);
       return;
     }

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/DeferredVersionSwapService.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/DeferredVersionSwapService.java
@@ -860,6 +860,11 @@ public class DeferredVersionSwapService extends AbstractVeniceService {
         logMessageIfNotRedundant(message);
 
         veniceParentHelixAdmin.rollbackToBackupVersion(clusterName, parentStore.getName(), regionsToRollback);
+        updateStore(clusterName, parentStore.getName(), VersionStatus.ROLLED_BACK, targetVersionNum);
+        LOGGER.info(
+            "Updated store status to ROLLED_BACK for store: {} on version: {}",
+            parentStore.getName(),
+            targetVersionNum);
       }
 
       if (!StoreVersionLifecycleEventOutcome.PROCEED.equals(outcome)) {

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceHelixAdmin.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceHelixAdmin.java
@@ -4618,15 +4618,6 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
             ? minNumberOfStoreVersionsToPreserve - 1
             : minNumberOfStoreVersionsToPreserve);
     List<Version> versionsToDelete = store.retrieveVersionsToDelete(numVersionToPreserve);
-    LOGGER.info(
-        "DIAG checkBackupVersionCleanupCapacityForNewPush: store={} cluster={} backupStrategy={} numVersionToPreserve={} currentVersion={} versions={} versionsToDelete={}",
-        storeName,
-        clusterName,
-        backupStrategy,
-        numVersionToPreserve,
-        store.getCurrentVersion(),
-        store.getVersions(),
-        versionsToDelete);
     if (versionsToDelete.isEmpty()) {
       return;
     }

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceHelixAdmin.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceHelixAdmin.java
@@ -4618,6 +4618,15 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
             ? minNumberOfStoreVersionsToPreserve - 1
             : minNumberOfStoreVersionsToPreserve);
     List<Version> versionsToDelete = store.retrieveVersionsToDelete(numVersionToPreserve);
+    LOGGER.info(
+        "DIAG checkBackupVersionCleanupCapacityForNewPush: store={} cluster={} backupStrategy={} numVersionToPreserve={} currentVersion={} versions={} versionsToDelete={}",
+        storeName,
+        clusterName,
+        backupStrategy,
+        numVersionToPreserve,
+        store.getCurrentVersion(),
+        store.getVersions(),
+        versionsToDelete);
     if (versionsToDelete.isEmpty()) {
       return;
     }

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceParentHelixAdmin.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceParentHelixAdmin.java
@@ -1543,6 +1543,12 @@ public class VeniceParentHelixAdmin implements Admin {
     } else if (lastVersion.getStatus() == KILLED || lastVersion.getStatus() == ERROR) {
       LOGGER.info("Store {} version {} is killed or in error state", storeName, lastVersionNum);
       return Optional.empty();
+    } else if (lastVersion.getStatus() == ROLLED_BACK) {
+      LOGGER.info("Store {} version {} is rolled back", storeName, lastVersionNum);
+      return Optional.empty();
+    } else if (lastVersion.getStatus() == PARTIALLY_ONLINE) {
+      LOGGER.info("Store {} version {} is partially online", storeName, lastVersionNum);
+      return Optional.empty();
     }
     LOGGER.info(
         "Found latest version status: {} for store: {}, version: {}",

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceParentHelixAdmin.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceParentHelixAdmin.java
@@ -1540,15 +1540,31 @@ public class VeniceParentHelixAdmin implements Admin {
     if (lastVersionNum == NON_EXISTING_VERSION || lastVersion == null) {
       LOGGER.info("Store {} does not have any version", storeName);
       return Optional.empty();
-    } else if (lastVersion.getStatus() == KILLED || lastVersion.getStatus() == ERROR) {
-      LOGGER.info("Store {} version {} is killed or in error state", storeName, lastVersionNum);
-      return Optional.empty();
-    } else if (lastVersion.getStatus() == ROLLED_BACK) {
-      LOGGER.info("Store {} version {} is rolled back", storeName, lastVersionNum);
-      return Optional.empty();
-    } else if (lastVersion.getStatus() == PARTIALLY_ONLINE) {
-      LOGGER.info("Store {} version {} is partially online", storeName, lastVersionNum);
-      return Optional.empty();
+    }
+
+    // Terminal statuses for the latest version mean there is no in-flight push to wait on, so
+    // the next push may proceed:
+    // - KILLED / ERROR: failed/aborted push, version not serving.
+    // - ROLLED_BACK: operator rolled back to a previous version; this version is preserved by
+    // the rolled-back retention window, enforced separately by
+    // checkRollbackOriginVersionCapacityForNewPush.
+    // - PARTIALLY_ONLINE: parent-only terminal state from a region-filtered rollback (some
+    // regions rolled back, some didn't); same retention window applies via the same guard.
+    // Non-terminal statuses fall through to the polling branch below to wait on the in-flight push.
+    switch (lastVersion.getStatus()) {
+      case KILLED:
+      case ERROR:
+      case ROLLED_BACK:
+      case PARTIALLY_ONLINE:
+        LOGGER.info(
+            "Store {} version {} is in terminal status {} (no ongoing push); allowing the next push to proceed",
+            storeName,
+            lastVersionNum,
+            lastVersion.getStatus());
+        return Optional.empty();
+      default:
+        // Non-terminal — fall through to the polling/wait branch below.
+        break;
     }
     LOGGER.info(
         "Found latest version status: {} for store: {}, version: {}",

--- a/services/venice-controller/src/test/java/com/linkedin/venice/controller/TestDeferredVersionSwapService.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/controller/TestDeferredVersionSwapService.java
@@ -38,6 +38,7 @@ import java.time.LocalDateTime;
 import java.time.ZoneOffset;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -829,5 +830,43 @@ public class TestDeferredVersionSwapService {
     });
 
     service.stopInner();
+  }
+
+  @Test
+  public void testComputeRegionsToRollbackSequentialCoversAllRolledForwardRegions() {
+    // Sequential rollout: targetRegion is the most recently rolled-forward region. All regions
+    // before it (plus itself) have rolled forward and must be rolled back.
+    List<String> rolloutOrder = Arrays.asList("region-a", "region-b", "region-c", "region-d");
+    Assert.assertEquals(DeferredVersionSwapService.computeRegionsToRollback("region-a", rolloutOrder), "region-a");
+    Assert.assertEquals(
+        DeferredVersionSwapService.computeRegionsToRollback("region-b", rolloutOrder),
+        "region-a,region-b");
+    Assert.assertEquals(
+        DeferredVersionSwapService.computeRegionsToRollback("region-c", rolloutOrder),
+        "region-a,region-b,region-c");
+    Assert.assertEquals(
+        DeferredVersionSwapService.computeRegionsToRollback("region-d", rolloutOrder),
+        "region-a,region-b,region-c,region-d");
+  }
+
+  @Test
+  public void testComputeRegionsToRollbackParallelReturnsTargetRegion() {
+    // Parallel rollout: rolloutOrder is empty. Only the named target region rolls back.
+    Assert.assertEquals(
+        DeferredVersionSwapService.computeRegionsToRollback("region-a", Collections.emptyList()),
+        "region-a");
+    Assert.assertEquals(DeferredVersionSwapService.computeRegionsToRollback("region-a", null), "region-a");
+    // Comma-separated targetRegion (parallel rollout can pass multiple regions) flows through unchanged.
+    Assert.assertEquals(
+        DeferredVersionSwapService.computeRegionsToRollback("region-a,region-b", Collections.emptyList()),
+        "region-a,region-b");
+  }
+
+  @Test
+  public void testComputeRegionsToRollbackTargetNotInRolloutOrderFallsBackToTarget() {
+    // Defensive: if targetRegion isn't in rolloutOrder (config drift / programming error),
+    // fall back to rolling back only the named region rather than throwing.
+    List<String> rolloutOrder = Arrays.asList("region-a", "region-b");
+    Assert.assertEquals(DeferredVersionSwapService.computeRegionsToRollback("region-c", rolloutOrder), "region-c");
   }
 }

--- a/services/venice-controller/src/test/java/com/linkedin/venice/controller/TestVeniceParentHelixAdmin.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/controller/TestVeniceParentHelixAdmin.java
@@ -2840,6 +2840,41 @@ public class TestVeniceParentHelixAdmin extends AbstractTestVeniceParentHelixAdm
         .waitVersion(eq(clusterName), eq(storeName), eq(1), any());
     currentPush = mockParentAdmin.getTopicForCurrentPushJob(clusterName, storeName, false, false);
     Assert.assertFalse(currentPush.isPresent());
+
+    // Latest version in ROLLED_BACK status: parent treats this as terminal and lets a new push
+    // proceed (returns empty), matching the behavior for KILLED / ERROR.
+    Store rolledBackStore = new ZKStore(
+        storeName,
+        "test_owner",
+        1,
+        PersistenceType.ROCKS_DB,
+        RoutingStrategy.CONSISTENT_HASH,
+        ReadStrategy.ANY_OF_ONLINE,
+        OfflinePushStrategy.WAIT_N_MINUS_ONE_REPLCIA_PER_PARTITION,
+        1);
+    VersionImpl rolledBackVersion = new VersionImpl(storeName, 1, "test_push_id");
+    rolledBackVersion.setStatus(VersionStatus.ROLLED_BACK);
+    rolledBackStore.addVersion(rolledBackVersion);
+    doReturn(rolledBackStore).when(mockParentAdmin).getStore(clusterName, storeName);
+    Assert.assertFalse(mockParentAdmin.getTopicForCurrentPushJob(clusterName, storeName, false, false).isPresent());
+
+    // Latest version in PARTIALLY_ONLINE status (parent-only state from region-filtered rollback):
+    // also treated as terminal — return empty so the next push isn't blocked waiting on a state
+    // that will never become ONLINE on the parent.
+    Store partiallyOnlineStore = new ZKStore(
+        storeName,
+        "test_owner",
+        1,
+        PersistenceType.ROCKS_DB,
+        RoutingStrategy.CONSISTENT_HASH,
+        ReadStrategy.ANY_OF_ONLINE,
+        OfflinePushStrategy.WAIT_N_MINUS_ONE_REPLCIA_PER_PARTITION,
+        1);
+    VersionImpl partiallyOnlineVersion = new VersionImpl(storeName, 1, "test_push_id");
+    partiallyOnlineVersion.setStatus(VersionStatus.PARTIALLY_ONLINE);
+    partiallyOnlineStore.addVersion(partiallyOnlineVersion);
+    doReturn(partiallyOnlineStore).when(mockParentAdmin).getStore(clusterName, storeName);
+    Assert.assertFalse(mockParentAdmin.getTopicForCurrentPushJob(clusterName, storeName, false, false).isPresent());
   }
 
   @Test


### PR DESCRIPTION
## Problem Statement

Two follow-ups on the rollback-origin guard work from #2688:

1. **`VeniceParentHelixAdmin.getTopicForCurrentPushJobParentVersionStatusBasedTracking`** treats `KILLED` and `ERROR` as terminal — returns `Optional.empty()` and lets a fresh push proceed. `ROLLED_BACK` and `PARTIALLY_ONLINE` are also non-serving terminal statuses on the parent and should follow the same path. Without this, the method falls through to the polling/wait branch on a version that will never become `ONLINE`, producing confusing "not completed, please wait" log spam during pushes that follow a rollback.
2. **`testPushBlockedAfterRollbackWithinRolledBackRetention`** previously only verified the block path. It now exercises both sides of the retention window in one run.

## Solution

### Controller change

Extend the early-return cascade in `getTopicForCurrentPushJobParentVersionStatusBasedTracking` to include `ROLLED_BACK` and `PARTIALLY_ONLINE`, mirroring the existing `KILLED` / `ERROR` handling.

### Test change

`testPushBlockedAfterRollbackWithinRolledBackRetention`:

- **Phase 1** (within retention): attempt v3 push, verify it's rejected with the guard's distinctive message and v3 is not created.
- **Phase 2** (rewind): set `latestVersionPromoteToCurrentTimestamp` to a value that puts the retention window in the past, on every controller (parent + each child). This is deterministic and clock-skew-safe vs. waiting out a real retention window.
- **Phase 3** (post-retention): re-run v3 push, verify it succeeds and v3 is created.

The rewind must be applied to **every** controller (parent + child) because the rollback-origin check runs on both:
- Parent synchronously at `/request_topic`.
- Child asynchronously when consuming the `AddVersion` admin message.

Rewinding only the parent would let request_topic succeed but cause the child admin task to keep rejecting the AddVersion, hanging the VPJ until job-status-unknown timeout.

Retention is now set to 30 minutes (realistic) since the rewind makes the test insensitive to wall-clock timing.

### Code changes

- [ ] Added new code behind **a config**.
- [ ] Introduced new **log lines**. (Two new info logs in the parent admin for ROLLED_BACK / PARTIALLY_ONLINE cases.)

### **Concurrency-Specific Checks**

- [x] Code has **no race conditions** or **thread safety issues**.
- [x] Proper **synchronization mechanisms** are used where needed. (Test rewind uses `createStoreWriteLock`.)
- [x] No **blocking calls** inside critical sections.
- [x] Verified **thread-safe collections** are used.
- [x] Validated proper exception handling in multi-threaded code.

## How was this PR tested?

- [ ] New unit tests added.
- [x] New integration tests added. (Phase 3 added to existing test.)
- [x] Modified or extended existing tests.
- [x] Verified backward compatibility (if applicable).

Re-ran `TestPushBlockedByRollbackOriginGuard` — passes in 46s, exercising both block and post-retention allow paths.

## Does this PR introduce any user-facing or breaking changes?

- [x] No. You can skip the rest of this section.