### PR TITLE
[da-vinci] Skip current-version-bootstrapping speedup throttler for future-slot versions

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/StoreBackend.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/StoreBackend.java
@@ -129,8 +129,19 @@ public class StoreBackend {
   }
 
   private void setDaVinciFutureVersion(VersionBackend version) {
+    // Keep the IngestionService's future-slot registry in sync so the current-version
+    // bootstrapping speedup throttler does not activate for a version DVC is treating as a
+    // future slot (target-region push + deferred swap can promote the version controller-side
+    // before DVC has finished ingesting it as a future slot).
+    VersionBackend previousFutureVersion = daVinciFutureVersion;
     daVinciFutureVersion = version;
     stats.recordFutureVersion(version);
+    if (previousFutureVersion != null) {
+      backend.getIngestionService().unmarkAsDaVinciFutureSlot(previousFutureVersion.getVersion().kafkaTopicName());
+    }
+    if (version != null) {
+      backend.getIngestionService().markAsDaVinciFutureSlot(version.getVersion().kafkaTopicName());
+    }
   }
 
   public CompletableFuture<Void> subscribe(ComplementSet<Integer> partitions) {

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/IngestionThrottler.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/IngestionThrottler.java
@@ -18,6 +18,7 @@ import java.util.EnumMap;
 import java.util.Map;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Predicate;
 import java.util.function.Supplier;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -55,6 +56,7 @@ public class IngestionThrottler implements Closeable {
         isDaVinciClient,
         serverConfig,
         ongoingIngestionTaskMapSupplier,
+        topic -> false,
         CURRENT_VERSION_BOOTSTRAPPING_DEFAULT_CHECK_INTERVAL,
         CURRENT_VERSION_BOOTSTRAPPING_DEFAULT_CHECK_TIMEUNIT,
         adaptiveThrottlerSignalService);
@@ -64,6 +66,41 @@ public class IngestionThrottler implements Closeable {
       boolean isDaVinciClient,
       VeniceServerConfig serverConfig,
       Supplier<Map<String, StoreIngestionTask>> ongoingIngestionTaskMapSupplier,
+      Predicate<String> isDaVinciFutureSlotTopic,
+      AdaptiveThrottlerSignalService adaptiveThrottlerSignalService) {
+    this(
+        isDaVinciClient,
+        serverConfig,
+        ongoingIngestionTaskMapSupplier,
+        isDaVinciFutureSlotTopic,
+        CURRENT_VERSION_BOOTSTRAPPING_DEFAULT_CHECK_INTERVAL,
+        CURRENT_VERSION_BOOTSTRAPPING_DEFAULT_CHECK_TIMEUNIT,
+        adaptiveThrottlerSignalService);
+  }
+
+  // Backwards-compatible overload for callers that don't supply a future-slot predicate.
+  public IngestionThrottler(
+      boolean isDaVinciClient,
+      VeniceServerConfig serverConfig,
+      Supplier<Map<String, StoreIngestionTask>> ongoingIngestionTaskMapSupplier,
+      int checkInterval,
+      TimeUnit checkTimeUnit,
+      AdaptiveThrottlerSignalService adaptiveThrottlerSignalService) {
+    this(
+        isDaVinciClient,
+        serverConfig,
+        ongoingIngestionTaskMapSupplier,
+        topic -> false,
+        checkInterval,
+        checkTimeUnit,
+        adaptiveThrottlerSignalService);
+  }
+
+  public IngestionThrottler(
+      boolean isDaVinciClient,
+      VeniceServerConfig serverConfig,
+      Supplier<Map<String, StoreIngestionTask>> ongoingIngestionTaskMapSupplier,
+      Predicate<String> isDaVinciFutureSlotTopic,
       int checkInterval,
       TimeUnit checkTimeUnit,
       AdaptiveThrottlerSignalService adaptiveThrottlerSignalService) {
@@ -238,7 +275,13 @@ public class IngestionThrottler implements Closeable {
         String topicOfCurrentVersionBootstrapping = "";
         for (Map.Entry<String, StoreIngestionTask> entry: ongoingStoreIngestionTaskMap.entrySet()) {
           StoreIngestionTask task = entry.getValue();
-          if (task.isCurrentVersion() && !task.hasAllPartitionReportedCompleted()) {
+          if (task.isCurrentVersion() && !task.hasAllPartitionReportedCompleted()
+          // Skip versions DVC is ingesting as a future-version slot. Under target-region push +
+          // deferred swap, the controller may have already promoted the version (so the
+          // store-metadata view says "current") while DVC still treats it as its future slot.
+          // The speedup throttler is meant to help current-version bootstraps catch up faster,
+          // not future-version pre-swap ingestion which has no SLA pressure.
+              && !isDaVinciFutureSlotTopic.test(entry.getKey())) {
             hasCurrentVersionBootstrapping = true;
             topicOfCurrentVersionBootstrapping = entry.getKey();
             break;

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/KafkaStoreIngestionService.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/KafkaStoreIngestionService.java
@@ -117,6 +117,7 @@ import java.util.Properties;
 import java.util.Queue;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.ConcurrentSkipListMap;
 import java.util.concurrent.ExecutorService;
@@ -174,6 +175,20 @@ public class KafkaStoreIngestionService extends AbstractVeniceService implements
    * for consuming messages and making changes to the local store accordingly.
    */
   private final NavigableMap<String, StoreIngestionTask> topicNameToIngestionTaskMap;
+
+  /**
+   * Set of Kafka version topics that DaVinci has assigned to its future-version slot.
+   * Maintained by {@link com.linkedin.davinci.StoreBackend} via {@link #markAsDaVinciFutureSlot}
+   * and {@link #unmarkAsDaVinciFutureSlot} as DVC subscribes / swaps / clears future versions.
+   *
+   * <p>Consulted by {@link IngestionThrottler} so the current-version-bootstrapping speedup
+   * throttler is not activated for versions DVC is ingesting as a future slot. Under
+   * target-region push + deferred swap, the controller-side {@code currentVersion} can already
+   * point at the new version while DVC still treats it as a future slot — without this signal,
+   * the speedup throttler would fire inappropriately for a version that has no SLA pressure
+   * to catch up yet.
+   */
+  private final Set<String> daVinciFutureSlotTopics = ConcurrentHashMap.newKeySet();
 
   private final Optional<SchemaReader> kafkaMessageEnvelopeSchemaReader;
 
@@ -285,6 +300,7 @@ public class KafkaStoreIngestionService extends AbstractVeniceService implements
         isDaVinciClient,
         serverConfig,
         () -> Collections.unmodifiableMap(topicNameToIngestionTaskMap),
+        daVinciFutureSlotTopics::contains,
         adaptiveThrottlerSignalService);
 
     final Map<String, EventThrottler> kafkaUrlToRecordsThrottler;
@@ -700,6 +716,33 @@ public class KafkaStoreIngestionService extends AbstractVeniceService implements
       }
     }
     return false;
+  }
+
+  /**
+   * Mark a Kafka version topic as currently subscribed by DaVinci as a future-version slot.
+   * Called by {@link com.linkedin.davinci.StoreBackend#setDaVinciFutureVersion} when a new
+   * future version is installed.
+   */
+  public void markAsDaVinciFutureSlot(String kafkaVersionTopic) {
+    daVinciFutureSlotTopics.add(kafkaVersionTopic);
+  }
+
+  /**
+   * Clear the future-slot mark for a Kafka version topic. Called when DaVinci either swaps the
+   * future version to current, removes the future version, or closes the store.
+   */
+  public void unmarkAsDaVinciFutureSlot(String kafkaVersionTopic) {
+    daVinciFutureSlotTopics.remove(kafkaVersionTopic);
+  }
+
+  /**
+   * Returns true if the given Kafka version topic is currently in DaVinci's future-version slot.
+   * Used by {@link IngestionThrottler} to skip the current-version-bootstrapping speedup throttler
+   * for versions whose controller-side status may say "current" while DaVinci still treats them
+   * as a future slot (target-region push + deferred swap).
+   */
+  public boolean isDaVinciFutureSlot(String kafkaVersionTopic) {
+    return daVinciFutureSlotTopics.contains(kafkaVersionTopic);
   }
 
   /**

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/StoreBackendTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/StoreBackendTest.java
@@ -543,4 +543,43 @@ public class StoreBackendTest {
       assertEquals(versionRef.get().getVersion().getNumber(), version4.getNumber());
     }
   }
+
+  /**
+   * Verify that {@link StoreBackend#setDaVinciFutureVersion} keeps
+   * {@link KafkaStoreIngestionService}'s future-slot registry in sync so the
+   * current-version-bootstrapping speedup throttler can skip future-slot versions.
+   *
+   * <ul>
+   *   <li>Assigning a future version → {@code markAsDaVinciFutureSlot} is called for that topic.
+   *   <li>Promoting future to current (via {@code trySwapDaVinciCurrentVersion}) →
+   *       {@code unmarkAsDaVinciFutureSlot} is called.
+   * </ul>
+   */
+  @Test
+  public void testDaVinciFutureSlotRegistryIsKeptInSync() throws Exception {
+    com.linkedin.davinci.kafka.consumer.KafkaStoreIngestionService ingestionService = backend.getIngestionService();
+
+    // Subscribe to version1 (becomes daVinciCurrentVersion). version1 is the existing current
+    // version, so trySubscribeDaVinciFutureVersion picks version2 as the future slot.
+    CompletableFuture<?> subscribeResult = storeBackend.subscribe(ComplementSet.of(0));
+    versionMap.get(version1.kafkaTopicName()).completePartition(0);
+    subscribeResult.get(3, TimeUnit.SECONDS);
+
+    // version2 should now be marked as the future slot.
+    verify(ingestionService, times(1)).markAsDaVinciFutureSlot(version2.kafkaTopicName());
+    verify(ingestionService, never()).unmarkAsDaVinciFutureSlot(version2.kafkaTopicName());
+
+    // Promote version2 (the future) → currentVersion. swapCurrentVersion calls
+    // setDaVinciFutureVersion(null), which should unmark the topic.
+    versionMap.get(version2.kafkaTopicName()).completePartition(0);
+    store.setCurrentVersion(version2.getNumber());
+    backend.handleStoreChanged(storeBackend);
+
+    verify(ingestionService, times(1)).unmarkAsDaVinciFutureSlot(version2.kafkaTopicName());
+
+    // Sanity: DVC is now serving version2.
+    try (ReferenceCounted<VersionBackend> versionRef = storeBackend.getDaVinciCurrentVersion()) {
+      assertEquals(versionRef.get().getVersion().getNumber(), version2.getNumber());
+    }
+  }
 }

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/IngestionThrottlerTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/IngestionThrottlerTest.java
@@ -84,6 +84,61 @@ public class IngestionThrottlerTest {
     throttlerForNonDaVinciClient.close();
   }
 
+  @Test
+  public void testSpeedupThrottlerSkipsDaVinciFutureSlotTopic() throws IOException {
+    VeniceServerConfig serverConfig = mock(VeniceServerConfig.class);
+    doReturn(100l).when(serverConfig).getKafkaFetchQuotaRecordPerSecond();
+    doReturn(60l).when(serverConfig).getKafkaFetchQuotaTimeWindow();
+    doReturn(1024l).when(serverConfig).getKafkaFetchQuotaBytesPerSecond();
+    doReturn(true).when(serverConfig).isDaVinciCurrentVersionBootstrappingSpeedupEnabled();
+    doReturn(500l).when(serverConfig).getDaVinciCurrentVersionBootstrappingQuotaRecordsPerSecond();
+    doReturn(10240l).when(serverConfig).getDaVinciCurrentVersionBootstrappingQuotaBytesPerSecond();
+    mockThottlerRate(serverConfig);
+
+    // task.isCurrentVersion() returns true (controller view says it's current — e.g. just after
+    // a deferred-swap promotion). But DVC is still treating it as its future-version slot, so we
+    // pass it through the future-slot predicate. Speedup throttler must not activate.
+    StoreIngestionTask futureSlotTask = mock(StoreIngestionTask.class);
+    doReturn(true).when(futureSlotTask).isCurrentVersion();
+    doReturn(false).when(futureSlotTask).hasAllPartitionReportedCompleted();
+
+    String futureSlotTopic = "store_v5";
+    ConcurrentHashMap<String, StoreIngestionTask> tasks = new ConcurrentHashMap<>();
+    tasks.put(futureSlotTopic, futureSlotTask);
+
+    java.util.Set<String> daVinciFutureSlotTopics = ConcurrentHashMap.newKeySet();
+    daVinciFutureSlotTopics.add(futureSlotTopic);
+
+    IngestionThrottler throttler = new IngestionThrottler(
+        true,
+        serverConfig,
+        () -> tasks,
+        daVinciFutureSlotTopics::contains,
+        10,
+        TimeUnit.MILLISECONDS,
+        null);
+
+    // Wait long enough that the periodic check could have flipped the throttler — and assert it
+    // didn't.
+    TestUtils.waitForNonDeterministicAssertion(2, TimeUnit.SECONDS, () -> {
+      assertFalse(
+          throttler.isUsingSpeedupThrottler(),
+          "Speedup throttler must not activate for a DVC future-slot topic, even when "
+              + "isCurrentVersion() returns true");
+    });
+
+    // Once the topic leaves the future slot (DVC swapped it to current), the speedup throttler
+    // should activate as before.
+    daVinciFutureSlotTopics.remove(futureSlotTopic);
+    TestUtils.waitForNonDeterministicAssertion(3, TimeUnit.SECONDS, () -> {
+      assertTrue(
+          throttler.isUsingSpeedupThrottler(),
+          "Speedup throttler should activate once the topic leaves DVC's future slot");
+    });
+
+    throttler.close();
+  }
+
   private static void mockThottlerRate(VeniceServerConfig serverConfig) {
     doReturn(-1).when(serverConfig).getCurrentVersionAAWCLeaderQuotaRecordsPerSecond();
     doReturn(-1).when(serverConfig).getCurrentVersionSepRTLeaderQuotaRecordsPerSecond();


### PR DESCRIPTION
## Problem Statement

Under target-region push + deferred swap, the parent controller promotes v_{n+1} in a non-target region (`store.setCurrentVersion(n+1)` + status flip to `ONLINE`) *before* DaVinci Client subscribes to that version. DVC then subscribes it into its own future-version slot (`StoreBackend.daVinciFutureVersion`).

At this moment two views of "current" disagree:
- **Controller view:** `store.getCurrentVersion() == n+1` (just promoted).
- **DVC view:** `daVinciCurrentVersion == v_n` (DVC has not yet finished ingesting v_{n+1} or run `swapCurrentVersion()`).

The DaVinci current-version-bootstrapping speedup throttler (gated on `da.vinci.current.version.bootstrapping.speedup.enabled`) decides whether to activate based on `task.isCurrentVersion()`, which uses the controller view (`versionNumber == store.getCurrentVersion()`). Under this timing the predicate is satisfied for what DVC is treating as a future-slot subscription, and the higher Kafka-bootstrapping quota is incorrectly applied to a version that has no SLA pressure to catch up quickly.

This was reported as one of two bugs in ACTIONITEM-20331 (the other one — DVRT CDC handoff — requires a larger design and is being tracked separately).

## Solution

Add a registry of Kafka version topics that DaVinci is currently treating as a future-version slot, maintained on `KafkaStoreIngestionService`:
- `markAsDaVinciFutureSlot(topic)` / `unmarkAsDaVinciFutureSlot(topic)` — wired by `StoreBackend.setDaVinciFutureVersion(...)`.
- `isDaVinciFutureSlot(topic)` — queried by `IngestionThrottler`.

`StoreBackend.setDaVinciFutureVersion(...)` is the single point of entry for assigning anything to the future slot. It is called when DVC subscribes a new future version, when DVC swaps future → current (with `null`), when DVC deletes an invalid future version, and on store close/delete. So mark/unmark fires correctly across every code path that touches the future slot.

`IngestionThrottler`'s speedup activation loop now has an additional condition: skip topics that are currently in the future-slot set. Once `swapCurrentVersion()` runs and the topic leaves the set, the speedup throttler can activate normally if the bootstrap is still in flight.

This is intentionally a registry/push model (DVC pushes membership into KSIS) rather than a pull model (throttler asking DVC) — KSIS does not need a DaVinciBackend reference, so no new architectural coupling.

###  Code changes
- [ ] Added new code behind **a config**. — No, the gate is unconditional. (The speedup throttler itself is still gated on `da.vinci.current.version.bootstrapping.speedup.enabled` as before.)
- [x] Introduced new **log lines**. — No new log lines; existing speedup activation logs continue.
  - [x] Confirmed if logs need to be **rate limited** to avoid excessive logging.

###  **Concurrency-Specific Checks**
- [x] Code has **no race conditions** or **thread safety issues**. — `daVinciFutureSlotTopics` is a `ConcurrentHashMap.newKeySet()`. The throttler loop reads via `Set.contains`, mark/unmark write via `add`/`remove`; both are thread-safe. Stale reads in the throttler loop are harmless (worst case: one extra/missed speedup tick).
- [x] Proper **synchronization mechanisms** are used where needed. — Existing `synchronized` in `StoreBackend` around `setDaVinciFutureVersion` callers is unchanged.
- [x] No **blocking calls** inside critical sections.
- [x] Verified **thread-safe collections** are used. — `ConcurrentHashMap.newKeySet()`.
- [x] Validated proper exception handling in multi-threaded code.

## How was this PR tested?

- [x] New unit tests added.
  - `IngestionThrottlerTest.testSpeedupThrottlerSkipsDaVinciFutureSlotTopic` — asserts the speedup throttler does NOT activate when `task.isCurrentVersion()` is true but the topic is in the future-slot set; activates again once the topic is removed.
  - `StoreBackendTest.testDaVinciFutureSlotRegistryIsKeptInSync` — asserts `markAsDaVinciFutureSlot` is called when DVC assigns a future version, and `unmarkAsDaVinciFutureSlot` is called when the future slot is cleared by `swapCurrentVersion`.
- [x] Modified or extended existing tests — full `StoreBackendTest` (12 existing) and `IngestionThrottlerTest` (2 existing) suites run; no regression.
- [x] Verified backward compatibility — `IngestionThrottler` has a backward-compatible constructor overload that defaults the future-slot predicate to `topic -> false`. Existing callers (including the server path) are unaffected.

Test output:
```
com.linkedin.davinci.kafka.consumer.IngestionThrottlerTest > testSpeedupThrottlerSkipsDaVinciFutureSlotTopic PASSED
com.linkedin.davinci.kafka.consumer.IngestionThrottlerTest > throttlerSwitchTest PASSED
com.linkedin.davinci.kafka.consumer.IngestionThrottlerTest > testDifferentThrottler PASSED
com.linkedin.davinci.StoreBackendTest > testDaVinciFutureSlotRegistryIsKeptInSync PASSED
... 12 existing StoreBackendTest tests PASSED
```

## Does this PR introduce any user-facing or breaking changes?
- [x] No. You can skip the rest of this section.