### PR TITLE
[server][dvc] Fix post-blob RTS regression in reportIfCatchUpVersionTopicOffset (cache eviction + leader-complete gate)

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/config/VeniceServerConfig.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/config/VeniceServerConfig.java
@@ -1091,8 +1091,16 @@ public class VeniceServerConfig extends VeniceClusterConfig {
         serverProperties.getInt(SERVER_NON_EXISTING_TOPIC_CHECK_RETRY_INTERNAL_SECOND, 60); // 1min
     leaderCompleteStateCheckInFollowerValidIntervalMs = serverProperties
         .getLong(SERVER_LEADER_COMPLETE_STATE_CHECK_IN_FOLLOWER_VALID_INTERVAL_MS, TimeUnit.MINUTES.toMillis(5));
+    /*
+     * Default OFF: this gate (when enabled) blocks the catch-up VT RTS shortcut for hybrid
+     * followers that have not seen a recent leader-complete signal. It is opt-in because the
+     * pre-existing un-gated behavior is the long-standing production default and many tests
+     * exercise it without simulating leader-complete heartbeats. Operators who hit the post-
+     * blob-transfer regression described on SERVER_REQUIRE_LEADER_COMPLETE_FOR_CATCH_UP_VT_RTS
+     * should turn this on per cluster.
+     */
     requireLeaderCompleteForCatchUpVtRts =
-        serverProperties.getBoolean(SERVER_REQUIRE_LEADER_COMPLETE_FOR_CATCH_UP_VT_RTS, true);
+        serverProperties.getBoolean(SERVER_REQUIRE_LEADER_COMPLETE_FOR_CATCH_UP_VT_RTS, false);
     consumerPoolStrategyType = KafkaConsumerServiceDelegator.ConsumerPoolStrategyType.valueOf(
         serverProperties.getString(
             SERVER_CONSUMER_POOL_ALLOCATION_STRATEGY,

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/config/VeniceServerConfig.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/config/VeniceServerConfig.java
@@ -190,6 +190,7 @@ import static com.linkedin.venice.ConfigKeys.SERVER_RECORD_LEVEL_METRICS_WHEN_BO
 import static com.linkedin.venice.ConfigKeys.SERVER_RECORD_LEVEL_TIMESTAMP_ENABLED;
 import static com.linkedin.venice.ConfigKeys.SERVER_REMOTE_CONSUMER_CONFIG_PREFIX;
 import static com.linkedin.venice.ConfigKeys.SERVER_REMOTE_INGESTION_REPAIR_SLEEP_INTERVAL_SECONDS;
+import static com.linkedin.venice.ConfigKeys.SERVER_REQUIRE_LEADER_COMPLETE_FOR_CATCH_UP_VT_RTS;
 import static com.linkedin.venice.ConfigKeys.SERVER_RESET_ERROR_REPLICA_ENABLED;
 import static com.linkedin.venice.ConfigKeys.SERVER_REST_SERVICE_EPOLL_ENABLED;
 import static com.linkedin.venice.ConfigKeys.SERVER_REST_SERVICE_STORAGE_THREAD_NUM;
@@ -619,6 +620,7 @@ public class VeniceServerConfig extends VeniceClusterConfig {
   private final boolean uniqueIngestedKeyCountHllEnabled;
   private final int uniqueIngestedKeyCountHllLog2K;
   private final long leaderCompleteStateCheckInFollowerValidIntervalMs;
+  private final boolean requireLeaderCompleteForCatchUpVtRts;
   private final boolean stuckConsumerRepairEnabled;
   private final int stuckConsumerRepairIntervalSecond;
   private final int stuckConsumerDetectionRepairThresholdSecond;
@@ -1089,6 +1091,8 @@ public class VeniceServerConfig extends VeniceClusterConfig {
         serverProperties.getInt(SERVER_NON_EXISTING_TOPIC_CHECK_RETRY_INTERNAL_SECOND, 60); // 1min
     leaderCompleteStateCheckInFollowerValidIntervalMs = serverProperties
         .getLong(SERVER_LEADER_COMPLETE_STATE_CHECK_IN_FOLLOWER_VALID_INTERVAL_MS, TimeUnit.MINUTES.toMillis(5));
+    requireLeaderCompleteForCatchUpVtRts =
+        serverProperties.getBoolean(SERVER_REQUIRE_LEADER_COMPLETE_FOR_CATCH_UP_VT_RTS, true);
     consumerPoolStrategyType = KafkaConsumerServiceDelegator.ConsumerPoolStrategyType.valueOf(
         serverProperties.getString(
             SERVER_CONSUMER_POOL_ALLOCATION_STRATEGY,
@@ -1947,6 +1951,10 @@ public class VeniceServerConfig extends VeniceClusterConfig {
 
   public long getLeaderCompleteStateCheckInFollowerValidIntervalMs() {
     return leaderCompleteStateCheckInFollowerValidIntervalMs;
+  }
+
+  public boolean isRequireLeaderCompleteForCatchUpVtRts() {
+    return requireLeaderCompleteForCatchUpVtRts;
   }
 
   public boolean isStuckConsumerRepairEnabled() {

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTask.java
@@ -2440,20 +2440,20 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
          */
         if (isCurrentVersion.getAsBoolean() || Utils.isFutureVersionReady(versionTopic.getName(), storeRepository)) {
           /*
-           * Optional leader-complete gate (default ON, controlled by
+           * Optional leader-complete gate (default OFF — opt-in per cluster, controlled by
            * server.require.leader.complete.for.catch.up.vt.rts).
            *
-           * Without this gate, a hybrid follower whose local VT is at-or-past the live VT end at
-           * this exact moment is marked READY_TO_SERVE even when the leader has not signalled
-           * completion. Post-blob-transfer this produces a measurable artifact: the per-record
-           * OTel metric Venice.Server.Ingestion.Replication.Record.Delay starts tagging records
-           * ready_to_serve while they still carry stale producer timestamps from the donor's
-           * pre-bootstrap RT replay window, polluting the SLI.
+           * When enabled: a hybrid follower whose local VT is at-or-past the live VT end at this
+           * exact moment is only marked READY_TO_SERVE if the leader has signalled completion
+           * recently. Post-blob-transfer the un-gated path produces a measurable artifact —
+           * Venice.Server.Ingestion.Replication.Record.Delay starts tagging records with the
+           * Replica.State=ready_to_serve dimension while they still carry stale producer
+           * timestamps from the donor's pre-bootstrap RT replay window, polluting the SLI.
            *
-           * Operators who hit the original Helix-rebalance edge case described above (no leader
-           * exists to send leader-complete heartbeats; cluster could end up with zero online
-           * replicas) can disable this gate to restore the pre-existing relax-completion
-           * behavior by setting the config to false.
+           * Default OFF preserves the pre-existing relax-completion behavior (which exists
+           * specifically to cover the Helix-rebalance edge case described above — no leader to
+           * send leader-complete heartbeats; cluster could end up with zero online replicas).
+           * Operators who hit the post-blob-transfer regression flip this on per cluster.
            */
           if (getServerConfig().isRequireLeaderCompleteForCatchUpVtRts() && isHybridFollower(pcs)
               && !isLeaderCompleteSignalRecent(pcs)) {

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTask.java
@@ -2391,20 +2391,24 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
   }
 
   @Override
-  protected void reportIfCatchUpVersionTopicOffset(PartitionConsumptionState pcs) {
+  protected void reportIfCatchUpVersionTopicOffset(PartitionConsumptionState pcs, boolean forceCacheRefresh) {
     if (pcs.isHybrid() && pcs.isEndOfPushReceived() && !isDaVinciClient() && pcs.isLatchCreated()
         && !pcs.isLatchReleased()) {
-      /*
-       * Force-evict the cached latest-position before measuring. Without this,
-       * getLatestPositionCached inside measureLagWithCallToPubSub can return a value up to
-       * server.source.topic.offset.check.interval.ms stale (default 60s), making lag <= 0
-       * evaluate as "caught up" while there are actually pending records on the wire — common
-       * after a blob-transfer bootstrap where the cache has not seen any read-traffic on this
-       * partition yet on the new replica. The cost is one extra broker round-trip on the next
-       * read; acceptable because this method only runs while the latch is held (a one-time-per-
-       * partition transition window).
-       */
-      getTopicManager(localKafkaServer).invalidatePartitionPositionCache(pcs.getReplicaTopicPartition());
+      if (forceCacheRefresh) {
+        /*
+         * Force-evict the cached latest-position before measuring. Without this,
+         * getLatestPositionCached inside measureLagWithCallToPubSub can return a value up to
+         * server.source.topic.offset.check.interval.ms stale (default 60s), making lag <= 0
+         * evaluate as "caught up" while there are actually pending records on the wire — common
+         * after a blob-transfer bootstrap where the cache has not seen any read-traffic on this
+         * partition yet on the new replica. The cost is one extra broker round-trip on the next
+         * read; only safe to do here from one-time-per-partition entry points (e.g.,
+         * validateAndSubscribePartition). Per-record callers must NOT force a refresh — the
+         * latch-held window can hold many thousands of records and forcing a round-trip on each
+         * would be a serious regression.
+         */
+        getTopicManager(localKafkaServer).invalidatePartitionPositionCache(pcs.getReplicaTopicPartition());
+      }
 
       long lag = measureLagWithCallToPubSub(
           localKafkaServer,

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTask.java
@@ -2394,6 +2394,18 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
   protected void reportIfCatchUpVersionTopicOffset(PartitionConsumptionState pcs) {
     if (pcs.isHybrid() && pcs.isEndOfPushReceived() && !isDaVinciClient() && pcs.isLatchCreated()
         && !pcs.isLatchReleased()) {
+      /*
+       * Force-evict the cached latest-position before measuring. Without this,
+       * getLatestPositionCached inside measureLagWithCallToPubSub can return a value up to
+       * server.source.topic.offset.check.interval.ms stale (default 60s), making lag <= 0
+       * evaluate as "caught up" while there are actually pending records on the wire — common
+       * after a blob-transfer bootstrap where the cache has not seen any read-traffic on this
+       * partition yet on the new replica. The cost is one extra broker round-trip on the next
+       * read; acceptable because this method only runs while the latch is held (a one-time-per-
+       * partition transition window).
+       */
+      getTopicManager(localKafkaServer).invalidatePartitionPositionCache(pcs.getReplicaTopicPartition());
+
       long lag = measureLagWithCallToPubSub(
           localKafkaServer,
           pcs.getReplicaTopicPartition(),
@@ -2423,11 +2435,42 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
          * the rebalance.
          */
         if (isCurrentVersion.getAsBoolean() || Utils.isFutureVersionReady(versionTopic.getName(), storeRepository)) {
+          /*
+           * Optional leader-complete gate (default ON, controlled by
+           * server.require.leader.complete.for.catch.up.vt.rts).
+           *
+           * Without this gate, a hybrid follower whose local VT is at-or-past the live VT end at
+           * this exact moment is marked READY_TO_SERVE even when the leader has not signalled
+           * completion. Post-blob-transfer this produces a measurable artifact: the per-record
+           * OTel metric Venice.Server.Ingestion.Replication.Record.Delay starts tagging records
+           * ready_to_serve while they still carry stale producer timestamps from the donor's
+           * pre-bootstrap RT replay window, polluting the SLI.
+           *
+           * Operators who hit the original Helix-rebalance edge case described above (no leader
+           * exists to send leader-complete heartbeats; cluster could end up with zero online
+           * replicas) can disable this gate to restore the pre-existing relax-completion
+           * behavior by setting the config to false.
+           */
+          if (getServerConfig().isRequireLeaderCompleteForCatchUpVtRts() && isHybridFollower(pcs)
+              && !isLeaderCompleteSignalRecent(pcs)) {
+            return;
+          }
           pcs.lagHasCaughtUp();
           reportCompleted(pcs, true);
         }
       }
     }
+  }
+
+  /**
+   * Whether the most recent leader-complete heartbeat header observed by this replica is fresh
+   * enough to be treated as authoritative. Mirrors the "leader-complete + recent update" check
+   * used by {@link #checkAndLogIfLagIsAcceptableForHybridStore} for consistency.
+   */
+  private boolean isLeaderCompleteSignalRecent(PartitionConsumptionState pcs) {
+    return pcs.isLeaderCompleted()
+        && (System.currentTimeMillis() - pcs.getLastLeaderCompleteStateUpdateInMs()) <= getServerConfig()
+            .getLeaderCompleteStateCheckInFollowerValidIntervalMs();
   }
 
   /**

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
@@ -1350,12 +1350,9 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
       boolean shouldLogLag);
 
   /**
-   * Check if the ingestion progress has reached to the end of the version topic. This is currently only
-   * used {@link LeaderFollowerStoreIngestionTask}.
-   */
-  /**
    * Check whether the local VT has been fully consumed and, if so, drive the safeguard-latch
-   * release / report-completed dance for hybrid followers.
+   * release / report-completed dance for hybrid followers. Currently only implemented by
+   * {@link LeaderFollowerStoreIngestionTask}.
    *
    * @param partitionConsumptionState the replica's PCS.
    * @param forceCacheRefresh when {@code true}, implementations MUST evict the cached latest

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
@@ -1353,7 +1353,24 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
    * Check if the ingestion progress has reached to the end of the version topic. This is currently only
    * used {@link LeaderFollowerStoreIngestionTask}.
    */
-  protected abstract void reportIfCatchUpVersionTopicOffset(PartitionConsumptionState partitionConsumptionState);
+  /**
+   * Check whether the local VT has been fully consumed and, if so, drive the safeguard-latch
+   * release / report-completed dance for hybrid followers.
+   *
+   * @param partitionConsumptionState the replica's PCS.
+   * @param forceCacheRefresh when {@code true}, implementations MUST evict the cached latest
+   *                          partition position before measuring lag so the lag check sees a
+   *                          fresh broker-side value. Pass {@code true} from one-time-per-
+   *                          partition entry points (e.g., {@code validateAndSubscribePartition})
+   *                          where a stale cache would cause a wrong "caught up" decision and
+   *                          the broker round-trip cost is bounded. Pass {@code false} from
+   *                          per-record callers where the cache is acceptable and a forced
+   *                          refresh would impose a round-trip on every record consumed during
+   *                          the latch-held catch-up window.
+   */
+  protected abstract void reportIfCatchUpVersionTopicOffset(
+      PartitionConsumptionState partitionConsumptionState,
+      boolean forceCacheRefresh);
 
   /**
    * This function will produce a pair of consumer record and a it's derived produced record to the writer buffers
@@ -2855,7 +2872,12 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
     }
 
     checkConsumptionStateWhenStart(offsetRecord, newPartitionConsumptionState);
-    reportIfCatchUpVersionTopicOffset(newPartitionConsumptionState);
+    /*
+     * SUBSCRIBE-time path: pass forceCacheRefresh=true so the lag check sees a fresh latest-
+     * position from the broker. This is a one-time-per-partition transition; the round-trip
+     * cost is bounded.
+     */
+    reportIfCatchUpVersionTopicOffset(newPartitionConsumptionState, true);
     versionedIngestionStats.recordSubscribePrepLatency(
         storeName,
         versionNumber,
@@ -3367,7 +3389,14 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
       }
       partitionConsumptionState.incrementProcessedRecordSizeSinceLastSync(recordSize);
     }
-    reportIfCatchUpVersionTopicOffset(partitionConsumptionState);
+    /*
+     * Per-record path: pass forceCacheRefresh=false. The latch-held catch-up window can hold many
+     * thousands of records; forcing a broker round-trip on each one would be a serious regression.
+     * The cached latest position (TTL-bounded by server.source.topic.offset.check.interval.ms)
+     * is acceptable here because the SUBSCRIBE-time call already primed the cache with a fresh
+     * value, and the leader-complete gate (when enabled) protects against firing too early.
+     */
+    reportIfCatchUpVersionTopicOffset(partitionConsumptionState, false);
 
     long syncBytesInterval = getSyncBytesInterval(partitionConsumptionState);
     boolean recordsProcessedAboveSyncIntervalThreshold = (syncBytesInterval > 0

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTaskTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTaskTest.java
@@ -2039,8 +2039,10 @@ public class LeaderFollowerStoreIngestionTaskTest {
     setField(spy, "ingestionNotificationDispatcher", mockDispatcher);
 
     /*
-     * Default config: gate is ON (require leader-complete). Default mockVeniceServerConfig
-     * returns false for booleans — explicitly enable the gate to mirror production default.
+     * Production default for server.require.leader.complete.for.catch.up.vt.rts is FALSE
+     * (opt-in per cluster). This test explicitly enables the gate to exercise the gated
+     * path's blocking behavior — without the override the test would fall through to the
+     * un-gated relax-completion behavior covered by testReportIfCatchUpVersionTopicOffsetGateDisabledRestoresOldBehavior.
      */
     when(mockVeniceServerConfig.isRequireLeaderCompleteForCatchUpVtRts()).thenReturn(true);
     when(mockVeniceServerConfig.getLeaderCompleteStateCheckInFollowerValidIntervalMs())

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTaskTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTaskTest.java
@@ -16,6 +16,7 @@ import static org.mockito.Mockito.doCallRealMethod;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
@@ -152,6 +153,7 @@ import org.apache.logging.log4j.core.LoggerContext;
 import org.apache.logging.log4j.core.config.Configuration;
 import org.apache.logging.log4j.core.config.LoggerConfig;
 import org.mockito.ArgumentCaptor;
+import org.mockito.InOrder;
 import org.mockito.internal.verification.VerificationModeFactory;
 import org.mockito.verification.Timeout;
 import org.testng.Assert;
@@ -1952,8 +1954,11 @@ public class LeaderFollowerStoreIngestionTaskTest {
 
   /*
    * Tests below cover the post-blob-transfer fix for reportIfCatchUpVersionTopicOffset:
-   *   1. Cache invalidation before lag measurement (closes stale-cache false positives).
-   *   2. Optional leader-complete gate for hybrid followers (closes the case where the local VT
+   *   1. Cache invalidation before lag measurement on the SUBSCRIBE-time path (forceCacheRefresh=true)
+   *      — closes stale-cache false positives without imposing a per-record broker round-trip.
+   *   2. Cache is NOT invalidated on the per-record path (forceCacheRefresh=false) — protects the
+   *      hot path during the latch-held catch-up window.
+   *   3. Optional leader-complete gate for hybrid followers (closes the case where the local VT
    *      genuinely hasn't moved past the donor's checkpoint and a fresh fetch confirms lag <= 0,
    *      but no leader-complete signal has arrived yet).
    *
@@ -1962,10 +1967,10 @@ public class LeaderFollowerStoreIngestionTaskTest {
    */
 
   @Test
-  public void testReportIfCatchUpVersionTopicOffsetEvictsCacheBeforeLagCheck() throws Exception {
+  public void testReportIfCatchUpVersionTopicOffsetEvictsCacheBeforeLagCheckOnSubscribe() throws Exception {
     setUp();
     LeaderFollowerStoreIngestionTask spy = leaderFollowerStoreIngestionTask;
-    doCallRealMethod().when(spy).reportIfCatchUpVersionTopicOffset(any(PartitionConsumptionState.class));
+    doCallRealMethod().when(spy).reportIfCatchUpVersionTopicOffset(any(PartitionConsumptionState.class), anyBoolean());
 
     IngestionNotificationDispatcher mockDispatcher = mock(IngestionNotificationDispatcher.class);
     setField(spy, "ingestionNotificationDispatcher", mockDispatcher);
@@ -1981,13 +1986,46 @@ public class LeaderFollowerStoreIngestionTaskTest {
     when(pcs.isLeaderCompleted()).thenReturn(true);
     when(pcs.getLastLeaderCompleteStateUpdateInMs()).thenReturn(System.currentTimeMillis());
 
-    spy.reportIfCatchUpVersionTopicOffset(pcs);
+    spy.reportIfCatchUpVersionTopicOffset(pcs, true);
 
     /*
      * Cache invalidation must happen exactly once per call, BEFORE measureLagWithCallToPubSub —
-     * proves the post-blob stale-cache regression is closed.
+     * proves the post-blob stale-cache regression is closed. InOrder verification asserts the
+     * ordering relationship explicitly so a future refactor that reorders the calls is caught.
      */
-    verify(localTopicManager, times(1)).invalidatePartitionPositionCache(tp);
+    InOrder inOrder = inOrder(localTopicManager, spy);
+    inOrder.verify(localTopicManager, times(1)).invalidatePartitionPositionCache(tp);
+    inOrder.verify(spy, times(1)).measureLagWithCallToPubSub(anyString(), eq(tp), any(PubSubPosition.class));
+    inOrder.verifyNoMoreInteractions();
+  }
+
+  @Test
+  public void testReportIfCatchUpVersionTopicOffsetSkipsCacheEvictionOnPerRecordPath() throws Exception {
+    setUp();
+    LeaderFollowerStoreIngestionTask spy = leaderFollowerStoreIngestionTask;
+    doCallRealMethod().when(spy).reportIfCatchUpVersionTopicOffset(any(PartitionConsumptionState.class), anyBoolean());
+
+    IngestionNotificationDispatcher mockDispatcher = mock(IngestionNotificationDispatcher.class);
+    setField(spy, "ingestionNotificationDispatcher", mockDispatcher);
+
+    PartitionConsumptionState pcs = makePcsForCatchUpTest();
+    PubSubTopicPartition tp = pcs.getReplicaTopicPartition();
+
+    TopicManager localTopicManager = mock(TopicManager.class);
+    doReturn(localTopicManager).when(spy).getTopicManager(anyString());
+    doReturn(0L).when(spy).measureLagWithCallToPubSub(anyString(), eq(tp), any(PubSubPosition.class));
+
+    when(pcs.isLeaderCompleted()).thenReturn(true);
+    when(pcs.getLastLeaderCompleteStateUpdateInMs()).thenReturn(System.currentTimeMillis());
+
+    /*
+     * Per-record path: forceCacheRefresh=false. The cached latest position must be reused — a
+     * forced eviction here would cost one broker round-trip per record processed during the
+     * latch-held window, which can hold thousands of records.
+     */
+    spy.reportIfCatchUpVersionTopicOffset(pcs, false);
+
+    verify(localTopicManager, never()).invalidatePartitionPositionCache(any());
     verify(spy, times(1)).measureLagWithCallToPubSub(anyString(), eq(tp), any(PubSubPosition.class));
   }
 
@@ -1995,7 +2033,7 @@ public class LeaderFollowerStoreIngestionTaskTest {
   public void testReportIfCatchUpVersionTopicOffsetGateBlocksWhenLeaderNotCompleted() throws Exception {
     setUp();
     LeaderFollowerStoreIngestionTask spy = leaderFollowerStoreIngestionTask;
-    doCallRealMethod().when(spy).reportIfCatchUpVersionTopicOffset(any(PartitionConsumptionState.class));
+    doCallRealMethod().when(spy).reportIfCatchUpVersionTopicOffset(any(PartitionConsumptionState.class), anyBoolean());
 
     IngestionNotificationDispatcher mockDispatcher = mock(IngestionNotificationDispatcher.class);
     setField(spy, "ingestionNotificationDispatcher", mockDispatcher);
@@ -2017,7 +2055,7 @@ public class LeaderFollowerStoreIngestionTaskTest {
     doReturn(0L).when(spy).measureLagWithCallToPubSub(anyString(), any(), any(PubSubPosition.class));
     doReturn(true).when(spy).isHybridFollower(pcs);
 
-    spy.reportIfCatchUpVersionTopicOffset(pcs);
+    spy.reportIfCatchUpVersionTopicOffset(pcs, true);
 
     /*
      * lag <= 0 path was taken (CATCH_UP_BASE_TOPIC_OFFSET_LAG notification fired) but the leader-
@@ -2031,7 +2069,7 @@ public class LeaderFollowerStoreIngestionTaskTest {
   public void testReportIfCatchUpVersionTopicOffsetGateAllowsWhenLeaderCompleteRecent() throws Exception {
     setUp();
     LeaderFollowerStoreIngestionTask spy = leaderFollowerStoreIngestionTask;
-    doCallRealMethod().when(spy).reportIfCatchUpVersionTopicOffset(any(PartitionConsumptionState.class));
+    doCallRealMethod().when(spy).reportIfCatchUpVersionTopicOffset(any(PartitionConsumptionState.class), anyBoolean());
 
     IngestionNotificationDispatcher mockDispatcher = mock(IngestionNotificationDispatcher.class);
     setField(spy, "ingestionNotificationDispatcher", mockDispatcher);
@@ -2050,7 +2088,7 @@ public class LeaderFollowerStoreIngestionTaskTest {
     doReturn(true).when(spy).isHybridFollower(pcs);
     doReturn(true).when(mockBooleanSupplier).getAsBoolean(); // isCurrentVersion
 
-    spy.reportIfCatchUpVersionTopicOffset(pcs);
+    spy.reportIfCatchUpVersionTopicOffset(pcs, true);
 
     verify(mockDispatcher, times(1)).reportCatchUpVersionTopicOffsetLag(pcs);
     verify(pcs, times(1)).lagHasCaughtUp();
@@ -2060,7 +2098,7 @@ public class LeaderFollowerStoreIngestionTaskTest {
   public void testReportIfCatchUpVersionTopicOffsetGateDisabledRestoresOldBehavior() throws Exception {
     setUp();
     LeaderFollowerStoreIngestionTask spy = leaderFollowerStoreIngestionTask;
-    doCallRealMethod().when(spy).reportIfCatchUpVersionTopicOffset(any(PartitionConsumptionState.class));
+    doCallRealMethod().when(spy).reportIfCatchUpVersionTopicOffset(any(PartitionConsumptionState.class), anyBoolean());
 
     IngestionNotificationDispatcher mockDispatcher = mock(IngestionNotificationDispatcher.class);
     setField(spy, "ingestionNotificationDispatcher", mockDispatcher);
@@ -2080,7 +2118,7 @@ public class LeaderFollowerStoreIngestionTaskTest {
     doReturn(0L).when(spy).measureLagWithCallToPubSub(anyString(), any(), any(PubSubPosition.class));
     doReturn(true).when(mockBooleanSupplier).getAsBoolean();
 
-    spy.reportIfCatchUpVersionTopicOffset(pcs);
+    spy.reportIfCatchUpVersionTopicOffset(pcs, true);
 
     verify(pcs, times(1)).lagHasCaughtUp();
   }

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTaskTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTaskTest.java
@@ -1950,6 +1950,153 @@ public class LeaderFollowerStoreIngestionTaskTest {
     verify(mockDispatcher, times(1)).reportStopped(eq(pcs));
   }
 
+  /*
+   * Tests below cover the post-blob-transfer fix for reportIfCatchUpVersionTopicOffset:
+   *   1. Cache invalidation before lag measurement (closes stale-cache false positives).
+   *   2. Optional leader-complete gate for hybrid followers (closes the case where the local VT
+   *      genuinely hasn't moved past the donor's checkpoint and a fresh fetch confirms lag <= 0,
+   *      but no leader-complete signal has arrived yet).
+   *
+   * Each test stubs reportIfCatchUpVersionTopicOffset to call the real method while everything
+   * else on the LFSIT spy is mocked.
+   */
+
+  @Test
+  public void testReportIfCatchUpVersionTopicOffsetEvictsCacheBeforeLagCheck() throws Exception {
+    setUp();
+    LeaderFollowerStoreIngestionTask spy = leaderFollowerStoreIngestionTask;
+    doCallRealMethod().when(spy).reportIfCatchUpVersionTopicOffset(any(PartitionConsumptionState.class));
+
+    IngestionNotificationDispatcher mockDispatcher = mock(IngestionNotificationDispatcher.class);
+    setField(spy, "ingestionNotificationDispatcher", mockDispatcher);
+
+    PartitionConsumptionState pcs = makePcsForCatchUpTest();
+    PubSubTopicPartition tp = pcs.getReplicaTopicPartition();
+
+    TopicManager localTopicManager = mock(TopicManager.class);
+    doReturn(localTopicManager).when(spy).getTopicManager(anyString());
+    doReturn(0L).when(spy).measureLagWithCallToPubSub(anyString(), eq(tp), any(PubSubPosition.class));
+
+    // Required by the leader-complete gate so it doesn't short-circuit before we observe the call
+    when(pcs.isLeaderCompleted()).thenReturn(true);
+    when(pcs.getLastLeaderCompleteStateUpdateInMs()).thenReturn(System.currentTimeMillis());
+
+    spy.reportIfCatchUpVersionTopicOffset(pcs);
+
+    /*
+     * Cache invalidation must happen exactly once per call, BEFORE measureLagWithCallToPubSub —
+     * proves the post-blob stale-cache regression is closed.
+     */
+    verify(localTopicManager, times(1)).invalidatePartitionPositionCache(tp);
+    verify(spy, times(1)).measureLagWithCallToPubSub(anyString(), eq(tp), any(PubSubPosition.class));
+  }
+
+  @Test
+  public void testReportIfCatchUpVersionTopicOffsetGateBlocksWhenLeaderNotCompleted() throws Exception {
+    setUp();
+    LeaderFollowerStoreIngestionTask spy = leaderFollowerStoreIngestionTask;
+    doCallRealMethod().when(spy).reportIfCatchUpVersionTopicOffset(any(PartitionConsumptionState.class));
+
+    IngestionNotificationDispatcher mockDispatcher = mock(IngestionNotificationDispatcher.class);
+    setField(spy, "ingestionNotificationDispatcher", mockDispatcher);
+
+    /*
+     * Default config: gate is ON (require leader-complete). Default mockVeniceServerConfig
+     * returns false for booleans — explicitly enable the gate to mirror production default.
+     */
+    when(mockVeniceServerConfig.isRequireLeaderCompleteForCatchUpVtRts()).thenReturn(true);
+    when(mockVeniceServerConfig.getLeaderCompleteStateCheckInFollowerValidIntervalMs())
+        .thenReturn(TimeUnit.MINUTES.toMillis(5));
+
+    PartitionConsumptionState pcs = makePcsForCatchUpTest();
+    when(pcs.isLeaderCompleted()).thenReturn(false);
+    when(pcs.getLastLeaderCompleteStateUpdateInMs()).thenReturn(0L);
+
+    TopicManager localTopicManager = mock(TopicManager.class);
+    doReturn(localTopicManager).when(spy).getTopicManager(anyString());
+    doReturn(0L).when(spy).measureLagWithCallToPubSub(anyString(), any(), any(PubSubPosition.class));
+    doReturn(true).when(spy).isHybridFollower(pcs);
+
+    spy.reportIfCatchUpVersionTopicOffset(pcs);
+
+    /*
+     * lag <= 0 path was taken (CATCH_UP_BASE_TOPIC_OFFSET_LAG notification fired) but the leader-
+     * complete gate must short-circuit before lagHasCaughtUp/reportCompleted is invoked.
+     */
+    verify(mockDispatcher, times(1)).reportCatchUpVersionTopicOffsetLag(pcs);
+    verify(pcs, never()).lagHasCaughtUp();
+  }
+
+  @Test
+  public void testReportIfCatchUpVersionTopicOffsetGateAllowsWhenLeaderCompleteRecent() throws Exception {
+    setUp();
+    LeaderFollowerStoreIngestionTask spy = leaderFollowerStoreIngestionTask;
+    doCallRealMethod().when(spy).reportIfCatchUpVersionTopicOffset(any(PartitionConsumptionState.class));
+
+    IngestionNotificationDispatcher mockDispatcher = mock(IngestionNotificationDispatcher.class);
+    setField(spy, "ingestionNotificationDispatcher", mockDispatcher);
+
+    when(mockVeniceServerConfig.isRequireLeaderCompleteForCatchUpVtRts()).thenReturn(true);
+    when(mockVeniceServerConfig.getLeaderCompleteStateCheckInFollowerValidIntervalMs())
+        .thenReturn(TimeUnit.MINUTES.toMillis(5));
+
+    PartitionConsumptionState pcs = makePcsForCatchUpTest();
+    when(pcs.isLeaderCompleted()).thenReturn(true);
+    when(pcs.getLastLeaderCompleteStateUpdateInMs()).thenReturn(System.currentTimeMillis());
+
+    TopicManager localTopicManager = mock(TopicManager.class);
+    doReturn(localTopicManager).when(spy).getTopicManager(anyString());
+    doReturn(0L).when(spy).measureLagWithCallToPubSub(anyString(), any(), any(PubSubPosition.class));
+    doReturn(true).when(spy).isHybridFollower(pcs);
+    doReturn(true).when(mockBooleanSupplier).getAsBoolean(); // isCurrentVersion
+
+    spy.reportIfCatchUpVersionTopicOffset(pcs);
+
+    verify(mockDispatcher, times(1)).reportCatchUpVersionTopicOffsetLag(pcs);
+    verify(pcs, times(1)).lagHasCaughtUp();
+  }
+
+  @Test
+  public void testReportIfCatchUpVersionTopicOffsetGateDisabledRestoresOldBehavior() throws Exception {
+    setUp();
+    LeaderFollowerStoreIngestionTask spy = leaderFollowerStoreIngestionTask;
+    doCallRealMethod().when(spy).reportIfCatchUpVersionTopicOffset(any(PartitionConsumptionState.class));
+
+    IngestionNotificationDispatcher mockDispatcher = mock(IngestionNotificationDispatcher.class);
+    setField(spy, "ingestionNotificationDispatcher", mockDispatcher);
+
+    /*
+     * Operator override: gate disabled. The pre-existing relax-completion behavior (no leader-
+     * complete required) must be restored — covers the original Helix-rebalance edge case.
+     */
+    when(mockVeniceServerConfig.isRequireLeaderCompleteForCatchUpVtRts()).thenReturn(false);
+
+    PartitionConsumptionState pcs = makePcsForCatchUpTest();
+    when(pcs.isLeaderCompleted()).thenReturn(false);
+    when(pcs.getLastLeaderCompleteStateUpdateInMs()).thenReturn(0L);
+
+    TopicManager localTopicManager = mock(TopicManager.class);
+    doReturn(localTopicManager).when(spy).getTopicManager(anyString());
+    doReturn(0L).when(spy).measureLagWithCallToPubSub(anyString(), any(), any(PubSubPosition.class));
+    doReturn(true).when(mockBooleanSupplier).getAsBoolean();
+
+    spy.reportIfCatchUpVersionTopicOffset(pcs);
+
+    verify(pcs, times(1)).lagHasCaughtUp();
+  }
+
+  private PartitionConsumptionState makePcsForCatchUpTest() {
+    PartitionConsumptionState pcs = mock(PartitionConsumptionState.class);
+    when(pcs.isHybrid()).thenReturn(true);
+    when(pcs.isEndOfPushReceived()).thenReturn(true);
+    when(pcs.isLatchCreated()).thenReturn(true);
+    when(pcs.isLatchReleased()).thenReturn(false);
+    when(pcs.getLatestProcessedVtPosition()).thenReturn(PubSubSymbolicPosition.EARLIEST);
+    when(pcs.getReplicaTopicPartition())
+        .thenReturn(new PubSubTopicPartitionImpl(TOPIC_REPOSITORY.getTopic("test-store_v1"), 0));
+    return pcs;
+  }
+
   private static void addStandbyPcs(Map<Integer, PartitionConsumptionState> pcsMap, int partition, long ageMs) {
     PartitionConsumptionState pcs = mock(PartitionConsumptionState.class);
     pcsMap.put(partition, pcs);

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTaskTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTaskTest.java
@@ -6430,7 +6430,7 @@ public abstract class StoreIngestionTaskTest {
   }
 
   /**
-   * Test that {@link LeaderFollowerStoreIngestionTask#reportIfCatchUpVersionTopicOffset(PartitionConsumptionState)}
+   * Test that {@link LeaderFollowerStoreIngestionTask#reportIfCatchUpVersionTopicOffset(PartitionConsumptionState, boolean)}
    * only executes if the latch was created and not released. Previously, it would not check if the latch was created.
    * Latch creation is at the start of ingestion {@link LeaderFollowerPartitionStateModel#onBecomeStandbyFromOffline}
    * only if the version is current, but {@link LeaderFollowerPartitionStateModel} is not tested in this unit test.
@@ -6458,20 +6458,20 @@ public abstract class StoreIngestionTaskTest {
       when(pcs.isLatchCreated()).thenReturn(false);
       when(pcs.isLatchReleased()).thenReturn(false);
       when(pcs.getLatestProcessedVtPosition()).thenReturn(PubSubSymbolicPosition.EARLIEST);
-      storeIngestionTaskUnderTest.reportIfCatchUpVersionTopicOffset(pcs);
+      storeIngestionTaskUnderTest.reportIfCatchUpVersionTopicOffset(pcs, false);
       verify(storeIngestionTaskUnderTest, never())
           .measureLagWithCallToPubSub(anyString(), eq(BAR_TP), any(PubSubPosition.class));
 
       // Case 2: Latch was created, so reportIfCatchUpVersionTopicOffset() should execute
       when(pcs.isLatchCreated()).thenReturn(true);
-      storeIngestionTaskUnderTest.reportIfCatchUpVersionTopicOffset(pcs);
+      storeIngestionTaskUnderTest.reportIfCatchUpVersionTopicOffset(pcs, false);
       verify(storeIngestionTaskUnderTest, times(1))
           .measureLagWithCallToPubSub(anyString(), eq(BAR_TP), any(PubSubPosition.class));
 
       // Case 3: Latch was created and released, so reportIfCatchUpVersionTopicOffset() shouldn't do anything
       when(pcs.isLatchReleased()).thenReturn(true);
 
-      storeIngestionTaskUnderTest.reportIfCatchUpVersionTopicOffset(pcs);
+      storeIngestionTaskUnderTest.reportIfCatchUpVersionTopicOffset(pcs, false);
       verify(storeIngestionTaskUnderTest, times(1))
           .measureLagWithCallToPubSub(anyString(), eq(BAR_TP), any(PubSubPosition.class));
     }, AA_OFF);

--- a/internal/venice-common/src/main/java/com/linkedin/venice/ConfigKeys.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/ConfigKeys.java
@@ -2784,6 +2784,21 @@ public class ConfigKeys {
       "server.leader.complete.state.check.in.follower.valid.interval.ms";
 
   /**
+   * Gate for the catch-up version-topic-offset RTS shortcut. When {@code true} (default), a hybrid
+   * follower that is caught up to the local version topic via
+   * {@code reportIfCatchUpVersionTopicOffset} (LeaderFollowerStoreIngestionTask) is only marked
+   * READY_TO_SERVE if the most recent leader-complete heartbeat header has been observed within
+   * {@link #SERVER_LEADER_COMPLETE_STATE_CHECK_IN_FOLLOWER_VALID_INTERVAL_MS}. This prevents the
+   * post-blob-transfer regression where a fresh follower that catches up to an idle local VT gets
+   * promoted to READY_TO_SERVE before any leader-complete signal arrives, causing the per-record
+   * Replica.State OTel metric to tag stale records as ready_to_serve. When {@code false}, the
+   * pre-existing behavior is restored (RTS may be reported without leader-complete, matching the
+   * Helix-rebalance edge case the original code documented).
+   */
+  public static final String SERVER_REQUIRE_LEADER_COMPLETE_FOR_CATCH_UP_VT_RTS =
+      "server.require.leader.complete.for.catch.up.vt.rts";
+
+  /**
    * Whether to enable stuck consumer repair in Server.
    */
   public static final String SERVER_STUCK_CONSUMER_REPAIR_ENABLED = "server.stuck.consumer.repair.enabled";

--- a/internal/venice-common/src/main/java/com/linkedin/venice/ConfigKeys.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/ConfigKeys.java
@@ -2784,16 +2784,19 @@ public class ConfigKeys {
       "server.leader.complete.state.check.in.follower.valid.interval.ms";
 
   /**
-   * Gate for the catch-up version-topic-offset RTS shortcut. When {@code true} (default), a hybrid
-   * follower that is caught up to the local version topic via
-   * {@code reportIfCatchUpVersionTopicOffset} (LeaderFollowerStoreIngestionTask) is only marked
-   * READY_TO_SERVE if the most recent leader-complete heartbeat header has been observed within
+   * Gate for the catch-up version-topic-offset RTS shortcut. When {@code true}, a hybrid follower
+   * that is caught up to the local version topic via {@code reportIfCatchUpVersionTopicOffset}
+   * (LeaderFollowerStoreIngestionTask) is only marked READY_TO_SERVE if the most recent leader-
+   * complete heartbeat header has been observed within
    * {@link #SERVER_LEADER_COMPLETE_STATE_CHECK_IN_FOLLOWER_VALID_INTERVAL_MS}. This prevents the
    * post-blob-transfer regression where a fresh follower that catches up to an idle local VT gets
-   * promoted to READY_TO_SERVE before any leader-complete signal arrives, causing the per-record
-   * Replica.State OTel metric to tag stale records as ready_to_serve. When {@code false}, the
-   * pre-existing behavior is restored (RTS may be reported without leader-complete, matching the
-   * Helix-rebalance edge case the original code documented).
+   * promoted to READY_TO_SERVE before any leader-complete signal arrives, causing the
+   * Replica.State dimension on the metric Venice.Server.Ingestion.Replication.Record.Delay to tag
+   * stale records as ready_to_serve. The default is {@code false} (pre-existing un-gated behavior
+   * preserved); operators who hit the post-blob-transfer regression should turn it on per cluster.
+   * The original Helix-rebalance edge case the relax-completion path was written for (no leader
+   * exists to send leader-complete heartbeats; cluster could end up with zero online replicas)
+   * remains covered by the default-off behavior.
    */
   public static final String SERVER_REQUIRE_LEADER_COMPLETE_FOR_CATCH_UP_VT_RTS =
       "server.require.leader.complete.for.catch.up.vt.rts";

--- a/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/manager/TopicManager.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/manager/TopicManager.java
@@ -990,6 +990,21 @@ public class TopicManager implements Closeable {
   }
 
   /**
+   * Invalidate the latest-position and earliest-position cache entries for one specific
+   * topic-partition. The next call to {@link #getLatestPositionCached(PubSubTopicPartition)} will
+   * synchronously fetch a fresh value from the broker.
+   *
+   * <p>Use this when an authoritative end-position is required at decision time (e.g., to confirm
+   * "we are caught up to live VT") and the caller cannot tolerate a value up to
+   * {@code server.source.topic.offset.check.interval.ms} stale (default 60s). Each call results in
+   * one extra broker round-trip on the next read, so prefer the cached path when the staleness is
+   * acceptable.
+   */
+  public void invalidatePartitionPositionCache(PubSubTopicPartition pubSubTopicPartition) {
+    topicMetadataFetcher.invalidateKey(pubSubTopicPartition);
+  }
+
+  /**
    * Prefetch and cache the latest offset for the given topic-partition.
    * @param pubSubTopicPartition the topic-partition to prefetch and cache the latest offset for
    */


### PR DESCRIPTION
## Summary

Two narrow fixes for a regression observed on a hybrid AA store after Helix `LOAD_REBALANCE` + blob-transfer bootstrap, where post-blob followers were marked READY_TO_SERVE before any leader-complete heartbeat arrived. The replicas then served reads while the per-record `Venice.Server.Ingestion.Replication.Record.Delay` OTel metric tagged records `ready_to_serve` with stale producer timestamps from the donor's pre-bootstrap RT replay window, polluting the SLI dashboard.

> ### Relationship to the companion PR #2773
>
> This PR fixes **what actually fired in production** — the `reportIfCatchUpVersionTopicOffset` path inside the running JVM, observable as the `Reported CATCH_UP_BASE_TOPIC_OFFSET_LAG` log entry on every affected replica.
>
> The companion PR **#2773** is a **defense-in-depth fix for an adjacent path** — the *fast-RTS* code (`checkFastReadyToServeForReplica` → `checkFastReadyToServeWithPreviousTimeLag`). That path was **not** the trigger in the captured incident (the `previouslyReadyToServe` clear from #2715 successfully short-circuited it), but the donor's `heartbeatTimestamp` / `lastCheckpointTimestamp` are still persisted to disk verbatim during blob transfer. If a JVM crashes between disk-persist and the SIT-side in-memory clear, restart re-reads the donor record and the heartbeat-INVALID early-return is the only remaining barrier. #2773 hardens that crash-restart window by clearing the donor-clock fields at every observable persistence point.
>
> **Both PRs are independent** — they touch different methods, fix different classes of artifact, and can land in either order. This PR is the **load-bearing production fix**; #2773 is **belt-and-suspenders** for the persistence-window variant.

## Root cause

Bug location: `LeaderFollowerStoreIngestionTask.reportIfCatchUpVersionTopicOffset`.

1. It reads the live VT end-position via `TopicManager.getLatestPositionCached`, which can return a value up to `server.source.topic.offset.check.interval.ms` stale (**default 60s**). On a fresh post-blob replica that has not seen any read traffic, the cache often had no entry or a pre-bootstrap value, so `lag <= 0` evaluated as "caught up" while records were actually pending on the wire.

2. After confirming `lag <= 0`, the method calls `pcs.lagHasCaughtUp() + reportCompleted(force=true)` **without any leader-complete gating** on hybrid followers.

Captured timeline on one partition (sub-second precision, single contiguous JVM lifetime — no crash):
```
T+0      blob-transfer-bootstrap completes
T+10ms   PCS reinitialized; lagCaughtUp=false, leaderCompleteState=LEADER_NOT_COMPLETED
T+38ms   Reported CATCH_UP_BASE_TOPIC_OFFSET_LAG               <- reportIfCatchUpVersionTopicOffset fires
T+59ms   Reported COMPLETED                                    <- replica marked RTS,
                                                                   leaderCompleteState STILL LEADER_NOT_COMPLETED
T+431ms  LeaderCompleteState changed NOT_COMPLETED -> COMPLETED  (372ms after the replica was marked RTS)
```

## Fixes in this PR

### 1. Cache eviction before lag measurement (SUBSCRIBE-time path only)

- Expose `TopicManager.invalidatePartitionPositionCache(PubSubTopicPartition)`. Previously this was only reachable as the heavy `invalidateCache(PubSubTopic)` which evicts every partition of the topic.
- `reportIfCatchUpVersionTopicOffset` gains a `forceCacheRefresh` parameter:
  - **SUBSCRIBE-time call** (`validateAndSubscribePartition`) passes `true` → invalidates the partition's cache entry before `measureLagWithCallToPubSub` so the next read is a fresh broker round-trip. One-time-per-partition; cost is bounded.
  - **Per-record call** (`processConsumerRecord`) passes `false` → reuses the cached value. The latch-held catch-up window can hold thousands of records; forcing a broker round-trip per record would be a serious regression.
- **Closes the stale-cache false-positive case**, the primary contributor to the observed spike.

### 2. Optional leader-complete gate

- New config `server.require.leader.complete.for.catch.up.vt.rts` (**default `false` — opt-in**).
- When enabled: `reportIfCatchUpVersionTopicOffset` on a hybrid follower additionally requires the most recent leader-complete heartbeat header to be observed within `server.leader.complete.state.check.in.follower.valid.interval.ms` (default 5 min) — same window the existing `checkAndLogIfLagIsAcceptableForHybridStore` uses.
- When disabled (default): pre-existing relax-completion behavior is preserved. The original Helix-rebalance edge case the comment in this method describes (no leader exists to send leader-complete heartbeats; cluster could end up with zero online replicas) is unaffected.
- **Closes the genuinely-quiet-VT case** where fresh-fetch confirms `lag <= 0` but no leader-complete signal has arrived yet. Operators who hit the post-blob-transfer regression flip this on per cluster.
- *Why default OFF:* many existing tests exercise this RTS path without simulating leader-complete heartbeats; default ON would silently wedge them. Opting in matches how this safeguard should be rolled out — start on cert clusters, validate, expand.

## Why this is a different bug than #2715

`#2715` (already merged) clears the `previouslyReadyToServe` flag in-memory in `completePostTransferPSCUpdated`, which gates the **fast-RTS** path (`checkFastReadyToServeForReplica` → `checkFastReadyToServeWithPreviousTimeLag`). That fix works correctly — verified empirically on the running version (no `"will mark the replica ready-to-serve directly"` log fires post-blob).

`reportIfCatchUpVersionTopicOffset` is a **separate** RTS-promotion path that fires in `validateAndSubscribePartition` immediately after `checkConsumptionStateWhenStart`. The `Reported CATCH_UP_BASE_TOPIC_OFFSET_LAG` log is the unique signature that confirms this method (and not fast-RTS) was the path that fired in the captured incident.

## Testing Done

Five new unit tests in `LeaderFollowerStoreIngestionTaskTest`:
- `testReportIfCatchUpVersionTopicOffsetEvictsCacheBeforeLagCheckOnSubscribe` — uses Mockito `InOrder` to assert `invalidatePartitionPositionCache` is called **before** `measureLagWithCallToPubSub` on the SUBSCRIBE-time path.
- `testReportIfCatchUpVersionTopicOffsetSkipsCacheEvictionOnPerRecordPath` — asserts `invalidatePartitionPositionCache` is **never** called when `forceCacheRefresh=false` (the per-record path). Locks down the perf protection.
- `testReportIfCatchUpVersionTopicOffsetGateBlocksWhenLeaderNotCompleted` — gate ON, hybrid follower, `LEADER_NOT_COMPLETED` → `lagHasCaughtUp` NOT called.
- `testReportIfCatchUpVersionTopicOffsetGateAllowsWhenLeaderCompleteRecent` — gate ON, hybrid follower, recent `LEADER_COMPLETED` → `lagHasCaughtUp` called.
- `testReportIfCatchUpVersionTopicOffsetGateDisabledRestoresOldBehavior` — gate OFF (default) → pre-existing behavior, `lagHasCaughtUp` called even with `LEADER_NOT_COMPLETED`.

Existing `testReportIfCatchUpVersionTopicOffset` in `StoreIngestionTaskTest` continues to pass — it asserts the latch-state preconditions, which this fix does not change.

Verified locally: `:clients:da-vinci-client:test --tests testReportIfCatchUpVersionTopicOffset*` passes; `testRecordLevelMetricForCurrentVersion` (the canary that broke when the gate defaulted ON) also passes with the gate default-OFF.

## Out of scope

- The defense-in-depth crash-restart-window fix (donor-clock fields cleared on disk via `clearInheritedDonorState`, etc.) — covered separately by **#2773**.
