### PR TITLE
[controller] Decrement parent currentVersion on rollback; age out stale rollback-origin guard entries

### DIFF
--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestPushBlockedByRollbackOriginGuard.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestPushBlockedByRollbackOriginGuard.java
@@ -193,6 +193,20 @@ public class TestPushBlockedByRollbackOriginGuard extends AbstractMultiRegionTes
       assertTrue(
           finalStoreResponse.getStore().getVersion(3).isPresent(),
           "Version 3 should have been created after retention expired");
+
+      // Phase 4: regression guard for the parent-currentVersion-decrement fix
+      IntegrationTestPushUtils.runVPJ(props);
+      TestUtils.waitForNonDeterministicPushCompletion(
+          Version.composeKafkaTopic(storeName, 4),
+          parentControllerClient,
+          60,
+          TimeUnit.SECONDS);
+
+      StoreResponse v4StoreResponse = parentControllerClient.getStore(storeName);
+      assertFalse(v4StoreResponse.isError());
+      assertTrue(
+          v4StoreResponse.getStore().getVersion(4).isPresent(),
+          "Version 4 should have been created — stale ROLLED_BACK v2 must not re-block subsequent pushes");
     }
   }
 

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestPushBlockedByRollbackOriginGuard.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestPushBlockedByRollbackOriginGuard.java
@@ -194,7 +194,26 @@ public class TestPushBlockedByRollbackOriginGuard extends AbstractMultiRegionTes
           finalStoreResponse.getStore().getVersion(3).isPresent(),
           "Version 3 should have been created after retention expired");
 
-      // Phase 4: regression guard for the parent-currentVersion-decrement fix
+      // Phase 4: regression for the parent-currentVersion-decrement + filter-tightening fix.
+      // v3's promotion in Phase 3 just re-bumped latestVersionPromoteToCurrentTimestamp, re-arming
+      // the retention window against the stale ROLLED_BACK v2 (which lingers in parent metadata
+      // because parent retains more versions than children). Pre-fix, the rollback-origin filter
+      // would match v2 again and block v4. Post-fix, v2.number=2 <= currentVersion=3 ages out.
+      StoreResponse preV4 = parentControllerClient.getStore(storeName);
+      assertFalse(preV4.isError());
+      assertTrue(
+          preV4.getStore().getVersion(2).isPresent()
+              && preV4.getStore().getVersion(2).get().getStatus() == VersionStatus.ROLLED_BACK,
+          "Phase 4 precondition: v2 must still be ROLLED_BACK on parent so the stale-entry "
+              + "age-out path is exercised; got: " + preV4.getStore().getVersion(2));
+      long retentionExpiresAt = preV4.getStore().getLatestVersionPromoteToCurrentTimestamp() + ROLLED_BACK_RETENTION_MS;
+      assertTrue(
+          System.currentTimeMillis() < retentionExpiresAt,
+          "Phase 4 precondition: retention must be re-armed by v3's promotion (otherwise v4 "
+              + "would pass via the early-return path, not the filter age-out). latestPromoteTs="
+              + preV4.getStore().getLatestVersionPromoteToCurrentTimestamp() + ", retentionExpiresAt="
+              + retentionExpiresAt);
+
       IntegrationTestPushUtils.runVPJ(props);
       TestUtils.waitForNonDeterministicPushCompletion(
           Version.composeKafkaTopic(storeName, 4),
@@ -205,8 +224,10 @@ public class TestPushBlockedByRollbackOriginGuard extends AbstractMultiRegionTes
       StoreResponse v4StoreResponse = parentControllerClient.getStore(storeName);
       assertFalse(v4StoreResponse.isError());
       assertTrue(
-          v4StoreResponse.getStore().getVersion(4).isPresent(),
-          "Version 4 should have been created — stale ROLLED_BACK v2 must not re-block subsequent pushes");
+          v4StoreResponse.getStore().getVersion(4).isPresent()
+              && v4StoreResponse.getStore().getVersion(4).get().getStatus() == VersionStatus.ONLINE,
+          "Version 4 should have been created and ONLINE — stale ROLLED_BACK v2 must not "
+              + "re-block subsequent pushes once currentVersion has moved past it");
     }
   }
 

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceHelixAdmin.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceHelixAdmin.java
@@ -4676,10 +4676,15 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
     int currentVersion = store.getCurrentVersion();
     for (Version v: store.getVersions()) {
       VersionStatus status = v.getStatus();
-      // PARTIALLY_ONLINE with number > currentVersion indicates a rollback-origin state
-      // (region-filtered rollback on the parent). Push-origin PARTIALLY_ONLINE has number == currentVersion.
+      // A rollback-origin version is one that was promoted then rolled back to a lower version,
+      // so number > currentVersion holds (parent decrements currentVersion on rollback to mirror
+      // children, see VeniceParentHelixAdmin.updateParentVersionStatusAfterRollback). Once a
+      // subsequent push promotes higher than the rolled-back version, the retention contract is
+      // satisfied/superseded and the entry — which can linger in parent metadata since parent
+      // retains more versions than children — is correctly aged out by this filter.
+      // Push-origin PARTIALLY_ONLINE (number == currentVersion) is correctly excluded.
       boolean isRollbackOrigin =
-          status == ROLLED_BACK || (status == PARTIALLY_ONLINE && v.getNumber() > currentVersion);
+          (status == ROLLED_BACK || status == PARTIALLY_ONLINE) && v.getNumber() > currentVersion;
       if (isRollbackOrigin) {
         throw new VeniceException(
             String.format(

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceHelixAdmin.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceHelixAdmin.java
@@ -4647,9 +4647,11 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
 
   /**
    * Throws if starting a new push would violate the retention window for a rollback-origin version.
-   * Blocks when a {@code ROLLED_BACK} version exists, or when a {@code PARTIALLY_ONLINE} version
-   * sits above the current version (parent controller, region-filtered rollback).
-   * The block lifts once {@code latestVersionPromoteToCurrentTimestamp + rolledBackVersionRetentionMs}
+   * Blocks when a {@code ROLLED_BACK} or {@code PARTIALLY_ONLINE} version sits strictly above the
+   * current version — the rollback-origin invariant, since rollback decrements currentVersion below
+   * the rolled-back-from version's number on both parent and child controllers. Stale entries
+   * lingering below currentVersion (e.g., after a subsequent push promoted higher) are skipped.
+   * The block also lifts once {@code latestVersionPromoteToCurrentTimestamp + rolledBackVersionRetentionMs}
    * elapses; past that point, the version will be swept on the next SOP deletion pass.
    */
   private void checkRollbackOriginVersionCapacityForNewPush(String clusterName, String storeName, Store store) {

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceParentHelixAdmin.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceParentHelixAdmin.java
@@ -2702,14 +2702,19 @@ public class VeniceParentHelixAdmin implements Admin {
       // Decrement parent.currentVersion to the backup version so it tracks the rolled-back-to state,
       // mirroring what children do during admin-message consumption. Without this, parent.currentVersion
       // remains at the rolled-back-from version, breaking the rollback-origin filter in
-      // checkRollbackOriginVersionCapacityForNewPush (which relies on rollback-origin versions having
-      // number > currentVersion to age out stale ROLLED_BACK entries that linger in parent metadata).
-      // Computed against the pre-update state; getBackupVersionNumber sorts in place but the side
-      // effect is benign here since updateStore persists the final list.
+      // checkRollbackOriginVersionCapacityForNewPush (which requires rollback-origin versions to have
+      // number > currentVersion so stale ROLLED_BACK entries lingering in parent metadata age out).
       int backupVersionNum =
           getVeniceHelixAdmin().getBackupVersionNumber(store.getVersions(), store.getCurrentVersion());
       if (backupVersionNum != NON_EXISTING_VERSION) {
         store.setCurrentVersion(backupVersionNum);
+      } else {
+        LOGGER.warn(
+            "No backup version found for store {} during rollback completion; parent currentVersion "
+                + "left at {}. This shouldn't be reachable if rollbackToBackupVersion succeeded — "
+                + "the rollback-origin filter will fall back to legacy semantics for this store.",
+            storeName,
+            store.getCurrentVersion());
       }
       store.updateVersionStatus(rolledBackVersionNum, parentStatus);
       repository.updateStore(store);

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceParentHelixAdmin.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceParentHelixAdmin.java
@@ -2699,13 +2699,27 @@ public class VeniceParentHelixAdmin implements Admin {
     try (AutoCloseableLock ignore = resources.getClusterLockManager().createStoreWriteLock(storeName)) {
       ReadWriteStoreRepository repository = resources.getStoreMetadataRepository();
       Store store = repository.getStore(storeName);
+      // Decrement parent.currentVersion to the backup version so it tracks the rolled-back-to state,
+      // mirroring what children do during admin-message consumption. Without this, parent.currentVersion
+      // remains at the rolled-back-from version, breaking the rollback-origin filter in
+      // checkRollbackOriginVersionCapacityForNewPush (which relies on rollback-origin versions having
+      // number > currentVersion to age out stale ROLLED_BACK entries that linger in parent metadata).
+      // Computed against the pre-update state; getBackupVersionNumber sorts in place but the side
+      // effect is benign here since updateStore persists the final list.
+      int backupVersionNum =
+          getVeniceHelixAdmin().getBackupVersionNumber(store.getVersions(), store.getCurrentVersion());
+      if (backupVersionNum != NON_EXISTING_VERSION) {
+        store.setCurrentVersion(backupVersionNum);
+      }
       store.updateVersionStatus(rolledBackVersionNum, parentStatus);
       repository.updateStore(store);
       LOGGER.info(
-          "Updated parent store {} version {} status to {} after rollback ({}/{} regions confirmed ROLLED_BACK)",
+          "Updated parent store {} version {} status to {} (currentVersion -> {}) after rollback "
+              + "({}/{} regions confirmed ROLLED_BACK)",
           storeName,
           rolledBackVersionNum,
           parentStatus,
+          backupVersionNum,
           rolledBackRegionCount,
           allRegions.size());
     } catch (Exception e) {

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceParentHelixAdmin.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceParentHelixAdmin.java
@@ -2719,7 +2719,7 @@ public class VeniceParentHelixAdmin implements Admin {
           storeName,
           rolledBackVersionNum,
           parentStatus,
-          backupVersionNum,
+          store.getCurrentVersion(),
           rolledBackRegionCount,
           allRegions.size());
     } catch (Exception e) {

--- a/services/venice-controller/src/test/java/com/linkedin/venice/controller/TestRollbackOriginVersionCapacityCheck.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/controller/TestRollbackOriginVersionCapacityCheck.java
@@ -101,6 +101,23 @@ public class TestRollbackOriginVersionCapacityCheck {
   }
 
   @Test
+  public void testPassesWhenRolledBackVersionBelowCurrentVersion() {
+    // Stale ROLLED_BACK entry on parent: a rollback happened, then a subsequent push promoted higher.
+    // Parent retains more versions than children, so the ROLLED_BACK entry can linger after parent's
+    // currentVersion has moved past it. The filter must skip such entries — otherwise every fresh
+    // promotion's retention window would re-trigger the guard against the stale entry forever.
+    long now = System.currentTimeMillis();
+    Store store = mockStoreWithVersions(
+        3,
+        TimeUnit.HOURS.toMillis(1),
+        mockVersion(2, VersionStatus.ROLLED_BACK),
+        mockVersion(3, VersionStatus.ONLINE));
+
+    VeniceHelixAdmin
+        .checkRollbackOriginVersionCapacityForNewPush(CLUSTER_NAME, STORE_NAME, store, ROLLED_BACK_RETENTION_MS, now);
+  }
+
+  @Test
   public void testPassesWhenPartiallyOnlineVersionEqualsCurrentVersion() {
     // Push-origin PARTIALLY_ONLINE: v4 is PARTIALLY_ONLINE and IS the current version → not rollback-origin
     long now = System.currentTimeMillis();

--- a/services/venice-controller/src/test/java/com/linkedin/venice/controller/TestRollbackOriginVersionCapacityCheck.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/controller/TestRollbackOriginVersionCapacityCheck.java
@@ -118,6 +118,33 @@ public class TestRollbackOriginVersionCapacityCheck {
   }
 
   @Test
+  public void testBlocksOnlyRolledBackEntryAboveCurrentVersion() {
+    // Multi-rollback on parent: stale ROLLED_BACK v2 lingers below currentVersion=4 (aged out by a
+    // subsequent push), while v5 is the active rollback-origin above current. The filter must skip
+    // v2 and block on v5 — pre-PR filter (status==ROLLED_BACK alone) would have matched v2 first
+    // and misattributed the block.
+    long now = System.currentTimeMillis();
+    Store store = mockStoreWithVersions(
+        4,
+        TimeUnit.HOURS.toMillis(1),
+        mockVersion(2, VersionStatus.ROLLED_BACK),
+        mockVersion(4, VersionStatus.ONLINE),
+        mockVersion(5, VersionStatus.ROLLED_BACK));
+
+    VeniceException e = expectThrows(
+        VeniceException.class,
+        () -> VeniceHelixAdmin.checkRollbackOriginVersionCapacityForNewPush(
+            CLUSTER_NAME,
+            STORE_NAME,
+            store,
+            ROLLED_BACK_RETENTION_MS,
+            now));
+    assertTrue(
+        e.getMessage().contains("version 5"),
+        "should block on v5 (above current), not stale v2: " + e.getMessage());
+  }
+
+  @Test
   public void testPassesWhenPartiallyOnlineVersionEqualsCurrentVersion() {
     // Push-origin PARTIALLY_ONLINE: v4 is PARTIALLY_ONLINE and IS the current version → not rollback-origin
     long now = System.currentTimeMillis();


### PR DESCRIPTION
## Problem Statement

The rollback-origin retention guard (`VeniceHelixAdmin.checkRollbackOriginVersionCapacityForNewPush`) re-fired indefinitely on the parent controller, blocking new pushes long after the rollback retention window had lapsed.

Root cause:
- Parent retains more versions than children (parent stores ~5 versions vs children's ~2-3), so `ROLLED_BACK` entries linger in parent metadata for a long time.
- `latestVersionPromoteToCurrentTimestamp` is bumped on every new promotion. The retention window is anchored to that timestamp, so each new promotion re-arms the window against the stale `ROLLED_BACK` entries.
- Additionally, parent's `currentVersion` was never decremented on rollback (only children decrement). This breaks the invariant the filter relies on (`number > currentVersion`).

Net effect: once any rollback occurred, the parent guard incorrectly blocked for subsequent pushes that don't require the delay

## Solution

Two-part fix that aligns parent semantics with children and tightens the filter so stale entries age out:

**1. `VeniceParentHelixAdmin.updateParentVersionStatusAfterRollback`** — now decrements `parent.currentVersion` to the backup version (`getBackupVersionNumber(...)`) alongside the existing version-status update, mirroring child controllers. This:
- Re-anchors `latestVersionPromoteToCurrentTimestamp` to the rollback time (since `setCurrentVersion` updates that timestamp), making the retention window count from rollback rather than from the original promotion.
- Establishes the invariant that rollback-origin versions on parent have `number > currentVersion`, same as children.

**2. `VeniceHelixAdmin.checkRollbackOriginVersionCapacityForNewPush`** — filters `ROLLED_BACK` and `PARTIALLY_ONLINE` uniformly by `number > currentVersion`. Once a subsequent push promotes higher than the rolled-back version, the entry no longer matches the filter, so stale entries that linger in parent metadata age out correctly.

Together these preserve the retention contract while it matters (between rollback and the next successful promotion) and stop blocking pushes once the contract is satisfied or superseded.

### Code changes

- [ ] Added new code behind **a config**. (No new configs.)
- [ ] Introduced new **log lines**. (Existing rollback-status update log line is extended to include the new `currentVersion` value — emitted once per rollback, no rate limiting needed.)

### **Concurrency-Specific Checks**

- [x] Code has **no race conditions** or **thread safety issues**. The new `setCurrentVersion` call happens within the existing `clusterLockManager.createStoreWriteLock(storeName)` block in `updateParentVersionStatusAfterRollback`.
- [x] Proper **synchronization mechanisms** are used where needed (existing store write-lock).
- [x] No **blocking calls** inside critical sections.
- [x] Verified **thread-safe collections** are used (no new collections added).
- [x] Validated proper exception handling — existing try/catch around the write-lock block is preserved.

## How was this PR tested?

- [x] New unit tests added: `testPassesWhenRolledBackVersionBelowCurrentVersion` covers the stale-entry case (ROLLED_BACK entry below currentVersion correctly skipped).
- [x] Modified or extended existing tests: existing `TestRollbackOriginVersionCapacityCheck` suite (10 tests total) all pass.
- [ ] New integration tests added.
- [x] Verified backward compatibility — existing rollback integration tests (`TestPushBlockedByRollbackOriginGuard`, `TestPushAllowedAfterRollbackRetentionExpires`) will validate the parent.currentVersion decrement and relaxed filter end-to-end via CI.

## Does this PR introduce any user-facing or breaking changes?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Clearly explain the behavior change and its impact.

**Behavioral change:** Parent's `getStore` API now returns `currentVersion = rolled-back-to-version` after a rollback (previously the parent kept reporting the rolled-back-from version). This matches child controller semantics and is observable to any dashboards or tooling reading the parent's `currentVersion` directly. Most callers already use `getCurrentVersionsForMultiColos` (which dispatches to children), so this primarily affects code paths that read parent's local store directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)