### PR TITLE
[server][da-vinci] Drop bad data partitions on storage engine restore

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/config/VeniceServerConfig.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/config/VeniceServerConfig.java
@@ -191,6 +191,7 @@ import static com.linkedin.venice.ConfigKeys.SERVER_RECORD_LEVEL_TIMESTAMP_ENABL
 import static com.linkedin.venice.ConfigKeys.SERVER_REMOTE_CONSUMER_CONFIG_PREFIX;
 import static com.linkedin.venice.ConfigKeys.SERVER_REMOTE_INGESTION_REPAIR_SLEEP_INTERVAL_SECONDS;
 import static com.linkedin.venice.ConfigKeys.SERVER_RESET_ERROR_REPLICA_ENABLED;
+import static com.linkedin.venice.ConfigKeys.SERVER_RESTORE_DROP_BAD_PARTITION_ENABLED;
 import static com.linkedin.venice.ConfigKeys.SERVER_REST_SERVICE_EPOLL_ENABLED;
 import static com.linkedin.venice.ConfigKeys.SERVER_REST_SERVICE_STORAGE_THREAD_NUM;
 import static com.linkedin.venice.ConfigKeys.SERVER_RESUBSCRIPTION_CHECK_INTERVAL_IN_SECONDS;
@@ -514,6 +515,7 @@ public class VeniceServerConfig extends VeniceClusterConfig {
 
   private final boolean databaseChecksumVerificationEnabled;
   private final boolean rocksDbStorageEngineConfigCheckEnabled;
+  private final boolean restoreDropBadPartitionEnabled;
 
   private final VeniceProperties kafkaConsumerConfigsForLocalConsumption;
   private final VeniceProperties kafkaConsumerConfigsForRemoteConsumption;
@@ -970,6 +972,7 @@ public class VeniceServerConfig extends VeniceClusterConfig {
 
     databaseChecksumVerificationEnabled =
         serverProperties.getBoolean(SERVER_DATABASE_CHECKSUM_VERIFICATION_ENABLED, false);
+    restoreDropBadPartitionEnabled = serverProperties.getBoolean(SERVER_RESTORE_DROP_BAD_PARTITION_ENABLED, false);
 
     kafkaConsumerConfigsForLocalConsumption =
         serverProperties.clipAndFilterNamespace(SERVER_LOCAL_CONSUMER_CONFIG_PREFIX);
@@ -1607,6 +1610,10 @@ public class VeniceServerConfig extends VeniceClusterConfig {
 
   public boolean isDatabaseChecksumVerificationEnabled() {
     return databaseChecksumVerificationEnabled;
+  }
+
+  public boolean isRestoreDropBadPartitionEnabled() {
+    return restoreDropBadPartitionEnabled;
   }
 
   public VeniceProperties getKafkaConsumerConfigsForLocalConsumption() {

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/store/AbstractStorageEngine.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/store/AbstractStorageEngine.java
@@ -163,7 +163,7 @@ public abstract class AbstractStorageEngine<Partition extends AbstractStoragePar
         try {
           addStoragePartitionIfAbsent(partitionId);
         } catch (Exception e) {
-          if (!dropBadPartitionEnabled) {
+          if (!dropBadPartitionEnabled || !shouldDropPartitionOnRestoreFailure(partitionId, e)) {
             throw e;
           }
           LOGGER.error(
@@ -197,6 +197,20 @@ public abstract class AbstractStorageEngine<Partition extends AbstractStoragePar
    */
   protected void dropPartitionDirectory(int partitionId) {
     // No-op for engines without on-disk state.
+  }
+
+  /**
+   * Whether a restore failure for the given data partition is safe to handle by dropping its on-disk state.
+   *
+   * Subclasses should return true only when the cause indicates state that is local to this partition (e.g. RocksDB
+   * Corruption, or an IO error reporting that a partition file went missing) — not for environmental failures such
+   * as disk full, permission denied, or a lock held by another process, where dropping would amplify the problem
+   * and could mask serious infra issues.
+   *
+   * The default returns true to preserve behavior for engines that have no way to introspect the cause.
+   */
+  protected boolean shouldDropPartitionOnRestoreFailure(int partitionId, Throwable cause) {
+    return true;
   }
 
   // For testing purpose only.

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/store/AbstractStorageEngine.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/store/AbstractStorageEngine.java
@@ -123,6 +123,22 @@ public abstract class AbstractStorageEngine<Partition extends AbstractStoragePar
   protected synchronized void restoreStoragePartitions(
       boolean restoreMetadataPartition,
       boolean restoreDataPartitions) {
+    restoreStoragePartitions(restoreMetadataPartition, restoreDataPartitions, false);
+  }
+
+  /**
+   * Load the existing storage partitions.
+   *
+   * @param dropBadPartitionEnabled when true, a single data partition that fails to be restored is logged and its
+   *                                on-disk directory dropped via {@link #dropPartitionDirectory(int)}, allowing the
+   *                                rest of the engine to come up. When false, the first restore failure aborts the
+   *                                whole restore and the exception propagates. Failures while restoring the metadata
+   *                                partition always propagate.
+   */
+  protected synchronized void restoreStoragePartitions(
+      boolean restoreMetadataPartition,
+      boolean restoreDataPartitions,
+      boolean dropBadPartitionEnabled) {
     Set<Integer> partitionIds = getPersistedPartitionIds();
 
     /**
@@ -140,15 +156,47 @@ public abstract class AbstractStorageEngine<Partition extends AbstractStoragePar
 
     if (restoreDataPartitions) {
       LOGGER.info("Data partitions restore enabled. Restoring data partitions.");
-      partitionIds.stream()
-          .sorted((o1, o2) -> Integer.compare(o2, o1)) // reverse order, to minimize array resizing in {@link
-                                                       // SparseConcurrentList}
-          .forEach(this::addStoragePartitionIfAbsent);
+      // reverse order, to minimize array resizing in SparseConcurrentList
+      List<Integer> sortedPartitionIds =
+          partitionIds.stream().sorted((o1, o2) -> Integer.compare(o2, o1)).collect(Collectors.toList());
+      for (int partitionId: sortedPartitionIds) {
+        try {
+          addStoragePartitionIfAbsent(partitionId);
+        } catch (Exception e) {
+          if (!dropBadPartitionEnabled) {
+            throw e;
+          }
+          LOGGER.error(
+              "Failed to restore partition: {} for store: {}. Dropping its on-disk directory so it will be "
+                  + "re-bootstrapped from scratch via ingestion.",
+              partitionId,
+              getStoreVersionName(),
+              e);
+          try {
+            dropPartitionDirectory(partitionId);
+          } catch (Exception cleanupException) {
+            LOGGER.error(
+                "Failed to drop on-disk directory for partition: {} of store: {}.",
+                partitionId,
+                getStoreVersionName(),
+                cleanupException);
+          }
+        }
+      }
     }
   }
 
   protected final synchronized void restoreStoragePartitions() {
     restoreStoragePartitions(true, true);
+  }
+
+  /**
+   * Remove any on-disk artifacts for a partition that failed to restore. Subclasses backed by a real filesystem
+   * (e.g. RocksDB) should delete the partition directory so the partition can be re-bootstrapped from scratch.
+   * The default implementation is a no-op for in-memory engines.
+   */
+  protected void dropPartitionDirectory(int partitionId) {
+    // No-op for engines without on-disk state.
   }
 
   // For testing purpose only.

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/store/AbstractStorageEngine.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/store/AbstractStorageEngine.java
@@ -172,6 +172,14 @@ public abstract class AbstractStorageEngine<Partition extends AbstractStoragePar
               partitionId,
               getStoreVersionName(),
               e);
+          /*
+           * Clear the stale offset record in the metadata partition BEFORE deleting the on-disk dir.
+           * Otherwise re-bootstrapping ingestion would resume from a checkpoint written in the partition's
+           * previous lifetime instead of starting from scratch, producing inconsistent data. If clearing the
+           * offset fails we deliberately do not delete the dir and let the original failure propagate -
+           * silently leaking a stale offset would be worse than aborting bootstrap.
+           */
+          clearPartitionOffset(partitionId);
           try {
             dropPartitionDirectory(partitionId);
           } catch (Exception cleanupException) {

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/store/AbstractStorageEngine.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/store/AbstractStorageEngine.java
@@ -15,6 +15,7 @@ import com.linkedin.venice.pubsub.PubSubContext;
 import com.linkedin.venice.serialization.avro.InternalAvroSpecificSerializer;
 import com.linkedin.venice.utils.LatencyUtils;
 import com.linkedin.venice.utils.SparseConcurrentList;
+import com.linkedin.venice.utils.Utils;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -167,10 +168,9 @@ public abstract class AbstractStorageEngine<Partition extends AbstractStoragePar
             throw e;
           }
           LOGGER.error(
-              "Failed to restore partition: {} for store: {}. Dropping its on-disk directory so it will be "
-                  + "re-bootstrapped from scratch via ingestion.",
-              partitionId,
-              getStoreVersionName(),
+              "Failed to restore replica: {}. Dropping its on-disk directory so it will be re-bootstrapped from "
+                  + "scratch via ingestion.",
+              Utils.getReplicaId(getStoreVersionName(), partitionId),
               e);
           /*
            * Clear the stale offset record in the metadata partition BEFORE deleting the on-disk dir.
@@ -184,9 +184,8 @@ public abstract class AbstractStorageEngine<Partition extends AbstractStoragePar
             dropPartitionDirectory(partitionId);
           } catch (Exception cleanupException) {
             LOGGER.error(
-                "Failed to drop on-disk directory for partition: {} of store: {}.",
-                partitionId,
-                getStoreVersionName(),
+                "Failed to drop on-disk directory for replica: {}.",
+                Utils.getReplicaId(getStoreVersionName(), partitionId),
                 cleanupException);
           }
         }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/store/rocksdb/RocksDBStorageEngine.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/store/rocksdb/RocksDBStorageEngine.java
@@ -27,6 +27,8 @@ import java.util.function.ToLongFunction;
 import org.apache.commons.io.FileUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.rocksdb.RocksDBException;
+import org.rocksdb.Status;
 
 
 public class RocksDBStorageEngine extends AbstractStorageEngine<RocksDBStoragePartition> {
@@ -205,6 +207,58 @@ public class RocksDBStorageEngine extends AbstractStorageEngine<RocksDBStoragePa
           "Failed to delete partition directory: " + partitionDbPath + " for store: " + getStoreVersionName(),
           e);
     }
+  }
+
+  /**
+   * Only drop a partition for failures that are clearly local to its on-disk state. Environmental failures
+   * (disk full, permission denied, lock contention) must not trigger a drop — re-bootstrapping would amplify the
+   * problem or mask infra issues that need human attention.
+   *
+   * The drop-eligible cases are:
+   * <ul>
+   *   <li>{@link Status.Code#Corruption}: RocksDB has detected on-disk state it cannot read.</li>
+   *   <li>{@link Status.Code#IOError} with a "No such file or directory" message: a partition file went missing.
+   *       rocksdbjni 8.x does not expose a dedicated SubCode for path-not-found, so we fall back to a message-prefix
+   *       check. Other IOError flavors (NoSpace, generic EIO, permission denied) are intentionally excluded.</li>
+   * </ul>
+   */
+  @Override
+  protected boolean shouldDropPartitionOnRestoreFailure(int partitionId, Throwable cause) {
+    RocksDBException rocksDBException = findRocksDBException(cause);
+    if (rocksDBException == null) {
+      return false;
+    }
+    Status status = rocksDBException.getStatus();
+    if (status == null) {
+      return false;
+    }
+    Status.Code code = status.getCode();
+    if (code == Status.Code.Corruption) {
+      return true;
+    }
+    if (code == Status.Code.IOError && isNoSuchFileOrDirectory(rocksDBException, status)) {
+      return true;
+    }
+    return false;
+  }
+
+  private static boolean isNoSuchFileOrDirectory(RocksDBException rocksDBException, Status status) {
+    String state = status.getState();
+    if (state != null && state.contains("No such file or directory")) {
+      return true;
+    }
+    String message = rocksDBException.getMessage();
+    return message != null && message.contains("No such file or directory");
+  }
+
+  private static RocksDBException findRocksDBException(Throwable t) {
+    while (t != null) {
+      if (t instanceof RocksDBException) {
+        return (RocksDBException) t;
+      }
+      t = t.getCause();
+    }
+    return null;
   }
 
   @Override

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/store/rocksdb/RocksDBStorageEngine.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/store/rocksdb/RocksDBStorageEngine.java
@@ -88,7 +88,10 @@ public class RocksDBStorageEngine extends AbstractStorageEngine<RocksDBStoragePa
     this.stats = new RocksDBStorageEngineStats(storeDbPath, this::getRMDSizeInBytes, this::getKeyCountEstimate);
 
     // restoreStoragePartitions will create metadata partition if not exist.
-    restoreStoragePartitions(storeConfig.isRestoreMetadataPartition(), storeConfig.isRestoreDataPartitions());
+    restoreStoragePartitions(
+        storeConfig.isRestoreMetadataPartition(),
+        storeConfig.isRestoreDataPartitions(),
+        storeConfig.isRestoreDropBadPartitionEnabled());
 
     if (storeConfig.isRestoreMetadataPartition()) {
       // Persist RocksDB table format option used in building the storage engine.
@@ -185,6 +188,23 @@ public class RocksDBStorageEngine extends AbstractStorageEngine<RocksDBStoragePa
       }
     }
     return sum;
+  }
+
+  @Override
+  protected void dropPartitionDirectory(int partitionId) {
+    String partitionDbPath = RocksDBUtils.composePartitionDbDir(rocksDbPath, getStoreVersionName(), partitionId);
+    File partitionDbDir = new File(partitionDbPath);
+    if (!partitionDbDir.exists()) {
+      return;
+    }
+    try {
+      FileUtils.deleteDirectory(partitionDbDir);
+      LOGGER.info("Dropped on-disk directory for partition: {} of store: {}", partitionId, getStoreVersionName());
+    } catch (IOException e) {
+      throw new VeniceException(
+          "Failed to delete partition directory: " + partitionDbPath + " for store: " + getStoreVersionName(),
+          e);
+    }
   }
 
   @Override

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/store/rocksdb/RocksDBStorageEngine.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/store/rocksdb/RocksDBStorageEngine.java
@@ -217,9 +217,12 @@ public class RocksDBStorageEngine extends AbstractStorageEngine<RocksDBStoragePa
    * The drop-eligible cases are:
    * <ul>
    *   <li>{@link Status.Code#Corruption}: RocksDB has detected on-disk state it cannot read.</li>
-   *   <li>{@link Status.Code#IOError} with a "No such file or directory" message: a partition file went missing.
-   *       rocksdbjni 8.x does not expose a dedicated SubCode for path-not-found, so we fall back to a message-prefix
-   *       check. Other IOError flavors (NoSpace, generic EIO, permission denied) are intentionally excluded.</li>
+   *   <li>{@link Status.Code#IOError} whose status state or exception message contains
+   *       "No such file or directory": a partition file went missing. rocksdbjni 8.x does not expose a dedicated
+   *       SubCode for path-not-found, so we fall back to a substring match on the human-readable status text.
+   *       The substring match is gated by {@code Code.IOError} so we never drop on message text alone.
+   *       Other IOError flavors (NoSpace, generic EIO, permission denied) are intentionally excluded because their
+   *       status messages do not contain this substring.</li>
    * </ul>
    */
   @Override

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/store/rocksdb/RocksDBStorageEngine.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/store/rocksdb/RocksDBStorageEngine.java
@@ -201,10 +201,11 @@ public class RocksDBStorageEngine extends AbstractStorageEngine<RocksDBStoragePa
     }
     try {
       FileUtils.deleteDirectory(partitionDbDir);
-      LOGGER.info("Dropped on-disk directory for partition: {} of store: {}", partitionId, getStoreVersionName());
+      LOGGER.info("Dropped on-disk directory for replica: {}", Utils.getReplicaId(getStoreVersionName(), partitionId));
     } catch (IOException e) {
       throw new VeniceException(
-          "Failed to delete partition directory: " + partitionDbPath + " for store: " + getStoreVersionName(),
+          "Failed to delete partition directory: " + partitionDbPath + " for replica: "
+              + Utils.getReplicaId(getStoreVersionName(), partitionId),
           e);
     }
   }

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/store/AbstractStorageEngineRestoreTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/store/AbstractStorageEngineRestoreTest.java
@@ -28,6 +28,7 @@ public class AbstractStorageEngineRestoreTest {
     private final Set<Integer> persistedPartitionIds;
     private final Set<Integer> failingPartitionIds;
     private final Set<Integer> droppedPartitionDirectories = new HashSet<>();
+    private boolean shouldDropOverride = true;
 
     TestStorageEngine(Set<Integer> persistedPartitionIds, Set<Integer> failingPartitionIds) {
       super(
@@ -62,8 +63,24 @@ public class AbstractStorageEngineRestoreTest {
       droppedPartitionDirectories.add(partitionId);
     }
 
+    @Override
+    protected boolean shouldDropPartitionOnRestoreFailure(int partitionId, Throwable cause) {
+      return shouldDropOverride;
+    }
+
+    void setShouldDropOverride(boolean shouldDropOverride) {
+      this.shouldDropOverride = shouldDropOverride;
+    }
+
     void invokeRestoreStoragePartitions(boolean dropBadPartitionEnabled) {
       restoreStoragePartitions(false, true, dropBadPartitionEnabled);
+    }
+
+    void invokeRestoreStoragePartitions(
+        boolean restoreMetadataPartition,
+        boolean restoreDataPartitions,
+        boolean dropBadPartitionEnabled) {
+      restoreStoragePartitions(restoreMetadataPartition, restoreDataPartitions, dropBadPartitionEnabled);
     }
 
     Set<Integer> getDroppedPartitionDirectories() {
@@ -178,6 +195,37 @@ public class AbstractStorageEngineRestoreTest {
         engine.getDroppedPartitionDirectories(),
         Collections.singleton(1),
         "Only the failed partition's directory should be dropped.");
+  }
+
+  @Test
+  public void testMetadataPartitionFailureAlwaysPropagates() {
+    Set<Integer> persisted = new HashSet<>();
+    persisted.add(0);
+    persisted.add(1);
+    Set<Integer> failing = new HashSet<>();
+    failing.add(AbstractStorageEngine.METADATA_PARTITION_ID);
+    TestStorageEngine engine = new TestStorageEngine(persisted, failing);
+
+    Assert.assertThrows(VeniceException.class, () -> engine.invokeRestoreStoragePartitions(true, true, true));
+    Assert.assertTrue(
+        engine.getDroppedPartitionDirectories().isEmpty(),
+        "Metadata partition failure must propagate without dropping anything, even when the flag is on.");
+  }
+
+  @Test
+  public void testRestoreRethrowsWhenShouldDropPredicateReturnsFalse() {
+    Set<Integer> persisted = new HashSet<>();
+    persisted.add(0);
+    persisted.add(1);
+    Set<Integer> failing = new HashSet<>();
+    failing.add(1);
+    TestStorageEngine engine = new TestStorageEngine(persisted, failing);
+    engine.setShouldDropOverride(false);
+
+    Assert.assertThrows(VeniceException.class, () -> engine.invokeRestoreStoragePartitions(true));
+    Assert.assertTrue(
+        engine.getDroppedPartitionDirectories().isEmpty(),
+        "When the subclass classifies the cause as not-drop-eligible, the failure must propagate.");
   }
 
   @Test

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/store/AbstractStorageEngineRestoreTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/store/AbstractStorageEngineRestoreTest.java
@@ -1,0 +1,206 @@
+package com.linkedin.davinci.store;
+
+import com.linkedin.davinci.callback.BytesStreamingCallback;
+import com.linkedin.venice.exceptions.VeniceException;
+import com.linkedin.venice.meta.PersistenceType;
+import com.linkedin.venice.serialization.avro.AvroProtocolDefinition;
+import java.nio.ByteBuffer;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+
+/**
+ * Unit tests for {@link AbstractStorageEngine#restoreStoragePartitions(boolean, boolean, boolean)} covering the
+ * drop-bad-partition-on-restore behavior.
+ */
+public class AbstractStorageEngineRestoreTest {
+  private static final String STORE_VERSION_NAME = "test_store_v1";
+
+  /**
+   * Test stub that exposes {@link #restoreStoragePartitions(boolean, boolean, boolean)} and lets tests configure
+   * which partitions are persisted on disk and which partition ids should fail to be created.
+   */
+  private static class TestStorageEngine extends AbstractStorageEngine<TestStoragePartition> {
+    private final Set<Integer> persistedPartitionIds;
+    private final Set<Integer> failingPartitionIds;
+    private final Set<Integer> droppedPartitionDirectories = new HashSet<>();
+
+    TestStorageEngine(Set<Integer> persistedPartitionIds, Set<Integer> failingPartitionIds) {
+      super(
+          STORE_VERSION_NAME,
+          AvroProtocolDefinition.STORE_VERSION_STATE.getSerializer(),
+          AvroProtocolDefinition.PARTITION_STATE.getSerializer());
+      this.persistedPartitionIds = persistedPartitionIds;
+      this.failingPartitionIds = failingPartitionIds;
+    }
+
+    @Override
+    public PersistenceType getType() {
+      return PersistenceType.IN_MEMORY;
+    }
+
+    @Override
+    public Set<Integer> getPersistedPartitionIds() {
+      return new HashSet<>(persistedPartitionIds);
+    }
+
+    @Override
+    public TestStoragePartition createStoragePartition(StoragePartitionConfig storagePartitionConfig) {
+      int partitionId = storagePartitionConfig.getPartitionId();
+      if (failingPartitionIds.contains(partitionId)) {
+        throw new VeniceException("Simulated failure to open partition: " + partitionId);
+      }
+      return new TestStoragePartition(partitionId);
+    }
+
+    @Override
+    protected void dropPartitionDirectory(int partitionId) {
+      droppedPartitionDirectories.add(partitionId);
+    }
+
+    void invokeRestoreStoragePartitions(boolean dropBadPartitionEnabled) {
+      restoreStoragePartitions(false, true, dropBadPartitionEnabled);
+    }
+
+    Set<Integer> getDroppedPartitionDirectories() {
+      return droppedPartitionDirectories;
+    }
+  }
+
+  private static class TestStoragePartition extends AbstractStoragePartition {
+    TestStoragePartition(int partitionId) {
+      super(partitionId);
+    }
+
+    @Override
+    public void put(byte[] key, byte[] value) {
+    }
+
+    @Override
+    public void put(byte[] key, ByteBuffer value) {
+    }
+
+    @Override
+    public <K, V> void put(K key, V value) {
+    }
+
+    @Override
+    public byte[] get(byte[] key) {
+      return null;
+    }
+
+    @Override
+    public <K, V> V get(K key) {
+      return null;
+    }
+
+    @Override
+    public byte[] get(ByteBuffer key) {
+      return null;
+    }
+
+    @Override
+    public void getByKeyPrefix(byte[] keyPrefix, BytesStreamingCallback callback) {
+    }
+
+    @Override
+    public void delete(byte[] key) {
+    }
+
+    @Override
+    public Map<String, String> sync() {
+      return Collections.emptyMap();
+    }
+
+    @Override
+    public void drop() {
+    }
+
+    @Override
+    public void close() {
+    }
+
+    @Override
+    public boolean verifyConfig(StoragePartitionConfig storagePartitionConfig) {
+      return true;
+    }
+
+    @Override
+    public void createSnapshot() {
+    }
+
+    @Override
+    public void cleanupSnapshot() {
+    }
+
+    @Override
+    public long getPartitionSizeInBytes() {
+      return 0;
+    }
+  }
+
+  @Test
+  public void testRestoreFailsFastWhenDropBadPartitionDisabled() {
+    Set<Integer> persisted = new HashSet<>();
+    persisted.add(0);
+    persisted.add(1);
+    persisted.add(2);
+    Set<Integer> failing = new HashSet<>();
+    failing.add(1);
+    TestStorageEngine engine = new TestStorageEngine(persisted, failing);
+
+    Assert.assertThrows(VeniceException.class, () -> engine.invokeRestoreStoragePartitions(false));
+    Assert.assertTrue(
+        engine.getDroppedPartitionDirectories().isEmpty(),
+        "No partition directory should be dropped when the flag is disabled.");
+  }
+
+  @Test
+  public void testRestoreDropsBadPartitionWhenEnabled() {
+    Set<Integer> persisted = new HashSet<>();
+    persisted.add(0);
+    persisted.add(1);
+    persisted.add(2);
+    Set<Integer> failing = new HashSet<>();
+    failing.add(1);
+    TestStorageEngine engine = new TestStorageEngine(persisted, failing);
+
+    engine.invokeRestoreStoragePartitions(true);
+
+    Assert.assertTrue(engine.containsPartition(0), "Partition 0 should be restored.");
+    Assert.assertFalse(engine.containsPartition(1), "Failed partition 1 should be skipped.");
+    Assert.assertTrue(engine.containsPartition(2), "Partition 2 should be restored.");
+    Assert.assertEquals(
+        engine.getDroppedPartitionDirectories(),
+        Collections.singleton(1),
+        "Only the failed partition's directory should be dropped.");
+  }
+
+  @Test
+  public void testRestoreDropsMultipleBadPartitionsWhenEnabled() {
+    Set<Integer> persisted = new HashSet<>();
+    persisted.add(0);
+    persisted.add(1);
+    persisted.add(2);
+    persisted.add(3);
+    Set<Integer> failing = new HashSet<>();
+    failing.add(1);
+    failing.add(3);
+    TestStorageEngine engine = new TestStorageEngine(persisted, failing);
+
+    engine.invokeRestoreStoragePartitions(true);
+
+    Assert.assertTrue(engine.containsPartition(0));
+    Assert.assertFalse(engine.containsPartition(1));
+    Assert.assertTrue(engine.containsPartition(2));
+    Assert.assertFalse(engine.containsPartition(3));
+    Set<Integer> expected = new HashSet<>();
+    expected.add(1);
+    expected.add(3);
+    Assert.assertEquals(engine.getDroppedPartitionDirectories(), expected);
+  }
+}

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/store/AbstractStorageEngineRestoreTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/store/AbstractStorageEngineRestoreTest.java
@@ -27,7 +27,9 @@ public class AbstractStorageEngineRestoreTest {
   private static class TestStorageEngine extends AbstractStorageEngine<TestStoragePartition> {
     private final Set<Integer> persistedPartitionIds;
     private final Set<Integer> failingPartitionIds;
-    private final Set<Integer> droppedPartitionDirectories = new HashSet<>();
+    private final java.util.List<Integer> dropOrder = new java.util.ArrayList<>();
+    private final java.util.List<Integer> clearOffsetOrder = new java.util.ArrayList<>();
+    private final Set<Integer> partitionsWithClearOffsetFailure = new HashSet<>();
     private boolean shouldDropOverride = true;
 
     TestStorageEngine(Set<Integer> persistedPartitionIds, Set<Integer> failingPartitionIds) {
@@ -59,8 +61,16 @@ public class AbstractStorageEngineRestoreTest {
     }
 
     @Override
+    public void clearPartitionOffset(int partitionId) {
+      clearOffsetOrder.add(partitionId);
+      if (partitionsWithClearOffsetFailure.contains(partitionId)) {
+        throw new VeniceException("Simulated failure to clear offset for partition: " + partitionId);
+      }
+    }
+
+    @Override
     protected void dropPartitionDirectory(int partitionId) {
-      droppedPartitionDirectories.add(partitionId);
+      dropOrder.add(partitionId);
     }
 
     @Override
@@ -70,6 +80,10 @@ public class AbstractStorageEngineRestoreTest {
 
     void setShouldDropOverride(boolean shouldDropOverride) {
       this.shouldDropOverride = shouldDropOverride;
+    }
+
+    void failClearOffsetFor(int partitionId) {
+      partitionsWithClearOffsetFailure.add(partitionId);
     }
 
     void invokeRestoreStoragePartitions(boolean dropBadPartitionEnabled) {
@@ -84,7 +98,15 @@ public class AbstractStorageEngineRestoreTest {
     }
 
     Set<Integer> getDroppedPartitionDirectories() {
-      return droppedPartitionDirectories;
+      return new HashSet<>(dropOrder);
+    }
+
+    java.util.List<Integer> getDropOrder() {
+      return dropOrder;
+    }
+
+    java.util.List<Integer> getClearOffsetOrder() {
+      return clearOffsetOrder;
     }
   }
 
@@ -226,6 +248,48 @@ public class AbstractStorageEngineRestoreTest {
     Assert.assertTrue(
         engine.getDroppedPartitionDirectories().isEmpty(),
         "When the subclass classifies the cause as not-drop-eligible, the failure must propagate.");
+  }
+
+  @Test
+  public void testRestoreClearsOffsetBeforeDroppingDirectory() {
+    Set<Integer> persisted = new HashSet<>();
+    persisted.add(0);
+    persisted.add(1);
+    Set<Integer> failing = new HashSet<>();
+    failing.add(1);
+    TestStorageEngine engine = new TestStorageEngine(persisted, failing);
+
+    engine.invokeRestoreStoragePartitions(true);
+
+    Assert.assertEquals(
+        engine.getClearOffsetOrder(),
+        Collections.singletonList(1),
+        "Stale offset record must be cleared for the dropped partition.");
+    Assert.assertEquals(
+        engine.getDropOrder(),
+        Collections.singletonList(1),
+        "On-disk directory must be dropped after clearing the offset.");
+  }
+
+  @Test
+  public void testRestoreAbortsDropWhenClearOffsetFails() {
+    Set<Integer> persisted = new HashSet<>();
+    persisted.add(0);
+    persisted.add(1);
+    Set<Integer> failing = new HashSet<>();
+    failing.add(1);
+    TestStorageEngine engine = new TestStorageEngine(persisted, failing);
+    engine.failClearOffsetFor(1);
+
+    Assert.assertThrows(VeniceException.class, () -> engine.invokeRestoreStoragePartitions(true));
+    Assert.assertEquals(
+        engine.getClearOffsetOrder(),
+        Collections.singletonList(1),
+        "clearPartitionOffset must be attempted before the drop.");
+    Assert.assertTrue(
+        engine.getDropOrder().isEmpty(),
+        "On-disk directory must NOT be dropped when clearing the offset fails - otherwise re-bootstrap would "
+            + "resume from a stale checkpoint.");
   }
 
   @Test

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/store/rocksdb/RocksDBStorageEngineDropPredicateTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/store/rocksdb/RocksDBStorageEngineDropPredicateTest.java
@@ -1,0 +1,133 @@
+package com.linkedin.davinci.store.rocksdb;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.linkedin.davinci.config.VeniceStoreVersionConfig;
+import com.linkedin.davinci.stats.AggVersionedStorageEngineStats;
+import com.linkedin.davinci.storage.StorageService;
+import com.linkedin.davinci.store.AbstractStorageEngineTest;
+import com.linkedin.davinci.store.StorageEngineAccessor;
+import com.linkedin.venice.exceptions.VeniceException;
+import com.linkedin.venice.meta.PersistenceType;
+import com.linkedin.venice.meta.ReadOnlyStoreRepository;
+import com.linkedin.venice.meta.Store;
+import com.linkedin.venice.meta.Version;
+import com.linkedin.venice.serialization.avro.AvroProtocolDefinition;
+import com.linkedin.venice.utils.Utils;
+import com.linkedin.venice.utils.VeniceProperties;
+import org.rocksdb.RocksDBException;
+import org.rocksdb.Status;
+import org.testng.Assert;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+
+/**
+ * Tests for {@link RocksDBStorageEngine#shouldDropPartitionOnRestoreFailure(int, Throwable)}.
+ * Confirms that only Status.Code.Corruption and Status.Code.IOError with a "No such file or directory" status
+ * trigger a drop. Environmental failures (NoSpace, lock contention, generic IOError, non-RocksDBException) must not.
+ */
+public class RocksDBStorageEngineDropPredicateTest {
+  private static final int PARTITION_ID = 0;
+  private StorageService storageService;
+  private VeniceStoreVersionConfig storeConfig;
+  private RocksDBStorageEngine engine;
+  private final ReadOnlyStoreRepository mockReadOnlyStoreRepository = mock(ReadOnlyStoreRepository.class);
+  private static final String storeName = Utils.getUniqueString("rocksdb_drop_predicate_test");
+  private static final int versionNumber = 0;
+  private static final String topicName = Version.composeKafkaTopic(storeName, versionNumber);
+
+  @BeforeClass
+  public void setUp() {
+    Version mockVersion = mock(Version.class);
+    when(mockVersion.isActiveActiveReplicationEnabled()).thenReturn(false);
+    Store mockStore = mock(Store.class);
+    when(mockStore.getVersion(versionNumber)).thenReturn(mockVersion);
+    when(mockReadOnlyStoreRepository.getStoreOrThrow(storeName)).thenReturn(mockStore);
+
+    VeniceProperties serverProps = AbstractStorageEngineTest.getServerProperties(PersistenceType.ROCKS_DB);
+    storageService = new StorageService(
+        AbstractStorageEngineTest.getVeniceConfigLoader(serverProps),
+        mock(AggVersionedStorageEngineStats.class),
+        null,
+        AvroProtocolDefinition.STORE_VERSION_STATE.getSerializer(),
+        AvroProtocolDefinition.PARTITION_STATE.getSerializer(),
+        mockReadOnlyStoreRepository);
+    storeConfig = new VeniceStoreVersionConfig(topicName, serverProps, PersistenceType.ROCKS_DB);
+    engine = (RocksDBStorageEngine) StorageEngineAccessor
+        .getInnerStorageEngine(storageService.openStoreForNewPartition(storeConfig, PARTITION_ID, () -> null));
+  }
+
+  @AfterClass
+  public void cleanUp() throws Exception {
+    storageService.dropStorePartition(storeConfig, PARTITION_ID);
+    storageService.stop();
+  }
+
+  @Test
+  public void testDropOnCorruption() {
+    RocksDBException rocksDBException =
+        new RocksDBException("simulated", new Status(Status.Code.Corruption, Status.SubCode.None, "boom"));
+    Throwable wrapped = new VeniceException("Failed to open RocksDB for replica: 0", rocksDBException);
+    Assert.assertTrue(engine.shouldDropPartitionOnRestoreFailure(PARTITION_ID, wrapped));
+  }
+
+  @Test
+  public void testDropOnIOErrorNoSuchFile() {
+    RocksDBException rocksDBException = new RocksDBException(
+        "IO error: No such file or directory: /path/to/CURRENT",
+        new Status(Status.Code.IOError, Status.SubCode.None, "No such file or directory"));
+    Throwable wrapped = new VeniceException("Failed to open RocksDB for replica: 0", rocksDBException);
+    Assert.assertTrue(engine.shouldDropPartitionOnRestoreFailure(PARTITION_ID, wrapped));
+  }
+
+  @Test
+  public void testDropOnIOErrorNoSuchFileViaMessageOnly() {
+    RocksDBException rocksDBException = new RocksDBException("IO error: No such file or directory: /path/to/CURRENT");
+    Throwable wrapped = new VeniceException("Failed to open RocksDB for replica: 0", rocksDBException);
+    // Without a Status, the predicate has no Code to inspect, so this must not drop. Confirms we
+    // never drop on message text alone — Status.Code.IOError gating is required.
+    Assert.assertFalse(engine.shouldDropPartitionOnRestoreFailure(PARTITION_ID, wrapped));
+  }
+
+  @Test
+  public void testNoDropOnIOErrorNoSpace() {
+    RocksDBException rocksDBException =
+        new RocksDBException("disk full", new Status(Status.Code.IOError, Status.SubCode.NoSpace, "ENOSPC"));
+    Throwable wrapped = new VeniceException("Failed to open RocksDB for replica: 0", rocksDBException);
+    Assert.assertFalse(engine.shouldDropPartitionOnRestoreFailure(PARTITION_ID, wrapped));
+  }
+
+  @Test
+  public void testNoDropOnGenericIOError() {
+    RocksDBException rocksDBException =
+        new RocksDBException("io", new Status(Status.Code.IOError, Status.SubCode.None, "EIO"));
+    Throwable wrapped = new VeniceException("Failed to open RocksDB for replica: 0", rocksDBException);
+    Assert.assertFalse(engine.shouldDropPartitionOnRestoreFailure(PARTITION_ID, wrapped));
+  }
+
+  @Test
+  public void testNoDropOnLockBusy() {
+    RocksDBException rocksDBException =
+        new RocksDBException("locked", new Status(Status.Code.Busy, Status.SubCode.LockLimit, "lock held"));
+    Throwable wrapped = new VeniceException("Failed to open RocksDB for replica: 0", rocksDBException);
+    Assert.assertFalse(engine.shouldDropPartitionOnRestoreFailure(PARTITION_ID, wrapped));
+  }
+
+  @Test
+  public void testNoDropOnNonRocksDBException() {
+    Throwable nonRocks = new RuntimeException("unrelated boom");
+    Assert.assertFalse(engine.shouldDropPartitionOnRestoreFailure(PARTITION_ID, nonRocks));
+  }
+
+  @Test
+  public void testFindsRocksDBExceptionThroughCauseChain() {
+    RocksDBException rocksDBException =
+        new RocksDBException("nested", new Status(Status.Code.Corruption, Status.SubCode.None, "boom"));
+    Throwable level2 = new VeniceException("Failed to open RocksDB for replica: 0", rocksDBException);
+    Throwable level1 = new RuntimeException("outer wrapper", level2);
+    Assert.assertTrue(engine.shouldDropPartitionOnRestoreFailure(PARTITION_ID, level1));
+  }
+}

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/store/rocksdb/RocksDBStorageEngineTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/store/rocksdb/RocksDBStorageEngineTest.java
@@ -291,6 +291,35 @@ public class RocksDBStorageEngineTest extends AbstractStorageEngineTest<RocksDBS
   }
 
   @Test
+  public void testDropPartitionDirectoryRemovesOnDiskDir() {
+    RocksDBStorageEngine rocksDBStorageEngine = (RocksDBStorageEngine) getTestStoreEngine();
+
+    int extraPartitionId = PARTITION_ID + 7777;
+    storageService.openStoreForNewPartition(storeConfig, extraPartitionId, () -> null);
+    Assert.assertTrue(
+        rocksDBStorageEngine.getPersistedPartitionIds().contains(extraPartitionId),
+        "Newly added partition should be persisted on disk before drop.");
+
+    // Close the partition first so RocksDB releases file handles before the directory is deleted.
+    rocksDBStorageEngine.closePartition(extraPartitionId);
+
+    rocksDBStorageEngine.dropPartitionDirectory(extraPartitionId);
+
+    Assert.assertFalse(
+        rocksDBStorageEngine.getPersistedPartitionIds().contains(extraPartitionId),
+        "Partition directory should be gone after dropPartitionDirectory.");
+  }
+
+  @Test
+  public void testDropPartitionDirectoryNoopWhenAbsent() {
+    RocksDBStorageEngine rocksDBStorageEngine = (RocksDBStorageEngine) getTestStoreEngine();
+    int missingPartitionId = PARTITION_ID + 99999;
+    Assert.assertFalse(rocksDBStorageEngine.getPersistedPartitionIds().contains(missingPartitionId));
+    // Should not throw even though there is nothing to delete.
+    rocksDBStorageEngine.dropPartitionDirectory(missingPartitionId);
+  }
+
+  @Test
   public void testGetPutDeleteGlobalRtDivMetadata() {
     RocksDBStorageEngine rocksDBStorageEngine = (RocksDBStorageEngine) getTestStoreEngine();
     byte[] key1 = "grtd-key-1".getBytes(StandardCharsets.UTF_8);

--- a/internal/venice-common/src/main/java/com/linkedin/venice/ConfigKeys.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/ConfigKeys.java
@@ -1213,6 +1213,14 @@ public class ConfigKeys {
       "server.database.checksum.verification.enabled";
 
   /**
+   * Whether to drop a data partition that fails to be restored at storage engine startup, rather than aborting the
+   * whole engine bootstrap. When enabled, the on-disk directory of the failed partition is deleted so that the
+   * partition is re-bootstrapped from scratch via Helix/ingestion on the next startup. Default false to preserve
+   * fail-fast behavior. Failures while restoring the metadata partition still propagate regardless of this flag.
+   */
+  public static final String SERVER_RESTORE_DROP_BAD_PARTITION_ENABLED = "server.restore.drop.bad.partition.enabled";
+
+  /**
    * Any server config that start with "server.local.consumer.config.prefix" will be used as a customized consumer config
    * for local consumer.
    */

--- a/internal/venice-common/src/main/java/com/linkedin/venice/ConfigKeys.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/ConfigKeys.java
@@ -1214,9 +1214,17 @@ public class ConfigKeys {
 
   /**
    * Whether to drop a data partition that fails to be restored at storage engine startup, rather than aborting the
-   * whole engine bootstrap. When enabled, the on-disk directory of the failed partition is deleted so that the
-   * partition is re-bootstrapped from scratch via Helix/ingestion on the next startup. Default false to preserve
-   * fail-fast behavior. Failures while restoring the metadata partition still propagate regardless of this flag.
+   * whole engine bootstrap. When enabled, the on-disk directory of the failed partition is deleted and the partition
+   * is re-bootstrapped from scratch via Helix/ingestion on the next startup.
+   *
+   * The drop is intentionally narrow: only failures that look like partition-local on-disk damage trigger it.
+   * For the RocksDB engine that means {@code Status.Code.Corruption}, or {@code Status.Code.IOError} whose status
+   * carries a "No such file or directory" message. Environmental failures - disk full, permission denied, lock
+   * contention from a concurrent open, generic IO errors - are NOT dropped; they re-throw and abort engine bootstrap
+   * so an operator can investigate. Failures while restoring the metadata partition always propagate, regardless
+   * of this flag.
+   *
+   * Default false to preserve fail-fast behavior.
    */
   public static final String SERVER_RESTORE_DROP_BAD_PARTITION_ENABLED = "server.restore.drop.bad.partition.enabled";
 


### PR DESCRIPTION
## Problem Statement

`AbstractStorageEngine.restoreStoragePartitions` is fail-fast: if any single data partition fails to be restored at startup (e.g. corrupt RocksDB state, mismatched options, missing files), the exception propagates and aborts the whole engine bootstrap. The store version then cannot come up at all, even if every other partition on the host is healthy.

Operators currently have no easy way to clean this up — the only remediation is to manually delete the partition directory off-host before restart, which is error-prone in production. We want an opt-in path where the host can drop the bad partition's on-disk state and let Helix/ingestion re-bootstrap it from scratch on the next restart, while the rest of the engine comes up immediately.

## Solution

Add a new server config `server.restore.drop.bad.partition.enabled` (default `false`, so existing deployments are unaffected). When enabled:

1. `AbstractStorageEngine.restoreStoragePartitions` catches per-data-partition exceptions instead of letting the first one abort the whole loop.
2. For each failure, it logs the partition id + store version + cause, then calls a new `dropPartitionDirectory(int)` hook to remove the partition's on-disk artifacts.
3. `RocksDBStorageEngine` overrides the hook to delete the partition's RocksDB directory via `RocksDBUtils.composePartitionDbDir` + `FileUtils.deleteDirectory`. In-memory engines inherit the no-op default.
4. Failures while restoring the **metadata** partition still propagate unconditionally — losing the metadata partition has different recovery semantics and we do not want to silently drop it.
5. If the cleanup itself fails (e.g. IOException deleting the dir), the error is logged but does not re-throw, so one undeletable directory cannot cascade-block the rest of the restore.

Same behavior applies to both Venice Server and Da Vinci Client, since both share `VeniceServerConfig`.

The flag is wired through:
- `ConfigKeys.SERVER_RESTORE_DROP_BAD_PARTITION_ENABLED`
- `VeniceServerConfig.isRestoreDropBadPartitionEnabled()`
- `RocksDBStorageEngine` constructor → new 3-arg `restoreStoragePartitions(restoreMetadataPartition, restoreDataPartitions, dropBadPartitionEnabled)` overload. The original 2-arg signature is preserved and delegates with `dropBadPartitionEnabled=false`.

###  Code changes
- [x] Added new code behind **a config**. Configs:
  - `server.restore.drop.bad.partition.enabled` — default `false`.
- [x] Introduced new **log lines**.
  - [x] Confirmed if logs need to be **rate limited** to avoid excessive logging. Restore runs once per engine bootstrap and only logs on failure, so rate limiting is not needed.

###  **Concurrency-Specific Checks**
Both reviewer and PR author to verify
- [x] Code has **no race conditions** or **thread safety issues**. Restore runs synchronously during engine construction before any other thread can interact with the engine; the new logic remains under the existing `synchronized` method.
- [x] Proper **synchronization mechanisms** (e.g., `synchronized`, `RWLock`) are used where needed. The new 3-arg `restoreStoragePartitions` keeps the `synchronized` modifier, matching the original.
- [x] No **blocking calls** inside critical sections that could lead to deadlocks or performance degradation. `FileUtils.deleteDirectory` is local IO on a partition dir that is no longer in use; same blast radius as the existing `RocksDBStoragePartition#drop` flow.
- [x] Verified **thread-safe collections** are used (e.g., `ConcurrentHashMap`, `CopyOnWriteArrayList`). No shared mutable collections introduced.
- [x] Validated proper exception handling in multi-threaded code to avoid silent thread termination. Failures are logged with full stack traces and re-thrown when the flag is off; cleanup-only failures are logged but do not re-throw to avoid masking the original restore error.

## How was this PR tested?

- [x] New unit tests added.
  - `AbstractStorageEngineRestoreTest` — three tests covering: fail-fast when flag is off, single bad partition dropped + healthy partitions restored when flag is on, multiple bad partitions all dropped while healthy ones survive.
  - `RocksDBStorageEngineTest#testDropPartitionDirectoryRemovesOnDiskDir` — adds a partition, calls `dropPartitionDirectory`, verifies the on-disk directory is gone (via `getPersistedPartitionIds`).
  - `RocksDBStorageEngineTest#testDropPartitionDirectoryNoopWhenAbsent` — verifies the hook is a no-op when the directory does not exist.
- [ ] New integration tests added.
- [x] Modified or extended existing tests. Existing `RocksDBStorageEngineTest` and `AbstractStorageEngineTest` suites continue to pass — the original 2-arg `restoreStoragePartitions` overload is preserved.
- [x] Verified backward compatibility (if applicable). Default config value is `false`, which preserves the existing fail-fast behavior exactly.

## Does this PR introduce any user-facing or breaking changes?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Clearly explain the behavior change and its impact.
