### PR TITLE
[server][da-vinci] Use replica ID in HLL log statements

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/PartitionConsumptionState.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/PartitionConsumptionState.java
@@ -471,7 +471,7 @@ public class PartitionConsumptionState {
     lgK = clampLgK(lgK);
     ByteBuffer hllBytes = offsetRecord.getUniqueIngestedKeyCountHllSketch();
     if (hllBytes == null || hllBytes.remaining() == 0) {
-      LOGGER.warn("Partition {} has no HLL checkpoint data to restore.", getPartition());
+      LOGGER.warn("Replica: {} has no HLL checkpoint data to restore.", getReplicaId());
       return;
     }
     restoreUniqueKeyCountHllFromCheckpoint(lgK, hllBytes);
@@ -547,8 +547,8 @@ public class PartitionConsumptionState {
     int restoredLgK = this.uniqueIngestedKeyCountHll.getLgConfigK();
     if (restoredLgK != lgK) {
       LOGGER.warn(
-          "Partition {} HLL restored with lgK={}, configured lgK={}. Keeping restored sketch.",
-          getPartition(),
+          "Replica: {} HLL restored with lgK={}, configured lgK={}. Keeping restored sketch.",
+          getReplicaId(),
           restoredLgK,
           lgK);
     }
@@ -558,8 +558,8 @@ public class PartitionConsumptionState {
     if (lgK < HLL_MIN_LOG_K || lgK > HLL_MAX_LOG_K) {
       int clamped = Math.max(HLL_MIN_LOG_K, Math.min(HLL_MAX_LOG_K, lgK));
       LOGGER.warn(
-          "Partition {} HLL lgK={} is out of valid range [{}, {}]. Clamping to {}.",
-          getPartition(),
+          "Replica: {} HLL lgK={} is out of valid range [{}, {}]. Clamping to {}.",
+          getReplicaId(),
           lgK,
           HLL_MIN_LOG_K,
           HLL_MAX_LOG_K,


### PR DESCRIPTION
## Problem Statement

The three HLL warning logs added in #2671 (`PartitionConsumptionState.restoreUniqueKeyCountHll`, `restoreUniqueKeyCountHllFromCheckpoint`, `clampLgK`) only print the partition number via `getPartition()`. A bare partition number is not useful on its own — without the store name and version, you cannot tell which replica triggered the warning when grepping server logs that span many stores.

## Solution

Switch the three logs to use `getReplicaId()`, which produces the standard `topic_partition` form (e.g. `store_v3-7`) used by the rest of the PCS log statements (see the `"Creating PCS for replica: {}"` log at PCS construction).

### Code changes
- [x] No new code, no new configs, no new log lines — just changes the substitution in three existing warnings.

### Concurrency-Specific Checks
- [x] No concurrency changes. `getReplicaId()` reads a final field set in the constructor.

## How was this PR tested?

- [x] `:clients:da-vinci-client:compileJava` passes.
- [x] No behavioral change beyond the log message text; existing unit tests cover the call sites.

## Does this PR introduce any user-facing or breaking changes?
- [x] No. You can skip the rest of this section.