### PR TITLE
[dvc] Hotfix 0.4.852.1: cherry-pick #2791 (DVC future-slot speedup throttler)

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/StoreBackend.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/StoreBackend.java
@@ -129,8 +129,19 @@ public class StoreBackend {
   }
 
   private void setDaVinciFutureVersion(VersionBackend version) {
+    // Keep the IngestionService's future-slot registry in sync so the current-version
+    // bootstrapping speedup throttler does not activate for a version DVC is treating as a
+    // future slot (target-region push + deferred swap can promote the version controller-side
+    // before DVC has finished ingesting it as a future slot).
+    VersionBackend previousFutureVersion = daVinciFutureVersion;
     daVinciFutureVersion = version;
     stats.recordFutureVersion(version);
+    if (previousFutureVersion != null) {
+      backend.getIngestionService().unmarkAsDaVinciFutureSlot(previousFutureVersion.getVersion().kafkaTopicName());
+    }
+    if (version != null) {
+      backend.getIngestionService().markAsDaVinciFutureSlot(version.getVersion().kafkaTopicName());
+    }
   }
 
   public CompletableFuture<Void> subscribe(ComplementSet<Integer> partitions) {

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/IngestionThrottler.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/IngestionThrottler.java
@@ -18,6 +18,7 @@ import java.util.EnumMap;
 import java.util.Map;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Predicate;
 import java.util.function.Supplier;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -55,6 +56,7 @@ public class IngestionThrottler implements Closeable {
         isDaVinciClient,
         serverConfig,
         ongoingIngestionTaskMapSupplier,
+        topic -> false,
         CURRENT_VERSION_BOOTSTRAPPING_DEFAULT_CHECK_INTERVAL,
         CURRENT_VERSION_BOOTSTRAPPING_DEFAULT_CHECK_TIMEUNIT,
         adaptiveThrottlerSignalService);
@@ -64,6 +66,41 @@ public class IngestionThrottler implements Closeable {
       boolean isDaVinciClient,
       VeniceServerConfig serverConfig,
       Supplier<Map<String, StoreIngestionTask>> ongoingIngestionTaskMapSupplier,
+      Predicate<String> isDaVinciFutureSlotTopic,
+      AdaptiveThrottlerSignalService adaptiveThrottlerSignalService) {
+    this(
+        isDaVinciClient,
+        serverConfig,
+        ongoingIngestionTaskMapSupplier,
+        isDaVinciFutureSlotTopic,
+        CURRENT_VERSION_BOOTSTRAPPING_DEFAULT_CHECK_INTERVAL,
+        CURRENT_VERSION_BOOTSTRAPPING_DEFAULT_CHECK_TIMEUNIT,
+        adaptiveThrottlerSignalService);
+  }
+
+  // Backwards-compatible overload for callers that don't supply a future-slot predicate.
+  public IngestionThrottler(
+      boolean isDaVinciClient,
+      VeniceServerConfig serverConfig,
+      Supplier<Map<String, StoreIngestionTask>> ongoingIngestionTaskMapSupplier,
+      int checkInterval,
+      TimeUnit checkTimeUnit,
+      AdaptiveThrottlerSignalService adaptiveThrottlerSignalService) {
+    this(
+        isDaVinciClient,
+        serverConfig,
+        ongoingIngestionTaskMapSupplier,
+        topic -> false,
+        checkInterval,
+        checkTimeUnit,
+        adaptiveThrottlerSignalService);
+  }
+
+  public IngestionThrottler(
+      boolean isDaVinciClient,
+      VeniceServerConfig serverConfig,
+      Supplier<Map<String, StoreIngestionTask>> ongoingIngestionTaskMapSupplier,
+      Predicate<String> isDaVinciFutureSlotTopic,
       int checkInterval,
       TimeUnit checkTimeUnit,
       AdaptiveThrottlerSignalService adaptiveThrottlerSignalService) {
@@ -238,7 +275,13 @@ public class IngestionThrottler implements Closeable {
         String topicOfCurrentVersionBootstrapping = "";
         for (Map.Entry<String, StoreIngestionTask> entry: ongoingStoreIngestionTaskMap.entrySet()) {
           StoreIngestionTask task = entry.getValue();
-          if (task.isCurrentVersion() && !task.hasAllPartitionReportedCompleted()) {
+          if (task.isCurrentVersion() && !task.hasAllPartitionReportedCompleted()
+          // Skip versions DVC is ingesting as a future-version slot. Under target-region push +
+          // deferred swap, the controller may have already promoted the version (so the
+          // store-metadata view says "current") while DVC still treats it as its future slot.
+          // The speedup throttler is meant to help current-version bootstraps catch up faster,
+          // not future-version pre-swap ingestion which has no SLA pressure.
+              && !isDaVinciFutureSlotTopic.test(entry.getKey())) {
             hasCurrentVersionBootstrapping = true;
             topicOfCurrentVersionBootstrapping = entry.getKey();
             break;

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/KafkaStoreIngestionService.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/KafkaStoreIngestionService.java
@@ -117,6 +117,7 @@ import java.util.Properties;
 import java.util.Queue;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.ConcurrentSkipListMap;
 import java.util.concurrent.ExecutorService;
@@ -174,6 +175,20 @@ public class KafkaStoreIngestionService extends AbstractVeniceService implements
    * for consuming messages and making changes to the local store accordingly.
    */
   private final NavigableMap<String, StoreIngestionTask> topicNameToIngestionTaskMap;
+
+  /**
+   * Set of Kafka version topics that DaVinci has assigned to its future-version slot.
+   * Maintained by {@link com.linkedin.davinci.StoreBackend} via {@link #markAsDaVinciFutureSlot}
+   * and {@link #unmarkAsDaVinciFutureSlot} as DVC subscribes / swaps / clears future versions.
+   *
+   * <p>Consulted by {@link IngestionThrottler} so the current-version-bootstrapping speedup
+   * throttler is not activated for versions DVC is ingesting as a future slot. Under
+   * target-region push + deferred swap, the controller-side {@code currentVersion} can already
+   * point at the new version while DVC still treats it as a future slot — without this signal,
+   * the speedup throttler would fire inappropriately for a version that has no SLA pressure
+   * to catch up yet.
+   */
+  private final Set<String> daVinciFutureSlotTopics = ConcurrentHashMap.newKeySet();
 
   private final Optional<SchemaReader> kafkaMessageEnvelopeSchemaReader;
 
@@ -285,6 +300,7 @@ public class KafkaStoreIngestionService extends AbstractVeniceService implements
         isDaVinciClient,
         serverConfig,
         () -> Collections.unmodifiableMap(topicNameToIngestionTaskMap),
+        daVinciFutureSlotTopics::contains,
         adaptiveThrottlerSignalService);
 
     final Map<String, EventThrottler> kafkaUrlToRecordsThrottler;
@@ -700,6 +716,33 @@ public class KafkaStoreIngestionService extends AbstractVeniceService implements
       }
     }
     return false;
+  }
+
+  /**
+   * Mark a Kafka version topic as currently subscribed by DaVinci as a future-version slot.
+   * Called by {@link com.linkedin.davinci.StoreBackend#setDaVinciFutureVersion} when a new
+   * future version is installed.
+   */
+  public void markAsDaVinciFutureSlot(String kafkaVersionTopic) {
+    daVinciFutureSlotTopics.add(kafkaVersionTopic);
+  }
+
+  /**
+   * Clear the future-slot mark for a Kafka version topic. Called when DaVinci either swaps the
+   * future version to current, removes the future version, or closes the store.
+   */
+  public void unmarkAsDaVinciFutureSlot(String kafkaVersionTopic) {
+    daVinciFutureSlotTopics.remove(kafkaVersionTopic);
+  }
+
+  /**
+   * Returns true if the given Kafka version topic is currently in DaVinci's future-version slot.
+   * Used by {@link IngestionThrottler} to skip the current-version-bootstrapping speedup throttler
+   * for versions whose controller-side status may say "current" while DaVinci still treats them
+   * as a future slot (target-region push + deferred swap).
+   */
+  public boolean isDaVinciFutureSlot(String kafkaVersionTopic) {
+    return daVinciFutureSlotTopics.contains(kafkaVersionTopic);
   }
 
   /**

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/StoreBackendTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/StoreBackendTest.java
@@ -543,4 +543,43 @@ public class StoreBackendTest {
       assertEquals(versionRef.get().getVersion().getNumber(), version4.getNumber());
     }
   }
+
+  /**
+   * Verify that {@link StoreBackend#setDaVinciFutureVersion} keeps
+   * {@link KafkaStoreIngestionService}'s future-slot registry in sync so the
+   * current-version-bootstrapping speedup throttler can skip future-slot versions.
+   *
+   * <ul>
+   *   <li>Assigning a future version → {@code markAsDaVinciFutureSlot} is called for that topic.
+   *   <li>Promoting future to current (via {@code trySwapDaVinciCurrentVersion}) →
+   *       {@code unmarkAsDaVinciFutureSlot} is called.
+   * </ul>
+   */
+  @Test
+  public void testDaVinciFutureSlotRegistryIsKeptInSync() throws Exception {
+    com.linkedin.davinci.kafka.consumer.KafkaStoreIngestionService ingestionService = backend.getIngestionService();
+
+    // Subscribe to version1 (becomes daVinciCurrentVersion). version1 is the existing current
+    // version, so trySubscribeDaVinciFutureVersion picks version2 as the future slot.
+    CompletableFuture<?> subscribeResult = storeBackend.subscribe(ComplementSet.of(0));
+    versionMap.get(version1.kafkaTopicName()).completePartition(0);
+    subscribeResult.get(3, TimeUnit.SECONDS);
+
+    // version2 should now be marked as the future slot.
+    verify(ingestionService, times(1)).markAsDaVinciFutureSlot(version2.kafkaTopicName());
+    verify(ingestionService, never()).unmarkAsDaVinciFutureSlot(version2.kafkaTopicName());
+
+    // Promote version2 (the future) → currentVersion. swapCurrentVersion calls
+    // setDaVinciFutureVersion(null), which should unmark the topic.
+    versionMap.get(version2.kafkaTopicName()).completePartition(0);
+    store.setCurrentVersion(version2.getNumber());
+    backend.handleStoreChanged(storeBackend);
+
+    verify(ingestionService, times(1)).unmarkAsDaVinciFutureSlot(version2.kafkaTopicName());
+
+    // Sanity: DVC is now serving version2.
+    try (ReferenceCounted<VersionBackend> versionRef = storeBackend.getDaVinciCurrentVersion()) {
+      assertEquals(versionRef.get().getVersion().getNumber(), version2.getNumber());
+    }
+  }
 }

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/IngestionThrottlerTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/IngestionThrottlerTest.java
@@ -84,6 +84,61 @@ public class IngestionThrottlerTest {
     throttlerForNonDaVinciClient.close();
   }
 
+  @Test
+  public void testSpeedupThrottlerSkipsDaVinciFutureSlotTopic() throws IOException {
+    VeniceServerConfig serverConfig = mock(VeniceServerConfig.class);
+    doReturn(100l).when(serverConfig).getKafkaFetchQuotaRecordPerSecond();
+    doReturn(60l).when(serverConfig).getKafkaFetchQuotaTimeWindow();
+    doReturn(1024l).when(serverConfig).getKafkaFetchQuotaBytesPerSecond();
+    doReturn(true).when(serverConfig).isDaVinciCurrentVersionBootstrappingSpeedupEnabled();
+    doReturn(500l).when(serverConfig).getDaVinciCurrentVersionBootstrappingQuotaRecordsPerSecond();
+    doReturn(10240l).when(serverConfig).getDaVinciCurrentVersionBootstrappingQuotaBytesPerSecond();
+    mockThottlerRate(serverConfig);
+
+    // task.isCurrentVersion() returns true (controller view says it's current — e.g. just after
+    // a deferred-swap promotion). But DVC is still treating it as its future-version slot, so we
+    // pass it through the future-slot predicate. Speedup throttler must not activate.
+    StoreIngestionTask futureSlotTask = mock(StoreIngestionTask.class);
+    doReturn(true).when(futureSlotTask).isCurrentVersion();
+    doReturn(false).when(futureSlotTask).hasAllPartitionReportedCompleted();
+
+    String futureSlotTopic = "store_v5";
+    ConcurrentHashMap<String, StoreIngestionTask> tasks = new ConcurrentHashMap<>();
+    tasks.put(futureSlotTopic, futureSlotTask);
+
+    java.util.Set<String> daVinciFutureSlotTopics = ConcurrentHashMap.newKeySet();
+    daVinciFutureSlotTopics.add(futureSlotTopic);
+
+    IngestionThrottler throttler = new IngestionThrottler(
+        true,
+        serverConfig,
+        () -> tasks,
+        daVinciFutureSlotTopics::contains,
+        10,
+        TimeUnit.MILLISECONDS,
+        null);
+
+    // Wait long enough that the periodic check could have flipped the throttler — and assert it
+    // didn't.
+    TestUtils.waitForNonDeterministicAssertion(2, TimeUnit.SECONDS, () -> {
+      assertFalse(
+          throttler.isUsingSpeedupThrottler(),
+          "Speedup throttler must not activate for a DVC future-slot topic, even when "
+              + "isCurrentVersion() returns true");
+    });
+
+    // Once the topic leaves the future slot (DVC swapped it to current), the speedup throttler
+    // should activate as before.
+    daVinciFutureSlotTopics.remove(futureSlotTopic);
+    TestUtils.waitForNonDeterministicAssertion(3, TimeUnit.SECONDS, () -> {
+      assertTrue(
+          throttler.isUsingSpeedupThrottler(),
+          "Speedup throttler should activate once the topic leaves DVC's future slot");
+    });
+
+    throttler.close();
+  }
+
   private static void mockThottlerRate(VeniceServerConfig serverConfig) {
     doReturn(-1).when(serverConfig).getCurrentVersionAAWCLeaderQuotaRecordsPerSecond();
     doReturn(-1).when(serverConfig).getCurrentVersionSepRTLeaderQuotaRecordsPerSecond();


### PR DESCRIPTION
## Summary

Hotfix-only cherry-pick of #2791 (`3211ed79a48d105ffbf776b86d085744efa34156`) onto the `hotfix-0.4.852` branch.

## Why this hotfix

The `0.4.857+` line carries the KME schema v14 bump (#2778), which requires `venice_system_store_KAFKA_MESSAGE_ENVELOPE` schema v14 to be registered in ZK across all fabrics before any producer using `venice-common` 0.4.857+ can start. That schema rollout has not completed in the dev/ETL fabric yet, so consumers picking up `venice-client` built off `0.4.857+` (e.g. `lss-core-mt`) fail healthcheck via `SchemaPresenceChecker.verifySchemaVersionPresentOrExit` and crash on startup.

The DVC future-slot speedup-throttler fix in #2791 is needed urgently to address a separate production issue and can't wait for the KME v14 ZK rollout to complete. So we're cutting a hotfix release off `0.4.852` (last good pre-KME-v14 OSS) and cherry-picking only #2791.

## Changes

Pure cherry-pick of #2791 — no manual modifications. The commit applies cleanly with no conflicts.

## Testing Done

Cherry-pick is a clean apply of an already-merged, already-tested change. The test suite carried along with the cherry-pick:

- `IngestionThrottlerTest.testSpeedupThrottlerSkipsDaVinciFutureSlotTopic`
- `StoreBackendTest.testDaVinciFutureSlotRegistryIsKeptInSync`
- Existing `IngestionThrottlerTest` + `StoreBackendTest` suites
