### PR TITLE
[controller] Fix blobDbEnabled being wiped from versions during clone

### DIFF
--- a/internal/venice-common/src/main/java/com/linkedin/venice/meta/ReadOnlyStore.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/meta/ReadOnlyStore.java
@@ -1070,7 +1070,6 @@ public class ReadOnlyStore implements Store {
     storeProperties.setKeyUrnFields(getKeyUrnFields().stream().map(String::toString).collect(Collectors.toList()));
     storeProperties.setPreviousCurrentVersion(getPreviousCurrentVersion());
     // Set fields to default values - fields exist in schema but not yet exposed via Store interface
-    storeProperties.setBlobDbEnabled("NOT_SPECIFIED");
     storeProperties.setTransientRecordCacheEnabled(false);
     storeProperties.setMergedValueRmdColumnFamilyEnabled(false);
 
@@ -1991,7 +1990,6 @@ public class ReadOnlyStore implements Store {
     storeVersion.setRepushTtlSeconds(version.getRepushTtlSeconds());
     storeVersion.setPreviousCurrentVersion(version.getPreviousCurrentVersion());
     // Set fields to default values - fields exist in schema but not yet exposed via Version interface
-    storeVersion.setBlobDbEnabled("NOT_SPECIFIED");
     storeVersion.setRollbackTrigger("NOT_ROLLED_BACK");
     storeVersion.setTransientRecordCacheEnabled(false);
     storeVersion.setMergedValueRmdColumnFamilyEnabled(false);

--- a/internal/venice-common/src/main/java/com/linkedin/venice/meta/VersionImpl.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/meta/VersionImpl.java
@@ -581,6 +581,7 @@ public class VersionImpl implements Version {
     clonedVersion.setViewConfigs(getViewConfigs());
     clonedVersion.setBlobTransferEnabled(isBlobTransferEnabled());
     clonedVersion.setBlobTransferInServerEnabled(getBlobTransferInServerEnabled());
+    clonedVersion.setBlobDbEnabled(getBlobDbEnabled());
     clonedVersion.setTargetSwapRegion(getTargetSwapRegion());
     clonedVersion.setTargetSwapRegionWaitTime(getTargetSwapRegionWaitTime());
     clonedVersion.setIsDavinciHeartbeatReported(getIsDavinciHeartbeatReported());

--- a/internal/venice-common/src/test/java/com/linkedin/venice/meta/ReadOnlyStoreTest.java
+++ b/internal/venice-common/src/test/java/com/linkedin/venice/meta/ReadOnlyStoreTest.java
@@ -292,4 +292,31 @@ public class ReadOnlyStoreTest {
     Version cloned = v1.cloneVersion();
     assertEquals(cloned.getPreviousCurrentVersion(), 99);
   }
+
+  @Test
+  public void testCloneVersionPreservesBlobDbEnabled() {
+    Version v = new VersionImpl("testStore", 1, "push1");
+    v.setBlobDbEnabled(ActivationState.DISABLED.name());
+
+    Version cloned = v.cloneVersion();
+    assertEquals(cloned.getBlobDbEnabled(), ActivationState.DISABLED.name());
+  }
+
+  @Test
+  public void testCloneStorePropertiesPreservesVersionBlobDbEnabled() {
+    ZKStore store = (ZKStore) TestUtils.createTestStore(
+        Long.toString(RANDOM.nextLong()),
+        Long.toString(RANDOM.nextLong()),
+        System.currentTimeMillis());
+    store.setBlobDbEnabled(ActivationState.DISABLED.name());
+    Version v = new VersionImpl(store.getName(), 1, "push1");
+    store.addVersion(v);
+    // addVersion stamps the store-level value onto the new version (AbstractStore.addVersion).
+    assertEquals(store.getVersion(1).getBlobDbEnabled(), ActivationState.DISABLED.name());
+
+    StoreProperties cloned = new ReadOnlyStore(store).cloneStoreProperties();
+    assertEquals(cloned.getBlobDbEnabled(), ActivationState.DISABLED.name());
+    assertEquals(cloned.getVersions().size(), 1);
+    assertEquals(cloned.getVersions().get(0).getBlobDbEnabled(), ActivationState.DISABLED.name());
+  }
 }

--- a/internal/venice-common/src/test/java/com/linkedin/venice/meta/TestZKStore.java
+++ b/internal/venice-common/src/test/java/com/linkedin/venice/meta/TestZKStore.java
@@ -10,6 +10,7 @@ import static org.testng.Assert.assertTrue;
 import com.linkedin.venice.exceptions.StoreDisabledException;
 import com.linkedin.venice.exceptions.StoreVersionNotFoundException;
 import com.linkedin.venice.exceptions.VeniceException;
+import com.linkedin.venice.utils.ConfigCommonUtils.ActivationState;
 import com.linkedin.venice.utils.TestUtils;
 import com.linkedin.venice.utils.Utils;
 import java.util.Arrays;
@@ -84,6 +85,22 @@ public class TestZKStore {
     Assert.assertEquals(s2, s2clone);
     s2clone.setEnableWrites(false);
     Assert.assertNotEquals(s2, s2clone);
+  }
+
+  @Test
+  public void testCloneStorePreservesVersionLevelBlobDbEnabled() {
+    Store store = TestUtils.createTestStore("blobDbStore", "owner", System.currentTimeMillis());
+    store.setBlobDbEnabled(ActivationState.DISABLED.name());
+    Version v = new VersionImpl(store.getName(), 1, "pushJobId");
+    store.addVersion(v);
+    // Sanity check: addVersion should stamp the store-level value onto the new version.
+    Assert.assertEquals(store.getVersion(1).getBlobDbEnabled(), ActivationState.DISABLED.name());
+
+    Store clonedStore = store.cloneStore();
+    // Regression: cloneVersion was dropping blobDbEnabled, which caused every read-modify-write
+    // cycle through the store repository to silently wipe the field back to NOT_SPECIFIED on
+    // all existing versions.
+    Assert.assertEquals(clonedStore.getVersion(1).getBlobDbEnabled(), ActivationState.DISABLED.name());
   }
 
   private static void assertVersionsEquals(


### PR DESCRIPTION
## Problem Statement

The store-level `blobDbEnabled` flag was not being durably propagated to versions in ZK. Symptoms:

- After flipping a store's `blobDbEnabled` to `DISABLED`, new pushes still ended up with version-level `blobDbEnabled = NOT_SPECIFIED` in parent ZK.
- Existing non-current versions in child colos that had previously been stamped with `ENABLED` or `DISABLED` were silently reverted to `NOT_SPECIFIED` over time, on routine store-update cycles unrelated to the blob-db feature.

Root cause is two parallel bugs in `internal/venice-common` that both surfaced once the `blobDbEnabled` field was added without finishing the plumbing:

1. **`VersionImpl.cloneVersion()` (the primary bug)** — missing `clonedVersion.setBlobDbEnabled(getBlobDbEnabled())`. Its two siblings `blobTransferEnabled` and `blobTransferInServerEnabled` were copied, so this was almost certainly a copy-paste miss. `HelixReadWriteStoreRepository.getStore()` returns `store.cloneStore()` on every read, and `ZKStore.cloneStore()` calls `cloneVersion()` for every version. Every read-modify-write cycle through the repository (push status transitions, admin updates, new versions, etc.) therefore wiped `blobDbEnabled` back to the Avro default `NOT_SPECIFIED` on every existing version before persisting back to ZK.

2. **`ReadOnlyStore.cloneStoreProperties()` / `convertVersion()` (secondary)** — both had a leftover default-init line that unconditionally set `blobDbEnabled = "NOT_SPECIFIED"` *after* the real value was copied. The accompanying comment claims the field is "not yet exposed via Store/Version interface," but in fact it is. This affected the server's `StorePropertiesFetchRequest` metadata RPC (`ServerReadMetadataRepository.getStoreProperties`), so clients fetching store metadata via that RPC always saw `NOT_SPECIFIED` regardless of actual state.

## Solution

- `VersionImpl.cloneVersion()`: add `clonedVersion.setBlobDbEnabled(getBlobDbEnabled())` alongside the existing `blobTransferEnabled` / `blobTransferInServerEnabled` clones.
- `ReadOnlyStore.cloneStoreProperties()`: drop the redundant `storeProperties.setBlobDbEnabled("NOT_SPECIFIED")` override; the value copied at line 1062 is now correct.
- `ReadOnlyStore.convertVersion()`: drop the redundant `storeVersion.setBlobDbEnabled("NOT_SPECIFIED")` override; the value copied at line 1975 is now correct.

The two `NOT_SPECIFIED` defaults that genuinely *aren't* exposed on the public interfaces (`transientRecordCacheEnabled`, `mergedValueRmdColumnFamilyEnabled`, `rollbackTrigger`) are left intact.

### Code changes
- [ ] Added new code behind **a config**. *(N/A — pure bug fix; no new config or log lines.)*
- [ ] Introduced new **log lines**.

### **Concurrency-Specific Checks**
- [x] Code has **no race conditions** or **thread safety issues**. *(Pure local data-copy fixes, no concurrency surface change.)*
- [x] Proper **synchronization mechanisms** are used where needed.
- [x] No **blocking calls** inside critical sections.
- [x] Verified **thread-safe collections** are used.
- [x] Validated proper exception handling in multi-threaded code.

## How was this PR tested?

- [x] New unit tests added:
  - `ReadOnlyStoreTest.testCloneVersionPreservesBlobDbEnabled` — verifies `VersionImpl.cloneVersion` preserves the field.
  - `ReadOnlyStoreTest.testCloneStorePropertiesPreservesVersionBlobDbEnabled` — verifies both store-level and version-level values survive `cloneStoreProperties()` (covers `convertVersion` + the store-level override).
  - `TestZKStore.testCloneStorePreservesVersionLevelBlobDbEnabled` — end-to-end check on the `ZKStore.cloneStore()` path that was actually breaking in production.
- [x] Modified or extended existing tests. *(Extended the existing test classes; their existing `testCloneStoreProperties` continues to pass since its default-NOT_SPECIFIED setup still holds under the fix.)*
- [x] Verified backward compatibility. Existing versions in ZK that carry `NOT_SPECIFIED` are unchanged; the fix only stops *wiping* values that were correctly set.

`./gradlew :internal:venice-common:test` and `:services:venice-server:test --tests ServerReadMetadataRepositoryTest` both pass.

## Does this PR introduce any user-facing or breaking changes?

- [x] No. It restores intended behavior of the existing `blobDbEnabled` store/version config. After this fix, store-level `DISABLED` will correctly propagate to versions created after the flip, and previously-stamped values on existing versions will stop being silently overwritten on routine store updates.
- [ ] Yes.
