### PR TITLE
[controller] Honor per-cluster config for backup version cleanup delay & rollback retention

### DIFF
--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/StoreBackupVersionCleanupService.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/StoreBackupVersionCleanupService.java
@@ -60,13 +60,6 @@ public class StoreBackupVersionCleanupService extends AbstractVeniceService {
   private static final Logger LOGGER = LogManager.getLogger(StoreBackupVersionCleanupService.class);
   private static final ObjectMapper OBJECT_MAPPER = ObjectMapperFactory.getInstance();
 
-  /**
-   * The minimum delay to clean up backup version, and this is used to make sure all the Routers have enough
-   * time to switch to the new promoted version. Configurable via
-   * {@link com.linkedin.venice.ConfigKeys#CONTROLLER_BACKUP_VERSION_MIN_CLEANUP_DELAY_MS}.
-   */
-  private final long minBackupVersionCleanupDelay;
-
   private final VeniceHelixAdmin admin;
   private final VeniceControllerMultiClusterConfig multiClusterConfig;
   private final Set<String> allClusters;
@@ -74,7 +67,6 @@ public class StoreBackupVersionCleanupService extends AbstractVeniceService {
   private final long sleepInterval;
   private final long defaultBackupVersionRetentionMs;
   private static long waitTimeDeleteRepushSourceVersion = TimeUnit.HOURS.toMillis(1);
-  private final long rolledBackVersionRetentionMs;
   private final AtomicBoolean stop = new AtomicBoolean(false);
 
   private final Map<String, StoreBackupVersionCleanupServiceStats> clusterNameCleanupStatsMap =
@@ -104,9 +96,6 @@ public class StoreBackupVersionCleanupService extends AbstractVeniceService {
     this.cleanupThread = new Thread(new StoreBackupVersionCleanupTask(), "StoreBackupVersionCleanupTask");
     this.sleepInterval = multiClusterConfig.getBackupVersionCleanupSleepMs();
     this.defaultBackupVersionRetentionMs = multiClusterConfig.getBackupVersionDefaultRetentionMs();
-    this.minBackupVersionCleanupDelay = multiClusterConfig.getBackupVersionMinCleanupDelayMs();
-    this.rolledBackVersionRetentionMs =
-        Math.max(multiClusterConfig.getRolledBackVersionRetentionMs(), this.minBackupVersionCleanupDelay);
     this.time = time;
     this.metricsRepository = metricsRepository;
     allClusters.forEach(clusterName -> {
@@ -150,8 +139,9 @@ public class StoreBackupVersionCleanupService extends AbstractVeniceService {
     waitTimeDeleteRepushSourceVersion = waitTime;
   }
 
-  long getRolledBackVersionRetentionMs() {
-    return rolledBackVersionRetentionMs;
+  long getRolledBackVersionRetentionMs(String clusterName) {
+    VeniceControllerClusterConfig clusterConfig = multiClusterConfig.getControllerConfig(clusterName);
+    return Math.max(clusterConfig.getRolledBackVersionRetentionMs(), clusterConfig.getBackupVersionMinCleanupDelayMs());
   }
 
   CloseableHttpAsyncClient getHttpAsyncClient() {
@@ -273,6 +263,9 @@ public class StoreBackupVersionCleanupService extends AbstractVeniceService {
       return false;
     }
 
+    long minBackupVersionCleanupDelay =
+        multiClusterConfig.getControllerConfig(clusterName).getBackupVersionMinCleanupDelayMs();
+
     // Rolled-back versions have their own retention (default 24h), independent of the normal backup retention.
     // Check this before the standard readiness gate since a rolled-back version may be the only non-current version.
     boolean rolledBackCleaned = cleanupRolledBackVersions(store, clusterName, versions);
@@ -282,7 +275,7 @@ public class StoreBackupVersionCleanupService extends AbstractVeniceService {
         admin.getBackupVersionDefaultRetentionMs(),
         time,
         currentVersion,
-        this.minBackupVersionCleanupDelay)) {
+        minBackupVersionCleanupDelay)) {
       // not ready to clean up backup versions yet, update the backup version ideal state to use 2 replicas after
       // minimal delay
       if (multiClusterConfig.getControllerConfig(clusterName).isBackupVersionReplicaReductionEnabled()) {
@@ -427,6 +420,7 @@ public class StoreBackupVersionCleanupService extends AbstractVeniceService {
    * a Version schema change.
    */
   boolean cleanupRolledBackVersions(Store store, String clusterName, List<Version> versions) {
+    long rolledBackVersionRetentionMs = getRolledBackVersionRetentionMs(clusterName);
     if (time.getMilliseconds() <= store.getLatestVersionPromoteToCurrentTimestamp() + rolledBackVersionRetentionMs) {
       return false;
     }

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceHelixAdmin.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceHelixAdmin.java
@@ -4608,7 +4608,7 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
         store,
         backupStrategy,
         minNumberOfStoreVersionsToPreserve,
-        multiClusterConfigs.getBackupVersionMinCleanupDelayMs(),
+        multiClusterConfigs.getControllerConfig(clusterName).getBackupVersionMinCleanupDelayMs(),
         System.currentTimeMillis());
   }
 
@@ -4657,7 +4657,7 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
         clusterName,
         storeName,
         store,
-        multiClusterConfigs.getRolledBackVersionRetentionMs(),
+        multiClusterConfigs.getControllerConfig(clusterName).getRolledBackVersionRetentionMs(),
         System.currentTimeMillis());
   }
 
@@ -4724,8 +4724,8 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
       // Include rollback-origin versions whose retention window has elapsed. retrieveVersionsToDelete
       // deliberately skips ROLLED_BACK (handled by StoreBackupVersionCleanupService), but once past
       // retention we can reclaim them at SOP as well.
-      long rolledBackRetentionExpiresAt =
-          store.getLatestVersionPromoteToCurrentTimestamp() + multiClusterConfigs.getRolledBackVersionRetentionMs();
+      long rolledBackRetentionExpiresAt = store.getLatestVersionPromoteToCurrentTimestamp()
+          + multiClusterConfigs.getControllerConfig(clusterName).getRolledBackVersionRetentionMs();
       if (System.currentTimeMillis() > rolledBackRetentionExpiresAt) {
         int currentVersion = store.getCurrentVersion();
         for (Version v: store.getVersions()) {
@@ -4743,7 +4743,8 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
       }
 
       // Skip if within min cleanup delay; StoreBackupVersionCleanupService will pick it up later.
-      long minBackupVersionCleanupDelay = multiClusterConfigs.getBackupVersionMinCleanupDelayMs();
+      long minBackupVersionCleanupDelay =
+          multiClusterConfigs.getControllerConfig(clusterName).getBackupVersionMinCleanupDelayMs();
       long minRetentionThreshold = store.getLatestVersionPromoteToCurrentTimestamp() + minBackupVersionCleanupDelay;
       if (System.currentTimeMillis() <= minRetentionThreshold) {
         LOGGER.info(

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceParentHelixAdmin.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceParentHelixAdmin.java
@@ -1849,7 +1849,7 @@ public class VeniceParentHelixAdmin implements Admin {
             clusterName,
             storeName,
             store,
-            getMultiClusterConfigs().getRolledBackVersionRetentionMs(),
+            getMultiClusterConfigs().getControllerConfig(clusterName).getRolledBackVersionRetentionMs(),
             System.currentTimeMillis());
       }
     }

--- a/services/venice-controller/src/test/java/com/linkedin/venice/controller/TestStoreBackupVersionCleanupService.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/controller/TestStoreBackupVersionCleanupService.java
@@ -83,8 +83,8 @@ public class TestStoreBackupVersionCleanupService {
     when(admin.getLiveInstanceMonitor(anyString())).thenReturn(liveInstanceMonitor);
     when(config.getControllerConfig(anyString())).thenReturn(controllerConfig);
     when(config.getBackupVersionDefaultRetentionMs()).thenReturn(DEFAULT_RETENTION_MS);
-    when(config.getBackupVersionMinCleanupDelayMs()).thenReturn(TimeUnit.HOURS.toMillis(1));
-    when(config.getRolledBackVersionRetentionMs()).thenReturn(TimeUnit.HOURS.toMillis(24));
+    when(controllerConfig.getBackupVersionMinCleanupDelayMs()).thenReturn(TimeUnit.HOURS.toMillis(1));
+    when(controllerConfig.getRolledBackVersionRetentionMs()).thenReturn(TimeUnit.HOURS.toMillis(24));
     when(admin.getBackupVersionDefaultRetentionMs()).thenReturn(DEFAULT_RETENTION_MS);
     when(metricsRepository.sensor(anyString(), any())).thenReturn(mock(Sensor.class));
 
@@ -656,10 +656,10 @@ public class TestStoreBackupVersionCleanupService {
             2,
             TimeUnit.HOURS.toMillis(1)));
 
-    // Verify that the service reads the configured delay from VeniceControllerMultiClusterConfig.
+    // Verify that the service reads the configured delay per-cluster from VeniceControllerClusterConfig.
     // With minDelay=2hr the pastMinRetention check fires before anything else:
     // (now - 90min) + 2hr = now + 30min > now → pastMinRetention=false → return false.
-    when(config.getBackupVersionMinCleanupDelayMs()).thenReturn(TimeUnit.HOURS.toMillis(2));
+    when(controllerConfig.getBackupVersionMinCleanupDelayMs()).thenReturn(TimeUnit.HOURS.toMillis(2));
     StoreBackupVersionCleanupService configuredService =
         new StoreBackupVersionCleanupService(admin, config, mockTime, metricsRepository);
     Assert.assertFalse(configuredService.cleanupBackupVersion(storeZeroRetention, CLUSTER_NAME));
@@ -912,7 +912,7 @@ public class TestStoreBackupVersionCleanupService {
   @Test
   public void testRolledBackVersionRetentionIsConfigurable() {
     // Create a service with 1-hour rolled-back retention via config
-    when(config.getRolledBackVersionRetentionMs()).thenReturn(TimeUnit.HOURS.toMillis(1));
+    when(controllerConfig.getRolledBackVersionRetentionMs()).thenReturn(TimeUnit.HOURS.toMillis(1));
     StoreBackupVersionCleanupService customService =
         new StoreBackupVersionCleanupService(admin, config, mockTime, metricsRepository);
 


### PR DESCRIPTION
## Problem Statement

`controller.backup.version.min.cleanup.delay.ms` and `controller.rolled.back.version.retention.ms` are defined per-cluster in `VeniceControllerClusterConfig`, but the cleanup paths read them from the common config via `VeniceControllerMultiClusterConfig` (which delegates to `getCommonConfig()`), silently ignoring per-cluster overrides. Operators who set either config under a specific cluster's section see no effect — the value from the common section wins.

## Solution

Route every cleanup call site through `multiClusterConfigs.getControllerConfig(clusterName).*` so per-cluster values are honored. The `Math.max(rolledBackRetention, minCleanupDelay)` floor that previously lived in the constructor is preserved by computing it per-cluster on demand.

Affected paths:
- `StoreBackupVersionCleanupService` (background cleanup loop): drop cached `minBackupVersionCleanupDelay` and `rolledBackVersionRetentionMs` fields; read both per-cluster inside `cleanupBackupVersion` and `cleanupRolledBackVersions`. New `getRolledBackVersionRetentionMs(clusterName)` helper applies the floor.
- `VeniceHelixAdmin.checkBackupVersionCleanupCapacityForNewPush` — per-cluster `backupVersionMinCleanupDelayMs`.
- `VeniceHelixAdmin.checkRollbackOriginVersionCapacityForNewPush` — per-cluster `rolledBackVersionRetentionMs`.
- `VeniceHelixAdmin.retireOldStoreVersions` (SOP-time deletion path) — both configs per-cluster.
- `VeniceParentHelixAdmin.checkRollbackOriginVersionCapacityForNewPush` — per-cluster `rolledBackVersionRetentionMs`.

The static testable variants of the capacity-check methods are unchanged — they take the resolved `long` values directly.

###  Code changes
- [ ] Added new code behind **a config**. No new configs; existing per-cluster configs `controller.backup.version.min.cleanup.delay.ms` (default 1h) and `controller.rolled.back.version.retention.ms` (default 24h) are now actually honored per-cluster.
- [ ] Introduced new **log lines**. None.

###  **Concurrency-Specific Checks**
- [x] Code has **no race conditions** or **thread safety issues**. Reads from `VeniceControllerMultiClusterConfig` are unchanged in semantics; only the source of the value moved from common to per-cluster.
- [x] Proper **synchronization mechanisms** are used where needed. No new shared state introduced.
- [x] No **blocking calls** inside critical sections.
- [x] Verified **thread-safe collections** are used. No collection changes.
- [x] Validated proper exception handling in multi-threaded code. No exception handling changes.

## How was this PR tested?

- [x] Modified or extended existing tests. `TestStoreBackupVersionCleanupService` mocks moved from multi-cluster `config.*` to per-cluster `controllerConfig.*` for both keys.
- [x] Verified backward compatibility — `TestBackupVersionCleanupCapacityCheck` and `TestRollbackOriginVersionCapacityCheck` continue to pass against the unchanged static helpers.

Verification:
- `./gradlew :services:venice-controller:compileJava :services:venice-controller:compileTestJava` clean.
- `TestStoreBackupVersionCleanupService` — all 21 tests pass.
- `TestBackupVersionCleanupCapacityCheck` — all tests pass.
- `TestRollbackOriginVersionCapacityCheck` — all tests pass.

## Does this PR introduce any user-facing or breaking changes?

- [x] No. Operators who only set these configs under the common section see identical behavior. Operators who previously set per-cluster overrides (which were silently ignored) will now have those overrides take effect — this is the intended fix.