### PR TITLE
[schema] Stage AdminOperation v98 + StoreMetaValue v43 for etlActiveFabrics

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -329,15 +329,14 @@ subprojects {
       // when actually using the new protocol. Example to pin KME to v12 when introducing v13:
       // project(':internal:venice-common').file('src/main/resources/avro/KafkaMessageEnvelope/v12', PathValidation.DIRECTORY)
       def versionOverrides = [
-          // StoreMetaValue v43 added `batchPushRecordCountVerificationEnabled` for the originally-
-          // planned per-store flag, but this PR pivoted to a server-side server-config gate
-          // (see `server.batch.push.record.count.verification.fail.on.mismatch.enabled`) and the
-          // field is no longer read or written by anyone. Pin to v42 so the field doesn't enter
-          // the active protocol.
+          // StoreMetaValue v43 introduces `etlActiveFabrics` on the StoreETLConfig for per-store
+          // fabric selection of ETL onboard/offboard triggers. Pinned to v42 until the per-store flag
+          // wiring (Store / ZKStore / ReadOnlyStore / SystemStore / StoreInfo / UpdateStoreQueryParams)
+          // lands in a follow-up PR.
           project(':internal:venice-common').file('src/main/resources/avro/StoreMetaValue/v42', PathValidation.DIRECTORY),
-          // AdminOperation v98 carried `batchPushRecordCountVerificationEnabled` on the SetStore
-          // admin op for the same originally-planned per-store flag. Pin to v97 for the same
-          // reason as StoreMetaValue v43 above.
+          // AdminOperation v98 carries `etlActiveFabrics` on the ETLStoreConfigRecord for per-store
+          // fabric selection of ETL onboard/offboard triggers. Pinned to v97 until the controller-side
+          // wiring (VeniceParentHelixAdmin / AdminExecutionTask) lands in a follow-up PR.
           project(':services:venice-controller').file('src/main/resources/avro/AdminOperation/v97', PathValidation.DIRECTORY)
       ]
 

--- a/internal/venice-common/src/main/resources/avro/StoreMetaValue/v43/StoreMetaValue.avsc
+++ b/internal/venice-common/src/main/resources/avro/StoreMetaValue/v43/StoreMetaValue.avsc
@@ -127,7 +127,8 @@
                     {"name": "etledUserProxyAccount", "type": "string", "doc": "If enabled regular ETL or future version ETL, this account name is part of path for where the ETLed snapshots will go. for example, for user account veniceetl001, snapshots will be published to HDFS /jobs/veniceetl001/storeName."},
                     {"name": "regularVersionETLEnabled", "type": "boolean", "doc": "Whether or not enable regular version ETL for this store."},
                     {"name": "futureVersionETLEnabled", "type": "boolean", "doc": "Whether or not enable future version ETL - the version that might come online in future - for this store."},
-                    {"name": "etlStrategy", "type": "int", "default": 1, "doc": "Strategy to use for ETL. Default is UNSPECIFIED"}
+                    {"name": "etlStrategy", "type": "int", "default": 1, "doc": "Strategy to use for ETL. Default is UNSPECIFIED"},
+                    {"name": "etlActiveFabrics", "type": ["null", {"type": "array", "items": "string"}], "default": null, "doc": "Allowlist of fabric names where ETL onboard/offboard fires. null = fire in every fabric (default behavior). When set, only listed fabrics' child controllers trigger the ExternalETLService."}
                   ]
                 }
               ],
@@ -324,8 +325,7 @@
             {"name": "transientRecordCacheEnabled", "type": "boolean", "default": false, "doc": "Whether the bounded hot transient record cache is enabled for this store to retain frequently accessed large records across consumer poll boundaries."},
             {"name": "mergedValueRmdColumnFamilyEnabled", "type": "boolean", "default": false, "doc": "Whether to store value and RMD in a single column family to reduce read amplification during A/A ingestion."},
             {"name": "ingestionPauseMode", "type": "int", "default": 0, "doc": "Ingestion pause mode. 0 => NOT_PAUSED, 1 => CURRENT_VERSION, 2 => ALL_VERSIONS"},
-            {"name": "ingestionPausedRegions", "type": {"type": "array", "items": "string"}, "default": [], "doc": "List of regions where pause is applied. Empty list means all regions."},
-            {"name": "batchPushRecordCountVerificationEnabled", "type": "boolean", "default": false, "doc": "If true, the server fails ingestion when the locally-counted batch-push record count is less than the producer-side count carried on the EOP message's prc PubSub header. If false (default for soft launch), the server only emits the batch_push_record_count_match / batch_push_record_count_mismatch sensors and a tagged log line; ingestion continues regardless. Both branches still count and persist batchPushRecordCount on PartitionState."}
+            {"name": "ingestionPausedRegions", "type": {"type": "array", "items": "string"}, "default": [], "doc": "List of regions where pause is applied. Empty list means all regions."}
           ]
         }
       ],

--- a/services/venice-controller/src/main/resources/avro/AdminOperation/v98/AdminOperation.avsc
+++ b/services/venice-controller/src/main/resources/avro/AdminOperation/v98/AdminOperation.avsc
@@ -439,6 +439,12 @@
                       "name": "etlStrategy",
                       "type": "int",
                       "default": 1
+                    },
+                    {
+                      "name": "etlActiveFabrics",
+                      "type": ["null", {"type": "array", "items": "string"}],
+                      "default": null,
+                      "doc": "Allowlist of fabric names where ETL onboard/offboard fires. null = fire in every fabric (default behavior). When set, only listed fabrics' child controllers trigger the ExternalETLService."
                     }
                   ]
                 }
@@ -804,12 +810,6 @@
               "doc": "List of regions where pause is applied. Empty list means all regions.",
               "type": {"type": "array", "items": "string"},
               "default": []
-            },
-            {
-              "name": "batchPushRecordCountVerificationEnabled",
-              "doc": "If true, the server fails ingestion when the locally-counted batch-push record count is less than the producer-side count carried on the EOP message's prc PubSub header. If false (default), only emits sensors and a tagged log line.",
-              "type": "boolean",
-              "default": false
             }
           ]
         },


### PR DESCRIPTION
## Problem Statement
Today the controller fires onboardETL / offboardETL on the ExternalETLService from every fabric's child controller for any ETL-enabled store. There's no way for a customer to restrict ETL triggering to a subset of fabrics - it's all-or-nothing. 


## Solution
Add an optional etlActiveFabrics: array<string> field on the ETL store config (in both the admin-protocol ETLStoreConfigRecord and the persisted StoreETLConfig). When set, only child controllers in listed fabrics fire ETL callbacks; null preserves today's "fire everywhere" default for backward compatibility.

Also, reverting schema changes made by @ymuppala in AdminOperation & StoreMetaValue (https://github.com/linkedin/venice/pull/2777) as they are no longer required. 

###  Code changes
- [ ] Added new code behind **a config**. If so list the config names and their default values in the PR description.
- [ ] Introduced new **log lines**. 
- [ ] Confirmed if logs need to be **rate limited** to avoid excessive logging.

###  **Concurrency-Specific Checks**
Both reviewer and PR author to verify
- [x] Code has **no race conditions** or **thread safety issues**.
- [x] Proper **synchronization mechanisms** (e.g., `synchronized`, `RWLock`) are used where needed.
- [x] No **blocking calls** inside critical sections that could lead to deadlocks or performance degradation.
- [x] Verified **thread-safe collections** are used (e.g., `ConcurrentHashMap`, `CopyOnWriteArrayList`).
- [x] Validated proper exception handling in multi-threaded code to avoid silent thread termination.


## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->

- [ ] New unit tests added.
- [ ] New integration tests added.
- [ ] Modified or extended existing tests.
- [x] Verified backward compatibility (if applicable).

## Does this PR introduce any user-facing or breaking changes?
<!--  
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [ ] No. You can skip the rest of this section.
- [ ] Yes. Clearly explain the behavior change and its impact.