### PR TITLE
[server] Switch follower per-record latency to true RT-entry E2E and tag by source region

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTask.java
@@ -3070,6 +3070,15 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
      * back to producerMetadata.messageTimestamp, preserving today's behavior.
      */
     long messageTimestamp = resolveRecordE2ETimestamp(consumerRecord);
+    /*
+     * Skip emission for malformed/legacy records whose resolved timestamp is non-positive. The
+     * downstream OTel reporter computes delay as `System.currentTimeMillis() - timestamp`, so
+     * forwarding a 0 or negative value would emit a multi-decade delay spike that corrupts the
+     * per-record latency series.
+     */
+    if (messageTimestamp <= 0) {
+      return;
+    }
     boolean isComplete = partitionConsumptionState.isComplete();
     HeartbeatKey cachedKey = partitionConsumptionState.getOrCreateCachedHeartbeatKey(region);
 

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTask.java
@@ -3062,7 +3062,7 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
      */
     String region = isLeader
         ? fallbackRegion
-        : resolveFollowerSourceRegion(consumerRecord, serverConfig.getKafkaClusterIdToAliasMap(), fallbackRegion);
+        : resolveFollowerSourceRegion(consumerRecord, kafkaClusterIdToAliasMap, fallbackRegion);
     /*
      * Prefer the upstream-message timestamp stamped by the leader so the per-record latency metric
      * reflects RT-entry → apply latency. Records produced before that stamping landed (or consumed

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTask.java
@@ -55,6 +55,7 @@ import com.linkedin.venice.guid.GuidUtils;
 import com.linkedin.venice.kafka.protocol.ControlMessage;
 import com.linkedin.venice.kafka.protocol.Delete;
 import com.linkedin.venice.kafka.protocol.KafkaMessageEnvelope;
+import com.linkedin.venice.kafka.protocol.LeaderMetadata;
 import com.linkedin.venice.kafka.protocol.Put;
 import com.linkedin.venice.kafka.protocol.TopicSwitch;
 import com.linkedin.venice.kafka.protocol.Update;
@@ -2276,6 +2277,57 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
   }
 
   /**
+   * Resolves the timestamp the heartbeat-monitoring service should record for an ingested record so
+   * that the per-record nearline latency metric reflects true upstream-RT-entry → apply latency.
+   *
+   * <p>Prefers {@code leaderMetadataFooter.upstreamMessageTimestamp} when populated by the leader
+   * ({@code > 0}). Falls back to {@code producerMetadata.messageTimestamp} for records produced
+   * before the leader-side stamping landed and for records consumed directly from the upstream
+   * (where producerMetadata IS the upstream producer's wall clock). Static + package-private so it
+   * can be unit-tested in isolation.
+   */
+  static long resolveRecordE2ETimestamp(DefaultPubSubMessage consumerRecord) {
+    KafkaMessageEnvelope value = consumerRecord.getValue();
+    if (value == null) {
+      return 0L;
+    }
+    LeaderMetadata leaderMd = value.leaderMetadataFooter;
+    if (leaderMd != null && leaderMd.upstreamMessageTimestamp > 0) {
+      return leaderMd.upstreamMessageTimestamp;
+    }
+    if (value.producerMetadata != null) {
+      return value.producerMetadata.messageTimestamp;
+    }
+    return 0L;
+  }
+
+  /**
+   * Resolves the source-region label for a follower-side record. In active-active replication a
+   * follower consumes from local VT, but each VT record carries the upstream cluster id stamped by
+   * the leader in {@code leaderMetadataFooter.upstreamKafkaClusterId}. Tagging the per-record
+   * latency metric by the originating fabric (rather than the local-VT URL) lets followers attribute
+   * end-to-end latency to each source region. Falls back to {@code fallbackRegion} for legacy
+   * records without an upstream cluster id or when the id isn't in the alias map. Static +
+   * package-private so it can be unit-tested in isolation.
+   */
+  static String resolveFollowerSourceRegion(
+      DefaultPubSubMessage consumerRecord,
+      Int2ObjectMap<String> kafkaClusterIdToAliasMap,
+      String fallbackRegion) {
+    KafkaMessageEnvelope value = consumerRecord.getValue();
+    if (value != null && value.leaderMetadataFooter != null) {
+      int upstreamClusterId = value.leaderMetadataFooter.upstreamKafkaClusterId;
+      if (upstreamClusterId >= 0 && kafkaClusterIdToAliasMap != null) {
+        String alias = kafkaClusterIdToAliasMap.get(upstreamClusterId);
+        if (alias != null) {
+          return alias;
+        }
+      }
+    }
+    return fallbackRegion;
+  }
+
+  /**
    * Mirrors {@link #sendGlobalRtDivMessage}'s LCVP-sync callback for leaders consuming from a remote VT source in NR
    * VT consumption has no RT DIV state to propagate, so {@link #sendGlobalRtDivMessage} — the normal path that hands
    * the VT DIV to the drainer — is never invoked. Without this callback, the OffsetRecord's latestConsumedVtPosition
@@ -2998,13 +3050,30 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
       return;
     }
 
-    String region =
+    boolean isLeader = partitionConsumptionState.getLeaderFollowerState().equals(LEADER);
+    String fallbackRegion =
         isDaVinciClient() ? serverConfig.getRegionName() : serverConfig.getKafkaClusterUrlToAliasMap().get(pubSubUrl);
-    long messageTimestamp = consumerRecord.getValue().getProducerMetadata().getMessageTimestamp();
+    /*
+     * On a leader, pubSubUrl is the upstream RT URL — fallbackRegion is already the source region.
+     * On a follower, pubSubUrl is the local VT URL, so fallbackRegion would always be local. For
+     * active-active stores we want per-source-region attribution, which is preserved by the leader
+     * in leaderMetadataFooter.upstreamKafkaClusterId — resolveFollowerSourceRegion uses that when
+     * present, otherwise it falls back to local for legacy records.
+     */
+    String region = isLeader
+        ? fallbackRegion
+        : resolveFollowerSourceRegion(consumerRecord, serverConfig.getKafkaClusterIdToAliasMap(), fallbackRegion);
+    /*
+     * Prefer the upstream-message timestamp stamped by the leader so the per-record latency metric
+     * reflects RT-entry → apply latency. Records produced before that stamping landed (or consumed
+     * directly from upstream RT, where producerMetadata IS the upstream producer's clock) fall
+     * back to producerMetadata.messageTimestamp, preserving today's behavior.
+     */
+    long messageTimestamp = resolveRecordE2ETimestamp(consumerRecord);
     boolean isComplete = partitionConsumptionState.isComplete();
     HeartbeatKey cachedKey = partitionConsumptionState.getOrCreateCachedHeartbeatKey(region);
 
-    if (partitionConsumptionState.getLeaderFollowerState().equals(LEADER)) {
+    if (isLeader) {
       hbService.recordLeaderRecordTimestamp(cachedKey, messageTimestamp, isComplete);
     } else {
       hbService.recordFollowerRecordTimestamp(cachedKey, messageTimestamp, isComplete);

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTaskTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTaskTest.java
@@ -3805,4 +3805,112 @@ public class LeaderFollowerStoreIngestionTaskTest {
         .resolveUpstreamMessageTimestamp(consumerRecord, NearlineLatencyTimestampSource.PRODUCER);
     assertEquals(resolved, com.linkedin.venice.writer.LeaderMetadataWrapper.DEFAULT_UPSTREAM_MESSAGE_TIMESTAMP);
   }
+
+  @Test
+  public void testResolveRecordE2ETimestampPrefersUpstreamMessageTimestamp() {
+    long upstreamTime = 1_700_000_000_111L;
+    long producerTime = 1_700_000_000_999L;
+    DefaultPubSubMessage consumerRecord = mock(DefaultPubSubMessage.class);
+    KafkaMessageEnvelope kme = new KafkaMessageEnvelope();
+    kme.producerMetadata = new ProducerMetadata();
+    kme.producerMetadata.messageTimestamp = producerTime;
+    kme.leaderMetadataFooter = new LeaderMetadata();
+    kme.leaderMetadataFooter.upstreamMessageTimestamp = upstreamTime;
+    when(consumerRecord.getValue()).thenReturn(kme);
+
+    assertEquals(LeaderFollowerStoreIngestionTask.resolveRecordE2ETimestamp(consumerRecord), upstreamTime);
+  }
+
+  @Test
+  public void testResolveRecordE2ETimestampFallsBackToProducerWhenUpstreamMissing() {
+    long producerTime = 1_700_000_000_777L;
+    DefaultPubSubMessage consumerRecord = mock(DefaultPubSubMessage.class);
+    KafkaMessageEnvelope kme = new KafkaMessageEnvelope();
+    kme.producerMetadata = new ProducerMetadata();
+    kme.producerMetadata.messageTimestamp = producerTime;
+    kme.leaderMetadataFooter = null;
+    when(consumerRecord.getValue()).thenReturn(kme);
+
+    assertEquals(LeaderFollowerStoreIngestionTask.resolveRecordE2ETimestamp(consumerRecord), producerTime);
+  }
+
+  @Test
+  public void testResolveRecordE2ETimestampFallsBackWhenUpstreamIsSentinel() {
+    long producerTime = 1_700_000_000_555L;
+    DefaultPubSubMessage consumerRecord = mock(DefaultPubSubMessage.class);
+    KafkaMessageEnvelope kme = new KafkaMessageEnvelope();
+    kme.producerMetadata = new ProducerMetadata();
+    kme.producerMetadata.messageTimestamp = producerTime;
+    kme.leaderMetadataFooter = new LeaderMetadata();
+    kme.leaderMetadataFooter.upstreamMessageTimestamp =
+        com.linkedin.venice.writer.LeaderMetadataWrapper.DEFAULT_UPSTREAM_MESSAGE_TIMESTAMP;
+    when(consumerRecord.getValue()).thenReturn(kme);
+
+    assertEquals(LeaderFollowerStoreIngestionTask.resolveRecordE2ETimestamp(consumerRecord), producerTime);
+  }
+
+  @Test
+  public void testResolveFollowerSourceRegionUsesUpstreamClusterId() {
+    Int2ObjectMap<String> idToAlias = new Int2ObjectOpenHashMap<>();
+    idToAlias.put(0, "prod-lva1");
+    idToAlias.put(1, "prod-ltx1");
+    idToAlias.put(2, "prod-lor1");
+
+    DefaultPubSubMessage consumerRecord = mock(DefaultPubSubMessage.class);
+    KafkaMessageEnvelope kme = new KafkaMessageEnvelope();
+    kme.leaderMetadataFooter = new LeaderMetadata();
+    kme.leaderMetadataFooter.upstreamKafkaClusterId = 2;
+    when(consumerRecord.getValue()).thenReturn(kme);
+
+    assertEquals(
+        LeaderFollowerStoreIngestionTask.resolveFollowerSourceRegion(consumerRecord, idToAlias, "prod-lva1"),
+        "prod-lor1");
+  }
+
+  @Test
+  public void testResolveFollowerSourceRegionFallsBackWhenLeaderMetadataMissing() {
+    Int2ObjectMap<String> idToAlias = new Int2ObjectOpenHashMap<>();
+    idToAlias.put(0, "prod-lva1");
+
+    DefaultPubSubMessage consumerRecord = mock(DefaultPubSubMessage.class);
+    KafkaMessageEnvelope kme = new KafkaMessageEnvelope();
+    kme.leaderMetadataFooter = null;
+    when(consumerRecord.getValue()).thenReturn(kme);
+
+    assertEquals(
+        LeaderFollowerStoreIngestionTask.resolveFollowerSourceRegion(consumerRecord, idToAlias, "fallback"),
+        "fallback");
+  }
+
+  @Test
+  public void testResolveFollowerSourceRegionFallsBackWhenClusterIdNotInMap() {
+    Int2ObjectMap<String> idToAlias = new Int2ObjectOpenHashMap<>();
+    idToAlias.put(0, "prod-lva1");
+
+    DefaultPubSubMessage consumerRecord = mock(DefaultPubSubMessage.class);
+    KafkaMessageEnvelope kme = new KafkaMessageEnvelope();
+    kme.leaderMetadataFooter = new LeaderMetadata();
+    kme.leaderMetadataFooter.upstreamKafkaClusterId = 99;
+    when(consumerRecord.getValue()).thenReturn(kme);
+
+    assertEquals(
+        LeaderFollowerStoreIngestionTask.resolveFollowerSourceRegion(consumerRecord, idToAlias, "fallback"),
+        "fallback");
+  }
+
+  @Test
+  public void testResolveFollowerSourceRegionFallsBackWhenClusterIdIsSentinel() {
+    Int2ObjectMap<String> idToAlias = new Int2ObjectOpenHashMap<>();
+    idToAlias.put(0, "prod-lva1");
+
+    DefaultPubSubMessage consumerRecord = mock(DefaultPubSubMessage.class);
+    KafkaMessageEnvelope kme = new KafkaMessageEnvelope();
+    kme.leaderMetadataFooter = new LeaderMetadata();
+    kme.leaderMetadataFooter.upstreamKafkaClusterId = -1;
+    when(consumerRecord.getValue()).thenReturn(kme);
+
+    assertEquals(
+        LeaderFollowerStoreIngestionTask.resolveFollowerSourceRegion(consumerRecord, idToAlias, "fallback"),
+        "fallback");
+  }
 }

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTaskTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTaskTest.java
@@ -3806,51 +3806,49 @@ public class LeaderFollowerStoreIngestionTaskTest {
     assertEquals(resolved, com.linkedin.venice.writer.LeaderMetadataWrapper.DEFAULT_UPSTREAM_MESSAGE_TIMESTAMP);
   }
 
-  @Test
-  public void testResolveRecordE2ETimestampPrefersUpstreamMessageTimestamp() {
-    long upstreamTime = 1_700_000_000_111L;
-    long producerTime = 1_700_000_000_999L;
+  @DataProvider(name = "ResolveRecordE2ETimestampCases")
+  public static Object[][] resolveRecordE2ETimestampCases() {
+    long sentinel = com.linkedin.venice.writer.LeaderMetadataWrapper.DEFAULT_UPSTREAM_MESSAGE_TIMESTAMP;
+    // {description, producerTime, upstreamMessageTimestamp (null = no leaderMetadataFooter), expected}
+    return new Object[][] { { "prefers upstream when > 0", 1_700_000_000_999L, 1_700_000_000_111L, 1_700_000_000_111L },
+        { "falls back to producer when leaderMetadataFooter is missing", 1_700_000_000_777L, null, 1_700_000_000_777L },
+        { "falls back to producer when upstream is sentinel", 1_700_000_000_555L, sentinel, 1_700_000_000_555L } };
+  }
+
+  @Test(dataProvider = "ResolveRecordE2ETimestampCases")
+  public void testResolveRecordE2ETimestamp(
+      String description,
+      long producerTime,
+      Long upstreamMessageTimestamp,
+      long expected) {
     DefaultPubSubMessage consumerRecord = mock(DefaultPubSubMessage.class);
     KafkaMessageEnvelope kme = new KafkaMessageEnvelope();
     kme.producerMetadata = new ProducerMetadata();
     kme.producerMetadata.messageTimestamp = producerTime;
-    kme.leaderMetadataFooter = new LeaderMetadata();
-    kme.leaderMetadataFooter.upstreamMessageTimestamp = upstreamTime;
+    if (upstreamMessageTimestamp != null) {
+      kme.leaderMetadataFooter = new LeaderMetadata();
+      kme.leaderMetadataFooter.upstreamMessageTimestamp = upstreamMessageTimestamp;
+    }
     when(consumerRecord.getValue()).thenReturn(kme);
 
-    assertEquals(LeaderFollowerStoreIngestionTask.resolveRecordE2ETimestamp(consumerRecord), upstreamTime);
+    assertEquals(LeaderFollowerStoreIngestionTask.resolveRecordE2ETimestamp(consumerRecord), expected, description);
   }
 
-  @Test
-  public void testResolveRecordE2ETimestampFallsBackToProducerWhenUpstreamMissing() {
-    long producerTime = 1_700_000_000_777L;
-    DefaultPubSubMessage consumerRecord = mock(DefaultPubSubMessage.class);
-    KafkaMessageEnvelope kme = new KafkaMessageEnvelope();
-    kme.producerMetadata = new ProducerMetadata();
-    kme.producerMetadata.messageTimestamp = producerTime;
-    kme.leaderMetadataFooter = null;
-    when(consumerRecord.getValue()).thenReturn(kme);
-
-    assertEquals(LeaderFollowerStoreIngestionTask.resolveRecordE2ETimestamp(consumerRecord), producerTime);
+  @DataProvider(name = "ResolveFollowerSourceRegionCases")
+  public static Object[][] resolveFollowerSourceRegionCases() {
+    // {description, upstreamClusterId (null = no leaderMetadataFooter), fallbackRegion, expected}
+    return new Object[][] { { "uses upstream cluster id when present and mapped", 2, "prod-lva1", "prod-lor1" },
+        { "falls back when leaderMetadataFooter is missing", null, "fallback", "fallback" },
+        { "falls back when cluster id not in alias map", 99, "fallback", "fallback" },
+        { "falls back when cluster id is sentinel (-1)", -1, "fallback", "fallback" } };
   }
 
-  @Test
-  public void testResolveRecordE2ETimestampFallsBackWhenUpstreamIsSentinel() {
-    long producerTime = 1_700_000_000_555L;
-    DefaultPubSubMessage consumerRecord = mock(DefaultPubSubMessage.class);
-    KafkaMessageEnvelope kme = new KafkaMessageEnvelope();
-    kme.producerMetadata = new ProducerMetadata();
-    kme.producerMetadata.messageTimestamp = producerTime;
-    kme.leaderMetadataFooter = new LeaderMetadata();
-    kme.leaderMetadataFooter.upstreamMessageTimestamp =
-        com.linkedin.venice.writer.LeaderMetadataWrapper.DEFAULT_UPSTREAM_MESSAGE_TIMESTAMP;
-    when(consumerRecord.getValue()).thenReturn(kme);
-
-    assertEquals(LeaderFollowerStoreIngestionTask.resolveRecordE2ETimestamp(consumerRecord), producerTime);
-  }
-
-  @Test
-  public void testResolveFollowerSourceRegionUsesUpstreamClusterId() {
+  @Test(dataProvider = "ResolveFollowerSourceRegionCases")
+  public void testResolveFollowerSourceRegion(
+      String description,
+      Integer upstreamClusterId,
+      String fallbackRegion,
+      String expected) {
     Int2ObjectMap<String> idToAlias = new Int2ObjectOpenHashMap<>();
     idToAlias.put(0, "prod-lva1");
     idToAlias.put(1, "prod-ltx1");
@@ -3858,59 +3856,15 @@ public class LeaderFollowerStoreIngestionTaskTest {
 
     DefaultPubSubMessage consumerRecord = mock(DefaultPubSubMessage.class);
     KafkaMessageEnvelope kme = new KafkaMessageEnvelope();
-    kme.leaderMetadataFooter = new LeaderMetadata();
-    kme.leaderMetadataFooter.upstreamKafkaClusterId = 2;
+    if (upstreamClusterId != null) {
+      kme.leaderMetadataFooter = new LeaderMetadata();
+      kme.leaderMetadataFooter.upstreamKafkaClusterId = upstreamClusterId;
+    }
     when(consumerRecord.getValue()).thenReturn(kme);
 
     assertEquals(
-        LeaderFollowerStoreIngestionTask.resolveFollowerSourceRegion(consumerRecord, idToAlias, "prod-lva1"),
-        "prod-lor1");
-  }
-
-  @Test
-  public void testResolveFollowerSourceRegionFallsBackWhenLeaderMetadataMissing() {
-    Int2ObjectMap<String> idToAlias = new Int2ObjectOpenHashMap<>();
-    idToAlias.put(0, "prod-lva1");
-
-    DefaultPubSubMessage consumerRecord = mock(DefaultPubSubMessage.class);
-    KafkaMessageEnvelope kme = new KafkaMessageEnvelope();
-    kme.leaderMetadataFooter = null;
-    when(consumerRecord.getValue()).thenReturn(kme);
-
-    assertEquals(
-        LeaderFollowerStoreIngestionTask.resolveFollowerSourceRegion(consumerRecord, idToAlias, "fallback"),
-        "fallback");
-  }
-
-  @Test
-  public void testResolveFollowerSourceRegionFallsBackWhenClusterIdNotInMap() {
-    Int2ObjectMap<String> idToAlias = new Int2ObjectOpenHashMap<>();
-    idToAlias.put(0, "prod-lva1");
-
-    DefaultPubSubMessage consumerRecord = mock(DefaultPubSubMessage.class);
-    KafkaMessageEnvelope kme = new KafkaMessageEnvelope();
-    kme.leaderMetadataFooter = new LeaderMetadata();
-    kme.leaderMetadataFooter.upstreamKafkaClusterId = 99;
-    when(consumerRecord.getValue()).thenReturn(kme);
-
-    assertEquals(
-        LeaderFollowerStoreIngestionTask.resolveFollowerSourceRegion(consumerRecord, idToAlias, "fallback"),
-        "fallback");
-  }
-
-  @Test
-  public void testResolveFollowerSourceRegionFallsBackWhenClusterIdIsSentinel() {
-    Int2ObjectMap<String> idToAlias = new Int2ObjectOpenHashMap<>();
-    idToAlias.put(0, "prod-lva1");
-
-    DefaultPubSubMessage consumerRecord = mock(DefaultPubSubMessage.class);
-    KafkaMessageEnvelope kme = new KafkaMessageEnvelope();
-    kme.leaderMetadataFooter = new LeaderMetadata();
-    kme.leaderMetadataFooter.upstreamKafkaClusterId = -1;
-    when(consumerRecord.getValue()).thenReturn(kme);
-
-    assertEquals(
-        LeaderFollowerStoreIngestionTask.resolveFollowerSourceRegion(consumerRecord, idToAlias, "fallback"),
-        "fallback");
+        LeaderFollowerStoreIngestionTask.resolveFollowerSourceRegion(consumerRecord, idToAlias, fallbackRegion),
+        expected,
+        description);
   }
 }

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/ActiveActiveReplicationForHybridTest.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/ActiveActiveReplicationForHybridTest.java
@@ -548,6 +548,15 @@ public class ActiveActiveReplicationForHybridTest extends AbstractMultiRegionTes
       String key3 = "key3";
       String value3 = "value3";
 
+      // Mirror the dc-0 wait above for dc-1: wait until dc-1's controller has registered
+      // version 1 before starting the Samza producer there. Without this, producerInDC1.start()
+      // can race the version-creation propagation from the parent controller and fail with
+      // "Store ... is not initialized with a version yet" on /request_topic.
+      waitForNonDeterministicAssertion(30, TimeUnit.SECONDS, () -> {
+        StoreResponse storeResponse = assertCommand(dc1Client.getStore(storeName));
+        assertEquals(storeResponse.getStore().getCurrentVersion(), 1);
+      });
+
       // Build the SystemProducer with the mock time
       VeniceMultiClusterWrapper childDataCenter1 = childDatacenters.get(1);
       try (VeniceSystemProducer producerInDC1 = new VeniceSystemProducer(

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/ActiveActiveReplicationForHybridTest.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/ActiveActiveReplicationForHybridTest.java
@@ -548,10 +548,12 @@ public class ActiveActiveReplicationForHybridTest extends AbstractMultiRegionTes
       String key3 = "key3";
       String value3 = "value3";
 
-      // Mirror the dc-0 wait above for dc-1: wait until dc-1's controller has registered
-      // version 1 before starting the Samza producer there. Without this, producerInDC1.start()
-      // can race the version-creation propagation from the parent controller and fail with
-      // "Store ... is not initialized with a version yet" on /request_topic.
+      /*
+       * Mirror the dc-0 wait above for dc-1: wait until dc-1's controller has registered
+       * version 1 before starting the Samza producer there. Without this, producerInDC1.start()
+       * can race the version-creation propagation from the parent controller and fail with
+       * "Store ... is not initialized with a version yet" on /request_topic.
+       */
       waitForNonDeterministicAssertion(30, TimeUnit.SECONDS, () -> {
         StoreResponse storeResponse = assertCommand(dc1Client.getStore(storeName));
         assertEquals(storeResponse.getStore().getCurrentVersion(), 1);

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/NearlineE2ELatencyTest.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/NearlineE2ELatencyTest.java
@@ -316,13 +316,15 @@ public class NearlineE2ELatencyTest extends AbstractMultiRegionTest {
      * EVERY fabric's RT — so leaders emit BOTH locality=LOCAL (records from local-fabric RT)
      * AND locality=REMOTE (records from remote-fabric RT).
      *
+     * Followers now also emit per-source-region: trackRecordReceived derives the region from
+     * leaderMetadataFooter.upstreamKafkaClusterId (via kafkaClusterIdToAliasMap) instead of the
+     * local-VT consumption URL, so a follower processing a record whose upstream RT lived in
+     * another fabric tags it locality=REMOTE. We therefore require BOTH LOCAL and REMOTE on
+     * both LEADER and FOLLOWER below.
+     *
      * The write_type and chunking_status dims are filtered to the values driven by the test
      * parameters — points with the wrong combo are ignored, which would itself indicate a bug
      * since this store should only emit one combo.
-     *
-     * NOTE: Followers always emit locality=LOCAL today because they read from local VT only.
-     * If/when followers start emitting per-region (e.g., follower-side cross-region tracking
-     * lands), update this test to also assert (FOLLOWER, REMOTE).
      */
     String expectedWriteType =
         (writeComputeEnabled ? VeniceStoreWriteType.WRITE_COMPUTE : VeniceStoreWriteType.REGULAR).getDimensionValue();
@@ -391,11 +393,18 @@ public class NearlineE2ELatencyTest extends AbstractMultiRegionTest {
           "No LEADER point with (writeType=" + expectedWriteType + ", chunking=" + expectedChunking
               + ", locality=REMOTE) — expected from AA cross-region pull. Observed leader localities: "
               + observedLeaderLocalities);
-      // Follower replicas only emit LOCAL today (they read from local VT).
+      // Follower replicas now emit BOTH localities, mirroring the leader pattern: locality is
+      // derived from the upstream cluster id stamped on the consumed VT record, so a record
+      // whose upstream RT lived in another fabric tags as REMOTE on the follower.
       Assert.assertTrue(
           observedFollowerLocalities.contains(VeniceRegionLocality.LOCAL.getDimensionValue()),
           "No FOLLOWER point with (writeType=" + expectedWriteType + ", chunking=" + expectedChunking
               + ", locality=LOCAL). Observed follower localities: " + observedFollowerLocalities);
+      Assert.assertTrue(
+          observedFollowerLocalities.contains(VeniceRegionLocality.REMOTE.getDimensionValue()),
+          "No FOLLOWER point with (writeType=" + expectedWriteType + ", chunking=" + expectedChunking
+              + ", locality=REMOTE) — expected from upstreamKafkaClusterId-based source-region tagging."
+              + " Observed follower localities: " + observedFollowerLocalities);
     });
   }
 

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/NearlineE2ELatencyTest.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/NearlineE2ELatencyTest.java
@@ -393,9 +393,11 @@ public class NearlineE2ELatencyTest extends AbstractMultiRegionTest {
           "No LEADER point with (writeType=" + expectedWriteType + ", chunking=" + expectedChunking
               + ", locality=REMOTE) — expected from AA cross-region pull. Observed leader localities: "
               + observedLeaderLocalities);
-      // Follower replicas now emit BOTH localities, mirroring the leader pattern: locality is
-      // derived from the upstream cluster id stamped on the consumed VT record, so a record
-      // whose upstream RT lived in another fabric tags as REMOTE on the follower.
+      /*
+       * Follower replicas now emit BOTH localities, mirroring the leader pattern: locality is
+       * derived from the upstream cluster id stamped on the consumed VT record, so a record
+       * whose upstream RT lived in another fabric tags as REMOTE on the follower.
+       */
       Assert.assertTrue(
           observedFollowerLocalities.contains(VeniceRegionLocality.LOCAL.getDimensionValue()),
           "No FOLLOWER point with (writeType=" + expectedWriteType + ", chunking=" + expectedChunking


### PR DESCRIPTION
## Problem Statement

The per-record latency metric on followers (`emitPerRecordFollowerOtelMetric`, added in #2399) has two gaps that combine to make it under-report and under-attribute end-to-end nearline lag for active-active stores:

1. **Wrong timestamp on the read side.** It uses `producerMetadata.messageTimestamp`, which on post-EOP Put/Update/Delete records written to VT is the leader's local clock at produce time. The value therefore reflects *leader-to-follower* latency, not the upstream-RT-entry → apply latency the metric ought to be measuring.
2. **Local-region tagging on followers.** Followers consume from local VT, so the existing label is always the local fabric. For active-active stores each follower emits a single series that conflates lag from all upstream RT regions, hiding per-source-region replication health from the follower view.

## Solution

Two narrow changes inside `LeaderFollowerStoreIngestionTask.trackRecordReceived`:

**Source switch.** Prefer `leaderMetadataFooter.upstreamMessageTimestamp` (stamped by the leader on records produced from a consumed upstream message — landed in the companion PR that activated KME v14) when it is `> 0`. Fall back to `producerMetadata.messageTimestamp` for:
- Records produced before the leader-side stamping landed.
- The leader-side path itself (where `producerMetadata` *is* the upstream producer's wall clock — no gap there today).

**Per-source-region tagging on the follower path.** Resolve the region from `leaderMetadataFooter.upstreamKafkaClusterId` via `getKafkaClusterIdToAliasMap()` instead of from the local-VT consumption URL. Falls back to the local-region label for records that lack the upstream cluster id (legacy / DaVinci / unknown id), so dashboards do not see a hard cut-over for stores running on older code.

The leader-side path is unchanged — `pubSubUrl` already maps to the source RT region, and `producerMetadata.messageTimestamp` on consumed RT records already is the upstream producer's wall clock.

### Heads-up for dashboard owners

For active-active stores, the follower-side per-record latency series will start splitting by source-region label (e.g., 3 series instead of 1 for a tri-fabric store). Existing dashboards keyed on a single local-region label will need to aggregate over the new region dimension. Consumers that key off the leader-side metric are unaffected.

## File-by-file

| File | Change |
|---|---|
| `LeaderFollowerStoreIngestionTask.java` | New static package-private helpers `resolveRecordE2ETimestamp` and `resolveFollowerSourceRegion`. `trackRecordReceived` now picks region per source-fabric for follower records and timestamp from the upstream-stamped value when present. |
| `LeaderFollowerStoreIngestionTaskTest.java` | 7 new unit tests covering the prefer-vs-fallback timestamp paths and per-source-region resolution (including all three fallback edges: missing leader metadata, cluster id not in map, sentinel cluster id). |

## Stacking

Stacked on the companion PR that activates KME v14 and stamps `upstreamMessageTimestamp` on the leader-produce path. Until that lands the field is always the sentinel and this PR is a behavioral no-op — the existing `producerMetadata` fallback handles every record. Once it lands, the diff for this PR narrows to just the changes here. Will rebase once the companion merges.

###  Code changes
- [ ] Added new code behind **a config**.
- [ ] Introduced new **log lines**.
  - [ ] Confirmed if logs need to be **rate limited**.

###  **Concurrency-Specific Checks**
- [x] No new shared mutable state. The two new helpers are pure / read-only over the consumed record and the cluster-id-to-alias map (which is unmodifiable per `VeniceClusterConfig`).

## How was this PR tested?

- [x] New unit tests added (7 tests covering the new helpers).
- [ ] New integration tests added.
- [x] Modified or extended existing tests (`trackRecordReceived` is exercised by existing harness; new helpers extracted for direct unit-testability).
- [x] Backward compatibility — fallback to `producerMetadata.messageTimestamp` and to local-region label preserves today's metric values for legacy records.

## Does this PR introduce any user-facing or breaking changes?

- [ ] No. You can skip the rest of this section.
- [x] Yes. For active-active stores, the follower-side per-record latency metric (`emitPerRecordFollowerOtelMetric`) will start emitting one series per source region instead of one series tagged with the local region. Dashboards keyed on a single local-region label need to aggregate over the new region dimension.