### PR TITLE
[controller] Pre-flight size check before allocating admin execution id

### DIFF
--- a/internal/venice-client-common/src/main/java/com/linkedin/venice/exceptions/AdminMessageTooLargeException.java
+++ b/internal/venice-client-common/src/main/java/com/linkedin/venice/exceptions/AdminMessageTooLargeException.java
@@ -1,0 +1,44 @@
+package com.linkedin.venice.exceptions;
+
+import org.apache.http.HttpStatus;
+
+
+/**
+ * Thrown when an admin operation's serialized size exceeds the admin topic payload cap. The
+ * pre-flight raises this before allocating an execution id, so callers can safely retry with a
+ * smaller payload. Returns HTTP 413 so clients can distinguish "payload too big" from generic
+ * server errors.
+ */
+public class AdminMessageTooLargeException extends VeniceException {
+  private static final long serialVersionUID = 1L;
+
+  private final String operationName;
+  private final int size;
+  private final int max;
+
+  public AdminMessageTooLargeException(String operationName, int size, int max) {
+    super(
+        "Admin message too large for admin topic. operation=" + operationName + ", size=" + size + ", max=" + max
+            + ". Reduce the payload (e.g. shrink/chunk a large schema) or split into multiple admin operations.");
+    this.operationName = operationName;
+    this.size = size;
+    this.max = max;
+  }
+
+  public String getOperationName() {
+    return operationName;
+  }
+
+  public int getSize() {
+    return size;
+  }
+
+  public int getMax() {
+    return max;
+  }
+
+  @Override
+  public int getHttpStatusCode() {
+    return HttpStatus.SC_REQUEST_TOO_LONG;
+  }
+}

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceParentHelixAdmin.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceParentHelixAdmin.java
@@ -696,6 +696,10 @@ public class VeniceParentHelixAdmin implements Admin {
   }
 
   void sendAdminMessageAndWaitForConsumed(String clusterName, String storeName, AdminOperation message) {
+    // Capture the writer reference once at method entry. Re-fetching from the map inside the
+    // cluster-read lock would race with cluster teardown / leadership handover removing the entry
+    // -- the second get() could return null and NPE on .put() AFTER an execution id was already
+    // allocated, reintroducing the exact leak shape this guard exists to prevent.
     VeniceWriter<byte[], byte[], byte[]> veniceWriter = veniceWriterMap.get(clusterName);
     if (veniceWriter == null) {
       throw new VeniceException("Cluster: " + clusterName + " is not started yet!");
@@ -713,16 +717,17 @@ public class VeniceParentHelixAdmin implements Admin {
       // Size probe with a Long.MAX_VALUE placeholder for the execution id, restored via try/finally
       // so the caller's AdminOperation is observably unmutated on either path. Long.MAX_VALUE encodes
       // to the largest Avro varint, so a passing probe guarantees the real serialization fits.
-      // isChunkingNeededForRecord matches VeniceWriter#put's rejection condition for the admin
-      // writer (no chunking, no pubsub passthrough enabled).
+      // The threshold (AdminTopicUtils.MAX_ADMIN_MESSAGE_PAYLOAD_SIZE_BYTES) is anchored to match
+      // VeniceWriter#put's default rejection point, intentionally independent of writer config --
+      // see the constant's Javadoc for the rationale.
       long savedExecutionId = message.executionId;
       message.executionId = Long.MAX_VALUE;
       try {
         int probeSize = emptyKeyByteArr.length + adminOperationSerializer.serialize(message, writerSchemaId).length;
-        if (veniceWriter.isChunkingNeededForRecord(probeSize)) {
+        if (probeSize > AdminTopicUtils.MAX_ADMIN_MESSAGE_PAYLOAD_SIZE_BYTES) {
           throw new VeniceException(
               "Admin message too large for admin topic. operation=" + AdminMessageType.valueOf(message).name()
-                  + ", size=" + probeSize + ", max=" + veniceWriter.getMaxSizeForUserPayloadPerMessageInBytes()
+                  + ", size=" + probeSize + ", max=" + AdminTopicUtils.MAX_ADMIN_MESSAGE_PAYLOAD_SIZE_BYTES
                   + ". Reduce the payload (e.g. shrink/chunk a large schema) or split into multiple admin operations.");
         }
       } finally {

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceParentHelixAdmin.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceParentHelixAdmin.java
@@ -714,8 +714,18 @@ public class VeniceParentHelixAdmin implements Admin {
 
         // Pre-flight payload-size check before allocating an execution id. If we allocated first and the
         // produce was rejected for size, the id would leak and stall the admin consumer with a DIV
-        // MissingDataException. Long.MAX_VALUE produces the largest Avro varint encoding, so a passing
-        // probe guarantees the real serialization will also fit.
+        // MissingDataException. Long.MAX_VALUE produces the largest Avro varint encoding for a long, so
+        // a passing probe with this placeholder guarantees the real serialization (with the actual
+        // execution id) will also fit.
+        //
+        // Why isChunkingNeededForRecord is the right predicate here:
+        // It returns (recordSize > maxSizeForUserPayloadPerMessageInBytes) -- the same internal
+        // `isLargeRecord` flag VeniceWriter#put computes. On the admin VeniceWriter (created in
+        // #createAdminWriter) neither Venice chunking nor pubsub-large-message passthrough is
+        // enabled, so `isLargeRecord = true` always falls through to the RecordTooLargeException
+        // path inside put(). Mirroring that internal predicate keeps this pre-flight in sync with
+        // put()'s actual rejection condition. If the admin writer ever opts into chunking or
+        // passthrough, this check would over-reject and should be revisited.
         VeniceWriter<byte[], byte[], byte[]> veniceWriter = veniceWriterMap.get(clusterName);
         message.executionId = Long.MAX_VALUE;
         byte[] sizeProbe = adminOperationSerializer.serialize(message, writerSchemaId);

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceParentHelixAdmin.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceParentHelixAdmin.java
@@ -196,6 +196,7 @@ import com.linkedin.venice.controllerapi.UpdateStoragePersonaQueryParams;
 import com.linkedin.venice.controllerapi.UpdateStoreQueryParams;
 import com.linkedin.venice.controllerapi.VersionResponse;
 import com.linkedin.venice.exceptions.AdminMessageConsumptionTimeoutException;
+import com.linkedin.venice.exceptions.AdminMessageTooLargeException;
 import com.linkedin.venice.exceptions.ConcurrentBatchPushException;
 import com.linkedin.venice.exceptions.ConfigurationException;
 import com.linkedin.venice.exceptions.ErrorType;
@@ -696,39 +697,38 @@ public class VeniceParentHelixAdmin implements Admin {
   }
 
   void sendAdminMessageAndWaitForConsumed(String clusterName, String storeName, AdminOperation message) {
-    // Capture the writer reference once at method entry. Re-fetching from the map inside the
-    // cluster-read lock would race with cluster teardown / leadership handover removing the entry
-    // -- the second get() could return null and NPE on .put() AFTER an execution id was already
-    // allocated, reintroducing the exact leak shape this guard exists to prevent.
+    /*
+     * Capture the writer reference once at method entry (single lookup, defensive -- the map is
+     * never removed-from in current code).
+     */
     VeniceWriter<byte[], byte[], byte[]> veniceWriter = veniceWriterMap.get(clusterName);
     if (veniceWriter == null) {
       throw new VeniceException("Cluster: " + clusterName + " is not started yet!");
     }
 
-    // Validate + size pre-flight run BEFORE acquiring any locks. The pre-flight needs no admin lock
-    // or cluster-read lock -- it does one ZK read (getWriterSchemaIdFromZK), one schema validation,
-    // and one in-memory size probe. On the failure path no lock is held, no execution id is
-    // allocated, and checkAndRepairCorruptedExecutionId is skipped. This also keeps oversized
-    // requests from queuing on the admin lock and blocking other admin ops on the cluster.
+    /*
+     * Validate + size pre-flight before acquiring any locks. On the failure path no lock is held,
+     * no execution id is allocated, checkAndRepairCorruptedExecutionId is skipped, and oversized
+     * requests don't queue on the admin lock blocking other ops.
+     */
     int writerSchemaId = getWriterSchemaIdFromZK(clusterName);
     try {
       adminOperationSerializer.validate(message, writerSchemaId);
 
-      // Size probe with a Long.MAX_VALUE placeholder for the execution id, restored via try/finally
-      // so the caller's AdminOperation is observably unmutated on either path. Long.MAX_VALUE encodes
-      // to the largest Avro varint, so a passing probe guarantees the real serialization fits.
-      // The threshold (AdminTopicUtils.MAX_ADMIN_MESSAGE_PAYLOAD_SIZE_BYTES) is anchored to match
-      // VeniceWriter#put's default rejection point, intentionally independent of writer config --
-      // see the constant's Javadoc for the rationale.
+      /*
+       * Size probe with a Long.MAX_VALUE placeholder for the execution id (largest possible Avro
+       * varint encoding, so a passing probe guarantees the real serialization fits). Restored via
+       * try/finally so the caller's AdminOperation is observably unmutated on either path.
+       */
       long savedExecutionId = message.executionId;
       message.executionId = Long.MAX_VALUE;
       try {
         int probeSize = emptyKeyByteArr.length + adminOperationSerializer.serialize(message, writerSchemaId).length;
         if (probeSize > AdminTopicUtils.MAX_ADMIN_MESSAGE_PAYLOAD_SIZE_BYTES) {
-          throw new VeniceException(
-              "Admin message too large for admin topic. operation=" + AdminMessageType.valueOf(message).name()
-                  + ", size=" + probeSize + ", max=" + AdminTopicUtils.MAX_ADMIN_MESSAGE_PAYLOAD_SIZE_BYTES
-                  + ". Reduce the payload (e.g. shrink/chunk a large schema) or split into multiple admin operations.");
+          throw new AdminMessageTooLargeException(
+              AdminMessageType.valueOf(message).name(),
+              probeSize,
+              AdminTopicUtils.MAX_ADMIN_MESSAGE_PAYLOAD_SIZE_BYTES);
         }
       } finally {
         message.executionId = savedExecutionId;
@@ -743,7 +743,7 @@ public class VeniceParentHelixAdmin implements Admin {
             .getClusterLockManager()
             .createClusterReadLock()) {
 
-          // Acquire execution id. The pre-flight size check above ensures produce will not reject for size.
+          /* Acquire execution id. The pre-flight size check above ensures produce will not reject for size. */
           AdminCommandExecutionTracker adminCommandExecutionTracker = adminCommandExecutionTrackers.get(clusterName);
           AdminCommandExecution execution =
               adminCommandExecutionTracker.createExecution(AdminMessageType.valueOf(message).name());
@@ -783,9 +783,25 @@ public class VeniceParentHelixAdmin implements Admin {
       } finally {
         releaseAdminMessageExecutionIdLock(clusterName);
       }
+    } catch (AdminMessageTooLargeException e) {
+      /*
+       * Pre-fix the visible signal was the resulting admin-queue stall; post-fix that stall is
+       * gone, so log the rejection with structured fields -- this plus the HTTP 413 + explicit
+       * reason in the response body is enough signal without a dedicated metric.
+       */
+      LOGGER.warn(
+          "Admin message rejected for size before execution-id allocation. cluster={}, store={}, operation={}, size={} bytes, max={} bytes.",
+          clusterName,
+          storeName,
+          e.getOperationName(),
+          e.getSize(),
+          e.getMax());
+      throw e;
     } catch (VeniceProtocolException e) {
-      // Catches VeniceProtocolException from either the pre-flight (validate / size-probe serialize)
-      // or the post-lock serialize, so the same logging + stats fire regardless of where it was raised.
+      /*
+       * Catches VeniceProtocolException from either the pre-flight (validate / size-probe serialize)
+       * or the post-lock serialize, so the same logging + stats fire regardless of where it was raised.
+       */
       LOGGER.error(
           "Failed to serialize admin message in cluster {}: {}. "
               + "Please check the schema compatibility. Full error message: {}",

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceParentHelixAdmin.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceParentHelixAdmin.java
@@ -712,20 +712,11 @@ public class VeniceParentHelixAdmin implements Admin {
         int writerSchemaId = getWriterSchemaIdFromZK(clusterName);
         adminOperationSerializer.validate(message, writerSchemaId);
 
-        // Pre-flight payload-size check before allocating an execution id. If we allocated first and the
-        // produce was rejected for size, the id would leak and stall the admin consumer with a DIV
-        // MissingDataException. Long.MAX_VALUE produces the largest Avro varint encoding for a long, so
-        // a passing probe with this placeholder guarantees the real serialization (with the actual
-        // execution id) will also fit.
-        //
-        // Why isChunkingNeededForRecord is the right predicate here:
-        // It returns (recordSize > maxSizeForUserPayloadPerMessageInBytes) -- the same internal
-        // `isLargeRecord` flag VeniceWriter#put computes. On the admin VeniceWriter (created in
-        // #createAdminWriter) neither Venice chunking nor pubsub-large-message passthrough is
-        // enabled, so `isLargeRecord = true` always falls through to the RecordTooLargeException
-        // path inside put(). Mirroring that internal predicate keeps this pre-flight in sync with
-        // put()'s actual rejection condition. If the admin writer ever opts into chunking or
-        // passthrough, this check would over-reject and should be revisited.
+        // Pre-flight size check before allocating an execution id; otherwise an oversized produce
+        // rejection leaks the id and stalls the admin consumer with a DIV MissingDataException.
+        // Long.MAX_VALUE encodes to the largest Avro varint, so a passing probe guarantees the real
+        // serialization will fit. isChunkingNeededForRecord matches VeniceWriter#put's rejection
+        // condition for the admin writer (no chunking, no pubsub passthrough enabled).
         VeniceWriter<byte[], byte[], byte[]> veniceWriter = veniceWriterMap.get(clusterName);
         message.executionId = Long.MAX_VALUE;
         byte[] sizeProbe = adminOperationSerializer.serialize(message, writerSchemaId);

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceParentHelixAdmin.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceParentHelixAdmin.java
@@ -718,10 +718,13 @@ public class VeniceParentHelixAdmin implements Admin {
         // serialization will fit. isChunkingNeededForRecord matches VeniceWriter#put's rejection
         // condition for the admin writer (no chunking, no pubsub passthrough enabled).
         VeniceWriter<byte[], byte[], byte[]> veniceWriter = veniceWriterMap.get(clusterName);
+        long originalExecutionId = message.executionId;
         message.executionId = Long.MAX_VALUE;
         byte[] sizeProbe = adminOperationSerializer.serialize(message, writerSchemaId);
         int probeSize = emptyKeyByteArr.length + sizeProbe.length;
         if (veniceWriter.isChunkingNeededForRecord(probeSize)) {
+          // Restore the input message's executionId so the caller never observes the placeholder.
+          message.executionId = originalExecutionId;
           throw new VeniceException(
               "Admin message too large for admin topic. operation=" + AdminMessageType.valueOf(message).name()
                   + ", size=" + probeSize + ", max=" + veniceWriter.getMaxSizeForUserPayloadPerMessageInBytes()

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceParentHelixAdmin.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceParentHelixAdmin.java
@@ -696,9 +696,37 @@ public class VeniceParentHelixAdmin implements Admin {
   }
 
   void sendAdminMessageAndWaitForConsumed(String clusterName, String storeName, AdminOperation message) {
-    if (!veniceWriterMap.containsKey(clusterName)) {
+    VeniceWriter<byte[], byte[], byte[]> veniceWriter = veniceWriterMap.get(clusterName);
+    if (veniceWriter == null) {
       throw new VeniceException("Cluster: " + clusterName + " is not started yet!");
     }
+
+    // Validate + size pre-flight run BEFORE acquiring any locks. The pre-flight needs nothing from
+    // cluster state, so on the failure path no lock is held, no execution id is allocated, and
+    // checkAndRepairCorruptedExecutionId's ZK round-trip is skipped. This also keeps oversized
+    // requests from queuing on the admin lock and blocking other admin ops on the cluster.
+    int writerSchemaId = getWriterSchemaIdFromZK(clusterName);
+    adminOperationSerializer.validate(message, writerSchemaId);
+
+    // Size probe with a Long.MAX_VALUE placeholder for the execution id, restored via try/finally so
+    // the caller's AdminOperation is observably unmutated on either path. Long.MAX_VALUE encodes to
+    // the largest Avro varint, so a passing probe guarantees the real serialization fits.
+    // isChunkingNeededForRecord matches VeniceWriter#put's rejection condition for the admin writer
+    // (no chunking, no pubsub passthrough enabled).
+    long savedExecutionId = message.executionId;
+    message.executionId = Long.MAX_VALUE;
+    try {
+      int probeSize = emptyKeyByteArr.length + adminOperationSerializer.serialize(message, writerSchemaId).length;
+      if (veniceWriter.isChunkingNeededForRecord(probeSize)) {
+        throw new VeniceException(
+            "Admin message too large for admin topic. operation=" + AdminMessageType.valueOf(message).name() + ", size="
+                + probeSize + ", max=" + veniceWriter.getMaxSizeForUserPayloadPerMessageInBytes()
+                + ". Reduce the payload (e.g. shrink/chunk a large schema) or split into multiple admin operations.");
+      }
+    } finally {
+      message.executionId = savedExecutionId;
+    }
+
     acquireAdminMessageExecutionIdLock(clusterName);
     try {
       checkAndRepairCorruptedExecutionId(clusterName);
@@ -708,30 +736,7 @@ public class VeniceParentHelixAdmin implements Admin {
           .getClusterLockManager()
           .createClusterReadLock()) {
 
-        // Validate message before acquiring execution id
-        int writerSchemaId = getWriterSchemaIdFromZK(clusterName);
-        adminOperationSerializer.validate(message, writerSchemaId);
-
-        // Pre-flight size check before allocating an execution id; otherwise an oversized produce
-        // rejection leaks the id and stalls the admin consumer with a DIV MissingDataException.
-        // Long.MAX_VALUE encodes to the largest Avro varint, so a passing probe guarantees the real
-        // serialization will fit. isChunkingNeededForRecord matches VeniceWriter#put's rejection
-        // condition for the admin writer (no chunking, no pubsub passthrough enabled).
-        VeniceWriter<byte[], byte[], byte[]> veniceWriter = veniceWriterMap.get(clusterName);
-        long originalExecutionId = message.executionId;
-        message.executionId = Long.MAX_VALUE;
-        byte[] sizeProbe = adminOperationSerializer.serialize(message, writerSchemaId);
-        int probeSize = emptyKeyByteArr.length + sizeProbe.length;
-        if (veniceWriter.isChunkingNeededForRecord(probeSize)) {
-          // Restore the input message's executionId so the caller never observes the placeholder.
-          message.executionId = originalExecutionId;
-          throw new VeniceException(
-              "Admin message too large for admin topic. operation=" + AdminMessageType.valueOf(message).name()
-                  + ", size=" + probeSize + ", max=" + veniceWriter.getMaxSizeForUserPayloadPerMessageInBytes()
-                  + ". Reduce the payload (e.g. shrink/chunk a large schema) or split into multiple admin operations.");
-        }
-
-        // Acquire execution id. Pre-flight size check above ensures produce will not reject for size.
+        // Acquire execution id. The pre-flight size check above ensures produce will not reject for size.
         AdminCommandExecutionTracker adminCommandExecutionTracker = adminCommandExecutionTrackers.get(clusterName);
         AdminCommandExecution execution =
             adminCommandExecutionTracker.createExecution(AdminMessageType.valueOf(message).name());

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceParentHelixAdmin.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceParentHelixAdmin.java
@@ -701,91 +701,96 @@ public class VeniceParentHelixAdmin implements Admin {
       throw new VeniceException("Cluster: " + clusterName + " is not started yet!");
     }
 
-    // Validate + size pre-flight run BEFORE acquiring any locks. The pre-flight needs nothing from
-    // cluster state, so on the failure path no lock is held, no execution id is allocated, and
-    // checkAndRepairCorruptedExecutionId's ZK round-trip is skipped. This also keeps oversized
+    // Validate + size pre-flight run BEFORE acquiring any locks. The pre-flight needs no admin lock
+    // or cluster-read lock -- it does one ZK read (getWriterSchemaIdFromZK), one schema validation,
+    // and one in-memory size probe. On the failure path no lock is held, no execution id is
+    // allocated, and checkAndRepairCorruptedExecutionId is skipped. This also keeps oversized
     // requests from queuing on the admin lock and blocking other admin ops on the cluster.
     int writerSchemaId = getWriterSchemaIdFromZK(clusterName);
-    adminOperationSerializer.validate(message, writerSchemaId);
-
-    // Size probe with a Long.MAX_VALUE placeholder for the execution id, restored via try/finally so
-    // the caller's AdminOperation is observably unmutated on either path. Long.MAX_VALUE encodes to
-    // the largest Avro varint, so a passing probe guarantees the real serialization fits.
-    // isChunkingNeededForRecord matches VeniceWriter#put's rejection condition for the admin writer
-    // (no chunking, no pubsub passthrough enabled).
-    long savedExecutionId = message.executionId;
-    message.executionId = Long.MAX_VALUE;
     try {
-      int probeSize = emptyKeyByteArr.length + adminOperationSerializer.serialize(message, writerSchemaId).length;
-      if (veniceWriter.isChunkingNeededForRecord(probeSize)) {
-        throw new VeniceException(
-            "Admin message too large for admin topic. operation=" + AdminMessageType.valueOf(message).name() + ", size="
-                + probeSize + ", max=" + veniceWriter.getMaxSizeForUserPayloadPerMessageInBytes()
-                + ". Reduce the payload (e.g. shrink/chunk a large schema) or split into multiple admin operations.");
-      }
-    } finally {
-      message.executionId = savedExecutionId;
-    }
+      adminOperationSerializer.validate(message, writerSchemaId);
 
-    acquireAdminMessageExecutionIdLock(clusterName);
-    try {
-      checkAndRepairCorruptedExecutionId(clusterName);
-      // Obtain the cluster level read lock so during a graceful shutdown or leadership handover there will be no
-      // execution id gap (execution id is generated but the message is not sent).
-      try (AutoCloseableLock ignore = veniceHelixAdmin.getHelixVeniceClusterResources(clusterName)
-          .getClusterLockManager()
-          .createClusterReadLock()) {
-
-        // Acquire execution id. The pre-flight size check above ensures produce will not reject for size.
-        AdminCommandExecutionTracker adminCommandExecutionTracker = adminCommandExecutionTrackers.get(clusterName);
-        AdminCommandExecution execution =
-            adminCommandExecutionTracker.createExecution(AdminMessageType.valueOf(message).name());
-        message.executionId = execution.getExecutionId();
-        byte[] serializedValue = adminOperationSerializer.serialize(message, writerSchemaId);
-        PubSubMessageHeaders pubSubMessageHeaders = new PubSubMessageHeaders();
-        try {
-          pubSubMessageHeaders.add(
-              new PubSubMessageHeader(
-                  PubSubMessageHeaders.EXECUTION_ID_KEY,
-                  ByteBuffer.allocate(Long.BYTES).putLong(message.executionId).array()));
-          Future<PubSubProduceResult> future = veniceWriter.put(
-              emptyKeyByteArr,
-              serializedValue,
-              writerSchemaId,
-              null,
-              DEFAULT_LEADER_METADATA_WRAPPER,
-              APP_DEFAULT_LOGICAL_TS,
-              null,
-              null,
-              null,
-              pubSubMessageHeaders);
-          veniceWriter.flush();
-          PubSubProduceResult produceResult = future.get();
-
-          LOGGER.info(
-              "Sent message: {} to {}, position: {}",
-              message,
-              Utils.getReplicaId(produceResult.getTopic(), produceResult.getPartition()),
-              produceResult.getPubSubPosition());
-        } catch (Exception e) {
-          throw new VeniceException("Got exception during sending message to Kafka -- " + e.getMessage(), e);
+      // Size probe with a Long.MAX_VALUE placeholder for the execution id, restored via try/finally
+      // so the caller's AdminOperation is observably unmutated on either path. Long.MAX_VALUE encodes
+      // to the largest Avro varint, so a passing probe guarantees the real serialization fits.
+      // isChunkingNeededForRecord matches VeniceWriter#put's rejection condition for the admin
+      // writer (no chunking, no pubsub passthrough enabled).
+      long savedExecutionId = message.executionId;
+      message.executionId = Long.MAX_VALUE;
+      try {
+        int probeSize = emptyKeyByteArr.length + adminOperationSerializer.serialize(message, writerSchemaId).length;
+        if (veniceWriter.isChunkingNeededForRecord(probeSize)) {
+          throw new VeniceException(
+              "Admin message too large for admin topic. operation=" + AdminMessageType.valueOf(message).name()
+                  + ", size=" + probeSize + ", max=" + veniceWriter.getMaxSizeForUserPayloadPerMessageInBytes()
+                  + ". Reduce the payload (e.g. shrink/chunk a large schema) or split into multiple admin operations.");
         }
-        // TODO Remove the admin command execution tracking code since no one is using it (might not even be working).
-        adminCommandExecutionTracker.startTrackingExecution(execution);
-      } catch (VeniceProtocolException e) {
-        LOGGER.error(
-            "Failed to serialize admin message in cluster {}: {}. "
-                + "Please check the schema compatibility. Full error message: {}",
-            clusterName,
-            message,
-            e.getMessage());
-        getVeniceHelixAdmin().getHelixVeniceClusterResources(clusterName)
-            .getVeniceAdminStats()
-            .recordFailedSerializingAdminOperationMessageCount();
-        throw e;
+      } finally {
+        message.executionId = savedExecutionId;
       }
-    } finally {
-      releaseAdminMessageExecutionIdLock(clusterName);
+
+      acquireAdminMessageExecutionIdLock(clusterName);
+      try {
+        checkAndRepairCorruptedExecutionId(clusterName);
+        // Obtain the cluster level read lock so during a graceful shutdown or leadership handover there will be no
+        // execution id gap (execution id is generated but the message is not sent).
+        try (AutoCloseableLock ignore = veniceHelixAdmin.getHelixVeniceClusterResources(clusterName)
+            .getClusterLockManager()
+            .createClusterReadLock()) {
+
+          // Acquire execution id. The pre-flight size check above ensures produce will not reject for size.
+          AdminCommandExecutionTracker adminCommandExecutionTracker = adminCommandExecutionTrackers.get(clusterName);
+          AdminCommandExecution execution =
+              adminCommandExecutionTracker.createExecution(AdminMessageType.valueOf(message).name());
+          message.executionId = execution.getExecutionId();
+          byte[] serializedValue = adminOperationSerializer.serialize(message, writerSchemaId);
+          PubSubMessageHeaders pubSubMessageHeaders = new PubSubMessageHeaders();
+          try {
+            pubSubMessageHeaders.add(
+                new PubSubMessageHeader(
+                    PubSubMessageHeaders.EXECUTION_ID_KEY,
+                    ByteBuffer.allocate(Long.BYTES).putLong(message.executionId).array()));
+            Future<PubSubProduceResult> future = veniceWriter.put(
+                emptyKeyByteArr,
+                serializedValue,
+                writerSchemaId,
+                null,
+                DEFAULT_LEADER_METADATA_WRAPPER,
+                APP_DEFAULT_LOGICAL_TS,
+                null,
+                null,
+                null,
+                pubSubMessageHeaders);
+            veniceWriter.flush();
+            PubSubProduceResult produceResult = future.get();
+
+            LOGGER.info(
+                "Sent message: {} to {}, position: {}",
+                message,
+                Utils.getReplicaId(produceResult.getTopic(), produceResult.getPartition()),
+                produceResult.getPubSubPosition());
+          } catch (Exception e) {
+            throw new VeniceException("Got exception during sending message to Kafka -- " + e.getMessage(), e);
+          }
+          // TODO Remove the admin command execution tracking code since no one is using it (might not even be working).
+          adminCommandExecutionTracker.startTrackingExecution(execution);
+        }
+      } finally {
+        releaseAdminMessageExecutionIdLock(clusterName);
+      }
+    } catch (VeniceProtocolException e) {
+      // Catches VeniceProtocolException from either the pre-flight (validate / size-probe serialize)
+      // or the post-lock serialize, so the same logging + stats fire regardless of where it was raised.
+      LOGGER.error(
+          "Failed to serialize admin message in cluster {}: {}. "
+              + "Please check the schema compatibility. Full error message: {}",
+          clusterName,
+          message,
+          e.getMessage());
+      getVeniceHelixAdmin().getHelixVeniceClusterResources(clusterName)
+          .getVeniceAdminStats()
+          .recordFailedSerializingAdminOperationMessageCount();
+      throw e;
     }
     waitingMessageToBeConsumed(clusterName, storeName, message.executionId);
   }

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceParentHelixAdmin.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceParentHelixAdmin.java
@@ -712,12 +712,26 @@ public class VeniceParentHelixAdmin implements Admin {
         int writerSchemaId = getWriterSchemaIdFromZK(clusterName);
         adminOperationSerializer.validate(message, writerSchemaId);
 
-        // Acquire execution id, any exception thrown after this point will result to a missing execution id.
+        // Pre-flight payload-size check before allocating an execution id. If we allocated first and the
+        // produce was rejected for size, the id would leak and stall the admin consumer with a DIV
+        // MissingDataException. Long.MAX_VALUE produces the largest Avro varint encoding, so a passing
+        // probe guarantees the real serialization will also fit.
+        VeniceWriter<byte[], byte[], byte[]> veniceWriter = veniceWriterMap.get(clusterName);
+        message.executionId = Long.MAX_VALUE;
+        byte[] sizeProbe = adminOperationSerializer.serialize(message, writerSchemaId);
+        int probeSize = emptyKeyByteArr.length + sizeProbe.length;
+        if (veniceWriter.isChunkingNeededForRecord(probeSize)) {
+          throw new VeniceException(
+              "Admin message too large for admin topic. operation=" + AdminMessageType.valueOf(message).name()
+                  + ", size=" + probeSize + ", max=" + veniceWriter.getMaxSizeForUserPayloadPerMessageInBytes()
+                  + ". Reduce the payload (e.g. shrink/chunk a large schema) or split into multiple admin operations.");
+        }
+
+        // Acquire execution id. Pre-flight size check above ensures produce will not reject for size.
         AdminCommandExecutionTracker adminCommandExecutionTracker = adminCommandExecutionTrackers.get(clusterName);
         AdminCommandExecution execution =
             adminCommandExecutionTracker.createExecution(AdminMessageType.valueOf(message).name());
         message.executionId = execution.getExecutionId();
-        VeniceWriter<byte[], byte[], byte[]> veniceWriter = veniceWriterMap.get(clusterName);
         byte[] serializedValue = adminOperationSerializer.serialize(message, writerSchemaId);
         PubSubMessageHeaders pubSubMessageHeaders = new PubSubMessageHeaders();
         try {

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/kafka/AdminTopicUtils.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/kafka/AdminTopicUtils.java
@@ -9,6 +9,28 @@ import java.util.List;
 public class AdminTopicUtils {
   public static final int PARTITION_NUM_FOR_ADMIN_TOPIC = 1;
   public static final int ADMIN_TOPIC_PARTITION_ID = 0;
+
+  /**
+   * Maximum serialized size of a single admin-topic record (key + value bytes), enforced by the
+   * controller before allocating an execution id.
+   *
+   * <p>Anchored at 950 KB to match the producer's rejection threshold
+   * ({@code VeniceWriter#DEFAULT_MAX_SIZE_FOR_USER_PAYLOAD_PER_MESSAGE_IN_BYTES}). If the pre-flight
+   * is looser than what the writer will accept, an oversized message gets past us, the producer
+   * rejects it on {@code put}, and we leak the already-allocated execution id -- which is the bug
+   * this guard exists to prevent.
+   *
+   * <p>It is also conservatively below the ZooKeeper {@code jute.maxbuffer} default of ~1 MB, so
+   * admin operations that pass this check will fit in the eventual znode write performed by the
+   * consumer.
+   *
+   * <p>The constant intentionally does not read from the writer's config: this keeps the pre-flight
+   * independent of whether Venice chunking or pubsub-large-message passthrough is enabled on the
+   * admin writer, both of which would otherwise route oversized records through alternate paths
+   * that this guard cannot model precisely.
+   */
+  public static final int MAX_ADMIN_MESSAGE_PAYLOAD_SIZE_BYTES = 950 * 1024;
+
   private static final String KAFKA_INTERNAL_TOPIC_PREFIX = "__";
   private static final List<String> TOPICS_TO_IGNORE;
   static {

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/kafka/AdminTopicUtils.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/kafka/AdminTopicUtils.java
@@ -2,6 +2,7 @@ package com.linkedin.venice.controller.kafka;
 
 import com.linkedin.venice.exceptions.VeniceException;
 import com.linkedin.venice.pubsub.api.PubSubTopicType;
+import com.linkedin.venice.writer.VeniceWriter;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -11,25 +12,17 @@ public class AdminTopicUtils {
   public static final int ADMIN_TOPIC_PARTITION_ID = 0;
 
   /**
-   * Maximum serialized size of a single admin-topic record (key + value bytes), enforced by the
-   * controller before allocating an execution id.
+   * Maximum serialized size of a single admin-topic record, enforced before allocating an
+   * execution id. Aliased to {@link VeniceWriter#DEFAULT_MAX_SIZE_FOR_USER_PAYLOAD_PER_MESSAGE_IN_BYTES}
+   * to track the producer's default rejection threshold, and is conservatively below ZK's
+   * {@code jute.maxbuffer} (~1 MB) so admin ops that pass this check will fit in the eventual znode.
    *
-   * <p>Anchored at 950 KB to match the producer's rejection threshold
-   * ({@code VeniceWriter#DEFAULT_MAX_SIZE_FOR_USER_PAYLOAD_PER_MESSAGE_IN_BYTES}). If the pre-flight
-   * is looser than what the writer will accept, an oversized message gets past us, the producer
-   * rejects it on {@code put}, and we leak the already-allocated execution id -- which is the bug
-   * this guard exists to prevent.
-   *
-   * <p>It is also conservatively below the ZooKeeper {@code jute.maxbuffer} default of ~1 MB, so
-   * admin operations that pass this check will fit in the eventual znode write performed by the
-   * consumer.
-   *
-   * <p>The constant intentionally does not read from the writer's config: this keeps the pre-flight
-   * independent of whether Venice chunking or pubsub-large-message passthrough is enabled on the
-   * admin writer, both of which would otherwise route oversized records through alternate paths
-   * that this guard cannot model precisely.
+   * <p>Read as a compile-time constant rather than the writer's runtime
+   * {@code getMaxSizeForUserPayloadPerMessageInBytes()} so the pre-flight stays independent of
+   * whether Venice chunking or pubsub-large-message passthrough is enabled on the admin writer.
    */
-  public static final int MAX_ADMIN_MESSAGE_PAYLOAD_SIZE_BYTES = 950 * 1024;
+  public static final int MAX_ADMIN_MESSAGE_PAYLOAD_SIZE_BYTES =
+      VeniceWriter.DEFAULT_MAX_SIZE_FOR_USER_PAYLOAD_PER_MESSAGE_IN_BYTES;
 
   private static final String KAFKA_INTERNAL_TOPIC_PREFIX = "__";
   private static final List<String> TOPICS_TO_IGNORE;

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/server/SchemaRoutes.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/server/SchemaRoutes.java
@@ -132,7 +132,11 @@ public class SchemaRoutes extends AbstractRoute {
         responseObject.setSchemaStr(valueSchemaEntry.getSchema().toString());
       } catch (Throwable e) {
         responseObject.setError(e);
-        AdminSparkServer.handleError(new VeniceException(e), request, response);
+        /*
+         * Pass `e` directly so VeniceException subclasses' typed HTTP codes propagate (e.g.
+         * AdminMessageTooLargeException -> 413). No-op for non-VeniceException causes.
+         */
+        AdminSparkServer.handleError(e, request, response);
       }
       return AdminSparkServer.OBJECT_MAPPER.writeValueAsString(responseObject);
     };
@@ -188,7 +192,8 @@ public class SchemaRoutes extends AbstractRoute {
         responseObject.setSchemaStr(derivedSchemaEntry.getSchema().toString());
       } catch (Throwable e) {
         responseObject.setError(e);
-        AdminSparkServer.handleError(new VeniceException(e), request, response);
+        /* Pass `e` directly (see addValueSchema above for rationale -- preserves typed HTTP codes). */
+        AdminSparkServer.handleError(e, request, response);
       }
       return AdminSparkServer.OBJECT_MAPPER.writeValueAsString(responseObject);
     };

--- a/services/venice-controller/src/test/java/com/linkedin/venice/controller/TestVeniceParentHelixAdmin.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/controller/TestVeniceParentHelixAdmin.java
@@ -482,6 +482,38 @@ public class TestVeniceParentHelixAdmin extends AbstractTestVeniceParentHelixAdm
   }
 
   @Test
+  public void testOversizedAdminMessageRejectedBeforeExecutionIdAllocated() {
+    // Reproduces the admin-topic exec-id leak scenario:
+    // an oversized admin message must be rejected BEFORE allocating an
+    // execution id; otherwise the id is consumed but no record is produced,
+    // leaving a gap that stalls every controller's AdminConsumptionTask
+    // with a DataValidationException MissingDataException.
+    parentAdmin.initStorageCluster(clusterName);
+
+    when(veniceWriter.isChunkingNeededForRecord(anyInt())).thenReturn(true);
+    when(veniceWriter.getMaxSizeForUserPayloadPerMessageInBytes()).thenReturn(900_000);
+
+    String storeName = "test-store-oversize";
+    String owner = "test-owner";
+    String keySchemaStr = "\"string\"";
+    String valueSchemaStr = "\"string\"";
+    Store store = TestUtils.createTestStore(storeName, owner, System.currentTimeMillis());
+    doReturn(store).when(internalAdmin).getStore(clusterName, storeName);
+
+    VeniceException e = expectThrows(
+        VeniceException.class,
+        () -> parentAdmin.createStore(clusterName, storeName, owner, keySchemaStr, valueSchemaStr));
+    assertTrue(
+        e.getMessage().contains("Admin message too large for admin topic"),
+        "Expected size-rejection message, got: " + e.getMessage());
+    assertTrue(e.getMessage().contains("max=900000"), "Expected max-size in message, got: " + e.getMessage());
+
+    // The leak prevention assertion: produce was never attempted, so no
+    // record (with or without an allocated exec id) hit the admin topic.
+    verify(veniceWriter, never()).put(any(), any(), anyInt(), any(), any(), anyLong(), any(), any(), any(), any());
+  }
+
+  @Test
   public void testSetStorePartitionCount() {
     String storeName = "test-store";
     when(internalAdmin.getLastExceptionForStore(clusterName, storeName)).thenReturn(null);

--- a/services/venice-controller/src/test/java/com/linkedin/venice/controller/TestVeniceParentHelixAdmin.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/controller/TestVeniceParentHelixAdmin.java
@@ -493,9 +493,6 @@ public class TestVeniceParentHelixAdmin extends AbstractTestVeniceParentHelixAdm
     when(veniceWriter.isChunkingNeededForRecord(anyInt())).thenReturn(true);
     when(veniceWriter.getMaxSizeForUserPayloadPerMessageInBytes()).thenReturn(900_000);
 
-    AdminCommandExecutionTracker tracker = parentAdmin.getAdminCommandExecutionTracker(clusterName).get();
-    long lastExecutionIdBefore = tracker.getLastExecutionId();
-
     String storeName = "test-store-oversize";
     String owner = "test-owner";
     String keySchemaStr = "\"string\"";
@@ -514,12 +511,11 @@ public class TestVeniceParentHelixAdmin extends AbstractTestVeniceParentHelixAdm
     // No produce was attempted -- nothing hit the admin topic.
     verify(veniceWriter, never()).put(any(), any(), anyInt(), any(), any(), anyLong(), any(), any(), any(), any());
 
-    // The actual leak-prevention assertion: the execution id counter did not advance,
-    // so a subsequent (small) admin message will reuse the slot the rejected one would have taken.
-    assertEquals(
-        tracker.getLastExecutionId(),
-        lastExecutionIdBefore,
-        "Execution id counter must not advance on oversize rejection");
+    // The actual leak-prevention assertion: incrementAndGetExecutionId was never called, so the ZK
+    // exec-id counter cannot have advanced and no slot can have been consumed. (Asserted directly on
+    // the accessor mock rather than via tracker.getLastExecutionId(), which is a mocked read that
+    // returns the same default regardless of whether the allocator was invoked.)
+    verify(internalAdmin.getExecutionIdAccessor(), never()).incrementAndGetExecutionId(clusterName);
   }
 
   @Test

--- a/services/venice-controller/src/test/java/com/linkedin/venice/controller/TestVeniceParentHelixAdmin.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/controller/TestVeniceParentHelixAdmin.java
@@ -493,6 +493,9 @@ public class TestVeniceParentHelixAdmin extends AbstractTestVeniceParentHelixAdm
     when(veniceWriter.isChunkingNeededForRecord(anyInt())).thenReturn(true);
     when(veniceWriter.getMaxSizeForUserPayloadPerMessageInBytes()).thenReturn(900_000);
 
+    AdminCommandExecutionTracker tracker = parentAdmin.getAdminCommandExecutionTracker(clusterName).get();
+    long lastExecutionIdBefore = tracker.getLastExecutionId();
+
     String storeName = "test-store-oversize";
     String owner = "test-owner";
     String keySchemaStr = "\"string\"";
@@ -508,9 +511,15 @@ public class TestVeniceParentHelixAdmin extends AbstractTestVeniceParentHelixAdm
         "Expected size-rejection message, got: " + e.getMessage());
     assertTrue(e.getMessage().contains("max=900000"), "Expected max-size in message, got: " + e.getMessage());
 
-    // The leak prevention assertion: produce was never attempted, so no
-    // record (with or without an allocated exec id) hit the admin topic.
+    // No produce was attempted -- nothing hit the admin topic.
     verify(veniceWriter, never()).put(any(), any(), anyInt(), any(), any(), anyLong(), any(), any(), any(), any());
+
+    // The actual leak-prevention assertion: the execution id counter did not advance,
+    // so a subsequent (small) admin message will reuse the slot the rejected one would have taken.
+    assertEquals(
+        tracker.getLastExecutionId(),
+        lastExecutionIdBefore,
+        "Execution id counter must not advance on oversize rejection");
   }
 
   @Test

--- a/services/venice-controller/src/test/java/com/linkedin/venice/controller/TestVeniceParentHelixAdmin.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/controller/TestVeniceParentHelixAdmin.java
@@ -56,6 +56,7 @@ import com.linkedin.venice.controllerapi.JobStatusQueryResponse;
 import com.linkedin.venice.controllerapi.MultiStoreStatusResponse;
 import com.linkedin.venice.controllerapi.StoreResponse;
 import com.linkedin.venice.controllerapi.UpdateStoreQueryParams;
+import com.linkedin.venice.exceptions.AdminMessageTooLargeException;
 import com.linkedin.venice.exceptions.ConcurrentBatchPushException;
 import com.linkedin.venice.exceptions.ConfigurationException;
 import com.linkedin.venice.exceptions.ErrorType;
@@ -481,20 +482,19 @@ public class TestVeniceParentHelixAdmin extends AbstractTestVeniceParentHelixAdm
         () -> parentAdmin.createStore(clusterName, storeName, owner, keySchemaStr, valueSchemaStr));
   }
 
+  /**
+   * Reproduces the admin-topic exec-id leak scenario: an oversized admin message must be rejected
+   * BEFORE allocating an execution id, otherwise the id is consumed but no record is produced,
+   * leaving a gap that stalls every controller's AdminConsumptionTask with a MissingDataException.
+   */
   @Test
   public void testOversizedAdminMessageRejectedBeforeExecutionIdAllocated() {
-    // Reproduces the admin-topic exec-id leak scenario:
-    // an oversized admin message must be rejected BEFORE allocating an
-    // execution id; otherwise the id is consumed but no record is produced,
-    // leaving a gap that stalls every controller's AdminConsumptionTask
-    // with a DataValidationException MissingDataException.
     parentAdmin.initStorageCluster(clusterName);
 
     String storeName = "test-store-oversize";
     String owner = "test-owner";
     String keySchemaStr = "\"string\"";
-    // Build a valid Avro record schema whose JSON exceeds the admin payload cap, so the resulting
-    // StoreCreation admin message will trip the pre-flight size guard.
+    /* Build a valid Avro record schema whose JSON exceeds the admin payload cap. */
     StringBuilder bigSchemaBuilder = new StringBuilder(1_200_000);
     bigSchemaBuilder.append("{\"type\":\"record\",\"name\":\"BigRecord\",\"fields\":[");
     int fieldCount = 32_000;
@@ -514,21 +514,20 @@ public class TestVeniceParentHelixAdmin extends AbstractTestVeniceParentHelixAdm
     Store store = TestUtils.createTestStore(storeName, owner, System.currentTimeMillis());
     doReturn(store).when(internalAdmin).getStore(clusterName, storeName);
 
-    VeniceException e = expectThrows(
-        VeniceException.class,
+    AdminMessageTooLargeException e = expectThrows(
+        AdminMessageTooLargeException.class,
         () -> parentAdmin.createStore(clusterName, storeName, owner, keySchemaStr, valueSchemaStr));
     assertTrue(
         e.getMessage().contains("Admin message too large for admin topic"),
         "Expected size-rejection message, got: " + e.getMessage());
-    assertTrue(
-        e.getMessage().contains("max=" + AdminTopicUtils.MAX_ADMIN_MESSAGE_PAYLOAD_SIZE_BYTES),
-        "Expected max-size in message, got: " + e.getMessage());
+    assertEquals(e.getHttpStatusCode(), HttpStatus.SC_REQUEST_TOO_LONG, "Expected HTTP 413 from typed exception");
 
-    // No produce was attempted -- nothing hit the admin topic.
     verify(veniceWriter, never()).put(any(), any(), anyInt(), any(), any(), anyLong(), any(), any(), any(), any());
 
-    // The actual leak-prevention assertion: incrementAndGetExecutionId was never called, so the ZK
-    // exec-id counter cannot have advanced and no slot can have been consumed.
+    /*
+     * The actual leak-prevention assertion: incrementAndGetExecutionId was never called, so the ZK
+     * exec-id counter cannot have advanced.
+     */
     verify(internalAdmin.getExecutionIdAccessor(), never()).incrementAndGetExecutionId(clusterName);
   }
 

--- a/services/venice-controller/src/test/java/com/linkedin/venice/controller/TestVeniceParentHelixAdmin.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/controller/TestVeniceParentHelixAdmin.java
@@ -490,13 +490,27 @@ public class TestVeniceParentHelixAdmin extends AbstractTestVeniceParentHelixAdm
     // with a DataValidationException MissingDataException.
     parentAdmin.initStorageCluster(clusterName);
 
-    when(veniceWriter.isChunkingNeededForRecord(anyInt())).thenReturn(true);
-    when(veniceWriter.getMaxSizeForUserPayloadPerMessageInBytes()).thenReturn(900_000);
-
     String storeName = "test-store-oversize";
     String owner = "test-owner";
     String keySchemaStr = "\"string\"";
-    String valueSchemaStr = "\"string\"";
+    // Build a valid Avro record schema whose JSON exceeds the admin payload cap, so the resulting
+    // StoreCreation admin message will trip the pre-flight size guard.
+    StringBuilder bigSchemaBuilder = new StringBuilder(1_200_000);
+    bigSchemaBuilder.append("{\"type\":\"record\",\"name\":\"BigRecord\",\"fields\":[");
+    int fieldCount = 32_000;
+    for (int i = 0; i < fieldCount; i++) {
+      if (i > 0) {
+        bigSchemaBuilder.append(",");
+      }
+      bigSchemaBuilder.append("{\"name\":\"f").append(i).append("\",\"type\":\"string\"}");
+    }
+    bigSchemaBuilder.append("]}");
+    String valueSchemaStr = bigSchemaBuilder.toString();
+    assertTrue(
+        valueSchemaStr.length() > AdminTopicUtils.MAX_ADMIN_MESSAGE_PAYLOAD_SIZE_BYTES,
+        "Test setup: generated schema length (" + valueSchemaStr.length() + ") must exceed the admin payload cap ("
+            + AdminTopicUtils.MAX_ADMIN_MESSAGE_PAYLOAD_SIZE_BYTES + ")");
+
     Store store = TestUtils.createTestStore(storeName, owner, System.currentTimeMillis());
     doReturn(store).when(internalAdmin).getStore(clusterName, storeName);
 
@@ -506,15 +520,15 @@ public class TestVeniceParentHelixAdmin extends AbstractTestVeniceParentHelixAdm
     assertTrue(
         e.getMessage().contains("Admin message too large for admin topic"),
         "Expected size-rejection message, got: " + e.getMessage());
-    assertTrue(e.getMessage().contains("max=900000"), "Expected max-size in message, got: " + e.getMessage());
+    assertTrue(
+        e.getMessage().contains("max=" + AdminTopicUtils.MAX_ADMIN_MESSAGE_PAYLOAD_SIZE_BYTES),
+        "Expected max-size in message, got: " + e.getMessage());
 
     // No produce was attempted -- nothing hit the admin topic.
     verify(veniceWriter, never()).put(any(), any(), anyInt(), any(), any(), anyLong(), any(), any(), any(), any());
 
     // The actual leak-prevention assertion: incrementAndGetExecutionId was never called, so the ZK
-    // exec-id counter cannot have advanced and no slot can have been consumed. (Asserted directly on
-    // the accessor mock rather than via tracker.getLastExecutionId(), which is a mocked read that
-    // returns the same default regardless of whether the allocator was invoked.)
+    // exec-id counter cannot have advanced and no slot can have been consumed.
     verify(internalAdmin.getExecutionIdAccessor(), never()).incrementAndGetExecutionId(clusterName);
   }
 

--- a/services/venice-controller/src/test/java/com/linkedin/venice/controller/server/SchemaRoutesTest.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/controller/server/SchemaRoutesTest.java
@@ -5,9 +5,11 @@ import static com.linkedin.venice.controllerapi.ControllerApiConstants.NAME;
 import static com.linkedin.venice.controllerapi.ControllerApiConstants.SCHEMA_COMPAT_TYPE;
 import static com.linkedin.venice.controllerapi.ControllerApiConstants.SCHEMA_ID;
 import static com.linkedin.venice.controllerapi.ControllerApiConstants.VALUE_SCHEMA;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -18,6 +20,7 @@ import static org.testng.Assert.assertTrue;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.linkedin.venice.controller.Admin;
 import com.linkedin.venice.controllerapi.SchemaResponse;
+import com.linkedin.venice.exceptions.AdminMessageTooLargeException;
 import com.linkedin.venice.exceptions.VeniceException;
 import com.linkedin.venice.exceptions.VeniceNoStoreException;
 import com.linkedin.venice.meta.Store;
@@ -29,6 +32,7 @@ import com.linkedin.venice.utils.ObjectMapperFactory;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
+import org.apache.http.HttpStatus;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 import spark.QueryParamsMap;
@@ -118,6 +122,48 @@ public class SchemaRoutesTest {
     Route route = schemaRoutes.addValueSchema(admin);
     route.handle(request, response);
     verify(response, times(0)).status(anyInt()); // no error
+  }
+
+  /**
+   * Pins the HTTP-413 contract: SchemaRoutes' catch must propagate AdminMessageTooLargeException's
+   * typed status code instead of wrapping it as a generic 500.
+   */
+  @Test
+  public void testAddValueSchemaPropagatesTypedHttpStatusOnOversize() throws Exception {
+    String cluster = "cluster_name";
+    String store = "store_name";
+    String schemaStr = "\"int\"";
+    int schemaId = 2;
+    DirectionalSchemaCompatibilityType schemaCompatType = DirectionalSchemaCompatibilityType.BACKWARD;
+
+    Admin admin = mock(Admin.class);
+    Request request = mock(Request.class);
+    Response response = mock(Response.class);
+
+    QueryParamsMap paramsMap = mock(QueryParamsMap.class);
+    doReturn(new HashMap<String, String[]>()).when(paramsMap).toMap();
+    doReturn(paramsMap).when(request).queryMap();
+
+    doReturn(cluster).when(request).queryParams(CLUSTER);
+    doReturn(store).when(request).queryParams(NAME);
+    doReturn(schemaStr).when(request).queryParams(VALUE_SCHEMA);
+    doReturn(Integer.toString(schemaId)).when(request).queryParams(SCHEMA_ID);
+    doReturn(schemaCompatType.toString()).when(request).queryParams(SCHEMA_COMPAT_TYPE);
+
+    doReturn(true).when(admin).isLeaderControllerFor(cluster);
+    doThrow(new AdminMessageTooLargeException("VALUE_SCHEMA_CREATION", 1_000_000, 950 * 1024)).when(admin)
+        .addValueSchema(
+            eq(cluster),
+            eq(store),
+            eq(schemaStr),
+            eq(schemaId),
+            any(DirectionalSchemaCompatibilityType.class));
+
+    SchemaRoutes schemaRoutes = new SchemaRoutes(false, Optional.empty(), schemaRequestHandler);
+    Route route = schemaRoutes.addValueSchema(admin);
+    route.handle(request, response);
+
+    verify(response).status(HttpStatus.SC_REQUEST_TOO_LONG); // 413, NOT 500
   }
 
   @Test


### PR DESCRIPTION
## Problem

`VeniceParentHelixAdmin#sendAdminMessageAndWaitForConsumed` allocated the admin
execution id BEFORE producing the message to the admin topic. The size limit
(`maxSizeForUserPayloadPerMessageInBytes`, default 950 KB) is enforced
downstream inside `VeniceWriter#put`. An oversized admin message (e.g. a large
FDS value-schema) hit the producer's size check AFTER the id was already
consumed, leaving a gap in the execution-id stream.

Every controller's `AdminConsumptionTask` (parent + every child in every
fabric) then stalled at the message after the gap with
`DataValidationException: MissingDataException`, blocking ALL admin operations
for the cluster until an operator manually issued
`--skip-admin-message --execution-id <failing> --skip-div true` against each
controller realm. Subsequent oversize-retries created new gaps and new stalls.

The method's own comment explicitly acknowledges the gap:

> Acquire execution id, any exception thrown after this point will result to a missing execution id.

## Solution

A pre-flight serialize + size check **before** allocating an execution id, and
**before** acquiring any locks. The guard is anchored at a new constant
`AdminTopicUtils.MAX_ADMIN_MESSAGE_PAYLOAD_SIZE_BYTES`, aliased to
`VeniceWriter.DEFAULT_MAX_SIZE_FOR_USER_PAYLOAD_PER_MESSAGE_IN_BYTES` (950 KB)
so it tracks the producer's default rejection threshold and stays conservatively
below ZooKeeper's `jute.maxbuffer` znode-size ceiling. On rejection the
controller throws a typed `AdminMessageTooLargeException` returning HTTP 413.

Pre-flight steps:

1. Capture `veniceWriter` reference once at method entry (single map lookup).
2. Resolve `writerSchemaId` via ZK, then `adminOperationSerializer.validate`.
3. Set `message.executionId = Long.MAX_VALUE` (largest Avro varint encoding, so
   a passing probe guarantees the real serialization will also fit), wrapped in
   `try/finally` to restore the caller's original value on both paths.
4. Serialize the message and compare `probeSize` against the threshold.
5. If oversized -> throw `AdminMessageTooLargeException`. No execution id has
   been allocated, no admin lock has been acquired, no cluster read lock has
   been taken, `checkAndRepairCorruptedExecutionId` is skipped, and the catch
   block logs a structured WARN line.
6. Otherwise proceed: acquire locks, allocate execution id, re-serialize with
   the real id, produce.

Because the pre-flight sits at the single chokepoint every admin operation
flows through, it covers all admin message types and also covers
internally-generated admin messages (e.g. superset schemas computed from the
union of existing schemas) that have no HTTP entry point.

## HTTP-response behavior

`SchemaRoutes#addValueSchema` and `#addDerivedSchema` previously caught
`Throwable` and called `handleError(new VeniceException(e), ...)`. The wrap
discarded VeniceException subclasses' declared HTTP codes -- everything was
forced to 500. This PR passes `e` directly so typed exceptions return their
intended status codes:

| Layer | Value |
|---|---|
| Exception thrown | `AdminMessageTooLargeException` (extends `VeniceException`) |
| HTTP status returned | **413 Payload Too Large** (`SC_REQUEST_TOO_LONG`) |
| Response body `error` | `"Admin message too large for admin topic. operation=<op>, size=<bytes>, max=<bytes>. Reduce the payload (e.g. shrink/chunk a large schema) or split into multiple admin operations."` |
| Client-side exception | `VeniceHttpException(413, <message>, ...)` -- clients with 5xx-retry policies correctly stop on 4xx |

The unwrap is a no-op for non-VeniceException causes (handleError still returns
500), so it's a safe upgrade. Existing typed exceptions
(`VeniceNoStoreException` -> 404, `PartitionerSchemaMismatchException` -> 400,
etc.) also benefit from the same routes. Other admin routes in `StoresRoutes`
and the remaining wraps in `SchemaRoutes` can be cleaned up in a follow-up.

## Observability

A structured WARN log fires from a dedicated
`catch (AdminMessageTooLargeException)` in `sendAdminMessageAndWaitForConsumed`:

```
WARN  Admin message rejected for size before execution-id allocation.
      cluster={}, store={}, operation={}, size={} bytes, max={} bytes.
```

The cluster/store/operation/size/max fields are pulled from typed getters on
the exception. Pre-fix the visible signal for "someone hit the admin-topic
cap" was the resulting cluster-wide queue stall plus AUDIT FAILURE log lines.
Post-fix the stall is gone, so this WARN line plus the HTTP 413 + explicit
reason in the response body is the durable replacement signal for dashboards /
alerts. Per @sushantmane review, no dedicated metric was added -- log-only is
sufficient for a low-frequency event.

###  Code changes
- [ ] Added new code behind a config -- No.
- [ ] Introduced new log lines -- One: structured WARN at the rejection point.

###  Concurrency-Specific Checks
- [x] No race conditions -- pre-flight runs before any lock is acquired and
  takes no shared mutable state. The `executionId` placeholder swap is
  restored via try/finally so the caller's `AdminOperation` is observably
  unmutated on both paths.

## How was this PR tested?

- [x] New unit test in `TestVeniceParentHelixAdmin`:
  `testOversizedAdminMessageRejectedBeforeExecutionIdAllocated`
  -- generates a real > 950 KB valid Avro record schema (32K string fields),
  calls `createStore`, then asserts:
  1. `AdminMessageTooLargeException` thrown
  2. `e.getHttpStatusCode() == HttpStatus.SC_REQUEST_TOO_LONG` (413)
  3. `veniceWriter.put(...)` never called -- nothing hit the admin topic
  4. `ExecutionIdAccessor.incrementAndGetExecutionId` never called -- the
     actual leak-prevention assertion
- [x] New wire-level test in `SchemaRoutesTest`:
  `testAddValueSchemaPropagatesTypedHttpStatusOnOversize` -- pins the HTTP-413
  contract by mocking `admin.addValueSchema` to throw, invoking the Spark
  Route, and asserting `response.status(SC_REQUEST_TOO_LONG)`.
- [x] Verified backward compatibility -- existing
  `TestVeniceParentHelixAdmin` and `SchemaRoutesTest` suites pass unchanged.

Local run: `./gradlew :services:venice-controller:test --tests
TestVeniceParentHelixAdmin --tests SchemaRoutesTest` -> **all passing**.

## Does this PR introduce any user-facing or breaking changes?
- [x] No.

Callers that previously failed with HTTP 500 on oversized payloads now fail
with HTTP 413 -- a strictly more accurate semantic. The error body content is
similar (size, max, remediation hint). Existing callers catching
`VeniceException` continue to catch the new typed exception via Java's
exception hierarchy; status-code-aware clients that retry on 5xx will now
correctly stop on 4xx, which is the right behavior for "payload too big."
