### PR TITLE
[thin-client] Support HTTP/HTTPS routing in createStoreMetadataFetcher

### DIFF
--- a/clients/venice-thin-client/src/main/java/com/linkedin/venice/client/store/ClientFactory.java
+++ b/clients/venice-thin-client/src/main/java/com/linkedin/venice/client/store/ClientFactory.java
@@ -153,7 +153,7 @@ public class ClientFactory {
   }
 
   public static StoreMetadataFetcher createStoreMetadataFetcher(ClientConfig clientConfig) {
-    return new RouterBasedStoreMetadataFetcher(clientConfig.getD2Client(), clientConfig.getD2ServiceName());
+    return new RouterBasedStoreMetadataFetcher(getTransportClient(clientConfig));
   }
 
   private static D2TransportClient generateD2TransportClient(ClientConfig clientConfig) {

--- a/clients/venice-thin-client/src/main/java/com/linkedin/venice/client/store/ClientFactory.java
+++ b/clients/venice-thin-client/src/main/java/com/linkedin/venice/client/store/ClientFactory.java
@@ -153,7 +153,7 @@ public class ClientFactory {
   }
 
   public static StoreMetadataFetcher createStoreMetadataFetcher(ClientConfig clientConfig) {
-    return new RouterBasedStoreMetadataFetcher(getTransportClient(clientConfig));
+    return new RouterBasedStoreMetadataFetcher(clientConfig);
   }
 
   private static D2TransportClient generateD2TransportClient(ClientConfig clientConfig) {

--- a/clients/venice-thin-client/src/main/java/com/linkedin/venice/client/store/RouterBasedStoreMetadataFetcher.java
+++ b/clients/venice-thin-client/src/main/java/com/linkedin/venice/client/store/RouterBasedStoreMetadataFetcher.java
@@ -23,8 +23,8 @@ import java.util.concurrent.TimeoutException;
  * is not tied to a specific store and operates on metadata available globally across clusters.
  *
  * This class uses a {@link TransportClient} directly (rather than {@link AbstractAvroStoreClient})
- * to avoid store-level D2 service discovery, which requires a store name and is unnecessary for
- * cluster-agnostic endpoints like {@code /stores}. The transport may be D2-, HTTPS-, or HTTP-backed
+ * because {@code AbstractAvroStoreClient} is store-scoped, whereas {@code /stores} is a
+ * cluster-agnostic router endpoint. The underlying transport may be D2-, HTTPS-, or HTTP-backed
  * depending on how the caller configured the {@link ClientConfig} passed to
  * {@link ClientFactory#createStoreMetadataFetcher(ClientConfig)}.
  */

--- a/clients/venice-thin-client/src/main/java/com/linkedin/venice/client/store/RouterBasedStoreMetadataFetcher.java
+++ b/clients/venice-thin-client/src/main/java/com/linkedin/venice/client/store/RouterBasedStoreMetadataFetcher.java
@@ -2,6 +2,8 @@ package com.linkedin.venice.client.store;
 
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.linkedin.d2.balancer.D2Client;
+import com.linkedin.venice.client.store.transport.D2TransportClient;
 import com.linkedin.venice.client.store.transport.TransportClient;
 import com.linkedin.venice.client.store.transport.TransportClientResponse;
 import com.linkedin.venice.controllerapi.MultiStoreResponse;
@@ -48,6 +50,16 @@ public class RouterBasedStoreMetadataFetcher implements StoreMetadataFetcher {
    */
   public RouterBasedStoreMetadataFetcher(ClientConfig clientConfig) {
     this(ClientFactory.getTransportClient(clientConfig));
+  }
+
+  /**
+   * Backward-compatible constructor matching the API introduced in #2704. Constructs and owns
+   * a {@link D2TransportClient}; closing this fetcher closes the transport. Prefer the
+   * {@link #RouterBasedStoreMetadataFetcher(ClientConfig)} overload for new code — it also
+   * supports HTTP/HTTPS routing.
+   */
+  public RouterBasedStoreMetadataFetcher(D2Client d2Client, String d2ServiceName) {
+    this(new D2TransportClient(d2ServiceName, d2Client));
   }
 
   // VisibleForTesting

--- a/clients/venice-thin-client/src/main/java/com/linkedin/venice/client/store/RouterBasedStoreMetadataFetcher.java
+++ b/clients/venice-thin-client/src/main/java/com/linkedin/venice/client/store/RouterBasedStoreMetadataFetcher.java
@@ -46,6 +46,11 @@ public class RouterBasedStoreMetadataFetcher implements StoreMetadataFetcher {
     this.transportClient = transportClient;
   }
 
+  // VisibleForTesting
+  TransportClient getTransportClient() {
+    return transportClient;
+  }
+
   /**
    * Returns all store names available across all clusters, as seen by the router's
    * non-cluster-specific {@link com.linkedin.venice.helix.HelixReadOnlyStoreConfigRepository}.

--- a/clients/venice-thin-client/src/main/java/com/linkedin/venice/client/store/RouterBasedStoreMetadataFetcher.java
+++ b/clients/venice-thin-client/src/main/java/com/linkedin/venice/client/store/RouterBasedStoreMetadataFetcher.java
@@ -2,8 +2,6 @@ package com.linkedin.venice.client.store;
 
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.linkedin.d2.balancer.D2Client;
-import com.linkedin.venice.client.store.transport.D2TransportClient;
 import com.linkedin.venice.client.store.transport.TransportClient;
 import com.linkedin.venice.client.store.transport.TransportClientResponse;
 import com.linkedin.venice.controllerapi.MultiStoreResponse;
@@ -50,16 +48,6 @@ public class RouterBasedStoreMetadataFetcher implements StoreMetadataFetcher {
    */
   public RouterBasedStoreMetadataFetcher(ClientConfig clientConfig) {
     this(ClientFactory.getTransportClient(clientConfig));
-  }
-
-  /**
-   * Backward-compatible constructor matching the API introduced in #2704. Constructs and owns
-   * a {@link D2TransportClient}; closing this fetcher closes the transport. Prefer the
-   * {@link #RouterBasedStoreMetadataFetcher(ClientConfig)} overload for new code — it also
-   * supports HTTP/HTTPS routing.
-   */
-  public RouterBasedStoreMetadataFetcher(D2Client d2Client, String d2ServiceName) {
-    this(new D2TransportClient(d2ServiceName, d2Client));
   }
 
   // VisibleForTesting

--- a/clients/venice-thin-client/src/main/java/com/linkedin/venice/client/store/RouterBasedStoreMetadataFetcher.java
+++ b/clients/venice-thin-client/src/main/java/com/linkedin/venice/client/store/RouterBasedStoreMetadataFetcher.java
@@ -42,7 +42,16 @@ public class RouterBasedStoreMetadataFetcher implements StoreMetadataFetcher {
 
   private final TransportClient transportClient;
 
-  public RouterBasedStoreMetadataFetcher(TransportClient transportClient) {
+  /**
+   * Constructs a fetcher that owns the underlying {@link TransportClient} built from
+   * {@code clientConfig}; closing this fetcher closes the transport.
+   */
+  public RouterBasedStoreMetadataFetcher(ClientConfig clientConfig) {
+    this(ClientFactory.getTransportClient(clientConfig));
+  }
+
+  // VisibleForTesting
+  RouterBasedStoreMetadataFetcher(TransportClient transportClient) {
     this.transportClient = transportClient;
   }
 

--- a/clients/venice-thin-client/src/main/java/com/linkedin/venice/client/store/RouterBasedStoreMetadataFetcher.java
+++ b/clients/venice-thin-client/src/main/java/com/linkedin/venice/client/store/RouterBasedStoreMetadataFetcher.java
@@ -2,8 +2,6 @@ package com.linkedin.venice.client.store;
 
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.linkedin.d2.balancer.D2Client;
-import com.linkedin.venice.client.store.transport.D2TransportClient;
 import com.linkedin.venice.client.store.transport.TransportClient;
 import com.linkedin.venice.client.store.transport.TransportClientResponse;
 import com.linkedin.venice.controllerapi.MultiStoreResponse;
@@ -24,9 +22,11 @@ import java.util.concurrent.TimeoutException;
  * Unlike {@link com.linkedin.venice.client.schema.RouterBasedStoreSchemaFetcher}, this class
  * is not tied to a specific store and operates on metadata available globally across clusters.
  *
- * This class uses {@link D2TransportClient} directly (rather than {@link AbstractAvroStoreClient})
+ * This class uses a {@link TransportClient} directly (rather than {@link AbstractAvroStoreClient})
  * to avoid store-level D2 service discovery, which requires a store name and is unnecessary for
- * cluster-agnostic endpoints like {@code /stores}.
+ * cluster-agnostic endpoints like {@code /stores}. The transport may be D2-, HTTPS-, or HTTP-backed
+ * depending on how the caller configured the {@link ClientConfig} passed to
+ * {@link ClientFactory#createStoreMetadataFetcher(ClientConfig)}.
  */
 public class RouterBasedStoreMetadataFetcher implements StoreMetadataFetcher {
   public static final String TYPE_STORES = "stores";
@@ -42,12 +42,7 @@ public class RouterBasedStoreMetadataFetcher implements StoreMetadataFetcher {
 
   private final TransportClient transportClient;
 
-  public RouterBasedStoreMetadataFetcher(D2Client d2Client, String d2ServiceName) {
-    this.transportClient = new D2TransportClient(d2ServiceName, d2Client);
-  }
-
-  // VisibleForTesting
-  RouterBasedStoreMetadataFetcher(TransportClient transportClient) {
+  public RouterBasedStoreMetadataFetcher(TransportClient transportClient) {
     this.transportClient = transportClient;
   }
 

--- a/clients/venice-thin-client/src/test/java/com/linkedin/venice/client/store/ClientFactoryTest.java
+++ b/clients/venice-thin-client/src/test/java/com/linkedin/venice/client/store/ClientFactoryTest.java
@@ -129,13 +129,22 @@ public class ClientFactoryTest {
 
   @Test
   public void testCreateStoreMetadataFetcherSupportsHttpRouting() throws IOException {
+    // ClientFactory uses static unitTestMode/provider hooks; reset them so a prior test cannot
+    // short-circuit getTransportClient and turn this assertion into a false positive.
+    ClientFactory.resetUnitTestMode();
+
     ClientConfig config = ClientConfig.defaultGenericClientConfig("store").setVeniceURL("http://localhost:8080");
 
     try (StoreMetadataFetcher fetcher = ClientFactory.createStoreMetadataFetcher(config)) {
-      Assert.assertNotNull(fetcher, "createStoreMetadataFetcher should succeed with HTTP url-based routing");
       Assert.assertTrue(
           fetcher instanceof RouterBasedStoreMetadataFetcher,
           "Expected RouterBasedStoreMetadataFetcher, got " + fetcher.getClass());
+      TransportClient underlying = ((RouterBasedStoreMetadataFetcher) fetcher).getTransportClient();
+      Assert.assertTrue(
+          underlying instanceof HttpTransportClient,
+          "Expected HttpTransportClient underlying, got " + underlying.getClass());
+      Assert
+          .assertFalse(underlying instanceof HttpsTransportClient, "HTTP url should not produce HttpsTransportClient");
     }
   }
 }

--- a/clients/venice-thin-client/src/test/java/com/linkedin/venice/client/store/ClientFactoryTest.java
+++ b/clients/venice-thin-client/src/test/java/com/linkedin/venice/client/store/ClientFactoryTest.java
@@ -9,6 +9,7 @@ import com.linkedin.venice.client.store.transport.TransportClient;
 import com.linkedin.venice.exceptions.VeniceUnsupportedOperationException;
 import com.linkedin.venice.security.SSLFactory;
 import com.linkedin.venice.utils.DataProviderUtils;
+import java.io.IOException;
 import java.util.function.Function;
 import javax.net.ssl.SSLContext;
 import org.testng.Assert;
@@ -124,5 +125,17 @@ public class ClientFactoryTest {
     Assert.assertNotSame(actualTransportClient3, transportClient);
 
     Assert.assertTrue(actualTransportClient3 instanceof HttpTransportClient);
+  }
+
+  @Test
+  public void testCreateStoreMetadataFetcherSupportsHttpRouting() throws IOException {
+    ClientConfig config = ClientConfig.defaultGenericClientConfig("store").setVeniceURL("http://localhost:8080");
+
+    try (StoreMetadataFetcher fetcher = ClientFactory.createStoreMetadataFetcher(config)) {
+      Assert.assertNotNull(fetcher, "createStoreMetadataFetcher should succeed with HTTP url-based routing");
+      Assert.assertTrue(
+          fetcher instanceof RouterBasedStoreMetadataFetcher,
+          "Expected RouterBasedStoreMetadataFetcher, got " + fetcher.getClass());
+    }
   }
 }

--- a/clients/venice-thin-client/src/test/java/com/linkedin/venice/client/store/ClientFactoryTest.java
+++ b/clients/venice-thin-client/src/test/java/com/linkedin/venice/client/store/ClientFactoryTest.java
@@ -13,11 +13,20 @@ import java.io.IOException;
 import java.util.function.Function;
 import javax.net.ssl.SSLContext;
 import org.testng.Assert;
+import org.testng.annotations.AfterMethod;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 
 public class ClientFactoryTest {
+  @AfterMethod(alwaysRun = true)
+  public void tearDown() {
+    // Several tests in this class flip ClientFactory into unit-test mode and install a transport-client
+    // provider. Reset after every method so the static hooks cannot leak into later tests in this class
+    // or into other classes that share the same JVM.
+    ClientFactory.resetUnitTestMode();
+  }
+
   @DataProvider(name = "protocol")
   public static Object[][] protocol() {
     return new Object[][] { { "http" }, { "https" } };
@@ -129,10 +138,6 @@ public class ClientFactoryTest {
 
   @Test
   public void testCreateStoreMetadataFetcherSupportsHttpRouting() throws IOException {
-    // ClientFactory uses static unitTestMode/provider hooks; reset them so a prior test cannot
-    // short-circuit getTransportClient and turn this assertion into a false positive.
-    ClientFactory.resetUnitTestMode();
-
     ClientConfig config = ClientConfig.defaultGenericClientConfig("store").setVeniceURL("http://localhost:8080");
 
     try (StoreMetadataFetcher fetcher = ClientFactory.createStoreMetadataFetcher(config)) {

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/client/store/TestRouterBasedStoreMetadataFetcher.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/client/store/TestRouterBasedStoreMetadataFetcher.java
@@ -6,6 +6,7 @@ import com.linkedin.d2.balancer.D2Client;
 import com.linkedin.venice.D2.D2ClientUtils;
 import com.linkedin.venice.controllerapi.ControllerClient;
 import com.linkedin.venice.integration.utils.ServiceFactory;
+import com.linkedin.venice.integration.utils.VeniceClusterWrapper;
 import com.linkedin.venice.integration.utils.VeniceControllerWrapper;
 import com.linkedin.venice.integration.utils.VeniceMultiRegionClusterCreateOptions;
 import com.linkedin.venice.integration.utils.VeniceRouterWrapper;
@@ -28,6 +29,7 @@ public class TestRouterBasedStoreMetadataFetcher {
 
   private VeniceTwoLayerMultiRegionMultiClusterWrapper venice;
   private D2Client d2Client;
+  private String routerHttpUrl;
   private String storeName1;
   private String storeName2;
   private ControllerClient parentControllerClient;
@@ -54,6 +56,9 @@ public class TestRouterBasedStoreMetadataFetcher {
     parentControllerClient = new ControllerClient(venice.getClusterNames()[0], parentController.getControllerUrl());
     d2Client = IntegrationTestPushUtils.getD2Client(venice.getChildRegions().get(0).getZkServerWrapper().getAddress());
     D2ClientUtils.startClient(d2Client);
+
+    VeniceClusterWrapper childCluster = venice.getChildRegions().get(0).getClusters().values().iterator().next();
+    routerHttpUrl = childCluster.getRandomRouterURL();
   }
 
   @AfterClass(alwaysRun = true)
@@ -87,9 +92,33 @@ public class TestRouterBasedStoreMetadataFetcher {
             .setD2ServiceName(VeniceRouterWrapper.CLUSTER_DISCOVERY_D2_SERVICE_NAME))) {
       TestUtils.waitForNonDeterministicAssertion(5, TimeUnit.SECONDS, () -> {
         Set<String> storeNames = fetcher.getAllStoreNames();
-        Assert.assertEquals(storeNames.size(), 2, "Expected exactly 2 stores, but got: " + storeNames);
-        Assert.assertTrue(storeNames.contains(storeName1), "Missing store: " + storeName1);
-        Assert.assertTrue(storeNames.contains(storeName2), "Missing store: " + storeName2);
+        Assert.assertTrue(storeNames.contains(storeName1), "Missing store " + storeName1 + " in " + storeNames);
+        Assert.assertTrue(storeNames.contains(storeName2), "Missing store " + storeName2 + " in " + storeNames);
+      });
+    }
+  }
+
+  @Test(timeOut = TEST_TIMEOUT_MS)
+  public void testGetAllStoreNamesViaHttpRouting() throws Exception {
+    // Cover the non-D2 path used by Hoptimator OSS: configure the fetcher with a raw
+    // router HTTP URL (no D2 client) and verify it can still enumerate stores.
+    String httpStoreName1 = Utils.getUniqueString("test-store-http");
+    String httpStoreName2 = Utils.getUniqueString("test-store-http");
+
+    parentControllerClient.createNewStore(httpStoreName1, "owner", STRING_SCHEMA.toString(), STRING_SCHEMA.toString());
+    parentControllerClient.createNewStore(httpStoreName2, "owner", STRING_SCHEMA.toString(), STRING_SCHEMA.toString());
+
+    TestUtils.waitForNonDeterministicAssertion(30, TimeUnit.SECONDS, () -> {
+      Assert.assertEquals(parentControllerClient.getStore(httpStoreName1).getStore().getName(), httpStoreName1);
+      Assert.assertEquals(parentControllerClient.getStore(httpStoreName2).getStore().getName(), httpStoreName2);
+    });
+
+    try (StoreMetadataFetcher fetcher =
+        ClientFactory.createStoreMetadataFetcher(new ClientConfig<>().setVeniceURL(routerHttpUrl))) {
+      TestUtils.waitForNonDeterministicAssertion(5, TimeUnit.SECONDS, () -> {
+        Set<String> storeNames = fetcher.getAllStoreNames();
+        Assert.assertTrue(storeNames.contains(httpStoreName1), "Missing store " + httpStoreName1 + " in " + storeNames);
+        Assert.assertTrue(storeNames.contains(httpStoreName2), "Missing store " + httpStoreName2 + " in " + storeNames);
       });
     }
   }


### PR DESCRIPTION
## Problem Statement

`ClientFactory.createStoreMetadataFetcher(ClientConfig)`, introduced in #2704, hard-wires a `D2TransportClient`. That works for callers that have D2 set up (the internal Hoptimator MP, our integration tests), but Hoptimator OSS uses plain HTTP url-based routing — see [linkedin/Hoptimator `ClusterSchema.java#L56`](https://github.com/linkedin/Hoptimator/blob/main/hoptimator-venice/src/main/java/com/linkedin/hoptimator/venice/ClusterSchema.java#L56) — so it can't adopt the new `/stores` API.

This blocks Hoptimator OSS from switching off the per-store schema-fetcher enumeration onto the cluster-agnostic `/stores` endpoint.

## Solution

Route `createStoreMetadataFetcher` through the existing `ClientFactory.getTransportClient(ClientConfig)` helper, which already picks `D2TransportClient` / `HttpsTransportClient` / `HttpTransportClient` based on the `ClientConfig`. This mirrors how `createStoreSchemaFetcher` is wired and is the same selection logic used by every other client `ClientFactory` builds.

Callers using D2 (`setD2Client` + `setD2ServiceName`) keep the same behavior — `setD2ServiceName(...)` flips `isD2Routing=true`, so `getTransportClient` returns a `D2TransportClient` exactly as before. Callers using `setVeniceURL("http://...")` or `setVeniceURL("https://...")` now get the corresponding HTTP transport.

`ClientFactory.createStoreMetadataFetcher(ClientConfig)` is the single supported entry point. To honor [#2704 discussion r3066176915](https://github.com/linkedin/venice/pull/2704#discussion_r3066176915) — the fetcher must not close a transport it doesn't own — `RouterBasedStoreMetadataFetcher`'s public constructor takes `ClientConfig` and builds its own `TransportClient` via `ClientFactory.getTransportClient(...)`. The `(TransportClient)` constructor remains package-private as `VisibleForTesting`. The old public `(D2Client, String)` constructor from #2704 is removed; callers should go through the factory.

###  Code changes
- [ ] Added new code behind **a config**.
- [ ] Introduced new **log lines**.
  - [ ] Confirmed if logs need to be **rate limited** to avoid excessive logging.

###  **Concurrency-Specific Checks**
- [x] Code has **no race conditions** or **thread safety issues**. (No new shared state — only a transport-construction switch.)
- [x] Proper **synchronization mechanisms** are used where needed.
- [x] No **blocking calls** inside critical sections.
- [x] Verified **thread-safe collections** are used.
- [x] Validated proper exception handling in multi-threaded code.

## How was this PR tested?

- [x] New unit tests added — `ClientFactoryTest#testCreateStoreMetadataFetcherSupportsHttpRouting` configures a `ClientConfig` with `setVeniceURL("http://...")`, builds a fetcher through `ClientFactory.createStoreMetadataFetcher`, and asserts that the underlying transport (via a new package-private `RouterBasedStoreMetadataFetcher#getTransportClient()` accessor) is `HttpTransportClient` and not `HttpsTransportClient`. The test resets `ClientFactory`'s static `unitTestMode`/provider hooks first so prior tests cannot short-circuit `getTransportClient`.
- [x] New integration tests added — `TestRouterBasedStoreMetadataFetcher#testGetAllStoreNamesViaHttpRouting` spins up the same multi-region cluster as the existing D2 case, creates two stores, and asserts both surface in `getAllStoreNames()` when the fetcher is built from `new ClientConfig<>().setVeniceURL(routerHttpUrl)` (no D2 client).
- [x] Modified or extended existing tests — the original D2 integration test's `size == 2` assertion was relaxed to `contains()` for the stores it created, since TestNG does not guarantee declaration order across methods in a class and the HTTP test creates additional stores in the same cluster.
- [x] Verified backward compatibility for the D2 routing path — `ClientConfig` callers using `setD2Client` + `setD2ServiceName` still wire through `D2TransportClient` exactly as before.

Local run:

```
./gradlew :clients:venice-thin-client:test \
    --tests com.linkedin.venice.client.store.ClientFactoryTest \
    --tests com.linkedin.venice.client.store.RouterBasedStoreMetadataFetcherTest
# BUILD SUCCESSFUL — all tests pass
```

The new integration test was not run locally — the `internal:venice-test-common:integrationTest` source set fails to compile on `main` (pre-existing Avro codegen / `UpdateStore` field-mismatch errors in unrelated files; confirmed by `git stash`). CI on a fresh checkout will validate it.

## Does this PR introduce any user-facing or breaking changes?
- [ ] No. You can skip the rest of this section.
- [x] Yes. Clearly explain the behavior change and its impact.

`RouterBasedStoreMetadataFetcher`'s public `(D2Client, String)` constructor is removed. The class was introduced in #2704 (not yet in a downstream release) and the intended construction path has always been `ClientFactory.createStoreMetadataFetcher(ClientConfig)`. Any out-of-tree caller using the old constructor should switch to:

```java
ClientFactory.createStoreMetadataFetcher(
    new ClientConfig<>().setD2Client(d2Client).setD2ServiceName(d2ServiceName));
```

which produces the same `D2TransportClient` under the hood.
