### PR TITLE
[server] Gate active-key-count metrics behind config and unify invalidation paths

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/config/VeniceServerConfig.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/config/VeniceServerConfig.java
@@ -2285,6 +2285,15 @@ public class VeniceServerConfig extends VeniceClusterConfig {
     return activeKeyCountForHybridStoreEnabled;
   }
 
+  /**
+   * True when active-key-count tracking is enabled for either batch-push or hybrid stores. Stats
+   * registrations and OTel metric creation are gated by this — if neither tracking mode is on,
+   * the gauges and the invalidation rate are meaningless and should not be registered.
+   */
+  public boolean isAnyActiveKeyCountTrackingEnabled() {
+    return activeKeyCountForAllBatchPushEnabled || activeKeyCountForHybridStoreEnabled;
+  }
+
   public int getPartialUpdateLargeResultLogThresholdBytes() {
     return partialUpdateLargeResultLogThresholdBytes;
   }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/config/VeniceServerConfig.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/config/VeniceServerConfig.java
@@ -2285,11 +2285,6 @@ public class VeniceServerConfig extends VeniceClusterConfig {
     return activeKeyCountForHybridStoreEnabled;
   }
 
-  /**
-   * True when active-key-count tracking is enabled for either batch-push or hybrid stores. Stats
-   * registrations and OTel metric creation are gated by this — if neither tracking mode is on,
-   * the gauges and the invalidation rate are meaningless and should not be registered.
-   */
   public boolean isAnyActiveKeyCountTrackingEnabled() {
     return activeKeyCountForAllBatchPushEnabled || activeKeyCountForHybridStoreEnabled;
   }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/ActiveActiveStoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/ActiveActiveStoreIngestionTask.java
@@ -937,7 +937,7 @@ public class ActiveActiveStoreIngestionTask extends LeaderFollowerStoreIngestion
       if (partitionConsumptionState.decrementActiveKeyCount()) {
         return new PubSubMessageHeaders().add(KEY_DELETED_SIGNAL);
       }
-      invalidateActiveKeyCount(partitionConsumptionState, "Decrement underflow on leader during DCR");
+      invalidateActiveKeyCount(partitionConsumptionState, ActiveKeyCountInvalidationReason.LEADER_DCR_UNDERFLOW);
       return new PubSubMessageHeaders().add(KEY_COUNT_INVALIDATE_SIGNAL);
     }
     return EmptyPubSubMessageHeaders.SINGLETON;
@@ -1050,9 +1050,7 @@ public class ActiveActiveStoreIngestionTask extends LeaderFollowerStoreIngestion
     try {
       return storageEngine.keyExists(partitionConsumptionState.getPartition(), storageKey);
     } catch (VeniceException e) {
-      // Transient RocksDB I/O failure: invalidate the count and assume key absent so ingestion
-      // doesn't halt and we stop publishing a wrong number.
-      invalidateActiveKeyCount(partitionConsumptionState, "keyExists failed", e);
+      invalidateActiveKeyCount(partitionConsumptionState, ActiveKeyCountInvalidationReason.KEY_EXISTS_FAILURE, e);
       return false;
     }
   }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/ActiveActiveStoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/ActiveActiveStoreIngestionTask.java
@@ -937,7 +937,6 @@ public class ActiveActiveStoreIngestionTask extends LeaderFollowerStoreIngestion
       if (partitionConsumptionState.decrementActiveKeyCount()) {
         return new PubSubMessageHeaders().add(KEY_DELETED_SIGNAL);
       }
-      // Underflow on leader: count drifted, propagate invalidation to followers.
       invalidateActiveKeyCount(partitionConsumptionState, "Decrement underflow on leader during DCR");
       return new PubSubMessageHeaders().add(KEY_COUNT_INVALIDATE_SIGNAL);
     }
@@ -1051,8 +1050,8 @@ public class ActiveActiveStoreIngestionTask extends LeaderFollowerStoreIngestion
     try {
       return storageEngine.keyExists(partitionConsumptionState.getPartition(), storageKey);
     } catch (VeniceException e) {
-      // A transient RocksDB I/O failure must not halt ingestion. Invalidate the count so we stop
-      // publishing a wrong number, and return false (assume key absent) to skip the signal.
+      // Transient RocksDB I/O failure: invalidate the count and assume key absent so ingestion
+      // doesn't halt and we stop publishing a wrong number.
       invalidateActiveKeyCount(partitionConsumptionState, "keyExists failed", e);
       return false;
     }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/ActiveActiveStoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/ActiveActiveStoreIngestionTask.java
@@ -937,9 +937,8 @@ public class ActiveActiveStoreIngestionTask extends LeaderFollowerStoreIngestion
       if (partitionConsumptionState.decrementActiveKeyCount()) {
         return new PubSubMessageHeaders().add(KEY_DELETED_SIGNAL);
       }
-      // Underflow detected (count was 0 but got a delete) — count drifted, now invalidated to
-      // ACTIVE_KEY_COUNT_NOT_TRACKED.
-      recordActiveKeyCountInvalidation();
+      // Underflow on leader: count drifted, propagate invalidation to followers.
+      invalidateActiveKeyCount(partitionConsumptionState, "Decrement underflow on leader during DCR");
       return new PubSubMessageHeaders().add(KEY_COUNT_INVALIDATE_SIGNAL);
     }
     return EmptyPubSubMessageHeaders.SINGLETON;
@@ -1054,13 +1053,7 @@ public class ActiveActiveStoreIngestionTask extends LeaderFollowerStoreIngestion
     } catch (VeniceException e) {
       // A transient RocksDB I/O failure must not halt ingestion. Invalidate the count so we stop
       // publishing a wrong number, and return false (assume key absent) to skip the signal.
-      partitionConsumptionState.setActiveKeyCount(ACTIVE_KEY_COUNT_NOT_TRACKED);
-      recordActiveKeyCountInvalidation();
-      String msg =
-          "keyExists failed for replica " + partitionConsumptionState.getReplicaId() + "; invalidating activeKeyCount.";
-      if (!REDUNDANT_LOGGING_FILTER.isRedundantException(msg)) {
-        LOGGER.error(msg, e);
-      }
+      invalidateActiveKeyCount(partitionConsumptionState, "keyExists failed", e);
       return false;
     }
   }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/ActiveKeyCountInvalidationReason.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/ActiveKeyCountInvalidationReason.java
@@ -1,0 +1,41 @@
+package com.linkedin.davinci.kafka.consumer;
+
+/**
+ * Reasons for invalidating a partition's active-key-count tracking. Each value carries a message
+ * template (some with a {@code %d} placeholder for runtime detail like the offending signal value
+ * or header length) that becomes the prefix of the operator-visible ERROR log emitted by
+ * {@link StoreIngestionTask#invalidateActiveKeyCount}.
+ */
+public enum ActiveKeyCountInvalidationReason {
+  /** Follower received {@code kcs=-1} but its count was already zero (count drifted). */
+  FOLLOWER_DECREMENT_UNDERFLOW("Decrement underflow on follower from kcs=-1"),
+  /** Follower received {@code kcs=0} (leader-propagated invalidation signal). */
+  LEADER_PROPAGATED_INVALIDATION("Leader propagated invalidation signal"),
+  /** Follower received a single-byte {@code kcs} value outside the {-1, 0, +1} contract. */
+  CORRUPT_KCS_SIGNAL_VALUE("Unexpected kcs signal value %d"),
+  /** Follower received a multi-byte {@code kcs} header (corrupt or future producer). */
+  CORRUPT_MULTI_BYTE_KCS_SIGNAL("Unexpected multi-byte kcs signal (length=%d)"),
+  /** Leader detected an underflow during DCR (count was zero but a delete was processed). */
+  LEADER_DCR_UNDERFLOW("Decrement underflow on leader during DCR"),
+  /**
+   * Leader's {@link com.linkedin.davinci.store.StorageEngine#keyExists} call (a RocksDB
+   * value-column-family lookup used to determine whether a key currently has a live value) threw.
+   * The transient I/O failure must not stop ingestion or leave the active count in a wrong state —
+   * invalidate so we stop publishing a stale value.
+   */
+  KEY_EXISTS_FAILURE("RocksDB value column family lookup failed");
+
+  private final String messageTemplate;
+
+  ActiveKeyCountInvalidationReason(String messageTemplate) {
+    this.messageTemplate = messageTemplate;
+  }
+
+  String getMessage() {
+    return messageTemplate;
+  }
+
+  String getMessage(int detail) {
+    return String.format(messageTemplate, detail);
+  }
+}

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
@@ -4740,35 +4740,57 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
           partitionConsumptionState.incrementActiveKeyCount();
         } else if (signal == ActiveActiveStoreIngestionTask.KEY_DELETED_SIGNAL_VALUE) {
           if (!partitionConsumptionState.decrementActiveKeyCount()) {
-            recordActiveKeyCountInvalidation();
+            // Underflow: count is already -1 from decrementActiveKeyCount's atomic update.
+            // Helper is idempotent — setActiveKeyCount(-1) is a no-op when already -1.
+            invalidateActiveKeyCount(partitionConsumptionState, "Decrement underflow on follower from kcs=-1");
           }
         } else if (signal == ActiveActiveStoreIngestionTask.KEY_COUNT_INVALIDATE_SIGNAL_VALUE) {
-          invalidateActiveKeyCount(partitionConsumptionState);
+          invalidateActiveKeyCount(partitionConsumptionState, "Leader propagated invalidation signal");
         } else {
           // Corrupt single-byte signal — invalidate to stop publishing wrong data.
-          invalidateActiveKeyCount(partitionConsumptionState);
-          String msg = "Unexpected kcs signal value " + signal + " for replica "
-              + partitionConsumptionState.getReplicaId() + "; invalidating activeKeyCount.";
-          if (!REDUNDANT_LOGGING_FILTER.isRedundantException(msg)) {
-            LOGGER.error(msg);
-          }
+          invalidateActiveKeyCount(partitionConsumptionState, "Unexpected kcs signal value " + signal);
         }
       } else if (signalHeader != null && signalHeader.value() != null && signalHeader.value().length > 1) {
         // Multi-byte signal — corrupt or from a future/buggy producer. Invalidate.
-        invalidateActiveKeyCount(partitionConsumptionState);
-        String msg = "Unexpected multi-byte kcs signal (length=" + signalHeader.value().length + ") for replica "
-            + partitionConsumptionState.getReplicaId() + "; invalidating activeKeyCount.";
-        if (!REDUNDANT_LOGGING_FILTER.isRedundantException(msg)) {
-          LOGGER.error(msg);
-        }
+        invalidateActiveKeyCount(
+            partitionConsumptionState,
+            "Unexpected multi-byte kcs signal (length=" + signalHeader.value().length + ")");
       }
     }
   }
 
-  /** Invalidates the active key count and records invalidation metrics (both OTel and Tehuti). */
-  private void invalidateActiveKeyCount(PartitionConsumptionState partitionConsumptionState) {
-    partitionConsumptionState.setActiveKeyCount(ACTIVE_KEY_COUNT_NOT_TRACKED);
-    recordActiveKeyCountInvalidation();
+  /**
+   * Invalidates the active key count and emits a rate-limited ERROR log line. Routes through
+   * {@code setActiveKeyCount(ACTIVE_KEY_COUNT_NOT_TRACKED)} and the shared invalidation metric so
+   * any future hook on the setter or the metric applies uniformly to every invalidation path.
+   *
+   * @param reason human-readable cause; replica id and "; invalidating activeKeyCount." are appended.
+   * @param cause optional throwable to attach to the log line; pass {@code null} when there is none.
+   */
+  protected final void invalidateActiveKeyCount(
+      PartitionConsumptionState partitionConsumptionState,
+      String reason,
+      Throwable cause) {
+    // The ERROR log is the operator's only signal that the count went bad on this replica. Wrap
+    // the state mutation and metric in try/finally so the log fires even if either throws — losing
+    // the log would silently mask the invalidation, defeating the whole point of this helper.
+    try {
+      partitionConsumptionState.setActiveKeyCount(ACTIVE_KEY_COUNT_NOT_TRACKED);
+      recordActiveKeyCountInvalidation();
+    } finally {
+      String msg =
+          reason + " for replica " + partitionConsumptionState.getReplicaId() + "; invalidating activeKeyCount.";
+      if (!REDUNDANT_LOGGING_FILTER.isRedundantException(msg)) {
+        // log4j2's (String, Throwable) overload accepts a null throwable and renders without a
+        // stack trace, so a single call covers both the with-cause and no-cause invalidation paths.
+        LOGGER.error(msg, cause);
+      }
+    }
+  }
+
+  /** Convenience overload for invalidations without an associated throwable. */
+  protected final void invalidateActiveKeyCount(PartitionConsumptionState partitionConsumptionState, String reason) {
+    invalidateActiveKeyCount(partitionConsumptionState, reason, null);
   }
 
   /** Records active-key-count invalidation on both the OTel (per-version) and Tehuti (host-level) paths. */

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
@@ -4740,18 +4740,14 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
           partitionConsumptionState.incrementActiveKeyCount();
         } else if (signal == ActiveActiveStoreIngestionTask.KEY_DELETED_SIGNAL_VALUE) {
           if (!partitionConsumptionState.decrementActiveKeyCount()) {
-            // Underflow: count is already -1 from decrementActiveKeyCount's atomic update.
-            // Helper is idempotent — setActiveKeyCount(-1) is a no-op when already -1.
             invalidateActiveKeyCount(partitionConsumptionState, "Decrement underflow on follower from kcs=-1");
           }
         } else if (signal == ActiveActiveStoreIngestionTask.KEY_COUNT_INVALIDATE_SIGNAL_VALUE) {
           invalidateActiveKeyCount(partitionConsumptionState, "Leader propagated invalidation signal");
         } else {
-          // Corrupt single-byte signal — invalidate to stop publishing wrong data.
           invalidateActiveKeyCount(partitionConsumptionState, "Unexpected kcs signal value " + signal);
         }
       } else if (signalHeader != null && signalHeader.value() != null && signalHeader.value().length > 1) {
-        // Multi-byte signal — corrupt or from a future/buggy producer. Invalidate.
         invalidateActiveKeyCount(
             partitionConsumptionState,
             "Unexpected multi-byte kcs signal (length=" + signalHeader.value().length + ")");
@@ -4760,20 +4756,14 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
   }
 
   /**
-   * Invalidates the active key count and emits a rate-limited ERROR log line. Routes through
-   * {@code setActiveKeyCount(ACTIVE_KEY_COUNT_NOT_TRACKED)} and the shared invalidation metric so
-   * any future hook on the setter or the metric applies uniformly to every invalidation path.
-   *
-   * @param reason human-readable cause; replica id and "; invalidating activeKeyCount." are appended.
-   * @param cause optional throwable to attach to the log line; pass {@code null} when there is none.
+   * Sets the active key count to {@link OffsetRecord#ACTIVE_KEY_COUNT_NOT_TRACKED}, records the
+   * invalidation metric, and emits a rate-limited ERROR log. The state mutation and metric are
+   * wrapped in try/finally so the log fires even if either throws.
    */
-  protected final void invalidateActiveKeyCount(
+  final void invalidateActiveKeyCount(
       PartitionConsumptionState partitionConsumptionState,
       String reason,
       Throwable cause) {
-    // The ERROR log is the operator's only signal that the count went bad on this replica. Wrap
-    // the state mutation and metric in try/finally so the log fires even if either throws — losing
-    // the log would silently mask the invalidation, defeating the whole point of this helper.
     try {
       partitionConsumptionState.setActiveKeyCount(ACTIVE_KEY_COUNT_NOT_TRACKED);
       recordActiveKeyCountInvalidation();
@@ -4781,15 +4771,14 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
       String msg =
           reason + " for replica " + partitionConsumptionState.getReplicaId() + "; invalidating activeKeyCount.";
       if (!REDUNDANT_LOGGING_FILTER.isRedundantException(msg)) {
-        // log4j2's (String, Throwable) overload accepts a null throwable and renders without a
-        // stack trace, so a single call covers both the with-cause and no-cause invalidation paths.
+        // log4j2's error(String, Throwable) accepts a null throwable, so this single call covers
+        // both with-cause and no-cause invocations.
         LOGGER.error(msg, cause);
       }
     }
   }
 
-  /** Convenience overload for invalidations without an associated throwable. */
-  protected final void invalidateActiveKeyCount(PartitionConsumptionState partitionConsumptionState, String reason) {
+  final void invalidateActiveKeyCount(PartitionConsumptionState partitionConsumptionState, String reason) {
     invalidateActiveKeyCount(partitionConsumptionState, reason, null);
   }
 

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
@@ -4740,46 +4740,74 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
           partitionConsumptionState.incrementActiveKeyCount();
         } else if (signal == ActiveActiveStoreIngestionTask.KEY_DELETED_SIGNAL_VALUE) {
           if (!partitionConsumptionState.decrementActiveKeyCount()) {
-            invalidateActiveKeyCount(partitionConsumptionState, "Decrement underflow on follower from kcs=-1");
+            invalidateActiveKeyCount(
+                partitionConsumptionState,
+                ActiveKeyCountInvalidationReason.FOLLOWER_DECREMENT_UNDERFLOW);
           }
         } else if (signal == ActiveActiveStoreIngestionTask.KEY_COUNT_INVALIDATE_SIGNAL_VALUE) {
-          invalidateActiveKeyCount(partitionConsumptionState, "Leader propagated invalidation signal");
+          invalidateActiveKeyCount(
+              partitionConsumptionState,
+              ActiveKeyCountInvalidationReason.LEADER_PROPAGATED_INVALIDATION);
         } else {
-          invalidateActiveKeyCount(partitionConsumptionState, "Unexpected kcs signal value " + signal);
+          invalidateActiveKeyCount(
+              partitionConsumptionState,
+              ActiveKeyCountInvalidationReason.CORRUPT_KCS_SIGNAL_VALUE,
+              signal);
         }
       } else if (signalHeader != null && signalHeader.value() != null && signalHeader.value().length > 1) {
         invalidateActiveKeyCount(
             partitionConsumptionState,
-            "Unexpected multi-byte kcs signal (length=" + signalHeader.value().length + ")");
+            ActiveKeyCountInvalidationReason.CORRUPT_MULTI_BYTE_KCS_SIGNAL,
+            signalHeader.value().length);
       }
     }
   }
 
   /**
    * Sets the active key count to {@link OffsetRecord#ACTIVE_KEY_COUNT_NOT_TRACKED}, records the
-   * invalidation metric, and emits a rate-limited ERROR log. The state mutation and metric are
-   * wrapped in try/finally so the log fires even if either throws.
+   * invalidation metric on both the OTel and Tehuti paths, and emits a rate-limited ERROR log.
+   * The state mutation and metric are wrapped in try/finally so the log fires even if either throws.
    */
   final void invalidateActiveKeyCount(
       PartitionConsumptionState partitionConsumptionState,
-      String reason,
+      ActiveKeyCountInvalidationReason reason) {
+    invalidateActiveKeyCountAndLog(partitionConsumptionState, reason.getMessage(), null);
+  }
+
+  /**
+   * @param cause attached to the ERROR log; {@code null} yields a no-stack-trace log
+   */
+  final void invalidateActiveKeyCount(
+      PartitionConsumptionState partitionConsumptionState,
+      ActiveKeyCountInvalidationReason reason,
+      Throwable cause) {
+    invalidateActiveKeyCountAndLog(partitionConsumptionState, reason.getMessage(), cause);
+  }
+
+  /**
+   * @param detail integer rendered into the reason's {@code %d} placeholder
+   */
+  final void invalidateActiveKeyCount(
+      PartitionConsumptionState partitionConsumptionState,
+      ActiveKeyCountInvalidationReason reason,
+      int detail) {
+    invalidateActiveKeyCountAndLog(partitionConsumptionState, reason.getMessage(detail), null);
+  }
+
+  private void invalidateActiveKeyCountAndLog(
+      PartitionConsumptionState partitionConsumptionState,
+      String reasonText,
       Throwable cause) {
     try {
       partitionConsumptionState.setActiveKeyCount(ACTIVE_KEY_COUNT_NOT_TRACKED);
       recordActiveKeyCountInvalidation();
     } finally {
       String msg =
-          reason + " for replica " + partitionConsumptionState.getReplicaId() + "; invalidating activeKeyCount.";
+          reasonText + " for replica " + partitionConsumptionState.getReplicaId() + "; invalidating activeKeyCount.";
       if (!REDUNDANT_LOGGING_FILTER.isRedundantException(msg)) {
-        // log4j2's error(String, Throwable) accepts a null throwable, so this single call covers
-        // both with-cause and no-cause invocations.
         LOGGER.error(msg, cause);
       }
     }
-  }
-
-  final void invalidateActiveKeyCount(PartitionConsumptionState partitionConsumptionState, String reason) {
-    invalidateActiveKeyCount(partitionConsumptionState, reason, null);
   }
 
   /** Records active-key-count invalidation on both the OTel (per-version) and Tehuti (host-level) paths. */

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/AggVersionedIngestionStats.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/AggVersionedIngestionStats.java
@@ -43,6 +43,7 @@ public class AggVersionedIngestionStats
   private final String localRegionName;
   private final boolean emitOtelIngestionStats;
   private final boolean uniqueIngestedKeyCountHllEnabled;
+  private final boolean activeKeyCountEnabled;
 
   public AggVersionedIngestionStats(
       MetricsRepository metricsRepository,
@@ -58,6 +59,7 @@ public class AggVersionedIngestionStats
     this.localRegionName = RegionUtils.normalizeRegionName(serverConfig.getRegionName());
     this.emitOtelIngestionStats = serverConfig.isIngestionOtelStatsEnabled();
     this.uniqueIngestedKeyCountHllEnabled = serverConfig.isUniqueIngestedKeyCountHllEnabled();
+    this.activeKeyCountEnabled = serverConfig.isAnyActiveKeyCountTrackingEnabled();
   }
 
   /** Updates version info for existing OTel stats only. Null guard needed because eager loading
@@ -120,7 +122,8 @@ public class AggVersionedIngestionStats
           clusterName,
           localRegionName,
           emitOtelIngestionStats,
-          uniqueIngestedKeyCountHllEnabled);
+          uniqueIngestedKeyCountHllEnabled,
+          activeKeyCountEnabled);
       stats.updateVersionInfo(currentVersion, futureVersion);
       return stats;
     });

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/HostLevelIngestionStats.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/HostLevelIngestionStats.java
@@ -250,9 +250,6 @@ public class HostLevelIngestionStats extends AbstractVeniceStats {
         () -> totalStats.totalTombstoneCreationDCRRate,
         time);
 
-    // Active key count invalidation rate is only meaningful when active-key-count tracking is enabled.
-    // Gating by either config (batch or hybrid) keeps the metric absent on stores not opted into the
-    // feature, and matches the gating on the active_key_count gauge below.
     boolean activeKeyCountEnabled = serverConfig.isAnyActiveKeyCountTrackingEnabled();
     this.totalActiveKeyCountInvalidationRate = activeKeyCountEnabled
         ? registerOnlyTotalRate(
@@ -317,9 +314,8 @@ public class HostLevelIngestionStats extends AbstractVeniceStats {
       registerSensor(new AsyncGauge((ignored, ignored2) -> ingestionTaskMap.size(), "ingestion_task_count"));
     }
 
-    // Active key count gauge. ACTIVE_KEY_COUNT_NOT_TRACKED = not tracked, 0 = tracked but empty.
+    // ACTIVE_KEY_COUNT_NOT_TRACKED = not tracked, 0 = tracked but empty.
     // Cannot use measurable() because its 0-fallback conflates "untracked" with "empty".
-    // Gated by either active-key-count config — gauge is meaningless when neither tracking mode is on.
     if (activeKeyCountEnabled) {
       if (isTotalStats) {
         registerSensor(new AsyncGauge((ignored, ignored2) -> {

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/HostLevelIngestionStats.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/HostLevelIngestionStats.java
@@ -314,29 +314,7 @@ public class HostLevelIngestionStats extends AbstractVeniceStats {
       registerSensor(new AsyncGauge((ignored, ignored2) -> ingestionTaskMap.size(), "ingestion_task_count"));
     }
 
-    // ACTIVE_KEY_COUNT_NOT_TRACKED = not tracked, 0 = tracked but empty.
-    // Cannot use measurable() because its 0-fallback conflates "untracked" with "empty".
-    if (activeKeyCountEnabled) {
-      if (isTotalStats) {
-        registerSensor(new AsyncGauge((ignored, ignored2) -> {
-          long total = 0;
-          boolean anyTracked = false;
-          for (StoreIngestionTask task: ingestionTaskMap.values()) {
-            long storeCount = task.getActiveKeyCount();
-            if (storeCount != ACTIVE_KEY_COUNT_NOT_TRACKED) {
-              anyTracked = true;
-              total += storeCount;
-            }
-          }
-          return anyTracked ? total : ACTIVE_KEY_COUNT_NOT_TRACKED;
-        }, "active_key_count"));
-      } else {
-        registerSensor(new AsyncGauge((ignored, ignored2) -> {
-          StoreIngestionTask sit = ingestionTaskMap.get(storeName);
-          return sit == null ? ACTIVE_KEY_COUNT_NOT_TRACKED : sit.getActiveKeyCount();
-        }, "active_key_count"));
-      }
-    }
+    registerActiveKeyCountGauge(activeKeyCountEnabled, isTotalStats, ingestionTaskMap, storeName);
 
     // Stats which are per-store only:
     String keySizeSensorName = "record_key_size_in_bytes";
@@ -758,6 +736,36 @@ public class HostLevelIngestionStats extends AbstractVeniceStats {
     if (totalActiveKeyCountInvalidationRate != null) {
       totalActiveKeyCountInvalidationRate.record();
     }
+  }
+
+  /** Uses the ACTIVE_KEY_COUNT_NOT_TRACKED sentinel to distinguish untracked from empty (which {@code measurable()}'s 0-fallback would conflate). */
+  private void registerActiveKeyCountGauge(
+      boolean activeKeyCountEnabled,
+      boolean isTotalStats,
+      Map<String, StoreIngestionTask> ingestionTaskMap,
+      String storeName) {
+    if (!activeKeyCountEnabled) {
+      return;
+    }
+    if (isTotalStats) {
+      registerSensor(new AsyncGauge((ignored, ignored2) -> {
+        long total = 0;
+        boolean anyTracked = false;
+        for (StoreIngestionTask task: ingestionTaskMap.values()) {
+          long storeCount = task.getActiveKeyCount();
+          if (storeCount != ACTIVE_KEY_COUNT_NOT_TRACKED) {
+            anyTracked = true;
+            total += storeCount;
+          }
+        }
+        return anyTracked ? total : ACTIVE_KEY_COUNT_NOT_TRACKED;
+      }, "active_key_count"));
+      return;
+    }
+    registerSensor(new AsyncGauge((ignored, ignored2) -> {
+      StoreIngestionTask sit = ingestionTaskMap.get(storeName);
+      return sit == null ? ACTIVE_KEY_COUNT_NOT_TRACKED : sit.getActiveKeyCount();
+    }, "active_key_count"));
   }
 
   public void recordTotalLeaderBytesConsumed(long bytes) {

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/HostLevelIngestionStats.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/HostLevelIngestionStats.java
@@ -250,11 +250,17 @@ public class HostLevelIngestionStats extends AbstractVeniceStats {
         () -> totalStats.totalTombstoneCreationDCRRate,
         time);
 
-    this.totalActiveKeyCountInvalidationRate = registerOnlyTotalRate(
-        "active_key_count_invalidation",
-        totalStats,
-        () -> totalStats.totalActiveKeyCountInvalidationRate,
-        time);
+    // Active key count invalidation rate is only meaningful when active-key-count tracking is enabled.
+    // Gating by either config (batch or hybrid) keeps the metric absent on stores not opted into the
+    // feature, and matches the gating on the active_key_count gauge below.
+    boolean activeKeyCountEnabled = serverConfig.isAnyActiveKeyCountTrackingEnabled();
+    this.totalActiveKeyCountInvalidationRate = activeKeyCountEnabled
+        ? registerOnlyTotalRate(
+            "active_key_count_invalidation",
+            totalStats,
+            () -> totalStats.totalActiveKeyCountInvalidationRate,
+            time)
+        : null;
 
     this.totalTimestampRegressionDCRErrorRate = registerOnlyTotalRate(
         "timestamp_regression_dcr_error",
@@ -313,24 +319,27 @@ public class HostLevelIngestionStats extends AbstractVeniceStats {
 
     // Active key count gauge. ACTIVE_KEY_COUNT_NOT_TRACKED = not tracked, 0 = tracked but empty.
     // Cannot use measurable() because its 0-fallback conflates "untracked" with "empty".
-    if (isTotalStats) {
-      registerSensor(new AsyncGauge((ignored, ignored2) -> {
-        long total = 0;
-        boolean anyTracked = false;
-        for (StoreIngestionTask task: ingestionTaskMap.values()) {
-          long storeCount = task.getActiveKeyCount();
-          if (storeCount != ACTIVE_KEY_COUNT_NOT_TRACKED) {
-            anyTracked = true;
-            total += storeCount;
+    // Gated by either active-key-count config — gauge is meaningless when neither tracking mode is on.
+    if (activeKeyCountEnabled) {
+      if (isTotalStats) {
+        registerSensor(new AsyncGauge((ignored, ignored2) -> {
+          long total = 0;
+          boolean anyTracked = false;
+          for (StoreIngestionTask task: ingestionTaskMap.values()) {
+            long storeCount = task.getActiveKeyCount();
+            if (storeCount != ACTIVE_KEY_COUNT_NOT_TRACKED) {
+              anyTracked = true;
+              total += storeCount;
+            }
           }
-        }
-        return anyTracked ? total : ACTIVE_KEY_COUNT_NOT_TRACKED;
-      }, "active_key_count"));
-    } else {
-      registerSensor(new AsyncGauge((ignored, ignored2) -> {
-        StoreIngestionTask sit = ingestionTaskMap.get(storeName);
-        return sit == null ? ACTIVE_KEY_COUNT_NOT_TRACKED : sit.getActiveKeyCount();
-      }, "active_key_count"));
+          return anyTracked ? total : ACTIVE_KEY_COUNT_NOT_TRACKED;
+        }, "active_key_count"));
+      } else {
+        registerSensor(new AsyncGauge((ignored, ignored2) -> {
+          StoreIngestionTask sit = ingestionTaskMap.get(storeName);
+          return sit == null ? ACTIVE_KEY_COUNT_NOT_TRACKED : sit.getActiveKeyCount();
+        }, "active_key_count"));
+      }
     }
 
     // Stats which are per-store only:
@@ -750,7 +759,9 @@ public class HostLevelIngestionStats extends AbstractVeniceStats {
   }
 
   public void recordActiveKeyCountInvalidation() {
-    totalActiveKeyCountInvalidationRate.record();
+    if (totalActiveKeyCountInvalidationRate != null) {
+      totalActiveKeyCountInvalidationRate.record();
+    }
   }
 
   public void recordTotalLeaderBytesConsumed(long bytes) {

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/ingestion/IngestionOtelStats.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/ingestion/IngestionOtelStats.java
@@ -406,7 +406,6 @@ public class IngestionOtelStats {
     /*
      * Mid-cycle leader/follower transitions can briefly double-count or skip a partition;
      * self-corrects on the next collection.
-     * Gated by either active-key-count config — gauge is meaningless when neither tracking mode is on.
      */
     if (activeKeyCountEnabled) {
       activeKeyCountByRoleAndReplicaType = createAsyncByRoleAndReplicaType(

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/ingestion/IngestionOtelStats.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/ingestion/IngestionOtelStats.java
@@ -275,7 +275,8 @@ public class IngestionOtelStats {
       String clusterName,
       String localRegionName,
       boolean ingestionOtelStatsEnabled,
-      boolean uniqueIngestedKeyCountHllEnabled) {
+      boolean uniqueIngestedKeyCountHllEnabled,
+      boolean activeKeyCountEnabled) {
     OpenTelemetryMetricsSetup.OpenTelemetryMetricsSetupInfo otelSetup =
         OpenTelemetryMetricsSetup.builder(metricsRepository)
             .setOtelEnabledOverride(ingestionOtelStatsEnabled)
@@ -383,7 +384,8 @@ public class IngestionOtelStats {
     checksumVerificationFailureCountMetric = createOneEnumMetric(CHECKSUM_VERIFICATION_FAILURE_COUNT.getMetricEntity());
     partialUpdateAmplificationAlertCountMetric =
         createOneEnumMetric(PARTIAL_UPDATE_AMPLIFICATION_ALERT_COUNT.getMetricEntity());
-    activeKeyCountInvalidationMetric = createOneEnumMetric(ACTIVE_KEY_COUNT_INVALIDATION.getMetricEntity());
+    activeKeyCountInvalidationMetric =
+        activeKeyCountEnabled ? createOneEnumMetric(ACTIVE_KEY_COUNT_INVALIDATION.getMetricEntity()) : null;
 
     // Initialize HostLevelIngestionStats OTel metrics - counters with 2nd enum dimension
     ingestionFailureCountMetric =
@@ -404,11 +406,16 @@ public class IngestionOtelStats {
     /*
      * Mid-cycle leader/follower transitions can briefly double-count or skip a partition;
      * self-corrects on the next collection.
+     * Gated by either active-key-count config — gauge is meaningless when neither tracking mode is on.
      */
-    activeKeyCountByRoleAndReplicaType = createAsyncByRoleAndReplicaType(
-        ACTIVE_KEY_COUNT.getMetricEntity(),
-        (role, replicaType) -> getTaskForRole(role),
-        (task, role, replicaType) -> task.getActiveKeyCount(replicaType));
+    if (activeKeyCountEnabled) {
+      activeKeyCountByRoleAndReplicaType = createAsyncByRoleAndReplicaType(
+          ACTIVE_KEY_COUNT.getMetricEntity(),
+          (role, replicaType) -> getTaskForRole(role),
+          (task, role, replicaType) -> task.getActiveKeyCount(replicaType));
+    } else {
+      activeKeyCountByRoleAndReplicaType = null;
+    }
 
     if (uniqueIngestedKeyCountHllEnabled) {
       uniqueIngestedKeyCountByRoleAndReplicaType = createAsyncByRoleAndReplicaType(
@@ -801,7 +808,9 @@ public class IngestionOtelStats {
   }
 
   public void recordActiveKeyCountInvalidation(int version) {
-    activeKeyCountInvalidationMetric.record(1, classifyVersion(version, versionInfo));
+    if (activeKeyCountInvalidationMetric != null) {
+      activeKeyCountInvalidationMetric.record(1, classifyVersion(version, versionInfo));
+    }
   }
 
 }

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/ActiveKeyCountScenarioTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/ActiveKeyCountScenarioTest.java
@@ -348,8 +348,10 @@ public class ActiveKeyCountScenarioTest {
             .build());
     AsyncGauge.AsyncGaugeExecutor asyncGaugeExecutor = new AsyncGauge.AsyncGaugeExecutor.Builder().build();
     TestMockTime mockTime = new TestMockTime();
-    // 3-arg ctor wires mockTime into MetricsRepository.measure(now); the 1-arg MetricConfig form
-    // silently uses SystemTime, which would defeat the time-advance below.
+    /*
+     * 3-arg ctor wires mockTime into MetricsRepository.measure(now); the 1-arg MetricConfig form
+     * silently uses SystemTime, which would defeat the time-advance below.
+     */
     MetricsRepository tehutiRepo =
         new MetricsRepository(new MetricConfig(asyncGaugeExecutor), Collections.emptyList(), mockTime);
 
@@ -386,8 +388,10 @@ public class ActiveKeyCountScenarioTest {
           ACTIVE_KEY_COUNT_INVALIDATION.getMetricEntity().getMetricName(),
           TEST_PREFIX);
 
-      // LongAdderRateGauge caches its value for RATE_GAUGE_CACHE_DURATION_IN_SECONDS; advance past
-      // the window to force a fresh measurement.
+      /*
+       * LongAdderRateGauge caches its value for RATE_GAUGE_CACHE_DURATION_IN_SECONDS; advance past
+       * the window to force a fresh measurement.
+       */
       mockTime.addMilliseconds(LongAdderRateGauge.RATE_GAUGE_CACHE_DURATION_IN_SECONDS * Time.MS_PER_SECOND);
       assertEquals(
           tehutiRepo.getMetric(".total--active_key_count_invalidation.Rate").value(),

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/ActiveKeyCountScenarioTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/ActiveKeyCountScenarioTest.java
@@ -338,7 +338,7 @@ public class ActiveKeyCountScenarioTest {
 
   /** A single invalidation event must increment both the Tehuti rate and the OTel counter exactly once. */
   @Test
-  public void testInvalidationParity_tehutiAndOtelBothRecord() {
+  public void testInvalidationParityRecordsToBothTehutiAndOtel() {
     InMemoryMetricReader reader = InMemoryMetricReader.create();
     VeniceMetricsRepository otelRepo = new VeniceMetricsRepository(
         new VeniceMetricsConfig.Builder().setMetricEntities(SERVER_METRIC_ENTITIES)

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/ActiveKeyCountScenarioTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/ActiveKeyCountScenarioTest.java
@@ -38,8 +38,8 @@ import io.tehuti.metrics.MetricsRepository;
 import io.tehuti.metrics.stats.AsyncGauge;
 import it.unimi.dsi.fastutil.ints.Int2ObjectMaps;
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import org.testng.annotations.DataProvider;
@@ -336,13 +336,7 @@ public class ActiveKeyCountScenarioTest {
     }
   }
 
-  /**
-   * Parity guard: a single invalidation event must be reflected in BOTH systems exactly once.
-   * Production calls flow through {@code StoreIngestionTask.recordActiveKeyCountInvalidation()}
-   * which fans out to {@code IngestionOtelStats} (per-version OTel counter) and
-   * {@code HostLevelIngestionStats} (host-level Tehuti rate). If a future change drops one fan-out
-   * leg, this test fails.
-   */
+  /** A single invalidation event must increment both the Tehuti rate and the OTel counter exactly once. */
   @Test
   public void testInvalidationParity_tehutiAndOtelBothRecord() {
     InMemoryMetricReader reader = InMemoryMetricReader.create();
@@ -354,19 +348,16 @@ public class ActiveKeyCountScenarioTest {
             .build());
     AsyncGauge.AsyncGaugeExecutor asyncGaugeExecutor = new AsyncGauge.AsyncGaugeExecutor.Builder().build();
     TestMockTime mockTime = new TestMockTime();
-    // 3-arg constructor wires mockTime into MetricsRepository.measure(now), so the LongAdderRateGauge
-    // sees the time we advance below. The 1-arg MetricsRepository(MetricConfig) form silently uses
-    // SystemTime and ignores mockTime — which is the trap that made this test fail on the first try.
+    // 3-arg ctor wires mockTime into MetricsRepository.measure(now); the 1-arg MetricConfig form
+    // silently uses SystemTime, which would defeat the time-advance below.
     MetricsRepository tehutiRepo =
-        new MetricsRepository(new MetricConfig(asyncGaugeExecutor), new ArrayList<>(0), mockTime);
+        new MetricsRepository(new MetricConfig(asyncGaugeExecutor), Collections.emptyList(), mockTime);
 
     try {
-      // OTel side: feature enabled.
       IngestionOtelStats otelStats =
           new IngestionOtelStats(otelRepo, STORE_NAME, CLUSTER_NAME, LOCAL_REGION, true, false, true);
       otelStats.updateVersionInfo(CURRENT_VERSION, FUTURE_VERSION);
 
-      // Tehuti side: enable the active-key-count rate registration via the new gating helper.
       VeniceServerConfig mockServerConfig = mock(VeniceServerConfig.class);
       doReturn(Int2ObjectMaps.emptyMap()).when(mockServerConfig).getKafkaClusterIdToAliasMap();
       doReturn(CLUSTER_NAME).when(mockServerConfig).getClusterName();
@@ -380,12 +371,9 @@ public class ActiveKeyCountScenarioTest {
           mock(ReadOnlyStoreRepository.class),
           true,
           mockTime);
-      // Production fan-out: StoreIngestionTask.recordActiveKeyCountInvalidation() invokes BOTH
-      // sides for a single event. Mirror that here.
       aggStats.getStoreStats(STORE_NAME).recordActiveKeyCountInvalidation();
       otelStats.recordActiveKeyCountInvalidation(CURRENT_VERSION);
 
-      // OTel: counter must read exactly 1 for the (store, cluster, version_role=CURRENT) point.
       Attributes invalidationAttrs = Attributes.builder()
           .put(VENICE_STORE_NAME.getDimensionNameInDefaultFormat(), STORE_NAME)
           .put(VENICE_CLUSTER_NAME.getDimensionNameInDefaultFormat(), CLUSTER_NAME)
@@ -398,9 +386,8 @@ public class ActiveKeyCountScenarioTest {
           ACTIVE_KEY_COUNT_INVALIDATION.getMetricEntity().getMetricName(),
           TEST_PREFIX);
 
-      // Tehuti: Rate gauge holds the cached value for RATE_GAUGE_CACHE_DURATION_IN_SECONDS;
-      // advance mock time past the cache window so the underlying LongAdder is drained into a
-      // measurable rate value (1 event / 30s window).
+      // LongAdderRateGauge caches its value for RATE_GAUGE_CACHE_DURATION_IN_SECONDS; advance past
+      // the window to force a fresh measurement.
       mockTime.addMilliseconds(LongAdderRateGauge.RATE_GAUGE_CACHE_DURATION_IN_SECONDS * Time.MS_PER_SECOND);
       assertEquals(
           tehutiRepo.getMetric(".total--active_key_count_invalidation.Rate").value(),
@@ -474,7 +461,6 @@ public class ActiveKeyCountScenarioTest {
     VeniceServerConfig mockServerConfig = mock(VeniceServerConfig.class);
     doReturn(Int2ObjectMaps.emptyMap()).when(mockServerConfig).getKafkaClusterIdToAliasMap();
     doReturn(CLUSTER_NAME).when(mockServerConfig).getClusterName();
-    // The active-key-count gauge and invalidation rate are gated by isAnyActiveKeyCountTrackingEnabled().
     doReturn(true).when(mockServerConfig).isAnyActiveKeyCountTrackingEnabled();
     Map<String, StoreIngestionTask> taskMap = new HashMap<>();
     taskMap.put(STORE_NAME, mockTask);

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/ActiveKeyCountScenarioTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/ActiveKeyCountScenarioTest.java
@@ -7,10 +7,12 @@ import static com.linkedin.davinci.kafka.consumer.ActiveKeyCountTestUtils.freshP
 import static com.linkedin.davinci.kafka.consumer.ActiveKeyCountTestUtils.restoreFrom;
 import static com.linkedin.davinci.stats.ServerMetricEntity.SERVER_METRIC_ENTITIES;
 import static com.linkedin.davinci.stats.ingestion.IngestionOtelMetricEntity.ACTIVE_KEY_COUNT;
+import static com.linkedin.davinci.stats.ingestion.IngestionOtelMetricEntity.ACTIVE_KEY_COUNT_INVALIDATION;
 import static com.linkedin.venice.stats.dimensions.VeniceMetricsDimensions.VENICE_CLUSTER_NAME;
 import static com.linkedin.venice.stats.dimensions.VeniceMetricsDimensions.VENICE_REPLICA_TYPE;
 import static com.linkedin.venice.stats.dimensions.VeniceMetricsDimensions.VENICE_STORE_NAME;
 import static com.linkedin.venice.stats.dimensions.VeniceMetricsDimensions.VENICE_VERSION_ROLE;
+import static com.linkedin.venice.utils.OpenTelemetryDataTestUtils.validateLongPointDataFromCounter;
 import static com.linkedin.venice.utils.OpenTelemetryDataTestUtils.validateLongPointDataFromGauge;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doCallRealMethod;
@@ -23,10 +25,12 @@ import com.linkedin.davinci.stats.AggHostLevelIngestionStats;
 import com.linkedin.davinci.stats.ingestion.IngestionOtelStats;
 import com.linkedin.venice.meta.ReadOnlyStoreRepository;
 import com.linkedin.venice.server.VersionRole;
+import com.linkedin.venice.stats.LongAdderRateGauge;
 import com.linkedin.venice.stats.VeniceMetricsConfig;
 import com.linkedin.venice.stats.VeniceMetricsRepository;
 import com.linkedin.venice.stats.dimensions.ReplicaType;
 import com.linkedin.venice.utils.TestMockTime;
+import com.linkedin.venice.utils.Time;
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.sdk.testing.exporter.InMemoryMetricReader;
 import io.tehuti.metrics.MetricConfig;
@@ -34,6 +38,7 @@ import io.tehuti.metrics.MetricsRepository;
 import io.tehuti.metrics.stats.AsyncGauge;
 import it.unimi.dsi.fastutil.ints.Int2ObjectMaps;
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
@@ -331,6 +336,87 @@ public class ActiveKeyCountScenarioTest {
     }
   }
 
+  /**
+   * Parity guard: a single invalidation event must be reflected in BOTH systems exactly once.
+   * Production calls flow through {@code StoreIngestionTask.recordActiveKeyCountInvalidation()}
+   * which fans out to {@code IngestionOtelStats} (per-version OTel counter) and
+   * {@code HostLevelIngestionStats} (host-level Tehuti rate). If a future change drops one fan-out
+   * leg, this test fails.
+   */
+  @Test
+  public void testInvalidationParity_tehutiAndOtelBothRecord() {
+    InMemoryMetricReader reader = InMemoryMetricReader.create();
+    VeniceMetricsRepository otelRepo = new VeniceMetricsRepository(
+        new VeniceMetricsConfig.Builder().setMetricEntities(SERVER_METRIC_ENTITIES)
+            .setMetricPrefix(TEST_PREFIX)
+            .setEmitOtelMetrics(true)
+            .setOtelAdditionalMetricsReader(reader)
+            .build());
+    AsyncGauge.AsyncGaugeExecutor asyncGaugeExecutor = new AsyncGauge.AsyncGaugeExecutor.Builder().build();
+    TestMockTime mockTime = new TestMockTime();
+    // 3-arg constructor wires mockTime into MetricsRepository.measure(now), so the LongAdderRateGauge
+    // sees the time we advance below. The 1-arg MetricsRepository(MetricConfig) form silently uses
+    // SystemTime and ignores mockTime — which is the trap that made this test fail on the first try.
+    MetricsRepository tehutiRepo =
+        new MetricsRepository(new MetricConfig(asyncGaugeExecutor), new ArrayList<>(0), mockTime);
+
+    try {
+      // OTel side: feature enabled.
+      IngestionOtelStats otelStats =
+          new IngestionOtelStats(otelRepo, STORE_NAME, CLUSTER_NAME, LOCAL_REGION, true, false, true);
+      otelStats.updateVersionInfo(CURRENT_VERSION, FUTURE_VERSION);
+
+      // Tehuti side: enable the active-key-count rate registration via the new gating helper.
+      VeniceServerConfig mockServerConfig = mock(VeniceServerConfig.class);
+      doReturn(Int2ObjectMaps.emptyMap()).when(mockServerConfig).getKafkaClusterIdToAliasMap();
+      doReturn(CLUSTER_NAME).when(mockServerConfig).getClusterName();
+      doReturn(true).when(mockServerConfig).isAnyActiveKeyCountTrackingEnabled();
+      Map<String, StoreIngestionTask> taskMap = new HashMap<>();
+      taskMap.put(STORE_NAME, mock(StoreIngestionTask.class));
+      AggHostLevelIngestionStats aggStats = new AggHostLevelIngestionStats(
+          tehutiRepo,
+          mockServerConfig,
+          taskMap,
+          mock(ReadOnlyStoreRepository.class),
+          true,
+          mockTime);
+      // Production fan-out: StoreIngestionTask.recordActiveKeyCountInvalidation() invokes BOTH
+      // sides for a single event. Mirror that here.
+      aggStats.getStoreStats(STORE_NAME).recordActiveKeyCountInvalidation();
+      otelStats.recordActiveKeyCountInvalidation(CURRENT_VERSION);
+
+      // OTel: counter must read exactly 1 for the (store, cluster, version_role=CURRENT) point.
+      Attributes invalidationAttrs = Attributes.builder()
+          .put(VENICE_STORE_NAME.getDimensionNameInDefaultFormat(), STORE_NAME)
+          .put(VENICE_CLUSTER_NAME.getDimensionNameInDefaultFormat(), CLUSTER_NAME)
+          .put(VENICE_VERSION_ROLE.getDimensionNameInDefaultFormat(), VersionRole.CURRENT.getDimensionValue())
+          .build();
+      validateLongPointDataFromCounter(
+          reader,
+          1L,
+          invalidationAttrs,
+          ACTIVE_KEY_COUNT_INVALIDATION.getMetricEntity().getMetricName(),
+          TEST_PREFIX);
+
+      // Tehuti: Rate gauge holds the cached value for RATE_GAUGE_CACHE_DURATION_IN_SECONDS;
+      // advance mock time past the cache window so the underlying LongAdder is drained into a
+      // measurable rate value (1 event / 30s window).
+      mockTime.addMilliseconds(LongAdderRateGauge.RATE_GAUGE_CACHE_DURATION_IN_SECONDS * Time.MS_PER_SECOND);
+      assertEquals(
+          tehutiRepo.getMetric(".total--active_key_count_invalidation.Rate").value(),
+          1d / LongAdderRateGauge.RATE_GAUGE_CACHE_DURATION_IN_SECONDS,
+          "Tehuti rate must reflect exactly the one invalidation we recorded");
+    } finally {
+      otelRepo.close();
+      // Do NOT close tehutiRepo — see MetricsTestContext.close() rationale.
+      try {
+        asyncGaugeExecutor.close();
+      } catch (IOException ignored) {
+        // best-effort
+      }
+    }
+  }
+
   // OTel helpers
 
   private Attributes buildAttributes(VersionRole versionRole, ReplicaType replicaType) {
@@ -377,7 +463,7 @@ public class ActiveKeyCountScenarioTest {
             .setOtelAdditionalMetricsReader(reader)
             .build());
     IngestionOtelStats otelStats =
-        new IngestionOtelStats(otelRepo, STORE_NAME, CLUSTER_NAME, LOCAL_REGION, true, false);
+        new IngestionOtelStats(otelRepo, STORE_NAME, CLUSTER_NAME, LOCAL_REGION, true, false, true);
     otelStats.updateVersionInfo(CURRENT_VERSION, FUTURE_VERSION);
     otelStats.setIngestionTask(CURRENT_VERSION, mockTask);
 
@@ -388,6 +474,8 @@ public class ActiveKeyCountScenarioTest {
     VeniceServerConfig mockServerConfig = mock(VeniceServerConfig.class);
     doReturn(Int2ObjectMaps.emptyMap()).when(mockServerConfig).getKafkaClusterIdToAliasMap();
     doReturn(CLUSTER_NAME).when(mockServerConfig).getClusterName();
+    // The active-key-count gauge and invalidation rate are gated by isAnyActiveKeyCountTrackingEnabled().
+    doReturn(true).when(mockServerConfig).isAnyActiveKeyCountTrackingEnabled();
     Map<String, StoreIngestionTask> taskMap = new HashMap<>();
     taskMap.put(STORE_NAME, mockTask);
     AggHostLevelIngestionStats aggStats = new AggHostLevelIngestionStats(

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/ActiveKeyCountTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/ActiveKeyCountTest.java
@@ -15,6 +15,7 @@ import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.testng.Assert.assertEquals;
 
@@ -35,6 +36,7 @@ import com.linkedin.venice.kafka.protocol.KafkaMessageEnvelope;
 import com.linkedin.venice.kafka.protocol.ProducerMetadata;
 import com.linkedin.venice.kafka.protocol.Put;
 import com.linkedin.venice.kafka.protocol.enums.MessageType;
+import com.linkedin.venice.logger.TestLogAppender;
 import com.linkedin.venice.message.KafkaKey;
 import com.linkedin.venice.offsets.OffsetRecord;
 import com.linkedin.venice.pubsub.api.DefaultPubSubMessage;
@@ -50,6 +52,9 @@ import java.nio.ByteBuffer;
 import java.util.Map;
 import java.util.Optional;
 import org.apache.avro.generic.GenericRecord;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.core.Logger;
+import org.apache.logging.log4j.core.layout.PatternLayout;
 import org.testng.Assert;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.DataProvider;
@@ -87,6 +92,11 @@ public class ActiveKeyCountTest {
     doCallRealMethod().when(ingestionTask).checkStorageOperationCommonInvalidPattern(any(), any());
     doCallRealMethod().when(ingestionTask).getStorageOperationTypeForPut(anyInt(), any());
     doCallRealMethod().when(ingestionTask).getStorageOperationTypeForDelete(anyInt(), any());
+    // invalidateActiveKeyCount is protected final, so Mockito intercepts it on the mock by default;
+    // call the real method so setActiveKeyCount(-1) and recordActiveKeyCountInvalidation actually fire.
+    doCallRealMethod().when(ingestionTask).invalidateActiveKeyCount(any(PartitionConsumptionState.class), anyString());
+    doCallRealMethod().when(ingestionTask)
+        .invalidateActiveKeyCount(any(PartitionConsumptionState.class), anyString(), any());
     setField(ingestionTask, "hostLevelIngestionStats", mock(HostLevelIngestionStats.class));
     doReturn(mock(HostLevelIngestionStats.class)).when(ingestionTask).getHostLevelIngestionStats();
     AggVersionedIngestionStats mockAggStats = mock(AggVersionedIngestionStats.class);
@@ -607,6 +617,111 @@ public class ActiveKeyCountTest {
     verify(mockPcs).setActiveKeyCount(-1);
   }
 
+  @Test
+  public void testTrackActiveKeyCount_followerUnderflow_routesThroughInvalidateHelper() throws Exception {
+    setupForTrackActiveKeyCount(false, true, true);
+
+    // Decrement returns false simulating underflow (count was 0 or stale -1 path produced false).
+    PartitionConsumptionState mockPcs = createMockPcsForTrack(true, 5L);
+    doReturn(false).when(mockPcs).decrementActiveKeyCount();
+    doReturn("replica-underflow").when(mockPcs).getReplicaId();
+
+    invokeTrackActiveKeyCount(
+        createMockConsumerRecord(createSignalHeaders(ActiveActiveStoreIngestionTask.KEY_DELETED_SIGNAL_VALUE)),
+        mockPcs,
+        null,
+        MessageType.DELETE,
+        USER_SCHEMA_ID);
+
+    // Underflow now routes through invalidateActiveKeyCount: setter is called explicitly,
+    // and the shared invalidation metric helper is invoked exactly once (no double-counting).
+    verify(mockPcs).decrementActiveKeyCount();
+    verify(mockPcs).setActiveKeyCount(OffsetRecord.ACTIVE_KEY_COUNT_NOT_TRACKED);
+    verify(ingestionTask, times(1)).recordActiveKeyCountInvalidation();
+  }
+
+  @Test
+  public void testTrackActiveKeyCount_followerInvalidationLogsError() throws Exception {
+    TestLogAppender appender = new TestLogAppender("ActiveKeyCountTestAppender", PatternLayout.createDefaultLayout());
+    appender.start();
+    Logger logger = (Logger) LogManager.getLogger(StoreIngestionTask.class);
+    logger.addAppender(appender);
+    try {
+      setupForTrackActiveKeyCount(false, true, true);
+
+      // Path 3: decrement underflow.
+      PartitionConsumptionState underflowPcs = createMockPcsForTrack(true, 5L);
+      doReturn(false).when(underflowPcs).decrementActiveKeyCount();
+      doReturn("replica-underflow").when(underflowPcs).getReplicaId();
+      invokeTrackActiveKeyCount(
+          createMockConsumerRecord(createSignalHeaders(ActiveActiveStoreIngestionTask.KEY_DELETED_SIGNAL_VALUE)),
+          underflowPcs,
+          null,
+          MessageType.DELETE,
+          USER_SCHEMA_ID);
+
+      // Path 4: explicit invalidate signal.
+      PartitionConsumptionState invalidatePcs = createMockPcsForTrack(true, 5L);
+      doReturn("replica-invalidate").when(invalidatePcs).getReplicaId();
+      invokeTrackActiveKeyCount(
+          createMockConsumerRecord(
+              createSignalHeaders(ActiveActiveStoreIngestionTask.KEY_COUNT_INVALIDATE_SIGNAL_VALUE)),
+          invalidatePcs,
+          null,
+          MessageType.PUT,
+          USER_SCHEMA_ID);
+
+      // Path 5: corrupt single-byte kcs (any value outside {-1, 0, +1}).
+      PartitionConsumptionState corruptByteValuePcs = createMockPcsForTrack(true, 5L);
+      doReturn("replica-corrupt-byte").when(corruptByteValuePcs).getReplicaId();
+      invokeTrackActiveKeyCount(
+          createMockConsumerRecord(createSignalHeaders((byte) 99)),
+          corruptByteValuePcs,
+          null,
+          MessageType.PUT,
+          USER_SCHEMA_ID);
+
+      // Path 6: multi-byte kcs (length > 1) — corrupt or future producer.
+      PartitionConsumptionState multiBytePcs = createMockPcsForTrack(true, 5L);
+      doReturn("replica-multibyte").when(multiBytePcs).getReplicaId();
+      PubSubMessageHeaders multiByteHeaders = new PubSubMessageHeaders();
+      multiByteHeaders.add(new PubSubMessageHeader(StoreIngestionTask.KEY_COUNT_SIGNAL_HEADER, new byte[] { 1, 2, 3 }));
+      invokeTrackActiveKeyCount(
+          createMockConsumerRecord(multiByteHeaders),
+          multiBytePcs,
+          null,
+          MessageType.PUT,
+          USER_SCHEMA_ID);
+
+      String capturedLog = appender.getLog();
+      Assert.assertTrue(
+          capturedLog.contains("Decrement underflow on follower from kcs=-1")
+              && capturedLog.contains("replica-underflow"),
+          "Expected follower-side underflow ERROR with replica id; got: " + capturedLog);
+      Assert.assertTrue(
+          capturedLog.contains("Leader propagated invalidation") && capturedLog.contains("replica-invalidate"),
+          "Expected leader-invalidate ERROR with replica id; got: " + capturedLog);
+      Assert.assertTrue(
+          capturedLog.contains("Unexpected kcs signal value 99") && capturedLog.contains("replica-corrupt-byte"),
+          "Expected corrupt single-byte ERROR with replica id; got: " + capturedLog);
+      Assert.assertTrue(
+          capturedLog.contains("Unexpected multi-byte kcs signal (length=3)")
+              && capturedLog.contains("replica-multibyte"),
+          "Expected multi-byte ERROR with replica id; got: " + capturedLog);
+
+      // Each path also routed through the helper, so all four invalidations went through both the
+      // setter and the metric recorder.
+      verify(underflowPcs).setActiveKeyCount(OffsetRecord.ACTIVE_KEY_COUNT_NOT_TRACKED);
+      verify(invalidatePcs).setActiveKeyCount(OffsetRecord.ACTIVE_KEY_COUNT_NOT_TRACKED);
+      verify(corruptByteValuePcs).setActiveKeyCount(OffsetRecord.ACTIVE_KEY_COUNT_NOT_TRACKED);
+      verify(multiBytePcs).setActiveKeyCount(OffsetRecord.ACTIVE_KEY_COUNT_NOT_TRACKED);
+      verify(ingestionTask, times(4)).recordActiveKeyCountInvalidation();
+    } finally {
+      logger.removeAppender(appender);
+      appender.stop();
+    }
+  }
+
   @Test(dataProvider = "followerSignalSkippedCases")
   public void testTrackActiveKeyCount_followerSignal_skipped(
       boolean hybridEnabled,
@@ -751,6 +866,50 @@ public class ActiveKeyCountTest {
         0L,
         0L);
     verifyNoCountChange(pcs);
+  }
+
+  @Test
+  public void testProcessMessage_leaderUnderflow_routesThroughInvalidateHelper() throws Exception {
+    // Leader detects an underflow during DCR (count was 0, but a delete arrived). The underflow
+    // path must (1) set the count to ACTIVE_KEY_COUNT_NOT_TRACKED via the helper, (2) record the
+    // invalidation metric, and (3) emit a rate-limited ERROR log identifying the leader path.
+    setupForProcessMessageTests(true);
+    PartitionConsumptionState localPcs = mock(PartitionConsumptionState.class);
+    doReturn(true).when(localPcs).isEndOfPushReceived();
+    // Count >= 0 so computeActiveKeyCountSignal does not take the early "already invalidated" branch.
+    doReturn(0L).when(localPcs).getActiveKeyCount();
+    // The atomic getAndUpdate inside decrementActiveKeyCount sets -1 internally and returns false
+    // to signal underflow.
+    doReturn(false).when(localPcs).decrementActiveKeyCount();
+    doReturn("leader-replica-underflow").when(localPcs).getReplicaId();
+
+    TestLogAppender appender = new TestLogAppender("LeaderUnderflowAppender", PatternLayout.createDefaultLayout());
+    appender.start();
+    Logger logger = (Logger) LogManager.getLogger(StoreIngestionTask.class);
+    logger.addAppender(appender);
+    try {
+      ingestionTask.processMessageAndMaybeProduceToKafka(
+          createWrapperWithResult(createMockMergeConflictResultWrapper(false, true, false)),
+          localPcs,
+          PARTITION,
+          "url",
+          0,
+          0L,
+          0L);
+
+      verify(localPcs).decrementActiveKeyCount();
+      verify(localPcs).setActiveKeyCount(OffsetRecord.ACTIVE_KEY_COUNT_NOT_TRACKED);
+      verify(ingestionTask, times(1)).recordActiveKeyCountInvalidation();
+
+      String capturedLog = appender.getLog();
+      Assert.assertTrue(
+          capturedLog.contains("Decrement underflow on leader during DCR")
+              && capturedLog.contains("leader-replica-underflow"),
+          "Expected leader-side underflow ERROR with replica id; got: " + capturedLog);
+    } finally {
+      logger.removeAppender(appender);
+      appender.stop();
+    }
   }
 
   @Test
@@ -976,11 +1135,30 @@ public class ActiveKeyCountTest {
     // Tier 3: keyExists throws VeniceException (simulating transient RocksDB I/O failure)
     doThrow(new VeniceException("disk error")).when(storageEngine).keyExists(anyInt(), any(byte[].class));
 
-    // Should return false (assume key absent) and NOT propagate the exception
-    Assert.assertFalse(invokeIsValuePresentForKey(Lazy.of(() -> null), pcs, KEY_BYTES));
+    TestLogAppender appender = new TestLogAppender("Tier3KeyExistsAppender", PatternLayout.createDefaultLayout());
+    appender.start();
+    Logger logger = (Logger) LogManager.getLogger(StoreIngestionTask.class);
+    logger.addAppender(appender);
+    try {
+      // Should return false (assume key absent) and NOT propagate the exception
+      Assert.assertFalse(invokeIsValuePresentForKey(Lazy.of(() -> null), pcs, KEY_BYTES));
 
-    // Count must be invalidated to -1
-    verify(pcs).setActiveKeyCount(-1);
+      // Count must be invalidated to -1
+      verify(pcs).setActiveKeyCount(-1);
+
+      // Helper must emit a rate-limited ERROR with the keyExists reason and the replica id.
+      // We don't assert on the attached throwable here because TestLogAppender only captures the
+      // formatted message, not the throwable. The 3-arg invalidateActiveKeyCount overload is the
+      // only entry point used by this code path, and a separate assertion on the message exercising
+      // it confirms the cause-carrying signature is used.
+      String capturedLog = appender.getLog();
+      Assert.assertTrue(
+          capturedLog.contains("keyExists failed") && capturedLog.contains("test-replica"),
+          "Expected keyExists ERROR with replica id; got: " + capturedLog);
+    } finally {
+      logger.removeAppender(appender);
+      appender.stop();
+    }
   }
 
   @Test

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/ActiveKeyCountTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/ActiveKeyCountTest.java
@@ -476,7 +476,7 @@ public class ActiveKeyCountTest {
   }
 
   @Test(dataProvider = "putRmdWithSchemaIds")
-  public void testPutInStorageEngine_batchRmdEnabled_writesRmd(int schemaId, String desc) throws Exception {
+  public void testPutInStorageEngineBatchRmdEnabledWritesRmd(int schemaId, String desc) throws Exception {
     setupForStorageEngineTests(true);
     ingestionTask.putInStorageEngine(PARTITION, KEY_BYTES, createBatchPut(schemaId));
     verify(storageEngine)
@@ -485,7 +485,7 @@ public class ActiveKeyCountTest {
   }
 
   @Test
-  public void testPutInStorageEngine_batchRmdEnabled_chunkFragment_fallsThrough() throws Exception {
+  public void testPutInStorageEngineBatchRmdEnabledChunkFragmentFallsThrough() throws Exception {
     setupForStorageEngineTests(true);
     ingestionTask.putInStorageEngine(PARTITION, KEY_BYTES, createBatchPut(CHUNK_SCHEMA_ID));
     verify(storageEngine).put(anyInt(), any(byte[].class), any(ByteBuffer.class));
@@ -494,8 +494,7 @@ public class ActiveKeyCountTest {
   }
 
   @Test(dataProvider = "putFallThroughCases")
-  public void testPutInStorageEngine_fallsThrough(boolean addRmdEnabled, boolean postEop, String desc)
-      throws Exception {
+  public void testPutInStorageEngineFallsThrough(boolean addRmdEnabled, boolean postEop, String desc) throws Exception {
     setupForStorageEngineTests(addRmdEnabled);
     doReturn(postEop).when(pcs).isEndOfPushReceived();
     ingestionTask.putInStorageEngine(PARTITION, KEY_BYTES, createBatchPut(USER_SCHEMA_ID));
@@ -505,7 +504,7 @@ public class ActiveKeyCountTest {
   }
 
   @Test
-  public void testPutInStorageEngine_batchRmdEnabled_pcsNull_fallsThrough() throws Exception {
+  public void testPutInStorageEngineBatchRmdEnabledPcsNullFallsThrough() throws Exception {
     setupPcsNullFallThrough();
     doCallRealMethod().when(ingestionTask).putInStorageEngine(anyInt(), any(), any(Put.class));
     doReturn(ActiveActiveStoreIngestionTask.StorageOperationType.VALUE).when(ingestionTask)
@@ -520,7 +519,7 @@ public class ActiveKeyCountTest {
   // regardless of addRmdToBatchPushForHybridStores, so the ts=0 sentinel only applies to PUTs.
 
   @Test
-  public void testRemoveFromStorageEngine_batchDeleteAlwaysUsesPlainDelete() throws Exception {
+  public void testRemoveFromStorageEngineBatchDeleteAlwaysUsesPlainDelete() throws Exception {
     setupForStorageEngineTests(true); // addRmdEnabled=true, but DELETE should still use plain delete
     ingestionTask.removeFromStorageEngine(PARTITION, KEY_BYTES, createBatchDelete());
     verify(storageEngine).delete(anyInt(), any(byte[].class));
@@ -528,7 +527,7 @@ public class ActiveKeyCountTest {
   }
 
   @Test
-  public void testRemoveFromStorageEngine_postEop_goesToValueAndRmd() throws Exception {
+  public void testRemoveFromStorageEnginePostEopGoesToValueAndRmd() throws Exception {
     setupForStorageEngineTests(true);
     doReturn(true).when(pcs).isEndOfPushReceived();
     ingestionTask.removeFromStorageEngine(PARTITION, KEY_BYTES, createBatchDelete());
@@ -540,7 +539,7 @@ public class ActiveKeyCountTest {
   // trackActiveKeyCount
 
   @Test
-  public void testTrackActiveKeyCount_batchCounting_schemaFiltering() throws Exception {
+  public void testTrackActiveKeyCountBatchCountingSchemaFiltering() throws Exception {
     setupForTrackActiveKeyCount(true, false, false);
     // Non-chunked PUT and manifest: counted
     for (int schemaId: new int[] { USER_SCHEMA_ID, CHUNK_MANIFEST_SCHEMA_ID }) {
@@ -565,7 +564,7 @@ public class ActiveKeyCountTest {
   }
 
   @Test(dataProvider = "batchCountingSkippedCases")
-  public void testTrackActiveKeyCount_batchCounting_skipped(
+  public void testTrackActiveKeyCountBatchCountingSkipped(
       boolean batchEnabled,
       boolean postEop,
       MessageType messageType,
@@ -583,7 +582,7 @@ public class ActiveKeyCountTest {
   }
 
   @Test
-  public void testTrackActiveKeyCount_batchAndFollower_bothEnabled() throws Exception {
+  public void testTrackActiveKeyCountBatchAndFollowerBothEnabled() throws Exception {
     setupForTrackActiveKeyCount(true, true, true);
     PartitionConsumptionState mockPcs = createMockPcsForTrack(false, -1L);
     invokeTrackActiveKeyCount(
@@ -597,7 +596,7 @@ public class ActiveKeyCountTest {
   }
 
   @Test
-  public void testTrackActiveKeyCount_followerSignal_createdAndDeleted() throws Exception {
+  public void testTrackActiveKeyCountFollowerSignalCreatedAndDeleted() throws Exception {
     setupForTrackActiveKeyCount(false, true, true);
     // Created signal
     PartitionConsumptionState mockPcs1 = createMockPcsForTrack(true, 5L);
@@ -671,7 +670,7 @@ public class ActiveKeyCountTest {
   }
 
   @Test(dataProvider = "followerSignalSkippedCases")
-  public void testTrackActiveKeyCount_followerSignal_skipped(
+  public void testTrackActiveKeyCountFollowerSignalSkipped(
       boolean hybridEnabled,
       boolean isAA,
       boolean postEop,
@@ -693,7 +692,7 @@ public class ActiveKeyCountTest {
   }
 
   @Test
-  public void testTrackActiveKeyCount_followerSignal_chunkFiltering() throws Exception {
+  public void testTrackActiveKeyCountFollowerSignalChunkFiltering() throws Exception {
     setupForTrackActiveKeyCount(false, true, true);
     // Manifest: signal applied
     PartitionConsumptionState manifestPcs = createMockPcsForTrack(true, 5L);
@@ -716,7 +715,7 @@ public class ActiveKeyCountTest {
   }
 
   @Test
-  public void testTrackActiveKeyCount_followerSignal_headerAbsentOrInvalid() throws Exception {
+  public void testTrackActiveKeyCountFollowerSignalHeaderAbsentOrInvalid() throws Exception {
     setupForTrackActiveKeyCount(false, true, true);
     // Test missing header, null value header, and empty byte array header
     PubSubMessageHeaders[] headerCases =
@@ -739,7 +738,7 @@ public class ActiveKeyCountTest {
   // processMessageAndMaybeProduceToKafka
 
   @Test
-  public void testProcessMessage_signalIncrementAndDecrement() throws Exception {
+  public void testProcessMessageSignalIncrementAndDecrement() throws Exception {
     setupForProcessMessageTests(true);
     doReturn(true).when(pcs).isEndOfPushReceived();
     doReturn(5L).when(pcs).getActiveKeyCount();
@@ -775,7 +774,7 @@ public class ActiveKeyCountTest {
   }
 
   @Test
-  public void testProcessMessage_noCountChange() throws Exception {
+  public void testProcessMessageNoCountChange() throws Exception {
     setupForProcessMessageTests(true);
     doReturn(true).when(pcs).isEndOfPushReceived();
     doReturn(5L).when(pcs).getActiveKeyCount();
@@ -801,7 +800,7 @@ public class ActiveKeyCountTest {
   }
 
   @Test
-  public void testProcessMessage_signalSkipped_featureDisabled() throws Exception {
+  public void testProcessMessageSignalSkippedFeatureDisabled() throws Exception {
     setupForProcessMessageTests(false);
     doReturn(true).when(pcs).isEndOfPushReceived();
     doReturn(5L).when(pcs).getActiveKeyCount();
@@ -908,7 +907,7 @@ public class ActiveKeyCountTest {
   }
 
   @Test
-  public void testProcessMessage_midRecordInvalidation_propagatesInvalidateSignal() throws Exception {
+  public void testMidRecordInvalidationPropagatesInvalidateSignal() throws Exception {
     setupForProcessMessageTests(true);
     doReturn(true).when(pcs).isEndOfPushReceived();
     // PCS count is -1 (invalidated mid-record by keyExists failure), but the wrapper
@@ -993,7 +992,7 @@ public class ActiveKeyCountTest {
   }
 
   @Test
-  public void testWasOldValueAlive_allBranches() throws Exception {
+  public void testWasOldValueAliveAllBranches() throws Exception {
     // Feature disabled → always false
     setField(ingestionTask, "activeKeyCountForHybridStoreEnabled", false);
     Assert
@@ -1048,7 +1047,7 @@ public class ActiveKeyCountTest {
   }
 
   @Test
-  public void testIsValuePresentForKey_allTiers() throws Exception {
+  public void testIsValuePresentForKeyAllTiers() throws Exception {
     setField(ingestionTask, "storageEngine", storageEngine);
 
     // Tier 1: Lazy already resolved by DCR → returns cached result
@@ -1077,7 +1076,7 @@ public class ActiveKeyCountTest {
   }
 
   @Test
-  public void testIsValuePresentForKey_tier3_chunkedStore_usesChunkingSuffix() throws Exception {
+  public void testIsValuePresentForKeyTier3ChunkedStoreUsesChunkingSuffix() throws Exception {
     setField(ingestionTask, "storageEngine", storageEngine);
     // Enable chunking on the ingestion task
     setField(ingestionTask, "isChunked", true);
@@ -1103,7 +1102,7 @@ public class ActiveKeyCountTest {
   }
 
   @Test
-  public void testIsValuePresentForKey_tier3_nonChunkedStore_usesRawKey() throws Exception {
+  public void testIsValuePresentForKeyTier3NonChunkedStoreUsesRawKey() throws Exception {
     setField(ingestionTask, "storageEngine", storageEngine);
     // Chunking disabled
     setField(ingestionTask, "isChunked", false);
@@ -1119,7 +1118,7 @@ public class ActiveKeyCountTest {
   }
 
   @Test
-  public void testIsValuePresentForKey_tier3_keyExistsThrows_invalidatesAndReturnsFalse() throws Exception {
+  public void testIsValuePresentForKeyTier3KeyExistsThrowsInvalidatesAndReturnsFalse() throws Exception {
     setField(ingestionTask, "storageEngine", storageEngine);
     setField(ingestionTask, "isChunked", false);
     doReturn(false).when(ingestionTask).isChunked();

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/ActiveKeyCountTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/ActiveKeyCountTest.java
@@ -10,6 +10,7 @@ import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.description;
 import static org.mockito.Mockito.doCallRealMethod;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;
@@ -53,9 +54,12 @@ import java.util.Map;
 import java.util.Optional;
 import org.apache.avro.generic.GenericRecord;
 import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.core.LogEvent;
 import org.apache.logging.log4j.core.Logger;
+import org.apache.logging.log4j.core.appender.AbstractAppender;
 import org.apache.logging.log4j.core.layout.PatternLayout;
 import org.testng.Assert;
+import org.testng.annotations.BeforeClass;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -93,9 +97,18 @@ public class ActiveKeyCountTest {
     doCallRealMethod().when(ingestionTask).getStorageOperationTypeForPut(anyInt(), any());
     doCallRealMethod().when(ingestionTask).getStorageOperationTypeForDelete(anyInt(), any());
     // Bypass Mockito interception of the final helper so setActiveKeyCount(-1) and the metric fire.
-    doCallRealMethod().when(ingestionTask).invalidateActiveKeyCount(any(PartitionConsumptionState.class), anyString());
     doCallRealMethod().when(ingestionTask)
-        .invalidateActiveKeyCount(any(PartitionConsumptionState.class), anyString(), any());
+        .invalidateActiveKeyCount(any(PartitionConsumptionState.class), any(ActiveKeyCountInvalidationReason.class));
+    doCallRealMethod().when(ingestionTask)
+        .invalidateActiveKeyCount(
+            any(PartitionConsumptionState.class),
+            any(ActiveKeyCountInvalidationReason.class),
+            any(Throwable.class));
+    doCallRealMethod().when(ingestionTask)
+        .invalidateActiveKeyCount(
+            any(PartitionConsumptionState.class),
+            any(ActiveKeyCountInvalidationReason.class),
+            anyInt());
     setField(ingestionTask, "hostLevelIngestionStats", mock(HostLevelIngestionStats.class));
     doReturn(mock(HostLevelIngestionStats.class)).when(ingestionTask).getHostLevelIngestionStats();
     AggVersionedIngestionStats mockAggStats = mock(AggVersionedIngestionStats.class);
@@ -103,6 +116,19 @@ public class ActiveKeyCountTest {
     setField(ingestionTask, "aggVersionedIngestionStats", mockAggStats);
     setField(ingestionTask, "storeName", "test-store");
     setField(ingestionTask, "versionNumber", 1);
+  }
+
+  /** Fails fast if mock-maker-inline is not active; otherwise final-method stubbing silently no-ops. */
+  @BeforeClass
+  public static void assertMockMakerInterceptsFinalMethods() {
+    ActiveActiveStoreIngestionTask probeTask = mock(ActiveActiveStoreIngestionTask.class);
+    PartitionConsumptionState probePcs = mock(PartitionConsumptionState.class);
+    doReturn("probe-replica").when(probePcs).getReplicaId();
+    doCallRealMethod().when(probeTask)
+        .invalidateActiveKeyCount(any(PartitionConsumptionState.class), any(ActiveKeyCountInvalidationReason.class));
+    probeTask.invalidateActiveKeyCount(probePcs, ActiveKeyCountInvalidationReason.LEADER_PROPAGATED_INVALIDATION);
+    verify(probePcs, description("mock-maker-inline must intercept final helpers; check mockito-extensions config"))
+        .setActiveKeyCount(OffsetRecord.ACTIVE_KEY_COUNT_NOT_TRACKED);
   }
 
   private Put createBatchPut(int schemaId) {
@@ -599,97 +625,45 @@ public class ActiveKeyCountTest {
   public Object[][] signalInvalidatesCases() {
     PubSubMessageHeaders multiByteHeaders = new PubSubMessageHeaders();
     multiByteHeaders.add(new PubSubMessageHeader(StoreIngestionTask.KEY_COUNT_SIGNAL_HEADER, new byte[] { 1, 2 }));
-    return new Object[][] { { createSignalHeaders((byte) 99), "unexpected single-byte value" },
-        { multiByteHeaders, "multi-byte signal" },
-        { createSignalHeaders(ActiveActiveStoreIngestionTask.KEY_COUNT_INVALIDATE_SIGNAL_VALUE),
-            "explicit invalidate signal" } };
+    /* Columns: headers, messageType, simulateUnderflow, expectedLogSubstring, desc */
+    return new Object[][] {
+        { createSignalHeaders(ActiveActiveStoreIngestionTask.KEY_DELETED_SIGNAL_VALUE), MessageType.DELETE, true,
+            "Decrement underflow on follower from kcs=-1", "decrement underflow" },
+        { createSignalHeaders(ActiveActiveStoreIngestionTask.KEY_COUNT_INVALIDATE_SIGNAL_VALUE), MessageType.PUT, false,
+            "Leader propagated invalidation signal", "explicit invalidate signal" },
+        { createSignalHeaders((byte) 99), MessageType.PUT, false, "Unexpected kcs signal value 99",
+            "unexpected single-byte value" },
+        { multiByteHeaders, MessageType.PUT, false, "Unexpected multi-byte kcs signal (length=2)",
+            "multi-byte signal" } };
   }
 
   @Test(dataProvider = "signalInvalidatesCases")
-  public void testTrackActiveKeyCount_followerSignal_invalidatesCount(PubSubMessageHeaders headers, String desc)
-      throws Exception {
+  public void testFollowerSignalInvalidatesCount(
+      PubSubMessageHeaders headers,
+      MessageType messageType,
+      boolean simulateUnderflow,
+      String expectedLogSubstring,
+      String desc) throws Exception {
     PartitionConsumptionState mockPcs = createMockPcsForTrack(true, 5L);
-    doReturn("test-replica").when(mockPcs).getReplicaId();
+    String replicaId = "test-replica-" + desc.replace(' ', '-');
+    doReturn(replicaId).when(mockPcs).getReplicaId();
+    if (simulateUnderflow) {
+      doReturn(false).when(mockPcs).decrementActiveKeyCount();
+    }
     setupForTrackActiveKeyCount(false, true, true);
-    invokeTrackActiveKeyCount(createMockConsumerRecord(headers), mockPcs, null, MessageType.PUT, USER_SCHEMA_ID);
-    verifyNoCountChange(mockPcs);
-    verify(mockPcs).setActiveKeyCount(-1);
-  }
 
-  @Test
-  public void testTrackActiveKeyCount_followerInvalidationLogsError() throws Exception {
-    TestLogAppender appender = new TestLogAppender("ActiveKeyCountTestAppender", PatternLayout.createDefaultLayout());
+    TestLogAppender appender = new TestLogAppender(desc + "-appender", PatternLayout.createDefaultLayout());
     appender.start();
     Logger logger = (Logger) LogManager.getLogger(StoreIngestionTask.class);
     logger.addAppender(appender);
     try {
-      setupForTrackActiveKeyCount(false, true, true);
-
-      // Path 3: decrement underflow.
-      PartitionConsumptionState underflowPcs = createMockPcsForTrack(true, 5L);
-      doReturn(false).when(underflowPcs).decrementActiveKeyCount();
-      doReturn("replica-underflow").when(underflowPcs).getReplicaId();
-      invokeTrackActiveKeyCount(
-          createMockConsumerRecord(createSignalHeaders(ActiveActiveStoreIngestionTask.KEY_DELETED_SIGNAL_VALUE)),
-          underflowPcs,
-          null,
-          MessageType.DELETE,
-          USER_SCHEMA_ID);
-
-      // Path 4: explicit invalidate signal.
-      PartitionConsumptionState invalidatePcs = createMockPcsForTrack(true, 5L);
-      doReturn("replica-invalidate").when(invalidatePcs).getReplicaId();
-      invokeTrackActiveKeyCount(
-          createMockConsumerRecord(
-              createSignalHeaders(ActiveActiveStoreIngestionTask.KEY_COUNT_INVALIDATE_SIGNAL_VALUE)),
-          invalidatePcs,
-          null,
-          MessageType.PUT,
-          USER_SCHEMA_ID);
-
-      // Path 5: corrupt single-byte kcs (any value outside {-1, 0, +1}).
-      PartitionConsumptionState corruptByteValuePcs = createMockPcsForTrack(true, 5L);
-      doReturn("replica-corrupt-byte").when(corruptByteValuePcs).getReplicaId();
-      invokeTrackActiveKeyCount(
-          createMockConsumerRecord(createSignalHeaders((byte) 99)),
-          corruptByteValuePcs,
-          null,
-          MessageType.PUT,
-          USER_SCHEMA_ID);
-
-      // Path 6: multi-byte kcs (length > 1) — corrupt or future producer.
-      PartitionConsumptionState multiBytePcs = createMockPcsForTrack(true, 5L);
-      doReturn("replica-multibyte").when(multiBytePcs).getReplicaId();
-      PubSubMessageHeaders multiByteHeaders = new PubSubMessageHeaders();
-      multiByteHeaders.add(new PubSubMessageHeader(StoreIngestionTask.KEY_COUNT_SIGNAL_HEADER, new byte[] { 1, 2, 3 }));
-      invokeTrackActiveKeyCount(
-          createMockConsumerRecord(multiByteHeaders),
-          multiBytePcs,
-          null,
-          MessageType.PUT,
-          USER_SCHEMA_ID);
-
+      invokeTrackActiveKeyCount(createMockConsumerRecord(headers), mockPcs, null, messageType, USER_SCHEMA_ID);
+      verify(mockPcs, never()).incrementActiveKeyCount();
+      verify(mockPcs).setActiveKeyCount(-1);
       String capturedLog = appender.getLog();
       Assert.assertTrue(
-          capturedLog.contains("Decrement underflow on follower from kcs=-1")
-              && capturedLog.contains("replica-underflow"),
-          "Expected follower-side underflow ERROR with replica id; got: " + capturedLog);
-      Assert.assertTrue(
-          capturedLog.contains("Leader propagated invalidation") && capturedLog.contains("replica-invalidate"),
-          "Expected leader-invalidate ERROR with replica id; got: " + capturedLog);
-      Assert.assertTrue(
-          capturedLog.contains("Unexpected kcs signal value 99") && capturedLog.contains("replica-corrupt-byte"),
-          "Expected corrupt single-byte ERROR with replica id; got: " + capturedLog);
-      Assert.assertTrue(
-          capturedLog.contains("Unexpected multi-byte kcs signal (length=3)")
-              && capturedLog.contains("replica-multibyte"),
-          "Expected multi-byte ERROR with replica id; got: " + capturedLog);
-
-      verify(underflowPcs).setActiveKeyCount(OffsetRecord.ACTIVE_KEY_COUNT_NOT_TRACKED);
-      verify(invalidatePcs).setActiveKeyCount(OffsetRecord.ACTIVE_KEY_COUNT_NOT_TRACKED);
-      verify(corruptByteValuePcs).setActiveKeyCount(OffsetRecord.ACTIVE_KEY_COUNT_NOT_TRACKED);
-      verify(multiBytePcs).setActiveKeyCount(OffsetRecord.ACTIVE_KEY_COUNT_NOT_TRACKED);
-      verify(ingestionTask, times(4)).recordActiveKeyCountInvalidation();
+          capturedLog.contains(expectedLogSubstring) && capturedLog.contains(replicaId),
+          "[" + desc + "] expected ERROR with reason and replica id; got: " + capturedLog);
     } finally {
       logger.removeAppender(appender);
       appender.stop();
@@ -843,7 +817,7 @@ public class ActiveKeyCountTest {
   }
 
   @Test
-  public void testProcessMessage_leaderUnderflow_routesThroughInvalidateHelper() throws Exception {
+  public void testLeaderUnderflowRoutesThroughInvalidateHelper() throws Exception {
     setupForProcessMessageTests(true);
     PartitionConsumptionState localPcs = mock(PartitionConsumptionState.class);
     doReturn(true).when(localPcs).isEndOfPushReceived();
@@ -878,6 +852,58 @@ public class ActiveKeyCountTest {
     } finally {
       logger.removeAppender(appender);
       appender.stop();
+    }
+  }
+
+  @Test
+  public void testInvalidateActiveKeyCountLogsEvenWhenInternalsThrow() throws Exception {
+    PartitionConsumptionState mutationFails = mock(PartitionConsumptionState.class);
+    doReturn("replica-mutation-fails").when(mutationFails).getReplicaId();
+    doThrow(new RuntimeException("setter explosion")).when(mutationFails).setActiveKeyCount(anyLong());
+
+    TestLogAppender appender = new TestLogAppender("MutationFailsAppender", PatternLayout.createDefaultLayout());
+    appender.start();
+    Logger logger = (Logger) LogManager.getLogger(StoreIngestionTask.class);
+    logger.addAppender(appender);
+    try {
+      try {
+        ingestionTask
+            .invalidateActiveKeyCount(mutationFails, ActiveKeyCountInvalidationReason.LEADER_PROPAGATED_INVALIDATION);
+        Assert.fail("expected the setter's RuntimeException to propagate");
+      } catch (RuntimeException expected) {
+        Assert.assertEquals(expected.getMessage(), "setter explosion");
+      }
+      Assert.assertTrue(
+          appender.getLog().contains("Leader propagated invalidation")
+              && appender.getLog().contains("replica-mutation-fails"),
+          "ERROR log must fire even when setActiveKeyCount throws; captured: " + appender.getLog());
+    } finally {
+      logger.removeAppender(appender);
+      appender.stop();
+    }
+
+    PartitionConsumptionState recorderFails = mock(PartitionConsumptionState.class);
+    doReturn("replica-recorder-fails").when(recorderFails).getReplicaId();
+    doThrow(new RuntimeException("metric explosion")).when(ingestionTask).recordActiveKeyCountInvalidation();
+
+    TestLogAppender appender2 = new TestLogAppender("RecorderFailsAppender", PatternLayout.createDefaultLayout());
+    appender2.start();
+    logger.addAppender(appender2);
+    try {
+      try {
+        ingestionTask.invalidateActiveKeyCount(recorderFails, ActiveKeyCountInvalidationReason.LEADER_DCR_UNDERFLOW);
+        Assert.fail("expected the recorder's RuntimeException to propagate");
+      } catch (RuntimeException expected) {
+        Assert.assertEquals(expected.getMessage(), "metric explosion");
+      }
+      Assert.assertTrue(
+          appender2.getLog().contains("Decrement underflow on leader during DCR")
+              && appender2.getLog().contains("replica-recorder-fails"),
+          "ERROR log must fire even when recordActiveKeyCountInvalidation throws; captured: " + appender2.getLog());
+      verify(recorderFails).setActiveKeyCount(OffsetRecord.ACTIVE_KEY_COUNT_NOT_TRACKED);
+    } finally {
+      logger.removeAppender(appender2);
+      appender2.stop();
     }
   }
 
@@ -1102,9 +1128,10 @@ public class ActiveKeyCountTest {
     doReturn("test-replica").when(pcs).getReplicaId();
 
     // Tier 3 keyExists I/O failure: must not propagate, must invalidate the count.
-    doThrow(new VeniceException("disk error")).when(storageEngine).keyExists(anyInt(), any(byte[].class));
+    VeniceException injected = new VeniceException("disk error");
+    doThrow(injected).when(storageEngine).keyExists(anyInt(), any(byte[].class));
 
-    TestLogAppender appender = new TestLogAppender("Tier3KeyExistsAppender", PatternLayout.createDefaultLayout());
+    ThrowableCapturingAppender appender = new ThrowableCapturingAppender();
     appender.start();
     Logger logger = (Logger) LogManager.getLogger(StoreIngestionTask.class);
     logger.addAppender(appender);
@@ -1112,15 +1139,40 @@ public class ActiveKeyCountTest {
       Assert.assertFalse(invokeIsValuePresentForKey(Lazy.of(() -> null), pcs, KEY_BYTES));
       verify(pcs).setActiveKeyCount(-1);
 
-      // TestLogAppender captures only the formatted message, not the attached throwable, so we
-      // can't assert on "disk error" here.
-      String capturedLog = appender.getLog();
       Assert.assertTrue(
-          capturedLog.contains("keyExists failed") && capturedLog.contains("test-replica"),
-          "Expected keyExists ERROR with replica id; got: " + capturedLog);
+          appender.getMessage().contains("RocksDB value column family lookup failed")
+              && appender.getMessage().contains("test-replica"),
+          "Expected keyExists ERROR with replica id; got: " + appender.getMessage());
+      Assert.assertSame(
+          appender.getThrown(),
+          injected,
+          "The VeniceException injected from keyExists must be attached as the log cause");
     } finally {
       logger.removeAppender(appender);
       appender.stop();
+    }
+  }
+
+  private static final class ThrowableCapturingAppender extends AbstractAppender {
+    private volatile String message = "";
+    private volatile Throwable thrown;
+
+    ThrowableCapturingAppender() {
+      super("ThrowableCapturingAppender", null, PatternLayout.createDefaultLayout(), false, null);
+    }
+
+    @Override
+    public void append(LogEvent event) {
+      this.message = event.getMessage().getFormattedMessage();
+      this.thrown = event.getThrown();
+    }
+
+    String getMessage() {
+      return message;
+    }
+
+    Throwable getThrown() {
+      return thrown;
     }
   }
 

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/ActiveKeyCountTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/ActiveKeyCountTest.java
@@ -92,8 +92,7 @@ public class ActiveKeyCountTest {
     doCallRealMethod().when(ingestionTask).checkStorageOperationCommonInvalidPattern(any(), any());
     doCallRealMethod().when(ingestionTask).getStorageOperationTypeForPut(anyInt(), any());
     doCallRealMethod().when(ingestionTask).getStorageOperationTypeForDelete(anyInt(), any());
-    // invalidateActiveKeyCount is protected final, so Mockito intercepts it on the mock by default;
-    // call the real method so setActiveKeyCount(-1) and recordActiveKeyCountInvalidation actually fire.
+    // Bypass Mockito interception of the final helper so setActiveKeyCount(-1) and the metric fire.
     doCallRealMethod().when(ingestionTask).invalidateActiveKeyCount(any(PartitionConsumptionState.class), anyString());
     doCallRealMethod().when(ingestionTask)
         .invalidateActiveKeyCount(any(PartitionConsumptionState.class), anyString(), any());
@@ -618,29 +617,6 @@ public class ActiveKeyCountTest {
   }
 
   @Test
-  public void testTrackActiveKeyCount_followerUnderflow_routesThroughInvalidateHelper() throws Exception {
-    setupForTrackActiveKeyCount(false, true, true);
-
-    // Decrement returns false simulating underflow (count was 0 or stale -1 path produced false).
-    PartitionConsumptionState mockPcs = createMockPcsForTrack(true, 5L);
-    doReturn(false).when(mockPcs).decrementActiveKeyCount();
-    doReturn("replica-underflow").when(mockPcs).getReplicaId();
-
-    invokeTrackActiveKeyCount(
-        createMockConsumerRecord(createSignalHeaders(ActiveActiveStoreIngestionTask.KEY_DELETED_SIGNAL_VALUE)),
-        mockPcs,
-        null,
-        MessageType.DELETE,
-        USER_SCHEMA_ID);
-
-    // Underflow now routes through invalidateActiveKeyCount: setter is called explicitly,
-    // and the shared invalidation metric helper is invoked exactly once (no double-counting).
-    verify(mockPcs).decrementActiveKeyCount();
-    verify(mockPcs).setActiveKeyCount(OffsetRecord.ACTIVE_KEY_COUNT_NOT_TRACKED);
-    verify(ingestionTask, times(1)).recordActiveKeyCountInvalidation();
-  }
-
-  @Test
   public void testTrackActiveKeyCount_followerInvalidationLogsError() throws Exception {
     TestLogAppender appender = new TestLogAppender("ActiveKeyCountTestAppender", PatternLayout.createDefaultLayout());
     appender.start();
@@ -709,8 +685,6 @@ public class ActiveKeyCountTest {
               && capturedLog.contains("replica-multibyte"),
           "Expected multi-byte ERROR with replica id; got: " + capturedLog);
 
-      // Each path also routed through the helper, so all four invalidations went through both the
-      // setter and the metric recorder.
       verify(underflowPcs).setActiveKeyCount(OffsetRecord.ACTIVE_KEY_COUNT_NOT_TRACKED);
       verify(invalidatePcs).setActiveKeyCount(OffsetRecord.ACTIVE_KEY_COUNT_NOT_TRACKED);
       verify(corruptByteValuePcs).setActiveKeyCount(OffsetRecord.ACTIVE_KEY_COUNT_NOT_TRACKED);
@@ -870,16 +844,11 @@ public class ActiveKeyCountTest {
 
   @Test
   public void testProcessMessage_leaderUnderflow_routesThroughInvalidateHelper() throws Exception {
-    // Leader detects an underflow during DCR (count was 0, but a delete arrived). The underflow
-    // path must (1) set the count to ACTIVE_KEY_COUNT_NOT_TRACKED via the helper, (2) record the
-    // invalidation metric, and (3) emit a rate-limited ERROR log identifying the leader path.
     setupForProcessMessageTests(true);
     PartitionConsumptionState localPcs = mock(PartitionConsumptionState.class);
     doReturn(true).when(localPcs).isEndOfPushReceived();
-    // Count >= 0 so computeActiveKeyCountSignal does not take the early "already invalidated" branch.
+    // Count >= 0 so computeActiveKeyCountSignal doesn't short-circuit on "already invalidated".
     doReturn(0L).when(localPcs).getActiveKeyCount();
-    // The atomic getAndUpdate inside decrementActiveKeyCount sets -1 internally and returns false
-    // to signal underflow.
     doReturn(false).when(localPcs).decrementActiveKeyCount();
     doReturn("leader-replica-underflow").when(localPcs).getReplicaId();
 
@@ -1132,7 +1101,7 @@ public class ActiveKeyCountTest {
     doReturn(0).when(pcs).getPartition();
     doReturn("test-replica").when(pcs).getReplicaId();
 
-    // Tier 3: keyExists throws VeniceException (simulating transient RocksDB I/O failure)
+    // Tier 3 keyExists I/O failure: must not propagate, must invalidate the count.
     doThrow(new VeniceException("disk error")).when(storageEngine).keyExists(anyInt(), any(byte[].class));
 
     TestLogAppender appender = new TestLogAppender("Tier3KeyExistsAppender", PatternLayout.createDefaultLayout());
@@ -1140,17 +1109,11 @@ public class ActiveKeyCountTest {
     Logger logger = (Logger) LogManager.getLogger(StoreIngestionTask.class);
     logger.addAppender(appender);
     try {
-      // Should return false (assume key absent) and NOT propagate the exception
       Assert.assertFalse(invokeIsValuePresentForKey(Lazy.of(() -> null), pcs, KEY_BYTES));
-
-      // Count must be invalidated to -1
       verify(pcs).setActiveKeyCount(-1);
 
-      // Helper must emit a rate-limited ERROR with the keyExists reason and the replica id.
-      // We don't assert on the attached throwable here because TestLogAppender only captures the
-      // formatted message, not the throwable. The 3-arg invalidateActiveKeyCount overload is the
-      // only entry point used by this code path, and a separate assertion on the message exercising
-      // it confirms the cause-carrying signature is used.
+      // TestLogAppender captures only the formatted message, not the attached throwable, so we
+      // can't assert on "disk error" here.
       String capturedLog = appender.getLog();
       Assert.assertTrue(
           capturedLog.contains("keyExists failed") && capturedLog.contains("test-replica"),

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/stats/AggHostLevelIngestionStatsTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/stats/AggHostLevelIngestionStatsTest.java
@@ -5,6 +5,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertThrows;
 
@@ -273,9 +274,7 @@ public class AggHostLevelIngestionStatsTest {
 
   @Test
   public void testActiveKeyCountMetricsAbsentWhenDisabled() {
-    // The default VeniceServerConfig mock in setUp() returns false for
-    // isAnyActiveKeyCountTrackingEnabled(). Confirm the gating actually skips registration of the
-    // active_key_count gauge (per-store + total) and the active_key_count_invalidation rate.
+    // setUp()'s VeniceServerConfig mock returns false for isAnyActiveKeyCountTrackingEnabled by default.
     assertNull(
         metricsRepository.getMetric("." + STORE_FOO + "--active_key_count.Gauge"),
         "Per-store active_key_count gauge should not exist when active-key-count tracking is disabled");
@@ -286,18 +285,14 @@ public class AggHostLevelIngestionStatsTest {
         metricsRepository.getMetric(".total--active_key_count_invalidation.Rate"),
         "active_key_count_invalidation rate should not exist when active-key-count tracking is disabled");
 
-    // Recording method must remain a safe no-op so producers (StoreIngestionTask) can call it
-    // unconditionally without checking the config flag.
+    // Recorder must stay a safe no-op so producers can call it unconditionally.
     fooStats.recordActiveKeyCountInvalidation();
   }
 
   @Test
   public void testActiveKeyCountMetricsRegisteredWhenEnabled() {
-    // Build a separate AggHostLevelIngestionStats with active-key-count tracking turned on, and
-    // assert both gauges + the invalidation rate are registered. Uses a dedicated MetricsRepository
-    // so it doesn't pollute the suite-shared one. Do NOT call localRepo.close() — that would shut
-    // down the JVM-static DEFAULT_ASYNC_GAUGE_EXECUTOR and break AsyncGauge in every subsequent
-    // test in this JVM (e.g., testMetrics's storage_quota_used gauge would read 0.0).
+    // Do NOT close localRepo: closing shuts down the JVM-static DEFAULT_ASYNC_GAUGE_EXECUTOR and
+    // breaks every subsequent AsyncGauge in this JVM.
     TestMockTime time = new TestMockTime();
     MetricsRepository localRepo = new MetricsRepository(time);
     VeniceServerConfig enabledConfig = mock(VeniceServerConfig.class);
@@ -314,17 +309,14 @@ public class AggHostLevelIngestionStatsTest {
         time);
     enabledAggStats.getStoreStats(STORE_FOO);
 
-    assertEquals(
-        localRepo.getMetric("." + STORE_FOO + "--active_key_count.Gauge") != null,
-        true,
+    assertNotNull(
+        localRepo.getMetric("." + STORE_FOO + "--active_key_count.Gauge"),
         "Per-store active_key_count gauge should be registered when tracking enabled");
-    assertEquals(
-        localRepo.getMetric(".total--active_key_count.Gauge") != null,
-        true,
+    assertNotNull(
+        localRepo.getMetric(".total--active_key_count.Gauge"),
         "Total active_key_count gauge should be registered when tracking enabled");
-    assertEquals(
-        localRepo.getMetric(".total--active_key_count_invalidation.Rate") != null,
-        true,
+    assertNotNull(
+        localRepo.getMetric(".total--active_key_count_invalidation.Rate"),
         "active_key_count_invalidation rate should be registered when tracking enabled");
   }
 

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/stats/AggHostLevelIngestionStatsTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/stats/AggHostLevelIngestionStatsTest.java
@@ -271,6 +271,63 @@ public class AggHostLevelIngestionStatsTest {
     assertNull(metricsRepository.getMetric("." + STORE_BAR + "--kafka_poll_result_num.Total"));
   }
 
+  @Test
+  public void testActiveKeyCountMetricsAbsentWhenDisabled() {
+    // The default VeniceServerConfig mock in setUp() returns false for
+    // isAnyActiveKeyCountTrackingEnabled(). Confirm the gating actually skips registration of the
+    // active_key_count gauge (per-store + total) and the active_key_count_invalidation rate.
+    assertNull(
+        metricsRepository.getMetric("." + STORE_FOO + "--active_key_count.Gauge"),
+        "Per-store active_key_count gauge should not exist when active-key-count tracking is disabled");
+    assertNull(
+        metricsRepository.getMetric(".total--active_key_count.Gauge"),
+        "Total active_key_count gauge should not exist when active-key-count tracking is disabled");
+    assertNull(
+        metricsRepository.getMetric(".total--active_key_count_invalidation.Rate"),
+        "active_key_count_invalidation rate should not exist when active-key-count tracking is disabled");
+
+    // Recording method must remain a safe no-op so producers (StoreIngestionTask) can call it
+    // unconditionally without checking the config flag.
+    fooStats.recordActiveKeyCountInvalidation();
+  }
+
+  @Test
+  public void testActiveKeyCountMetricsRegisteredWhenEnabled() {
+    // Build a separate AggHostLevelIngestionStats with active-key-count tracking turned on, and
+    // assert both gauges + the invalidation rate are registered. Uses a dedicated MetricsRepository
+    // so it doesn't pollute the suite-shared one. Do NOT call localRepo.close() — that would shut
+    // down the JVM-static DEFAULT_ASYNC_GAUGE_EXECUTOR and break AsyncGauge in every subsequent
+    // test in this JVM (e.g., testMetrics's storage_quota_used gauge would read 0.0).
+    TestMockTime time = new TestMockTime();
+    MetricsRepository localRepo = new MetricsRepository(time);
+    VeniceServerConfig enabledConfig = mock(VeniceServerConfig.class);
+    doReturn(Int2ObjectMaps.emptyMap()).when(enabledConfig).getKafkaClusterIdToAliasMap();
+    doReturn(true).when(enabledConfig).isAnyActiveKeyCountTrackingEnabled();
+    Map<String, StoreIngestionTask> taskMap = new HashMap<>();
+    taskMap.put(STORE_FOO, fooSIT);
+    AggHostLevelIngestionStats enabledAggStats = new AggHostLevelIngestionStats(
+        localRepo,
+        enabledConfig,
+        taskMap,
+        mock(ReadOnlyStoreRepository.class),
+        true,
+        time);
+    enabledAggStats.getStoreStats(STORE_FOO);
+
+    assertEquals(
+        localRepo.getMetric("." + STORE_FOO + "--active_key_count.Gauge") != null,
+        true,
+        "Per-store active_key_count gauge should be registered when tracking enabled");
+    assertEquals(
+        localRepo.getMetric(".total--active_key_count.Gauge") != null,
+        true,
+        "Total active_key_count gauge should be registered when tracking enabled");
+    assertEquals(
+        localRepo.getMetric(".total--active_key_count_invalidation.Rate") != null,
+        true,
+        "active_key_count_invalidation rate should be registered when tracking enabled");
+  }
+
   private void assertCallCounts(
       int fooSITgetStorageEngine,
       int barSITgetStorageEngine,

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/stats/AggHostLevelIngestionStatsTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/stats/AggHostLevelIngestionStatsTest.java
@@ -290,8 +290,10 @@ public class AggHostLevelIngestionStatsTest {
 
   @Test
   public void testActiveKeyCountMetricsRegisteredWhenEnabled() {
-    // Do NOT close localRepo: closing shuts down the JVM-static DEFAULT_ASYNC_GAUGE_EXECUTOR and
-    // breaks every subsequent AsyncGauge in this JVM.
+    /*
+     * Do NOT close localRepo: closing shuts down the JVM-static DEFAULT_ASYNC_GAUGE_EXECUTOR and
+     * breaks every subsequent AsyncGauge in this JVM.
+     */
     TestMockTime time = new TestMockTime();
     MetricsRepository localRepo = new MetricsRepository(time);
     VeniceServerConfig enabledConfig = mock(VeniceServerConfig.class);

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/stats/AggHostLevelIngestionStatsTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/stats/AggHostLevelIngestionStatsTest.java
@@ -5,7 +5,6 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertThrows;
 
@@ -298,8 +297,10 @@ public class AggHostLevelIngestionStatsTest {
     VeniceServerConfig enabledConfig = mock(VeniceServerConfig.class);
     doReturn(Int2ObjectMaps.emptyMap()).when(enabledConfig).getKafkaClusterIdToAliasMap();
     doReturn(true).when(enabledConfig).isAnyActiveKeyCountTrackingEnabled();
+    StoreIngestionTask localFooSIT = mock(StoreIngestionTask.class);
+    doReturn(42L).when(localFooSIT).getActiveKeyCount();
     Map<String, StoreIngestionTask> taskMap = new HashMap<>();
-    taskMap.put(STORE_FOO, fooSIT);
+    taskMap.put(STORE_FOO, localFooSIT);
     AggHostLevelIngestionStats enabledAggStats = new AggHostLevelIngestionStats(
         localRepo,
         enabledConfig,
@@ -307,17 +308,20 @@ public class AggHostLevelIngestionStatsTest {
         mock(ReadOnlyStoreRepository.class),
         true,
         time);
-    enabledAggStats.getStoreStats(STORE_FOO);
+    HostLevelIngestionStats fooHostStats = enabledAggStats.getStoreStats(STORE_FOO);
 
-    assertNotNull(
-        localRepo.getMetric("." + STORE_FOO + "--active_key_count.Gauge"),
-        "Per-store active_key_count gauge should be registered when tracking enabled");
-    assertNotNull(
-        localRepo.getMetric(".total--active_key_count.Gauge"),
-        "Total active_key_count gauge should be registered when tracking enabled");
-    assertNotNull(
-        localRepo.getMetric(".total--active_key_count_invalidation.Rate"),
-        "active_key_count_invalidation rate should be registered when tracking enabled");
+    // Per-store gauge: should report the SIT's getActiveKeyCount() (42).
+    assertEquals(localRepo.getMetric("." + STORE_FOO + "--active_key_count.Gauge").value(), 42.0);
+    // Total gauge: aggregates all tracked SITs (just 42 here).
+    assertEquals(localRepo.getMetric(".total--active_key_count.Gauge").value(), 42.0);
+
+    // Invalidation rate: record once, advance past the rate-cache window, assert the rate reflects it.
+    fooHostStats.recordActiveKeyCountInvalidation();
+    time.addMilliseconds(LongAdderRateGauge.RATE_GAUGE_CACHE_DURATION_IN_SECONDS * Time.MS_PER_SECOND);
+    assertEquals(
+        localRepo.getMetric(".total--active_key_count_invalidation.Rate").value(),
+        1d / LongAdderRateGauge.RATE_GAUGE_CACHE_DURATION_IN_SECONDS,
+        "Invalidation rate must reflect the one recording");
   }
 
   private void assertCallCounts(

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/stats/ingestion/IngestionOtelStatsTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/stats/ingestion/IngestionOtelStatsTest.java
@@ -94,9 +94,11 @@ import com.linkedin.venice.stats.dimensions.VeniceRegionLocality;
 import com.linkedin.venice.utils.OpenTelemetryDataTestUtils;
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.sdk.metrics.data.LongPointData;
+import io.opentelemetry.sdk.metrics.data.MetricData;
 import io.opentelemetry.sdk.testing.exporter.InMemoryMetricReader;
 import io.tehuti.metrics.MetricsRepository;
 import java.lang.reflect.Field;
+import java.util.Collection;
 import java.util.Map;
 import java.util.function.BiConsumer;
 import org.testng.annotations.AfterMethod;
@@ -153,10 +155,6 @@ public class IngestionOtelStatsTest {
 
   @Test
   public void testActiveKeyCountMetricsNotRegisteredWhenDisabled() {
-    // When activeKeyCountEnabled = false, both the ASYNC_GAUGE (active_count) and the COUNTER
-    // (active_count_invalidation) must be absent from the OTel reader, even after we attempt to
-    // record. This proves the gating actually skipped instrument creation rather than just
-    // null-guarding the recorder method.
     InMemoryMetricReader localReader = InMemoryMetricReader.create();
     try (VeniceMetricsRepository localRepo = new VeniceMetricsRepository(
         new VeniceMetricsConfig.Builder().setMetricEntities(SERVER_METRIC_ENTITIES)
@@ -167,17 +165,15 @@ public class IngestionOtelStatsTest {
       IngestionOtelStats statsDisabled =
           new IngestionOtelStats(localRepo, STORE_NAME, CLUSTER_NAME, LOCAL_REGION, true, true, false);
       statsDisabled.updateVersionInfo(CURRENT_VERSION, FUTURE_VERSION);
-      // Must not throw — null guard in the recorder method is the safety net for production code
-      // that doesn't know whether the feature is on (e.g. trackActiveKeyCount fall-through paths).
+      // Recorder must be a safe no-op so producers can call it without checking the flag.
       statsDisabled.recordActiveKeyCountInvalidation(CURRENT_VERSION);
 
       String activeKeyCountFullName = TEST_PREFIX + "." + ACTIVE_KEY_COUNT.getMetricEntity().getMetricName();
       String invalidationFullName =
           TEST_PREFIX + "." + IngestionOtelMetricEntity.ACTIVE_KEY_COUNT_INVALIDATION.getMetricEntity().getMetricName();
-      boolean foundActiveKeyCount =
-          localReader.collectAllMetrics().stream().anyMatch(md -> md.getName().equals(activeKeyCountFullName));
-      boolean foundInvalidation =
-          localReader.collectAllMetrics().stream().anyMatch(md -> md.getName().equals(invalidationFullName));
+      Collection<MetricData> metrics = localReader.collectAllMetrics();
+      boolean foundActiveKeyCount = metrics.stream().anyMatch(md -> md.getName().equals(activeKeyCountFullName));
+      boolean foundInvalidation = metrics.stream().anyMatch(md -> md.getName().equals(invalidationFullName));
       assertFalse(foundActiveKeyCount, "active_count gauge should not be registered when activeKeyCountEnabled=false");
       assertFalse(
           foundInvalidation,

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/stats/ingestion/IngestionOtelStatsTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/stats/ingestion/IngestionOtelStatsTest.java
@@ -48,6 +48,7 @@ import static com.linkedin.davinci.stats.ingestion.IngestionOtelMetricEntity.UNE
 import static com.linkedin.davinci.stats.ingestion.IngestionOtelMetricEntity.VIEW_WRITER_ACK_TIME;
 import static com.linkedin.davinci.stats.ingestion.IngestionOtelMetricEntity.VIEW_WRITER_PRODUCE_TIME;
 import static com.linkedin.venice.meta.Store.NON_EXISTING_VERSION;
+import static com.linkedin.venice.stats.VeniceOpenTelemetryMetricsRepository.DEFAULT_METRIC_PREFIX;
 import static com.linkedin.venice.stats.dimensions.VeniceMetricsDimensions.VENICE_CLUSTER_NAME;
 import static com.linkedin.venice.stats.dimensions.VeniceMetricsDimensions.VENICE_DCR_EVENT;
 import static com.linkedin.venice.stats.dimensions.VeniceMetricsDimensions.VENICE_DCR_OPERATION;
@@ -168,17 +169,48 @@ public class IngestionOtelStatsTest {
       // Recorder must be a safe no-op so producers can call it without checking the flag.
       statsDisabled.recordActiveKeyCountInvalidation(CURRENT_VERSION);
 
-      String activeKeyCountFullName = TEST_PREFIX + "." + ACTIVE_KEY_COUNT.getMetricEntity().getMetricName();
-      String invalidationFullName =
-          TEST_PREFIX + "." + IngestionOtelMetricEntity.ACTIVE_KEY_COUNT_INVALIDATION.getMetricEntity().getMetricName();
       Collection<MetricData> metrics = localReader.collectAllMetrics();
-      boolean foundActiveKeyCount = metrics.stream().anyMatch(md -> md.getName().equals(activeKeyCountFullName));
-      boolean foundInvalidation = metrics.stream().anyMatch(md -> md.getName().equals(invalidationFullName));
-      assertFalse(foundActiveKeyCount, "active_count gauge should not be registered when activeKeyCountEnabled=false");
       assertFalse(
-          foundInvalidation,
+          metrics.stream().anyMatch(md -> md.getName().equals(activeKeyCountFullName())),
+          "active_count gauge should not be registered when activeKeyCountEnabled=false");
+      assertFalse(
+          metrics.stream().anyMatch(md -> md.getName().equals(activeKeyCountInvalidationFullName())),
           "active_count_invalidation counter should not be registered when activeKeyCountEnabled=false");
     }
+  }
+
+  /** Positive control for {@link #testActiveKeyCountMetricsNotRegisteredWhenDisabled}: proves the
+   * full-name format the negative test compares against actually matches a registered metric. If
+   * the OTel prefix scheme ever changes, this test fails loudly instead of the negative test
+   * silently passing. */
+  @Test
+  public void testActiveKeyCountInvalidationMetricRegisteredWhenEnabled() {
+    InMemoryMetricReader localReader = InMemoryMetricReader.create();
+    try (VeniceMetricsRepository localRepo = new VeniceMetricsRepository(
+        new VeniceMetricsConfig.Builder().setMetricEntities(SERVER_METRIC_ENTITIES)
+            .setMetricPrefix(TEST_PREFIX)
+            .setEmitOtelMetrics(true)
+            .setOtelAdditionalMetricsReader(localReader)
+            .build())) {
+      IngestionOtelStats statsEnabled =
+          new IngestionOtelStats(localRepo, STORE_NAME, CLUSTER_NAME, LOCAL_REGION, true, true, true);
+      statsEnabled.updateVersionInfo(CURRENT_VERSION, FUTURE_VERSION);
+      statsEnabled.recordActiveKeyCountInvalidation(CURRENT_VERSION);
+
+      Collection<MetricData> metrics = localReader.collectAllMetrics();
+      assertTrue(
+          metrics.stream().anyMatch(md -> md.getName().equals(activeKeyCountInvalidationFullName())),
+          "active_count_invalidation counter must be registered when activeKeyCountEnabled=true");
+    }
+  }
+
+  private static String activeKeyCountFullName() {
+    return DEFAULT_METRIC_PREFIX + TEST_PREFIX + "." + ACTIVE_KEY_COUNT.getMetricEntity().getMetricName();
+  }
+
+  private static String activeKeyCountInvalidationFullName() {
+    return DEFAULT_METRIC_PREFIX + TEST_PREFIX + "."
+        + IngestionOtelMetricEntity.ACTIVE_KEY_COUNT_INVALIDATION.getMetricEntity().getMetricName();
   }
 
   @Test

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/stats/ingestion/IngestionOtelStatsTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/stats/ingestion/IngestionOtelStatsTest.java
@@ -129,7 +129,7 @@ public class IngestionOtelStatsTest {
   }
 
   private static IngestionOtelStats createStats(VeniceMetricsRepository repo) {
-    return new IngestionOtelStats(repo, STORE_NAME, CLUSTER_NAME, LOCAL_REGION, true, true);
+    return new IngestionOtelStats(repo, STORE_NAME, CLUSTER_NAME, LOCAL_REGION, true, true, true);
   }
 
   @BeforeMethod
@@ -152,6 +152,40 @@ public class IngestionOtelStatsTest {
   }
 
   @Test
+  public void testActiveKeyCountMetricsNotRegisteredWhenDisabled() {
+    // When activeKeyCountEnabled = false, both the ASYNC_GAUGE (active_count) and the COUNTER
+    // (active_count_invalidation) must be absent from the OTel reader, even after we attempt to
+    // record. This proves the gating actually skipped instrument creation rather than just
+    // null-guarding the recorder method.
+    InMemoryMetricReader localReader = InMemoryMetricReader.create();
+    try (VeniceMetricsRepository localRepo = new VeniceMetricsRepository(
+        new VeniceMetricsConfig.Builder().setMetricEntities(SERVER_METRIC_ENTITIES)
+            .setMetricPrefix(TEST_PREFIX)
+            .setEmitOtelMetrics(true)
+            .setOtelAdditionalMetricsReader(localReader)
+            .build())) {
+      IngestionOtelStats statsDisabled =
+          new IngestionOtelStats(localRepo, STORE_NAME, CLUSTER_NAME, LOCAL_REGION, true, true, false);
+      statsDisabled.updateVersionInfo(CURRENT_VERSION, FUTURE_VERSION);
+      // Must not throw — null guard in the recorder method is the safety net for production code
+      // that doesn't know whether the feature is on (e.g. trackActiveKeyCount fall-through paths).
+      statsDisabled.recordActiveKeyCountInvalidation(CURRENT_VERSION);
+
+      String activeKeyCountFullName = TEST_PREFIX + "." + ACTIVE_KEY_COUNT.getMetricEntity().getMetricName();
+      String invalidationFullName =
+          TEST_PREFIX + "." + IngestionOtelMetricEntity.ACTIVE_KEY_COUNT_INVALIDATION.getMetricEntity().getMetricName();
+      boolean foundActiveKeyCount =
+          localReader.collectAllMetrics().stream().anyMatch(md -> md.getName().equals(activeKeyCountFullName));
+      boolean foundInvalidation =
+          localReader.collectAllMetrics().stream().anyMatch(md -> md.getName().equals(invalidationFullName));
+      assertFalse(foundActiveKeyCount, "active_count gauge should not be registered when activeKeyCountEnabled=false");
+      assertFalse(
+          foundInvalidation,
+          "active_count_invalidation counter should not be registered when activeKeyCountEnabled=false");
+    }
+  }
+
+  @Test
   public void testConstructorWithGlobalOtelDisabled() {
     try (VeniceMetricsRepository disabledMetricsRepository = new VeniceMetricsRepository(
         new VeniceMetricsConfig.Builder().setMetricEntities(SERVER_METRIC_ENTITIES)
@@ -159,7 +193,7 @@ public class IngestionOtelStatsTest {
             .setOtelAdditionalMetricsReader(inMemoryMetricReader)
             .build())) {
       IngestionOtelStats stats =
-          new IngestionOtelStats(disabledMetricsRepository, STORE_NAME, CLUSTER_NAME, LOCAL_REGION, true, true);
+          new IngestionOtelStats(disabledMetricsRepository, STORE_NAME, CLUSTER_NAME, LOCAL_REGION, true, true, true);
       assertFalse(stats.emitOtelMetrics(), "OTel metrics should be disabled when global OTel is off");
     }
   }
@@ -173,7 +207,7 @@ public class IngestionOtelStatsTest {
             .setOtelAdditionalMetricsReader(inMemoryMetricReader)
             .build())) {
       IngestionOtelStats stats =
-          new IngestionOtelStats(enabledMetricsRepository, STORE_NAME, CLUSTER_NAME, LOCAL_REGION, false, true);
+          new IngestionOtelStats(enabledMetricsRepository, STORE_NAME, CLUSTER_NAME, LOCAL_REGION, false, true, true);
       assertFalse(stats.emitOtelMetrics(), "OTel metrics should be disabled when ingestion override is off");
     }
   }
@@ -182,7 +216,7 @@ public class IngestionOtelStatsTest {
   public void testConstructorWithNonVeniceMetricsRepository() {
     MetricsRepository regularRepository = new MetricsRepository();
     IngestionOtelStats stats =
-        new IngestionOtelStats(regularRepository, STORE_NAME, CLUSTER_NAME, LOCAL_REGION, true, true);
+        new IngestionOtelStats(regularRepository, STORE_NAME, CLUSTER_NAME, LOCAL_REGION, true, true, true);
     assertFalse(stats.emitOtelMetrics(), "OTel metrics should be disabled for non-Venice repository");
 
     // RT recording methods should not throw when baseDimensionsMap is null
@@ -957,7 +991,7 @@ public class IngestionOtelStatsTest {
             .setOtelAdditionalMetricsReader(disabledMetricReader)
             .build())) {
       IngestionOtelStats stats =
-          new IngestionOtelStats(disabledMetricsRepository, STORE_NAME, CLUSTER_NAME, LOCAL_REGION, true, true);
+          new IngestionOtelStats(disabledMetricsRepository, STORE_NAME, CLUSTER_NAME, LOCAL_REGION, true, true, true);
       stats.updateVersionInfo(CURRENT_VERSION, FUTURE_VERSION);
       stats.recordRecordsConsumed(CURRENT_VERSION, ReplicaType.LEADER, 10);
       stats.recordIngestionTime(CURRENT_VERSION, 50.0);

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/stats/ingestion/IngestionOtelStatsTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/stats/ingestion/IngestionOtelStatsTest.java
@@ -179,31 +179,6 @@ public class IngestionOtelStatsTest {
     }
   }
 
-  /** Positive control for {@link #testActiveKeyCountMetricsNotRegisteredWhenDisabled}: proves the
-   * full-name format the negative test compares against actually matches a registered metric. If
-   * the OTel prefix scheme ever changes, this test fails loudly instead of the negative test
-   * silently passing. */
-  @Test
-  public void testActiveKeyCountInvalidationMetricRegisteredWhenEnabled() {
-    InMemoryMetricReader localReader = InMemoryMetricReader.create();
-    try (VeniceMetricsRepository localRepo = new VeniceMetricsRepository(
-        new VeniceMetricsConfig.Builder().setMetricEntities(SERVER_METRIC_ENTITIES)
-            .setMetricPrefix(TEST_PREFIX)
-            .setEmitOtelMetrics(true)
-            .setOtelAdditionalMetricsReader(localReader)
-            .build())) {
-      IngestionOtelStats statsEnabled =
-          new IngestionOtelStats(localRepo, STORE_NAME, CLUSTER_NAME, LOCAL_REGION, true, true, true);
-      statsEnabled.updateVersionInfo(CURRENT_VERSION, FUTURE_VERSION);
-      statsEnabled.recordActiveKeyCountInvalidation(CURRENT_VERSION);
-
-      Collection<MetricData> metrics = localReader.collectAllMetrics();
-      assertTrue(
-          metrics.stream().anyMatch(md -> md.getName().equals(activeKeyCountInvalidationFullName())),
-          "active_count_invalidation counter must be registered when activeKeyCountEnabled=true");
-    }
-  }
-
   private static String activeKeyCountFullName() {
     return DEFAULT_METRIC_PREFIX + TEST_PREFIX + "." + ACTIVE_KEY_COUNT.getMetricEntity().getMetricName();
   }

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/stats/ingestion/IngestionOtelStatsTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/stats/ingestion/IngestionOtelStatsTest.java
@@ -166,6 +166,14 @@ public class IngestionOtelStatsTest {
       IngestionOtelStats statsDisabled =
           new IngestionOtelStats(localRepo, STORE_NAME, CLUSTER_NAME, LOCAL_REGION, true, true, false);
       statsDisabled.updateVersionInfo(CURRENT_VERSION, FUTURE_VERSION);
+      /*
+       * Register a task with a non-trivial active-key-count so that, if the ASYNC_GAUGE were
+       * mistakenly still registered, its callback would emit a point. Without this, the absence
+       * assertion below would also pass when no task is registered (false negative).
+       */
+      StoreIngestionTask probeTask = mock(StoreIngestionTask.class);
+      when(probeTask.getActiveKeyCount(any(ReplicaType.class))).thenReturn(42L);
+      statsDisabled.setIngestionTask(CURRENT_VERSION, probeTask);
       // Recorder must be a safe no-op so producers can call it without checking the flag.
       statsDisabled.recordActiveKeyCountInvalidation(CURRENT_VERSION);
 


### PR DESCRIPTION
## Problem Statement

The active-key-count (introduced in #2676) had two operational gaps:

1. **Metrics emitted on stores not opted into the feature flag.** The `active_key_count` gauge (Tehuti per-store + total) and the `ingestion.key.active_count` OTel gauge were registered unconditionally. Followers/Da-Vinci hosts on stores without active-key-count tracking emitted `-1` (sentinel for "not tracked") on every collection cycle even when the feature is not enabled.
2. **Asymmetric invalidation paths.** Six distinct code paths could invalidate the count (follower decrement underflow, leader DCR underflow, leader-propagated invalidate signal, corrupt single-byte kcs signal, multi-byte kcs signal, Tier-3 keyExists I/O failure). Of those, some called `setActiveKeyCount(-1)` inline, some routed through a small helper, two emitted ERROR logs, and two were silent. Operators had no visibility into the silent paths.

## Solution

**Gate registration behind config.** Add `VeniceServerConfig.isAnyActiveKeyCountTrackingEnabled()` (= `activeKeyCountForAllBatchPushEnabled || activeKeyCountForHybridStoreEnabled`). When neither flag is on:
- `HostLevelIngestionStats` skips registering the per-store + total `active_key_count` gauge and the `active_key_count_invalidation` Tehuti rate.
- `IngestionOtelStats` skips creating the `ingestion.key.active_count` ASYNC_GAUGE and the `ingestion.key.active_count_invalidation` COUNTER.
- The recorder methods on both classes are null-guarded so producers (`StoreIngestionTask.recordActiveKeyCountInvalidation`) can call them unconditionally regardless of config state.

**Consolidate invalidation through one helper.** New package-private final helper `StoreIngestionTask.invalidateActiveKeyCount(pcs, reason[, cause])` that:
1. Sets the count to `ACTIVE_KEY_COUNT_NOT_TRACKED`.
2. Records the invalidation metric (per-version OTel + host-level Tehuti).
3. Emits a rate-limited ERROR log via `REDUNDANT_LOGGING_FILTER`, with the optional throwable attached.

The state mutation and metric are wrapped in try/finally so the log fires even if either throws. All six invalidation paths now route through this helper with location-specific reason strings.

**No NPE when disabled.** Every reader of a now-nullable field (`totalActiveKeyCountInvalidationRate`, `activeKeyCountInvalidationMetric`, `activeKeyCountByRoleAndReplicaType`) is either null-guarded at the call site or unused after construction (the OTel ASYNC_GAUGE field is only read by the SDK's collection callback, which is never registered when `null`).

###  Code changes
- [x] Added new code behind **a config**. The gating is controlled by the existing flags `server.active.key.count.for.all.batch.push.enabled` (default `false`) and `server.active.key.count.for.hybrid.store.enabled` (default `false`). No new config introduced — this PR consumes them via the new aggregator helper.
- [x] Introduced new **log lines**. Six rate-limited ERROR logs (one per invalidation reason) emitted from `invalidateActiveKeyCount`.
  - [x] Confirmed if logs need to be **rate limited** to avoid excessive logging. All paths route through `REDUNDANT_LOGGING_FILTER.isRedundantException()` before logging.

###  **Concurrency-Specific Checks**
- [x] Code has **no race conditions** or **thread safety issues**. The helper only touches per-PCS state; the underlying `decrementActiveKeyCount` already uses `AtomicLong.getAndUpdate` for the underflow detection.
- [x] Proper **synchronization mechanisms** are used where needed. No new locks added; the helper is per-PCS and the metric/log calls are independently thread-safe.
- [x] No **blocking calls** inside critical sections that could lead to deadlocks or performance degradation.
- [x] Verified **thread-safe collections** are used. No new collections introduced.
- [x] Validated proper exception handling in multi-threaded code to avoid silent thread termination. The helper's try/finally guarantees the operator-visible ERROR log fires even if the state mutation or metric record throws.

## How was this PR tested?

- [x] New unit tests added.
  - `ActiveKeyCountTest.testTrackActiveKeyCount_followerInvalidationLogsError` — `TestLogAppender` capture asserting all four follower-side paths (underflow, leader-propagated, corrupt single-byte, multi-byte) emit the expected ERROR with the replica id, route through `setActiveKeyCount(-1)`, and increment the metric exactly once each.
  - `ActiveKeyCountTest.testProcessMessage_leaderUnderflow_routesThroughInvalidateHelper` — leader-side DCR underflow goes through the helper.
  - `ActiveKeyCountTest.testIsValuePresentForKey_tier3_keyExistsThrows_invalidatesAndReturnsFalse` extended with log capture for the Tier-3 keyExists path.
  - `ActiveKeyCountScenarioTest.testInvalidationParity_tehutiAndOtelBothRecord` — cross-system parity: a single recording fans out to both Tehuti rate and OTel counter exactly once.
  - `AggHostLevelIngestionStatsTest.testActiveKeyCountMetricsAbsentWhenDisabled` / `testActiveKeyCountMetricsRegisteredWhenEnabled` — gating coverage for both the gauges and the rate.
  - `IngestionOtelStatsTest.testActiveKeyCountMetricsNotRegisteredWhenDisabled` — asserts the OTel ASYNC_GAUGE and COUNTER are absent from `InMemoryMetricReader.collectAllMetrics()` when disabled, and that the recorder is a safe no-op.
- [ ] New integration tests added.
- [x] Modified or extended existing tests. Updated all existing `IngestionOtelStats` constructor call sites for the new `activeKeyCountEnabled` parameter; added `doCallRealMethod` stubs for the new helper to bypass Mockito interception in `ActiveKeyCountTest` setup.
- [x] Verified backward compatibility (if applicable). Wire format (`kcs` PubSub header semantics: `-1`/`0`/`+1`) is unchanged. Default behavior is no metric registration when both flags are off — matches what these flags would have wanted from the start.

## Does this PR introduce any user-facing or breaking changes?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Clearly explain the behavior change and its impact.

The dashboard difference is intentional: stores not opted into active-key-count tracking will no longer emit the `active_key_count` gauge or `active_key_count_invalidation` rate. This is a correctness fix — the prior emission of `-1` was a sentinel meaning "not tracked", which dashboards were misinterpreting. The flags themselves are pre-existing and default `false`, so no opted-in store loses metrics.
