### PR TITLE
[server][dvc] Global RT DIV: Send VT DIV on Control Messages for Remote VT

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTask.java
@@ -2290,17 +2290,25 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
    *   - Leader consuming remote VT (NR): {@code isRealTime()} is false → installs the on-completion
    *     VT DIV sync.
    *
-   * No-op unless Global RT DIV is enabled, the consumed source is non-RT, and the byte threshold for a
-   * Global RT DIV sync has been reached. The same predicate gates {@code sendGlobalRtDivMessage}, keyed
-   * on the local VT name — VT-source bytes share the VT-name counter, tracked separately from RT bytes.
+   * No-op unless Global RT DIV is enabled and the consumed source is non-RT. When those hold, the
+   * snapshot install fires on either: (a) a non-segment control message (SOP / EOP / IP_SOP / IP_EOP /
+   * TOPIC_SWITCH / VERSION_SWAP) — semantically meaningful checkpoints that should not wait for the
+   * byte threshold; or (b) the byte threshold guarded by {@code shouldSendGlobalRtDiv}, keyed on the
+   * local VT name (VT-source bytes share the VT-name counter, tracked separately from RT bytes).
+   * Mirrors the follower path's {@code shouldSendVtDivSnapshot} so leader and follower share the same
+   * "what counts as a sync boundary" predicate. Segment control messages (SOS / EOS) remain excluded —
+   * same high-cardinality reasoning as the follower path.
    */
   void addVtDivToProducerCallbackIfNeeded(
       DefaultPubSubMessage consumerRecord,
       LeaderProducerCallback callback,
       PartitionConsumptionState pcs,
       CompletableFuture<Void> persistedToDBFuture) {
-    if (!isGlobalRtDivEnabled() || consumerRecord.getTopicPartition().getPubSubTopic().isRealTime()
-        || !shouldSendGlobalRtDiv(consumerRecord, pcs, getVersionTopic().getName())) {
+    if (!isGlobalRtDivEnabled() || consumerRecord.getTopicPartition().getPubSubTopic().isRealTime()) {
+      return;
+    }
+    boolean isControlBoundary = isNonSegmentControlMessage(consumerRecord, null);
+    if (!isControlBoundary && !shouldSendGlobalRtDiv(consumerRecord, pcs, getVersionTopic().getName())) {
       return;
     }
     PubSubTopicPartition topicPartition = pcs.getReplicaTopicPartition();

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTask.java
@@ -2276,28 +2276,18 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
   }
 
   /**
-   * Mirrors {@link #sendGlobalRtDivMessage}'s LCVP-sync callback for leaders consuming from a remote VT source in NR
-   * VT consumption has no RT DIV state to propagate, so {@link #sendGlobalRtDivMessage} — the normal path that hands
-   * the VT DIV to the drainer — is never invoked. Without this callback, the OffsetRecord's latestConsumedVtPosition
-   * stays at EARLIEST and ingestion rewinds to the start of VT on the next leader restart.
+   * For leaders consuming a remote VT source (NR), installs an LCVP-sync callback on the local-VT
+   * producer. Remote VT consumption never invokes {@link #sendGlobalRtDivMessage} (there's no RT
+   * DIV state to propagate), so without this path the OffsetRecord's latestConsumedVtPosition stays
+   * at EARLIEST and ingestion rewinds to the start of VT on the next leader restart.
    *
-   * Why {@code !isRealTime()} is the right gate, even though PubSubTopic cannot distinguish local VT
-   * from remote VT (the topic name is identical across regions):
-   *   - {@link #produceToLocalKafka} is only called on the leader ({@link #shouldProduceToVersionTopic}
-   *     is true), and a leader does not consume its own local VT.
-   *   - Leader consuming RT (local or remote): {@code isRealTime()} is true → early return; LCVP sync
-   *     is handled by {@code sendGlobalRtDivMessage}.
-   *   - Leader consuming remote VT (NR): {@code isRealTime()} is false → installs the on-completion
-   *     VT DIV sync.
+   * <p>The {@code !isRealTime()} gate is sufficient even though PubSubTopic cannot distinguish
+   * local from remote VT: {@link #produceToLocalKafka} is leader-only, and a leader does not
+   * consume its own local VT — so a non-RT source here always means remote VT in NR mode.
    *
-   * No-op unless Global RT DIV is enabled and the consumed source is non-RT. When those hold, the
-   * snapshot install fires on either: (a) a non-segment control message (SOP / EOP / IP_SOP / IP_EOP /
-   * TOPIC_SWITCH / VERSION_SWAP) — semantically meaningful checkpoints that should not wait for the
-   * byte threshold; or (b) the byte threshold guarded by {@code shouldSendGlobalRtDiv}, keyed on the
-   * local VT name (VT-source bytes share the VT-name counter, tracked separately from RT bytes).
-   * Mirrors the follower path's {@code shouldSendVtDivSnapshot} so leader and follower share the same
-   * "what counts as a sync boundary" predicate. Segment control messages (SOS / EOS) remain excluded —
-   * same high-cardinality reasoning as the follower path.
+   * <p>Fires on either a non-segment control message (semantically meaningful checkpoints —
+   * matches the follower path's {@code shouldSendVtDivSnapshot}) or the byte threshold gated by
+   * {@code shouldSendGlobalRtDiv}.
    */
   void addVtDivToProducerCallbackIfNeeded(
       DefaultPubSubMessage consumerRecord,
@@ -3192,11 +3182,10 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
             beforeProcessingBatchRecordsTimestampMs);
         updateLatestConsumedRtPositions(partitionConsumptionState, kafkaUrl, consumerRecord.getPosition());
       } else if (isGlobalRtDivEnabled()) {
-        // Remote VT consumption (NR leader): mirror the !produceToLocalKafka branch's LCVP update.
-        // Without this, consumerDiv's latestConsumedVtPosition stays at EARLIEST for the entire push
-        // (the LCVP update site for local VT consumption above is gated on !produceToLocalKafka and
-        // therefore skipped here), so every VT DIV snapshot starts from EARLIEST and only gets a
-        // non-EARLIEST value via the produce-completion callback's local-VT override.
+        // Remote VT consumption (NR leader): the LCVP-update site for local VT is gated on
+        // !produceToLocalKafka above and skipped here, so without this every VT DIV snapshot would
+        // start from EARLIEST until the produce-completion callback overwrites it with a local-VT
+        // position.
         getConsumerDiv().updateLatestConsumedVtPosition(partition, consumerRecord.getPosition());
       }
 

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTask.java
@@ -2276,18 +2276,28 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
   }
 
   /**
-   * For leaders consuming a remote VT source (NR), installs an LCVP-sync callback on the local-VT
-   * producer. Remote VT consumption never invokes {@link #sendGlobalRtDivMessage} (there's no RT
-   * DIV state to propagate), so without this path the OffsetRecord's latestConsumedVtPosition stays
-   * at EARLIEST and ingestion rewinds to the start of VT on the next leader restart.
+   * Mirrors {@link #sendGlobalRtDivMessage}'s LCVP-sync callback for leaders consuming from a remote VT source in NR
+   * VT consumption has no RT DIV state to propagate, so {@link #sendGlobalRtDivMessage} — the normal path that hands
+   * the VT DIV to the drainer — is never invoked. Without this callback, the OffsetRecord's latestConsumedVtPosition
+   * stays at EARLIEST and ingestion rewinds to the start of VT on the next leader restart.
    *
-   * <p>The {@code !isRealTime()} gate is sufficient even though PubSubTopic cannot distinguish
-   * local from remote VT: {@link #produceToLocalKafka} is leader-only, and a leader does not
-   * consume its own local VT — so a non-RT source here always means remote VT in NR mode.
+   * Why {@code !isRealTime()} is the right gate, even though PubSubTopic cannot distinguish local VT
+   * from remote VT (the topic name is identical across regions):
+   *   - {@link #produceToLocalKafka} is only called on the leader ({@link #shouldProduceToVersionTopic}
+   *     is true), and a leader does not consume its own local VT.
+   *   - Leader consuming RT (local or remote): {@code isRealTime()} is true → early return; LCVP sync
+   *     is handled by {@code sendGlobalRtDivMessage}.
+   *   - Leader consuming remote VT (NR): {@code isRealTime()} is false → installs the on-completion
+   *     VT DIV sync.
    *
-   * <p>Fires on either a non-segment control message (semantically meaningful checkpoints —
-   * matches the follower path's {@code shouldSendVtDivSnapshot}) or the byte threshold gated by
-   * {@code shouldSendGlobalRtDiv}.
+   * No-op unless Global RT DIV is enabled and the consumed source is non-RT. When those hold, the
+   * snapshot install fires on either: (a) a non-segment control message (SOP / EOP / IP_SOP / IP_EOP /
+   * TOPIC_SWITCH / VERSION_SWAP) — semantically meaningful checkpoints that should not wait for the
+   * byte threshold; or (b) the byte threshold guarded by {@code shouldSendGlobalRtDiv}, keyed on the
+   * local VT name (VT-source bytes share the VT-name counter, tracked separately from RT bytes).
+   * Mirrors the follower path's {@code shouldSendVtDivSnapshot} so leader and follower share the same
+   * "what counts as a sync boundary" predicate. Segment control messages (SOS / EOS) remain excluded —
+   * same high-cardinality reasoning as the follower path.
    */
   void addVtDivToProducerCallbackIfNeeded(
       DefaultPubSubMessage consumerRecord,
@@ -3182,10 +3192,11 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
             beforeProcessingBatchRecordsTimestampMs);
         updateLatestConsumedRtPositions(partitionConsumptionState, kafkaUrl, consumerRecord.getPosition());
       } else if (isGlobalRtDivEnabled()) {
-        // Remote VT consumption (NR leader): the LCVP-update site for local VT is gated on
-        // !produceToLocalKafka above and skipped here, so without this every VT DIV snapshot would
-        // start from EARLIEST until the produce-completion callback overwrites it with a local-VT
-        // position.
+        // Remote VT consumption (NR leader): mirror the !produceToLocalKafka branch's LCVP update.
+        // Without this, consumerDiv's latestConsumedVtPosition stays at EARLIEST for the entire push
+        // (the LCVP update site for local VT consumption above is gated on !produceToLocalKafka and
+        // therefore skipped here), so every VT DIV snapshot starts from EARLIEST and only gets a
+        // non-EARLIEST value via the produce-completion callback's local-VT override.
         getConsumerDiv().updateLatestConsumedVtPosition(partition, consumerRecord.getPosition());
       }
 

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTask.java
@@ -3191,6 +3191,13 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
             consumerRecord.getPayloadSize(),
             beforeProcessingBatchRecordsTimestampMs);
         updateLatestConsumedRtPositions(partitionConsumptionState, kafkaUrl, consumerRecord.getPosition());
+      } else if (isGlobalRtDivEnabled()) {
+        // Remote VT consumption (NR leader): mirror the !produceToLocalKafka branch's LCVP update.
+        // Without this, consumerDiv's latestConsumedVtPosition stays at EARLIEST for the entire push
+        // (the LCVP update site for local VT consumption above is gated on !produceToLocalKafka and
+        // therefore skipped here), so every VT DIV snapshot starts from EARLIEST and only gets a
+        // non-EARLIEST value via the produce-completion callback's local-VT override.
+        getConsumerDiv().updateLatestConsumedVtPosition(partition, consumerRecord.getPosition());
       }
 
       // heavy leader processing starts here

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTask.java
@@ -3191,13 +3191,6 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
             consumerRecord.getPayloadSize(),
             beforeProcessingBatchRecordsTimestampMs);
         updateLatestConsumedRtPositions(partitionConsumptionState, kafkaUrl, consumerRecord.getPosition());
-      } else if (isGlobalRtDivEnabled()) {
-        // Remote VT consumption (NR leader): mirror the !produceToLocalKafka branch's LCVP update.
-        // Without this, consumerDiv's latestConsumedVtPosition stays at EARLIEST for the entire push
-        // (the LCVP update site for local VT consumption above is gated on !produceToLocalKafka and
-        // therefore skipped here), so every VT DIV snapshot starts from EARLIEST and only gets a
-        // non-EARLIEST value via the produce-completion callback's local-VT override.
-        getConsumerDiv().updateLatestConsumedVtPosition(partition, consumerRecord.getPosition());
       }
 
       // heavy leader processing starts here

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/validation/DataIntegrityValidator.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/validation/DataIntegrityValidator.java
@@ -251,4 +251,10 @@ public class DataIntegrityValidator {
     LOGGER.info("No VT DIV state found for partition: {}", partition);
     return false;
   }
+
+  @VisibleForTesting
+  public PubSubPosition getLatestConsumedVtPosition(int partition) {
+    PartitionTracker partitionTracker = this.partitionTrackers.get(partition);
+    return partitionTracker == null ? null : partitionTracker.getLatestConsumedVtPosition();
+  }
 }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/validation/DataIntegrityValidator.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/validation/DataIntegrityValidator.java
@@ -251,10 +251,4 @@ public class DataIntegrityValidator {
     LOGGER.info("No VT DIV state found for partition: {}", partition);
     return false;
   }
-
-  @VisibleForTesting
-  public PubSubPosition getLatestConsumedVtPosition(int partition) {
-    PartitionTracker partitionTracker = this.partitionTrackers.get(partition);
-    return partitionTracker == null ? null : partitionTracker.getLatestConsumedVtPosition();
-  }
 }

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTaskTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTaskTest.java
@@ -775,9 +775,10 @@ public class LeaderFollowerStoreIngestionTaskTest {
 
   /**
    * Data provider covering every branch of {@link LeaderFollowerStoreIngestionTask#addVtDivToProducerCallbackIfNeeded}'s
-   * install gate: the callback is installed only when Global RT DIV is enabled, the consumed source is
-   * non-RT, AND the byte threshold for a Global RT DIV sync has been reached. Each tuple shifts exactly
-   * one input from the "install" baseline.
+   * install gate for non-control-message records: the callback is installed only when Global RT DIV is
+   * enabled, the consumed source is non-RT, AND the byte threshold for a Global RT DIV sync has been
+   * reached. Each tuple shifts exactly one input from the "install" baseline. Control-message branches
+   * are covered separately by {@link #addVtDivToProducerCallbackIfNeededControlMessageParams}.
    */
   @DataProvider
   public Object[][] addVtDivToProducerCallbackIfNeededGatingParams() {
@@ -803,6 +804,11 @@ public class LeaderFollowerStoreIngestionTaskTest {
     doReturn(mockSourceTp).when(mockSourceRecord).getTopicPartition();
     doReturn(mockSourceTopic).when(mockSourceTp).getPubSubTopic();
     doReturn(sourceIsRealTime).when(mockSourceTopic).isRealTime();
+    // Non-control-message baseline: short-circuits isNonSegmentControlMessage so the install decision
+    // flows through shouldSendGlobalRtDiv as before.
+    KafkaKey mockKey = mock(KafkaKey.class);
+    doReturn(false).when(mockKey).isControlMessage();
+    doReturn(mockKey).when(mockSourceRecord).getKey();
 
     doReturn(globalRtDivEnabled).when(leaderFollowerStoreIngestionTask).isGlobalRtDivEnabled();
     String versionTopicName = leaderFollowerStoreIngestionTask.getVersionTopic().getName();
@@ -822,6 +828,81 @@ public class LeaderFollowerStoreIngestionTaskTest {
         new CompletableFuture<>());
 
     // Both side effects fire iff the install gate accepts.
+    int expectedTimes = expectedInstall ? 1 : 0;
+    verify(mockCallback, times(expectedTimes)).setOnCompletionCallback(any());
+    verify(mockPartitionConsumptionState, times(expectedTimes))
+        .resetConsumedBytesSinceLastGlobalRtDivSync(versionTopicName);
+  }
+
+  /**
+   * Data provider for {@link LeaderFollowerStoreIngestionTask#addVtDivToProducerCallbackIfNeeded}'s
+   * control-message branch: a non-segment control message must install the snapshot callback even when
+   * {@code shouldSendGlobalRtDiv} returns false (production always returns false for control messages),
+   * because EOP on the leader's remote-VT path is the only sync trigger for batch-only stores. Segment
+   * control messages remain excluded — same high-cardinality reasoning as the follower path.
+   */
+  @DataProvider
+  public Object[][] addVtDivToProducerCallbackIfNeededControlMessageParams() {
+    return new Object[][] {
+        // {controlMessageType, sourceIsRealTime, globalRtDivEnabled, expectedInstall}
+        // Non-segment control messages: install on leader's remote-VT path.
+        { ControlMessageType.END_OF_PUSH, false, true, true }, { ControlMessageType.START_OF_PUSH, false, true, true },
+        { ControlMessageType.START_OF_INCREMENTAL_PUSH, false, true, true },
+        { ControlMessageType.END_OF_INCREMENTAL_PUSH, false, true, true },
+        { ControlMessageType.TOPIC_SWITCH, false, true, true }, { ControlMessageType.VERSION_SWAP, false, true, true },
+        // Segment control messages: do not install (high cardinality).
+        { ControlMessageType.START_OF_SEGMENT, false, true, false },
+        { ControlMessageType.END_OF_SEGMENT, false, true, false },
+        // RT source short-circuits regardless of message type.
+        { ControlMessageType.END_OF_PUSH, true, true, false },
+        // Feature disabled short-circuits regardless of message type.
+        { ControlMessageType.END_OF_PUSH, false, false, false } };
+  }
+
+  @Test(dataProvider = "addVtDivToProducerCallbackIfNeededControlMessageParams")
+  public void testAddVtDivToProducerCallbackIfNeededControlMessageGating(
+      ControlMessageType controlMessageType,
+      boolean sourceIsRealTime,
+      boolean globalRtDivEnabled,
+      boolean expectedInstall) throws InterruptedException {
+    setUp();
+    DefaultPubSubMessage mockSourceRecord = mock(DefaultPubSubMessage.class);
+    PubSubTopicPartition mockSourceTp = mock(PubSubTopicPartition.class);
+    PubSubTopic mockSourceTopic = mock(PubSubTopic.class);
+    doReturn(mockSourceTp).when(mockSourceRecord).getTopicPartition();
+    doReturn(mockSourceTopic).when(mockSourceTp).getPubSubTopic();
+    doReturn(sourceIsRealTime).when(mockSourceTopic).isRealTime();
+
+    // Build a control-message record matching isNonSegmentControlMessage's contract:
+    // record.getKey().isControlMessage() == true
+    // ((ControlMessage) record.getValue().getPayloadUnion()).getControlMessageType() == <type>
+    KafkaKey mockKey = mock(KafkaKey.class);
+    doReturn(true).when(mockKey).isControlMessage();
+    doReturn(mockKey).when(mockSourceRecord).getKey();
+    KafkaMessageEnvelope mockKme = mock(KafkaMessageEnvelope.class);
+    ControlMessage mockControlMessage = mock(ControlMessage.class);
+    doReturn(controlMessageType.getValue()).when(mockControlMessage).getControlMessageType();
+    doReturn(mockControlMessage).when(mockKme).getPayloadUnion();
+    doReturn(mockKme).when(mockSourceRecord).getValue();
+
+    doReturn(globalRtDivEnabled).when(leaderFollowerStoreIngestionTask).isGlobalRtDivEnabled();
+    String versionTopicName = leaderFollowerStoreIngestionTask.getVersionTopic().getName();
+    // Mirror production: shouldSendGlobalRtDiv always returns false for control messages. The new
+    // non-segment-CM branch is what must drive the install.
+    doReturn(false).when(leaderFollowerStoreIngestionTask)
+        .shouldSendGlobalRtDiv(eq(mockSourceRecord), eq(mockPartitionConsumptionState), eq(versionTopicName));
+
+    doReturn(mock(PubSubTopicPartition.class)).when(mockPartitionConsumptionState).getReplicaTopicPartition();
+    doReturn(0L).when(mockPartitionConsumptionState).getLatestMessageTimeInMs();
+    doReturn(1).when(mockPartitionConsumptionState).getPartition();
+
+    LeaderProducerCallback mockCallback = mock(LeaderProducerCallback.class);
+    leaderFollowerStoreIngestionTask.addVtDivToProducerCallbackIfNeeded(
+        mockSourceRecord,
+        mockCallback,
+        mockPartitionConsumptionState,
+        new CompletableFuture<>());
+
     int expectedTimes = expectedInstall ? 1 : 0;
     verify(mockCallback, times(expectedTimes)).setOnCompletionCallback(any());
     verify(mockPartitionConsumptionState, times(expectedTimes))
@@ -928,13 +1009,18 @@ public class LeaderFollowerStoreIngestionTaskTest {
     LeaderProducedRecordContext mockContext = mock(LeaderProducedRecordContext.class);
     doReturn(persistedFuture).when(mockContext).getPersistedToDBFuture();
 
-    // Build a consumer record on a non-RT topic so the install gate accepts it.
+    // Build a consumer record on a non-RT topic so the install gate accepts it. Non-control-message
+    // record so isNonSegmentControlMessage short-circuits and the install decision flows through
+    // shouldSendGlobalRtDiv (which we stub to true below).
     DefaultPubSubMessage mockConsumerRecord = mock(DefaultPubSubMessage.class);
     PubSubTopicPartition mockSourceTp = mock(PubSubTopicPartition.class);
     PubSubTopic mockSourceTopic = mock(PubSubTopic.class);
     doReturn(mockSourceTp).when(mockConsumerRecord).getTopicPartition();
     doReturn(mockSourceTopic).when(mockSourceTp).getPubSubTopic();
     doReturn(false).when(mockSourceTopic).isRealTime();
+    KafkaKey mockKey = mock(KafkaKey.class);
+    doReturn(false).when(mockKey).isControlMessage();
+    doReturn(mockKey).when(mockConsumerRecord).getKey();
 
     // Open the install gate.
     doReturn(true).when(leaderFollowerStoreIngestionTask).isGlobalRtDivEnabled();

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTaskTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTaskTest.java
@@ -1115,40 +1115,6 @@ public class LeaderFollowerStoreIngestionTaskTest {
     verify(consumerDiv, times(1)).updateLatestConsumedVtPosition(0, cm.getMessage().getPosition());
   }
 
-  /**
-   * Verifies that the leader's remote-VT consumption path also updates consumerDiv's
-   * latestConsumedVtPosition. Without this, every VT DIV snapshot starts from EARLIEST during a NR
-   * leader's batch push (the LCVP-update site for local VT consumption is gated on
-   * {@code !produceToLocalKafka} and therefore skipped here), so the in-memory consumerDiv tracker
-   * has no record of remote VT progress until the produce-completion callback fires.
-   */
-  @Test
-  public void testUpdateLatestConsumedVtOffsetOnRemoteVtLeader() throws InterruptedException {
-    setUp();
-    LeaderFollowerStoreIngestionTask mockIngestionTask = mock(LeaderFollowerStoreIngestionTask.class);
-    PubSubMessageProcessedResultWrapper cm = getMockMessage(1);
-    PubSubTopic mockTopic = cm.getMessage().getTopicPartition().getPubSubTopic();
-    doReturn(false).when(mockTopic).isRealTime();
-    doReturn(mockPartitionConsumptionState).when(mockIngestionTask).getPartitionConsumptionState(anyInt());
-    // Leader consuming remote VT: shouldProduceToVersionTopic() returns true, so the
-    // !produceToLocalKafka branch (which holds the existing LCVP update at line 3166) is skipped.
-    doReturn(true).when(mockIngestionTask).shouldProduceToVersionTopic(any());
-    doCallRealMethod().when(mockIngestionTask)
-        .delegateConsumerRecord(any(), anyInt(), any(), anyInt(), anyLong(), anyLong());
-    DataIntegrityValidator consumerDiv = mock(DataIntegrityValidator.class);
-    doReturn(consumerDiv).when(mockIngestionTask).getConsumerDiv();
-    doReturn(true).when(mockIngestionTask).isGlobalRtDivEnabled();
-
-    // The downstream produce machinery is not wired on this pure mock, so the call will throw once
-    // it reaches it. We only assert the LCVP update fires before that.
-    try {
-      mockIngestionTask.delegateConsumerRecord(cm, 0, "testURL", 0, 0, 0);
-    } catch (Exception expected) {
-      // Expected: leader-produce machinery not wired on this pure mock.
-    }
-    verify(consumerDiv, times(1)).updateLatestConsumedVtPosition(0, cm.getMessage().getPosition());
-  }
-
   @Test
   public void testShouldSendVtDivSnapshot() throws InterruptedException {
     setUp();

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTaskTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTaskTest.java
@@ -1115,6 +1115,40 @@ public class LeaderFollowerStoreIngestionTaskTest {
     verify(consumerDiv, times(1)).updateLatestConsumedVtPosition(0, cm.getMessage().getPosition());
   }
 
+  /**
+   * Verifies that the leader's remote-VT consumption path also updates consumerDiv's
+   * latestConsumedVtPosition. Without this, every VT DIV snapshot starts from EARLIEST during a NR
+   * leader's batch push (the LCVP-update site for local VT consumption is gated on
+   * {@code !produceToLocalKafka} and therefore skipped here), so the in-memory consumerDiv tracker
+   * has no record of remote VT progress until the produce-completion callback fires.
+   */
+  @Test
+  public void testUpdateLatestConsumedVtOffsetOnRemoteVtLeader() throws InterruptedException {
+    setUp();
+    LeaderFollowerStoreIngestionTask mockIngestionTask = mock(LeaderFollowerStoreIngestionTask.class);
+    PubSubMessageProcessedResultWrapper cm = getMockMessage(1);
+    PubSubTopic mockTopic = cm.getMessage().getTopicPartition().getPubSubTopic();
+    doReturn(false).when(mockTopic).isRealTime();
+    doReturn(mockPartitionConsumptionState).when(mockIngestionTask).getPartitionConsumptionState(anyInt());
+    // Leader consuming remote VT: shouldProduceToVersionTopic() returns true, so the
+    // !produceToLocalKafka branch (which holds the existing LCVP update at line 3166) is skipped.
+    doReturn(true).when(mockIngestionTask).shouldProduceToVersionTopic(any());
+    doCallRealMethod().when(mockIngestionTask)
+        .delegateConsumerRecord(any(), anyInt(), any(), anyInt(), anyLong(), anyLong());
+    DataIntegrityValidator consumerDiv = mock(DataIntegrityValidator.class);
+    doReturn(consumerDiv).when(mockIngestionTask).getConsumerDiv();
+    doReturn(true).when(mockIngestionTask).isGlobalRtDivEnabled();
+
+    // The downstream produce machinery is not wired on this pure mock, so the call will throw once
+    // it reaches it. We only assert the LCVP update fires before that.
+    try {
+      mockIngestionTask.delegateConsumerRecord(cm, 0, "testURL", 0, 0, 0);
+    } catch (Exception expected) {
+      // Expected: leader-produce machinery not wired on this pure mock.
+    }
+    verify(consumerDiv, times(1)).updateLatestConsumedVtPosition(0, cm.getMessage().getPosition());
+  }
+
   @Test
   public void testShouldSendVtDivSnapshot() throws InterruptedException {
     setUp();

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTaskTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTaskTest.java
@@ -873,9 +873,7 @@ public class LeaderFollowerStoreIngestionTaskTest {
     doReturn(mockSourceTopic).when(mockSourceTp).getPubSubTopic();
     doReturn(sourceIsRealTime).when(mockSourceTopic).isRealTime();
 
-    // Build a control-message record matching isNonSegmentControlMessage's contract:
-    // record.getKey().isControlMessage() == true
-    // ((ControlMessage) record.getValue().getPayloadUnion()).getControlMessageType() == <type>
+    // Build a control-message record matching isNonSegmentControlMessage's contract.
     KafkaKey mockKey = mock(KafkaKey.class);
     doReturn(true).when(mockKey).isControlMessage();
     doReturn(mockKey).when(mockSourceRecord).getKey();
@@ -1104,6 +1102,9 @@ public class LeaderFollowerStoreIngestionTaskTest {
     doReturn(false).when(mockTopic).isRealTime();
     doReturn(mockPartitionConsumptionState).when(mockIngestionTask).getPartitionConsumptionState(anyInt());
     doReturn(LeaderFollowerStateType.STANDBY).when(mockPartitionConsumptionState).getLeaderFollowerState();
+    // Stub shouldProduceToVersionTopic to return false so we enter the !produceToLocalKafka branch
+    // where updateLatestConsumedVtPosition is called.
+    doReturn(false).when(mockIngestionTask).shouldProduceToVersionTopic(mockPartitionConsumptionState);
     doCallRealMethod().when(mockIngestionTask)
         .delegateConsumerRecord(any(), anyInt(), any(), anyInt(), anyLong(), anyLong());
     DataIntegrityValidator consumerDiv = mock(DataIntegrityValidator.class);
@@ -1111,6 +1112,7 @@ public class LeaderFollowerStoreIngestionTaskTest {
     doReturn(true).when(mockIngestionTask).isGlobalRtDivEnabled();
 
     // delegateConsumerRecord() should cause updateLatestConsumedVtPosition() to be called
+    // when consuming from version topic (!produceToLocalKafka).
     mockIngestionTask.delegateConsumerRecord(cm, 0, "testURL", 0, 0, 0);
     verify(consumerDiv, times(1)).updateLatestConsumedVtPosition(0, cm.getMessage().getPosition());
   }

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTaskTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTaskTest.java
@@ -804,8 +804,7 @@ public class LeaderFollowerStoreIngestionTaskTest {
     doReturn(mockSourceTp).when(mockSourceRecord).getTopicPartition();
     doReturn(mockSourceTopic).when(mockSourceTp).getPubSubTopic();
     doReturn(sourceIsRealTime).when(mockSourceTopic).isRealTime();
-    // Non-control-message baseline: short-circuits isNonSegmentControlMessage so the install decision
-    // flows through shouldSendGlobalRtDiv as before.
+    // Non-control-message baseline; control-message branches are covered by the sibling test.
     KafkaKey mockKey = mock(KafkaKey.class);
     doReturn(false).when(mockKey).isControlMessage();
     doReturn(mockKey).when(mockSourceRecord).getKey();
@@ -835,11 +834,9 @@ public class LeaderFollowerStoreIngestionTaskTest {
   }
 
   /**
-   * Data provider for {@link LeaderFollowerStoreIngestionTask#addVtDivToProducerCallbackIfNeeded}'s
-   * control-message branch: a non-segment control message must install the snapshot callback even when
-   * {@code shouldSendGlobalRtDiv} returns false (production always returns false for control messages),
-   * because EOP on the leader's remote-VT path is the only sync trigger for batch-only stores. Segment
-   * control messages remain excluded — same high-cardinality reasoning as the follower path.
+   * Control-message branch of the install gate: non-segment CMs must install even though
+   * {@code shouldSendGlobalRtDiv} always returns false for control messages — EOP on the
+   * remote-VT leader is the only sync trigger for batch-only stores. Segment CMs stay excluded.
    */
   @DataProvider
   public Object[][] addVtDivToProducerCallbackIfNeededControlMessageParams() {
@@ -873,9 +870,7 @@ public class LeaderFollowerStoreIngestionTaskTest {
     doReturn(mockSourceTopic).when(mockSourceTp).getPubSubTopic();
     doReturn(sourceIsRealTime).when(mockSourceTopic).isRealTime();
 
-    // Build a control-message record matching isNonSegmentControlMessage's contract:
-    // record.getKey().isControlMessage() == true
-    // ((ControlMessage) record.getValue().getPayloadUnion()).getControlMessageType() == <type>
+    // Wire isNonSegmentControlMessage's contract: isControlMessage() + payload union with type.
     KafkaKey mockKey = mock(KafkaKey.class);
     doReturn(true).when(mockKey).isControlMessage();
     doReturn(mockKey).when(mockSourceRecord).getKey();
@@ -887,8 +882,7 @@ public class LeaderFollowerStoreIngestionTaskTest {
 
     doReturn(globalRtDivEnabled).when(leaderFollowerStoreIngestionTask).isGlobalRtDivEnabled();
     String versionTopicName = leaderFollowerStoreIngestionTask.getVersionTopic().getName();
-    // Mirror production: shouldSendGlobalRtDiv always returns false for control messages. The new
-    // non-segment-CM branch is what must drive the install.
+    // Mirror production: shouldSendGlobalRtDiv always returns false for control messages.
     doReturn(false).when(leaderFollowerStoreIngestionTask)
         .shouldSendGlobalRtDiv(eq(mockSourceRecord), eq(mockPartitionConsumptionState), eq(versionTopicName));
 
@@ -1009,9 +1003,8 @@ public class LeaderFollowerStoreIngestionTaskTest {
     LeaderProducedRecordContext mockContext = mock(LeaderProducedRecordContext.class);
     doReturn(persistedFuture).when(mockContext).getPersistedToDBFuture();
 
-    // Build a consumer record on a non-RT topic so the install gate accepts it. Non-control-message
-    // record so isNonSegmentControlMessage short-circuits and the install decision flows through
-    // shouldSendGlobalRtDiv (which we stub to true below).
+    // Non-control-message record on a non-RT topic; the install decision flows through
+    // shouldSendGlobalRtDiv (stubbed to true below).
     DefaultPubSubMessage mockConsumerRecord = mock(DefaultPubSubMessage.class);
     PubSubTopicPartition mockSourceTp = mock(PubSubTopicPartition.class);
     PubSubTopic mockSourceTopic = mock(PubSubTopic.class);
@@ -1116,11 +1109,9 @@ public class LeaderFollowerStoreIngestionTaskTest {
   }
 
   /**
-   * Verifies that the leader's remote-VT consumption path also updates consumerDiv's
-   * latestConsumedVtPosition. Without this, every VT DIV snapshot starts from EARLIEST during a NR
-   * leader's batch push (the LCVP-update site for local VT consumption is gated on
-   * {@code !produceToLocalKafka} and therefore skipped here), so the in-memory consumerDiv tracker
-   * has no record of remote VT progress until the produce-completion callback fires.
+   * Counterpart to {@link #testUpdateLatestConsumedVtOffset}: the NR-leader path
+   * (shouldProduceToVersionTopic=true) must also update consumerDiv's LCVP, otherwise VT DIV
+   * snapshots start from EARLIEST until the produce-completion callback fires.
    */
   @Test
   public void testUpdateLatestConsumedVtOffsetOnRemoteVtLeader() throws InterruptedException {
@@ -1130,8 +1121,6 @@ public class LeaderFollowerStoreIngestionTaskTest {
     PubSubTopic mockTopic = cm.getMessage().getTopicPartition().getPubSubTopic();
     doReturn(false).when(mockTopic).isRealTime();
     doReturn(mockPartitionConsumptionState).when(mockIngestionTask).getPartitionConsumptionState(anyInt());
-    // Leader consuming remote VT: shouldProduceToVersionTopic() returns true, so the
-    // !produceToLocalKafka branch (which holds the existing LCVP update at line 3166) is skipped.
     doReturn(true).when(mockIngestionTask).shouldProduceToVersionTopic(any());
     doCallRealMethod().when(mockIngestionTask)
         .delegateConsumerRecord(any(), anyInt(), any(), anyInt(), anyLong(), anyLong());
@@ -1139,12 +1128,12 @@ public class LeaderFollowerStoreIngestionTaskTest {
     doReturn(consumerDiv).when(mockIngestionTask).getConsumerDiv();
     doReturn(true).when(mockIngestionTask).isGlobalRtDivEnabled();
 
-    // The downstream produce machinery is not wired on this pure mock, so the call will throw once
-    // it reaches it. We only assert the LCVP update fires before that.
+    // Downstream leader-produce machinery isn't wired on this pure mock; we only assert the LCVP
+    // update fires before that.
     try {
       mockIngestionTask.delegateConsumerRecord(cm, 0, "testURL", 0, 0, 0);
     } catch (Exception expected) {
-      // Expected: leader-produce machinery not wired on this pure mock.
+      // expected
     }
     verify(consumerDiv, times(1)).updateLatestConsumedVtPosition(0, cm.getMessage().getPosition());
   }

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTaskTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTaskTest.java
@@ -804,7 +804,8 @@ public class LeaderFollowerStoreIngestionTaskTest {
     doReturn(mockSourceTp).when(mockSourceRecord).getTopicPartition();
     doReturn(mockSourceTopic).when(mockSourceTp).getPubSubTopic();
     doReturn(sourceIsRealTime).when(mockSourceTopic).isRealTime();
-    // Non-control-message baseline; control-message branches are covered by the sibling test.
+    // Non-control-message baseline: short-circuits isNonSegmentControlMessage so the install decision
+    // flows through shouldSendGlobalRtDiv as before.
     KafkaKey mockKey = mock(KafkaKey.class);
     doReturn(false).when(mockKey).isControlMessage();
     doReturn(mockKey).when(mockSourceRecord).getKey();
@@ -834,9 +835,11 @@ public class LeaderFollowerStoreIngestionTaskTest {
   }
 
   /**
-   * Control-message branch of the install gate: non-segment CMs must install even though
-   * {@code shouldSendGlobalRtDiv} always returns false for control messages — EOP on the
-   * remote-VT leader is the only sync trigger for batch-only stores. Segment CMs stay excluded.
+   * Data provider for {@link LeaderFollowerStoreIngestionTask#addVtDivToProducerCallbackIfNeeded}'s
+   * control-message branch: a non-segment control message must install the snapshot callback even when
+   * {@code shouldSendGlobalRtDiv} returns false (production always returns false for control messages),
+   * because EOP on the leader's remote-VT path is the only sync trigger for batch-only stores. Segment
+   * control messages remain excluded — same high-cardinality reasoning as the follower path.
    */
   @DataProvider
   public Object[][] addVtDivToProducerCallbackIfNeededControlMessageParams() {
@@ -870,7 +873,9 @@ public class LeaderFollowerStoreIngestionTaskTest {
     doReturn(mockSourceTopic).when(mockSourceTp).getPubSubTopic();
     doReturn(sourceIsRealTime).when(mockSourceTopic).isRealTime();
 
-    // Wire isNonSegmentControlMessage's contract: isControlMessage() + payload union with type.
+    // Build a control-message record matching isNonSegmentControlMessage's contract:
+    // record.getKey().isControlMessage() == true
+    // ((ControlMessage) record.getValue().getPayloadUnion()).getControlMessageType() == <type>
     KafkaKey mockKey = mock(KafkaKey.class);
     doReturn(true).when(mockKey).isControlMessage();
     doReturn(mockKey).when(mockSourceRecord).getKey();
@@ -882,7 +887,8 @@ public class LeaderFollowerStoreIngestionTaskTest {
 
     doReturn(globalRtDivEnabled).when(leaderFollowerStoreIngestionTask).isGlobalRtDivEnabled();
     String versionTopicName = leaderFollowerStoreIngestionTask.getVersionTopic().getName();
-    // Mirror production: shouldSendGlobalRtDiv always returns false for control messages.
+    // Mirror production: shouldSendGlobalRtDiv always returns false for control messages. The new
+    // non-segment-CM branch is what must drive the install.
     doReturn(false).when(leaderFollowerStoreIngestionTask)
         .shouldSendGlobalRtDiv(eq(mockSourceRecord), eq(mockPartitionConsumptionState), eq(versionTopicName));
 
@@ -1003,8 +1009,9 @@ public class LeaderFollowerStoreIngestionTaskTest {
     LeaderProducedRecordContext mockContext = mock(LeaderProducedRecordContext.class);
     doReturn(persistedFuture).when(mockContext).getPersistedToDBFuture();
 
-    // Non-control-message record on a non-RT topic; the install decision flows through
-    // shouldSendGlobalRtDiv (stubbed to true below).
+    // Build a consumer record on a non-RT topic so the install gate accepts it. Non-control-message
+    // record so isNonSegmentControlMessage short-circuits and the install decision flows through
+    // shouldSendGlobalRtDiv (which we stub to true below).
     DefaultPubSubMessage mockConsumerRecord = mock(DefaultPubSubMessage.class);
     PubSubTopicPartition mockSourceTp = mock(PubSubTopicPartition.class);
     PubSubTopic mockSourceTopic = mock(PubSubTopic.class);
@@ -1109,9 +1116,11 @@ public class LeaderFollowerStoreIngestionTaskTest {
   }
 
   /**
-   * Counterpart to {@link #testUpdateLatestConsumedVtOffset}: the NR-leader path
-   * (shouldProduceToVersionTopic=true) must also update consumerDiv's LCVP, otherwise VT DIV
-   * snapshots start from EARLIEST until the produce-completion callback fires.
+   * Verifies that the leader's remote-VT consumption path also updates consumerDiv's
+   * latestConsumedVtPosition. Without this, every VT DIV snapshot starts from EARLIEST during a NR
+   * leader's batch push (the LCVP-update site for local VT consumption is gated on
+   * {@code !produceToLocalKafka} and therefore skipped here), so the in-memory consumerDiv tracker
+   * has no record of remote VT progress until the produce-completion callback fires.
    */
   @Test
   public void testUpdateLatestConsumedVtOffsetOnRemoteVtLeader() throws InterruptedException {
@@ -1121,6 +1130,8 @@ public class LeaderFollowerStoreIngestionTaskTest {
     PubSubTopic mockTopic = cm.getMessage().getTopicPartition().getPubSubTopic();
     doReturn(false).when(mockTopic).isRealTime();
     doReturn(mockPartitionConsumptionState).when(mockIngestionTask).getPartitionConsumptionState(anyInt());
+    // Leader consuming remote VT: shouldProduceToVersionTopic() returns true, so the
+    // !produceToLocalKafka branch (which holds the existing LCVP update at line 3166) is skipped.
     doReturn(true).when(mockIngestionTask).shouldProduceToVersionTopic(any());
     doCallRealMethod().when(mockIngestionTask)
         .delegateConsumerRecord(any(), anyInt(), any(), anyInt(), anyLong(), anyLong());
@@ -1128,12 +1139,12 @@ public class LeaderFollowerStoreIngestionTaskTest {
     doReturn(consumerDiv).when(mockIngestionTask).getConsumerDiv();
     doReturn(true).when(mockIngestionTask).isGlobalRtDivEnabled();
 
-    // Downstream leader-produce machinery isn't wired on this pure mock; we only assert the LCVP
-    // update fires before that.
+    // The downstream produce machinery is not wired on this pure mock, so the call will throw once
+    // it reaches it. We only assert the LCVP update fires before that.
     try {
       mockIngestionTask.delegateConsumerRecord(cm, 0, "testURL", 0, 0, 0);
     } catch (Exception expected) {
-      // expected
+      // Expected: leader-produce machinery not wired on this pure mock.
     }
     verify(consumerDiv, times(1)).updateLatestConsumedVtPosition(0, cm.getMessage().getPosition());
   }

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestGlobalRtDiv.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestGlobalRtDiv.java
@@ -1324,16 +1324,16 @@ public class TestGlobalRtDiv {
             offsetRecord.isEndOfPushReceived(),
             "EOP must be processed on dc-1 leader before checking LCVP — otherwise we're racing the push.");
         PubSubPosition lcvp = offsetRecord.getLatestConsumedVtPosition();
-        LOGGER.info(
-            "event=globalRtDiv LCVP on dc-1 leader {} (high-threshold): {}",
-            currentLeaderWrapper.getAddress(),
-            lcvp);
         assertNotEquals(
             lcvp,
             PubSubSymbolicPosition.EARLIEST,
             "LCVP should be persisted (non-EARLIEST) on dc-1 leader after batch push with high byte "
                 + "thresholds. Without the EOP-sync trigger on addVtDivToProducerCallbackIfNeeded, "
                 + "the only possible sync path (byte threshold) is disabled and LCVP stays at EARLIEST.");
+        LOGGER.info(
+            "event=globalRtDiv LCVP on dc-1 leader {} (high-threshold): {}",
+            currentLeaderWrapper.getAddress(),
+            lcvp);
       });
     }
   }

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestGlobalRtDiv.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestGlobalRtDiv.java
@@ -1149,16 +1149,29 @@ public class TestGlobalRtDiv {
 
           boolean isLeader = server.getPort() == env.leaderServer.getPort();
           LOGGER.info(
-              "remote-dc {} ({}): hasVtDivState={}, hasGlobalRtDivState={}",
+              "remote-dc {} ({}): hasVtDivState={}, hasGlobalRtDivState={}, lcvp={}",
               server.getAddress(),
               isLeader ? "leader" : "follower",
               div.hasVtDivState(PARTITION),
-              div.hasGlobalRtDivState(PARTITION));
+              div.hasGlobalRtDivState(PARTITION),
+              div.getLatestConsumedVtPosition(PARTITION));
 
           if (isLeader) {
             assertTrue(
                 div.hasVtDivState(PARTITION),
                 "VT DIV state should exist on dc-1 leader after topicType fix. Server: " + server.getAddress());
+            // The NR leader consumes remote VT but produces to local VT, so the LCVP-update site
+            // for local VT consumption in delegateConsumerRecord is skipped. Without a matching
+            // update on the produceToLocalKafka path, consumerDiv's LCVP never advances past the
+            // initial Helix STANDBY-phase value (offset 0) — *not* EARLIEST, so a simple
+            // non-EARLIEST assertion would miss the bug. Compare against a meaningful threshold:
+            // a 100-record batch push must leave LCVP well past offset 0.
+            PubSubPosition leaderLcvp = div.getLatestConsumedVtPosition(PARTITION);
+            assertNotNull(leaderLcvp, "consumerDiv LCVP should not be null on dc-1 leader");
+            assertTrue(
+                leaderLcvp.getNumericOffset() >= 50,
+                "consumerDiv LCVP on dc-1 leader must reflect actual remote VT progress, but was " + leaderLcvp
+                    + " after a 100-record batch push. Server: " + server.getAddress());
           }
           assertFalse(
               div.hasGlobalRtDivState(PARTITION),

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestGlobalRtDiv.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestGlobalRtDiv.java
@@ -1286,17 +1286,20 @@ public class TestGlobalRtDiv {
   }
 
   /**
-   * Verifies that EOP alone (not byte-threshold syncs) drives the Global RT DIV OffsetRecord sync
-   * on the remote-VT leader. With both sync-bytes thresholds pushed above the dataset size, the
-   * byte-threshold branch cannot fire — so a non-EARLIEST LCVP after the push proves the
-   * non-segment-control-message branch of {@code addVtDivToProducerCallbackIfNeeded} is the
-   * trigger.
+   * Verifies that EOP alone (not byte-threshold syncs) triggers a Global RT DIV OffsetRecord sync on
+   * the remote-VT leader. Both the transactional-mode and deferred-write-mode sync thresholds are
+   * pushed above the dataset size, so {@code shouldSendGlobalRtDiv}'s byte-threshold branch cannot
+   * fire during the small batch push. The only sync trigger remaining is the non-segment-control-
+   * message branch in {@code addVtDivToProducerCallbackIfNeeded} — specifically, the EOP produced to
+   * local VT after the leader consumes EOP from remote VT. If that branch is absent (the pre-fix
+   * behavior), LCVP stays at EARLIEST on the dc-1 leader's OffsetRecord after batch push completes.
    */
   @Test(timeOut = 180 * Time.MS_PER_SECOND)
   public void testBatchOnlyNRRemoteVTLeaderEopTriggersLcvpSyncWithHighByteThreshold() throws Exception {
     int PARTITION = 0;
-    // 100 MB thresholds — well above the 100-record payload — disable the byte-threshold path so
-    // EOP is the only possible sync trigger.
+    // 100 MB thresholds for both transactional and deferred-write modes — well above the 100-record
+    // batch push payload — so the byte-threshold branch of shouldSendGlobalRtDiv cannot fire and EOP
+    // becomes the only possible sync trigger for LCVP on the remote-VT leader.
     Properties extraServerProps = new Properties();
     extraServerProps.setProperty(SERVER_DATABASE_SYNC_BYTES_INTERNAL_FOR_TRANSACTIONAL_MODE, "104857600");
     extraServerProps.setProperty(SERVER_DATABASE_SYNC_BYTES_INTERNAL_FOR_DEFERRED_WRITE_MODE, "104857600");
@@ -1328,8 +1331,9 @@ public class TestGlobalRtDiv {
         assertNotEquals(
             lcvp,
             PubSubSymbolicPosition.EARLIEST,
-            "LCVP must be non-EARLIEST after batch push with byte thresholds disabled; EOP is the "
-                + "only remaining sync trigger.");
+            "LCVP should be persisted (non-EARLIEST) on dc-1 leader after batch push with high byte "
+                + "thresholds. Without the EOP-sync trigger on addVtDivToProducerCallbackIfNeeded, "
+                + "the only possible sync path (byte threshold) is disabled and LCVP stays at EARLIEST.");
       });
     }
   }

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestGlobalRtDiv.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestGlobalRtDiv.java
@@ -1286,20 +1286,17 @@ public class TestGlobalRtDiv {
   }
 
   /**
-   * Verifies that EOP alone (not byte-threshold syncs) triggers a Global RT DIV OffsetRecord sync on
-   * the remote-VT leader. Both the transactional-mode and deferred-write-mode sync thresholds are
-   * pushed above the dataset size, so {@code shouldSendGlobalRtDiv}'s byte-threshold branch cannot
-   * fire during the small batch push. The only sync trigger remaining is the non-segment-control-
-   * message branch in {@code addVtDivToProducerCallbackIfNeeded} — specifically, the EOP produced to
-   * local VT after the leader consumes EOP from remote VT. If that branch is absent (the pre-fix
-   * behavior), LCVP stays at EARLIEST on the dc-1 leader's OffsetRecord after batch push completes.
+   * Verifies that EOP alone (not byte-threshold syncs) drives the Global RT DIV OffsetRecord sync
+   * on the remote-VT leader. With both sync-bytes thresholds pushed above the dataset size, the
+   * byte-threshold branch cannot fire — so a non-EARLIEST LCVP after the push proves the
+   * non-segment-control-message branch of {@code addVtDivToProducerCallbackIfNeeded} is the
+   * trigger.
    */
   @Test(timeOut = 180 * Time.MS_PER_SECOND)
   public void testBatchOnlyNRRemoteVTLeaderEopTriggersLcvpSyncWithHighByteThreshold() throws Exception {
     int PARTITION = 0;
-    // 100 MB thresholds for both transactional and deferred-write modes — well above the 100-record
-    // batch push payload — so the byte-threshold branch of shouldSendGlobalRtDiv cannot fire and EOP
-    // becomes the only possible sync trigger for LCVP on the remote-VT leader.
+    // 100 MB thresholds — well above the 100-record payload — disable the byte-threshold path so
+    // EOP is the only possible sync trigger.
     Properties extraServerProps = new Properties();
     extraServerProps.setProperty(SERVER_DATABASE_SYNC_BYTES_INTERNAL_FOR_TRANSACTIONAL_MODE, "104857600");
     extraServerProps.setProperty(SERVER_DATABASE_SYNC_BYTES_INTERNAL_FOR_DEFERRED_WRITE_MODE, "104857600");
@@ -1331,9 +1328,8 @@ public class TestGlobalRtDiv {
         assertNotEquals(
             lcvp,
             PubSubSymbolicPosition.EARLIEST,
-            "LCVP should be persisted (non-EARLIEST) on dc-1 leader after batch push with high byte "
-                + "thresholds. Without the EOP-sync trigger on addVtDivToProducerCallbackIfNeeded, "
-                + "the only possible sync path (byte threshold) is disabled and LCVP stays at EARLIEST.");
+            "LCVP must be non-EARLIEST after batch push with byte thresholds disabled; EOP is the "
+                + "only remaining sync trigger.");
       });
     }
   }

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestGlobalRtDiv.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestGlobalRtDiv.java
@@ -1149,29 +1149,16 @@ public class TestGlobalRtDiv {
 
           boolean isLeader = server.getPort() == env.leaderServer.getPort();
           LOGGER.info(
-              "remote-dc {} ({}): hasVtDivState={}, hasGlobalRtDivState={}, lcvp={}",
+              "remote-dc {} ({}): hasVtDivState={}, hasGlobalRtDivState={}",
               server.getAddress(),
               isLeader ? "leader" : "follower",
               div.hasVtDivState(PARTITION),
-              div.hasGlobalRtDivState(PARTITION),
-              div.getLatestConsumedVtPosition(PARTITION));
+              div.hasGlobalRtDivState(PARTITION));
 
           if (isLeader) {
             assertTrue(
                 div.hasVtDivState(PARTITION),
                 "VT DIV state should exist on dc-1 leader after topicType fix. Server: " + server.getAddress());
-            // The NR leader consumes remote VT but produces to local VT, so the LCVP-update site
-            // for local VT consumption in delegateConsumerRecord is skipped. Without a matching
-            // update on the produceToLocalKafka path, consumerDiv's LCVP never advances past the
-            // initial Helix STANDBY-phase value (offset 0) — *not* EARLIEST, so a simple
-            // non-EARLIEST assertion would miss the bug. Compare against a meaningful threshold:
-            // a 100-record batch push must leave LCVP well past offset 0.
-            PubSubPosition leaderLcvp = div.getLatestConsumedVtPosition(PARTITION);
-            assertNotNull(leaderLcvp, "consumerDiv LCVP should not be null on dc-1 leader");
-            assertTrue(
-                leaderLcvp.getNumericOffset() >= 50,
-                "consumerDiv LCVP on dc-1 leader must reflect actual remote VT progress, but was " + leaderLcvp
-                    + " after a 100-record batch push. Server: " + server.getAddress());
           }
           assertFalse(
               div.hasGlobalRtDivState(PARTITION),

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestGlobalRtDiv.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestGlobalRtDiv.java
@@ -1286,6 +1286,59 @@ public class TestGlobalRtDiv {
   }
 
   /**
+   * Verifies that EOP alone (not byte-threshold syncs) triggers a Global RT DIV OffsetRecord sync on
+   * the remote-VT leader. Both the transactional-mode and deferred-write-mode sync thresholds are
+   * pushed above the dataset size, so {@code shouldSendGlobalRtDiv}'s byte-threshold branch cannot
+   * fire during the small batch push. The only sync trigger remaining is the non-segment-control-
+   * message branch in {@code addVtDivToProducerCallbackIfNeeded} — specifically, the EOP produced to
+   * local VT after the leader consumes EOP from remote VT. If that branch is absent (the pre-fix
+   * behavior), LCVP stays at EARLIEST on the dc-1 leader's OffsetRecord after batch push completes.
+   */
+  @Test(timeOut = 180 * Time.MS_PER_SECOND)
+  public void testBatchOnlyNRRemoteVTLeaderEopTriggersLcvpSyncWithHighByteThreshold() throws Exception {
+    int PARTITION = 0;
+    // 100 MB thresholds for both transactional and deferred-write modes — well above the 100-record
+    // batch push payload — so the byte-threshold branch of shouldSendGlobalRtDiv cannot fire and EOP
+    // becomes the only possible sync trigger for LCVP on the remote-VT leader.
+    Properties extraServerProps = new Properties();
+    extraServerProps.setProperty(SERVER_DATABASE_SYNC_BYTES_INTERNAL_FOR_TRANSACTIONAL_MODE, "104857600");
+    extraServerProps.setProperty(SERVER_DATABASE_SYNC_BYTES_INTERNAL_FOR_DEFERRED_WRITE_MODE, "104857600");
+
+    try (NRGlobalRtDivBatchEnv env = setUpNRGlobalRtDivBatchPushed(
+        "venice-cluster0",
+        "nrRemoteVtLeaderEopSync",
+        100,
+        1,
+        PARTITION,
+        extraServerProps)) {
+      VeniceClusterWrapper remoteDcCluster = env.remoteDcCluster;
+      String topicName = env.topicName;
+
+      TestUtils.waitForNonDeterministicAssertion(60, TimeUnit.SECONDS, true, true, () -> {
+        Instance currentLeader = env.routingDataRepo.getLeaderInstance(topicName, PARTITION);
+        assertNotNull(currentLeader, "Leader should be assigned in remote dc for partition " + PARTITION);
+        VeniceServerWrapper currentLeaderWrapper = remoteDcCluster.getVeniceServerByPort(currentLeader.getPort());
+        assertNotNull(currentLeaderWrapper, "Leader server wrapper not found");
+        OffsetRecord offsetRecord = getRemoteDcLeaderOffsetRecord(currentLeaderWrapper, topicName, PARTITION);
+        assertTrue(
+            offsetRecord.isEndOfPushReceived(),
+            "EOP must be processed on dc-1 leader before checking LCVP — otherwise we're racing the push.");
+        PubSubPosition lcvp = offsetRecord.getLatestConsumedVtPosition();
+        LOGGER.info(
+            "event=globalRtDiv LCVP on dc-1 leader {} (high-threshold): {}",
+            currentLeaderWrapper.getAddress(),
+            lcvp);
+        assertNotEquals(
+            lcvp,
+            PubSubSymbolicPosition.EARLIEST,
+            "LCVP should be persisted (non-EARLIEST) on dc-1 leader after batch push with high byte "
+                + "thresholds. Without the EOP-sync trigger on addVtDivToProducerCallbackIfNeeded, "
+                + "the only possible sync path (byte threshold) is disabled and LCVP stays at EARLIEST.");
+      });
+    }
+  }
+
+  /**
    * Reads OffsetRecord directly from the given server's storage metadata service. Throws an
    * AssertionError if the record is not yet available, so callers inside
    * {@link TestUtils#waitForNonDeterministicAssertion} retry on the AssertionError.


### PR DESCRIPTION
## Problem Statement

On the Global RT DIV feature's NR-leader remote-VT consumption path, `addVtDivToProducerCallbackIfNeeded` was gated solely on the byte threshold via `shouldSendGlobalRtDiv`, which filters out every control message. The follower path (`shouldSendVtDivSnapshot`) already syncs on non-segment control messages — leader and follower were asymmetric.

For a batch-only store with a high `SERVER_DATABASE_SYNC_BYTES_INTERNAL_FOR_DEFERRED_WRITE_MODE` threshold, the byte-threshold callback may never fire during the entire batch push. EOP is the natural sync boundary for batch-only stores, and the follower path already treats it as such — but the leader path didn't.

## Solution

`addVtDivToProducerCallbackIfNeeded` now installs the snapshot callback when **either**:
- (a) the record is a non-segment control message (SOP / EOP / IP_SOP / IP_EOP / TOPIC_SWITCH / VERSION_SWAP) — semantically meaningful checkpoints that should not wait for the byte threshold, OR
- (b) the existing byte threshold is reached.

Segment control messages (SOS / EOS) remain excluded — same high-cardinality reasoning as the follower path. `shouldSendGlobalRtDiv` and `sendGlobalRtDivMessage` are unchanged; we only want the LCVP sync on control messages, not an extra Global RT DIV chunk produced into VT.

This mirrors the follower path's `shouldSendVtDivSnapshot` predicate so leader and follower share the same "what counts as a sync boundary" rule.

### Code changes
- [ ] Added new code behind **a config**.
- [ ] Introduced new **log lines**.
  - [ ] Confirmed if logs need to be **rate limited** to avoid excessive logging.

### **Concurrency-Specific Checks**
- [x] Code has **no race conditions** or **thread safety issues**. The new branch only adds a condition to install an on-completion callback on the existing `LeaderProducerCallback`; no new mutable state.
- [x] Proper **synchronization mechanisms** are used where needed.
- [x] No **blocking calls** inside critical sections.
- [x] Verified **thread-safe collections** are used.
- [x] Validated proper exception handling.

## How was this PR tested?

- [x] New unit tests added.
  - `testAddVtDivToProducerCallbackIfNeededControlMessageGating` (in `LeaderFollowerStoreIngestionTaskTest`) — 10 scenarios across EOP / SOP / IP_SOP / IP_EOP / TOPIC_SWITCH / VERSION_SWAP install, SOS / EOS skip, RT-source skip, feature-disabled skip.
- [x] New integration test added.
  - `testBatchOnlyNRRemoteVTLeaderEopTriggersLcvpSyncWithHighByteThreshold` (in `TestGlobalRtDiv`) — runs a batch push with 100 MB byte thresholds, asserts the OffsetRecord's `lastConsumedVtPosition` is non-EARLIEST on the dc-1 remote-VT leader after EOP. With the byte-threshold path disabled, only the new non-segment-CM branch can drive the sync.
- [x] Modified or extended existing tests.
  - Extended `addVtDivToProducerCallbackIfNeededGatingParams` baseline to stub a non-control-message key, since the new gate path reads `record.getKey().isControlMessage()`.
- [x] Verified backward compatibility — no schema or config changes.

Full LF unit suite passes locally; `TestGlobalRtDiv` integration tests including `testBatchOnlyNRStoreWithGlobalRtDiv` and `testBatchOnlyNRRemoteVTLeaderRestartDoesNotRewindToEarliest` all pass.

## Does this PR introduce any user-facing or breaking changes?
- [x] No. Internal correctness fix on the NR leader's Global RT DIV path; no protocol, schema, or config changes.
